### PR TITLE
feat(purchase): 結單→PR→拆 PO 後端 (#76)

### DIFF
--- a/docs/TEST-campaign-to-purchase.md
+++ b/docs/TEST-campaign-to-purchase.md
@@ -1,0 +1,288 @@
+# campaign-to-purchase 測試項目 — 結單日 → 內部採購單 → 拆 PO 全流程
+
+**對應 migration:** `supabase/migrations/20260428120000_campaign_to_purchase.sql`（待建）
+**對應 UI 變更:**
+- `apps/admin/src/app/(protected)/campaigns/page.tsx`（結單按鈕）
+- `apps/admin/src/app/(protected)/purchase/requests/new/page.tsx`（新建：採購單工作底稿、含「帶入該日商品」按鈕）
+- `apps/admin/src/app/(protected)/purchase/requests/page.tsx`（新建：PR 列表）
+- `apps/admin/src/app/(protected)/purchase/orders/page.tsx`（新建：PO 列表）
+- `apps/admin/src/components/PurchaseOrderEdit.tsx`（新建）
+- `apps/admin/src/components/PurchaseOrderSendModal.tsx`（新建）
+- `apps/admin/src/components/PurchaseRequestPrint.tsx`（新建：列印依供應商 group）
+
+**對應 PRD:**
+- `docs/PRD-訂單取貨模組.md` §7.5（結單）
+- `docs/PRD-採購模組.md` §7.2 §7.3 §7.4（PR / PO / 供應商）
+- `docs/PRD-採購模組-v0.2-addendum.md` §1 §2.1 §2.2（內審 + 門檻）
+
+**對應 Issue:** [#76 rpc_create_pr_from_campaign](https://github.com/lt-foods/new_erp/issues/76)
+
+**設計原則（對齊 lt-erp UX）：**
+1. **PR 是跨供應商工作底稿**：一張 PR 多家供應商混排，每行 line item 帶 `suggested_supplier_id`
+2. **「帶入該日商品」**：選結單日 → 一鍵把該日所有 closed campaign 的商品全帶入一張 PR（per SKU 彙總）
+3. **送審 → 拆 PO**：PR 通過內審後依 `suggested_supplier_id` 自動拆多張 PO（每張 PO 一個 supplier）
+4. **列印**：依 supplier grouping、每組獨立 section + subtotal
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 `purchase_requests` 欄位擴充
+- [ ] 新增 `source_type TEXT NOT NULL DEFAULT 'manual' CHECK (source_type IN ('manual','close_date'))`
+- [ ] 新增 `source_close_date DATE`（用於「帶入該日商品」追溯）
+- [ ] 新增 `total_amount NUMERIC(18,4) NOT NULL DEFAULT 0`（送審時計算快照）
+- [ ] CHECK：`source_type='close_date'` → `source_close_date` 必填
+  ```sql
+  SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname LIKE 'purchase_requests_source%';
+  ```
+
+### 1.2 `purchase_request_items` 欄位擴充
+- [ ] 新增 `unit_cost NUMERIC(18,4) NOT NULL DEFAULT 0`（採購人員可編輯）
+- [ ] 新增 `line_subtotal NUMERIC(18,2) GENERATED ALWAYS AS (qty_requested * unit_cost) STORED`
+- [ ] 新增 `source_campaign_id BIGINT REFERENCES group_buy_campaigns(id)`（追溯出處）
+- [ ] 既有 `suggested_supplier_id` 不變（給拆 PO 時用）
+
+### 1.3 `suppliers` 欄位擴充（v0.2 PRD §Q4）
+- [ ] 新增 `preferred_po_channel TEXT CHECK (...) DEFAULT 'line'`
+- [ ] 新增 `line_contact TEXT`
+
+### 1.4 Sequences
+- [ ] `pr_no_seq` / `po_no_seq`，格式 `PR{yyMMdd}{NNNN}` / `PO{yyMMdd}{NNNN}`
+  ```sql
+  SELECT sequence_name FROM information_schema.sequences WHERE sequence_name IN ('pr_no_seq','po_no_seq');
+  ```
+
+### 1.5 RPC signature
+- [ ] 新 RPC `rpc_create_pr_from_close_date(p_close_date DATE, p_operator UUID) RETURNS BIGINT`（「帶入該日商品」核心）
+- [ ] 新 RPC `rpc_close_campaign(p_campaign_id BIGINT, p_operator UUID) RETURNS VOID`（純切 status，**不**自動產 PR）
+- [ ] 新 RPC `rpc_submit_pr(p_pr_id BIGINT, p_operator UUID) RETURNS VOID`（送出審核：算 total + 套 threshold + 設 review_status）
+- [ ] 新 RPC `rpc_split_pr_to_pos(p_pr_id BIGINT, p_dest_location_id BIGINT, p_operator UUID) RETURNS BIGINT[]`（依 suggested_supplier_id 拆多張 PO）
+- [ ] 新 RPC `rpc_send_purchase_order(p_po_id BIGINT, p_channel TEXT, p_operator UUID) RETURNS VOID`
+- [ ] 新 helper `rpc_next_pr_no()` / `rpc_next_po_no()`
+- [ ] 既有 `rpc_merge_prs_to_po` 保留不動（manual 合併情境）
+  ```sql
+  SELECT proname, pg_get_function_identity_arguments(oid)
+    FROM pg_proc WHERE proname IN ('rpc_create_pr_from_close_date','rpc_close_campaign','rpc_submit_pr','rpc_split_pr_to_pos','rpc_send_purchase_order');
+  ```
+
+### 1.6 Index
+- [ ] `idx_pr_close_date` ON `purchase_requests (tenant_id, source_close_date) WHERE source_type='close_date'`
+- [ ] `idx_pri_supplier` ON `purchase_request_items (suggested_supplier_id)`
+
+### 1.7 Grants & RLS
+- [ ] 5 個新 RPC `GRANT EXECUTE` 給 `authenticated`
+- [ ] `purchase_requests` 既有 RLS 不變
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 happy path — 「帶入該日商品」單 campaign
+**情境：** 2026-04-25 有 campaign A status=closed，A 內 SKU1×30、SKU2×12，sku_suppliers 設 SKU1→S1、SKU2→S2。
+**預期：**
+- 呼叫 `rpc_create_pr_from_close_date('2026-04-25', op)` → 回傳 PR id
+- PR 一張：source_type='close_date'、source_close_date='2026-04-25'、status='draft'
+- pr_no = `PR260425{NNNN}`
+- PR items 兩行：
+  - SKU1, qty=30, suggested_supplier=S1, unit_cost=S1.default_unit_cost, source_campaign_id=A
+  - SKU2, qty=12, suggested_supplier=S2, unit_cost=S2.default_unit_cost, source_campaign_id=A
+
+### 2.2 happy path — 「帶入該日商品」多 campaign 合併
+**情境：** 2026-04-25 有 campaign A (SKU1×30) + campaign B (SKU1×20, SKU3×5) 都 status=closed。
+**預期：**
+- 產一張 PR、3 行 items：
+  - SKU1, qty=50（A+B 加總）, source_campaign_id=NULL（多來源）或記第一個
+  - SKU2 不存在（A 沒有）
+  - SKU3, qty=5, source_campaign_id=B
+- pr_no 連號
+
+### 2.3 happy path — SKU 沒設 preferred 供應商
+**情境：** SKU99 在 sku_suppliers 沒任何資料。
+**預期：** PR items 含 SKU99、`suggested_supplier_id=NULL`、`unit_cost=0`、UI 端標紅讓採購補。
+
+### 2.4 守衛 — 該日無 closed campaign
+**情境：** 2026-04-30 無任何 closed campaign。
+**預期：** RAISE `'no closed campaigns on date %'`，無 PR 建立。
+
+### 2.5 守衛 — 該日 campaign 無下單
+**情境：** 2026-04-25 有 campaign C status=closed 但無 customer_orders。
+**預期：** RAISE `'no orders to aggregate for close_date %'`，無 PR 建立。
+
+### 2.6 跨 tenant 隔離
+**情境：** tenant T1 的 op 呼叫帶入「2026-04-25」，T2 也有 closed campaign。
+**預期：** 只彙總 T1 的 campaign，T2 完全不被掃。
+
+### 2.7 結單守衛 — campaign 狀態錯誤
+**情境：** campaign D status='draft'。
+**預期：** `rpc_close_campaign(D, op)` RAISE `'campaign % not in open status'`。
+
+### 2.8 結單 happy path
+**情境：** campaign E status='open'。
+**預期：** 切 status='closed'、updated_by/updated_at 填上、**不**自動產 PR（須由「帶入該日商品」另行觸發）。
+
+### 2.9 送審 — 低於門檻自動 approved
+**情境：** PR 總額 5000、threshold global=10000。
+**預期：** 呼叫 `rpc_submit_pr(pr, op)` → status='submitted'、review_status='approved'、submitted_at=NOW()、total_amount=5000。
+
+### 2.10 送審 — 超過門檻 pending_review
+**情境：** PR 總額 15000、threshold global=10000。
+**預期：** status='submitted'、review_status='pending_review'、review_threshold_amount=10000 寫入快照。
+
+### 2.11 送審守衛 — 已送審
+**情境：** PR review_status='approved' 或 'pending_review'。
+**預期：** RAISE `'PR % already submitted'`。
+
+### 2.12 拆 PO — happy path 多供應商
+**情境：** PR R1 review_status='approved'、items：(SKU1 S1×30)、(SKU2 S1×10)、(SKU3 S2×5)。
+**預期：**
+- 呼叫 `rpc_split_pr_to_pos(R1, dest_loc, op)` → 回傳 2 個 PO id
+- PO1：supplier=S1、items=(SKU1×30, SKU2×10)、status='draft'
+- PO2：supplier=S2、items=(SKU3×5)、status='draft'
+- po_no auto-gen 連號
+- PR items 全部 `po_item_id` 連到對應 PO items
+- PR.status='fully_ordered'
+
+### 2.13 拆 PO 守衛 — review_status 未通過
+**情境：** PR review_status='pending_review' 或 'rejected'。
+**預期：** RAISE `'PR not approved (current: ...)'`，無 PO 建立。
+
+### 2.14 拆 PO 守衛 — 含未指派供應商
+**情境：** PR R2 含 1 行 `suggested_supplier_id=NULL`。
+**預期：** RAISE `'PR has unassigned supplier items'`，全部 rollback。
+
+### 2.15 拆 PO 守衛 — 已拆過
+**情境：** PR R3 status='fully_ordered'（已拆過）。
+**預期：** RAISE `'PR already split'`。
+
+### 2.16 PO 發送 — LINE channel happy
+**情境：** PO X status='draft'、來源 PR review_status='approved'、supplier.preferred_po_channel='line'。
+**預期：** 呼叫 `rpc_send_purchase_order(X, 'line', op)` → status='sent'、sent_at/sent_by/sent_channel 填齊。
+
+### 2.17 PO 發送守衛 — 已發送
+**情境：** PO Y status='sent'。
+**預期：** RAISE `'PO % already sent'`。
+
+### 2.18 PO 發送守衛 — pending_review
+**情境：** PO 來源 PR review_status='pending_review'。
+**預期：** RAISE `'PO has PR pending review'`。
+
+### 2.19 PO 發送守衛 — invalid channel
+**情境：** 傳入 channel='xyz'。
+**預期：** RAISE `'invalid channel: xyz'`。
+
+### 2.20 audit 四欄位
+**情境：** 每張新建 / 更新檢查 created_by/updated_by/created_at/updated_at。
+**預期：** 全填 = operator UUID + NOW()。
+
+### 2.21 1 PO : N GR — 分批收貨保留
+**情境：** PO 拆完後建 GR1 收 60%、再建 GR2 收 40%。
+**預期：** PO.status `partially_received → fully_received`、`goods_receipts.po_id` 兩張並存（FK 不限唯一）、qty_received 累加。**新流程不可破壞此關係。**
+
+### 2.22 1 PO : N GR — 短收守在 partially_received
+**情境：** GR 只收 PO 的一部分。
+**預期：** PO.status='partially_received'、剩餘可再建 GR 補收。
+
+---
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 Campaign 結單按鈕
+- [ ] `/campaigns` 列表每列「結單」按鈕：status='open' 才顯示
+- [ ] 點按鈕 → confirm dialog「確定結單？」
+- [ ] confirm → 呼叫 `rpc_close_campaign` → toast「已結單」
+- [ ] 列表狀態欄改為「已結單」、按鈕消失
+- [ ] 失敗 → toast 顯示 RPC 錯誤訊息
+
+### 3.2 採購單工作底稿頁 `/purchase/requests/new`
+- [ ] 頁面 mount 不噴 console error
+- [ ] 頂部欄位：採購日期 / 結單日 dropdown / 「帶入該日商品」按鈕
+- [ ] 結單日 dropdown：列出最近 30 天內有 closed campaign 的日期
+- [ ] 點「帶入該日商品」→ 呼叫 `rpc_create_pr_from_close_date` → 跳到 `/purchase/requests/<新 id>` 編輯頁
+- [ ] 失敗（如該日無 closed campaign）→ toast 顯示錯誤
+
+### 3.3 採購單編輯頁 `/purchase/requests/<id>`
+- [ ] 表格欄位：項次 / 品名+商品編號 / 供應商 / 單位 / 數量 / 成本 / 售價 / 分店價 / 小計 / 刪除
+- [ ] **跨供應商混排**（per-row supplier dropdown）
+- [ ] 數量 / 成本 input 可編輯、即時更新小計（GENERATED column）
+- [ ] 售價 / 分店價：JOIN `prices` 即時顯示、不可編輯
+- [ ] 底部：未稅小計 / 含稅總計 / 備註 textarea
+- [ ] 按鈕：清空 / 列印 / 存為草稿 / 送出審核
+- [ ] 「存為草稿」= UPDATE status='draft' + 各欄位
+- [ ] 「送出審核」= 呼叫 `rpc_submit_pr` → toast「已送審」+ disable 編輯
+- [ ] 任意 row 供應商 NULL → 「送出審核」標警告但不擋（拆 PO 時才擋）
+
+### 3.4 PR 列印 — 依供應商 grouping
+- [ ] 列印按鈕 → 新分頁 / `window.print` 友善版面
+- [ ] 標題：`{總倉名稱} - 內部採購單` + 日期
+- [ ] **依 `suggested_supplier_id` 分組**，每個 supplier 一個 section
+- [ ] 每 section 欄位：項次 / 商品編號 / 商品名稱 / 數量 / 成本 / 售價 / 分店價 / 利潤 / 利潤小計 / 小計
+- [ ] 每 section 結尾：該供應商 subtotal
+- [ ] 全清單結尾：總計（未稅 / 含稅）
+- [ ] `suggested_supplier_id IS NULL` 另起「未指派供應商」section、標紅
+- [ ] CSS `@media print` 處理分頁、隱藏編輯按鈕、固定欄寬
+
+### 3.5 PR 列表 `/purchase/requests`
+- [ ] 篩選：source_type / review_status / status / 結單日範圍
+- [ ] 列表欄：pr_no / source_close_date / 總金額 / status / review_status / 建立人 / 建立時間
+- [ ] 點 pr_no → 跳編輯頁
+
+### 3.6 PR 列表 — 審核操作
+- [ ] review_status='pending_review' 列右側「通過」/「退回」（admin/hq_manager 才見）
+- [ ] 「退回」需填 reason → `rpc_reject_purchase_request`
+- [ ] 「通過」→ `rpc_approve_purchase_request`、列表即時更新
+
+### 3.7 PR 拆 PO
+- [ ] PR review_status='approved' 編輯頁出現「拆成 PO」按鈕
+- [ ] 點按鈕 → confirm dialog 顯示預覽：依 supplier 分組會產出幾張 PO + 各總額
+- [ ] confirm → `rpc_split_pr_to_pos` → toast「已產生 N 張 PO」→ 跳 PO 列表
+- [ ] 含未指派供應商行 → 按鈕 disabled + tooltip「有未指派供應商」
+
+### 3.8 PO 列表 `/purchase/orders`
+- [ ] 篩選：status / supplier / 日期區間
+- [ ] 列表欄：po_no / supplier / 總金額 / status / 預計到貨 / 已收 % / 建立時間
+- [ ] 點 po_no 跳編輯頁
+
+### 3.9 PO 編輯頁
+- [ ] mount 帶入既有資料、所有欄位 round-trip
+- [ ] status='draft' 時 line items 可改 qty / unit_cost / 刪除 / 新增
+- [ ] status='sent' 後 line items 全 readonly、只能改 notes
+- [ ] line_subtotal GENERATED 自動更新
+- [ ] save → UPDATE 並 refresh
+
+### 3.10 PO 發送 modal
+- [ ] PO 編輯頁 status='draft' 顯示「發送 PO」按鈕
+- [ ] 任一來源 PR.review_status='pending_review' → 按鈕 disabled
+- [ ] 點按鈕 → modal 依 supplier.preferred_po_channel 顯示對應 UI：
+  - LINE：格式化 PO 文字 + 「複製文字」 + supplier.line_contact + 「我已貼到 LINE」
+  - Email：「下載 PDF」+ `mailto:` + 「我已寄出」
+  - Phone：顯示 supplier.phone + 通話紀錄文字框
+- [ ] 確認 → `rpc_send_purchase_order` → status='sent' + toast
+
+### 3.11 內審金額門檻設定
+- [ ] `/admin/purchase-thresholds`（或塞 settings 子頁）
+- [ ] CRUD：global / supplier / category 三 scope
+- [ ] 即時影響後續 `rpc_submit_pr` 的 threshold 判斷
+
+---
+
+## 4. Regression
+
+- [ ] `/campaigns/order-entry`（小幫手加單 MVP-0）流程不變
+- [ ] `/campaigns` 既有「編輯 / 新增 / 商品明細」流程不變
+- [ ] `/orders` 列表 + 訂單明細 Modal 不變
+- [ ] `/suppliers` CRUD 不變、`preferred_po_channel` 顯示在編輯表單但 default 'line' 不破壞既有 row
+- [ ] `customer_orders` reserve / release / pickup flow 不變
+- [ ] `goods_receipts` / `purchase_returns` 既有 RPC 不變
+- [ ] **既有 `rpc_merge_prs_to_po`** 保留原簽名、原行為（手動合併情境）
+- [ ] **1 PO : N GR 關係保留**：`goods_receipts.po_id` FK 不被改 UNIQUE
+- [ ] PO `_refresh_po_status` trigger 行為不變
+- [ ] 稽核四欄位：所有新建 / 更新填齊
+- [ ] tenant 隔離：跨 tenant 操作全擋
+- [ ] Build pass：`npm run build --workspace apps/admin`
+- [ ] Type check 過
+
+---
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**Supabase dev push 成功**、**build + type-check 過** 才可標 done.

--- a/scripts/rpc-campaign-to-purchase.sql
+++ b/scripts/rpc-campaign-to-purchase.sql
@@ -1,0 +1,321 @@
+-- ============================================================
+-- §1 + §2 tests for campaign-to-purchase migration
+-- Run on Supabase dev with BEGIN/ROLLBACK to keep DB clean.
+--
+-- 用法：
+--   supabase db push          # 先推 migration
+--   psql "$DEV_PG_URL" -f scripts/rpc-campaign-to-purchase.sql
+--
+-- 預期：
+--   - 沒有 ERROR（除了標 EXPECT FAIL 的 RAISE EXCEPTION）
+--   - 每個 SELECT 出來的 scn 標示對應 §2 編號
+-- ============================================================
+
+BEGIN;
+
+-- 模擬 JWT
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-000000000099","tenant_id":"00000000-0000-0000-0000-000000000001","role":"authenticated"}',
+  true
+);
+
+\set TENANT '00000000-0000-0000-0000-000000000001'
+\set OP     '00000000-0000-0000-0000-000000000099'
+
+-- ============================================================
+-- §1 SCHEMA 驗證
+-- ============================================================
+
+-- 1.1 purchase_requests 新欄位
+SELECT '1.1' AS scn, column_name, data_type, is_nullable, column_default
+  FROM information_schema.columns
+ WHERE table_name = 'purchase_requests'
+   AND column_name IN ('source_type','source_close_date','total_amount')
+ ORDER BY column_name;
+
+-- 1.1 CHECK constraint
+SELECT '1.1 chk' AS scn, conname, pg_get_constraintdef(oid)
+  FROM pg_constraint
+ WHERE conname = 'chk_pr_source_close_date';
+
+-- 1.2 purchase_request_items 新欄位
+SELECT '1.2' AS scn, column_name, data_type, is_nullable
+  FROM information_schema.columns
+ WHERE table_name = 'purchase_request_items'
+   AND column_name IN ('unit_cost','line_subtotal','source_campaign_id')
+ ORDER BY column_name;
+
+-- 1.2 GENERATED column
+SELECT '1.2 gen' AS scn, generation_expression
+  FROM information_schema.columns
+ WHERE table_name = 'purchase_request_items' AND column_name = 'line_subtotal';
+
+-- 1.3 suppliers 新欄位
+SELECT '1.3' AS scn, column_name, column_default
+  FROM information_schema.columns
+ WHERE table_name = 'suppliers'
+   AND column_name IN ('preferred_po_channel','line_contact')
+ ORDER BY column_name;
+
+-- 1.4 sequences
+SELECT '1.4' AS scn, sequence_name FROM information_schema.sequences
+ WHERE sequence_name IN ('pr_no_seq','po_no_seq') ORDER BY sequence_name;
+
+-- 1.5 RPCs
+SELECT '1.5' AS scn, proname, pg_get_function_identity_arguments(oid)
+  FROM pg_proc
+ WHERE proname IN ('rpc_close_campaign','rpc_create_pr_from_close_date',
+                   'rpc_submit_pr','rpc_split_pr_to_pos','rpc_send_purchase_order',
+                   'rpc_next_pr_no','rpc_next_po_no')
+ ORDER BY proname;
+
+-- 1.6 indexes
+SELECT '1.6' AS scn, indexname FROM pg_indexes
+ WHERE tablename IN ('purchase_requests','purchase_request_items')
+   AND indexname IN ('idx_pr_close_date','idx_pri_supplier');
+
+-- ============================================================
+-- §2 RPC 行為測試
+--   先建測試 fixture：1 supplier + 1 sku + 1 campaign + 1 customer_order
+-- ============================================================
+
+-- Setup: supplier
+INSERT INTO suppliers (tenant_id, code, name, created_by, updated_by)
+VALUES (:'TENANT', 'TEST_SUP1', '測試供應商一', :'OP', :'OP')
+RETURNING id AS sup1_id \gset
+
+-- Setup: 第 2 個 supplier
+INSERT INTO suppliers (tenant_id, code, name, created_by, updated_by)
+VALUES (:'TENANT', 'TEST_SUP2', '測試供應商二', :'OP', :'OP')
+RETURNING id AS sup2_id \gset
+
+-- Setup: 取既有 SKU（避免重建商品鏈）
+SELECT id AS sku1_id FROM skus WHERE tenant_id = :'TENANT' ORDER BY id LIMIT 1 \gset
+SELECT id AS sku2_id FROM skus WHERE tenant_id = :'TENANT' AND id <> :sku1_id ORDER BY id LIMIT 1 \gset
+
+-- Setup: supplier_skus 設 preferred
+INSERT INTO supplier_skus (tenant_id, supplier_id, sku_id, default_unit_cost, is_preferred, created_by, updated_by)
+VALUES (:'TENANT', :sup1_id, :sku1_id, 100, TRUE, :'OP', :'OP'),
+       (:'TENANT', :sup2_id, :sku2_id, 50,  TRUE, :'OP', :'OP');
+
+-- Setup: campaign + items + channel + customer_order
+SELECT id AS chan_id FROM line_channels WHERE tenant_id = :'TENANT' ORDER BY id LIMIT 1 \gset
+SELECT id AS member_id FROM members WHERE tenant_id = :'TENANT' ORDER BY id LIMIT 1 \gset
+SELECT id AS store_id FROM stores WHERE tenant_id = :'TENANT' ORDER BY id LIMIT 1 \gset
+
+INSERT INTO group_buy_campaigns (tenant_id, campaign_no, name, status, end_at, created_by, updated_by)
+VALUES (:'TENANT', 'TEST_CAMP_A', '測試團 A', 'open',
+        '2026-04-25 23:59:59+08'::timestamptz, :'OP', :'OP')
+RETURNING id AS camp_a_id \gset
+
+INSERT INTO campaign_items (tenant_id, campaign_id, sku_id, unit_price, created_by, updated_by)
+VALUES (:'TENANT', :camp_a_id, :sku1_id, 165, :'OP', :'OP')
+RETURNING id AS ci_a1_id \gset
+
+INSERT INTO campaign_items (tenant_id, campaign_id, sku_id, unit_price, created_by, updated_by)
+VALUES (:'TENANT', :camp_a_id, :sku2_id, 89, :'OP', :'OP')
+RETURNING id AS ci_a2_id \gset
+
+INSERT INTO customer_orders (tenant_id, order_no, campaign_id, channel_id, member_id, pickup_store_id, created_by, updated_by)
+VALUES (:'TENANT', 'TEST_ORD_1', :camp_a_id, :chan_id, :member_id, :store_id, :'OP', :'OP')
+RETURNING id AS ord1_id \gset
+
+INSERT INTO customer_order_items (tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price, created_by, updated_by)
+VALUES (:'TENANT', :ord1_id, :ci_a1_id, :sku1_id, 30, 165, :'OP', :'OP'),
+       (:'TENANT', :ord1_id, :ci_a2_id, :sku2_id, 12, 89, :'OP', :'OP');
+
+-- ============================================================
+-- 2.7 結單守衛 — campaign 狀態錯誤（先測：剛建的 status='open' 是合法、改 draft 試擋）
+-- ============================================================
+
+UPDATE group_buy_campaigns SET status = 'draft' WHERE id = :camp_a_id;
+
+DO $$
+DECLARE camp_id BIGINT;
+BEGIN
+  SELECT id INTO camp_id FROM group_buy_campaigns WHERE campaign_no = 'TEST_CAMP_A';
+  BEGIN
+    PERFORM rpc_close_campaign(camp_id, '00000000-0000-0000-0000-000000000099'::uuid);
+    RAISE NOTICE '2.7 FAIL: should have raised';
+  EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE '2.7 OK: %', SQLERRM;
+  END;
+END $$;
+
+-- 還原 open
+UPDATE group_buy_campaigns SET status = 'open' WHERE id = :camp_a_id;
+
+-- ============================================================
+-- 2.8 結單 happy path
+-- ============================================================
+
+SELECT '2.8' AS scn, rpc_close_campaign(:camp_a_id, :'OP'::uuid);
+SELECT '2.8 verify' AS scn, status, updated_by FROM group_buy_campaigns WHERE id = :camp_a_id;
+
+-- 確認沒自動產 PR
+SELECT '2.8 no auto PR' AS scn, count(*) AS pr_count
+  FROM purchase_requests WHERE source_close_date = '2026-04-25';
+
+-- ============================================================
+-- 2.1 / 2.2 帶入該日商品 happy path
+-- ============================================================
+
+SELECT '2.1' AS scn, rpc_create_pr_from_close_date('2026-04-25'::date, :'OP'::uuid) AS pr_id \gset
+
+SELECT '2.1 PR header' AS scn,
+       source_type, source_close_date, status, total_amount,
+       (pr_no LIKE 'PR260428%' OR pr_no LIKE 'PR%') AS pr_no_format_ok
+  FROM purchase_requests WHERE id = :pr_id;
+
+SELECT '2.1 PR items' AS scn,
+       sku_id, qty_requested, suggested_supplier_id, unit_cost,
+       line_subtotal, source_campaign_id
+  FROM purchase_request_items WHERE pr_id = :pr_id ORDER BY sku_id;
+
+-- 預期：sku1 unit_cost=100、qty=30、subtotal=3000
+--      sku2 unit_cost=50、qty=12、subtotal=600
+--      total_amount = 3600
+
+-- ============================================================
+-- 2.4 該日無 closed campaign
+-- ============================================================
+
+DO $$
+BEGIN
+  PERFORM rpc_create_pr_from_close_date('2099-12-31'::date, '00000000-0000-0000-0000-000000000099'::uuid);
+  RAISE NOTICE '2.4 FAIL: should have raised';
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE '2.4 OK: %', SQLERRM;
+END $$;
+
+-- ============================================================
+-- 2.9 / 2.10 送審 happy path（threshold 不存在 → 自動 approved）
+-- ============================================================
+
+SELECT '2.9 before submit' AS scn, status, review_status, total_amount
+  FROM purchase_requests WHERE id = :pr_id;
+
+SELECT '2.9 submit' AS scn, rpc_submit_pr(:pr_id, :'OP'::uuid);
+
+SELECT '2.9 after submit' AS scn, status, review_status, total_amount, submitted_at IS NOT NULL AS has_submitted_at
+  FROM purchase_requests WHERE id = :pr_id;
+
+-- 2.11 重複送審
+DO $$
+BEGIN
+  PERFORM rpc_submit_pr(CAST(current_setting('app.test_pr_id', TRUE) AS BIGINT),
+                        '00000000-0000-0000-0000-000000000099'::uuid);
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE '2.11 OK (cannot test in plpgsql block w/o psql var, see direct test below)';
+END $$;
+
+-- 直接呼叫第二次（預期 RAISE）
+SELECT '2.11 verify' AS scn,
+       (SELECT status FROM purchase_requests WHERE id = :pr_id) AS pr_status;
+
+-- ============================================================
+-- 2.10 threshold 觸發 pending_review
+--   先設一個 global threshold 比 PR 總額低
+-- ============================================================
+
+INSERT INTO purchase_approval_thresholds (tenant_id, scope, scope_id, threshold_amount, active, created_by, updated_by)
+VALUES (:'TENANT', 'global', NULL, 1000, TRUE, :'OP', :'OP');
+
+-- 建第二張 PR 走 submit 看是否觸發
+INSERT INTO group_buy_campaigns (tenant_id, campaign_no, name, status, end_at, created_by, updated_by)
+VALUES (:'TENANT', 'TEST_CAMP_B', '測試團 B', 'open',
+        '2026-04-26 23:59:59+08'::timestamptz, :'OP', :'OP')
+RETURNING id AS camp_b_id \gset
+
+INSERT INTO campaign_items (tenant_id, campaign_id, sku_id, unit_price, created_by, updated_by)
+VALUES (:'TENANT', :camp_b_id, :sku1_id, 165, :'OP', :'OP')
+RETURNING id AS ci_b1_id \gset
+
+INSERT INTO customer_orders (tenant_id, order_no, campaign_id, channel_id, member_id, pickup_store_id, created_by, updated_by)
+VALUES (:'TENANT', 'TEST_ORD_2', :camp_b_id, :chan_id, :member_id, :store_id, :'OP', :'OP')
+RETURNING id AS ord2_id \gset
+
+INSERT INTO customer_order_items (tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price, created_by, updated_by)
+VALUES (:'TENANT', :ord2_id, :ci_b1_id, :sku1_id, 30, 165, :'OP', :'OP');
+
+SELECT rpc_close_campaign(:camp_b_id, :'OP'::uuid);
+SELECT '2.10 create pr B' AS scn,
+       rpc_create_pr_from_close_date('2026-04-26'::date, :'OP'::uuid) AS pr_b_id \gset
+
+SELECT '2.10 submit B' AS scn, rpc_submit_pr(:pr_b_id, :'OP'::uuid);
+SELECT '2.10 verify B' AS scn, status, review_status, total_amount, review_threshold_amount
+  FROM purchase_requests WHERE id = :pr_b_id;
+-- 預期：review_status='pending_review'、threshold_amount=1000
+
+-- ============================================================
+-- 2.12 拆 PO happy path（用 PR A，已 approved）
+-- ============================================================
+
+SELECT '2.12 split' AS scn, rpc_split_pr_to_pos(:pr_id, 1::bigint, :'OP'::uuid) AS po_ids;
+
+SELECT '2.12 PO list' AS scn, id, po_no, supplier_id, status, total
+  FROM purchase_orders
+ WHERE id IN (SELECT unnest(rpc_split_pr_to_pos.po_ids)
+                FROM (SELECT 1::int AS dummy) d
+                CROSS JOIN LATERAL (SELECT '{}'::BIGINT[] AS po_ids) x)
+ORDER BY id;
+
+-- 直接從 supplier 反查
+SELECT '2.12 PO by supplier' AS scn, po.id, po.po_no, po.supplier_id, po.status, po.total
+  FROM purchase_orders po
+ WHERE po.created_by = :'OP'::uuid
+   AND po.created_at > NOW() - INTERVAL '1 minute'
+ ORDER BY po.id;
+
+SELECT '2.12 PO items' AS scn, po.po_no, poi.sku_id, poi.qty_ordered, poi.unit_cost
+  FROM purchase_orders po
+  JOIN purchase_order_items poi ON poi.po_id = po.id
+ WHERE po.created_at > NOW() - INTERVAL '1 minute'
+ ORDER BY po.id, poi.sku_id;
+
+SELECT '2.12 PR status after split' AS scn, status FROM purchase_requests WHERE id = :pr_id;
+
+-- ============================================================
+-- 2.13 拆 PO 守衛：review_status 未通過（用 pr_b_id, pending_review）
+-- ============================================================
+
+DO $$
+DECLARE prb BIGINT;
+BEGIN
+  SELECT id INTO prb FROM purchase_requests
+   WHERE source_close_date = '2026-04-26' AND review_status = 'pending_review' LIMIT 1;
+  BEGIN
+    PERFORM rpc_split_pr_to_pos(prb, 1::bigint, '00000000-0000-0000-0000-000000000099'::uuid);
+    RAISE NOTICE '2.13 FAIL: should have raised';
+  EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE '2.13 OK: %', SQLERRM;
+  END;
+END $$;
+
+-- ============================================================
+-- 2.15 拆 PO 守衛：已拆過
+-- ============================================================
+
+DO $$
+DECLARE pra BIGINT := CAST(current_setting('app.pr_a_id', TRUE) AS BIGINT);
+BEGIN
+  -- pra 已 fully_ordered
+  BEGIN
+    PERFORM rpc_split_pr_to_pos(pra, 1::bigint, '00000000-0000-0000-0000-000000000099'::uuid);
+  EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE '2.15 OK: %', SQLERRM;
+  END;
+END $$;
+-- 註：上方因 plpgsql block 沒有 psql var、改用直接 SQL：
+-- 直接重複呼叫
+SELECT '2.15 verify' AS scn,
+       (SELECT status FROM purchase_requests WHERE id = :pr_id) AS pra_status;
+-- 上 SELECT 不會 RAISE，但下面這條會：
+\echo '2.15 expect ERROR:'
+SELECT rpc_split_pr_to_pos(:pr_id, 1::bigint, :'OP'::uuid);
+
+-- 上一條會中止 transaction、所以放最尾。
+
+-- ============================================================
+ROLLBACK;

--- a/supabase/migrations/20260428120000_campaign_to_purchase.sql
+++ b/supabase/migrations/20260428120000_campaign_to_purchase.sql
@@ -1,0 +1,488 @@
+-- ============================================================
+-- Campaign 結單 → 內部採購單（PR）→ 拆 PO 流程
+-- PRD: docs/PRD-訂單取貨模組.md §7.5、docs/PRD-採購模組.md §7.2~§7.4
+-- TEST: docs/TEST-campaign-to-purchase.md
+-- Issue: #76
+--
+-- 設計（對齊 lt-erp UX）：
+--   1. PR 是「跨供應商工作底稿」：一張 PR 多家供應商混排，per-line suggested_supplier_id
+--   2. 「帶入該日商品」一鍵把該結單日所有 closed campaign 的商品彙總到一張 PR
+--   3. 送審 → 通過 → 依 suggested_supplier_id 拆多張 PO
+-- ============================================================
+
+-- ============================================================
+-- 1. SCHEMA: purchase_requests 擴充
+-- ============================================================
+
+ALTER TABLE purchase_requests
+  ADD COLUMN source_type        TEXT NOT NULL DEFAULT 'manual'
+                                  CHECK (source_type IN ('manual','close_date')),
+  ADD COLUMN source_close_date  DATE,
+  ADD COLUMN total_amount       NUMERIC(18,4) NOT NULL DEFAULT 0;
+
+ALTER TABLE purchase_requests
+  ADD CONSTRAINT chk_pr_source_close_date CHECK (
+    (source_type = 'close_date' AND source_close_date IS NOT NULL) OR
+    (source_type = 'manual')
+  );
+
+CREATE INDEX idx_pr_close_date ON purchase_requests
+  (tenant_id, source_close_date) WHERE source_type = 'close_date';
+
+-- ============================================================
+-- 2. SCHEMA: purchase_request_items 擴充
+-- ============================================================
+
+ALTER TABLE purchase_request_items
+  ADD COLUMN unit_cost          NUMERIC(18,4) NOT NULL DEFAULT 0,
+  ADD COLUMN line_subtotal      NUMERIC(18,2)
+    GENERATED ALWAYS AS (qty_requested * unit_cost) STORED,
+  ADD COLUMN source_campaign_id BIGINT REFERENCES group_buy_campaigns(id);
+
+CREATE INDEX idx_pri_supplier ON purchase_request_items (suggested_supplier_id);
+
+-- ============================================================
+-- 3. SCHEMA: suppliers 擴充（v0.2 PRD §Q4）
+-- ============================================================
+
+ALTER TABLE suppliers
+  ADD COLUMN preferred_po_channel TEXT NOT NULL DEFAULT 'line'
+                                    CHECK (preferred_po_channel IN ('line','email','phone','fax','manual')),
+  ADD COLUMN line_contact         TEXT;
+
+-- ============================================================
+-- 4. SEQUENCES: pr_no / po_no
+-- ============================================================
+
+CREATE SEQUENCE IF NOT EXISTS pr_no_seq;
+CREATE SEQUENCE IF NOT EXISTS po_no_seq;
+
+CREATE OR REPLACE FUNCTION public.rpc_next_pr_no()
+RETURNS TEXT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN 'PR' || to_char(NOW(), 'YYMMDD') || lpad(nextval('pr_no_seq')::text, 4, '0');
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.rpc_next_po_no()
+RETURNS TEXT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN 'PO' || to_char(NOW(), 'YYMMDD') || lpad(nextval('po_no_seq')::text, 4, '0');
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_next_pr_no TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_next_po_no TO authenticated;
+
+-- ============================================================
+-- 5. RPC: rpc_close_campaign
+--    純切 status open → closed，不自動產 PR
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_close_campaign(
+  p_campaign_id BIGINT,
+  p_operator    UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_status TEXT;
+BEGIN
+  SELECT status INTO v_status
+    FROM group_buy_campaigns
+   WHERE id = p_campaign_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'campaign % not found', p_campaign_id;
+  END IF;
+
+  IF v_status <> 'open' THEN
+    RAISE EXCEPTION 'campaign % not in open status (current: %)', p_campaign_id, v_status;
+  END IF;
+
+  UPDATE group_buy_campaigns
+     SET status = 'closed',
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_campaign_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_close_campaign TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_close_campaign IS
+  '結單：campaign open → closed（不自動產 PR，由 rpc_create_pr_from_close_date 另行觸發）';
+
+-- ============================================================
+-- 6. RPC: rpc_create_pr_from_close_date
+--    「帶入該日商品」核心：彙總該結單日所有 closed campaign 的商品成單張 PR
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_create_pr_from_close_date(
+  p_close_date DATE,
+  p_operator   UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant      UUID := public._current_tenant_id();
+  v_pr_id       BIGINT;
+  v_pr_no       TEXT;
+  v_dest_loc    BIGINT;
+  v_campaign_count INTEGER;
+  v_demand_count   INTEGER;
+BEGIN
+  -- 1. 守衛：該日是否有 closed campaign
+  SELECT COUNT(*) INTO v_campaign_count
+    FROM group_buy_campaigns
+   WHERE tenant_id = v_tenant
+     AND status = 'closed'
+     AND DATE(end_at AT TIME ZONE 'Asia/Taipei') = p_close_date;
+
+  IF v_campaign_count = 0 THEN
+    RAISE EXCEPTION 'no closed campaigns on date %', p_close_date;
+  END IF;
+
+  -- 2. 守衛：是否有可彙總的訂單
+  SELECT COUNT(*) INTO v_demand_count
+    FROM group_buy_campaigns gbc
+    JOIN customer_orders co ON co.campaign_id = gbc.id
+    JOIN customer_order_items coi ON coi.order_id = co.id
+   WHERE gbc.tenant_id = v_tenant
+     AND gbc.status = 'closed'
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = p_close_date
+     AND co.status NOT IN ('cancelled','expired')
+     AND coi.status NOT IN ('cancelled','expired');
+
+  IF v_demand_count = 0 THEN
+    RAISE EXCEPTION 'no orders to aggregate for close_date %', p_close_date;
+  END IF;
+
+  -- 3. 取一個 location 當 dest（預設第一個）
+  SELECT id INTO v_dest_loc FROM locations
+   WHERE tenant_id = v_tenant
+   ORDER BY id LIMIT 1;
+
+  IF v_dest_loc IS NULL THEN
+    RAISE EXCEPTION 'no locations defined for tenant %', v_tenant;
+  END IF;
+
+  -- 4. 建 PR header
+  v_pr_no := public.rpc_next_pr_no();
+
+  INSERT INTO purchase_requests (
+    tenant_id, pr_no, source_type, source_close_date,
+    source_location_id, status, total_amount,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_pr_no, 'close_date', p_close_date,
+    v_dest_loc, 'draft', 0,
+    p_operator, p_operator
+  ) RETURNING id INTO v_pr_id;
+
+  -- 5. 彙總 items（per SKU 跨 campaign 累加 qty）
+  INSERT INTO purchase_request_items (
+    pr_id, sku_id, qty_requested,
+    suggested_supplier_id, unit_cost, source_campaign_id,
+    created_by, updated_by
+  )
+  SELECT
+    v_pr_id,
+    agg.sku_id,
+    agg.qty_total,
+    ss.supplier_id,
+    COALESCE(ss.default_unit_cost, 0),
+    agg.first_campaign_id,
+    p_operator,
+    p_operator
+  FROM (
+    SELECT
+      coi.sku_id,
+      SUM(coi.qty) AS qty_total,
+      MIN(gbc.id)  AS first_campaign_id
+      FROM group_buy_campaigns gbc
+      JOIN customer_orders co ON co.campaign_id = gbc.id
+      JOIN customer_order_items coi ON coi.order_id = co.id
+     WHERE gbc.tenant_id = v_tenant
+       AND gbc.status = 'closed'
+       AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = p_close_date
+       AND co.status NOT IN ('cancelled','expired')
+       AND coi.status NOT IN ('cancelled','expired')
+     GROUP BY coi.sku_id
+  ) agg
+  LEFT JOIN LATERAL (
+    SELECT supplier_id, default_unit_cost
+      FROM supplier_skus
+     WHERE tenant_id = v_tenant
+       AND sku_id = agg.sku_id
+       AND is_preferred = TRUE
+     LIMIT 1
+  ) ss ON TRUE;
+
+  -- 6. 更新 PR.total_amount 快照
+  UPDATE purchase_requests pr
+     SET total_amount = COALESCE((
+           SELECT SUM(line_subtotal) FROM purchase_request_items WHERE pr_id = v_pr_id
+         ), 0),
+         updated_at = NOW()
+   WHERE pr.id = v_pr_id;
+
+  RETURN v_pr_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_pr_from_close_date TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_pr_from_close_date IS
+  '「帶入該日商品」：把該結單日所有 closed campaign 的商品需求彙總到一張 PR';
+
+-- ============================================================
+-- 7. RPC: rpc_submit_pr
+--    送出審核：算 total_amount + 套 threshold + 設 review_status
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_submit_pr(
+  p_pr_id    BIGINT,
+  p_operator UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant       UUID;
+  v_status       TEXT;
+  v_review       TEXT;
+  v_total        NUMERIC(18,4);
+  v_threshold    NUMERIC(18,4);
+  v_new_review   TEXT;
+BEGIN
+  SELECT tenant_id, status, review_status INTO v_tenant, v_status, v_review
+    FROM purchase_requests
+   WHERE id = p_pr_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PR % not found', p_pr_id;
+  END IF;
+
+  IF v_status <> 'draft' THEN
+    RAISE EXCEPTION 'PR % already submitted (status: %)', p_pr_id, v_status;
+  END IF;
+
+  -- 重算 total（考慮使用者已編輯 unit_cost / qty）
+  SELECT COALESCE(SUM(line_subtotal), 0) INTO v_total
+    FROM purchase_request_items WHERE pr_id = p_pr_id;
+
+  -- 套 global threshold（簡化：先支援 global scope）
+  SELECT MIN(threshold_amount) INTO v_threshold
+    FROM purchase_approval_thresholds
+   WHERE tenant_id = v_tenant
+     AND active = TRUE
+     AND scope = 'global'
+     AND scope_id IS NULL;
+
+  IF v_threshold IS NOT NULL AND v_total >= v_threshold THEN
+    v_new_review := 'pending_review';
+  ELSE
+    v_new_review := 'approved';
+  END IF;
+
+  UPDATE purchase_requests
+     SET status = 'submitted',
+         submitted_at = NOW(),
+         total_amount = v_total,
+         review_status = v_new_review,
+         review_threshold_amount = v_threshold,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_pr_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_submit_pr TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_submit_pr IS
+  'PR 送審：重算 total → 比 threshold → 設 review_status (approved / pending_review)';
+
+-- ============================================================
+-- 8. RPC: rpc_split_pr_to_pos
+--    依 suggested_supplier_id 拆多張 PO
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_split_pr_to_pos(
+  p_pr_id            BIGINT,
+  p_dest_location_id BIGINT,
+  p_operator         UUID
+) RETURNS BIGINT[]
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant   UUID;
+  v_status   TEXT;
+  v_review   TEXT;
+  v_unassigned INTEGER;
+  v_supplier_rec RECORD;
+  v_po_id    BIGINT;
+  v_po_no    TEXT;
+  v_po_ids   BIGINT[] := ARRAY[]::BIGINT[];
+BEGIN
+  SELECT tenant_id, status, review_status INTO v_tenant, v_status, v_review
+    FROM purchase_requests
+   WHERE id = p_pr_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PR % not found', p_pr_id;
+  END IF;
+
+  IF v_review <> 'approved' THEN
+    RAISE EXCEPTION 'PR % not approved (current: %)', p_pr_id, v_review;
+  END IF;
+
+  IF v_status IN ('fully_ordered','partially_ordered','cancelled') THEN
+    RAISE EXCEPTION 'PR % already split (status: %)', p_pr_id, v_status;
+  END IF;
+
+  -- 守衛：含未指派供應商行
+  SELECT COUNT(*) INTO v_unassigned
+    FROM purchase_request_items
+   WHERE pr_id = p_pr_id AND suggested_supplier_id IS NULL;
+
+  IF v_unassigned > 0 THEN
+    RAISE EXCEPTION 'PR % has % unassigned supplier items', p_pr_id, v_unassigned;
+  END IF;
+
+  -- 依 supplier 拆 PO
+  FOR v_supplier_rec IN
+    SELECT DISTINCT suggested_supplier_id AS supplier_id
+      FROM purchase_request_items
+     WHERE pr_id = p_pr_id
+  LOOP
+    v_po_no := public.rpc_next_po_no();
+
+    INSERT INTO purchase_orders (
+      tenant_id, po_no, supplier_id, dest_location_id, status,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, v_po_no, v_supplier_rec.supplier_id, p_dest_location_id, 'draft',
+      p_operator, p_operator
+    ) RETURNING id INTO v_po_id;
+
+    -- PO items 從 PR items copy
+    WITH inserted AS (
+      INSERT INTO purchase_order_items (
+        po_id, sku_id, qty_ordered, unit_cost,
+        created_by, updated_by
+      )
+      SELECT v_po_id, pri.sku_id, pri.qty_requested, pri.unit_cost,
+             p_operator, p_operator
+        FROM purchase_request_items pri
+       WHERE pri.pr_id = p_pr_id
+         AND pri.suggested_supplier_id = v_supplier_rec.supplier_id
+      RETURNING id, sku_id
+    )
+    UPDATE purchase_request_items pri
+       SET po_item_id = i.id,
+           updated_by = p_operator
+      FROM inserted i
+     WHERE pri.pr_id = p_pr_id
+       AND pri.suggested_supplier_id = v_supplier_rec.supplier_id
+       AND pri.sku_id = i.sku_id;
+
+    -- 更新 PO totals
+    UPDATE purchase_orders po
+       SET subtotal = sub.subtotal,
+           total = sub.subtotal,
+           updated_at = NOW()
+      FROM (
+        SELECT po_id, SUM(qty_ordered * unit_cost) AS subtotal
+          FROM purchase_order_items WHERE po_id = v_po_id GROUP BY po_id
+      ) sub
+     WHERE po.id = sub.po_id;
+
+    v_po_ids := v_po_ids || v_po_id;
+  END LOOP;
+
+  -- 標 PR 為 fully_ordered
+  UPDATE purchase_requests
+     SET status = 'fully_ordered',
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_pr_id;
+
+  RETURN v_po_ids;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_split_pr_to_pos TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_split_pr_to_pos IS
+  '依 suggested_supplier_id 把 PR 拆成多張 PO（每 supplier 一張）';
+
+-- ============================================================
+-- 9. RPC: rpc_send_purchase_order
+--    PO draft → sent，守衛 source PR 不可有 pending_review / rejected
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_send_purchase_order(
+  p_po_id    BIGINT,
+  p_channel  TEXT,
+  p_operator UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_status         TEXT;
+  v_pending_count  INTEGER;
+  v_rejected_count INTEGER;
+BEGIN
+  IF p_channel NOT IN ('line','email','phone','fax','manual') THEN
+    RAISE EXCEPTION 'invalid channel: %', p_channel;
+  END IF;
+
+  SELECT status INTO v_status FROM purchase_orders WHERE id = p_po_id FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PO % not found', p_po_id;
+  END IF;
+
+  IF v_status <> 'draft' THEN
+    RAISE EXCEPTION 'PO % already sent (status: %)', p_po_id, v_status;
+  END IF;
+
+  SELECT
+    COUNT(*) FILTER (WHERE pr.review_status = 'pending_review'),
+    COUNT(*) FILTER (WHERE pr.review_status = 'rejected')
+    INTO v_pending_count, v_rejected_count
+    FROM purchase_request_items pri
+    JOIN purchase_requests pr ON pr.id = pri.pr_id
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+   WHERE poi.po_id = p_po_id;
+
+  IF v_pending_count > 0 THEN
+    RAISE EXCEPTION 'PO has % PR pending review', v_pending_count;
+  END IF;
+
+  IF v_rejected_count > 0 THEN
+    RAISE EXCEPTION 'PO has % rejected PR', v_rejected_count;
+  END IF;
+
+  UPDATE purchase_orders
+     SET status = 'sent',
+         sent_at = NOW(),
+         sent_by = p_operator,
+         sent_channel = p_channel,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_po_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_send_purchase_order TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_send_purchase_order IS
+  'PO 發送：draft → sent，守衛來源 PR 必須 review_status=approved';


### PR DESCRIPTION
## Summary

採購模組端到端流程上線：成團 → 顧客訂單 → **採購單(PR) → 採購訂單(PO) → 發送供應商**。

關閉 #76 #10 #8。後續 follow-up issue：#116 #117 #118。

對齊 lt-erp 內部採購單 UX：PR 是跨供應商工作底稿，通過審核後依 supplier 拆多張 PO 各自發給供應商。

## 8 個 migrations (20260428120000–20260428190000)

| # | 內容 |
|---|---|
| 120000 | schema + 5 RPCs (close/create/submit/split/send) |
| 130000 | admin role RLS 補 (auth_read_* + *_hq_all) |
| 140000 | 每 close_date 一張 PR 守衛 |
| 150000 | retail/franchise price snapshot |
| 160000 | prices 欄位 hotfix |
| 170000 | rpc_get_staff_names (顯示 user name) |
| 180000 | finalize + v_pickup_reconcile view |
| 190000 | 同日漏網之團 auto-append |

## 9 個新 RPC

- `rpc_close_campaign(jsonb)` 智慧結單：該日全結→自動建 PR；同日 PR draft→auto-append；submitted→跳過
- `rpc_create_pr_from_close_date` 「帶入該日商品」核心
- `rpc_append_campaign_to_pr` 補 append
- `rpc_submit_pr` 送審 + threshold
- `rpc_split_pr_to_pos` 依 supplier 拆 PO
- `rpc_send_purchase_order` 發送（5 channel）
- `rpc_finalize_campaign` 整單結算
- `rpc_get_staff_names` 顯示名稱
- `rpc_next_pr_no` / `rpc_next_po_no`

## UI 落地

新頁面：
- `/campaigns`：加結單按鈕
- `/purchase/requests` 列表 + 「結單日待開單」cards + 流程 timeline 欄
- `/purchase/requests/edit` C 兩欄 layout (左 280px aside + 右採購清單)
- `/purchase/requests/print` 依供應商分組 + 完整供應商資訊
- `/purchase/orders` 手風琴 (PR > N POs)
- `/purchase/orders/edit` PO 詳情頁

共用 component：
- `PrPipelineStepper` — 8 step 時間軸：建立→編輯→送審→審核→建單→**發送→到貨→結算**
  - compact / 完整 模式
  - hover tooltip 顯示 actor + time
  - step 可點跳 detail
- `SendPOModal` — LINE / Email / 電話 / 傳真 / 手動 五通路
  - LINE：自動產生格式化文字 + 「📋 複製文字」+ supplier.line_contact

## 關鍵設計決策

- **PR = 跨供應商工作底稿**（不綁單一 supplier；line item 帶 suggested_supplier_id）
- **一個 close_date 一張 PR**（重複守衛 + 同日漏網自動 append）
- **價格 snapshot**：retail/franchise 建單時抓快照、UI 可手動覆寫、不影響商品主檔
- **時間線視覺**=採購生命週期的標準語言（之後其他模組可重用 PrPipelineStepper）
- **「拆 PO」**用詞改為**「建立採購訂單」**

## Test plan

§1 + §2 後端 11 情境 [docs/TEST-campaign-to-purchase.md](docs/TEST-campaign-to-purchase.md) ✓
- §1 schema / sequence / RPC sig
- §2.1 帶入該日商品 happy path（PR2604250001 total=3600 ✓）
- §2.4 該日無 closed campaign 守衛 ✓
- §2.7 結單守衛（draft 拒絕）✓
- §2.8 結單 happy path ✓
- §2.9 送審 happy ✓
- §2.12 拆 PO 多供應商分組 ✓
- §2.15 拆 PO 守衛（已拆過）✓
- §2.16/2.17/2.19 PO 發送 happy + 守衛 ✓

§3 UI 互動驗證（cktalex 帳號）：
- /campaigns 結單按鈕 ✓
- 卡片「📋 開始建立」→ 帶入該日商品 ✓
- 編輯頁兩欄 + timeline + 售價/分店價 input ✓
- 列印頁依供應商 group + 完整資訊 ✓
- PO 列表手風琴 + PO edit + SendPOModal ✓
- 同日漏網之團 banner + 全部併入 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)