### PR TITLE
feat(admin): /orders 加 3 個 tab — 未取貨 / 已完成 / 取消

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { MemberForm, type MemberFormValues } from "@/components/MemberForm";
@@ -28,16 +29,7 @@ function displayPhone(p: string | null): string {
   return p;
 }
 
-type Tier = { id: number; code: string; name: string };
 type Store = { id: number; code: string; name: string };
-
-const STATUS_LABEL: Record<Status, string> = {
-  active: "活躍",
-  inactive: "停用",
-  blocked: "封鎖",
-  merged: "已合併",
-  deleted: "已刪除",
-};
 
 const PAGE_SIZE = 50;
 
@@ -49,14 +41,11 @@ export default function MembersListPage() {
 
   const [queryDraft, setQueryDraft] = useState("");
   const [query, setQuery] = useState("");
-  const [tierId, setTierId] = useState<string>("");
-  const [status, setStatus] = useState<string>("");
   const [storeId, setStoreId] = useState<string>("");
   const [sortBy, setSortBy] = useState<SortKey>("updated_at");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [page, setPage] = useState(1);
 
-  const [tiers, setTiers] = useState<Tier[]>([]);
   const [stores, setStores] = useState<Store[]>([]);
   const [balances, setBalances] = useState<Map<number, { points: number; wallet: number }>>(new Map());
   const [reloadTick, setReloadTick] = useState(0);
@@ -77,21 +66,21 @@ export default function MembersListPage() {
 
   useEffect(() => {
     setPage(1);
-  }, [tierId, status, storeId, sortBy, sortDir]);
+  }, [storeId, sortBy, sortDir]);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const [t, s] = await Promise.all([
-        getSupabase().from("member_tiers").select("id, code, name").order("sort_order"),
-        getSupabase().from("stores").select("id, code, name").eq("is_active", true).order("name"),
-      ]);
+      const s = await getSupabase()
+        .from("stores")
+        .select("id, code, name")
+        .eq("is_active", true)
+        .order("name");
       if (cancelled) return;
-      if (t.error || s.error) {
-        setError(t.error?.message ?? s.error?.message ?? "載入篩選選項失敗");
+      if (s.error) {
+        setError(s.error.message);
         return;
       }
-      setTiers((t.data ?? []) as Tier[]);
       setStores((s.data ?? []) as Store[]);
     })();
     return () => {
@@ -114,8 +103,6 @@ export default function MembersListPage() {
           const safe = query.replace(/[%,()]/g, " ").trim();
           q = q.or(`name.ilike.%${safe}%,phone.ilike.%${safe}%,member_no.ilike.%${safe}%`);
         }
-        if (tierId) q = q.eq("tier_id", Number(tierId));
-        if (status) q = q.eq("status", status);
         if (storeId) q = q.eq("home_store_id", Number(storeId));
 
         const { data, count, error } = await q;
@@ -157,9 +144,8 @@ export default function MembersListPage() {
     return () => {
       cancelled = true;
     };
-  }, [query, tierId, status, storeId, sortBy, sortDir, page, reloadTick]);
+  }, [query, storeId, sortBy, sortDir, page, reloadTick]);
 
-  const tierMap = useMemo(() => new Map(tiers.map((t) => [t.id, t])), [tiers]);
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const fromIdx = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
   const toIdx = Math.min(page * PAGE_SIZE, total);
