### PR TITLE
feat(layout): mobile 漢堡選單 + 抽屜

### DIFF
--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useAuth } from "@/components/AuthProvider";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
@@ -62,6 +62,7 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
   const { session, loading, user, signOut } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   useEffect(() => {
     if (loading) return;
@@ -70,6 +71,26 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
       router.replace(`/login?next=${next}`);
     }
   }, [loading, session, pathname, router]);
+
+  // Auto-close drawer when route changes
+  useEffect(() => {
+    setDrawerOpen(false);
+  }, [pathname]);
+
+  // ESC closes drawer + lock body scroll while open
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setDrawerOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [drawerOpen]);
 
   if (loading || !session) {
     return (
@@ -147,19 +168,97 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
 
       {/* Mobile bar */}
       <div className="md:hidden print:hidden">
-        <header className="flex items-center justify-between border-b border-zinc-200 bg-white px-4 py-2 dark:border-zinc-800 dark:bg-zinc-900">
-          <Link href="/" className="font-semibold">new_erp</Link>
+        <header className="flex items-center justify-between border-b border-zinc-200 bg-white px-3 py-2 dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setDrawerOpen(true)}
+              aria-label="開啟選單"
+              className="-ml-1 inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
+                <line x1="3" y1="6" x2="21" y2="6" />
+                <line x1="3" y1="12" x2="21" y2="12" />
+                <line x1="3" y1="18" x2="21" y2="18" />
+              </svg>
+            </button>
+            <Link href="/" className="font-semibold">new_erp</Link>
+          </div>
           <div className="flex items-center gap-2 text-sm">
             <ThemeToggle />
-            <button
-              onClick={onLogout}
-              className="rounded-md border border-zinc-300 px-2 py-1 text-zinc-700 dark:border-zinc-700 dark:text-zinc-300"
-            >
-              登出
-            </button>
           </div>
         </header>
       </div>
+
+      {/* Mobile drawer */}
+      {drawerOpen && (
+        <div className="fixed inset-0 z-50 md:hidden print:hidden" role="dialog" aria-modal="true">
+          <div
+            className="absolute inset-0 bg-zinc-900/50 backdrop-blur-sm"
+            onClick={() => setDrawerOpen(false)}
+            aria-hidden
+          />
+          <aside className="absolute left-0 top-0 flex h-full w-72 max-w-[85vw] flex-col border-r border-zinc-200 bg-zinc-50 shadow-xl dark:border-zinc-800 dark:bg-zinc-950">
+            <div className="flex items-start justify-between border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">
+              <Link href="/" onClick={() => setDrawerOpen(false)} className="block">
+                <div className="text-lg font-semibold tracking-tight">new_erp</div>
+                <div className="text-xs text-zinc-500">團購店管理</div>
+              </Link>
+              <button
+                onClick={() => setDrawerOpen(false)}
+                aria-label="關閉選單"
+                className="-mr-1 inline-flex h-8 w-8 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+              >
+                ✕
+              </button>
+            </div>
+
+            <nav className="flex-1 overflow-y-auto px-2 py-3 text-sm">
+              {NAV.map((g, gi) => (
+                <div key={gi} className="mb-4">
+                  {g.title && (
+                    <div className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+                      {g.title}
+                    </div>
+                  )}
+                  <ul className="space-y-0.5">
+                    {g.items.map((it) => {
+                      const active = it.match.test(pathname || "");
+                      return (
+                        <li key={it.href}>
+                          <Link
+                            href={it.href}
+                            onClick={() => setDrawerOpen(false)}
+                            className={
+                              active
+                                ? "flex items-center justify-between rounded-md bg-zinc-900 px-3 py-2 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                                : "flex items-center justify-between rounded-md px-3 py-2 text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900"
+                            }
+                          >
+                            <span>{it.label}</span>
+                            {active && <span className="text-xs opacity-60">›</span>}
+                          </Link>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ))}
+            </nav>
+
+            <div className="border-t border-zinc-200 p-3 text-xs dark:border-zinc-800">
+              <div className="mb-2 truncate text-zinc-500" title={user?.email ?? ""}>
+                {user?.email}
+              </div>
+              <button
+                onClick={onLogout}
+                className="w-full rounded-md border border-zinc-300 px-2 py-1.5 text-zinc-700 transition hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-900"
+              >
+                登出
+              </button>
+            </div>
+          </aside>
+        </div>
+      )}
 
       <main className="flex flex-1 flex-col">{children}</main>
     </div>


### PR DESCRIPTION
## Summary
- 原本手機版 admin 介面沒 nav drawer、登入後完全進不去任何頁
- 加漢堡按鈕（mobile bar 左側）+ 從左滑入的 drawer，內容直接複用 desktop sidebar 同一份 \`NAV\` 結構（含 4 個群組標題、active 狀態高亮、用戶 email、登出）
- 4 種關閉路徑：✕ / 背景 click / Esc / 點 nav link（自動關+導頁）
- 開啟時鎖 body scroll，關閉還原

## Test plan
- [x] 手機 viewport 點漢堡 → drawer 開啟、22 個 nav link + 4 個群組標題顯示完整
- [x] 點背景 → drawer 關閉、body scroll 解鎖
- [x] Esc → drawer 關閉
- [x] 點 nav link → 導頁 + drawer 自動關
- [x] Desktop ≥768px → 完全不變、drawer 不顯示

🤖 Generated with [Claude Code](https://claude.com/claude-code)