### PR TITLE
fix(orders): 訂單狀態顯示改中文

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -251,7 +251,7 @@ export default function OrdersListPage() {
           orderNo={pickup.no}
           onPickedUp={(r) => {
             setPickup(null);
-            alert(`取貨完成 (${r.picked_count} 項)\n訂單狀態：${r.new_order_status}`);
+            alert(`取貨完成 (${r.picked_count} 項)\n訂單狀態：${STATUS_LABEL[r.new_order_status as OrderStatus] ?? r.new_order_status}`);
             setReloadOrders((n) => n + 1);
           }}
         />

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -46,6 +46,14 @@ type TimelineStep = {
   detailOnClick?: () => void;
 };
 
+const STATUS_LABEL: Record<string, string> = {
+  pending: "待確認", confirmed: "已確認", reserved: "已保留", shipping: "派貨中",
+  ready: "可取貨", partially_ready: "部分可取", partially_completed: "部分取貨",
+  completed: "已完成", expired: "逾期", cancelled: "已取消",
+  transferred_out: "已轉出", picked_up: "已取貨",
+};
+const statusLabel = (s: string) => STATUS_LABEL[s] ?? s;
+
 function staffLabel(uid: string | null, names: Map<string, string>): string {
   if (!uid) return "—";
   return names.get(uid) ?? uid.slice(0, 8);
@@ -182,7 +190,7 @@ export function OrderDetail({
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <Field label="訂單號" value={<span className="font-mono">{head.order_no}</span>} />
-        <Field label="狀態" value={head.status} />
+        <Field label="狀態" value={statusLabel(head.status)} />
         <Field label="取貨截止" value={head.pickup_deadline ?? "—"} />
         <Field
           label="會員"
@@ -287,7 +295,7 @@ export function OrderDetail({
         orderNo={head.order_no}
         onPickedUp={(r) => {
           setPickupOpen(false);
-          alert(`取貨完成 (${r.picked_count} 項)\n訂單狀態：${r.new_order_status}`);
+          alert(`取貨完成 (${r.picked_count} 項)\n訂單狀態：${statusLabel(r.new_order_status)}`);
           setReloadTick((n) => n + 1);
         }}
       />
@@ -380,7 +388,7 @@ async function buildTimeline(
       label: "顧客取貨",
       ts: null,
       done: rank >= 5,
-      detail: rank >= 5 ? "已完成" : `當前：${head.status}`,
+      detail: rank >= 5 ? "已完成" : `當前：${statusLabel(head.status)}`,
     };
 
     if (head.is_air_transfer) {
@@ -559,7 +567,7 @@ async function buildTimeline(
     { label: "撿貨完成", ts: waveTs, done: wavePicked, detail: waveDetail || undefined, detailHref: waveHref },
     { label: "派貨出倉", ts: shippedTs, done: xferShipped, detail: xferDetail || undefined, detailHref: xferHref },
     { label: "分店收貨", ts: receivedTs, done: xferReceived, detail: xferDetail || undefined, detailHref: xferHref },
-    { label: "顧客取貨", ts: null, done: pickedUp, detail: status },
+    { label: "顧客取貨", ts: null, done: pickedUp, detail: statusLabel(status) },
   ];
 }
 


### PR DESCRIPTION
## Summary
- 訂單明細頁狀態欄位 + timeline 「顧客取貨」detail + 取貨 alert 原本直接顯示英文（pending / completed / ready 等）
- OrderDetail.tsx 加 \`statusLabel()\` 輔助函式，把 4 處 raw status 顯示改成中文
- orders/page.tsx 取貨 alert 也用既有的 STATUS_LABEL 對應

## Status mapping
- pending → 待確認、confirmed → 已確認、reserved → 已保留
- shipping → 派貨中、ready → 可取貨
- partially_ready → 部分可取、partially_completed → 部分取貨
- completed → 已完成、expired → 逾期、cancelled → 已取消
- transferred_out → 已轉出、picked_up → 已取貨

## Test plan
- [ ] /orders 點任一訂單看「訂單明細」popup → 「狀態」欄位顯示中文
- [ ] 互助訂單明細 timeline 「顧客取貨」detail 顯示中文「當前：…」
- [ ] 點「✅ 取貨」按鈕完成取貨 → alert 顯示「訂單狀態：已完成」（中文）
- [ ] 從 OrderDetail 內按取貨 → alert 同上

🤖 Generated with [Claude Code](https://claude.com/claude-code)