### PR TITLE
fix(liff): /me 頁加儲值金卡 + silent catch 改 warn

### DIFF
--- a/apps/member/src/app/overview/page.tsx
+++ b/apps/member/src/app/overview/page.tsx
@@ -46,7 +46,11 @@ export default function OverviewPage() {
       try {
         const [d, w] = await Promise.all([
           callLiffApi<Overview>(s.token, { action: "get_overview" }),
-          callLiffApi<WalletInfo>(s.token, { action: "get_wallet" }).catch(() => null),
+          callLiffApi<WalletInfo>(s.token, { action: "get_wallet" }).catch((e) => {
+            // get_wallet 失敗不擋整頁，但要 warn（例：edge fn 版本不對、token 過期、env 缺）
+            console.warn("[liff] get_wallet failed; wallet card hidden:", e);
+            return null;
+          }),
         ]);
         setData(d);
         if (w) setWallet(w);

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -114,7 +114,10 @@ export default function LandingPage() {
     // 抓門市清單給下拉選用(免 token,公開資訊)
     callLiffApi<{ stores: StoreOption[] }>("", { action: "list_stores" })
       .then((r) => setStores(r.stores ?? []))
-      .catch(() => { /* 抓不到就退回手動輸入 */ });
+      .catch((e) => {
+        // 抓不到就退回手動輸入；但要 warn 以免靜默失敗（例：.env.local 缺 NEXT_PUBLIC_SUPABASE_URL → callLiffApi throw）
+        console.warn("[liff] list_stores failed, falling back to text input:", e);
+      });
 
     // 3. 從 LIFF 配對流程切回 PWA 時，自動 claim
     void tryClaimPairToken();


### PR DESCRIPTION
延伸 PR #193 (Phase D) — 修兩個問題：

## 1. 主要 bug：/me 頁沒有儲值金卡 🔴

PR #193 我把儲值金卡放在 `/overview`，但**正常瀏覽器**進 LIFF 的預設落點是 `/me`（會員中心）— 多數使用者實際進來看的是這頁。

\`\`\`ts
// apps/member/src/app/page.tsx line 101
const landing = sa ? "/shop" : "/me";  // PWA 才到 /shop，瀏覽器到 /me
\`\`\`

→ 所以使用者反映「LIFF 沒看到儲值金」是真的看不到，不是 cache 問題。

修：`apps/member/src/app/me/page.tsx`
- 加 WalletInfo type + state
- 並行 fetch `get_wallet`
- 在「未結單金額」卡下加「💰 儲值金餘額」卡（樣式對齊 /overview）
- 點「查看儲值流水 ›」跳 `/wallet`

## 2. silent catch → console.warn

剛剛 debug 時發現 `apps/member/.env.local` 沒設 → `callLiffApi` throw → `.catch(() => {})` 把錯吞掉 → UI 默默退回備援版本。改成 `console.warn` 不影響 prod 行為，但 dev 端能看到訊息。

兩個檔案：
- `apps/member/src/app/page.tsx` (list_stores)
- `apps/member/src/app/overview/page.tsx` (get_wallet)

## Test plan
- [x] `tsc --noEmit` 過
- [ ] LIFF 進 /me 看到「💰 儲值金餘額」卡（merge 後 Vercel deploy + 清 SW cache）

🤖 Generated with [Claude Code](https://claude.com/claude-code)