### PR TITLE
test(e2e): 完整 seed 系統 + 8 軌 E2E 測試文件 + 12 反向情境

### DIFF
--- a/docs/TEST-E2E-T1-master-data.md
+++ b/docs/TEST-E2E-T1-master-data.md
@@ -1,0 +1,91 @@
+# TEST-E2E-T1 — 主檔（商品 / SKU / 加盟店 / 會員 / 員工）
+
+**範圍：** products / skus / sku_packs / categories / brands / suppliers / supplier_skus / stores / line_channels / post_templates / members / member_cards / member_line_bindings / audit 4 欄位 / 自動編號規則
+**對應 master §：** §1
+**對應 fixture seed：** 01-master.sql / 02-base-fixtures.sql
+**反向情境：** 主檔本身少（軟刪 status 變更為主）
+
+---
+
+## 既有 docs
+
+| 文件 | 範圍 | 三色 | 動作 |
+|---|---|---|---|
+| TEST-B3-products-ext.md | 商品擴充欄位 | 🟢 | relink |
+| TEST-core-modules.md | 核心 CRUD（products/skus/stores/suppliers）| 🟢 | relink |
+| TEST-member-merge-ux.md | 會員合併 UX | 🟡 | 跑 |
+| TEST-member-tabs-notifications.md | 會員分頁 + 通知 | 🟡 | 跑 |
+| TEST-member-type-guest.md | guest 訪客 member | 🟡 | 跑 |
+
+---
+
+## Gap addendum
+
+### G1.1 categories 3 層樹完整
+- [ ] **SQL:** 17 categories: 3 level1 + 9 level2 + 5 level3
+- [ ] **SQL:** parent_id 鏈正確
+  ```sql
+  SELECT level, code, name, (SELECT code FROM categories p WHERE p.id = c.parent_id) AS parent_code
+    FROM categories c ORDER BY level, sort_order;
+  ```
+- [ ] **UI:** 商品建立頁面 category dropdown 應顯示樹狀
+
+### G1.2 sku_packs 多單位
+- [ ] **SQL:** P004（香米）/ P008（雞蛋）/ P010（餅乾）有 base + 額外 pack
+- [ ] **驗證 is_default_sale 唯一：**
+  ```sql
+  SELECT sku_id, COUNT(*) FILTER (WHERE is_default_sale) AS default_count
+    FROM sku_packs GROUP BY sku_id HAVING COUNT(*) FILTER (WHERE is_default_sale) <> 1;
+  -- expect 0 rows (every sku 恰一個 default)
+  ```
+- [ ] **UI:** /products/SKU-004 顯示「個 / 箱(10)」兩單位
+
+### G1.3 多供應商分配
+- [ ] **SQL:** SUP-JP 對 SKU-001/3/6/10 為 is_preferred；SUP-XL 對 SKU-008
+- [ ] **UI:** /products 列表能顯示主要供應商欄
+- [ ] **UI:** /suppliers/SUP-JP 顯示供應 4 個 SKU
+
+### G1.4 Audit 4 欄位
+（詳見 T10 §4，T1 在此 spot-check 主要 8 表）
+- [ ] products / skus / stores / members / suppliers / categories / sku_packs / line_channels 4 欄位齊
+- [ ] 修改 row 後 updated_at / updated_by 自動更新（trigger touch_updated_at 仍掛）
+
+### G1.5 Member tier + LINE 綁定
+- [ ] **SQL:** 4 會員（M-001/2/3/INT-001）tier 對應正確（normal/gold/silver/normal）
+- [ ] **SQL:** 3 會員有 member_line_bindings（M-INT-001 沒有，因為 store_internal）
+- [ ] **SQL:** customer_line_aliases 4 筆（含 LC-VIP 1 筆）
+- [ ] **UI:** /members/M-TEST-002 wallet tab 顯示 4500 + ledger 流水
+
+### G1.6 Multi-channel + post_templates
+- [ ] **SQL:** 3 channels (LC-MAIN/VIP/DAILY)、3 templates (DEFAULT/PROMO/CLOSING)
+- [ ] **UI:** 開團頁面 channel dropdown 有 3 選項、template dropdown 有 3 選項
+
+### G1.7 Purchase approval thresholds 多級
+- [ ] **SQL:** 5 thresholds: 1 global + 2 store + 2 supplier
+  ```sql
+  SELECT scope, scope_id, threshold_amount, approver_role
+    FROM purchase_approval_thresholds ORDER BY scope, scope_id;
+  ```
+- [ ] **驗證解析邏輯：** PR 走 supplier scope 優先還是 global？（UI/RPC 應有規則）
+
+---
+
+## 反向情境（主檔特性少、僅軟刪 + 狀態變更）
+
+### Soft-delete 會員（GDPR）
+- [ ] **RPC:** `rpc_member_gdpr_delete` 應把 status='deleted' + 清 PII
+- [ ] **Trigger:** `forbid_member_delete` 攔 hard DELETE
+- [ ] **驗證 ripple：**
+  - members.status='deleted'
+  - phone_enc / email_enc / birthday_enc 清空
+  - phone_hash 仍保留（avoid duplicate registration）
+  - wallet_balances 不動（保留 audit）
+
+---
+
+## 驗收門檻
+
+- [ ] G1.1 ~ G1.7 全勾
+- [ ] 既有 5 docs 各跑完 inline report
+- [ ] 結 `TEST-E2E-T1-master-data-report.md` status: passed
+- [ ] [TEST-INDEX.md](TEST-INDEX.md) 此軌標 🟢

--- a/docs/TEST-E2E-T10-security-rls.md
+++ b/docs/TEST-E2E-T10-security-rls.md
@@ -1,0 +1,252 @@
+# TEST-E2E-T10 — 權限 / RLS / 安全
+
+**範圍：** HQ vs branch RLS、SECURITY DEFINER RPC 清冊、LINE User ID 馬賽克、稽核 4 欄位覆蓋、負面測試
+**對應 master §：** §9
+**對應 fixture seed：** with-orders + with-wallet-history + with-transfers（RLS / audit 都建在這之上）
+**這份 doc 是新寫，無既有 doc 可 link。**
+
+---
+
+## 前置
+
+- `bash scripts/e2e/reset.sh full-demo --yes` 已跑
+- 至少 3 個 auth.users 已建：
+  1. **HQ admin** (`cktalex@gmail.com` 或同等 raw_app_meta_data: tenant_id + role='owner'/'admin')
+  2. **S001 branch user** (raw_app_meta_data: tenant_id + role='store_manager' + store_id=S001 + location_id=WH-S001)
+  3. **anon** （不登入、無 jwt）
+
+---
+
+## § 1. RLS 矩陣
+
+### 1.1 主要交易表覆蓋（10 張）
+
+逐表跑 `SET LOCAL ROLE authenticated; SET LOCAL request.jwt.claims = '{...}';`，檢查 SELECT count：
+
+| Table | HQ admin 應讀 | S001 branch 應讀 | anon 應讀 |
+|---|---|---|---|
+| `members` | 全部 4 筆 | 只 home_store=S001 的 (M-001 + M-INT-001) | 0 |
+| `customer_orders` | 全部 8 筆 | pickup_store=S001 的 (ORD-0001/3/5/6) | 0 |
+| `customer_order_items` | 全部 14+ 筆 | 透過 order JOIN | 0 |
+| `customer_line_aliases` | 全部 4 筆 | 0 (HQ-only) | 0 |
+| `member_line_bindings` | 全部 3 筆 | store_id=S001 的 1 筆 | 0 |
+| `wallet_balances` | 全部 4 筆 | 0 (HQ-only via members RLS) | 0 |
+| `wallet_ledger` | 全部 7+ 筆 | 0 (HQ-only) | 0 |
+| `transfers` | 全部 8 筆 | source/dest=WH-S001 的（TF-0001/0005）| 0 |
+| `purchase_requests` | 全部 4 筆 | source_location=WH-S001 的（PR-0001/0003）| 0 |
+| `purchase_orders` | 全部 5 筆 | 通常店家不讀 PO（HQ-only）| 0 |
+| `goods_receipts` | 全部 3 筆 | 0 | 0 |
+| `vendor_bills` | 全部 2 筆 | 0 (HQ-accountant only) | 0 |
+| `mutual_aid_board` | 全部 7 筆 | 全部（互助板全 tenant 可讀）| 0 |
+| `store_monthly_settlements` | 全部 2 筆 | store_id=S001 的 1 筆 | 0 |
+| `picking_waves` | 全部 2 筆 | wave_items 含 store=S001 的 1 筆 | 0 |
+
+### 1.2 SQL 驗證樣板
+
+```sql
+-- HQ admin
+SET LOCAL ROLE authenticated;
+SET LOCAL "request.jwt.claims" = '{"tenant_id":"...","role":"owner"}';
+SELECT 'members' AS table, COUNT(*) FROM members UNION ALL
+SELECT 'customer_orders', COUNT(*) FROM customer_orders UNION ALL
+SELECT 'transfers', COUNT(*) FROM transfers;
+
+-- S001 branch
+SET LOCAL ROLE authenticated;
+SET LOCAL "request.jwt.claims" = '{"tenant_id":"...","role":"store_manager","store_id":"<S001-id>","location_id":"<WH-S001-id>"}';
+-- 同上 SELECT、預期數量符合表格
+
+-- anonymous
+RESET ROLE;
+SET LOCAL ROLE anon;
+-- 同上 SELECT、應全部 0 rows
+```
+
+---
+
+## § 2. SECURITY DEFINER RPC 清冊
+
+### 2.1 全清冊
+```sql
+SELECT proname, pg_get_function_arguments(oid) AS args
+  FROM pg_proc
+ WHERE prosecdef = TRUE AND proname LIKE 'rpc_%'
+ ORDER BY proname;
+```
+
+預期回傳 80+ RPC（per Plan agent 早先 explore 結果）。
+
+### 2.2 抽查覆蓋（每 domain 抽 1-2）
+
+| Domain | 抽查 RPC | 驗證重點 |
+|---|---|---|
+| Member | `rpc_resolve_member` | tenant_id 從 jwt 取（不從 param）|
+| Wallet | `rpc_wallet_topup` / `rpc_wallet_reverse` | tenant_id 從 jwt、append-only 強制 |
+| Order | `rpc_create_customer_orders` / `rpc_advance_order_status` | RLS 對 branch 角色拒絕跨店 |
+| Transfer | `rpc_create_free_transfer` / `rpc_receive_transfer` / `rpc_reject_transfer` | source/dest store 屬同 tenant |
+| Aid | `rpc_post_aid_board` / `rpc_cancel_aid_order` | offer 必帶 source_customer_order_id（已驗 R11） |
+| Picking | `rpc_create_picking_wave` / `rpc_confirm_picked` | wave_items 跨 store 對 |
+| Purchase | `rpc_submit_pr` / `rpc_send_purchase_order` / `rpc_confirm_gr` | 角色 owner/admin/hq_manager 才能執行 |
+| Settlement | `rpc_generate_hq_to_store_settlement` / `rpc_confirm_transfer_settlement` | HQ-only |
+
+### 2.3 GRANT EXECUTE 一致性
+```sql
+SELECT p.proname, ARRAY_AGG(g.grantee_role)
+  FROM pg_proc p
+  LEFT JOIN LATERAL (
+    SELECT (aclexplode(p.proacl)).grantee::regrole AS grantee_role
+  ) g ON TRUE
+ WHERE p.prosecdef = TRUE AND p.proname LIKE 'rpc_%'
+ GROUP BY p.proname
+ ORDER BY p.proname;
+```
+
+預期：所有 public RPC 都 grant 給 `authenticated`、`fn_check_wallet_consistency` 不 grant authenticated（ops only）。
+
+---
+
+## § 3. LINE User ID 馬賽克抽查
+
+### 3.1 後台 UI（preview）
+- [ ] HQ admin 視角開 `/members/M-TEST-001/detail` → LINE 綁定區應顯示**完整** `line_user_id`
+- [ ] S001 branch user 視角開同頁 → 應顯示 `U***xyz`（前綴 U + 3 個 *）
+- [ ] anon → 整頁不應載入（被 redirect 到 login）
+
+### 3.2 LIFF 顧客端（雖然 LIFF 跳過、但 schema 限制要在）
+- [ ] **任何 view 不應對非 HQ role 回 raw `line_user_id`**
+  ```sql
+  -- 找所有用到 line_user_id 的 view / RPC
+  SELECT viewname FROM pg_views WHERE definition LIKE '%line_user_id%';
+  SELECT proname FROM pg_proc
+   WHERE pg_get_functiondef(oid) LIKE '%line_user_id%' AND prosecdef = TRUE;
+  ```
+- [ ] 對找到的每支：用 branch role 跑、確認不直接回 raw user_id
+
+### 3.3 直讀 customer_line_aliases / member_line_bindings
+- [ ] HQ admin SELECT * → OK
+- [ ] S001 branch user SELECT * → 0 rows 或 RLS 拒絕
+
+### 3.4 fixture-level 驗證
+```sql
+SELECT line_user_id FROM member_line_bindings LIMIT 5;
+-- 預期: U + 31 chars (per fixture pattern)
+```
+
+---
+
+## § 4. 稽核 4 欄位覆蓋
+
+### 4.1 主檔表必有 4 欄
+```sql
+SELECT table_name
+  FROM information_schema.columns
+ WHERE table_schema = 'public'
+   AND column_name IN ('created_by','created_at','updated_by','updated_at')
+ GROUP BY table_name
+HAVING COUNT(*) = 4
+ ORDER BY table_name;
+```
+
+預期清單包含（必）：
+- products / skus / sku_packs / categories / brands / suppliers / stores
+- members / member_cards / member_tiers
+- customer_orders / customer_order_items / group_buy_campaigns / campaign_items
+- transfers / transfer_items / picking_waves / picking_wave_items
+- purchase_requests / purchase_request_items / purchase_orders / purchase_order_items
+- goods_receipts / goods_receipt_items / purchase_returns / purchase_return_items
+- vendor_bills / vendor_payments / petty_cash_accounts / expense_categories
+- transfer_settlements / store_monthly_settlements
+- mutual_aid_board / aid_clearance_offers / demand_requests / backorders / reorder_rules
+
+### 4.2 Append-only 表 trigger 仍掛
+```sql
+SELECT tgrelid::regclass AS table_name, tgname
+  FROM pg_trigger
+ WHERE NOT tgisinternal
+   AND tgname LIKE 'trg_no_%'
+ ORDER BY 1, 2;
+```
+
+預期至少：
+- `wallet_ledger`: trg_no_update_wallet, trg_no_delete_wallet
+- `points_ledger`: trg_no_update_points, trg_no_delete_points
+- `members`: trg_no_delete_member
+- `mutual_aid_replies`: trg_no_mut_aid_replies
+- `mutual_aid_claims`: trg_no_mut_aid_claims
+- `transfer_settlement_items`: trg_no_mut_settle_items
+- `store_monthly_settlement_items`: trg_no_mut_smsi
+- `picking_wave_audit_log`: trg_no_mut_wave_audit
+- `order_pickup_events / order_expiry_events / order_shortage_events`: forbid_*_mutation triggers
+
+### 4.3 Append-only 違規測試
+```sql
+-- 直接 UPDATE wallet_ledger → 必 RAISE
+BEGIN;
+UPDATE wallet_ledger SET reason = 'x' WHERE id = (SELECT id FROM wallet_ledger LIMIT 1);
+-- expected: ERROR: wallet_ledger is append-only. Use a reversing entry.
+ROLLBACK;
+
+-- 直接 DELETE wallet_ledger → 必 RAISE
+BEGIN;
+DELETE FROM wallet_ledger WHERE id = (SELECT id FROM wallet_ledger LIMIT 1);
+ROLLBACK;
+```
+
+---
+
+## § 5. 負面測試（branch 跨店嘗試）
+
+S001 user 嘗試讀/寫 S002 資料，預期 RLS 拒絕：
+
+| 動作 | 預期 |
+|---|---|
+| `SELECT * FROM customer_orders WHERE pickup_store_id=<S002-id>` | 0 rows |
+| `INSERT INTO customer_orders (..., pickup_store_id=<S002-id>, ...)` | RLS RAISE 42501 |
+| `UPDATE customer_orders SET notes='x' WHERE pickup_store_id=<S002-id>` | 0 rows updated |
+| `DELETE FROM customer_orders WHERE id=<S002 訂單>` | 0 rows / RLS reject |
+| `SELECT * FROM wallet_ledger WHERE member_id=<M-002 id>` | 0 rows（HQ-only 表）|
+| `INSERT INTO purchase_orders (...)` | 0 rows / RLS reject（PO 是 HQ 寫）|
+| RPC `rpc_send_purchase_order(po_id=PO-0001, ...)` 用 store_manager | RAISE permission denied |
+
+```sql
+-- 模板
+SET LOCAL ROLE authenticated;
+SET LOCAL "request.jwt.claims" = '{"tenant_id":"...","role":"store_manager","store_id":"<S001>"}';
+SELECT * FROM customer_orders WHERE pickup_store_id = <S002-id>;
+-- 預期 0 rows
+
+INSERT INTO customer_orders (tenant_id, order_no, ..., pickup_store_id) VALUES (..., <S002-id>);
+-- 預期 ERROR 42501 (RLS violation)
+```
+
+---
+
+## § 6. JWT role NULL → SECURITY DEFINER 例外（memory 提到）
+
+`reference_admin_jwt_role_null.md` memory 指：admin user JWT 的 role NULL，會讓 HQ-only RLS policy 靜默拒絕 0 rows。Memory 提到「解法包成 SECURITY DEFINER RPC」。
+
+驗證：
+- [ ] `cktalex@gmail.com` 的 JWT 解 role 出來應為 NULL（或 admin 設定後變 'owner'）
+- [ ] 跑 `rpc_wallet_topup` 正常（透過 SECDEF 繞過）
+- [ ] 直接 SELECT 不透過 RPC：應 0 rows（confirm 該 memory 仍適用）
+
+---
+
+## 驗收門檻
+
+- [ ] §1 RLS 矩陣全表跑過、預期數量都對
+- [ ] §2 SECURITY DEFINER 抽查 8 支 RPC 全 pass
+- [ ] §3 LINE User ID 馬賽克 UI + SQL 雙驗、無 raw user_id 給非 HQ
+- [ ] §4 audit 4 欄位 + append-only triggers 全在
+- [ ] §5 負面測試：branch 跨店嘗試全被擋
+- [ ] §6 admin role NULL 行為仍與 memory 描述一致
+- [ ] 結 `TEST-E2E-T10-security-rls-report.md` status: passed
+- [ ] [TEST-INDEX.md](TEST-INDEX.md) 此軌標🟢 + 最近驗證日
+
+---
+
+## Risk callout
+
+- **NO existing TEST doc** for this track — 全新撰寫、首次跑可能發現多個 RLS gap
+- 找到的 gap 可能要：(a) 補 RLS policy（schema 改動）/ (b) 補 SECDEF RPC / (c) 補 mask helper function
+- 任何 RLS gap 開新 issue、不在本軌修

--- a/docs/TEST-E2E-T2-campaign.md
+++ b/docs/TEST-E2E-T2-campaign.md
@@ -1,0 +1,75 @@
+# TEST-E2E-T2 — 候選 → 開團
+
+**範圍：** 候選週曆同步開團 / candidate → draft → finalize / campaign_no 規則 / campaign_audit_log / auto-PR 觸發 / close 自動建新 PR
+**對應 master §：** §2 / §4（auto-PR 鏈接）
+**對應 fixture seed：** with-campaign.sql（10 campaigns 多狀態）
+**反向情境：** campaign cancelled（draft 階段）
+
+---
+
+## 既有 docs
+
+| 文件 | 範圍 | 三色 | 動作 |
+|---|---|---|---|
+| TEST-candidate-to-draft-and-pricing.md | 候選 → 草稿 + 定價 | 🟡 | 跑 |
+| TEST-campaign-finalize.md | finalize 流程 | 🟡 | 跑 |
+| TEST-campaign-to-purchase.md | finalize 觸發 PR | 🟡 | 跑 |
+| TEST-close-campaign-auto-new-pr.md | close 自動建新 PR | 🟡 | 跑 |
+
+---
+
+## Gap addendum
+
+### G2.1 campaign_no 規則
+- [ ] **SQL:** 新建 campaign 的 campaign_no 應符合 `GB{YYYYMMDD}-C{padded6}` 格式
+  ```sql
+  SELECT campaign_no FROM group_buy_campaigns
+   WHERE campaign_no ~ '^GB[0-9]{8}-C[0-9]{6}$';
+  ```
+- [ ] **memory ref:** `reference_candidate_campaign_linkage.md` substring FROM 13 FOR 6 取 candidate id
+
+### G2.2 跨 channel campaign_channels
+- [ ] **SQL:** 既有 10 campaigns 全掛 LC-MAIN
+- [ ] **新測：** 開新 campaign 掛 LC-VIP + LC-MAIN（multi-channel）
+- [ ] **驗證 cap_qty：** 每 channel 各自的 cap_qty 不互相干擾
+
+### G2.3 候選週曆 → 同步開團（memory project_business_context）
+- [ ] **UI:** `/community-candidates/calendar` 推 candidate 到指定週、指定 channel
+- [ ] **UI:** finalize 後返回 calendar → 該 slot 應顯示成 'campaign'
+- [ ] **SQL:** group_buy_campaigns.matrix_row_order 對齊
+
+### G2.4 Auto-PR 觸發鏈（finalize 觸發）
+- [ ] **RPC:** `rpc_finalize_campaign` 應自動 call rpc_create_pr_from_campaigns
+- [ ] **SQL:** 新 campaign finalize 後 → 對應 PR 出現 status='draft'
+- [ ] **SQL:** PR 內 items 對齊 campaign_items 的 SKU + qty 累計
+
+### G2.5 close 觸發新 PR (TEST-close-campaign-auto-new-pr 對應)
+- [ ] **驗證：** campaign close 後若仍有 backorder → auto rollover 到下一個 open campaign
+
+### G2.6 campaign_audit_log
+- [ ] **SQL:** 任何 campaign 編輯（item / channel）都應在 campaign_audit_log 留 row
+  ```sql
+  SELECT entity_type, action, edit_reason FROM campaign_audit_log
+   WHERE campaign_id = ? ORDER BY created_at DESC LIMIT 5;
+  ```
+
+---
+
+## 反向情境
+
+### Campaign cancel（draft 階段）
+- [ ] **SQL:** UPDATE group_buy_campaigns SET status='cancelled' WHERE status='draft'
+- [ ] **不可 cancel：** 已有 customer_orders / PR 的 campaign（應 RPC 拒絕、留 status 不動）
+- [ ] **驗證：** `rpc_finalize_campaign` 對 cancelled status 應 RAISE
+
+### Campaign expired（自動）
+- [ ] **RPC:** `rpc_auto_close_expired_campaigns` 應掃 end_at < NOW + status='open'
+- [ ] **驗證：** seed 有 CAMP-006/7/8 狀態為 ordered/receiving/ready，不應被誤標 expired
+
+---
+
+## 驗收門檻
+
+- [ ] G2.1 ~ G2.6 全勾
+- [ ] 4 既有 docs 各跑完
+- [ ] 結 `TEST-E2E-T2-campaign-report.md` status: passed

