### PR TITLE
feat(liff): 字體放大 + 訂單卡細節

### DIFF
--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -92,7 +92,7 @@ export default function MePage() {
       <main className="mx-auto w-full max-w-md">
         <MemberTabBar />
         <div className="p-6 pt-16 text-center">
-          <p className="text-sm text-zinc-500">載入中…</p>
+          <p className="text-base text-zinc-500">載入中…</p>
         </div>
       </main>
     );
@@ -103,8 +103,8 @@ export default function MePage() {
       <main className="mx-auto w-full max-w-md">
         <MemberTabBar />
         <div className="p-6 pt-16 text-center">
-          <p className="text-sm text-zinc-500">{error ?? "尚未登入，請回首頁。"}</p>
-          <a href="/" className="mt-4 inline-block text-sm text-blue-600 hover:underline">回首頁</a>
+          <p className="text-base text-zinc-500">{error ?? "尚未登入，請回首頁。"}</p>
+          <a href="/" className="mt-4 inline-block text-base text-blue-600 hover:underline">回首頁</a>
         </div>
       </main>
     );
@@ -118,11 +118,11 @@ export default function MePage() {
       <MemberTabBar />
       <div className="flex flex-col gap-5 p-6 pt-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">會員中心</h1>
+        <h1 className="text-2xl font-semibold">會員中心</h1>
         {!editing && (
           <button
             onClick={() => setEditing(true)}
-            className="text-sm text-blue-600 hover:underline"
+            className="text-base text-blue-600 hover:underline"
           >
             編輯
           </button>
@@ -130,7 +130,7 @@ export default function MePage() {
       </div>
 
       {error && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-base text-red-800">
           {error}
         </div>
       )}
@@ -141,21 +141,21 @@ export default function MePage() {
             // eslint-disable-next-line @next/next/no-img-element
             <img src={avatarSrc} alt="" className="h-14 w-14 rounded-full object-cover" />
           ) : (
-            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-zinc-200 text-xl text-zinc-500">
+            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-zinc-200 text-2xl text-zinc-500">
               {displayName[0]}
             </div>
           )}
           <div className="flex-1">
-            <div className="text-xs text-zinc-500">✓ 已綁定 LINE</div>
-            <div className="text-lg font-semibold">{displayName}</div>
-            <div className="font-mono text-xs text-zinc-400">{me.member_no}</div>
+            <div className="text-sm text-zinc-500">✓ 已綁定 LINE</div>
+            <div className="text-xl font-semibold">{displayName}</div>
+            <div className="font-mono text-sm text-zinc-400">{me.member_no}</div>
           </div>
         </div>
       </div>
 
       {!editing ? (
         // 檢視模式
-        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 text-sm">
+        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 text-base">
           <dt className="text-zinc-500">手機</dt>
           <dd className="font-mono">{me.phone ?? <span className="text-zinc-400">未填</span>}</dd>
 
@@ -171,7 +171,7 @@ export default function MePage() {
           {lineUserId && (
             <>
               <dt className="text-zinc-500">LINE ID</dt>
-              <dd className="break-all font-mono text-xs">{lineUserId}</dd>
+              <dd className="break-all font-mono text-sm">{lineUserId}</dd>
             </>
           )}
         </dl>
@@ -182,19 +182,19 @@ export default function MePage() {
           className="flex flex-col gap-4"
         >
           <label className="flex flex-col gap-1">
-            <span className="text-sm font-medium">姓名</span>
+            <span className="text-base font-medium">姓名</span>
             <input
               type="text"
               value={form.name}
               onChange={(e) => setForm({ ...form, name: e.target.value })}
-              className="rounded-md border border-zinc-300 px-3 py-2 text-sm"
+              className="rounded-md border border-zinc-300 px-3 py-2 text-base"
               required
             />
           </label>
 
           <label className="flex flex-col gap-1">
-            <span className="text-sm font-medium">
-              手機號碼 <span className="text-xs text-zinc-400">（台灣手機 09xxxxxxxx）</span>
+            <span className="text-base font-medium">
+              手機號碼 <span className="text-sm text-zinc-400">（台灣手機 09xxxxxxxx）</span>
             </span>
             <input
               type="tel"
@@ -202,28 +202,28 @@ export default function MePage() {
               value={form.phone}
               onChange={(e) => setForm({ ...form, phone: e.target.value })}
               placeholder="0912345678"
-              className="rounded-md border border-zinc-300 px-3 py-2 text-sm"
+              className="rounded-md border border-zinc-300 px-3 py-2 text-base"
             />
           </label>
 
           <label className="flex flex-col gap-1">
-            <span className="text-sm font-medium">生日</span>
+            <span className="text-base font-medium">生日</span>
             <input
               type="date"
               value={form.birthday}
               onChange={(e) => setForm({ ...form, birthday: e.target.value })}
-              className="rounded-md border border-zinc-300 px-3 py-2 text-sm"
+              className="rounded-md border border-zinc-300 px-3 py-2 text-base"
             />
           </label>
 
           <label className="flex flex-col gap-1">
-            <span className="text-sm font-medium">Email</span>
+            <span className="text-base font-medium">Email</span>
             <input
               type="email"
               value={form.email}
               onChange={(e) => setForm({ ...form, email: e.target.value })}
               placeholder="you@example.com"
-              className="rounded-md border border-zinc-300 px-3 py-2 text-sm"
+              className="rounded-md border border-zinc-300 px-3 py-2 text-base"
             />
           </label>
 
@@ -241,14 +241,14 @@ export default function MePage() {
                 });
               }}
               disabled={saving}
-              className="flex-1 rounded-md border border-zinc-300 px-4 py-2.5 text-sm disabled:opacity-50"
+              className="flex-1 rounded-md border border-zinc-300 px-4 py-2.5 text-base disabled:opacity-50"
             >
               取消
             </button>
             <button
               type="submit"
               disabled={saving}
-              className="flex-1 rounded-md bg-[#06C755] px-4 py-2.5 text-sm font-medium text-white shadow disabled:opacity-50"
+              className="flex-1 rounded-md bg-[#06C755] px-4 py-2.5 text-base font-medium text-white shadow disabled:opacity-50"
             >
               {saving ? "儲存中…" : "儲存"}
             </button>
@@ -256,7 +256,7 @@ export default function MePage() {
         </form>
       )}
 
-      <p className="text-xs text-zinc-400">
+      <p className="text-sm text-zinc-400">
         會員卡 QR、點數、訂單等功能尚未上線（MVP-1 開發中）。
       </p>
       </div>

--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -54,16 +54,16 @@ export default function OrdersPage() {
       />
 
       <div className="space-y-3 p-4">
-        {loading && <p className="text-sm text-zinc-400">載入中…</p>}
+        {loading && <p className="text-base text-zinc-400">載入中…</p>}
 
         {err && (
-          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-base text-red-800">
             {err}
           </div>
         )}
 
         {!loading && !err && orders.length === 0 && (
-          <p className="py-12 text-center text-sm text-zinc-400">
+          <p className="py-12 text-center text-base text-zinc-400">
             目前沒有{tab === "active" ? "未完成" : "已完成"}訂單
           </p>
         )}

--- a/apps/member/src/app/overview/page.tsx
+++ b/apps/member/src/app/overview/page.tsx
@@ -50,10 +50,10 @@ export default function OverviewPage() {
       <MemberTabBar />
 
       <div className="space-y-4 p-4">
-        {loading && <p className="text-sm text-zinc-400">載入中…</p>}
+        {loading && <p className="text-base text-zinc-400">載入中…</p>}
 
         {err && (
-          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-base text-red-800">
             {err}
           </div>
         )}
@@ -69,16 +69,16 @@ export default function OverviewPage() {
               />
             ) : (
               <div className="flex h-32 items-center justify-center rounded-md bg-pink-100 text-pink-700">
-                <span className="text-lg font-medium">{data.store.name}</span>
+                <span className="text-xl font-medium">{data.store.name}</span>
               </div>
             )}
 
-            <h1 className="text-xl font-semibold text-pink-600">{data.store.name}</h1>
+            <h1 className="text-2xl font-semibold text-pink-600">{data.store.name}</h1>
 
             {data.store.description && (
               <section>
-                <h2 className="text-sm font-medium text-pink-600">📢 賣場介紹</h2>
-                <p className="mt-1 whitespace-pre-wrap text-sm text-zinc-600">
+                <h2 className="text-base font-medium text-pink-600">📢 賣場介紹</h2>
+                <p className="mt-1 whitespace-pre-wrap text-base text-zinc-600">
                   {data.store.description}
                 </p>
               </section>
@@ -86,14 +86,14 @@ export default function OverviewPage() {
 
             {(data.store.payment_methods_text || data.store.shipping_methods_text) && (
               <section>
-                <h2 className="text-sm font-medium text-pink-600">🛒 付款、出貨方式</h2>
+                <h2 className="text-base font-medium text-pink-600">🛒 付款、出貨方式</h2>
                 {data.store.payment_methods_text && (
-                  <p className="mt-1 whitespace-pre-wrap text-sm text-zinc-600">
+                  <p className="mt-1 whitespace-pre-wrap text-base text-zinc-600">
                     {data.store.payment_methods_text}
                   </p>
                 )}
                 {data.store.shipping_methods_text && (
-                  <p className="mt-1 whitespace-pre-wrap text-sm text-zinc-600">
+                  <p className="mt-1 whitespace-pre-wrap text-base text-zinc-600">
                     {data.store.shipping_methods_text}
                   </p>
                 )}
@@ -101,9 +101,9 @@ export default function OverviewPage() {
             )}
 
             <section>
-              <h2 className="text-sm text-pink-600">未結單金額</h2>
+              <h2 className="text-base text-pink-600">未結單金額</h2>
               <div className="mt-2 rounded-md border border-pink-100 bg-white p-6 text-center">
-                <span className="text-2xl font-semibold text-pink-600">
+                <span className="text-3xl font-semibold text-pink-600">
                   {Number(data.receivable_amount).toLocaleString()}元
                 </span>
               </div>
@@ -112,7 +112,7 @@ export default function OverviewPage() {
             {data.active_orders_count > 0 && (
               <button
                 onClick={() => router.push("/orders")}
-                className="w-full rounded-md border border-pink-200 bg-pink-50 p-3 text-sm text-pink-700 hover:bg-pink-100"
+                className="w-full rounded-md border border-pink-200 bg-pink-50 p-3 text-base text-pink-700 hover:bg-pink-100"
               >
                 你有 {data.active_orders_count} 筆進行中訂單 →
               </button>

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -72,40 +72,40 @@ export default function LandingPage() {
 
   return (
     <main className="mx-auto flex w-full max-w-md flex-col items-center gap-6 p-6 pt-16">
-      <h1 className="text-2xl font-semibold">團購店會員</h1>
-      <p className="text-sm text-zinc-500">歡迎加入！點下方按鈕用 LINE 快速註冊。</p>
+      <h1 className="text-3xl font-semibold">團購店會員</h1>
+      <p className="text-base text-zinc-500">歡迎加入！點下方按鈕用 LINE 快速註冊。</p>
 
       {error && (
-        <div className="w-full rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+        <div className="w-full rounded-md border border-red-200 bg-red-50 p-3 text-base text-red-800">
           登入失敗：{error}
         </div>
       )}
 
       {status === "loading" && (
-        <p className="text-sm text-zinc-400">載入中…</p>
+        <p className="text-base text-zinc-400">載入中…</p>
       )}
 
       {status === "liff_auth" && (
-        <p className="text-sm text-zinc-500">LINE 驗證中…請稍候</p>
+        <p className="text-base text-zinc-500">LINE 驗證中…請稍候</p>
       )}
 
       {status === "idle" && !storeId && (
-        <div className="w-full rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
+        <div className="w-full rounded-md border border-amber-300 bg-amber-50 p-4 text-base text-amber-900">
           請從門市 LINE 官方帳號提供的連結進入。
-          <div className="mt-1 font-mono text-xs text-amber-700">缺少 store 參數</div>
+          <div className="mt-1 font-mono text-sm text-amber-700">缺少 store 參數</div>
         </div>
       )}
 
       {status === "idle" && storeId && (
         <button
           onClick={start}
-          className="w-full rounded-md bg-[#06C755] px-4 py-3 text-sm font-medium text-white shadow hover:bg-[#05b04c]"
+          className="w-full rounded-md bg-[#06C755] px-4 py-3 text-base font-medium text-white shadow hover:bg-[#05b04c]"
         >
           用 LINE 註冊 / 登入
         </button>
       )}
 
-      <p className="text-center text-xs text-zinc-400">
+      <p className="text-center text-sm text-zinc-400">
         門市代號：{storeId ?? "—"}
       </p>
     </main>

--- a/apps/member/src/app/register/page.tsx
+++ b/apps/member/src/app/register/page.tsx
@@ -99,7 +99,7 @@ export default function RegisterPage() {
   if (!ready) {
     return (
       <main className="mx-auto max-w-md p-6">
-        {error ? <p className="text-sm text-red-700">{error}</p> : <p className="text-sm text-zinc-500">載入中…</p>}
+        {error ? <p className="text-base text-red-700">{error}</p> : <p className="text-base text-zinc-500">載入中…</p>}
       </main>
     );
   }
@@ -108,22 +108,22 @@ export default function RegisterPage() {
 
   return (
     <main className="mx-auto flex w-full max-w-md flex-col gap-5 p-6 pt-10">
-      <h1 className="text-xl font-semibold">完成會員註冊</h1>
+      <h1 className="text-2xl font-semibold">完成會員註冊</h1>
 
       {/* LINE 資訊預覽卡 */}
       {hasLineInfo && (
-        <div className="rounded-md border border-[#06C755]/30 bg-[#06C755]/5 p-4 text-sm">
+        <div className="rounded-md border border-[#06C755]/30 bg-[#06C755]/5 p-4 text-base">
           <div className="mb-3 flex items-center gap-3">
             {linePicture && (
               // eslint-disable-next-line @next/next/no-img-element
               <img src={linePicture} alt="" className="h-12 w-12 rounded-full" />
             )}
             <div>
-              <div className="text-xs text-zinc-500">已透過 LINE 驗證</div>
-              <div className="text-base font-semibold">{lineName ?? "(未提供)"}</div>
+              <div className="text-sm text-zinc-500">已透過 LINE 驗證</div>
+              <div className="text-lg font-semibold">{lineName ?? "(未提供)"}</div>
             </div>
           </div>
-          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-zinc-600">
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm text-zinc-600">
             {lineUserId && (
               <>
                 <dt className="text-zinc-400">LINE ID</dt>
@@ -141,13 +141,13 @@ export default function RegisterPage() {
       )}
 
       {error && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">{error}</div>
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-base text-red-800">{error}</div>
       )}
 
       <form onSubmit={onSubmit} className="flex flex-col gap-4">
         <label className="flex flex-col gap-1">
-          <span className="text-sm font-medium">
-            手機號碼 <span className="text-xs text-zinc-400">（LINE 無法提供，請手動輸入）</span>
+          <span className="text-base font-medium">
+            手機號碼 <span className="text-sm text-zinc-400">（LINE 無法提供，請手動輸入）</span>
           </span>
           <input
             type="tel"
@@ -156,43 +156,43 @@ export default function RegisterPage() {
             onChange={(e) => { setPhone(e.target.value); setLookup(null); }}
             onBlur={onCheckPhone}
             placeholder="0912345678"
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none"
+            className="rounded-md border border-zinc-300 px-3 py-2 text-base focus:border-zinc-500 focus:outline-none"
             required
           />
         </label>
 
         {lookup && (
-          <div className="rounded-md border border-green-300 bg-green-50 p-3 text-sm text-green-900">
+          <div className="rounded-md border border-green-300 bg-green-50 p-3 text-base text-green-900">
             <p className="font-medium">偵測到您已是會員</p>
             <p className="mt-1">姓名：{lookup.name_masked ?? "—"}</p>
             <p>主要門市：{lookup.home_store_name ?? "—"}</p>
-            <p className="mt-2 text-xs">按「確認綁定」將本 LINE 與此會員連結。</p>
+            <p className="mt-2 text-sm">按「確認綁定」將本 LINE 與此會員連結。</p>
           </div>
         )}
 
         {!lookup && (
           <>
             <label className="flex flex-col gap-1">
-              <span className="text-sm font-medium">
+              <span className="text-base font-medium">
                 姓名
-                {lineName && <span className="ml-2 text-xs text-[#06C755]">✓ 已由 LINE 帶入，可修改</span>}
+                {lineName && <span className="ml-2 text-sm text-[#06C755]">✓ 已由 LINE 帶入，可修改</span>}
               </span>
               <input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="王小明"
-                className="rounded-md border border-zinc-300 px-3 py-2 text-sm"
+                className="rounded-md border border-zinc-300 px-3 py-2 text-base"
                 required
               />
             </label>
             <label className="flex flex-col gap-1">
-              <span className="text-sm font-medium">生日</span>
+              <span className="text-base font-medium">生日</span>
               <input
                 type="date"
                 value={birthday}
                 onChange={(e) => setBirthday(e.target.value)}
-                className="rounded-md border border-zinc-300 px-3 py-2 text-sm"
+                className="rounded-md border border-zinc-300 px-3 py-2 text-base"
                 required
               />
             </label>
@@ -202,12 +202,12 @@ export default function RegisterPage() {
         <button
           type="submit"
           disabled={submitting}
-          className="mt-2 rounded-md bg-[#06C755] px-4 py-3 text-sm font-medium text-white shadow hover:bg-[#05b04c] disabled:opacity-50"
+          className="mt-2 rounded-md bg-[#06C755] px-4 py-3 text-base font-medium text-white shadow hover:bg-[#05b04c] disabled:opacity-50"
         >
           {submitting ? "處理中…" : lookup ? "確認綁定此 LINE" : "建立會員並綁定 LINE"}
         </button>
 
-        <p className="text-center text-xs text-zinc-400">
+        <p className="text-center text-sm text-zinc-400">
           送出後將在 ERP 系統建立會員資料、並與您的 LINE 帳號永久綁定。
         </p>
       </form>

--- a/apps/member/src/app/settlements/page.tsx
+++ b/apps/member/src/app/settlements/page.tsx
@@ -54,16 +54,16 @@ export default function SettlementsPage() {
       />
 
       <div className="space-y-3 p-4">
-        {loading && <p className="text-sm text-zinc-400">載入中…</p>}
+        {loading && <p className="text-base text-zinc-400">載入中…</p>}
 
         {err && (
-          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-base text-red-800">
             {err}
           </div>
         )}
 
         {!loading && !err && list.length === 0 && (
-          <p className="py-12 text-center text-sm text-zinc-400">
+          <p className="py-12 text-center text-base text-zinc-400">
             目前沒有{tab === "unpaid" ? "待付款" : "已寄出"}結單
           </p>
         )}

--- a/apps/member/src/components/MemberTabBar.tsx
+++ b/apps/member/src/components/MemberTabBar.tsx
@@ -20,7 +20,7 @@ export default function MemberTabBar() {
           <Link
             key={t.href}
             href={t.href}
-            className={`relative flex-1 px-2 py-3 text-center text-sm transition-colors ${
+            className={`relative flex-1 px-2 py-3 text-center text-base transition-colors ${
               active
                 ? "font-medium text-pink-600"
                 : "text-zinc-500 hover:text-zinc-700"

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -1,56 +1,157 @@
 import StatusChip from "./StatusChip";
 
+export type OrderItem = {
+  id: number;
+  sku_id: number;
+  sku_code: string | null;
+  product_name: string | null;
+  variant_name: string | null;
+  campaign_item_id: number | null;
+  qty: number;
+  unit_price: number;
+  subtotal: number;
+  status: string;
+  notes: string | null;
+};
+
 export type OrderRow = {
   id: number;
   order_no: string;
   pickup_deadline: string | null;
   payable_amount: number;
+  items_total: number;
+  shipping_fee: number;
+  discount_amount: number;
   arrived: boolean;
   settled: boolean;
   paid: boolean;
   shipped: boolean;
-  items: Array<{ qty: number; unit_price: number; status: string }>;
+  items: OrderItem[];
   notes: string | null;
+  created_at: string;
+  campaign_name: string | null;
+  campaign_cover_url: string | null;
+  campaign_cutoff_date: string | null;
+  store_name: string | null;
+  settlement_no: string;
 };
 
-export default function OrderCard({
-  order,
-  campaignName,
-}: {
-  order: OrderRow;
-  campaignName?: string;
-}) {
+function fmtAmount(n: number | string | null | undefined): string {
+  return Number(n ?? 0).toLocaleString();
+}
+
+function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return "-";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}/${m}/${day}`;
+}
+
+export default function OrderCard({ order }: { order: OrderRow }) {
   const totalQty = order.items.reduce((s, i) => s + Number(i.qty ?? 0), 0);
+  const title = order.campaign_name ?? `訂單 ${order.order_no}`;
 
   return (
-    <article className="rounded-md border border-pink-100 bg-white p-4 shadow-sm">
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex-1">
-          <h3 className="text-sm font-medium text-zinc-900">
-            {campaignName ?? `訂單 ${order.order_no}`}
-          </h3>
-          <p className="mt-0.5 text-xs text-zinc-400">
-            {order.pickup_deadline ? `截止 ${order.pickup_deadline}・` : ""}共 {totalQty} 件
+    <article className="overflow-hidden rounded-md border border-pink-100 bg-white shadow-sm">
+      <header className="flex items-start gap-3 border-b border-pink-50 p-4">
+        {order.campaign_cover_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={order.campaign_cover_url}
+            alt=""
+            className="h-16 w-16 flex-shrink-0 rounded-md object-cover"
+          />
+        ) : (
+          <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-md bg-pink-100 text-2xl">
+            📦
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-lg font-medium text-zinc-900">{title}</h3>
+          <p className="mt-1 text-sm text-zinc-500">
+            訂單編號：<span className="font-mono">{order.order_no}</span>
+          </p>
+          <p className="text-sm text-zinc-500">
+            訂購日期：{fmtDate(order.created_at)}
+            {order.campaign_cutoff_date ? `・結單日：${order.campaign_cutoff_date}` : ""}
           </p>
         </div>
-        <div className="text-right">
-          <div className="text-xs text-zinc-400">總金額</div>
-          <div className="text-base font-semibold text-pink-600">
-            {Number(order.payable_amount).toLocaleString()}
+      </header>
+
+      <div className="space-y-3 p-4">
+        <div className="flex flex-wrap gap-1.5">
+          <StatusChip tone={order.arrived ? "ok" : "muted"} label={order.arrived ? "全到" : "未到"} />
+          <StatusChip tone={order.settled ? "ok" : "muted"} label={order.settled ? "全結" : "未結"} />
+          <StatusChip tone={order.paid    ? "ok" : "muted"} label={order.paid    ? "已付" : "未付"} />
+          <StatusChip tone={order.shipped ? "ok" : "muted"} label={order.shipped ? "已寄" : "未寄"} />
+        </div>
+
+        <ul className="divide-y divide-zinc-100">
+          {order.items.map((it) => (
+            <li key={it.id} className="flex items-start justify-between gap-2 py-2">
+              <div className="min-w-0 flex-1">
+                <div className="text-base text-zinc-900">
+                  {it.product_name ?? `SKU#${it.sku_id}`}
+                  {it.variant_name && (
+                    <span className="ml-1 text-sm text-zinc-500">/ {it.variant_name}</span>
+                  )}
+                </div>
+                {it.sku_code && (
+                  <div className="font-mono text-xs text-zinc-400">{it.sku_code}</div>
+                )}
+                <div className="text-sm text-zinc-500">
+                  {fmtAmount(it.unit_price)} × {it.qty}
+                </div>
+                {it.notes && (
+                  <div className="mt-0.5 text-sm text-zinc-500">📝 {it.notes}</div>
+                )}
+              </div>
+              <div className="flex-shrink-0 text-right">
+                <div className="text-base font-medium text-zinc-900">
+                  {fmtAmount(it.subtotal)}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        {order.notes && (
+          <div className="rounded-md bg-zinc-50 p-2 text-sm text-zinc-600">
+            📝 {order.notes}
+          </div>
+        )}
+
+        <div className="space-y-1 border-t border-zinc-100 pt-3 text-sm">
+          <div className="flex justify-between text-zinc-500">
+            <span>商品 ({totalQty} 件)</span>
+            <span>{fmtAmount(order.items_total)}</span>
+          </div>
+          {Number(order.shipping_fee) > 0 && (
+            <div className="flex justify-between text-zinc-500">
+              <span>運費</span>
+              <span>{fmtAmount(order.shipping_fee)}</span>
+            </div>
+          )}
+          {Number(order.discount_amount) > 0 && (
+            <div className="flex justify-between text-zinc-500">
+              <span>折扣</span>
+              <span>-{fmtAmount(order.discount_amount)}</span>
+            </div>
+          )}
+          <div className="flex justify-between border-t border-zinc-100 pt-1 text-lg font-semibold text-pink-600">
+            <span>應付金額</span>
+            <span>{fmtAmount(order.payable_amount)}</span>
           </div>
         </div>
-      </div>
 
-      <div className="mt-2 flex flex-wrap gap-1.5">
-        <StatusChip tone={order.arrived ? "ok" : "muted"} label={order.arrived ? "全到" : "未到"} />
-        <StatusChip tone={order.settled ? "ok" : "muted"} label={order.settled ? "全結" : "未結"} />
-        <StatusChip tone={order.paid    ? "ok" : "muted"} label={order.paid    ? "已付" : "未付"} />
-        <StatusChip tone={order.shipped ? "ok" : "muted"} label={order.shipped ? "已寄" : "未寄"} />
+        <div className="text-xs text-zinc-400">
+          結單編號：<span className="font-mono">{order.settlement_no}</span>
+          {order.store_name && <span>・取貨：{order.store_name}</span>}
+        </div>
       </div>
-
-      {order.notes && (
-        <p className="mt-2 text-xs text-zinc-500">📝 {order.notes}</p>
-      )}
     </article>
   );
 }

--- a/apps/member/src/components/SettlementCard.tsx
+++ b/apps/member/src/components/SettlementCard.tsx
@@ -29,11 +29,11 @@ export default function SettlementCard({ settlement: s }: { settlement: Settleme
   return (
     <article className="overflow-hidden rounded-md border border-pink-100 bg-white shadow-sm">
       <div className="border-b border-pink-100 bg-pink-50 px-4 py-2">
-        <span className="text-xs font-medium text-pink-700"># 結單編號 </span>
-        <span className="font-mono text-xs text-pink-700">{s.settlement_no}</span>
+        <span className="text-sm font-medium text-pink-700"># 結單編號 </span>
+        <span className="font-mono text-sm text-pink-700">{s.settlement_no}</span>
       </div>
 
-      <div className="space-y-3 px-4 py-3 text-sm">
+      <div className="space-y-3 px-4 py-3 text-base">
         <div>
           <span className="text-zinc-500">狀態：</span>
           <span className="text-pink-600">{paymentLabel}</span>
@@ -44,40 +44,40 @@ export default function SettlementCard({ settlement: s }: { settlement: Settleme
         <div>
           <div className="text-pink-600">💳 付款方式</div>
           <div className="text-zinc-700">{s.payment_method ?? "-"}</div>
-          <div className="text-xs text-zinc-500">匯款金額：{fmtAmount(s.remit_amount)} 元</div>
-          <div className="text-xs text-zinc-500">匯款時間：{s.remit_at ?? "-"}</div>
-          <div className="text-xs text-zinc-500">匯款備註：{s.remit_note ?? "-"}</div>
+          <div className="text-sm text-zinc-500">匯款金額：{fmtAmount(s.remit_amount)} 元</div>
+          <div className="text-sm text-zinc-500">匯款時間：{s.remit_at ?? "-"}</div>
+          <div className="text-sm text-zinc-500">匯款備註：{s.remit_note ?? "-"}</div>
           {s.payment_status !== "paid" && (
-            <div className="mt-1 text-base font-semibold text-zinc-900">未付款</div>
+            <div className="mt-1 text-lg font-semibold text-zinc-900">未付款</div>
           )}
         </div>
 
         <div>
           <div className="text-pink-600">🚚 出貨方式</div>
           <div className="text-zinc-700">{s.shipping_method ?? "-"}</div>
-          <div className="text-xs text-zinc-500">{s.shipping_phone ?? "未填寫電話"}</div>
+          <div className="text-sm text-zinc-500">{s.shipping_phone ?? "未填寫電話"}</div>
           {s.shipping_address && (
-            <div className="text-xs text-zinc-500">{s.shipping_address}</div>
+            <div className="text-sm text-zinc-500">{s.shipping_address}</div>
           )}
-          <div className="text-xs text-zinc-500">{s.shipping_note ?? "未填寫備註"}</div>
+          <div className="text-sm text-zinc-500">{s.shipping_note ?? "未填寫備註"}</div>
         </div>
 
         <div className="space-y-1 border-t border-zinc-100 pt-3">
-          <div className="flex justify-between text-xs text-zinc-500">
+          <div className="flex justify-between text-sm text-zinc-500">
             <span>總金額</span>
             <span>{fmtAmount(s.items_total)}</span>
           </div>
-          <div className="flex justify-between text-xs text-zinc-500">
+          <div className="flex justify-between text-sm text-zinc-500">
             <span>運費</span>
             <span>{fmtAmount(s.shipping_fee)}</span>
           </div>
-          <div className="flex justify-between text-xs text-zinc-500">
+          <div className="flex justify-between text-sm text-zinc-500">
             <span>促銷活動</span>
             <span>
               {s.discount_amount > 0 ? `-${fmtAmount(s.discount_amount)}` : "0.00"}
             </span>
           </div>
-          <div className="flex justify-between border-t border-zinc-100 pt-1 text-base font-semibold text-pink-600">
+          <div className="flex justify-between border-t border-zinc-100 pt-1 text-lg font-semibold text-pink-600">
             <span>應付金額</span>
             <span>{fmtAmount(s.payable_amount)}</span>
           </div>

--- a/apps/member/src/components/StatusChip.tsx
+++ b/apps/member/src/components/StatusChip.tsx
@@ -9,13 +9,13 @@ export default function StatusChip({
 }) {
   if (tone === "ok") {
     return (
-      <span className="inline-flex items-center gap-0.5 rounded-full bg-pink-100 px-2 py-0.5 text-xs font-medium text-pink-700">
+      <span className="inline-flex items-center gap-0.5 rounded-full bg-pink-100 px-2 py-0.5 text-sm font-medium text-pink-700">
         ✓ {label}
       </span>
     );
   }
   return (
-    <span className="inline-flex items-center gap-0.5 rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-500">
+    <span className="inline-flex items-center gap-0.5 rounded-full bg-zinc-100 px-2 py-0.5 text-sm text-zinc-500">
       ! {label}
     </span>
   );

--- a/apps/member/src/components/SubTabs.tsx
+++ b/apps/member/src/components/SubTabs.tsx
@@ -19,7 +19,7 @@ export default function SubTabs({
           <button
             key={o.value}
             onClick={() => onChange(o.value)}
-            className={`relative px-3 py-2.5 text-sm transition-colors ${
+            className={`relative px-3 py-2.5 text-base transition-colors ${
               active
                 ? "font-medium text-pink-600"
                 : "text-zinc-500 hover:text-zinc-700"
@@ -27,7 +27,7 @@ export default function SubTabs({
           >
             {o.label}
             {o.count !== undefined && (
-              <span className="ml-1 text-xs text-zinc-400">({o.count})</span>
+              <span className="ml-1 text-sm text-zinc-400">({o.count})</span>
             )}
             {active && (
               <span className="absolute inset-x-3 -bottom-px h-0.5 bg-pink-600" />

--- a/supabase/migrations/20260429160003_v_customer_order_summary_items_detail.sql
+++ b/supabase/migrations/20260429160003_v_customer_order_summary_items_detail.sql
@@ -1,0 +1,92 @@
+-- ============================================================
+-- v_customer_order_summary：加品項詳細 + campaign 名
+--
+-- LIFF 顧客端「我的訂單」要顯示：
+--   - 商品名 / 規格 / sku_code（避免顧客看到只有 sku_id）
+--   - campaign 名（活動名 = 卡片頂部 title）
+--   - campaign cover image
+-- ============================================================
+
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  agg.items_total,
+  agg.items_total + co.shipping_fee - co.discount_amount   AS payable_amount,
+  agg.items,
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','shipping','completed'))                  AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))              AS settled,
+  (co.payment_status = 'paid')                                                   AS paid,
+  (co.status IN ('shipping','completed'))                                        AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                   AS settlement_no,
+  s.name                                                                          AS store_name,
+  s.code                                                                          AS store_code,
+  -- campaign 顯示資訊
+  gbc.name                                                                        AS campaign_name,
+  gbc.cover_image_url                                                             AS campaign_cover_url,
+  gbc.end_at                                                                      AS campaign_end_at,
+  gbc.cutoff_date                                                                 AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price), 0)                                   AS items_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'sku_code',         sk.sku_code,
+          'product_name',     sk.product_name,
+          'variant_name',     sk.variant_name,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'subtotal',         coi.qty * coi.unit_price,
+          'status',           coi.status,
+          'notes',            coi.notes
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                             AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus sk ON sk.id = coi.sku_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細（含 sku 名/規格） + campaign 名 + 結單號';


### PR DESCRIPTION
## Summary

接續 #145 的 LIFF 顧客端，依用戶手機閱讀回饋優化：

1. **字體全面放大一階**（text-xs→sm, sm→base, base→lg, lg→xl, xl→2xl, 2xl→3xl）— 套用所有 11 個 apps/member 檔
2. **訂單卡顯示完整細節**：
   - cover image + campaign 名（如「日本醬油 #2」）
   - 訂單編號 / 訂購日期 / 結單日
   - 4 個狀態 chip（到/結/付/寄）
   - **每筆 item 一行**：品名 + 規格 + sku_code + 單價×數量 + 小計
   - notes
   - 金額分解：商品 + 運費 + 折扣 + 應付
   - 結單編號 + 取貨店

## Schema

- `v_customer_order_summary` 重做：每筆 item 加 `sku_code` / `product_name` / `variant_name` / `subtotal`；單頭加 `campaign_name` / `campaign_cover_url` / `campaign_cutoff_date`
- 已 apply 到 prod（migration `20260429160003`）

## Test plan

- [ ] /orders 頁面卡片顯示 cover + campaign 名（不再是純 order_no）
- [ ] 每筆 item 顯示「品名 + sku_code + 單價×數量 + 小計」
- [ ] 字體在 iPhone SE 閱讀不費力（text-base = 16px）
- [ ] 金額分解正確（商品總額 + 運費 - 折扣 = 應付）

🤖 Generated with [Claude Code](https://claude.com/claude-code)