### PR TITLE
fix/feat: 規格刪除/訂單跨店可見/取貨店/加單修復+timer/候選池批次排日期

### DIFF
--- a/apps/admin/src/app/(protected)/community-candidates/page.tsx
+++ b/apps/admin/src/app/(protected)/community-candidates/page.tsx
@@ -62,8 +62,23 @@ export default function CommunityCandidatesPage() {
   const [adoptCost, setAdoptCost] = useState("");
   const [adoptSalePrice, setAdoptSalePrice] = useState("");
   const [highlightId, setHighlightId] = useState<number | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [bulkDate, setBulkDate] = useState("");
 
   const highlightRowRef = useRef<HTMLElement | null>(null);
+
+  const isSelectable = (r: Candidate) =>
+    r.owner_action !== "scheduled" && r.owner_action !== "adopted";
+
+  const toggleOne = (id: number) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const clearSelected = () => setSelected(new Set());
 
   useEffect(() => {
     const id = Number(new URLSearchParams(window.location.search).get("highlight"));
@@ -114,6 +129,7 @@ export default function CommunityCandidatesPage() {
 
   useEffect(() => {
     reload();
+    clearSelected();
   }, [query, tab]);
 
   const patch = async (id: number, updates: Record<string, unknown>) => {
@@ -226,6 +242,47 @@ export default function CommunityCandidatesPage() {
     await scheduleAt(id, dateStr);
     setScheduling(null);
     setScheduleDate("");
+  };
+
+  const handleBulkSchedule = async (dateStr: string) => {
+    if (!dateStr || selected.size === 0) return;
+    const ids = [...selected].filter((id) => {
+      const r = rows?.find((x) => x.id === id);
+      return r && isSelectable(r);
+    });
+    if (ids.length === 0) {
+      setError("沒有可排程的候選（已排程或已採用的會略過）");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      // 順序執行：每一筆建 product/sku/campaign 再補 sort_order，避免 sort 撞號
+      for (const id of ids) {
+        const row = rows?.find((r) => r.id === id);
+        if (!row) continue;
+        const productName = deriveProductName(row);
+        const { error: rpcErr } = await sb.rpc("rpc_schedule_candidate", {
+          p_candidate_id: id,
+          p_scheduled_date: dateStr,
+          p_product_name: productName,
+        });
+        if (rpcErr) throw rpcErr;
+        const nextOrder = await nextSortOrderForDay(dateStr);
+        await sb
+          .from("community_product_candidates")
+          .update({ scheduled_sort_order: nextOrder })
+          .eq("id", id);
+      }
+      clearSelected();
+      setBulkDate("");
+      await reload();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
   };
 
   const extractPrice = (text: string): string => {
@@ -537,6 +594,50 @@ export default function CommunityCandidatesPage() {
         </div>
       )}
 
+      {/* 批次排日期工具列 */}
+      {selected.size > 0 && (
+        <div className="sticky top-0 z-10 flex flex-wrap items-center gap-2 rounded-md border border-amber-300 bg-amber-50 p-2.5 text-sm dark:border-amber-700 dark:bg-amber-950/40">
+          <span className="font-medium text-amber-800 dark:text-amber-200">
+            已選 {selected.size} 筆
+          </span>
+          <div className="flex flex-wrap items-center gap-1">
+            {[
+              { label: "明天", date: localDateStr(1) },
+              { label: "後天", date: localDateStr(2) },
+              { label: "下週一", date: nextWeekMonday() },
+            ].map(({ label, date }) => (
+              <button
+                key={label}
+                onClick={() => handleBulkSchedule(date)}
+                disabled={busy}
+                className="rounded bg-amber-500 px-2.5 py-1 text-xs text-white hover:bg-amber-600 disabled:opacity-50"
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <DatePicker
+            value={bulkDate}
+            onChange={setBulkDate}
+            className="rounded border border-zinc-300 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-900"
+          />
+          <button
+            onClick={() => handleBulkSchedule(bulkDate)}
+            disabled={!bulkDate || busy}
+            className="rounded bg-amber-600 px-3 py-1 text-xs font-semibold text-white hover:bg-amber-700 disabled:opacity-50"
+          >
+            {busy ? "排程中…" : "📅 批次排日期"}
+          </button>
+          <button
+            onClick={clearSelected}
+            disabled={busy}
+            className="ml-auto rounded border border-zinc-300 px-2.5 py-1 text-xs text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800 disabled:opacity-50"
+          >
+            清除選取
+          </button>
+        </div>
+      )}
+
       {rows === null ? (
         <div className="text-sm text-zinc-400">載入中…</div>
       ) : rows.length === 0 ? (
@@ -549,6 +650,28 @@ export default function CommunityCandidatesPage() {
           <table className="w-full text-sm">
             <thead className="bg-zinc-50 text-xs text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400">
               <tr>
+                <th className="w-8 px-2 py-2 text-left">
+                  {(() => {
+                    const selectables = (rows ?? []).filter(isSelectable);
+                    const allSelected = selectables.length > 0 && selectables.every((r) => selected.has(r.id));
+                    return (
+                      <input
+                        type="checkbox"
+                        checked={allSelected}
+                        disabled={selectables.length === 0}
+                        onChange={(e) => {
+                          if (e.target.checked) {
+                            setSelected(new Set(selectables.map((r) => r.id)));
+                          } else {
+                            clearSelected();
+                          }
+                        }}
+                        title="全選可排程的候選"
+                        className="h-4 w-4 cursor-pointer"
+                      />
+                    );
+                  })()}
+                </th>
                 <th className="px-3 py-2 text-left font-medium">時間</th>
                 <th className="px-3 py-2 text-left font-medium">商品名稱</th>
                 <th className="px-3 py-2 text-left font-medium">文案</th>
@@ -571,6 +694,16 @@ export default function CommunityCandidatesPage() {
                       : ""
                   }`}
                 >
+                  <td className="px-2 py-3">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(r.id)}
+                      disabled={!isSelectable(r)}
+                      onChange={() => toggleOne(r.id)}
+                      className="h-4 w-4 cursor-pointer disabled:cursor-not-allowed disabled:opacity-30"
+                      title={isSelectable(r) ? "選取" : "已排程或已採用,不可批次排程"}
+                    />
+                  </td>
                   <td className="whitespace-nowrap px-3 py-3 text-zinc-500">{fmt(r.created_at)}</td>
                   <td className="px-3 py-3 font-medium">
                     {r.product_name_hint ?? "—"}
@@ -636,11 +769,20 @@ export default function CommunityCandidatesPage() {
                 }`}
               >
                 <div className="flex items-center justify-between gap-2">
-                  <span
-                    className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-medium ${ACTION_COLOR[r.owner_action] ?? ACTION_COLOR.none}`}
-                  >
-                    {ACTION_LABEL[r.owner_action] ?? r.owner_action}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(r.id)}
+                      disabled={!isSelectable(r)}
+                      onChange={() => toggleOne(r.id)}
+                      className="h-4 w-4 cursor-pointer disabled:cursor-not-allowed disabled:opacity-30"
+                    />
+                    <span
+                      className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-medium ${ACTION_COLOR[r.owner_action] ?? ACTION_COLOR.none}`}
+                    >
+                      {ACTION_LABEL[r.owner_action] ?? r.owner_action}
+                    </span>
+                  </div>
                   <span className="text-[11px] text-zinc-400">{fmt(r.created_at)}</span>
                 </div>
 

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -14,6 +14,7 @@ type Member = {
   birthday: string | null;
   email: string | null;
   tier_id: number | null;
+  home_store_id: number | null;
   status: string;
   member_type: string | null;
   notes: string | null;
@@ -27,6 +28,7 @@ type Member = {
   merged_into_member_id: number | null;
 };
 type Tier = { id: number; name: string };
+type Store = { id: number; code: string; name: string };
 
 type PointsEntry = {
   id: number;
@@ -50,6 +52,7 @@ type WalletEntry = {
 export function MemberDetail({ memberId }: { memberId: number }) {
   const [member, setMember] = useState<Member | null>(null);
   const [tier, setTier] = useState<Tier | null>(null);
+  const [stores, setStores] = useState<Store[]>([]);
   const [points, setPoints] = useState(0);
   const [wallet, setWallet] = useState(0);
   const [pLedger, setPLedger] = useState<PointsEntry[]>([]);
@@ -63,6 +66,8 @@ export function MemberDetail({ memberId }: { memberId: number }) {
   const [draftAdminNote, setDraftAdminNote] = useState("");
   const [draftNoNotify, setDraftNoNotify] = useState(false);
   const [draftNoNewOrder, setDraftNoNewOrder] = useState(false);
+  const [draftHomeStoreId, setDraftHomeStoreId] = useState<string>("");
+  const [savingStore, setSavingStore] = useState(false);
 
   async function saveFlags() {
     if (!member) return;
@@ -82,6 +87,23 @@ export function MemberDetail({ memberId }: { memberId: number }) {
       setReloadTick((n) => n + 1);
     } finally {
       setSavingFlags(false);
+    }
+  }
+
+  async function saveHomeStore() {
+    if (!member) return;
+    setSavingStore(true);
+    try {
+      const sb = getSupabase();
+      const newId = draftHomeStoreId === "" ? null : Number(draftHomeStoreId);
+      const { error: e } = await sb.rpc("rpc_set_member_home_store", {
+        p_member_id: member.id,
+        p_home_store_id: newId,
+      });
+      if (e) { alert(`儲存失敗：${translateRpcError(e)}`); return; }
+      setReloadTick((n) => n + 1);
+    } finally {
+      setSavingStore(false);
     }
   }
 
@@ -128,7 +150,7 @@ export function MemberDetail({ memberId }: { memberId: number }) {
       const sb = getSupabase();
       const { data: m, error: err } = await sb
         .from("members")
-        .select("id, member_no, phone, name, gender, birthday, email, tier_id, status, member_type, notes, admin_note, no_notify_pickup, no_new_order, avatar_url, line_user_id, joined_at, last_visit_at, merged_into_member_id")
+        .select("id, member_no, phone, name, gender, birthday, email, tier_id, home_store_id, status, member_type, notes, admin_note, no_notify_pickup, no_new_order, avatar_url, line_user_id, joined_at, last_visit_at, merged_into_member_id")
         .eq("id", memberId).maybeSingle<Member>();
       if (cancelled) return;
       if (err) { setError(err.message); return; }
@@ -137,9 +159,11 @@ export function MemberDetail({ memberId }: { memberId: number }) {
       setDraftAdminNote(m.admin_note ?? "");
       setDraftNoNotify(!!m.no_notify_pickup);
       setDraftNoNewOrder(!!m.no_new_order);
+      setDraftHomeStoreId(m.home_store_id ? String(m.home_store_id) : "");
 
-      const [tierQ, pb, wb, pl, wl] = await Promise.all([
+      const [tierQ, storesQ, pb, wb, pl, wl] = await Promise.all([
         m.tier_id ? sb.from("member_tiers").select("id, name").eq("id", m.tier_id).maybeSingle<Tier>() : Promise.resolve({ data: null }),
+        sb.from("stores").select("id, code, name").eq("is_active", true).order("name"),
         sb.from("member_points_balance").select("balance").eq("member_id", memberId).maybeSingle<{ balance: number }>(),
         sb.from("wallet_balances").select("balance").eq("member_id", memberId).maybeSingle<{ balance: number }>(),
         sb.from("points_ledger").select("id, change, balance_after, source_type, reason, created_at").eq("member_id", memberId).order("created_at", { ascending: false }).limit(50),
@@ -147,6 +171,7 @@ export function MemberDetail({ memberId }: { memberId: number }) {
       ]);
       if (cancelled) return;
       setTier(tierQ.data as Tier | null);
+      setStores((storesQ.data as Store[]) ?? []);
       setPoints(Number(pb.data?.balance ?? 0));
       setWallet(Number(wb.data?.balance ?? 0));
       setPLedger((pl.data as PointsEntry[]) ?? []);
@@ -269,6 +294,53 @@ export function MemberDetail({ memberId }: { memberId: number }) {
             </button>
           </div>
         )}
+      </div>
+
+      {/* 取貨店 — admin 可改；改店守衛在 RPC 內檢查未取貨訂單 */}
+      <div className="rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
+        <div className="mb-2 flex items-center justify-between">
+          <div className="text-xs font-medium text-zinc-500">取貨店（會員預設取貨店）</div>
+          {member.home_store_id && (
+            <span className="text-xs text-zinc-500">
+              現：{stores.find((s) => s.id === member.home_store_id)?.name ?? `#${member.home_store_id}`}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={draftHomeStoreId}
+            onChange={(e) => setDraftHomeStoreId(e.target.value)}
+            className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+          >
+            <option value="">— 未指定 —</option>
+            {stores.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name} ({s.code})
+              </option>
+            ))}
+          </select>
+          {draftHomeStoreId !== (member.home_store_id ? String(member.home_store_id) : "") && (
+            <>
+              <button
+                onClick={() => setDraftHomeStoreId(member.home_store_id ? String(member.home_store_id) : "")}
+                disabled={savingStore}
+                className="rounded-md border border-zinc-300 px-3 py-1 text-xs hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              >
+                還原
+              </button>
+              <button
+                onClick={saveHomeStore}
+                disabled={savingStore}
+                className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+              >
+                {savingStore ? "儲存中…" : "💾 儲存"}
+              </button>
+            </>
+          )}
+        </div>
+        <p className="mt-1 text-xs text-zinc-500">
+          會員仍有未取貨訂單時，後端會擋下改店動作（保護既有訂單的取貨地點）。
+        </p>
       </div>
 
       <MemberMergeModal

--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -22,8 +22,6 @@ type MemberData = {
   status: string;
 };
 
-type StoreOption = { id: number; code: string; name: string };
-
 type Overview = {
   store: {
     id: number;
@@ -52,8 +50,7 @@ export default function MePage() {
 
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [form, setForm] = useState({ name: "", phone: "", birthday: "", email: "", home_store_id: "" });
-  const [stores, setStores] = useState<StoreOption[]>([]);
+  const [form, setForm] = useState({ name: "", phone: "", birthday: "", email: "" });
 
   // 推播訂閱狀態 lift 到頁面層,頭像區跟底部 PushNotificationManager 共用
   const pushState = usePushNotification(getSession()?.token ?? null);
@@ -114,20 +111,17 @@ export default function MePage() {
 
     (async () => {
       try {
-        const [meData, ovData, storesData] = await Promise.all([
+        const [meData, ovData] = await Promise.all([
           callLiffApi<MemberData>(s.token, { action: "get_me" }),
           callLiffApi<Overview>(s.token, { action: "get_overview" }).catch(() => null),
-          callLiffApi<{ stores: StoreOption[] }>("", { action: "list_stores" }).catch(() => ({ stores: [] })),
         ]);
         setMe(meData);
         if (ovData) setOverview(ovData);
-        setStores(storesData.stores ?? []);
         setForm({
           name: meData.name ?? "",
           phone: meData.phone ?? "",
           birthday: meData.birthday ?? "",
           email: meData.email ?? "",
-          home_store_id: meData.home_store_id ? String(meData.home_store_id) : "",
         });
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
@@ -149,7 +143,6 @@ export default function MePage() {
         phone: form.phone,
         birthday: form.birthday,
         email: form.email,
-        home_store_id: form.home_store_id || null,
       });
       const data = await callLiffApi<MemberData>(s.token, { action: "get_me" });
       setMe(data);
@@ -413,19 +406,10 @@ export default function MePage() {
                     className="w-full bg-transparent text-right text-[17px] text-[var(--foreground)] outline-none placeholder:text-[var(--tertiary-label)]"
                   />
                 </FormField>
-                <FormField label="取貨店" hint="預設取貨地點">
-                  <select
-                    value={form.home_store_id}
-                    onChange={(e) => setForm({ ...form, home_store_id: e.target.value })}
-                    className="w-full bg-transparent text-right text-[17px] text-[var(--foreground)] outline-none"
-                  >
-                    <option value="">未選擇</option>
-                    {stores.map((s) => (
-                      <option key={s.id} value={s.id}>{s.name}</option>
-                    ))}
-                  </select>
-                </FormField>
               </div>
+              <p className="px-4 pt-2 text-[12px] text-[var(--tertiary-label)]">
+                取貨店請聯絡店家調整。
+              </p>
             </section>
 
             <div className="flex gap-2 px-1 pt-1">
@@ -439,7 +423,6 @@ export default function MePage() {
                     phone: me.phone ?? "",
                     birthday: me.birthday ?? "",
                     email: me.email ?? "",
-                    home_store_id: me.home_store_id ? String(me.home_store_id) : "",
                   });
                 }}
                 disabled={saving}

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -205,13 +205,7 @@ async function updateMe(sb: any, tenantId: string, memberId: number, p: any) {
       patch.email_hash = null;
     }
   }
-  if (p.home_store_id !== undefined && p.home_store_id !== null && p.home_store_id !== "") {
-    const sid = Number(p.home_store_id);
-    if (!Number.isFinite(sid) || sid <= 0) return json({ error: "home_store_id invalid" }, 400);
-    const { data: s } = await sb.from("stores").select("id").eq("tenant_id", tenantId).eq("id", sid).eq("is_active", true).maybeSingle();
-    if (!s) return json({ error: "store not found or inactive" }, 400);
-    patch.home_store_id = sid;
-  }
+  // home_store_id 只允許 admin 從會員明細頁改 (rpc_set_member_home_store)；LIFF 不可改。
   if (Object.keys(patch).length === 0) return json({ error: "nothing to update" }, 400);
   patch.updated_at = new Date().toISOString();
   const { error } = await sb.from("members").update(patch).eq("tenant_id", tenantId).eq("id", memberId);

--- a/supabase/migrations/20260605000012_rpc_set_member_home_store.sql
+++ b/supabase/migrations/20260605000012_rpc_set_member_home_store.sql
@@ -1,0 +1,55 @@
+-- ============================================================
+-- 改 home_store_id 專用 RPC（給 admin 會員明細頁用）
+--   守衛同 rpc_upsert_member: 仍有未取貨訂單時不允許改取貨店
+--   SECURITY DEFINER 繞過 admin JWT role NULL 的 RLS 限制
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_set_member_home_store(
+  p_member_id     BIGINT,
+  p_home_store_id BIGINT
+) RETURNS members
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant      UUID := public._current_tenant_id();
+  v_old_store   BIGINT;
+  v_open_orders INT;
+  v_row         members;
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+
+  IF p_home_store_id IS NOT NULL THEN
+    PERFORM 1 FROM stores WHERE id = p_home_store_id AND tenant_id = v_tenant AND is_active = TRUE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'store % not in tenant or inactive', p_home_store_id; END IF;
+  END IF;
+
+  SELECT home_store_id INTO v_old_store FROM members
+   WHERE id = p_member_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'member % not in tenant', p_member_id; END IF;
+
+  IF v_old_store IS DISTINCT FROM p_home_store_id THEN
+    SELECT COUNT(*) INTO v_open_orders FROM customer_orders
+     WHERE tenant_id = v_tenant
+       AND member_id = p_member_id
+       AND status NOT IN ('completed','cancelled','expired');
+    IF v_open_orders > 0 THEN
+      RAISE EXCEPTION '會員仍有 % 筆未取貨訂單，請先處理完才能改取貨店', v_open_orders;
+    END IF;
+  END IF;
+
+  UPDATE members
+     SET home_store_id = p_home_store_id,
+         updated_by    = auth.uid(),
+         updated_at    = NOW()
+   WHERE id = p_member_id AND tenant_id = v_tenant
+   RETURNING * INTO v_row;
+
+  RETURN v_row;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_set_member_home_store(BIGINT, BIGINT) TO authenticated;

--- a/supabase/migrations/20260605000013_rpc_create_customer_orders_skip_cancelled.sql
+++ b/supabase/migrations/20260605000013_rpc_create_customer_orders_skip_cancelled.sql
@@ -1,0 +1,147 @@
+-- ============================================================
+-- rpc_create_customer_orders 找既有訂單時排除 cancelled / expired / transferred_out
+--
+-- bug：原本 SELECT id INTO v_order_id 沒過濾 status，會抓到歷史已取消訂單
+-- 走 UPDATE branch，把新 items 加進取消的訂單裡，使用者看起來像「加單沒成功」。
+-- 修：SELECT 條件對齊 UNIQUE INDEX customer_orders_trio_kind_active_uniq 的 partial
+-- WHERE 條件，讓 cancelled/expired/transferred_out 不擋 INSERT 新訂單。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_create_customer_orders(
+  p_campaign_id BIGINT,
+  p_channel_id  BIGINT,
+  p_rows        JSONB
+) RETURNS TABLE (out_order_id BIGINT, out_order_no TEXT, out_item_count INT)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant       UUID := public._current_tenant_id();
+  v_user         UUID := auth.uid();
+  v_status       TEXT;
+  v_campaign_no  TEXT;
+  v_row          JSONB;
+  v_item         JSONB;
+  v_member_id    BIGINT;
+  v_pickup_store BIGINT;
+  v_nickname     TEXT;
+  v_order_id     BIGINT;
+  v_order_no     TEXT;
+  v_seq          INT;
+  v_ci_id        BIGINT;
+  v_ci_price     NUMERIC;
+  v_qty          NUMERIC;
+  v_ci_sku       BIGINT;
+  v_existing_qty NUMERIC;
+  v_count        INT;
+  v_blacklisted  BOOLEAN;
+  v_member_name  TEXT;
+BEGIN
+  SELECT status, campaign_no INTO v_status, v_campaign_no
+    FROM group_buy_campaigns WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  IF v_status IS NULL THEN RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id; END IF;
+  IF v_status <> 'open' THEN
+    RAISE EXCEPTION 'campaign % is %; only open campaigns accept manual entry',
+                    p_campaign_id, v_status;
+  END IF;
+
+  PERFORM 1 FROM line_channels WHERE id = p_channel_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'channel % not in tenant', p_channel_id; END IF;
+
+  IF p_rows IS NULL OR jsonb_array_length(p_rows) = 0 THEN
+    RAISE EXCEPTION 'p_rows is empty';
+  END IF;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_rows)
+  LOOP
+    v_member_id    := (v_row ->> 'member_id')::BIGINT;
+    v_pickup_store := (v_row ->> 'pickup_store_id')::BIGINT;
+    v_nickname     := v_row ->> 'nickname';
+
+    IF v_member_id IS NULL THEN RAISE EXCEPTION 'member_id required'; END IF;
+    IF v_pickup_store IS NULL THEN RAISE EXCEPTION 'pickup_store_id required'; END IF;
+
+    SELECT no_new_order, COALESCE(name, member_no)
+      INTO v_blacklisted, v_member_name
+      FROM members
+     WHERE id = v_member_id AND tenant_id = v_tenant;
+    IF v_blacklisted IS NULL THEN
+      RAISE EXCEPTION 'member % not in tenant', v_member_id;
+    END IF;
+    IF v_blacklisted THEN
+      RAISE EXCEPTION '會員「%」已被列入黑名單，禁止建立 / 加單', v_member_name;
+    END IF;
+
+    PERFORM 1 FROM stores WHERE id = v_pickup_store AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'store % not in tenant', v_pickup_store; END IF;
+
+    -- 找既有訂單時排除已 cancelled / expired / transferred_out（對齊 UNIQUE 部分索引）
+    SELECT id INTO v_order_id FROM customer_orders
+     WHERE tenant_id = v_tenant
+       AND campaign_id = p_campaign_id
+       AND channel_id  = p_channel_id
+       AND member_id   = v_member_id
+       AND status NOT IN ('cancelled','expired','transferred_out');
+
+    IF v_order_id IS NULL THEN
+      SELECT COUNT(*) + 1 INTO v_seq FROM customer_orders
+       WHERE tenant_id = v_tenant AND campaign_id = p_campaign_id;
+      v_order_no := v_campaign_no || '-' || lpad(v_seq::text, 4, '0');
+
+      INSERT INTO customer_orders (
+        tenant_id, order_no, campaign_id, channel_id, member_id,
+        nickname_snapshot, pickup_store_id, status, created_by, updated_by
+      ) VALUES (
+        v_tenant, v_order_no, p_campaign_id, p_channel_id, v_member_id,
+        v_nickname, v_pickup_store, 'pending', v_user, v_user
+      ) RETURNING id INTO v_order_id;
+    ELSE
+      UPDATE customer_orders SET
+        nickname_snapshot = COALESCE(v_nickname, nickname_snapshot),
+        pickup_store_id   = v_pickup_store,
+        updated_by        = v_user
+      WHERE id = v_order_id
+      RETURNING order_no INTO v_order_no;
+    END IF;
+
+    FOR v_item IN SELECT * FROM jsonb_array_elements(v_row -> 'items')
+    LOOP
+      v_ci_id := (v_item ->> 'campaign_item_id')::BIGINT;
+      v_qty   := (v_item ->> 'qty')::NUMERIC;
+      IF v_qty IS NULL OR v_qty <= 0 THEN RAISE EXCEPTION 'qty must be > 0'; END IF;
+
+      SELECT unit_price, sku_id INTO v_ci_price, v_ci_sku
+        FROM campaign_items
+       WHERE id = v_ci_id AND tenant_id = v_tenant AND campaign_id = p_campaign_id;
+      IF v_ci_price IS NULL THEN
+        RAISE EXCEPTION 'campaign_item % not in campaign %', v_ci_id, p_campaign_id;
+      END IF;
+
+      SELECT coi.qty INTO v_existing_qty FROM customer_order_items coi
+       WHERE coi.order_id = v_order_id AND coi.campaign_item_id = v_ci_id;
+
+      IF v_existing_qty IS NULL THEN
+        INSERT INTO customer_order_items (
+          tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+          status, source, created_by, updated_by
+        ) VALUES (
+          v_tenant, v_order_id, v_ci_id, v_ci_sku, v_qty, v_ci_price,
+          'pending', 'manual', v_user, v_user
+        );
+      ELSE
+        UPDATE customer_order_items coi SET
+          qty        = v_existing_qty + v_qty,
+          updated_by = v_user
+        WHERE coi.order_id = v_order_id AND coi.campaign_item_id = v_ci_id;
+      END IF;
+    END LOOP;
+
+    SELECT COUNT(*) INTO v_count FROM customer_order_items coi WHERE coi.order_id = v_order_id;
+    out_order_id   := v_order_id;
+    out_order_no   := v_order_no;
+    out_item_count := v_count;
+    RETURN NEXT;
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_customer_orders TO authenticated;

--- a/supabase/migrations/20260605000014_auto_close_expired_campaigns.sql
+++ b/supabase/migrations/20260605000014_auto_close_expired_campaigns.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- 開團 end_at 到期自動切 status=closed (已收單)
+--   pg_cron 每分鐘掃 status='open' 且 end_at < NOW() 的活動切成 closed
+--   end_at IS NULL 視為「無到期日」不自動關
+-- ============================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+
+-- 給 cron schema 在 postgres role 之外可訪問
+GRANT USAGE ON SCHEMA cron TO postgres;
+
+-- RPC：執行一次掃描 + 關團；回傳關掉的數量供觀察
+CREATE OR REPLACE FUNCTION public.rpc_auto_close_expired_campaigns()
+RETURNS INT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count INT;
+BEGIN
+  WITH closed AS (
+    UPDATE group_buy_campaigns
+       SET status     = 'closed',
+           updated_at = NOW()
+     WHERE status     = 'open'
+       AND end_at IS NOT NULL
+       AND end_at < NOW()
+    RETURNING id
+  )
+  SELECT COUNT(*) INTO v_count FROM closed;
+  RETURN v_count;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_auto_close_expired_campaigns IS
+  '每分鐘 cron 掃 end_at 到期的 open 活動切成 closed';
+
+-- 排程：每分鐘執行
+-- 注意：cron.schedule 會 idempotent 處理同名 job，重複 run migration 不會炸
+SELECT cron.schedule(
+  'auto-close-expired-campaigns',
+  '* * * * *',
+  $cron$ SELECT public.rpc_auto_close_expired_campaigns(); $cron$
+);


### PR DESCRIPTION
## Summary

一輪 session 累積 6 個 commit,涵蓋 admin/member 兩端 + edge function + DB migrations。

### 修復
- **fix(admin)**: 規格刪除後沒從列表消失(軟刪 status='discontinued',前端沒過濾)
- **fix(orders)**: 取消過的會員無法重新加單(rpc_create_customer_orders 找既有訂單時沒排除 cancelled,items 加進已取消訂單)

### 新功能
- **feat(member)**: 我的訂單/結單跨店可見(原本依 JWT.store_id 過濾,但同 line_user 可綁多店,跨 OA 看不到自己訂單);OrderCard 已會顯示 store_name 區別
- **feat(admin)**: 會員明細頁可改取貨店(`rpc_set_member_home_store` + 未取貨訂單 guard);唯一改 home_store 入口,LIFF 端唯讀
- **feat(timer)**: 開團 end_at 到期自動切 closed(已收單) — pg_cron 每分鐘掃 status='open' AND end_at < NOW() → closed
- **feat(admin)**: 候選池多選 + 批次排日期 — checkbox 全選/單選 + sticky 工具列(明天/後天/下週一 quick options + DatePicker + 確定),已排程/已採用會 disable

### Migrations (4)
- `20260605000012_rpc_set_member_home_store.sql`
- `20260605000013_rpc_create_customer_orders_skip_cancelled.sql`
- `20260605000014_auto_close_expired_campaigns.sql`(+ pg_cron extension)

> 4 個 migration 已透過 `supabase db push --linked` 套到 production DB。
> `liff-api` edge function 也在 session 中 deploy 了多次。
> admin frontend 變動 merge 到 main 後由 deploy-admin.yml 自動 build/deploy。

## Test plan
- [x] admin preview: /products 編輯商品 → 規格列表只顯示 active SKU(discontinued 已隱藏)
- [x] admin preview: /campaigns/order-entry?id=10 用有 cancelled 訂單的 Alex 重新加單成功(產出新 order_no)
- [x] admin preview: /community-candidates 勾 2 筆 → 出現「已選 N 筆」工具列含 4 個排程入口
- [x] admin preview: /members/detail?id=6 取貨店 select 顯示 18 個 active store 並讀到 home_store_id
- [x] DB: cron.job 'auto-close-expired-campaigns' active=true,手動 invoke RPC 回 0(無到期)
- [x] DB: rpc_set_member_home_store 對 Alex 觸發未取貨 guard 行為(open orders > 0 時 RAISE EXCEPTION)
- [ ] 手機 LIFF: 「我的訂單」現在會看到自己所有店的訂單 (待手動驗)
- [ ] 等明天 (5/9 之前) 看 cron 是否自動關 GB20260509-S000001

🤖 Generated with [Claude Code](https://claude.com/claude-code)