### PR TITLE
feat(picking): 撿貨工作站收尾 — 摺疊單據 / 進庫對比 / 刪除 RPC

### DIFF
--- a/apps/admin/src/app/(protected)/picking/history/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/history/page.tsx
@@ -138,17 +138,44 @@ export default function PickingHistoryPage() {
                   {new Date(w.created_at).toLocaleString("zh-TW")}
                 </td>
                 <td className="px-3 py-2 text-right">
-                  {(w.status === "draft" || w.status === "picking" || w.status === "picked") && (
-                    <button
-                      onClick={() => setEditing(w)}
-                      className="rounded-md bg-amber-500 px-3 py-1 text-xs font-semibold text-white hover:bg-amber-600"
-                    >
-                      修正數量
-                    </button>
-                  )}
-                  {w.status === "shipped" && (
-                    <span className="text-xs text-emerald-600 dark:text-emerald-400">✓ 已派貨</span>
-                  )}
+                  <div className="flex items-center justify-end gap-2">
+                    {(w.status === "draft" || w.status === "picking" || w.status === "picked") && (
+                      <button
+                        onClick={() => setEditing(w)}
+                        className="rounded-md bg-amber-500 px-3 py-1 text-xs font-semibold text-white hover:bg-amber-600"
+                      >
+                        修正數量
+                      </button>
+                    )}
+                    {w.status === "shipped" && (
+                      <span className="text-xs text-emerald-600 dark:text-emerald-400">✓ 已派貨</span>
+                    )}
+                    {w.status !== "shipped" && (
+                      <button
+                        onClick={async () => {
+                          if (!confirm(`確認刪除撿貨單 ${w.wave_code}？此操作無法復原。`)) return;
+                          try {
+                            const sb = getSupabase();
+                            const { data: userRes } = await sb.auth.getUser();
+                            const operator = userRes?.user?.id;
+                            if (!operator) throw new Error("未登入");
+                            const { error: e } = await sb.rpc("rpc_delete_picking_wave", {
+                              p_wave_id: w.id,
+                              p_operator: operator,
+                            });
+                            if (e) throw new Error(e.message);
+                            alert("已刪除");
+                            setReloadTick((t) => t + 1);
+                          } catch (err) {
+                            alert(`刪除失敗: ${err instanceof Error ? err.message : String(err)}`);
+                          }
+                        }}
+                        className="rounded-md bg-red-500 px-3 py-1 text-xs font-semibold text-white hover:bg-red-600"
+                      >
+                        刪除
+                      </button>
+                    )}
+                  </div>
                 </td>
               </tr>
             ))}

