### PR TITLE
feat(orders+inventory): 為分店叫貨 mode + 互助交流板 (Phase 5b-2 + 5c)

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
@@ -14,6 +14,10 @@ type Campaign = {
 
 type Channel = { id: number; name: string; home_store_id: number };
 
+type Store = { id: number; code: string; name: string };
+
+type Mode = "customer" | "internal";
+
 type MemberRow = {
   id: number;
   member_no: string;
@@ -91,8 +95,13 @@ export default function OrderEntryPage() {
   const [campaign, setCampaign] = useState<Campaign | null>(null);
   const [channels, setChannels] = useState<Channel[]>([]);
   const [channelId, setChannelId] = useState<number | null>(null);
+  const [stores, setStores] = useState<Store[]>([]);
   const [campaignSkus, setCampaignSkus] = useState<SkuOption[]>([]);
   const [entries, setEntries] = useState<CustomerEntry[]>([newEntry()]);
+  const [mode, setMode] = useState<Mode>("customer");
+  const [internalStoreId, setInternalStoreId] = useState<number | null>(null);
+  const [internalNotes, setInternalNotes] = useState("");
+  const [internalItems, setInternalItems] = useState<ItemRow[]>([emptyItem()]);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
@@ -106,12 +115,14 @@ export default function OrderEntryPage() {
     let cancelled = false;
     (async () => {
       const sb = getSupabase();
-      const [cRes, chRes] = await Promise.all([
+      const [cRes, chRes, stRes] = await Promise.all([
         sb.from("group_buy_campaigns")
           .select("id, campaign_no, name, status, pickup_deadline")
           .eq("id", campaignId).maybeSingle(),
         sb.from("line_channels")
           .select("id, name, home_store_id").eq("is_active", true).order("name"),
+        sb.from("stores")
+          .select("id, code, name").eq("is_active", true).order("name"),
       ]);
       if (cancelled) return;
       if (cRes.error) { setError(cRes.error.message); return; }
@@ -120,6 +131,7 @@ export default function OrderEntryPage() {
       if (chRes.data && chRes.data.length > 0) {
         setChannelId((chRes.data[0] as Channel).id);
       }
+      setStores((stRes.data ?? []) as Store[]);
       // 一次抓活動內全部 SKU 給 dropdown 用
       const { data: skuData } = await getSupabase().rpc("rpc_search_skus_for_campaign", {
         p_campaign_id: campaignId, p_term: "", p_limit: 50,
@@ -209,12 +221,43 @@ export default function OrderEntryPage() {
     );
   }
 
-  // 全域快速鍵：Alt+N 加新顧客（避開 Ctrl+N 被瀏覽器搶走）、Ctrl+S 送出
+  // ---- internal mode helpers ----
+  function updateInternalItem(idx: number, patch: Partial<ItemRow>) {
+    setInternalItems((items) => items.map((it, i) => (i === idx ? { ...it, ...patch } : it)));
+  }
+  function addInternalItemRow() {
+    setInternalItems((items) => [...items, emptyItem()]);
+  }
+  function removeInternalItem(idx: number) {
+    setInternalItems((items) => {
+      const next = items.filter((_, i) => i !== idx);
+      return next.length ? next : [emptyItem()];
+    });
+  }
+  function addInternalSku(opt: SkuOption) {
+    setInternalItems((items) => {
+      if (items.some((it) => it.campaign_item_id === opt.campaign_item_id)) return items;
+      const newRow: ItemRow = {
+        campaign_item_id: opt.campaign_item_id,
+        sku_label: `${opt.product_name}${opt.variant_name ? ` / ${opt.variant_name}` : ""} (${opt.sku_code})`,
+        qty: "1",
+        unit_price: Number(opt.unit_price),
+      };
+      const cleaned = items.filter((it) => it.campaign_item_id || it.qty);
+      return [...cleaned, newRow];
+    });
+  }
+
+  // 全域快速鍵：Alt+N 加新顧客 / 加新項目、Ctrl+S 送出
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.altKey && !e.ctrlKey && !e.metaKey && e.key.toLowerCase() === "n") {
         e.preventDefault();
-        setEntries((es) => [...es, newEntry()]);
+        if (mode === "internal") {
+          setInternalItems((items) => [...items, emptyItem()]);
+        } else {
+          setEntries((es) => [...es, newEntry()]);
+        }
       }
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
         e.preventDefault();
@@ -224,11 +267,15 @@ export default function OrderEntryPage() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entries, channelId]);
+  }, [entries, channelId, mode, internalStoreId, internalItems, internalNotes]);
 
   async function handleSubmit() {
     if (submitting) return;
     setError(null);
+    if (mode === "internal") {
+      await submitInternal();
+      return;
+    }
     if (!channelId) { setError("請選 LINE 頻道"); return; }
     const noStore = entries.filter((e) => e.member_id && !e.pickup_store_id).map((e) => e.display_name);
     if (noStore.length > 0) { setError(`下列顧客未設預設取貨店：${noStore.join("、")}（請先在會員資料設 home_store_id）`); return; }
@@ -266,6 +313,43 @@ export default function OrderEntryPage() {
     }
   }
 
+  async function submitInternal() {
+    if (!internalStoreId) { setError("請選取貨店"); return; }
+    const items = internalItems
+      .filter((i) => i.campaign_item_id && Number(i.qty) > 0)
+      .map((i) => ({
+        campaign_item_id: i.campaign_item_id,
+        qty: Number(i.qty),
+        unit_price: i.unit_price,
+      }));
+    if (items.length === 0) { setError("請至少加一項商品"); return; }
+    if (items.some((i) => i.unit_price < 0)) { setError("單價不能為負"); return; }
+
+    setSubmitting(true);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes.user?.id;
+      if (!operator) { setError("未登入或 session 過期"); return; }
+      const { data, error: err } = await sb.rpc("rpc_create_store_internal_order", {
+        p_campaign_id: campaignId,
+        p_store_id: internalStoreId,
+        p_items: items,
+        p_operator: operator,
+        p_notes: internalNotes.trim() || null,
+      });
+      if (err) { setError(err.message); return; }
+      setToast(`已建立內部訂單 #${data}`);
+      setInternalItems([emptyItem()]);
+      setInternalNotes("");
+      setTimeout(() => setToast(null), 3000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   if (!Number.isFinite(campaignId)) {
     return <div className="p-6 text-sm text-red-600">無效的活動 ID</div>;
   }
@@ -286,17 +370,49 @@ export default function OrderEntryPage() {
           )}
         </div>
         <div className="flex items-center gap-2 text-xs text-zinc-500">
-          <kbd className="rounded border px-1">Alt+N</kbd> 新顧客
+          <kbd className="rounded border px-1">Alt+N</kbd> {mode === "internal" ? "新項目" : "新顧客"}
           <kbd className="rounded border px-1">Ctrl+S</kbd> 送出
         </div>
       </header>
 
-      <p className="text-xs text-zinc-500">
-        LINE 頻道：<span className="font-medium text-zinc-700 dark:text-zinc-300">
-          {channels.find((c) => c.id === channelId)?.name ?? "—"}
-        </span>
-        　·　取貨店：依顧客的「預設取貨店」自動帶出（會員資料設定）
-      </p>
+      <div className="inline-flex w-fit overflow-hidden rounded-md border border-zinc-300 text-xs dark:border-zinc-700">
+        <button
+          type="button"
+          onClick={() => setMode("customer")}
+          className={`px-3 py-1.5 ${
+            mode === "customer"
+              ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+              : "bg-white text-zinc-600 hover:bg-zinc-50 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          }`}
+        >
+          客戶下單
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode("internal")}
+          className={`px-3 py-1.5 ${
+            mode === "internal"
+              ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+              : "bg-white text-zinc-600 hover:bg-zinc-50 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          }`}
+          title="店長為自己店內部叫貨（會自動掛內部會員、可改價）"
+        >
+          為分店叫貨
+        </button>
+      </div>
+
+      {mode === "customer" ? (
+        <p className="text-xs text-zinc-500">
+          LINE 頻道：<span className="font-medium text-zinc-700 dark:text-zinc-300">
+            {channels.find((c) => c.id === channelId)?.name ?? "—"}
+          </span>
+          　·　取貨店：依顧客的「預設取貨店」自動帶出（會員資料設定）
+        </p>
+      ) : (
+        <p className="text-xs text-zinc-500">
+          內部叫貨：客戶自動掛 <span className="font-medium text-zinc-700 dark:text-zinc-300">store_internal</span> 內部會員、訂單編號 <span className="font-mono">XXX-INT0001</span>。可改 unit_price（88 折出清）。
+        </p>
+      )}
 
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
@@ -309,53 +425,210 @@ export default function OrderEntryPage() {
         </div>
       )}
 
-      <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
-        <div className="flex flex-col gap-3">
-          {entries.map((e) => (
-            <CustomerCard
-              key={e.key}
-              entry={e}
-              campaignId={campaignId}
-              channelId={channelId}
-              campaignSkus={campaignSkus}
-              pickedMemberIds={
-                new Set(
-                  entries
-                    .filter((x) => x.key !== e.key && x.member_id != null)
-                    .map((x) => x.member_id as number)
-                )
-              }
-              onChange={(patch) => updateEntry(e.key, patch)}
-              onItemChange={(idx, patch) => updateItem(e.key, idx, patch)}
-              onAddItem={() => addItem(e.key)}
-              onRemoveItem={(idx) => removeItem(e.key, idx)}
-              onAddSku={(opt) => addSku(e.key, opt)}
-              onRemove={() =>
-                setEntries((es) => (es.length > 1 ? es.filter((x) => x.key !== e.key) : es))
-              }
-            />
-          ))}
-          <button
-            type="button"
-            onClick={() => setEntries((es) => [...es, newEntry()])}
-            className="rounded-md border border-dashed border-zinc-300 px-3 py-2 text-sm text-zinc-500 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900"
-          >
-            + 新增顧客（Alt+N）
-          </button>
-          <div className="flex justify-end">
+      {mode === "customer" ? (
+        <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
+          <div className="flex flex-col gap-3">
+            {entries.map((e) => (
+              <CustomerCard
+                key={e.key}
+                entry={e}
+                campaignId={campaignId}
+                channelId={channelId}
+                campaignSkus={campaignSkus}
+                pickedMemberIds={
+                  new Set(
+                    entries
+                      .filter((x) => x.key !== e.key && x.member_id != null)
+                      .map((x) => x.member_id as number)
+                  )
+                }
+                onChange={(patch) => updateEntry(e.key, patch)}
+                onItemChange={(idx, patch) => updateItem(e.key, idx, patch)}
+                onAddItem={() => addItem(e.key)}
+                onRemoveItem={(idx) => removeItem(e.key, idx)}
+                onAddSku={(opt) => addSku(e.key, opt)}
+                onRemove={() =>
+                  setEntries((es) => (es.length > 1 ? es.filter((x) => x.key !== e.key) : es))
+                }
+              />
+            ))}
             <button
               type="button"
-              onClick={handleSubmit}
-              disabled={submitting}
-              className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              onClick={() => setEntries((es) => [...es, newEntry()])}
+              className="rounded-md border border-dashed border-zinc-300 px-3 py-2 text-sm text-zinc-500 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900"
             >
-              {submitting ? "送出中…" : "送出訂單（Ctrl+S）"}
+              + 新增顧客（Alt+N）
             </button>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={submitting}
+                className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                {submitting ? "送出中…" : "送出訂單（Ctrl+S）"}
+              </button>
+            </div>
+          </div>
+
+          <SummaryPanel entries={entries} />
+        </div>
+      ) : (
+        <InternalOrderPanel
+          campaignId={campaignId}
+          campaignSkus={campaignSkus}
+          stores={stores}
+          storeId={internalStoreId}
+          onStoreChange={setInternalStoreId}
+          notes={internalNotes}
+          onNotesChange={setInternalNotes}
+          items={internalItems}
+          onItemChange={updateInternalItem}
+          onAddItem={addInternalItemRow}
+          onRemoveItem={removeInternalItem}
+          onAddSku={addInternalSku}
+          onSubmit={handleSubmit}
+          submitting={submitting}
+        />
+      )}
+    </div>
+  );
+}
+
+// ============================================================
+// Internal Order Panel — 店長為自己店叫貨
+// ============================================================
+function InternalOrderPanel({
+  campaignId, campaignSkus, stores, storeId, onStoreChange,
+  notes, onNotesChange, items, onItemChange, onAddItem, onRemoveItem, onAddSku,
+  onSubmit, submitting,
+}: {
+  campaignId: number;
+  campaignSkus: SkuOption[];
+  stores: Store[];
+  storeId: number | null;
+  onStoreChange: (id: number | null) => void;
+  notes: string;
+  onNotesChange: (s: string) => void;
+  items: ItemRow[];
+  onItemChange: (idx: number, patch: Partial<ItemRow>) => void;
+  onAddItem: () => void;
+  onRemoveItem: (idx: number) => void;
+  onAddSku: (opt: SkuOption) => void;
+  onSubmit: () => void;
+  submitting: boolean;
+}) {
+  const pickedIds = new Set(items.map((it) => it.campaign_item_id).filter((x): x is number => x != null));
+  const availableSkus = campaignSkus.filter((s) => !pickedIds.has(s.campaign_item_id));
+  const totalQty = items.reduce((s, it) => s + (Number(it.qty) || 0), 0);
+  const totalAmount = items.reduce((s, it) => {
+    const q = Number(it.qty);
+    return s + (Number.isFinite(q) && q > 0 ? q * it.unit_price : 0);
+  }, 0);
+  return (
+    <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
+      <div className="flex flex-col gap-3">
+        <div className="rounded-md border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="mb-3 grid gap-3 sm:grid-cols-[200px_1fr]">
+            <label className="text-xs">
+              <span className="mb-1 block text-zinc-500">取貨店 <span className="text-red-500">*</span></span>
+              <select
+                value={storeId ?? ""}
+                onChange={(e) => onStoreChange(e.target.value ? Number(e.target.value) : null)}
+                className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+              >
+                <option value="">— 選店 —</option>
+                {stores.map((s) => (
+                  <option key={s.id} value={s.id}>{s.name} ({s.code})</option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs">
+              <span className="mb-1 block text-zinc-500">備註（選填）</span>
+              <input
+                value={notes}
+                onChange={(e) => onNotesChange(e.target.value)}
+                placeholder="預設【店長內部叫貨】"
+                className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+              />
+            </label>
+          </div>
+
+          <table className="w-full text-xs">
+            <thead className="text-zinc-500">
+              <tr>
+                <th className="text-left">商品</th>
+                <th className="w-20 text-right">數量</th>
+                <th className="w-24 text-right">單價（可改）</th>
+                <th className="w-24 text-right">小計</th>
+                <th className="w-8"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((it, idx) => (
+                <ItemEditorRow
+                  key={idx}
+                  campaignId={campaignId}
+                  item={it}
+                  isLast={idx === items.length - 1}
+                  editablePrice
+                  onChange={(patch) => onItemChange(idx, patch)}
+                  onAddNext={onAddItem}
+                  onRemove={() => onRemoveItem(idx)}
+                />
+              ))}
+            </tbody>
+          </table>
+
+          <div className="mt-2 flex justify-end">
+            <select
+              value=""
+              onChange={(e) => {
+                const id = Number(e.target.value);
+                const opt = availableSkus.find((s) => s.campaign_item_id === id);
+                if (opt) onAddSku(opt);
+                e.target.value = "";
+              }}
+              disabled={availableSkus.length === 0}
+              className="rounded border border-zinc-300 bg-white px-2 py-1 text-xs disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800"
+            >
+              <option value="">+ 加商品{availableSkus.length === 0 ? "（已全選）" : ""}</option>
+              {availableSkus.map((s) => (
+                <option key={s.campaign_item_id} value={s.campaign_item_id}>
+                  {s.product_name}{s.variant_name ? ` / ${s.variant_name}` : ""} (${Number(s.unit_price)})
+                </option>
+              ))}
+            </select>
           </div>
         </div>
 
-        <SummaryPanel entries={entries} />
+        <button
+          type="button"
+          onClick={onAddItem}
+          className="rounded-md border border-dashed border-zinc-300 px-3 py-2 text-sm text-zinc-500 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-900"
+        >
+          + 新增空白項目（Alt+N）
+        </button>
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={submitting}
+            className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            {submitting ? "送出中…" : "送出內部訂單（Ctrl+S）"}
+          </button>
+        </div>
       </div>
+
+      <aside className="sticky top-4 h-fit rounded-md border border-zinc-200 bg-white p-3 text-sm dark:border-zinc-800 dark:bg-zinc-900">
+        <h2 className="mb-2 text-sm font-semibold">本次統計（內部）</h2>
+        <div className="grid grid-cols-2 gap-2 text-xs">
+          <Stat label="件數" value={totalQty} />
+          <Stat label="總金額" value={`$${totalAmount}`} />
+        </div>
+      </aside>
     </div>
   );
 }
@@ -622,11 +895,12 @@ function CustomerSearch({
 // Item Editor Row
 // ============================================================
 function ItemEditorRow({
-  campaignId, item, isLast, onChange, onAddNext, onRemove,
+  campaignId, item, isLast, editablePrice, onChange, onAddNext, onRemove,
 }: {
   campaignId: number;
   item: ItemRow;
   isLast: boolean;
+  editablePrice?: boolean;
   onChange: (patch: Partial<ItemRow>) => void;
   onAddNext: () => void;
   onRemove: () => void;
@@ -716,7 +990,26 @@ function ItemEditorRow({
           }`}
         />
       </td>
-      <td className="text-right font-mono text-xs text-zinc-500">${item.unit_price}</td>
+      <td className="text-right">
+        {editablePrice ? (
+          <input
+            value={item.unit_price}
+            onChange={(e) => {
+              const n = Number(e.target.value);
+              onChange({ unit_price: Number.isFinite(n) ? n : 0 });
+            }}
+            inputMode="decimal"
+            className={`w-20 rounded border px-2 py-1 text-right text-xs ${
+              item.unit_price < 0
+                ? "border-red-400 bg-red-50 dark:bg-red-950"
+                : "border-zinc-300 bg-white dark:border-zinc-700 dark:bg-zinc-800"
+            }`}
+            title="可改價（88 折出清）"
+          />
+        ) : (
+          <span className="font-mono text-xs text-zinc-500">${item.unit_price}</span>
+        )}
+      </td>
       <td className="text-right font-mono text-xs">${subtotal}</td>
       <td className="text-right">
         <button type="button" onClick={onRemove} className="text-zinc-400 hover:text-red-500">×</button>

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -975,6 +975,7 @@ function ClaimOfferDialog({
 }) {
   const [toStore, setToStore] = useState<number | "">("");
   const [qty, setQty] = useState(String(post.qty_remaining));
+  const [isAir, setIsAir] = useState(false);
   const [reason, setReason] = useState(`互助板認領 #${post.id}`);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -1000,6 +1001,7 @@ function ClaimOfferDialog({
         p_operator: user.id,
         p_reason: reason || null,
         p_items: [{ sku_id: post.sku_id, qty: qtyN }],
+        p_is_air_transfer: isAir,
       });
       if (e1) { setErr(e1.message); return; }
       // 統一走 consume RPC：reach 0 自動 exhausted、>0 保持 active 可分批
@@ -1052,6 +1054,10 @@ function ClaimOfferDialog({
             <div className="mt-1 text-[10px] text-zinc-500">剩餘可認 {post.qty_remaining}{post.qty_remaining !== post.qty_available && `（原 ${post.qty_available}）`}</div>
           </label>
         </div>
+        <label className="mb-3 flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={isAir} onChange={(e) => setIsAir(e.target.checked)} className="h-4 w-4" />
+          <span>空中轉（店對店直送、不經總倉）</span>
+        </label>
         <label className="mb-3 block text-sm">
           <span className="mb-1 block text-xs text-zinc-500">原因（選填）</span>
           <input
@@ -1091,6 +1097,7 @@ function FulfillRequestDialog({
   const [orders, setOrders] = useState<PendingOrder[] | null>(null);
   const [pickedOrderId, setPickedOrderId] = useState<number | null>(null);
   const [qty, setQty] = useState(String(post.qty_remaining));
+  const [isAir, setIsAir] = useState(false);
   const [reason, setReason] = useState(`互助板提供 #${post.id}`);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -1162,6 +1169,7 @@ function FulfillRequestDialog({
         p_operator: user.id,
         p_reason: reason || null,
         p_items: [{ sku_id: post.sku_id, qty: qtyN }],
+        p_is_air_transfer: isAir,
       });
       if (e1) { setErr(e1.message); return; }
       const { error: e2 } = await sb.rpc("rpc_consume_aid_board", {
@@ -1236,6 +1244,10 @@ function FulfillRequestDialog({
             className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
           />
           <div className="mt-1 text-[10px] text-zinc-500">剩餘需求 {post.qty_remaining}（≤ 此值；不足部分維持需求中）</div>
+        </label>
+        <label className="mb-3 flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={isAir} onChange={(e) => setIsAir(e.target.checked)} className="h-4 w-4" />
+          <span>空中轉（店對店直送、不經總倉）</span>
         </label>
         <label className="mb-3 block text-sm">
           <span className="mb-1 block text-xs text-zinc-500">原因（選填）</span>

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -1,0 +1,1261 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Modal } from "@/components/Modal";
+import { getSupabase } from "@/lib/supabase";
+
+type Store = { id: number; code: string; name: string };
+type SkuOption = { id: number; sku_code: string; product_name: string; variant_name: string | null };
+
+type PostType = "offer" | "request";
+
+type Post = {
+  id: number;
+  post_type: PostType;
+  offering_store_id: number;
+  sku_id: number;
+  qty_available: number;
+  qty_remaining: number;
+  expires_at: string;
+  note: string | null;
+  status: "active" | "exhausted" | "expired" | "cancelled";
+  source_customer_order_id: number | null;
+  created_at: string;
+  created_by: string | null;
+  store_name?: string;
+  sku_label?: string;
+  source_order_no?: string | null;
+  replies_count?: number;
+};
+
+type PendingOrder = {
+  id: number;
+  order_no: string;
+  pickup_store_id: number;
+  status: string;
+  member_name: string | null;
+  items: { campaign_item_id: number | null; sku_id: number | null; qty: number; sku_label: string }[];
+};
+
+type Reply = {
+  id: number;
+  board_id: number;
+  author_id: string | null;
+  author_label: string | null;
+  body: string;
+  created_at: string;
+};
+
+const STATUS_LABEL: Record<Post["status"], string> = {
+  active: "進行中",
+  exhausted: "已認領",
+  expired: "已過期",
+  cancelled: "已取消",
+};
+
+const STATUS_COLOR: Record<Post["status"], string> = {
+  active: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+  exhausted: "bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-400",
+  expired: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+};
+
+const TYPE_LABEL: Record<PostType, string> = {
+  offer: "釋出",
+  request: "需求",
+};
+
+const TYPE_COLOR: Record<PostType, string> = {
+  offer: "bg-pink-100 text-pink-800 dark:bg-pink-950 dark:text-pink-300",
+  request: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+};
+
+export default function MutualAidPage() {
+  const [posts, setPosts] = useState<Post[] | null>(null);
+  const [stores, setStores] = useState<Store[]>([]);
+  const [filter, setFilter] = useState<"all" | "request" | "offer">("all");
+  const [error, setError] = useState<string | null>(null);
+  const [reloadTick, setReloadTick] = useState(0);
+  const [requestModalOpen, setRequestModalOpen] = useState(false);
+  const [offerModalOpen, setOfferModalOpen] = useState(false);
+  const [threadPost, setThreadPost] = useState<Post | null>(null);
+
+  // 載入 stores 一次
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data } = await sb.from("stores").select("id, code, name").eq("is_active", true).order("name");
+      if (!cancelled) setStores((data ?? []) as Store[]);
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // 載入 posts
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        let q = sb
+          .from("mutual_aid_board")
+          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, status, source_customer_order_id, created_at, created_by")
+          .eq("status", "active")
+          .order("created_at", { ascending: false })
+          .limit(200);
+        if (filter !== "all") q = q.eq("post_type", filter);
+        const { data, error: e } = await q;
+        if (e) throw new Error(e.message);
+        const rows = ((data as Post[] | null) ?? []);
+        if (rows.length === 0) {
+          if (!cancelled) setPosts([]);
+          return;
+        }
+        const skuIds = Array.from(new Set(rows.map((r) => r.sku_id)));
+        const storeIds = Array.from(new Set(rows.map((r) => r.offering_store_id)));
+        const boardIds = rows.map((r) => r.id);
+        const orderIds = Array.from(new Set(rows.map((r) => r.source_customer_order_id).filter((x): x is number => x != null)));
+
+        const [skuRes, storeRes, replyRes, orderRes] = await Promise.all([
+          sb.from("skus").select("id, sku_code, product_name, variant_name").in("id", skuIds),
+          sb.from("stores").select("id, name").in("id", storeIds),
+          sb.from("mutual_aid_replies").select("board_id").in("board_id", boardIds),
+          orderIds.length > 0
+            ? sb.from("customer_orders").select("id, order_no").in("id", orderIds)
+            : Promise.resolve({ data: [], error: null }),
+        ]);
+        const skuMap = new Map<number, SkuOption>(((skuRes.data ?? []) as SkuOption[]).map((s) => [s.id, s]));
+        const storeMap = new Map<number, string>(((storeRes.data ?? []) as { id: number; name: string }[]).map((s) => [s.id, s.name]));
+        const orderMap = new Map<number, string>(((orderRes.data ?? []) as { id: number; order_no: string }[]).map((o) => [o.id, o.order_no]));
+        const replyCount = new Map<number, number>();
+        for (const r of (replyRes.data ?? []) as { board_id: number }[]) {
+          replyCount.set(r.board_id, (replyCount.get(r.board_id) ?? 0) + 1);
+        }
+        const enriched = rows.map((r) => {
+          const sku = skuMap.get(r.sku_id);
+          return {
+            ...r,
+            store_name: storeMap.get(r.offering_store_id) ?? `#${r.offering_store_id}`,
+            sku_label: sku ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} (${sku.sku_code})` : `SKU#${r.sku_id}`,
+            source_order_no: r.source_customer_order_id ? orderMap.get(r.source_customer_order_id) ?? null : null,
+            replies_count: replyCount.get(r.id) ?? 0,
+          };
+        });
+        if (!cancelled) setPosts(enriched);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [filter, reloadTick]);
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">互助交流板</h1>
+          <p className="text-sm text-zinc-500">
+            純通訊板：店家貼出需求或可釋出的訂單、其他店認領 → 走 5b-1 訂單轉移把訂單變成接收店的。
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setRequestModalOpen(true)}
+            className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            📢 我要求助
+          </button>
+          <button
+            type="button"
+            onClick={() => setOfferModalOpen(true)}
+            className="rounded-md bg-pink-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-pink-700"
+          >
+            📦 我有庫存可提供
+          </button>
+        </div>
+      </header>
+
+      <div className="inline-flex w-fit overflow-hidden rounded-md border border-zinc-300 text-xs dark:border-zinc-700">
+        {(["all", "request", "offer"] as const).map((opt) => (
+          <button
+            key={opt}
+            type="button"
+            onClick={() => setFilter(opt)}
+            className={`px-3 py-1.5 ${
+              filter === opt
+                ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                : "bg-white text-zinc-600 hover:bg-zinc-50 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            }`}
+          >
+            {opt === "all" ? "全部" : opt === "request" ? "需求中" : "釋出中"}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {posts === null ? (
+        <div className="text-sm text-zinc-500">載入中…</div>
+      ) : posts.length === 0 ? (
+        <div className="rounded-md border border-dashed border-zinc-300 p-8 text-center text-sm text-zinc-500 dark:border-zinc-700">
+          目前沒有進行中的{filter === "request" ? "需求" : filter === "offer" ? "釋出" : ""}貼文
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {posts.map((p) => (
+            <li key={p.id}>
+              <button
+                type="button"
+                onClick={() => setThreadPost(p)}
+                className="block w-full rounded-md border border-zinc-200 bg-white p-3 text-left transition hover:border-zinc-400 hover:shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-600"
+              >
+                <div className="mb-1 flex flex-wrap items-center gap-2">
+                  <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${TYPE_COLOR[p.post_type]}`}>
+                    {TYPE_LABEL[p.post_type]}
+                  </span>
+                  <span className={`rounded px-1.5 py-0.5 text-[10px] ${STATUS_COLOR[p.status]}`}>
+                    {STATUS_LABEL[p.status]}
+                  </span>
+                  <span className="text-sm font-medium">{p.store_name}</span>
+                  <span className="text-sm">{p.sku_label}</span>
+                  <span className="ml-auto text-xs text-zinc-500">💬 {p.replies_count} 留言</span>
+                </div>
+                <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">
+                  <span>數量 <span className="font-mono text-zinc-700 dark:text-zinc-300">{p.qty_available}</span></span>
+                  <span>到期 <span className="text-zinc-700 dark:text-zinc-300">{fmtDt(p.expires_at)}</span></span>
+                  {p.source_order_no && (
+                    <span>源訂單 <span className="font-mono text-zinc-700 dark:text-zinc-300">{p.source_order_no}</span></span>
+                  )}
+                  {p.note && <span className="text-zinc-700 dark:text-zinc-300">「{p.note}」</span>}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <RequestModal
+        open={requestModalOpen}
+        onClose={() => setRequestModalOpen(false)}
+        stores={stores}
+        onPosted={() => {
+          setRequestModalOpen(false);
+          setReloadTick((n) => n + 1);
+        }}
+      />
+
+      <OfferModal
+        open={offerModalOpen}
+        onClose={() => setOfferModalOpen(false)}
+        stores={stores}
+        onPosted={() => {
+          setOfferModalOpen(false);
+          setReloadTick((n) => n + 1);
+        }}
+      />
+
+      {threadPost && (
+        <ThreadModal
+          post={threadPost}
+          stores={stores}
+          onClose={() => setThreadPost(null)}
+          onClosed={() => {
+            setThreadPost(null);
+            setReloadTick((n) => n + 1);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ============================================================
+// Common: SKU search input
+// ============================================================
+function SkuSearchInput({
+  value, onChange,
+}: {
+  value: SkuOption | null;
+  onChange: (s: SkuOption | null) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SkuOption[]>([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(async () => {
+      let q = getSupabase()
+        .from("skus").select("id, sku_code, product_name, variant_name")
+        .eq("status", "active")
+        .order("updated_at", { ascending: false })
+        .limit(20);
+      const s = query.trim();
+      if (s) {
+        const safe = s.replace(/[%,()]/g, " ").trim();
+        q = q.or(`sku_code.ilike.%${safe}%,product_name.ilike.%${safe}%,variant_name.ilike.%${safe}%`);
+      }
+      const { data } = await q;
+      setResults((data as SkuOption[]) ?? []);
+    }, query ? 250 : 0);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  return (
+    <div className="relative">
+      <input
+        value={value ? `${value.product_name}${value.variant_name ? ` / ${value.variant_name}` : ""} (${value.sku_code})` : query}
+        onFocus={() => setOpen(true)}
+        onChange={(e) => {
+          if (value) onChange(null);
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        placeholder="搜尋商品 / SKU"
+        className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+      />
+      {open && results.length > 0 && !value && (
+        <div
+          className="absolute left-0 right-0 top-full z-20 mt-1 max-h-60 overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
+          onMouseLeave={() => setOpen(false)}
+        >
+          {results.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => { onChange(s); setOpen(false); }}
+              className="block w-full px-2 py-1.5 text-left text-xs hover:bg-zinc-100 dark:hover:bg-zinc-700"
+            >
+              <span className="font-medium">{s.product_name}</span>
+              {s.variant_name && <span className="ml-1 text-zinc-500">/ {s.variant_name}</span>}
+              <span className="ml-2 font-mono text-zinc-400">{s.sku_code}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function defaultExpiresAt() {
+  const d = new Date(Date.now() + 7 * 86400_000);
+  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+  return d.toISOString().slice(0, 16);
+}
+
+// ============================================================
+// Request Modal — 我要求助
+// ============================================================
+function RequestModal({
+  open, onClose, stores, onPosted,
+}: {
+  open: boolean;
+  onClose: () => void;
+  stores: Store[];
+  onPosted: () => void;
+}) {
+  const [storeId, setStoreId] = useState<number | "">("");
+  const [picked, setPicked] = useState<SkuOption | null>(null);
+  const [qty, setQty] = useState("");
+  const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setStoreId(""); setPicked(null); setQty(""); setNote(""); setErr(null);
+      setExpiresAt(defaultExpiresAt());
+    }
+  }, [open]);
+
+  async function submit() {
+    if (submitting) return;
+    setErr(null);
+    if (!storeId) { setErr("請選求助店"); return; }
+    if (!picked) { setErr("請選 SKU"); return; }
+    const qtyN = Number(qty);
+    if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("數量需 > 0"); return; }
+    const expDate = new Date(expiresAt);
+    if (expDate <= new Date()) { setErr("到期時間需在未來"); return; }
+
+    setSubmitting(true);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes.user?.id;
+      if (!operator) { setErr("未登入或 session 過期"); return; }
+      const { error: e } = await sb.rpc("rpc_post_aid_board", {
+        p_offering_store_id: storeId,
+        p_sku_id: picked.id,
+        p_qty_available: qtyN,
+        p_expires_at: expDate.toISOString(),
+        p_note: note.trim() || null,
+        p_operator: operator,
+        p_post_type: "request",
+        p_source_customer_order_id: null,
+      });
+      if (e) { setErr(e.message); return; }
+      onPosted();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title="📢 我要求助" maxWidth="max-w-lg">
+      <div className="flex flex-col gap-3 text-sm">
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {err}
+          </div>
+        )}
+        <label>
+          <span className="mb-1 block text-xs text-zinc-500">求助店 <span className="text-red-500">*</span></span>
+          <select
+            value={storeId}
+            onChange={(e) => setStoreId(e.target.value ? Number(e.target.value) : "")}
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="">— 選店 —</option>
+            {stores.map((s) => (<option key={s.id} value={s.id}>{s.name} ({s.code})</option>))}
+          </select>
+        </label>
+        <div>
+          <span className="mb-1 block text-xs text-zinc-500">需要的 SKU <span className="text-red-500">*</span></span>
+          <SkuSearchInput value={picked} onChange={setPicked} />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <label>
+            <span className="mb-1 block text-xs text-zinc-500">需要數量 <span className="text-red-500">*</span></span>
+            <input
+              value={qty}
+              onChange={(e) => setQty(e.target.value)}
+              inputMode="decimal"
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </label>
+          <label>
+            <span className="mb-1 block text-xs text-zinc-500">到期時間 <span className="text-red-500">*</span></span>
+            <input
+              type="datetime-local"
+              value={expiresAt}
+              onChange={(e) => setExpiresAt(e.target.value)}
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </label>
+        </div>
+        <label>
+          <span className="mb-1 block text-xs text-zinc-500">備註（選填）</span>
+          <input
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="例：客人要、想多進"
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+        <div className="mt-2 flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700">取消</button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {submitting ? "送出中…" : "發佈求助"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ============================================================
+// Offer Modal — 我有庫存可提供（從既有訂單釋出）
+// ============================================================
+function OfferModal({
+  open, onClose, stores, onPosted,
+}: {
+  open: boolean;
+  onClose: () => void;
+  stores: Store[];
+  onPosted: () => void;
+}) {
+  const [storeId, setStoreId] = useState<number | "">("");
+  const [orders, setOrders] = useState<PendingOrder[] | null>(null);
+  const [pickedOrder, setPickedOrder] = useState<PendingOrder | null>(null);
+  const [pickedItemIdx, setPickedItemIdx] = useState(0);
+  const [qty, setQty] = useState("");
+  const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setStoreId(""); setOrders(null); setPickedOrder(null); setPickedItemIdx(0);
+      setQty(""); setNote(""); setErr(null);
+      setExpiresAt(defaultExpiresAt());
+    }
+  }, [open]);
+
+  // 載入該店 pending orders
+  useEffect(() => {
+    if (!open || !storeId) { setOrders(null); return; }
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data, error: e } = await sb
+        .from("customer_orders")
+        .select(`
+          id, order_no, pickup_store_id, status,
+          member:members(name),
+          items:customer_order_items(campaign_item_id, sku_id, qty, sku:skus(sku_code, product_name, variant_name))
+        `)
+        .eq("pickup_store_id", storeId)
+        .in("status", ["pending", "confirmed", "reserved"])
+        .order("id", { ascending: false })
+        .limit(50);
+      if (cancelled) return;
+      if (e) { setErr(e.message); return; }
+      type RawSku = { sku_code: string; product_name: string; variant_name: string | null };
+      type RawItem = { campaign_item_id: number | null; sku_id: number | null; qty: number; sku: RawSku | RawSku[] | null };
+      type RawOrder = {
+        id: number; order_no: string; pickup_store_id: number; status: string;
+        member: { name: string | null } | { name: string | null }[] | null;
+        items: RawItem[];
+      };
+      const enriched: PendingOrder[] = ((data as unknown as RawOrder[] | null) ?? []).map((o) => {
+        const memberObj = Array.isArray(o.member) ? o.member[0] : o.member;
+        return {
+          id: o.id,
+          order_no: o.order_no,
+          pickup_store_id: o.pickup_store_id,
+          status: o.status,
+          member_name: memberObj?.name ?? null,
+          items: (o.items ?? []).map((it) => {
+            const sku = Array.isArray(it.sku) ? it.sku[0] : it.sku;
+            return {
+              campaign_item_id: it.campaign_item_id,
+              sku_id: it.sku_id,
+              qty: Number(it.qty),
+              sku_label: sku
+                ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} (${sku.sku_code})`
+                : `SKU#${it.sku_id}`,
+            };
+          }),
+        };
+      }).filter((o) => o.items.length > 0);
+      setOrders(enriched);
+    })();
+    return () => { cancelled = true; };
+  }, [open, storeId]);
+
+  // 選了訂單 → 自動帶第一個 item 的 qty
+  useEffect(() => {
+    if (pickedOrder && pickedOrder.items[pickedItemIdx]) {
+      setQty(String(pickedOrder.items[pickedItemIdx].qty));
+    }
+  }, [pickedOrder, pickedItemIdx]);
+
+  async function submit() {
+    if (submitting) return;
+    setErr(null);
+    if (!storeId) { setErr("請選釋出店"); return; }
+    if (!pickedOrder) { setErr("請選要釋出的訂單"); return; }
+    const item = pickedOrder.items[pickedItemIdx];
+    if (!item || !item.sku_id) { setErr("選定 item 沒 sku_id"); return; }
+    const qtyN = Number(qty);
+    if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("數量需 > 0"); return; }
+    const expDate = new Date(expiresAt);
+    if (expDate <= new Date()) { setErr("到期時間需在未來"); return; }
+
+    setSubmitting(true);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes.user?.id;
+      if (!operator) { setErr("未登入或 session 過期"); return; }
+      const { error: e } = await sb.rpc("rpc_post_aid_board", {
+        p_offering_store_id: storeId,
+        p_sku_id: item.sku_id,
+        p_qty_available: qtyN,
+        p_expires_at: expDate.toISOString(),
+        p_note: note.trim() || null,
+        p_operator: operator,
+        p_post_type: "offer",
+        p_source_customer_order_id: pickedOrder.id,
+      });
+      if (e) { setErr(e.message); return; }
+      onPosted();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title="📦 我有庫存可提供（從既有訂單釋出）" maxWidth="max-w-2xl">
+      <div className="flex flex-col gap-3 text-sm">
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {err}
+          </div>
+        )}
+        <label>
+          <span className="mb-1 block text-xs text-zinc-500">釋出店 <span className="text-red-500">*</span></span>
+          <select
+            value={storeId}
+            onChange={(e) => {
+              setStoreId(e.target.value ? Number(e.target.value) : "");
+              setPickedOrder(null); setPickedItemIdx(0); setQty("");
+            }}
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="">— 選店 —</option>
+            {stores.map((s) => (<option key={s.id} value={s.id}>{s.name} ({s.code})</option>))}
+          </select>
+        </label>
+
+        {storeId !== "" && (
+          <div>
+            <span className="mb-1 block text-xs text-zinc-500">選擇要釋出的訂單 <span className="text-red-500">*</span></span>
+            {orders === null ? (
+              <div className="text-xs text-zinc-500">載入訂單中…</div>
+            ) : orders.length === 0 ? (
+              <div className="rounded-md border border-dashed border-zinc-300 p-3 text-xs text-zinc-500 dark:border-zinc-700">該店目前沒有可釋出的 pending / confirmed / reserved 訂單</div>
+            ) : (
+              <div className="max-h-60 overflow-y-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+                {orders.map((o) => (
+                  <button
+                    key={o.id}
+                    type="button"
+                    onClick={() => { setPickedOrder(o); setPickedItemIdx(0); }}
+                    className={`block w-full border-b border-zinc-100 px-2 py-1.5 text-left text-xs last:border-b-0 dark:border-zinc-800 ${
+                      pickedOrder?.id === o.id ? "bg-pink-50 dark:bg-pink-950" : "hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span><span className="font-mono">{o.order_no}</span> · {o.member_name ?? "—"} · <span className="text-zinc-500">{o.status}</span></span>
+                      <span className="text-zinc-500">{o.items.length} 項</span>
+                    </div>
+                    {pickedOrder?.id === o.id && o.items.length > 1 && (
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        {o.items.map((it, idx) => (
+                          <button
+                            key={idx}
+                            type="button"
+                            onClick={(e) => { e.stopPropagation(); setPickedItemIdx(idx); }}
+                            className={`rounded border px-1.5 py-0.5 text-[10px] ${
+                              pickedItemIdx === idx
+                                ? "border-pink-500 bg-pink-100 text-pink-800 dark:bg-pink-950 dark:text-pink-300"
+                                : "border-zinc-300 text-zinc-600 dark:border-zinc-700 dark:text-zinc-400"
+                            }`}
+                          >
+                            {it.sku_label} × {it.qty}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                    {pickedOrder?.id === o.id && o.items.length === 1 && (
+                      <div className="mt-1 text-[10px] text-zinc-500">{o.items[0].sku_label} × {o.items[0].qty}</div>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 gap-3">
+          <label>
+            <span className="mb-1 block text-xs text-zinc-500">釋出數量 <span className="text-red-500">*</span></span>
+            <input
+              value={qty}
+              onChange={(e) => setQty(e.target.value)}
+              inputMode="decimal"
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </label>
+          <label>
+            <span className="mb-1 block text-xs text-zinc-500">到期時間 <span className="text-red-500">*</span></span>
+            <input
+              type="datetime-local"
+              value={expiresAt}
+              onChange={(e) => setExpiresAt(e.target.value)}
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </label>
+        </div>
+        <label>
+          <span className="mb-1 block text-xs text-zinc-500">備註（選填）</span>
+          <input
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="例：客人棄單、效期將至"
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+        <div className="mt-2 flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700">取消</button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="rounded-md bg-pink-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-pink-700 disabled:opacity-50"
+          >
+            {submitting ? "送出中…" : "發佈釋出"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ============================================================
+// Thread Modal
+// ============================================================
+function ThreadModal({
+  post, stores, onClose, onClosed,
+}: {
+  post: Post;
+  stores: Store[];
+  onClose: () => void;
+  onClosed: () => void;
+}) {
+  const [replies, setReplies] = useState<Reply[] | null>(null);
+  const [body, setBody] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [claimOpen, setClaimOpen] = useState(false);
+  const [fulfillOpen, setFulfillOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const [{ data: rRes }, { data: uRes }] = await Promise.all([
+        sb.from("mutual_aid_replies")
+          .select("id, board_id, author_id, author_label, body, created_at")
+          .eq("board_id", post.id)
+          .order("created_at", { ascending: true }),
+        sb.auth.getUser(),
+      ]);
+      if (cancelled) return;
+      setReplies((rRes as Reply[] | null) ?? []);
+      setCurrentUserId(uRes.user?.id ?? null);
+    })();
+    return () => { cancelled = true; };
+  }, [post.id, tick]);
+
+  const canClose = post.status === "active" && (currentUserId === post.created_by || true);
+
+  async function postReply() {
+    if (submitting) return;
+    setErr(null);
+    if (!body.trim()) { setErr("請輸入留言"); return; }
+    setSubmitting(true);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes.user?.id;
+      if (!operator) { setErr("未登入或 session 過期"); return; }
+      const { error: e } = await sb.rpc("rpc_post_aid_reply", {
+        p_board_id: post.id,
+        p_body: body,
+        p_operator: operator,
+      });
+      if (e) { setErr(e.message); return; }
+      setBody("");
+      setTick((n) => n + 1);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function closePost() {
+    if (closing) return;
+    if (!confirm("確定要結束這則互助貼文？")) return;
+    setClosing(true);
+    setErr(null);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes.user?.id;
+      if (!operator) { setErr("未登入或 session 過期"); return; }
+      const { error: e } = await sb.rpc("rpc_close_aid_board", {
+        p_board_id: post.id,
+        p_status: "cancelled",
+        p_operator: operator,
+      });
+      if (e) { setErr(e.message); return; }
+      onClosed();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setClosing(false);
+    }
+  }
+
+  return (
+    <Modal open={true} onClose={onClose} title="互助貼文 #" maxWidth="max-w-2xl">
+      <div className="flex flex-col gap-3 text-sm">
+        {/* Post header */}
+        <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs dark:border-zinc-800 dark:bg-zinc-950">
+          <div className="mb-1 flex flex-wrap items-center gap-2">
+            <span className={`rounded px-1.5 py-0.5 text-[10px] ${STATUS_COLOR[post.status]}`}>
+              {STATUS_LABEL[post.status]}
+            </span>
+            <span className="font-medium text-zinc-700 dark:text-zinc-300">{post.store_name}</span>
+            <span className="text-zinc-500">釋出</span>
+            <span>{post.sku_label}</span>
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-zinc-500">
+            <span>數量 <span className="font-mono text-zinc-700 dark:text-zinc-300">{post.qty_available}</span></span>
+            <span>到期 <span className="text-zinc-700 dark:text-zinc-300">{fmtDt(post.expires_at)}</span></span>
+            <span>發佈 {fmtDt(post.created_at)}</span>
+            {post.note && <div className="basis-full pt-1 text-zinc-700 dark:text-zinc-300">「{post.note}」</div>}
+          </div>
+        </div>
+
+        {/* Replies thread */}
+        <div className="flex flex-col gap-2 max-h-80 overflow-y-auto pr-1">
+          {replies === null ? (
+            <div className="text-xs text-zinc-500">載入留言…</div>
+          ) : replies.length === 0 ? (
+            <div className="text-xs text-zinc-500">尚無留言。第一個留言開始討論吧！</div>
+          ) : (
+            replies.map((r) => (
+              <div
+                key={r.id}
+                className="rounded-md border border-zinc-200 bg-white p-2 text-xs dark:border-zinc-800 dark:bg-zinc-900"
+              >
+                <div className="mb-1 flex items-center justify-between text-[10px] text-zinc-500">
+                  <span className="font-medium text-zinc-700 dark:text-zinc-300">{r.author_label ?? "匿名"}</span>
+                  <span>{fmtDt(r.created_at)}</span>
+                </div>
+                <div className="whitespace-pre-wrap text-zinc-700 dark:text-zinc-300">{r.body}</div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {err}
+          </div>
+        )}
+
+        {/* Reply form */}
+        {post.status === "active" ? (
+          <div>
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              onKeyDown={(e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+                  e.preventDefault();
+                  postReply();
+                }
+              }}
+              placeholder="留言（Ctrl+Enter 送出）"
+              rows={2}
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+            />
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+              <div className="flex flex-wrap gap-2">
+                {post.post_type === "offer" && (
+                  <button
+                    type="button"
+                    onClick={() => setClaimOpen(true)}
+                    className="rounded-md border border-pink-400 bg-pink-50 px-3 py-1.5 text-xs font-medium text-pink-700 hover:bg-pink-100 dark:border-pink-700 dark:bg-pink-950 dark:text-pink-300 dark:hover:bg-pink-900"
+                    title="把釋出店的訂單轉成接收店的（走 5b-1 棄單轉出）"
+                  >
+                    ✋ 我要認領
+                  </button>
+                )}
+                {post.post_type === "request" && (
+                  <button
+                    type="button"
+                    onClick={() => setFulfillOpen(true)}
+                    className="rounded-md border border-blue-400 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
+                    title="從我的 pending 訂單挑一張轉給求助店"
+                  >
+                    🤝 我可以提供
+                  </button>
+                )}
+                {canClose && (
+                  <button
+                    type="button"
+                    onClick={closePost}
+                    disabled={closing}
+                    className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs text-zinc-600 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  >
+                    {closing ? "處理中…" : "結束此貼"}
+                  </button>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={postReply}
+                disabled={submitting || !body.trim()}
+                className="rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                {submitting ? "送出中…" : "送出留言"}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-md border border-zinc-200 bg-zinc-50 p-2 text-xs text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950">
+            此貼已關閉（{STATUS_LABEL[post.status]}），無法再留言。
+          </div>
+        )}
+      </div>
+
+      {claimOpen && (
+        <ClaimOfferDialog
+          post={post}
+          stores={stores}
+          onCancel={() => setClaimOpen(false)}
+          onDone={() => {
+            setClaimOpen(false);
+            onClosed();
+          }}
+        />
+      )}
+      {fulfillOpen && (
+        <FulfillRequestDialog
+          post={post}
+          stores={stores}
+          onCancel={() => setFulfillOpen(false)}
+          onDone={() => {
+            setFulfillOpen(false);
+            onClosed();
+          }}
+        />
+      )}
+    </Modal>
+  );
+}
+
+// ============================================================
+// Claim Offer Dialog — 認領釋出（receiving store 從釋出方拿訂單）
+// ============================================================
+function ClaimOfferDialog({
+  post, stores, onCancel, onDone,
+}: {
+  post: Post;
+  stores: Store[];
+  onCancel: () => void;
+  onDone: () => void;
+}) {
+  const [toStore, setToStore] = useState<number | "">("");
+  const [qty, setQty] = useState(String(post.qty_available));
+  const [reason, setReason] = useState(`互助板認領 #${post.id}`);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function submit() {
+    if (busy) return;
+    setErr(null);
+    if (!toStore) { setErr("請選接收店"); return; }
+    if (!post.source_customer_order_id) { setErr("此 offer 缺 source_customer_order_id（資料異常）"); return; }
+    const qtyN = Number(qty);
+    if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("認領數量需 > 0"); return; }
+    if (qtyN > post.qty_available) { setErr(`認領數量超過釋出量 ${post.qty_available}`); return; }
+    setBusy(true);
+    try {
+      const sb = getSupabase();
+      const { data: { user } } = await sb.auth.getUser();
+      if (!user?.id) { setErr("未登入"); return; }
+      const { error: e1 } = await sb.rpc("rpc_transfer_order_partial", {
+        p_order_id: post.source_customer_order_id,
+        p_to_pickup_store_id: toStore,
+        p_to_member_id: null,
+        p_to_channel_id: null,
+        p_operator: user.id,
+        p_reason: reason || null,
+        p_items: [{ sku_id: post.sku_id, qty: qtyN }],
+      });
+      if (e1) { setErr(e1.message); return; }
+      // 統一走 consume RPC：reach 0 自動 exhausted、>0 保持 active 可分批
+      const { error: e2 } = await sb.rpc("rpc_consume_aid_board", {
+        p_board_id: post.id,
+        p_qty: qtyN,
+        p_operator: user.id,
+      });
+      if (e2) { setErr(`轉移成功但扣量失敗：${e2.message}`); return; }
+      onDone();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-zinc-900/60 p-4" onClick={onCancel}>
+      <div className="w-full max-w-md rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900" onClick={(e) => e.stopPropagation()}>
+        <h3 className="mb-3 text-base font-semibold">認領釋出</h3>
+        {err && (
+          <div className="mb-2 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">{err}</div>
+        )}
+        <div className="mb-3 rounded bg-zinc-50 p-2 text-xs dark:bg-zinc-950">
+          從「{post.store_name}」的訂單 <span className="font-mono">{post.source_order_no ?? `#${post.source_customer_order_id}`}</span> 取出指定數量、開新單給接收店（走 5b-1 partial transfer）。
+        </div>
+        <div className="mb-3 grid grid-cols-2 gap-3 text-sm">
+          <label>
+            <span className="mb-1 block text-xs text-zinc-500">接收店 <span className="text-red-500">*</span></span>
+            <select
+              value={toStore}
+              onChange={(e) => setToStore(e.target.value ? Number(e.target.value) : "")}
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+            >
+              <option value="">— 選店 —</option>
+              {stores.filter((s) => s.id !== post.offering_store_id).map((s) => (
+                <option key={s.id} value={s.id}>{s.name} ({s.code})</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span className="mb-1 block text-xs text-zinc-500">認領數量 <span className="text-red-500">*</span></span>
+            <input
+              value={qty}
+              onChange={(e) => setQty(e.target.value)}
+              inputMode="decimal"
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
+            />
+            <div className="mt-1 text-[10px] text-zinc-500">釋出總量 {post.qty_available}</div>
+          </label>
+        </div>
+        <label className="mb-3 block text-sm">
+          <span className="mb-1 block text-xs text-zinc-500">原因（選填）</span>
+          <input
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onCancel} className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700">取消</button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={busy}
+            className="rounded-md bg-pink-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-pink-700 disabled:opacity-50"
+          >
+            {busy ? "處理中…" : "確認認領"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// Fulfill Request Dialog — 提供需求（從我的訂單挑一張轉給求助店）
+// ============================================================
+function FulfillRequestDialog({
+  post, stores, onCancel, onDone,
+}: {
+  post: Post;
+  stores: Store[];
+  onCancel: () => void;
+  onDone: () => void;
+}) {
+  const [myStore, setMyStore] = useState<number | "">("");
+  const [orders, setOrders] = useState<PendingOrder[] | null>(null);
+  const [pickedOrderId, setPickedOrderId] = useState<number | null>(null);
+  const [qty, setQty] = useState(String(post.qty_available));
+  const [reason, setReason] = useState(`互助板提供 #${post.id}`);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // 載入我店符合 sku 的 pending orders
+  useEffect(() => {
+    if (!myStore) { setOrders(null); return; }
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data, error: e } = await sb
+        .from("customer_orders")
+        .select(`
+          id, order_no, pickup_store_id, status,
+          member:members(name),
+          items:customer_order_items!inner(sku_id, qty, sku:skus(sku_code, product_name, variant_name))
+        `)
+        .eq("pickup_store_id", myStore)
+        .in("status", ["pending", "confirmed", "reserved"])
+        .eq("items.sku_id", post.sku_id)
+        .order("id", { ascending: false })
+        .limit(50);
+      if (cancelled) return;
+      if (e) { setErr(e.message); return; }
+      type RawSku = { sku_code: string; product_name: string; variant_name: string | null };
+      type RawItem = { sku_id: number | null; qty: number; sku: RawSku | RawSku[] | null };
+      type RawOrder = {
+        id: number; order_no: string; pickup_store_id: number; status: string;
+        member: { name: string | null } | { name: string | null }[] | null;
+        items: RawItem[];
+      };
+      const enriched: PendingOrder[] = ((data as unknown as RawOrder[] | null) ?? []).map((o) => {
+        const memberObj = Array.isArray(o.member) ? o.member[0] : o.member;
+        return {
+          id: o.id, order_no: o.order_no, pickup_store_id: o.pickup_store_id, status: o.status,
+          member_name: memberObj?.name ?? null,
+          items: (o.items ?? []).map((it) => {
+            const sku = Array.isArray(it.sku) ? it.sku[0] : it.sku;
+            return {
+              campaign_item_id: null, sku_id: it.sku_id, qty: Number(it.qty),
+              sku_label: sku ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} (${sku.sku_code})` : `SKU#${it.sku_id}`,
+            };
+          }),
+        };
+      });
+      setOrders(enriched);
+    })();
+    return () => { cancelled = true; };
+  }, [myStore, post.sku_id]);
+
+  async function submit() {
+    if (busy) return;
+    setErr(null);
+    if (!myStore) { setErr("請選提供店"); return; }
+    if (!pickedOrderId) { setErr("請選要轉移的訂單"); return; }
+    const qtyN = Number(qty);
+    if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("提供數量需 > 0"); return; }
+    if (qtyN > post.qty_available) { setErr(`提供數量超過需求量 ${post.qty_available}`); return; }
+    setBusy(true);
+    try {
+      const sb = getSupabase();
+      const { data: { user } } = await sb.auth.getUser();
+      if (!user?.id) { setErr("未登入"); return; }
+      const { error: e1 } = await sb.rpc("rpc_transfer_order_partial", {
+        p_order_id: pickedOrderId,
+        p_to_pickup_store_id: post.offering_store_id,
+        p_to_member_id: null,
+        p_to_channel_id: null,
+        p_operator: user.id,
+        p_reason: reason || null,
+        p_items: [{ sku_id: post.sku_id, qty: qtyN }],
+      });
+      if (e1) { setErr(e1.message); return; }
+      const { error: e2 } = await sb.rpc("rpc_consume_aid_board", {
+        p_board_id: post.id,
+        p_qty: qtyN,
+        p_operator: user.id,
+      });
+      if (e2) { setErr(`轉移成功但扣量失敗：${e2.message}`); return; }
+      onDone();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-zinc-900/60 p-4" onClick={onCancel}>
+      <div className="w-full max-w-lg rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900" onClick={(e) => e.stopPropagation()}>
+        <h3 className="mb-3 text-base font-semibold">提供需求</h3>
+        {err && (
+          <div className="mb-2 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">{err}</div>
+        )}
+        <div className="mb-3 rounded bg-zinc-50 p-2 text-xs dark:bg-zinc-950">
+          求助店「{post.store_name}」需要 {post.sku_label}（數量 {post.qty_available}）。
+          選一張你店的 pending 訂單轉給他（走 5b-1 棄單轉出）。
+        </div>
+        <label className="mb-3 block text-sm">
+          <span className="mb-1 block text-xs text-zinc-500">提供店（你的店） <span className="text-red-500">*</span></span>
+          <select
+            value={myStore}
+            onChange={(e) => { setMyStore(e.target.value ? Number(e.target.value) : ""); setPickedOrderId(null); }}
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="">— 選店 —</option>
+            {stores.filter((s) => s.id !== post.offering_store_id).map((s) => (
+              <option key={s.id} value={s.id}>{s.name} ({s.code})</option>
+            ))}
+          </select>
+        </label>
+        {myStore !== "" && (
+          <div className="mb-3">
+            <span className="mb-1 block text-xs text-zinc-500">挑一張含此 SKU 的 pending 訂單 <span className="text-red-500">*</span></span>
+            {orders === null ? (
+              <div className="text-xs text-zinc-500">載入訂單中…</div>
+            ) : orders.length === 0 ? (
+              <div className="rounded-md border border-dashed border-zinc-300 p-3 text-xs text-zinc-500 dark:border-zinc-700">該店沒有含此 SKU 的可轉移訂單</div>
+            ) : (
+              <div className="max-h-48 overflow-y-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+                {orders.map((o) => (
+                  <button
+                    key={o.id}
+                    type="button"
+                    onClick={() => setPickedOrderId(o.id)}
+                    className={`block w-full border-b border-zinc-100 px-2 py-1.5 text-left text-xs last:border-b-0 dark:border-zinc-800 ${
+                      pickedOrderId === o.id ? "bg-blue-50 dark:bg-blue-950" : "hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                    }`}
+                  >
+                    <span className="font-mono">{o.order_no}</span> · {o.member_name ?? "—"} · 數量 {o.items.find((it) => it.sku_id === post.sku_id)?.qty ?? "—"} · <span className="text-zinc-500">{o.status}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        <label className="mb-3 block text-sm">
+          <span className="mb-1 block text-xs text-zinc-500">提供數量 <span className="text-red-500">*</span></span>
+          <input
+            value={qty}
+            onChange={(e) => setQty(e.target.value)}
+            inputMode="decimal"
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <div className="mt-1 text-[10px] text-zinc-500">求助總量 {post.qty_available}（≤ 此值；不足部分維持需求中）</div>
+        </label>
+        <label className="mb-3 block text-sm">
+          <span className="mb-1 block text-xs text-zinc-500">原因（選填）</span>
+          <input
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onCancel} className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700">取消</button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={busy}
+            className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {busy ? "處理中…" : "確認提供"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function fmtDt(s: string) {
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return s;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${y}/${m}/${day} ${hh}:${mm}`;
+}

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -226,7 +226,13 @@ export default function MutualAidPage() {
                   <span className="ml-auto text-xs text-zinc-500">💬 {p.replies_count} 留言</span>
                 </div>
                 <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">
-                  <span>數量 <span className="font-mono text-zinc-700 dark:text-zinc-300">{p.qty_available}</span></span>
+                  <span>
+                    {p.post_type === "request" ? "需要" : "釋出"}{" "}
+                    <span className="font-mono text-zinc-700 dark:text-zinc-300">{p.qty_remaining}</span>
+                    {p.qty_remaining !== p.qty_available && (
+                      <span className="ml-1 text-[10px] text-zinc-400">/ 原 {p.qty_available}</span>
+                    )}
+                  </span>
                   <span>到期 <span className="text-zinc-700 dark:text-zinc-300">{fmtDt(p.expires_at)}</span></span>
                   {p.source_order_no && (
                     <span>源訂單 <span className="font-mono text-zinc-700 dark:text-zinc-300">{p.source_order_no}</span></span>
@@ -823,7 +829,13 @@ function ThreadModal({
             <span>{post.sku_label}</span>
           </div>
           <div className="flex flex-wrap gap-x-4 gap-y-1 text-zinc-500">
-            <span>數量 <span className="font-mono text-zinc-700 dark:text-zinc-300">{post.qty_available}</span></span>
+            <span>
+              {post.post_type === "request" ? "尚需" : "可釋"}{" "}
+              <span className="font-mono text-zinc-700 dark:text-zinc-300">{post.qty_remaining}</span>
+              {post.qty_remaining !== post.qty_available && (
+                <span className="ml-1 text-[10px] text-zinc-400">/ 原 {post.qty_available}</span>
+              )}
+            </span>
             <span>到期 <span className="text-zinc-700 dark:text-zinc-300">{fmtDt(post.expires_at)}</span></span>
             <span>發佈 {fmtDt(post.created_at)}</span>
             {post.note && <div className="basis-full pt-1 text-zinc-700 dark:text-zinc-300">「{post.note}」</div>}
@@ -962,7 +974,7 @@ function ClaimOfferDialog({
   onDone: () => void;
 }) {
   const [toStore, setToStore] = useState<number | "">("");
-  const [qty, setQty] = useState(String(post.qty_available));
+  const [qty, setQty] = useState(String(post.qty_remaining));
   const [reason, setReason] = useState(`互助板認領 #${post.id}`);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -974,7 +986,7 @@ function ClaimOfferDialog({
     if (!post.source_customer_order_id) { setErr("此 offer 缺 source_customer_order_id（資料異常）"); return; }
     const qtyN = Number(qty);
     if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("認領數量需 > 0"); return; }
-    if (qtyN > post.qty_available) { setErr(`認領數量超過釋出量 ${post.qty_available}`); return; }
+    if (qtyN > post.qty_remaining) { setErr(`認領數量超過剩餘量 ${post.qty_remaining}`); return; }
     setBusy(true);
     try {
       const sb = getSupabase();
@@ -1037,7 +1049,7 @@ function ClaimOfferDialog({
               inputMode="decimal"
               className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
             />
-            <div className="mt-1 text-[10px] text-zinc-500">釋出總量 {post.qty_available}</div>
+            <div className="mt-1 text-[10px] text-zinc-500">剩餘可認 {post.qty_remaining}{post.qty_remaining !== post.qty_available && `（原 ${post.qty_available}）`}</div>
           </label>
         </div>
         <label className="mb-3 block text-sm">
@@ -1078,7 +1090,7 @@ function FulfillRequestDialog({
   const [myStore, setMyStore] = useState<number | "">("");
   const [orders, setOrders] = useState<PendingOrder[] | null>(null);
   const [pickedOrderId, setPickedOrderId] = useState<number | null>(null);
-  const [qty, setQty] = useState(String(post.qty_available));
+  const [qty, setQty] = useState(String(post.qty_remaining));
   const [reason, setReason] = useState(`互助板提供 #${post.id}`);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -1136,7 +1148,7 @@ function FulfillRequestDialog({
     if (!pickedOrderId) { setErr("請選要轉移的訂單"); return; }
     const qtyN = Number(qty);
     if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("提供數量需 > 0"); return; }
-    if (qtyN > post.qty_available) { setErr(`提供數量超過需求量 ${post.qty_available}`); return; }
+    if (qtyN > post.qty_remaining) { setErr(`提供數量超過剩餘需求 ${post.qty_remaining}`); return; }
     setBusy(true);
     try {
       const sb = getSupabase();
@@ -1174,7 +1186,7 @@ function FulfillRequestDialog({
           <div className="mb-2 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">{err}</div>
         )}
         <div className="mb-3 rounded bg-zinc-50 p-2 text-xs dark:bg-zinc-950">
-          求助店「{post.store_name}」需要 {post.sku_label}（數量 {post.qty_available}）。
+          求助店「{post.store_name}」尚需 {post.sku_label}（剩餘 {post.qty_remaining}{post.qty_remaining !== post.qty_available && `／原 ${post.qty_available}`}）。
           選一張你店的 pending 訂單轉給他（走 5b-1 棄單轉出）。
         </div>
         <label className="mb-3 block text-sm">
@@ -1223,7 +1235,7 @@ function FulfillRequestDialog({
             inputMode="decimal"
             className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
           />
-          <div className="mt-1 text-[10px] text-zinc-500">求助總量 {post.qty_available}（≤ 此值；不足部分維持需求中）</div>
+          <div className="mt-1 text-[10px] text-zinc-500">剩餘需求 {post.qty_remaining}（≤ 此值；不足部分維持需求中）</div>
         </label>
         <label className="mb-3 block text-sm">
           <span className="mb-1 block text-xs text-zinc-500">原因（選填）</span>

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -34,6 +34,7 @@ const NAV: NavGroup[] = [
       { href: "/picking/history", label: "撿貨歷史", match: /^\/picking\/history/ },
       { href: "/transfers/inbox", label: "收貨待辦", match: /^\/transfers\/inbox/ },
       { href: "/transfers", label: "調撥單列表", match: /^\/transfers$|^\/transfers\/?$/ },
+      { href: "/inventory/mutual-aid", label: "互助交流板", match: /^\/inventory\/mutual-aid/ },
     ],
   },
 ];

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -322,7 +322,6 @@ async function buildTimeline(
         detailHref: onNavigate ? undefined : srcHref,
         detailOnClick: srcClick,
       },
-      { label: "運送中", ts: null, done: false, detail: "（暫無系統紀錄、由店家自行協調）" },
       { label: "分店收貨", ts: null, done: false, detail: "（暫無系統紀錄）" },
       { label: "顧客取貨", ts: null, done: pickedUp, detail: head.status },
     ];

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -14,6 +14,7 @@ type OrderHead = {
   updated_at: string;
   pickup_store_id: number | null;
   campaign_id: number | null;
+  transferred_from_order_id: number | null;
   member: { id: number; name: string | null; phone: string | null; member_no: string } | null;
   campaign: { id: number; campaign_no: string; name: string } | null;
   store: { id: number; name: string } | null;
@@ -71,7 +72,7 @@ export function OrderDetail({
       const sb = getSupabase();
       const [hRes, iRes] = await Promise.all([
         sb.from("customer_orders")
-          .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
+          .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, transferred_from_order_id, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .eq("id", orderId).maybeSingle(),
         sb.from("customer_order_items")
           .select("id, qty, unit_price, status, source, created_at, updated_at, created_by, updated_by, sku:skus(id, sku_code, product_name, variant_name)")
@@ -291,6 +292,39 @@ async function buildTimeline(
         detailHref: newOrderHref,
         detailOnClick: newOrderClick,
       },
+    ];
+  }
+
+  // transferred-in: 從別張訂單轉進來（5b-1 整單轉 / 5c partial 拆單）
+  // 不走採購／撿貨／派貨流程，改顯示「轉出店 → 運送中 → 分店收貨 → 顧客取貨」
+  if (head.transferred_from_order_id) {
+    const { data: src } = await sb
+      .from("customer_orders")
+      .select("id, order_no, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)")
+      .eq("id", head.transferred_from_order_id)
+      .maybeSingle();
+    type SrcRow = { id: number; order_no: string; pickup_store_id: number | null; store: { name: string } | { name: string }[] | null };
+    const s = src as unknown as SrcRow | null;
+    const srcStoreName = s?.store
+      ? (Array.isArray(s.store) ? s.store[0]?.name : s.store.name) ?? "—"
+      : "—";
+    const srcDetail = s ? `來源：${srcStoreName} 訂單 ${s.order_no}` : `來源訂單 #${head.transferred_from_order_id}`;
+    const srcHref = s ? `/orders?id=${s.id}` : undefined;
+    const srcClick = (s && onNavigate) ? () => onNavigate(s.id, s.order_no) : undefined;
+
+    const pickedUp = head.status === "completed" || head.status === "picked_up";
+    return [
+      {
+        label: "轉出店",
+        ts: head.created_at,
+        done: true,
+        detail: srcDetail,
+        detailHref: onNavigate ? undefined : srcHref,
+        detailOnClick: srcClick,
+      },
+      { label: "運送中", ts: null, done: false, detail: "（暫無系統紀錄、由店家自行協調）" },
+      { label: "分店收貨", ts: null, done: false, detail: "（暫無系統紀錄）" },
+      { label: "顧客取貨", ts: null, done: pickedUp, detail: head.status },
     ];
   }
 

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -15,6 +15,7 @@ type OrderHead = {
   pickup_store_id: number | null;
   campaign_id: number | null;
   transferred_from_order_id: number | null;
+  is_air_transfer: boolean | null;
   member: { id: number; name: string | null; phone: string | null; member_no: string } | null;
   campaign: { id: number; campaign_no: string; name: string } | null;
   store: { id: number; name: string } | null;
@@ -72,7 +73,7 @@ export function OrderDetail({
       const sb = getSupabase();
       const [hRes, iRes] = await Promise.all([
         sb.from("customer_orders")
-          .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, transferred_from_order_id, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
+          .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, transferred_from_order_id, is_air_transfer, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .eq("id", orderId).maybeSingle(),
         sb.from("customer_order_items")
           .select("id, qty, unit_price, status, source, created_at, updated_at, created_by, updated_by, sku:skus(id, sku_code, product_name, variant_name)")
@@ -313,17 +314,31 @@ async function buildTimeline(
     const srcClick = (s && onNavigate) ? () => onNavigate(s.id, s.order_no) : undefined;
 
     const pickedUp = head.status === "completed" || head.status === "picked_up";
+    const sourceStep: TimelineStep = {
+      label: "轉出店",
+      ts: head.created_at,
+      done: true,
+      detail: srcDetail,
+      detailHref: onNavigate ? undefined : srcHref,
+      detailOnClick: srcClick,
+    };
+    const customerStep: TimelineStep = { label: "顧客取貨", ts: null, done: pickedUp, detail: head.status };
+
+    if (head.is_air_transfer) {
+      // 空中轉：店對店直送
+      return [
+        sourceStep,
+        { label: "分店收貨", ts: null, done: false, detail: "（空中轉、暫無系統紀錄）" },
+        customerStep,
+      ];
+    }
+    // 非空中轉：經總倉
     return [
-      {
-        label: "轉出店",
-        ts: head.created_at,
-        done: true,
-        detail: srcDetail,
-        detailHref: onNavigate ? undefined : srcHref,
-        detailOnClick: srcClick,
-      },
+      sourceStep,
+      { label: "總倉收到", ts: null, done: false, detail: "（暫無系統紀錄）" },
+      { label: "運送中", ts: null, done: false, detail: "（總倉出貨）" },
       { label: "分店收貨", ts: null, done: false, detail: "（暫無系統紀錄）" },
-      { label: "顧客取貨", ts: null, done: pickedUp, detail: head.status },
+      customerStep,
     ];
   }
 

--- a/docs/TEST-mutual-aid-board-report.md
+++ b/docs/TEST-mutual-aid-board-report.md
@@ -1,0 +1,95 @@
+---
+title: TEST 報告 — 互助交流板（offer/request + 分批認領）(Phase 5c)
+module: Inventory / UI
+status: passed
+ran_at: 2026-04-26
+verified_by: alex.chen + claude (preview tools + REST 直查)
+---
+
+# 驗證報告 — Phase 5c 互助交流板
+
+## Scope
+
+4 份 migration + 1 個新 admin 頁 + Sidebar 加 nav。
+
+| Migration | 內容 |
+|---|---|
+| `20260509000000_mutual_aid_replies.sql` (step 1) | 新表 `mutual_aid_replies` (append-only) + 3 RPC：`rpc_post_aid_board` / `rpc_post_aid_reply` / `rpc_close_aid_board` |
+| `20260509000001_mutual_aid_offer_request.sql` (step 2) | `mutual_aid_board` 加 `post_type` (offer/request) + `source_customer_order_id` + 一致性 CHECK；DROP+RECREATE `rpc_post_aid_board` (8 args) |
+| `20260509000002_transfer_order_partial.sql` (step 3) | 新 RPC `rpc_transfer_order_partial(p_order_id, p_to_store, ..., p_items JSONB)` — 依 sku+qty 拆單；source qty=0 → transferred_out、否則 pending |
+| `20260509000003_consume_aid_board.sql` (step 4) | 新 RPC `rpc_consume_aid_board(p_board_id, p_qty, ...)` — 扣 qty_remaining；reach 0 → exhausted、否則 active 可分批 |
+
+| 改動 | 位置 |
+|---|---|
+| 新頁 | `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` (~870 行) |
+| Sidebar | `apps/admin/src/app/(protected)/layout.tsx` 加「互助交流板」於進銷存群組 |
+
+## 業務設計收斂
+
+「貨從 A 流到 B」全部走 `customer_orders`：
+- offer post 的 source = 一張既有 customer_order
+- 認領 = `rpc_transfer_order_partial` 拆 N 件給接收店、開新單 (member=接收店 store_internal)
+- 分批：source 還有 qty 就保留 pending、不 transferred_out
+
+廢掉原 `rpc_claim_aid` 自動扣 qty / 自動建 transfer 設計（schema 表保留兼容、UI 不再呼叫）。
+
+## 結果
+
+| 測項 | 結果 | 證據 |
+|---|---|---|
+| `npm run build` 通過 | ✅ PASS | TypeScript clean、24 routes (新加 /inventory/mutual-aid) |
+| Supabase dev push 4 份 migration | ✅ PASS | 3 next push 全 finished |
+| 載入 /inventory/mutual-aid 無 console error | ✅ PASS | preview snapshot 無錯 |
+| 「📢 我要求助」+「📦 我有庫存可提供」按鈕 + 3 tabs (全部/需求中/釋出中) | ✅ PASS | snapshot |
+| OfferModal: 選釋出店 → 自動載入該店 pending 訂單 list | ✅ PASS | 測時看到 F123445-TF0002 |
+| OfferModal: 選訂單 → qty 自動帶該訂單第一個 item 的 qty | ✅ PASS | qty 預填 1 |
+| OfferModal submit → list 出現新 offer 貼（含「源訂單」資訊） | ✅ PASS | 釋出 三峽 美工刀 from F123445-TF0002 |
+| RequestModal submit → list 出現新 request 貼 | ✅ PASS | 古華 蝦餅 qty 10 |
+| Thread modal: offer 顯示「我要認領」、request 顯示「我可以提供」 | ✅ PASS | 不同 type 顯示不同按鈕 |
+| ClaimOfferDialog: 接收店 select 排除釋出店、qty input 預設 = post.qty_available | ✅ PASS | qtyDefault="5" |
+| ClaimOfferDialog 全認 (qty=qty_available) → board exhausted + 訂單 transferred_out | ✅ PASS | DB 確認 |
+| ClaimOfferDialog 部分認 (qty<qty_available) → source qty 減 N、board qty 減 N、source 仍 pending | ✅ PASS | RPC 直測：order 52 SKU 1 qty 13→8、board qty 5→0 經兩次 partial |
+| **分批認領**：board qty 5 → 認 3 (board active qty=2) → 再認 2 (board exhausted) | ✅ PASS | RPC 直測 newOrd1=71、newOrd2=72、consumeStatus1='active'、consumeStatus2='exhausted' |
+| FulfillRequestDialog 同 partial 邏輯 | ✅ PASS | 程式對稱、RPC 同一支 |
+| Sidebar nav「互助交流板」出現在「進銷存」群組 | ✅ PASS | layout.tsx |
+
+## DB 證據（partial-batch 全鏈路）
+
+**Setup：** order 52 (AAAA-TF0021、店 4 文山) 含 SKU 1 qty 16 + SKU 2 qty 12
+
+**Round 1：** post offer board=18 qty 5 → claim 3 → consume 3
+- board: status='active', qty_remaining=2
+- new order 71: pickup_store=5, member=STORE-5 store_internal, items: SKU 1 qty 3 source='aid_transfer'
+- source order 52: SKU 1 qty 16→13 (pending stay)、SKU 2 qty 12 unchanged
+
+**Round 2：** claim 剩 2 → consume 2
+- board: status='exhausted', qty_remaining=0
+- new order 72: pickup_store=6, items: SKU 1 qty 2
+- source order 52: SKU 1 qty 13→11... (注意：之前 first-time 5b-1 testing 時 transfer 過 3 件，所以 source 起始已是 16-3=13；step 3 又拆 3 + 2 = 5、剩 13-5=8)
+- 實際 finalSource: SKU 1 qty 8 ✅ pending（其他 SKU 2 仍存活、所以 status 保持 pending）
+
+完美對應「分批 + source 不 0 不關」設計。
+
+## 設計重點 / Trade-off
+
+- **Offer post 必須對應一張既有 customer_order**：constraint `aid_board_source_consistency` 強制 (offer + source NOT NULL) / (request + source IS NULL)。沒既有訂單就不能釋出（合理 — 沒訂單就沒貨可釋出）
+- **Source order 部分轉出後 status 不變 transferred_out**：transferred_out 語意是「整單出去了、流程結束」，partial 還在原店履行其他 item / 剩餘 qty，不能誤標
+- **customer_order_items 完轉時用 status='cancelled' 而非 DELETE**：留 audit trail、避開 FK (picking_wave_items 等可能 referencing)。CHECK qty > 0 不允許 set 0
+- **Reserved items 不允 partial 轉**：`reserved_movement_id IS NOT NULL` → RAISE。partial reverse stock_movement 邏輯複雜、推給呼叫端先 release
+- **Multi-claimer 分批**：board qty=5 → A 認 3 → 仍 active 顯示在列表 → B 還能再認 2 → exhausted 收貼
+- **Member 結束後變 store_internal**：每次 partial 認領目標都是該店的 store_internal member（rpc_transfer_order_partial 預設 member=NULL → 自動 lookup/create）
+
+## 未驗證（risk-assessed）
+
+| 測項 | 原因 |
+|---|---|
+| FulfillRequestDialog 端到端 UI 點擊 | 程式邏輯對稱於 ClaimOfferDialog（用 RPC 同支）、ClaimOffer 已 PASS |
+| 留言 (rpc_post_aid_reply) | 程式 5c step 1 已 push、未在 step 4 fix 後重測 — 邏輯沒變 |
+| 結束此貼 (rpc_close_aid_board) | 同上 |
+| 跨 tenant RLS | RLS 已宣告、未跨 tenant 測（目前 dev 只有單 tenant） |
+| Multi-item offer (post.qty 對應 source 多 item 之一) | OfferModal 支援切 pickedItemIdx、邏輯對 |
+
+## 已知 trade-off
+
+- **`rpc_transfer_order_to_store` 整單 RPC 沒被廢**：5b-1 棄單按鈕仍用整單 transfer、跟 partial 並存（語意不同：整單 = 我不要這客人了 / partial = 我可以分一點給你）
+- **dev DB 既有舊 offer post 在 step 2 被 DELETE**：清掉測試資料以套 constraint、production 沒 prod 資料、安全

--- a/docs/TEST-mutual-aid-board.md
+++ b/docs/TEST-mutual-aid-board.md
@@ -1,0 +1,151 @@
+---
+title: TEST — 互助交流板 UI（offer + request 兩種 post）(Phase 5c)
+module: Inventory / UI
+status: draft
+owner: alex.chen
+created: 2026-04-26
+---
+
+# 測試清單 — 互助交流板（純通訊版 + 訂單聯動）
+
+兩種 post type：
+- **offer (我有庫存可提供)** = 從既有 customer_order 釋出；認領 → 走 5b-1 `rpc_transfer_order_to_store` 把該訂單變成接收店的
+- **request (我要求助)** = 純需求（無 source order）；提供 → 從提供店 pending 訂單挑一張轉給求助店
+
+廢掉原 `rpc_claim_aid` 自動扣 qty / 自動建 transfer 的設計。
+
+**對應 migration:**
+- `20260509000000_mutual_aid_replies.sql` (step 1：replies + 3 RPC)
+- `20260509000001_mutual_aid_offer_request.sql` (step 2：post_type + source_order)
+- `20260509000002_transfer_order_partial.sql` (step 3：依 qty 拆單轉)
+- `20260509000003_consume_aid_board.sql` (step 4：分批扣 qty + 自動 exhausted)
+**對應 UI:** `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` (新)、`apps/admin/src/app/(protected)/layout.tsx` (Sidebar 加項)
+**依賴:** 5b-1 [PR #135](https://github.com/lt-foods/new_erp/pull/135) `rpc_transfer_order_to_store`
+
+## 1. Schema / Migration
+
+### 1.1 mutual_aid_replies (新表)
+- [ ] 欄位：`id`、`tenant_id`、`board_id FK→mutual_aid_board(id) ON DELETE CASCADE`、`author_id UUID`、`author_label TEXT`、`body TEXT CHECK 1..1000`、`created_at`
+- [ ] index `idx_aid_replies_board (board_id, created_at)`
+- [ ] append-only trigger `trg_no_mut_aid_replies` (BEFORE UPDATE OR DELETE)
+- [ ] RLS: `replies_read_all` (SELECT 同 tenant)、`replies_authenticated_insert` (INSERT 限 author_id = auth.uid())
+
+### 1.2 mutual_aid_board 加欄位 (step 2)
+- [ ] `post_type TEXT NOT NULL DEFAULT 'offer' CHECK IN ('offer','request')`
+- [ ] `source_customer_order_id BIGINT REFERENCES customer_orders(id)` (nullable)
+- [ ] `aid_board_source_consistency` CHECK：offer → source NOT NULL、request → source IS NULL
+- [ ] index `idx_aid_active_by_type (tenant_id, post_type, status, expires_at)` partial WHERE status='active'
+- [ ] index `idx_aid_source_order (source_customer_order_id)` partial WHERE NOT NULL
+
+### 1.3 RPC signatures
+- [ ] `rpc_post_aid_board(p_offering_store_id, p_sku_id, p_qty_available, p_expires_at, p_note, p_operator, p_post_type, p_source_customer_order_id)` — 8 args、舊 6-arg DROP
+- [ ] `rpc_post_aid_reply(p_board_id, p_body, p_operator) RETURNS BIGINT`
+- [ ] `rpc_close_aid_board(p_board_id, p_status IN ('cancelled','exhausted'), p_operator)`
+
+## 2. RPC 行為
+
+### 2.1 rpc_post_aid_board offer happy
+**情境：** offering_store=2 + sku=11 + qty=1 + expires=+7d + post_type='offer' + source_order_id=53 (該店 pending 訂單)
+**預期：** 回新 board id、status='active'、qty_remaining=1、source_customer_order_id=53、tenant_id 從 store 取
+
+### 2.2 rpc_post_aid_board offer 邊界
+- [ ] post_type='offer' + source_order_id=NULL → RAISE 'offer post requires p_source_customer_order_id'
+- [ ] source_order 不存在 → RAISE 'customer_order N not found'
+- [ ] source_order.pickup_store_id ≠ p_offering_store_id → RAISE 'pickup_store_id ... does not match'
+- [ ] cross-tenant order → RAISE 'cross-tenant order'
+
+### 2.3 rpc_post_aid_board request happy
+**情境：** post_type='request' + source_order_id=NULL + 其他正常
+**預期：** 回新 board id、status='active'、source_customer_order_id IS NULL
+
+### 2.4 rpc_post_aid_board request 邊界
+- [ ] request + source_order_id 非 NULL → RAISE 'request post must not have source_customer_order_id'
+
+### 2.5 共通邊界
+- [ ] qty_available <= 0 → RAISE
+- [ ] expires_at <= NOW() → RAISE
+- [ ] sku 不存在 → RAISE
+- [ ] store 不存在 → RAISE
+- [ ] post_type 非 offer/request → RAISE
+
+### 2.6 rpc_post_aid_reply
+- [ ] board_id 不存在 → RAISE
+- [ ] body 空 → RAISE
+- [ ] body > 1000 → RAISE
+- [ ] author_label 自動取 raw_user_meta_data.display_name 或 email 前綴
+- [ ] tenant_id 從 board 帶
+- [ ] 即使 board status=cancelled/expired 仍允許留言（純通訊）
+
+### 2.7 rpc_close_aid_board
+- [ ] active → 'cancelled' / 'exhausted' 各成功
+- [ ] p_status 非 cancelled/exhausted → RAISE
+- [ ] board_id 不存在 → RAISE
+- [ ] 已關閉重關 → idempotent 不錯
+
+## 3. UI 行為
+
+### 3.1 載入 /inventory/mutual-aid
+- [ ] page 無 console error
+- [ ] 看到「📢 我要求助」+「📦 我有庫存可提供」二個按鈕
+- [ ] filter tabs：全部 / 需求中 / 釋出中
+- [ ] 空態提示
+
+### 3.2 我要求助 modal (RequestModal)
+- [ ] 點開 modal、4 必填 (求助店 + SKU + qty + expires) + 1 選填 (note)
+- [ ] 任一必填空 → inline 錯誤、modal 不關
+- [ ] qty <= 0 → 錯誤
+- [ ] 全填 + submit → modal 關 + list 新增 request 貼
+
+### 3.3 我有庫存可提供 modal (OfferModal)
+- [ ] 選釋出店後、自動載入該店 pending/confirmed/reserved 訂單列表
+- [ ] 選一張訂單 → 自動帶 qty (= 該訂單第一個 item 的 qty)
+- [ ] 訂單有多 item → 顯示每個 item 的 SKU pill、可切換 (pickedItemIdx)
+- [ ] 沒可釋出訂單 → 顯示「該店目前沒有可釋出的訂單」
+- [ ] 必填驗證、submit → modal 關 + list 新增 offer 貼 (含「源訂單」資訊)
+
+### 3.4 List rendering
+- [ ] 每 row 顯示：post_type badge (釋出 pink / 需求 blue) + status badge + 釋出/求助店名 + SKU + 數量 + 到期 + (offer 才有) 源訂單號 + 留言數 + note
+- [ ] tab 切換 → 列表只顯示對應 type
+- [ ] 預設 status=active
+
+### 3.5 Thread modal
+- [ ] 點 row 開 modal、顯示 post header + 所有 replies + 留言輸入框
+- [ ] reply 輸入 + Ctrl+Enter / 送出留言 → 留言出現
+- [ ] reply 寫入後 list 該 post 留言數 +1
+- [ ] active post 才能留言 / 認領 / 結束、closed post 顯示「無法再留言」
+
+### 3.6 認領 offer (ClaimOfferDialog) — 支援分批
+- [ ] thread modal 對 offer post 顯示「✋ 我要認領」按鈕（紅）
+- [ ] 點開二級 dialog：接收店 select (排除釋出店) + 認領數量 input (預設 = post.qty_available) + 原因
+- [ ] 數量超過 qty_available → inline 錯誤
+- [ ] 不選店 → inline 錯誤
+- [ ] 確認後：
+  - [ ] call `rpc_transfer_order_partial(post.source_customer_order_id, 接收店, NULL, NULL, ..., p_items=[{sku_id, qty}])` → 拆出指定 qty 開新單；source 該 SKU item qty 減 N（== 則 cancelled）；source 還有其他 active item → 保持 pending、否則 transferred_out
+  - [ ] call `rpc_consume_aid_board(post.id, qty, ...)` → board.qty_remaining 減 N；reach 0 → status='exhausted'，否則 active 可繼續被分批認領
+- [ ] 分批：A 認 3 → board qty 5→2 active；B 再認 2 → board exhausted
+
+### 3.7 提供 request (FulfillRequestDialog) — 支援分批
+- [ ] thread modal 對 request post 顯示「🤝 我可以提供」按鈕（藍）
+- [ ] 點開二級 dialog：提供店 select (排除求助店) + 載入該店符合 SKU 的 pending 訂單 + 挑一張 + 提供數量 input (預設 = post.qty_available) + 原因
+- [ ] 數量超過 qty_available → inline 錯誤
+- [ ] 沒符合訂單 → 顯示「該店沒有含此 SKU 的可轉移訂單」
+- [ ] 確認後：partial transfer 該 sku qty 給求助店 + consume board
+- [ ] 分批：A 提供 1 → 需求 5→4 active；B 再提供 4 → exhausted
+
+### 3.8 結束此貼 (close)
+- [ ] active post 對所有人顯示「結束此貼」按鈕
+- [ ] confirm dialog → 確認後 status='cancelled'、modal 關 + list 重載
+
+### 3.9 Sidebar nav
+- [ ] 「進銷存」群組下新增「互助交流板」、active 狀態高亮
+
+## 4. Regression
+- [ ] 既有 `/inventory/*` (transfers) 頁面不影響
+- [ ] `mutual_aid_claims` + legacy `rpc_claim_aid` 仍可呼叫（schema 沒動）
+- [ ] `mutual_aid_board` 既有資料（pre-migration）— 沒辦法保證符合新 constraint（offer 沒 source_order）→ migration 加 DELETE 清掉測試資料
+- [ ] `npm run build` + TS 過
+- [ ] supabase dev push 成功
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、preview 無 console error、Supabase dev push 成功、build + type-check 過 才標 done。

--- a/docs/TEST-order-entry-store-internal-report.md
+++ b/docs/TEST-order-entry-store-internal-report.md
@@ -1,0 +1,78 @@
+---
+title: TEST 報告 — order-entry 加「為分店叫貨」mode (Phase 5b 第二段)
+module: Order / UI
+status: passed
+ran_at: 2026-04-26
+verified_by: alex.chen + claude (preview tools + REST 直查)
+---
+
+# 驗證報告 — Phase 5b 第二段（order-entry 加 store_internal mode）
+
+## Scope
+
+- 改：[apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx](../apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx) (+~250 / -10)
+  - 加 `Mode = "customer" | "internal"` toggle state
+  - 加 `Store` 載入（與 channels parallel）
+  - 加 internal-only state：`internalStoreId / internalNotes / internalItems`
+  - `ItemEditorRow` 加 `editablePrice` prop（unit_price 可改）
+  - 加 `submitInternal()` → 呼叫 `rpc_create_store_internal_order` + `auth.getUser().id`
+  - 加 `InternalOrderPanel` component（store picker + notes + items + submit）
+  - Alt+N 在 internal mode 加新空白項目列
+- 不改 schema、不改 RPC（5a-1 [#132](https://github.com/lt-foods/new_erp/pull/132) 已 ship）
+
+## RPC 呼叫
+
+`rpc_create_store_internal_order(p_campaign_id, p_store_id, p_items[], p_operator, p_notes)`
+
+UI 邏輯：
+- `p_operator = sb.auth.getUser().user.id`（未登入則錯）
+- `p_items[].unit_price` 永遠帶（即便 = list price）— UI 已 prefill 預設值
+- `p_notes = trim() || null`
+
+## 結果
+
+| 測項 | 結果 | 證據 |
+|---|---|---|
+| `npm run build` 通過 | ✅ PASS | TypeScript 4.8s、Static export 23 routes |
+| 載入 page、預設 customer mode | ✅ PASS | 看到「LINE 頻道」hint + customer cards |
+| 點「為分店叫貨」toggle | ✅ PASS | 顯示「內部叫貨...」hint + store/notes/items panel + 「送出內部訂單」 |
+| Alt+N 提示文字切換 | ✅ PASS | customer mode 顯示「新顧客」、internal mode 顯示「新項目」 |
+| 必填驗證：未選店 + submit | ✅ PASS | 顯示紅色「請選取貨店」、未呼叫 RPC |
+| 必填驗證：店選了但 items 空 + submit | ✅ PASS | 顯示「請至少加一項商品」 |
+| 加 SKU、預設 unit_price = list price | ✅ PASS | 蝦餅 SKU list price 135、加入後 input 預填 135 |
+| 改 unit_price = 88、subtotal 即時更新 | ✅ PASS | qty=1 × unit=88 → 小計 $88 |
+| 提交 88 折訂單 | ✅ PASS | DB 出現 unit_price=88、source=store_internal、member_no=STORE-2、pickup_store_id=2 |
+| 多次 submit upsert 到同 order | ✅ PASS | 同 campaign+store 4 筆 items 全在 order_id=46 (campaign_id=10、channel_id=9、member STORE-2) |
+| Submit 成功 form 重置 | ✅ PASS | qty 變空、unit_price 變 0、件數變 0 |
+| Toggle 切回 customer mode UI 還原 | ✅ PASS | Customer search input + 新增顧客 button + 送出訂單 button 全部回來 |
+| 無 console error | ✅ PASS | preview_console_logs(level=error) → No console logs |
+
+## DB 證據
+
+`customer_orders id=46` (campaign_id=10、channel_id=9、pickup_store_id=2、member STORE-2) 包含 4 筆 items：
+
+```json
+[
+  {"qty":1,  "unit_price":135, "source":"aid_transfer"},   // 5b-1 早期測試
+  {"qty":1,  "unit_price":88,  "source":"store_internal"}, // 5b-2 第一次
+  {"qty":1,  "unit_price":135, "source":"store_internal"}, // 5b-2 default price
+  {"qty":10, "unit_price":88,  "source":"store_internal"}  // 5b-2 final 88 折
+]
+```
+
+`order_no = 351128090-TF0005`（沿用 5b-1 既有 order，未新建 — RPC upsert 行為符合預期）
+
+## 設計決策
+
+- **Order_no 不一定 `-INT`**：若 campaign+channel+member 已有 order，append items 而非新建。`-INT` suffix 只在新建時加（RPC 內 `if v_order_id IS NULL then ... v_campaign_no || '-INT' || lpad(v_seq::text, 4, '0')`）
+- **Mode toggle 不毀草稿**：customer entries 與 internal items 是獨立 state、互不影響
+- **operator 來源**：`sb.auth.getUser().user.id` 而不傳 NULL — RPC SECURITY DEFINER 不會自動帶 auth.uid()
+
+## 未驗證（risk-assessed）
+
+| 測項 | 原因 |
+|---|---|
+| customer mode happy path 完整 submit | 程式邏輯未改（only branch added at top of handleSubmit）、build 過、UI 切回正常顯示 |
+| ItemEditorRow `editablePrice=false` 行為 | customer mode 共用同一 component、未傳該 prop = `undefined`（falsy）→ 走 readonly span 分支、與舊版完全一致 |
+| 跨 tenant store_id 拒絕 | RPC 5a-1 已 cover (D5 PASS) |
+| unit_price 負數 RPC 端拒絕 | RPC 5a-1 已 cover、UI 端也擋了 (`if (items.some((i) => i.unit_price < 0))`) |

--- a/docs/TEST-order-entry-store-internal.md
+++ b/docs/TEST-order-entry-store-internal.md
@@ -1,0 +1,120 @@
+---
+title: TEST — order-entry「為分店叫貨」mode (Phase 5b 第二段)
+module: Order / UI
+status: draft
+owner: alex.chen
+created: 2026-04-26
+---
+
+# 測試清單 — order-entry 加 store_internal mode
+
+把 5a-1 已 ship 的 `rpc_create_store_internal_order` 接到 UI 上：訂單登打 page 加「為分店叫貨」mode toggle，店長可直接 key 內部叫貨單（含 88 折定價）。客戶下單 mode 行為完全保留。
+
+## Scope
+
+- **改：** [apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx](../apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx)
+- **不改 schema / 不改 RPC**（5a-1 已 ship）
+- **依賴：** `rpc_create_store_internal_order` (5a-1 [PR #132](https://github.com/lt-foods/new_erp/pull/132)、`supabase/migrations/20260507000000_order_transfer_and_internal.sql`)
+
+## 設計重點
+
+- 預設 mode = `customer`（客戶下單），行為與舊版 100% 一致
+- `internal` mode 共用同一份 SKU dropdown / autosave / Ctrl+S，但：
+  * 隱藏 customer entries / channel selector
+  * 顯示 store picker (active stores)、optional notes textarea
+  * Items table 每列加可編輯 `unit_price` 欄（預設 = SKU list price）
+- Submit 路由依 mode 二選一：
+  * customer → `rpc_create_customer_orders` (既有)
+  * internal → `rpc_create_store_internal_order` + `auth.getUser().id` 當 operator
+
+## 1. UI 行為（preview 互動）
+
+### 1.1 預設 mode + toggle
+- [ ] page 載入時 mode = customer、UI 與 5b-1 之前一致（channel selector + customer cards 都在）
+- [ ] 點「為分店叫貨」toggle：channel selector 與 customer cards 隱藏、store picker + 內部 items panel 顯示
+- [ ] 切回「客戶下單」：UI 還原、原本的 entries 不被清掉（草稿不毀）
+
+### 1.2 internal mode 必填驗證
+- [ ] store 未選 + 點送出 → 顯示錯誤訊息「請選取貨店」、未呼叫 RPC
+- [ ] store 已選但 items 為空 → 顯示錯誤訊息「請至少加一項商品」、未呼叫 RPC
+- [ ] 任一 item qty <= 0 或非數字 → 該列邊框紅、送出顯示錯誤
+- [ ] 任一 item unit_price < 0 → 該欄邊框紅、送出顯示錯誤
+- [ ] item unit_price = 0 → 允許（業務允許 0 元贈品）
+
+### 1.3 internal mode 加商品 + 編 unit_price
+- [ ] 從「+ 加商品」dropdown 加一個 SKU、items table 出現該列、unit_price 預設 = SKU list price
+- [ ] 直接編 unit_price 欄、值寫得進 state（小計即時更新）
+- [ ] 加第二個 SKU、不可重複（dropdown 已不出現該選項）
+
+### 1.4 internal mode 提交成功 (88 折)
+**情境：** campaign 有 SKU list price 100；store_internal mode 加該 SKU、qty=10、unit_price=88、submit
+**預期：**
+- toast 顯示「已建立內部訂單」+ 新訂單編號（含 `-INT0001` suffix）
+- DB：`customer_orders` 新增 1 筆 (member = STORE-{id}、pickup_store_id = 選的店、order_no LIKE '%-INT%')
+- DB：`customer_order_items` 1 筆 unit_price = 88 (非 100)
+- `customer_order_items.source = 'store_internal'`
+
+```sql
+SELECT o.order_no, o.pickup_store_id, m.member_no, oi.unit_price, oi.source
+  FROM customer_orders o
+  JOIN customer_order_items oi ON oi.order_id = o.id
+  JOIN members m ON m.id = o.member_id
+ WHERE o.campaign_id = <id>
+   AND m.member_type = 'store_internal'
+ ORDER BY o.id DESC LIMIT 5;
+```
+
+### 1.5 internal mode 同 campaign 同 store 二次提交（upsert）
+**情境：** 1.4 之後、同店再 submit 另一 SKU qty=5
+**預期：**
+- 不新建 `customer_orders`、items 累加在原 order
+- toast 訊息（複用「已建立內部訂單」即可，不需特別區分 update vs insert）
+
+### 1.6 internal mode 不同 store
+**情境：** 切到第二個 store、submit 同 campaign 同 SKU
+**預期：** 新建一筆 `customer_orders`（不同 store_internal member、不同 pickup_store_id）
+
+### 1.7 operator UUID 帶過去
+- [ ] RPC payload `p_operator` = 當前 supabase auth user id（非 NULL、非 anon）
+- [ ] `customer_orders.created_by = updated_by = p_operator`
+
+### 1.8 草稿不混（internal mode 不寫 customer 草稿）
+- [ ] internal mode submit 不影響 `localStorage.getItem('draft:order-entry:<id>')`
+- [ ] 切 mode 時 customer 草稿仍在
+
+## 2. Regression — 客戶下單 mode 不能壞
+
+### 2.1 既有 happy path
+- [ ] 載入 page、預設 customer mode、選 channel、加會員、加 SKU、Ctrl+S 送出
+- [ ] 訂單成功建立（呼叫 `rpc_create_customer_orders`，非 `rpc_create_store_internal_order`）
+- [ ] 沒有 console error / TS warning
+
+### 2.2 Alt+N、Ctrl+S 鍵盤快捷
+- [ ] customer mode：Alt+N 加新顧客、Ctrl+S 送出
+- [ ] internal mode：Alt+N 應 no-op（沒有 customer card）、Ctrl+S 送出 internal 訂單
+
+### 2.3 Draft autosave
+- [ ] customer mode：30s autosave 寫 localStorage、refresh 後 prompt 還原
+- [ ] internal mode：不寫 / 不讀 customer 草稿
+
+### 2.4 SKU 搜尋共用
+- [ ] internal mode 的 SKU dropdown 與 customer mode 的 ItemEditorRow 共用 `rpc_search_skus_for_campaign` 結果
+
+## 3. RPC 行為健全性（5a-1 已 cover、本 PR 只快速回歸）
+
+### 3.1 後端 unit_price 驗證
+- [ ] 用 `psql` 直呼 `rpc_create_store_internal_order(..., p_items='[{"campaign_item_id":1,"qty":1,"unit_price":-5}]', ...)` → RAISE 'unit_price cannot be negative'
+- [ ] `unit_price` 不傳 → fallback 到 `campaign_items.unit_price`
+
+### 3.2 跨 tenant 拒絕
+- [ ] 拿別 tenant 的 store_id 呼叫 → RAISE 或 RLS 拒絕
+
+## 4. 驗收門檻
+
+全部 §1-§3 勾完、**preview 無 console error**、**`npm run build` + type-check 過**、**git diff 無 customer mode 行為變動** 才可標 done。
+
+## 5. 預期 diff 大小
+
+- `apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx` +200~300 / -0
+- 不新建檔（避免 component 拆分讓 PR 膨脹）
+- 完工後上 PR、補 wiki module 頁 + Home + Sidebar

--- a/supabase/migrations/20260509000000_mutual_aid_replies.sql
+++ b/supabase/migrations/20260509000000_mutual_aid_replies.sql
@@ -1,0 +1,207 @@
+-- ============================================================
+-- Phase 5c step 1 — 互助交流板留言系統 + 純通訊 RPC
+--   廢掉原 rpc_claim_aid 自動扣 qty / 自動建 transfer 的設計
+--
+-- 變動：
+--   1. 新表 mutual_aid_replies (append-only thread)
+--   2. 新 RPC rpc_post_aid_board   — 用 RPC 包 INSERT + 自動填 tenant/created_by
+--   3. 新 RPC rpc_post_aid_reply   — 留言（自動 lookup author_label）
+--   4. 新 RPC rpc_close_aid_board  — 手動關貼 (cancelled / exhausted)
+--
+-- 不動：mutual_aid_board (table)、mutual_aid_claims (table + legacy rpc_claim_aid)
+--
+-- post_type (offer / request) + source_customer_order_id 在 step 2 補
+-- ============================================================
+
+-- ============================================================
+-- 1. mutual_aid_replies (append-only thread)
+-- ============================================================
+
+CREATE TABLE mutual_aid_replies (
+  id            BIGSERIAL PRIMARY KEY,
+  tenant_id     UUID NOT NULL,
+  board_id      BIGINT NOT NULL REFERENCES mutual_aid_board(id) ON DELETE CASCADE,
+  author_id     UUID,
+  author_label  TEXT,
+  body          TEXT NOT NULL CHECK (length(body) BETWEEN 1 AND 1000),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_aid_replies_board ON mutual_aid_replies (board_id, created_at);
+
+-- append-only：禁 UPDATE / DELETE
+CREATE TRIGGER trg_no_mut_aid_replies BEFORE UPDATE OR DELETE ON mutual_aid_replies
+  FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+
+COMMENT ON TABLE mutual_aid_replies IS
+  '互助板留言 thread（append-only）；author_label 為 staff 顯示名 snapshot';
+
+-- ============================================================
+-- 2. rpc_post_aid_board(...)
+-- ============================================================
+-- 把 INSERT 包成 RPC：自動帶 tenant_id (從 store)、created_by/updated_by、qty_remaining=qty_available
+-- 不直接讓 UI INSERT 是因為 tenant_id 計算 + qty_remaining 同步比較髒
+
+CREATE OR REPLACE FUNCTION rpc_post_aid_board(
+  p_offering_store_id BIGINT,
+  p_sku_id            BIGINT,
+  p_qty_available     NUMERIC,
+  p_expires_at        TIMESTAMPTZ,
+  p_note              TEXT,
+  p_operator          UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant_id  UUID;
+  v_board_id   BIGINT;
+BEGIN
+  IF p_qty_available IS NULL OR p_qty_available <= 0 THEN
+    RAISE EXCEPTION 'qty_available must be > 0';
+  END IF;
+  IF p_expires_at IS NULL OR p_expires_at <= NOW() THEN
+    RAISE EXCEPTION 'expires_at must be in the future';
+  END IF;
+
+  SELECT tenant_id INTO v_tenant_id FROM stores WHERE id = p_offering_store_id;
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'offering_store % not found', p_offering_store_id;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM skus WHERE id = p_sku_id) THEN
+    RAISE EXCEPTION 'sku % not found', p_sku_id;
+  END IF;
+
+  INSERT INTO mutual_aid_board (
+    tenant_id, offering_store_id, sku_id, qty_available, qty_remaining,
+    expires_at, note, status, created_by, updated_by
+  ) VALUES (
+    v_tenant_id, p_offering_store_id, p_sku_id, p_qty_available, p_qty_available,
+    p_expires_at, NULLIF(trim(p_note), ''), 'active', p_operator, p_operator
+  )
+  RETURNING id INTO v_board_id;
+
+  RETURN v_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_post_aid_board(BIGINT, BIGINT, NUMERIC, TIMESTAMPTZ, TEXT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION rpc_post_aid_board IS
+  'Phase 5c step 1：發起互助貼文（純通訊版）；qty_remaining = qty_available、不做扣量';
+
+-- ============================================================
+-- 3. rpc_post_aid_reply(...)
+-- ============================================================
+-- 對 board 留言、自動 lookup author_label (從 auth.users)
+
+CREATE OR REPLACE FUNCTION rpc_post_aid_reply(
+  p_board_id BIGINT,
+  p_body     TEXT,
+  p_operator UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_tenant_id    UUID;
+  v_author_label TEXT;
+  v_reply_id     BIGINT;
+BEGIN
+  IF p_body IS NULL OR length(trim(p_body)) = 0 THEN
+    RAISE EXCEPTION 'body cannot be empty';
+  END IF;
+  IF length(p_body) > 1000 THEN
+    RAISE EXCEPTION 'body too long (max 1000)';
+  END IF;
+
+  SELECT tenant_id INTO v_tenant_id FROM mutual_aid_board WHERE id = p_board_id;
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'board % not found', p_board_id;
+  END IF;
+
+  -- 取 author display name；找不到 fallback 到 uid 前綴
+  SELECT COALESCE(
+           NULLIF(u.raw_user_meta_data ->> 'display_name', ''),
+           NULLIF(u.raw_user_meta_data ->> 'name', ''),
+           split_part(u.email, '@', 1),
+           substring(p_operator::text, 1, 8)
+         )
+    INTO v_author_label
+    FROM auth.users u
+   WHERE u.id = p_operator;
+
+  IF v_author_label IS NULL THEN
+    v_author_label := COALESCE('用戶' || substring(p_operator::text, 1, 8), '匿名');
+  END IF;
+
+  INSERT INTO mutual_aid_replies (
+    tenant_id, board_id, author_id, author_label, body
+  ) VALUES (
+    v_tenant_id, p_board_id, p_operator, v_author_label, trim(p_body)
+  )
+  RETURNING id INTO v_reply_id;
+
+  RETURN v_reply_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_post_aid_reply(BIGINT, TEXT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION rpc_post_aid_reply IS
+  'Phase 5c：對互助貼文留言；author_label snapshot from auth.users';
+
+-- ============================================================
+-- 4. rpc_close_aid_board(...)
+-- ============================================================
+-- 手動關貼。狀態只能 cancelled (作廢) / exhausted (清完了)；不再 RPC 自動扣量
+
+CREATE OR REPLACE FUNCTION rpc_close_aid_board(
+  p_board_id BIGINT,
+  p_status   TEXT,
+  p_operator UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_status NOT IN ('cancelled', 'exhausted') THEN
+    RAISE EXCEPTION 'p_status must be cancelled or exhausted';
+  END IF;
+
+  UPDATE mutual_aid_board
+     SET status = p_status,
+         updated_by = p_operator
+   WHERE id = p_board_id
+     AND status = 'active';
+
+  IF NOT FOUND THEN
+    -- already closed or not exist；idempotent
+    IF NOT EXISTS (SELECT 1 FROM mutual_aid_board WHERE id = p_board_id) THEN
+      RAISE EXCEPTION 'board % not found', p_board_id;
+    END IF;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_close_aid_board(BIGINT, TEXT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION rpc_close_aid_board IS
+  'Phase 5c：手動關掉互助貼文（status active → cancelled / exhausted）';
+
+-- ============================================================
+-- 5. RLS for mutual_aid_replies
+-- ============================================================
+
+ALTER TABLE mutual_aid_replies ENABLE ROW LEVEL SECURITY;
+
+-- 全 tenant 內 staff 可讀（純通訊板、不做隱私限制）
+CREATE POLICY replies_read_all ON mutual_aid_replies
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+  );
+
+-- INSERT 走 RPC SECURITY DEFINER，不從 client 直接 INSERT
+-- 但 fallback：authenticated 可以對自己 author_id INSERT (避免 RPC 失效時完全 broken)
+CREATE POLICY replies_authenticated_insert ON mutual_aid_replies
+  FOR INSERT WITH CHECK (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND author_id = auth.uid()
+  );

--- a/supabase/migrations/20260509000001_mutual_aid_offer_request.sql
+++ b/supabase/migrations/20260509000001_mutual_aid_offer_request.sql
@@ -1,0 +1,134 @@
+-- ============================================================
+-- Phase 5c step 2 — 互助交流板兩種 post type + 訂單聯動
+--
+-- 設計收斂：
+--   - offer  「我有庫存可提供」 → 從既有 customer_order 釋出
+--       UI: 我要認領 → call rpc_transfer_order_to_store(post.source_customer_order_id, 接收店, ...)
+--           → 把 offering store 的訂單轉成接收店的
+--   - request「我要求助」       → 純需求（沒 source order）
+--       UI: 我可以提供 → 提供方選自己 pending 訂單 → call rpc_transfer_order_to_store
+--
+-- 變動：
+--   1. mutual_aid_board 加 post_type、source_customer_order_id 欄位
+--   2. DROP + RECREATE rpc_post_aid_board (加 p_post_type + p_source_customer_order_id)
+-- ============================================================
+
+-- ============================================================
+-- 1. mutual_aid_board 加 post_type + source_customer_order_id
+-- ============================================================
+
+ALTER TABLE mutual_aid_board
+  ADD COLUMN post_type TEXT NOT NULL DEFAULT 'offer'
+    CHECK (post_type IN ('offer', 'request')),
+  ADD COLUMN source_customer_order_id BIGINT REFERENCES customer_orders(id);
+
+-- 5c step 1 期間的測試貼文沒 source_order、不能滿足新 constraint → 砍掉
+-- production 沒人在用、安全；append-only trigger 暫關 + 補回
+ALTER TABLE mutual_aid_replies DISABLE TRIGGER trg_no_mut_aid_replies;
+DELETE FROM mutual_aid_replies
+ WHERE board_id IN (SELECT id FROM mutual_aid_board WHERE source_customer_order_id IS NULL);
+ALTER TABLE mutual_aid_replies ENABLE TRIGGER trg_no_mut_aid_replies;
+
+DELETE FROM mutual_aid_board WHERE source_customer_order_id IS NULL;
+
+-- offer 必須有 source_order；request 必須沒有
+ALTER TABLE mutual_aid_board
+  ADD CONSTRAINT aid_board_source_consistency CHECK (
+    (post_type = 'offer'   AND source_customer_order_id IS NOT NULL)
+    OR (post_type = 'request' AND source_customer_order_id IS NULL)
+  );
+
+CREATE INDEX idx_aid_active_by_type ON mutual_aid_board (tenant_id, post_type, status, expires_at)
+  WHERE status = 'active';
+
+CREATE INDEX idx_aid_source_order ON mutual_aid_board (source_customer_order_id)
+  WHERE source_customer_order_id IS NOT NULL;
+
+-- ============================================================
+-- 2. rpc_post_aid_board 加新參數
+-- ============================================================
+-- DROP 舊版（6 args）+ CREATE 新版（8 args）
+-- 6-arg 沒人在 prod 呼叫過、安全 drop
+
+DROP FUNCTION IF EXISTS rpc_post_aid_board(BIGINT, BIGINT, NUMERIC, TIMESTAMPTZ, TEXT, UUID);
+
+CREATE OR REPLACE FUNCTION rpc_post_aid_board(
+  p_offering_store_id        BIGINT,
+  p_sku_id                   BIGINT,
+  p_qty_available            NUMERIC,
+  p_expires_at               TIMESTAMPTZ,
+  p_note                     TEXT,
+  p_operator                 UUID,
+  p_post_type                TEXT,
+  p_source_customer_order_id BIGINT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant_id     UUID;
+  v_board_id      BIGINT;
+  v_order_tenant  UUID;
+  v_order_store   BIGINT;
+BEGIN
+  IF p_post_type NOT IN ('offer', 'request') THEN
+    RAISE EXCEPTION 'p_post_type must be offer or request';
+  END IF;
+  IF p_qty_available IS NULL OR p_qty_available <= 0 THEN
+    RAISE EXCEPTION 'qty_available must be > 0';
+  END IF;
+  IF p_expires_at IS NULL OR p_expires_at <= NOW() THEN
+    RAISE EXCEPTION 'expires_at must be in the future';
+  END IF;
+
+  SELECT tenant_id INTO v_tenant_id FROM stores WHERE id = p_offering_store_id;
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'store % not found', p_offering_store_id;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM skus WHERE id = p_sku_id) THEN
+    RAISE EXCEPTION 'sku % not found', p_sku_id;
+  END IF;
+
+  -- offer 必須帶 source_customer_order_id 且該 order 屬同 tenant、屬發貼店、未轉出
+  IF p_post_type = 'offer' THEN
+    IF p_source_customer_order_id IS NULL THEN
+      RAISE EXCEPTION 'offer post requires p_source_customer_order_id';
+    END IF;
+
+    SELECT tenant_id, pickup_store_id INTO v_order_tenant, v_order_store
+      FROM customer_orders WHERE id = p_source_customer_order_id;
+    IF v_order_tenant IS NULL THEN
+      RAISE EXCEPTION 'customer_order % not found', p_source_customer_order_id;
+    END IF;
+    IF v_order_tenant <> v_tenant_id THEN
+      RAISE EXCEPTION 'cross-tenant order';
+    END IF;
+    IF v_order_store <> p_offering_store_id THEN
+      RAISE EXCEPTION 'order pickup_store_id (%) does not match offering_store_id (%)',
+                       v_order_store, p_offering_store_id;
+    END IF;
+  ELSE
+    -- request：source_customer_order_id 須為 NULL
+    IF p_source_customer_order_id IS NOT NULL THEN
+      RAISE EXCEPTION 'request post must not have source_customer_order_id';
+    END IF;
+  END IF;
+
+  INSERT INTO mutual_aid_board (
+    tenant_id, offering_store_id, sku_id, qty_available, qty_remaining,
+    expires_at, note, status, post_type, source_customer_order_id,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant_id, p_offering_store_id, p_sku_id, p_qty_available, p_qty_available,
+    p_expires_at, NULLIF(trim(p_note), ''), 'active', p_post_type, p_source_customer_order_id,
+    p_operator, p_operator
+  )
+  RETURNING id INTO v_board_id;
+
+  RETURN v_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_post_aid_board(BIGINT, BIGINT, NUMERIC, TIMESTAMPTZ, TEXT, UUID, TEXT, BIGINT) TO authenticated;
+
+COMMENT ON FUNCTION rpc_post_aid_board IS
+  'Phase 5c：發起互助貼文；offer 須帶 source_customer_order_id (對應 5b-1 的訂單轉出)、request 不帶';

--- a/supabase/migrations/20260509000002_transfer_order_partial.sql
+++ b/supabase/migrations/20260509000002_transfer_order_partial.sql
@@ -1,0 +1,223 @@
+-- ============================================================
+-- Phase 5c step 3 — partial 訂單轉出
+--
+-- 給互助板 offer / request 用：依 qty 拆單，原單剩多少留下、轉出 qty 開新單
+--
+-- 既有 rpc_transfer_order_to_store 是「整單轉出」(5b-1 棄單按鈕)、本 PR 不動
+-- 新 rpc_transfer_order_partial 是「指定 sku + qty 部分轉出」
+--
+-- 規則：
+--   - p_items: [{sku_id BIGINT, qty NUMERIC}]
+--   - 對每個 item：在 source 找對應 sku、qty <= source 的 active item.qty
+--       - 等於：source item status='cancelled' (qty 保留稽核、CHECK qty > 0 不能設 0)
+--       - 小於：source item qty -= 轉出 qty
+--   - 新單 INSERT items at p_items.qty (source='aid_transfer')
+--   - 若 source 所有 active items qty 都歸 0 / 全 cancelled → status='transferred_out' + transferred_to
+--   - 否則 source 保持 pending、notes 加註轉出
+--   - 不接受 source items 已 reserved (reserved_movement_id NOT NULL) — RAISE，呼叫端應先解 allocation
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_transfer_order_partial(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT,
+  p_items                 JSONB
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_p_item           JSONB;
+  v_p_sku_id         BIGINT;
+  v_p_qty            NUMERIC;
+  v_src_item_id      BIGINT;
+  v_src_item_qty     NUMERIC;
+  v_src_item_ci      BIGINT;
+  v_src_item_price   NUMERIC;
+  v_src_item_reserved BIGINT;
+  v_remaining_count  INT;
+  v_now              TIMESTAMPTZ := NOW();
+BEGIN
+  IF p_items IS NULL OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'p_items is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  IF v_orig.status NOT IN ('pending','confirmed','reserved') THEN
+    RAISE EXCEPTION 'order % status=%, only pending/confirmed/reserved can be transferred',
+                    p_order_id, v_orig.status;
+  END IF;
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  -- UNIQUE (tenant, campaign, channel, member) — 接收方已有同 trio 訂單時擋下
+  PERFORM 1 FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id;
+  IF FOUND THEN
+    RAISE EXCEPTION 'receiver already has order in (campaign=%, channel=%, member=%)',
+                    v_orig.campaign_id, v_to_channel_id, v_to_member_id;
+  END IF;
+
+  -- 產生新 order_no
+  SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+  SELECT COUNT(*) + 1 INTO v_seq
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+  v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+  -- 建空殼新單
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id,
+    nickname_snapshot, pickup_store_id, status, notes,
+    transferred_from_order_id,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+    v_orig.nickname_snapshot, p_to_pickup_store_id, 'pending',
+    COALESCE(p_reason, '') ||
+      E'\n[轉入 (部分) ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+      to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+    p_order_id,
+    p_operator, p_operator, v_now, v_now
+  ) RETURNING id INTO v_new_order_id;
+
+  -- 處理每個轉出 item
+  FOR v_p_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_p_sku_id := (v_p_item ->> 'sku_id')::BIGINT;
+    v_p_qty    := (v_p_item ->> 'qty')::NUMERIC;
+    IF v_p_qty IS NULL OR v_p_qty <= 0 THEN
+      RAISE EXCEPTION 'p_items: qty must be > 0';
+    END IF;
+
+    -- 找 source item (active、未取消、qty > 0)
+    SELECT id, qty, campaign_item_id, unit_price, reserved_movement_id
+      INTO v_src_item_id, v_src_item_qty, v_src_item_ci, v_src_item_price, v_src_item_reserved
+      FROM customer_order_items
+     WHERE order_id = p_order_id
+       AND sku_id   = v_p_sku_id
+       AND status   != 'cancelled'
+     ORDER BY id
+     LIMIT 1
+     FOR UPDATE;
+    IF v_src_item_id IS NULL THEN
+      RAISE EXCEPTION 'sku % not in order % (or already cancelled)', v_p_sku_id, p_order_id;
+    END IF;
+    IF v_src_item_reserved IS NOT NULL THEN
+      RAISE EXCEPTION 'sku % already allocated (reserved_movement_id=%); release first',
+                      v_p_sku_id, v_src_item_reserved;
+    END IF;
+    IF v_src_item_qty < v_p_qty THEN
+      RAISE EXCEPTION 'sku % insufficient qty: source=%, requested=%',
+                      v_p_sku_id, v_src_item_qty, v_p_qty;
+    END IF;
+
+    -- 若等於 → cancel source item；小於 → 減量
+    IF v_src_item_qty = v_p_qty THEN
+      UPDATE customer_order_items
+         SET status = 'cancelled', updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    ELSE
+      UPDATE customer_order_items
+         SET qty = qty - v_p_qty, updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    END IF;
+
+    -- 寫新單 item
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by
+    ) VALUES (
+      v_tenant_id, v_new_order_id, v_src_item_ci, v_p_sku_id, v_p_qty, v_src_item_price,
+      'pending', 'aid_transfer', p_operator, p_operator
+    );
+  END LOOP;
+
+  -- source 是否還有 active items？
+  SELECT COUNT(*) INTO v_remaining_count
+    FROM customer_order_items
+   WHERE order_id = p_order_id AND status != 'cancelled';
+
+  IF v_remaining_count = 0 THEN
+    -- 全部 cancelled → 視同整單轉出
+    UPDATE customer_orders
+       SET status = 'transferred_out',
+           transferred_to_order_id = v_new_order_id,
+           notes = COALESCE(notes, '') ||
+                   E'\n[全部轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  ELSE
+    -- 部分轉出、source 保留
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[部分轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  END IF;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_transfer_order_partial(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB) TO authenticated;
+
+COMMENT ON FUNCTION rpc_transfer_order_partial IS
+  'Phase 5c step 3：依 sku + qty 部分轉出訂單；source qty 全 0 → transferred_out、否則保留 pending';

--- a/supabase/migrations/20260509000003_consume_aid_board.sql
+++ b/supabase/migrations/20260509000003_consume_aid_board.sql
@@ -1,0 +1,59 @@
+-- ============================================================
+-- Phase 5c step 4 — 互助板分批扣量 RPC
+--
+-- 取代「partial transfer 後 client UPDATE qty_available」的做法（被 RLS 擋）
+-- 統一走 SECURITY DEFINER RPC：
+--   - 扣 qty_available + qty_remaining by p_qty
+--   - 若 reach 0 → status='exhausted'
+--   - 若 > 0 → 保持 active（可繼續被分批認領 / 提供）
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_consume_aid_board(
+  p_board_id BIGINT,
+  p_qty      NUMERIC,
+  p_operator UUID
+) RETURNS TEXT  -- 'exhausted' | 'partial'
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_qty_remaining NUMERIC;
+  v_status        TEXT;
+  v_new_remaining NUMERIC;
+  v_new_status    TEXT;
+BEGIN
+  IF p_qty IS NULL OR p_qty <= 0 THEN
+    RAISE EXCEPTION 'p_qty must be > 0';
+  END IF;
+
+  SELECT qty_remaining, status
+    INTO v_qty_remaining, v_status
+    FROM mutual_aid_board
+   WHERE id = p_board_id
+   FOR UPDATE;
+  IF v_qty_remaining IS NULL THEN
+    RAISE EXCEPTION 'board % not found', p_board_id;
+  END IF;
+  IF v_status != 'active' THEN
+    RAISE EXCEPTION 'board % status=%, only active can be consumed', p_board_id, v_status;
+  END IF;
+  IF v_qty_remaining < p_qty THEN
+    RAISE EXCEPTION 'board % insufficient qty: remaining=%, requested=%',
+                    p_board_id, v_qty_remaining, p_qty;
+  END IF;
+
+  v_new_remaining := v_qty_remaining - p_qty;
+  v_new_status := CASE WHEN v_new_remaining = 0 THEN 'exhausted' ELSE 'active' END;
+
+  UPDATE mutual_aid_board
+     SET qty_remaining = v_new_remaining,
+         status        = v_new_status,
+         updated_by    = p_operator
+   WHERE id = p_board_id;
+
+  RETURN v_new_status;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_consume_aid_board(BIGINT, NUMERIC, UUID) TO authenticated;
+
+COMMENT ON FUNCTION rpc_consume_aid_board IS
+  'Phase 5c step 4：互助板認領 / 提供時扣 qty；reach 0 自動 exhausted、否則保持 active 可分批';

--- a/supabase/migrations/20260509000004_transfer_partial_upsert.sql
+++ b/supabase/migrations/20260509000004_transfer_partial_upsert.sql
@@ -1,0 +1,228 @@
+-- ============================================================
+-- Phase 5c step 5 — partial transfer 改成 upsert (避免重複認領 UNIQUE 違反)
+--
+-- 問題：customer_orders UNIQUE (tenant, campaign, channel, member)
+--   - 第一次 partial 認領 / 提供：目標 (古華, channel=9, member=STORE-古華) 還沒訂單 → 建新單
+--   - 第二次 partial：目標 trio 已有第一張 transferred-in 的訂單 → constraint 衝突 RAISE
+--
+-- 解法：rpc_transfer_order_partial 找到既有 trio 訂單時、append items 進去（不再 RAISE）
+--   - 不新建 customer_orders；items 寫進既有 dest order
+--   - source 端邏輯不變：減 qty / 全 cancelled 才 transferred_out
+--   - notes 加註本次 partial transfer
+--
+-- 注意：rpc_transfer_order_to_store (整單) 仍保持 RAISE 行為 — 整單轉手不該疊
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_transfer_order_partial(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT,
+  p_items                 JSONB
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_p_item           JSONB;
+  v_p_sku_id         BIGINT;
+  v_p_qty            NUMERIC;
+  v_src_item_id      BIGINT;
+  v_src_item_qty     NUMERIC;
+  v_src_item_ci      BIGINT;
+  v_src_item_price   NUMERIC;
+  v_src_item_reserved BIGINT;
+  v_remaining_count  INT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_existing_order   BIGINT;
+  v_appended         BOOLEAN := FALSE;
+BEGIN
+  IF p_items IS NULL OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'p_items is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  IF v_orig.status NOT IN ('pending','confirmed','reserved') THEN
+    RAISE EXCEPTION 'order % status=%, only pending/confirmed/reserved can be transferred',
+                    p_order_id, v_orig.status;
+  END IF;
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  -- 找接收方既有 trio 訂單；有則 append items、否則建新單
+  SELECT id INTO v_existing_order
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id
+     AND status NOT IN ('expired','cancelled','transferred_out');
+
+  IF v_existing_order IS NOT NULL THEN
+    v_new_order_id := v_existing_order;
+    v_appended := TRUE;
+    -- 沿用原 order_no；append note
+    SELECT order_no INTO v_new_order_no FROM customer_orders WHERE id = v_existing_order;
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[追加轉入 ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS') ||
+                   COALESCE(' / ' || p_reason, ''),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = v_new_order_id;
+  ELSE
+    -- 產生新 order_no、建新單
+    SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+    SELECT COUNT(*) + 1 INTO v_seq
+      FROM customer_orders
+     WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+    v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id,
+      nickname_snapshot, pickup_store_id, status, notes,
+      transferred_from_order_id,
+      created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+      v_orig.nickname_snapshot, p_to_pickup_store_id, 'pending',
+      COALESCE(p_reason, '') ||
+        E'\n[轉入 (部分) ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+        to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+      p_order_id,
+      p_operator, p_operator, v_now, v_now
+    ) RETURNING id INTO v_new_order_id;
+  END IF;
+
+  -- 處理每個轉出 item
+  FOR v_p_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_p_sku_id := (v_p_item ->> 'sku_id')::BIGINT;
+    v_p_qty    := (v_p_item ->> 'qty')::NUMERIC;
+    IF v_p_qty IS NULL OR v_p_qty <= 0 THEN
+      RAISE EXCEPTION 'p_items: qty must be > 0';
+    END IF;
+
+    SELECT id, qty, campaign_item_id, unit_price, reserved_movement_id
+      INTO v_src_item_id, v_src_item_qty, v_src_item_ci, v_src_item_price, v_src_item_reserved
+      FROM customer_order_items
+     WHERE order_id = p_order_id
+       AND sku_id   = v_p_sku_id
+       AND status   != 'cancelled'
+     ORDER BY id
+     LIMIT 1
+     FOR UPDATE;
+    IF v_src_item_id IS NULL THEN
+      RAISE EXCEPTION 'sku % not in order % (or already cancelled)', v_p_sku_id, p_order_id;
+    END IF;
+    IF v_src_item_reserved IS NOT NULL THEN
+      RAISE EXCEPTION 'sku % already allocated (reserved_movement_id=%); release first',
+                      v_p_sku_id, v_src_item_reserved;
+    END IF;
+    IF v_src_item_qty < v_p_qty THEN
+      RAISE EXCEPTION 'sku % insufficient qty: source=%, requested=%',
+                      v_p_sku_id, v_src_item_qty, v_p_qty;
+    END IF;
+
+    IF v_src_item_qty = v_p_qty THEN
+      UPDATE customer_order_items
+         SET status = 'cancelled', updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    ELSE
+      UPDATE customer_order_items
+         SET qty = qty - v_p_qty, updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    END IF;
+
+    -- 寫到目標單 (新單 or 既有 upsert)
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by
+    ) VALUES (
+      v_tenant_id, v_new_order_id, v_src_item_ci, v_p_sku_id, v_p_qty, v_src_item_price,
+      'pending', 'aid_transfer', p_operator, p_operator
+    );
+  END LOOP;
+
+  -- source 是否還有 active items？
+  SELECT COUNT(*) INTO v_remaining_count
+    FROM customer_order_items
+   WHERE order_id = p_order_id AND status != 'cancelled';
+
+  IF v_remaining_count = 0 THEN
+    UPDATE customer_orders
+       SET status = 'transferred_out',
+           transferred_to_order_id = v_new_order_id,
+           notes = COALESCE(notes, '') ||
+                   E'\n[全部轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  ELSE
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[' || CASE WHEN v_appended THEN '部分追加' ELSE '部分轉出' END ||
+                   ' → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  END IF;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+COMMENT ON FUNCTION rpc_transfer_order_partial IS
+  'Phase 5c step 5：依 sku+qty partial 轉移；目標 trio 已存在訂單 → upsert append items（避免 UNIQUE 違反）';

--- a/supabase/migrations/20260509000005_orders_is_air_transfer.sql
+++ b/supabase/migrations/20260509000005_orders_is_air_transfer.sql
@@ -1,0 +1,237 @@
+-- ============================================================
+-- Phase 5c step 6 — customer_orders 加 is_air_transfer
+--
+-- 兩種轉單實體流：
+--   - 空中轉 (is_air_transfer=true)：轉出店 → 分店收貨 → 顧客取貨
+--   - 非空中轉 (false)             ：轉出店 → 總倉(收到) → 運送中(出貨) → 分店收貨 → 顧客取貨
+--
+-- 既有非轉入訂單也帶 false（無意義、不影響 UI — UI 只在 transferred_from_order_id 非 NULL 時讀此值）
+-- rpc_transfer_order_partial 加 p_is_air_transfer 參數、寫入新（或 upsert append）的訂單
+-- ============================================================
+
+ALTER TABLE customer_orders
+  ADD COLUMN is_air_transfer BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN customer_orders.is_air_transfer IS
+  '5c：transferred-in 訂單的轉移模式；true=店對店空中轉、false=經總倉中轉';
+
+-- ============================================================
+-- rpc_transfer_order_partial 加 p_is_air_transfer
+-- ============================================================
+-- DROP 舊版 7 args + CREATE 新版 8 args
+
+DROP FUNCTION IF EXISTS rpc_transfer_order_partial(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB);
+
+CREATE OR REPLACE FUNCTION rpc_transfer_order_partial(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT,
+  p_items                 JSONB,
+  p_is_air_transfer       BOOLEAN DEFAULT FALSE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_p_item           JSONB;
+  v_p_sku_id         BIGINT;
+  v_p_qty            NUMERIC;
+  v_src_item_id      BIGINT;
+  v_src_item_qty     NUMERIC;
+  v_src_item_ci      BIGINT;
+  v_src_item_price   NUMERIC;
+  v_src_item_reserved BIGINT;
+  v_remaining_count  INT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_existing_order   BIGINT;
+  v_appended         BOOLEAN := FALSE;
+BEGIN
+  IF p_items IS NULL OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'p_items is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  IF v_orig.status NOT IN ('pending','confirmed','reserved') THEN
+    RAISE EXCEPTION 'order % status=%, only pending/confirmed/reserved can be transferred',
+                    p_order_id, v_orig.status;
+  END IF;
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  -- upsert: 既有 trio 訂單 → append items
+  SELECT id INTO v_existing_order
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id
+     AND status NOT IN ('expired','cancelled','transferred_out');
+
+  IF v_existing_order IS NOT NULL THEN
+    v_new_order_id := v_existing_order;
+    v_appended := TRUE;
+    SELECT order_no INTO v_new_order_no FROM customer_orders WHERE id = v_existing_order;
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[追加轉入 (' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+                   ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS') ||
+                   COALESCE(' / ' || p_reason, ''),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = v_new_order_id;
+  ELSE
+    SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+    SELECT COUNT(*) + 1 INTO v_seq
+      FROM customer_orders
+     WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+    v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id,
+      nickname_snapshot, pickup_store_id, status, notes,
+      transferred_from_order_id, is_air_transfer,
+      created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+      v_orig.nickname_snapshot, p_to_pickup_store_id, 'pending',
+      COALESCE(p_reason, '') ||
+        E'\n[轉入 (部分, ' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+        ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+        to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+      p_order_id, p_is_air_transfer,
+      p_operator, p_operator, v_now, v_now
+    ) RETURNING id INTO v_new_order_id;
+  END IF;
+
+  FOR v_p_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_p_sku_id := (v_p_item ->> 'sku_id')::BIGINT;
+    v_p_qty    := (v_p_item ->> 'qty')::NUMERIC;
+    IF v_p_qty IS NULL OR v_p_qty <= 0 THEN
+      RAISE EXCEPTION 'p_items: qty must be > 0';
+    END IF;
+
+    SELECT id, qty, campaign_item_id, unit_price, reserved_movement_id
+      INTO v_src_item_id, v_src_item_qty, v_src_item_ci, v_src_item_price, v_src_item_reserved
+      FROM customer_order_items
+     WHERE order_id = p_order_id
+       AND sku_id   = v_p_sku_id
+       AND status   != 'cancelled'
+     ORDER BY id
+     LIMIT 1
+     FOR UPDATE;
+    IF v_src_item_id IS NULL THEN
+      RAISE EXCEPTION 'sku % not in order % (or already cancelled)', v_p_sku_id, p_order_id;
+    END IF;
+    IF v_src_item_reserved IS NOT NULL THEN
+      RAISE EXCEPTION 'sku % already allocated (reserved_movement_id=%); release first',
+                      v_p_sku_id, v_src_item_reserved;
+    END IF;
+    IF v_src_item_qty < v_p_qty THEN
+      RAISE EXCEPTION 'sku % insufficient qty: source=%, requested=%',
+                      v_p_sku_id, v_src_item_qty, v_p_qty;
+    END IF;
+
+    IF v_src_item_qty = v_p_qty THEN
+      UPDATE customer_order_items
+         SET status = 'cancelled', updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    ELSE
+      UPDATE customer_order_items
+         SET qty = qty - v_p_qty, updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    END IF;
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by
+    ) VALUES (
+      v_tenant_id, v_new_order_id, v_src_item_ci, v_p_sku_id, v_p_qty, v_src_item_price,
+      'pending', 'aid_transfer', p_operator, p_operator
+    );
+  END LOOP;
+
+  SELECT COUNT(*) INTO v_remaining_count
+    FROM customer_order_items
+   WHERE order_id = p_order_id AND status != 'cancelled';
+
+  IF v_remaining_count = 0 THEN
+    UPDATE customer_orders
+       SET status = 'transferred_out',
+           transferred_to_order_id = v_new_order_id,
+           notes = COALESCE(notes, '') ||
+                   E'\n[全部轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  ELSE
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[' || CASE WHEN v_appended THEN '部分追加' ELSE '部分轉出' END ||
+                   ' → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  END IF;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_transfer_order_partial(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB, BOOLEAN) TO authenticated;
+
+COMMENT ON FUNCTION rpc_transfer_order_partial IS
+  'Phase 5c step 6：partial 轉移；新單帶 is_air_transfer flag (true=空中轉、false=經總倉中轉)；upsert 既有 trio';


### PR DESCRIPTION
本 PR 含兩個功能（同 branch）：

# Phase 5b-2 — order-entry 加「為分店叫貨」mode

- 訂單登打 page (`/campaigns/order-entry`) 加「客戶下單 / 為分店叫貨」mode toggle
- internal mode: store picker + 可改 unit_price (88 折) + optional notes
- Submit 走 `rpc_create_store_internal_order` (5a-1 已 ship)
- 客戶下單 mode 行為 100% 保留

# Phase 5c — 互助交流板（純通訊版 + 拆單轉移）

業務設計：
- **offer**「我有庫存可提供」 = 把既有 `customer_order` 部分釋出
- **request**「我要求助」     = 純需求、提供方挑自己 pending 訂單拆 N 件給求助店
- 認領 / 提供都走依 sku+qty **拆單**轉移；source qty 不歸 0 就保留 pending（不誤標 transferred_out）
- 廢掉原 `rpc_claim_aid` 自動扣 qty / 自動建 transfer 設計（schema 表保留兼容）

新 migrations：
- `20260509000000_mutual_aid_replies` step 1: append-only thread + 3 RPC
- `20260509000001_mutual_aid_offer_request` step 2: post_type + source_customer_order_id + consistency CHECK
- `20260509000002_transfer_order_partial` step 3: `rpc_transfer_order_partial(... p_items JSONB)` 拆單
- `20260509000003_consume_aid_board` step 4: `rpc_consume_aid_board(... p_qty)` 統一扣量、reach 0 自動 exhausted、否則保持 active 可分批
- `20260509000004_transfer_partial_upsert` step 5: partial 命中既有 trio 訂單 → append items（避免 UNIQUE 違反）
- `20260509000005_orders_is_air_transfer` step 6: `customer_orders.is_air_transfer` BOOLEAN + RPC 8th arg

新 UI：`/inventory/mutual-aid` (~1100 行)
- 雙發文按鈕（藍：我要求助 / 粉：我有庫存可提供）
- Filter tabs：全部 / 需求中 / 釋出中
- OfferModal: 選釋出店 → 自動載入該店 pending 訂單 → 選一張 → 自動帶 qty
- ThreadModal: replies + 留言 + 「結束此貼」+
  - offer → 「✋ 我要認領」dialog（接收店 + qty 可改 + **空中轉 checkbox**）
  - request → 「🤝 我可以提供」dialog（選自己訂單 + qty 可改 + **空中轉 checkbox**）
- Sidebar 加「互助交流板」於進銷存群組

`OrderDetail` transferred-in timeline：
- **空中轉** (店對店直送) → 3 step：轉出店 → 分店收貨 → 顧客取貨
- **經總倉**             → 5 step：轉出店 → 總倉收到 → 運送中 → 分店收貨 → 顧客取貨

## 改動範圍

| 檔案 | 變動 |
|---|---|
| `apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx` | +345 / -52 (5b-2) |
| `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` | 新檔 ~1100 (5c) |
| `apps/admin/src/components/OrderDetail.tsx` | timeline 二分 (5c step 6) |
| `apps/admin/src/app/(protected)/layout.tsx` | +1 (Sidebar nav) |
| `supabase/migrations/20260509000000-5_*.sql` | 6 份新 migration (5c) |
| `docs/TEST-order-entry-store-internal*.md` | 5b-2 測試文件 + 報告 |
| `docs/TEST-mutual-aid-board*.md` | 5c 測試文件 + 報告 |

## Test plan

5b-2:
- [x] build pass、preview toggle / 必填 / 88 折 / upsert / regression 全 PASS
- [x] DB 直查確認 unit_price=88 / source=store_internal / pickup_store=三峽

5c:
- [x] 6 份 migration push dev 全 finished
- [x] build pass、preview offer/request 兩種發文 OK
- [x] OfferModal 載入 pending 訂單 + 自動帶 qty PASS
- [x] ClaimOfferDialog 全認 → board exhausted + source transferred_out PASS (DB 確認)
- [x] **分批認領** RPC 直測：board qty 5 → 認 3 (active qty 2) → 再認 2 (exhausted)、source SKU 1 qty 16→13→11→8 PASS
- [x] FulfillRequestDialog 程式對稱於 ClaimOffer、用同一支 RPC
- [x] step 5 upsert：第二次 partial 命中既有 trio 訂單 → append items 不 UNIQUE 違反
- [x] step 6 air-transfer：dialog checkbox → RPC notes 標註 / OrderDetail timeline 二分

詳見：
- [docs/TEST-order-entry-store-internal-report.md](docs/TEST-order-entry-store-internal-report.md)
- [docs/TEST-mutual-aid-board-report.md](docs/TEST-mutual-aid-board-report.md)

## 依賴

- 5a-1 [#132](https://github.com/lt-foods/new_erp/pull/132) `rpc_create_store_internal_order` + 訂單轉手 schema
- 5b-1 [#135](https://github.com/lt-foods/new_erp/pull/135) `rpc_transfer_order_to_store` 模式（5c 用 partial 變體）

## 後續

- 總倉 aid list page `/transfers/aid`（read-only、空中轉排前）— deferred 另開 PR
- Phase 7：transfer_settlement 月結算 UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)