### PR TITLE
chore(nav): 隱藏「店間月結算」 sidebar 入口

### DIFF
--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -36,7 +36,8 @@ const NAV: NavGroup[] = [
       { href: "/transfers", label: "調撥單列表", match: /^\/transfers$|^\/transfers\/?$/ },
       { href: "/inventory/mutual-aid", label: "互助交流板", match: /^\/inventory\/mutual-aid/ },
       { href: "/transfers/aid", label: "互助轉移單", match: /^\/transfers\/aid/ },
-      { href: "/transfers/settlement", label: "店間月結算", match: /^\/transfers\/settlement/ },
+      // 店間月結 (transfer_settlement) 隱藏 — 實際 99% 走 AP 月結；頁面保留可直接 URL 訪問
+      // { href: "/transfers/settlement", label: "店間月結算", match: /^\/transfers\/settlement/ },
     ],
   },
 ];


### PR DESCRIPTION
## Why

店間月結 (`transfer_settlement`) 設計假設店↔店流量大才需要雙向沖銷淨額。實際業務：
- 99% 貨流 = **總倉 → 加盟店**（單向、一般 AP 月結即可）
- 店↔店直接互轉量極小（`/transfers/aid` 才幾十筆）

→ 過度設計，主導航不該放。

## Change

`apps/admin/src/app/(protected)/layout.tsx`：sidebar 那行 nav 註解掉。
頁面 (`/transfers/settlement`) + RPC (`rpc_generate_transfer_settlement` / `rpc_confirm_transfer_settlement`) **保留**：
- 仍可直接 URL 訪問
- 後端 schema 不動
- 未來如需重啟、把 nav 解註解即可

## Test

- [x] preview reload、sidebar 不見「店間月結算」
- [x] direct URL `/transfers/settlement` 仍可訪問

🤖 Generated with [Claude Code](https://claude.com/claude-code)