### PR TITLE
fix(picking): build 失敗 — new Set() 泛型

### DIFF
--- a/apps/admin/src/app/(protected)/picking/workstation/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/workstation/page.tsx
@@ -182,8 +182,8 @@ export default function PickingWorkstationPage() {
       // 檢查缺貨：進庫量 < 訂單需求
       card.is_short = card.received_qty < card.total_demand;
       // 設置 PO 和訂單號
-      card.po_numbers = Array.from(poSet.get(card.sku_id) || new Set()).sort();
-      card.order_numbers = Array.from(orderSet.get(card.sku_id) || new Set()).sort();
+      card.po_numbers = Array.from(poSet.get(card.sku_id) ?? new Set<string>()).sort();
+      card.order_numbers = Array.from(orderSet.get(card.sku_id) ?? new Set<string>()).sort();
     }
     return Array.from(m.values()).sort((a, b) =>
       (a.sku_code ?? "").localeCompare(b.sku_code ?? ""),
@@ -259,8 +259,8 @@ export default function PickingWorkstationPage() {
       }
       card.short_stores = arr.sort((a, b) => b.qty - a.qty);
       card.is_short = card.received_qty < card.total_demand;
-      card.po_numbers = Array.from(poSet.get(card.sku_id) || new Set()).sort();
-      card.order_numbers = Array.from(orderSet.get(card.sku_id) || new Set()).sort();
+      card.po_numbers = Array.from(poSet.get(card.sku_id) ?? new Set<string>()).sort();
+      card.order_numbers = Array.from(orderSet.get(card.sku_id) ?? new Set<string>()).sort();
     }
     return Array.from(m.values()).sort((a, b) =>
       (a.sku_code ?? "").localeCompare(b.sku_code ?? ""),


### PR DESCRIPTION
## Summary

main 在 PR #124 merge 後 CI build 失敗：

```
./src/app/(protected)/picking/workstation/page.tsx:185:7
Type error: Type 'unknown[]' is not assignable to type 'string[]'.
```

`poSet.get(card.sku_id) ?? new Set()` 中沒帶泛型的 `new Set()` 被推斷為 `Set<unknown>`，與 `Set<string>` union 後 `Array.from()` 結果退化為 `unknown[]`，無法賦給 `card.po_numbers: string[]`。

## Fix

兩處 fallback `new Set()` 加 `<string>` 泛型，順便把 `||` 改 `??`（語意更精確 — Map.get 只會回 `undefined`，不會回 falsy string）。

- line 185-186 (allSkuCards memo)
- line 262-263 (selectedCards memo)

## Test plan

- [x] 本地 \`npx tsc --noEmit\` 通過
- [ ] CI build 通過