### PR TITLE
feat: 訂單刪除/負數單 + 收貨推播 + 候選週曆同步 + sidebar 重組

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
@@ -16,7 +16,7 @@ type Channel = { id: number; name: string; home_store_id: number };
 
 type Store = { id: number; code: string; name: string };
 
-type Mode = "customer" | "internal";
+type Mode = "customer" | "internal" | "offset";
 
 type MemberRow = {
   id: number;
@@ -110,6 +110,9 @@ function PageContent() {
   const [internalStoreId, setInternalStoreId] = useState<number | null>(null);
   const [internalNotes, setInternalNotes] = useState("");
   const [internalItems, setInternalItems] = useState<ItemRow[]>([emptyItem()]);
+  const [offsetStoreId, setOffsetStoreId] = useState<number | null>(null);
+  const [offsetReason, setOffsetReason] = useState("");
+  const [offsetItems, setOffsetItems] = useState<ItemRow[]>([emptyItem()]);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
@@ -256,6 +259,33 @@ function PageContent() {
     });
   }
 
+  // ---- offset mode helpers ----
+  function updateOffsetItem(idx: number, patch: Partial<ItemRow>) {
+    setOffsetItems((items) => items.map((it, i) => (i === idx ? { ...it, ...patch } : it)));
+  }
+  function addOffsetItemRow() {
+    setOffsetItems((items) => [...items, emptyItem()]);
+  }
+  function removeOffsetItem(idx: number) {
+    setOffsetItems((items) => {
+      const next = items.filter((_, i) => i !== idx);
+      return next.length ? next : [emptyItem()];
+    });
+  }
+  function addOffsetSku(opt: SkuOption) {
+    setOffsetItems((items) => {
+      if (items.some((it) => it.campaign_item_id === opt.campaign_item_id)) return items;
+      const newRow: ItemRow = {
+        campaign_item_id: opt.campaign_item_id,
+        sku_label: `${opt.product_name}${opt.variant_name ? ` / ${opt.variant_name}` : ""} (${opt.sku_code})`,
+        qty: "1",
+        unit_price: Number(opt.unit_price),
+      };
+      const cleaned = items.filter((it) => it.campaign_item_id || it.qty);
+      return [...cleaned, newRow];
+    });
+  }
+
   // 全域快速鍵：Alt+N 加新顧客 / 加新項目、Ctrl+S 送出
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -263,6 +293,8 @@ function PageContent() {
         e.preventDefault();
         if (mode === "internal") {
           setInternalItems((items) => [...items, emptyItem()]);
+        } else if (mode === "offset") {
+          setOffsetItems((items) => [...items, emptyItem()]);
         } else {
           setEntries((es) => [...es, newEntry()]);
         }
@@ -275,13 +307,17 @@ function PageContent() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entries, channelId, mode, internalStoreId, internalItems, internalNotes]);
+  }, [entries, channelId, mode, internalStoreId, internalItems, internalNotes, offsetStoreId, offsetItems, offsetReason]);
 
   async function handleSubmit() {
     if (submitting) return;
     setError(null);
     if (mode === "internal") {
       await submitInternal();
+      return;
+    }
+    if (mode === "offset") {
+      await submitOffset();
       return;
     }
     if (!channelId) { setError("請選 LINE 頻道"); return; }
@@ -313,6 +349,42 @@ function PageContent() {
       setToast(`已建立/更新 ${created.length} 筆訂單`);
       setEntries([newEntry()]);
       localStorage.removeItem(draftKey);
+      setTimeout(() => setToast(null), 3000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function submitOffset() {
+    if (!offsetStoreId) { setError("請選取貨店"); return; }
+    if (!offsetReason.trim()) { setError("抵減原因必填"); return; }
+    const items = offsetItems
+      .filter((i) => i.campaign_item_id && Number(i.qty) > 0)
+      .map((i) => ({
+        campaign_item_id: i.campaign_item_id,
+        qty: -Math.abs(Number(i.qty)), // 自動轉為負
+      }));
+    if (items.length === 0) { setError("請至少加一項商品"); return; }
+
+    setSubmitting(true);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes.user?.id;
+      if (!operator) { setError("未登入或 session 過期"); return; }
+      const { data, error: err } = await sb.rpc("rpc_create_offset_order", {
+        p_campaign_id: campaignId,
+        p_store_id: offsetStoreId,
+        p_items: items,
+        p_reason: offsetReason.trim(),
+        p_operator: operator,
+      });
+      if (err) { setError(err.message); return; }
+      setToast(`已建立抵減單 #${data}`);
+      setOffsetItems([emptyItem()]);
+      setOffsetReason("");
       setTimeout(() => setToast(null), 3000);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -407,6 +479,18 @@ function PageContent() {
         >
           為分店叫貨
         </button>
+        <button
+          type="button"
+          onClick={() => setMode("offset")}
+          className={`px-3 py-1.5 border-l border-zinc-300 dark:border-zinc-700 ${
+            mode === "offset"
+              ? "bg-red-700 text-white"
+              : "bg-white text-red-700 hover:bg-red-50 dark:bg-zinc-900 dark:text-red-400 dark:hover:bg-red-950"
+          }`}
+          title="店內已有庫存、不想多訂 → 採購聚合會自動扣掉這筆數量"
+        >
+          庫存抵減單
+        </button>
       </div>
 
       {mode === "customer" ? (
@@ -416,9 +500,13 @@ function PageContent() {
           </span>
           　·　取貨店：依顧客的「預設取貨店」自動帶出（會員資料設定）
         </p>
-      ) : (
+      ) : mode === "internal" ? (
         <p className="text-xs text-zinc-500">
           內部叫貨：客戶自動掛 <span className="font-medium text-zinc-700 dark:text-zinc-300">store_internal</span> 內部會員、訂單編號 <span className="font-mono">XXX-INT0001</span>。可改 unit_price（88 折出清）。
+        </p>
+      ) : (
+        <p className="text-xs text-red-700 dark:text-red-400">
+          庫存抵減單：店內已有庫存不想多訂時建立。qty 會自動轉為負，採購聚合自動扣掉這筆。訂單編號 <span className="font-mono">XXX-OFF0001</span>，不影響顧客視角。
         </p>
       )}
 
@@ -481,7 +569,7 @@ function PageContent() {
 
           <SummaryPanel entries={entries} />
         </div>
-      ) : (
+      ) : mode === "internal" ? (
         <InternalOrderPanel
           campaignId={campaignId}
           campaignSkus={campaignSkus}
@@ -498,6 +586,24 @@ function PageContent() {
           onSubmit={handleSubmit}
           submitting={submitting}
         />
+      ) : (
+        <InternalOrderPanel
+          campaignId={campaignId}
+          campaignSkus={campaignSkus}
+          stores={stores}
+          storeId={offsetStoreId}
+          onStoreChange={setOffsetStoreId}
+          notes={offsetReason}
+          onNotesChange={setOffsetReason}
+          items={offsetItems}
+          onItemChange={updateOffsetItem}
+          onAddItem={addOffsetItemRow}
+          onRemoveItem={removeOffsetItem}
+          onAddSku={addOffsetSku}
+          onSubmit={handleSubmit}
+          submitting={submitting}
+          offsetMode
+        />
       )}
     </div>
   );
@@ -509,7 +615,7 @@ function PageContent() {
 function InternalOrderPanel({
   campaignId, campaignSkus, stores, storeId, onStoreChange,
   notes, onNotesChange, items, onItemChange, onAddItem, onRemoveItem, onAddSku,
-  onSubmit, submitting,
+  onSubmit, submitting, offsetMode = false,
 }: {
   campaignId: number;
   campaignSkus: SkuOption[];
@@ -525,6 +631,7 @@ function InternalOrderPanel({
   onAddSku: (opt: SkuOption) => void;
   onSubmit: () => void;
   submitting: boolean;
+  offsetMode?: boolean;
 }) {
   const pickedIds = new Set(items.map((it) => it.campaign_item_id).filter((x): x is number => x != null));
   const availableSkus = campaignSkus.filter((s) => !pickedIds.has(s.campaign_item_id));
@@ -552,11 +659,13 @@ function InternalOrderPanel({
               </select>
             </label>
             <label className="text-xs">
-              <span className="mb-1 block text-zinc-500">備註（選填）</span>
+              <span className="mb-1 block text-zinc-500">
+                {offsetMode ? <>抵減原因 <span className="text-red-500">*</span></> : "備註（選填）"}
+              </span>
               <input
                 value={notes}
                 onChange={(e) => onNotesChange(e.target.value)}
-                placeholder="預設【店長內部叫貨】"
+                placeholder={offsetMode ? "例：店內已有 3 個現貨" : "預設【店長內部叫貨】"}
                 className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
               />
             </label>
@@ -623,19 +732,28 @@ function InternalOrderPanel({
             type="button"
             onClick={onSubmit}
             disabled={submitting}
-            className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            className={`rounded-md px-4 py-2 text-sm font-medium text-white disabled:opacity-50 ${
+              offsetMode
+                ? "bg-red-700 hover:bg-red-800"
+                : "bg-zinc-900 hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            }`}
           >
-            {submitting ? "送出中…" : "送出內部訂單（Ctrl+S）"}
+            {submitting ? "送出中…" : offsetMode ? "送出抵減單（Ctrl+S）" : "送出內部訂單（Ctrl+S）"}
           </button>
         </div>
       </div>
 
       <aside className="sticky top-4 h-fit rounded-md border border-zinc-200 bg-white p-3 text-sm dark:border-zinc-800 dark:bg-zinc-900">
-        <h2 className="mb-2 text-sm font-semibold">本次統計（內部）</h2>
+        <h2 className="mb-2 text-sm font-semibold">{offsetMode ? "本次抵減（負數）" : "本次統計（內部）"}</h2>
         <div className="grid grid-cols-2 gap-2 text-xs">
           <Stat label="件數" value={totalQty} />
-          <Stat label="總金額" value={`$${totalAmount}`} />
+          <Stat label="總金額" value={offsetMode ? `-$${totalAmount}` : `$${totalAmount}`} />
         </div>
+        {offsetMode && (
+          <p className="mt-2 text-[11px] text-red-700 dark:text-red-400">
+            ⚠ 送出時 qty 自動轉為負，採購聚合會扣掉這部分。
+          </p>
+        )}
       </aside>
     </div>
   );

--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -70,6 +70,7 @@ export default function CampaignsListPage() {
   const [page, setPage] = useState(1);
 
   const [itemCounts, setItemCounts] = useState<Map<number, number>>(new Map());
+  const [listOrderCounts, setListOrderCounts] = useState<Map<number, { normalQty: number; offsetQty: number }>>(new Map());
   const [modal, setModal] = useState<{ mode: "edit"; values: CampaignFormValues } | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
   const [closingId, setClosingId] = useState<number | null>(null);
@@ -91,6 +92,7 @@ export default function CampaignsListPage() {
   const [calRows, setCalRows] = useState<CalRow[] | null>(null);
   const [calItemCounts, setCalItemCounts] = useState<Map<number, number>>(new Map());
   const [calOrderCounts, setCalOrderCounts] = useState<Map<number, number>>(new Map());
+  const [calOffsetCounts, setCalOffsetCounts] = useState<Map<number, number>>(new Map());
   const [monthAnchor, setMonthAnchor] = useState<Date>(() => startOfDay(new Date()));
 
   async function closeCampaign(id: number, name: string) {
@@ -182,15 +184,37 @@ export default function CampaignsListPage() {
         setRows((data ?? []) as Row[]);
         setTotal(count ?? 0);
 
-        // 補商品數
+        // 補商品數 + 下單總數量（normal / offset 分開、SUM(qty)）
         const ids = (data ?? []).map((r) => r.id);
         if (ids.length) {
-          const { data: items } = await getSupabase()
-            .from("campaign_items").select("campaign_id").in("campaign_id", ids);
+          const sb = getSupabase();
+          const [itemRes, orderRes] = await Promise.all([
+            sb.from("campaign_items").select("campaign_id").in("campaign_id", ids),
+            sb.from("customer_orders").select("id, campaign_id, order_kind").in("campaign_id", ids),
+          ]);
           const m = new Map<number, number>();
           for (const id of ids) m.set(id, 0);
-          for (const it of items ?? []) m.set(it.campaign_id, (m.get(it.campaign_id) ?? 0) + 1);
+          for (const it of itemRes.data ?? []) m.set(it.campaign_id, (m.get(it.campaign_id) ?? 0) + 1);
           if (!cancelled) setItemCounts(m);
+
+          // 抓 items qty 並依 order_kind 聚合到 campaign
+          const ordersList = (orderRes.data ?? []) as { id: number; campaign_id: number; order_kind: string }[];
+          const orderIds = ordersList.map((o) => o.id);
+          const oqRes = orderIds.length
+            ? await sb.from("customer_order_items").select("order_id, qty").in("order_id", orderIds)
+            : { data: [] as { order_id: number; qty: number }[] };
+          const orderMeta = new Map(ordersList.map((o) => [o.id, o]));
+          const om = new Map<number, { normalQty: number; offsetQty: number }>();
+          for (const id of ids) om.set(id, { normalQty: 0, offsetQty: 0 });
+          for (const it of (oqRes.data ?? []) as { order_id: number; qty: number }[]) {
+            const meta = orderMeta.get(it.order_id);
+            if (!meta) continue;
+            const cur = om.get(meta.campaign_id) ?? { normalQty: 0, offsetQty: 0 };
+            if (meta.order_kind === "offset") cur.offsetQty += Number(it.qty);
+            else cur.normalQty += Number(it.qty);
+            om.set(meta.campaign_id, cur);
+          }
+          if (!cancelled) setListOrderCounts(om);
         }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
@@ -218,35 +242,55 @@ export default function CampaignsListPage() {
       }
       const { data, error } = await getSupabase()
         .from("group_buy_campaigns")
-        .select("id, campaign_no, name, status, start_at")
+        .select("id, campaign_no, name, status, start_at, display_order")
         .gte("start_at", from.toISOString())
         .lt("start_at", to.toISOString())
-        .order("start_at", { ascending: true });
+        .order("start_at", { ascending: true })
+        .order("display_order", { ascending: true });
       if (cancelled) return;
       if (error) { setError(error.message); return; }
       setError(null);
       const list = (data ?? []) as CalRow[];
       setCalRows(list);
 
-      // 補商品數 + 訂單數
+      // 補商品數 + 下單總數量（normal / offset 分開計、SUM(qty)）
       const ids = list.map((r) => r.id);
       if (ids.length > 0) {
         const sb = getSupabase();
         const [itemRes, orderRes] = await Promise.all([
           sb.from("campaign_items").select("campaign_id").in("campaign_id", ids),
-          sb.from("customer_orders").select("campaign_id").in("campaign_id", ids),
+          sb.from("customer_orders").select("id, campaign_id, order_kind").in("campaign_id", ids),
         ]);
         if (cancelled) return;
         const im = new Map<number, number>();
         const om = new Map<number, number>();
-        for (const id of ids) { im.set(id, 0); om.set(id, 0); }
+        const offm = new Map<number, number>();
+        for (const id of ids) { im.set(id, 0); om.set(id, 0); offm.set(id, 0); }
         for (const it of itemRes.data ?? []) im.set(it.campaign_id, (im.get(it.campaign_id) ?? 0) + 1);
-        for (const o of orderRes.data ?? []) om.set(o.campaign_id, (om.get(o.campaign_id) ?? 0) + 1);
+
+        const ordersList = (orderRes.data ?? []) as { id: number; campaign_id: number; order_kind: string }[];
+        const orderIds = ordersList.map((o) => o.id);
+        const oqRes = orderIds.length
+          ? await sb.from("customer_order_items").select("order_id, qty").in("order_id", orderIds)
+          : { data: [] as { order_id: number; qty: number }[] };
+        if (cancelled) return;
+        const orderMeta = new Map(ordersList.map((o) => [o.id, o]));
+        for (const it of (oqRes.data ?? []) as { order_id: number; qty: number }[]) {
+          const meta = orderMeta.get(it.order_id);
+          if (!meta) continue;
+          if (meta.order_kind === "offset") {
+            offm.set(meta.campaign_id, (offm.get(meta.campaign_id) ?? 0) + Number(it.qty));
+          } else {
+            om.set(meta.campaign_id, (om.get(meta.campaign_id) ?? 0) + Number(it.qty));
+          }
+        }
         setCalItemCounts(im);
         setCalOrderCounts(om);
+        setCalOffsetCounts(offm);
       } else {
         setCalItemCounts(new Map());
         setCalOrderCounts(new Map());
+        setCalOffsetCounts(new Map());
       }
     })();
     return () => { cancelled = true; };
@@ -347,6 +391,7 @@ export default function CampaignsListPage() {
           monthAnchor={monthAnchor}
           itemCounts={calItemCounts}
           orderCounts={calOrderCounts}
+          offsetCounts={calOffsetCounts}
           onPick={(id) => openEdit(id)}
         />
       )}
@@ -356,14 +401,14 @@ export default function CampaignsListPage() {
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr>
-              <Th>團號</Th><Th>名稱</Th><Th>狀態</Th><Th>開團/收單</Th><Th>取貨截止</Th><Th className="text-right">商品數</Th><Th className="text-right">更新</Th><Th>{""}</Th>
+              <Th>團號</Th><Th>名稱</Th><Th>狀態</Th><Th>開團/收單</Th><Th>取貨截止</Th><Th className="text-right">商品數</Th><Th className="text-right">下單總數</Th><Th className="text-right">更新</Th><Th>{""}</Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={8} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={9} className="p-3 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={8} className="p-6 text-center text-zinc-500">{total === 0 && !query && !status ? "還沒有開團，按「新增開團」開始。" : "沒有符合條件的開團。"}</td></tr>
+              <tr><td colSpan={9} className="p-6 text-center text-zinc-500">{total === 0 && !query && !status ? "還沒有開團，按「新增開團」開始。" : "沒有符合條件的開團。"}</td></tr>
             ) : rows.map((r) => (
               <tr key={r.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
                 <Td className="font-mono">
@@ -378,6 +423,31 @@ export default function CampaignsListPage() {
                 </Td>
                 <Td className="text-xs">{r.pickup_deadline ?? "—"}</Td>
                 <Td className="text-right font-mono">{itemCounts.get(r.id) ?? 0}</Td>
+                <Td className="text-right">
+                  {(() => {
+                    const oc = listOrderCounts.get(r.id) ?? { normalQty: 0, offsetQty: 0 };
+                    const totalQty = oc.normalQty + oc.offsetQty;
+                    if (oc.normalQty === 0 && oc.offsetQty === 0) {
+                      return <span className="font-mono text-zinc-400">0</span>;
+                    }
+                    return (
+                      <Link
+                        href={`/orders?campaignId=${r.id}`}
+                        className="inline-flex items-center gap-1 rounded font-mono hover:bg-zinc-100 px-1 dark:hover:bg-zinc-800"
+                        title={`點擊查看此開團的訂單\n正常下單總量：${oc.normalQty} 件${oc.offsetQty !== 0 ? `\n抵減量：${oc.offsetQty} 件\n淨需求：${totalQty} 件` : ""}`}
+                      >
+                        <span className="text-blue-700 hover:underline dark:text-blue-400">
+                          {oc.normalQty}
+                        </span>
+                        {oc.offsetQty !== 0 && (
+                          <span className="rounded bg-red-100 px-1 text-[11px] text-red-800 dark:bg-red-950 dark:text-red-300">
+                            {oc.offsetQty}
+                          </span>
+                        )}
+                      </Link>
+                    );
+                  })()}
+                </Td>
                 <Td className="text-right text-xs text-zinc-500">{new Date(r.updated_at).toLocaleString("zh-TW")}</Td>
                 <Td>
                   <div className="flex gap-2">
@@ -501,6 +571,7 @@ function CalendarView({
   monthAnchor,
   itemCounts,
   orderCounts,
+  offsetCounts,
   onPick,
 }: {
   view: View;
@@ -508,6 +579,7 @@ function CalendarView({
   monthAnchor: Date;
   itemCounts: Map<number, number>;
   orderCounts: Map<number, number>;
+  offsetCounts: Map<number, number>;
   onPick: (id: number) => void;
 }) {
   if (rows === null) {
@@ -576,6 +648,7 @@ function CalendarView({
                     r={r}
                     itemCount={itemCounts.get(r.id) ?? 0}
                     orderCount={orderCounts.get(r.id) ?? 0}
+                    offsetCount={offsetCounts.get(r.id) ?? 0}
                     onPick={onPick}
                   />
                 ))}
@@ -639,6 +712,7 @@ function CalendarView({
                     compact
                     itemCount={itemCounts.get(r.id) ?? 0}
                     orderCount={orderCounts.get(r.id) ?? 0}
+                    offsetCount={offsetCounts.get(r.id) ?? 0}
                     onPick={onPick}
                   />
                 ))}
@@ -946,12 +1020,14 @@ function CampaignCard({
   compact,
   itemCount,
   orderCount,
+  offsetCount,
   onPick,
 }: {
   r: CalRow;
   compact?: boolean;
   itemCount: number;
   orderCount: number;
+  offsetCount: number;
   onPick: (id: number) => void;
 }) {
   const statusBadgeColor: Record<Status, string> = {
@@ -980,7 +1056,7 @@ function CampaignCard({
       <button
         onClick={() => onPick(r.id)}
         className={`block w-full truncate rounded px-1.5 py-0.5 text-left text-[10px] ${compactBg[r.status]} hover:opacity-80`}
-        title={`${r.campaign_no}｜${r.name}｜${STATUS_LABEL[r.status]}｜${itemCount} 商品｜${orderCount} 單`}
+        title={`${r.campaign_no}｜${r.name}｜${STATUS_LABEL[r.status]}｜${itemCount} 商品｜下單 ${orderCount} 件${offsetCount !== 0 ? `｜抵減 ${offsetCount} 件` : ""}`}
       >
         <span className="font-medium">{r.name || r.campaign_no}</span>
       </button>
@@ -1011,14 +1087,33 @@ function CampaignCard({
         {r.campaign_no}
       </button>
 
-      {/* 數據：商品數 / 訂單數 */}
-      <div className="mb-2 flex gap-2 text-[11px]">
+      {/* 數據：商品數 / 下單總量 / 抵減總量 */}
+      <div className="mb-2 flex flex-wrap gap-2 text-[11px]">
         <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
           📦 {itemCount} 商品
         </span>
-        <span className={`rounded px-1.5 py-0.5 ${orderCount > 0 ? "bg-blue-100 font-medium text-blue-800 dark:bg-blue-950 dark:text-blue-300" : "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400"}`}>
-          🛒 {orderCount} 單
-        </span>
+        {orderCount !== 0 || offsetCount !== 0 ? (
+          <Link
+            href={`/orders?campaignId=${r.id}`}
+            className={`rounded px-1.5 py-0.5 transition ${orderCount > 0 ? "bg-blue-100 font-medium text-blue-800 hover:bg-blue-200 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900" : "bg-zinc-100 text-zinc-500 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400"}`}
+            title={`點擊查看訂單｜下單總量：${orderCount} 件${offsetCount !== 0 ? `｜抵減量：${offsetCount} 件｜淨需求：${orderCount + offsetCount} 件` : ""}`}
+          >
+            🛒 {orderCount} 件
+          </Link>
+        ) : (
+          <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+            🛒 0 件
+          </span>
+        )}
+        {offsetCount !== 0 && (
+          <Link
+            href={`/orders?campaignId=${r.id}`}
+            className="rounded bg-red-100 px-1.5 py-0.5 font-medium text-red-800 hover:bg-red-200 dark:bg-red-950 dark:text-red-300 dark:hover:bg-red-900"
+            title={`庫存抵減 ${offsetCount} 件（採購聚合會扣掉這部分）`}
+          >
+            {offsetCount} 抵
+          </Link>
+        )}
       </div>
 
       {/* 動作 */}

--- a/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
+++ b/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
@@ -5,11 +5,14 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import {
   DndContext,
+  pointerWithin,
+  rectIntersection,
   closestCorners,
   PointerSensor,
   useSensor,
   useSensors,
   useDroppable,
+  type CollisionDetection,
   type DragEndEvent,
   type DragOverEvent,
   type DragStartEvent,
@@ -161,6 +164,16 @@ export default function CommunityCandidatesCalendarPage() {
     return null;
   }
 
+  // 自訂 collision detection：優先 pointerWithin（指標真的進入 column 才命中），
+  // 沒命中再退回 rectIntersection / closestCorners。這樣空 column 也能被命中。
+  const collisionDetection: CollisionDetection = useCallback((args) => {
+    const pointerCollisions = pointerWithin(args);
+    if (pointerCollisions.length > 0) return pointerCollisions;
+    const rectCollisions = rectIntersection(args);
+    if (rectCollisions.length > 0) return rectCollisions;
+    return closestCorners(args);
+  }, []);
+
   const onDragStart = (e: DragStartEvent) => {
     const id = Number(e.active.id);
     for (const cards of Object.values(localByDate)) {
@@ -244,16 +257,30 @@ export default function CommunityCandidatesCalendarPage() {
   async function persistDay(dayKey: string, items: CalendarCandidate[]) {
     const sb = getSupabase();
     const now = new Date().toISOString();
+    const { data: userRes } = await sb.auth.getUser();
+    const operator = userRes?.user?.id ?? null;
     for (let i = 0; i < items.length; i++) {
+      const order = i + 1;
       const { error: err } = await sb
         .from("community_product_candidates")
         .update({
           scheduled_open_at: dayKey,
-          scheduled_sort_order: i + 1,
+          scheduled_sort_order: order,
           updated_at: now,
         })
         .eq("id", items[i].id);
       if (err) throw new Error(err.message);
+
+      // 同步更新對應 campaign（透過 RPC 繞過 RLS — admin 客戶端 JWT role claim 可能為 null）
+      if (operator) {
+        const { error: rpcErr } = await sb.rpc("rpc_reorder_candidate_campaign", {
+          p_candidate_id: items[i].id,
+          p_day_key: dayKey,
+          p_order: order,
+          p_operator: operator,
+        });
+        if (rpcErr) console.warn("campaign reorder failed:", rpcErr.message);
+      }
     }
   }
 
@@ -285,7 +312,7 @@ export default function CommunityCandidatesCalendarPage() {
       ) : (
         <DndContext
           sensors={sensors}
-          collisionDetection={closestCorners}
+          collisionDetection={collisionDetection}
           onDragStart={onDragStart}
           onDragOver={onDragOver}
           onDragEnd={onDragEnd}
@@ -348,8 +375,8 @@ function DayColumn({
   return (
     <div
       ref={setNodeRef}
-      className={`flex min-w-[120px] flex-col gap-2 rounded-md p-1 transition ${
-        isOver && cards.length === 0
+      className={`flex min-h-[200px] min-w-[120px] flex-col gap-2 rounded-md p-1 transition ${
+        isOver
           ? "bg-amber-50 ring-2 ring-amber-300 dark:bg-amber-950/30 dark:ring-amber-700"
           : ""
       }`}

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState, type ReactNode } from "react";
 import { useAuth } from "@/components/AuthProvider";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { getTenantName } from "@/lib/tenant";
 
 type NavItem = { href: string; label: string; match: RegExp };
 type NavGroup = { title?: string; items: NavItem[] };
@@ -18,35 +19,45 @@ const NAV: NavGroup[] = [
   {
     title: "核心業務",
     items: [
-      { href: "/orders", label: "訂單", match: /^\/orders/ },
-      { href: "/pickup", label: "取貨", match: /^\/pickup/ },
       { href: "/campaigns", label: "開團", match: /^\/campaigns/ },
       { href: "/products", label: "商品", match: /^\/products/ },
+      { href: "/suppliers", label: "供應商", match: /^\/suppliers/ },
+    ],
+  },
+  {
+    title: "分店業務",
+    items: [
+      { href: "/orders", label: "訂單", match: /^\/orders/ },
+      { href: "/pickup", label: "取貨", match: /^\/pickup/ },
       { href: "/members", label: "會員", match: /^\/members/ },
+      { href: "/inventory/mutual-aid", label: "互助交流板", match: /^\/inventory\/mutual-aid/ },
+      { href: "/transfers/aid", label: "互助轉移單（總倉檢視）", match: /^\/transfers\/aid/ },
+      { href: "/transfers/free", label: "自由轉貨", match: /^\/transfers\/free/ },
     ],
   },
   {
     title: "進銷存",
     items: [
-      { href: "/suppliers", label: "供應商", match: /^\/suppliers/ },
       { href: "/purchase/requests", label: "採購單", match: /^\/purchase\/requests/ },
       { href: "/purchase/orders", label: "採購訂單", match: /^\/purchase\/orders/ },
       { href: "/restock", label: "補貨申請", match: /^\/restock(?!\/inbox)/ },
       { href: "/restock/inbox", label: "補貨申請 (HQ)", match: /^\/restock\/inbox/ },
+    ],
+  },
+  {
+    title: "倉儲",
+    items: [
       { href: "/picking/workstation", label: "撿貨工作站", match: /^\/picking\/workstation/ },
       { href: "/picking/history", label: "撿貨歷史", match: /^\/picking\/history/ },
       { href: "/transfers/dispatch", label: "總倉派貨", match: /^\/transfers\/dispatch|^\/transfers$|^\/transfers\/?$/ },
       { href: "/transfers/inbox", label: "收貨待辦", match: /^\/transfers\/inbox/ },
-      { href: "/transfers/free", label: "自由轉貨", match: /^\/transfers\/free/ },
-      { href: "/inventory/mutual-aid", label: "互助交流板", match: /^\/inventory\/mutual-aid/ },
-      { href: "/transfers/aid", label: "互助轉移單", match: /^\/transfers\/aid/ },
-      { href: "/transfers/settlement", label: "月結算", match: /^\/transfers\/settlement/ },
     ],
   },
   {
     title: "財務",
     items: [
       { href: "/finance/receivables", label: "HQ 應收", match: /^\/finance\/receivables(?!\/print)/ },
+      { href: "/transfers/settlement", label: "月結算", match: /^\/transfers\/settlement/ },
     ],
   },
   {
@@ -58,11 +69,35 @@ const NAV: NavGroup[] = [
   },
 ];
 
+const NAV_COLLAPSE_KEY = "new_erp-nav-collapsed";
+
 export default function ProtectedLayout({ children }: { children: ReactNode }) {
   const { session, loading, user, signOut } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const tenantName = getTenantName();
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  // 載入 collapsed groups (localStorage)
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(NAV_COLLAPSE_KEY);
+      if (raw) setCollapsed(new Set(JSON.parse(raw) as string[]));
+    } catch { /* noop */ }
+  }, []);
+
+  function toggleGroup(title: string) {
+    setCollapsed((cur) => {
+      const next = new Set(cur);
+      if (next.has(title)) next.delete(title);
+      else next.add(title);
+      try {
+        localStorage.setItem(NAV_COLLAPSE_KEY, JSON.stringify(Array.from(next)));
+      } catch { /* noop */ }
+      return next;
+    });
+  }
 
   useEffect(() => {
     if (loading) return;
@@ -110,8 +145,8 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
       <aside className="hidden w-52 shrink-0 flex-col border-r border-zinc-200 bg-zinc-50 md:flex print:hidden dark:border-zinc-800 dark:bg-zinc-950">
         <div className="border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">
           <Link href="/" className="block">
-            <div className="text-lg font-semibold tracking-tight">new_erp</div>
-            <div className="text-xs text-zinc-500">團購店管理</div>
+            <div className="text-lg font-semibold tracking-tight">{tenantName}</div>
+            <div className="text-xs text-zinc-500">管理頁面</div>
           </Link>
           <div className="mt-2 inline-flex items-center gap-1 rounded-full border border-zinc-300 bg-white px-2 py-0.5 text-[10px] text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
             <span className="h-1.5 w-1.5 rounded-full bg-amber-400" /> 開發版
@@ -119,35 +154,46 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
         </div>
 
         <nav className="flex-1 overflow-y-auto px-2 py-3 text-sm">
-          {NAV.map((g, gi) => (
-            <div key={gi} className="mb-4">
-              {g.title && (
-                <div className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-                  {g.title}
-                </div>
-              )}
-              <ul className="space-y-0.5">
-                {g.items.map((it) => {
-                  const active = it.match.test(pathname || "");
-                  return (
-                    <li key={it.href}>
-                      <Link
-                        href={it.href}
-                        className={
-                          active
-                            ? "flex items-center justify-between rounded-md bg-zinc-900 px-3 py-2 text-white dark:bg-zinc-100 dark:text-zinc-900"
-                            : "flex items-center justify-between rounded-md px-3 py-2 text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900"
-                        }
-                      >
-                        <span>{it.label}</span>
-                        {active && <span className="text-xs opacity-60">›</span>}
-                      </Link>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          ))}
+          {NAV.map((g, gi) => {
+            const groupHasActive = g.items.some((it) => it.match.test(pathname || ""));
+            const isCollapsed = g.title ? collapsed.has(g.title) && !groupHasActive : false;
+            return (
+              <div key={gi} className="mb-4">
+                {g.title && (
+                  <button
+                    type="button"
+                    onClick={() => toggleGroup(g.title!)}
+                    className="flex w-full items-center justify-between rounded px-2 pb-1.5 pt-0.5 text-xs font-semibold tracking-wider text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+                  >
+                    <span>{g.title}</span>
+                    <span className="text-xs opacity-60">{isCollapsed ? "▸" : "▾"}</span>
+                  </button>
+                )}
+                {!isCollapsed && (
+                  <ul className="space-y-0.5">
+                    {g.items.map((it) => {
+                      const active = it.match.test(pathname || "");
+                      return (
+                        <li key={it.href}>
+                          <Link
+                            href={it.href}
+                            className={
+                              active
+                                ? "flex items-center justify-between rounded-md bg-zinc-900 px-3 py-2 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                                : "flex items-center justify-between rounded-md px-3 py-2 text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900"
+                            }
+                          >
+                            <span>{it.label}</span>
+                            {active && <span className="text-xs opacity-60">›</span>}
+                          </Link>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
         </nav>
 
         <div className="border-t border-zinc-200 p-3 text-xs dark:border-zinc-800">
@@ -181,7 +227,7 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
                 <line x1="3" y1="18" x2="21" y2="18" />
               </svg>
             </button>
-            <Link href="/" className="font-semibold">new_erp</Link>
+            <Link href="/" className="font-semibold">{tenantName}</Link>
           </div>
           <div className="flex items-center gap-2 text-sm">
             <ThemeToggle />
@@ -200,8 +246,8 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
           <aside className="absolute left-0 top-0 flex h-full w-72 max-w-[85vw] flex-col border-r border-zinc-200 bg-zinc-50 shadow-xl dark:border-zinc-800 dark:bg-zinc-950">
             <div className="flex items-start justify-between border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">
               <Link href="/" onClick={() => setDrawerOpen(false)} className="block">
-                <div className="text-lg font-semibold tracking-tight">new_erp</div>
-                <div className="text-xs text-zinc-500">團購店管理</div>
+                <div className="text-lg font-semibold tracking-tight">{tenantName}</div>
+                <div className="text-xs text-zinc-500">管理頁面</div>
               </Link>
               <button
                 onClick={() => setDrawerOpen(false)}
@@ -213,36 +259,47 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
             </div>
 
             <nav className="flex-1 overflow-y-auto px-2 py-3 text-sm">
-              {NAV.map((g, gi) => (
-                <div key={gi} className="mb-4">
-                  {g.title && (
-                    <div className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-                      {g.title}
-                    </div>
-                  )}
-                  <ul className="space-y-0.5">
-                    {g.items.map((it) => {
-                      const active = it.match.test(pathname || "");
-                      return (
-                        <li key={it.href}>
-                          <Link
-                            href={it.href}
-                            onClick={() => setDrawerOpen(false)}
-                            className={
-                              active
-                                ? "flex items-center justify-between rounded-md bg-zinc-900 px-3 py-2 text-white dark:bg-zinc-100 dark:text-zinc-900"
-                                : "flex items-center justify-between rounded-md px-3 py-2 text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900"
-                            }
-                          >
-                            <span>{it.label}</span>
-                            {active && <span className="text-xs opacity-60">›</span>}
-                          </Link>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </div>
-              ))}
+              {NAV.map((g, gi) => {
+                const groupHasActive = g.items.some((it) => it.match.test(pathname || ""));
+                const isCollapsed = g.title ? collapsed.has(g.title) && !groupHasActive : false;
+                return (
+                  <div key={gi} className="mb-4">
+                    {g.title && (
+                      <button
+                        type="button"
+                        onClick={() => toggleGroup(g.title!)}
+                        className="flex w-full items-center justify-between rounded px-2 pb-1.5 pt-0.5 text-xs font-semibold tracking-wider text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+                      >
+                        <span>{g.title}</span>
+                        <span className="text-xs opacity-60">{isCollapsed ? "▸" : "▾"}</span>
+                      </button>
+                    )}
+                    {!isCollapsed && (
+                      <ul className="space-y-0.5">
+                        {g.items.map((it) => {
+                          const active = it.match.test(pathname || "");
+                          return (
+                            <li key={it.href}>
+                              <Link
+                                href={it.href}
+                                onClick={() => setDrawerOpen(false)}
+                                className={
+                                  active
+                                    ? "flex items-center justify-between rounded-md bg-zinc-900 px-3 py-2 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                                    : "flex items-center justify-between rounded-md px-3 py-2 text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900"
+                                }
+                              >
+                                <span>{it.label}</span>
+                                {active && <span className="text-xs opacity-60">›</span>}
+                              </Link>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </div>
+                );
+              })}
             </nav>
 
             <div className="border-t border-zinc-200 p-3 text-xs dark:border-zinc-800">

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
 import { PickupDialog } from "@/components/PickupDialog";
+import { translateRpcError } from "@/lib/rpcError";
 
 type OrderStatus =
   | "pending" | "confirmed" | "reserved" | "shipping" | "ready" | "partially_ready"
@@ -20,12 +22,13 @@ type Row = {
   pickup_store_id: number;
   pickup_deadline: string | null;
   status: OrderStatus;
+  created_at: string;
   updated_at: string;
 };
 
-type Campaign = { id: number; campaign_no: string; name: string };
+type Campaign = { id: number; campaign_no: string; name: string; cover_image_url: string | null };
 type Store = { id: number; code: string; name: string };
-type Member = { id: number; name: string | null; phone: string | null; member_no: string };
+type Member = { id: number; name: string | null; phone: string | null; member_no: string; avatar_url: string | null };
 
 const STATUS_LABEL: Record<OrderStatus, string> = {
   pending: "待確認", confirmed: "已確認", reserved: "已保留", shipping: "派貨中",
@@ -37,21 +40,41 @@ const STATUS_LABEL: Record<OrderStatus, string> = {
 const PAGE_SIZE = 50;
 
 export default function OrdersListPage() {
+  return (
+    <Suspense fallback={<div className="p-6 text-sm text-zinc-500">載入中…</div>}>
+      <OrdersListContent />
+    </Suspense>
+  );
+}
+
+function OrdersListContent() {
+  const searchParams = useSearchParams();
+  // 支援單個 campaignId（舊）+ campaignIds 多個逗號分隔（新）
+  const initialCampaignIds = ((): string[] => {
+    const multi = searchParams.get("campaignIds");
+    if (multi) return multi.split(",").map((s) => s.trim()).filter(Boolean);
+    const single = searchParams.get("campaignId");
+    return single ? [single] : [];
+  })();
+  const initialStatus = searchParams.get("status") ?? "";
+  const initialStoreId = searchParams.get("storeId") ?? "";
+
   const [rows, setRows] = useState<Row[] | null>(null);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const [campaignId, setCampaignId] = useState("");
-  const [status, setStatus] = useState("");
-  const [storeId, setStoreId] = useState("");
+  const [campaignIds, setCampaignIds] = useState<string[]>(initialCampaignIds);
+  const [status, setStatus] = useState(initialStatus);
+  const [storeId, setStoreId] = useState(initialStoreId);
   const [page, setPage] = useState(1);
+  const [campaignPickerOpen, setCampaignPickerOpen] = useState(false);
 
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [stores, setStores] = useState<Store[]>([]);
   const [members, setMembers] = useState<Map<number, Member>>(new Map());
   const [itemSummary, setItemSummary] = useState<
-    Map<number, { lineCount: number; totalQty: number; totalAmount: number }>
+    Map<number, { lineCount: number; totalQty: number; totalAmount: number; items: { name: string; qty: number }[] }>
   >(new Map());
   const [pickupReady, setPickupReady] = useState<Map<number, boolean>>(new Map());
   const [detailId, setDetailId] = useState<number | null>(null);
@@ -59,13 +82,13 @@ export default function OrdersListPage() {
   const [pickup, setPickup] = useState<{ id: number; no: string } | null>(null);
   const [reloadOrders, setReloadOrders] = useState(0);
 
-  useEffect(() => { setPage(1); }, [campaignId, status, storeId]);
+  useEffect(() => { setPage(1); }, [campaignIds, status, storeId]);
 
   useEffect(() => {
     (async () => {
       const sb = getSupabase();
       const [c, s] = await Promise.all([
-        sb.from("group_buy_campaigns").select("id, campaign_no, name").order("updated_at", { ascending: false }).limit(200),
+        sb.from("group_buy_campaigns").select("id, campaign_no, name, cover_image_url").order("updated_at", { ascending: false }).limit(200),
         sb.from("stores").select("id, code, name").order("name"),
       ]);
       setCampaigns((c.data as Campaign[]) ?? []);
@@ -80,11 +103,12 @@ export default function OrdersListPage() {
       try {
         let q = getSupabase()
           .from("customer_orders")
-          .select("id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, updated_at", { count: "exact" })
+          .select("id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, created_at, updated_at", { count: "exact" })
           .order("updated_at", { ascending: false })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 
-        if (campaignId) q = q.eq("campaign_id", Number(campaignId));
+        if (campaignIds.length === 1) q = q.eq("campaign_id", Number(campaignIds[0]));
+        else if (campaignIds.length > 1) q = q.in("campaign_id", campaignIds.map((x) => Number(x)));
         if (status) q = q.eq("status", status);
         else q = q.neq("status", "transferred_out"); // 預設隱藏已轉出（5a-1：視同關閉、金額/數量不入統計）
         if (storeId) q = q.eq("pickup_store_id", Number(storeId));
@@ -100,22 +124,26 @@ export default function OrdersListPage() {
         const memIds = Array.from(new Set((data ?? []).map((r) => r.member_id).filter((x): x is number => x != null)));
         const [ic, ms, pr] = await Promise.all([
           ids.length
-            ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price").in("order_id", ids)
-            : Promise.resolve({ data: [] as { order_id: number; qty: number; unit_price: number }[] }),
+            ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price, sku:skus(product_name, variant_name)").in("order_id", ids)
+            : Promise.resolve({ data: [] as { order_id: number; qty: number; unit_price: number; sku: { product_name: string | null; variant_name: string | null } | null }[] }),
           memIds.length
-            ? getSupabase().from("members").select("id, name, phone, member_no").in("id", memIds)
+            ? getSupabase().from("members").select("id, name, phone, member_no, avatar_url").in("id", memIds)
             : Promise.resolve({ data: [] as Member[] }),
           ids.length
             ? getSupabase().from("v_order_pickup_ready").select("order_id, pickup_ready").in("order_id", ids)
             : Promise.resolve({ data: [] as { order_id: number; pickup_ready: boolean }[] }),
         ]);
-        const im = new Map<number, { lineCount: number; totalQty: number; totalAmount: number }>();
-        for (const id of ids) im.set(id, { lineCount: 0, totalQty: 0, totalAmount: 0 });
-        for (const it of (ic.data as { order_id: number; qty: number; unit_price: number }[]) ?? []) {
-          const cur = im.get(it.order_id) ?? { lineCount: 0, totalQty: 0, totalAmount: 0 };
+        const im = new Map<number, { lineCount: number; totalQty: number; totalAmount: number; items: { name: string; qty: number }[] }>();
+        for (const id of ids) im.set(id, { lineCount: 0, totalQty: 0, totalAmount: 0, items: [] });
+        for (const it of (ic.data as { order_id: number; qty: number; unit_price: number; sku: { product_name: string | null; variant_name: string | null } | null }[]) ?? []) {
+          const cur = im.get(it.order_id) ?? { lineCount: 0, totalQty: 0, totalAmount: 0, items: [] };
           cur.lineCount += 1;
           cur.totalQty += Number(it.qty);
           cur.totalAmount += Number(it.qty) * Number(it.unit_price);
+          const skuName = it.sku
+            ? `${it.sku.product_name ?? ""}${it.sku.variant_name ? ` / ${it.sku.variant_name}` : ""}`.trim() || "—"
+            : "—";
+          cur.items.push({ name: skuName, qty: Number(it.qty) });
           im.set(it.order_id, cur);
         }
         const mm = new Map<number, Member>();
@@ -132,10 +160,31 @@ export default function OrdersListPage() {
       }
     })();
     return () => { cancelled = true; };
-  }, [campaignId, status, storeId, page, reloadOrders]);
+  }, [campaignIds, status, storeId, page, reloadOrders]);
 
   const campaignMap = useMemo(() => new Map(campaigns.map((c) => [c.id, c])), [campaigns]);
   const storeMap = useMemo(() => new Map(stores.map((s) => [s.id, s])), [stores]);
+
+  async function cancelOrder(orderId: number, orderNo: string, status: string) {
+    const reason = prompt(
+      status === "shipping"
+        ? `撤回派貨：${orderNo}\n會反向回收已出庫存，請輸入原因：`
+        : `取消訂單：${orderNo}\n請輸入取消原因：`
+    );
+    if (reason === null) return;
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id ?? null;
+    if (!operator) { alert("尚未登入"); return; }
+    const { error: rpcErr } = await sb.rpc("rpc_cancel_aid_order", {
+      p_order_id: orderId,
+      p_reason: reason,
+      p_operator: operator,
+    });
+    if (rpcErr) { alert(`取消失敗：${translateRpcError(rpcErr)}`); return; }
+    alert("已取消");
+    setReloadOrders((n) => n + 1);
+  }
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const fromIdx = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
   const toIdx = Math.min(page * PAGE_SIZE, total);
@@ -152,11 +201,62 @@ export default function OrdersListPage() {
       </header>
 
       <div className="grid gap-3 sm:grid-cols-3">
-        <select value={campaignId} onChange={(e) => setCampaignId(e.target.value)}
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
-          <option value="">全部開團</option>
-          {campaigns.map((c) => <option key={c.id} value={c.id}>{c.campaign_no} {c.name}</option>)}
-        </select>
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setCampaignPickerOpen((v) => !v)}
+            className="flex w-full items-center justify-between rounded-md border border-zinc-300 bg-white px-3 py-2 text-left text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <span className="truncate">
+              {campaignIds.length === 0
+                ? "全部開團"
+                : campaignIds.length === 1
+                ? campaigns.find((c) => String(c.id) === campaignIds[0])?.name ?? `團 ${campaignIds[0]}`
+                : `已選 ${campaignIds.length} 個開團`}
+            </span>
+            <span className="ml-2 text-zinc-400">▾</span>
+          </button>
+          {campaignPickerOpen && (
+            <div className="absolute z-20 mt-1 max-h-80 w-full overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+              <div className="sticky top-0 flex justify-between border-b border-zinc-200 bg-white px-3 py-2 text-xs dark:border-zinc-800 dark:bg-zinc-900">
+                <button
+                  onClick={() => setCampaignIds([])}
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  全部清除
+                </button>
+                <button
+                  onClick={() => setCampaignPickerOpen(false)}
+                  className="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400"
+                >
+                  關閉
+                </button>
+              </div>
+              {campaigns.map((c) => {
+                const checked = campaignIds.includes(String(c.id));
+                return (
+                  <label
+                    key={c.id}
+                    className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:hover:bg-zinc-950"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => {
+                        const id = String(c.id);
+                        setCampaignIds((cur) =>
+                          e.target.checked ? [...cur, id] : cur.filter((x) => x !== id),
+                        );
+                      }}
+                    />
+                    <span className="font-mono text-xs text-zinc-500">{c.campaign_no}</span>
+                    <span className="truncate">{c.name}</span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+        </div>
         <select value={status} onChange={(e) => setStatus(e.target.value)}
           className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
           <option value="">全部狀態</option>
@@ -179,62 +279,143 @@ export default function OrdersListPage() {
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr>
-              <Th>訂單號</Th><Th>開團</Th><Th>會員 / 暱稱</Th><Th>取貨店</Th><Th>取貨截止</Th><Th>狀態</Th><Th className="text-right">項數</Th><Th className="text-right">總數量</Th><Th className="text-right">總金額</Th><Th className="text-right">更新</Th><Th className="text-right">操作</Th>
+              <Th>開團</Th><Th>會員 / 暱稱</Th><Th>取貨店</Th><Th className="text-right">項數</Th><Th className="text-right">總數量</Th><Th className="text-right">總金額</Th><Th className="text-right">日期</Th><Th className="text-right">操作</Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={11} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={8} className="p-3 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={11} className="p-6 text-center text-zinc-500">{total === 0 && !campaignId && !status && !storeId ? "尚無訂單。" : "沒有符合條件的訂單。"}</td></tr>
+              <tr><td colSpan={8} className="p-6 text-center text-zinc-500">{total === 0 && campaignIds.length === 0 && !status && !storeId ? "尚無訂單。" : "沒有符合條件的訂單。"}</td></tr>
             ) : rows.map((r) => {
               const m = r.member_id ? members.get(r.member_id) : null;
               const c = campaignMap.get(r.campaign_id);
               const s = storeMap.get(r.pickup_store_id);
               return (
-                <tr key={r.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
-                  <Td className="font-mono">
+                <tr
+                  key={r.id}
+                  className={
+                    r.status === "cancelled"
+                      ? "bg-red-50 hover:bg-red-100 dark:bg-red-950/30 dark:hover:bg-red-950/50"
+                      : r.status === "expired"
+                      ? "bg-amber-50 hover:bg-amber-100 dark:bg-amber-950/30 dark:hover:bg-amber-950/50"
+                      : r.status === "transferred_out"
+                      ? "bg-zinc-100 text-zinc-500 hover:bg-zinc-200 dark:bg-zinc-900 dark:text-zinc-500 dark:hover:bg-zinc-800"
+                      : "odd:bg-white even:bg-zinc-50 hover:bg-zinc-100 dark:odd:bg-zinc-950 dark:even:bg-zinc-900 dark:hover:bg-zinc-800"
+                  }
+                >
+                  <Td>
                     <button
                       onClick={() => { setDetailId(r.id); setDetailNo(r.order_no); }}
-                      className="hover:underline"
+                      className="block w-full text-left hover:underline"
+                      title={r.order_no}
                     >
-                      {r.order_no}
+                      {c ? (
+                        <div className="flex items-start gap-2">
+                          <CoverThumb src={c.cover_image_url} alt={c.name} />
+                          <div className="min-w-0 flex-1 space-y-0.5">
+                            <div className="text-xs text-zinc-500 break-words">{c.name}</div>
+                            {(itemSummary.get(r.id)?.items ?? []).map((it, idx) => (
+                              <div key={idx} className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 break-words">
+                                {it.name}
+                                <span className="ml-1 text-xs font-normal text-zinc-500">× {it.qty}</span>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      ) : "—"}
                     </button>
                   </Td>
-                  <Td>{c ? <span className="text-xs text-zinc-600 dark:text-zinc-400"><span className="font-mono">{c.campaign_no}</span> {c.name}</span> : "—"}</Td>
                   <Td>
                     {m ? (
-                      <span>
-                        <Link href={`/members/detail?id=${m.id}`} className="hover:underline">{m.name ?? "—"}</Link>
-                        <span className="ml-1 font-mono text-xs text-zinc-500">{m.phone}</span>
+                      <span className="flex items-center gap-2">
+                        <Avatar src={m.avatar_url} name={m.name ?? r.nickname_snapshot ?? "?"} />
+                        <span className="min-w-0">
+                          <Link href={`/members/detail?id=${m.id}`} className="hover:underline">{m.name ?? "—"}</Link>
+                          <span className="ml-1 font-mono text-xs text-zinc-500">{m.phone}</span>
+                        </span>
                       </span>
                     ) : r.nickname_snapshot ? (
-                      <span className="text-zinc-500">({r.nickname_snapshot})</span>
+                      <span className="flex items-center gap-2">
+                        <Avatar src={null} name={r.nickname_snapshot} />
+                        <span className="text-zinc-500">({r.nickname_snapshot})</span>
+                      </span>
                     ) : "—"}
                   </Td>
                   <Td className="text-xs">{s?.name ?? "—"}</Td>
-                  <Td className="text-xs">{r.pickup_deadline ?? "—"}</Td>
-                  <Td><StatusBadge s={r.status} /></Td>
                   <Td className="text-right font-mono">{itemSummary.get(r.id)?.lineCount ?? 0}</Td>
                   <Td className="text-right font-mono">{itemSummary.get(r.id)?.totalQty ?? 0}</Td>
                   <Td className="text-right font-mono">${itemSummary.get(r.id)?.totalAmount ?? 0}</Td>
-                  <Td className="text-right text-xs text-zinc-500">{new Date(r.updated_at).toLocaleString("zh-TW")}</Td>
+                  <Td
+                    className="text-right text-xs text-zinc-500"
+                    title={`訂單日：${new Date(r.created_at).toLocaleString("zh-TW", { hour12: false })}\n更新日：${new Date(r.updated_at).toLocaleString("zh-TW", { hour12: false })}`}
+                  >
+                    <div>訂 {new Date(r.created_at).toLocaleDateString("zh-TW", { month: "numeric", day: "numeric" })}</div>
+                    <div>更 {new Date(r.updated_at).toLocaleDateString("zh-TW", { month: "numeric", day: "numeric" })}</div>
+                  </Td>
                   <Td className="text-right">
-                    {!["completed","expired","cancelled","transferred_out"].includes(r.status) && (() => {
-                      // 取貨判斷改用 v_order_pickup_ready (基於分店收貨 transfer 實際狀態)
-                      // 不再依賴 customer_orders.status === 'ready'（status 同步可能漏推）
-                      const canPickup = pickupReady.get(r.id) === true;
-                      return (
+                    <div className="flex items-center justify-end gap-1">
+                      {!["completed","expired","cancelled","transferred_out"].includes(r.status) && (() => {
+                        // 取貨判斷改用 v_order_pickup_ready (基於分店收貨 transfer 實際狀態)
+                        // 不再依賴 customer_orders.status === 'ready'（status 同步可能漏推）
+                        const canPickup = pickupReady.get(r.id) === true;
+                        return (
+                          <button
+                            onClick={() => setPickup({ id: r.id, no: r.order_no })}
+                            disabled={!canPickup}
+                            title={canPickup ? undefined : "分店尚未收貨，無法取貨"}
+                            className="rounded-md bg-emerald-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-200 disabled:text-emerald-700 disabled:hover:bg-emerald-200 dark:disabled:bg-emerald-950 dark:disabled:text-emerald-400 dark:disabled:hover:bg-emerald-950"
+                          >
+                            ✅ 取貨
+                          </button>
+                        );
+                      })()}
+                      {["pending", "confirmed", "shipping"].includes(r.status) && (
                         <button
-                          onClick={() => setPickup({ id: r.id, no: r.order_no })}
-                          disabled={!canPickup}
-                          title={canPickup ? undefined : "分店尚未收貨，無法取貨"}
-                          className="rounded-md bg-emerald-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-zinc-200 disabled:text-zinc-400 disabled:hover:bg-zinc-200 dark:disabled:bg-zinc-800 dark:disabled:text-zinc-600 dark:disabled:hover:bg-zinc-800"
+                          onClick={() => cancelOrder(r.id, r.order_no, r.status)}
+                          title={r.status === "shipping" ? "撤回派貨並反向回收已出庫存" : "取消訂單"}
+                          className="rounded-md bg-red-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-red-700"
                         >
-                          ✅ 取貨
+                          取消
                         </button>
-                      );
-                    })()}
+                      )}
+                      {r.status === "cancelled" && (
+                        <button
+                          disabled
+                          title="此訂單已取消"
+                          className="rounded-md bg-red-200 px-2 py-1 text-[11px] font-medium text-red-700 cursor-not-allowed dark:bg-red-950 dark:text-red-300"
+                        >
+                          已取消
+                        </button>
+                      )}
+                      {r.status === "expired" && (
+                        <button
+                          disabled
+                          title="此訂單已逾期"
+                          className="rounded-md bg-amber-200 px-2 py-1 text-[11px] font-medium text-amber-800 cursor-not-allowed dark:bg-amber-950 dark:text-amber-300"
+                        >
+                          已逾期
+                        </button>
+                      )}
+                      {r.status === "completed" && (
+                        <button
+                          disabled
+                          title="此訂單已完成"
+                          className="rounded-md bg-emerald-200 px-2 py-1 text-[11px] font-medium text-emerald-800 cursor-not-allowed dark:bg-emerald-950 dark:text-emerald-300"
+                        >
+                          已完成
+                        </button>
+                      )}
+                      {r.status === "transferred_out" && (
+                        <button
+                          disabled
+                          title="此訂單已轉出"
+                          className="rounded-md bg-zinc-300 px-2 py-1 text-[11px] font-medium text-zinc-700 cursor-not-allowed dark:bg-zinc-700 dark:text-zinc-300"
+                        >
+                          已轉出
+                        </button>
+                      )}
+                    </div>
                   </Td>
                 </tr>
               );
@@ -295,6 +476,55 @@ function Td({ children, className = "" }: { children: React.ReactNode; className
 }
 function PagerBtn({ onClick, disabled, children }: { onClick: () => void; disabled?: boolean; children: React.ReactNode }) {
   return <button onClick={onClick} disabled={disabled} className="rounded-md border border-zinc-300 px-2 py-1 transition-colors hover:bg-zinc-100 disabled:opacity-40 disabled:hover:bg-transparent dark:border-zinc-700 dark:hover:bg-zinc-800">{children}</button>;
+}
+function CoverThumb({ src, alt }: { src: string | null; alt: string }) {
+  if (!src) {
+    return (
+      <span
+        aria-hidden
+        className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded bg-zinc-100 text-xs text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500"
+      >
+        ▦
+      </span>
+    );
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      alt={alt}
+      className="h-10 w-10 flex-shrink-0 rounded object-cover"
+      onError={(e) => {
+        (e.currentTarget as HTMLImageElement).style.display = "none";
+      }}
+    />
+  );
+}
+function Avatar({ src, name }: { src: string | null; name: string }) {
+  const initial = name.trim().charAt(0) || "?";
+  if (!src) {
+    return (
+      <span
+        aria-hidden
+        className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-zinc-200 text-xs font-medium text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300"
+      >
+        {initial}
+      </span>
+    );
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      alt=""
+      referrerPolicy="no-referrer"
+      className="h-8 w-8 flex-shrink-0 rounded-full object-cover"
+      onError={(e) => {
+        const el = e.currentTarget as HTMLImageElement;
+        el.style.display = "none";
+      }}
+    />
+  );
 }
 function StatusBadge({ s }: { s: OrderStatus }) {
   const st: Record<OrderStatus, string> = {

--- a/apps/admin/src/app/(protected)/transfers/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/inbox/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import {
@@ -11,11 +12,16 @@ import {
 } from "@/components/TransferReceiveModal";
 
 type Location = { id: number; name: string };
+type StoreLite = { id: number; location_id: number | null };
+type ItemSummary = { lines: number; totalQty: number; names: string[] };
 
 export default function TransfersInboxPage() {
   const [transfers, setTransfers] = useState<Transfer[] | null>(null);
   const [locations, setLocations] = useState<Map<number, string>>(new Map());
   const [waves, setWaves] = useState<Map<number, Wave>>(new Map());
+  const [itemSummary, setItemSummary] = useState<Map<number, ItemSummary>>(new Map());
+  const [locationToStore, setLocationToStore] = useState<Map<number, number>>(new Map());
+  const [transferCampaigns, setTransferCampaigns] = useState<Map<number, number[]>>(new Map());
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
   const [opening, setOpening] = useState<Transfer | null>(null);
@@ -64,10 +70,70 @@ export default function TransfersInboxPage() {
           for (const w of (ws as Wave[] | null) ?? []) waveMap.set(w.id, w);
         }
 
+        // 抓 transfer_items + skus 用於顯示「商品/數量」
+        const summary = new Map<number, ItemSummary>();
+        if (rows.length > 0) {
+          const transferIds = rows.map((r) => r.id);
+          const { data: tiRows } = await sb
+            .from("transfer_items")
+            .select("transfer_id, sku_id, qty_shipped")
+            .in("transfer_id", transferIds);
+          const items = (tiRows ?? []) as { transfer_id: number; sku_id: number; qty_shipped: number }[];
+          const skuIds = Array.from(new Set(items.map((it) => it.sku_id)));
+          const skuNameMap = new Map<number, string>();
+          if (skuIds.length > 0) {
+            const { data: skuRows } = await sb
+              .from("skus")
+              .select("id, product_name, variant_name")
+              .in("id", skuIds);
+            for (const s of (skuRows ?? []) as { id: number; product_name: string | null; variant_name: string | null }[]) {
+              const label = `${s.product_name ?? ""}${s.variant_name ? ` / ${s.variant_name}` : ""}`.trim() || `#${s.id}`;
+              skuNameMap.set(s.id, label);
+            }
+          }
+          for (const tid of transferIds) summary.set(tid, { lines: 0, totalQty: 0, names: [] });
+          for (const it of items) {
+            const cur = summary.get(it.transfer_id) ?? { lines: 0, totalQty: 0, names: [] };
+            cur.lines += 1;
+            cur.totalQty += Number(it.qty_shipped);
+            cur.names.push(`${skuNameMap.get(it.sku_id) ?? `#${it.sku_id}`} × ${Number(it.qty_shipped)}`);
+            summary.set(it.transfer_id, cur);
+          }
+        }
+
+        // location → store mapping (for /orders link filter)
+        const locStoreMap = new Map<number, number>();
+        if (locIds.length > 0) {
+          const { data: storeRows } = await sb
+            .from("stores")
+            .select("id, location_id")
+            .in("location_id", locIds);
+          for (const s of (storeRows ?? []) as StoreLite[]) {
+            if (s.location_id) locStoreMap.set(s.location_id, s.id);
+          }
+        }
+
+        // 抓每張 transfer 涵蓋的 campaign_ids（用於 /orders link 多選 filter）
+        const tcMap = new Map<number, number[]>();
+        await Promise.allSettled(
+          rows.map(async (r) => {
+            const { data: cs } = await sb.rpc("rpc_get_campaigns_for_transfer", {
+              p_transfer_id: r.id,
+            });
+            const ids = ((cs as { campaign_id: number }[] | null) ?? [])
+              .map((x) => Number(x.campaign_id))
+              .filter((x) => Number.isFinite(x));
+            tcMap.set(r.id, ids);
+          }),
+        );
+
         if (!cancelled) {
           setTransfers(rows);
           setLocations(locMap);
           setWaves(waveMap);
+          setItemSummary(summary);
+          setLocationToStore(locStoreMap);
+          setTransferCampaigns(tcMap);
           setError(null);
           const auto = new Set<string>();
           for (const r of rows) {
@@ -228,6 +294,7 @@ export default function TransfersInboxPage() {
                         <Th>分店</Th>
                         <Th>單號</Th>
                         <Th>類型</Th>
+                        <Th>商品 / 數量</Th>
                         <Th>派出時間</Th>
                         <Th>狀態</Th>
                         <Th></Th>
@@ -236,6 +303,8 @@ export default function TransfersInboxPage() {
                     <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
                       {g.transfers.map((t) => {
                         const isShipped = t.status === "shipped";
+                        const summary = itemSummary.get(t.id);
+                        const storeId = locationToStore.get(t.dest_location);
                         return (
                           <tr key={t.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-950">
                             <td className="px-3 py-2 text-sm font-medium">
@@ -244,6 +313,38 @@ export default function TransfersInboxPage() {
                             <td className="px-3 py-2 font-mono text-xs">{t.transfer_no}</td>
                             <td className="px-3 py-2 text-xs text-zinc-600 dark:text-zinc-300">
                               {TRANSFER_TYPE_LABEL[t.transfer_type] ?? t.transfer_type}
+                            </td>
+                            <td className="px-3 py-2 text-xs">
+                              {summary && summary.lines > 0 ? (
+                                <div className="space-y-0.5" title={summary.names.join("\n")}>
+                                  <div className="flex gap-2 text-[11px] text-zinc-500">
+                                    <span>{summary.lines} 項</span>
+                                    <span>共 {summary.totalQty} 件</span>
+                                  </div>
+                                  <div className="text-zinc-700 dark:text-zinc-300 font-medium">
+                                    {summary.names.slice(0, 2).join("、")}
+                                    {summary.names.length > 2 && (
+                                      <span className="text-zinc-400">… +{summary.names.length - 2}</span>
+                                    )}
+                                  </div>
+                                  {storeId && (() => {
+                                    const cids = transferCampaigns.get(t.id) ?? [];
+                                    const qs = new URLSearchParams({ storeId: String(storeId) });
+                                    if (cids.length > 0) qs.set("campaignIds", cids.join(","));
+                                    return (
+                                      <Link
+                                        href={`/orders?${qs.toString()}`}
+                                        className="inline-block text-[11px] text-blue-600 hover:underline dark:text-blue-400"
+                                        title={cids.length > 0 ? `關聯 ${cids.length} 個開團` : undefined}
+                                      >
+                                        → 查看此店訂單{cids.length > 0 ? `（${cids.length} 團）` : ""}
+                                      </Link>
+                                    );
+                                  })()}
+                                </div>
+                              ) : (
+                                <span className="text-zinc-400">—</span>
+                              )}
                             </td>
                             <td className="px-3 py-2 text-xs text-zinc-600 dark:text-zinc-300">
                               {t.shipped_at

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { AuthProvider } from "@/components/AuthProvider";
 import { themeInitScript } from "@/lib/theme";
+import { getAdminTitle, getTenantName } from "@/lib/tenant";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -15,8 +16,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "new_erp admin",
-  description: "團購店 ERP admin console",
+  title: getAdminTitle(),
+  description: `${getTenantName()} 管理後台`,
 };
 
 export default function RootLayout({

--- a/apps/admin/src/app/login/page.tsx
+++ b/apps/admin/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState, useEffect, type FormEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/components/AuthProvider";
+import { getTenantName } from "@/lib/tenant";
 
 export default function LoginPage() {
   return (
@@ -52,7 +53,7 @@ function LoginForm() {
     <div className="flex flex-1 items-center justify-center bg-zinc-50 p-6 dark:bg-zinc-950">
       <div className="w-full max-w-sm space-y-6 rounded-lg border border-zinc-200 bg-white p-8 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
         <div className="space-y-1">
-          <h1 className="text-2xl font-semibold">登入 new_erp</h1>
+          <h1 className="text-2xl font-semibold">登入 {getTenantName()}管理頁面</h1>
           <p className="text-sm text-zinc-500">使用管理員帳號</p>
         </div>
 

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -6,6 +6,7 @@ import { OrderTransferModal } from "@/components/OrderTransferModal";
 import { PickupDialog } from "@/components/PickupDialog";
 import { AidOrderTimeline } from "@/components/AidOrderTimeline";
 import { withBasePath } from "@/lib/basePath";
+import { translateRpcError } from "@/lib/rpcError";
 
 type OrderHead = {
   id: number;
@@ -149,7 +150,30 @@ export function OrderDetail({
   const totalAmount = items.reduce((s, i) => s + Number(i.qty) * Number(i.unit_price), 0);
 
   const canTransfer = ["pending", "confirmed", "reserved"].includes(head.status);
+  const canCancel = ["pending", "confirmed", "shipping"].includes(head.status);
   const isTransferredOut = head.status === "transferred_out";
+
+  async function cancelOrder() {
+    if (!head) return;
+    const reason = prompt(
+      head.status === "shipping"
+        ? `撤回派貨：${head.order_no}\n會反向回收已出庫存，請輸入原因：`
+        : `取消訂單：${head.order_no}\n請輸入取消原因：`
+    );
+    if (reason === null) return;
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id ?? null;
+    if (!operator) { alert("尚未登入"); return; }
+    const { error: rpcErr } = await sb.rpc("rpc_cancel_aid_order", {
+      p_order_id: head.id,
+      p_reason: reason,
+      p_operator: operator,
+    });
+    if (rpcErr) { alert(`取消失敗：${translateRpcError(rpcErr)}`); return; }
+    alert("已取消");
+    setReloadTick((n) => n + 1);
+  }
   const pickableItems = items.filter((it) => ["pending", "reserved", "ready"].includes(it.status));
   // 取貨判斷改用 v_order_pickup_ready (基於分店收貨 transfer 實際狀態)
   // 不再依賴 customer_orders.status === 'ready'（status 同步可能漏推）
@@ -162,7 +186,7 @@ export function OrderDetail({
 
   return (
     <div className="space-y-4 text-sm">
-      {(canTransfer || canPickup || isTransferredOut) && (
+      {(canTransfer || canPickup || canCancel || isTransferredOut) && (
         <div className="flex items-center justify-end gap-2">
           {canPickup && (
             <button
@@ -182,6 +206,15 @@ export function OrderDetail({
               ↗ 轉出此訂單
             </button>
           )}
+          {canCancel && (
+            <button
+              onClick={cancelOrder}
+              className="rounded-md border border-red-300 px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950"
+              title={head.status === "shipping" ? "撤回派貨並反向回收已出庫存" : "取消訂單"}
+            >
+              ✕ 取消訂單
+            </button>
+          )}
           {isTransferredOut && (
             <span className="text-xs text-zinc-500">⚠️ 此訂單已轉出</span>
           )}
@@ -190,7 +223,26 @@ export function OrderDetail({
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <Field label="訂單號" value={<span className="font-mono">{head.order_no}</span>} />
-        <Field label="狀態" value={statusLabel(head.status)} />
+        <Field
+          label="狀態"
+          value={
+            <span
+              className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${
+                head.status === "cancelled"
+                  ? "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300"
+                  : head.status === "expired"
+                  ? "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                  : head.status === "transferred_out"
+                  ? "bg-zinc-300 text-zinc-700 line-through dark:bg-zinc-700 dark:text-zinc-300"
+                  : head.status === "completed"
+                  ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
+                  : "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300"
+              }`}
+            >
+              {statusLabel(head.status)}
+            </span>
+          }
+        />
         <Field label="取貨截止" value={head.pickup_deadline ?? "—"} />
         <Field
           label="會員"

--- a/apps/admin/src/components/TransferReceiveModal.tsx
+++ b/apps/admin/src/components/TransferReceiveModal.tsx
@@ -4,6 +4,53 @@ import { Fragment, useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
 
+async function fanoutPushNotifications(transferId: number): Promise<number> {
+  const sb = getSupabase();
+  const { data: rows, error } = await sb.rpc("rpc_get_members_to_notify_for_transfer", {
+    p_transfer_id: transferId,
+  });
+  if (error) {
+    console.warn("get members for push failed:", error.message);
+    return 0;
+  }
+  const list = (rows as { member_id: number; order_id: number; order_no: string }[] | null) ?? [];
+  if (list.length === 0) return 0;
+
+  // 去重：同一會員多張訂單只推一次
+  const memberIds = Array.from(new Set(list.map((r) => r.member_id)));
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!supabaseUrl) return 0;
+  const { data: sess } = await sb.auth.getSession();
+  const token = sess.session?.access_token;
+  if (!token) return 0;
+
+  let success = 0;
+  await Promise.allSettled(
+    memberIds.map(async (memberId) => {
+      try {
+        const resp = await fetch(`${supabaseUrl}/functions/v1/admin-notify`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            member_id: memberId,
+            title: "您的商品到貨",
+            message: "點此開啟訂單頁查看",
+            url: "/orders",
+          }),
+        });
+        if (resp.ok) success += 1;
+      } catch (e) {
+        console.warn(`push to member ${memberId} failed:`, e);
+      }
+    }),
+  );
+  return success;
+}
+
 export type Transfer = {
   id: number;
   transfer_no: string;
@@ -180,8 +227,16 @@ export function TransferReceiveModal({
         r && Number(r.total_variance) < 0
           ? `\n⚠ 短收 ${Math.abs(Number(r.total_variance))}`
           : "";
+
+      // Fire-and-forget：通知該店所有受影響的顧客「貨已到店」
+      // 失敗不影響收貨流程（push 失敗只是該會員拿不到推播）
+      const pushed = await fanoutPushNotifications(transfer.id).catch((err) => {
+        console.warn("push fanout error:", err);
+        return 0;
+      });
+      const pushNote = pushed > 0 ? `\n📩 已推播 ${pushed} 位顧客` : "";
       alert(
-        `收貨完成：${r?.items_received ?? 0} 行，實收合計 ${r?.total_qty_received ?? 0}${varNote}`,
+        `收貨完成：${r?.items_received ?? 0} 行，實收合計 ${r?.total_qty_received ?? 0}${varNote}${pushNote}`,
       );
       onSubmitted();
     } catch (e) {

--- a/apps/admin/src/lib/tenant.ts
+++ b/apps/admin/src/lib/tenant.ts
@@ -1,0 +1,13 @@
+// 集中管理 tenant 顯示名稱。
+// 目前 single-tenant，靠 NEXT_PUBLIC_TENANT_NAME env 切換；
+// 未來若要 multi-tenant，把 getTenantName() 改成 DB query 即可（呼叫端不用改）。
+
+const DEFAULT_TENANT_NAME = "包子媽生鮮小舖";
+
+export function getTenantName(): string {
+  return process.env.NEXT_PUBLIC_TENANT_NAME || DEFAULT_TENANT_NAME;
+}
+
+export function getAdminTitle(): string {
+  return `${getTenantName()}管理頁面`;
+}

--- a/apps/member/next-env.d.ts
+++ b/apps/member/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/member/src/app/auth/success/page.tsx
+++ b/apps/member/src/app/auth/success/page.tsx
@@ -6,6 +6,10 @@ import { consumeFragmentToSession } from "@/lib/session";
 export default function AuthSuccessPage() {
   const [code, setCode] = useState<string | null>(null);
   const [paired, setPaired] = useState(false);
+  const [profile, setProfile] = useState<{ name: string | null; picture: string | null }>({
+    name: null,
+    picture: null,
+  });
 
   useEffect(() => {
     // 從 hash 抓 code / paired 旗標 (line-oauth-callback 把全部塞進 fragment)
@@ -23,38 +27,49 @@ export default function AuthSuccessPage() {
     if (qc) setCode(qc);
     if (sp.get("paired") === "1") setPaired(true);
 
-    // 把 fragment 寫進 localStorage 並清 URL
-    consumeFragmentToSession();
+    // 把 fragment 寫進 localStorage 並清 URL；同時抓 LINE 個資顯示
+    const session = consumeFragmentToSession();
+    if (session) {
+      setProfile({ name: session.lineName, picture: session.linePicture });
+    }
   }, []);
 
   return (
     <main className="mx-auto flex w-full max-w-md flex-col items-center gap-8 p-6 pt-16 text-center">
-      <div className="flex h-20 w-20 items-center justify-center rounded-full bg-green-100">
-        <svg className="h-10 w-10 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-        </svg>
-      </div>
+      {profile.picture ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={profile.picture}
+          alt=""
+          className="h-20 w-20 rounded-full shadow-md"
+          referrerPolicy="no-referrer"
+        />
+      ) : (
+        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-green-100">
+          <svg className="h-10 w-10 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+      )}
 
       <div className="space-y-2">
-        <h1 className="text-2xl font-bold">LINE 驗證成功</h1>
+        <h1 className="text-2xl font-bold">{profile.name ?? "LINE 驗證成功"}</h1>
+        {profile.name && (
+          <p className="text-sm text-zinc-500">驗證成功</p>
+        )}
         {paired ? (
-          <p className="text-base text-zinc-600">
+          <p className="pt-2 text-base text-zinc-600">
             請關閉此視窗，回到桌面點擊 <span className="font-semibold">PWA App</span> 圖示
             <br />
             App 會自動完成登入
           </p>
         ) : (
-          <>
-            <p className="text-base text-zinc-500">
-              如果您是從桌面瀏覽器登入，請直接點擊下方按鈕：
-            </p>
-            <a
-              href="/shop"
-              className="inline-block rounded-md bg-[#06C755] px-6 py-2.5 text-base font-medium text-white shadow"
-            >
-              進入會員中心
-            </a>
-          </>
+          <a
+            href="/install"
+            className="mt-4 inline-block rounded-md bg-[#06C755] px-6 py-2.5 text-base font-medium text-white shadow hover:bg-[#05b04c] transition"
+          >
+            前往安裝步驟
+          </a>
         )}
       </div>
 

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -344,7 +344,7 @@ export default function LandingPage() {
             <div className="space-y-8">
               <div className="space-y-4">
                 <p className="text-base text-zinc-500">
-                  您目前位於 <span className="font-bold text-zinc-900 dark:text-zinc-100">{storeId}</span> 門市
+                  您目前位於 <span className="font-bold text-zinc-900 dark:text-zinc-100">{stores.find((s) => s.code === storeId)?.name ?? storeId}</span> 門市
                 </p>
                 <button
                   onClick={start}
@@ -359,37 +359,41 @@ export default function LandingPage() {
                 )}
               </div>
 
-              <div className="relative py-4">
-                <div className="absolute inset-0 flex items-center">
-                  <span className="w-full border-t border-zinc-200"></span>
-                </div>
-                <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-white px-2 text-zinc-400 dark:bg-zinc-950">或者</span>
-                </div>
-              </div>
+              {standalone && (
+                <>
+                  <div className="relative py-4">
+                    <div className="absolute inset-0 flex items-center">
+                      <span className="w-full border-t border-zinc-200"></span>
+                    </div>
+                    <div className="relative flex justify-center text-xs uppercase">
+                      <span className="bg-white px-2 text-zinc-400 dark:bg-zinc-950">或者</span>
+                    </div>
+                  </div>
 
-              <div className="space-y-4 rounded-xl border border-zinc-200 p-4 bg-zinc-50/50">
-                <p className="text-sm text-zinc-500">如果您已在瀏覽器登入，請輸入驗證碼：</p>
-                <form onSubmit={handleSyncSubmit} className="flex gap-2">
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    pattern="[0-9]*"
-                    maxLength={6}
-                    placeholder="6 位數驗證碼"
-                    value={syncCode}
-                    onChange={(e) => setSyncCode(e.target.value)}
-                    className="flex-1 rounded-md border border-zinc-300 px-3 py-2 text-center font-mono text-xl tracking-widest focus:border-indigo-500 focus:outline-none"
-                  />
-                  <button
-                    type="submit"
-                    disabled={syncCode.length !== 6 || syncing}
-                    className="rounded-md bg-indigo-600 px-4 py-2 text-base font-medium text-white shadow disabled:opacity-50"
-                  >
-                    {syncing ? "..." : "驗證"}
-                  </button>
-                </form>
-              </div>
+                  <div className="space-y-4 rounded-xl border border-zinc-200 p-4 bg-zinc-50/50">
+                    <p className="text-sm text-zinc-500">如果您已在瀏覽器登入，請輸入驗證碼：</p>
+                    <form onSubmit={handleSyncSubmit} className="flex gap-2">
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        maxLength={6}
+                        placeholder="6 位數驗證碼"
+                        value={syncCode}
+                        onChange={(e) => setSyncCode(e.target.value)}
+                        className="flex-1 rounded-md border border-zinc-300 px-3 py-2 text-center font-mono text-xl tracking-widest focus:border-indigo-500 focus:outline-none"
+                      />
+                      <button
+                        type="submit"
+                        disabled={syncCode.length !== 6 || syncing}
+                        className="rounded-md bg-indigo-600 px-4 py-2 text-base font-medium text-white shadow disabled:opacity-50"
+                      >
+                        {syncing ? "..." : "驗證"}
+                      </button>
+                    </form>
+                  </div>
+                </>
+              )}
 
               <button
                 onClick={() => { setStoreId(null); setInputStoreId(""); }}

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -12,6 +12,7 @@ export type OrderItem = {
   subtotal: number;
   status: string;
   notes: string | null;
+  image_url: string | null;
 };
 
 export type OrderRow = {
@@ -85,20 +86,29 @@ export default function OrderCard({ order }: { order: OrderRow }) {
       </header>
 
       <div className="flex flex-wrap gap-1.5 px-4 pb-3">
-        <StatusChip tone={order.arrived ? "ok" : "muted"} label={order.arrived ? "全到" : "未到"} />
-        <StatusChip tone={order.settled ? "ok" : "muted"} label={order.settled ? "全結" : "未結"} />
-        <StatusChip tone={order.paid ? "ok" : "muted"} label={order.paid ? "已付" : "未付"} />
-        <StatusChip tone={order.shipped ? "ok" : "muted"} label={order.shipped ? "已寄" : "未寄"} />
+        <StatusChip tone={order.arrived ? "ok" : "muted"} label={order.arrived ? "已到貨" : "未到貨"} />
       </div>
 
       <ul className="border-t border-[var(--separator)] px-4">
         {order.items.map((it, idx) => (
           <li
             key={it.id}
-            className={`flex items-start justify-between gap-2 py-3 ${
+            className={`flex items-start gap-3 py-3 ${
               idx > 0 ? "border-t border-[var(--separator)]" : ""
             }`}
           >
+            {it.image_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={it.image_url}
+                alt=""
+                className="h-12 w-12 flex-shrink-0 rounded-lg object-cover bg-[#7676801a]"
+              />
+            ) : (
+              <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg bg-[#7676801a] text-xl">
+                📦
+              </div>
+            )}
             <div className="min-w-0 flex-1">
               <div className="text-[16px] text-[var(--foreground)]">
                 {it.product_name ?? `SKU#${it.sku_id}`}

--- a/docs/TEST-訂單刪除與負數訂單.md
+++ b/docs/TEST-訂單刪除與負數訂單.md
@@ -1,0 +1,204 @@
+---
+title: TEST — 訂單軟刪除 + 負數訂單 + member 登入流程優化 + 訂單列表 cosmetics
+module: Orders / Member-app
+status: draft
+owner: alex.chen
+created: 2026-05-03
+---
+
+# 測試清單 — 訂單軟刪除 + 負數訂單 + member 登入優化
+
+**對應 plan:** `C:\Users\Alex\.claude\plans\buzzing-singing-stream.md`
+**對應 migration:**
+- `supabase/migrations/20260516000000_allow_negative_order_qty.sql`（新）
+- `supabase/migrations/20260516000001_rpc_create_offset_order.sql`（新）
+
+**對應 UI 變更：**
+- `apps/member/src/app/page.tsx`（A1 / A2）
+- `apps/member/src/app/auth/success/page.tsx`（A3）
+- `apps/admin/src/app/(protected)/orders/page.tsx`（B1 / B1b）
+- `apps/admin/src/components/OrderDetail.tsx`（B2）
+- `apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx`（C5）
+
+**復用 RPC：** `rpc_cancel_aid_order`、`rpc_get_or_create_store_member`、`list_stores` LIFF API
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 customer_order_items.qty 約束放寬
+- [ ] 舊 CHECK `qty > 0` 已 drop
+- [ ] 新 CHECK `qty <> 0` 存在
+- [ ] 嘗試 INSERT qty=0 → 拒絕；qty=-1 → 接受；qty=1 → 接受
+  ```sql
+  SELECT check_clause FROM information_schema.check_constraints
+  WHERE constraint_name = 'customer_order_items_qty_check';
+  ```
+
+### 1.2 customer_orders.order_kind 欄位
+- [ ] 欄位存在、TEXT NOT NULL DEFAULT 'normal'
+- [ ] CHECK constraint 限制 IN ('normal', 'offset')
+- [ ] COMMENT 說明已寫入
+- [ ] 既有 row 全部填入 'normal'（DEFAULT 生效）
+  ```sql
+  SELECT COUNT(*), order_kind FROM customer_orders GROUP BY order_kind;
+  -- 應全為 normal
+  ```
+
+### 1.3 Indexes
+- [ ] `idx_customer_orders_kind` on `(tenant_id, campaign_id, order_kind)`
+  ```sql
+  SELECT indexname, indexdef FROM pg_indexes WHERE indexname = 'idx_customer_orders_kind';
+  ```
+
+### 1.4 RPC signature
+- [ ] `rpc_create_offset_order(BIGINT, BIGINT, JSONB, TEXT, UUID) RETURNS BIGINT` 存在
+- [ ] `rpc_cancel_offset_order(BIGINT, TEXT, UUID) RETURNS VOID` 存在
+- [ ] 兩個 RPC 都 SECURITY DEFINER
+- [ ] GRANT EXECUTE TO authenticated（與專案慣例一致）
+  ```sql
+  SELECT proname, prosecdef, pg_get_function_arguments(oid)
+  FROM pg_proc WHERE proname IN ('rpc_create_offset_order', 'rpc_cancel_offset_order');
+  ```
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 rpc_create_offset_order — happy path
+**情境：** campaign A 已 open；store S 已存在；items=`[{campaign_item_id:5, qty:-3}]`、reason='店內現有 3 個'
+**預期：**
+- 回傳新 order_id
+- `customer_orders.order_kind='offset'`、`status='confirmed'`、`notes` 開頭 `[庫存抵減單]`
+- `member_id` 對應 store_internal member（rpc_get_or_create_store_member 結果）
+- `customer_order_items.qty = -3`
+- `created_by = updated_by = p_operator`
+
+### 2.2 rpc_create_offset_order — qty 正數被拒
+**情境：** items 內含 `qty: 2`
+**預期：** RAISE EXCEPTION '負數訂單所有品項 qty 必須 < 0'，無 row 寫入
+
+### 2.3 rpc_create_offset_order — qty=0 被拒
+**情境：** items=`[{campaign_item_id:5, qty:0}]`
+**預期：** 同樣 RAISE（>= 0 被擋）
+
+### 2.4 rpc_create_offset_order — store_internal member 復用
+**情境：** 同一 store 連續呼叫兩次
+**預期：** 兩次 order 的 member_id 一致；members 表只多一筆（第一次建、第二次重用）
+
+### 2.5 rpc_cancel_offset_order — happy path
+**情境：** 上一條建立的 offset order
+**預期：** `status='cancelled'`、`cancelled_at` 有值、`updated_by` 為 operator
+
+### 2.6 rpc_cancel_offset_order — non-offset 拒絕
+**情境：** 對 `order_kind='normal'` 的訂單呼叫
+**預期：** RAISE EXCEPTION（提示用 rpc_cancel_aid_order）
+
+### 2.7 rpc_cancel_aid_order 對 offset 訂單
+**情境：** 對 `order_kind='offset'` 訂單呼叫 rpc_cancel_aid_order
+**預期：** 不會誤觸發 transfer chain 邏輯（offset 單沒有 transfer 關聯，但仍應走基本 cancel path 或被拒；實作時擇一明確）
+
+### 2.8 picking_demand_view 抵減驗證
+**情境：** campaign A，3 筆 normal 訂單共 qty=10、1 筆 offset 訂單 qty=-3
+**預期：** demand_view 的 `demand_qty` SUM = 7（不是 10）
+  ```sql
+  SELECT campaign_item_id, demand_qty FROM picking_demand_view
+  WHERE campaign_id = <A>;
+  ```
+
+### 2.9 Cross-tenant 拒絕
+**情境：** store_id 屬於 tenant B、campaign 屬於 tenant A、operator 屬於 A
+**預期：** RAISE 或 0 row（不應跨 tenant 寫入）
+
+---
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 A1 — 中文店名顯示
+- [ ] `apps/member` 開啟、URL 帶 `?store=S002`
+- [ ] 載入完成後顯示「您目前位於 **<中文店名>** 門市」
+- [ ] list_stores 失敗（拔網路 / mock 500）→ fallback 顯示 `S002`
+- [ ] 切換不同 store code → 名稱跟著變
+
+### 3.2 A2 — 非 PWA 模式隱藏驗證碼區
+- [ ] 桌機瀏覽器（非 standalone）：看不到「或者」分隔線、看不到 6 位數驗證碼 form
+- [ ] 仍看得到「更換其他門市」連結
+- [ ] 模擬 standalone（DevTools application → Service Worker → Add to home / Chrome installed PWA）：驗證碼區出現
+- [ ] 已 sync 過的 6 位驗證碼仍能在 PWA 模式下提交
+
+### 3.3 A3 — 驗證成功頁
+- [ ] OAuth 走完跳到 `/auth/success`，看到 LINE 頭貼（圓形）+ 名稱（h1）
+- [ ] 沒有「進入會員中心」按鈕
+- [ ] 有「前往安裝步驟」綠色按鈕，點擊跳到 `/install`
+- [ ] PWA 配對流程（paired=1）：顯示「請關閉此視窗、回到 PWA App」原文案
+- [ ] 6 位數驗證碼區塊：`code && !paired` 時顯示
+- [ ] LINE 個資抓不到（fragment 缺 line_picture/line_name）→ fallback 綠勾 + 「LINE 驗證成功」標題
+- [ ] console 無 error
+
+### 3.4 B1 — 訂單列表「取消」按鈕
+- [ ] status=pending/confirmed/reserved/shipping/ready/partially_ready：看到紅色「取消」按鈕
+- [ ] status=completed/cancelled/expired/transferred_out：看不到「取消」按鈕
+- [ ] 點「取消」→ confirm dialog → 確認 → 列表自動 reload、該 row status 變 cancelled
+- [ ] 取消失敗（例如 RPC error）→ alert 顯示翻譯後錯誤訊息
+- [ ] 取消 shipping 中訂單 → 走全鏈路逆轉、相關 transfer 也變 cancelled（`rpc_cancel_aid_order` 既有行為）
+
+### 3.5 B1b — 訂單列表 cosmetics
+- [ ] 「開團」column 顯示 campaign cover_image_url 圖片（h-10 w-10 rounded）+ campaign_no + name
+- [ ] cover_image_url 為 null → 顯示 placeholder（首字 / svg / 灰底）
+- [ ] 「會員」column 顯示 avatar_url（h-8 w-8 rounded-full）+ 暱稱/姓名
+- [ ] avatar_url 為 null → 顯示 fallback 首字圓圈
+- [ ] 圖片載入失敗（壞 URL）→ 不破版（`onError` 替成 fallback）
+
+### 3.6 B2 — 訂單詳情頁「取消」按鈕
+- [ ] OrderDetail modal 上 action bar 看到紅色「取消訂單」按鈕（與「轉出」「取貨」並列）
+- [ ] 點擊跳出原因輸入 → 送出 → modal 顯示成功訊息 → 列表自動 reload
+- [ ] 已 cancelled 訂單再開詳情：取消按鈕隱藏
+
+### 3.7 C5 — 訂單新增頁 [負數模式] toggle
+- [ ] Mode 切換器看到三顆按鈕：客戶 / 店內 / 庫存抵減單（紅/橘色）
+- [ ] 切到 offset → 顧客選擇區隱藏、自動帶 store_internal
+- [ ] 「抵減原因」必填欄位顯示、空白送出 → 阻擋
+- [ ] qty 欄位 placeholder 改提示「正數會自動轉為負」
+- [ ] 送出時 qty = -|input|；DB 寫入確實為負
+- [ ] 送出成功 → 跳回列表、該 order 顯示「抵」徽章
+- [ ] 既有 customer / internal mode 不受影響（regression）
+
+### 3.8 訂單列表 — offset 徽章
+- [ ] order_kind=offset 的 row 顯示「抵」灰色徽章
+- [ ] 點開詳情：可看到 notes 開頭 `[庫存抵減單]`
+- [ ] 顧客視角（apps/member /me）：看不到 offset 訂單（member_id 不同）
+
+---
+
+## 4. Regression
+
+### 4.1 既有 OAuth 流程
+- [ ] 從 LINE 內 webview 開啟 → LIFF 自動登入 → /me 不破
+- [ ] 從桌機瀏覽器開啟 → 走 OAuth → success page → 點「前往安裝步驟」 → /install 顯示正確 UA 分支
+- [ ] PWA standalone 點登入 → 開瀏覽器 OAuth → 6 位數碼仍能 sync 回 PWA
+
+### 4.2 既有訂單流程
+- [ ] 一般訂單建立（rpc_create_customer_orders）不受 qty 約束放寬影響
+- [ ] 一般訂單取消（pending/confirmed）走 `rpc_cancel_aid_order` 直接 cancel 路徑正常
+- [ ] 訂單轉手 (rpc_transfer_order) 對 offset 單應拒絕（加 guard）
+- [ ] 取貨流程 / picking wave 流程不受 offset 訂單影響（offset 不進 picking）
+
+### 4.3 採購聚合
+- [ ] picking_demand_view、PR 計算包含 offset 抵減後的數字
+- [ ] 結算金額（settlement）行為與 plan 開放問題 #2 一致（依實作後實際行為記錄）
+- [ ] 既有 v_customer_order_summary、v_customer_order_summary_items_detail 不破
+
+### 4.4 訂單列表查詢效能
+- [ ] 加入 cover_image_url、avatar_url 後列表載入時間無顯著退化
+- [ ] 大量 row（>1000）下 JOIN/IN query 仍可接受
+
+---
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**Supabase dev push 成功**（記憶提醒：URL 要帶 `sslmode=require`）、**apps/admin + apps/member build + type-check 通過** 才可標 done。
+
+完成後依使用者記憶規則：
+1. GitHub Issues 開新 issue + merge 後關閉
+2. Wiki 更新訂單模組頁、Home、Sidebar
+3. PRD `docs/PRD-訂單取貨模組-v0.2-addendum.md` 補負數訂單一節

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -223,7 +223,18 @@ async function listMyOrders(sb: any, tenantId: string, storeId: number, memberId
   else q = q.eq("status", "completed");
   const { data, error } = await q;
   if (error) return json({ error: error.message }, 500);
-  return json({ orders: data ?? [] });
+
+  // 把 items.image_url + campaign_cover_url 轉成 storage public URL
+  const supabaseUrl = requireEnv("SUPABASE_URL");
+  const orders = (data ?? []).map((o: any) => ({
+    ...o,
+    campaign_cover_url: toPublicUrl(supabaseUrl, "products", o.campaign_cover_url),
+    items: (o.items ?? []).map((it: any) => ({
+      ...it,
+      image_url: toPublicUrl(supabaseUrl, "products", it.image_url),
+    })),
+  }));
+  return json({ orders });
 }
 
 async function listMySettlements(sb: any, tenantId: string, storeId: number, memberId: number, tab: string) {

--- a/supabase/migrations/20260516000000_allow_negative_order_qty.sql
+++ b/supabase/migrations/20260516000000_allow_negative_order_qty.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- 負數訂單（庫存抵減單）schema 支援
+--
+-- 業務情境：店裡已有庫存不想多訂，又不想取消顧客的訂單，
+-- 但要讓採購聚合扣掉這部分。做法是門市建一張 order_kind='offset'
+-- 的訂單、qty 為負，由 store_internal member 持有，僅在 demand
+-- 聚合時參與抵減，不會出現在顧客視角。
+--
+-- 變更：
+--   1. customer_order_items.qty CHECK qty > 0 → CHECK qty <> 0
+--   2. customer_orders 新增 order_kind 欄位 (normal | offset)
+--   3. 加 idx_customer_orders_kind 加速依 kind 過濾
+-- ============================================================
+
+ALTER TABLE customer_order_items DROP CONSTRAINT customer_order_items_qty_check;
+ALTER TABLE customer_order_items ADD CONSTRAINT customer_order_items_qty_check CHECK (qty <> 0);
+
+ALTER TABLE customer_orders
+  ADD COLUMN IF NOT EXISTS order_kind TEXT NOT NULL DEFAULT 'normal'
+    CHECK (order_kind IN ('normal', 'offset'));
+
+COMMENT ON COLUMN customer_orders.order_kind IS
+  'normal=一般訂單; offset=門市庫存抵減單（qty<0，由 store_internal member 建立，僅影響採購聚合）';
+
+CREATE INDEX IF NOT EXISTS idx_customer_orders_kind
+  ON customer_orders(tenant_id, campaign_id, order_kind);
+
+-- 既有 partial UNIQUE INDEX customer_orders_trio_active_uniq（20260509000006 建立）
+-- 不含 order_kind，會讓同 store_internal member 不能同時有 normal (店長叫貨) 與
+-- offset (抵減單)。改成包含 order_kind 才允許共存。
+DROP INDEX IF EXISTS customer_orders_trio_active_uniq;
+
+CREATE UNIQUE INDEX customer_orders_trio_kind_active_uniq
+  ON customer_orders (tenant_id, campaign_id, channel_id, member_id, order_kind)
+  WHERE status NOT IN ('transferred_out', 'expired', 'cancelled');
+
+COMMENT ON INDEX customer_orders_trio_kind_active_uniq IS
+  '同 (tenant, campaign, channel, member, order_kind) 只允許一筆 active 訂單；'
+  'closed (transferred_out/expired/cancelled) 不佔 slot。'
+  '加 order_kind 是為了讓 store_internal member 可同時有 normal 與 offset 兩張單。';

--- a/supabase/migrations/20260516000001_rpc_create_offset_order.sql
+++ b/supabase/migrations/20260516000001_rpc_create_offset_order.sql
@@ -1,0 +1,195 @@
+-- ============================================================
+-- rpc_create_offset_order：建立庫存抵減單（負數訂單）
+-- rpc_cancel_offset_order：取消庫存抵減單
+--
+-- 業務情境：店裡已有庫存不想多訂，又不想取消顧客的訂單，
+-- 但要讓採購聚合扣掉這部分。做法是門市建一張 order_kind='offset'
+-- 的訂單、qty 為負，由 store_internal member 持有。
+--
+-- 與 rpc_create_store_internal_order 的差異：
+--   - order_kind='offset'（vs 'normal'）
+--   - qty 必須全為負（vs 必須為正）
+--   - status 直接 'confirmed'（vs 'pending'，不需經過確認）
+--   - notes 必填，會被加上「[庫存抵減單]」前綴
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_create_offset_order(
+  p_campaign_id BIGINT,
+  p_store_id    BIGINT,
+  p_items       JSONB,         -- [{campaign_item_id, qty}], qty 必須 < 0
+  p_reason      TEXT,
+  p_operator    UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant_id    UUID;
+  v_campaign_no  TEXT;
+  v_campaign_st  TEXT;
+  v_member_id    BIGINT;
+  v_channel_id   BIGINT;
+  v_seq          INT;
+  v_order_no     TEXT;
+  v_order_id     BIGINT;
+  v_item         JSONB;
+  v_ci_id        BIGINT;
+  v_ci_sku       BIGINT;
+  v_ci_price     NUMERIC;
+  v_qty          NUMERIC;
+BEGIN
+  -- 必填驗證
+  IF p_reason IS NULL OR length(trim(p_reason)) = 0 THEN
+    RAISE EXCEPTION '抵減原因 (p_reason) 必填';
+  END IF;
+  IF p_items IS NULL OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'p_items is empty';
+  END IF;
+
+  -- qty 全為負驗證
+  IF EXISTS (
+    SELECT 1 FROM jsonb_array_elements(p_items) e
+    WHERE (e->>'qty')::numeric >= 0
+  ) THEN
+    RAISE EXCEPTION '抵減單所有品項 qty 必須 < 0';
+  END IF;
+
+  -- campaign 驗證
+  SELECT tenant_id, campaign_no, status
+    INTO v_tenant_id, v_campaign_no, v_campaign_st
+    FROM group_buy_campaigns WHERE id = p_campaign_id;
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'campaign % not found', p_campaign_id;
+  END IF;
+  IF v_campaign_st NOT IN ('open', 'closed') THEN
+    RAISE EXCEPTION 'campaign % is %; only open/closed accept offset order',
+                    p_campaign_id, v_campaign_st;
+  END IF;
+
+  -- 取得 / 建立 store_internal member
+  v_member_id := rpc_get_or_create_store_member(p_store_id, p_operator);
+
+  -- 取該店任一 line_channel；無則 fallback 到 tenant 第一個
+  SELECT id INTO v_channel_id
+    FROM line_channels
+   WHERE tenant_id = v_tenant_id AND home_store_id = p_store_id
+   LIMIT 1;
+  IF v_channel_id IS NULL THEN
+    SELECT id INTO v_channel_id FROM line_channels
+     WHERE tenant_id = v_tenant_id LIMIT 1;
+  END IF;
+  IF v_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for tenant';
+  END IF;
+
+  -- 抵減單獨立 (UNIQUE: tenant+campaign+channel+member 用了 store_internal
+  -- 會跟 rpc_create_store_internal_order 撞)，所以 offset 單帶 -OFF 後綴
+  -- 跳過 UNIQUE 衝突 → 改用獨立 member（用 -INT 後綴的另一個 member？）
+  --
+  -- 簡化：暫不允許同 store + 同 campaign 多張 offset 單，沿用既有 member
+  -- 並將 order_no 後綴設 -OFF{seq}。若 UNIQUE 衝突，回傳既有 order_id
+  -- 並將新 items 累加到既有單。
+  SELECT id INTO v_order_id FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = p_campaign_id
+     AND channel_id  = v_channel_id
+     AND member_id   = v_member_id
+     AND order_kind  = 'offset';
+
+  IF v_order_id IS NULL THEN
+    SELECT COUNT(*) + 1 INTO v_seq
+      FROM customer_orders
+     WHERE tenant_id = v_tenant_id AND campaign_id = p_campaign_id
+       AND order_kind = 'offset';
+    v_order_no := v_campaign_no || '-OFF' || lpad(v_seq::text, 4, '0');
+
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id,
+      pickup_store_id, order_kind, status, notes, created_by, updated_by
+    ) VALUES (
+      v_tenant_id, v_order_no, p_campaign_id, v_channel_id, v_member_id,
+      p_store_id, 'offset', 'confirmed',
+      '[庫存抵減單] ' || p_reason,
+      p_operator, p_operator
+    ) RETURNING id INTO v_order_id;
+  ELSE
+    -- 既有 offset 單，累加 notes（保留歷次原因）
+    UPDATE customer_orders SET
+      notes      = COALESCE(notes, '') || E'\n[追加] ' || p_reason,
+      updated_by = p_operator
+    WHERE id = v_order_id;
+  END IF;
+
+  -- 寫 items
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_ci_id := (v_item ->> 'campaign_item_id')::BIGINT;
+    v_qty   := (v_item ->> 'qty')::NUMERIC;
+
+    SELECT unit_price, sku_id INTO v_ci_price, v_ci_sku
+      FROM campaign_items
+     WHERE id = v_ci_id AND tenant_id = v_tenant_id AND campaign_id = p_campaign_id;
+    IF v_ci_price IS NULL THEN
+      RAISE EXCEPTION 'campaign_item % not in campaign %', v_ci_id, p_campaign_id;
+    END IF;
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by
+    ) VALUES (
+      v_tenant_id, v_order_id, v_ci_id, v_ci_sku, v_qty, v_ci_price,
+      'pending', 'store_internal', p_operator, p_operator
+    );
+  END LOOP;
+
+  RETURN v_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_create_offset_order(BIGINT, BIGINT, JSONB, TEXT, UUID) TO authenticated;
+
+
+-- ============================================================
+-- rpc_cancel_offset_order：取消抵減單
+--
+-- 抵減單沒有 transfer / picking_wave 關聯，直接 status='cancelled' 即可，
+-- 不走 rpc_cancel_aid_order 的全鏈路逆轉。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_cancel_offset_order(
+  p_order_id BIGINT,
+  p_reason   TEXT,
+  p_operator UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_kind   TEXT;
+  v_status TEXT;
+BEGIN
+  SELECT order_kind, status INTO v_kind, v_status
+    FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_kind IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  IF v_kind <> 'offset' THEN
+    RAISE EXCEPTION 'order % is order_kind=%, use rpc_cancel_aid_order instead', p_order_id, v_kind;
+  END IF;
+  IF v_status = 'cancelled' THEN
+    RETURN; -- idempotent
+  END IF;
+
+  UPDATE customer_orders SET
+    status     = 'cancelled',
+    notes      = COALESCE(notes, '') || E'\n[cancelled] ' || COALESCE(p_reason, ''),
+    updated_by = p_operator,
+    updated_at = NOW()
+  WHERE id = p_order_id;
+
+  -- 同時把 items 標 cancelled
+  UPDATE customer_order_items SET
+    status     = 'cancelled',
+    updated_by = p_operator,
+    updated_at = NOW()
+  WHERE order_id = p_order_id AND status NOT IN ('cancelled');
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_cancel_offset_order(BIGINT, TEXT, UUID) TO authenticated;

--- a/supabase/migrations/20260516000002_campaign_display_order.sql
+++ b/supabase/migrations/20260516000002_campaign_display_order.sql
@@ -1,0 +1,20 @@
+-- ============================================================
+-- group_buy_campaigns 加 display_order 欄
+--
+-- 原因：候選週曆 (community-candidates calendar) 拖拉卡片時，
+-- 應該同步調整對應 campaign 在同日的顯示順序。candidate 已有
+-- scheduled_sort_order，但 campaign 端沒對應欄位，導致 /campaigns
+-- 週曆/月曆排序與候選週曆不一致。
+--
+-- 約定：display_order 由 candidate calendar 的 persistDay 同步寫入；
+-- campaigns 列表/月曆/週曆 ORDER BY display_order ASC, start_at ASC。
+-- ============================================================
+
+ALTER TABLE group_buy_campaigns
+  ADD COLUMN IF NOT EXISTS display_order INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN group_buy_campaigns.display_order IS
+  '同日內顯示順序（由 community_product_candidates 拖拉週曆同步寫入）';
+
+CREATE INDEX IF NOT EXISTS idx_gbc_date_order
+  ON group_buy_campaigns(tenant_id, (DATE(start_at AT TIME ZONE 'Asia/Taipei')), display_order);

--- a/supabase/migrations/20260516000003_backfill_campaign_display_order.sql
+++ b/supabase/migrations/20260516000003_backfill_campaign_display_order.sql
@@ -1,0 +1,16 @@
+-- ============================================================
+-- 回填 group_buy_campaigns.display_order
+--
+-- 既有 campaign 的 display_order 都是預設 0，導致同日 campaign 排序
+-- 沒有跟 community_product_candidates 的 scheduled_sort_order 同步。
+-- 從 campaign_no 'GB{YYYYMMDD}-C{padded candidate_id}' 推回 candidate，
+-- 把 candidate.scheduled_sort_order 寫進 campaign.display_order。
+-- ============================================================
+
+UPDATE group_buy_campaigns gbc
+   SET display_order = c.scheduled_sort_order
+  FROM community_product_candidates c
+ WHERE gbc.campaign_no ~ '^GB[0-9]{8}-C[0-9]{6}$'
+   AND substring(gbc.campaign_no FROM 13 FOR 6)::bigint = c.id
+   AND c.scheduled_sort_order IS NOT NULL
+   AND c.tenant_id = gbc.tenant_id;

--- a/supabase/migrations/20260516000004_rpc_reorder_candidate_campaign.sql
+++ b/supabase/migrations/20260516000004_rpc_reorder_candidate_campaign.sql
@@ -1,0 +1,53 @@
+-- ============================================================
+-- rpc_reorder_candidate_campaign：拖拉候選週曆時同步更新 campaign 順序
+--
+-- 為什麼要 RPC：group_buy_campaigns 的 RLS policy gbc_hq_all 限制需要
+-- role IN (owner/admin/hq_manager/purchaser)。但 admin 使用者有時 JWT
+-- 的 role claim 是 NULL，從 client 直接 UPDATE 會被 RLS 拒絕（0 rows
+-- updated 但沒 error）。包成 SECURITY DEFINER RPC 即可繞過。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_reorder_candidate_campaign(
+  p_candidate_id BIGINT,
+  p_day_key      DATE,
+  p_order        INTEGER,
+  p_operator     UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant      UUID;
+  v_campaign_id BIGINT;
+  v_new_no      TEXT;
+  v_pad_id      TEXT := lpad(p_candidate_id::TEXT, 6, '0');
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM community_product_candidates WHERE id = p_candidate_id;
+  IF v_tenant IS NULL THEN
+    RETURN NULL; -- candidate 不存在就跳過
+  END IF;
+
+  v_new_no := 'GB' || to_char(p_day_key, 'YYYYMMDD') || '-C' || v_pad_id;
+
+  -- 找對應 campaign（用 candidate id 後綴 LIKE）
+  SELECT id INTO v_campaign_id
+    FROM group_buy_campaigns
+   WHERE tenant_id = v_tenant
+     AND campaign_no LIKE '%-C' || v_pad_id
+   LIMIT 1;
+
+  IF v_campaign_id IS NULL THEN
+    RETURN NULL; -- candidate 還沒被 schedule，沒對應 campaign
+  END IF;
+
+  UPDATE group_buy_campaigns SET
+    display_order = p_order,
+    start_at      = p_day_key::TIMESTAMPTZ,
+    campaign_no   = v_new_no,
+    updated_by    = p_operator,
+    updated_at    = NOW()
+  WHERE id = v_campaign_id;
+
+  RETURN v_campaign_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_reorder_candidate_campaign(BIGINT, DATE, INTEGER, UUID) TO authenticated;

--- a/supabase/migrations/20260516000005_rpc_members_for_transfer.sql
+++ b/supabase/migrations/20260516000005_rpc_members_for_transfer.sql
@@ -1,0 +1,39 @@
+-- ============================================================
+-- rpc_get_members_to_notify_for_transfer：取得收貨後該推播的會員
+--
+-- 給定一張 transfer.id，回傳所有 pickup_store=this transfer 的 dest store
+-- 且訂單品項與 transfer items 重疊 / 訂單未終結 / 非抵減單的會員。
+-- 用於收貨成功後 fan-out web-push 通知「貨已到店」。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_get_members_to_notify_for_transfer(
+  p_transfer_id BIGINT
+) RETURNS TABLE(
+  member_id BIGINT,
+  order_id  BIGINT,
+  order_no  TEXT
+)
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  WITH dest AS (
+    SELECT t.dest_location, t.tenant_id, s.id AS store_id
+      FROM transfers t
+      LEFT JOIN stores s ON s.location_id = t.dest_location AND s.tenant_id = t.tenant_id
+     WHERE t.id = p_transfer_id
+  ),
+  skus AS (
+    SELECT DISTINCT sku_id FROM transfer_items WHERE transfer_id = p_transfer_id
+  )
+  SELECT DISTINCT co.member_id, co.id, co.order_no
+    FROM customer_orders co
+    JOIN dest d
+      ON d.store_id = co.pickup_store_id
+     AND d.tenant_id = co.tenant_id
+    JOIN customer_order_items coi
+      ON coi.order_id = co.id
+   WHERE coi.sku_id IN (SELECT sku_id FROM skus)
+     AND co.member_id IS NOT NULL
+     AND co.status NOT IN ('cancelled', 'expired', 'transferred_out', 'completed')
+     AND COALESCE(co.order_kind, 'normal') = 'normal'
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_get_members_to_notify_for_transfer(BIGINT) TO authenticated;

--- a/supabase/migrations/20260516000006_rpc_campaigns_for_transfer.sql
+++ b/supabase/migrations/20260516000006_rpc_campaigns_for_transfer.sql
@@ -1,0 +1,39 @@
+-- ============================================================
+-- rpc_get_campaigns_for_transfer：取得 transfer 涵蓋的 campaign IDs
+--
+-- 給 transfer.id，回傳所有相關 campaigns（用於收貨頁「→ 查看此店訂單」
+-- 連結帶 campaignIds filter）。
+--
+-- 邏輯：
+--   1. WAVE-{wave_id}-S{...} 類 transfer：從 picking_wave_items 取
+--   2. 其他（aid transfer 等）：從 transfers.customer_order_id 取
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_get_campaigns_for_transfer(
+  p_transfer_id BIGINT
+) RETURNS TABLE(campaign_id BIGINT)
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  WITH t AS (
+    SELECT id, transfer_no, customer_order_id, tenant_id FROM transfers WHERE id = p_transfer_id
+  ),
+  wave_match AS (
+    SELECT (substring(transfer_no FROM '^WAVE-(\d+)-S\d+$'))::BIGINT AS wave_id
+      FROM t
+     WHERE transfer_no ~ '^WAVE-\d+-S\d+$'
+  ),
+  from_wave AS (
+    SELECT DISTINCT pwi.campaign_id
+      FROM picking_wave_items pwi
+      JOIN wave_match w ON w.wave_id = pwi.wave_id
+  ),
+  from_co AS (
+    SELECT DISTINCT co.campaign_id
+      FROM customer_orders co
+      JOIN t ON t.customer_order_id = co.id
+  )
+  SELECT campaign_id FROM from_wave
+  UNION
+  SELECT campaign_id FROM from_co
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_get_campaigns_for_transfer(BIGINT) TO authenticated;

--- a/supabase/migrations/20260516000007_rpc_campaigns_for_transfer_v2.sql
+++ b/supabase/migrations/20260516000007_rpc_campaigns_for_transfer_v2.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- rpc_get_campaigns_for_transfer v2：透過 customer_orders 反推 campaigns
+--
+-- v1 從 picking_wave_items.campaign_id 取，但很多資料 campaign_id 為 NULL。
+-- 改用更可靠的路徑：dest store + transfer items 的 SKU → 對應 customer_orders
+-- → distinct campaign_id。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_get_campaigns_for_transfer(
+  p_transfer_id BIGINT
+) RETURNS TABLE(campaign_id BIGINT)
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  WITH t AS (
+    SELECT id, transfer_no, customer_order_id, dest_location, tenant_id
+      FROM transfers WHERE id = p_transfer_id
+  ),
+  store AS (
+    SELECT s.id AS store_id
+      FROM t
+      JOIN stores s ON s.location_id = t.dest_location AND s.tenant_id = t.tenant_id
+  ),
+  skus AS (
+    SELECT DISTINCT sku_id FROM transfer_items WHERE transfer_id = p_transfer_id
+  ),
+  from_co_match AS (
+    -- 從 dest store + sku 對到的 customer_orders.campaign_id
+    SELECT DISTINCT co.campaign_id
+      FROM customer_orders co
+      JOIN store s ON s.store_id = co.pickup_store_id
+      JOIN customer_order_items coi ON coi.order_id = co.id
+     WHERE coi.sku_id IN (SELECT sku_id FROM skus)
+       AND COALESCE(co.order_kind, 'normal') = 'normal'
+  ),
+  from_aid AS (
+    -- aid transfer 直接帶 customer_order_id
+    SELECT DISTINCT co.campaign_id
+      FROM customer_orders co
+      JOIN t ON t.customer_order_id = co.id
+  )
+  SELECT campaign_id FROM from_co_match WHERE campaign_id IS NOT NULL
+  UNION
+  SELECT campaign_id FROM from_aid WHERE campaign_id IS NOT NULL
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_get_campaigns_for_transfer(BIGINT) TO authenticated;

--- a/supabase/migrations/20260516000008_v_customer_order_summary_item_image.sql
+++ b/supabase/migrations/20260516000008_v_customer_order_summary_item_image.sql
@@ -1,0 +1,96 @@
+-- ============================================================
+-- v_customer_order_summary：items 加 image_url
+--
+-- LIFF 顧客端的「我的訂單」要在每個品項旁顯示商品圖。images 是 products
+-- 的 JSONB array，可能是 ["path"] 或 [{url:"path"}]，取第一張當縮圖。
+-- 注意：image_url 留下相對 path（liff-api 端會經 toPublicUrl 轉 storage URL）
+-- ============================================================
+
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  agg.items_total,
+  agg.items_total + co.shipping_fee - co.discount_amount   AS payable_amount,
+  agg.items,
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','shipping','completed'))                  AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))              AS settled,
+  (co.payment_status = 'paid')                                                   AS paid,
+  (co.status IN ('shipping','completed'))                                        AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                   AS settlement_no,
+  s.name                                                                          AS store_name,
+  s.code                                                                          AS store_code,
+  gbc.name                                                                        AS campaign_name,
+  gbc.cover_image_url                                                             AS campaign_cover_url,
+  gbc.end_at                                                                      AS campaign_end_at,
+  gbc.cutoff_date                                                                 AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price), 0)                                   AS items_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'sku_code',         sk.sku_code,
+          'product_name',     sk.product_name,
+          'variant_name',     sk.variant_name,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'subtotal',         coi.qty * coi.unit_price,
+          'status',           coi.status,
+          'notes',            coi.notes,
+          'image_url',        CASE
+            WHEN jsonb_typeof(p.images) = 'array' AND jsonb_array_length(p.images) > 0 THEN
+              COALESCE(p.images -> 0 ->> 'url', p.images ->> 0)
+            ELSE NULL
+          END
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                             AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus     sk ON sk.id = coi.sku_id
+  LEFT JOIN products p  ON p.id  = sk.product_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細（含 sku 名/規格/縮圖 path） + campaign 名 + 結單號';


### PR DESCRIPTION
## Summary
此分支累積 5 個主題改動，全部 8 支 migrations 已 push prod、liff-api edge function 已 deploy。

### 1. apps/member 登入優化 + 訂單頁商品圖
- 登入頁中文店名（fallback store code）；非 PWA 隱驗證碼區
- 驗證成功頁顯示 LINE 頭貼+名稱、移除「進入會員中心」、改放「前往安裝步驟 → /install」
- 訂單頁僅留「已到貨/未到貨」chip（移除全結/已付/已寄）；每個 item 顯示縮圖

### 2. admin tenant 名稱 + sidebar 重組
- `lib/tenant.ts` 集中管理顯示名稱（env-driven，未來改 DB 只動一處）
- root title / sidebar header / login h1 全用上
- sidebar 重排：核心業務（開團/商品/供應商）/ **分店業務**（訂單/取貨/會員/互助交流板/互助轉移單(總倉檢視)/自由轉貨）/ 進銷存 / **倉儲**（撿貨/派貨/收貨待辦）/ 財務（HQ應收/月結算）/ 社群選品
- group 可摺疊（localStorage 持久），active 路由所在 group 強制展開

### 3. 訂單刪除/取消 + 負數訂單
- 新 schema：`customer_order_items.qty <> 0`、`customer_orders.order_kind`、partial unique index 含 order_kind 維度
- 新 RPC：`rpc_create_offset_order` + `rpc_cancel_offset_order`
- 訂單新增頁第三 toggle「庫存抵減單」紅色強調，qty 自動轉負
- 訂單列表大重整：移除訂單號/取貨截止/狀態欄，改顯示封面圖+品項粗體/大頭貼/zebra/已取消紅底/closed-state badges/日期 M/D + tooltip
- 取消按鈕（pending/confirmed/shipping）+ OrderDetail modal 紅色 ✕ 取消訂單
- 開團 filter 改成多選 checkbox picker（URL `campaignIds=1,2,3`）
- 測試文件 `docs/TEST-訂單刪除與負數訂單.md`

### 4. 候選週曆排序同步開團
- `group_buy_campaigns.display_order` 新欄 + 既有資料回填
- `rpc_reorder_candidate_campaign` SECURITY DEFINER 繞過 RLS（admin 用戶 JWT role claim 為 NULL 的問題）
- 候選週曆空 column min-h + collision detection 改 pointerWithin → rectIntersection → closestCorners
- 拖拉同步寫入對應 campaign 的 display_order/start_at/campaign_no
- /campaigns 週曆 ORDER BY 加 display_order
- 開團卡/列加「🛒 N 件」+「−N 抵」可點擊 badge → /orders?campaignId

### 5. 收貨頁顯示 + 商品到貨推播
- 新 RPC：`rpc_get_members_to_notify_for_transfer`、`rpc_get_campaigns_for_transfer`
- 收貨頁新「商品 / 數量」column 顯示 N 項/共 N 件/前 2 名稱 + 「→ 查看此店訂單（N 團）」link 帶 campaignIds 多選
- TransferReceiveModal 收貨成功後 fan-out web-push 到所有受影響顧客（去重）：title「您的商品到貨」/ url `/orders` PWA 訂單頁

## Migrations (8)
- `20260516000000` qty CHECK 放寬 + order_kind + partial unique index
- `20260516000001` rpc_create_offset_order + rpc_cancel_offset_order
- `20260516000002` group_buy_campaigns.display_order
- `20260516000003` 回填 display_order
- `20260516000004` rpc_reorder_candidate_campaign
- `20260516000005` rpc_get_members_to_notify_for_transfer
- `20260516000006` + `20260516000007` rpc_get_campaigns_for_transfer (v1 + v2)
- `20260516000008` v_customer_order_summary 加 items.image_url

Edge Function: `liff-api` 已 deploy。

## Test plan
- [ ] apps/member 登入 → 看到中文店名 + 非 PWA 不顯驗證碼
- [ ] OAuth 走完 → success page 頭貼 + 名稱 + 安裝步驟 link
- [ ] PWA /orders → 已到貨 chip + 商品縮圖
- [ ] /orders 多選 campaign filter；點開團 badge 帶 campaignIds 跳過去
- [ ] 訂單列表 cancelled row 紅底 + 已取消按鈕
- [ ] 訂單新增頁切「庫存抵減單」mode → qty 自動轉負 + 必填原因
- [ ] DB 驗：rpc_create_offset_order 建單 → order_kind=offset, qty<0
- [ ] picking_demand_view 含 offset 抵減（採購聚合扣掉這部分）
- [ ] 候選週曆拖拉 → /campaigns 週曆同步排序
- [ ] 收貨頁顯示商品名 + qty + 點 link 到 /orders 帶 N 團
- [ ] 收貨成功 → 受影響顧客收到推播「您的商品到貨」

🤖 Generated with [Claude Code](https://claude.com/claude-code)