--- a/docs/TEST-E2E-T3-orders-wallet.md
+++ b/docs/TEST-E2E-T3-orders-wallet.md
@@ -1,0 +1,167 @@
+# TEST-E2E-T3 — 訂單 + Wallet
+
+**範圍：** 後台加單 / LIFF 建單在 admin 顯示 / 訂單轉手 / 88 折 / soft-cancel / 負數訂單 / wallet（topup/spend/refund/adjust/reverse）
+**對應 master §：** §3a / §3b / §3c / §3d / §7 / §11 / §14 / §16
+**對應 fixture seed：** with-orders.sql (8 orders) + with-wallet-history.sql (3 members × wallet 歷史) + with-mutual-aid (R11d offset 訂單)
+**反向情境覆蓋：** R4 / R8 / R10
+
+---
+
+## 既有 docs（直接複跑、勿重寫）
+
+> 跑法：每 doc 用 `run-feature-tests` skill 對著 seeded DB 跑、產 inline `-report.md`
+
+| 既有文件 | 範圍 | 三色 | 動作 |
+|---|---|---|---|
+| TEST-order-entry-mvp0.md | admin 加單 baseline | 🟡 | 跑 |
+| TEST-order-entry-store-internal.md | store_internal member 加單 | 🟢 | relink |
+| TEST-order-transfer.md | 跨會員訂單轉手 | 🟢 | relink |
+| TEST-order-transfer-button.md | 轉手 UI 按鈕 | 🟡 | 跑 |
+| TEST-orders-edit.md | 訂單編輯 / 折扣 / 修價 | 🟡 | 跑 |
+| TEST-訂單刪除與負數訂單.md | soft-cancel + 負數 | 🟡 | 跑 |
+| TEST-order-expiry-events.md | 取貨逾期 append-only | 🟡 | 跑 |
+| TEST-order-shortage-events.md | 缺貨事件 append-only | 🟡 | 跑 |
+| TEST-wallet-phase-a.md | wallet 寫入 / refund / adjust / reverse | 🟡 | 跑 |
+| TEST-wallet-phase-b.md | wallet phase b | 🟡 | 跑 |
+| TEST-wallet-phase-c.md | wallet phase c | 🟡 | 跑 |
+| TEST-wallet-phase-d.md | wallet phase d | 🟡 | 跑 |
+
+---
+
+## Gap addendum — 既有 doc 沒 cover 的整合情境
+
+### G3.1 LIFF 建的訂單在 admin /orders 顯示
+- [ ] **SQL:** `customer_order_items.source = 'liff'` 的 row 應在 `/orders` 列表帶來源標籤渲染
+  ```sql
+  SELECT o.order_no, coi.source FROM customer_orders o
+   JOIN customer_order_items coi ON coi.order_id = o.id
+   WHERE coi.source = 'liff';
+  ```
+- [ ] **UI (preview):** `/orders` 列表能依 source filter（manual / liff / csv / screenshot_parse）
+
+### G3.2 customer_order_sources 多源類型
+- [ ] **SQL:** seed 已建 3 種 source_type（screenshot/manual_paste/csv），`/orders` 詳情頁能顯示
+  ```sql
+  SELECT cos.source_type, cos.screenshot_url, cos.order_id FROM customer_order_sources cos;
+  -- expect: 3 rows for ORD-0001(screenshot), ORD-0002(manual_paste), ORD-0008(csv)
+  ```
+
+### G3.3 88 折 + 銀卡雙折扣（ORD-0008）
+- [ ] **SQL:** ORD-0008 unit_price = ROUND(campaign_items.unit_price × 0.92 × 0.88, 4) = 65 × 0.8096 = 52.624
+  ```sql
+  SELECT coi.unit_price, coi.notes FROM customer_orders o
+   JOIN customer_order_items coi ON coi.order_id = o.id
+   WHERE o.order_no = 'ORD-0008';
+  ```
+- [ ] **UI:** `/orders/ORD-0008` 顯示折扣計算明細
+
+### G3.4 負數訂單 + wallet refund 串
+- [ ] 從 ORD-0005（cancelled）建 offset order
+- [ ] **RPC:** `rpc_create_offset_order(p_order_id, ...)` 執行
+- [ ] **SQL:** offset order 的 customer_order_items.qty 為負數
+- [ ] **SQL:** wallet refund row 對應 offset 金額
+- [ ] **驗收：**
+  ```sql
+  SELECT type, change, balance_after, source_type, source_id, reason
+    FROM wallet_ledger
+   WHERE source_type = 'customer_order'
+     AND source_id IN (SELECT id FROM customer_orders WHERE order_no LIKE 'OFFSET-%')
+   ORDER BY id;
+  ```
+
+---
+
+## 反向情境驗證（4 維 ripple）
+
+### R4. 訂單缺貨（ORD-0007 partially_completed）
+
+**Seed 起點：** with-orders.sql 灌 ORD-0007 status='partially_completed' + order_shortage_events 1 筆（SKU-009 申請 3 實得 2）
+
+**4 維 ripple 驗證：**
+
+| 維度 | 預期 | 驗證 SQL |
+|---|---|---|
+| stock_movements | 不應有 sale movement（撿貨還沒做、缺貨在訂單確認時就發現）| `SELECT * FROM stock_movements WHERE source_doc_id = (SELECT id FROM customer_orders WHERE order_no='ORD-0007') AND movement_type='sale';` 應 0 rows |
+| wallet_ledger | M-TEST-002 wallet **不應**因 ORD-0007 扣款（除非已預扣需 refund）| `SELECT * FROM wallet_ledger WHERE source_type='customer_order' AND source_id=(SELECT id FROM customer_orders WHERE order_no='ORD-0007');` |
+| customer_order_items | status='partially_picked_up' + qty=3 unchanged | `SELECT status, qty FROM customer_order_items WHERE order_id=(SELECT id FROM customer_orders WHERE order_no='ORD-0007');` |
+| store_monthly_settlement | 不入結算（訂單未完成）| `SELECT * FROM store_monthly_settlement_items smsi JOIN transfers t ON t.id=smsi.transfer_id WHERE ...` |
+
+**額外：** order_shortage_events 1 筆、shortage_qty = 1（GENERATED column）
+
+### R8. 顧客取貨後反悔（ORD-0006）
+
+**Seed 起點：** ORD-0006 status='completed' + order_pickup_events 1 筆（picked_up）+ stock_movement type='customer_return' (+1 SKU-002 @ S001) + wallet_ledger refund +80 給 M-TEST-001
+
+**4 維 ripple 驗證：**
+
+| 維度 | 預期 | 驗證 SQL |
+|---|---|---|
+| stock_movements | 1 筆 customer_return @ S001 location, qty=+1, source_doc_id=ORD-0006 | `SELECT * FROM stock_movements WHERE source_doc_type='customer_order' AND movement_type='customer_return' AND source_doc_id=(SELECT id FROM customer_orders WHERE order_no='ORD-0006');` |
+| wallet_ledger | 1 筆 refund +80 給 M-TEST-001（reason 提到 ORD-0006）| `SELECT * FROM wallet_ledger WHERE member_id=(SELECT id FROM members WHERE member_no='M-TEST-001') AND type='refund' AND reason LIKE '%ORD-0006%';` |
+| customer_order_items | SKU-002 status='picked_up'（取貨後退、不改 status）| 註：實作上若有 'returned' status 應更新；現狀無 'returned' enum |
+| store_monthly_settlement | ORD-0006 是顧客直接交易、不走 hq_to_store transfer、無月結算影響 | — |
+
+**驗收：** wallet_balances M-TEST-001 = 750 (history) + 80 (R8 refund) = 830
+```sql
+SELECT balance, version FROM wallet_balances
+ WHERE member_id = (SELECT id FROM members WHERE member_no = 'M-TEST-001');
+```
+
+### R10. Wallet topup reversal（M-TEST-003）
+
+**Seed 起點：** with-wallet-history.sql 給 M-TEST-003 灌 topup +200 → topup +100 (reversed) → reversal -100 → balance=200
+
+**驗證：**
+
+| 維度 | 預期 | 驗證 SQL |
+|---|---|---|
+| wallet_ledger | 3 rows: topup(+200), topup(+100, reversed_by=L3), reversal(-100, reverses=L2) | `SELECT id, type, change, balance_after, reverses, reversed_by FROM wallet_ledger WHERE member_id=(SELECT id FROM members WHERE member_no='M-TEST-003') ORDER BY id;` |
+| wallet_balances | balance=200, version=3 | `SELECT balance, version FROM wallet_balances WHERE member_id=(SELECT id FROM members WHERE member_no='M-TEST-003');` |
+| append-only invariant | 直接 `UPDATE wallet_ledger SET reason='x' WHERE ...` 應 RAISE | `BEGIN; UPDATE wallet_ledger SET reason='x' WHERE member_id=...; ROLLBACK;` |
+| consistency | 三筆 ledger 累加 = balance | `SELECT SUM(change) FROM wallet_ledger WHERE member_id=(SELECT id FROM members WHERE member_no='M-TEST-003');` 應 = 200 |
+| 不能反向 reversal | 對 L3 (reversal) 跑 `rpc_wallet_reverse` 應 RAISE 'cannot reverse a reversal' | 跑 RPC 確認 |
+
+---
+
+## Wallet 全套對齊（含 base + history + R8 refund）
+
+預期最終 balance（reset.sh full-demo --yes 跑完後）：
+
+| Member | base seed | history | R8 refund | 預期 balance |
+|---|---|---|---|---|
+| M-TEST-001 | 0 | +1000 -300 +50 = 750 | +80 (R8) | **830** |
+| M-TEST-002 | +5000 | -500 | — | **4500** |
+| M-TEST-003 | 0 | +200 +100 -100 (rev) = 200 | — | **200** |
+| M-TEST-INT-001 | 0 | — | — | **0** |
+
+驗證：
+```sql
+SELECT m.member_no, wb.balance, wb.version,
+       (SELECT SUM(change) FROM wallet_ledger wl WHERE wl.member_id = m.id) AS ledger_sum
+  FROM members m
+  LEFT JOIN wallet_balances wb ON wb.member_id = m.id
+ WHERE m.tenant_id = ?::uuid
+ ORDER BY m.member_no;
+```
+
+預期 `balance = ledger_sum` for all rows（fn_check_wallet_consistency 0 rows）。
+
+---
+
+## Regression / 不應壞
+
+- [ ] 既有 wallet read-only 顯示沒壞
+- [ ] 既有「積分流水」tab 不受影響
+- [ ] LIFF 顧客端任何頁不受影響（本軌跳過 LIFF UI 測試、但 schema 不應動）
+- [ ] admin app `pnpm build` + typecheck 過
+
+---
+
+## 驗收門檻
+
+- [ ] G3.1 ~ G3.4 + R4 + R8 + R10 + Wallet 對齊全勾
+- [ ] 既有 12 docs 各跑完 inline report
+- [ ] preview 無 console error
+- [ ] `fn_check_wallet_consistency()` 回 0 rows
+- [ ] 結 `TEST-E2E-T3-orders-wallet-report.md` status: passed
+- [ ] [TEST-INDEX.md](TEST-INDEX.md) 此軌標🟢 + 最近驗證日

--- a/docs/TEST-E2E-T4-purchase.md
+++ b/docs/TEST-E2E-T4-purchase.md
@@ -1,0 +1,127 @@
+# TEST-E2E-T4 — 採購 PR / PO / GR + 應付帳款
+
+**範圍：** PR 自動 / 手動建立、PR 拆 PO、PO 發送、GR 收貨、vendor_bills、vendor_payments、purchase_returns
+**對應 master §：** §4 / §5a / §10 (反向)
+**對應 fixture seed：** with-pr-po.sql（4 PR + 5 PO + 3 GR + 2 bills + 1 payment + 1 return）
+**反向情境：** R1 PR 取消 / R2a PO 取消（無 GR）/ R2b PO 取消（部分 GR）/ R3 GR 來貨不足
+
+---
+
+## 既有 docs
+
+| 文件 | 範圍 | 三色 | 動作 |
+|---|---|---|---|
+| TEST-pr-manual-creation.md | 手動建 PR + 加列 UI | 🟡 | 跑 |
+| TEST-picking-require-po.md | 撿貨需有對應 PO | 🟡 | 跨 T4/T5 |
+
+---
+
+## Gap addendum
+
+### G4.1 PR 多 campaign / 多 supplier 拆 PO
+- [ ] **SQL:** 從 1 PR 拆出多 PO（每 supplier 一 PO）
+  ```sql
+  SELECT pr.pr_no, pr.status, COUNT(DISTINCT poi.po_id) AS po_count
+    FROM purchase_requests pr
+    JOIN purchase_request_items pri ON pri.pr_id = pr.id
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+   GROUP BY pr.pr_no, pr.status;
+  ```
+- [ ] **驗證：** PR-0004 拆 PO-0003 (SUP-JP) + PO-0005 (SUP-LOCAL)
+
+### G4.2 vendor_bills 自動產生
+- [ ] **SQL:** GR 確認後應自動產 vendor_bill（or 手動觸發）
+- [ ] **驗證：** VB-0001 (PO-0002) amount = subtotal × 1.05 = 1500 × 1.05 = 1575 ✓
+- [ ] **驗證：** VB-0002 (PO-0004) amount = 7 × 230 × 1.05 = 1690.5（fixture 1697 略差，需確認 tax 邏輯）
+
+### G4.3 vendor_payment + allocation
+- [ ] **SQL:** VP-0001 allocate 給 VB-0001 全額 1575
+  ```sql
+  SELECT vp.payment_no, vp.amount, vpa.bill_id, vpa.allocated_amount, vb.bill_no
+    FROM vendor_payments vp
+    JOIN vendor_payment_allocations vpa ON vpa.payment_id = vp.id
+    JOIN vendor_bills vb ON vb.id = vpa.bill_id;
+  ```
+- [ ] **驗證：** VB-0001 status='paid'、paid_amount = amount
+
+### G4.4 Approval thresholds 多級
+- [ ] **驗證：** 為 SUP-JP 建 PO 金額 < 10000 → owner approval not required（only > 10000 需要）
+- [ ] **驗證：** 為 SUP-LOCAL 建 store-scope PO 金額 < 3000 → hq_manager approval
+
+### G4.5 多供應商 cost 比較（同 SKU 不同 supplier 不同 cost）
+- [ ] **UI:** /purchase/requests 編輯時應能看到 supplier_skus 多 supplier cost 比較
+- [ ] **SQL:** SKU-001 從 SUP-LOCAL=90 / SUP-JP=85 → 應推薦 JP
+
+---
+
+## 反向情境（4 維 ripple）
+
+### R1. PR cancelled (PR-0003)
+
+**Seed 起點：** PR-0003 status='cancelled', notes='R1: PR 取消（HQ 拒絕）'
+
+**4 維 ripple：**
+
+| 維度 | 預期 | 驗證 SQL |
+|---|---|---|
+| stock_movements | 0 (無動到庫存) | `SELECT * FROM stock_movements WHERE source_doc_type='purchase_request' AND source_doc_id=(SELECT id FROM purchase_requests WHERE pr_no='PR-0003');` |
+| wallet_ledger | 不影響 | — |
+| customer_order_items | 不影響 | — |
+| store_monthly_settlement | 不影響 | — |
+
+**額外：** 不應產 vendor_bill / 不應出現在 inbox
+
+### R2a. PO cancelled (no GR) — PO-0003
+
+**Seed 起點：** PO-0003 status='cancelled', qty_ordered=10, qty_received=0
+
+**4 維 ripple：**
+
+| 維度 | 預期 | 驗證 SQL |
+|---|---|---|
+| stock_movements | 0 | `SELECT * FROM stock_movements WHERE source_doc_type='goods_receipt' AND source_doc_id IN (SELECT id FROM goods_receipts WHERE po_id=(SELECT id FROM purchase_orders WHERE po_no='PO-0003'));` |
+| 對應 PR | PR-0004 對應 SKU-001 行的 po_item_id 應 NULL or 釋放回 unallocated | `SELECT pri.po_item_id FROM purchase_request_items pri JOIN purchase_requests pr ON pr.id=pri.pr_id WHERE pr.pr_no='PR-0004' AND pri.sku_id=(SELECT id FROM skus WHERE sku_code='SKU-001');` |
+| vendor_bill | 不應產 | `SELECT * FROM vendor_bills WHERE source_id=(SELECT id FROM purchase_orders WHERE po_no='PO-0003');` 應 0 rows |
+
+### R2b. PO cancelled (partial GR) — PO-0004
+
+**Seed 起點：** PO-0004 status='cancelled', qty_ordered=10, qty_received=7（GR-0002 confirmed 7 件）
+
+**4 維 ripple：**
+
+| 維度 | 預期 | 驗證 SQL |
+|---|---|---|
+| stock_movements | 1 筆 purchase_receipt @ WH-HQ qty=7 | `SELECT quantity FROM stock_movements WHERE source_doc_type='goods_receipt' AND source_doc_id=(SELECT id FROM goods_receipts WHERE gr_no='GR-0002');` 應 = 7 |
+| vendor_bill | VB-0002 status='pending', amount = 7×230×1.05 ≈ 1690 | `SELECT bill_no, status, amount FROM vendor_bills WHERE bill_no='VB-0002';` |
+| 剩 3 件 | 不應出現在後續流程（cancelled 部分被丟棄） | — |
+
+### R3. GR shortage — PO-0005 / GR-0003
+
+**Seed 起點：** PO-0005 status='partially_received', qty_ordered=8, qty_received=5; GR-0003 confirmed for 5
+
+**4 維 ripple：**
+
+| 維度 | 預期 | 驗證 SQL |
+|---|---|---|
+| stock_movements | 1 筆 purchase_receipt @ WH-HQ qty=5 SKU-002 | `SELECT * FROM stock_movements WHERE source_doc_type='goods_receipt' AND source_doc_id=(SELECT id FROM goods_receipts WHERE gr_no='GR-0003');` |
+| GR variance_reason | 'R3: 來貨不足 5/8 — 短少 3 件，預期成 backorder' | `SELECT variance_reason FROM goods_receipt_items gri JOIN goods_receipts gr ON gr.id=gri.gr_id WHERE gr.gr_no='GR-0003';` |
+| backorders | 應有 1 筆對應短少（未來補貨）| `SELECT * FROM backorders WHERE sku_id=(SELECT id FROM skus WHERE sku_code='SKU-002') AND status='pending';` |
+| vendor_bill | 應只 bill 5 件（不是 8）| `SELECT amount FROM vendor_bills vb JOIN vendor_bill_items vbi ON vbi.bill_id=vb.id WHERE vbi.sku_id=(SELECT id FROM skus WHERE sku_code='SKU-002');` |
+
+### Purchase return（PRET-0001）
+
+**Seed 起點：** PRET-0001 confirmed, return SKU-004 1 件
+
+**驗證：**
+- [ ] **SQL:** stock_movements 1 筆 return_to_supplier @ WH-HQ qty=-1 SKU-004
+- [ ] **SQL:** purchase_return_items.movement_id 對應該 movement
+- [ ] **SQL:** WH-HQ stock_balances SKU-004 = 100(open) + 10(GR-0001) - 1(return) = 109
+
+---
+
+## 驗收門檻
+
+- [ ] G4.1 ~ G4.5 全勾
+- [ ] R1 / R2a / R2b / R3 + purchase_return 4 維 ripple 全驗
+- [ ] 既有 2 docs 各跑完
+- [ ] 結 `TEST-E2E-T4-purchase-report.md` status: passed

--- a/docs/TEST-E2E-T5-wms-shipping.md
+++ b/docs/TEST-E2E-T5-wms-shipping.md
@@ -1,0 +1,103 @@
+# TEST-E2E-T5 — WMS 出貨（Wave / Pick / Ship / Receive / 逆轉 / 異常）
+
+**範圍：** picking_waves 建立 / 撿貨 / generate_transfer_from_wave / hq_to_store transfer ship / receive / wave 取消 / 撿貨不足 / 異常處理工作台
+**對應 master §：** §5a / §5b / §12 / §15 (反向)
+**對應 fixture seed：** with-picking-wave.sql（WAVE-0001 picked R5 + WAVE-0002 cancelled R9）+ with-pr-po（GR）+ with-transfers（hq_to_store TF-0002/0005/0006）
+**反向情境：** R5 撿貨不足 / R9 wave 整單取消
+
+---
+
+## 既有 docs
+
+| 文件 | 範圍 | 三色 | 動作 |
+|---|---|---|---|
+| TEST-arrive-and-distribute.md | rpc_arrive_and_distribute 進貨派送 | 🟡 | 跑 |
+| TEST-hq-dispatch-ui.md | HQ 派貨 UI | 🟢 | relink |
+| TEST-picking-require-po.md | 撿貨需要對應 PO | 🟡 | 跨 T4/T5 |
+
+---
+
+## Gap addendum
+
+### G5.1 stock_movements 鏈完整
+- [ ] **SQL:** GR confirmed → 1 筆 purchase_receipt @ HQ
+- [ ] **SQL:** wave generate_transfer_from_wave → 對每店建 transfer + transfer_out movement @ HQ + transfer_in movement @ store
+- [ ] **驗證鏈:**
+  ```sql
+  SELECT sm.movement_type, sm.quantity, sm.location_id, sm.source_doc_type, sm.source_doc_id
+    FROM stock_movements sm
+   WHERE sm.tenant_id = ?::uuid
+     AND sm.source_doc_type IN ('purchase_receipt','transfer','customer_order','purchase_return')
+   ORDER BY sm.created_at;
+  ```
+
+### G5.2 stock_balances 一致性
+- [ ] **SQL:** 對每 (location, sku) 的 balance.on_hand = SUM(stock_movements.quantity)
+  ```sql
+  SELECT sb.location_id, sb.sku_id, sb.on_hand,
+         (SELECT SUM(quantity) FROM stock_movements sm
+           WHERE sm.tenant_id = sb.tenant_id
+             AND sm.location_id = sb.location_id
+             AND sm.sku_id = sb.sku_id) AS calc_on_hand
+    FROM stock_balances sb
+   WHERE sb.on_hand <> (SELECT COALESCE(SUM(quantity),0) FROM stock_movements sm
+                         WHERE sm.location_id = sb.location_id AND sm.sku_id = sb.sku_id);
+  -- expect 0 rows (full balance reconciliation)
+  ```
+
+### G5.3 Wave generate transfers post-condition
+- [ ] **SQL:** picking_wave_items.generated_transfer_id 對 picked > 0 都有值
+- [ ] **SQL:** transfer count 對應 distinct stores in wave_items
+
+### G5.4 異常處理工作台 `/wms/exceptions`
+- [ ] **UI:** 應列出 R5 / R6 / R3 異常 row（從 fixture seed 可見）
+- [ ] **UI:** 點 row 後 → 對應 RPC 流程（resolve / 補單 / 退）
+
+### G5.5 收件匣整合（pickers task → /hq/inbox）
+- [ ] **驗證：** WAVE-0001 picked 但未 shipped → inbox `pending` tab 有 row
+- [ ] **驗證：** WAVE-0002 cancelled → 不在 inbox
+
+---
+
+## 反向情境（4 維 ripple）
+
+### R5. 撿貨不足量 — WAVE-0001 SKU-003
+
+**Seed 起點：** WAVE-0001 status='picked'，picking_wave_items SKU-003（ORD-0002）申請 2 / 撿 1，shortage 1; backorders 1 row pending
+
+**4 維 ripple：**
+
+| 維度 | 預期 | 驗證 SQL |
+|---|---|---|
+| stock_movements | wave 撿到的 1 個還沒走 sale movement（要等 transfer ship 才會走 transfer_out）| 此時應 0 筆 sale movement for WAVE-0001 |
+| wallet_ledger | wave 不直接動 wallet | — |
+| customer_order_items | ORD-0002 SKU-003 對應 line 預期狀態：撿不足要怎麼標？（fixture 沒改 status，需確認業務語意）| `SELECT status, qty FROM customer_order_items coi JOIN customer_orders o ON o.id=coi.order_id WHERE o.order_no='ORD-0002';` |
+| store_monthly_settlement | hq_to_store transfer 還沒 generate（wave generate 後才有）| — |
+| backorders | 1 row pending、qty_pending=1、original_customer_order_item_id 對 ORD-0002 SKU-003 | `SELECT * FROM backorders WHERE original_customer_order_item_id IN (SELECT coi.id FROM customer_order_items coi JOIN customer_orders o ON o.id=coi.order_id WHERE o.order_no='ORD-0002');` |
+| picking_wave_audit_log | 'picked_qty_changed' 含 shortage:1 | `SELECT after_value, note FROM picking_wave_audit_log WHERE wave_id=(SELECT id FROM picking_waves WHERE wave_code='WAVE-0001') AND action='picked_qty_changed';` |
+
+### R9. Wave 整單取消 — WAVE-0002
+
+**Seed 起點：** WAVE-0002 status='cancelled'
+
+**4 維 ripple：**
+
+| 維度 | 預期 | 驗證 SQL |
+|---|---|---|
+| stock_movements | 0（wave 還沒走到 transfer 階段就被取消）| — |
+| picking_wave_items | picked_qty=NULL、generated_transfer_id=NULL | — |
+| customer_order_items | ORD-0003 SKU-008 不受影響（仍可被另一 wave 撿）| — |
+| audit log | 1 筆 'wave_cancelled' | `SELECT after_value FROM picking_wave_audit_log WHERE wave_id=(SELECT id FROM picking_waves WHERE wave_code='WAVE-0002') AND action='wave_cancelled';` |
+
+### Wave reverse（派貨後逆轉，per memory `session_resume_2026-04-26_wave12_cleanup.md`）
+- [ ] **驗證：** 已 shipped wave 走逆轉 → transfers cancel + stock 反流
+- [ ] **驗證：** 對應 customer_order_items 釋放回 reserved
+
+---
+
+## 驗收門檻
+
+- [ ] G5.1 ~ G5.5 全勾
+- [ ] R5 / R9 + wave reverse 4 維 ripple 全驗
+- [ ] 既有 3 docs 各跑完
+- [ ] 結 `TEST-E2E-T5-wms-shipping-report.md` status: passed

