### PR TITLE
feat(admin): 訂單售價/折扣/備註 + 黑名單 + 通知 + 會員合併 (一輪 11 commits)

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -20,6 +20,7 @@ type OpenOrder = {
   status: string;
   pickup_deadline: string | null;
   pickup_store_id: number | null;
+  discount_amount: number;
   pickup_ready?: boolean; // 從 v_order_pickup_ready merge 進來
   campaign: { id: number; campaign_no: string; name: string } | null;
   store: { id: number; name: string } | null;
@@ -102,7 +103,7 @@ function PickupPageContent() {
       const { data: ords, error: e2 } = await sb
         .from("customer_orders")
         .select(
-          `id, order_no, status, pickup_deadline, pickup_store_id, member_id,
+          `id, order_no, status, pickup_deadline, pickup_store_id, discount_amount, member_id,
            campaign:group_buy_campaigns(id, campaign_no, name),
            store:stores!customer_orders_pickup_store_id_fkey(id, name),
            items:customer_order_items(id, qty, unit_price, status, sku:skus(variant_name, product_name, product:products(images)))`,
@@ -181,8 +182,10 @@ function PickupPageContent() {
       }
       if (errors.length > 0) setError(errors.join("\n"));
       if (eventIds.length > 0) {
-        // 自動開列印（一張頁面、多張收據連續分頁）
+        // 自動開列印 — 大張取貨單 + 熱感應小白單
         window.open(withBasePath(`/pickup/print?event_ids=${eventIds.join(",")}`), "_blank");
+        const okOrderIds = memberOrders.map((o) => o.id).join(",");
+        window.open(withBasePath(`/pickup/print-list?order_ids=${okOrderIds}`), "_blank");
       }
       alert(`完成 ${okCount}/${memberOrders.length} 張取貨${errors.length > 0 ? `\n失敗 ${errors.length} 張：\n${errors.join("\n")}` : ""}`);
       setReloadTick((t) => t + 1);
@@ -291,7 +294,9 @@ function PickupPageContent() {
                         const canPickup = isPickable(o);
                         const active = activeItems(o);
                         const pickableCount = canPickup ? active.length : 0;
-                        const totalAmt = active.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0);
+                        const subAmt = active.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0);
+                        const discAmt = Number(o.discount_amount ?? 0);
+                        const totalAmt = Math.max(0, subAmt - discAmt);
                         return (
                           <li key={o.id} className={`flex items-center gap-3 rounded-md border p-3 ${selected.has(o.id) ? "border-emerald-400 bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-950" : "border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950"}`}>
                             <input
@@ -332,6 +337,11 @@ function PickupPageContent() {
                                   <>
                                     <span className="ml-2">{pickableCount} 項可取</span>
                                     <span className="ml-2 font-mono text-zinc-700 dark:text-zinc-200">${totalAmt}</span>
+                                    {discAmt > 0 && (
+                                      <span className="ml-1 text-[10px] text-red-600 dark:text-red-400" title={`小計 $${subAmt} − 折扣 $${discAmt}`}>
+                                        (含 ${discAmt} 折扣)
+                                      </span>
+                                    )}
                                   </>
                                 ) : (
                                   <span className="ml-2 text-amber-600 dark:text-amber-400">⏳ 分店尚未收貨，無法取貨</span>
@@ -384,14 +394,24 @@ function PickupPageContent() {
           const selectedHere = allMemberOrders.filter((o) => selected.has(o.id));
           const memberOrders = selectedHere.length > 0 ? selectedHere : allMemberOrders;
           const totalItems = memberOrders.reduce((s, o) => s + activeItems(o).length, 0);
-          const totalAmount = memberOrders.reduce(
+          const totalSubtotal = memberOrders.reduce(
             (s, o) => s + activeItems(o).reduce((ss, it) => ss + Number(it.qty) * Number(it.unit_price), 0),
             0,
           );
+          const totalDiscount = memberOrders.reduce((s, o) => s + Number(o.discount_amount ?? 0), 0);
+          const totalAmount = Math.max(0, totalSubtotal - totalDiscount);
           return (
             <div className="space-y-3">
               <p className="text-sm text-zinc-600 dark:text-zinc-300">
-                即將取走 <b>{memberOrders.length}</b> 張訂單、共 <b>{totalItems}</b> 項商品、合計 <b className="font-mono text-base text-zinc-900 dark:text-zinc-100">${totalAmount}</b>：
+                即將取走 <b>{memberOrders.length}</b> 張訂單、共 <b>{totalItems}</b> 項商品。
+                {totalDiscount > 0 ? (
+                  <>
+                    <br />
+                    小計 <span className="font-mono">${totalSubtotal}</span> − 折扣 <span className="font-mono text-red-600 dark:text-red-400">${totalDiscount}</span> = 應收 <b className="font-mono text-base text-zinc-900 dark:text-zinc-100">${totalAmount}</b>
+                  </>
+                ) : (
+                  <>合計 <b className="font-mono text-base text-zinc-900 dark:text-zinc-100">${totalAmount}</b></>
+                )}
               </p>
               <div className="max-h-80 space-y-3 overflow-y-auto rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
                 {memberOrders.map((o) => {

--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -8,6 +8,9 @@ type Order = {
   id: number;
   order_no: string;
   status: string;
+  discount_amount: number;
+  discount_percent: number;
+  notes: string | null;
   member: { id: number; member_no: string; name: string | null; phone: string | null } | null;
   campaign: { id: number; name: string } | null;
   store: { id: number; name: string } | null;
@@ -15,10 +18,25 @@ type Order = {
     id: number;
     qty: number;
     unit_price: number;
+    discount_amount: number;
+    discount_percent: number;
+    notes: string | null;
     status: string;
     sku: { variant_name: string | null; product_name: string | null } | null;
   }[];
 };
+
+function lineGross(it: { qty: number; unit_price: number }): number {
+  return Number(it.qty) * Number(it.unit_price);
+}
+function lineSub(it: { qty: number; unit_price: number; discount_amount: number; discount_percent: number }): number {
+  const gross = Number(it.qty) * Number(it.unit_price);
+  const afterPct = gross * (1 - Number(it.discount_percent ?? 0) / 100);
+  return Math.max(0, Math.round(afterPct * 10000) / 10000 - Number(it.discount_amount ?? 0));
+}
+function hasLineDisc(it: { discount_amount: number; discount_percent: number }): boolean {
+  return Number(it.discount_amount ?? 0) > 0 || Number(it.discount_percent ?? 0) > 0;
+}
 
 const ACTIVE_ITEM_STATUSES = new Set(["pending", "reserved", "ready"]);
 
@@ -47,11 +65,11 @@ function Body() {
       const { data, error: e } = await sb
         .from("customer_orders")
         .select(
-          `id, order_no, status,
+          `id, order_no, status, discount_amount, discount_percent, notes,
            member:members(id, member_no, name, phone),
            campaign:group_buy_campaigns(id, name),
            store:stores!customer_orders_pickup_store_id_fkey(id, name),
-           items:customer_order_items(id, qty, unit_price, status, sku:skus(variant_name, product_name))`,
+           items:customer_order_items(id, qty, unit_price, discount_amount, discount_percent, notes, status, sku:skus(variant_name, product_name))`,
         )
         .in("id", ids);
       if (cancelled) return;
@@ -82,10 +100,23 @@ function Body() {
   // 假設 bulkConfirm 進來都是同一個會員
   const member = orders[0]?.member;
   const store = orders[0]?.store;
-  const grandTotal = orders.reduce((s, o) => {
+  const orderSub = (o: Order) => {
     const active = o.items.filter((it) => ACTIVE_ITEM_STATUSES.has(it.status));
-    return s + active.reduce((a, it) => a + Number(it.qty) * Number(it.unit_price), 0);
+    return active.reduce((a, it) => a + lineSub(it), 0);
+  };
+  const orderPay = (o: Order) => {
+    const sub = orderSub(o);
+    const pct = Number(o.discount_percent ?? 0);
+    const pctDed = Math.round(sub * pct) / 100;
+    return Math.max(0, sub - pctDed - Number(o.discount_amount ?? 0));
+  };
+  const totalOrderDisc = orders.reduce((s, o) => {
+    const sub = orderSub(o);
+    const pct = Number(o.discount_percent ?? 0);
+    return s + Math.round(sub * pct) / 100 + Number(o.discount_amount ?? 0);
   }, 0);
+  const grandSubtotal = orders.reduce((s, o) => s + orderSub(o), 0);
+  const grandTotal = orders.reduce((s, o) => s + orderPay(o), 0);
   const totalQty = orders.reduce((s, o) => {
     const active = o.items.filter((it) => ACTIVE_ITEM_STATUSES.has(it.status));
     return s + active.reduce((a, it) => a + Number(it.qty), 0);
@@ -137,31 +168,72 @@ function Body() {
         <div className="mt-2 space-y-2">
           {orders.map((o) => {
             const active = o.items.filter((it) => ACTIVE_ITEM_STATUSES.has(it.status));
-            const sub = active.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0);
+            const disc = Number(o.discount_amount ?? 0);
+            const pct = Number(o.discount_percent ?? 0);
+            const sub = orderSub(o);
+            const pctDed = Math.round(sub * pct) / 100;
             return (
               <div key={o.id} className="border-b border-dashed border-zinc-400 pb-1">
                 <div>{o.campaign?.name ?? "(未知活動)"}</div>
+                {o.notes && (
+                  <div className="text-[10px] italic">📝 {o.notes}</div>
+                )}
                 {active.map((it) => {
-                  const subtotal = Number(it.qty) * Number(it.unit_price);
+                  const subtotal = lineSub(it);
+                  const gross = lineGross(it);
+                  const discounted = hasLineDisc(it);
                   return (
-                    <div key={it.id} className="flex items-baseline justify-between">
-                      <span className="flex-1 truncate pr-2 font-bold">
-                        {it.sku?.variant_name || it.sku?.product_name || "—"}
-                      </span>
-                      <span className="whitespace-nowrap">
-                        × {Number(it.qty)}
-                        <span className="ml-1.5 text-[11px]">${subtotal}</span>
-                      </span>
+                    <div key={it.id}>
+                      <div className="flex items-baseline justify-between gap-2">
+                        <span className="min-w-0 flex-1 break-words font-bold">
+                          {it.sku?.variant_name || it.sku?.product_name || "—"}
+                        </span>
+                        <span className="whitespace-nowrap">
+                          × {Number(it.qty)}
+                          {discounted ? (
+                            <>
+                              <span className="ml-1.5 text-[10px] line-through">${gross}</span>
+                              <span className="ml-1 text-[11px] font-bold">${subtotal}</span>
+                            </>
+                          ) : (
+                            <span className="ml-1.5 text-[11px]">${subtotal}</span>
+                          )}
+                        </span>
+                      </div>
+                      {discounted && (
+                        <div className="pl-2 text-[10px] font-bold text-red-700">
+                          ↳ 折扣 {Number(it.discount_percent ?? 0) > 0
+                            ? `${it.discount_percent}% (= -$${Math.round(gross * Number(it.discount_percent)) / 100})`
+                            : `-$${it.discount_amount}`}
+                        </div>
+                      )}
+                      {it.notes && (
+                        <div className="pl-2 text-[10px] italic">↳ 備註：{it.notes}</div>
+                      )}
                     </div>
                   );
                 })}
+                {pct > 0 && (
+                  <div className="text-right text-[11px]">
+                    <span className="text-zinc-600">本單{pct}%折扣 </span>
+                    <span>−${pctDed}</span>
+                  </div>
+                )}
+                {disc > 0 && (
+                  <div className="text-right text-[11px]">
+                    <span className="text-zinc-600">本單折扣金額 </span>
+                    <span>−${disc}</span>
+                  </div>
+                )}
               </div>
             );
           })}
         </div>
 
-        <div className="mt-2 border-t-2 border-black pt-1.5 text-right text-[14px] font-bold">
-          合計 {totalQty} 項　$ {grandTotal.toLocaleString()}
+        <div className="mt-2 border-t-2 border-black pt-1.5 text-right text-[12px]">
+          <div>小計 $ {grandSubtotal.toLocaleString()}</div>
+          {totalOrderDisc > 0 && <div>− 整單折扣 $ {totalOrderDisc.toLocaleString()}</div>}
+          <div className="text-[14px] font-bold">合計 {totalQty} 項　$ {grandTotal.toLocaleString()}</div>
         </div>
 
       </div>

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Fragment, Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 
@@ -19,6 +19,9 @@ type Order = {
   order_no: string;
   status: string;
   pickup_store_id: number | null;
+  discount_amount: number;
+  discount_percent: number;
+  notes: string | null;
   member: { id: number; member_no: string; name: string | null; phone: string | null } | null;
   campaign: { id: number; campaign_no: string; name: string } | null;
   store: { id: number; name: string } | null;
@@ -28,9 +31,24 @@ type Item = {
   id: number;
   qty: number;
   unit_price: number;
+  discount_amount: number;
+  discount_percent: number;
+  notes: string | null;
   status: string;
   sku: { sku_code: string; product_name: string | null; variant_name: string | null } | null;
 };
+
+function lineGross(it: Item): number {
+  return Number(it.qty) * Number(it.unit_price);
+}
+function lineSub(it: Item): number {
+  const gross = lineGross(it);
+  const afterPct = gross * (1 - Number(it.discount_percent ?? 0) / 100);
+  return Math.max(0, Math.round(afterPct * 10000) / 10000 - Number(it.discount_amount ?? 0));
+}
+function hasLineDisc(it: Item): boolean {
+  return Number(it.discount_amount ?? 0) > 0 || Number(it.discount_percent ?? 0) > 0;
+}
 
 export default function PickupPrintPage() {
   return (
@@ -64,10 +82,10 @@ function Body() {
       const allItemIds = events.flatMap((e) => e.item_ids ?? []);
       const [{ data: ords }, { data: itms }] = await Promise.all([
         sb.from("customer_orders")
-          .select("id, order_no, status, pickup_store_id, member:members(id, member_no, name, phone), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
+          .select("id, order_no, status, pickup_store_id, discount_amount, discount_percent, notes, member:members(id, member_no, name, phone), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .in("id", orderIds),
         allItemIds.length > 0
-          ? sb.from("customer_order_items").select("id, qty, unit_price, status, sku:skus(sku_code, product_name, variant_name)").in("id", allItemIds)
+          ? sb.from("customer_order_items").select("id, qty, unit_price, discount_amount, discount_percent, notes, status, sku:skus(sku_code, product_name, variant_name)").in("id", allItemIds)
           : Promise.resolve({ data: [] }),
       ]);
       const ordMap = new Map<number, Order>();
@@ -98,10 +116,13 @@ function Body() {
   if (!receipts) return <div className="p-6 text-sm text-zinc-500">載入中…</div>;
 
   const combined = receipts.length > 1;
-  const grandTotal = receipts.reduce(
-    (s, r) => s + r.items.reduce((a, it) => a + Number(it.qty) * Number(it.unit_price), 0),
-    0,
-  );
+  const orderPayable = (r: { order: Order; items: Item[] }) => {
+    const sub = r.items.reduce((a, it) => a + lineSub(it), 0);
+    const pct = Number(r.order?.discount_percent ?? 0);
+    const pctDed = Math.round(sub * pct) / 100;
+    return Math.max(0, sub - pctDed - Number(r.order?.discount_amount ?? 0));
+  };
+  const grandTotal = receipts.reduce((s, r) => s + orderPayable(r), 0);
 
   return (
     <>
@@ -132,7 +153,11 @@ function Body() {
             </div>
 
             {receipts.map((r, idx) => {
-              const sub = r.items.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0);
+              const sub = r.items.reduce((s, it) => s + lineSub(it), 0);
+              const disc = Number(r.order?.discount_amount ?? 0);
+              const pct = Number(r.order?.discount_percent ?? 0);
+              const pctDed = Math.round(sub * pct) / 100;
+              const pay = Math.max(0, sub - pctDed - disc);
               return (
                 <div
                   key={r.event.id}
@@ -152,35 +177,79 @@ function Body() {
                   <table className="w-full border-collapse text-xs">
                     <tbody>
                       {r.items.map((it) => {
-                        const itSub = Number(it.qty) * Number(it.unit_price);
+                        const itSub = lineSub(it);
+                        const itGross = lineGross(it);
+                        const discounted = hasLineDisc(it);
                         return (
-                          <tr key={it.id} className="border-b border-zinc-200">
-                            <td className="px-1 py-0.5">
-                              <span className="font-medium">
-                                {it.sku?.variant_name ?? it.sku?.product_name ?? "—"}
-                              </span>
-                              {it.sku?.sku_code && (
-                                <span className="ml-1 font-mono text-[9px] text-zinc-500">
-                                  {it.sku.sku_code}
+                          <Fragment key={it.id}>
+                            <tr className={it.notes ? "" : "border-b border-zinc-200"}>
+                              <td className="px-1 py-0.5">
+                                <span className="font-medium">
+                                  {it.sku?.variant_name ?? it.sku?.product_name ?? "—"}
                                 </span>
-                              )}
-                            </td>
-                            <td className="px-1 py-0.5 text-right font-mono">× {Number(it.qty)}</td>
-                            <td className="px-1 py-0.5 text-right font-mono text-zinc-500">
-                              ${Number(it.unit_price)}
-                            </td>
-                            <td className="px-1 py-0.5 text-right font-mono">${itSub}</td>
-                          </tr>
+                                {it.sku?.sku_code && (
+                                  <span className="ml-1 font-mono text-[9px] text-zinc-500">
+                                    {it.sku.sku_code}
+                                  </span>
+                                )}
+                                {discounted && (
+                                  <span className="ml-1 rounded bg-red-100 px-1 text-[9px] font-bold text-red-700">
+                                    {Number(it.discount_percent ?? 0) > 0 ? `${it.discount_percent}%` : `減$${it.discount_amount}`}
+                                  </span>
+                                )}
+                              </td>
+                              <td className="px-1 py-0.5 text-right font-mono">× {Number(it.qty)}</td>
+                              <td className="px-1 py-0.5 text-right font-mono text-zinc-500">
+                                ${Number(it.unit_price)}
+                              </td>
+                              <td className="px-1 py-0.5 text-right font-mono">
+                                {discounted ? (
+                                  <>
+                                    <span className="mr-1 text-zinc-400 line-through">${itGross}</span>
+                                    <span className="font-bold text-red-700">${itSub}</span>
+                                  </>
+                                ) : (
+                                  <>${itSub}</>
+                                )}
+                              </td>
+                            </tr>
+                            {it.notes && (
+                              <tr className="border-b border-zinc-200">
+                                <td colSpan={4} className="px-1 pb-1 text-[10px] italic text-zinc-600">
+                                  ↳ 備註：{it.notes}
+                                </td>
+                              </tr>
+                            )}
+                          </Fragment>
                         );
                       })}
-                      <tr className="font-bold">
-                        <td colSpan={3} className="px-1 py-0.5 text-right">本單小計</td>
+                      <tr>
+                        <td colSpan={3} className="px-1 py-0.5 text-right text-zinc-600">本單小計</td>
                         <td className="px-1 py-0.5 text-right font-mono">${sub}</td>
+                      </tr>
+                      {pct > 0 && (
+                        <tr>
+                          <td colSpan={3} className="px-1 py-0.5 text-right text-zinc-600">− 折扣 {pct}%</td>
+                          <td className="px-1 py-0.5 text-right font-mono">−${pctDed}</td>
+                        </tr>
+                      )}
+                      {disc > 0 && (
+                        <tr>
+                          <td colSpan={3} className="px-1 py-0.5 text-right text-zinc-600">− 折扣金額</td>
+                          <td className="px-1 py-0.5 text-right font-mono">−${disc}</td>
+                        </tr>
+                      )}
+                      <tr className="font-bold">
+                        <td colSpan={3} className="px-1 py-0.5 text-right">本單應收</td>
+                        <td className="px-1 py-0.5 text-right font-mono">${pay}</td>
                       </tr>
                     </tbody>
                   </table>
+                  {r.order?.notes && (
+                    <div className="mt-1 text-[10px] text-zinc-700">📝 訂單備註：{r.order.notes}</div>
+                  )}
                   {r.event.notes && (
-                    <div className="mt-1 text-[10px] text-zinc-600">備註：{r.event.notes}</div>
+                    <div className="mt-1 text-[10px] text-zinc-600">取貨備註：{r.event.notes}</div>
                   )}
                 </div>
               );
@@ -221,32 +290,85 @@ function Body() {
                 </thead>
                 <tbody>
                   {r.items.map((it) => {
-                    const sub = Number(it.qty) * Number(it.unit_price);
+                    const sub = lineSub(it);
+                    const gross = lineGross(it);
+                    const discounted = hasLineDisc(it);
                     return (
-                      <tr key={it.id} className="border-b border-zinc-200">
-                        <td className="px-2 py-1">
-                          {it.sku?.variant_name ?? it.sku?.product_name ?? "—"}
-                          {it.sku?.sku_code && <span className="ml-1 font-mono text-[10px] text-zinc-500">{it.sku.sku_code}</span>}
-                        </td>
-                        <td className="px-2 py-1 text-right font-mono">{Number(it.qty)}</td>
-                        <td className="px-2 py-1 text-right font-mono">${Number(it.unit_price)}</td>
-                        <td className="px-2 py-1 text-right font-mono">${sub}</td>
-                      </tr>
+                      <Fragment key={it.id}>
+                        <tr className={it.notes ? "" : "border-b border-zinc-200"}>
+                          <td className="px-2 py-1">
+                            {it.sku?.variant_name ?? it.sku?.product_name ?? "—"}
+                            {it.sku?.sku_code && <span className="ml-1 font-mono text-[10px] text-zinc-500">{it.sku.sku_code}</span>}
+                            {discounted && (
+                              <span className="ml-1 rounded bg-red-100 px-1 text-[9px] font-bold text-red-700">
+                                {Number(it.discount_percent ?? 0) > 0 ? `${it.discount_percent}%` : `減$${it.discount_amount}`}
+                              </span>
+                            )}
+                          </td>
+                          <td className="px-2 py-1 text-right font-mono">{Number(it.qty)}</td>
+                          <td className="px-2 py-1 text-right font-mono">${Number(it.unit_price)}</td>
+                          <td className="px-2 py-1 text-right font-mono">
+                            {discounted ? (
+                              <>
+                                <span className="mr-1 text-zinc-400 line-through">${gross}</span>
+                                <span className="font-bold text-red-700">${sub}</span>
+                              </>
+                            ) : (
+                              <>${sub}</>
+                            )}
+                          </td>
+                        </tr>
+                        {it.notes && (
+                          <tr className="border-b border-zinc-200">
+                            <td colSpan={4} className="px-2 pb-1 text-[10px] italic text-zinc-600">
+                              ↳ 備註：{it.notes}
+                            </td>
+                          </tr>
+                        )}
+                      </Fragment>
                     );
                   })}
                 </tbody>
                 <tfoot>
-                  <tr className="border-t-2 border-zinc-400 font-bold">
-                    <td colSpan={3} className="px-2 py-2 text-right">合計</td>
-                    <td className="px-2 py-2 text-right font-mono">
-                      ${r.items.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0)}
-                    </td>
-                  </tr>
+                  {(() => {
+                    const sub = r.items.reduce((s, it) => s + lineSub(it), 0);
+                    const disc = Number(r.order?.discount_amount ?? 0);
+                    const pct = Number(r.order?.discount_percent ?? 0);
+                    const pctDed = Math.round(sub * pct) / 100;
+                    const pay = Math.max(0, sub - pctDed - disc);
+                    return (
+                      <>
+                        <tr className="border-t border-zinc-300">
+                          <td colSpan={3} className="px-2 py-1 text-right text-xs text-zinc-600">小計</td>
+                          <td className="px-2 py-1 text-right font-mono">${sub}</td>
+                        </tr>
+                        {pct > 0 && (
+                          <tr>
+                            <td colSpan={3} className="px-2 py-1 text-right text-xs text-zinc-600">− 折扣 {pct}%</td>
+                            <td className="px-2 py-1 text-right font-mono">−${pctDed}</td>
+                          </tr>
+                        )}
+                        {disc > 0 && (
+                          <tr>
+                            <td colSpan={3} className="px-2 py-1 text-right text-xs text-zinc-600">− 折扣金額</td>
+                            <td className="px-2 py-1 text-right font-mono">−${disc}</td>
+                          </tr>
+                        )}
+                        <tr className="border-t-2 border-zinc-400 font-bold">
+                          <td colSpan={3} className="px-2 py-2 text-right">應收</td>
+                          <td className="px-2 py-2 text-right font-mono">${pay}</td>
+                        </tr>
+                      </>
+                    );
+                  })()}
                 </tfoot>
               </table>
 
+              {r.order?.notes && (
+                <div className="mb-1 text-xs text-zinc-700">📝 訂單備註：{r.order.notes}</div>
+              )}
               {r.event.notes && (
-                <div className="mb-2 text-xs text-zinc-600">備註：{r.event.notes}</div>
+                <div className="mb-2 text-xs text-zinc-600">取貨備註：{r.event.notes}</div>
               )}
             </div>
           ))

--- a/apps/admin/src/components/EditableCell.tsx
+++ b/apps/admin/src/components/EditableCell.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export function EditableNumber({
+  value,
+  onSave,
+  disabled,
+  className,
+  min,
+  prefix,
+}: {
+  value: number;
+  onSave: (newValue: number) => Promise<void>;
+  disabled?: boolean;
+  className?: string;
+  min?: number;
+  prefix?: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(String(value));
+  const [busy, setBusy] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { setDraft(String(value)); }, [value]);
+  useEffect(() => { if (editing) inputRef.current?.select(); }, [editing]);
+
+  async function commit() {
+    const n = Number(draft);
+    if (Number.isNaN(n) || (min != null && n < min)) {
+      alert(`數值無效（需 >= ${min ?? "any"}）`);
+      setDraft(String(value));
+      setEditing(false);
+      return;
+    }
+    if (n === Number(value)) { setEditing(false); return; }
+    setBusy(true);
+    try {
+      await onSave(n);
+      setEditing(false);
+    } catch (e) {
+      alert(`儲存失敗：${(e as Error).message}`);
+      setDraft(String(value));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function cancel() {
+    setDraft(String(value));
+    setEditing(false);
+  }
+
+  if (disabled) {
+    return <span className={className}>{prefix ?? ""}{Number(value)}</span>;
+  }
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        className={`${className ?? ""} cursor-pointer rounded px-1 hover:bg-yellow-50 dark:hover:bg-yellow-950`}
+        title="點擊編輯"
+      >
+        {prefix ?? ""}{Number(value)}
+      </button>
+    );
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      type="number"
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={() => { if (!busy) commit(); }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") { e.preventDefault(); commit(); }
+        if (e.key === "Escape") cancel();
+      }}
+      step="any"
+      min={min}
+      disabled={busy}
+      className={`${className ?? ""} w-24 rounded border border-blue-400 bg-white px-1 text-right font-mono dark:bg-zinc-900`}
+    />
+  );
+}
+
+export function EditableText({
+  value,
+  onSave,
+  disabled,
+  placeholder,
+  className,
+  multiline,
+}: {
+  value: string | null;
+  onSave: (newValue: string | null) => Promise<void>;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  multiline?: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value ?? "");
+  const [busy, setBusy] = useState(false);
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+
+  useEffect(() => { setDraft(value ?? ""); }, [value]);
+  useEffect(() => { if (editing) inputRef.current?.focus(); }, [editing]);
+
+  async function commit() {
+    const trimmed = draft.trim();
+    const newVal: string | null = trimmed === "" ? null : draft;
+    if (newVal === (value ?? null)) { setEditing(false); return; }
+    setBusy(true);
+    try {
+      await onSave(newVal);
+      setEditing(false);
+    } catch (e) {
+      alert(`儲存失敗：${(e as Error).message}`);
+      setDraft(value ?? "");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function cancel() {
+    setDraft(value ?? "");
+    setEditing(false);
+  }
+
+  if (disabled) {
+    return (
+      <span className={`${className ?? ""} ${value ? "" : "text-zinc-400"}`}>
+        {value || placeholder || "—"}
+      </span>
+    );
+  }
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        className={`${className ?? ""} cursor-pointer rounded px-1 text-left hover:bg-yellow-50 dark:hover:bg-yellow-950 ${value ? "" : "italic text-zinc-400"}`}
+        title="點擊編輯"
+      >
+        {value || placeholder || "（點此加備註）"}
+      </button>
+    );
+  }
+
+  if (multiline) {
+    return (
+      <textarea
+        ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => { if (!busy) commit(); }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); commit(); }
+          if (e.key === "Escape") cancel();
+        }}
+        rows={2}
+        disabled={busy}
+        className={`${className ?? ""} w-full rounded border border-blue-400 bg-white px-1 dark:bg-zinc-900`}
+      />
+    );
+  }
+
+  return (
+    <input
+      ref={inputRef as React.RefObject<HTMLInputElement>}
+      type="text"
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={() => { if (!busy) commit(); }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") { e.preventDefault(); commit(); }
+        if (e.key === "Escape") cancel();
+      }}
+      disabled={busy}
+      placeholder={placeholder}
+      className={`${className ?? ""} w-full rounded border border-blue-400 bg-white px-1 dark:bg-zinc-900`}
+    />
+  );
+}

--- a/apps/admin/src/components/EditableDiscount.tsx
+++ b/apps/admin/src/components/EditableDiscount.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+// 折扣 1 欄（金額/百分比二擇一）— 用於 OrderDetail 的 draft state
+// 不直接 RPC，由 parent 蒐集後一次儲存。
+
+export type DiscountKind = "percent" | "amount";
+export type DiscountValue = { kind: DiscountKind; value: number };
+
+export function deriveDiscount(percent: number, amount: number): DiscountValue {
+  if (Number(percent) > 0) return { kind: "percent", value: Number(percent) };
+  return { kind: "amount", value: Number(amount) };
+}
+
+export function discountLabel(d: DiscountValue): string {
+  if (!d.value || d.value === 0) return "—";
+  return d.kind === "percent" ? `${d.value}%` : `$${d.value}`;
+}
+
+// 把 DiscountValue 轉成金額（依 referenceAmount）
+export function discountToAmount(d: DiscountValue, referenceAmount: number): number {
+  if (d.value <= 0) return 0;
+  if (d.kind === "percent") return Math.round(referenceAmount * Number(d.value)) / 100;
+  return Number(d.value);
+}
+
+export function EditableDiscount({
+  value,
+  onChange,
+  disabled,
+  compact,
+  referenceAmount,
+}: {
+  value: DiscountValue;
+  onChange: (v: DiscountValue) => void;
+  disabled?: boolean;
+  compact?: boolean;
+  // 用於 % → $ 換算提示
+  referenceAmount?: number;
+}) {
+  const equivAmount = referenceAmount != null && value.kind === "percent" && value.value > 0
+    ? Math.round(referenceAmount * Number(value.value)) / 100
+    : null;
+
+  if (disabled) {
+    return (
+      <span className="font-mono">
+        {discountLabel(value)}
+        {equivAmount != null && <span className="ml-1 text-zinc-500">(= ${equivAmount})</span>}
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1">
+      <select
+        value={value.kind}
+        onChange={(e) => onChange({ kind: e.target.value as DiscountKind, value: value.value })}
+        className="rounded border border-zinc-300 bg-white px-1 py-0.5 text-xs dark:border-zinc-700 dark:bg-zinc-900"
+      >
+        <option value="amount">$</option>
+        <option value="percent">%</option>
+      </select>
+      <input
+        type="number"
+        value={value.value === 0 ? "" : String(value.value)}
+        placeholder="0"
+        min={0}
+        max={value.kind === "percent" ? 100 : undefined}
+        step="any"
+        onChange={(e) => {
+          const raw = e.target.value === "" ? 0 : Number(e.target.value);
+          onChange({ kind: value.kind, value: Number.isNaN(raw) ? 0 : raw });
+        }}
+        className={`${compact ? "w-14" : "w-20"} rounded border border-zinc-300 bg-white px-1 py-0.5 text-right font-mono text-xs dark:border-zinc-700 dark:bg-zinc-900`}
+      />
+      {equivAmount != null && (
+        <span className="text-[10px] text-zinc-500">= ${equivAmount}</span>
+      )}
+    </span>
+  );
+}

--- a/apps/admin/src/components/Modal.tsx
+++ b/apps/admin/src/components/Modal.tsx
@@ -13,27 +13,24 @@ export function Modal({
 }) {
   useEffect(() => {
     if (!open) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
-    document.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
     return () => {
-      document.removeEventListener("keydown", onKey);
       document.body.style.overflow = "";
     };
-  }, [open, onClose]);
+  }, [open]);
 
   if (!open) return null;
 
+  // 不再支援 Esc / 背景點擊關閉，避免操作中 popup 不小心被關。
+  // 只能按右上 ✕ 關（或 dialog 內部的明確按鈕）
   return (
     <div
       className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-zinc-900/50 px-4 py-8 backdrop-blur-sm"
-      onClick={onClose}
       aria-modal="true"
       role="dialog"
     >
       <div
         className={`w-full ${maxWidth} rounded-lg border border-zinc-200 bg-white shadow-2xl dark:border-zinc-800 dark:bg-zinc-900`}
-        onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b border-zinc-200 px-5 py-3 dark:border-zinc-800">
           <h2 className="text-base font-semibold">{title}</h2>

--- a/apps/admin/src/components/OrderAuditDrawer.tsx
+++ b/apps/admin/src/components/OrderAuditDrawer.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Modal } from "@/components/Modal";
+import { getSupabase } from "@/lib/supabase";
+
+type AuditRow = {
+  id: number;
+  entity_type: "order" | "item";
+  entity_id: number | null;
+  field: "unit_price" | "item_notes" | "item_discount_amount" | "item_discount_percent" | "discount_amount" | "discount_percent" | "order_notes";
+  before_value: unknown;
+  after_value: unknown;
+  edit_reason: string | null;
+  operator_id: string;
+  created_at: string;
+};
+
+const FIELD_LABEL: Record<string, string> = {
+  unit_price: "單價",
+  item_notes: "商品備註",
+  item_discount_amount: "單品折扣 $",
+  item_discount_percent: "單品折扣 %",
+  discount_amount: "整單折扣 $",
+  discount_percent: "整單折扣 %",
+  order_notes: "單頭備註",
+};
+
+function valLabel(v: unknown): string {
+  if (v === null || v === undefined) return "—";
+  if (typeof v === "string") return v === "" ? '""' : v;
+  return String(v);
+}
+
+export function OrderAuditDrawer({
+  open,
+  onClose,
+  orderId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  orderId: number;
+}) {
+  const [rows, setRows] = useState<AuditRow[] | null>(null);
+  const [staffNames, setStaffNames] = useState<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data, error } = await sb
+        .from("customer_order_audit_log")
+        .select(
+          "id, entity_type, entity_id, field, before_value, after_value, edit_reason, operator_id, created_at",
+        )
+        .eq("order_id", orderId)
+        .order("created_at", { ascending: false });
+      if (cancelled) return;
+      if (error) {
+        setRows([]);
+        return;
+      }
+      const rs = (data ?? []) as AuditRow[];
+      setRows(rs);
+      const uids = Array.from(new Set(rs.map((r) => r.operator_id))).filter(Boolean);
+      if (uids.length > 0) {
+        const { data: ns } = await sb.rpc("rpc_get_staff_names", { p_uids: uids });
+        const m = new Map<string, string>();
+        for (const n of (ns as { id: string; display_name: string }[] | null) ?? []) {
+          m.set(n.id, n.display_name);
+        }
+        if (!cancelled) setStaffNames(m);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, orderId]);
+
+  return (
+    <Modal open={open} onClose={onClose} title="編輯歷史" maxWidth="max-w-3xl">
+      {rows === null ? (
+        <div className="text-sm text-zinc-500">載入中…</div>
+      ) : rows.length === 0 ? (
+        <div className="text-sm text-zinc-500">尚無編輯紀錄</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-zinc-200 text-xs dark:divide-zinc-800">
+            <thead className="bg-zinc-50 dark:bg-zinc-900">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium text-zinc-500">時間</th>
+                <th className="px-3 py-2 text-left font-medium text-zinc-500">欄位</th>
+                <th className="px-3 py-2 text-left font-medium text-zinc-500">變更</th>
+                <th className="px-3 py-2 text-left font-medium text-zinc-500">操作人</th>
+                <th className="px-3 py-2 text-left font-medium text-zinc-500">修改原因</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {rows.map((r) => (
+                <tr key={r.id}>
+                  <td className="whitespace-nowrap px-3 py-2 text-zinc-500">
+                    {new Date(r.created_at).toLocaleString("zh-TW", { hour12: false })}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2">
+                    {FIELD_LABEL[r.field] ?? r.field}
+                    {r.entity_type === "item" && r.entity_id != null && (
+                      <span className="ml-1 text-[10px] text-zinc-400">#{r.entity_id}</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 font-mono">
+                    <span className="text-zinc-500 line-through">{valLabel(r.before_value)}</span>
+                    <span className="mx-1">→</span>
+                    <span>{valLabel(r.after_value)}</span>
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2 text-zinc-500">
+                    {staffNames.get(r.operator_id) ?? r.operator_id.slice(0, 8)}
+                  </td>
+                  <td className="px-3 py-2 text-zinc-500">{r.edit_reason ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { OrderTransferModal } from "@/components/OrderTransferModal";
 import { PickupDialog } from "@/components/PickupDialog";
 import { AidOrderTimeline } from "@/components/AidOrderTimeline";
+import { OrderAuditDrawer } from "@/components/OrderAuditDrawer";
+import { EditableNumber, EditableText } from "@/components/EditableCell";
+import { EditableDiscount, deriveDiscount, type DiscountValue } from "@/components/EditableDiscount";
+import { useAuth } from "@/components/AuthProvider";
+import { useRole } from "@/lib/role";
 import { withBasePath } from "@/lib/basePath";
 import { translateRpcError } from "@/lib/rpcError";
 
@@ -20,6 +25,9 @@ type OrderHead = {
   campaign_id: number | null;
   transferred_from_order_id: number | null;
   is_air_transfer: boolean | null;
+  discount_amount: number;
+  discount_percent: number;
+  notes: string | null;
   member: { id: number; name: string | null; phone: string | null; member_no: string } | null;
   campaign: { id: number; campaign_no: string; name: string } | null;
   store: { id: number; name: string } | null;
@@ -31,12 +39,47 @@ type ItemRow = {
   unit_price: number;
   status: string;
   source: string;
+  notes: string | null;
+  discount_amount: number;
+  discount_percent: number;
   created_at: string;
   updated_at: string;
   created_by: string | null;
   updated_by: string | null;
   sku: { id: number; sku_code: string; product_name: string | null; variant_name: string | null } | null;
 };
+
+function computeLineSubtotal(qty: number, unitPrice: number, d: DiscountValue): number {
+  const gross = Number(qty) * Number(unitPrice);
+  const pct = d.kind === "percent" ? Number(d.value) : 0;
+  const amt = d.kind === "amount" ? Number(d.value) : 0;
+  const afterPct = gross * (1 - pct / 100);
+  return Math.max(0, Math.round(afterPct * 10000) / 10000 - amt);
+}
+
+function applyOrderDiscount(subtotal: number, d: DiscountValue): { deduction: number; payable: number } {
+  const pct = d.kind === "percent" ? Number(d.value) : 0;
+  const amt = d.kind === "amount" ? Number(d.value) : 0;
+  const pctDed = Math.round(subtotal * pct) / 100;
+  return {
+    deduction: pctDed + amt,
+    payable: Math.max(0, subtotal - pctDed - amt),
+  };
+}
+
+type ItemDraft = {
+  unit_price?: number;
+  notes?: string | null;
+  discount?: DiscountValue;
+};
+type OrderDraft = {
+  notes?: string | null;
+  discount?: DiscountValue;
+  items: Map<number, ItemDraft>;
+};
+const EMPTY_DRAFT: OrderDraft = { items: new Map() };
+
+const HQ_ROLES = new Set(["owner", "admin", "hq_manager", "hq_accountant", ""]);
 
 type TimelineStep = {
   label: string;
@@ -80,6 +123,33 @@ export function OrderDetail({
   const [reloadTick, setReloadTick] = useState(0);
   const [transferOpen, setTransferOpen] = useState(false);
   const [pickupOpen, setPickupOpen] = useState(false);
+  const [auditOpen, setAuditOpen] = useState(false);
+  const [draft, setDraft] = useState<OrderDraft>(EMPTY_DRAFT);
+  const [saving, setSaving] = useState(false);
+  const [editReason, setEditReason] = useState("");
+
+  function clearDraft() { setDraft({ items: new Map() }); setEditReason(""); }
+  function setOrderDraft(patch: Partial<{ notes: string | null; discount: DiscountValue }>) {
+    setDraft((d) => ({ ...d, ...patch }));
+  }
+  function setItemDraft(itemId: number, patch: ItemDraft) {
+    setDraft((d) => {
+      const next = new Map(d.items);
+      next.set(itemId, { ...next.get(itemId), ...patch });
+      return { ...d, items: next };
+    });
+  }
+
+  const { user } = useAuth();
+  const role = useRole();
+  const userStores = (user?.app_metadata?.stores as unknown[] | undefined) ?? [];
+  const canEdit = useMemo(() => {
+    if (role === null) return false;
+    if (HQ_ROLES.has(role)) return true;
+    if (Array.isArray(userStores) && userStores.includes("總倉")) return true;
+    if (head?.store?.name && Array.isArray(userStores) && userStores.includes(head.store.name)) return true;
+    return false;
+  }, [role, userStores, head?.store?.name]);
 
   useEffect(() => {
     let cancelled = false;
@@ -87,10 +157,10 @@ export function OrderDetail({
       const sb = getSupabase();
       const [hRes, iRes] = await Promise.all([
         sb.from("customer_orders")
-          .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, transferred_from_order_id, is_air_transfer, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
+          .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, transferred_from_order_id, is_air_transfer, discount_amount, discount_percent, notes, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .eq("id", orderId).maybeSingle(),
         sb.from("customer_order_items")
-          .select("id, qty, unit_price, status, source, created_at, updated_at, created_by, updated_by, sku:skus(id, sku_code, product_name, variant_name)")
+          .select("id, qty, unit_price, status, source, notes, discount_amount, discount_percent, created_at, updated_at, created_by, updated_by, sku:skus(id, sku_code, product_name, variant_name)")
           .eq("order_id", orderId)
           .order("created_at", { ascending: true }),
       ]);
@@ -146,8 +216,119 @@ export function OrderDetail({
   }
   if (!head || !items) return <div className="text-sm text-zinc-500">載入中…</div>;
 
+  // ----- 從 head + draft 取「目前生效的值」 -----
+  const itemEffective = (it: ItemRow) => {
+    const d = draft.items.get(it.id);
+    const unit_price = d?.unit_price ?? Number(it.unit_price);
+    const notes = d && Object.prototype.hasOwnProperty.call(d, "notes") ? d.notes! : it.notes;
+    const discount: DiscountValue = d?.discount ?? deriveDiscount(it.discount_percent, it.discount_amount);
+    return { unit_price, notes, discount };
+  };
+  const orderDiscountValue: DiscountValue = draft.discount ?? deriveDiscount(head.discount_percent, head.discount_amount);
+  const orderNotesValue: string | null = Object.prototype.hasOwnProperty.call(draft, "notes") ? draft.notes! : head.notes;
+
   const totalQty = items.reduce((s, i) => s + Number(i.qty), 0);
-  const totalAmount = items.reduce((s, i) => s + Number(i.qty) * Number(i.unit_price), 0);
+  const grossTotal = items.reduce((s, i) => s + Number(i.qty) * Number(itemEffective(i).unit_price), 0);
+  const subtotal = items.reduce((s, i) => {
+    const eff = itemEffective(i);
+    return s + computeLineSubtotal(Number(i.qty), eff.unit_price, eff.discount);
+  }, 0);
+  const lineDiscountTotal = Math.round((grossTotal - subtotal) * 10000) / 10000;
+  const { deduction: orderDeduction, payable: payableAmount } = applyOrderDiscount(subtotal, orderDiscountValue);
+
+  // ----- draft 修改數計算 -----
+  const itemDraftCount = Array.from(draft.items.values()).reduce(
+    (n, d) => n + Object.keys(d).length, 0,
+  );
+  const orderDraftCount = (draft.discount ? 1 : 0) + (Object.prototype.hasOwnProperty.call(draft, "notes") ? 1 : 0);
+  const draftCount = itemDraftCount + orderDraftCount;
+
+  async function saveAllDraft() {
+    if (!head || !items) return;
+    if (draftCount === 0) return;
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id ?? null;
+    if (!operator) { alert("尚未登入"); return; }
+    setSaving(true);
+    const errors: string[] = [];
+    const reason = editReason.trim() === "" ? null : editReason.trim();
+    try {
+      // 訂單頭部備註
+      if (Object.prototype.hasOwnProperty.call(draft, "notes")) {
+        const { error } = await sb.rpc("rpc_update_order_notes", {
+          p_order_id: head.id,
+          p_new_notes: draft.notes ?? null,
+          p_operator: operator,
+          p_reason: reason,
+        });
+        if (error) errors.push(`整單備註：${translateRpcError(error)}`);
+      }
+      // 訂單頭部折扣（型別二擇一，把對方歸零）
+      if (draft.discount) {
+        const d = draft.discount;
+        const newPct = d.kind === "percent" ? Number(d.value) : 0;
+        const newAmt = d.kind === "amount" ? Number(d.value) : 0;
+        if (Number(head.discount_percent ?? 0) !== newPct) {
+          const { error } = await sb.rpc("rpc_update_order_discount_percent", {
+            p_order_id: head.id, p_new_percent: newPct, p_operator: operator, p_reason: reason,
+          });
+          if (error) errors.push(`整單折扣%：${translateRpcError(error)}`);
+        }
+        if (Number(head.discount_amount ?? 0) !== newAmt) {
+          const { error } = await sb.rpc("rpc_update_order_discount", {
+            p_order_id: head.id, p_new_discount: newAmt, p_operator: operator, p_reason: reason,
+          });
+          if (error) errors.push(`整單折扣$：${translateRpcError(error)}`);
+        }
+      }
+      // 商品 (unit_price / notes / discount)
+      for (const [itemId, d] of draft.items) {
+        const it = items.find((x) => x.id === itemId);
+        if (!it) continue;
+        if (d.unit_price !== undefined && Number(d.unit_price) !== Number(it.unit_price)) {
+          const { error } = await sb.rpc("rpc_update_order_item_price", {
+            p_order_id: head.id, p_item_id: itemId,
+            p_new_unit_price: Number(d.unit_price), p_operator: operator, p_reason: reason,
+          });
+          if (error) errors.push(`#${itemId} 單價：${translateRpcError(error)}`);
+        }
+        if (Object.prototype.hasOwnProperty.call(d, "notes") && d.notes !== it.notes) {
+          const { error } = await sb.rpc("rpc_update_order_item_notes", {
+            p_order_id: head.id, p_item_id: itemId,
+            p_new_notes: d.notes ?? null, p_operator: operator, p_reason: reason,
+          });
+          if (error) errors.push(`#${itemId} 備註：${translateRpcError(error)}`);
+        }
+        if (d.discount) {
+          const newPct = d.discount.kind === "percent" ? Number(d.discount.value) : 0;
+          const newAmt = d.discount.kind === "amount" ? Number(d.discount.value) : 0;
+          if (Number(it.discount_percent ?? 0) !== newPct) {
+            const { error } = await sb.rpc("rpc_update_order_item_discount_percent", {
+              p_order_id: head.id, p_item_id: itemId,
+              p_new_percent: newPct, p_operator: operator, p_reason: reason,
+            });
+            if (error) errors.push(`#${itemId} 折扣%：${translateRpcError(error)}`);
+          }
+          if (Number(it.discount_amount ?? 0) !== newAmt) {
+            const { error } = await sb.rpc("rpc_update_order_item_discount_amount", {
+              p_order_id: head.id, p_item_id: itemId,
+              p_new_amount: newAmt, p_operator: operator, p_reason: reason,
+            });
+            if (error) errors.push(`#${itemId} 折扣$：${translateRpcError(error)}`);
+          }
+        }
+      }
+    } finally {
+      setSaving(false);
+    }
+    if (errors.length > 0) {
+      alert(`儲存部分失敗：\n${errors.join("\n")}`);
+    } else {
+      clearDraft();
+    }
+    setReloadTick((n) => n + 1);
+  }
 
   const canTransfer = ["pending", "confirmed", "reserved"].includes(head.status);
   const canCancel = ["pending", "confirmed", "shipping"].includes(head.status);
