### PR TITLE
fix(admin): /members 「查訂單」每筆 row 後面 + /pickup 接 ?q= 自動搜

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -167,20 +167,12 @@ export default function MembersListPage() {
             {loading ? "載入中…" : total === 0 ? "共 0 筆" : `共 ${total} 筆（顯示 ${fromIdx}-${toIdx}）`}
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <Link
-            href="/pickup"
-            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
-          >
-            🔎 查詢會員訂單
-          </Link>
-          <button
-            onClick={() => setModal({ mode: "new" })}
-            className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-          >
-            新增會員
-          </button>
-        </div>
+        <button
+          onClick={() => setModal({ mode: "new" })}
+          className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          新增會員
+        </button>
       </header>
 
       <div className="grid gap-3 sm:grid-cols-2">
@@ -269,25 +261,33 @@ export default function MembersListPage() {
                       {new Date(r.updated_at).toLocaleString("zh-TW")}
                     </Td>
                     <Td>
-                      <button
-                        onClick={async () => {
-                          const { data } = await getSupabase()
-                            .from("members")
-                            .select("id, member_no, phone, name, gender, birthday, email, tier_id, home_store_id, status, notes")
-                            .eq("id", r.id).maybeSingle();
-                          if (data) setModal({ mode: "edit", values: {
-                            id: data.id, member_no: data.member_no,
-                            // LIFF auto-register 的 placeholder「line:<uid>」不要灌進編輯表單
-                            phone: data.phone && !data.phone.startsWith("line:") ? data.phone : "",
-                            name: data.name ?? "", gender: data.gender, birthday: data.birthday,
-                            email: data.email, tier_id: data.tier_id, home_store_id: data.home_store_id,
-                            status: data.status, notes: data.notes,
-                          }});
-                        }}
-                        className="text-xs text-blue-600 hover:underline dark:text-blue-400"
-                      >
-                        編輯
-                      </button>
+                      <div className="flex items-center justify-end gap-3">
+                        <Link
+                          href={`/pickup?q=${encodeURIComponent(r.member_no)}`}
+                          className="text-xs text-emerald-600 hover:underline dark:text-emerald-400"
+                        >
+                          🔎 查訂單
+                        </Link>
+                        <button
+                          onClick={async () => {
+                            const { data } = await getSupabase()
+                              .from("members")
+                              .select("id, member_no, phone, name, gender, birthday, email, tier_id, home_store_id, status, notes")
+                              .eq("id", r.id).maybeSingle();
+                            if (data) setModal({ mode: "edit", values: {
+                              id: data.id, member_no: data.member_no,
+                              // LIFF auto-register 的 placeholder「line:<uid>」不要灌進編輯表單
+                              phone: data.phone && !data.phone.startsWith("line:") ? data.phone : "",
+                              name: data.name ?? "", gender: data.gender, birthday: data.birthday,
+                              email: data.email, tier_id: data.tier_id, home_store_id: data.home_store_id,
+                              status: data.status, notes: data.notes,
+                            }});
+                          }}
+                          className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                        >
+                          編輯
+                        </button>
+                      </div>
                     </Td>
                   </tr>
                 );

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { PickupDialog } from "@/components/PickupDialog";
@@ -48,12 +49,23 @@ function activeItems(order: OpenOrder) {
 }
 
 export default function PickupPage() {
-  const [query, setQuery] = useState("");
+  return (
+    <Suspense fallback={<div className="p-6 text-sm text-zinc-500">載入中…</div>}>
+      <PickupPageContent />
+    </Suspense>
+  );
+}
+
+function PickupPageContent() {
+  const searchParams = useSearchParams();
+  const initialQuery = searchParams.get("q") ?? "";
+  const [query, setQuery] = useState(initialQuery);
   const [searching, setSearching] = useState(false);
   const [members, setMembers] = useState<Member[] | null>(null);
   const [orders, setOrders] = useState<Map<number, OpenOrder[]>>(new Map());
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
+  const autoSearchedRef = useRef(false);
 
   const [pickup, setPickup] = useState<{ orderId: number; orderNo: string } | null>(null);
   const [bulking, setBulking] = useState<number | null>(null);
@@ -186,6 +198,15 @@ export default function PickupPage() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reloadTick]);
+
+  // 從 /members 點「查訂單」帶 ?q= 進來,首次自動觸發搜尋
+  useEffect(() => {
+    if (!autoSearchedRef.current && initialQuery.trim().length >= 2) {
+      autoSearchedRef.current = true;
+      search();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">


### PR DESCRIPTION
## Summary

接 #171 後依使用者回饋「查詢訂單是在每一筆 user row 後面」修正:

- `/members` 移除 header 的「🔎 查詢會員訂單」link
- 改成每筆 row 的 action 欄並列「🔎 查訂單 | 編輯」,綠色強調
- link 帶 `?q=<member_no>` 進 `/pickup`
- `/pickup` 用 `Suspense` 包、讀 URL `?q=` 初始化 query state、首次掛載自動觸發 search

## Test plan
- [x] `npm run build -w apps/admin` 綠燈
- [ ] /members 每筆 row 出現「🔎 查訂單」綠字按鈕,點了帶到 /pickup 並顯示該會員訂單

🤖 Generated with [Claude Code](https://claude.com/claude-code)