### PR TITLE
feat(members): list 表格改版 — 未取貨金額 / 訂單數 / 加入時間 / 最後登入

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -27,6 +27,8 @@ type MemberRow = {
   tier_id: number | null;
   status: Status;
   updated_at: string;
+  joined_at: string;
+  last_visit_at: string | null;
 };
 
 /** 顯示手機，若是 LIFF auto-register 的 placeholder (line:Uxxxx) 則視為未填 */
@@ -67,7 +69,7 @@ function MembersListBody() {
 
   const [stores, setStores] = useState<Store[]>([]);
   useDefaultStoreFromUser(stores, storeId, setStoreId);
-  const [balances, setBalances] = useState<Map<number, { unpicked: number; wallet: number }>>(new Map());
+  const [balances, setBalances] = useState<Map<number, { unpicked: number; wallet: number; orderCount: number }>>(new Map());
   const [reloadTick, setReloadTick] = useState(0);
   const [modal, setModal] = useState<
     | { mode: "new" }
@@ -127,7 +129,7 @@ function MembersListBody() {
       try {
         let q = getSupabase()
           .from("members")
-          .select("id, member_no, name, phone, avatar_url, tier_id, status, updated_at", { count: "exact" })
+          .select("id, member_no, name, phone, avatar_url, tier_id, status, updated_at, joined_at, last_visit_at", { count: "exact" })
           .order(sortBy, { ascending: sortDir === "asc" })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 
@@ -153,18 +155,25 @@ function MembersListBody() {
           const [ord, wal] = await Promise.all([
             getSupabase()
               .from("customer_orders")
-              .select("id, member_id")
-              .in("member_id", ids)
-              .in("status", PENDING_STATUSES),
+              .select("id, member_id, status")
+              .in("member_id", ids),
             getSupabase().from("wallet_balances").select("member_id, balance").in("member_id", ids),
           ]);
+          // 訂單數量 不計取消/過期/轉出（視為 void）
+          const VOID_STATUSES = new Set<string>(["cancelled", "expired", "transferred_out"]);
           const orderToMember = new Map<number, number>();
-          for (const o of (ord.data ?? []) as { id: number; member_id: number }[]) {
-            orderToMember.set(o.id, o.member_id);
+          const countByMember = new Map<number, number>();
+          for (const o of (ord.data ?? []) as { id: number; member_id: number; status: string }[]) {
+            if (!VOID_STATUSES.has(o.status)) {
+              countByMember.set(o.member_id, (countByMember.get(o.member_id) ?? 0) + 1);
+            }
+            if ((PENDING_STATUSES as string[]).includes(o.status)) {
+              orderToMember.set(o.id, o.member_id);
+            }
           }
           const orderIds = Array.from(orderToMember.keys());
-          const m = new Map<number, { unpicked: number; wallet: number }>();
-          for (const id of ids) m.set(id, { unpicked: 0, wallet: 0 });
+          const m = new Map<number, { unpicked: number; wallet: number; orderCount: number }>();
+          for (const id of ids) m.set(id, { unpicked: 0, wallet: 0, orderCount: countByMember.get(id) ?? 0 });
           if (orderIds.length) {
             const items = await getSupabase()
               .from("customer_order_items")
@@ -270,16 +279,19 @@ function MembersListBody() {
           <ThSort label="編號" col="member_no" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
           <ThSort label="姓名" col="name" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
           <Th>手機</Th>
+          <Th align="right">訂單數</Th>
           <Th align="right">未取貨金額</Th>
           <Th align="right">儲值</Th>
+          <Th align="right">加入時間</Th>
+          <Th align="right">最後登入</Th>
           <ThSort label="更新" col="updated_at" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} align="right" />
           <Th>{""}</Th>
         </THead>
         <TBody>
           {rows === null ? (
-            <SkeletonRows cols={7} />
+            <SkeletonRows cols={10} />
           ) : rows.length === 0 ? (
-            <EmptyRow colSpan={7}>
+            <EmptyRow colSpan={10}>
               {total === 0 && !query ? "還沒有會員，按「新增會員」開始建立。" : "沒有符合條件的會員。"}
             </EmptyRow>
           ) : (
@@ -287,72 +299,81 @@ function MembersListBody() {
               const bal = balances.get(r.id);
               return (
                 <Tr key={r.id}>
-                    <Td className="font-mono">
-                      <SpinButton
-                        onClick={() => setModal({ mode: "detail", memberId: r.id, memberNo: r.member_no })}
-                        className={r.status === "merged" || r.status === "deleted" ? "text-zinc-400 hover:underline" : "hover:underline"}
+                  <Td className="font-mono">
+                    <SpinButton
+                      onClick={() => setModal({ mode: "detail", memberId: r.id, memberNo: r.member_no })}
+                      className={r.status === "merged" || r.status === "deleted" ? "text-zinc-400 hover:underline" : "hover:underline"}
+                    >
+                      {r.member_no}
+                    </SpinButton>
+                    {r.status === "merged" && (
+                      <span className="ml-2 rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-normal text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">已合併</span>
+                    )}
+                    {r.status === "deleted" && (
+                      <span className="ml-2 rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-normal text-red-700 dark:bg-red-950 dark:text-red-300">已刪除</span>
+                    )}
+                  </Td>
+                  <Td>
+                    <div className="flex items-center gap-2">
+                      {r.avatar_url ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={r.avatar_url} alt="" className="h-7 w-7 rounded-full object-cover" />
+                      ) : (
+                        <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-200 text-[10px] text-zinc-500 dark:bg-zinc-800">
+                          {r.name?.[0] ?? "?"}
+                        </div>
+                      )}
+                      <span>{r.name ?? "—"}</span>
+                    </div>
+                  </Td>
+                  <Td className="font-mono text-xs">{displayPhone(r.phone)}</Td>
+                  <Td align="right" className="font-mono">{bal?.orderCount ?? 0}</Td>
+                  <Td align="right" className="font-mono">{bal?.unpicked ? `$${bal.unpicked.toLocaleString()}` : "—"}</Td>
+                  <Td align="right" className="font-mono">{bal?.wallet?.toLocaleString() ?? "—"}</Td>
+                  <Td align="right" className="whitespace-nowrap text-xs text-zinc-500">
+                    {new Date(r.joined_at).toLocaleDateString("zh-TW")}
+                  </Td>
+                  <Td align="right" className="whitespace-nowrap text-xs text-zinc-500">
+                    {r.last_visit_at
+                      ? new Date(r.last_visit_at).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" })
+                      : "—"}
+                  </Td>
+                  <Td align="right" className="whitespace-nowrap text-xs text-zinc-500">
+                    {new Date(r.updated_at).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" })}
+                  </Td>
+                  <Td>
+                    <div className="flex items-center justify-end gap-3">
+                      <Link
+                        href={`/pickup?q=${encodeURIComponent(r.member_no)}`}
+                        className="text-xs text-emerald-600 hover:underline dark:text-emerald-400"
                       >
-                        {r.member_no}
+                        🔎 查訂單
+                      </Link>
+                      <SpinButton
+                        onClick={async () => {
+                          const { data } = await getSupabase()
+                            .from("members")
+                            .select("id, member_no, phone, name, gender, birthday, email, tier_id, home_store_id, status, notes")
+                            .eq("id", r.id).maybeSingle();
+                          if (data) setModal({ mode: "edit", values: {
+                            id: data.id, member_no: data.member_no,
+                            // LIFF auto-register 的 placeholder「line:<uid>」不要灌進編輯表單
+                            phone: data.phone && !data.phone.startsWith("line:") ? data.phone : "",
+                            name: data.name ?? "", gender: data.gender, birthday: data.birthday,
+                            email: data.email, tier_id: data.tier_id, home_store_id: data.home_store_id,
+                            status: data.status, notes: data.notes,
+                          }});
+                        }}
+                        className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                      >
+                        編輯
                       </SpinButton>
-                      {r.status === "merged" && (
-                        <span className="ml-2 rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-normal text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">已合併</span>
-                      )}
-                      {r.status === "deleted" && (
-                        <span className="ml-2 rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-normal text-red-700 dark:bg-red-950 dark:text-red-300">已刪除</span>
-                      )}
-                    </Td>
-                    <Td>
-                      <div className="flex items-center gap-2">
-                        {r.avatar_url ? (
-                          // eslint-disable-next-line @next/next/no-img-element
-                          <img src={r.avatar_url} alt="" className="h-7 w-7 rounded-full object-cover" />
-                        ) : (
-                          <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-200 text-[10px] text-zinc-500 dark:bg-zinc-800">
-                            {r.name?.[0] ?? "?"}
-                          </div>
-                        )}
-                        <span>{r.name ?? "—"}</span>
-                      </div>
-                    </Td>
-                    <Td className="font-mono text-xs">{displayPhone(r.phone)}</Td>
-                    <Td className="text-right font-mono">{bal?.unpicked ? `$${bal.unpicked.toLocaleString()}` : "—"}</Td>
-                    <Td className="text-right font-mono">{bal?.wallet?.toLocaleString() ?? "—"}</Td>
-                    <Td className="text-right text-zinc-500">
-                      {new Date(r.updated_at).toLocaleString("zh-TW")}
-                    </Td>
-                    <Td>
-                      <div className="flex items-center justify-end gap-3">
-                        <Link
-                          href={`/pickup?q=${encodeURIComponent(r.member_no)}`}
-                          className="text-xs text-emerald-600 hover:underline dark:text-emerald-400"
-                        >
-                          🔎 查訂單
-                        </Link>
-                        <SpinButton
-                          onClick={async () => {
-                            const { data } = await getSupabase()
-                              .from("members")
-                              .select("id, member_no, phone, name, gender, birthday, email, tier_id, home_store_id, status, notes")
-                              .eq("id", r.id).maybeSingle();
-                            if (data) setModal({ mode: "edit", values: {
-                              id: data.id, member_no: data.member_no,
-                              // LIFF auto-register 的 placeholder「line:<uid>」不要灌進編輯表單
-                              phone: data.phone && !data.phone.startsWith("line:") ? data.phone : "",
-                              name: data.name ?? "", gender: data.gender, birthday: data.birthday,
-                              email: data.email, tier_id: data.tier_id, home_store_id: data.home_store_id,
-                              status: data.status, notes: data.notes,
-                            }});
-                          }}
-                          className="text-xs text-blue-600 hover:underline dark:text-blue-400"
-                        >
-                          編輯
-                        </SpinButton>
-                      </div>
-                    </Td>
-                  </Tr>
-                );
-              })
-            )}
+                    </div>
+                  </Td>
+                </Tr>
+              );
+            })
+          )}
         </TBody>
       </Table>
 

