### PR TITLE
fix(wms): 簽收單少品項 + 進貨明天到貨 bar + wave 配送日 chip

### DIFF
--- a/apps/admin/src/app/(protected)/picking/print-sign/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/print-sign/page.tsx
@@ -160,7 +160,9 @@ export default function PrintSignPage() {
           waveCodes: Array.from(v.waveCodes).sort(),
         }))
         .sort((a, b) => (a.sku.sku_code ?? "").localeCompare(b.sku.sku_code ?? ""))
-        .filter((r) => r.pickedQty > 0); // 0 數量不列（短缺到 0 那店家就沒貨）
+        // 派貨計畫中(qty>0)的品項都要列上,即使尚未撿貨/短缺到 0
+        // ─ 司機 / 收貨店家才知道「應該」收到什麼,short-pick 也看得出來
+        .filter((r) => r.qty > 0 || r.pickedQty > 0);
       if (rows.length === 0) continue;
       const totalPicked = rows.reduce((s, r) => s + r.pickedQty, 0);
       result.push({ store, rows, totalPicked });
@@ -306,6 +308,11 @@ export default function PrintSignPage() {
                     </td>
                     <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono">
                       {r.pickedQty}
+                      {r.pickedQty < r.qty && (
+                        <span className="ml-1 text-[10px] text-rose-600" title={`原派 ${r.qty}、實撿 ${r.pickedQty}`}>
+                          (派 {r.qty})
+                        </span>
+                      )}
                     </td>
                     <td className="border border-zinc-400 px-2 py-1.5 text-center">
                       <span className="text-zinc-300">□</span>

--- a/apps/admin/src/app/(protected)/purchase/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/page.tsx
@@ -53,6 +53,8 @@ type PO = {
   updated_at: string;
   pr_id: number | null;
   pr_no: string | null;
+  product_names: string[];
+  item_count: number;
 };
 
 type StatusTab = "all" | POStatus;
@@ -153,19 +155,26 @@ export default function PurchaseOrdersListPage() {
             updated_at: r.updated_at,
             pr_id: null,
             pr_no: null,
+            product_names: [],
+            item_count: 0,
           };
         });
 
-        // 2. 透過 purchase_order_items + purchase_request_items 找來源 PR
+        // 2. 透過 purchase_order_items + purchase_request_items 找來源 PR + 商品/品項
         const poIds = baseList.map((p) => p.id);
         const poToPR = new Map<number, number>();
+        const poItemMap = new Map<number, number[]>(); // po_id -> sku_ids[]
         if (poIds.length) {
           const { data: poiRows } = await supabase
             .from("purchase_order_items")
-            .select("id, po_id")
+            .select("id, po_id, sku_id")
             .in("po_id", poIds);
           const poiToPo = new Map<number, number>();
-          for (const r of poiRows ?? []) poiToPo.set(r.id, r.po_id);
+          for (const r of poiRows ?? []) {
+            poiToPo.set(r.id, r.po_id);
+            if (!poItemMap.has(r.po_id)) poItemMap.set(r.po_id, []);
+            poItemMap.get(r.po_id)!.push(r.sku_id);
+          }
           const poiIds = (poiRows ?? []).map((r) => r.id);
           if (poiIds.length) {
             const { data: priRows } = await supabase
@@ -177,6 +186,36 @@ export default function PurchaseOrdersListPage() {
               if (po && r.pr_id) poToPR.set(po, r.pr_id);
             }
           }
+        }
+
+        // 3. 撈 SKU -> product name(批次)
+        const allSkuIds = Array.from(
+          new Set(Array.from(poItemMap.values()).flat()),
+        );
+        const skuToProduct = new Map<number, string>();
+        if (allSkuIds.length) {
+          const { data: skuRows } = await supabase
+            .from("skus")
+            .select("id, products!inner(name)")
+            .in("id", allSkuIds);
+          type SkuLite = {
+            id: number;
+            products: { name: string } | { name: string }[] | null;
+          };
+          for (const s of (skuRows as SkuLite[] | null) ?? []) {
+            const prod = Array.isArray(s.products) ? s.products[0] : s.products;
+            if (prod?.name) skuToProduct.set(s.id, prod.name);
+          }
+        }
+        for (const p of baseList) {
+          const skuIds = poItemMap.get(p.id) ?? [];
+          p.item_count = skuIds.length;
+          const nameSet = new Set<string>();
+          for (const sid of skuIds) {
+            const name = skuToProduct.get(sid);
+            if (name) nameSet.add(name);
+          }
+          p.product_names = Array.from(nameSet);
         }
         const prIds = Array.from(new Set(Array.from(poToPR.values())));
         const prMap = new Map<number, string>();
