### PR TITLE
fix(oauth): resolve store code → numeric ID before binding lookup

### DIFF
--- a/supabase/functions/_shared/store-resolve.ts
+++ b/supabase/functions/_shared/store-resolve.ts
@@ -1,0 +1,50 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// store-resolve: 把使用者帶進來的 store key (可能是 code "S001" 或 numeric "1")
+// 解析成 canonical { id, code }。給 OAuth callback / LIFF session 在打 DB 前
+// 統一轉成數字 ID，避免 BIGINT 欄位收到 code 字串爆 PostgREST 400。
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function resolveStore(
+  supabaseUrl: string,
+  serviceKey: string,
+  tenantId: string,
+  storeKey: string,
+): Promise<{ id: number; code: string } | null> {
+  const trimmed = (storeKey ?? "").trim();
+  if (!trimmed) return null;
+
+  const authHeaders = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+  };
+
+  // 1) 先當 code 查（最常見：使用者用下拉或舊 URL `?store=S001`）
+  const byCodeUrl =
+    `${supabaseUrl}/rest/v1/stores` +
+    `?select=id,code` +
+    `&tenant_id=eq.${encodeURIComponent(tenantId)}` +
+    `&code=eq.${encodeURIComponent(trimmed)}` +
+    `&is_active=eq.true&limit=1`;
+  const byCodeResp = await fetch(byCodeUrl, { headers: authHeaders });
+  if (byCodeResp.ok) {
+    const rows = await byCodeResp.json() as Array<{ id: number; code: string }>;
+    if (rows.length > 0) return { id: rows[0].id, code: rows[0].code };
+  }
+
+  // 2) 純數字 → 改用 id 查（向後相容舊 URL `?store=1`）
+  if (/^\d+$/.test(trimmed)) {
+    const byIdUrl =
+      `${supabaseUrl}/rest/v1/stores` +
+      `?select=id,code` +
+      `&tenant_id=eq.${encodeURIComponent(tenantId)}` +
+      `&id=eq.${trimmed}` +
+      `&is_active=eq.true&limit=1`;
+    const byIdResp = await fetch(byIdUrl, { headers: authHeaders });
+    if (byIdResp.ok) {
+      const rows = await byIdResp.json() as Array<{ id: number; code: string }>;
+      if (rows.length > 0) return { id: rows[0].id, code: rows[0].code };
+    }
+  }
+
+  return null;
+}

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -487,9 +487,11 @@ async function generatePwaAuthCode(
   p: any,
 ) {
   const code6 = Math.floor(100000 + Math.random() * 900000).toString();
+  // session_data.store 是給前端顯示用,要回 code (e.g. "S001") 而非數字 ID
+  // claims.store_code 由 line-oauth-callback / liff-session 寫入
   const sessionData = {
     token: jwt,
-    store: String(claims.store_id ?? ""),
+    store: String(claims.store_code ?? claims.store_id ?? ""),
     member_id: memberId,
     line_user_id: String(claims.line_user_id ?? ""),
     line_name: typeof p.line_name === "string" ? p.line_name : null,

--- a/supabase/functions/liff-session/index.ts
+++ b/supabase/functions/liff-session/index.ts
@@ -18,6 +18,7 @@ import { corsHeaders } from "../_shared/cors.ts";
 import { signJwtHs256 } from "../_shared/jwt.ts";
 import { verifyIdToken } from "../_shared/line.ts";
 import { autoRegister } from "../_shared/auto-register.ts";
+import { resolveStore } from "../_shared/store-resolve.ts";
 
 const SESSION_TTL_SEC = 60 * 60 * 24 * 30; // 30 天
 
@@ -43,13 +44,19 @@ Deno.serve(async (req) => {
       channelId,
     });
     const lineUserId = payload.sub;
-    const storeId    = String(body.store);
+    const storeKey   = String(body.store);
+
+    // 1b) 解析 store key (code "S001" 或 numeric "1") → canonical { id, code }
+    const resolved = await resolveStore(supabaseUrl, serviceKey, tenantId, storeKey);
+    if (!resolved) return json({ error: "store_not_found", detail: storeKey }, 400);
+    const storeNumericId = resolved.id;
+    const storeCode = resolved.code;
 
     // 2) lookup binding
     const bindingUrl =
       `${supabaseUrl}/rest/v1/member_line_bindings` +
       `?select=member_id&tenant_id=eq.${tenantId}` +
-      `&store_id=eq.${storeId}&line_user_id=eq.${lineUserId}` +
+      `&store_id=eq.${storeNumericId}&line_user_id=eq.${lineUserId}` +
       `&unbound_at=is.null&limit=1`;
 
     const resp = await fetch(bindingUrl, {
@@ -65,7 +72,7 @@ Deno.serve(async (req) => {
         supabaseUrl,
         serviceKey,
         tenantId,
-        storeId,
+        storeId: String(storeNumericId),
         lineUserId,
         lineName:    payload.name    ?? null,
         linePicture: payload.picture ?? null,
@@ -80,7 +87,8 @@ Deno.serve(async (req) => {
       aud: "authenticated",
       exp: now + SESSION_TTL_SEC,
       tenant_id: tenantId,
-      store_id: storeId,
+      store_id: storeNumericId,
+      store_code: storeCode,
       line_user_id: lineUserId,
       sub: String(memberId),
       member_id: memberId,
@@ -89,7 +97,7 @@ Deno.serve(async (req) => {
     const sessionPayload = {
       token: jwt,
       member_id: memberId,
-      store: storeId,
+      store: storeCode,
       line_user_id: lineUserId,
       line_name:    payload.name    ?? null,
       line_picture: payload.picture ?? null,

--- a/supabase/functions/line-oauth-callback/index.ts
+++ b/supabase/functions/line-oauth-callback/index.ts
@@ -17,6 +17,7 @@ import { corsHeaders } from "../_shared/cors.ts";
 import { signJwtHs256, verifyStateToken } from "../_shared/jwt.ts";
 import { exchangeCode, verifyIdToken } from "../_shared/line.ts";
 import { autoRegister } from "../_shared/auto-register.ts";
+import { resolveStore } from "../_shared/store-resolve.ts";
 
 const SESSION_TTL_SEC = 60 * 60 * 24 * 30; // 30 天
 
@@ -72,7 +73,16 @@ Deno.serve(async (req) => {
     const tenantId      = requireEnv("DEFAULT_TENANT_ID"); // v1 單 tenant
 
     // 1) state
-    const { store_id: storeId, pair_code: pairCode } = await verifyStateToken(state, stateSecret);
+    const { store_id: storeKey, pair_code: pairCode } = await verifyStateToken(state, stateSecret);
+
+    // 1b) 解析 store key (code "S001" 或 numeric "1") → canonical { id, code }
+    //     下游 binding lookup / autoRegister / JWT 全部用數字 ID,前端 redirect 用 code
+    const resolved = await resolveStore(supabaseUrl, serviceKey, tenantId, storeKey);
+    if (!resolved) {
+      return redirectFront("/", { error: "oauth_failed", detail: "store_not_found" });
+    }
+    const storeNumericId = resolved.id;
+    const storeCode = resolved.code;
 
     // 2) code → token
     const tokens = await exchangeCode({
@@ -93,7 +103,7 @@ Deno.serve(async (req) => {
     const bindingUrl =
       `${supabaseUrl}/rest/v1/member_line_bindings` +
       `?select=member_id&tenant_id=eq.${tenantId}` +
-      `&store_id=eq.${storeId}&line_user_id=eq.${lineUserId}` +
+      `&store_id=eq.${storeNumericId}&line_user_id=eq.${lineUserId}` +
       `&unbound_at=is.null&limit=1`;
 
     const resp = await fetch(bindingUrl, {
@@ -117,7 +127,7 @@ Deno.serve(async (req) => {
         supabaseUrl,
         serviceKey,
         tenantId,
-        storeId,
+        storeId: String(storeNumericId),
         lineUserId,
         lineName: payload.name ?? null,
         linePicture: payload.picture ?? null,
@@ -133,7 +143,8 @@ Deno.serve(async (req) => {
         aud: "authenticated",
         exp: now + SESSION_TTL_SEC,
         tenant_id: tenantId,
-        store_id: storeId,
+        store_id: storeNumericId,
+        store_code: storeCode,
         line_user_id: lineUserId,
         sub: String(memberId),
         member_id: memberId,
@@ -145,7 +156,7 @@ Deno.serve(async (req) => {
     const code6 = Math.floor(100000 + Math.random() * 900000).toString();
     const sessionData = {
       token: jwt,
-      store: storeId,
+      store: storeCode,
       member_id: memberId,
       line_user_id: lineUserId,
       line_name: payload.name ?? null,
@@ -188,7 +199,7 @@ Deno.serve(async (req) => {
     const params = new URLSearchParams({
       code: code6,
       bound: "1",
-      store: storeId,
+      store: storeCode,
     });
     if (pairCode) params.set("paired", "1");
     return redirectFrontWithFragment(


### PR DESCRIPTION
## Summary

修使用者選擇門市後走 LINE OAuth 登入會看到 `發生錯誤：oauth_failed` 的問題。

**Root cause（既有 bug、被 #4228fe8 下拉選單放大）：**
- `member_line_bindings.store_id` schema 是 `BIGINT REFERENCES stores(id)`
- 但 LIFF / OAuth flow 一直把使用者輸入 / 下拉選的 store **code**（"S001"）原樣傳到 PostgREST `?store_id=eq.S001` → 對 bigint 欄位回 400 → catch → `oauth_failed`
- 之前 text input 時代沒這麼明顯（測試用 `?store=1` 還能過），下拉只給 code 後使用者必中

**Fix:**
- 新增 `_shared/store-resolve.ts`：把 `"S001"` / `"1"` 統一解析成 canonical `{ id, code }`
- `line-oauth-callback` 和 `liff-session` 在 entry point 解析後，下游 binding lookup / autoRegister / JWT 全用數字 ID
- JWT 多帶 `store_code` 給前端顯示用
- `liff-api` `generate_pwa_auth_code` 走 `claims.store_code` fallback，避免 session_data.store 變成 "1"
- 前端、URL bookmark 通通不變

## Test plan

已驗：
- [x] 3 個 edge functions deploy 上 erp-dev 沒 import 錯
- [x] `list_stores` 回傳 S001=1, S002=2 ... S005=5 正常（dropdown 來源沒迴歸）
- [x] OAuth callback 對 bogus state 優雅 redirect `?error=oauth_failed&detail=invalid+jwt+format`，沒 500

待驗（要 LINE 帳號）：
- [ ] iPhone 無痕 → https://new-erp-admin.vercel.app → 下拉選 S001 → 用 LINE 註冊/登入 → 預期跳到 /me 或 /shop，不再看到 `oauth_failed`
- [ ] PWA standalone：加到主畫面 → 下拉 S001 → 用 LINE 登入 → LIFF 登完回桌面自動 claim
- [ ] 6 位數驗證碼 fallback
- [ ] LIFF SDK 流（從 LINE 點 `?store=S001`）→ 自動跳 /me 不破

🤖 Generated with [Claude Code](https://claude.com/claude-code)