--- a/supabase/functions/liff-session/index.ts
+++ b/supabase/functions/liff-session/index.ts
@@ -97,6 +97,11 @@ Deno.serve(async (req) => {
       });
     }
 
+    // bump members.last_visit_at（fire-and-forget，不阻塞登入；trigger 透過 GUC 跳過 updated_at）
+    if (memberId != null) {
+      void touchMemberVisit(supabaseUrl, serviceKey, memberId);
+    }
+
     // 4) 簽 JWT
     const now = Math.floor(Date.now() / 1000);
     const jwt = await signJwtHs256({
@@ -165,4 +170,23 @@ function json(body: unknown, status = 200) {
     status,
     headers: { ...corsHeaders, "Content-Type": "application/json" },
   });
+}
+
+async function touchMemberVisit(supabaseUrl: string, serviceKey: string, memberId: number) {
+  try {
+    const resp = await fetch(`${supabaseUrl}/rest/v1/rpc/rpc_member_touch_visit`, {
+      method: "POST",
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ p_member_id: memberId }),
+    });
+    if (!resp.ok) {
+      console.warn("touch_visit failed", resp.status, await resp.text());
+    }
+  } catch (e) {
+    console.warn("touch_visit error", e);
+  }
 }

--- a/supabase/functions/line-oauth-callback/index.ts
+++ b/supabase/functions/line-oauth-callback/index.ts
@@ -134,6 +134,11 @@ Deno.serve(async (req) => {
       });
     }
 
