### PR TITLE
infra(db): v0.1.1 order/stores backfill + 5 v0.2 migrations (+40 tables)

### DIFF
--- a/.claude-scripts/lint_sql.js
+++ b/.claude-scripts/lint_sql.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Validates SQL syntax of all migration files using PostgreSQL parser.
+const fs = require('fs');
+const path = require('path');
+
+const MIG_DIR = path.join(__dirname, '..', 'supabase', 'migrations');
+const files = fs.readdirSync(MIG_DIR).filter(f => f.endsWith('.sql')).sort();
+
+(async () => {
+  const init = require('pg-query-emscripten').default;
+  let totalErrors = 0;
+  for (const file of files) {
+    const filePath = path.join(MIG_DIR, file);
+    const sql = fs.readFileSync(filePath, 'utf8');
+    const api = await init();  // Fresh wasm instance per file (avoids heap exhaustion)
+    try {
+      const result = api.parse(sql);
+      if (result.error) {
+        console.error(`[FAIL] ${file}: ${result.error.message} at cursor ${result.error.cursorpos}`);
+        const ctx = sql.slice(Math.max(0, result.error.cursorpos - 80), result.error.cursorpos + 80);
+        console.error(`        context: ...${ctx.replace(/\n/g, ' ')}...`);
+        totalErrors++;
+      } else {
+        console.log(`[OK]   ${file}: ${result.parse_tree.stmts.length} statements parsed`);
+      }
+    } catch (e) {
+      console.error(`[CRASH] ${file}: ${e.message}`);
+      totalErrors++;
+    }
+  }
+  console.log(`\n${totalErrors === 0 ? 'All files parsed cleanly' : totalErrors + ' file(s) had errors'}`);
+  process.exit(totalErrors === 0 ? 0 : 1);
+})();

--- a/supabase/migrations/20260423120000_stores_order_schema.sql
+++ b/supabase/migrations/20260423120000_stores_order_schema.sql
@@ -1,0 +1,509 @@
+-- ============================================================
+-- Stores + Order/Pickup Module Schema v0.1.1
+-- PostgreSQL 15+ / Supabase
+-- Backfills v0.1 tables that were specified in PRDs but never migrated
+-- See docs/PRD-訂單取貨模組.md, docs/PRD-通知模組.md
+-- ============================================================
+
+-- ============================================================
+-- TABLES
+-- ============================================================
+
+-- 1. 加盟店主檔（franchise store detail, separate from inventory `locations`）
+CREATE TABLE stores (
+  id                          BIGSERIAL PRIMARY KEY,
+  tenant_id                   UUID NOT NULL,
+  code                        TEXT NOT NULL,
+  name                        TEXT NOT NULL,
+  location_id                 BIGINT REFERENCES locations(id),
+  -- Notification module fields (PRD-通知模組 §7)
+  notification_mode           TEXT NOT NULL DEFAULT 'simple'
+                                CHECK (notification_mode IN ('full','simple','none')),
+  line_oa_channel_id          TEXT,
+  line_oa_channel_secret_enc  BYTEA,
+  line_oa_access_token_enc    BYTEA,
+  line_oa_basic_id            TEXT,
+  line_oa_plan                TEXT
+                                CHECK (line_oa_plan IN ('free','advanced','pro')),
+  line_oa_quota_monthly       INTEGER,
+  line_oa_verified            BOOLEAN NOT NULL DEFAULT FALSE,
+  line_oa_verified_at         TIMESTAMPTZ,
+  line_group_id               TEXT,
+  -- Pickup / operational fields (PRD-訂單取貨)
+  pickup_window_days          INTEGER NOT NULL DEFAULT 5,
+  off_days                    JSONB NOT NULL DEFAULT '[]'::jsonb,
+  allowed_payment_methods     JSONB NOT NULL DEFAULT '["cash"]'::jsonb,
+  -- Mapping for Flag 8 (AP settlement); FK filled after suppliers exists
+  supplier_id                 BIGINT REFERENCES suppliers(id),
+  is_active                   BOOLEAN NOT NULL DEFAULT TRUE,
+  notes                       TEXT,
+  created_by                  UUID,
+  updated_by                  UUID,
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, code),
+  UNIQUE (tenant_id, location_id)
+);
+COMMENT ON TABLE stores IS '加盟店主檔（franchise-specific detail, 與 locations 分離）';
+COMMENT ON COLUMN stores.location_id IS '對應 inventory locations.id（型別須為 store）';
+COMMENT ON COLUMN stores.off_days IS '公休日 JSONB：weekday list or date list';
+
+CREATE INDEX idx_stores_active ON stores (tenant_id) WHERE is_active;
+
+-- 2. LINE 社群頻道（OpenChat / OA）
+CREATE TABLE line_channels (
+  id                 BIGSERIAL PRIMARY KEY,
+  tenant_id          UUID NOT NULL,
+  code               TEXT NOT NULL,
+  name               TEXT NOT NULL,
+  channel_type       TEXT NOT NULL DEFAULT 'open_chat'
+                       CHECK (channel_type IN ('open_chat','oa_channel','group')),
+  home_store_id      BIGINT NOT NULL REFERENCES stores(id),
+  additional_pickup_store_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+  is_active          BOOLEAN NOT NULL DEFAULT TRUE,
+  notes              TEXT,
+  created_by         UUID,
+  updated_by         UUID,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, code)
+);
+COMMENT ON TABLE line_channels IS 'LINE 社群頻道（一頻道對應一主店，可附 multi-pickup 店列）';
+
+CREATE INDEX idx_line_channels_home ON line_channels (tenant_id, home_store_id);
+
+-- 3. 發文範本
+CREATE TABLE post_templates (
+  id         BIGSERIAL PRIMARY KEY,
+  tenant_id  UUID NOT NULL,
+  code       TEXT NOT NULL,
+  name       TEXT NOT NULL,
+  body       TEXT NOT NULL,
+  is_active  BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by UUID,
+  updated_by UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, code)
+);
+
+-- 4. 團購活動單頭
+CREATE TABLE group_buy_campaigns (
+  id                BIGSERIAL PRIMARY KEY,
+  tenant_id         UUID NOT NULL,
+  campaign_no       TEXT NOT NULL,
+  name              TEXT NOT NULL,
+  description       TEXT,
+  cover_image_url   TEXT,
+  status            TEXT NOT NULL DEFAULT 'draft'
+                      CHECK (status IN ('draft','open','closed','ordered',
+                                        'receiving','ready','completed','cancelled')),
+  close_type        TEXT NOT NULL DEFAULT 'regular'
+                      CHECK (close_type IN ('regular','fast','limited')),
+  start_at          TIMESTAMPTZ,
+  end_at            TIMESTAMPTZ,
+  pickup_deadline   DATE,
+  pickup_days       INTEGER,
+  total_cap_qty     NUMERIC(18,3),
+  post_template_id  BIGINT REFERENCES post_templates(id),
+  notes             TEXT,
+  created_by        UUID,
+  updated_by        UUID,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, campaign_no)
+);
+COMMENT ON TABLE group_buy_campaigns IS '團購活動單頭（v0.2 addendum 會加 cutoff_date / expected_arrival_date / matrix_row_order）';
+
+CREATE INDEX idx_gbc_status ON group_buy_campaigns (tenant_id, status, end_at DESC);
+
+-- 5. 活動商品明細
+CREATE TABLE campaign_items (
+  id           BIGSERIAL PRIMARY KEY,
+  tenant_id    UUID NOT NULL,
+  campaign_id  BIGINT NOT NULL REFERENCES group_buy_campaigns(id) ON DELETE CASCADE,
+  sku_id       BIGINT NOT NULL REFERENCES skus(id),
+  unit_price   NUMERIC(18,4) NOT NULL CHECK (unit_price >= 0),
+  cap_qty      NUMERIC(18,3),
+  sort_order   INTEGER NOT NULL DEFAULT 0,
+  notes        TEXT,
+  created_by   UUID,
+  updated_by   UUID,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (campaign_id, sku_id)
+);
+
+CREATE INDEX idx_campaign_items_sku ON campaign_items (tenant_id, sku_id);
+
+-- 6. 活動頻道關聯
+CREATE TABLE campaign_channels (
+  id            BIGSERIAL PRIMARY KEY,
+  tenant_id     UUID NOT NULL,
+  campaign_id   BIGINT NOT NULL REFERENCES group_buy_campaigns(id) ON DELETE CASCADE,
+  channel_id    BIGINT NOT NULL REFERENCES line_channels(id),
+  cap_qty       NUMERIC(18,3),
+  posted_at     TIMESTAMPTZ,
+  created_by    UUID,
+  updated_by    UUID,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (campaign_id, channel_id)
+);
+
+-- 7. 顧客社群暱稱 ↔ 會員綁定
+CREATE TABLE customer_line_aliases (
+  id          BIGSERIAL PRIMARY KEY,
+  tenant_id   UUID NOT NULL,
+  channel_id  BIGINT NOT NULL REFERENCES line_channels(id),
+  nickname    TEXT NOT NULL,
+  member_id   BIGINT NOT NULL REFERENCES members(id),
+  notes       TEXT,
+  created_by  UUID,
+  updated_by  UUID,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, channel_id, nickname)
+);
+COMMENT ON TABLE customer_line_aliases IS 'LINE 暱稱 ↔ 會員對應（同暱稱跨頻道可對不同會員）';
+
+CREATE INDEX idx_cla_member ON customer_line_aliases (member_id);
+
+-- 8. 顧客訂單單頭
+CREATE TABLE customer_orders (
+  id                BIGSERIAL PRIMARY KEY,
+  tenant_id         UUID NOT NULL,
+  order_no          TEXT NOT NULL,
+  campaign_id       BIGINT NOT NULL REFERENCES group_buy_campaigns(id),
+  channel_id        BIGINT NOT NULL REFERENCES line_channels(id),
+  member_id         BIGINT REFERENCES members(id),
+  nickname_snapshot TEXT,
+  pickup_store_id   BIGINT NOT NULL REFERENCES stores(id),
+  pickup_deadline   DATE,
+  status            TEXT NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending','confirmed','reserved','ready',
+                                        'partially_ready','partially_completed',
+                                        'completed','expired','cancelled')),
+  notes             TEXT,
+  created_by        UUID,
+  updated_by        UUID,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, order_no),
+  -- Q6: 同團同頻道同會員合併為一筆訂單
+  UNIQUE (tenant_id, campaign_id, channel_id, member_id)
+);
+
+CREATE INDEX idx_corders_campaign ON customer_orders (tenant_id, campaign_id, status);
+CREATE INDEX idx_corders_member ON customer_orders (member_id, status);
+CREATE INDEX idx_corders_pickup_store ON customer_orders (pickup_store_id, status);
+
+-- 9. 顧客訂單明細
+CREATE TABLE customer_order_items (
+  id                    BIGSERIAL PRIMARY KEY,
+  tenant_id             UUID NOT NULL,
+  order_id              BIGINT NOT NULL REFERENCES customer_orders(id) ON DELETE CASCADE,
+  campaign_item_id      BIGINT NOT NULL REFERENCES campaign_items(id),
+  sku_id                BIGINT NOT NULL REFERENCES skus(id),
+  qty                   NUMERIC(18,3) NOT NULL CHECK (qty > 0),
+  unit_price            NUMERIC(18,4) NOT NULL,
+  status                TEXT NOT NULL DEFAULT 'pending'
+                          CHECK (status IN ('pending','reserved','ready',
+                                            'picked_up','partially_picked_up',
+                                            'cancelled','expired')),
+  source                TEXT NOT NULL DEFAULT 'manual'
+                          CHECK (source IN ('manual','screenshot_parse','csv',
+                                            'rollover','liff')),
+  reserved_movement_id  BIGINT REFERENCES stock_movements(id),
+  pickup_movement_id    BIGINT REFERENCES stock_movements(id),
+  notes                 TEXT,
+  created_by            UUID,
+  updated_by            UUID,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_coi_order ON customer_order_items (order_id);
+CREATE INDEX idx_coi_sku_status ON customer_order_items (tenant_id, sku_id, status);
+CREATE INDEX idx_coi_campaign_item ON customer_order_items (campaign_item_id);
+
+-- 10. 候補清單（Q2 waitlist）
+CREATE TABLE order_waitlist (
+  id                  BIGSERIAL PRIMARY KEY,
+  tenant_id           UUID NOT NULL,
+  campaign_id         BIGINT NOT NULL REFERENCES group_buy_campaigns(id),
+  sku_id              BIGINT NOT NULL REFERENCES skus(id),
+  channel_id          BIGINT REFERENCES line_channels(id),
+  member_id           BIGINT REFERENCES members(id),
+  nickname            TEXT,
+  qty                 NUMERIC(18,3) NOT NULL CHECK (qty > 0),
+  position            INTEGER,
+  status              TEXT NOT NULL DEFAULT 'waiting'
+                        CHECK (status IN ('waiting','promoted','cancelled','expired')),
+  promoted_order_id   BIGINT REFERENCES customer_orders(id),
+  notes               TEXT,
+  created_by          UUID,
+  updated_by          UUID,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_waitlist_campaign ON order_waitlist (tenant_id, campaign_id, sku_id, position)
+  WHERE status = 'waiting';
+
+-- 11. 活動稽核（append-only, Q4）
+CREATE TABLE campaign_audit_log (
+  id           BIGSERIAL PRIMARY KEY,
+  tenant_id    UUID NOT NULL,
+  campaign_id  BIGINT NOT NULL REFERENCES group_buy_campaigns(id) ON DELETE CASCADE,
+  entity_type  TEXT NOT NULL CHECK (entity_type IN ('campaign','item','channel')),
+  entity_id    BIGINT,
+  field        TEXT NOT NULL,
+  before_value JSONB,
+  after_value  JSONB,
+  edit_reason  TEXT NOT NULL,
+  operator_id  UUID NOT NULL,
+  operator_ip  INET,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  -- append-only: 無 updated_*
+);
+
+CREATE INDEX idx_camp_audit_campaign ON campaign_audit_log (tenant_id, campaign_id, created_at DESC);
+
+-- 12. 取貨事件（append-only log）
+CREATE TABLE order_pickup_events (
+  id                BIGSERIAL PRIMARY KEY,
+  tenant_id         UUID NOT NULL,
+  order_id          BIGINT NOT NULL REFERENCES customer_orders(id) ON DELETE CASCADE,
+  pickup_store_id   BIGINT NOT NULL REFERENCES stores(id),
+  event_type        TEXT NOT NULL
+                      CHECK (event_type IN ('picked_up','partial_pickup',
+                                            'no_show_expired','cancelled','refunded')),
+  pos_sale_id       BIGINT REFERENCES pos_sales(id),
+  item_ids          JSONB,  -- 本次取貨的 customer_order_items.id[]
+  notes             TEXT,
+  created_by        UUID NOT NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  -- append-only
+);
+
+CREATE INDEX idx_pickup_events_order ON order_pickup_events (order_id, created_at DESC);
+CREATE INDEX idx_pickup_events_store ON order_pickup_events (tenant_id, pickup_store_id, created_at DESC);
+
+-- 13. 訂單來源：截圖 + LLM 解析（append-only）
+CREATE TABLE customer_order_sources (
+  id                BIGSERIAL PRIMARY KEY,
+  tenant_id         UUID NOT NULL,
+  campaign_id       BIGINT NOT NULL REFERENCES group_buy_campaigns(id),
+  order_id          BIGINT REFERENCES customer_orders(id),
+  source_type       TEXT NOT NULL CHECK (source_type IN ('screenshot','csv','manual_paste')),
+  screenshot_url    TEXT,
+  raw_content       TEXT,
+  llm_parsed_json   JSONB,
+  llm_model         TEXT,
+  created_by        UUID NOT NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  -- append-only
+);
+
+CREATE INDEX idx_cos_campaign ON customer_order_sources (tenant_id, campaign_id, created_at DESC);
+
+-- ============================================================
+-- TRIGGERS (reuse touch_updated_at() from inventory_schema)
+-- ============================================================
+
+CREATE TRIGGER trg_touch_stores                 BEFORE UPDATE ON stores
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_line_channels          BEFORE UPDATE ON line_channels
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_post_templates         BEFORE UPDATE ON post_templates
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_gbc                    BEFORE UPDATE ON group_buy_campaigns
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_campaign_items         BEFORE UPDATE ON campaign_items
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_campaign_channels      BEFORE UPDATE ON campaign_channels
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_cla                    BEFORE UPDATE ON customer_line_aliases
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_corders                BEFORE UPDATE ON customer_orders
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_coi                    BEFORE UPDATE ON customer_order_items
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_waitlist               BEFORE UPDATE ON order_waitlist
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+-- 稽核 / log 表禁止 UPDATE / DELETE（依 feedback_audit_columns）
+CREATE OR REPLACE FUNCTION forbid_append_only_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION '% is append-only', TG_TABLE_NAME;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_no_mut_camp_audit BEFORE UPDATE OR DELETE ON campaign_audit_log
+  FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+CREATE TRIGGER trg_no_mut_pickup_ev  BEFORE UPDATE OR DELETE ON order_pickup_events
+  FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+CREATE TRIGGER trg_no_mut_cos        BEFORE UPDATE OR DELETE ON customer_order_sources
+  FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+
+-- ============================================================
+-- RLS (Row-Level Security)
+-- ============================================================
+
+ALTER TABLE stores                    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE line_channels             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE post_templates            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE group_buy_campaigns       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE campaign_items            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE campaign_channels         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE customer_line_aliases     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE customer_orders           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE customer_order_items      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE order_waitlist            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE campaign_audit_log        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE order_pickup_events       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE customer_order_sources    ENABLE ROW LEVEL SECURITY;
+
+-- stores: 總部 ALL；店東 / 店長讀自己店 + 更新通知設定
+CREATE POLICY stores_hq_all ON stores
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+CREATE POLICY stores_store_read_own ON stores
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND id = (auth.jwt() ->> 'store_id')::bigint
+  );
+CREATE POLICY stores_store_update_own ON stores
+  FOR UPDATE USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND id = (auth.jwt() ->> 'store_id')::bigint
+    AND (auth.jwt() ->> 'role') IN ('store_owner','store_manager')
+  );
+
+-- group_buy_campaigns / campaign_items / campaign_channels: 總部 ALL；店家讀 open/closed/ready 階段
+CREATE POLICY gbc_hq_all ON group_buy_campaigns
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','purchaser')
+  );
+CREATE POLICY gbc_store_read ON group_buy_campaigns
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND status IN ('open','closed','ordered','receiving','ready','completed')
+  );
+
+CREATE POLICY ci_hq_all ON campaign_items
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','purchaser')
+  );
+CREATE POLICY ci_store_read ON campaign_items
+  FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid);
+
+CREATE POLICY cc_hq_all ON campaign_channels
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+
+-- line_channels / post_templates: 總部 ALL；店家讀 own store
+CREATE POLICY lc_hq_all ON line_channels
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+CREATE POLICY lc_store_read ON line_channels
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND home_store_id = (auth.jwt() ->> 'store_id')::bigint
+  );
+
+CREATE POLICY pt_hq_all ON post_templates
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+
+-- customer_line_aliases: 總部 ALL；店員 I/R/U for own channel
+CREATE POLICY cla_hq_all ON customer_line_aliases
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+CREATE POLICY cla_store_access ON customer_line_aliases
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND channel_id IN (
+      SELECT id FROM line_channels
+       WHERE home_store_id = (auth.jwt() ->> 'store_id')::bigint
+    )
+  );
+
+-- customer_orders / customer_order_items: 總部 ALL；店讀自己是 pickup_store
+CREATE POLICY corders_hq_all ON customer_orders
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+CREATE POLICY corders_store_access ON customer_orders
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND pickup_store_id = (auth.jwt() ->> 'store_id')::bigint
+  );
+
+CREATE POLICY coi_hq_all ON customer_order_items
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+CREATE POLICY coi_store_access ON customer_order_items
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND order_id IN (
+      SELECT id FROM customer_orders
+       WHERE pickup_store_id = (auth.jwt() ->> 'store_id')::bigint
+    )
+  );
+
+-- order_waitlist: 類似 customer_orders
+CREATE POLICY wl_hq_all ON order_waitlist
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+CREATE POLICY wl_store_read ON order_waitlist
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND channel_id IN (
+      SELECT id FROM line_channels
+       WHERE home_store_id = (auth.jwt() ->> 'store_id')::bigint
+    )
+  );
+
+-- campaign_audit_log / order_pickup_events / customer_order_sources: 總部 SELECT；寫由 RPC 用 SECURITY DEFINER
+CREATE POLICY camp_audit_hq_read ON campaign_audit_log
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+
+CREATE POLICY pickup_ev_hq_read ON order_pickup_events
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+CREATE POLICY pickup_ev_store_read ON order_pickup_events
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND pickup_store_id = (auth.jwt() ->> 'store_id')::bigint
+  );
+
+CREATE POLICY cos_hq_read ON customer_order_sources
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );

