### PR TITLE
fix(transfers-dispatch): 看明細 改為 popup

### DIFF
--- a/apps/admin/src/app/(protected)/transfers/dispatch/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/dispatch/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
+import { TransferReceiveModal, parseWaveId, type Wave } from "@/components/TransferReceiveModal";
 import { Modal } from "@/components/Modal";
 
 type Transfer = {
@@ -83,6 +83,8 @@ export default function HqDispatchPage() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [damageOpen, setDamageOpen] = useState<Transfer | null>(null);
+  const [detailOpen, setDetailOpen] = useState<Transfer | null>(null);
+  const [waves, setWaves] = useState<Map<number, Wave>>(new Map());
   const [editingNotes, setEditingNotes] = useState<Map<number, string>>(new Map());
 
   // Load
@@ -146,11 +148,24 @@ export default function HqDispatchPage() {
           for (const l of (lRows as Loc[] | null) ?? []) locMap.set(l.id, l.name);
         }
 
+        const waveIds = Array.from(
+          new Set(trs.map((t) => parseWaveId(t.transfer_no)).filter((x): x is number => x !== null)),
+        );
+        const waveMap = new Map<number, Wave>();
+        if (waveIds.length > 0) {
+          const { data: ws } = await sb
+            .from("picking_waves")
+            .select("id, wave_code, wave_date, created_at")
+            .in("id", waveIds);
+          for (const w of (ws as Wave[] | null) ?? []) waveMap.set(w.id, w);
+        }
+
         if (!cancelled) {
           setTransfers(trs);
           setItems(itMap);
           setSkus(skuMap);
           setLocs(locMap);
+          setWaves(waveMap);
           setHqLoc(hqId);
           setError(null);
         }
@@ -538,12 +553,12 @@ export default function HqDispatchPage() {
                         登記損壞
                       </button>
                     )}
-                    <Link
-                      href={`/transfers?id=${t.id}`}
+                    <button
+                      onClick={() => setDetailOpen(t)}
                       className="ml-2 text-xs text-blue-600 hover:underline dark:text-blue-400"
                     >
                       看明細
-                    </Link>
+                    </button>
                   </td>
                 </tr>
               );
@@ -560,6 +575,23 @@ export default function HqDispatchPage() {
           onClose={() => setDamageOpen(null)}
           onSubmitted={() => {
             setDamageOpen(null);
+            setReloadTick((n) => n + 1);
+          }}
+        />
+      )}
+
+      {detailOpen && (
+        <TransferReceiveModal
+          transfer={detailOpen}
+          srcName={locs.get(detailOpen.source_location) ?? `#${detailOpen.source_location}`}
+          dstName={locs.get(detailOpen.dest_location) ?? `#${detailOpen.dest_location}`}
+          wave={(() => {
+            const wid = parseWaveId(detailOpen.transfer_no);
+            return wid !== null ? waves.get(wid) ?? null : null;
+          })()}
+          onClose={() => setDetailOpen(null)}
+          onSubmitted={() => {
+            setDetailOpen(null);
             setReloadTick((n) => n + 1);
           }}
         />


### PR DESCRIPTION
## Summary
- `/transfers/dispatch` 的「看明細」原本連到 `/transfers?id={id}`，但 `/transfers` 列表頁從不讀 `id` 參數，連結等於壞的（只會把使用者帶到列表頁）。
- 改為點擊直接在原頁彈出 `TransferReceiveModal`（依 `status !== 'shipped'` 自動切 readOnly），沿用既有 `DamageModal` 的 state 模式。
- 同 useEffect 補載 `picking_waves`，讓 modal 內的「撿貨單建立」timeline 正常顯示。

## Test plan
- [x] 待審核 tab 點「看明細」→ popup 開啟，標題「收貨：TR…」、無「確認收貨/拒收」按鈕、停在 `/transfers/dispatch`
- [x] 已收到 tab 點「看明細」→ popup 開啟，input 鎖定、顯示已收貨徽章
- [x] 已到總倉 tab 點「看明細」→ popup 開啟，timeline 正確
- [x] 點「關閉」→ modal 關掉、URL 不變
- [x] 「登記損壞」按鈕仍正常運作（已收到 tab）

🤖 Generated with [Claude Code](https://claude.com/claude-code)