### PR TITLE
feat(inventory): rpc_receive_transfer — 分店端收貨 (#127)

### DIFF
--- a/docs/TEST-rpc-receive-transfer.md
+++ b/docs/TEST-rpc-receive-transfer.md
@@ -1,0 +1,83 @@
+---
+title: TEST — rpc_receive_transfer
+module: Inventory / Transfer
+status: draft
+owner: alex.chen
+created: 2026-04-26
+---
+
+# 測試清單 — `rpc_receive_transfer`
+
+分店端確認收貨：把 `transfers.status='shipped'` 推進到 `'received'`、寫 `transfer_items.qty_received`、對 dest_location 做 `transfer_in` stock_movement。
+
+## Scope
+
+- Migration：`supabase/migrations/20260504000000_rpc_receive_transfer.sql`
+- 上游：`generate_transfer_from_wave` 產生的 `WAVE-{wave_id}-S{store_id}` TR (status='shipped')
+- 下游（本 PR 不含）：分店收貨 UI
+
+## Schema 假設（已存在、不改）
+
+- `transfers.status` enum 包含 `'received'`
+- `transfer_items.qty_received` / `in_movement_id` 欄位存在
+- `transfer_items.qty_variance` 是 `qty_received - qty_shipped` 的 generated stored column
+- `stock_movements.movement_type` 包含 `'transfer_in'`
+
+## 簽章
+
+```sql
+rpc_receive_transfer(
+  p_transfer_id BIGINT,
+  p_lines       JSONB,   -- [{transfer_item_id: BIGINT, qty_received: NUMERIC}, ...] 或 NULL = 全收 (qty_received = qty_shipped)
+  p_operator    UUID,
+  p_notes       TEXT DEFAULT NULL
+) RETURNS JSONB
+-- { transfer_id, items_received: int, total_qty_received: numeric, total_variance: numeric }
+```
+
+## 測試項目
+
+### A. Happy path — 全收
+
+- [ ] A1：`p_lines=NULL` 時，每行 `qty_received := qty_shipped`
+- [ ] A2：每行寫入 1 筆 `transfer_in` stock_movement 至 `dest_location`，`source_doc_type='transfer'`、`source_doc_id=transfer_id`
+- [ ] A3：`stock_movements.unit_cost` 沿用對應 `out_movement` 的 unit_cost（保持成本流）
+- [ ] A4：`transfer_items.in_movement_id` 寫入新 movement id
+- [ ] A5：`transfers.status='received'`、`received_by=p_operator`、`received_at=NOW()`
+- [ ] A6：dest_location 的 `stock_balances.on_hand` 增加對應 qty
+- [ ] A7：返回 JSONB 含 `items_received` / `total_qty_received` / `total_variance=0`
+
+### B. Happy path — 部分收（短收）
+
+- [ ] B1：`p_lines` 指定 `qty_received < qty_shipped` → 該行寫入該 qty
+- [ ] B2：`qty_variance` (generated) 自動算為負值
+- [ ] B3：`transfer_in` stock_movement 只進實收 qty
+- [ ] B4：status 仍轉 `'received'`（短收不卡單）
+- [ ] B5：返回 JSONB 中 `total_variance < 0`
+
+### C. 邊界 / 錯誤
+
+- [ ] C1：transfer 不存在 → `RAISE EXCEPTION 'transfer % not found'`
+- [ ] C2：transfer status ≠ 'shipped'（draft / received / cancelled）→ `RAISE EXCEPTION 'transfer % is in status %, expected shipped'`
+- [ ] C3：`qty_received < 0` → exception
+- [ ] C4：`qty_received > qty_shipped`（過收）→ exception（避免無中生有）
+- [ ] C5：`p_lines` 內含不屬於本 transfer 的 `transfer_item_id` → exception
+- [ ] C6：`p_lines` 漏掉某 transfer_item（不全列出）→ 該行視為全收 `qty_received = qty_shipped`（與 A1 一致的 default）
+- [ ] C7：concurrent 兩支 RPC 同 transfer_id → 第二支拿不到 lock，後執行者看到 status 已轉 received → exception（advisory lock 或 SELECT FOR UPDATE）
+
+### D. 與既有 wave 鏈路整合
+
+- [ ] D1：完整鏈路 wave open → picked → ship（generate transfers）→ rpc_receive_transfer → 庫存從 HQ 流到 store，`stock_movements` 兩筆對應（transfer_out @ HQ + transfer_in @ store）
+- [ ] D2：`v_pr_progress` view 不受影響（如果有用 transfers.status 的話）
+- [ ] D3：append-only 約束：transfer 已 received，再呼叫 rpc_receive_transfer → C2 擋住
+
+### E. RLS / 權限（後續 UI 才驗，本 RPC 是 SECURITY DEFINER）
+
+- [ ] E1：RPC GRANT EXECUTE TO authenticated
+- [ ] E2：應用層由 UI 傳 p_operator（後續 admin / 店長 RLS 在 UI 層 / view 層處理）
+
+## 不在範圍
+
+- 短收處理流程（補單 / 退款 / claim 對 carrier）— 短收只記錄 variance，後續處理另案
+- 收貨 UI（下個 PR）
+- 月結算金流（PRD §3.5）— 那是另一條線

--- a/scripts/test-rpc-receive-transfer.sql
+++ b/scripts/test-rpc-receive-transfer.sql
@@ -1,0 +1,160 @@
+-- 測試 rpc_receive_transfer。整段在一個 transaction 裡、最後 ROLLBACK。
+-- 為了單一 prepared statement，全部包在一個 DO 區塊裡，最後 RAISE 'ROLLBACK_OK' 強迫整段回滾。
+DO $outer$
+DECLARE
+  v_tenant      UUID := '11111111-1111-1111-1111-111111111111';
+  v_op          UUID := '22222222-2222-2222-2222-222222222222';
+  v_src_loc     BIGINT;
+  v_dst_loc     BIGINT;
+  v_sku_a       BIGINT;
+  v_sku_b       BIGINT;
+  v_xfer_id     BIGINT;
+  v_item_a_id   BIGINT;
+  v_item_b_id   BIGINT;
+  v_out_a       BIGINT;
+  v_out_b       BIGINT;
+  v_result      JSONB;
+  v_status      TEXT;
+  v_qty_a       NUMERIC;
+  v_qty_b       NUMERIC;
+  v_var_a       NUMERIC;
+  v_in_mov_a    BIGINT;
+  v_in_mov_b    BIGINT;
+  v_in_qty      NUMERIC;
+  v_in_cost     NUMERIC;
+BEGIN
+  -- C1: not found
+  BEGIN
+    PERFORM rpc_receive_transfer(-99999, NULL, v_op, NULL);
+    RAISE EXCEPTION 'C1 FAILED: should have raised';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%not found%' THEN
+      RAISE NOTICE 'C1 PASS: %', SQLERRM;
+    ELSE RAISE; END IF;
+  END;
+
+  SELECT id INTO v_src_loc FROM locations ORDER BY id LIMIT 1;
+  SELECT id INTO v_dst_loc FROM locations WHERE id <> v_src_loc ORDER BY id LIMIT 1;
+  IF v_src_loc IS NULL OR v_dst_loc IS NULL THEN
+    RAISE EXCEPTION 'need at least 2 locations';
+  END IF;
+
+  SELECT id INTO v_sku_a FROM skus ORDER BY id LIMIT 1;
+  SELECT id INTO v_sku_b FROM skus WHERE id <> v_sku_a ORDER BY id LIMIT 1;
+  IF v_sku_a IS NULL OR v_sku_b IS NULL THEN
+    RAISE EXCEPTION 'need at least 2 skus';
+  END IF;
+
+  INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location,
+                         status, transfer_type, requested_by, shipped_by, shipped_at,
+                         created_by, updated_by)
+  VALUES (v_tenant, 'TEST-RECV-' || EXTRACT(EPOCH FROM NOW())::TEXT,
+          v_src_loc, v_dst_loc, 'shipped', 'hq_to_store',
+          v_op, v_op, NOW(), v_op, v_op)
+  RETURNING id INTO v_xfer_id;
+
+  INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                                movement_type, source_doc_type, source_doc_id, operator_id)
+  VALUES (v_tenant, v_src_loc, v_sku_a, -10, 25.5, 'transfer_out', 'transfer', v_xfer_id, v_op)
+  RETURNING id INTO v_out_a;
+  INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                                movement_type, source_doc_type, source_doc_id, operator_id)
+  VALUES (v_tenant, v_src_loc, v_sku_b, -5, 100, 'transfer_out', 'transfer', v_xfer_id, v_op)
+  RETURNING id INTO v_out_b;
+
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped,
+                              out_movement_id, created_by, updated_by)
+  VALUES (v_xfer_id, v_sku_a, 10, 10, v_out_a, v_op, v_op)
+  RETURNING id INTO v_item_a_id;
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped,
+                              out_movement_id, created_by, updated_by)
+  VALUES (v_xfer_id, v_sku_b, 5, 5, v_out_b, v_op, v_op)
+  RETURNING id INTO v_item_b_id;
+
+  RAISE NOTICE 'fixture: transfer_id=% items=%,%', v_xfer_id, v_item_a_id, v_item_b_id;
+
+  -- C4: over-receipt
+  BEGIN
+    PERFORM rpc_receive_transfer(v_xfer_id,
+      jsonb_build_array(jsonb_build_object('transfer_item_id', v_item_a_id, 'qty_received', 999)),
+      v_op, NULL);
+    RAISE EXCEPTION 'C4 FAILED';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%over-receipt%' THEN RAISE NOTICE 'C4 PASS: %', SQLERRM;
+    ELSE RAISE; END IF;
+  END;
+
+  -- C3: negative
+  BEGIN
+    PERFORM rpc_receive_transfer(v_xfer_id,
+      jsonb_build_array(jsonb_build_object('transfer_item_id', v_item_a_id, 'qty_received', -1)),
+      v_op, NULL);
+    RAISE EXCEPTION 'C3 FAILED';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%>= 0%' THEN RAISE NOTICE 'C3 PASS: %', SQLERRM;
+    ELSE RAISE; END IF;
+  END;
+
+  -- C5: foreign item id
+  BEGIN
+    PERFORM rpc_receive_transfer(v_xfer_id,
+      jsonb_build_array(jsonb_build_object('transfer_item_id', -77777, 'qty_received', 1)),
+      v_op, NULL);
+    RAISE EXCEPTION 'C5 FAILED';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%not belonging%' THEN RAISE NOTICE 'C5 PASS: %', SQLERRM;
+    ELSE RAISE; END IF;
+  END;
+
+  -- B: A 短收 8/10，B 漏列 → 預設全收 5
+  v_result := rpc_receive_transfer(v_xfer_id,
+    jsonb_build_array(jsonb_build_object('transfer_item_id', v_item_a_id, 'qty_received', 8)),
+    v_op, 'broken 2 in transit');
+
+  RAISE NOTICE 'B result: %', v_result;
+  IF (v_result->>'items_received')::INT <> 2 OR
+     (v_result->>'total_qty_received')::NUMERIC <> 13 OR
+     (v_result->>'total_variance')::NUMERIC <> -2 THEN
+    RAISE EXCEPTION 'B FAILED: %', v_result;
+  END IF;
+  RAISE NOTICE 'B PASS';
+
+  SELECT status INTO v_status FROM transfers WHERE id = v_xfer_id;
+  IF v_status <> 'received' THEN RAISE EXCEPTION 'A5 FAILED: %', v_status; END IF;
+  RAISE NOTICE 'A5 PASS: status=received';
+
+  SELECT qty_received, qty_variance, in_movement_id
+    INTO v_qty_a, v_var_a, v_in_mov_a
+    FROM transfer_items WHERE id = v_item_a_id;
+  IF v_qty_a <> 8 OR v_var_a <> -2 OR v_in_mov_a IS NULL THEN
+    RAISE EXCEPTION 'B1/B2 FAILED: qty=% var=% mov=%', v_qty_a, v_var_a, v_in_mov_a;
+  END IF;
+  RAISE NOTICE 'B1/B2 PASS: A qty=8 var=-2';
+
+  SELECT qty_received, in_movement_id INTO v_qty_b, v_in_mov_b
+    FROM transfer_items WHERE id = v_item_b_id;
+  IF v_qty_b <> 5 OR v_in_mov_b IS NULL THEN
+    RAISE EXCEPTION 'C6 FAILED: qty_b=%', v_qty_b;
+  END IF;
+  RAISE NOTICE 'C6 PASS: missing line defaults full';
+
+  SELECT quantity, unit_cost INTO v_in_qty, v_in_cost
+    FROM stock_movements WHERE id = v_in_mov_a;
+  IF v_in_qty <> 8 OR v_in_cost <> 25.5 THEN
+    RAISE EXCEPTION 'A2/A3 FAILED: qty=% cost=%', v_in_qty, v_in_cost;
+  END IF;
+  RAISE NOTICE 'A2/A3 PASS: in_mov qty=+8 cost=25.5';
+
+  -- C2: re-receive
+  BEGIN
+    PERFORM rpc_receive_transfer(v_xfer_id, NULL, v_op, NULL);
+    RAISE EXCEPTION 'C2 FAILED';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%expected shipped%' THEN RAISE NOTICE 'C2 PASS: %', SQLERRM;
+    ELSE RAISE; END IF;
+  END;
+
+  RAISE NOTICE 'ALL TESTS PASSED — rolling back';
+  RAISE EXCEPTION 'ROLLBACK_OK';
+END
+$outer$;