--- a/supabase/migrations/20260423120001_inventory_v02_demand_aid_settlement.sql
+++ b/supabase/migrations/20260423120001_inventory_v02_demand_aid_settlement.sql
@@ -1,0 +1,688 @@
+-- ============================================================
+-- Inventory v0.2 addendum: demand / backorder / mutual aid / clearance / transfer settlement
+-- PRD: docs/PRD-庫存模組-v0.2-addendum.md
+-- ============================================================
+
+-- ============================================================
+-- 1. 既有表欄位補充：transfers.transfer_type (Q5)
+-- ============================================================
+
+ALTER TABLE transfers
+  ADD COLUMN transfer_type TEXT NOT NULL DEFAULT 'store_to_store'
+    CHECK (transfer_type IN ('store_to_store','return_to_hq','hq_to_store'));
+
+CREATE INDEX idx_transfers_type ON transfers (tenant_id, transfer_type, status);
+
+-- ============================================================
+-- 2. TABLES
+-- ============================================================
+
+-- 需求單
+CREATE TABLE demand_requests (
+  id                       BIGSERIAL PRIMARY KEY,
+  tenant_id                UUID NOT NULL,
+  requester_store_id       BIGINT NOT NULL REFERENCES stores(id),
+  sku_id                   BIGINT NOT NULL REFERENCES skus(id),
+  qty                      NUMERIC(18,3) NOT NULL CHECK (qty > 0),
+  urgency                  TEXT NOT NULL DEFAULT 'normal'
+                             CHECK (urgency IN ('normal','urgent','critical')),
+  reason                   TEXT,
+  status                   TEXT NOT NULL DEFAULT 'open'
+                             CHECK (status IN ('open','fulfilled_by_transfer',
+                                               'fulfilled_by_po','cancelled','expired')),
+  target_date              DATE,
+  fulfilled_transfer_id    BIGINT REFERENCES transfers(id),
+  fulfilled_po_id          BIGINT REFERENCES purchase_orders(id),
+  notes                    TEXT,
+  created_by               UUID,
+  updated_by               UUID,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_dr_store_status ON demand_requests (tenant_id, requester_store_id, status);
+CREATE INDEX idx_dr_sku_open ON demand_requests (tenant_id, sku_id) WHERE status = 'open';
+
+-- 欠品 roll-over
+CREATE TABLE backorders (
+  id                                BIGSERIAL PRIMARY KEY,
+  tenant_id                         UUID NOT NULL,
+  original_customer_order_item_id   BIGINT NOT NULL REFERENCES customer_order_items(id),
+  sku_id                            BIGINT NOT NULL REFERENCES skus(id),
+  store_id                          BIGINT NOT NULL REFERENCES stores(id),
+  member_id                         BIGINT REFERENCES members(id),
+  qty_pending                       NUMERIC(18,3) NOT NULL CHECK (qty_pending > 0),
+  rollover_to_campaign_id           BIGINT REFERENCES group_buy_campaigns(id),
+  rollover_customer_order_item_id   BIGINT REFERENCES customer_order_items(id),
+  status                            TEXT NOT NULL DEFAULT 'pending'
+                                      CHECK (status IN ('pending','rolled_over','resolved','cancelled')),
+  notes                             TEXT,
+  created_by                        UUID,
+  updated_by                        UUID,
+  created_at                        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_backorders_sku_status ON backorders (tenant_id, sku_id, status);
+CREATE INDEX idx_backorders_member_pending ON backorders (member_id, status) WHERE status = 'pending';
+
+-- 互助交流板
+CREATE TABLE mutual_aid_board (
+  id                  BIGSERIAL PRIMARY KEY,
+  tenant_id           UUID NOT NULL,
+  offering_store_id   BIGINT NOT NULL REFERENCES stores(id),
+  sku_id              BIGINT NOT NULL REFERENCES skus(id),
+  qty_available       NUMERIC(18,3) NOT NULL CHECK (qty_available > 0),
+  qty_remaining       NUMERIC(18,3) NOT NULL,
+  expires_at          TIMESTAMPTZ NOT NULL,
+  note                TEXT,
+  status              TEXT NOT NULL DEFAULT 'active'
+                        CHECK (status IN ('active','exhausted','expired','cancelled')),
+  created_by          UUID,
+  updated_by          UUID,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_aid_active ON mutual_aid_board (tenant_id, status, expires_at)
+  WHERE status = 'active';
+
+-- 互助板認領（append-only）
+CREATE TABLE mutual_aid_claims (
+  id                      BIGSERIAL PRIMARY KEY,
+  tenant_id               UUID NOT NULL,
+  board_id                BIGINT NOT NULL REFERENCES mutual_aid_board(id),
+  claiming_store_id       BIGINT NOT NULL REFERENCES stores(id),
+  qty                     NUMERIC(18,3) NOT NULL CHECK (qty > 0),
+  resulting_transfer_id   BIGINT REFERENCES transfers(id),
+  created_by              UUID,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_aid_claims_board ON mutual_aid_claims (board_id, created_at DESC);
+
+-- 88 折出清
+CREATE TABLE aid_clearance_offers (
+  id                    BIGSERIAL PRIMARY KEY,
+  tenant_id             UUID NOT NULL,
+  offering_store_id     BIGINT NOT NULL REFERENCES stores(id),
+  sku_id                BIGINT NOT NULL REFERENCES skus(id),
+  qty_available         NUMERIC(18,3) NOT NULL CHECK (qty_available > 0),
+  qty_remaining         NUMERIC(18,3) NOT NULL,
+  discount_rate         NUMERIC(5,3) NOT NULL DEFAULT 0.88
+                          CHECK (discount_rate IN (0.88, 0.85, 0.80)),
+  expires_at            TIMESTAMPTZ NOT NULL,
+  reason                TEXT,
+  status                TEXT NOT NULL DEFAULT 'offered'
+                          CHECK (status IN ('offered','claimed_by_store',
+                                            'backfilled_by_hq','expired','cancelled')),
+  converted_demand_id   BIGINT REFERENCES demand_requests(id),
+  created_by            UUID,
+  updated_by            UUID,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_aid_clearance_active ON aid_clearance_offers (tenant_id, status)
+  WHERE status = 'offered';
+
+-- 店轉店月結算
+CREATE TABLE transfer_settlements (
+  id                            BIGSERIAL PRIMARY KEY,
+  tenant_id                     UUID NOT NULL,
+  settlement_month              DATE NOT NULL,
+  store_a_id                    BIGINT NOT NULL REFERENCES stores(id),
+  store_b_id                    BIGINT NOT NULL REFERENCES stores(id),
+  a_to_b_amount                 NUMERIC(18,4) NOT NULL DEFAULT 0,
+  b_to_a_amount                 NUMERIC(18,4) NOT NULL DEFAULT 0,
+  net_amount                    NUMERIC(18,4) NOT NULL,
+  transfer_count                INTEGER NOT NULL DEFAULT 0,
+  status                        TEXT NOT NULL DEFAULT 'draft'
+                                  CHECK (status IN ('draft','confirmed','settled','disputed')),
+  settled_at                    TIMESTAMPTZ,
+  settled_by                    UUID,
+  -- FK to vendor_bills 在 PRD #5 (AP) migration 後補
+  generated_vendor_bill_id      BIGINT,
+  notes                         TEXT,
+  created_by                    UUID,
+  updated_by                    UUID,
+  created_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, settlement_month, store_a_id, store_b_id),
+  CHECK (store_a_id < store_b_id)
+);
+
+CREATE INDEX idx_settlements_month ON transfer_settlements (tenant_id, settlement_month DESC);
+
+-- 月結算明細（append-only）
+CREATE TABLE transfer_settlement_items (
+  id              BIGSERIAL PRIMARY KEY,
+  tenant_id       UUID NOT NULL,
+  settlement_id   BIGINT NOT NULL REFERENCES transfer_settlements(id) ON DELETE CASCADE,
+  transfer_id     BIGINT NOT NULL REFERENCES transfers(id),
+  direction       TEXT NOT NULL CHECK (direction IN ('a_to_b','b_to_a')),
+  amount          NUMERIC(18,4) NOT NULL,
+  transfer_date   DATE NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_settlement_items_settlement ON transfer_settlement_items (settlement_id);
+
+-- ============================================================
+-- 3. TRIGGERS
+-- ============================================================
+
+CREATE TRIGGER trg_touch_demand_requests       BEFORE UPDATE ON demand_requests
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_backorders            BEFORE UPDATE ON backorders
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_aid_board             BEFORE UPDATE ON mutual_aid_board
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_aid_clearance         BEFORE UPDATE ON aid_clearance_offers
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_settlements           BEFORE UPDATE ON transfer_settlements
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+CREATE TRIGGER trg_no_mut_aid_claims          BEFORE UPDATE OR DELETE ON mutual_aid_claims
+  FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+CREATE TRIGGER trg_no_mut_settle_items        BEFORE UPDATE OR DELETE ON transfer_settlement_items
+  FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+
+-- ============================================================
+-- 4. RPC FUNCTIONS
+-- ============================================================
+
+-- 以 transfer 滿足需求單
+CREATE OR REPLACE FUNCTION rpc_fulfill_demand_by_transfer(
+  p_demand_id        BIGINT,
+  p_source_store_id  BIGINT,
+  p_operator         UUID
+) RETURNS BIGINT AS $$
+DECLARE
+  v_demand           RECORD;
+  v_src_location_id  BIGINT;
+  v_dst_location_id  BIGINT;
+  v_new_xfer_id      BIGINT;
+BEGIN
+  SELECT * INTO v_demand FROM demand_requests
+   WHERE id = p_demand_id AND status = 'open' FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'demand % not found or not open', p_demand_id;
+  END IF;
+
+  SELECT location_id INTO v_src_location_id FROM stores WHERE id = p_source_store_id;
+  SELECT location_id INTO v_dst_location_id FROM stores WHERE id = v_demand.requester_store_id;
+
+  IF v_src_location_id IS NULL OR v_dst_location_id IS NULL THEN
+    RAISE EXCEPTION 'source or dest store has no location_id';
+  END IF;
+
+  INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location,
+                         status, transfer_type, requested_by, created_by, updated_by)
+  VALUES (v_demand.tenant_id,
+          'DR-' || p_demand_id || '-' || EXTRACT(EPOCH FROM NOW())::bigint,
+          v_src_location_id, v_dst_location_id, 'confirmed', 'store_to_store',
+          p_operator, p_operator, p_operator)
+  RETURNING id INTO v_new_xfer_id;
+
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, created_by, updated_by)
+  VALUES (v_new_xfer_id, v_demand.sku_id, v_demand.qty, p_operator, p_operator);
+
+  UPDATE demand_requests
+     SET status = 'fulfilled_by_transfer',
+         fulfilled_transfer_id = v_new_xfer_id,
+         updated_by = p_operator
+   WHERE id = p_demand_id;
+
+  RETURN v_new_xfer_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- backorder 自動 roll-over 到下波 campaign
+CREATE OR REPLACE FUNCTION rpc_rollover_backorders(
+  p_new_campaign_id BIGINT,
+  p_operator        UUID
+) RETURNS INTEGER AS $$
+DECLARE
+  v_tenant_id       UUID;
+  v_campaign_status TEXT;
+  v_b               RECORD;
+  v_new_order_id    BIGINT;
+  v_new_item_id     BIGINT;
+  v_campaign_item_id BIGINT;
+  v_count           INTEGER := 0;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('rollover:' || p_new_campaign_id::text));
+
+  SELECT tenant_id, status INTO v_tenant_id, v_campaign_status
+    FROM group_buy_campaigns WHERE id = p_new_campaign_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'campaign % not found', p_new_campaign_id;
+  END IF;
+  IF v_campaign_status <> 'open' THEN
+    RAISE EXCEPTION 'campaign % is not open (status=%)', p_new_campaign_id, v_campaign_status;
+  END IF;
+
+  FOR v_b IN
+    SELECT b.* FROM backorders b
+     WHERE b.tenant_id = v_tenant_id
+       AND b.status = 'pending'
+       AND b.sku_id IN (SELECT sku_id FROM campaign_items WHERE campaign_id = p_new_campaign_id)
+  LOOP
+    SELECT id INTO v_campaign_item_id
+      FROM campaign_items
+     WHERE campaign_id = p_new_campaign_id AND sku_id = v_b.sku_id;
+
+    -- find or create customer_order
+    SELECT id INTO v_new_order_id
+      FROM customer_orders
+     WHERE tenant_id = v_tenant_id
+       AND campaign_id = p_new_campaign_id
+       AND member_id = v_b.member_id
+       AND pickup_store_id = v_b.store_id
+     LIMIT 1;
+
+    IF v_new_order_id IS NULL THEN
+      -- 從原 backorder 對應的 customer_order 取 channel_id (避免店無 channel 時 NULL violation)
+      INSERT INTO customer_orders (tenant_id, order_no, campaign_id, channel_id,
+                                   member_id, pickup_store_id, status, notes,
+                                   created_by, updated_by)
+      SELECT v_tenant_id,
+             'RO-' || p_new_campaign_id || '-' || v_b.id,
+             p_new_campaign_id,
+             COALESCE(orig_co.channel_id,
+                      (SELECT lc.id FROM line_channels lc
+                        WHERE lc.home_store_id = v_b.store_id LIMIT 1)),
+             v_b.member_id, v_b.store_id, 'pending',
+             '上期欠品 roll-over (backorder #' || v_b.id || ')',
+             p_operator, p_operator
+        FROM customer_order_items orig_coi
+        JOIN customer_orders orig_co ON orig_co.id = orig_coi.order_id
+       WHERE orig_coi.id = v_b.original_customer_order_item_id
+      RETURNING id INTO v_new_order_id;
+
+      IF v_new_order_id IS NULL THEN
+        RAISE EXCEPTION 'failed to derive channel_id for backorder %', v_b.id;
+      END IF;
+    END IF;
+
+    INSERT INTO customer_order_items (tenant_id, order_id, campaign_item_id, sku_id,
+                                      qty, unit_price, source, status, created_by, updated_by)
+    SELECT v_tenant_id, v_new_order_id, v_campaign_item_id, v_b.sku_id,
+           v_b.qty_pending,
+           (SELECT unit_price FROM campaign_items WHERE id = v_campaign_item_id),
+           'rollover', 'pending', p_operator, p_operator
+    RETURNING id INTO v_new_item_id;
+
+    UPDATE backorders
+       SET status = 'rolled_over',
+           rollover_to_campaign_id = p_new_campaign_id,
+           rollover_customer_order_item_id = v_new_item_id,
+           updated_by = p_operator
+     WHERE id = v_b.id;
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 認領互助板
+CREATE OR REPLACE FUNCTION rpc_claim_aid(
+  p_board_id          BIGINT,
+  p_claiming_store_id BIGINT,
+  p_qty               NUMERIC,
+  p_operator          UUID
+) RETURNS BIGINT AS $$
+DECLARE
+  v_board            RECORD;
+  v_src_location_id  BIGINT;
+  v_dst_location_id  BIGINT;
+  v_new_xfer_id      BIGINT;
+  v_claim_id         BIGINT;
+BEGIN
+  SELECT * INTO v_board FROM mutual_aid_board
+   WHERE id = p_board_id AND status = 'active' FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'board % not found or not active', p_board_id;
+  END IF;
+  IF v_board.qty_remaining < p_qty THEN
+    RAISE EXCEPTION 'insufficient qty: remaining=%, requested=%', v_board.qty_remaining, p_qty;
+  END IF;
+
+  SELECT location_id INTO v_src_location_id FROM stores WHERE id = v_board.offering_store_id;
+  SELECT location_id INTO v_dst_location_id FROM stores WHERE id = p_claiming_store_id;
+  IF v_src_location_id IS NULL OR v_dst_location_id IS NULL THEN
+    RAISE EXCEPTION 'store missing location_id mapping';
+  END IF;
+
+  UPDATE mutual_aid_board
+     SET qty_remaining = qty_remaining - p_qty,
+         status = CASE WHEN qty_remaining - p_qty = 0 THEN 'exhausted' ELSE status END,
+         updated_by = p_operator
+   WHERE id = p_board_id;
+
+  INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location,
+                         status, transfer_type, requested_by, created_by, updated_by)
+  VALUES (v_board.tenant_id,
+          'AID-' || p_board_id || '-' || EXTRACT(EPOCH FROM NOW())::bigint,
+          v_src_location_id, v_dst_location_id, 'confirmed', 'store_to_store',
+          p_operator, p_operator, p_operator)
+  RETURNING id INTO v_new_xfer_id;
+
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, created_by, updated_by)
+  VALUES (v_new_xfer_id, v_board.sku_id, p_qty, p_operator, p_operator);
+
+  INSERT INTO mutual_aid_claims (tenant_id, board_id, claiming_store_id, qty,
+                                 resulting_transfer_id, created_by)
+  VALUES (v_board.tenant_id, p_board_id, p_claiming_store_id, p_qty, v_new_xfer_id, p_operator)
+  RETURNING id INTO v_claim_id;
+
+  RETURN v_new_xfer_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 認領 88 折出清
+CREATE OR REPLACE FUNCTION rpc_claim_clearance(
+  p_offer_id          BIGINT,
+  p_claiming_store_id BIGINT,
+  p_qty               NUMERIC,
+  p_operator          UUID
+) RETURNS BIGINT AS $$
+DECLARE
+  v_offer            RECORD;
+  v_src_location_id  BIGINT;
+  v_dst_location_id  BIGINT;
+  v_new_xfer_id      BIGINT;
+BEGIN
+  SELECT * INTO v_offer FROM aid_clearance_offers
+   WHERE id = p_offer_id AND status = 'offered' FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'offer % not found or not offered', p_offer_id;
+  END IF;
+  IF v_offer.qty_remaining < p_qty THEN
+    RAISE EXCEPTION 'insufficient qty: remaining=%, requested=%', v_offer.qty_remaining, p_qty;
+  END IF;
+
+  SELECT location_id INTO v_src_location_id FROM stores WHERE id = v_offer.offering_store_id;
+  SELECT location_id INTO v_dst_location_id FROM stores WHERE id = p_claiming_store_id;
+
+  UPDATE aid_clearance_offers
+     SET qty_remaining = qty_remaining - p_qty,
+         status = CASE WHEN qty_remaining - p_qty = 0 THEN 'claimed_by_store' ELSE status END,
+         updated_by = p_operator
+   WHERE id = p_offer_id;
+
+  INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location,
+                         status, transfer_type, requested_by, notes, created_by, updated_by)
+  VALUES (v_offer.tenant_id,
+          'CLR-' || p_offer_id || '-' || EXTRACT(EPOCH FROM NOW())::bigint,
+          v_src_location_id, v_dst_location_id, 'confirmed', 'store_to_store',
+          p_operator,
+          'clearance @ ' || v_offer.discount_rate::text,
+          p_operator, p_operator)
+  RETURNING id INTO v_new_xfer_id;
+
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, created_by, updated_by)
+  VALUES (v_new_xfer_id, v_offer.sku_id, p_qty, p_operator, p_operator);
+
+  RETURN v_new_xfer_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- admin 把出清轉成 HQ 收貨需求
+CREATE OR REPLACE FUNCTION rpc_convert_clearance_to_demand(
+  p_offer_id   BIGINT,
+  p_hq_store_id BIGINT,
+  p_operator   UUID
+) RETURNS BIGINT AS $$
+DECLARE
+  v_offer       RECORD;
+  v_new_demand_id BIGINT;
+BEGIN
+  SELECT * INTO v_offer FROM aid_clearance_offers
+   WHERE id = p_offer_id AND status = 'offered' FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'offer % not found or not offered', p_offer_id;
+  END IF;
+
+  INSERT INTO demand_requests (tenant_id, requester_store_id, sku_id, qty,
+                               urgency, reason, status, created_by, updated_by)
+  VALUES (v_offer.tenant_id, p_hq_store_id, v_offer.sku_id, v_offer.qty_remaining,
+          'normal',
+          '88 折出清收回 (offer #' || p_offer_id || ', rate=' || v_offer.discount_rate::text || ')',
+          'open', p_operator, p_operator)
+  RETURNING id INTO v_new_demand_id;
+
+  UPDATE aid_clearance_offers
+     SET status = 'backfilled_by_hq',
+         converted_demand_id = v_new_demand_id,
+         updated_by = p_operator
+   WHERE id = p_offer_id;
+
+  RETURN v_new_demand_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 月結算 generate（draft）
+CREATE OR REPLACE FUNCTION rpc_generate_transfer_settlement(
+  p_tenant_id UUID,
+  p_month     DATE,
+  p_operator  UUID
+) RETURNS INTEGER AS $$
+DECLARE
+  v_existing_confirmed INTEGER;
+  v_pair               RECORD;
+  v_settlement_id      BIGINT;
+  v_a_to_b             NUMERIC(18,4);
+  v_b_to_a             NUMERIC(18,4);
+  v_count              INTEGER := 0;
+  v_xfer_count         INTEGER;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('settlement:' || p_tenant_id::text || ':' || p_month::text));
+
+  SELECT COUNT(*) INTO v_existing_confirmed
+    FROM transfer_settlements
+   WHERE tenant_id = p_tenant_id
+     AND settlement_month = p_month
+     AND status IN ('confirmed','settled');
+  IF v_existing_confirmed > 0 THEN
+    RAISE EXCEPTION 'settlement for month % already confirmed/settled', p_month;
+  END IF;
+
+  -- 砍掉 draft 重算
+  DELETE FROM transfer_settlements
+   WHERE tenant_id = p_tenant_id AND settlement_month = p_month AND status = 'draft';
+
+  -- aggregate transfers by (store_a < store_b)
+  FOR v_pair IN
+    SELECT
+      LEAST(src_store.id, dst_store.id)    AS store_a,
+      GREATEST(src_store.id, dst_store.id) AS store_b
+    FROM transfers t
+    JOIN stores src_store ON src_store.location_id = t.source_location
+    JOIN stores dst_store ON dst_store.location_id = t.dest_location
+    WHERE t.tenant_id = p_tenant_id
+      AND DATE_TRUNC('month', t.shipped_at) = p_month
+      AND t.transfer_type IN ('store_to_store','return_to_hq')
+      AND t.status IN ('received','closed')
+    GROUP BY 1, 2
+  LOOP
+    SELECT
+      COALESCE(SUM(CASE WHEN src_store.id = v_pair.store_a THEN line_amount END), 0),
+      COALESCE(SUM(CASE WHEN src_store.id = v_pair.store_b THEN line_amount END), 0),
+      COUNT(DISTINCT t.id)
+    INTO v_a_to_b, v_b_to_a, v_xfer_count
+    FROM transfers t
+    JOIN stores src_store ON src_store.location_id = t.source_location
+    JOIN stores dst_store ON dst_store.location_id = t.dest_location
+    JOIN LATERAL (
+      SELECT SUM(ti.qty_received * COALESCE(sb.avg_cost, 0)) AS line_amount
+        FROM transfer_items ti
+        LEFT JOIN stock_balances sb ON sb.location_id = t.source_location
+                                   AND sb.sku_id = ti.sku_id
+       WHERE ti.transfer_id = t.id
+    ) amt ON TRUE
+    WHERE t.tenant_id = p_tenant_id
+      AND DATE_TRUNC('month', t.shipped_at) = p_month
+      AND t.transfer_type IN ('store_to_store','return_to_hq')
+      AND t.status IN ('received','closed')
+      AND ((src_store.id = v_pair.store_a AND dst_store.id = v_pair.store_b)
+        OR (src_store.id = v_pair.store_b AND dst_store.id = v_pair.store_a));
+
+    INSERT INTO transfer_settlements (tenant_id, settlement_month, store_a_id, store_b_id,
+                                      a_to_b_amount, b_to_a_amount, net_amount,
+                                      transfer_count, status, created_by, updated_by)
+    VALUES (p_tenant_id, p_month, v_pair.store_a, v_pair.store_b,
+            v_a_to_b, v_b_to_a, v_a_to_b - v_b_to_a,
+            v_xfer_count, 'draft', p_operator, p_operator)
+    RETURNING id INTO v_settlement_id;
+
+    -- 明細
+    INSERT INTO transfer_settlement_items (tenant_id, settlement_id, transfer_id,
+                                           direction, amount, transfer_date)
+    SELECT p_tenant_id, v_settlement_id, t.id,
+           CASE WHEN src_store.id = v_pair.store_a THEN 'a_to_b' ELSE 'b_to_a' END,
+           amt.line_amount,
+           t.shipped_at::date
+    FROM transfers t
+    JOIN stores src_store ON src_store.location_id = t.source_location
+    JOIN stores dst_store ON dst_store.location_id = t.dest_location
+    JOIN LATERAL (
+      SELECT SUM(ti.qty_received * COALESCE(sb.avg_cost, 0)) AS line_amount
+        FROM transfer_items ti
+        LEFT JOIN stock_balances sb ON sb.location_id = t.source_location
+                                   AND sb.sku_id = ti.sku_id
+       WHERE ti.transfer_id = t.id
+    ) amt ON TRUE
+    WHERE t.tenant_id = p_tenant_id
+      AND DATE_TRUNC('month', t.shipped_at) = p_month
+      AND t.transfer_type IN ('store_to_store','return_to_hq')
+      AND t.status IN ('received','closed')
+      AND ((src_store.id = v_pair.store_a AND dst_store.id = v_pair.store_b)
+        OR (src_store.id = v_pair.store_b AND dst_store.id = v_pair.store_a));
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 月結算 confirm（Flag 8: net>0 → vendor_bill 由 PRD #5 trigger 處理；本 RPC 只標 confirmed）
+-- AP migration 後會 ALTER 此函數加入 vendor_bill insert 邏輯
+CREATE OR REPLACE FUNCTION rpc_confirm_transfer_settlement(
+  p_settlement_id BIGINT,
+  p_operator      UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_s RECORD;
+BEGIN
+  SELECT * INTO v_s FROM transfer_settlements
+   WHERE id = p_settlement_id AND status = 'draft' FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'settlement % not found or not draft', p_settlement_id;
+  END IF;
+
+  UPDATE transfer_settlements
+     SET status = 'confirmed',
+         settled_by = p_operator,
+         settled_at = NOW(),
+         updated_by = p_operator
+   WHERE id = p_settlement_id;
+
+  RETURN jsonb_build_object(
+    'settlement_id', p_settlement_id,
+    'net_amount', v_s.net_amount,
+    'vendor_bill_id', NULL  -- PRD #5 migration 後會擴充此 RPC 自動建 bill
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================
+-- 5. RLS
+-- ============================================================
+
+ALTER TABLE demand_requests             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE backorders                  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mutual_aid_board            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mutual_aid_claims           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE aid_clearance_offers        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE transfer_settlements        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE transfer_settlement_items   ENABLE ROW LEVEL SECURITY;
+
+-- demand_requests
+CREATE POLICY dr_hq_all ON demand_requests
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+CREATE POLICY dr_store_own ON demand_requests
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND requester_store_id = (auth.jwt() ->> 'store_id')::bigint
+  );
+
+-- backorders
+CREATE POLICY bo_hq_all ON backorders
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+CREATE POLICY bo_store_read ON backorders
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND store_id = (auth.jwt() ->> 'store_id')::bigint
+  );
+
+-- mutual_aid_board / aid_clearance_offers: 全店家可讀
+CREATE POLICY aid_board_read_all ON mutual_aid_board
+  FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid);
+CREATE POLICY aid_board_owner_write ON mutual_aid_board
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (offering_store_id = (auth.jwt() ->> 'store_id')::bigint
+         OR (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager'))
+  );
+
+CREATE POLICY clr_read_all ON aid_clearance_offers
+  FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid);
+CREATE POLICY clr_owner_write ON aid_clearance_offers
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (offering_store_id = (auth.jwt() ->> 'store_id')::bigint
+         OR (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager'))
+  );
+
+-- mutual_aid_claims
+CREATE POLICY aid_claims_hq_all ON mutual_aid_claims
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+CREATE POLICY aid_claims_store_read ON mutual_aid_claims
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (claiming_store_id = (auth.jwt() ->> 'store_id')::bigint
+         OR board_id IN (SELECT id FROM mutual_aid_board
+                         WHERE offering_store_id = (auth.jwt() ->> 'store_id')::bigint))
+  );
+
+-- transfer_settlements / items
+CREATE POLICY ts_hq_all ON transfer_settlements
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','hq_accountant')
+  );
+CREATE POLICY ts_store_read ON transfer_settlements
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND ((auth.jwt() ->> 'store_id')::bigint IN (store_a_id, store_b_id))
+  );
+
+CREATE POLICY tsi_hq_all ON transfer_settlement_items
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','hq_accountant')
+  );

