### PR TITLE
feat(liff): 顧客端加總覽 / 我的訂單 / 我的結單

### DIFF
--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { consumeFragmentToSession, getSession } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
+import MemberTabBar from "@/components/MemberTabBar";
 
 type MemberData = {
   member_id: number;
@@ -88,17 +89,23 @@ export default function MePage() {
 
   if (loading) {
     return (
-      <main className="mx-auto max-w-md p-6 pt-16 text-center">
-        <p className="text-sm text-zinc-500">載入中…</p>
+      <main className="mx-auto w-full max-w-md">
+        <MemberTabBar />
+        <div className="p-6 pt-16 text-center">
+          <p className="text-sm text-zinc-500">載入中…</p>
+        </div>
       </main>
     );
   }
 
   if (!me) {
     return (
-      <main className="mx-auto max-w-md p-6 pt-16 text-center">
-        <p className="text-sm text-zinc-500">{error ?? "尚未登入，請回首頁。"}</p>
-        <a href="/" className="mt-4 inline-block text-sm text-blue-600 hover:underline">回首頁</a>
+      <main className="mx-auto w-full max-w-md">
+        <MemberTabBar />
+        <div className="p-6 pt-16 text-center">
+          <p className="text-sm text-zinc-500">{error ?? "尚未登入，請回首頁。"}</p>
+          <a href="/" className="mt-4 inline-block text-sm text-blue-600 hover:underline">回首頁</a>
+        </div>
       </main>
     );
   }
@@ -107,7 +114,9 @@ export default function MePage() {
   const displayName = me.name ?? lineName ?? "(未提供)";
 
   return (
-    <main className="mx-auto flex w-full max-w-md flex-col gap-5 p-6 pt-10">
+    <main className="mx-auto w-full max-w-md">
+      <MemberTabBar />
+      <div className="flex flex-col gap-5 p-6 pt-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">會員中心</h1>
         {!editing && (
@@ -250,6 +259,7 @@ export default function MePage() {
       <p className="text-xs text-zinc-400">
         會員卡 QR、點數、訂單等功能尚未上線（MVP-1 開發中）。
       </p>
+      </div>
     </main>
   );
 }

--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { consumeFragmentToSession, getSession } from "@/lib/session";
+import { callLiffApi } from "@/lib/supabase";
+import MemberTabBar from "@/components/MemberTabBar";
+import SubTabs from "@/components/SubTabs";
+import OrderCard, { type OrderRow } from "@/components/OrderCard";
+
+type Tab = "active" | "history";
+
+export default function OrdersPage() {
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>("active");
+  const [orders, setOrders] = useState<OrderRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    consumeFragmentToSession();
+    const s = getSession();
+    if (!s || !s.memberId) {
+      router.replace("/");
+      return;
+    }
+    (async () => {
+      setLoading(true);
+      setErr(null);
+      try {
+        const d = await callLiffApi<{ orders: OrderRow[] }>(s.token, {
+          action: "list_my_orders",
+          tab,
+        });
+        setOrders(d.orders);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [tab, router]);
+
+  return (
+    <main className="mx-auto w-full max-w-md">
+      <MemberTabBar />
+      <SubTabs
+        value={tab}
+        onChange={(v) => setTab(v as Tab)}
+        options={[
+          { value: "active",  label: "未完成" },
+          { value: "history", label: "訂單紀錄" },
+        ]}
+      />
+
+      <div className="space-y-3 p-4">
+        {loading && <p className="text-sm text-zinc-400">載入中…</p>}
+
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+            {err}
+          </div>
+        )}
+
+        {!loading && !err && orders.length === 0 && (
+          <p className="py-12 text-center text-sm text-zinc-400">
+            目前沒有{tab === "active" ? "未完成" : "已完成"}訂單
+          </p>
+        )}
+
+        {orders.map((o) => (
+          <OrderCard key={o.id} order={o} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/member/src/app/overview/page.tsx
+++ b/apps/member/src/app/overview/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { consumeFragmentToSession, getSession } from "@/lib/session";
+import { callLiffApi } from "@/lib/supabase";
+import MemberTabBar from "@/components/MemberTabBar";
+
+type Overview = {
+  store: {
+    id: number;
+    code: string;
+    name: string;
+    banner_url: string | null;
+    description: string | null;
+    payment_methods_text: string | null;
+    shipping_methods_text: string | null;
+  };
+  receivable_amount: number;
+  active_orders_count: number;
+};
+
+export default function OverviewPage() {
+  const router = useRouter();
+  const [data, setData] = useState<Overview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    consumeFragmentToSession();
+    const s = getSession();
+    if (!s || !s.memberId) {
+      router.replace("/");
+      return;
+    }
+    (async () => {
+      try {
+        const d = await callLiffApi<Overview>(s.token, { action: "get_overview" });
+        setData(d);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [router]);
+
+  return (
+    <main className="mx-auto w-full max-w-md">
+      <MemberTabBar />
+
+      <div className="space-y-4 p-4">
+        {loading && <p className="text-sm text-zinc-400">載入中…</p>}
+
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+            {err}
+          </div>
+        )}
+
+        {data && (
+          <>
+            {data.store.banner_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={data.store.banner_url}
+                alt=""
+                className="h-40 w-full rounded-md object-cover"
+              />
+            ) : (
+              <div className="flex h-32 items-center justify-center rounded-md bg-pink-100 text-pink-700">
+                <span className="text-lg font-medium">{data.store.name}</span>
+              </div>
+            )}
+
+            <h1 className="text-xl font-semibold text-pink-600">{data.store.name}</h1>
+
+            {data.store.description && (
+              <section>
+                <h2 className="text-sm font-medium text-pink-600">📢 賣場介紹</h2>
+                <p className="mt-1 whitespace-pre-wrap text-sm text-zinc-600">
+                  {data.store.description}
+                </p>
+              </section>
+            )}
+
+            {(data.store.payment_methods_text || data.store.shipping_methods_text) && (
+              <section>
+                <h2 className="text-sm font-medium text-pink-600">🛒 付款、出貨方式</h2>
+                {data.store.payment_methods_text && (
+                  <p className="mt-1 whitespace-pre-wrap text-sm text-zinc-600">
+                    {data.store.payment_methods_text}
+                  </p>
+                )}
+                {data.store.shipping_methods_text && (
+                  <p className="mt-1 whitespace-pre-wrap text-sm text-zinc-600">
+                    {data.store.shipping_methods_text}
+                  </p>
+                )}
+              </section>
+            )}
+
+            <section>
+              <h2 className="text-sm text-pink-600">未結單金額</h2>
+              <div className="mt-2 rounded-md border border-pink-100 bg-white p-6 text-center">
+                <span className="text-2xl font-semibold text-pink-600">
+                  {Number(data.receivable_amount).toLocaleString()}元
+                </span>
+              </div>
+            </section>
+
+            {data.active_orders_count > 0 && (
+              <button
+                onClick={() => router.push("/orders")}
+                className="w-full rounded-md border border-pink-200 bg-pink-50 p-3 text-sm text-pink-700 hover:bg-pink-100"
+              >
+                你有 {data.active_orders_count} 筆進行中訂單 →
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/member/src/app/settlements/page.tsx
+++ b/apps/member/src/app/settlements/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { consumeFragmentToSession, getSession } from "@/lib/session";
+import { callLiffApi } from "@/lib/supabase";
+import MemberTabBar from "@/components/MemberTabBar";
+import SubTabs from "@/components/SubTabs";
+import SettlementCard, { type SettlementRow } from "@/components/SettlementCard";
+
+type Tab = "unpaid" | "shipped";
+
+export default function SettlementsPage() {
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>("unpaid");
+  const [list, setList] = useState<SettlementRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    consumeFragmentToSession();
+    const s = getSession();
+    if (!s || !s.memberId) {
+      router.replace("/");
+      return;
+    }
+    (async () => {
+      setLoading(true);
+      setErr(null);
+      try {
+        const d = await callLiffApi<{ settlements: SettlementRow[] }>(s.token, {
+          action: "list_my_settlements",
+          tab,
+        });
+        setList(d.settlements);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [tab, router]);
+
+  return (
+    <main className="mx-auto w-full max-w-md">
+      <MemberTabBar />
+      <SubTabs
+        value={tab}
+        onChange={(v) => setTab(v as Tab)}
+        options={[
+          { value: "unpaid",  label: "待付款" },
+          { value: "shipped", label: "已寄出" },
+        ]}
+      />
+
+      <div className="space-y-3 p-4">
+        {loading && <p className="text-sm text-zinc-400">載入中…</p>}
+
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+            {err}
+          </div>
+        )}
+
+        {!loading && !err && list.length === 0 && (
+          <p className="py-12 text-center text-sm text-zinc-400">
+            目前沒有{tab === "unpaid" ? "待付款" : "已寄出"}結單
+          </p>
+        )}
+
+        {list.map((s) => (
+          <SettlementCard key={s.id} settlement={s} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/member/src/components/MemberTabBar.tsx
+++ b/apps/member/src/components/MemberTabBar.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const tabs = [
+  { href: "/overview",    label: "總覽" },
+  { href: "/orders",      label: "我的訂單" },
+  { href: "/settlements", label: "我的結單" },
+  { href: "/me",          label: "我" },
+];
+
+export default function MemberTabBar() {
+  const pathname = usePathname() ?? "";
+  return (
+    <nav className="flex border-b border-zinc-200 bg-white">
+      {tabs.map((t) => {
+        const active = pathname.startsWith(t.href);
+        return (
+          <Link
+            key={t.href}
+            href={t.href}
+            className={`relative flex-1 px-2 py-3 text-center text-sm transition-colors ${
+              active
+                ? "font-medium text-pink-600"
+                : "text-zinc-500 hover:text-zinc-700"
+            }`}
+          >
+            {t.label}
+            {active && (
+              <span className="absolute inset-x-3 bottom-0 h-0.5 bg-pink-600" />
+            )}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -1,0 +1,56 @@
+import StatusChip from "./StatusChip";
+
+export type OrderRow = {
+  id: number;
+  order_no: string;
+  pickup_deadline: string | null;
+  payable_amount: number;
+  arrived: boolean;
+  settled: boolean;
+  paid: boolean;
+  shipped: boolean;
+  items: Array<{ qty: number; unit_price: number; status: string }>;
+  notes: string | null;
+};
+
+export default function OrderCard({
+  order,
+  campaignName,
+}: {
+  order: OrderRow;
+  campaignName?: string;
+}) {
+  const totalQty = order.items.reduce((s, i) => s + Number(i.qty ?? 0), 0);
+
+  return (
+    <article className="rounded-md border border-pink-100 bg-white p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1">
+          <h3 className="text-sm font-medium text-zinc-900">
+            {campaignName ?? `訂單 ${order.order_no}`}
+          </h3>
+          <p className="mt-0.5 text-xs text-zinc-400">
+            {order.pickup_deadline ? `截止 ${order.pickup_deadline}・` : ""}共 {totalQty} 件
+          </p>
+        </div>
+        <div className="text-right">
+          <div className="text-xs text-zinc-400">總金額</div>
+          <div className="text-base font-semibold text-pink-600">
+            {Number(order.payable_amount).toLocaleString()}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        <StatusChip tone={order.arrived ? "ok" : "muted"} label={order.arrived ? "全到" : "未到"} />
+        <StatusChip tone={order.settled ? "ok" : "muted"} label={order.settled ? "全結" : "未結"} />
+        <StatusChip tone={order.paid    ? "ok" : "muted"} label={order.paid    ? "已付" : "未付"} />
+        <StatusChip tone={order.shipped ? "ok" : "muted"} label={order.shipped ? "已寄" : "未寄"} />
+      </div>
+
+      {order.notes && (
+        <p className="mt-2 text-xs text-zinc-500">📝 {order.notes}</p>
+      )}
+    </article>
+  );
+}

--- a/apps/member/src/components/SettlementCard.tsx
+++ b/apps/member/src/components/SettlementCard.tsx
@@ -1,0 +1,88 @@
+export type SettlementRow = {
+  id: number;
+  settlement_no: string;
+  status: string;
+  payment_status: string;
+  payment_method: string | null;
+  paid_at: string | null;
+  remit_amount: number;
+  remit_at: string | null;
+  remit_note: string | null;
+  shipping_method: string | null;
+  shipping_address: string | null;
+  shipping_phone: string | null;
+  shipping_note: string | null;
+  items_total: number;
+  shipping_fee: number;
+  discount_amount: number;
+  payable_amount: number;
+};
+
+function fmtAmount(n: number): string {
+  return Number(n ?? 0).toLocaleString();
+}
+
+export default function SettlementCard({ settlement: s }: { settlement: SettlementRow }) {
+  const paymentLabel  = s.payment_status === "paid" ? "已付款" : "未付款";
+  const shippingLabel = ["shipping", "completed"].includes(s.status) ? "已出貨" : "未出貨";
+
+  return (
+    <article className="overflow-hidden rounded-md border border-pink-100 bg-white shadow-sm">
+      <div className="border-b border-pink-100 bg-pink-50 px-4 py-2">
+        <span className="text-xs font-medium text-pink-700"># 結單編號 </span>
+        <span className="font-mono text-xs text-pink-700">{s.settlement_no}</span>
+      </div>
+
+      <div className="space-y-3 px-4 py-3 text-sm">
+        <div>
+          <span className="text-zinc-500">狀態：</span>
+          <span className="text-pink-600">{paymentLabel}</span>
+          <span className="mx-1 text-zinc-300">/</span>
+          <span className="text-pink-600">{shippingLabel}</span>
+        </div>
+
+        <div>
+          <div className="text-pink-600">💳 付款方式</div>
+          <div className="text-zinc-700">{s.payment_method ?? "-"}</div>
+          <div className="text-xs text-zinc-500">匯款金額：{fmtAmount(s.remit_amount)} 元</div>
+          <div className="text-xs text-zinc-500">匯款時間：{s.remit_at ?? "-"}</div>
+          <div className="text-xs text-zinc-500">匯款備註：{s.remit_note ?? "-"}</div>
+          {s.payment_status !== "paid" && (
+            <div className="mt-1 text-base font-semibold text-zinc-900">未付款</div>
+          )}
+        </div>
+
+        <div>
+          <div className="text-pink-600">🚚 出貨方式</div>
+          <div className="text-zinc-700">{s.shipping_method ?? "-"}</div>
+          <div className="text-xs text-zinc-500">{s.shipping_phone ?? "未填寫電話"}</div>
+          {s.shipping_address && (
+            <div className="text-xs text-zinc-500">{s.shipping_address}</div>
+          )}
+          <div className="text-xs text-zinc-500">{s.shipping_note ?? "未填寫備註"}</div>
+        </div>
+
+        <div className="space-y-1 border-t border-zinc-100 pt-3">
+          <div className="flex justify-between text-xs text-zinc-500">
+            <span>總金額</span>
+            <span>{fmtAmount(s.items_total)}</span>
+          </div>
+          <div className="flex justify-between text-xs text-zinc-500">
+            <span>運費</span>
+            <span>{fmtAmount(s.shipping_fee)}</span>
+          </div>
+          <div className="flex justify-between text-xs text-zinc-500">
+            <span>促銷活動</span>
+            <span>
+              {s.discount_amount > 0 ? `-${fmtAmount(s.discount_amount)}` : "0.00"}
+            </span>
+          </div>
+          <div className="flex justify-between border-t border-zinc-100 pt-1 text-base font-semibold text-pink-600">
+            <span>應付金額</span>
+            <span>{fmtAmount(s.payable_amount)}</span>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/apps/member/src/components/StatusChip.tsx
+++ b/apps/member/src/components/StatusChip.tsx
@@ -1,0 +1,22 @@
+type Tone = "ok" | "muted";
+
+export default function StatusChip({
+  tone,
+  label,
+}: {
+  tone: Tone;
+  label: string;
+}) {
+  if (tone === "ok") {
+    return (
+      <span className="inline-flex items-center gap-0.5 rounded-full bg-pink-100 px-2 py-0.5 text-xs font-medium text-pink-700">
+        ✓ {label}
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-0.5 rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-500">
+      ! {label}
+    </span>
+  );
+}

--- a/apps/member/src/components/SubTabs.tsx
+++ b/apps/member/src/components/SubTabs.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+type Option = { value: string; label: string; count?: number };
+
+export default function SubTabs({
+  value,
+  onChange,
+  options,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: Option[];
+}) {
+  return (
+    <div className="flex gap-2 border-b border-zinc-200 px-2">
+      {options.map((o) => {
+        const active = value === o.value;
+        return (
+          <button
+            key={o.value}
+            onClick={() => onChange(o.value)}
+            className={`relative px-3 py-2.5 text-sm transition-colors ${
+              active
+                ? "font-medium text-pink-600"
+                : "text-zinc-500 hover:text-zinc-700"
+            }`}
+          >
+            {o.label}
+            {o.count !== undefined && (
+              <span className="ml-1 text-xs text-zinc-400">({o.count})</span>
+            )}
+            {active && (
+              <span className="absolute inset-x-3 -bottom-px h-0.5 bg-pink-600" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/docs/TEST-LIFF-overview-orders-settlements.md
+++ b/docs/TEST-LIFF-overview-orders-settlements.md
@@ -1,0 +1,132 @@
+# TEST — LIFF 顧客端：總覽 / 我的訂單 / 我的結單
+
+## 目標
+驗證 `apps/member/` 三個顧客可見頁面 + 對應 `liff-api` Edge Function actions + supporting schema 全鏈路正確。
+
+## 前置條件
+- Migrations 已 apply：
+  - `stores_liff_overview_columns.sql`（5 個 column）
+  - `customer_orders_payment_shipping_columns.sql`（12 個 column）
+  - `v_customer_order_summary.sql`
+- Edge Function `liff-api` 已部署（含 3 個新 case：`get_overview` / `list_my_orders` / `list_my_settlements`）
+- 測試 tenant_id / store_id / member_id / 對應 LIFF JWT 已知（test fixture 在 `apps/admin/.env.local`）
+- 至少 1 筆 customer_orders（含 order_items）對該 member 存在，狀態橫跨 pending / shipping / completed
+- 至少 2 個 store 的訂單同時存在（驗跨店隔離）
+
+---
+
+## T1 — Schema 欄位存在確認
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T1-1 | `\d stores` | 含 `banner_url TEXT`, `description TEXT`, `payment_methods_text TEXT`, `shipping_methods_text TEXT`, `store_short_code TEXT` |
+| T1-2 | `\d customer_orders` | 含 `payment_method`, `payment_status` (NOT NULL DEFAULT 'unpaid' CHECK), `paid_at`, `remit_amount`, `remit_at`, `remit_note`, `shipping_method`, `shipping_address`, `shipping_phone`, `shipping_note`, `shipping_fee`, `discount_amount` |
+| T1-3 | `SELECT payment_status, count(*) FROM customer_orders GROUP BY 1` | 全部 = `'unpaid'`（既有資料 backfill） |
+| T1-4 | `SELECT store_short_code, count(*) FROM stores GROUP BY 1` | 每筆都有值（migration 內 backfill 為 `upper(left(code,2))`） |
+
+## T2 — v_customer_order_summary view
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T2-1 | `SELECT * FROM v_customer_order_summary LIMIT 1` | 不報錯，欄位含：id, order_no, member_id, store_id, status, payment_status, items_total, payable_amount, all_arrived, all_completed, settlement_no, items |
+| T2-2 | 挑 1 筆已知訂單，比對 `payable_amount = items_total + shipping_fee - discount_amount` | 數字相符 |
+| T2-3 | 挑 1 筆所有 items.status = 'picked_up' 的訂單 | `all_arrived=true`, `all_completed=true` |
+| T2-4 | 挑 1 筆所有 items.status = 'pending' 的訂單 | `all_arrived=false`, `all_completed=false` |
+| T2-5 | settlement_no 格式 | `S-<8位數字>-<2字大寫>`，例：`S-00000123-SK` |
+
+## T3 — Edge Function `get_overview`
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T3-1 | `curl POST /functions/v1/liff-api { action: "get_overview" }` 用會員 A、A 店 token | 200，回 `{store: {...}, receivable_amount, active_orders_count}` |
+| T3-2 | T3-1 回應的 store.id | = JWT 中的 store_id |
+| T3-3 | T3-1 回應的 store 必含欄位 | id, code, name, banner_url, description, payment_methods_text, shipping_methods_text |
+| T3-4 | T3-1 回應的 receivable_amount | = SUM(payable_amount) WHERE payment_status='unpaid' AND status NOT IN ('cancelled','expired') for that member+store |
+| T3-5 | active_orders_count | = COUNT(*) WHERE status NOT IN ('completed','cancelled','expired') |
+| T3-6 | 不帶 Authorization | 401 missing authorization |
+| T3-7 | 帶過期 / 偽造 JWT | 401 invalid token |
+
+## T4 — Edge Function `list_my_orders`
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T4-1 | `{ action: "list_my_orders", tab: "active" }` | 200，`{orders: [...]}` 含未完成訂單 |
+| T4-2 | T4-1 中 orders 的 status | 全部 NOT IN ('completed','cancelled','expired') |
+| T4-3 | `{ action: "list_my_orders", tab: "history" }` | 200，全部 status='completed' |
+| T4-4 | 不傳 tab 或 tab 為其他值 | 400 invalid tab |
+| T4-5 | 訂單列表過濾 6 個月 | created_at >= NOW() - INTERVAL '6 months' |
+| T4-6 | ORDER BY created_at DESC | 第一筆是最新訂單 |
+| T4-7 | 跨店隔離：A 店 token 看 B 店 member 的訂單 | 不會出現（store_id 過濾） |
+| T4-8 | 訂單 items 結構 | 每筆訂單帶 items array（含 sku_id, qty, unit_price, status） |
+
+## T5 — Edge Function `list_my_settlements`
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T5-1 | `{ action: "list_my_settlements", tab: "unpaid" }` | 200，`{settlements: [...]}` 全部 payment_status='unpaid' |
+| T5-2 | `{ action: "list_my_settlements", tab: "shipped" }` | 200，全部 status IN ('shipping','completed') |
+| T5-3 | settlement 結構含 settlement_no | 格式 `S-xxxxxxxx-XX` |
+| T5-4 | 金額分解欄位 | items_total, shipping_fee, discount_amount, payable_amount 全部存在 |
+| T5-5 | 跨店隔離 | 同 T4-7 |
+| T5-6 | 付款資訊欄位 | payment_method, paid_at, remit_amount, remit_at, remit_note 在 unpaid tab 可為 null/0 |
+| T5-7 | 出貨資訊欄位 | shipping_method, shipping_address, shipping_phone, shipping_note 在卡片內可顯示 |
+
+## T6 — UI: /overview 頁
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T6-1 | 未登入直接訪問 /overview | redirect 回 / |
+| T6-2 | 已登入訪問 | 載入後顯示店名、店家描述（若有）、付款方式、出貨方式、未結金額大字塊、進行中訂單 chip |
+| T6-3 | banner_url 為空 | fallback 顯示純色背景 + 店名（不破版） |
+| T6-4 | receivable_amount = 0 | 顯示「0 元」不出錯 |
+| T6-5 | 點擊「進行中訂單 (N)」chip | 跳到 /orders 並停在 active sub-tab |
+| T6-6 | 頂部 TabBar 含 4 個 tab | 總覽 / 我的訂單 / 我的結單 / 我，當前 tab 高亮 |
+
+## T7 — UI: /orders 頁
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T7-1 | 預設停在「未完成」sub-tab | 顯示 active 訂單 |
+| T7-2 | 切換到「訂單紀錄」sub-tab | 顯示 history 訂單 |
+| T7-3 | sub-tab 切換重新打 list_my_orders | 看 network panel 確認 |
+| T7-4 | 訂單卡片內容 | 商品名 + 截止日 + 數量 + 金額 + 狀態 chips |
+| T7-5 | 狀態 chips 邏輯 | items 全部 picked_up → 「全到 全結」；否則 「!未到 !未結 !未付 !未寄」（依 all_arrived / all_completed / payment_status / status 判斷） |
+| T7-6 | empty state（無訂單） | 顯示「目前沒有未完成訂單」/「目前沒有已完成訂單」 |
+| T7-7 | API 失敗 | 顯示錯誤 banner，不破版 |
+
+## T8 — UI: /settlements 頁
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T8-1 | 預設停在「待付款」sub-tab | 顯示 unpaid 結單 |
+| T8-2 | 切換到「已寄出」sub-tab | 顯示 shipping/completed 結單 |
+| T8-3 | 結單卡片頂部 | 顯示 `# 結單編號 S-xxxxxxxx-XX` 字樣 |
+| T8-4 | 卡片狀態列 | 「未付款 / 未出貨」或「已付款 / 已寄出」依資料 |
+| T8-5 | 付款方式區 | payment_method, 匯款金額 (remit_amount), 匯款時間 (remit_at), 匯款備註 (remit_note) — 缺值顯示 "-" 或 "0" |
+| T8-6 | 出貨方式區 | shipping_method + 收件人/電話/備註（從 shipping_address/phone/note） |
+| T8-7 | 金額分解 | 總金額 / 運費 / 促銷活動 / 應付金額 4 列數字 |
+| T8-8 | empty state | 顯示「目前沒有待付款結單」/「目前沒有已寄出結單」 |
+
+## T9 — 跨店隔離 / 安全
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T9-1 | 偽造 JWT 把 store_id 改成另一店 | Edge Function 驗 JWT 簽章失敗 → 401 |
+| T9-2 | 用 A 店合法 token 跑三個 action | 結果只含 pickup_store_id = A 的資料 |
+| T9-3 | 用未綁會員 token（無 member_id）跑 list_my_orders | 401 no member_id in token |
+
+## T10 — 已知限制（不在本次 scope）
+
+| # | 項目 | 說明 |
+|---|------|------|
+| T10-1 | admin 端寫入新欄位 UI | payment_status / shipping_* / remit_* 等 12 個新欄位的 admin 編輯 UI 留 P1 |
+| T10-2 | 「個人賣場」/「我的發票」tab | 留 P1，不在本次實作 |
+| T10-3 | 結單合併（多 order → 1 settlement） | 結單 1:1 從 order 衍生，未來真合併再升級 |
+| T10-4 | 訂單 / 結單分頁 | v1 限制最近 6 個月，無分頁 UI |
+
+---
+
+## 通過條件
+- T1~T9 全部 pass
+- T10 條目於最終 PR description 標明為「已知限制」
+- 所有 SQL / API / UI 證據（query result, curl response, screenshot）保留於 `docs/TEST-LIFF-overview-orders-settlements-report.md`

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -78,6 +78,15 @@ Deno.serve(async (req) => {
           birthday: body.birthday as string | undefined,
           email:    body.email    as string | undefined,
         });
+      case "get_overview":
+        if (!memberId) return json({ error: "no member_id in token" }, 401);
+        return await getOverview(sb, tenantId, storeId, memberId);
+      case "list_my_orders":
+        if (!memberId) return json({ error: "no member_id in token" }, 401);
+        return await listMyOrders(sb, tenantId, storeId, memberId, String(body.tab ?? ""));
+      case "list_my_settlements":
+        if (!memberId) return json({ error: "no member_id in token" }, 401);
+        return await listMySettlements(sb, tenantId, storeId, memberId, String(body.tab ?? ""));
       default:
         return json({ error: `unknown action: ${action}` }, 400);
     }
@@ -363,6 +372,131 @@ async function updateMe(
 
   if (error) return json({ error: error.message }, 500);
   return json({ ok: true });
+}
+
+// ─── overview / orders / settlements ────────────────────────────────────────
+
+async function getOverview(
+  sb: ReturnType<typeof createClient>,
+  tenantId: string,
+  storeId: number,
+  memberId: number,
+) {
+  // store info
+  const { data: storeRow, error: sErr } = await sb
+    .from("stores")
+    .select("id, code, name, banner_url, description, payment_methods_text, shipping_methods_text")
+    .eq("tenant_id", tenantId)
+    .eq("id", storeId)
+    .single();
+  if (sErr || !storeRow) {
+    return json({ error: "store not found", detail: sErr?.message }, 404);
+  }
+
+  // 未結金額（payment_status='unpaid' AND status NOT IN cancelled/expired）
+  const { data: unpaidRows, error: uErr } = await sb
+    .from("v_customer_order_summary")
+    .select("payable_amount")
+    .eq("tenant_id", tenantId)
+    .eq("member_id", memberId)
+    .eq("store_id", storeId)
+    .eq("payment_status", "unpaid")
+    .not("status", "in", "(cancelled,expired)");
+  if (uErr) return json({ error: "receivable query failed", detail: uErr.message }, 500);
+
+  const receivable = (unpaidRows ?? []).reduce(
+    (s, r) => s + Number((r as { payable_amount: number }).payable_amount ?? 0),
+    0,
+  );
+
+  // 進行中訂單數（status NOT IN completed/cancelled/expired）
+  const { count: activeCount, error: aErr } = await sb
+    .from("v_customer_order_summary")
+    .select("*", { count: "exact", head: true })
+    .eq("tenant_id", tenantId)
+    .eq("member_id", memberId)
+    .eq("store_id", storeId)
+    .not("status", "in", "(completed,cancelled,expired)");
+  if (aErr) return json({ error: "active count failed", detail: aErr.message }, 500);
+
+  return json({
+    store: storeRow,
+    receivable_amount:   receivable,
+    active_orders_count: activeCount ?? 0,
+  });
+}
+
+async function listMyOrders(
+  sb: ReturnType<typeof createClient>,
+  tenantId: string,
+  storeId: number,
+  memberId: number,
+  tab: string,
+) {
+  if (tab !== "active" && tab !== "history") {
+    return json({ error: "tab must be 'active' or 'history'" }, 400);
+  }
+
+  // 6 個月內（PRD-LIFF前端 Q8）
+  const cutoff = new Date();
+  cutoff.setMonth(cutoff.getMonth() - 6);
+
+  let q = sb
+    .from("v_customer_order_summary")
+    .select("*")
+    .eq("tenant_id", tenantId)
+    .eq("member_id", memberId)
+    .eq("store_id", storeId)
+    .gte("created_at", cutoff.toISOString())
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  if (tab === "active") {
+    q = q.not("status", "in", "(completed,cancelled,expired)");
+  } else {
+    q = q.eq("status", "completed");
+  }
+
+  const { data, error } = await q;
+  if (error) return json({ error: error.message }, 500);
+
+  return json({ orders: data ?? [] });
+}
+
+async function listMySettlements(
+  sb: ReturnType<typeof createClient>,
+  tenantId: string,
+  storeId: number,
+  memberId: number,
+  tab: string,
+) {
+  if (tab !== "unpaid" && tab !== "shipped") {
+    return json({ error: "tab must be 'unpaid' or 'shipped'" }, 400);
+  }
+
+  const cutoff = new Date();
+  cutoff.setMonth(cutoff.getMonth() - 6);
+
+  let q = sb
+    .from("v_customer_order_summary")
+    .select("*")
+    .eq("tenant_id", tenantId)
+    .eq("member_id", memberId)
+    .eq("store_id", storeId)
+    .gte("created_at", cutoff.toISOString())
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  if (tab === "unpaid") {
+    q = q.eq("payment_status", "unpaid").not("status", "in", "(cancelled,expired)");
+  } else {
+    q = q.in("status", ["shipping", "completed"]);
+  }
+
+  const { data, error } = await q;
+  if (error) return json({ error: error.message }, 500);
+
+  return json({ settlements: data ?? [] });
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────

--- a/supabase/migrations/20260429160000_stores_liff_overview_columns.sql
+++ b/supabase/migrations/20260429160000_stores_liff_overview_columns.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- stores: 加 LIFF 顧客端「總覽」頁所需的 5 個顯示欄位
+--
+-- 與既有 allowed_payment_methods (JSONB) 並存：
+--   - allowed_payment_methods 是程式判斷用的 enum 陣列
+--   - payment_methods_text / shipping_methods_text 是顯示給顧客看的文字
+--
+-- store_short_code：用於顧客端結單號尾碼（例：S-00000123-SK 中的 SK）
+--   backfill = upper(left(code, 2))
+-- ============================================================
+
+ALTER TABLE stores
+  ADD COLUMN banner_url            TEXT,
+  ADD COLUMN description           TEXT,
+  ADD COLUMN payment_methods_text  TEXT,
+  ADD COLUMN shipping_methods_text TEXT,
+  ADD COLUMN store_short_code      TEXT;
+
+COMMENT ON COLUMN stores.banner_url            IS 'LIFF 總覽頁 banner 圖 URL';
+COMMENT ON COLUMN stores.description           IS 'LIFF 總覽頁「賣場介紹」純文字';
+COMMENT ON COLUMN stores.payment_methods_text  IS 'LIFF 總覽頁顯示用付款方式文字';
+COMMENT ON COLUMN stores.shipping_methods_text IS 'LIFF 總覽頁顯示用出貨方式文字';
+COMMENT ON COLUMN stores.store_short_code      IS '結單號尾碼（2 字大寫），例：SK';
+
+-- backfill：既有 store 用 code 前 2 字大寫
+UPDATE stores
+   SET store_short_code = upper(left(code, 2))
+ WHERE store_short_code IS NULL;

--- a/supabase/migrations/20260429160001_customer_orders_payment_shipping_columns.sql
+++ b/supabase/migrations/20260429160001_customer_orders_payment_shipping_columns.sql
@@ -1,0 +1,39 @@
+-- ============================================================
+-- customer_orders: 加 LIFF 顧客端「我的結單」頁所需的付款 / 出貨 / 金額欄位
+--
+-- 不另開 shipping_status：出貨狀態用既有 customer_orders.status 派生
+--   shipping / completed → 已寄出
+--   其他                 → 未寄出
+--
+-- payment_status 是新維度，與 status 平行（一筆訂單同時有 status 與 payment_status）
+-- ============================================================
+
+ALTER TABLE customer_orders
+  ADD COLUMN payment_method   TEXT,
+  ADD COLUMN payment_status   TEXT NOT NULL DEFAULT 'unpaid'
+    CHECK (payment_status IN ('unpaid', 'paid')),
+  ADD COLUMN paid_at          TIMESTAMPTZ,
+  ADD COLUMN remit_amount     NUMERIC(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN remit_at         TIMESTAMPTZ,
+  ADD COLUMN remit_note       TEXT,
+  ADD COLUMN shipping_method  TEXT,
+  ADD COLUMN shipping_address TEXT,
+  ADD COLUMN shipping_phone   TEXT,
+  ADD COLUMN shipping_note    TEXT,
+  ADD COLUMN shipping_fee     NUMERIC(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN discount_amount  NUMERIC(18,2) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN customer_orders.payment_method   IS '付款方式（顧客可見）：貨到付款 / 匯款 / 信用卡 等';
+COMMENT ON COLUMN customer_orders.payment_status   IS '付款狀態：unpaid / paid（與 status 平行）';
+COMMENT ON COLUMN customer_orders.paid_at          IS '付款完成時點';
+COMMENT ON COLUMN customer_orders.remit_amount     IS '匯款金額（顧客匯款備案）';
+COMMENT ON COLUMN customer_orders.remit_at         IS '匯款時間';
+COMMENT ON COLUMN customer_orders.remit_note       IS '匯款備註（後 5 碼等）';
+COMMENT ON COLUMN customer_orders.shipping_method  IS '出貨方式：面交 / 宅配 / 自取';
+COMMENT ON COLUMN customer_orders.shipping_address IS '收件地址（宅配用）';
+COMMENT ON COLUMN customer_orders.shipping_phone   IS '收件人電話';
+COMMENT ON COLUMN customer_orders.shipping_note    IS '出貨備註';
+COMMENT ON COLUMN customer_orders.shipping_fee     IS '運費（含於應付）';
+COMMENT ON COLUMN customer_orders.discount_amount  IS '折扣金額（從應付扣除）';
+
+CREATE INDEX idx_corders_payment_status ON customer_orders (member_id, payment_status, status);

--- a/supabase/migrations/20260429160002_v_customer_order_summary.sql
+++ b/supabase/migrations/20260429160002_v_customer_order_summary.sql
@@ -1,0 +1,87 @@
+-- ============================================================
+-- v_customer_order_summary
+--   LIFF 顧客端「我的訂單 / 我的結單」共用 view
+--
+-- 提供：
+--   - 聚合金額（items_total / payable_amount）
+--   - items JSONB 陣列（避免 N+1 query）
+--   - 4 個狀態 chips boolean：arrived / settled / paid / shipped
+--   - 結單衍生欄位 settlement_no（S-xxxxxxxx-XX）
+--   - store_name / store_code（顯示用）
+--
+-- 由 service_role（Edge Function liff-api）讀，view 不需獨立 RLS；
+-- 呼叫端負責 member_id + store_id filter。
+-- ============================================================
+
+CREATE OR REPLACE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  -- 聚合金額 + items
+  agg.items_total,
+  agg.items_total + co.shipping_fee - co.discount_amount   AS payable_amount,
+  agg.items,
+  -- 狀態 chips（4 個 boolean）
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','shipping','completed'))                  AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))              AS settled,
+  (co.payment_status = 'paid')                                                   AS paid,
+  (co.status IN ('shipping','completed'))                                        AS shipped,
+  -- 結單衍生
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                   AS settlement_no,
+  s.name                                                                          AS store_name,
+  s.code                                                                          AS store_code
+FROM customer_orders co
+LEFT JOIN stores s ON s.id = co.pickup_store_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price), 0)                                   AS items_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'status',           coi.status
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                             AS items
+  FROM customer_order_items coi
+  WHERE coi.order_id = co.id
+) agg ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合金額 + items + 4 chip booleans + 結單號（S-xxxxxxxx-XX）';


### PR DESCRIPTION
## Summary

LIFF 顧客端 (`apps/member/`) 加上 lt-erp legacy 截圖中的 3 個顧客可見頁，資料層全照 new_erp schema：

- **總覽** — 店面 banner / 賣場介紹 / 付款出貨方式 / 未結金額大字塊 / 進行中訂單 chip
- **我的訂單** — sub-tab：未完成 / 訂單紀錄；卡片含商品 + 截止日 + 4 chip booleans (到/結/付/寄)
- **我的結單** — sub-tab：待付款 / 已寄出；卡片含結單號 + 付款方式 + 出貨方式 + 金額分解
- **我** — 加上 TabBar，整合進新導覽

## Schema

3 個 migration（一次 PR ship 完）：
- `stores` 加 5 col：`banner_url` / `description` / `payment_methods_text` / `shipping_methods_text` / `store_short_code`
- `customer_orders` 加 12 col：`payment_method` / `payment_status` / `paid_at` / `remit_amount/at/note` / `shipping_method/address/phone/note` / `shipping_fee` / `discount_amount`
- `v_customer_order_summary` view：聚合金額 + 4 chip booleans (`arrived` / `settled` / `paid` / `shipped`) + `settlement_no` (S-xxxxxxxx-XX 從 order id 衍生)

## RPC (Edge Function)

`liff-api` 新增 3 個 action（service_role 手動 filter `member_id` + `store_id`）：
- `get_overview` — 店資訊 + 未結金額 + 進行中訂單數
- `list_my_orders { tab: active|history }` — 6 個月內訂單
- `list_my_settlements { tab: unpaid|shipped }` — 6 個月內結單

## 設計決策

- **結單 1:1 從 customer_order 衍生**（不建獨立表）— 一筆 customer_order = 一筆 settlement view，settlement_no 從 id 計算
- **Sub-tab 各 2 個**（截圖中其他 tab 留 P1）
- **不必 1:1 仿粉色**，但對齊資訊架構與 sub-tab 命名
- 所有顧客端查詢走 `liff-api` Edge Function（HS256 JWT 過不了 PostgREST）

## 已知限制

- admin 端的 12 個新欄位寫入 UI 留 P1（payment_status / shipping_* / remit_*）
- 「個人賣場」/「我的發票」tab 留 P1
- 結單合併（多 order → 1 settlement）未來真有需求再升級
- v1 限制最近 6 個月，無分頁 UI

## Test plan

- [ ] Migration apply：`supabase db push --linked`
- [ ] Edge Function deploy：`supabase functions deploy liff-api`
- [ ] T1 Schema 欄位：`\d stores` / `\d customer_orders` 確認 17 個新欄位
- [ ] T2 view：`SELECT * FROM v_customer_order_summary LIMIT 1` settlement_no 格式正確
- [ ] T3-T5 三個 action：用測試 JWT curl，驗回傳結構 + 跨店隔離
- [ ] T6 /overview：banner fallback、未結金額大字、進行中訂單 chip
- [ ] T7 /orders：sub-tab 切換、4 chip 顯示、empty state
- [ ] T8 /settlements：結單號 + 付款 + 出貨 + 金額分解
- [ ] T9 跨店隔離：A 店 token 看不到 B 店訂單
- [ ] Vercel preview deploy 在 LINE 內可開啟
- [ ] 詳細測試清單：[docs/TEST-LIFF-overview-orders-settlements.md](docs/TEST-LIFF-overview-orders-settlements.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)