### PR TITLE
feat(pickup): 顧客取貨 (Phase 6) — /pickup 電話查 + RPC + OrderDetail 按鈕

### DIFF
--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -19,6 +19,7 @@ const NAV: NavGroup[] = [
     title: "核心業務",
     items: [
       { href: "/orders", label: "訂單", match: /^\/orders/ },
+      { href: "/pickup", label: "取貨", match: /^\/pickup/ },
       { href: "/campaigns", label: "開團", match: /^\/campaigns/ },
       { href: "/products", label: "商品", match: /^\/products/ },
       { href: "/members", label: "會員", match: /^\/members/ },

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
+import { PickupDialog } from "@/components/PickupDialog";
 
 type OrderStatus =
   | "pending" | "confirmed" | "reserved" | "shipping" | "ready" | "partially_ready"
@@ -54,6 +55,8 @@ export default function OrdersListPage() {
   >(new Map());
   const [detailId, setDetailId] = useState<number | null>(null);
   const [detailNo, setDetailNo] = useState<string>("");
+  const [pickup, setPickup] = useState<{ id: number; no: string } | null>(null);
+  const [reloadOrders, setReloadOrders] = useState(0);
 
   useEffect(() => { setPage(1); }, [campaignId, status, storeId]);
 
@@ -121,7 +124,7 @@ export default function OrdersListPage() {
       }
     })();
     return () => { cancelled = true; };
-  }, [campaignId, status, storeId, page]);
+  }, [campaignId, status, storeId, page, reloadOrders]);
 
   const campaignMap = useMemo(() => new Map(campaigns.map((c) => [c.id, c])), [campaigns]);
   const storeMap = useMemo(() => new Map(stores.map((s) => [s.id, s])), [stores]);
@@ -168,14 +171,14 @@ export default function OrdersListPage() {
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr>
-              <Th>訂單號</Th><Th>開團</Th><Th>會員 / 暱稱</Th><Th>取貨店</Th><Th>取貨截止</Th><Th>狀態</Th><Th className="text-right">項數</Th><Th className="text-right">總數量</Th><Th className="text-right">總金額</Th><Th className="text-right">更新</Th>
+              <Th>訂單號</Th><Th>開團</Th><Th>會員 / 暱稱</Th><Th>取貨店</Th><Th>取貨截止</Th><Th>狀態</Th><Th className="text-right">項數</Th><Th className="text-right">總數量</Th><Th className="text-right">總金額</Th><Th className="text-right">更新</Th><Th className="text-right">操作</Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={10} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={11} className="p-3 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={10} className="p-6 text-center text-zinc-500">{total === 0 && !campaignId && !status && !storeId ? "尚無訂單。" : "沒有符合條件的訂單。"}</td></tr>
+              <tr><td colSpan={11} className="p-6 text-center text-zinc-500">{total === 0 && !campaignId && !status && !storeId ? "尚無訂單。" : "沒有符合條件的訂單。"}</td></tr>
             ) : rows.map((r) => {
               const m = r.member_id ? members.get(r.member_id) : null;
               const c = campaignMap.get(r.campaign_id);
@@ -208,12 +211,36 @@ export default function OrdersListPage() {
                   <Td className="text-right font-mono">{itemSummary.get(r.id)?.totalQty ?? 0}</Td>
                   <Td className="text-right font-mono">${itemSummary.get(r.id)?.totalAmount ?? 0}</Td>
                   <Td className="text-right text-xs text-zinc-500">{new Date(r.updated_at).toLocaleString("zh-TW")}</Td>
+                  <Td className="text-right">
+                    {["pending","confirmed","reserved","ready","partially_ready","partially_completed","shipping"].includes(r.status) && (
+                      <button
+                        onClick={() => setPickup({ id: r.id, no: r.order_no })}
+                        className="rounded-md bg-emerald-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-emerald-700"
+                      >
+                        ✅ 取貨
+                      </button>
+                    )}
+                  </Td>
                 </tr>
               );
             })}
           </tbody>
         </table>
       </div>
