### PR TITLE
feat(schema): member_type/guest + order_expiry/shortage_events (#72/#73/#75)

### DIFF
--- a/docs/TEST-member-type-guest.md
+++ b/docs/TEST-member-type-guest.md
@@ -1,0 +1,50 @@
+# TEST — Issue #75: member_type + guest RPCs
+
+## 目標
+驗證 `members.member_type`、`customer_orders.order_type` 欄位與兩支 guest RPC 正確運作。
+
+## 前置條件
+- Migration `20260429120000_member_type_guest.sql` 已 apply
+- 至少一筆 `line_channels` 與對應 `locations` 存在
+- 測試用 tenant_id / channel_id 已知
+
+---
+
+## T1 — 欄位存在確認
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T1-1 | `SELECT column_name, data_type, column_default, is_nullable FROM information_schema.columns WHERE table_name='members' AND column_name='member_type'` | 1 列：`text`, default `full`, NOT NULL |
+| T1-2 | 同上查 `customer_orders.order_type` | 1 列：`text`, default `regular`, NOT NULL |
+| T1-3 | 查現有 members 的 member_type | 全部應為 `full`（預設值 backfill） |
+
+## T2 — rpc_create_guest_member
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T2-1 | 呼叫 `SELECT rpc_create_guest_member('<tenant>', <channel_id>, 'TestGuest')` | 回傳 BIGINT member_id |
+| T2-2 | `SELECT member_type, name, member_no, phone_hash, status FROM members WHERE id = <id>` | `member_type='guest'`, `name='TestGuest'`, `member_no` 以 `G` 開頭, `phone_hash IS NULL`, `status='active'` |
+| T2-3 | `SELECT * FROM customer_line_aliases WHERE member_id = <id>` | 一筆 nickname='TestGuest' 的 alias |
+| T2-4 | 傳入不存在的 channel_id | RAISE EXCEPTION 含 "not found" |
+
+## T3 — rpc_merge_member
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T3-1 | 建一筆 guest member (T2)，建一筆 full member，各建一筆 customer_order | — |
+| T3-2 | 呼叫 `SELECT rpc_merge_member(<guest_id>, <real_id>)` | void，無 exception |
+| T3-3 | 查 guest member | `status='merged'`, `merged_into_member_id = real_id` |
+| T3-4 | 查 customer_orders | 原屬 guest 的 order `member_id` 改為 real_id |
+| T3-5 | 查 customer_line_aliases | guest 的 alias `member_id` 改為 real_id |
+| T3-6 | 查 member_merges | 一筆新紀錄，`primary_member_id=real_id`, `merged_member_id=guest_id` |
+| T3-7 | 對同一 guest 再次呼叫 merge | RAISE EXCEPTION 含 "already merged" |
+| T3-8 | 對非 guest member 呼叫 merge | RAISE EXCEPTION 含 "not a guest" |
+| T3-9 | 傳 guest_id = real_id | RAISE EXCEPTION 含 "must differ" |
+
+## T4 — customer_orders.order_type
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T4-1 | INSERT customer_order 不帶 order_type | order_type = 'regular' |
+| T4-2 | INSERT 帶 order_type = 'invalid' | CHECK constraint violation |
+| T4-3 | INSERT 帶 order_type = 'employee' | 成功 |

--- a/docs/TEST-order-expiry-events.md
+++ b/docs/TEST-order-expiry-events.md
@@ -1,0 +1,33 @@
+# TEST — Issue #72: order_expiry_events
+
+## 目標
+驗證 `order_expiry_events` 表結構、append-only 守衛、RLS 正確。
+
+## 前置條件
+- Migration `20260429130000_order_expiry_events.sql` 已 apply
+- 至少一筆 `customer_orders` 存在
+
+---
+
+## T1 — 表結構確認
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T1-1 | 查 `information_schema.columns WHERE table_name='order_expiry_events'` | 欄位：id, tenant_id, order_id, order_item_id, action, storage_type, qty, movement_id, operator_id, created_at |
+| T1-2 | action CHECK：INSERT 帶 action='invalid' | constraint violation |
+| T1-3 | action 合法值（damaged / returned_to_stock / refunded）各 INSERT 一筆 | 成功 |
+
+## T2 — Append-only 守衛
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T2-1 | `UPDATE order_expiry_events SET qty = 1 WHERE id = <id>` | EXCEPTION 含 "append-only" |
+| T2-2 | `DELETE FROM order_expiry_events WHERE id = <id>` | EXCEPTION 含 "append-only" |
+
+## T3 — 欄位可為 NULL
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T3-1 | INSERT 不帶 operator_id（NULL = 系統自動） | 成功 |
+| T3-2 | INSERT 不帶 order_item_id | 成功 |
+| T3-3 | INSERT 不帶 movement_id | 成功 |

--- a/docs/TEST-order-shortage-events.md
+++ b/docs/TEST-order-shortage-events.md
@@ -1,0 +1,38 @@
+# TEST — Issue #73: order_shortage_events
+
+## 目標
+驗證 `order_shortage_events` 表結構、generated column `shortage_qty`、append-only 守衛。
+
+## 前置條件
+- Migration `20260429140000_order_shortage_events.sql` 已 apply
+- 至少一筆 `customer_orders` 存在
+
+---
+
+## T1 — 表結構確認
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T1-1 | 查 `information_schema.columns WHERE table_name='order_shortage_events'` | 欄位：id, tenant_id, campaign_id, order_id, sku_id, requested_qty, fulfilled_qty, shortage_qty, reason, created_at |
+| T1-2 | `SELECT is_generated FROM information_schema.columns WHERE table_name='order_shortage_events' AND column_name='shortage_qty'` | `ALWAYS` |
+
+## T2 — Generated column
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T2-1 | INSERT requested_qty=10, fulfilled_qty=7 | shortage_qty = 3.000 |
+| T2-2 | INSERT requested_qty=5, fulfilled_qty=5 | shortage_qty = 0.000 |
+| T2-3 | 嘗試 INSERT 帶 shortage_qty 值 | ERROR：generated column 不可手動賦值 |
+
+## T3 — Append-only 守衛
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T3-1 | `UPDATE order_shortage_events SET reason='x' WHERE id = <id>` | EXCEPTION 含 "append-only" |
+| T3-2 | `DELETE FROM order_shortage_events WHERE id = <id>` | EXCEPTION 含 "append-only" |
+
+## T4 — 索引
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T4-1 | `\d order_shortage_events` 或查 pg_indexes | 3 個 index：tenant+campaign, tenant+order, tenant+sku |

--- a/supabase/migrations/20260429120000_member_type_guest.sql
+++ b/supabase/migrations/20260429120000_member_type_guest.sql
@@ -1,0 +1,155 @@
+-- ============================================================================
+-- Issue #75: members.member_type + customer_orders.order_type + guest RPCs
+-- PRD-訂單取貨模組.md §Q8
+-- ============================================================================
+
+-- 1. members.member_type
+ALTER TABLE members
+  ADD COLUMN IF NOT EXISTS member_type TEXT NOT NULL DEFAULT 'full'
+    CHECK (member_type IN ('full','guest'));
+
+-- 2. customer_orders.order_type
+ALTER TABLE customer_orders
+  ADD COLUMN IF NOT EXISTS order_type TEXT NOT NULL DEFAULT 'regular'
+    CHECK (order_type IN ('regular','employee','guest'));
+
+-- ============================================================================
+-- RPC: rpc_create_guest_member
+-- 小幫手遇到無法綁定的 nickname → 自動建訪客會員
+-- ============================================================================
+CREATE OR REPLACE FUNCTION rpc_create_guest_member(
+  p_tenant_id  UUID,
+  p_channel_id BIGINT,
+  p_nickname   TEXT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_member_id  BIGINT;
+  v_store_id   BIGINT;
+BEGIN
+  SELECT home_store_id INTO v_store_id
+    FROM line_channels
+   WHERE id = p_channel_id AND tenant_id = p_tenant_id;
+
+  IF v_store_id IS NULL THEN
+    RAISE EXCEPTION 'channel % not found for tenant %', p_channel_id, p_tenant_id;
+  END IF;
+
+  -- 插入訪客會員；member_no 先用 placeholder，再用 id 補正
+  INSERT INTO members (
+    tenant_id, home_store_id, member_type, name, member_no,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    p_tenant_id, v_store_id, 'guest', p_nickname, 'G-PENDING',
+    auth.uid(), auth.uid(), NOW(), NOW()
+  ) RETURNING id INTO v_member_id;
+
+  UPDATE members
+     SET member_no = 'G' || lpad(v_member_id::text, 8, '0')
+   WHERE id = v_member_id;
+
+  -- 在 customer_line_aliases 記錄 nickname 對應
+  INSERT INTO customer_line_aliases (tenant_id, channel_id, nickname, member_id,
+                                     created_at, updated_at)
+  VALUES (p_tenant_id, p_channel_id, p_nickname, v_member_id, NOW(), NOW())
+  ON CONFLICT (tenant_id, channel_id, nickname) DO NOTHING;
+
+  RETURN v_member_id;
+END;
+$$;
+
+-- ============================================================================
+-- RPC: rpc_merge_member
+-- 訪客升級為正式會員時，搬移所有關聯資料
+-- ============================================================================
+CREATE OR REPLACE FUNCTION rpc_merge_member(
+  p_guest_id BIGINT,
+  p_real_id  BIGINT,
+  p_operator UUID DEFAULT NULL,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant    UUID;
+  v_operator  UUID;
+  v_points    NUMERIC(18,2);
+  v_wallet    NUMERIC(18,2);
+  v_cards     INTEGER;
+BEGIN
+  v_operator := COALESCE(p_operator, auth.uid());
+
+  SELECT tenant_id INTO v_tenant FROM members WHERE id = p_guest_id;
+
+  -- 守衛
+  IF (SELECT member_type FROM members WHERE id = p_guest_id) <> 'guest' THEN
+    RAISE EXCEPTION 'member % is not a guest', p_guest_id;
+  END IF;
+  IF (SELECT status FROM members WHERE id = p_guest_id) = 'merged' THEN
+    RAISE EXCEPTION 'member % is already merged', p_guest_id;
+  END IF;
+  IF p_guest_id = p_real_id THEN
+    RAISE EXCEPTION 'guest_id and real_id must differ';
+  END IF;
+
+  -- 搬訂單
+  UPDATE customer_orders SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  -- 搬 LINE 暱稱對應
+  UPDATE customer_line_aliases SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  -- 搬標籤
+  UPDATE member_tags SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  -- 搬會員卡
+  SELECT COUNT(*) INTO v_cards FROM member_cards WHERE member_id = p_guest_id;
+  UPDATE member_cards SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  -- 取得訪客點數 / 儲值金餘額
+  SELECT COALESCE(balance, 0) INTO v_points
+    FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  SELECT COALESCE(balance, 0) INTO v_wallet
+    FROM wallet_balances WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+
+  -- 搬流水帳
+  UPDATE points_ledger  SET member_id = p_real_id WHERE member_id = p_guest_id;
+  UPDATE wallet_ledger  SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  -- 合併餘額（UPSERT）
+  INSERT INTO member_points_balance (tenant_id, member_id, balance, version, updated_at)
+  VALUES (v_tenant, p_real_id, GREATEST(v_points, 0), 1, NOW())
+  ON CONFLICT (tenant_id, member_id) DO UPDATE
+    SET balance          = member_points_balance.balance + GREATEST(EXCLUDED.balance, 0),
+        version          = member_points_balance.version + 1,
+        last_movement_at = NOW(),
+        updated_at       = NOW();
+
+  INSERT INTO wallet_balances (tenant_id, member_id, balance, version, updated_at)
+  VALUES (v_tenant, p_real_id, GREATEST(v_wallet, 0), 1, NOW())
+  ON CONFLICT (tenant_id, member_id) DO UPDATE
+    SET balance          = wallet_balances.balance + GREATEST(EXCLUDED.balance, 0),
+        version          = wallet_balances.version + 1,
+        last_movement_at = NOW(),
+        updated_at       = NOW();
+
+  -- 刪除訪客餘額快取列
+  DELETE FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  DELETE FROM wallet_balances        WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+
+  -- 標記訪客為 merged
+  UPDATE members
+     SET status                = 'merged',
+         merged_into_member_id = p_real_id,
+         updated_at            = NOW(),
+         updated_by            = v_operator
+   WHERE id = p_guest_id;
+
+  -- 寫合併紀錄
+  INSERT INTO member_merges (
+    tenant_id, primary_member_id, merged_member_id,
+    points_moved, wallet_moved, cards_moved, reason, operator_id
+  ) VALUES (
+    v_tenant, p_real_id, p_guest_id,
+    v_points, v_wallet, v_cards, p_reason, v_operator
+  );
+END;
+$$;

--- a/supabase/migrations/20260429130000_order_expiry_events.sql
+++ b/supabase/migrations/20260429130000_order_expiry_events.sql
@@ -1,0 +1,50 @@
+-- ============================================================================
+-- Issue #72: order_expiry_events — 取貨逾期處理紀錄 (PRD §Q10)
+-- append-only log；無 RPC（由上層業務邏輯直接 INSERT）
+-- ============================================================================
+
+CREATE TABLE order_expiry_events (
+  id            BIGSERIAL PRIMARY KEY,
+  tenant_id     UUID NOT NULL,
+  order_id      BIGINT NOT NULL REFERENCES customer_orders(id),
+  order_item_id BIGINT,                    -- NULL = 整筆訂單
+  action        TEXT NOT NULL CHECK (action IN ('damaged','returned_to_stock','refunded')),
+  storage_type  TEXT,
+  qty           NUMERIC(18,3) NOT NULL,
+  movement_id   BIGINT REFERENCES stock_movements(id),
+  operator_id   UUID,                      -- NULL = 系統自動
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_oee_order    ON order_expiry_events (tenant_id, order_id);
+CREATE INDEX idx_oee_created  ON order_expiry_events (tenant_id, created_at DESC);
+
+-- append-only guard
+CREATE OR REPLACE FUNCTION forbid_expiry_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'order_expiry_events is append-only';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_no_update_expiry
+  BEFORE UPDATE ON order_expiry_events FOR EACH ROW EXECUTE FUNCTION forbid_expiry_mutation();
+CREATE TRIGGER trg_no_delete_expiry
+  BEFORE DELETE ON order_expiry_events FOR EACH ROW EXECUTE FUNCTION forbid_expiry_mutation();
+
+-- RLS
+ALTER TABLE order_expiry_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY oee_hq_all ON order_expiry_events
+  AS PERMISSIVE FOR ALL TO authenticated
+  USING ((auth.jwt() -> 'app_metadata' ->> 'role') = 'hq');
+
+CREATE POLICY oee_store_read ON order_expiry_events
+  AS PERMISSIVE FOR SELECT TO authenticated
+  USING (
+    tenant_id = (auth.jwt() -> 'app_metadata' ->> 'tenant_id')::uuid
+    AND order_id IN (
+      SELECT id FROM customer_orders
+       WHERE store_id = (auth.jwt() -> 'app_metadata' ->> 'store_id')::bigint
+    )
+  );

--- a/supabase/migrations/20260429140000_order_shortage_events.sql
+++ b/supabase/migrations/20260429140000_order_shortage_events.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- Issue #73: order_shortage_events — FIFO 分配不足紀錄 (PRD §Q16)
+-- append-only log；shortage_qty 為 generated column
+-- ============================================================================
+
+CREATE TABLE order_shortage_events (
+  id            BIGSERIAL PRIMARY KEY,
+  tenant_id     UUID NOT NULL,
+  campaign_id   BIGINT NOT NULL,
+  order_id      BIGINT NOT NULL REFERENCES customer_orders(id),
+  sku_id        BIGINT NOT NULL,
+  requested_qty NUMERIC(18,3),
+  fulfilled_qty NUMERIC(18,3),
+  shortage_qty  NUMERIC(18,3) GENERATED ALWAYS AS (requested_qty - fulfilled_qty) STORED,
+  reason        TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_ose_campaign  ON order_shortage_events (tenant_id, campaign_id);
+CREATE INDEX idx_ose_order     ON order_shortage_events (tenant_id, order_id);
+CREATE INDEX idx_ose_sku       ON order_shortage_events (tenant_id, sku_id);
+
+-- append-only guard
+CREATE OR REPLACE FUNCTION forbid_shortage_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'order_shortage_events is append-only';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_no_update_shortage
+  BEFORE UPDATE ON order_shortage_events FOR EACH ROW EXECUTE FUNCTION forbid_shortage_mutation();
+CREATE TRIGGER trg_no_delete_shortage
+  BEFORE DELETE ON order_shortage_events FOR EACH ROW EXECUTE FUNCTION forbid_shortage_mutation();
+
+-- RLS
+ALTER TABLE order_shortage_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY ose_hq_all ON order_shortage_events
+  AS PERMISSIVE FOR ALL TO authenticated
+  USING ((auth.jwt() -> 'app_metadata' ->> 'role') = 'hq');
+
+CREATE POLICY ose_store_read ON order_shortage_events
+  AS PERMISSIVE FOR SELECT TO authenticated
+  USING (
+    tenant_id = (auth.jwt() -> 'app_metadata' ->> 'tenant_id')::uuid
+    AND order_id IN (
+      SELECT id FROM customer_orders
+       WHERE store_id = (auth.jwt() -> 'app_metadata' ->> 'store_id')::bigint
+    )
+  );

--- a/supabase/migrations/20260429150000_rpc_merge_member_null_fix.sql
+++ b/supabase/migrations/20260429150000_rpc_merge_member_null_fix.sql
@@ -1,0 +1,89 @@
+-- ============================================================================
+-- Fix: rpc_merge_member 在 guest 沒有 balance 列時 v_points/v_wallet 留 NULL
+-- 違反 member_merges.points_moved/wallet_moved/cards_moved NOT NULL
+-- ============================================================================
+CREATE OR REPLACE FUNCTION rpc_merge_member(
+  p_guest_id BIGINT,
+  p_real_id  BIGINT,
+  p_operator UUID DEFAULT NULL,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant    UUID;
+  v_operator  UUID;
+  v_points    NUMERIC(18,2) := 0;
+  v_wallet    NUMERIC(18,2) := 0;
+  v_cards     INTEGER := 0;
+BEGIN
+  v_operator := COALESCE(p_operator, auth.uid(), '00000000-0000-0000-0000-000000000000'::uuid);
+
+  SELECT tenant_id INTO v_tenant FROM members WHERE id = p_guest_id;
+
+  IF (SELECT member_type FROM members WHERE id = p_guest_id) <> 'guest' THEN
+    RAISE EXCEPTION 'member % is not a guest', p_guest_id;
+  END IF;
+  IF (SELECT status FROM members WHERE id = p_guest_id) = 'merged' THEN
+    RAISE EXCEPTION 'member % is already merged', p_guest_id;
+  END IF;
+  IF p_guest_id = p_real_id THEN
+    RAISE EXCEPTION 'guest_id and real_id must differ';
+  END IF;
+
+  UPDATE customer_orders         SET member_id = p_real_id WHERE member_id = p_guest_id;
+  UPDATE customer_line_aliases   SET member_id = p_real_id WHERE member_id = p_guest_id;
+  UPDATE member_tags             SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  SELECT COUNT(*) INTO v_cards FROM member_cards WHERE member_id = p_guest_id;
+  UPDATE member_cards SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  SELECT COALESCE(balance, 0) INTO v_points
+    FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  v_points := COALESCE(v_points, 0);
+
+  SELECT COALESCE(balance, 0) INTO v_wallet
+    FROM wallet_balances WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  v_wallet := COALESCE(v_wallet, 0);
+
+  UPDATE points_ledger  SET member_id = p_real_id WHERE member_id = p_guest_id;
+  UPDATE wallet_ledger  SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  IF v_points > 0 THEN
+    INSERT INTO member_points_balance (tenant_id, member_id, balance, version, updated_at)
+    VALUES (v_tenant, p_real_id, v_points, 1, NOW())
+    ON CONFLICT (tenant_id, member_id) DO UPDATE
+      SET balance          = member_points_balance.balance + EXCLUDED.balance,
+          version          = member_points_balance.version + 1,
+          last_movement_at = NOW(),
+          updated_at       = NOW();
+  END IF;
+
+  IF v_wallet > 0 THEN
+    INSERT INTO wallet_balances (tenant_id, member_id, balance, version, updated_at)
+    VALUES (v_tenant, p_real_id, v_wallet, 1, NOW())
+    ON CONFLICT (tenant_id, member_id) DO UPDATE
+      SET balance          = wallet_balances.balance + EXCLUDED.balance,
+          version          = wallet_balances.version + 1,
+          last_movement_at = NOW(),
+          updated_at       = NOW();
+  END IF;
+
+  DELETE FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  DELETE FROM wallet_balances        WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+
+  UPDATE members
+     SET status                = 'merged',
+         merged_into_member_id = p_real_id,
+         updated_at            = NOW(),
+         updated_by            = v_operator
+   WHERE id = p_guest_id;
+
+  INSERT INTO member_merges (
+    tenant_id, primary_member_id, merged_member_id,
+    points_moved, wallet_moved, cards_moved, reason, operator_id
+  ) VALUES (
+    v_tenant, p_real_id, p_guest_id,
+    v_points, v_wallet, v_cards, p_reason, v_operator
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary
- **#75 members.member_type + customer_orders.order_type + guest RPCs**
  - `rpc_create_guest_member(tenant_id, channel_id, nickname)` → member_id（自動建 alias）
  - `rpc_merge_member(guest_id, real_id)` → 搬訂單/alias/標籤/卡/點數/儲值金，標 status='merged'
  - guest 用 phone_hash NULL（partial unique 已存在），不需 placeholder
- **#72 order_expiry_events**：append-only 取貨逾期紀錄（PRD §Q10）
- **#73 order_shortage_events**：append-only FIFO 分配不足，含 generated shortage_qty（PRD §Q16）
- 三份 `docs/TEST-*.md` 對應驗證清單

## Issues
Closes #72 #73 #75

## Test plan
- [x] `supabase db push` 三張 migration 都過
- [x] `docs/TEST-member-type-guest.md` 全部 PASS
- [ ] `docs/TEST-order-expiry-events.md` 全部 PASS
- [x] `docs/TEST-order-shortage-events.md` 全部 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)