### PR TITLE
feat(wallet): Phase C 取消 auto-refund + Phase D LIFF 餘額顯示

### DIFF
--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -337,23 +337,30 @@ export function OrderDetail({
 
   async function cancelOrder() {
     if (!head) return;
+    const walletPaid = Number(head.wallet_paid_amount ?? 0);
+    const walletNote = walletPaid > 0
+      ? `\n\n⚠️ 此訂單已用儲值金 $${walletPaid}，取消後會自動退回會員餘額。`
+      : "";
     const reason = prompt(
-      head.status === "shipping"
+      (head.status === "shipping"
         ? `撤回派貨：${head.order_no}\n會反向回收已出庫存，請輸入原因：`
-        : `取消訂單：${head.order_no}\n請輸入取消原因：`
+        : `取消訂單：${head.order_no}\n請輸入取消原因：`) + walletNote
     );
     if (reason === null) return;
     const sb = getSupabase();
     const { data: sess } = await sb.auth.getSession();
     const operator = sess.session?.user?.id ?? null;
     if (!operator) { alert("尚未登入"); return; }
-    const { error: rpcErr } = await sb.rpc("rpc_cancel_aid_order", {
+    const { data, error: rpcErr } = await sb.rpc("rpc_cancel_aid_order", {
       p_order_id: head.id,
       p_reason: reason,
       p_operator: operator,
     });
     if (rpcErr) { alert(`取消失敗：${translateRpcError(rpcErr)}`); return; }
-    alert("已取消");
+    const refunded = Number((data as { wallet_refunded?: number } | null)?.wallet_refunded ?? 0);
+    alert(refunded > 0
+      ? `已取消，已退回 $${refunded} 儲值金到會員餘額`
+      : "已取消");
     setReloadTick((n) => n + 1);
   }
   const pickableItems = items.filter((it) => ["pending", "reserved", "ready"].includes(it.status));
@@ -433,6 +440,9 @@ export function OrderDetail({
               title={head.status === "shipping" ? "撤回派貨並反向回收已出庫存" : "取消訂單"}
             >
               ✕ 取消訂單
+              {Number(head.wallet_paid_amount ?? 0) > 0 && (
+                <span className="ml-1 text-[10px] font-normal text-zinc-500">(將退 ${Number(head.wallet_paid_amount)})</span>
+              )}
             </button>
           )}
           {isTransferredOut && (

--- a/apps/member/src/app/overview/page.tsx
+++ b/apps/member/src/app/overview/page.tsx
@@ -22,9 +22,15 @@ type Overview = {
   active_orders_count: number;
 };
 
+type WalletInfo = {
+  balance: number;
+  last_movement_at: string | null;
+};
+
 export default function OverviewPage() {
   const router = useRouter();
   const [data, setData] = useState<Overview | null>(null);
+  const [wallet, setWallet] = useState<WalletInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
   const pushState = usePushNotification(getSession()?.token ?? null);
@@ -38,8 +44,12 @@ export default function OverviewPage() {
     }
     (async () => {
       try {
-        const d = await callLiffApi<Overview>(s.token, { action: "get_overview" });
+        const [d, w] = await Promise.all([
+          callLiffApi<Overview>(s.token, { action: "get_overview" }),
+          callLiffApi<WalletInfo>(s.token, { action: "get_wallet" }).catch(() => null),
+        ]);
         setData(d);
+        if (w) setWallet(w);
       } catch (e) {
         setErr(e instanceof Error ? e.message : String(e));
       } finally {
@@ -105,6 +115,30 @@ export default function OverviewPage() {
                 </button>
               )}
             </section>
+
+            {/* 儲值金卡 — 永遠顯示（即便為 0，讓客人知道有此功能 + 可在門市加值） */}
+            {wallet && (
+              <section className="rounded-2xl bg-[var(--card-bg)] px-5 py-4 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
+                <div className="flex items-baseline justify-between">
+                  <div className="text-[14px] text-[var(--secondary-label)]">💰 儲值金餘額</div>
+                </div>
+                <div className="mt-1 flex items-baseline gap-1">
+                  <span className="text-[40px] font-semibold tabular-nums leading-none text-[var(--foreground)]">
+                    ${Number(wallet.balance).toLocaleString()}
+                  </span>
+                </div>
+                <button
+                  onClick={() => router.push("/wallet")}
+                  className="mt-3 flex w-full items-center justify-between rounded-xl bg-[#7676801a] px-3 py-3 text-[16px] text-[var(--foreground)] active:bg-[#76768033]"
+                >
+                  <span>查看儲值流水</span>
+                  <span className="text-[var(--ios-gray)]">›</span>
+                </button>
+                <div className="mt-2 text-[12px] text-[var(--tertiary-label)]">
+                  儲值金不可退現；可在門市加值或結帳時抵扣
+                </div>
+              </section>
+            )}
 
             {/* 賣場介紹 */}
             {data.store.description && (

--- a/apps/member/src/app/wallet/page.tsx
+++ b/apps/member/src/app/wallet/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { consumeFragmentToSession, getSession } from "@/lib/session";
+import { callLiffApi } from "@/lib/supabase";
+import PageShell from "@/components/PageShell";
+
+type WalletInfo = {
+  balance: number;
+  last_movement_at: string | null;
+};
+
+type LedgerRow = {
+  id: number;
+  change: number;
+  balance_after: number;
+  type: "topup" | "spend" | "refund" | "adjust" | "reversal";
+  source_type: string | null;
+  source_id: number | null;
+  payment_method: string | null;
+  reverses: number | null;
+  reason: string | null;
+  created_at: string;
+};
+
+const TYPE_LABEL: Record<string, string> = {
+  topup:    "加值",
+  spend:    "扣款",
+  refund:   "退款",
+  adjust:   "調整",
+  reversal: "反向",
+};
+
+const PAYMENT_LABEL: Record<string, string> = {
+  cash:        "現金",
+  credit_card: "信用卡",
+  transfer:    "轉帳",
+};
+
+export default function WalletPage() {
+  const router = useRouter();
+  const [wallet, setWallet] = useState<WalletInfo | null>(null);
+  const [ledger, setLedger] = useState<LedgerRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    consumeFragmentToSession();
+    const s = getSession();
+    if (!s || !s.memberId) {
+      router.replace("/");
+      return;
+    }
+    (async () => {
+      try {
+        const [w, l] = await Promise.all([
+          callLiffApi<WalletInfo>(s.token, { action: "get_wallet" }),
+          callLiffApi<{ ledger: LedgerRow[]; has_more: boolean }>(s.token, {
+            action: "list_wallet_ledger",
+            limit: 30,
+          }),
+        ]);
+        setWallet(w);
+        setLedger(l.ledger);
+        setHasMore(l.has_more);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [router]);
+
+  async function loadMore() {
+    if (loadingMore || ledger.length === 0) return;
+    const s = getSession();
+    if (!s) return;
+    setLoadingMore(true);
+    try {
+      const beforeId = ledger[ledger.length - 1].id;
+      const r = await callLiffApi<{ ledger: LedgerRow[]; has_more: boolean }>(s.token, {
+        action: "list_wallet_ledger",
+        limit: 30,
+        before_id: beforeId,
+      });
+      setLedger((prev) => [...prev, ...r.ledger]);
+      setHasMore(r.has_more);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoadingMore(false);
+    }
+  }
+
+  return (
+    <PageShell title="儲值金">
+      <div className="space-y-4 px-4 pt-3 pb-6">
+        {loading && (
+          <p className="px-1 text-[15px] text-[var(--tertiary-label)]">載入中…</p>
+        )}
+
+        {err && (
+          <div className="rounded-2xl bg-[#ff3b30]/10 p-3 text-[14px] text-[#c4271d]">{err}</div>
+        )}
+
+        {wallet && (
+          <section className="rounded-2xl bg-[var(--card-bg)] px-5 py-4 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
+            <div className="text-[14px] text-[var(--secondary-label)]">目前餘額</div>
+            <div className="mt-1 flex items-baseline gap-1">
+              <span className="text-[40px] font-semibold tabular-nums leading-none text-[var(--foreground)]">
+                ${Number(wallet.balance).toLocaleString()}
+              </span>
+            </div>
+            <div className="mt-2 text-[12px] text-[var(--tertiary-label)]">
+              儲值金不可退現；門市加值、結帳抵扣
+            </div>
+          </section>
+        )}
+
+        <section>
+          <div className="px-4 pb-1 pt-2 text-[12px] uppercase tracking-wide text-[var(--tertiary-label)]">
+            交易紀錄
+          </div>
+          <div className="overflow-hidden rounded-2xl bg-[var(--card-bg)] shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
+            {ledger.length === 0 && !loading ? (
+              <div className="px-4 py-12 text-center text-[14px] text-[var(--tertiary-label)]">
+                尚無紀錄
+              </div>
+            ) : (
+              <ul className="divide-y divide-[var(--separator)]">
+                {ledger.map((row) => {
+                  const sign = row.change >= 0 ? "+" : "";
+                  const amountColor = row.change >= 0 ? "text-[#34c759]" : "text-[#ff3b30]";
+                  return (
+                    <li key={row.id} className="px-4 py-3">
+                      <div className="flex items-baseline justify-between gap-3">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-baseline gap-2 text-[15px] font-medium">
+                            <span>{TYPE_LABEL[row.type] ?? row.type}</span>
+                            {row.payment_method && (
+                              <span className="text-[12px] font-normal text-[var(--secondary-label)]">
+                                ({PAYMENT_LABEL[row.payment_method] ?? row.payment_method})
+                              </span>
+                            )}
+                            {row.source_type === "customer_order" && row.source_id && (
+                              <span className="text-[11px] font-normal text-[var(--tertiary-label)]">
+                                訂單 #{row.source_id}
+                              </span>
+                            )}
+                          </div>
+                          <div className="mt-0.5 text-[12px] text-[var(--tertiary-label)]">
+                            {new Date(row.created_at).toLocaleString("zh-TW", { hour12: false })}
+                          </div>
+                          {row.reason && (
+                            <div className="mt-0.5 text-[13px] text-[var(--secondary-label)]">
+                              {row.reason}
+                            </div>
+                          )}
+                        </div>
+                        <div className="text-right">
+                          <div className={`font-mono text-[17px] font-semibold ${amountColor}`}>
+                            {sign}{Number(row.change).toLocaleString()}
+                          </div>
+                          <div className="text-[11px] text-[var(--tertiary-label)]">
+                            餘 ${Number(row.balance_after).toLocaleString()}
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            {hasMore && (
+              <button
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="block w-full border-t border-[var(--separator)] px-4 py-3 text-center text-[15px] text-[var(--brand-strong)] active:bg-[#76768033] disabled:opacity-50"
+              >
+                {loadingMore ? "載入中…" : "載入更多"}
+              </button>
+            )}
+          </div>
+        </section>
+      </div>
+    </PageShell>
+  );
+}

--- a/docs/TEST-wallet-phase-c.md
+++ b/docs/TEST-wallet-phase-c.md
@@ -1,0 +1,145 @@
+# wallet-phase-c 測試項目 — 取消訂單自動退儲值金
+
+**對應 migration:**
+- `supabase/migrations/20260606000040_rpc_cancel_aid_order_wallet_refund.sql`
+- `supabase/migrations/20260606000041_rpc_wallet_partial_refund.sql`
+
+**對應 UI 變更:**
+- `apps/admin/src/components/OrderDetail.tsx`（cancel 按鈕旁顯示「將退回 $X 儲值金」提示）
+
+**對應 plan:** `C:\Users\Alex\.claude\plans\session-db-federated-thunder.md` (Phase C)
+
+**前置：** Phase A (PR #188) + Phase B (PR #190) 已 landed。
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 rpc_cancel_aid_order 已加 wallet refund 邏輯
+- [ ] 函式 source 含 `IF v_order.wallet_paid_amount > 0` 區塊
+  ```sql
+  SELECT pg_get_functiondef('rpc_cancel_aid_order(bigint,text,uuid)'::regprocedure);
+  ```
+- [ ] 仍然 GRANT EXECUTE TO authenticated
+
+### 1.2 rpc_wallet_partial_refund 存在
+- [ ] 函式存在、SECURITY DEFINER、回傳 BIGINT
+- [ ] GRANT EXECUTE TO authenticated
+- [ ] reason 必填 ≥ 4 chars
+
+---
+
+## 2. RPC 行為（curl / SQL 直測）
+
+### 2.1 cancel — 0 wallet 訂單
+**前置：** 訂單 status='pending' / 'confirmed'，wallet_paid_amount=0
+**操作：** `rpc_cancel_aid_order(order_id, 'test', op)`
+**預期：**
+- 訂單 status='cancelled', cancelled_at=NOW()
+- **無**新 wallet ledger 紀錄（不該 refund $0）
+- 回傳 `{order_id, cancelled_transfer_ids, source_order_reverted, wallet_refunded: 0}`
+
+### 2.2 cancel — 部分 wallet pay 訂單
+**前置：** 訂單 payable=500, wallet_paid_amount=300, balance_due=200
+**操作：** cancel
+**預期：**
+- 訂單 status='cancelled'
+- ledger 多一筆 `type='refund', change=+300, source_type='customer_order', source_id=<order>, reason='order_cancelled: test'`
+- 會員 wallet_balances.balance += 300（補回去）
+- `wallet_paid_amount` **保持 300**（歷史紀錄；ledger refund 才是 source of truth）
+- 回傳含 `wallet_refunded: 300`
+
+### 2.3 cancel — 全付清訂單（payment_status='paid'）
+**前置：** wallet_paid=500=payable, payment_status='paid'
+**操作：** cancel
+**預期：**
+- ledger 多 refund $500
+- 訂單 cancelled
+- payment_status 不變（cancelled 後 status 才是真實狀態）
+
+### 2.4 cancel — shipping 階段（含 transfer chain）
+**前置：** 訂單 status='shipping', wallet_paid=200, transfer chain 含 shipped legs
+**操作：** cancel
+**預期：**
+- transfer chain 反向（既有邏輯）
+- wallet refund $200 同 transaction 完成
+- 兩者都成功才訂單 cancelled
+
+### 2.5 cancel — already received transfer 拒絕
+**前置：** 訂單 shipping，transfer chain 有一段 status='received'
+**預期：** RAISE `transfer X already received...`，**訂單 + wallet 都不動**（transaction roll back）
+
+### 2.6 cancel — completed/cancelled/expired 訂單拒絕
+- [ ] status='completed' → RAISE
+- [ ] status='cancelled' → RAISE  
+- [ ] status='expired' → RAISE
+- [ ] status='transferred_out' → RAISE（既有邏輯）
+
+### 2.7 partial_refund — happy path
+**前置：** 訂單 wallet_paid=300, status='ready'（未取貨、可退）
+**操作：** `rpc_wallet_partial_refund(order_id, 100, '補退一半', op)`
+**預期：**
+- ledger refund +100
+- 訂單 wallet_paid_amount: 300 → 200
+- 餘額 += 100
+- 回傳 `{ledger_id, wallet_paid_amount: 200, ...}`
+
+### 2.8 partial_refund — 超退拒絕
+**前置：** wallet_paid=200
+**操作：** `rpc_wallet_partial_refund(order_id, 300, ...)`
+**預期：** RAISE `partial refund exceeds wallet_paid_amount`
+
+### 2.9 partial_refund — reason 必填
+- [ ] NULL → RAISE
+- [ ] '' / 短於 4 chars → RAISE
+
+### 2.10 partial_refund — amount <= 0 拒絕
+- [ ] 0 → RAISE
+- [ ] -10 → RAISE
+
+### 2.11 partial_refund — terminal 訂單拒絕
+- [ ] status='cancelled' → RAISE（已退完了）
+- [ ] status='completed' → 視 PRD 決定（先放行，可重複部分退）
+
+### 2.12 一致性
+**前置：** 跑完上面所有測試
+- [ ] `SELECT * FROM fn_check_wallet_consistency()` 回 0 rows
+- [ ] 對任一退過的訂單：`SUM(wallet_ledger.change WHERE source_id=X AND type IN ('spend','refund')) >= 0`
+
+---
+
+## 3. UI 行為
+
+### 3.1 OrderDetail — cancel 按鈕提示
+**前置：** 訂單 wallet_paid_amount=300
+- [ ] cancel 按鈕旁（或 confirm dialog）顯示「將自動退回 $300 儲值金」
+- [ ] 按下 cancel → confirm dialog 包含這條訊息
+- [ ] 確認後 alert 顯示「訂單已取消，已退回 $300 儲值金」
+- [ ] reload 後訂單 status='cancelled'，會員餘額已更新
+
+### 3.2 OrderDetail — 0 wallet 訂單
+- [ ] cancel 按鈕無「將退回」提示（因為沒得退）
+- [ ] 行為跟舊版一樣
+
+### 3.3 取消後 audit trail
+- [ ] 會員詳細頁 wallet ledger tab 多一筆 `refund` row
+- [ ] reason 顯示「order_cancelled: ...」
+- [ ] source 連結到取消的訂單
+
+---
+
+## 4. Regression
+
+- [ ] Phase A 5 個 button + reverse 全部正常
+- [ ] Phase B `rpc_wallet_pay_order` 行為不變
+- [ ] 既有 `rpc_cancel_aid_order` 對 0-wallet 訂單行為完全沒變（transfer chain 反向、source order 回 confirmed）
+- [ ] LIFF 顧客端訂單列表不破
+- [ ] `fn_check_wallet_consistency()` 0 rows
+
+---
+
+## 5. 驗收門檻
+
+§1-§4 全勾、無 console error、Supabase push 成功、tsc + build 過。
+
+PR merge 後同步 GitHub Issues #191 (close) + Wiki（會員模組頁加 Phase C ✅）。

--- a/docs/TEST-wallet-phase-d.md
+++ b/docs/TEST-wallet-phase-d.md
@@ -1,0 +1,118 @@
+# wallet-phase-d 測試項目 — LIFF 顧客端餘額顯示
+
+**對應 edge function:**
+- `supabase/functions/liff-api/index.ts` — 加 `get_wallet` + `list_wallet_ledger` 兩個 actions
+
+**對應 LIFF UI:**
+- `apps/member/src/app/overview/page.tsx`（加儲值金卡片）
+- `apps/member/src/app/wallet/page.tsx`（新頁，完整 ledger）
+
+**對應 plan:** `C:\Users\Alex\.claude\plans\session-db-federated-thunder.md` (Phase D)
+
+---
+
+## 1. Edge function 行為（curl 直測）
+
+### 1.1 get_wallet — 有餘額會員
+**前置：** member 1659 (M-SEED-01628 何佩珊) 餘額 > 0
+**操作：** POST /functions/v1/liff-api `{action:"get_wallet"}` 帶有效 LIFF token
+**預期：**
+```json
+{ "balance": 800, "version": 2, "last_movement_at": "2026-05-07T12:41:38.440745+00:00", "updated_at": "..." }
+```
+
+### 1.2 get_wallet — 從未動過的會員
+**前置：** 一個從未 topup 過的會員（無 wallet_balances row）
+**預期：** `{balance:0, version:0, last_movement_at:null, updated_at:null}` — 不報錯
+
+### 1.3 list_wallet_ledger — 預設 30 筆
+**操作：** POST `{action:"list_wallet_ledger"}`
+**預期：**
+- 回傳 `{ledger: [...], has_more: bool}`
+- 按 `id desc` 排序（最新在最上）
+- 每筆含 id / change / balance_after / type / source_type / source_id / payment_method / reverses / reason / created_at
+
+### 1.4 list_wallet_ledger — 分頁
+- [ ] 第一頁 `limit=10` → 回 10 筆 + has_more=true
+- [ ] 第二頁 `before_id=<上頁最後一筆.id>` → 回下 10 筆
+- [ ] 最後一頁 `has_more=false`
+
+### 1.5 limit 邊界
+- [ ] `limit=0` → 用最小 1
+- [ ] `limit=999` → 上限 100
+- [ ] `limit=null/undefined` → 預設 30
+
+### 1.6 跨 tenant / 跨會員
+- [ ] tenant1 token 試問 tenant2 member → RLS 把關，回 0 rows（不該有 leak）
+- [ ] member A token 不應拿到 member B 的 ledger（filter by token claim memberId）
+
+### 1.7 無 memberId token
+- [ ] 401 `{error: "no member_id"}`
+
+---
+
+## 2. LIFF UI 行為
+
+### 2.1 Overview 頁 — 儲值金卡片
+**路徑：** /overview
+- [ ] 載入後看到「💰 儲值金餘額」卡片
+- [ ] 餘額金額大字顯示 + 千分位逗號
+- [ ] 「查看儲值流水 ›」按鈕 → 點擊跳轉 /wallet
+- [ ] 提示文字：「儲值金不可退現；可在門市加值或結帳時抵扣」
+- [ ] 既有「未結單金額」「逛商品」「賣場介紹」卡都還在
+
+### 2.2 Wallet 頁 — /wallet
+**路徑：** /wallet
+- [ ] 進頁載入順暢、無 console error
+- [ ] 上方「目前餘額」卡片（同 overview 樣式）
+- [ ] 下方「交易紀錄」list
+- [ ] 每筆顯示：類型（中文：加值/扣款/退款/調整/反向）+ 付款方式（現金/信用卡/轉帳，topup 才有）+ 訂單關聯（source=customer_order 顯示「訂單 #X」）+ 時間 + reason + 變動金額（綠色 +N / 紅色 -N）+ 餘額
+- [ ] 加值類型 = 綠色 +N
+- [ ] 扣款類型 = 紅色 -N
+- [ ] 退款類型 = 綠色 +N
+- [ ] 反向類型 = 對應原方向相反
+
+### 2.3 Wallet 頁 — 載入更多
+- [ ] 30+ 筆紀錄會出現「載入更多」按鈕
+- [ ] 點擊載入下 30 筆、追加到列表底部
+- [ ] 最後一頁 has_more=false → 按鈕消失
+
+### 2.4 Wallet 頁 — 空狀態
+- [ ] 餘額 0 + 0 ledger → 顯示「尚無紀錄」訊息
+
+### 2.5 未登入 / 過期 token
+- [ ] /wallet 直接訪問且無 session → router.replace("/")
+
+---
+
+## 3. 整合測試（端到端流程）
+
+### 3.1 Admin 加值 → LIFF 立即看到
+1. Admin: 對 member X 加值 $500
+2. LIFF: member X 開 /overview → 餘額卡顯示 $500
+3. /wallet 看到 topup +500 row、payment_method 顯示中文「現金」
+4. ✅ 整鏈通
+
+### 3.2 取貨用儲值金 → LIFF ledger 有 spend
+1. Admin: member 取貨用 $300 儲值金
+2. LIFF /wallet → 多一筆 spend −300、source 顯示「訂單 #X」
+3. 餘額減 300
+
+### 3.3 訂單取消 → LIFF 看到 refund
+1. Admin: 取消已 wallet pay 的訂單
+2. LIFF /wallet → 多一筆 refund +X
+3. 餘額補回去
+
+---
+
+## 4. Regression
+
+- [ ] Overview 既有功能完全不破：未結單金額、進行中訂單按鈕、賣場介紹、PushNotificationManager
+- [ ] /orders / /settlements / /shop 不受影響
+- [ ] LIFF auth 流程不變
+
+---
+
+## 5. 驗收門檻
+
+§1-§4 全勾、無 console error、edge fn deploy 成功、`tsc --noEmit` 過。

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -213,6 +213,39 @@ async function updateMe(sb: any, tenantId: string, memberId: number, p: any) {
   return json({ ok: true });
 }
 
+async function getWallet(sb: any, tenantId: string, memberId: number) {
+  const { data, error } = await sb
+    .from("wallet_balances")
+    .select("balance, version, last_movement_at, updated_at")
+    .eq("tenant_id", tenantId)
+    .eq("member_id", memberId)
+    .maybeSingle();
+  if (error) return json({ error: error.message }, 500);
+  // 沒 row 表示從未動過 → 餘額 0
+  return json({
+    balance: Number(data?.balance ?? 0),
+    version: Number(data?.version ?? 0),
+    last_movement_at: data?.last_movement_at ?? null,
+    updated_at: data?.updated_at ?? null,
+  });
+}
+
+async function listWalletLedger(sb: any, tenantId: string, memberId: number, body: any) {
+  const limit = Math.min(Math.max(Number(body.limit ?? 30), 1), 100);
+  const beforeId = body.before_id ? Number(body.before_id) : null;
+  let q = sb
+    .from("wallet_ledger")
+    .select("id, change, balance_after, type, source_type, source_id, payment_method, reverses, reason, created_at")
+    .eq("tenant_id", tenantId)
+    .eq("member_id", memberId)
+    .order("id", { ascending: false })
+    .limit(limit);
+  if (beforeId) q = q.lt("id", beforeId);
+  const { data, error } = await q;
+  if (error) return json({ error: error.message }, 500);
+  return json({ ledger: data ?? [], has_more: (data?.length ?? 0) === limit });
+}
+
 async function getOverview(sb: any, tenantId: string, storeId: number, memberId: number) {
   const { data: storeRow, error: sErr } = await sb.from("stores").select("id, code, name, banner_url, description, payment_methods_text, shipping_methods_text").eq("tenant_id", tenantId).eq("id", storeId).single();
   if (sErr || !storeRow) return json({ error: "store not found" }, 404);
@@ -656,6 +689,8 @@ Deno.serve(async (req) => {
       case "get_me": if (!memberId) return json({ error: "no member_id" }, 401); return await getMe(sb, tenantId, memberId);
       case "update_me": if (!memberId) return json({ error: "no member_id" }, 401); return await updateMe(sb, tenantId, memberId, body);
       case "get_overview": if (!memberId) return json({ error: "no member_id" }, 401); return await getOverview(sb, tenantId, storeId, memberId);
+      case "get_wallet": if (!memberId) return json({ error: "no member_id" }, 401); return await getWallet(sb, tenantId, memberId);
+      case "list_wallet_ledger": if (!memberId) return json({ error: "no member_id" }, 401); return await listWalletLedger(sb, tenantId, memberId, body);
       case "list_my_orders": if (!memberId) return json({ error: "no member_id" }, 401); return await listMyOrders(sb, tenantId, storeId, memberId, String(body.tab ?? ""));
       case "list_my_settlements": if (!memberId) return json({ error: "no member_id" }, 401); return await listMySettlements(sb, tenantId, storeId, memberId, String(body.tab ?? ""));
       case "upsert_push_subscription": if (!memberId) return json({ error: "no member_id" }, 401); return await upsertPushSubscription(sb, tenantId, memberId, body);

--- a/supabase/migrations/20260606000040_rpc_cancel_aid_order_wallet_refund.sql
+++ b/supabase/migrations/20260606000040_rpc_cancel_aid_order_wallet_refund.sql
@@ -1,0 +1,156 @@
+-- ============================================================
+-- rpc_cancel_aid_order: 取消訂單時自動退回已扣的儲值金
+--
+-- 之前取消訂單只 mark cancelled + 反向 transfer chain，
+-- 但 wallet_paid_amount 沒退 → 客人錢被扣訂單卻取消、帳對不起來。
+--
+-- 加入：取消前若 wallet_paid_amount > 0 → 自動 rpc_wallet_refund 回沖。
+-- 全在同一個 transaction，refund 失敗整個取消 abort。
+--
+-- wallet_paid_amount 欄位**保留歷史值**（不清零）—
+-- ledger refund row 才是 source of truth，欄位是快取/索引用途。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_cancel_aid_order(
+  p_order_id BIGINT,
+  p_reason   TEXT,
+  p_operator UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_terminal_id      BIGINT;
+  v_xfer             transfers%ROWTYPE;
+  v_ti               RECORD;
+  v_cancelled_ids    BIGINT[] := ARRAY[]::BIGINT[];
+  v_reason_note      TEXT;
+  v_refund_ledger_id BIGINT;
+  v_refunded_amount  NUMERIC := 0;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('aid_order:' || p_order_id));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  IF v_order.status NOT IN ('pending', 'confirmed', 'shipping') THEN
+    RAISE EXCEPTION 'order % is %, only pending/confirmed/shipping can be cancelled', p_order_id, v_order.status;
+  END IF;
+
+  v_reason_note := '[cancelled by source: ' || COALESCE(p_reason, '') || ']';
+
+  -- 場景 B：已派貨，要回收 transfer chain
+  IF v_order.status = 'shipping' THEN
+    SELECT id INTO v_terminal_id
+      FROM transfers
+     WHERE customer_order_id = p_order_id
+       AND tenant_id = v_order.tenant_id
+     LIMIT 1;
+
+    IF v_terminal_id IS NULL THEN
+      RAISE EXCEPTION 'order % is shipping but has no terminal transfer', p_order_id;
+    END IF;
+
+    FOR v_xfer IN
+      WITH RECURSIVE chain_back AS (
+        SELECT * FROM transfers WHERE id = v_terminal_id
+        UNION ALL
+        SELECT t.* FROM transfers t
+          JOIN chain_back c ON c.id = ANY(
+            SELECT id FROM transfers WHERE next_transfer_id = c.id
+          )
+      ),
+      head AS (
+        SELECT id FROM chain_back
+         WHERE id NOT IN (SELECT next_transfer_id FROM transfers WHERE next_transfer_id IS NOT NULL)
+         LIMIT 1
+      ),
+      chain_forward AS (
+        SELECT * FROM transfers WHERE id = (SELECT id FROM head)
+        UNION ALL
+        SELECT t.* FROM transfers t
+          JOIN chain_forward c ON t.id = c.next_transfer_id
+      )
+      SELECT * FROM chain_forward ORDER BY id
+    LOOP
+      IF v_xfer.status = 'received' THEN
+        RAISE EXCEPTION 'transfer % already received, cannot cancel chain', v_xfer.id;
+      END IF;
+
+      IF v_xfer.status = 'shipped' THEN
+        FOR v_ti IN
+          SELECT id, sku_id, qty_shipped FROM transfer_items
+           WHERE transfer_id = v_xfer.id AND qty_shipped > 0
+        LOOP
+          PERFORM rpc_inbound(
+            p_tenant_id       => v_xfer.tenant_id,
+            p_location_id     => v_xfer.source_location,
+            p_sku_id          => v_ti.sku_id,
+            p_quantity        => v_ti.qty_shipped,
+            p_unit_cost       => 0,
+            p_movement_type   => 'transfer_cancel',
+            p_source_doc_type => 'transfer',
+            p_source_doc_id   => v_xfer.id,
+            p_operator        => p_operator
+          );
+        END LOOP;
+      END IF;
+
+      UPDATE transfers
+         SET status = 'cancelled',
+             notes = CASE
+                       WHEN notes IS NULL OR notes = '' THEN v_reason_note
+                       ELSE notes || E'\n' || v_reason_note
+                     END,
+             updated_by = p_operator
+       WHERE id = v_xfer.id;
+      v_cancelled_ids := v_cancelled_ids || v_xfer.id;
+    END LOOP;
+  END IF;
+
+  -- ✨ 新增：若有用儲值金結帳，自動 refund 回會員餘額
+  IF v_order.wallet_paid_amount > 0 AND v_order.member_id IS NOT NULL THEN
+    v_refund_ledger_id := rpc_wallet_refund(
+      v_order.tenant_id,
+      v_order.member_id,
+      v_order.wallet_paid_amount,
+      'customer_order',
+      p_order_id,
+      'order_cancelled: ' || COALESCE(p_reason, '(no reason)'),
+      p_operator
+    );
+    v_refunded_amount := v_order.wallet_paid_amount;
+    -- wallet_paid_amount 保留歷史值，不清零
+  END IF;
+
+  -- 標記訂單 cancelled
+  UPDATE customer_orders
+     SET status       = 'cancelled',
+         cancelled_at = NOW(),
+         updated_by   = p_operator,
+         updated_at   = NOW()
+   WHERE id = p_order_id;
+
+  -- source order 回到 confirmed
+  IF v_order.transferred_from_order_id IS NOT NULL THEN
+    UPDATE customer_orders
+       SET status                   = 'confirmed',
+           transferred_to_order_id  = NULL,
+           updated_by               = p_operator,
+           updated_at               = NOW()
+     WHERE id = v_order.transferred_from_order_id
+       AND status = 'transferred_out';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'order_id', p_order_id,
+    'cancelled_transfer_ids', to_jsonb(v_cancelled_ids),
+    'source_order_reverted', v_order.transferred_from_order_id IS NOT NULL,
+    'wallet_refunded',       v_refunded_amount,
+    'wallet_refund_ledger_id', v_refund_ledger_id
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION rpc_cancel_aid_order IS
+  'Aid order 取消 / 撤回派貨：早期 status only；shipping 反向 transfer chain；若有 wallet_paid 自動 refund 回會員餘額（PR #190 + Phase C）';

--- a/supabase/migrations/20260606000041_rpc_wallet_partial_refund.sql
+++ b/supabase/migrations/20260606000041_rpc_wallet_partial_refund.sql
@@ -1,0 +1,104 @@
+-- ============================================================
+-- rpc_wallet_partial_refund: 訂單部分退儲值金（手動）
+--
+-- 場景：訂單未取消、但客人想退一部分（item-level partial cancel
+-- 等更精細場景的 v1 替代）。
+--
+-- 流程（單一 transaction）：
+--   1. advisory lock + SELECT FOR UPDATE on customer_orders
+--   2. 斷言 p_amount <= wallet_paid_amount
+--   3. 呼叫 rpc_wallet_refund(... type='refund')
+--   4. UPDATE customer_orders SET wallet_paid_amount -= p_amount
+--   5. 回 JSONB
+--
+-- reason 必填 ≥ 4 chars，沿用 rpc_wallet_refund 既有檢查。
+-- 訂單狀態不擋（completed / partially_completed 都允許部分退）；
+-- cancelled 不該再 partial — 因為 cancel 時已全退。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_wallet_partial_refund(
+  p_order_id  BIGINT,
+  p_amount    NUMERIC,
+  p_reason    TEXT,
+  p_operator  UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_member_status    TEXT;
+  v_new_wallet_paid  NUMERIC;
+  v_ledger_id        BIGINT;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'amount must be positive';
+  END IF;
+  IF p_reason IS NULL OR LENGTH(TRIM(p_reason)) < 4 THEN
+    RAISE EXCEPTION 'reason required (>=4 chars)';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('aid_order:' || p_order_id));
+
+  SELECT * INTO v_order FROM customer_orders
+   WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  IF v_order.status = 'cancelled' THEN
+    RAISE EXCEPTION 'order % already cancelled (use cancel flow which auto-refunds)', p_order_id;
+  END IF;
+  IF v_order.member_id IS NULL THEN
+    RAISE EXCEPTION 'order % has no member', p_order_id;
+  END IF;
+  IF v_order.wallet_paid_amount <= 0 THEN
+    RAISE EXCEPTION 'order % has no wallet payment to refund', p_order_id;
+  END IF;
+  IF p_amount > v_order.wallet_paid_amount THEN
+    RAISE EXCEPTION 'partial refund exceeds wallet_paid_amount: requesting=%, paid=%',
+      p_amount, v_order.wallet_paid_amount;
+  END IF;
+
+  -- 會員狀態（merged / deleted 仍允許 refund — 錢應該還）
+  SELECT status INTO v_member_status FROM members
+   WHERE id = v_order.member_id AND tenant_id = v_order.tenant_id;
+  IF v_member_status IS NULL THEN
+    RAISE EXCEPTION 'member % not found', v_order.member_id;
+  END IF;
+
+  v_ledger_id := rpc_wallet_refund(
+    v_order.tenant_id,
+    v_order.member_id,
+    p_amount,
+    'customer_order',
+    p_order_id,
+    p_reason,
+    p_operator
+  );
+
+  v_new_wallet_paid := v_order.wallet_paid_amount - p_amount;
+
+  UPDATE customer_orders
+     SET wallet_paid_amount = v_new_wallet_paid,
+         -- 全退完且原本是 paid → 改回 unpaid（balance_due 又 > 0 了）
+         payment_status = CASE
+           WHEN v_new_wallet_paid = 0 AND payment_status = 'paid' THEN 'unpaid'
+           ELSE payment_status
+         END,
+         paid_at = CASE
+           WHEN v_new_wallet_paid = 0 AND payment_status = 'paid' THEN NULL
+           ELSE paid_at
+         END,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_order_id;
+
+  RETURN jsonb_build_object(
+    'ledger_id',          v_ledger_id,
+    'wallet_paid_amount', v_new_wallet_paid,
+    'refunded_amount',    p_amount
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION rpc_wallet_partial_refund(BIGINT, NUMERIC, TEXT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION rpc_wallet_partial_refund(BIGINT, NUMERIC, TEXT, UUID) IS
+  '訂單部分退儲值金；不取消訂單、只還錢。reason 必填。cancelled 訂單拒絕（用 cancel flow 自動退）';


### PR DESCRIPTION
延續 PR #190 (Phase B + status + 取整) merged，補上 Phase C + D。

Closes #191 (Phase C) · Closes #192 (Phase D)

## Phase C — 取消訂單自動退儲值金

### DB（2 支 migration）

| Migration | 用途 |
|---|---|
| `20260606000040_rpc_cancel_aid_order_wallet_refund.sql` | CREATE OR REPLACE rpc_cancel_aid_order — 在 status='cancelled' 之前 if `wallet_paid_amount > 0` 自動 `rpc_wallet_refund` 回沖。同 transaction、refund 失敗整個取消 abort。`wallet_paid_amount` 保留歷史（ledger 才是 source of truth）。回傳 JSONB 多 `wallet_refunded` + `wallet_refund_ledger_id`。 |
| `20260606000041_rpc_wallet_partial_refund.sql` | 新 RPC `rpc_wallet_partial_refund(order_id, amount, reason, operator)` — 訂單未取消時手動部分退（item-level cancel 的 v1 替代）。reason 必填 ≥4 字。全退完且原 paid → 改 unpaid + 清 paid_at。cancelled 訂單拒絕。 |

### UI

`apps/admin/src/components/OrderDetail.tsx`：
- 取消按鈕含「(將退 $X)」當 wallet_paid > 0
- cancel confirm prompt 加警示「⚠️ 此訂單已用儲值金 $X，取消後會自動退回會員餘額」
- 成功 alert 顯示「已取消，已退回 $X 儲值金到會員餘額」（從 RPC 回傳值取得）

## Phase D — LIFF 顧客端餘額顯示

### Edge function

`supabase/functions/liff-api/index.ts` 加 2 個 actions：
- `get_wallet` — 回 `{balance, version, last_movement_at, updated_at}`；無 row 時 balance=0、不報錯
- `list_wallet_ledger` — 分頁（limit 預設 30、上限 100、keyset via `before_id`）；回 `{ledger:[...], has_more:bool}`

✅ Edge fn 已 deploy 到 dev project。

### LIFF UI

- `apps/member/src/app/overview/page.tsx`：在「未結單金額」卡下加「💰 儲值金餘額」卡 + 「查看儲值流水 ›」跳 /wallet
- `apps/member/src/app/wallet/page.tsx`（新頁）：上方餘額卡 + 下方交易紀錄 list（中文 type/payment_method、訂單關聯、變動金額綠紅、餘額、時間、reason）+ 載入更多按鈕（keyset pagination）+ 空狀態

## Test plan

### 已驗證 ✅
- `npx tsc --noEmit` 過（admin + member）
- 2 支 migration applied to dev DB（連 PR #190 共 10 支全部 applied）
- Edge function `liff-api` 已 deploy
- DB invariants 全綠（fn_check_wallet_consistency 0 rows / 7 會員 wallet vs ledger 全一致）
- curl 直測 edge fn dispatch 通

### 仍需手動跑
- [ ] cancel 帶 wallet_paid 的訂單 → 看 alert 顯示退回 $X
- [ ] partial_refund RPC（後台尚未做 UI；可用 SQL/curl 直測）
- [ ] LIFF /wallet 頁實機看：分頁、空狀態、跨會員 RLS 把關
- [ ] 端到端：admin topup → LIFF 立即看到 / 取貨用儲值金 → LIFF 看到 spend / 取消 → LIFF 看到 refund

對應測試文件：
- `docs/TEST-wallet-phase-c.md`
- `docs/TEST-wallet-phase-d.md`

## Phase 規劃進度

| Phase | 狀態 |
|---|---|
| Phase A — Admin 寫入介面 | ✅ PR #188 merged |
| Phase B — 訂單抵扣 + 取貨整合 + status + 取整 | ✅ PR #190 merged |
| Phase C — 取消自動退儲值金 + partial refund | ✅ 本 PR |
| Phase D — LIFF 顧客端餘額顯示 | ✅ 本 PR |

Phase A+B+C+D 全套完成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)