### PR TITLE
fix(aid-timeline): 左側豎線對齊圓點中心

### DIFF
--- a/apps/admin/src/components/AidOrderTimeline.tsx
+++ b/apps/admin/src/components/AidOrderTimeline.tsx
@@ -318,7 +318,7 @@ export function AidOrderTimeline({ orderId }: { orderId: number }) {
         {events.map((ev, i) => (
           <li key={`${ev.kind}-${i}`} className="relative">
             <span
-              className={`absolute -left-[1.4rem] top-1 inline-block h-3 w-3 rounded-full border-2 ${dotClass(ev.status)}`}
+              className={`absolute -left-[1.625rem] top-1 inline-block h-3 w-3 rounded-full border-2 ${dotClass(ev.status)}`}
             />
             <div className="flex flex-wrap items-baseline gap-2">
               <span className={`text-sm font-medium ${textClass(ev.status)}`}>


### PR DESCRIPTION
## Summary
- 互助轉移進度 timeline 左側的豎線（OL `border-l`）原本沒對齊圓點中心 — 圓點偏右約 4px
- 數學：OL 有 1px border-l + pl-5 (20px)，LI content edge = 21px；原 dot offset \`-1.4rem\` (-22.4px) 讓 dot center 落在 4.6px、線在 0.5px
- 改為 \`-1.625rem\` (-26px) → dot center = 1px，視覺上線從圓點正中通過

## Test plan
- [ ] 開任一含互助轉移的 order detail（/orders 點進去 / /transfers/aid 看明細），確認 timeline 左側豎線穿過圓點中心

🤖 Generated with [Claude Code](https://claude.com/claude-code)