### PR TITLE
feat(calendar): 拖拉卡片排序 / 跨日換排程日 (dnd-kit)

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@supabase/supabase-js": "^2.104.0",
     "@tiptap/extension-link": "^3.22.5",
     "@tiptap/pm": "^3.22.5",

--- a/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
+++ b/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
@@ -3,6 +3,24 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import {
+  DndContext,
+  closestCorners,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDroppable,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 type CalendarCandidate = {
   id: number;
@@ -88,58 +106,20 @@ export default function CommunityCandidatesCalendarPage() {
     reload();
   }, [reload]);
 
-  const byDate = useMemo(() => {
-    const map = new Map<string, CalendarCandidate[]>();
-    for (const d of days) map.set(formatDate(d), []);
+  // Local mirror of byDate so drag can produce optimistic updates
+  const [localByDate, setLocalByDate] = useState<Record<string, CalendarCandidate[]>>({});
+
+  useEffect(() => {
+    const map: Record<string, CalendarCandidate[]> = {};
+    for (const d of days) map[formatDate(d)] = [];
     for (const r of rows ?? []) {
       if (r.scheduled_open_at) {
         const key = r.scheduled_open_at.slice(0, 10);
-        map.get(key)?.push(r);
+        if (map[key]) map[key].push(r);
       }
     }
-    return map;
-  }, [days, rows]);
-
-  const swapWith = async (a: CalendarCandidate, b: CalendarCandidate) => {
-    setBusy(true);
-    try {
-      const sa = a.scheduled_sort_order ?? 0;
-      const sb = b.scheduled_sort_order ?? 0;
-      const now = new Date().toISOString();
-      const sb1 = getSupabase();
-      const r1 = await sb1
-        .from("community_product_candidates")
-        .update({ scheduled_sort_order: sb, updated_at: now })
-        .eq("id", a.id);
-      if (r1.error) throw r1.error;
-      const r2 = await sb1
-        .from("community_product_candidates")
-        .update({ scheduled_sort_order: sa, updated_at: now })
-        .eq("id", b.id);
-      if (r2.error) throw r2.error;
-      await reload();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const handleMoveUp = async (r: CalendarCandidate) => {
-    if (!r.scheduled_open_at) return;
-    const dayCards = byDate.get(r.scheduled_open_at.slice(0, 10)) ?? [];
-    const idx = dayCards.findIndex((c) => c.id === r.id);
-    if (idx <= 0) return;
-    await swapWith(r, dayCards[idx - 1]);
-  };
-
-  const handleMoveDown = async (r: CalendarCandidate) => {
-    if (!r.scheduled_open_at) return;
-    const dayCards = byDate.get(r.scheduled_open_at.slice(0, 10)) ?? [];
-    const idx = dayCards.findIndex((c) => c.id === r.id);
-    if (idx < 0 || idx >= dayCards.length - 1) return;
-    await swapWith(r, dayCards[idx + 1]);
-  };
+    setLocalByDate(map);
+  }, [rows, days]);
 
   const handleRemove = async (r: CalendarCandidate) => {
     const label = r.product_name_hint ?? "（無商品名）";
@@ -164,6 +144,119 @@ export default function CommunityCandidatesCalendarPage() {
     }
   };
 
+  // ============ DnD ============
+
+  const [activeCard, setActiveCard] = useState<CalendarCandidate | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  function findContainer(id: number | string): string | null {
+    if (typeof id === "string" && days.some((d) => formatDate(d) === id)) return id;
+    const numId = Number(id);
+    for (const [day, cards] of Object.entries(localByDate)) {
+      if (cards.some((c) => c.id === numId)) return day;
+    }
+    return null;
+  }
+
+  const onDragStart = (e: DragStartEvent) => {
+    const id = Number(e.active.id);
+    for (const cards of Object.values(localByDate)) {
+      const c = cards.find((c) => c.id === id);
+      if (c) {
+        setActiveCard(c);
+        break;
+      }
+    }
+  };
+
+  const onDragOver = (e: DragOverEvent) => {
+    const { active, over } = e;
+    if (!over) return;
+    const activeId = Number(active.id);
+    const overContainer = findContainer(over.id as number | string);
+    const activeContainer = findContainer(activeId);
+    if (!activeContainer || !overContainer) return;
+    if (activeContainer === overContainer) return;
+
+    setLocalByDate((prev) => {
+      const src = [...(prev[activeContainer] ?? [])];
+      const dst = [...(prev[overContainer] ?? [])];
+      const idx = src.findIndex((c) => c.id === activeId);
+      if (idx < 0) return prev;
+      const [card] = src.splice(idx, 1);
+      // figure out target index: drop above the over card, or end of list
+      const overIdx =
+        typeof over.id === "number"
+          ? dst.findIndex((c) => c.id === Number(over.id))
+          : dst.length;
+      dst.splice(overIdx >= 0 ? overIdx : dst.length, 0, card);
+      return { ...prev, [activeContainer]: src, [overContainer]: dst };
+    });
+  };
+
+  const onDragEnd = async (e: DragEndEvent) => {
+    const card = activeCard;
+    setActiveCard(null);
+    const { active, over } = e;
+    if (!over || !card) return;
+    const activeId = Number(active.id);
+    const overContainer = findContainer(over.id as number | string);
+    const originalContainer = card.scheduled_open_at?.slice(0, 10) ?? null;
+    if (!overContainer) return;
+
+    // Determine current container after onDragOver moves
+    const currentContainer = findContainer(activeId);
+    if (!currentContainer) return;
+
+    if (currentContainer === originalContainer) {
+      // Same-day reorder: arrayMove + persist
+      const items = localByDate[currentContainer] ?? [];
+      const oldIdx = items.findIndex((c) => c.id === activeId);
+      const newIdx =
+        typeof over.id === "number"
+          ? items.findIndex((c) => c.id === Number(over.id))
+          : items.length - 1;
+      if (oldIdx < 0 || newIdx < 0 || oldIdx === newIdx) return;
+      const newItems = arrayMove(items, oldIdx, newIdx);
+      setLocalByDate((p) => ({ ...p, [currentContainer]: newItems }));
+      await persistDay(currentContainer, newItems);
+      await reload();
+    } else {
+      // Cross-day move: source already updated in onDragOver
+      const srcItems = localByDate[originalContainer ?? ""] ?? [];
+      const dstItems = localByDate[currentContainer] ?? [];
+      setBusy(true);
+      try {
+        await persistDay(currentContainer, dstItems);
+        if (originalContainer) await persistDay(originalContainer, srcItems);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setBusy(false);
+      }
+      await reload();
+    }
+  };
+
+  async function persistDay(dayKey: string, items: CalendarCandidate[]) {
+    const sb = getSupabase();
+    const now = new Date().toISOString();
+    for (let i = 0; i < items.length; i++) {
+      const { error: err } = await sb
+        .from("community_product_candidates")
+        .update({
+          scheduled_open_at: dayKey,
+          scheduled_sort_order: i + 1,
+          updated_at: now,
+        })
+        .eq("id", items[i].id);
+      if (err) throw new Error(err.message);
+    }
+  }
+
   const todayStr = formatDate(days[0]);
 
   return (
@@ -171,7 +264,7 @@ export default function CommunityCandidatesCalendarPage() {
       <header className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold">選品週曆</h1>
-          <p className="mt-0.5 text-sm text-zinc-500">未來 7 天</p>
+          <p className="mt-0.5 text-sm text-zinc-500">未來 7 天 · 拖拉卡片排序或換日</p>
         </div>
         <Link
           href="/community-candidates"
@@ -190,117 +283,176 @@ export default function CommunityCandidatesCalendarPage() {
       {rows === null ? (
         <div className="text-sm text-zinc-400">載入中…</div>
       ) : (
-        <div className="grid grid-cols-7 gap-2 overflow-x-auto">
-          {days.map((d) => {
-            const key = formatDate(d);
-            const isToday = key === todayStr;
-            const cards = byDate.get(key) ?? [];
-            return (
-              <div key={key} className="flex min-w-[120px] flex-col gap-2">
-                <div
-                  className={`rounded-md px-2 py-1.5 text-center text-xs font-semibold ${
-                    isToday
-                      ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
-                      : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
-                  }`}
-                >
-                  <div>{d.getMonth() + 1}/{d.getDate()}</div>
-                  <div className="text-[10px] font-normal opacity-70">週{WEEKDAYS[d.getDay()]}</div>
-                </div>
-
-                {cards.length === 0 ? (
-                  <div className="rounded border border-dashed border-zinc-200 px-2 py-4 text-center text-[10px] text-zinc-400 dark:border-zinc-800">
-                    無排程
-                  </div>
-                ) : (
-                  cards.map((r, idx) => {
-                    const any = r.adopted_supplier_name || r.adopted_cost !== null || r.adopted_sale_price !== null;
-                    const complete = !!(r.adopted_supplier_name && r.adopted_cost !== null && r.adopted_sale_price !== null);
-                    const isFirst = idx === 0;
-                    const isLast = idx === cards.length - 1;
-                    return (
-                      <div
-                        key={r.id}
-                        className="flex flex-col gap-1.5 rounded-md border border-zinc-200 bg-white p-2 text-xs dark:border-zinc-800 dark:bg-zinc-900"
-                      >
-                        <div className="flex items-baseline gap-1.5">
-                          <span className="font-mono text-[10px] font-semibold text-zinc-500 dark:text-zinc-400">
-                            {suggestedTime(idx)}
-                          </span>
-                          <Link
-                            href={`/community-candidates?highlight=${r.id}`}
-                            className="font-medium leading-snug hover:underline"
-                          >
-                            {r.product_name_hint ?? "（無商品名）"}
-                          </Link>
-                        </div>
-                        <div className="flex flex-wrap gap-1">
-                          <span
-                            className={`inline-flex rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
-                              ACTION_COLOR[r.owner_action] ?? ACTION_COLOR.none
-                            }`}
-                          >
-                            {ACTION_LABEL[r.owner_action] ?? r.owner_action}
-                          </span>
-                          {complete && (
-                            <span className="inline-flex rounded-full bg-teal-100 px-1.5 py-0.5 text-[10px] font-medium text-teal-700 dark:bg-teal-900/30 dark:text-teal-300">
-                              已補資料
-                            </span>
-                          )}
-                          {any && !complete && (
-                            <span className="inline-flex rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
-                              資料未完整
-                            </span>
-                          )}
-                        </div>
-                        {any && (
-                          <div className="space-y-0.5 text-[10px] text-zinc-500 dark:text-zinc-400">
-                            {r.adopted_supplier_name && <div>廠商：{r.adopted_supplier_name}</div>}
-                            {r.adopted_cost !== null && <div>成本：{r.adopted_cost}</div>}
-                            {r.adopted_sale_price !== null && <div>售價：{r.adopted_sale_price}</div>}
-                          </div>
-                        )}
-                        <div className="flex gap-1 pt-0.5">
-                          {!isFirst && (
-                            <button
-                              onClick={() => handleMoveUp(r)}
-                              disabled={busy}
-                              className="rounded border border-zinc-300 px-1.5 py-0.5 text-[10px] text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800 disabled:opacity-50"
-                              title="上移"
-                            >
-                              上移
-                            </button>
-                          )}
-                          {!isLast && (
-                            <button
-                              onClick={() => handleMoveDown(r)}
-                              disabled={busy}
-                              className="rounded border border-zinc-300 px-1.5 py-0.5 text-[10px] text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800 disabled:opacity-50"
-                              title="下移"
-                            >
-                              下移
-                            </button>
-                          )}
-                          <button
-                            onClick={() => handleRemove(r)}
-                            disabled={busy}
-                            className="ml-auto rounded border border-red-300 px-1.5 py-0.5 text-[10px] text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950/30 disabled:opacity-50"
-                            title="移出排程"
-                          >
-                            移出
-                          </button>
-                        </div>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCorners}
+          onDragStart={onDragStart}
+          onDragOver={onDragOver}
+          onDragEnd={onDragEnd}
+        >
+          <div className="grid grid-cols-7 gap-2 overflow-x-auto">
+            {days.map((d) => {
+              const key = formatDate(d);
+              const isToday = key === todayStr;
+              const cards = localByDate[key] ?? [];
+              return (
+                <DayColumn key={key} dayKey={key} day={d} isToday={isToday} cards={cards}>
+                  <SortableContext
+                    id={key}
+                    items={cards.map((c) => c.id)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    {cards.length === 0 ? (
+                      <div className="rounded border border-dashed border-zinc-200 px-2 py-4 text-center text-[10px] text-zinc-400 dark:border-zinc-800">
+                        無排程
                       </div>
-                    );
-                  })
-                )}
-              </div>
-            );
-          })}
-        </div>
+                    ) : (
+                      cards.map((r, idx) => (
+                        <SortableCard
+                          key={r.id}
+                          card={r}
+                          idx={idx}
+                          busy={busy}
+                          onRemove={handleRemove}
+                        />
+                      ))
+                    )}
+                  </SortableContext>
+                </DayColumn>
+              );
+            })}
+          </div>
+        </DndContext>
       )}
 
       <div className="text-xs text-zinc-400">共 {rows?.length ?? 0} 筆</div>
+    </div>
+  );
+}
+
+function DayColumn({
+  dayKey,
+  day,
+  isToday,
+  cards,
+  children,
+}: {
+  dayKey: string;
+  day: Date;
+  isToday: boolean;
+  cards: CalendarCandidate[];
+  children: React.ReactNode;
+}) {
+  // useDroppable so empty columns can accept drops
+  const { setNodeRef, isOver } = useDroppable({ id: dayKey });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex min-w-[120px] flex-col gap-2 rounded-md p-1 transition ${
+        isOver && cards.length === 0
+          ? "bg-amber-50 ring-2 ring-amber-300 dark:bg-amber-950/30 dark:ring-amber-700"
+          : ""
+      }`}
+    >
+      <div
+        className={`rounded-md px-2 py-1.5 text-center text-xs font-semibold ${
+          isToday
+            ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+            : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+        }`}
+      >
+        <div>
+          {day.getMonth() + 1}/{day.getDate()}
+        </div>
+        <div className="text-[10px] font-normal opacity-70">週{WEEKDAYS[day.getDay()]}</div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function SortableCard({
+  card: r,
+  idx,
+  busy,
+  onRemove,
+}: {
+  card: CalendarCandidate;
+  idx: number;
+  busy: boolean;
+  onRemove: (r: CalendarCandidate) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: r.id,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  const any = r.adopted_supplier_name || r.adopted_cost !== null || r.adopted_sale_price !== null;
+  const complete = !!(r.adopted_supplier_name && r.adopted_cost !== null && r.adopted_sale_price !== null);
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex flex-col gap-1.5 rounded-md border border-zinc-200 bg-white p-2 text-xs shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div className="flex items-baseline gap-1.5">
+        <span
+          {...attributes}
+          {...listeners}
+          className="cursor-grab select-none touch-none font-mono text-[10px] font-semibold text-zinc-400 hover:text-zinc-700 active:cursor-grabbing dark:text-zinc-500 dark:hover:text-zinc-200"
+          title="拖拉排序 / 換日"
+        >
+          ⋮⋮ {suggestedTime(idx)}
+        </span>
+        <Link
+          href={`/community-candidates?highlight=${r.id}`}
+          className="font-medium leading-snug hover:underline"
+        >
+          {r.product_name_hint ?? "（無商品名）"}
+        </Link>
+      </div>
+      <div className="flex flex-wrap gap-1">
+        <span
+          className={`inline-flex rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
+            ACTION_COLOR[r.owner_action] ?? ACTION_COLOR.none
+          }`}
+        >
+          {ACTION_LABEL[r.owner_action] ?? r.owner_action}
+        </span>
+        {complete && (
+          <span className="inline-flex rounded-full bg-teal-100 px-1.5 py-0.5 text-[10px] font-medium text-teal-700 dark:bg-teal-900/30 dark:text-teal-300">
+            已補資料
+          </span>
+        )}
+        {any && !complete && (
+          <span className="inline-flex rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+            資料未完整
+          </span>
+        )}
+      </div>
+      {any && (
+        <div className="space-y-0.5 text-[10px] text-zinc-500 dark:text-zinc-400">
+          {r.adopted_supplier_name && <div>廠商：{r.adopted_supplier_name}</div>}
+          {r.adopted_cost !== null && <div>成本：{r.adopted_cost}</div>}
+          {r.adopted_sale_price !== null && <div>售價：{r.adopted_sale_price}</div>}
+        </div>
+      )}
+      <div className="flex gap-1 pt-0.5">
+        <button
+          onClick={() => onRemove(r)}
+          disabled={busy}
+          className="ml-auto rounded border border-red-300 px-1.5 py-0.5 text-[10px] text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950/30 disabled:opacity-50"
+          title="移出排程"
+        >
+          移出
+        </button>
+      </div>
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
     "apps/admin": {
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
         "@supabase/supabase-js": "^2.104.0",
         "@tiptap/extension-link": "^3.22.5",
         "@tiptap/pm": "^3.22.5",
@@ -503,6 +506,73 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {


### PR DESCRIPTION
## Summary
裝 \`@dnd-kit/core + sortable + modifiers\`，週曆桌機 7 欄行事曆每張卡片有抓把（卡片左上 \`⋮⋮ 時間\` 區），抓住可：
- **同日內拖移** → 上下調整順序
- **拖到別欄** → \`scheduled_open_at\` 改成該日 + sort_order 排到目標位置
- **拖到「無排程」空欄** → 用 \`useDroppable\` 接住、卡片落到該日尾端

UX 細節：
- Optimistic UI：\`onDragOver\` 即時更新 \`localByDate\`，\`onDragEnd\` 才 batch 寫 DB
- 寫 DB 邏輯：單日整批 \`update scheduled_sort_order = idx + 1\`，跨日同時更兩天
- 寫完 \`reload()\`
- 拖動中：卡片 opacity 0.4；空欄被 hover：amber ring

移除既有 **上移 / 下移** 兩顆按鈕（拖拉取代）；**移出** 按鈕保留（drag 不能取代「unschedule」語意）。

## 注意 / 限制
- 只動桌機 7 欄 grid。手機版（PR #153 的單日視圖）目前還是用 \`<select>\` 換日；mobile drag 是後續 follow-up
- 因為 base = origin/main，diff 不含 PR #153 的手機改動。兩個 PR 都改 \`calendar/page.tsx\` → 哪個先 merge，另一個要 rebase
- 也跟 PR #155 (DatePicker) 在 \`package.json\`/\`package-lock.json\` 會有 lockfile 衝突 → 順手解一下即可

## Test plan
- [ ] 桌機週曆：拖卡片在同欄上下、寫 DB 後 reload 順序保留
- [ ] 拖到別欄：卡片落到目標日、scheduled_open_at 寫入該日
- [ ] 拖到空欄：useDroppable 接住、卡片落入
- [ ] 連拖多張：optimistic UI 不抖、最後 DB 結果正確
- [ ] 移出 按鈕仍可用

🤖 Generated with [Claude Code](https://claude.com/claude-code)