### PR TITLE
feat(wallet): Phase B+C+D + status 中央化 + 取整 + 取貨整合

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -9,10 +9,7 @@ import { OrderDetail } from "@/components/OrderDetail";
 import { translateRpcError } from "@/lib/rpcError";
 import { withBasePath } from "@/lib/basePath";
 import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
-
-type OrderStatus =
-  | "pending" | "confirmed" | "reserved" | "shipping" | "ready" | "partially_ready"
-  | "partially_completed" | "completed" | "expired" | "cancelled" | "transferred_out";
+import { ORDER_STATUS_LABEL as STATUS_LABEL, type OrderStatus } from "@/lib/orderStatus";
 
 type Row = {
   id: number;
@@ -31,23 +28,13 @@ type Campaign = { id: number; campaign_no: string; name: string; cover_image_url
 type Store = { id: number; code: string; name: string };
 type Member = { id: number; name: string | null; phone: string | null; member_no: string; avatar_url: string | null };
 
-const STATUS_LABEL: Record<OrderStatus, string> = {
-  pending: "待確認", confirmed: "已確認", reserved: "已保留", shipping: "派貨中",
-  ready: "可取貨", partially_ready: "部分可取", partially_completed: "部分取貨",
-  completed: "已完成", expired: "逾期", cancelled: "已取消",
-  transferred_out: "已轉出",
-};
-
 type Tab = "pending" | "completed" | "cancelled";
 const TABS: { value: Tab; label: string }[] = [
   { value: "pending", label: "未取貨" },
   { value: "completed", label: "已完成" },
   { value: "cancelled", label: "取消" },
 ];
-const PENDING_STATUSES: OrderStatus[] = [
-  "pending", "confirmed", "reserved", "shipping",
-  "ready", "partially_ready", "partially_completed",
-];
+const PENDING_STATUSES: OrderStatus[] = ["pending", "confirmed", "shipping", "ready"];
 const CANCELLED_STATUSES: OrderStatus[] = ["cancelled", "expired"];
 
 const PAGE_SIZE = 50;
@@ -628,11 +615,8 @@ function StatusBadge({ s }: { s: OrderStatus }) {
   const st: Record<OrderStatus, string> = {
     pending: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
     confirmed: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
-    reserved: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
     shipping: "bg-purple-100 text-purple-800 dark:bg-purple-950 dark:text-purple-300",
     ready: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
-    partially_ready: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
-    partially_completed: "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300",
     completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
     expired: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
     cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -617,6 +617,7 @@ function StatusBadge({ s }: { s: OrderStatus }) {
     confirmed: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
     shipping: "bg-purple-100 text-purple-800 dark:bg-purple-950 dark:text-purple-300",
     ready: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
+    partially_completed: "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300",
     completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
     expired: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
     cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",

--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -10,6 +10,8 @@ type Order = {
   status: string;
   discount_amount: number;
   discount_percent: number;
+  wallet_paid_amount: number;
+  payment_status: string | null;
   notes: string | null;
   member: { id: number; member_no: string; name: string | null; phone: string | null } | null;
   campaign: { id: number; name: string } | null;
@@ -65,7 +67,7 @@ function Body() {
       const { data, error: e } = await sb
         .from("customer_orders")
         .select(
-          `id, order_no, status, discount_amount, discount_percent, notes,
+          `id, order_no, status, discount_amount, discount_percent, wallet_paid_amount, payment_status, notes,
            member:members(id, member_no, name, phone),
            campaign:group_buy_campaigns(id, name),
            store:stores!customer_orders_pickup_store_id_fkey(id, name),
@@ -104,19 +106,17 @@ function Body() {
     const active = o.items.filter((it) => ACTIVE_ITEM_STATUSES.has(it.status));
     return active.reduce((a, it) => a + lineSub(it), 0);
   };
+  // payable 四捨五入到整數 NTD（對齊 v_customer_order_summary）
   const orderPay = (o: Order) => {
     const sub = orderSub(o);
     const pct = Number(o.discount_percent ?? 0);
-    const pctDed = Math.round(sub * pct) / 100;
-    return Math.max(0, sub - pctDed - Number(o.discount_amount ?? 0));
+    return Math.max(0, Math.round(sub * (1 - pct / 100) - Number(o.discount_amount ?? 0)));
   };
-  const totalOrderDisc = orders.reduce((s, o) => {
-    const sub = orderSub(o);
-    const pct = Number(o.discount_percent ?? 0);
-    return s + Math.round(sub * pct) / 100 + Number(o.discount_amount ?? 0);
-  }, 0);
   const grandSubtotal = orders.reduce((s, o) => s + orderSub(o), 0);
   const grandTotal = orders.reduce((s, o) => s + orderPay(o), 0);
+  const totalOrderDisc = grandSubtotal - grandTotal; // 倒推、含取整誤差
+  const grandWalletPaid = orders.reduce((s, o) => s + Number(o.wallet_paid_amount ?? 0), 0);
+  const grandBalanceDue = Math.max(0, grandTotal - grandWalletPaid);
   const totalQty = orders.reduce((s, o) => {
     const active = o.items.filter((it) => ACTIVE_ITEM_STATUSES.has(it.status));
     return s + active.reduce((a, it) => a + Number(it.qty), 0);
@@ -171,7 +171,9 @@ function Body() {
             const disc = Number(o.discount_amount ?? 0);
             const pct = Number(o.discount_percent ?? 0);
             const sub = orderSub(o);
-            const pctDed = Math.round(sub * pct) / 100;
+            const pay = orderPay(o);
+            // pctDed 倒推（subtotal − pct − amt = payable，所以 pctDed = subtotal − payable − amt）
+            const pctDed = Math.max(0, sub - pay - disc);
             return (
               <div key={o.id} className="border-b border-dashed border-zinc-400 pb-1">
                 <div>{o.campaign?.name ?? "(未知活動)"}</div>
@@ -234,6 +236,16 @@ function Body() {
           <div>小計 $ {grandSubtotal.toLocaleString()}</div>
           {totalOrderDisc > 0 && <div>− 整單折扣 $ {totalOrderDisc.toLocaleString()}</div>}
           <div className="text-[14px] font-bold">合計 {totalQty} 項　$ {grandTotal.toLocaleString()}</div>
+          {grandWalletPaid > 0 && (
+            <>
+              <div className="mt-1">− 已用儲值金 $ {grandWalletPaid.toLocaleString()}</div>
+              <div className="text-[13px] font-bold">
+                {grandBalanceDue === 0
+                  ? "✅ 已付清"
+                  : <>應付剩餘 $ {grandBalanceDue.toLocaleString()}</>}
+              </div>
+            </>
+          )}
         </div>
 
       </div>

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -21,6 +21,8 @@ type Order = {
   pickup_store_id: number | null;
   discount_amount: number;
   discount_percent: number;
+  wallet_paid_amount: number;
+  payment_status: string | null;
   notes: string | null;
   member: { id: number; member_no: string; name: string | null; phone: string | null } | null;
   campaign: { id: number; campaign_no: string; name: string } | null;
@@ -82,7 +84,7 @@ function Body() {
       const allItemIds = events.flatMap((e) => e.item_ids ?? []);
       const [{ data: ords }, { data: itms }] = await Promise.all([
         sb.from("customer_orders")
-          .select("id, order_no, status, pickup_store_id, discount_amount, discount_percent, notes, member:members(id, member_no, name, phone), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
+          .select("id, order_no, status, pickup_store_id, discount_amount, discount_percent, wallet_paid_amount, payment_status, notes, member:members(id, member_no, name, phone), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .in("id", orderIds),
         allItemIds.length > 0
           ? sb.from("customer_order_items").select("id, qty, unit_price, discount_amount, discount_percent, notes, status, sku:skus(sku_code, product_name, variant_name)").in("id", allItemIds)
@@ -116,13 +118,15 @@ function Body() {
   if (!receipts) return <div className="p-6 text-sm text-zinc-500">載入中…</div>;
 
   const combined = receipts.length > 1;
+  // payable 四捨五入到整數 NTD
   const orderPayable = (r: { order: Order; items: Item[] }) => {
     const sub = r.items.reduce((a, it) => a + lineSub(it), 0);
     const pct = Number(r.order?.discount_percent ?? 0);
-    const pctDed = Math.round(sub * pct) / 100;
-    return Math.max(0, sub - pctDed - Number(r.order?.discount_amount ?? 0));
+    return Math.max(0, Math.round(sub * (1 - pct / 100) - Number(r.order?.discount_amount ?? 0)));
   };
   const grandTotal = receipts.reduce((s, r) => s + orderPayable(r), 0);
+  const grandWalletPaid = receipts.reduce((s, r) => s + Number(r.order?.wallet_paid_amount ?? 0), 0);
+  const grandBalanceDue = Math.max(0, grandTotal - grandWalletPaid);
 
   return (
     <>
@@ -156,8 +160,10 @@ function Body() {
               const sub = r.items.reduce((s, it) => s + lineSub(it), 0);
               const disc = Number(r.order?.discount_amount ?? 0);
               const pct = Number(r.order?.discount_percent ?? 0);
-              const pctDed = Math.round(sub * pct) / 100;
-              const pay = Math.max(0, sub - pctDed - disc);
+              const pay = Math.max(0, Math.round(sub * (1 - pct / 100) - disc));
+              const pctDed = Math.max(0, sub - pay - disc);
+              const walletPaid = Number(r.order?.wallet_paid_amount ?? 0);
+              const balanceDue = Math.max(0, pay - walletPaid);
               return (
                 <div
                   key={r.event.id}
@@ -243,6 +249,20 @@ function Body() {
                         <td colSpan={3} className="px-1 py-0.5 text-right">本單應收</td>
                         <td className="px-1 py-0.5 text-right font-mono">${pay}</td>
                       </tr>
+                      {walletPaid > 0 && (
+                        <>
+                          <tr>
+                            <td colSpan={3} className="px-1 py-0.5 text-right text-zinc-600">− 已用儲值金</td>
+                            <td className="px-1 py-0.5 text-right font-mono">−${walletPaid}</td>
+                          </tr>
+                          <tr className="font-bold">
+                            <td colSpan={3} className="px-1 py-0.5 text-right">
+                              {balanceDue === 0 ? "✅ 已付清" : "應付剩餘"}
+                            </td>
+                            <td className="px-1 py-0.5 text-right font-mono">${balanceDue}</td>
+                          </tr>
+                        </>
+                      )}
                     </tbody>
                   </table>
                   {r.order?.notes && (
@@ -255,8 +275,18 @@ function Body() {
               );
             })}
 
-            <div className="mt-3 border-t-2 border-zinc-700 pt-2 text-right text-sm font-bold">
-              合計 ${grandTotal.toLocaleString()}
+            <div className="mt-3 border-t-2 border-zinc-700 pt-2 text-right text-sm">
+              <div className="font-bold">合計 ${grandTotal.toLocaleString()}</div>
+              {grandWalletPaid > 0 && (
+                <>
+                  <div className="text-zinc-600">− 已用儲值金 ${grandWalletPaid.toLocaleString()}</div>
+                  <div className="font-bold">
+                    {grandBalanceDue === 0
+                      ? "✅ 已付清"
+                      : <>應付剩餘 ${grandBalanceDue.toLocaleString()}</>}
+                  </div>
+                </>
+              )}
             </div>
           </div>
         ) : (
@@ -334,8 +364,10 @@ function Body() {
                     const sub = r.items.reduce((s, it) => s + lineSub(it), 0);
                     const disc = Number(r.order?.discount_amount ?? 0);
                     const pct = Number(r.order?.discount_percent ?? 0);
-                    const pctDed = Math.round(sub * pct) / 100;
-                    const pay = Math.max(0, sub - pctDed - disc);
+                    const pay = Math.max(0, Math.round(sub * (1 - pct / 100) - disc));
+                    const pctDed = Math.max(0, sub - pay - disc);
+                    const walletPaid = Number(r.order?.wallet_paid_amount ?? 0);
+                    const balanceDue = Math.max(0, pay - walletPaid);
                     return (
                       <>
                         <tr className="border-t border-zinc-300">
@@ -358,6 +390,20 @@ function Body() {
                           <td colSpan={3} className="px-2 py-2 text-right">應收</td>
                           <td className="px-2 py-2 text-right font-mono">${pay}</td>
                         </tr>
+                        {walletPaid > 0 && (
+                          <>
+                            <tr>
+                              <td colSpan={3} className="px-2 py-1 text-right text-xs text-zinc-600">− 已用儲值金</td>
+                              <td className="px-2 py-1 text-right font-mono">−${walletPaid}</td>
+                            </tr>
+                            <tr className="border-t border-zinc-300 font-bold">
+                              <td colSpan={3} className="px-2 py-1 text-right">
+                                {balanceDue === 0 ? "✅ 已付清" : "應付剩餘"}
+                              </td>
+                              <td className="px-2 py-1 text-right font-mono">${balanceDue}</td>
+                            </tr>
+                          </>
+                        )}
                       </>
                     );
                   })()}

--- a/apps/admin/src/app/(protected)/transfers/aid/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/aid/page.tsx
@@ -5,10 +5,7 @@ import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
-
-type OrderStatus =
-  | "pending" | "confirmed" | "reserved" | "shipping" | "ready" | "partially_ready"
-  | "partially_completed" | "completed" | "expired" | "cancelled" | "transferred_out";
+import { ORDER_STATUS_LABEL as STATUS_LABEL, type OrderStatus } from "@/lib/orderStatus";
 
 type AidItem = {
   id: number;
@@ -53,21 +50,11 @@ type SourceOrder = {
   store: { id: number; name: string } | null;
 };
 
-const STATUS_LABEL: Record<OrderStatus, string> = {
-  pending: "待確認", confirmed: "已確認", reserved: "已保留", shipping: "派貨中",
-  ready: "可取貨", partially_ready: "部分可取", partially_completed: "部分取貨",
-  completed: "已完成", expired: "逾期", cancelled: "已取消",
-  transferred_out: "已轉出",
-};
-
 const STATUS_COLOR: Record<OrderStatus, string> = {
   pending: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
   confirmed: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
-  reserved: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
   shipping: "bg-purple-100 text-purple-800 dark:bg-purple-950 dark:text-purple-300",
   ready: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
-  partially_ready: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
-  partially_completed: "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300",
   completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
   expired: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
   cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",

--- a/apps/admin/src/app/(protected)/transfers/aid/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/aid/page.tsx
@@ -55,6 +55,7 @@ const STATUS_COLOR: Record<OrderStatus, string> = {
   confirmed: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
   shipping: "bg-purple-100 text-purple-800 dark:bg-purple-950 dark:text-purple-300",
   ready: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
+  partially_completed: "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300",
   completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
   expired: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
   cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",

--- a/apps/admin/src/components/AidOrderTimeline.tsx
+++ b/apps/admin/src/components/AidOrderTimeline.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { orderStatusLabel } from "@/lib/orderStatus";
 
 type Order = {
   id: number;
@@ -48,17 +49,7 @@ type TimelineEvent = {
   status: "done" | "current" | "future" | "error";
 };
 
-const ORDER_STATUS_LABEL: Record<string, string> = {
-  pending: "待確認",
-  confirmed: "已確認",
-  shipping: "派貨中",
-  ready: "可取貨",
-  completed: "已完成",
-  cancelled: "已取消",
-  expired: "逾期",
-  reserved: "已保留",
-  transferred_out: "已轉出",
-};
+// ORDER_STATUS_LABEL imported from @/lib/orderStatus
 
 export function AidOrderTimeline({ orderId }: { orderId: number }) {
   const [order, setOrder] = useState<Order | null>(null);
@@ -310,7 +301,7 @@ export function AidOrderTimeline({ orderId }: { orderId: number }) {
           </span>
         )}
         <span className="ml-2 text-xs font-normal text-zinc-500">
-          目前狀態：{ORDER_STATUS_LABEL[order.status] ?? order.status}
+          目前狀態：{orderStatusLabel(order.status)}
         </span>
       </h3>
 

--- a/apps/admin/src/components/CampaignOrdersPanel.tsx
+++ b/apps/admin/src/components/CampaignOrdersPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
+import { orderStatusLabel } from "@/lib/orderStatus";
 
 type OrderRow = {
   id: number;
@@ -19,26 +20,11 @@ type OrderRow = {
 
 type Store = { id: number; code: string; name: string };
 
-const STATUS_LABEL: Record<string, string> = {
-  pending: "待確認",
-  confirmed: "已確認",
-  reserved: "已備貨",
-  partially_ready: "部分備貨",
-  partially_completed: "部分完成",
-  shipping: "出貨中",
-  ready: "可取貨",
-  completed: "已完成",
-  cancelled: "已取消",
-  expired: "已逾期",
-  transferred_out: "已轉出",
-};
+// STATUS_LABEL imported from @/lib/orderStatus（單一中央定義）
 
 const STATUS_BADGE: Record<string, string> = {
   pending: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
   confirmed: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
-  reserved: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
-  partially_ready: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
-  partially_completed: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
   shipping: "bg-cyan-100 text-cyan-800 dark:bg-cyan-950 dark:text-cyan-300",
   ready: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
   completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
@@ -205,7 +191,7 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
                       <td className="px-3 py-1.5 text-zinc-600 dark:text-zinc-400">{store?.name ?? "—"}</td>
                       <td className="px-3 py-1.5">
                         <span className={`inline-block rounded px-1.5 py-0.5 ${STATUS_BADGE[r.status] ?? STATUS_BADGE.pending}`}>
-                          {STATUS_LABEL[r.status] ?? r.status}
+                          {orderStatusLabel(r.status)}
                         </span>
                       </td>
                       <td className={`px-3 py-1.5 text-right font-mono tabular-nums ${isOffset ? "text-red-700 dark:text-red-300" : ""}`}>

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -6,6 +6,7 @@ import { MemberMergeModal } from "@/components/MemberMergeModal";
 import { WalletActionModal, type WalletActionMode } from "@/components/WalletActionModal";
 import { translateRpcError } from "@/lib/rpcError";
 import { canAdjustWallet, useRole } from "@/lib/role";
+import { walletLedgerTypeLabel, walletPaymentMethodLabel } from "@/lib/walletLedger";
 
 type Member = {
   id: number;
@@ -478,8 +479,8 @@ export function MemberDetail({ memberId }: { memberId: number }) {
                       return (
                         <tr key={e.id}>
                           <Td className="text-xs text-zinc-500">{new Date(e.created_at).toLocaleString("zh-TW")}</Td>
-                          <Td>{e.type}{e.reverses ? <span className="ml-1 text-[10px] text-zinc-400">→#{e.reverses}</span> : null}</Td>
-                          <Td className="text-xs">{e.payment_method ?? "—"}</Td>
+                          <Td>{walletLedgerTypeLabel(e.type)}{e.reverses ? <span className="ml-1 text-[10px] text-zinc-400">→#{e.reverses}</span> : null}</Td>
+                          <Td className="text-xs">{walletPaymentMethodLabel(e.payment_method)}</Td>
                           <Td className={`text-right font-mono ${Number(e.change) >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}`}>
                             {Number(e.change) >= 0 ? "+" : ""}{Number(e.change)}
                           </Td>

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -65,10 +65,11 @@ function computeLineSubtotal(qty: number, unitPrice: number, d: DiscountValue): 
 function applyOrderDiscount(subtotal: number, d: DiscountValue): { deduction: number; payable: number } {
   const pct = d.kind === "percent" ? Number(d.value) : 0;
   const amt = d.kind === "amount" ? Number(d.value) : 0;
-  const pctDed = Math.round(subtotal * pct) / 100;
+  // 應收四捨五入到整數 NTD（對齊 v_customer_order_summary + rpc_wallet_pay_order）
+  const payable = Math.max(0, Math.round(subtotal * (1 - pct / 100) - amt));
   return {
-    deduction: pctDed + amt,
-    payable: Math.max(0, subtotal - pctDed - amt),
+    deduction: subtotal - payable,
+    payable,
   };
 }
 

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -544,7 +544,8 @@ export function OrderDetail({
             {(() => {
               const balDue = Math.max(0, payableAmount - Number(head.wallet_paid_amount ?? 0));
               const isPaid = head.payment_status === "paid";
-              const canPay = head.member && balDue > 0 && (head.status === "pending" || head.status === "confirmed");
+              const TERMINAL_STATUSES = ["completed","picked_up","cancelled","expired","transferred_out"];
+              const canPay = !!head.member && balDue > 0 && !isPaid && !TERMINAL_STATUSES.includes(head.status);
               return (
                 <>
                   {Number(head.wallet_paid_amount) > 0 && (

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -6,6 +6,7 @@ import { OrderTransferModal } from "@/components/OrderTransferModal";
 import { PickupDialog } from "@/components/PickupDialog";
 import { AidOrderTimeline } from "@/components/AidOrderTimeline";
 import { OrderAuditDrawer } from "@/components/OrderAuditDrawer";
+import { WalletPayOrderModal } from "@/components/WalletPayOrderModal";
 import { EditableNumber, EditableText } from "@/components/EditableCell";
 import { EditableDiscount, deriveDiscount, type DiscountValue } from "@/components/EditableDiscount";
 import { useAuth } from "@/components/AuthProvider";
@@ -27,6 +28,9 @@ type OrderHead = {
   is_air_transfer: boolean | null;
   discount_amount: number;
   discount_percent: number;
+  wallet_paid_amount: number;
+  payment_status: string | null;
+  paid_at: string | null;
   notes: string | null;
   member: { id: number; name: string | null; phone: string | null; member_no: string } | null;
   campaign: { id: number; campaign_no: string; name: string } | null;
@@ -123,6 +127,7 @@ export function OrderDetail({
   const [reloadTick, setReloadTick] = useState(0);
   const [transferOpen, setTransferOpen] = useState(false);
   const [pickupOpen, setPickupOpen] = useState(false);
+  const [walletPayOpen, setWalletPayOpen] = useState(false);
   const [auditOpen, setAuditOpen] = useState(false);
   const [draft, setDraft] = useState<OrderDraft>(EMPTY_DRAFT);
   const [saving, setSaving] = useState(false);
@@ -157,7 +162,7 @@ export function OrderDetail({
       const sb = getSupabase();
       const [hRes, iRes] = await Promise.all([
         sb.from("customer_orders")
-          .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, transferred_from_order_id, is_air_transfer, discount_amount, discount_percent, notes, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
+          .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, transferred_from_order_id, is_air_transfer, discount_amount, discount_percent, wallet_paid_amount, payment_status, paid_at, notes, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .eq("id", orderId).maybeSingle(),
         sb.from("customer_order_items")
           .select("id, qty, unit_price, status, source, notes, discount_amount, discount_percent, created_at, updated_at, created_by, updated_by, sku:skus(id, sku_code, product_name, variant_name)")
@@ -533,6 +538,30 @@ export function OrderDetail({
               </span>
             )}
             <span className="text-base">= 應收 <span className="font-semibold">${payableAmount}</span></span>
+            {Number(head.wallet_paid_amount) > 0 && (
+              <span className="text-zinc-500">− 已用儲值金 ${Number(head.wallet_paid_amount)}</span>
+            )}
+            {(() => {
+              const balDue = Math.max(0, payableAmount - Number(head.wallet_paid_amount ?? 0));
+              const isPaid = head.payment_status === "paid";
+              const canPay = head.member && balDue > 0 && (head.status === "pending" || head.status === "confirmed");
+              return (
+                <>
+                  {Number(head.wallet_paid_amount) > 0 && (
+                    <span className="text-base">= 應付剩餘 <span className={`font-semibold ${balDue === 0 ? "text-emerald-700 dark:text-emerald-400" : ""}`}>${balDue}</span></span>
+                  )}
+                  {isPaid && (
+                    <span className="rounded bg-emerald-100 px-2 py-0.5 text-xs text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">✅ 已付清</span>
+                  )}
+                  {canPay && (
+                    <button
+                      onClick={() => setWalletPayOpen(true)}
+                      className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700"
+                    >💳 用儲值金結帳</button>
+                  )}
+                </>
+              );
+            })()}
           </div>
         </div>
         <div className="overflow-x-auto">
@@ -640,6 +669,18 @@ export function OrderDetail({
         onClose={() => setAuditOpen(false)}
         orderId={head.id}
       />
+      {head.member && (
+        <WalletPayOrderModal
+          open={walletPayOpen}
+          onClose={() => setWalletPayOpen(false)}
+          onSuccess={() => setReloadTick((n) => n + 1)}
+          orderId={head.id}
+          orderNo={head.order_no}
+          memberId={head.member.id}
+          memberName={head.member.name}
+          balanceDue={Math.max(0, payableAmount - Number(head.wallet_paid_amount ?? 0))}
+        />
+      )}
     </div>
   );
 }

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -11,6 +11,7 @@ import { EditableNumber, EditableText } from "@/components/EditableCell";
 import { EditableDiscount, deriveDiscount, type DiscountValue } from "@/components/EditableDiscount";
 import { useAuth } from "@/components/AuthProvider";
 import { useRole } from "@/lib/role";
+import { orderStatusLabel as statusLabel, canPayWithWallet } from "@/lib/orderStatus";
 import { withBasePath } from "@/lib/basePath";
 import { translateRpcError } from "@/lib/rpcError";
 
@@ -94,13 +95,7 @@ type TimelineStep = {
   detailOnClick?: () => void;
 };
 
-const STATUS_LABEL: Record<string, string> = {
-  pending: "待確認", confirmed: "已確認", reserved: "已保留", shipping: "派貨中",
-  ready: "可取貨", partially_ready: "部分可取", partially_completed: "部分取貨",
-  completed: "已完成", expired: "逾期", cancelled: "已取消",
-  transferred_out: "已轉出", picked_up: "已取貨",
-};
-const statusLabel = (s: string) => STATUS_LABEL[s] ?? s;
+// STATUS_LABEL / statusLabel imported from @/lib/orderStatus
 
 function staffLabel(uid: string | null, names: Map<string, string>): string {
   if (!uid) return "—";
@@ -544,8 +539,7 @@ export function OrderDetail({
             {(() => {
               const balDue = Math.max(0, payableAmount - Number(head.wallet_paid_amount ?? 0));
               const isPaid = head.payment_status === "paid";
-              const TERMINAL_STATUSES = ["completed","picked_up","cancelled","expired","transferred_out"];
-              const canPay = !!head.member && balDue > 0 && !isPaid && !TERMINAL_STATUSES.includes(head.status);
+              const canPay = !!head.member && balDue > 0 && canPayWithWallet(head.status, head.payment_status);
               return (
                 <>
                   {Number(head.wallet_paid_amount) > 0 && (

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -88,10 +88,11 @@ export function PickupDialog({
         if (!cancelled) {
           const bal = Number(wb?.balance ?? 0);
           setWalletBalance(bal);
-          // 預填：min(餘額, 本次應收) — 已選全 item 預設算
+          // 預填：min(餘額, 本次應收) — 已選全 item 預設算（payable 四捨五入到 1 元）
           const itemSubtotal = list.reduce((s, it) => s + lineSub(it), 0);
-          const pct = Math.round(itemSubtotal * Number(head?.discount_percent ?? 0)) / 100;
-          const initialPayable = Math.max(0, itemSubtotal - pct - Number(head?.discount_amount ?? 0));
+          const dpct = Number(head?.discount_percent ?? 0);
+          const damt = Number(head?.discount_amount ?? 0);
+          const initialPayable = Math.max(0, Math.round(itemSubtotal * (1 - dpct / 100) - damt));
           const preFill = Math.min(bal, initialPayable);
           setWalletAmount(preFill > 0 ? String(preFill) : "");
         }
@@ -152,8 +153,9 @@ export function PickupDialog({
   const subtotal = items
     ? items.filter((it) => picked.has(it.id)).reduce((s, it) => s + lineSub(it), 0)
     : 0;
+  // 顯示用 deduction（含小數）+ 最終 payable 四捨五入到整數 NTD
   const percentDeduction = Math.round(subtotal * discountPercent) / 100;
-  const payableAmount = Math.max(0, subtotal - percentDeduction - discount);
+  const payableAmount = Math.max(0, Math.round(subtotal * (1 - discountPercent / 100) - discount));
 
   // 儲值金抵扣計算：本次最多扣 = min(會員餘額, 本次應收)
   const walletNum = Number(walletAmount) || 0;

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -153,9 +153,10 @@ export function PickupDialog({
   const subtotal = items
     ? items.filter((it) => picked.has(it.id)).reduce((s, it) => s + lineSub(it), 0)
     : 0;
-  // 顯示用 deduction（含小數）+ 最終 payable 四捨五入到整數 NTD
-  const percentDeduction = Math.round(subtotal * discountPercent) / 100;
+  // payable 四捨五入到整數 NTD；deduction 倒推、確保 subtotal − pct − amt = payable 完全對齊
   const payableAmount = Math.max(0, Math.round(subtotal * (1 - discountPercent / 100) - discount));
+  const totalDeduction = subtotal - payableAmount;
+  const percentDeduction = Math.max(0, totalDeduction - discount);
 
   // 儲值金抵扣計算：本次最多扣 = min(會員餘額, 本次應收)
   const walletNum = Number(walletAmount) || 0;

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -81,14 +81,23 @@ export function PickupDialog({
       setDiscountPercent(Number(head?.discount_percent ?? 0));
       setMemberId(head?.member_id ?? null);
       setWalletPaidSoFar(Number(head?.wallet_paid_amount ?? 0));
-      setWalletAmount("");
-      // 抓會員儲值餘額
+      // 抓會員儲值餘額 + 預填本次抵扣（min(餘額, 應收)）
       if (head?.member_id) {
         const { data: wb } = await sb.from("wallet_balances")
           .select("balance").eq("member_id", head.member_id).maybeSingle<{ balance: number }>();
-        if (!cancelled) setWalletBalance(Number(wb?.balance ?? 0));
+        if (!cancelled) {
+          const bal = Number(wb?.balance ?? 0);
+          setWalletBalance(bal);
+          // 預填：min(餘額, 本次應收) — 已選全 item 預設算
+          const itemSubtotal = list.reduce((s, it) => s + lineSub(it), 0);
+          const pct = Math.round(itemSubtotal * Number(head?.discount_percent ?? 0)) / 100;
+          const initialPayable = Math.max(0, itemSubtotal - pct - Number(head?.discount_amount ?? 0));
+          const preFill = Math.min(bal, initialPayable);
+          setWalletAmount(preFill > 0 ? String(preFill) : "");
+        }
       } else {
         setWalletBalance(null);
+        setWalletAmount("");
       }
     })();
     return () => { cancelled = true; };

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -274,7 +274,7 @@ export function PickupDialog({
                   />
                 </label>
                 <div className="block">
-                  <span className="mb-1 block text-xs text-zinc-500">找現金</span>
+                  <span className="mb-1 block text-xs text-zinc-500">需收現金</span>
                   <div className="rounded-md border border-zinc-200 bg-white px-3 py-2 font-mono dark:border-zinc-800 dark:bg-zinc-950">${cashAmount}</div>
                 </div>
                 {walletMax > 0 && (
@@ -333,7 +333,7 @@ export function PickupDialog({
               {busy
                 ? "處理中…"
                 : walletNum > 0
-                  ? `✅ 確認取貨 (儲值 $${walletNum} + 現金 $${cashAmount})`
+                  ? `✅ 確認取貨 (儲值 $${walletNum} + 收現 $${cashAmount})`
                   : `✅ 確認取貨 (${picked.size} 項 · $${payableAmount})`}
             </button>
           </div>

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -142,8 +142,12 @@ export function PickupDialog({
       });
       if (error) { setErr(error.message); return; }
       const result = data as { event_id: number; new_order_status: string; picked_count: number; active_remaining: number };
+      // 取貨單一定印（收據）
       window.open(withBasePath(`/pickup/print?event_ids=${result.event_id}`), "_blank");
-      window.open(withBasePath(`/pickup/print-list?order_ids=${orderId}`), "_blank");
+      // 取貨清單只在「部分取貨」時印（提醒客人剩下未取的 items）；全取完省略
+      if (result.active_remaining > 0) {
+        window.open(withBasePath(`/pickup/print-list?order_ids=${orderId}`), "_blank");
+      }
       onPickedUp(result);
     } finally {
       setBusy(false);

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { withBasePath } from "@/lib/basePath";
+import { translateRpcError } from "@/lib/rpcError";
 
 type PickableItem = {
   id: number;
@@ -13,6 +14,14 @@ type PickableItem = {
   discount_percent: number;
   status: string;
   sku: { id: number; sku_code: string; product_name: string | null; variant_name: string | null } | null;
+};
+
+type OrderHead = {
+  discount_amount: number;
+  discount_percent: number;
+  member_id: number | null;
+  wallet_paid_amount: number;
+  payment_status: string | null;
 };
 
 function lineSub(it: PickableItem): number {
@@ -37,6 +46,10 @@ export function PickupDialog({
   const [items, setItems] = useState<PickableItem[] | null>(null);
   const [discount, setDiscount] = useState(0);
   const [discountPercent, setDiscountPercent] = useState(0);
+  const [memberId, setMemberId] = useState<number | null>(null);
+  const [walletPaidSoFar, setWalletPaidSoFar] = useState(0);
+  const [walletBalance, setWalletBalance] = useState<number | null>(null);
+  const [walletAmount, setWalletAmount] = useState("");
   const [picked, setPicked] = useState<Set<number>>(new Set());
   const [notes, setNotes] = useState("");
   const [busy, setBusy] = useState(false);
@@ -54,19 +67,29 @@ export function PickupDialog({
           .in("status", ["pending", "reserved", "ready"])
           .order("id"),
         sb.from("customer_orders")
-          .select("discount_amount, discount_percent")
+          .select("discount_amount, discount_percent, member_id, wallet_paid_amount, payment_status")
           .eq("id", orderId)
-          .maybeSingle(),
+          .maybeSingle<OrderHead>(),
       ]);
       if (cancelled) return;
       if (iRes.error) { setErr(iRes.error.message); return; }
       const list = (iRes.data ?? []) as unknown as PickableItem[];
       setItems(list);
-      // 預設全選
       setPicked(new Set(list.map((it) => it.id)));
-      const head = hRes.data as { discount_amount: number; discount_percent: number } | null;
+      const head = hRes.data;
       setDiscount(Number(head?.discount_amount ?? 0));
       setDiscountPercent(Number(head?.discount_percent ?? 0));
+      setMemberId(head?.member_id ?? null);
+      setWalletPaidSoFar(Number(head?.wallet_paid_amount ?? 0));
+      setWalletAmount("");
+      // 抓會員儲值餘額
+      if (head?.member_id) {
+        const { data: wb } = await sb.from("wallet_balances")
+          .select("balance").eq("member_id", head.member_id).maybeSingle<{ balance: number }>();
+        if (!cancelled) setWalletBalance(Number(wb?.balance ?? 0));
+      } else {
+        setWalletBalance(null);
+      }
     })();
     return () => { cancelled = true; };
   }, [open, orderId]);
@@ -88,6 +111,19 @@ export function PickupDialog({
       const { data: sess } = await sb.auth.getSession();
       const operator = sess.session?.user?.id;
       if (!operator) { setErr("尚未登入"); return; }
+
+      // Step 1：先扣儲值金（若有）— 失敗就中止，pickup 不寫
+      const wAmt = Number(walletAmount);
+      if (wAmt > 0) {
+        const { error: wErr } = await sb.rpc("rpc_wallet_pay_order", {
+          p_order_id: orderId,
+          p_amount: wAmt,
+          p_operator: operator,
+        });
+        if (wErr) { setErr(`儲值金扣款失敗：${translateRpcError(wErr)}`); return; }
+      }
+
+      // Step 2：寫 pickup
       const { data, error } = await sb.rpc("rpc_record_pickup", {
         p_order_id: orderId,
         p_item_ids: Array.from(picked),
@@ -96,7 +132,6 @@ export function PickupDialog({
       });
       if (error) { setErr(error.message); return; }
       const result = data as { event_id: number; new_order_status: string; picked_count: number; active_remaining: number };
-      // 自動開新分頁列印 — 大張取貨單 + 熱感應小白單
       window.open(withBasePath(`/pickup/print?event_ids=${result.event_id}`), "_blank");
       window.open(withBasePath(`/pickup/print-list?order_ids=${orderId}`), "_blank");
       onPickedUp(result);
@@ -110,6 +145,15 @@ export function PickupDialog({
     : 0;
   const percentDeduction = Math.round(subtotal * discountPercent) / 100;
   const payableAmount = Math.max(0, subtotal - percentDeduction - discount);
+
+  // 儲值金抵扣計算：本次最多扣 = min(會員餘額, 本次應收)
+  const walletNum = Number(walletAmount) || 0;
+  const walletMax = Math.min(walletBalance ?? 0, payableAmount);
+  const cashAmount = Math.max(0, payableAmount - walletNum);
+  const walletInvalid =
+    walletNum < 0 ||
+    walletNum > walletMax ||
+    (walletBalance != null && walletNum > walletBalance);
 
   return (
     <Modal open={open} onClose={onClose} title={`✅ 確認取貨 — 訂單 ${orderNo}`} maxWidth="max-w-2xl">
@@ -193,6 +237,51 @@ export function PickupDialog({
             </table>
           </div>
 
+          {memberId != null && (
+            <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="mb-2 flex flex-wrap items-baseline gap-x-4 gap-y-1 text-xs text-zinc-600 dark:text-zinc-400">
+                <span>會員儲值餘額：
+                  {walletBalance == null
+                    ? <span className="text-zinc-500">載入中…</span>
+                    : <span className={`font-mono font-semibold ${walletBalance <= 0 ? "text-zinc-400" : ""}`}>${walletBalance}</span>}
+                </span>
+                {walletPaidSoFar > 0 && (
+                  <span>本訂單已扣：<span className="font-mono">${walletPaidSoFar}</span></span>
+                )}
+              </div>
+              <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
+                <label className="block">
+                  <span className="mb-1 block text-xs text-zinc-500">本次抵扣儲值金</span>
+                  <input
+                    type="number"
+                    min={0}
+                    max={walletMax}
+                    step="0.01"
+                    value={walletAmount}
+                    onChange={(e) => setWalletAmount(e.target.value)}
+                    placeholder={walletMax > 0 ? `最多 $${walletMax}` : "餘額不足"}
+                    disabled={walletMax <= 0}
+                    className={`w-full rounded-md border px-3 py-2 font-mono dark:bg-zinc-800 ${walletInvalid ? "border-red-400 dark:border-red-700" : "border-zinc-300 dark:border-zinc-700"} disabled:opacity-50`}
+                  />
+                </label>
+                <div className="block">
+                  <span className="mb-1 block text-xs text-zinc-500">找現金</span>
+                  <div className="rounded-md border border-zinc-200 bg-white px-3 py-2 font-mono dark:border-zinc-800 dark:bg-zinc-950">${cashAmount}</div>
+                </div>
+                {walletMax > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setWalletAmount(String(walletMax))}
+                    className="self-end rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs font-medium text-emerald-800 hover:bg-emerald-100 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
+                  >全用儲值金 ${walletMax}</button>
+                )}
+              </div>
+              {walletInvalid && (
+                <p className="mt-2 text-xs text-red-600 dark:text-red-400">金額超過餘額或本次應收上限</p>
+              )}
+            </div>
+          )}
+
           <label className="block text-sm">
             <span className="mb-1 block text-xs text-zinc-500">備註（選填）</span>
             <input
@@ -229,10 +318,14 @@ export function PickupDialog({
             </button>
             <button
               onClick={submit}
-              disabled={busy || picked.size === 0}
+              disabled={busy || picked.size === 0 || walletInvalid}
               className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:opacity-50"
             >
-              {busy ? "處理中…" : `✅ 確認取貨 (${picked.size} 項 · $${payableAmount})`}
+              {busy
+                ? "處理中…"
+                : walletNum > 0
+                  ? `✅ 確認取貨 (儲值 $${walletNum} + 現金 $${cashAmount})`
+                  : `✅ 確認取貨 (${picked.size} 項 · $${payableAmount})`}
             </button>
           </div>
         </div>

--- a/apps/admin/src/components/WalletActionModal.tsx
+++ b/apps/admin/src/components/WalletActionModal.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 import { Modal } from "@/components/Modal";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
+import { WALLET_PAYMENT_METHODS, WALLET_PAYMENT_METHOD_LABEL } from "@/lib/walletLedger";
 
 export type WalletActionMode = "topup" | "spend" | "refund" | "adjust" | "reverse";
 
@@ -39,11 +40,10 @@ const TITLES: Record<WalletActionMode, string> = {
   reverse: "反向（reversal）",
 };
 
-const PAYMENT_METHODS = [
-  { value: "cash",        label: "現金 cash" },
-  { value: "credit_card", label: "信用卡 credit_card" },
-  { value: "transfer",    label: "轉帳 transfer" },
-];
+const PAYMENT_METHODS = WALLET_PAYMENT_METHODS.map((v) => ({
+  value: v,
+  label: WALLET_PAYMENT_METHOD_LABEL[v],
+}));
 
 export function WalletActionModal({
   open, onClose, onSuccess,

--- a/apps/admin/src/components/WalletPayOrderModal.tsx
+++ b/apps/admin/src/components/WalletPayOrderModal.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+// 訂單用儲值金結帳 modal
+// 對應 RPC: rpc_wallet_pay_order(p_order_id, p_amount, p_operator)
+
+import { useEffect, useState } from "react";
+import { Modal } from "@/components/Modal";
+import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  orderId: number;
+  orderNo: string;
+  memberId: number;
+  memberName: string | null;
+  balanceDue: number;
+};
+
+export function WalletPayOrderModal({
+  open, onClose, onSuccess,
+  orderId, orderNo, memberId, memberName, balanceDue,
+}: Props) {
+  const [walletBalance, setWalletBalance] = useState<number | null>(null);
+  const [amount, setAmount] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setErr(null);
+    setWalletBalance(null);
+    setAmount("");
+    (async () => {
+      const sb = getSupabase();
+      const { data } = await sb.from("wallet_balances")
+        .select("balance").eq("member_id", memberId).maybeSingle<{ balance: number }>();
+      const bal = Number(data?.balance ?? 0);
+      setWalletBalance(bal);
+      // 預設值 = min(balance_due, walletBalance)
+      const def = Math.min(balanceDue, bal);
+      if (def > 0) setAmount(String(def));
+    })();
+  }, [open, memberId, balanceDue]);
+
+  async function submit() {
+    setErr(null);
+    const a = Number(amount);
+    if (!Number.isFinite(a) || a <= 0) { setErr("金額必須 > 0"); return; }
+    if (a > balanceDue)               { setErr(`金額不可超過應付剩餘 $${balanceDue}`); return; }
+    if (walletBalance != null && a > walletBalance) {
+      setErr(`金額超過會員餘額 $${walletBalance}`); return;
+    }
+
+    setBusy(true);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) { setErr("尚未登入"); return; }
+
+      const { error } = await sb.rpc("rpc_wallet_pay_order", {
+        p_order_id: orderId,
+        p_amount:   a,
+        p_operator: operator,
+      });
+      if (error) { setErr(translateRpcError(error)); return; }
+      onSuccess();
+      onClose();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const insufficientWallet = walletBalance != null && walletBalance <= 0;
+
+  return (
+    <Modal open={open} onClose={onClose} title={`用儲值金結帳`} maxWidth="max-w-md">
+      <div className="space-y-4 text-sm">
+        <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs dark:border-zinc-800 dark:bg-zinc-900">
+          <div>訂單：<span className="font-mono">{orderNo}</span></div>
+          <div>會員：{memberName ?? "—"} <span className="font-mono text-zinc-500">#{memberId}</span></div>
+          <div className="mt-1">應付剩餘：<span className="font-mono font-semibold">${balanceDue}</span></div>
+          <div>會員餘額：
+            {walletBalance == null
+              ? <span className="text-zinc-500">載入中…</span>
+              : <span className={`font-mono font-semibold ${insufficientWallet ? "text-red-600" : ""}`}>${walletBalance}</span>}
+          </div>
+        </div>
+
+        {insufficientWallet && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+            ⚠️ 會員儲值金餘額為 0，請先到會員頁加值後再回來結帳。
+          </div>
+        )}
+
+        <label className="block">
+          <span className="mb-1 block text-xs text-zinc-500">
+            金額（&gt; 0，≤ 應付剩餘 ${balanceDue}{walletBalance != null ? ` / 餘額 $${walletBalance}` : ""}）
+          </span>
+          <input
+            type="number"
+            step="0.01"
+            min={0}
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            disabled={insufficientWallet}
+            autoFocus
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono dark:border-zinc-700 dark:bg-zinc-900 disabled:opacity-50"
+          />
+        </label>
+
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {err}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={busy}
+            className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            取消
+          </button>
+          <button
+            onClick={submit}
+            disabled={busy || insufficientWallet || walletBalance == null}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {busy ? "結帳中…" : "💳 確認結帳"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/admin/src/lib/orderStatus.ts
+++ b/apps/admin/src/lib/orderStatus.ts
@@ -9,10 +9,9 @@
 //   4. 視語意調整 isTerminalStatus / canPayWithWallet
 //
 // 已砍掉但保留歷史翻譯（檔案最下方）：
-//   - reserved (已備貨)         — 未啟用，DB 0 筆
-//   - partially_ready (部分可取) — 未啟用
-//   - partially_completed (部分取貨) — 未啟用
-//   - picked_up (已取貨)        — 未啟用，跟 completed 重複語意
+//   - reserved (已備貨)         — 未啟用，DB 0 筆，無 RPC SET
+//   - partially_ready (部分可取) — 未啟用，無 RPC SET
+//   - picked_up (已取貨)        — 是 customer_order_items.status，不是 orders.status
 // ============================================================
 
 export const ORDER_STATUSES = [
@@ -20,6 +19,7 @@ export const ORDER_STATUSES = [
   "confirmed",
   "ready",
   "shipping",
+  "partially_completed",
   "completed",
   "cancelled",
   "transferred_out",
@@ -29,14 +29,15 @@ export const ORDER_STATUSES = [
 export type OrderStatus = (typeof ORDER_STATUSES)[number];
 
 export const ORDER_STATUS_LABEL: Record<OrderStatus, string> = {
-  pending:         "待確認",
-  confirmed:       "已確認",
-  ready:           "可取貨",
-  shipping:        "派貨中",
-  completed:       "已完成",
-  cancelled:       "已取消",
-  transferred_out: "已轉出",
-  expired:         "已過期",
+  pending:             "待確認",
+  confirmed:           "已確認",
+  ready:               "可取貨",
+  shipping:            "派貨中",
+  partially_completed: "部分取貨",
+  completed:           "已完成",
+  cancelled:           "已取消",
+  transferred_out:     "已轉出",
+  expired:             "已過期",
 };
 
 /** 取中文 label；未知 status 直接 fallback 原字串。 */
@@ -75,6 +76,5 @@ export function canPayWithWallet(
 // 歷史翻譯（已砍、僅留紀錄；未來重啟用時引用此處避免重新討論）
 //   reserved              → 已備貨   （之前部分檔案誤翻「已保留」）
 //   partially_ready       → 部分可取
-//   partially_completed   → 部分取貨
-//   picked_up             → 已取貨
+//   picked_up             → 已取貨   （只用於 customer_order_items.status）
 // ============================================================

--- a/apps/admin/src/lib/orderStatus.ts
+++ b/apps/admin/src/lib/orderStatus.ts
@@ -1,0 +1,80 @@
+// ============================================================
+// 顧客訂單 (customer_orders.status) 中央定義
+//
+// Single source of truth — 所有 admin 端 / LIFF 端 status 中文 label
+// 都從這裡 import。新增 status 時：
+//   1. 加到 ORDER_STATUSES tuple
+//   2. 加到 ORDER_STATUS_LABEL
+//   3. 同步 supabase migration 的 CHECK constraint
+//   4. 視語意調整 isTerminalStatus / canPayWithWallet
+//
+// 已砍掉但保留歷史翻譯（檔案最下方）：
+//   - reserved (已備貨)         — 未啟用，DB 0 筆
+//   - partially_ready (部分可取) — 未啟用
+//   - partially_completed (部分取貨) — 未啟用
+//   - picked_up (已取貨)        — 未啟用，跟 completed 重複語意
+// ============================================================
+
+export const ORDER_STATUSES = [
+  "pending",
+  "confirmed",
+  "ready",
+  "shipping",
+  "completed",
+  "cancelled",
+  "transferred_out",
+  "expired",
+] as const;
+
+export type OrderStatus = (typeof ORDER_STATUSES)[number];
+
+export const ORDER_STATUS_LABEL: Record<OrderStatus, string> = {
+  pending:         "待確認",
+  confirmed:       "已確認",
+  ready:           "可取貨",
+  shipping:        "派貨中",
+  completed:       "已完成",
+  cancelled:       "已取消",
+  transferred_out: "已轉出",
+  expired:         "已過期",
+};
+
+/** 取中文 label；未知 status 直接 fallback 原字串。 */
+export function orderStatusLabel(s: string | null | undefined): string {
+  if (!s) return "—";
+  return ORDER_STATUS_LABEL[s as OrderStatus] ?? s;
+}
+
+const TERMINAL_STATUSES = new Set<string>([
+  "completed",
+  "cancelled",
+  "transferred_out",
+  "expired",
+]);
+
+/** 終態 = 訂單流程已結束、不會再轉換。 */
+export function isTerminalStatus(s: string | null | undefined): boolean {
+  return s != null && TERMINAL_STATUSES.has(s);
+}
+
+/**
+ * 此 status 的訂單能不能用儲值金結帳。
+ * 規則：非終態 + 非已付清（payment_status 由呼叫端另判）。
+ * 跟 supabase/migrations/20260606000013 rpc_wallet_pay_order 同步。
+ */
+export function canPayWithWallet(
+  status: string | null | undefined,
+  paymentStatus: string | null | undefined,
+): boolean {
+  if (paymentStatus === "paid") return false;
+  if (isTerminalStatus(status)) return false;
+  return true;
+}
+
+// ============================================================
+// 歷史翻譯（已砍、僅留紀錄；未來重啟用時引用此處避免重新討論）
+//   reserved              → 已備貨   （之前部分檔案誤翻「已保留」）
+//   partially_ready       → 部分可取
+//   partially_completed   → 部分取貨
+//   picked_up             → 已取貨
+// ============================================================

--- a/apps/admin/src/lib/walletLedger.ts
+++ b/apps/admin/src/lib/walletLedger.ts
@@ -1,0 +1,53 @@
+// ============================================================
+// 儲值金 ledger 中央定義
+//
+// Single source of truth for:
+//   - wallet_ledger.type 中文 label (對應 supabase migrations 內 CHECK)
+//   - wallet_ledger.payment_method 中文 label (topup 用)
+// ============================================================
+
+export const WALLET_LEDGER_TYPES = [
+  "topup",
+  "spend",
+  "refund",
+  "adjust",
+  "reversal",
+] as const;
+
+export type WalletLedgerType = (typeof WALLET_LEDGER_TYPES)[number];
+
+export const WALLET_LEDGER_TYPE_LABEL: Record<WalletLedgerType, string> = {
+  topup:    "加值",
+  spend:    "扣款",
+  refund:   "退款",
+  adjust:   "調整",
+  reversal: "反向",
+};
+
+export function walletLedgerTypeLabel(t: string | null | undefined): string {
+  if (!t) return "—";
+  return WALLET_LEDGER_TYPE_LABEL[t as WalletLedgerType] ?? t;
+}
+
+// ============================================================
+// payment_method (主要 topup 時記錄)
+// ============================================================
+
+export const WALLET_PAYMENT_METHODS = [
+  "cash",
+  "credit_card",
+  "transfer",
+] as const;
+
+export type WalletPaymentMethod = (typeof WALLET_PAYMENT_METHODS)[number];
+
+export const WALLET_PAYMENT_METHOD_LABEL: Record<WalletPaymentMethod, string> = {
+  cash:        "現金",
+  credit_card: "信用卡",
+  transfer:    "轉帳",
+};
+
+export function walletPaymentMethodLabel(m: string | null | undefined): string {
+  if (!m) return "—";
+  return WALLET_PAYMENT_METHOD_LABEL[m as WalletPaymentMethod] ?? m;
+}

--- a/docs/TEST-wallet-phase-b.md
+++ b/docs/TEST-wallet-phase-b.md
@@ -1,0 +1,148 @@
+# wallet-phase-b 測試項目 — 訂單抵扣
+
+**對應 migration:**
+- `supabase/migrations/20260606000010_customer_orders_wallet_paid.sql`（新欄位）
+- `supabase/migrations/20260606000011_v_customer_order_summary_balance_due.sql`（view 加 balance_due）
+- `supabase/migrations/20260606000012_rpc_wallet_pay_order.sql`（新 RPC）
+
+**對應 UI 變更:**
+- `apps/admin/src/components/OrderDetail.tsx`（加付款摘要 + 用儲值金結帳按鈕）
+- `apps/admin/src/components/WalletPayOrderModal.tsx`（新 modal）
+
+**對應 plan:** `C:\Users\Alex\.claude\plans\session-db-federated-thunder.md` (Phase B)
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 customer_orders.wallet_paid_amount 欄位
+- [ ] 欄位存在、`NUMERIC(18,2) NOT NULL DEFAULT 0`
+  ```sql
+  SELECT column_name, data_type, numeric_precision, numeric_scale, column_default, is_nullable
+    FROM information_schema.columns
+   WHERE table_name='customer_orders' AND column_name='wallet_paid_amount';
+  -- expect: numeric, 18, 2, 0, NO
+  ```
+- [ ] CHECK constraint `wallet_paid_amount >= 0` 存在
+- [ ] index `idx_corders_wallet_paid` 存在（partial index where > 0）
+- [ ] 既有 row 全填 0（migration 不破壞現有資料）
+
+### 1.2 v_customer_order_summary 新加 balance_due
+- [ ] view 多兩欄：`wallet_paid_amount`, `balance_due`
+- [ ] `balance_due = payable_amount - wallet_paid_amount`
+- [ ] 既有欄位都還在（payable_amount / items / chips / settlement_no...）
+- [ ] LIFF Edge function 取出來無 schema mismatch
+
+### 1.3 rpc_wallet_pay_order
+- [ ] 函式存在、SECURITY DEFINER、回傳 JSONB（含新 ledger_id + new wallet_paid_amount + new balance_due + payment_status）
+- [ ] `GRANT EXECUTE TO authenticated`
+
+---
+
+## 2. RPC 行為（SQL / curl 直測）
+
+### 2.1 happy path（部分付）
+**情境：** 訂單 #X，payable=500、wallet_paid_amount=0；會員餘額 1000；payment_status='unpaid'
+**操作：** `rpc_wallet_pay_order(X, 200, op)`
+**預期：**
+- ledger 多一筆 type='spend'、change=-200、source_type='customer_order'、source_id=X
+- 會員餘額 = 800
+- `customer_orders.wallet_paid_amount` = 200
+- `payment_status` 仍 'unpaid'（balance_due > 0）
+- 回傳 JSONB `{ ledger_id, wallet_paid_amount: 200, balance_due: 300, payment_status: 'unpaid' }`
+
+### 2.2 happy path（剛好付清）
+**情境：** payable=500、wallet_paid_amount=200、餘額 800
+**操作：** `rpc_wallet_pay_order(X, 300, op)`
+**預期：**
+- 餘額 = 500
+- `wallet_paid_amount` = 500
+- **`payment_status` = 'paid'**, **`paid_at` 設 NOW()**
+- balance_due = 0
+
+### 2.3 餘額不足
+**情境：** payable=500、wallet_paid_amount=0；會員餘額 100
+**操作：** `rpc_wallet_pay_order(X, 200, op)`
+**預期：** RAISE `Insufficient wallet`（從 rpc_wallet_spend 冒泡）；訂單 column 沒動
+
+### 2.4 超付防護
+**情境：** payable=500、wallet_paid_amount=400
+**操作：** `rpc_wallet_pay_order(X, 200, op)`（總和 > 500）
+**預期：** RAISE `wallet pay exceeds balance_due`；無 ledger 寫入
+
+### 2.5 訂單狀態擋
+- [ ] `status='pending'` → 通過
+- [ ] `status='confirmed'` → 通過
+- [ ] `status='cancelled'` → RAISE
+- [ ] `status='completed'` → RAISE（已完成不能再付）
+- [ ] `status='shipping'` → 視 PRD 決定（目前讓過，之後若有問題再加擋）
+
+### 2.6 跨 tenant
+- [ ] 用 tenant1 的 JWT 試付 tenant2 的訂單 → RAISE `order not found`
+
+### 2.7 並發（兩個 session 同時 pay 同訂單）
+**情境：** 同訂單同時兩個 session 付 300、300（payable=500）
+**預期：** 第二個等第一個 commit；其中一個會 RAISE 超付；最終 `wallet_paid_amount <= payable`
+
+### 2.8 amount <= 0 拒絕
+- [ ] `p_amount = 0` → RAISE
+- [ ] `p_amount = -10` → RAISE
+
+### 2.9 member.status 擋
+- [ ] order.member 是 'merged' → RAISE（不能對已合併的會員扣）
+
+---
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 OrderDetail — 付款摘要
+**前置：** 訂單 status='pending'、payable=500、wallet_paid_amount=0
+- [ ] 應收區塊顯示：`= 應收 $500`
+- [ ] 若 wallet_paid_amount > 0：多一行 `− 已用儲值金 $X`
+- [ ] 若 balance_due > 0：多一行 `= 應付剩餘 $Y`
+- [ ] 顯示「💳 用儲值金結帳」按鈕（可點）
+
+### 3.2 已付清訂單
+**前置：** wallet_paid_amount = payable
+- [ ] 顯示綠色「✅ 已付清（儲值金 $X）」chip
+- [ ] 「用儲值金結帳」按鈕 disabled / 隱藏
+
+### 3.3 取消／完成訂單
+- [ ] status='cancelled' / 'completed' → 按鈕 disabled、tooltip 解釋
+
+### 3.4 WalletPayOrderModal
+**操作：** 點「💳 用儲值金結帳」
+- [ ] modal 開啟，顯示：
+  - 訂單號 / 應付剩餘 $X
+  - 會員目前儲值餘額 $Y（從 wallet_balances 即時撈）
+  - 金額 input（預設 = min(balance_due, wallet_balance)、max=balance_due）
+- [ ] 若會員餘額 = 0 → 顯示警告「會員餘額不足，請先加值」、確認鈕 disabled
+- [ ] 送出後 modal 關、訂單 reload、wallet_paid_amount 更新
+- [ ] 若全付清，自動更新 payment_status='paid'
+
+### 3.5 錯誤處理
+- [ ] RPC 各種 RAISE（Insufficient wallet / exceeds / not found）→ 經 `translateRpcError` alert
+
+### 3.6 跨權限
+- [ ] HQ admin 看自店 / 他店訂單 → 都能用儲值金結帳
+- [ ] 店家帳號看自店訂單 → 可結帳；他店訂單 → 按鈕 disabled / 不顯示
+
+---
+
+## 4. Regression
+
+- [ ] Phase A 的 4 顆按鈕 + reverse 全部正常
+- [ ] 既有訂單 audit 顯示沒壞
+- [ ] LIFF `/orders/:id` 顧客端的 `payable_amount` 仍對（balance_due 在 view 裡是新增欄）
+- [ ] LIFF `OrderCard` / `SettlementCard` UI 沒破
+- [ ] `rpc_cancel_aid_order` 還能執行（Phase C 才會改它）— 現在取消後 `wallet_paid_amount` 留著，之後 Phase C auto-refund
+- [ ] `rpc_record_pickup` 不受影響
+- [ ] `pnpm build` 過、type-check 過
+
+---
+
+## 5. 驗收門檻
+
+§1-§4 全勾、無 console error、Supabase push 成功、跑 `fn_check_wallet_consistency()` 回 0 rows、build 過 才能標 done。
+
+PR merge 後同步 GitHub Issues + Wiki。

--- a/supabase/migrations/20260606000001_fix_wallet_adjust_role_jwt.sql
+++ b/supabase/migrations/20260606000001_fix_wallet_adjust_role_jwt.sql
@@ -1,0 +1,84 @@
+-- ============================================================
+-- rpc_wallet_adjust: 修 role 讀取 (對齊 20260605000003 fix pattern)
+--   原版讀 auth.jwt() ->> 'role'，但這欄位是 PostgREST 預設 'authenticated'
+--   而非 app 自定義 role；admin user 在這欄永遠拿到 'authenticated'，被誤擋
+--   → 改成優先讀 app_metadata.role（與 useRole() / canAdjustWallet() 一致）
+--   → app_metadata.role 為 NULL/空 視為 HQ tier
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_wallet_adjust(
+  p_tenant_id  UUID,
+  p_member_id  BIGINT,
+  p_change     NUMERIC,
+  p_reason     TEXT,
+  p_operator   UUID
+) RETURNS BIGINT AS $$
+DECLARE
+  v_cur_balance NUMERIC;
+  v_new_balance NUMERIC;
+  v_id BIGINT;
+  v_role TEXT := COALESCE(
+                   NULLIF(auth.jwt() -> 'app_metadata' ->> 'role', ''),
+                   NULLIF(auth.jwt() ->> 'role', 'authenticated'),
+                   ''
+                 );
+  v_member_status TEXT;
+BEGIN
+  -- Role gate: BRANCH_ROLES from apps/admin/src/lib/role.ts
+  --   '' (HQ admin / 無自定 role) / owner / admin / hq_manager / hq_accountant / store_manager
+  -- 排除：assistant / store_staff (低權限店員)
+  IF v_role NOT IN ('', 'owner', 'admin', 'hq_manager', 'hq_accountant', 'store_manager') THEN
+    RAISE EXCEPTION 'permission denied for wallet adjust (role=%)', v_role;
+  END IF;
+
+  IF p_change IS NULL OR p_change = 0 THEN
+    RAISE EXCEPTION 'adjust change must be non-zero';
+  END IF;
+  IF p_reason IS NULL OR LENGTH(TRIM(p_reason)) < 4 THEN
+    RAISE EXCEPTION 'reason required (>=4 chars)';
+  END IF;
+
+  SELECT status INTO v_member_status FROM members
+   WHERE id = p_member_id AND tenant_id = p_tenant_id;
+  IF v_member_status IS NULL THEN
+    RAISE EXCEPTION 'member % not found', p_member_id;
+  END IF;
+  IF v_member_status <> 'active' THEN
+    RAISE EXCEPTION 'member status=% cannot adjust', v_member_status;
+  END IF;
+
+  INSERT INTO wallet_balances (tenant_id, member_id)
+  VALUES (p_tenant_id, p_member_id) ON CONFLICT DO NOTHING;
+
+  SELECT balance INTO v_cur_balance FROM wallet_balances
+  WHERE tenant_id = p_tenant_id AND member_id = p_member_id FOR UPDATE;
+
+  v_new_balance := v_cur_balance + p_change;
+  IF v_new_balance < 0 THEN
+    RAISE EXCEPTION 'adjust would make balance negative: current=%, change=%',
+      v_cur_balance, p_change;
+  END IF;
+
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after,
+                             type, reason, operator_id)
+  VALUES (p_tenant_id, p_member_id, p_change, v_new_balance,
+          'adjust', p_reason, p_operator)
+  RETURNING id INTO v_id;
+
+  UPDATE wallet_balances
+     SET balance = v_new_balance, version = version + 1,
+         last_movement_at = NOW(), updated_at = NOW()
+   WHERE tenant_id = p_tenant_id AND member_id = p_member_id;
+
+  INSERT INTO member_audit_log (tenant_id, entity_type, entity_id, action,
+                                before_value, after_value, reason, operator_id)
+  VALUES (p_tenant_id, 'wallet', p_member_id, 'adjust',
+          jsonb_build_object('balance', v_cur_balance),
+          jsonb_build_object('balance', v_new_balance, 'change', p_change),
+          p_reason, p_operator);
+
+  RETURN v_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION rpc_wallet_adjust(UUID, BIGINT, NUMERIC, TEXT, UUID) TO authenticated;

--- a/supabase/migrations/20260606000010_customer_orders_wallet_paid.sql
+++ b/supabase/migrations/20260606000010_customer_orders_wallet_paid.sql
@@ -1,0 +1,17 @@
+-- ============================================================
+-- customer_orders.wallet_paid_amount
+--   訂單以儲值金支付的累計金額
+--   對應 wallet_ledger spend/refund/reversal entries (source_type='customer_order')
+--   應付剩餘 = payable_amount - wallet_paid_amount (新 view 提供 balance_due)
+-- ============================================================
+
+ALTER TABLE customer_orders
+  ADD COLUMN wallet_paid_amount NUMERIC(18,2) NOT NULL DEFAULT 0
+    CHECK (wallet_paid_amount >= 0);
+
+COMMENT ON COLUMN customer_orders.wallet_paid_amount IS
+  '此訂單以儲值金支付的累計金額；source of truth 仍是 wallet_ledger，本欄位為快取/索引用途';
+
+-- partial index：只索引有用儲值金的訂單（多數訂單為 0、不入索引）
+CREATE INDEX idx_corders_wallet_paid ON customer_orders (member_id)
+  WHERE wallet_paid_amount > 0;

--- a/supabase/migrations/20260606000011_v_customer_order_summary_balance_due.sql
+++ b/supabase/migrations/20260606000011_v_customer_order_summary_balance_due.sql
@@ -1,0 +1,111 @@
+-- ============================================================
+-- v_customer_order_summary：加 wallet_paid_amount + balance_due
+--   - wallet_paid_amount：直接帶 customer_orders 欄位
+--   - balance_due = payable_amount - wallet_paid_amount
+--   - payable_amount 公式不變（沿用 20260605000005 的 percent + amount 雙折扣）
+-- ============================================================
+
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.discount_percent,
+  co.wallet_paid_amount,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  agg.items_total,
+  GREATEST(
+    0,
+    ROUND(agg.items_total * (1 - co.discount_percent / 100), 4)
+      + co.shipping_fee
+      - co.discount_amount
+  )                                                                             AS payable_amount,
+  GREATEST(
+    0,
+    GREATEST(
+      0,
+      ROUND(agg.items_total * (1 - co.discount_percent / 100), 4)
+        + co.shipping_fee
+        - co.discount_amount
+    ) - co.wallet_paid_amount
+  )                                                                             AS balance_due,
+  agg.items,
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','shipping','completed'))                AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))            AS settled,
+  (co.payment_status = 'paid')                                                 AS paid,
+  (co.status IN ('shipping','completed'))                                      AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                 AS settlement_no,
+  s.name                                                                        AS store_name,
+  s.code                                                                        AS store_code,
+  gbc.name                                                                      AS campaign_name,
+  gbc.cover_image_url                                                           AS campaign_cover_url,
+  gbc.end_at                                                                    AS campaign_end_at,
+  gbc.cutoff_date                                                               AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price), 0)                                 AS items_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'sku_code',         sk.sku_code,
+          'product_name',     sk.product_name,
+          'variant_name',     sk.variant_name,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'subtotal',         coi.qty * coi.unit_price,
+          'status',           coi.status,
+          'notes',            coi.notes,
+          'image_url',        CASE
+            WHEN jsonb_typeof(p.images) = 'array' AND jsonb_array_length(p.images) > 0 THEN
+              COALESCE(p.images -> 0 ->> 'url', p.images ->> 0)
+            ELSE NULL
+          END
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                           AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus     sk ON sk.id = coi.sku_id
+  LEFT JOIN products p  ON p.id  = sk.product_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細 + percent + amount 雙折扣 + 儲值金抵扣 + balance_due';

--- a/supabase/migrations/20260606000012_rpc_wallet_pay_order.sql
+++ b/supabase/migrations/20260606000012_rpc_wallet_pay_order.sql
@@ -1,0 +1,114 @@
+-- ============================================================
+-- rpc_wallet_pay_order
+--   Admin 後台「用儲值金結帳」單一原子操作
+--
+--   流程（單一 transaction）：
+--   1. advisory lock + SELECT FOR UPDATE on customer_orders
+--   2. 斷言 status IN (pending, confirmed)
+--   3. 算 payable_amount（沿用 view 的公式：percent + amount 雙折扣）
+--   4. 斷言 wallet_paid_amount + p_amount <= payable_amount
+--   5. 呼叫 rpc_wallet_spend(...)（餘額不足會 RAISE）
+--   6. UPDATE customer_orders SET wallet_paid_amount += p_amount
+--      若 balance_due 歸 0 則 payment_status='paid' + paid_at=NOW
+--   7. 回 JSONB 給前端 reload
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_wallet_pay_order(
+  p_order_id  BIGINT,
+  p_amount    NUMERIC,
+  p_operator  UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_order             customer_orders%ROWTYPE;
+  v_member_status     TEXT;
+  v_items_total       NUMERIC;
+  v_payable           NUMERIC;
+  v_new_wallet_paid   NUMERIC;
+  v_new_balance_due   NUMERIC;
+  v_ledger_id         BIGINT;
+  v_paid              BOOLEAN := FALSE;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'amount must be positive';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('aid_order:' || p_order_id));
+
+  SELECT * INTO v_order FROM customer_orders
+   WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  IF v_order.status NOT IN ('pending','confirmed') THEN
+    RAISE EXCEPTION 'order % is %, only pending/confirmed can be paid by wallet',
+      p_order_id, v_order.status;
+  END IF;
+  IF v_order.member_id IS NULL THEN
+    RAISE EXCEPTION 'order % has no member', p_order_id;
+  END IF;
+
+  -- 會員狀態擋（避免對 merged/deleted 扣款）
+  SELECT status INTO v_member_status FROM members
+   WHERE id = v_order.member_id AND tenant_id = v_order.tenant_id;
+  IF v_member_status IS NULL THEN
+    RAISE EXCEPTION 'member % not found', v_order.member_id;
+  END IF;
+  IF v_member_status <> 'active' THEN
+    RAISE EXCEPTION 'member status=% cannot be charged', v_member_status;
+  END IF;
+
+  -- 算 payable（沿用 view 公式）
+  SELECT COALESCE(SUM(qty * unit_price), 0)
+    INTO v_items_total
+    FROM customer_order_items
+   WHERE order_id = p_order_id;
+
+  v_payable := GREATEST(
+    0,
+    ROUND(v_items_total * (1 - v_order.discount_percent / 100), 4)
+      + v_order.shipping_fee
+      - v_order.discount_amount
+  );
+
+  v_new_wallet_paid := v_order.wallet_paid_amount + p_amount;
+  IF v_new_wallet_paid > v_payable THEN
+    RAISE EXCEPTION 'wallet pay exceeds balance_due: paying=%, already_paid=%, payable=%',
+      p_amount, v_order.wallet_paid_amount, v_payable;
+  END IF;
+
+  -- 走 spend RPC（內部 FOR UPDATE 餘額、餘額不足 RAISE Insufficient wallet）
+  v_ledger_id := rpc_wallet_spend(
+    v_order.tenant_id,
+    v_order.member_id,
+    p_amount,
+    'customer_order',
+    p_order_id,
+    p_operator
+  );
+
+  v_new_balance_due := v_payable - v_new_wallet_paid;
+  v_paid := (v_new_balance_due = 0);
+
+  UPDATE customer_orders
+     SET wallet_paid_amount = v_new_wallet_paid,
+         payment_status = CASE WHEN v_paid THEN 'paid' ELSE payment_status END,
+         paid_at        = CASE WHEN v_paid AND paid_at IS NULL THEN NOW() ELSE paid_at END,
+         updated_by     = p_operator,
+         updated_at     = NOW()
+   WHERE id = p_order_id;
+
+  RETURN jsonb_build_object(
+    'ledger_id',          v_ledger_id,
+    'wallet_paid_amount', v_new_wallet_paid,
+    'payable_amount',     v_payable,
+    'balance_due',        v_new_balance_due,
+    'payment_status',     CASE WHEN v_paid THEN 'paid' ELSE v_order.payment_status END,
+    'paid_at',            CASE WHEN v_paid THEN COALESCE(v_order.paid_at, NOW()) ELSE v_order.paid_at END
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION rpc_wallet_pay_order(BIGINT, NUMERIC, UUID) TO authenticated;
+
+COMMENT ON FUNCTION rpc_wallet_pay_order(BIGINT, NUMERIC, UUID) IS
+  '用儲值金結帳；原子操作：lock 訂單 + 算 payable + 走 rpc_wallet_spend + UPDATE wallet_paid_amount + 全付清自動標 payment_status=paid';

--- a/supabase/migrations/20260606000013_rpc_wallet_pay_order_expand_status.sql
+++ b/supabase/migrations/20260606000013_rpc_wallet_pay_order_expand_status.sql
@@ -1,0 +1,100 @@
+-- ============================================================
+-- rpc_wallet_pay_order: 放寬可結帳的訂單狀態
+--   原版只允許 pending / confirmed，但實務上 confirmed 後很快會
+--   跳到 reserved / ready（商品到齊待取），這些都應該還能用儲值金結帳。
+--   只擋已完成 / 取消 / 轉出 / 逾期 / 已取貨 + 已 paid 的訂單。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_wallet_pay_order(
+  p_order_id  BIGINT,
+  p_amount    NUMERIC,
+  p_operator  UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_order             customer_orders%ROWTYPE;
+  v_member_status     TEXT;
+  v_items_total       NUMERIC;
+  v_payable           NUMERIC;
+  v_new_wallet_paid   NUMERIC;
+  v_new_balance_due   NUMERIC;
+  v_ledger_id         BIGINT;
+  v_paid              BOOLEAN := FALSE;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'amount must be positive';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('aid_order:' || p_order_id));
+
+  SELECT * INTO v_order FROM customer_orders
+   WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  IF v_order.status IN ('completed','picked_up','cancelled','expired','transferred_out') THEN
+    RAISE EXCEPTION 'order % is %, cannot be paid by wallet', p_order_id, v_order.status;
+  END IF;
+  IF v_order.payment_status = 'paid' THEN
+    RAISE EXCEPTION 'order % already paid', p_order_id;
+  END IF;
+  IF v_order.member_id IS NULL THEN
+    RAISE EXCEPTION 'order % has no member', p_order_id;
+  END IF;
+
+  SELECT status INTO v_member_status FROM members
+   WHERE id = v_order.member_id AND tenant_id = v_order.tenant_id;
+  IF v_member_status IS NULL THEN
+    RAISE EXCEPTION 'member % not found', v_order.member_id;
+  END IF;
+  IF v_member_status <> 'active' THEN
+    RAISE EXCEPTION 'member status=% cannot be charged', v_member_status;
+  END IF;
+
+  SELECT COALESCE(SUM(qty * unit_price), 0)
+    INTO v_items_total
+    FROM customer_order_items
+   WHERE order_id = p_order_id;
+
+  v_payable := GREATEST(
+    0,
+    ROUND(v_items_total * (1 - v_order.discount_percent / 100), 4)
+      + v_order.shipping_fee
+      - v_order.discount_amount
+  );
+
+  v_new_wallet_paid := v_order.wallet_paid_amount + p_amount;
+  IF v_new_wallet_paid > v_payable THEN
+    RAISE EXCEPTION 'wallet pay exceeds balance_due: paying=%, already_paid=%, payable=%',
+      p_amount, v_order.wallet_paid_amount, v_payable;
+  END IF;
+
+  v_ledger_id := rpc_wallet_spend(
+    v_order.tenant_id,
+    v_order.member_id,
+    p_amount,
+    'customer_order',
+    p_order_id,
+    p_operator
+  );
+
+  v_new_balance_due := v_payable - v_new_wallet_paid;
+  v_paid := (v_new_balance_due = 0);
+
+  UPDATE customer_orders
+     SET wallet_paid_amount = v_new_wallet_paid,
+         payment_status = CASE WHEN v_paid THEN 'paid' ELSE payment_status END,
+         paid_at        = CASE WHEN v_paid AND paid_at IS NULL THEN NOW() ELSE paid_at END,
+         updated_by     = p_operator,
+         updated_at     = NOW()
+   WHERE id = p_order_id;
+
+  RETURN jsonb_build_object(
+    'ledger_id',          v_ledger_id,
+    'wallet_paid_amount', v_new_wallet_paid,
+    'payable_amount',     v_payable,
+    'balance_due',        v_new_balance_due,
+    'payment_status',     CASE WHEN v_paid THEN 'paid' ELSE v_order.payment_status END,
+    'paid_at',            CASE WHEN v_paid THEN COALESCE(v_order.paid_at, NOW()) ELSE v_order.paid_at END
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20260606000020_customer_orders_status_check.sql
+++ b/supabase/migrations/20260606000020_customer_orders_status_check.sql
@@ -1,0 +1,49 @@
+-- ============================================================
+-- customer_orders.status: 加 CHECK constraint 鎖死合法值
+--
+-- 對齊 apps/admin/src/lib/orderStatus.ts ORDER_STATUSES (single source of truth)
+-- 砍掉的 reserved / partially_ready / partially_completed / picked_up
+-- 從未寫進 DB（生產確認 0 筆），不需 backfill。
+--
+-- 之前 status 是 free TEXT，導致：
+--   - 各檔案 STATUS_LABEL 不一致（reserved/shipping/expired 翻譯歧義）
+--   - 寫錯字串會悄悄混進去
+--
+-- 加完此 constraint 之後，新增 status 必須：
+--   1. 改 ORDER_STATUSES tuple（lib/orderStatus.ts）
+--   2. 寫一支 ALTER 改 CHECK
+-- ============================================================
+
+-- 防禦性：先檢查現有資料是否全在白名單內（理論應該都在）
+DO $$
+DECLARE
+  v_bad_count INT;
+  v_bad_samples TEXT;
+BEGIN
+  SELECT count(*), string_agg(DISTINCT status, ',')
+    INTO v_bad_count, v_bad_samples
+    FROM customer_orders
+   WHERE status NOT IN (
+     'pending','confirmed','ready','shipping',
+     'completed','cancelled','transferred_out','expired'
+   );
+  IF v_bad_count > 0 THEN
+    RAISE EXCEPTION 'cannot apply CHECK: % rows have status NOT IN whitelist (samples: %)',
+      v_bad_count, v_bad_samples;
+  END IF;
+END $$;
+
+-- 既有 customer_orders_status_check 涵蓋 11 個 status（含 reserved /
+-- partially_ready / partially_completed 三個從未寫進 DB 的）；
+-- DROP 重建為更窄的 8 個（對齊 lib/orderStatus.ts ORDER_STATUSES）
+ALTER TABLE customer_orders DROP CONSTRAINT IF EXISTS customer_orders_status_check;
+
+ALTER TABLE customer_orders
+  ADD CONSTRAINT customer_orders_status_check
+  CHECK (status IN (
+    'pending','confirmed','ready','shipping',
+    'completed','cancelled','transferred_out','expired'
+  ));
+
+COMMENT ON CONSTRAINT customer_orders_status_check ON customer_orders IS
+  '對齊 apps/admin/src/lib/orderStatus.ts ORDER_STATUSES；新增 status 須同步改此 constraint + lib';

--- a/supabase/migrations/20260606000021_customer_orders_status_check_add_partial.sql
+++ b/supabase/migrations/20260606000021_customer_orders_status_check_add_partial.sql
@@ -1,0 +1,18 @@
+-- ============================================================
+-- 修補：CHECK 漏掉 partially_completed
+--   rpc_record_pickup 部分取貨時會 SET customer_orders.status='partially_completed'
+--   先前 20260606000020 砍掉它導致 partial pickup 會被 CHECK 擋
+--   （生產 0 筆是因為偶然沒人做過 partial，不代表這個 status 沒在用）
+-- ============================================================
+
+ALTER TABLE customer_orders DROP CONSTRAINT IF EXISTS customer_orders_status_check;
+
+ALTER TABLE customer_orders
+  ADD CONSTRAINT customer_orders_status_check
+  CHECK (status IN (
+    'pending','confirmed','ready','shipping','partially_completed',
+    'completed','cancelled','transferred_out','expired'
+  ));
+
+COMMENT ON CONSTRAINT customer_orders_status_check ON customer_orders IS
+  '對齊 apps/admin/src/lib/orderStatus.ts ORDER_STATUSES (9 個)；新增 status 須同步改此 + lib';

--- a/supabase/migrations/20260606000030_payable_round_to_integer.sql
+++ b/supabase/migrations/20260606000030_payable_round_to_integer.sql
@@ -1,0 +1,224 @@
+-- ============================================================
+-- 應收金額一律四捨五入到整數 NTD
+--
+-- 之前 payable = ROUND(items*(1-pct/100), 4) + shipping - discount
+--   → 折扣 23% 會出現 $228.69 之類小數，不能實際收費
+-- 改為 payable = ROUND(items*(1-pct/100) + shipping - discount, 0)
+--   → 一律取整數 NTD（PostgreSQL ROUND(numeric, 0) 為 half-away-from-zero）
+--
+-- 同步：
+--   1. v_customer_order_summary.payable_amount + balance_due
+--   2. rpc_wallet_pay_order 內 v_payable 計算
+-- 對應 frontend：OrderDetail.applyOrderDiscount + PickupDialog.payableAmount
+-- ============================================================
+
+-- 1) v_customer_order_summary
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.discount_percent,
+  co.wallet_paid_amount,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  agg.items_total,
+  GREATEST(
+    0,
+    ROUND(
+      agg.items_total * (1 - co.discount_percent / 100)
+        + co.shipping_fee
+        - co.discount_amount,
+      0
+    )
+  )                                                                            AS payable_amount,
+  GREATEST(
+    0,
+    GREATEST(
+      0,
+      ROUND(
+        agg.items_total * (1 - co.discount_percent / 100)
+          + co.shipping_fee
+          - co.discount_amount,
+        0
+      )
+    ) - co.wallet_paid_amount
+  )                                                                            AS balance_due,
+  agg.items,
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','shipping','completed'))                AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))            AS settled,
+  (co.payment_status = 'paid')                                                 AS paid,
+  (co.status IN ('shipping','completed'))                                      AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                 AS settlement_no,
+  s.name                                                                        AS store_name,
+  s.code                                                                        AS store_code,
+  gbc.name                                                                      AS campaign_name,
+  gbc.cover_image_url                                                           AS campaign_cover_url,
+  gbc.end_at                                                                    AS campaign_end_at,
+  gbc.cutoff_date                                                               AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price), 0)                                 AS items_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'sku_code',         sk.sku_code,
+          'product_name',     sk.product_name,
+          'variant_name',     sk.variant_name,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'subtotal',         coi.qty * coi.unit_price,
+          'status',           coi.status,
+          'notes',            coi.notes,
+          'image_url',        CASE
+            WHEN jsonb_typeof(p.images) = 'array' AND jsonb_array_length(p.images) > 0 THEN
+              COALESCE(p.images -> 0 ->> 'url', p.images ->> 0)
+            ELSE NULL
+          END
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                           AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus     sk ON sk.id = coi.sku_id
+  LEFT JOIN products p  ON p.id  = sk.product_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細 + percent + amount 雙折扣 + 儲值金抵扣 + balance_due（應收已四捨五入到整數 NTD）';
+
+-- 2) rpc_wallet_pay_order — payable 算式同步
+CREATE OR REPLACE FUNCTION rpc_wallet_pay_order(
+  p_order_id  BIGINT,
+  p_amount    NUMERIC,
+  p_operator  UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_order             customer_orders%ROWTYPE;
+  v_member_status     TEXT;
+  v_items_total       NUMERIC;
+  v_payable           NUMERIC;
+  v_new_wallet_paid   NUMERIC;
+  v_new_balance_due   NUMERIC;
+  v_ledger_id         BIGINT;
+  v_paid              BOOLEAN := FALSE;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'amount must be positive';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('aid_order:' || p_order_id));
+
+  SELECT * INTO v_order FROM customer_orders
+   WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  IF v_order.status IN ('completed','picked_up','cancelled','expired','transferred_out') THEN
+    RAISE EXCEPTION 'order % is %, cannot be paid by wallet', p_order_id, v_order.status;
+  END IF;
+  IF v_order.payment_status = 'paid' THEN
+    RAISE EXCEPTION 'order % already paid', p_order_id;
+  END IF;
+  IF v_order.member_id IS NULL THEN
+    RAISE EXCEPTION 'order % has no member', p_order_id;
+  END IF;
+
+  SELECT status INTO v_member_status FROM members
+   WHERE id = v_order.member_id AND tenant_id = v_order.tenant_id;
+  IF v_member_status IS NULL THEN
+    RAISE EXCEPTION 'member % not found', v_order.member_id;
+  END IF;
+  IF v_member_status <> 'active' THEN
+    RAISE EXCEPTION 'member status=% cannot be charged', v_member_status;
+  END IF;
+
+  SELECT COALESCE(SUM(qty * unit_price), 0)
+    INTO v_items_total
+    FROM customer_order_items
+   WHERE order_id = p_order_id;
+
+  -- payable 四捨五入到整數 NTD（同 v_customer_order_summary）
+  v_payable := GREATEST(
+    0,
+    ROUND(
+      v_items_total * (1 - v_order.discount_percent / 100)
+        + v_order.shipping_fee
+        - v_order.discount_amount,
+      0
+    )
+  );
+
+  v_new_wallet_paid := v_order.wallet_paid_amount + p_amount;
+  IF v_new_wallet_paid > v_payable THEN
+    RAISE EXCEPTION 'wallet pay exceeds balance_due: paying=%, already_paid=%, payable=%',
+      p_amount, v_order.wallet_paid_amount, v_payable;
+  END IF;
+
+  v_ledger_id := rpc_wallet_spend(
+    v_order.tenant_id,
+    v_order.member_id,
+    p_amount,
+    'customer_order',
+    p_order_id,
+    p_operator
+  );
+
+  v_new_balance_due := v_payable - v_new_wallet_paid;
+  v_paid := (v_new_balance_due = 0);
+
+  UPDATE customer_orders
+     SET wallet_paid_amount = v_new_wallet_paid,
+         payment_status = CASE WHEN v_paid THEN 'paid' ELSE payment_status END,
+         paid_at        = CASE WHEN v_paid AND paid_at IS NULL THEN NOW() ELSE paid_at END,
+         updated_by     = p_operator,
+         updated_at     = NOW()
+   WHERE id = p_order_id;
+
+  RETURN jsonb_build_object(
+    'ledger_id',          v_ledger_id,
+    'wallet_paid_amount', v_new_wallet_paid,
+    'payable_amount',     v_payable,
+    'balance_due',        v_new_balance_due,
+    'payment_status',     CASE WHEN v_paid THEN 'paid' ELSE v_order.payment_status END,
+    'paid_at',            CASE WHEN v_paid THEN COALESCE(v_order.paid_at, NOW()) ELSE v_order.paid_at END
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
延續 PR #188 (Phase A) 已 merged 的後續工作 — 把儲值金 Phase B/C/D 一次到位 + 順手把 order status 跟應收金額取整也統一了。

Closes #191 (Phase C) · Closes #192 (Phase D)

## 主軸

1. **儲值金 Phase B**：訂單抵扣 + 取貨時結帳整合 + 列印收據顯示
2. **儲值金 Phase C**：取消訂單自動退儲值金 + `rpc_wallet_partial_refund` 手動部分退
3. **儲值金 Phase D**：LIFF 顧客端餘額顯示 + ledger 列表
4. **Order status 中央化**：消除 5 處 STATUS_LABEL 不一致 + DB CHECK 鎖死
5. **應收金額一律四捨五入到整數 NTD**：DB / RPC / Frontend / 列印 完全對齊

## DB 層（10 支 migration）

| Migration | 用途 | Phase |
|---|---|---|
| `20260606000001_fix_wallet_adjust_role_jwt.sql` | rpc_wallet_adjust JWT role 讀錯位置（auth.jwt()->>'role' 是 PostgREST 'authenticated'，自定 role 在 app_metadata.role） | B |
| `20260606000010_customer_orders_wallet_paid.sql` | ALTER ADD `wallet_paid_amount NUMERIC(18,2)` + partial index | B |
| `20260606000011_v_customer_order_summary_balance_due.sql` | view 加 `wallet_paid_amount` + `balance_due` | B |
| `20260606000012_rpc_wallet_pay_order.sql` | 新 RPC 原子操作 | B |
| `20260606000013_rpc_wallet_pay_order_expand_status.sql` | 放寬可結帳 status：黑名單擋終態 + paid | B |
| `20260606000020_customer_orders_status_check.sql` | DROP 舊 11-status CHECK，重建 8-status | refactor |
| `20260606000021_customer_orders_status_check_add_partial.sql` | 補回 `partially_completed`（rpc_record_pickup 部分取貨會 SET 它） | refactor |
| `20260606000030_payable_round_to_integer.sql` | view + RPC payable 改 ROUND(..., 0) | refactor |
| `20260606000040_rpc_cancel_aid_order_wallet_refund.sql` | cancel 自動 refund | C |
| `20260606000041_rpc_wallet_partial_refund.sql` | 部分退款 RPC | C |

## Edge function

`supabase/functions/liff-api/index.ts` 加兩個 actions：
- `get_wallet` — 回 `{balance, version, last_movement_at, updated_at}`
- `list_wallet_ledger` — 分頁（limit 預設 30、上限 100、keyset via `before_id`）

## Frontend 層

### 新元件 / lib
- `apps/admin/src/lib/orderStatus.ts` — 9 個 status SSOT + canPayWithWallet/isTerminalStatus helper
- `apps/admin/src/lib/walletLedger.ts` — wallet ledger.type + payment_method 中文 label SSOT
- `apps/admin/src/components/WalletPayOrderModal.tsx` — 訂單詳細頁「提早結帳」用儲值金 modal
- `apps/member/src/app/wallet/page.tsx` — LIFF 顧客端 ledger 詳細頁（有分頁）

### Refactor / 整合
- 5 處 admin status 硬編碼改 import 中央定義
- `PickupDialog`：取貨時整合儲值金結帳（自動撈餘額 + 預填 + 「需收現金」+ 全用儲值金按鈕 + 兩 RPC 序列）
- `OrderDetail`：應收區塊加 wallet_paid / balance_due / 已付清 chip + 「💳 用儲值金結帳」+ 取消按鈕含「(將退 $X)」+ confirm prompt 警示
- `MemberDetail`：儲值流水 table 「類型 / 支付」欄改顯示中文
- 列印小白單 / 取貨單：加「− 已用儲值金 / 應付剩餘」+ 全部取完不再印空白清單
- LIFF Overview：加「💰 儲值金餘額」卡片 + 跳轉 `/wallet`

## 應收金額取整

**統一四捨五入到 1 元**（台灣零售 mainstream），4+ 處同步：
- `v_customer_order_summary.payable_amount` 用 `ROUND(..., 0)`
- `rpc_wallet_pay_order` 內 `v_payable` 同公式
- `OrderDetail.applyOrderDiscount` / `PickupDialog.payableAmount` 用 `Math.round`
- 列印小白單 / 取貨單也用整數
- 折扣金額顯示倒推自 payable，數學一定對齊

## Test plan

### 已驗證 ✅
- `npx tsc --noEmit` 過（admin + member）
- `npm run build` 過 (admin Next.js 16 Turbopack)
- 10 支 migrations 已 applied to dev DB（session pooler 5432）
- Edge function `liff-api` 已 deploy 到 dev
- `fn_check_wallet_consistency()` 回 0 rows
- 7 個會員 wallet_balances vs ledger 累加全一致
- 3 張用儲值金訂單 wallet_paid_amount = ledger 淨 spend 全對
- curl 直測 `rpc_wallet_pay_order` / `rpc_wallet_adjust` / cancel auto-refund OK
- PickupDialog 端到端走過：餘額 1000 → 扣 200 → 餘額 800 ✅

### 仍需手動跑
- [ ] 部分取貨 + 後續再取貨流程（partially_completed → completed）
- [ ] cancel 帶 wallet_paid 的訂單 → 看 alert 顯示退回 $X
- [ ] partial_refund RPC（後台尚未做 UI）
- [ ] LIFF /wallet 頁分頁、空狀態、跨會員 RLS 把關
- [ ] role 負面測試：assistant / store_staff 試 adjust → RAISE
- [ ] member.status='merged' 嘗試扣款 → RAISE

### 已同步（PR merge 後不用再動）
- ✅ Wiki 會員模組 + 訂單取貨模組 + Home 都已加 Phase A+B+ status + 取整
- ✅ Issue [#191](https://github.com/lt-foods/new_erp/issues/191) Phase C / [#192](https://github.com/lt-foods/new_erp/issues/192) Phase D 已開
- ✅ Issue [#23](https://github.com/lt-foods/new_erp/issues/23) (QPS 併發) 留 comment

## Phase 規劃進度

| Phase | 狀態 |
|---|---|
| Phase A — Admin 寫入介面 | ✅ PR #188 merged |
| Phase B — 訂單抵扣（含取貨整合 + 列印） | ✅ 本 PR |
| Phase C — 取消訂單 auto-refund + partial refund | ✅ 本 PR |
| Phase D — LIFF 顧客端餘額顯示 | ✅ 本 PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)