### PR TITLE
feat: 訂單/商品/會員/規格 一連串 UX + RPC 補強（PR #113 後續）

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
@@ -14,14 +14,14 @@ type Campaign = {
 
 type Channel = { id: number; name: string; home_store_id: number };
 
-type Store = { id: number; name: string };
-
 type MemberRow = {
   id: number;
   member_no: string;
   name: string;
   phone: string | null;
   avatar_url: string | null;
+  home_store_id: number | null;
+  home_store_name: string | null;
 };
 
 type AliasRow = {
@@ -32,6 +32,8 @@ type AliasRow = {
   member_name: string;
   phone: string | null;
   avatar_url: string | null;
+  home_store_id: number | null;
+  home_store_name: string | null;
 };
 
 type SkuOption = {
@@ -58,6 +60,7 @@ type CustomerEntry = {
   display_name: string;
   nickname: string;
   pickup_store_id: number | null;
+  pickup_store_name: string | null;
   items: ItemRow[];
 };
 
@@ -72,6 +75,7 @@ function newEntry(): CustomerEntry {
     display_name: "",
     nickname: "",
     pickup_store_id: null,
+    pickup_store_name: null,
     items: [emptyItem()],
   };
 }
@@ -86,9 +90,8 @@ export default function OrderEntryPage() {
 
   const [campaign, setCampaign] = useState<Campaign | null>(null);
   const [channels, setChannels] = useState<Channel[]>([]);
-  const [stores, setStores] = useState<Store[]>([]);
   const [channelId, setChannelId] = useState<number | null>(null);
-  const [defaultStoreId, setDefaultStoreId] = useState<number | null>(null);
+  const [campaignSkus, setCampaignSkus] = useState<SkuOption[]>([]);
   const [entries, setEntries] = useState<CustomerEntry[]>([newEntry()]);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -97,30 +100,31 @@ export default function OrderEntryPage() {
 
   const draftKey = useMemo(() => `${DRAFT_PREFIX}${campaignId}`, [campaignId]);
 
-  // 載入活動 / channels / stores
+  // 載入活動 / channels
   useEffect(() => {
     if (!Number.isFinite(campaignId)) return;
     let cancelled = false;
     (async () => {
       const sb = getSupabase();
-      const [cRes, chRes, sRes] = await Promise.all([
+      const [cRes, chRes] = await Promise.all([
         sb.from("group_buy_campaigns")
           .select("id, campaign_no, name, status, pickup_deadline")
           .eq("id", campaignId).maybeSingle(),
         sb.from("line_channels")
           .select("id, name, home_store_id").eq("is_active", true).order("name"),
-        sb.from("stores").select("id, name").eq("is_active", true).order("name"),
       ]);
       if (cancelled) return;
       if (cRes.error) { setError(cRes.error.message); return; }
       setCampaign(cRes.data as Campaign);
       setChannels((chRes.data ?? []) as Channel[]);
-      setStores((sRes.data ?? []) as Store[]);
       if (chRes.data && chRes.data.length > 0) {
-        const first = chRes.data[0] as Channel;
-        setChannelId(first.id);
-        setDefaultStoreId(first.home_store_id);
+        setChannelId((chRes.data[0] as Channel).id);
       }
+      // 一次抓活動內全部 SKU 給 dropdown 用
+      const { data: skuData } = await getSupabase().rpc("rpc_search_skus_for_campaign", {
+        p_campaign_id: campaignId, p_term: "", p_limit: 50,
+      });
+      if (!cancelled) setCampaignSkus((skuData as SkuOption[]) ?? []);
     })();
     return () => { cancelled = true; };
   }, [campaignId]);
@@ -157,15 +161,6 @@ export default function OrderEntryPage() {
     return () => clearInterval(t);
   }, [entries, channelId, draftKey, draftLoaded]);
 
-  // 套用 channel 的 home_store_id 為新 entry 預設 + 補上既有空白
-  useEffect(() => {
-    const ch = channels.find((c) => c.id === channelId);
-    if (!ch) return;
-    setDefaultStoreId(ch.home_store_id);
-    setEntries((es) =>
-      es.map((e) => (e.pickup_store_id == null ? { ...e, pickup_store_id: ch.home_store_id } : e))
-    );
-  }, [channelId, channels]);
 
   function updateEntry(key: string, patch: Partial<CustomerEntry>) {
     setEntries((es) => es.map((e) => (e.key === key ? { ...e, ...patch } : e)));
@@ -197,12 +192,29 @@ export default function OrderEntryPage() {
     );
   }
 
+  function addSku(key: string, opt: SkuOption) {
+    setEntries((es) =>
+      es.map((e) => {
+        if (e.key !== key) return e;
+        if (e.items.some((it) => it.campaign_item_id === opt.campaign_item_id)) return e;
+        const newRow: ItemRow = {
+          campaign_item_id: opt.campaign_item_id,
+          sku_label: `${opt.product_name}${opt.variant_name ? ` / ${opt.variant_name}` : ""} (${opt.sku_code})`,
+          qty: "1",
+          unit_price: Number(opt.unit_price),
+        };
+        const cleaned = e.items.filter((it) => it.campaign_item_id || it.qty);
+        return { ...e, items: [...cleaned, newRow] };
+      })
+    );
+  }
+
   // 全域快速鍵：Ctrl+N 加新顧客、Ctrl+S 送出
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "n") {
         e.preventDefault();
-        setEntries((es) => [...es, { ...newEntry(), pickup_store_id: defaultStoreId }]);
+        setEntries((es) => [...es, newEntry()]);
       }
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
         e.preventDefault();
@@ -212,12 +224,14 @@ export default function OrderEntryPage() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entries, channelId, defaultStoreId]);
+  }, [entries, channelId]);
 
   async function handleSubmit() {
     if (submitting) return;
     setError(null);
     if (!channelId) { setError("請選 LINE 頻道"); return; }
+    const noStore = entries.filter((e) => e.member_id && !e.pickup_store_id).map((e) => e.display_name);
+    if (noStore.length > 0) { setError(`下列顧客未設預設取貨店：${noStore.join("、")}（請先在會員資料設 home_store_id）`); return; }
     const rows = entries
       .filter((e) => e.member_id && e.pickup_store_id)
       .map((e) => ({
@@ -242,7 +256,7 @@ export default function OrderEntryPage() {
       if (err) { setError(err.message); return; }
       const created = (data as { out_order_id: number; out_order_no: string; out_item_count: number }[]) ?? [];
       setToast(`已建立/更新 ${created.length} 筆訂單`);
-      setEntries([{ ...newEntry(), pickup_store_id: defaultStoreId }]);
+      setEntries([newEntry()]);
       localStorage.removeItem(draftKey);
       setTimeout(() => setToast(null), 3000);
     } catch (e) {
@@ -260,7 +274,7 @@ export default function OrderEntryPage() {
     <div className="flex flex-1 flex-col gap-4 p-6">
       <header className="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h1 className="text-xl font-semibold">小幫手 key 單</h1>
+          <h1 className="text-xl font-semibold">小幫手加單</h1>
           {campaign ? (
             <p className="text-sm text-zinc-500">
               <span className="font-mono">{campaign.campaign_no}</span> · {campaign.name} ·
@@ -277,19 +291,12 @@ export default function OrderEntryPage() {
         </div>
       </header>
 
-      <div className="grid gap-3 sm:grid-cols-2">
-        <label className="flex items-center gap-2 text-sm">
-          <span className="w-20 text-zinc-500">LINE 頻道</span>
-          <select
-            value={channelId ?? ""}
-            onChange={(e) => setChannelId(Number(e.target.value) || null)}
-            className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-          >
-            <option value="">— 選頻道 —</option>
-            {channels.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
-          </select>
-        </label>
-      </div>
+      <p className="text-xs text-zinc-500">
+        LINE 頻道：<span className="font-medium text-zinc-700 dark:text-zinc-300">
+          {channels.find((c) => c.id === channelId)?.name ?? "—"}
+        </span>
+        　·　取貨店：依顧客的「預設取貨店」自動帶出（會員資料設定）
+      </p>
 
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
@@ -310,11 +317,19 @@ export default function OrderEntryPage() {
               entry={e}
               campaignId={campaignId}
               channelId={channelId}
-              stores={stores}
+              campaignSkus={campaignSkus}
+              pickedMemberIds={
+                new Set(
+                  entries
+                    .filter((x) => x.key !== e.key && x.member_id != null)
+                    .map((x) => x.member_id as number)
+                )
+              }
               onChange={(patch) => updateEntry(e.key, patch)}
               onItemChange={(idx, patch) => updateItem(e.key, idx, patch)}
               onAddItem={() => addItem(e.key)}
               onRemoveItem={(idx) => removeItem(e.key, idx)}
+              onAddSku={(opt) => addSku(e.key, opt)}
               onRemove={() =>
                 setEntries((es) => (es.length > 1 ? es.filter((x) => x.key !== e.key) : es))
               }
@@ -322,7 +337,7 @@ export default function OrderEntryPage() {
           ))}
           <button
             type="button"
-            onClick={() => setEntries((es) => [...es, { ...newEntry(), pickup_store_id: defaultStoreId }])}
+            onClick={() => setEntries((es) => [...es, newEntry()])}
             className="rounded-md border border-dashed border-zinc-300 px-3 py-2 text-sm text-zinc-500 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900"
           >
             + 新增顧客（Ctrl+N）
@@ -349,27 +364,46 @@ export default function OrderEntryPage() {
 // Customer Card
 // ============================================================
 function CustomerCard({
-  entry, campaignId, channelId, stores,
-  onChange, onItemChange, onAddItem, onRemoveItem, onRemove,
+  entry, campaignId, channelId, campaignSkus, pickedMemberIds,
+  onChange, onItemChange, onAddItem, onRemoveItem, onAddSku, onRemove,
 }: {
   entry: CustomerEntry;
   campaignId: number;
   channelId: number | null;
-  stores: Store[];
+  campaignSkus: SkuOption[];
+  pickedMemberIds: Set<number>;
   onChange: (patch: Partial<CustomerEntry>) => void;
   onItemChange: (idx: number, patch: Partial<ItemRow>) => void;
   onAddItem: () => void;
   onRemoveItem: (idx: number) => void;
+  onAddSku: (opt: SkuOption) => void;
   onRemove: () => void;
 }) {
+  const pickedIds = new Set(entry.items.map((it) => it.campaign_item_id).filter((x): x is number => x != null));
+  const availableSkus = campaignSkus.filter((s) => !pickedIds.has(s.campaign_item_id));
   return (
     <div className="rounded-md border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
-      <div className="mb-2 flex items-start justify-between gap-2">
-        <CustomerSearch
-          channelId={channelId}
-          value={entry}
-          onPick={(picked) => onChange(picked)}
-        />
+      <div className="mb-2 flex items-start gap-2">
+        <div className="flex-1">
+          <CustomerSearch
+            channelId={channelId}
+            value={entry}
+            pickedMemberIds={pickedMemberIds}
+            onPick={(picked) => onChange(picked)}
+          />
+        </div>
+        <div className="w-40 shrink-0 pt-1.5 text-xs">
+          <span className="text-zinc-500">取貨店：</span>
+          {entry.member_id ? (
+            entry.pickup_store_name ? (
+              <span className="font-medium">{entry.pickup_store_name}</span>
+            ) : (
+              <span className="text-red-500">⚠ 未設</span>
+            )
+          ) : (
+            <span className="text-zinc-400">—</span>
+          )}
+        </div>
         <button
           type="button"
           onClick={onRemove}
@@ -378,29 +412,6 @@ function CustomerCard({
         >
           ✕
         </button>
-      </div>
-
-      <div className="mb-2 grid gap-2 sm:grid-cols-2">
-        <label className="flex items-center gap-2 text-xs">
-          <span className="w-16 text-zinc-500">取貨店</span>
-          <select
-            value={entry.pickup_store_id ?? ""}
-            onChange={(e) => onChange({ pickup_store_id: Number(e.target.value) || null })}
-            className="flex-1 rounded border border-zinc-300 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-          >
-            <option value="">— 選店 —</option>
-            {stores.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
-          </select>
-        </label>
-        <label className="flex items-center gap-2 text-xs">
-          <span className="w-16 text-zinc-500">暱稱</span>
-          <input
-            value={entry.nickname}
-            onChange={(e) => onChange({ nickname: e.target.value })}
-            placeholder="LINE 顯示名稱"
-            className="flex-1 rounded border border-zinc-300 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-          />
-        </label>
       </div>
 
       <table className="w-full text-xs">
@@ -427,18 +438,41 @@ function CustomerCard({
           ))}
         </tbody>
       </table>
+
+      <div className="mt-2 flex justify-end">
+        <select
+          value=""
+          onChange={(e) => {
+            const id = Number(e.target.value);
+            const opt = availableSkus.find((s) => s.campaign_item_id === id);
+            if (opt) onAddSku(opt);
+            e.target.value = "";
+          }}
+          disabled={availableSkus.length === 0}
+          className="rounded border border-zinc-300 bg-white px-2 py-1 text-xs disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800"
+        >
+          <option value="">+ 加商品{availableSkus.length === 0 ? "（已全選）" : ""}</option>
+          {availableSkus.map((s) => (
+            <option key={s.campaign_item_id} value={s.campaign_item_id}>
+              {s.product_name}{s.variant_name ? ` / ${s.variant_name}` : ""} (${Number(s.unit_price)})
+            </option>
+          ))}
+        </select>
+      </div>
     </div>
   );
 }
+
 
 // ============================================================
 // Customer Search (combo: alias + member)
 // ============================================================
 function CustomerSearch({
-  channelId, value, onPick,
+  channelId, value, pickedMemberIds, onPick,
 }: {
   channelId: number | null;
   value: CustomerEntry;
+  pickedMemberIds: Set<number>;
   onPick: (patch: Partial<CustomerEntry>) => void;
 }) {
   const [term, setTerm] = useState("");
@@ -499,25 +533,35 @@ function CustomerSearch({
           {aliases.length > 0 && (
             <div>
               <div className="px-2 py-1 text-xs font-medium text-zinc-400">綁過的暱稱</div>
-              {aliases.map((a) => (
-                <button
-                  key={`a-${a.alias_id}`}
-                  type="button"
-                  onClick={() => {
-                    onPick({
-                      member_id: a.member_id,
-                      member_no: a.member_no,
-                      display_name: a.member_name,
-                      nickname: a.nickname,
-                    });
-                    setOpen(false);
-                  }}
-                  className="block w-full px-2 py-1.5 text-left text-xs hover:bg-zinc-100 dark:hover:bg-zinc-700"
-                >
-                  <span className="font-medium">{a.nickname}</span>
-                  <span className="ml-2 text-zinc-500">→ {a.member_name} ({a.member_no})</span>
-                </button>
-              ))}
+              {aliases.map((a) => {
+                const dup = pickedMemberIds.has(a.member_id);
+                const noStore = a.home_store_id == null;
+                const blocked = dup || noStore;
+                return (
+                  <button
+                    key={`a-${a.alias_id}`}
+                    type="button"
+                    disabled={blocked}
+                    onClick={() => {
+                      onPick({
+                        member_id: a.member_id,
+                        member_no: a.member_no,
+                        display_name: a.member_name,
+                        nickname: a.nickname,
+                        pickup_store_id: a.home_store_id,
+                        pickup_store_name: a.home_store_name,
+                      });
+                      setOpen(false);
+                    }}
+                    className="block w-full px-2 py-1.5 text-left text-xs hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent dark:hover:bg-zinc-700"
+                  >
+                    <span className="font-medium">{a.nickname}</span>
+                    <span className="ml-2 text-zinc-500">→ {a.member_name} ({a.member_no})</span>
+                    {dup && <span className="ml-2 text-amber-600">已選</span>}
+                    {!dup && noStore && <span className="ml-2 text-red-500">未設取貨店</span>}
+                  </button>
+                );
+              })}
             </div>
           )}
           {members.length > 0 && (
@@ -525,6 +569,9 @@ function CustomerSearch({
               <div className="px-2 py-1 text-xs font-medium text-zinc-400">會員</div>
               {members.map((m) => {
                 const aliased = aliases.some((a) => a.member_id === m.id);
+                const dup = pickedMemberIds.has(m.id);
+                const noStore = m.home_store_id == null;
+                const blocked = dup || noStore;
                 return (
                   <div
                     key={`m-${m.id}`}
@@ -532,16 +579,25 @@ function CustomerSearch({
                   >
                     <button
                       type="button"
+                      disabled={blocked}
                       onClick={() => {
-                        onPick({ member_id: m.id, member_no: m.member_no, display_name: m.name });
+                        onPick({
+                          member_id: m.id,
+                          member_no: m.member_no,
+                          display_name: m.name,
+                          pickup_store_id: m.home_store_id,
+                          pickup_store_name: m.home_store_name,
+                        });
                         setOpen(false);
                       }}
-                      className="flex-1 text-left"
+                      className="flex-1 text-left disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <span className="font-medium">{m.name}</span>
                       <span className="ml-2 text-zinc-500">{m.member_no} · {m.phone ?? "—"}</span>
+                      {dup && <span className="ml-2 text-amber-600">已選</span>}
+                      {!dup && noStore && <span className="ml-2 text-red-500">未設取貨店</span>}
                     </button>
-                    {!aliased && channelId && (
+                    {!aliased && channelId && !blocked && (
                       <button
                         type="button"
                         onClick={() => handleBindAlias(m.id, m.name)}

--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -197,7 +197,7 @@ export default function CampaignsListPage() {
                         href={`/campaigns/order-entry?id=${r.id}`}
                         className="text-xs text-green-600 hover:underline dark:text-green-400"
                       >
-                        key 單
+                        加單
                       </a>
                     )}
                   </div>
@@ -225,13 +225,13 @@ export default function CampaignsListPage() {
         )}
         {modal?.mode === "edit" && (
           <div className="space-y-6">
-            <CampaignForm
-              initial={modal.values}
-              onSaved={() => { setModal(null); setReloadTick((t) => t + 1); }}
-              onCancel={() => setModal(null)}
-            />
+            <CampaignItemsTable campaignId={modal.values.id!} />
             <div className="border-t border-zinc-200 pt-4 dark:border-zinc-800">
-              <CampaignItemsTable campaignId={modal.values.id!} />
+              <CampaignForm
+                initial={modal.values}
+                onSaved={() => { setModal(null); setReloadTick((t) => t + 1); }}
+                onCancel={() => setModal(null)}
+              />
             </div>
           </div>
         )}

--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -215,13 +215,19 @@ export default function CampaignsListPage() {
         maxWidth="max-w-4xl"
       >
         {modal?.mode === "new" && (
-          <CampaignForm
-            onSaved={async (id) => {
-              setReloadTick((t) => t + 1);
-              await openEdit(id);
-            }}
-            onCancel={() => setModal(null)}
-          />
+          <div className="space-y-4">
+            <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-xs text-blue-800 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-200">
+              先建立開團 → 自動進入編輯，加入商品明細
+            </div>
+            <CampaignForm
+              onSaved={async (id) => {
+                setReloadTick((t) => t + 1);
+                await openEdit(id);
+              }}
+              onCancel={() => setModal(null)}
+              submitLabel="建立並加商品"
+            />
+          </div>
         )}
         {modal?.mode === "edit" && (
           <div className="space-y-6">

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { Modal } from "@/components/Modal";
+import { OrderDetail } from "@/components/OrderDetail";
 
 type OrderStatus =
   | "pending" | "confirmed" | "reserved" | "ready" | "partially_ready"
@@ -46,7 +48,11 @@ export default function OrdersListPage() {
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [stores, setStores] = useState<Store[]>([]);
   const [members, setMembers] = useState<Map<number, Member>>(new Map());
-  const [itemCounts, setItemCounts] = useState<Map<number, number>>(new Map());
+  const [itemSummary, setItemSummary] = useState<
+    Map<number, { lineCount: number; totalQty: number; totalAmount: number }>
+  >(new Map());
+  const [detailId, setDetailId] = useState<number | null>(null);
+  const [detailNo, setDetailNo] = useState<string>("");
 
   useEffect(() => { setPage(1); }, [campaignId, status, storeId]);
 
@@ -88,18 +94,24 @@ export default function OrdersListPage() {
         const memIds = Array.from(new Set((data ?? []).map((r) => r.member_id).filter((x): x is number => x != null)));
         const [ic, ms] = await Promise.all([
           ids.length
-            ? getSupabase().from("customer_order_items").select("order_id").in("order_id", ids)
-            : Promise.resolve({ data: [] as { order_id: number }[] }),
+            ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price").in("order_id", ids)
+            : Promise.resolve({ data: [] as { order_id: number; qty: number; unit_price: number }[] }),
           memIds.length
             ? getSupabase().from("members").select("id, name, phone, member_no").in("id", memIds)
             : Promise.resolve({ data: [] as Member[] }),
         ]);
-        const im = new Map<number, number>();
-        for (const id of ids) im.set(id, 0);
-        for (const it of (ic.data as { order_id: number }[]) ?? []) im.set(it.order_id, (im.get(it.order_id) ?? 0) + 1);
+        const im = new Map<number, { lineCount: number; totalQty: number; totalAmount: number }>();
+        for (const id of ids) im.set(id, { lineCount: 0, totalQty: 0, totalAmount: 0 });
+        for (const it of (ic.data as { order_id: number; qty: number; unit_price: number }[]) ?? []) {
+          const cur = im.get(it.order_id) ?? { lineCount: 0, totalQty: 0, totalAmount: 0 };
+          cur.lineCount += 1;
+          cur.totalQty += Number(it.qty);
+          cur.totalAmount += Number(it.qty) * Number(it.unit_price);
+          im.set(it.order_id, cur);
+        }
         const mm = new Map<number, Member>();
         for (const m of (ms.data as Member[]) ?? []) mm.set(m.id, m);
-        if (!cancelled) { setItemCounts(im); setMembers(mm); }
+        if (!cancelled) { setItemSummary(im); setMembers(mm); }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       } finally {
@@ -154,21 +166,28 @@ export default function OrdersListPage() {
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr>
-              <Th>訂單號</Th><Th>開團</Th><Th>會員 / 暱稱</Th><Th>取貨店</Th><Th>取貨截止</Th><Th>狀態</Th><Th className="text-right">項數</Th><Th className="text-right">更新</Th>
+              <Th>訂單號</Th><Th>開團</Th><Th>會員 / 暱稱</Th><Th>取貨店</Th><Th>取貨截止</Th><Th>狀態</Th><Th className="text-right">項數</Th><Th className="text-right">總數量</Th><Th className="text-right">總金額</Th><Th className="text-right">更新</Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={8} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={10} className="p-3 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={8} className="p-6 text-center text-zinc-500">{total === 0 && !campaignId && !status && !storeId ? "尚無訂單。" : "沒有符合條件的訂單。"}</td></tr>
+              <tr><td colSpan={10} className="p-6 text-center text-zinc-500">{total === 0 && !campaignId && !status && !storeId ? "尚無訂單。" : "沒有符合條件的訂單。"}</td></tr>
             ) : rows.map((r) => {
               const m = r.member_id ? members.get(r.member_id) : null;
               const c = campaignMap.get(r.campaign_id);
               const s = storeMap.get(r.pickup_store_id);
               return (
                 <tr key={r.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
-                  <Td className="font-mono">{r.order_no}</Td>
+                  <Td className="font-mono">
+                    <button
+                      onClick={() => { setDetailId(r.id); setDetailNo(r.order_no); }}
+                      className="hover:underline"
+                    >
+                      {r.order_no}
+                    </button>
+                  </Td>
                   <Td>{c ? <span className="text-xs text-zinc-600 dark:text-zinc-400"><span className="font-mono">{c.campaign_no}</span> {c.name}</span> : "—"}</Td>
                   <Td>
                     {m ? (
@@ -183,7 +202,9 @@ export default function OrdersListPage() {
                   <Td className="text-xs">{s?.name ?? "—"}</Td>
                   <Td className="text-xs">{r.pickup_deadline ?? "—"}</Td>
                   <Td><StatusBadge s={r.status} /></Td>
-                  <Td className="text-right font-mono">{itemCounts.get(r.id) ?? 0}</Td>
+                  <Td className="text-right font-mono">{itemSummary.get(r.id)?.lineCount ?? 0}</Td>
+                  <Td className="text-right font-mono">{itemSummary.get(r.id)?.totalQty ?? 0}</Td>
+                  <Td className="text-right font-mono">${itemSummary.get(r.id)?.totalAmount ?? 0}</Td>
                   <Td className="text-right text-xs text-zinc-500">{new Date(r.updated_at).toLocaleString("zh-TW")}</Td>
                 </tr>
               );
@@ -191,6 +212,15 @@ export default function OrdersListPage() {
           </tbody>
         </table>
       </div>
+
+      <Modal
+        open={detailId !== null}
+        onClose={() => setDetailId(null)}
+        title={`訂單明細 ${detailNo}`}
+        maxWidth="max-w-4xl"
+      >
+        {detailId !== null && <OrderDetail orderId={detailId} />}
+      </Modal>
 
       {totalPages > 1 && (
         <div className="flex items-center justify-end gap-2 text-sm">

--- a/apps/admin/src/components/CampaignForm.tsx
+++ b/apps/admin/src/components/CampaignForm.tsx
@@ -53,10 +53,12 @@ export function CampaignForm({
   initial,
   onSaved,
   onCancel,
+  submitLabel,
 }: {
   initial?: CampaignFormValues;
   onSaved?: (id: number) => void;
   onCancel?: () => void;
+  submitLabel?: string;
 }) {
   const router = useRouter();
   const [v, setV] = useState<CampaignFormValues>(initial ?? emptyCampaignValues);
@@ -152,7 +154,7 @@ export function CampaignForm({
 
       <div className="flex items-center gap-3">
         <button type="submit" disabled={saving} className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200">
-          {saving ? "儲存中…" : v.id ? "儲存" : "建立開團"}
+          {saving ? "儲存中…" : submitLabel ?? (v.id ? "儲存" : "建立開團")}
         </button>
         <button type="button" onClick={() => onCancel ? onCancel() : router.push("/campaigns")} className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800">取消</button>
       </div>

--- a/apps/admin/src/components/CampaignItemsTable.tsx
+++ b/apps/admin/src/components/CampaignItemsTable.tsx
@@ -170,7 +170,18 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
               <li key={s.id}>
                 <button
                   type="button"
-                  onClick={() => setAdding({ sku: s, price: "", cap: "" })}
+                  onClick={async () => {
+                    // 從 prices 抓最新 retail 價當預設
+                    const { data: pData } = await getSupabase()
+                      .from("prices")
+                      .select("price")
+                      .eq("sku_id", s.id)
+                      .eq("scope", "retail")
+                      .order("effective_from", { ascending: false })
+                      .limit(1);
+                    const defaultPrice = pData?.[0]?.price != null ? String(Number(pData[0].price)) : "";
+                    setAdding({ sku: s, price: defaultPrice, cap: "" });
+                  }}
                   className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-zinc-50 dark:hover:bg-zinc-800"
                 >
                   <span className="font-mono">{s.sku_code}</span>
@@ -199,8 +210,9 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
                 className="w-28 rounded-md border border-zinc-300 px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800" />
             </label>
             <label className="text-sm">
-              <div className="text-xs text-zinc-500">量上限</div>
+              <div className="text-xs text-zinc-500">量上限<span className="ml-1 text-zinc-400">（空=無上限）</span></div>
               <input type="number" step="0.001" value={adding.cap} onChange={(e) => setAdding({ ...adding, cap: e.target.value })}
+                placeholder="無上限"
                 className="w-28 rounded-md border border-zinc-300 px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800" />
             </label>
             <button type="button" onClick={addItem} className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200">加入</button>

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+
+type OrderHead = {
+  id: number;
+  order_no: string;
+  status: string;
+  pickup_deadline: string | null;
+  nickname_snapshot: string | null;
+  created_at: string;
+  updated_at: string;
+  member: { id: number; name: string | null; phone: string | null; member_no: string } | null;
+  campaign: { id: number; campaign_no: string; name: string } | null;
+  store: { id: number; name: string } | null;
+};
+
+type ItemRow = {
+  id: number;
+  qty: number;
+  unit_price: number;
+  status: string;
+  source: string;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
+  updated_by: string | null;
+  sku: { id: number; sku_code: string; product_name: string | null; variant_name: string | null } | null;
+};
+
+function uidShort(uid: string | null): string {
+  if (!uid) return "—";
+  return uid.slice(0, 8);
+}
+
+function fmtDt(iso: string): string {
+  return new Date(iso).toLocaleString("zh-TW", { hour12: false });
+}
+
+export function OrderDetail({ orderId }: { orderId: number }) {
+  const [head, setHead] = useState<OrderHead | null>(null);
+  const [items, setItems] = useState<ItemRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const [hRes, iRes] = await Promise.all([
+        sb.from("customer_orders")
+          .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
+          .eq("id", orderId).maybeSingle(),
+        sb.from("customer_order_items")
+          .select("id, qty, unit_price, status, source, created_at, updated_at, created_by, updated_by, sku:skus(id, sku_code, product_name, variant_name)")
+          .eq("order_id", orderId)
+          .order("created_at", { ascending: true }),
+      ]);
+      if (cancelled) return;
+      if (hRes.error) { setError(hRes.error.message); return; }
+      setHead(hRes.data as unknown as OrderHead);
+      if (iRes.error) { setError(iRes.error.message); return; }
+      setItems((iRes.data ?? []) as unknown as ItemRow[]);
+    })();
+    return () => { cancelled = true; };
+  }, [orderId]);
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+        {error}
+      </div>
+    );
+  }
+  if (!head || !items) return <div className="text-sm text-zinc-500">載入中…</div>;
+
+  const totalQty = items.reduce((s, i) => s + Number(i.qty), 0);
+  const totalAmount = items.reduce((s, i) => s + Number(i.qty) * Number(i.unit_price), 0);
+
+  return (
+    <div className="space-y-4 text-sm">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <Field label="訂單號" value={<span className="font-mono">{head.order_no}</span>} />
+        <Field label="狀態" value={head.status} />
+        <Field label="取貨截止" value={head.pickup_deadline ?? "—"} />
+        <Field
+          label="會員"
+          value={
+            head.member ? (
+              <span>
+                {head.member.name ?? "—"}{" "}
+                <span className="font-mono text-xs text-zinc-500">{head.member.member_no}</span>
+                <br />
+                <span className="font-mono text-xs text-zinc-500">{head.member.phone ?? "—"}</span>
+              </span>
+            ) : (
+              <span className="text-zinc-500">({head.nickname_snapshot ?? "—"})</span>
+            )
+          }
+        />
+        <Field label="開團" value={head.campaign ? `${head.campaign.campaign_no} ${head.campaign.name}` : "—"} />
+        <Field label="取貨店" value={head.store?.name ?? "—"} />
+        <Field label="建立" value={fmtDt(head.created_at)} />
+        <Field label="最後更新" value={fmtDt(head.updated_at)} />
+      </div>
+
+      <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
+        <div className="flex items-center justify-between border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-xs font-medium dark:border-zinc-800 dark:bg-zinc-900">
+          <span>明細（{items.length} 項 · {totalQty} 件 · ${totalAmount}）</span>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-zinc-200 text-xs dark:divide-zinc-800">
+            <thead className="bg-zinc-50 dark:bg-zinc-900">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium text-zinc-500">商品</th>
+                <th className="px-3 py-2 text-right font-medium text-zinc-500">數量</th>
+                <th className="px-3 py-2 text-right font-medium text-zinc-500">單價</th>
+                <th className="px-3 py-2 text-right font-medium text-zinc-500">小計</th>
+                <th className="px-3 py-2 text-left font-medium text-zinc-500">第一次加</th>
+                <th className="px-3 py-2 text-left font-medium text-zinc-500">最後更新</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {items.length === 0 ? (
+                <tr><td colSpan={6} className="p-4 text-center text-zinc-500">尚無明細</td></tr>
+              ) : items.map((it) => {
+                const sub = Number(it.qty) * Number(it.unit_price);
+                return (
+                  <tr key={it.id}>
+                    <td className="px-3 py-2">
+                      {it.sku ? (
+                        <span>
+                          {it.sku.product_name ?? "—"}
+                          {it.sku.variant_name && <span className="text-zinc-500"> / {it.sku.variant_name}</span>}
+                          <span className="ml-1 font-mono text-zinc-400">{it.sku.sku_code}</span>
+                        </span>
+                      ) : "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono">{Number(it.qty)}</td>
+                    <td className="px-3 py-2 text-right font-mono text-zinc-500">${Number(it.unit_price)}</td>
+                    <td className="px-3 py-2 text-right font-mono">${sub}</td>
+                    <td className="px-3 py-2 text-zinc-500">
+                      {fmtDt(it.created_at)}<br />
+                      <span className="font-mono text-[10px]">by {uidShort(it.created_by)}</span>
+                    </td>
+                    <td className="px-3 py-2 text-zinc-500">
+                      {fmtDt(it.updated_at)}<br />
+                      <span className="font-mono text-[10px]">by {uidShort(it.updated_by)}</span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <p className="border-t border-zinc-200 bg-zinc-50 px-3 py-1.5 text-[11px] text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900">
+          ※ 同顧客在同活動連 key 多次會合併到同一筆，舊 qty 被新值覆寫。如需「每次 +N 紀錄」請告知改完整版（加 append-only audit table）。
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-xs text-zinc-500">{label}</div>
+      <div>{value}</div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/ProductForm.tsx
+++ b/apps/admin/src/components/ProductForm.tsx
@@ -110,6 +110,20 @@ export function ProductForm({
     setValues((v) => ({ ...v, [key]: value }));
   }
 
+  // 新建商品時：選溫層就（重新）產生商品編號；之後可手動改
+  const [codeIsAuto, setCodeIsAuto] = useState(true);
+  useEffect(() => {
+    if (values.id != null) return;
+    if (!codeIsAuto) return;
+    (async () => {
+      const { data } = await getSupabase().rpc("rpc_next_product_code", {
+        p_storage_type: values.storage_type,
+      });
+      if (typeof data === "string") setValues((v) => ({ ...v, product_code: data }));
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [values.storage_type, values.id, codeIsAuto]);
+
   async function onSubmit(e: FormEvent) {
     e.preventDefault();
     setError(null);
@@ -119,10 +133,18 @@ export function ProductForm({
       return;
     }
 
+    let code = values.product_code;
+    if (!code && values.id == null) {
+      const { data } = await getSupabase().rpc("rpc_next_product_code", {
+        p_storage_type: values.storage_type,
+      });
+      if (typeof data === "string") code = data;
+    }
+
     setSaving(true);
     const { data, error: err } = await getSupabase().rpc("rpc_upsert_product", {
       p_id: values.id,
-      p_product_code: values.product_code,
+      p_product_code: code,
       p_name: values.name,
       p_short_name: values.short_name || null,
       p_brand_id: values.brand_id,
@@ -163,13 +185,19 @@ export function ProductForm({
   return (
     <form onSubmit={onSubmit} className="space-y-5">
       <Grid>
-        <Field label="商品編號" required>
+        <Field label="商品編號">
           <input
-            required
             value={values.product_code}
-            onChange={(e) => set("product_code", e.target.value)}
+            onChange={(e) => { setCodeIsAuto(false); set("product_code", e.target.value); }}
+            placeholder={values.id == null ? "選溫層後自動產生（可手動覆蓋）" : ""}
             className={inputClass}
           />
+          {values.id == null && (
+            <p className="mt-1 text-[11px] text-zinc-500">
+              {codeIsAuto ? "自動依溫層產生 — " : "已手動指定 — "}
+              前綴：F=冷凍 / R=冷藏 / A=常溫 / M=餐車 / G=未指定
+            </p>
+          )}
         </Field>
         <Field label="狀態" required>
           <select

--- a/apps/admin/src/components/ProductSkuSection.tsx
+++ b/apps/admin/src/components/ProductSkuSection.tsx
@@ -91,8 +91,9 @@ export function ProductSkuSection({ productId }: { productId: number }) {
     refresh();
   }, [refresh]);
 
-  function startNew() {
-    setDraft({ ...EMPTY_DRAFT });
+  async function startNew() {
+    const { data } = await getSupabase().rpc("rpc_next_sku_code", { p_product_id: productId });
+    setDraft({ ...EMPTY_DRAFT, sku_code: typeof data === "string" ? data : "" });
   }
 
   function startEdit(sku: Sku) {
@@ -156,9 +157,9 @@ export function ProductSkuSection({ productId }: { productId: number }) {
     <section className="space-y-3 rounded-lg border border-zinc-200 p-5 dark:border-zinc-800">
       <header className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold">SKU 變體</h2>
+          <h2 className="text-lg font-semibold">規格 / 品項</h2>
           <p className="text-xs text-zinc-500">
-            每個 SKU 是獨立可賣 / 計庫存單位。零售價版本化、成本從採購入庫後自動算（avg_cost）。
+            一個商品可以有多個規格（口味 / 容量 / 入數），各自獨立計庫存。零售價版本化、成本從採購入庫後自動算。
           </p>
         </div>
         {!draft && (
@@ -167,7 +168,7 @@ export function ProductSkuSection({ productId }: { productId: number }) {
             onClick={startNew}
             className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
           >
-            + 新增 SKU
+            + 新增規格
           </button>
         )}
       </header>
@@ -182,11 +183,9 @@ export function ProductSkuSection({ productId }: { productId: number }) {
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr>
-              <Th>SKU 編號</Th>
-              <Th>變體名</Th>
+              <Th>規格編號</Th>
+              <Th>規格說明</Th>
               <Th>單位</Th>
-              <Th className="text-right">重量 (g)</Th>
-              <Th className="text-right">稅率</Th>
               <Th>狀態</Th>
               <Th className="text-right">零售價</Th>
               <Th className="text-right">動作</Th>
@@ -195,7 +194,7 @@ export function ProductSkuSection({ productId }: { productId: number }) {
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {skus === null ? (
               <tr>
-                <td colSpan={8} className="p-3">
+                <td colSpan={6} className="p-3">
                   <div className="h-4 animate-pulse rounded bg-zinc-100 dark:bg-zinc-800" />
                 </td>
               </tr>
@@ -216,8 +215,6 @@ export function ProductSkuSection({ productId }: { productId: number }) {
                       <Td className="font-mono">{s.sku_code}</Td>
                       <Td>{s.variant_name ?? "—"}</Td>
                       <Td>{s.base_unit}</Td>
-                      <Td className="text-right">{s.weight_g ?? "—"}</Td>
-                      <Td className="text-right">{s.tax_rate}</Td>
                       <Td>
                         <StatusBadge status={s.status} />
                       </Td>
@@ -247,8 +244,8 @@ export function ProductSkuSection({ productId }: { productId: number }) {
                 )}
                 {skus.length === 0 && !draft && (
                   <tr>
-                    <td colSpan={8} className="p-4 text-center text-sm text-zinc-500">
-                      還沒有 SKU。按「新增 SKU」開始。
+                    <td colSpan={6} className="p-4 text-center text-sm text-zinc-500">
+                      還沒有規格。按「新增規格」開始。
                     </td>
                   </tr>
                 )}
@@ -284,7 +281,7 @@ function DraftRow({
         <input
           value={draft.sku_code}
           onChange={(e) => set("sku_code", e.target.value)}
-          placeholder="SKU 編號"
+          placeholder="自動產生（可改）"
           className={inputClass}
         />
       </Td>
@@ -292,7 +289,7 @@ function DraftRow({
         <input
           value={draft.variant_name}
           onChange={(e) => set("variant_name", e.target.value)}
-          placeholder="例：100 入"
+          placeholder="例：100 入 / 鮮肉口味"
           className={inputClass}
         />
       </Td>
@@ -301,23 +298,6 @@ function DraftRow({
           value={draft.base_unit}
           onChange={(e) => set("base_unit", e.target.value)}
           className={`${inputClass} w-14`}
-        />
-      </Td>
-      <Td>
-        <input
-          type="number"
-          value={draft.weight_g}
-          onChange={(e) => set("weight_g", e.target.value)}
-          className={`${inputClass} w-20 text-right`}
-        />
-      </Td>
-      <Td>
-        <input
-          type="number"
-          step="0.0001"
-          value={draft.tax_rate}
-          onChange={(e) => set("tax_rate", e.target.value)}
-          className={`${inputClass} w-20 text-right`}
         />
       </Td>
       <Td>

--- a/apps/admin/src/components/ProductSkuSection.tsx
+++ b/apps/admin/src/components/ProductSkuSection.tsx
@@ -153,6 +153,14 @@ export function ProductSkuSection({ productId }: { productId: number }) {
     }
   }
 
+  async function deleteSku(sku: Sku) {
+    if (!confirm(`確定刪除規格「${sku.sku_code}${sku.variant_name ? ` / ${sku.variant_name}` : ""}」？\n（軟刪除：狀態改為「停產」、保留歷史紀錄）`)) return;
+    setError(null);
+    const { error: err } = await getSupabase().rpc("rpc_delete_sku", { p_id: sku.id });
+    if (err) { setError(err.message); return; }
+    await refresh();
+  }
+
   return (
     <section className="space-y-3 rounded-lg border border-zinc-200 p-5 dark:border-zinc-800">
       <header className="flex items-center justify-between">
@@ -222,13 +230,24 @@ export function ProductSkuSection({ productId }: { productId: number }) {
                         {s.id in prices ? `$${prices[s.id]}` : "—"}
                       </Td>
                       <Td className="text-right">
-                        <button
-                          type="button"
-                          onClick={() => startEdit(s)}
-                          className="text-xs text-zinc-600 hover:underline dark:text-zinc-400"
-                        >
-                          編輯
-                        </button>
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => startEdit(s)}
+                            className="text-xs text-zinc-600 hover:underline dark:text-zinc-400"
+                          >
+                            編輯
+                          </button>
+                          {s.status !== "discontinued" && (
+                            <button
+                              type="button"
+                              onClick={() => deleteSku(s)}
+                              className="text-xs text-red-600 hover:underline dark:text-red-400"
+                            >
+                              刪除
+                            </button>
+                          )}
+                        </div>
                       </Td>
                     </tr>
                   )

--- a/scripts/rpc-home-store-guard.sql
+++ b/scripts/rpc-home-store-guard.sql
@@ -1,0 +1,68 @@
+-- 驗 home_store_id 改變守衛
+BEGIN;
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-000000000099","tenant_id":"00000000-0000-0000-0000-000000000001","role":"authenticated"}',
+  true
+);
+
+CREATE TEMP TABLE _r (scn TEXT, verdict TEXT, msg TEXT);
+
+-- A: 同 store 改其他欄位 → 應通
+DO $$
+DECLARE v_msg TEXT;
+BEGIN
+  BEGIN
+    -- Alex Chen (id=6) 目前 home_store=1；改 store 仍=1 + 改名
+    PERFORM rpc_upsert_member(6, 'M20260424072640046', '0979297810', 'Alex Chen 改', NULL, NULL, NULL, NULL, 1, 'active', NULL);
+    INSERT INTO _r VALUES ('A 同 store 改其他欄位', 'PASS', 'no error');
+  EXCEPTION WHEN OTHERS THEN
+    v_msg := SQLERRM;
+    INSERT INTO _r VALUES ('A 同 store 改其他欄位', 'FAIL', v_msg);
+  END;
+END $$;
+
+-- B: 改 store + 該會員身上有 pending 訂單 → 應拒
+-- 先確保有 pending 訂單存在
+SELECT COUNT(*) AS open_orders FROM customer_orders WHERE member_id=6 AND status NOT IN ('completed','cancelled','expired');
+DO $$
+DECLARE v_msg TEXT;
+BEGIN
+  BEGIN
+    PERFORM rpc_upsert_member(6, 'M20260424072640046', '0979297810', 'Alex Chen 改', NULL, NULL, NULL, NULL, 999, 'active', NULL);
+    INSERT INTO _r VALUES ('B 有未完成訂單改 store', 'FAIL', '應該拒絕但通了');
+  EXCEPTION WHEN OTHERS THEN
+    v_msg := SQLERRM;
+    INSERT INTO _r VALUES ('B 有未完成訂單改 store', CASE WHEN v_msg LIKE '%未取貨訂單%' THEN 'PASS' ELSE 'FAIL' END, v_msg);
+  END;
+END $$;
+
+-- C: 改 store + 訂單全 completed → 應通
+UPDATE customer_orders SET status='completed' WHERE member_id=6;
+DO $$
+DECLARE v_msg TEXT;
+BEGIN
+  BEGIN
+    PERFORM rpc_upsert_member(6, 'M20260424072640046', '0979297810', 'Alex Chen 改', NULL, NULL, NULL, NULL, 1, 'active', NULL);
+    INSERT INTO _r VALUES ('C 訂單全 completed 改 store', 'PASS', 'no error');
+  EXCEPTION WHEN OTHERS THEN
+    v_msg := SQLERRM;
+    INSERT INTO _r VALUES ('C 訂單全 completed 改 store', 'FAIL', v_msg);
+  END;
+END $$;
+
+-- D: 沒訂單的 member 改 store → 應通（用 member id=5 asdasd）
+DO $$
+DECLARE v_msg TEXT;
+BEGIN
+  BEGIN
+    PERFORM rpc_upsert_member(5, 'M20260424071146106', (SELECT phone FROM members WHERE id=5), 'asdasd', NULL, NULL, NULL, NULL, 1, 'active', NULL);
+    INSERT INTO _r VALUES ('D 無訂單會員改 store', 'PASS', 'no error');
+  EXCEPTION WHEN OTHERS THEN
+    v_msg := SQLERRM;
+    INSERT INTO _r VALUES ('D 無訂單會員改 store', 'FAIL', v_msg);
+  END;
+END $$;
+
+SELECT * FROM _r ORDER BY scn;
+ROLLBACK;

--- a/supabase/migrations/20260427120000_order_entry_search_with_home_store.sql
+++ b/supabase/migrations/20260427120000_order_entry_search_with_home_store.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- 補：search_members / search_aliases 回傳 home_store_id + 名稱
+-- 用途：order-entry 頁拿來自動帶出顧客的預設取貨店
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.rpc_search_members(TEXT, INT);
+DROP FUNCTION IF EXISTS public.rpc_search_aliases(BIGINT, TEXT, INT);
+
+CREATE OR REPLACE FUNCTION public.rpc_search_members(
+  p_term  TEXT,
+  p_limit INT DEFAULT 20
+) RETURNS TABLE (
+  id              BIGINT,
+  member_no       TEXT,
+  name            TEXT,
+  phone           TEXT,
+  avatar_url      TEXT,
+  home_store_id   BIGINT,
+  home_store_name TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_term   TEXT := COALESCE(NULLIF(TRIM(p_term), ''), NULL);
+  v_lim    INT  := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+BEGIN
+  RETURN QUERY
+  SELECT m.id, m.member_no, m.name, m.phone, m.avatar_url,
+         m.home_store_id, s.name
+    FROM members m
+    LEFT JOIN stores s ON s.id = m.home_store_id
+   WHERE m.tenant_id = v_tenant
+     AND (
+       v_term IS NULL
+       OR m.name      ILIKE '%' || v_term || '%'
+       OR m.member_no ILIKE '%' || v_term || '%'
+       OR m.phone     ILIKE '%' || v_term || '%'
+     )
+   ORDER BY m.created_at DESC
+   LIMIT v_lim;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_search_members TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_search_aliases(
+  p_channel_id BIGINT,
+  p_term       TEXT,
+  p_limit      INT DEFAULT 20
+) RETURNS TABLE (
+  alias_id        BIGINT,
+  nickname        TEXT,
+  member_id       BIGINT,
+  member_no       TEXT,
+  member_name     TEXT,
+  phone           TEXT,
+  avatar_url      TEXT,
+  home_store_id   BIGINT,
+  home_store_name TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_term   TEXT := COALESCE(NULLIF(TRIM(p_term), ''), NULL);
+  v_lim    INT  := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+BEGIN
+  RETURN QUERY
+  SELECT a.id, a.nickname, m.id, m.member_no, m.name, m.phone, m.avatar_url,
+         m.home_store_id, s.name
+    FROM customer_line_aliases a
+    JOIN members m ON m.id = a.member_id
+    LEFT JOIN stores s ON s.id = m.home_store_id
+   WHERE a.tenant_id  = v_tenant
+     AND a.channel_id = p_channel_id
+     AND (v_term IS NULL OR a.nickname ILIKE '%' || v_term || '%')
+   ORDER BY a.updated_at DESC
+   LIMIT v_lim;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_search_aliases TO authenticated;

--- a/supabase/migrations/20260427130000_member_home_store_change_guard.sql
+++ b/supabase/migrations/20260427130000_member_home_store_change_guard.sql
@@ -1,0 +1,100 @@
+-- ============================================================
+-- 改 home_store_id 守衛：member 身上有未取貨訂單時不允許改取貨店
+-- 「未取貨」= status NOT IN ('completed','cancelled','expired')
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_upsert_member(
+  p_id            BIGINT,
+  p_member_no     TEXT,
+  p_phone         TEXT,
+  p_name          TEXT,
+  p_gender        TEXT DEFAULT NULL,
+  p_birthday      DATE DEFAULT NULL,
+  p_email         TEXT DEFAULT NULL,
+  p_tier_id       BIGINT DEFAULT NULL,
+  p_home_store_id BIGINT DEFAULT NULL,
+  p_status        TEXT DEFAULT 'active',
+  p_notes         TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant      UUID := public._current_tenant_id();
+  v_id          BIGINT;
+  v_phone_hash  TEXT;
+  v_email_hash  TEXT;
+  v_birth_md    TEXT;
+  v_old_store   BIGINT;
+  v_open_orders INT;
+BEGIN
+  IF p_phone IS NULL OR p_phone = '' THEN
+    RAISE EXCEPTION 'phone is required';
+  END IF;
+  IF p_name IS NULL OR p_name = '' THEN
+    RAISE EXCEPTION 'name is required';
+  END IF;
+
+  v_phone_hash := encode(digest(p_phone, 'sha256'), 'hex');
+  v_email_hash := CASE WHEN p_email IS NOT NULL AND p_email <> ''
+                       THEN encode(digest(lower(p_email), 'sha256'), 'hex')
+                  END;
+  v_birth_md   := CASE WHEN p_birthday IS NOT NULL
+                       THEN to_char(p_birthday, 'MM-DD')
+                  END;
+
+  IF p_tier_id IS NOT NULL THEN
+    PERFORM 1 FROM member_tiers WHERE id = p_tier_id AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'tier % not in tenant', p_tier_id; END IF;
+  END IF;
+
+  IF p_id IS NULL THEN
+    INSERT INTO members (
+      tenant_id, member_no, phone_hash, phone, email_hash, email,
+      name, birthday, birth_md, gender, tier_id, home_store_id,
+      status, notes, created_by, updated_by
+    ) VALUES (
+      v_tenant, p_member_no, v_phone_hash, p_phone, v_email_hash, p_email,
+      p_name, p_birthday, v_birth_md, p_gender, p_tier_id, p_home_store_id,
+      COALESCE(p_status, 'active'), p_notes, auth.uid(), auth.uid()
+    ) RETURNING id INTO v_id;
+  ELSE
+    -- 取得目前 home_store_id；若有變更，先檢查未完成訂單
+    SELECT home_store_id INTO v_old_store FROM members
+     WHERE id = p_id AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'member % not in tenant', p_id; END IF;
+
+    IF v_old_store IS DISTINCT FROM p_home_store_id THEN
+      SELECT COUNT(*) INTO v_open_orders FROM customer_orders
+       WHERE tenant_id = v_tenant
+         AND member_id = p_id
+         AND status NOT IN ('completed','cancelled','expired');
+      IF v_open_orders > 0 THEN
+        RAISE EXCEPTION '會員仍有 % 筆未取貨訂單，請先處理完才能改取貨店', v_open_orders;
+      END IF;
+    END IF;
+
+    UPDATE members SET
+      member_no     = COALESCE(p_member_no, member_no),
+      phone_hash    = v_phone_hash,
+      phone         = p_phone,
+      email_hash    = v_email_hash,
+      email         = p_email,
+      name          = COALESCE(p_name, name),
+      birthday      = p_birthday,
+      birth_md      = v_birth_md,
+      gender        = p_gender,
+      tier_id       = p_tier_id,
+      home_store_id = p_home_store_id,
+      status        = COALESCE(p_status, status),
+      notes         = p_notes,
+      updated_by    = auth.uid()
+    WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'member % not in tenant', p_id; END IF;
+  END IF;
+
+  RETURN v_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_upsert_member TO authenticated;

--- a/supabase/migrations/20260427140000_product_code_autogen.sql
+++ b/supabase/migrations/20260427140000_product_code_autogen.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- 商品編號自動產生：依溫層加前綴 + 5 位流水
+-- F = 冷凍 / R = 冷藏(生鮮) / A = 常溫 / M = 美食列車 / G = 一般
+-- 例：F00001、R00012、A00007
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_next_product_code(
+  p_storage_type product_storage_type DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_prefix TEXT;
+  v_next   INT;
+BEGIN
+  v_prefix := CASE p_storage_type
+    WHEN 'frozen'        THEN 'F'
+    WHEN 'refrigerated'  THEN 'R'
+    WHEN 'room_temp'     THEN 'A'
+    WHEN 'meal_train'    THEN 'M'
+    ELSE 'G'
+  END;
+
+  SELECT COALESCE(MAX((SUBSTRING(product_code FROM '^' || v_prefix || '(\d+)$'))::INT), 0) + 1
+    INTO v_next
+    FROM products
+   WHERE tenant_id = v_tenant
+     AND product_code ~ ('^' || v_prefix || '\d+$');
+
+  RETURN v_prefix || lpad(v_next::text, 5, '0');
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_next_product_code TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_next_product_code IS
+  '依溫層回傳下一個商品編號：F=冷凍 R=冷藏 A=常溫 M=美食列車 G=未指定';

--- a/supabase/migrations/20260427150000_sku_code_autogen.sql
+++ b/supabase/migrations/20260427150000_sku_code_autogen.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+-- SKU 規格編號自動產生：{product_code}-{NN}
+-- 例：F00001-01、F00001-02
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_next_sku_code(
+  p_product_id BIGINT
+) RETURNS TEXT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant       UUID := public._current_tenant_id();
+  v_product_code TEXT;
+  v_next         INT;
+BEGIN
+  SELECT product_code INTO v_product_code
+    FROM products
+   WHERE id = p_product_id AND tenant_id = v_tenant;
+  IF v_product_code IS NULL THEN
+    RAISE EXCEPTION 'product % not in tenant', p_product_id;
+  END IF;
+
+  SELECT COALESCE(MAX((SUBSTRING(sku_code FROM '^' || v_product_code || '-(\d+)$'))::INT), 0) + 1
+    INTO v_next
+    FROM skus
+   WHERE tenant_id = v_tenant
+     AND product_id = p_product_id
+     AND sku_code ~ ('^' || v_product_code || '-\d+$');
+
+  RETURN v_product_code || '-' || lpad(v_next::text, 2, '0');
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_next_sku_code TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_next_sku_code IS
+  '依商品產生下一個 SKU 編號：{product_code}-{NN}';

--- a/supabase/migrations/20260427160000_sku_delete.sql
+++ b/supabase/migrations/20260427160000_sku_delete.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- 規格刪除：實質為軟刪除（status='discontinued'），避免 FK 衝突
+-- 若有 inventory / orders 參照仍可保留歷史紀錄
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_delete_sku(
+  p_id BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_found  BIGINT;
+BEGIN
+  UPDATE skus
+     SET status     = 'discontinued',
+         updated_by = auth.uid()
+   WHERE id = p_id AND tenant_id = v_tenant
+   RETURNING id INTO v_found;
+  IF v_found IS NULL THEN
+    RAISE EXCEPTION 'sku % not in tenant', p_id;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_delete_sku TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_delete_sku IS
+  '規格軟刪除：將 status 設為 discontinued';


### PR DESCRIPTION
## Summary
PR #113 merge 後使用者陸續提的小幫手加單與商品/規格管理 UX 改良 + 對應 RPC。

## Commits
- `feat(orders)`: 列表加總數量/總金額 + 訂單明細 Modal（快版）
- `feat(order-entry)`: UX 大改 — 取貨店/頻道/SKU 多顧客邏輯
- `feat(member)`: 改 home_store_id 守衛 + 新增開團 modal hint
- `feat(campaign-items)`: 單價從 prices.retail 帶出 + 量上限空=無上限
- `feat(product)`: 商品編號依溫層自動產生（F/R/A/M/G + 5 位流水）
- `feat(sku)`: 規格用語 + 編號自動產生 + 隱藏重量/稅率
- `feat(sku)`: 規格刪除（軟刪除為 discontinued）

## Migrations（已 push dev）
- `20260427120000_order_entry_search_with_home_store.sql`
- `20260427130000_member_home_store_change_guard.sql`
- `20260427140000_product_code_autogen.sql`
- `20260427150000_sku_code_autogen.sql`
- `20260427160000_sku_delete.sql`

## Test plan
- [x] Build + TypeScript pass
- [x] Migrations applied to dev
- [x] SQL smoke test for new RPCs
- [x] Manual UI verify（autocomplete / 自動帶碼 / 取貨店守衛 / 規格刪除）

🤖 Generated with [Claude Code](https://claude.com/claude-code)