--- a/supabase/migrations/20260504000000_rpc_receive_transfer.sql
+++ b/supabase/migrations/20260504000000_rpc_receive_transfer.sql
@@ -1,0 +1,150 @@
+-- rpc_receive_transfer：分店端確認收貨
+--
+-- 流程：
+--   transfers.status='shipped' → 'received'
+--   每行 transfer_items 寫入實收 qty + transfer_in stock_movement 至 dest_location
+--   short receipt（qty_received < qty_shipped）只記錄 variance、不卡單；over receipt 擋住
+--
+-- 上游：generate_transfer_from_wave 產生的 hq_to_store TR
+-- 下游：分店 inbox UI（後續 PR）
+
+CREATE OR REPLACE FUNCTION rpc_receive_transfer(
+  p_transfer_id BIGINT,
+  p_lines       JSONB,        -- [{transfer_item_id, qty_received}, ...] 或 NULL = 全收
+  p_operator    UUID,
+  p_notes       TEXT DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+  v_tenant_id        UUID;
+  v_status           TEXT;
+  v_dest_location    BIGINT;
+  v_existing_notes   TEXT;
+  v_item             RECORD;
+  v_qty_received     NUMERIC;
+  v_unit_cost        NUMERIC;
+  v_in_mov_id        BIGINT;
+  v_total_qty        NUMERIC := 0;
+  v_total_variance   NUMERIC := 0;
+  v_items_received   INTEGER := 0;
+  v_lines_consumed   INTEGER := 0;
+  v_lines_count      INTEGER;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('transfer:' || p_transfer_id));
+
+  SELECT tenant_id, status, dest_location, notes
+    INTO v_tenant_id, v_status, v_dest_location, v_existing_notes
+    FROM transfers
+   WHERE id = p_transfer_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transfer % not found', p_transfer_id;
+  END IF;
+
+  IF v_status <> 'shipped' THEN
+    RAISE EXCEPTION 'transfer % is in status %, expected shipped', p_transfer_id, v_status;
+  END IF;
+
+  IF p_lines IS NOT NULL THEN
+    v_lines_count := jsonb_array_length(p_lines);
+
+    -- p_lines 內所有 transfer_item_id 必須屬於本 transfer
+    IF EXISTS (
+      SELECT 1
+        FROM jsonb_array_elements(p_lines) AS l
+        LEFT JOIN transfer_items ti
+          ON ti.id = (l->>'transfer_item_id')::BIGINT
+         AND ti.transfer_id = p_transfer_id
+       WHERE ti.id IS NULL
+    ) THEN
+      RAISE EXCEPTION 'p_lines contains transfer_item_id not belonging to transfer %', p_transfer_id;
+    END IF;
+  END IF;
+
+  FOR v_item IN
+    SELECT ti.id, ti.sku_id, ti.qty_shipped, sm.unit_cost AS out_cost
+      FROM transfer_items ti
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE ti.transfer_id = p_transfer_id
+     ORDER BY ti.id
+  LOOP
+    -- 預設全收；若 p_lines 有指定該 item，採用指定值
+    v_qty_received := v_item.qty_shipped;
+
+    IF p_lines IS NOT NULL THEN
+      SELECT (l->>'qty_received')::NUMERIC
+        INTO v_qty_received
+        FROM jsonb_array_elements(p_lines) AS l
+       WHERE (l->>'transfer_item_id')::BIGINT = v_item.id
+       LIMIT 1;
+
+      IF FOUND THEN
+        v_lines_consumed := v_lines_consumed + 1;
+      ELSE
+        v_qty_received := v_item.qty_shipped;  -- 漏列 = 視為全收
+      END IF;
+    END IF;
+
+    IF v_qty_received IS NULL OR v_qty_received < 0 THEN
+      RAISE EXCEPTION 'transfer_item % qty_received must be >= 0, got %', v_item.id, v_qty_received;
+    END IF;
+    IF v_qty_received > v_item.qty_shipped THEN
+      RAISE EXCEPTION 'transfer_item % over-receipt: qty_received=% > qty_shipped=%',
+        v_item.id, v_qty_received, v_item.qty_shipped;
+    END IF;
+
+    IF v_qty_received > 0 THEN
+      v_unit_cost := COALESCE(ABS(v_item.out_cost), 0);
+
+      v_in_mov_id := rpc_inbound(
+        p_tenant_id       => v_tenant_id,
+        p_location_id     => v_dest_location,
+        p_sku_id          => v_item.sku_id,
+        p_quantity        => v_qty_received,
+        p_unit_cost       => v_unit_cost,
+        p_movement_type   => 'transfer_in',
+        p_source_doc_type => 'transfer',
+        p_source_doc_id   => p_transfer_id,
+        p_operator        => p_operator
+      );
+
+      UPDATE transfer_items
+         SET qty_received   = v_qty_received,
+             in_movement_id = v_in_mov_id,
+             updated_by     = p_operator
+       WHERE id = v_item.id;
+    ELSE
+      -- 0 收：仍標記 qty_received=0，no movement
+      UPDATE transfer_items
+         SET qty_received = 0,
+             updated_by   = p_operator
+       WHERE id = v_item.id;
+    END IF;
+
+    v_total_qty      := v_total_qty + v_qty_received;
+    v_total_variance := v_total_variance + (v_qty_received - v_item.qty_shipped);
+    v_items_received := v_items_received + 1;
+  END LOOP;
+
+  UPDATE transfers
+     SET status      = 'received',
+         received_by = p_operator,
+         received_at = NOW(),
+         notes       = CASE
+                         WHEN p_notes IS NULL OR p_notes = '' THEN v_existing_notes
+                         WHEN v_existing_notes IS NULL OR v_existing_notes = '' THEN p_notes
+                         ELSE v_existing_notes || E'\n' || p_notes
+                       END,
+         updated_by  = p_operator
+   WHERE id = p_transfer_id;
+
+  RETURN jsonb_build_object(
+    'transfer_id',        p_transfer_id,
+    'items_received',     v_items_received,
+    'total_qty_received', v_total_qty,
+    'total_variance',     v_total_variance
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION rpc_receive_transfer(BIGINT, JSONB, UUID, TEXT) TO authenticated;


### PR DESCRIPTION
## Summary

WV 派貨後 `generate_transfer_from_wave` 為每分店建 TR (`hq_to_store`, `shipped`)，總倉端已扣庫存，但**分店端沒有收貨流程**。本 PR 補 `rpc_receive_transfer`：

- `shipped → received` 狀態轉換
- 寫 `transfer_items.qty_received` + `in_movement_id`
- 對 `dest_location` 做 `transfer_in`，`unit_cost` 沿用對應 `out_movement`（保持成本流）
- 短收（qty_received < qty_shipped）只記 variance、不卡單
- 過收 / 重收 / negative qty 全擋
- `p_lines=NULL` 或漏列 = 預設全收
- `pg_advisory_xact_lock` 防 concurrent 重收

## Migration

- \`supabase/migrations/20260504000000_rpc_receive_transfer.sql\` ✅ pushed to remote

## Test plan

- [x] \`scripts/test-rpc-receive-transfer.sql\` 跑過 — C1-C6 + B + A2/A3/A5 全通過
- [x] DB 乾淨（測資全 ROLLBACK）
- [ ] 分店收貨 UI（後續 PR）
- [ ] 完整 wave → ship → receive E2E（等 UI 出來再驗）

Closes #127