### PR TITLE
fix(admin): isBranchUser 型別 widening 以相容 supabase User type

### DIFF
--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -84,7 +84,7 @@ const BRANCH_HIDDEN_GROUPS = new Set([
   "社群選品", // 整個 group 隱藏
 ]);
 
-function isBranchUser(user: { app_metadata?: { stores?: unknown } } | null | undefined): boolean {
+function isBranchUser(user: { app_metadata?: Record<string, unknown> } | null | undefined): boolean {
   const stores = user?.app_metadata?.stores;
   if (!Array.isArray(stores) || stores.length === 0) return false;
   return !stores.includes("總倉");


### PR DESCRIPTION
PR #175 引入的 type error hotfix。

\`User.app_metadata: UserAppMetadata\` 跟 \`{ stores?: unknown }\` 不相容,改用 \`Record<string, unknown>\` widening,執行期 Array.isArray 檢查仍安全。

- [x] \`npm run build -w apps/admin\` 綠燈

🤖 Generated with [Claude Code](https://claude.com/claude-code)