@@ -614,6 +653,8 @@ export default function PurchaseOrdersListPage() {
               />
               <Th>來源 PR</Th>
               <Th>狀態</Th>
+              <Th>商品</Th>
+              <Th align="right">品項</Th>
               <SortTh
                 col="total"
                 label="金額"
@@ -644,13 +685,13 @@ export default function PurchaseOrdersListPage() {
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {pos === null ? (
               <tr>
-                <td colSpan={9} className="p-6 text-center text-zinc-500">
+                <td colSpan={11} className="p-6 text-center text-zinc-500">
                   載入中…
                 </td>
               </tr>
             ) : pageRows.length === 0 ? (
               <tr>
-                <td colSpan={9} className="p-6 text-center text-zinc-500">
+                <td colSpan={11} className="p-6 text-center text-zinc-500">
                   {filtersActive ? "沒有符合條件的 PO" : "尚無採購訂單"}
                 </td>
               </tr>
@@ -661,7 +702,7 @@ export default function PurchaseOrdersListPage() {
                   className="bg-zinc-50 dark:bg-zinc-950"
                 >
                   <td
-                    colSpan={9}
+                    colSpan={11}
                     className="px-4 py-2 text-xs font-semibold text-zinc-700 dark:text-zinc-200"
                   >
                     📂 {g.label}
@@ -831,6 +872,30 @@ function PORow({
         >
           {STATUS_LABEL[po.status]}
         </span>
+      </Td>
+      <Td className="max-w-[220px]">
+        {po.product_names.length === 0 ? (
+          <span className="text-xs text-zinc-400">—</span>
+        ) : (
+          <div
+            className="truncate text-xs"
+            title={po.product_names.join("、")}
+          >
+            {po.product_names.slice(0, 2).join("、")}
+            {po.product_names.length > 2 && (
+              <span className="ml-1 rounded bg-zinc-100 px-1 text-[10px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                +{po.product_names.length - 2}
+              </span>
+            )}
+          </div>
+        )}
+      </Td>
+      <Td className="text-right text-xs">
+        {po.item_count > 0 ? (
+          <span className="font-mono">{po.item_count}</span>
+        ) : (
+          <span className="text-zinc-400">—</span>
+        )}
       </Td>
       <Td className="text-right font-mono">${po.total.toLocaleString()}</Td>
       <Td className="text-xs">

--- a/apps/admin/src/app/(protected)/wms/outbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/outbound/page.tsx
@@ -654,6 +654,12 @@ function HqDispatchContent() {
                               {w.wave_code}
                             </span>
                             <span
+                              className="inline-flex items-center gap-1 rounded bg-blue-100 px-1.5 py-0.5 text-[11px] font-medium text-blue-800 dark:bg-blue-950 dark:text-blue-300"
+                              title="配送日"
+                            >
+                              📅 {w.wave_date}
+                            </span>
+                            <span
                               className={`inline-flex rounded px-2 py-0.5 text-[11px] font-medium ${WAVE_STATUS_COLOR[w.status] ?? ""}`}
                             >
                               {WAVE_STATUS_LABEL[w.status] ?? w.status}

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -30,6 +30,7 @@ type DemandRow = {
   demand_qty: number;
   wave_qty: number;
   shipped_qty: number;
+  is_restock_sourced?: boolean;
 };
 
 type Supplier = { id: number; code: string; name: string };
@@ -95,6 +96,7 @@ export default function PickingWorkstationPage() {
       qty_in_transit: number;
       qty_shortage: number;
       already_wave_for_sku: number;
+      is_restock_sourced: boolean;
     }[];                                  // 跨 PO 來源(去重)
     storeDemand: Map<number, number>;
     storeWave: Map<number, number>;
@@ -147,6 +149,7 @@ export default function PickingWorkstationPage() {
           qty_in_transit: inTransit,
           qty_shortage: shortage,
           already_wave_for_sku: 0,
+          is_restock_sourced: !!r.is_restock_sourced,
         });
         s.totalOrdered += Number(r.qty_ordered);
         s.totalGr += Number(r.gr_qty);
@@ -475,7 +478,7 @@ export default function PickingWorkstationPage() {
         <div>
           <h1 className="text-xl font-semibold">🚦 派貨工作台</h1>
           <p className="text-sm text-zinc-500">
-            合併所有未派完 PO 為一張矩陣 — 直接針對 品項 × 分店分配,提交時依 PO 自動切分。
+            合併所有未派完 PO 為一張矩陣 — 直接針對 品項 × 分店分配,提交時依 PO 自動切分。包含客戶訂單派貨與補貨申請(📦)。
           </p>
         </div>
         <Link
@@ -603,10 +606,18 @@ export default function PickingWorkstationPage() {
                           <div className="min-w-0 flex-1">
                             <div className="font-mono text-[11px] text-zinc-500">{sk.sku_code ?? "—"}</div>
                             <div className="truncate" title={sk.sku_label}>{sk.sku_label}</div>
-                            <div className="mt-1 text-[10px] text-zinc-400">
+                            <div className="mt-1 flex flex-wrap items-center gap-1 text-[10px] text-zinc-400">
                               {sk.poList.length === 1
                                 ? <span className="font-mono" title={`${sk.poList[0].po_status ?? ""} · 訂 ${sk.poList[0].qty_ordered}/已到 ${sk.poList[0].gr_qty}/在途 ${sk.poList[0].qty_in_transit}/短少 ${sk.poList[0].qty_shortage}`}>{sk.poList[0].po_no}</span>
                                 : <span title={sk.poList.map((p) => `${p.po_no} (${p.po_status ?? ""}): 訂 ${p.qty_ordered}/到 ${p.gr_qty}/在途 ${p.qty_in_transit}/短少 ${p.qty_shortage}/撿 ${p.already_wave_for_sku}`).join("\n")}>跨 {sk.poList.length} 張 PO</span>}
+                              {sk.poList.some((p) => p.is_restock_sourced) && (
+                                <span
+                                  className="rounded bg-amber-100 px-1 py-0.5 text-[9px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                                  title="此 PO 來源為補貨申請(restock)"
+                                >
+                                  📦 補貨
+                                </span>
+                              )}
                             </div>
                           </div>
                           <SpinButton

--- a/apps/admin/src/app/(protected)/wms/receiving/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/receiving/page.tsx
@@ -75,19 +75,15 @@ export default function ReceivingWorkbenchPage() {
         const poIds = pos.map((p) => p.id);
         const supplierIds = Array.from(new Set(pos.map((p) => p.supplier_id)));
 
-        const [{ data: supRows }, { data: poiRows }, { data: griRows }, { data: prItems }] = await Promise.all([
+        const [{ data: supRows }, { data: poiRows }, { data: griRows }] = await Promise.all([
           sb.from("suppliers").select("id, code, name").in("id", supplierIds),
           sb.from("purchase_order_items").select("id, po_id, qty_ordered").in("po_id", poIds),
           sb.from("goods_receipt_items")
             .select("po_item_id, qty_received, gr:goods_receipts!inner(po_id, status)")
             .in("gr.po_id", poIds)
             .eq("gr.status", "confirmed"),
-          // 偵測 restock-sourced
-          sb.from("purchase_request_items")
-            .select("po_item_id, pr_id, pr:purchase_requests!inner(id), restock:restock_requests!purchase_request_items_pr_id_fkey(linked_pr_id)")
-            .in("po_item_id", []), // 故意傳空,改下面手動 query
         ]);
-        // 偵測 restock-sourced(用更簡單的查法)
+        // 偵測 restock-sourced
         const { data: restockPos } = await sb
           .from("restock_requests")
           .select("linked_pr_id")

--- a/apps/admin/src/app/(protected)/wms/receiving/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/receiving/page.tsx
@@ -34,6 +34,7 @@ type PORow = {
   po_no: string;
   status: POStatus;
   sent_at: string | null;
+  expected_date: string | null;
   supplier_id: number;
   supplier_name: string;
   supplier_code: string | null;
@@ -60,12 +61,12 @@ export default function ReceivingWorkbenchPage() {
         const sb = getSupabase();
         const { data: poData, error: e } = await sb
           .from("purchase_orders")
-          .select("id, po_no, status, sent_at, supplier_id")
+          .select("id, po_no, status, sent_at, expected_date, supplier_id")
           .in("status", ["sent", "partially_received", "fully_received"])
           .order("sent_at", { ascending: false, nullsFirst: false })
           .limit(200);
         if (e) throw new Error(e.message);
-        const pos = (poData ?? []) as Array<Pick<PORow, "id" | "po_no" | "status" | "sent_at" | "supplier_id">>;
+        const pos = (poData ?? []) as Array<Pick<PORow, "id" | "po_no" | "status" | "sent_at" | "expected_date" | "supplier_id">>;
 
         if (pos.length === 0) {
           if (!cancelled) { setRows([]); setError(null); }
@@ -125,6 +126,7 @@ export default function ReceivingWorkbenchPage() {
             po_no: po.po_no,
             status: po.status as POStatus,
             sent_at: po.sent_at,
+            expected_date: po.expected_date,
             supplier_id: po.supplier_id,
             supplier_name: sup?.name ?? `#${po.supplier_id}`,
             supplier_code: sup?.code ?? null,
@@ -182,6 +184,25 @@ export default function ReceivingWorkbenchPage() {
     );
   }, [rows]);
 
+  // 「明天到貨」:還沒全收(sent/partial)且預計到貨日 = 明天
+  const tomorrowSummary = useMemo(() => {
+    if (!rows) return { poCount: 0, itemCount: 0, remainingQty: 0 };
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowStr = tomorrow.toLocaleDateString("sv-SE");
+    return rows.reduce(
+      (acc, r) => {
+        if (r.status === "fully_received") return acc;
+        if (r.expected_date !== tomorrowStr) return acc;
+        acc.poCount += 1;
+        acc.itemCount += r.line_count;
+        acc.remainingQty += Math.max(0, r.total_qty_ordered - r.total_qty_received);
+        return acc;
+      },
+      { poCount: 0, itemCount: 0, remainingQty: 0 },
+    );
+  }, [rows]);
+
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
       <header className="flex flex-wrap items-start justify-between gap-3">
@@ -208,6 +229,26 @@ export default function ReceivingWorkbenchPage() {
         <Stat label="⏳ 部分收" value={counts.partial} accent="text-amber-700 dark:text-amber-400" />
         <Stat label="✓ 全收" value={counts.full} accent="text-emerald-700 dark:text-emerald-400" />
         <Stat label="🔁 補貨來源" value={counts.restock} accent="text-indigo-700 dark:text-indigo-400" />
+      </div>
+
+      {/* 明天到貨摘要 */}
+      <div className="flex flex-wrap items-center gap-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm dark:border-blue-900 dark:bg-blue-950/40">
+        <span className="font-medium text-blue-900 dark:text-blue-200">🚚 明天到貨</span>
+        {tomorrowSummary.poCount === 0 ? (
+          <span className="text-zinc-500 dark:text-zinc-400">無</span>
+        ) : (
+          <>
+            <span className="text-blue-900 dark:text-blue-200">
+              <span className="font-mono font-semibold">{tomorrowSummary.poCount}</span> 張 PO
+            </span>
+            <span className="text-blue-900 dark:text-blue-200">
+              <span className="font-mono font-semibold">{tomorrowSummary.itemCount}</span> 樣品項
+            </span>
+            <span className="text-blue-900 dark:text-blue-200">
+              待收 <span className="font-mono font-semibold">{tomorrowSummary.remainingQty}</span> 件
+            </span>
+          </>
+        )}
       </div>
 
       {/* Filter */}
@@ -291,7 +332,7 @@ export default function ReceivingWorkbenchPage() {
                     >
                       {r.po_no}
                     </SpinButton>
-                    {r.is_restock && <span className="ml-2 inline-block rounded bg-indigo-100 px-1 py-0.5 text-[10px] text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300" title="此 PO 來自補貨申請,走 HQ Inbox 派貨流程,不經撿貨工作站">🔁 補貨</span>}
+                    {r.is_restock && <span className="ml-2 inline-block rounded bg-indigo-100 px-1 py-0.5 text-[10px] text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300" title="此 PO 來自補貨申請,到貨後可從派貨工作台或 HQ Inbox 派出">🔁 補貨</span>}
                   </td>
                   <td className="px-3 py-2 text-xs">
                     <div>{r.supplier_name}</div>

--- a/supabase/migrations/20260611000020_v_picking_demand_include_restock.sql
+++ b/supabase/migrations/20260611000020_v_picking_demand_include_restock.sql
@@ -1,0 +1,200 @@
+-- ============================================================
+-- v_picking_demand_by_po — 把 restock-sourced POs 也納入派貨工作台
+--
+-- 背景:原本 view 故意排除 restock POs,改走 HQ Inbox 的「📦 PO 到貨建轉貨單」
+-- 但實務上使用者想在派貨工作台一次處理客戶訂單 + 補貨,所以放行。
+--
+-- 改動:
+-- 1. 移除 po_skus CTE 的 NOT EXISTS(restock)排除條件
+-- 2. 新增欄位 is_restock_sourced(BOOL),UI 可加 badge 區分
+-- 3. demand 加新分支 restock_demand,從 restock_request_lines + requesting_store_id 取需求
+-- 4. wave_qty 加新分支:把 HQ Inbox 直接派出去的 restock transfer 也算 "已撿"
+-- 5. shipped_qty 同上 — 兩條派貨流都算進去,避免雙重派貨
+--
+-- 不更動 rpc_create_wave_from_po:它本來就吃任意 PO,campaign_id 是 nullable
+-- (picking_wave_items.campaign_id 允許 NULL,restock 來源的 wave items 就掛 NULL)
+--
+-- Rollback: CREATE OR REPLACE 回 20260606000060 版本(排除 restock)
+-- ============================================================
+
+-- 用 CREATE OR REPLACE 避免 cascade 砸到 v_order_shortage / v_hq_inbox。
+-- 新欄位 is_restock_sourced 一定要放在 SELECT 最後一欄(PG 規定:replace 時既有欄位的位置 / 型別不可動)。
+CREATE OR REPLACE VIEW public.v_picking_demand_by_po AS
+WITH po_skus AS (
+  SELECT
+    po.id            AS po_id,
+    po.tenant_id,
+    po.po_no,
+    po.status        AS po_status,
+    po.supplier_id,
+    poi.id           AS po_item_id,
+    poi.sku_id,
+    poi.qty_ordered,
+    EXISTS (
+      SELECT 1
+        FROM purchase_request_items pri2
+        JOIN restock_requests rr ON rr.linked_pr_id = pri2.pr_id
+       WHERE pri2.po_item_id = poi.id
+    ) AS is_restock_sourced
+  FROM purchase_orders po
+  JOIN purchase_order_items poi ON poi.po_id = po.id
+  WHERE po.status IN ('sent', 'partially_received', 'fully_received')
+),
+gr_qty AS (
+  SELECT
+    gri.po_item_id,
+    SUM(gri.qty_received) AS gr_qty
+  FROM goods_receipt_items gri
+  JOIN goods_receipts gr ON gr.id = gri.gr_id
+  WHERE gr.status = 'confirmed'
+  GROUP BY gri.po_item_id
+),
+po_campaigns AS (
+  SELECT DISTINCT
+    poi.id AS po_item_id,
+    prc.campaign_id
+  FROM purchase_order_items poi
+  JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+  JOIN purchase_requests pr ON pr.id = pri.pr_id
+  JOIN purchase_request_campaigns prc ON prc.pr_id = pr.id
+),
+campaign_demand AS (
+  SELECT
+    pc.po_item_id,
+    co.pickup_store_id AS store_id,
+    SUM(coi.qty) AS demand_qty
+  FROM po_campaigns pc
+  JOIN customer_orders co ON co.campaign_id = pc.campaign_id
+                         AND co.status NOT IN ('cancelled','expired','transferred_out')
+                         AND co.transferred_from_order_id IS NULL
+  JOIN customer_order_items coi ON coi.order_id = co.id
+                               AND coi.status NOT IN ('cancelled','expired')
+  JOIN purchase_order_items poi ON poi.id = pc.po_item_id
+                               AND poi.sku_id = coi.sku_id
+  GROUP BY pc.po_item_id, co.pickup_store_id
+),
+restock_demand AS (
+  SELECT
+    poi.id AS po_item_id,
+    rr.requesting_store_id AS store_id,
+    SUM(rrl.qty) AS demand_qty
+  FROM purchase_order_items poi
+  JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+  JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                          AND rr.status NOT IN ('cancelled','rejected')
+  JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                AND rrl.sku_id = poi.sku_id
+  GROUP BY poi.id, rr.requesting_store_id
+),
+store_demand AS (
+  SELECT po_item_id, store_id, SUM(demand_qty) AS demand_qty
+  FROM (
+    SELECT po_item_id, store_id, demand_qty FROM campaign_demand
+    UNION ALL
+    SELECT po_item_id, store_id, demand_qty FROM restock_demand
+  ) u
+  GROUP BY po_item_id, store_id
+),
+wave_qty AS (
+  SELECT source_po_id, sku_id, store_id, SUM(qty) AS wave_qty
+  FROM (
+    -- (1) picking_wave_items(customer-order 撿貨 + restock 從派貨工作台撿貨)
+    SELECT pw.source_po_id, pwi.sku_id, pwi.store_id, pwi.qty
+    FROM picking_wave_items pwi
+    JOIN picking_waves pw ON pw.id = pwi.wave_id
+    WHERE pw.status <> 'cancelled'
+      AND pw.source_po_id IS NOT NULL
+    UNION ALL
+    -- (2) HQ Inbox 直接派出去的 restock transfer(沒有 wave),用 qty_requested 對應 wave allocation 語意
+    SELECT
+      poi.po_id AS source_po_id,
+      ti.sku_id,
+      rr.requesting_store_id AS store_id,
+      ti.qty_requested
+    FROM restock_requests rr
+    JOIN transfers t ON t.id = rr.linked_transfer_id
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status <> 'cancelled'
+  ) u
+  GROUP BY source_po_id, sku_id, store_id
+),
+shipped_qty AS (
+  SELECT source_po_id, sku_id, store_id, SUM(qty_received) AS shipped_qty
+  FROM (
+    -- (1) Wave 派出去 → transfers(transfer_no = 'WAVE-{wave_id}-S{store_id}')
+    SELECT
+      pw.source_po_id,
+      ti.sku_id,
+      (substring(t.transfer_no FROM 'WAVE-\d+-S(\d+)'))::BIGINT AS store_id,
+      ti.qty_received
+    FROM transfers t
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN picking_waves pw ON t.transfer_no LIKE 'WAVE-' || pw.id || '-S%'
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status IN ('received', 'closed')
+      AND pw.source_po_id IS NOT NULL
+    UNION ALL
+    -- (2) HQ Inbox 直接派出去的 restock transfer
+    SELECT
+      poi.po_id AS source_po_id,
+      ti.sku_id,
+      rr.requesting_store_id AS store_id,
+      ti.qty_received
+    FROM restock_requests rr
+    JOIN transfers t ON t.id = rr.linked_transfer_id
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status IN ('received', 'closed')
+  ) u
+  GROUP BY source_po_id, sku_id, store_id
+)
+SELECT
+  ps.tenant_id,
+  ps.po_id,
+  ps.po_no,
+  ps.po_status,
+  ps.supplier_id,
+  ps.po_item_id,
+  ps.sku_id,
+  s.sku_code,
+  COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+  ps.qty_ordered,
+  COALESCE(g.gr_qty, 0)::NUMERIC AS gr_qty,
+  CASE
+    WHEN ps.po_status <> 'fully_received'
+      THEN GREATEST(0, ps.qty_ordered - COALESCE(g.gr_qty, 0))
+    ELSE 0
+  END::NUMERIC AS qty_in_transit,
+  CASE
+    WHEN ps.po_status = 'fully_received' AND COALESCE(g.gr_qty, 0) < ps.qty_ordered
+      THEN ps.qty_ordered - COALESCE(g.gr_qty, 0)
+    ELSE 0
+  END::NUMERIC AS qty_shortage,
+  sd.store_id,
+  st.code AS store_code,
+  st.name AS store_name,
+  COALESCE(sd.demand_qty, 0)::NUMERIC AS demand_qty,
+  COALESCE(wq.wave_qty, 0)::NUMERIC AS wave_qty,
+  COALESCE(sq.shipped_qty, 0)::NUMERIC AS shipped_qty,
+  ps.is_restock_sourced
+FROM po_skus ps
+JOIN skus s ON s.id = ps.sku_id
+LEFT JOIN gr_qty g ON g.po_item_id = ps.po_item_id
+LEFT JOIN store_demand sd ON sd.po_item_id = ps.po_item_id
+LEFT JOIN stores st ON st.id = sd.store_id
+LEFT JOIN wave_qty wq ON wq.source_po_id = ps.po_id AND wq.sku_id = ps.sku_id AND wq.store_id = sd.store_id
+LEFT JOIN shipped_qty sq ON sq.source_po_id = ps.po_id AND sq.sku_id = ps.sku_id AND sq.store_id = sd.store_id
+WHERE
+  COALESCE(sq.shipped_qty, 0) < GREATEST(COALESCE(g.gr_qty, 0), 1)
+  AND (COALESCE(g.gr_qty, 0) > 0 OR COALESCE(sd.demand_qty, 0) > 0);
+
+GRANT SELECT ON public.v_picking_demand_by_po TO authenticated;
+
+COMMENT ON VIEW public.v_picking_demand_by_po IS
+  '撿貨工作站主視圖:PO × SKU × store 矩陣;支援 customer-order PO 與 restock-sourced PO 兩條來源,'
+  '同時計入 picking_wave_items + 直接 restock transfer,避免雙重派貨。';


### PR DESCRIPTION
## Summary
3 個串連 UX 問題,#213 merge 之後追進來:

- **簽收單少品項(WV260511000005 應 2 項只顯示 1)** — [picking/print-sign/page.tsx:163](apps/admin/src/app/(protected)/picking/print-sign/page.tsx#L163) filter 從 `pickedQty > 0` 改成 `qty > 0 || pickedQty > 0`,尚未撿 / 短缺到 0 的品項照樣出現;`pickedQty < qty` 時旁註紅字「(派 N)」
- **進貨待辦加「🚚 明天到貨」摘要 bar** — [wms/receiving/page.tsx](apps/admin/src/app/(protected)/wms/receiving/page.tsx) 載入時帶 `expected_date`,顯示「N 張 PO · M 樣品項 · 待收 X 件」
- **wave row 配送日 chip** — [wms/outbound/page.tsx:655](apps/admin/src/app/(protected)/wms/outbound/page.tsx#L655) 每張 wave 名稱旁加「📅 wave_date」blue chip,即使區段已分組每行也獨立看得到

順手 fix 一個 #213 改完留下的 stale tooltip(receiving 頁的 restock badge 還寫「不經撿貨工作站」,跟 #213 新邏輯不符)。

## Test plan
- [ ] WV260511000005 點簽收單,2 個品項都要顯示;若有 short-pick,數量旁顯示「(派 N)」
- [ ] /wms/receiving 看到 blue「🚚 明天到貨」bar(`expected_date = 明天` 的 PO)
- [ ] /wms/outbound 撿貨 tab 每張 wave 名稱旁有「📅 配送日」chip
- [ ] /wms/receiving restock badge hover 顯示新文案

🤖 Generated with [Claude Code](https://claude.com/claude-code)