+    // bump members.last_visit_at（fire-and-forget，不阻塞登入；trigger 透過 GUC 跳過 updated_at）
+    if (memberId != null) {
+      void touchMemberVisit(supabaseUrl, serviceKey, memberId);
+    }
+
     // 6) sign session JWT（memberId 保證有值）
     const now = Math.floor(Date.now() / 1000);
     const jwt = await signJwtHs256(
@@ -212,3 +217,22 @@ Deno.serve(async (req) => {
     return redirectFront("/", { error: "oauth_failed", detail: msg });
   }
 });
+
+async function touchMemberVisit(supabaseUrl: string, serviceKey: string, memberId: number) {
+  try {
+    const resp = await fetch(`${supabaseUrl}/rest/v1/rpc/rpc_member_touch_visit`, {
+      method: "POST",
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ p_member_id: memberId }),
+    });
+    if (!resp.ok) {
+      console.warn("touch_visit failed", resp.status, await resp.text());
+    }
+  } catch (e) {
+    console.warn("touch_visit error", e);
+  }
+}

--- a/supabase/migrations/20260611000010_member_touch_visit.sql
+++ b/supabase/migrations/20260611000010_member_touch_visit.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- Member: last_visit_at touch
+-- ============================================================
+-- 目的：LIFF / OAuth login 時 bump members.last_visit_at,
+-- 但不要連帶把 updated_at 也 bump（會干擾「更新」排序語意）。
+--
+-- 做法：
+--   1. touch_updated_at() 加判斷,當 session GUC app.skip_updated_at='1' 時跳過
+--   2. 新增 rpc_member_touch_visit(p_member_id) — 先 set GUC 再 UPDATE
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF current_setting('app.skip_updated_at', true) = '1' THEN
+    RETURN NEW;
+  END IF;
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION rpc_member_touch_visit(p_member_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- transaction-local：只影響當下這次 UPDATE 的 trigger
+  PERFORM set_config('app.skip_updated_at', '1', true);
+  UPDATE members SET last_visit_at = NOW() WHERE id = p_member_id;
+END;
+$$;
+
+-- 開放 service_role / authenticated 呼叫
+GRANT EXECUTE ON FUNCTION rpc_member_touch_visit(BIGINT) TO service_role, authenticated;
+
+COMMENT ON FUNCTION rpc_member_touch_visit(BIGINT) IS
+  'LIFF / OAuth login 時 bump members.last_visit_at；不影響 updated_at（觸發器透過 GUC 跳過）。';


### PR DESCRIPTION
## Summary

會員列表頁 (`/members`) 表格改版：

- 「積分」欄位拿掉，換成 **未取貨金額** —
  PENDING_STATUSES (`pending`/`confirmed`/`shipping`/`ready`) 訂單的 `Σ qty × unit_price`
- 新增 **訂單數** — 排除 `cancelled`/`expired`/`transferred_out` 的 customer_orders 計數
- 新增 **加入時間** (`joined_at`)、**最後登入** (`last_visit_at`)
- 樣式統一：`align="right"` prop、timestamp `text-xs whitespace-nowrap` + compact `dateStyle/timeStyle`，並 reflow 舊 migration 留下的多餘 4-space 縮排

## last_visit_at 寫入鏈

`members.last_visit_at` 過去從沒被寫過。本 PR 補上：

- `migration 20260611000010_member_touch_visit.sql`
  - `touch_updated_at()` 加 GUC `app.skip_updated_at` 判斷（3 表共用此 trigger，但只會在新 RPC 設了 GUC 時才略過）
  - 新 RPC `rpc_member_touch_visit(p_member_id)` — 設 GUC 後 UPDATE，避免連帶把 `updated_at` 也 bump 掉
- `liff-session` edge function：每次 LIFF init 確定 memberId 後 fire-and-forget call RPC
- `line-oauth-callback` edge function：PWA standalone OAuth 一樣處理

## Test plan

- [ ] `/members` 表頭看到 10 欄：編號 / 姓名 / 手機 / 訂單數 / 未取貨金額 / 儲值 / 加入時間 / 最後登入 / 更新 / 動作
- [ ] 「未取貨金額」格式 `$1,234`，無資料 `—`
- [ ] 「訂單數」是 lifetime 計數（含已完成、不含取消/過期/轉出）
- [ ] migration 跑完之前 / 還沒 LIFF 登入過的會員，「最後登入」顯示 `—`
- [ ] migration + edge function 部署後，LIFF 開站／OAuth 登入會 bump `last_visit_at`，但「更新」欄不會被連帶 bump
- [ ] 樣式跟 `/products`、`/campaigns`、`/restock` 一致

https://claude.ai/code/session_01Ubw1JCAyog6BAr1Q6kxX43

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ubw1JCAyog6BAr1Q6kxX43)_