### PR TITLE
fix(liff): /me 移除「取貨店」row（已在 chip 顯示）

### DIFF
--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -385,7 +385,7 @@ export default function MePage() {
               <InfoRow label="手機" value={me.phone ?? null} mono />
               <InfoRow label="生日" value={me.birthday ?? null} />
               <InfoRow label="Email" value={me.email ?? null} breakAll />
-              <InfoRow label="取貨店" value={me.home_store_name ?? null} />
+              {/* 取貨店已在頭像旁 chip 顯示，這裡不重複 */}
               {lineUserId && (
                 <InfoRow label="LINE ID" value={lineUserId} mono breakAll small />
               )}


### PR DESCRIPTION
## Summary
- PR #196 squash-merge 時漏掉這個 commit（後 push 但 PR 已 merge）
- /me 頁的 InfoRow「取貨店」與頂部 chip「📍 X 店」資訊重複，移除 list 那行

## Test plan
- [ ] LIFF /me 頁的個人資料 list 不再有「取貨店」row
- [ ] 頂部 chip 仍正確顯示 home_store

🤖 Generated with [Claude Code](https://claude.com/claude-code)