### PR TITLE
feat(admin): 訂單批次取貨 + 整合列印 + 品項只顯示 SKU

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -8,6 +8,7 @@ import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
 import { PickupDialog } from "@/components/PickupDialog";
 import { translateRpcError } from "@/lib/rpcError";
+import { withBasePath } from "@/lib/basePath";
 
 type OrderStatus =
   | "pending" | "confirmed" | "reserved" | "shipping" | "ready" | "partially_ready"
@@ -74,13 +75,23 @@ function OrdersListContent() {
   const [stores, setStores] = useState<Store[]>([]);
   const [members, setMembers] = useState<Map<number, Member>>(new Map());
   const [itemSummary, setItemSummary] = useState<
-    Map<number, { lineCount: number; totalQty: number; totalAmount: number; items: { name: string; qty: number }[] }>
+    Map<
+      number,
+      {
+        lineCount: number;
+        totalQty: number;
+        totalAmount: number;
+        items: { product_name: string | null; variant_name: string | null; qty: number }[];
+      }
+    >
   >(new Map());
   const [pickupReady, setPickupReady] = useState<Map<number, boolean>>(new Map());
   const [detailId, setDetailId] = useState<number | null>(null);
   const [detailNo, setDetailNo] = useState<string>("");
   const [pickup, setPickup] = useState<{ id: number; no: string } | null>(null);
   const [reloadOrders, setReloadOrders] = useState(0);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
 
   useEffect(() => { setPage(1); }, [campaignIds, status, storeId]);
 
@@ -133,17 +144,18 @@ function OrdersListContent() {
             ? getSupabase().from("v_order_pickup_ready").select("order_id, pickup_ready").in("order_id", ids)
             : Promise.resolve({ data: [] as { order_id: number; pickup_ready: boolean }[] }),
         ]);
-        const im = new Map<number, { lineCount: number; totalQty: number; totalAmount: number; items: { name: string; qty: number }[] }>();
+        const im = new Map<number, { lineCount: number; totalQty: number; totalAmount: number; items: { product_name: string | null; variant_name: string | null; qty: number }[] }>();
         for (const id of ids) im.set(id, { lineCount: 0, totalQty: 0, totalAmount: 0, items: [] });
         for (const it of (ic.data as { order_id: number; qty: number; unit_price: number; sku: { product_name: string | null; variant_name: string | null } | null }[]) ?? []) {
           const cur = im.get(it.order_id) ?? { lineCount: 0, totalQty: 0, totalAmount: 0, items: [] };
           cur.lineCount += 1;
           cur.totalQty += Number(it.qty);
           cur.totalAmount += Number(it.qty) * Number(it.unit_price);
-          const skuName = it.sku
-            ? `${it.sku.product_name ?? ""}${it.sku.variant_name ? ` / ${it.sku.variant_name}` : ""}`.trim() || "—"
-            : "—";
-          cur.items.push({ name: skuName, qty: Number(it.qty) });
+          cur.items.push({
+            product_name: it.sku?.product_name ?? null,
+            variant_name: it.sku?.variant_name ?? null,
+            qty: Number(it.qty),
+          });
           im.set(it.order_id, cur);
         }
         const mm = new Map<number, Member>();
