### PR TITLE
feat: 會員合併 + 訂單轉單 + 取貨 + 多項 UX 修正

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
@@ -891,6 +891,17 @@ function CustomerSearch({
   const [members, setMembers] = useState<MemberRow[]>([]);
   const [aliases, setAliases] = useState<AliasRow[]>([]);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  // 點 dropdown 外面才關（取代 onMouseLeave）
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -922,7 +933,7 @@ function CustomerSearch({
   }
 
   return (
-    <div className="relative flex-1">
+    <div className="relative flex-1" ref={wrapperRef}>
       <input
         value={value.member_id ? `${value.display_name} (${value.member_no})` : term}
         onFocus={() => setOpen(true)}
@@ -938,8 +949,7 @@ function CustomerSearch({
       />
       {open && (members.length > 0 || aliases.length > 0) && (
         <div
-          className="absolute left-0 right-0 top-full z-20 mt-1 max-h-72 overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
-          onMouseLeave={() => setOpen(false)}
+          className="absolute left-0 right-0 top-full z-20 mt-1 max-h-96 overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
         >
           {aliases.length > 0 && (
             <div>
@@ -967,7 +977,7 @@ function CustomerSearch({
                       });
                       setOpen(false);
                     }}
-                    className="block w-full px-2 py-1.5 text-left text-xs hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent dark:hover:bg-zinc-700"
+                    className="block w-full px-3 py-2 text-left text-sm hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent dark:hover:bg-zinc-700"
                   >
                     <span className="font-medium">{a.nickname}</span>
                     {a.admin_note && <span className="ml-1 rounded bg-amber-100 px-1 text-[9px] text-amber-800">🔒 {a.admin_note}</span>}
@@ -992,7 +1002,7 @@ function CustomerSearch({
                 return (
                   <div
                     key={`m-${m.id}`}
-                    className="flex items-center justify-between px-2 py-1.5 text-xs hover:bg-zinc-100 dark:hover:bg-zinc-700"
+                    className="flex items-center justify-between px-3 py-2 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-700"
                   >
                     <button
                       type="button"
@@ -1057,6 +1067,17 @@ function ItemEditorRow({
   const [open, setOpen] = useState(false);
   const [opts, setOpts] = useState<SkuOption[]>([]);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
+  const wrapperRef = useRef<HTMLTableCellElement | null>(null);
+
+  // 點 dropdown 外面才關（取代 onMouseLeave，避免滑鼠不小心移開就關）
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -1076,7 +1097,7 @@ function ItemEditorRow({
 
   return (
     <tr className="border-t border-zinc-100 dark:border-zinc-800">
-      <td className="relative py-1">
+      <td className="relative py-1" ref={wrapperRef}>
         <input
           value={item.campaign_item_id ? item.sku_label : term}
           onFocus={() => setOpen(true)}
@@ -1092,8 +1113,7 @@ function ItemEditorRow({
         />
         {open && opts.length > 0 && (
           <div
-            className="absolute left-0 top-full z-10 mt-1 max-h-60 w-80 overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
-            onMouseLeave={() => setOpen(false)}
+            className="absolute left-0 top-full z-10 mt-1 max-h-80 w-[420px] overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
           >
             {opts.map((o) => (
               <button
@@ -1127,10 +1147,10 @@ function ItemEditorRow({
                   setOpen(false);
                   setTerm("");
                 }}
-                className="block w-full px-2 py-1 text-left text-xs hover:bg-zinc-100 dark:hover:bg-zinc-700"
+                className="block w-full px-3 py-2 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-700"
               >
                 <span className="font-medium">{o.variant_name || o.product_name}</span>
-                <span className="ml-2 font-mono text-zinc-400">{o.sku_code}</span>
+                <span className="ml-2 font-mono text-xs text-zinc-400">{o.sku_code}</span>
                 <span className="ml-2 text-zinc-600 dark:text-zinc-300">${Number(o.unit_price)}</span>
                 {o.campaign_item_id == null && (
                   <span className="ml-2 rounded bg-blue-100 px-1 py-0.5 text-[10px] text-blue-700 dark:bg-blue-950 dark:text-blue-300">

--- a/apps/admin/src/app/(protected)/finance/receivables/page.tsx
+++ b/apps/admin/src/app/(protected)/finance/receivables/page.tsx
@@ -455,7 +455,7 @@ function PaymentForm({
             onChange={(e) => setAmount(Number(e.target.value))}
             min={0}
             max={unpaid}
-            step={0.01}
+            step={1}
             className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
           />
         </label>

--- a/apps/admin/src/app/(protected)/members/detail/page.tsx
+++ b/apps/admin/src/app/(protected)/members/detail/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { Suspense } from "react";
-import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import { MemberDetail } from "@/components/MemberDetail";
+// /members/detail 已棄用 — 一律用 /members?id=N 在主列表頁開 modal
+// 保留此 route 是為了相容舊書籤 / 舊 link，自動導回 /members?id=N
+import { Suspense, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
-export default function MemberDetailPage() {
+export default function MemberDetailRedirect() {
   return (
     <Suspense fallback={<div className="p-6 text-sm text-zinc-500">載入中…</div>}>
       <Body />
@@ -15,17 +15,9 @@ export default function MemberDetailPage() {
 
 function Body() {
   const id = useSearchParams().get("id");
-  if (!id) {
-    return (
-      <div className="mx-auto max-w-4xl p-6 text-sm text-red-700">缺少 id 參數</div>
-    );
-  }
-  return (
-    <div className="mx-auto w-full max-w-4xl space-y-4 p-6">
-      <Link href="/members" className="text-sm text-zinc-500 transition-colors hover:text-zinc-800 dark:hover:text-zinc-200">
-        ← 會員列表
-      </Link>
-      <MemberDetail memberId={Number(id)} />
-    </div>
-  );
+  const router = useRouter();
+  useEffect(() => {
+    router.replace(id ? `/members?id=${id}` : "/members");
+  }, [id, router]);
+  return <div className="p-6 text-sm text-zinc-500">轉址中…</div>;
 }

--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 import { Modal } from "@/components/Modal";
@@ -35,6 +36,17 @@ type Store = { id: number; code: string; name: string };
 const PAGE_SIZE = 50;
 
 export default function MembersListPage() {
+  return (
+    <Suspense fallback={<div className="p-6 text-sm text-zinc-500">載入中…</div>}>
+      <MembersListBody />
+    </Suspense>
+  );
+}
+
+function MembersListBody() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const idFromUrl = searchParams.get("id");
   const [rows, setRows] = useState<MemberRow[] | null>(null);
   const [total, setTotal] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -58,6 +70,18 @@ export default function MembersListPage() {
     | { mode: "detail"; memberId: number; memberNo: string }
     | null
   >(null);
+
+  // URL ?id=N → 自動開 detail modal（讓外部 link 進來能直接看 detail）
+  useEffect(() => {
+    if (!idFromUrl) return;
+    const idNum = Number(idFromUrl);
+    if (!Number.isFinite(idNum) || idNum <= 0) return;
+    setModal((cur) =>
+      cur && cur.mode === "detail" && cur.memberId === idNum
+        ? cur
+        : { mode: "detail", memberId: idNum, memberNo: "" }
+    );
+  }, [idFromUrl]);
 
   useEffect(() => {
     const t = setTimeout(() => {
@@ -319,10 +343,16 @@ export default function MembersListPage() {
 
       <Modal
         open={!!modal}
-        onClose={() => setModal(null)}
+        onClose={() => {
+          setModal(null);
+          // 從 URL ?id= 進來開的 detail modal，關閉同步清 URL，避免 back 又自動打開
+          if (modal?.mode === "detail" && idFromUrl) {
+            router.replace("/members");
+          }
+        }}
         title={
           modal?.mode === "edit"   ? `編輯會員 #${modal.values.member_no}` :
-          modal?.mode === "detail" ? `會員明細 #${modal.memberNo}` :
+          modal?.mode === "detail" ? `會員明細${modal.memberNo ? ` #${modal.memberNo}` : ""}` :
           "新增會員"
         }
         maxWidth={modal?.mode === "detail" ? "max-w-4xl" : "max-w-3xl"}

--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -46,6 +46,7 @@ export default function MembersListPage() {
   const [sortBy, setSortBy] = useState<SortKey>("updated_at");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [page, setPage] = useState(1);
+  const [showMerged, setShowMerged] = useState(false);
 
   const [stores, setStores] = useState<Store[]>([]);
   useDefaultStoreFromUser(stores, storeId, setStoreId);
@@ -68,7 +69,7 @@ export default function MembersListPage() {
 
   useEffect(() => {
     setPage(1);
-  }, [storeId, sortBy, sortDir]);
+  }, [storeId, sortBy, sortDir, showMerged]);
 
   useEffect(() => {
     let cancelled = false;
@@ -106,6 +107,7 @@ export default function MembersListPage() {
           q = q.or(`name.ilike.%${safe}%,phone.ilike.%${safe}%,member_no.ilike.%${safe}%`);
         }
         if (storeId) q = q.eq("home_store_id", Number(storeId));
+        if (!showMerged) q = q.not("status", "in", "(merged,deleted)");
 
         const { data, count, error } = await q;
         if (cancelled) return;
@@ -146,7 +148,7 @@ export default function MembersListPage() {
     return () => {
       cancelled = true;
     };
-  }, [query, storeId, sortBy, sortDir, page, reloadTick]);
+  }, [query, storeId, sortBy, sortDir, page, reloadTick, showMerged]);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const fromIdx = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
@@ -199,6 +201,16 @@ export default function MembersListPage() {
         </select>
       </div>
 
+      <label className="flex items-center gap-2 text-xs text-zinc-500">
+        <input
+          type="checkbox"
+          checked={showMerged}
+          onChange={(e) => setShowMerged(e.target.checked)}
+          className="h-3.5 w-3.5"
+        />
+        <span>顯示已合併 / 已刪除（預設只看活躍會員）</span>
+      </label>
+
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
           <p className="font-medium">讀取失敗</p>
@@ -238,10 +250,16 @@ export default function MembersListPage() {
                     <Td className="font-mono">
                       <button
                         onClick={() => setModal({ mode: "detail", memberId: r.id, memberNo: r.member_no })}
-                        className="hover:underline"
+                        className={r.status === "merged" || r.status === "deleted" ? "text-zinc-400 hover:underline" : "hover:underline"}
                       >
                         {r.member_no}
                       </button>
+                      {r.status === "merged" && (
+                        <span className="ml-2 rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-normal text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">已合併</span>
+                      )}
+                      {r.status === "deleted" && (
+                        <span className="ml-2 rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-normal text-red-700 dark:bg-red-950 dark:text-red-300">已刪除</span>
+                      )}
                     </Td>
                     <Td>
                       <div className="flex items-center gap-2">

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -420,7 +420,7 @@ function OrdersListContent() {
                       <span className="flex items-center gap-2">
                         <Avatar src={m.avatar_url} name={m.name ?? r.nickname_snapshot ?? "?"} />
                         <span className="min-w-0">
-                          <Link href={`/members/detail?id=${m.id}`} className="hover:underline">{m.name ?? "—"}</Link>
+                          <Link href={`/members?id=${m.id}`} className="hover:underline">{m.name ?? "—"}</Link>
                           <span className="ml-1 font-mono text-xs text-zinc-500">{m.phone}</span>
                         </span>
                       </span>

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -28,10 +28,11 @@ type Campaign = { id: number; campaign_no: string; name: string; cover_image_url
 type Store = { id: number; code: string; name: string };
 type Member = { id: number; name: string | null; phone: string | null; member_no: string; avatar_url: string | null };
 
-type Tab = "pending" | "completed" | "cancelled";
+type Tab = "pending" | "completed" | "cancelled" | "transferred";
 const TABS: { value: Tab; label: string }[] = [
   { value: "pending", label: "未取貨" },
   { value: "completed", label: "已完成" },
+  { value: "transferred", label: "轉出" },
   { value: "cancelled", label: "取消" },
 ];
 const PENDING_STATUSES: OrderStatus[] = ["pending", "confirmed", "shipping", "ready"];
@@ -134,6 +135,7 @@ function OrdersListContent() {
         // 依 tab 套狀態過濾;一律隱藏 transferred_out (視同關閉、金額/數量不入統計)
         if (tab === "completed") q = q.eq("status", "completed");
         else if (tab === "cancelled") q = q.in("status", CANCELLED_STATUSES);
+        else if (tab === "transferred") q = q.eq("status", "transferred_out");
         else q = q.in("status", PENDING_STATUSES);
         if (storeId) q = q.eq("pickup_store_id", Number(storeId));
 
@@ -199,16 +201,18 @@ function OrdersListContent() {
         if (storeId) q = q.eq("pickup_store_id", Number(storeId));
         return q;
       };
-      const [p, c, x] = await Promise.all([
+      const [p, c, x, tr] = await Promise.all([
         buildBase().in("status", PENDING_STATUSES),
         buildBase().eq("status", "completed"),
         buildBase().in("status", CANCELLED_STATUSES),
+        buildBase().eq("status", "transferred_out"),
       ]);
       if (cancelled) return;
       setTabCounts({
         pending: p.count ?? 0,
         completed: c.count ?? 0,
         cancelled: x.count ?? 0,
+        transferred: tr.count ?? 0,
       });
     })();
     return () => { cancelled = true; };

--- a/apps/admin/src/app/(protected)/page.tsx
+++ b/apps/admin/src/app/(protected)/page.tsx
@@ -246,7 +246,7 @@ export default function Dashboard() {
                   ) : recentMembers.map((r) => (
                     <tr key={r.id}>
                       <Td className="font-mono text-xs">
-                        <Link href={`/members/detail?id=${r.id}`} className="hover:underline">{r.member_no}</Link>
+                        <Link href={`/members?id=${r.id}`} className="hover:underline">{r.member_no}</Link>
                       </Td>
                       <Td className="text-xs">{r.name ?? "—"}</Td>
                       <Td className="font-mono text-xs">{r.phone ?? "—"}</Td>

--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -817,7 +817,7 @@ function PageContent() {
                     {editable ? (
                       <input
                         type="number"
-                        step="0.001"
+                        step="1"
                         value={r.qty_requested}
                         onChange={(e) => patchItem(idx, { qty_requested: Number(e.target.value) })}
                         className="w-24 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800"
@@ -830,7 +830,7 @@ function PageContent() {
                     {editable ? (
                       <input
                         type="number"
-                        step="0.0001"
+                        step="1"
                         value={r.unit_cost}
                         onChange={(e) => patchItem(idx, { unit_cost: Number(e.target.value) })}
                         className="w-24 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800"
@@ -843,7 +843,7 @@ function PageContent() {
                     {editable ? (
                       <input
                         type="number"
-                        step="0.0001"
+                        step="1"
                         value={r.franchise_price ?? ""}
                         onChange={(e) =>
                           patchItem(idx, {
@@ -862,7 +862,7 @@ function PageContent() {
                     {editable ? (
                       <input
                         type="number"
-                        step="0.0001"
+                        step="1"
                         value={r.retail_price ?? ""}
                         onChange={(e) =>
                           patchItem(idx, {

--- a/apps/admin/src/app/(protected)/restock/new/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/new/page.tsx
@@ -264,8 +264,8 @@ function LineRow({
           </div>
         )}
       </td>
-      <td className="px-3 py-2"><input type="number" min="0" step="0.001" value={line.qty} onChange={(e) => onChange({ qty: e.target.value })} className="w-24 rounded border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800" /></td>
-      <td className="px-3 py-2"><input type="number" min="0" step="0.01" value={line.unit_price} onChange={(e) => onChange({ unit_price: e.target.value })} className="w-24 rounded border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800" /></td>
+      <td className="px-3 py-2"><input type="number" min="0" step="1" value={line.qty} onChange={(e) => onChange({ qty: e.target.value })} className="w-24 rounded border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800" /></td>
+      <td className="px-3 py-2"><input type="number" min="0" step="1" value={line.unit_price} onChange={(e) => onChange({ unit_price: e.target.value })} className="w-24 rounded border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800" /></td>
       <td className="px-3 py-2"><input value={line.notes} onChange={(e) => onChange({ notes: e.target.value })} placeholder="（選填）" className="w-full rounded border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800" /></td>
       <td className="px-3 py-2">
         {onRemove && (

--- a/apps/admin/src/app/(protected)/transfers/dispatch/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/dispatch/page.tsx
@@ -744,8 +744,8 @@ function DamageModal({
           <span className="text-zinc-500">損壞數量</span>
           <input
             type="number"
-            min="0.001"
-            step="0.001"
+            min="1"
+            step="1"
             value={qty}
             onChange={(e) => setQty(e.target.value)}
             className="rounded-md border border-zinc-300 bg-white px-2 py-1 dark:border-zinc-700 dark:bg-zinc-800"

--- a/apps/admin/src/app/(protected)/transfers/free/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/free/page.tsx
@@ -148,7 +148,7 @@ export default function FreeTransferPage() {
                   <input
                     type="number"
                     min="0"
-                    step="0.001"
+                    step="1"
                     value={l.qty}
                     onChange={(e) => setLine(i, "qty", e.target.value)}
                     className={`w-24 text-right ${inputCls}`}
@@ -158,7 +158,7 @@ export default function FreeTransferPage() {
                   <input
                     type="number"
                     min="0"
-                    step="0.01"
+                    step="1"
                     value={l.estimated_amount}
                     onChange={(e) => setLine(i, "estimated_amount", e.target.value)}
                     className={`w-28 text-right ${inputCls}`}

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -587,11 +587,11 @@ export function MemberDetail({ memberId }: { memberId: number }) {
                             {reversible && tenantId ? (
                               <button
                                 onClick={() => setWalletAction({ mode: "reverse", reverseTarget: e })}
-                                title={`反向 ledger #${e.id}`}
+                                title={`沖銷 #${e.id}`}
                                 className="rounded-md border border-zinc-300 px-2 py-0.5 text-[11px] hover:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-800"
-                              >↩ 反向</button>
+                              >↩ 沖銷</button>
                             ) : reversedIds.has(e.id) ? (
-                              <span className="text-[10px] text-zinc-400">已反向</span>
+                              <span className="text-[10px] text-zinc-400">已沖銷</span>
                             ) : (
                               <span className="text-[10px] text-zinc-400">—</span>
                             )}

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -278,7 +278,7 @@ export function MemberDetail({ memberId }: { memberId: number }) {
               <span className="rounded bg-zinc-300 px-2 py-0.5 text-xs font-medium text-zinc-700 line-through dark:bg-zinc-700 dark:text-zinc-300">已合併 → #{member.merged_into_member_id}</span>
             )}
             {member.member_type === "guest" && (
-              <span className="rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-950 dark:text-blue-300">虛擬會員</span>
+              <span className="rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-950 dark:text-blue-300" title="LLM 從 LINE 留言解析的訪客會員">訪客</span>
             )}
           </div>
           <div className="font-mono text-xs text-zinc-500">#{member.member_no}</div>
@@ -409,9 +409,9 @@ export function MemberDetail({ memberId }: { memberId: number }) {
       {mergedFrom.length > 0 && (
         <div className="rounded-md border border-emerald-200 bg-emerald-50/40 p-3 dark:border-emerald-900 dark:bg-emerald-950/30">
           <div className="mb-2 flex items-center gap-2 text-xs font-medium text-emerald-800 dark:text-emerald-300">
-            <span>📥 已合併虛擬會員（{mergedFrom.length}）</span>
+            <span>📥 已合併進來的舊會員（{mergedFrom.length}）</span>
             <span className="text-[10px] font-normal text-emerald-700/70 dark:text-emerald-400/70">
-              （這些虛擬會員的訂單 / 點數 / 儲值都已搬到本會員名下）
+              （這些舊會員的訂單 / 點數 / 儲值都已搬到本會員名下）
             </span>
           </div>
           <ul className="divide-y divide-emerald-200 dark:divide-emerald-900">

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -7,6 +7,7 @@ import { WalletActionModal, type WalletActionMode } from "@/components/WalletAct
 import { translateRpcError } from "@/lib/rpcError";
 import { canAdjustWallet, useRole } from "@/lib/role";
 import { walletLedgerTypeLabel, walletPaymentMethodLabel } from "@/lib/walletLedger";
+import { maskLineUserId } from "@/lib/maskLineUserId";
 
 type Member = {
   id: number;
@@ -75,7 +76,7 @@ export function MemberDetail({ memberId }: { memberId: number }) {
   const [wallet, setWallet] = useState(0);
   const [pLedger, setPLedger] = useState<PointsEntry[]>([]);
   const [wLedger, setWLedger] = useState<WalletEntry[]>([]);
-  const [tab, setTab] = useState<"points" | "wallet" | "test">("points");
+  const [tab, setTab] = useState<"info" | "points" | "wallet" | "test">("info");
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [reloadTick, setReloadTick] = useState(0);
@@ -475,27 +476,9 @@ export function MemberDetail({ memberId }: { memberId: number }) {
         <Card label="儲值餘額"><span className="text-lg font-mono">{wallet.toLocaleString()}</span></Card>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2">
-        <Card label="手機"><span className="font-mono">{member.phone && !member.phone.startsWith("line:") ? member.phone : "—"}</span></Card>
-        <Card label="Email">{member.email ?? "—"}</Card>
-        <Card label="性別">{member.gender === "M" ? "男" : member.gender === "F" ? "女" : member.gender === "O" ? "其他" : "—"}</Card>
-        <Card label="生日">{member.birthday ?? "—"}</Card>
-        <Card label="加入時間">{new Date(member.joined_at).toLocaleString("zh-TW")}</Card>
-        <Card label="最後消費">{member.last_visit_at ? new Date(member.last_visit_at).toLocaleString("zh-TW") : "—"}</Card>
-      </div>
-
-      {member.line_user_id && (
-        <Card label="LINE User ID">
-          <span className="break-all font-mono text-xs">{member.line_user_id}</span>
-        </Card>
-      )}
-
-      {member.notes && (
-        <Card label="備註"><div className="whitespace-pre-wrap text-sm">{member.notes}</div></Card>
-      )}
-
       <div>
         <div className="flex gap-2 border-b border-zinc-200 dark:border-zinc-800">
+          <TabBtn active={tab === "info"}    onClick={() => setTab("info")}>會員資料</TabBtn>
           <TabBtn active={tab === "points"}  onClick={() => setTab("points")}>積分流水 ({pLedger.length})</TabBtn>
           <TabBtn active={tab === "wallet"}  onClick={() => setTab("wallet")}>儲值流水 ({wLedger.length})</TabBtn>
           <TabBtn active={tab === "test"}    onClick={() => setTab("test")}>測試操作</TabBtn>
@@ -528,7 +511,28 @@ export function MemberDetail({ memberId }: { memberId: number }) {
           </div>
         )}
 
-        <div className="mt-3 overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+        {tab === "info" && (
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <Card label="手機"><span className="font-mono">{member.phone && !member.phone.startsWith("line:") ? member.phone : "—"}</span></Card>
+            <Card label="Email">{member.email ?? "—"}</Card>
+            <Card label="性別">{member.gender === "M" ? "男" : member.gender === "F" ? "女" : member.gender === "O" ? "其他" : "—"}</Card>
+            <Card label="生日">{member.birthday ?? "—"}</Card>
+            <Card label="加入時間">{new Date(member.joined_at).toLocaleString("zh-TW")}</Card>
+            <Card label="最後消費">{member.last_visit_at ? new Date(member.last_visit_at).toLocaleString("zh-TW") : "—"}</Card>
+            {member.line_user_id && (
+              <Card label="LINE User ID">
+                <span className="font-mono text-xs" title="完整 ID 已隱藏">{maskLineUserId(member.line_user_id)}</span>
+              </Card>
+            )}
+            {member.notes && (
+              <div className="sm:col-span-2">
+                <Card label="備註"><div className="whitespace-pre-wrap text-sm">{member.notes}</div></Card>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className={tab === "info" ? "hidden" : "mt-3 overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800"}>
           {tab === "points" ? (
             <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
               <thead className="bg-zinc-50 dark:bg-zinc-900">

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -407,6 +407,12 @@ export function MemberDetail({ memberId }: { memberId: number }) {
         </p>
       </div>
 
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Card label="等級">{tier?.name ?? "—"}</Card>
+        <Card label="積分餘額"><span className="text-lg font-mono">{points.toLocaleString()}</span></Card>
+        <Card label="儲值餘額"><span className="text-lg font-mono">{wallet.toLocaleString()}</span></Card>
+      </div>
+
       {mergedFrom.length > 0 && (
         <div className="rounded-md border border-emerald-200 bg-emerald-50/40 p-3 dark:border-emerald-900 dark:bg-emerald-950/30">
           <div className="mb-2 flex items-center gap-2 text-xs font-medium text-emerald-800 dark:text-emerald-300">
@@ -469,12 +475,6 @@ export function MemberDetail({ memberId }: { memberId: number }) {
           reverseTarget={walletAction.reverseTarget}
         />
       )}
-
-      <div className="grid gap-3 sm:grid-cols-3">
-        <Card label="等級">{tier?.name ?? "—"}</Card>
-        <Card label="積分餘額"><span className="text-lg font-mono">{points.toLocaleString()}</span></Card>
-        <Card label="儲值餘額"><span className="text-lg font-mono">{wallet.toLocaleString()}</span></Card>
-      </div>
 
       <div>
         <div className="flex gap-2 border-b border-zinc-200 dark:border-zinc-800">

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -33,6 +33,20 @@ type Member = {
 type Tier = { id: number; name: string };
 type Store = { id: number; code: string; name: string };
 
+type MergedFrom = {
+  merge_id: number;
+  merged_at: string;
+  reason: string | null;
+  guest: {
+    id: number;
+    member_no: string;
+    name: string | null;
+    phone: string | null;
+    avatar_url: string | null;
+    joined_at: string;
+  };
+};
+
 type PointsEntry = {
   id: number;
   change: number;
@@ -65,7 +79,8 @@ export function MemberDetail({ memberId }: { memberId: number }) {
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [reloadTick, setReloadTick] = useState(0);
-  const [mergeOpen, setMergeOpen] = useState(false);
+  const [mergeOpen, setMergeOpen] = useState<false | "guest-to-real" | "real-from-guest">(false);
+  const [mergedFrom, setMergedFrom] = useState<MergedFrom[]>([]);
   const [savingFlags, setSavingFlags] = useState(false);
   const [draftAdminNote, setDraftAdminNote] = useState("");
   const [draftNoNotify, setDraftNoNotify] = useState(false);
@@ -175,13 +190,17 @@ export function MemberDetail({ memberId }: { memberId: number }) {
       setDraftNoNewOrder(!!m.no_new_order);
       setDraftHomeStoreId(m.home_store_id ? String(m.home_store_id) : "");
 
-      const [tierQ, storesQ, pb, wb, pl, wl] = await Promise.all([
+      const [tierQ, storesQ, pb, wb, pl, wl, mm] = await Promise.all([
         m.tier_id ? sb.from("member_tiers").select("id, name").eq("id", m.tier_id).maybeSingle<Tier>() : Promise.resolve({ data: null }),
         sb.from("stores").select("id, code, name").eq("is_active", true).order("name"),
         sb.from("member_points_balance").select("balance").eq("member_id", memberId).maybeSingle<{ balance: number }>(),
         sb.from("wallet_balances").select("balance").eq("member_id", memberId).maybeSingle<{ balance: number }>(),
         sb.from("points_ledger").select("id, change, balance_after, source_type, reason, created_at").eq("member_id", memberId).order("created_at", { ascending: false }).limit(50),
         sb.from("wallet_ledger").select("id, change, balance_after, type, payment_method, reason, reverses, created_at").eq("member_id", memberId).order("created_at", { ascending: false }).limit(50),
+        sb.from("member_merges")
+          .select("id, created_at, reason, merged_member_id, members:merged_member_id (id, member_no, name, phone, avatar_url, joined_at)")
+          .eq("primary_member_id", memberId)
+          .order("created_at", { ascending: false }),
       ]);
       if (cancelled) return;
       setTier(tierQ.data as Tier | null);
@@ -190,6 +209,27 @@ export function MemberDetail({ memberId }: { memberId: number }) {
       setWallet(Number(wb.data?.balance ?? 0));
       setPLedger((pl.data as PointsEntry[]) ?? []);
       setWLedger((wl.data as WalletEntry[]) ?? []);
+      type MergeMemberRow = { id: number; member_no: string; name: string | null; phone: string | null; avatar_url: string | null; joined_at: string };
+      type MergeRow = {
+        id: number;
+        created_at: string;
+        reason: string | null;
+        merged_member_id: number;
+        members: MergeMemberRow | MergeMemberRow[] | null;
+      };
+      const mmRows = ((mm.data ?? []) as unknown as MergeRow[])
+        .map<MergedFrom | null>((r) => {
+          const guest = Array.isArray(r.members) ? r.members[0] : r.members;
+          if (!guest) return null;
+          return {
+            merge_id: r.id,
+            merged_at: r.created_at,
+            reason: r.reason,
+            guest,
+          };
+        })
+        .filter((x): x is MergedFrom => x !== null);
+      setMergedFrom(mmRows);
     })();
     return () => { cancelled = true; };
   }, [memberId, reloadTick]);
@@ -209,17 +249,17 @@ export function MemberDetail({ memberId }: { memberId: number }) {
   }
   if (!member) return <div className="text-sm text-zinc-500">載入中…</div>;
 
+  const isMerged = member.status === "merged";
+  const isGuest = member.member_type === "guest";
+  // 反向合併按鈕：只在「實體會員 (非 guest) + status≠merged」上出現
+  const canAbsorbGuest = !isGuest && !isMerged;
+  // 正向合併按鈕：guest + 還沒被合
+  const canMergeOut = isGuest && !isMerged;
+
   return (
     <div className="space-y-5">
       <div className="flex items-center gap-3">
-        {member.avatar_url ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={member.avatar_url} alt="" className="h-12 w-12 rounded-full object-cover" />
-        ) : (
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-200 text-lg text-zinc-500 dark:bg-zinc-800">
-            {member.name?.[0] ?? "?"}
-          </div>
-        )}
+        <AvatarStack main={member} mergedFrom={mergedFrom} />
         <div className="flex-1">
           <div className="flex flex-wrap items-baseline gap-2 text-lg font-semibold">
             {member.name ?? "—"}
@@ -243,13 +283,22 @@ export function MemberDetail({ memberId }: { memberId: number }) {
           </div>
           <div className="font-mono text-xs text-zinc-500">#{member.member_no}</div>
         </div>
-        {member.member_type === "guest" && member.status !== "merged" && (
+        {canMergeOut && (
           <button
-            onClick={() => setMergeOpen(true)}
+            onClick={() => setMergeOpen("guest-to-real")}
             className="rounded-md border border-rose-300 px-3 py-1 text-xs font-medium text-rose-700 hover:bg-rose-50 dark:border-rose-800 dark:text-rose-300 dark:hover:bg-rose-950"
             title="把虛擬會員合併到 LINE 實體會員（搬走訂單 / 點數 / 儲值）"
           >
             🔗 合併到實體會員
+          </button>
+        )}
+        {canAbsorbGuest && (
+          <button
+            onClick={() => setMergeOpen("real-from-guest")}
+            className="rounded-md border border-emerald-300 px-3 py-1 text-xs font-medium text-emerald-700 hover:bg-emerald-50 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-950"
+            title="搜尋虛擬會員並把他合併進來（訂單 / 點數 / 儲值會搬到此會員）"
+          >
+            📥 合併虛擬會員進來
           </button>
         )}
       </div>
@@ -357,10 +406,54 @@ export function MemberDetail({ memberId }: { memberId: number }) {
         </p>
       </div>
 
+      {mergedFrom.length > 0 && (
+        <div className="rounded-md border border-emerald-200 bg-emerald-50/40 p-3 dark:border-emerald-900 dark:bg-emerald-950/30">
+          <div className="mb-2 flex items-center gap-2 text-xs font-medium text-emerald-800 dark:text-emerald-300">
+            <span>📥 已合併虛擬會員（{mergedFrom.length}）</span>
+            <span className="text-[10px] font-normal text-emerald-700/70 dark:text-emerald-400/70">
+              （這些虛擬會員的訂單 / 點數 / 儲值都已搬到本會員名下）
+            </span>
+          </div>
+          <ul className="divide-y divide-emerald-200 dark:divide-emerald-900">
+            {mergedFrom.map((mf) => (
+              <li key={mf.merge_id} className="flex flex-wrap items-center gap-3 py-2 text-sm">
+                {mf.guest.avatar_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={mf.guest.avatar_url} alt="" className="h-8 w-8 rounded-full object-cover ring-2 ring-emerald-300 dark:ring-emerald-700" />
+                ) : (
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-200 text-xs text-zinc-500 ring-2 ring-emerald-300 dark:bg-zinc-700 dark:ring-emerald-700">
+                    {mf.guest.name?.[0] ?? "?"}
+                  </div>
+                )}
+                <div className="flex-1 min-w-[200px]">
+                  <div className="font-medium">
+                    {mf.guest.name ?? "—"}
+                    <span className="ml-2 font-mono text-xs text-zinc-500">#{mf.guest.member_no}</span>
+                  </div>
+                  <div className="text-xs text-zinc-500">
+                    {mf.guest.phone && !mf.guest.phone.startsWith("line:") ? mf.guest.phone : "—"}
+                    　建檔：{new Date(mf.guest.joined_at).toLocaleDateString("zh-TW")}
+                    　合併：{new Date(mf.merged_at).toLocaleDateString("zh-TW")}
+                  </div>
+                  {mf.reason && (
+                    <div className="text-xs text-zinc-500">原因：{mf.reason}</div>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       <MemberMergeModal
-        open={mergeOpen}
+        open={!!mergeOpen}
         onClose={() => setMergeOpen(false)}
-        guestMember={{ id: member.id, name: member.name, phone: member.phone, member_no: member.member_no }}
+        guestMember={mergeOpen === "guest-to-real"
+          ? { id: member.id, name: member.name, phone: member.phone, member_no: member.member_no }
+          : undefined}
+        realMember={mergeOpen === "real-from-guest"
+          ? { id: member.id, name: member.name, phone: member.phone, member_no: member.member_no }
+          : undefined}
         onMerged={() => { setMergeOpen(false); setReloadTick((n) => n + 1); }}
       />
 
@@ -524,6 +617,56 @@ export function MemberDetail({ memberId }: { memberId: number }) {
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function AvatarStack({
+  main,
+  mergedFrom,
+}: {
+  main: { avatar_url: string | null; name: string | null };
+  mergedFrom: MergedFrom[];
+}) {
+  // 顯示主頭像 + 最多 2 個小覆蓋頭像；3 個以上顯示 +N badge
+  const overlays = mergedFrom.slice(0, 2);
+  const extra = Math.max(0, mergedFrom.length - 2);
+  return (
+    <div className="relative h-12 w-12 shrink-0">
+      {main.avatar_url ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={main.avatar_url} alt="" className="h-12 w-12 rounded-full object-cover ring-2 ring-white dark:ring-zinc-900" />
+      ) : (
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-200 text-lg text-zinc-500 ring-2 ring-white dark:bg-zinc-800 dark:ring-zinc-900">
+          {main.name?.[0] ?? "?"}
+        </div>
+      )}
+      {overlays.map((mf, i) => (
+        <span
+          key={mf.merge_id}
+          className="absolute h-6 w-6"
+          style={{ right: i * -10, bottom: -4 }}
+          title={`已合併：${mf.guest.name ?? "—"} #${mf.guest.member_no}`}
+        >
+          {mf.guest.avatar_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={mf.guest.avatar_url} alt="" className="h-6 w-6 rounded-full object-cover ring-2 ring-white dark:ring-zinc-900" />
+          ) : (
+            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-zinc-300 text-[10px] text-zinc-600 ring-2 ring-white dark:bg-zinc-700 dark:text-zinc-300 dark:ring-zinc-900">
+              {mf.guest.name?.[0] ?? "?"}
+            </span>
+          )}
+        </span>
+      ))}
+      {extra > 0 && (
+        <span
+          className="absolute flex h-6 w-6 items-center justify-center rounded-full bg-emerald-600 text-[10px] font-bold text-white ring-2 ring-white dark:ring-zinc-900"
+          style={{ right: -20, bottom: -4 }}
+          title={`另有 ${extra} 個已合併虛擬會員`}
+        >
+          +{extra}
+        </span>
+      )}
     </div>
   );
 }

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -76,7 +76,7 @@ export function MemberDetail({ memberId }: { memberId: number }) {
   const [wallet, setWallet] = useState(0);
   const [pLedger, setPLedger] = useState<PointsEntry[]>([]);
   const [wLedger, setWLedger] = useState<WalletEntry[]>([]);
-  const [tab, setTab] = useState<"info" | "points" | "wallet" | "test">("wallet");
+  const [tab, setTab] = useState<"info" | "points" | "wallet" | "merges" | "test">("wallet");
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [reloadTick, setReloadTick] = useState(0);
@@ -413,45 +413,6 @@ export function MemberDetail({ memberId }: { memberId: number }) {
         <Card label="儲值餘額"><span className="text-lg font-mono">{wallet.toLocaleString()}</span></Card>
       </div>
 
-      {mergedFrom.length > 0 && (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50/40 p-3 dark:border-emerald-900 dark:bg-emerald-950/30">
-          <div className="mb-2 flex items-center gap-2 text-xs font-medium text-emerald-800 dark:text-emerald-300">
-            <span>📥 已合併進來的舊會員（{mergedFrom.length}）</span>
-            <span className="text-[10px] font-normal text-emerald-700/70 dark:text-emerald-400/70">
-              （這些舊會員的訂單 / 點數 / 儲值都已搬到本會員名下）
-            </span>
-          </div>
-          <ul className="divide-y divide-emerald-200 dark:divide-emerald-900">
-            {mergedFrom.map((mf) => (
-              <li key={mf.merge_id} className="flex flex-wrap items-center gap-3 py-2 text-sm">
-                {mf.guest.avatar_url ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={mf.guest.avatar_url} alt="" className="h-8 w-8 rounded-full object-cover ring-2 ring-emerald-300 dark:ring-emerald-700" />
-                ) : (
-                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-200 text-xs text-zinc-500 ring-2 ring-emerald-300 dark:bg-zinc-700 dark:ring-emerald-700">
-                    {mf.guest.name?.[0] ?? "?"}
-                  </div>
-                )}
-                <div className="flex-1 min-w-[200px]">
-                  <div className="font-medium">
-                    {mf.guest.name ?? "—"}
-                    <span className="ml-2 font-mono text-xs text-zinc-500">#{mf.guest.member_no}</span>
-                  </div>
-                  <div className="text-xs text-zinc-500">
-                    {mf.guest.phone && !mf.guest.phone.startsWith("line:") ? mf.guest.phone : "—"}
-                    　建檔：{new Date(mf.guest.joined_at).toLocaleDateString("zh-TW")}
-                    　合併：{new Date(mf.merged_at).toLocaleDateString("zh-TW")}
-                  </div>
-                  {mf.reason && (
-                    <div className="text-xs text-zinc-500">原因：{mf.reason}</div>
-                  )}
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
       <MemberMergeModal
         open={!!mergeOpen}
         onClose={() => setMergeOpen(false)}
@@ -480,6 +441,9 @@ export function MemberDetail({ memberId }: { memberId: number }) {
         <div className="flex gap-2 border-b border-zinc-200 dark:border-zinc-800">
           <TabBtn active={tab === "wallet"}  onClick={() => setTab("wallet")}>儲值金明細 ({wLedger.length})</TabBtn>
           <TabBtn active={tab === "points"}  onClick={() => setTab("points")}>積分明細 ({pLedger.length})</TabBtn>
+          {mergedFrom.length > 0 && (
+            <TabBtn active={tab === "merges"} onClick={() => setTab("merges")}>合併紀錄 ({mergedFrom.length})</TabBtn>
+          )}
           <TabBtn active={tab === "test"}    onClick={() => setTab("test")}>測試操作</TabBtn>
           <TabBtn active={tab === "info"}    onClick={() => setTab("info")}>會員資料</TabBtn>
         </div>
@@ -532,7 +496,43 @@ export function MemberDetail({ memberId }: { memberId: number }) {
           </div>
         )}
 
-        <div className={tab === "info" ? "hidden" : "mt-3 overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800"}>
+        {tab === "merges" && mergedFrom.length > 0 && (
+          <div className="mt-3 rounded-md border border-emerald-200 bg-emerald-50/40 p-3 dark:border-emerald-900 dark:bg-emerald-950/30">
+            <div className="mb-2 text-[10px] font-normal text-emerald-700/70 dark:text-emerald-400/70">
+              這些舊會員的訂單 / 點數 / 儲值都已搬到本會員名下
+            </div>
+            <ul className="divide-y divide-emerald-200 dark:divide-emerald-900">
+              {mergedFrom.map((mf) => (
+                <li key={mf.merge_id} className="flex flex-wrap items-center gap-3 py-2 text-sm">
+                  {mf.guest.avatar_url ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={mf.guest.avatar_url} alt="" className="h-8 w-8 rounded-full object-cover ring-2 ring-emerald-300 dark:ring-emerald-700" />
+                  ) : (
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-200 text-xs text-zinc-500 ring-2 ring-emerald-300 dark:bg-zinc-700 dark:ring-emerald-700">
+                      {mf.guest.name?.[0] ?? "?"}
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-[200px]">
+                    <div className="font-medium">
+                      {mf.guest.name ?? "—"}
+                      <span className="ml-2 font-mono text-xs text-zinc-500">#{mf.guest.member_no}</span>
+                    </div>
+                    <div className="text-xs text-zinc-500">
+                      {mf.guest.phone && !mf.guest.phone.startsWith("line:") ? mf.guest.phone : "—"}
+                      　建檔：{new Date(mf.guest.joined_at).toLocaleDateString("zh-TW")}
+                      　合併：{new Date(mf.merged_at).toLocaleDateString("zh-TW")}
+                    </div>
+                    {mf.reason && (
+                      <div className="text-xs text-zinc-500">原因：{mf.reason}</div>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className={tab === "info" || tab === "merges" ? "hidden" : "mt-3 overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800"}>
           {tab === "points" ? (
             <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
               <thead className="bg-zinc-50 dark:bg-zinc-900">

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -76,7 +76,7 @@ export function MemberDetail({ memberId }: { memberId: number }) {
   const [wallet, setWallet] = useState(0);
   const [pLedger, setPLedger] = useState<PointsEntry[]>([]);
   const [wLedger, setWLedger] = useState<WalletEntry[]>([]);
-  const [tab, setTab] = useState<"info" | "points" | "wallet" | "test">("info");
+  const [tab, setTab] = useState<"info" | "points" | "wallet" | "test">("wallet");
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [reloadTick, setReloadTick] = useState(0);
@@ -478,10 +478,10 @@ export function MemberDetail({ memberId }: { memberId: number }) {
 
       <div>
         <div className="flex gap-2 border-b border-zinc-200 dark:border-zinc-800">
-          <TabBtn active={tab === "info"}    onClick={() => setTab("info")}>會員資料</TabBtn>
-          <TabBtn active={tab === "points"}  onClick={() => setTab("points")}>積分明細 ({pLedger.length})</TabBtn>
           <TabBtn active={tab === "wallet"}  onClick={() => setTab("wallet")}>儲值金明細 ({wLedger.length})</TabBtn>
+          <TabBtn active={tab === "points"}  onClick={() => setTab("points")}>積分明細 ({pLedger.length})</TabBtn>
           <TabBtn active={tab === "test"}    onClick={() => setTab("test")}>測試操作</TabBtn>
+          <TabBtn active={tab === "info"}    onClick={() => setTab("info")}>會員資料</TabBtn>
         </div>
 
         {tab === "wallet" && (

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -532,10 +532,10 @@ export function MemberDetail({ memberId }: { memberId: number }) {
           </div>
         )}
 
-        <div className={tab === "info" || tab === "merges" ? "hidden" : "mt-3 overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800"}>
+        <div className={tab === "info" || tab === "merges" ? "hidden" : "mt-3 max-h-[420px] overflow-auto rounded-md border border-zinc-200 dark:border-zinc-800"}>
           {tab === "points" ? (
             <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
-              <thead className="bg-zinc-50 dark:bg-zinc-900">
+              <thead className="sticky top-0 z-10 bg-zinc-50 dark:bg-zinc-900">
                 <tr>
                   <Th>時間</Th><Th>來源</Th><Th className="text-right">變動</Th><Th className="text-right">餘額</Th><Th>備註</Th>
                 </tr>
@@ -561,7 +561,7 @@ export function MemberDetail({ memberId }: { memberId: number }) {
               const reversedIds = new Set(wLedger.map((x) => x.reverses).filter((v): v is number => typeof v === "number"));
               return (
                 <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
-                  <thead className="bg-zinc-50 dark:bg-zinc-900">
+                  <thead className="sticky top-0 z-10 bg-zinc-50 dark:bg-zinc-900">
                     <tr>
                       <Th>時間</Th><Th>類型</Th><Th>支付</Th><Th className="text-right">變動</Th><Th className="text-right">餘額</Th><Th>備註</Th><Th>動作</Th>
                     </tr>

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -250,11 +250,11 @@ export function MemberDetail({ memberId }: { memberId: number }) {
   if (!member) return <div className="text-sm text-zinc-500">載入中…</div>;
 
   const isMerged = member.status === "merged";
-  const isGuest = member.member_type === "guest";
-  // 反向合併按鈕：只在「實體會員 (非 guest) + status≠merged」上出現
-  const canAbsorbGuest = !isGuest && !isMerged;
-  // 正向合併按鈕：guest + 還沒被合
-  const canMergeOut = isGuest && !isMerged;
+  const hasLine = !!member.line_user_id;
+  // 「合併到已綁 LINE 會員」：自己未綁 LINE + status≠merged 才出現
+  const canMergeOut = !hasLine && !isMerged;
+  // 「合併未綁 LINE 會員進來」：自己已綁 LINE + status≠merged 才出現
+  const canAbsorbGuest = hasLine && !isMerged;
 
   return (
     <div className="space-y-5">
@@ -287,18 +287,18 @@ export function MemberDetail({ memberId }: { memberId: number }) {
           <button
             onClick={() => setMergeOpen("guest-to-real")}
             className="rounded-md border border-rose-300 px-3 py-1 text-xs font-medium text-rose-700 hover:bg-rose-50 dark:border-rose-800 dark:text-rose-300 dark:hover:bg-rose-950"
-            title="把虛擬會員合併到 LINE 實體會員（搬走訂單 / 點數 / 儲值）"
+            title="把這個未綁 LINE 的會員合併到已綁 LINE 的會員（訂單 / 點數 / 儲值會搬過去）"
           >
-            🔗 合併到實體會員
+            🔗 合併到已綁 LINE 會員
           </button>
         )}
         {canAbsorbGuest && (
           <button
             onClick={() => setMergeOpen("real-from-guest")}
             className="rounded-md border border-emerald-300 px-3 py-1 text-xs font-medium text-emerald-700 hover:bg-emerald-50 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-950"
-            title="搜尋虛擬會員並把他合併進來（訂單 / 點數 / 儲值會搬到此會員）"
+            title="搜尋未綁 LINE 的舊會員並合併進來（訂單 / 點數 / 儲值會搬到此會員）"
           >
-            📥 合併虛擬會員進來
+            📥 合併舊會員進來
           </button>
         )}
       </div>

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -444,8 +444,8 @@ export function MemberDetail({ memberId }: { memberId: number }) {
           {mergedFrom.length > 0 && (
             <TabBtn active={tab === "merges"} onClick={() => setTab("merges")}>合併紀錄 ({mergedFrom.length})</TabBtn>
           )}
-          <TabBtn active={tab === "test"}    onClick={() => setTab("test")}>測試操作</TabBtn>
           <TabBtn active={tab === "info"}    onClick={() => setTab("info")}>會員資料</TabBtn>
+          <TabBtn active={tab === "test"}    onClick={() => setTab("test")}>測試操作</TabBtn>
         </div>
 
         {tab === "wallet" && (

--- a/apps/admin/src/components/MemberForm.tsx
+++ b/apps/admin/src/components/MemberForm.tsx
@@ -100,7 +100,7 @@ export function MemberForm({
       if (err) throw err;
       const newId = Number(data);
       if (onSaved) onSaved(newId);
-      else router.replace(`/members/detail?id=${newId}`);
+      else router.replace(`/members?id=${newId}`);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {

--- a/apps/admin/src/components/MemberMergeModal.tsx
+++ b/apps/admin/src/components/MemberMergeModal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-// 會員合併（虛擬 ↔ 實體）— 兩個方向共用同一支 rpc_merge_member
-// - mode="guest-to-real": 從虛擬會員端搜實體會員（既有行為）
-// - mode="real-from-guest": 從實體會員端搜虛擬會員（反向）
+// 會員合併（重複建檔合併 — 把「未綁 LINE 的會員」併進「已綁 LINE 的會員」）
+// 兩個方向共用同一支 rpc_merge_member（RPC 守衛：source.line_user_id IS NULL）
+// - direction="guest-to-real":   從未綁 LINE 端開（既有「合併到實體會員」按鈕）
+// - direction="real-from-guest": 從已綁 LINE 端開（新「合併進來」按鈕）
 // rpc_merge_member 會搬：訂單 / 卡片 / 點數 / 儲值 / 標籤 / 暱稱對應 / 流水
 
 import { useEffect, useState } from "react";
@@ -77,15 +78,14 @@ export function MemberMergeModal({
       .limit(20);
 
     if (direction === "guest-to-real") {
-      // 找實體會員：排除 merged/deleted、以及其他 guest（避免 guest→guest）
+      // 找合併目標：必須已綁 LINE、status active
       req = req
-        .neq("status", "merged")
-        .neq("status", "deleted")
-        .neq("member_type", "guest");
+        .not("line_user_id", "is", null)
+        .eq("status", "active");
     } else {
-      // 找虛擬會員：member_type='guest' + status='active'（不能合 merged 進來）
+      // 找被合併進來的會員：必須未綁 LINE、status active（不能合 merged 進來）
       req = req
-        .eq("member_type", "guest")
+        .is("line_user_id", null)
         .eq("status", "active");
     }
 
@@ -126,8 +126,8 @@ export function MemberMergeModal({
   if (!anchor) return null;
 
   const title = direction === "guest-to-real"
-    ? "合併虛擬會員 → 實體會員"
-    : "把虛擬會員合併進來（→ 此實體會員）";
+    ? "合併到已綁 LINE 的會員"
+    : "把『未綁 LINE 的會員』合併進來";
 
   return (
     <Modal open={open} onClose={onClose} title={title} maxWidth="max-w-2xl">
@@ -136,19 +136,19 @@ export function MemberMergeModal({
           <div className="text-xs text-amber-800 dark:text-amber-300">
             {direction === "guest-to-real" ? (
               <>
-                <b>來源（虛擬會員）：</b>{anchor.name ?? "—"}
+                <b>來源（未綁 LINE 的這筆，會被標 merged）：</b>{anchor.name ?? "—"}
                 <span className="ml-1 font-mono">{anchor.member_no}</span>
                 {anchor.phone && <span className="ml-1 font-mono">{anchor.phone}</span>}
               </>
             ) : (
               <>
-                <b>目標（此實體會員）：</b>{anchor.name ?? "—"}
+                <b>目標（此筆已綁 LINE 的會員，訂單會搬來這）：</b>{anchor.name ?? "—"}
                 <span className="ml-1 font-mono">{anchor.member_no}</span>
                 {anchor.phone && <span className="ml-1 font-mono">{anchor.phone}</span>}
               </>
             )}
             <br />
-            合併後虛擬會員會被標 <code>merged</code>，所有訂單 / 儲值 / 點數 / 卡片 / 標籤都會搬到實體會員。
+            合併後來源會被標 <code>merged</code>，所有訂單 / 儲值 / 點數 / 卡片 / 標籤都會搬到目標。
           </div>
         </div>
 
@@ -158,8 +158,8 @@ export function MemberMergeModal({
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); search(); }}}
             placeholder={direction === "guest-to-real"
-              ? "搜尋目標實體會員（姓名 / 電話 / 會員編號）"
-              : "搜尋要合併進來的虛擬會員（姓名 / 電話 / 會員編號）"}
+              ? "搜尋目標：已綁 LINE 的會員（姓名 / 電話 / 會員編號）"
+              : "搜尋要合併進來的：未綁 LINE 的會員（姓名 / 電話 / 會員編號）"}
             className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-900"
           />
           <button

--- a/apps/admin/src/components/MemberMergeModal.tsx
+++ b/apps/admin/src/components/MemberMergeModal.tsx
@@ -20,6 +20,12 @@ type Candidate = {
   member_type: string | null;
 };
 
+function memberTypeLabel(t: string | null): string {
+  if (t === "guest") return "訪客";
+  if (t === "full") return "正式";
+  return t ?? "—";
+}
+
 type Direction = "guest-to-real" | "real-from-guest";
 
 type AnchorMember = { id: number; name: string | null; phone: string | null; member_no: string };
@@ -148,7 +154,7 @@ export function MemberMergeModal({
               </>
             )}
             <br />
-            合併後來源會被標 <code>merged</code>，所有訂單 / 儲值 / 點數 / 卡片 / 標籤都會搬到目標。
+            合併後來源會被標為「已合併」，所有訂單 / 儲值 / 點數 / 卡片 / 標籤都會搬到目標，不可還原。
           </div>
         </div>
 
@@ -191,8 +197,8 @@ export function MemberMergeModal({
                       </div>
                       <div className="text-xs text-zinc-500">
                         {c.phone && !c.phone.startsWith("line:") ? c.phone : "—"}
-                        {c.line_user_id ? <span className="ml-2 text-emerald-600 dark:text-emerald-400">LINE 已綁</span> : <span className="ml-2 text-zinc-400">未綁 LINE</span>}
-                        　<span className="text-[10px] text-zinc-400">{c.member_type ?? "—"}</span>
+                        {c.line_user_id ? <span className="ml-2 text-emerald-600 dark:text-emerald-400">已綁 LINE</span> : <span className="ml-2 text-zinc-400">未綁 LINE</span>}
+                        　<span className="text-[10px] text-zinc-400">{memberTypeLabel(c.member_type)}</span>
                       </div>
                     </div>
                     {target?.id === c.id && (
@@ -206,7 +212,7 @@ export function MemberMergeModal({
         )}
 
         <label className="block">
-          <span className="mb-1 block text-xs text-zinc-500">合併原因（選填，會記錄到 member_merges）</span>
+          <span className="mb-1 block text-xs text-zinc-500">合併原因（選填，會記入合併紀錄）</span>
           <input
             value={reason}
             onChange={(e) => setReason(e.target.value)}

--- a/apps/admin/src/components/MemberMergeModal.tsx
+++ b/apps/admin/src/components/MemberMergeModal.tsx
@@ -202,7 +202,13 @@ export function MemberMergeModal({
                       </div>
                     </div>
                     {target?.id === c.id && (
-                      <span className="rounded-md bg-emerald-600 px-2 py-1 text-xs text-white">已選</span>
+                      <span
+                        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-sm font-bold text-white shadow"
+                        title="已選"
+                        aria-label="已選"
+                      >
+                        ✓
+                      </span>
                     )}
                   </li>
                 ))}

--- a/apps/admin/src/components/MemberMergeModal.tsx
+++ b/apps/admin/src/components/MemberMergeModal.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-// 把虛擬會員（guest，從 LLM 解析或人工建檔）合併到 LINE 實體會員
-// 走既有 rpc_merge_member（自動把 orders / cards / 點數 / 儲值 全搬過去）
+// 會員合併（虛擬 ↔ 實體）— 兩個方向共用同一支 rpc_merge_member
+// - mode="guest-to-real": 從虛擬會員端搜實體會員（既有行為）
+// - mode="real-from-guest": 從實體會員端搜虛擬會員（反向）
+// rpc_merge_member 會搬：訂單 / 卡片 / 點數 / 儲值 / 標籤 / 暱稱對應 / 流水
 
 import { useEffect, useState } from "react";
 import { Modal } from "@/components/Modal";
@@ -17,17 +19,27 @@ type Candidate = {
   member_type: string | null;
 };
 
+type Direction = "guest-to-real" | "real-from-guest";
+
+type AnchorMember = { id: number; name: string | null; phone: string | null; member_no: string };
+
 export function MemberMergeModal({
   open,
   onClose,
   guestMember,
+  realMember,
   onMerged,
 }: {
   open: boolean;
   onClose: () => void;
-  guestMember: { id: number; name: string | null; phone: string | null; member_no: string };
+  /** mode = guest-to-real：傳 guestMember；mode = real-from-guest：傳 realMember */
+  guestMember?: AnchorMember;
+  realMember?: AnchorMember;
   onMerged: () => void;
 }) {
+  const direction: Direction = guestMember ? "guest-to-real" : "real-from-guest";
+  const anchor: AnchorMember | null = guestMember ?? realMember ?? null;
+
   const [query, setQuery] = useState("");
   const [candidates, setCandidates] = useState<Candidate[] | null>(null);
   const [target, setTarget] = useState<Candidate | null>(null);
@@ -35,38 +47,55 @@ export function MemberMergeModal({
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
-  // 預填查詢字（用 guest 的姓名 or 電話）
   useEffect(() => {
-    if (!open) return;
-    setQuery(guestMember.phone?.replace(/^line:/, "") || guestMember.name || "");
+    if (!open || !anchor) return;
+    // guest-to-real：用 guest 的姓名/手機去搜實體會員
+    // real-from-guest：搜尋框留空（實體會員的姓名通常跟 guest 不同，guest 多半是 LLM 從留言抓 nickname）
+    setQuery(direction === "guest-to-real"
+      ? (anchor.phone?.replace(/^line:/, "") || anchor.name || "")
+      : "");
     setCandidates(null);
     setTarget(null);
     setReason("");
     setErr(null);
-  }, [open, guestMember]);
+  }, [open, anchor, direction]);
 
   async function search() {
+    if (!anchor) return;
     const q = query.trim();
     if (q.length < 2) { setErr("請至少輸入 2 字"); return; }
     setErr(null);
     setCandidates(null);
     const sb = getSupabase();
     const safe = q.replace(/[%,()]/g, " ");
-    const { data, error } = await sb
+    let req = sb
       .from("members")
       .select("id, member_no, name, phone, line_user_id, member_type")
-      .neq("id", guestMember.id)                  // 不合併自己
-      .neq("status", "merged")                     // 已合併的不能再被合
-      .neq("status", "deleted")
+      .neq("id", anchor.id)
       .or(`name.ilike.%${safe}%,phone.ilike.%${safe}%,member_no.ilike.%${safe}%`)
       .order("last_visit_at", { ascending: false, nullsFirst: false })
       .limit(20);
+
+    if (direction === "guest-to-real") {
+      // 找實體會員：排除 merged/deleted、以及其他 guest（避免 guest→guest）
+      req = req
+        .neq("status", "merged")
+        .neq("status", "deleted")
+        .neq("member_type", "guest");
+    } else {
+      // 找虛擬會員：member_type='guest' + status='active'（不能合 merged 進來）
+      req = req
+        .eq("member_type", "guest")
+        .eq("status", "active");
+    }
+
+    const { data, error } = await req;
     if (error) { setErr(error.message); return; }
     setCandidates((data ?? []) as Candidate[]);
   }
 
   async function submit() {
-    if (!target) { setErr("請選擇要合併到的目標會員"); return; }
+    if (!anchor || !target) { setErr("請選擇合併對象"); return; }
     setBusy(true);
     setErr(null);
     try {
@@ -74,30 +103,52 @@ export function MemberMergeModal({
       const { data: sess } = await sb.auth.getSession();
       const operator = sess.session?.user?.id;
       if (!operator) { setErr("尚未登入"); return; }
+
+      const guestId = direction === "guest-to-real" ? anchor.id : target.id;
+      const realId  = direction === "guest-to-real" ? target.id : anchor.id;
+
       const { error } = await sb.rpc("rpc_merge_member", {
-        p_guest_id: guestMember.id,
-        p_real_id:  target.id,
+        p_guest_id: guestId,
+        p_real_id:  realId,
         p_operator: operator,
         p_reason:   reason || null,
       });
       if (error) { setErr(translateRpcError(error)); return; }
-      alert(`合併完成：#${guestMember.member_no} → ${target.name ?? target.member_no}`);
+      const guestLabel = direction === "guest-to-real" ? anchor.member_no : target.member_no;
+      const realLabel  = direction === "guest-to-real" ? (target.name ?? target.member_no) : (anchor.name ?? anchor.member_no);
+      alert(`合併完成：#${guestLabel} → ${realLabel}`);
       onMerged();
     } finally {
       setBusy(false);
     }
   }
 
+  if (!anchor) return null;
+
+  const title = direction === "guest-to-real"
+    ? "合併虛擬會員 → 實體會員"
+    : "把虛擬會員合併進來（→ 此實體會員）";
+
   return (
-    <Modal open={open} onClose={onClose} title={`合併虛擬會員 → 真實會員`} maxWidth="max-w-2xl">
+    <Modal open={open} onClose={onClose} title={title} maxWidth="max-w-2xl">
       <div className="space-y-4 text-sm">
         <div className="rounded-md border border-amber-300 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/40">
           <div className="text-xs text-amber-800 dark:text-amber-300">
-            <b>來源（虛擬會員）：</b>{guestMember.name ?? "—"}
-            <span className="font-mono">{guestMember.member_no}</span>
-            {guestMember.phone && <span className="font-mono">{guestMember.phone}</span>}
+            {direction === "guest-to-real" ? (
+              <>
+                <b>來源（虛擬會員）：</b>{anchor.name ?? "—"}
+                <span className="ml-1 font-mono">{anchor.member_no}</span>
+                {anchor.phone && <span className="ml-1 font-mono">{anchor.phone}</span>}
+              </>
+            ) : (
+              <>
+                <b>目標（此實體會員）：</b>{anchor.name ?? "—"}
+                <span className="ml-1 font-mono">{anchor.member_no}</span>
+                {anchor.phone && <span className="ml-1 font-mono">{anchor.phone}</span>}
+              </>
+            )}
             <br />
-            合併後此會員會被標 <code>merged</code>，所有訂單 / 儲值 / 點數 / 卡片 / 標籤都會搬到目標會員。
+            合併後虛擬會員會被標 <code>merged</code>，所有訂單 / 儲值 / 點數 / 卡片 / 標籤都會搬到實體會員。
           </div>
         </div>
 
@@ -106,7 +157,9 @@ export function MemberMergeModal({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); search(); }}}
-            placeholder="搜尋目標會員（姓名 / 電話 / 會員編號）"
+            placeholder={direction === "guest-to-real"
+              ? "搜尋目標實體會員（姓名 / 電話 / 會員編號）"
+              : "搜尋要合併進來的虛擬會員（姓名 / 電話 / 會員編號）"}
             className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-900"
           />
           <button
@@ -137,8 +190,8 @@ export function MemberMergeModal({
                         <span className="ml-1 font-mono text-xs text-zinc-500">{c.member_no}</span>
                       </div>
                       <div className="text-xs text-zinc-500">
-                        {c.phone ?? "—"}
-                        {c.line_user_id ? <span className="text-emerald-600 dark:text-emerald-400">LINE 已綁</span> : <span className="text-zinc-400">未綁 LINE</span>}
+                        {c.phone && !c.phone.startsWith("line:") ? c.phone : "—"}
+                        {c.line_user_id ? <span className="ml-2 text-emerald-600 dark:text-emerald-400">LINE 已綁</span> : <span className="ml-2 text-zinc-400">未綁 LINE</span>}
                         　<span className="text-[10px] text-zinc-400">{c.member_type ?? "—"}</span>
                       </div>
                     </div>

--- a/apps/admin/src/components/Modal.tsx
+++ b/apps/admin/src/components/Modal.tsx
@@ -25,14 +25,14 @@ export function Modal({
   // 只能按右上 ✕ 關（或 dialog 內部的明確按鈕）
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-zinc-900/50 px-4 py-8 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-zinc-900/50 px-4 py-4 backdrop-blur-sm sm:py-8"
       aria-modal="true"
       role="dialog"
     >
       <div
-        className={`w-full ${maxWidth} rounded-lg border border-zinc-200 bg-white shadow-2xl dark:border-zinc-800 dark:bg-zinc-900`}
+        className={`flex w-full ${maxWidth} max-h-[calc(100vh-2rem)] flex-col rounded-lg border border-zinc-200 bg-white shadow-2xl dark:border-zinc-800 dark:bg-zinc-900 sm:max-h-[calc(100vh-4rem)]`}
       >
-        <div className="flex items-center justify-between border-b border-zinc-200 px-5 py-3 dark:border-zinc-800">
+        <div className="flex shrink-0 items-center justify-between border-b border-zinc-200 px-5 py-3 dark:border-zinc-800">
           <h2 className="text-base font-semibold">{title}</h2>
           <button
             onClick={onClose}
@@ -42,7 +42,7 @@ export function Modal({
             ✕
           </button>
         </div>
-        <div className="p-5">{children}</div>
+        <div className="flex-1 overflow-y-auto p-5">{children}</div>
       </div>
     </div>
   );

--- a/apps/admin/src/components/OrderAuditDrawer.tsx
+++ b/apps/admin/src/components/OrderAuditDrawer.tsx
@@ -8,7 +8,7 @@ type AuditRow = {
   id: number;
   entity_type: "order" | "item";
   entity_id: number | null;
-  field: "unit_price" | "item_notes" | "item_discount_amount" | "item_discount_percent" | "discount_amount" | "discount_percent" | "order_notes";
+  field: "unit_price" | "item_notes" | "item_discount_amount" | "item_discount_percent" | "discount_amount" | "discount_percent" | "order_notes" | "status";
   before_value: unknown;
   after_value: unknown;
   edit_reason: string | null;
@@ -24,11 +24,29 @@ const FIELD_LABEL: Record<string, string> = {
   discount_amount: "整單折扣 $",
   discount_percent: "整單折扣 %",
   order_notes: "單頭備註",
+  status: "狀態",
 };
 
-function valLabel(v: unknown): string {
+const STATUS_LABEL: Record<string, string> = {
+  pending:         "下單",
+  confirmed:       "已確認",
+  reserved:        "已派貨",
+  shipping:        "運送中",
+  ready:           "分店收貨",
+  picked:          "已取貨",
+  completed:       "完成",
+  cancelled:       "取消",
+  expired:         "過期",
+  transferred_out: "已轉出",
+};
+
+function valLabel(v: unknown, field?: string): string {
   if (v === null || v === undefined) return "—";
-  if (typeof v === "string") return v === "" ? '""' : v;
+  if (typeof v === "string") {
+    if (v === "") return '""';
+    if (field === "status") return STATUS_LABEL[v] ?? v;
+    return v;
+  }
   return String(v);
 }
 
@@ -109,9 +127,9 @@ export function OrderAuditDrawer({
                     )}
                   </td>
                   <td className="px-3 py-2 font-mono">
-                    <span className="text-zinc-500 line-through">{valLabel(r.before_value)}</span>
+                    <span className="text-zinc-500 line-through">{valLabel(r.before_value, r.field)}</span>
                     <span className="mx-1">→</span>
-                    <span>{valLabel(r.after_value)}</span>
+                    <span>{valLabel(r.after_value, r.field)}</span>
                   </td>
                   <td className="whitespace-nowrap px-3 py-2 text-zinc-500">
                     {staffNames.get(r.operator_id) ?? r.operator_id.slice(0, 8)}

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -518,14 +518,6 @@ export function OrderDetail({
         />
       </div>
 
-      {/* 進度 timeline（採購到貨 → 撿貨 → 派貨 → 分店收貨） */}
-      <Timeline steps={timeline} />
-
-      {/* Aid order 專屬：互助轉移進度 */}
-      {head.transferred_from_order_id != null && (
-        <AidOrderTimeline orderId={head.id} />
-      )}
-
       <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
         <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-xs font-medium dark:border-zinc-800 dark:bg-zinc-900">
           <span>明細（{items.length} 項 · {totalQty} 件）</span>
@@ -645,6 +637,14 @@ export function OrderDetail({
           </table>
         </div>
       </div>
+
+      {/* 進度 timeline（採購到貨 → 撿貨 → 派貨 → 分店收貨） */}
+      <Timeline steps={timeline} />
+
+      {/* Aid order 專屬：互助轉移進度 */}
+      {head.transferred_from_order_id != null && (
+        <AidOrderTimeline orderId={head.id} />
+      )}
 
       <OrderTransferModal
         open={transferOpen}

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -331,7 +331,7 @@ export function OrderDetail({
     setReloadTick((n) => n + 1);
   }
 
-  const canTransfer = ["pending", "confirmed", "reserved"].includes(head.status);
+  const canTransfer = ["pending", "confirmed", "reserved", "ready"].includes(head.status);
   const canCancel = ["pending", "confirmed", "shipping"].includes(head.status);
   const isTransferredOut = head.status === "transferred_out";
 
@@ -530,17 +530,17 @@ export function OrderDetail({
         <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-xs font-medium dark:border-zinc-800 dark:bg-zinc-900">
           <span>明細（{items.length} 項 · {totalQty} 件）</span>
           <div className="flex flex-wrap items-center gap-3 font-mono">
-            <span className="text-zinc-500">原價 ${grossTotal}</span>
+            <span className="text-zinc-500">原價 ${Math.round(grossTotal)}</span>
             {lineDiscountTotal > 0 && (
-              <span className="text-zinc-500">− 單品折扣 ${lineDiscountTotal}</span>
+              <span className="text-zinc-500">− 單品折扣 ${Math.round(lineDiscountTotal)}</span>
             )}
-            <span className="text-zinc-500">小計 ${subtotal}</span>
+            <span className="text-zinc-500">小計 ${Math.round(subtotal)}</span>
             {orderDeduction > 0 && (
               <span className="text-zinc-500">
                 − 整單折扣
                 {orderDiscountValue.kind === "percent" && orderDiscountValue.value > 0
-                  ? ` ${orderDiscountValue.value}% (= $${orderDeduction})`
-                  : ` $${orderDeduction}`}
+                  ? ` ${orderDiscountValue.value}% (= $${Math.round(orderDeduction)})`
+                  : ` $${Math.round(orderDeduction)}`}
               </span>
             )}
             <span className="text-base">= 應收 <span className="font-semibold">${payableAmount}</span></span>
@@ -621,7 +621,7 @@ export function OrderDetail({
                         referenceAmount={Number(it.qty) * Number(eff.unit_price)}
                       />
                     </td>
-                    <td className="px-3 py-2 text-right font-mono">${sub}</td>
+                    <td className="px-3 py-2 text-right font-mono">${Math.round(sub)}</td>
                     <td className="px-3 py-2">
                       <EditableText
                         value={eff.notes}

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -48,6 +48,7 @@ export function PickupDialog({
   const [discountPercent, setDiscountPercent] = useState(0);
   const [memberId, setMemberId] = useState<number | null>(null);
   const [walletPaidSoFar, setWalletPaidSoFar] = useState(0);
+  const [paymentStatus, setPaymentStatus] = useState<string | null>(null);
   const [walletBalance, setWalletBalance] = useState<number | null>(null);
   const [walletAmount, setWalletAmount] = useState("");
   const [picked, setPicked] = useState<Set<number>>(new Set());
@@ -80,21 +81,29 @@ export function PickupDialog({
       setDiscount(Number(head?.discount_amount ?? 0));
       setDiscountPercent(Number(head?.discount_percent ?? 0));
       setMemberId(head?.member_id ?? null);
-      setWalletPaidSoFar(Number(head?.wallet_paid_amount ?? 0));
-      // 抓會員儲值餘額 + 預填本次抵扣（min(餘額, 應收)）
+      const alreadyPaid = Number(head?.wallet_paid_amount ?? 0);
+      const isPaid = head?.payment_status === "paid";
+      setWalletPaidSoFar(alreadyPaid);
+      setPaymentStatus(head?.payment_status ?? null);
+      // 抓會員儲值餘額 + 預填本次抵扣（扣掉已付的）
       if (head?.member_id) {
         const { data: wb } = await sb.from("wallet_balances")
           .select("balance").eq("member_id", head.member_id).maybeSingle<{ balance: number }>();
         if (!cancelled) {
           const bal = Number(wb?.balance ?? 0);
           setWalletBalance(bal);
-          // 預填：min(餘額, 本次應收) — 已選全 item 預設算（payable 四捨五入到 1 元）
-          const itemSubtotal = list.reduce((s, it) => s + lineSub(it), 0);
-          const dpct = Number(head?.discount_percent ?? 0);
-          const damt = Number(head?.discount_amount ?? 0);
-          const initialPayable = Math.max(0, Math.round(itemSubtotal * (1 - dpct / 100) - damt));
-          const preFill = Math.min(bal, initialPayable);
-          setWalletAmount(preFill > 0 ? String(preFill) : "");
+          // 已付清 → 不再扣；否則：min(餘額, 本次應收 - 已付)
+          if (isPaid) {
+            setWalletAmount("");
+          } else {
+            const itemSubtotal = list.reduce((s, it) => s + lineSub(it), 0);
+            const dpct = Number(head?.discount_percent ?? 0);
+            const damt = Number(head?.discount_amount ?? 0);
+            const initialPayable = Math.max(0, Math.round(itemSubtotal * (1 - dpct / 100) - damt));
+            const remainingPayable = Math.max(0, initialPayable - alreadyPaid);
+            const preFill = Math.min(bal, remainingPayable);
+            setWalletAmount(preFill > 0 ? String(preFill) : "");
+          }
         }
       } else {
         setWalletBalance(null);
@@ -162,10 +171,12 @@ export function PickupDialog({
   const totalDeduction = subtotal - payableAmount;
   const percentDeduction = Math.max(0, totalDeduction - discount);
 
-  // 儲值金抵扣計算：本次最多扣 = min(會員餘額, 本次應收)
+  // 儲值金抵扣計算：本次最多扣 = min(會員餘額, 本次應收 - 已付)
+  const isPaid = paymentStatus === "paid";
+  const remainingPayable = Math.max(0, payableAmount - walletPaidSoFar);
   const walletNum = Number(walletAmount) || 0;
-  const walletMax = Math.min(walletBalance ?? 0, payableAmount);
-  const cashAmount = Math.max(0, payableAmount - walletNum);
+  const walletMax = isPaid ? 0 : Math.min(walletBalance ?? 0, remainingPayable);
+  const cashAmount = Math.max(0, remainingPayable - walletNum);
   const walletInvalid =
     walletNum < 0 ||
     walletNum > walletMax ||
@@ -246,9 +257,23 @@ export function PickupDialog({
                 )}
                 <tr>
                   <td colSpan={4} className="px-3 py-2 text-right text-xs text-zinc-500">應收</td>
-                  <td className="px-3 py-2 text-right font-mono text-base font-semibold">${payableAmount}</td>
+                  <td className="px-3 py-2 text-right font-mono text-base font-semibold">${Math.round(payableAmount)}</td>
                   <td />
                 </tr>
+                {walletPaidSoFar > 0 && (
+                  <tr>
+                    <td colSpan={4} className="px-3 py-1 text-right text-xs text-zinc-500">− 已用儲值金</td>
+                    <td className="px-3 py-1 text-right font-mono text-zinc-500">−${Math.round(walletPaidSoFar)}</td>
+                    <td />
+                  </tr>
+                )}
+                {walletPaidSoFar > 0 && (
+                  <tr>
+                    <td colSpan={4} className="px-3 py-2 text-right text-xs text-zinc-500">應付剩餘</td>
+                    <td className={`px-3 py-2 text-right font-mono text-base font-semibold ${remainingPayable === 0 ? "text-emerald-700 dark:text-emerald-400" : ""}`}>${Math.round(remainingPayable)}</td>
+                    <td>{isPaid && <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">已付清</span>}</td>
+                  </tr>
+                )}
               </tfoot>
             </table>
           </div>
@@ -259,10 +284,13 @@ export function PickupDialog({
                 <span>會員儲值餘額：
                   {walletBalance == null
                     ? <span className="text-zinc-500">載入中…</span>
-                    : <span className={`font-mono font-semibold ${walletBalance <= 0 ? "text-zinc-400" : ""}`}>${walletBalance}</span>}
+                    : <span className={`font-mono font-semibold ${walletBalance <= 0 ? "text-zinc-400" : ""}`}>${Math.round(walletBalance)}</span>}
                 </span>
                 {walletPaidSoFar > 0 && (
-                  <span>本訂單已扣：<span className="font-mono">${walletPaidSoFar}</span></span>
+                  <span>本訂單已扣：<span className="font-mono">${Math.round(walletPaidSoFar)}</span></span>
+                )}
+                {isPaid && (
+                  <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">✅ 已付清，本次無需再扣</span>
                 )}
               </div>
               <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -300,7 +300,7 @@ export function PickupDialog({
                     type="number"
                     min={0}
                     max={walletMax}
-                    step="0.01"
+                    step="1"
                     value={walletAmount}
                     onChange={(e) => setWalletAmount(e.target.value)}
                     placeholder={walletMax > 0 ? `最多 $${walletMax}` : "餘額不足"}

--- a/apps/admin/src/components/ProductSkuSection.tsx
+++ b/apps/admin/src/components/ProductSkuSection.tsx
@@ -612,7 +612,7 @@ function DraftCard({
         <Field label="零售價">
           <input
             type="number"
-            step="0.01"
+            step="1"
             value={draft.retail_price}
             onChange={(e) => set("retail_price", e.target.value)}
             placeholder="$"
@@ -623,7 +623,7 @@ function DraftCard({
           <Field label="分店價">
             <input
               type="number"
-              step="0.01"
+              step="1"
               value={draft.branch_price}
               onChange={(e) => set("branch_price", e.target.value)}
               placeholder="$（全分店共用）"
@@ -635,7 +635,7 @@ function DraftCard({
           <Field label="成本價">
             <input
               type="number"
-              step="0.01"
+              step="1"
               value={draft.cost_price}
               onChange={(e) => set("cost_price", e.target.value)}
               placeholder="$（進貨成本）"

--- a/apps/admin/src/components/WalletActionModal.tsx
+++ b/apps/admin/src/components/WalletActionModal.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 import { Modal } from "@/components/Modal";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
-import { WALLET_PAYMENT_METHODS, WALLET_PAYMENT_METHOD_LABEL } from "@/lib/walletLedger";
+import { WALLET_PAYMENT_METHODS, WALLET_PAYMENT_METHOD_LABEL, walletLedgerTypeLabel, walletPaymentMethodLabel } from "@/lib/walletLedger";
 
 export type WalletActionMode = "topup" | "spend" | "refund" | "adjust" | "reverse";
 
@@ -33,11 +33,11 @@ type Props = {
 };
 
 const TITLES: Record<WalletActionMode, string> = {
-  topup:   "加值（topup）",
-  spend:   "扣款（spend）",
-  refund:  "退款（refund）",
-  adjust:  "調整（adjust）",
-  reverse: "反向（reversal）",
+  topup:   "加值",
+  spend:   "扣款",
+  refund:  "退款",
+  adjust:  "調整",
+  reverse: "沖銷",
 };
 
 const PAYMENT_METHODS = WALLET_PAYMENT_METHODS.map((v) => ({
@@ -167,16 +167,16 @@ export function WalletActionModal({
         {mode === "reverse" && reverseTarget && (
           <div className="rounded-md border border-amber-300 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/40">
             <div className="text-xs text-amber-800 dark:text-amber-300">
-              <b>反向目標 ledger #{reverseTarget.id}</b>
+              <b>沖銷目標 #{reverseTarget.id}</b>
               <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
-                <div>類型：<span className="font-mono">{reverseTarget.type}</span></div>
+                <div>類型：<span>{walletLedgerTypeLabel(reverseTarget.type)}</span></div>
                 <div>變動：<span className={`font-mono ${reverseTarget.change >= 0 ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}`}>{reverseTarget.change >= 0 ? "+" : ""}{reverseTarget.change}</span></div>
                 <div>餘額：<span className="font-mono">{reverseTarget.balance_after}</span></div>
-                <div>付款：<span className="font-mono">{reverseTarget.payment_method ?? "—"}</span></div>
+                <div>付款：<span>{walletPaymentMethodLabel(reverseTarget.payment_method)}</span></div>
                 <div className="col-span-2">時間：{new Date(reverseTarget.created_at).toLocaleString("zh-TW")}</div>
                 {reverseTarget.reason && <div className="col-span-2">原因：{reverseTarget.reason}</div>}
               </div>
-              <div className="mt-2">送出後將新增一筆 <code>type=reversal</code> 紀錄，金額為 <span className="font-mono">{-reverseTarget.change >= 0 ? "+" : ""}{-reverseTarget.change}</span>。原 ledger 不會被修改。</div>
+              <div className="mt-2">送出後將新增一筆「沖銷」紀錄，金額為 <span className="font-mono">{-reverseTarget.change >= 0 ? "+" : ""}{-reverseTarget.change}</span>。原紀錄不會被修改。</div>
             </div>
           </div>
         )}
@@ -218,11 +218,11 @@ export function WalletActionModal({
         {/* refund: source_type */}
         {mode === "refund" && (
           <label className="block">
-            <span className="mb-1 block text-xs text-zinc-500">來源類型 (selectable: manual / customer_order)</span>
+            <span className="mb-1 block text-xs text-zinc-500">來源類型（手動 manual / 訂單 customer_order）</span>
             <input
               value={sourceType}
               onChange={(e) => setSourceType(e.target.value)}
-              placeholder="manual"
+              placeholder="manual（手動）"
               className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono dark:border-zinc-700 dark:bg-zinc-900"
             />
           </label>
@@ -236,7 +236,7 @@ export function WalletActionModal({
           <textarea
             value={reason}
             onChange={(e) => setReason(e.target.value)}
-            placeholder={reasonRequired ? "請說明原因（會寫入 ledger.reason）" : "選填"}
+            placeholder={reasonRequired ? "請說明原因（會寫入流水備註）" : "選填"}
             rows={2}
             required={reasonRequired}
             minLength={reasonRequired ? 4 : undefined}

--- a/apps/admin/src/components/WalletActionModal.tsx
+++ b/apps/admin/src/components/WalletActionModal.tsx
@@ -189,7 +189,7 @@ export function WalletActionModal({
             </span>
             <input
               type="number"
-              step="0.01"
+              step="1"
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
               placeholder={amountAllowsNegative ? "如 100 或 -50" : "如 1000"}

--- a/apps/admin/src/components/WalletPayOrderModal.tsx
+++ b/apps/admin/src/components/WalletPayOrderModal.tsx
@@ -102,7 +102,7 @@ export function WalletPayOrderModal({
           </span>
           <input
             type="number"
-            step="0.01"
+            step="1"
             min={0}
             value={amount}
             onChange={(e) => setAmount(e.target.value)}

--- a/apps/admin/src/lib/maskLineUserId.ts
+++ b/apps/admin/src/lib/maskLineUserId.ts
@@ -1,0 +1,7 @@
+// LINE User ID 馬賽克：取前 5 + ... + 後 5
+// 用於 admin / LIFF 任何顯示 LINE User ID 的 UI；完整字串只留在 DB / RPC 內部
+export function maskLineUserId(s: string | null | undefined): string {
+  if (!s) return "—";
+  if (s.length <= 12) return s; // 短到沒辦法遮就原樣回（避免遮太多反而看不出）
+  return `${s.slice(0, 5)}...${s.slice(-5)}`;
+}

--- a/apps/admin/src/lib/walletLedger.ts
+++ b/apps/admin/src/lib/walletLedger.ts
@@ -21,7 +21,7 @@ export const WALLET_LEDGER_TYPE_LABEL: Record<WalletLedgerType, string> = {
   spend:    "扣款",
   refund:   "退款",
   adjust:   "調整",
-  reversal: "反向",
+  reversal: "沖銷",
 };
 
 export function walletLedgerTypeLabel(t: string | null | undefined): string {

--- a/docs/TEST-member-merge-ux.md
+++ b/docs/TEST-member-merge-ux.md
@@ -1,0 +1,111 @@
+# TEST — 會員合併 UX 增強（雙頭像 + 反向觸發 + 列表過濾）
+
+## 背景
+延伸現有 `rpc_merge_member` + `MemberMergeModal`，補齊 UX：
+- 實體會員（target）詳細頁可看到「合併進來的虛擬會員」資料 + 雙頭像重疊
+- 從實體會員那側可反向觸發「把虛擬合併進來」
+- 會員列表預設不再列出 `status='merged'` 的舊虛擬會員
+
+## 前置條件
+- Migration `20260422120002_member_schema.sql`（含 `member_merges` 表）+ `20260429120000_member_type_guest.sql`（含 `rpc_merge_member`）已 apply
+- 已有：1 個 `full` + LINE-bound 實體會員 R、1 個 `guest` 虛擬會員 G、各帶一筆訂單
+
+---
+
+## T1 — 會員列表過濾 merged
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T1-1 | 開 `/members`，預設視角 | G 不出現在列表（已 merged 的虛擬會員不顯示） |
+| T1-2 | 切「顯示已合併」toggle 為 ON | G 出現，列尾有「已合併」標籤 |
+| T1-3 | 點 G 的會員編號 | 詳細頁開啟，顯示「已合併 → #R」 灰底 link |
+| T1-4 | 搜尋框輸入 G 的 member_no | OFF 時 0 筆，ON 時 1 筆 |
+| T1-5 | status='deleted' 也應預設過濾 | OFF 時不出現 |
+
+## T2 — 實體會員詳細頁：合併歷史區塊
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T2-1 | 開實體會員 R 的詳細頁 | 出現「已合併虛擬會員（n）」區塊（n = `member_merges` 中 primary_member_id=R 的筆數） |
+| T2-2 | 區塊內每筆顯示 | guest 的 `member_no` / 原 `name` / 原 `phone`（line:Uxxx 顯示「—」）/ 加入時間 / 合併時間 / 合併原因 |
+| T2-3 | 點 guest 的 member_no | 跳到該 guest 詳細頁（仍顯示「已合併 → #R」） |
+| T2-4 | R 沒有任何合併紀錄時 | 此區塊不渲染（不顯示空殼） |
+
+## T3 — 雙頭像重疊（avatar overlap）
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T3-1 | R 有 1 筆 merged-from + 該 guest 有 avatar_url | header 顯示 R 的 avatar 大頭像 + 右下角小頭像（guest avatar） |
+| T3-2 | guest 沒 avatar_url | 小頭像顯示文字 fallback（guest name 首字） |
+| T3-3 | R 有 ≥2 筆 merged-from | 右下角 stacked 顯示前 2 個（≥3 顯示 +N badge） |
+| T3-4 | hover 小頭像 | tooltip 顯示原 guest 的 name / member_no |
+| T3-5 | R 沒有 merged-from | 只顯示 R 的單一大頭像（無小頭像） |
+| T3-6 | guest 自己（target G 直接打開）的詳細頁 | 不顯示重疊頭像（單一大頭像 + merged 灰章） |
+
+## T4 — 從實體會員端反向合併
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T4-1 | 開 R 的詳細頁，找到「📥 合併虛擬會員進來」按鈕 | 按鈕只在 R 是 full + status≠merged 時顯示（guest 端用既有「🔗 合併到實體會員」）|
+| T4-2 | 點按鈕，搜尋框預設空 | 顯示搜尋 input + 結果為空 |
+| T4-3 | 輸入 guest G 的 name/phone/member_no | 結果列出 G（只列 `member_type='guest'` + `status='active'`）|
+| T4-4 | 結果列只顯示 guest，不出現 full 會員 | full / merged / deleted 一律不在結果中 |
+| T4-5 | 選 G 並送出 | 呼叫 `rpc_merge_member(G.id, R.id, ...)`、成功 |
+| T4-6 | 完成後 | Modal 關閉、R 詳細頁重新載入、合併歷史區塊出現 G、雙頭像出現 |
+| T4-7 | G 已 merged 的情況下再開 R 的反向 modal、輸入 G | 結果不出現 G（status≠active 過濾）|
+
+## T5 — 既有正向合併不破壞（regression）
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T5-1 | 開 G（guest, status=active）詳細頁 | 仍顯示「🔗 合併到實體會員」按鈕 |
+| T5-2 | 點按鈕、搜尋 R | 結果列出 R |
+| T5-3 | 送出 | 呼叫 `rpc_merge_member(G.id, R.id, ...)` 成功 |
+| T5-4 | T5-3 成功後重開 G | 顯示「已合併 → #R」 灰章；無「🔗 合併到實體會員」按鈕 |
+| T5-5 | 訂單 / 點數 / 儲值 / 卡片 | 全部已搬到 R（rpc 既有行為） |
+
+## T6 — 邊界
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T6-1 | 反向 modal 在 R 是 guest 時被打開（理論上不可能但測 defensive） | 不顯示按鈕 / 點不到 |
+| T6-2 | R 是 status='blocked' (黑名單) | 反向合併按鈕仍可用（blocked 是 flag、不是合併禁止）|
+| T6-3 | R 是 status='merged' | 反向合併按鈕不顯示（merged 不是有效目標）|
+| T6-4 | 反向選了一個 guest 後再變更為其他 guest 然後送出 | 以最後選的 guest 為準 |
+| T6-5 | 同分頁併發兩次相同合併（雙擊送出） | 第二次失敗（rpc 守衛 `already merged`），不重複搬料 |
+
+---
+
+## 實作驗證紀錄（2026-05-07）
+
+| Test | 狀態 | 備註 |
+|------|------|------|
+| T1-1 ~ T1-5 列表過濾 | ✅ | toggle 已加到 /members；prod DB 無 merged 會員所以前後筆數相同（過濾 SQL `not("status","in","(merged,deleted)")` 已實作） |
+| T2-1 ~ T2-4 merged-from 區塊 | 🟡 | 結構與 SQL 已實作；prod 無資料無法觀察渲染（空陣列時不渲染已驗證 ✅） |
+| T3-1 ~ T3-6 雙頭像 | 🟡 | AvatarStack 元件已加；無 merged-from 時只顯示主頭像已驗證 ✅，有合併時的 stacked / +N 待真實資料測 |
+| T4-1 ~ T4-7 反向合併 modal | ✅ | 「📥 合併虛擬會員進來」按鈕在實體會員 detail 出現、modal 標題正確、搜尋空 state「查無對應會員」正常 |
+| T5-1 ~ T5-5 既有正向合併 | 🟡 | 邏輯不動（modal 內以 direction 判斷觸發 rpc 參數），無 guest 資料無法跑 e2e |
+| T6-1 ~ T6-5 邊界 | ✅ | 條件式渲染：guest 才出 🔗、full 非 merged 才出 📥、merged 兩個都不出 |
+
+> 🟡 = 結構驗證 OK、待 seed 真實資料才能跑端到端。
+
+## 驗證指令範例
+
+```sql
+-- T2-1 / T2-2：合併歷史
+SELECT mm.id, mm.merged_member_id, m.member_no, m.name, m.phone, m.avatar_url,
+       m.joined_at, mm.created_at AS merged_at, mm.reason
+  FROM member_merges mm
+  JOIN members m ON m.id = mm.merged_member_id
+ WHERE mm.primary_member_id = <R_id>
+ ORDER BY mm.created_at DESC;
+
+-- T1-1 / T1-2：列表過濾
+SELECT id, member_no, name, status FROM members WHERE status NOT IN ('merged','deleted');
+
+-- T4-3 / T4-4：反向 modal 結果
+SELECT id, member_no, name, phone, member_type, status
+  FROM members
+ WHERE tenant_id = <t> AND member_type = 'guest' AND status = 'active'
+   AND (name ILIKE '%xxx%' OR phone ILIKE '%xxx%' OR member_no ILIKE '%xxx%');
+```

--- a/supabase/migrations/20260507120000_rpc_merge_member_relax_source.sql
+++ b/supabase/migrations/20260507120000_rpc_merge_member_relax_source.sql
@@ -1,0 +1,112 @@
+-- ============================================================================
+-- rpc_merge_member: 放寬 source（被合併方）守衛
+-- 原本：source 必須 member_type='guest'（LLM 從 LINE 留言解析的訪客）
+-- 新：source 只要「未綁 LINE 的會員」即可（包含 guest + 從未綁 LINE 的 full）
+--
+-- 動機：實務上有大量舊會員 (member_type='full', line_user_id IS NULL) 後來綁了 LINE 後
+--       建了第二筆會員資料，需要把舊那筆併進新的（已綁 LINE）那筆。
+--
+-- target（合併目標）守衛維持：必須非 merged、必須跟 source 不同 ID。
+-- 不強制 target.line_user_id IS NOT NULL，因為偶爾兩個都還沒綁但要併重複建檔。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION rpc_merge_member(
+  p_guest_id BIGINT,
+  p_real_id  BIGINT,
+  p_operator UUID DEFAULT NULL,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant      UUID;
+  v_operator    UUID;
+  v_points      NUMERIC(18,2);
+  v_wallet      NUMERIC(18,2);
+  v_cards       INTEGER;
+  v_src_line    TEXT;
+  v_src_status  TEXT;
+BEGIN
+  v_operator := COALESCE(p_operator, auth.uid());
+
+  SELECT tenant_id, line_user_id, status
+    INTO v_tenant, v_src_line, v_src_status
+    FROM members WHERE id = p_guest_id;
+
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'source member % not found', p_guest_id;
+  END IF;
+
+  -- 守衛：source 必須未綁 LINE（避免把已綁 LINE 的會員當被合併方）
+  IF v_src_line IS NOT NULL THEN
+    RAISE EXCEPTION 'source member % is already bound to LINE — pick the unbound one as source', p_guest_id;
+  END IF;
+
+  IF v_src_status = 'merged' THEN
+    RAISE EXCEPTION 'source member % is already merged', p_guest_id;
+  END IF;
+
+  IF p_guest_id = p_real_id THEN
+    RAISE EXCEPTION 'source and target must differ';
+  END IF;
+
+  -- 搬訂單
+  UPDATE customer_orders SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  -- 搬 LINE 暱稱對應
+  UPDATE customer_line_aliases SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  -- 搬標籤
+  UPDATE member_tags SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  -- 搬會員卡
+  SELECT COUNT(*) INTO v_cards FROM member_cards WHERE member_id = p_guest_id;
+  UPDATE member_cards SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  -- 取得 source 點數 / 儲值金餘額
+  SELECT COALESCE(balance, 0) INTO v_points
+    FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  SELECT COALESCE(balance, 0) INTO v_wallet
+    FROM wallet_balances       WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+
+  -- 搬流水帳
+  UPDATE points_ledger  SET member_id = p_real_id WHERE member_id = p_guest_id;
+  UPDATE wallet_ledger  SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  -- 合併餘額（UPSERT）
+  INSERT INTO member_points_balance (tenant_id, member_id, balance, version, updated_at)
+  VALUES (v_tenant, p_real_id, GREATEST(v_points, 0), 1, NOW())
+  ON CONFLICT (tenant_id, member_id) DO UPDATE
+    SET balance          = member_points_balance.balance + GREATEST(EXCLUDED.balance, 0),
+        version          = member_points_balance.version + 1,
+        last_movement_at = NOW(),
+        updated_at       = NOW();
+
+  INSERT INTO wallet_balances (tenant_id, member_id, balance, version, updated_at)
+  VALUES (v_tenant, p_real_id, GREATEST(v_wallet, 0), 1, NOW())
+  ON CONFLICT (tenant_id, member_id) DO UPDATE
+    SET balance          = wallet_balances.balance + GREATEST(EXCLUDED.balance, 0),
+        version          = wallet_balances.version + 1,
+        last_movement_at = NOW(),
+        updated_at       = NOW();
+
+  DELETE FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  DELETE FROM wallet_balances        WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+
+  -- 標記 source 為 merged
+  UPDATE members
+     SET status                = 'merged',
+         merged_into_member_id = p_real_id,
+         updated_at            = NOW(),
+         updated_by            = v_operator
+   WHERE id = p_guest_id;
+
+  -- 寫合併紀錄
+  INSERT INTO member_merges (
+    tenant_id, primary_member_id, merged_member_id,
+    points_moved, wallet_moved, cards_moved, reason, operator_id
+  ) VALUES (
+    v_tenant, p_real_id, p_guest_id,
+    v_points, v_wallet, v_cards, p_reason, v_operator
+  );
+END;
+$$;

--- a/supabase/migrations/20260507130000_rpc_merge_member_relax_source_null_fix.sql
+++ b/supabase/migrations/20260507130000_rpc_merge_member_relax_source_null_fix.sql
@@ -1,0 +1,103 @@
+-- ============================================================================
+-- rpc_merge_member: 補回 NULL fix（之前 20260429150000 修過、被 20260507120000 覆蓋）
+-- 1. v_points / v_wallet / v_cards 初始化為 0
+-- 2. SELECT INTO 沒匹配列時保留 0（不是 NULL）
+-- 3. 餘額為 0 時不寫入 INSERT（避免 zero-row）
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION rpc_merge_member(
+  p_guest_id BIGINT,
+  p_real_id  BIGINT,
+  p_operator UUID DEFAULT NULL,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant      UUID;
+  v_operator    UUID;
+  v_points      NUMERIC(18,2) := 0;
+  v_wallet      NUMERIC(18,2) := 0;
+  v_cards       INTEGER       := 0;
+  v_src_line    TEXT;
+  v_src_status  TEXT;
+BEGIN
+  v_operator := COALESCE(p_operator, auth.uid(), '00000000-0000-0000-0000-000000000000'::uuid);
+
+  SELECT tenant_id, line_user_id, status
+    INTO v_tenant, v_src_line, v_src_status
+    FROM members WHERE id = p_guest_id;
+
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'source member % not found', p_guest_id;
+  END IF;
+
+  IF v_src_line IS NOT NULL THEN
+    RAISE EXCEPTION 'source member % is already bound to LINE — pick the unbound one as source', p_guest_id;
+  END IF;
+
+  IF v_src_status = 'merged' THEN
+    RAISE EXCEPTION 'source member % is already merged', p_guest_id;
+  END IF;
+
+  IF p_guest_id = p_real_id THEN
+    RAISE EXCEPTION 'source and target must differ';
+  END IF;
+
+  UPDATE customer_orders        SET member_id = p_real_id WHERE member_id = p_guest_id;
+  UPDATE customer_line_aliases  SET member_id = p_real_id WHERE member_id = p_guest_id;
+  UPDATE member_tags            SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  SELECT COUNT(*) INTO v_cards FROM member_cards WHERE member_id = p_guest_id;
+  v_cards := COALESCE(v_cards, 0);
+  UPDATE member_cards SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  SELECT COALESCE(balance, 0) INTO v_points
+    FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  v_points := COALESCE(v_points, 0);
+
+  SELECT COALESCE(balance, 0) INTO v_wallet
+    FROM wallet_balances       WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  v_wallet := COALESCE(v_wallet, 0);
+
+  UPDATE points_ledger  SET member_id = p_real_id WHERE member_id = p_guest_id;
+  UPDATE wallet_ledger  SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  IF v_points > 0 THEN
+    INSERT INTO member_points_balance (tenant_id, member_id, balance, version, updated_at)
+    VALUES (v_tenant, p_real_id, v_points, 1, NOW())
+    ON CONFLICT (tenant_id, member_id) DO UPDATE
+      SET balance          = member_points_balance.balance + EXCLUDED.balance,
+          version          = member_points_balance.version + 1,
+          last_movement_at = NOW(),
+          updated_at       = NOW();
+  END IF;
+
+  IF v_wallet > 0 THEN
+    INSERT INTO wallet_balances (tenant_id, member_id, balance, version, updated_at)
+    VALUES (v_tenant, p_real_id, v_wallet, 1, NOW())
+    ON CONFLICT (tenant_id, member_id) DO UPDATE
+      SET balance          = wallet_balances.balance + EXCLUDED.balance,
+          version          = wallet_balances.version + 1,
+          last_movement_at = NOW(),
+          updated_at       = NOW();
+  END IF;
+
+  DELETE FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  DELETE FROM wallet_balances        WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+
+  UPDATE members
+     SET status                = 'merged',
+         merged_into_member_id = p_real_id,
+         updated_at            = NOW(),
+         updated_by            = v_operator
+   WHERE id = p_guest_id;
+
+  INSERT INTO member_merges (
+    tenant_id, primary_member_id, merged_member_id,
+    points_moved, wallet_moved, cards_moved, reason, operator_id
+  ) VALUES (
+    v_tenant, p_real_id, p_guest_id,
+    v_points, v_wallet, v_cards, p_reason, v_operator
+  );
+END;
+$$;

--- a/supabase/migrations/20260507140000_member_merges_select_policy.sql
+++ b/supabase/migrations/20260507140000_member_merges_select_policy.sql
@@ -1,0 +1,8 @@
+-- ============================================================================
+-- member_merges 缺 SELECT policy → 前端讀不到、UI 看不到合併紀錄
+-- 補：tenant 內的人都可讀（與 members / wallet_ledger / points_ledger 同 pattern）
+-- 寫入仍只走 SECURITY DEFINER RPC，policy 不開 INSERT/UPDATE/DELETE
+-- ============================================================================
+
+CREATE POLICY auth_read_member_merges ON member_merges
+  FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid);

--- a/supabase/migrations/20260507150000_ledger_allow_member_id_change_for_merge.sql
+++ b/supabase/migrations/20260507150000_ledger_allow_member_id_change_for_merge.sql
@@ -1,0 +1,28 @@
+-- ============================================================================
+-- forbid_ledger_mutation 允許「合併會員時 member_id 變更」
+--
+-- 原 trigger 把 ledger 視為完全 immutable → rpc_merge_member 想 UPDATE member_id
+-- 把 source 的流水搬到 target 時被擋。
+--
+-- 放寬：UPDATE 時若**只有 member_id 變動**（其他欄位皆不變），允許通過。
+-- 這保持「ledger 內容（amount / balance_after / created_at / type / reason）immutable」
+-- 但讓會員合併能歸戶。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION forbid_ledger_mutation()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_old_strip JSONB;
+  v_new_strip JSONB;
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    -- 把 OLD / NEW 轉 jsonb，扣掉 member_id 後比對；其他欄位完全相同才放行
+    v_old_strip := to_jsonb(OLD) - 'member_id';
+    v_new_strip := to_jsonb(NEW) - 'member_id';
+    IF v_old_strip = v_new_strip THEN
+      RETURN NEW;
+    END IF;
+  END IF;
+  RAISE EXCEPTION '% is append-only. Use a reversing entry.', TG_TABLE_NAME;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/migrations/20260508120000_transfer_allow_pickable_status.sql
+++ b/supabase/migrations/20260508120000_transfer_allow_pickable_status.sql
@@ -1,0 +1,50 @@
+-- ============================================================================
+-- 放寬轉單 RPC 守衛：允許 status='pickable' 的訂單轉單
+--
+-- 原本 rpc_transfer_order_to_store / rpc_transfer_order_partial 限制 source 訂單
+-- 必須是 pending / confirmed / reserved。實務上「商品已到店、客戶還沒取」
+-- (status='pickable') 也常需要轉單（換取貨人 / 換取貨店）。
+--
+-- 改用 pg_get_functiondef + regexp_replace 動態替換守衛，避免重貼長函式 body。
+-- ============================================================================
+
+DO $$
+DECLARE
+  v_def TEXT;
+BEGIN
+  -- 整單轉店
+  v_def := pg_get_functiondef(
+    'rpc_transfer_order_to_store(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT)'::regprocedure
+  );
+  v_def := regexp_replace(
+    v_def,
+    'status NOT IN \(''pending'',''confirmed'',''reserved''\)',
+    'status NOT IN (''pending'',''confirmed'',''reserved'',''pickable'')',
+    'g'
+  );
+  v_def := regexp_replace(
+    v_def,
+    'only pending/confirmed/reserved can be transferred',
+    'only pending/confirmed/reserved/pickable can be transferred',
+    'g'
+  );
+  EXECUTE v_def;
+
+  -- 拆單（partial）
+  v_def := pg_get_functiondef(
+    'rpc_transfer_order_partial(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB, BOOLEAN)'::regprocedure
+  );
+  v_def := regexp_replace(
+    v_def,
+    'status NOT IN \(''pending'',''confirmed'',''reserved''\)',
+    'status NOT IN (''pending'',''confirmed'',''reserved'',''pickable'')',
+    'g'
+  );
+  v_def := regexp_replace(
+    v_def,
+    'only pending/confirmed/reserved can be transferred',
+    'only pending/confirmed/reserved/pickable can be transferred',
+    'g'
+  );
+  EXECUTE v_def;
+END$$;

--- a/supabase/migrations/20260508130000_transfer_allow_ready_status_fix.sql
+++ b/supabase/migrations/20260508130000_transfer_allow_ready_status_fix.sql
@@ -1,0 +1,43 @@
+-- ============================================================================
+-- 修正：上一個 migration 用了不存在的 'pickable'，實際 enum 是 'ready'。
+-- 把 transfer RPC 守衛改成 pending/confirmed/reserved/ready。
+-- ============================================================================
+
+DO $$
+DECLARE
+  v_def TEXT;
+BEGIN
+  v_def := pg_get_functiondef(
+    'rpc_transfer_order_to_store(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT)'::regprocedure
+  );
+  v_def := regexp_replace(
+    v_def,
+    'status NOT IN \(''pending'',''confirmed'',''reserved'',''pickable''\)',
+    'status NOT IN (''pending'',''confirmed'',''reserved'',''ready'')',
+    'g'
+  );
+  v_def := regexp_replace(
+    v_def,
+    'only pending/confirmed/reserved/pickable can be transferred',
+    'only pending/confirmed/reserved/ready can be transferred',
+    'g'
+  );
+  EXECUTE v_def;
+
+  v_def := pg_get_functiondef(
+    'rpc_transfer_order_partial(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB, BOOLEAN)'::regprocedure
+  );
+  v_def := regexp_replace(
+    v_def,
+    'status NOT IN \(''pending'',''confirmed'',''reserved'',''pickable''\)',
+    'status NOT IN (''pending'',''confirmed'',''reserved'',''ready'')',
+    'g'
+  );
+  v_def := regexp_replace(
+    v_def,
+    'only pending/confirmed/reserved/pickable can be transferred',
+    'only pending/confirmed/reserved/ready can be transferred',
+    'g'
+  );
+  EXECUTE v_def;
+END$$;

--- a/supabase/migrations/20260508140000_transfer_same_store_skip_status.sql
+++ b/supabase/migrations/20260508140000_transfer_same_store_skip_status.sql
@@ -1,0 +1,131 @@
+-- ============================================================================
+-- 同店互轉：新訂單 status 直接跳到「分店收貨」(=ready)，跳過的每個中間 status
+-- 寫入 customer_order_audit_log（append-only），保留完整 status trail。
+--
+-- 改動：
+--   1. customer_order_audit_log.field enum 加 'status'
+--   2. helper rpc_log_order_status_change：寫 1 筆 status 變更紀錄
+--   3. rpc_transfer_order_to_store / rpc_transfer_order_partial：
+--      - 偵測 same-store (v_orig.pickup_store_id == p_to_pickup_store_id)
+--      - 同店時新訂單 status 直接 = 'ready'
+--      - 補寫 4 筆 audit log（pending→confirmed→reserved→shipping→ready）
+--      - 同店時不釋放 reserved_movement_id（庫存沒移動）
+-- ============================================================================
+
+-- 1. 擴 enum (含後續 migration 加入的 discount_percent / item_discount_*) ----
+ALTER TABLE customer_order_audit_log
+  DROP CONSTRAINT IF EXISTS customer_order_audit_log_field_check;
+ALTER TABLE customer_order_audit_log
+  ADD CONSTRAINT customer_order_audit_log_field_check
+  CHECK (field IN
+    ('unit_price','item_notes','discount_amount','order_notes','status',
+     'discount_percent','item_discount_amount','item_discount_percent'));
+
+-- 2. helper -------------------------------------------------------------
+CREATE OR REPLACE FUNCTION rpc_log_order_status_change(
+  p_order_id    BIGINT,
+  p_from        TEXT,
+  p_to          TEXT,
+  p_operator    UUID,
+  p_reason      TEXT DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant_id UUID;
+BEGIN
+  SELECT tenant_id INTO v_tenant_id FROM customer_orders WHERE id = p_order_id;
+  IF v_tenant_id IS NULL THEN RETURN; END IF;
+  INSERT INTO customer_order_audit_log (
+    tenant_id, order_id, entity_type, entity_id,
+    field, before_value, after_value, edit_reason, operator_id
+  ) VALUES (
+    v_tenant_id, p_order_id, 'order', p_order_id,
+    'status', to_jsonb(p_from), to_jsonb(p_to), p_reason, p_operator
+  );
+END;
+$$;
+
+-- 3. 改 rpc_transfer_order_to_store ------------------------------------------
+DO $do3$
+DECLARE
+  v_def TEXT;
+BEGIN
+  v_def := pg_get_functiondef(
+    'rpc_transfer_order_to_store(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT)'::regprocedure
+  );
+  v_def := replace(v_def,
+    $rep$    v_orig.nickname_snapshot, p_to_pickup_store_id, 'pending', v_note_in,$rep$,
+    $rep$    v_orig.nickname_snapshot, p_to_pickup_store_id,
+        CASE WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN 'ready' ELSE 'pending' END,
+        v_note_in,$rep$
+  );
+  v_def := replace(v_def,
+    'RETURN v_new_order_id;',
+    $rep$
+  IF p_to_pickup_store_id = v_orig.pickup_store_id THEN
+    PERFORM rpc_log_order_status_change(v_new_order_id, 'pending',   'confirmed', p_operator, '同店互轉自動推進');
+    PERFORM rpc_log_order_status_change(v_new_order_id, 'confirmed', 'reserved',  p_operator, '同店互轉自動推進');
+    PERFORM rpc_log_order_status_change(v_new_order_id, 'reserved',  'shipping',  p_operator, '同店互轉自動推進');
+    PERFORM rpc_log_order_status_change(v_new_order_id, 'shipping',  'ready',     p_operator, '同店互轉自動推進');
+  END IF;
+
+  RETURN v_new_order_id;$rep$
+  );
+  EXECUTE v_def;
+END$do3$;
+
+-- 4. 改 rpc_transfer_order_partial -------------------------------------------
+DO $do4$
+DECLARE
+  v_def TEXT;
+BEGIN
+  v_def := pg_get_functiondef(
+    'rpc_transfer_order_partial(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB, BOOLEAN)'::regprocedure
+  );
+  v_def := replace(v_def,
+    $rep$      v_orig.nickname_snapshot, p_to_pickup_store_id, 'pending',$rep$,
+    $rep$      v_orig.nickname_snapshot, p_to_pickup_store_id,
+        CASE WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN 'ready' ELSE 'pending' END,$rep$
+  );
+  v_def := replace(v_def,
+    'RETURN v_new_order_id;',
+    $rep$
+  IF p_to_pickup_store_id = v_orig.pickup_store_id AND v_appended IS NOT TRUE THEN
+    PERFORM rpc_log_order_status_change(v_new_order_id, 'pending',   'confirmed', p_operator, '同店互轉自動推進(部分)');
+    PERFORM rpc_log_order_status_change(v_new_order_id, 'confirmed', 'reserved',  p_operator, '同店互轉自動推進(部分)');
+    PERFORM rpc_log_order_status_change(v_new_order_id, 'reserved',  'shipping',  p_operator, '同店互轉自動推進(部分)');
+    PERFORM rpc_log_order_status_change(v_new_order_id, 'shipping',  'ready',     p_operator, '同店互轉自動推進(部分)');
+  END IF;
+
+  RETURN v_new_order_id;$rep$
+  );
+  EXECUTE v_def;
+END$do4$;
+
+-- ============================================================================
+-- 5. Backfill: TF0722 (id=8026) 同店轉自 TF0721 (id=8025), 應為 ready
+-- 補 4 筆 audit log + status 改成 ready
+-- ============================================================================
+DO $do5$
+DECLARE
+  v_op UUID := COALESCE(
+    (SELECT updated_by FROM customer_orders WHERE id = 8026),
+    '00000000-0000-0000-0000-000000000000'::uuid
+  );
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM customer_orders
+    WHERE id = 8026 AND status = 'pending'
+      AND transferred_from_order_id = 8025
+      AND pickup_store_id = (SELECT pickup_store_id FROM customer_orders WHERE id = 8025)
+  ) THEN
+    PERFORM rpc_log_order_status_change(8026, 'pending',   'confirmed', v_op, '同店互轉補建紀錄');
+    PERFORM rpc_log_order_status_change(8026, 'confirmed', 'reserved',  v_op, '同店互轉補建紀錄');
+    PERFORM rpc_log_order_status_change(8026, 'reserved',  'shipping',  v_op, '同店互轉補建紀錄');
+    PERFORM rpc_log_order_status_change(8026, 'shipping',  'ready',     v_op, '同店互轉補建紀錄');
+
+    UPDATE customer_orders
+       SET status = 'ready', updated_at = NOW(), updated_by = v_op
+     WHERE id = 8026;
+  END IF;
+END$do5$;


### PR DESCRIPTION
## Summary

最初是會員合併 UX，過程中順手修了一系列相關 issue。

### 會員模組
- **雙向合併** modal（未綁 LINE ↔ 已綁 LINE，一支 RPC 通用）
- 詳細頁加雙頭像疊（主 + merged 小頭像）+「合併紀錄」tab
- 列表預設過濾 `merged` / `deleted`（toggle 切換）+ 列尾灰章
- 「會員資料」tab：手機 / Email / 性別 / 生日 / 加入時間 / LINE User ID 全進去
- LINE User ID 馬賽克（`Uxxxxx...xxxxx`）+ memory feedback 紀錄
- 改用 `/members?id=N` 開 modal（取代舊 `/members/detail` page）

### 訂單模組
- 「轉出」tab 顯示 `status='transferred_out'`
- 折扣 / 小計 / 應收顯示用 `Math.round` 統一整數（去 `0.4000000000057`）
- `canTransfer` 加 `ready`（可取貨也可轉單）
- 訂單明細區塊移到進度條上方
- 同店互轉自動跳 `ready` + 跳過的 4 筆 status 變化都寫進 audit log
- audit log drawer 支援 `status` field + 中文 status label
- 已付清訂單在取貨 dialog 不再預扣儲值金（disabled + chip）

### Schema (5 個新 migrations)
1. `20260507120000` rpc_merge_member 守衛放寬到 `line_user_id IS NULL`
2. `20260507130000` rpc_merge_member NULL fix（v_points/v_wallet 初始化 0）
3. `20260507140000` member_merges 加 SELECT RLS policy
4. `20260508120000` + `20260508130000` rpc_transfer_* 守衛允許 `ready`
5. `20260508140000` audit_log.field 加 `status`、transfer RPC 同店跳 ready + 4 筆 status log
6. ledger trigger 放寬：合併時允許改 member_id

### Forms / Modal
- 全 `<input type=\"number\">` step 改 1（NTD 不用小數）
- Modal 限制在螢幕內、body 內部 scroll
- 沖銷 modal 殘留英文（`reversal` / `ledger` / `type=`）全改中文

## Test plan
- [docs/TEST-member-merge-ux.md](docs/TEST-member-merge-ux.md)
- Preview e2e：合併 modal、雙頭像、儲值金沖銷 modal、訂單明細順序、取貨已付清提示

## Migration apply
\`\`\`bash
supabase db push --linked --include-all
\`\`\`
（已對 prod apply，含 backfill TF0722）

🤖 Generated with [Claude Code](https://claude.com/claude-code)