### PR TITLE
feat(orders): 訂單明細 timeline + RPC 錯誤中文化

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "admin",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
@@ -209,10 +209,10 @@ export default function OrderEntryPage() {
     );
   }
 
-  // 全域快速鍵：Ctrl+N 加新顧客、Ctrl+S 送出
+  // 全域快速鍵：Alt+N 加新顧客（避開 Ctrl+N 被瀏覽器搶走）、Ctrl+S 送出
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "n") {
+      if (e.altKey && !e.ctrlKey && !e.metaKey && e.key.toLowerCase() === "n") {
         e.preventDefault();
         setEntries((es) => [...es, newEntry()]);
       }
@@ -286,7 +286,7 @@ export default function OrderEntryPage() {
           )}
         </div>
         <div className="flex items-center gap-2 text-xs text-zinc-500">
-          <kbd className="rounded border px-1">Ctrl+N</kbd> 新顧客
+          <kbd className="rounded border px-1">Alt+N</kbd> 新顧客
           <kbd className="rounded border px-1">Ctrl+S</kbd> 送出
         </div>
       </header>
@@ -340,7 +340,7 @@ export default function OrderEntryPage() {
             onClick={() => setEntries((es) => [...es, newEntry()])}
             className="rounded-md border border-dashed border-zinc-300 px-3 py-2 text-sm text-zinc-500 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900"
           >
-            + 新增顧客（Ctrl+N）
+            + 新增顧客（Alt+N）
           </button>
           <div className="flex justify-end">
             <button
@@ -682,6 +682,7 @@ function ItemEditorRow({
                     campaign_item_id: o.campaign_item_id,
                     sku_label: `${o.product_name}${o.variant_name ? ` / ${o.variant_name}` : ""} (${o.sku_code})`,
                     unit_price: Number(o.unit_price),
+                    qty: item.qty === "" ? "1" : item.qty,
                   });
                   setOpen(false);
                   setTerm("");

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -33,6 +33,7 @@ const NAV: NavGroup[] = [
       { href: "/picking/workstation", label: "撿貨工作站", match: /^\/picking\/workstation/ },
       { href: "/picking/history", label: "撿貨歷史", match: /^\/picking\/history/ },
       { href: "/transfers/inbox", label: "收貨待辦", match: /^\/transfers\/inbox/ },
+      { href: "/transfers", label: "調撥單列表", match: /^\/transfers$|^\/transfers\/?$/ },
     ],
   },
 ];

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -32,6 +32,7 @@ const NAV: NavGroup[] = [
       { href: "/purchase/orders", label: "採購訂單", match: /^\/purchase\/orders/ },
       { href: "/picking/workstation", label: "撿貨工作站", match: /^\/picking\/workstation/ },
       { href: "/picking/history", label: "撿貨歷史", match: /^\/picking\/history/ },
+      { href: "/transfers/inbox", label: "收貨待辦", match: /^\/transfers\/inbox/ },
     ],
   },
 ];

--- a/apps/admin/src/app/(protected)/picking/history/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/history/page.tsx
@@ -50,6 +50,20 @@ export default function PickingHistoryPage() {
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState<Wave | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
+  const [autoOpenWaveId, setAutoOpenWaveId] = useState<number | null>(() => {
+    if (typeof window === "undefined") return null;
+    const id = new URLSearchParams(window.location.search).get("wave");
+    return id ? Number(id) : null;
+  });
+
+  useEffect(() => {
+    if (autoOpenWaveId === null || waves === null) return;
+    const target = waves.find((w) => w.id === autoOpenWaveId);
+    if (target) {
+      setEditing(target);
+      setAutoOpenWaveId(null);
+    }
+  }, [waves, autoOpenWaveId]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/admin/src/app/(protected)/picking/history/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/history/page.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
 
 type Wave = {
   id: number;
@@ -108,7 +109,7 @@ export default function PickingHistoryPage() {
           setError(null);
         }
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        if (!cancelled) setError(translateRpcError(e));
       }
     })();
     return () => {
@@ -195,7 +196,7 @@ export default function PickingHistoryPage() {
                             if (er) throw new Error(er.message);
                             setReloadTick((t) => t + 1);
                           } catch (err) {
-                            alert(`配送日更新失敗：${err instanceof Error ? err.message : String(err)}`);
+                            alert(`配送日更新失敗：${translateRpcError(err)}`);
                           }
                         }}
                         className="rounded border border-zinc-300 bg-white px-1 py-0.5 text-xs dark:border-zinc-700 dark:bg-zinc-800"
@@ -255,7 +256,7 @@ export default function PickingHistoryPage() {
                             alert("已刪除");
                             setReloadTick((t) => t + 1);
                           } catch (err) {
-                            alert(`刪除失敗: ${err instanceof Error ? err.message : String(err)}`);
+                            alert(`刪除失敗: ${translateRpcError(err)}`);
                           }
                         }}
                         className="rounded-md bg-red-500 px-3 py-1 text-xs font-semibold text-white hover:bg-red-600"
