### PR TITLE
feat(purchase): PR 手動建立 — A 針對團購 + B 全空白入口

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -668,7 +668,16 @@ export default function EditPurchaseRequestPage() {
             {items.length === 0 ? (
               <tr>
                 <td colSpan={10} className="p-6 text-center text-zinc-500">
-                  無品項
+                  {header?.source_type === "manual" ? (
+                    <div className="space-y-1">
+                      <div>無品項</div>
+                      <div className="text-xs text-amber-600 dark:text-amber-400">
+                        ⚠️ 手動加列 UI 尚未實作；目前空白 PR 僅可觀察 / 取消，加列功能跟隨 PR 將補上
+                      </div>
+                    </div>
+                  ) : (
+                    "無品項"
+                  )}
                 </td>
               </tr>
             ) : (

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -38,6 +38,20 @@ const REVIEW_LABEL: Record<string, string> = {
   rejected: "已退回",
 };
 
+const SOURCE_LABEL: Record<string, string> = {
+  close_date: "結單日帶入",
+  campaign: "單一團購",
+  manual: "手動",
+};
+
+type ClosedCampaignRow = {
+  id: number;
+  name: string;
+  close_date: string;
+  existing_pr_id: number | null;
+  same_close_date_has_pr: boolean;
+};
+
 export default function PurchaseRequestsListPage() {
   const router = useRouter();
   const [rows, setRows] = useState<Row[] | null>(null);
@@ -48,6 +62,10 @@ export default function PurchaseRequestsListPage() {
   const [reloadTick, setReloadTick] = useState(0);
   const [busyId, setBusyId] = useState<number | null>(null);
   const [busyDate, setBusyDate] = useState<string | null>(null);
+  const [creatingBlank, setCreatingBlank] = useState(false);
+  const [showCampaignModal, setShowCampaignModal] = useState(false);
+  const [closedCampaigns, setClosedCampaigns] = useState<ClosedCampaignRow[] | null>(null);
+  const [creatingFromCampaignId, setCreatingFromCampaignId] = useState<number | null>(null);
   const [progressById, setProgressById] = useState<
     Map<number, {
       po_total: number; po_sent: number; po_received_fully: number;
@@ -234,6 +252,98 @@ export default function PurchaseRequestsListPage() {
     }
   }
 
+  async function handleCreateBlank() {
+    setCreatingBlank(true);
+    setError(null);
+    try {
+      const supabase = getSupabase();
+      const { data: userData } = await supabase.auth.getUser();
+      const { data: prId, error: rpcErr } = await supabase.rpc("rpc_create_pr_blank", {
+        p_operator: userData.user?.id,
+      });
+      if (rpcErr) throw new Error(rpcErr.message);
+      router.push(`/purchase/requests/edit?id=${prId}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setCreatingBlank(false);
+    }
+  }
+
+  async function openCampaignModal() {
+    setShowCampaignModal(true);
+    setError(null);
+    if (closedCampaigns !== null) return;
+    try {
+      const supabase = getSupabase();
+      const since = new Date();
+      since.setDate(since.getDate() - 60);
+      const { data: camps } = await supabase
+        .from("group_buy_campaigns")
+        .select("id, name, end_at")
+        .eq("status", "closed")
+        .gte("end_at", since.toISOString())
+        .order("end_at", { ascending: false });
+
+      const { data: existingCampaignPRs } = await supabase
+        .from("purchase_requests")
+        .select("id, source_campaign_id")
+        .eq("source_type", "campaign")
+        .neq("status", "cancelled");
+      const prByCamp = new Map<number, number>(
+        ((existingCampaignPRs as { id: number; source_campaign_id: number | null }[] | null) ?? [])
+          .filter((p) => p.source_campaign_id !== null)
+          .map((p) => [p.source_campaign_id as number, p.id]),
+      );
+
+      const { data: existingCloseDatePRs } = await supabase
+        .from("purchase_requests")
+        .select("source_close_date")
+        .eq("source_type", "close_date")
+        .neq("status", "cancelled");
+      const closeDateSet = new Set(
+        ((existingCloseDatePRs as { source_close_date: string | null }[] | null) ?? [])
+          .map((p) => p.source_close_date)
+          .filter((d): d is string => !!d),
+      );
+
+      const result: ClosedCampaignRow[] = ((camps as { id: number; name: string; end_at: string | null }[] | null) ?? [])
+        .filter((c) => !!c.end_at)
+        .map((c) => {
+          const closeDate = new Date(c.end_at as string).toLocaleDateString("sv-SE");
+          return {
+            id: c.id,
+            name: c.name,
+            close_date: closeDate,
+            existing_pr_id: prByCamp.get(c.id) ?? null,
+            same_close_date_has_pr: closeDateSet.has(closeDate),
+          };
+        });
+
+      setClosedCampaigns(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setClosedCampaigns([]);
+    }
+  }
+
+  async function handleCreateFromCampaign(campaignId: number) {
+    setCreatingFromCampaignId(campaignId);
+    setError(null);
+    try {
+      const supabase = getSupabase();
+      const { data: userData } = await supabase.auth.getUser();
+      const { data: prId, error: rpcErr } = await supabase.rpc("rpc_create_pr_from_campaign", {
+        p_campaign_id: campaignId,
+        p_operator: userData.user?.id,
+      });
+      if (rpcErr) throw new Error(rpcErr.message);
+      router.push(`/purchase/requests/edit?id=${prId}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setCreatingFromCampaignId(null);
+    }
+  }
+
   async function approve(id: number) {
     if (!confirm("確定通過審核？")) return;
     setBusyId(id);
@@ -277,11 +387,29 @@ export default function PurchaseRequestsListPage() {
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
-      <header>
-        <h1 className="text-xl font-semibold">採購單（PR）</h1>
-        <p className="text-sm text-zinc-500">
-          {rows === null ? "載入中…" : `共 ${rows.length} 筆`}
-        </p>
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">採購單（PR）</h1>
+          <p className="text-sm text-zinc-500">
+            {rows === null ? "載入中…" : `共 ${rows.length} 筆`}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={openCampaignModal}
+            disabled={creatingBlank}
+            className="rounded-md border border-blue-600 bg-white px-3 py-2 text-sm font-medium text-blue-600 hover:bg-blue-50 disabled:opacity-50 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+          >
+            + 針對團購建單
+          </button>
+          <button
+            onClick={handleCreateBlank}
+            disabled={creatingBlank}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
+          >
+            {creatingBlank ? "建立中…" : "+ 空白採購單"}
+          </button>
+        </div>
       </header>
 
       {error && (
@@ -398,7 +526,7 @@ export default function PurchaseRequestsListPage() {
                     </a>
                   </Td>
                   <Td className="text-xs text-zinc-500">
-                    {r.source_type === "close_date" ? "結單日帶入" : "手動"}
+                    {SOURCE_LABEL[r.source_type] ?? r.source_type}
                   </Td>
                   <Td className="text-xs">{r.source_close_date ?? "—"}</Td>
                   <Td>
@@ -474,6 +602,69 @@ export default function PurchaseRequestsListPage() {
           </tbody>
         </table>
       </div>
+
+      {showCampaignModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => setShowCampaignModal(false)}
+        >
+          <div
+            className="max-h-[80vh] w-full max-w-2xl overflow-hidden rounded-lg bg-white shadow-xl dark:bg-zinc-900"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+              <h3 className="text-base font-semibold">針對單一團購建單</h3>
+              <button
+                onClick={() => setShowCampaignModal(false)}
+                className="text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="max-h-[60vh] overflow-y-auto p-4">
+              {closedCampaigns === null ? (
+                <div className="text-center text-sm text-zinc-500">載入中…</div>
+              ) : closedCampaigns.length === 0 ? (
+                <div className="text-center text-sm text-zinc-500">過去 60 天無已結單團購</div>
+              ) : (
+                <ul className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                  {closedCampaigns.map((c) => {
+                    const disabled = c.existing_pr_id !== null || creatingFromCampaignId !== null;
+                    return (
+                      <li key={c.id} className="flex items-center justify-between gap-3 py-2">
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-sm font-medium">{c.name}</div>
+                          <div className="mt-0.5 text-xs text-zinc-500">
+                            結單日 {c.close_date}
+                            {c.existing_pr_id !== null && (
+                              <a
+                                href={`/purchase/requests/edit?id=${c.existing_pr_id}`}
+                                className="ml-2 text-amber-600 hover:underline dark:text-amber-400"
+                              >
+                                · 已有採購單 #{c.existing_pr_id}
+                              </a>
+                            )}
+                            {c.existing_pr_id === null && c.same_close_date_has_pr && (
+                              <span className="ml-2 text-zinc-400">· 同日已有結單日 PR（共存）</span>
+                            )}
+                          </div>
+                        </div>
+                        <button
+                          onClick={() => handleCreateFromCampaign(c.id)}
+                          disabled={disabled}
+                          className="shrink-0 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-500 disabled:opacity-40"
+                        >
+                          {creatingFromCampaignId === c.id ? "建立中…" : "建單"}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/TEST-pr-manual-creation.md
+++ b/docs/TEST-pr-manual-creation.md
@@ -1,0 +1,115 @@
+# PR 手動建立 — A+B 入口測試項目
+
+**對應 migration:** `supabase/migrations/20260505000000_pr_manual_creation.sql`（待建）
+**對應 UI 變更:**
+- `apps/admin/src/app/(protected)/purchase/requests/page.tsx`（列表頁加 2 顆建單按鈕 + campaign 選擇 modal + source_type 顯示加 'campaign' 標籤）
+
+**需求脈絡（決策來自 2026-04-26 對話）：**
+- 同結單日多個團購可能要分開叫貨（不同供應商急迫度、追貨需求）→ A
+- 補貨/樣品/總部自訂進貨需要全空白單 → B
+
+**3 項關鍵決策（已確認）：**
+1. **共存規則**：campaign PR 與 close_date PR 完全允許共存（不互斥）
+2. **B 初始狀態**：全空白草稿、無守衛、直接跳 edit
+3. **campaign 狀態**：A 只允許 closed campaign（不允許 open）
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 `purchase_requests` 擴充
+- [ ] CHECK 約束 `source_type` 增加 `'campaign'` 值（既有 'manual','close_date' 不變）
+  ```sql
+  SELECT pg_get_constraintdef(oid)
+    FROM pg_constraint
+   WHERE conrelid = 'purchase_requests'::regclass
+     AND conname LIKE '%source_type%';
+  -- 應包含: source_type IN ('manual','close_date','campaign')
+  ```
+- [ ] 新增 `source_campaign_id BIGINT REFERENCES group_buy_campaigns(id)`
+- [ ] 重寫 `chk_pr_source_close_date` → `chk_pr_source_consistency`：
+  - `close_date` → `source_close_date IS NOT NULL`
+  - `campaign` → `source_campaign_id IS NOT NULL`
+  - `manual` → 兩者皆可為 NULL
+- [ ] Index：`idx_pr_campaign` ON `(tenant_id, source_campaign_id) WHERE source_type='campaign'`
+
+### 1.2 RPC signature
+- [ ] 新 RPC `rpc_create_pr_from_campaign(p_campaign_id BIGINT, p_operator UUID) RETURNS BIGINT`
+- [ ] 新 RPC `rpc_create_pr_blank(p_operator UUID) RETURNS BIGINT`
+- [ ] grant execute 給 authenticated
+
+---
+
+## 2. RPC: `rpc_create_pr_from_campaign`
+
+### 2.1 Happy path
+- [ ] 對 closed campaign 呼叫 → 回傳新 PR id；PR.source_type='campaign'、source_campaign_id=該 id、source_close_date=該 campaign 的 close_date
+- [ ] items 每行帶 `source_campaign_id` 等於該 campaign id
+- [ ] items 含 retail_price / franchise_price snapshot（從 `prices` 抓最新）
+- [ ] items 含 unit_cost / suggested_supplier_id（從 `supplier_skus` is_preferred=TRUE）
+- [ ] PR.total_amount = SUM(line_subtotal)
+
+### 2.2 守衛
+- [ ] open campaign → RAISE `campaign % not in closed status`
+- [ ] cancelled campaign → 同上
+- [ ] 不存在 campaign → RAISE `campaign % not found`
+- [ ] 該 campaign 無未取消訂單 → RAISE `no orders to aggregate for campaign`
+- [ ] **同 campaign 已有未取消 PR**（status<>'cancelled'）→ RAISE `campaign % already has PR (id=N)`
+- [ ] **共存允許**：同 close_date 已有 close_date PR 不阻擋 campaign PR 建立（重點）
+
+### 2.3 Edge case
+- [ ] 同 campaign 之前的 PR 已 cancelled → 允許重建
+- [ ] tenant 跨檢查：跨 tenant 看不到別家的 campaign
+
+---
+
+## 3. RPC: `rpc_create_pr_blank`
+
+### 3.1 Happy path
+- [ ] 呼叫 → 回傳新 PR id；PR.source_type='manual'、source_close_date=NULL、source_campaign_id=NULL
+- [ ] PR.status='draft'、review_status='approved'（沿用 default）
+- [ ] PR.total_amount=0
+- [ ] purchase_request_items 該 PR 0 筆
+
+### 3.2 守衛
+- [ ] 無守衛（隨時可建）
+- [ ] tenant 用 `_current_tenant_id()` 取，無權限會 fail
+
+---
+
+## 4. 列表頁 UI（`/purchase/requests`）
+
+### 4.1 兩顆建單按鈕
+- [ ] 右上角顯示「+ 空白採購單」「+ 針對團購建單」兩顆按鈕
+- [ ] 「+ 空白採購單」點擊 → 直接呼叫 `rpc_create_pr_blank` → 跳 `/purchase/requests/edit?id=N`
+- [ ] 「+ 針對團購建單」點擊 → 開 modal 選 closed campaign
+
+### 4.2 Campaign 選擇 modal
+- [ ] modal 顯示：過去 60 天 closed campaign 列表
+- [ ] 已有未取消 campaign PR 的 campaign → 禁用 + 顯示「已有採購單」
+- [ ] 已有同日 close_date PR 的 campaign → 不禁用（共存允許）+ 顯示「同日已有結單日 PR」提示
+- [ ] 選一個 → 呼叫 `rpc_create_pr_from_campaign` → 跳 edit page
+
+### 4.3 列表 source_type 顯示
+- [ ] `source_type='campaign'` → 顯示「單一團購」
+- [ ] `source_type='close_date'` → 顯示「結單日帶入」
+- [ ] `source_type='manual'` → 顯示「手動」
+- [ ] campaign 來源那行的「結單日」欄顯示 campaign.name 或 source_close_date
+
+---
+
+## 5. 共存性回歸測試
+
+- [ ] 4/28 已有 close_date PR → 對 4/28 某個 campaign 建 campaign PR → 兩張並存
+- [ ] 兩張 PR 都能各自送審、拆 PO、不互相干擾
+- [ ] `v_pr_progress` 對兩種 source_type 都正確（不報錯）
+- [ ] PrPipelineStepper 對 campaign / manual PR 顯示正常（建立 → 編輯 → 送審 → ...）
+
+---
+
+## 6. 既有功能不破
+
+- [ ] 現有結單日 PR 流程 (`rpc_create_pr_from_close_date`) 不變
+- [ ] 現有 close_date PR 的「同 close_date 守衛」仍生效（只擋 source_type='close_date'）
+- [ ] 現有 PR 的 source_type='manual' 既有資料能正常編輯（向下相容）
+- [ ] PR edit page 對所有 source_type 都能 render（不依賴 source_close_date 必填）

--- a/scripts/rpc-pr-manual-creation.sql
+++ b/scripts/rpc-pr-manual-creation.sql
@@ -1,0 +1,114 @@
+-- ============================================================
+-- PR 手動建立 — A+B 驗證 SQL
+-- 對應 migration: 20260505000000_pr_manual_creation.sql
+-- 對應 TEST: docs/TEST-pr-manual-creation.md
+--
+-- 用法：在 Supabase SQL editor 跑（會建立資料），逐段執行。
+--   p_operator 換成自己的 auth.users.id
+--   p_campaign_id 換成 closed campaign id
+-- ============================================================
+
+-- 1. Schema 驗證：source_type CHECK 應含 'campaign'
+SELECT conname, pg_get_constraintdef(oid)
+  FROM pg_constraint
+ WHERE conrelid = 'purchase_requests'::regclass
+   AND conname = 'purchase_requests_source_type_check';
+-- 預期：CHECK (source_type = ANY (ARRAY['manual','close_date','campaign']))
+
+-- 2. Schema 驗證：chk_pr_source_consistency
+SELECT pg_get_constraintdef(oid)
+  FROM pg_constraint
+ WHERE conrelid = 'purchase_requests'::regclass
+   AND conname = 'chk_pr_source_consistency';
+-- 預期：含三條 OR：close_date / campaign / manual
+
+-- 3. Schema 驗證：source_campaign_id 欄 + index
+\d+ purchase_requests
+SELECT indexname FROM pg_indexes
+ WHERE tablename = 'purchase_requests' AND indexname = 'idx_pr_campaign';
+
+-- 4. RPC: rpc_create_pr_blank
+DO $$
+DECLARE v_pr_id BIGINT;
+BEGIN
+  v_pr_id := public.rpc_create_pr_blank(
+    p_operator := '00000000-0000-0000-0000-000000000000'::uuid  -- 換成你的 user id
+  );
+  RAISE NOTICE 'blank PR id = %', v_pr_id;
+END $$;
+
+SELECT id, pr_no, source_type, source_close_date, source_campaign_id, status, total_amount
+  FROM purchase_requests
+ WHERE source_type = 'manual'
+ ORDER BY id DESC LIMIT 3;
+-- 預期：source_close_date / source_campaign_id 都 NULL；status='draft'；total_amount=0
+
+SELECT COUNT(*) FROM purchase_request_items
+ WHERE pr_id = (SELECT MAX(id) FROM purchase_requests WHERE source_type='manual');
+-- 預期：0
+
+-- 5. RPC: rpc_create_pr_from_campaign happy path
+-- 換 p_campaign_id 成自己的 closed campaign id
+DO $$
+DECLARE v_pr_id BIGINT;
+BEGIN
+  v_pr_id := public.rpc_create_pr_from_campaign(
+    p_campaign_id := 1,  -- ← 換成 closed campaign id
+    p_operator    := '00000000-0000-0000-0000-000000000000'::uuid
+  );
+  RAISE NOTICE 'campaign PR id = %', v_pr_id;
+END $$;
+
+SELECT id, pr_no, source_type, source_campaign_id, source_close_date, status, total_amount
+  FROM purchase_requests
+ WHERE source_type = 'campaign'
+ ORDER BY id DESC LIMIT 3;
+-- 預期：source_type='campaign'、source_campaign_id 已填、source_close_date 從 campaign.end_at 抓
+
+SELECT pri.sku_id, pri.qty_requested, pri.unit_cost, pri.line_subtotal,
+       pri.suggested_supplier_id, pri.source_campaign_id,
+       pri.retail_price, pri.franchise_price
+  FROM purchase_request_items pri
+ WHERE pri.pr_id = (SELECT MAX(id) FROM purchase_requests WHERE source_type='campaign');
+-- 預期：每行 source_campaign_id = 該 campaign id；line_subtotal = qty * unit_cost
+
+-- 6. 守衛：同 campaign 重複建
+DO $$
+BEGIN
+  PERFORM public.rpc_create_pr_from_campaign(
+    p_campaign_id := 1,  -- ← 同上
+    p_operator    := '00000000-0000-0000-0000-000000000000'::uuid
+  );
+  RAISE EXCEPTION 'should have raised: campaign already has PR';
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'expected error: %', SQLERRM;
+END $$;
+
+-- 7. 守衛：open campaign（先把上一張 cancel 才能重建）
+-- UPDATE purchase_requests SET status='cancelled' WHERE id=(...);
+-- UPDATE group_buy_campaigns SET status='open' WHERE id=1;
+-- 然後跑：
+-- DO $$ BEGIN PERFORM public.rpc_create_pr_from_campaign(1, '...'); END $$;
+-- 預期：RAISE 'campaign 1 not in closed status (current: open)'
+
+-- 8. 共存性驗證：4/28 已有 close_date PR + 4/28 某 campaign PR
+SELECT id, pr_no, source_type, source_close_date, source_campaign_id, status
+  FROM purchase_requests
+ WHERE source_close_date = '2026-04-28'
+   AND status <> 'cancelled'
+ ORDER BY source_type;
+-- 預期：可同時看到 close_date / campaign 兩種行
+
+-- 9. 列表頁來源欄位
+SELECT source_type, COUNT(*) FROM purchase_requests
+ WHERE status <> 'cancelled' GROUP BY source_type;
+-- 預期：close_date / campaign / manual 三種值都可能出現
+
+-- 10. v_pr_progress 對 campaign / manual PR 不報錯
+SELECT pr_id, po_total, po_sent, transfer_total, all_campaigns_finalized
+  FROM v_pr_progress
+ WHERE pr_id IN (
+   SELECT id FROM purchase_requests
+    WHERE source_type IN ('campaign','manual') AND status<>'cancelled'
+ );
+-- 預期：每行都正常返回，campaign_finalized 對 manual=NULL 或 false

--- a/supabase/migrations/20260505000000_pr_manual_creation.sql
+++ b/supabase/migrations/20260505000000_pr_manual_creation.sql
@@ -1,0 +1,237 @@
+-- ============================================================
+-- PR 手動建立：A. 針對單一 campaign 建 PR / B. 全空白手動 PR
+-- TEST: docs/TEST-pr-manual-creation.md
+--
+-- 設計決策（2026-04-26 確認）：
+--   1. campaign PR 與 close_date PR 完全允許共存（不互斥）
+--      → 同 campaign 不可重複（源 source_campaign_id 守）
+--   2. 全空白 PR 無守衛（隨時可建）
+--   3. campaign PR 只允許 closed campaign（不允許 open）
+-- ============================================================
+
+-- ============================================================
+-- 1. SCHEMA: purchase_requests source_type 加 'campaign' + source_campaign_id
+-- ============================================================
+
+ALTER TABLE purchase_requests
+  DROP CONSTRAINT IF EXISTS purchase_requests_source_type_check;
+
+ALTER TABLE purchase_requests
+  ADD CONSTRAINT purchase_requests_source_type_check
+  CHECK (source_type IN ('manual','close_date','campaign'));
+
+ALTER TABLE purchase_requests
+  ADD COLUMN IF NOT EXISTS source_campaign_id BIGINT
+  REFERENCES group_buy_campaigns(id);
+
+-- 重寫一致性 CHECK
+ALTER TABLE purchase_requests
+  DROP CONSTRAINT IF EXISTS chk_pr_source_close_date;
+
+ALTER TABLE purchase_requests
+  DROP CONSTRAINT IF EXISTS chk_pr_source_consistency;
+
+ALTER TABLE purchase_requests
+  ADD CONSTRAINT chk_pr_source_consistency CHECK (
+    (source_type = 'close_date' AND source_close_date IS NOT NULL) OR
+    (source_type = 'campaign'   AND source_campaign_id IS NOT NULL) OR
+    (source_type = 'manual')
+  );
+
+CREATE INDEX IF NOT EXISTS idx_pr_campaign ON purchase_requests
+  (tenant_id, source_campaign_id) WHERE source_type = 'campaign';
+
+-- ============================================================
+-- 2. RPC: rpc_create_pr_from_campaign
+--    針對單一 closed campaign 建 PR；不影響同日 close_date PR
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_create_pr_from_campaign(
+  p_campaign_id BIGINT,
+  p_operator    UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant         UUID := public._current_tenant_id();
+  v_camp_tenant    UUID;
+  v_camp_status    TEXT;
+  v_close_date     DATE;
+  v_existing_pr_id BIGINT;
+  v_demand_count   INTEGER;
+  v_pr_id          BIGINT;
+  v_pr_no          TEXT;
+  v_dest_loc       BIGINT;
+BEGIN
+  -- 1. 載入 campaign + 守衛
+  SELECT tenant_id, status, DATE(end_at AT TIME ZONE 'Asia/Taipei')
+    INTO v_camp_tenant, v_camp_status, v_close_date
+    FROM group_buy_campaigns
+   WHERE id = p_campaign_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'campaign % not found', p_campaign_id;
+  END IF;
+
+  IF v_camp_tenant <> v_tenant THEN
+    RAISE EXCEPTION 'tenant mismatch';
+  END IF;
+
+  IF v_camp_status <> 'closed' THEN
+    RAISE EXCEPTION 'campaign % not in closed status (current: %)',
+      p_campaign_id, v_camp_status;
+  END IF;
+
+  -- 2. 守衛：同 campaign 已有未取消 PR
+  SELECT id INTO v_existing_pr_id
+    FROM purchase_requests
+   WHERE tenant_id = v_tenant
+     AND source_type = 'campaign'
+     AND source_campaign_id = p_campaign_id
+     AND status <> 'cancelled'
+   LIMIT 1;
+
+  IF v_existing_pr_id IS NOT NULL THEN
+    RAISE EXCEPTION 'campaign % already has PR (id=%)',
+      p_campaign_id, v_existing_pr_id
+      USING HINT = '請至既有採購單繼續編輯，或先取消後重開';
+  END IF;
+
+  -- 3. 守衛：是否有可彙總的訂單
+  SELECT COUNT(*) INTO v_demand_count
+    FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+   WHERE co.tenant_id = v_tenant
+     AND co.campaign_id = p_campaign_id
+     AND co.status NOT IN ('cancelled','expired')
+     AND coi.status NOT IN ('cancelled','expired');
+
+  IF v_demand_count = 0 THEN
+    RAISE EXCEPTION 'no orders to aggregate for campaign %', p_campaign_id;
+  END IF;
+
+  -- 4. dest location
+  SELECT id INTO v_dest_loc FROM locations
+   WHERE tenant_id = v_tenant
+   ORDER BY id LIMIT 1;
+
+  IF v_dest_loc IS NULL THEN
+    RAISE EXCEPTION 'no locations defined for tenant %', v_tenant;
+  END IF;
+
+  -- 5. PR header
+  v_pr_no := public.rpc_next_pr_no();
+
+  INSERT INTO purchase_requests (
+    tenant_id, pr_no, source_type, source_campaign_id, source_close_date,
+    source_location_id, status, total_amount,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_pr_no, 'campaign', p_campaign_id, v_close_date,
+    v_dest_loc, 'draft', 0,
+    p_operator, p_operator
+  ) RETURNING id INTO v_pr_id;
+
+  -- 6. items：彙總該 campaign 的 SKU 需求 + price/cost snapshot
+  INSERT INTO purchase_request_items (
+    pr_id, sku_id, qty_requested,
+    suggested_supplier_id, unit_cost,
+    retail_price, franchise_price,
+    source_campaign_id,
+    created_by, updated_by
+  )
+  SELECT
+    v_pr_id, agg.sku_id, agg.qty_total,
+    ss.supplier_id, COALESCE(ss.default_unit_cost, 0),
+    pr_retail.price, pr_franchise.price,
+    p_campaign_id, p_operator, p_operator
+  FROM (
+    SELECT coi.sku_id, SUM(coi.qty) AS qty_total
+      FROM customer_orders co
+      JOIN customer_order_items coi ON coi.order_id = co.id
+     WHERE co.tenant_id = v_tenant
+       AND co.campaign_id = p_campaign_id
+       AND co.status NOT IN ('cancelled','expired')
+       AND coi.status NOT IN ('cancelled','expired')
+     GROUP BY coi.sku_id
+  ) agg
+  LEFT JOIN LATERAL (
+    SELECT supplier_id, default_unit_cost
+      FROM supplier_skus
+     WHERE tenant_id = v_tenant AND sku_id = agg.sku_id AND is_preferred = TRUE
+     LIMIT 1
+  ) ss ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT price FROM prices
+     WHERE sku_id = agg.sku_id AND scope = 'retail'
+     ORDER BY effective_from DESC NULLS LAST
+     LIMIT 1
+  ) pr_retail ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT price FROM prices
+     WHERE sku_id = agg.sku_id AND scope = 'franchise'
+     ORDER BY effective_from DESC NULLS LAST
+     LIMIT 1
+  ) pr_franchise ON TRUE;
+
+  -- 7. total snapshot
+  UPDATE purchase_requests pr
+     SET total_amount = COALESCE((
+           SELECT SUM(line_subtotal) FROM purchase_request_items WHERE pr_id = v_pr_id
+         ), 0),
+         updated_at = NOW()
+   WHERE pr.id = v_pr_id;
+
+  RETURN v_pr_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_pr_from_campaign TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_pr_from_campaign IS
+  '針對單一 closed campaign 建 PR（與同日 close_date PR 共存；同 campaign 不可重複）';
+
+-- ============================================================
+-- 3. RPC: rpc_create_pr_blank
+--    全空白手動 PR；無守衛
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_create_pr_blank(
+  p_operator UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant   UUID := public._current_tenant_id();
+  v_pr_id    BIGINT;
+  v_pr_no    TEXT;
+  v_dest_loc BIGINT;
+BEGIN
+  SELECT id INTO v_dest_loc FROM locations
+   WHERE tenant_id = v_tenant
+   ORDER BY id LIMIT 1;
+
+  IF v_dest_loc IS NULL THEN
+    RAISE EXCEPTION 'no locations defined for tenant %', v_tenant;
+  END IF;
+
+  v_pr_no := public.rpc_next_pr_no();
+
+  INSERT INTO purchase_requests (
+    tenant_id, pr_no, source_type,
+    source_location_id, status, total_amount,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_pr_no, 'manual',
+    v_dest_loc, 'draft', 0,
+    p_operator, p_operator
+  ) RETURNING id INTO v_pr_id;
+
+  RETURN v_pr_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_pr_blank TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_pr_blank IS
+  '全空白手動 PR：無守衛、items 空、跳轉編輯頁手動加 SKU';


### PR DESCRIPTION
## Summary
- 採購單除「結單日彙總」外，新增 2 個建單入口：
  - **A. 針對單一團購建 PR** — 只彙總該 campaign 的 SKU；與同日 close_date PR 共存
  - **B. 全空白手動 PR** — 無守衛、items 空白；給補貨/樣品/總部自訂進貨用
- Schema 加 `source_type='campaign'` enum 值與 `source_campaign_id` 欄位

## 決策（2026-04-26 對話）
1. campaign PR 與 close_date PR **完全允許共存**（不互斥）
2. 全空白 PR **無守衛**
3. campaign PR **只允許 closed campaign**

## 改動
**Migration** `supabase/migrations/20260505000000_pr_manual_creation.sql`
- `purchase_requests.source_type` CHECK 加 `'campaign'`
- 新欄位 `purchase_requests.source_campaign_id BIGINT REFERENCES group_buy_campaigns`
- 重寫 `chk_pr_source_consistency`：close_date 需 source_close_date、campaign 需 source_campaign_id
- 新 index `idx_pr_campaign`
- 新 RPC `rpc_create_pr_from_campaign(p_campaign_id, p_operator)`：守 closed + 同 campaign 不重複；items 含 supplier/cost/retail/franchise snapshot
- 新 RPC `rpc_create_pr_blank(p_operator)`：無守衛、items 空

**UI**
- `purchase/requests/page.tsx`：右上加「+ 針對團購建單」「+ 空白採購單」、campaign 選擇 modal（已有 PR 禁用、同日 close_date PR 顯示「共存」提示）、清單 source_type 顯示加 'campaign' 標籤
- `purchase/requests/edit/page.tsx`：對 source_type='manual' + 0 items 顯示「⚠️ 加列 UI 尚未實作」提示

## 已分拆（跟隨 task）
- B 的 edit page「+ 加列」UI（SKU 選取器 + saveDraft INSERT 分支）→ 跟隨 PR

## Test plan
- [ ] schema：`SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid='purchase_requests'::regclass AND conname IN ('purchase_requests_source_type_check','chk_pr_source_consistency')`
- [ ] `rpc_create_pr_blank`：成功返回 PR id；source_type='manual'、items=0
- [ ] `rpc_create_pr_from_campaign`：closed campaign happy path；items 帶 source_campaign_id + price snapshot
- [ ] 守衛：open campaign / 同 campaign 已有未取消 PR / 無訂單 → 三條 RAISE
- [ ] 共存：4/28 已有 close_date PR + 4/28 某 campaign PR 兩張並存
- [ ] 列表頁兩顆按鈕點擊路徑（modal、空白 RPC、跳轉 edit）
- [ ] Edit page 對 source_type='manual' 顯示警示
- [ ] type-check 通過（已驗）

完整測試清單見 `docs/TEST-pr-manual-creation.md`、驗證 SQL 見 `scripts/rpc-pr-manual-creation.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)