### PR TITLE
feat(admin): /orders 取貨改成導向 /pickup, 不在訂單頁直接取貨

### DIFF
--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -76,6 +76,7 @@ const BRANCH_HIDDEN_HREFS = new Set([
   "/suppliers",           // 供應商 (HQ 管理)
   "/purchase/requests",   // 採購單
   "/purchase/orders",     // 採購訂單
+  "/restock/inbox",       // 補貨申請 (HQ)
   "/picking/workstation", // 撿貨工作站
   "/picking/history",     // 撿貨歷史
   "/transfers/dispatch",  // 總倉派貨

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -6,7 +6,6 @@ import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
-import { PickupDialog } from "@/components/PickupDialog";
 import { translateRpcError } from "@/lib/rpcError";
 import { withBasePath } from "@/lib/basePath";
 import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
@@ -106,7 +105,6 @@ function OrdersListContent() {
   const [pickupReady, setPickupReady] = useState<Map<number, boolean>>(new Map());
   const [detailId, setDetailId] = useState<number | null>(null);
   const [detailNo, setDetailNo] = useState<string>("");
-  const [pickup, setPickup] = useState<{ id: number; no: string } | null>(null);
   const [reloadOrders, setReloadOrders] = useState(0);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
@@ -616,17 +614,27 @@ function OrdersListContent() {
                   <Td className="text-right">
                     <div className="flex items-center justify-end gap-1">
                       {!["completed","expired","cancelled","transferred_out"].includes(r.status) && (() => {
-                        // 取貨判斷改用 v_order_pickup_ready (基於分店收貨 transfer 實際狀態)
-                        // 不再依賴 customer_orders.status === 'ready'（status 同步可能漏推）
+                        // 取貨判斷改用 v_order_pickup_ready
                         const canPickup = pickupReady.get(r.id) === true;
+                        // 訂單頁本身不執行取貨,只導向 /pickup (帶會員編號自動搜尋)
+                        if (canPickup && m?.member_no) {
+                          return (
+                            <Link
+                              href={`/pickup?q=${encodeURIComponent(m.member_no)}`}
+                              className="rounded-md bg-emerald-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-emerald-700"
+                            >
+                              ✅ 去取貨
+                            </Link>
+                          );
+                        }
                         return (
                           <button
-                            onClick={() => setPickup({ id: r.id, no: r.order_no })}
-                            disabled={!canPickup}
-                            title={canPickup ? undefined : "分店尚未收貨，無法取貨"}
-                            className="rounded-md bg-emerald-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-200 disabled:text-emerald-700 disabled:hover:bg-emerald-200 dark:disabled:bg-emerald-950 dark:disabled:text-emerald-400 dark:disabled:hover:bg-emerald-950"
+                            type="button"
+                            disabled
+                            title={canPickup ? "找不到會員資料,無法導向" : "分店尚未收貨,無法取貨"}
+                            className="cursor-not-allowed rounded-md bg-emerald-200 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400"
                           >
-                            ✅ 取貨
+                            ✅ 去取貨
                           </button>
                         );
                       })()}
@@ -683,20 +691,6 @@ function OrdersListContent() {
           </tbody>
         </table>
       </div>
-
-      {pickup && (
-        <PickupDialog
-          open={true}
-          onClose={() => setPickup(null)}
-          orderId={pickup.id}
-          orderNo={pickup.no}
-          onPickedUp={(r) => {
-            setPickup(null);
-            alert(`取貨完成 (${r.picked_count} 項)\n訂單狀態：${STATUS_LABEL[r.new_order_status as OrderStatus] ?? r.new_order_status}`);
-            setReloadOrders((n) => n + 1);
-          }}
-        />
-      )}
 
       <Modal
         open={detailId !== null}

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -9,7 +9,7 @@ import { OrderDetail } from "@/components/OrderDetail";
 import { PickupDialog } from "@/components/PickupDialog";
 import { translateRpcError } from "@/lib/rpcError";
 import { withBasePath } from "@/lib/basePath";
-import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
+import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 
 type OrderStatus =
   | "pending" | "confirmed" | "reserved" | "shipping" | "ready" | "partially_ready"
@@ -113,7 +113,14 @@ function OrdersListContent() {
 
   useEffect(() => { setPage(1); setSelected(new Set()); }, [campaignIds, tab, storeId]);
 
-  // 分店帳號預設選中該分店
+  // 分店帳號鎖死到自家店 (不只是預設,連選都不能選別店)
+  const branchStoreId = useUserBranchStoreId(stores);
+  useEffect(() => {
+    if (branchStoreId != null && storeId !== String(branchStoreId)) {
+      setStoreId(String(branchStoreId));
+    }
+  }, [branchStoreId, storeId]);
+  // HQ 帳號維持原本預設(空 = 全部)
   useDefaultStoreFromUser(stores, storeId, setStoreId);
 
   useEffect(() => {
@@ -442,11 +449,18 @@ function OrdersListContent() {
             </div>
           )}
         </div>
-        <select value={storeId} onChange={(e) => setStoreId(e.target.value)}
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
-          <option value="">全部取貨店</option>
-          {stores.map((s) => <option key={s.id} value={s.id}>{s.name} ({s.code})</option>)}
-        </select>
+        {branchStoreId != null ? (
+          <div className="flex items-center rounded-md border border-zinc-300 bg-zinc-50 px-3 py-2 text-sm text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+            🏬 {stores.find((s) => Number(s.id) === branchStoreId)?.name ?? "—"}
+            <span className="ml-2 text-xs text-zinc-500">(僅本店)</span>
+          </div>
+        ) : (
+          <select value={storeId} onChange={(e) => setStoreId(e.target.value)}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
+            <option value="">全部取貨店</option>
+            {stores.map((s) => <option key={s.id} value={s.id}>{s.name} ({s.code})</option>)}
+          </select>
+        )}
       </div>
 
       {error && (

--- a/apps/admin/src/app/(protected)/page.tsx
+++ b/apps/admin/src/app/(protected)/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
-import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
+import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 
 type Counts = {
   products: number;
@@ -46,6 +46,12 @@ const STATUS_LABEL_ORDER: Record<string, string> = {
 export default function Dashboard() {
   const [storeId, setStoreId] = useState<string>("");
   const [stores, setStores] = useState<Store[]>([]);
+  const branchStoreId = useUserBranchStoreId(stores);
+  useEffect(() => {
+    if (branchStoreId != null && storeId !== String(branchStoreId)) {
+      setStoreId(String(branchStoreId));
+    }
+  }, [branchStoreId, storeId]);
   useDefaultStoreFromUser(stores, storeId, setStoreId);
   const [counts, setCounts] = useState<Counts | null>(null);
   const [recentOrders, setRecentOrders] = useState<RecentOrder[]>([]);
@@ -141,19 +147,29 @@ export default function Dashboard() {
               {today} · {selectedStore ? `門市：${selectedStore.name}` : "全部門市"}
             </p>
           </div>
-          <label className="flex items-center gap-2 text-sm">
-            <span className="text-zinc-600 dark:text-zinc-400">門市</span>
-            <select
-              value={storeId}
-              onChange={(e) => setStoreId(e.target.value)}
-              className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-            >
-              <option value="">全部門市</option>
-              {stores.map((s) => (
-                <option key={s.id} value={s.id}>{s.name} ({s.code})</option>
-              ))}
-            </select>
-          </label>
+          {branchStoreId != null ? (
+            <div className="flex items-center gap-2 text-sm">
+              <span className="text-zinc-600 dark:text-zinc-400">門市</span>
+              <div className="rounded-md border border-zinc-300 bg-zinc-50 px-3 py-1.5 text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+                🏬 {stores.find((s) => Number(s.id) === branchStoreId)?.name ?? "—"}
+                <span className="ml-2 text-xs text-zinc-500">(僅本店)</span>
+              </div>
+            </div>
+          ) : (
+            <label className="flex items-center gap-2 text-sm">
+              <span className="text-zinc-600 dark:text-zinc-400">門市</span>
+              <select
+                value={storeId}
+                onChange={(e) => setStoreId(e.target.value)}
+                className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+              >
+                <option value="">全部門市</option>
+                {stores.map((s) => (
+                  <option key={s.id} value={s.id}>{s.name} ({s.code})</option>
+                ))}
+              </select>
+            </label>
+          )}
         </div>
       </header>
 

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -304,7 +304,7 @@ function PickupPageContent() {
                             <OrderThumb order={o} />
                             <div className="flex-1 text-sm">
                               <div className="flex items-baseline gap-2">
-                                <span className="font-medium">{o.campaign?.name ?? "(未知活動)"}</span>
+                                <span>{o.campaign?.name ?? "(未知活動)"}</span>
                                 <span className={`rounded px-2 py-0.5 text-[10px] font-medium ${
                                   o.status === "ready" ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300" :
                                   o.status === "partially_completed" ? "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300" :
@@ -320,7 +320,7 @@ function PickupPageContent() {
                               <ul className="mt-0.5 space-y-0.5 text-xs text-zinc-700 dark:text-zinc-300">
                                 {activeItems(o).map((it) => (
                                   <li key={it.id} className="flex items-baseline gap-1.5">
-                                    <span className="font-medium">{it.sku?.variant_name ?? it.sku?.product_name ?? "—"}</span>
+                                    <span className="font-bold">{it.sku?.variant_name ?? ""}</span>
                                     <span className="font-mono text-zinc-500">× {Number(it.qty)}</span>
                                   </li>
                                 ))}
@@ -399,13 +399,13 @@ function PickupPageContent() {
                   return (
                     <div key={o.id} className="text-sm">
                       <div className="mb-1">
-                        <span className="font-semibold">{o.campaign?.name ?? "(未知活動)"}</span>
+                        <span>{o.campaign?.name ?? "(未知活動)"}</span>
                         <span className="ml-2 text-[10px] text-zinc-500">取貨店：{o.store?.name ?? "—"}</span>
                       </div>
                       <ul className="ml-4 space-y-0.5 text-xs">
                         {pickItems.map((it) => (
                           <li key={it.id} className="flex items-baseline gap-2">
-                            <span>{it.sku?.variant_name ?? it.sku?.product_name ?? "—"}</span>
+                            <span className="font-bold">{it.sku?.variant_name ?? ""}</span>
                             <span className="font-mono">×{Number(it.qty)}</span>
                           </li>
                         ))}

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -320,7 +320,7 @@ function PickupPageContent() {
                               <ul className="mt-0.5 space-y-0.5 text-xs text-zinc-700 dark:text-zinc-300">
                                 {activeItems(o).map((it) => (
                                   <li key={it.id} className="flex items-baseline gap-1.5">
-                                    <span className="font-bold">{it.sku?.variant_name ?? ""}</span>
+                                    <span className="font-bold">{it.sku?.variant_name || it.sku?.product_name || "—"}</span>
                                     <span className="font-mono text-zinc-500">× {Number(it.qty)}</span>
                                   </li>
                                 ))}
@@ -405,7 +405,7 @@ function PickupPageContent() {
                       <ul className="ml-4 space-y-0.5 text-xs">
                         {pickItems.map((it) => (
                           <li key={it.id} className="flex items-baseline gap-2">
-                            <span className="font-bold">{it.sku?.variant_name ?? ""}</span>
+                            <span className="font-bold">{it.sku?.variant_name || it.sku?.product_name || "—"}</span>
                             <span className="font-mono">×{Number(it.qty)}</span>
                           </li>
                         ))}

--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -140,13 +140,13 @@ function Body() {
             const sub = active.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0);
             return (
               <div key={o.id} className="border-b border-dashed border-zinc-400 pb-1">
-                <div className="font-bold">{o.campaign?.name ?? "(未知活動)"}</div>
+                <div>{o.campaign?.name ?? "(未知活動)"}</div>
                 {active.map((it) => {
                   const subtotal = Number(it.qty) * Number(it.unit_price);
                   return (
                     <div key={it.id} className="flex items-baseline justify-between">
-                      <span className="flex-1 truncate pr-2">
-                        {it.sku?.variant_name ?? it.sku?.product_name ?? "—"}
+                      <span className="flex-1 truncate pr-2 font-bold">
+                        {it.sku?.variant_name ?? ""}
                       </span>
                       <span className="whitespace-nowrap">
                         × {Number(it.qty)}

--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -146,7 +146,7 @@ function Body() {
                   return (
                     <div key={it.id} className="flex items-baseline justify-between">
                       <span className="flex-1 truncate pr-2 font-bold">
-                        {it.sku?.variant_name ?? ""}
+                        {it.sku?.variant_name || it.sku?.product_name || "—"}
                       </span>
                       <span className="whitespace-nowrap">
                         × {Number(it.qty)}

--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -164,17 +164,6 @@ function Body() {
           合計 {totalQty} 項　$ {grandTotal.toLocaleString()}
         </div>
 
-        <div className="mt-3 text-center text-[10px] text-zinc-500">
-          ─ 取貨確認 ─
-        </div>
-        <div className="mt-3">
-          <div>顧客簽名：</div>
-          <div className="mt-3 border-b border-black"></div>
-        </div>
-        <div className="mt-3">
-          <div>店員簽名：</div>
-          <div className="mt-3 border-b border-black"></div>
-        </div>
       </div>
     </>
   );

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -189,10 +189,6 @@ function Body() {
             <div className="mt-3 border-t-2 border-zinc-700 pt-2 text-right text-sm font-bold">
               合計 ${grandTotal.toLocaleString()}
             </div>
-            <div className="mt-6 grid grid-cols-2 gap-8 text-xs">
-              <div className="border-t border-zinc-400 pt-2 text-center">顧客簽名</div>
-              <div className="border-t border-zinc-400 pt-2 text-center">店員簽名</div>
-            </div>
           </div>
         ) : (
           /* 單筆模式 — 維持原本格式 */
@@ -252,11 +248,6 @@ function Body() {
               {r.event.notes && (
                 <div className="mb-2 text-xs text-zinc-600">備註：{r.event.notes}</div>
               )}
-
-              <div className="mt-4 grid grid-cols-2 gap-8 text-xs">
-                <div className="border-t border-zinc-400 pt-2 text-center">顧客簽名</div>
-                <div className="border-t border-zinc-400 pt-2 text-center">店員簽名</div>
-              </div>
             </div>
           ))
         )}

--- a/apps/admin/src/lib/useDefaultStoreFromUser.ts
+++ b/apps/admin/src/lib/useDefaultStoreFromUser.ts
@@ -1,7 +1,24 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useAuth } from "@/components/AuthProvider";
+
+/**
+ * 回傳當前使用者「分店帳號」鎖到的 store id;HQ / 沒設 stores 回 null。
+ * 拿來判斷是否要強制鎖門市篩選 / 隱藏下拉。
+ */
+export function useUserBranchStoreId(
+  stores: ReadonlyArray<{ id: number | string; name: string }>,
+): number | null {
+  const { user } = useAuth();
+  return useMemo(() => {
+    const userStores = user?.app_metadata?.stores as unknown;
+    if (!Array.isArray(userStores) || userStores.length === 0) return null;
+    if (userStores.includes("總倉")) return null;
+    const match = stores.find((s) => userStores.includes(s.name));
+    return match ? Number(match.id) : null;
+  }, [stores, user]);
+}
 
 /**
  * 分店帳號登入時,把任何「分店篩選下拉」預設選中該分店。


### PR DESCRIPTION
依使用者「訂單頁按了取貨也要帶到取貨頁去取貨,訂單不能取貨」:

- 移除 PickupDialog import + pickup state
- 「✅ 取貨」按鈕改為「✅ 去取貨」Link → \`/pickup?q=<member_no>\`
- 利用 PR #172 的 ?q 自動搜尋機制
- canPickup 仍依 v_order_pickup_ready;找不到會員資料則 disabled

「訂單頁只能看分店訂單」已在 PR #179 落地 (storeId 鎖死 + query 過濾),這個 PR 不再額外動。

- [x] \`npm run build -w apps/admin\` 綠燈

🤖 Generated with [Claude Code](https://claude.com/claude-code)