### PR TITLE
fix(orders): customer_orders UNIQUE 改 partial（排除 closed 狀態）

### DIFF
--- a/supabase/migrations/20260509000006_corders_unique_active_only.sql
+++ b/supabase/migrations/20260509000006_corders_unique_active_only.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- Phase 5c step 7 — customer_orders UNIQUE 改 partial（active 才 unique）
+--
+-- 問題：UNIQUE (tenant, campaign, channel, member) 完整、不分 status
+--   - rpc_transfer_order_partial 的 upsert SELECT 排除 ('expired','cancelled','transferred_out')
+--   - trio 若已有 closed-status row（例：5b-1 測試遺留 transferred_out 訂單）
+--     → SELECT 找不到、INSERT 撞 UNIQUE → 「duplicate key value violates ...」
+--
+-- 修法：原 UNIQUE 改 partial WHERE status NOT IN (3 closed states)
+--   - 同 trio active 仍只允許 1 筆（Q6: 同團同頻道同會員合併）
+--   - 同 trio 可有 1+ closed + 1 active（場景：被 transferred_out 後再收新轉入）
+-- ============================================================
+
+ALTER TABLE customer_orders
+  DROP CONSTRAINT customer_orders_tenant_id_campaign_id_channel_id_member_id_key;
+
+CREATE UNIQUE INDEX customer_orders_trio_active_uniq
+  ON customer_orders (tenant_id, campaign_id, channel_id, member_id)
+  WHERE status NOT IN ('transferred_out', 'expired', 'cancelled');
+
+COMMENT ON INDEX customer_orders_trio_active_uniq IS
+  'Phase 5c step 7：同團同頻道同會員只允許一筆 active 訂單；closed (transferred_out/expired/cancelled) 不佔 slot';


### PR DESCRIPTION
## Bug

互助交流板「🤝 我可以提供」→ 提供方挑自己 pending 訂單 → 提交：

```
duplicate key value violates unique constraint
"customer_orders_tenant_id_campaign_id_channel_id_member_id_key"
```

## 根因

`rpc_transfer_order_partial` 的 upsert SELECT：

```sql
SELECT id INTO v_existing_order
  FROM customer_orders
 WHERE tenant_id = v_tenant_id
   AND campaign_id = v_orig.campaign_id
   AND channel_id  = v_to_channel_id
   AND member_id   = v_to_member_id
   AND status NOT IN ('expired','cancelled','transferred_out');  -- 排 closed
```

但 `customer_orders` UNIQUE constraint 是完整的 `(tenant, campaign, channel, member)`、不分 status。

→ 當接收店該 trio 已有 closed-status row（例：5b-1 棄單測試遺留 `transferred_out`）：
- SELECT 找不到 → 走 INSERT 分支
- INSERT 撞完整 UNIQUE → RAISE

## 修法

UNIQUE 改 partial：只 active 才 unique。

```sql
DROP CONSTRAINT customer_orders_tenant_id_campaign_id_channel_id_member_id_key;

CREATE UNIQUE INDEX customer_orders_trio_active_uniq
  ON customer_orders (tenant_id, campaign_id, channel_id, member_id)
  WHERE status NOT IN ('transferred_out', 'expired', 'cancelled');
```

語意：
- 同 trio active 仍只 1 筆（Q6 spec）
- 同 trio 可有 1+ closed + 1 active（被棄單轉出後再收新轉入）

## Test plan

- [x] migration push dev success
- [ ] 重跑互助板「我可以提供」→ 應成功 (no duplicate key error)
- [ ] regression：customer_orders 寫入 (一般下單) 仍正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)