### PR TITLE
feat(purchase): 進貨/撿貨同一動作 + PR pipeline 升 10-step timeline

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/page.tsx
@@ -301,6 +301,7 @@ export default function PurchaseOrdersListPage() {
                         <Th>預計到貨</Th>
                         <Th>發送</Th>
                         <Th className="text-right">更新</Th>
+                        <Th></Th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
@@ -334,6 +335,16 @@ export default function PurchaseOrdersListPage() {
                           </Td>
                           <Td className="text-right text-xs text-zinc-500">
                             {new Date(p.updated_at).toLocaleString("zh-TW")}
+                          </Td>
+                          <Td className="text-right">
+                            {(p.status === "sent" || p.status === "partially_received") && (
+                              <a
+                                href={`/purchase/orders/receive?po=${p.id}`}
+                                className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-semibold text-white hover:bg-emerald-700"
+                              >
+                                進貨
+                              </a>
+                            )}
                           </Td>
                         </tr>
                       ))}

--- a/apps/admin/src/app/(protected)/purchase/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { PrPipelineStepper } from "@/components/PrPipelineStepper";
 
 type POStatus =
   | "draft"
@@ -28,8 +29,19 @@ type PRGroup = {
   pr_id: number | null; // null = 手動建立 / 找不到來源 PR
   pr_no: string | null;
   pr_status: string | null;
+  pr_review_status: string | null;
   pr_source_close_date: string | null;
   pos: PO[];
+};
+
+type PRProgress = {
+  po_total: number;
+  po_sent: number;
+  po_received_fully: number;
+  transfer_total: number;
+  transfer_shipped: number;
+  transfer_delivered: number;
+  all_campaigns_finalized: boolean;
 };
 
 const STATUS_LABEL: Record<POStatus, string> = {
@@ -54,6 +66,7 @@ export default function PurchaseOrdersListPage() {
   const [error, setError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState("");
   const [openPRs, setOpenPRs] = useState<Set<string>>(new Set()); // 'null' or pr_id 字串
+  const [progressById, setProgressById] = useState<Map<number, PRProgress>>(new Map());
 
   useEffect(() => {
     let cancelled = false;
@@ -130,20 +143,49 @@ export default function PurchaseOrdersListPage() {
         const prIds = Array.from(new Set(Array.from(poToPR.values())));
         const prMap = new Map<
           number,
-          { pr_no: string; status: string; source_close_date: string | null }
+          { pr_no: string; status: string; review_status: string; source_close_date: string | null }
         >();
         if (prIds.length) {
           const { data: prRows } = await supabase
             .from("purchase_requests")
-            .select("id, pr_no, status, source_close_date")
+            .select("id, pr_no, status, review_status, source_close_date")
             .in("id", prIds);
           for (const r of prRows ?? []) {
             prMap.set(r.id, {
               pr_no: r.pr_no,
               status: r.status,
+              review_status: r.review_status,
               source_close_date: r.source_close_date,
             });
           }
+
+          const { data: prog } = await supabase
+            .from("v_pr_progress")
+            .select("pr_id, po_total, po_sent, po_received_fully, transfer_total, transfer_shipped, transfer_delivered, all_campaigns_finalized")
+            .in("pr_id", prIds);
+          const m = new Map<number, PRProgress>();
+          type ProgRow = {
+            pr_id: number;
+            po_total: number;
+            po_sent: number;
+            po_received_fully: number;
+            transfer_total: number;
+            transfer_shipped: number;
+            transfer_delivered: number;
+            all_campaigns_finalized: boolean;
+          };
+          for (const p of (prog as ProgRow[] | null) ?? []) {
+            m.set(p.pr_id, {
+              po_total: Number(p.po_total),
+              po_sent: Number(p.po_sent),
+              po_received_fully: Number(p.po_received_fully),
+              transfer_total: Number(p.transfer_total),
+              transfer_shipped: Number(p.transfer_shipped),
+              transfer_delivered: Number(p.transfer_delivered),
+              all_campaigns_finalized: !!p.all_campaigns_finalized,
+            });
+          }
+          if (!cancelled) setProgressById(m);
         }
 
         // 4. 按 PR 分組
@@ -157,6 +199,7 @@ export default function PurchaseOrdersListPage() {
               pr_id: prId,
               pr_no: prInfo?.pr_no ?? null,
               pr_status: prInfo?.status ?? null,
+              pr_review_status: prInfo?.review_status ?? null,
               pr_source_close_date: prInfo?.source_close_date ?? null,
               pos: [],
             });
@@ -247,9 +290,10 @@ export default function PurchaseOrdersListPage() {
               key={key}
               className="overflow-hidden rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
             >
+              <div className="flex flex-col gap-2 border-b border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900">
               <button
                 onClick={() => togglePR(key)}
-                className="flex w-full items-center justify-between gap-3 border-b border-zinc-200 bg-zinc-50 px-4 py-3 text-left hover:bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+                className="-mx-4 -my-3 flex w-[calc(100%+2rem)] items-center justify-between gap-3 px-4 py-3 text-left hover:bg-zinc-100 dark:hover:bg-zinc-800"
               >
                 <div className="flex items-center gap-3">
                   <span className="text-zinc-400">{open ? "▼" : "▶"}</span>
@@ -288,6 +332,35 @@ export default function PurchaseOrdersListPage() {
                   </a>
                 )}
               </button>
+              {g.pr_id !== null && g.pr_status && (
+                <div className="px-1">
+                  <PrPipelineStepper
+                    status={g.pr_status}
+                    reviewStatus={g.pr_review_status ?? "approved"}
+                    compact
+                    poSummary={(() => {
+                      const p = progressById.get(g.pr_id);
+                      return p
+                        ? { total: p.po_total, sent: p.po_sent, receivedFully: p.po_received_fully }
+                        : { total: g.pos.length, sent: 0, receivedFully: 0 };
+                    })()}
+                    transferSummary={(() => {
+                      const p = progressById.get(g.pr_id);
+                      return p
+                        ? { total: p.transfer_total, shipped: p.transfer_shipped, delivered: p.transfer_delivered }
+                        : undefined;
+                    })()}
+                    campaignFinalized={progressById.get(g.pr_id)?.all_campaigns_finalized}
+                    events={{
+                      create: { href: `/purchase/requests/edit?id=${g.pr_id}` },
+                      draft: { href: `/purchase/requests/edit?id=${g.pr_id}` },
+                      submit: { href: `/purchase/requests/edit?id=${g.pr_id}` },
+                      review: { href: `/purchase/requests/edit?id=${g.pr_id}` },
+                    }}
+                  />
+                </div>
+              )}
+              </div>
 
               {open && (
                 <div className="overflow-x-auto">

--- a/apps/admin/src/app/(protected)/purchase/orders/receive/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/receive/page.tsx
@@ -1,0 +1,548 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { getSupabase } from "@/lib/supabase";
+
+type POItem = {
+  id: number;
+  sku_id: number;
+  qty_ordered: number;
+  qty_received: number;
+  unit_cost: number;
+  sku_code: string | null;
+  sku_name: string | null;
+  product_name: string | null;
+};
+
+type DemandRow = {
+  po_item_id: number;
+  sku_id: number;
+  store_id: number;
+  store_name: string;
+  demand_qty: number;
+};
+
+type AllocationInput = {
+  store_id: number;
+  store_name: string;
+  demand: number;
+  qty: string;
+};
+
+type ArrivalForm = {
+  po_item_id: number;
+  sku_id: number;
+  sku_label: string;
+  qty_ordered: number;
+  qty_already_received: number;
+  qty_received: string;
+  qty_damaged: string;
+  unit_cost: string;
+  batch_no: string;
+  expiry_date: string;
+  variance_reason: string;
+  allocations: AllocationInput[];
+};
+
+export default function ReceivePOPage() {
+  const router = useRouter();
+  const search = useSearchParams();
+  const poId = Number(search.get("po") ?? "0");
+
+  const [poInfo, setPOInfo] = useState<{
+    po_no: string;
+    supplier_name: string | null;
+    status: string;
+    close_date: string | null;
+  } | null>(null);
+  const [forms, setForms] = useState<ArrivalForm[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [invoiceNo, setInvoiceNo] = useState("");
+  const [notes, setNotes] = useState("");
+
+  useEffect(() => {
+    if (!poId) {
+      setError("缺少 po 參數");
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+
+        // 1) PO header + items + sku 資訊
+        const { data: po, error: poErr } = await sb
+          .from("purchase_orders")
+          .select("id, po_no, status, suppliers(name)")
+          .eq("id", poId)
+          .single();
+        if (poErr) throw new Error(poErr.message);
+
+        const { data: items, error: itemsErr } = await sb
+          .from("purchase_order_items")
+          .select("id, sku_id, qty_ordered, qty_received, unit_cost")
+          .eq("po_id", poId)
+          .order("id");
+        if (itemsErr) throw new Error(itemsErr.message);
+
+        type RawItem = {
+          id: number;
+          sku_id: number;
+          qty_ordered: number;
+          qty_received: number;
+          unit_cost: number;
+        };
+        const skuIds = Array.from(new Set(((items as RawItem[]) ?? []).map((r) => r.sku_id)));
+        const skuMap = new Map<number, { code: string | null; name: string | null; product_name: string | null }>();
+        if (skuIds.length) {
+          const { data: skuData, error: skuErr } = await sb
+            .from("skus")
+            .select("id, sku_code, variant_name, product_name")
+            .in("id", skuIds);
+          if (skuErr) throw new Error(skuErr.message);
+          type RawSku = {
+            id: number;
+            sku_code: string | null;
+            variant_name: string | null;
+            product_name: string | null;
+          };
+          for (const r of (skuData as RawSku[] | null) ?? []) {
+            skuMap.set(r.id, { code: r.sku_code, name: r.variant_name, product_name: r.product_name });
+          }
+        }
+        const poiArr: POItem[] = ((items as RawItem[]) ?? []).map((r) => {
+          const sku = skuMap.get(r.sku_id);
+          return {
+            id: r.id,
+            sku_id: r.sku_id,
+            qty_ordered: Number(r.qty_ordered),
+            qty_received: Number(r.qty_received ?? 0),
+            unit_cost: Number(r.unit_cost),
+            sku_code: sku?.code ?? null,
+            sku_name: sku?.name ?? null,
+            product_name: sku?.product_name ?? null,
+          };
+        });
+
+        // 2) 對應分店需求（v_po_demand_by_store）
+        const { data: demand, error: demErr } = await sb
+          .from("v_po_demand_by_store")
+          .select("po_item_id, sku_id, store_id, store_name, demand_qty, close_date")
+          .eq("po_id", poId);
+        if (demErr) throw new Error(demErr.message);
+
+        type RawDemand = {
+          po_item_id: number;
+          sku_id: number;
+          store_id: number;
+          store_name: string;
+          demand_qty: number;
+          close_date: string | null;
+        };
+        const demandArr = ((demand as RawDemand[]) ?? []).map((r) => ({
+          po_item_id: r.po_item_id,
+          sku_id: r.sku_id,
+          store_id: r.store_id,
+          store_name: r.store_name,
+          demand_qty: Number(r.demand_qty),
+        })) as DemandRow[];
+
+        const closeDate =
+          ((demand as RawDemand[]) ?? []).find((r) => r.close_date)?.close_date ?? null;
+
+        // 3) 組裝 form
+        const supplierName = (() => {
+          const s = (po as unknown as { suppliers: { name: string } | { name: string }[] | null })
+            .suppliers;
+          return Array.isArray(s) ? s[0]?.name ?? null : s?.name ?? null;
+        })();
+
+        const formArr: ArrivalForm[] = poiArr.map((it) => {
+          const allocs = demandArr
+            .filter((d) => d.po_item_id === it.id)
+            .map((d) => ({
+              store_id: d.store_id,
+              store_name: d.store_name,
+              demand: d.demand_qty,
+              qty: String(d.demand_qty), // 預設 = 需求量
+            }));
+          return {
+            po_item_id: it.id,
+            sku_id: it.sku_id,
+            sku_label: `${it.sku_code ?? ""} ${it.product_name ?? ""}${it.sku_name ? ` / ${it.sku_name}` : ""}`.trim(),
+            qty_ordered: it.qty_ordered,
+            qty_already_received: it.qty_received,
+            qty_received: String(Math.max(0, it.qty_ordered - it.qty_received)), // 預設 = 還沒到貨的部分
+            qty_damaged: "0",
+            unit_cost: String(it.unit_cost),
+            batch_no: "",
+            expiry_date: "",
+            variance_reason: "",
+            allocations: allocs,
+          };
+        });
+
+        if (!cancelled) {
+          setPOInfo({
+            po_no: (po as { po_no: string }).po_no,
+            supplier_name: supplierName,
+            status: (po as { status: string }).status,
+            close_date: closeDate,
+          });
+          setForms(formArr);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [poId]);
+
+  function updateForm(idx: number, patch: Partial<ArrivalForm>) {
+    setForms((cur) => {
+      if (!cur) return cur;
+      const next = [...cur];
+      next[idx] = { ...next[idx], ...patch };
+      return next;
+    });
+  }
+
+  function updateAllocation(idx: number, allocIdx: number, qty: string) {
+    setForms((cur) => {
+      if (!cur) return cur;
+      const next = [...cur];
+      const allocs = [...next[idx].allocations];
+      allocs[allocIdx] = { ...allocs[allocIdx], qty };
+      next[idx] = { ...next[idx], allocations: allocs };
+      return next;
+    });
+  }
+
+  function autoBalance(idx: number) {
+    setForms((cur) => {
+      if (!cur) return cur;
+      const f = cur[idx];
+      const received = Number(f.qty_received) || 0;
+      const totalDemand = f.allocations.reduce((s, a) => s + a.demand, 0);
+      if (totalDemand === 0) return cur;
+      const next = [...cur];
+      const allocs = f.allocations.map((a, i, arr) => {
+        if (i === arr.length - 1) {
+          // 最後一個吃尾差
+          const allocated = arr.slice(0, i).reduce((s, x) => s + Math.floor((received * x.demand) / totalDemand), 0);
+          return { ...a, qty: String(received - allocated) };
+        }
+        return { ...a, qty: String(Math.floor((received * a.demand) / totalDemand)) };
+      });
+      next[idx] = { ...f, allocations: allocs };
+      return next;
+    });
+  }
+
+  const totals = useMemo(() => {
+    if (!forms) return null;
+    return forms.map((f) => {
+      const allocSum = f.allocations.reduce((s, a) => s + (Number(a.qty) || 0), 0);
+      const received = Number(f.qty_received) || 0;
+      const damaged = Number(f.qty_damaged) || 0;
+      const usable = received - damaged;
+      return {
+        allocSum,
+        received,
+        damaged,
+        usable,
+        diff: usable - allocSum,
+        ok: allocSum === usable && received > 0,
+      };
+    });
+  }, [forms]);
+
+  async function submit() {
+    if (!forms) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const arrivals = forms
+        .filter((f) => Number(f.qty_received) > 0)
+        .map((f) => ({
+          po_item_id: f.po_item_id,
+          sku_id: f.sku_id,
+          qty_received: Number(f.qty_received),
+          qty_damaged: Number(f.qty_damaged) || 0,
+          unit_cost: Number(f.unit_cost),
+          batch_no: f.batch_no || null,
+          expiry_date: f.expiry_date || null,
+          variance_reason: f.variance_reason || null,
+          allocations: f.allocations
+            .filter((a) => Number(a.qty) > 0)
+            .map((a) => ({ store_id: a.store_id, qty: Number(a.qty) })),
+        }));
+
+      if (arrivals.length === 0) {
+        throw new Error("請至少輸入一個品項的到貨數量");
+      }
+
+      const { data: userRes } = await getSupabase().auth.getUser();
+      const operator = userRes?.user?.id;
+      if (!operator) throw new Error("未登入");
+
+      const { data, error: rpcErr } = await getSupabase().rpc("rpc_arrive_and_distribute", {
+        p_po_id: poId,
+        p_arrivals: arrivals,
+        p_operator: operator,
+        p_invoice_no: invoiceNo || null,
+        p_notes: notes || null,
+      });
+      if (rpcErr) throw new Error(rpcErr.message);
+
+      const result = data as { gr_no: string; wave_code: string | null };
+      alert(
+        `進貨完成！\n進貨單：${result.gr_no}` +
+          (result.wave_code ? `\n撿貨波次：${result.wave_code}` : ""),
+      );
+      router.push("/purchase/orders");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!poId) return <div className="p-6 text-red-600">{error ?? "缺少參數"}</div>;
+  if (error && !poInfo) return <div className="p-6 text-red-600">{error}</div>;
+  if (!poInfo || !forms) return <div className="p-6 text-zinc-500">載入中…</div>;
+
+  const canSubmit =
+    forms.some((f) => Number(f.qty_received) > 0) &&
+    totals?.every(
+      (t, i) =>
+        Number(forms[i].qty_received) === 0 ||
+        (t.received > 0 &&
+          t.usable >= 0 &&
+          (forms[i].allocations.length === 0 || t.allocSum <= t.usable)),
+    );
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">進貨／撿貨</h1>
+          <p className="text-sm text-zinc-500">
+            <span className="font-mono">{poInfo.po_no}</span>
+            {" · "}
+            {poInfo.supplier_name ?? "—"}
+            {poInfo.close_date && (
+              <>
+                {" · "}結單日 {poInfo.close_date}
+              </>
+            )}
+            {" · 狀態 "}
+            {poInfo.status}
+          </p>
+        </div>
+        <a
+          href="/purchase/orders"
+          className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          ← 返回 PO 列表
+        </a>
+      </header>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-3 rounded-md border border-zinc-200 bg-zinc-50 p-3 text-sm dark:border-zinc-800 dark:bg-zinc-900">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-zinc-500">供應商發票號</span>
+          <input
+            value={invoiceNo}
+            onChange={(e) => setInvoiceNo(e.target.value)}
+            className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+            placeholder="optional"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-zinc-500">備註</span>
+          <input
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+            placeholder="optional"
+          />
+        </label>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        {forms.map((f, idx) => {
+          const t = totals?.[idx];
+          return (
+            <div
+              key={f.po_item_id}
+              className="rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="font-semibold">{f.sku_label}</div>
+                  <div className="text-xs text-zinc-500">
+                    PO 訂量 {f.qty_ordered} 件
+                    {f.qty_already_received > 0 && (
+                      <> · 累計已收 {f.qty_already_received}</>
+                    )}
+                  </div>
+                </div>
+                {t && (
+                  <div className="text-right text-xs">
+                    <div>到貨可用：<span className="font-mono font-semibold">{t.usable}</span></div>
+                    <div className={t.diff === 0 ? "text-emerald-600" : "text-amber-600"}>
+                      已分配：<span className="font-mono">{t.allocSum}</span>
+                      （差 {t.diff}）
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-3 grid grid-cols-2 gap-2 md:grid-cols-5">
+                <NumField
+                  label="實到數量"
+                  value={f.qty_received}
+                  onChange={(v) => updateForm(idx, { qty_received: v })}
+                />
+                <NumField
+                  label="瑕疵 / 不入庫"
+                  value={f.qty_damaged}
+                  onChange={(v) => updateForm(idx, { qty_damaged: v })}
+                />
+                <NumField
+                  label="單價"
+                  value={f.unit_cost}
+                  onChange={(v) => updateForm(idx, { unit_cost: v })}
+                />
+                <TextField
+                  label="批號"
+                  value={f.batch_no}
+                  onChange={(v) => updateForm(idx, { batch_no: v })}
+                />
+                <TextField
+                  label="效期"
+                  value={f.expiry_date}
+                  onChange={(v) => updateForm(idx, { expiry_date: v })}
+                  placeholder="YYYY-MM-DD"
+                />
+              </div>
+
+              {f.allocations.length > 0 && (
+                <div className="mt-3">
+                  <div className="mb-2 flex items-center justify-between">
+                    <div className="text-xs font-semibold text-zinc-600 dark:text-zinc-400">
+                      分店分配（共 {f.allocations.length} 店、需求合計{" "}
+                      {f.allocations.reduce((s, a) => s + a.demand, 0)}）
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => autoBalance(idx)}
+                      className="rounded-md border border-zinc-300 px-2 py-0.5 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                    >
+                      按需求比例自動分配
+                    </button>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+                    {f.allocations.map((a, ai) => (
+                      <label key={a.store_id} className="flex flex-col gap-1 text-xs">
+                        <span className="text-zinc-500">
+                          {a.store_name}（需 {a.demand}）
+                        </span>
+                        <input
+                          inputMode="decimal"
+                          value={a.qty}
+                          onChange={(e) => updateAllocation(idx, ai, e.target.value)}
+                          className="rounded-md border border-zinc-300 bg-white px-2 py-1 font-mono text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                        />
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {f.allocations.length === 0 && (
+                <div className="mt-3 rounded-md bg-amber-50 p-2 text-xs text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                  該 SKU 沒有對應分店訂單，將只入總倉庫存（不產生撿貨單）。
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => router.push("/purchase/orders")}
+          className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          取消
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!canSubmit || submitting}
+          className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
+        >
+          {submitting ? "處理中…" : "確認進貨／撿貨"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function NumField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs">
+      <span className="text-zinc-500">{label}</span>
+      <input
+        inputMode="decimal"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-md border border-zinc-300 bg-white px-2 py-1 font-mono text-sm dark:border-zinc-700 dark:bg-zinc-800"
+      />
+    </label>
+  );
+}
+
+function TextField({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs">
+      <span className="text-zinc-500">{label}</span>
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+      />
+    </label>
+  );
+}

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -48,6 +48,13 @@ export default function PurchaseRequestsListPage() {
   const [reloadTick, setReloadTick] = useState(0);
   const [busyId, setBusyId] = useState<number | null>(null);
   const [busyDate, setBusyDate] = useState<string | null>(null);
+  const [progressById, setProgressById] = useState<
+    Map<number, {
+      po_total: number; po_sent: number; po_received_fully: number;
+      transfer_total: number; transfer_shipped: number; transfer_delivered: number;
+      all_campaigns_finalized: boolean;
+    }>
+  >(new Map());
 
   // ============== 載入既有 PRs ==============
   useEffect(() => {
@@ -70,7 +77,50 @@ export default function PurchaseRequestsListPage() {
           return;
         }
         setError(null);
-        setRows((data ?? []) as Row[]);
+        const prRows = (data ?? []) as Row[];
+        setRows(prRows);
+
+        const ids = prRows.map((r) => r.id);
+        if (ids.length) {
+          const { data: prog } = await getSupabase()
+            .from("v_pr_progress")
+            .select("pr_id, po_total, po_sent, po_received_fully, transfer_total, transfer_shipped, transfer_delivered, all_campaigns_finalized")
+            .in("pr_id", ids);
+          if (!cancelled) {
+            const m = new Map<
+              number,
+              {
+                po_total: number; po_sent: number; po_received_fully: number;
+                transfer_total: number; transfer_shipped: number; transfer_delivered: number;
+                all_campaigns_finalized: boolean;
+              }
+            >();
+            type ProgRow = {
+              pr_id: number;
+              po_total: number;
+              po_sent: number;
+              po_received_fully: number;
+              transfer_total: number;
+              transfer_shipped: number;
+              transfer_delivered: number;
+              all_campaigns_finalized: boolean;
+            };
+            for (const p of (prog as ProgRow[] | null) ?? []) {
+              m.set(p.pr_id, {
+                po_total: Number(p.po_total),
+                po_sent: Number(p.po_sent),
+                po_received_fully: Number(p.po_received_fully),
+                transfer_total: Number(p.transfer_total),
+                transfer_shipped: Number(p.transfer_shipped),
+                transfer_delivered: Number(p.transfer_delivered),
+                all_campaigns_finalized: !!p.all_campaigns_finalized,
+              });
+            }
+            setProgressById(m);
+          }
+        } else {
+          setProgressById(new Map());
+        }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       }
@@ -392,12 +442,27 @@ export default function PurchaseRequestsListPage() {
                       status={r.status}
                       reviewStatus={r.review_status}
                       compact
+                      poSummary={(() => {
+                        const p = progressById.get(r.id);
+                        return p
+                          ? { total: p.po_total, sent: p.po_sent, receivedFully: p.po_received_fully }
+                          : undefined;
+                      })()}
+                      transferSummary={(() => {
+                        const p = progressById.get(r.id);
+                        return p
+                          ? { total: p.transfer_total, shipped: p.transfer_shipped, delivered: p.transfer_delivered }
+                          : undefined;
+                      })()}
+                      campaignFinalized={progressById.get(r.id)?.all_campaigns_finalized}
                       events={{
                         create: { href: `/purchase/requests/edit?id=${r.id}` },
                         draft: { href: `/purchase/requests/edit?id=${r.id}` },
                         submit: { href: `/purchase/requests/edit?id=${r.id}` },
                         review: { href: `/purchase/requests/edit?id=${r.id}` },
                         split: { href: `/purchase/orders` },
+                        send: { href: `/purchase/orders` },
+                        receive: { href: `/purchase/orders` },
                       }}
                     />
                   </Td>

--- a/apps/admin/src/components/PrPipelineStepper.tsx
+++ b/apps/admin/src/components/PrPipelineStepper.tsx
@@ -17,6 +17,8 @@ export type PrStepEvents = {
   split?: StepEvent;
   send?: StepEvent;
   receive?: StepEvent;
+  ship?: StepEvent;
+  delivered?: StepEvent;
   finalize?: StepEvent;
 };
 
@@ -26,11 +28,18 @@ export type POSummary = {
   receivedFully: number; // status IN fully_received / closed
 };
 
+export type TransferSummary = {
+  total: number; // 該 PR 撿出多少張 transfer (hq_to_store)
+  shipped: number; // transfer.status >= shipped
+  delivered: number; // transfer.status = received
+};
+
 export function PrPipelineStepper({
   status,
   reviewStatus,
   events,
   poSummary,
+  transferSummary,
   campaignFinalized,
   compact = false,
 }: {
@@ -38,6 +47,7 @@ export function PrPipelineStepper({
   reviewStatus: string;
   events?: PrStepEvents;
   poSummary?: POSummary;
+  transferSummary?: TransferSummary;
   campaignFinalized?: boolean;
   compact?: boolean;
 }) {
@@ -86,7 +96,7 @@ export function PrPipelineStepper({
     steps.push({ key: "send", label: "部分發送", state: "current" });
   else steps.push({ key: "send", label: "已發送供應商", state: "done" });
 
-  // S7 收貨
+  // S7 收貨（總倉收供應商貨）
   if (isRejected || isCancelled)
     steps.push({ key: "receive", label: "收貨", state: "skipped" });
   else if (!poSummary || poSummary.total === 0 || poSummary.receivedFully === 0)
@@ -95,7 +105,27 @@ export function PrPipelineStepper({
     steps.push({ key: "receive", label: "部分到貨", state: "current" });
   else steps.push({ key: "receive", label: "全部到貨", state: "done" });
 
-  // S8 結算
+  // S8 正在派貨（撿完出庫到分店、transfer.shipped）
+  if (isRejected || isCancelled)
+    steps.push({ key: "ship", label: "派貨", state: "skipped" });
+  else if (!transferSummary || transferSummary.total === 0 || transferSummary.shipped === 0)
+    steps.push({ key: "ship", label: "派貨", state: "pending" });
+  else if (transferSummary.shipped < transferSummary.total)
+    steps.push({ key: "ship", label: "部分派貨", state: "current" });
+  else if (transferSummary.delivered < transferSummary.total)
+    steps.push({ key: "ship", label: "派貨中", state: "current" });
+  else steps.push({ key: "ship", label: "已派貨", state: "done" });
+
+  // S9 分店收到確認（transfer.received）
+  if (isRejected || isCancelled)
+    steps.push({ key: "delivered", label: "分店確認", state: "skipped" });
+  else if (!transferSummary || transferSummary.total === 0 || transferSummary.delivered === 0)
+    steps.push({ key: "delivered", label: "分店確認", state: "pending" });
+  else if (transferSummary.delivered < transferSummary.total)
+    steps.push({ key: "delivered", label: "部分簽收", state: "current" });
+  else steps.push({ key: "delivered", label: "全部簽收", state: "done" });
+
+  // S10 結算
   if (isCancelled)
     steps.push({ key: "finalize", label: "結算", state: "skipped" });
   else if (campaignFinalized)

--- a/docs/TEST-arrive-and-distribute.md
+++ b/docs/TEST-arrive-and-distribute.md
@@ -1,0 +1,60 @@
+# TEST — 進貨/撿貨同一動作 (rpc_arrive_and_distribute + UI)
+
+## 目標
+驗證從 PO 列表「進貨」按鈕進入進貨/撿貨頁，一次完成 GR + picking_wave + 入庫。
+
+## 前置
+- migration `20260430120000_arrive_and_distribute.sql` apply
+- 一張 status='sent' 的 PO，且其來源 PR 是 `source_type='close_date'`（這樣才能反查到分店訂單）
+- 該結單日有 customer_orders（status not cancelled/expired）
+
+---
+
+## T1 — RPC 結構
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T1-1 | `SELECT proname FROM pg_proc WHERE proname='rpc_arrive_and_distribute';` | 1 列 |
+| T1-2 | `SELECT * FROM v_po_demand_by_store WHERE po_id=<id> LIMIT 1;` | 該 PO 對應分店需求列出 |
+
+## T2 — RPC happy path
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T2-1 | `SELECT rpc_arrive_and_distribute(<po_id>, '[{"po_item_id":...,"sku_id":...,"qty_received":<full>,"unit_cost":...,"allocations":[{"store_id":...,"qty":...}]}]'::jsonb, <op>);` | 回 `{gr_id, gr_no, wave_id, wave_code, close_date}` |
+| T2-2 | 查 goods_receipts 該列 status | `confirmed` |
+| T2-3 | 查 picking_waves 該列 status | `picked` |
+| T2-4 | 查 picking_wave_items 該 wave 的 (sku, store) qty | 與 allocations 一致 |
+| T2-5 | 查 stock_movements `source_doc_id=<gr_id>` | 1 列、`movement_type=purchase_receipt`、qty 與 received 一致 |
+| T2-6 | 查 purchase_orders 該列 status | `fully_received`（若 PO 收完）或 `partially_received` |
+
+## T3 — RPC guards
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T3-1 | PO status='draft'/'fully_received' 時呼叫 | RAISE `must be sent/partially_received` |
+| T3-2 | allocations 合計 > qty_received | RAISE `allocation total ... exceeds received` |
+| T3-3 | 呼叫不存在 PO id | RAISE `PO ... not found` |
+| T3-4 | 沒 allocations 的 SKU | 仍入總倉、wave_items 無該 sku × store 列、不報錯 |
+
+## T4 — UI 進貨頁
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T4-1 | 在 PO 列表，sent/partially_received 的 PO 列右側 | 顯示綠色「進貨」按鈕 |
+| T4-2 | draft / fully_received / cancelled 的 PO 列 | 不顯示「進貨」按鈕 |
+| T4-3 | 點「進貨」進入 `/purchase/orders/receive?po=<id>` | 載入 PO header + 各 SKU + 分店需求 |
+| T4-4 | 預設「實到 = 訂量 - 已收量」、各分店分配 = 各分店需求 | 對 |
+| T4-5 | 修改實到數，點「按需求比例自動分配」 | 各分店分配按比例重算 |
+| T4-6 | 已分配 vs 到貨可用差為 0 → 綠字、不為 0 → 黃字 | 對 |
+| T4-7 | 按「確認進貨／撿貨」 | alert 顯示 GR 號 + 撿貨號，回 PO 列表 |
+| T4-8 | PO 列表中該 PO status 變 `partially_received` 或 `fully_received` | 對 |
+
+## T5 — 多次到貨
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T5-1 | 第一次進貨輸入 < PO 總量 | PO 變 `partially_received`，產生 GR1 + Wave1 |
+| T5-2 | 第二次進貨 PO 列表「進貨」按鈕仍可見 | 對 |
+| T5-3 | 第二次進貨頁預設實到 = 剩餘量 (po.qty_ordered - poi.qty_received) | 對 |
+| T5-4 | 完成第二次後 PO 變 `fully_received`，產生 GR2 + Wave2 | 對 |

--- a/supabase/migrations/20260430120000_arrive_and_distribute.sql
+++ b/supabase/migrations/20260430120000_arrive_and_distribute.sql
@@ -1,0 +1,255 @@
+-- ============================================================================
+-- 進貨/撿貨同一動作 wrapper RPC
+-- 一次完成：GR header+items → rpc_confirm_gr → picking_wave + items
+-- 不含 transfer（留給 PR-B 簽收環節）
+--
+-- 業務脈絡：
+--   團購店供應商到貨時，總倉「對 PO 點數量 + 同時按各分店訂單分包」是同一個動作。
+--   底層仍寫 goods_receipts + picking_waves 兩張單，UI 透過此 RPC 一次完成。
+-- ============================================================================
+
+CREATE SEQUENCE IF NOT EXISTS gr_no_seq;
+CREATE SEQUENCE IF NOT EXISTS wave_code_seq;
+
+CREATE OR REPLACE FUNCTION public.rpc_next_gr_no()
+RETURNS TEXT LANGUAGE plpgsql AS $$
+BEGIN
+  RETURN 'GR' || to_char(NOW(), 'YYMMDD') || lpad(nextval('gr_no_seq')::text, 4, '0');
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.rpc_next_wave_code()
+RETURNS TEXT LANGUAGE plpgsql AS $$
+BEGIN
+  RETURN 'WV' || to_char(NOW(), 'YYMMDD') || lpad(nextval('wave_code_seq')::text, 4, '0');
+END;
+$$;
+
+-- ============================================================================
+-- rpc_arrive_and_distribute
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.rpc_arrive_and_distribute(
+  p_po_id      BIGINT,
+  p_arrivals   JSONB,    -- [{po_item_id, sku_id, qty_received, qty_damaged?, unit_cost?, batch_no?, expiry_date?, variance_reason?, allocations: [{store_id, qty}]}]
+  p_operator   UUID,
+  p_invoice_no TEXT DEFAULT NULL,
+  p_notes      TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_po              RECORD;
+  v_close_dates     DATE[];
+  v_close_date      DATE;
+  v_gr_id           BIGINT;
+  v_gr_no           TEXT;
+  v_wave_id         BIGINT := NULL;
+  v_wave_code       TEXT := NULL;
+  v_arrival         JSONB;
+  v_alloc           JSONB;
+  v_po_item_id      BIGINT;
+  v_sku_id          BIGINT;
+  v_qty_received    NUMERIC(18,3);
+  v_qty_damaged     NUMERIC(18,3);
+  v_unit_cost       NUMERIC(18,4);
+  v_alloc_total     NUMERIC(18,3);
+  v_default_cost    NUMERIC(18,4);
+  v_item_count      INTEGER;
+  v_store_count     INTEGER;
+  v_total_qty       NUMERIC(18,3);
+BEGIN
+  -- 1. PO 守衛
+  SELECT id, tenant_id, supplier_id, dest_location_id, status
+    INTO v_po
+    FROM purchase_orders
+   WHERE id = p_po_id
+     FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PO % not found', p_po_id;
+  END IF;
+  IF v_po.status NOT IN ('sent','partially_received') THEN
+    RAISE EXCEPTION 'PO % must be sent/partially_received (current: %)', p_po_id, v_po.status;
+  END IF;
+
+  -- 2. 反查 close_date（理論一個 PO 對應一個結單日；多個則 RAISE）
+  SELECT array_agg(DISTINCT pr.source_close_date)
+    INTO v_close_dates
+    FROM purchase_order_items poi
+    JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+    JOIN purchase_requests pr ON pr.id = pri.pr_id
+   WHERE poi.po_id = p_po_id
+     AND pr.source_close_date IS NOT NULL;
+
+  IF v_close_dates IS NOT NULL AND array_length(v_close_dates, 1) > 1 THEN
+    RAISE EXCEPTION 'PO % spans multiple close_dates: %', p_po_id, v_close_dates;
+  END IF;
+
+  v_close_date := COALESCE(v_close_dates[1], NULL);
+
+  -- 3. 建 GR header（draft → 等下用 rpc_confirm_gr 推進）
+  v_gr_no := public.rpc_next_gr_no();
+
+  INSERT INTO goods_receipts (
+    tenant_id, gr_no, po_id, supplier_id, dest_location_id,
+    status, supplier_invoice_no, received_by, notes,
+    created_by, updated_by
+  ) VALUES (
+    v_po.tenant_id, v_gr_no, v_po.id, v_po.supplier_id, v_po.dest_location_id,
+    'draft', p_invoice_no, p_operator, p_notes,
+    p_operator, p_operator
+  ) RETURNING id INTO v_gr_id;
+
+  -- 4. 寫 GR items
+  FOR v_arrival IN SELECT * FROM jsonb_array_elements(p_arrivals) LOOP
+    v_po_item_id   := (v_arrival->>'po_item_id')::BIGINT;
+    v_sku_id       := (v_arrival->>'sku_id')::BIGINT;
+    v_qty_received := (v_arrival->>'qty_received')::NUMERIC;
+    v_qty_damaged  := COALESCE((v_arrival->>'qty_damaged')::NUMERIC, 0);
+    v_unit_cost    := (v_arrival->>'unit_cost')::NUMERIC;
+
+    IF v_qty_received IS NULL OR v_qty_received <= 0 THEN
+      RAISE EXCEPTION 'arrival sku_id % has invalid qty_received', v_sku_id;
+    END IF;
+
+    -- unit_cost fallback：取 PO item 的 unit_cost
+    IF v_unit_cost IS NULL THEN
+      SELECT unit_cost INTO v_default_cost FROM purchase_order_items WHERE id = v_po_item_id;
+      v_unit_cost := COALESCE(v_default_cost, 0);
+    END IF;
+
+    INSERT INTO goods_receipt_items (
+      gr_id, po_item_id, sku_id,
+      qty_expected, qty_received, qty_damaged, unit_cost,
+      batch_no, expiry_date, variance_reason,
+      created_by, updated_by
+    ) VALUES (
+      v_gr_id, v_po_item_id, v_sku_id,
+      (SELECT qty_ordered FROM purchase_order_items WHERE id = v_po_item_id),
+      v_qty_received, v_qty_damaged, v_unit_cost,
+      v_arrival->>'batch_no',
+      NULLIF(v_arrival->>'expiry_date','')::DATE,
+      v_arrival->>'variance_reason',
+      p_operator, p_operator
+    );
+  END LOOP;
+
+  -- 5. confirm GR → 入總倉（rpc_inbound 在內部）
+  PERFORM rpc_confirm_gr(v_gr_id, p_operator);
+
+  -- 6. 撿貨段：若該 PO 有對應 close_date → 建 picking_wave
+  IF v_close_date IS NOT NULL THEN
+    v_wave_code := public.rpc_next_wave_code();
+
+    INSERT INTO picking_waves (
+      tenant_id, wave_code, wave_date, status, note,
+      created_by, updated_by
+    ) VALUES (
+      v_po.tenant_id, v_wave_code, v_close_date, 'picking',
+      'auto from PO ' || p_po_id::text || ' / GR ' || v_gr_no,
+      p_operator, p_operator
+    ) RETURNING id INTO v_wave_id;
+
+    -- 寫 picking_wave_items
+    FOR v_arrival IN SELECT * FROM jsonb_array_elements(p_arrivals) LOOP
+      v_sku_id    := (v_arrival->>'sku_id')::BIGINT;
+      v_qty_received := (v_arrival->>'qty_received')::NUMERIC;
+      v_alloc_total := 0;
+
+      IF v_arrival ? 'allocations' AND jsonb_array_length(v_arrival->'allocations') > 0 THEN
+        FOR v_alloc IN SELECT * FROM jsonb_array_elements(v_arrival->'allocations') LOOP
+          IF (v_alloc->>'qty')::NUMERIC > 0 THEN
+            INSERT INTO picking_wave_items (
+              tenant_id, wave_id, sku_id, store_id, qty, picked_qty,
+              created_by, updated_by
+            ) VALUES (
+              v_po.tenant_id, v_wave_id, v_sku_id,
+              (v_alloc->>'store_id')::BIGINT,
+              (v_alloc->>'qty')::NUMERIC,
+              (v_alloc->>'qty')::NUMERIC,
+              p_operator, p_operator
+            )
+            ON CONFLICT (wave_id, sku_id, store_id) DO UPDATE
+              SET qty = picking_wave_items.qty + EXCLUDED.qty,
+                  picked_qty = COALESCE(picking_wave_items.picked_qty, 0) + EXCLUDED.picked_qty,
+                  updated_by = p_operator;
+            v_alloc_total := v_alloc_total + (v_alloc->>'qty')::NUMERIC;
+          END IF;
+        END LOOP;
+
+        -- 守衛：分配總和 ≤ 到貨量
+        IF v_alloc_total > v_qty_received THEN
+          RAISE EXCEPTION 'sku % allocation total % exceeds received %', v_sku_id, v_alloc_total, v_qty_received;
+        END IF;
+      END IF;
+    END LOOP;
+
+    -- 更新 wave totals
+    SELECT COUNT(*), COUNT(DISTINCT store_id), COALESCE(SUM(qty),0)
+      INTO v_item_count, v_store_count, v_total_qty
+      FROM picking_wave_items WHERE wave_id = v_wave_id;
+
+    UPDATE picking_waves
+       SET item_count  = v_item_count,
+           store_count = v_store_count,
+           total_qty   = v_total_qty,
+           status      = 'picked',
+           updated_at  = NOW()
+     WHERE id = v_wave_id;
+
+    INSERT INTO picking_wave_audit_log (tenant_id, wave_id, action, after_value, created_by)
+    VALUES (v_po.tenant_id, v_wave_id, 'wave_created',
+            jsonb_build_object('wave_code', v_wave_code, 'po_id', p_po_id, 'gr_id', v_gr_id,
+                               'item_count', v_item_count, 'store_count', v_store_count),
+            p_operator);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'gr_id', v_gr_id,
+    'gr_no', v_gr_no,
+    'wave_id', v_wave_id,
+    'wave_code', v_wave_code,
+    'close_date', v_close_date
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_arrive_and_distribute TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_arrive_and_distribute IS
+  '進貨+撿貨同一動作：對 PO 點數→入總倉→按各分店訂單分配寫 picking_wave';
+
+-- ============================================================================
+-- 反查視圖：給 UI 預先載入「該 PO 對應的各分店訂單需求」
+-- 用法：SELECT * FROM v_po_demand_by_store WHERE po_id = ?
+-- ============================================================================
+CREATE OR REPLACE VIEW v_po_demand_by_store AS
+SELECT
+  po.id              AS po_id,
+  po.tenant_id,
+  poi.id             AS po_item_id,
+  poi.sku_id,
+  pr.source_close_date AS close_date,
+  co.pickup_store_id AS store_id,
+  s.code             AS store_code,
+  s.name             AS store_name,
+  SUM(coi.qty)       AS demand_qty
+FROM purchase_orders po
+JOIN purchase_order_items poi ON poi.po_id = po.id
+JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+JOIN purchase_requests pr ON pr.id = pri.pr_id AND pr.source_close_date IS NOT NULL
+JOIN group_buy_campaigns gbc
+  ON gbc.tenant_id = po.tenant_id
+ AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = pr.source_close_date
+ AND gbc.status IN ('closed','ordered','receiving','ready','completed')
+JOIN customer_orders co ON co.campaign_id = gbc.id AND co.status NOT IN ('cancelled','expired')
+JOIN customer_order_items coi ON coi.order_id = co.id
+                              AND coi.sku_id = poi.sku_id
+                              AND coi.status NOT IN ('cancelled','expired')
+JOIN stores s ON s.id = co.pickup_store_id
+GROUP BY po.id, po.tenant_id, poi.id, poi.sku_id, pr.source_close_date,
+         co.pickup_store_id, s.code, s.name;
+
+GRANT SELECT ON v_po_demand_by_store TO authenticated;
+
+COMMENT ON VIEW v_po_demand_by_store IS
+  '從 PO 反查同 close_date 各分店對該 PO SKU 的訂單需求量（撿貨分配參考）';

--- a/supabase/migrations/20260430130000_v_pr_progress.sql
+++ b/supabase/migrations/20260430130000_v_pr_progress.sql
@@ -1,0 +1,44 @@
+-- ============================================================================
+-- v_pr_progress：給 PR 列表 / PO 列表 PR header 用的進度摘要
+-- 一次查就有：每張 PR 的 PO 總數 / 已發送 / 已全收，以及對應 close_date 的 campaign 是否全部 finalized
+-- ============================================================================
+
+CREATE OR REPLACE VIEW public.v_pr_progress AS
+SELECT
+  pr.id   AS pr_id,
+  pr.tenant_id,
+  pr.source_close_date,
+  COALESCE(po_agg.po_total, 0)          AS po_total,
+  COALESCE(po_agg.po_sent, 0)           AS po_sent,
+  COALESCE(po_agg.po_received_fully, 0) AS po_received_fully,
+  CASE
+    WHEN pr.source_close_date IS NULL THEN FALSE
+    WHEN cmp.total_campaigns = 0 THEN FALSE
+    ELSE cmp.completed_campaigns = cmp.total_campaigns
+  END AS all_campaigns_finalized
+FROM purchase_requests pr
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(DISTINCT po.id)                                                         AS po_total,
+    COUNT(DISTINCT po.id) FILTER (WHERE po.status IN ('sent','partially_received','fully_received','closed')) AS po_sent,
+    COUNT(DISTINCT po.id) FILTER (WHERE po.status IN ('fully_received','closed')) AS po_received_fully
+    FROM purchase_request_items pri
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+    JOIN purchase_orders po       ON po.id  = poi.po_id
+   WHERE pri.pr_id = pr.id
+) po_agg ON TRUE
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(*)                                                AS total_campaigns,
+    COUNT(*) FILTER (WHERE gbc.status = 'completed')        AS completed_campaigns
+    FROM group_buy_campaigns gbc
+   WHERE gbc.tenant_id = pr.tenant_id
+     AND pr.source_close_date IS NOT NULL
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = pr.source_close_date
+     AND gbc.status NOT IN ('cancelled')
+) cmp ON TRUE;
+
+GRANT SELECT ON public.v_pr_progress TO authenticated;
+
+COMMENT ON VIEW public.v_pr_progress IS
+  'PR 進度摘要：PO 收貨進度 + close_date 對應 campaigns 是否全部 finalized（給 stepper 用）';

--- a/supabase/migrations/20260430140000_arrive_with_transfer.sql
+++ b/supabase/migrations/20260430140000_arrive_with_transfer.sql
@@ -1,0 +1,303 @@
+-- ============================================================================
+-- 升級 rpc_arrive_and_distribute：撿完同時建 transfer(shipped) + 出總倉庫存
+-- 業務：撿完 = 派貨中 (transfer.status='shipped')，等分店簽收 → received
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_arrive_and_distribute(
+  p_po_id      BIGINT,
+  p_arrivals   JSONB,
+  p_operator   UUID,
+  p_invoice_no TEXT DEFAULT NULL,
+  p_notes      TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_po              RECORD;
+  v_close_dates     DATE[];
+  v_close_date      DATE;
+  v_gr_id           BIGINT;
+  v_gr_no           TEXT;
+  v_wave_id         BIGINT := NULL;
+  v_wave_code       TEXT := NULL;
+  v_arrival         JSONB;
+  v_alloc           JSONB;
+  v_po_item_id      BIGINT;
+  v_sku_id          BIGINT;
+  v_qty_received    NUMERIC(18,3);
+  v_qty_damaged     NUMERIC(18,3);
+  v_unit_cost       NUMERIC(18,4);
+  v_alloc_total     NUMERIC(18,3);
+  v_default_cost    NUMERIC(18,4);
+  v_item_count      INTEGER;
+  v_store_count     INTEGER;
+  v_total_qty       NUMERIC(18,3);
+  v_store_rec       RECORD;
+  v_dest_loc        BIGINT;
+  v_xfer_id         BIGINT;
+  v_xfer_no         TEXT;
+  v_xfer_ids        BIGINT[] := ARRAY[]::BIGINT[];
+  v_pwi             RECORD;
+  v_out_mov_id      BIGINT;
+BEGIN
+  -- 1. PO 守衛
+  SELECT id, tenant_id, supplier_id, dest_location_id, status
+    INTO v_po
+    FROM purchase_orders
+   WHERE id = p_po_id
+     FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PO % not found', p_po_id;
+  END IF;
+  IF v_po.status NOT IN ('sent','partially_received') THEN
+    RAISE EXCEPTION 'PO % must be sent/partially_received (current: %)', p_po_id, v_po.status;
+  END IF;
+
+  -- 2. 反查 close_date
+  SELECT array_agg(DISTINCT pr.source_close_date)
+    INTO v_close_dates
+    FROM purchase_order_items poi
+    JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+    JOIN purchase_requests pr ON pr.id = pri.pr_id
+   WHERE poi.po_id = p_po_id
+     AND pr.source_close_date IS NOT NULL;
+
+  IF v_close_dates IS NOT NULL AND array_length(v_close_dates, 1) > 1 THEN
+    RAISE EXCEPTION 'PO % spans multiple close_dates: %', p_po_id, v_close_dates;
+  END IF;
+
+  v_close_date := COALESCE(v_close_dates[1], NULL);
+
+  -- 3. GR header
+  v_gr_no := public.rpc_next_gr_no();
+  INSERT INTO goods_receipts (
+    tenant_id, gr_no, po_id, supplier_id, dest_location_id,
+    status, supplier_invoice_no, received_by, notes, created_by, updated_by
+  ) VALUES (
+    v_po.tenant_id, v_gr_no, v_po.id, v_po.supplier_id, v_po.dest_location_id,
+    'draft', p_invoice_no, p_operator, p_notes, p_operator, p_operator
+  ) RETURNING id INTO v_gr_id;
+
+  -- 4. GR items
+  FOR v_arrival IN SELECT * FROM jsonb_array_elements(p_arrivals) LOOP
+    v_po_item_id   := (v_arrival->>'po_item_id')::BIGINT;
+    v_sku_id       := (v_arrival->>'sku_id')::BIGINT;
+    v_qty_received := (v_arrival->>'qty_received')::NUMERIC;
+    v_qty_damaged  := COALESCE((v_arrival->>'qty_damaged')::NUMERIC, 0);
+    v_unit_cost    := (v_arrival->>'unit_cost')::NUMERIC;
+
+    IF v_qty_received IS NULL OR v_qty_received <= 0 THEN
+      RAISE EXCEPTION 'arrival sku_id % has invalid qty_received', v_sku_id;
+    END IF;
+
+    IF v_unit_cost IS NULL THEN
+      SELECT unit_cost INTO v_default_cost FROM purchase_order_items WHERE id = v_po_item_id;
+      v_unit_cost := COALESCE(v_default_cost, 0);
+    END IF;
+
+    INSERT INTO goods_receipt_items (
+      gr_id, po_item_id, sku_id,
+      qty_expected, qty_received, qty_damaged, unit_cost,
+      batch_no, expiry_date, variance_reason, created_by, updated_by
+    ) VALUES (
+      v_gr_id, v_po_item_id, v_sku_id,
+      (SELECT qty_ordered FROM purchase_order_items WHERE id = v_po_item_id),
+      v_qty_received, v_qty_damaged, v_unit_cost,
+      v_arrival->>'batch_no',
+      NULLIF(v_arrival->>'expiry_date','')::DATE,
+      v_arrival->>'variance_reason',
+      p_operator, p_operator
+    );
+  END LOOP;
+
+  -- 5. confirm GR (rpc_inbound 入總倉)
+  PERFORM rpc_confirm_gr(v_gr_id, p_operator);
+
+  -- 6. picking_wave + items（若有 close_date 對應分店訂單）
+  IF v_close_date IS NOT NULL THEN
+    v_wave_code := public.rpc_next_wave_code();
+
+    INSERT INTO picking_waves (
+      tenant_id, wave_code, wave_date, status, note, created_by, updated_by
+    ) VALUES (
+      v_po.tenant_id, v_wave_code, v_close_date, 'picking',
+      'auto from PO ' || p_po_id::text || ' / GR ' || v_gr_no,
+      p_operator, p_operator
+    ) RETURNING id INTO v_wave_id;
+
+    FOR v_arrival IN SELECT * FROM jsonb_array_elements(p_arrivals) LOOP
+      v_sku_id    := (v_arrival->>'sku_id')::BIGINT;
+      v_qty_received := (v_arrival->>'qty_received')::NUMERIC;
+      v_alloc_total := 0;
+
+      IF v_arrival ? 'allocations' AND jsonb_array_length(v_arrival->'allocations') > 0 THEN
+        FOR v_alloc IN SELECT * FROM jsonb_array_elements(v_arrival->'allocations') LOOP
+          IF (v_alloc->>'qty')::NUMERIC > 0 THEN
+            INSERT INTO picking_wave_items (
+              tenant_id, wave_id, sku_id, store_id, qty, picked_qty,
+              created_by, updated_by
+            ) VALUES (
+              v_po.tenant_id, v_wave_id, v_sku_id,
+              (v_alloc->>'store_id')::BIGINT,
+              (v_alloc->>'qty')::NUMERIC,
+              (v_alloc->>'qty')::NUMERIC,
+              p_operator, p_operator
+            )
+            ON CONFLICT (wave_id, sku_id, store_id) DO UPDATE
+              SET qty = picking_wave_items.qty + EXCLUDED.qty,
+                  picked_qty = COALESCE(picking_wave_items.picked_qty, 0) + EXCLUDED.picked_qty,
+                  updated_by = p_operator;
+            v_alloc_total := v_alloc_total + (v_alloc->>'qty')::NUMERIC;
+          END IF;
+        END LOOP;
+
+        IF v_alloc_total > v_qty_received THEN
+          RAISE EXCEPTION 'sku % allocation total % exceeds received %', v_sku_id, v_alloc_total, v_qty_received;
+        END IF;
+      END IF;
+    END LOOP;
+
+    SELECT COUNT(*), COUNT(DISTINCT store_id), COALESCE(SUM(qty),0)
+      INTO v_item_count, v_store_count, v_total_qty
+      FROM picking_wave_items WHERE wave_id = v_wave_id;
+
+    UPDATE picking_waves
+       SET item_count = v_item_count, store_count = v_store_count, total_qty = v_total_qty,
+           status = 'picked', updated_at = NOW()
+     WHERE id = v_wave_id;
+
+    INSERT INTO picking_wave_audit_log (tenant_id, wave_id, action, after_value, created_by)
+    VALUES (v_po.tenant_id, v_wave_id, 'wave_created',
+            jsonb_build_object('wave_code', v_wave_code, 'po_id', p_po_id, 'gr_id', v_gr_id,
+                               'item_count', v_item_count, 'store_count', v_store_count),
+            p_operator);
+
+    -- 7. 撿完即派貨：對每分店建 transfer(shipped) + 從總倉 outbound
+    FOR v_store_rec IN
+      SELECT DISTINCT pwi.store_id, s.location_id
+        FROM picking_wave_items pwi
+        JOIN stores s ON s.id = pwi.store_id
+       WHERE pwi.wave_id = v_wave_id AND pwi.picked_qty > 0
+    LOOP
+      v_dest_loc := v_store_rec.location_id;
+      IF v_dest_loc IS NULL THEN
+        RAISE EXCEPTION 'store % has no location_id', v_store_rec.store_id;
+      END IF;
+
+      v_xfer_no := 'TR' || to_char(NOW(), 'YYMMDD') || '-W' || v_wave_id || '-S' || v_store_rec.store_id;
+
+      INSERT INTO transfers (
+        tenant_id, transfer_no, source_location, dest_location,
+        status, transfer_type, requested_by, shipped_by, shipped_at,
+        created_by, updated_by
+      ) VALUES (
+        v_po.tenant_id, v_xfer_no, v_po.dest_location_id, v_dest_loc,
+        'shipped', 'hq_to_store', p_operator, p_operator, NOW(),
+        p_operator, p_operator
+      ) RETURNING id INTO v_xfer_id;
+
+      -- 寫 transfer_items + 從總倉 outbound
+      FOR v_pwi IN
+        SELECT id, sku_id, picked_qty
+          FROM picking_wave_items
+         WHERE wave_id = v_wave_id
+           AND store_id = v_store_rec.store_id
+           AND picked_qty > 0
+      LOOP
+        v_out_mov_id := rpc_outbound(
+          p_tenant_id       => v_po.tenant_id,
+          p_location_id     => v_po.dest_location_id,
+          p_sku_id          => v_pwi.sku_id,
+          p_quantity        => v_pwi.picked_qty,
+          p_movement_type   => 'transfer_out',
+          p_source_doc_type => 'transfer',
+          p_source_doc_id   => v_xfer_id,
+          p_operator        => p_operator,
+          p_allow_negative  => FALSE
+        );
+
+        INSERT INTO transfer_items (
+          transfer_id, sku_id, qty_requested, qty_shipped, out_movement_id,
+          created_by, updated_by
+        ) VALUES (
+          v_xfer_id, v_pwi.sku_id, v_pwi.picked_qty, v_pwi.picked_qty, v_out_mov_id,
+          p_operator, p_operator
+        );
+
+        UPDATE picking_wave_items
+           SET generated_transfer_id = v_xfer_id, updated_by = p_operator
+         WHERE id = v_pwi.id;
+      END LOOP;
+
+      v_xfer_ids := v_xfer_ids || v_xfer_id;
+    END LOOP;
+
+    UPDATE picking_waves SET status = 'shipped', updated_by = p_operator WHERE id = v_wave_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'gr_id', v_gr_id,
+    'gr_no', v_gr_no,
+    'wave_id', v_wave_id,
+    'wave_code', v_wave_code,
+    'transfer_ids', to_jsonb(v_xfer_ids),
+    'close_date', v_close_date
+  );
+END;
+$$;
+
+-- ============================================================================
+-- v_pr_progress 升級：加 transfer 統計
+-- ============================================================================
+DROP VIEW IF EXISTS public.v_pr_progress;
+CREATE VIEW public.v_pr_progress AS
+SELECT
+  pr.id   AS pr_id,
+  pr.tenant_id,
+  pr.source_close_date,
+  COALESCE(po_agg.po_total, 0)          AS po_total,
+  COALESCE(po_agg.po_sent, 0)           AS po_sent,
+  COALESCE(po_agg.po_received_fully, 0) AS po_received_fully,
+  COALESCE(xfer_agg.xfer_total, 0)      AS transfer_total,
+  COALESCE(xfer_agg.xfer_shipped, 0)    AS transfer_shipped,
+  COALESCE(xfer_agg.xfer_delivered, 0)  AS transfer_delivered,
+  CASE
+    WHEN pr.source_close_date IS NULL THEN FALSE
+    WHEN cmp.total_campaigns = 0 THEN FALSE
+    ELSE cmp.completed_campaigns = cmp.total_campaigns
+  END AS all_campaigns_finalized
+FROM purchase_requests pr
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(DISTINCT po.id)                                                         AS po_total,
+    COUNT(DISTINCT po.id) FILTER (WHERE po.status IN ('sent','partially_received','fully_received','closed')) AS po_sent,
+    COUNT(DISTINCT po.id) FILTER (WHERE po.status IN ('fully_received','closed')) AS po_received_fully
+    FROM purchase_request_items pri
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+    JOIN purchase_orders po       ON po.id  = poi.po_id
+   WHERE pri.pr_id = pr.id
+) po_agg ON TRUE
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(DISTINCT t.id)                                                AS xfer_total,
+    COUNT(DISTINCT t.id) FILTER (WHERE t.status IN ('shipped','received','closed')) AS xfer_shipped,
+    COUNT(DISTINCT t.id) FILTER (WHERE t.status IN ('received','closed')) AS xfer_delivered
+    FROM picking_waves pw
+    JOIN picking_wave_items pwi ON pwi.wave_id = pw.id
+    JOIN transfers t            ON t.id = pwi.generated_transfer_id
+   WHERE pw.tenant_id = pr.tenant_id
+     AND pr.source_close_date IS NOT NULL
+     AND pw.wave_date = pr.source_close_date
+) xfer_agg ON TRUE
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(*)                                                AS total_campaigns,
+    COUNT(*) FILTER (WHERE gbc.status = 'completed')        AS completed_campaigns
+    FROM group_buy_campaigns gbc
+   WHERE gbc.tenant_id = pr.tenant_id
+     AND pr.source_close_date IS NOT NULL
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = pr.source_close_date
+     AND gbc.status NOT IN ('cancelled')
+) cmp ON TRUE;
+
+GRANT SELECT ON public.v_pr_progress TO authenticated;


### PR DESCRIPTION
## Summary
**業務鏈整合：採購 PR/PO → 訂單 → 進貨/撿貨 → 派貨 → 分店簽收 → 顧客取貨**

PR-A 範圍：
- **進貨/撿貨同一動作**：團購店供應商到貨即按各分店訂單分包，UI 一頁完成、底層 GR + picking_wave + transfer 三張單一次寫入
- **PR pipeline timeline 升 10-step**：加「派貨」(transfer.shipped) +「分店確認」(transfer.received)
- **PO 列表 PR 群組 header** 也呈現同一個 timeline（之前只在 PR 列表頁有）

## 新增

### Migrations
- `20260430120000_arrive_and_distribute.sql` — `rpc_arrive_and_distribute` 第一版（GR + picking_wave）+ `v_po_demand_by_store` view
- `20260430130000_v_pr_progress.sql` — 給 timeline 用的進度摘要 view
- `20260430140000_arrive_with_transfer.sql` — RPC 升級：撿完同時建 transfer(shipped) + 從總倉 outbound（撿完=派貨中）；view 加 transfer 統計欄

### UI
- `/purchase/orders/receive?po=<id>` — 進貨/撿貨頁：對 PO 點數 + 自動填各分店分配（可手調）+ 提交一次完成
- `/purchase/orders` PO 列表：sent/部分到貨列加綠色「進貨」按鈕；PR 群組 header 加 10-step timeline
- `/purchase/requests` PR 列表 timeline 從 8-step 升 10-step、且現在會推進到 step 6/7/8/9/10

### Component
- `PrPipelineStepper` 加 `transferSummary` prop、新增兩個 step、events map 加 `ship`/`delivered` keys

## 業務邏輯
| 階段 | 動作 | 庫存變化 | Step |
|---|---|---|---|
| 採購 PO | 對供應商下訂 | — | 5 建立採購訂單 |
| 發送 | rpc_send_purchase_order | — | 6 已發送供應商 |
| 進貨/撿貨 | rpc_arrive_and_distribute | 總倉 +N → -N（出到 transfer in-transit） | 7 全部到貨 + 8 派貨中 |
| 分店簽收 | (PR-B 待補) rpc_confirm_transfer_receipt | 在途 → 分店庫存 | 9 分店確認 |
| 顧客取貨 | (PR-C 待補) rpc_pickup_order | 分店 -N | — |
| 結算 | rpc_finalize_campaign | — | 10 結算 |

## DB 驗證
- PO5 / PO6 各跑了完整 GR + picking_wave 流程（PR-A 第一版）
- View 結構驗證：3 筆 PR 的 progress 都正確反映 PO 進度
- 升級版 RPC 待新 PO 進貨時自然驗證 transfer 推進（需先設好分店 location）

## TEST 文件
- `docs/TEST-arrive-and-distribute.md` 全段對應驗證清單

## 後續 PR
- **PR-B** 分店簽收：`rpc_confirm_transfer_receipt` + `/deliveries` UI（推進 step 9）
- **PR-C** 顧客取貨：`rpc_pickup_order` + 取貨作業 UI（端到端最後一段）

🤖 Generated with [Claude Code](https://claude.com/claude-code)