--- a/supabase/migrations/20260423120002_picking_waves.sql
+++ b/supabase/migrations/20260423120002_picking_waves.sql
@@ -1,0 +1,490 @@
+-- ============================================================
+-- Order v0.2 addendum: picking waves + matrix view + stalled items
+-- PRD: docs/PRD-訂單取貨模組-v0.2-addendum.md
+-- ============================================================
+
+-- ============================================================
+-- 1. 既有表欄位補充：group_buy_campaigns
+-- ============================================================
+
+ALTER TABLE group_buy_campaigns
+  ADD COLUMN cutoff_date            DATE,
+  ADD COLUMN expected_arrival_date  DATE,
+  ADD COLUMN matrix_row_order       INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX idx_gbc_cutoff_date ON group_buy_campaigns (tenant_id, cutoff_date)
+  WHERE status IN ('open', 'closed');
+
+-- ============================================================
+-- 2. TABLES
+-- ============================================================
+
+-- 揀貨波次單頭
+CREATE TABLE picking_waves (
+  id           BIGSERIAL PRIMARY KEY,
+  tenant_id    UUID NOT NULL,
+  wave_code    TEXT NOT NULL,
+  wave_date    DATE NOT NULL,
+  status       TEXT NOT NULL DEFAULT 'draft'
+                 CHECK (status IN ('draft','picking','picked','shipped','cancelled')),
+  store_count  INTEGER NOT NULL DEFAULT 0,
+  item_count   INTEGER NOT NULL DEFAULT 0,
+  total_qty    NUMERIC(18,3) NOT NULL DEFAULT 0,
+  note         TEXT,
+  created_by   UUID,
+  updated_by   UUID,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, wave_code)
+);
+COMMENT ON TABLE picking_waves IS '揀貨波次主檔';
+
+CREATE INDEX idx_waves_date ON picking_waves (tenant_id, wave_date DESC);
+CREATE INDEX idx_waves_status ON picking_waves (tenant_id, status);
+
+-- 揀貨波次明細
+CREATE TABLE picking_wave_items (
+  id                   BIGSERIAL PRIMARY KEY,
+  tenant_id            UUID NOT NULL,
+  wave_id              BIGINT NOT NULL REFERENCES picking_waves(id) ON DELETE CASCADE,
+  sku_id               BIGINT NOT NULL REFERENCES skus(id),
+  store_id             BIGINT NOT NULL REFERENCES stores(id),
+  qty                  NUMERIC(18,3) NOT NULL CHECK (qty > 0),
+  picked_qty           NUMERIC(18,3),
+  campaign_id          BIGINT REFERENCES group_buy_campaigns(id),
+  generated_transfer_id BIGINT REFERENCES transfers(id),
+  note                 TEXT,
+  created_by           UUID,
+  updated_by           UUID,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (wave_id, sku_id, store_id)
+);
+
+CREATE INDEX idx_wave_items_wave ON picking_wave_items (wave_id);
+CREATE INDEX idx_wave_items_store ON picking_wave_items (tenant_id, store_id, wave_id);
+
+-- 揀貨波次稽核（append-only）
+CREATE TABLE picking_wave_audit_log (
+  id           BIGSERIAL PRIMARY KEY,
+  tenant_id    UUID NOT NULL,
+  wave_id      BIGINT NOT NULL REFERENCES picking_waves(id) ON DELETE CASCADE,
+  wave_item_id BIGINT REFERENCES picking_wave_items(id) ON DELETE SET NULL,
+  action       TEXT NOT NULL CHECK (action IN (
+                 'wave_created','wave_status_changed','item_added','item_removed',
+                 'picked_qty_changed','so_generated','wave_cancelled'
+               )),
+  before_value JSONB,
+  after_value  JSONB,
+  note         TEXT,
+  created_by   UUID,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_wave_audit_wave ON picking_wave_audit_log (tenant_id, wave_id, created_at DESC);
+CREATE INDEX idx_wave_audit_item ON picking_wave_audit_log (wave_item_id) WHERE wave_item_id IS NOT NULL;
+
+-- 外部訂單匯入 staging（樂樂 CSV 等）
+CREATE TABLE external_order_imports (
+  id                          BIGSERIAL PRIMARY KEY,
+  tenant_id                   UUID NOT NULL,
+  source                      TEXT NOT NULL CHECK (source IN ('lele','shopee','other')),
+  batch_id                    TEXT NOT NULL,
+  raw_row                     JSONB NOT NULL,
+  parsed_sku_id               BIGINT REFERENCES skus(id),
+  parsed_customer_identifier  TEXT,
+  parsed_qty                  NUMERIC(18,3),
+  parsed_amount               NUMERIC(18,4),
+  resolved_order_id           BIGINT REFERENCES customer_orders(id),
+  status                      TEXT NOT NULL DEFAULT 'pending'
+                                CHECK (status IN ('pending','resolved','skipped','error')),
+  error_message               TEXT,
+  created_by                  UUID,
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_ext_imports_batch ON external_order_imports (tenant_id, batch_id);
+CREATE INDEX idx_ext_imports_status ON external_order_imports (tenant_id, status);
+
+-- ============================================================
+-- 3. VIEWS
+-- ============================================================
+
+-- 開團總表 matrix dataset
+CREATE OR REPLACE VIEW v_open_group_matrix AS
+SELECT
+  gbc.id                AS campaign_id,
+  gbc.tenant_id,
+  gbc.cutoff_date,
+  gbc.matrix_row_order,
+  ci.sku_id,
+  s.id                  AS store_id,
+  s.name                AS store_name,
+  COALESCE(SUM(coi.qty), 0)        AS total_qty,
+  COUNT(DISTINCT co.member_id)     AS customer_count,
+  COUNT(DISTINCT co.id)            AS order_count
+FROM group_buy_campaigns gbc
+JOIN campaign_items ci ON ci.campaign_id = gbc.id
+LEFT JOIN customer_order_items coi ON coi.campaign_item_id = ci.id
+                                  AND coi.status NOT IN ('cancelled','expired')
+LEFT JOIN customer_orders co ON co.id = coi.order_id
+LEFT JOIN stores s ON s.id = co.pickup_store_id
+WHERE gbc.status IN ('open','closed')
+GROUP BY gbc.id, gbc.tenant_id, gbc.cutoff_date, gbc.matrix_row_order,
+         ci.sku_id, s.id, s.name;
+
+-- 未到貨積壓
+CREATE OR REPLACE VIEW v_stalled_items AS
+SELECT
+  coi.id                AS order_item_id,
+  coi.tenant_id,
+  gbc.id                AS campaign_id,
+  gbc.cutoff_date,
+  gbc.expected_arrival_date,
+  coi.sku_id,
+  coi.qty,
+  co.channel_id,
+  co.member_id,
+  co.pickup_store_id,
+  EXTRACT(DAY FROM NOW() - gbc.expected_arrival_date)::INT AS days_overdue
+FROM customer_order_items coi
+JOIN customer_orders co ON co.id = coi.order_id
+JOIN campaign_items ci ON ci.id = coi.campaign_item_id
+JOIN group_buy_campaigns gbc ON gbc.id = ci.campaign_id
+WHERE coi.status IN ('pending','reserved')
+  AND gbc.expected_arrival_date IS NOT NULL
+  AND gbc.expected_arrival_date < CURRENT_DATE;
+
+-- ============================================================
+-- 4. TRIGGERS
+-- ============================================================
+
+CREATE TRIGGER trg_touch_picking_waves      BEFORE UPDATE ON picking_waves
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_picking_wave_items BEFORE UPDATE ON picking_wave_items
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+CREATE TRIGGER trg_no_mut_wave_audit BEFORE UPDATE OR DELETE ON picking_wave_audit_log
+  FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+-- Note: external_order_imports 允許 UPDATE (status / resolved_order_id 轉移), 不裝 forbid trigger
+
+-- ============================================================
+-- 5. RPC FUNCTIONS (SECURITY DEFINER)
+-- ============================================================
+
+-- 建立揀貨波次（aggregate sku × store from campaigns）
+CREATE OR REPLACE FUNCTION rpc_create_picking_wave(
+  p_tenant_id   UUID,
+  p_campaign_ids BIGINT[],
+  p_wave_date   DATE,
+  p_wave_code   TEXT,
+  p_operator    UUID
+) RETURNS BIGINT AS $$
+DECLARE
+  v_wave_id     BIGINT;
+  v_item_count  INTEGER;
+  v_store_count INTEGER;
+  v_total_qty   NUMERIC(18,3);
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('picking_wave:create:' || p_tenant_id::text));
+
+  INSERT INTO picking_waves (tenant_id, wave_code, wave_date, status, created_by, updated_by)
+  VALUES (p_tenant_id, p_wave_code, p_wave_date, 'draft', p_operator, p_operator)
+  RETURNING id INTO v_wave_id;
+
+  INSERT INTO picking_wave_items (
+    tenant_id, wave_id, sku_id, store_id, qty, campaign_id, created_by, updated_by
+  )
+  SELECT p_tenant_id, v_wave_id, coi.sku_id, co.pickup_store_id,
+         SUM(coi.qty), ci.campaign_id, p_operator, p_operator
+    FROM customer_order_items coi
+    JOIN customer_orders co ON co.id = coi.order_id
+    JOIN campaign_items ci ON ci.id = coi.campaign_item_id
+   WHERE ci.campaign_id = ANY(p_campaign_ids)
+     AND coi.tenant_id = p_tenant_id
+     AND coi.status IN ('pending','reserved')
+   GROUP BY coi.sku_id, co.pickup_store_id, ci.campaign_id
+  HAVING SUM(coi.qty) > 0;
+
+  SELECT COUNT(*),
+         COUNT(DISTINCT store_id),
+         COALESCE(SUM(qty), 0)
+    INTO v_item_count, v_store_count, v_total_qty
+    FROM picking_wave_items
+   WHERE wave_id = v_wave_id;
+
+  UPDATE picking_waves
+     SET item_count = v_item_count,
+         store_count = v_store_count,
+         total_qty = v_total_qty
+   WHERE id = v_wave_id;
+
+  INSERT INTO picking_wave_audit_log (tenant_id, wave_id, action, after_value, created_by)
+  VALUES (p_tenant_id, v_wave_id, 'wave_created',
+          jsonb_build_object('wave_code', p_wave_code, 'campaign_ids', p_campaign_ids,
+                             'item_count', v_item_count, 'store_count', v_store_count),
+          p_operator);
+
+  RETURN v_wave_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 更新單列 picked_qty（現場揀貨用）
+CREATE OR REPLACE FUNCTION rpc_update_picked_qty(
+  p_wave_item_id BIGINT,
+  p_new_qty      NUMERIC,
+  p_operator     UUID,
+  p_note         TEXT DEFAULT NULL
+) RETURNS VOID AS $$
+DECLARE
+  v_tenant_id   UUID;
+  v_wave_id     BIGINT;
+  v_wave_status TEXT;
+  v_old_qty     NUMERIC(18,3);
+BEGIN
+  SELECT pwi.tenant_id, pwi.wave_id, pw.status, pwi.picked_qty
+    INTO v_tenant_id, v_wave_id, v_wave_status, v_old_qty
+    FROM picking_wave_items pwi
+    JOIN picking_waves pw ON pw.id = pwi.wave_id
+   WHERE pwi.id = p_wave_item_id
+   FOR UPDATE OF pwi, pw;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'picking_wave_item % not found', p_wave_item_id;
+  END IF;
+
+  IF v_wave_status NOT IN ('draft','picking') THEN
+    RAISE EXCEPTION 'wave % is in status %, cannot update picked_qty', v_wave_id, v_wave_status;
+  END IF;
+
+  UPDATE picking_wave_items
+     SET picked_qty = p_new_qty,
+         updated_by = p_operator
+   WHERE id = p_wave_item_id;
+
+  INSERT INTO picking_wave_audit_log (
+    tenant_id, wave_id, wave_item_id, action, before_value, after_value, note, created_by
+  ) VALUES (
+    v_tenant_id, v_wave_id, p_wave_item_id, 'picked_qty_changed',
+    jsonb_build_object('picked_qty', v_old_qty),
+    jsonb_build_object('picked_qty', p_new_qty),
+    p_note, p_operator
+  );
+
+  IF v_wave_status = 'draft' THEN
+    UPDATE picking_waves SET status = 'picking', updated_by = p_operator WHERE id = v_wave_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 從揀貨波次生成 transfers (transfer_type='hq_to_store', 每店一張) + post-commit count 驗證
+-- 註: PRD #1 §4.2 原寫 sales_orders, 但 sales_orders 需 customer_id NOT NULL (B2B 用),
+--     語意應為 HQ→store 內部出貨 → 用 transfers 更合理。
+-- 注意: 本 RPC 引用 transfers.transfer_type, 該欄位由 PRD #2 庫存 v0.2 migration 加;
+--     需在 inventory v0.2 migration 套用後才能正常使用。
+CREATE OR REPLACE FUNCTION generate_transfer_from_wave(
+  p_wave_id  BIGINT,
+  p_hq_location_id BIGINT,
+  p_operator UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_tenant_id            UUID;
+  v_wave_status          TEXT;
+  v_expected_store_count INTEGER;
+  v_expected_item_count  INTEGER;
+  v_actual_xfer_count    INTEGER;
+  v_actual_item_count    INTEGER;
+  v_store_rec            RECORD;
+  v_dest_location_id     BIGINT;
+  v_new_xfer_id          BIGINT;
+  v_inserted_items       INTEGER;
+  v_xfer_ids             BIGINT[] := ARRAY[]::BIGINT[];
+BEGIN
+  PERFORM pg_advisory_xact_lock(p_wave_id);
+
+  SELECT tenant_id, status INTO v_tenant_id, v_wave_status
+    FROM picking_waves WHERE id = p_wave_id FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'wave % not found', p_wave_id;
+  END IF;
+  IF v_wave_status <> 'picked' THEN
+    RAISE EXCEPTION 'wave % is in status %, expected picked', p_wave_id, v_wave_status;
+  END IF;
+
+  SELECT COUNT(DISTINCT store_id), COUNT(*)
+    INTO v_expected_store_count, v_expected_item_count
+    FROM picking_wave_items
+   WHERE wave_id = p_wave_id AND picked_qty > 0;
+
+  IF v_expected_item_count = 0 THEN
+    RAISE EXCEPTION 'wave % has no picked items, cannot generate transfer', p_wave_id;
+  END IF;
+
+  FOR v_store_rec IN
+    SELECT DISTINCT pwi.store_id, s.location_id
+      FROM picking_wave_items pwi
+      JOIN stores s ON s.id = pwi.store_id
+     WHERE pwi.wave_id = p_wave_id AND pwi.picked_qty > 0
+  LOOP
+    v_dest_location_id := v_store_rec.location_id;
+    IF v_dest_location_id IS NULL THEN
+      RAISE EXCEPTION 'store % has no location_id mapped', v_store_rec.store_id;
+    END IF;
+
+    INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location,
+                           status, transfer_type, requested_by, created_by, updated_by)
+    VALUES (v_tenant_id,
+            'WAVE-' || p_wave_id || '-S' || v_store_rec.store_id,
+            p_hq_location_id, v_dest_location_id,
+            'confirmed', 'hq_to_store', p_operator, p_operator, p_operator)
+    RETURNING id INTO v_new_xfer_id;
+
+    INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped,
+                                created_by, updated_by)
+    SELECT v_new_xfer_id, pwi.sku_id, pwi.picked_qty, pwi.picked_qty,
+           p_operator, p_operator
+      FROM picking_wave_items pwi
+     WHERE pwi.wave_id = p_wave_id
+       AND pwi.store_id = v_store_rec.store_id
+       AND pwi.picked_qty > 0;
+
+    GET DIAGNOSTICS v_inserted_items = ROW_COUNT;
+    IF v_inserted_items = 0 THEN
+      RAISE EXCEPTION 'empty transfer generated for store %', v_store_rec.store_id;
+    END IF;
+
+    UPDATE picking_wave_items
+       SET generated_transfer_id = v_new_xfer_id, updated_by = p_operator
+     WHERE wave_id = p_wave_id AND store_id = v_store_rec.store_id AND picked_qty > 0;
+
+    INSERT INTO picking_wave_audit_log (tenant_id, wave_id, action, after_value, created_by)
+    VALUES (v_tenant_id, p_wave_id, 'so_generated',
+            jsonb_build_object('transfer_id', v_new_xfer_id,
+                               'store_id', v_store_rec.store_id,
+                               'items_count', v_inserted_items),
+            p_operator);
+
+    v_xfer_ids := v_xfer_ids || v_new_xfer_id;
+  END LOOP;
+
+  UPDATE picking_waves SET status = 'shipped', updated_by = p_operator WHERE id = p_wave_id;
+
+  -- Post-execution count 驗證（Flag 4）
+  SELECT COUNT(DISTINCT generated_transfer_id)
+    INTO v_actual_xfer_count
+    FROM picking_wave_items
+   WHERE wave_id = p_wave_id AND generated_transfer_id IS NOT NULL;
+
+  SELECT COUNT(*)
+    INTO v_actual_item_count
+    FROM transfer_items ti
+    JOIN picking_wave_items pwi ON pwi.generated_transfer_id = ti.transfer_id
+   WHERE pwi.wave_id = p_wave_id;
+
+  IF v_actual_xfer_count <> v_expected_store_count THEN
+    RAISE EXCEPTION 'transfer count mismatch: expected %, got %', v_expected_store_count, v_actual_xfer_count;
+  END IF;
+  IF v_actual_item_count <> v_expected_item_count THEN
+    RAISE EXCEPTION 'item count mismatch: expected %, got %', v_expected_item_count, v_actual_item_count;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'transfer_count', v_actual_xfer_count,
+    'item_count', v_actual_item_count,
+    'transfer_ids', v_xfer_ids
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 樂樂 / 外部訂單匯入 resolve
+CREATE OR REPLACE FUNCTION rpc_import_external_orders(
+  p_tenant_id   UUID,
+  p_batch_id    TEXT,
+  p_campaign_id BIGINT,
+  p_operator    UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_row              RECORD;
+  v_campaign_status  TEXT;
+  v_resolved INTEGER := 0;
+  v_skipped  INTEGER := 0;
+  v_errors   INTEGER := 0;
+BEGIN
+  SELECT status INTO v_campaign_status
+    FROM group_buy_campaigns
+   WHERE id = p_campaign_id AND tenant_id = p_tenant_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'campaign % not found', p_campaign_id;
+  END IF;
+  IF v_campaign_status NOT IN ('open','closed') THEN
+    RAISE EXCEPTION 'campaign % is in status %, cannot import', p_campaign_id, v_campaign_status;
+  END IF;
+
+  FOR v_row IN
+    SELECT * FROM external_order_imports
+     WHERE tenant_id = p_tenant_id AND batch_id = p_batch_id AND status = 'pending'
+  LOOP
+    IF v_row.parsed_sku_id IS NULL THEN
+      v_skipped := v_skipped + 1;
+      CONTINUE;
+    END IF;
+    -- Note: full customer/order resolution 留給 admin UI；此處只做 staging → skipped
+    -- (actual matching logic 依實際 CSV 格式決定；先保守標 resolved=0)
+    v_skipped := v_skipped + 1;
+  END LOOP;
+
+  RETURN jsonb_build_object('resolved', v_resolved, 'skipped', v_skipped, 'errors', v_errors);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================
+-- 6. RLS
+-- ============================================================
+
+ALTER TABLE picking_waves           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE picking_wave_items      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE picking_wave_audit_log  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE external_order_imports  ENABLE ROW LEVEL SECURITY;
+
+-- 總倉 / admin：ALL
+CREATE POLICY pw_hq_all ON picking_waves
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','warehouse')
+  );
+
+-- 加盟店：只讀 wave_items where store = 自己
+CREATE POLICY pw_store_read ON picking_waves
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND id IN (
+      SELECT wave_id FROM picking_wave_items
+       WHERE store_id = (auth.jwt() ->> 'store_id')::bigint
+    )
+  );
+
+CREATE POLICY pwi_hq_all ON picking_wave_items
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','warehouse')
+  );
+CREATE POLICY pwi_store_read ON picking_wave_items
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND store_id = (auth.jwt() ->> 'store_id')::bigint
+  );
+
+CREATE POLICY pwal_hq_read ON picking_wave_audit_log
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+
+CREATE POLICY eoi_hq_all ON external_order_imports
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );

