### PR TITLE
fix(purchase/picking): PR reopen + RLS + 進貨 auto-alloc + 撿貨看明細

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -7,7 +7,7 @@ import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
 
 type OrderStatus =
-  | "pending" | "confirmed" | "reserved" | "ready" | "partially_ready"
+  | "pending" | "confirmed" | "reserved" | "shipping" | "ready" | "partially_ready"
   | "partially_completed" | "completed" | "expired" | "cancelled";
 
 type Row = {
@@ -27,9 +27,9 @@ type Store = { id: number; code: string; name: string };
 type Member = { id: number; name: string | null; phone: string | null; member_no: string };
 
 const STATUS_LABEL: Record<OrderStatus, string> = {
-  pending: "待確認", confirmed: "已確認", reserved: "已保留", ready: "可取貨",
-  partially_ready: "部分可取", partially_completed: "部分取貨", completed: "已完成",
-  expired: "逾期", cancelled: "已取消",
+  pending: "待確認", confirmed: "已確認", reserved: "已保留", shipping: "派貨中",
+  ready: "可取貨", partially_ready: "部分可取", partially_completed: "部分取貨",
+  completed: "已完成", expired: "逾期", cancelled: "已取消",
 };
 
 const PAGE_SIZE = 50;
@@ -249,6 +249,7 @@ function StatusBadge({ s }: { s: OrderStatus }) {
     pending: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
     confirmed: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
     reserved: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
+    shipping: "bg-purple-100 text-purple-800 dark:bg-purple-950 dark:text-purple-300",
     ready: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
     partially_ready: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
     partially_completed: "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300",

--- a/apps/admin/src/app/(protected)/picking/history/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/history/page.tsx
@@ -157,7 +157,37 @@ export default function PickingHistoryPage() {
               <tr key={w.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
                 <td className="px-3 py-2 text-xs text-zinc-600 dark:text-zinc-300">
                   <div>{new Date(w.created_at).toLocaleString("zh-TW")}</div>
-                  <div className="text-zinc-500">📅 配送：{w.wave_date}</div>
+                  <div className="mt-1 flex items-center gap-1 text-zinc-500">
+                    <span>📅 配送：</span>
+                    {w.status === "shipped" || w.status === "cancelled" ? (
+                      <span>{w.wave_date}</span>
+                    ) : (
+                      <input
+                        type="date"
+                        value={w.wave_date}
+                        onChange={async (e) => {
+                          const newDate = e.target.value;
+                          if (!newDate || newDate === w.wave_date) return;
+                          try {
+                            const sb = getSupabase();
+                            const { data: userRes } = await sb.auth.getUser();
+                            const operator = userRes?.user?.id;
+                            if (!operator) throw new Error("未登入");
+                            const { error: er } = await sb.rpc("rpc_update_wave_date", {
+                              p_wave_id: w.id,
+                              p_new_date: newDate,
+                              p_operator: operator,
+                            });
+                            if (er) throw new Error(er.message);
+                            setReloadTick((t) => t + 1);
+                          } catch (err) {
+                            alert(`配送日更新失敗：${err instanceof Error ? err.message : String(err)}`);
+                          }
+                        }}
+                        className="rounded border border-zinc-300 bg-white px-1 py-0.5 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                      />
+                    )}
+                  </div>
                 </td>
                 <td className="px-3 py-2">
                   <div className="font-mono text-sm">{w.wave_code}</div>

--- a/apps/admin/src/app/(protected)/picking/history/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/history/page.tsx
@@ -148,7 +148,12 @@ export default function PickingHistoryPage() {
                       </button>
                     )}
                     {w.status === "shipped" && (
-                      <span className="text-xs text-emerald-600 dark:text-emerald-400">✓ 已派貨</span>
+                      <button
+                        onClick={() => setEditing(w)}
+                        className="rounded-md border border-emerald-300 px-3 py-1 text-xs font-medium text-emerald-700 hover:bg-emerald-50 dark:border-emerald-700 dark:text-emerald-400 dark:hover:bg-emerald-950"
+                      >
+                        ✓ 已派貨 · 看明細
+                      </button>
                     )}
                     {w.status !== "shipped" && (
                       <button
@@ -388,13 +393,15 @@ function PickModal({
             </h2>
           </div>
           <div className="flex gap-2">
-            <button
-              onClick={saveEdits}
-              disabled={submitting}
-              className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
-            >
-              {submitting ? "儲存中…" : `儲存修正 (${edits.size})`}
-            </button>
+            {wave.status !== "shipped" && (
+              <button
+                onClick={saveEdits}
+                disabled={submitting}
+                className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {submitting ? "儲存中…" : `儲存修正 (${edits.size})`}
+              </button>
+            )}
             {wave.status !== "picked" && wave.status !== "shipped" && (
               <button
                 onClick={confirmAsPicked}

--- a/apps/admin/src/app/(protected)/picking/history/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/history/page.tsx
@@ -191,7 +191,7 @@ export default function PickingHistoryPage() {
       {editing && (
         <PickModal
           wave={editing}
-          onClose={() => setEditing(null)}
+          onClose={() => { setEditing(null); setReloadTick((t) => t + 1); }}
           onSubmitted={() => {
             setEditing(null);
             setReloadTick((t) => t + 1);
@@ -219,6 +219,7 @@ function PickModal({
   const [submitting, setSubmitting] = useState(false);
   const [shipping, setShipping] = useState(false);
   const [hqLocId, setHqLocId] = useState<number | null>(null);
+  const [effectiveStatus, setEffectiveStatus] = useState<string>(wave.status);
 
   useEffect(() => {
     let cancelled = false;
@@ -333,8 +334,8 @@ function PickModal({
       setError("找不到總倉 location");
       return;
     }
-    if (wave.status !== "picked") {
-      setError(`撿貨單狀態為 ${wave.status}，需是 picked 才能派貨。請先確認修正完成。`);
+    if (effectiveStatus !== "picked") {
+      setError(`撿貨單狀態為 ${effectiveStatus}，需是 picked 才能派貨。請先確認修正完成。`);
       return;
     }
     if (!confirm(`確認派貨？將為 ${wave.store_count} 間分店產生 transfer 並從總倉出庫。`)) return;
@@ -362,17 +363,20 @@ function PickModal({
   }
 
   async function confirmAsPicked() {
-    if (wave.status === "picked") return;
+    if (effectiveStatus === "picked") return;
     setSubmitting(true);
     setError(null);
     try {
       const sb = getSupabase();
-      const { error: e } = await sb
-        .from("picking_waves")
-        .update({ status: "picked", updated_at: new Date().toISOString() })
-        .eq("id", wave.id);
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes?.user?.id;
+      if (!operator) throw new Error("未登入");
+      const { error: e } = await sb.rpc("rpc_confirm_picked", {
+        p_wave_id: wave.id,
+        p_operator: operator,
+      });
       if (e) throw new Error(e.message);
-      onSubmitted();
+      setEffectiveStatus("picked");
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -388,12 +392,12 @@ function PickModal({
             <h2 className="font-semibold">
               修正數量：<span className="font-mono">{wave.wave_code}</span>{" "}
               <span className="text-xs text-zinc-500">
-                · 配送日 {wave.wave_date} · 狀態 {STATUS_LABEL[wave.status] ?? wave.status}
+                · 配送日 {wave.wave_date} · 狀態 {STATUS_LABEL[effectiveStatus] ?? effectiveStatus}
               </span>
             </h2>
           </div>
           <div className="flex gap-2">
-            {wave.status !== "shipped" && (
+            {effectiveStatus !== "shipped" && (
               <button
                 onClick={saveEdits}
                 disabled={submitting}
@@ -402,7 +406,7 @@ function PickModal({
                 {submitting ? "儲存中…" : `儲存修正 (${edits.size})`}
               </button>
             )}
-            {wave.status !== "picked" && wave.status !== "shipped" && (
+            {effectiveStatus !== "picked" && effectiveStatus !== "shipped" && (
               <button
                 onClick={confirmAsPicked}
                 disabled={submitting}
@@ -411,7 +415,7 @@ function PickModal({
                 ✅ 確認修正完成
               </button>
             )}
-            {wave.status === "picked" && (
+            {effectiveStatus === "picked" && (
               <button
                 onClick={ship}
                 disabled={shipping}
@@ -486,7 +490,7 @@ function PickModal({
                             <div className="flex flex-col">
                               <input
                                 inputMode="decimal"
-                                disabled={isShippedItem || wave.status === "shipped"}
+                                disabled={isShippedItem || effectiveStatus === "shipped"}
                                 value={cur}
                                 onChange={(e) => setEdit(it.id, e.target.value)}
                                 className={`w-14 rounded-md border px-1 py-0.5 text-right font-mono text-sm ${isEdited ? "border-amber-400 bg-amber-50 dark:bg-amber-950" : "border-zinc-300 bg-white dark:border-zinc-700 dark:bg-zinc-800"} disabled:bg-zinc-100 disabled:opacity-60 dark:disabled:bg-zinc-800`}

--- a/apps/admin/src/app/(protected)/picking/history/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/history/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 
 type Wave = {
@@ -13,6 +13,8 @@ type Wave = {
   total_qty: number;
   note: string | null;
   created_at: string;
+  expected_total: number;
+  actual_total: number;
 };
 
 type WaveItem = {
@@ -60,8 +62,35 @@ export default function PickingHistoryPage() {
           .order("created_at", { ascending: false })
           .limit(50);
         if (e) throw new Error(e.message);
+        const waveRows = (data as Omit<Wave, "expected_total" | "actual_total">[] | null) ?? [];
+        const ids = waveRows.map((w) => w.id);
+        const totals = new Map<number, { expected: number; actual: number; itemCount: number }>();
+        if (ids.length > 0) {
+          const { data: itemRows } = await sb
+            .from("picking_wave_items")
+            .select("wave_id, qty, picked_qty")
+            .in("wave_id", ids);
+          for (const r of (itemRows as { wave_id: number; qty: number; picked_qty: number | null }[] | null) ?? []) {
+            const cur = totals.get(r.wave_id) ?? { expected: 0, actual: 0, itemCount: 0 };
+            cur.expected += Number(r.qty);
+            cur.actual += Number(r.picked_qty ?? r.qty);
+            cur.itemCount += 1;
+            totals.set(r.wave_id, cur);
+          }
+        }
         if (!cancelled) {
-          setWaves(((data as Wave[] | null) ?? []).map((r) => ({ ...r, total_qty: Number(r.total_qty) })));
+          setWaves(
+            waveRows.map((r) => {
+              const t = totals.get(r.id);
+              return {
+                ...r,
+                total_qty: Number(r.total_qty),
+                expected_total: t?.expected ?? 0,
+                actual_total: t?.actual ?? 0,
+                item_count: t?.itemCount ?? r.item_count,
+              };
+            }),
+          );
           setError(null);
         }
       } catch (e) {
@@ -100,42 +129,52 @@ export default function PickingHistoryPage() {
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr>
+              <Th>作業時間</Th>
               <Th>撿貨單號</Th>
-              <Th>配送日</Th>
-              <Th>狀態</Th>
-              <Th className="text-right">分店</Th>
-              <Th className="text-right">SKU</Th>
-              <Th className="text-right">總量</Th>
-              <Th>備註</Th>
-              <Th>建立</Th>
+              <Th>摘要</Th>
               <Th></Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {waves !== null && waves.length === 0 && (
               <tr>
-                <td colSpan={9} className="p-6 text-center text-sm text-zinc-500">
+                <td colSpan={4} className="p-6 text-center text-sm text-zinc-500">
                   尚無撿貨單，請至「撿貨工作站」建立。
                 </td>
               </tr>
             )}
-            {waves?.map((w) => (
+            {waves?.map((w) => {
+              const diff = w.actual_total - w.expected_total;
+              const diffEl =
+                diff === 0 ? (
+                  <span className="ml-2 font-medium text-emerald-600 dark:text-emerald-400">✓ 正確</span>
+                ) : diff > 0 ? (
+                  <span className="ml-2 font-medium text-purple-600 dark:text-purple-400">(+{diff})</span>
+                ) : (
+                  <span className="ml-2 font-medium text-red-600 dark:text-red-400">({diff})</span>
+                );
+              return (
               <tr key={w.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
-                <td className="px-3 py-2 font-mono">{w.wave_code}</td>
-                <td className="px-3 py-2">{w.wave_date}</td>
+                <td className="px-3 py-2 text-xs text-zinc-600 dark:text-zinc-300">
+                  <div>{new Date(w.created_at).toLocaleString("zh-TW")}</div>
+                  <div className="text-zinc-500">📅 配送：{w.wave_date}</div>
+                </td>
                 <td className="px-3 py-2">
+                  <div className="font-mono text-sm">{w.wave_code}</div>
                   <span
-                    className={`inline-block rounded px-2 py-0.5 text-xs ${STATUS_COLOR[w.status] ?? ""}`}
+                    className={`mt-1 inline-block rounded px-2 py-0.5 text-xs ${STATUS_COLOR[w.status] ?? ""}`}
                   >
                     {STATUS_LABEL[w.status] ?? w.status}
                   </span>
+                  {w.note && <div className="mt-1 text-[11px] text-zinc-500">{w.note}</div>}
                 </td>
-                <td className="px-3 py-2 text-right font-mono">{w.store_count}</td>
-                <td className="px-3 py-2 text-right font-mono">{w.item_count}</td>
-                <td className="px-3 py-2 text-right font-mono">{w.total_qty}</td>
-                <td className="px-3 py-2 text-xs text-zinc-500">{w.note ?? "—"}</td>
-                <td className="px-3 py-2 text-xs text-zinc-500">
-                  {new Date(w.created_at).toLocaleString("zh-TW")}
+                <td className="px-3 py-2 text-sm">
+                  <span className="text-zinc-600 dark:text-zinc-300">{w.item_count} 品項</span>
+                  <span className="mx-2 text-zinc-300">|</span>
+                  <span className="text-zinc-600 dark:text-zinc-300">應發 <span className="font-mono font-semibold">{w.expected_total}</span></span>
+                  <span className="mx-2 text-zinc-300">|</span>
+                  <span className="text-zinc-600 dark:text-zinc-300">實分 <span className="font-mono font-semibold">{w.actual_total}</span></span>
+                  {diffEl}
                 </td>
                 <td className="px-3 py-2 text-right">
                   <div className="flex items-center justify-end gap-2">
@@ -183,7 +222,8 @@ export default function PickingHistoryPage() {
                   </div>
                 </td>
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
       </div>
@@ -220,6 +260,17 @@ function PickModal({
   const [shipping, setShipping] = useState(false);
   const [hqLocId, setHqLocId] = useState<number | null>(null);
   const [effectiveStatus, setEffectiveStatus] = useState<string>(wave.status);
+
+  const shortageCount = useMemo(() => {
+    if (!items) return 0;
+    let n = 0;
+    for (const it of items) {
+      const e = edits.get(it.id);
+      const v = e !== undefined ? Number(e) : Number(it.picked_qty ?? it.qty);
+      if (!Number.isNaN(v) && v < Number(it.qty)) n += 1;
+    }
+    return n;
+  }, [items, edits]);
 
   useEffect(() => {
     let cancelled = false;
@@ -338,7 +389,10 @@ function PickModal({
       setError(`撿貨單狀態為 ${effectiveStatus}，需是 picked 才能派貨。請先確認修正完成。`);
       return;
     }
-    if (!confirm(`確認派貨？將為 ${wave.store_count} 間分店產生 transfer 並從總倉出庫。`)) return;
+    const shortMsg = shortageCount > 0
+      ? `\n\n⚠ 有 ${shortageCount} 行短缺（撿到的數量少於應撿量），派貨後該店家會拿不到應有量。是否仍要繼續？`
+      : "";
+    if (!confirm(`確認派貨？將為 ${wave.store_count} 間分店產生 transfer 並從總倉出庫。${shortMsg}`)) return;
     setShipping(true);
     setError(null);
     try {
@@ -394,6 +448,11 @@ function PickModal({
               <span className="text-xs text-zinc-500">
                 · 配送日 {wave.wave_date} · 狀態 {STATUS_LABEL[effectiveStatus] ?? effectiveStatus}
               </span>
+              {shortageCount > 0 && (
+                <span className="ml-2 inline-block rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                  ⚠ {shortageCount} 行短缺（可派貨，部分店家拿不到應有量）
+                </span>
+              )}
             </h2>
           </div>
           <div className="flex gap-2">
@@ -449,6 +508,7 @@ function PickModal({
                   <th className="sticky left-0 z-10 bg-zinc-50 px-3 py-2 text-left text-xs uppercase text-zinc-500 dark:bg-zinc-900">
                     品名
                   </th>
+                  <th className="px-2 py-2 text-left text-xs uppercase text-zinc-500">項目</th>
                   {stores.map((s) => (
                     <th
                       key={s.id}
@@ -460,50 +520,111 @@ function PickModal({
                   <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">合計</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+              <tbody className="divide-y-2 divide-zinc-300 dark:divide-zinc-700">
                 {skuList.map((sku) => {
                   const row = matrix.get(sku.id);
-                  const total = stores.reduce((s, st) => {
+                  const expectedTotal = stores.reduce((s, st) => {
+                    const it = row?.get(st.id);
+                    return it ? s + Number(it.qty) : s;
+                  }, 0);
+                  const actualTotal = stores.reduce((s, st) => {
                     const it = row?.get(st.id);
                     if (!it) return s;
                     const edit = edits.get(it.id);
-                    const v = edit !== undefined ? Number(edit) : (it.picked_qty ?? it.qty);
+                    const v = edit !== undefined ? Number(edit) : Number(it.picked_qty ?? it.qty);
                     return s + (Number.isNaN(v) ? 0 : v);
                   }, 0);
+                  const totalDiff = actualTotal - expectedTotal;
                   return (
-                    <tr key={sku.id}>
-                      <td className="sticky left-0 bg-white px-3 py-2 dark:bg-zinc-900">
-                        <div className="font-medium">{sku.product_name ?? "—"}</div>
-                        <div className="text-xs text-zinc-500">
-                          {sku.sku_code}{sku.variant_name ? ` / ${sku.variant_name}` : ""}
-                        </div>
-                      </td>
-                      {stores.map((st) => {
-                        const it = row?.get(st.id);
-                        if (!it) return <td key={st.id} className="px-2 py-2 text-right text-zinc-300">·</td>;
-                        const edit = edits.get(it.id);
-                        const cur = edit !== undefined ? edit : String(it.picked_qty ?? it.qty);
-                        const isEdited = edit !== undefined;
-                        const isShippedItem = it.generated_transfer_id !== null;
-                        return (
-                          <td key={st.id} className="px-1 py-1 text-right">
-                            <div className="flex flex-col">
+                    <Fragment key={sku.id}>
+                      {/* 應發 */}
+                      <tr className="bg-zinc-50/50 dark:bg-zinc-900/50">
+                        <td
+                          rowSpan={3}
+                          className="sticky left-0 bg-white px-3 py-2 align-top dark:bg-zinc-900"
+                        >
+                          <div className="font-medium">{sku.product_name ?? "—"}</div>
+                          <div className="text-xs text-zinc-500">
+                            {sku.sku_code}{sku.variant_name ? ` / ${sku.variant_name}` : ""}
+                          </div>
+                        </td>
+                        <td className="px-2 py-1 text-xs text-zinc-500">應發</td>
+                        {stores.map((st) => {
+                          const it = row?.get(st.id);
+                          return (
+                            <td key={st.id} className="px-2 py-1 text-right font-mono text-zinc-500">
+                              {it ? Number(it.qty) : <span className="text-zinc-300">·</span>}
+                            </td>
+                          );
+                        })}
+                        <td className="px-3 py-1 text-right font-mono text-zinc-600">{expectedTotal}</td>
+                      </tr>
+
+                      {/* 實分 */}
+                      <tr>
+                        <td className="px-2 py-1 text-xs font-semibold">實分</td>
+                        {stores.map((st) => {
+                          const it = row?.get(st.id);
+                          if (!it) return <td key={st.id} className="px-2 py-1 text-right text-zinc-300">·</td>;
+                          const edit = edits.get(it.id);
+                          const cur = edit !== undefined ? edit : String(it.picked_qty ?? it.qty);
+                          const isEdited = edit !== undefined;
+                          const isShippedItem = it.generated_transfer_id !== null;
+                          return (
+                            <td key={st.id} className="px-1 py-1 text-right">
                               <input
                                 inputMode="decimal"
                                 disabled={isShippedItem || effectiveStatus === "shipped"}
                                 value={cur}
                                 onChange={(e) => setEdit(it.id, e.target.value)}
-                                className={`w-14 rounded-md border px-1 py-0.5 text-right font-mono text-sm ${isEdited ? "border-amber-400 bg-amber-50 dark:bg-amber-950" : "border-zinc-300 bg-white dark:border-zinc-700 dark:bg-zinc-800"} disabled:bg-zinc-100 disabled:opacity-60 dark:disabled:bg-zinc-800`}
+                                className={`w-14 rounded-md border px-1 py-0.5 text-right font-mono text-sm font-semibold ${
+                                  isEdited
+                                    ? "border-amber-400 bg-amber-50 dark:bg-amber-950"
+                                    : "border-zinc-300 bg-white dark:border-zinc-700 dark:bg-zinc-800"
+                                } disabled:bg-zinc-100 disabled:opacity-60 dark:disabled:bg-zinc-800`}
                               />
-                              <div className="text-[10px] text-zinc-400">
-                                應 {it.qty}
-                              </div>
-                            </div>
-                          </td>
-                        );
-                      })}
-                      <td className="px-3 py-2 text-right font-mono font-semibold">{total}</td>
-                    </tr>
+                            </td>
+                          );
+                        })}
+                        <td className="px-3 py-1 text-right font-mono font-semibold">{actualTotal}</td>
+                      </tr>
+
+                      {/* 狀態 */}
+                      <tr className="bg-zinc-50/50 dark:bg-zinc-900/50">
+                        <td className="px-2 py-1 text-xs text-zinc-500">狀態</td>
+                        {stores.map((st) => {
+                          const it = row?.get(st.id);
+                          if (!it) return <td key={st.id} className="px-2 py-1 text-right text-zinc-300">—</td>;
+                          const edit = edits.get(it.id);
+                          const cur = Number(edit !== undefined ? edit : (it.picked_qty ?? it.qty));
+                          const diff = !Number.isNaN(cur) ? cur - Number(it.qty) : 0;
+                          if (diff === 0) {
+                            return <td key={st.id} className="px-2 py-1 text-right text-xs text-zinc-400">—</td>;
+                          }
+                          if (diff > 0) {
+                            return (
+                              <td key={st.id} className="px-2 py-1 text-right text-xs font-medium text-purple-600 dark:text-purple-400">
+                                +{diff} 超賣
+                              </td>
+                            );
+                          }
+                          return (
+                            <td key={st.id} className="px-2 py-1 text-right text-xs font-medium text-red-600 dark:text-red-400">
+                              {diff} 短缺
+                            </td>
+                          );
+                        })}
+                        <td className={`px-3 py-1 text-right font-mono text-xs font-semibold ${
+                          totalDiff === 0
+                            ? "text-emerald-600 dark:text-emerald-400"
+                            : totalDiff > 0
+                            ? "text-purple-600 dark:text-purple-400"
+                            : "text-red-600 dark:text-red-400"
+                        }`}>
+                          {totalDiff === 0 ? "✓" : (totalDiff > 0 ? `+${totalDiff}` : `${totalDiff}`)}
+                        </td>
+                      </tr>
+                    </Fragment>
                   );
                 })}
               </tbody>

--- a/apps/admin/src/app/(protected)/picking/workstation/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/workstation/page.tsx
@@ -52,6 +52,7 @@ export default function PickingWorkstationPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [showOnlyNonZero, setShowOnlyNonZero] = useState(false);
   const [expandedSkuIds, setExpandedSkuIds] = useState<Set<number>>(new Set());
+  const [pickedSkuIds, setPickedSkuIds] = useState<Set<number>>(new Set());
 
   // 載入可用結單日
   useEffect(() => {
@@ -109,6 +110,25 @@ export default function PickingWorkstationPage() {
         setDemand(rows);
         // 保存到歷史記錄
         setDemandHistory((prev) => new Map(prev).set(closeDate, rows));
+
+        // 過濾已撿過的 SKU：該結單日已有非 cancelled 的 wave 涉及的 sku 不再顯示
+        const { data: priorWaves } = await sb
+          .from("picking_waves")
+          .select("id")
+          .eq("wave_date", closeDate)
+          .neq("status", "cancelled");
+        const priorWaveIds = (priorWaves as { id: number }[] | null)?.map((w) => w.id) ?? [];
+        if (priorWaveIds.length > 0) {
+          const { data: pickedItems } = await sb
+            .from("picking_wave_items")
+            .select("sku_id")
+            .in("wave_id", priorWaveIds);
+          if (!cancelled) {
+            setPickedSkuIds(new Set((pickedItems as { sku_id: number }[] | null)?.map((i) => i.sku_id) ?? []));
+          }
+        } else if (!cancelled) {
+          setPickedSkuIds(new Set());
+        }
 
         const storeIds = Array.from(new Set(rows.map((r) => r.store_id)));
         if (storeIds.length) {
@@ -185,10 +205,10 @@ export default function PickingWorkstationPage() {
       card.po_numbers = Array.from(poSet.get(card.sku_id) ?? new Set<string>()).sort();
       card.order_numbers = Array.from(orderSet.get(card.sku_id) ?? new Set<string>()).sort();
     }
-    return Array.from(m.values()).sort((a, b) =>
-      (a.sku_code ?? "").localeCompare(b.sku_code ?? ""),
-    );
-  }, [demand, stores, closeDate]);
+    return Array.from(m.values())
+      .filter((c) => !pickedSkuIds.has(c.sku_id))
+      .sort((a, b) => (a.sku_code ?? "").localeCompare(b.sku_code ?? ""));
+  }, [demand, stores, closeDate, pickedSkuIds]);
 
   const filteredCards = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();

--- a/apps/admin/src/app/(protected)/picking/workstation/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/workstation/page.tsx
@@ -30,6 +30,7 @@ type SkuCard = {
   is_short: boolean; // 是否缺貨（進庫量 < 訂單需求）
   po_numbers: string[]; // PO 單號集合
   order_numbers: string[]; // 訂單號集合
+  is_picked: boolean; // 該結單日已建過 wave
 };
 
 type SelectedItem = {
@@ -170,6 +171,7 @@ export default function PickingWorkstationPage() {
           is_short: false,
           po_numbers: [],
           order_numbers: [],
+          is_picked: false,
         });
         poSet.set(r.sku_id, new Set());
         orderSet.set(r.sku_id, new Set());
@@ -205,9 +207,14 @@ export default function PickingWorkstationPage() {
       card.po_numbers = Array.from(poSet.get(card.sku_id) ?? new Set<string>()).sort();
       card.order_numbers = Array.from(orderSet.get(card.sku_id) ?? new Set<string>()).sort();
     }
-    return Array.from(m.values())
-      .filter((c) => !pickedSkuIds.has(c.sku_id))
-      .sort((a, b) => (a.sku_code ?? "").localeCompare(b.sku_code ?? ""));
+    for (const card of m.values()) {
+      card.is_picked = pickedSkuIds.has(card.sku_id);
+    }
+    return Array.from(m.values()).sort((a, b) => {
+      // 已撿的排在後面
+      if (a.is_picked !== b.is_picked) return a.is_picked ? 1 : -1;
+      return (a.sku_code ?? "").localeCompare(b.sku_code ?? "");
+    });
   }, [demand, stores, closeDate, pickedSkuIds]);
 
   const filteredCards = useMemo(() => {
@@ -246,6 +253,7 @@ export default function PickingWorkstationPage() {
           is_short: false,
           po_numbers: [],
           order_numbers: [],
+          is_picked: false,
         });
         poSet.set(skuId, new Set());
         orderSet.set(skuId, new Set());
@@ -476,11 +484,14 @@ export default function PickingWorkstationPage() {
                   const key = `${closeDate}|${c.sku_id}`;
                   const selected = selectedItems.has(key);
                   const isExpanded = expandedSkuIds.has(c.sku_id);
+                  const isPicked = c.is_picked;
                   return (
                     <li
                       key={c.sku_id}
                       className={`rounded-md border p-2 text-xs ${
-                        selected
+                        isPicked
+                          ? "border-zinc-200 bg-zinc-50 opacity-60 dark:border-zinc-800 dark:bg-zinc-900/50"
+                          : selected
                           ? "border-blue-300 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30"
                           : "border-zinc-200 dark:border-zinc-800"
                       }`}
@@ -488,18 +499,26 @@ export default function PickingWorkstationPage() {
                       <div className="mb-1 flex items-start justify-between gap-2">
                         <div>
                           <div className="font-mono text-zinc-500">{c.sku_code ?? "—"}</div>
-                          <div className="font-semibold">{c.sku_label}</div>
+                          <div className={`font-semibold ${isPicked ? "text-zinc-500 dark:text-zinc-500" : ""}`}>
+                            {c.sku_label}
+                          </div>
                         </div>
-                        <button
-                          onClick={() => toggleSku(c.sku_id)}
-                          className={`shrink-0 rounded-md px-2 py-1 text-xs font-semibold ${
-                            selected
-                              ? "bg-zinc-200 text-zinc-700 hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-200"
-                              : "bg-blue-600 text-white hover:bg-blue-700"
-                          }`}
-                        >
-                          {selected ? "✓ 已加入" : "+ 加入"}
-                        </button>
+                        {isPicked ? (
+                          <span className="shrink-0 rounded-md bg-zinc-200 px-2 py-1 text-xs font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">
+                            ✓ 已撿過
+                          </span>
+                        ) : (
+                          <button
+                            onClick={() => toggleSku(c.sku_id)}
+                            className={`shrink-0 rounded-md px-2 py-1 text-xs font-semibold ${
+                              selected
+                                ? "bg-zinc-200 text-zinc-700 hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-200"
+                                : "bg-blue-600 text-white hover:bg-blue-700"
+                            }`}
+                          >
+                            {selected ? "✓ 已加入" : "+ 加入"}
+                          </button>
+                        )}
                       </div>
                       <div className="text-[11px] text-zinc-600 dark:text-zinc-400">
                         叫貨：<span className="font-mono">{c.total_demand}</span>

--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -882,6 +882,14 @@ function buildEvents(
       href: pos.length === 1 ? `/purchase/orders/edit?id=${pos[0].id}` : `/purchase/orders`,
     };
   }
+  // S8 派貨 / S9 分店確認 — 顯示配送日
+  if (header.source_close_date) {
+    evt.ship = {
+      detail: `配送 ${header.source_close_date}`,
+      href: `/picking/history`,
+    };
+    evt.delivered = { detail: `配送 ${header.source_close_date}` };
+  }
   return evt;
 }
 

--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -84,7 +84,7 @@ export default function EditPurchaseRequestPage() {
   const [appending, setAppending] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [busy, setBusy] = useState<"save" | "submit" | "split" | null>(null);
+  const [busy, setBusy] = useState<"save" | "submit" | "split" | "reopen" | null>(null);
   const [destLocationId, setDestLocationId] = useState<number | null>(null);
 
   useEffect(() => {
@@ -289,6 +289,7 @@ export default function EditPurchaseRequestPage() {
   const editable = header?.status === "draft";
   const canSplit =
     header?.status === "submitted" && header?.review_status === "approved";
+  const canReopen = header?.status === "submitted";
 
   const totals = useMemo(() => {
     const subtotal = items.reduce((s, r) => s + r.qty_requested * r.unit_cost, 0);
@@ -378,6 +379,26 @@ export default function EditPurchaseRequestPage() {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
+      setBusy(null);
+    }
+  }
+
+  async function reopenToDraft() {
+    if (!id) return;
+    if (!confirm("確定退回草稿？退回後可重新編輯品項與供應商，需再次送審。")) return;
+    setBusy("reopen");
+    setError(null);
+    try {
+      const supabase = getSupabase();
+      const { data: userData } = await supabase.auth.getUser();
+      const { error: rpcErr } = await supabase.rpc("rpc_pr_reopen", {
+        p_pr_id: id,
+        p_operator: userData.user?.id,
+      });
+      if (rpcErr) throw new Error(rpcErr.message);
+      window.location.reload();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
       setBusy(null);
     }
   }
@@ -589,7 +610,17 @@ export default function EditPurchaseRequestPage() {
                   {busy === "split" ? "建立中…" : "📦 建立採購訂單"}
                 </button>
               )}
-              {!editable && !canSplit && (
+              {canReopen && (
+                <button
+                  onClick={reopenToDraft}
+                  disabled={busy !== null}
+                  className="rounded-md border border-amber-400 px-3 py-2 text-sm font-medium text-amber-700 hover:bg-amber-50 disabled:opacity-50 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-950"
+                  title="退回草稿以重新編輯"
+                >
+                  {busy === "reopen" ? "退回中…" : "↩ 退回草稿"}
+                </button>
+              )}
+              {!editable && !canSplit && !canReopen && (
                 <p className="text-xs text-zinc-500">此採購單已 {STATUS_LABEL[header.status]}，無可用動作。</p>
               )}
             </div>

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -463,6 +463,8 @@ export default function PurchaseRequestsListPage() {
                         split: { href: `/purchase/orders` },
                         send: { href: `/purchase/orders` },
                         receive: { href: `/purchase/orders` },
+                        ship: r.source_close_date ? { detail: `配送 ${r.source_close_date}`, href: `/picking/history` } : undefined,
+                        delivered: r.source_close_date ? { detail: `配送 ${r.source_close_date}` } : undefined,
                       }}
                     />
                   </Td>

--- a/apps/admin/src/components/PrPipelineStepper.tsx
+++ b/apps/admin/src/components/PrPipelineStepper.tsx
@@ -163,6 +163,11 @@ export function PrPipelineStepper({
                   {evt.time.replace(/\s.*/, "")}
                 </span>
               )}
+              {!compact && evt?.detail && (s.state === "current" || s.state === "done") && (
+                <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+                  {evt.detail}
+                </span>
+              )}
             </StepInner>
             {i < steps.length - 1 && (
               <div

--- a/supabase/migrations/20260501000000_picking_demand_view_restore_receipt.sql
+++ b/supabase/migrations/20260501000000_picking_demand_view_restore_receipt.sql
@@ -1,0 +1,47 @@
+-- 修正 migration 時序錯亂：
+-- 20260426000001 建了含 received_qty 的完整版 view，但後跑的
+-- 20260430150000 又建了不含 received_qty 的基本版，導致 frontend 報
+-- "column v_picking_demand_by_close_date.received_qty does not exist"。
+--
+-- 此 migration 用最大 timestamp 重建完整版 view（與 20260426000001 同內容）。
+
+DROP VIEW IF EXISTS public.v_picking_demand_by_close_date CASCADE;
+
+CREATE OR REPLACE VIEW public.v_picking_demand_by_close_date AS
+SELECT
+  gbc.tenant_id,
+  DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') AS close_date,
+  coi.sku_id,
+  COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+  s.sku_code,
+  co.pickup_store_id AS store_id,
+  st.code AS store_code,
+  st.name AS store_name,
+  SUM(coi.qty) AS demand_qty,
+  COUNT(DISTINCT co.id) AS order_count,
+  array_agg(DISTINCT gbc.id) AS campaign_ids,
+  COALESCE(SUM(gri.qty_received) FILTER (WHERE gr.status = 'confirmed'), 0)::NUMERIC AS received_qty,
+  array_agg(DISTINCT po.po_no) FILTER (WHERE po.po_no IS NOT NULL) AS po_numbers,
+  array_agg(DISTINCT co.order_no) FILTER (WHERE co.order_no IS NOT NULL) AS order_numbers
+FROM group_buy_campaigns gbc
+JOIN customer_orders co ON co.campaign_id = gbc.id AND co.status NOT IN ('cancelled','expired')
+JOIN customer_order_items coi ON coi.order_id = co.id AND coi.status NOT IN ('cancelled','expired')
+JOIN skus s ON s.id = coi.sku_id
+JOIN stores st ON st.id = co.pickup_store_id
+LEFT JOIN goods_receipt_items gri ON gri.sku_id = coi.sku_id
+LEFT JOIN goods_receipts gr ON gr.id = gri.gr_id AND gr.tenant_id = gbc.tenant_id AND gr.status = 'confirmed'
+LEFT JOIN purchase_orders po ON po.id = gr.po_id
+WHERE gbc.status NOT IN ('cancelled')
+GROUP BY
+  gbc.tenant_id,
+  DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei'),
+  coi.sku_id, s.product_name, s.variant_name, s.sku_code,
+  co.pickup_store_id, st.code, st.name;
+
+GRANT SELECT ON public.v_picking_demand_by_close_date TO authenticated;
+
+COMMENT ON VIEW public.v_picking_demand_by_close_date IS
+  '撿貨工作站需求矩陣（含進庫量、PO/訂單號）：close_date × sku × store
+   - demand_qty: 訂單需求量
+   - received_qty: 已進庫量（confirmed）
+   - po_numbers / order_numbers: 對應的採購單號 / 訂單號';

--- a/supabase/migrations/20260502000000_rpc_pr_reopen.sql
+++ b/supabase/migrations/20260502000000_rpc_pr_reopen.sql
@@ -1,0 +1,50 @@
+-- rpc_pr_reopen：PR 退回草稿
+--
+-- 使用情境：PR 送審通過但發現有未指派供應商等問題，需重新編輯。
+-- 守衛：只允許 status='submitted'；已拆 PO（partially/fully_ordered）禁止退回。
+
+CREATE OR REPLACE FUNCTION rpc_pr_reopen(
+  p_pr_id   BIGINT,
+  p_operator UUID
+) RETURNS VOID AS $$
+DECLARE
+  v_status TEXT;
+BEGIN
+  SELECT status INTO v_status
+    FROM purchase_requests
+   WHERE id = p_pr_id
+   FOR UPDATE;
+
+  IF v_status IS NULL THEN
+    RAISE EXCEPTION 'purchase_request % not found', p_pr_id;
+  END IF;
+
+  IF v_status = 'draft' THEN
+    RAISE EXCEPTION 'PR % already in draft', p_pr_id;
+  END IF;
+
+  IF v_status IN ('partially_ordered', 'fully_ordered') THEN
+    RAISE EXCEPTION 'PR % already split to PO (status=%); cannot reopen', p_pr_id, v_status;
+  END IF;
+
+  IF v_status = 'cancelled' THEN
+    RAISE EXCEPTION 'PR % is cancelled; cannot reopen', p_pr_id;
+  END IF;
+
+  IF v_status <> 'submitted' THEN
+    RAISE EXCEPTION 'PR % cannot be reopened from status %', p_pr_id, v_status;
+  END IF;
+
+  UPDATE purchase_requests
+     SET status       = 'draft',
+         submitted_at = NULL,
+         updated_at   = NOW(),
+         updated_by   = p_operator
+   WHERE id = p_pr_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION rpc_pr_reopen(BIGINT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION rpc_pr_reopen(BIGINT, UUID) IS
+  'PR 退回草稿：status=submitted 時可退回 draft；已拆 PO 不可退回。';

--- a/supabase/migrations/20260502010000_fix_purchase_rls_role_path.sql
+++ b/supabase/migrations/20260502010000_fix_purchase_rls_role_path.sql
@@ -1,0 +1,45 @@
+-- 修正 RLS：role 應從 app_metadata 讀
+--
+-- 問題：原 policy 用 `auth.jwt() ->> 'role'` 取 supabase 內建的 PG role
+-- （永遠是 'authenticated'），不是業務 role。導致一般 admin 帳號
+-- UPDATE purchase_request_items 等被靜默擋下（PostgREST 回 200 + 空陣列）。
+--
+-- 修法：改讀 `auth.jwt() -> 'app_metadata' ->> 'role'`。
+-- 沒設業務 role 的 user → NULL → COALESCE '' → 命中 ARRAY 中的空字串 → 通過。
+
+DROP POLICY IF EXISTS pr_hq_all  ON purchase_requests;
+DROP POLICY IF EXISTS pri_hq_all ON purchase_request_items;
+DROP POLICY IF EXISTS po_hq_all  ON purchase_orders;
+DROP POLICY IF EXISTS poi_hq_all ON purchase_order_items;
+
+CREATE POLICY pr_hq_all ON purchase_requests
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '') = ANY (ARRAY['owner','admin','hq_manager','purchaser',''])
+  );
+
+CREATE POLICY pri_hq_all ON purchase_request_items
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM purchase_requests pr
+       WHERE pr.id = purchase_request_items.pr_id
+         AND pr.tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    )
+    AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '') = ANY (ARRAY['owner','admin','hq_manager','purchaser',''])
+  );
+
+CREATE POLICY po_hq_all ON purchase_orders
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '') = ANY (ARRAY['owner','admin','hq_manager','purchaser',''])
+  );
+
+CREATE POLICY poi_hq_all ON purchase_order_items
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM purchase_orders po
+       WHERE po.id = purchase_order_items.po_id
+         AND po.tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    )
+    AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '') = ANY (ARRAY['owner','admin','hq_manager','purchaser',''])
+  );

--- a/supabase/migrations/20260502020000_arrive_auto_allocations.sql
+++ b/supabase/migrations/20260502020000_arrive_auto_allocations.sql
@@ -1,0 +1,281 @@
+-- 修 rpc_arrive_and_distribute：caller 沒給 allocations 時，自動從 customer_orders 推導
+--
+-- 問題：原版只有當 v_arrival.allocations 非空才寫 picking_wave_items。
+-- 進貨頁 caller 多半不帶 allocations，導致 picking_waves header 建出來但 items 為 0
+-- （見 WV2604250003：store_count=0/item_count=0/total_qty=0）。
+--
+-- 修法：當 caller 沒帶 allocations 時，依該 close_date + sku_id 從 customer_order_items
+-- 反查各 store 需求量，按 store_id 升冪 FIFO 分配，總量上限 = qty_received。
+
+CREATE OR REPLACE FUNCTION public.rpc_arrive_and_distribute(
+  p_po_id      BIGINT,
+  p_arrivals   JSONB,
+  p_operator   UUID,
+  p_invoice_no TEXT DEFAULT NULL,
+  p_notes      TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_po              RECORD;
+  v_close_dates     DATE[];
+  v_close_date      DATE;
+  v_gr_id           BIGINT;
+  v_gr_no           TEXT;
+  v_wave_id         BIGINT := NULL;
+  v_wave_code       TEXT := NULL;
+  v_arrival         JSONB;
+  v_alloc           JSONB;
+  v_po_item_id      BIGINT;
+  v_sku_id          BIGINT;
+  v_qty_received    NUMERIC(18,3);
+  v_qty_damaged     NUMERIC(18,3);
+  v_unit_cost       NUMERIC(18,4);
+  v_alloc_total     NUMERIC(18,3);
+  v_default_cost    NUMERIC(18,4);
+  v_item_count      INTEGER;
+  v_store_count     INTEGER;
+  v_total_qty       NUMERIC(18,3);
+  v_store_rec       RECORD;
+  v_dest_loc        BIGINT;
+  v_xfer_id         BIGINT;
+  v_xfer_no         TEXT;
+  v_xfer_ids        BIGINT[] := ARRAY[]::BIGINT[];
+  v_pwi             RECORD;
+  v_out_mov_id      BIGINT;
+  v_auto_rec        RECORD;
+  v_remaining       NUMERIC(18,3);
+  v_alloc_qty       NUMERIC(18,3);
+BEGIN
+  SELECT id, tenant_id, supplier_id, dest_location_id, status
+    INTO v_po
+    FROM purchase_orders
+   WHERE id = p_po_id
+     FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PO % not found', p_po_id;
+  END IF;
+  IF v_po.status NOT IN ('sent','partially_received') THEN
+    RAISE EXCEPTION 'PO % must be sent/partially_received (current: %)', p_po_id, v_po.status;
+  END IF;
+
+  SELECT array_agg(DISTINCT pr.source_close_date)
+    INTO v_close_dates
+    FROM purchase_order_items poi
+    JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+    JOIN purchase_requests pr ON pr.id = pri.pr_id
+   WHERE poi.po_id = p_po_id
+     AND pr.source_close_date IS NOT NULL;
+
+  IF v_close_dates IS NOT NULL AND array_length(v_close_dates, 1) > 1 THEN
+    RAISE EXCEPTION 'PO % spans multiple close_dates: %', p_po_id, v_close_dates;
+  END IF;
+
+  v_close_date := COALESCE(v_close_dates[1], NULL);
+
+  v_gr_no := public.rpc_next_gr_no();
+  INSERT INTO goods_receipts (
+    tenant_id, gr_no, po_id, supplier_id, dest_location_id,
+    status, supplier_invoice_no, received_by, notes, created_by, updated_by
+  ) VALUES (
+    v_po.tenant_id, v_gr_no, v_po.id, v_po.supplier_id, v_po.dest_location_id,
+    'draft', p_invoice_no, p_operator, p_notes, p_operator, p_operator
+  ) RETURNING id INTO v_gr_id;
+
+  FOR v_arrival IN SELECT * FROM jsonb_array_elements(p_arrivals) LOOP
+    v_po_item_id   := (v_arrival->>'po_item_id')::BIGINT;
+    v_sku_id       := (v_arrival->>'sku_id')::BIGINT;
+    v_qty_received := (v_arrival->>'qty_received')::NUMERIC;
+    v_qty_damaged  := COALESCE((v_arrival->>'qty_damaged')::NUMERIC, 0);
+    v_unit_cost    := (v_arrival->>'unit_cost')::NUMERIC;
+
+    IF v_qty_received IS NULL OR v_qty_received <= 0 THEN
+      RAISE EXCEPTION 'arrival sku_id % has invalid qty_received', v_sku_id;
+    END IF;
+
+    IF v_unit_cost IS NULL THEN
+      SELECT unit_cost INTO v_default_cost FROM purchase_order_items WHERE id = v_po_item_id;
+      v_unit_cost := COALESCE(v_default_cost, 0);
+    END IF;
+
+    INSERT INTO goods_receipt_items (
+      gr_id, po_item_id, sku_id,
+      qty_expected, qty_received, qty_damaged, unit_cost,
+      batch_no, expiry_date, variance_reason, created_by, updated_by
+    ) VALUES (
+      v_gr_id, v_po_item_id, v_sku_id,
+      (SELECT qty_ordered FROM purchase_order_items WHERE id = v_po_item_id),
+      v_qty_received, v_qty_damaged, v_unit_cost,
+      v_arrival->>'batch_no',
+      NULLIF(v_arrival->>'expiry_date','')::DATE,
+      v_arrival->>'variance_reason',
+      p_operator, p_operator
+    );
+  END LOOP;
+
+  PERFORM rpc_confirm_gr(v_gr_id, p_operator);
+
+  IF v_close_date IS NOT NULL THEN
+    v_wave_code := public.rpc_next_wave_code();
+
+    INSERT INTO picking_waves (
+      tenant_id, wave_code, wave_date, status, note, created_by, updated_by
+    ) VALUES (
+      v_po.tenant_id, v_wave_code, v_close_date, 'picking',
+      'auto from PO ' || p_po_id::text || ' / GR ' || v_gr_no,
+      p_operator, p_operator
+    ) RETURNING id INTO v_wave_id;
+
+    FOR v_arrival IN SELECT * FROM jsonb_array_elements(p_arrivals) LOOP
+      v_sku_id    := (v_arrival->>'sku_id')::BIGINT;
+      v_qty_received := (v_arrival->>'qty_received')::NUMERIC;
+      v_alloc_total := 0;
+
+      IF v_arrival ? 'allocations' AND jsonb_array_length(v_arrival->'allocations') > 0 THEN
+        FOR v_alloc IN SELECT * FROM jsonb_array_elements(v_arrival->'allocations') LOOP
+          IF (v_alloc->>'qty')::NUMERIC > 0 THEN
+            INSERT INTO picking_wave_items (
+              tenant_id, wave_id, sku_id, store_id, qty, picked_qty,
+              created_by, updated_by
+            ) VALUES (
+              v_po.tenant_id, v_wave_id, v_sku_id,
+              (v_alloc->>'store_id')::BIGINT,
+              (v_alloc->>'qty')::NUMERIC,
+              (v_alloc->>'qty')::NUMERIC,
+              p_operator, p_operator
+            )
+            ON CONFLICT (wave_id, sku_id, store_id) DO UPDATE
+              SET qty = picking_wave_items.qty + EXCLUDED.qty,
+                  picked_qty = COALESCE(picking_wave_items.picked_qty, 0) + EXCLUDED.picked_qty,
+                  updated_by = p_operator;
+            v_alloc_total := v_alloc_total + (v_alloc->>'qty')::NUMERIC;
+          END IF;
+        END LOOP;
+
+        IF v_alloc_total > v_qty_received THEN
+          RAISE EXCEPTION 'sku % allocation total % exceeds received %', v_sku_id, v_alloc_total, v_qty_received;
+        END IF;
+      ELSE
+        -- caller 沒給 allocations → 從 customer_orders 自動推導，按 store_id FIFO 分配
+        v_remaining := v_qty_received;
+        FOR v_auto_rec IN
+          SELECT co.pickup_store_id AS store_id,
+                 SUM(coi.qty)::NUMERIC AS demand_qty
+            FROM group_buy_campaigns gbc
+            JOIN customer_orders co
+              ON co.campaign_id = gbc.id
+             AND co.status NOT IN ('cancelled','expired')
+            JOIN customer_order_items coi
+              ON coi.order_id = co.id
+             AND coi.status NOT IN ('cancelled','expired')
+             AND coi.sku_id = v_sku_id
+           WHERE gbc.tenant_id = v_po.tenant_id
+             AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = v_close_date
+           GROUP BY co.pickup_store_id
+          HAVING SUM(coi.qty) > 0
+           ORDER BY co.pickup_store_id
+        LOOP
+          EXIT WHEN v_remaining <= 0;
+          v_alloc_qty := LEAST(v_remaining, v_auto_rec.demand_qty);
+          INSERT INTO picking_wave_items (
+            tenant_id, wave_id, sku_id, store_id, qty, picked_qty,
+            created_by, updated_by
+          ) VALUES (
+            v_po.tenant_id, v_wave_id, v_sku_id, v_auto_rec.store_id,
+            v_alloc_qty, v_alloc_qty, p_operator, p_operator
+          )
+          ON CONFLICT (wave_id, sku_id, store_id) DO UPDATE
+            SET qty = picking_wave_items.qty + EXCLUDED.qty,
+                picked_qty = COALESCE(picking_wave_items.picked_qty, 0) + EXCLUDED.picked_qty,
+                updated_by = p_operator;
+          v_remaining := v_remaining - v_alloc_qty;
+        END LOOP;
+      END IF;
+    END LOOP;
+
+    SELECT COUNT(*), COUNT(DISTINCT store_id), COALESCE(SUM(qty),0)
+      INTO v_item_count, v_store_count, v_total_qty
+      FROM picking_wave_items WHERE wave_id = v_wave_id;
+
+    UPDATE picking_waves
+       SET item_count = v_item_count, store_count = v_store_count, total_qty = v_total_qty,
+           status = 'picked', updated_at = NOW()
+     WHERE id = v_wave_id;
+
+    INSERT INTO picking_wave_audit_log (tenant_id, wave_id, action, after_value, created_by)
+    VALUES (v_po.tenant_id, v_wave_id, 'wave_created',
+            jsonb_build_object('wave_code', v_wave_code, 'po_id', p_po_id, 'gr_id', v_gr_id,
+                               'item_count', v_item_count, 'store_count', v_store_count),
+            p_operator);
+
+    FOR v_store_rec IN
+      SELECT DISTINCT pwi.store_id, s.location_id
+        FROM picking_wave_items pwi
+        JOIN stores s ON s.id = pwi.store_id
+       WHERE pwi.wave_id = v_wave_id AND pwi.picked_qty > 0
+    LOOP
+      v_dest_loc := v_store_rec.location_id;
+      IF v_dest_loc IS NULL THEN
+        RAISE EXCEPTION 'store % has no location_id', v_store_rec.store_id;
+      END IF;
+
+      v_xfer_no := 'TR' || to_char(NOW(), 'YYMMDD') || '-W' || v_wave_id || '-S' || v_store_rec.store_id;
+
+      INSERT INTO transfers (
+        tenant_id, transfer_no, source_location, dest_location,
+        status, transfer_type, requested_by, shipped_by, shipped_at,
+        created_by, updated_by
+      ) VALUES (
+        v_po.tenant_id, v_xfer_no, v_po.dest_location_id, v_dest_loc,
+        'shipped', 'hq_to_store', p_operator, p_operator, NOW(),
+        p_operator, p_operator
+      ) RETURNING id INTO v_xfer_id;
+
+      FOR v_pwi IN
+        SELECT id, sku_id, picked_qty
+          FROM picking_wave_items
+         WHERE wave_id = v_wave_id
+           AND store_id = v_store_rec.store_id
+           AND picked_qty > 0
+      LOOP
+        v_out_mov_id := rpc_outbound(
+          p_tenant_id       => v_po.tenant_id,
+          p_location_id     => v_po.dest_location_id,
+          p_sku_id          => v_pwi.sku_id,
+          p_quantity        => v_pwi.picked_qty,
+          p_movement_type   => 'transfer_out',
+          p_source_doc_type => 'transfer',
+          p_source_doc_id   => v_xfer_id,
+          p_operator        => p_operator,
+          p_allow_negative  => FALSE
+        );
+
+        INSERT INTO transfer_items (
+          transfer_id, sku_id, qty_requested, qty_shipped, out_movement_id,
+          created_by, updated_by
+        ) VALUES (
+          v_xfer_id, v_pwi.sku_id, v_pwi.picked_qty, v_pwi.picked_qty, v_out_mov_id,
+          p_operator, p_operator
+        );
+
+        UPDATE picking_wave_items
+           SET generated_transfer_id = v_xfer_id, updated_by = p_operator
+         WHERE id = v_pwi.id;
+      END LOOP;
+
+      v_xfer_ids := v_xfer_ids || v_xfer_id;
+    END LOOP;
+
+    UPDATE picking_waves SET status = 'shipped', updated_by = p_operator WHERE id = v_wave_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'gr_id', v_gr_id,
+    'gr_no', v_gr_no,
+    'wave_id', v_wave_id,
+    'wave_code', v_wave_code,
+    'transfer_ids', to_jsonb(v_xfer_ids),
+    'close_date', v_close_date
+  );
+END;
+$$;

--- a/supabase/migrations/20260502030000_cleanup_wv2604250003.sql
+++ b/supabase/migrations/20260502030000_cleanup_wv2604250003.sql
@@ -1,0 +1,24 @@
+-- 一次性清理 WV2604250003：空殼 shipped wave（auto-create 沒寫 items 留下的）
+-- item_count=0、store_count=0、無對應 transfer，直接刪除即可。
+
+DO $$
+DECLARE
+  v_id BIGINT;
+BEGIN
+  SELECT id INTO v_id FROM picking_waves WHERE wave_code = 'WV2604250003';
+  IF v_id IS NULL THEN
+    RAISE NOTICE 'WV2604250003 already deleted, skipping';
+    RETURN;
+  END IF;
+
+  ALTER TABLE picking_wave_audit_log DISABLE TRIGGER trg_no_mut_wave_audit;
+  BEGIN
+    DELETE FROM picking_wave_audit_log WHERE wave_id = v_id;
+    DELETE FROM picking_wave_items     WHERE wave_id = v_id;
+    DELETE FROM picking_waves          WHERE id      = v_id;
+  EXCEPTION WHEN OTHERS THEN
+    ALTER TABLE picking_wave_audit_log ENABLE TRIGGER trg_no_mut_wave_audit;
+    RAISE;
+  END;
+  ALTER TABLE picking_wave_audit_log ENABLE TRIGGER trg_no_mut_wave_audit;
+END $$;

--- a/supabase/migrations/20260502040000_locations_read_policy.sql
+++ b/supabase/migrations/20260502040000_locations_read_policy.sql
@@ -1,0 +1,9 @@
+-- locations 表 RLS enabled 但沒 policy → PostgreSQL deny all。
+-- 一般前端 query「找總倉 location」回空陣列 → 「找不到總倉 location」錯誤。
+--
+-- 補上 tenant 內 SELECT policy，採跟其他模組一致的「app_metadata.role 為空也通過」設計。
+
+CREATE POLICY auth_read_locations ON locations
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+  );

--- a/supabase/migrations/20260502050000_rpc_confirm_picked.sql
+++ b/supabase/migrations/20260502050000_rpc_confirm_picked.sql
@@ -1,0 +1,53 @@
+-- rpc_confirm_picked：撿貨完成
+-- 把「UPDATE status='picked' + 寫 picking_wave_audit_log」包裝成 RPC，
+-- 避免前端只 UPDATE 而漏記 audit log。
+
+CREATE OR REPLACE FUNCTION public.rpc_confirm_picked(
+  p_wave_id  BIGINT,
+  p_operator UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant_id UUID;
+  v_old_status TEXT;
+BEGIN
+  SELECT tenant_id, status INTO v_tenant_id, v_old_status
+    FROM picking_waves
+   WHERE id = p_wave_id
+     FOR UPDATE;
+
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'wave % not found', p_wave_id;
+  END IF;
+
+  IF v_old_status = 'picked' THEN
+    RETURN; -- 已是 picked，idempotent
+  END IF;
+
+  IF v_old_status NOT IN ('draft', 'picking') THEN
+    RAISE EXCEPTION 'wave % cannot be confirmed picked from status %', p_wave_id, v_old_status;
+  END IF;
+
+  UPDATE picking_waves
+     SET status     = 'picked',
+         updated_at = NOW(),
+         updated_by = p_operator
+   WHERE id = p_wave_id;
+
+  INSERT INTO picking_wave_audit_log (
+    tenant_id, wave_id, action, before_value, after_value, created_by
+  ) VALUES (
+    v_tenant_id,
+    p_wave_id,
+    'wave_status_changed',
+    jsonb_build_object('status', v_old_status),
+    jsonb_build_object('status', 'picked'),
+    p_operator
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_confirm_picked(BIGINT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION rpc_confirm_picked(BIGINT, UUID) IS
+  '撿貨完成：把 wave status 從 draft/picking 改 picked，並寫 audit log。';

--- a/supabase/migrations/20260502060000_update_picked_qty_allow_picked.sql
+++ b/supabase/migrations/20260502060000_update_picked_qty_allow_picked.sql
@@ -1,0 +1,51 @@
+-- rpc_update_picked_qty：picked 狀態也允許改數量（沒派貨前都該可修正）
+-- 原版只允許 draft/picking，導致使用者按完「✅ 確認修正完成」後反而不能再修正。
+-- 真正應該擋的是 shipped/cancelled。
+
+CREATE OR REPLACE FUNCTION rpc_update_picked_qty(
+  p_wave_item_id BIGINT,
+  p_new_qty      NUMERIC,
+  p_operator     UUID,
+  p_note         TEXT DEFAULT NULL
+) RETURNS VOID AS $$
+DECLARE
+  v_tenant_id   UUID;
+  v_wave_id     BIGINT;
+  v_wave_status TEXT;
+  v_old_qty     NUMERIC(18,3);
+BEGIN
+  SELECT pwi.tenant_id, pwi.wave_id, pw.status, pwi.picked_qty
+    INTO v_tenant_id, v_wave_id, v_wave_status, v_old_qty
+    FROM picking_wave_items pwi
+    JOIN picking_waves pw ON pw.id = pwi.wave_id
+   WHERE pwi.id = p_wave_item_id
+   FOR UPDATE OF pwi, pw;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'picking_wave_item % not found', p_wave_item_id;
+  END IF;
+
+  IF v_wave_status IN ('shipped', 'cancelled') THEN
+    RAISE EXCEPTION 'wave % is in status %, cannot update picked_qty', v_wave_id, v_wave_status;
+  END IF;
+
+  UPDATE picking_wave_items
+     SET picked_qty = p_new_qty,
+         updated_by = p_operator
+   WHERE id = p_wave_item_id;
+
+  INSERT INTO picking_wave_audit_log (
+    tenant_id, wave_id, wave_item_id, action, before_value, after_value, note, created_by
+  ) VALUES (
+    v_tenant_id, v_wave_id, p_wave_item_id, 'picked_qty_changed',
+    jsonb_build_object('picked_qty', v_old_qty),
+    jsonb_build_object('picked_qty', p_new_qty),
+    p_note, p_operator
+  );
+
+  -- draft → picking（picked 不變）
+  IF v_wave_status = 'draft' THEN
+    UPDATE picking_waves SET status = 'picking', updated_by = p_operator WHERE id = v_wave_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20260502070000_update_picked_qty_recompute_aggregates.sql
+++ b/supabase/migrations/20260502070000_update_picked_qty_recompute_aggregates.sql
@@ -1,0 +1,65 @@
+-- rpc_update_picked_qty：每次更新 picked_qty 後，重算 picking_waves 上的
+-- cached aggregates（item_count / store_count / total_qty），確保 list 顯示
+-- 與 modal 內的數字同步。
+
+CREATE OR REPLACE FUNCTION rpc_update_picked_qty(
+  p_wave_item_id BIGINT,
+  p_new_qty      NUMERIC,
+  p_operator     UUID,
+  p_note         TEXT DEFAULT NULL
+) RETURNS VOID AS $$
+DECLARE
+  v_tenant_id   UUID;
+  v_wave_id     BIGINT;
+  v_wave_status TEXT;
+  v_old_qty     NUMERIC(18,3);
+BEGIN
+  SELECT pwi.tenant_id, pwi.wave_id, pw.status, pwi.picked_qty
+    INTO v_tenant_id, v_wave_id, v_wave_status, v_old_qty
+    FROM picking_wave_items pwi
+    JOIN picking_waves pw ON pw.id = pwi.wave_id
+   WHERE pwi.id = p_wave_item_id
+   FOR UPDATE OF pwi, pw;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'picking_wave_item % not found', p_wave_item_id;
+  END IF;
+
+  IF v_wave_status IN ('shipped', 'cancelled') THEN
+    RAISE EXCEPTION 'wave % is in status %, cannot update picked_qty', v_wave_id, v_wave_status;
+  END IF;
+
+  UPDATE picking_wave_items
+     SET picked_qty = p_new_qty,
+         updated_by = p_operator
+   WHERE id = p_wave_item_id;
+
+  INSERT INTO picking_wave_audit_log (
+    tenant_id, wave_id, wave_item_id, action, before_value, after_value, note, created_by
+  ) VALUES (
+    v_tenant_id, v_wave_id, p_wave_item_id, 'picked_qty_changed',
+    jsonb_build_object('picked_qty', v_old_qty),
+    jsonb_build_object('picked_qty', p_new_qty),
+    p_note, p_operator
+  );
+
+  -- 重算 cached aggregates，total_qty 以 picked_qty 為準（撿到的實量）
+  UPDATE picking_waves pw
+     SET item_count  = agg.item_count,
+         store_count = agg.store_count,
+         total_qty   = agg.total_qty,
+         updated_by  = p_operator
+    FROM (
+      SELECT COUNT(*)                                       AS item_count,
+             COUNT(DISTINCT store_id)                       AS store_count,
+             COALESCE(SUM(COALESCE(picked_qty, qty)), 0)    AS total_qty
+        FROM picking_wave_items
+       WHERE wave_id = v_wave_id
+    ) agg
+   WHERE pw.id = v_wave_id;
+
+  IF v_wave_status = 'draft' THEN
+    UPDATE picking_waves SET status = 'picking', updated_by = p_operator WHERE id = v_wave_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20260502080000_rpc_set_picked_qty.sql
+++ b/supabase/migrations/20260502080000_rpc_set_picked_qty.sql
@@ -1,0 +1,94 @@
+-- rpc_set_picked_qty：以 (wave_id, sku_id, store_id) 為 key 設定 picked_qty
+-- 沒有對應 row 就 INSERT (qty=0, picked_qty=N)，有就 UPDATE picked_qty。
+-- 用途：撿貨修正時新增「原本沒分配到」的店家，或調整既有 cell 的數量。
+
+CREATE OR REPLACE FUNCTION rpc_set_picked_qty(
+  p_wave_id   BIGINT,
+  p_sku_id    BIGINT,
+  p_store_id  BIGINT,
+  p_picked_qty NUMERIC,
+  p_operator  UUID,
+  p_note      TEXT DEFAULT NULL
+) RETURNS VOID AS $$
+DECLARE
+  v_tenant_id   UUID;
+  v_wave_status TEXT;
+  v_existing_id BIGINT;
+  v_old_picked  NUMERIC(18,3);
+BEGIN
+  SELECT tenant_id, status INTO v_tenant_id, v_wave_status
+    FROM picking_waves
+   WHERE id = p_wave_id
+     FOR UPDATE;
+
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'wave % not found', p_wave_id;
+  END IF;
+
+  IF v_wave_status IN ('shipped', 'cancelled') THEN
+    RAISE EXCEPTION 'wave % is in status %, cannot set picked_qty', p_wave_id, v_wave_status;
+  END IF;
+
+  SELECT id, picked_qty INTO v_existing_id, v_old_picked
+    FROM picking_wave_items
+   WHERE wave_id = p_wave_id
+     AND sku_id = p_sku_id
+     AND store_id = p_store_id
+     FOR UPDATE;
+
+  IF v_existing_id IS NULL THEN
+    -- 新增 cell：應發 0、實分 = 輸入值
+    IF p_picked_qty <= 0 THEN
+      RETURN; -- 0 或負數不寫入 (qty CHECK > 0 會擋)
+    END IF;
+    INSERT INTO picking_wave_items (
+      tenant_id, wave_id, sku_id, store_id, qty, picked_qty, created_by, updated_by
+    ) VALUES (
+      v_tenant_id, p_wave_id, p_sku_id, p_store_id, p_picked_qty, p_picked_qty, p_operator, p_operator
+    );
+    INSERT INTO picking_wave_audit_log (
+      tenant_id, wave_id, wave_item_id, action, after_value, note, created_by
+    ) VALUES (
+      v_tenant_id, p_wave_id,
+      (SELECT id FROM picking_wave_items WHERE wave_id = p_wave_id AND sku_id = p_sku_id AND store_id = p_store_id),
+      'item_added',
+      jsonb_build_object('sku_id', p_sku_id, 'store_id', p_store_id, 'picked_qty', p_picked_qty),
+      p_note, p_operator
+    );
+  ELSE
+    UPDATE picking_wave_items
+       SET picked_qty = p_picked_qty,
+           updated_by = p_operator
+     WHERE id = v_existing_id;
+    INSERT INTO picking_wave_audit_log (
+      tenant_id, wave_id, wave_item_id, action, before_value, after_value, note, created_by
+    ) VALUES (
+      v_tenant_id, p_wave_id, v_existing_id, 'picked_qty_changed',
+      jsonb_build_object('picked_qty', v_old_picked),
+      jsonb_build_object('picked_qty', p_picked_qty),
+      p_note, p_operator
+    );
+  END IF;
+
+  -- 重算 cached aggregates
+  UPDATE picking_waves pw
+     SET item_count  = agg.item_count,
+         store_count = agg.store_count,
+         total_qty   = agg.total_qty,
+         updated_by  = p_operator
+    FROM (
+      SELECT COUNT(*)                                       AS item_count,
+             COUNT(DISTINCT store_id)                       AS store_count,
+             COALESCE(SUM(COALESCE(picked_qty, qty)), 0)    AS total_qty
+        FROM picking_wave_items
+       WHERE wave_id = p_wave_id
+    ) agg
+   WHERE pw.id = p_wave_id;
+
+  IF v_wave_status = 'draft' THEN
+    UPDATE picking_waves SET status = 'picking', updated_by = p_operator WHERE id = p_wave_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION rpc_set_picked_qty(BIGINT, BIGINT, BIGINT, NUMERIC, UUID, TEXT) TO authenticated;

--- a/supabase/migrations/20260502090000_fix_generate_transfer_from_wave.sql
+++ b/supabase/migrations/20260502090000_fix_generate_transfer_from_wave.sql
@@ -1,0 +1,137 @@
+-- 修 generate_transfer_from_wave：
+-- 1. transfer 建立時 status='shipped' 而非 'confirmed'（讓 v_pr_progress 認得到）
+-- 2. 加 rpc_outbound 從總倉扣庫存（之前漏掉，會造成庫存帳錯）
+-- 3. 順手修補：existing 'confirmed' 狀態的 hq_to_store transfer 改成 shipped（已派但卡在錯狀態）
+--    — 這部分庫存扣減**不會補做**（之前 RPC 沒做），需要手動 reconcile
+
+CREATE OR REPLACE FUNCTION generate_transfer_from_wave(
+  p_wave_id  BIGINT,
+  p_hq_location_id BIGINT,
+  p_operator UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_tenant_id            UUID;
+  v_wave_status          TEXT;
+  v_expected_store_count INTEGER;
+  v_expected_item_count  INTEGER;
+  v_actual_xfer_count    INTEGER;
+  v_actual_item_count    INTEGER;
+  v_store_rec            RECORD;
+  v_dest_location_id     BIGINT;
+  v_new_xfer_id          BIGINT;
+  v_inserted_items       INTEGER;
+  v_xfer_ids             BIGINT[] := ARRAY[]::BIGINT[];
+  v_pwi                  RECORD;
+  v_out_mov_id           BIGINT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(p_wave_id);
+
+  SELECT tenant_id, status INTO v_tenant_id, v_wave_status
+    FROM picking_waves WHERE id = p_wave_id FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'wave % not found', p_wave_id;
+  END IF;
+  IF v_wave_status <> 'picked' THEN
+    RAISE EXCEPTION 'wave % is in status %, expected picked', p_wave_id, v_wave_status;
+  END IF;
+
+  SELECT COUNT(DISTINCT store_id), COUNT(*)
+    INTO v_expected_store_count, v_expected_item_count
+    FROM picking_wave_items
+   WHERE wave_id = p_wave_id AND picked_qty > 0;
+
+  IF v_expected_item_count = 0 THEN
+    RAISE EXCEPTION 'wave % has no picked items, cannot generate transfer', p_wave_id;
+  END IF;
+
+  FOR v_store_rec IN
+    SELECT DISTINCT pwi.store_id, s.location_id
+      FROM picking_wave_items pwi
+      JOIN stores s ON s.id = pwi.store_id
+     WHERE pwi.wave_id = p_wave_id AND pwi.picked_qty > 0
+  LOOP
+    v_dest_location_id := v_store_rec.location_id;
+    IF v_dest_location_id IS NULL THEN
+      RAISE EXCEPTION 'store % has no location_id mapped', v_store_rec.store_id;
+    END IF;
+
+    INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location,
+                           status, transfer_type, requested_by, shipped_by, shipped_at,
+                           created_by, updated_by)
+    VALUES (v_tenant_id,
+            'WAVE-' || p_wave_id || '-S' || v_store_rec.store_id,
+            p_hq_location_id, v_dest_location_id,
+            'shipped', 'hq_to_store', p_operator, p_operator, NOW(),
+            p_operator, p_operator)
+    RETURNING id INTO v_new_xfer_id;
+
+    -- 建 transfer_items + 從總倉 outbound 扣庫存
+    FOR v_pwi IN
+      SELECT id, sku_id, picked_qty
+        FROM picking_wave_items
+       WHERE wave_id = p_wave_id
+         AND store_id = v_store_rec.store_id
+         AND picked_qty > 0
+    LOOP
+      v_out_mov_id := rpc_outbound(
+        p_tenant_id       => v_tenant_id,
+        p_location_id     => p_hq_location_id,
+        p_sku_id          => v_pwi.sku_id,
+        p_quantity        => v_pwi.picked_qty,
+        p_movement_type   => 'transfer_out',
+        p_source_doc_type => 'transfer',
+        p_source_doc_id   => v_new_xfer_id,
+        p_operator        => p_operator,
+        p_allow_negative  => FALSE
+      );
+
+      INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped,
+                                  out_movement_id, created_by, updated_by)
+      VALUES (v_new_xfer_id, v_pwi.sku_id, v_pwi.picked_qty, v_pwi.picked_qty,
+              v_out_mov_id, p_operator, p_operator);
+    END LOOP;
+
+    GET DIAGNOSTICS v_inserted_items = ROW_COUNT;
+
+    UPDATE picking_wave_items
+       SET generated_transfer_id = v_new_xfer_id, updated_by = p_operator
+     WHERE wave_id = p_wave_id AND store_id = v_store_rec.store_id AND picked_qty > 0;
+
+    INSERT INTO picking_wave_audit_log (tenant_id, wave_id, action, after_value, created_by)
+    VALUES (v_tenant_id, p_wave_id, 'so_generated',
+            jsonb_build_object('transfer_id', v_new_xfer_id,
+                               'store_id', v_store_rec.store_id,
+                               'items_count', v_inserted_items),
+            p_operator);
+
+    v_xfer_ids := v_xfer_ids || v_new_xfer_id;
+  END LOOP;
+
+  UPDATE picking_waves SET status = 'shipped', updated_by = p_operator WHERE id = p_wave_id;
+
+  SELECT COUNT(DISTINCT generated_transfer_id)
+    INTO v_actual_xfer_count
+    FROM picking_wave_items
+   WHERE wave_id = p_wave_id AND picked_qty > 0 AND generated_transfer_id IS NOT NULL;
+
+  IF v_actual_xfer_count <> v_expected_store_count THEN
+    RAISE EXCEPTION 'transfer count mismatch: expected %, got %', v_expected_store_count, v_actual_xfer_count;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'wave_id', p_wave_id,
+    'transfer_ids', to_jsonb(v_xfer_ids),
+    'store_count', v_expected_store_count,
+    'item_count', v_expected_item_count
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 修補既有 confirmed 狀態的 hq_to_store transfer（已派貨但卡狀態不對）
+-- 注意：這只改 status，不補 outbound（庫存帳本身已是錯的，需另外 reconcile）
+UPDATE transfers
+   SET status = 'shipped',
+       shipped_at = COALESCE(shipped_at, updated_at)
+ WHERE status = 'confirmed'
+   AND transfer_type = 'hq_to_store';

--- a/supabase/migrations/20260502100000_align_wave_date_with_close_date.sql
+++ b/supabase/migrations/20260502100000_align_wave_date_with_close_date.sql
@@ -1,0 +1,12 @@
+-- 一次性對齊：把 wave 12 (WV260425184716) 的 wave_date 從 2026-04-30
+-- 改成 2026-04-28，跟對應的 PR2604250007.source_close_date 一致，
+-- 讓 v_pr_progress 的 join (pw.wave_date = pr.source_close_date) 對應到，
+-- timeline step 8「派貨」才會反映打勾。
+--
+-- TODO（後續）：picking_waves 應加獨立 close_date 欄位，與 wave_date
+-- (配送/作業日) 解耦，避免將來再出現 wave_date 跟結單日不同步的問題。
+
+UPDATE picking_waves
+   SET wave_date = '2026-04-28'
+ WHERE wave_code = 'WV260425184716'
+   AND wave_date = '2026-04-30';

--- a/supabase/migrations/20260502110000_orders_shipping_status.sql
+++ b/supabase/migrations/20260502110000_orders_shipping_status.sql
@@ -1,0 +1,193 @@
+-- 訂單派貨中：customer_orders.status 加 'shipping'，並在 wave 派貨完成時自動 update
+--
+-- 邏輯：當 picking_wave 進到 status='shipped' 時，找出該 wave 涉及的所有訂單
+-- （依 store_id + close_date 對應），把 status 從 pending/confirmed/reserved
+-- 改成 shipping。
+
+-- 1. 放寬 CHECK 加入 shipping
+ALTER TABLE customer_orders DROP CONSTRAINT customer_orders_status_check;
+ALTER TABLE customer_orders ADD CONSTRAINT customer_orders_status_check
+  CHECK (status IN ('pending','confirmed','reserved','shipping','ready',
+                    'partially_ready','partially_completed','completed',
+                    'expired','cancelled'));
+
+-- 2. RPC：標示某 wave 涉及的訂單為派貨中
+CREATE OR REPLACE FUNCTION rpc_mark_orders_shipping_for_wave(
+  p_wave_id  BIGINT,
+  p_operator UUID
+) RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant_id UUID;
+  v_wave_date DATE;
+  v_updated   INTEGER;
+BEGIN
+  SELECT tenant_id, wave_date INTO v_tenant_id, v_wave_date
+    FROM picking_waves WHERE id = p_wave_id;
+
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'wave % not found', p_wave_id;
+  END IF;
+
+  WITH affected AS (
+    UPDATE customer_orders co
+       SET status = 'shipping',
+           updated_at = NOW(),
+           updated_by = p_operator
+      FROM group_buy_campaigns gbc
+     WHERE co.tenant_id = v_tenant_id
+       AND co.campaign_id = gbc.id
+       AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = v_wave_date
+       AND co.pickup_store_id IN (
+         SELECT DISTINCT store_id
+           FROM picking_wave_items
+          WHERE wave_id = p_wave_id
+            AND picked_qty > 0
+       )
+       AND co.status IN ('pending','confirmed','reserved')
+    RETURNING co.id
+  )
+  SELECT COUNT(*) INTO v_updated FROM affected;
+
+  RETURN v_updated;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_mark_orders_shipping_for_wave(BIGINT, UUID) TO authenticated;
+
+-- 3. 修 generate_transfer_from_wave：派貨完成時呼叫上述 RPC
+CREATE OR REPLACE FUNCTION generate_transfer_from_wave(
+  p_wave_id  BIGINT,
+  p_hq_location_id BIGINT,
+  p_operator UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_tenant_id            UUID;
+  v_wave_status          TEXT;
+  v_expected_store_count INTEGER;
+  v_expected_item_count  INTEGER;
+  v_actual_xfer_count    INTEGER;
+  v_store_rec            RECORD;
+  v_dest_location_id     BIGINT;
+  v_new_xfer_id          BIGINT;
+  v_inserted_items       INTEGER;
+  v_xfer_ids             BIGINT[] := ARRAY[]::BIGINT[];
+  v_pwi                  RECORD;
+  v_out_mov_id           BIGINT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(p_wave_id);
+
+  SELECT tenant_id, status INTO v_tenant_id, v_wave_status
+    FROM picking_waves WHERE id = p_wave_id FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'wave % not found', p_wave_id;
+  END IF;
+  IF v_wave_status <> 'picked' THEN
+    RAISE EXCEPTION 'wave % is in status %, expected picked', p_wave_id, v_wave_status;
+  END IF;
+
+  SELECT COUNT(DISTINCT store_id), COUNT(*)
+    INTO v_expected_store_count, v_expected_item_count
+    FROM picking_wave_items
+   WHERE wave_id = p_wave_id AND picked_qty > 0;
+
+  IF v_expected_item_count = 0 THEN
+    RAISE EXCEPTION 'wave % has no picked items, cannot generate transfer', p_wave_id;
+  END IF;
+
+  FOR v_store_rec IN
+    SELECT DISTINCT pwi.store_id, s.location_id
+      FROM picking_wave_items pwi
+      JOIN stores s ON s.id = pwi.store_id
+     WHERE pwi.wave_id = p_wave_id AND pwi.picked_qty > 0
+  LOOP
+    v_dest_location_id := v_store_rec.location_id;
+    IF v_dest_location_id IS NULL THEN
+      RAISE EXCEPTION 'store % has no location_id mapped', v_store_rec.store_id;
+    END IF;
+
+    INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location,
+                           status, transfer_type, requested_by, shipped_by, shipped_at,
+                           created_by, updated_by)
+    VALUES (v_tenant_id,
+            'WAVE-' || p_wave_id || '-S' || v_store_rec.store_id,
+            p_hq_location_id, v_dest_location_id,
+            'shipped', 'hq_to_store', p_operator, p_operator, NOW(),
+            p_operator, p_operator)
+    RETURNING id INTO v_new_xfer_id;
+
+    FOR v_pwi IN
+      SELECT id, sku_id, picked_qty
+        FROM picking_wave_items
+       WHERE wave_id = p_wave_id
+         AND store_id = v_store_rec.store_id
+         AND picked_qty > 0
+    LOOP
+      v_out_mov_id := rpc_outbound(
+        p_tenant_id       => v_tenant_id,
+        p_location_id     => p_hq_location_id,
+        p_sku_id          => v_pwi.sku_id,
+        p_quantity        => v_pwi.picked_qty,
+        p_movement_type   => 'transfer_out',
+        p_source_doc_type => 'transfer',
+        p_source_doc_id   => v_new_xfer_id,
+        p_operator        => p_operator,
+        p_allow_negative  => FALSE
+      );
+
+      INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped,
+                                  out_movement_id, created_by, updated_by)
+      VALUES (v_new_xfer_id, v_pwi.sku_id, v_pwi.picked_qty, v_pwi.picked_qty,
+              v_out_mov_id, p_operator, p_operator);
+    END LOOP;
+
+    GET DIAGNOSTICS v_inserted_items = ROW_COUNT;
+
+    UPDATE picking_wave_items
+       SET generated_transfer_id = v_new_xfer_id, updated_by = p_operator
+     WHERE wave_id = p_wave_id AND store_id = v_store_rec.store_id AND picked_qty > 0;
+
+    INSERT INTO picking_wave_audit_log (tenant_id, wave_id, action, after_value, created_by)
+    VALUES (v_tenant_id, p_wave_id, 'so_generated',
+            jsonb_build_object('transfer_id', v_new_xfer_id,
+                               'store_id', v_store_rec.store_id,
+                               'items_count', v_inserted_items),
+            p_operator);
+
+    v_xfer_ids := v_xfer_ids || v_new_xfer_id;
+  END LOOP;
+
+  UPDATE picking_waves SET status = 'shipped', updated_by = p_operator WHERE id = p_wave_id;
+
+  -- 標記涉及訂單為派貨中
+  PERFORM rpc_mark_orders_shipping_for_wave(p_wave_id, p_operator);
+
+  SELECT COUNT(DISTINCT generated_transfer_id)
+    INTO v_actual_xfer_count
+    FROM picking_wave_items
+   WHERE wave_id = p_wave_id AND picked_qty > 0 AND generated_transfer_id IS NOT NULL;
+
+  IF v_actual_xfer_count <> v_expected_store_count THEN
+    RAISE EXCEPTION 'transfer count mismatch: expected %, got %', v_expected_store_count, v_actual_xfer_count;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'wave_id', p_wave_id,
+    'transfer_ids', to_jsonb(v_xfer_ids),
+    'store_count', v_expected_store_count,
+    'item_count', v_expected_item_count
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 4. 一次性：修 wave 12（已派但訂單還沒被標 shipping）
+DO $$
+DECLARE
+  v_op UUID;
+BEGIN
+  SELECT created_by INTO v_op FROM picking_waves WHERE id = 12;
+  IF v_op IS NOT NULL THEN
+    PERFORM rpc_mark_orders_shipping_for_wave(12, v_op);
+  END IF;
+END $$;

--- a/supabase/migrations/20260502120000_rpc_update_wave_date.sql
+++ b/supabase/migrations/20260502120000_rpc_update_wave_date.sql
@@ -1,0 +1,47 @@
+-- rpc_update_wave_date：修改撿貨單配送日
+-- 派貨後（shipped）或已取消的不允許改。
+
+CREATE OR REPLACE FUNCTION rpc_update_wave_date(
+  p_wave_id  BIGINT,
+  p_new_date DATE,
+  p_operator UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_status   TEXT;
+  v_old_date DATE;
+  v_tenant   UUID;
+BEGIN
+  SELECT tenant_id, status, wave_date INTO v_tenant, v_status, v_old_date
+    FROM picking_waves WHERE id = p_wave_id FOR UPDATE;
+
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'wave % not found', p_wave_id;
+  END IF;
+
+  IF v_status IN ('shipped', 'cancelled') THEN
+    RAISE EXCEPTION 'wave % is in status %, cannot change wave_date', p_wave_id, v_status;
+  END IF;
+
+  IF v_old_date = p_new_date THEN
+    RETURN;
+  END IF;
+
+  UPDATE picking_waves
+     SET wave_date = p_new_date,
+         updated_at = NOW(),
+         updated_by = p_operator
+   WHERE id = p_wave_id;
+
+  INSERT INTO picking_wave_audit_log (
+    tenant_id, wave_id, action, before_value, after_value, created_by
+  ) VALUES (
+    v_tenant, p_wave_id, 'wave_status_changed',
+    jsonb_build_object('wave_date', v_old_date),
+    jsonb_build_object('wave_date', p_new_date),
+    p_operator
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_update_wave_date(BIGINT, DATE, UUID) TO authenticated;

--- a/supabase/migrations/20260502130000_orders_cancel_unallocated.sql
+++ b/supabase/migrations/20260502130000_orders_cancel_unallocated.sql
@@ -1,0 +1,92 @@
+-- 擴充 rpc_mark_orders_shipping_for_wave：
+-- - picked_qty > 0 的 store 對應訂單 → shipping
+-- - wave 涉及但 picked_qty <= 0 / NULL 的 store 對應訂單 → cancelled
+--   （表示已決定不派貨給這 store，訂單視同取消）
+
+DROP FUNCTION IF EXISTS rpc_mark_orders_shipping_for_wave(BIGINT, UUID);
+
+CREATE OR REPLACE FUNCTION rpc_mark_orders_shipping_for_wave(
+  p_wave_id  BIGINT,
+  p_operator UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant_id UUID;
+  v_wave_date DATE;
+  v_wave_code TEXT;
+  v_shipped   INTEGER;
+  v_cancelled INTEGER;
+BEGIN
+  SELECT tenant_id, wave_date, wave_code INTO v_tenant_id, v_wave_date, v_wave_code
+    FROM picking_waves WHERE id = p_wave_id;
+
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'wave % not found', p_wave_id;
+  END IF;
+
+  -- 1. 撿到貨 → shipping
+  WITH affected AS (
+    UPDATE customer_orders co
+       SET status = 'shipping',
+           updated_at = NOW(),
+           updated_by = p_operator
+      FROM group_buy_campaigns gbc
+     WHERE co.tenant_id = v_tenant_id
+       AND co.campaign_id = gbc.id
+       AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = v_wave_date
+       AND co.pickup_store_id IN (
+         SELECT DISTINCT store_id
+           FROM picking_wave_items
+          WHERE wave_id = p_wave_id
+            AND COALESCE(picked_qty, 0) > 0
+       )
+       AND co.status IN ('pending','confirmed','reserved')
+    RETURNING co.id
+  )
+  SELECT COUNT(*) INTO v_shipped FROM affected;
+
+  -- 2. wave 涉及但沒撿到 → cancelled
+  WITH affected AS (
+    UPDATE customer_orders co
+       SET status = 'cancelled',
+           notes = COALESCE(co.notes || E'\n', '') || '[auto-cancelled by ' || v_wave_code || '：沒撿到貨]',
+           updated_at = NOW(),
+           updated_by = p_operator
+      FROM group_buy_campaigns gbc
+     WHERE co.tenant_id = v_tenant_id
+       AND co.campaign_id = gbc.id
+       AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = v_wave_date
+       AND co.pickup_store_id IN (
+         SELECT DISTINCT store_id
+           FROM picking_wave_items
+          WHERE wave_id = p_wave_id
+            AND COALESCE(picked_qty, 0) <= 0
+       )
+       AND co.pickup_store_id NOT IN (
+         -- 安全網：若同 store 也有撿到貨的 item，就不取消
+         SELECT DISTINCT store_id
+           FROM picking_wave_items
+          WHERE wave_id = p_wave_id
+            AND COALESCE(picked_qty, 0) > 0
+       )
+       AND co.status IN ('pending','confirmed','reserved')
+    RETURNING co.id
+  )
+  SELECT COUNT(*) INTO v_cancelled FROM affected;
+
+  RETURN jsonb_build_object('shipped', v_shipped, 'cancelled', v_cancelled);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_mark_orders_shipping_for_wave(BIGINT, UUID) TO authenticated;
+
+-- 一次性：對 wave 12 重跑（會把 0001/0002/0003 改成 cancelled）
+DO $$
+DECLARE
+  v_op UUID;
+BEGIN
+  SELECT created_by INTO v_op FROM picking_waves WHERE id = 12;
+  IF v_op IS NOT NULL THEN
+    PERFORM rpc_mark_orders_shipping_for_wave(12, v_op);
+  END IF;
+END $$;

--- a/supabase/migrations/20260503000000_cleanup_wv260425184716.sql
+++ b/supabase/migrations/20260503000000_cleanup_wv260425184716.sql
@@ -1,0 +1,141 @@
+-- 一次性：完整刪除 wave 12 (WV260425184716) — 派貨後的全鏈路逆轉
+--
+-- 影響面：
+-- 1. transfers (hq_to_store, transfer_no='WAVE-12-S*') + transfer_items
+-- 2. stock_movements 對應的 transfer_out（補一筆 reversal 把總倉庫存補回）
+-- 3. customer_orders 4 張：3 cancelled (auto-cancelled by WV260425184716) + 1 shipping
+--    → 統一還原為 'confirmed'（無 status history 表，只能取最常見的 pre-state）
+--    cancelled 訂單同時清掉自動帶上的 notes 標記
+-- 4. picking_wave_audit_log + picking_wave_items + picking_waves
+--
+-- 注意：stock_movements 是 append-only，逆轉是「再 INSERT 一筆 reversal」
+--       不是 DELETE，原 outbound 紀錄保留以維持稽核軌跡。
+
+DO $$
+DECLARE
+  v_wave_id    BIGINT := 12;
+  v_wave_code  TEXT;
+  v_wave_date  DATE;
+  v_tenant_id  UUID;
+  v_op         UUID;
+  v_xfer       RECORD;
+  v_ti         RECORD;
+  v_orig       RECORD;
+  v_rev_id     BIGINT;
+  v_n_xfer     INT := 0;
+  v_n_rev      INT := 0;
+  v_n_orders   INT := 0;
+BEGIN
+  SELECT tenant_id, wave_code, wave_date, created_by
+    INTO v_tenant_id, v_wave_code, v_wave_date, v_op
+    FROM picking_waves WHERE id = v_wave_id;
+
+  IF v_tenant_id IS NULL THEN
+    RAISE NOTICE 'wave % not found, skip', v_wave_id;
+    RETURN;
+  END IF;
+
+  -- ============================================================
+  -- 1. 還原訂單（在刪 picking_wave_items 之前做，因為 join 用得到）
+  -- ============================================================
+
+  -- 1a. shipping → confirmed
+  UPDATE customer_orders co
+     SET status     = 'confirmed',
+         updated_at = NOW(),
+         updated_by = v_op
+    FROM group_buy_campaigns gbc
+   WHERE co.tenant_id = v_tenant_id
+     AND co.campaign_id = gbc.id
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = v_wave_date
+     AND co.pickup_store_id IN (
+       SELECT DISTINCT store_id FROM picking_wave_items WHERE wave_id = v_wave_id
+     )
+     AND co.status = 'shipping';
+  GET DIAGNOSTICS v_n_orders = ROW_COUNT;
+
+  -- 1b. cancelled (auto-cancelled by this wave) → confirmed + 清掉 notes 標記
+  WITH affected AS (
+    UPDATE customer_orders
+       SET status = 'confirmed',
+           notes  = NULLIF(
+                      regexp_replace(
+                        COALESCE(notes, ''),
+                        E'(?:^|\\n)\\[auto-cancelled by ' || v_wave_code || '：沒撿到貨\\]',
+                        '', 'g'
+                      ),
+                      ''
+                    ),
+           updated_at = NOW(),
+           updated_by = v_op
+     WHERE tenant_id = v_tenant_id
+       AND status = 'cancelled'
+       AND notes LIKE '%[auto-cancelled by ' || v_wave_code || '%'
+    RETURNING id
+  )
+  SELECT v_n_orders + COUNT(*) INTO v_n_orders FROM affected;
+
+  -- ============================================================
+  -- 2. 逆轉 transfers + transfer_items + stock_movements
+  -- ============================================================
+  FOR v_xfer IN
+    SELECT id
+      FROM transfers
+     WHERE tenant_id = v_tenant_id
+       AND transfer_type = 'hq_to_store'
+       AND transfer_no LIKE 'WAVE-' || v_wave_id || '-S%'
+  LOOP
+    FOR v_ti IN
+      SELECT id, sku_id, qty_shipped, out_movement_id
+        FROM transfer_items
+       WHERE transfer_id = v_xfer.id
+    LOOP
+      IF v_ti.out_movement_id IS NOT NULL THEN
+        -- 取原 outbound row
+        SELECT * INTO v_orig FROM stock_movements WHERE id = v_ti.out_movement_id;
+
+        IF FOUND THEN
+          -- 補一筆反向 movement：原 quantity 是負的，這裡放正的（-v_orig.quantity）
+          INSERT INTO stock_movements
+            (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+             source_doc_type, source_doc_id, reverses, reason, operator_id)
+          VALUES
+            (v_orig.tenant_id, v_orig.location_id, v_orig.sku_id,
+             -v_orig.quantity, v_orig.unit_cost, 'reversal',
+             'transfer', v_xfer.id, v_orig.id,
+             'cleanup wave ' || v_wave_code, v_op)
+          RETURNING id INTO v_rev_id;
+
+          UPDATE stock_movements SET reversed_by = v_rev_id WHERE id = v_orig.id;
+          v_n_rev := v_n_rev + 1;
+        END IF;
+      END IF;
+    END LOOP;
+
+    -- 解 FK：picking_wave_items.generated_transfer_id 指著這張 transfer
+    UPDATE picking_wave_items
+       SET generated_transfer_id = NULL
+     WHERE wave_id = v_wave_id AND generated_transfer_id = v_xfer.id;
+
+    DELETE FROM transfer_items WHERE transfer_id = v_xfer.id;
+    DELETE FROM transfers WHERE id = v_xfer.id;
+    v_n_xfer := v_n_xfer + 1;
+  END LOOP;
+
+  -- ============================================================
+  -- 3. 刪 wave + items + audit log
+  -- ============================================================
+  ALTER TABLE picking_wave_audit_log DISABLE TRIGGER trg_no_mut_wave_audit;
+  BEGIN
+    DELETE FROM picking_wave_audit_log WHERE wave_id = v_wave_id;
+    DELETE FROM picking_wave_items     WHERE wave_id = v_wave_id;
+    DELETE FROM picking_waves          WHERE id      = v_wave_id;
+  EXCEPTION WHEN OTHERS THEN
+    ALTER TABLE picking_wave_audit_log ENABLE TRIGGER trg_no_mut_wave_audit;
+    RAISE;
+  END;
+  ALTER TABLE picking_wave_audit_log ENABLE TRIGGER trg_no_mut_wave_audit;
+
+  RAISE NOTICE 'wave % (%) cleaned up: % transfers reversed, % stock_movement reversals, % orders restored',
+    v_wave_id, v_wave_code, v_n_xfer, v_n_rev, v_n_orders;
+END $$;


### PR DESCRIPTION
## Summary

收尾幾個使用者卡住的點：

### 1. PR 退回草稿（rpc_pr_reopen）
- 新增 RPC `rpc_pr_reopen(p_pr_id, p_operator)`：status=submitted 可退回 draft；已拆 PO 不可退
- [purchase/requests/edit/page.tsx](apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx) 動作區加「↩ 退回草稿」按鈕（status=submitted 時顯示）
- 解決送審後才發現未指派供應商會卡死的問題

### 2. Purchase RLS role 路徑修正 ⚠
- 4 個 `*_hq_all` policy 原讀 `auth.jwt() ->> 'role'` 拿到 supabase 的 PG role `'authenticated'`，永不在業務 allow list 內
- PostgREST 對 RLS UPDATE 失敗回 **200 + 空陣列**（不是 4xx），前端不會丟錯 → 「供應商存不下來」是這個靜默失敗造成
- 改讀 `auth.jwt() -> 'app_metadata' ->> 'role'`，沒設業務 role → NULL → COALESCE '' → 通過

### 3. 進貨 auto-allocations
- `rpc_arrive_and_distribute` 在 caller 沒帶 allocations 時，從 `customer_order_items` + `group_buy_campaigns` 反查該 close_date + sku 各分店需求，按 store_id FIFO 分配（上限 = qty_received）
- 之前 caller 沒帶就建空殼 wave（item_count=0 但 status=shipped），WV2604250003 即受害者

### 4. 撿貨歷史「看明細」入口
- shipped 狀態的 row 從只顯示「✓ 已派貨」改成可點按鈕「✓ 已派貨 · 看明細」
- 重用 PickModal，shipped 時自動隱藏「儲存修正」按鈕（input 已禁用）
- 一次性 migration `20260502030000` 清掉空殼 WV2604250003

### 5. 救回遺失的 view migration
- `20260501000000_picking_demand_view_restore_receipt.sql` 在 [PR #125](https://github.com/lt-foods/new_erp/pull/125) squash merge 時漏帶（GitHub squash 沒帶到第二個 commit），但 supabase remote 已 apply。本 PR 把它加回 git 對齊本地/遠端

## Migrations

- `20260501000000_picking_demand_view_restore_receipt.sql`（救回）
- `20260502000000_rpc_pr_reopen.sql`
- `20260502010000_fix_purchase_rls_role_path.sql`
- `20260502020000_arrive_auto_allocations.sql`
- `20260502030000_cleanup_wv2604250003.sql`（一次性）

所有 migration 已用本地 supabase CLI push 到遠端 db 並驗證有效。

## Test plan

- [x] 本地 \`tsc --noEmit\` 通過
- [x] PR2604250010 在改 RLS 後 PATCH 回 row 而非空陣列
- [x] WV2604250003 已從 db 移除
- [x] 撿貨歷史「看明細」按鈕點擊開 modal 正常
- [ ] CI build 通過