@@ -164,6 +176,100 @@ function OrdersListContent() {
 
   const campaignMap = useMemo(() => new Map(campaigns.map((c) => [c.id, c])), [campaigns]);
   const storeMap = useMemo(() => new Map(stores.map((s) => [s.id, s])), [stores]);
+
+  // 批次取貨 — 抓所有勾選訂單的 pickable items, 連續呼 rpc_record_pickup,
+  // 收集 event_ids,最後開一個合併的列印頁(/pickup/print?event_ids=a,b,c)
+  const pickableRows = useMemo(
+    () =>
+      (rows ?? []).filter(
+        (r) =>
+          pickupReady.get(r.id) === true &&
+          !["completed", "expired", "cancelled", "transferred_out"].includes(r.status),
+      ),
+    [rows, pickupReady],
+  );
+  const allPickableSelected =
+    pickableRows.length > 0 && pickableRows.every((r) => selected.has(r.id));
+
+  function toggleAllPickable() {
+    if (allPickableSelected) setSelected(new Set());
+    else setSelected(new Set(pickableRows.map((r) => r.id)));
+  }
+  function toggleSelected(id: number) {
+    setSelected((s) => {
+      const next = new Set(s);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function bulkPickup() {
+    if (selected.size === 0) return;
+    if (!confirm(`對 ${selected.size} 筆訂單執行取貨並列印整合單?`)) return;
+    setBulkBusy(true);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) {
+        alert("尚未登入");
+        return;
+      }
+      const orderIds = Array.from(selected);
+      const { data: itemsData, error: ie } = await sb
+        .from("customer_order_items")
+        .select("id, order_id, status")
+        .in("order_id", orderIds)
+        .in("status", ["pending", "reserved", "ready"]);
+      if (ie) {
+        alert(`抓 items 失敗：${ie.message}`);
+        return;
+      }
+      const itemsByOrder = new Map<number, number[]>();
+      for (const it of (itemsData ?? []) as { id: number; order_id: number }[]) {
+        const list = itemsByOrder.get(it.order_id) ?? [];
+        list.push(it.id);
+        itemsByOrder.set(it.order_id, list);
+      }
+      const eventIds: number[] = [];
+      const failed: { id: number; msg: string }[] = [];
+      for (const oid of orderIds) {
+        const itemIds = itemsByOrder.get(oid) ?? [];
+        if (itemIds.length === 0) continue;
+        const { data, error } = await sb.rpc("rpc_record_pickup", {
+          p_order_id: oid,
+          p_item_ids: itemIds,
+          p_operator: operator,
+          p_notes: null,
+        });
+        if (error) {
+          failed.push({ id: oid, msg: translateRpcError(error) });
+          continue;
+        }
+        const result = data as { event_id: number };
+        eventIds.push(result.event_id);
+      }
+      if (eventIds.length > 0) {
+        window.open(
+          withBasePath(`/pickup/print?event_ids=${eventIds.join(",")}`),
+          "_blank",
+        );
+      }
+      if (failed.length > 0) {
+        alert(
+          `已完成 ${eventIds.length} 筆\n失敗 ${failed.length} 筆:\n` +
+            failed.map((f) => `#${f.id}: ${f.msg}`).join("\n"),
+        );
+      } else if (eventIds.length === 0) {
+        alert("沒有可取的項目");
+      }
+      setSelected(new Set());
+      setReloadOrders((n) => n + 1);
+    } finally {
+      setBulkBusy(false);
+    }
+  }
 
   async function cancelOrder(orderId: number, orderNo: string, status: string) {
     const reason = prompt(
@@ -275,18 +381,65 @@ function OrdersListContent() {
         </div>
       )}
 
+      {/* 批次取貨工具列 — 至少有一張可取的訂單時才出現 */}
+      {pickableRows.length > 0 && (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 dark:border-emerald-900 dark:bg-emerald-950">
+          <div className="flex items-center gap-2 text-xs">
+            <input
+              type="checkbox"
+              checked={allPickableSelected}
+              onChange={toggleAllPickable}
+              className="h-4 w-4"
+            />
+            <span className="text-zinc-700 dark:text-zinc-200">
+              全選可取訂單
+              <span className="ml-1 text-zinc-500">
+                (本頁可取 {pickableRows.length} 筆 · 已選 {selected.size})
+              </span>
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            {selected.size > 0 && (
+              <button
+                onClick={() => setSelected(new Set())}
+                className="text-xs text-zinc-600 hover:underline dark:text-zinc-300"
+              >
+                取消選取
+              </button>
+            )}
+            <button
+              onClick={bulkPickup}
+              disabled={selected.size === 0 || bulkBusy}
+              className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-300 disabled:text-emerald-700 dark:disabled:bg-emerald-950 dark:disabled:text-emerald-400"
+            >
+              {bulkBusy ? "處理中…" : `✅ 取貨並列印整合單${selected.size > 0 ? ` (${selected.size})` : ""}`}
+            </button>
+          </div>
+        </div>
+      )}
+
       <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr>
+              <Th className="w-10">
+                <input
+                  type="checkbox"
+                  checked={allPickableSelected}
+                  onChange={toggleAllPickable}
+                  disabled={pickableRows.length === 0}
+                  className="h-4 w-4"
+                  aria-label="全選可取訂單"
+                />
+              </Th>
               <Th>開團</Th><Th>會員 / 暱稱</Th><Th>取貨店</Th><Th className="text-right">項數</Th><Th className="text-right">總數量</Th><Th className="text-right">總金額</Th><Th className="text-right">日期</Th><Th className="text-right">操作</Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={8} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={9} className="p-3 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={8} className="p-6 text-center text-zinc-500">{total === 0 && campaignIds.length === 0 && !status && !storeId ? "尚無訂單。" : "沒有符合條件的訂單。"}</td></tr>
+              <tr><td colSpan={9} className="p-6 text-center text-zinc-500">{total === 0 && campaignIds.length === 0 && !status && !storeId ? "尚無訂單。" : "沒有符合條件的訂單。"}</td></tr>
             ) : rows.map((r) => {
               const m = r.member_id ? members.get(r.member_id) : null;
               const c = campaignMap.get(r.campaign_id);
@@ -304,6 +457,20 @@ function OrdersListContent() {
                       : "odd:bg-white even:bg-zinc-50 hover:bg-zinc-100 dark:odd:bg-zinc-950 dark:even:bg-zinc-900 dark:hover:bg-zinc-800"
                   }
                 >
+                  <Td className="w-10">
+                    {pickupReady.get(r.id) === true &&
+                      !["completed", "expired", "cancelled", "transferred_out"].includes(
+                        r.status,
+                      ) && (
+                        <input
+                          type="checkbox"
+                          checked={selected.has(r.id)}
+                          onChange={() => toggleSelected(r.id)}
+                          className="h-4 w-4"
+                          aria-label={`選取訂單 ${r.order_no}`}
+                        />
+                      )}
+                  </Td>
                   <Td>
                     <button
                       onClick={() => { setDetailId(r.id); setDetailNo(r.order_no); }}
@@ -316,9 +483,14 @@ function OrdersListContent() {
                           <div className="min-w-0 flex-1 space-y-0.5">
                             <div className="text-xs text-zinc-500 break-words">{c.name}</div>
                             {(itemSummary.get(r.id)?.items ?? []).map((it, idx) => (
-                              <div key={idx} className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 break-words">
-                                {it.name}
-                                <span className="ml-1 text-xs font-normal text-zinc-500">× {it.qty}</span>
+                              <div
+                                key={idx}
+                                className="break-words text-base font-bold text-zinc-900 dark:text-zinc-100"
+                              >
+                                {it.variant_name || it.product_name || "—"}
+                                <span className="ml-1.5 text-xs font-normal text-zinc-500">
+                                  × {it.qty}
+                                </span>
                               </div>
                             ))}
                           </div>

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -97,14 +97,21 @@ function Body() {
   if (error) return <div className="p-6 text-sm text-red-700">{error}</div>;
   if (!receipts) return <div className="p-6 text-sm text-zinc-500">載入中…</div>;
 
+  const combined = receipts.length > 1;
+  const grandTotal = receipts.reduce(
+    (s, r) => s + r.items.reduce((a, it) => a + Number(it.qty) * Number(it.unit_price), 0),
+    0,
+  );
+
   return (
     <>
       <style jsx global>{`
         @media print {
-          @page { margin: 10mm; }
+          @page { margin: 8mm; }
           body { background: white !important; }
           .no-print { display: none !important; }
-          .receipt { page-break-inside: avoid; }
+          .receipt-single { page-break-inside: avoid; }
+          .order-block { page-break-inside: avoid; }
         }
       `}</style>
       <div className="mx-auto max-w-2xl p-6">
@@ -112,76 +119,147 @@ function Body() {
           <button onClick={() => window.print()} className="rounded-md bg-zinc-900 px-4 py-2 text-sm text-white hover:bg-zinc-700">🖨️ 列印</button>
           <button onClick={() => window.close()} className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100">關閉</button>
         </div>
-        {receipts.length > 1 && (
-          <div className="mb-3 text-center">
-            <h1 className="text-xl font-bold">取貨單（共 {receipts.length} 張）</h1>
+
+        {combined ? (
+          /* 整合單模式 — 多筆訂單共用 1 個 header / 1 組簽名,各訂單緊湊排列 */
+          <div className="bg-white text-zinc-900">
+            <div className="mb-3 border-b-2 border-zinc-700 pb-2 text-center">
+              <h1 className="text-xl font-bold">取貨整合單</h1>
+              <div className="mt-0.5 text-xs text-zinc-600">
+                共 {receipts.length} 張訂單 · 列印時間 {new Date().toLocaleString("zh-TW")} · 合計 $
+                {grandTotal.toLocaleString()}
+              </div>
+            </div>
+
+            {receipts.map((r, idx) => {
+              const sub = r.items.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0);
+              return (
+                <div
+                  key={r.event.id}
+                  className={`order-block ${idx > 0 ? "mt-3 border-t border-dashed border-zinc-400 pt-3" : ""}`}
+                >
+                  <div className="mb-1.5 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5 text-xs">
+                    <span className="font-mono text-sm font-bold">{r.order?.order_no ?? "—"}</span>
+                    <span>
+                      {r.order?.member?.name ?? "—"}
+                      {r.order?.member?.phone && (
+                        <span className="ml-1 font-mono text-zinc-600">{r.order.member.phone}</span>
+                      )}
+                    </span>
+                    <span className="text-zinc-600">{r.order?.store?.name ?? "—"}</span>
+                    <span className="text-zinc-600">{r.order?.campaign?.name ?? "—"}</span>
+                  </div>
+                  <table className="w-full border-collapse text-xs">
+                    <tbody>
+                      {r.items.map((it) => {
+                        const itSub = Number(it.qty) * Number(it.unit_price);
+                        return (
+                          <tr key={it.id} className="border-b border-zinc-200">
+                            <td className="px-1 py-0.5">
+                              <span className="font-medium">
+                                {it.sku?.variant_name ?? it.sku?.product_name ?? "—"}
+                              </span>
+                              {it.sku?.sku_code && (
+                                <span className="ml-1 font-mono text-[9px] text-zinc-500">
+                                  {it.sku.sku_code}
+                                </span>
+                              )}
+                            </td>
+                            <td className="px-1 py-0.5 text-right font-mono">× {Number(it.qty)}</td>
+                            <td className="px-1 py-0.5 text-right font-mono text-zinc-500">
+                              ${Number(it.unit_price)}
+                            </td>
+                            <td className="px-1 py-0.5 text-right font-mono">${itSub}</td>
+                          </tr>
+                        );
+                      })}
+                      <tr className="font-bold">
+                        <td colSpan={3} className="px-1 py-0.5 text-right">本單小計</td>
+                        <td className="px-1 py-0.5 text-right font-mono">${sub}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  {r.event.notes && (
+                    <div className="mt-1 text-[10px] text-zinc-600">備註：{r.event.notes}</div>
+                  )}
+                </div>
+              );
+            })}
+
+            <div className="mt-3 border-t-2 border-zinc-700 pt-2 text-right text-sm font-bold">
+              合計 ${grandTotal.toLocaleString()}
+            </div>
+            <div className="mt-6 grid grid-cols-2 gap-8 text-xs">
+              <div className="border-t border-zinc-400 pt-2 text-center">顧客簽名</div>
+              <div className="border-t border-zinc-400 pt-2 text-center">店員簽名</div>
+            </div>
           </div>
-        )}
-        {receipts.map((r, i) => (
-          <div key={r.event.id} className={`receipt bg-white p-4 text-zinc-900 ${i < receipts.length - 1 ? "border-b-2 border-dashed border-zinc-400" : ""}`}>
-            {receipts.length === 1 && (
+        ) : (
+          /* 單筆模式 — 維持原本格式 */
+          receipts.map((r) => (
+            <div key={r.event.id} className="receipt-single bg-white p-4 text-zinc-900">
               <div className="mb-3 text-center">
                 <h1 className="text-xl font-bold">取貨單</h1>
                 <div className="text-xs text-zinc-500">
                   {r.event.event_type === "picked_up" ? "全部取貨" : "部分取貨"}
                 </div>
               </div>
-            )}
 
-            <div className="mb-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-              <Field label="訂單號" value={<span className="font-mono font-semibold">{r.order?.order_no ?? "—"}</span>} />
-              <Field label="取貨時間" value={new Date(r.event.created_at).toLocaleString("zh-TW")} />
-              <Field label="會員" value={r.order?.member ? `${r.order.member.name ?? "—"} (${r.order.member.member_no})` : "—"} />
-              <Field label="電話" value={r.order?.member?.phone ?? "—"} />
-              <Field label="取貨店" value={r.order?.store?.name ?? "—"} />
-              <Field label="開團" value={r.order?.campaign ? `${r.order.campaign.campaign_no} ${r.order.campaign.name}` : "—"} />
+              <div className="mb-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                <Field label="訂單號" value={<span className="font-mono font-semibold">{r.order?.order_no ?? "—"}</span>} />
+                <Field label="取貨時間" value={new Date(r.event.created_at).toLocaleString("zh-TW")} />
+                <Field label="會員" value={r.order?.member ? `${r.order.member.name ?? "—"} (${r.order.member.member_no})` : "—"} />
+                <Field label="電話" value={r.order?.member?.phone ?? "—"} />
+                <Field label="取貨店" value={r.order?.store?.name ?? "—"} />
+                <Field label="開團" value={r.order?.campaign ? `${r.order.campaign.campaign_no} ${r.order.campaign.name}` : "—"} />
+              </div>
+
+              <table className="mb-2 w-full border-collapse text-xs">
+                <thead>
+                  <tr className="border-b-2 border-zinc-400">
+                    <th className="px-2 py-1 text-left">商品</th>
+                    <th className="px-2 py-1 text-right">數量</th>
+                    <th className="px-2 py-1 text-right">單價</th>
+                    <th className="px-2 py-1 text-right">小計</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {r.items.map((it) => {
+                    const sub = Number(it.qty) * Number(it.unit_price);
+                    return (
+                      <tr key={it.id} className="border-b border-zinc-200">
+                        <td className="px-2 py-1">
+                          {it.sku?.variant_name ?? it.sku?.product_name ?? "—"}
+                          {it.sku?.sku_code && <span className="ml-1 font-mono text-[10px] text-zinc-500">{it.sku.sku_code}</span>}
+                        </td>
+                        <td className="px-2 py-1 text-right font-mono">{Number(it.qty)}</td>
+                        <td className="px-2 py-1 text-right font-mono">${Number(it.unit_price)}</td>
+                        <td className="px-2 py-1 text-right font-mono">${sub}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+                <tfoot>
+                  <tr className="border-t-2 border-zinc-400 font-bold">
+                    <td colSpan={3} className="px-2 py-2 text-right">合計</td>
+                    <td className="px-2 py-2 text-right font-mono">
+                      ${r.items.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0)}
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+
+              {r.event.notes && (
+                <div className="mb-2 text-xs text-zinc-600">備註：{r.event.notes}</div>
+              )}
+
+              <div className="mt-4 grid grid-cols-2 gap-8 text-xs">
+                <div className="border-t border-zinc-400 pt-2 text-center">顧客簽名</div>
+                <div className="border-t border-zinc-400 pt-2 text-center">店員簽名</div>
+              </div>
             </div>
-
-            <table className="mb-2 w-full border-collapse text-xs">
-              <thead>
-                <tr className="border-b-2 border-zinc-400">
-                  <th className="px-2 py-1 text-left">商品</th>
-                  <th className="px-2 py-1 text-right">數量</th>
-                  <th className="px-2 py-1 text-right">單價</th>
-                  <th className="px-2 py-1 text-right">小計</th>
-                </tr>
-              </thead>
-              <tbody>
-                {r.items.map((it) => {
-                  const sub = Number(it.qty) * Number(it.unit_price);
-                  return (
-                    <tr key={it.id} className="border-b border-zinc-200">
-                      <td className="px-2 py-1">
-                        {it.sku?.variant_name ?? it.sku?.product_name ?? "—"}
-                        {it.sku?.sku_code && <span className="ml-1 font-mono text-[10px] text-zinc-500">{it.sku.sku_code}</span>}
-                      </td>
-                      <td className="px-2 py-1 text-right font-mono">{Number(it.qty)}</td>
-                      <td className="px-2 py-1 text-right font-mono">${Number(it.unit_price)}</td>
-                      <td className="px-2 py-1 text-right font-mono">${sub}</td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-              <tfoot>
-                <tr className="border-t-2 border-zinc-400 font-bold">
-                  <td colSpan={3} className="px-2 py-2 text-right">合計</td>
-                  <td className="px-2 py-2 text-right font-mono">
-                    ${r.items.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0)}
-                  </td>
-                </tr>
-              </tfoot>
-            </table>
-
-            {r.event.notes && (
-              <div className="mb-2 text-xs text-zinc-600">備註：{r.event.notes}</div>
-            )}
-          </div>
-        ))}
-
-        <div className="mt-4 grid grid-cols-2 gap-8 text-xs">
-          <div className="border-t border-zinc-400 pt-2 text-center">顧客簽名</div>
-          <div className="border-t border-zinc-400 pt-2 text-center">店員簽名</div>
-        </div>
+          ))
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

### 1. 訂單批次取貨
- 表頭加勾選欄,只能勾「可取貨且未終結」的訂單
- 上方工具列(有可取訂單時出現): 全選 checkbox / 已選計數 / 取消選取 /「✅ 取貨並列印整合單 (N)」
- `bulkPickup()` 一次抓所有勾選訂單的 pickable items,連續呼 `rpc_record_pickup`,收集 event_ids,最後開合併列印頁
- 部分失敗仍會列印已成功部分,並 alert 列出失敗的

### 2. 品項只顯示 SKU(variant_name)
依使用者指示「訂單的品項不用再出現商品名稱了 只需要 sku」:
- `itemSummary.items` 從合併字串 `"product / variant"` 改保留 `{ product_name, variant_name, qty }`
- JSX 只渲染 `variant_name`,沒 variant 才 fallback `product_name`
- 字級 `text-sm semibold` → `text-base bold`,品項更明顯

### 3. /pickup/print 整合列印
- 多筆 event_ids 走「取貨整合單」緊湊版面: 1 個 header / 1 組簽名欄 / 各訂單只 1 行 meta + 緊湊 items 表 / 末尾大字合計
- 單筆走原本完整收據版面
- `@page margin 10mm → 8mm`,`page-break-inside` 從 `.receipt` 移到 `.order-block`

## Test plan
- [x] `npm run build -w apps/admin` 綠燈
- [ ] 部署後實機驗證:
  - /orders 勾選 2-3 張可取訂單 → 點「取貨並列印整合單」→ 看到單一 PDF/列印頁含全部訂單
  - 訂單列品項只顯示 SKU(粗體大字)、商品名稱不再出現

🤖 Generated with [Claude Code](https://claude.com/claude-code)