### PR TITLE
feat(wallet): Phase A 儲值金後台寫入操作 (refund/adjust/reverse) + UI

### DIFF
--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -3,7 +3,9 @@
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { MemberMergeModal } from "@/components/MemberMergeModal";
+import { WalletActionModal, type WalletActionMode } from "@/components/WalletActionModal";
 import { translateRpcError } from "@/lib/rpcError";
+import { canAdjustWallet, useRole } from "@/lib/role";
 
 type Member = {
   id: number;
@@ -46,6 +48,7 @@ type WalletEntry = {
   type: string;
   payment_method: string | null;
   reason: string | null;
+  reverses: number | null;
   created_at: string;
 };
 
@@ -68,6 +71,10 @@ export function MemberDetail({ memberId }: { memberId: number }) {
   const [draftNoNewOrder, setDraftNoNewOrder] = useState(false);
   const [draftHomeStoreId, setDraftHomeStoreId] = useState<string>("");
   const [savingStore, setSavingStore] = useState(false);
+  const [tenantId, setTenantId] = useState<string | null>(null);
+  const [walletAction, setWalletAction] = useState<{ mode: WalletActionMode; reverseTarget?: WalletEntry } | null>(null);
+  const role = useRole();
+  const canAdjust = canAdjustWallet(role);
 
   async function saveFlags() {
     if (!member) return;
@@ -148,6 +155,12 @@ export function MemberDetail({ memberId }: { memberId: number }) {
     let cancelled = false;
     (async () => {
       const sb = getSupabase();
+      // operator tenant_id from JWT app_metadata（沿用 ProductImagesField pattern）
+      const { data: sessData } = await sb.auth.getSession();
+      const tid = (sessData.session?.user?.app_metadata as Record<string, unknown> | undefined)
+        ?.tenant_id as string | undefined;
+      if (!cancelled && tid) setTenantId(tid);
+
       const { data: m, error: err } = await sb
         .from("members")
         .select("id, member_no, phone, name, gender, birthday, email, tier_id, home_store_id, status, member_type, notes, admin_note, no_notify_pickup, no_new_order, avatar_url, line_user_id, joined_at, last_visit_at, merged_into_member_id")
@@ -167,7 +180,7 @@ export function MemberDetail({ memberId }: { memberId: number }) {
         sb.from("member_points_balance").select("balance").eq("member_id", memberId).maybeSingle<{ balance: number }>(),
         sb.from("wallet_balances").select("balance").eq("member_id", memberId).maybeSingle<{ balance: number }>(),
         sb.from("points_ledger").select("id, change, balance_after, source_type, reason, created_at").eq("member_id", memberId).order("created_at", { ascending: false }).limit(50),
-        sb.from("wallet_ledger").select("id, change, balance_after, type, payment_method, reason, created_at").eq("member_id", memberId).order("created_at", { ascending: false }).limit(50),
+        sb.from("wallet_ledger").select("id, change, balance_after, type, payment_method, reason, reverses, created_at").eq("member_id", memberId).order("created_at", { ascending: false }).limit(50),
       ]);
       if (cancelled) return;
       setTier(tierQ.data as Tier | null);
@@ -350,6 +363,18 @@ export function MemberDetail({ memberId }: { memberId: number }) {
         onMerged={() => { setMergeOpen(false); setReloadTick((n) => n + 1); }}
       />
 
+      {walletAction && tenantId && (
+        <WalletActionModal
+          open={true}
+          onClose={() => setWalletAction(null)}
+          onSuccess={() => setReloadTick((n) => n + 1)}
+          tenantId={tenantId}
+          memberId={member.id}
+          mode={walletAction.mode}
+          reverseTarget={walletAction.reverseTarget}
+        />
+      )}
+
       <div className="grid gap-3 sm:grid-cols-3">
         <Card label="等級">{tier?.name ?? "—"}</Card>
         <Card label="積分餘額"><span className="text-lg font-mono">{points.toLocaleString()}</span></Card>
@@ -381,6 +406,34 @@ export function MemberDetail({ memberId }: { memberId: number }) {
           <TabBtn active={tab === "wallet"}  onClick={() => setTab("wallet")}>儲值流水 ({wLedger.length})</TabBtn>
           <TabBtn active={tab === "test"}    onClick={() => setTab("test")}>測試操作</TabBtn>
         </div>
+
+        {tab === "wallet" && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              onClick={() => tenantId && setWalletAction({ mode: "topup" })}
+              disabled={!tenantId}
+              className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+            >+ 加值</button>
+            <button
+              onClick={() => tenantId && setWalletAction({ mode: "spend" })}
+              disabled={!tenantId}
+              className="rounded-md bg-amber-600 px-3 py-1 text-xs font-medium text-white hover:bg-amber-700 disabled:opacity-50"
+            >− 扣款</button>
+            <button
+              onClick={() => tenantId && setWalletAction({ mode: "refund" })}
+              disabled={!tenantId}
+              className="rounded-md bg-sky-600 px-3 py-1 text-xs font-medium text-white hover:bg-sky-700 disabled:opacity-50"
+            >↺ 退款</button>
+            {canAdjust && (
+              <button
+                onClick={() => tenantId && setWalletAction({ mode: "adjust" })}
+                disabled={!tenantId}
+                className="rounded-md border border-zinc-400 bg-white px-3 py-1 text-xs font-medium text-zinc-800 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
+              >⚙ 調整</button>
+            )}
+          </div>
+        )}
+
         <div className="mt-3 overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
           {tab === "points" ? (
             <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
@@ -406,29 +459,52 @@ export function MemberDetail({ memberId }: { memberId: number }) {
               </tbody>
             </table>
           ) : tab === "wallet" ? (
-            <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
-              <thead className="bg-zinc-50 dark:bg-zinc-900">
-                <tr>
-                  <Th>時間</Th><Th>類型</Th><Th>支付</Th><Th className="text-right">變動</Th><Th className="text-right">餘額</Th><Th>備註</Th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                {wLedger.length === 0 ? (
-                  <tr><td colSpan={6} className="p-6 text-center text-zinc-500">尚無紀錄</td></tr>
-                ) : wLedger.map((e) => (
-                  <tr key={e.id}>
-                    <Td className="text-xs text-zinc-500">{new Date(e.created_at).toLocaleString("zh-TW")}</Td>
-                    <Td>{e.type}</Td>
-                    <Td className="text-xs">{e.payment_method ?? "—"}</Td>
-                    <Td className={`text-right font-mono ${Number(e.change) >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}`}>
-                      {Number(e.change) >= 0 ? "+" : ""}{Number(e.change)}
-                    </Td>
-                    <Td className="text-right font-mono">{Number(e.balance_after)}</Td>
-                    <Td className="text-xs text-zinc-500">{e.reason ?? "—"}</Td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            (() => {
+              const reversedIds = new Set(wLedger.map((x) => x.reverses).filter((v): v is number => typeof v === "number"));
+              return (
+                <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+                  <thead className="bg-zinc-50 dark:bg-zinc-900">
+                    <tr>
+                      <Th>時間</Th><Th>類型</Th><Th>支付</Th><Th className="text-right">變動</Th><Th className="text-right">餘額</Th><Th>備註</Th><Th>動作</Th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                    {wLedger.length === 0 ? (
+                      <tr><td colSpan={7} className="p-6 text-center text-zinc-500">尚無紀錄</td></tr>
+                    ) : wLedger.map((e) => {
+                      const reversible =
+                        ["topup","spend","refund","adjust"].includes(e.type) &&
+                        !reversedIds.has(e.id);
+                      return (
+                        <tr key={e.id}>
+                          <Td className="text-xs text-zinc-500">{new Date(e.created_at).toLocaleString("zh-TW")}</Td>
+                          <Td>{e.type}{e.reverses ? <span className="ml-1 text-[10px] text-zinc-400">→#{e.reverses}</span> : null}</Td>
+                          <Td className="text-xs">{e.payment_method ?? "—"}</Td>
+                          <Td className={`text-right font-mono ${Number(e.change) >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}`}>
+                            {Number(e.change) >= 0 ? "+" : ""}{Number(e.change)}
+                          </Td>
+                          <Td className="text-right font-mono">{Number(e.balance_after)}</Td>
+                          <Td className="text-xs text-zinc-500">{e.reason ?? "—"}</Td>
+                          <Td className="text-xs">
+                            {reversible && tenantId ? (
+                              <button
+                                onClick={() => setWalletAction({ mode: "reverse", reverseTarget: e })}
+                                title={`反向 ledger #${e.id}`}
+                                className="rounded-md border border-zinc-300 px-2 py-0.5 text-[11px] hover:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-800"
+                              >↩ 反向</button>
+                            ) : reversedIds.has(e.id) ? (
+                              <span className="text-[10px] text-zinc-400">已反向</span>
+                            ) : (
+                              <span className="text-[10px] text-zinc-400">—</span>
+                            )}
+                          </Td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              );
+            })()
           ) : (
             <div className="p-6">
               <h4 className="text-sm font-medium text-zinc-900 dark:text-zinc-100 mb-4">PWA 通知測試</h4>

--- a/apps/admin/src/components/WalletActionModal.tsx
+++ b/apps/admin/src/components/WalletActionModal.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+// 儲值金後台寫入操作 modal：加值 / 扣款 / 退款 / 調整 / 反向
+// 對應 RPCs: rpc_wallet_topup / rpc_wallet_spend / rpc_wallet_refund
+//            rpc_wallet_adjust / rpc_wallet_reverse
+
+import { useEffect, useState } from "react";
+import { Modal } from "@/components/Modal";
+import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
+
+export type WalletActionMode = "topup" | "spend" | "refund" | "adjust" | "reverse";
+
+type ReverseTarget = {
+  id: number;
+  type: string;
+  change: number;
+  balance_after: number;
+  payment_method: string | null;
+  reason: string | null;
+  created_at: string;
+};
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  tenantId: string;
+  memberId: number;
+  mode: WalletActionMode;
+  reverseTarget?: ReverseTarget;
+};
+
+const TITLES: Record<WalletActionMode, string> = {
+  topup:   "加值（topup）",
+  spend:   "扣款（spend）",
+  refund:  "退款（refund）",
+  adjust:  "調整（adjust）",
+  reverse: "反向（reversal）",
+};
+
+const PAYMENT_METHODS = [
+  { value: "cash",        label: "現金 cash" },
+  { value: "credit_card", label: "信用卡 credit_card" },
+  { value: "transfer",    label: "轉帳 transfer" },
+];
+
+export function WalletActionModal({
+  open, onClose, onSuccess,
+  tenantId, memberId, mode, reverseTarget,
+}: Props) {
+  const [amount, setAmount] = useState("");
+  const [paymentMethod, setPaymentMethod] = useState("cash");
+  const [sourceType, setSourceType] = useState("");
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // 開啟時清空欄位
+  useEffect(() => {
+    if (!open) return;
+    setAmount("");
+    setPaymentMethod("cash");
+    setSourceType(mode === "refund" ? "manual" : "");
+    setReason("");
+    setErr(null);
+  }, [open, mode]);
+
+  const reasonRequired = mode === "refund" || mode === "adjust" || mode === "reverse";
+  const amountAllowsNegative = mode === "adjust";
+
+  async function submit() {
+    setErr(null);
+
+    // Reason 驗證
+    if (reasonRequired && reason.trim().length < 4) {
+      setErr("請輸入原因（至少 4 字）");
+      return;
+    }
+
+    // 金額驗證 (reverse 不需要 amount)
+    let amountNum = 0;
+    if (mode !== "reverse") {
+      amountNum = Number(amount);
+      if (!Number.isFinite(amountNum)) {
+        setErr("金額格式錯誤");
+        return;
+      }
+      if (mode === "adjust") {
+        if (amountNum === 0) { setErr("變動金額不可為 0"); return; }
+      } else {
+        if (amountNum <= 0) { setErr("金額必須大於 0"); return; }
+      }
+    }
+
+    setBusy(true);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) { setErr("尚未登入"); return; }
+
+      let rpcResult;
+      if (mode === "topup") {
+        rpcResult = await sb.rpc("rpc_wallet_topup", {
+          p_tenant_id:      tenantId,
+          p_member_id:      memberId,
+          p_amount:         amountNum,
+          p_payment_method: paymentMethod,
+          p_source_type:    "manual",
+          p_source_id:      null,
+          p_operator:       operator,
+        });
+      } else if (mode === "spend") {
+        rpcResult = await sb.rpc("rpc_wallet_spend", {
+          p_tenant_id:   tenantId,
+          p_member_id:   memberId,
+          p_amount:      amountNum,
+          p_source_type: "manual",
+          p_source_id:   null,
+          p_operator:    operator,
+        });
+      } else if (mode === "refund") {
+        rpcResult = await sb.rpc("rpc_wallet_refund", {
+          p_tenant_id:   tenantId,
+          p_member_id:   memberId,
+          p_amount:      amountNum,
+          p_source_type: sourceType || "manual",
+          p_source_id:   null,
+          p_reason:      reason.trim(),
+          p_operator:    operator,
+        });
+      } else if (mode === "adjust") {
+        rpcResult = await sb.rpc("rpc_wallet_adjust", {
+          p_tenant_id: tenantId,
+          p_member_id: memberId,
+          p_change:    amountNum,
+          p_reason:    reason.trim(),
+          p_operator:  operator,
+        });
+      } else {
+        // reverse
+        if (!reverseTarget) { setErr("缺少反向目標"); return; }
+        rpcResult = await sb.rpc("rpc_wallet_reverse", {
+          p_tenant_id: tenantId,
+          p_ledger_id: reverseTarget.id,
+          p_reason:    reason.trim(),
+          p_operator:  operator,
+        });
+      }
+
+      if (rpcResult.error) {
+        setErr(translateRpcError(rpcResult.error));
+        return;
+      }
+      onSuccess();
+      onClose();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title={`儲值金 — ${TITLES[mode]}`} maxWidth="max-w-md">
+      <div className="space-y-4 text-sm">
+        {/* reverse 模式：顯示原 ledger 摘要 */}
+        {mode === "reverse" && reverseTarget && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/40">
+            <div className="text-xs text-amber-800 dark:text-amber-300">
+              <b>反向目標 ledger #{reverseTarget.id}</b>
+              <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+                <div>類型：<span className="font-mono">{reverseTarget.type}</span></div>
+                <div>變動：<span className={`font-mono ${reverseTarget.change >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}`}>{reverseTarget.change >= 0 ? "+" : ""}{reverseTarget.change}</span></div>
+                <div>餘額：<span className="font-mono">{reverseTarget.balance_after}</span></div>
+                <div>付款：<span className="font-mono">{reverseTarget.payment_method ?? "—"}</span></div>
+                <div className="col-span-2">時間：{new Date(reverseTarget.created_at).toLocaleString("zh-TW")}</div>
+                {reverseTarget.reason && <div className="col-span-2">原因：{reverseTarget.reason}</div>}
+              </div>
+              <div className="mt-2">送出後將新增一筆 <code>type=reversal</code> 紀錄，金額為 <span className="font-mono">{-reverseTarget.change >= 0 ? "+" : ""}{-reverseTarget.change}</span>。原 ledger 不會被修改。</div>
+            </div>
+          </div>
+        )}
+
+        {/* 金額（非 reverse） */}
+        {mode !== "reverse" && (
+          <label className="block">
+            <span className="mb-1 block text-xs text-zinc-500">
+              {mode === "adjust" ? "變動金額（可正可負，不為 0）" : "金額（>0）"}
+            </span>
+            <input
+              type="number"
+              step="0.01"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              placeholder={amountAllowsNegative ? "如 100 或 -50" : "如 1000"}
+              autoFocus
+              className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono dark:border-zinc-700 dark:bg-zinc-900"
+            />
+          </label>
+        )}
+
+        {/* topup: 付款方式 */}
+        {mode === "topup" && (
+          <label className="block">
+            <span className="mb-1 block text-xs text-zinc-500">付款方式</span>
+            <select
+              value={paymentMethod}
+              onChange={(e) => setPaymentMethod(e.target.value)}
+              className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-900"
+            >
+              {PAYMENT_METHODS.map((m) => (
+                <option key={m.value} value={m.value}>{m.label}</option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        {/* refund: source_type */}
+        {mode === "refund" && (
+          <label className="block">
+            <span className="mb-1 block text-xs text-zinc-500">來源類型 (selectable: manual / customer_order)</span>
+            <input
+              value={sourceType}
+              onChange={(e) => setSourceType(e.target.value)}
+              placeholder="manual"
+              className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono dark:border-zinc-700 dark:bg-zinc-900"
+            />
+          </label>
+        )}
+
+        {/* 原因 */}
+        <label className="block">
+          <span className="mb-1 block text-xs text-zinc-500">
+            原因 {reasonRequired ? <span className="text-red-600">*（必填，≥ 4 字）</span> : "（選填）"}
+          </span>
+          <textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder={reasonRequired ? "請說明原因（會寫入 ledger.reason）" : "選填"}
+            rows={2}
+            required={reasonRequired}
+            minLength={reasonRequired ? 4 : undefined}
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-900"
+          />
+        </label>
+
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {err}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={busy}
+            className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            取消
+          </button>
+          <button
+            onClick={submit}
+            disabled={busy}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {busy ? "送出中…" : "✅ 確認"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/admin/src/lib/role.ts
+++ b/apps/admin/src/lib/role.ts
@@ -28,6 +28,12 @@ export function canSeeBranch(role: Role | null): boolean {
   return BRANCH_ROLES.includes(role);
 }
 
+// 對齊 supabase/migrations/20260606000000_wallet_write_rpcs.sql 內 rpc_wallet_adjust 的 role gate
+export function canAdjustWallet(role: Role | null): boolean {
+  if (role === null) return false;
+  return BRANCH_ROLES.includes(role);
+}
+
 export function useRole(): Role | null {
   const [role, setRole] = useState<Role | null>(null);
 

--- a/docs/TEST-wallet-phase-a.md
+++ b/docs/TEST-wallet-phase-a.md
@@ -1,0 +1,225 @@
+# wallet-phase-a 測試項目 — admin 寫入介面
+
+**對應 migration:**
+- `supabase/migrations/20260606000000_wallet_write_rpcs.sql`（新）
+
+**對應 UI 變更:**
+- `apps/admin/src/components/MemberDetail.tsx`（修）
+- `apps/admin/src/components/WalletActionModal.tsx`（新）
+
+**對應 plan:** `C:\Users\Alex\.claude\plans\session-db-federated-thunder.md`
+
+**前置背景:** `wallet_balances` + `wallet_ledger` + `rpc_wallet_topup` + `rpc_wallet_spend` 已在 `20260422120002_member_schema.sql` 落地。本階段補完寫入操作（refund / adjust / reverse）+ 後台 UI。
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 新 RPC 都存在
+- [ ] `rpc_wallet_refund(uuid, bigint, numeric, text, bigint, text, uuid)` 存在、SECURITY DEFINER、回傳 BIGINT
+- [ ] `rpc_wallet_adjust(uuid, bigint, numeric, text, uuid)` 存在、SECURITY DEFINER、回傳 BIGINT
+- [ ] `rpc_wallet_reverse(uuid, bigint, text, uuid)` 存在、SECURITY DEFINER、回傳 BIGINT
+- [ ] `fn_check_wallet_consistency()` 存在、READS sql、回傳 setof
+  ```sql
+  SELECT proname, prosecdef, pg_get_function_arguments(oid)
+    FROM pg_proc
+   WHERE proname IN ('rpc_wallet_refund','rpc_wallet_adjust',
+                     'rpc_wallet_reverse','fn_check_wallet_consistency');
+  ```
+
+### 1.2 GRANT 設定
+- [ ] 三支 public RPC（refund / adjust / reverse）都 `GRANT EXECUTE TO authenticated`
+- [ ] `fn_check_wallet_consistency` 不對 authenticated grant（只給 ops 用）
+
+### 1.3 既有約束未動
+- [ ] `wallet_ledger` 仍是 append-only（`forbid_ledger_mutation` trigger 沒被改）
+  ```sql
+  SELECT tgname FROM pg_trigger
+   WHERE tgrelid='wallet_ledger'::regclass AND NOT tgisinternal;
+  -- expect: trg_no_update_wallet, trg_no_delete_wallet
+  ```
+- [ ] `wallet_balances` CHECK `balance >= 0` 仍在
+- [ ] `wallet_ledger.type` CHECK 仍是 `IN ('topup','spend','refund','adjust','reversal')`
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 rpc_wallet_refund — happy path
+**情境：** 會員餘額 100，refund +50（reason='會員退費 ABC'）
+**預期：**
+- 餘額 = 150
+- ledger 多一筆 `type='refund', change=50, balance_after=150, reason='會員退費 ABC', source_type=…, source_id=…, operator_id=…`
+- `wallet_balances.version` +1、`last_movement_at` 更新
+
+### 2.2 rpc_wallet_refund — 金額 ≤ 0 拒絕
+- [ ] `p_amount = 0` → RAISE
+- [ ] `p_amount = -10` → RAISE
+- [ ] balance / ledger 都不動
+
+### 2.3 rpc_wallet_refund — reason 必填
+- [ ] `p_reason = NULL` → RAISE `reason required (>=4 chars)`
+- [ ] `p_reason = ''` → RAISE
+- [ ] `p_reason = '12'`（< 4 chars）→ RAISE
+- [ ] `p_reason = '   abc   '`（trim 後 3 chars）→ RAISE
+- [ ] `p_reason = 'abcd'` → 通過
+
+### 2.4 rpc_wallet_adjust — happy path（補償 +）
+**情境：** 餘額 100、role='owner'、`p_change = 30, p_reason = '客訴補償 #1234'`
+**預期：**
+- 餘額 = 130
+- ledger 多一筆 `type='adjust', change=30, balance_after=130`
+- **`member_audit_log` 多一筆** `entity_type='wallet', action='adjust', before_value={"balance":100}, after_value={"balance":130}, reason='客訴補償 #1234', operator_id=…`
+
+### 2.5 rpc_wallet_adjust — happy path（修正 −）
+**情境：** 餘額 100、`p_change = -30, p_reason = '誤入帳修正'`
+**預期：** 餘額 = 70；ledger `change=-30, balance_after=70`；audit log 寫入
+
+### 2.6 rpc_wallet_adjust — 0 拒絕
+- [ ] `p_change = 0` → RAISE（CHECK 也擋，但 RPC 應提早報錯）
+
+### 2.7 rpc_wallet_adjust — 餘額 < 0 拒絕
+**情境：** 餘額 50，`p_change = -100`
+**預期：** RAISE（CHECK 攔；錯誤訊息應友善）；balance / ledger / audit log 都不動
+
+### 2.8 rpc_wallet_adjust — role gate（對齊 `apps/admin/src/lib/role.ts` BRANCH_ROLES）
+| JWT role | 預期 |
+|---|---|
+| `''`（admin role NULL → empty） | 過 |
+| `owner` | 過 |
+| `admin` | 過 |
+| `hq_manager` | 過 |
+| `hq_accountant` | 過 |
+| `store_manager` | 過 |
+| `assistant` | RAISE `permission denied for wallet adjust` |
+| `store_staff` | RAISE |
+| 無 role claim | 過（NULL → empty） |
+
+- [ ] 至少測 3 種：HQ admin (空字串)、store_manager、store_staff（拒絕）
+
+### 2.9 rpc_wallet_adjust — reason 必填（同 2.3 規則）
+- [ ] NULL / '' / 短於 4 chars 都 RAISE
+
+### 2.10 rpc_wallet_reverse — happy path
+**前置：** 先用 `rpc_wallet_topup` 加 100（產生 ledger row L1，type='topup'）
+**操作：** `rpc_wallet_reverse(tenant, L1, '誤刷取消', operator)`
+**預期：**
+- 餘額 = 0
+- ledger 多一筆 L2 `type='reversal', change=-100, balance_after=0, reverses=L1, reason='誤刷取消'`
+- L1 **不被更新**（append-only）
+- 反查「L1 是否已被反向」：`EXISTS (SELECT 1 FROM wallet_ledger WHERE reverses=L1)` → true
+
+### 2.11 rpc_wallet_reverse — 反向 spend
+**前置：** 餘額 100，`rpc_wallet_spend(50, ...)` → L1 type='spend', change=-50, balance_after=50
+**操作：** reverse(L1)
+**預期：** 餘額回到 100；L2 `type='reversal', change=+50, balance_after=100, reverses=L1`
+
+### 2.12 rpc_wallet_reverse — 拒絕反向 reversal
+**前置：** 已有 reversal row L2
+**操作：** `rpc_wallet_reverse(L2, ...)`
+**預期：** RAISE `cannot reverse a reversal`
+
+### 2.13 rpc_wallet_reverse — 拒絕重複反向
+**前置：** L1 已被 L2 反向
+**操作：** `rpc_wallet_reverse(L1, ...)`（再一次）
+**預期：** RAISE `ledger already reversed`
+
+### 2.14 rpc_wallet_reverse — 反向後餘額會變負則拒絕
+**情境：** topup 100（L1）→ spend 80 → 餘額 20 → reverse(L1)
+**預期：** RAISE（會讓餘額 = -80，CHECK 擋）；L1 仍未被反向
+
+### 2.15 rpc_wallet_reverse — reason 必填
+- [ ] NULL / '' / 短於 4 chars → RAISE
+
+### 2.16 並發鎖定
+**情境：** 兩個 session 同時對同會員 topup + adjust
+**預期：** `FOR UPDATE on wallet_balances` 序列化；兩筆 ledger 都成功，最終餘額 = 起始 + 兩筆 change 總和；`balance_after` 各自正確
+
+### 2.17 Member status guard
+- [ ] member.status='merged' → 三支 RPC 全 RAISE
+- [ ] member.status='deleted' → 三支 RPC 全 RAISE
+- [ ] member.status='active' → 通過
+
+### 2.18 Append-only invariants
+- [ ] 直接 `UPDATE wallet_ledger SET reason='x'` → trigger 擋
+- [ ] 直接 `DELETE FROM wallet_ledger` → trigger 擋
+- [ ] 認證 user 直接 `INSERT INTO wallet_ledger` → 失敗（無 INSERT policy；只能走 SECURITY DEFINER RPC）
+
+### 2.19 fn_check_wallet_consistency
+**前置：** 跑完上面所有測試
+**預期：** `SELECT * FROM fn_check_wallet_consistency()` 回傳 0 rows（所有 member 的 ledger 累加 = balance）
+
+---
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 MemberDetail wallet tab — 入口
+**路徑：** `/members` → 點任一會員 → 切到「儲值流水」tab
+- [ ] tab 切換無 console error
+- [ ] 既有餘額顯示卡片仍在
+- [ ] tab 表頭上方多 4 顆按鈕：`[+ 加值] [− 扣款] [↺ 退款] [⚙ 調整]`
+- [ ] 表格每筆 row 在最後一欄看到「↩ 反向」icon（type=topup/spend/refund/adjust 且未被反向時）
+- [ ] reversal row 本身**沒有**反向 icon
+
+### 3.2 加值 modal
+- [ ] 點「+ 加值」開 modal
+- [ ] 欄位：金額（必填、>0）、付款方式 select（cash/credit_card/transfer）、原因（選填）
+- [ ] 送出後 modal 關閉、wallet tab 餘額 + ledger 自動 reload（reloadTick）
+- [ ] 餘額更新到正確值
+- [ ] 新 ledger row 出現在最頂端、type='topup'、payment_method 對
+
+### 3.3 扣款 modal
+- [ ] 點「− 扣款」開 modal
+- [ ] 欄位：金額（必填、>0）、原因（選填）
+- [ ] 送出後 reload，type='spend'
+- [ ] **餘額不足**：輸入 > 現有餘額 → alert 中文錯誤訊息（translateRpcError）
+
+### 3.4 退款 modal
+- [ ] 欄位：金額（必填、>0）、原因（必填、≥4 字）
+- [ ] 原因留空 → 前端 `required` 阻擋送出
+- [ ] 送出後 reload，type='refund'
+
+### 3.5 調整 modal
+- [ ] 欄位：變動金額（必填、不為 0、可正可負）、原因（必填、≥4 字）
+- [ ] 送出後 reload，type='adjust'；balance_after 對
+- [ ] **role gate (UI)**：assistant / store_staff 帳號登入 → 「⚙ 調整」按鈕**不顯示**
+- [ ] HQ admin (role='') / owner / store_manager 登入 → 顯示
+- [ ] store_staff 用 dev tool 強制送 RPC → 後端 RAISE，alert 顯示
+
+### 3.6 反向 icon
+- [ ] 點 row 的「↩ 反向」→ 開 modal、預填要反向的 ledger 摘要
+- [ ] 欄位：原因（必填、≥4 字）
+- [ ] 送出後 reload；新 reversal row 出現在最上；原 row 在表中不變（reverses 反查讓它失去 icon）
+- [ ] 重複點同一 row 反向 → RPC RAISE → alert
+
+### 3.7 reload pattern
+- [ ] 任何成功操作後，`reloadTick` 觸發 useEffect 重撈、餘額卡片 + ledger 都更新
+
+### 3.8 錯誤翻譯
+- [ ] RPC 各種 RAISE 訊息（reason required / Insufficient wallet / cannot reverse / permission denied）都經 `translateRpcError` 轉成中文 alert（若 dictionary 未涵蓋，至少不 crash）
+
+### 3.9 Modal 樣式
+- [ ] 樣式視覺上對齊 `MemberMergeModal` 風格
+- [ ] dark mode 顯示正常
+- [ ] 送出按鈕在 loading 狀態 disabled
+
+---
+
+## 4. Regression
+
+- [ ] 既有 wallet read-only 顯示沒壞（餘額 + 50 筆 ledger）
+- [ ] 既有「積分流水」tab 與「測試操作」tab 完全沒動
+- [ ] 既有 `rpc_wallet_topup` 行為不變（沒被新 migration 重 define）
+- [ ] 既有 `rpc_wallet_spend` 行為不變
+- [ ] member 合併 (`rpc_merge_guest_member`) 仍能搬走 wallet
+- [ ] 訂單流程完全沒受影響（Phase A 不碰訂單）
+- [ ] LIFF 顧客端任何頁不受影響
+- [ ] admin app build + type-check 過
+
+---
+
+## 5. 驗收門檻
+
+§1-§4 全勾、**無 console error**、**Supabase dev push 成功**、**`fn_check_wallet_consistency()` 回 0 rows**、**`pnpm build` 過** 才能標 done。
+
+PR merge 後依使用者偏好同步 GitHub Issues + Wiki（會員模組頁）。

--- a/supabase/migrations/20260606000000_wallet_write_rpcs.sql
+++ b/supabase/migrations/20260606000000_wallet_write_rpcs.sql
@@ -1,0 +1,242 @@
+-- ============================================================
+-- Wallet phase A: 寫入操作 RPCs (refund / adjust / reverse)
+--   + 一致性檢查工具
+-- 沿用 rpc_wallet_topup / rpc_wallet_spend 既有鎖定模式
+-- (參考 20260422120002_member_schema.sql:472-550)
+-- ============================================================
+
+-- 儲值金退款 (type='refund', change=+amount)
+CREATE OR REPLACE FUNCTION rpc_wallet_refund(
+  p_tenant_id    UUID,
+  p_member_id    BIGINT,
+  p_amount       NUMERIC,
+  p_source_type  TEXT,
+  p_source_id    BIGINT,
+  p_reason       TEXT,
+  p_operator     UUID
+) RETURNS BIGINT AS $$
+DECLARE
+  v_cur_balance NUMERIC;
+  v_new_balance NUMERIC;
+  v_id BIGINT;
+  v_member_status TEXT;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'Refund amount must be positive';
+  END IF;
+  IF p_reason IS NULL OR LENGTH(TRIM(p_reason)) < 4 THEN
+    RAISE EXCEPTION 'reason required (>=4 chars)';
+  END IF;
+
+  SELECT status INTO v_member_status FROM members
+   WHERE id = p_member_id AND tenant_id = p_tenant_id;
+  IF v_member_status IS NULL THEN
+    RAISE EXCEPTION 'member % not found', p_member_id;
+  END IF;
+  IF v_member_status <> 'active' THEN
+    RAISE EXCEPTION 'member status=% cannot receive refund', v_member_status;
+  END IF;
+
+  INSERT INTO wallet_balances (tenant_id, member_id)
+  VALUES (p_tenant_id, p_member_id) ON CONFLICT DO NOTHING;
+
+  SELECT balance INTO v_cur_balance FROM wallet_balances
+  WHERE tenant_id = p_tenant_id AND member_id = p_member_id FOR UPDATE;
+
+  v_new_balance := v_cur_balance + p_amount;
+
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after,
+                             type, source_type, source_id, reason, operator_id)
+  VALUES (p_tenant_id, p_member_id, p_amount, v_new_balance,
+          'refund', p_source_type, p_source_id, p_reason, p_operator)
+  RETURNING id INTO v_id;
+
+  UPDATE wallet_balances
+     SET balance = v_new_balance, version = version + 1,
+         last_movement_at = NOW(), updated_at = NOW()
+   WHERE tenant_id = p_tenant_id AND member_id = p_member_id;
+
+  RETURN v_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 儲值金調整 (客訴/補償/修正；signed change；role gate)
+CREATE OR REPLACE FUNCTION rpc_wallet_adjust(
+  p_tenant_id  UUID,
+  p_member_id  BIGINT,
+  p_change     NUMERIC,
+  p_reason     TEXT,
+  p_operator   UUID
+) RETURNS BIGINT AS $$
+DECLARE
+  v_cur_balance NUMERIC;
+  v_new_balance NUMERIC;
+  v_id BIGINT;
+  v_role TEXT := COALESCE(auth.jwt() ->> 'role', '');
+  v_member_status TEXT;
+BEGIN
+  -- Role gate: BRANCH_ROLES from apps/admin/src/lib/role.ts
+  --   '' (admin role NULL legacy) / owner / admin / hq_manager / hq_accountant / store_manager
+  -- 排除：assistant / store_staff (低權限店員)
+  IF v_role NOT IN ('', 'owner', 'admin', 'hq_manager', 'hq_accountant', 'store_manager') THEN
+    RAISE EXCEPTION 'permission denied for wallet adjust (role=%)', v_role;
+  END IF;
+
+  IF p_change IS NULL OR p_change = 0 THEN
+    RAISE EXCEPTION 'adjust change must be non-zero';
+  END IF;
+  IF p_reason IS NULL OR LENGTH(TRIM(p_reason)) < 4 THEN
+    RAISE EXCEPTION 'reason required (>=4 chars)';
+  END IF;
+
+  SELECT status INTO v_member_status FROM members
+   WHERE id = p_member_id AND tenant_id = p_tenant_id;
+  IF v_member_status IS NULL THEN
+    RAISE EXCEPTION 'member % not found', p_member_id;
+  END IF;
+  IF v_member_status <> 'active' THEN
+    RAISE EXCEPTION 'member status=% cannot adjust', v_member_status;
+  END IF;
+
+  INSERT INTO wallet_balances (tenant_id, member_id)
+  VALUES (p_tenant_id, p_member_id) ON CONFLICT DO NOTHING;
+
+  SELECT balance INTO v_cur_balance FROM wallet_balances
+  WHERE tenant_id = p_tenant_id AND member_id = p_member_id FOR UPDATE;
+
+  v_new_balance := v_cur_balance + p_change;
+  IF v_new_balance < 0 THEN
+    RAISE EXCEPTION 'adjust would make balance negative: current=%, change=%',
+      v_cur_balance, p_change;
+  END IF;
+
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after,
+                             type, reason, operator_id)
+  VALUES (p_tenant_id, p_member_id, p_change, v_new_balance,
+          'adjust', p_reason, p_operator)
+  RETURNING id INTO v_id;
+
+  UPDATE wallet_balances
+     SET balance = v_new_balance, version = version + 1,
+         last_movement_at = NOW(), updated_at = NOW()
+   WHERE tenant_id = p_tenant_id AND member_id = p_member_id;
+
+  -- 高層 audit (低頻動作多寫一條無妨)
+  INSERT INTO member_audit_log (tenant_id, entity_type, entity_id, action,
+                                before_value, after_value, reason, operator_id)
+  VALUES (p_tenant_id, 'wallet', p_member_id, 'adjust',
+          jsonb_build_object('balance', v_cur_balance),
+          jsonb_build_object('balance', v_new_balance, 'change', p_change),
+          p_reason, p_operator);
+
+  RETURN v_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 反向某筆 ledger (新增 type='reversal' row；原 row 不更新，append-only)
+CREATE OR REPLACE FUNCTION rpc_wallet_reverse(
+  p_tenant_id  UUID,
+  p_ledger_id  BIGINT,
+  p_reason     TEXT,
+  p_operator   UUID
+) RETURNS BIGINT AS $$
+DECLARE
+  v_orig wallet_ledger;
+  v_cur_balance NUMERIC;
+  v_new_balance NUMERIC;
+  v_id BIGINT;
+  v_already_reversed BOOLEAN;
+BEGIN
+  IF p_reason IS NULL OR LENGTH(TRIM(p_reason)) < 4 THEN
+    RAISE EXCEPTION 'reason required (>=4 chars)';
+  END IF;
+
+  -- 鎖原 ledger row (FOR UPDATE 只是 row-lock，不觸發 UPDATE trigger)
+  SELECT * INTO v_orig FROM wallet_ledger
+   WHERE id = p_ledger_id AND tenant_id = p_tenant_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'ledger % not found', p_ledger_id;
+  END IF;
+
+  -- 拒絕反向 reversal
+  IF v_orig.type = 'reversal' THEN
+    RAISE EXCEPTION 'cannot reverse a reversal (id=%)', p_ledger_id;
+  END IF;
+
+  -- 拒絕重複反向 (用 reverses 反查；不寫 reversed_by 避開 append-only trigger)
+  SELECT EXISTS(
+    SELECT 1 FROM wallet_ledger
+     WHERE tenant_id = p_tenant_id AND reverses = p_ledger_id
+  ) INTO v_already_reversed;
+  IF v_already_reversed THEN
+    RAISE EXCEPTION 'ledger % already reversed', p_ledger_id;
+  END IF;
+
+  -- 鎖餘額 row
+  SELECT balance INTO v_cur_balance FROM wallet_balances
+  WHERE tenant_id = p_tenant_id AND member_id = v_orig.member_id FOR UPDATE;
+  IF v_cur_balance IS NULL THEN
+    RAISE EXCEPTION 'wallet_balances row missing for member %', v_orig.member_id;
+  END IF;
+
+  v_new_balance := v_cur_balance - v_orig.change;
+  IF v_new_balance < 0 THEN
+    RAISE EXCEPTION 'reverse would make balance negative: current=%, undoing=%',
+      v_cur_balance, v_orig.change;
+  END IF;
+
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after,
+                             type, source_type, source_id, reverses,
+                             reason, operator_id)
+  VALUES (p_tenant_id, v_orig.member_id, -v_orig.change, v_new_balance,
+          'reversal', v_orig.source_type, v_orig.source_id, p_ledger_id,
+          p_reason, p_operator)
+  RETURNING id INTO v_id;
+
+  UPDATE wallet_balances
+     SET balance = v_new_balance, version = version + 1,
+         last_movement_at = NOW(), updated_at = NOW()
+   WHERE tenant_id = p_tenant_id AND member_id = v_orig.member_id;
+
+  INSERT INTO member_audit_log (tenant_id, entity_type, entity_id, action,
+                                before_value, after_value, reason, operator_id)
+  VALUES (p_tenant_id, 'wallet', v_orig.member_id, 'reverse',
+          jsonb_build_object('balance', v_cur_balance,
+                             'reversing_ledger_id', p_ledger_id,
+                             'reversing_type', v_orig.type,
+                             'reversing_change', v_orig.change),
+          jsonb_build_object('balance', v_new_balance,
+                             'new_ledger_id', v_id),
+          p_reason, p_operator);
+
+  RETURN v_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ops 工具：找 ledger 累加 ≠ balance 的 member
+CREATE OR REPLACE FUNCTION fn_check_wallet_consistency()
+RETURNS TABLE(tenant_id UUID, member_id BIGINT,
+              balance NUMERIC, ledger_sum NUMERIC, diff NUMERIC) AS $$
+  SELECT wb.tenant_id, wb.member_id,
+         wb.balance,
+         COALESCE(SUM(wl.change), 0) AS ledger_sum,
+         wb.balance - COALESCE(SUM(wl.change), 0) AS diff
+    FROM wallet_balances wb
+    LEFT JOIN wallet_ledger wl USING (tenant_id, member_id)
+   GROUP BY wb.tenant_id, wb.member_id, wb.balance
+  HAVING wb.balance <> COALESCE(SUM(wl.change), 0);
+$$ LANGUAGE sql STABLE;
+
+GRANT EXECUTE ON FUNCTION rpc_wallet_refund(UUID, BIGINT, NUMERIC, TEXT, BIGINT, TEXT, UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION rpc_wallet_adjust(UUID, BIGINT, NUMERIC, TEXT, UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION rpc_wallet_reverse(UUID, BIGINT, TEXT, UUID) TO authenticated;
+-- fn_check_wallet_consistency 不對 authenticated grant；只給 ops 用 service_role 跑
+
+COMMENT ON FUNCTION rpc_wallet_refund(UUID, BIGINT, NUMERIC, TEXT, BIGINT, TEXT, UUID)
+  IS '儲值金退款 (type=refund, change=+amount); reason 必填';
+COMMENT ON FUNCTION rpc_wallet_adjust(UUID, BIGINT, NUMERIC, TEXT, UUID)
+  IS '儲值金調整 (客訴補償/修正; signed change; role gate: owner/store_manager/HQ)';
+COMMENT ON FUNCTION rpc_wallet_reverse(UUID, BIGINT, TEXT, UUID)
+  IS '反向某筆 ledger (type=reversal; 不更新原 row; reverses 指針)';
+COMMENT ON FUNCTION fn_check_wallet_consistency()
+  IS 'ops 工具：找 ledger 累加 ≠ balance 的 member';


### PR DESCRIPTION
## Summary

儲值金 Phase A — Admin 寫入介面（最小可用切片，先 ship）。對應 [plan](C:/Users/Alex/.claude/plans/session-db-federated-thunder.md) 的第一階段。

之後 Phase B/C/D 規劃中：訂單抵扣、取消自動退、LIFF 顯示。

### DB
- 新 RPCs（SECURITY DEFINER）：
  - `rpc_wallet_refund` — type=refund, change=+amount, reason 必填 ≥4
  - `rpc_wallet_adjust` — signed change, reason 必填, role gate 對齊 BRANCH_ROLES
  - `rpc_wallet_reverse` — 走 `reverses` 前向指針新增 reversal row，不更新原 row（維持 append-only invariant）
- `fn_check_wallet_consistency()` — ops 工具，找出 ledger 累加 ≠ balance 的 member
- `adjust` + `reverse` 額外寫 `member_audit_log (entity_type='wallet')` 高層稽核
- Member status guard：merged/deleted 拒絕

### UI (`apps/admin/src/components/MemberDetail.tsx`)
- 儲值 tab 加 4 顆按鈕：`+ 加值` / `− 扣款` / `↺ 退款` / `⚙ 調整`
- 每筆 ledger row 加「↩ 反向」icon（type ∈ topup/spend/refund/adjust 且未被反向才顯示；reversed row 顯示「已反向」）
- 新 `WalletActionModal.tsx` 對齊 `MemberMergeModal` 樣式
- 「調整」按鈕用 `canAdjustWallet(role)` 控制顯隱；server side RPC 也擋（depth defense）
- `apps/admin/src/lib/role.ts` 新增 `canAdjustWallet` helper（list 與 RPC role gate 對齊）

### ⚠️ Migration push 需要人工執行

Auto mode 環境下，`supabase db push` 對共享 dev DB 的權限被擋。請手動執行：

\`\`\`bash
set -a && source apps/admin/.env.local && set +a
DB_URL="postgresql://\${SUPABASE_DB_USER}:\${SUPABASE_DB_PASSWORD}@\${SUPABASE_DB_HOST}:6543/postgres?sslmode=require"
supabase db push --db-url "\$DB_URL" --include-all
\`\`\`

## Test plan

### 已自動驗證
- [x] `npm run build` (admin app, Next.js 16, Turbopack) 過
- [x] TypeScript `tsc --noEmit` 過
- [x] Preview server (localhost:3000) 啟動，登入 admin，進 `/members/detail?id=6`
  - 切到「儲值流水」tab — 4 顆按鈕渲染正確（含「⚙ 調整」for HQ admin）
  - 表格 7 欄含「動作」
  - 開「+ 加值」modal — 金額 / 付款方式 / 選填原因
  - 開「⚙ 調整」modal — 變動金額（可正可負）/ 必填原因（紅色 *）
  - 前端驗證：reason 太短 → 紅色錯誤訊息「請輸入原因（至少 4 字）」
  - 無 console error

### 待 migration push 後執行
- [ ] 跑 `docs/TEST-wallet-phase-a.md` 的 §1-§4 全部
- [ ] `SELECT * FROM fn_check_wallet_consistency()` 回 0 rows
- [ ] role 負面測試：store_staff 試 adjust → RPC RAISE permission denied

### 後續同步（依使用者偏好）
- [ ] PR merge 後同步 GitHub Issues + Wiki（會員模組頁）

🤖 Generated with [Claude Code](https://claude.com/claude-code)