--- a/supabase/migrations/20260423120003_purchase_v02_review_arrival.sql
+++ b/supabase/migrations/20260423120003_purchase_v02_review_arrival.sql
@@ -1,0 +1,320 @@
+-- ============================================================
+-- Purchase v0.2 addendum: PR pending review + arrival tracking + sub-brand + marketplace import
+-- PRD: docs/PRD-採購模組-v0.2-addendum.md
+-- ============================================================
+
+-- ============================================================
+-- 1. 既有表欄位補充
+-- ============================================================
+
+-- purchase_requests: 內部審核 (review_status orthogonal to lifecycle status)
+ALTER TABLE purchase_requests
+  ADD COLUMN review_status            TEXT NOT NULL DEFAULT 'approved'
+                                        CHECK (review_status IN ('pending_review','approved','rejected')),
+  ADD COLUMN review_note              TEXT,
+  ADD COLUMN reviewed_by              UUID,
+  ADD COLUMN reviewed_at              TIMESTAMPTZ,
+  ADD COLUMN review_threshold_amount  NUMERIC(18,4);
+
+CREATE INDEX idx_pr_review_status ON purchase_requests (tenant_id, review_status)
+  WHERE review_status = 'pending_review';
+
+-- suppliers: 海外旗標 (Flag 11 A)
+ALTER TABLE suppliers
+  ADD COLUMN is_overseas BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX idx_suppliers_overseas ON suppliers (tenant_id, is_overseas)
+  WHERE is_overseas = TRUE;
+
+-- goods_receipts: 陸貨多月到貨追蹤
+ALTER TABLE goods_receipts
+  ADD COLUMN expected_arrival_date  DATE,
+  ADD COLUMN arrival_status         TEXT NOT NULL DEFAULT 'pending'
+                                      CHECK (arrival_status IN ('pending','arrived','delayed','partial','cancelled')),
+  ADD COLUMN arrival_note           TEXT,
+  ADD COLUMN is_land_goods          BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX idx_gr_arrival ON goods_receipts (tenant_id, arrival_status, expected_arrival_date)
+  WHERE arrival_status IN ('pending','delayed');
+
+-- brands: 子品牌 (漂漂館)
+ALTER TABLE brands
+  ADD COLUMN is_sub_brand    BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN parent_brand_id BIGINT REFERENCES brands(id);
+
+CREATE INDEX idx_brands_sub ON brands (tenant_id, parent_brand_id)
+  WHERE is_sub_brand = TRUE;
+
+-- ============================================================
+-- 2. 新增表
+-- ============================================================
+
+-- 採購審核門檻
+CREATE TABLE purchase_approval_thresholds (
+  id                BIGSERIAL PRIMARY KEY,
+  tenant_id         UUID NOT NULL,
+  scope             TEXT NOT NULL CHECK (scope IN ('global','category','supplier','store')),
+  scope_id          BIGINT,
+  threshold_amount  NUMERIC(18,4) NOT NULL CHECK (threshold_amount >= 0),
+  approver_role     TEXT NOT NULL DEFAULT 'admin'
+                      CHECK (approver_role IN ('admin','hq_manager','owner')),
+  active            BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by        UUID,
+  updated_by        UUID,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_pat_scope ON purchase_approval_thresholds (tenant_id, scope, COALESCE(scope_id, 0))
+  WHERE active = TRUE;
+
+-- 1688 / 拼多多 訂單 staging
+CREATE TABLE external_purchase_imports (
+  id                              BIGSERIAL PRIMARY KEY,
+  tenant_id                       UUID NOT NULL,
+  source                          TEXT NOT NULL CHECK (source IN ('1688','pinduoduo','taobao','other')),
+  batch_id                        TEXT NOT NULL,
+  raw_row                         JSONB NOT NULL,
+  parsed_sku_id                   BIGINT REFERENCES skus(id),
+  parsed_supplier_id              BIGINT REFERENCES suppliers(id),
+  parsed_qty                      NUMERIC(18,3),
+  parsed_unit_cost                NUMERIC(18,4),
+  parsed_amount                   NUMERIC(18,4),
+  parsed_expected_arrival_date    DATE,
+  resolved_po_id                  BIGINT REFERENCES purchase_orders(id),
+  status                          TEXT NOT NULL DEFAULT 'pending'
+                                    CHECK (status IN ('pending','resolved','skipped','error')),
+  error_message                   TEXT,
+  created_by                      UUID,
+  created_at                      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_ext_pur_batch ON external_purchase_imports (tenant_id, batch_id);
+CREATE INDEX idx_ext_pur_status ON external_purchase_imports (tenant_id, status);
+
+-- ============================================================
+-- 3. VIEW: 陸貨到貨追蹤
+-- ============================================================
+
+CREATE OR REPLACE VIEW v_pending_arrivals AS
+SELECT
+  gr.id                AS gr_id,
+  gr.tenant_id,
+  gr.gr_no,
+  gr.po_id,
+  po.po_no,
+  po.supplier_id,
+  sup.name             AS supplier_name,
+  gr.expected_arrival_date,
+  gr.arrival_status,
+  gr.arrival_note,
+  EXTRACT(DAY FROM NOW() - gr.expected_arrival_date)::INT AS days_overdue,
+  (SELECT SUM(gri.qty_expected * gri.unit_cost)
+     FROM goods_receipt_items gri
+    WHERE gri.gr_id = gr.id) AS expected_value
+FROM goods_receipts gr
+JOIN purchase_orders po ON po.id = gr.po_id
+JOIN suppliers sup ON sup.id = po.supplier_id
+WHERE gr.is_land_goods = TRUE
+  AND gr.arrival_status IN ('pending','delayed');
+
+-- ============================================================
+-- 4. TRIGGERS
+-- ============================================================
+
+CREATE TRIGGER trg_touch_pat BEFORE UPDATE ON purchase_approval_thresholds
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+-- Note: external_purchase_imports 允許 UPDATE (status 轉移), 不裝 forbid trigger
+
+-- 自動標 is_land_goods 依 supplier.is_overseas
+CREATE OR REPLACE FUNCTION mark_gr_land_goods()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.is_land_goods = FALSE THEN
+    SELECT COALESCE(s.is_overseas, FALSE) INTO NEW.is_land_goods
+      FROM purchase_orders po
+      JOIN suppliers s ON s.id = po.supplier_id
+     WHERE po.id = NEW.po_id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_gr_mark_land BEFORE INSERT ON goods_receipts
+  FOR EACH ROW EXECUTE FUNCTION mark_gr_land_goods();
+
+-- ============================================================
+-- 5. RPC FUNCTIONS
+-- ============================================================
+
+-- 審核通過
+CREATE OR REPLACE FUNCTION rpc_approve_purchase_request(
+  p_pr_id    BIGINT,
+  p_note     TEXT,
+  p_operator UUID
+) RETURNS VOID AS $$
+DECLARE
+  v_pr RECORD;
+BEGIN
+  SELECT * INTO v_pr FROM purchase_requests
+   WHERE id = p_pr_id AND review_status = 'pending_review' FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PR % not found or not pending_review', p_pr_id;
+  END IF;
+
+  UPDATE purchase_requests
+     SET review_status = 'approved',
+         review_note = p_note,
+         reviewed_by = p_operator,
+         reviewed_at = NOW(),
+         updated_by = p_operator,
+         status = CASE WHEN status = 'draft' THEN 'submitted' ELSE status END,
+         submitted_at = CASE WHEN status = 'draft' THEN NOW() ELSE submitted_at END
+   WHERE id = p_pr_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 審核退回
+CREATE OR REPLACE FUNCTION rpc_reject_purchase_request(
+  p_pr_id    BIGINT,
+  p_reason   TEXT,
+  p_operator UUID
+) RETURNS VOID AS $$
+BEGIN
+  IF p_reason IS NULL OR length(p_reason) = 0 THEN
+    RAISE EXCEPTION 'rejection reason is required';
+  END IF;
+
+  UPDATE purchase_requests
+     SET review_status = 'rejected',
+         review_note = p_reason,
+         reviewed_by = p_operator,
+         reviewed_at = NOW(),
+         updated_by = p_operator
+   WHERE id = p_pr_id AND review_status = 'pending_review';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PR % not found or not pending_review', p_pr_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 更新 GR ETA + 自動標 delayed
+CREATE OR REPLACE FUNCTION rpc_update_arrival_eta(
+  p_gr_id    BIGINT,
+  p_new_eta  DATE,
+  p_note     TEXT,
+  p_operator UUID
+) RETURNS VOID AS $$
+DECLARE
+  v_old_eta DATE;
+  v_status  TEXT;
+BEGIN
+  SELECT expected_arrival_date, arrival_status INTO v_old_eta, v_status
+    FROM goods_receipts
+   WHERE id = p_gr_id AND arrival_status IN ('pending','delayed') FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'GR % not found or not in trackable status', p_gr_id;
+  END IF;
+
+  UPDATE goods_receipts
+     SET expected_arrival_date = p_new_eta,
+         arrival_note = COALESCE(arrival_note || E'\n', '')
+                        || NOW()::date::text || ': ' || p_note,
+         arrival_status = CASE
+                           WHEN v_old_eta IS NOT NULL AND p_new_eta > v_old_eta + INTERVAL '7 days'
+                           THEN 'delayed'
+                           ELSE 'pending'
+                         END,
+         updated_by = p_operator
+   WHERE id = p_gr_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- marketplace import resolve
+CREATE OR REPLACE FUNCTION rpc_resolve_external_purchase(
+  p_tenant_id        UUID,
+  p_batch_id         TEXT,
+  p_dest_location_id BIGINT,
+  p_operator         UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_supplier_rec  RECORD;
+  v_row           RECORD;
+  v_new_po_id     BIGINT;
+  v_pos_created   INTEGER := 0;
+  v_items_created INTEGER := 0;
+  v_errors        INTEGER := 0;
+BEGIN
+  FOR v_supplier_rec IN
+    SELECT DISTINCT parsed_supplier_id
+      FROM external_purchase_imports
+     WHERE tenant_id = p_tenant_id AND batch_id = p_batch_id
+       AND status = 'pending' AND parsed_supplier_id IS NOT NULL
+  LOOP
+    INSERT INTO purchase_orders (tenant_id, po_no, supplier_id, dest_location_id,
+                                 status, order_date, notes, created_by, updated_by)
+    VALUES (p_tenant_id,
+            'MKT-' || p_batch_id || '-' || v_supplier_rec.parsed_supplier_id,
+            v_supplier_rec.parsed_supplier_id, p_dest_location_id,
+            'sent', CURRENT_DATE,
+            'source: marketplace_import / batch ' || p_batch_id,
+            p_operator, p_operator)
+    RETURNING id INTO v_new_po_id;
+    v_pos_created := v_pos_created + 1;
+
+    FOR v_row IN
+      SELECT * FROM external_purchase_imports
+       WHERE tenant_id = p_tenant_id AND batch_id = p_batch_id
+         AND status = 'pending'
+         AND parsed_supplier_id = v_supplier_rec.parsed_supplier_id
+    LOOP
+      IF v_row.parsed_sku_id IS NULL OR v_row.parsed_qty IS NULL OR v_row.parsed_unit_cost IS NULL THEN
+        UPDATE external_purchase_imports
+           SET status = 'error', error_message = 'missing parsed fields'
+         WHERE id = v_row.id;
+        v_errors := v_errors + 1;
+        CONTINUE;
+      END IF;
+
+      INSERT INTO purchase_order_items (po_id, sku_id, qty_ordered, unit_cost,
+                                        created_by, updated_by)
+      VALUES (v_new_po_id, v_row.parsed_sku_id, v_row.parsed_qty,
+              v_row.parsed_unit_cost, p_operator, p_operator);
+      v_items_created := v_items_created + 1;
+
+      UPDATE external_purchase_imports
+         SET resolved_po_id = v_new_po_id, status = 'resolved'
+       WHERE id = v_row.id;
+    END LOOP;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'pos_created', v_pos_created,
+    'items_created', v_items_created,
+    'errors', v_errors
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================
+-- 6. RLS
+-- ============================================================
+
+ALTER TABLE purchase_approval_thresholds  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE external_purchase_imports     ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY pat_admin_all ON purchase_approval_thresholds
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+CREATE POLICY pat_others_read ON purchase_approval_thresholds
+  FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid);
+
+CREATE POLICY epi_admin_all ON external_purchase_imports
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','purchaser')
+  );

--- a/supabase/migrations/20260423120004_xiaolan_tables.sql
+++ b/supabase/migrations/20260423120004_xiaolan_tables.sql
@@ -1,0 +1,334 @@
+-- ============================================================
+-- 供應商整合 (Supplier Integration) v0.2: xiaolan_* tables
+-- PRD: docs/PRD-供應商整合-v0.2.md
+-- ============================================================
+
+-- ============================================================
+-- 1. TABLES (5 staging + 1 settings)
+-- ============================================================
+
+-- 小蘭採購流水
+CREATE TABLE xiaolan_purchases (
+  id                BIGSERIAL PRIMARY KEY,
+  tenant_id         UUID NOT NULL,
+  source_ref_id     TEXT NOT NULL,
+  sheet_tab         TEXT NOT NULL,
+  purchase_date     DATE,
+  supplier_code     TEXT,
+  item_description  TEXT,
+  qty               NUMERIC(18,3),
+  unit_cost         NUMERIC(18,4),
+  amount            NUMERIC(18,4),
+  resolved_po_id    BIGINT REFERENCES purchase_orders(id),
+  resolved_sku_id   BIGINT REFERENCES skus(id),
+  status            TEXT NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending','resolved','skipped','error')),
+  raw_row           JSONB,
+  created_by        UUID,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, source_ref_id)
+);
+
+CREATE INDEX idx_xiaolan_pur_status ON xiaolan_purchases (tenant_id, status);
+CREATE INDEX idx_xiaolan_pur_date ON xiaolan_purchases (tenant_id, purchase_date DESC);
+
+-- 漂漂館進貨 staging
+CREATE TABLE xiaolan_piaopiao (
+  id                  BIGSERIAL PRIMARY KEY,
+  tenant_id           UUID NOT NULL,
+  source_ref_id       TEXT NOT NULL,
+  sheet_tab           TEXT,
+  purchase_date       DATE,
+  item_description    TEXT,
+  qty                 NUMERIC(18,3),
+  unit_cost           NUMERIC(18,4),
+  resolved_sku_id     BIGINT REFERENCES skus(id),
+  resolved_brand_id   BIGINT REFERENCES brands(id),
+  status              TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending','resolved','skipped','error')),
+  raw_row             JSONB,
+  created_by          UUID,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, source_ref_id)
+);
+
+CREATE INDEX idx_xiaolan_pp_status ON xiaolan_piaopiao (tenant_id, status);
+
+-- 訂單追蹤流水
+CREATE TABLE xiaolan_order_tracking (
+  id                BIGSERIAL PRIMARY KEY,
+  tenant_id         UUID NOT NULL,
+  source_ref_id     TEXT NOT NULL,
+  external_order_no TEXT NOT NULL,
+  tracking_no       TEXT,
+  carrier           TEXT,
+  status_text       TEXT,
+  status_code       TEXT
+                      CHECK (status_code IN ('created','shipped','in_transit','arrived','returned','unknown')),
+  last_event_at     TIMESTAMPTZ,
+  resolved_po_id    BIGINT REFERENCES purchase_orders(id),
+  resolved_gr_id    BIGINT REFERENCES goods_receipts(id),
+  raw_row           JSONB,
+  created_by        UUID,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, source_ref_id)
+);
+
+CREATE INDEX idx_xiaolan_track_external ON xiaolan_order_tracking (tenant_id, external_order_no);
+
+-- 到貨紀錄
+CREATE TABLE xiaolan_arrivals (
+  id                BIGSERIAL PRIMARY KEY,
+  tenant_id         UUID NOT NULL,
+  source_ref_id     TEXT NOT NULL,
+  arrival_date      DATE NOT NULL,
+  external_order_no TEXT,
+  item_description  TEXT,
+  qty_arrived       NUMERIC(18,3),
+  condition_note    TEXT,
+  resolved_gr_id    BIGINT REFERENCES goods_receipts(id),
+  status            TEXT NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending','resolved','skipped','error')),
+  raw_row           JSONB,
+  created_by        UUID,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, source_ref_id)
+);
+
+CREATE INDEX idx_xiaolan_arr_status ON xiaolan_arrivals (tenant_id, status);
+CREATE INDEX idx_xiaolan_arr_date ON xiaolan_arrivals (tenant_id, arrival_date DESC);
+
+-- 退貨紀錄
+CREATE TABLE xiaolan_returns (
+  id                              BIGSERIAL PRIMARY KEY,
+  tenant_id                       UUID NOT NULL,
+  source_ref_id                   TEXT NOT NULL,
+  return_date                     DATE NOT NULL,
+  external_order_no               TEXT,
+  reason                          TEXT,
+  qty_returned                    NUMERIC(18,3),
+  refund_amount                   NUMERIC(18,4),
+  resolved_purchase_return_id     BIGINT REFERENCES purchase_returns(id),
+  status                          TEXT NOT NULL DEFAULT 'pending'
+                                    CHECK (status IN ('pending','resolved','skipped','error')),
+  raw_row                         JSONB,
+  created_by                      UUID,
+  created_at                      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, source_ref_id)
+);
+
+CREATE INDEX idx_xiaolan_ret_status ON xiaolan_returns (tenant_id, status);
+
+-- 設定主檔
+CREATE TABLE xiaolan_settings (
+  id                       BIGSERIAL PRIMARY KEY,
+  tenant_id                UUID NOT NULL,
+  sheet_id                 TEXT NOT NULL,
+  sheet_tabs               JSONB NOT NULL,
+  supplier_code_mapping    JSONB,
+  sku_match_rules          JSONB,
+  sync_enabled             BOOLEAN NOT NULL DEFAULT TRUE,
+  last_synced_at           TIMESTAMPTZ,
+  last_sync_status         TEXT,
+  last_sync_error          TEXT,
+  created_by               UUID,
+  updated_by               UUID,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, sheet_id)
+);
+
+CREATE TRIGGER trg_touch_xiaolan_settings BEFORE UPDATE ON xiaolan_settings
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+-- ============================================================
+-- 2. RPC FUNCTIONS
+-- ============================================================
+
+-- 解決一筆 xiaolan_purchases (建 PO item / 標 resolved)
+CREATE OR REPLACE FUNCTION rpc_resolve_xiaolan_purchase(
+  p_xiaolan_id BIGINT,
+  p_po_id      BIGINT,
+  p_sku_id     BIGINT,
+  p_operator   UUID
+) RETURNS VOID AS $$
+DECLARE
+  v_x  RECORD;
+  v_po RECORD;
+BEGIN
+  SELECT * INTO v_x FROM xiaolan_purchases
+   WHERE id = p_xiaolan_id AND status = 'pending' FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'xiaolan_purchase % not found or not pending', p_xiaolan_id;
+  END IF;
+
+  SELECT * INTO v_po FROM purchase_orders WHERE id = p_po_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PO % not found', p_po_id;
+  END IF;
+
+  -- optionally append a PO item
+  IF v_x.qty IS NOT NULL AND v_x.unit_cost IS NOT NULL THEN
+    INSERT INTO purchase_order_items (po_id, sku_id, qty_ordered, unit_cost,
+                                      created_by, updated_by)
+    VALUES (p_po_id, p_sku_id, v_x.qty, v_x.unit_cost, p_operator, p_operator);
+  END IF;
+
+  UPDATE xiaolan_purchases
+     SET resolved_po_id = p_po_id, resolved_sku_id = p_sku_id, status = 'resolved'
+   WHERE id = p_xiaolan_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 解決 xiaolan_arrivals (連到 GR)
+CREATE OR REPLACE FUNCTION rpc_resolve_xiaolan_arrival(
+  p_xiaolan_id BIGINT,
+  p_gr_id      BIGINT,
+  p_operator   UUID
+) RETURNS VOID AS $$
+BEGIN
+  UPDATE xiaolan_arrivals
+     SET resolved_gr_id = p_gr_id, status = 'resolved'
+   WHERE id = p_xiaolan_id AND status = 'pending';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'xiaolan_arrival % not found or not pending', p_xiaolan_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 解決 xiaolan_returns (連到 purchase_return)
+CREATE OR REPLACE FUNCTION rpc_resolve_xiaolan_return(
+  p_xiaolan_id BIGINT,
+  p_return_id  BIGINT,
+  p_operator   UUID
+) RETURNS VOID AS $$
+BEGIN
+  UPDATE xiaolan_returns
+     SET resolved_purchase_return_id = p_return_id, status = 'resolved'
+   WHERE id = p_xiaolan_id AND status = 'pending';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'xiaolan_return % not found or not pending', p_xiaolan_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 解決 xiaolan_order_tracking (連到 PO + GR + status sync)
+CREATE OR REPLACE FUNCTION rpc_resolve_xiaolan_tracking(
+  p_xiaolan_id BIGINT,
+  p_po_id      BIGINT,
+  p_gr_id      BIGINT,
+  p_operator   UUID
+) RETURNS VOID AS $$
+DECLARE
+  v_x RECORD;
+BEGIN
+  SELECT * INTO v_x FROM xiaolan_order_tracking
+   WHERE id = p_xiaolan_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'xiaolan_order_tracking % not found', p_xiaolan_id;
+  END IF;
+
+  UPDATE xiaolan_order_tracking
+     SET resolved_po_id = p_po_id, resolved_gr_id = p_gr_id
+   WHERE id = p_xiaolan_id;
+
+  -- sync goods_receipts.arrival_status if applicable
+  IF p_gr_id IS NOT NULL AND v_x.status_code IN ('arrived','in_transit','shipped') THEN
+    UPDATE goods_receipts
+       SET arrival_status = CASE
+                              WHEN v_x.status_code = 'arrived' THEN 'arrived'
+                              WHEN v_x.status_code IN ('in_transit','shipped') THEN 'pending'
+                              ELSE arrival_status
+                            END,
+           updated_by = p_operator
+     WHERE id = p_gr_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 批次解決 (auto-match 走 sku_match_rules in xiaolan_settings)
+CREATE OR REPLACE FUNCTION rpc_bulk_resolve_xiaolan(
+  p_table    TEXT,
+  p_ids      BIGINT[],
+  p_operator UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_resolved INTEGER := 0;
+  v_skipped  INTEGER := 0;
+  v_errors   INTEGER := 0;
+BEGIN
+  IF p_table NOT IN ('purchases','piaopiao','arrivals','returns','tracking') THEN
+    RAISE EXCEPTION 'invalid table: %', p_table;
+  END IF;
+
+  -- 為避免 dynamic SQL 複雜度, 此 RPC 僅做 status='skipped' 標記;
+  -- admin UI 應逐筆呼叫對應的 rpc_resolve_xiaolan_<table>
+  IF p_table = 'purchases' THEN
+    UPDATE xiaolan_purchases SET status = 'skipped'
+     WHERE id = ANY(p_ids) AND status = 'pending';
+    GET DIAGNOSTICS v_skipped = ROW_COUNT;
+  ELSIF p_table = 'piaopiao' THEN
+    UPDATE xiaolan_piaopiao SET status = 'skipped'
+     WHERE id = ANY(p_ids) AND status = 'pending';
+    GET DIAGNOSTICS v_skipped = ROW_COUNT;
+  ELSIF p_table = 'arrivals' THEN
+    UPDATE xiaolan_arrivals SET status = 'skipped'
+     WHERE id = ANY(p_ids) AND status = 'pending';
+    GET DIAGNOSTICS v_skipped = ROW_COUNT;
+  ELSIF p_table = 'returns' THEN
+    UPDATE xiaolan_returns SET status = 'skipped'
+     WHERE id = ANY(p_ids) AND status = 'pending';
+    GET DIAGNOSTICS v_skipped = ROW_COUNT;
+  END IF;
+
+  RETURN jsonb_build_object('resolved', v_resolved, 'skipped', v_skipped, 'errors', v_errors);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================
+-- 3. RLS
+-- ============================================================
+
+ALTER TABLE xiaolan_purchases       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE xiaolan_piaopiao        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE xiaolan_order_tracking  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE xiaolan_arrivals        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE xiaolan_returns         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE xiaolan_settings        ENABLE ROW LEVEL SECURITY;
+
+-- service_role bypass: PostgREST 用 service_role key 連線時自動 bypass RLS, 不用寫 policy
+-- admin: ALL on all tables
+-- 其他 role: 看不到
+
+CREATE POLICY xp_admin_all ON xiaolan_purchases
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','purchaser')
+  );
+CREATE POLICY xpp_admin_all ON xiaolan_piaopiao
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','purchaser')
+  );
+CREATE POLICY xt_admin_all ON xiaolan_order_tracking
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','purchaser')
+  );
+CREATE POLICY xa_admin_all ON xiaolan_arrivals
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','purchaser')
+  );
+CREATE POLICY xr_admin_all ON xiaolan_returns
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','purchaser')
+  );
+CREATE POLICY xs_admin_all ON xiaolan_settings
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );

