### PR TITLE
feat(picking): 累積式撿貨單 — 多結單日商品合併

### DIFF
--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -30,6 +30,8 @@ const NAV: NavGroup[] = [
       { href: "/suppliers", label: "供應商", match: /^\/suppliers/ },
       { href: "/purchase/requests", label: "採購單", match: /^\/purchase\/requests/ },
       { href: "/purchase/orders", label: "採購訂單", match: /^\/purchase\/orders/ },
+      { href: "/picking/workstation", label: "撿貨工作站", match: /^\/picking\/workstation/ },
+      { href: "/picking/history", label: "撿貨歷史", match: /^\/picking\/history/ },
     ],
   },
 ];

--- a/apps/admin/src/app/(protected)/picking/history/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/history/page.tsx
@@ -1,0 +1,488 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+
+type Wave = {
+  id: number;
+  wave_code: string;
+  wave_date: string;
+  status: string;
+  store_count: number;
+  item_count: number;
+  total_qty: number;
+  note: string | null;
+  created_at: string;
+};
+
+type WaveItem = {
+  id: number;
+  sku_id: number;
+  store_id: number;
+  qty: number;
+  picked_qty: number | null;
+  generated_transfer_id: number | null;
+};
+
+type Store = { id: number; name: string };
+type Sku = { id: number; sku_code: string | null; product_name: string | null; variant_name: string | null };
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: "草稿",
+  picking: "撿貨中",
+  picked: "撿貨完成",
+  shipped: "已派貨",
+  cancelled: "已取消",
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  draft: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+  picking: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  picked: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  shipped: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+  cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+};
+
+export default function PickingHistoryPage() {
+  const [waves, setWaves] = useState<Wave[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<Wave | null>(null);
+  const [reloadTick, setReloadTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data, error: e } = await sb
+          .from("picking_waves")
+          .select("id, wave_code, wave_date, status, store_count, item_count, total_qty, note, created_at")
+          .order("created_at", { ascending: false })
+          .limit(50);
+        if (e) throw new Error(e.message);
+        if (!cancelled) {
+          setWaves(((data as Wave[] | null) ?? []).map((r) => ({ ...r, total_qty: Number(r.total_qty) })));
+          setError(null);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadTick]);
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">撿貨歷史</h1>
+          <p className="text-sm text-zinc-500">
+            {waves === null ? "載入中…" : `共 ${waves.length} 張撿貨單`}
+          </p>
+        </div>
+        <a
+          href="/picking/workstation"
+          className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          + 至撿貨工作站
+        </a>
+      </header>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+        <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+          <thead className="bg-zinc-50 dark:bg-zinc-900">
+            <tr>
+              <Th>撿貨單號</Th>
+              <Th>配送日</Th>
+              <Th>狀態</Th>
+              <Th className="text-right">分店</Th>
+              <Th className="text-right">SKU</Th>
+              <Th className="text-right">總量</Th>
+              <Th>備註</Th>
+              <Th>建立</Th>
+              <Th></Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+            {waves !== null && waves.length === 0 && (
+              <tr>
+                <td colSpan={9} className="p-6 text-center text-sm text-zinc-500">
+                  尚無撿貨單，請至「撿貨工作站」建立。
+                </td>
+              </tr>
+            )}
+            {waves?.map((w) => (
+              <tr key={w.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
+                <td className="px-3 py-2 font-mono">{w.wave_code}</td>
+                <td className="px-3 py-2">{w.wave_date}</td>
+                <td className="px-3 py-2">
+                  <span
+                    className={`inline-block rounded px-2 py-0.5 text-xs ${STATUS_COLOR[w.status] ?? ""}`}
+                  >
+                    {STATUS_LABEL[w.status] ?? w.status}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-right font-mono">{w.store_count}</td>
+                <td className="px-3 py-2 text-right font-mono">{w.item_count}</td>
+                <td className="px-3 py-2 text-right font-mono">{w.total_qty}</td>
+                <td className="px-3 py-2 text-xs text-zinc-500">{w.note ?? "—"}</td>
+                <td className="px-3 py-2 text-xs text-zinc-500">
+                  {new Date(w.created_at).toLocaleString("zh-TW")}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {(w.status === "draft" || w.status === "picking" || w.status === "picked") && (
+                    <button
+                      onClick={() => setEditing(w)}
+                      className="rounded-md bg-amber-500 px-3 py-1 text-xs font-semibold text-white hover:bg-amber-600"
+                    >
+                      修正數量
+                    </button>
+                  )}
+                  {w.status === "shipped" && (
+                    <span className="text-xs text-emerald-600 dark:text-emerald-400">✓ 已派貨</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {editing && (
+        <PickModal
+          wave={editing}
+          onClose={() => setEditing(null)}
+          onSubmitted={() => {
+            setEditing(null);
+            setReloadTick((t) => t + 1);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function PickModal({
+  wave,
+  onClose,
+  onSubmitted,
+}: {
+  wave: Wave;
+  onClose: () => void;
+  onSubmitted: () => void;
+}) {
+  const [items, setItems] = useState<WaveItem[] | null>(null);
+  const [stores, setStores] = useState<Store[]>([]);
+  const [skus, setSkus] = useState<Sku[]>([]);
+  const [edits, setEdits] = useState<Map<number, string>>(new Map()); // wave_item_id -> new picked_qty string
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [shipping, setShipping] = useState(false);
+  const [hqLocId, setHqLocId] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data: itemsData, error: e1 } = await sb
+          .from("picking_wave_items")
+          .select("id, sku_id, store_id, qty, picked_qty, generated_transfer_id")
+          .eq("wave_id", wave.id);
+        if (e1) throw new Error(e1.message);
+        if (cancelled) return;
+        const arr = ((itemsData as WaveItem[] | null) ?? []).map((r) => ({
+          ...r,
+          qty: Number(r.qty),
+          picked_qty: r.picked_qty === null ? null : Number(r.picked_qty),
+        }));
+        setItems(arr);
+
+        const skuIds = Array.from(new Set(arr.map((r) => r.sku_id)));
+        const storeIds = Array.from(new Set(arr.map((r) => r.store_id)));
+
+        if (skuIds.length) {
+          const { data: skuData } = await sb
+            .from("skus")
+            .select("id, sku_code, product_name, variant_name")
+            .in("id", skuIds);
+          if (!cancelled) setSkus((skuData as Sku[] | null) ?? []);
+        }
+        if (storeIds.length) {
+          const { data: storeData } = await sb
+            .from("stores")
+            .select("id, name")
+            .in("id", storeIds)
+            .order("id");
+          if (!cancelled) setStores((storeData as Store[] | null) ?? []);
+        }
+
+        // 找一個 central_warehouse location 當 HQ
+        const { data: loc } = await sb
+          .from("locations")
+          .select("id")
+          .eq("type", "central_warehouse")
+          .eq("is_active", true)
+          .limit(1);
+        if (!cancelled) setHqLocId(((loc as { id: number }[] | null) ?? [])[0]?.id ?? null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [wave.id]);
+
+  const matrix: Map<number, Map<number, WaveItem>> = useMemo(() => {
+    const m = new Map<number, Map<number, WaveItem>>();
+    for (const it of items ?? []) {
+      if (!m.has(it.sku_id)) m.set(it.sku_id, new Map());
+      m.get(it.sku_id)!.set(it.store_id, it);
+    }
+    return m;
+  }, [items]);
+
+  const skuList = useMemo(
+    () => skus.sort((a, b) => (a.sku_code ?? "").localeCompare(b.sku_code ?? "")),
+    [skus],
+  );
+
+  function setEdit(itemId: number, val: string) {
+    setEdits((cur) => {
+      const next = new Map(cur);
+      next.set(itemId, val);
+      return next;
+    });
+  }
+
+  async function saveEdits() {
+    if (edits.size === 0) {
+      onSubmitted();
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes?.user?.id;
+      if (!operator) throw new Error("未登入");
+
+      for (const [itemId, val] of edits) {
+        const newQty = Number(val);
+        if (Number.isNaN(newQty) || newQty < 0) continue;
+        const { error: e } = await sb.rpc("rpc_update_picked_qty", {
+          p_wave_item_id: itemId,
+          p_new_qty: newQty,
+          p_operator: operator,
+          p_note: "manual fix in /picking/history",
+        });
+        if (e) throw new Error(`item ${itemId}: ${e.message}`);
+      }
+      onSubmitted();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function ship() {
+    if (!hqLocId) {
+      setError("找不到總倉 location");
+      return;
+    }
+    if (wave.status !== "picked") {
+      setError(`撿貨單狀態為 ${wave.status}，需是 picked 才能派貨。請先確認修正完成。`);
+      return;
+    }
+    if (!confirm(`確認派貨？將為 ${wave.store_count} 間分店產生 transfer 並從總倉出庫。`)) return;
+    setShipping(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes?.user?.id;
+      if (!operator) throw new Error("未登入");
+
+      const { error: e } = await sb.rpc("generate_transfer_from_wave", {
+        p_wave_id: wave.id,
+        p_hq_location_id: hqLocId,
+        p_operator: operator,
+      });
+      if (e) throw new Error(e.message);
+      alert(`派貨完成！${wave.store_count} 張 transfer 已建立`);
+      onSubmitted();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setShipping(false);
+    }
+  }
+
+  async function confirmAsPicked() {
+    if (wave.status === "picked") return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { error: e } = await sb
+        .from("picking_waves")
+        .update({ status: "picked", updated_at: new Date().toISOString() })
+        .eq("id", wave.id);
+      if (e) throw new Error(e.message);
+      onSubmitted();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="flex max-h-[90vh] w-full max-w-[90vw] flex-col overflow-hidden rounded-md bg-white shadow-xl dark:bg-zinc-900">
+        <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+          <div>
+            <h2 className="font-semibold">
+              修正數量：<span className="font-mono">{wave.wave_code}</span>{" "}
+              <span className="text-xs text-zinc-500">
+                · 配送日 {wave.wave_date} · 狀態 {STATUS_LABEL[wave.status] ?? wave.status}
+              </span>
+            </h2>
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={saveEdits}
+              disabled={submitting}
+              className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? "儲存中…" : `儲存修正 (${edits.size})`}
+            </button>
+            {wave.status !== "picked" && wave.status !== "shipped" && (
+              <button
+                onClick={confirmAsPicked}
+                disabled={submitting}
+                className="rounded-md bg-blue-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-600 disabled:opacity-50"
+              >
+                ✅ 確認修正完成
+              </button>
+            )}
+            {wave.status === "picked" && (
+              <button
+                onClick={ship}
+                disabled={shipping}
+                className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+              >
+                {shipping ? "派貨中…" : "🚚 派貨出倉"}
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              關閉
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="border-b border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        <div className="overflow-auto p-3">
+          {items === null ? (
+            <div className="p-6 text-center text-sm text-zinc-500">載入中…</div>
+          ) : (
+            <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+              <thead className="sticky top-0 bg-zinc-50 dark:bg-zinc-900">
+                <tr>
+                  <th className="sticky left-0 z-10 bg-zinc-50 px-3 py-2 text-left text-xs uppercase text-zinc-500 dark:bg-zinc-900">
+                    品名
+                  </th>
+                  {stores.map((s) => (
+                    <th
+                      key={s.id}
+                      className="px-2 py-2 text-right text-xs uppercase text-zinc-500"
+                    >
+                      {s.name}
+                    </th>
+                  ))}
+                  <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">合計</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                {skuList.map((sku) => {
+                  const row = matrix.get(sku.id);
+                  const total = stores.reduce((s, st) => {
+                    const it = row?.get(st.id);
+                    if (!it) return s;
+                    const edit = edits.get(it.id);
+                    const v = edit !== undefined ? Number(edit) : (it.picked_qty ?? it.qty);
+                    return s + (Number.isNaN(v) ? 0 : v);
+                  }, 0);
+                  return (
+                    <tr key={sku.id}>
+                      <td className="sticky left-0 bg-white px-3 py-2 dark:bg-zinc-900">
+                        <div className="font-medium">{sku.product_name ?? "—"}</div>
+                        <div className="text-xs text-zinc-500">
+                          {sku.sku_code}{sku.variant_name ? ` / ${sku.variant_name}` : ""}
+                        </div>
+                      </td>
+                      {stores.map((st) => {
+                        const it = row?.get(st.id);
+                        if (!it) return <td key={st.id} className="px-2 py-2 text-right text-zinc-300">·</td>;
+                        const edit = edits.get(it.id);
+                        const cur = edit !== undefined ? edit : String(it.picked_qty ?? it.qty);
+                        const isEdited = edit !== undefined;
+                        const isShippedItem = it.generated_transfer_id !== null;
+                        return (
+                          <td key={st.id} className="px-1 py-1 text-right">
+                            <div className="flex flex-col">
+                              <input
+                                inputMode="decimal"
+                                disabled={isShippedItem || wave.status === "shipped"}
+                                value={cur}
+                                onChange={(e) => setEdit(it.id, e.target.value)}
+                                className={`w-14 rounded-md border px-1 py-0.5 text-right font-mono text-sm ${isEdited ? "border-amber-400 bg-amber-50 dark:bg-amber-950" : "border-zinc-300 bg-white dark:border-zinc-700 dark:bg-zinc-800"} disabled:bg-zinc-100 disabled:opacity-60 dark:disabled:bg-zinc-800`}
+                              />
+                              <div className="text-[10px] text-zinc-400">
+                                應 {it.qty}
+                              </div>
+                            </div>
+                          </td>
+                        );
+                      })}
+                      <td className="px-3 py-2 text-right font-mono font-semibold">{total}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Th({ children, className = "" }: { children?: React.ReactNode; className?: string }) {
+  return (
+    <th
+      className={`px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 ${className}`}
+    >
+      {children}
+    </th>
+  );
+}

--- a/apps/admin/src/app/(protected)/picking/workstation/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/workstation/page.tsx
@@ -1,0 +1,473 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { getSupabase } from "@/lib/supabase";
+
+type DemandRow = {
+  close_date: string;
+  sku_id: number;
+  sku_label: string;
+  sku_code: string | null;
+  store_id: number;
+  store_name: string;
+  demand_qty: number;
+  campaign_ids: number[];
+};
+
+type SkuCard = {
+  sku_id: number;
+  sku_code: string | null;
+  sku_label: string;
+  total_demand: number;
+  by_store: Map<number, number>;
+  short_stores: { id: number; name: string; qty: number }[]; // 欠品店家
+};
+
+export default function PickingWorkstationPage() {
+  const router = useRouter();
+  const [closeDate, setCloseDate] = useState("");
+  const [waveDate, setWaveDate] = useState("");
+  const [allCloseDates, setAllCloseDates] = useState<string[]>([]);
+  const [demand, setDemand] = useState<DemandRow[] | null>(null);
+  const [stores, setStores] = useState<{ id: number; name: string; code: string | null }[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [selectedSkuIds, setSelectedSkuIds] = useState<Set<number>>(new Set());
+  const [searchTerm, setSearchTerm] = useState("");
+  const [showOnlyNonZero, setShowOnlyNonZero] = useState(false);
+
+  // 載入可用結單日
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data } = await sb
+          .from("v_picking_demand_by_close_date")
+          .select("close_date")
+          .order("close_date", { ascending: false });
+        if (cancelled) return;
+        const set = new Set<string>();
+        for (const r of (data as { close_date: string }[] | null) ?? []) {
+          if (r.close_date) {
+            const d = new Date(r.close_date).toLocaleDateString("sv-SE");
+            set.add(d);
+          }
+        }
+        const list = Array.from(set).sort().reverse();
+        setAllCloseDates(list);
+        if (!closeDate && list.length > 0) {
+          setCloseDate(list[0]);
+          const d = new Date(list[0]);
+          d.setDate(d.getDate() + 2);
+          setWaveDate(d.toLocaleDateString("sv-SE"));
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 載入需求
+  useEffect(() => {
+    if (!closeDate) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data, error: e } = await sb
+          .from("v_picking_demand_by_close_date")
+          .select("close_date, sku_id, sku_label, sku_code, store_id, store_name, demand_qty, campaign_ids")
+          .eq("close_date", closeDate);
+        if (e) throw new Error(e.message);
+        if (cancelled) return;
+        const rows = ((data as DemandRow[] | null) ?? []).map((r) => ({
+          ...r,
+          demand_qty: Number(r.demand_qty),
+        }));
+        setDemand(rows);
+        setSelectedSkuIds(new Set()); // 換結單日 reset
+
+        const storeIds = Array.from(new Set(rows.map((r) => r.store_id)));
+        if (storeIds.length) {
+          const { data: ss } = await sb
+            .from("stores")
+            .select("id, code, name")
+            .in("id", storeIds)
+            .order("id");
+          if (!cancelled)
+            setStores((ss as { id: number; code: string | null; name: string }[] | null) ?? []);
+        } else {
+          setStores([]);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [closeDate]);
+
+  const allSkuCards: SkuCard[] = useMemo(() => {
+    if (!demand) return [];
+    const m = new Map<number, SkuCard>();
+    for (const r of demand) {
+      if (!m.has(r.sku_id)) {
+        m.set(r.sku_id, {
+          sku_id: r.sku_id,
+          sku_code: r.sku_code,
+          sku_label: r.sku_label,
+          total_demand: 0,
+          by_store: new Map(),
+          short_stores: [],
+        });
+      }
+      const e = m.get(r.sku_id)!;
+      e.total_demand += r.demand_qty;
+      e.by_store.set(r.store_id, (e.by_store.get(r.store_id) ?? 0) + r.demand_qty);
+    }
+    // 欠品店家 = 有需求量的分店
+    for (const card of m.values()) {
+      const arr: { id: number; name: string; qty: number }[] = [];
+      for (const [sid, q] of card.by_store) {
+        if (q > 0) {
+          const st = stores.find((s) => s.id === sid);
+          arr.push({ id: sid, name: st?.name ?? `#${sid}`, qty: q });
+        }
+      }
+      card.short_stores = arr.sort((a, b) => b.qty - a.qty);
+    }
+    return Array.from(m.values()).sort((a, b) =>
+      (a.sku_code ?? "").localeCompare(b.sku_code ?? ""),
+    );
+  }, [demand, stores]);
+
+  const filteredCards = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    if (!term) return allSkuCards;
+    return allSkuCards.filter(
+      (c) =>
+        (c.sku_code ?? "").toLowerCase().includes(term) ||
+        c.sku_label.toLowerCase().includes(term),
+    );
+  }, [allSkuCards, searchTerm]);
+
+  const selectedCards = useMemo(
+    () => allSkuCards.filter((c) => selectedSkuIds.has(c.sku_id)),
+    [allSkuCards, selectedSkuIds],
+  );
+
+  // 右側矩陣：篩有量欄位
+  const visibleStores = useMemo(() => {
+    if (!showOnlyNonZero) return stores;
+    const has = new Set<number>();
+    for (const c of selectedCards) for (const [sid, q] of c.by_store) if (q > 0) has.add(sid);
+    return stores.filter((s) => has.has(s.id));
+  }, [stores, selectedCards, showOnlyNonZero]);
+
+  const allCampaignIds = useMemo(() => {
+    if (!demand) return [];
+    const set = new Set<number>();
+    for (const r of demand) {
+      if (selectedSkuIds.has(r.sku_id)) {
+        for (const id of r.campaign_ids ?? []) set.add(id);
+      }
+    }
+    return Array.from(set);
+  }, [demand, selectedSkuIds]);
+
+  function toggleSku(skuId: number) {
+    setSelectedSkuIds((cur) => {
+      const next = new Set(cur);
+      if (next.has(skuId)) next.delete(skuId);
+      else next.add(skuId);
+      return next;
+    });
+  }
+
+  function selectAll() {
+    setSelectedSkuIds(new Set(allSkuCards.map((c) => c.sku_id)));
+  }
+
+  function clearAll() {
+    setSelectedSkuIds(new Set());
+  }
+
+  async function createWave() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (selectedCards.length === 0) throw new Error("請先從左側加入商品到大表");
+      if (allCampaignIds.length === 0) throw new Error("選中的商品沒有對應 campaign");
+      if (!waveDate) throw new Error("請選配送日");
+
+      const { data: userRes } = await getSupabase().auth.getUser();
+      const operator = userRes?.user?.id;
+      if (!operator) throw new Error("未登入");
+
+      const { data: camp } = await getSupabase()
+        .from("group_buy_campaigns")
+        .select("tenant_id")
+        .eq("id", allCampaignIds[0])
+        .single();
+      const tenantId = (camp as { tenant_id: string } | null)?.tenant_id;
+      if (!tenantId) throw new Error("無法取得 tenant_id");
+
+      const code = "WV" + new Date().toISOString().replace(/[-:T.]/g, "").slice(2, 14);
+
+      const { error: rpcErr } = await getSupabase().rpc("rpc_create_picking_wave", {
+        p_tenant_id: tenantId,
+        p_campaign_ids: allCampaignIds,
+        p_wave_date: waveDate,
+        p_wave_code: code,
+        p_operator: operator,
+      });
+      if (rpcErr) throw new Error(rpcErr.message);
+
+      alert(
+        `撿貨單建立完成：${code}\n含 ${selectedCards.length} 個 SKU、${visibleStores.length} 間分店`,
+      );
+      router.push(`/picking/history`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-3 p-4">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">批次撿貨工作站</h1>
+          <p className="text-sm text-zinc-500">
+            選結單日 → 從左側商品卡加入到右側大表 → 建立撿貨單
+          </p>
+        </div>
+        <a
+          href="/picking/history"
+          className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          撿貨歷史 →
+        </a>
+      </header>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-12 gap-3" style={{ minHeight: "70vh" }}>
+        {/* 左側：1. 搜尋商品並加入大表 */}
+        <section className="col-span-4 flex flex-col gap-2 rounded-md border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold">1. 搜尋商品並加入大表</h2>
+            <div className="flex gap-1 text-xs">
+              <button
+                onClick={selectAll}
+                className="rounded-md border border-zinc-300 px-2 py-0.5 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              >
+                全選
+              </button>
+              <button
+                onClick={clearAll}
+                className="rounded-md border border-zinc-300 px-2 py-0.5 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              >
+                清空
+              </button>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] text-zinc-500">結單日</span>
+              <select
+                value={closeDate}
+                onChange={(e) => setCloseDate(e.target.value)}
+                className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+              >
+                <option value="">— 選 —</option>
+                {allCloseDates.map((d) => (
+                  <option key={d} value={d}>
+                    {d}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] text-zinc-500">配送日</span>
+              <input
+                type="date"
+                value={waveDate}
+                onChange={(e) => setWaveDate(e.target.value)}
+                className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+              />
+            </label>
+          </div>
+
+          <input
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            placeholder="商編或品項"
+            className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          />
+
+          <div className="flex-1 overflow-y-auto">
+            {filteredCards.length === 0 ? (
+              <div className="p-6 text-center text-xs text-zinc-500">
+                {closeDate ? "無對應商品" : "請先選結單日"}
+              </div>
+            ) : (
+              <ul className="space-y-2">
+                {filteredCards.map((c) => {
+                  const selected = selectedSkuIds.has(c.sku_id);
+                  return (
+                    <li
+                      key={c.sku_id}
+                      className={`rounded-md border p-2 text-xs ${
+                        selected
+                          ? "border-blue-300 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30"
+                          : "border-zinc-200 dark:border-zinc-800"
+                      }`}
+                    >
+                      <div className="mb-1 flex items-start justify-between gap-2">
+                        <div>
+                          <div className="font-mono text-zinc-500">{c.sku_code ?? "—"}</div>
+                          <div className="font-semibold">{c.sku_label}</div>
+                        </div>
+                        <button
+                          onClick={() => toggleSku(c.sku_id)}
+                          className={`shrink-0 rounded-md px-2 py-1 text-xs font-semibold ${
+                            selected
+                              ? "bg-zinc-200 text-zinc-700 hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-200"
+                              : "bg-blue-600 text-white hover:bg-blue-700"
+                          }`}
+                        >
+                          {selected ? "✓ 已加入" : "+ 加入"}
+                        </button>
+                      </div>
+                      <div className="text-[11px] text-zinc-600 dark:text-zinc-400">
+                        叫貨：<span className="font-mono">{c.total_demand}</span>
+                        {" · "}店家：{c.short_stores.length}
+                      </div>
+                      {c.short_stores.length > 0 && (
+                        <div className="mt-1 text-[11px] text-rose-600 dark:text-rose-400">
+                          {c.short_stores
+                            .slice(0, 8)
+                            .map((s) => `${s.name} ${s.qty}`)
+                            .join("、")}
+                          {c.short_stores.length > 8 && "…"}
+                        </div>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </section>
+
+        {/* 右側：2. 分發作業大表 */}
+        <section className="col-span-8 flex flex-col gap-2 rounded-md border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="text-sm font-semibold">
+              2. 分發作業大表（{selectedCards.length} 個 SKU、
+              {visibleStores.length}/{stores.length} 間分店）
+            </h2>
+            <div className="flex flex-wrap items-center gap-2">
+              <label className="flex items-center gap-1 text-xs">
+                <input
+                  type="checkbox"
+                  checked={showOnlyNonZero}
+                  onChange={(e) => setShowOnlyNonZero(e.target.checked)}
+                />
+                只顯示有量欄位
+              </label>
+              <button
+                onClick={createWave}
+                disabled={submitting || selectedCards.length === 0 || !waveDate}
+                className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
+              >
+                {submitting ? "建立中…" : "🧾 建立撿貨單"}
+              </button>
+            </div>
+          </div>
+
+          <div className="flex-1 overflow-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+            <table className="min-w-full text-sm">
+              <thead className="sticky top-0 bg-zinc-50 dark:bg-zinc-900">
+                <tr>
+                  <th className="sticky left-0 z-10 bg-zinc-50 px-3 py-2 text-left text-xs uppercase text-zinc-500 dark:bg-zinc-900">
+                    商品名稱
+                  </th>
+                  {visibleStores.map((s) => (
+                    <th
+                      key={s.id}
+                      className="px-2 py-2 text-right text-xs uppercase text-zinc-500"
+                    >
+                      {s.name}
+                    </th>
+                  ))}
+                  <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">合計</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                {selectedCards.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={visibleStores.length + 2}
+                      className="p-6 text-center text-sm text-zinc-500"
+                    >
+                      尚未加入商品。從左側點「+ 加入」把要撿的商品加進來。
+                    </td>
+                  </tr>
+                ) : (
+                  selectedCards.map((c) => (
+                    <tr key={c.sku_id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
+                      <td className="sticky left-0 bg-white px-3 py-2 dark:bg-zinc-900">
+                        <div className="flex items-start gap-2">
+                          <button
+                            onClick={() => toggleSku(c.sku_id)}
+                            title="從大表移除"
+                            className="text-rose-500 hover:text-rose-600"
+                          >
+                            ✕
+                          </button>
+                          <div>
+                            <div className="font-medium">{c.sku_label}</div>
+                            <div className="font-mono text-xs text-zinc-500">{c.sku_code}</div>
+                          </div>
+                        </div>
+                      </td>
+                      {visibleStores.map((s) => {
+                        const q = c.by_store.get(s.id) ?? 0;
+                        return (
+                          <td
+                            key={s.id}
+                            className={`px-3 py-2 text-right font-mono ${q === 0 ? "text-zinc-300" : ""}`}
+                          >
+                            {q || "0"}
+                          </td>
+                        );
+                      })}
+                      <td className="px-3 py-2 text-right font-mono font-semibold">
+                        {c.total_demand}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(protected)/picking/workstation/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/workstation/page.tsx
@@ -22,6 +22,13 @@ type SkuCard = {
   total_demand: number;
   by_store: Map<number, number>;
   short_stores: { id: number; name: string; qty: number }[]; // 欠品店家
+  close_date: string; // 結單日
+};
+
+type SelectedItem = {
+  key: string; // "${close_date}|${sku_id}"
+  close_date: string;
+  sku_id: number;
 };
 
 export default function PickingWorkstationPage() {
@@ -33,7 +40,8 @@ export default function PickingWorkstationPage() {
   const [stores, setStores] = useState<{ id: number; name: string; code: string | null }[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [selectedSkuIds, setSelectedSkuIds] = useState<Set<number>>(new Set());
+  const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set()); // "${close_date}|${sku_id}"
+  const [demandHistory, setDemandHistory] = useState<Map<string, DemandRow[]>>(new Map()); // closeDate -> rows
   const [searchTerm, setSearchTerm] = useState("");
   const [showOnlyNonZero, setShowOnlyNonZero] = useState(false);
 
@@ -91,7 +99,8 @@ export default function PickingWorkstationPage() {
           demand_qty: Number(r.demand_qty),
         }));
         setDemand(rows);
-        setSelectedSkuIds(new Set()); // 換結單日 reset
+        // 保存到歷史記錄
+        setDemandHistory((prev) => new Map(prev).set(closeDate, rows));
 
         const storeIds = Array.from(new Set(rows.map((r) => r.store_id)));
         if (storeIds.length) {
@@ -115,7 +124,7 @@ export default function PickingWorkstationPage() {
   }, [closeDate]);
 
   const allSkuCards: SkuCard[] = useMemo(() => {
-    if (!demand) return [];
+    if (!demand || !closeDate) return [];
     const m = new Map<number, SkuCard>();
     for (const r of demand) {
       if (!m.has(r.sku_id)) {
@@ -126,6 +135,7 @@ export default function PickingWorkstationPage() {
           total_demand: 0,
           by_store: new Map(),
           short_stores: [],
+          close_date: closeDate,
         });
       }
       const e = m.get(r.sku_id)!;
@@ -146,7 +156,7 @@ export default function PickingWorkstationPage() {
     return Array.from(m.values()).sort((a, b) =>
       (a.sku_code ?? "").localeCompare(b.sku_code ?? ""),
     );
-  }, [demand, stores]);
+  }, [demand, stores, closeDate]);
 
   const filteredCards = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();
@@ -158,10 +168,49 @@ export default function PickingWorkstationPage() {
     );
   }, [allSkuCards, searchTerm]);
 
-  const selectedCards = useMemo(
-    () => allSkuCards.filter((c) => selectedSkuIds.has(c.sku_id)),
-    [allSkuCards, selectedSkuIds],
-  );
+  const selectedCards = useMemo(() => {
+    const m = new Map<number, SkuCard>();
+    // 遍歷所有 selectedItems，聚合它們的數據
+    for (const item of selectedItems) {
+      const [cd, skuIdStr] = item.split("|");
+      const skuId = Number(skuIdStr);
+      const rows = demandHistory.get(cd) ?? [];
+      const itemRows = rows.filter((r) => r.sku_id === skuId);
+      if (itemRows.length === 0) continue;
+
+      if (!m.has(skuId)) {
+        const first = itemRows[0];
+        m.set(skuId, {
+          sku_id: skuId,
+          sku_code: first.sku_code,
+          sku_label: first.sku_label,
+          total_demand: 0,
+          by_store: new Map(),
+          short_stores: [],
+          close_date: cd,
+        });
+      }
+      const card = m.get(skuId)!;
+      for (const r of itemRows) {
+        card.total_demand += r.demand_qty;
+        card.by_store.set(r.store_id, (card.by_store.get(r.store_id) ?? 0) + r.demand_qty);
+      }
+    }
+    // 重新計算欠品店家
+    for (const card of m.values()) {
+      const arr: { id: number; name: string; qty: number }[] = [];
+      for (const [sid, q] of card.by_store) {
+        if (q > 0) {
+          const st = stores.find((s) => s.id === sid);
+          arr.push({ id: sid, name: st?.name ?? `#${sid}`, qty: q });
+        }
+      }
+      card.short_stores = arr.sort((a, b) => b.qty - a.qty);
+    }
+    return Array.from(m.values()).sort((a, b) =>
+      (a.sku_code ?? "").localeCompare(b.sku_code ?? ""),
+    );
+  }, [selectedItems, demandHistory, stores]);
 
   // 右側矩陣：篩有量欄位
   const visibleStores = useMemo(() => {
@@ -172,31 +221,44 @@ export default function PickingWorkstationPage() {
   }, [stores, selectedCards, showOnlyNonZero]);
 
   const allCampaignIds = useMemo(() => {
-    if (!demand) return [];
     const set = new Set<number>();
-    for (const r of demand) {
-      if (selectedSkuIds.has(r.sku_id)) {
-        for (const id of r.campaign_ids ?? []) set.add(id);
+    for (const item of selectedItems) {
+      const [cd, skuIdStr] = item.split("|");
+      const skuId = Number(skuIdStr);
+      const rows = demandHistory.get(cd) ?? [];
+      for (const r of rows) {
+        if (r.sku_id === skuId) {
+          for (const id of r.campaign_ids ?? []) set.add(id);
+        }
       }
     }
     return Array.from(set);
-  }, [demand, selectedSkuIds]);
+  }, [selectedItems, demandHistory]);
 
   function toggleSku(skuId: number) {
-    setSelectedSkuIds((cur) => {
+    if (!closeDate) return;
+    const key = `${closeDate}|${skuId}`;
+    setSelectedItems((cur) => {
       const next = new Set(cur);
-      if (next.has(skuId)) next.delete(skuId);
-      else next.add(skuId);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
       return next;
     });
   }
 
   function selectAll() {
-    setSelectedSkuIds(new Set(allSkuCards.map((c) => c.sku_id)));
+    if (!closeDate) return;
+    setSelectedItems((cur) => {
+      const next = new Set(cur);
+      for (const c of allSkuCards) {
+        next.add(`${closeDate}|${c.sku_id}`);
+      }
+      return next;
+    });
   }
 
   function clearAll() {
-    setSelectedSkuIds(new Set());
+    setSelectedItems(new Set());
   }
 
   async function createWave() {
@@ -327,7 +389,8 @@ export default function PickingWorkstationPage() {
             ) : (
               <ul className="space-y-2">
                 {filteredCards.map((c) => {
-                  const selected = selectedSkuIds.has(c.sku_id);
+                  const key = `${closeDate}|${c.sku_id}`;
+                  const selected = selectedItems.has(key);
                   return (
                     <li
                       key={c.sku_id}
@@ -434,7 +497,19 @@ export default function PickingWorkstationPage() {
                       <td className="sticky left-0 bg-white px-3 py-2 dark:bg-zinc-900">
                         <div className="flex items-start gap-2">
                           <button
-                            onClick={() => toggleSku(c.sku_id)}
+                            onClick={() => {
+                              // 移除該 SKU 的所有 selectedItems
+                              setSelectedItems((cur) => {
+                                const next = new Set(cur);
+                                for (const item of next) {
+                                  const [, skuIdStr] = item.split("|");
+                                  if (Number(skuIdStr) === c.sku_id) {
+                                    next.delete(item);
+                                  }
+                                }
+                                return next;
+                              });
+                            }}
                             title="從大表移除"
                             className="text-rose-500 hover:text-rose-600"
                           >

--- a/supabase/migrations/20260430150000_picking_demand_view.sql
+++ b/supabase/migrations/20260430150000_picking_demand_view.sql
@@ -1,0 +1,31 @@
+-- ============================================================================
+-- v_picking_demand_by_close_date
+-- 給「撿貨工作站」用：以結單日（close_date）為單位，列出 SKU × 分店的需求矩陣
+-- ============================================================================
+CREATE OR REPLACE VIEW public.v_picking_demand_by_close_date AS
+SELECT
+  gbc.tenant_id,
+  DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') AS close_date,
+  coi.sku_id,
+  COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+  s.sku_code,
+  co.pickup_store_id AS store_id,
+  st.code AS store_code,
+  st.name AS store_name,
+  SUM(coi.qty)   AS demand_qty,
+  COUNT(DISTINCT co.id) AS order_count,
+  array_agg(DISTINCT gbc.id) AS campaign_ids
+FROM group_buy_campaigns gbc
+JOIN customer_orders co ON co.campaign_id = gbc.id AND co.status NOT IN ('cancelled','expired')
+JOIN customer_order_items coi ON coi.order_id = co.id AND coi.status NOT IN ('cancelled','expired')
+JOIN skus s ON s.id = coi.sku_id
+JOIN stores st ON st.id = co.pickup_store_id
+WHERE gbc.status NOT IN ('cancelled')
+GROUP BY gbc.tenant_id, DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei'),
+         coi.sku_id, s.product_name, s.variant_name, s.sku_code,
+         co.pickup_store_id, st.code, st.name;
+
+GRANT SELECT ON public.v_picking_demand_by_close_date TO authenticated;
+
+COMMENT ON VIEW public.v_picking_demand_by_close_date IS
+  '撿貨工作站需求矩陣：close_date × sku × store 各分店的需求量';

--- a/supabase/migrations/20260430160000_picking_auth_read_rls.sql
+++ b/supabase/migrations/20260430160000_picking_auth_read_rls.sql
@@ -1,0 +1,23 @@
+-- ============================================================================
+-- 給 picking_waves / picking_wave_items / transfers / transfer_items / goods_receipts / goods_receipt_items
+-- 加 authenticated SELECT policy（admin UI 用）
+-- 既有 hq/store policy 保留
+-- ============================================================================
+
+CREATE POLICY auth_read_picking_waves ON picking_waves
+  FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY auth_read_picking_wave_items ON picking_wave_items
+  FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY auth_read_transfers ON transfers
+  FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY auth_read_transfer_items ON transfer_items
+  FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY auth_read_goods_receipts ON goods_receipts
+  FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY auth_read_goods_receipt_items ON goods_receipt_items
+  FOR SELECT TO authenticated USING (true);


### PR DESCRIPTION
## 📋 說明

改變撿貨工作站的狀態管理，使得用戶可以在多個結單日中累積選擇商品，而不會因為改結單日就清空左欄。

## ✨ 改動內容

**核心變更：**
- `selectedSkuIds` → `selectedItems`（格式：`"${closeDate}|${skuId}"`）
- 加入 `demandHistory` 保存所有結單日的需求數據
- 移除改結單日時自動清空左欄的邏輯
- `selectedCards` 改為聚合所有 selectedItems，跨結單日合併商品需求

**使用流程：**
1. 選結單日 2026-04-28 → 加商品 SKU1 ✓
2. 選結單日 2026-04-30 → 加商品 SKU2 ✓  
3. 左欄保留 SKU1，右欄同時顯示 SKU1 + SKU2 的合併矩陣
4. 建立撿貨單時包含兩個結單日的所有商品

## 🔧 技術細節

- 移除了 `useEffect` 中的 `setSelectedSkuIds(new Set())` reset（第 94 行）
- `selectedCards` 計算邏輯改為從 `demandHistory` 聚合
- `toggleSku()` 改為操作 `"${closeDate}|${skuId}"` 格式的 key
- 移除商品時移除該 SKU 在所有結單日中的 items

## 📝 相關 Issue

解決：改結單日時左欄不應該清空的問題