@@ -362,7 +363,7 @@ function PickModal({
           .limit(1);
         if (!cancelled) setHqLocId(((loc as { id: number }[] | null) ?? [])[0]?.id ?? null);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        if (!cancelled) setError(translateRpcError(e));
       }
     })();
     return () => {
@@ -418,7 +419,7 @@ function PickModal({
       }
       onSubmitted();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setSubmitting(false);
     }
@@ -454,7 +455,7 @@ function PickModal({
       alert(`派貨完成！${wave.store_count} 張 transfer 已建立`);
       onSubmitted();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setShipping(false);
     }
@@ -476,7 +477,7 @@ function PickModal({
       if (e) throw new Error(e.message);
       setEffectiveStatus("picked");
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setSubmitting(false);
     }

--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
-import { PrPipelineStepper, type PrStepEvents, type POSummary } from "@/components/PrPipelineStepper";
+import { PrPipelineStepper, type PrStepEvents, type POSummary, type TransferSummary } from "@/components/PrPipelineStepper";
 
 type PRHeader = {
   id: number;
@@ -78,6 +78,7 @@ export default function EditPurchaseRequestPage() {
   const [items, setItems] = useState<ItemRow[]>([]);
   const [derivedPOs, setDerivedPOs] = useState<DerivedPO[]>([]);
   const [campaignFinalized, setCampaignFinalized] = useState<boolean>(false);
+  const [transferSummary, setTransferSummary] = useState<TransferSummary | undefined>(undefined);
   const [staffNames, setStaffNames] = useState<Map<string, string>>(new Map());
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
   const [missingCampaigns, setMissingCampaigns] = useState<{ id: number; name: string; campaign_no: string }[]>([]);
@@ -148,6 +149,22 @@ export default function EditPurchaseRequestPage() {
               .in("id", poIds)
               .order("id");
             setDerivedPOs((pos ?? []) as DerivedPO[]);
+          }
+        }
+
+        // 從 v_pr_progress 讀 transfer 進度（與 PR / PO list 共用同一個 source of truth）
+        {
+          const { data: prog } = await supabase
+            .from("v_pr_progress")
+            .select("transfer_total, transfer_shipped, transfer_delivered")
+            .eq("pr_id", id)
+            .maybeSingle();
+          if (!cancelled && prog) {
+            setTransferSummary({
+              total: Number(prog.transfer_total),
+              shipped: Number(prog.transfer_shipped),
+              delivered: Number(prog.transfer_delivered),
+            });
           }
         }
 
@@ -538,6 +555,7 @@ export default function EditPurchaseRequestPage() {
           reviewStatus={header.review_status}
           events={buildEvents(header, derivedPOs, staffNames)}
           poSummary={computePOSummary(derivedPOs)}
+          transferSummary={transferSummary}
           campaignFinalized={campaignFinalized}
         />
       </div>

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -52,6 +52,7 @@ export default function PurchaseRequestsListPage() {
     Map<number, {
       po_total: number; po_sent: number; po_received_fully: number;
       transfer_total: number; transfer_shipped: number; transfer_delivered: number;
+      item_count: number; unassigned_supplier_count: number;
       all_campaigns_finalized: boolean;
     }>
   >(new Map());
@@ -84,7 +85,7 @@ export default function PurchaseRequestsListPage() {
         if (ids.length) {
           const { data: prog } = await getSupabase()
             .from("v_pr_progress")
-            .select("pr_id, po_total, po_sent, po_received_fully, transfer_total, transfer_shipped, transfer_delivered, all_campaigns_finalized")
+            .select("pr_id, po_total, po_sent, po_received_fully, transfer_total, transfer_shipped, transfer_delivered, item_count, unassigned_supplier_count, all_campaigns_finalized")
             .in("pr_id", ids);
           if (!cancelled) {
             const m = new Map<
@@ -92,6 +93,7 @@ export default function PurchaseRequestsListPage() {
               {
                 po_total: number; po_sent: number; po_received_fully: number;
                 transfer_total: number; transfer_shipped: number; transfer_delivered: number;
+                item_count: number; unassigned_supplier_count: number;
                 all_campaigns_finalized: boolean;
               }
             >();
@@ -103,6 +105,8 @@ export default function PurchaseRequestsListPage() {
               transfer_total: number;
               transfer_shipped: number;
               transfer_delivered: number;
+              item_count: number;
+              unassigned_supplier_count: number;
               all_campaigns_finalized: boolean;
             };
             for (const p of (prog as ProgRow[] | null) ?? []) {
@@ -113,6 +117,8 @@ export default function PurchaseRequestsListPage() {
                 transfer_total: Number(p.transfer_total),
                 transfer_shipped: Number(p.transfer_shipped),
                 transfer_delivered: Number(p.transfer_delivered),
+                item_count: Number(p.item_count),
+                unassigned_supplier_count: Number(p.unassigned_supplier_count),
                 all_campaigns_finalized: !!p.all_campaigns_finalized,
               });
             }
@@ -367,6 +373,7 @@ export default function PurchaseRequestsListPage() {
               <Th>結單日</Th>
               <Th>狀態</Th>
               <Th>審核</Th>
+              <Th className="text-right">品項</Th>
               <Th className="text-right">總金額</Th>
               <Th className="text-right">更新</Th>
               <Th></Th>
@@ -376,13 +383,13 @@ export default function PurchaseRequestsListPage() {
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
               <tr>
-                <td colSpan={9} className="p-3 text-center text-zinc-500">
+                <td colSpan={10} className="p-3 text-center text-zinc-500">
                   載入中…
                 </td>
               </tr>
             ) : rows.length === 0 ? (
               <tr>
-                <td colSpan={9} className="p-6 text-center text-zinc-500">
+                <td colSpan={10} className="p-6 text-center text-zinc-500">
                   尚無採購單
                 </td>
               </tr>
@@ -410,6 +417,25 @@ export default function PurchaseRequestsListPage() {
                       kind="review"
                       status={r.review_status}
                     />
+                  </Td>
+                  <Td className="text-right text-xs">
+                    {(() => {
+                      const p = progressById.get(r.id);
+                      if (!p) return <span className="text-zinc-400">—</span>;
+                      return (
+                        <span className="font-mono">
+                          {p.item_count}
+                          {p.unassigned_supplier_count > 0 && (
+                            <span
+                              className="ml-1 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                              title="未指派供應商"
+                            >
+                              {p.unassigned_supplier_count} 待指派
+                            </span>
+                          )}
+                        </span>
+                      );
+                    })()}
                   </Td>
                   <Td className="text-right font-mono">${Number(r.total_amount).toFixed(0)}</Td>
                   <Td className="text-right text-xs text-zinc-500">

--- a/apps/admin/src/app/(protected)/transfers/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/inbox/page.tsx
@@ -1,0 +1,717 @@
+"use client";
+
+import { Fragment, useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+
+type Transfer = {
+  id: number;
+  transfer_no: string;
+  source_location: number;
+  dest_location: number;
+  status: string;
+  transfer_type: string;
+  shipped_at: string | null;
+  received_at: string | null;
+  notes: string | null;
+};
+
+type TransferItem = {
+  id: number;
+  transfer_id: number;
+  sku_id: number;
+  qty_requested: number;
+  qty_shipped: number;
+  qty_received: number;
+};
+
+type Location = { id: number; name: string };
+type Sku = {
+  id: number;
+  sku_code: string | null;
+  product_name: string | null;
+  variant_name: string | null;
+};
+
+type Wave = { id: number; wave_code: string; wave_date: string; created_at: string };
+
+const TYPE_LABEL: Record<string, string> = {
+  hq_to_store: "總倉配送",
+  store_to_store: "店轉店",
+  return_to_hq: "退回龍潭",
+};
+
+function parseWaveId(transferNo: string): number | null {
+  const m = /^WAVE-(\d+)-S\d+$/.exec(transferNo);
+  return m ? Number(m[1]) : null;
+}
+
+export default function TransfersInboxPage() {
+  const [transfers, setTransfers] = useState<Transfer[] | null>(null);
+  const [locations, setLocations] = useState<Map<number, string>>(new Map());
+  const [waves, setWaves] = useState<Map<number, Wave>>(new Map());
+  const [error, setError] = useState<string | null>(null);
+  const [reloadTick, setReloadTick] = useState(0);
+  const [opening, setOpening] = useState<Transfer | null>(null);
+  const [locationFilter, setLocationFilter] = useState<number | "all">("all");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data, error: e } = await sb
+          .from("transfers")
+          .select(
+            "id, transfer_no, source_location, dest_location, status, transfer_type, shipped_at, received_at, notes",
+          )
+          .in("status", ["shipped", "received"])
+          .order("shipped_at", { ascending: false })
+          .limit(100);
+        if (e) throw new Error(e.message);
+        const rows = (data as Transfer[] | null) ?? [];
+
+        const locIds = Array.from(
+          new Set(rows.flatMap((r) => [r.source_location, r.dest_location])),
+        );
+        const locMap = new Map<number, string>();
+        if (locIds.length > 0) {
+          const { data: locs } = await sb
+            .from("locations")
+            .select("id, name")
+            .in("id", locIds);
+          for (const l of (locs as Location[] | null) ?? []) {
+            locMap.set(l.id, l.name);
+          }
+        }
+
+        const waveIds = Array.from(
+          new Set(rows.map((r) => parseWaveId(r.transfer_no)).filter((x): x is number => x !== null)),
+        );
+        const waveMap = new Map<number, Wave>();
+        if (waveIds.length > 0) {
+          const { data: ws } = await sb
+            .from("picking_waves")
+            .select("id, wave_code, wave_date, created_at")
+            .in("id", waveIds);
+          for (const w of (ws as Wave[] | null) ?? []) waveMap.set(w.id, w);
+        }
+
+        if (!cancelled) {
+          setTransfers(rows);
+          setLocations(locMap);
+          setWaves(waveMap);
+          setError(null);
+          // Auto-expand groups that contain pending
+          const auto = new Set<string>();
+          for (const r of rows) {
+            if (r.status !== "shipped") continue;
+            const wid = parseWaveId(r.transfer_no);
+            auto.add(wid !== null ? `wave-${wid}` : "other");
+          }
+          setExpanded(auto);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadTick]);
+
+  const destOptions = useMemo(() => {
+    const set = new Map<number, string>();
+    for (const t of transfers ?? []) {
+      set.set(t.dest_location, locations.get(t.dest_location) ?? `#${t.dest_location}`);
+    }
+    return Array.from(set.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+  }, [transfers, locations]);
+
+  const filtered = useMemo(
+    () =>
+      (transfers ?? []).filter(
+        (t) => locationFilter === "all" || t.dest_location === locationFilter,
+      ),
+    [transfers, locationFilter],
+  );
+
+  const groups = useMemo(() => {
+    const map = new Map<string, { label: string; subLabel: string; transfers: Transfer[]; sortKey: number }>();
+    for (const t of filtered) {
+      const wid = parseWaveId(t.transfer_no);
+      const key = wid !== null ? `wave-${wid}` : "other";
+      let entry = map.get(key);
+      if (!entry) {
+        const w = wid !== null ? waves.get(wid) : undefined;
+        entry = {
+          label: w?.wave_code ?? (wid !== null ? `WAVE-${wid}` : "其他 transfer"),
+          subLabel: w ? `配送日 ${w.wave_date}` : "",
+          transfers: [],
+          sortKey: w ? new Date(w.created_at).getTime() : 0,
+        };
+        map.set(key, entry);
+      }
+      entry.transfers.push(t);
+    }
+    return Array.from(map.entries())
+      .sort((a, b) => b[1].sortKey - a[1].sortKey)
+      .map(([key, v]) => ({ key, ...v }));
+  }, [filtered, waves]);
+
+  function toggle(key: string) {
+    setExpanded((cur) => {
+      const next = new Set(cur);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">收貨</h1>
+          <p className="text-sm text-zinc-500">
+            {transfers === null
+              ? "載入中…"
+              : (() => {
+                  const pending = filtered.filter((t) => t.status === "shipped").length;
+                  const done = filtered.length - pending;
+                  return `待收 ${pending} · 已收 ${done}`;
+                })()}
+          </p>
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-zinc-500">分店</span>
+          <select
+            value={String(locationFilter)}
+            onChange={(e) =>
+              setLocationFilter(e.target.value === "all" ? "all" : Number(e.target.value))
+            }
+            className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="all">全部</option>
+            {destOptions.map(([id, name]) => (
+              <option key={id} value={id}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </header>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {transfers !== null && groups.length === 0 && (
+        <div className="rounded-md border border-zinc-200 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900">
+          沒有符合條件的 transfer。
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        {groups.map((g) => {
+          const open = expanded.has(g.key);
+          const pendingCount = g.transfers.filter((t) => t.status === "shipped").length;
+          const doneCount = g.transfers.length - pendingCount;
+          return (
+            <section
+              key={g.key}
+              className="overflow-hidden rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+            >
+              <button
+                onClick={() => toggle(g.key)}
+                className="flex w-full items-center justify-between gap-3 px-4 py-2 text-left hover:bg-zinc-50 dark:hover:bg-zinc-950"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-zinc-400">{open ? "▾" : "▸"}</span>
+                  <div>
+                    <div className="font-mono text-sm font-semibold">{g.label}</div>
+                    {g.subLabel && (
+                      <div className="text-[11px] text-zinc-500">{g.subLabel}</div>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 text-xs">
+                  {pendingCount > 0 && (
+                    <span className="rounded bg-amber-100 px-2 py-0.5 text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                      待收 {pendingCount}
+                    </span>
+                  )}
+                  {doneCount > 0 && (
+                    <span className="rounded bg-emerald-100 px-2 py-0.5 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+                      已收 {doneCount}
+                    </span>
+                  )}
+                </div>
+              </button>
+
+              {open && (
+                <div className="overflow-x-auto border-t border-zinc-200 dark:border-zinc-800">
+                  <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+                    <thead className="bg-zinc-50 dark:bg-zinc-950">
+                      <tr>
+                        <Th>分店</Th>
+                        <Th>單號</Th>
+                        <Th>類型</Th>
+                        <Th>派出時間</Th>
+                        <Th>狀態</Th>
+                        <Th></Th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                      {g.transfers.map((t) => {
+                        const isShipped = t.status === "shipped";
+                        return (
+                          <tr key={t.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-950">
+                            <td className="px-3 py-2 text-sm font-medium">
+                              {locations.get(t.dest_location) ?? `#${t.dest_location}`}
+                            </td>
+                            <td className="px-3 py-2 font-mono text-xs">{t.transfer_no}</td>
+                            <td className="px-3 py-2 text-xs text-zinc-600 dark:text-zinc-300">
+                              {TYPE_LABEL[t.transfer_type] ?? t.transfer_type}
+                            </td>
+                            <td className="px-3 py-2 text-xs text-zinc-600 dark:text-zinc-300">
+                              {t.shipped_at
+                                ? new Date(t.shipped_at).toLocaleString("zh-TW")
+                                : "—"}
+                            </td>
+                            <td className="px-3 py-2">
+                              {isShipped ? (
+                                <span className="inline-block rounded bg-amber-100 px-2 py-0.5 text-xs text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                                  待收
+                                </span>
+                              ) : (
+                                <span className="inline-block rounded bg-emerald-100 px-2 py-0.5 text-xs text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+                                  ✓ 已收
+                                  {t.received_at && (
+                                    <span className="ml-1">
+                                      {new Date(t.received_at).toLocaleString("zh-TW", {
+                                        dateStyle: "short",
+                                        timeStyle: "short",
+                                      })}
+                                    </span>
+                                  )}
+                                </span>
+                              )}
+                            </td>
+                            <td className="px-3 py-2 text-right">
+                              {isShipped ? (
+                                <button
+                                  onClick={() => setOpening(t)}
+                                  className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-semibold text-white hover:bg-emerald-700"
+                                >
+                                  收貨
+                                </button>
+                              ) : (
+                                <button
+                                  onClick={() => setOpening(t)}
+                                  className="rounded-md border border-zinc-300 px-3 py-1 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                                >
+                                  看明細
+                                </button>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </div>
+
+      {opening && (
+        <ReceiveModal
+          transfer={opening}
+          srcName={locations.get(opening.source_location) ?? `#${opening.source_location}`}
+          dstName={locations.get(opening.dest_location) ?? `#${opening.dest_location}`}
+          wave={(() => {
+            const wid = parseWaveId(opening.transfer_no);
+            return wid !== null ? waves.get(wid) ?? null : null;
+          })()}
+          onClose={() => setOpening(null)}
+          onSubmitted={() => {
+            setOpening(null);
+            setReloadTick((t) => t + 1);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function ReceiveModal({
+  transfer,
+  srcName,
+  dstName,
+  wave,
+  onClose,
+  onSubmitted,
+}: {
+  transfer: Transfer;
+  srcName: string;
+  dstName: string;
+  wave: Wave | null;
+  onClose: () => void;
+  onSubmitted: () => void;
+}) {
+  const [items, setItems] = useState<TransferItem[] | null>(null);
+  const [skus, setSkus] = useState<Map<number, Sku>>(new Map());
+  const [edits, setEdits] = useState<Map<number, string>>(new Map());
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const readOnly = transfer.status !== "shipped";
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data: itemRows, error: e } = await sb
+          .from("transfer_items")
+          .select("id, transfer_id, sku_id, qty_requested, qty_shipped, qty_received")
+          .eq("transfer_id", transfer.id)
+          .order("id");
+        if (e) throw new Error(e.message);
+        const list = ((itemRows as TransferItem[] | null) ?? []).map((r) => ({
+          ...r,
+          qty_requested: Number(r.qty_requested),
+          qty_shipped: Number(r.qty_shipped),
+          qty_received: Number(r.qty_received),
+        }));
+        if (cancelled) return;
+        setItems(list);
+
+        const skuIds = Array.from(new Set(list.map((r) => r.sku_id)));
+        if (skuIds.length > 0) {
+          const { data: skuRows } = await sb
+            .from("skus")
+            .select("id, sku_code, product_name, variant_name")
+            .in("id", skuIds);
+          const m = new Map<number, Sku>();
+          for (const s of (skuRows as Sku[] | null) ?? []) m.set(s.id, s);
+          if (!cancelled) setSkus(m);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [transfer.id]);
+
+  const totalShipped = useMemo(
+    () => (items ?? []).reduce((s, r) => s + r.qty_shipped, 0),
+    [items],
+  );
+  const totalReceived = useMemo(() => {
+    if (!items) return 0;
+    return items.reduce((s, r) => {
+      if (readOnly) return s + r.qty_received;
+      const e = edits.get(r.id);
+      const v = e !== undefined ? Number(e) : r.qty_shipped;
+      return s + (Number.isNaN(v) ? 0 : v);
+    }, 0);
+  }, [items, edits, readOnly]);
+  const variance = totalReceived - totalShipped;
+
+  function setQty(itemId: number, val: string) {
+    setEdits((cur) => {
+      const next = new Map(cur);
+      next.set(itemId, val);
+      return next;
+    });
+  }
+
+  async function submit() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes?.user?.id;
+      if (!operator) throw new Error("未登入");
+
+      const lines: Array<{ transfer_item_id: number; qty_received: number }> = [];
+      for (const it of items ?? []) {
+        const e = edits.get(it.id);
+        if (e === undefined) continue;
+        const v = Number(e);
+        if (Number.isNaN(v) || v < 0) {
+          throw new Error(`item ${it.id}: 數量無效`);
+        }
+        if (v > it.qty_shipped) {
+          throw new Error(`item ${it.id}: 收貨量不可大於出貨量 ${it.qty_shipped}`);
+        }
+        if (v !== it.qty_shipped) {
+          lines.push({ transfer_item_id: it.id, qty_received: v });
+        }
+      }
+
+      const { data, error: e } = await sb.rpc("rpc_receive_transfer", {
+        p_transfer_id: transfer.id,
+        p_lines: lines.length === 0 ? null : lines,
+        p_operator: operator,
+        p_notes: note.trim() === "" ? null : note.trim(),
+      });
+      if (e) throw new Error(e.message);
+
+      const r = data as
+        | {
+            transfer_id: number;
+            items_received: number;
+            total_qty_received: number;
+            total_variance: number;
+          }
+        | null;
+      const varNote =
+        r && Number(r.total_variance) < 0
+          ? `\n⚠ 短收 ${Math.abs(Number(r.total_variance))}`
+          : "";
+      alert(`收貨完成：${r?.items_received ?? 0} 行，實收合計 ${r?.total_qty_received ?? 0}${varNote}`);
+      onSubmitted();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-md bg-white shadow-xl dark:bg-zinc-900">
+        <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+          <div>
+            <h2 className="font-semibold">
+              收貨：<span className="font-mono">{transfer.transfer_no}</span>
+            </h2>
+            <div className="mt-0.5 text-xs text-zinc-500">
+              {srcName} → {dstName} · {TYPE_LABEL[transfer.transfer_type] ?? transfer.transfer_type}
+              {wave && (
+                <>
+                  {" · 來自撿貨單 "}
+                  <span className="font-mono">{wave.wave_code}</span>
+                </>
+              )}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            {readOnly ? (
+              <span className="self-center rounded bg-emerald-100 px-2 py-1 text-xs text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+                ✓ 已收貨
+              </span>
+            ) : (
+              <button
+                onClick={submit}
+                disabled={submitting || !items}
+                className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+              >
+                {submitting ? "送出中…" : "確認收貨"}
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              關閉
+            </button>
+          </div>
+        </div>
+
+        <Timeline transfer={transfer} wave={wave} />
+
+        {error && (
+          <div className="border-b border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        <div className="overflow-auto p-3">
+          {items === null ? (
+            <div className="p-6 text-center text-sm text-zinc-500">載入中…</div>
+          ) : (
+            <Fragment>
+              <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+                <thead className="sticky top-0 bg-zinc-50 dark:bg-zinc-900">
+                  <tr>
+                    <th className="px-3 py-2 text-left text-xs uppercase text-zinc-500">商品</th>
+                    <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">出貨</th>
+                    <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">實收</th>
+                    <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">差異</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                  {items.map((it) => {
+                    const sku = skus.get(it.sku_id);
+                    const editVal = edits.get(it.id);
+                    const cur = readOnly
+                      ? String(it.qty_received)
+                      : editVal !== undefined
+                      ? editVal
+                      : String(it.qty_shipped);
+                    const numCur = Number(cur);
+                    const diff = !Number.isNaN(numCur) ? numCur - it.qty_shipped : 0;
+                    const overflowing = !readOnly && numCur > it.qty_shipped;
+                    return (
+                      <tr key={it.id}>
+                        <td className="px-3 py-2">
+                          <div className="font-medium">{sku?.product_name ?? "—"}</div>
+                          <div className="text-xs text-zinc-500">
+                            {sku?.sku_code}
+                            {sku?.variant_name ? ` / ${sku.variant_name}` : ""}
+                          </div>
+                        </td>
+                        <td className="px-3 py-2 text-right font-mono text-zinc-600 dark:text-zinc-300">
+                          {it.qty_shipped}
+                        </td>
+                        <td className="px-3 py-2 text-right">
+                          <input
+                            inputMode="decimal"
+                            value={cur}
+                            disabled={readOnly}
+                            onChange={(e) => setQty(it.id, e.target.value)}
+                            className={`w-20 rounded-md border px-2 py-0.5 text-right font-mono text-sm font-semibold ${
+                              overflowing
+                                ? "border-red-400 bg-red-50 dark:bg-red-950"
+                                : editVal !== undefined
+                                ? "border-amber-400 bg-amber-50 dark:bg-amber-950"
+                                : "border-zinc-300 bg-white dark:border-zinc-700 dark:bg-zinc-800"
+                            } disabled:bg-zinc-100 disabled:opacity-70 dark:disabled:bg-zinc-800`}
+                          />
+                        </td>
+                        <td
+                          className={`px-3 py-2 text-right font-mono text-xs ${
+                            diff === 0
+                              ? "text-zinc-400"
+                              : diff < 0
+                              ? "text-red-600 dark:text-red-400"
+                              : "text-purple-600 dark:text-purple-400"
+                          }`}
+                        >
+                          {diff === 0 ? "—" : diff > 0 ? `+${diff}` : `${diff}`}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+                <tfoot className="bg-zinc-50 dark:bg-zinc-900">
+                  <tr>
+                    <td className="px-3 py-2 text-right text-xs font-semibold text-zinc-500">
+                      合計
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono font-semibold">
+                      {totalShipped}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono font-semibold">
+                      {totalReceived}
+                    </td>
+                    <td
+                      className={`px-3 py-2 text-right font-mono text-xs font-semibold ${
+                        variance === 0
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : variance < 0
+                          ? "text-red-600 dark:text-red-400"
+                          : "text-purple-600 dark:text-purple-400"
+                      }`}
+                    >
+                      {variance === 0
+                        ? "✓"
+                        : variance > 0
+                        ? `+${variance}`
+                        : `${variance}`}
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+
+              {!readOnly && (
+                <div className="mt-4">
+                  <label className="block text-xs text-zinc-500">備註（短收 / 異常說明）</label>
+                  <textarea
+                    value={note}
+                    onChange={(e) => setNote(e.target.value)}
+                    rows={2}
+                    className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                    placeholder="例：途中破損 2 件"
+                  />
+                </div>
+              )}
+              {readOnly && transfer.notes && (
+                <div className="mt-4 rounded-md border border-zinc-200 bg-zinc-50 p-2 text-xs text-zinc-600 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300">
+                  <div className="mb-1 text-zinc-500">備註</div>
+                  <div className="whitespace-pre-line">{transfer.notes}</div>
+                </div>
+              )}
+            </Fragment>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Timeline({ transfer, wave }: { transfer: Transfer; wave: Wave | null }) {
+  const steps: Array<{ label: string; ts: string | null; done: boolean }> = [
+    { label: "撿貨單建立", ts: wave?.created_at ?? null, done: !!wave },
+    { label: "派貨出倉", ts: transfer.shipped_at, done: !!transfer.shipped_at },
+    { label: "收貨", ts: transfer.received_at, done: transfer.status === "received" },
+  ];
+  return (
+    <div className="border-b border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
+      <ol className="flex items-center gap-1 overflow-x-auto text-xs">
+        {steps.map((s, i) => (
+          <Fragment key={s.label}>
+            <li className="flex min-w-0 items-center gap-2">
+              <span
+                className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${
+                  s.done
+                    ? "bg-emerald-600 text-white"
+                    : "bg-zinc-300 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300"
+                }`}
+              >
+                {s.done ? "✓" : i + 1}
+              </span>
+              <div className="min-w-0">
+                <div className={s.done ? "font-medium" : "text-zinc-500"}>{s.label}</div>
+                {s.ts && (
+                  <div className="text-[10px] text-zinc-500">
+                    {new Date(s.ts).toLocaleString("zh-TW")}
+                  </div>
+                )}
+              </div>
+            </li>
+            {i < steps.length - 1 && (
+              <li
+                aria-hidden
+                className={`h-[1px] flex-1 ${
+                  steps[i + 1].done
+                    ? "bg-emerald-400"
+                    : "bg-zinc-300 dark:bg-zinc-700"
+                }`}
+              />
+            )}
+          </Fragment>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function Th({ children }: { children?: React.ReactNode }) {
+  return (
+    <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">
+      {children}
+    </th>
+  );
+}

--- a/apps/admin/src/app/(protected)/transfers/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/inbox/page.tsx
@@ -1,49 +1,16 @@
 "use client";
 
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
-
-type Transfer = {
-  id: number;
-  transfer_no: string;
-  source_location: number;
-  dest_location: number;
-  status: string;
-  transfer_type: string;
-  shipped_at: string | null;
-  received_at: string | null;
-  notes: string | null;
-};
-
-type TransferItem = {
-  id: number;
-  transfer_id: number;
-  sku_id: number;
-  qty_requested: number;
-  qty_shipped: number;
-  qty_received: number;
-};
+import {
+  TransferReceiveModal,
+  TRANSFER_TYPE_LABEL,
+  parseWaveId,
+  type Transfer,
+  type Wave,
+} from "@/components/TransferReceiveModal";
 
 type Location = { id: number; name: string };
-type Sku = {
-  id: number;
-  sku_code: string | null;
-  product_name: string | null;
-  variant_name: string | null;
-};
-
-type Wave = { id: number; wave_code: string; wave_date: string; created_at: string };
-
-const TYPE_LABEL: Record<string, string> = {
-  hq_to_store: "總倉配送",
-  store_to_store: "店轉店",
-  return_to_hq: "退回龍潭",
-};
-
-function parseWaveId(transferNo: string): number | null {
-  const m = /^WAVE-(\d+)-S\d+$/.exec(transferNo);
-  return m ? Number(m[1]) : null;
-}
 
 export default function TransfersInboxPage() {
   const [transfers, setTransfers] = useState<Transfer[] | null>(null);
@@ -102,7 +69,6 @@ export default function TransfersInboxPage() {
           setLocations(locMap);
           setWaves(waveMap);
           setError(null);
-          // Auto-expand groups that contain pending
           const auto = new Set<string>();
           for (const r of rows) {
             if (r.status !== "shipped") continue;
@@ -137,7 +103,10 @@ export default function TransfersInboxPage() {
   );
 
   const groups = useMemo(() => {
-    const map = new Map<string, { label: string; subLabel: string; transfers: Transfer[]; sortKey: number }>();
+    const map = new Map<
+      string,
+      { label: string; subLabel: string; transfers: Transfer[]; sortKey: number }
+    >();
     for (const t of filtered) {
       const wid = parseWaveId(t.transfer_no);
       const key = wid !== null ? `wave-${wid}` : "other";
@@ -274,7 +243,7 @@ export default function TransfersInboxPage() {
                             </td>
                             <td className="px-3 py-2 font-mono text-xs">{t.transfer_no}</td>
                             <td className="px-3 py-2 text-xs text-zinc-600 dark:text-zinc-300">
-                              {TYPE_LABEL[t.transfer_type] ?? t.transfer_type}
+                              {TRANSFER_TYPE_LABEL[t.transfer_type] ?? t.transfer_type}
                             </td>
                             <td className="px-3 py-2 text-xs text-zinc-600 dark:text-zinc-300">
                               {t.shipped_at
@@ -330,7 +299,7 @@ export default function TransfersInboxPage() {
       </div>
 
       {opening && (
-        <ReceiveModal
+        <TransferReceiveModal
           transfer={opening}
           srcName={locations.get(opening.source_location) ?? `#${opening.source_location}`}
           dstName={locations.get(opening.dest_location) ?? `#${opening.dest_location}`}
@@ -345,365 +314,6 @@ export default function TransfersInboxPage() {
           }}
         />
       )}
-    </div>
-  );
-}
-
-function ReceiveModal({
-  transfer,
-  srcName,
-  dstName,
-  wave,
-  onClose,
-  onSubmitted,
-}: {
-  transfer: Transfer;
-  srcName: string;
-  dstName: string;
-  wave: Wave | null;
-  onClose: () => void;
-  onSubmitted: () => void;
-}) {
-  const [items, setItems] = useState<TransferItem[] | null>(null);
-  const [skus, setSkus] = useState<Map<number, Sku>>(new Map());
-  const [edits, setEdits] = useState<Map<number, string>>(new Map());
-  const [note, setNote] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const readOnly = transfer.status !== "shipped";
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const sb = getSupabase();
-        const { data: itemRows, error: e } = await sb
-          .from("transfer_items")
-          .select("id, transfer_id, sku_id, qty_requested, qty_shipped, qty_received")
-          .eq("transfer_id", transfer.id)
-          .order("id");
-        if (e) throw new Error(e.message);
-        const list = ((itemRows as TransferItem[] | null) ?? []).map((r) => ({
-          ...r,
-          qty_requested: Number(r.qty_requested),
-          qty_shipped: Number(r.qty_shipped),
-          qty_received: Number(r.qty_received),
-        }));
-        if (cancelled) return;
-        setItems(list);
-
-        const skuIds = Array.from(new Set(list.map((r) => r.sku_id)));
-        if (skuIds.length > 0) {
-          const { data: skuRows } = await sb
-            .from("skus")
-            .select("id, sku_code, product_name, variant_name")
-            .in("id", skuIds);
-          const m = new Map<number, Sku>();
-          for (const s of (skuRows as Sku[] | null) ?? []) m.set(s.id, s);
-          if (!cancelled) setSkus(m);
-        }
-      } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [transfer.id]);
-
-  const totalShipped = useMemo(
-    () => (items ?? []).reduce((s, r) => s + r.qty_shipped, 0),
-    [items],
-  );
-  const totalReceived = useMemo(() => {
-    if (!items) return 0;
-    return items.reduce((s, r) => {
-      if (readOnly) return s + r.qty_received;
-      const e = edits.get(r.id);
-      const v = e !== undefined ? Number(e) : r.qty_shipped;
-      return s + (Number.isNaN(v) ? 0 : v);
-    }, 0);
-  }, [items, edits, readOnly]);
-  const variance = totalReceived - totalShipped;
-
-  function setQty(itemId: number, val: string) {
-    setEdits((cur) => {
-      const next = new Map(cur);
-      next.set(itemId, val);
-      return next;
-    });
-  }
-
-  async function submit() {
-    setSubmitting(true);
-    setError(null);
-    try {
-      const sb = getSupabase();
-      const { data: userRes } = await sb.auth.getUser();
-      const operator = userRes?.user?.id;
-      if (!operator) throw new Error("未登入");
-
-      const lines: Array<{ transfer_item_id: number; qty_received: number }> = [];
-      for (const it of items ?? []) {
-        const e = edits.get(it.id);
-        if (e === undefined) continue;
-        const v = Number(e);
-        if (Number.isNaN(v) || v < 0) {
-          throw new Error(`item ${it.id}: 數量無效`);
-        }
-        if (v > it.qty_shipped) {
-          throw new Error(`item ${it.id}: 收貨量不可大於出貨量 ${it.qty_shipped}`);
-        }
-        if (v !== it.qty_shipped) {
-          lines.push({ transfer_item_id: it.id, qty_received: v });
-        }
-      }
-
-      const { data, error: e } = await sb.rpc("rpc_receive_transfer", {
-        p_transfer_id: transfer.id,
-        p_lines: lines.length === 0 ? null : lines,
-        p_operator: operator,
-        p_notes: note.trim() === "" ? null : note.trim(),
-      });
-      if (e) throw new Error(e.message);
-
-      const r = data as
-        | {
-            transfer_id: number;
-            items_received: number;
-            total_qty_received: number;
-            total_variance: number;
-          }
-        | null;
-      const varNote =
-        r && Number(r.total_variance) < 0
-          ? `\n⚠ 短收 ${Math.abs(Number(r.total_variance))}`
-          : "";
-      alert(`收貨完成：${r?.items_received ?? 0} 行，實收合計 ${r?.total_qty_received ?? 0}${varNote}`);
-      onSubmitted();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-md bg-white shadow-xl dark:bg-zinc-900">
-        <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
-          <div>
-            <h2 className="font-semibold">
-              收貨：<span className="font-mono">{transfer.transfer_no}</span>
-            </h2>
-            <div className="mt-0.5 text-xs text-zinc-500">
-              {srcName} → {dstName} · {TYPE_LABEL[transfer.transfer_type] ?? transfer.transfer_type}
-              {wave && (
-                <>
-                  {" · 來自撿貨單 "}
-                  <span className="font-mono">{wave.wave_code}</span>
-                </>
-              )}
-            </div>
-          </div>
-          <div className="flex gap-2">
-            {readOnly ? (
-              <span className="self-center rounded bg-emerald-100 px-2 py-1 text-xs text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
-                ✓ 已收貨
-              </span>
-            ) : (
-              <button
-                onClick={submit}
-                disabled={submitting || !items}
-                className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
-              >
-                {submitting ? "送出中…" : "確認收貨"}
-              </button>
-            )}
-            <button
-              onClick={onClose}
-              className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
-            >
-              關閉
-            </button>
-          </div>
-        </div>
-
-        <Timeline transfer={transfer} wave={wave} />
-
-        {error && (
-          <div className="border-b border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
-            {error}
-          </div>
-        )}
-
-        <div className="overflow-auto p-3">
-          {items === null ? (
-            <div className="p-6 text-center text-sm text-zinc-500">載入中…</div>
-          ) : (
-            <Fragment>
-              <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
-                <thead className="sticky top-0 bg-zinc-50 dark:bg-zinc-900">
-                  <tr>
-                    <th className="px-3 py-2 text-left text-xs uppercase text-zinc-500">商品</th>
-                    <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">出貨</th>
-                    <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">實收</th>
-                    <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">差異</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                  {items.map((it) => {
-                    const sku = skus.get(it.sku_id);
-                    const editVal = edits.get(it.id);
-                    const cur = readOnly
-                      ? String(it.qty_received)
-                      : editVal !== undefined
-                      ? editVal
-                      : String(it.qty_shipped);
-                    const numCur = Number(cur);
-                    const diff = !Number.isNaN(numCur) ? numCur - it.qty_shipped : 0;
-                    const overflowing = !readOnly && numCur > it.qty_shipped;
-                    return (
-                      <tr key={it.id}>
-                        <td className="px-3 py-2">
-                          <div className="font-medium">{sku?.product_name ?? "—"}</div>
-                          <div className="text-xs text-zinc-500">
-                            {sku?.sku_code}
-                            {sku?.variant_name ? ` / ${sku.variant_name}` : ""}
-                          </div>
-                        </td>
-                        <td className="px-3 py-2 text-right font-mono text-zinc-600 dark:text-zinc-300">
-                          {it.qty_shipped}
-                        </td>
-                        <td className="px-3 py-2 text-right">
-                          <input
-                            inputMode="decimal"
-                            value={cur}
-                            disabled={readOnly}
-                            onChange={(e) => setQty(it.id, e.target.value)}
-                            className={`w-20 rounded-md border px-2 py-0.5 text-right font-mono text-sm font-semibold ${
-                              overflowing
-                                ? "border-red-400 bg-red-50 dark:bg-red-950"
-                                : editVal !== undefined
-                                ? "border-amber-400 bg-amber-50 dark:bg-amber-950"
-                                : "border-zinc-300 bg-white dark:border-zinc-700 dark:bg-zinc-800"
-                            } disabled:bg-zinc-100 disabled:opacity-70 dark:disabled:bg-zinc-800`}
-                          />
-                        </td>
-                        <td
-                          className={`px-3 py-2 text-right font-mono text-xs ${
-                            diff === 0
-                              ? "text-zinc-400"
-                              : diff < 0
-                              ? "text-red-600 dark:text-red-400"
-                              : "text-purple-600 dark:text-purple-400"
-                          }`}
-                        >
-                          {diff === 0 ? "—" : diff > 0 ? `+${diff}` : `${diff}`}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-                <tfoot className="bg-zinc-50 dark:bg-zinc-900">
-                  <tr>
-                    <td className="px-3 py-2 text-right text-xs font-semibold text-zinc-500">
-                      合計
-                    </td>
-                    <td className="px-3 py-2 text-right font-mono font-semibold">
-                      {totalShipped}
-                    </td>
-                    <td className="px-3 py-2 text-right font-mono font-semibold">
-                      {totalReceived}
-                    </td>
-                    <td
-                      className={`px-3 py-2 text-right font-mono text-xs font-semibold ${
-                        variance === 0
-                          ? "text-emerald-600 dark:text-emerald-400"
-                          : variance < 0
-                          ? "text-red-600 dark:text-red-400"
-                          : "text-purple-600 dark:text-purple-400"
-                      }`}
-                    >
-                      {variance === 0
-                        ? "✓"
-                        : variance > 0
-                        ? `+${variance}`
-                        : `${variance}`}
-                    </td>
-                  </tr>
-                </tfoot>
-              </table>
-
-              {!readOnly && (
-                <div className="mt-4">
-                  <label className="block text-xs text-zinc-500">備註（短收 / 異常說明）</label>
-                  <textarea
-                    value={note}
-                    onChange={(e) => setNote(e.target.value)}
-                    rows={2}
-                    className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-                    placeholder="例：途中破損 2 件"
-                  />
-                </div>
-              )}
-              {readOnly && transfer.notes && (
-                <div className="mt-4 rounded-md border border-zinc-200 bg-zinc-50 p-2 text-xs text-zinc-600 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300">
-                  <div className="mb-1 text-zinc-500">備註</div>
-                  <div className="whitespace-pre-line">{transfer.notes}</div>
-                </div>
-              )}
-            </Fragment>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function Timeline({ transfer, wave }: { transfer: Transfer; wave: Wave | null }) {
-  const steps: Array<{ label: string; ts: string | null; done: boolean }> = [
-    { label: "撿貨單建立", ts: wave?.created_at ?? null, done: !!wave },
-    { label: "派貨出倉", ts: transfer.shipped_at, done: !!transfer.shipped_at },
-    { label: "收貨", ts: transfer.received_at, done: transfer.status === "received" },
-  ];
-  return (
-    <div className="border-b border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
-      <ol className="flex items-center gap-1 overflow-x-auto text-xs">
-        {steps.map((s, i) => (
-          <Fragment key={s.label}>
-            <li className="flex min-w-0 items-center gap-2">
-              <span
-                className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${
-                  s.done
-                    ? "bg-emerald-600 text-white"
-                    : "bg-zinc-300 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300"
-                }`}
-              >
-                {s.done ? "✓" : i + 1}
-              </span>
-              <div className="min-w-0">
-                <div className={s.done ? "font-medium" : "text-zinc-500"}>{s.label}</div>
-                {s.ts && (
-                  <div className="text-[10px] text-zinc-500">
-                    {new Date(s.ts).toLocaleString("zh-TW")}
-                  </div>
-                )}
-              </div>
-            </li>
-            {i < steps.length - 1 && (
-              <li
-                aria-hidden
-                className={`h-[1px] flex-1 ${
-                  steps[i + 1].done
-                    ? "bg-emerald-400"
-                    : "bg-zinc-300 dark:bg-zinc-700"
-                }`}
-              />
-            )}
-          </Fragment>
-        ))}
-      </ol>
     </div>
   );
 }

--- a/apps/admin/src/app/(protected)/transfers/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/page.tsx
@@ -272,7 +272,7 @@ export default function TransfersListPage() {
               <Th>單號</Th>
               <Th>類型</Th>
               <Th>來源 → 目的地</Th>
-              <Th>來源 WV</Th>
+              <Th>撿貨單號</Th>
               <Th>派出時間</Th>
               <Th className="text-right">品項</Th>
               <Th className="text-right">出貨 / 實收</Th>
@@ -311,7 +311,7 @@ export default function TransfersListPage() {
                   <td className="whitespace-nowrap px-3 py-2 text-xs">
                     {wave ? (
                       <a
-                        href={`/picking/history`}
+                        href={`/picking/history?wave=${wave.id}`}
                         className="font-mono text-blue-600 hover:underline dark:text-blue-400"
                         title={`配送日 ${wave.wave_date}`}
                       >

--- a/apps/admin/src/app/(protected)/transfers/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/page.tsx
@@ -1,0 +1,438 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import {
+  TransferReceiveModal,
+  TRANSFER_TYPE_LABEL,
+  parseWaveId,
+  type Transfer,
+  type Wave,
+} from "@/components/TransferReceiveModal";
+
+type Location = { id: number; name: string };
+
+type ItemAgg = {
+  itemCount: number;
+  totalShipped: number;
+  totalReceived: number;
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: "草稿",
+  confirmed: "已確認",
+  shipped: "已派貨",
+  received: "已收貨",
+  cancelled: "已取消",
+  closed: "已結案",
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  draft: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+  confirmed: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  shipped: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  received: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+  cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+  closed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-400",
+};
+
+export default function TransfersListPage() {
+  const [transfers, setTransfers] = useState<Transfer[] | null>(null);
+  const [locations, setLocations] = useState<Map<number, string>>(new Map());
+  const [waves, setWaves] = useState<Map<number, Wave>>(new Map());
+  const [aggs, setAggs] = useState<Map<number, ItemAgg>>(new Map());
+  const [error, setError] = useState<string | null>(null);
+  const [reloadTick, setReloadTick] = useState(0);
+  const [opening, setOpening] = useState<Transfer | null>(null);
+
+  // Filters
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [srcFilter, setSrcFilter] = useState<number | "all">("all");
+  const [dstFilter, setDstFilter] = useState<number | "all">("all");
+  const [varianceFilter, setVarianceFilter] = useState<"all" | "shortage" | "match">("all");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data, error: e } = await sb
+          .from("transfers")
+          .select(
+            "id, transfer_no, source_location, dest_location, status, transfer_type, shipped_at, received_at, notes",
+          )
+          .order("id", { ascending: false })
+          .limit(200);
+        if (e) throw new Error(e.message);
+        const rows = (data as Transfer[] | null) ?? [];
+
+        const locIds = Array.from(
+          new Set(rows.flatMap((r) => [r.source_location, r.dest_location])),
+        );
+        const locMap = new Map<number, string>();
+        if (locIds.length > 0) {
+          const { data: locs } = await sb
+            .from("locations")
+            .select("id, name")
+            .in("id", locIds);
+          for (const l of (locs as Location[] | null) ?? []) {
+            locMap.set(l.id, l.name);
+          }
+        }
+
+        const waveIds = Array.from(
+          new Set(rows.map((r) => parseWaveId(r.transfer_no)).filter((x): x is number => x !== null)),
+        );
+        const waveMap = new Map<number, Wave>();
+        if (waveIds.length > 0) {
+          const { data: ws } = await sb
+            .from("picking_waves")
+            .select("id, wave_code, wave_date, created_at")
+            .in("id", waveIds);
+          for (const w of (ws as Wave[] | null) ?? []) waveMap.set(w.id, w);
+        }
+
+        const aggMap = new Map<number, ItemAgg>();
+        const tIds = rows.map((r) => r.id);
+        if (tIds.length > 0) {
+          const { data: itemRows } = await sb
+            .from("transfer_items")
+            .select("transfer_id, qty_shipped, qty_received")
+            .in("transfer_id", tIds);
+          for (const r of (itemRows as
+            | { transfer_id: number; qty_shipped: number; qty_received: number }[]
+            | null) ?? []) {
+            const cur = aggMap.get(r.transfer_id) ?? {
+              itemCount: 0,
+              totalShipped: 0,
+              totalReceived: 0,
+            };
+            cur.itemCount += 1;
+            cur.totalShipped += Number(r.qty_shipped);
+            cur.totalReceived += Number(r.qty_received);
+            aggMap.set(r.transfer_id, cur);
+          }
+        }
+
+        if (!cancelled) {
+          setTransfers(rows);
+          setLocations(locMap);
+          setWaves(waveMap);
+          setAggs(aggMap);
+          setError(null);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadTick]);
+
+  const srcOptions = useMemo(() => {
+    const set = new Map<number, string>();
+    for (const t of transfers ?? []) {
+      set.set(t.source_location, locations.get(t.source_location) ?? `#${t.source_location}`);
+    }
+    return Array.from(set.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+  }, [transfers, locations]);
+
+  const dstOptions = useMemo(() => {
+    const set = new Map<number, string>();
+    for (const t of transfers ?? []) {
+      set.set(t.dest_location, locations.get(t.dest_location) ?? `#${t.dest_location}`);
+    }
+    return Array.from(set.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+  }, [transfers, locations]);
+
+  const filtered = useMemo(() => {
+    return (transfers ?? []).filter((t) => {
+      if (statusFilter !== "all" && t.status !== statusFilter) return false;
+      if (typeFilter !== "all" && t.transfer_type !== typeFilter) return false;
+      if (srcFilter !== "all" && t.source_location !== srcFilter) return false;
+      if (dstFilter !== "all" && t.dest_location !== dstFilter) return false;
+      if (varianceFilter !== "all") {
+        const a = aggs.get(t.id);
+        if (!a) return false;
+        const v = a.totalReceived - a.totalShipped;
+        if (varianceFilter === "shortage" && v >= 0) return false;
+        if (varianceFilter === "match" && v !== 0) return false;
+      }
+      return true;
+    });
+  }, [transfers, statusFilter, typeFilter, srcFilter, dstFilter, varianceFilter, aggs]);
+
+  const summary = useMemo(() => {
+    const total = filtered.length;
+    let pending = 0;
+    let received = 0;
+    let shortageCount = 0;
+    let totalVariance = 0;
+    for (const t of filtered) {
+      if (t.status === "shipped") pending += 1;
+      if (t.status === "received") received += 1;
+      const a = aggs.get(t.id);
+      if (a) {
+        const v = a.totalReceived - a.totalShipped;
+        if (t.status === "received" && v < 0) {
+          shortageCount += 1;
+          totalVariance += v;
+        }
+      }
+    }
+    return { total, pending, received, shortageCount, totalVariance };
+  }, [filtered, aggs]);
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">調撥單列表</h1>
+          <p className="text-sm text-zinc-500">
+            {transfers === null
+              ? "載入中…"
+              : `共 ${summary.total} 張 · 待收 ${summary.pending} · 已收 ${summary.received}` +
+                (summary.shortageCount > 0
+                  ? ` · 短收 ${summary.shortageCount} 張 (合計 ${summary.totalVariance})`
+                  : "")}
+          </p>
+        </div>
+        <a
+          href="/transfers/inbox"
+          className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          → 收貨待辦
+        </a>
+      </header>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-end gap-3 rounded-md border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
+        <FilterSelect label="狀態" value={statusFilter} onChange={setStatusFilter}>
+          <option value="all">全部</option>
+          {Object.entries(STATUS_LABEL).map(([v, l]) => (
+            <option key={v} value={v}>
+              {l}
+            </option>
+          ))}
+        </FilterSelect>
+        <FilterSelect label="類型" value={typeFilter} onChange={setTypeFilter}>
+          <option value="all">全部</option>
+          {Object.entries(TRANSFER_TYPE_LABEL).map(([v, l]) => (
+            <option key={v} value={v}>
+              {l}
+            </option>
+          ))}
+        </FilterSelect>
+        <FilterSelect
+          label="來源"
+          value={String(srcFilter)}
+          onChange={(v) => setSrcFilter(v === "all" ? "all" : Number(v))}
+        >
+          <option value="all">全部</option>
+          {srcOptions.map(([id, name]) => (
+            <option key={id} value={id}>
+              {name}
+            </option>
+          ))}
+        </FilterSelect>
+        <FilterSelect
+          label="目的地"
+          value={String(dstFilter)}
+          onChange={(v) => setDstFilter(v === "all" ? "all" : Number(v))}
+        >
+          <option value="all">全部</option>
+          {dstOptions.map(([id, name]) => (
+            <option key={id} value={id}>
+              {name}
+            </option>
+          ))}
+        </FilterSelect>
+        <FilterSelect
+          label="差異"
+          value={varianceFilter}
+          onChange={(v) => setVarianceFilter(v as "all" | "shortage" | "match")}
+        >
+          <option value="all">全部</option>
+          <option value="shortage">僅短收</option>
+          <option value="match">無差異</option>
+        </FilterSelect>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+        <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+          <thead className="bg-zinc-50 dark:bg-zinc-900">
+            <tr>
+              <Th>單號</Th>
+              <Th>類型</Th>
+              <Th>來源 → 目的地</Th>
+              <Th>來源 WV</Th>
+              <Th>派出時間</Th>
+              <Th className="text-right">品項</Th>
+              <Th className="text-right">出貨 / 實收</Th>
+              <Th className="text-right">差異</Th>
+              <Th>狀態</Th>
+              <Th></Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+            {transfers !== null && filtered.length === 0 && (
+              <tr>
+                <td colSpan={10} className="p-6 text-center text-sm text-zinc-500">
+                  沒有符合條件的 transfer。
+                </td>
+              </tr>
+            )}
+            {filtered.map((t) => {
+              const a = aggs.get(t.id);
+              const variance = a ? a.totalReceived - a.totalShipped : 0;
+              const wid = parseWaveId(t.transfer_no);
+              const wave = wid !== null ? waves.get(wid) : undefined;
+              const isShipped = t.status === "shipped";
+              return (
+                <tr key={t.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-950">
+                  <td className="whitespace-nowrap px-3 py-2 font-mono text-xs">{t.transfer_no}</td>
+                  <td className="whitespace-nowrap px-3 py-2 text-xs text-zinc-600 dark:text-zinc-300">
+                    {TRANSFER_TYPE_LABEL[t.transfer_type] ?? t.transfer_type}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2 text-xs">
+                    <span>{locations.get(t.source_location) ?? `#${t.source_location}`}</span>
+                    <span className="mx-1 text-zinc-400">→</span>
+                    <span className="font-medium">
+                      {locations.get(t.dest_location) ?? `#${t.dest_location}`}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2 text-xs">
+                    {wave ? (
+                      <a
+                        href={`/picking/history`}
+                        className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                        title={`配送日 ${wave.wave_date}`}
+                      >
+                        {wave.wave_code}
+                      </a>
+                    ) : (
+                      <span className="text-zinc-400">—</span>
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2 text-xs text-zinc-600 dark:text-zinc-300">
+                    {t.shipped_at ? new Date(t.shipped_at).toLocaleString("zh-TW") : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-xs">
+                    {a?.itemCount ?? 0}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-xs">
+                    <span>{a?.totalShipped ?? 0}</span>
+                    <span className="mx-1 text-zinc-400">/</span>
+                    <span>{a?.totalReceived ?? 0}</span>
+                  </td>
+                  <td
+                    className={`px-3 py-2 text-right font-mono text-xs font-semibold ${
+                      variance === 0
+                        ? "text-zinc-400"
+                        : variance < 0
+                        ? "text-red-600 dark:text-red-400"
+                        : "text-purple-600 dark:text-purple-400"
+                    }`}
+                  >
+                    {variance === 0 ? "—" : variance > 0 ? `+${variance}` : `${variance}`}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`inline-block rounded px-2 py-0.5 text-xs ${
+                        STATUS_COLOR[t.status] ?? ""
+                      }`}
+                    >
+                      {STATUS_LABEL[t.status] ?? t.status}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    {isShipped ? (
+                      <button
+                        onClick={() => setOpening(t)}
+                        className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-semibold text-white hover:bg-emerald-700"
+                      >
+                        收貨
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => setOpening(t)}
+                        className="rounded-md border border-zinc-300 px-3 py-1 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                      >
+                        看明細
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {opening && (
+        <TransferReceiveModal
+          transfer={opening}
+          srcName={locations.get(opening.source_location) ?? `#${opening.source_location}`}
+          dstName={locations.get(opening.dest_location) ?? `#${opening.dest_location}`}
+          wave={(() => {
+            const wid = parseWaveId(opening.transfer_no);
+            return wid !== null ? waves.get(wid) ?? null : null;
+          })()}
+          onClose={() => setOpening(null)}
+          onSubmitted={() => {
+            setOpening(null);
+            setReloadTick((t) => t + 1);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function FilterSelect({
+  label,
+  value,
+  onChange,
+  children,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs">
+      <span className="text-zinc-500">{label}</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+      >
+        {children}
+      </select>
+    </label>
+  );
+}
+
+function Th({
+  children,
+  className = "",
+}: {
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <th
+      className={`whitespace-nowrap px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 ${className}`}
+    >
+      {children}
+    </th>
+  );
+}

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -261,6 +261,7 @@ async function buildTimeline(
   let xferReceived = false;
   let receivedTs: string | null = null;
   let xferDetail = "";
+  let xferHref: string | undefined;
 
   if (campaignId && storeId && skuIds.length > 0) {
     // 找此 order 對應的 wave_ids（同 campaign + 同店 + 同 sku）
@@ -304,8 +305,14 @@ async function buildTimeline(
         .select("transfer_no, status, shipped_at, received_at")
         .in("transfer_no", transferNos);
       const xfers = ((ts as { transfer_no: string; status: string; shipped_at: string | null; received_at: string | null }[] | null) ?? []);
-      if (xfers.length > 0) {
+      if (xfers.length === 1) {
+        xferDetail = xfers[0].transfer_no;
+        xferHref = `/transfers/`;
+      } else if (xfers.length > 1) {
         xferDetail = `${xfers.length} 張 TR`;
+        xferHref = `/transfers/`;
+      }
+      if (xfers.length > 0) {
         const allShipped = xfers.every((t) => ["shipped", "received", "closed"].includes(t.status));
         if (allShipped) {
           xferShipped = true;
@@ -334,8 +341,8 @@ async function buildTimeline(
   return [
     { label: "採購到貨", ts: poTs, done: poDone, detail: poDetail || undefined },
     { label: "撿貨完成", ts: waveTs, done: wavePicked, detail: waveDetail || undefined, detailHref: waveHref },
-    { label: "派貨出倉", ts: shippedTs, done: xferShipped, detail: xferDetail || undefined },
-    { label: "分店收貨", ts: receivedTs, done: xferReceived },
+    { label: "派貨出倉", ts: shippedTs, done: xferShipped, detail: xferDetail || undefined, detailHref: xferHref },
+    { label: "分店收貨", ts: receivedTs, done: xferReceived, detail: xferDetail || undefined, detailHref: xferHref },
     { label: "顧客取貨", ts: null, done: pickedUp, detail: status },
   ];
 }

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 
 type OrderHead = {
@@ -11,6 +11,8 @@ type OrderHead = {
   nickname_snapshot: string | null;
   created_at: string;
   updated_at: string;
+  pickup_store_id: number | null;
+  campaign_id: number | null;
   member: { id: number; name: string | null; phone: string | null; member_no: string } | null;
   campaign: { id: number; campaign_no: string; name: string } | null;
   store: { id: number; name: string } | null;
@@ -29,6 +31,8 @@ type ItemRow = {
   sku: { id: number; sku_code: string; product_name: string | null; variant_name: string | null } | null;
 };
 
+type TimelineStep = { label: string; ts: string | null; done: boolean; detail?: string };
+
 function uidShort(uid: string | null): string {
   if (!uid) return "—";
   return uid.slice(0, 8);
@@ -41,6 +45,7 @@ function fmtDt(iso: string): string {
 export function OrderDetail({ orderId }: { orderId: number }) {
   const [head, setHead] = useState<OrderHead | null>(null);
   const [items, setItems] = useState<ItemRow[] | null>(null);
+  const [timeline, setTimeline] = useState<TimelineStep[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -49,7 +54,7 @@ export function OrderDetail({ orderId }: { orderId: number }) {
       const sb = getSupabase();
       const [hRes, iRes] = await Promise.all([
         sb.from("customer_orders")
-          .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
+          .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .eq("id", orderId).maybeSingle(),
         sb.from("customer_order_items")
           .select("id, qty, unit_price, status, source, created_at, updated_at, created_by, updated_by, sku:skus(id, sku_code, product_name, variant_name)")
@@ -58,9 +63,16 @@ export function OrderDetail({ orderId }: { orderId: number }) {
       ]);
       if (cancelled) return;
       if (hRes.error) { setError(hRes.error.message); return; }
-      setHead(hRes.data as unknown as OrderHead);
+      const headData = hRes.data as unknown as OrderHead;
+      setHead(headData);
       if (iRes.error) { setError(iRes.error.message); return; }
-      setItems((iRes.data ?? []) as unknown as ItemRow[]);
+      const itemsData = (iRes.data ?? []) as unknown as ItemRow[];
+      setItems(itemsData);
+
+      // ========== 載入 timeline ==========
+      const skuIds = itemsData.map((it) => it.sku?.id).filter((x): x is number => !!x);
+      const tl = await buildTimeline(headData, skuIds);
+      if (!cancelled) setTimeline(tl);
     })();
     return () => { cancelled = true; };
   }, [orderId]);
@@ -103,6 +115,9 @@ export function OrderDetail({ orderId }: { orderId: number }) {
         <Field label="建立" value={fmtDt(head.created_at)} />
         <Field label="最後更新" value={fmtDt(head.updated_at)} />
       </div>
+
+      {/* 進度 timeline（採購到貨 → 撿貨 → 派貨 → 分店收貨） */}
+      <Timeline steps={timeline} />
 
       <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
         <div className="flex items-center justify-between border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-xs font-medium dark:border-zinc-800 dark:bg-zinc-900">
@@ -157,6 +172,186 @@ export function OrderDetail({ orderId }: { orderId: number }) {
           ※ 同顧客在同活動連 key 多次會合併到同一筆，舊 qty 被新值覆寫。如需「每次 +N 紀錄」請告知改完整版（加 append-only audit table）。
         </p>
       </div>
+    </div>
+  );
+}
+
+async function buildTimeline(
+  head: OrderHead,
+  skuIds: number[],
+): Promise<TimelineStep[]> {
+  const sb = getSupabase();
+  const campaignId = head.campaign_id;
+  const storeId = head.pickup_store_id;
+  const status = head.status;
+
+  // Step 1: 採購到貨 — campaign 對應的 POs 是否都 fully_received
+  let poDone = false;
+  let poTs: string | null = null;
+  let poDetail = "";
+  if (campaignId) {
+    const { data: pris } = await sb
+      .from("purchase_request_items")
+      .select("po_item_id")
+      .eq("source_campaign_id", campaignId)
+      .not("po_item_id", "is", null);
+    const poItemIds = ((pris as { po_item_id: number | null }[] | null) ?? [])
+      .map((r) => r.po_item_id)
+      .filter((x): x is number => x !== null);
+    if (poItemIds.length > 0) {
+      const { data: pois } = await sb
+        .from("purchase_order_items")
+        .select("po_id")
+        .in("id", poItemIds);
+      const poIds = Array.from(
+        new Set(((pois as { po_id: number }[] | null) ?? []).map((r) => r.po_id)),
+      );
+      if (poIds.length > 0) {
+        const { data: pos } = await sb
+          .from("purchase_orders")
+          .select("id, status, updated_at")
+          .in("id", poIds);
+        const poList = ((pos as { id: number; status: string; updated_at: string }[] | null) ?? []);
+        const allDone = poList.length > 0 && poList.every((p) => p.status === "fully_received" || p.status === "closed");
+        if (allDone) {
+          poDone = true;
+          poTs = poList
+            .map((p) => p.updated_at)
+            .sort()
+            .reverse()[0] ?? null;
+        }
+        poDetail = `${poList.filter((p) => p.status === "fully_received" || p.status === "closed").length}/${poList.length} PO`;
+      }
+    }
+  }
+
+  // Step 2/3/4: wave → transfer
+  let wavePicked = false;
+  let waveTs: string | null = null;
+  let xferShipped = false;
+  let shippedTs: string | null = null;
+  let xferReceived = false;
+  let receivedTs: string | null = null;
+  let xferDetail = "";
+
+  if (campaignId && storeId && skuIds.length > 0) {
+    // 找此 order 對應的 wave_ids（同 campaign + 同店 + 同 sku）
+    const { data: pwis } = await sb
+      .from("picking_wave_items")
+      .select("wave_id")
+      .eq("campaign_id", campaignId)
+      .eq("store_id", storeId)
+      .in("sku_id", skuIds);
+    const waveIds = Array.from(
+      new Set(((pwis as { wave_id: number }[] | null) ?? []).map((r) => r.wave_id)),
+    );
+
+    if (waveIds.length > 0) {
+      // wave 狀態
+      const { data: ws } = await sb
+        .from("picking_waves")
+        .select("id, status, updated_at")
+        .in("id", waveIds);
+      const waves = ((ws as { id: number; status: string; updated_at: string }[] | null) ?? []);
+      const allPicked = waves.length > 0 && waves.every((w) => ["picked", "shipped", "cancelled"].includes(w.status));
+      if (allPicked) {
+        wavePicked = true;
+        waveTs = waves
+          .map((w) => w.updated_at)
+          .sort()
+          .reverse()[0] ?? null;
+      }
+
+      // transfer for each wave to this store
+      const transferNos = waveIds.map((wid) => `WAVE-${wid}-S${storeId}`);
+      const { data: ts } = await sb
+        .from("transfers")
+        .select("transfer_no, status, shipped_at, received_at")
+        .in("transfer_no", transferNos);
+      const xfers = ((ts as { transfer_no: string; status: string; shipped_at: string | null; received_at: string | null }[] | null) ?? []);
+      if (xfers.length > 0) {
+        xferDetail = `${xfers.length} 張 TR`;
+        const allShipped = xfers.every((t) => ["shipped", "received", "closed"].includes(t.status));
+        if (allShipped) {
+          xferShipped = true;
+          shippedTs = xfers
+            .map((t) => t.shipped_at)
+            .filter((x): x is string => !!x)
+            .sort()
+            .reverse()[0] ?? null;
+        }
+        const allReceived = xfers.every((t) => ["received", "closed"].includes(t.status));
+        if (allReceived) {
+          xferReceived = true;
+          receivedTs = xfers
+            .map((t) => t.received_at)
+            .filter((x): x is string => !!x)
+            .sort()
+            .reverse()[0] ?? null;
+        }
+      }
+    }
+  }
+
+  // Step 5: 顧客取貨 — order.status
+  const pickedUp = status === "completed" || status === "picked_up";
+
+  return [
+    { label: "採購到貨", ts: poTs, done: poDone, detail: poDetail || undefined },
+    { label: "撿貨完成", ts: waveTs, done: wavePicked, detail: xferDetail || undefined },
+    { label: "派貨出倉", ts: shippedTs, done: xferShipped },
+    { label: "分店收貨", ts: receivedTs, done: xferReceived },
+    { label: "顧客取貨", ts: null, done: pickedUp, detail: status },
+  ];
+}
+
+function Timeline({ steps }: { steps: TimelineStep[] | null }) {
+  if (steps === null) {
+    return (
+      <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900">
+        進度載入中…
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="mb-2 text-xs font-medium text-zinc-500">進度</div>
+      <ol className="flex items-start gap-1 overflow-x-auto text-xs">
+        {steps.map((s, i) => (
+          <Fragment key={s.label}>
+            <li className="flex min-w-0 flex-col items-center text-center">
+              <span
+                className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${
+                  s.done
+                    ? "bg-emerald-600 text-white"
+                    : "bg-zinc-300 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300"
+                }`}
+              >
+                {s.done ? "✓" : i + 1}
+              </span>
+              <div className={`mt-1 text-[11px] ${s.done ? "font-medium" : "text-zinc-500"}`}>
+                {s.label}
+              </div>
+              {s.detail && (
+                <div className="text-[10px] text-zinc-500">{s.detail}</div>
+              )}
+              {s.ts && (
+                <div className="text-[10px] text-zinc-400">
+                  {new Date(s.ts).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" })}
+                </div>
+              )}
+            </li>
+            {i < steps.length - 1 && (
+              <li
+                aria-hidden
+                className={`mt-3 h-[2px] flex-1 ${
+                  steps[i + 1].done ? "bg-emerald-400" : "bg-zinc-300 dark:bg-zinc-700"
+                }`}
+              />
+            )}
+          </Fragment>
+        ))}
+      </ol>
     </div>
   );
 }

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -31,11 +31,17 @@ type ItemRow = {
   sku: { id: number; sku_code: string; product_name: string | null; variant_name: string | null } | null;
 };
 
-type TimelineStep = { label: string; ts: string | null; done: boolean; detail?: string };
+type TimelineStep = {
+  label: string;
+  ts: string | null;
+  done: boolean;
+  detail?: string;
+  detailHref?: string;
+};
 
-function uidShort(uid: string | null): string {
+function staffLabel(uid: string | null, names: Map<string, string>): string {
   if (!uid) return "—";
-  return uid.slice(0, 8);
+  return names.get(uid) ?? uid.slice(0, 8);
 }
 
 function fmtDt(iso: string): string {
@@ -46,6 +52,7 @@ export function OrderDetail({ orderId }: { orderId: number }) {
   const [head, setHead] = useState<OrderHead | null>(null);
   const [items, setItems] = useState<ItemRow[] | null>(null);
   const [timeline, setTimeline] = useState<TimelineStep[] | null>(null);
+  const [staffNames, setStaffNames] = useState<Map<string, string>>(new Map());
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -68,6 +75,23 @@ export function OrderDetail({ orderId }: { orderId: number }) {
       if (iRes.error) { setError(iRes.error.message); return; }
       const itemsData = (iRes.data ?? []) as unknown as ItemRow[];
       setItems(itemsData);
+
+      // ========== 載入加單者 user names ==========
+      const uids = new Set<string>();
+      for (const it of itemsData) {
+        if (it.created_by) uids.add(it.created_by);
+        if (it.updated_by) uids.add(it.updated_by);
+      }
+      if (uids.size > 0) {
+        const { data: names } = await sb.rpc("rpc_get_staff_names", {
+          p_uids: Array.from(uids),
+        });
+        const m = new Map<string, string>();
+        for (const n of (names as { id: string; display_name: string }[] | null) ?? []) {
+          m.set(n.id, n.display_name);
+        }
+        if (!cancelled) setStaffNames(m);
+      }
 
       // ========== 載入 timeline ==========
       const skuIds = itemsData.map((it) => it.sku?.id).filter((x): x is number => !!x);
@@ -156,11 +180,11 @@ export function OrderDetail({ orderId }: { orderId: number }) {
                     <td className="px-3 py-2 text-right font-mono">${sub}</td>
                     <td className="px-3 py-2 text-zinc-500">
                       {fmtDt(it.created_at)}<br />
-                      <span className="font-mono text-[10px]">by {uidShort(it.created_by)}</span>
+                      <span className="text-[10px]">by {staffLabel(it.created_by, staffNames)}</span>
                     </td>
                     <td className="px-3 py-2 text-zinc-500">
                       {fmtDt(it.updated_at)}<br />
-                      <span className="font-mono text-[10px]">by {uidShort(it.updated_by)}</span>
+                      <span className="text-[10px]">by {staffLabel(it.updated_by, staffNames)}</span>
                     </td>
                   </tr>
                 );
@@ -189,11 +213,13 @@ async function buildTimeline(
   let poDone = false;
   let poTs: string | null = null;
   let poDetail = "";
-  if (campaignId) {
+  // 只看這張訂單裡實際 SKU 對應的 PO（過濾掉同 campaign 但其它 SKU 用到的 PO）
+  if (campaignId && skuIds.length > 0) {
     const { data: pris } = await sb
       .from("purchase_request_items")
       .select("po_item_id")
       .eq("source_campaign_id", campaignId)
+      .in("sku_id", skuIds)
       .not("po_item_id", "is", null);
     const poItemIds = ((pris as { po_item_id: number | null }[] | null) ?? [])
       .map((r) => r.po_item_id)
@@ -228,6 +254,8 @@ async function buildTimeline(
   // Step 2/3/4: wave → transfer
   let wavePicked = false;
   let waveTs: string | null = null;
+  let waveDetail = "";
+  let waveHref: string | undefined;
   let xferShipped = false;
   let shippedTs: string | null = null;
   let xferReceived = false;
@@ -250,9 +278,9 @@ async function buildTimeline(
       // wave 狀態
       const { data: ws } = await sb
         .from("picking_waves")
-        .select("id, status, updated_at")
+        .select("id, wave_code, status, updated_at")
         .in("id", waveIds);
-      const waves = ((ws as { id: number; status: string; updated_at: string }[] | null) ?? []);
+      const waves = ((ws as { id: number; wave_code: string; status: string; updated_at: string }[] | null) ?? []);
       const allPicked = waves.length > 0 && waves.every((w) => ["picked", "shipped", "cancelled"].includes(w.status));
       if (allPicked) {
         wavePicked = true;
@@ -260,6 +288,13 @@ async function buildTimeline(
           .map((w) => w.updated_at)
           .sort()
           .reverse()[0] ?? null;
+      }
+      if (waves.length === 1) {
+        waveDetail = waves[0].wave_code;
+        waveHref = `/picking/history?wave=${waves[0].id}`;
+      } else if (waves.length > 1) {
+        waveDetail = `${waves.length} 張撿貨單`;
+        waveHref = `/picking/history`;
       }
 
       // transfer for each wave to this store
@@ -298,8 +333,8 @@ async function buildTimeline(
 
   return [
     { label: "採購到貨", ts: poTs, done: poDone, detail: poDetail || undefined },
-    { label: "撿貨完成", ts: waveTs, done: wavePicked, detail: xferDetail || undefined },
-    { label: "派貨出倉", ts: shippedTs, done: xferShipped },
+    { label: "撿貨完成", ts: waveTs, done: wavePicked, detail: waveDetail || undefined, detailHref: waveHref },
+    { label: "派貨出倉", ts: shippedTs, done: xferShipped, detail: xferDetail || undefined },
     { label: "分店收貨", ts: receivedTs, done: xferReceived },
     { label: "顧客取貨", ts: null, done: pickedUp, detail: status },
   ];
@@ -333,7 +368,16 @@ function Timeline({ steps }: { steps: TimelineStep[] | null }) {
                 {s.label}
               </div>
               {s.detail && (
-                <div className="text-[10px] text-zinc-500">{s.detail}</div>
+                s.detailHref ? (
+                  <a
+                    href={s.detailHref}
+                    className="text-[10px] font-mono text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {s.detail}
+                  </a>
+                ) : (
+                  <div className="text-[10px] text-zinc-500">{s.detail}</div>
+                )
               )}
               {s.ts && (
                 <div className="text-[10px] text-zinc-400">

--- a/apps/admin/src/components/PrPipelineStepper.tsx
+++ b/apps/admin/src/components/PrPipelineStepper.tsx
@@ -105,15 +105,13 @@ export function PrPipelineStepper({
     steps.push({ key: "receive", label: "部分到貨", state: "current" });
   else steps.push({ key: "receive", label: "全部到貨", state: "done" });
 
-  // S8 正在派貨（撿完出庫到分店、transfer.shipped）
+  // S8 派貨（撿完出庫到分店、transfer.shipped）— 只看 shipped 進度
   if (isRejected || isCancelled)
     steps.push({ key: "ship", label: "派貨", state: "skipped" });
   else if (!transferSummary || transferSummary.total === 0 || transferSummary.shipped === 0)
     steps.push({ key: "ship", label: "派貨", state: "pending" });
   else if (transferSummary.shipped < transferSummary.total)
     steps.push({ key: "ship", label: "部分派貨", state: "current" });
-  else if (transferSummary.delivered < transferSummary.total)
-    steps.push({ key: "ship", label: "派貨中", state: "current" });
   else steps.push({ key: "ship", label: "已派貨", state: "done" });
 
   // S9 分店收到確認（transfer.received）

--- a/apps/admin/src/components/TransferReceiveModal.tsx
+++ b/apps/admin/src/components/TransferReceiveModal.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import { Fragment, useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+
+export type Transfer = {
+  id: number;
+  transfer_no: string;
+  source_location: number;
+  dest_location: number;
+  status: string;
+  transfer_type: string;
+  shipped_at: string | null;
+  received_at: string | null;
+  notes: string | null;
+};
+
+export type Wave = {
+  id: number;
+  wave_code: string;
+  wave_date: string;
+  created_at: string;
+};
+
+type TransferItem = {
+  id: number;
+  transfer_id: number;
+  sku_id: number;
+  qty_requested: number;
+  qty_shipped: number;
+  qty_received: number;
+};
+
+type Sku = {
+  id: number;
+  sku_code: string | null;
+  product_name: string | null;
+  variant_name: string | null;
+};
+
+export const TRANSFER_TYPE_LABEL: Record<string, string> = {
+  hq_to_store: "總倉配送",
+  store_to_store: "店轉店",
+  return_to_hq: "退回龍潭",
+};
+
+export function parseWaveId(transferNo: string): number | null {
+  const m = /^WAVE-(\d+)-S\d+$/.exec(transferNo);
+  return m ? Number(m[1]) : null;
+}
+
+export function TransferReceiveModal({
+  transfer,
+  srcName,
+  dstName,
+  wave,
+  onClose,
+  onSubmitted,
+}: {
+  transfer: Transfer;
+  srcName: string;
+  dstName: string;
+  wave: Wave | null;
+  onClose: () => void;
+  onSubmitted: () => void;
+}) {
+  const [items, setItems] = useState<TransferItem[] | null>(null);
+  const [skus, setSkus] = useState<Map<number, Sku>>(new Map());
+  const [edits, setEdits] = useState<Map<number, string>>(new Map());
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const readOnly = transfer.status !== "shipped";
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data: itemRows, error: e } = await sb
+          .from("transfer_items")
+          .select("id, transfer_id, sku_id, qty_requested, qty_shipped, qty_received")
+          .eq("transfer_id", transfer.id)
+          .order("id");
+        if (e) throw new Error(e.message);
+        const list = ((itemRows as TransferItem[] | null) ?? []).map((r) => ({
+          ...r,
+          qty_requested: Number(r.qty_requested),
+          qty_shipped: Number(r.qty_shipped),
+          qty_received: Number(r.qty_received),
+        }));
+        if (cancelled) return;
+        setItems(list);
+
+        const skuIds = Array.from(new Set(list.map((r) => r.sku_id)));
+        if (skuIds.length > 0) {
+          const { data: skuRows } = await sb
+            .from("skus")
+            .select("id, sku_code, product_name, variant_name")
+            .in("id", skuIds);
+          const m = new Map<number, Sku>();
+          for (const s of (skuRows as Sku[] | null) ?? []) m.set(s.id, s);
+          if (!cancelled) setSkus(m);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [transfer.id]);
+
+  const totalShipped = useMemo(
+    () => (items ?? []).reduce((s, r) => s + r.qty_shipped, 0),
+    [items],
+  );
+  const totalReceived = useMemo(() => {
+    if (!items) return 0;
+    return items.reduce((s, r) => {
+      if (readOnly) return s + r.qty_received;
+      const e = edits.get(r.id);
+      const v = e !== undefined ? Number(e) : r.qty_shipped;
+      return s + (Number.isNaN(v) ? 0 : v);
+    }, 0);
+  }, [items, edits, readOnly]);
+  const variance = totalReceived - totalShipped;
+
+  function setQty(itemId: number, val: string) {
+    setEdits((cur) => {
+      const next = new Map(cur);
+      next.set(itemId, val);
+      return next;
+    });
+  }
+
+  async function submit() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes?.user?.id;
+      if (!operator) throw new Error("未登入");
+
+      const lines: Array<{ transfer_item_id: number; qty_received: number }> = [];
+      for (const it of items ?? []) {
+        const e = edits.get(it.id);
+        if (e === undefined) continue;
+        const v = Number(e);
+        if (Number.isNaN(v) || v < 0) {
+          throw new Error(`item ${it.id}: 數量無效`);
+        }
+        if (v > it.qty_shipped) {
+          throw new Error(`item ${it.id}: 收貨量不可大於出貨量 ${it.qty_shipped}`);
+        }
+        if (v !== it.qty_shipped) {
+          lines.push({ transfer_item_id: it.id, qty_received: v });
+        }
+      }
+
+      const { data, error: e } = await sb.rpc("rpc_receive_transfer", {
+        p_transfer_id: transfer.id,
+        p_lines: lines.length === 0 ? null : lines,
+        p_operator: operator,
+        p_notes: note.trim() === "" ? null : note.trim(),
+      });
+      if (e) throw new Error(e.message);
+
+      const r = data as
+        | {
+            transfer_id: number;
+            items_received: number;
+            total_qty_received: number;
+            total_variance: number;
+          }
+        | null;
+      const varNote =
+        r && Number(r.total_variance) < 0
+          ? `\n⚠ 短收 ${Math.abs(Number(r.total_variance))}`
+          : "";
+      alert(
+        `收貨完成：${r?.items_received ?? 0} 行，實收合計 ${r?.total_qty_received ?? 0}${varNote}`,
+      );
+      onSubmitted();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-md bg-white shadow-xl dark:bg-zinc-900">
+        <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+          <div>
+            <h2 className="font-semibold">
+              收貨：<span className="font-mono">{transfer.transfer_no}</span>
+            </h2>
+            <div className="mt-0.5 text-xs text-zinc-500">
+              {srcName} → {dstName} ·{" "}
+              {TRANSFER_TYPE_LABEL[transfer.transfer_type] ?? transfer.transfer_type}
+              {wave && (
+                <>
+                  {" · 來自撿貨單 "}
+                  <span className="font-mono">{wave.wave_code}</span>
+                </>
+              )}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            {readOnly ? (
+              <span className="self-center rounded bg-emerald-100 px-2 py-1 text-xs text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+                ✓ 已收貨
+              </span>
+            ) : (
+              <button
+                onClick={submit}
+                disabled={submitting || !items}
+                className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+              >
+                {submitting ? "送出中…" : "確認收貨"}
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              關閉
+            </button>
+          </div>
+        </div>
+
+        <Timeline transfer={transfer} wave={wave} />
+
+        {error && (
+          <div className="border-b border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        <div className="overflow-auto p-3">
+          {items === null ? (
+            <div className="p-6 text-center text-sm text-zinc-500">載入中…</div>
+          ) : (
+            <Fragment>
+              <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+                <thead className="sticky top-0 bg-zinc-50 dark:bg-zinc-900">
+                  <tr>
+                    <th className="px-3 py-2 text-left text-xs uppercase text-zinc-500">商品</th>
+                    <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">出貨</th>
+                    <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">實收</th>
+                    <th className="px-3 py-2 text-right text-xs uppercase text-zinc-500">差異</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                  {items.map((it) => {
+                    const sku = skus.get(it.sku_id);
+                    const editVal = edits.get(it.id);
+                    const cur = readOnly
+                      ? String(it.qty_received)
+                      : editVal !== undefined
+                      ? editVal
+                      : String(it.qty_shipped);
+                    const numCur = Number(cur);
+                    const diff = !Number.isNaN(numCur) ? numCur - it.qty_shipped : 0;
+                    const overflowing = !readOnly && numCur > it.qty_shipped;
+                    return (
+                      <tr key={it.id}>
+                        <td className="px-3 py-2">
+                          <div className="font-medium">{sku?.product_name ?? "—"}</div>
+                          <div className="text-xs text-zinc-500">
+                            {sku?.sku_code}
+                            {sku?.variant_name ? ` / ${sku.variant_name}` : ""}
+                          </div>
+                        </td>
+                        <td className="px-3 py-2 text-right font-mono text-zinc-600 dark:text-zinc-300">
+                          {it.qty_shipped}
+                        </td>
+                        <td className="px-3 py-2 text-right">
+                          <input
+                            inputMode="decimal"
+                            value={cur}
+                            disabled={readOnly}
+                            onChange={(e) => setQty(it.id, e.target.value)}
+                            className={`w-20 rounded-md border px-2 py-0.5 text-right font-mono text-sm font-semibold ${
+                              overflowing
+                                ? "border-red-400 bg-red-50 dark:bg-red-950"
+                                : editVal !== undefined
+                                ? "border-amber-400 bg-amber-50 dark:bg-amber-950"
+                                : "border-zinc-300 bg-white dark:border-zinc-700 dark:bg-zinc-800"
+                            } disabled:bg-zinc-100 disabled:opacity-70 dark:disabled:bg-zinc-800`}
+                          />
+                        </td>
+                        <td
+                          className={`px-3 py-2 text-right font-mono text-xs ${
+                            diff === 0
+                              ? "text-zinc-400"
+                              : diff < 0
+                              ? "text-red-600 dark:text-red-400"
+                              : "text-purple-600 dark:text-purple-400"
+                          }`}
+                        >
+                          {diff === 0 ? "—" : diff > 0 ? `+${diff}` : `${diff}`}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+                <tfoot className="bg-zinc-50 dark:bg-zinc-900">
+                  <tr>
+                    <td className="px-3 py-2 text-right text-xs font-semibold text-zinc-500">合計</td>
+                    <td className="px-3 py-2 text-right font-mono font-semibold">{totalShipped}</td>
+                    <td className="px-3 py-2 text-right font-mono font-semibold">{totalReceived}</td>
+                    <td
+                      className={`px-3 py-2 text-right font-mono text-xs font-semibold ${
+                        variance === 0
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : variance < 0
+                          ? "text-red-600 dark:text-red-400"
+                          : "text-purple-600 dark:text-purple-400"
+                      }`}
+                    >
+                      {variance === 0 ? "✓" : variance > 0 ? `+${variance}` : `${variance}`}
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+
+              {!readOnly && (
+                <div className="mt-4">
+                  <label className="block text-xs text-zinc-500">備註（短收 / 異常說明）</label>
+                  <textarea
+                    value={note}
+                    onChange={(e) => setNote(e.target.value)}
+                    rows={2}
+                    className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                    placeholder="例：途中破損 2 件"
+                  />
+                </div>
+              )}
+              {readOnly && transfer.notes && (
+                <div className="mt-4 rounded-md border border-zinc-200 bg-zinc-50 p-2 text-xs text-zinc-600 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300">
+                  <div className="mb-1 text-zinc-500">備註</div>
+                  <div className="whitespace-pre-line">{transfer.notes}</div>
+                </div>
+              )}
+            </Fragment>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Timeline({ transfer, wave }: { transfer: Transfer; wave: Wave | null }) {
+  const steps: Array<{ label: string; ts: string | null; done: boolean }> = [
+    { label: "撿貨單建立", ts: wave?.created_at ?? null, done: !!wave },
+    { label: "派貨出倉", ts: transfer.shipped_at, done: !!transfer.shipped_at },
+    { label: "收貨", ts: transfer.received_at, done: transfer.status === "received" },
+  ];
+  return (
+    <div className="border-b border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
+      <ol className="flex items-center gap-1 overflow-x-auto text-xs">
+        {steps.map((s, i) => (
+          <Fragment key={s.label}>
+            <li className="flex min-w-0 items-center gap-2">
+              <span
+                className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${
+                  s.done
+                    ? "bg-emerald-600 text-white"
+                    : "bg-zinc-300 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300"
+                }`}
+              >
+                {s.done ? "✓" : i + 1}
+              </span>
+              <div className="min-w-0">
+                <div className={s.done ? "font-medium" : "text-zinc-500"}>{s.label}</div>
+                {s.ts && (
+                  <div className="text-[10px] text-zinc-500">
+                    {new Date(s.ts).toLocaleString("zh-TW")}
+                  </div>
+                )}
+              </div>
+            </li>
+            {i < steps.length - 1 && (
+              <li
+                aria-hidden
+                className={`h-[1px] flex-1 ${
+                  steps[i + 1].done ? "bg-emerald-400" : "bg-zinc-300 dark:bg-zinc-700"
+                }`}
+              />
+            )}
+          </Fragment>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -1,0 +1,36 @@
+// Map known Postgres RAISE EXCEPTION messages → Chinese.
+// Add patterns as more surface in production.
+
+type Rule = { pattern: RegExp; render: (m: RegExpMatchArray) => string };
+
+const RULES: Rule[] = [
+  {
+    pattern: /Insufficient stock:\s*available=([\d.]+),\s*required=([\d.]+)/i,
+    render: (m) => `庫存不足：總倉只剩 ${fmt(m[1])} 件，本次需要 ${fmt(m[2])} 件`,
+  },
+  {
+    pattern: /Insufficient points:\s*available=([\d.]+),\s*required=([\d.]+)/i,
+    render: (m) => `點數不足：可用 ${fmt(m[1])} 點，本次需要 ${fmt(m[2])} 點`,
+  },
+  {
+    pattern: /Insufficient wallet:\s*available=([\d.]+),\s*required=([\d.]+)/i,
+    render: (m) => `儲值金不足：可用 $${fmt(m[1])}，本次需要 $${fmt(m[2])}`,
+  },
+  { pattern: /Outbound quantity must be positive/i, render: () => "出庫數量必須大於 0" },
+  { pattern: /Inbound quantity must be positive/i, render: () => "入庫數量必須大於 0" },
+];
+
+function fmt(s: string): string {
+  const n = Number(s);
+  if (!Number.isFinite(n)) return s;
+  return Number.isInteger(n) ? String(n) : String(n);
+}
+
+export function translateRpcError(raw: unknown): string {
+  const msg = raw instanceof Error ? raw.message : String(raw);
+  for (const r of RULES) {
+    const m = msg.match(r.pattern);
+    if (m) return r.render(m);
+  }
+  return msg;
+}

--- a/docs/TEST-rpc-receive-transfer.md
+++ b/docs/TEST-rpc-receive-transfer.md
@@ -1,0 +1,83 @@
+---
+title: TEST — rpc_receive_transfer
+module: Inventory / Transfer
+status: draft
+owner: alex.chen
+created: 2026-04-26
+---
+
+# 測試清單 — `rpc_receive_transfer`
+
+分店端確認收貨：把 `transfers.status='shipped'` 推進到 `'received'`、寫 `transfer_items.qty_received`、對 dest_location 做 `transfer_in` stock_movement。
+
+## Scope
+
+- Migration：`supabase/migrations/20260504000000_rpc_receive_transfer.sql`
+- 上游：`generate_transfer_from_wave` 產生的 `WAVE-{wave_id}-S{store_id}` TR (status='shipped')
+- 下游（本 PR 不含）：分店收貨 UI
+
+## Schema 假設（已存在、不改）
+
+- `transfers.status` enum 包含 `'received'`
+- `transfer_items.qty_received` / `in_movement_id` 欄位存在
+- `transfer_items.qty_variance` 是 `qty_received - qty_shipped` 的 generated stored column
+- `stock_movements.movement_type` 包含 `'transfer_in'`
+
+## 簽章
+
+```sql
+rpc_receive_transfer(
+  p_transfer_id BIGINT,
+  p_lines       JSONB,   -- [{transfer_item_id: BIGINT, qty_received: NUMERIC}, ...] 或 NULL = 全收 (qty_received = qty_shipped)
+  p_operator    UUID,
+  p_notes       TEXT DEFAULT NULL
+) RETURNS JSONB
+-- { transfer_id, items_received: int, total_qty_received: numeric, total_variance: numeric }
+```
+
+## 測試項目
+
+### A. Happy path — 全收
+
+- [ ] A1：`p_lines=NULL` 時，每行 `qty_received := qty_shipped`
+- [ ] A2：每行寫入 1 筆 `transfer_in` stock_movement 至 `dest_location`，`source_doc_type='transfer'`、`source_doc_id=transfer_id`
+- [ ] A3：`stock_movements.unit_cost` 沿用對應 `out_movement` 的 unit_cost（保持成本流）
+- [ ] A4：`transfer_items.in_movement_id` 寫入新 movement id
+- [ ] A5：`transfers.status='received'`、`received_by=p_operator`、`received_at=NOW()`
+- [ ] A6：dest_location 的 `stock_balances.on_hand` 增加對應 qty
+- [ ] A7：返回 JSONB 含 `items_received` / `total_qty_received` / `total_variance=0`
+
+### B. Happy path — 部分收（短收）
+
+- [ ] B1：`p_lines` 指定 `qty_received < qty_shipped` → 該行寫入該 qty
+- [ ] B2：`qty_variance` (generated) 自動算為負值
+- [ ] B3：`transfer_in` stock_movement 只進實收 qty
+- [ ] B4：status 仍轉 `'received'`（短收不卡單）
+- [ ] B5：返回 JSONB 中 `total_variance < 0`
+
+### C. 邊界 / 錯誤
+
+- [ ] C1：transfer 不存在 → `RAISE EXCEPTION 'transfer % not found'`
+- [ ] C2：transfer status ≠ 'shipped'（draft / received / cancelled）→ `RAISE EXCEPTION 'transfer % is in status %, expected shipped'`
+- [ ] C3：`qty_received < 0` → exception
+- [ ] C4：`qty_received > qty_shipped`（過收）→ exception（避免無中生有）
+- [ ] C5：`p_lines` 內含不屬於本 transfer 的 `transfer_item_id` → exception
+- [ ] C6：`p_lines` 漏掉某 transfer_item（不全列出）→ 該行視為全收 `qty_received = qty_shipped`（與 A1 一致的 default）
+- [ ] C7：concurrent 兩支 RPC 同 transfer_id → 第二支拿不到 lock，後執行者看到 status 已轉 received → exception（advisory lock 或 SELECT FOR UPDATE）
+
+### D. 與既有 wave 鏈路整合
+
+- [ ] D1：完整鏈路 wave open → picked → ship（generate transfers）→ rpc_receive_transfer → 庫存從 HQ 流到 store，`stock_movements` 兩筆對應（transfer_out @ HQ + transfer_in @ store）
+- [ ] D2：`v_pr_progress` view 不受影響（如果有用 transfers.status 的話）
+- [ ] D3：append-only 約束：transfer 已 received，再呼叫 rpc_receive_transfer → C2 擋住
+
+### E. RLS / 權限（後續 UI 才驗，本 RPC 是 SECURITY DEFINER）
+
+- [ ] E1：RPC GRANT EXECUTE TO authenticated
+- [ ] E2：應用層由 UI 傳 p_operator（後續 admin / 店長 RLS 在 UI 層 / view 層處理）
+
+## 不在範圍
+
+- 短收處理流程（補單 / 退款 / claim 對 carrier）— 短收只記錄 variance，後續處理另案
+- 收貨 UI（下個 PR）
+- 月結算金流（PRD §3.5）— 那是另一條線

--- a/scripts/fixture-shipped-transfer.sql
+++ b/scripts/fixture-shipped-transfer.sql
@@ -1,0 +1,45 @@
+-- 建一筆 shipped transfer fixture 給 UI 手動測試用。回傳 transfer_id。
+DO $do$
+DECLARE
+  v_tenant   UUID;
+  v_op       UUID := '22222222-2222-2222-2222-222222222222';
+  v_src      BIGINT;
+  v_dst      BIGINT;
+  v_sku_a    BIGINT;
+  v_sku_b    BIGINT;
+  v_xfer     BIGINT;
+  v_out_a    BIGINT;
+  v_out_b    BIGINT;
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM locations LIMIT 1;
+  SELECT id INTO v_src FROM locations WHERE type = 'central_warehouse' AND is_active LIMIT 1;
+  SELECT id INTO v_dst FROM locations WHERE id <> v_src LIMIT 1;
+  SELECT id INTO v_sku_a FROM skus ORDER BY id LIMIT 1;
+  SELECT id INTO v_sku_b FROM skus WHERE id <> v_sku_a ORDER BY id LIMIT 1;
+
+  INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location,
+                         status, transfer_type, requested_by, shipped_by, shipped_at,
+                         created_by, updated_by)
+  VALUES (v_tenant, 'FIXTURE-' || EXTRACT(EPOCH FROM NOW())::BIGINT,
+          v_src, v_dst, 'shipped', 'hq_to_store',
+          v_op, v_op, NOW(), v_op, v_op)
+  RETURNING id INTO v_xfer;
+
+  INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                                movement_type, source_doc_type, source_doc_id, operator_id)
+  VALUES (v_tenant, v_src, v_sku_a, -10, 25.5, 'transfer_out', 'transfer', v_xfer, v_op)
+  RETURNING id INTO v_out_a;
+
+  INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                                movement_type, source_doc_type, source_doc_id, operator_id)
+  VALUES (v_tenant, v_src, v_sku_b, -5, 100, 'transfer_out', 'transfer', v_xfer, v_op)
+  RETURNING id INTO v_out_b;
+
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped,
+                              out_movement_id, created_by, updated_by)
+  VALUES (v_xfer, v_sku_a, 10, 10, v_out_a, v_op, v_op),
+         (v_xfer, v_sku_b, 5, 5, v_out_b, v_op, v_op);
+
+  RAISE NOTICE 'fixture transfer_id=%', v_xfer;
+END
+$do$;

--- a/scripts/test-rpc-receive-transfer.sql
+++ b/scripts/test-rpc-receive-transfer.sql
@@ -1,0 +1,160 @@
+-- 測試 rpc_receive_transfer。整段在一個 transaction 裡、最後 ROLLBACK。
+-- 為了單一 prepared statement，全部包在一個 DO 區塊裡，最後 RAISE 'ROLLBACK_OK' 強迫整段回滾。
+DO $outer$
+DECLARE
+  v_tenant      UUID := '11111111-1111-1111-1111-111111111111';
+  v_op          UUID := '22222222-2222-2222-2222-222222222222';
+  v_src_loc     BIGINT;
+  v_dst_loc     BIGINT;
+  v_sku_a       BIGINT;
+  v_sku_b       BIGINT;
+  v_xfer_id     BIGINT;
+  v_item_a_id   BIGINT;
+  v_item_b_id   BIGINT;
+  v_out_a       BIGINT;
+  v_out_b       BIGINT;
+  v_result      JSONB;
+  v_status      TEXT;
+  v_qty_a       NUMERIC;
+  v_qty_b       NUMERIC;
+  v_var_a       NUMERIC;
+  v_in_mov_a    BIGINT;
+  v_in_mov_b    BIGINT;
+  v_in_qty      NUMERIC;
+  v_in_cost     NUMERIC;
+BEGIN
+  -- C1: not found
+  BEGIN
+    PERFORM rpc_receive_transfer(-99999, NULL, v_op, NULL);
+    RAISE EXCEPTION 'C1 FAILED: should have raised';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%not found%' THEN
+      RAISE NOTICE 'C1 PASS: %', SQLERRM;
+    ELSE RAISE; END IF;
+  END;
+
+  SELECT id INTO v_src_loc FROM locations ORDER BY id LIMIT 1;
+  SELECT id INTO v_dst_loc FROM locations WHERE id <> v_src_loc ORDER BY id LIMIT 1;
+  IF v_src_loc IS NULL OR v_dst_loc IS NULL THEN
+    RAISE EXCEPTION 'need at least 2 locations';
+  END IF;
+
+  SELECT id INTO v_sku_a FROM skus ORDER BY id LIMIT 1;
+  SELECT id INTO v_sku_b FROM skus WHERE id <> v_sku_a ORDER BY id LIMIT 1;
+  IF v_sku_a IS NULL OR v_sku_b IS NULL THEN
+    RAISE EXCEPTION 'need at least 2 skus';
+  END IF;
+
+  INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location,
+                         status, transfer_type, requested_by, shipped_by, shipped_at,
+                         created_by, updated_by)
+  VALUES (v_tenant, 'TEST-RECV-' || EXTRACT(EPOCH FROM NOW())::TEXT,
+          v_src_loc, v_dst_loc, 'shipped', 'hq_to_store',
+          v_op, v_op, NOW(), v_op, v_op)
+  RETURNING id INTO v_xfer_id;
+
+  INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                                movement_type, source_doc_type, source_doc_id, operator_id)
+  VALUES (v_tenant, v_src_loc, v_sku_a, -10, 25.5, 'transfer_out', 'transfer', v_xfer_id, v_op)
+  RETURNING id INTO v_out_a;
+  INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                                movement_type, source_doc_type, source_doc_id, operator_id)
+  VALUES (v_tenant, v_src_loc, v_sku_b, -5, 100, 'transfer_out', 'transfer', v_xfer_id, v_op)
+  RETURNING id INTO v_out_b;
+
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped,
+                              out_movement_id, created_by, updated_by)
+  VALUES (v_xfer_id, v_sku_a, 10, 10, v_out_a, v_op, v_op)
+  RETURNING id INTO v_item_a_id;
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped,
+                              out_movement_id, created_by, updated_by)
+  VALUES (v_xfer_id, v_sku_b, 5, 5, v_out_b, v_op, v_op)
+  RETURNING id INTO v_item_b_id;
+
+  RAISE NOTICE 'fixture: transfer_id=% items=%,%', v_xfer_id, v_item_a_id, v_item_b_id;
+
+  -- C4: over-receipt
+  BEGIN
+    PERFORM rpc_receive_transfer(v_xfer_id,
+      jsonb_build_array(jsonb_build_object('transfer_item_id', v_item_a_id, 'qty_received', 999)),
+      v_op, NULL);
+    RAISE EXCEPTION 'C4 FAILED';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%over-receipt%' THEN RAISE NOTICE 'C4 PASS: %', SQLERRM;
+    ELSE RAISE; END IF;
+  END;
+
+  -- C3: negative
+  BEGIN
+    PERFORM rpc_receive_transfer(v_xfer_id,
+      jsonb_build_array(jsonb_build_object('transfer_item_id', v_item_a_id, 'qty_received', -1)),
+      v_op, NULL);
+    RAISE EXCEPTION 'C3 FAILED';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%>= 0%' THEN RAISE NOTICE 'C3 PASS: %', SQLERRM;
+    ELSE RAISE; END IF;
+  END;
+
+  -- C5: foreign item id
+  BEGIN
+    PERFORM rpc_receive_transfer(v_xfer_id,
+      jsonb_build_array(jsonb_build_object('transfer_item_id', -77777, 'qty_received', 1)),
+      v_op, NULL);
+    RAISE EXCEPTION 'C5 FAILED';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%not belonging%' THEN RAISE NOTICE 'C5 PASS: %', SQLERRM;
+    ELSE RAISE; END IF;
+  END;
+
+  -- B: A 短收 8/10，B 漏列 → 預設全收 5
+  v_result := rpc_receive_transfer(v_xfer_id,
+    jsonb_build_array(jsonb_build_object('transfer_item_id', v_item_a_id, 'qty_received', 8)),
+    v_op, 'broken 2 in transit');
+
+  RAISE NOTICE 'B result: %', v_result;
+  IF (v_result->>'items_received')::INT <> 2 OR
+     (v_result->>'total_qty_received')::NUMERIC <> 13 OR
+     (v_result->>'total_variance')::NUMERIC <> -2 THEN
+    RAISE EXCEPTION 'B FAILED: %', v_result;
+  END IF;
+  RAISE NOTICE 'B PASS';
+
+  SELECT status INTO v_status FROM transfers WHERE id = v_xfer_id;
+  IF v_status <> 'received' THEN RAISE EXCEPTION 'A5 FAILED: %', v_status; END IF;
+  RAISE NOTICE 'A5 PASS: status=received';
+
+  SELECT qty_received, qty_variance, in_movement_id
+    INTO v_qty_a, v_var_a, v_in_mov_a
+    FROM transfer_items WHERE id = v_item_a_id;
+  IF v_qty_a <> 8 OR v_var_a <> -2 OR v_in_mov_a IS NULL THEN
+    RAISE EXCEPTION 'B1/B2 FAILED: qty=% var=% mov=%', v_qty_a, v_var_a, v_in_mov_a;
+  END IF;
+  RAISE NOTICE 'B1/B2 PASS: A qty=8 var=-2';
+
+  SELECT qty_received, in_movement_id INTO v_qty_b, v_in_mov_b
+    FROM transfer_items WHERE id = v_item_b_id;
+  IF v_qty_b <> 5 OR v_in_mov_b IS NULL THEN
+    RAISE EXCEPTION 'C6 FAILED: qty_b=%', v_qty_b;
+  END IF;
+  RAISE NOTICE 'C6 PASS: missing line defaults full';
+
+  SELECT quantity, unit_cost INTO v_in_qty, v_in_cost
+    FROM stock_movements WHERE id = v_in_mov_a;
+  IF v_in_qty <> 8 OR v_in_cost <> 25.5 THEN
+    RAISE EXCEPTION 'A2/A3 FAILED: qty=% cost=%', v_in_qty, v_in_cost;
+  END IF;
+  RAISE NOTICE 'A2/A3 PASS: in_mov qty=+8 cost=25.5';
+
+  -- C2: re-receive
+  BEGIN
+    PERFORM rpc_receive_transfer(v_xfer_id, NULL, v_op, NULL);
+    RAISE EXCEPTION 'C2 FAILED';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE '%expected shipped%' THEN RAISE NOTICE 'C2 PASS: %', SQLERRM;
+    ELSE RAISE; END IF;
+  END;
+
+  RAISE NOTICE 'ALL TESTS PASSED — rolling back';
+  RAISE EXCEPTION 'ROLLBACK_OK';
+END
+$outer$;

--- a/supabase/migrations/20260504000000_rpc_receive_transfer.sql
+++ b/supabase/migrations/20260504000000_rpc_receive_transfer.sql
@@ -1,0 +1,150 @@
+-- rpc_receive_transfer：分店端確認收貨
+--
+-- 流程：
+--   transfers.status='shipped' → 'received'
+--   每行 transfer_items 寫入實收 qty + transfer_in stock_movement 至 dest_location
+--   short receipt（qty_received < qty_shipped）只記錄 variance、不卡單；over receipt 擋住
+--
+-- 上游：generate_transfer_from_wave 產生的 hq_to_store TR
+-- 下游：分店 inbox UI（後續 PR）
+
+CREATE OR REPLACE FUNCTION rpc_receive_transfer(
+  p_transfer_id BIGINT,
+  p_lines       JSONB,        -- [{transfer_item_id, qty_received}, ...] 或 NULL = 全收
+  p_operator    UUID,
+  p_notes       TEXT DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+  v_tenant_id        UUID;
+  v_status           TEXT;
+  v_dest_location    BIGINT;
+  v_existing_notes   TEXT;
+  v_item             RECORD;
+  v_qty_received     NUMERIC;
+  v_unit_cost        NUMERIC;
+  v_in_mov_id        BIGINT;
+  v_total_qty        NUMERIC := 0;
+  v_total_variance   NUMERIC := 0;
+  v_items_received   INTEGER := 0;
+  v_lines_consumed   INTEGER := 0;
+  v_lines_count      INTEGER;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('transfer:' || p_transfer_id));
+
+  SELECT tenant_id, status, dest_location, notes
+    INTO v_tenant_id, v_status, v_dest_location, v_existing_notes
+    FROM transfers
+   WHERE id = p_transfer_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transfer % not found', p_transfer_id;
+  END IF;
+
+  IF v_status <> 'shipped' THEN
+    RAISE EXCEPTION 'transfer % is in status %, expected shipped', p_transfer_id, v_status;
+  END IF;
+
+  IF p_lines IS NOT NULL THEN
+    v_lines_count := jsonb_array_length(p_lines);
+
+    -- p_lines 內所有 transfer_item_id 必須屬於本 transfer
+    IF EXISTS (
+      SELECT 1
+        FROM jsonb_array_elements(p_lines) AS l
+        LEFT JOIN transfer_items ti
+          ON ti.id = (l->>'transfer_item_id')::BIGINT
+         AND ti.transfer_id = p_transfer_id
+       WHERE ti.id IS NULL
+    ) THEN
+      RAISE EXCEPTION 'p_lines contains transfer_item_id not belonging to transfer %', p_transfer_id;
+    END IF;
+  END IF;
+
+  FOR v_item IN
+    SELECT ti.id, ti.sku_id, ti.qty_shipped, sm.unit_cost AS out_cost
+      FROM transfer_items ti
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE ti.transfer_id = p_transfer_id
+     ORDER BY ti.id
+  LOOP
+    -- 預設全收；若 p_lines 有指定該 item，採用指定值
+    v_qty_received := v_item.qty_shipped;
+
+    IF p_lines IS NOT NULL THEN
+      SELECT (l->>'qty_received')::NUMERIC
+        INTO v_qty_received
+        FROM jsonb_array_elements(p_lines) AS l
+       WHERE (l->>'transfer_item_id')::BIGINT = v_item.id
+       LIMIT 1;
+
+      IF FOUND THEN
+        v_lines_consumed := v_lines_consumed + 1;
+      ELSE
+        v_qty_received := v_item.qty_shipped;  -- 漏列 = 視為全收
+      END IF;
+    END IF;
+
+    IF v_qty_received IS NULL OR v_qty_received < 0 THEN
+      RAISE EXCEPTION 'transfer_item % qty_received must be >= 0, got %', v_item.id, v_qty_received;
+    END IF;
+    IF v_qty_received > v_item.qty_shipped THEN
+      RAISE EXCEPTION 'transfer_item % over-receipt: qty_received=% > qty_shipped=%',
+        v_item.id, v_qty_received, v_item.qty_shipped;
+    END IF;
+
+    IF v_qty_received > 0 THEN
+      v_unit_cost := COALESCE(ABS(v_item.out_cost), 0);
+
+      v_in_mov_id := rpc_inbound(
+        p_tenant_id       => v_tenant_id,
+        p_location_id     => v_dest_location,
+        p_sku_id          => v_item.sku_id,
+        p_quantity        => v_qty_received,
+        p_unit_cost       => v_unit_cost,
+        p_movement_type   => 'transfer_in',
+        p_source_doc_type => 'transfer',
+        p_source_doc_id   => p_transfer_id,
+        p_operator        => p_operator
+      );
+
+      UPDATE transfer_items
+         SET qty_received   = v_qty_received,
+             in_movement_id = v_in_mov_id,
+             updated_by     = p_operator
+       WHERE id = v_item.id;
+    ELSE
+      -- 0 收：仍標記 qty_received=0，no movement
+      UPDATE transfer_items
+         SET qty_received = 0,
+             updated_by   = p_operator
+       WHERE id = v_item.id;
+    END IF;
+
+    v_total_qty      := v_total_qty + v_qty_received;
+    v_total_variance := v_total_variance + (v_qty_received - v_item.qty_shipped);
+    v_items_received := v_items_received + 1;
+  END LOOP;
+
+  UPDATE transfers
+     SET status      = 'received',
+         received_by = p_operator,
+         received_at = NOW(),
+         notes       = CASE
+                         WHEN p_notes IS NULL OR p_notes = '' THEN v_existing_notes
+                         WHEN v_existing_notes IS NULL OR v_existing_notes = '' THEN p_notes
+                         ELSE v_existing_notes || E'\n' || p_notes
+                       END,
+         updated_by  = p_operator
+   WHERE id = p_transfer_id;
+
+  RETURN jsonb_build_object(
+    'transfer_id',        p_transfer_id,
+    'items_received',     v_items_received,
+    'total_qty_received', v_total_qty,
+    'total_variance',     v_total_variance
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION rpc_receive_transfer(BIGINT, JSONB, UUID, TEXT) TO authenticated;

--- a/supabase/migrations/20260504010000_confirm_picked_backfill_picked_qty.sql
+++ b/supabase/migrations/20260504010000_confirm_picked_backfill_picked_qty.sql
@@ -1,0 +1,77 @@
+-- rpc_confirm_picked 在轉 status='picked' 時，若仍有 picked_qty IS NULL 的行
+-- 自動 backfill picked_qty := qty（語意：「沒手動改 = 全照計畫撿到」）。
+--
+-- 修補的 bug：使用者只看了 modal、沒動數字直接按「確認修正完成」，
+-- DB 裡 picked_qty 仍是 NULL；接著「派貨出倉」時 generate_transfer_from_wave
+-- 掃 picked_qty > 0 抓到 0 行，raise 'wave X has no picked items'。
+--
+-- 順便修補存量資料：把已是 picked / shipped / cancelled 狀態的 wave 中
+-- 仍 NULL 的 picked_qty 補成 qty（給 wave 17 之類已卡住的單一條救援路）。
+
+CREATE OR REPLACE FUNCTION public.rpc_confirm_picked(
+  p_wave_id  BIGINT,
+  p_operator UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant_id  UUID;
+  v_old_status TEXT;
+  v_backfilled INTEGER;
+BEGIN
+  SELECT tenant_id, status INTO v_tenant_id, v_old_status
+    FROM picking_waves
+   WHERE id = p_wave_id
+     FOR UPDATE;
+
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'wave % not found', p_wave_id;
+  END IF;
+
+  IF v_old_status = 'picked' THEN
+    -- idempotent，但仍把 NULL 的 picked_qty backfill 一次（救援已卡住的單）
+    UPDATE picking_wave_items
+       SET picked_qty = qty,
+           updated_by = p_operator
+     WHERE wave_id = p_wave_id
+       AND picked_qty IS NULL;
+    RETURN;
+  END IF;
+
+  IF v_old_status NOT IN ('draft', 'picking') THEN
+    RAISE EXCEPTION 'wave % cannot be confirmed picked from status %', p_wave_id, v_old_status;
+  END IF;
+
+  UPDATE picking_wave_items
+     SET picked_qty = qty,
+         updated_by = p_operator
+   WHERE wave_id = p_wave_id
+     AND picked_qty IS NULL;
+  GET DIAGNOSTICS v_backfilled = ROW_COUNT;
+
+  UPDATE picking_waves
+     SET status     = 'picked',
+         updated_at = NOW(),
+         updated_by = p_operator
+   WHERE id = p_wave_id;
+
+  INSERT INTO picking_wave_audit_log (
+    tenant_id, wave_id, action, before_value, after_value, created_by
+  ) VALUES (
+    v_tenant_id,
+    p_wave_id,
+    'wave_status_changed',
+    jsonb_build_object('status', v_old_status),
+    jsonb_build_object('status', 'picked', 'picked_qty_backfilled', v_backfilled),
+    p_operator
+  );
+END;
+$$;
+
+-- 一次性救援：所有非 draft / picking 狀態的 wave 中還是 NULL 的 picked_qty
+-- 補成 qty（含 wave 17 等卡住的單）。
+UPDATE picking_wave_items pwi
+   SET picked_qty = qty
+  FROM picking_waves pw
+ WHERE pwi.wave_id = pw.id
+   AND pwi.picked_qty IS NULL
+   AND pw.status IN ('picked', 'shipped', 'cancelled');

--- a/supabase/migrations/20260504020000_v_pr_progress_with_transfers.sql
+++ b/supabase/migrations/20260504020000_v_pr_progress_with_transfers.sql
@@ -1,0 +1,68 @@
+-- v_pr_progress 補上 transfer 統計：
+--   transfer_total      該 PR 的 close_date 對應的 hq_to_store transfer 總數
+--   transfer_shipped    其中 status >= shipped 的張數
+--   transfer_delivered  其中 status = received 的張數
+--
+-- 路徑：PR.source_close_date = picking_waves.wave_date → 抓 wave.id
+--       → transfers WHERE transfer_no LIKE 'WAVE-{wave.id}-S%' AND transfer_type='hq_to_store'
+--
+-- 為什麼 PR list 的 step 8 / step 9 一直是 pending：前端讀
+-- p.transfer_total / transfer_shipped / transfer_delivered，但 v_pr_progress 沒這些欄位。
+-- 補上後 timeline 才會跟著 wave 派貨 / 分店收貨更新。
+
+CREATE OR REPLACE VIEW public.v_pr_progress AS
+SELECT
+  pr.id   AS pr_id,
+  pr.tenant_id,
+  pr.source_close_date,
+  COALESCE(po_agg.po_total, 0)          AS po_total,
+  COALESCE(po_agg.po_sent, 0)           AS po_sent,
+  COALESCE(po_agg.po_received_fully, 0) AS po_received_fully,
+  COALESCE(xfer_agg.transfer_total, 0)     AS transfer_total,
+  COALESCE(xfer_agg.transfer_shipped, 0)   AS transfer_shipped,
+  COALESCE(xfer_agg.transfer_delivered, 0) AS transfer_delivered,
+  CASE
+    WHEN pr.source_close_date IS NULL THEN FALSE
+    WHEN cmp.total_campaigns = 0 THEN FALSE
+    ELSE cmp.completed_campaigns = cmp.total_campaigns
+  END AS all_campaigns_finalized
+FROM purchase_requests pr
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(DISTINCT po.id)                                                         AS po_total,
+    COUNT(DISTINCT po.id) FILTER (WHERE po.status IN ('sent','partially_received','fully_received','closed')) AS po_sent,
+    COUNT(DISTINCT po.id) FILTER (WHERE po.status IN ('fully_received','closed')) AS po_received_fully
+    FROM purchase_request_items pri
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+    JOIN purchase_orders po       ON po.id  = poi.po_id
+   WHERE pri.pr_id = pr.id
+) po_agg ON TRUE
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(DISTINCT t.id)                                                                         AS transfer_total,
+    COUNT(DISTINCT t.id) FILTER (WHERE t.status IN ('shipped','received','closed'))              AS transfer_shipped,
+    COUNT(DISTINCT t.id) FILTER (WHERE t.status IN ('received','closed'))                        AS transfer_delivered
+    FROM picking_waves pw
+    JOIN transfers t
+      ON t.tenant_id      = pw.tenant_id
+     AND t.transfer_type  = 'hq_to_store'
+     AND t.transfer_no LIKE 'WAVE-' || pw.id || '-S%'
+   WHERE pw.tenant_id = pr.tenant_id
+     AND pr.source_close_date IS NOT NULL
+     AND pw.wave_date = pr.source_close_date
+) xfer_agg ON TRUE
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(*)                                                AS total_campaigns,
+    COUNT(*) FILTER (WHERE gbc.status = 'completed')        AS completed_campaigns
+    FROM group_buy_campaigns gbc
+   WHERE gbc.tenant_id = pr.tenant_id
+     AND pr.source_close_date IS NOT NULL
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = pr.source_close_date
+     AND gbc.status NOT IN ('cancelled')
+) cmp ON TRUE;
+
+GRANT SELECT ON public.v_pr_progress TO authenticated;
+
+COMMENT ON VIEW public.v_pr_progress IS
+  'PR 進度摘要：PO 收貨進度 + 配送 transfer 進度 + close_date 對應 campaigns 是否全部 finalized（給 stepper 用）';

--- a/supabase/migrations/20260504030000_v_pr_progress_fix_transfer_join.sql
+++ b/supabase/migrations/20260504030000_v_pr_progress_fix_transfer_join.sql
@@ -1,0 +1,73 @@
+-- v_pr_progress 的 transfer 統計用 wave_date == source_close_date join 是錯的，
+-- 因為累積式撿貨單會把多個結單日的商品合到同一張 wave（wave_date 是配送日，
+-- 不一定等於某張 PR 的 close_date）。
+--
+-- 正確路徑：
+--   PR.source_close_date → group_buy_campaigns（DATE(end_at AT 'Asia/Taipei') = source_close_date）
+--   → picking_wave_items.campaign_id IN (那些 campaign)
+--   → picking_wave_items.wave_id
+--   → transfers WHERE transfer_no LIKE 'WAVE-{wave_id}-S%' AND transfer_type='hq_to_store'
+--
+-- 改用 campaign_id 鏈路後，多 close_date 共用一張 wave 也能正確攤算：
+-- 同一張 transfer 可能會被多個 PR 算到（各自結單日商品都在那張 wave 裡），
+-- 這對 step 8/9 是合理的（兩個 PR 的「派貨」確實由同一張 transfer 處理）。
+
+CREATE OR REPLACE VIEW public.v_pr_progress AS
+SELECT
+  pr.id   AS pr_id,
+  pr.tenant_id,
+  pr.source_close_date,
+  COALESCE(po_agg.po_total, 0)          AS po_total,
+  COALESCE(po_agg.po_sent, 0)           AS po_sent,
+  COALESCE(po_agg.po_received_fully, 0) AS po_received_fully,
+  COALESCE(xfer_agg.transfer_total, 0)     AS transfer_total,
+  COALESCE(xfer_agg.transfer_shipped, 0)   AS transfer_shipped,
+  COALESCE(xfer_agg.transfer_delivered, 0) AS transfer_delivered,
+  CASE
+    WHEN pr.source_close_date IS NULL THEN FALSE
+    WHEN cmp.total_campaigns = 0 THEN FALSE
+    ELSE cmp.completed_campaigns = cmp.total_campaigns
+  END AS all_campaigns_finalized
+FROM purchase_requests pr
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(DISTINCT po.id)                                                         AS po_total,
+    COUNT(DISTINCT po.id) FILTER (WHERE po.status IN ('sent','partially_received','fully_received','closed')) AS po_sent,
+    COUNT(DISTINCT po.id) FILTER (WHERE po.status IN ('fully_received','closed')) AS po_received_fully
+    FROM purchase_request_items pri
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+    JOIN purchase_orders po       ON po.id  = poi.po_id
+   WHERE pri.pr_id = pr.id
+) po_agg ON TRUE
+LEFT JOIN LATERAL (
+  -- 透過 PR close_date → campaign → picking_wave_items.campaign_id → wave → transfer
+  SELECT
+    COUNT(DISTINCT t.id)                                                                  AS transfer_total,
+    COUNT(DISTINCT t.id) FILTER (WHERE t.status IN ('shipped','received','closed'))       AS transfer_shipped,
+    COUNT(DISTINCT t.id) FILTER (WHERE t.status IN ('received','closed'))                 AS transfer_delivered
+    FROM group_buy_campaigns gbc
+    JOIN picking_wave_items pwi ON pwi.campaign_id = gbc.id
+    JOIN transfers t
+      ON t.tenant_id      = gbc.tenant_id
+     AND t.transfer_type  = 'hq_to_store'
+     AND t.transfer_no LIKE 'WAVE-' || pwi.wave_id || '-S%'
+   WHERE gbc.tenant_id = pr.tenant_id
+     AND pr.source_close_date IS NOT NULL
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = pr.source_close_date
+     AND gbc.status NOT IN ('cancelled')
+) xfer_agg ON TRUE
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(*)                                                AS total_campaigns,
+    COUNT(*) FILTER (WHERE gbc.status = 'completed')        AS completed_campaigns
+    FROM group_buy_campaigns gbc
+   WHERE gbc.tenant_id = pr.tenant_id
+     AND pr.source_close_date IS NOT NULL
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = pr.source_close_date
+     AND gbc.status NOT IN ('cancelled')
+) cmp ON TRUE;
+
+GRANT SELECT ON public.v_pr_progress TO authenticated;
+
+COMMENT ON VIEW public.v_pr_progress IS
+  'PR 進度摘要：PO 收貨進度 + 配送 transfer 進度（透過 campaign_id 鏈路，支援累積式 wave）';

--- a/supabase/migrations/20260504040000_v_pr_progress_item_counts.sql
+++ b/supabase/migrations/20260504040000_v_pr_progress_item_counts.sql
@@ -1,0 +1,74 @@
+-- v_pr_progress 補上 item_count + unassigned_supplier_count
+-- 解決 PR 列表草稿 PR 顯示 $0 看起來像空單、實際裡面有內容、admin 不知道要進去填的問題。
+--
+-- 用 DROP + CREATE 是因為新欄位插在中間、CREATE OR REPLACE 不允許改欄位順序。
+
+DROP VIEW IF EXISTS public.v_pr_progress;
+
+CREATE VIEW public.v_pr_progress AS
+SELECT
+  pr.id   AS pr_id,
+  pr.tenant_id,
+  pr.source_close_date,
+  COALESCE(po_agg.po_total, 0)          AS po_total,
+  COALESCE(po_agg.po_sent, 0)           AS po_sent,
+  COALESCE(po_agg.po_received_fully, 0) AS po_received_fully,
+  COALESCE(xfer_agg.transfer_total, 0)     AS transfer_total,
+  COALESCE(xfer_agg.transfer_shipped, 0)   AS transfer_shipped,
+  COALESCE(xfer_agg.transfer_delivered, 0) AS transfer_delivered,
+  COALESCE(item_agg.item_count, 0)               AS item_count,
+  COALESCE(item_agg.unassigned_supplier_count, 0) AS unassigned_supplier_count,
+  CASE
+    WHEN pr.source_close_date IS NULL THEN FALSE
+    WHEN cmp.total_campaigns = 0 THEN FALSE
+    ELSE cmp.completed_campaigns = cmp.total_campaigns
+  END AS all_campaigns_finalized
+FROM purchase_requests pr
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(DISTINCT po.id)                                                         AS po_total,
+    COUNT(DISTINCT po.id) FILTER (WHERE po.status IN ('sent','partially_received','fully_received','closed')) AS po_sent,
+    COUNT(DISTINCT po.id) FILTER (WHERE po.status IN ('fully_received','closed')) AS po_received_fully
+    FROM purchase_request_items pri
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+    JOIN purchase_orders po       ON po.id  = poi.po_id
+   WHERE pri.pr_id = pr.id
+) po_agg ON TRUE
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(DISTINCT t.id)                                                                  AS transfer_total,
+    COUNT(DISTINCT t.id) FILTER (WHERE t.status IN ('shipped','received','closed'))       AS transfer_shipped,
+    COUNT(DISTINCT t.id) FILTER (WHERE t.status IN ('received','closed'))                 AS transfer_delivered
+    FROM group_buy_campaigns gbc
+    JOIN picking_wave_items pwi ON pwi.campaign_id = gbc.id
+    JOIN transfers t
+      ON t.tenant_id      = gbc.tenant_id
+     AND t.transfer_type  = 'hq_to_store'
+     AND t.transfer_no LIKE 'WAVE-' || pwi.wave_id || '-S%'
+   WHERE gbc.tenant_id = pr.tenant_id
+     AND pr.source_close_date IS NOT NULL
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = pr.source_close_date
+     AND gbc.status NOT IN ('cancelled')
+) xfer_agg ON TRUE
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(*)                                                       AS item_count,
+    COUNT(*) FILTER (WHERE pri.suggested_supplier_id IS NULL)      AS unassigned_supplier_count
+    FROM purchase_request_items pri
+   WHERE pri.pr_id = pr.id
+) item_agg ON TRUE
+LEFT JOIN LATERAL (
+  SELECT
+    COUNT(*)                                                AS total_campaigns,
+    COUNT(*) FILTER (WHERE gbc.status = 'completed')        AS completed_campaigns
+    FROM group_buy_campaigns gbc
+   WHERE gbc.tenant_id = pr.tenant_id
+     AND pr.source_close_date IS NOT NULL
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = pr.source_close_date
+     AND gbc.status NOT IN ('cancelled')
+) cmp ON TRUE;
+
+GRANT SELECT ON public.v_pr_progress TO authenticated;
+
+COMMENT ON VIEW public.v_pr_progress IS
+  'PR 進度摘要：PO / transfer / 品項數 / 未指派 supplier 數 / campaigns finalized';


### PR DESCRIPTION
## Summary

- 訂單明細加 5 步進度 timeline（採購到貨 → 撿貨 → 派貨出倉 → 分店收貨 → 顧客取貨）
- step 3 撿貨 顯示 wave_no、可點到 `/picking/history?wave=N`
- step 4/5 派貨/收貨 顯示 TR 單號、可點到 `/transfers`
- 新增 `lib/rpcError.ts` 把 Postgres `RAISE EXCEPTION` 英文訊息翻成中文（庫存/點數/儲值金不足、出入庫數量為 0），套到 picking/history 全部錯誤顯示
- 加 PR 列表「品項」欄位 + 未指派 supplier 琥珀 badge
- 訂單明細 by 顯示 user name（非 UUID）
- dev server `autoPort: true` 避免 3000 被佔擋住

## 14 commits in this PR

涵蓋 orders timeline / picking history / pr 列表 / 撿貨 backfill / transfer 看板 / 訂單細節改善 等，主要新功能在最後 4 個。

## Test plan

- [ ] 訂單列表 → 點開明細 → timeline 5 步顯示
- [ ] step 3 撿貨單號可點 → 跳到 /picking/history?wave=N 自動展開
- [ ] step 4/5 TR 單號可點 → 跳到 /transfers 列表
- [ ] picking/history 派貨時故意製造庫存不足 → 錯誤顯示中文「庫存不足：總倉只剩 X 件，本次需要 Y 件」
- [ ] 已有 commits 在另一 branch (pedantic-shirley) 跑過 dev server，core feature 驗過；rpcError 還沒實機驗，需 reviewer 跑一次

🤖 Generated with [Claude Code](https://claude.com/claude-code)