--- a/supabase/migrations/20260423120005_ap_petty_expense.sql
+++ b/supabase/migrations/20260423120005_ap_petty_expense.sql
@@ -1,0 +1,692 @@
+-- ============================================================
+-- 應付帳款 (AP) + 零用金 (Petty Cash) + 費用 (Expense) v0.2
+-- PRD: docs/PRD-應付帳款零用金-v0.2.md
+-- ============================================================
+
+-- ============================================================
+-- 1. expense_categories (master, 先建以供 expenses FK)
+-- ============================================================
+
+CREATE TABLE expense_categories (
+  id                    BIGSERIAL PRIMARY KEY,
+  tenant_id             UUID NOT NULL,
+  code                  TEXT NOT NULL,
+  name                  TEXT NOT NULL,
+  parent_id             BIGINT REFERENCES expense_categories(id),
+  approval_threshold    NUMERIC(18,4),
+  default_pay_method    TEXT
+                          CHECK (default_pay_method IN ('petty_cash','company_account','either')),
+  is_active             BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by            UUID,
+  updated_by            UUID,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, code)
+);
+
+CREATE TRIGGER trg_touch_expense_cat BEFORE UPDATE ON expense_categories
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+-- ============================================================
+-- 2. vendor_bills
+-- ============================================================
+
+CREATE TABLE vendor_bills (
+  id                    BIGSERIAL PRIMARY KEY,
+  tenant_id             UUID NOT NULL,
+  bill_no               TEXT NOT NULL,
+  supplier_id           BIGINT NOT NULL REFERENCES suppliers(id),
+  source_type           TEXT NOT NULL
+                          CHECK (source_type IN ('purchase_order','goods_receipt',
+                                                 'transfer_settlement','xiaolan_import','manual')),
+  source_id             BIGINT,
+  bill_date             DATE NOT NULL,
+  due_date              DATE NOT NULL,
+  amount                NUMERIC(18,4) NOT NULL CHECK (amount > 0),
+  paid_amount           NUMERIC(18,4) NOT NULL DEFAULT 0
+                          CHECK (paid_amount >= 0 AND paid_amount <= amount),
+  status                TEXT NOT NULL DEFAULT 'pending'
+                          CHECK (status IN ('pending','partially_paid','paid','cancelled','disputed')),
+  currency              TEXT NOT NULL DEFAULT 'TWD',
+  tax_amount            NUMERIC(18,4) NOT NULL DEFAULT 0,
+  supplier_invoice_no   TEXT,
+  notes                 TEXT,
+  created_by            UUID,
+  updated_by            UUID,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, bill_no)
+);
+
+CREATE INDEX idx_bills_supplier ON vendor_bills (tenant_id, supplier_id, status);
+CREATE INDEX idx_bills_due ON vendor_bills (tenant_id, due_date)
+  WHERE status IN ('pending','partially_paid');
+CREATE INDEX idx_bills_source ON vendor_bills (tenant_id, source_type, source_id);
+
+-- vendor_bill_items (append-only)
+CREATE TABLE vendor_bill_items (
+  id            BIGSERIAL PRIMARY KEY,
+  tenant_id     UUID NOT NULL,
+  bill_id       BIGINT NOT NULL REFERENCES vendor_bills(id) ON DELETE CASCADE,
+  line_no       INTEGER NOT NULL,
+  description   TEXT NOT NULL,
+  sku_id        BIGINT REFERENCES skus(id),
+  qty           NUMERIC(18,3),
+  unit_cost     NUMERIC(18,4),
+  amount        NUMERIC(18,4) NOT NULL,
+  po_item_id    BIGINT REFERENCES purchase_order_items(id),
+  gr_item_id    BIGINT REFERENCES goods_receipt_items(id),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_bill_items_bill ON vendor_bill_items (bill_id, line_no);
+
+-- ============================================================
+-- 3. vendor_payments
+-- ============================================================
+
+CREATE TABLE vendor_payments (
+  id                       BIGSERIAL PRIMARY KEY,
+  tenant_id                UUID NOT NULL,
+  payment_no               TEXT NOT NULL,
+  supplier_id              BIGINT NOT NULL REFERENCES suppliers(id),
+  amount                   NUMERIC(18,4) NOT NULL CHECK (amount > 0),
+  method                   TEXT NOT NULL
+                             CHECK (method IN ('cash','bank_transfer','check','offset','petty_cash','other')),
+  bank_account             TEXT,
+  check_no                 TEXT,
+  paid_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  paid_from_petty_cash_id  BIGINT,  -- FK 加在 petty_cash_transactions 建表後
+  status                   TEXT NOT NULL DEFAULT 'completed'
+                             CHECK (status IN ('pending','completed','voided')),
+  notes                    TEXT,
+  created_by               UUID,
+  updated_by               UUID,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, payment_no)
+);
+
+CREATE INDEX idx_vpay_supplier ON vendor_payments (tenant_id, supplier_id, paid_at DESC);
+
+-- vendor_payment_allocations (append-only)
+CREATE TABLE vendor_payment_allocations (
+  id                  BIGSERIAL PRIMARY KEY,
+  tenant_id           UUID NOT NULL,
+  payment_id          BIGINT NOT NULL REFERENCES vendor_payments(id) ON DELETE CASCADE,
+  bill_id             BIGINT NOT NULL REFERENCES vendor_bills(id),
+  allocated_amount    NUMERIC(18,4) NOT NULL CHECK (allocated_amount > 0),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_vpay_alloc_bill ON vendor_payment_allocations (bill_id);
+CREATE INDEX idx_vpay_alloc_pay ON vendor_payment_allocations (payment_id);
+
+-- ============================================================
+-- 4. petty_cash_accounts + transactions
+-- ============================================================
+
+CREATE TABLE petty_cash_accounts (
+  id                  BIGSERIAL PRIMARY KEY,
+  tenant_id           UUID NOT NULL,
+  store_id            BIGINT NOT NULL REFERENCES stores(id),
+  account_name        TEXT NOT NULL,
+  balance             NUMERIC(18,4) NOT NULL DEFAULT 0,
+  credit_limit        NUMERIC(18,4) NOT NULL DEFAULT 0,
+  custodian_user_id   UUID,
+  is_active           BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by          UUID,
+  updated_by          UUID,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, store_id, account_name)
+);
+
+CREATE INDEX idx_pca_store ON petty_cash_accounts (tenant_id, store_id) WHERE is_active;
+
+CREATE TABLE petty_cash_transactions (
+  id                  BIGSERIAL PRIMARY KEY,
+  tenant_id           UUID NOT NULL,
+  account_id          BIGINT NOT NULL REFERENCES petty_cash_accounts(id),
+  txn_date            DATE NOT NULL DEFAULT CURRENT_DATE,
+  direction           TEXT NOT NULL CHECK (direction IN ('in','out')),
+  amount              NUMERIC(18,4) NOT NULL CHECK (amount > 0),
+  purpose             TEXT NOT NULL,
+  category_id         BIGINT REFERENCES expense_categories(id),
+  expense_id          BIGINT,  -- FK 加在 expenses 建表後
+  vendor_payment_id   BIGINT REFERENCES vendor_payments(id),
+  receipt_photo_url   TEXT,
+  notes               TEXT,
+  created_by          UUID,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_pct_account_date ON petty_cash_transactions (account_id, txn_date DESC);
+CREATE INDEX idx_pct_category ON petty_cash_transactions (category_id) WHERE category_id IS NOT NULL;
+
+-- 補建 vendor_payments → petty_cash_transactions FK
+ALTER TABLE vendor_payments
+  ADD CONSTRAINT fk_vpay_petty_cash
+  FOREIGN KEY (paid_from_petty_cash_id) REFERENCES petty_cash_transactions(id);
+
+-- ============================================================
+-- 5. expenses
+-- ============================================================
+
+CREATE TABLE expenses (
+  id                            BIGSERIAL PRIMARY KEY,
+  tenant_id                     UUID NOT NULL,
+  expense_no                    TEXT NOT NULL,
+  applicant_id                  UUID NOT NULL,
+  store_id                      BIGINT REFERENCES stores(id),
+  category_id                   BIGINT NOT NULL REFERENCES expense_categories(id),
+  amount                        NUMERIC(18,4) NOT NULL CHECK (amount > 0),
+  currency                      TEXT NOT NULL DEFAULT 'TWD',
+  expense_date                  DATE NOT NULL,
+  description                   TEXT NOT NULL,
+  receipt_photo_url             TEXT,
+  approval_status               TEXT NOT NULL DEFAULT 'pending'
+                                  CHECK (approval_status IN ('pending','approved','rejected','paid')),
+  approved_by                   UUID,
+  approved_at                   TIMESTAMPTZ,
+  rejection_reason              TEXT,
+  paid_by_vendor_payment_id     BIGINT REFERENCES vendor_payments(id),
+  paid_by_petty_cash_txn_id     BIGINT REFERENCES petty_cash_transactions(id),
+  settled_by_hq                 BOOLEAN NOT NULL DEFAULT FALSE,
+  created_by                    UUID,
+  updated_by                    UUID,
+  created_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, expense_no),
+  CHECK (
+    (paid_by_vendor_payment_id IS NULL)::int
+    + (paid_by_petty_cash_txn_id IS NULL)::int >= 1
+  )
+);
+
+CREATE INDEX idx_expenses_status ON expenses (tenant_id, approval_status);
+CREATE INDEX idx_expenses_store ON expenses (tenant_id, store_id, expense_date DESC);
+CREATE INDEX idx_expenses_applicant ON expenses (applicant_id, approval_status);
+
+-- 補建 petty_cash_transactions → expenses FK
+ALTER TABLE petty_cash_transactions
+  ADD CONSTRAINT fk_pct_expense
+  FOREIGN KEY (expense_id) REFERENCES expenses(id);
+
+-- 補建 transfer_settlements → vendor_bills FK (Flag 8)
+ALTER TABLE transfer_settlements
+  ADD CONSTRAINT fk_settlement_vendor_bill
+  FOREIGN KEY (generated_vendor_bill_id) REFERENCES vendor_bills(id);
+
+-- ============================================================
+-- 6. TRIGGERS
+-- ============================================================
+
+CREATE TRIGGER trg_touch_vendor_bills      BEFORE UPDATE ON vendor_bills
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_vendor_payments   BEFORE UPDATE ON vendor_payments
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_petty_acct        BEFORE UPDATE ON petty_cash_accounts
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+CREATE TRIGGER trg_touch_expenses          BEFORE UPDATE ON expenses
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+-- append-only 防 mutation
+CREATE TRIGGER trg_no_mut_bill_items   BEFORE UPDATE OR DELETE ON vendor_bill_items
+  FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+CREATE TRIGGER trg_no_mut_alloc        BEFORE UPDATE OR DELETE ON vendor_payment_allocations
+  FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+CREATE TRIGGER trg_no_mut_pct          BEFORE UPDATE OR DELETE ON petty_cash_transactions
+  FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+
+-- petty_cash_accounts.balance 自動由 transactions 維護
+CREATE OR REPLACE FUNCTION apply_petty_cash_txn()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_acct RECORD;
+  v_new_balance NUMERIC(18,4);
+BEGIN
+  SELECT * INTO v_acct FROM petty_cash_accounts
+   WHERE id = NEW.account_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'petty cash account % not found', NEW.account_id;
+  END IF;
+
+  v_new_balance := v_acct.balance + CASE WHEN NEW.direction = 'in' THEN NEW.amount ELSE -NEW.amount END;
+
+  IF v_new_balance + v_acct.credit_limit < 0 THEN
+    RAISE EXCEPTION 'petty cash overdraw: balance=%, credit_limit=%, change=%',
+      v_acct.balance, v_acct.credit_limit,
+      CASE WHEN NEW.direction = 'in' THEN NEW.amount ELSE -NEW.amount END;
+  END IF;
+
+  UPDATE petty_cash_accounts
+     SET balance = v_new_balance,
+         updated_at = NOW()
+   WHERE id = NEW.account_id;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_apply_petty_cash AFTER INSERT ON petty_cash_transactions
+  FOR EACH ROW EXECUTE FUNCTION apply_petty_cash_txn();
+
+-- 加盟店 supplier 同步 (Flag 8)
+CREATE OR REPLACE FUNCTION sync_store_as_supplier()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_supplier_id BIGINT;
+BEGIN
+  IF NEW.supplier_id IS NULL THEN
+    INSERT INTO suppliers (tenant_id, code, name, is_active, created_by, updated_by)
+    VALUES (NEW.tenant_id, 'STORE-' || NEW.code, NEW.name, TRUE,
+            NEW.created_by, COALESCE(NEW.updated_by, NEW.created_by))
+    RETURNING id INTO v_supplier_id;
+    NEW.supplier_id := v_supplier_id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_store_as_supplier BEFORE INSERT ON stores
+  FOR EACH ROW EXECUTE FUNCTION sync_store_as_supplier();
+
+-- ============================================================
+-- 7. VIEW: AP aging
+-- ============================================================
+
+CREATE OR REPLACE VIEW v_ap_aging AS
+SELECT
+  supplier_id,
+  supplier_name,
+  SUM(CASE WHEN due_date >= CURRENT_DATE THEN unpaid END) AS current_due,
+  SUM(CASE WHEN due_date BETWEEN CURRENT_DATE - 30 AND CURRENT_DATE - 1 THEN unpaid END) AS overdue_1_30,
+  SUM(CASE WHEN due_date BETWEEN CURRENT_DATE - 60 AND CURRENT_DATE - 31 THEN unpaid END) AS overdue_31_60,
+  SUM(CASE WHEN due_date < CURRENT_DATE - 60 THEN unpaid END) AS overdue_60_plus,
+  SUM(unpaid) AS total_unpaid
+FROM (
+  SELECT b.supplier_id, s.name AS supplier_name, b.due_date,
+         b.amount - b.paid_amount AS unpaid
+    FROM vendor_bills b
+    JOIN suppliers s ON s.id = b.supplier_id
+   WHERE b.status IN ('pending','partially_paid')
+) sub
+GROUP BY supplier_id, supplier_name;
+
+-- ============================================================
+-- 8. RPC FUNCTIONS
+-- ============================================================
+
+-- 手動建 bill
+CREATE OR REPLACE FUNCTION rpc_create_manual_bill(
+  p_tenant_id   UUID,
+  p_supplier_id BIGINT,
+  p_bill_no     TEXT,
+  p_bill_date   DATE,
+  p_due_date    DATE,
+  p_amount      NUMERIC,
+  p_notes       TEXT,
+  p_operator    UUID
+) RETURNS BIGINT AS $$
+DECLARE v_id BIGINT;
+BEGIN
+  INSERT INTO vendor_bills (tenant_id, bill_no, supplier_id, source_type,
+                            bill_date, due_date, amount, status, notes,
+                            created_by, updated_by)
+  VALUES (p_tenant_id, p_bill_no, p_supplier_id, 'manual',
+          p_bill_date, p_due_date, p_amount, 'pending', p_notes,
+          p_operator, p_operator)
+  RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 付款 + 分配多張 bill
+CREATE OR REPLACE FUNCTION rpc_make_payment(
+  p_tenant_id   UUID,
+  p_supplier_id BIGINT,
+  p_payment_no  TEXT,
+  p_amount      NUMERIC,
+  p_method      TEXT,
+  p_paid_at     TIMESTAMPTZ,
+  p_allocations JSONB,  -- [{bill_id, allocated_amount}]
+  p_operator    UUID
+) RETURNS BIGINT AS $$
+DECLARE
+  v_pay_id     BIGINT;
+  v_alloc      JSONB;
+  v_bill_id    BIGINT;
+  v_alloc_amt  NUMERIC(18,4);
+  v_total      NUMERIC(18,4) := 0;
+  v_bill       RECORD;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('vpay:' || p_supplier_id::text));
+
+  -- 驗 allocations 總和 = amount
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations)
+  LOOP
+    v_total := v_total + (v_alloc->>'allocated_amount')::numeric;
+  END LOOP;
+  IF v_total <> p_amount THEN
+    RAISE EXCEPTION 'allocations sum (%) does not match payment amount (%)', v_total, p_amount;
+  END IF;
+
+  INSERT INTO vendor_payments (tenant_id, payment_no, supplier_id, amount, method,
+                               paid_at, status, created_by, updated_by)
+  VALUES (p_tenant_id, p_payment_no, p_supplier_id, p_amount, p_method,
+          p_paid_at, 'completed', p_operator, p_operator)
+  RETURNING id INTO v_pay_id;
+
+  -- 分配
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations)
+  LOOP
+    v_bill_id := (v_alloc->>'bill_id')::bigint;
+    v_alloc_amt := (v_alloc->>'allocated_amount')::numeric;
+
+    SELECT * INTO v_bill FROM vendor_bills
+     WHERE id = v_bill_id AND tenant_id = p_tenant_id FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'bill % not found', v_bill_id;
+    END IF;
+    IF v_bill.paid_amount + v_alloc_amt > v_bill.amount THEN
+      RAISE EXCEPTION 'over-allocation on bill %: paid=%, alloc=%, total=%',
+        v_bill_id, v_bill.paid_amount, v_alloc_amt, v_bill.amount;
+    END IF;
+
+    INSERT INTO vendor_payment_allocations (tenant_id, payment_id, bill_id, allocated_amount)
+    VALUES (p_tenant_id, v_pay_id, v_bill_id, v_alloc_amt);
+
+    UPDATE vendor_bills
+       SET paid_amount = paid_amount + v_alloc_amt,
+           status = CASE WHEN paid_amount + v_alloc_amt = amount THEN 'paid' ELSE 'partially_paid' END,
+           updated_by = p_operator
+     WHERE id = v_bill_id;
+  END LOOP;
+
+  RETURN v_pay_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 員工申請費用
+CREATE OR REPLACE FUNCTION rpc_add_expense(
+  p_tenant_id    UUID,
+  p_expense_no   TEXT,
+  p_applicant    UUID,
+  p_store_id     BIGINT,
+  p_category_id  BIGINT,
+  p_amount       NUMERIC,
+  p_expense_date DATE,
+  p_description  TEXT,
+  p_receipt_url  TEXT
+) RETURNS BIGINT AS $$
+DECLARE
+  v_id        BIGINT;
+  v_threshold NUMERIC(18,4);
+  v_status    TEXT;
+BEGIN
+  SELECT approval_threshold INTO v_threshold
+    FROM expense_categories WHERE id = p_category_id;
+
+  v_status := CASE
+                WHEN v_threshold IS NULL OR p_amount < v_threshold THEN 'approved'
+                ELSE 'pending'
+              END;
+
+  INSERT INTO expenses (tenant_id, expense_no, applicant_id, store_id, category_id,
+                        amount, expense_date, description, receipt_photo_url,
+                        approval_status, approved_at, approved_by,
+                        created_by, updated_by)
+  VALUES (p_tenant_id, p_expense_no, p_applicant, p_store_id, p_category_id,
+          p_amount, p_expense_date, p_description, p_receipt_url,
+          v_status,
+          CASE WHEN v_status = 'approved' THEN NOW() END,
+          CASE WHEN v_status = 'approved' THEN p_applicant END,
+          p_applicant, p_applicant)
+  RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 審核通過
+CREATE OR REPLACE FUNCTION rpc_approve_expense(
+  p_expense_id BIGINT,
+  p_note       TEXT,
+  p_operator   UUID
+) RETURNS VOID AS $$
+DECLARE
+  v_applicant UUID;
+BEGIN
+  SELECT applicant_id INTO v_applicant FROM expenses
+   WHERE id = p_expense_id AND approval_status = 'pending' FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'expense % not found or not pending', p_expense_id;
+  END IF;
+
+  IF v_applicant = p_operator THEN
+    RAISE EXCEPTION 'cannot approve own expense';
+  END IF;
+
+  UPDATE expenses
+     SET approval_status = 'approved',
+         approved_by = p_operator,
+         approved_at = NOW(),
+         rejection_reason = NULL,
+         updated_by = p_operator
+   WHERE id = p_expense_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 審核退回
+CREATE OR REPLACE FUNCTION rpc_reject_expense(
+  p_expense_id BIGINT,
+  p_reason     TEXT,
+  p_operator   UUID
+) RETURNS VOID AS $$
+BEGIN
+  IF p_reason IS NULL OR length(p_reason) = 0 THEN
+    RAISE EXCEPTION 'rejection reason is required';
+  END IF;
+
+  UPDATE expenses
+     SET approval_status = 'rejected',
+         rejection_reason = p_reason,
+         approved_by = p_operator,
+         approved_at = NOW(),
+         updated_by = p_operator
+   WHERE id = p_expense_id AND approval_status = 'pending';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'expense % not found or not pending', p_expense_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 零用金流水
+CREATE OR REPLACE FUNCTION rpc_post_petty_cash_txn(
+  p_tenant_id  UUID,
+  p_account_id BIGINT,
+  p_direction  TEXT,
+  p_amount     NUMERIC,
+  p_purpose    TEXT,
+  p_category_id BIGINT,
+  p_operator   UUID,
+  p_notes      TEXT DEFAULT NULL,
+  p_receipt_url TEXT DEFAULT NULL
+) RETURNS BIGINT AS $$
+DECLARE v_id BIGINT;
+BEGIN
+  INSERT INTO petty_cash_transactions (tenant_id, account_id, direction, amount,
+                                       purpose, category_id, notes, receipt_photo_url,
+                                       created_by)
+  VALUES (p_tenant_id, p_account_id, p_direction, p_amount,
+          p_purpose, p_category_id, p_notes, p_receipt_url, p_operator)
+  RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 重新定義 rpc_confirm_transfer_settlement (擴充: net>0 自動建 vendor_bill, Flag 8)
+CREATE OR REPLACE FUNCTION rpc_confirm_transfer_settlement(
+  p_settlement_id BIGINT,
+  p_operator      UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_s            RECORD;
+  v_debtor_id    BIGINT;
+  v_creditor_id  BIGINT;
+  v_supplier_id  BIGINT;
+  v_bill_id      BIGINT;
+BEGIN
+  SELECT * INTO v_s FROM transfer_settlements
+   WHERE id = p_settlement_id AND status = 'draft' FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'settlement % not found or not draft', p_settlement_id;
+  END IF;
+
+  UPDATE transfer_settlements
+     SET status = 'confirmed',
+         settled_by = p_operator,
+         settled_at = NOW(),
+         updated_by = p_operator
+   WHERE id = p_settlement_id;
+
+  IF v_s.net_amount > 0 THEN
+    -- A 欠 B (a_to_b > b_to_a, 故 store_a 欠 store_b)
+    v_debtor_id := v_s.store_a_id;
+    v_creditor_id := v_s.store_b_id;
+  ELSIF v_s.net_amount < 0 THEN
+    -- B 欠 A
+    v_debtor_id := v_s.store_b_id;
+    v_creditor_id := v_s.store_a_id;
+  END IF;
+
+  IF v_s.net_amount <> 0 THEN
+    SELECT supplier_id INTO v_supplier_id FROM stores WHERE id = v_creditor_id;
+    IF v_supplier_id IS NULL THEN
+      RAISE EXCEPTION 'creditor store % has no supplier_id mapping', v_creditor_id;
+    END IF;
+
+    INSERT INTO vendor_bills (tenant_id, bill_no, supplier_id, source_type, source_id,
+                              bill_date, due_date, amount, status, notes,
+                              created_by, updated_by)
+    VALUES (v_s.tenant_id,
+            'SETTLE-' || p_settlement_id,
+            v_supplier_id, 'transfer_settlement', p_settlement_id,
+            CURRENT_DATE, CURRENT_DATE + INTERVAL '30 days',
+            ABS(v_s.net_amount), 'pending',
+            'auto-generated from transfer_settlement #' || p_settlement_id,
+            p_operator, p_operator)
+    RETURNING id INTO v_bill_id;
+
+    UPDATE transfer_settlements
+       SET generated_vendor_bill_id = v_bill_id, updated_by = p_operator
+     WHERE id = p_settlement_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'settlement_id', p_settlement_id,
+    'net_amount', v_s.net_amount,
+    'vendor_bill_id', v_bill_id
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================
+-- 9. RLS
+-- ============================================================
+
+ALTER TABLE vendor_bills                 ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vendor_bill_items            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vendor_payments              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vendor_payment_allocations   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE petty_cash_accounts          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE petty_cash_transactions      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE expenses                     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE expense_categories           ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY vb_admin_all ON vendor_bills
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','hq_accountant')
+  );
+CREATE POLICY vb_store_read ON vendor_bills
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND supplier_id = (SELECT supplier_id FROM stores WHERE id = (auth.jwt() ->> 'store_id')::bigint)
+  );
+
+CREATE POLICY vbi_admin_all ON vendor_bill_items
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','hq_accountant')
+  );
+
+CREATE POLICY vp_admin_all ON vendor_payments
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','hq_accountant')
+  );
+
+CREATE POLICY vpa_admin_all ON vendor_payment_allocations
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','hq_accountant')
+  );
+
+CREATE POLICY pca_admin_all ON petty_cash_accounts
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','hq_accountant')
+  );
+CREATE POLICY pca_store_own ON petty_cash_accounts
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND store_id = (auth.jwt() ->> 'store_id')::bigint
+  );
+
+CREATE POLICY pct_admin_all ON petty_cash_transactions
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','hq_accountant')
+  );
+CREATE POLICY pct_store_access ON petty_cash_transactions
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND account_id IN (SELECT id FROM petty_cash_accounts
+                        WHERE store_id = (auth.jwt() ->> 'store_id')::bigint)
+  );
+
+CREATE POLICY exp_applicant ON expenses
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND applicant_id = (auth.jwt() ->> 'sub')::uuid
+  );
+CREATE POLICY exp_admin_all ON expenses
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager','hq_accountant')
+  );
+
+CREATE POLICY ec_read_all ON expense_categories
+  FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid);
+CREATE POLICY ec_admin_write ON expense_categories
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+
+-- ============================================================
+-- 10. SEED expense_categories (placeholder tenant_id 須由 admin 後續 update)
+-- ============================================================
+
+-- 預留：實際 seed 須在租戶建立後手動執行 (依 tenant_id)
+-- 樣板:
+-- INSERT INTO expense_categories (tenant_id, code, name, default_pay_method) VALUES
+--   ('<tenant_id>', 'TRANSPORT',  '交通',     'either'),
+--   ('<tenant_id>', 'STATIONERY', '文具',     'petty_cash'),
+--   ('<tenant_id>', 'MEAL',       '餐飲',     'petty_cash'),
+--   ('<tenant_id>', 'COMMS',      '通訊',     'company_account'),
+--   ('<tenant_id>', 'UTILITY',    '水電',     'company_account'),
+--   ('<tenant_id>', 'MISC',       '雜支',     'either'),
+--   ('<tenant_id>', 'REPAIR',     '修繕',     'company_account'),
+--   ('<tenant_id>', 'PURCHASE_MISC', '採購雜項', 'either');