--- a/docs/TEST-E2E-T6-returns-transfers.md
+++ b/docs/TEST-E2E-T6-returns-transfers.md
@@ -1,0 +1,167 @@
+# TEST-E2E-T6 — 退貨 / 轉貨 / 互助 / 月結算
+
+**範圍：** free transfer 店↔店 / 店→總倉退貨（rpc_create_order_return）/ 互助板 offer/request/claim/reply / 88 折出清 / transfer_settlements / store_monthly_settlements
+**對應 master §：** §6a / §6b / §13 / §17 / §18 (反向)
+**對應 fixture seed：** with-transfers (6 TF + 1 settlement) + with-mutual-aid (3 req + 4 offer + 3 reply + 3 claim) + with-monthly-settlement (2 SMS draft)
+**反向情境：** R6a Transfer 拒收 / R6b 運送破損 / R7 過期 write-off / R11a-d 互助 offer 取消 / R12 互助 received 後退單
+
+---
+
+## 既有 docs
+
+| 文件 | 範圍 | 三色 | 動作 |
+|---|---|---|---|
+| TEST-rpc-receive-transfer.md | rpc_receive_transfer 收貨 | 🟡 | 跑 |
+| TEST-transfer-hq-dispatch.md | HQ 派貨 dispatch | 🟢 | relink |
+| TEST-mutual-aid-board.md | 互助板 baseline | 🟢 | relink |
+
+---
+
+## Gap addendum
+
+### G6.1 退貨回總倉必須關聯訂單（per memory）
+> Memory `feedback_return_to_hq_requires_order.md`：店→總倉走 `rpc_create_order_return`，限 SKU + qty ≤ 已派量 - 已退量
+
+- [ ] **驗證 RPC 存在：** `SELECT proname FROM pg_proc WHERE proname = 'rpc_create_order_return';`
+- [ ] **正面測試：** 對 ORD-0006 已派 SKU-002 ×2 → 退 1 件回 HQ
+- [ ] **負面測試：** 退超量（已派 2、退 3）→ RAISE
+- [ ] **負面測試：** 退非該訂單的 SKU → RAISE
+- [ ] **負面測試：** 跨 tenant → RAISE
+
+> ⚠ **若 RPC 不存在：** 標 RED in INDEX，flag 開新 issue
+
+### G6.2 store → store 自由轉貨
+- [ ] **正面：** rpc_create_free_transfer S001 → S002 SKU-001 ×2 → 應建 transfer + transfer_items（draft）
+- [ ] **負面：** S001 → HQ → 應 RAISE「店→總倉必須走 order return」（符合 memory）
+
+### G6.3 互助板完整流程
+- [ ] **rpc_post_aid_board:** offer 必帶 source_customer_order_id（per fixture R11 demo）
+- [ ] **rpc_post_aid_board:** request 不能帶 source_customer_order_id
+- [ ] **rpc_post_aid_reply:** 對 active board 留言 OK
+- [ ] **rpc_close_aid_board:** active → cancelled / exhausted
+- [ ] **rpc_claim_aid:** 認領應自動建 transfer + claim row（fixture AID-OFR-001 已 demo）
+
+### G6.4 88 折出清（aid_clearance_offers）
+- [ ] **RPC:** `rpc_post_clearance_offer` / `rpc_claim_clearance` / `rpc_convert_clearance_to_demand`
+- [ ] **驗證 discount_rate enum：** CHECK IN (0.88, 0.85, 0.80)
+- [ ] **驗證流程：** offer → store_claim or convert_to_demand
+
+### G6.5 transfer_settlements 結算
+- [ ] **正面：** rpc_generate_transfer_settlement(month) → draft settlements
+- [ ] **驗證：** seed 有 1 筆 draft (TF-0003 對 S002↔S004)
+- [ ] **rpc_confirm_transfer_settlement:** draft → confirmed → 應產 vendor_bill
+
+### G6.6 store_monthly_settlements 月結
+- [ ] **驗證：** seed 2 筆 draft (SMS-S001=1840 / SMS-S002=450)
+- [ ] **計算驗證：**
+  ```sql
+  SELECT sms.store_id, sms.payable_amount,
+         (SELECT SUM(qty_received * unit_cost) FROM store_monthly_settlement_items
+           WHERE settlement_id = sms.id) AS calc
+    FROM store_monthly_settlements sms;
+  ```
+  payable_amount 應 = SUM(items.line_amount)
+
+---
+
+## 反向情境（4 維 ripple）
+
+### R6a. Transfer 拒收 — TF-0004
+
+**Seed 起點：** TF-0004 status='cancelled', transfer_type='hq_to_store', source=WH-HQ dest=WH-S005, qty_shipped=8, qty_received=0
+**stock_movements:** transfer_out -8 + transfer_reject +8 (reverses out)
+
+**4 維 ripple：**
+
+| 維度 | 預期 | 驗證 SQL |
+|---|---|---|
+| stock_movements | 2 筆 (transfer_out -8 + transfer_reject +8)、reverses 連結對 | `SELECT movement_type, quantity, reverses FROM stock_movements WHERE source_doc_id=(SELECT id FROM transfers WHERE transfer_no='TF-0004');` |
+| stock_balances | WH-HQ SKU-007 變化淨 0（出 8 + 反流回 8）| WH-HQ SKU-007 應 = 開帳 100（不變）|
+| customer_order_items | 不直接影響（hq_to_store transfer 不直接綁訂單）| — |
+| store_monthly_settlement | 不入 SMS（status='cancelled'）| 確認 SMS-S005（如有）不含 TF-0004 |
+
+### R6b. 運送遺失/破損 — TF-0005
+
+**Seed 起點：** TF-0005 status='received', source=WH-HQ dest=WH-S001, qty_shipped=10, qty_received=8 (-2 damage)
+**stock_movements:** transfer_out -10 + transfer_in +8 + damage -2 (at HQ)
+
+**4 維 ripple：**
+
+| 維度 | 預期 | 驗證 SQL |
+|---|---|---|
+| stock_movements | 3 筆（out -10 / in +8 / damage -2 全 @ HQ source）| `SELECT movement_type, quantity, location_id FROM stock_movements WHERE source_doc_id=(SELECT id FROM transfers WHERE transfer_no='TF-0005');` |
+| stock_balances | WH-HQ SKU-006: 100(open) - 10 - 2 = 88; WH-S001 SKU-006: 20(open) + 8 = 28 | reconcile per G5.2 |
+| store_monthly_settlement | SMS-S001 應入 8 件（不是 10）= 8 × 230 = 1840 ✓ | `SELECT line_amount FROM store_monthly_settlement_items smsi JOIN transfers t ON t.id=smsi.transfer_id WHERE t.transfer_no='TF-0005';` 應 = 1840 |
+| 損失 2 件帳上 | HQ 損失需有去處（write-off 或保險）— damage movement 已記、後續會計處理 | — |
+
+### R7. 店家發現過期 (write-off)
+
+**Seed 起點：** （未有專屬 fixture，需透過 master 跑時模擬）
+
+**驗證：**
+- [ ] **RPC:** `rpc_register_damage` 在 S001 倉對 SKU-XXX 寫 -X 件 type='damage'
+- [ ] **stock_movements:** 1 筆 damage @ S001
+- [ ] **stock_balances:** S001 SKU-XXX 對應減
+- [ ] **月結算:** 該 stock 已過月結 → 不影響本月 SMS（但需確認 credit memo 邏輯）
+
+### R11a/b/c. 互助 offer 取消（fixture R11 chain）
+
+**Seed 起點：**
+- AID-OFR-002 status='cancelled', 無 claim
+- AID-OFR-003 status='cancelled', 1 claim (claim 留 audit、無 transfer)
+- AID-OFR-004 status='cancelled', 1 claim (TF-AID-002 cancelled, transfer_out + transfer_reject 反流)
+
+**4 維 ripple per scenario：**
+
+| 子情境 | stock_movements | wallet_ledger | customer_order | SMS |
+|---|---|---|---|---|
+| R11a | 0 | 0 | 不影響（source_order ORD-0001 留原狀）| 0 |
+| R11b | 0 | 0 | 不影響（source_order ORD-0004 留原狀）| 0 |
+| R11c | 2 (out + reject reverse) | 0 | source_order ORD-0003 留原狀（offer 不消耗 order）| 0 |
+| R11d | (取貨後退) customer_return + wallet refund | refund row | items.status='returned' | 看月結時點 |
+
+**驗證 SQL：**
+```sql
+-- 各 R11 board 的 status + claim
+SELECT b.note, b.status, b.qty_remaining, c.id AS claim_id, c.resulting_transfer_id
+  FROM mutual_aid_board b
+  LEFT JOIN mutual_aid_claims c ON c.board_id = b.id
+ WHERE b.note LIKE 'R11%' OR b.note LIKE 'AID-OFR%'
+ ORDER BY b.note;
+
+-- R11c stock_movements 反流鏈
+SELECT sm.movement_type, sm.quantity, sm.reverses, sm.reason
+  FROM stock_movements sm
+ WHERE sm.source_doc_id = (SELECT id FROM transfers WHERE transfer_no='TF-AID-002')
+ ORDER BY sm.created_at;
+```
+
+### R12. 互助 received 後對方退單（**RPC gap**）
+
+**情境：** offer 已 claimed → transfer shipped → **received** → 對面店反悔退單
+**既有 RPC `rpc_cancel_aid_order` 對 received 階段 RAISE「不能撤」**
+
+**Workaround 流程：**
+- B（受方）建 free transfer B → A 反向 1 件 → ship → A receive
+- mutual_aid_board.qty_remaining 需手動 +1 回（因為 RPC 沒覆蓋）or 開新 offer
+
+**驗證：**
+- [ ] **RAISE 驗證：**
+  ```sql
+  -- 找一筆 received 階段的 aid order，跑 rpc_cancel_aid_order → 應 RAISE
+  SELECT rpc_cancel_aid_order(?::bigint, '退單', ?::uuid);
+  -- expect: ERROR — 已 received 的不能撤
+  ```
+- [ ] **Workaround 驗證：** 建 reverse free transfer，stock 應對得上
+
+> ⚠ **後續 issue：** 考慮新增 `rpc_return_aid_order` 處理 received 階段退單（含 wallet refund + qty_remaining 還原）
+
+---
+
+## 驗收門檻
+
+- [ ] G6.1 ~ G6.6 全勾
+- [ ] R6a / R6b / R7 / R11a/b/c / R12 4 維 ripple 全驗
+- [ ] 既有 3 docs 各跑完
+- [ ] 結 `TEST-E2E-T6-returns-transfers-report.md` status: passed
+- [ ] **若 R12 確認 RPC gap：** 開新 issue「Add rpc_return_aid_order for received-aid cancellation」

--- a/docs/TEST-E2E-T7-inbox.md
+++ b/docs/TEST-E2E-T7-inbox.md
@@ -1,0 +1,103 @@
+# TEST-E2E-T7 — HQ 收件匣
+
+**範圍：** /hq/inbox unified inbox / restock 整合 / 撿貨整合 / counts RPC / 4 個 tab（pending / in_transit / done / 全部）/ 真分頁
+**對應 master §：** §8
+**對應 fixture seed：** 整體 seed（campaign close / PR / wave / aid post / restock 都會在 inbox 出現）
+**反向情境：** 主要為「不應在 inbox 出現」的反向驗證
+
+---
+
+## 既有 docs
+
+| 文件 | 範圍 | 三色 | 動作 |
+|---|---|---|---|
+| TEST-store-self-service.md | 加盟店自助 / restock | 🟡 | 跑（部分 cover）|
+
+> T7 既有 doc 少，本軌主要是 **inline checklist**。
+
+---
+
+## Inline checklist
+
+### G7.1 RPCs 存在
+- [ ] `rpc_hq_inbox_keys` 存在、SECDEF
+- [ ] `rpc_inbox_counts` 存在、回傳 4 tab 計數
+  ```sql
+  SELECT proname, prosecdef, pg_get_function_arguments(oid)
+    FROM pg_proc WHERE proname IN ('rpc_hq_inbox_keys','rpc_inbox_counts');
+  ```
+
+### G7.2 Inbox 來源整合（per recent commits）
+> commit `b80835f`: 採購頁 KPI 重設計 + 撿貨整合進收件匣 + 軟取消 wave
+> commit `be0091f`: counts 改一支 RPC + 「全部」視圖真分頁
+
+- [ ] **驗證：** /hq/inbox 涵蓋以下來源（每個都該有 row）：
+  - campaign close 通知（CAMP-004/005 status='closed'）
+  - PR auto-create / 待審（PR-0002 status='fully_ordered' / PR-0004 status='submitted'）
+  - PR cancelled (PR-0003 應在 done tab 或不顯示)
+  - PO partially_received / pending (PO-0005)
+  - GR confirmed 待後續處理
+  - restock requests
+  - mutual aid 求助/出讓 (active 7 筆 + cancelled 4 筆)
+  - shortage events (ORD-0007)
+  - picking wave 撿貨任務 (WAVE-0001 picked / WAVE-0002 cancelled)
+  - transfer 收貨待處理 (TF-0002 shipped 等待 dest 收)
+
+### G7.3 Counts RPC 一致性
+- [ ] **SQL:** rpc_inbox_counts() 回傳 4 個數字：pending + in_transit + done + 全部
+  ```sql
+  SELECT * FROM rpc_inbox_counts();
+  -- expect: 4 rows or 1 row 4 cols
+  ```
+- [ ] **驗證：** counts.pending = inbox-keys WHERE status='pending' 的 distinct row 數
+- [ ] **驗證：** counts.全部 = pending + in_transit + done
+
+### G7.4 真分頁（per commit be0091f）
+- [ ] **UI:** /hq/inbox 「全部」視圖切到 page 2 → 應走 server-side 分頁、不在 client 分
+- [ ] **驗證：** 後端 RPC 接 page / page_size 參數、回傳對應 slice
+
+### G7.5 撿貨整合（per commit b80835f）
+- [ ] **UI:** /hq/inbox 看到 picking wave 任務（pending tab 應有 WAVE-0001）
+- [ ] **UI:** 點 wave row → 跳到 /wms/picking/[wave_id] 正確
+
+### G7.6 軟取消 wave（per commit b80835f）
+- [ ] **驗證：** WAVE-0002 cancelled → 不在 pending tab、可在 done tab 找到
+- [ ] **UI:** done tab 顯示「已取消」標籤
+
+### G7.7 Restock 整合
+- [ ] **驗證：** 加盟店發 restock request → HQ inbox 應有 row（pending tab）
+- [ ] **rpc_approve_restock_to_pr / rpc_approve_restock_to_transfer / rpc_reject_restock**: 三種處理方式
+- [ ] **驗證：** approve_to_pr → restock 移到 done、新 PR 建在 in_transit
+- [ ] **驗證：** approve_to_transfer → restock 移到 done、新 transfer 建在 in_transit
+
+### G7.8 6 頁列表 unified table 樣式（per commit 7f11418）
+- [ ] **UI:** /hq/inbox 列表樣式 + /restock + /transfers + /orders + ... 應對齊（同樣 column / hover / pagination）
+
+---
+
+## 反向情境（負面驗證）
+
+### Cancelled / closed 不應在 pending tab
+- [ ] PR-0003 (cancelled) 不在 pending
+- [ ] PO-0003 (cancelled) 不在 pending
+- [ ] PO-0004 (cancelled) 不在 pending
+- [ ] WAVE-0002 (cancelled) 不在 pending
+- [ ] AID-OFR-002/3/4 (cancelled offer) 不在 pending
+- [ ] CAMP-010 (completed) 不在 pending
+
+### Done 不應重複出現在 pending
+- [ ] GR-0001 (confirmed) 出現在 done tab、不在 pending tab
+- [ ] VP-0001 (paid) 不出現在 pending tab
+
+### 跨 tenant
+- [ ] anon 連 inbox → 0 rows
+- [ ] branch user 連 inbox → 應只看自己 store 相關（hq_to_store 給該 store 的、自己 store 發出的 restock）
+
+---
+
+## 驗收門檻
+
+- [ ] G7.1 ~ G7.8 全勾
+- [ ] 反向「不應出現」全驗
+- [ ] 既有 1 doc 跑完
+- [ ] 結 `TEST-E2E-T7-inbox-report.md` status: passed

--- a/docs/TEST-E2E-master.md
+++ b/docs/TEST-E2E-master.md
@@ -1,0 +1,328 @@
+# TEST-E2E-master — 一日營運循環黃金路徑
+
+> 從候選 → 開團 → 訂單 → 採購 → 撿貨 → 派貨 → 退貨 → 月結 整個串。**半手動**：SQL/RPC 驗資料層 + preview MCP 點 admin UI。
+
+**對應 plan：** `C:\Users\Alex\.claude\plans\q1-c-q2-b-expressive-emerson.md`
+**對應 INDEX：** [TEST-INDEX.md](TEST-INDEX.md)
+**Sub-docs：** T1-T10 共 8 軌、各自 gap addendum 對應到此 master 對應 § 編號
+
+---
+
+## Prerequisites
+
+### 1. seed
+```bash
+bash scripts/e2e/reset.sh full-demo --yes
+```
+
+跑完應看到 row count summary，預期至少：
+
+| table | count (≥) | 來源 |
+|---|---|---|
+| locations | 6 | 01-master |
+| stores | 5 | 01-master |
+| products | 10 | 01-master |
+| skus | 10 | 01-master |
+| sku_packs | 13 | 01-master（10 base + P004/P008/P010 multi）|
+| prices | 40 | 01-master（10 retail + 30 tier）|
+| supplier_skus | 15 | 01-master（10 LOCAL + 4 JP + 1 XL）|
+| line_channels | 3 | 01-master |
+| post_templates | 3 | 01-master |
+| purchase_approval_thresholds | 5 | 01-master |
+| categories | 17 | 01-master（3 level1 + 9 level2 + 5 level3）|
+| members | 4 | 02-base |
+| member_cards | 4 | 02-base |
+| member_line_bindings | 3 | 02-base |
+| customer_line_aliases | 4 | 02-base（3 LC-MAIN + 1 LC-VIP）|
+| wallet_balances | 4 | 02-base / with-wallet-history |
+| wallet_ledger | 7+ | 02-base 1 topup + with-wallet-history 6 |
+| group_buy_campaigns | 10 | with-campaign |
+| campaign_items | 16 | with-campaign |
+| customer_orders | 8 | with-orders |
+| customer_order_items | 14+ | with-orders |
+| order_shortage_events | 1 | with-orders R4 |
+| order_pickup_events | 2 | with-orders（ORD-0004/0006）|
+| customer_order_sources | 3 | with-orders |
+| stock_balances | 60 | with-stock 觸發 |
+| stock_movements | 60+ | with-stock 開帳 + GR + transfer + R8 |
+| picking_waves | 2 | with-picking-wave |
+| picking_wave_items | 4 | with-picking-wave |
+| picking_wave_audit_log | 7 | with-picking-wave |
+| backorders | 1 | with-picking-wave R5 |
+| purchase_requests | 4 | with-pr-po |
+| purchase_orders | 5 | with-pr-po |
+| goods_receipts | 3 | with-pr-po |
+| vendor_bills | 2 | with-pr-po |
+| vendor_payments | 1 | with-pr-po |
+| vendor_payment_allocations | 1 | with-pr-po |
+| purchase_returns | 1 | with-pr-po |
+| transfers | 8 | with-transfers 6 + with-mutual-aid 2 |
+| transfer_items | 10+ | |
+| transfer_settlements | 1 | with-transfers |
+| transfer_settlement_items | 1 | with-transfers |
+| store_monthly_settlements | 2 | with-monthly-settlement |
+| store_monthly_settlement_items | 2 | with-monthly-settlement |
+| mutual_aid_board | 7 | with-mutual-aid（3 req + 4 offer）|
+| mutual_aid_replies | 3 | with-mutual-aid |
+| mutual_aid_claims | 3 | with-mutual-aid |
+
+抓的指令：
+```sql
+SELECT 'locations' AS t, COUNT(*) FROM locations UNION ALL
+SELECT 'customer_orders', COUNT(*) FROM customer_orders UNION ALL
+SELECT 'wallet_ledger', COUNT(*) FROM wallet_ledger UNION ALL
+SELECT 'stock_movements', COUNT(*) FROM stock_movements UNION ALL
+SELECT 'transfers', COUNT(*) FROM transfers UNION ALL
+SELECT 'mutual_aid_board', COUNT(*) FROM mutual_aid_board
+ORDER BY 1;
+```
+
+### 2. admin auth user
+- `cktalex@gmail.com` 已能登入後台、`raw_app_meta_data.tenant_id` 已設
+
+### 3. preview MCP
+- `preview_start` 啟 dev server（apps/admin）
+- 之後 § 全用 preview_navigate / preview_click / preview_snapshot
+
+---
+
+## Cast（黃金路徑用既有 seed 資料）
+
+| 角色 | 來源 | 用途 |
+|---|---|---|
+| HQ 經總倉 | location WH-HQ | 採購收貨、派貨源 |
+| S001 平鎮店 | stores S001 | 主受貨點 |
+| S002 松山店 | stores S002 | 跨店轉貨 / mutual aid |
+| 小明 (M-TEST-001) | members | normal tier、wallet 750 |
+| 小華 (M-TEST-002) | members | gold tier、wallet 4500 |
+| 小芳 (M-TEST-003) | members | silver tier、wallet 200（有 R10 reversal）|
+| SUP-LOCAL | suppliers | 主供應商 |
+| 多 SKUs | from with-stock | 庫存已開帳 |
+
+---
+
+## § 1. T1 — 主檔基線驗證
+
+**目標：** 確認 seed 跑完後主檔資料完整、4 欄 audit、自動編號規則對。
+
+### SQL 驗證
+- [ ] **products / skus 已建 10 個 + 4 audit 欄位齊：**
+  ```sql
+  SELECT product_code, name, created_by, created_at, updated_by, updated_at
+    FROM products WHERE tenant_id = ?::uuid ORDER BY product_code;
+  -- expect: 10 rows, created_at IS NOT NULL
+  ```
+- [ ] **sku_packs 多規格（P004/P008/P010）：**
+  ```sql
+  SELECT s.sku_code, sp.unit, sp.qty_in_base, sp.is_default_sale
+    FROM sku_packs sp JOIN skus s ON s.id = sp.sku_id
+   WHERE s.sku_code IN ('SKU-004','SKU-008','SKU-010') ORDER BY s.sku_code, sp.unit;
+  -- expect: SKU-004 個+箱(10), SKU-008 個+盒(10), SKU-010 個+箱(6)
+  ```
+- [ ] **多供應商分配：**
+  ```sql
+  SELECT s.sku_code, sup.code AS supplier, ss.is_preferred, ss.default_unit_cost
+    FROM supplier_skus ss
+    JOIN skus s ON s.id = ss.sku_id
+    JOIN suppliers sup ON sup.id = ss.supplier_id
+   WHERE s.sku_code IN ('SKU-001','SKU-008') ORDER BY s.sku_code, sup.code;
+  -- expect: SKU-001 LOCAL(F)+JP(T), SKU-008 LOCAL(F)+XL(T)
+  ```
+- [ ] **categories 樹狀（3 層）：**
+  ```sql
+  SELECT level, COUNT(*) FROM categories GROUP BY 1 ORDER BY 1;
+  -- expect: 1=3, 2=9, 3=5
+  ```
+- [ ] **member_line_bindings 已綁 3 會員（M-TEST-001/2/3）：**
+  ```sql
+  SELECT m.member_no, mlb.line_user_id, mlb.bound_at IS NOT NULL AS bound
+    FROM member_line_bindings mlb JOIN members m ON m.id = mlb.member_id ORDER BY m.member_no;
+  ```
+
+### UI 驗證 (preview)
+- [ ] `/products` 列表渲染 10 SKU、有圖、有規格選單
+- [ ] `/members` 列表 4 會員、tier 顯示對、LINE User ID **已馬賽克**（U***）
+- [ ] `/members/M-TEST-002/detail` 錢包 tab 顯示 4500、ledger 流水有 1 筆 +5000
+
+---
+
+## § 2. T2 — 候選 → 開團
+
+**目標：** 從候選週曆推 1 個團（CAMP-MASTER-001）→ finalize → 自動觸發 PR。
+
+### SQL 驗證 baseline
+- [ ] 既有 10 campaigns（CAMP-001~010）狀態多元（open/closed/ordered/receiving/ready/completed）
+
+### 操作 + 驗證
+- [ ] preview 開 `/community-candidates/calendar`
+- [ ] 推一個 candidate → 草稿 campaign **CAMP-MASTER-001**
+  - 含 SKU-FRESH-001 (生鮮)、SKU-DRY-001 (乾貨) 兩品
+  - end_at = NOW + 3 days
+- [ ] preview 開 `/campaigns/CAMP-MASTER-001` → 點 finalize
+- [ ] **SQL: campaign_no 規則** `GB{YYYYMMDD}-C{padded6}`
+  ```sql
+  SELECT campaign_no, status FROM group_buy_campaigns
+   WHERE campaign_no LIKE 'GB%-C%' ORDER BY created_at DESC LIMIT 1;
+  ```
+- [ ] **SQL: campaign_audit_log 寫了 finalize 記錄**
+
+---
+
+## § 3. T3 — 訂單流程（4 子段）
+
+### § 3a — 88折促銷單（小明）
+- [ ] preview `/campaigns/order-entry?campaign_no=CAMP-MASTER-001`
+- [ ] 為 M-TEST-001 開單 O-MASTER-001
+  - SKU-FRESH-001 ×2 + SKU-DRY-001 ×1
+  - 套 88 折 promo（unit_price × 0.88）
+- [ ] **SQL: 訂單明細 unit_price 對**
+  ```sql
+  SELECT o.order_no, coi.qty, coi.unit_price, coi.notes
+    FROM customer_orders o JOIN customer_order_items coi ON coi.order_id = o.id
+   WHERE o.order_no = 'O-MASTER-001';
+  ```
+
+### § 3b — wallet pay（小華）
+- [ ] 為 M-TEST-002 開單 O-MASTER-002（同 campaign）
+  - SKU-FRESH-001 ×3
+  - 用 wallet 付款（從 4500 扣 X）
+- [ ] **SQL: wallet_ledger spend row + balance 更新**
+  ```sql
+  SELECT type, change, balance_after, source_type, source_id
+    FROM wallet_ledger WHERE member_id = (SELECT id FROM members WHERE member_no = 'M-TEST-002')
+   ORDER BY id DESC LIMIT 3;
+  ```
+
+### § 3c — cross-member transfer（O-MASTER-001 SKU-DRY → O-MASTER-002）
+- [ ] preview 開 `/orders/O-MASTER-001` → 點轉手 → 選 O-MASTER-002
+- [ ] **SQL: customer_order_items 拆 + transferred_from / transferred_to FK**
+
+### § 3d — soft-cancel + 負數訂單
+- [ ] O-MASTER-001 SKU-FRESH 取消 → 整單轉成負數
+- [ ] **SQL: order status='cancelled' + offset order created**
+- [ ] **SQL: wallet refund 88 折金額（如有預扣）**
+
+---
+
+## § 4. T4 — 採購 PR → PO → 發送
+
+- [ ] §2 finalize 應自動觸發 PR（驗證 PR-MASTER-001 存在）
+- [ ] preview `/purchase/requests/[id]/edit` → 補加 SKU-FRESH +5
+- [ ] close PR → split PO（PO-MASTER-001 to SUP-LOCAL）
+- [ ] preview 點 send → status='sent'、`sent_at` 寫入
+- [ ] **SQL: 確認 GENERATED line_subtotal 對**
+
+---
+
+## § 5. T5 — WMS 收貨 + 撿貨 + 派貨
+
+### § 5a 收 PO
+- [ ] preview `/wms/receiving` → 收 PO-MASTER-001 全量 → confirm GR
+- [ ] **SQL: stock_movements purchase_receipt + stock_balances 對應 +5**
+
+### § 5b Wave + 撿貨 + 派貨
+- [ ] preview `/wms/picking` → 為 CAMP-MASTER-001 + S001/S002 建 wave **WAVE-MASTER-001**
+- [ ] 撿貨：S001 撿 SKU-FRESH ×2、S002 撿 SKU-FRESH ×3
+- [ ] confirm picked → status='picked'
+- [ ] generate transfer → 自動建 hq_to_store transfers（每店 1 張）
+- [ ] mark shipped
+- [ ] **SQL: stock_movements transfer_out 對 + picking_wave_audit_log 完整**
+
+---
+
+## § 6. T6 — 退貨 / 互助（2 子段）
+
+### § 6a — S002 收 transfer
+- [ ] preview S002 視角 `/wms/receiving` → 收 wave 派來的 transfer
+- [ ] **SQL: stock_movements transfer_in @ S002 location**
+
+### § 6b — S002 缺 SKU-FRESH → 互助板 → S001 提供 → offset
+- [ ] preview `/inventory/mutual-aid` → S002 發 request post（SKU-FRESH ×1）
+- [ ] S001 認領 → mutual_aid_claims + transfer 自動建立
+- [ ] **SQL: mutual_aid_board.qty_remaining 扣減正確**
+
+---
+
+## § 7. T3 收尾 — pickup + wallet refund
+- [ ] preview `/pickup` (S002 視角) → 雙會員取貨
+- [ ] O-MASTER-002 部分退費 → wallet refund 補回（rpc_wallet_refund）
+- [ ] **SQL: order_pickup_events 寫入 + wallet refund row**
+
+---
+
+## § 8. T7 — HQ 收件匣 unified
+
+- [ ] preview `/hq/inbox` → 切 4 個 tab（pending / in_transit / done / 全部）
+- [ ] **SQL: rpc_hq_inbox_keys + rpc_inbox_counts 回傳對**
+- [ ] 確認 master 跑出來的：CAMP-MASTER-001 close / PR-MASTER-001 / wave / aid post 都在 inbox 出現
+
+---
+
+## § 9. T10 — 安全 RLS + LINE 馬賽克 + audit
+
+### § 9a RLS 矩陣
+- [ ] **HQ admin** 連 `customer_orders`：能讀 8+ 筆
+- [ ] **S001 branch user** 連 `customer_orders`：只應讀 home_store=S001 的訂單
+  ```sql
+  SET LOCAL ROLE authenticated;  -- 模擬 branch user
+  -- 加上 jwt claims 模擬 store_id=S001
+  ```
+- [ ] **anonymous** 連 `customer_orders`：0 rows
+
+### § 9b LINE User ID 馬賽克
+- [ ] preview HQ 後台 `/members/M-TEST-001/detail` 顯示完整 LINE User ID（HQ 看得到）
+- [ ] preview branch user 視角同頁 → 應顯示 `U***xyz`
+- [ ] **SQL: 任何 view 不得回 raw line_user_id 給非 HQ role**
+  ```sql
+  SELECT proname FROM pg_proc WHERE proname LIKE 'rpc_%' AND prosecdef = TRUE;
+  ```
+
+### § 9c audit 4 欄位覆蓋
+- [ ] 主檔表（products / customer_orders / transfers / purchase_requests / store_monthly_settlements / wallet_balances）created_by/updated_by/created_at/updated_at 4 欄齊
+  ```sql
+  SELECT table_name FROM information_schema.columns
+   WHERE column_name IN ('created_by','created_at','updated_by','updated_at')
+   GROUP BY 1 HAVING COUNT(*) = 4 ORDER BY 1;
+  ```
+- [ ] wallet_ledger / customer_order_sources / order_pickup_events 是 append-only（trigger `forbid_append_only_mutation` / `forbid_ledger_mutation` 仍掛）
+  ```sql
+  SELECT tgname FROM pg_trigger WHERE NOT tgisinternal AND tgname LIKE 'trg_no_%';
+  ```
+
+---
+
+## 驗收門檻
+
+- [ ] §1-§9 全勾、preview 無 console error
+- [ ] `fn_check_wallet_consistency()` 回 0 rows（所有 member 的 ledger 累加 = balance）
+- [ ] `apps/admin` `pnpm build` 過、`pnpm typecheck` 過
+- [ ] 寫 `TEST-E2E-master-report.md`、status: passed
+- [ ] 同步回填 [TEST-INDEX.md](TEST-INDEX.md) 軌道狀態 + 最近驗證日
+
+---
+
+## 反向情境驗證（黃金路徑跑完後另跑）
+
+每個反向情境跑「**從 seeded 終態驗 4 維 ripple 對不對**」：
+
+| § | 反向 | 對應軌 sub-doc | seeded 起點 |
+|---|---|---|---|
+| §10 R1-R3 採購反向 | T4 | T4-purchase | PR-0003 / PO-0003 / PO-0004 / GR-0002 / GR-0003 |
+| §11 R4 訂單缺貨 | T3 | T3-orders-wallet | ORD-0007 + order_shortage_events |
+| §12 R5 撿貨不足 | T5 | T5-wms-shipping | WAVE-0001 + backorders |
+| §13 R6a/R6b 轉貨 | T6 | T6-returns-transfers | TF-0004 / TF-0005 + stock_movements |
+| §14 R8 客退 | T3 | T3-orders-wallet | ORD-0006 + customer_return movement + refund |
+| §15 R9 wave 取消 | T5 | T5-wms-shipping | WAVE-0002 |
+| §16 R10 wallet reversal | T3 | T3-orders-wallet | M-TEST-003 reversal row |
+| §17 R11a/b/c aid 取消 | T6 | T6-returns-transfers | AID-OFR-002/3/4 |
+| §18 R12 aid 退單（gap）| T6 | T6-returns-transfers | 走 free transfer 反向 workaround |
+
+各軌 sub-doc 會逐項列 4 維 ripple 驗證 SQL。
+
+---
+
+## 附錄：跑完後同步
+
+依使用者偏好（feedback memory）：
+- 更新 GitHub Issues（已完成的關掉、新發現的開）
+- 更新 Wiki 模組頁 + Home + Sidebar

