### PR TITLE
feat(admin): /pickup 顯示活動名 + 分店帳號預設選店 + 加蔽 供應商/互助轉移單

### DIFF
--- a/apps/admin/src/app/(protected)/finance/receivables/page.tsx
+++ b/apps/admin/src/app/(protected)/finance/receivables/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 import { Modal } from "@/components/Modal";
 import { withBasePath } from "@/lib/basePath";
 import { DatePicker } from "@/components/DatePicker";
@@ -61,6 +62,7 @@ export default function ReceivablesPage() {
   const [page, setPage] = useState(1);
 
   const [stores, setStores] = useState<Map<number, Store>>(new Map());
+  useDefaultStoreFromUser(Array.from(stores.values()), storeFilter, setStoreFilter);
   const [detail, setDetail] = useState<Receivable | null>(null);
 
   useEffect(() => { setPage(1); }, [statusFilter, storeFilter]);

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -84,7 +84,7 @@ const BRANCH_HIDDEN_GROUPS = new Set([
   "社群選品", // 整個 group 隱藏
 ]);
 
-function isBranchUser(user: { app_metadata?: { stores?: unknown } } | null | undefined): boolean {
+function isBranchUser(user: { app_metadata?: Record<string, unknown> } | null | undefined): boolean {
   const stores = user?.app_metadata?.stores;
   if (!Array.isArray(stores) || stores.length === 0) return false;
   return !stores.includes("總倉");

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -73,11 +73,13 @@ const NAV_COLLAPSE_KEY = "new_erp-nav-collapsed";
 
 // 分店帳號 (app_metadata.stores 有值且不含「總倉」) 隱藏的項目
 const BRANCH_HIDDEN_HREFS = new Set([
+  "/suppliers",           // 供應商 (HQ 管理)
   "/purchase/requests",   // 採購單
   "/purchase/orders",     // 採購訂單
   "/picking/workstation", // 撿貨工作站
   "/picking/history",     // 撿貨歷史
   "/transfers/dispatch",  // 總倉派貨
+  "/transfers/aid",       // 互助轉移單(總倉檢視)
   "/finance/receivables", // HQ 應收
 ]);
 const BRANCH_HIDDEN_GROUPS = new Set([

--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 import { Modal } from "@/components/Modal";
 import { MemberForm, type MemberFormValues } from "@/components/MemberForm";
 import { MemberDetail } from "@/components/MemberDetail";
@@ -47,6 +48,7 @@ export default function MembersListPage() {
   const [page, setPage] = useState(1);
 
   const [stores, setStores] = useState<Store[]>([]);
+  useDefaultStoreFromUser(stores, storeId, setStoreId);
   const [balances, setBalances] = useState<Map<number, { points: number; wallet: number }>>(new Map());
   const [reloadTick, setReloadTick] = useState(0);
   const [modal, setModal] = useState<

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -9,6 +9,7 @@ import { OrderDetail } from "@/components/OrderDetail";
 import { PickupDialog } from "@/components/PickupDialog";
 import { translateRpcError } from "@/lib/rpcError";
 import { withBasePath } from "@/lib/basePath";
+import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 
 type OrderStatus =
   | "pending" | "confirmed" | "reserved" | "shipping" | "ready" | "partially_ready"
@@ -111,6 +112,9 @@ function OrdersListContent() {
   const [bulkBusy, setBulkBusy] = useState(false);
 
   useEffect(() => { setPage(1); setSelected(new Set()); }, [campaignIds, tab, storeId]);
+
+  // 分店帳號預設選中該分店
+  useDefaultStoreFromUser(stores, storeId, setStoreId);
 
   useEffect(() => {
     (async () => {

--- a/apps/admin/src/app/(protected)/page.tsx
+++ b/apps/admin/src/app/(protected)/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 
 type Counts = {
   products: number;
@@ -45,6 +46,7 @@ const STATUS_LABEL_ORDER: Record<string, string> = {
 export default function Dashboard() {
   const [storeId, setStoreId] = useState<string>("");
   const [stores, setStores] = useState<Store[]>([]);
+  useDefaultStoreFromUser(stores, storeId, setStoreId);
   const [counts, setCounts] = useState<Counts | null>(null);
   const [recentOrders, setRecentOrders] = useState<RecentOrder[]>([]);
   const [recentMembers, setRecentMembers] = useState<RecentMember[]>([]);

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -304,7 +304,7 @@ function PickupPageContent() {
                             <OrderThumb order={o} />
                             <div className="flex-1 text-sm">
                               <div className="flex items-baseline gap-2">
-                                <span className="font-mono font-medium">{o.order_no}</span>
+                                <span className="font-medium">{o.campaign?.name ?? "(未知活動)"}</span>
                                 <span className={`rounded px-2 py-0.5 text-[10px] font-medium ${
                                   o.status === "ready" ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300" :
                                   o.status === "partially_completed" ? "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300" :
@@ -317,11 +317,14 @@ function PickupPageContent() {
                                    o.status}
                                 </span>
                               </div>
-                              {o.campaign && (
-                                <div className="text-[10px] text-zinc-400">
-                                  <span className="font-mono">{o.campaign.campaign_no}</span> {o.campaign.name}
-                                </div>
-                              )}
+                              <ul className="mt-0.5 space-y-0.5 text-xs text-zinc-700 dark:text-zinc-300">
+                                {activeItems(o).map((it) => (
+                                  <li key={it.id} className="flex items-baseline gap-1.5">
+                                    <span className="font-medium">{it.sku?.variant_name ?? it.sku?.product_name ?? "—"}</span>
+                                    <span className="font-mono text-zinc-500">× {Number(it.qty)}</span>
+                                  </li>
+                                ))}
+                              </ul>
                               <div className="mt-1 text-xs text-zinc-500">
                                 取貨店：{o.store?.name ?? "—"}
                                 {o.pickup_deadline && <span className="ml-2">截止：{o.pickup_deadline}</span>}
@@ -396,12 +399,7 @@ function PickupPageContent() {
                   return (
                     <div key={o.id} className="text-sm">
                       <div className="mb-1">
-                        <span className="font-mono font-semibold">{o.order_no}</span>
-                        {o.campaign && (
-                          <span className="ml-2 text-[10px] text-zinc-400">
-                            {o.campaign.campaign_no} {o.campaign.name}
-                          </span>
-                        )}
+                        <span className="font-semibold">{o.campaign?.name ?? "(未知活動)"}</span>
                         <span className="ml-2 text-[10px] text-zinc-500">取貨店：{o.store?.name ?? "—"}</span>
                       </div>
                       <ul className="ml-4 space-y-0.5 text-xs">

--- a/apps/admin/src/components/CampaignOrdersPanel.tsx
+++ b/apps/admin/src/components/CampaignOrdersPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
+import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 
 type OrderRow = {
   id: number;
@@ -50,6 +51,7 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
   const [rows, setRows] = useState<OrderRow[] | null>(null);
   const [stores, setStores] = useState<Store[]>([]);
   const [storeFilter, setStoreFilter] = useState<string>("");
+  useDefaultStoreFromUser(stores, storeFilter, setStoreFilter);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {

--- a/apps/admin/src/lib/useDefaultStoreFromUser.ts
+++ b/apps/admin/src/lib/useDefaultStoreFromUser.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useAuth } from "@/components/AuthProvider";
+
+/**
+ * 分店帳號登入時,把任何「分店篩選下拉」預設選中該分店。
+ *
+ * - 使用者 app_metadata.stores 為陣列且非空 → 比對 stores[i].name 找出第一個 match
+ *   設成 storeId state (如果現在還是空的)
+ * - HQ 帳號 (沒 stores 或包含「總倉」) → 不動
+ * - 一旦套過就不再 reapply,使用者手動切回「全部」也尊重
+ *
+ * 用法:
+ *   useDefaultStoreFromUser(stores, storeId, setStoreId);
+ */
+export function useDefaultStoreFromUser(
+  stores: ReadonlyArray<{ id: number | string; name: string }>,
+  currentStoreId: string,
+  setStoreId: (v: string) => void,
+) {
+  const { user } = useAuth();
+  const appliedRef = useRef(false);
+
+  useEffect(() => {
+    if (appliedRef.current) return;
+    if (currentStoreId) {
+      // URL 或使用者已預先設過 → 不覆蓋
+      appliedRef.current = true;
+      return;
+    }
+    if (stores.length === 0) return;
+    const userStores = user?.app_metadata?.stores as unknown;
+    if (!Array.isArray(userStores) || userStores.length === 0) return;
+    if (userStores.includes("總倉")) return;
+    const match = stores.find((s) => userStores.includes(s.name));
+    if (match) {
+      setStoreId(String(match.id));
+      appliedRef.current = true;
+    }
+  }, [stores, user, currentStoreId, setStoreId]);
+}


### PR DESCRIPTION
## Summary

3 件相關的 admin UX 改動。

### 1. /pickup 訂單列改顯示活動名 + SKU 規格
原本: `GB20260504-S000001-0001` (mono 大字) + 小字 campaign_no + 名稱
改後: `🎉 日本岡田屋海老蝦餅 快團限量` (粗體) + items 列表

bulkConfirm modal 同步。

### 2. Sidebar 分店帳號補蔽
- `/suppliers` (供應商)
- `/transfers/aid` (互助轉移單(總倉檢視))

### 3. 新 hook `useDefaultStoreFromUser`
讀 `user.app_metadata.stores` 找出該使用者管的店名,比對傳入 stores 陣列,設預設 storeId。

套用到 5 個下拉:
- `/orders` (取貨店)
- `/members` (門市)
- `/finance/receivables` (分店)
- `/` 儀表板 (門市)
- `components/CampaignOrdersPanel` (modal 內分店)

HQ user 不動,使用者改回「全部」也尊重。

## Test plan
- [x] `npm run build -w apps/admin` 綠燈
- [ ] 部署後用分店帳號 `c90601189@gmail.com` (經國店) 登入
  - sidebar 不出現 供應商 / 互助轉移單
  - /orders /members /儀表板 取貨店篩選預設「經國店」
  - /pickup 訂單列大字是活動名而非訂單號

🤖 Generated with [Claude Code](https://claude.com/claude-code)