### PR DESCRIPTION
## Summary

- **v0.1.1 backfill**: `stores` + 12 order/pickup tables（訂單取貨 v0.1.1 最終定稿，補齊 `docs/PRD-訂單取貨模組.md` 已規劃但 `docs/sql/` 還沒落的 schema）
- **v0.2 migrations × 5**: 落 5 份 v0.2 PRD（commit 7979e99）的 schema
  - `picking_waves` — 3 表 + 2 view + 4 RPC（揀貨波次，PRD #1）
  - `inventory_v02_demand_aid_settlement` — 7 表 + 7 RPC（需求 / 欠品 / 互助 / 88 折 / 月結算，PRD #2）
  - `purchase_v02_review_arrival` — 2 表 + 4 ALTER + view + 4 RPC（PR 內審 / 陸貨多月到貨，PRD #3）
  - `xiaolan_tables` — 6 表 + 5 RPC（供應商小瀻 + Apps Script sync，PRD #4）
  - `ap_petty_expense` — 8 表 + balance trigger + sync_store_as_supplier + view + 7 RPC（應付帳款 / 零用金，PRD #5）
- **lint**: 加 `.claude-scripts/lint_sql.js`（pg-query-emscripten-based、可重跑）

## Deployment status

- ✅ **全部 6 個 migration 已推 Supabase dev**（project `anfyoeviuhmzzrhilwtm`，SG region）
- ✅ pg-query-emscripten lint 全過（修了 6 個 schema 不相容）
- ✅ Supabase dev 目前 ~96 tables（56 initial + 40 v0.2）

## Test plan

- [x] Lint 全過（`node .claude-scripts/lint_sql.js`）
- [x] 推 Supabase dev 成功（`supabase db push --include-all`）
- [ ] Reviewer 驗證 PRD ↔ schema 對應（5 份 addendum 都在 `docs/`）
- [ ] Merge 後把 dev 資料複製到 staging（staging 還沒建）

## Related

- PRD commit: 7979e99（5 份 v0.2 addendum + Q1-Q5 決策 doc）
- Epics: #96（訂單取貨）/ #97（庫存）/ #98（採購）/ #99（供應商）
- Follows: #95（initial 56-table schema，已 merge）

🤖 Generated with [Claude Code](https://claude.com/claude-code)