--- a/docs/TEST-INDEX.md
+++ b/docs/TEST-INDEX.md
@@ -1,0 +1,154 @@
+# TEST-INDEX — 全套 E2E 測試入口
+
+> **目的：** 把現有 31 份 TEST 文件 + 8 軌 E2E sub-doc + 1 主黃金路徑串成可重複跑的回歸測試套件。
+> **執行模式（決策已鎖）：** master + 子文件 / 半手動（SQL/RPC 驗 + preview UI）/ 跳過 LIFF & PWA push。
+> **規劃文件：** `C:\Users\Alex\.claude\plans\q1-c-q2-b-expressive-emerson.md`
+
+---
+
+## 怎麼跑
+
+### 前置：seed
+1. 確認 `scripts/e2e/.env.e2e` 設定（`E2E_EXPECTED_HOST` 防呆）
+2. `bash scripts/e2e/reset.sh full-demo --yes`
+3. 抓尾段 row count 表當 baseline，貼進 `TEST-E2E-master.md` § Prerequisites
+
+### 主黃金路徑
+跑 `docs/TEST-E2E-master.md` 全 13 步、產 `TEST-E2E-master-report.md`
+
+### 各軌道（依序或挑跑）
+1. `reset.sh full-demo --yes`（每軌前都 reset 一次乾淨）
+2. 跑該軌道既有 docs（`run-feature-tests` skill）
+3. 跑該軌道 sub-doc 的 gap addendum
+4. 跑 master 對應 sections
+5. 結 sub-doc rolling `-report.md`、勾回此表
+
+### ⚠ 安全提醒
+**永遠別把 `reset.sh` 跑到 prod connection。** `.env.e2e` `E2E_EXPECTED_HOST` 防呆只擋換 project、不擋 prod 自殺。
+
+---
+
+## 軌道（8 in scope）
+
+| Track | 主文件 | 範圍 | 狀態 | 最近驗證 | Report |
+|---|---|---|---|---|---|
+| T1 主檔 | [TEST-E2E-T1-master-data.md](TEST-E2E-T1-master-data.md) | 商品/SKU/規格/加盟店/會員/員工/audit cols | 🟡 | — | — |
+| T2 候選→開團 | [TEST-E2E-T2-campaign.md](TEST-E2E-T2-campaign.md) | 候選週曆/campaign/finalize/auto-PR | 🟡 | — | — |
+| T3 訂單+wallet | [TEST-E2E-T3-orders-wallet.md](TEST-E2E-T3-orders-wallet.md) | admin 加單/轉手/88折/soft-cancel/負數/wallet a-d/R4 R8 R10 | 🟡 | — | — |
+| T4 採購 | [TEST-E2E-T4-purchase.md](TEST-E2E-T4-purchase.md) | PR/PO/GR + R1 R2a R2b R3 + vendor_bills + purchase_returns | 🟡 | — | — |
+| T5 WMS 出貨 | [TEST-E2E-T5-wms-shipping.md](TEST-E2E-T5-wms-shipping.md) | Wave/Pick/Ship/Receive/逆轉 + R5 R9 + 異常處理 | 🟡 | — | — |
+| T6 退貨/轉貨 | [TEST-E2E-T6-returns-transfers.md](TEST-E2E-T6-returns-transfers.md) | free transfer/store→HQ/aid + R6a R6b R7 R11a-d R12 | 🟡 | — | — |
+| T7 收件匣 | [TEST-E2E-T7-inbox.md](TEST-E2E-T7-inbox.md) | HQ inbox + restock + counts RPC | 🟡 | — | — |
+| T10 安全 RLS | [TEST-E2E-T10-security-rls.md](TEST-E2E-T10-security-rls.md) | RLS 矩陣/SECURITY DEFINER/LINE 馬賽克/audit 4 欄位 | 🆕 | — | — |
+
+### 主黃金路徑
+| 文件 | 說明 | 狀態 | Report |
+|---|---|---|---|
+| [TEST-E2E-master.md](TEST-E2E-master.md) | 13 步串全鏈黃金路徑（候選→開團→訂單→採購→撿貨→派貨→收貨→退貨→月結）| 🟡 | — |
+
+---
+
+## 既有 31 份 TEST 文件分類（P1 triage 結果）
+
+> **規則：** 🟢 GREEN（有 -report.md status: passed）/ 🟡 YELLOW（無 report、跑前 refresh 或直接跑）/ 🔴 RED（migration/RPC/path 已不存在、需 rewrite）/ ⚪ SKIP（不在範圍）
+
+| 文件 | 軌 | 等級 | 動作 |
+|---|---|---|---|
+| TEST-B3-products-ext.md | T1 | 🟢 | relink、有 -report |
+| TEST-core-modules.md | T1 | 🟢 | relink、有 -report |
+| TEST-member-merge-ux.md | T1 | 🟡 | 跑 |
+| TEST-member-tabs-notifications.md | T1 | 🟡 | 跑 |
+| TEST-member-type-guest.md | T1 | 🟡 | 跑 |
+| TEST-candidate-to-draft-and-pricing.md | T2 | 🟡 | 跑 |
+| TEST-campaign-finalize.md | T2 | 🟡 | 跑 |
+| TEST-campaign-to-purchase.md | T2 | 🟡 | 跑 |
+| TEST-close-campaign-auto-new-pr.md | T2 | 🟡 | 跑 |
+| TEST-order-entry-mvp0.md | T3 | 🟡 | 跑 |
+| TEST-order-entry-store-internal.md | T3 | 🟢 | relink、有 -report |
+| TEST-order-transfer.md | T3 | 🟢 | relink、有 -report |
+| TEST-order-transfer-button.md | T3 | 🟡 | 跑 |
+| TEST-orders-edit.md | T3 | 🟡 | 跑 |
+| TEST-訂單刪除與負數訂單.md | T3 | 🟡 | 跑 |
+| TEST-order-expiry-events.md | T3 | 🟡 | 跑 |
+| TEST-order-shortage-events.md | T3 | 🟡 | 跑 |
+| TEST-wallet-phase-a.md | T3 | 🟡 | 跑 |
+| TEST-wallet-phase-b.md | T3 | 🟡 | 跑 |
+| TEST-wallet-phase-c.md | T3 | 🟡 | 跑 |
+| TEST-wallet-phase-d.md | T3 | 🟡 | 跑 |
+| TEST-pr-manual-creation.md | T4 | 🟡 | 跑 |
+| TEST-picking-require-po.md | T4/T5 | 🟡 | 跑 |
+| TEST-arrive-and-distribute.md | T5 | 🟡 | 跑 |
+| TEST-hq-dispatch-ui.md | T5 | 🟢 | relink、有 -report |
+| TEST-rpc-receive-transfer.md | T6 | 🟡 | 跑 |
+| TEST-transfer-hq-dispatch.md | T6 | 🟢 | relink、有 -report |
+| TEST-mutual-aid-board.md | T6 | 🟢 | relink、有 -report |
+| TEST-store-self-service.md | T7 | 🟡 | 跑（部分 cover）|
+| TEST-LIFF-overview-orders-settlements.md | — | ⚪ | LIFF、本次跳過 |
+| TEST-deploy-admin.md | — | ⚪ | infra deploy、不算 feature |
+
+**統計：** 6 GREEN + 22 YELLOW + 2 SKIP + 1 跨軌 (picking-require-po)
+
+---
+
+## 排除（不在 8 軌）
+
+- LIFF 真機（TEST-LIFF-*.md）— 真機 / Safari / LINE in-app 環境難自動化
+- PWA push 真機 — iOS PWA Web Push 訂閱 timeout / SW 重加主畫面踩雷
+- TEST-deploy-admin — 部署 infra
+- POS / 銷售 / pos_sales / customers — 與團購流程平行、本次不測
+
+---
+
+## 慣例
+
+- 既有 31 份 docs：保留 5 段格式（Schema/Migration → RPC 行為 → UI 行為 → Regression → 驗收門檻）
+- 新 sub-doc：用 meta + gap addendum（軌道 ≥2 既有 docs）或 inline checklist（T7/T10 沒既有 docs）
+- 各 sub-doc 跑完一輪 → 寫 rolling `TEST-E2E-T{n}-*-report.md`、回填此 INDEX
+- 主黃金路徑跑完 → `TEST-E2E-master-report.md`
+- 反向情境（R1-R12）對應 fixture 在 `scripts/e2e/fixtures/` 已備好
+
+---
+
+## 反向情境清冊（在哪測）
+
+| # | 反向情境 | 對應軌道 | Fixture 種子位置 |
+|---|---|---|---|
+| R1 | PR 取消 | T4 | with-pr-po.sql / PR-0003 |
+| R2a | PO 取消（無 GR）| T4 | with-pr-po.sql / PO-0003 |
+| R2b | PO 取消（部分 GR）| T4 | with-pr-po.sql / PO-0004 + GR-0002 |
+| R3 | GR 來貨不足 | T4 | with-pr-po.sql / PO-0005 + GR-0003 |
+| R4 | 訂單缺貨 | T3 | with-orders.sql / ORD-0007 + order_shortage_events |
+| R5 | 撿貨不足量 | T5 | with-picking-wave.sql / WAVE-0001 + backorder |
+| R6a | Transfer 拒收 | T6 | with-transfers.sql / TF-0004 + transfer_reject |
+| R6b | 運送遺失/破損 | T6 | with-transfers.sql / TF-0005 + damage |
+| R7 | 店家發現過期 | T6/T5 | （走 R6b 同 RPC `rpc_register_damage`）|
+| R8 | 顧客取貨後反悔 | T3 | with-orders.sql / ORD-0006 + customer_return movement + wallet refund |
+| R9 | Wave 整單取消 | T5 | with-picking-wave.sql / WAVE-0002 |
+| R10 | Wallet topup 反向 | T3 | with-wallet-history.sql / M-TEST-003 reversal |
+| R11a | 互助 offer 取消（無 claim）| T6 | with-mutual-aid.sql / AID-OFR-002 |
+| R11b | 互助 offer 取消（有 cancelled claim）| T6 | with-mutual-aid.sql / AID-OFR-003 |
+| R11c | 互助 offer 取消（已 ship）| T6 | with-mutual-aid.sql / AID-OFR-004 + TF-AID-002 |
+| R12 | 互助 received 後對方退單 | T6 | **RPC gap** — 用 free transfer 反向 workaround |
+
+---
+
+## 跑法 cheatsheet
+
+```bash
+# 黃金路徑（master）
+bash scripts/e2e/reset.sh full-demo --yes
+# → 開 admin、依 TEST-E2E-master.md § 1 ~ § 13 逐步跑、寫 report
+
+# 個別軌道
+bash scripts/e2e/reset.sh full-demo --yes
+# → 用 run-feature-tests skill 跑該軌道既有 docs
+# → 跑 sub-doc gap addendum
+# → 寫 rolling report
+
+# 全套（big-bang）
+# Day 1: P0+P1+master+T3
+# Day 2: T1/T2/T4
+# Day 3: T5/T6/T7
+# Day 4: T10
+# Day 5: master rerun
+```

--- a/scripts/e2e/00-truncate.sql
+++ b/scripts/e2e/00-truncate.sql
@@ -20,6 +20,7 @@ TRUNCATE TABLE
   -- inventory
   reorder_rules,
   stocktake_items, stocktakes,
+  store_monthly_settlement_items, store_monthly_settlements,
   transfer_items, transfers,
   transfer_settlement_items, transfer_settlements,
   stock_movements, stock_balances,

--- a/scripts/e2e/01-master.sql
+++ b/scripts/e2e/01-master.sql
@@ -28,11 +28,40 @@ INSERT INTO brands (tenant_id, code, name) VALUES
   (:'tenant_id'::uuid, 'BR-IMP', '進口品牌'),
   (:'tenant_id'::uuid, 'BR-OTH', '其他');
 
--- ── categories（level=1 的三大類）─────────────────────────
+-- ── categories（3 層分類樹：level1 大類 → level2 中類 → level3 小類）──
+-- level 1（3 大類）
 INSERT INTO categories (tenant_id, code, name, level, sort_order) VALUES
   (:'tenant_id'::uuid, 'C-FRESH', '生鮮', 1, 1),
   (:'tenant_id'::uuid, 'C-DRY',   '乾貨', 1, 2),
   (:'tenant_id'::uuid, 'C-COND',  '調味', 1, 3);
+
+-- level 2（9 中類）— 用 parent_id 串到 level 1
+INSERT INTO categories (tenant_id, parent_id, code, name, level, sort_order)
+SELECT :'tenant_id'::uuid, p.id, x.code, x.name, 2, x.sort
+FROM (VALUES
+  ('C-FRESH', 'C-FRESH-VEG',   '蔬菜',     1),
+  ('C-FRESH', 'C-FRESH-FRUIT', '水果',     2),
+  ('C-FRESH', 'C-FRESH-MEAT',  '肉品海鮮', 3),
+  ('C-DRY',   'C-DRY-SNACK',   '餅乾零食', 1),
+  ('C-DRY',   'C-DRY-RICE',    '米麵雜糧', 2),
+  ('C-DRY',   'C-DRY-CAN',     '罐頭',     3),
+  ('C-COND',  'C-COND-SAUCE',  '醬料',     1),
+  ('C-COND',  'C-COND-VINEGAR','醋類',     2),
+  ('C-COND',  'C-COND-SUGAR',  '糖蜜',     3)
+) AS x(parent_code, code, name, sort)
+JOIN categories p ON p.tenant_id = :'tenant_id'::uuid AND p.code = x.parent_code;
+
+-- level 3（5 小類示範）— 用 parent_id 串到 level 2
+INSERT INTO categories (tenant_id, parent_id, code, name, level, sort_order)
+SELECT :'tenant_id'::uuid, p.id, x.code, x.name, 3, x.sort
+FROM (VALUES
+  ('C-DRY-SNACK', 'C-SNACK-CRACKER', '餅乾類',   1),
+  ('C-DRY-SNACK', 'C-SNACK-CHIP',    '洋芋片',   2),
+  ('C-DRY-RICE',  'C-RICE-BROWN',    '糙米',     1),
+  ('C-DRY-RICE',  'C-RICE-WHITE',    '白米',     2),
+  ('C-COND-SAUCE','C-SAUCE-SOY',     '醬油',     1)
+) AS x(parent_code, code, name, sort)
+JOIN categories p ON p.tenant_id = :'tenant_id'::uuid AND p.code = x.parent_code;
 
 -- ── member_tiers ──────────────────────────────────────────
 INSERT INTO member_tiers (tenant_id, code, name, sort_order, benefits) VALUES
@@ -104,11 +133,27 @@ SELECT p.tenant_id,
 FROM products p
 WHERE p.tenant_id = :'tenant_id'::uuid;
 
--- ── sku_packs（每 SKU 一個預設 pack：unit=base_unit、qty=1、is_default_sale=true）
+-- ── sku_packs（每 SKU 至少一個 default pack；部分 SKU 加 multi-unit）──
+-- 1. base unit pack（每 SKU 必有，is_default_sale=TRUE）
 INSERT INTO sku_packs (sku_id, unit, qty_in_base, for_sale, for_purchase, for_transfer, is_default_sale)
 SELECT id, '個', 1, TRUE, TRUE, TRUE, TRUE
 FROM skus
 WHERE tenant_id = :'tenant_id'::uuid;
+
+-- 2. P004 香米：個 + 箱(qty=10)（採購用箱、銷售用個）
+INSERT INTO sku_packs (sku_id, unit, qty_in_base, for_sale, for_purchase, for_transfer, is_default_sale)
+SELECT s.id, '箱', 10, FALSE, TRUE, TRUE, FALSE
+FROM skus s WHERE s.tenant_id = :'tenant_id'::uuid AND s.sku_code = 'SKU-004';
+
+-- 3. P008 雞蛋：個 + 盒(qty=10)（銷售用盒）
+INSERT INTO sku_packs (sku_id, unit, qty_in_base, for_sale, for_purchase, for_transfer, is_default_sale)
+SELECT s.id, '盒', 10, TRUE, TRUE, TRUE, FALSE
+FROM skus s WHERE s.tenant_id = :'tenant_id'::uuid AND s.sku_code = 'SKU-008';
+
+-- 4. P010 餅乾：個 + 箱(qty=6)
+INSERT INTO sku_packs (sku_id, unit, qty_in_base, for_sale, for_purchase, for_transfer, is_default_sale)
+SELECT s.id, '箱', 6, FALSE, TRUE, TRUE, FALSE
+FROM skus s WHERE s.tenant_id = :'tenant_id'::uuid AND s.sku_code = 'SKU-010';
 
 -- ── barcodes（每 SKU 一個 internal 條碼）──────────────────
 INSERT INTO barcodes (tenant_id, barcode_value, sku_id, unit, pack_qty, type, is_primary)
@@ -190,28 +235,50 @@ SELECT :'tenant_id'::uuid, s.id, '主零用金', 5000, 20000
 FROM stores s
 WHERE s.tenant_id = :'tenant_id'::uuid;
 
--- ── line_channels（一個測試社群，主店 = 平鎮）─────────────
+-- ── line_channels（3 個 channel：主社群 + VIP + 日常）────────
 INSERT INTO line_channels (tenant_id, code, name, channel_type, home_store_id, additional_pickup_store_ids)
