### PR TITLE
fix(ui): DataTable 加白底,跟其他手刻 table 視覺一致

### DIFF
--- a/apps/admin/src/components/DataTable.tsx
+++ b/apps/admin/src/components/DataTable.tsx
@@ -12,7 +12,7 @@ function alignCls(align: Align | undefined) {
 
 export function Table({ children, className = "" }: { children: ReactNode; className?: string }) {
   return (
-    <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+    <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
       <table className={`min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800 ${className}`}>
         {children}
       </table>


### PR DESCRIPTION
## Summary
- page background 是 `#efeeeb` 暖灰(`apps/admin/src/app/globals.css:6`),共用 `<Table>` 元件 wrapper 沒設背景,table body 透出灰底
- WMS / purchase / hq inbox 等頁的 table 是手刻 wrapper 帶 `bg-white`,看起來像白卡片,造成兩種 table 視覺不一致
- 在 `apps/admin/src/components/DataTable.tsx:15` 的 `Table` wrapper 加上 `bg-white dark:bg-zinc-900`,一處改、5 支頁面同步生效:members / products / suppliers / restock / campaigns

## Test plan
- [ ] `pnpm dev` 起 admin,逐一打開 `/members`、`/products`、`/suppliers`、`/restock`、`/campaigns`,確認 table 底色變白、跟 `/wms/picking`、`/purchase/orders` 等一致
- [ ] dark mode 切換,確認 table 底色變 `zinc-900`(原本透出 body dark `#18181b` 也是深色,視覺差異本來就小,但也驗一下)
- [ ] hover row 仍然是 `zinc-50` 變灰(`Tr` 的 hover class 沒動)

https://claude.ai/code/session_01S4EJduiDjDXavpN4FZrkzu

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4EJduiDjDXavpN4FZrkzu)_