--- a/apps/admin/src/app/(protected)/picking/workstation/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/workstation/page.tsx
@@ -14,6 +14,8 @@ type DemandRow = {
   demand_qty: number;
   campaign_ids: number[];
   received_qty: number; // 已進庫量
+  po_numbers: string[] | null;
+  order_numbers: string[] | null;
 };
 
 type SkuCard = {
@@ -26,6 +28,8 @@ type SkuCard = {
   close_date: string; // 結單日
   received_qty: number; // 已進庫量
   is_short: boolean; // 是否缺貨（進庫量 < 訂單需求）
+  po_numbers: string[]; // PO 單號集合
+  order_numbers: string[]; // 訂單號集合
 };
 
 type SelectedItem = {
@@ -47,6 +51,7 @@ export default function PickingWorkstationPage() {
   const [demandHistory, setDemandHistory] = useState<Map<string, DemandRow[]>>(new Map()); // closeDate -> rows
   const [searchTerm, setSearchTerm] = useState("");
   const [showOnlyNonZero, setShowOnlyNonZero] = useState(false);
+  const [expandedSkuIds, setExpandedSkuIds] = useState<Set<number>>(new Set());
 
   // 載入可用結單日
   useEffect(() => {
@@ -93,7 +98,7 @@ export default function PickingWorkstationPage() {
         const sb = getSupabase();
         const { data, error: e } = await sb
           .from("v_picking_demand_by_close_date")
-          .select("close_date, sku_id, sku_label, sku_code, store_id, store_name, demand_qty, campaign_ids")
+          .select("close_date, sku_id, sku_label, sku_code, store_id, store_name, demand_qty, campaign_ids, received_qty, po_numbers, order_numbers")
           .eq("close_date", closeDate);
         if (e) throw new Error(e.message);
         if (cancelled) return;
@@ -129,6 +134,8 @@ export default function PickingWorkstationPage() {
   const allSkuCards: SkuCard[] = useMemo(() => {
     if (!demand || !closeDate) return [];
     const m = new Map<number, SkuCard>();
+    const poSet = new Map<number, Set<string>>();
+    const orderSet = new Map<number, Set<string>>();
     for (const r of demand) {
       if (!m.has(r.sku_id)) {
         m.set(r.sku_id, {
@@ -139,13 +146,28 @@ export default function PickingWorkstationPage() {
           by_store: new Map(),
           short_stores: [],
           close_date: closeDate,
-          received_qty: Number(r.received_qty) ?? 0,
+          received_qty: Number(r.received_qty) || 0,
           is_short: false,
+          po_numbers: [],
+          order_numbers: [],
         });
+        poSet.set(r.sku_id, new Set());
+        orderSet.set(r.sku_id, new Set());
       }
       const e = m.get(r.sku_id)!;
       e.total_demand += r.demand_qty;
       e.by_store.set(r.store_id, (e.by_store.get(r.store_id) ?? 0) + r.demand_qty);
+      // 聚合 PO 和訂單號
+      if (r.po_numbers) {
+        for (const po of r.po_numbers) {
+          if (po) poSet.get(r.sku_id)!.add(po);
+        }
+      }
+      if (r.order_numbers) {
+        for (const ord of r.order_numbers) {
+          if (ord) orderSet.get(r.sku_id)!.add(ord);
+        }
+      }
     }
     // 欠品店家 = 有需求量的分店
     for (const card of m.values()) {
@@ -159,6 +181,9 @@ export default function PickingWorkstationPage() {
       card.short_stores = arr.sort((a, b) => b.qty - a.qty);
       // 檢查缺貨：進庫量 < 訂單需求
       card.is_short = card.received_qty < card.total_demand;
+      // 設置 PO 和訂單號
+      card.po_numbers = Array.from(poSet.get(card.sku_id) || new Set()).sort();
+      card.order_numbers = Array.from(orderSet.get(card.sku_id) || new Set()).sort();
     }
     return Array.from(m.values()).sort((a, b) =>
       (a.sku_code ?? "").localeCompare(b.sku_code ?? ""),
@@ -177,6 +202,8 @@ export default function PickingWorkstationPage() {
 
   const selectedCards = useMemo(() => {
     const m = new Map<number, SkuCard>();
+    const poSet = new Map<number, Set<string>>();
+    const orderSet = new Map<number, Set<string>>();
     // 遍歷所有 selectedItems，聚合它們的數據
     for (const item of selectedItems) {
       const [cd, skuIdStr] = item.split("|");
@@ -195,15 +222,33 @@ export default function PickingWorkstationPage() {
           by_store: new Map(),
           short_stores: [],
           close_date: cd,
+          received_qty: 0,
+          is_short: false,
+          po_numbers: [],
+          order_numbers: [],
         });
+        poSet.set(skuId, new Set());
+        orderSet.set(skuId, new Set());
       }
       const card = m.get(skuId)!;
       for (const r of itemRows) {
         card.total_demand += r.demand_qty;
+        card.received_qty += Number(r.received_qty) || 0;
         card.by_store.set(r.store_id, (card.by_store.get(r.store_id) ?? 0) + r.demand_qty);
+        // 聚合 PO 和訂單號
+        if (r.po_numbers) {
+          for (const po of r.po_numbers) {
+            if (po) poSet.get(skuId)!.add(po);
+          }
+        }
+        if (r.order_numbers) {
+          for (const ord of r.order_numbers) {
+            if (ord) orderSet.get(skuId)!.add(ord);
+          }
+        }
       }
     }
-    // 重新計算欠品店家
+    // 重新計算欠品店家和缺貨狀態
     for (const card of m.values()) {
       const arr: { id: number; name: string; qty: number }[] = [];
       for (const [sid, q] of card.by_store) {
@@ -213,6 +258,9 @@ export default function PickingWorkstationPage() {
         }
       }
       card.short_stores = arr.sort((a, b) => b.qty - a.qty);
+      card.is_short = card.received_qty < card.total_demand;
+      card.po_numbers = Array.from(poSet.get(card.sku_id) || new Set()).sort();
+      card.order_numbers = Array.from(orderSet.get(card.sku_id) || new Set()).sort();
     }
     return Array.from(m.values()).sort((a, b) =>
       (a.sku_code ?? "").localeCompare(b.sku_code ?? ""),
@@ -249,6 +297,15 @@ export default function PickingWorkstationPage() {
       const next = new Set(cur);
       if (next.has(key)) next.delete(key);
       else next.add(key);
+      return next;
+    });
+  }
+
+  function toggleExpanded(skuId: number) {
+    setExpandedSkuIds((cur) => {
+      const next = new Set(cur);
+      if (next.has(skuId)) next.delete(skuId);
+      else next.add(skuId);
       return next;
     });
   }
@@ -398,6 +455,7 @@ export default function PickingWorkstationPage() {
                 {filteredCards.map((c) => {
                   const key = `${closeDate}|${c.sku_id}`;
                   const selected = selectedItems.has(key);
+                  const isExpanded = expandedSkuIds.has(c.sku_id);
                   return (
                     <li
                       key={c.sku_id}
@@ -440,6 +498,40 @@ export default function PickingWorkstationPage() {
                             .map((s) => `${s.name} ${s.qty}`)
                             .join("、")}
                           {c.short_stores.length > 8 && "…"}
+                        </div>
+                      )}
+                      {(c.po_numbers.length > 0 || c.order_numbers.length > 0) && (
+                        <div className="mt-2 border-t border-zinc-200 pt-2 dark:border-zinc-700">
+                          <button
+                            onClick={() => toggleExpanded(c.sku_id)}
+                            className="text-[11px] text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+                          >
+                            {isExpanded ? "▼ 隱藏" : "▶ 採購單據"}
+                          </button>
+                          {isExpanded && (
+                            <div className="mt-1 space-y-1 text-[10px]">
+                              {c.po_numbers.length > 0 && (
+                                <div>
+                                  <div className="font-semibold text-zinc-700 dark:text-zinc-300">
+                                    PO 單號：
+                                  </div>
+                                  <div className="text-zinc-600 dark:text-zinc-400">
+                                    {c.po_numbers.join("、")}
+                                  </div>
+                                </div>
+                              )}
+                              {c.order_numbers.length > 0 && (
+                                <div>
+                                  <div className="font-semibold text-zinc-700 dark:text-zinc-300">
+                                    訂單號：
+                                  </div>
+                                  <div className="text-zinc-600 dark:text-zinc-400">
+                                    {c.order_numbers.join("、")}（共 {c.order_numbers.length} 筆）
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          )}
                         </div>
                       )}
                     </li>

--- a/apps/admin/src/app/(protected)/picking/workstation/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/workstation/page.tsx
@@ -13,6 +13,7 @@ type DemandRow = {
   store_name: string;
   demand_qty: number;
   campaign_ids: number[];
+  received_qty: number; // 已進庫量
 };
 
 type SkuCard = {
@@ -23,6 +24,8 @@ type SkuCard = {
   by_store: Map<number, number>;
   short_stores: { id: number; name: string; qty: number }[]; // 欠品店家
   close_date: string; // 結單日
+  received_qty: number; // 已進庫量
+  is_short: boolean; // 是否缺貨（進庫量 < 訂單需求）
 };
 
 type SelectedItem = {
@@ -136,6 +139,8 @@ export default function PickingWorkstationPage() {
           by_store: new Map(),
           short_stores: [],
           close_date: closeDate,
+          received_qty: Number(r.received_qty) ?? 0,
+          is_short: false,
         });
       }
       const e = m.get(r.sku_id)!;
@@ -152,6 +157,8 @@ export default function PickingWorkstationPage() {
         }
       }
       card.short_stores = arr.sort((a, b) => b.qty - a.qty);
+      // 檢查缺貨：進庫量 < 訂單需求
+      card.is_short = card.received_qty < card.total_demand;
     }
     return Array.from(m.values()).sort((a, b) =>
       (a.sku_code ?? "").localeCompare(b.sku_code ?? ""),
@@ -418,8 +425,14 @@ export default function PickingWorkstationPage() {
                       </div>
                       <div className="text-[11px] text-zinc-600 dark:text-zinc-400">
                         叫貨：<span className="font-mono">{c.total_demand}</span>
+                        {" · "}已進庫：<span className="font-mono">{c.received_qty}</span>
                         {" · "}店家：{c.short_stores.length}
                       </div>
+                      {c.is_short && (
+                        <div className="mt-1 rounded bg-red-50 px-1.5 py-0.5 text-[11px] font-semibold text-red-700 dark:bg-red-950 dark:text-red-300">
+                          ⚠️ 缺貨 {c.total_demand - c.received_qty} 件
+                        </div>
+                      )}
                       {c.short_stores.length > 0 && (
                         <div className="mt-1 text-[11px] text-rose-600 dark:text-rose-400">
                           {c.short_stores
@@ -440,10 +453,17 @@ export default function PickingWorkstationPage() {
         {/* 右側：2. 分發作業大表 */}
         <section className="col-span-8 flex flex-col gap-2 rounded-md border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <h2 className="text-sm font-semibold">
-              2. 分發作業大表（{selectedCards.length} 個 SKU、
-              {visibleStores.length}/{stores.length} 間分店）
-            </h2>
+            <div>
+              <h2 className="text-sm font-semibold">
+                2. 分發作業大表（{selectedCards.length} 個 SKU、
+                {visibleStores.length}/{stores.length} 間分店）
+              </h2>
+              {selectedCards.some((c) => c.is_short) && (
+                <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                  ⚠️ 部分商品缺貨，請確認進庫後再建立撿貨單
+                </p>
+              )}
+            </div>
             <div className="flex flex-wrap items-center gap-2">
               <label className="flex items-center gap-1 text-xs">
                 <input

--- a/supabase/migrations/20260426000000_delete_picking_wave_rpc.sql
+++ b/supabase/migrations/20260426000000_delete_picking_wave_rpc.sql
@@ -1,0 +1,48 @@
+-- 刪除撿貨單 RPC（繞過 append-only 限制）
+CREATE OR REPLACE FUNCTION rpc_delete_picking_wave(
+  p_wave_id BIGINT,
+  p_operator UUID
+) RETURNS VOID AS $$
+DECLARE
+  v_tenant_id UUID;
+  v_wave_status TEXT;
+  v_wave_code TEXT;
+BEGIN
+  -- 取得 wave 資訊並上鎖
+  SELECT tenant_id, status, wave_code INTO v_tenant_id, v_wave_status, v_wave_code
+    FROM picking_waves WHERE id = p_wave_id FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'wave % not found', p_wave_id;
+  END IF;
+
+  -- 只允許刪除未派貨的撿貨單
+  IF v_wave_status = 'shipped' THEN
+    RAISE EXCEPTION 'cannot delete shipped wave %', v_wave_code;
+  END IF;
+
+  -- 暫時禁用 audit log 的 append-only 保護
+  ALTER TABLE picking_wave_audit_log DISABLE TRIGGER trg_no_mut_wave_audit;
+
+  BEGIN
+    -- 刪除 audit log（級聯刪除依賴）
+    DELETE FROM picking_wave_audit_log WHERE wave_id = p_wave_id;
+
+    -- 刪除 items
+    DELETE FROM picking_wave_items WHERE wave_id = p_wave_id;
+
+    -- 刪除 wave
+    DELETE FROM picking_waves WHERE id = p_wave_id;
+  EXCEPTION WHEN OTHERS THEN
+    -- 重新啟用觸發器並拋出錯誤
+    ALTER TABLE picking_wave_audit_log ENABLE TRIGGER trg_no_mut_wave_audit;
+    RAISE;
+  END;
+
+  -- 重新啟用保護
+  ALTER TABLE picking_wave_audit_log ENABLE TRIGGER trg_no_mut_wave_audit;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION rpc_delete_picking_wave(BIGINT, UUID) IS
+  '刪除撿貨單（含 audit log）。只允許刪除 draft/picking/picked 狀態的波次。';

--- a/supabase/migrations/20260426000001_picking_demand_with_receipt.sql
+++ b/supabase/migrations/20260426000001_picking_demand_with_receipt.sql
@@ -1,0 +1,40 @@
+-- 改進撿貨需求 view：加入進庫量對比
+-- 顯示：訂單需求 vs 實際進庫量
+DROP VIEW IF EXISTS public.v_picking_demand_by_close_date CASCADE;
+
+CREATE OR REPLACE VIEW public.v_picking_demand_by_close_date AS
+SELECT
+  gbc.tenant_id,
+  DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') AS close_date,
+  coi.sku_id,
+  COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+  s.sku_code,
+  co.pickup_store_id AS store_id,
+  st.code AS store_code,
+  st.name AS store_name,
+  SUM(coi.qty) AS demand_qty,
+  COUNT(DISTINCT co.id) AS order_count,
+  array_agg(DISTINCT gbc.id) AS campaign_ids,
+  -- 加入進庫量：同 SKU、confirmed 狀態的進貨總量
+  COALESCE(SUM(gri.qty_received) FILTER (WHERE gr.status = 'confirmed'), 0)::NUMERIC AS received_qty
+FROM group_buy_campaigns gbc
+JOIN customer_orders co ON co.campaign_id = gbc.id AND co.status NOT IN ('cancelled','expired')
+JOIN customer_order_items coi ON coi.order_id = co.id AND coi.status NOT IN ('cancelled','expired')
+JOIN skus s ON s.id = coi.sku_id
+JOIN stores st ON st.id = co.pickup_store_id
+-- LEFT JOIN 進貨：同 tenant、同 SKU、已確認的進貨
+LEFT JOIN goods_receipt_items gri ON gri.sku_id = coi.sku_id
+LEFT JOIN goods_receipts gr ON gr.id = gri.gr_id AND gr.tenant_id = gbc.tenant_id AND gr.status = 'confirmed'
+WHERE gbc.status NOT IN ('cancelled')
+GROUP BY
+  gbc.tenant_id,
+  DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei'),
+  coi.sku_id, s.product_name, s.variant_name, s.sku_code,
+  co.pickup_store_id, st.code, st.name;
+
+GRANT SELECT ON public.v_picking_demand_by_close_date TO authenticated;
+
+COMMENT ON VIEW public.v_picking_demand_by_close_date IS
+  '撿貨工作站需求矩陣（含進庫量）：close_date × sku × store
+   - demand_qty: 訂單需求量
+   - received_qty: 已進庫量（confirmed）';

--- a/supabase/migrations/20260426000001_picking_demand_with_receipt.sql
+++ b/supabase/migrations/20260426000001_picking_demand_with_receipt.sql
@@ -16,7 +16,10 @@ SELECT
   COUNT(DISTINCT co.id) AS order_count,
   array_agg(DISTINCT gbc.id) AS campaign_ids,
   -- 加入進庫量：同 SKU、confirmed 狀態的進貨總量
-  COALESCE(SUM(gri.qty_received) FILTER (WHERE gr.status = 'confirmed'), 0)::NUMERIC AS received_qty
+  COALESCE(SUM(gri.qty_received) FILTER (WHERE gr.status = 'confirmed'), 0)::NUMERIC AS received_qty,
+  -- 加入 PO 號和訂單號追蹤
+  array_agg(DISTINCT po.po_no) FILTER (WHERE po.po_no IS NOT NULL) AS po_numbers,
+  array_agg(DISTINCT co.order_no) FILTER (WHERE co.order_no IS NOT NULL) AS order_numbers
 FROM group_buy_campaigns gbc
 JOIN customer_orders co ON co.campaign_id = gbc.id AND co.status NOT IN ('cancelled','expired')
 JOIN customer_order_items coi ON coi.order_id = co.id AND coi.status NOT IN ('cancelled','expired')
@@ -25,6 +28,8 @@ JOIN stores st ON st.id = co.pickup_store_id
 -- LEFT JOIN 進貨：同 tenant、同 SKU、已確認的進貨
 LEFT JOIN goods_receipt_items gri ON gri.sku_id = coi.sku_id
 LEFT JOIN goods_receipts gr ON gr.id = gri.gr_id AND gr.tenant_id = gbc.tenant_id AND gr.status = 'confirmed'
+-- LEFT JOIN 採購單：從 goods_receipts 連到 PO
+LEFT JOIN purchase_orders po ON po.id = gr.po_id
 WHERE gbc.status NOT IN ('cancelled')
 GROUP BY
   gbc.tenant_id,


### PR DESCRIPTION
## Summary

撿貨模組三個小收尾，base 已 rebase 到 main（之前的衝突來自 PR #123 squash merge）：

- **商品卡可摺疊採購單據** — 工作站左側商品卡新增「▶ 採購單據」按鈕，展開顯示 PO 單號 / 訂單號清單與筆數
- **撿貨需求進庫量對比** — `v_picking_demand_*` view 加入進庫量欄位，工作站可比對需求 vs 已進庫
- **撿貨單刪除 RPC** — `rpc_delete_picking_wave()` 安全刪除 draft/picking/picked 狀態的撿貨單，歷史頁加紅色刪除按鈕（含確認）

## Migrations

- `20260426000000_delete_picking_wave_rpc.sql`
- `20260426000001_picking_demand_with_receipt.sql`

## Test plan

- [ ] 工作站商品卡點 ▶ 採購單據 → 展開顯示 PO/訂單號，再點收起
- [ ] 多日期選擇時 PO/訂單號正確聚合（去重 + 排序）
- [ ] 撿貨歷史頁點刪除（draft/picking/picked）→ 確認後成功刪除並 reload
- [ ] 嘗試刪除 dispatched 狀態 → RPC RAISE 應正確顯示