-SELECT :'tenant_id'::uuid, 'LC-MAIN', '主社群（測試）', 'open_chat',
-       (SELECT id FROM stores WHERE tenant_id = :'tenant_id'::uuid AND code = 'S001'),
-       (
-         SELECT COALESCE(jsonb_agg(id), '[]'::jsonb)
-         FROM stores
-         WHERE tenant_id = :'tenant_id'::uuid AND code IN ('S002','S003','S004','S005')
-       );
+SELECT :'tenant_id'::uuid, x.code, x.name, x.ctype,
+       (SELECT id FROM stores WHERE tenant_id = :'tenant_id'::uuid AND code = x.home),
+       x.additional::jsonb
+FROM (VALUES
+  ('LC-MAIN',  '主社群（測試）',   'open_chat', 'S001',
+   '[' || (SELECT string_agg(id::text, ',') FROM stores
+            WHERE tenant_id = :'tenant_id'::uuid AND code IN ('S002','S003','S004','S005')) || ']'),
+  ('LC-VIP',   '金卡 VIP 群',      'open_chat', 'S002',
+   '[' || (SELECT string_agg(id::text, ',') FROM stores
+            WHERE tenant_id = :'tenant_id'::uuid AND code IN ('S001','S003')) || ']'),
+  ('LC-DAILY', '日常用品群',       'open_chat', 'S003',
+   '[]')
+) AS x(code, name, ctype, home, additional);
 
--- ── post_templates ─────────────────────────────────────────
+-- ── post_templates（3 個：預設 / 促銷 / 結團）────────────
 INSERT INTO post_templates (tenant_id, code, name, body) VALUES
   (:'tenant_id'::uuid, 'PT-DEFAULT', '預設模板',
-   '【開團】{{name}}\n截止：{{end_at}}\n商品：{{items}}');
+   '【開團】{{name}}\n截止：{{end_at}}\n商品：{{items}}'),
+  (:'tenant_id'::uuid, 'PT-PROMO',   '促銷模板',
+   '🔥 限時促銷 🔥\n{{name}}\n優惠價：{{price}}\n截止：{{end_at}}'),
+  (:'tenant_id'::uuid, 'PT-CLOSING', '結團模板',
+   '【結團通知】{{name}}\n感謝大家的訂購！\n預計到貨：{{arrival_date}}');
 
--- ── purchase_approval_thresholds
--- 索引 idx_pat_scope unique on (tenant_id, scope, COALESCE(scope_id, 0)) WHERE active = TRUE
--- → 一個 scope+scope_id 只能有 1 筆 active；先放 1 筆 global，多級門檻 UI 再建
+-- ── purchase_approval_thresholds（3 級：全域 / 店 / 供應商）──
+-- 一個 scope+scope_id 只能有 1 筆 active
 INSERT INTO purchase_approval_thresholds (tenant_id, scope, scope_id, threshold_amount, approver_role) VALUES
   (:'tenant_id'::uuid, 'global', NULL, 5000, 'admin');
 
--- ── supplier_skus（每 SKU 預設由 SUP-LOCAL 提供）──────────
+-- store 層門檻（每店 3000，HQ 角色為 hq_manager 才能 approve）
+INSERT INTO purchase_approval_thresholds (tenant_id, scope, scope_id, threshold_amount, approver_role)
+SELECT :'tenant_id'::uuid, 'store', s.id, 3000, 'hq_manager'
+FROM stores s
+WHERE s.tenant_id = :'tenant_id'::uuid AND s.code IN ('S001','S002');
+
+-- supplier 層門檻：JP / XL 因金額大、走 owner 核准
+INSERT INTO purchase_approval_thresholds (tenant_id, scope, scope_id, threshold_amount, approver_role)
+SELECT :'tenant_id'::uuid, 'supplier', sup.id, 10000, 'owner'
+FROM suppliers sup
+WHERE sup.tenant_id = :'tenant_id'::uuid AND sup.code IN ('SUP-JP','SUP-XL');
+
+-- ── supplier_skus（多供應商：JP 進口品由 SUP-JP / 雞蛋由 SUP-XL / 其餘 SUP-LOCAL）──
+-- 預設由 SUP-LOCAL 提供（10 SKU 全覆蓋，作為 fallback）
 INSERT INTO supplier_skus (tenant_id, supplier_id, sku_id, default_unit_cost, pack_qty, is_preferred)
 SELECT :'tenant_id'::uuid,
        (SELECT id FROM suppliers WHERE tenant_id = :'tenant_id'::uuid AND code = 'SUP-LOCAL'),
@@ -224,9 +291,40 @@ SELECT :'tenant_id'::uuid,
           WHEN 'SKU-009' THEN 60  WHEN 'SKU-010' THEN 320
         END)::numeric,
        1,
-       TRUE
+       (s.sku_code NOT IN ('SKU-001','SKU-003','SKU-006','SKU-008','SKU-010'))  -- JP/XL 主供應的設 FALSE
 FROM skus s
 WHERE s.tenant_id = :'tenant_id'::uuid;
+
+-- SUP-JP 進口品（蝦餅 / 醬油 / 蜂蜜 / 餅乾）
+INSERT INTO supplier_skus (tenant_id, supplier_id, sku_id, supplier_sku_code,
+                           default_unit_cost, pack_qty, is_preferred)
+SELECT :'tenant_id'::uuid,
+       (SELECT id FROM suppliers WHERE tenant_id = :'tenant_id'::uuid AND code = 'SUP-JP'),
+       s.id,
+       'JP-' || s.sku_code,
+       (CASE s.sku_code
+          WHEN 'SKU-001' THEN 85   -- 比 LOCAL 便宜 5
+          WHEN 'SKU-003' THEN 140
+          WHEN 'SKU-006' THEN 230
+          WHEN 'SKU-010' THEN 300
+        END)::numeric,
+       1,
+       TRUE
+FROM skus s
+WHERE s.tenant_id = :'tenant_id'::uuid AND s.sku_code IN ('SKU-001','SKU-003','SKU-006','SKU-010');
+
+-- SUP-XL 小蘭（雞蛋）
+INSERT INTO supplier_skus (tenant_id, supplier_id, sku_id, supplier_sku_code,
+                           default_unit_cost, pack_qty, is_preferred)
+SELECT :'tenant_id'::uuid,
+       (SELECT id FROM suppliers WHERE tenant_id = :'tenant_id'::uuid AND code = 'SUP-XL'),
+       s.id,
+       'XL-' || s.sku_code,
+       70::numeric,  -- 比 LOCAL 便宜 5
+       1,
+       TRUE
+FROM skus s
+WHERE s.tenant_id = :'tenant_id'::uuid AND s.sku_code = 'SKU-008';
 
 COMMIT;
 

--- a/scripts/e2e/02-base-fixtures.sql
+++ b/scripts/e2e/02-base-fixtures.sql
@@ -1,8 +1,11 @@
 -- ============================================================
 -- E2E reset · step 02 · base fixtures
 -- 所有 scenario 都會跑這支：
---   - 1 個測試會員（手機 0900000001、家店 = S001 平鎮店、tier = T-NORMAL）
---   - LINE 暱稱 ↔ 會員綁定（讓「貼單建單」的解析能命中）
+--   - 4 個測試會員：full × 3 (normal / silver / gold) + store_internal × 1
+--   - customer_line_aliases（舊版暱稱表）+ member_line_bindings（新版 LINE Login 表）並存
+--   - member_cards 一張（每會員）
+--   - member_points_balance / wallet_balances 初始化
+--   - M-TEST-002 wallet 預灌 $5000（master 黃金路徑用、wallet_ledger 有 topup row）
 --
 -- 不動 auth.users（員工帳號 / 員工→店家的綁定一律手動透過 Supabase
 -- Dashboard 維護 raw_app_meta_data.location_id）
@@ -11,39 +14,56 @@
 
 BEGIN;
 
--- 測試會員 M-TEST-001
+-- ── 4 個測試會員 ──────────────────────────────────────────
+-- M-TEST-001 普通會員、家店 S001
 INSERT INTO members (
   tenant_id, member_no, phone_hash, name, member_type,
   tier_id, home_store_id, status, joined_at
 ) VALUES (
-  :'tenant_id'::uuid,
-  'M-TEST-001',
-  encode(digest('0900000001', 'sha256'), 'hex'),
-  '測試小明',
-  'full',
+  :'tenant_id'::uuid, 'M-TEST-001',
+  encode(digest('0900000001', 'sha256'), 'hex'), '測試小明', 'full',
   (SELECT id FROM member_tiers WHERE tenant_id = :'tenant_id'::uuid AND code = 'T-NORMAL'),
   (SELECT id FROM stores       WHERE tenant_id = :'tenant_id'::uuid AND code = 'S001'),
-  'active',
-  NOW()
+  'active', NOW()
 );
 
--- 第二個會員 M-TEST-002（家店 S002 松山，金卡）
+-- M-TEST-002 金卡、家店 S002（master 黃金路徑要用、wallet 預灌 5000）
 INSERT INTO members (
   tenant_id, member_no, phone_hash, name, member_type,
   tier_id, home_store_id, status, joined_at
 ) VALUES (
-  :'tenant_id'::uuid,
-  'M-TEST-002',
-  encode(digest('0900000002', 'sha256'), 'hex'),
-  '測試小華',
-  'full',
+  :'tenant_id'::uuid, 'M-TEST-002',
+  encode(digest('0900000002', 'sha256'), 'hex'), '測試小華', 'full',
   (SELECT id FROM member_tiers WHERE tenant_id = :'tenant_id'::uuid AND code = 'T-GOLD'),
   (SELECT id FROM stores       WHERE tenant_id = :'tenant_id'::uuid AND code = 'S002'),
-  'active',
-  NOW()
+  'active', NOW()
 );
 
--- LINE 暱稱 ↔ 會員（讓 LINE 貼單解析能找到）
+-- M-TEST-003 銀卡、家店 S003
+INSERT INTO members (
+  tenant_id, member_no, phone_hash, name, member_type,
+  tier_id, home_store_id, status, joined_at
+) VALUES (
+  :'tenant_id'::uuid, 'M-TEST-003',
+  encode(digest('0900000003', 'sha256'), 'hex'), '測試小芳', 'full',
+  (SELECT id FROM member_tiers WHERE tenant_id = :'tenant_id'::uuid AND code = 'T-SILVER'),
+  (SELECT id FROM stores       WHERE tenant_id = :'tenant_id'::uuid AND code = 'S003'),
+  'active', NOW()
+);
+
+-- M-TEST-INT-001 店內購買（store_internal、S001 平鎮店店長代叫貨用）
+INSERT INTO members (
+  tenant_id, member_no, phone_hash, name, member_type,
+  tier_id, home_store_id, status, joined_at
+) VALUES (
+  :'tenant_id'::uuid, 'M-TEST-INT-001',
+  encode(digest('0900000099', 'sha256'), 'hex'), 'S001 內購', 'store_internal',
+  (SELECT id FROM member_tiers WHERE tenant_id = :'tenant_id'::uuid AND code = 'T-NORMAL'),
+  (SELECT id FROM stores       WHERE tenant_id = :'tenant_id'::uuid AND code = 'S001'),
+  'active', NOW()
+);
+
+-- ── customer_line_aliases（舊版暱稱表）─────────────────────
 INSERT INTO customer_line_aliases (tenant_id, channel_id, nickname, member_id)
 SELECT :'tenant_id'::uuid,
        (SELECT id FROM line_channels WHERE tenant_id = :'tenant_id'::uuid AND code = 'LC-MAIN'),
@@ -51,16 +71,61 @@ SELECT :'tenant_id'::uuid,
        (SELECT id FROM members WHERE tenant_id = :'tenant_id'::uuid AND member_no = n.member_no)
 FROM (VALUES
   ('小明', 'M-TEST-001'),
-  ('小華', 'M-TEST-002')
+  ('小華', 'M-TEST-002'),
+  ('小芳', 'M-TEST-003')
 ) AS n(nickname, member_no);
 
--- member_points_balance 初始化
+-- 小華也在 LC-VIP 群（同會員跨頻道可有不同暱稱）
+INSERT INTO customer_line_aliases (tenant_id, channel_id, nickname, member_id)
+SELECT :'tenant_id'::uuid,
+       (SELECT id FROM line_channels WHERE tenant_id = :'tenant_id'::uuid AND code = 'LC-VIP'),
+       'VIP小華',
+       (SELECT id FROM members WHERE tenant_id = :'tenant_id'::uuid AND member_no = 'M-TEST-002');
+
+-- ── member_line_bindings（新版 LINE Login 綁定表）────────────
+-- 一會員可在多店綁定；line_user_id 用 fixture 固定值（前綴 U + 31 chars）
+INSERT INTO member_line_bindings (tenant_id, store_id, member_id, line_user_id, bound_at)
+SELECT :'tenant_id'::uuid,
+       m.home_store_id,
+       m.id,
+       'U' || lpad(replace(m.member_no, '-', ''), 31, '0'),
+       NOW()
+FROM members m
+WHERE m.tenant_id = :'tenant_id'::uuid
+  AND m.member_no IN ('M-TEST-001','M-TEST-002','M-TEST-003');
+
+-- ── member_cards（每會員一張 virtual）─────────────────────
+INSERT INTO member_cards (tenant_id, member_id, card_no, type, is_primary, status)
+SELECT :'tenant_id'::uuid, m.id,
+       'CARD-' || REPLACE(m.member_no, '-', ''),
+       'virtual', TRUE, 'active'
+FROM members m
+WHERE m.tenant_id = :'tenant_id'::uuid;
+
+-- ── points + wallet 餘額初始化（4 會員都 0）───────────────
 INSERT INTO member_points_balance (tenant_id, member_id, balance)
 SELECT tenant_id, id, 0 FROM members WHERE tenant_id = :'tenant_id'::uuid;
 
 INSERT INTO wallet_balances (tenant_id, member_id, balance)
 SELECT tenant_id, id, 0 FROM members WHERE tenant_id = :'tenant_id'::uuid;
 
+-- ── M-TEST-002 wallet 預灌 5000（黃金路徑要用）──────────
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
+     m2       AS (SELECT id FROM members WHERE tenant_id = :'tenant_id'::uuid AND member_no = 'M-TEST-002')
+INSERT INTO wallet_ledger (
+  tenant_id, member_id, change, balance_after, type,
+  source_type, source_id, payment_method, reason, operator_id
+)
+SELECT :'tenant_id'::uuid, (SELECT id FROM m2),
+       5000, 5000, 'topup',
+       'seed', NULL, 'cash', 'E2E base seed: M-TEST-002 預灌 5000',
+       (SELECT id FROM any_user);
+
+UPDATE wallet_balances
+   SET balance = 5000, version = 1, last_movement_at = NOW(), updated_at = NOW()
+ WHERE tenant_id = :'tenant_id'::uuid
+   AND member_id = (SELECT id FROM members WHERE tenant_id = :'tenant_id'::uuid AND member_no = 'M-TEST-002');
+
 COMMIT;
 
-\echo 'base fixtures seeded.'
+\echo 'base fixtures seeded (4 members; M-TEST-002 wallet=5000).'

--- a/scripts/e2e/fixtures/full-demo.sql
+++ b/scripts/e2e/fixtures/full-demo.sql
@@ -1,14 +1,27 @@
 -- ============================================================
 -- fixture: full-demo
--- 串接所有情境：庫存 + 團購 + 訂單 + 採購 + 轉撥 + 互助
--- 適合給人 demo 或跨情境整合測試。
+-- 串接所有情境：庫存 + 團購 + 訂單 + 採購 + 撿貨 + 轉撥 + 互助 + 月結算
+-- 適合給人 demo、跨情境整合測試、E2E 黃金路徑與反向情境驗證。
+--
+-- 依賴順序：
+--   with-stock              （庫存開帳，stock_movements + 自動 stock_balances）
+--   with-orders             （內部 \ir with-campaign；建 8 筆 customer_orders 含反向）
+--   with-wallet-history     （依賴 02-base 的 members；wallet_ledger + R10 reversal）
+--   with-pr-po              （獨立；R1 PR 取消 / R2 PO 取消 / R3 GR 短少 + vendor_bills + purchase_returns）
+--   with-picking-wave       （依賴 with-orders + with-campaign；R5 撿貨不足 / R9 wave 取消）
+--   with-transfers          （獨立；R6a transfer 拒收 / R6b 運送破損 + transfer_settlements）
+--   with-mutual-aid         （依賴 with-orders 的 customer_orders；R11a/b/c offer 取消 + replies/claims）
+--   with-monthly-settlement （依賴 with-transfers 的 hq_to_store）
 -- ============================================================
 \set ON_ERROR_STOP on
 
 \ir with-stock.sql
 \ir with-orders.sql
+\ir with-wallet-history.sql
 \ir with-pr-po.sql
+\ir with-picking-wave.sql
 \ir with-transfers.sql
 \ir with-mutual-aid.sql
+\ir with-monthly-settlement.sql
 
 \echo 'fixture full-demo seeded.'

--- a/scripts/e2e/fixtures/with-monthly-settlement.sql
+++ b/scripts/e2e/fixtures/with-monthly-settlement.sql
@@ -1,0 +1,100 @@
+-- ============================================================
+-- fixture: with-monthly-settlement
+-- 店月結算：HQ 對加盟店每月計算貨款（賣斷制）
+-- 依賴：with-transfers 已建 hq_to_store transfers + stock_movements
+--
+-- 建立 2 筆月結算（draft）：
+--   SMS-S001  S001 平鎮店 — 來自 TF-0005 已收 8 件 SKU-006 × cost 230 = 1840
+--   SMS-S002  S002 松山店 — 來自 TF-0006 已收 6 件 SKU-008 × cost 75  =  450
+--
+-- 都是當月、status='draft'。confirm + 產 vendor_bill 留給測試 RPC 觸發。
+-- ============================================================
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ── S001 月結算 ──────────────────────────────────────────
+DO $$
+DECLARE
+  v_tenant     UUID := :'tenant_id'::uuid;
+  v_month      DATE := DATE_TRUNC('month', NOW())::date;
+  v_store      BIGINT;
+  v_settlement BIGINT;
+  v_operator   UUID;
+  v_tf         BIGINT;
+  v_ti         BIGINT;
+  v_sku        BIGINT;
+BEGIN
+  SELECT id INTO v_store FROM stores
+   WHERE tenant_id = v_tenant AND code = 'S001';
+  SELECT id INTO v_operator FROM auth.users LIMIT 1;
+  SELECT id INTO v_tf FROM transfers
+   WHERE tenant_id = v_tenant AND transfer_no = 'TF-0005';
+  SELECT id, sku_id INTO v_ti, v_sku FROM transfer_items
+   WHERE transfer_id = v_tf;
+
+  INSERT INTO store_monthly_settlements (
+    tenant_id, settlement_month, store_id,
+    payable_amount, transfer_count, item_count,
+    status, notes, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_month, v_store,
+    1840, 1, 1,
+    'draft',
+    'E2E SMS-S001: TF-0005 partial 8/10（R6b 損壞 2）×230 = 1840',
+    v_operator, v_operator
+  ) RETURNING id INTO v_settlement;
+
+  INSERT INTO store_monthly_settlement_items (
+    tenant_id, settlement_id, transfer_id, transfer_item_id, sku_id,
+    qty_received, unit_cost, line_amount, received_at
+  ) VALUES (
+    v_tenant, v_settlement, v_tf, v_ti, v_sku,
+    8, 230, 1840, NOW() - INTERVAL '12 hours'
+  );
+END $$;
+
+-- ── S002 月結算 ──────────────────────────────────────────
+DO $$
+DECLARE
+  v_tenant     UUID := :'tenant_id'::uuid;
+  v_month      DATE := DATE_TRUNC('month', NOW())::date;
+  v_store      BIGINT;
+  v_settlement BIGINT;
+  v_operator   UUID;
+  v_tf         BIGINT;
+  v_ti         BIGINT;
+  v_sku        BIGINT;
+BEGIN
+  SELECT id INTO v_store FROM stores
+   WHERE tenant_id = v_tenant AND code = 'S002';
+  SELECT id INTO v_operator FROM auth.users LIMIT 1;
+  SELECT id INTO v_tf FROM transfers
+   WHERE tenant_id = v_tenant AND transfer_no = 'TF-0006';
+  SELECT id, sku_id INTO v_ti, v_sku FROM transfer_items
+   WHERE transfer_id = v_tf;
+
+  INSERT INTO store_monthly_settlements (
+    tenant_id, settlement_month, store_id,
+    payable_amount, transfer_count, item_count,
+    status, notes, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_month, v_store,
+    450, 1, 1,
+    'draft',
+    'E2E SMS-S002: TF-0006 received 6 ×75 = 450',
+    v_operator, v_operator
+  ) RETURNING id INTO v_settlement;
+
+  INSERT INTO store_monthly_settlement_items (
+    tenant_id, settlement_id, transfer_id, transfer_item_id, sku_id,
+    qty_received, unit_cost, line_amount, received_at
+  ) VALUES (
+    v_tenant, v_settlement, v_tf, v_ti, v_sku,
+    6, 75, 450, NOW() - INTERVAL '12 hours'
+  );
+END $$;
+
+COMMIT;
+
+\echo 'fixture with-monthly-settlement seeded (2 draft settlements: S001=1840, S002=450).'

--- a/scripts/e2e/fixtures/with-mutual-aid.sql
+++ b/scripts/e2e/fixtures/with-mutual-aid.sql
@@ -1,13 +1,26 @@
 -- ============================================================
 -- fixture: with-mutual-aid
--- 互助板：3 則 request 類型貼文（求助），都是 active。
--- 註：post_type='offer' 必須帶 source_customer_order_id，固定流程改在
---     with-orders 之後另外處理；此處只放 request 不依賴交易單。
+-- 互助板情境（依賴 with-orders 已建 customer_orders）：
+--
+--   request 類型（純求助）:
+--     AID-REQ-001  active  S001 SKU-002 ×12
+--     AID-REQ-002  active  S002 SKU-006 ×6（剩 3）
+--     AID-REQ-003  active  S003 SKU-008 ×20
+--
+--   offer 類型（從 customer_order 釋出）:
+--     AID-OFR-001  active     S002 SKU-003 ×2 src=ORD-0002（黃金路徑用）+ 3 replies
+--     AID-OFR-002  cancelled  S001 SKU-008 ×3 src=ORD-0001  R11a: 取消、無 claim
+--     AID-OFR-003  cancelled  S002 SKU-010 ×1 src=ORD-0004  R11b: 取消、claim 也取消
+--     AID-OFR-004  cancelled  S001 SKU-009 ×1 src=ORD-0003  R11c: 已 ship 後取消、stock 反流
+--
+--   R12: aid received 後對方退單（既有 RPC gap、走 free transfer 反向 workaround）
+--     用 AID-OFR-001 chain 但這份 fixture 不灌 received 終態，留給未來 with-cancellations 補
 -- ============================================================
 \set ON_ERROR_STOP on
 
 BEGIN;
 
