### PR TITLE
fix(member): /overview page use new PushNotificationManager state API

### DIFF
--- a/apps/member/src/app/overview/page.tsx
+++ b/apps/member/src/app/overview/page.tsx
@@ -6,6 +6,7 @@ import { consumeFragmentToSession, getSession } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
 import { PushNotificationManager } from "@/components/PushNotificationManager";
+import { usePushNotification } from "@/lib/usePushNotification";
 
 type Overview = {
   store: {
@@ -26,6 +27,7 @@ export default function OverviewPage() {
   const [data, setData] = useState<Overview | null>(null);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
+  const pushState = usePushNotification(getSession()?.token ?? null);
 
   useEffect(() => {
     consumeFragmentToSession();
@@ -135,7 +137,7 @@ export default function OverviewPage() {
               </Section>
             )}
 
-            <PushNotificationManager jwt={getSession()?.token ?? null} />
+            <PushNotificationManager state={pushState} />
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary

Hotfix for type error introduced in #162. `PushNotificationManager` 改成 `state` prop 但 `/overview/page.tsx` 漏改,main 的 `next build` 直接 type-error。

同 /me page 的處理 — 加 `usePushNotification(jwt)` hook、state 傳給 component。

## Test plan
- [x] `npm run build -w apps/member` 綠燈

🤖 Generated with [Claude Code](https://claude.com/claude-code)