@@ -181,15 +167,23 @@ export default function MembersListPage() {
             {loading ? "載入中…" : total === 0 ? "共 0 筆" : `共 ${total} 筆（顯示 ${fromIdx}-${toIdx}）`}
           </p>
         </div>
-        <button
-          onClick={() => setModal({ mode: "new" })}
-          className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-        >
-          新增會員
-        </button>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/pickup"
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
+          >
+            🔎 查詢會員訂單
+          </Link>
+          <button
+            onClick={() => setModal({ mode: "new" })}
+            className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            新增會員
+          </button>
+        </div>
       </header>
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-3 sm:grid-cols-2">
         <input
           type="search"
           placeholder="搜尋 會員編號 / 姓名 / 手機"
@@ -197,28 +191,6 @@ export default function MembersListPage() {
           onChange={(e) => setQueryDraft(e.target.value)}
           className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
         />
-        <select
-          value={tierId}
-          onChange={(e) => setTierId(e.target.value)}
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-        >
-          <option value="">全部等級</option>
-          {tiers.map((t) => (
-            <option key={t.id} value={t.id}>
-              {t.name}
-            </option>
-          ))}
-        </select>
-        <select
-          value={status}
-          onChange={(e) => setStatus(e.target.value)}
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-        >
-          <option value="">全部狀態</option>
-          <option value="active">活躍</option>
-          <option value="inactive">停用</option>
-          <option value="blocked">封鎖</option>
-        </select>
         <select
           value={storeId}
           onChange={(e) => setStoreId(e.target.value)}
@@ -247,21 +219,19 @@ export default function MembersListPage() {
               <ThSort label="編號" col="member_no" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
               <ThSort label="姓名" col="name" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
               <Th>手機</Th>
-              <Th>等級</Th>
               <Th className="text-right">積分</Th>
               <Th className="text-right">儲值</Th>
-              <Th>狀態</Th>
               <ThSort label="更新" col="updated_at" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} align="right" />
               <Th>{""}</Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <SkeletonRows cols={9} />
+              <SkeletonRows cols={7} />
             ) : rows.length === 0 ? (
               <tr>
-                <td colSpan={9} className="p-6 text-center text-sm text-zinc-500">
-                  {total === 0 && !query && !tierId && !status
+                <td colSpan={7} className="p-6 text-center text-sm text-zinc-500">
+                  {total === 0 && !query
                     ? "還沒有會員，按「新增會員」開始建立。"
                     : "沒有符合條件的會員。"}
                 </td>
@@ -293,14 +263,8 @@ export default function MembersListPage() {
                       </div>
                     </Td>
                     <Td className="font-mono text-xs">{displayPhone(r.phone)}</Td>
-                    <Td className="text-xs text-zinc-600 dark:text-zinc-400">
-                      {r.tier_id ? tierMap.get(r.tier_id)?.name ?? "—" : "—"}
-                    </Td>
                     <Td className="text-right font-mono">{bal?.points?.toLocaleString() ?? "—"}</Td>
                     <Td className="text-right font-mono">{bal?.wallet?.toLocaleString() ?? "—"}</Td>
-                    <Td>
-                      <StatusBadge status={r.status} />
-                    </Td>
                     <Td className="text-right text-zinc-500">
                       {new Date(r.updated_at).toLocaleString("zh-TW")}
                     </Td>
@@ -391,17 +355,6 @@ function ThSort({
 
 function Td({ children, className = "" }: { children: React.ReactNode; className?: string }) {
   return <td className={`px-4 py-3 ${className}`}>{children}</td>;
-}
-
-function StatusBadge({ status }: { status: Status }) {
-  const styles: Record<Status, string> = {
-    active: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
-    inactive: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
-    blocked: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
-    merged: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
-    deleted: "bg-zinc-100 text-zinc-500 line-through dark:bg-zinc-800",
-  };
-  return <span className={`inline-block rounded px-2 py-0.5 text-xs ${styles[status]}`}>{STATUS_LABEL[status]}</span>;
 }
 
 function SkeletonRows({ cols }: { cols: number }) {

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -38,6 +38,18 @@ const STATUS_LABEL: Record<OrderStatus, string> = {
   transferred_out: "已轉出",
 };
 
+type Tab = "pending" | "completed" | "cancelled";
+const TABS: { value: Tab; label: string }[] = [
+  { value: "pending", label: "未取貨" },
+  { value: "completed", label: "已完成" },
+  { value: "cancelled", label: "取消" },
+];
+const PENDING_STATUSES: OrderStatus[] = [
+  "pending", "confirmed", "reserved", "shipping",
+  "ready", "partially_ready", "partially_completed",
+];
+const CANCELLED_STATUSES: OrderStatus[] = ["cancelled", "expired"];
+
 const PAGE_SIZE = 50;
 
 export default function OrdersListPage() {
@@ -57,7 +69,11 @@ function OrdersListContent() {
     const single = searchParams.get("campaignId");
     return single ? [single] : [];
   })();
-  const initialStatus = searchParams.get("status") ?? "";
+  const initialTab: Tab = (() => {
+    const t = searchParams.get("tab");
+    if (t === "pending" || t === "completed" || t === "cancelled") return t;
+    return "pending";
+  })();
   const initialStoreId = searchParams.get("storeId") ?? "";
 
   const [rows, setRows] = useState<Row[] | null>(null);
@@ -66,8 +82,9 @@ function OrdersListContent() {
   const [error, setError] = useState<string | null>(null);
 
   const [campaignIds, setCampaignIds] = useState<string[]>(initialCampaignIds);
-  const [status, setStatus] = useState(initialStatus);
+  const [tab, setTab] = useState<Tab>(initialTab);
   const [storeId, setStoreId] = useState(initialStoreId);
+  const [tabCounts, setTabCounts] = useState<Record<Tab, number> | null>(null);
   const [page, setPage] = useState(1);
   const [campaignPickerOpen, setCampaignPickerOpen] = useState(false);
 
@@ -93,7 +110,7 @@ function OrdersListContent() {
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
 
-  useEffect(() => { setPage(1); }, [campaignIds, status, storeId]);
+  useEffect(() => { setPage(1); setSelected(new Set()); }, [campaignIds, tab, storeId]);
 
   useEffect(() => {
     (async () => {
@@ -120,8 +137,10 @@ function OrdersListContent() {
 
         if (campaignIds.length === 1) q = q.eq("campaign_id", Number(campaignIds[0]));
         else if (campaignIds.length > 1) q = q.in("campaign_id", campaignIds.map((x) => Number(x)));
-        if (status) q = q.eq("status", status);
-        else q = q.neq("status", "transferred_out"); // 預設隱藏已轉出（5a-1：視同關閉、金額/數量不入統計）
+        // 依 tab 套狀態過濾;一律隱藏 transferred_out (視同關閉、金額/數量不入統計)
+        if (tab === "completed") q = q.eq("status", "completed");
+        else if (tab === "cancelled") q = q.in("status", CANCELLED_STATUSES);
+        else q = q.in("status", PENDING_STATUSES);
         if (storeId) q = q.eq("pickup_store_id", Number(storeId));
 
         const { data, count, error } = await q;
@@ -172,7 +191,34 @@ function OrdersListContent() {
       }
     })();
     return () => { cancelled = true; };
-  }, [campaignIds, status, storeId, page, reloadOrders]);
+  }, [campaignIds, tab, storeId, page, reloadOrders]);
+
+  // 各 tab 數量 — 切 tab 不重抓,只在其他 filter / reload 時更新
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const buildBase = () => {
+        let q = sb.from("customer_orders").select("id", { count: "exact", head: true });
+        if (campaignIds.length === 1) q = q.eq("campaign_id", Number(campaignIds[0]));
+        else if (campaignIds.length > 1) q = q.in("campaign_id", campaignIds.map((x) => Number(x)));
+        if (storeId) q = q.eq("pickup_store_id", Number(storeId));
+        return q;
+      };
+      const [p, c, x] = await Promise.all([
+        buildBase().in("status", PENDING_STATUSES),
+        buildBase().eq("status", "completed"),
+        buildBase().in("status", CANCELLED_STATUSES),
+      ]);
+      if (cancelled) return;
+      setTabCounts({
+        pending: p.count ?? 0,
+        completed: c.count ?? 0,
+        cancelled: x.count ?? 0,
+      });
+    })();
+    return () => { cancelled = true; };
+  }, [campaignIds, storeId, reloadOrders]);
 
   const campaignMap = useMemo(() => new Map(campaigns.map((c) => [c.id, c])), [campaigns]);
   const storeMap = useMemo(() => new Map(stores.map((s) => [s.id, s])), [stores]);
@@ -306,6 +352,35 @@ function OrdersListContent() {
         </div>
       </header>
 
+      {/* Tab bar — 未取貨 / 已完成 / 取消;含各 tab 數量 */}
+      <div className="flex items-center gap-1 border-b border-zinc-200 dark:border-zinc-800">
+        {TABS.map((t) => {
+          const active = tab === t.value;
+          const count = tabCounts?.[t.value];
+          return (
+            <button
+              key={t.value}
+              onClick={() => setTab(t.value)}
+              className={`relative px-4 py-2 text-sm font-medium transition-colors ${
+                active
+                  ? "text-zinc-900 dark:text-zinc-100"
+                  : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+              }`}
+            >
+              {t.label}
+              {count !== undefined && (
+                <span className={`ml-1.5 ${active ? "" : "text-zinc-400 dark:text-zinc-500"}`}>
+                  ({count})
+                </span>
+              )}
+              {active && (
+                <span className="absolute -bottom-px left-0 right-0 h-0.5 bg-zinc-900 dark:bg-zinc-100" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
       <div className="grid gap-3 sm:grid-cols-3">
         <div className="relative">
           <button
@@ -363,11 +438,6 @@ function OrdersListContent() {
             </div>
           )}
         </div>
-        <select value={status} onChange={(e) => setStatus(e.target.value)}
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
-          <option value="">全部狀態</option>
-          {Object.entries(STATUS_LABEL).map(([v, l]) => <option key={v} value={v}>{l}</option>)}
-        </select>
         <select value={storeId} onChange={(e) => setStoreId(e.target.value)}
           className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
           <option value="">全部取貨店</option>
@@ -439,7 +509,7 @@ function OrdersListContent() {
             {rows === null ? (
               <tr><td colSpan={9} className="p-3 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={9} className="p-6 text-center text-zinc-500">{total === 0 && campaignIds.length === 0 && !status && !storeId ? "尚無訂單。" : "沒有符合條件的訂單。"}</td></tr>
+              <tr><td colSpan={9} className="p-6 text-center text-zinc-500">{total === 0 && campaignIds.length === 0 && !storeId ? `此 tab 下尚無訂單。` : "沒有符合條件的訂單。"}</td></tr>
             ) : rows.map((r) => {
               const m = r.member_id ? members.get(r.member_id) : null;
               const c = campaignMap.get(r.campaign_id);

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -48,7 +48,7 @@ function activeItems(order: OpenOrder) {
 }
 
 export default function PickupPage() {
-  const [suffix, setSuffix] = useState("");
+  const [query, setQuery] = useState("");
   const [searching, setSearching] = useState(false);
   const [members, setMembers] = useState<Member[] | null>(null);
   const [orders, setOrders] = useState<Map<number, OpenOrder[]>>(new Map());
@@ -62,8 +62,9 @@ export default function PickupPage() {
 
   async function search(e?: React.FormEvent) {
     e?.preventDefault();
-    if (suffix.length < 3) {
-      setError("請至少輸入 3 碼（建議後 6 碼）");
+    const q = query.trim();
+    if (q.length < 2) {
+      setError("請至少輸入 2 字 (姓名 / 電話末 N 碼 / 會員編號)");
       return;
     }
     setSearching(true);
@@ -72,10 +73,12 @@ export default function PickupPage() {
     setOrders(new Map());
     try {
       const sb = getSupabase();
+      // 一個關鍵字同時對 name / phone / member_no 做 ilike,任一命中皆列出
+      const safe = q.replace(/[%,()]/g, " ");
       const { data: ms, error: e1 } = await sb
         .from("members")
         .select("id, member_no, name, phone")
-        .like("phone", `%${suffix}`)
+        .or(`name.ilike.%${safe}%,phone.ilike.%${safe}%,member_no.ilike.%${safe}%`)
         .neq("status", "deleted")
         .order("last_visit_at", { ascending: false, nullsFirst: false })
         .limit(20);
@@ -188,26 +191,24 @@ export default function PickupPage() {
     <div className="flex flex-1 flex-col gap-4 p-6">
       <header>
         <h1 className="text-xl font-semibold">取貨</h1>
-        <p className="text-sm text-zinc-500">輸入顧客電話後幾碼（建議 6 碼）→ 找出本人未取訂單 → 確認取貨。</p>
+        <p className="text-sm text-zinc-500">輸入 姓名 / 電話末 N 碼 / 會員編號 → 找出本人未取訂單 → 確認取貨。</p>
       </header>
 
       <form onSubmit={search} className="flex items-end gap-2">
-        <label className="text-sm">
-          <span className="mb-1 block text-xs text-zinc-500">電話後 N 碼（≥3）</span>
+        <label className="text-sm flex-1 max-w-md">
+          <span className="mb-1 block text-xs text-zinc-500">姓名 / 電話 / 會員編號</span>
           <input
-            type="tel"
-            inputMode="numeric"
-            pattern="\d*"
-            value={suffix}
-            onChange={(e) => setSuffix(e.target.value.replace(/\D/g, "").slice(0, 10))}
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
             autoFocus
-            placeholder="123456"
-            className="w-40 rounded-md border border-zinc-300 bg-white px-3 py-2 text-lg font-mono dark:border-zinc-700 dark:bg-zinc-800"
+            placeholder="例: 王小明 / 123456 / M20260501..."
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-base dark:border-zinc-700 dark:bg-zinc-800"
           />
         </label>
         <button
           type="submit"
-          disabled={searching || suffix.length < 3}
+          disabled={searching || query.trim().length < 2}
           className="rounded-md bg-zinc-900 px-4 py-2 text-sm text-white transition hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
         >
           {searching ? "搜尋中…" : "🔍 搜尋"}
@@ -215,7 +216,7 @@ export default function PickupPage() {
         {(members || error) && (
           <button
             type="button"
-            onClick={() => { setSuffix(""); setMembers(null); setOrders(new Map()); setError(null); }}
+            onClick={() => { setQuery(""); setMembers(null); setOrders(new Map()); setError(null); }}
             className="rounded-md border border-zinc-300 px-3 py-2 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
           >
             清空


### PR DESCRIPTION
## Summary

訂單頁加 3 個 tab 取代「全部狀態」下拉。

| Tab | 對應 status |
|---|---|
| 未取貨 (default) | pending, confirmed, reserved, shipping, ready, partially_ready, partially_completed |
| 已完成 | completed |
| 取消 | cancelled, expired |

`transferred_out` 一律隱藏(視同關閉)。

URL: `?tab=pending|completed|cancelled`(舊 `?status=` 不再支援)。

`tabCounts` 額外查 3 個 head-only count,標籤後顯示 `(N)`,只在 campaignIds/storeId/reload 變動時 refetch(切 tab 不重抓)。切 tab 自動清空 selected。

## Test plan
- [x] `npm run build -w apps/admin` 綠燈
- [ ] 部署後實機:三個 tab 切換、計數正確、批次取貨工具列僅在「未取貨」tab 出現

🤖 Generated with [Claude Code](https://claude.com/claude-code)