+-- ── 1. request 類型（原 3 則）────────────────────────────
 WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
 INSERT INTO mutual_aid_board (
   tenant_id, offering_store_id, sku_id,
@@ -17,13 +30,9 @@ INSERT INTO mutual_aid_board (
 SELECT :'tenant_id'::uuid,
        (SELECT id FROM stores WHERE tenant_id = :'tenant_id'::uuid AND code = x.store_code),
        (SELECT id FROM skus   WHERE tenant_id = :'tenant_id'::uuid AND sku_code = x.sku_code),
-       x.qty,
-       x.qty_remain,
+       x.qty, x.qty_remain,
        NOW() + (x.expires_in_days || ' days')::interval,
-       x.note,
-       'active',
-       'request',
-       NULL,
+       x.note, 'active', 'request', NULL,
        (SELECT id FROM any_user)
 FROM (VALUES
   ('S001', 'SKU-002', 12, 12, '需求：請其他店支援',     7),
@@ -31,6 +40,190 @@ FROM (VALUES
   ('S003', 'SKU-008', 20, 20, '需求：要辦活動，求支援', 3)
 ) AS x(store_code, sku_code, qty, qty_remain, note, expires_in_days);
 
+-- ── 2. offer 類型（依賴 customer_orders）─────────────────
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
+     orders AS (
+       SELECT * FROM customer_orders WHERE tenant_id = :'tenant_id'::uuid
+     )
+INSERT INTO mutual_aid_board (
+  tenant_id, offering_store_id, sku_id,
+  qty_available, qty_remaining, expires_at, note, status,
+  post_type, source_customer_order_id, created_by, updated_by
+)
+SELECT :'tenant_id'::uuid,
+       (SELECT id FROM stores WHERE tenant_id = :'tenant_id'::uuid AND code = x.store_code),
+       (SELECT id FROM skus   WHERE tenant_id = :'tenant_id'::uuid AND sku_code = x.sku_code),
+       x.qty, x.qty_remain,
+       NOW() + (x.expires_days || ' days')::interval,
+       x.note, x.status, 'offer',
+       (SELECT id FROM orders WHERE order_no = x.src_order),
+       (SELECT id FROM any_user),
+       (SELECT id FROM any_user)
+FROM (VALUES
+  ('S002', 'SKU-003', 2, 2, 'active',    'AID-OFR-001: 黃金路徑用、可被認領',     7, 'ORD-0002'),
+  ('S001', 'SKU-008', 3, 3, 'cancelled', 'R11a: offer 取消、無 claim',            3, 'ORD-0001'),
+  ('S002', 'SKU-010', 1, 1, 'cancelled', 'R11b: offer + claim 都取消',            3, 'ORD-0004'),
+  ('S001', 'SKU-009', 1, 1, 'cancelled', 'R11c: offer 已 ship 後取消、stock 反流', 3, 'ORD-0003')
+) AS x(store_code, sku_code, qty, qty_remain, status, note, expires_days, src_order);
+
+-- ── 3. mutual_aid_replies（active offer 上 3 則對話）──────
+INSERT INTO mutual_aid_replies (tenant_id, board_id, author_id, author_label, body)
+SELECT :'tenant_id'::uuid, b.id,
+       (SELECT id FROM auth.users LIMIT 1),
+       x.author,
+       x.body
+FROM mutual_aid_board b
+JOIN (VALUES
+  ('S002', '小華',     '我想認領 1 件，可以嗎？'),
+  ('S002', 'S002 店長', '請補一下品項細節 + 預期到貨'),
+  ('S002', '小芳',     '我也想要 1 件')
+) AS x(store_code, author, body) ON x.store_code = 'S002'
+WHERE b.tenant_id = :'tenant_id'::uuid
+  AND b.note LIKE 'AID-OFR-001%';
+
+-- ── 4. mutual_aid_claims ────────────────────────────────
+-- AID-OFR-001 active：S001 認領 1 件（resulting transfer = TF-AID-001 shipped）
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
+     b AS (SELECT id, offering_store_id, sku_id FROM mutual_aid_board
+           WHERE tenant_id = :'tenant_id'::uuid AND note LIKE 'AID-OFR-001%'),
+     s_target AS (SELECT id, location_id FROM stores
+                  WHERE tenant_id = :'tenant_id'::uuid AND code = 'S001'),
+     s_source AS (SELECT location_id FROM stores
+                  WHERE tenant_id = :'tenant_id'::uuid AND code = 'S002'),
+     new_transfer AS (
+       INSERT INTO transfers (
+         tenant_id, transfer_no, source_location, dest_location,
+         status, transfer_type, requested_by, shipped_at, shipped_by, created_by, notes
+       ) VALUES (
+         :'tenant_id'::uuid, 'TF-AID-001',
+         (SELECT location_id FROM s_source),
+         (SELECT location_id FROM s_target),
+         'shipped', 'store_to_store',
+         (SELECT id FROM any_user),
+         NOW() - INTERVAL '6 hours', (SELECT id FROM any_user),
+         (SELECT id FROM any_user),
+         '互助 AID-OFR-001 認領出貨'
+       ) RETURNING id
+     ),
+     new_item AS (
+       INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped, qty_received)
+       SELECT (SELECT id FROM new_transfer), (SELECT sku_id FROM b), 1, 1, 0
+       RETURNING id
+     ),
+     -- transfer_out movement (S002 倉)
+     out_mv AS (
+       INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                                    movement_type, source_doc_type, source_doc_id,
+                                    reason, operator_id)
+       SELECT :'tenant_id'::uuid,
+              (SELECT location_id FROM s_source),
+              (SELECT sku_id FROM b),
+              -1, 150,  -- SKU-003 cost
+              'transfer_out', 'transfer', (SELECT id FROM new_transfer),
+              'AID-OFR-001 → TF-AID-001 ship',
+              (SELECT id FROM any_user)
+       RETURNING id
+     )
+INSERT INTO mutual_aid_claims (tenant_id, board_id, claiming_store_id, qty,
+                                resulting_transfer_id, created_by)
+SELECT :'tenant_id'::uuid, (SELECT id FROM b),
+       (SELECT id FROM s_target),
+       1,
+       (SELECT id FROM new_transfer),
+       (SELECT id FROM any_user);
+
+-- AID-OFR-001 qty_remaining 從 2 扣到 1
+UPDATE mutual_aid_board
+   SET qty_remaining = 1
+ WHERE tenant_id = :'tenant_id'::uuid
+   AND note LIKE 'AID-OFR-001%';
+
+-- ── 5. R11b: 已取消的 offer + 已取消的 claim ───────────────
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
+     b AS (SELECT id, offering_store_id, sku_id FROM mutual_aid_board
+           WHERE tenant_id = :'tenant_id'::uuid AND note LIKE 'R11b:%')
+INSERT INTO mutual_aid_claims (tenant_id, board_id, claiming_store_id, qty,
+                                resulting_transfer_id, created_by)
+SELECT :'tenant_id'::uuid, (SELECT id FROM b),
+       (SELECT id FROM stores WHERE tenant_id = :'tenant_id'::uuid AND code = 'S004'),
+       1, NULL,  -- 沒有 transfer 因為 claim 在 cancel 前就被取消了
+       (SELECT id FROM any_user);
+-- 註：claim 表是 append-only、無 status 欄位。實務上「取消 claim」靠
+-- mutual_aid_board.status='cancelled' 標示；claims 行保留供 audit。
+
+-- ── 6. R11c: 已 ship 後 offer 取消、stock 反流 ──────────────
+-- S001 的 SKU-009 從 customer_order ORD-0003 釋出 1 件、給 S004
+-- 已 shipped + 對應 stock_movements.transfer_out + 取消後 transfer_reject 反流
+DO $$
+DECLARE
+  v_tenant     UUID := :'tenant_id'::uuid;
+  v_operator   UUID;
+  v_sku        BIGINT;
+  v_src_loc    BIGINT;
+  v_dst_loc    BIGINT;
+  v_dst_store  BIGINT;
+  v_board      BIGINT;
+  v_transfer   BIGINT;
+  v_item       BIGINT;
+  v_out_mv     BIGINT;
+BEGIN
+  SELECT id INTO v_operator FROM auth.users LIMIT 1;
+  SELECT id, offering_store_id, sku_id, NULL::int INTO v_board, v_dst_store, v_sku, v_dst_store
+    FROM mutual_aid_board
+   WHERE tenant_id = v_tenant AND note LIKE 'R11c:%';
+  SELECT id, sku_id INTO v_board, v_sku FROM mutual_aid_board
+   WHERE tenant_id = v_tenant AND note LIKE 'R11c:%';
+  SELECT location_id INTO v_src_loc FROM stores WHERE tenant_id = v_tenant AND code = 'S001';
+  SELECT id, location_id INTO v_dst_store, v_dst_loc FROM stores
+   WHERE tenant_id = v_tenant AND code = 'S004';
+
+  -- transfers
+  INSERT INTO transfers (
+    tenant_id, transfer_no, source_location, dest_location,
+    status, transfer_type, requested_by, shipped_at, shipped_by, created_by, notes
+  ) VALUES (
+    v_tenant, 'TF-AID-002', v_src_loc, v_dst_loc,
+    'cancelled', 'store_to_store',
+    v_operator, NOW() - INTERVAL '8 hours', v_operator,
+    v_operator, 'R11c: 互助已 ship 後取消'
+  ) RETURNING id INTO v_transfer;
+
+  -- transfer_items
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped, qty_received)
+  VALUES (v_transfer, v_sku, 1, 1, 0)
+  RETURNING id INTO v_item;
+
+  -- transfer_out
+  INSERT INTO stock_movements (
+    tenant_id, location_id, sku_id, quantity, unit_cost,
+    movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+    reason, operator_id
+  ) VALUES (
+    v_tenant, v_src_loc, v_sku, -1, 60,
+    'transfer_out', 'transfer', v_transfer, v_item,
+    'TF-AID-002 ship', v_operator
+  ) RETURNING id INTO v_out_mv;
+
+  -- transfer_reject reversal
+  INSERT INTO stock_movements (
+    tenant_id, location_id, sku_id, quantity, unit_cost,
+    movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+    reverses, reason, operator_id
+  ) VALUES (
+    v_tenant, v_src_loc, v_sku, 1, 60,
+    'transfer_reject', 'transfer', v_transfer, v_item,
+    v_out_mv, 'R11c: 取消、stock 反流', v_operator
+  );
+
+  -- claim
+  INSERT INTO mutual_aid_claims (
+    tenant_id, board_id, claiming_store_id, qty, resulting_transfer_id, created_by
+  ) VALUES (
+    v_tenant, v_board, v_dst_store, 1, v_transfer, v_operator
+  );
+END $$;
+
 COMMIT;
 
-\echo 'fixture with-mutual-aid seeded.'
+\echo 'fixture with-mutual-aid seeded (3 req + 4 offers incl. R11a/b/c + 1 active claim + 3 replies).'
+

--- a/scripts/e2e/fixtures/with-orders.sql
+++ b/scripts/e2e/fixtures/with-orders.sql
@@ -2,11 +2,15 @@
 -- fixture: with-orders
 -- 依賴 with-campaign 已建立活動。直接 \i 串入 with-campaign 確保獨立可跑。
 --
--- 建立 4 筆顧客訂單，覆蓋多種狀態：
---   ORD-0001  pending           （CAMP-001、會員 M-TEST-001、平鎮取貨）
---   ORD-0002  reserved          （CAMP-002、會員 M-TEST-002、松山取貨）
---   ORD-0003  ready             （CAMP-009、會員 M-TEST-001）
---   ORD-0004  completed         （CAMP-010、會員 M-TEST-002）
+-- 8 筆顧客訂單覆蓋正常 + 反向情境：
+--   ORD-0001  pending              （CAMP-001、M-TEST-001、平鎮取貨）
+--   ORD-0002  reserved             （CAMP-002、M-TEST-002、松山取貨、wallet pay）
+--   ORD-0003  ready                （CAMP-009、M-TEST-001）
+--   ORD-0004  completed            （CAMP-010、M-TEST-002、含 pickup_event）
+--   ORD-0005  cancelled            （CAMP-003、M-TEST-001、soft-cancel 負數情境）
+--   ORD-0006  completed → returned （CAMP-005、M-TEST-001、R8 顧客退貨情境 + wallet refund）
+--   ORD-0007  partially_completed  （CAMP-006、M-TEST-002、R4 缺貨情境 + shortage_events）
+--   ORD-0008  pending              （CAMP-008、M-TEST-003、銀卡 0.92 + 88 折促銷雙折扣）
 -- ============================================================
 \set ON_ERROR_STOP on
 
@@ -14,43 +18,41 @@
 
 BEGIN;
 
-WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
-     ch       AS (SELECT id FROM line_channels WHERE tenant_id = :'tenant_id'::uuid AND code = 'LC-MAIN'),
-     m1       AS (SELECT id FROM members WHERE tenant_id = :'tenant_id'::uuid AND member_no = 'M-TEST-001'),
-     m2       AS (SELECT id FROM members WHERE tenant_id = :'tenant_id'::uuid AND member_no = 'M-TEST-002'),
-     s_pz     AS (SELECT id FROM stores  WHERE tenant_id = :'tenant_id'::uuid AND code = 'S001'),
-     s_ss     AS (SELECT id FROM stores  WHERE tenant_id = :'tenant_id'::uuid AND code = 'S002')
+-- ── 8 筆訂單單頭 ────────────────────────────────────────
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
 INSERT INTO customer_orders (
   tenant_id, order_no, campaign_id, channel_id, member_id,
-  nickname_snapshot, pickup_store_id, pickup_deadline, status, created_by
+  nickname_snapshot, pickup_store_id, pickup_deadline, status, created_by, notes
 )
 SELECT :'tenant_id'::uuid,
        x.order_no,
        (SELECT id FROM group_buy_campaigns WHERE tenant_id = :'tenant_id'::uuid AND campaign_no = x.camp),
-       (SELECT id FROM ch),
+       (SELECT id FROM line_channels WHERE tenant_id = :'tenant_id'::uuid AND code = x.channel_code),
        (SELECT id FROM members WHERE tenant_id = :'tenant_id'::uuid AND member_no = x.member_no),
        x.nickname,
        (SELECT id FROM stores  WHERE tenant_id = :'tenant_id'::uuid AND code = x.store),
        (CURRENT_DATE + 14)::date,
        x.status,
-       (SELECT id FROM any_user)
+       (SELECT id FROM any_user),
+       x.notes
 FROM (VALUES
-  ('ORD-0001', 'CAMP-001', 'M-TEST-001', '小明', 'S001', 'pending'),
-  ('ORD-0002', 'CAMP-002', 'M-TEST-002', '小華', 'S002', 'reserved'),
-  ('ORD-0003', 'CAMP-009', 'M-TEST-001', '小明', 'S001', 'ready'),
-  ('ORD-0004', 'CAMP-010', 'M-TEST-002', '小華', 'S002', 'completed')
-) AS x(order_no, camp, member_no, nickname, store, status);
+  ('ORD-0001', 'CAMP-001', 'LC-MAIN', 'M-TEST-001', '小明',  'S001', 'pending',              NULL),
+  ('ORD-0002', 'CAMP-002', 'LC-MAIN', 'M-TEST-002', '小華',  'S002', 'reserved',             'wallet 付款'),
+  ('ORD-0003', 'CAMP-009', 'LC-MAIN', 'M-TEST-001', '小明',  'S001', 'ready',                NULL),
+  ('ORD-0004', 'CAMP-010', 'LC-MAIN', 'M-TEST-002', '小華',  'S002', 'completed',            '已取貨'),
+  ('ORD-0005', 'CAMP-003', 'LC-MAIN', 'M-TEST-001', '小明',  'S001', 'cancelled',            'R4: soft-cancel 負數情境'),
+  ('ORD-0006', 'CAMP-005', 'LC-MAIN', 'M-TEST-001', '小明',  'S001', 'completed',            'R8: 取貨後反悔退貨'),
+  ('ORD-0007', 'CAMP-006', 'LC-MAIN', 'M-TEST-002', '小華',  'S002', 'partially_completed',  'R4: 部分缺貨'),
+  ('ORD-0008', 'CAMP-008', 'LC-MAIN', 'M-TEST-003', '小芳',  'S003', 'pending',              '88折促銷 + 銀卡 0.92')
+) AS x(order_no, camp, channel_code, member_no, nickname, store, status, notes);
 
--- 訂單明細
+-- ── 訂單明細：依各訂單情境分別灌 ────────────────────────
+-- ORD-0001 ~ ORD-0004 沿用原 mapping（依 campaign_items sort_order）
 INSERT INTO customer_order_items (
   tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price, status, source
 )
 SELECT
-  :'tenant_id'::uuid,
-  o.id,
-  ci.id,
-  ci.sku_id,
-  -- 主商品 2 個、第二商品 1 個
+  :'tenant_id'::uuid, o.id, ci.id, ci.sku_id,
   CASE WHEN ci.sort_order = 1 THEN 2 ELSE 1 END,
   ci.unit_price,
   CASE o.status
@@ -61,10 +63,146 @@ SELECT
   END,
   'manual'
 FROM customer_orders o
-JOIN campaign_items ci
-  ON ci.campaign_id = o.campaign_id AND ci.tenant_id = o.tenant_id
+JOIN campaign_items ci ON ci.campaign_id = o.campaign_id AND ci.tenant_id = o.tenant_id
+WHERE o.tenant_id = :'tenant_id'::uuid AND o.order_no IN ('ORD-0001','ORD-0002','ORD-0003','ORD-0004');
+
+-- ORD-0005 cancelled：原訂 SKU-006 蜂蜜 ×3 → cancelled（負數情境用）
+INSERT INTO customer_order_items (
+  tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price, status, source
+)
+SELECT :'tenant_id'::uuid, o.id, ci.id, ci.sku_id, 3, ci.unit_price, 'cancelled', 'manual'
+FROM customer_orders o
+JOIN campaign_items ci ON ci.campaign_id = o.campaign_id AND ci.sort_order = 1
+WHERE o.tenant_id = :'tenant_id'::uuid AND o.order_no = 'ORD-0005';
+
+-- ORD-0006 completed → returned（R8 退貨情境）
+-- 訂 SKU-002 黑糖薑茶 ×2 + SKU-007 麵粉 ×1，已 picked_up（之後 R8 用 movement+wallet 反映退貨）
+INSERT INTO customer_order_items (
+  tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price, status, source
+)
+SELECT
+  :'tenant_id'::uuid, o.id, ci.id, ci.sku_id,
+  CASE WHEN ci.sort_order = 1 THEN 2 ELSE 1 END,
+  ci.unit_price, 'picked_up', 'manual'
+FROM customer_orders o
+JOIN campaign_items ci ON ci.campaign_id = o.campaign_id AND ci.tenant_id = o.tenant_id
+WHERE o.tenant_id = :'tenant_id'::uuid AND o.order_no = 'ORD-0006';
+
+-- ORD-0007 partially_completed（R4 缺貨）
+-- 訂 SKU-009 糯米醋 ×3，但只供應 2 個 → 1 個 shortage
+INSERT INTO customer_order_items (
+  tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price, status, source
+)
+SELECT :'tenant_id'::uuid, o.id, ci.id, ci.sku_id, 3, ci.unit_price, 'partially_picked_up', 'manual'
+FROM customer_orders o
+JOIN campaign_items ci ON ci.campaign_id = o.campaign_id AND ci.sort_order = 1
+WHERE o.tenant_id = :'tenant_id'::uuid AND o.order_no = 'ORD-0007';
+
+-- ORD-0008 pending：銀卡 + 88 折促銷雙折扣 (CAMP-008 SKU-007 麵粉 65 → 65*0.92*0.88 = 52.62)
+INSERT INTO customer_order_items (
+  tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price, status, source, notes
+)
+SELECT
+  :'tenant_id'::uuid, o.id, ci.id, ci.sku_id,
+  2,
+  ROUND(ci.unit_price * 0.92 * 0.88, 4),  -- 銀卡 0.92 × 88折 = 0.8096
+  'pending', 'manual',
+  '88折 + 銀卡雙折扣'
+FROM customer_orders o
+JOIN campaign_items ci ON ci.campaign_id = o.campaign_id AND ci.sort_order = 1
+WHERE o.tenant_id = :'tenant_id'::uuid AND o.order_no = 'ORD-0008';
+
+-- ── customer_order_sources（訂單來源 audit 4 種）─────────
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
+INSERT INTO customer_order_sources (
+  tenant_id, campaign_id, order_id, source_type, screenshot_url, created_by
+)
+SELECT :'tenant_id'::uuid,
+       o.campaign_id,
+       o.id,
+       x.stype,
+       x.url,
+       (SELECT id FROM any_user)
+FROM customer_orders o
+JOIN (VALUES
+  ('ORD-0001', 'screenshot',   'https://example.com/screenshot/ord-0001.jpg'),
+  ('ORD-0002', 'manual_paste', NULL),
+  ('ORD-0008', 'csv',          NULL)
+) AS x(order_no, stype, url) ON o.order_no = x.order_no
 WHERE o.tenant_id = :'tenant_id'::uuid;
+
+-- ── R4 缺貨事件（ORD-0007）──────────────────────────────
+INSERT INTO order_shortage_events (
+  tenant_id, campaign_id, order_id, sku_id, requested_qty, fulfilled_qty, reason
+)
+SELECT :'tenant_id'::uuid, o.campaign_id, o.id, coi.sku_id,
+       coi.qty, 2, 'R4: 確認時發現庫存只有 2 個（請求 3 個）'
+FROM customer_orders o
+JOIN customer_order_items coi ON coi.order_id = o.id
+WHERE o.tenant_id = :'tenant_id'::uuid AND o.order_no = 'ORD-0007';
+
+-- ── ORD-0004 取貨事件（completed）+ ORD-0006 取貨事件（後 R8）──
+INSERT INTO order_pickup_events (
+  tenant_id, order_id, pickup_store_id, event_type, item_ids, created_by
+)
+SELECT :'tenant_id'::uuid, o.id, o.pickup_store_id, 'picked_up',
+       (SELECT jsonb_agg(coi.id) FROM customer_order_items coi WHERE coi.order_id = o.id),
+       o.created_by
+FROM customer_orders o
+WHERE o.tenant_id = :'tenant_id'::uuid AND o.order_no IN ('ORD-0004','ORD-0006');
+
+-- ── R8: ORD-0006 SKU-002 黑糖薑茶 ×1 取貨後退回 ────────────
+-- step 1: stock_movement type='customer_return' 把 1 個還回 S001 平鎮店
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
+     o AS (SELECT * FROM customer_orders WHERE tenant_id = :'tenant_id'::uuid AND order_no = 'ORD-0006'),
+     coi AS (SELECT coi.* FROM customer_order_items coi
+              JOIN o ON coi.order_id = o.id
+              JOIN skus s ON s.id = coi.sku_id
+             WHERE s.sku_code = 'SKU-002')
+INSERT INTO stock_movements (
+  tenant_id, location_id, sku_id, quantity, unit_cost,
+  movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+  reason, operator_id
+)
+SELECT :'tenant_id'::uuid,
+       (SELECT location_id FROM stores WHERE tenant_id = :'tenant_id'::uuid AND code = 'S001'),
+       (SELECT sku_id FROM coi),
+       1, 50,  -- 用 SUP-LOCAL 黑糖薑茶 cost
+       'customer_return',
+       'customer_order', (SELECT id FROM o), (SELECT id FROM coi),
+       'R8: ORD-0006 顧客取貨後反悔退回 SKU-002 ×1',
+       (SELECT id FROM any_user);
+
+-- step 2: wallet refund（M-TEST-001 退 80 = SKU-002 unit_price）
+DO $$
+DECLARE
+  v_tenant   UUID := :'tenant_id'::uuid;
+  v_member   BIGINT;
+  v_balance  NUMERIC;
+  v_operator UUID;
+  v_order_id BIGINT;
+BEGIN
+  SELECT id INTO v_member FROM members
+   WHERE tenant_id = v_tenant AND member_no = 'M-TEST-001';
+  SELECT id INTO v_order_id FROM customer_orders
+   WHERE tenant_id = v_tenant AND order_no = 'ORD-0006';
+  SELECT id INTO v_operator FROM auth.users LIMIT 1;
+  SELECT balance INTO v_balance FROM wallet_balances
+   WHERE tenant_id = v_tenant AND member_id = v_member;
+
+  -- M-TEST-001 base+wallet-history 後 balance = 750；退款 +80 → 830
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after, type,
+                             source_type, source_id, reason, operator_id)
+  VALUES (v_tenant, v_member, 80, v_balance + 80, 'refund',
+          'customer_order', v_order_id, 'R8: ORD-0006 取貨後退貨補回 wallet',
+          v_operator);
+
+  UPDATE wallet_balances
+     SET balance = v_balance + 80, version = version + 1,
+         last_movement_at = NOW(), updated_at = NOW()
+   WHERE tenant_id = v_tenant AND member_id = v_member;
+END $$;
 
 COMMIT;
 
-\echo 'fixture with-orders seeded (4 orders).'
+\echo 'fixture with-orders seeded (8 orders incl. R4 shortage + R8 customer return + 88折).'