@@ -186,6 +367,44 @@ export function OrderDetail({
 
   return (
     <div className="space-y-4 text-sm">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <button
+          onClick={() => setAuditOpen(true)}
+          className="rounded-md border border-zinc-300 px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          title="售價 / 備註變更歷史"
+        >
+          📜 查看編輯歷史
+        </button>
+      </div>
+
+      {draftCount > 0 && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-yellow-300 bg-yellow-50 p-3 dark:border-yellow-800 dark:bg-yellow-950/40">
+          <span className="text-xs font-medium text-yellow-800 dark:text-yellow-300">
+            ⚠️ 您有 {draftCount} 項未儲存的修改
+          </span>
+          <input
+            type="text"
+            value={editReason}
+            onChange={(e) => setEditReason(e.target.value)}
+            placeholder="修改原因（選填，會記錄到編輯歷史）"
+            className="ml-auto w-72 rounded-md border border-zinc-300 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-900"
+          />
+          <button
+            onClick={clearDraft}
+            disabled={saving}
+            className="rounded-md border border-zinc-300 px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          >
+            取消修改
+          </button>
+          <button
+            onClick={saveAllDraft}
+            disabled={saving}
+            className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {saving ? "儲存中…" : `💾 儲存（${draftCount}）`}
+          </button>
+        </div>
+      )}
       {(canTransfer || canPickup || canCancel || isTransferredOut) && (
         <div className="flex items-center justify-end gap-2">
           {canPickup && (
@@ -263,6 +482,29 @@ export function OrderDetail({
         <Field label="取貨店" value={head.store?.name ?? "—"} />
         <Field label="建立" value={fmtDt(head.created_at)} />
         <Field label="最後更新" value={fmtDt(head.updated_at)} />
+        <Field
+          label="整單折扣"
+          value={
+            <EditableDiscount
+              value={orderDiscountValue}
+              disabled={!canEdit}
+              onChange={(v) => setOrderDraft({ discount: v })}
+              referenceAmount={subtotal}
+            />
+          }
+        />
+        <Field
+          label="單頭備註"
+          value={
+            <EditableText
+              value={orderNotesValue}
+              disabled={!canEdit}
+              placeholder="（點此加備註）"
+              onSave={async (v) => setOrderDraft({ notes: v })}
+              multiline
+            />
+          }
+        />
       </div>
 
       {/* 進度 timeline（採購到貨 → 撿貨 → 派貨 → 分店收貨） */}
@@ -274,8 +516,24 @@ export function OrderDetail({
       )}
 
       <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
-        <div className="flex items-center justify-between border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-xs font-medium dark:border-zinc-800 dark:bg-zinc-900">
-          <span>明細（{items.length} 項 · {totalQty} 件 · ${totalAmount}）</span>
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-xs font-medium dark:border-zinc-800 dark:bg-zinc-900">
+          <span>明細（{items.length} 項 · {totalQty} 件）</span>
+          <div className="flex flex-wrap items-center gap-3 font-mono">
+            <span className="text-zinc-500">原價 ${grossTotal}</span>
+            {lineDiscountTotal > 0 && (
+              <span className="text-zinc-500">− 單品折扣 ${lineDiscountTotal}</span>
+            )}
+            <span className="text-zinc-500">小計 ${subtotal}</span>
+            {orderDeduction > 0 && (
+              <span className="text-zinc-500">
+                − 整單折扣
+                {orderDiscountValue.kind === "percent" && orderDiscountValue.value > 0
+                  ? ` ${orderDiscountValue.value}% (= $${orderDeduction})`
+                  : ` $${orderDeduction}`}
+              </span>
+            )}
+            <span className="text-base">= 應收 <span className="font-semibold">${payableAmount}</span></span>
+          </div>
         </div>
         <div className="overflow-x-auto">
           <table className="min-w-full divide-y divide-zinc-200 text-xs dark:divide-zinc-800">
@@ -284,18 +542,22 @@ export function OrderDetail({
                 <th className="px-3 py-2 text-left font-medium text-zinc-500">商品</th>
                 <th className="px-3 py-2 text-right font-medium text-zinc-500">數量</th>
                 <th className="px-3 py-2 text-right font-medium text-zinc-500">單價</th>
+                <th className="px-3 py-2 text-right font-medium text-zinc-500">折扣</th>
                 <th className="px-3 py-2 text-right font-medium text-zinc-500">小計</th>
+                <th className="px-3 py-2 text-left font-medium text-zinc-500">備註</th>
                 <th className="px-3 py-2 text-left font-medium text-zinc-500">第一次加</th>
                 <th className="px-3 py-2 text-left font-medium text-zinc-500">最後更新</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
               {items.length === 0 ? (
-                <tr><td colSpan={6} className="p-4 text-center text-zinc-500">尚無明細</td></tr>
+                <tr><td colSpan={8} className="p-4 text-center text-zinc-500">尚無明細</td></tr>
               ) : items.map((it) => {
-                const sub = Number(it.qty) * Number(it.unit_price);
+                const eff = itemEffective(it);
+                const sub = computeLineSubtotal(Number(it.qty), eff.unit_price, eff.discount);
+                const isDirty = draft.items.has(it.id);
                 return (
-                  <tr key={it.id}>
+                  <tr key={it.id} className={isDirty ? "bg-yellow-50 dark:bg-yellow-950/30" : ""}>
                     <td className="px-3 py-2">
                       {it.sku ? (
                         <span>
@@ -306,8 +568,33 @@ export function OrderDetail({
                       ) : "—"}
                     </td>
                     <td className="px-3 py-2 text-right font-mono">{Number(it.qty)}</td>
-                    <td className="px-3 py-2 text-right font-mono text-zinc-500">${Number(it.unit_price)}</td>
+                    <td className="px-3 py-2 text-right font-mono">
+                      <EditableNumber
+                        value={Number(eff.unit_price)}
+                        min={0}
+                        prefix="$"
+                        disabled={!canEdit}
+                        onSave={async (v) => setItemDraft(it.id, { unit_price: v })}
+                      />
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono">
+                      <EditableDiscount
+                        value={eff.discount}
+                        disabled={!canEdit}
+                        onChange={(v) => setItemDraft(it.id, { discount: v })}
+                        compact
+                        referenceAmount={Number(it.qty) * Number(eff.unit_price)}
+                      />
+                    </td>
                     <td className="px-3 py-2 text-right font-mono">${sub}</td>
+                    <td className="px-3 py-2">
+                      <EditableText
+                        value={eff.notes}
+                        disabled={!canEdit}
+                        placeholder="（點此加備註）"
+                        onSave={async (v) => setItemDraft(it.id, { notes: v })}
+                      />
+                    </td>
                     <td className="px-3 py-2 text-zinc-500">
                       {fmtDt(it.created_at)}<br />
                       <span className="text-[10px]">by {staffLabel(it.created_by, staffNames)}</span>
@@ -322,9 +609,6 @@ export function OrderDetail({
             </tbody>
           </table>
         </div>
-        <p className="border-t border-zinc-200 bg-zinc-50 px-3 py-1.5 text-[11px] text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900">
-          ※ 同顧客在同活動連 key 多次會合併到同一筆，舊 qty 被新值覆寫。如需「每次 +N 紀錄」請告知改完整版（加 append-only audit table）。
-        </p>
       </div>
 
       <OrderTransferModal
@@ -350,6 +634,11 @@ export function OrderDetail({
           alert(`取貨完成 (${r.picked_count} 項)\n訂單狀態：${statusLabel(r.new_order_status)}`);
           setReloadTick((n) => n + 1);
         }}
+      />
+      <OrderAuditDrawer
+        open={auditOpen}
+        onClose={() => setAuditOpen(false)}
+        orderId={head.id}
       />
     </div>
   );

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -209,13 +209,23 @@ export function PickupDialog({
             </div>
           )}
 
-          <div className="flex justify-end gap-2">
+          <div className="flex flex-wrap justify-end gap-2">
             <button
               onClick={onClose}
               disabled={busy}
               className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
             >
               取消
+            </button>
+            <button
+              onClick={() => {
+                window.open(withBasePath(`/pickup/print-list?order_ids=${orderId}`), "_blank");
+              }}
+              disabled={busy}
+              className="rounded-md border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:border-zinc-300 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
+              title="先印小白單給客人看，未確認取貨"
+            >
+              🖨️ 列印小白單
             </button>
             <button
               onClick={submit}

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -9,9 +9,17 @@ type PickableItem = {
   id: number;
   qty: number;
   unit_price: number;
+  discount_amount: number;
+  discount_percent: number;
   status: string;
   sku: { id: number; sku_code: string; product_name: string | null; variant_name: string | null } | null;
 };
+
+function lineSub(it: PickableItem): number {
+  const gross = Number(it.qty) * Number(it.unit_price);
+  const afterPct = gross * (1 - Number(it.discount_percent ?? 0) / 100);
+  return Math.max(0, Math.round(afterPct * 10000) / 10000 - Number(it.discount_amount ?? 0));
+}
 
 export function PickupDialog({
   open,
@@ -27,6 +35,8 @@ export function PickupDialog({
   onPickedUp: (result: { event_id: number; new_order_status: string; picked_count: number; active_remaining: number }) => void;
 }) {
   const [items, setItems] = useState<PickableItem[] | null>(null);
+  const [discount, setDiscount] = useState(0);
+  const [discountPercent, setDiscountPercent] = useState(0);
   const [picked, setPicked] = useState<Set<number>>(new Set());
   const [notes, setNotes] = useState("");
   const [busy, setBusy] = useState(false);
@@ -37,18 +47,26 @@ export function PickupDialog({
     let cancelled = false;
     (async () => {
       const sb = getSupabase();
-      const { data, error } = await sb
-        .from("customer_order_items")
-        .select("id, qty, unit_price, status, sku:skus(id, sku_code, product_name, variant_name)")
-        .eq("order_id", orderId)
-        .in("status", ["pending", "reserved", "ready"])
-        .order("id");
+      const [iRes, hRes] = await Promise.all([
+        sb.from("customer_order_items")
+          .select("id, qty, unit_price, discount_amount, discount_percent, status, sku:skus(id, sku_code, product_name, variant_name)")
+          .eq("order_id", orderId)
+          .in("status", ["pending", "reserved", "ready"])
+          .order("id"),
+        sb.from("customer_orders")
+          .select("discount_amount, discount_percent")
+          .eq("id", orderId)
+          .maybeSingle(),
+      ]);
       if (cancelled) return;
-      if (error) { setErr(error.message); return; }
-      const list = (data ?? []) as unknown as PickableItem[];
+      if (iRes.error) { setErr(iRes.error.message); return; }
+      const list = (iRes.data ?? []) as unknown as PickableItem[];
       setItems(list);
       // 預設全選
       setPicked(new Set(list.map((it) => it.id)));
+      const head = hRes.data as { discount_amount: number; discount_percent: number } | null;
+      setDiscount(Number(head?.discount_amount ?? 0));
+      setDiscountPercent(Number(head?.discount_percent ?? 0));
     })();
     return () => { cancelled = true; };
   }, [open, orderId]);
@@ -78,17 +96,20 @@ export function PickupDialog({
       });
       if (error) { setErr(error.message); return; }
       const result = data as { event_id: number; new_order_status: string; picked_count: number; active_remaining: number };
-      // 自動開新分頁列印
+      // 自動開新分頁列印 — 大張取貨單 + 熱感應小白單
       window.open(withBasePath(`/pickup/print?event_ids=${result.event_id}`), "_blank");
+      window.open(withBasePath(`/pickup/print-list?order_ids=${orderId}`), "_blank");
       onPickedUp(result);
     } finally {
       setBusy(false);
     }
   }
 
-  const totalAmount = items
-    ? items.filter((it) => picked.has(it.id)).reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0)
+  const subtotal = items
+    ? items.filter((it) => picked.has(it.id)).reduce((s, it) => s + lineSub(it), 0)
     : 0;
+  const percentDeduction = Math.round(subtotal * discountPercent) / 100;
+  const payableAmount = Math.max(0, subtotal - percentDeduction - discount);
 
   return (
     <Modal open={open} onClose={onClose} title={`✅ 確認取貨 — 訂單 ${orderNo}`} maxWidth="max-w-2xl">
@@ -112,7 +133,8 @@ export function PickupDialog({
               </thead>
               <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
                 {items.map((it) => {
-                  const sub = Number(it.qty) * Number(it.unit_price);
+                  const sub = lineSub(it);
+                  const hasLineDisc = Number(it.discount_amount ?? 0) > 0 || Number(it.discount_percent ?? 0) > 0;
                   return (
                     <tr key={it.id} className={picked.has(it.id) ? "bg-emerald-50 dark:bg-emerald-950" : ""}>
                       <td className="px-3 py-2">
@@ -128,6 +150,11 @@ export function PickupDialog({
                         {it.sku?.sku_code && (
                           <span className="ml-2 font-mono text-[10px] text-zinc-400">{it.sku.sku_code}</span>
                         )}
+                        {hasLineDisc && (
+                          <span className="ml-2 text-[10px] text-red-600 dark:text-red-400">
+                            (折{Number(it.discount_percent ?? 0) > 0 ? `${it.discount_percent}%` : ""}{Number(it.discount_amount ?? 0) > 0 ? ` -$${it.discount_amount}` : ""})
+                          </span>
+                        )}
                       </td>
                       <td className="px-3 py-2 text-right font-mono">{Number(it.qty)}</td>
                       <td className="px-3 py-2 text-right font-mono text-zinc-500">${Number(it.unit_price)}</td>
@@ -139,9 +166,28 @@ export function PickupDialog({
               </tbody>
               <tfoot className="bg-zinc-50 dark:bg-zinc-900">
                 <tr>
-                  <td colSpan={4} className="px-3 py-2 text-right text-xs text-zinc-500">取貨小計</td>
-                  <td className="px-3 py-2 text-right font-mono font-semibold">${totalAmount}</td>
-                  <td className="px-3 py-2 text-xs text-zinc-500">{picked.size}/{items.length} 項</td>
+                  <td colSpan={4} className="px-3 py-1 text-right text-xs text-zinc-500">取貨小計</td>
+                  <td className="px-3 py-1 text-right font-mono">${subtotal}</td>
+                  <td className="px-3 py-1 text-xs text-zinc-500">{picked.size}/{items.length} 項</td>
+                </tr>
+                {discountPercent > 0 && (
+                  <tr>
+                    <td colSpan={4} className="px-3 py-1 text-right text-xs text-zinc-500">− 全單折扣 {discountPercent}%</td>
+                    <td className="px-3 py-1 text-right font-mono text-red-600 dark:text-red-400">−${percentDeduction}</td>
+                    <td />
+                  </tr>
+                )}
+                {discount > 0 && (
+                  <tr>
+                    <td colSpan={4} className="px-3 py-1 text-right text-xs text-zinc-500">− 全單折扣金額</td>
+                    <td className="px-3 py-1 text-right font-mono text-red-600 dark:text-red-400">−${discount}</td>
+                    <td />
+                  </tr>
+                )}
+                <tr>
+                  <td colSpan={4} className="px-3 py-2 text-right text-xs text-zinc-500">應收</td>
+                  <td className="px-3 py-2 text-right font-mono text-base font-semibold">${payableAmount}</td>
+                  <td />
                 </tr>
               </tfoot>
             </table>
@@ -176,7 +222,7 @@ export function PickupDialog({
               disabled={busy || picked.size === 0}
               className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:opacity-50"
             >
-              {busy ? "處理中…" : `✅ 確認取貨 (${picked.size} 項)`}
+              {busy ? "處理中…" : `✅ 確認取貨 (${picked.size} 項 · $${payableAmount})`}
             </button>
           </div>
         </div>

--- a/docs/TEST-orders-edit.md
+++ b/docs/TEST-orders-edit.md
@@ -1,0 +1,209 @@
+# orders-edit 測試項目 — /orders 改售價 + 加備註
+
+**對應 migration:**
+- `supabase/migrations/20260605000000_orders_discount_widen_and_check.sql`
+- `supabase/migrations/20260605000001_customer_order_audit_log.sql`
+- `supabase/migrations/20260605000002_rpc_edit_order_price_and_notes.sql`
+
+**對應 UI 變更:**
+- `apps/admin/src/components/OrderDetail.tsx`
+- `apps/admin/src/components/OrderAuditDrawer.tsx`（新）
+- `apps/admin/src/app/(protected)/pickup/print/page.tsx`
+- `apps/admin/src/app/(protected)/pickup/print-list/page.tsx`
+- `apps/admin/src/app/(protected)/pickup/page.tsx`
+- `apps/admin/src/components/PickupDialog.tsx`
+
+**對應 plan:** `C:\Users\Alex\.claude\plans\zazzy-mapping-starfish.md`
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 customer_orders.discount_amount 變更
+- [ ] `discount_amount` 型別已是 `NUMERIC(18,4)`
+  ```sql
+  SELECT data_type, numeric_precision, numeric_scale
+    FROM information_schema.columns
+   WHERE table_name='customer_orders' AND column_name='discount_amount';
+  -- expect: numeric, 18, 4
+  ```
+- [ ] CHECK constraint `customer_orders_discount_amount_nonneg` 存在
+  ```sql
+  SELECT conname, pg_get_constraintdef(oid)
+    FROM pg_constraint
+   WHERE conrelid='customer_orders'::regclass
+     AND conname='customer_orders_discount_amount_nonneg';
+  ```
+- [ ] 既有 row 沒被破壞（migration 不能讓現有資料失敗）
+  ```sql
+  SELECT count(*) FROM customer_orders WHERE discount_amount < 0;  -- expect 0
+  ```
+
+### 1.2 customer_order_audit_log 表
+- [ ] 表存在且欄位齊全
+  ```sql
+  SELECT column_name, data_type, is_nullable
+    FROM information_schema.columns
+   WHERE table_name='customer_order_audit_log'
+   ORDER BY ordinal_position;
+  -- expect: id bigint, tenant_id uuid, order_id bigint, entity_type text,
+  --         entity_id bigint nullable, field text, before_value jsonb,
+  --         after_value jsonb, edit_reason text nullable,
+  --         operator_id uuid, created_at timestamptz
+  ```
+- [ ] CHECK constraint：`entity_type IN ('order','item')` + `field IN ('unit_price','item_notes','discount_amount','order_notes')`
+- [ ] FK：`order_id REFERENCES customer_orders(id) ON DELETE CASCADE`
+- [ ] Index：`(tenant_id, order_id, created_at DESC)` + `(order_id, entity_type, entity_id)`
+  ```sql
+  SELECT indexname, indexdef FROM pg_indexes
+   WHERE tablename='customer_order_audit_log';
+  ```
+- [ ] RLS 已啟用且只有 SELECT policy（無 INSERT/UPDATE/DELETE policy）
+  ```sql
+  SELECT polname, polcmd FROM pg_policy
+   WHERE polrelid='customer_order_audit_log'::regclass;
+  -- expect only 'r' (SELECT) policies
+  ```
+- [ ] `forbid_append_only_mutation` trigger 在表上
+  ```sql
+  SELECT tgname FROM pg_trigger
+   WHERE tgrelid='customer_order_audit_log'::regclass
+     AND NOT tgisinternal;
+  ```
+
+### 1.3 RPC signatures
+- [ ] `_check_order_edit_perm(BIGINT)` 存在、SECURITY DEFINER、回傳 customer_orders
+- [ ] `rpc_update_order_item_price(BIGINT, BIGINT, NUMERIC, UUID, TEXT)` 存在
+- [ ] `rpc_update_order_discount(BIGINT, NUMERIC, UUID, TEXT)` 存在
+- [ ] `rpc_update_order_notes(BIGINT, TEXT, UUID, TEXT)` 存在
+- [ ] `rpc_update_order_item_notes(BIGINT, BIGINT, TEXT, UUID, TEXT)` 存在
+- [ ] 4 個 public RPC 都 GRANT EXECUTE TO authenticated；helper 沒 grant
+  ```sql
+  SELECT proname, prosecdef, pg_get_function_arguments(oid)
+    FROM pg_proc
+   WHERE proname IN ('_check_order_edit_perm','rpc_update_order_item_price',
+                     'rpc_update_order_discount','rpc_update_order_notes',
+                     'rpc_update_order_item_notes');
+  ```
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 rpc_update_order_item_price — happy path
+**情境：** HQ 帳號改某 item 的 unit_price 從 100 → 90
+**預期：**
+- `customer_order_items.unit_price = 90`、`updated_by = operator`、`updated_at` 更新
+- `customer_order_audit_log` 多一筆：`entity_type='item', entity_id=<item>, field='unit_price', before_value=100, after_value=90, operator_id=<operator>`
+
+### 2.2 rpc_update_order_item_price — no-op
+**情境：** new 值 = 舊值
+**預期：** 不更新主表 `updated_at`、**不寫 audit log**、不報錯，回傳目前 row
+
+### 2.3 rpc_update_order_item_price — 負值拒絕
+**情境：** `p_new_unit_price = -1`
+**預期：** RAISE EXCEPTION `unit_price must be >= 0`，主表與 audit log 都沒動
+
+### 2.4 rpc_update_order_item_price — item 不屬於 order
+**情境：** `p_item_id` 屬於別張 order
+**預期：** RAISE EXCEPTION `item % not in order %`
+
+### 2.5 rpc_update_order_discount — happy path
+**情境：** HQ 改 discount_amount 0 → 50
+**預期：** `customer_orders.discount_amount = 50`，audit log `field='discount_amount', before=0, after=50`
+
+### 2.6 rpc_update_order_discount — CHECK 拒絕負值
+**情境：** `p_new_discount = -1`
+**預期：** RAISE EXCEPTION（RPC 主動檢查 + DB CHECK 雙保險）
+
+### 2.7 rpc_update_order_notes — null 與空字串
+- [ ] `p_new_notes = NULL` → 寫入 NULL，audit log `after_value = null`
+- [ ] `p_new_notes = ''` → 寫入空字串，audit log `after_value = ""`
+
+### 2.8 rpc_update_order_item_notes — happy path
+**情境：** 從 NULL → "客人現金付清"
+**預期：** item.notes 更新；audit `field='item_notes', before=null, after='客人現金付清'`
+
+### 2.9 權限矩陣（同一張 order，pickup_store_id=A）
+> 用三組 JWT 分別跑：HQ admin / store-A user / store-B user
+
+| 角色 | 4 個 RPC | 預期 |
+|---|---|---|
+| HQ owner / admin / hq_manager | 全部 | 成功 |
+| role NULL（admin tier 慣例） | 全部 | 成功 |
+| store-A user (`store_id`=A) | 全部 | 成功 |
+| store-B user (`store_id`=B) | 全部 | RAISE `permission denied` |
+| 無 role 無 store_id | 全部 | RAISE `permission denied` |
+
+- [ ] HQ admin 全部過
+- [ ] role NULL 全部過
+- [ ] store-A 全部過
+- [ ] store-B 全部被拒
+- [ ] 跨 tenant：HQ-tenant1 對 tenant2 訂單 → RAISE `order % not found`
+
+### 2.10 並發鎖
+**情境：** 同 item 兩個 session 同時改 unit_price
+**預期：** 第二個 session 等第一個 commit 後讀到新值；兩筆 audit log 都在；無 lost update
+
+### 2.11 Audit log append-only
+- [ ] 直接 `UPDATE customer_order_audit_log SET ...` → 報錯（trigger）
+- [ ] 直接 `DELETE FROM customer_order_audit_log` → 報錯（trigger）
+- [ ] 認證 user 直接 `INSERT INTO customer_order_audit_log` → 失敗（無 INSERT policy）
+
+---
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 OrderDetail — header 編輯
+**路徑：** `/orders` → 點任一訂單列 → OrderDetail 開啟
+- [ ] 開啟 OrderDetail 無 console error
+- [ ] 看到「整單折扣」與「單頭備註」欄位
+- [ ] 應收金額顯示三行：原始小計 / − 整單折扣 / = 應收
+- [ ] 點折扣欄 → 變 input → 輸入 50 → blur → 折扣顯示 50、應收金額 = 小計 − 50
+- [ ] reload 頁面後折扣仍是 50
+- [ ] 點折扣欄 → 輸入 -1 → blur → alert 錯誤訊息、值回到原本
+- [ ] 點折扣欄 → 輸入 0 → blur → 應收金額 = 小計
+- [ ] 點單頭備註 → 輸入 "test note" → blur → 顯示更新；reload 還在
+- [ ] Esc 取消編輯（不打 RPC、值還原）
+
+### 3.2 OrderDetail — line item 編輯
+- [ ] 商品 table 多一欄「備註」
+- [ ] 點 unit_price → 輸入 90 → blur → cell 顯示 90、小計 / 應收同步重算
+- [ ] 點 unit_price → 輸入 -5 → blur → alert 錯、值還原
+- [ ] 點 item.notes → 輸入文字 → blur → 顯示更新
+- [ ] 同一輪改多個 item 都各自獨立 RPC，不互相干擾
+
+### 3.3 OrderAuditDrawer
+- [ ] 動作列有「查看編輯歷史」按鈕
+- [ ] 點開 drawer，列出剛剛的編輯（時間 desc），每筆顯示：時間 / 欄位中文名 / before → after / 操作人姓名 / reason（若有）
+- [ ] 沒有編輯的訂單 → drawer 顯示「尚無編輯紀錄」
+- [ ] 操作人 UUID 解析為姓名（透過 `rpc_get_staff_names`）
+
+### 3.4 店家權限 UI
+- [ ] 店家帳號（store_id=A）開自店訂單 → 4 個欄位都可編輯
+- [ ] 店家帳號開**他店**訂單 → 4 個欄位純文字、無 input
+- [ ] HQ 帳號開任何店訂單 → 全部可編輯
+
+### 3.5 Pickup 列印金額對齊
+**前置：** 找一張 discount_amount > 0 的訂單
+- [ ] `/pickup/print/<order>` 列印小白單顯示「折扣 -X」、總額 = 小計 − 折扣
+- [ ] `/pickup/print-list` 列表合計含折扣
+- [ ] `/pickup` 主頁訂單列「金額」顯示扣折扣後
+- [ ] PickupDialog 顯示的 `totalAmount` 已扣折扣
+
+---
+
+## 4. Regression
+
+- [ ] LIFF `/orders/:id` 顧客端的 `payable_amount` 仍正確（直接讀 `v_customer_order_summary` 不應壞）
+- [ ] LIFF `OrderCard.tsx` / `SettlementCard.tsx` 的應付金額仍對得起 admin
+- [ ] `rpc_record_pickup` 仍可正常執行（不依賴金額計算）
+- [ ] 既有訂單列表 `/orders` 篩選 / 排序 / 分頁 不受影響
+- [ ] 訂單轉手 (`rpc_create_offset_order`) 仍能執行（已知限制：事後改價不會回灌 offset 訂單，預期）
+- [ ] 商品 / 候選池 / 其他模組 build 過、type-check 過
+
+---
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**Supabase dev push 成功**、**build + type-check 過** 才可標 done。

--- a/supabase/migrations/20260605000000_orders_discount_widen_and_check.sql
+++ b/supabase/migrations/20260605000000_orders_discount_widen_and_check.sql
@@ -1,0 +1,108 @@
+-- ============================================================
+-- customer_orders.discount_amount
+--   widen NUMERIC(18,2) -> NUMERIC(18,4) 對齊 unit_price 精度
+--   加 CHECK >= 0
+--
+-- v_customer_order_summary 依賴 discount_amount，要先 drop 才能 ALTER；
+-- 再以同一份 SQL（沿用 20260516000008 的最新版）重建。
+-- ============================================================
+
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+ALTER TABLE customer_orders
+  ALTER COLUMN discount_amount TYPE NUMERIC(18,4);
+
+ALTER TABLE customer_orders
+  ADD CONSTRAINT customer_orders_discount_amount_nonneg
+    CHECK (discount_amount >= 0);
+
+COMMENT ON COLUMN customer_orders.discount_amount IS
+  '整單折扣（從應付扣除）；line items 各自用 unit_price 編輯';
+
+-- ---------- 重建 v_customer_order_summary（沿用 20260516000008 內容） ----------
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  agg.items_total,
+  agg.items_total + co.shipping_fee - co.discount_amount   AS payable_amount,
+  agg.items,
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','shipping','completed'))                  AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))              AS settled,
+  (co.payment_status = 'paid')                                                   AS paid,
+  (co.status IN ('shipping','completed'))                                        AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                   AS settlement_no,
+  s.name                                                                          AS store_name,
+  s.code                                                                          AS store_code,
+  gbc.name                                                                        AS campaign_name,
+  gbc.cover_image_url                                                             AS campaign_cover_url,
+  gbc.end_at                                                                      AS campaign_end_at,
+  gbc.cutoff_date                                                                 AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price), 0)                                   AS items_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'sku_code',         sk.sku_code,
+          'product_name',     sk.product_name,
+          'variant_name',     sk.variant_name,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'subtotal',         coi.qty * coi.unit_price,
+          'status',           coi.status,
+          'notes',            coi.notes,
+          'image_url',        CASE
+            WHEN jsonb_typeof(p.images) = 'array' AND jsonb_array_length(p.images) > 0 THEN
+              COALESCE(p.images -> 0 ->> 'url', p.images ->> 0)
+            ELSE NULL
+          END
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                             AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus     sk ON sk.id = coi.sku_id
+  LEFT JOIN products p  ON p.id  = sk.product_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細（含 sku 名/規格/縮圖 path） + campaign 名 + 結單號（widened discount_amount）';

--- a/supabase/migrations/20260605000001_customer_order_audit_log.sql
+++ b/supabase/migrations/20260605000001_customer_order_audit_log.sql
@@ -1,0 +1,50 @@
+-- ============================================================
+-- customer_order_audit_log: 訂單售價 / 備註變更歷史 (append-only)
+--   涵蓋 entity_type IN ('order','item')
+--   涵蓋 field IN ('unit_price','item_notes','discount_amount','order_notes')
+--   edit_reason 為 optional（與 campaign_audit_log 不同），UI 不強制填
+-- ============================================================
+
+CREATE TABLE customer_order_audit_log (
+  id           BIGSERIAL PRIMARY KEY,
+  tenant_id    UUID   NOT NULL,
+  order_id     BIGINT NOT NULL REFERENCES customer_orders(id) ON DELETE CASCADE,
+  entity_type  TEXT   NOT NULL CHECK (entity_type IN ('order','item')),
+  entity_id    BIGINT,
+  field        TEXT   NOT NULL CHECK (field IN
+                  ('unit_price','item_notes','discount_amount','order_notes')),
+  before_value JSONB,
+  after_value  JSONB,
+  edit_reason  TEXT,
+  operator_id  UUID   NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  -- append-only：無 updated_*
+);
+
+CREATE INDEX idx_coa_order  ON customer_order_audit_log (tenant_id, order_id, created_at DESC);
+CREATE INDEX idx_coa_entity ON customer_order_audit_log (order_id, entity_type, entity_id);
+
+CREATE TRIGGER trg_no_mut_coa BEFORE UPDATE OR DELETE ON customer_order_audit_log
+  FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+
+ALTER TABLE customer_order_audit_log ENABLE ROW LEVEL SECURITY;
+
+-- HQ 可看本 tenant 全部
+CREATE POLICY coa_hq_read ON customer_order_audit_log
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND COALESCE(auth.jwt() ->> 'role', '') IN
+      ('owner','admin','hq_manager','hq_accountant','')
+  );
+
+-- 店家只看自己 pickup_store 的訂單
+CREATE POLICY coa_store_read ON customer_order_audit_log
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND order_id IN (
+      SELECT id FROM customer_orders
+       WHERE pickup_store_id = NULLIF(auth.jwt() ->> 'store_id','')::bigint
+    )
+  );
+
+-- 不開 INSERT/UPDATE/DELETE policy → 只允 SECURITY DEFINER RPC 寫

--- a/supabase/migrations/20260605000002_rpc_edit_order_price_and_notes.sql
+++ b/supabase/migrations/20260605000002_rpc_edit_order_price_and_notes.sql
@@ -1,0 +1,248 @@
+-- ============================================================
+-- /orders 改售價 + 加備註 RPC 集
+--   全部 SECURITY DEFINER（admin user JWT role 常為 NULL，需繞 RLS）
+--   權限：HQ (owner/admin/hq_manager) 全 + 店家僅自店訂單
+--   role 為 NULL 視同 admin tier（reference_admin_jwt_role_null.md）
+--   每次修改寫一筆 customer_order_audit_log；no-op (新值=舊值) 不寫
+-- ============================================================
+
+-- ---------- helper：權限檢查 + 鎖 order ----------
+CREATE OR REPLACE FUNCTION _check_order_edit_perm(p_order_id BIGINT)
+RETURNS customer_orders
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order  customer_orders%ROWTYPE;
+  v_tenant UUID   := (auth.jwt() ->> 'tenant_id')::uuid;
+  v_role   TEXT   := COALESCE(auth.jwt() ->> 'role', '');
+  v_store  BIGINT := NULLIF(auth.jwt() ->> 'store_id','')::bigint;
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+
+  SELECT * INTO v_order
+    FROM customer_orders
+   WHERE id = p_order_id AND tenant_id = v_tenant
+   FOR UPDATE;
+
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found in tenant %', p_order_id, v_tenant;
+  END IF;
+
+  -- HQ tier（含 role NULL）
+  IF v_role IN ('owner','admin','hq_manager','hq_accountant','') THEN
+    RETURN v_order;
+  END IF;
+
+  -- 店家：限自店
+  IF v_store IS NOT NULL AND v_order.pickup_store_id = v_store THEN
+    RETURN v_order;
+  END IF;
+
+  RAISE EXCEPTION 'permission denied: role=% store=% cannot edit order %',
+    v_role, COALESCE(v_store::text,'NULL'), p_order_id;
+END;
+$$;
+
+-- ---------- 1. line item unit_price ----------
+CREATE OR REPLACE FUNCTION rpc_update_order_item_price(
+  p_order_id       BIGINT,
+  p_item_id        BIGINT,
+  p_new_unit_price NUMERIC,
+  p_operator       UUID,
+  p_reason         TEXT DEFAULT NULL
+) RETURNS customer_order_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order customer_orders%ROWTYPE;
+  v_old   NUMERIC;
+  v_row   customer_order_items;
+BEGIN
+  v_order := _check_order_edit_perm(p_order_id);
+
+  IF p_new_unit_price IS NULL OR p_new_unit_price < 0 THEN
+    RAISE EXCEPTION 'unit_price must be >= 0';
+  END IF;
+
+  SELECT unit_price INTO v_old
+    FROM customer_order_items
+   WHERE id = p_item_id AND order_id = p_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'item % not in order %', p_item_id, p_order_id;
+  END IF;
+
+  IF v_old = p_new_unit_price THEN
+    SELECT * INTO v_row FROM customer_order_items WHERE id = p_item_id;
+    RETURN v_row;
+  END IF;
+
+  UPDATE customer_order_items
+     SET unit_price = p_new_unit_price,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_item_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'item', p_item_id, 'unit_price',
+     to_jsonb(v_old), to_jsonb(p_new_unit_price), p_reason, p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+-- ---------- 2. order header discount_amount ----------
+CREATE OR REPLACE FUNCTION rpc_update_order_discount(
+  p_order_id     BIGINT,
+  p_new_discount NUMERIC,
+  p_operator     UUID,
+  p_reason       TEXT DEFAULT NULL
+) RETURNS customer_orders
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order customer_orders%ROWTYPE;
+  v_old   NUMERIC;
+  v_row   customer_orders;
+BEGIN
+  v_order := _check_order_edit_perm(p_order_id);
+
+  IF p_new_discount IS NULL OR p_new_discount < 0 THEN
+    RAISE EXCEPTION 'discount must be >= 0';
+  END IF;
+
+  v_old := v_order.discount_amount;
+
+  IF v_old = p_new_discount THEN
+    RETURN v_order;
+  END IF;
+
+  UPDATE customer_orders
+     SET discount_amount = p_new_discount,
+         updated_by      = p_operator,
+         updated_at      = NOW()
+   WHERE id = p_order_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'order', NULL, 'discount_amount',
+     to_jsonb(v_old), to_jsonb(p_new_discount), p_reason, p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+-- ---------- 3. order header notes ----------
+CREATE OR REPLACE FUNCTION rpc_update_order_notes(
+  p_order_id  BIGINT,
+  p_new_notes TEXT,
+  p_operator  UUID,
+  p_reason    TEXT DEFAULT NULL
+) RETURNS customer_orders
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order customer_orders%ROWTYPE;
+  v_old   TEXT;
+  v_row   customer_orders;
+BEGIN
+  v_order := _check_order_edit_perm(p_order_id);
+
+  v_old := v_order.notes;
+
+  IF v_old IS NOT DISTINCT FROM p_new_notes THEN
+    RETURN v_order;
+  END IF;
+
+  UPDATE customer_orders
+     SET notes      = p_new_notes,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_order_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'order', NULL, 'order_notes',
+     to_jsonb(v_old), to_jsonb(p_new_notes), p_reason, p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+-- ---------- 4. line item notes ----------
+CREATE OR REPLACE FUNCTION rpc_update_order_item_notes(
+  p_order_id  BIGINT,
+  p_item_id   BIGINT,
+  p_new_notes TEXT,
+  p_operator  UUID,
+  p_reason    TEXT DEFAULT NULL
+) RETURNS customer_order_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order customer_orders%ROWTYPE;
+  v_old   TEXT;
+  v_row   customer_order_items;
+BEGIN
+  v_order := _check_order_edit_perm(p_order_id);
+
+  SELECT notes INTO v_old
+    FROM customer_order_items
+   WHERE id = p_item_id AND order_id = p_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'item % not in order %', p_item_id, p_order_id;
+  END IF;
+
+  IF v_old IS NOT DISTINCT FROM p_new_notes THEN
+    SELECT * INTO v_row FROM customer_order_items WHERE id = p_item_id;
+    RETURN v_row;
+  END IF;
+
+  UPDATE customer_order_items
+     SET notes      = p_new_notes,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_item_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'item', p_item_id, 'item_notes',
+     to_jsonb(v_old), to_jsonb(p_new_notes), p_reason, p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+-- ---------- GRANT EXECUTE（4 個對外 RPC；helper 不開 grant） ----------
+GRANT EXECUTE ON FUNCTION rpc_update_order_item_price(BIGINT, BIGINT, NUMERIC, UUID, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION rpc_update_order_discount(BIGINT, NUMERIC, UUID, TEXT)           TO authenticated;
+GRANT EXECUTE ON FUNCTION rpc_update_order_notes(BIGINT, TEXT, UUID, TEXT)                 TO authenticated;
+GRANT EXECUTE ON FUNCTION rpc_update_order_item_notes(BIGINT, BIGINT, TEXT, UUID, TEXT)    TO authenticated;

--- a/supabase/migrations/20260605000003_fix_check_order_edit_perm_jwt.sql
+++ b/supabase/migrations/20260605000003_fix_check_order_edit_perm_jwt.sql
@@ -1,0 +1,55 @@
+-- ============================================================
+-- _check_order_edit_perm: 修權限判斷
+--   原版讀 auth.jwt() ->> 'role'，但這欄位是 PostgREST 預設 'authenticated'
+--   而不是 app 自定義 role；admin user 在這欄永遠拿到 'authenticated'
+--   → 改成優先讀 app_metadata.role（與 useRole() / canSeeCost() 一致）
+--   → app_metadata.role 為 NULL 時視為 HQ tier
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION _check_order_edit_perm(p_order_id BIGINT)
+RETURNS customer_orders
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order  customer_orders%ROWTYPE;
+  v_tenant UUID   := (auth.jwt() ->> 'tenant_id')::uuid;
+  -- 優先 app_metadata.role；若為 NULL/空 視為 admin tier
+  v_role   TEXT   := COALESCE(
+                       NULLIF(auth.jwt() -> 'app_metadata' ->> 'role', ''),
+                       NULLIF(auth.jwt() ->> 'role', 'authenticated'),
+                       ''
+                     );
+  v_store  BIGINT := COALESCE(
+                       NULLIF(auth.jwt() -> 'app_metadata' ->> 'store_id', '')::bigint,
+                       NULLIF(auth.jwt() ->> 'store_id','')::bigint
+                     );
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+
+  SELECT * INTO v_order
+    FROM customer_orders
+   WHERE id = p_order_id AND tenant_id = v_tenant
+   FOR UPDATE;
+
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found in tenant %', p_order_id, v_tenant;
+  END IF;
+
+  -- HQ tier（含 role NULL/空字串）
+  IF v_role IN ('owner','admin','hq_manager','hq_accountant','') THEN
+    RETURN v_order;
+  END IF;
+
+  -- 店家：限自店
+  IF v_store IS NOT NULL AND v_order.pickup_store_id = v_store THEN
+    RETURN v_order;
+  END IF;
+
+  RAISE EXCEPTION 'permission denied: role=% store=% cannot edit order %',
+    v_role, COALESCE(v_store::text,'NULL'), p_order_id;
+END;
+$$;

--- a/supabase/migrations/20260605000004_fix_audit_log_rls_app_metadata.sql
+++ b/supabase/migrations/20260605000004_fix_audit_log_rls_app_metadata.sql
@@ -1,0 +1,32 @@
+-- ============================================================
+-- customer_order_audit_log RLS：同 SECURITY DEFINER 修法
+--   admin user JWT 的 role 是 'authenticated'，自定義 role 在 app_metadata.role
+--   修 SELECT policy 讓 HQ 與店家都能正確判斷
+-- ============================================================
+
+DROP POLICY IF EXISTS coa_hq_read    ON customer_order_audit_log;
+DROP POLICY IF EXISTS coa_store_read ON customer_order_audit_log;
+
+-- HQ：app_metadata.role IN HQ tier，或無自定義 role 視為 HQ tier
+CREATE POLICY coa_hq_read ON customer_order_audit_log
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND COALESCE(
+          NULLIF(auth.jwt() -> 'app_metadata' ->> 'role', ''),
+          NULLIF(auth.jwt() ->> 'role', 'authenticated'),
+          ''
+        ) IN ('owner','admin','hq_manager','hq_accountant','')
+  );
+
+-- 店家：app_metadata.store_id 或 top-level store_id 對到自己 pickup_store
+CREATE POLICY coa_store_read ON customer_order_audit_log
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND order_id IN (
+      SELECT id FROM customer_orders
+       WHERE pickup_store_id = COALESCE(
+         NULLIF(auth.jwt() -> 'app_metadata' ->> 'store_id', '')::bigint,
+         NULLIF(auth.jwt() ->> 'store_id','')::bigint
+       )
+    )
+  );

--- a/supabase/migrations/20260605000005_add_discount_percent.sql
+++ b/supabase/migrations/20260605000005_add_discount_percent.sql
@@ -1,0 +1,166 @@
+-- ============================================================
+-- customer_orders.discount_percent
+--   整單折扣的「比例版」（與 discount_amount 並存可同時使用）
+--   值範圍 0-100，例：10 = 9折
+--   payable = subtotal × (1 - percent/100) − discount_amount
+--
+-- 也擴充 customer_order_audit_log.field 允許 'discount_percent'
+-- 並重建 v_customer_order_summary.payable_amount 公式
+-- ============================================================
+
+ALTER TABLE customer_orders
+  ADD COLUMN discount_percent NUMERIC(5,2) NOT NULL DEFAULT 0
+    CHECK (discount_percent >= 0 AND discount_percent <= 100);
+
+COMMENT ON COLUMN customer_orders.discount_percent IS
+  '整單折扣比例（0-100，例 10 = 9折）；與 discount_amount 並存：payable = subtotal × (1 − percent/100) − discount_amount';
+
+-- 擴充 audit log field CHECK
+ALTER TABLE customer_order_audit_log DROP CONSTRAINT customer_order_audit_log_field_check;
+ALTER TABLE customer_order_audit_log
+  ADD CONSTRAINT customer_order_audit_log_field_check
+    CHECK (field IN ('unit_price','item_notes','discount_amount','discount_percent','order_notes'));
+
+-- 重建 v_customer_order_summary 套用 percent
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.discount_percent,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  agg.items_total,
+  GREATEST(
+    0,
+    ROUND(agg.items_total * (1 - co.discount_percent / 100), 4)
+      + co.shipping_fee
+      - co.discount_amount
+  )                                                                            AS payable_amount,
+  agg.items,
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','shipping','completed'))                AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))            AS settled,
+  (co.payment_status = 'paid')                                                 AS paid,
+  (co.status IN ('shipping','completed'))                                      AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                 AS settlement_no,
+  s.name                                                                        AS store_name,
+  s.code                                                                        AS store_code,
+  gbc.name                                                                      AS campaign_name,
+  gbc.cover_image_url                                                           AS campaign_cover_url,
+  gbc.end_at                                                                    AS campaign_end_at,
+  gbc.cutoff_date                                                               AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price), 0)                                 AS items_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'sku_code',         sk.sku_code,
+          'product_name',     sk.product_name,
+          'variant_name',     sk.variant_name,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'subtotal',         coi.qty * coi.unit_price,
+          'status',           coi.status,
+          'notes',            coi.notes,
+          'image_url',        CASE
+            WHEN jsonb_typeof(p.images) = 'array' AND jsonb_array_length(p.images) > 0 THEN
+              COALESCE(p.images -> 0 ->> 'url', p.images ->> 0)
+            ELSE NULL
+          END
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                           AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus     sk ON sk.id = coi.sku_id
+  LEFT JOIN products p  ON p.id  = sk.product_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細 + percent + amount 雙折扣';
+
+-- 新 RPC：rpc_update_order_discount_percent
+CREATE OR REPLACE FUNCTION rpc_update_order_discount_percent(
+  p_order_id    BIGINT,
+  p_new_percent NUMERIC,
+  p_operator    UUID,
+  p_reason      TEXT DEFAULT NULL
+) RETURNS customer_orders
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order customer_orders%ROWTYPE;
+  v_old   NUMERIC;
+  v_row   customer_orders;
+BEGIN
+  v_order := _check_order_edit_perm(p_order_id);
+
+  IF p_new_percent IS NULL OR p_new_percent < 0 OR p_new_percent > 100 THEN
+    RAISE EXCEPTION 'discount_percent must be between 0 and 100';
+  END IF;
+
+  v_old := v_order.discount_percent;
+
+  IF v_old = p_new_percent THEN
+    RETURN v_order;
+  END IF;
+
+  UPDATE customer_orders
+     SET discount_percent = p_new_percent,
+         updated_by       = p_operator,
+         updated_at       = NOW()
+   WHERE id = p_order_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'order', NULL, 'discount_percent',
+     to_jsonb(v_old), to_jsonb(p_new_percent), p_reason, p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_update_order_discount_percent(BIGINT, NUMERIC, UUID, TEXT) TO authenticated;

--- a/supabase/migrations/20260605000006_add_line_level_discount.sql
+++ b/supabase/migrations/20260605000006_add_line_level_discount.sql
@@ -1,0 +1,246 @@
+-- ============================================================
+-- 單品項折扣（customer_order_items）：金額 + 百分比
+--   line_subtotal = qty × unit_price × (1 − line_pct/100) − line_amt
+-- 累計後再套用 order-level discount_percent / discount_amount
+--
+-- 也擴 audit log field、重建 v_customer_order_summary 套用線性折扣
+-- ============================================================
+
+ALTER TABLE customer_order_items
+  ADD COLUMN discount_amount  NUMERIC(18,4) NOT NULL DEFAULT 0
+    CHECK (discount_amount  >= 0),
+  ADD COLUMN discount_percent NUMERIC(5,2)  NOT NULL DEFAULT 0
+    CHECK (discount_percent >= 0 AND discount_percent <= 100);
+
+COMMENT ON COLUMN customer_order_items.discount_amount  IS '單品項折扣金額 (line subtotal 直接扣除)';
+COMMENT ON COLUMN customer_order_items.discount_percent IS '單品項折扣比例 0-100，例 20 = 80折';
+
+-- 擴 audit log field
+ALTER TABLE customer_order_audit_log DROP CONSTRAINT customer_order_audit_log_field_check;
+ALTER TABLE customer_order_audit_log
+  ADD CONSTRAINT customer_order_audit_log_field_check
+    CHECK (field IN (
+      'unit_price','item_notes','item_discount_amount','item_discount_percent',
+      'discount_amount','discount_percent','order_notes'
+    ));
+
+-- 重建 view 套用 line-level discount → items_total → order discount
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.discount_percent,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  agg.items_total,
+  GREATEST(
+    0,
+    ROUND(agg.items_total * (1 - co.discount_percent / 100), 4)
+      + co.shipping_fee
+      - co.discount_amount
+  )                                                                            AS payable_amount,
+  agg.items,
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','shipping','completed'))                AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))            AS settled,
+  (co.payment_status = 'paid')                                                 AS paid,
+  (co.status IN ('shipping','completed'))                                      AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                 AS settlement_no,
+  s.name                                                                        AS store_name,
+  s.code                                                                        AS store_code,
+  gbc.name                                                                      AS campaign_name,
+  gbc.cover_image_url                                                           AS campaign_cover_url,
+  gbc.end_at                                                                    AS campaign_end_at,
+  gbc.cutoff_date                                                               AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    -- items_total 已套線性折扣
+    COALESCE(SUM(
+      GREATEST(
+        0,
+        ROUND(coi.qty * coi.unit_price * (1 - coi.discount_percent / 100), 4)
+          - coi.discount_amount
+      )
+    ), 0) AS items_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',                    coi.id,
+          'sku_id',                coi.sku_id,
+          'sku_code',              sk.sku_code,
+          'product_name',          sk.product_name,
+          'variant_name',          sk.variant_name,
+          'campaign_item_id',      coi.campaign_item_id,
+          'qty',                   coi.qty,
+          'unit_price',            coi.unit_price,
+          'discount_amount',       coi.discount_amount,
+          'discount_percent',      coi.discount_percent,
+          'subtotal',              GREATEST(
+            0,
+            ROUND(coi.qty * coi.unit_price * (1 - coi.discount_percent / 100), 4)
+              - coi.discount_amount
+          ),
+          'status',                coi.status,
+          'notes',                 coi.notes,
+          'image_url',             CASE
+            WHEN jsonb_typeof(p.images) = 'array' AND jsonb_array_length(p.images) > 0 THEN
+              COALESCE(p.images -> 0 ->> 'url', p.images ->> 0)
+            ELSE NULL
+          END
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                           AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus     sk ON sk.id = coi.sku_id
+  LEFT JOIN products p  ON p.id  = sk.product_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細（含線性 + 整單兩層折扣 / amount + percent）';
+
+-- 兩個新 RPC：item-level discount amount / percent
+CREATE OR REPLACE FUNCTION rpc_update_order_item_discount_amount(
+  p_order_id   BIGINT,
+  p_item_id    BIGINT,
+  p_new_amount NUMERIC,
+  p_operator   UUID,
+  p_reason     TEXT DEFAULT NULL
+) RETURNS customer_order_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order customer_orders%ROWTYPE;
+  v_old   NUMERIC;
+  v_row   customer_order_items;
+BEGIN
+  v_order := _check_order_edit_perm(p_order_id);
+
+  IF p_new_amount IS NULL OR p_new_amount < 0 THEN
+    RAISE EXCEPTION 'item discount_amount must be >= 0';
+  END IF;
+
+  SELECT discount_amount INTO v_old
+    FROM customer_order_items
+   WHERE id = p_item_id AND order_id = p_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'item % not in order %', p_item_id, p_order_id;
+  END IF;
+
+  IF v_old = p_new_amount THEN
+    SELECT * INTO v_row FROM customer_order_items WHERE id = p_item_id;
+    RETURN v_row;
+  END IF;
+
+  UPDATE customer_order_items
+     SET discount_amount = p_new_amount,
+         updated_by      = p_operator,
+         updated_at      = NOW()
+   WHERE id = p_item_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'item', p_item_id, 'item_discount_amount',
+     to_jsonb(v_old), to_jsonb(p_new_amount), p_reason, p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION rpc_update_order_item_discount_percent(
+  p_order_id    BIGINT,
+  p_item_id     BIGINT,
+  p_new_percent NUMERIC,
+  p_operator    UUID,
+  p_reason      TEXT DEFAULT NULL
+) RETURNS customer_order_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order customer_orders%ROWTYPE;
+  v_old   NUMERIC;
+  v_row   customer_order_items;
+BEGIN
+  v_order := _check_order_edit_perm(p_order_id);
+
+  IF p_new_percent IS NULL OR p_new_percent < 0 OR p_new_percent > 100 THEN
+    RAISE EXCEPTION 'item discount_percent must be between 0 and 100';
+  END IF;
+
+  SELECT discount_percent INTO v_old
+    FROM customer_order_items
+   WHERE id = p_item_id AND order_id = p_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'item % not in order %', p_item_id, p_order_id;
+  END IF;
+
+  IF v_old = p_new_percent THEN
+    SELECT * INTO v_row FROM customer_order_items WHERE id = p_item_id;
+    RETURN v_row;
+  END IF;
+
+  UPDATE customer_order_items
+     SET discount_percent = p_new_percent,
+         updated_by       = p_operator,
+         updated_at       = NOW()
+   WHERE id = p_item_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'item', p_item_id, 'item_discount_percent',
+     to_jsonb(v_old), to_jsonb(p_new_percent), p_reason, p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_update_order_item_discount_amount(BIGINT, BIGINT, NUMERIC, UUID, TEXT)  TO authenticated;
+GRANT EXECUTE ON FUNCTION rpc_update_order_item_discount_percent(BIGINT, BIGINT, NUMERIC, UUID, TEXT) TO authenticated;


### PR DESCRIPTION
## TL;DR
這輪把訂單編輯、催取貨、奧客處理、會員合併 一條龍 ship。**白話版 release note**：[docs/RELEASE-2026-05-06.md](docs/RELEASE-2026-05-06.md)

## 主要功能（依使用者視角）

### 1. 訂單編輯（售價 / 折扣 / 備註）
- 8 個欄位可編：line item × { unit_price, 折扣, 備註 } + order header × { 折扣, 備註 }
- 折扣 1 欄、$/% 二擇一，% 即時顯示等值金額（如 `8% (= $11.52)`）
- **batch draft**：所有改動先進黃底 draft 區、附選填「修改原因」、一次按 💾 儲存
- **audit log**：append-only 表，drawer 顯示時間/欄位/before→after/操作人/原因

### 2. /pickup 取貨優化
- 排序：**可取貨在前 + 到貨時間久的優先催**
- 顯示「✅ 已到貨 / ⏳ 未到貨 / 📨 上次通知 X 時」
- PickupDialog 加「🖨️ 列印小白單」(取貨前先給客人對金額)
- 確認取貨自動同開大張取貨單 + 熱感應小白單

### 3. 列印優化（讓客人覺得有賺到）
- 商品原價 ~~刪除線~~ + 折扣價紅字
- 商品備註 / 訂單備註 都印出
- 22% 顯示為「22%」(過去誤寫成「22折」)

### 4. 通知顧客取貨
- 每張可取訂單加「🔔 通知」按鈕 → 走 admin-notify edge fn
- **分店收貨自動推播**已存在 → 加黑名單過濾 + 標 last_notify_pickup_at
- 推播完訂單列顯示「📨 上次通知 X」(避免重複轟炸)

### 5. 黑名單 (members)
- `no_notify_pickup` — 跳過取貨通知 (手動 + 自動)
- `no_new_order` — **小幫手加單頁擋住**（client UI + server RPC 雙重 guard）
- `admin_note` — 管理員專用暱稱備註，**LIFF / 列印 / 我的介面都不會出現**

### 6. 虛擬 ↔ LINE 會員合併
- MemberMergeModal：搜尋目標 + 確認 → 走既有 `rpc_merge_member`
- 訂單 / 點數 / 儲值 / 卡片 / 標籤 全部搬到實體會員

### 7. UI 細節
- Modal 改為**只能按 ✕ 關**（避免操作中誤關）
- /orders 拿掉批次取貨工具列（取貨集中到 /pickup）
- /orders 拿掉 pending / 可取貨 / 運送中 標籤（已被其他訊號表達）

## DB / RPC 變更（11 migrations）

| 編號 | 內容 |
|---|---|
| `20260605000000` | widen `discount_amount` → NUMERIC(18,4) + CHECK + 重建 view |
| `20260605000001` | 新表 `customer_order_audit_log` (append-only + RLS) |
| `20260605000002` | 4 SECURITY DEFINER RPC + 共用權限 helper `_check_order_edit_perm` |
| `20260605000003` | helper 修：JWT `role='authenticated'` 改讀 `app_metadata.role` |
| `20260605000004` | audit log RLS 同樣修法 |
| `20260605000005` | order-level `discount_percent` + view + RPC |
| `20260605000006` | line-level `discount_amount`/`discount_percent` + view + 2 RPC |
| `20260605000007` | members 加 `no_notify_pickup` / `no_new_order` / `admin_note` + `rpc_set_member_flags` |
| `20260605000008` | `rpc_create_customer_orders` 加黑名單檢查 |
| `20260605000009` | `rpc_search_members` / `rpc_search_aliases` 回傳黑名單欄位 |
| `20260605000010` | `customer_orders.last_notify_pickup_at/notify_pickup_count` + `rpc_mark_pickup_notified` |
| `20260605000011` | `rpc_get_members_to_notify_for_transfer` 加黑名單過濾 |

## 應收金額計算
\`\`\`
line_subtotal = qty × unit_price × (1 − line_pct/100) − line_amt
order_subtotal = sum(line_subtotal)
payable = max(0, order_subtotal × (1 − order_pct/100) − order_amt + shipping_fee)
\`\`\`

## 權限
- HQ (owner / admin / hq_manager / hq_accountant / role NULL) → 全部 OK
- 店家 (`store_id` 對到 `pickup_store_id`) → 自店訂單 OK
- 任何狀態都能改（含已完成）

## Test plan
- [x] HQ 帳號改 unit_price / 折扣 / 備註 → audit drawer 出現對應變更（preview 驗過）
- [x] 折扣 \$ ↔ % 切換與儲存正確（會把對方歸零）
- [x] 批次修改 → draft 區 → 一次儲存 → audit log 對 + 原因正確
- [x] 負值被前後端雙重拒絕
- [x] 黑名單會員在小幫手加單頁顯示「🚫 黑名單禁加單」+ 整列禁用 + 送出按鈕禁用
- [x] 黑名單會員在 /pickup 通知按鈕禁用
- [ ] 店家帳號限自店；他店訂單僅能讀（待 QA 用店帳號驗）
- [ ] LIFF 顧客端 \`payable_amount\` 對齊 admin 應收
- [ ] 分店收貨自動通知時黑名單會員確實被跳過
- [ ] 列印頁 /pickup/print 與 /pickup/print-list 顯示原價刪除線 + 折扣 + 備註

## 測試文件
\`docs/TEST-orders-edit.md\` (隨 PR 附)

## Release note (給老人看)
\`docs/RELEASE-2026-05-06.md\` — 已用白話寫，可直接貼群組

🤖 Generated with [Claude Code](https://claude.com/claude-code)