### PR TITLE
feat(purchase): campaign 整單結算按鈕 (#116)

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -46,6 +46,7 @@ export default function CampaignsListPage() {
   >(null);
   const [reloadTick, setReloadTick] = useState(0);
   const [closingId, setClosingId] = useState<number | null>(null);
+  const [finalizingId, setFinalizingId] = useState<number | null>(null);
 
   async function closeCampaign(id: number, name: string) {
     if (!confirm(`確定結單「${name}」？結單後可從採購單頁面「帶入該日商品」產生 PR。`)) return;
@@ -61,6 +62,23 @@ export default function CampaignsListPage() {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setClosingId(null);
+    }
+  }
+
+  async function finalizeCampaign(id: number, name: string) {
+    if (!confirm(`整單結算「${name}」？結算後無法復原，請確認所有顧客訂單皆已完成 / 逾期 / 取消。`)) return;
+    setFinalizingId(id);
+    try {
+      const { error: rpcErr } = await getSupabase().rpc("rpc_finalize_campaign", {
+        p_campaign_id: id,
+        p_operator: (await getSupabase().auth.getUser()).data.user?.id,
+      });
+      if (rpcErr) throw new Error(rpcErr.message);
+      setReloadTick((t) => t + 1);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setFinalizingId(null);
     }
   }
 
@@ -225,6 +243,15 @@ export default function CampaignsListPage() {
                         className="text-xs text-amber-600 hover:underline disabled:opacity-50 dark:text-amber-400"
                       >
                         {closingId === r.id ? "結單中…" : "結單"}
+                      </button>
+                    )}
+                    {(["closed", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
+                      <button
+                        onClick={() => finalizeCampaign(r.id, r.name)}
+                        disabled={finalizingId === r.id}
+                        className="text-xs text-purple-600 hover:underline disabled:opacity-50 dark:text-purple-400"
+                      >
+                        {finalizingId === r.id ? "結算中…" : "結算"}
                       </button>
                     )}
                   </div>

--- a/docs/TEST-campaign-finalize.md
+++ b/docs/TEST-campaign-finalize.md
@@ -1,0 +1,56 @@
+# campaign-finalize 測試項目 — 開團整單結算 UI
+
+**對應 migration:** `supabase/migrations/20260428180000_workflow_close_loop.sql`（rpc_finalize_campaign 已建）
+**對應 UI 變更:**
+- `apps/admin/src/app/(protected)/campaigns/page.tsx`（新增「結算」按鈕）
+
+**對應 PRD:** `docs/PRD-訂單取貨模組.md` §7.5（結單 → 結算 timeline 第 8 步）
+**對應 Issue:** [#116 campaign finalize button](https://github.com/lt-foods/new_erp/issues/116)
+
+---
+
+## 1. 顯示層
+
+### 1.1 按鈕可見性
+- [ ] `status='draft'` → 不顯示「結算」按鈕
+- [ ] `status='open'` → 不顯示「結算」按鈕（只顯示「結單」）
+- [ ] `status='closed'` → 顯示「結算」按鈕
+- [ ] `status='ordered'` → 顯示「結算」按鈕
+- [ ] `status='receiving'` → 顯示「結算」按鈕
+- [ ] `status='ready'` → 顯示「結算」按鈕
+- [ ] `status='completed'` → 不顯示
+- [ ] `status='cancelled'` → 不顯示
+
+### 1.2 按鈕狀態
+- [ ] 點擊先 `confirm()` 提示「整單結算後不可逆」
+- [ ] 取消 confirm 不發 RPC
+- [ ] 按鈕 disabled + 顯示「結算中…」直到 RPC 完成
+
+---
+
+## 2. RPC 整合
+
+### 2.1 守衛：未結案訂單
+- [ ] 製造一筆 `customer_orders.status='confirmed'` 的開團 → 點結算 → 看到 error toast 含 `unfinished customer orders`
+- [ ] campaign 仍維持原狀態（不改 completed）
+
+### 2.2 成功路徑
+- [ ] 全部 customer_orders 都 completed/expired/cancelled → 點結算 → 列表 reload，狀態變「已完成」
+- [ ] DB 驗證：
+  ```sql
+  SELECT status, updated_by, updated_at
+    FROM group_buy_campaigns
+   WHERE id = <測試 campaign>;
+  ```
+  status='completed', updated_by 是當前 user
+
+### 2.3 重複點擊
+- [ ] 已 completed 的 campaign 點結算 → RPC RAISE `not in finalizable status` → UI 顯示錯誤
+
+---
+
+## 3. UX
+
+- [ ] error toast 與既有 closeCampaign 風格一致
+- [ ] 結算後不需手動 reload 列表
+- [ ] 表頭計數（共 N 筆）不會卡住載入中狀態


### PR DESCRIPTION
## Summary
- /campaigns 列表加「結算」按鈕（狀態 closed/ordered/receiving/ready 顯示），接上 PR #115 已建的 `rpc_finalize_campaign`
- confirm 確認後呼叫 RPC，成功 reload 列表，campaign status → completed
- 守衛由 RPC 端把關（仍有未結案 customer_orders 會 RAISE，UI 顯示錯誤）
- 對應 timeline 第 8 步「結算」

## Test plan
測試清單見 `docs/TEST-campaign-finalize.md`，主要驗證：
- [ ] 按鈕只在 closed/ordered/receiving/ready 出現
- [ ] 仍有未結案訂單 → RPC RAISE → UI 紅 banner 顯示錯誤訊息
- [ ] 全部完成 → 點結算 → 狀態變「已完成」、按鈕消失
- [ ] 已 completed 再點 → RPC RAISE `not in finalizable status`

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)