--- a/scripts/e2e/fixtures/with-picking-wave.sql
+++ b/scripts/e2e/fixtures/with-picking-wave.sql
@@ -1,0 +1,132 @@
+-- ============================================================
+-- fixture: with-picking-wave
+-- 撿貨波次情境（依賴 with-orders 的 customer_orders + with-campaign）：
+--
+--   WAVE-0001  picked      正常 wave + R5 撿貨不足量
+--                          - SKU-001 ORD-0001 申請 2、實撿 2
+--                          - SKU-007 ORD-0001 申請 1、實撿 1
+--                          - SKU-003 ORD-0002 申請 2、實撿 1（R5 短少 1 件 → 應產 backorder）
+--   WAVE-0002  cancelled   R9: wave 整單取消（picking 中）
+--                          - SKU-008 ORD-0003 申請 1、picked_qty 還沒填
+--
+-- 不模擬 generate_transfer_from_wave（generated_transfer_id 留空）。
+-- ============================================================
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ── WAVE-0001 picked（含 R5 撿貨不足）───────────────────
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
+INSERT INTO picking_waves (
+  tenant_id, wave_code, wave_date, status, store_count, item_count, total_qty,
+  note, created_by, updated_by
+)
+SELECT :'tenant_id'::uuid,
+       'WAVE-0001',
+       CURRENT_DATE,
+       'picked',
+       2, 3, 4,  -- 2 stores (S001+S002), 3 items, total picked 4
+       'CAMP-001 + CAMP-002 撿貨波次（含 R5 短少）',
+       (SELECT id FROM any_user),
+       (SELECT id FROM any_user);
+
+-- WAVE-0001 items
+INSERT INTO picking_wave_items (
+  tenant_id, wave_id, sku_id, store_id, qty, picked_qty, campaign_id,
+  note, created_by, updated_by
+)
+SELECT :'tenant_id'::uuid,
+       (SELECT id FROM picking_waves WHERE tenant_id = :'tenant_id'::uuid AND wave_code = 'WAVE-0001'),
+       (SELECT id FROM skus WHERE tenant_id = :'tenant_id'::uuid AND sku_code = x.sku),
+       (SELECT id FROM stores WHERE tenant_id = :'tenant_id'::uuid AND code = x.store),
+       x.qty, x.picked,
+       (SELECT id FROM group_buy_campaigns WHERE tenant_id = :'tenant_id'::uuid AND campaign_no = x.camp),
+       x.note,
+       (SELECT id FROM auth.users LIMIT 1),
+       (SELECT id FROM auth.users LIMIT 1)
+FROM (VALUES
+  ('SKU-001', 'S001', 'CAMP-001', 2, 2, NULL),
+  ('SKU-007', 'S001', 'CAMP-001', 1, 1, NULL),
+  ('SKU-003', 'S002', 'CAMP-002', 2, 1, 'R5: 申請 2 實撿 1（短少 1 件 → backorder）')
+) AS x(sku, store, camp, qty, picked, note);
+
+-- WAVE-0001 audit log
+INSERT INTO picking_wave_audit_log (tenant_id, wave_id, action, after_value, note, created_by)
+SELECT :'tenant_id'::uuid,
+       (SELECT id FROM picking_waves WHERE tenant_id = :'tenant_id'::uuid AND wave_code = 'WAVE-0001'),
+       a.action, a.after_value::jsonb, a.note,
+       (SELECT id FROM auth.users LIMIT 1)
+FROM (VALUES
+  ('wave_created',         '{"wave_code":"WAVE-0001","item_count":3}',         NULL),
+  ('picked_qty_changed',   '{"sku":"SKU-001","picked_qty":2}',                  NULL),
+  ('picked_qty_changed',   '{"sku":"SKU-007","picked_qty":1}',                  NULL),
+  ('picked_qty_changed',   '{"sku":"SKU-003","picked_qty":1,"shortage":1}',     'R5 短少'),
+  ('wave_status_changed',  '{"from":"picking","to":"picked"}',                  NULL)
+) AS a(action, after_value, note);
+
+-- ── R5: backorders 為短少件數開單 ─────────────────────────
+-- ORD-0002 SKU-003 申請 2 實得 1 → 1 件 backorder
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
+     o AS (SELECT * FROM customer_orders WHERE tenant_id = :'tenant_id'::uuid AND order_no = 'ORD-0002'),
+     coi AS (SELECT coi.* FROM customer_order_items coi
+              JOIN o ON coi.order_id = o.id
+              JOIN skus s ON s.id = coi.sku_id
+             WHERE s.sku_code = 'SKU-003')
+INSERT INTO backorders (
+  tenant_id, original_customer_order_item_id, sku_id, store_id, member_id,
+  qty_pending, status, notes, created_by, updated_by
+)
+SELECT :'tenant_id'::uuid,
+       (SELECT id FROM coi),
+       (SELECT sku_id FROM coi),
+       (SELECT pickup_store_id FROM o),
+       (SELECT member_id FROM o),
+       1,
+       'pending',
+       'R5: WAVE-0001 撿貨不足、ORD-0002 SKU-003 短少 1 件',
+       (SELECT id FROM any_user),
+       (SELECT id FROM any_user);
+
+-- ── WAVE-0002 cancelled（R9 wave 整單取消）──────────────
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
+INSERT INTO picking_waves (
+  tenant_id, wave_code, wave_date, status, store_count, item_count, total_qty,
+  note, created_by, updated_by
+)
+SELECT :'tenant_id'::uuid,
+       'WAVE-0002',
+       CURRENT_DATE,
+       'cancelled',
+       1, 1, 0,
+       'R9: 撿貨中發現拼錯波次、整單取消',
+       (SELECT id FROM any_user),
+       (SELECT id FROM any_user);
+
+INSERT INTO picking_wave_items (
+  tenant_id, wave_id, sku_id, store_id, qty, picked_qty, campaign_id,
+  note, created_by, updated_by
+)
+SELECT :'tenant_id'::uuid,
+       (SELECT id FROM picking_waves WHERE tenant_id = :'tenant_id'::uuid AND wave_code = 'WAVE-0002'),
+       (SELECT id FROM skus WHERE tenant_id = :'tenant_id'::uuid AND sku_code = 'SKU-008'),
+       (SELECT id FROM stores WHERE tenant_id = :'tenant_id'::uuid AND code = 'S001'),
+       1, NULL,  -- 還沒撿就取消
+       (SELECT id FROM group_buy_campaigns WHERE tenant_id = :'tenant_id'::uuid AND campaign_no = 'CAMP-009'),
+       NULL,
+       (SELECT id FROM auth.users LIMIT 1),
+       (SELECT id FROM auth.users LIMIT 1);
+
+-- WAVE-0002 audit log
+INSERT INTO picking_wave_audit_log (tenant_id, wave_id, action, after_value, note, created_by)
+SELECT :'tenant_id'::uuid,
+       (SELECT id FROM picking_waves WHERE tenant_id = :'tenant_id'::uuid AND wave_code = 'WAVE-0002'),
+       a.action, a.after_value::jsonb, a.note,
+       (SELECT id FROM auth.users LIMIT 1)
+FROM (VALUES
+  ('wave_created',     '{"wave_code":"WAVE-0002","item_count":1}',  NULL),
+  ('wave_cancelled',   '{"reason":"R9: 拼錯波次"}',                  'R9 整單取消')
+) AS a(action, after_value, note);
+
+COMMIT;
+
+\echo 'fixture with-picking-wave seeded (1 picked wave with R5 shortage + 1 cancelled wave R9 + 1 backorder).'

--- a/scripts/e2e/fixtures/with-pr-po.sql
+++ b/scripts/e2e/fixtures/with-pr-po.sql
@@ -1,27 +1,44 @@
 -- ============================================================
 -- fixture: with-pr-po
--- 採購流：PR (請購) / PO (採購單) / GR (進貨)
+-- 採購流：PR (請購) / PO (採購單) / GR (進貨) + 反向情境
+--
+-- 正常情境：
 --   PR-0001  draft           平鎮店請購 P004 香米×10
 --   PR-0002  fully_ordered   松山店請購 P003 醬油×6
---   PO-0001  sent            SUP-LOCAL → WH-HQ
---   PO-0002  fully_received  SUP-LOCAL → WH-HQ，已驗收 → GR-0001
+--   PO-0001  sent            SUP-LOCAL → WH-HQ（剛發送、未驗收）
+--   PO-0002  fully_received  SUP-LOCAL → WH-HQ → GR-0001 confirmed
+--
+-- 反向情境：
+--   PR-0003  cancelled              R1: PR 直接取消
+--   PR-0004  submitted              準備拆單到 PO-0003
+--   PO-0003  cancelled (no GR)      R2a: PO 已 sent 後取消、未進貨
+--   PO-0004  cancelled (partial)    R2b: 收 7 個後取消剩 3 個 → GR-0002 confirmed
+--   PO-0005  partially_received     R3: 訂 8 個實收 5 個 → GR-0003 confirmed (3 件短少 → backorder)
+--
+-- AP / 退貨：
+--   VB-0001  paid           PO-0002 應付帳款 + VP-0001 已付
+--   VB-0002  pending        PO-0004 partial bill（only 7 received）
+--   PRET-0001 confirmed     PO-0002 GR-0001 退貨 1 個 SKU-004 因瑕疵 → 走退供
 -- ============================================================
 \set ON_ERROR_STOP on
 
 BEGIN;
 
 WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
-INSERT INTO purchase_requests (tenant_id, pr_no, source_location_id, status, created_by, submitted_at)
+INSERT INTO purchase_requests (tenant_id, pr_no, source_location_id, status, created_by, submitted_at, notes)
 SELECT :'tenant_id'::uuid,
        x.pr_no,
        (SELECT id FROM locations WHERE tenant_id = :'tenant_id'::uuid AND code = x.loc),
        x.status,
        (SELECT id FROM any_user),
-       CASE WHEN x.status = 'draft' THEN NULL ELSE NOW() - INTERVAL '2 days' END
+       CASE WHEN x.status = 'draft' THEN NULL ELSE NOW() - INTERVAL '2 days' END,
+       x.notes
 FROM (VALUES
-  ('PR-0001', 'WH-S001', 'draft'),
-  ('PR-0002', 'WH-S002', 'fully_ordered')
-) AS x(pr_no, loc, status);
+  ('PR-0001', 'WH-S001', 'draft',         NULL),
+  ('PR-0002', 'WH-S002', 'fully_ordered', NULL),
+  ('PR-0003', 'WH-S001', 'cancelled',     'R1: PR 取消（HQ 拒絕）'),
+  ('PR-0004', 'WH-S003', 'submitted',     '北投店請購 → 準備拆 PO-0003 / PO-0005')
+) AS x(pr_no, loc, status, notes);
 
 INSERT INTO purchase_request_items (pr_id, sku_id, qty_requested)
 SELECT pr.id,
@@ -30,7 +47,10 @@ SELECT pr.id,
 FROM purchase_requests pr
 JOIN (VALUES
   ('PR-0001', 'SKU-004', 10),
-  ('PR-0002', 'SKU-003',  6)
+  ('PR-0002', 'SKU-003',  6),
+  ('PR-0003', 'SKU-005',  5),  -- R1 cancelled
+  ('PR-0004', 'SKU-001', 10),  -- 對應 PO-0003 cancelled
+  ('PR-0004', 'SKU-002',  8)   -- 對應 PO-0005 R3 短少
 ) AS x(pr_no, sku_code, qty) ON pr.pr_no = x.pr_no
 WHERE pr.tenant_id = :'tenant_id'::uuid;
 
@@ -38,7 +58,7 @@ WHERE pr.tenant_id = :'tenant_id'::uuid;
 WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
 INSERT INTO purchase_orders (
   tenant_id, po_no, supplier_id, dest_location_id, status,
-  order_date, expected_date, subtotal, tax, total, created_by, sent_at, sent_by
+  order_date, expected_date, subtotal, tax, total, created_by, sent_at, sent_by, notes
 )
 SELECT :'tenant_id'::uuid,
        x.po_no,
@@ -51,48 +71,73 @@ SELECT :'tenant_id'::uuid,
        ROUND(x.subtotal * 0.05, 2),
        ROUND(x.subtotal * 1.05, 2),
        (SELECT id FROM any_user),
-       CASE WHEN x.status IN ('sent','fully_received') THEN NOW() - INTERVAL '4 days' ELSE NULL END,
-       CASE WHEN x.status IN ('sent','fully_received') THEN (SELECT id FROM any_user)      ELSE NULL END
+       CASE WHEN x.status IN ('sent','partially_received','fully_received','cancelled')
+            THEN NOW() - INTERVAL '4 days' ELSE NULL END,
+       CASE WHEN x.status IN ('sent','partially_received','fully_received','cancelled')
+            THEN (SELECT id FROM any_user) ELSE NULL END,
+       x.notes
 FROM (VALUES
-  ('PO-0001', 'SUP-LOCAL', 'WH-HQ', 'sent',           900),
-  ('PO-0002', 'SUP-LOCAL', 'WH-HQ', 'fully_received', 1500)
-) AS x(po_no, sup_code, dest_code, status, subtotal);
+  ('PO-0001', 'SUP-LOCAL', 'WH-HQ', 'sent',                900,  NULL),
+  ('PO-0002', 'SUP-LOCAL', 'WH-HQ', 'fully_received',     1500,  NULL),
+  ('PO-0003', 'SUP-JP',    'WH-HQ', 'cancelled',           850,  'R2a: 已 sent 後取消、未進貨'),
+  ('PO-0004', 'SUP-LOCAL', 'WH-HQ', 'cancelled',          1300,  'R2b: 收 7/10 後取消剩 3'),
+  ('PO-0005', 'SUP-LOCAL', 'WH-HQ', 'partially_received',  400,  'R3: 訂 8 個實收 5 個（短少 3）')
+) AS x(po_no, sup_code, dest_code, status, subtotal, notes);
 
 -- purchase_order_items：line_subtotal 為 GENERATED 欄位，不要塞值
 INSERT INTO purchase_order_items (po_id, sku_id, qty_ordered, qty_received, unit_cost)
 SELECT po.id,
        (SELECT id FROM skus WHERE tenant_id = :'tenant_id'::uuid AND sku_code = x.sku_code),
        x.qty,
-       (CASE WHEN po.status = 'fully_received' THEN x.qty ELSE 0 END),
+       x.qty_recv,
        x.cost
 FROM purchase_orders po
 JOIN (VALUES
-  ('PO-0001', 'SKU-003',  6, 150),
-  ('PO-0002', 'SKU-004', 10, 130),
-  ('PO-0002', 'SKU-007',  4,  40)
-) AS x(po_no, sku_code, qty, cost) ON po.po_no = x.po_no
+  ('PO-0001', 'SKU-003',  6,  0, 150),
+  ('PO-0002', 'SKU-004', 10, 10, 130),
+  ('PO-0002', 'SKU-007',  4,  4,  40),
+  ('PO-0003', 'SKU-001', 10,  0,  85),  -- R2a 全 0 收
+  ('PO-0004', 'SKU-006', 10,  7, 230),  -- R2b partial 7/10
+  ('PO-0005', 'SKU-002',  8,  5,  50)   -- R3 short 5/8
+) AS x(po_no, sku_code, qty, qty_recv, cost) ON po.po_no = x.po_no
 WHERE po.tenant_id = :'tenant_id'::uuid;
 
--- ── GR（PO-0002 已驗收 → status = confirmed）──────────────
+-- 把 PR-0004 的 items po_item_id 連到 PO-0003 / PO-0005
+UPDATE purchase_request_items pri
+   SET po_item_id = poi.id
+  FROM purchase_orders po, purchase_order_items poi, purchase_requests pr,
+       skus s
+ WHERE pr.tenant_id = :'tenant_id'::uuid
+   AND pr.pr_no = 'PR-0004'
+   AND pri.pr_id = pr.id
+   AND po.tenant_id = :'tenant_id'::uuid
+   AND po.po_no IN ('PO-0003','PO-0005')
+   AND poi.po_id = po.id
+   AND s.id = pri.sku_id
+   AND s.id = poi.sku_id;
+
+-- ── GR（3 張：GR-0001 PO-0002 fully + GR-0002 PO-0004 partial + GR-0003 PO-0005 short）──
 WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
 INSERT INTO goods_receipts (
   tenant_id, gr_no, po_id, supplier_id, dest_location_id, status, receive_date,
-  received_by, confirmed_at, confirmed_by, created_by
+  received_by, confirmed_at, confirmed_by, created_by, notes
 )
-SELECT :'tenant_id'::uuid,
-       'GR-0001',
-       po.id,
-       po.supplier_id,
-       po.dest_location_id,
-       'confirmed',
-       (CURRENT_DATE - INTERVAL '1 day')::date,
+SELECT :'tenant_id'::uuid, x.gr_no, po.id, po.supplier_id, po.dest_location_id,
+       'confirmed', (CURRENT_DATE - INTERVAL '1 day')::date,
        (SELECT id FROM any_user),
        NOW() - INTERVAL '1 day',
        (SELECT id FROM any_user),
-       (SELECT id FROM any_user)
+       (SELECT id FROM any_user),
+       x.notes
 FROM purchase_orders po
-WHERE po.tenant_id = :'tenant_id'::uuid AND po.po_no = 'PO-0002';
+JOIN (VALUES
+  ('GR-0001', 'PO-0002', NULL),
+  ('GR-0002', 'PO-0004', 'R2b: 收 7/10 後 PO 取消'),
+  ('GR-0003', 'PO-0005', 'R3: 訂 8 實收 5 — 短少 3 件')
+) AS x(gr_no, po_no, notes) ON po.po_no = x.po_no
+WHERE po.tenant_id = :'tenant_id'::uuid;
 
+-- GR-0001 全收（PO-0002 fully_received）
 INSERT INTO goods_receipt_items (gr_id, po_item_id, sku_id, qty_expected, qty_received, unit_cost)
 SELECT gr.id, poi.id, poi.sku_id, poi.qty_ordered, poi.qty_ordered, poi.unit_cost
 FROM goods_receipts gr
@@ -100,6 +145,161 @@ JOIN purchase_orders po ON po.id = gr.po_id
 JOIN purchase_order_items poi ON poi.po_id = po.id
 WHERE gr.tenant_id = :'tenant_id'::uuid AND gr.gr_no = 'GR-0001';
 
+-- GR-0002 partial（R2b）：PO-0004 SKU-006 訂 10、收 7
+INSERT INTO goods_receipt_items (gr_id, po_item_id, sku_id, qty_expected, qty_received, unit_cost,
+                                 variance_reason)
+SELECT gr.id, poi.id, poi.sku_id, poi.qty_ordered, 7, poi.unit_cost,
+       'R2b: 7/10 部分到貨後 PO 取消剩餘'
+FROM goods_receipts gr
+JOIN purchase_orders po ON po.id = gr.po_id
+JOIN purchase_order_items poi ON poi.po_id = po.id
+WHERE gr.tenant_id = :'tenant_id'::uuid AND gr.gr_no = 'GR-0002';
+
+-- GR-0003 short（R3）：PO-0005 SKU-002 訂 8、收 5
+INSERT INTO goods_receipt_items (gr_id, po_item_id, sku_id, qty_expected, qty_received, unit_cost,
+                                 variance_reason)
+SELECT gr.id, poi.id, poi.sku_id, poi.qty_ordered, 5, poi.unit_cost,
+       'R3: 來貨不足 5/8 — 短少 3 件，預期成 backorder'
+FROM goods_receipts gr
+JOIN purchase_orders po ON po.id = gr.po_id
+JOIN purchase_order_items poi ON poi.po_id = po.id
+WHERE gr.tenant_id = :'tenant_id'::uuid AND gr.gr_no = 'GR-0003';
+
+-- ── stock_movements: 已驗收的 GR 寫一筆 purchase_receipt 入 WH-HQ ──
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
+INSERT INTO stock_movements (
+  tenant_id, location_id, sku_id, quantity, unit_cost,
+  movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+  reason, operator_id
+)
+SELECT :'tenant_id'::uuid,
+       gr.dest_location_id,
+       gri.sku_id,
+       gri.qty_received,
+       gri.unit_cost,
+       'purchase_receipt',
+       'goods_receipt', gr.id, gri.id,
+       'GR ' || gr.gr_no || ' 入庫',
+       (SELECT id FROM any_user)
+FROM goods_receipts gr
+JOIN goods_receipt_items gri ON gri.gr_id = gr.id
+WHERE gr.tenant_id = :'tenant_id'::uuid
+  AND gr.gr_no IN ('GR-0001','GR-0002','GR-0003');
+
+-- ── vendor_bills + payments + allocations ────────────────
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
+INSERT INTO vendor_bills (
+  tenant_id, bill_no, supplier_id, source_type, source_id,
+  bill_date, due_date, amount, paid_amount, status, tax_amount,
+  supplier_invoice_no, created_by, notes
+)
+SELECT :'tenant_id'::uuid,
+       x.bill_no,
+       (SELECT id FROM suppliers WHERE tenant_id = :'tenant_id'::uuid AND code = x.sup),
+       x.src_type,
+       (SELECT id FROM purchase_orders WHERE tenant_id = :'tenant_id'::uuid AND po_no = x.src_po),
+       (CURRENT_DATE - INTERVAL '1 day')::date,
+       (CURRENT_DATE + INTERVAL '29 days')::date,
+       x.amount,
+       x.paid,
+       x.status,
+       ROUND(x.amount * 0.05, 4),
+       x.invoice_no,
+       (SELECT id FROM any_user),
+       x.notes
+FROM (VALUES
+  ('VB-0001', 'SUP-LOCAL', 'purchase_order', 'PO-0002', 1575, 1575, 'paid',     'INV-LOCAL-001', 'PO-0002 全收貨應付'),
+  ('VB-0002', 'SUP-LOCAL', 'purchase_order', 'PO-0004', 1697,    0, 'pending',  'INV-LOCAL-002', 'R2b: PO-0004 partial 7×230×1.05+tax')
+) AS x(bill_no, sup, src_type, src_po, amount, paid, status, invoice_no, notes);
+
+-- vendor_bill_items（依 PO + GR 行展開）
+INSERT INTO vendor_bill_items (
+  tenant_id, bill_id, line_no, description, sku_id, qty, unit_cost, amount,
+  po_item_id, gr_item_id
+)
+SELECT :'tenant_id'::uuid,
+       vb.id,
+       ROW_NUMBER() OVER (PARTITION BY vb.id ORDER BY gri.id),
+       sk.product_name || ' - ' || sk.sku_code,
+       gri.sku_id,
+       gri.qty_received,
+       gri.unit_cost,
+       ROUND(gri.qty_received * gri.unit_cost * 1.05, 4),
+       gri.po_item_id,
+       gri.id
+FROM vendor_bills vb
+JOIN purchase_orders po ON po.id = vb.source_id
+JOIN goods_receipts gr ON gr.po_id = po.id
+JOIN goods_receipt_items gri ON gri.gr_id = gr.id
+JOIN skus sk ON sk.id = gri.sku_id
+WHERE vb.tenant_id = :'tenant_id'::uuid AND vb.bill_no IN ('VB-0001','VB-0002');
+
+-- vendor_payments: VP-0001 付掉 VB-0001
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
+INSERT INTO vendor_payments (
+  tenant_id, payment_no, supplier_id, amount, method, paid_at, status, created_by, notes
+)
+SELECT :'tenant_id'::uuid,
+       'VP-0001',
+       (SELECT id FROM suppliers WHERE tenant_id = :'tenant_id'::uuid AND code = 'SUP-LOCAL'),
+       1575, 'bank_transfer',
+       NOW() - INTERVAL '12 hours',
+       'completed',
+       (SELECT id FROM any_user),
+       '付 VB-0001';
+
+INSERT INTO vendor_payment_allocations (tenant_id, payment_id, bill_id, allocated_amount)
+SELECT :'tenant_id'::uuid,
+       (SELECT id FROM vendor_payments WHERE tenant_id = :'tenant_id'::uuid AND payment_no = 'VP-0001'),
+       (SELECT id FROM vendor_bills    WHERE tenant_id = :'tenant_id'::uuid AND bill_no    = 'VB-0001'),
+       1575;
+
+-- ── purchase_returns: PRET-0001 退 1 個 SKU-004 因瑕疵 ──
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
+INSERT INTO purchase_returns (
+  tenant_id, return_no, supplier_id, source_location_id, source_gr_id, status,
+  return_date, reason, created_by, confirmed_at, confirmed_by, notes
+)
+SELECT :'tenant_id'::uuid,
+       'PRET-0001',
+       (SELECT id FROM suppliers WHERE tenant_id = :'tenant_id'::uuid AND code = 'SUP-LOCAL'),
+       (SELECT id FROM locations WHERE tenant_id = :'tenant_id'::uuid AND code = 'WH-HQ'),
+       (SELECT id FROM goods_receipts WHERE tenant_id = :'tenant_id'::uuid AND gr_no = 'GR-0001'),
+       'confirmed',
+       (CURRENT_DATE - INTERVAL '6 hours')::date,
+       'GR-0001 SKU-004 瑕疵 1 個 退供應商',
+       (SELECT id FROM any_user),
+       NOW() - INTERVAL '6 hours',
+       (SELECT id FROM any_user),
+       'E2E: PO-0002 退供 1 件';
+
+-- purchase_return_items 對應的 stock_movement type='return_to_supplier'
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
+     mv AS (
+       INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                                    movement_type, source_doc_type, source_doc_id,
+                                    reason, operator_id)
+       SELECT :'tenant_id'::uuid,
+              (SELECT id FROM locations WHERE tenant_id = :'tenant_id'::uuid AND code = 'WH-HQ'),
+              s.id,
+              -1, 130, 'return_to_supplier',
+              'purchase_return',
+              (SELECT id FROM purchase_returns WHERE tenant_id = :'tenant_id'::uuid AND return_no = 'PRET-0001'),
+              'PRET-0001 退供 1 件 SKU-004',
+              (SELECT id FROM any_user)
+       FROM skus s WHERE s.tenant_id = :'tenant_id'::uuid AND s.sku_code = 'SKU-004'
+       RETURNING id, sku_id
+     )
+INSERT INTO purchase_return_items (
+  return_id, gr_item_id, sku_id, qty, unit_cost, reason, movement_id
+)
+SELECT (SELECT id FROM purchase_returns WHERE tenant_id = :'tenant_id'::uuid AND return_no = 'PRET-0001'),
+       gri.id, mv.sku_id, 1, 130, '瑕疵', mv.id
+FROM mv
+JOIN goods_receipt_items gri ON gri.sku_id = mv.sku_id
+JOIN goods_receipts gr ON gr.id = gri.gr_id AND gr.gr_no = 'GR-0001'
+WHERE gr.tenant_id = :'tenant_id'::uuid;
+
 COMMIT;
 
-\echo 'fixture with-pr-po seeded.'
+\echo 'fixture with-pr-po seeded (4 PRs + 5 POs + 3 GRs + 2 vendor_bills + 1 payment + 1 purchase_return).'

--- a/scripts/e2e/fixtures/with-stock.sql
+++ b/scripts/e2e/fixtures/with-stock.sql
@@ -3,26 +3,42 @@
 -- 在每個 location（總倉 + 5 店）幫每支 SKU 灌一筆初始庫存
 -- 量級：總倉 100 個、店家 20 個。avg_cost 取 supplier_skus.default_unit_cost 折 0.95
 --
