### PR TITLE
feat(admin): /orders 鎖店 + pickup 列印簡化(去簽名/字重對調)

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -9,7 +9,7 @@ import { OrderDetail } from "@/components/OrderDetail";
 import { PickupDialog } from "@/components/PickupDialog";
 import { translateRpcError } from "@/lib/rpcError";
 import { withBasePath } from "@/lib/basePath";
-import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
+import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 
 type OrderStatus =
   | "pending" | "confirmed" | "reserved" | "shipping" | "ready" | "partially_ready"
@@ -113,7 +113,14 @@ function OrdersListContent() {
 
   useEffect(() => { setPage(1); setSelected(new Set()); }, [campaignIds, tab, storeId]);
 
-  // 分店帳號預設選中該分店
+  // 分店帳號鎖死到自家店 (不只是預設,連選都不能選別店)
+  const branchStoreId = useUserBranchStoreId(stores);
+  useEffect(() => {
+    if (branchStoreId != null && storeId !== String(branchStoreId)) {
+      setStoreId(String(branchStoreId));
+    }
+  }, [branchStoreId, storeId]);
+  // HQ 帳號維持原本預設(空 = 全部)
   useDefaultStoreFromUser(stores, storeId, setStoreId);
 
   useEffect(() => {
@@ -442,11 +449,18 @@ function OrdersListContent() {
             </div>
           )}
         </div>
-        <select value={storeId} onChange={(e) => setStoreId(e.target.value)}
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
-          <option value="">全部取貨店</option>
-          {stores.map((s) => <option key={s.id} value={s.id}>{s.name} ({s.code})</option>)}
-        </select>
+        {branchStoreId != null ? (
+          <div className="flex items-center rounded-md border border-zinc-300 bg-zinc-50 px-3 py-2 text-sm text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+            🏬 {stores.find((s) => Number(s.id) === branchStoreId)?.name ?? "—"}
+            <span className="ml-2 text-xs text-zinc-500">(僅本店)</span>
+          </div>
+        ) : (
+          <select value={storeId} onChange={(e) => setStoreId(e.target.value)}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
+            <option value="">全部取貨店</option>
+            {stores.map((s) => <option key={s.id} value={s.id}>{s.name} ({s.code})</option>)}
+          </select>
+        )}
       </div>
 
       {error && (

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -304,7 +304,7 @@ function PickupPageContent() {
                             <OrderThumb order={o} />
                             <div className="flex-1 text-sm">
                               <div className="flex items-baseline gap-2">
-                                <span className="font-medium">{o.campaign?.name ?? "(未知活動)"}</span>
+                                <span>{o.campaign?.name ?? "(未知活動)"}</span>
                                 <span className={`rounded px-2 py-0.5 text-[10px] font-medium ${
                                   o.status === "ready" ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300" :
                                   o.status === "partially_completed" ? "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300" :
@@ -320,7 +320,7 @@ function PickupPageContent() {
                               <ul className="mt-0.5 space-y-0.5 text-xs text-zinc-700 dark:text-zinc-300">
                                 {activeItems(o).map((it) => (
                                   <li key={it.id} className="flex items-baseline gap-1.5">
-                                    <span className="font-medium">{it.sku?.variant_name ?? it.sku?.product_name ?? "—"}</span>
+                                    <span className="font-bold">{it.sku?.variant_name ?? ""}</span>
                                     <span className="font-mono text-zinc-500">× {Number(it.qty)}</span>
                                   </li>
                                 ))}
@@ -399,13 +399,13 @@ function PickupPageContent() {
                   return (
                     <div key={o.id} className="text-sm">
                       <div className="mb-1">
-                        <span className="font-semibold">{o.campaign?.name ?? "(未知活動)"}</span>
+                        <span>{o.campaign?.name ?? "(未知活動)"}</span>
                         <span className="ml-2 text-[10px] text-zinc-500">取貨店：{o.store?.name ?? "—"}</span>
                       </div>
                       <ul className="ml-4 space-y-0.5 text-xs">
                         {pickItems.map((it) => (
                           <li key={it.id} className="flex items-baseline gap-2">
-                            <span>{it.sku?.variant_name ?? it.sku?.product_name ?? "—"}</span>
+                            <span className="font-bold">{it.sku?.variant_name ?? ""}</span>
                             <span className="font-mono">×{Number(it.qty)}</span>
                           </li>
                         ))}

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -320,7 +320,7 @@ function PickupPageContent() {
                               <ul className="mt-0.5 space-y-0.5 text-xs text-zinc-700 dark:text-zinc-300">
                                 {activeItems(o).map((it) => (
                                   <li key={it.id} className="flex items-baseline gap-1.5">
-                                    <span className="font-bold">{it.sku?.variant_name ?? ""}</span>
+                                    <span className="font-bold">{it.sku?.variant_name || it.sku?.product_name || "—"}</span>
                                     <span className="font-mono text-zinc-500">× {Number(it.qty)}</span>
                                   </li>
                                 ))}
@@ -405,7 +405,7 @@ function PickupPageContent() {
                       <ul className="ml-4 space-y-0.5 text-xs">
                         {pickItems.map((it) => (
                           <li key={it.id} className="flex items-baseline gap-2">
-                            <span className="font-bold">{it.sku?.variant_name ?? ""}</span>
+                            <span className="font-bold">{it.sku?.variant_name || it.sku?.product_name || "—"}</span>
                             <span className="font-mono">×{Number(it.qty)}</span>
                           </li>
                         ))}

--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -140,13 +140,13 @@ function Body() {
             const sub = active.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0);
             return (
               <div key={o.id} className="border-b border-dashed border-zinc-400 pb-1">
-                <div className="font-bold">{o.campaign?.name ?? "(未知活動)"}</div>
+                <div>{o.campaign?.name ?? "(未知活動)"}</div>
                 {active.map((it) => {
                   const subtotal = Number(it.qty) * Number(it.unit_price);
                   return (
                     <div key={it.id} className="flex items-baseline justify-between">
-                      <span className="flex-1 truncate pr-2">
-                        {it.sku?.variant_name ?? it.sku?.product_name ?? "—"}
+                      <span className="flex-1 truncate pr-2 font-bold">
+                        {it.sku?.variant_name ?? ""}
                       </span>
                       <span className="whitespace-nowrap">
                         × {Number(it.qty)}

--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -146,7 +146,7 @@ function Body() {
                   return (
                     <div key={it.id} className="flex items-baseline justify-between">
                       <span className="flex-1 truncate pr-2 font-bold">
-                        {it.sku?.variant_name ?? ""}
+                        {it.sku?.variant_name || it.sku?.product_name || "—"}
                       </span>
                       <span className="whitespace-nowrap">
                         × {Number(it.qty)}

--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -164,17 +164,6 @@ function Body() {
           合計 {totalQty} 項　$ {grandTotal.toLocaleString()}
         </div>
 
-        <div className="mt-3 text-center text-[10px] text-zinc-500">
-          ─ 取貨確認 ─
-        </div>
-        <div className="mt-3">
-          <div>顧客簽名：</div>
-          <div className="mt-3 border-b border-black"></div>
-        </div>
-        <div className="mt-3">
-          <div>店員簽名：</div>
-          <div className="mt-3 border-b border-black"></div>
-        </div>
       </div>
     </>
   );

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -189,10 +189,6 @@ function Body() {
             <div className="mt-3 border-t-2 border-zinc-700 pt-2 text-right text-sm font-bold">
               合計 ${grandTotal.toLocaleString()}
             </div>
-            <div className="mt-6 grid grid-cols-2 gap-8 text-xs">
-              <div className="border-t border-zinc-400 pt-2 text-center">顧客簽名</div>
-              <div className="border-t border-zinc-400 pt-2 text-center">店員簽名</div>
-            </div>
           </div>
         ) : (
           /* 單筆模式 — 維持原本格式 */
@@ -252,11 +248,6 @@ function Body() {
               {r.event.notes && (
                 <div className="mb-2 text-xs text-zinc-600">備註：{r.event.notes}</div>
               )}
-
-              <div className="mt-4 grid grid-cols-2 gap-8 text-xs">
-                <div className="border-t border-zinc-400 pt-2 text-center">顧客簽名</div>
-                <div className="border-t border-zinc-400 pt-2 text-center">店員簽名</div>
-              </div>
             </div>
           ))
         )}

--- a/apps/admin/src/lib/useDefaultStoreFromUser.ts
+++ b/apps/admin/src/lib/useDefaultStoreFromUser.ts
@@ -1,7 +1,24 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useAuth } from "@/components/AuthProvider";
+
+/**
+ * 回傳當前使用者「分店帳號」鎖到的 store id;HQ / 沒設 stores 回 null。
+ * 拿來判斷是否要強制鎖門市篩選 / 隱藏下拉。
+ */
+export function useUserBranchStoreId(
+  stores: ReadonlyArray<{ id: number | string; name: string }>,
+): number | null {
+  const { user } = useAuth();
+  return useMemo(() => {
+    const userStores = user?.app_metadata?.stores as unknown;
+    if (!Array.isArray(userStores) || userStores.length === 0) return null;
+    if (userStores.includes("總倉")) return null;
+    const match = stores.find((s) => userStores.includes(s.name));
+    return match ? Number(match.id) : null;
+  }, [stores, user]);
+}
 
 /**
  * 分店帳號登入時,把任何「分店篩選下拉」預設選中該分店。


### PR DESCRIPTION
## Summary

3 個 commits 一起送 (前次 PR create 504 timeout 重試):

### 1. /orders 分店帳號鎖死自家店 (`3698994`)
- 新 hook `useUserBranchStoreId(stores)` 偵測 branch 帳號的 store id
- /orders effect 永遠強制 storeId = 自家店 (即使使用者改回也拉回)
- 取貨店下拉換成唯讀「🏬 經國店 (僅本店)」
- HQ 維持原下拉

### 2. pickup 列印頁拿掉簽名欄 (`9313a7d`)
- /pickup/print + /pickup/print-list 兩個頁面都拿掉「顧客簽名 / 店員簽名」雙欄
- print-list 順帶拿掉「─ 取貨確認 ─」分隔字

### 3. 字重商品/SKU 對調 + SKU 不 fallback 商品名 (this commit)
- 商品(campaign 名)拿掉 bold,改普通字重
- SKU(variant_name)加 bold
- SKU 拿掉 `?? product_name` fallback,單規格商品 SKU 行只剩 ×qty
- 套到: print-list / 主 pickup 列表 / bulkConfirm modal 三處

## Test plan
- [x] `npm run build -w apps/admin` 綠燈
- [ ] 部署後分店帳號 /orders 看到「🏬 〇〇店 (僅本店)」
- [ ] /pickup 列印小白單看不到簽名欄, SKU 是粗體, 商品名細
- [ ] /pickup 列表訂單 SKU 加粗、商品名變細

🤖 Generated with [Claude Code](https://claude.com/claude-code)