### PR TITLE
feat(campaigns+pricing): candidate→draft + 3-tier prices + 1:1 invariant

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -10,6 +10,11 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.104.0",
+    "@tiptap/extension-link": "^3.22.5",
+    "@tiptap/pm": "^3.22.5",
+    "@tiptap/react": "^3.22.5",
+    "@tiptap/starter-kit": "^3.22.5",
+    "isomorphic-dompurify": "^3.11.0",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
@@ -957,11 +957,29 @@ function ItemEditorRow({
           >
             {opts.map((o) => (
               <button
-                key={o.campaign_item_id}
+                key={o.campaign_item_id ?? `s-${o.sku_id}`}
                 type="button"
-                onClick={() => {
+                onClick={async () => {
+                  // 兄弟 SKU（campaign_item_id=NULL）→ lazy 建 campaign_item
+                  let ciId = o.campaign_item_id;
+                  if (ciId == null) {
+                    const { data: newId, error } = await getSupabase().rpc("rpc_upsert_campaign_item", {
+                      p_id: null,
+                      p_campaign_id: campaignId,
+                      p_sku_id: o.sku_id,
+                      p_unit_price: Number(o.unit_price) || 0,
+                      p_cap_qty: null,
+                      p_sort_order: 0,
+                      p_notes: null,
+                    });
+                    if (error) {
+                      alert("加入此規格失敗：" + error.message);
+                      return;
+                    }
+                    ciId = Number(newId);
+                  }
                   onChange({
-                    campaign_item_id: o.campaign_item_id,
+                    campaign_item_id: ciId,
                     sku_label: `${o.product_name}${o.variant_name ? ` / ${o.variant_name}` : ""} (${o.sku_code})`,
                     unit_price: Number(o.unit_price),
                     qty: item.qty === "" ? "1" : item.qty,
@@ -975,6 +993,11 @@ function ItemEditorRow({
                 {o.variant_name && <span className="ml-1 text-zinc-500">/ {o.variant_name}</span>}
                 <span className="ml-2 font-mono text-zinc-400">{o.sku_code}</span>
                 <span className="ml-2 text-zinc-600 dark:text-zinc-300">${Number(o.unit_price)}</span>
+                {o.campaign_item_id == null && (
+                  <span className="ml-2 rounded bg-blue-100 px-1 py-0.5 text-[10px] text-blue-700 dark:bg-blue-950 dark:text-blue-300">
+                    + 加入此團
+                  </span>
+                )}
               </button>
             ))}
           </div>

--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -28,6 +28,35 @@ const STATUS_LABEL: Record<Status, string> = {
 
 const PAGE_SIZE = 50;
 
+type View = "list" | "week" | "month";
+
+type CalRow = {
+  id: number;
+  campaign_no: string;
+  name: string;
+  status: Status;
+  start_at: string | null;
+};
+
+function localDateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+function addDays(d: Date, n: number): Date {
+  const x = new Date(d);
+  x.setDate(x.getDate() + n);
+  return x;
+}
+
 export default function CampaignsListPage() {
   const [rows, setRows] = useState<Row[] | null>(null);
   const [total, setTotal] = useState(0);
@@ -44,6 +73,24 @@ export default function CampaignsListPage() {
   const [reloadTick, setReloadTick] = useState(0);
   const [closingId, setClosingId] = useState<number | null>(null);
   const [finalizingId, setFinalizingId] = useState<number | null>(null);
+
+  const [view, setView] = useState<View>(() => {
+    if (typeof window === "undefined") return "list";
+    const saved = window.localStorage.getItem("campaigns:view");
+    return saved === "week" || saved === "month" || saved === "list" ? saved : "list";
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("campaigns:view", view);
+  }, [view]);
+
+  const [showRecurring, setShowRecurring] = useState(false);
+
+  const [calRows, setCalRows] = useState<CalRow[] | null>(null);
+  const [calItemCounts, setCalItemCounts] = useState<Map<number, number>>(new Map());
+  const [calOrderCounts, setCalOrderCounts] = useState<Map<number, number>>(new Map());
+  const [monthAnchor, setMonthAnchor] = useState<Date>(() => startOfDay(new Date()));
 
   async function closeCampaign(id: number, name: string) {
     if (!confirm(`確定結單「${name}」？結單後可從採購單頁面「帶入該日商品」產生 PR。`)) return;
@@ -153,6 +200,57 @@ export default function CampaignsListPage() {
     return () => { cancelled = true; };
   }, [query, status, page, reloadTick]);
 
+  // Calendar (week / month) 取資料：依視圖決定範圍
+  useEffect(() => {
+    if (view === "list") return;
+    let cancelled = false;
+    (async () => {
+      const today = startOfDay(new Date());
+      let from: Date;
+      let to: Date;
+      if (view === "week") {
+        from = today;
+        to = addDays(today, 7);
+      } else {
+        from = new Date(monthAnchor.getFullYear(), monthAnchor.getMonth(), 1);
+        to = new Date(monthAnchor.getFullYear(), monthAnchor.getMonth() + 1, 1);
+      }
+      const { data, error } = await getSupabase()
+        .from("group_buy_campaigns")
+        .select("id, campaign_no, name, status, start_at")
+        .gte("start_at", from.toISOString())
+        .lt("start_at", to.toISOString())
+        .order("start_at", { ascending: true });
+      if (cancelled) return;
+      if (error) { setError(error.message); return; }
+      setError(null);
+      const list = (data ?? []) as CalRow[];
+      setCalRows(list);
+
+      // 補商品數 + 訂單數
+      const ids = list.map((r) => r.id);
+      if (ids.length > 0) {
+        const sb = getSupabase();
+        const [itemRes, orderRes] = await Promise.all([
+          sb.from("campaign_items").select("campaign_id").in("campaign_id", ids),
+          sb.from("customer_orders").select("campaign_id").in("campaign_id", ids),
+        ]);
+        if (cancelled) return;
+        const im = new Map<number, number>();
+        const om = new Map<number, number>();
+        for (const id of ids) { im.set(id, 0); om.set(id, 0); }
+        for (const it of itemRes.data ?? []) im.set(it.campaign_id, (im.get(it.campaign_id) ?? 0) + 1);
+        for (const o of orderRes.data ?? []) om.set(o.campaign_id, (om.get(o.campaign_id) ?? 0) + 1);
+        setCalItemCounts(im);
+        setCalOrderCounts(om);
+      } else {
+        setCalItemCounts(new Map());
+        setCalOrderCounts(new Map());
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [view, monthAnchor, reloadTick]);
+
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const fromIdx = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
   const toIdx = Math.min(page * PAGE_SIZE, total);
@@ -166,22 +264,73 @@ export default function CampaignsListPage() {
             {loading ? "載入中…" : total === 0 ? "共 0 筆" : `共 ${total} 筆（${fromIdx}-${toIdx}）`}
           </p>
         </div>
-        <Link href="/products?mode=campaign" className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200">
-          + 從商品開團
-        </Link>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setShowRecurring(true)}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm font-medium hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            🔁 批次建立
+          </button>
+          <Link href="/products?mode=campaign" className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200">
+            + 從商品開團
+          </Link>
+        </div>
       </header>
 
-      <div className="grid gap-3 sm:grid-cols-2">
-        <input
-          type="search" placeholder="搜尋 團號 / 名稱" value={queryDraft} onChange={(e) => setQueryDraft(e.target.value)}
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
-        />
-        <select value={status} onChange={(e) => setStatus(e.target.value)}
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
-          <option value="">全部狀態</option>
-          {Object.entries(STATUS_LABEL).map(([v, l]) => <option key={v} value={v}>{l}</option>)}
-        </select>
+      <div className="flex gap-1 border-b border-zinc-200 dark:border-zinc-800">
+        {(["list", "week", "month"] as View[]).map((v) => (
+          <button
+            key={v}
+            onClick={() => setView(v)}
+            className={
+              view === v
+                ? "border-b-2 border-zinc-900 px-4 py-2 text-sm font-medium text-zinc-900 dark:border-zinc-100 dark:text-zinc-100"
+                : "px-4 py-2 text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+            }
+          >
+            {v === "list" ? "列表" : v === "week" ? "未來 7 天" : "月曆"}
+          </button>
+        ))}
       </div>
+
+      {view === "list" && (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <input
+            type="search" placeholder="搜尋 團號 / 名稱" value={queryDraft} onChange={(e) => setQueryDraft(e.target.value)}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <select value={status} onChange={(e) => setStatus(e.target.value)}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
+            <option value="">全部狀態</option>
+            {Object.entries(STATUS_LABEL).map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+          </select>
+        </div>
+      )}
+
+      {view === "month" && (
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setMonthAnchor(new Date(monthAnchor.getFullYear(), monthAnchor.getMonth() - 1, 1))}
+              className="rounded-md border border-zinc-300 px-2 py-1 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >‹ 上月</button>
+            <span className="font-medium">
+              {monthAnchor.getFullYear()} 年 {monthAnchor.getMonth() + 1} 月
+            </span>
+            <button
+              onClick={() => setMonthAnchor(new Date(monthAnchor.getFullYear(), monthAnchor.getMonth() + 1, 1))}
+              className="rounded-md border border-zinc-300 px-2 py-1 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >下月 ›</button>
+            <button
+              onClick={() => setMonthAnchor(startOfDay(new Date()))}
+              className="rounded-md border border-zinc-300 px-2 py-1 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >今天</button>
+          </div>
+          <span className="text-sm text-zinc-500">
+            {calRows === null ? "載入中…" : `${calRows.length} 場`}
+          </span>
+        </div>
+      )}
 
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
@@ -190,6 +339,18 @@ export default function CampaignsListPage() {
         </div>
       )}
 
+      {view !== "list" && (
+        <CalendarView
+          view={view}
+          rows={calRows}
+          monthAnchor={monthAnchor}
+          itemCounts={calItemCounts}
+          orderCounts={calOrderCounts}
+          onPick={(id) => openEdit(id)}
+        />
+      )}
+
+      {view === "list" && (
       <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
@@ -258,11 +419,26 @@ export default function CampaignsListPage() {
           </tbody>
         </table>
       </div>
+      )}
+
+      <Modal
+        open={showRecurring}
+        onClose={() => setShowRecurring(false)}
+        title="批次建立草稿開團"
+        maxWidth="max-w-2xl"
+      >
+        {showRecurring && (
+          <RecurringCampaignsForm
+            onClose={() => setShowRecurring(false)}
+            onCreated={() => { setShowRecurring(false); setReloadTick((t) => t + 1); }}
+          />
+        )}
+      </Modal>
 
       <Modal
         open={!!modal}
         onClose={() => setModal(null)}
-        title={modal ? `編輯開團 #${modal.values.campaign_no}` : ""}
+        title={modal ? `編輯開團 #${modal.values.campaign_no}｜${modal.values.name}` : ""}
         maxWidth="max-w-4xl"
       >
         {modal && (
@@ -279,7 +455,7 @@ export default function CampaignsListPage() {
         )}
       </Modal>
 
-      {totalPages > 1 && (
+      {view === "list" && totalPages > 1 && (
         <div className="flex items-center justify-end gap-2 text-sm">
           <PagerBtn disabled={page === 1} onClick={() => setPage(1)}>« 第一頁</PagerBtn>
           <PagerBtn disabled={page === 1} onClick={() => setPage((p) => p - 1)}>‹ 上頁</PagerBtn>
@@ -313,4 +489,554 @@ function StatusBadge({ s }: { s: Status }) {
     cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
   };
   return <span className={`inline-block rounded px-2 py-0.5 text-xs ${st[s]}`}>{STATUS_LABEL[s]}</span>;
+}
+
+// ============================================================
+// Calendar (week / month) view — 點卡片 → 開編輯 modal（共用 openEdit）
+// ============================================================
+function CalendarView({
+  view,
+  rows,
+  monthAnchor,
+  itemCounts,
+  orderCounts,
+  onPick,
+}: {
+  view: View;
+  rows: CalRow[] | null;
+  monthAnchor: Date;
+  itemCounts: Map<number, number>;
+  orderCounts: Map<number, number>;
+  onPick: (id: number) => void;
+}) {
+  if (rows === null) {
+    return <div className="p-6 text-center text-sm text-zinc-500">載入中…</div>;
+  }
+  // 按日期分桶（key = YYYY-MM-DD）
+  const buckets = new Map<string, CalRow[]>();
+  for (const r of rows) {
+    if (!r.start_at) continue;
+    const key = localDateKey(new Date(r.start_at));
+    const arr = buckets.get(key) ?? [];
+    arr.push(r);
+    buckets.set(key, arr);
+  }
+
+  if (view === "week") {
+    const today = startOfDay(new Date());
+    const days = Array.from({ length: 7 }, (_, i) => addDays(today, i));
+    const weekdayCh = "日一二三四五六";
+    return (
+      <div className="grid gap-2 md:grid-cols-7">
+        {days.map((d) => {
+          const key = localDateKey(d);
+          const list = buckets.get(key) ?? [];
+          const isToday = key === localDateKey(new Date());
+          return (
+            <div
+              key={key}
+              className={`flex min-h-[200px] flex-col rounded-md border ${
+                isToday
+                  ? "border-zinc-900 dark:border-zinc-100"
+                  : "border-zinc-200 dark:border-zinc-800"
+              }`}
+            >
+              <div
+                className={`flex items-baseline justify-between border-b px-3 py-2 ${
+                  isToday
+                    ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+                    : "border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900"
+                }`}
+              >
+                <div>
+                  <div className={`text-[11px] ${isToday ? "opacity-90" : "text-zinc-500"}`}>
+                    {d.getMonth() + 1} 月
+                  </div>
+                  <div className="flex items-baseline gap-1.5">
+                    <span className="text-xl font-semibold leading-none">{d.getDate()}</span>
+                    <span className={`text-xs ${isToday ? "opacity-90" : "text-zinc-500"}`}>
+                      週{weekdayCh[d.getDay()]}
+                    </span>
+                  </div>
+                </div>
+                {isToday && (
+                  <span className="rounded bg-white px-1.5 py-0.5 text-[10px] font-medium text-zinc-900 dark:bg-zinc-900 dark:text-zinc-100">
+                    今天
+                  </span>
+                )}
+              </div>
+              <div className="flex-1 space-y-2 p-2">
+                {list.length === 0 && (
+                  <div className="py-4 text-center text-[11px] text-zinc-400">—</div>
+                )}
+                {list.map((r) => (
+                  <CampaignCard
+                    key={r.id}
+                    r={r}
+                    itemCount={itemCounts.get(r.id) ?? 0}
+                    orderCount={orderCounts.get(r.id) ?? 0}
+                    onPick={onPick}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // month
+  const year = monthAnchor.getFullYear();
+  const month = monthAnchor.getMonth();
+  const firstOfMonth = new Date(year, month, 1);
+  const startWeekday = firstOfMonth.getDay(); // 0=Sun ... 6=Sat
+  // 從這週日開始，一直渲到 6 週（42 格）
+  const gridStart = addDays(firstOfMonth, -startWeekday);
+  const cells = Array.from({ length: 42 }, (_, i) => addDays(gridStart, i));
+  const todayKey = localDateKey(new Date());
+
+  return (
+    <div>
+      <div className="grid grid-cols-7 border-l border-t border-zinc-200 dark:border-zinc-800">
+        {"日一二三四五六".split("").map((d) => (
+          <div
+            key={d}
+            className="border-b border-r border-zinc-200 bg-zinc-50 px-2 py-1.5 text-center text-xs font-medium text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400"
+          >
+            {d}
+          </div>
+        ))}
+        {cells.map((d) => {
+          const key = localDateKey(d);
+          const inMonth = d.getMonth() === month;
+          const isToday = key === todayKey;
+          const list = buckets.get(key) ?? [];
+          return (
+            <div
+              key={key}
+              className={`min-h-[110px] border-b border-r border-zinc-200 p-1.5 dark:border-zinc-800 ${
+                inMonth ? "bg-white dark:bg-zinc-950" : "bg-zinc-50 dark:bg-zinc-900/40"
+              }`}
+            >
+              <div
+                className={`mb-1 text-right text-xs ${
+                  isToday
+                    ? "font-bold text-zinc-900 dark:text-zinc-100"
+                    : inMonth
+                    ? "text-zinc-600 dark:text-zinc-400"
+                    : "text-zinc-400 dark:text-zinc-600"
+                }`}
+              >
+                {d.getDate()}
+              </div>
+              <div className="space-y-1">
+                {list.slice(0, 3).map((r) => (
+                  <CampaignCard
+                    key={r.id}
+                    r={r}
+                    compact
+                    itemCount={itemCounts.get(r.id) ?? 0}
+                    orderCount={orderCounts.get(r.id) ?? 0}
+                    onPick={onPick}
+                  />
+                ))}
+                {list.length > 3 && (
+                  <div className="text-[10px] text-zinc-500">+{list.length - 3} 場</div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// RecurringCampaignsForm — 批次建立草稿開團（每月 N 號 / 每週 N / 每隔 N 天）
+// ============================================================
+
+type RecMode = "monthly" | "weekly" | "daily";
+
+type ActiveProductRow = {
+  id: number;
+  product_code: string;
+  name: string;
+  skus: { id: number; sku_code: string; variant_name: string | null; status: string }[];
+};
+
+function RecurringCampaignsForm({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const [products, setProducts] = useState<ActiveProductRow[] | null>(null);
+  const [productId, setProductId] = useState<number | null>(null);
+  const [skuId, setSkuId] = useState<number | null>(null);
+  const [mode, setMode] = useState<RecMode>("monthly");
+  const [anchorDate, setAnchorDate] = useState<string>(() => localDateKey(addDays(startOfDay(new Date()), 1)));
+  const [time, setTime] = useState<string>("08:00");
+  const [count, setCount] = useState<number>(3);
+  const [intervalDays, setIntervalDays] = useState<number>(7);
+  const [dayOfMonth, setDayOfMonth] = useState<number>(() => new Date().getDate());
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data: prods, error } = await sb
+        .from("products")
+        .select("id, product_code, name, status")
+        .eq("status", "active")
+        .order("product_code");
+      if (cancelled) return;
+      if (error) { setError(error.message); return; }
+      const ids = (prods ?? []).map((p) => p.id);
+      let skusByProd = new Map<number, ActiveProductRow["skus"]>();
+      if (ids.length > 0) {
+        const { data: skus } = await sb
+          .from("skus")
+          .select("id, product_id, sku_code, variant_name, status")
+          .in("product_id", ids)
+          .eq("status", "active")
+          .order("id");
+        for (const s of (skus ?? []) as { id: number; product_id: number; sku_code: string; variant_name: string | null; status: string }[]) {
+          const arr = skusByProd.get(s.product_id) ?? [];
+          arr.push({ id: s.id, sku_code: s.sku_code, variant_name: s.variant_name, status: s.status });
+          skusByProd.set(s.product_id, arr);
+        }
+      }
+      const list: ActiveProductRow[] = (prods ?? [])
+        .map((p) => ({ ...p, skus: skusByProd.get(p.id) ?? [] }))
+        .filter((p) => p.skus.length > 0);
+      setProducts(list);
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const selectedProduct = products?.find((p) => p.id === productId) ?? null;
+
+  // 切換 product 時、自動選第一個 sku
+  useEffect(() => {
+    if (selectedProduct && selectedProduct.skus.length > 0) {
+      if (!selectedProduct.skus.some((s) => s.id === skuId)) {
+        setSkuId(selectedProduct.skus[0].id);
+      }
+    } else {
+      setSkuId(null);
+    }
+  }, [selectedProduct, skuId]);
+
+  // 計算預覽日期
+  // monthly: 使用 anchorDate 的年月當起點 + dayOfMonth 為固定日；遇 30/31 不存在月份用該月最後一天
+  const previewDates = (() => {
+    if (!anchorDate) return [];
+    const [y, m, d] = anchorDate.split("-").map(Number);
+    const result: Date[] = [];
+    const n = Math.max(1, Math.min(count, 24));
+    for (let i = 0; i < n; i++) {
+      if (mode === "monthly") {
+        const targetMonth = m - 1 + i;
+        const lastDay = new Date(y, targetMonth + 1, 0).getDate();
+        const day = Math.min(dayOfMonth, lastDay);
+        result.push(new Date(y, targetMonth, day));
+      } else if (mode === "weekly") {
+        const base = new Date(y, m - 1, d);
+        result.push(new Date(base.getFullYear(), base.getMonth(), base.getDate() + i * 7));
+      } else {
+        const base = new Date(y, m - 1, d);
+        result.push(new Date(base.getFullYear(), base.getMonth(), base.getDate() + i * intervalDays));
+      }
+    }
+    return result;
+  })();
+
+  async function handleSubmit() {
+    setError(null);
+    if (!productId || !skuId || !selectedProduct) {
+      setError("請先選擇商品 / 規格");
+      return;
+    }
+    if (previewDates.length === 0) {
+      setError("無預覽日期");
+      return;
+    }
+    setBusy(true);
+    setProgress({ done: 0, total: previewDates.length });
+    const sb = getSupabase();
+
+    const errors: string[] = [];
+    for (let i = 0; i < previewDates.length; i++) {
+      const d = previewDates[i];
+      const [hh, mm] = time.split(":").map(Number);
+      const startAt = new Date(d.getFullYear(), d.getMonth(), d.getDate(), hh ?? 8, mm ?? 0);
+      const ymd = `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, "0")}${String(d.getDate()).padStart(2, "0")}`;
+      const campaignNo = `GB${ymd}-S${String(skuId).padStart(6, "0")}`;
+
+      try {
+        const { data: campId, error: cErr } = await sb.rpc("rpc_upsert_campaign", {
+          p_id: null,
+          p_campaign_no: campaignNo,
+          p_name: selectedProduct.name,
+          p_description: null,
+          p_status: "draft",
+          p_close_type: "regular",
+          p_start_at: startAt.toISOString(),
+          p_end_at: null,
+          p_pickup_deadline: null,
+          p_pickup_days: null,
+          p_total_cap_qty: null,
+          p_notes: `recurring batch (${mode}) for product ${selectedProduct.product_code}`,
+        });
+        if (cErr) throw cErr;
+        const { error: iErr } = await sb.rpc("rpc_upsert_campaign_item", {
+          p_id: null,
+          p_campaign_id: Number(campId),
+          p_sku_id: skuId,
+          p_unit_price: 0,
+          p_cap_qty: null,
+          p_sort_order: 0,
+          p_notes: null,
+        });
+        if (iErr) throw iErr;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        errors.push(`${campaignNo}: ${msg}`);
+      }
+      setProgress({ done: i + 1, total: previewDates.length });
+    }
+
+    setBusy(false);
+    if (errors.length > 0) {
+      setError(`完成 ${previewDates.length - errors.length} / ${previewDates.length}\n失敗：\n${errors.join("\n")}`);
+    } else {
+      onCreated();
+    }
+  }
+
+  if (products === null) {
+    return <div className="p-4 text-center text-sm text-zinc-500">載入上架商品…</div>;
+  }
+  if (products.length === 0) {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-zinc-700 dark:text-zinc-300">目前沒有上架商品。請先到商品頁把商品設為「上架」（需有規格 + 三種價格）。</p>
+        <button onClick={onClose} className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700">關閉</button>
+      </div>
+    );
+  }
+
+  const inputCls = "w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800";
+
+  return (
+    <div className="space-y-4">
+      {/* 商品 / 規格 */}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-600 dark:text-zinc-400">商品（上架中）</span>
+          <select value={productId ?? ""} onChange={(e) => setProductId(Number(e.target.value) || null)} className={inputCls}>
+            <option value="">— 請選 —</option>
+            {products.map((p) => (
+              <option key={p.id} value={p.id}>{p.product_code} {p.name}</option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-600 dark:text-zinc-400">規格</span>
+          <select value={skuId ?? ""} onChange={(e) => setSkuId(Number(e.target.value) || null)} disabled={!selectedProduct} className={inputCls}>
+            <option value="">— 請選商品先 —</option>
+            {selectedProduct?.skus.map((s) => (
+              <option key={s.id} value={s.id}>{s.sku_code}{s.variant_name ? ` / ${s.variant_name}` : ""}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {/* 重複頻率 */}
+      <div className="grid gap-3 sm:grid-cols-3">
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-600 dark:text-zinc-400">重複頻率</span>
+          <select value={mode} onChange={(e) => setMode(e.target.value as RecMode)} className={inputCls}>
+            <option value="monthly">每月</option>
+            <option value="weekly">每週</option>
+            <option value="daily">每隔 N 天</option>
+          </select>
+        </label>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-600 dark:text-zinc-400">第一場日期</span>
+          <input type="date" value={anchorDate} onChange={(e) => setAnchorDate(e.target.value)} className={inputCls} />
+        </label>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-600 dark:text-zinc-400">開團時間</span>
+          <input type="time" value={time} onChange={(e) => setTime(e.target.value)} className={inputCls} />
+        </label>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {mode === "monthly" && (
+          <label className="block space-y-1 text-sm">
+            <span className="text-zinc-600 dark:text-zinc-400">每月 N 號（1-31，超過該月天數會用該月最後一天）</span>
+            <input type="number" min={1} max={31} value={dayOfMonth} onChange={(e) => setDayOfMonth(Math.max(1, Math.min(31, Number(e.target.value) || 1)))} className={inputCls} />
+          </label>
+        )}
+        {mode === "daily" && (
+          <label className="block space-y-1 text-sm">
+            <span className="text-zinc-600 dark:text-zinc-400">每隔幾天</span>
+            <input type="number" min={1} max={60} value={intervalDays} onChange={(e) => setIntervalDays(Math.max(1, Math.min(60, Number(e.target.value) || 1)))} className={inputCls} />
+          </label>
+        )}
+        <label className="block space-y-1 text-sm">
+          <span className="text-zinc-600 dark:text-zinc-400">建立場次（最多 24）</span>
+          <input type="number" min={1} max={24} value={count} onChange={(e) => setCount(Math.max(1, Math.min(24, Number(e.target.value) || 1)))} className={inputCls} />
+        </label>
+      </div>
+
+      {/* 預覽 */}
+      <div className="rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
+        <div className="mb-2 text-xs font-medium text-zinc-700 dark:text-zinc-300">
+          將建立 {previewDates.length} 場開團（draft）：
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {previewDates.map((d, i) => (
+            <span key={i} className="rounded bg-zinc-100 px-2 py-0.5 text-xs text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+              {d.getFullYear()}/{d.getMonth() + 1}/{d.getDate()}（週{"日一二三四五六"[d.getDay()]}）
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="whitespace-pre-wrap rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {progress && (
+        <div className="text-xs text-zinc-500">
+          建立中 {progress.done} / {progress.total}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleSubmit}
+          disabled={busy || !productId || !skuId}
+          className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900"
+        >
+          {busy ? `建立中… ${progress?.done ?? 0}/${progress?.total ?? 0}` : `建立 ${previewDates.length} 場`}
+        </button>
+        <button onClick={onClose} disabled={busy} className="rounded-md border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700">取消</button>
+      </div>
+    </div>
+  );
+}
+
+function CampaignCard({
+  r,
+  compact,
+  itemCount,
+  orderCount,
+  onPick,
+}: {
+  r: CalRow;
+  compact?: boolean;
+  itemCount: number;
+  orderCount: number;
+  onPick: (id: number) => void;
+}) {
+  const statusBadgeColor: Record<Status, string> = {
+    draft: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-200",
+    open: "bg-green-200 text-green-800 dark:bg-green-900 dark:text-green-200",
+    closed: "bg-amber-200 text-amber-800 dark:bg-amber-900 dark:text-amber-200",
+    ordered: "bg-blue-200 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    receiving: "bg-indigo-200 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200",
+    ready: "bg-emerald-200 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200",
+    completed: "bg-zinc-300 text-zinc-700 dark:bg-zinc-600 dark:text-zinc-200",
+    cancelled: "bg-red-200 text-red-800 dark:bg-red-900 dark:text-red-200",
+  };
+  const compactBg: Record<Status, string> = {
+    draft: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+    open: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
+    closed: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+    ordered: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+    receiving: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
+    ready: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+    completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
+    cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+  };
+
+  if (compact) {
+    return (
+      <button
+        onClick={() => onPick(r.id)}
+        className={`block w-full truncate rounded px-1.5 py-0.5 text-left text-[10px] ${compactBg[r.status]} hover:opacity-80`}
+        title={`${r.campaign_no}｜${r.name}｜${STATUS_LABEL[r.status]}｜${itemCount} 商品｜${orderCount} 單`}
+      >
+        <span className="font-medium">{r.name || r.campaign_no}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-zinc-200 bg-white p-2.5 shadow-sm transition hover:border-zinc-400 hover:shadow dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-500">
+      {/* 標題：商品名稱 + 狀態 */}
+      <div className="mb-1.5 flex items-start justify-between gap-1.5">
+        <button
+          onClick={() => onPick(r.id)}
+          className="flex-1 truncate text-left text-sm font-semibold text-zinc-900 hover:underline dark:text-zinc-100"
+          title={`${r.campaign_no}｜${r.name}`}
+        >
+          {r.name || r.campaign_no}
+        </button>
+        <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${statusBadgeColor[r.status]}`}>
+          {STATUS_LABEL[r.status]}
+        </span>
+      </div>
+
+      {/* 團號 */}
+      <button
+        onClick={() => onPick(r.id)}
+        className="mb-2 block w-full truncate text-left font-mono text-[10px] text-zinc-500 hover:underline"
+      >
+        {r.campaign_no}
+      </button>
+
+      {/* 數據：商品數 / 訂單數 */}
+      <div className="mb-2 flex gap-2 text-[11px]">
+        <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+          📦 {itemCount} 商品
+        </span>
+        <span className={`rounded px-1.5 py-0.5 ${orderCount > 0 ? "bg-blue-100 font-medium text-blue-800 dark:bg-blue-950 dark:text-blue-300" : "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400"}`}>
+          🛒 {orderCount} 單
+        </span>
+      </div>
+
+      {/* 動作 */}
+      <div className="flex flex-wrap gap-1">
+        {r.status === "open" && (
+          <Link
+            href={`/campaigns/order-entry?id=${r.id}`}
+            className="rounded border border-green-400 bg-green-50 px-2 py-0.5 text-[11px] font-medium text-green-700 hover:bg-green-100 dark:border-green-700 dark:bg-green-950 dark:text-green-300 dark:hover:bg-green-900"
+          >
+            + 加單
+          </Link>
+        )}
+        <button
+          onClick={() => onPick(r.id)}
+          className="rounded border border-zinc-300 px-2 py-0.5 text-[11px] text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800"
+        >
+          編輯
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/apps/admin/src/app/(protected)/community-candidates/page.tsx
+++ b/apps/admin/src/app/(protected)/community-candidates/page.tsx
@@ -151,20 +151,40 @@ export default function CommunityCandidatesPage() {
     return max + 1;
   };
 
+  const deriveProductName = (row: Candidate): string => {
+    const hint = (row.product_name_hint ?? "").trim();
+    if (hint) return hint.slice(0, 60);
+    const raw = (row.raw_text ?? "").trim().replace(/\s+/g, " ");
+    if (raw) return raw.slice(0, 30);
+    return `候選 #${row.id}`;
+  };
+
   const scheduleAt = async (id: number, dateStr: string) => {
+    const row = rows?.find((r) => r.id === id);
+    if (!row) {
+      setError("找不到該候選資料，請重新整理後再試");
+      return;
+    }
+    const productName = deriveProductName(row);
+
     setBusy(true);
     try {
+      const sb = getSupabase();
+      // 呼叫 rpc_schedule_candidate：建 draft product + sku + campaign + items + 標 candidate scheduled
+      const { error: rpcErr } = await sb.rpc("rpc_schedule_candidate", {
+        p_candidate_id: id,
+        p_scheduled_date: dateStr,
+        p_product_name: productName,
+      });
+      if (rpcErr) throw rpcErr;
+
+      // RPC 不負責 scheduled_sort_order（行事曆排序遺留欄位），補一下
       const nextOrder = await nextSortOrderForDay(dateStr);
-      const { error: err } = await getSupabase()
+      await sb
         .from("community_product_candidates")
-        .update({
-          owner_action: "scheduled",
-          scheduled_open_at: dateStr,
-          scheduled_sort_order: nextOrder,
-          updated_at: new Date().toISOString(),
-        })
+        .update({ scheduled_sort_order: nextOrder })
         .eq("id", id);
-      if (err) throw err;
+
       await reload();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));

--- a/apps/admin/src/app/(protected)/finance/receivables/page.tsx
+++ b/apps/admin/src/app/(protected)/finance/receivables/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
+import { withBasePath } from "@/lib/basePath";
 
 type ReceivableStatus = "pending" | "partially_paid" | "paid" | "cancelled" | "disputed";
 type SourceType = "store_monthly_settlement" | "manual";
@@ -327,7 +328,7 @@ function ReceivableDetail({
       {receivable.source_type === "store_monthly_settlement" && receivable.source_id && (
         <div className="flex justify-end">
           <a
-            href={`/finance/receivables/print?settlement_id=${receivable.source_id}`}
+            href={withBasePath(`/finance/receivables/print?settlement_id=${receivable.source_id}`)}
             target="_blank"
             rel="noopener noreferrer"
             className="rounded-md border border-blue-300 bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300"

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { PickupDialog } from "@/components/PickupDialog";
+import { withBasePath } from "@/lib/basePath";
 
 type Member = {
   id: number;
@@ -166,7 +167,7 @@ export default function PickupPage() {
       if (errors.length > 0) setError(errors.join("\n"));
       if (eventIds.length > 0) {
         // 自動開列印（一張頁面、多張收據連續分頁）
-        window.open(`/pickup/print?event_ids=${eventIds.join(",")}`, "_blank");
+        window.open(withBasePath(`/pickup/print?event_ids=${eventIds.join(",")}`), "_blank");
       }
       alert(`完成 ${okCount}/${memberOrders.length} 張取貨${errors.length > 0 ? `\n失敗 ${errors.length} 張：\n${errors.join("\n")}` : ""}`);
       setReloadTick((t) => t + 1);

--- a/apps/admin/src/app/(protected)/products/page.tsx
+++ b/apps/admin/src/app/(protected)/products/page.tsx
@@ -131,11 +131,15 @@ function CreateCampaignModal({
     if (!endAt) { setError("請設定收單時間"); return; }
     setSaving(true); setError(null);
     try {
-      const { data, error: err } = await getSupabase().rpc("rpc_create_campaign_from_products", {
+      // 1 campaign : 1 product invariant — UI 端已限制 products.length=1
+      if (products.length !== 1) {
+        throw new Error("一個開團只能對應一個商品");
+      }
+      const { data, error: err } = await getSupabase().rpc("rpc_create_campaign_from_product", {
         p_name: name.trim(),
         p_end_at: new Date(endAt).toISOString(),
         p_pickup_deadline: pickupDeadline || null,
-        p_product_ids: products.map((p) => p.id),
+        p_product_id: products[0].id,
       });
       if (err) throw err;
       onCreated(Number(data));
@@ -242,6 +246,7 @@ function PageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const campaignMode = searchParams.get("mode") === "campaign";
+  const urlEditId = searchParams.get("id");
 
   const [rows, setRows] = useState<ProductRow[] | null>(null);
   const [total, setTotal] = useState(0);
@@ -276,6 +281,7 @@ function PageContent() {
   >(null);
   const [reloadTick, setReloadTick] = useState(0);
   const newSkuRef = useRef<ProductSkuSectionHandle | null>(null);
+  const lastUrlEditId = useRef<string | null>(null);
 
   async function openEdit(id: number) {
     const { data, error: err } = await getSupabase()
@@ -346,6 +352,17 @@ function PageContent() {
       }))
     );
   }
+
+  // 從 URL ?id=X 自動開啟商品編輯 modal（給 CampaignItemsTable 跳轉用）
+  useEffect(() => {
+    if (!urlEditId) return;
+    if (lastUrlEditId.current === urlEditId) return;
+    const idNum = Number(urlEditId);
+    if (!Number.isFinite(idNum) || idNum <= 0) return;
+    lastUrlEditId.current = urlEditId;
+    openEdit(idNum);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlEditId]);
 
   // debounce search
   useEffect(() => {
@@ -424,6 +441,10 @@ function PageContent() {
 
   function toggleSelect(id: number) {
     setSelectedIds((prev) => {
+      // 1 campaign : 1 product invariant — campaign mode 改成單選
+      if (campaignMode) {
+        return prev.has(id) ? new Set() : new Set([id]);
+      }
       const next = new Set(prev);
       if (next.has(id)) next.delete(id); else next.add(id);
       return next;

--- a/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
+import { withBasePath } from "@/lib/basePath";
 
 type SettlementStatus = "draft" | "confirmed" | "settled" | "disputed";
 type SettlementStatusExt = SettlementStatus | "cancelled";
@@ -431,7 +432,7 @@ function HqToStoreDetail({
           )}
         </div>
         <a
-          href={`/finance/receivables/print?settlement_id=${settlement.id}`}
+          href={withBasePath(`/finance/receivables/print?settlement_id=${settlement.id}`)}
           target="_blank"
           rel="noopener noreferrer"
           className="rounded-md border border-blue-300 bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300"

--- a/apps/admin/src/components/CampaignForm.tsx
+++ b/apps/admin/src/components/CampaignForm.tsx
@@ -38,16 +38,21 @@ export const emptyCampaignValues: CampaignFormValues = {
   notes: null,
 };
 
+// 使用者可手動切換的狀態僅 3 個；ordered / receiving / ready / completed / cancelled
+// 由下游 RPC（建 PR / 收貨 / finalize / cancel）自動推進，不在 UI 下拉中
 const STATUS_OPT: { v: CampaignStatus; label: string }[] = [
   { v: "draft", label: "草稿" },
   { v: "open", label: "開團中" },
   { v: "closed", label: "已收單" },
-  { v: "ordered", label: "已下訂" },
-  { v: "receiving", label: "到貨中" },
-  { v: "ready", label: "可取貨" },
-  { v: "completed", label: "已完成" },
-  { v: "cancelled", label: "已取消" },
 ];
+
+const DOWNSTREAM_LABEL: Record<string, string> = {
+  ordered: "已下訂",
+  receiving: "到貨中",
+  ready: "可取貨",
+  completed: "已完成",
+  cancelled: "已取消",
+};
 
 export function CampaignForm({
   initial,
@@ -71,13 +76,38 @@ export function CampaignForm({
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!v.name) { setError("名稱必填"); return; }
     setSaving(true); setError(null);
     try {
+      // 開團驗證：status='open' 時、所有關聯商品需為 'active'（不可有 draft 商品）
+      if (v.status === "open" && v.id != null) {
+        const sb = getSupabase();
+        const { data: items } = await sb
+          .from("campaign_items")
+          .select("sku_id")
+          .eq("campaign_id", v.id);
+        const skuIds = (items ?? []).map((it) => it.sku_id);
+        if (skuIds.length === 0) {
+          throw new Error("開團前需至少有一個商品（規格）");
+        }
+        const { data: skus } = await sb.from("skus").select("product_id").in("id", skuIds);
+        const productIds = [...new Set((skus ?? []).map((s) => s.product_id))];
+        const { data: products } = await sb
+          .from("products")
+          .select("id, product_code, name, status")
+          .in("id", productIds);
+        const drafts = (products ?? []).filter((p) => p.status !== "active");
+        if (drafts.length > 0) {
+          const list = drafts.map((p) => `${p.product_code} ${p.name}（${p.status}）`).join("、");
+          throw new Error(`下列商品尚未上架，無法開團：${list}`);
+        }
+      }
+
+      // 名稱 / 描述 / 收單時間 / 取貨截止 / 取貨天數 / 總量上限 / 備註
+      // 都從商品 / RPC 自動帶入；UI 不可編輯，保留原值送回。
       const { data, error: err } = await getSupabase().rpc("rpc_upsert_campaign", {
         p_id: v.id,
         p_campaign_no: v.campaign_no.trim(),
-        p_name: v.name.trim(),
+        p_name: (v.name || "(open campaign)").trim(),
         p_description: v.description,
         p_status: v.status,
         p_close_type: v.close_type,
@@ -108,13 +138,18 @@ export function CampaignForm({
         <Field label="狀態">
           <select value={v.status} onChange={(e) => update("status", e.target.value as CampaignStatus)} className={inputCls}>
             {STATUS_OPT.map((o) => <option key={o.v} value={o.v}>{o.label}</option>)}
+            {/* 若 campaign 已被下游推進到 ordered/... 也保留現值在選單中（disabled），避免顯示空白 */}
+            {!STATUS_OPT.some((o) => o.v === v.status) && (
+              <option value={v.status} disabled>
+                {DOWNSTREAM_LABEL[v.status] ?? v.status}（系統推進中）
+              </option>
+            )}
           </select>
         </Field>
 
-        <Field label="名稱 *" className="sm:col-span-2">
-          <input value={v.name} onChange={(e) => update("name", e.target.value)} className={inputCls} required />
+        <Field label="開團時間">
+          <input type="datetime-local" value={toDtLocal(v.start_at)} onChange={(e) => update("start_at", e.target.value ? new Date(e.target.value).toISOString() : null)} className={inputCls} />
         </Field>
-
         <Field label="收單類型">
           <select value={v.close_type} onChange={(e) => update("close_type", e.target.value as CloseType)} className={inputCls}>
             <option value="regular">常規</option>
@@ -122,31 +157,24 @@ export function CampaignForm({
             <option value="limited">限量</option>
           </select>
         </Field>
-        <Field label="總量上限">
-          <input type="number" step="0.001" value={v.total_cap_qty ?? ""} onChange={(e) => update("total_cap_qty", e.target.value ? Number(e.target.value) : null)} className={inputCls} />
-        </Field>
-
-        <Field label="開團時間">
-          <input type="datetime-local" value={toDtLocal(v.start_at)} onChange={(e) => update("start_at", e.target.value ? new Date(e.target.value).toISOString() : null)} className={inputCls} />
-        </Field>
-        <Field label="收單時間">
-          <input type="datetime-local" value={toDtLocal(v.end_at)} onChange={(e) => update("end_at", e.target.value ? new Date(e.target.value).toISOString() : null)} className={inputCls} />
-        </Field>
-
-        <Field label="取貨截止">
-          <input type="date" value={v.pickup_deadline ?? ""} onChange={(e) => update("pickup_deadline", e.target.value || null)} className={inputCls} />
-        </Field>
-        <Field label="取貨天數">
-          <input type="number" min="0" value={v.pickup_days ?? ""} onChange={(e) => update("pickup_days", e.target.value ? Number(e.target.value) : null)} className={inputCls} />
-        </Field>
+        {v.close_type === "limited" && (
+          <Field label="總量上限（限量團）" className="sm:col-span-2">
+            <input
+              type="number"
+              min="0"
+              step="1"
+              placeholder="整團總量上限數字"
+              value={v.total_cap_qty ?? ""}
+              onChange={(e) => update("total_cap_qty", e.target.value ? Number(e.target.value) : null)}
+              className={inputCls}
+            />
+          </Field>
+        )}
       </div>
 
-      <Field label="描述">
-        <textarea value={v.description ?? ""} onChange={(e) => update("description", e.target.value || null)} className={`${inputCls} min-h-16`} />
-      </Field>
-      <Field label="備註">
-        <textarea value={v.notes ?? ""} onChange={(e) => update("notes", e.target.value || null)} className={`${inputCls} min-h-16`} />
-      </Field>
+      <p className="text-xs text-zinc-500 dark:text-zinc-400">
+        其他資訊（名稱、描述、收單時間、取貨截止 / 天數、總量上限）依商品自動帶入；如需調整請至商品編輯頁。
+      </p>
 
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">{error}</div>

--- a/apps/admin/src/components/CampaignItemsTable.tsx
+++ b/apps/admin/src/components/CampaignItemsTable.tsx
@@ -1,18 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 
 type Row = {
   id: number;
   sku_id: number;
   sku_code: string;
+  product_id: number;
   product_name: string | null;
   variant_name: string | null;
   unit_price: number;
   cap_qty: number | null;
   sort_order: number;
   notes: string | null;
+  locked_at: string | null;
 };
 
 export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
@@ -20,32 +23,53 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
   const [error, setError] = useState<string | null>(null);
 
   const reload = async () => {
+    // products.name 是 source of truth；skus.product_name 是 denorm 可能過期、不用它
     const { data, error: err } = await getSupabase()
       .from("campaign_items")
-      .select("id, sku_id, unit_price, cap_qty, sort_order, notes, skus!inner(id, sku_code, product_name, variant_name)")
+      .select("id, sku_id, unit_price, cap_qty, sort_order, notes, locked_at, skus!inner(id, sku_code, product_id, variant_name, products!inner(id, name))")
       .eq("campaign_id", campaignId)
       .order("sort_order");
     if (err) { setError(err.message); return; }
     setRows(
       (data as unknown as Array<{
         id: number; sku_id: number; unit_price: number; cap_qty: number | null;
-        sort_order: number; notes: string | null;
-        skus: { id: number; sku_code: string; product_name: string | null; variant_name: string | null };
+        sort_order: number; notes: string | null; locked_at: string | null;
+        skus: { id: number; sku_code: string; product_id: number; variant_name: string | null;
+          products: { id: number; name: string };
+        };
       }>).map((r) => ({
         id: r.id, sku_id: r.sku_id, sku_code: r.skus.sku_code,
-        product_name: r.skus.product_name, variant_name: r.skus.variant_name,
+        product_id: r.skus.product_id,
+        product_name: r.skus.products?.name ?? null,
+        variant_name: r.skus.variant_name,
         unit_price: Number(r.unit_price), cap_qty: r.cap_qty != null ? Number(r.cap_qty) : null,
-        sort_order: r.sort_order, notes: r.notes,
+        sort_order: r.sort_order, notes: r.notes, locked_at: r.locked_at,
       }))
     );
   };
 
   useEffect(() => { reload(); }, [campaignId]);
 
+  const anyLocked = (rows ?? []).some((r) => !!r.locked_at);
+  const earliestLock = (rows ?? [])
+    .map((r) => r.locked_at)
+    .filter((t): t is string => !!t)
+    .sort()[0];
+
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold">商品明細</h2>
+        <div className="flex items-baseline gap-2">
+          <h2 className="text-base font-semibold">商品明細</h2>
+          {anyLocked && earliestLock && (
+            <span
+              title="開團（status=open）後活動單價已 snapshot 鎖定，零售價變動不再影響此團"
+              className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-200"
+            >
+              🔒 已鎖定 {new Date(earliestLock).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" })}
+            </span>
+          )}
+        </div>
         <span className="text-xs text-zinc-500">{rows?.length ?? 0} 項</span>
       </div>
 
@@ -57,23 +81,38 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr>
-              <Th>規格</Th><Th>名稱</Th><Th className="text-right">單價</Th><Th className="text-right">量上限</Th>
+              <Th>規格</Th><Th>名稱</Th><Th className="text-right">單價</Th><Th className="text-right">量上限</Th><Th>鎖定時間</Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={4} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={5} className="p-3 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={4} className="p-6 text-center text-zinc-500">尚無商品</td></tr>
+              <tr><td colSpan={5} className="p-6 text-center text-zinc-500">尚無商品</td></tr>
             ) : rows.map((r) => (
               <tr key={r.id}>
-                <Td className="font-mono">{r.sku_code}</Td>
+                <Td className="font-mono">
+                  <Link
+                    href={`/products?id=${r.product_id}`}
+                    className="text-blue-600 hover:underline dark:text-blue-400"
+                    title="點此跳轉到商品編輯頁"
+                  >
+                    {r.sku_code}
+                  </Link>
+                </Td>
                 <Td>
-                  <div>{r.product_name ?? "—"}</div>
-                  {r.variant_name && <div className="text-xs text-zinc-500">{r.variant_name}</div>}
+                  <div className="text-xs text-zinc-500">{r.product_name ?? "—"}</div>
+                  {r.variant_name && (
+                    <div className="text-base font-bold text-zinc-900 dark:text-zinc-100">
+                      {r.variant_name}
+                    </div>
+                  )}
                 </Td>
                 <Td className="text-right font-mono">${r.unit_price}</Td>
                 <Td className="text-right text-xs text-zinc-500">{r.cap_qty ?? "—"}</Td>
+                <Td className="text-xs text-zinc-500">
+                  {r.locked_at ? new Date(r.locked_at).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" }) : "—"}
+                </Td>
               </tr>
             ))}
           </tbody>

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -5,6 +5,7 @@ import { getSupabase } from "@/lib/supabase";
 import { OrderTransferModal } from "@/components/OrderTransferModal";
 import { PickupDialog } from "@/components/PickupDialog";
 import { AidOrderTimeline } from "@/components/AidOrderTimeline";
+import { withBasePath } from "@/lib/basePath";
 
 type OrderHead = {
   id: number;
@@ -600,7 +601,7 @@ function Timeline({ steps }: { steps: TimelineStep[] | null }) {
                   </button>
                 ) : s.detailHref ? (
                   <a
-                    href={s.detailHref}
+                    href={withBasePath(s.detailHref)}
                     className="text-[10px] font-mono text-blue-600 hover:underline dark:text-blue-400"
                   >
                     {s.detail}

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
+import { withBasePath } from "@/lib/basePath";
 
 type PickableItem = {
   id: number;
@@ -78,7 +79,7 @@ export function PickupDialog({
       if (error) { setErr(error.message); return; }
       const result = data as { event_id: number; new_order_status: string; picked_count: number; active_remaining: number };
       // 自動開新分頁列印
-      window.open(`/pickup/print?event_ids=${result.event_id}`, "_blank");
+      window.open(withBasePath(`/pickup/print?event_ids=${result.event_id}`), "_blank");
       onPickedUp(result);
     } finally {
       setBusy(false);

--- a/apps/admin/src/components/ProductForm.tsx
+++ b/apps/admin/src/components/ProductForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { ProductImagesField } from "@/components/ProductImagesField";
 import { CategoryCombobox, type CategoryOption } from "@/components/CategoryCombobox";
+import { RichTextEditor } from "@/components/RichTextEditor";
 
 type Status = "draft" | "active" | "inactive" | "discontinued";
 type StorageType = "room_temp" | "refrigerated" | "frozen" | "meal_train";
@@ -121,6 +122,40 @@ export function ProductForm({
     if (values.customized_text && values.customized_text.length > 7) {
       setError("客製文字最多 7 字");
       return;
+    }
+
+    // 上架驗證：至少一個規格要有 cost / retail / branch 三種價格
+    if (values.status === "active") {
+      if (values.id == null) {
+        setError("新商品請先儲存為「草稿」、補完一個規格的成本/零售/分店三種價格後再切到「上架」");
+        return;
+      }
+      const sb = getSupabase();
+      const { data: skus } = await sb.from("skus").select("id").eq("product_id", values.id);
+      if (!skus?.length) {
+        setError("上架前需先新增至少一個規格");
+        return;
+      }
+      const skuIds = skus.map((s) => s.id);
+      const { data: prices } = await sb
+        .from("prices")
+        .select("sku_id, scope")
+        .in("sku_id", skuIds)
+        .in("scope", ["retail", "cost", "branch"])
+        .is("effective_to", null);
+      const m = new Map<number, Set<string>>();
+      for (const p of (prices ?? []) as { sku_id: number; scope: string }[]) {
+        const set = m.get(p.sku_id) ?? new Set<string>();
+        set.add(p.scope);
+        m.set(p.sku_id, set);
+      }
+      const ok = [...m.values()].some(
+        (s) => s.has("retail") && s.has("cost") && s.has("branch")
+      );
+      if (!ok) {
+        setError("上架需至少一個規格已設定成本 / 零售 / 分店三種價格");
+        return;
+      }
     }
 
     let code = values.product_code;
@@ -293,11 +328,10 @@ export function ProductForm({
       </div>
 
       <Field label="描述">
-        <textarea
-          rows={4}
+        <RichTextEditor
           value={values.description}
-          onChange={(e) => set("description", e.target.value)}
-          className={inputClass}
+          onChange={(html) => set("description", html)}
+          placeholder="輸入商品描述、可加粗體、列表、連結…"
         />
       </Field>
 

--- a/apps/admin/src/components/ProductSkuSection.tsx
+++ b/apps/admin/src/components/ProductSkuSection.tsx
@@ -8,6 +8,7 @@ import {
   type Ref,
 } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { useRole, canSeeCost, canSeeBranch, type Role } from "@/lib/role";
 
 type Sku = {
   id: number;
@@ -16,7 +17,9 @@ type Sku = {
   base_unit: string;
 };
 
-type PriceRow = { sku_id: number; price: number; effective_from: string };
+type PriceScope = "retail" | "cost" | "branch";
+type PriceRow = { sku_id: number; price: number; scope: PriceScope; effective_from: string };
+type PriceMap = { retail?: number; cost?: number; branch?: number };
 
 type Draft = {
   id: number | null;
@@ -24,6 +27,8 @@ type Draft = {
   variant_name: string;
   base_unit: string;
   retail_price: string;
+  cost_price: string;
+  branch_price: string;
 };
 
 type PendingSku = Draft & { tempId: number };
@@ -34,7 +39,45 @@ const EMPTY_DRAFT: Draft = {
   variant_name: "",
   base_unit: "個",
   retail_price: "",
+  cost_price: "",
+  branch_price: "",
 };
+
+// 寫 retail / cost / branch 三種價格。空字串跳過、與 existing 同值跳過、
+// 角色不允許的 scope 也跳過（若角色看不到，DraftCard 該欄位本來就不渲染、永遠空字串）。
+async function writePrices(
+  skuId: number,
+  draft: { retail_price: string; cost_price: string; branch_price: string },
+  role: Role | null,
+  existing?: PriceMap
+) {
+  const sb = getSupabase();
+  const now = new Date().toISOString();
+  type PriceJob = { rpc: string; field: keyof PriceMap; value: string };
+  const jobs: PriceJob[] = [
+    { rpc: "rpc_set_retail_price", field: "retail", value: draft.retail_price },
+    { rpc: "rpc_set_cost_price", field: "cost", value: draft.cost_price },
+    { rpc: "rpc_set_branch_price", field: "branch", value: draft.branch_price },
+  ];
+  for (const job of jobs) {
+    const trimmed = job.value.trim();
+    if (trimmed === "") continue;
+    if (job.field === "cost" && !canSeeCost(role)) continue;
+    if (job.field === "branch" && !canSeeBranch(role)) continue;
+    const num = Number(trimmed);
+    if (!Number.isFinite(num) || num < 0) {
+      throw new Error(`${job.field} 價格必須為 ≥ 0 的數字`);
+    }
+    if (existing && existing[job.field] === num) continue;
+    const { error } = await sb.rpc(job.rpc, {
+      p_sku_id: skuId,
+      p_price: num,
+      p_effective_from: now,
+      p_reason: null,
+    });
+    if (error) throw error;
+  }
+}
 
 export type ProductSkuSectionHandle = {
   flush: (productId: number) => Promise<void>;
@@ -49,9 +92,12 @@ export function ProductSkuSection({
   ref?: Ref<ProductSkuSectionHandle>;
 }) {
   const isPending = productId === null;
+  const role = useRole();
+  const showCost = canSeeCost(role);
+  const showBranch = canSeeBranch(role);
 
   const [skus, setSkus] = useState<Sku[] | null>(isPending ? [] : null);
-  const [prices, setPrices] = useState<Record<number, number>>({});
+  const [prices, setPrices] = useState<Record<number, PriceMap>>({});
   const [pending, setPending] = useState<PendingSku[]>([]);
   const [editingTempId, setEditingTempId] = useState<number | null>(null);
   const [draft, setDraft] = useState<Draft | null>(null);
@@ -76,16 +122,18 @@ export function ProductSkuSection({
 
     if (list.length > 0) {
       const ids = list.map((s) => s.id);
+      // RLS 自動依 role × scope 過濾 — store_staff 拿不到 cost/branch、store_manager 拿不到 cost
       const { data: priceRows } = await sb
         .from("prices")
-        .select("sku_id, price, effective_from")
-        .eq("scope", "retail")
+        .select("sku_id, price, scope, effective_from")
+        .in("scope", ["retail", "cost", "branch"])
         .is("effective_to", null)
         .in("sku_id", ids)
         .order("effective_from", { ascending: false });
-      const map: Record<number, number> = {};
+      const map: Record<number, PriceMap> = {};
       for (const row of (priceRows ?? []) as PriceRow[]) {
-        if (!(row.sku_id in map)) map[row.sku_id] = Number(row.price);
+        const slot = (map[row.sku_id] ??= {});
+        if (slot[row.scope] === undefined) slot[row.scope] = Number(row.price);
       }
       setPrices(map);
     } else {
@@ -118,21 +166,12 @@ export function ProductSkuSection({
             p_reason: null,
           });
           if (rpcErr) throw rpcErr;
-          const priceStr = p.retail_price.trim();
-          if (priceStr !== "") {
-            const { error: priceErr } = await sb.rpc("rpc_set_retail_price", {
-              p_sku_id: skuId,
-              p_price: Number(priceStr),
-              p_effective_from: new Date().toISOString(),
-              p_reason: null,
-            });
-            if (priceErr) throw priceErr;
-          }
+          await writePrices(skuId as number, p, role);
         }
         setPending([]);
       },
     }),
-    [pending]
+    [pending, role]
   );
 
   async function startNew() {
@@ -143,17 +182,46 @@ export function ProductSkuSection({
       });
       if (typeof data === "string") code = data;
     }
-    setDraft({ ...EMPTY_DRAFT, sku_code: code });
+    // 帶入第一筆規格的價格 / base_unit（已存的優先、否則用 pending 第一筆）
+    const firstSaved = skus && skus.length > 0 ? skus[0] : null;
+    const firstPending = pending.length > 0 ? pending[0] : null;
+    let prefilledRetail = "";
+    let prefilledCost = "";
+    let prefilledBranch = "";
+    let prefilledUnit = EMPTY_DRAFT.base_unit;
+    if (firstSaved) {
+      const p = prices[firstSaved.id] ?? {};
+      prefilledRetail = p.retail !== undefined ? String(p.retail) : "";
+      prefilledCost = p.cost !== undefined ? String(p.cost) : "";
+      prefilledBranch = p.branch !== undefined ? String(p.branch) : "";
+      prefilledUnit = firstSaved.base_unit || prefilledUnit;
+    } else if (firstPending) {
+      prefilledRetail = firstPending.retail_price;
+      prefilledCost = firstPending.cost_price;
+      prefilledBranch = firstPending.branch_price;
+      prefilledUnit = firstPending.base_unit || prefilledUnit;
+    }
+    setDraft({
+      ...EMPTY_DRAFT,
+      sku_code: code,
+      base_unit: prefilledUnit,
+      retail_price: prefilledRetail,
+      cost_price: prefilledCost,
+      branch_price: prefilledBranch,
+    });
     setEditingTempId(null);
   }
 
   function startEditExisting(sku: Sku) {
+    const p = prices[sku.id] ?? {};
     setDraft({
       id: sku.id,
       sku_code: sku.sku_code,
       variant_name: sku.variant_name ?? "",
       base_unit: sku.base_unit,
-      retail_price: sku.id in prices ? String(prices[sku.id]) : "",
+      retail_price: p.retail !== undefined ? String(p.retail) : "",
+      cost_price: p.cost !== undefined ? String(p.cost) : "",
+      branch_price: p.branch !== undefined ? String(p.branch) : "",
     });
     setEditingTempId(null);
   }
@@ -165,6 +233,8 @@ export function ProductSkuSection({
       variant_name: p.variant_name,
       base_unit: p.base_unit,
       retail_price: p.retail_price,
+      cost_price: p.cost_price,
+      branch_price: p.branch_price,
     });
     setEditingTempId(p.tempId);
   }
@@ -222,20 +292,8 @@ export function ProductSkuSection({
       });
       if (rpcErr) throw rpcErr;
 
-      const priceStr = draft.retail_price.trim();
-      if (priceStr !== "") {
-        const priceNum = Number(priceStr);
-        const existing = skuId in prices ? prices[skuId as number] : null;
-        if (existing !== priceNum) {
-          const { error: priceErr } = await sb.rpc("rpc_set_retail_price", {
-            p_sku_id: skuId,
-            p_price: priceNum,
-            p_effective_from: new Date().toISOString(),
-            p_reason: null,
-          });
-          if (priceErr) throw priceErr;
-        }
-      }
+      const existing = (skuId as number) in prices ? prices[skuId as number] : {};
+      await writePrices(skuId as number, draft, role, existing);
 
       cancelEdit();
       await refresh();
@@ -308,12 +366,16 @@ export function ProductSkuSection({
               onSave={save}
               onCancel={cancelEdit}
               saving={saving}
+              showCost={showCost}
+              showBranch={showBranch}
             />
           ) : (
             <SkuCard
               key={s.id}
               sku={s}
-              price={prices[s.id]}
+              priceMap={prices[s.id] ?? {}}
+              showCost={showCost}
+              showBranch={showBranch}
               onEdit={() => startEditExisting(s)}
               onDelete={() => deleteSku(s)}
             />
@@ -329,11 +391,15 @@ export function ProductSkuSection({
               onSave={save}
               onCancel={cancelEdit}
               saving={saving}
+              showCost={showCost}
+              showBranch={showBranch}
             />
           ) : (
             <PendingCard
               key={p.tempId}
               p={p}
+              showCost={showCost}
+              showBranch={showBranch}
               onEdit={() => startEditPending(p)}
               onDelete={() => deletePending(p.tempId)}
             />
@@ -347,6 +413,8 @@ export function ProductSkuSection({
             onSave={save}
             onCancel={cancelEdit}
             saving={saving}
+            showCost={showCost}
+            showBranch={showBranch}
           />
         )}
 
@@ -368,12 +436,16 @@ export function ProductSkuSection({
 
 function SkuCard({
   sku,
-  price,
+  priceMap,
+  showCost,
+  showBranch,
   onEdit,
   onDelete,
 }: {
   sku: Sku;
-  price: number | undefined;
+  priceMap: PriceMap;
+  showCost: boolean;
+  showBranch: boolean;
   onEdit: () => void;
   onDelete: () => void;
 }) {
@@ -388,9 +460,23 @@ function SkuCard({
             </span>
           )}
         </div>
-        <div className="mt-0.5 text-xs text-zinc-500">
-          {sku.base_unit}
-          {price != null ? ` · $${price}` : ""}
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500">
+          <span>{sku.base_unit}</span>
+          {priceMap.retail !== undefined && (
+            <span className="rounded bg-emerald-100 px-1.5 py-0.5 font-bold text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+              零售 ${priceMap.retail}
+            </span>
+          )}
+          {showBranch && priceMap.branch !== undefined && (
+            <span className="rounded bg-amber-100 px-1.5 py-0.5 font-bold text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+              分店 ${priceMap.branch}
+            </span>
+          )}
+          {showCost && priceMap.cost !== undefined && (
+            <span className="rounded bg-rose-100 px-1.5 py-0.5 font-bold text-rose-800 dark:bg-rose-950 dark:text-rose-300">
+              成本 ${priceMap.cost}
+            </span>
+          )}
         </div>
       </div>
       <button
@@ -413,10 +499,14 @@ function SkuCard({
 
 function PendingCard({
   p,
+  showCost,
+  showBranch,
   onEdit,
   onDelete,
 }: {
   p: PendingSku;
+  showCost: boolean;
+  showBranch: boolean;
   onEdit: () => void;
   onDelete: () => void;
 }) {
@@ -434,9 +524,23 @@ function PendingCard({
             待寫入
           </span>
         </div>
-        <div className="mt-0.5 text-xs text-zinc-500">
-          {p.base_unit}
-          {p.retail_price ? ` · $${p.retail_price}` : ""}
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500">
+          <span>{p.base_unit}</span>
+          {p.retail_price && (
+            <span className="rounded bg-emerald-100 px-1.5 py-0.5 font-bold text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+              零售 ${p.retail_price}
+            </span>
+          )}
+          {showBranch && p.branch_price && (
+            <span className="rounded bg-amber-100 px-1.5 py-0.5 font-bold text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+              分店 ${p.branch_price}
+            </span>
+          )}
+          {showCost && p.cost_price && (
+            <span className="rounded bg-rose-100 px-1.5 py-0.5 font-bold text-rose-800 dark:bg-rose-950 dark:text-rose-300">
+              成本 ${p.cost_price}
+            </span>
+          )}
         </div>
       </div>
       <button
@@ -463,12 +567,16 @@ function DraftCard({
   onSave,
   onCancel,
   saving,
+  showCost,
+  showBranch,
 }: {
   draft: Draft;
   setDraft: (d: Draft) => void;
   onSave: () => void;
   onCancel: () => void;
   saving: boolean;
+  showCost: boolean;
+  showBranch: boolean;
 }) {
   function set<K extends keyof Draft>(key: K, value: Draft[K]) {
     setDraft({ ...draft, [key]: value });
@@ -510,6 +618,30 @@ function DraftCard({
             className={inputClass}
           />
         </Field>
+        {showBranch && (
+          <Field label="分店價">
+            <input
+              type="number"
+              step="0.01"
+              value={draft.branch_price}
+              onChange={(e) => set("branch_price", e.target.value)}
+              placeholder="$（全分店共用）"
+              className={inputClass}
+            />
+          </Field>
+        )}
+        {showCost && (
+          <Field label="成本價">
+            <input
+              type="number"
+              step="0.01"
+              value={draft.cost_price}
+              onChange={(e) => set("cost_price", e.target.value)}
+              placeholder="$（進貨成本）"
+              className={inputClass}
+            />
+          </Field>
+        )}
       </div>
       <div className="flex items-center gap-2">
         <button

--- a/apps/admin/src/components/RichTextEditor.tsx
+++ b/apps/admin/src/components/RichTextEditor.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEditor, EditorContent, type Editor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Link from "@tiptap/extension-link";
+import { useEffect } from "react";
+
+type Props = {
+  value: string;
+  onChange: (html: string) => void;
+  placeholder?: string;
+  minHeight?: number;
+  disabled?: boolean;
+};
+
+export function RichTextEditor({ value, onChange, placeholder, minHeight = 160, disabled }: Props) {
+  const editor = useEditor({
+    immediatelyRender: false,
+    editable: !disabled,
+    extensions: [
+      StarterKit.configure({
+        heading: { levels: [1, 2, 3] },
+      }),
+      Link.configure({
+        openOnClick: false,
+        autolink: true,
+        HTMLAttributes: {
+          class: "text-blue-600 underline dark:text-blue-400",
+          rel: "noopener noreferrer",
+          target: "_blank",
+        },
+      }),
+    ],
+    content: value || "",
+    editorProps: {
+      attributes: {
+        class:
+          "prose prose-sm max-w-none focus:outline-none dark:prose-invert px-3 py-2 " +
+          (disabled ? "cursor-not-allowed opacity-60 " : ""),
+        style: `min-height:${minHeight}px`,
+      },
+    },
+    onUpdate({ editor }) {
+      onChange(editor.getHTML());
+    },
+  });
+
+  useEffect(() => {
+    if (!editor) return;
+    if (editor.getHTML() !== value) {
+      editor.commands.setContent(value || "", { emitUpdate: false });
+    }
+  }, [value, editor]);
+
+  if (!editor) {
+    return (
+      <div
+        className="rounded-md border border-zinc-300 bg-white p-3 text-sm text-zinc-400 dark:border-zinc-700 dark:bg-zinc-900"
+        style={{ minHeight }}
+      >
+        {placeholder ?? "編輯器載入中…"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-zinc-300 bg-white dark:border-zinc-700 dark:bg-zinc-900">
+      <Toolbar editor={editor} disabled={disabled} />
+      <EditorContent editor={editor} />
+    </div>
+  );
+}
+
+function Toolbar({ editor, disabled }: { editor: Editor; disabled?: boolean }) {
+  const btn = (active: boolean) =>
+    `rounded px-2 py-1 text-xs font-medium ${
+      active
+        ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+        : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+    } ${disabled ? "pointer-events-none opacity-40" : ""}`;
+
+  const setLink = () => {
+    const previousUrl = editor.getAttributes("link").href as string | undefined;
+    const url = window.prompt("輸入連結 URL（留空清除）", previousUrl ?? "");
+    if (url === null) return;
+    if (url === "") {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+      return;
+    }
+    editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run();
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-1 border-b border-zinc-200 bg-zinc-50 px-2 py-1.5 dark:border-zinc-800 dark:bg-zinc-950/50">
+      <button type="button" className={btn(editor.isActive("bold"))} onClick={() => editor.chain().focus().toggleBold().run()} aria-label="粗體">
+        <strong>B</strong>
+      </button>
+      <button type="button" className={btn(editor.isActive("italic"))} onClick={() => editor.chain().focus().toggleItalic().run()} aria-label="斜體">
+        <em>I</em>
+      </button>
+      <button type="button" className={btn(editor.isActive("strike"))} onClick={() => editor.chain().focus().toggleStrike().run()} aria-label="刪除線">
+        <s>S</s>
+      </button>
+      <span className="mx-1 h-4 w-px bg-zinc-300 dark:bg-zinc-700" />
+      <button type="button" className={btn(editor.isActive("heading", { level: 1 }))} onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}>
+        H1
+      </button>
+      <button type="button" className={btn(editor.isActive("heading", { level: 2 }))} onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}>
+        H2
+      </button>
+      <button type="button" className={btn(editor.isActive("heading", { level: 3 }))} onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}>
+        H3
+      </button>
+      <span className="mx-1 h-4 w-px bg-zinc-300 dark:bg-zinc-700" />
+      <button type="button" className={btn(editor.isActive("bulletList"))} onClick={() => editor.chain().focus().toggleBulletList().run()}>
+        • 列
+      </button>
+      <button type="button" className={btn(editor.isActive("orderedList"))} onClick={() => editor.chain().focus().toggleOrderedList().run()}>
+        1. 列
+      </button>
+      <button type="button" className={btn(editor.isActive("blockquote"))} onClick={() => editor.chain().focus().toggleBlockquote().run()}>
+        ❝
+      </button>
+      <span className="mx-1 h-4 w-px bg-zinc-300 dark:bg-zinc-700" />
+      <button type="button" className={btn(editor.isActive("link"))} onClick={setLink}>
+        🔗
+      </button>
+      <button type="button" className={btn(false)} onClick={() => editor.chain().focus().setHorizontalRule().run()}>
+        ─
+      </button>
+      <span className="mx-1 h-4 w-px bg-zinc-300 dark:bg-zinc-700" />
+      <button type="button" className={btn(false)} onClick={() => editor.chain().focus().undo().run()} disabled={!editor.can().undo()}>
+        ↶
+      </button>
+      <button type="button" className={btn(false)} onClick={() => editor.chain().focus().redo().run()} disabled={!editor.can().redo()}>
+        ↷
+      </button>
+    </div>
+  );
+}

--- a/apps/admin/src/lib/basePath.ts
+++ b/apps/admin/src/lib/basePath.ts
@@ -1,0 +1,13 @@
+// Next.js's <Link> auto-prefixes basePath, but raw <a href> and window.open
+// don't. Use this for those cases (especially print pages opened via
+// window.open and external-style <a target="_blank"> links).
+export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
+export function withBasePath(path: string): string {
+  if (!path) return path;
+  if (/^https?:\/\//i.test(path) || path.startsWith("mailto:") || path.startsWith("tel:")) {
+    return path;
+  }
+  if (!path.startsWith("/")) return path;
+  return BASE_PATH + path;
+}

--- a/apps/admin/src/lib/role.ts
+++ b/apps/admin/src/lib/role.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+
+// JWT app_metadata.role values used across the project.
+// Empty string ("") = legacy / dev admin without explicit role; treated as admin tier.
+export type Role =
+  | "owner"
+  | "admin"
+  | "hq_manager"
+  | "hq_accountant"
+  | "assistant"
+  | "store_manager"
+  | "store_staff"
+  | "";
+
+const HQ_ROLES: Role[] = ["owner", "admin", "hq_manager", "hq_accountant", ""];
+const BRANCH_ROLES: Role[] = ["owner", "admin", "hq_manager", "hq_accountant", "store_manager", ""];
+
+export function canSeeCost(role: Role | null): boolean {
+  if (role === null) return false;
+  return HQ_ROLES.includes(role);
+}
+
+export function canSeeBranch(role: Role | null): boolean {
+  if (role === null) return false;
+  return BRANCH_ROLES.includes(role);
+}
+
+export function useRole(): Role | null {
+  const [role, setRole] = useState<Role | null>(null);
+
+  useEffect(() => {
+    const sb = getSupabase();
+    let active = true;
+    sb.auth.getSession().then(({ data }) => {
+      if (!active) return;
+      const meta = data.session?.user?.app_metadata as Record<string, unknown> | undefined;
+      const raw = (meta?.role as string | undefined) ?? "";
+      setRole(raw as Role);
+    });
+    const sub = sb.auth.onAuthStateChange((_event, session) => {
+      const meta = session?.user?.app_metadata as Record<string, unknown> | undefined;
+      const raw = (meta?.role as string | undefined) ?? "";
+      setRole(raw as Role);
+    });
+    return () => {
+      active = false;
+      sub.data.subscription.unsubscribe();
+    };
+  }, []);
+
+  return role;
+}

--- a/docs/TEST-candidate-to-draft-and-pricing.md
+++ b/docs/TEST-candidate-to-draft-and-pricing.md
@@ -1,0 +1,246 @@
+# 候選池→草稿商品+草稿開團 / 三層價格 / 角色顯隱 / 開團行事曆 測試項目
+
+**對應 migration（待建）:**
+- `supabase/migrations/<ts>_prices_scope_cost_branch.sql`（prices.scope CHECK 加 cost/branch）
+- `supabase/migrations/<ts>_rpc_set_cost_branch_price.sql`（兩支價格 wrapper）
+- `supabase/migrations/<ts>_rpc_schedule_candidate.sql`（schedule → draft product+sku+campaign+items）
+- `supabase/migrations/<ts>_prices_role_rls.sql`（依 role 過濾 cost/branch）
+
+**對應 UI 變更（待建）:**
+- `apps/admin/src/app/(protected)/products/edit/page.tsx`（加成本/分店價、依 role 顯隱）
+- `apps/admin/src/app/(protected)/products/page.tsx`（status badge / draft filter）
+- `apps/admin/src/app/(protected)/community-candidates/page.tsx`（排日期改呼叫新 RPC、移除採用、加跳轉連結）
+- `apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx`（**移除**或 redirect → /campaigns）
+- `apps/admin/src/app/(protected)/campaigns/page.tsx`（加 7 天 / 月曆視圖、完整度檢查、開團按鈕）
+- `apps/admin/src/app/(protected)/layout.tsx`（sidebar 移除「社群選品 → 週曆」項）
+
+**對應 PRD:** `docs/BRIEF-社群商品候選池與商品行事曆.md`
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 prices.scope CHECK 擴充
+- [ ] `prices.scope` CHECK 接受新值 `'cost'` 和 `'branch'`（既有 retail/store/member_tier/promo 不動）
+- [ ] 嘗試 INSERT scope='unknown' 仍被擋
+- [ ] 既有 row scope='retail'/'store' 不受影響
+
+**驗證 SQL：**
+```sql
+-- 確認 CHECK 條件
+SELECT pg_get_constraintdef(oid)
+  FROM pg_constraint
+ WHERE conrelid = 'prices'::regclass AND contype = 'c';
+
+-- 嘗試合法 INSERT
+INSERT INTO prices (tenant_id, sku_id, scope, scope_id, price, created_by)
+VALUES (...,'cost',NULL,80,...);   -- 應成功
+INSERT INTO prices (tenant_id, sku_id, scope, scope_id, price, created_by)
+VALUES (...,'branch',NULL,120,...); -- 應成功
+
+-- 嘗試非法 INSERT
+INSERT INTO prices (..., scope, ...) VALUES (...,'foo',...); -- 應被擋
+```
+
+### 1.2 RPC signature
+- [ ] `rpc_set_cost_price(p_sku_id BIGINT, p_price NUMERIC, p_effective_from TIMESTAMPTZ DEFAULT NOW(), p_reason TEXT DEFAULT NULL)` 存在
+- [ ] `rpc_set_branch_price(p_sku_id BIGINT, p_price NUMERIC, p_effective_from TIMESTAMPTZ DEFAULT NOW(), p_reason TEXT DEFAULT NULL)` 存在
+- [ ] `rpc_schedule_candidate(p_candidate_id BIGINT, p_scheduled_date DATE, p_product_name TEXT)` 存在
+- [ ] 三支都 GRANT TO authenticated
+
+### 1.3 prices RLS policy 加 role 過濾
+- [ ] 既有 `read_tenant_prices` 仍存在（同 tenant 才讀）
+- [ ] 新增 row-level filter：scope='cost' 只給 role IN ('owner','admin','hq_manager','hq_accountant') 看
+- [ ] scope='branch' 給 role IN ('owner','admin','hq_manager','store_manager') 看
+- [ ] scope='retail' / 'store' / 'member_tier' / 'promo' 不過濾（既有行為）
+
+**驗證 SQL：**
+```sql
+-- 切到 store_staff JWT 後 SELECT prices 只能看到 retail/store/promo
+-- 切到 store_manager JWT 後 SELECT 應多看到 branch
+-- 切到 admin JWT 後 SELECT 應全部
+```
+
+### 1.4 既有 rpc_adopt_candidate 處理
+- [ ] 決定保留原 RPC 或 deprecate（若新流程完全取代採用按鈕，這支應僅供 idempotent 補救）
+- [ ] 若保留，加 COMMENT 標記「legacy: prefer rpc_schedule_candidate」
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 rpc_set_cost_price — 基本寫入
+**情境：** authenticated（admin role）對某 sku 設 cost=80。
+
+**預期：** prices 表多一筆 scope='cost'/scope_id=NULL/price=80 的 row、created_by = auth.uid()、effective_to=NULL。
+
+### 2.2 rpc_set_cost_price — 排程後第二次寫入會關閉舊版
+**情境：** 連續呼叫兩次，effective_from 不同。
+
+**預期：** 舊 row.effective_to 被填成新 row.effective_from（沿用 rpc_upsert_price 行為）。
+
+### 2.3 rpc_set_cost_price — 跨 tenant SKU 拒絕
+**情境：** sku_id 屬於別 tenant。
+
+**預期：** RAISE EXCEPTION 'sku % not in tenant'。
+
+### 2.4 rpc_set_cost_price — store_staff 角色被擋
+**情境：** JWT role='store_staff' 呼叫 rpc_set_cost_price。
+
+**預期：** RAISE EXCEPTION（permission denied 或 RLS 擋寫）。
+
+### 2.5 rpc_set_branch_price — store_manager 可寫
+**情境：** JWT role='store_manager' 呼叫 rpc_set_branch_price。
+
+**預期：** 成功寫入 scope='branch'。
+
+### 2.6 rpc_set_branch_price — store_staff 被擋
+**情境：** JWT role='store_staff' 呼叫。
+
+**預期：** 拒絕。
+
+### 2.7 rpc_schedule_candidate — happy path
+**情境：** candidate.id=X 還沒 adopted/scheduled，呼叫 rpc_schedule_candidate(X, '2026-05-15', '蒜香麵包')。
+
+**預期：**
+- products 多一筆 status='draft' / name='蒜香麵包' / 自動 product_code
+- skus 多一筆 status='draft' / sku_code = product_code（沿用 rpc_ensure_default_sku 行為）
+- group_buy_campaigns 多一筆 status='draft' / scheduled_open_at='2026-05-15' / 自動 campaign 編號
+- campaign_items 多一筆 (campaign_id, sku_id) 對應
+- candidate.adopted_product_id=新 product / owner_action='scheduled' / scheduled_open_at='2026-05-15' / scheduled_by=auth.uid() / scheduled_at=NOW()
+- 回傳 jsonb { product_id, product_code, sku_id, campaign_id, already_scheduled:false }
+
+### 2.8 rpc_schedule_candidate — idempotent
+**情境：** 同一 candidate 重呼第二次（已 scheduled、adopted_product_id 有值）。
+
+**預期：** 不重建，回傳既有 product_id/sku_id/campaign_id、already_scheduled=true。
+
+### 2.9 rpc_schedule_candidate — product_name 空白
+**情境：** p_product_name = ''.
+
+**預期：** RAISE EXCEPTION 'product_name must not be blank'。
+
+### 2.10 rpc_schedule_candidate — 跨 tenant candidate 拒絕
+**情境：** candidate_id 屬於別 tenant。
+
+**預期：** RAISE EXCEPTION 'candidate % not found or cross-tenant'。
+
+### 2.11 rpc_schedule_candidate — role 限制
+**情境：** JWT role='store_staff' 呼叫。
+
+**預期：** RAISE EXCEPTION（only owner/admin/hq_manager/assistant 可排程）。
+
+### 2.12 rpc_schedule_candidate — 並行雙呼叫
+**情境：** 同 candidate 兩個 transaction 同時 call。
+
+**預期：** 第二個被 FOR UPDATE 鎖、走到 idempotent 分支、不重建。
+
+### 2.13 prices RLS — 非預期 scope 默認可讀
+**情境：** 既有 scope='member_tier' / 'promo' 在新 policy 後仍可讀（避免 regression）。
+
+**預期：** retail/store 跟舊 row 都不受影響。
+
+---
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 商品編輯頁 — admin 看到三種價格
+- [ ] `/products/edit?id=X` 載入無 console error
+- [ ] 看得到三個 input：成本價、零售價、分店價
+- [ ] 三個欄位都能輸入並送出，DB 對應 prices scope=cost/retail/branch 各多一筆
+
+### 3.2 商品編輯頁 — store_manager 看到兩種
+- [ ] 切到 store_manager JWT 後重載 `/products/edit?id=X`
+- [ ] 只看到零售價 + 分店價輸入；成本價區塊不渲染、不在 DOM
+- [ ] 嘗試直接呼叫 rpc_set_cost_price（透過 console）被 RLS 擋
+
+### 3.3 商品編輯頁 — store_staff 只看一種
+- [ ] 切到 store_staff JWT 後重載
+- [ ] 只看到零售價；成本價、分店價區塊都不渲染
+
+### 3.4 商品列表頁 — 草稿狀態 badge
+- [ ] `/products` 列表能看到新 status='draft' 的商品（從 candidate schedule 建出來的）
+- [ ] draft 列以灰色 badge 顯示
+- [ ] 列表頁加上「狀態」filter，可切 draft / active / 全部
+
+### 3.5 商品列表頁 — draft 不可下訂
+- [ ] 對 draft 商品的訂單動作（建單、加入活動）UI 上 disabled 或顯示「需補完才能下訂」
+
+### 3.6 候選池頁 — 排日期改呼叫新 RPC
+- [ ] 對 owner_action='none' 的 candidate 點「排日期」→ 選 2026-05-15 → 「確定」
+- [ ] 預期成功後：
+  - candidate row 變綠色 badge「已排程」 + scheduled_open_at 顯示日期
+  - DB 中 products / skus / group_buy_campaigns / campaign_items 各多 1 筆 draft
+- [ ] 排程失敗時錯誤訊息顯示給使用者
+
+### 3.7 候選池頁 — 採用按鈕已移除
+- [ ] candidate row 動作區只剩「補資料 / 排日期 / 收藏 / 忽略 / 還原」，沒有「採用」
+- [ ] 點補資料 popup 仍能寫 supplier/cost/sale_price 到 candidate（給排程前的暫存）
+
+### 3.8 候選池頁 — 已排程列加跳轉連結
+- [ ] owner_action='scheduled' 或 'adopted' 的 row 出現 「→ 編輯商品」按鈕（連到 /products/edit?id=adopted_product_id）
+- [ ] 同 row 出現「→ 編輯開團」按鈕（連到 /campaigns/edit?id=...，campaign_id 從 product → campaign_items 反查）
+- [ ] 兩個連結點開後該頁能正確載入對應草稿
+
+### 3.9 候選池週曆頁 — 已移除或 redirect
+- [ ] `/community-candidates/calendar` 不存在（404）或 redirect → `/campaigns?view=week`
+- [ ] sidebar「社群選品」區組不再有「週曆」子項
+
+### 3.10 開團頁 — 7 天視圖
+- [ ] `/campaigns?view=week` 載入無 console error
+- [ ] 顯示今天 + 未來 6 天共 7 個欄位
+- [ ] 每欄列出該天 scheduled_open_at = 該日 的草稿開團（含從 candidate schedule 建出來的）
+- [ ] 每張卡片顯示：商品名 / 來源 candidate（可選）/ status badge / 完整度狀態
+- [ ] 卡片可點擊 → 跳到開團詳情編輯頁
+
+### 3.11 開團頁 — 月視圖
+- [ ] `/campaigns?view=month` 顯示當月日曆網格
+- [ ] 每天格子裡顯示該日 scheduled_open_at 的開團縮卡（>3 個用「+N」摺疊）
+- [ ] 上月 / 下月 切換按鈕能用
+- [ ] 點縮卡 → 跳到該開團編輯頁
+
+### 3.12 開團頁 — 視圖切換
+- [ ] 列表 / 7 天 / 月曆三個 tab 互切無 console error
+- [ ] 切換不重打 API（cache 或 URL 狀態保留）
+
+### 3.13 開團編輯頁 — 完整度檢查
+- [ ] 草稿開團頁顯示 checklist：「商品已補完 / 成本價已設 / 零售價已設 / 分店價已設 / 開團起訖時間 / 結單日」
+- [ ] 全勾 → 「開團」按鈕 enabled；任一未勾 → disabled + tooltip 標出缺什麼
+- [ ] 未補完試圖直接 update status='open' 後端 RPC 也應拒絕（防 bypass）
+
+### 3.14 開團編輯頁 — 開團按鈕
+- [ ] 點「開團」 → status 從 draft → open
+- [ ] 同步將關聯 product status draft → active、sku status draft → active
+- [ ] 開完團後 candidate.owner_action 維持 'scheduled'（不改 'adopted'，'adopted' 留給後續另議）
+
+---
+
+## 4. Regression
+
+### 4.1 既有零售價設定不受影響
+- [ ] 對既有 sku 呼叫 rpc_set_retail_price，能照常寫入、不被新 RLS 擋
+
+### 4.2 既有 sku_retail_prices view（如有）未崩
+- [ ] 商品列表的零售價欄仍正確顯示
+
+### 4.3 既有 group_buy_campaigns 列表
+- [ ] 既有 status='open'/'closed'/... 開團在「列表」tab 仍正常顯示
+- [ ] 既有開團詳情頁未受影響（campaign_items / channels CRUD 仍可用）
+
+### 4.4 既有候選池其他動作
+- [ ] 收藏 / 忽略 / 還原 / 補資料 仍能用
+
+### 4.5 既有 community-bot-ingest Edge Function
+- [ ] LINE 機器人 ingest 一筆新 candidate 仍正常寫入（沒被本次改動波及）
+
+### 4.6 既有 rpc_adopt_candidate（若保留）
+- [ ] 對舊已 adopted candidate 重呼仍 idempotent 回傳 product 資訊
+
+### 4.7 sidebar 不破
+- [ ] 移掉「週曆」子項後，sidebar render 正常、其他 nav 連結未壞
+
+---
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**Supabase dev push 成功**、**build + type-check 過** 才可標 done。

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.104.0",
+        "@tiptap/extension-link": "^3.22.5",
+        "@tiptap/pm": "^3.22.5",
+        "@tiptap/react": "^3.22.5",
+        "@tiptap/starter-kit": "^3.22.5",
+        "isomorphic-dompurify": "^3.11.0",
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -66,6 +71,53 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -307,6 +359,152 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -483,6 +681,51 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -1644,6 +1887,434 @@
         "tailwindcss": "4.2.4"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.5.tgz",
+      "integrity": "sha512-L1lhWz6ujGny8LduTJ7MBWYhzigwOvfUJUrJ7IzOJSuy3+OAzisdGDD1GV7LEO/hU0Hr2Mkm1wajRIHExvS9HQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.5.tgz",
+      "integrity": "sha512-ajyP5W8fG5Hrru47T/eF3xMKOpNvWofgNJqBTeNuGl02sYxsy9a4EunyFxudsaZP9WW3VOD4SaIWr5+MqpbnOQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.5.tgz",
+      "integrity": "sha512-l/uDtpJISiFFyfctvnODNWBN/XPZI1jVZRacTRDDnSn8+x6KQ7G2qgFYueU7KvVJGDFVT39Iio56mcFRG/Pozg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.5.tgz",
+      "integrity": "sha512-yrNlFQQJY5MmhBpmD8tnmaSmyUQrEvgyPKa3bzVeWEhDSG1CW4A0ZSMx3hrA9yFO0HWfw3IJmvSCycEZQBalpQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.5.tgz",
+      "integrity": "sha512-cf54fG9AybU8NgPMv1TOcoqAkELeRc/VpnSCt/rIJZphWQx9nsFmrtkrlCatrIcCaGtNZYwlHlMnC5LVVMu0uA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.5.tgz",
+      "integrity": "sha512-mwDNOJC9rYbDu/JcqrN4dbUQRklJU8Fuk2raxD/IvFw9qUIcPCmxQ2XT9UTKmZz/Ju7Kdy72fss6XpgWv6gLAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.5.tgz",
+      "integrity": "sha512-d123kCfLdJTi4fue1m0+TNFztDkmIRSZGZmGu6H9KqwG5Q7IzjT9o8lzRsz+pXxYqHvqgYmXoEpM6srbzXx/Ag==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.5.tgz",
+      "integrity": "sha512-8NJERd+pCtvSuEP4C4WMGYmRRCV12ePZL7bC+QUdFlbdXg+kNZS0zZ7hh879tYA0Kidbi8rWWD1Tx+H2ezkmMw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.5.tgz",
+      "integrity": "sha512-Mp40DaFrY3sEUVtFqmxrR0BmU4G3k8GCYYNGqNa9OqWv7BrcFDC03V2n3okESDKt4MKkzhQQmypq+ouLy8dLfA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.5.tgz",
+      "integrity": "sha512-dhem4sTPhyQgQ+pFp2Oud4k4FSQz9PVMgeQAC9288SmGwxBkJNveDAw6sKTMrumqDvwkJrtslXIupq9TZYQnzg==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.5.tgz",
+      "integrity": "sha512-4WkMu7qqjbsm8hCQS+8X+la1wjriN0SKoRdvpfKH33qM50MB34tYJuGLAO+y7TTh4MMMco3AZCKPBL5JVMqNIg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.5.tgz",
+      "integrity": "sha512-n0R2mUVYZU2AVbJhg/WcY9+zx690wVwvsItHJf0DrYbf1tCYHx+PRHUt/AoXk6u8BSmnkb8/FDziS8m3mjfpSg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.5.tgz",
+      "integrity": "sha512-hjyEG4947PAhMBfP1G6B0QAh6+y9mp2C5BQmNjprA05/lQzDAT7KFZzNh8ZVp3ol6aICKq/N1gFOW9Dc/9FUOw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.5.tgz",
+      "integrity": "sha512-vUV0/ugIbXOc8SJib0h8UMhgcqZXWu/dkEhlswZN4VVven1o5enkfxEiDw+OyIJHi5rUkrdhsQ/KTxG/Xb7X8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.5.tgz",
+      "integrity": "sha512-4T8baSiLkeIymTgEwirxDFt5YgYofkP3m1+MGYdGy2HKcOK+1vpvlPhEO1X5qtZngtJW5S4+njKjinRg52A4PA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.5.tgz",
+      "integrity": "sha512-d671MvF3GPKoS2OVxjIlQ7hIE7MS3hREdR+d4cvnnoiLLD+ZJ6KgDnxmWqF0a1s4qxLWK2KxKRSOIfYGE31QWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.5.tgz",
+      "integrity": "sha512-cVO3ZHCgxAWZ4zrFSs81FO2nyCk1wb2EHkpLpW98FzbJLkN9rDkazhW99P3HRWy/CvUldOT+8ecI1YrQtBojMg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.5.tgz",
+      "integrity": "sha512-W7uTmyKLhlsvuTPLv+8WwnsY+mlikBFIoLSvVcBaFt4MwpsZ+DeB6KQg02Y7tbtaAnG7rXu9Fvw2QORh2P728A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.5.tgz",
+      "integrity": "sha512-cGUnxJ0y515e1bVHNjUmbx7oWHoEon59w6BA5N2KwV9iW2mZZchlTX4yxJSOX+ixeVRChsa7YwC3Z1jUZ6AMEg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.5.tgz",
+      "integrity": "sha512-OXdh4k4CNrukwiSdWdEQ49uvgnqvR0Z9aNSP4HI5/kZQ/Te1NtRtYCpUrzWyO/7CtjcCisXHti0o9C/TV8YMbQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.5.tgz",
+      "integrity": "sha512-52KCto4+XKpnBWpIufspWLyq4UWxAWC72ANPdGuIhbi72NRTabiTbTVN40uwGSPkyakeESG0/vKdWJCVvB4f0g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.5.tgz",
+      "integrity": "sha512-42WrrFK5gOom/0znH85x12Mw5IQ/6O6DWdyUWoRIrNA/qJpuHtU8oVU+bIgU2tuomMGHruRjIzgBQv5sBjEtww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.5.tgz",
+      "integrity": "sha512-bzpDOdAEo1JeoVZDIyV0oY0jGXkEG+AzF70SzHoRSjOvFDtKWunyXf9eO1OnOr2/fmMcckT2qwUBNBMQplWBzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.5.tgz",
+      "integrity": "sha512-9ut09rJD0iEbS6sk7yd2j6IwuFDLTNmDEGTDLodvqAfi+bq7ddsTDv0YviXoZaA9sdHAdTEVr2ITy2m6WK5jpA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.5.tgz",
+      "integrity": "sha512-Ifg4MzKCj3uRqe3ieTwYnomu2y4p7EXr2avVSKZYfh12i2dyWe2Gkn1KuZDREANVE+gHqFlQjJRYzhJFwzSCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.5.tgz",
+      "integrity": "sha512-Cr9Mv4igxvI2tKMiahw48sZxva3PfDzypErH8IB82N+9qa9n9ygVMt0BOaDg53hLKxEEVeYr2S/wCcJIVFgBTw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.22.5.tgz",
+      "integrity": "sha512-36WHEs+vPmB//V1ff7Ujcnpz7Ey5g8lhpI/0+hoanSbdiPMTQ7qZVWwMovIkMKDlqWVp2fxBgeYM1861jyFzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.22.5",
+        "@tiptap/extension-floating-menu": "^3.22.5"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.5",
+        "@tiptap/pm": "3.22.5",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.5.tgz",
+      "integrity": "sha512-LZ/LYbwH6rnDi5DnRyagkuNsYAVyhM+yJvvz+ZuYA0JkPiTXJV86J5PWSKew8M0gVfMHcNVtKjfQCvViFCeIgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.22.5",
+        "@tiptap/extension-blockquote": "^3.22.5",
+        "@tiptap/extension-bold": "^3.22.5",
+        "@tiptap/extension-bullet-list": "^3.22.5",
+        "@tiptap/extension-code": "^3.22.5",
+        "@tiptap/extension-code-block": "^3.22.5",
+        "@tiptap/extension-document": "^3.22.5",
+        "@tiptap/extension-dropcursor": "^3.22.5",
+        "@tiptap/extension-gapcursor": "^3.22.5",
+        "@tiptap/extension-hard-break": "^3.22.5",
+        "@tiptap/extension-heading": "^3.22.5",
+        "@tiptap/extension-horizontal-rule": "^3.22.5",
+        "@tiptap/extension-italic": "^3.22.5",
+        "@tiptap/extension-link": "^3.22.5",
+        "@tiptap/extension-list": "^3.22.5",
+        "@tiptap/extension-list-item": "^3.22.5",
+        "@tiptap/extension-list-keymap": "^3.22.5",
+        "@tiptap/extension-ordered-list": "^3.22.5",
+        "@tiptap/extension-paragraph": "^3.22.5",
+        "@tiptap/extension-strike": "^3.22.5",
+        "@tiptap/extension-text": "^3.22.5",
+        "@tiptap/extension-underline": "^3.22.5",
+        "@tiptap/extensions": "^3.22.5",
+        "@tiptap/pm": "^3.22.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1689,7 +2360,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1699,11 +2369,23 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -2587,6 +3269,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -2797,11 +3488,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2810,6 +3513,19 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -2883,6 +3599,12 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2949,6 +3671,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2990,6 +3721,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -3605,6 +4348,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
@@ -4044,6 +4796,18 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -4375,6 +5139,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4534,6 +5304,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic-dompurify": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.11.0.tgz",
+      "integrity": "sha512-il0sNhLnfawc6vKoMqnZX1JXzEzw0pP3DZWg7mM7VJNJ8cq6DCxeAjEcfjTazyBF8dkUn+rBsBPS5NQs4ZaI3g==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.4.1",
+        "jsdom": "^29.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4580,6 +5363,55 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -4950,6 +5782,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5015,6 +5853,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/member": {
       "resolved": "apps/member",
@@ -5363,6 +6207,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -5424,6 +6274,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -5680,11 +6542,139 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5783,6 +6773,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
@@ -5837,6 +6836,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -5915,6 +6920,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -6364,6 +7381,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
@@ -6433,6 +7456,24 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6444,6 +7485,30 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6639,6 +7704,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -6719,6 +7793,65 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -6856,6 +7989,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/supabase/migrations/20260514000000_prices_scope_extend_and_role_rls.sql
+++ b/supabase/migrations/20260514000000_prices_scope_extend_and_role_rls.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- prices.scope CHECK 擴充 + RLS 依 role × scope 分層讀取
+--
+-- 背景：現行 prices.scope 只支援 retail / store / member_tier / promo，
+-- 且 RLS 只擋 tenant 層、所有同 tenant role 都看得到全部 scope。
+--
+-- 需求 (BRIEF: docs/TEST-candidate-to-draft-and-pricing.md)：
+--   1. 加 cost / branch 兩個 scope value
+--      - cost   = 進貨成本價（限總部 role 看）
+--      - branch = 全分店共用單一分店價（區別零售價；限 store_manager+/總部 看）
+--   2. RLS 依 role 過濾：
+--      - owner / admin / hq_manager / hq_accountant      → 看全部 scope
+--      - store_manager                                    → retail + store + branch + member_tier + promo（不含 cost）
+--      - store_staff                                      → retail + store + member_tier + promo（不含 cost / branch）
+--      - 其他 role / 無 role                              → 同 store_staff 待遇
+--
+-- Scope: 只動 prices 表 CHECK + RLS policy；不動既有 RPC 行為（rpc_upsert_price 仍可寫所有 scope）
+-- Rollback:
+--   ALTER TABLE prices DROP CONSTRAINT prices_scope_check;
+--   ALTER TABLE prices ADD CONSTRAINT prices_scope_check CHECK (scope IN ('retail','store','member_tier','promo'));
+--   DROP POLICY IF EXISTS read_prices_role_scoped ON prices;
+--   CREATE POLICY read_tenant_prices ON prices FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid);
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. 擴充 prices.scope CHECK 接受 'cost' 和 'branch'
+-- ----------------------------------------------------------------
+
+ALTER TABLE prices DROP CONSTRAINT IF EXISTS prices_scope_check;
+
+ALTER TABLE prices ADD CONSTRAINT prices_scope_check
+  CHECK (scope IN ('retail','store','member_tier','promo','cost','branch'));
+
+COMMENT ON COLUMN prices.scope IS
+  'retail=零售價(scope_id NULL) / store=分店覆寫(scope_id=store_location_id) / branch=全分店共用分店價(scope_id NULL) / cost=進貨成本(scope_id NULL) / member_tier=會員等級(scope_id=tier_id) / promo=促銷(scope_id=promotion_id)';
+
+-- ----------------------------------------------------------------
+-- 2. 砍舊 read policy、改用依 role × scope 分層的新 policy
+-- ----------------------------------------------------------------
+
+DROP POLICY IF EXISTS read_tenant_prices ON prices;
+
+-- 新 policy：tenant 比對 + 依 role 過濾 cost/branch
+-- 寫法沿用 community_product_candidates ccp_hq_all 的 jwt path（app_metadata.role）
+CREATE POLICY read_prices_role_scoped ON prices
+  FOR SELECT
+  USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (
+      -- 公開 scope：任何同 tenant role 都看得到
+      scope IN ('retail','store','member_tier','promo')
+      OR
+      -- cost：僅總部 role 看
+      (scope = 'cost'
+       AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+           = ANY (ARRAY['owner','admin','hq_manager','hq_accountant']))
+      OR
+      -- branch：總部 role + store_manager 看（不給 store_staff）
+      (scope = 'branch'
+       AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+           = ANY (ARRAY['owner','admin','hq_manager','hq_accountant','store_manager']))
+    )
+  );
+
+COMMENT ON POLICY read_prices_role_scoped ON prices IS
+  '依 role × scope 分層：總部全看 / store_manager 不看 cost / store_staff 不看 cost+branch';

--- a/supabase/migrations/20260514000001_rpc_price_wrappers_cost_branch.sql
+++ b/supabase/migrations/20260514000001_rpc_price_wrappers_cost_branch.sql
@@ -1,0 +1,97 @@
+-- ============================================================
+-- 成本價 / 分店共用價 wrapper RPC
+--
+-- 沿用 rpc_set_retail_price / rpc_set_store_price 的形狀（20260424120001_price_wrappers.sql）
+-- 都從 JWT 讀 tenant_id、auth.uid() 讀 operator，呼叫既有 rpc_upsert_price。
+--
+-- Role 限制：
+--   - rpc_set_cost_price   只給 owner/admin/hq_manager/hq_accountant
+--   - rpc_set_branch_price 多給 store_manager
+-- (RLS 雖也擋讀、但寫入要在 RPC body 內主動 check 才會擋住、因為 SECURITY DEFINER 會繞過 RLS)
+--
+-- Scope: 只加 RPC、不動 schema
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.rpc_set_cost_price(BIGINT, NUMERIC, TIMESTAMPTZ, TEXT);
+--   DROP FUNCTION IF EXISTS public.rpc_set_branch_price(BIGINT, NUMERIC, TIMESTAMPTZ, TEXT);
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 設定成本價（cost）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_set_cost_price(
+  p_sku_id         BIGINT,
+  p_price          NUMERIC,
+  p_effective_from TIMESTAMPTZ DEFAULT NOW(),
+  p_reason         TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_user   UUID := auth.uid();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+BEGIN
+  -- role check：成本價只給總部 role
+  IF v_role NOT IN ('owner','admin','hq_manager','hq_accountant') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot set cost price', v_role;
+  END IF;
+
+  -- tenant 比對
+  PERFORM 1 FROM skus WHERE id = p_sku_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'sku % not in tenant', p_sku_id;
+  END IF;
+
+  -- 寫入（scope='cost', scope_id=NULL）
+  RETURN public.rpc_upsert_price(
+    v_tenant, p_sku_id, 'cost', NULL, p_price, p_effective_from, p_reason, v_user
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_set_cost_price(BIGINT, NUMERIC, TIMESTAMPTZ, TEXT) IS
+  'Set cost price (scope=cost, scope_id=NULL). HQ roles only (owner/admin/hq_manager/hq_accountant). Versioned append-only via rpc_upsert_price.';
+
+GRANT EXECUTE ON FUNCTION public.rpc_set_cost_price(BIGINT, NUMERIC, TIMESTAMPTZ, TEXT)
+  TO authenticated;
+
+-- ----------------------------------------------------------------
+-- 設定全分店共用分店價（branch）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_set_branch_price(
+  p_sku_id         BIGINT,
+  p_price          NUMERIC,
+  p_effective_from TIMESTAMPTZ DEFAULT NOW(),
+  p_reason         TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_user   UUID := auth.uid();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+BEGIN
+  -- role check：分店共用價給總部 + store_manager
+  IF v_role NOT IN ('owner','admin','hq_manager','hq_accountant','store_manager') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot set branch price', v_role;
+  END IF;
+
+  PERFORM 1 FROM skus WHERE id = p_sku_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'sku % not in tenant', p_sku_id;
+  END IF;
+
+  -- 寫入（scope='branch', scope_id=NULL，全分店共用）
+  RETURN public.rpc_upsert_price(
+    v_tenant, p_sku_id, 'branch', NULL, p_price, p_effective_from, p_reason, v_user
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_set_branch_price(BIGINT, NUMERIC, TIMESTAMPTZ, TEXT) IS
+  'Set branch-wide price (scope=branch, scope_id=NULL — single price for all stores, distinct from retail). HQ roles + store_manager. Versioned append-only via rpc_upsert_price.';
+
+GRANT EXECUTE ON FUNCTION public.rpc_set_branch_price(BIGINT, NUMERIC, TIMESTAMPTZ, TEXT)
+  TO authenticated;

--- a/supabase/migrations/20260514000002_rpc_schedule_candidate.sql
+++ b/supabase/migrations/20260514000002_rpc_schedule_candidate.sql
@@ -1,0 +1,212 @@
+-- ============================================================
+-- 候選池排日期 → 一次建立 draft product + draft sku + draft campaign + campaign_items
+--
+-- 取代 rpc_adopt_candidate 的舊流程（後者保留為 legacy / idempotent 補救）。
+-- 流程：
+--   1. role check (owner/admin/hq_manager/assistant) — 同 rpc_adopt_candidate
+--   2. 鎖 candidate row
+--   3. 已 scheduled (adopted_product_id NOT NULL) → idempotent 回傳既有資料
+--   4. 否則：
+--      a. rpc_next_product_code() → 建 product (status='draft')
+--      b. rpc_next_sku_code() → 建 sku (status='draft')
+--      c. 若 candidate.adopted_sale_price NOT NULL → rpc_set_retail_price 預填
+--      d. 產生 campaign_no = 'GB' + YYYYMMDD + '-C' + zeropad6(candidate_id)
+--      e. rpc_upsert_campaign → 建 campaign (status='draft', start_at = scheduled_date 00:00 UTC)
+--      f. rpc_upsert_campaign_item → 連 campaign ↔ sku（unit_price = adopted_sale_price 或 0）
+--      g. update candidate: adopted_product_id / owner_action='scheduled' /
+--         scheduled_open_at / scheduled_by / scheduled_at
+--
+-- 不直接寫 cost：候選 cost 留在 candidate.adopted_cost；HQ 角色之後在商品編輯頁手動套用。
+-- (rpc_set_cost_price 的 role check 會擋掉 assistant)
+--
+-- Scope: 只新增此 RPC、不動既有表/RPC
+-- Rollback: DROP FUNCTION IF EXISTS public.rpc_schedule_candidate(BIGINT, DATE, TEXT);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_schedule_candidate(
+  p_candidate_id    BIGINT,
+  p_scheduled_date  DATE,
+  p_product_name    TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant         UUID := public._current_tenant_id();
+  v_user           UUID := auth.uid();
+  v_role           TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_cand           RECORD;
+  v_product_code   TEXT;
+  v_product_id     BIGINT;
+  v_sku_code       TEXT;
+  v_sku_id         BIGINT;
+  v_campaign_no    TEXT;
+  v_campaign_id    BIGINT;
+  v_unit_price     NUMERIC;
+  v_existing_camp  RECORD;
+BEGIN
+  -- 1. role check
+  IF v_role NOT IN ('owner','admin','hq_manager','assistant') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot schedule candidate', v_role;
+  END IF;
+
+  -- 2. input validation
+  IF TRIM(COALESCE(p_product_name, '')) = '' THEN
+    RAISE EXCEPTION 'product_name must not be blank';
+  END IF;
+
+  IF p_scheduled_date IS NULL THEN
+    RAISE EXCEPTION 'scheduled_date must not be null';
+  END IF;
+
+  -- 3. 鎖 candidate row 防並行雙建
+  SELECT id, owner_action, adopted_product_id, adopted_sale_price, raw_text
+    INTO v_cand
+    FROM community_product_candidates
+   WHERE id = p_candidate_id
+     AND tenant_id = v_tenant
+     FOR UPDATE;
+
+  IF v_cand.id IS NULL THEN
+    RAISE EXCEPTION 'candidate % not found or cross-tenant', p_candidate_id;
+  END IF;
+
+  -- 4. idempotent：已有 adopted_product_id → 找既有 campaign 回傳
+  IF v_cand.adopted_product_id IS NOT NULL THEN
+    SELECT c.id AS campaign_id, c.campaign_no, p.product_code,
+           (SELECT id FROM skus WHERE product_id = v_cand.adopted_product_id
+              AND tenant_id = v_tenant ORDER BY id LIMIT 1) AS sku_id
+      INTO v_existing_camp
+      FROM products p
+      LEFT JOIN skus s ON s.product_id = p.id AND s.tenant_id = v_tenant
+      LEFT JOIN campaign_items ci ON ci.sku_id = s.id AND ci.tenant_id = v_tenant
+      LEFT JOIN group_buy_campaigns c ON c.id = ci.campaign_id AND c.tenant_id = v_tenant
+     WHERE p.id = v_cand.adopted_product_id
+       AND p.tenant_id = v_tenant
+     ORDER BY c.created_at ASC NULLS LAST
+     LIMIT 1;
+
+    -- 若 product 存在但無 campaign（例如舊 rpc_adopt_candidate 採用過）→ 補建 campaign
+    IF v_existing_camp.campaign_id IS NULL THEN
+      v_product_id  := v_cand.adopted_product_id;
+      v_sku_id      := v_existing_camp.sku_id;
+      v_product_code:= v_existing_camp.product_code;
+      -- 跳到 step 7 建 campaign（不用重建 product/sku）
+    ELSE
+      RETURN jsonb_build_object(
+        'product_id',         v_cand.adopted_product_id,
+        'product_code',       v_existing_camp.product_code,
+        'sku_id',             v_existing_camp.sku_id,
+        'campaign_id',        v_existing_camp.campaign_id,
+        'campaign_no',        v_existing_camp.campaign_no,
+        'already_scheduled',  TRUE
+      );
+    END IF;
+  ELSE
+    -- 5. 建 product (status='draft')
+    v_product_code := public.rpc_next_product_code();
+
+    v_product_id := public.rpc_upsert_product(
+      p_id           := NULL,
+      p_product_code := v_product_code,
+      p_name         := TRIM(p_product_name),
+      p_short_name   := NULL,
+      p_brand_id     := NULL,
+      p_category_id  := NULL,
+      p_description  := v_cand.raw_text,
+      p_status       := 'draft',
+      p_reason       := 'schedule candidate #' || p_candidate_id::TEXT
+    );
+
+    -- 6. 建 sku (status='draft')
+    v_sku_code := public.rpc_next_sku_code(v_product_id);
+
+    v_sku_id := public.rpc_upsert_sku(
+      p_id           := NULL,
+      p_product_id   := v_product_id,
+      p_sku_code     := v_sku_code,
+      p_variant_name := NULL,
+      p_spec         := '{}'::jsonb,
+      p_base_unit    := NULL,
+      p_weight_g     := NULL,
+      p_tax_rate     := NULL,
+      p_status       := 'draft',
+      p_reason       := 'schedule candidate #' || p_candidate_id::TEXT
+    );
+
+    -- 6.1 若 candidate 已補 adopted_sale_price → 預填零售價
+    IF v_cand.adopted_sale_price IS NOT NULL THEN
+      PERFORM public.rpc_set_retail_price(
+        v_sku_id,
+        v_cand.adopted_sale_price,
+        NOW(),
+        'schedule candidate #' || p_candidate_id::TEXT
+      );
+    END IF;
+  END IF;
+
+  -- 7. 建 campaign (status='draft')
+  -- campaign_no = GB{YYYYMMDD}-C{padded candidate_id} 保證 per-candidate 唯一
+  v_campaign_no := 'GB' || to_char(p_scheduled_date, 'YYYYMMDD')
+                 || '-C' || lpad(p_candidate_id::TEXT, 6, '0');
+
+  v_campaign_id := public.rpc_upsert_campaign(
+    p_id              := NULL,
+    p_campaign_no     := v_campaign_no,
+    p_name            := TRIM(p_product_name),
+    p_description     := v_cand.raw_text,
+    p_cover_image_url := NULL,
+    p_status          := 'draft',
+    p_close_type      := 'regular',
+    p_start_at        := p_scheduled_date::TIMESTAMPTZ,
+    p_end_at          := NULL,
+    p_pickup_deadline := NULL,
+    p_pickup_days     := NULL,
+    p_total_cap_qty   := NULL,
+    p_notes           := 'schedule candidate #' || p_candidate_id::TEXT
+  );
+
+  -- 8. 建 campaign_items (campaign ↔ sku)
+  -- unit_price 預填 candidate.adopted_sale_price，否則 0；後續編輯頁可改
+  v_unit_price := COALESCE(v_cand.adopted_sale_price, 0);
+
+  PERFORM public.rpc_upsert_campaign_item(
+    p_id          := NULL,
+    p_campaign_id := v_campaign_id,
+    p_sku_id      := v_sku_id,
+    p_unit_price  := v_unit_price,
+    p_cap_qty     := NULL,
+    p_sort_order  := 0,
+    p_notes       := NULL
+  );
+
+  -- 9. 標 candidate scheduled
+  UPDATE community_product_candidates
+     SET adopted_product_id = v_product_id,
+         owner_action       = 'scheduled',
+         scheduled_open_at  = p_scheduled_date,
+         scheduled_by       = v_user,
+         scheduled_at       = NOW(),
+         updated_at         = NOW(),
+         updated_by         = v_user
+   WHERE id = p_candidate_id
+     AND tenant_id = v_tenant;
+
+  RETURN jsonb_build_object(
+    'product_id',         v_product_id,
+    'product_code',       v_product_code,
+    'sku_id',             v_sku_id,
+    'campaign_id',        v_campaign_id,
+    'campaign_no',        v_campaign_no,
+    'already_scheduled',  FALSE
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_schedule_candidate(BIGINT, DATE, TEXT)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_schedule_candidate(BIGINT, DATE, TEXT) IS
+  'Schedule a candidate: creates draft product + draft sku + draft campaign + campaign_items, optionally pre-populates retail price from candidate.adopted_sale_price. Idempotent on re-call. Replaces the manual rpc_adopt_candidate flow.';

--- a/supabase/migrations/20260514000003_fix_role_allow_empty.sql
+++ b/supabase/migrations/20260514000003_fix_role_allow_empty.sql
@@ -1,0 +1,267 @@
+-- ============================================================
+-- 修：三支新 RPC + prices RLS 把空 role ('') 視為 admin 等級
+--
+-- 背景：dev / 早期帳號 JWT app_metadata.role 沒設值（""），
+-- codebase 既有 RLS / RPC 慣例（如 ccp_hq_all、purchase_rls_admin）都會把空字串
+-- 也納入 admin 等級允許清單。本批新加的 rpc_set_cost_price / rpc_set_branch_price /
+-- rpc_schedule_candidate / read_prices_role_scoped 漏了，導致實際登入後呼叫 RPC 被擋。
+--
+-- Scope: 只重建 RPC body 跟 RLS policy，不動 schema
+-- Rollback: 重新 apply 20260514000001 + 20260514000002 + 20260514000000 對應段
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- rpc_set_cost_price — 加空 role
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_set_cost_price(
+  p_sku_id         BIGINT,
+  p_price          NUMERIC,
+  p_effective_from TIMESTAMPTZ DEFAULT NOW(),
+  p_reason         TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_user   UUID := auth.uid();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','hq_accountant','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot set cost price', v_role;
+  END IF;
+
+  PERFORM 1 FROM skus WHERE id = p_sku_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'sku % not in tenant', p_sku_id; END IF;
+
+  RETURN public.rpc_upsert_price(
+    v_tenant, p_sku_id, 'cost', NULL, p_price, p_effective_from, p_reason, v_user
+  );
+END;
+$$;
+
+-- ----------------------------------------------------------------
+-- rpc_set_branch_price — 加空 role
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_set_branch_price(
+  p_sku_id         BIGINT,
+  p_price          NUMERIC,
+  p_effective_from TIMESTAMPTZ DEFAULT NOW(),
+  p_reason         TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_user   UUID := auth.uid();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','hq_accountant','store_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot set branch price', v_role;
+  END IF;
+
+  PERFORM 1 FROM skus WHERE id = p_sku_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'sku % not in tenant', p_sku_id; END IF;
+
+  RETURN public.rpc_upsert_price(
+    v_tenant, p_sku_id, 'branch', NULL, p_price, p_effective_from, p_reason, v_user
+  );
+END;
+$$;
+
+-- ----------------------------------------------------------------
+-- rpc_schedule_candidate — 加空 role
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_schedule_candidate(
+  p_candidate_id    BIGINT,
+  p_scheduled_date  DATE,
+  p_product_name    TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant         UUID := public._current_tenant_id();
+  v_user           UUID := auth.uid();
+  v_role           TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_cand           RECORD;
+  v_product_code   TEXT;
+  v_product_id     BIGINT;
+  v_sku_code       TEXT;
+  v_sku_id         BIGINT;
+  v_campaign_no    TEXT;
+  v_campaign_id    BIGINT;
+  v_unit_price     NUMERIC;
+  v_existing_camp  RECORD;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','assistant','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot schedule candidate', v_role;
+  END IF;
+
+  IF TRIM(COALESCE(p_product_name, '')) = '' THEN
+    RAISE EXCEPTION 'product_name must not be blank';
+  END IF;
+
+  IF p_scheduled_date IS NULL THEN
+    RAISE EXCEPTION 'scheduled_date must not be null';
+  END IF;
+
+  SELECT id, owner_action, adopted_product_id, adopted_sale_price, raw_text
+    INTO v_cand
+    FROM community_product_candidates
+   WHERE id = p_candidate_id
+     AND tenant_id = v_tenant
+     FOR UPDATE;
+
+  IF v_cand.id IS NULL THEN
+    RAISE EXCEPTION 'candidate % not found or cross-tenant', p_candidate_id;
+  END IF;
+
+  IF v_cand.adopted_product_id IS NOT NULL THEN
+    SELECT c.id AS campaign_id, c.campaign_no, p.product_code,
+           (SELECT id FROM skus WHERE product_id = v_cand.adopted_product_id
+              AND tenant_id = v_tenant ORDER BY id LIMIT 1) AS sku_id
+      INTO v_existing_camp
+      FROM products p
+      LEFT JOIN skus s ON s.product_id = p.id AND s.tenant_id = v_tenant
+      LEFT JOIN campaign_items ci ON ci.sku_id = s.id AND ci.tenant_id = v_tenant
+      LEFT JOIN group_buy_campaigns c ON c.id = ci.campaign_id AND c.tenant_id = v_tenant
+     WHERE p.id = v_cand.adopted_product_id
+       AND p.tenant_id = v_tenant
+     ORDER BY c.created_at ASC NULLS LAST
+     LIMIT 1;
+
+    IF v_existing_camp.campaign_id IS NULL THEN
+      v_product_id  := v_cand.adopted_product_id;
+      v_sku_id      := v_existing_camp.sku_id;
+      v_product_code:= v_existing_camp.product_code;
+    ELSE
+      RETURN jsonb_build_object(
+        'product_id',         v_cand.adopted_product_id,
+        'product_code',       v_existing_camp.product_code,
+        'sku_id',             v_existing_camp.sku_id,
+        'campaign_id',        v_existing_camp.campaign_id,
+        'campaign_no',        v_existing_camp.campaign_no,
+        'already_scheduled',  TRUE
+      );
+    END IF;
+  ELSE
+    v_product_code := public.rpc_next_product_code();
+
+    v_product_id := public.rpc_upsert_product(
+      p_id           := NULL,
+      p_product_code := v_product_code,
+      p_name         := TRIM(p_product_name),
+      p_short_name   := NULL,
+      p_brand_id     := NULL,
+      p_category_id  := NULL,
+      p_description  := v_cand.raw_text,
+      p_status       := 'draft',
+      p_reason       := 'schedule candidate #' || p_candidate_id::TEXT
+    );
+
+    v_sku_code := public.rpc_next_sku_code(v_product_id);
+
+    v_sku_id := public.rpc_upsert_sku(
+      p_id           := NULL,
+      p_product_id   := v_product_id,
+      p_sku_code     := v_sku_code,
+      p_variant_name := NULL,
+      p_spec         := '{}'::jsonb,
+      p_base_unit    := NULL,
+      p_weight_g     := NULL,
+      p_tax_rate     := NULL,
+      p_status       := 'draft',
+      p_reason       := 'schedule candidate #' || p_candidate_id::TEXT
+    );
+
+    IF v_cand.adopted_sale_price IS NOT NULL THEN
+      PERFORM public.rpc_set_retail_price(
+        v_sku_id,
+        v_cand.adopted_sale_price,
+        NOW(),
+        'schedule candidate #' || p_candidate_id::TEXT
+      );
+    END IF;
+  END IF;
+
+  v_campaign_no := 'GB' || to_char(p_scheduled_date, 'YYYYMMDD')
+                 || '-C' || lpad(p_candidate_id::TEXT, 6, '0');
+
+  v_campaign_id := public.rpc_upsert_campaign(
+    p_id              := NULL,
+    p_campaign_no     := v_campaign_no,
+    p_name            := TRIM(p_product_name),
+    p_description     := v_cand.raw_text,
+    p_cover_image_url := NULL,
+    p_status          := 'draft',
+    p_close_type      := 'regular',
+    p_start_at        := p_scheduled_date::TIMESTAMPTZ,
+    p_end_at          := NULL,
+    p_pickup_deadline := NULL,
+    p_pickup_days     := NULL,
+    p_total_cap_qty   := NULL,
+    p_notes           := 'schedule candidate #' || p_candidate_id::TEXT
+  );
+
+  v_unit_price := COALESCE(v_cand.adopted_sale_price, 0);
+
+  PERFORM public.rpc_upsert_campaign_item(
+    p_id          := NULL,
+    p_campaign_id := v_campaign_id,
+    p_sku_id      := v_sku_id,
+    p_unit_price  := v_unit_price,
+    p_cap_qty     := NULL,
+    p_sort_order  := 0,
+    p_notes       := NULL
+  );
+
+  UPDATE community_product_candidates
+     SET adopted_product_id = v_product_id,
+         owner_action       = 'scheduled',
+         scheduled_open_at  = p_scheduled_date,
+         scheduled_by       = v_user,
+         scheduled_at       = NOW(),
+         updated_at         = NOW(),
+         updated_by         = v_user
+   WHERE id = p_candidate_id
+     AND tenant_id = v_tenant;
+
+  RETURN jsonb_build_object(
+    'product_id',         v_product_id,
+    'product_code',       v_product_code,
+    'sku_id',             v_sku_id,
+    'campaign_id',        v_campaign_id,
+    'campaign_no',        v_campaign_no,
+    'already_scheduled',  FALSE
+  );
+END;
+$$;
+
+-- ----------------------------------------------------------------
+-- prices RLS — 加空 role 到 cost/branch 允許清單
+-- ----------------------------------------------------------------
+DROP POLICY IF EXISTS read_prices_role_scoped ON prices;
+
+CREATE POLICY read_prices_role_scoped ON prices
+  FOR SELECT
+  USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (
+      scope IN ('retail','store','member_tier','promo')
+      OR
+      (scope = 'cost'
+       AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+           = ANY (ARRAY['owner','admin','hq_manager','hq_accountant','']))
+      OR
+      (scope = 'branch'
+       AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+           = ANY (ARRAY['owner','admin','hq_manager','hq_accountant','store_manager','']))
+    )
+  );
+
+COMMENT ON POLICY read_prices_role_scoped ON prices IS
+  '依 role × scope 分層：總部全看 / store_manager 不看 cost / store_staff 不看 cost+branch / 空 role 視為 admin 等級（dev/legacy 帳號）';

--- a/supabase/migrations/20260514000004_search_skus_include_siblings.sql
+++ b/supabase/migrations/20260514000004_search_skus_include_siblings.sql
@@ -1,0 +1,118 @@
+-- ============================================================
+-- 擴 rpc_search_skus_for_campaign 把同商品的其他 SKU 也撈進來
+--
+-- 背景：原本 search 只回 campaign_items 內的 SKU；
+-- 加單時若使用者想下別的規格（例如同商品「芒果」/「草莓」）就找不到。
+--
+-- 變更：
+--   - 改回傳：campaign_items 內 SKU + 同商品其他 active SKU（campaign_item_id=NULL）
+--   - 兄弟 SKU 的 unit_price 用 prices(scope='retail') 最新值；查不到回 0
+--   - 排序：is_in_campaign 先（true 在前），再依 sort_order / product_name
+--
+-- UI 端如挑到 campaign_item_id=NULL 的 SKU，下單前會 lazy 呼叫
+-- rpc_upsert_campaign_item 補進 campaign_items（unit_price 用回傳值）。
+--
+-- Scope: 重建 RPC（簽章不變），不動其他物件
+-- Rollback: 重新 apply 20260426120000_order_entry_rpcs.sql 中的 D2 段
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_search_skus_for_campaign(
+  p_campaign_id BIGINT,
+  p_term        TEXT,
+  p_limit       INT DEFAULT 20
+) RETURNS TABLE (
+  campaign_item_id BIGINT,
+  sku_id           BIGINT,
+  sku_code         TEXT,
+  product_name     TEXT,
+  variant_name     TEXT,
+  unit_price       NUMERIC,
+  cap_qty          NUMERIC
+)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_term   TEXT := COALESCE(NULLIF(TRIM(p_term), ''), NULL);
+  v_lim    INT  := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+BEGIN
+  PERFORM 1 FROM group_buy_campaigns WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id; END IF;
+
+  RETURN QUERY
+  WITH campaign_products AS (
+    SELECT DISTINCT s.product_id
+      FROM campaign_items ci
+      JOIN skus s ON s.id = ci.sku_id
+     WHERE ci.tenant_id = v_tenant
+       AND ci.campaign_id = p_campaign_id
+  ),
+  -- 既有：campaign_items 內 SKU（已加進此團）
+  in_campaign AS (
+    SELECT ci.id AS campaign_item_id,
+           s.id AS sku_id, s.sku_code,
+           COALESCE(s.product_name, p.name) AS product_name,
+           s.variant_name,
+           ci.unit_price,
+           ci.cap_qty,
+           ci.sort_order,
+           p.name AS p_name
+      FROM campaign_items ci
+      JOIN skus s     ON s.id = ci.sku_id
+      JOIN products p ON p.id = s.product_id
+     WHERE ci.tenant_id   = v_tenant
+       AND ci.campaign_id = p_campaign_id
+  ),
+  -- 新：同商品的其他 active SKU（不在 campaign_items 中）
+  siblings AS (
+    SELECT NULL::BIGINT AS campaign_item_id,
+           s.id AS sku_id, s.sku_code,
+           COALESCE(s.product_name, p.name) AS product_name,
+           s.variant_name,
+           COALESCE((
+             SELECT pr.price
+               FROM prices pr
+              WHERE pr.tenant_id = v_tenant
+                AND pr.sku_id = s.id
+                AND pr.scope = 'retail'
+                AND pr.effective_to IS NULL
+              ORDER BY pr.effective_from DESC
+              LIMIT 1
+           ), 0)::NUMERIC AS unit_price,
+           NULL::NUMERIC AS cap_qty,
+           999999::INT AS sort_order,
+           p.name AS p_name
+      FROM skus s
+      JOIN products p ON p.id = s.product_id
+     WHERE s.tenant_id = v_tenant
+       AND s.status = 'active'
+       AND s.product_id IN (SELECT product_id FROM campaign_products)
+       AND NOT EXISTS (
+         SELECT 1 FROM campaign_items ci
+          WHERE ci.tenant_id = v_tenant
+            AND ci.campaign_id = p_campaign_id
+            AND ci.sku_id = s.id
+       )
+  ),
+  combined AS (
+    SELECT * FROM in_campaign
+    UNION ALL
+    SELECT * FROM siblings
+  )
+  SELECT campaign_item_id, sku_id, sku_code, product_name, variant_name, unit_price, cap_qty
+    FROM combined
+   WHERE (
+     v_term IS NULL
+     OR sku_code     ILIKE '%' || v_term || '%'
+     OR variant_name ILIKE '%' || v_term || '%'
+     OR p_name       ILIKE '%' || v_term || '%'
+     OR product_name ILIKE '%' || v_term || '%'
+   )
+   ORDER BY (campaign_item_id IS NULL), sort_order, product_name
+   LIMIT v_lim;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_search_skus_for_campaign(BIGINT, TEXT, INT) IS
+  'Search SKUs for campaign order entry. Returns existing campaign_items + sibling SKUs (same product, status=active, not in campaign_items, campaign_item_id=NULL). UI lazy-adds chosen siblings via rpc_upsert_campaign_item.';

--- a/supabase/migrations/20260514000005_fix_search_skus_ambiguous.sql
+++ b/supabase/migrations/20260514000005_fix_search_skus_ambiguous.sql
@@ -1,0 +1,106 @@
+-- ============================================================
+-- 修：rpc_search_skus_for_campaign 內部 ambiguous 欄位（與 OUT 參數同名）
+--
+-- 上一版（20260514000004）的 ORDER BY (campaign_item_id IS NULL) 觸發
+-- "column reference campaign_item_id is ambiguous"，因為 RETURNS TABLE 的 OUT
+-- 參數同時也叫 campaign_item_id。改成用 CTE alias 全部 qualify。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_search_skus_for_campaign(
+  p_campaign_id BIGINT,
+  p_term        TEXT,
+  p_limit       INT DEFAULT 20
+) RETURNS TABLE (
+  campaign_item_id BIGINT,
+  sku_id           BIGINT,
+  sku_code         TEXT,
+  product_name     TEXT,
+  variant_name     TEXT,
+  unit_price       NUMERIC,
+  cap_qty          NUMERIC
+)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_term   TEXT := COALESCE(NULLIF(TRIM(p_term), ''), NULL);
+  v_lim    INT  := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+BEGIN
+  PERFORM 1 FROM group_buy_campaigns WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id; END IF;
+
+  RETURN QUERY
+  WITH campaign_products AS (
+    SELECT DISTINCT s.product_id
+      FROM campaign_items ci
+      JOIN skus s ON s.id = ci.sku_id
+     WHERE ci.tenant_id = v_tenant
+       AND ci.campaign_id = p_campaign_id
+  ),
+  in_campaign AS (
+    SELECT ci.id          AS x_ci_id,
+           s.id           AS x_sku_id,
+           s.sku_code     AS x_sku_code,
+           COALESCE(s.product_name, p.name) AS x_product_name,
+           s.variant_name AS x_variant_name,
+           ci.unit_price  AS x_unit_price,
+           ci.cap_qty     AS x_cap_qty,
+           ci.sort_order  AS x_sort_order,
+           p.name         AS x_p_name
+      FROM campaign_items ci
+      JOIN skus s     ON s.id = ci.sku_id
+      JOIN products p ON p.id = s.product_id
+     WHERE ci.tenant_id   = v_tenant
+       AND ci.campaign_id = p_campaign_id
+  ),
+  siblings AS (
+    SELECT NULL::BIGINT   AS x_ci_id,
+           s.id           AS x_sku_id,
+           s.sku_code     AS x_sku_code,
+           COALESCE(s.product_name, p.name) AS x_product_name,
+           s.variant_name AS x_variant_name,
+           COALESCE((
+             SELECT pr.price
+               FROM prices pr
+              WHERE pr.tenant_id = v_tenant
+                AND pr.sku_id = s.id
+                AND pr.scope = 'retail'
+                AND pr.effective_to IS NULL
+              ORDER BY pr.effective_from DESC
+              LIMIT 1
+           ), 0)::NUMERIC AS x_unit_price,
+           NULL::NUMERIC  AS x_cap_qty,
+           999999::INT    AS x_sort_order,
+           p.name         AS x_p_name
+      FROM skus s
+      JOIN products p ON p.id = s.product_id
+     WHERE s.tenant_id = v_tenant
+       AND s.status = 'active'
+       AND s.product_id IN (SELECT product_id FROM campaign_products)
+       AND NOT EXISTS (
+         SELECT 1 FROM campaign_items ci
+          WHERE ci.tenant_id = v_tenant
+            AND ci.campaign_id = p_campaign_id
+            AND ci.sku_id = s.id
+       )
+  ),
+  combined AS (
+    SELECT * FROM in_campaign
+    UNION ALL
+    SELECT * FROM siblings
+  )
+  SELECT c.x_ci_id, c.x_sku_id, c.x_sku_code, c.x_product_name,
+         c.x_variant_name, c.x_unit_price, c.x_cap_qty
+    FROM combined c
+   WHERE (
+     v_term IS NULL
+     OR c.x_sku_code     ILIKE '%' || v_term || '%'
+     OR c.x_variant_name ILIKE '%' || v_term || '%'
+     OR c.x_p_name       ILIKE '%' || v_term || '%'
+     OR c.x_product_name ILIKE '%' || v_term || '%'
+   )
+   ORDER BY (c.x_ci_id IS NULL), c.x_sort_order, c.x_product_name
+   LIMIT v_lim;
+END;
+$$;

--- a/supabase/migrations/20260514000006_auto_sync_skus_to_campaigns.sql
+++ b/supabase/migrations/20260514000006_auto_sync_skus_to_campaigns.sql
@@ -1,0 +1,148 @@
+-- ============================================================
+-- 新 SKU 自動加到該商品所有 draft / open 的 campaign 商品明細
+--
+-- 背景：
+--   - rpc_schedule_candidate 建出的 campaign 一開始只有 1 個自動 default SKU。
+--   - 之後使用者去商品編輯頁加第 2 個規格、campaign 那邊不會跟著同步。
+--   - rpc_create_campaign_from_products 已經會抓所有 active SKU（不需修），
+--     這個 trigger 補的是「campaign 建立後新增 SKU」的同步。
+--
+-- 行為：
+--   AFTER INSERT ON skus（status='active'）→
+--     找該 product_id 在 group_buy_campaigns status IN ('draft','open') 的 campaign
+--     對每個 campaign 補一筆 campaign_items（unit_price 用 retail 最新值或 0）
+--     ON CONFLICT (campaign_id, sku_id) DO NOTHING — 防 race
+--
+-- AFTER UPDATE ON skus（status: 非 active → active）也同步
+-- AFTER UPDATE ON skus（status: active → 非 active）不主動移除，保留歷史 / 訂單參照
+--
+-- 不動 closed/ordered/receiving/ready/completed/cancelled 的 campaign（已凍結）
+--
+-- Scope: 加 trigger function + trigger，不動既有 RPC
+-- Rollback:
+--   DROP TRIGGER IF EXISTS trg_skus_sync_campaigns_ins ON skus;
+--   DROP TRIGGER IF EXISTS trg_skus_sync_campaigns_upd ON skus;
+--   DROP FUNCTION IF EXISTS public._sync_sku_to_open_campaigns();
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public._sync_sku_to_open_campaigns()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_unit_price NUMERIC;
+  c            RECORD;
+BEGIN
+  -- 只處理 active SKU
+  IF NEW.status IS DISTINCT FROM 'active' THEN
+    RETURN NEW;
+  END IF;
+
+  -- UPDATE 路徑：若 status 沒從非 active 變成 active 就不同步
+  IF TG_OP = 'UPDATE' AND OLD.status = 'active' THEN
+    RETURN NEW;
+  END IF;
+
+  -- 抓最新 retail price 當 unit_price（找不到回 0）
+  SELECT COALESCE(p.price, 0)
+    INTO v_unit_price
+    FROM prices p
+   WHERE p.tenant_id = NEW.tenant_id
+     AND p.sku_id    = NEW.id
+     AND p.scope     = 'retail'
+     AND p.effective_to IS NULL
+   ORDER BY p.effective_from DESC
+   LIMIT 1;
+  v_unit_price := COALESCE(v_unit_price, 0);
+
+  -- 對所有同 product 的 draft / open campaign 補一筆 campaign_items
+  FOR c IN
+    SELECT DISTINCT gbc.id AS campaign_id
+      FROM group_buy_campaigns gbc
+      JOIN campaign_items ci ON ci.campaign_id = gbc.id AND ci.tenant_id = NEW.tenant_id
+      JOIN skus s ON s.id = ci.sku_id AND s.tenant_id = NEW.tenant_id
+     WHERE gbc.tenant_id = NEW.tenant_id
+       AND gbc.status IN ('draft','open')
+       AND s.product_id = NEW.product_id
+  LOOP
+    INSERT INTO campaign_items (
+      tenant_id, campaign_id, sku_id, unit_price, sort_order,
+      created_by, updated_by
+    ) VALUES (
+      NEW.tenant_id, c.campaign_id, NEW.id, v_unit_price, 999,
+      auth.uid(), auth.uid()
+    )
+    ON CONFLICT (campaign_id, sku_id) DO NOTHING;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_skus_sync_campaigns_ins ON skus;
+CREATE TRIGGER trg_skus_sync_campaigns_ins
+  AFTER INSERT ON skus
+  FOR EACH ROW
+  EXECUTE FUNCTION public._sync_sku_to_open_campaigns();
+
+DROP TRIGGER IF EXISTS trg_skus_sync_campaigns_upd ON skus;
+CREATE TRIGGER trg_skus_sync_campaigns_upd
+  AFTER UPDATE OF status ON skus
+  FOR EACH ROW
+  EXECUTE FUNCTION public._sync_sku_to_open_campaigns();
+
+COMMENT ON FUNCTION public._sync_sku_to_open_campaigns() IS
+  'Auto-add new active SKU to draft/open campaigns of the same product. Trigger on skus INSERT/UPDATE.';
+
+-- ============================================================
+-- 一次性 backfill：把目前 draft / open campaign 缺漏的同商品 active SKU 補齊
+-- ============================================================
+DO $$
+DECLARE
+  cnt INT;
+BEGIN
+  WITH inserted AS (
+    INSERT INTO campaign_items (
+      tenant_id, campaign_id, sku_id, unit_price, sort_order,
+      created_by, updated_by
+    )
+    SELECT DISTINCT
+           s_new.tenant_id,
+           gbc.id,
+           s_new.id,
+           COALESCE((
+             SELECT p.price
+               FROM prices p
+              WHERE p.tenant_id = s_new.tenant_id
+                AND p.sku_id = s_new.id
+                AND p.scope = 'retail'
+                AND p.effective_to IS NULL
+              ORDER BY p.effective_from DESC
+              LIMIT 1
+           ), 0),
+           999,
+           NULL::UUID,
+           NULL::UUID
+      FROM group_buy_campaigns gbc
+      JOIN campaign_items ci_existing ON ci_existing.campaign_id = gbc.id
+                                      AND ci_existing.tenant_id = gbc.tenant_id
+      JOIN skus s_existing ON s_existing.id = ci_existing.sku_id
+                           AND s_existing.tenant_id = gbc.tenant_id
+      JOIN skus s_new ON s_new.product_id = s_existing.product_id
+                      AND s_new.tenant_id = gbc.tenant_id
+                      AND s_new.status = 'active'
+                      AND s_new.id <> s_existing.id
+     WHERE gbc.status IN ('draft','open')
+       AND NOT EXISTS (
+         SELECT 1 FROM campaign_items ci_check
+          WHERE ci_check.campaign_id = gbc.id
+            AND ci_check.sku_id      = s_new.id
+       )
+    ON CONFLICT (campaign_id, sku_id) DO NOTHING
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO cnt FROM inserted;
+  RAISE NOTICE 'Backfill: added % campaign_items rows', cnt;
+END $$;

--- a/supabase/migrations/20260514000007_sync_price_and_name_to_campaigns.sql
+++ b/supabase/migrations/20260514000007_sync_price_and_name_to_campaigns.sql
@@ -1,0 +1,171 @@
+-- ============================================================
+-- 同步 product / SKU 變更到關聯的 draft/open campaign
+--
+-- 兩個情境：
+--   1. 商品零售價更新 → campaign_items.unit_price 自動跟（draft/open campaign）
+--   2. 商品名稱更新   → group_buy_campaigns.name 自動跟（限 1-product 的 campaign）
+--
+-- 設計：
+--   - 只動 status IN ('draft','open') 的 campaign（已收單後不再變動）
+--   - 多商品 campaign（campaign_items 跨多個 product_id）不自動改 name，避免覆蓋使用者命名
+--   - 1-product campaign（候選池排日期 / 從單一商品開團）name 跟著 product 走
+--
+-- Scope: 加 trigger function + trigger + backfill；不動既有表 / RPC
+-- Rollback:
+--   DROP TRIGGER IF EXISTS trg_prices_sync_campaigns ON prices;
+--   DROP TRIGGER IF EXISTS trg_products_sync_campaign_name ON products;
+--   DROP FUNCTION IF EXISTS public._sync_retail_price_to_campaigns();
+--   DROP FUNCTION IF EXISTS public._sync_product_name_to_campaigns();
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- Trigger 1: prices INSERT (scope='retail') → 同步 campaign_items.unit_price
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._sync_retail_price_to_campaigns()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- 只處理 retail（cost / branch / promo 不影響 campaign 售價）
+  IF NEW.scope IS DISTINCT FROM 'retail' THEN
+    RETURN NEW;
+  END IF;
+  -- 只處理「現行價」（effective_to IS NULL = 最新版）
+  IF NEW.effective_to IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE campaign_items ci
+     SET unit_price = NEW.price,
+         updated_at = NOW()
+    FROM group_buy_campaigns gbc
+   WHERE ci.tenant_id  = NEW.tenant_id
+     AND ci.sku_id     = NEW.sku_id
+     AND ci.campaign_id = gbc.id
+     AND gbc.tenant_id = NEW.tenant_id
+     AND gbc.status IN ('draft','open');
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prices_sync_campaigns ON prices;
+CREATE TRIGGER trg_prices_sync_campaigns
+  AFTER INSERT ON prices
+  FOR EACH ROW
+  EXECUTE FUNCTION public._sync_retail_price_to_campaigns();
+
+-- ----------------------------------------------------------------
+-- Trigger 2: products UPDATE OF name → 同步 1-product campaign.name
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._sync_product_name_to_campaigns()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.name IS NOT DISTINCT FROM OLD.name THEN
+    RETURN NEW;
+  END IF;
+
+  -- 只更新「campaign_items 內所有 SKU 都屬於這個 product」的 campaign
+  -- (子查詢用 GROUP BY + HAVING 篩出 1-product campaign)
+  UPDATE group_buy_campaigns gbc
+     SET name = NEW.name,
+         updated_at = NOW()
+   WHERE gbc.tenant_id = NEW.tenant_id
+     AND gbc.status IN ('draft','open')
+     AND gbc.id IN (
+       SELECT ci.campaign_id
+         FROM campaign_items ci
+         JOIN skus s ON s.id = ci.sku_id AND s.tenant_id = ci.tenant_id
+        WHERE ci.tenant_id = NEW.tenant_id
+        GROUP BY ci.campaign_id
+       HAVING COUNT(DISTINCT s.product_id) = 1
+          AND MAX(s.product_id) = NEW.id
+     );
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_products_sync_campaign_name ON products;
+CREATE TRIGGER trg_products_sync_campaign_name
+  AFTER UPDATE OF name ON products
+  FOR EACH ROW
+  EXECUTE FUNCTION public._sync_product_name_to_campaigns();
+
+COMMENT ON FUNCTION public._sync_retail_price_to_campaigns() IS
+  'Auto-sync retail price changes to campaign_items.unit_price for draft/open campaigns.';
+COMMENT ON FUNCTION public._sync_product_name_to_campaigns() IS
+  'Auto-sync product.name to group_buy_campaigns.name for single-product draft/open campaigns.';
+
+-- ----------------------------------------------------------------
+-- 一次性 backfill：把 draft/open campaign 的價格 / 名稱補齊到目前 product/price 狀態
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  cnt_price INT;
+  cnt_name  INT;
+BEGIN
+  -- 價格 backfill：每個 campaign_items 的 unit_price 更新成 SKU 目前的 retail 最新值
+  WITH updated AS (
+    UPDATE campaign_items ci
+       SET unit_price = sub.retail_price,
+           updated_at = NOW()
+      FROM (
+        SELECT s.id AS sku_id, s.tenant_id,
+               COALESCE((
+                 SELECT pr.price
+                   FROM prices pr
+                  WHERE pr.tenant_id = s.tenant_id
+                    AND pr.sku_id    = s.id
+                    AND pr.scope     = 'retail'
+                    AND pr.effective_to IS NULL
+                  ORDER BY pr.effective_from DESC
+                  LIMIT 1
+               ), 0) AS retail_price
+          FROM skus s
+      ) sub,
+           group_buy_campaigns gbc
+     WHERE ci.sku_id      = sub.sku_id
+       AND ci.tenant_id   = sub.tenant_id
+       AND ci.campaign_id = gbc.id
+       AND gbc.tenant_id  = sub.tenant_id
+       AND gbc.status IN ('draft','open')
+       AND ci.unit_price IS DISTINCT FROM sub.retail_price
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO cnt_price FROM updated;
+  RAISE NOTICE 'Backfill: synced % campaign_items.unit_price', cnt_price;
+
+  -- 名稱 backfill：1-product campaign 名稱跟 product.name 對齊
+  WITH single_product_campaigns AS (
+    SELECT ci.campaign_id,
+           MAX(s.product_id)        AS product_id,
+           MAX(p.name)              AS p_name,
+           (MAX(gbc.tenant_id::TEXT))::UUID AS tenant_id
+      FROM campaign_items ci
+      JOIN skus s ON s.id = ci.sku_id
+      JOIN products p ON p.id = s.product_id
+      JOIN group_buy_campaigns gbc ON gbc.id = ci.campaign_id
+     WHERE gbc.status IN ('draft','open')
+     GROUP BY ci.campaign_id
+    HAVING COUNT(DISTINCT s.product_id) = 1
+  ),
+  updated AS (
+    UPDATE group_buy_campaigns gbc
+       SET name = spc.p_name,
+           updated_at = NOW()
+      FROM single_product_campaigns spc
+     WHERE gbc.id = spc.campaign_id
+       AND gbc.tenant_id = spc.tenant_id
+       AND gbc.name IS DISTINCT FROM spc.p_name
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO cnt_name FROM updated;
+  RAISE NOTICE 'Backfill: synced % campaign names', cnt_name;
+END $$;

--- a/supabase/migrations/20260514000008_lock_campaign_prices_on_open.sql
+++ b/supabase/migrations/20260514000008_lock_campaign_prices_on_open.sql
@@ -1,0 +1,114 @@
+-- ============================================================
+-- 開團 status 從 draft → open 時、把活動單價 snapshot 鎖定
+--
+-- 變更：
+--   1. campaign_items 加 locked_at TIMESTAMPTZ 欄位（鎖定時間）
+--   2. 修 _sync_retail_price_to_campaigns trigger：只動 status='draft' 的 campaign
+--      （open 後 retail 改不影響活動單價）
+--   3. 加 trigger _lock_campaign_prices_on_open：
+--      campaign.status: draft → open 那一刻、把所有 campaign_items.locked_at 設成 NOW()
+--   4. Backfill：既有 status >= open 的 campaign，locked_at 補成 campaign.updated_at
+--
+-- 之後使用者要手動調整 open 後的活動單價，仍可直接 UPDATE campaign_items.unit_price
+-- （trigger 不會干擾）
+--
+-- Scope: 加欄位 + 加 trigger + 改 trigger，不動 RPC / customer_order_items
+-- Rollback:
+--   ALTER TABLE campaign_items DROP COLUMN locked_at;
+--   DROP TRIGGER IF EXISTS trg_campaigns_lock_on_open ON group_buy_campaigns;
+--   DROP FUNCTION IF EXISTS public._lock_campaign_prices_on_open();
+--   重新 apply 20260514000007 的 _sync_retail_price_to_campaigns
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. 加 locked_at 欄位
+-- ----------------------------------------------------------------
+ALTER TABLE campaign_items
+  ADD COLUMN IF NOT EXISTS locked_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN campaign_items.locked_at IS
+  'Snapshot lock time. NULL = draft（unit_price 跟 retail 走）；NOT NULL = 已鎖定（status >= open，retail 改不再影響）';
+
+-- ----------------------------------------------------------------
+-- 2. 改 _sync_retail_price_to_campaigns：只動 draft 的 campaign
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._sync_retail_price_to_campaigns()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.scope IS DISTINCT FROM 'retail' THEN
+    RETURN NEW;
+  END IF;
+  IF NEW.effective_to IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- 只動 draft 階段（open 後鎖定）
+  UPDATE campaign_items ci
+     SET unit_price = NEW.price,
+         updated_at = NOW()
+    FROM group_buy_campaigns gbc
+   WHERE ci.tenant_id  = NEW.tenant_id
+     AND ci.sku_id     = NEW.sku_id
+     AND ci.campaign_id = gbc.id
+     AND gbc.tenant_id = NEW.tenant_id
+     AND gbc.status    = 'draft';
+
+  RETURN NEW;
+END;
+$$;
+
+-- ----------------------------------------------------------------
+-- 3. 新 trigger：campaign.status: draft → open 鎖定價格
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._lock_campaign_prices_on_open()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF OLD.status = 'draft' AND NEW.status = 'open' THEN
+    UPDATE campaign_items
+       SET locked_at  = NOW(),
+           updated_at = NOW()
+     WHERE campaign_id = NEW.id
+       AND tenant_id   = NEW.tenant_id
+       AND locked_at IS NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_campaigns_lock_on_open ON group_buy_campaigns;
+CREATE TRIGGER trg_campaigns_lock_on_open
+  AFTER UPDATE OF status ON group_buy_campaigns
+  FOR EACH ROW
+  EXECUTE FUNCTION public._lock_campaign_prices_on_open();
+
+COMMENT ON FUNCTION public._lock_campaign_prices_on_open() IS
+  'On campaign status draft→open: snapshot locked_at = NOW() for all campaign_items.';
+
+-- ----------------------------------------------------------------
+-- 4. Backfill：既有 status >= open 的 campaign_items.locked_at = campaign.updated_at
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  cnt INT;
+BEGIN
+  WITH updated AS (
+    UPDATE campaign_items ci
+       SET locked_at = gbc.updated_at
+      FROM group_buy_campaigns gbc
+     WHERE ci.campaign_id = gbc.id
+       AND ci.tenant_id   = gbc.tenant_id
+       AND gbc.status IN ('open','closed','ordered','receiving','ready','completed','cancelled')
+       AND ci.locked_at IS NULL
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO cnt FROM updated;
+  RAISE NOTICE 'Backfill: locked_at set on % campaign_items rows', cnt;
+END $$;

--- a/supabase/migrations/20260514000009_campaign_product_invariant.sql
+++ b/supabase/migrations/20260514000009_campaign_product_invariant.sql
@@ -1,0 +1,184 @@
+-- ============================================================
+-- 1 campaign : 1 product invariant
+--
+-- 變更：
+--   1. group_buy_campaigns 加 product_id BIGINT REFERENCES products(id)
+--   2. Backfill：從既有 campaign_items 反查 product（多商品 campaign 取第一個 product_id）
+--   3. 加 trigger：campaign_items INSERT/UPDATE 時，新 SKU 的 product_id 必須等於 campaign.product_id
+--   4. 簡化 _sync_product_name_to_campaigns trigger：直接看 campaign.product_id（拿掉 1-product 子查詢）
+--   5. rpc_schedule_candidate / rpc_create_campaign_from_products 之後在後續 migration / RPC 重寫負責設 product_id
+--
+-- 既有 6 個多商品 campaign：backfill 取第一個 product_id；constraint 只擋未來 INSERT、不破壞歷史
+--
+-- Scope: 加欄位 + 簡化 trigger + 加 trigger
+-- Rollback:
+--   ALTER TABLE group_buy_campaigns DROP COLUMN product_id;
+--   DROP TRIGGER IF EXISTS trg_campaign_items_check_product ON campaign_items;
+--   DROP FUNCTION IF EXISTS public._enforce_campaign_product_invariant();
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. 加 product_id 欄位
+-- ----------------------------------------------------------------
+ALTER TABLE group_buy_campaigns
+  ADD COLUMN IF NOT EXISTS product_id BIGINT REFERENCES products(id);
+
+CREATE INDEX IF NOT EXISTS idx_gbc_product
+  ON group_buy_campaigns (tenant_id, product_id);
+
+COMMENT ON COLUMN group_buy_campaigns.product_id IS
+  '1 campaign : 1 product invariant；所有 campaign_items.skus.product_id 必須等於此欄位';
+
+-- ----------------------------------------------------------------
+-- 2. Backfill：每個 campaign 找 SKU 對應的 product_id（多商品取最小 sku_id 的 product）
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  cnt INT;
+BEGIN
+  WITH first_product_per_campaign AS (
+    SELECT DISTINCT ON (ci.campaign_id)
+           ci.campaign_id,
+           s.product_id,
+           ci.tenant_id
+      FROM campaign_items ci
+      JOIN skus s ON s.id = ci.sku_id
+     ORDER BY ci.campaign_id, ci.sku_id
+  ),
+  updated AS (
+    UPDATE group_buy_campaigns gbc
+       SET product_id = fp.product_id
+      FROM first_product_per_campaign fp
+     WHERE gbc.id = fp.campaign_id
+       AND gbc.tenant_id = fp.tenant_id
+       AND gbc.product_id IS NULL
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO cnt FROM updated;
+  RAISE NOTICE 'Backfill: set product_id on % group_buy_campaigns', cnt;
+END $$;
+
+-- ----------------------------------------------------------------
+-- 3. campaign_items 防呆 trigger：新加的 SKU 必須跟 campaign.product_id 同 product
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._enforce_campaign_product_invariant()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_campaign_product BIGINT;
+  v_sku_product      BIGINT;
+BEGIN
+  SELECT product_id INTO v_campaign_product
+    FROM group_buy_campaigns
+   WHERE id = NEW.campaign_id
+     AND tenant_id = NEW.tenant_id;
+
+  -- campaign 還沒設 product_id（理論上 backfill 後不會發生）→ 略過
+  IF v_campaign_product IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT product_id INTO v_sku_product
+    FROM skus
+   WHERE id = NEW.sku_id
+     AND tenant_id = NEW.tenant_id;
+
+  IF v_sku_product IS DISTINCT FROM v_campaign_product THEN
+    RAISE EXCEPTION '1-campaign-1-product invariant violated: campaign % is for product %, but sku % belongs to product %',
+      NEW.campaign_id, v_campaign_product, NEW.sku_id, v_sku_product;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_campaign_items_check_product ON campaign_items;
+CREATE TRIGGER trg_campaign_items_check_product
+  BEFORE INSERT OR UPDATE OF sku_id ON campaign_items
+  FOR EACH ROW
+  EXECUTE FUNCTION public._enforce_campaign_product_invariant();
+
+-- ----------------------------------------------------------------
+-- 4. 簡化 _sync_product_name_to_campaigns：直接 join campaign.product_id
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._sync_product_name_to_campaigns()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.name IS NOT DISTINCT FROM OLD.name THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE group_buy_campaigns
+     SET name = NEW.name,
+         updated_at = NOW()
+   WHERE tenant_id = NEW.tenant_id
+     AND product_id = NEW.id
+     AND status IN ('draft','open');
+
+  RETURN NEW;
+END;
+$$;
+
+-- ----------------------------------------------------------------
+-- 5. _sync_sku_to_open_campaigns 也改成用 campaign.product_id（更直接）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._sync_sku_to_open_campaigns()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_unit_price NUMERIC;
+  c            RECORD;
+BEGIN
+  IF NEW.status IS DISTINCT FROM 'active' THEN
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'UPDATE' AND OLD.status = 'active' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT COALESCE(p.price, 0) INTO v_unit_price
+    FROM prices p
+   WHERE p.tenant_id = NEW.tenant_id
+     AND p.sku_id    = NEW.id
+     AND p.scope     = 'retail'
+     AND p.effective_to IS NULL
+   ORDER BY p.effective_from DESC
+   LIMIT 1;
+  v_unit_price := COALESCE(v_unit_price, 0);
+
+  -- 改用 campaign.product_id 直接找：所有此 product 的 draft/open campaign
+  FOR c IN
+    SELECT id AS campaign_id
+      FROM group_buy_campaigns
+     WHERE tenant_id  = NEW.tenant_id
+       AND product_id = NEW.product_id
+       AND status IN ('draft','open')
+  LOOP
+    INSERT INTO campaign_items (
+      tenant_id, campaign_id, sku_id, unit_price, sort_order,
+      created_by, updated_by
+    ) VALUES (
+      NEW.tenant_id, c.campaign_id, NEW.id, v_unit_price, 999,
+      auth.uid(), auth.uid()
+    )
+    ON CONFLICT (campaign_id, sku_id) DO NOTHING;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public._sync_product_name_to_campaigns() IS
+  'Auto-sync product.name → group_buy_campaigns.name for draft/open campaigns linked via product_id (1:1 invariant).';
+COMMENT ON FUNCTION public._sync_sku_to_open_campaigns() IS
+  'Auto-add new active SKU to draft/open campaigns linked to the same product via campaign.product_id.';

--- a/supabase/migrations/20260514000010_rpc_singular_product.sql
+++ b/supabase/migrations/20260514000010_rpc_singular_product.sql
@@ -1,0 +1,239 @@
+-- ============================================================
+-- RPC 配合 1:1 invariant：
+--   1. 新 rpc_create_campaign_from_product（單 product）取代 _from_products（多）
+--   2. rpc_schedule_candidate 內部建 campaign 時補設 product_id
+--
+-- 變更後：
+--   - 「從商品開團」UI 改 call 新 RPC、單 product 入參
+--   - rpc_schedule_candidate 建出來的 campaign 自動帶 product_id
+--   - 既有 rpc_create_campaign_from_products 維持運作（dev 過渡），但內部會 RAISE WARNING 提醒；
+--     UI 切換完成後可再寫 migration 砍掉
+--
+-- Scope: 加 RPC + 修 RPC，不動表
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.rpc_create_campaign_from_product(TEXT, TIMESTAMPTZ, DATE, BIGINT);
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- rpc_create_campaign_from_product — 單 product 建團
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_campaign_from_product(
+  p_name            TEXT,
+  p_end_at          TIMESTAMPTZ,
+  p_pickup_deadline DATE,
+  p_product_id      BIGINT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant      UUID := public._current_tenant_id();
+  v_no          TEXT;
+  v_campaign_id BIGINT;
+  v_sort        INT  := 1;
+  r             RECORD;
+BEGIN
+  -- 確認 product 在同 tenant
+  PERFORM 1 FROM products WHERE id = p_product_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'product % not in tenant', p_product_id;
+  END IF;
+
+  v_no := public.rpc_next_campaign_no();
+
+  INSERT INTO group_buy_campaigns (
+    tenant_id, campaign_no, name, status, product_id,
+    start_at, end_at, pickup_deadline,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_no, p_name, 'open', p_product_id,
+    NOW(), p_end_at, p_pickup_deadline,
+    auth.uid(), auth.uid()
+  ) RETURNING id INTO v_campaign_id;
+
+  -- 對該 product 的所有 active SKU 補進 campaign_items
+  FOR r IN
+    SELECT
+      s.id AS sku_id,
+      COALESCE(
+        (SELECT p.price
+           FROM prices p
+          WHERE p.sku_id    = s.id
+            AND p.scope     = 'retail'
+            AND p.tenant_id = v_tenant
+            AND p.effective_to IS NULL
+          ORDER BY p.effective_from DESC
+          LIMIT 1),
+        0
+      ) AS unit_price
+    FROM skus s
+   WHERE s.product_id = p_product_id
+     AND s.tenant_id  = v_tenant
+     AND s.status     = 'active'
+   ORDER BY s.id
+  LOOP
+    INSERT INTO campaign_items (
+      tenant_id, campaign_id, sku_id, unit_price, sort_order,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, v_campaign_id, r.sku_id, r.unit_price, v_sort,
+      auth.uid(), auth.uid()
+    )
+    ON CONFLICT (campaign_id, sku_id) DO NOTHING;
+    v_sort := v_sort + 1;
+  END LOOP;
+
+  RETURN v_campaign_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_campaign_from_product(TEXT, TIMESTAMPTZ, DATE, BIGINT)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_campaign_from_product(TEXT, TIMESTAMPTZ, DATE, BIGINT) IS
+  '從單一商品建團（1:1 invariant）：自動產生團號、設 product_id、塞入所有 active SKU。';
+
+-- ----------------------------------------------------------------
+-- rpc_schedule_candidate：補設 product_id
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_schedule_candidate(
+  p_candidate_id    BIGINT,
+  p_scheduled_date  DATE,
+  p_product_name    TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant         UUID := public._current_tenant_id();
+  v_user           UUID := auth.uid();
+  v_role           TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_cand           RECORD;
+  v_product_code   TEXT;
+  v_product_id     BIGINT;
+  v_sku_code       TEXT;
+  v_sku_id         BIGINT;
+  v_campaign_no    TEXT;
+  v_campaign_id    BIGINT;
+  v_unit_price     NUMERIC;
+  v_existing_camp  RECORD;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','assistant','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot schedule candidate', v_role;
+  END IF;
+
+  IF TRIM(COALESCE(p_product_name, '')) = '' THEN
+    RAISE EXCEPTION 'product_name must not be blank';
+  END IF;
+  IF p_scheduled_date IS NULL THEN
+    RAISE EXCEPTION 'scheduled_date must not be null';
+  END IF;
+
+  SELECT id, owner_action, adopted_product_id, adopted_sale_price, raw_text
+    INTO v_cand
+    FROM community_product_candidates
+   WHERE id = p_candidate_id AND tenant_id = v_tenant
+     FOR UPDATE;
+
+  IF v_cand.id IS NULL THEN
+    RAISE EXCEPTION 'candidate % not found or cross-tenant', p_candidate_id;
+  END IF;
+
+  IF v_cand.adopted_product_id IS NOT NULL THEN
+    SELECT c.id AS campaign_id, c.campaign_no, p.product_code,
+           (SELECT id FROM skus WHERE product_id = v_cand.adopted_product_id
+              AND tenant_id = v_tenant ORDER BY id LIMIT 1) AS sku_id
+      INTO v_existing_camp
+      FROM products p
+      LEFT JOIN group_buy_campaigns c
+             ON c.product_id = p.id AND c.tenant_id = v_tenant
+     WHERE p.id = v_cand.adopted_product_id
+       AND p.tenant_id = v_tenant
+     ORDER BY c.created_at ASC NULLS LAST
+     LIMIT 1;
+
+    IF v_existing_camp.campaign_id IS NULL THEN
+      v_product_id  := v_cand.adopted_product_id;
+      v_sku_id      := v_existing_camp.sku_id;
+      v_product_code:= v_existing_camp.product_code;
+    ELSE
+      RETURN jsonb_build_object(
+        'product_id',         v_cand.adopted_product_id,
+        'product_code',       v_existing_camp.product_code,
+        'sku_id',             v_existing_camp.sku_id,
+        'campaign_id',        v_existing_camp.campaign_id,
+        'campaign_no',        v_existing_camp.campaign_no,
+        'already_scheduled',  TRUE
+      );
+    END IF;
+  ELSE
+    v_product_code := public.rpc_next_product_code();
+    v_product_id := public.rpc_upsert_product(
+      p_id := NULL, p_product_code := v_product_code,
+      p_name := TRIM(p_product_name), p_short_name := NULL,
+      p_brand_id := NULL, p_category_id := NULL,
+      p_description := v_cand.raw_text, p_status := 'draft',
+      p_reason := 'schedule candidate #' || p_candidate_id::TEXT
+    );
+
+    v_sku_code := public.rpc_next_sku_code(v_product_id);
+    v_sku_id := public.rpc_upsert_sku(
+      p_id := NULL, p_product_id := v_product_id, p_sku_code := v_sku_code,
+      p_variant_name := NULL, p_spec := '{}'::jsonb,
+      p_base_unit := NULL, p_weight_g := NULL, p_tax_rate := NULL,
+      p_status := 'draft',
+      p_reason := 'schedule candidate #' || p_candidate_id::TEXT
+    );
+
+    IF v_cand.adopted_sale_price IS NOT NULL THEN
+      PERFORM public.rpc_set_retail_price(
+        v_sku_id, v_cand.adopted_sale_price, NOW(),
+        'schedule candidate #' || p_candidate_id::TEXT
+      );
+    END IF;
+  END IF;
+
+  v_campaign_no := 'GB' || to_char(p_scheduled_date, 'YYYYMMDD')
+                 || '-C' || lpad(p_candidate_id::TEXT, 6, '0');
+
+  v_campaign_id := public.rpc_upsert_campaign(
+    p_id := NULL, p_campaign_no := v_campaign_no,
+    p_name := TRIM(p_product_name), p_description := v_cand.raw_text,
+    p_cover_image_url := NULL, p_status := 'draft', p_close_type := 'regular',
+    p_start_at := p_scheduled_date::TIMESTAMPTZ, p_end_at := NULL,
+    p_pickup_deadline := NULL, p_pickup_days := NULL,
+    p_total_cap_qty := NULL,
+    p_notes := 'schedule candidate #' || p_candidate_id::TEXT
+  );
+
+  -- 補設 product_id（rpc_upsert_campaign 沒有此參數）
+  UPDATE group_buy_campaigns
+     SET product_id = v_product_id
+   WHERE id = v_campaign_id AND tenant_id = v_tenant;
+
+  v_unit_price := COALESCE(v_cand.adopted_sale_price, 0);
+  PERFORM public.rpc_upsert_campaign_item(
+    p_id := NULL, p_campaign_id := v_campaign_id, p_sku_id := v_sku_id,
+    p_unit_price := v_unit_price, p_cap_qty := NULL,
+    p_sort_order := 0, p_notes := NULL
+  );
+
+  UPDATE community_product_candidates
+     SET adopted_product_id = v_product_id, owner_action = 'scheduled',
+         scheduled_open_at  = p_scheduled_date,
+         scheduled_by = v_user, scheduled_at = NOW(),
+         updated_at = NOW(), updated_by = v_user
+   WHERE id = p_candidate_id AND tenant_id = v_tenant;
+
+  RETURN jsonb_build_object(
+    'product_id',         v_product_id,
+    'product_code',       v_product_code,
+    'sku_id',             v_sku_id,
+    'campaign_id',        v_campaign_id,
+    'campaign_no',        v_campaign_no,
+    'already_scheduled',  FALSE
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary
- **候選池→草稿開團**：候選池排日期一鍵建 draft product+sku+campaign+items，下游 trigger 自動同步 SKU/價格/名稱
- **三層價格 + role 顯隱**：成本/零售/分店 三種，admin 看全部、store_manager 看零售+分店、store_staff 只看零售；DB RLS + RPC role check 雙層擋
- **1 campaign : 1 product invariant**：加 `group_buy_campaigns.product_id`，campaign_items 防呆 trigger 擋跨 product；自動同步 product.name / retail price / 新 SKU 到 draft/open campaign；draft→open 那一刻 snapshot 鎖定活動單價（後續 retail 變動不影響）
- **TipTap rich text 描述**、**開團頁三 tab**（列表/未來 7 天/月曆，tab 持久化）、**開團卡片**含商品數+訂單數+加單按鈕、**批次建立**（每月 N 號 / 每週 / 每隔 N 天）、**加單下拉支援同商品其他規格**（lazy-create campaign_items）
- **Print page basePath fix**：5 個 site（window.open + 原生 `<a href>`）漏了 `/new_erp/`，加 `withBasePath` helper

## Schema 改動 (11 migrations, all applied to dev)
- prices.scope CHECK 加 cost / branch
- group_buy_campaigns.product_id（含 backfill 66 campaigns）
- campaign_items.locked_at
- 7 個 trigger function（auto-sync new SKU / retail price / product name / lock on open / 1:1 invariant 防呆）
- rpc_set_cost_price / rpc_set_branch_price / rpc_schedule_candidate / rpc_create_campaign_from_product

## Test plan
- [ ] 候選池排日期：candidate → draft product+sku+campaign+items 全部建好、product_id 設定、locked_at 為 NULL（draft）
- [ ] 商品上架前驗：未填三種價格擋下；填齊後 draft → active 通過
- [ ] 開團上線前驗：linked product 還是 draft 擋下；product 上架後 draft → open 通過、campaign_items.locked_at 寫入 NOW()
- [ ] role × scope：admin 看 3 種價、store_manager 看 retail+branch、store_staff 只看 retail（DB RLS 直接擋）
- [ ] 同 product 加新 SKU：trigger 自動補進 draft/open campaign；變動 retail：draft 跟、open 鎖定
- [ ] 加單下拉：sibling SKU 顯示「+ 加入此團」、選了 lazy-create campaign_items
- [ ] 批次建立：選 1 active product → 預覽 N 場 → 一次建好（campaign_no 格式 GB{YYYYMMDD}-S{sku_id}）
- [ ] 1:1 invariant：手動 INSERT 跨 product 的 SKU 進 campaign_items 被 trigger 擋下
- [ ] basePath fix：production build with NEXT_PUBLIC_BASE_PATH=/new_erp，所有列印頁（pickup/picking-sign/receivables/PR）正確帶前綴

🤖 Generated with [Claude Code](https://claude.com/claude-code)