### PR TITLE
fix(liff): /me 頁加儲值金卡 + 店 chip 對齊取貨店資料來源

### DIFF
--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -36,11 +36,17 @@ type Overview = {
   active_orders_count: number;
 };
 
+type WalletInfo = {
+  balance: number;
+  last_movement_at: string | null;
+};
+
 export default function MePage() {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [me, setMe] = useState<MemberData | null>(null);
   const [overview, setOverview] = useState<Overview | null>(null);
+  const [wallet, setWallet] = useState<WalletInfo | null>(null);
   const [isPWA, setIsPWA] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lineName, setLineName] = useState<string | null>(null);
@@ -111,12 +117,17 @@ export default function MePage() {
 
     (async () => {
       try {
-        const [meData, ovData] = await Promise.all([
+        const [meData, ovData, wData] = await Promise.all([
           callLiffApi<MemberData>(s.token, { action: "get_me" }),
           callLiffApi<Overview>(s.token, { action: "get_overview" }).catch(() => null),
+          callLiffApi<WalletInfo>(s.token, { action: "get_wallet" }).catch((e) => {
+            console.warn("[liff] get_wallet failed; wallet card hidden:", e);
+            return null;
+          }),
         ]);
         setMe(meData);
         if (ovData) setOverview(ovData);
+        if (wData) setWallet(wData);
         setForm({
           name: meData.name ?? "",
           phone: meData.phone ?? "",
@@ -296,6 +307,28 @@ export default function MePage() {
                 <span className="text-[var(--ios-gray)]">›</span>
               </a>
             )}
+          </section>
+        )}
+
+        {/* 儲值金餘額卡 — 永遠顯示（即便為 0，讓客人知道有此功能 + 可在門市加值） */}
+        {wallet && (
+          <section className="rounded-2xl bg-[var(--card-bg)] px-5 py-4 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
+            <div className="text-[14px] text-[var(--secondary-label)]">💰 儲值金餘額</div>
+            <div className="mt-1 flex items-baseline gap-1">
+              <span className="text-[34px] font-semibold tabular-nums leading-none text-[var(--foreground)]">
+                ${Number(wallet.balance).toLocaleString()}
+              </span>
+            </div>
+            <a
+              href="/wallet"
+              className="mt-3 flex w-full items-center justify-between rounded-xl bg-[#7676801a] px-3 py-3 text-[16px] text-[var(--foreground)] active:bg-[#76768033]"
+            >
+              <span>查看儲值流水</span>
+              <span className="text-[var(--ios-gray)]">›</span>
+            </a>
+            <div className="mt-2 text-[12px] text-[var(--tertiary-label)]">
+              儲值金不可退現；可在門市加值或結帳時抵扣
+            </div>
           </section>
         )}
 

--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -228,9 +228,9 @@ export default function MePage() {
                     🔔 已啟用通知
                   </span>
                 )}
-                {overview?.store.name && (
+                {me.home_store_name && (
                   <span className="inline-flex items-center gap-1 rounded-full bg-[#7676801f] px-2.5 py-[3px] text-[12px] font-medium text-[var(--secondary-label)]">
-                    📍 {overview.store.name}
+                    📍 {me.home_store_name}
                   </span>
                 )}
               </div>


### PR DESCRIPTION
延伸 PR #193 (Phase D) + #194 — 修兩個使用者直接反映的 bug。

## 1. /me 頁沒顯示儲值金卡 🔴

PR #193 (Phase D) 我把儲值金卡放在 `/overview`，但**正常瀏覽器**進 LIFF 預設落點是 `/me`：

\`\`\`ts
// apps/member/src/app/page.tsx line 101
const landing = sa ? "/shop" : "/me";  // PWA → /shop，瀏覽器 → /me
\`\`\`

→ 多數使用者實際看到的是 `/me`，根本看不到儲值金。

修：`apps/member/src/app/me/page.tsx`
- 加 WalletInfo type + state + 並行 fetch get_wallet
- 在「未結單金額」卡下加「💰 儲值金餘額」卡
- 點「查看儲值流水 ›」跳 `/wallet`

## 2. 頂部 chip 顯示的「店」跟下面「取貨店」資料來源不同 🔴

| 位置 | 之前來源 |
|---|---|
| 頭像旁 chip 「📍 X 店」 | `overview.store.name`（LIFF session 開的店） |
| 個人資料 list「取貨店：X 店」 | `me.home_store_name`（`members.home_store_id`） |

客人從 A 店 OA 點 LIFF 但 `home_store` 是 B 時，頂部會顯示 A、下面顯示 B，自相矛盾。

改：頂部 chip 也用 `me.home_store_name`，single source of truth = `members.home_store_id`

## Test plan
- [x] `tsc --noEmit` 過
- [ ] LIFF 進 `/me` 看到「💰 儲值金餘額」卡
- [ ] 頂部「📍 X 店」跟下面「取貨店」一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)