--- 採直寫 stock_balances（避免動 stock_movements 的 trigger 鏈）
+-- 改版：走 stock_movements (type='manual_adjust') 鏈，由 trigger 自動更新
+--      stock_balances + 保留審計歷史。為了讓 reverse 情境可以走 stock_movements
+--      鏈（如 R6 transfer / R7 damage 找得到對應 source movement），開帳行
+--      也用 stock_movements 寫入。
 -- ============================================================
 \set ON_ERROR_STOP on
 
 BEGIN;
 
-INSERT INTO stock_balances (tenant_id, location_id, sku_id, on_hand, avg_cost, last_movement_at)
+-- 開帳行：每個 (location × sku) 一筆 manual_adjust 正向 movement
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
+INSERT INTO stock_movements (
+  tenant_id, location_id, sku_id, quantity, unit_cost,
+  movement_type, source_doc_type, reason, operator_id
+)
 SELECT :'tenant_id'::uuid,
        l.id,
        s.id,
        (CASE WHEN l.type = 'central_warehouse' THEN 100 ELSE 20 END)::numeric,
        ROUND(COALESCE(ss.default_unit_cost, 50) * 0.95, 4),
-       NOW()
+       'manual_adjust',
+       'opening_balance',
+       'E2E 開帳行 (with-stock fixture)',
+       (SELECT id FROM any_user)
 FROM locations l
 CROSS JOIN skus s
 LEFT JOIN supplier_skus ss
-       ON ss.tenant_id = s.tenant_id AND ss.sku_id = s.id
+       ON ss.tenant_id = s.tenant_id
+      AND ss.sku_id    = s.id
+      AND ss.is_preferred = TRUE
 WHERE l.tenant_id = :'tenant_id'::uuid
   AND s.tenant_id = :'tenant_id'::uuid;
 
+-- trigger apply_movement_to_balance 已自動把 stock_balances 拉起來
+-- 這裡確認一下沒漏（保險：可能某些 SKU 的 supplier_skus 全部 is_preferred=FALSE）
+
 COMMIT;
 
-\echo 'fixture with-stock seeded.'
+\echo 'fixture with-stock seeded (stock_movements + auto stock_balances).'

--- a/scripts/e2e/fixtures/with-transfers.sql
+++ b/scripts/e2e/fixtures/with-transfers.sql
@@ -1,9 +1,12 @@
 -- ============================================================
 -- fixture: with-transfers
--- 庫存調撥情境覆蓋多狀態：
---   TF-0001  draft           平鎮 → 松山
---   TF-0002  shipped         WH-HQ → 北投店倉（待店家收貨）
---   TF-0003  received        松山 → 內湖（已完成）
+-- 庫存調撥情境 + 反向情境：
+--   TF-0001  draft           平鎮 → 松山                 （正常 draft）
+--   TF-0002  shipped         WH-HQ → 北投（hq_to_store） （shipped、待收）
+--   TF-0003  received        松山 → 內湖                 （正常完成、含 movements）
+--   TF-0004  cancelled       WH-HQ → 信義（hq_to_store） R6a: 對方拒收、stock 反流 transfer_reject
+--   TF-0005  received        WH-HQ → 平鎮（hq_to_store） R6b: 出 10 收 8、運送破損 2 件
+--   TF-0006  received        WH-HQ → 松山（hq_to_store） 月結算用、近期 shipped + received
 -- ============================================================
 \set ON_ERROR_STOP on
 
@@ -13,7 +16,7 @@ WITH any_user AS (SELECT id FROM auth.users LIMIT 1)
 INSERT INTO transfers (
   tenant_id, transfer_no, source_location, dest_location,
   status, transfer_type, requested_by, shipped_at, shipped_by,
-  received_at, received_by, created_by
+  received_at, received_by, created_by, notes
 )
 SELECT :'tenant_id'::uuid,
        x.no,
@@ -22,32 +25,209 @@ SELECT :'tenant_id'::uuid,
        x.status,
        x.tf_type,
        (SELECT id FROM any_user),
-       CASE WHEN x.status IN ('shipped','received') THEN NOW() - INTERVAL '1 day' END,
-       CASE WHEN x.status IN ('shipped','received') THEN (SELECT id FROM any_user) END,
+       CASE WHEN x.status IN ('shipped','received','cancelled') THEN NOW() - INTERVAL '1 day' END,
+       CASE WHEN x.status IN ('shipped','received','cancelled') THEN (SELECT id FROM any_user) END,
        CASE WHEN x.status = 'received' THEN NOW() - INTERVAL '12 hours' END,
        CASE WHEN x.status = 'received' THEN (SELECT id FROM any_user) END,
-       (SELECT id FROM any_user)
+       (SELECT id FROM any_user),
+       x.notes
 FROM (VALUES
-  ('TF-0001', 'WH-S001', 'WH-S002', 'draft',    'store_to_store'),
-  ('TF-0002', 'WH-HQ',   'WH-S003', 'shipped',  'hq_to_store'),
-  ('TF-0003', 'WH-S002', 'WH-S004', 'received', 'store_to_store')
-) AS x(no, src, dst, status, tf_type);
+  ('TF-0001', 'WH-S001', 'WH-S002', 'draft',     'store_to_store', NULL),
+  ('TF-0002', 'WH-HQ',   'WH-S003', 'shipped',   'hq_to_store',    NULL),
+  ('TF-0003', 'WH-S002', 'WH-S004', 'received',  'store_to_store', NULL),
+  ('TF-0004', 'WH-HQ',   'WH-S005', 'cancelled', 'hq_to_store',    'R6a: 對方拒收、stock 反流'),
+  ('TF-0005', 'WH-HQ',   'WH-S001', 'received',  'hq_to_store',    'R6b: 出 10 收 8、損壞 2 件'),
+  ('TF-0006', 'WH-HQ',   'WH-S002', 'received',  'hq_to_store',    '月結算用近期 hq_to_store')
+) AS x(no, src, dst, status, tf_type, notes);
 
+-- transfer_items
 INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped, qty_received)
 SELECT t.id,
        (SELECT id FROM skus WHERE tenant_id = :'tenant_id'::uuid AND sku_code = x.sku_code),
-       x.qty_req,
-       (CASE WHEN t.status IN ('shipped','received') THEN x.qty_req ELSE 0 END),
-       (CASE WHEN t.status = 'received' THEN x.qty_req ELSE 0 END)
+       x.qty_req, x.qty_ship, x.qty_recv
 FROM transfers t
 JOIN (VALUES
-  ('TF-0001', 'SKU-001', 5),
-  ('TF-0001', 'SKU-002', 3),
-  ('TF-0002', 'SKU-001', 10),
-  ('TF-0003', 'SKU-005', 4)
-) AS x(no, sku_code, qty_req) ON t.transfer_no = x.no
+  -- (no, sku, requested, shipped, received)
+  ('TF-0001', 'SKU-001', 5,  0, 0),
+  ('TF-0001', 'SKU-002', 3,  0, 0),
+  ('TF-0002', 'SKU-001', 10, 10, 0),
+  ('TF-0003', 'SKU-005', 4,  4, 4),
+  ('TF-0004', 'SKU-007', 8,  8, 0),     -- R6a: shipped 8 後拒收
+  ('TF-0005', 'SKU-006', 10, 10, 8),    -- R6b: shipped 10 received 8 (-2 damaged)
+  ('TF-0006', 'SKU-008', 6,  6, 6)      -- 月結算用
+) AS x(no, sku_code, qty_req, qty_ship, qty_recv) ON t.transfer_no = x.no
 WHERE t.tenant_id = :'tenant_id'::uuid;
+
+-- ── stock_movements 鏈 ──────────────────────────────────
+-- TF-0002 shipped (hq_to_store): 只有 transfer_out（dest 還沒 transfer_in）
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
+     t AS (SELECT * FROM transfers WHERE tenant_id = :'tenant_id'::uuid AND transfer_no = 'TF-0002'),
+     ti AS (SELECT ti.* FROM transfer_items ti JOIN t ON ti.transfer_id = t.id),
+     mv AS (
+       INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                                    movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+                                    reason, operator_id)
+       SELECT :'tenant_id'::uuid,
+              (SELECT source_location FROM t),
+              ti.sku_id,
+              -ti.qty_shipped, 90,  -- SKU-001 cost
+              'transfer_out', 'transfer', (SELECT id FROM t), ti.id,
+              'TF-0002 shipped',
+              (SELECT id FROM any_user)
+       FROM ti
+       RETURNING id, source_doc_line_id
+     )
+UPDATE transfer_items ti SET out_movement_id = mv.id
+FROM mv WHERE ti.id = mv.source_doc_line_id;
+
+-- TF-0003 received (store_to_store): transfer_out + transfer_in
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
+     t AS (SELECT * FROM transfers WHERE tenant_id = :'tenant_id'::uuid AND transfer_no = 'TF-0003'),
+     ti AS (SELECT ti.* FROM transfer_items ti JOIN t ON ti.transfer_id = t.id)
+INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                             movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+                             reason, operator_id)
+SELECT :'tenant_id'::uuid, loc, ti.sku_id, qty, 60,  -- SKU-005 cost
+       mtype, 'transfer', (SELECT id FROM t), ti.id, lbl, (SELECT id FROM any_user)
+FROM ti
+CROSS JOIN (VALUES
+  ((SELECT source_location FROM t), -1, 'transfer_out', 'TF-0003 transfer_out'),
+  ((SELECT dest_location   FROM t),  1, 'transfer_in',  'TF-0003 transfer_in')
+) AS x(loc, sign, mtype, lbl)
+CROSS JOIN LATERAL (SELECT (CASE WHEN x.sign = -1 THEN -ti.qty_received ELSE ti.qty_received END) AS qty) q;
+
+-- TF-0004 cancelled (R6a): transfer_out shipped + transfer_reject 反流
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
+     t AS (SELECT * FROM transfers WHERE tenant_id = :'tenant_id'::uuid AND transfer_no = 'TF-0004'),
+     ti AS (SELECT ti.* FROM transfer_items ti JOIN t ON ti.transfer_id = t.id),
+     out_mv AS (
+       INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                                    movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+                                    reason, operator_id)
+       SELECT :'tenant_id'::uuid,
+              (SELECT source_location FROM t),
+              ti.sku_id, -ti.qty_shipped, 40,  -- SKU-007 cost
+              'transfer_out', 'transfer', (SELECT id FROM t), ti.id,
+              'TF-0004 shipped (將被拒收)',
+              (SELECT id FROM any_user)
+       FROM ti
+       RETURNING id, source_doc_line_id
+     )
+INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                             movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+                             reverses, reason, operator_id)
+SELECT :'tenant_id'::uuid,
+       (SELECT source_location FROM t),
+       ti.sku_id, ti.qty_shipped, 40,
+       'transfer_reject', 'transfer', (SELECT id FROM t), ti.id,
+       om.id,
+       'R6a: 對方拒收、回流',
+       (SELECT id FROM auth.users LIMIT 1)
+FROM ti, out_mv om WHERE om.source_doc_line_id = ti.id;
+
+-- TF-0005 received with damage (R6b): transfer_out 10 / transfer_in 8 / damage 2
+DO $$
+DECLARE
+  v_tenant   UUID := :'tenant_id'::uuid;
+  v_operator UUID;
+  v_t        BIGINT;
+  v_ti       BIGINT;
+  v_sku      BIGINT;
+  v_src_loc  BIGINT;
+  v_dst_loc  BIGINT;
+BEGIN
+  SELECT id INTO v_operator FROM auth.users LIMIT 1;
+  SELECT id, source_location, dest_location INTO v_t, v_src_loc, v_dst_loc
+    FROM transfers WHERE tenant_id = v_tenant AND transfer_no = 'TF-0005';
+  SELECT id, sku_id INTO v_ti, v_sku FROM transfer_items WHERE transfer_id = v_t;
+
+  -- transfer_out at HQ
+  INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                               movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+                               reason, operator_id)
+  VALUES (v_tenant, v_src_loc, v_sku, -10, 230,
+          'transfer_out', 'transfer', v_t, v_ti, 'TF-0005 ship 10', v_operator);
+
+  -- transfer_in at S001 (8 件)
+  INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                               movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+                               reason, operator_id)
+  VALUES (v_tenant, v_dst_loc, v_sku, 8, 230,
+          'transfer_in', 'transfer', v_t, v_ti, 'TF-0005 receive 8', v_operator);
+
+  -- damage 2 件記在 source（HQ）做 write-off
+  INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                               movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+                               reason, operator_id)
+  VALUES (v_tenant, v_src_loc, v_sku, -2, 230,
+          'damage', 'transfer', v_t, v_ti, 'R6b: 運送破損 2 件', v_operator);
+END $$;
+
+-- TF-0006 normal hq_to_store received（月結算用）
+DO $$
+DECLARE
+  v_tenant   UUID := :'tenant_id'::uuid;
+  v_operator UUID;
+  v_t        BIGINT;
+  v_ti       BIGINT;
+  v_sku      BIGINT;
+  v_src_loc  BIGINT;
+  v_dst_loc  BIGINT;
+BEGIN
+  SELECT id INTO v_operator FROM auth.users LIMIT 1;
+  SELECT id, source_location, dest_location INTO v_t, v_src_loc, v_dst_loc
+    FROM transfers WHERE tenant_id = v_tenant AND transfer_no = 'TF-0006';
+  SELECT id, sku_id INTO v_ti, v_sku FROM transfer_items WHERE transfer_id = v_t;
+
+  INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                               movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+                               reason, operator_id)
+  VALUES (v_tenant, v_src_loc, v_sku, -6, 75,
+          'transfer_out', 'transfer', v_t, v_ti, 'TF-0006 ship', v_operator);
+
+  INSERT INTO stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost,
+                               movement_type, source_doc_type, source_doc_id, source_doc_line_id,
+                               reason, operator_id)
+  VALUES (v_tenant, v_dst_loc, v_sku, 6, 75,
+          'transfer_in', 'transfer', v_t, v_ti, 'TF-0006 receive', v_operator);
+END $$;
+
+-- ── transfer_settlements: 給 TF-0003（store↔store 已 received）建一筆 draft ──
+-- store_a < store_b：TF-0003 src=S002 dst=S004，store_a=S002, store_b=S004
+DO $$
+DECLARE
+  v_tenant     UUID := :'tenant_id'::uuid;
+  v_month      DATE := DATE_TRUNC('month', NOW())::date;
+  v_s2         BIGINT;
+  v_s4         BIGINT;
+  v_settlement BIGINT;
+  v_tf3        BIGINT;
+  v_amount     NUMERIC;
+  v_operator   UUID;
+BEGIN
+  SELECT id INTO v_s2 FROM stores WHERE tenant_id = v_tenant AND code = 'S002';
+  SELECT id INTO v_s4 FROM stores WHERE tenant_id = v_tenant AND code = 'S004';
+  SELECT id INTO v_tf3 FROM transfers WHERE tenant_id = v_tenant AND transfer_no = 'TF-0003';
+  SELECT id INTO v_operator FROM auth.users LIMIT 1;
+  v_amount := 4 * 60;  -- 4 件 × cost 60
+
+  INSERT INTO transfer_settlements (
+    tenant_id, settlement_month, store_a_id, store_b_id,
+    a_to_b_amount, b_to_a_amount, net_amount, transfer_count,
+    status, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_month, LEAST(v_s2, v_s4), GREATEST(v_s2, v_s4),
+    v_amount, 0, v_amount, 1,
+    'draft', v_operator, v_operator
+  ) RETURNING id INTO v_settlement;
+
+  INSERT INTO transfer_settlement_items (
+    tenant_id, settlement_id, transfer_id, direction, amount, transfer_date
+  ) VALUES (
+    v_tenant, v_settlement, v_tf3, 'a_to_b', v_amount, NOW()::date
+  );
+END $$;
 
 COMMIT;
 
-\echo 'fixture with-transfers seeded.'
+\echo 'fixture with-transfers seeded (6 TFs incl. R6a R6b + 1 settlement).'

--- a/scripts/e2e/fixtures/with-wallet-history.sql
+++ b/scripts/e2e/fixtures/with-wallet-history.sql
@@ -1,0 +1,127 @@
+-- ============================================================
+-- fixture: with-wallet-history
+-- 灌 wallet_ledger 歷史，覆蓋 5 種 type：topup / spend / refund / adjust / reversal
+-- 含 R10：wallet topup 反向（reverse）情境
+--
+-- 灌完餘額：
+--   M-TEST-001  →  750  (topup 1000 - spend 300 + refund 50)
+--   M-TEST-002  → 4500  (前 base 5000 - spend 500)
+--   M-TEST-003  →  200  (topup 200 + topup 100 + reversal -100)
+--   M-TEST-INT-001 → 0  (內購不灌)
+-- ============================================================
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- M-TEST-001：topup 1000 → spend 300 → refund 50（balance 1000 → 700 → 750）
+DO $$
+DECLARE
+  v_tenant   UUID := :'tenant_id'::uuid;
+  v_member   BIGINT;
+  v_operator UUID;
+  v_topup_id BIGINT;
+  v_spend_id BIGINT;
+BEGIN
+  SELECT id INTO v_member FROM members
+   WHERE tenant_id = v_tenant AND member_no = 'M-TEST-001';
+  SELECT id INTO v_operator FROM auth.users LIMIT 1;
+
+  -- 1. topup 1000
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after, type,
+                             source_type, payment_method, reason, operator_id)
+  VALUES (v_tenant, v_member, 1000, 1000, 'topup',
+          'seed', 'cash', 'E2E: 加值 1000', v_operator)
+  RETURNING id INTO v_topup_id;
+
+  -- 2. spend 300
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after, type,
+                             source_type, reason, operator_id)
+  VALUES (v_tenant, v_member, -300, 700, 'spend',
+          'seed', 'E2E: 訂單付款 300', v_operator)
+  RETURNING id INTO v_spend_id;
+
+  -- 3. refund 50（補貼）
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after, type,
+                             source_type, reason, operator_id)
+  VALUES (v_tenant, v_member, 50, 750, 'refund',
+          'seed', 'E2E: 客訴補償 50', v_operator);
+
+  -- 同步 wallet_balances
+  UPDATE wallet_balances
+     SET balance = 750, version = 3, last_movement_at = NOW(), updated_at = NOW()
+   WHERE tenant_id = v_tenant AND member_id = v_member;
+END $$;
+
+-- M-TEST-002：base 已給 5000；加 spend 500（balance 5000 → 4500）
+DO $$
+DECLARE
+  v_tenant   UUID := :'tenant_id'::uuid;
+  v_member   BIGINT;
+  v_operator UUID;
+BEGIN
+  SELECT id INTO v_member FROM members
+   WHERE tenant_id = v_tenant AND member_no = 'M-TEST-002';
+  SELECT id INTO v_operator FROM auth.users LIMIT 1;
+
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after, type,
+                             source_type, reason, operator_id)
+  VALUES (v_tenant, v_member, -500, 4500, 'spend',
+          'seed', 'E2E: 黃金路徑 預扣 500', v_operator);
+
+  UPDATE wallet_balances
+     SET balance = 4500, version = version + 1,
+         last_movement_at = NOW(), updated_at = NOW()
+   WHERE tenant_id = v_tenant AND member_id = v_member;
+END $$;
+
+-- M-TEST-003：topup 200 → topup 100 → reverse 100（R10 反向情境）
+-- balance: 0 → 200 → 300 → 200
+DO $$
+DECLARE
+  v_tenant      UUID := :'tenant_id'::uuid;
+  v_member      BIGINT;
+  v_operator    UUID;
+  v_topup1_id   BIGINT;
+  v_topup2_id   BIGINT;  -- 待反向的 topup
+  v_reversal_id BIGINT;
+BEGIN
+  SELECT id INTO v_member FROM members
+   WHERE tenant_id = v_tenant AND member_no = 'M-TEST-003';
+  SELECT id INTO v_operator FROM auth.users LIMIT 1;
+
+  -- topup +200
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after, type,
+                             source_type, payment_method, reason, operator_id)
+  VALUES (v_tenant, v_member, 200, 200, 'topup',
+          'seed', 'cash', 'E2E: 加值 200', v_operator)
+  RETURNING id INTO v_topup1_id;
+
+  -- topup +100（誤刷、稍後反向）
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after, type,
+                             source_type, payment_method, reason, operator_id)
+  VALUES (v_tenant, v_member, 100, 300, 'topup',
+          'seed', 'credit_card', 'E2E: 誤刷 100（將反向）', v_operator)
+  RETURNING id INTO v_topup2_id;
+
+  -- reversal -100 → 反向 v_topup2
+  INSERT INTO wallet_ledger (tenant_id, member_id, change, balance_after, type,
+                             reverses, reason, operator_id)
+  VALUES (v_tenant, v_member, -100, 200, 'reversal',
+          v_topup2_id, 'E2E: 取消誤刷', v_operator)
+  RETURNING id INTO v_reversal_id;
+
+  -- 互填 reversed_by（讓查詢能反查）
+  -- wallet_ledger 是 append-only trigger 會擋；要先暫關再開
+  ALTER TABLE wallet_ledger DISABLE TRIGGER trg_no_update_wallet;
+  UPDATE wallet_ledger SET reversed_by = v_reversal_id WHERE id = v_topup2_id;
+  ALTER TABLE wallet_ledger ENABLE TRIGGER trg_no_update_wallet;
+
+  -- 同步 wallet_balances
+  UPDATE wallet_balances
+     SET balance = 200, version = 3, last_movement_at = NOW(), updated_at = NOW()
+   WHERE tenant_id = v_tenant AND member_id = v_member;
+END $$;
+
+COMMIT;
+
+\echo 'fixture with-wallet-history seeded (M001=750, M002=4500, M003=200 with R10 reversal).'


### PR DESCRIPTION
## Summary

- **Seed 強化（11 SQL files / +1042 lines）**：3 層 categories / 多供應商分配 / multi-pack sku_packs / 4 會員（含 store_internal）+ M-002 wallet 預灌 5000 / 12 反向情境內建到 fixtures（R1-R12）
- **3 新 fixture**：`with-wallet-history.sql`（R10 reversal）/ `with-picking-wave.sql`（R5 R9）/ `with-monthly-settlement.sql`（店月結算）
- **E2E 測試文件（10 docs / +1567 lines）**：`TEST-INDEX.md` 軌道入口 + 既有 31 docs triage / `TEST-E2E-master.md` 13 步黃金路徑 / 8 軌 sub-doc（T1/T2/T3/T4/T5/T6/T7/T10）含 4 維 ripple 驗證

## 反向情境覆蓋

每個都驗 **stock_movements** / **wallet_ledger** / **customer_order_items** / **store_monthly_settlements** 4 維 ripple：

| ID | 情境 | 對應軌 | Fixture |
|---|---|---|---|
| R1 | PR 取消 | T4 | with-pr-po (PR-0003) |
| R2a | PO 取消（無 GR）| T4 | with-pr-po (PO-0003) |
| R2b | PO 取消（部分 GR）| T4 | with-pr-po (PO-0004 + GR-0002) |
| R3 | GR 來貨不足 | T4 | with-pr-po (PO-0005 + GR-0003) |
| R4 | 訂單缺貨 | T3 | with-orders (ORD-0007) |
| R5 | 撿貨不足量 | T5 | with-picking-wave (WAVE-0001) |
| R6a | Transfer 拒收 | T6 | with-transfers (TF-0004) |
| R6b | 運送遺失 / 破損 | T6 | with-transfers (TF-0005) |
| R7 | 過期 write-off | T6 | rpc_register_damage |
| R8 | 客退 | T3 | with-orders (ORD-0006) |
| R9 | Wave 整單取消 | T5 | with-picking-wave (WAVE-0002) |
| R10 | Wallet topup 反向 | T3 | with-wallet-history (M-003) |
| R11a-d | 互助 offer 取消 | T6 | with-mutual-aid (AID-OFR-002/3/4) |
| R12 | 互助 received 後退單 | T6 | **RPC gap — 標記 follow-up issue** |

## 規劃文件

`C:\Users\Alex\.claude\plans\q1-c-q2-b-expressive-emerson.md` — 完整 6 階段執行計畫

## 不在這個 PR 範圍

- 實際跑 `reset.sh full-demo` + 寫 -report.md（要先決定 DB target）
- 補 `rpc_return_aid_order`（R12 RPC gap、屬後續 issue）
- LIFF / PWA push 真機測試（已排除）

## Test plan

- [ ] 確認 `scripts/e2e/.env.e2e` 設定（非 prod、`E2E_EXPECTED_HOST` 防呆已存在）
- [ ] `bash scripts/e2e/reset.sh full-demo --yes` 跑完無 SQL error
- [ ] reset 結尾 row count summary 對齊 `TEST-E2E-master.md` § Prerequisites baseline
- [ ] 抽驗：`SELECT * FROM fn_check_wallet_consistency()` 回 0 rows
- [ ] 抽驗：stock_balances.on_hand = SUM(stock_movements.quantity) for all (location, sku)
- [ ] 跑 master 黃金路徑 § 1-§ 9 + 各軌 sub-doc 的 reverse section
- [ ] 結 8 軌 + master 共 9 份 -report.md status: passed
- [ ] 回填 [TEST-INDEX.md](docs/TEST-INDEX.md) 軌道狀態 + 最近驗證日

🤖 Generated with [Claude Code](https://claude.com/claude-code)