### PR TITLE
feat(admin): 會員/開團/訂單/供應商 4 模組核心 UI (#107) (#109)

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -3,8 +3,6 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
-import { Modal } from "@/components/Modal";
-import { CampaignForm, type CampaignFormValues } from "@/components/CampaignForm";
 
 type Status =
   | "draft" | "open" | "closed" | "ordered" | "receiving" | "ready" | "completed" | "cancelled";
@@ -39,8 +37,6 @@ export default function CampaignsListPage() {
   const [page, setPage] = useState(1);
 
   const [itemCounts, setItemCounts] = useState<Map<number, number>>(new Map());
-  const [modalOpen, setModalOpen] = useState(false);
-  const [reloadTick, setReloadTick] = useState(0);
 
   useEffect(() => {
     const t = setTimeout(() => { setQuery(queryDraft); setPage(1); }, 250);
@@ -89,7 +85,7 @@ export default function CampaignsListPage() {
       }
     })();
     return () => { cancelled = true; };
-  }, [query, status, page, reloadTick]);
+  }, [query, status, page]);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const fromIdx = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
@@ -104,9 +100,9 @@ export default function CampaignsListPage() {
             {loading ? "載入中…" : total === 0 ? "共 0 筆" : `共 ${total} 筆（${fromIdx}-${toIdx}）`}
           </p>
         </div>
-        <button onClick={() => setModalOpen(true)} className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200">
+        <Link href="/campaigns/new" className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200">
           新增開團
-        </button>
+        </Link>
       </header>
 
       <div className="grid gap-3 sm:grid-cols-2">
@@ -160,15 +156,6 @@ export default function CampaignsListPage() {
           </tbody>
         </table>
       </div>
-
-      <Modal open={modalOpen} onClose={() => setModalOpen(false)} title="新增開團">
-        {modalOpen && (
-          <CampaignForm
-            onSaved={(id) => { setModalOpen(false); setReloadTick((t) => t + 1); window.location.href = `/campaigns/edit?id=${id}&saved=1`; }}
-            onCancel={() => setModalOpen(false)}
-          />
-        )}
-      </Modal>
 
       {totalPages > 1 && (
         <div className="flex items-center justify-end gap-2 text-sm">

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -6,30 +6,12 @@ import { useEffect, type ReactNode } from "react";
 import { useAuth } from "@/components/AuthProvider";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
-type NavItem = { href: string; label: string; match: RegExp };
-type NavGroup = { title?: string; items: NavItem[] };
-
-const NAV: NavGroup[] = [
-  {
-    items: [
-      { href: "/", label: "儀表板", match: /^\/$/ },
-    ],
-  },
-  {
-    title: "核心業務",
-    items: [
-      { href: "/orders", label: "訂單", match: /^\/orders/ },
-      { href: "/campaigns", label: "開團", match: /^\/campaigns/ },
-      { href: "/products", label: "商品", match: /^\/products/ },
-      { href: "/members", label: "會員", match: /^\/members/ },
-    ],
-  },
-  {
-    title: "進銷存",
-    items: [
-      { href: "/suppliers", label: "供應商", match: /^\/suppliers/ },
-    ],
-  },
+const NAV_ITEMS: { href: string; label: string; match: RegExp }[] = [
+  { href: "/products",  label: "商品",   match: /^\/products/  },
+  { href: "/members",   label: "會員",   match: /^\/members/   },
+  { href: "/campaigns", label: "開團",   match: /^\/campaigns/ },
+  { href: "/orders",    label: "訂單",   match: /^\/orders/    },
+  { href: "/suppliers", label: "供應商", match: /^\/suppliers/ },
 ];
 
 export default function ProtectedLayout({ children }: { children: ReactNode }) {
@@ -59,48 +41,28 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
   }
 
   return (
-    <div className="flex min-h-full flex-1">
-      <aside className="hidden w-52 shrink-0 flex-col border-r border-zinc-200 bg-zinc-50 md:flex dark:border-zinc-800 dark:bg-zinc-950">
-        <div className="border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">
-          <Link href="/" className="block">
-            <div className="text-lg font-semibold tracking-tight">new_erp</div>
-            <div className="text-xs text-zinc-500">團購店管理</div>
+    <div className="flex min-h-full flex-1 flex-col">
+      <header className="flex items-center justify-between border-b border-zinc-200 bg-white px-6 py-3 dark:border-zinc-800 dark:bg-zinc-900">
+        <nav className="flex items-center gap-4 text-sm">
+          <Link href="/" className="font-semibold">
+            new_erp
           </Link>
-          <div className="mt-2 inline-flex items-center gap-1 rounded-full border border-zinc-300 bg-white px-2 py-0.5 text-[10px] text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
-            <span className="h-1.5 w-1.5 rounded-full bg-amber-400" /> 開發版
-          </div>
-        </div>
-
-        <nav className="flex-1 overflow-y-auto px-2 py-3 text-sm">
-          {NAV.map((g, gi) => (
-            <div key={gi} className="mb-4">
-              {g.title && (
-                <div className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-                  {g.title}
-                </div>
-              )}
-              <ul className="space-y-0.5">
-                {g.items.map((it) => {
-                  const active = it.match.test(pathname || "");
-                  return (
-                    <li key={it.href}>
-                      <Link
-                        href={it.href}
-                        className={
-                          active
-                            ? "flex items-center justify-between rounded-md bg-zinc-900 px-3 py-2 text-white dark:bg-zinc-100 dark:text-zinc-900"
-                            : "flex items-center justify-between rounded-md px-3 py-2 text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900"
-                        }
-                      >
-                        <span>{it.label}</span>
-                        {active && <span className="text-xs opacity-60">›</span>}
-                      </Link>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          ))}
+          {NAV_ITEMS.map((it) => {
+            const active = it.match.test(pathname || "");
+            return (
+              <Link
+                key={it.href}
+                href={it.href}
+                className={
+                  active
+                    ? "rounded-md bg-zinc-100 px-2 py-1 font-medium text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"
+                    : "rounded-md px-2 py-1 text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                }
+              >
+                {it.label}
+              </Link>
+            );
+          })}
         </nav>
 
         <div className="border-t border-zinc-200 p-3 text-xs dark:border-zinc-800">

--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -3,8 +3,6 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
-import { Modal } from "@/components/Modal";
-import { MemberForm, type MemberFormValues } from "@/components/MemberForm";
 
 type Status = "active" | "inactive" | "blocked" | "merged" | "deleted";
 type SortKey = "updated_at" | "member_no" | "name";
@@ -42,16 +40,12 @@ export default function MembersListPage() {
   const [query, setQuery] = useState("");
   const [tierId, setTierId] = useState<string>("");
   const [status, setStatus] = useState<string>("");
-  const [storeId, setStoreId] = useState<string>("");
   const [sortBy, setSortBy] = useState<SortKey>("updated_at");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [page, setPage] = useState(1);
 
   const [tiers, setTiers] = useState<Tier[]>([]);
-  const [stores, setStores] = useState<Store[]>([]);
   const [balances, setBalances] = useState<Map<number, { points: number; wallet: number }>>(new Map());
-  const [reloadTick, setReloadTick] = useState(0);
-  const [modal, setModal] = useState<{ mode: "new" } | { mode: "edit"; values: MemberFormValues } | null>(null);
 
   useEffect(() => {
     const t = setTimeout(() => {
@@ -63,16 +57,15 @@ export default function MembersListPage() {
 
   useEffect(() => {
     setPage(1);
-  }, [tierId, status, storeId, sortBy, sortDir]);
+  }, [tierId, status, sortBy, sortDir]);
 
   useEffect(() => {
     (async () => {
-      const [t, s] = await Promise.all([
-        getSupabase().from("member_tiers").select("id, code, name").order("sort_order"),
-        getSupabase().from("stores").select("id, code, name").eq("is_active", true).order("name"),
-      ]);
-      if (t.data) setTiers(t.data as Tier[]);
-      if (s.data) setStores(s.data as Store[]);
+      const { data } = await getSupabase()
+        .from("member_tiers")
+        .select("id, code, name")
+        .order("sort_order");
+      if (data) setTiers(data as Tier[]);
     })();
   }, []);
 
@@ -93,7 +86,6 @@ export default function MembersListPage() {
         }
         if (tierId) q = q.eq("tier_id", Number(tierId));
         if (status) q = q.eq("status", status);
-        if (storeId) q = q.eq("home_store_id", Number(storeId));
 
         const { data, count, error } = await q;
         if (cancelled) return;
@@ -134,7 +126,7 @@ export default function MembersListPage() {
     return () => {
       cancelled = true;
     };
-  }, [query, tierId, status, storeId, sortBy, sortDir, page, reloadTick]);
+  }, [query, tierId, status, sortBy, sortDir, page]);
 
   const tierMap = useMemo(() => new Map(tiers.map((t) => [t.id, t])), [tiers]);
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -158,15 +150,15 @@ export default function MembersListPage() {
             {loading ? "載入中…" : total === 0 ? "共 0 筆" : `共 ${total} 筆（顯示 ${fromIdx}-${toIdx}）`}
           </p>
         </div>
-        <button
-          onClick={() => setModal({ mode: "new" })}
+        <Link
+          href="/members/new"
           className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
         >
           新增會員
-        </button>
+        </Link>
       </header>
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         <input
           type="search"
           placeholder="搜尋 會員編號 / 姓名 / 手機"
@@ -196,18 +188,6 @@ export default function MembersListPage() {
           <option value="inactive">停用</option>
           <option value="blocked">封鎖</option>
         </select>
-        <select
-          value={storeId}
-          onChange={(e) => setStoreId(e.target.value)}
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-        >
-          <option value="">全部門市</option>
-          {stores.map((s) => (
-            <option key={s.id} value={s.id}>
-              {s.name} ({s.code})
-            </option>
-          ))}
-        </select>
       </div>
 
       {error && (
@@ -229,15 +209,14 @@ export default function MembersListPage() {
               <Th className="text-right">儲值</Th>
               <Th>狀態</Th>
               <ThSort label="更新" col="updated_at" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} align="right" />
-              <Th>{""}</Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <SkeletonRows cols={9} />
+              <SkeletonRows cols={8} />
             ) : rows.length === 0 ? (
               <tr>
-                <td colSpan={9} className="p-6 text-center text-sm text-zinc-500">
+                <td colSpan={8} className="p-6 text-center text-sm text-zinc-500">
                   {total === 0 && !query && !tierId && !status
                     ? "還沒有會員，按「新增會員」開始建立。"
                     : "沒有符合條件的會員。"}
@@ -266,25 +245,6 @@ export default function MembersListPage() {
                     <Td className="text-right text-zinc-500">
                       {new Date(r.updated_at).toLocaleString("zh-TW")}
                     </Td>
-                    <Td>
-                      <button
-                        onClick={async () => {
-                          const { data } = await getSupabase()
-                            .from("members")
-                            .select("id, member_no, phone, name, gender, birthday, email, tier_id, home_store_id, status, notes")
-                            .eq("id", r.id).maybeSingle();
-                          if (data) setModal({ mode: "edit", values: {
-                            id: data.id, member_no: data.member_no, phone: data.phone ?? "",
-                            name: data.name ?? "", gender: data.gender, birthday: data.birthday,
-                            email: data.email, tier_id: data.tier_id, home_store_id: data.home_store_id,
-                            status: data.status, notes: data.notes,
-                          }});
-                        }}
-                        className="text-xs text-blue-600 hover:underline dark:text-blue-400"
-                      >
-                        編輯
-                      </button>
-                    </Td>
                   </tr>
                 );
               })
@@ -292,20 +252,6 @@ export default function MembersListPage() {
           </tbody>
         </table>
       </div>
-
-      <Modal
-        open={!!modal}
-        onClose={() => setModal(null)}
-        title={modal?.mode === "edit" ? `編輯會員 #${modal.values.member_no}` : "新增會員"}
-      >
-        {modal && (
-          <MemberForm
-            initial={modal.mode === "edit" ? modal.values : undefined}
-            onSaved={() => { setModal(null); setReloadTick((t) => t + 1); }}
-            onCancel={() => setModal(null)}
-          />
-        )}
-      </Modal>
 
       {totalPages > 1 && (
         <div className="flex items-center justify-end gap-2 text-sm">

--- a/apps/admin/src/components/CampaignForm.tsx
+++ b/apps/admin/src/components/CampaignForm.tsx
@@ -49,15 +49,7 @@ const STATUS_OPT: { v: CampaignStatus; label: string }[] = [
   { v: "cancelled", label: "已取消" },
 ];
 
-export function CampaignForm({
-  initial,
-  onSaved,
-  onCancel,
-}: {
-  initial?: CampaignFormValues;
-  onSaved?: (id: number) => void;
-  onCancel?: () => void;
-}) {
+export function CampaignForm({ initial }: { initial?: CampaignFormValues }) {
   const router = useRouter();
   const [v, setV] = useState<CampaignFormValues>(initial ?? emptyCampaignValues);
   const [saving, setSaving] = useState(false);
@@ -87,9 +79,7 @@ export function CampaignForm({
         p_notes: v.notes,
       });
       if (err) throw err;
-      const newId = Number(data);
-      if (onSaved) onSaved(newId);
-      else router.replace(`/campaigns/edit?id=${newId}&saved=1`);
+      router.replace(`/campaigns/edit?id=${Number(data)}&saved=1`);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -154,7 +144,7 @@ export function CampaignForm({
         <button type="submit" disabled={saving} className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200">
           {saving ? "儲存中…" : v.id ? "儲存" : "建立開團"}
         </button>
-        <button type="button" onClick={() => onCancel ? onCancel() : router.push("/campaigns")} className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800">取消</button>
+        <button type="button" onClick={() => router.push("/campaigns")} className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800">取消</button>
       </div>
     </form>
   );

--- a/apps/admin/src/components/CampaignItemsTable.tsx
+++ b/apps/admin/src/components/CampaignItemsTable.tsx
@@ -7,15 +7,14 @@ type Row = {
   id: number;
   sku_id: number;
   sku_code: string;
-  product_name: string | null;
-  variant_name: string | null;
+  sku_name: string;
   unit_price: number;
   cap_qty: number | null;
   sort_order: number;
   notes: string | null;
 };
 
-type SkuOption = { id: number; sku_code: string; product_name: string | null; variant_name: string | null };
+type SkuOption = { id: number; sku_code: string; name: string };
 
 export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
   const [rows, setRows] = useState<Row[] | null>(null);
@@ -27,7 +26,7 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
   const reload = async () => {
     const { data, error: err } = await getSupabase()
       .from("campaign_items")
-      .select("id, sku_id, unit_price, cap_qty, sort_order, notes, skus!inner(id, sku_code, product_name, variant_name)")
+      .select("id, sku_id, unit_price, cap_qty, sort_order, notes, skus!inner(id, sku_code, name)")
       .eq("campaign_id", campaignId)
       .order("sort_order");
     if (err) { setError(err.message); return; }
@@ -35,10 +34,9 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
       (data as unknown as Array<{
         id: number; sku_id: number; unit_price: number; cap_qty: number | null;
         sort_order: number; notes: string | null;
-        skus: { id: number; sku_code: string; product_name: string | null; variant_name: string | null };
+        skus: { id: number; sku_code: string; name: string };
       }>).map((r) => ({
-        id: r.id, sku_id: r.sku_id, sku_code: r.skus.sku_code,
-        product_name: r.skus.product_name, variant_name: r.skus.variant_name,
+        id: r.id, sku_id: r.sku_id, sku_code: r.skus.sku_code, sku_name: r.skus.name,
         unit_price: Number(r.unit_price), cap_qty: r.cap_qty != null ? Number(r.cap_qty) : null,
         sort_order: r.sort_order, notes: r.notes,
       }))
@@ -48,20 +46,15 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
   useEffect(() => { reload(); }, [campaignId]);
 
   useEffect(() => {
+    if (!skuQuery.trim()) { setSkuResults([]); return; }
     const t = setTimeout(async () => {
-      let q = getSupabase()
-        .from("skus").select("id, sku_code, product_name, variant_name")
-        .eq("status", "active")
-        .order("updated_at", { ascending: false })
-        .limit(20);
-      const s = skuQuery.trim();
-      if (s) {
-        const safe = s.replace(/[%,()]/g, " ").trim();
-        q = q.or(`sku_code.ilike.%${safe}%,product_name.ilike.%${safe}%,variant_name.ilike.%${safe}%`);
-      }
-      const { data } = await q;
+      const safe = skuQuery.replace(/[%,()]/g, " ").trim();
+      const { data } = await getSupabase()
+        .from("skus").select("id, sku_code, name")
+        .or(`sku_code.ilike.%${safe}%,name.ilike.%${safe}%`)
+        .limit(10);
       setSkuResults((data as SkuOption[]) ?? []);
-    }, skuQuery ? 250 : 0);
+    }, 250);
     return () => clearTimeout(t);
   }, [skuQuery]);
 
@@ -126,10 +119,7 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
             ) : rows.map((r) => (
               <tr key={r.id}>
                 <Td className="font-mono">{r.sku_code}</Td>
-                <Td>
-                  <div>{r.product_name ?? "—"}</div>
-                  {r.variant_name && <div className="text-xs text-zinc-500">{r.variant_name}</div>}
-                </Td>
+                <Td>{r.sku_name}</Td>
                 <Td className="text-right">
                   <input
                     type="number" step="0.0001" defaultValue={r.unit_price}
@@ -159,13 +149,8 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
             />
           </div>
         </div>
-        {skuResults.length === 0 && !adding && (
-          <div className="mt-2 rounded-md border border-dashed border-zinc-300 p-3 text-center text-xs text-zinc-500 dark:border-zinc-700">
-            尚無 SKU。先去 <a href="/products" className="underline">商品</a> 頁建 SKU
-          </div>
-        )}
         {skuResults.length > 0 && !adding && (
-          <ul className="mt-2 max-h-72 divide-y divide-zinc-200 overflow-y-auto rounded-md border border-zinc-200 dark:divide-zinc-800 dark:border-zinc-800">
+          <ul className="mt-2 divide-y divide-zinc-200 rounded-md border border-zinc-200 dark:divide-zinc-800 dark:border-zinc-800">
             {skuResults.map((s) => (
               <li key={s.id}>
                 <button
@@ -174,10 +159,7 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
                   className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-zinc-50 dark:hover:bg-zinc-800"
                 >
                   <span className="font-mono">{s.sku_code}</span>
-                  <span className="text-zinc-600 dark:text-zinc-400">
-                    {s.product_name ?? "—"}
-                    {s.variant_name ? ` · ${s.variant_name}` : ""}
-                  </span>
+                  <span className="text-zinc-600 dark:text-zinc-400">{s.name}</span>
                 </button>
               </li>
             ))}
@@ -188,10 +170,7 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
             <div className="text-sm">
               <div className="text-xs text-zinc-500">已選 SKU</div>
               <div className="font-mono">{adding.sku.sku_code}</div>
-              <div className="text-xs text-zinc-600 dark:text-zinc-400">
-                {adding.sku.product_name ?? "—"}
-                {adding.sku.variant_name ? ` · ${adding.sku.variant_name}` : ""}
-              </div>
+              <div className="text-xs text-zinc-600 dark:text-zinc-400">{adding.sku.name}</div>
             </div>
             <label className="text-sm">
               <div className="text-xs text-zinc-500">單價</div>

--- a/apps/admin/src/components/MemberForm.tsx
+++ b/apps/admin/src/components/MemberForm.tsx
@@ -38,15 +38,7 @@ export const emptyMemberValues: MemberFormValues = {
   notes: null,
 };
 
-export function MemberForm({
-  initial,
-  onSaved,
-  onCancel,
-}: {
-  initial?: MemberFormValues;
-  onSaved?: (id: number) => void;
-  onCancel?: () => void;
-}) {
+export function MemberForm({ initial }: { initial?: MemberFormValues }) {
   const router = useRouter();
   const [v, setV] = useState<MemberFormValues>(initial ?? emptyMemberValues);
   const [tiers, setTiers] = useState<Tier[]>([]);
@@ -98,8 +90,7 @@ export function MemberForm({
       });
       if (err) throw err;
       const newId = Number(data);
-      if (onSaved) onSaved(newId);
-      else router.replace(`/members/detail?id=${newId}`);
+      router.replace(`/members/edit?id=${newId}&saved=1`);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -223,7 +214,7 @@ export function MemberForm({
         </button>
         <button
           type="button"
-          onClick={() => onCancel ? onCancel() : router.push("/members")}
+          onClick={() => router.push("/members")}
           className="rounded-md border border-zinc-300 px-4 py-2 text-sm text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
         >
           取消


### PR DESCRIPTION
- migration 20260425120000_core_crud_rpcs.sql
  - 17 relaxed read RLS policies（authenticated + tenant match）
  - 7 write RPCs: upsert_member/tier/supplier/store/line_channel/campaign/campaign_item
  - rpc_delete_campaign_item
  - members + phone/email/birthday plaintext columns (MVP、未來改 pgp_sym_encrypt)
- 會員：列表（搜尋/篩 tier/status/積分+儲值餘額/分頁）+ new + edit + detail（積分/儲值 ledger tabs）
- 開團：列表 + new + edit（含 CampaignItemsTable inline 商品 CRUD）
- 訂單：列表（篩 campaign/status/store、會員姓名+手機）
- 供應商：列表 + inline 新增/編輯（搜尋、只啟用 toggle）
- Header nav 加 會員/開團/訂單/供應商（active 樣式）
- 測試：docs/TEST-core-modules*.md + .claude-scripts/test_core_rpcs.js
  - RPC 驗證：upsert_campaign/supplier/member PASS + duplicate phone 正確被 UNIQUE 阻擋
  - Preview：17 routes build PASS、members 建立+detail / supplier 建立 全通