+
+      {pickup && (
+        <PickupDialog
+          open={true}
+          onClose={() => setPickup(null)}
+          orderId={pickup.id}
+          orderNo={pickup.no}
+          onPickedUp={(r) => {
+            setPickup(null);
+            alert(`取貨完成 (${r.picked_count} 項)\n訂單狀態：${r.new_order_status}`);
+            setReloadOrders((n) => n + 1);
+          }}
+        />
+      )}
 
       <Modal
         open={detailId !== null}

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { PickupDialog } from "@/components/PickupDialog";
+
+type Member = {
+  id: number;
+  member_no: string;
+  name: string | null;
+  phone: string | null;
+};
+
+type OpenOrder = {
+  id: number;
+  order_no: string;
+  status: string;
+  pickup_deadline: string | null;
+  pickup_store_id: number | null;
+  campaign: { id: number; campaign_no: string; name: string } | null;
+  store: { id: number; name: string } | null;
+  items: { id: number; qty: number; status: string }[];
+};
+
+const ACTIVE_STATUSES = ["pending", "confirmed", "reserved", "ready", "partially_ready", "partially_completed", "shipping"];
+
+export default function PickupPage() {
+  const [suffix, setSuffix] = useState("");
+  const [searching, setSearching] = useState(false);
+  const [members, setMembers] = useState<Member[] | null>(null);
+  const [orders, setOrders] = useState<Map<number, OpenOrder[]>>(new Map());
+  const [error, setError] = useState<string | null>(null);
+  const [reloadTick, setReloadTick] = useState(0);
+
+  const [pickup, setPickup] = useState<{ orderId: number; orderNo: string } | null>(null);
+
+  async function search(e?: React.FormEvent) {
+    e?.preventDefault();
+    if (suffix.length < 3) {
+      setError("請至少輸入 3 碼（建議後 6 碼）");
+      return;
+    }
+    setSearching(true);
+    setError(null);
+    setMembers(null);
+    setOrders(new Map());
+    try {
+      const sb = getSupabase();
+      const { data: ms, error: e1 } = await sb
+        .from("members")
+        .select("id, member_no, name, phone")
+        .like("phone", `%${suffix}`)
+        .neq("status", "deleted")
+        .order("last_visit_at", { ascending: false, nullsFirst: false })
+        .limit(20);
+      if (e1) { setError(e1.message); return; }
+      const list = (ms ?? []) as Member[];
+      setMembers(list);
+      if (list.length === 0) return;
+
+      const { data: ords, error: e2 } = await sb
+        .from("customer_orders")
+        .select(
+          `id, order_no, status, pickup_deadline, pickup_store_id, member_id,
+           campaign:group_buy_campaigns(id, campaign_no, name),
+           store:stores!customer_orders_pickup_store_id_fkey(id, name),
+           items:customer_order_items(id, qty, status)`,
+        )
+        .in("member_id", list.map((m) => m.id))
+        .in("status", ACTIVE_STATUSES)
+        .order("updated_at", { ascending: false });
+      if (e2) { setError(e2.message); return; }
+      const m = new Map<number, OpenOrder[]>();
+      for (const r of (ords ?? []) as unknown as (OpenOrder & { member_id: number })[]) {
+        const arr = m.get(r.member_id) ?? [];
+        arr.push(r);
+        m.set(r.member_id, arr);
+      }
+      setOrders(m);
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  // 重新跑搜尋（取貨後 reload）
+  useEffect(() => {
+    if (reloadTick > 0 && members && members.length > 0) {
+      search();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reloadTick]);
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header>
+        <h1 className="text-xl font-semibold">取貨</h1>
+        <p className="text-sm text-zinc-500">輸入顧客電話後幾碼（建議 6 碼）→ 找出本人未取訂單 → 確認取貨。</p>
+      </header>
+
+      <form onSubmit={search} className="flex items-end gap-2">
+        <label className="text-sm">
+          <span className="mb-1 block text-xs text-zinc-500">電話後 N 碼（≥3）</span>
+          <input
+            type="tel"
+            inputMode="numeric"
+            pattern="\d*"
+            value={suffix}
+            onChange={(e) => setSuffix(e.target.value.replace(/\D/g, "").slice(0, 10))}
+            autoFocus
+            placeholder="123456"
+            className="w-40 rounded-md border border-zinc-300 bg-white px-3 py-2 text-lg font-mono dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={searching || suffix.length < 3}
+          className="rounded-md bg-zinc-900 px-4 py-2 text-sm text-white transition hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
+        >
+          {searching ? "搜尋中…" : "🔍 搜尋"}
+        </button>
+        {(members || error) && (
+          <button
+            type="button"
+            onClick={() => { setSuffix(""); setMembers(null); setOrders(new Map()); setError(null); }}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            清空
+          </button>
+        )}
+      </form>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          <p className="font-mono text-xs">{error}</p>
+        </div>
+      )}
+
+      {members !== null && (
+        members.length === 0 ? (
+          <p className="rounded-md border border-zinc-200 bg-zinc-50 p-6 text-center text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900">
+            找不到電話含「{suffix}」的會員。
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {members.map((m) => {
+              const memberOrders = orders.get(m.id) ?? [];
+              return (
+                <div key={m.id} className="rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+                  <div className="mb-2 flex items-baseline gap-3">
+                    <h2 className="text-base font-semibold">{m.name ?? "—"}</h2>
+                    <span className="font-mono text-xs text-zinc-500">{m.member_no}</span>
+                    <span className="font-mono text-sm text-zinc-700 dark:text-zinc-300">{m.phone ?? "—"}</span>
+                  </div>
+                  {memberOrders.length === 0 ? (
+                    <p className="text-xs text-zinc-500">無未取訂單。</p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {memberOrders.map((o) => {
+                        const pickableCount = o.items.filter((it) => ["pending","reserved","ready"].includes(it.status)).length;
+                        return (
+                          <li key={o.id} className="flex items-center gap-3 rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-950">
+                            <div className="flex-1 text-sm">
+                              <div className="flex items-baseline gap-2">
+                                <span className="font-mono font-medium">{o.order_no}</span>
+                                <span className={`rounded px-2 py-0.5 text-[10px] ${o.status === "ready" ? "bg-emerald-100 text-emerald-800" : "bg-zinc-200 text-zinc-700"}`}>
+                                  {o.status}
+                                </span>
+                              </div>
+                              {o.campaign && (
+                                <div className="text-[10px] text-zinc-400">
+                                  <span className="font-mono">{o.campaign.campaign_no}</span> {o.campaign.name}
+                                </div>
+                              )}
+                              <div className="mt-1 text-xs text-zinc-500">
+                                取貨店：{o.store?.name ?? "—"}
+                                {o.pickup_deadline && <span className="ml-2">截止：{o.pickup_deadline}</span>}
+                                <span className="ml-2">{pickableCount} 項可取</span>
+                              </div>
+                            </div>
+                            <button
+                              onClick={() => setPickup({ orderId: o.id, orderNo: o.order_no })}
+                              disabled={pickableCount === 0}
+                              className="rounded-md bg-emerald-600 px-3 py-2 text-xs font-medium text-white transition hover:bg-emerald-700 disabled:opacity-50"
+                            >
+                              ✅ 取貨
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )
+      )}
+
+      {pickup && (
+        <PickupDialog
+          open={true}
+          onClose={() => setPickup(null)}
+          orderId={pickup.orderId}
+          orderNo={pickup.orderNo}
+          onPickedUp={(r) => {
+            setPickup(null);
+            alert(`取貨完成 (${r.picked_count} 項)\n訂單狀態：${r.new_order_status}`);
+            setReloadTick((n) => n + 1);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -20,7 +20,17 @@ type OpenOrder = {
   pickup_store_id: number | null;
   campaign: { id: number; campaign_no: string; name: string } | null;
   store: { id: number; name: string } | null;
-  items: { id: number; qty: number; status: string; sku: { variant_name: string | null; product_name: string | null } | null }[];
+  items: {
+    id: number;
+    qty: number;
+    unit_price: number;
+    status: string;
+    sku: {
+      variant_name: string | null;
+      product_name: string | null;
+      product: { images: string[] | null } | null;
+    } | null;
+  }[];
 };
 
 const ACTIVE_STATUSES = ["pending", "confirmed", "reserved", "ready", "partially_ready", "partially_completed", "shipping"];
@@ -36,6 +46,7 @@ export default function PickupPage() {
   const [pickup, setPickup] = useState<{ orderId: number; orderNo: string } | null>(null);
   const [bulking, setBulking] = useState<number | null>(null);
   const [bulkConfirm, setBulkConfirm] = useState<Member | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
 
   async function search(e?: React.FormEvent) {
     e?.preventDefault();
@@ -67,7 +78,7 @@ export default function PickupPage() {
           `id, order_no, status, pickup_deadline, pickup_store_id, member_id,
            campaign:group_buy_campaigns(id, campaign_no, name),
            store:stores!customer_orders_pickup_store_id_fkey(id, name),
-           items:customer_order_items(id, qty, status, sku:skus(variant_name, product_name))`,
+           items:customer_order_items(id, qty, unit_price, status, sku:skus(variant_name, product_name, product:products(images)))`,
         )
         .in("member_id", list.map((m) => m.id))
         .in("status", ACTIVE_STATUSES)
@@ -85,11 +96,22 @@ export default function PickupPage() {
     }
   }
 
+  function toggleSelect(orderId: number) {
+    setSelected((s) => {
+      const next = new Set(s);
+      if (next.has(orderId)) next.delete(orderId); else next.add(orderId);
+      return next;
+    });
+  }
+
   async function bulkPickAllConfirmed(member: Member) {
     const memberId = member.id;
-    const memberOrders = (orders.get(memberId) ?? []).filter((o) =>
+    const allMemberOrders = (orders.get(memberId) ?? []).filter((o) =>
       o.items.some((it) => ["pending", "reserved", "ready"].includes(it.status)),
     );
+    // 若有勾選 → 只取勾選的；無勾選 → 全取
+    const memberSelected = allMemberOrders.filter((o) => selected.has(o.id));
+    const memberOrders = memberSelected.length > 0 ? memberSelected : allMemberOrders;
     if (memberOrders.length === 0) return;
     setBulkConfirm(null);
     setBulking(memberId);
@@ -199,15 +221,20 @@ export default function PickupPage() {
                     <h2 className="text-base font-semibold">{m.name ?? "—"}</h2>
                     <span className="font-mono text-xs text-zinc-500">{m.member_no}</span>
                     <span className="font-mono text-sm text-zinc-700 dark:text-zinc-300">{m.phone ?? "—"}</span>
-                    {memberOrders.length > 0 && (
-                      <button
-                        onClick={() => setBulkConfirm(m)}
-                        disabled={bulking === m.id}
-                        className="ml-auto rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-emerald-700 disabled:opacity-50"
-                      >
-                        {bulking === m.id ? "處理中…" : `📦 一次全取（${memberOrders.length} 張）`}
-                      </button>
-                    )}
+                    {memberOrders.length > 0 && (() => {
+                      const selectedHere = memberOrders.filter((o) => selected.has(o.id));
+                      const useSel = selectedHere.length > 0;
+                      const count = useSel ? selectedHere.length : memberOrders.length;
+                      return (
+                        <button
+                          onClick={() => setBulkConfirm(m)}
+                          disabled={bulking === m.id}
+                          className="ml-auto rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-emerald-700 disabled:opacity-50"
+                        >
+                          {bulking === m.id ? "處理中…" : useSel ? `📦 取選定的 ${count} 張` : `📦 一次全取（${count} 張）`}
+                        </button>
+                      );
+                    })()}
                   </div>
                   {memberOrders.length === 0 ? (
                     <p className="text-xs text-zinc-500">無未取訂單。</p>
@@ -216,7 +243,15 @@ export default function PickupPage() {
                       {memberOrders.map((o) => {
                         const pickableCount = o.items.filter((it) => ["pending","reserved","ready"].includes(it.status)).length;
                         return (
-                          <li key={o.id} className="flex items-center gap-3 rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-950">
+                          <li key={o.id} className={`flex items-center gap-3 rounded-md border p-3 ${selected.has(o.id) ? "border-emerald-400 bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-950" : "border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950"}`}>
+                            <input
+                              type="checkbox"
+                              checked={selected.has(o.id)}
+                              onChange={() => toggleSelect(o.id)}
+                              disabled={pickableCount === 0}
+                              className="h-4 w-4"
+                            />
+                            <OrderThumb order={o} />
                             <div className="flex-1 text-sm">
                               <div className="flex items-baseline gap-2">
                                 <span className="font-mono font-medium">{o.order_no}</span>
@@ -233,6 +268,9 @@ export default function PickupPage() {
                                 取貨店：{o.store?.name ?? "—"}
                                 {o.pickup_deadline && <span className="ml-2">截止：{o.pickup_deadline}</span>}
                                 <span className="ml-2">{pickableCount} 項可取</span>
+                                <span className="ml-2 font-mono text-zinc-700 dark:text-zinc-200">
+                                  ${o.items.filter((it) => ["pending","reserved","ready"].includes(it.status)).reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0)}
+                                </span>
                               </div>
                             </div>
                             <button
@@ -275,17 +313,23 @@ export default function PickupPage() {
         maxWidth="max-w-2xl"
       >
         {bulkConfirm && (() => {
-          const memberOrders = (orders.get(bulkConfirm.id) ?? []).filter((o) =>
+          const allMemberOrders = (orders.get(bulkConfirm.id) ?? []).filter((o) =>
             o.items.some((it) => ["pending", "reserved", "ready"].includes(it.status)),
           );
+          const selectedHere = allMemberOrders.filter((o) => selected.has(o.id));
+          const memberOrders = selectedHere.length > 0 ? selectedHere : allMemberOrders;
           const totalItems = memberOrders.reduce(
             (s, o) => s + o.items.filter((it) => ["pending","reserved","ready"].includes(it.status)).length,
+            0,
+          );
+          const totalAmount = memberOrders.reduce(
+            (s, o) => s + o.items.filter((it) => ["pending","reserved","ready"].includes(it.status)).reduce((ss, it) => ss + Number(it.qty) * Number(it.unit_price), 0),
             0,
           );
           return (
             <div className="space-y-3">
               <p className="text-sm text-zinc-600 dark:text-zinc-300">
-                即將取走 <b>{memberOrders.length}</b> 張訂單、共 <b>{totalItems}</b> 項商品：
+                即將取走 <b>{memberOrders.length}</b> 張訂單、共 <b>{totalItems}</b> 項商品、合計 <b className="font-mono text-base text-zinc-900 dark:text-zinc-100">${totalAmount}</b>：
               </p>
               <div className="max-h-80 space-y-3 overflow-y-auto rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
                 {memberOrders.map((o) => {
@@ -324,7 +368,7 @@ export default function PickupPage() {
                   onClick={() => bulkPickAllConfirmed(bulkConfirm)}
                   className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700"
                 >
-                  ✅ 確認全取（{memberOrders.length} 張、{totalItems} 項）
+                  ✅ 確認取貨（{memberOrders.length} 張、{totalItems} 項、${totalAmount}）
                 </button>
               </div>
             </div>
@@ -332,5 +376,23 @@ export default function PickupPage() {
         })()}
       </Modal>
     </div>
+  );
+}
+
+function OrderThumb({ order }: { order: OpenOrder }) {
+  // 取第一個 active item 的 product 第一張 image
+  const firstImg = order.items
+    .map((it) => it.sku?.product?.images?.[0])
+    .find((u): u is string => typeof u === "string" && !!u);
+  if (!firstImg) {
+    return (
+      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-zinc-200 text-xs text-zinc-500 dark:bg-zinc-800">
+        —
+      </div>
+    );
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={firstImg} alt="" className="h-12 w-12 shrink-0 rounded-md object-cover" />
   );
 }

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { Modal } from "@/components/Modal";
 import { PickupDialog } from "@/components/PickupDialog";
 
 type Member = {
@@ -19,7 +20,7 @@ type OpenOrder = {
   pickup_store_id: number | null;
   campaign: { id: number; campaign_no: string; name: string } | null;
   store: { id: number; name: string } | null;
-  items: { id: number; qty: number; status: string }[];
+  items: { id: number; qty: number; status: string; sku: { variant_name: string | null; product_name: string | null } | null }[];
 };
 
 const ACTIVE_STATUSES = ["pending", "confirmed", "reserved", "ready", "partially_ready", "partially_completed", "shipping"];
@@ -34,6 +35,7 @@ export default function PickupPage() {
 
   const [pickup, setPickup] = useState<{ orderId: number; orderNo: string } | null>(null);
   const [bulking, setBulking] = useState<number | null>(null);
+  const [bulkConfirm, setBulkConfirm] = useState<Member | null>(null);
 
   async function search(e?: React.FormEvent) {
     e?.preventDefault();
@@ -65,7 +67,7 @@ export default function PickupPage() {
           `id, order_no, status, pickup_deadline, pickup_store_id, member_id,
            campaign:group_buy_campaigns(id, campaign_no, name),
            store:stores!customer_orders_pickup_store_id_fkey(id, name),
-           items:customer_order_items(id, qty, status)`,
+           items:customer_order_items(id, qty, status, sku:skus(variant_name, product_name))`,
         )
         .in("member_id", list.map((m) => m.id))
         .in("status", ACTIVE_STATUSES)
@@ -83,12 +85,13 @@ export default function PickupPage() {
     }
   }
 
-  async function bulkPickAll(memberId: number) {
+  async function bulkPickAllConfirmed(member: Member) {
+    const memberId = member.id;
     const memberOrders = (orders.get(memberId) ?? []).filter((o) =>
       o.items.some((it) => ["pending", "reserved", "ready"].includes(it.status)),
     );
     if (memberOrders.length === 0) return;
-    if (!confirm(`一次取走此會員 ${memberOrders.length} 張未取訂單的全部商品？`)) return;
+    setBulkConfirm(null);
     setBulking(memberId);
     setError(null);
     try {
@@ -198,7 +201,7 @@ export default function PickupPage() {
                     <span className="font-mono text-sm text-zinc-700 dark:text-zinc-300">{m.phone ?? "—"}</span>
                     {memberOrders.length > 0 && (
                       <button
-                        onClick={() => bulkPickAll(m.id)}
+                        onClick={() => setBulkConfirm(m)}
                         disabled={bulking === m.id}
                         className="ml-auto rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-emerald-700 disabled:opacity-50"
                       >
@@ -264,6 +267,70 @@ export default function PickupPage() {
           }}
         />
       )}
+
+      <Modal
+        open={bulkConfirm !== null}
+        onClose={() => setBulkConfirm(null)}
+        title={bulkConfirm ? `📦 一次全取 — ${bulkConfirm.name ?? "—"} (${bulkConfirm.member_no})` : ""}
+        maxWidth="max-w-2xl"
+      >
+        {bulkConfirm && (() => {
+          const memberOrders = (orders.get(bulkConfirm.id) ?? []).filter((o) =>
+            o.items.some((it) => ["pending", "reserved", "ready"].includes(it.status)),
+          );
+          const totalItems = memberOrders.reduce(
+            (s, o) => s + o.items.filter((it) => ["pending","reserved","ready"].includes(it.status)).length,
+            0,
+          );
+          return (
+            <div className="space-y-3">
+              <p className="text-sm text-zinc-600 dark:text-zinc-300">
+                即將取走 <b>{memberOrders.length}</b> 張訂單、共 <b>{totalItems}</b> 項商品：
+              </p>
+              <div className="max-h-80 space-y-3 overflow-y-auto rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
+                {memberOrders.map((o) => {
+                  const pickItems = o.items.filter((it) => ["pending","reserved","ready"].includes(it.status));
+                  return (
+                    <div key={o.id} className="text-sm">
+                      <div className="mb-1">
+                        <span className="font-mono font-semibold">{o.order_no}</span>
+                        {o.campaign && (
+                          <span className="ml-2 text-[10px] text-zinc-400">
+                            {o.campaign.campaign_no} {o.campaign.name}
+                          </span>
+                        )}
+                        <span className="ml-2 text-[10px] text-zinc-500">取貨店：{o.store?.name ?? "—"}</span>
+                      </div>
+                      <ul className="ml-4 space-y-0.5 text-xs">
+                        {pickItems.map((it) => (
+                          <li key={it.id} className="flex items-baseline gap-2">
+                            <span>{it.sku?.variant_name ?? it.sku?.product_name ?? "—"}</span>
+                            <span className="font-mono">×{Number(it.qty)}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={() => setBulkConfirm(null)}
+                  className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                >
+                  取消
+                </button>
+                <button
+                  onClick={() => bulkPickAllConfirmed(bulkConfirm)}
+                  className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700"
+                >
+                  ✅ 確認全取（{memberOrders.length} 張、{totalItems} 項）
+                </button>
+              </div>
+            </div>
+          );
+        })()}
+      </Modal>
     </div>
   );
 }

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -33,6 +33,7 @@ export default function PickupPage() {
   const [reloadTick, setReloadTick] = useState(0);
 
   const [pickup, setPickup] = useState<{ orderId: number; orderNo: string } | null>(null);
+  const [bulking, setBulking] = useState<number | null>(null);
 
   async function search(e?: React.FormEvent) {
     e?.preventDefault();
@@ -79,6 +80,51 @@ export default function PickupPage() {
       setOrders(m);
     } finally {
       setSearching(false);
+    }
+  }
+
+  async function bulkPickAll(memberId: number) {
+    const memberOrders = (orders.get(memberId) ?? []).filter((o) =>
+      o.items.some((it) => ["pending", "reserved", "ready"].includes(it.status)),
+    );
+    if (memberOrders.length === 0) return;
+    if (!confirm(`一次取走此會員 ${memberOrders.length} 張未取訂單的全部商品？`)) return;
+    setBulking(memberId);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) { setError("尚未登入"); return; }
+      let okCount = 0;
+      const errors: string[] = [];
+      const eventIds: number[] = [];
+      for (const o of memberOrders) {
+        const itemIds = o.items
+          .filter((it) => ["pending", "reserved", "ready"].includes(it.status))
+          .map((it) => it.id);
+        const { data, error: e } = await sb.rpc("rpc_record_pickup", {
+          p_order_id: o.id,
+          p_item_ids: itemIds,
+          p_operator: operator,
+          p_notes: "一次全取",
+        });
+        if (e) errors.push(`${o.order_no}: ${e.message}`);
+        else {
+          okCount++;
+          const ev = data as { event_id: number };
+          if (ev?.event_id) eventIds.push(ev.event_id);
+        }
+      }
+      if (errors.length > 0) setError(errors.join("\n"));
+      if (eventIds.length > 0) {
+        // 自動開列印（一張頁面、多張收據連續分頁）
+        window.open(`/pickup/print?event_ids=${eventIds.join(",")}`, "_blank");
+      }
+      alert(`完成 ${okCount}/${memberOrders.length} 張取貨${errors.length > 0 ? `\n失敗 ${errors.length} 張：\n${errors.join("\n")}` : ""}`);
+      setReloadTick((t) => t + 1);
+    } finally {
+      setBulking(null);
     }
   }
 
@@ -150,6 +196,15 @@ export default function PickupPage() {
                     <h2 className="text-base font-semibold">{m.name ?? "—"}</h2>
                     <span className="font-mono text-xs text-zinc-500">{m.member_no}</span>
                     <span className="font-mono text-sm text-zinc-700 dark:text-zinc-300">{m.phone ?? "—"}</span>
+                    {memberOrders.length > 0 && (
+                      <button
+                        onClick={() => bulkPickAll(m.id)}
+                        disabled={bulking === m.id}
+                        className="ml-auto rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-emerald-700 disabled:opacity-50"
+                      >
+                        {bulking === m.id ? "處理中…" : `📦 一次全取（${memberOrders.length} 張）`}
+                      </button>
+                    )}
                   </div>
                   {memberOrders.length === 0 ? (
                     <p className="text-xs text-zinc-500">無未取訂單。</p>

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -101,11 +101,10 @@ function Body() {
     <>
       <style jsx global>{`
         @media print {
-          @page { margin: 12mm; }
+          @page { margin: 10mm; }
           body { background: white !important; }
           .no-print { display: none !important; }
-          .receipt { page-break-after: always; }
-          .receipt:last-child { page-break-after: auto; }
+          .receipt { page-break-inside: avoid; }
         }
       `}</style>
       <div className="mx-auto max-w-2xl p-6">
@@ -113,17 +112,24 @@ function Body() {
           <button onClick={() => window.print()} className="rounded-md bg-zinc-900 px-4 py-2 text-sm text-white hover:bg-zinc-700">🖨️ 列印</button>
           <button onClick={() => window.close()} className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100">關閉</button>
         </div>
-        {receipts.map((r) => (
-          <div key={r.event.id} className="receipt mb-8 rounded-md border border-zinc-300 bg-white p-6 text-zinc-900">
-            <div className="mb-4 text-center">
-              <h1 className="text-xl font-bold">取貨單</h1>
-              <div className="text-xs text-zinc-500">
-                {r.event.event_type === "picked_up" ? "全部取貨" : "部分取貨"}
+        {receipts.length > 1 && (
+          <div className="mb-3 text-center">
+            <h1 className="text-xl font-bold">取貨單（共 {receipts.length} 張）</h1>
+          </div>
+        )}
+        {receipts.map((r, i) => (
+          <div key={r.event.id} className={`receipt bg-white p-4 text-zinc-900 ${i < receipts.length - 1 ? "border-b-2 border-dashed border-zinc-400" : ""}`}>
+            {receipts.length === 1 && (
+              <div className="mb-3 text-center">
+                <h1 className="text-xl font-bold">取貨單</h1>
+                <div className="text-xs text-zinc-500">
+                  {r.event.event_type === "picked_up" ? "全部取貨" : "部分取貨"}
+                </div>
               </div>
-            </div>
+            )}
 
-            <div className="mb-4 grid grid-cols-2 gap-2 text-sm">
-              <Field label="訂單號" value={<span className="font-mono">{r.order?.order_no ?? "—"}</span>} />
+            <div className="mb-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+              <Field label="訂單號" value={<span className="font-mono font-semibold">{r.order?.order_no ?? "—"}</span>} />
               <Field label="取貨時間" value={new Date(r.event.created_at).toLocaleString("zh-TW")} />
               <Field label="會員" value={r.order?.member ? `${r.order.member.name ?? "—"} (${r.order.member.member_no})` : "—"} />
               <Field label="電話" value={r.order?.member?.phone ?? "—"} />
@@ -131,7 +137,7 @@ function Body() {
               <Field label="開團" value={r.order?.campaign ? `${r.order.campaign.campaign_no} ${r.order.campaign.name}` : "—"} />
             </div>
 
-            <table className="mb-4 w-full border-collapse text-sm">
+            <table className="mb-2 w-full border-collapse text-xs">
               <thead>
                 <tr className="border-b-2 border-zinc-400">
                   <th className="px-2 py-1 text-left">商品</th>
@@ -167,15 +173,15 @@ function Body() {
             </table>
 
             {r.event.notes && (
-              <div className="mb-3 text-xs text-zinc-600">備註：{r.event.notes}</div>
+              <div className="mb-2 text-xs text-zinc-600">備註：{r.event.notes}</div>
             )}
-
-            <div className="mt-6 grid grid-cols-2 gap-8 text-xs">
-              <div className="border-t border-zinc-400 pt-2 text-center">顧客簽名</div>
-              <div className="border-t border-zinc-400 pt-2 text-center">店員簽名</div>
-            </div>
           </div>
         ))}
+
+        <div className="mt-4 grid grid-cols-2 gap-8 text-xs">
+          <div className="border-t border-zinc-400 pt-2 text-center">顧客簽名</div>
+          <div className="border-t border-zinc-400 pt-2 text-center">店員簽名</div>
+        </div>
       </div>
     </>
   );

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { getSupabase } from "@/lib/supabase";
+
+type PickupEvent = {
+  id: number;
+  order_id: number;
+  pickup_store_id: number;
+  event_type: string;
+  item_ids: number[];
+  notes: string | null;
+  created_at: string;
+};
+
+type Order = {
+  id: number;
+  order_no: string;
+  status: string;
+  pickup_store_id: number | null;
+  member: { id: number; member_no: string; name: string | null; phone: string | null } | null;
+  campaign: { id: number; campaign_no: string; name: string } | null;
+  store: { id: number; name: string } | null;
+};
+
+type Item = {
+  id: number;
+  qty: number;
+  unit_price: number;
+  status: string;
+  sku: { sku_code: string; product_name: string | null; variant_name: string | null } | null;
+};
+
+export default function PickupPrintPage() {
+  return (
+    <Suspense fallback={<div className="p-6 text-sm">載入中…</div>}>
+      <Body />
+    </Suspense>
+  );
+}
+
+function Body() {
+  const eventIds = useSearchParams().get("event_ids");
+  const ids = eventIds ? eventIds.split(",").map(Number).filter(Boolean) : [];
+  const [receipts, setReceipts] = useState<{ event: PickupEvent; order: Order; items: Item[] }[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (ids.length === 0) { setError("缺 event_ids 參數"); return; }
+    (async () => {
+      const sb = getSupabase();
+      const { data: evts, error: e1 } = await sb
+        .from("order_pickup_events")
+        .select("id, order_id, pickup_store_id, event_type, item_ids, notes, created_at")
+        .in("id", ids);
+      if (cancelled) return;
+      if (e1) { setError(e1.message); return; }
+      const events = (evts ?? []) as unknown as PickupEvent[];
+      if (events.length === 0) { setError("找不到對應取貨記錄"); return; }
+
+      const orderIds = Array.from(new Set(events.map((e) => e.order_id)));
+      const allItemIds = events.flatMap((e) => e.item_ids ?? []);
+      const [{ data: ords }, { data: itms }] = await Promise.all([
+        sb.from("customer_orders")
+          .select("id, order_no, status, pickup_store_id, member:members(id, member_no, name, phone), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
+          .in("id", orderIds),
+        allItemIds.length > 0
+          ? sb.from("customer_order_items").select("id, qty, unit_price, status, sku:skus(sku_code, product_name, variant_name)").in("id", allItemIds)
+          : Promise.resolve({ data: [] }),
+      ]);
+      const ordMap = new Map<number, Order>();
+      for (const o of (ords ?? []) as unknown as Order[]) ordMap.set(o.id, o);
+      const itemMap = new Map<number, Item>();
+      for (const i of (itms ?? []) as unknown as Item[]) itemMap.set(i.id, i);
+
+      const result = events.map((ev) => ({
+        event: ev,
+        order: ordMap.get(ev.order_id) as Order,
+        items: (ev.item_ids ?? []).map((id) => itemMap.get(id)).filter((x): x is Item => !!x),
+      }));
+      if (!cancelled) setReceipts(result);
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventIds]);
+
+  // 自動跳列印
+  useEffect(() => {
+    if (receipts && receipts.length > 0) {
+      const t = setTimeout(() => window.print(), 500);
+      return () => clearTimeout(t);
+    }
+  }, [receipts]);
+
+  if (error) return <div className="p-6 text-sm text-red-700">{error}</div>;
+  if (!receipts) return <div className="p-6 text-sm text-zinc-500">載入中…</div>;
+
+  return (
+    <>
+      <style jsx global>{`
+        @media print {
+          @page { margin: 12mm; }
+          body { background: white !important; }
+          .no-print { display: none !important; }
+          .receipt { page-break-after: always; }
+          .receipt:last-child { page-break-after: auto; }
+        }
+      `}</style>
+      <div className="mx-auto max-w-2xl p-6">
+        <div className="no-print mb-4 flex justify-end gap-2">
+          <button onClick={() => window.print()} className="rounded-md bg-zinc-900 px-4 py-2 text-sm text-white hover:bg-zinc-700">🖨️ 列印</button>
+          <button onClick={() => window.close()} className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100">關閉</button>
+        </div>
+        {receipts.map((r) => (
+          <div key={r.event.id} className="receipt mb-8 rounded-md border border-zinc-300 bg-white p-6 text-zinc-900">
+            <div className="mb-4 text-center">
+              <h1 className="text-xl font-bold">取貨單</h1>
+              <div className="text-xs text-zinc-500">
+                {r.event.event_type === "picked_up" ? "全部取貨" : "部分取貨"}
+              </div>
+            </div>
+
+            <div className="mb-4 grid grid-cols-2 gap-2 text-sm">
+              <Field label="訂單號" value={<span className="font-mono">{r.order?.order_no ?? "—"}</span>} />
+              <Field label="取貨時間" value={new Date(r.event.created_at).toLocaleString("zh-TW")} />
+              <Field label="會員" value={r.order?.member ? `${r.order.member.name ?? "—"} (${r.order.member.member_no})` : "—"} />
+              <Field label="電話" value={r.order?.member?.phone ?? "—"} />
+              <Field label="取貨店" value={r.order?.store?.name ?? "—"} />
+              <Field label="開團" value={r.order?.campaign ? `${r.order.campaign.campaign_no} ${r.order.campaign.name}` : "—"} />
+            </div>
+
+            <table className="mb-4 w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b-2 border-zinc-400">
+                  <th className="px-2 py-1 text-left">商品</th>
+                  <th className="px-2 py-1 text-right">數量</th>
+                  <th className="px-2 py-1 text-right">單價</th>
+                  <th className="px-2 py-1 text-right">小計</th>
+                </tr>
+              </thead>
+              <tbody>
+                {r.items.map((it) => {
+                  const sub = Number(it.qty) * Number(it.unit_price);
+                  return (
+                    <tr key={it.id} className="border-b border-zinc-200">
+                      <td className="px-2 py-1">
+                        {it.sku?.variant_name ?? it.sku?.product_name ?? "—"}
+                        {it.sku?.sku_code && <span className="ml-1 font-mono text-[10px] text-zinc-500">{it.sku.sku_code}</span>}
+                      </td>
+                      <td className="px-2 py-1 text-right font-mono">{Number(it.qty)}</td>
+                      <td className="px-2 py-1 text-right font-mono">${Number(it.unit_price)}</td>
+                      <td className="px-2 py-1 text-right font-mono">${sub}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+              <tfoot>
+                <tr className="border-t-2 border-zinc-400 font-bold">
+                  <td colSpan={3} className="px-2 py-2 text-right">合計</td>
+                  <td className="px-2 py-2 text-right font-mono">
+                    ${r.items.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0)}
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+
+            {r.event.notes && (
+              <div className="mb-3 text-xs text-zinc-600">備註：{r.event.notes}</div>
+            )}
+
+            <div className="mt-6 grid grid-cols-2 gap-8 text-xs">
+              <div className="border-t border-zinc-400 pt-2 text-center">顧客簽名</div>
+              <div className="border-t border-zinc-400 pt-2 text-center">店員簽名</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <span className="text-xs text-zinc-500">{label}：</span>
+      <span>{value}</span>
+    </div>
+  );
+}

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { OrderTransferModal } from "@/components/OrderTransferModal";
+import { PickupDialog } from "@/components/PickupDialog";
 
 type OrderHead = {
   id: number;
@@ -66,6 +67,7 @@ export function OrderDetail({
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
   const [transferOpen, setTransferOpen] = useState(false);
+  const [pickupOpen, setPickupOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -127,14 +129,25 @@ export function OrderDetail({
 
   const canTransfer = ["pending", "confirmed", "reserved"].includes(head.status);
   const isTransferredOut = head.status === "transferred_out";
+  const pickableItems = items.filter((it) => ["pending", "reserved", "ready"].includes(it.status));
+  const canPickup = pickableItems.length > 0 && !["completed","expired","cancelled","transferred_out"].includes(head.status);
   const memberLabel = head.member
     ? `${head.member.name ?? "—"} (${head.member.member_no})`
     : `(${head.nickname_snapshot ?? "—"})`;
 
   return (
     <div className="space-y-4 text-sm">
-      {(canTransfer || isTransferredOut) && (
+      {(canTransfer || canPickup || isTransferredOut) && (
         <div className="flex items-center justify-end gap-2">
+          {canPickup && (
+            <button
+              onClick={() => setPickupOpen(true)}
+              className="rounded-md border border-emerald-300 px-3 py-1 text-xs font-medium text-emerald-700 hover:bg-emerald-50 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-950"
+              title="顧客取貨 — 可選哪些 item"
+            >
+              ✅ 確認取貨
+            </button>
+          )}
           {canTransfer && (
             <button
               onClick={() => setTransferOpen(true)}
@@ -242,6 +255,17 @@ export function OrderDetail({
         onSubmitted={(newId) => {
           setTransferOpen(false);
           alert(`訂單已轉出 → 新訂單 #${newId}`);
+          setReloadTick((n) => n + 1);
+        }}
+      />
+      <PickupDialog
+        open={pickupOpen}
+        onClose={() => setPickupOpen(false)}
+        orderId={head.id}
+        orderNo={head.order_no}
+        onPickedUp={(r) => {
+          setPickupOpen(false);
+          alert(`取貨完成 (${r.picked_count} 項)\n訂單狀態：${r.new_order_status}`);
           setReloadTick((n) => n + 1);
         }}
       />

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -76,7 +76,10 @@ export function PickupDialog({
         p_notes: notes || null,
       });
       if (error) { setErr(error.message); return; }
-      onPickedUp(data as { event_id: number; new_order_status: string; picked_count: number; active_remaining: number });
+      const result = data as { event_id: number; new_order_status: string; picked_count: number; active_remaining: number };
+      // 自動開新分頁列印
+      window.open(`/pickup/print?event_ids=${result.event_id}`, "_blank");
+      onPickedUp(result);
     } finally {
       setBusy(false);
     }

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { Modal } from "@/components/Modal";
+
+type PickableItem = {
+  id: number;
+  qty: number;
+  unit_price: number;
+  status: string;
+  sku: { id: number; sku_code: string; product_name: string | null; variant_name: string | null } | null;
+};
+
+export function PickupDialog({
+  open,
+  onClose,
+  orderId,
+  orderNo,
+  onPickedUp,
+}: {
+  open: boolean;
+  onClose: () => void;
+  orderId: number;
+  orderNo: string;
+  onPickedUp: (result: { event_id: number; new_order_status: string; picked_count: number; active_remaining: number }) => void;
+}) {
+  const [items, setItems] = useState<PickableItem[] | null>(null);
+  const [picked, setPicked] = useState<Set<number>>(new Set());
+  const [notes, setNotes] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data, error } = await sb
+        .from("customer_order_items")
+        .select("id, qty, unit_price, status, sku:skus(id, sku_code, product_name, variant_name)")
+        .eq("order_id", orderId)
+        .in("status", ["pending", "reserved", "ready"])
+        .order("id");
+      if (cancelled) return;
+      if (error) { setErr(error.message); return; }
+      const list = (data ?? []) as unknown as PickableItem[];
+      setItems(list);
+      // 預設全選
+      setPicked(new Set(list.map((it) => it.id)));
+    })();
+    return () => { cancelled = true; };
+  }, [open, orderId]);
+
+  function toggle(id: number) {
+    setPicked((s) => {
+      const next = new Set(s);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  async function submit() {
+    if (picked.size === 0) { setErr("至少選一個 item"); return; }
+    setBusy(true);
+    setErr(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) { setErr("尚未登入"); return; }
+      const { data, error } = await sb.rpc("rpc_record_pickup", {
+        p_order_id: orderId,
+        p_item_ids: Array.from(picked),
+        p_operator: operator,
+        p_notes: notes || null,
+      });
+      if (error) { setErr(error.message); return; }
+      onPickedUp(data as { event_id: number; new_order_status: string; picked_count: number; active_remaining: number });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const totalAmount = items
+    ? items.filter((it) => picked.has(it.id)).reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0)
+    : 0;
+
+  return (
+    <Modal open={open} onClose={onClose} title={`✅ 確認取貨 — 訂單 ${orderNo}`} maxWidth="max-w-2xl">
+      {items === null ? (
+        <p className="text-sm text-zinc-500">載入中…</p>
+      ) : items.length === 0 ? (
+        <p className="text-sm text-zinc-500">無可取貨 item（皆已取貨/取消/逾期）。</p>
+      ) : (
+        <div className="space-y-3">
+          <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+            <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+              <thead className="bg-zinc-50 dark:bg-zinc-900">
+                <tr>
+                  <th className="px-3 py-2 text-left text-xs">取</th>
+                  <th className="px-3 py-2 text-left text-xs">商品</th>
+                  <th className="px-3 py-2 text-right text-xs">數量</th>
+                  <th className="px-3 py-2 text-right text-xs">單價</th>
+                  <th className="px-3 py-2 text-right text-xs">小計</th>
+                  <th className="px-3 py-2 text-left text-xs">狀態</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                {items.map((it) => {
+                  const sub = Number(it.qty) * Number(it.unit_price);
+                  return (
+                    <tr key={it.id} className={picked.has(it.id) ? "bg-emerald-50 dark:bg-emerald-950" : ""}>
+                      <td className="px-3 py-2">
+                        <input
+                          type="checkbox"
+                          checked={picked.has(it.id)}
+                          onChange={() => toggle(it.id)}
+                          className="h-4 w-4"
+                        />
+                      </td>
+                      <td className="px-3 py-2">
+                        <span className="font-medium">{it.sku?.variant_name ?? it.sku?.product_name ?? "—"}</span>
+                        {it.sku?.sku_code && (
+                          <span className="ml-2 font-mono text-[10px] text-zinc-400">{it.sku.sku_code}</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono">{Number(it.qty)}</td>
+                      <td className="px-3 py-2 text-right font-mono text-zinc-500">${Number(it.unit_price)}</td>
+                      <td className="px-3 py-2 text-right font-mono">${sub}</td>
+                      <td className="px-3 py-2 text-xs text-zinc-500">{it.status}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+              <tfoot className="bg-zinc-50 dark:bg-zinc-900">
+                <tr>
+                  <td colSpan={4} className="px-3 py-2 text-right text-xs text-zinc-500">取貨小計</td>
+                  <td className="px-3 py-2 text-right font-mono font-semibold">${totalAmount}</td>
+                  <td className="px-3 py-2 text-xs text-zinc-500">{picked.size}/{items.length} 項</td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+
+          <label className="block text-sm">
+            <span className="mb-1 block text-xs text-zinc-500">備註（選填）</span>
+            <input
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="如：客人現金付清"
+              className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </label>
+
+          {err && (
+            <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+              <p className="font-mono text-xs">{err}</p>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={onClose}
+              disabled={busy}
+              className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              取消
+            </button>
+            <button
+              onClick={submit}
+              disabled={busy || picked.size === 0}
+              className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:opacity-50"
+            >
+              {busy ? "處理中…" : `✅ 確認取貨 (${picked.size} 項)`}
+            </button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/supabase/migrations/20260509000008_rpc_record_pickup.sql
+++ b/supabase/migrations/20260509000008_rpc_record_pickup.sql
@@ -1,0 +1,105 @@
+-- ============================================================
+-- Phase 6 — rpc_record_pickup：顧客取貨
+--
+-- 寫 order_pickup_events (append-only) + 改 customer_order_items.status='picked_up'
+-- + 重算 customer_orders.status (completed / partially_completed)
+--
+-- v1 範疇（簡化）：
+--   - 全 item 取貨（每個 item 整筆取走、不支援 partial qty）；要 partial 先 cancel 再分單
+--   - 不寫 stock_movements（既有 reservation/allocate 流程未完整、之後再補）
+--   - allowed source status: pending / reserved / ready (active items)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_record_pickup(
+  p_order_id  BIGINT,
+  p_item_ids  BIGINT[],
+  p_operator  UUID,
+  p_notes     TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_item_id          BIGINT;
+  v_picked_count     INT := 0;
+  v_active_remaining INT;
+  v_new_status       TEXT;
+  v_event_type       TEXT;
+  v_event_id         BIGINT;
+  v_now              TIMESTAMPTZ := NOW();
+BEGIN
+  IF p_item_ids IS NULL OR array_length(p_item_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_item_ids is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_pickup:' || p_order_id::text));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  IF v_order.status IN ('completed','expired','cancelled','transferred_out') THEN
+    RAISE EXCEPTION 'order % status=% cannot pickup', p_order_id, v_order.status;
+  END IF;
+
+  -- 驗每個 item 屬本訂單、且 status 可取
+  FOR v_item_id IN SELECT unnest(p_item_ids) LOOP
+    PERFORM 1 FROM customer_order_items
+      WHERE id = v_item_id
+        AND order_id = p_order_id
+        AND status IN ('pending','reserved','ready')
+      FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'item % not in order % or status not pickable', v_item_id, p_order_id;
+    END IF;
+  END LOOP;
+
+  -- 標記 picked_up
+  UPDATE customer_order_items
+     SET status = 'picked_up',
+         updated_by = p_operator,
+         updated_at = v_now
+   WHERE id = ANY(p_item_ids);
+  GET DIAGNOSTICS v_picked_count = ROW_COUNT;
+
+  -- 重算 order status
+  SELECT COUNT(*) INTO v_active_remaining
+    FROM customer_order_items
+   WHERE order_id = p_order_id
+     AND status IN ('pending','reserved','ready');
+
+  IF v_active_remaining = 0 THEN
+    v_new_status := 'completed';
+    v_event_type := 'picked_up';
+  ELSE
+    v_new_status := 'partially_completed';
+    v_event_type := 'partial_pickup';
+  END IF;
+
+  UPDATE customer_orders
+     SET status = v_new_status,
+         updated_by = p_operator,
+         updated_at = v_now
+   WHERE id = p_order_id;
+
+  -- 寫 event (append-only)
+  INSERT INTO order_pickup_events (
+    tenant_id, order_id, pickup_store_id, event_type, item_ids, notes, created_by
+  ) VALUES (
+    v_order.tenant_id, p_order_id, v_order.pickup_store_id, v_event_type,
+    to_jsonb(p_item_ids), p_notes, p_operator
+  ) RETURNING id INTO v_event_id;
+
+  RETURN jsonb_build_object(
+    'event_id', v_event_id,
+    'event_type', v_event_type,
+    'picked_count', v_picked_count,
+    'active_remaining', v_active_remaining,
+    'new_order_status', v_new_status
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_record_pickup(BIGINT, BIGINT[], UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION rpc_record_pickup IS
+  'Phase 6：顧客取貨；items 改 picked_up、order 改 completed/partially_completed、寫 order_pickup_events';


### PR DESCRIPTION
## Summary

完成 PRD 7.7 取貨流程的 admin 端 UI + RPC。

## Backend

**新 RPC `rpc_record_pickup(order_id, item_ids[], operator, notes?)`**：
- 驗 items 屬本訂單、status ∈ (pending/reserved/ready)
- UPDATE items.status='picked_up'
- UPDATE order.status = completed (全取完) / partially_completed (部分)
- INSERT `order_pickup_events` (append-only)
- v1 簡化：full-item pickup（每 item 整筆取走、partial qty 之後再做）；**不寫 stock_movement**（既有 reservation 流程未完整、stock balance 之後另議）

## UI

**新頁 `/pickup`**：
- 電話後 N 碼（≥3）搜會員 → `members.phone LIKE '%suffix'`
- 找出每個會員的未取訂單（status 在 active 集合）
- 列出可取項數 + 取貨店 + 截止日 + 「✅ 取貨」按鈕

**新元件 `PickupDialog`**：
- 列訂單可取 items + checkbox（預設全選）
- 計算取貨小計
- 備註欄
- 確認 → call rpc_record_pickup → reload

**OrderDetail.tsx**：加「✅ 確認取貨」按鈕（status 在 pending/confirmed/reserved/ready 等可取時顯示），open PickupDialog。

**Sidebar**：「核心業務」加 nav「取貨」（在「訂單」後）。

## Test plan

- [x] migration push dev OK
- [x] build pass、`/pickup` prerendered
- [x] preview `/pickup` h1 + 搜尋輸入 + 按鈕 render OK
- [ ] 電話搜尋實測（待有 dev 資料）
- [ ] PickupDialog 端到端測試 + DB 驗證 (留 user 試)

## 後續

- Partial qty pickup（拆 item row）
- stock_movement 整合（需要先補 reservation 流程）
- 列印 receipt（POS 端整合）
- LINE 通知顧客取貨完成

🤖 Generated with [Claude Code](https://claude.com/claude-code)