### PR TITLE
feat(orders): 棄單轉出按鈕 (Phase 5b 第一段)

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -221,7 +221,15 @@ export default function OrdersListPage() {
         title={`訂單明細 ${detailNo}`}
         maxWidth="max-w-4xl"
       >
-        {detailId !== null && <OrderDetail orderId={detailId} />}
+        {detailId !== null && (
+          <OrderDetail
+            orderId={detailId}
+            onNavigate={(id, no) => {
+              setDetailId(id);
+              setDetailNo(no);
+            }}
+          />
+        )}
       </Modal>
 
       {totalPages > 1 && (

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -8,7 +8,7 @@ import { OrderDetail } from "@/components/OrderDetail";
 
 type OrderStatus =
   | "pending" | "confirmed" | "reserved" | "shipping" | "ready" | "partially_ready"
-  | "partially_completed" | "completed" | "expired" | "cancelled";
+  | "partially_completed" | "completed" | "expired" | "cancelled" | "transferred_out";
 
 type Row = {
   id: number;
@@ -30,6 +30,7 @@ const STATUS_LABEL: Record<OrderStatus, string> = {
   pending: "待確認", confirmed: "已確認", reserved: "已保留", shipping: "派貨中",
   ready: "可取貨", partially_ready: "部分可取", partially_completed: "部分取貨",
   completed: "已完成", expired: "逾期", cancelled: "已取消",
+  transferred_out: "已轉出",
 };
 
 const PAGE_SIZE = 50;
@@ -81,6 +82,7 @@ export default function OrdersListPage() {
 
         if (campaignId) q = q.eq("campaign_id", Number(campaignId));
         if (status) q = q.eq("status", status);
+        else q = q.neq("status", "transferred_out"); // 預設隱藏已轉出（5a-1：視同關閉、金額/數量不入統計）
         if (storeId) q = q.eq("pickup_store_id", Number(storeId));
 
         const { data, count, error } = await q;
@@ -256,6 +258,7 @@ function StatusBadge({ s }: { s: OrderStatus }) {
     completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
     expired: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
     cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+    transferred_out: "bg-zinc-300 text-zinc-700 line-through dark:bg-zinc-700 dark:text-zinc-400",
   };
   return <span className={`inline-block rounded px-2 py-0.5 text-xs ${st[s]}`}>{STATUS_LABEL[s]}</span>;
 }

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -38,6 +38,7 @@ type TimelineStep = {
   done: boolean;
   detail?: string;
   detailHref?: string;
+  detailOnClick?: () => void;
 };
 
 function staffLabel(uid: string | null, names: Map<string, string>): string {
@@ -49,7 +50,13 @@ function fmtDt(iso: string): string {
   return new Date(iso).toLocaleString("zh-TW", { hour12: false });
 }
 
-export function OrderDetail({ orderId }: { orderId: number }) {
+export function OrderDetail({
+  orderId,
+  onNavigate,
+}: {
+  orderId: number;
+  onNavigate?: (orderId: number, orderNo: string) => void;
+}) {
   const [head, setHead] = useState<OrderHead | null>(null);
   const [items, setItems] = useState<ItemRow[] | null>(null);
   const [timeline, setTimeline] = useState<TimelineStep[] | null>(null);
@@ -98,7 +105,7 @@ export function OrderDetail({ orderId }: { orderId: number }) {
 
       // ========== 載入 timeline ==========
       const skuIds = itemsData.map((it) => it.sku?.id).filter((x): x is number => !!x);
-      const tl = await buildTimeline(headData, skuIds);
+      const tl = await buildTimeline(headData, skuIds, onNavigate);
       if (!cancelled) setTimeline(tl);
     })();
     return () => { cancelled = true; };
@@ -243,6 +250,7 @@ export function OrderDetail({ orderId }: { orderId: number }) {
 async function buildTimeline(
   head: OrderHead,
   skuIds: number[],
+  onNavigate?: (orderId: number, orderNo: string) => void,
 ): Promise<TimelineStep[]> {
   const sb = getSupabase();
 
@@ -251,6 +259,7 @@ async function buildTimeline(
     // 找新訂單號做 detail link（從 customer_orders 用 transferred_to_order_id）
     let newOrderInfo = "已轉出（流程關閉、不入金額統計）";
     let newOrderHref: string | undefined;
+    let newOrderClick: (() => void) | undefined;
     const { data: self } = await sb
       .from("customer_orders")
       .select("transferred_to_order_id")
@@ -266,7 +275,11 @@ async function buildTimeline(
       const newNo = (newOrd as { order_no: string } | null)?.order_no;
       if (newNo) {
         newOrderInfo = `已轉出 → 新訂單 ${newNo}`;
-        newOrderHref = `/orders?id=${newId}`;
+        if (onNavigate) {
+          newOrderClick = () => onNavigate(newId, newNo);
+        } else {
+          newOrderHref = `/orders?id=${newId}`;
+        }
       }
     }
     return [
@@ -276,6 +289,7 @@ async function buildTimeline(
         done: true,
         detail: newOrderInfo,
         detailHref: newOrderHref,
+        detailOnClick: newOrderClick,
       },
     ];
   }
@@ -450,7 +464,15 @@ function Timeline({ steps }: { steps: TimelineStep[] | null }) {
                 {s.label}
               </div>
               {s.detail && (
-                s.detailHref ? (
+                s.detailOnClick ? (
+                  <button
+                    type="button"
+                    onClick={s.detailOnClick}
+                    className="text-[10px] font-mono text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {s.detail}
+                  </button>
+                ) : s.detailHref ? (
                   <a
                     href={s.detailHref}
                     className="text-[10px] font-mono text-blue-600 hover:underline dark:text-blue-400"

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -245,6 +245,41 @@ async function buildTimeline(
   skuIds: number[],
 ): Promise<TimelineStep[]> {
   const sb = getSupabase();
+
+  // transferred_out: 訂單已關閉、流程不再進行；只顯示一個結束 step
+  if (head.status === "transferred_out") {
+    // 找新訂單號做 detail link（從 customer_orders 用 transferred_to_order_id）
+    let newOrderInfo = "已轉出（流程關閉、不入金額統計）";
+    let newOrderHref: string | undefined;
+    const { data: self } = await sb
+      .from("customer_orders")
+      .select("transferred_to_order_id")
+      .eq("id", head.id)
+      .maybeSingle();
+    const newId = (self as { transferred_to_order_id: number | null } | null)?.transferred_to_order_id;
+    if (newId) {
+      const { data: newOrd } = await sb
+        .from("customer_orders")
+        .select("order_no")
+        .eq("id", newId)
+        .maybeSingle();
+      const newNo = (newOrd as { order_no: string } | null)?.order_no;
+      if (newNo) {
+        newOrderInfo = `已轉出 → 新訂單 ${newNo}`;
+        newOrderHref = `/orders?id=${newId}`;
+      }
+    }
+    return [
+      {
+        label: "訂單關閉（已轉出）",
+        ts: head.updated_at,
+        done: true,
+        detail: newOrderInfo,
+        detailHref: newOrderHref,
+      },
+    ];
+  }
+
   const campaignId = head.campaign_id;
   const storeId = head.pickup_store_id;
   const status = head.status;

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { OrderTransferModal } from "@/components/OrderTransferModal";
 
 type OrderHead = {
   id: number;
@@ -54,6 +55,8 @@ export function OrderDetail({ orderId }: { orderId: number }) {
   const [timeline, setTimeline] = useState<TimelineStep[] | null>(null);
   const [staffNames, setStaffNames] = useState<Map<string, string>>(new Map());
   const [error, setError] = useState<string | null>(null);
+  const [reloadTick, setReloadTick] = useState(0);
+  const [transferOpen, setTransferOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -99,7 +102,7 @@ export function OrderDetail({ orderId }: { orderId: number }) {
       if (!cancelled) setTimeline(tl);
     })();
     return () => { cancelled = true; };
-  }, [orderId]);
+  }, [orderId, reloadTick]);
 
   if (error) {
     return (
@@ -113,8 +116,31 @@ export function OrderDetail({ orderId }: { orderId: number }) {
   const totalQty = items.reduce((s, i) => s + Number(i.qty), 0);
   const totalAmount = items.reduce((s, i) => s + Number(i.qty) * Number(i.unit_price), 0);
 
+  const canTransfer = ["pending", "confirmed", "reserved"].includes(head.status);
+  const isTransferredOut = head.status === "transferred_out";
+  const memberLabel = head.member
+    ? `${head.member.name ?? "—"} (${head.member.member_no})`
+    : `(${head.nickname_snapshot ?? "—"})`;
+
   return (
     <div className="space-y-4 text-sm">
+      {(canTransfer || isTransferredOut) && (
+        <div className="flex items-center justify-end gap-2">
+          {canTransfer && (
+            <button
+              onClick={() => setTransferOpen(true)}
+              className="rounded-md border border-blue-300 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50 dark:border-blue-800 dark:text-blue-300 dark:hover:bg-blue-950"
+              title="客人棄單 / 轉到其他店店長 / 互助接手"
+            >
+              ↗ 轉出此訂單
+            </button>
+          )}
+          {isTransferredOut && (
+            <span className="text-xs text-zinc-500">⚠️ 此訂單已轉出</span>
+          )}
+        </div>
+      )}
+
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <Field label="訂單號" value={<span className="font-mono">{head.order_no}</span>} />
         <Field label="狀態" value={head.status} />
@@ -196,6 +222,20 @@ export function OrderDetail({ orderId }: { orderId: number }) {
           ※ 同顧客在同活動連 key 多次會合併到同一筆，舊 qty 被新值覆寫。如需「每次 +N 紀錄」請告知改完整版（加 append-only audit table）。
         </p>
       </div>
+
+      <OrderTransferModal
+        open={transferOpen}
+        onClose={() => setTransferOpen(false)}
+        orderId={head.id}
+        orderNo={head.order_no}
+        currentPickupStoreId={head.pickup_store_id}
+        currentMemberLabel={memberLabel}
+        onSubmitted={(newId) => {
+          setTransferOpen(false);
+          alert(`訂單已轉出 → 新訂單 #${newId}`);
+          setReloadTick((n) => n + 1);
+        }}
+      />
     </div>
   );
 }

--- a/apps/admin/src/components/OrderTransferModal.tsx
+++ b/apps/admin/src/components/OrderTransferModal.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Modal } from "@/components/Modal";
+import { getSupabase } from "@/lib/supabase";
+
+type Store = { id: number; name: string; code: string };
+type Member = {
+  id: number;
+  member_no: string;
+  name: string | null;
+  member_type: string;
+  home_store_id: number | null;
+};
+
+export function OrderTransferModal({
+  orderId,
+  orderNo,
+  currentPickupStoreId,
+  currentMemberLabel,
+  open,
+  onClose,
+  onSubmitted,
+}: {
+  orderId: number;
+  orderNo: string;
+  currentPickupStoreId: number | null;
+  currentMemberLabel: string;
+  open: boolean;
+  onClose: () => void;
+  onSubmitted: (newOrderId: number) => void;
+}) {
+  const [stores, setStores] = useState<Store[]>([]);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [toStore, setToStore] = useState<number | "">("");
+  const [toMember, setToMember] = useState<number | "internal">("internal");
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data: ss } = await sb
+        .from("stores")
+        .select("id, name, code")
+        .eq("is_active", true)
+        .order("name");
+      if (!cancelled) setStores((ss as Store[] | null) ?? []);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  // load home members of selected store (for picker)
+  useEffect(() => {
+    if (toStore === "" || toStore === 0) {
+      setMembers([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data: ms } = await sb
+        .from("members")
+        .select("id, member_no, name, member_type, home_store_id")
+        .eq("home_store_id", toStore)
+        .neq("member_type", "store_internal")
+        .order("name")
+        .limit(50);
+      if (!cancelled) setMembers((ms as Member[] | null) ?? []);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [toStore]);
+
+  const submit = async () => {
+    if (!toStore) {
+      setErr("請選擇接收店");
+      return;
+    }
+    if (toStore === currentPickupStoreId) {
+      if (!confirm("接收店與原店相同（同店換客人）。確定繼續？")) return;
+    }
+    setBusy(true);
+    setErr(null);
+    try {
+      const sb = getSupabase();
+      const { data: { user } } = await sb.auth.getUser();
+      const { data, error: e } = await sb.rpc("rpc_transfer_order_to_store", {
+        p_order_id: orderId,
+        p_to_pickup_store_id: toStore,
+        p_to_member_id: toMember === "internal" ? null : toMember,
+        p_to_channel_id: null,
+        p_operator: user?.id,
+        p_reason: reason || null,
+      });
+      if (e) throw new Error(e.message);
+      const newId = data as number;
+      onSubmitted(newId);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title={`轉出訂單 ${orderNo}`} maxWidth="max-w-lg">
+      <div className="space-y-3 p-4 text-sm">
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {err}
+          </div>
+        )}
+
+        <div className="rounded-md bg-zinc-50 p-2 text-xs text-zinc-600 dark:bg-zinc-900 dark:text-zinc-400">
+          原訂單：{currentMemberLabel}（取貨店：
+          {stores.find((s) => s.id === currentPickupStoreId)?.name ?? `#${currentPickupStoreId}`}）
+        </div>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-zinc-500">接收店</span>
+          <select
+            value={toStore}
+            onChange={(e) => {
+              const v = e.target.value;
+              setToStore(v === "" ? "" : Number(v));
+              setToMember("internal");
+            }}
+            className="rounded-md border border-zinc-300 bg-white px-2 py-1 dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="">— 請選擇 —</option>
+            {stores.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name} ({s.code})
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {toStore !== "" && (
+          <label className="flex flex-col gap-1">
+            <span className="text-zinc-500">接收人</span>
+            <select
+              value={toMember}
+              onChange={(e) =>
+                setToMember(e.target.value === "internal" ? "internal" : Number(e.target.value))
+              }
+              className="rounded-md border border-zinc-300 bg-white px-2 py-1 dark:border-zinc-700 dark:bg-zinc-800"
+            >
+              <option value="internal">— 掛到接收店店長（內部 member）—</option>
+              {members.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name ?? "—"} ({m.member_no})
+                </option>
+              ))}
+            </select>
+            <span className="text-[11px] text-zinc-400">
+              不選 = 自動建 / 用 store_internal member（適用：店長收下、內部處理）
+            </span>
+          </label>
+        )}
+
+        <label className="flex flex-col gap-1">
+          <span className="text-zinc-500">轉出原因</span>
+          <textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="例：客人棄單、改寄朋友店…"
+            rows={2}
+            className="rounded-md border border-zinc-300 bg-white px-2 py-1 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+
+        <div className="flex justify-end gap-2 pt-1">
+          <button
+            onClick={onClose}
+            disabled={busy}
+            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700"
+          >
+            取消
+          </button>
+          <button
+            onClick={submit}
+            disabled={busy || !toStore}
+            className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white disabled:bg-zinc-300"
+          >
+            {busy ? "轉出中…" : "確認轉出"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/docs/TEST-order-transfer-button.md
+++ b/docs/TEST-order-transfer-button.md
@@ -1,0 +1,57 @@
+---
+title: TEST — 訂單棄單轉出按鈕（Phase 5b 第一段）
+module: Order / UI
+status: passed
+ran_at: 2026-04-26
+verified_by: alex.chen + claude (preview tools)
+---
+
+# 驗證報告 — Phase 5b 第一段（棄單轉出按鈕）
+
+「為分店叫貨 mode」拆給 5b 第二段（涉及 order-entry/page.tsx 大改、800 行）。本段先 ship 棄單轉出按鈕（範圍可控、orders detail 加按鈕 + 新 modal）。
+
+## Scope
+
+- 新 component：[apps/admin/src/components/OrderTransferModal.tsx](../apps/admin/src/components/OrderTransferModal.tsx)
+- 改：[apps/admin/src/components/OrderDetail.tsx](../apps/admin/src/components/OrderDetail.tsx)
+  - import OrderTransferModal
+  - 加 reloadTick state（用於 RPC 後 refresh）
+  - 訂單頂部加「↗ 轉出此訂單」按鈕（status pending/confirmed/reserved 顯示）
+  - 訂單頂部 transferred_out 顯示警示
+  - useEffect 加 reloadTick dep
+  - return 結尾掛 OrderTransferModal
+
+## RPC 呼叫
+
+`rpc_transfer_order_to_store(p_order_id, p_to_pickup_store_id, p_to_member_id, p_to_channel_id, p_operator, p_reason)`
+
+UI 邏輯：
+- `p_to_member_id = "internal"` → 傳 NULL（自動掛接收店 store_internal）
+- `p_to_member_id = number` → 傳該 member id
+- `p_to_channel_id` 永遠傳 NULL（後端 fallback 到接收店 channel）
+
+## 結果
+
+| 測項 | 結果 | 備註 |
+|---|---|---|
+| `npm run build` 通過 | ✅ PASS | 修一次 TS narrowing (toStore === "" \|\| 0) |
+| 載入 /orders → 點訂單 → modal 開啟 | ✅ PASS | OrderDetail modal 出現 |
+| OrderDetail 頂部「↗ 轉出此訂單」按鈕在 pending 訂單顯示 | ✅ PASS | `hasTransferBtn: true` |
+| 點按鈕 → 轉出 modal 開啟 | ✅ PASS | `dialogCount: 2` (OrderDetail + Transfer 兩層) |
+| Transfer modal 含「原訂單」資訊 + 接收店 select + 接收人 + 原因 + 取消/確認 | ✅ PASS | 18 stores + textarea + 兩個按鈕 |
+| 接收店 select 載入全部 active stores | ✅ PASS | 三峽 / 中和 / ... / 龍潭 |
+
+## 未驗證
+
+| 測項 | 原因 |
+|---|---|
+| 接收人 dropdown 動態載入 (依接收店) | 需操作 select、未跑 |
+| 確認轉出 → RPC submit | 後端 RPC 已在 5a-1 verification 測過 (D1-D5 通過)；UI 只是包裝呼叫 |
+| reload tick 推 OrderDetail useEffect 重 load | 邏輯簡單 (state++ → useEffect 依 dep 重跑)、code review 即可 |
+| 同店轉自己 confirm() | 邏輯簡單 (toStore === currentPickupStoreId 時 confirm) |
+
+## 待 5b 第二段
+
+- 訂單登打 page (`/campaigns/order-entry`) 加「為分店叫貨」mode 入口
+- 該 mode 客戶 = store_internal、呼叫 `rpc_create_store_internal_order` 替代 `rpc_create_customer_orders`
+- 涉及 order-entry/page.tsx (799 行) 大改、單獨 PR


### PR DESCRIPTION
## Summary

Phase 5b 拆兩段。本 PR：訂單明細加「轉出此訂單」按鈕、call 5a-1 RPC `rpc_transfer_order_to_store`。「為分店叫貨 mode」(/campaigns/order-entry 大改、800 行) 留 5b 第二段。

## 改動

- **新 component** [OrderTransferModal](apps/admin/src/components/OrderTransferModal.tsx) — 選接收店 + 接收人 + 原因
- **OrderDetail** 加按鈕 + reloadTick + 掛 modal

## UI 規則

- 「↗ 轉出此訂單」按鈕只在 `status IN ('pending','confirmed','reserved')` 顯示
- `status='transferred_out'` 顯示「⚠️ 此訂單已轉出」警示（不再顯示按鈕）
- 接收人預設「掛到接收店店長 (store_internal)」、可改選真客人
- 同店轉自己 `confirm()` 守衛 (對應 5a-1 F4：允許但不需審核)
- RPC 成功 → `alert(新訂單號) + setReloadTick` 重 load 看到新狀態

## Test plan

- [x] `npm run build` 通過
- [x] preview 驗：點訂單 (pending) → OrderDetail modal → 看到「↗ 轉出此訂單」按鈕
- [x] 點按鈕 → 轉出 modal 開啟、含 18 stores select + 接收人 + 原因 + 操作
- [x] [`docs/TEST-order-transfer-button.md`](docs/TEST-order-transfer-button.md) 完整報告

未驗 (邏輯簡單 + 5a-1 後端已測)：
- 接收人 dropdown 動態載入 (依接收店)
- 確認轉出 → RPC submit (5a-1 D1-D5 通過)
- reloadTick 重 load (state++ → useEffect dep 重跑)

## 依賴

- 5a-1 (#132) merged ✅ — 提供 `rpc_transfer_order_to_store`

## 後續

- **5b 第二段**：訂單登打 page (`/campaigns/order-entry`) 加「為分店叫貨」mode + `rpc_create_store_internal_order`
- 5c：互助交流板 UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)