### PR TITLE
feat: 樂樂顧客 CSV 匯入 + 員工權限管理 v1

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -17,9 +17,11 @@
     "@tiptap/pm": "^3.22.5",
     "@tiptap/react": "^3.22.5",
     "@tiptap/starter-kit": "^3.22.5",
+    "@types/papaparse": "^5.5.2",
     "date-fns": "^4.1.0",
     "isomorphic-dompurify": "^3.11.0",
     "next": "16.2.4",
+    "papaparse": "^5.5.3",
     "react": "19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4"

--- a/apps/admin/src/app/(protected)/members/import/page.tsx
+++ b/apps/admin/src/app/(protected)/members/import/page.tsx
@@ -27,6 +27,7 @@ type StagedRow = {
   parsed_home_store_id: number | null;
   parsed_joined_at: string | null;
   parsed_last_visit_at: string | null;
+  parsed_wallet_balance: number | string | null;
   validation_status: ValidationStatus;
   validation_errors: { field: string; code: string; value?: string }[];
   resolved_member_id: number | null;
@@ -40,9 +41,11 @@ type StageStats = {
   errors: number;
 };
 
-type Phase = "pristine" | "parsed" | "staged" | "committed";
+type Phase = "pristine" | "parsed" | "staging" | "staged" | "committing" | "committed";
 
 const PREVIEW_LIMIT = 50;
+const STAGE_CHUNK = 500;
+const COMMIT_CHUNK = 500;
 
 function statusChip(s: ValidationStatus) {
   const map: Record<ValidationStatus, { label: string; cls: string }> = {
@@ -71,6 +74,7 @@ export default function MemberImportPage() {
   const [error, setError] = useState<string | null>(null);
   const [commitResult, setCommitResult] = useState<{ committed: number; skipped: number } | null>(null);
   const [confirmCommit, setConfirmCommit] = useState(false);
+  const [progress, setProgress] = useState<{ done: number; total: number; label: string } | null>(null);
 
   const onPickFile = useCallback(async (f: File | null) => {
     setError(null);
@@ -95,29 +99,52 @@ export default function MemberImportPage() {
   const handleStage = useCallback(async () => {
     if (!parsedRows.length) return;
     setError(null);
+    setPhase("staging");
     const bid = (typeof crypto !== "undefined" && "randomUUID" in crypto)
       ? crypto.randomUUID()
       : `b_${Date.now()}_${Math.random().toString(36).slice(2)}`;
 
-    const payload = parsedRows.map((r) => ({
-      external_id: r.external_id,
-      name_raw: r.name_raw,
-      label: r.label,
-      joined_at: r.joined_at,
-      last_visit_at: r.last_visit_at,
-    }));
+    const sb = getSupabase();
+    const agg: StageStats = {
+      total: 0, ok: 0,
+      duplicate_in_batch: 0, duplicate_existing: 0, errors: 0,
+    };
+    setProgress({ done: 0, total: parsedRows.length, label: "上傳中" });
 
-    const { data, error: err } = await getSupabase().rpc("rpc_stage_member_import", {
-      p_batch_id: bid,
-      p_source: "lele",
-      p_rows: payload,
-    });
-    if (err) {
-      setError(err.message);
-      return;
+    for (let i = 0; i < parsedRows.length; i += STAGE_CHUNK) {
+      const chunk = parsedRows.slice(i, i + STAGE_CHUNK);
+      const payload = chunk.map((r) => ({
+        external_id: r.external_id,
+        name_raw: r.name_raw,
+        label: r.label,
+        joined_at: r.joined_at,
+        last_visit_at: r.last_visit_at,
+        wallet_balance: r.wallet_balance,
+      }));
+      const { data, error: err } = await sb.rpc("rpc_stage_member_import", {
+        p_batch_id: bid,
+        p_source: "lele",
+        p_rows: payload,
+        p_row_offset: i,
+      });
+      if (err) {
+        setError(`第 ${i + 1}~${i + chunk.length} 筆上傳失敗：${err.message}`);
+        setProgress(null);
+        setPhase("parsed");
+        return;
+      }
+      const r = data as Record<string, number>;
+      agg.total              += r.chunk_total              ?? 0;
+      agg.ok                 += r.chunk_ok                 ?? 0;
+      agg.duplicate_in_batch += r.chunk_duplicate_in_batch ?? 0;
+      agg.duplicate_existing += r.chunk_duplicate_existing ?? 0;
+      agg.errors             += r.chunk_errors             ?? 0;
+      setProgress({ done: Math.min(i + chunk.length, parsedRows.length), total: parsedRows.length, label: "上傳中" });
     }
+
     setBatchId(bid);
-    setStats(data as StageStats);
+    setStats(agg);
+    setProgress(null);
     await reloadStaged(bid);
     setPhase("staged");
   }, [parsedRows]);
@@ -126,7 +153,7 @@ export default function MemberImportPage() {
     const { data, error: err, count } = await getSupabase()
       .from("member_imports")
       .select(
-        "id, row_index, parsed_external_id, parsed_name, parsed_name_suffix, parsed_takeout_store_name_hint, parsed_home_store_id, parsed_joined_at, parsed_last_visit_at, validation_status, validation_errors, resolved_member_id",
+        "id, row_index, parsed_external_id, parsed_name, parsed_name_suffix, parsed_takeout_store_name_hint, parsed_home_store_id, parsed_joined_at, parsed_last_visit_at, parsed_wallet_balance, validation_status, validation_errors, resolved_member_id",
         { count: "exact" },
       )
       .eq("batch_id", bid)
@@ -141,20 +168,45 @@ export default function MemberImportPage() {
   }, []);
 
   const handleCommit = useCallback(async () => {
-    if (!batchId) return;
+    if (!batchId || !stats) return;
     setError(null);
-    const { data, error: err } = await getSupabase().rpc("rpc_commit_member_import", {
-      p_batch_id: batchId,
-    });
-    if (err) {
-      setError(err.message);
-      return;
-    }
-    setCommitResult(data as { committed: number; skipped: number });
     setConfirmCommit(false);
+    setPhase("committing");
+    const sb = getSupabase();
+    let committed = 0;
+    let skipped = 0;
+    const target = stats.ok;
+    setProgress({ done: 0, total: target, label: "匯入中" });
+
+    let safety = 0;
+    while (true) {
+      const { data, error: err } = await sb.rpc("rpc_commit_member_import", {
+        p_batch_id: batchId,
+        p_limit: COMMIT_CHUNK,
+      });
+      if (err) {
+        setError(`匯入失敗（已寫 ${committed} 筆）：${err.message}`);
+        setProgress(null);
+        setPhase("staged");
+        return;
+      }
+      const r = data as { committed: number; skipped: number };
+      committed += r.committed;
+      skipped   += r.skipped;
+      setProgress({ done: committed, total: target, label: "匯入中" });
+      if (r.committed === 0) break;
+      safety++;
+      if (safety > 200) {
+        setError("safety break: 超過 200 個 chunk 仍未完成");
+        break;
+      }
+    }
+
+    setCommitResult({ committed, skipped });
+    setProgress(null);
     await reloadStaged(batchId);
     setPhase("committed");
-  }, [batchId, reloadStaged]);
+  }, [batchId, stats, reloadStaged]);
 
   const handleCancel = useCallback(async () => {
     if (!batchId) return;
@@ -221,6 +273,24 @@ export default function MemberImportPage() {
         )}
       </section>
 
+      {/* 進度條 */}
+      {progress && (
+        <section className="rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="flex items-center justify-between text-sm">
+            <span>{progress.label}：{progress.done.toLocaleString()} / {progress.total.toLocaleString()}</span>
+            <span className="font-mono text-xs text-zinc-500">
+              {progress.total > 0 ? Math.floor((progress.done / progress.total) * 100) : 0}%
+            </span>
+          </div>
+          <div className="mt-2 h-2 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800">
+            <div
+              className="h-full bg-emerald-500 transition-all"
+              style={{ width: `${progress.total > 0 ? (progress.done / progress.total) * 100 : 0}%` }}
+            />
+          </div>
+        </section>
+      )}
+
       {/* 步驟 2：stage */}
       {phase === "parsed" && (
         <section className="rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
@@ -272,34 +342,41 @@ export default function MemberImportPage() {
               <Th>取貨店 hint</Th>
               <Th>取貨店對應</Th>
               <Th>加入日期</Th>
+              <Th align="right">儲值金</Th>
               <Th>狀態</Th>
               <Th>錯誤</Th>
             </THead>
             <TBody>
               {stagedRows.length === 0 ? (
-                <EmptyRow colSpan={8}>還沒有 staging 資料</EmptyRow>
+                <EmptyRow colSpan={9}>還沒有 staging 資料</EmptyRow>
               ) : (
-                stagedRows.map((r) => (
-                  <Tr key={r.id}>
-                    <Td className="font-mono text-xs text-zinc-400">{r.row_index}</Td>
-                    <Td className="font-mono text-xs">{r.parsed_external_id ?? "—"}</Td>
-                    <Td>
-                      {r.parsed_name ?? "—"}
-                      {r.parsed_name_suffix && (
-                        <span className="ml-1 text-xs text-zinc-400">／{r.parsed_name_suffix}</span>
-                      )}
-                    </Td>
-                    <Td className="text-xs">{r.parsed_takeout_store_name_hint ?? "—"}</Td>
-                    <Td className="text-xs">{r.parsed_home_store_id ? `store#${r.parsed_home_store_id}` : "—"}</Td>
-                    <Td className="text-xs">{r.parsed_joined_at?.slice(0, 10) ?? "—"}</Td>
-                    <Td>{statusChip(r.validation_status)}</Td>
-                    <Td className="text-xs text-rose-600">
-                      {r.validation_errors?.length
-                        ? r.validation_errors.map((e) => `${e.field}:${e.code}`).join("、")
-                        : "—"}
-                    </Td>
-                  </Tr>
-                ))
+                stagedRows.map((r) => {
+                  const w = r.parsed_wallet_balance == null ? null : Number(r.parsed_wallet_balance);
+                  return (
+                    <Tr key={r.id}>
+                      <Td className="font-mono text-xs text-zinc-400">{r.row_index}</Td>
+                      <Td className="font-mono text-xs">{r.parsed_external_id ?? "—"}</Td>
+                      <Td>
+                        {r.parsed_name ?? "—"}
+                        {r.parsed_name_suffix && (
+                          <span className="ml-1 text-xs text-zinc-400">／{r.parsed_name_suffix}</span>
+                        )}
+                      </Td>
+                      <Td className="text-xs">{r.parsed_takeout_store_name_hint ?? "—"}</Td>
+                      <Td className="text-xs">{r.parsed_home_store_id ? `store#${r.parsed_home_store_id}` : "—"}</Td>
+                      <Td className="text-xs">{r.parsed_joined_at?.slice(0, 10) ?? "—"}</Td>
+                      <Td align="right" className={`font-mono text-xs ${w && w > 0 ? "text-emerald-700 dark:text-emerald-300" : "text-zinc-400"}`}>
+                        {w == null ? "—" : w > 0 ? `$${w.toLocaleString()}` : "0"}
+                      </Td>
+                      <Td>{statusChip(r.validation_status)}</Td>
+                      <Td className="text-xs text-rose-600">
+                        {r.validation_errors?.length
+                          ? r.validation_errors.map((e) => `${e.field}:${e.code}`).join("、")
+                          : "—"}
+                      </Td>
+                    </Tr>
+                  );
+                })
               )}
             </TBody>
           </Table>

--- a/apps/admin/src/app/(protected)/members/import/page.tsx
+++ b/apps/admin/src/app/(protected)/members/import/page.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { parseLeleMemberCsv, downloadLeleTemplate, type LeleMemberRow } from "@/lib/parseLeleMemberCsv";
+import SpinButton from "@/components/SpinButton";
+import { Table, THead, TBody, Tr, Th, Td, EmptyRow } from "@/components/DataTable";
+
+type ValidationStatus =
+  | "pending"
+  | "ok"
+  | "duplicate_existing"
+  | "duplicate_in_batch"
+  | "error"
+  | "committed"
+  | "cancelled"
+  | "error_at_commit";
+
+type StagedRow = {
+  id: number;
+  row_index: number;
+  parsed_external_id: string | null;
+  parsed_name: string | null;
+  parsed_name_suffix: string | null;
+  parsed_takeout_store_name_hint: string | null;
+  parsed_home_store_id: number | null;
+  parsed_joined_at: string | null;
+  parsed_last_visit_at: string | null;
+  validation_status: ValidationStatus;
+  validation_errors: { field: string; code: string; value?: string }[];
+  resolved_member_id: number | null;
+};
+
+type StageStats = {
+  total: number;
+  ok: number;
+  duplicate_in_batch: number;
+  duplicate_existing: number;
+  errors: number;
+};
+
+type Phase = "pristine" | "parsed" | "staged" | "committed";
+
+const PREVIEW_LIMIT = 50;
+
+function statusChip(s: ValidationStatus) {
+  const map: Record<ValidationStatus, { label: string; cls: string }> = {
+    pending:            { label: "待驗證", cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300" },
+    ok:                 { label: "可匯入", cls: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300" },
+    duplicate_existing: { label: "已存在",  cls: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300" },
+    duplicate_in_batch: { label: "批內重複", cls: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300" },
+    error:              { label: "錯誤",    cls: "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300" },
+    committed:          { label: "已匯入",  cls: "bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-300" },
+    cancelled:          { label: "已取消",  cls: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400" },
+    error_at_commit:    { label: "匯入失敗", cls: "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300" },
+  };
+  const m = map[s];
+  return <span className={`inline-flex rounded-full px-2 py-0.5 text-xs ${m.cls}`}>{m.label}</span>;
+}
+
+export default function MemberImportPage() {
+  const [phase, setPhase] = useState<Phase>("pristine");
+  const [file, setFile] = useState<File | null>(null);
+  const [parsedRows, setParsedRows] = useState<LeleMemberRow[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [batchId, setBatchId] = useState<string | null>(null);
+  const [stats, setStats] = useState<StageStats | null>(null);
+  const [stagedRows, setStagedRows] = useState<StagedRow[]>([]);
+  const [stagedTotal, setStagedTotal] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [commitResult, setCommitResult] = useState<{ committed: number; skipped: number } | null>(null);
+  const [confirmCommit, setConfirmCommit] = useState(false);
+
+  const onPickFile = useCallback(async (f: File | null) => {
+    setError(null);
+    setParseError(null);
+    setFile(f);
+    setParsedRows([]);
+    setStats(null);
+    setStagedRows([]);
+    setBatchId(null);
+    setCommitResult(null);
+    setPhase("pristine");
+    if (!f) return;
+    const result = await parseLeleMemberCsv(f);
+    if (!result.ok) {
+      setParseError(result.error);
+      return;
+    }
+    setParsedRows(result.rows);
+    setPhase("parsed");
+  }, []);
+
+  const handleStage = useCallback(async () => {
+    if (!parsedRows.length) return;
+    setError(null);
+    const bid = (typeof crypto !== "undefined" && "randomUUID" in crypto)
+      ? crypto.randomUUID()
+      : `b_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+
+    const payload = parsedRows.map((r) => ({
+      external_id: r.external_id,
+      name_raw: r.name_raw,
+      label: r.label,
+      joined_at: r.joined_at,
+      last_visit_at: r.last_visit_at,
+    }));
+
+    const { data, error: err } = await getSupabase().rpc("rpc_stage_member_import", {
+      p_batch_id: bid,
+      p_source: "lele",
+      p_rows: payload,
+    });
+    if (err) {
+      setError(err.message);
+      return;
+    }
+    setBatchId(bid);
+    setStats(data as StageStats);
+    await reloadStaged(bid);
+    setPhase("staged");
+  }, [parsedRows]);
+
+  const reloadStaged = useCallback(async (bid: string) => {
+    const { data, error: err, count } = await getSupabase()
+      .from("member_imports")
+      .select(
+        "id, row_index, parsed_external_id, parsed_name, parsed_name_suffix, parsed_takeout_store_name_hint, parsed_home_store_id, parsed_joined_at, parsed_last_visit_at, validation_status, validation_errors, resolved_member_id",
+        { count: "exact" },
+      )
+      .eq("batch_id", bid)
+      .order("row_index", { ascending: true })
+      .limit(PREVIEW_LIMIT);
+    if (err) {
+      setError(err.message);
+      return;
+    }
+    setStagedRows((data ?? []) as StagedRow[]);
+    setStagedTotal(count ?? 0);
+  }, []);
+
+  const handleCommit = useCallback(async () => {
+    if (!batchId) return;
+    setError(null);
+    const { data, error: err } = await getSupabase().rpc("rpc_commit_member_import", {
+      p_batch_id: batchId,
+    });
+    if (err) {
+      setError(err.message);
+      return;
+    }
+    setCommitResult(data as { committed: number; skipped: number });
+    setConfirmCommit(false);
+    await reloadStaged(batchId);
+    setPhase("committed");
+  }, [batchId, reloadStaged]);
+
+  const handleCancel = useCallback(async () => {
+    if (!batchId) return;
+    setError(null);
+    const { error: err } = await getSupabase().rpc("rpc_cancel_member_import", {
+      p_batch_id: batchId,
+    });
+    if (err) {
+      setError(err.message);
+      return;
+    }
+    setBatchId(null);
+    setStagedRows([]);
+    setStats(null);
+    setPhase("pristine");
+    setFile(null);
+    setParsedRows([]);
+  }, [batchId]);
+
+  const canCommit = useMemo(() => phase === "staged" && (stats?.ok ?? 0) > 0, [phase, stats]);
+
+  return (
+    <div className="space-y-4 p-6">
+      <header className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-lg font-semibold">會員匯入（樂樂顧客 CSV）</h1>
+          <p className="mt-1 text-xs text-zinc-500">
+            從樂樂團購訂單管理系統「顧客管理」匯出 CSV，以「顧客代號」為 dedupe key 比對既有會員。
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <SpinButton
+            onClick={() => downloadLeleTemplate()}
+            className="whitespace-nowrap rounded-md border border-zinc-300 bg-white px-3 py-2 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+          >
+            下載範本 CSV
+          </SpinButton>
+          <Link
+            href="/members"
+            className="whitespace-nowrap rounded-md border border-zinc-300 bg-white px-3 py-2 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+          >
+            ← 回會員列表
+          </Link>
+        </div>
+      </header>
+
+      {/* 步驟 1：選檔 */}
+      <section className="rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <h2 className="mb-2 text-sm font-medium">① 選擇 CSV 檔案</h2>
+        <input
+          type="file"
+          accept=".csv,text/csv"
+          onChange={(e) => onPickFile(e.target.files?.[0] ?? null)}
+          className="block w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-zinc-900 file:px-3 file:py-2 file:text-white hover:file:bg-zinc-800 dark:file:bg-zinc-100 dark:file:text-zinc-900"
+        />
+        {file && (
+          <p className="mt-2 text-xs text-zinc-500">
+            {file.name}（{(file.size / 1024).toFixed(1)} KB）
+            {parsedRows.length > 0 && ` · 解析 ${parsedRows.length} 筆`}
+          </p>
+        )}
+        {parseError && (
+          <p className="mt-2 text-xs text-rose-600">{parseError}</p>
+        )}
+      </section>
+
+      {/* 步驟 2：stage */}
+      {phase === "parsed" && (
+        <section className="rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <h2 className="mb-2 text-sm font-medium">② 上傳到 staging 驗證</h2>
+          <p className="text-xs text-zinc-500">
+            客端已解析 {parsedRows.length} 筆。下一步上傳到 staging 由後端驗證去重、解析名字、對應取貨店。
+          </p>
+          <div className="mt-3 flex gap-2">
+            <SpinButton
+              onClick={handleStage}
+              className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            >
+              上傳到 staging
+            </SpinButton>
+          </div>
+        </section>
+      )}
+
+      {/* 步驟 3：staged 預覽 + commit */}
+      {(phase === "staged" || phase === "committed") && stats && (
+        <section className="space-y-3 rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <h2 className="text-sm font-medium">
+            {phase === "committed" ? "④ 匯入完成" : "③ 驗證結果"}
+          </h2>
+          <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-5">
+            <Stat label="總筆數" value={stats.total} />
+            <Stat label="可匯入" value={stats.ok} tone="emerald" />
+            <Stat label="已存在" value={stats.duplicate_existing} tone="amber" />
+            <Stat label="批內重複" value={stats.duplicate_in_batch} tone="amber" />
+            <Stat label="錯誤" value={stats.errors} tone="rose" />
+          </div>
+
+          {commitResult && (
+            <div className="rounded-md border border-sky-200 bg-sky-50 p-3 text-xs text-sky-800 dark:border-sky-900 dark:bg-sky-950 dark:text-sky-200">
+              已寫入 {commitResult.committed} 筆 / 跳過 {commitResult.skipped} 筆。
+              <Link href="/members" className="ml-2 underline">前往會員列表</Link>
+            </div>
+          )}
+
+          <div className="text-xs text-zinc-500">
+            預覽前 {Math.min(PREVIEW_LIMIT, stagedTotal)} 筆（共 {stagedTotal} 筆）
+          </div>
+
+          <Table>
+            <THead>
+              <Th>#</Th>
+              <Th>樂樂代號</Th>
+              <Th>姓名</Th>
+              <Th>取貨店 hint</Th>
+              <Th>取貨店對應</Th>
+              <Th>加入日期</Th>
+              <Th>狀態</Th>
+              <Th>錯誤</Th>
+            </THead>
+            <TBody>
+              {stagedRows.length === 0 ? (
+                <EmptyRow colSpan={8}>還沒有 staging 資料</EmptyRow>
+              ) : (
+                stagedRows.map((r) => (
+                  <Tr key={r.id}>
+                    <Td className="font-mono text-xs text-zinc-400">{r.row_index}</Td>
+                    <Td className="font-mono text-xs">{r.parsed_external_id ?? "—"}</Td>
+                    <Td>
+                      {r.parsed_name ?? "—"}
+                      {r.parsed_name_suffix && (
+                        <span className="ml-1 text-xs text-zinc-400">／{r.parsed_name_suffix}</span>
+                      )}
+                    </Td>
+                    <Td className="text-xs">{r.parsed_takeout_store_name_hint ?? "—"}</Td>
+                    <Td className="text-xs">{r.parsed_home_store_id ? `store#${r.parsed_home_store_id}` : "—"}</Td>
+                    <Td className="text-xs">{r.parsed_joined_at?.slice(0, 10) ?? "—"}</Td>
+                    <Td>{statusChip(r.validation_status)}</Td>
+                    <Td className="text-xs text-rose-600">
+                      {r.validation_errors?.length
+                        ? r.validation_errors.map((e) => `${e.field}:${e.code}`).join("、")
+                        : "—"}
+                    </Td>
+                  </Tr>
+                ))
+              )}
+            </TBody>
+          </Table>
+
+          {phase === "staged" && (
+            <div className="flex justify-end gap-2 pt-2">
+              <SpinButton
+                onClick={handleCancel}
+                className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+              >
+                取消批次
+              </SpinButton>
+              <SpinButton
+                onClick={() => setConfirmCommit(true)}
+                disabled={!canCommit}
+                className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                確認匯入 {stats.ok} 筆
+              </SpinButton>
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* commit 二次確認 */}
+      {confirmCommit && stats && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-900/50 px-4">
+          <div className="w-full max-w-md rounded-lg border border-zinc-200 bg-white p-5 shadow-xl dark:border-zinc-800 dark:bg-zinc-900">
+            <h3 className="text-base font-semibold">確認匯入</h3>
+            <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
+              將寫入 <b>{stats.ok}</b> 筆新會員。
+              {stats.duplicate_existing > 0 && <> 已存在 {stats.duplicate_existing} 筆不重複寫入。</>}
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <SpinButton
+                onClick={() => setConfirmCommit(false)}
+                className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+              >
+                取消
+              </SpinButton>
+              <SpinButton
+                onClick={handleCommit}
+                className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700"
+              >
+                確認匯入
+              </SpinButton>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800 dark:border-rose-900 dark:bg-rose-950 dark:text-rose-300">
+          <p className="font-medium">操作失敗</p>
+          <p className="mt-1 font-mono text-xs">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: number; tone?: "emerald" | "amber" | "rose" }) {
+  const toneCls =
+    tone === "emerald" ? "text-emerald-600 dark:text-emerald-400" :
+    tone === "amber"   ? "text-amber-600 dark:text-amber-400" :
+    tone === "rose"    ? "text-rose-600 dark:text-rose-400" :
+                         "text-zinc-900 dark:text-zinc-100";
+  return (
+    <div className="rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 dark:border-zinc-800 dark:bg-zinc-800/50">
+      <div className="text-xs text-zinc-500">{label}</div>
+      <div className={`text-lg font-semibold ${toneCls}`}>{value}</div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -227,12 +227,20 @@ function MembersListBody() {
             {loading ? "載入中…" : total === 0 ? "共 0 筆" : `共 ${total} 筆（顯示 ${fromIdx}-${toIdx}）`}
           </p>
         </div>
-        <SpinButton
-          onClick={() => setModal({ mode: "new" })}
-          className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-        >
-          新增會員
-        </SpinButton>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/members/import"
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+          >
+            批次匯入
+          </Link>
+          <SpinButton
+            onClick={() => setModal({ mode: "new" })}
+            className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            新增會員
+          </SpinButton>
+        </div>
       </header>
 
       <div className="grid gap-3 sm:grid-cols-2">

--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -15,7 +15,7 @@ import type { OrderStatus } from "@/lib/orderStatus";
 const PENDING_STATUSES: OrderStatus[] = ["pending", "confirmed", "shipping", "ready"];
 
 type Status = "active" | "inactive" | "blocked" | "merged" | "deleted";
-type SortKey = "updated_at" | "member_no" | "name";
+type SortKey = "updated_at" | "member_no" | "name" | "home_store_id" | "joined_at" | "last_visit_at" | "external_source";
 type SortDir = "asc" | "desc";
 
 type MemberRow = {
@@ -290,13 +290,13 @@ function MembersListBody() {
         <THead>
           <ThSort label="編號" col="member_no" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
           <ThSort label="姓名" col="name" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
-          <Th>取貨店</Th>
+          <ThSort label="取貨店" col="home_store_id" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
           <Th>手機</Th>
           <Th align="right">訂單數</Th>
           <Th align="right">未取貨金額</Th>
           <Th align="right">儲值</Th>
-          <Th align="right">加入時間</Th>
-          <Th align="right">最後登入</Th>
+          <ThSort label="加入時間" col="joined_at" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} align="right" />
+          <ThSort label="最後登入" col="last_visit_at" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} align="right" />
           <ThSort label="更新" col="updated_at" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} align="right" />
           <Th>{""}</Th>
         </THead>
@@ -312,7 +312,11 @@ function MembersListBody() {
               const bal = balances.get(r.id);
               const store = r.home_store_id ? stores.find((s) => s.id === r.home_store_id) : null;
               return (
-                <Tr key={r.id}>
+                <Tr
+                  key={r.id}
+                  onClick={() => setModal({ mode: "detail", memberId: r.id, memberNo: r.member_no })}
+                  className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+                >
                   <Td className="font-mono">
                     <SpinButton
                       onClick={() => setModal({ mode: "detail", memberId: r.id, memberNo: r.member_no })}
@@ -379,12 +383,14 @@ function MembersListBody() {
                     <div className="flex items-center justify-end gap-3">
                       <Link
                         href={`/pickup?q=${encodeURIComponent(r.member_no)}`}
+                        onClick={(e) => e.stopPropagation()}
                         className="text-xs text-emerald-600 hover:underline dark:text-emerald-400"
                       >
                         🔎 查訂單
                       </Link>
                       <SpinButton
-                        onClick={async () => {
+                        onClick={async (e) => {
+                          e.stopPropagation();
                           const { data } = await getSupabase()
                             .from("members")
                             .select("id, member_no, phone, name, gender, birthday, email, tier_id, home_store_id, status, notes")

--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -29,6 +29,8 @@ type MemberRow = {
   updated_at: string;
   joined_at: string;
   last_visit_at: string | null;
+  external_source: string | null;
+  external_id: string | null;
 };
 
 /** 顯示手機，若是 LIFF auto-register 的 placeholder (line:Uxxxx) 則視為未填 */
@@ -129,7 +131,7 @@ function MembersListBody() {
       try {
         let q = getSupabase()
           .from("members")
-          .select("id, member_no, name, phone, avatar_url, tier_id, status, updated_at, joined_at, last_visit_at", { count: "exact" })
+          .select("id, member_no, name, phone, avatar_url, tier_id, status, updated_at, joined_at, last_visit_at, external_source, external_id", { count: "exact" })
           .order(sortBy, { ascending: sortDir === "asc" })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 
@@ -332,6 +334,14 @@ function MembersListBody() {
                         </div>
                       )}
                       <span>{r.name ?? "—"}</span>
+                      {r.external_source === "lele" && (
+                        <span
+                          title={r.external_id ? `樂樂顧客代號 ${r.external_id}` : "樂樂匯入"}
+                          className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-normal text-amber-700 dark:bg-amber-950 dark:text-amber-300"
+                        >
+                          樂樂
+                        </span>
+                      )}
                     </div>
                   </Td>
                   <Td className="font-mono text-xs">{displayPhone(r.phone)}</Td>

--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -31,6 +31,8 @@ type MemberRow = {
   last_visit_at: string | null;
   external_source: string | null;
   external_id: string | null;
+  home_store_id: number | null;
+  takeout_store_name_hint: string | null;
 };
 
 /** 顯示手機，若是 LIFF auto-register 的 placeholder (line:Uxxxx) 則視為未填 */
@@ -131,7 +133,7 @@ function MembersListBody() {
       try {
         let q = getSupabase()
           .from("members")
-          .select("id, member_no, name, phone, avatar_url, tier_id, status, updated_at, joined_at, last_visit_at, external_source, external_id", { count: "exact" })
+          .select("id, member_no, name, phone, avatar_url, tier_id, status, updated_at, joined_at, last_visit_at, external_source, external_id, home_store_id, takeout_store_name_hint", { count: "exact" })
           .order(sortBy, { ascending: sortDir === "asc" })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 
@@ -288,6 +290,7 @@ function MembersListBody() {
         <THead>
           <ThSort label="編號" col="member_no" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
           <ThSort label="姓名" col="name" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
+          <Th>取貨店</Th>
           <Th>手機</Th>
           <Th align="right">訂單數</Th>
           <Th align="right">未取貨金額</Th>
@@ -299,14 +302,15 @@ function MembersListBody() {
         </THead>
         <TBody>
           {rows === null ? (
-            <SkeletonRows cols={10} />
+            <SkeletonRows cols={11} />
           ) : rows.length === 0 ? (
-            <EmptyRow colSpan={10}>
+            <EmptyRow colSpan={11}>
               {total === 0 && !query ? "還沒有會員，按「新增會員」開始建立。" : "沒有符合條件的會員。"}
             </EmptyRow>
           ) : (
             rows.map((r) => {
               const bal = balances.get(r.id);
+              const store = r.home_store_id ? stores.find((s) => s.id === r.home_store_id) : null;
               return (
                 <Tr key={r.id}>
                   <Td className="font-mono">
@@ -343,6 +347,18 @@ function MembersListBody() {
                         </span>
                       )}
                     </div>
+                  </Td>
+                  <Td className="text-xs">
+                    {store ? (
+                      <span>{store.name}</span>
+                    ) : r.takeout_store_name_hint ? (
+                      <span className="text-zinc-500" title="樂樂標籤、尚未對應到 store">
+                        {r.takeout_store_name_hint}
+                        <span className="ml-1 rounded bg-zinc-100 px-1 py-0.5 text-[10px] text-zinc-500 dark:bg-zinc-800">hint</span>
+                      </span>
+                    ) : (
+                      <span className="text-zinc-400">—</span>
+                    )}
                   </Td>
                   <Td className="font-mono text-xs">{displayPhone(r.phone)}</Td>
                   <Td align="right" className="font-mono">{bal?.orderCount ?? 0}</Td>

--- a/apps/admin/src/lib/parseLeleMemberCsv.ts
+++ b/apps/admin/src/lib/parseLeleMemberCsv.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import Papa from "papaparse";
+
+export type LeleMemberRow = {
+  external_id: string;
+  name_raw: string;
+  label: string;
+  joined_at: string;
+  last_visit_at: string;
+};
+
+export type ParseResult =
+  | { ok: true; rows: LeleMemberRow[]; totalLines: number }
+  | { ok: false; error: string };
+
+const HEADERS = {
+  external_id: "顧客代號",
+  name_raw: "名字",
+  label: "標籤",
+  joined_at: "加入日期",
+  last_visit_at: "最後登入",
+} as const;
+
+export async function parseLeleMemberCsv(file: File): Promise<ParseResult> {
+  return new Promise((resolve) => {
+    Papa.parse<string[]>(file, {
+      skipEmptyLines: true,
+      complete(result) {
+        if (result.errors.length) {
+          const e = result.errors[0];
+          resolve({ ok: false, error: `CSV 解析錯誤 (row ${e.row}): ${e.message}` });
+          return;
+        }
+        const rows = result.data;
+        if (!rows.length) {
+          resolve({ ok: false, error: "CSV 是空的" });
+          return;
+        }
+
+        const header = rows[0];
+        const idx: Partial<Record<keyof typeof HEADERS, number>> = {};
+        const missing: string[] = [];
+        for (const [k, h] of Object.entries(HEADERS) as [keyof typeof HEADERS, string][]) {
+          const i = header.findIndex((c) => (c ?? "").trim() === h);
+          if (i < 0) missing.push(h);
+          else idx[k] = i;
+        }
+        if (missing.length) {
+          resolve({ ok: false, error: `CSV 缺欄位：${missing.join("、")}` });
+          return;
+        }
+
+        const out: LeleMemberRow[] = [];
+        for (let i = 1; i < rows.length; i++) {
+          const r = rows[i];
+          const externalId = (r[idx.external_id!] ?? "").trim();
+          if (!externalId) continue;
+          out.push({
+            external_id: externalId,
+            name_raw: r[idx.name_raw!] ?? "",
+            label: r[idx.label!] ?? "",
+            joined_at: r[idx.joined_at!] ?? "",
+            last_visit_at: r[idx.last_visit_at!] ?? "",
+          });
+        }
+        resolve({ ok: true, rows: out, totalLines: rows.length - 1 });
+      },
+      error(err) {
+        resolve({ ok: false, error: err.message });
+      },
+    });
+  });
+}
+
+export function downloadLeleTemplate() {
+  const header = '"全選","","","顧客代號","名字","標籤","未配單","已配未結單","未付款","未寄出","區間金額","錢包餘額","未結單$","最後登入","加入日期",""\n';
+  const sample = '"","","","18267783","#18267783 : 【範例顧客】123456-永和","永和","0","0","0筆","0筆","－","0","0","2026-05-12 18:59:33","2026-05-12 18:59:33",""\n';
+  const blob = new Blob(["﻿" + header + sample], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "lele-member-import-template.csv";
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/apps/admin/src/lib/parseLeleMemberCsv.ts
+++ b/apps/admin/src/lib/parseLeleMemberCsv.ts
@@ -8,6 +8,7 @@ export type LeleMemberRow = {
   label: string;
   joined_at: string;
   last_visit_at: string;
+  wallet_balance: string;
 };
 
 export type ParseResult =
@@ -20,6 +21,7 @@ const HEADERS = {
   label: "標籤",
   joined_at: "加入日期",
   last_visit_at: "最後登入",
+  wallet_balance: "錢包餘額",
 } as const;
 
 export async function parseLeleMemberCsv(file: File): Promise<ParseResult> {
@@ -62,6 +64,7 @@ export async function parseLeleMemberCsv(file: File): Promise<ParseResult> {
             label: r[idx.label!] ?? "",
             joined_at: r[idx.joined_at!] ?? "",
             last_visit_at: r[idx.last_visit_at!] ?? "",
+            wallet_balance: r[idx.wallet_balance!] ?? "",
           });
         }
         resolve({ ok: true, rows: out, totalLines: rows.length - 1 });

--- a/docs/TEST-member-import.md
+++ b/docs/TEST-member-import.md
@@ -1,0 +1,219 @@
+# 會員匯入測試項目 — 樂樂顧客 CSV → members
+
+**對應 migration（待建）：** `supabase/migrations/20260613000010_member_import.sql`
+**對應 UI 變更（待建）：**
+- `apps/admin/src/app/(protected)/members/import/page.tsx`（新頁面）
+- `apps/admin/src/app/(protected)/members/page.tsx`（加「匯入」入口）
+- `apps/admin/src/lib/parseLeleMemberCsv.ts`（樂樂 CSV 專用解析）
+
+**對應 PRD：**
+- `docs/PRD-會員模組.md`
+- `docs/BRIEF-Alex-2026-04-23-session.md` §2「樂樂 CSV 對應」（members.external_id + takeout_store_name_hint）
+
+**參考實作：** `rpc_upsert_member` @ `supabase/migrations/20260425120000_core_crud_rpcs.sql:97`
+
+**範例 CSV：** `C:\Users\Alex\Downloads\顧客管理-樂樂團購訂單管理系統.csv`（12,397 筆會員）
+
+---
+
+## 樂樂顧客 CSV 欄位 mapping
+
+| CSV 欄位 | members 欄位 | 解析規則 |
+|---|---|---|
+| 顧客代號 | `external_id` | 直接複製字串（內部數字 ID）|
+| 名字 | `name` + `notes`（後綴）| regex `^#(\d+)\s*[:：]\s*【(.+?)】\s*(.*)$` → 取 group2 = name；group3 = 後綴存 notes（若有）|
+| 標籤 | `takeout_store_name_hint` + 嘗試對 `home_store_id` | 標籤 `—` 視為空；非空時設 hint，模糊比對 `stores.name` like 標籤% 唯一 match → `home_store_id` |
+| 加入日期 | `joined_at` | TIMESTAMPTZ parse；`—` → NULL |
+| 最後登入 | `last_visit_at` | TIMESTAMPTZ parse；`—` → NULL |
+| 其他（錢包餘額 / 未結單 / 區間金額 / 未配單 …）| — | **不匯入**，本次任務 out-of-scope |
+
+**固定值：** `external_source = 'lele'`、`status = 'active'`、phone 留 NULL（樂樂 CSV 不含）。
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 ALTER `members` 加欄位
+- [ ] `external_source TEXT` (CHECK `IN ('lele','pinduoduo','1688','line_community','manual')`)
+  ```sql
+  SELECT column_name, data_type
+    FROM information_schema.columns
+   WHERE table_name='members' AND column_name='external_source';
+  ```
+- [ ] 既有 `external_id TEXT` 不動（已存在）
+- [ ] 既有 `takeout_store_name_hint TEXT` 不動（已存在）
+
+### 1.2 Unique partial index on members
+- [ ] `uniq_members_tenant_extsrc_extid` ON `(tenant_id, external_source, external_id) WHERE external_id IS NOT NULL`
+  ```sql
+  SELECT indexname, indexdef FROM pg_indexes
+   WHERE tablename='members' AND indexname LIKE '%external%';
+  ```
+
+### 1.3 新增 `member_imports` staging 表
+- [ ] 欄位：`id, tenant_id, batch_id, row_index, source, raw_data JSONB, parsed_external_id, parsed_name, parsed_name_suffix, parsed_takeout_store_name_hint, parsed_home_store_id, parsed_joined_at, parsed_last_visit_at, parsed_notes, validation_status, validation_errors JSONB, resolved_member_id, audit columns`
+- [ ] `source TEXT NOT NULL DEFAULT 'lele' CHECK (source IN ('lele','pinduoduo','1688','manual'))`
+- [ ] `validation_status` CHECK `IN ('pending','ok','duplicate_existing','duplicate_in_batch','error','committed','cancelled','error_at_commit')`
+- [ ] UNIQUE `(tenant_id, batch_id, row_index)`
+  ```sql
+  SELECT column_name, data_type, is_nullable FROM information_schema.columns
+   WHERE table_name='member_imports' ORDER BY ordinal_position;
+  ```
+
+### 1.4 Indexes
+- [ ] `idx_mi_batch (tenant_id, batch_id)`
+- [ ] `idx_mi_status (tenant_id, batch_id, validation_status)`
+- [ ] `idx_mi_ext (tenant_id, source, parsed_external_id)` WHERE parsed_external_id IS NOT NULL
+
+### 1.5 RLS
+- [ ] `mi_hq_all` policy（role in owner/admin/hq_manager）
+- [ ] `auth_read_member_imports` 給 authenticated 同 tenant SELECT
+
+### 1.6 RPC signature
+- [ ] `rpc_stage_member_import(p_batch_id TEXT, p_source TEXT, p_rows JSONB) RETURNS JSONB`
+- [ ] `rpc_commit_member_import(p_batch_id TEXT) RETURNS JSONB`
+- [ ] `rpc_cancel_member_import(p_batch_id TEXT) RETURNS JSONB`
+- [ ] 全 SECURITY DEFINER + `GRANT EXECUTE TO authenticated`
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 `rpc_stage_member_import` — 全 ok（樂樂 CSV 典型 row）
+**情境：** 3 row 都帶 external_id + 名字（含「【...】」格式）+ 標籤（對得到 store）+ 加入日期
+**預期：** 回 `{ total:3, ok:3 }`；staging row parsed_name 正確抽出（如「Doris Wang」），parsed_home_store_id 填上對應 store
+
+### 2.2 名字 regex 解析
+**情境：** name 欄分別為：
+  - `#18267783 : 【Doris Wang】969616-永和`
+  - `#18266831 : 【妞妞】`
+  - `#18251224 : 【小褕 🐟 牙牙】小褕 🐟 牙牙880804-平鎮2`
+  - `#18217314 : 【868231-南平】`
+**預期：** parsed_name = `Doris Wang` / `妞妞` / `小褕 🐟 牙牙` / `868231-南平`；parsed_name_suffix = `969616-永和` / NULL / `小褕 🐟 牙牙880804-平鎮2` / NULL
+
+### 2.3 名字 regex match 失敗 fallback
+**情境：** 名字欄為 `亂寫的格式`（沒 `#代號 : 【...】`）
+**預期：** parsed_name = 原字串 trim 後；validation_errors 加 warning `name_format_unparsed`（不 fail，仍 ok）
+
+### 2.4 標籤對應 home_store_id 唯一 match
+**情境：** 標籤 = `永和`，stores 內有 `永和店`（name LIKE '永和%'）唯一
+**預期：** parsed_home_store_id 填上；parsed_takeout_store_name_hint = '永和'
+
+### 2.5 標籤多筆 match → 只填 hint
+**情境：** 標籤 = `平鎮`，stores 有 `平鎮店` + `平鎮2店`
+**預期：** parsed_home_store_id = NULL；parsed_takeout_store_name_hint = '平鎮'；validation_errors 加 warning `store_ambiguous`
+
+### 2.6 標籤 = `—` （樂樂特殊空值）
+**情境：** 標籤 = `—`
+**預期：** parsed_takeout_store_name_hint = NULL；parsed_home_store_id = NULL；無 warning
+
+### 2.7 external_id 必填
+**情境：** row 沒帶顧客代號
+**預期：** status='error'，errors 含 `{field:'external_id', code:'required'}`
+
+### 2.8 dedupe — duplicate_existing（同 external_id 在 DB）
+**情境：** members 已有 (tenant, external_source='lele', external_id='18267783')，再 stage 同 external_id
+**預期：** status='duplicate_existing'，resolved_member_id = 既有 id
+
+### 2.9 dedupe — duplicate_in_batch
+**情境：** 同批兩 row 同 external_id
+**預期：** 第一筆 ok，第二筆 duplicate_in_batch
+
+### 2.10 加入日期 / 最後登入 parse
+**情境：** `2026-05-12 18:59:33` / `—` / 空字串
+**預期：** 第一個 → TIMESTAMPTZ；其餘 → NULL（無 error）
+
+### 2.11 `rpc_commit_member_import` happy path
+**情境：** 3 ok rows commit
+**預期：** members 新增 3 筆（external_source='lele'、external_id、name、joined_at、last_visit_at、takeout_store_name_hint、home_store_id 全填）；member_no 自動生成；status='active'
+
+### 2.12 commit 自動 member_no
+**情境：** 樂樂 CSV 不帶 member_no
+**預期：** 每筆 commit 都用 `rpc_next_member_no()` 生成（'M' + lpad）
+
+### 2.13 commit — phone / phone_hash 留 NULL
+**情境：** 樂樂 CSV 不含 phone
+**預期：** members.phone IS NULL、members.phone_hash IS NULL；不違反任何 unique constraint
+
+### 2.14 commit 防重入
+**情境：** 同 batch 第二次 commit
+**預期：** 已 committed row 不重做；只處理新進 ok row；回傳 committed=0 若無新 row
+
+### 2.15 commit 觸發 unique violation（race）
+**情境：** stage 時不存在的 external_id，commit 前另一 session 寫了同 external_id
+**預期：** 該 row 標 'error_at_commit'，validation_errors 加 unique_violation；其他 row 不受影響
+
+### 2.16 跨 tenant reject
+**情境：** tenant B JWT 對 tenant A 的 batch 呼叫 commit
+**預期：** 0 rows 命中或 RAISE EXCEPTION
+
+### 2.17 `rpc_cancel_member_import`
+**情境：** stage 後 cancel
+**預期：** validation_status 全改 'cancelled'（已 committed 不動）
+
+### 2.18 大批量壓測（接近實際資料）
+**情境：** stage 一批 5,000 row（取樂樂 CSV 前 5k）
+**預期：** 完成時間 < 30s；commit 完 members 增加 5,000 筆（若 dev DB 原本無此 external_id）
+
+---
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 `/members/import` 頁面 mount
+- [ ] 載入無 console error
+- [ ] 標題「會員匯入（樂樂顧客 CSV）」可見
+- [ ] 「下載範本 CSV」按鈕 → 下載樂樂格式 header 的空 CSV
+
+### 3.2 檔案上傳
+- [ ] 接受 `.csv`
+- [ ] 上傳樂樂實際 CSV（12k row）能客端解析（papaparse worker）不 freeze
+- [ ] 解析中顯示 progress
+
+### 3.3 預覽表格
+- [ ] 顯示前 20 row + 分頁
+- [ ] 每 row 顯示：external_id / parsed_name / hint / home_store / joined_at / status chip
+- [ ] 統計列：「總 X / 可匯入 Y / 已存在 Z / 錯誤 W」
+
+### 3.4 Stage 按鈕
+- [ ] 點「上傳到 staging」→ 分批呼叫 `rpc_stage_member_import`（每批 500 row 避免 timeout）
+- [ ] 進度條顯示批次進度
+- [ ] 成功後從 staging 重抓資料刷新預覽
+
+### 3.5 Commit 按鈕
+- [ ] 至少 1 row ok 才 enable
+- [ ] 點 commit → 二次確認 modal「將寫入 N 筆新會員」
+- [ ] 確認後呼叫 `rpc_commit_member_import` → toast「成功匯入 N 筆」
+- [ ] 跳轉 `/members?ordered=newest`，新會員可見
+
+### 3.6 Cancel
+- [ ] 「取消批次」→ 確認 → 呼叫 cancel RPC → staging 清空
+
+### 3.7 個資遮罩
+- [ ] 樂樂 CSV 不含 phone / line_user_id，預覽頁無遮罩問題
+- [ ] **不允許** UI 顯示 line_user_id 欄位（即使未來 CSV 含也馬賽克）
+
+### 3.8 `/members` 列表加入口
+- [ ] 列表右上角加「批次匯入」按鈕 → 連 `/members/import`
+- [ ] 既有「新增」按鈕不變
+
+### 3.9 視覺一致性
+- [ ] 用既有 `Table` 元件 + 白底
+- [ ] chip 用既有 status color tokens
+
+---
+
+## 4. Regression
+
+- [ ] `/members` 列表 / 詳情 / 新增編輯 modal 全部不變
+- [ ] `rpc_upsert_member` 不被改 signature
+- [ ] `rpc_register_member_via_liff` 不受影響
+- [ ] `rpc_resolve_member` 仍可 phone 查（既有 plaintext member）
+- [ ] LIFF 顧客端三頁不受影響
+- [ ] members.phone_hash partial unique index 不被改回 NOT NULL
+- [ ] 新增的 `external_source` + unique index 不影響既有 members（既有 row external_id IS NULL，partial index 不收）
+
+---
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**`supabase db push` 成功**、**`pnpm --filter admin build` + type-check 過**、**用實際樂樂 CSV 完整跑一遍**（12,397 筆 stage + commit）才可標 done。

--- a/docs/TEST-order-import.md
+++ b/docs/TEST-order-import.md
@@ -1,0 +1,219 @@
+# 訂單匯入測試項目 — Order Import (樂樂 CSV → external_order_imports → customer_orders)
+
+**對應 migration（待建）：** `supabase/migrations/2026MMDDxxxxxx_order_import.sql`
+**對應 UI 變更（待建）：**
+- `apps/admin/src/app/(protected)/orders/import/page.tsx`（新頁面）
+- `apps/admin/src/app/(protected)/orders/page.tsx`（加「匯入」入口）
+- 共用 `apps/admin/src/lib/parseCsv.ts`（與 member-import 共用）
+
+**對應 PRD：**
+- `docs/PRD-訂單取貨模組-v0.2-addendum.md`（樂樂 CSV 段）
+- `docs/PRD-訂單取貨模組.md` §6（訂單來源）
+
+**既有資產（要利用 / 補完）：**
+- `external_order_imports` staging 表 @ `supabase/migrations/20260423120002_picking_waves.sql:88`
+- `rpc_import_external_orders` 空殼 @ same file:401（要補完邏輯）
+- `customer_orders` UNIQUE `(tenant_id, campaign_id, channel_id, member_id)` → 合併單規則
+- `customer_order_sources` 表（append-only，記錄匯入來源）
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 ALTER `external_order_imports` 補欄位
+- [ ] 加 `channel_id BIGINT REFERENCES line_channels(id)`（同批同 channel；現在 schema 缺）
+- [ ] 加 `campaign_id BIGINT REFERENCES group_buy_campaigns(id)`（同上）
+- [ ] 加 `parsed_member_id BIGINT REFERENCES members(id)`（match 結果）
+- [ ] 加 `parsed_pickup_store_id BIGINT REFERENCES stores(id)`
+- [ ] 加 `parsed_nickname TEXT`（樂樂 CSV 可能有 LINE 暱稱）
+- [ ] 加 `validation_errors JSONB`
+- [ ] 既有欄位（parsed_sku_id / parsed_customer_identifier / parsed_qty / parsed_amount / status / resolved_order_id）不改
+- [ ] status CHECK 加值：`('pending','resolved','skipped','error','unresolved_member','unresolved_sku')`
+  ```sql
+  SELECT pg_get_constraintdef(oid) FROM pg_constraint
+   WHERE conrelid='external_order_imports'::regclass AND contype='c';
+  ```
+
+### 1.2 Indexes
+- [ ] `idx_eoi_campaign` ON `(tenant_id, campaign_id, status)`
+- [ ] 既有 `idx_ext_imports_batch / idx_ext_imports_status` 保留
+
+### 1.3 RPC signature
+- [ ] 新增 `rpc_stage_external_order_import(p_batch_id TEXT, p_source TEXT, p_campaign_id BIGINT, p_channel_id BIGINT, p_rows JSONB) RETURNS JSONB`
+- [ ] 補完既有 `rpc_import_external_orders(p_tenant_id, p_batch_id, p_campaign_id, p_operator)` 邏輯（不變簽名以維持相容）
+- [ ] 新增 `rpc_resolve_import_member(p_import_id BIGINT, p_member_id BIGINT) RETURNS BIGINT`（admin 手動綁定 unresolved row）
+- [ ] 新增 `rpc_cancel_external_order_import(p_batch_id TEXT) RETURNS JSONB`
+- [ ] 全部 SECURITY DEFINER + `GRANT EXECUTE TO authenticated`
+  ```sql
+  SELECT proname, pg_get_function_arguments(oid)
+    FROM pg_proc WHERE proname LIKE 'rpc_%_external_order%' OR proname='rpc_resolve_import_member';
+  ```
+
+### 1.4 RLS（HQ-only）
+- [ ] 既有 `eoi_hq_all` 涵蓋新欄位
+- [ ] 跨 tenant SELECT 取不到資料
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 `rpc_stage_external_order_import` — 全 ok
+**情境：** 樂樂 CSV 3 row，全部 phone 對得到 member、SKU 對得到 campaign_items、pickup_store code 對得到 stores
+**預期：** staging 3 筆 status='pending'，parsed_member_id/parsed_sku_id/parsed_pickup_store_id 全填
+
+### 2.2 phone 對不到 member → unresolved_member（不自動建會員）
+**情境：** CSV 含一筆陌生 phone='0911999888'
+**預期：** staging 該筆 status='unresolved_member'，parsed_member_id=NULL；不在 members 建任何 row
+
+### 2.3 SKU 名稱模糊 match → unresolved_sku
+**情境：** CSV 商品名「鳳梨酥10入」，campaign_items 內有「鳳梨酥(10入)」（括號差異）
+**預期：** 視 match 策略而定 → 完全 match 失敗時標 'unresolved_sku'，validation_errors 標出原文；admin 可手動 resolve
+
+### 2.4 pickup_store_code 找不到
+**情境：** CSV 取貨店 code='STORE_999'
+**預期：** status='error'，validation_errors 含 `{ field: 'pickup_store', code: 'not_found' }`
+
+### 2.5 campaign 不在 open/closed 狀態 reject
+**情境：** campaign 已 status='completed'，呼叫 stage
+**預期：** RAISE EXCEPTION 'campaign is in status completed, cannot import'（沿用既有檢查）
+
+### 2.6 channel 不在 campaign_channels reject
+**情境：** channel_id 沒掛在該 campaign
+**預期：** RAISE EXCEPTION 'channel not associated with campaign'
+
+### 2.7 數量 / 金額為 0 / 負數 reject
+**情境：** parsed_qty=0 或 -1
+**預期：** status='error'，validation_errors 含 `{ field: 'qty', code: 'invalid' }`
+
+### 2.8 `rpc_import_external_orders` commit — 新建單 happy path
+**情境：** batch 內 3 ok row（member A / B / C），同 campaign + channel
+**預期：** 寫入 3 筆 customer_orders（pending）+ 3 筆 customer_order_items + 3 筆 customer_order_sources(source_type='csv')；staging row 標 'resolved' + resolved_order_id 填入
+
+### 2.9 commit — 同會員同活動同頻道合併單（UNIQUE 規則）
+**情境：** member A 已有訂單 OD-001 在 campaign X / channel Y；CSV 又匯入 member A 同 campaign 同 channel 的新項目
+**預期：** **不**建新 customer_orders；把 customer_order_items append 到 OD-001；staging row resolved_order_id 指向 OD-001
+
+### 2.10 commit — items 內含同 SKU 重複合併數量
+**情境：** member A 同訂單兩 row 都是 SKU=S1，qty=2 + qty=3
+**預期：** customer_order_items 合併為一筆 qty=5（或兩筆，依設計擇一明確記錄）
+
+### 2.11 commit — unresolved_member rows 跳過
+**情境：** batch 含 3 pending + 2 unresolved_member
+**預期：** 只 commit 3 筆；unresolved 維持原 status，待 admin 手動 resolve
+
+### 2.12 `rpc_resolve_import_member` — admin 手動綁
+**情境：** unresolved_member row + admin 指定 member_id
+**預期：** staging row 改 status='pending'、parsed_member_id 填入；下次 commit 會處理它
+
+### 2.13 commit 防重入
+**情境：** 同 batch_id commit 兩次
+**預期：** 第二次只處理新進的 pending row（resolved 不重做），不重複建單
+
+### 2.14 commit 跨 tenant reject
+**情境：** 用 tenant B JWT 呼叫 batch_of_tenant_A
+**預期：** 0 rows 命中或 RAISE EXCEPTION
+
+### 2.15 customer_order_sources 寫入正確
+**情境：** commit 完查 customer_order_sources
+**預期：** source_type='csv'、raw_content 含原 CSV 內容片段、created_by=operator、order_id 對得起來
+
+### 2.16 audit / created_by
+**情境：** commit 後查 customer_orders 與 customer_order_items
+**預期：** `created_by` 填入 operator UUID；`updated_by` 同上；created_at 在 commit 時間 ±5s
+
+### 2.17 `rpc_cancel_external_order_import` — 取消未 commit 的 batch
+**情境：** 未 commit 的 batch 呼叫 cancel
+**預期：** staging row 全標 'skipped' 或刪除；commit 拒絕已 cancelled
+
+### 2.18 cancel 已部分 commit 的 batch
+**情境：** batch 內已有 resolved row（已建單）+ pending row，呼叫 cancel
+**預期：** 已 resolved 的不動（保留 customer_orders）；剩下 pending 標 'skipped'
+
+---
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 `/orders/import` 頁面 mount
+- [ ] 路由載入無 console error
+- [ ] 標題「訂單匯入（樂樂 CSV）」可見
+- [ ] 上方下拉選 campaign（只列 status in open/closed）+ channel（依 campaign 篩 campaign_channels）
+- [ ] 「下載範本 CSV」按鈕 → 含正確欄位 header
+
+### 3.2 必須先選 campaign + channel
+- [ ] 沒選 campaign 時上傳按鈕 disabled
+- [ ] 選了 campaign 後 channel 下拉刷新只列該 campaign 的 channels
+
+### 3.3 檔案上傳 + 客端解析
+- [ ] 上傳 CSV → 客端 papaparse 解析 → 顯示預覽（前 20 row + 分頁）
+- [ ] xlsx 也可解析（呼叫 xlsx lib）
+- [ ] 大檔 5k row 不 freeze
+
+### 3.4 Stage → preview validation 結果
+- [ ] 點「上傳到 staging」→ 呼叫 `rpc_stage_external_order_import`
+- [ ] 預覽表格 refresh 顯示每 row 的 server-side validation status chip
+- [ ] 統計列：「總 X / 可建單 Y / 待手動綁 Z / 錯誤 W」
+
+### 3.5 Unresolved member 手動綁
+- [ ] 每 unresolved_member row 旁有「指派會員」按鈕 → 開 modal 搜尋 member（phone / name / member_no）
+- [ ] 選定後呼叫 `rpc_resolve_import_member` → row status 變 pending、chip 變綠
+- [ ] 預覽刷新
+
+### 3.6 Commit 按鈕
+- [ ] 至少有 1 row pending 時 commit enable
+- [ ] 點 commit → 二次確認 modal「將建 / 合併 N 筆訂單；M 筆 unresolved 仍留 staging」
+- [ ] 確認後呼叫 `rpc_import_external_orders` → toast「已建 X 筆 / 合併到既有 Y 筆」
+- [ ] 跳轉 `/orders?campaignId=...` 列表，新訂單可見
+
+### 3.7 合併單視覺提示
+- [ ] commit 完，預覽 row 顯示「合併到 OD-001」連結（resolved_order_id 對應）
+- [ ] 點連結開 `/orders` 該訂單 detail
+
+### 3.8 Cancel
+- [ ] 「取消批次」按鈕 → 確認 → 呼叫 cancel RPC
+- [ ] 已 resolved 的 row 保留標示「已建單」；pending 清空
+
+### 3.9 個資遮罩
+- [ ] 預覽表格 phone 顯示完整（admin 匯入 flow 需要 cross-check）
+- [ ] 但若 row 有 line_user_id 欄位 → **馬賽克**為 `Uxxxxx...xxxxx`（依 memory）
+- [ ] 樂樂 CSV 預設不含 line_user_id，但若未來 source='shopee' 含，仍須馬賽克
+
+### 3.10 `/orders` 列表加入口
+- [ ] 列表右上角加「批次匯入」按鈕 → 連 `/orders/import?campaignId=`（可帶當前 campaign）
+- [ ] 既有訂單入單頁、清單、篩選不變
+
+### 3.11 視覺一致性
+- [ ] 用既有 `Table` 元件 + 白底（PR #209 後的規範）
+- [ ] 「合併單」chip 用區隔色（如藍色）跟「新建單」chip（綠）區分
+
+---
+
+## 4. Regression
+
+- [ ] `/orders` 列表頁原功能不變（多 campaign 篩選 / 標籤頁 / 取貨狀態）
+- [ ] `/campaigns/order-entry` 手動入單頁不變
+- [ ] `rpc_create_customer_orders` 不被覆寫
+- [ ] `rpc_advance_order_status` 不變
+- [ ] `rpc_record_pickup` 不變
+- [ ] picking_waves 流程不受影響（匯入的訂單能被既有揀貨波次拉到）
+- [ ] `customer_order_sources` append-only trigger 仍有效（嘗試 UPDATE 應 RAISE EXCEPTION）
+- [ ] LIFF 顧客端訂單頁仍能看到新匯入的訂單（依 member_id RLS）
+
+---
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**`supabase db push` 成功**、**`pnpm --filter admin build` + type-check 過** 才可標 done。
+
+---
+
+## 附註 — 兩個匯入功能的共用點
+
+| 共用 | 細節 |
+|------|------|
+| CSV/Excel 解析 lib | `papaparse` + `xlsx` 各裝一次，`apps/admin/src/lib/parseCsv.ts` |
+| Batch ID 生成 | client 端 `crypto.randomUUID()` |
+| Validation chip 元件 | `apps/admin/src/components/ImportStatusChip.tsx` |
+| 範本下載 | client 端組 CSV string 觸發 download |
+| Audit | 全 RPC `created_by = auth.uid()` |
+
+如要先實作哪個：建議**會員匯入先**（沒有外部依賴），完成後再做訂單匯入（依賴 member 已存在）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,11 @@
         "@tiptap/pm": "^3.22.5",
         "@tiptap/react": "^3.22.5",
         "@tiptap/starter-kit": "^3.22.5",
+        "@types/papaparse": "^5.5.2",
         "date-fns": "^4.1.0",
         "isomorphic-dompurify": "^3.11.0",
         "next": "16.2.4",
+        "papaparse": "^5.5.3",
         "react": "19.2.4",
         "react-day-picker": "^9.14.0",
         "react-dom": "19.2.4"
@@ -2594,6 +2596,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -6696,6 +6707,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/scripts/check-import-status.mjs
+++ b/scripts/check-import-status.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+
+const ENV = Object.fromEntries(
+  readFileSync("apps/admin/.env.local", "utf8")
+    .split(/\r?\n/).filter((l) => l && !l.startsWith("#"))
+    .map((l) => l.split("=").map((s, i, a) => (i === 0 ? s.trim() : a.slice(1).join("=").trim()))),
+);
+const sb = createClient(ENV.NEXT_PUBLIC_SUPABASE_URL, ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY, { auth: { persistSession: false } });
+await sb.auth.signInWithPassword({ email: ENV.ADMIN_EMAIL, password: ENV.ADMIN_PASSWORD });
+
+const bid = process.argv[2] ?? "15be7b3d-b65c-4e56-ba7a-9f0b2e052ab4";
+
+// 該 batch 各 status 計數
+const statuses = ["pending","ok","duplicate_existing","duplicate_in_batch","error","committed","cancelled","error_at_commit"];
+console.log(`batch ${bid}:`);
+for (const s of statuses) {
+  const { count } = await sb.from("member_imports").select("id", { count: "exact", head: true }).eq("batch_id", bid).eq("validation_status", s);
+  if (count) console.log(`  ${s.padEnd(22)} ${count}`);
+}
+
+// 該 batch resolved_member_id 對應到的 members 數
+const { count: memberCount } = await sb.from("members").select("id", { count: "exact", head: true }).eq("external_source", "lele");
+console.log(`\nmembers WHERE external_source='lele': ${memberCount}`);
+
+// wallet ledger 樂樂匯入計數
+const { count: walletCount } = await sb.from("wallet_ledger").select("id", { count: "exact", head: true }).eq("source_type", "import_lele");
+console.log(`wallet_ledger source_type='import_lele': ${walletCount}`);

--- a/scripts/check-trigger.mjs
+++ b/scripts/check-trigger.mjs
@@ -1,0 +1,8 @@
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+const ENV = Object.fromEntries(readFileSync("apps/admin/.env.local","utf8").split(/\r?\n/).filter(l=>l&&!l.startsWith("#")).map(l=>l.split("=").map((s,i,a)=>i===0?s.trim():a.slice(1).join("=").trim())));
+const sb = createClient(ENV.NEXT_PUBLIC_SUPABASE_URL, ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY, { auth: { persistSession: false } });
+await sb.auth.signInWithPassword({ email: ENV.ADMIN_EMAIL, password: ENV.ADMIN_PASSWORD });
+// 用 query 來看 triggers — 需要 rpc 或 view
+const { data, error } = await sb.from("pg_trigger").select("*").limit(1);
+console.log("test:", { data, error });

--- a/scripts/check-wallet-trigger.mjs
+++ b/scripts/check-wallet-trigger.mjs
@@ -1,0 +1,8 @@
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+const ENV = Object.fromEntries(readFileSync("apps/admin/.env.local","utf8").split(/\r?\n/).filter(l=>l&&!l.startsWith("#")).map(l=>l.split("=").map((s,i,a)=>i===0?s.trim():a.slice(1).join("=").trim())));
+const sb = createClient(ENV.NEXT_PUBLIC_SUPABASE_URL, ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY, { auth: { persistSession: false } });
+await sb.auth.signInWithPassword({ email: ENV.ADMIN_EMAIL, password: ENV.ADMIN_PASSWORD });
+// 列出 wallet_ledger 上的 trigger names — 需要 RPC
+const { data: maybe } = await sb.from("wallet_ledger").select("id").limit(1);
+console.log(maybe);

--- a/scripts/purge-lele-100.mjs
+++ b/scripts/purge-lele-100.mjs
@@ -1,0 +1,23 @@
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+const ENV = Object.fromEntries(readFileSync("apps/admin/.env.local","utf8").split(/\r?\n/).filter(l=>l&&!l.startsWith("#")).map(l=>l.split("=").map((s,i,a)=>i===0?s.trim():a.slice(1).join("=").trim())));
+const sb = createClient(ENV.NEXT_PUBLIC_SUPABASE_URL, ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY, { auth: { persistSession: false } });
+await sb.auth.signInWithPassword({ email: ENV.ADMIN_EMAIL, password: ENV.ADMIN_PASSWORD });
+const t0 = Date.now();
+let total = 0;
+let safety = 0;
+while (true) {
+  const t1 = Date.now();
+  const { data, error } = await sb.rpc("rpc_admin_purge_lele_imports", { p_limit: 50 });
+  if (error) { console.error(`error +${Date.now()-t1}ms:`, error.message); break; }
+  total += data.members_deleted;
+  if (safety % 10 === 0 || data.members_deleted === 0) {
+    console.log(`  -${data.members_deleted} total=${total} +${Date.now()-t1}ms`);
+  }
+  if (data.members_deleted === 0) {
+    console.log(`  imports=${data.imports_deleted} stores=${data.stores_deleted}`);
+    break;
+  }
+  if (++safety > 500) { console.log("safety break"); break; }
+}
+console.log(`✓ ${Date.now()-t0}ms total purged=${total}`);

--- a/scripts/purge-lele.mjs
+++ b/scripts/purge-lele.mjs
@@ -1,0 +1,21 @@
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+const ENV = Object.fromEntries(readFileSync("apps/admin/.env.local","utf8").split(/\r?\n/).filter(l=>l&&!l.startsWith("#")).map(l=>l.split("=").map((s,i,a)=>i===0?s.trim():a.slice(1).join("=").trim())));
+const sb = createClient(ENV.NEXT_PUBLIC_SUPABASE_URL, ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY, { auth: { persistSession: false } });
+await sb.auth.signInWithPassword({ email: ENV.ADMIN_EMAIL, password: ENV.ADMIN_PASSWORD });
+const t0 = Date.now();
+let total = 0;
+let safety = 0;
+while (true) {
+  const t1 = Date.now();
+  const { data, error } = await sb.rpc("rpc_admin_purge_lele_imports", { p_limit: 500 });
+  if (error) { console.error(`chunk error after ${Date.now()-t1}ms:`, error); break; }
+  total += data.members_deleted;
+  console.log(`  -${data.members_deleted} members (wallet=${data.wallet_ledger_deleted} push=${data.push_subs_deleted}) total=${total} +${Date.now()-t1}ms`);
+  if (data.members_deleted === 0) {
+    console.log(`  imports_deleted=${data.imports_deleted}, stores_deleted=${data.stores_deleted}`);
+    break;
+  }
+  if (++safety > 100) { console.log("safety break"); break; }
+}
+console.log(`✓ done in ${Date.now()-t0}ms`);

--- a/scripts/run-commit-now.mjs
+++ b/scripts/run-commit-now.mjs
@@ -1,0 +1,21 @@
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+const ENV = Object.fromEntries(
+  readFileSync("apps/admin/.env.local", "utf8")
+    .split(/\r?\n/).filter((l) => l && !l.startsWith("#"))
+    .map((l) => l.split("=").map((s, i, a) => (i === 0 ? s.trim() : a.slice(1).join("=").trim()))),
+);
+const sb = createClient(ENV.NEXT_PUBLIC_SUPABASE_URL, ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY, { auth: { persistSession: false } });
+await sb.auth.signInWithPassword({ email: ENV.ADMIN_EMAIL, password: ENV.ADMIN_PASSWORD });
+const bid = process.argv[2];
+const t0 = Date.now();
+let total = 0;
+while (true) {
+  const t1 = Date.now();
+  const { data, error } = await sb.rpc("rpc_commit_member_import", { p_batch_id: bid, p_limit: 500 });
+  if (error) { console.error(`chunk error after ${Date.now() - t1}ms:`, error); break; }
+  total += data.committed;
+  console.log(`+${data.committed} skip=${data.skipped} wallet=${data.wallet_initialized} (${Date.now() - t1}ms) total=${total}`);
+  if (data.committed === 0) break;
+}
+console.log(`\n✓ done in ${Date.now() - t0}ms, total committed=${total}`);

--- a/scripts/test-member-import-chunked.mjs
+++ b/scripts/test-member-import-chunked.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Chunked stage + commit smoke test (uses p_row_offset + p_limit)
+//   node scripts/test-member-import-chunked.mjs [N]
+
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+import Papa from "papaparse";
+
+const ENV = Object.fromEntries(
+  readFileSync("apps/admin/.env.local", "utf8")
+    .split(/\r?\n/).filter((l) => l && !l.startsWith("#"))
+    .map((l) => l.split("=").map((s, i, a) => (i === 0 ? s.trim() : a.slice(1).join("=").trim()))),
+);
+const sb = createClient(ENV.NEXT_PUBLIC_SUPABASE_URL, ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY, { auth: { persistSession: false } });
+const { error: e1 } = await sb.auth.signInWithPassword({ email: ENV.ADMIN_EMAIL, password: ENV.ADMIN_PASSWORD });
+if (e1) throw e1;
+
+const N = Number(process.argv[2] ?? 1500);
+const CHUNK = 500;
+const csv = readFileSync("C:/Users/Alex/Downloads/顧客管理-樂樂團購訂單管理系統.csv", "utf8");
+const data = Papa.parse(csv, { skipEmptyLines: true }).data;
+const header = data[0];
+const idx = {
+  external_id: header.findIndex((c) => c?.trim() === "顧客代號"),
+  name_raw:    header.findIndex((c) => c?.trim() === "名字"),
+  label:       header.findIndex((c) => c?.trim() === "標籤"),
+  joined_at:   header.findIndex((c) => c?.trim() === "加入日期"),
+  last_visit_at: header.findIndex((c) => c?.trim() === "最後登入"),
+};
+const rows = [];
+for (let i = 1; i < data.length && rows.length < N; i++) {
+  const r = data[i];
+  const eid = (r[idx.external_id] ?? "").trim();
+  if (!eid) continue;
+  rows.push({
+    external_id: eid,
+    name_raw: r[idx.name_raw] ?? "",
+    label: r[idx.label] ?? "",
+    joined_at: r[idx.joined_at] ?? "",
+    last_visit_at: r[idx.last_visit_at] ?? "",
+  });
+}
+console.log(`✓ parsed ${rows.length} rows`);
+
+const bid = `chunked_${Date.now()}`;
+const agg = { total: 0, ok: 0, duplicate_in_batch: 0, duplicate_existing: 0, errors: 0 };
+const tStage = Date.now();
+for (let i = 0; i < rows.length; i += CHUNK) {
+  const chunk = rows.slice(i, i + CHUNK);
+  const { data: out, error } = await sb.rpc("rpc_stage_member_import", {
+    p_batch_id: bid, p_source: "lele", p_rows: chunk, p_row_offset: i,
+  });
+  if (error) { console.error("stage err", error); process.exit(1); }
+  agg.total += out.chunk_total; agg.ok += out.chunk_ok;
+  agg.duplicate_in_batch += out.chunk_duplicate_in_batch;
+  agg.duplicate_existing += out.chunk_duplicate_existing;
+  agg.errors += out.chunk_errors;
+  console.log(`  chunk ${i + 1}~${i + chunk.length}: ${JSON.stringify(out)}`);
+}
+console.log(`✓ stage done in ${Date.now() - tStage}ms, agg=${JSON.stringify(agg)}`);
+
+const tCommit = Date.now();
+let committed = 0, skipped = 0;
+while (true) {
+  const { data: out, error } = await sb.rpc("rpc_commit_member_import", { p_batch_id: bid, p_limit: 500 });
+  if (error) { console.error("commit err", error); process.exit(1); }
+  committed += out.committed; skipped += out.skipped;
+  console.log(`  commit chunk: +${out.committed} (skipped ${out.skipped})`);
+  if (out.committed === 0) break;
+}
+console.log(`✓ commit done in ${Date.now() - tCommit}ms, committed=${committed} skipped=${skipped}`);
+
+await sb.rpc("rpc_cancel_member_import", { p_batch_id: bid });
+console.log("✓ cancel done");

--- a/scripts/test-member-import-wallet.mjs
+++ b/scripts/test-member-import-wallet.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Wallet 初始化驗證：手動塞幾筆 row 帶 wallet_balance 跑 stage→commit→查 wallet_ledger/balances
+
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+
+const ENV = Object.fromEntries(
+  readFileSync("apps/admin/.env.local", "utf8")
+    .split(/\r?\n/).filter((l) => l && !l.startsWith("#"))
+    .map((l) => l.split("=").map((s, i, a) => (i === 0 ? s.trim() : a.slice(1).join("=").trim()))),
+);
+const sb = createClient(ENV.NEXT_PUBLIC_SUPABASE_URL, ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY, { auth: { persistSession: false } });
+await sb.auth.signInWithPassword({ email: ENV.ADMIN_EMAIL, password: ENV.ADMIN_PASSWORD });
+console.log("✓ logged in");
+
+const bid = `wallet_${Date.now()}`;
+const rows = [
+  { external_id: "TEST-W-001", name_raw: "#TEST-W-001 : 【錢包小張】", label: "永和", joined_at: "2026-05-12", last_visit_at: "", wallet_balance: "500" },
+  { external_id: "TEST-W-002", name_raw: "#TEST-W-002 : 【沒儲值】",   label: "—",    joined_at: "2026-05-12", last_visit_at: "", wallet_balance: "0" },
+  { external_id: "TEST-W-003", name_raw: "#TEST-W-003 : 【千元儲值】", label: "平鎮", joined_at: "2026-05-12", last_visit_at: "", wallet_balance: "1,000" },
+  { external_id: "TEST-W-004", name_raw: "#TEST-W-004 : 【負數壞值】", label: "",     joined_at: "2026-05-12", last_visit_at: "", wallet_balance: "-50" },
+  { external_id: "TEST-W-005", name_raw: "#TEST-W-005 : 【亂值】",     label: "",     joined_at: "2026-05-12", last_visit_at: "", wallet_balance: "abc" },
+];
+
+const { data: stageOut, error: e1 } = await sb.rpc("rpc_stage_member_import", {
+  p_batch_id: bid, p_source: "lele", p_rows: rows, p_row_offset: 0,
+});
+if (e1) { console.error("stage err", e1); process.exit(1); }
+console.log("stage:", stageOut);
+
+const { data: staged } = await sb.from("member_imports")
+  .select("row_index, parsed_external_id, parsed_name, parsed_wallet_balance, validation_status, validation_errors")
+  .eq("batch_id", bid).order("row_index");
+for (const r of staged) {
+  console.log(`  #${r.row_index} ${r.validation_status.padEnd(20)} ext=${r.parsed_external_id} wallet=${r.parsed_wallet_balance ?? "—"} errs=${JSON.stringify(r.validation_errors)}`);
+}
+
+const { data: commitOut, error: e2 } = await sb.rpc("rpc_commit_member_import", { p_batch_id: bid, p_limit: 500 });
+if (e2) { console.error("commit err", e2); process.exit(1); }
+console.log("\ncommit:", commitOut);
+
+// 查 wallet_ledger + wallet_balances
+const { data: created } = await sb.from("members")
+  .select("id, member_no, external_id, name")
+  .eq("external_source", "lele")
+  .in("external_id", rows.map(r => r.external_id));
+console.log(`\nnew members (${created.length}):`);
+for (const m of created) console.log(`  ${m.member_no} ext=${m.external_id} ${m.name}`);
+
+const ids = created.map(m => m.id);
+const { data: ledger } = await sb.from("wallet_ledger")
+  .select("member_id, change, balance_after, type, source_type, reason")
+  .in("member_id", ids);
+console.log(`\nwallet_ledger entries (${ledger.length}):`);
+for (const l of ledger) console.log(`  member#${l.member_id} change=${l.change} bal=${l.balance_after} type=${l.type} src=${l.source_type} reason=${l.reason}`);
+
+const { data: bals } = await sb.from("wallet_balances")
+  .select("member_id, balance, version")
+  .in("member_id", ids);
+console.log(`\nwallet_balances (${bals.length}):`);
+for (const b of bals) console.log(`  member#${b.member_id} balance=${b.balance} v=${b.version}`);
+
+await sb.rpc("rpc_cancel_member_import", { p_batch_id: bid });
+console.log("\n✓ done");

--- a/scripts/test-member-import.mjs
+++ b/scripts/test-member-import.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// One-shot integration test for rpc_stage / commit / cancel _member_import
+// Uses ADMIN_EMAIL / ADMIN_PASSWORD from apps/admin/.env.local
+//
+// Run:  node scripts/test-member-import.mjs
+
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import Papa from "papaparse";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ENV = Object.fromEntries(
+  readFileSync(resolve(__dirname, "../apps/admin/.env.local"), "utf8")
+    .split(/\r?\n/)
+    .filter((l) => l && !l.startsWith("#"))
+    .map((l) => l.split("=").map((s, i, a) => (i === 0 ? s.trim() : a.slice(1).join("=").trim()))),
+);
+
+const URL  = ENV.NEXT_PUBLIC_SUPABASE_URL;
+const ANON = ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const EMAIL = ENV.ADMIN_EMAIL;
+const PASSWORD = ENV.ADMIN_PASSWORD;
+if (!URL || !ANON || !EMAIL || !PASSWORD) {
+  console.error("Missing env"); process.exit(1);
+}
+
+const sb = createClient(URL, ANON, { auth: { persistSession: false } });
+
+const { error: signErr } = await sb.auth.signInWithPassword({ email: EMAIL, password: PASSWORD });
+if (signErr) { console.error("login fail", signErr); process.exit(1); }
+console.log("✓ logged in as", EMAIL);
+
+// 取實際樂樂 CSV 前 N 筆
+const N = Number(process.argv[2] ?? 20);
+const csvPath = "C:/Users/Alex/Downloads/顧客管理-樂樂團購訂單管理系統.csv";
+const csvText = readFileSync(csvPath, "utf8");
+const parsed = Papa.parse(csvText, { skipEmptyLines: true });
+const allRows = parsed.data;
+const header = allRows[0];
+const idx = {
+  external_id:   header.findIndex((c) => c?.trim() === "顧客代號"),
+  name_raw:      header.findIndex((c) => c?.trim() === "名字"),
+  label:         header.findIndex((c) => c?.trim() === "標籤"),
+  joined_at:     header.findIndex((c) => c?.trim() === "加入日期"),
+  last_visit_at: header.findIndex((c) => c?.trim() === "最後登入"),
+};
+console.log("header idx:", idx);
+
+const rows = [];
+for (let i = 1; i < allRows.length && rows.length < N; i++) {
+  const r = allRows[i];
+  const externalId = (r[idx.external_id] ?? "").trim();
+  if (!externalId) continue;
+  rows.push({
+    external_id: externalId,
+    name_raw: r[idx.name_raw] ?? "",
+    label: r[idx.label] ?? "",
+    joined_at: r[idx.joined_at] ?? "",
+    last_visit_at: r[idx.last_visit_at] ?? "",
+  });
+}
+console.log(`✓ parsed ${rows.length} rows from CSV`);
+console.log("sample rows:", JSON.stringify(rows.slice(0, 3), null, 2));
+
+// 加幾個 edge case row
+const batchId = `test_${Date.now()}`;
+const testRows = [
+  ...rows,
+  // duplicate within batch (same external_id as row 0)
+  { ...rows[0], name_raw: rows[0].name_raw + " (dup)" },
+  // missing external_id
+  { external_id: "", name_raw: "#x : 【缺代號】", label: "永和", joined_at: "", last_visit_at: "" },
+  // name regex fail
+  { external_id: "99999991", name_raw: "亂寫格式", label: "—", joined_at: "", last_visit_at: "" },
+  // label ambiguous (平鎮 → 多 store)
+  { external_id: "99999992", name_raw: "#99999992 : 【模糊店】", label: "平鎮", joined_at: "2026-05-01", last_visit_at: "—" },
+];
+
+console.log(`\n=== stage batch ${batchId} with ${testRows.length} rows ===`);
+const { data: stageData, error: stageErr } = await sb.rpc("rpc_stage_member_import", {
+  p_batch_id: batchId,
+  p_source: "lele",
+  p_rows: testRows,
+});
+if (stageErr) { console.error("stage error:", stageErr); process.exit(1); }
+console.log("stage result:", stageData);
+
+// 從 staging 抓回所有 row
+const { data: staged, error: readErr } = await sb
+  .from("member_imports")
+  .select("row_index, parsed_external_id, parsed_name, parsed_name_suffix, parsed_takeout_store_name_hint, parsed_home_store_id, parsed_joined_at, validation_status, validation_errors, resolved_member_id")
+  .eq("batch_id", batchId)
+  .order("row_index");
+if (readErr) { console.error("read error:", readErr); process.exit(1); }
+console.log(`\n=== staged rows (${staged.length}) ===`);
+for (const r of staged) {
+  console.log(
+    `#${String(r.row_index).padStart(3)} ${r.validation_status.padEnd(20)} ext=${r.parsed_external_id ?? "—"}  name=${r.parsed_name ?? "—"}  hint=${r.parsed_takeout_store_name_hint ?? "—"}  store=${r.parsed_home_store_id ?? "—"}  suffix=${r.parsed_name_suffix ?? "—"}  errs=${JSON.stringify(r.validation_errors)}`
+  );
+}
+
+// commit
+console.log(`\n=== commit ===`);
+const { data: commitData, error: commitErr } = await sb.rpc("rpc_commit_member_import", { p_batch_id: batchId });
+if (commitErr) { console.error("commit error:", commitErr); process.exit(1); }
+console.log("commit result:", commitData);
+
+// 驗證 members 新增
+const { data: newMembers, error: mErr } = await sb
+  .from("members")
+  .select("id, member_no, external_source, external_id, name, takeout_store_name_hint, home_store_id, status, joined_at")
+  .in("external_id", testRows.map((r) => r.external_id).filter(Boolean))
+  .eq("external_source", "lele");
+if (mErr) { console.error("members read error:", mErr); process.exit(1); }
+console.log(`\n=== members with these external_id (${newMembers.length}) ===`);
+for (const m of newMembers) {
+  console.log(`  ${m.member_no} ext=${m.external_id} name=${m.name} hint=${m.takeout_store_name_hint ?? "—"} store=${m.home_store_id ?? "—"}`);
+}
+
+// cancel (清掉 staging 殘餘 non-committed row)
+const { data: cancelData } = await sb.rpc("rpc_cancel_member_import", { p_batch_id: batchId });
+console.log("\ncancel result:", cancelData);
+
+console.log("\n✓ test complete");

--- a/supabase/migrations/20260613000010_member_import.sql
+++ b/supabase/migrations/20260613000010_member_import.sql
@@ -1,0 +1,446 @@
+-- ============================================================
+-- Member Import (樂樂顧客 CSV → staging → commit)
+-- PRD:  docs/PRD-會員模組.md
+-- TEST: docs/TEST-member-import.md
+-- 來源：樂樂團購訂單管理系統「顧客管理」匯出 CSV
+--   主要 dedupe key：external_id（樂樂顧客代號）+ external_source='lele'
+--   樂樂 CSV 不含 phone / birthday / email，全留 NULL
+-- ============================================================
+
+-- ============================================================
+-- 1. ALTER members: 加 external_source + unique partial index
+-- ============================================================
+ALTER TABLE members
+  ADD COLUMN IF NOT EXISTS external_source TEXT
+    CHECK (external_source IS NULL OR external_source IN (
+      'lele','pinduoduo','1688','line_community','manual'
+    ));
+
+COMMENT ON COLUMN members.external_source IS
+  '外部來源系統；與 external_id 一起構成 dedupe key（樂樂/PDD/1688 等）';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_members_tenant_extsrc_extid
+  ON members (tenant_id, external_source, external_id)
+  WHERE external_id IS NOT NULL;
+
+-- ============================================================
+-- 2. CREATE TABLE: member_imports (staging)
+-- ============================================================
+CREATE TABLE member_imports (
+  id                              BIGSERIAL PRIMARY KEY,
+  tenant_id                       UUID NOT NULL,
+  batch_id                        TEXT NOT NULL,
+  row_index                       INTEGER NOT NULL,
+  source                          TEXT NOT NULL DEFAULT 'lele'
+                                    CHECK (source IN ('lele','pinduoduo','1688','manual')),
+  raw_data                        JSONB NOT NULL,
+
+  parsed_external_id              TEXT,
+  parsed_name                     TEXT,
+  parsed_name_suffix              TEXT,
+  parsed_takeout_store_name_hint  TEXT,
+  parsed_home_store_id            BIGINT REFERENCES stores(id),
+  parsed_joined_at                TIMESTAMPTZ,
+  parsed_last_visit_at            TIMESTAMPTZ,
+  parsed_notes                    TEXT,
+
+  validation_status               TEXT NOT NULL DEFAULT 'pending' CHECK (
+                                    validation_status IN (
+                                      'pending','ok','duplicate_existing','duplicate_in_batch',
+                                      'error','committed','cancelled','error_at_commit'
+                                    )),
+  validation_errors               JSONB NOT NULL DEFAULT '[]'::jsonb,
+  resolved_member_id              BIGINT REFERENCES members(id) ON DELETE SET NULL,
+
+  created_by                      UUID,
+  updated_by                      UUID,
+  created_at                      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE (tenant_id, batch_id, row_index)
+);
+COMMENT ON TABLE member_imports IS
+  '會員匯入 staging（樂樂等 CSV 解析後逐 row 暫存，commit 後寫入 members）';
+
+CREATE INDEX idx_mi_batch  ON member_imports (tenant_id, batch_id);
+CREATE INDEX idx_mi_status ON member_imports (tenant_id, batch_id, validation_status);
+CREATE INDEX idx_mi_ext    ON member_imports (tenant_id, source, parsed_external_id)
+  WHERE parsed_external_id IS NOT NULL;
+
+CREATE TRIGGER trg_touch_member_imports BEFORE UPDATE ON member_imports
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+ALTER TABLE member_imports ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY mi_hq_all ON member_imports
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+
+CREATE POLICY auth_read_member_imports ON member_imports
+  FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid);
+
+-- ============================================================
+-- 3. HELPERS
+-- ============================================================
+
+-- 3.1 rpc_next_member_no: 'M' + lpad(max+1, 6, '0')
+CREATE OR REPLACE FUNCTION public.rpc_next_member_no()
+RETURNS TEXT LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_next   INT;
+BEGIN
+  SELECT COALESCE(MAX((SUBSTRING(member_no FROM '^M(\d+)$'))::INT), 0) + 1
+    INTO v_next
+    FROM members
+   WHERE tenant_id = v_tenant
+     AND member_no ~ '^M\d+$';
+  RETURN 'M' || lpad(v_next::text, 6, '0');
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_next_member_no TO authenticated;
+
+-- 3.2 _parse_lele_name: regex 抽「#代號 : 【名字】後綴」
+-- 回傳 JSONB { name, suffix }；match 不到則 name=原 trim 字串、suffix=null
+CREATE OR REPLACE FUNCTION public._parse_lele_name(p_raw TEXT)
+RETURNS JSONB LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+  v_match TEXT[];
+  v_name  TEXT;
+  v_suf   TEXT;
+BEGIN
+  IF p_raw IS NULL OR TRIM(p_raw) = '' THEN
+    RETURN jsonb_build_object('name', NULL, 'suffix', NULL);
+  END IF;
+
+  -- ^#(\d+)\s*[:：]\s*【(.+?)】\s*(.*)$
+  v_match := regexp_match(p_raw, '^#(\d+)\s*[:：]\s*【(.+?)】\s*(.*)$');
+  IF v_match IS NOT NULL THEN
+    v_name := TRIM(v_match[2]);
+    v_suf  := NULLIF(TRIM(v_match[3]), '');
+    RETURN jsonb_build_object('name', v_name, 'suffix', v_suf);
+  END IF;
+
+  RETURN jsonb_build_object('name', TRIM(p_raw), 'suffix', NULL);
+END;
+$$;
+
+-- 3.3 _resolve_takeout_store: 標籤 fuzzy match stores.name
+-- 回傳 store_id；多筆或無 match 都回 NULL
+CREATE OR REPLACE FUNCTION public._resolve_takeout_store(p_tenant UUID, p_hint TEXT)
+RETURNS BIGINT LANGUAGE plpgsql STABLE AS $$
+DECLARE
+  v_count INT;
+  v_id    BIGINT;
+BEGIN
+  IF p_hint IS NULL OR TRIM(p_hint) = '' OR p_hint = '—' THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT COUNT(*), MIN(id) INTO v_count, v_id
+    FROM stores
+   WHERE tenant_id = p_tenant
+     AND is_active = TRUE
+     AND (name ILIKE p_hint || '%' OR name = p_hint);
+
+  IF v_count = 1 THEN RETURN v_id; END IF;
+  RETURN NULL;
+END;
+$$;
+
+-- 3.4 _parse_lele_timestamp: '2026-05-12 18:59:33' / '—' / 空 → TIMESTAMPTZ
+CREATE OR REPLACE FUNCTION public._parse_lele_timestamp(p_raw TEXT)
+RETURNS TIMESTAMPTZ LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+  v_trim TEXT;
+BEGIN
+  v_trim := NULLIF(TRIM(p_raw), '');
+  IF v_trim IS NULL OR v_trim = '—' THEN RETURN NULL; END IF;
+  BEGIN
+    RETURN v_trim::TIMESTAMPTZ;
+  EXCEPTION WHEN OTHERS THEN
+    RETURN NULL;
+  END;
+END;
+$$;
+
+-- ============================================================
+-- 4. RPC: rpc_stage_member_import
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.rpc_stage_member_import(
+  p_batch_id TEXT,
+  p_source   TEXT,
+  p_rows     JSONB
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant       UUID := public._current_tenant_id();
+  v_uid          UUID := auth.uid();
+  v_row          JSONB;
+  v_index        INT := 0;
+  v_total        INT := 0;
+  v_ok           INT := 0;
+  v_dup_in_batch INT := 0;
+  v_dup_existing INT := 0;
+  v_errors       INT := 0;
+
+  v_external_id  TEXT;
+  v_name_raw     TEXT;
+  v_name_parsed  JSONB;
+  v_name         TEXT;
+  v_name_suffix  TEXT;
+  v_label        TEXT;
+  v_hint         TEXT;
+  v_home_store   BIGINT;
+  v_joined_at    TIMESTAMPTZ;
+  v_last_at      TIMESTAMPTZ;
+  v_errs         JSONB;
+  v_status       TEXT;
+  v_existing_id  BIGINT;
+  v_store_count  INT;
+BEGIN
+  IF p_rows IS NULL OR jsonb_typeof(p_rows) <> 'array' THEN
+    RAISE EXCEPTION 'p_rows must be jsonb array';
+  END IF;
+  IF p_source IS NULL OR p_source NOT IN ('lele','pinduoduo','1688','manual') THEN
+    RAISE EXCEPTION 'invalid source: %', p_source;
+  END IF;
+
+  -- 同 batch_id 多次 stage：允許累加（不像會員 phone-dedupe 那麼嚴），跳過已存在 row_index
+  -- 這裡採「整批一次傳」設計，所以若已 stage 過直接報錯
+  IF EXISTS (
+    SELECT 1 FROM member_imports
+     WHERE tenant_id = v_tenant AND batch_id = p_batch_id
+  ) THEN
+    RAISE EXCEPTION 'batch % already staged; use rpc_cancel_member_import first', p_batch_id;
+  END IF;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_rows) LOOP
+    v_index := v_index + 1;
+    v_total := v_total + 1;
+    -- reset per-row
+    v_errs        := '[]'::jsonb;
+    v_external_id := NULLIF(TRIM(v_row->>'external_id'), '');
+    v_name_raw    := v_row->>'name_raw';
+    v_label       := NULLIF(TRIM(v_row->>'label'), '');
+    v_name        := NULL;
+    v_name_suffix := NULL;
+    v_hint        := NULL;
+    v_home_store  := NULL;
+    v_joined_at   := NULL;
+    v_last_at     := NULL;
+    v_status      := NULL;
+    v_existing_id := NULL;
+
+    -- external_id 必填
+    IF v_external_id IS NULL THEN
+      v_errs := v_errs || jsonb_build_array(jsonb_build_object('field','external_id','code','required'));
+    END IF;
+
+    -- 名字 regex 解析
+    v_name_parsed := public._parse_lele_name(v_name_raw);
+    v_name        := v_name_parsed->>'name';
+    v_name_suffix := v_name_parsed->>'suffix';
+
+    IF v_name IS NULL OR v_name = '' THEN
+      v_errs := v_errs || jsonb_build_array(jsonb_build_object('field','name','code','required'));
+    END IF;
+
+    -- 標籤 → hint + home_store fuzzy match
+    IF v_label IS NOT NULL AND v_label <> '—' THEN
+      v_hint := v_label;
+      -- 多筆 match 偵測
+      SELECT COUNT(*) INTO v_store_count
+        FROM stores
+       WHERE tenant_id = v_tenant
+         AND is_active = TRUE
+         AND (name ILIKE v_label || '%' OR name = v_label);
+      IF v_store_count = 1 THEN
+        v_home_store := public._resolve_takeout_store(v_tenant, v_label);
+      ELSIF v_store_count > 1 THEN
+        v_errs := v_errs || jsonb_build_array(jsonb_build_object(
+          'field','label','code','store_ambiguous','value',v_label
+        ));
+      END IF;
+    END IF;
+
+    -- 時間 parse
+    v_joined_at := public._parse_lele_timestamp(v_row->>'joined_at');
+    v_last_at   := public._parse_lele_timestamp(v_row->>'last_visit_at');
+
+    -- 決定 status（warning 不算 error）
+    IF EXISTS (
+      SELECT 1 FROM jsonb_array_elements(v_errs) AS x
+       WHERE x->>'code' IN ('required','invalid_format','invalid_value')
+    ) THEN
+      v_status := 'error';
+      v_errors := v_errors + 1;
+    ELSE
+      -- batch 內 dedupe
+      IF v_external_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM member_imports
+         WHERE tenant_id = v_tenant
+           AND batch_id = p_batch_id
+           AND source = p_source
+           AND parsed_external_id = v_external_id
+      ) THEN
+        v_status := 'duplicate_in_batch';
+        v_dup_in_batch := v_dup_in_batch + 1;
+      ELSE
+        -- DB 內 dedupe
+        IF v_external_id IS NOT NULL THEN
+          SELECT id INTO v_existing_id
+            FROM members
+           WHERE tenant_id = v_tenant
+             AND external_source = p_source
+             AND external_id = v_external_id
+             AND status NOT IN ('deleted','merged')
+           LIMIT 1;
+        END IF;
+        IF v_existing_id IS NOT NULL THEN
+          v_status := 'duplicate_existing';
+          v_dup_existing := v_dup_existing + 1;
+        ELSE
+          v_status := 'ok';
+          v_ok := v_ok + 1;
+        END IF;
+      END IF;
+    END IF;
+
+    INSERT INTO member_imports (
+      tenant_id, batch_id, row_index, source, raw_data,
+      parsed_external_id, parsed_name, parsed_name_suffix,
+      parsed_takeout_store_name_hint, parsed_home_store_id,
+      parsed_joined_at, parsed_last_visit_at, parsed_notes,
+      validation_status, validation_errors, resolved_member_id,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, p_batch_id, v_index, p_source, v_row,
+      v_external_id, v_name, v_name_suffix,
+      v_hint, v_home_store,
+      v_joined_at, v_last_at, v_name_suffix,
+      v_status, v_errs, v_existing_id,
+      v_uid, v_uid
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'batch_id', p_batch_id,
+    'source', p_source,
+    'total', v_total,
+    'ok', v_ok,
+    'duplicate_in_batch', v_dup_in_batch,
+    'duplicate_existing', v_dup_existing,
+    'errors', v_errors
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_stage_member_import TO authenticated;
+
+-- ============================================================
+-- 5. RPC: rpc_commit_member_import
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.rpc_commit_member_import(
+  p_batch_id TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  v_uid        UUID := auth.uid();
+  v_row        member_imports%ROWTYPE;
+  v_committed  INT := 0;
+  v_skipped    INT := 0;
+  v_member_no  TEXT;
+  v_new_id     BIGINT;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM member_imports
+     WHERE tenant_id = v_tenant AND batch_id = p_batch_id
+  ) THEN
+    RAISE EXCEPTION 'batch % not found', p_batch_id;
+  END IF;
+
+  FOR v_row IN
+    SELECT * FROM member_imports
+     WHERE tenant_id = v_tenant
+       AND batch_id  = p_batch_id
+       AND validation_status = 'ok'
+     ORDER BY row_index FOR UPDATE
+  LOOP
+    v_member_no := public.rpc_next_member_no();
+
+    BEGIN
+      INSERT INTO members (
+        tenant_id, member_no,
+        external_source, external_id,
+        name, status,
+        takeout_store_name_hint, home_store_id,
+        joined_at, last_visit_at, notes,
+        created_by, updated_by
+      ) VALUES (
+        v_tenant, v_member_no,
+        v_row.source, v_row.parsed_external_id,
+        v_row.parsed_name, 'active',
+        v_row.parsed_takeout_store_name_hint, v_row.parsed_home_store_id,
+        COALESCE(v_row.parsed_joined_at, NOW()),
+        v_row.parsed_last_visit_at,
+        v_row.parsed_notes,
+        v_uid, v_uid
+      ) RETURNING id INTO v_new_id;
+
+      UPDATE member_imports
+         SET validation_status  = 'committed',
+             resolved_member_id = v_new_id,
+             updated_by         = v_uid
+       WHERE id = v_row.id;
+
+      v_committed := v_committed + 1;
+    EXCEPTION
+      WHEN unique_violation THEN
+        UPDATE member_imports
+           SET validation_status = 'error_at_commit',
+               validation_errors = validation_errors || jsonb_build_array(
+                 jsonb_build_object('field','commit','code','unique_violation','message',SQLERRM)
+               ),
+               updated_by = v_uid
+         WHERE id = v_row.id;
+        v_skipped := v_skipped + 1;
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'batch_id',  p_batch_id,
+    'committed', v_committed,
+    'skipped',   v_skipped
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_commit_member_import TO authenticated;
+
+-- ============================================================
+-- 6. RPC: rpc_cancel_member_import
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.rpc_cancel_member_import(
+  p_batch_id TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant   UUID := public._current_tenant_id();
+  v_affected INT;
+BEGIN
+  UPDATE member_imports
+     SET validation_status = 'cancelled',
+         updated_by        = auth.uid()
+   WHERE tenant_id = v_tenant
+     AND batch_id  = p_batch_id
+     AND validation_status NOT IN ('committed','cancelled');
+  GET DIAGNOSTICS v_affected = ROW_COUNT;
+  RETURN jsonb_build_object('batch_id', p_batch_id, 'cancelled', v_affected);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_cancel_member_import TO authenticated;

--- a/supabase/migrations/20260613000020_member_import_next_no_fix.sql
+++ b/supabase/migrations/20260613000020_member_import_next_no_fix.sql
@@ -1,0 +1,21 @@
+-- ============================================================
+-- Fix: rpc_next_member_no INT overflow when DB has legacy
+-- member_no like 'M20260511150125485' (17-digit timestamp form).
+-- Constrain regex to M + 1~9 digits so timestamp-form 編號 are
+-- ignored as not part of the auto sequence.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_next_member_no()
+RETURNS TEXT LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_next   INT;
+BEGIN
+  SELECT COALESCE(MAX((SUBSTRING(member_no FROM '^M(\d{1,9})$'))::INT), 0) + 1
+    INTO v_next
+    FROM members
+   WHERE tenant_id = v_tenant
+     AND member_no ~ '^M\d{1,9}$';
+  RETURN 'M' || lpad(v_next::text, 6, '0');
+END;
+$$;

--- a/supabase/migrations/20260613000030_member_import_auto_create_store.sql
+++ b/supabase/migrations/20260613000030_member_import_auto_create_store.sql
@@ -1,0 +1,213 @@
+-- ============================================================
+-- Member Import: 取貨店標籤找不到時自動建 store
+-- 規則：標籤「永和」→ 找 stores name='永和店' (優先) 或 '永和' → 找不到就建「永和店」
+-- code 用 LELE-{hint}；衝突時 append timestamp suffix
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public._resolve_or_create_takeout_store(
+  p_tenant UUID,
+  p_hint   TEXT,
+  p_uid    UUID
+) RETURNS BIGINT LANGUAGE plpgsql AS $$
+DECLARE
+  v_id    BIGINT;
+  v_count INT;
+  v_code  TEXT;
+  v_name  TEXT;
+BEGIN
+  IF p_hint IS NULL OR TRIM(p_hint) = '' OR p_hint = '—' THEN
+    RETURN NULL;
+  END IF;
+
+  -- 1) 精確 match：name = hint+'店' 或 name = hint
+  SELECT id INTO v_id
+    FROM stores
+   WHERE tenant_id = p_tenant
+     AND is_active = TRUE
+     AND name IN (p_hint || '店', p_hint)
+   LIMIT 1;
+  IF v_id IS NOT NULL THEN RETURN v_id; END IF;
+
+  -- 2) 模糊 match：name LIKE 'hint%' 唯一
+  SELECT COUNT(*), MIN(id) INTO v_count, v_id
+    FROM stores
+   WHERE tenant_id = p_tenant
+     AND is_active = TRUE
+     AND name ILIKE p_hint || '%';
+  IF v_count = 1 THEN RETURN v_id; END IF;
+  -- v_count > 1 也走自動建，避免「平鎮」對到「平鎮舊店」+「平鎮新店」時卡住；
+  -- 反正自動建出來的「平鎮店」有獨立 LELE-平鎮 code，事後 admin 可手動合併
+
+  -- 3) 自動建：name = hint+'店'；code = 'LELE-'+hint (衝突 append seq)
+  v_name := p_hint || '店';
+  v_code := 'LELE-' || p_hint;
+  IF EXISTS (
+    SELECT 1 FROM stores WHERE tenant_id = p_tenant AND code = v_code
+  ) THEN
+    v_code := v_code || '-' || extract(epoch from now())::bigint::text;
+  END IF;
+
+  INSERT INTO stores (
+    tenant_id, code, name, is_active, notes,
+    created_by, updated_by
+  ) VALUES (
+    p_tenant, v_code, v_name, TRUE,
+    '(auto) 樂樂 CSV 匯入時依顧客「標籤=' || p_hint || '」自動建立',
+    p_uid, p_uid
+  ) RETURNING id INTO v_id;
+
+  RETURN v_id;
+END;
+$$;
+
+-- ============================================================
+-- 改 rpc_stage_member_import 改用 _resolve_or_create_takeout_store
+-- （取代既有「找不到唯一就只填 hint」邏輯）
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_stage_member_import(
+  p_batch_id TEXT,
+  p_source   TEXT,
+  p_rows     JSONB
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant       UUID := public._current_tenant_id();
+  v_uid          UUID := auth.uid();
+  v_row          JSONB;
+  v_index        INT := 0;
+  v_total        INT := 0;
+  v_ok           INT := 0;
+  v_dup_in_batch INT := 0;
+  v_dup_existing INT := 0;
+  v_errors       INT := 0;
+
+  v_external_id  TEXT;
+  v_name_raw     TEXT;
+  v_name_parsed  JSONB;
+  v_name         TEXT;
+  v_name_suffix  TEXT;
+  v_label        TEXT;
+  v_hint         TEXT;
+  v_home_store   BIGINT;
+  v_joined_at    TIMESTAMPTZ;
+  v_last_at      TIMESTAMPTZ;
+  v_errs         JSONB;
+  v_status       TEXT;
+  v_existing_id  BIGINT;
+BEGIN
+  IF p_rows IS NULL OR jsonb_typeof(p_rows) <> 'array' THEN
+    RAISE EXCEPTION 'p_rows must be jsonb array';
+  END IF;
+  IF p_source IS NULL OR p_source NOT IN ('lele','pinduoduo','1688','manual') THEN
+    RAISE EXCEPTION 'invalid source: %', p_source;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM member_imports
+     WHERE tenant_id = v_tenant AND batch_id = p_batch_id
+  ) THEN
+    RAISE EXCEPTION 'batch % already staged; use rpc_cancel_member_import first', p_batch_id;
+  END IF;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_rows) LOOP
+    v_index := v_index + 1;
+    v_total := v_total + 1;
+    v_errs        := '[]'::jsonb;
+    v_external_id := NULLIF(TRIM(v_row->>'external_id'), '');
+    v_name_raw    := v_row->>'name_raw';
+    v_label       := NULLIF(TRIM(v_row->>'label'), '');
+    v_name        := NULL;
+    v_name_suffix := NULL;
+    v_hint        := NULL;
+    v_home_store  := NULL;
+    v_joined_at   := NULL;
+    v_last_at     := NULL;
+    v_status      := NULL;
+    v_existing_id := NULL;
+
+    IF v_external_id IS NULL THEN
+      v_errs := v_errs || jsonb_build_array(jsonb_build_object('field','external_id','code','required'));
+    END IF;
+
+    v_name_parsed := public._parse_lele_name(v_name_raw);
+    v_name        := v_name_parsed->>'name';
+    v_name_suffix := v_name_parsed->>'suffix';
+
+    IF v_name IS NULL OR v_name = '' THEN
+      v_errs := v_errs || jsonb_build_array(jsonb_build_object('field','name','code','required'));
+    END IF;
+
+    -- 標籤 → hint + home_store（找不到就自動建）
+    IF v_label IS NOT NULL AND v_label <> '—' THEN
+      v_hint := v_label;
+      v_home_store := public._resolve_or_create_takeout_store(v_tenant, v_label, v_uid);
+    END IF;
+
+    v_joined_at := public._parse_lele_timestamp(v_row->>'joined_at');
+    v_last_at   := public._parse_lele_timestamp(v_row->>'last_visit_at');
+
+    IF EXISTS (
+      SELECT 1 FROM jsonb_array_elements(v_errs) AS x
+       WHERE x->>'code' IN ('required','invalid_format','invalid_value')
+    ) THEN
+      v_status := 'error';
+      v_errors := v_errors + 1;
+    ELSE
+      IF v_external_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM member_imports
+         WHERE tenant_id = v_tenant
+           AND batch_id = p_batch_id
+           AND source = p_source
+           AND parsed_external_id = v_external_id
+      ) THEN
+        v_status := 'duplicate_in_batch';
+        v_dup_in_batch := v_dup_in_batch + 1;
+      ELSE
+        IF v_external_id IS NOT NULL THEN
+          SELECT id INTO v_existing_id
+            FROM members
+           WHERE tenant_id = v_tenant
+             AND external_source = p_source
+             AND external_id = v_external_id
+             AND status NOT IN ('deleted','merged')
+           LIMIT 1;
+        END IF;
+        IF v_existing_id IS NOT NULL THEN
+          v_status := 'duplicate_existing';
+          v_dup_existing := v_dup_existing + 1;
+        ELSE
+          v_status := 'ok';
+          v_ok := v_ok + 1;
+        END IF;
+      END IF;
+    END IF;
+
+    INSERT INTO member_imports (
+      tenant_id, batch_id, row_index, source, raw_data,
+      parsed_external_id, parsed_name, parsed_name_suffix,
+      parsed_takeout_store_name_hint, parsed_home_store_id,
+      parsed_joined_at, parsed_last_visit_at, parsed_notes,
+      validation_status, validation_errors, resolved_member_id,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, p_batch_id, v_index, p_source, v_row,
+      v_external_id, v_name, v_name_suffix,
+      v_hint, v_home_store,
+      v_joined_at, v_last_at, v_name_suffix,
+      v_status, v_errs, v_existing_id,
+      v_uid, v_uid
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'batch_id', p_batch_id,
+    'source', p_source,
+    'total', v_total,
+    'ok', v_ok,
+    'duplicate_in_batch', v_dup_in_batch,
+    'duplicate_existing', v_dup_existing,
+    'errors', v_errors
+  );
+END;
+$$;

--- a/supabase/migrations/20260613000040_member_import_chunked_stage.sql
+++ b/supabase/migrations/20260613000040_member_import_chunked_stage.sql
@@ -1,0 +1,230 @@
+-- ============================================================
+-- Member Import: stage 改支援 chunked 累加（避免 statement timeout）
+-- 加 p_row_offset 參數；移除「already staged 就 RAISE」邏輯
+-- INSERT 改 ON CONFLICT DO NOTHING（idempotent 重試安全）
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- rpc_commit_member_import 加 p_limit 支援分批 commit
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_commit_member_import(
+  p_batch_id TEXT,
+  p_limit    INT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  v_uid        UUID := auth.uid();
+  v_row        member_imports%ROWTYPE;
+  v_committed  INT := 0;
+  v_skipped    INT := 0;
+  v_member_no  TEXT;
+  v_new_id     BIGINT;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM member_imports
+     WHERE tenant_id = v_tenant AND batch_id = p_batch_id
+  ) THEN
+    RAISE EXCEPTION 'batch % not found', p_batch_id;
+  END IF;
+
+  FOR v_row IN
+    SELECT * FROM member_imports
+     WHERE tenant_id = v_tenant
+       AND batch_id  = p_batch_id
+       AND validation_status = 'ok'
+     ORDER BY row_index FOR UPDATE
+     LIMIT COALESCE(p_limit, 2147483647)
+  LOOP
+    v_member_no := public.rpc_next_member_no();
+
+    BEGIN
+      INSERT INTO members (
+        tenant_id, member_no,
+        external_source, external_id,
+        name, status,
+        takeout_store_name_hint, home_store_id,
+        joined_at, last_visit_at, notes,
+        created_by, updated_by
+      ) VALUES (
+        v_tenant, v_member_no,
+        v_row.source, v_row.parsed_external_id,
+        v_row.parsed_name, 'active',
+        v_row.parsed_takeout_store_name_hint, v_row.parsed_home_store_id,
+        COALESCE(v_row.parsed_joined_at, NOW()),
+        v_row.parsed_last_visit_at,
+        v_row.parsed_notes,
+        v_uid, v_uid
+      ) RETURNING id INTO v_new_id;
+
+      UPDATE member_imports
+         SET validation_status  = 'committed',
+             resolved_member_id = v_new_id,
+             updated_by         = v_uid
+       WHERE id = v_row.id;
+
+      v_committed := v_committed + 1;
+    EXCEPTION
+      WHEN unique_violation THEN
+        UPDATE member_imports
+           SET validation_status = 'error_at_commit',
+               validation_errors = validation_errors || jsonb_build_array(
+                 jsonb_build_object('field','commit','code','unique_violation','message',SQLERRM)
+               ),
+               updated_by = v_uid
+         WHERE id = v_row.id;
+        v_skipped := v_skipped + 1;
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'batch_id',  p_batch_id,
+    'committed', v_committed,
+    'skipped',   v_skipped
+  );
+END;
+$$;
+
+-- ------------------------------------------------------------
+-- rpc_stage_member_import 加 p_row_offset 支援 chunked stage
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_stage_member_import(
+  p_batch_id   TEXT,
+  p_source     TEXT,
+  p_rows       JSONB,
+  p_row_offset INT DEFAULT 0
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant       UUID := public._current_tenant_id();
+  v_uid          UUID := auth.uid();
+  v_row          JSONB;
+  v_index        INT := p_row_offset;
+  v_total        INT := 0;
+  v_ok           INT := 0;
+  v_dup_in_batch INT := 0;
+  v_dup_existing INT := 0;
+  v_errors       INT := 0;
+
+  v_external_id  TEXT;
+  v_name_raw     TEXT;
+  v_name_parsed  JSONB;
+  v_name         TEXT;
+  v_name_suffix  TEXT;
+  v_label        TEXT;
+  v_hint         TEXT;
+  v_home_store   BIGINT;
+  v_joined_at    TIMESTAMPTZ;
+  v_last_at      TIMESTAMPTZ;
+  v_errs         JSONB;
+  v_status       TEXT;
+  v_existing_id  BIGINT;
+BEGIN
+  IF p_rows IS NULL OR jsonb_typeof(p_rows) <> 'array' THEN
+    RAISE EXCEPTION 'p_rows must be jsonb array';
+  END IF;
+  IF p_source IS NULL OR p_source NOT IN ('lele','pinduoduo','1688','manual') THEN
+    RAISE EXCEPTION 'invalid source: %', p_source;
+  END IF;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_rows) LOOP
+    v_index := v_index + 1;
+    v_total := v_total + 1;
+    v_errs        := '[]'::jsonb;
+    v_external_id := NULLIF(TRIM(v_row->>'external_id'), '');
+    v_name_raw    := v_row->>'name_raw';
+    v_label       := NULLIF(TRIM(v_row->>'label'), '');
+    v_name        := NULL;
+    v_name_suffix := NULL;
+    v_hint        := NULL;
+    v_home_store  := NULL;
+    v_joined_at   := NULL;
+    v_last_at     := NULL;
+    v_status      := NULL;
+    v_existing_id := NULL;
+
+    IF v_external_id IS NULL THEN
+      v_errs := v_errs || jsonb_build_array(jsonb_build_object('field','external_id','code','required'));
+    END IF;
+
+    v_name_parsed := public._parse_lele_name(v_name_raw);
+    v_name        := v_name_parsed->>'name';
+    v_name_suffix := v_name_parsed->>'suffix';
+
+    IF v_name IS NULL OR v_name = '' THEN
+      v_errs := v_errs || jsonb_build_array(jsonb_build_object('field','name','code','required'));
+    END IF;
+
+    IF v_label IS NOT NULL AND v_label <> '—' THEN
+      v_hint := v_label;
+      v_home_store := public._resolve_or_create_takeout_store(v_tenant, v_label, v_uid);
+    END IF;
+
+    v_joined_at := public._parse_lele_timestamp(v_row->>'joined_at');
+    v_last_at   := public._parse_lele_timestamp(v_row->>'last_visit_at');
+
+    IF EXISTS (
+      SELECT 1 FROM jsonb_array_elements(v_errs) AS x
+       WHERE x->>'code' IN ('required','invalid_format','invalid_value')
+    ) THEN
+      v_status := 'error';
+      v_errors := v_errors + 1;
+    ELSE
+      IF v_external_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM member_imports
+         WHERE tenant_id = v_tenant
+           AND batch_id = p_batch_id
+           AND source = p_source
+           AND parsed_external_id = v_external_id
+      ) THEN
+        v_status := 'duplicate_in_batch';
+        v_dup_in_batch := v_dup_in_batch + 1;
+      ELSE
+        IF v_external_id IS NOT NULL THEN
+          SELECT id INTO v_existing_id
+            FROM members
+           WHERE tenant_id = v_tenant
+             AND external_source = p_source
+             AND external_id = v_external_id
+             AND status NOT IN ('deleted','merged')
+           LIMIT 1;
+        END IF;
+        IF v_existing_id IS NOT NULL THEN
+          v_status := 'duplicate_existing';
+          v_dup_existing := v_dup_existing + 1;
+        ELSE
+          v_status := 'ok';
+          v_ok := v_ok + 1;
+        END IF;
+      END IF;
+    END IF;
+
+    INSERT INTO member_imports (
+      tenant_id, batch_id, row_index, source, raw_data,
+      parsed_external_id, parsed_name, parsed_name_suffix,
+      parsed_takeout_store_name_hint, parsed_home_store_id,
+      parsed_joined_at, parsed_last_visit_at, parsed_notes,
+      validation_status, validation_errors, resolved_member_id,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, p_batch_id, v_index, p_source, v_row,
+      v_external_id, v_name, v_name_suffix,
+      v_hint, v_home_store,
+      v_joined_at, v_last_at, v_name_suffix,
+      v_status, v_errs, v_existing_id,
+      v_uid, v_uid
+    )
+    ON CONFLICT (tenant_id, batch_id, row_index) DO NOTHING;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'batch_id', p_batch_id,
+    'source', p_source,
+    'chunk_total', v_total,
+    'chunk_ok', v_ok,
+    'chunk_duplicate_in_batch', v_dup_in_batch,
+    'chunk_duplicate_existing', v_dup_existing,
+    'chunk_errors', v_errors
+  );
+END;
+$$;

--- a/supabase/migrations/20260613000050_member_import_drop_old_overloads.sql
+++ b/supabase/migrations/20260613000050_member_import_drop_old_overloads.sql
@@ -1,0 +1,102 @@
+-- ============================================================
+-- Drop 舊版 rpc_stage_member_import / rpc_commit_member_import overloads
+-- 之前 CREATE OR REPLACE 加新參數時不會 replace、只會 overload，
+-- 導致 PostgREST 收到沒帶新參數的 body 時 match 到舊版（無 LIMIT、會 timeout）。
+-- ============================================================
+
+-- stage 舊版：(p_batch_id TEXT, p_source TEXT, p_rows JSONB)
+DROP FUNCTION IF EXISTS public.rpc_stage_member_import(TEXT, TEXT, JSONB);
+
+-- commit 舊版：(p_batch_id TEXT)
+DROP FUNCTION IF EXISTS public.rpc_commit_member_import(TEXT);
+
+-- ============================================================
+-- commit RPC default p_limit 從 NULL 改 500，client 若忘了帶也不會跑全部 → timeout
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.rpc_commit_member_import(
+  p_batch_id TEXT,
+  p_limit    INT DEFAULT 500
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  v_uid        UUID := auth.uid();
+  v_row        member_imports%ROWTYPE;
+  v_committed  INT := 0;
+  v_skipped    INT := 0;
+  v_member_no  TEXT;
+  v_new_id     BIGINT;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM member_imports
+     WHERE tenant_id = v_tenant AND batch_id = p_batch_id
+  ) THEN
+    RAISE EXCEPTION 'batch % not found', p_batch_id;
+  END IF;
+
+  FOR v_row IN
+    SELECT * FROM member_imports
+     WHERE tenant_id = v_tenant
+       AND batch_id  = p_batch_id
+       AND validation_status = 'ok'
+     ORDER BY row_index FOR UPDATE
+     LIMIT COALESCE(p_limit, 500)
+  LOOP
+    v_member_no := public.rpc_next_member_no();
+
+    BEGIN
+      INSERT INTO members (
+        tenant_id, member_no,
+        external_source, external_id,
+        name, status,
+        takeout_store_name_hint, home_store_id,
+        joined_at, last_visit_at, notes,
+        created_by, updated_by
+      ) VALUES (
+        v_tenant, v_member_no,
+        v_row.source, v_row.parsed_external_id,
+        v_row.parsed_name, 'active',
+        v_row.parsed_takeout_store_name_hint, v_row.parsed_home_store_id,
+        COALESCE(v_row.parsed_joined_at, NOW()),
+        v_row.parsed_last_visit_at,
+        v_row.parsed_notes,
+        v_uid, v_uid
+      ) RETURNING id INTO v_new_id;
+
+      UPDATE member_imports
+         SET validation_status  = 'committed',
+             resolved_member_id = v_new_id,
+             updated_by         = v_uid
+       WHERE id = v_row.id;
+
+      v_committed := v_committed + 1;
+    EXCEPTION
+      WHEN unique_violation THEN
+        UPDATE member_imports
+           SET validation_status = 'error_at_commit',
+               validation_errors = validation_errors || jsonb_build_array(
+                 jsonb_build_object('field','commit','code','unique_violation','message',SQLERRM)
+               ),
+               updated_by = v_uid
+         WHERE id = v_row.id;
+        v_skipped := v_skipped + 1;
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'batch_id',  p_batch_id,
+    'committed', v_committed,
+    'skipped',   v_skipped
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_commit_member_import(TEXT, INT) TO authenticated;
+
+-- 驗證：之後只應有
+--   rpc_stage_member_import(TEXT, TEXT, JSONB, INT)
+--   rpc_commit_member_import(TEXT, INT)
+-- 可在 dev DB 上跑：
+--   SELECT proname, pg_get_function_arguments(oid)
+--     FROM pg_proc
+--    WHERE proname IN ('rpc_stage_member_import','rpc_commit_member_import');

--- a/supabase/migrations/20260613000060_member_import_commit_default_limit.sql
+++ b/supabase/migrations/20260613000060_member_import_commit_default_limit.sql
@@ -1,0 +1,83 @@
+-- ============================================================
+-- commit RPC default p_limit 從 NULL 改 500
+-- 不帶 p_limit 的 caller 也不會跑全部 → timeout
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.rpc_commit_member_import(
+  p_batch_id TEXT,
+  p_limit    INT DEFAULT 500
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  v_uid        UUID := auth.uid();
+  v_row        member_imports%ROWTYPE;
+  v_committed  INT := 0;
+  v_skipped    INT := 0;
+  v_member_no  TEXT;
+  v_new_id     BIGINT;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM member_imports
+     WHERE tenant_id = v_tenant AND batch_id = p_batch_id
+  ) THEN
+    RAISE EXCEPTION 'batch % not found', p_batch_id;
+  END IF;
+
+  FOR v_row IN
+    SELECT * FROM member_imports
+     WHERE tenant_id = v_tenant
+       AND batch_id  = p_batch_id
+       AND validation_status = 'ok'
+     ORDER BY row_index FOR UPDATE
+     LIMIT COALESCE(p_limit, 500)
+  LOOP
+    v_member_no := public.rpc_next_member_no();
+
+    BEGIN
+      INSERT INTO members (
+        tenant_id, member_no,
+        external_source, external_id,
+        name, status,
+        takeout_store_name_hint, home_store_id,
+        joined_at, last_visit_at, notes,
+        created_by, updated_by
+      ) VALUES (
+        v_tenant, v_member_no,
+        v_row.source, v_row.parsed_external_id,
+        v_row.parsed_name, 'active',
+        v_row.parsed_takeout_store_name_hint, v_row.parsed_home_store_id,
+        COALESCE(v_row.parsed_joined_at, NOW()),
+        v_row.parsed_last_visit_at,
+        v_row.parsed_notes,
+        v_uid, v_uid
+      ) RETURNING id INTO v_new_id;
+
+      UPDATE member_imports
+         SET validation_status  = 'committed',
+             resolved_member_id = v_new_id,
+             updated_by         = v_uid
+       WHERE id = v_row.id;
+
+      v_committed := v_committed + 1;
+    EXCEPTION
+      WHEN unique_violation THEN
+        UPDATE member_imports
+           SET validation_status = 'error_at_commit',
+               validation_errors = validation_errors || jsonb_build_array(
+                 jsonb_build_object('field','commit','code','unique_violation','message',SQLERRM)
+               ),
+               updated_by = v_uid
+         WHERE id = v_row.id;
+        v_skipped := v_skipped + 1;
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'batch_id',  p_batch_id,
+    'committed', v_committed,
+    'skipped',   v_skipped
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_commit_member_import(TEXT, INT) TO authenticated;

--- a/supabase/migrations/20260613000070_member_import_wallet.sql
+++ b/supabase/migrations/20260613000070_member_import_wallet.sql
@@ -1,0 +1,289 @@
+-- ============================================================
+-- Member Import: 一併匯入樂樂「錢包餘額」→ wallet_ledger + wallet_balances
+-- 邏輯：commit 階段建 member 後，若 parsed_wallet_balance > 0：
+--   INSERT wallet_ledger (type='adjust', source_type='import_lele')
+--   UPSERT wallet_balances (balance = parsed_wallet_balance)
+-- 0 / NULL → 不寫 ledger（避免污染 balance history）
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. ALTER member_imports 加 parsed_wallet_balance
+-- ------------------------------------------------------------
+ALTER TABLE member_imports
+  ADD COLUMN IF NOT EXISTS parsed_wallet_balance NUMERIC(18,2);
+
+COMMENT ON COLUMN member_imports.parsed_wallet_balance IS
+  '樂樂 CSV「錢包餘額」欄；commit 階段 > 0 才寫 wallet_ledger';
+
+-- ------------------------------------------------------------
+-- 2. rpc_stage_member_import：加抽 wallet_balance 欄
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_stage_member_import(
+  p_batch_id   TEXT,
+  p_source     TEXT,
+  p_rows       JSONB,
+  p_row_offset INT DEFAULT 0
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant       UUID := public._current_tenant_id();
+  v_uid          UUID := auth.uid();
+  v_row          JSONB;
+  v_index        INT := p_row_offset;
+  v_total        INT := 0;
+  v_ok           INT := 0;
+  v_dup_in_batch INT := 0;
+  v_dup_existing INT := 0;
+  v_errors       INT := 0;
+
+  v_external_id  TEXT;
+  v_name_raw     TEXT;
+  v_name_parsed  JSONB;
+  v_name         TEXT;
+  v_name_suffix  TEXT;
+  v_label        TEXT;
+  v_hint         TEXT;
+  v_home_store   BIGINT;
+  v_joined_at    TIMESTAMPTZ;
+  v_last_at      TIMESTAMPTZ;
+  v_wallet_raw   TEXT;
+  v_wallet       NUMERIC(18,2);
+  v_errs         JSONB;
+  v_status       TEXT;
+  v_existing_id  BIGINT;
+BEGIN
+  IF p_rows IS NULL OR jsonb_typeof(p_rows) <> 'array' THEN
+    RAISE EXCEPTION 'p_rows must be jsonb array';
+  END IF;
+  IF p_source IS NULL OR p_source NOT IN ('lele','pinduoduo','1688','manual') THEN
+    RAISE EXCEPTION 'invalid source: %', p_source;
+  END IF;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_rows) LOOP
+    v_index := v_index + 1;
+    v_total := v_total + 1;
+    v_errs        := '[]'::jsonb;
+    v_external_id := NULLIF(TRIM(v_row->>'external_id'), '');
+    v_name_raw    := v_row->>'name_raw';
+    v_label       := NULLIF(TRIM(v_row->>'label'), '');
+    v_wallet_raw  := NULLIF(TRIM(v_row->>'wallet_balance'), '');
+    v_name        := NULL;
+    v_name_suffix := NULL;
+    v_hint        := NULL;
+    v_home_store  := NULL;
+    v_joined_at   := NULL;
+    v_last_at     := NULL;
+    v_wallet      := NULL;
+    v_status      := NULL;
+    v_existing_id := NULL;
+
+    IF v_external_id IS NULL THEN
+      v_errs := v_errs || jsonb_build_array(jsonb_build_object('field','external_id','code','required'));
+    END IF;
+
+    v_name_parsed := public._parse_lele_name(v_name_raw);
+    v_name        := v_name_parsed->>'name';
+    v_name_suffix := v_name_parsed->>'suffix';
+
+    IF v_name IS NULL OR v_name = '' THEN
+      v_errs := v_errs || jsonb_build_array(jsonb_build_object('field','name','code','required'));
+    END IF;
+
+    IF v_label IS NOT NULL AND v_label <> '—' THEN
+      v_hint := v_label;
+      v_home_store := public._resolve_or_create_takeout_store(v_tenant, v_label, v_uid);
+    END IF;
+
+    v_joined_at := public._parse_lele_timestamp(v_row->>'joined_at');
+    v_last_at   := public._parse_lele_timestamp(v_row->>'last_visit_at');
+
+    -- wallet parse：'—'/'－'/'' → NULL；其他 cast NUMERIC（cast 失敗 → 標 error）
+    IF v_wallet_raw IS NOT NULL AND v_wallet_raw NOT IN ('—','－') THEN
+      BEGIN
+        v_wallet := REGEXP_REPLACE(v_wallet_raw, '[^\d.\-]', '', 'g')::NUMERIC(18,2);
+        IF v_wallet < 0 THEN
+          v_errs := v_errs || jsonb_build_array(jsonb_build_object('field','wallet_balance','code','negative','value',v_wallet_raw));
+          v_wallet := NULL;
+        END IF;
+      EXCEPTION WHEN OTHERS THEN
+        v_errs := v_errs || jsonb_build_array(jsonb_build_object('field','wallet_balance','code','invalid_format','value',v_wallet_raw));
+      END;
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM jsonb_array_elements(v_errs) AS x
+       WHERE x->>'code' IN ('required','invalid_format','invalid_value')
+    ) THEN
+      v_status := 'error';
+      v_errors := v_errors + 1;
+    ELSE
+      IF v_external_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM member_imports
+         WHERE tenant_id = v_tenant
+           AND batch_id = p_batch_id
+           AND source = p_source
+           AND parsed_external_id = v_external_id
+      ) THEN
+        v_status := 'duplicate_in_batch';
+        v_dup_in_batch := v_dup_in_batch + 1;
+      ELSE
+        IF v_external_id IS NOT NULL THEN
+          SELECT id INTO v_existing_id
+            FROM members
+           WHERE tenant_id = v_tenant
+             AND external_source = p_source
+             AND external_id = v_external_id
+             AND status NOT IN ('deleted','merged')
+           LIMIT 1;
+        END IF;
+        IF v_existing_id IS NOT NULL THEN
+          v_status := 'duplicate_existing';
+          v_dup_existing := v_dup_existing + 1;
+        ELSE
+          v_status := 'ok';
+          v_ok := v_ok + 1;
+        END IF;
+      END IF;
+    END IF;
+
+    INSERT INTO member_imports (
+      tenant_id, batch_id, row_index, source, raw_data,
+      parsed_external_id, parsed_name, parsed_name_suffix,
+      parsed_takeout_store_name_hint, parsed_home_store_id,
+      parsed_joined_at, parsed_last_visit_at, parsed_notes,
+      parsed_wallet_balance,
+      validation_status, validation_errors, resolved_member_id,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, p_batch_id, v_index, p_source, v_row,
+      v_external_id, v_name, v_name_suffix,
+      v_hint, v_home_store,
+      v_joined_at, v_last_at, v_name_suffix,
+      v_wallet,
+      v_status, v_errs, v_existing_id,
+      v_uid, v_uid
+    )
+    ON CONFLICT (tenant_id, batch_id, row_index) DO NOTHING;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'batch_id', p_batch_id,
+    'source', p_source,
+    'chunk_total', v_total,
+    'chunk_ok', v_ok,
+    'chunk_duplicate_in_batch', v_dup_in_batch,
+    'chunk_duplicate_existing', v_dup_existing,
+    'chunk_errors', v_errors
+  );
+END;
+$$;
+
+-- ------------------------------------------------------------
+-- 3. rpc_commit_member_import：建 member 後若 wallet > 0 寫 ledger + balance
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_commit_member_import(
+  p_batch_id TEXT,
+  p_limit    INT DEFAULT 500
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  v_uid        UUID := auth.uid();
+  v_row        member_imports%ROWTYPE;
+  v_committed  INT := 0;
+  v_skipped    INT := 0;
+  v_wallet_initialized INT := 0;
+  v_member_no  TEXT;
+  v_new_id     BIGINT;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM member_imports
+     WHERE tenant_id = v_tenant AND batch_id = p_batch_id
+  ) THEN
+    RAISE EXCEPTION 'batch % not found', p_batch_id;
+  END IF;
+
+  FOR v_row IN
+    SELECT * FROM member_imports
+     WHERE tenant_id = v_tenant
+       AND batch_id  = p_batch_id
+       AND validation_status = 'ok'
+     ORDER BY row_index FOR UPDATE
+     LIMIT COALESCE(p_limit, 500)
+  LOOP
+    v_member_no := public.rpc_next_member_no();
+
+    BEGIN
+      INSERT INTO members (
+        tenant_id, member_no,
+        external_source, external_id,
+        name, status,
+        takeout_store_name_hint, home_store_id,
+        joined_at, last_visit_at, notes,
+        created_by, updated_by
+      ) VALUES (
+        v_tenant, v_member_no,
+        v_row.source, v_row.parsed_external_id,
+        v_row.parsed_name, 'active',
+        v_row.parsed_takeout_store_name_hint, v_row.parsed_home_store_id,
+        COALESCE(v_row.parsed_joined_at, NOW()),
+        v_row.parsed_last_visit_at,
+        v_row.parsed_notes,
+        v_uid, v_uid
+      ) RETURNING id INTO v_new_id;
+
+      -- 初始化 wallet（只在 > 0 時）
+      IF v_row.parsed_wallet_balance IS NOT NULL AND v_row.parsed_wallet_balance > 0 THEN
+        INSERT INTO wallet_ledger (
+          tenant_id, member_id, change, balance_after,
+          type, source_type, source_id, reason, operator_id
+        ) VALUES (
+          v_tenant, v_new_id, v_row.parsed_wallet_balance, v_row.parsed_wallet_balance,
+          'adjust', 'import_lele', v_row.id,
+          '樂樂 CSV 匯入初始錢包餘額', v_uid
+        );
+
+        INSERT INTO wallet_balances (
+          tenant_id, member_id, balance, version, last_movement_at, updated_at
+        ) VALUES (
+          v_tenant, v_new_id, v_row.parsed_wallet_balance, 1, NOW(), NOW()
+        )
+        ON CONFLICT (tenant_id, member_id) DO UPDATE
+          SET balance          = EXCLUDED.balance,
+              version          = wallet_balances.version + 1,
+              last_movement_at = NOW(),
+              updated_at       = NOW();
+
+        v_wallet_initialized := v_wallet_initialized + 1;
+      END IF;
+
+      UPDATE member_imports
+         SET validation_status  = 'committed',
+             resolved_member_id = v_new_id,
+             updated_by         = v_uid
+       WHERE id = v_row.id;
+
+      v_committed := v_committed + 1;
+    EXCEPTION
+      WHEN unique_violation THEN
+        UPDATE member_imports
+           SET validation_status = 'error_at_commit',
+               validation_errors = validation_errors || jsonb_build_array(
+                 jsonb_build_object('field','commit','code','unique_violation','message',SQLERRM)
+               ),
+               updated_by = v_uid
+         WHERE id = v_row.id;
+        v_skipped := v_skipped + 1;
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'batch_id',           p_batch_id,
+    'committed',          v_committed,
+    'skipped',            v_skipped,
+    'wallet_initialized', v_wallet_initialized
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_commit_member_import(TEXT, INT) TO authenticated;

--- a/supabase/migrations/20260613000080_commit_perf_inline_seq.sql
+++ b/supabase/migrations/20260613000080_commit_perf_inline_seq.sql
@@ -1,0 +1,121 @@
+-- ============================================================
+-- Perf fix: rpc_commit_member_import 內每筆 commit 都呼叫
+-- rpc_next_member_no()，每次跑整表 SELECT MAX regex scan O(n)，
+-- 12k members 下 500 筆 chunk 就會 timeout。
+--
+-- 改：chunk 開始一次性 SELECT MAX，後續 row 用記憶體變數 +1
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.rpc_commit_member_import(
+  p_batch_id TEXT,
+  p_limit    INT DEFAULT 500
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant             UUID := public._current_tenant_id();
+  v_uid                UUID := auth.uid();
+  v_row                member_imports%ROWTYPE;
+  v_committed          INT := 0;
+  v_skipped            INT := 0;
+  v_wallet_initialized INT := 0;
+  v_last_no            INT;
+  v_member_no          TEXT;
+  v_new_id             BIGINT;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM member_imports
+     WHERE tenant_id = v_tenant AND batch_id = p_batch_id
+  ) THEN
+    RAISE EXCEPTION 'batch % not found', p_batch_id;
+  END IF;
+
+  -- chunk 開始時一次性算 max；後續用 v_last_no 累加避免 O(n) 重 scan
+  SELECT COALESCE(MAX((SUBSTRING(member_no FROM '^M(\d{1,9})$'))::INT), 0)
+    INTO v_last_no
+    FROM members
+   WHERE tenant_id = v_tenant
+     AND member_no ~ '^M\d{1,9}$';
+
+  FOR v_row IN
+    SELECT * FROM member_imports
+     WHERE tenant_id = v_tenant
+       AND batch_id  = p_batch_id
+       AND validation_status = 'ok'
+     ORDER BY row_index FOR UPDATE
+     LIMIT COALESCE(p_limit, 500)
+  LOOP
+    v_last_no := v_last_no + 1;
+    v_member_no := 'M' || lpad(v_last_no::text, 6, '0');
+
+    BEGIN
+      INSERT INTO members (
+        tenant_id, member_no,
+        external_source, external_id,
+        name, status,
+        takeout_store_name_hint, home_store_id,
+        joined_at, last_visit_at, notes,
+        created_by, updated_by
+      ) VALUES (
+        v_tenant, v_member_no,
+        v_row.source, v_row.parsed_external_id,
+        v_row.parsed_name, 'active',
+        v_row.parsed_takeout_store_name_hint, v_row.parsed_home_store_id,
+        COALESCE(v_row.parsed_joined_at, NOW()),
+        v_row.parsed_last_visit_at,
+        v_row.parsed_notes,
+        v_uid, v_uid
+      ) RETURNING id INTO v_new_id;
+
+      IF v_row.parsed_wallet_balance IS NOT NULL AND v_row.parsed_wallet_balance > 0 THEN
+        INSERT INTO wallet_ledger (
+          tenant_id, member_id, change, balance_after,
+          type, source_type, source_id, reason, operator_id
+        ) VALUES (
+          v_tenant, v_new_id, v_row.parsed_wallet_balance, v_row.parsed_wallet_balance,
+          'adjust', 'import_lele', v_row.id,
+          '樂樂 CSV 匯入初始錢包餘額', v_uid
+        );
+
+        INSERT INTO wallet_balances (
+          tenant_id, member_id, balance, version, last_movement_at, updated_at
+        ) VALUES (
+          v_tenant, v_new_id, v_row.parsed_wallet_balance, 1, NOW(), NOW()
+        )
+        ON CONFLICT (tenant_id, member_id) DO UPDATE
+          SET balance          = EXCLUDED.balance,
+              version          = wallet_balances.version + 1,
+              last_movement_at = NOW(),
+              updated_at       = NOW();
+
+        v_wallet_initialized := v_wallet_initialized + 1;
+      END IF;
+
+      UPDATE member_imports
+         SET validation_status  = 'committed',
+             resolved_member_id = v_new_id,
+             updated_by         = v_uid
+       WHERE id = v_row.id;
+
+      v_committed := v_committed + 1;
+    EXCEPTION
+      WHEN unique_violation THEN
+        UPDATE member_imports
+           SET validation_status = 'error_at_commit',
+               validation_errors = validation_errors || jsonb_build_array(
+                 jsonb_build_object('field','commit','code','unique_violation','message',SQLERRM)
+               ),
+               updated_by = v_uid
+         WHERE id = v_row.id;
+        v_skipped := v_skipped + 1;
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'batch_id',           p_batch_id,
+    'committed',          v_committed,
+    'skipped',            v_skipped,
+    'wallet_initialized', v_wallet_initialized
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_commit_member_import(TEXT, INT) TO authenticated;

--- a/supabase/migrations/20260613000090_rpc_purge_lele_imports.sql
+++ b/supabase/migrations/20260613000090_rpc_purge_lele_imports.sql
@@ -1,0 +1,64 @@
+-- ============================================================
+-- 一次性 cleanup RPC：清掉所有 external_source='lele' 的匯入會員
+-- + 連帶 wallet / points / cards / aliases / push_subs / staging /
+--   自動建的 LELE-* stores
+-- 用於 dev DB 試錯後 reset
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_admin_purge_lele_imports()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  v_member_ids BIGINT[];
+  v_n_members  INT := 0;
+  v_n_stores   INT := 0;
+  v_n_imports  INT := 0;
+  v_n_wallet_l INT := 0;
+  v_n_wallet_b INT := 0;
+  v_n_push     INT := 0;
+BEGIN
+  SELECT array_agg(id) INTO v_member_ids
+    FROM members
+   WHERE tenant_id = v_tenant
+     AND external_source = 'lele';
+
+  IF v_member_ids IS NOT NULL AND array_length(v_member_ids, 1) > 0 THEN
+    DELETE FROM wallet_ledger          WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_l = ROW_COUNT;
+
+    DELETE FROM wallet_balances        WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_b = ROW_COUNT;
+
+    DELETE FROM points_ledger          WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_points_balance  WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_cards           WHERE member_id = ANY(v_member_ids);
+    DELETE FROM customer_line_aliases  WHERE member_id = ANY(v_member_ids);
+
+    DELETE FROM push_subscriptions     WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_push = ROW_COUNT;
+
+    -- staging row resolved_member_id 是 ON DELETE SET NULL，不另外處理
+    DELETE FROM members                WHERE id = ANY(v_member_ids);
+    v_n_members := array_length(v_member_ids, 1);
+  END IF;
+
+  DELETE FROM member_imports WHERE tenant_id = v_tenant;
+  GET DIAGNOSTICS v_n_imports = ROW_COUNT;
+
+  DELETE FROM stores
+   WHERE tenant_id = v_tenant
+     AND code LIKE 'LELE-%';
+  GET DIAGNOSTICS v_n_stores = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'members_deleted',         v_n_members,
+    'wallet_ledger_deleted',   v_n_wallet_l,
+    'wallet_balances_deleted', v_n_wallet_b,
+    'push_subs_deleted',       v_n_push,
+    'imports_deleted',         v_n_imports,
+    'stores_deleted',          v_n_stores
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_admin_purge_lele_imports TO authenticated;

--- a/supabase/migrations/20260613000100_rpc_purge_lele_imports_fix.sql
+++ b/supabase/migrations/20260613000100_rpc_purge_lele_imports_fix.sql
@@ -1,0 +1,63 @@
+-- ============================================================
+-- Fix purge RPC: wallet_ledger 有 append-only trigger 擋 DELETE
+-- 在 RPC 內暫時 SET session_replication_role='replica' 跳過 user trigger
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_admin_purge_lele_imports()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  v_member_ids BIGINT[];
+  v_n_members  INT := 0;
+  v_n_stores   INT := 0;
+  v_n_imports  INT := 0;
+  v_n_wallet_l INT := 0;
+  v_n_wallet_b INT := 0;
+  v_n_push     INT := 0;
+BEGIN
+  -- 暫停 user trigger（含 forbid_append_only_mutation 等）以允許 cleanup DELETE
+  SET LOCAL session_replication_role = 'replica';
+
+  SELECT array_agg(id) INTO v_member_ids
+    FROM members
+   WHERE tenant_id = v_tenant
+     AND external_source = 'lele';
+
+  IF v_member_ids IS NOT NULL AND array_length(v_member_ids, 1) > 0 THEN
+    DELETE FROM wallet_ledger          WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_l = ROW_COUNT;
+
+    DELETE FROM wallet_balances        WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_b = ROW_COUNT;
+
+    DELETE FROM points_ledger          WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_points_balance  WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_cards           WHERE member_id = ANY(v_member_ids);
+    DELETE FROM customer_line_aliases  WHERE member_id = ANY(v_member_ids);
+
+    DELETE FROM push_subscriptions     WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_push = ROW_COUNT;
+
+    DELETE FROM members                WHERE id = ANY(v_member_ids);
+    v_n_members := array_length(v_member_ids, 1);
+  END IF;
+
+  DELETE FROM member_imports WHERE tenant_id = v_tenant;
+  GET DIAGNOSTICS v_n_imports = ROW_COUNT;
+
+  DELETE FROM stores
+   WHERE tenant_id = v_tenant
+     AND code LIKE 'LELE-%';
+  GET DIAGNOSTICS v_n_stores = ROW_COUNT;
+
+  -- end of LOCAL replica；RESET implicit on TX end
+  RETURN jsonb_build_object(
+    'members_deleted',         v_n_members,
+    'wallet_ledger_deleted',   v_n_wallet_l,
+    'wallet_balances_deleted', v_n_wallet_b,
+    'push_subs_deleted',       v_n_push,
+    'imports_deleted',         v_n_imports,
+    'stores_deleted',          v_n_stores
+  );
+END;
+$$;

--- a/supabase/migrations/20260613000110_rpc_purge_lele_imports_v3.sql
+++ b/supabase/migrations/20260613000110_rpc_purge_lele_imports_v3.sql
@@ -1,0 +1,69 @@
+-- ============================================================
+-- v3: 用 EXECUTE 'ALTER TABLE DISABLE TRIGGER' 繞 forbid_append_only_mutation
+-- session_replication_role 是 superuser-only，普通 DEFINER role 用 ALTER TABLE
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_admin_purge_lele_imports()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  v_member_ids BIGINT[];
+  v_n_members  INT := 0;
+  v_n_stores   INT := 0;
+  v_n_imports  INT := 0;
+  v_n_wallet_l INT := 0;
+  v_n_wallet_b INT := 0;
+  v_n_push     INT := 0;
+BEGIN
+  SELECT array_agg(id) INTO v_member_ids
+    FROM members
+   WHERE tenant_id = v_tenant
+     AND external_source = 'lele';
+
+  IF v_member_ids IS NOT NULL AND array_length(v_member_ids, 1) > 0 THEN
+    -- 暫關 append-only / no-delete trigger
+    EXECUTE 'ALTER TABLE wallet_ledger DISABLE TRIGGER trg_no_delete_wallet';
+    EXECUTE 'ALTER TABLE points_ledger DISABLE TRIGGER USER';
+    EXECUTE 'ALTER TABLE members       DISABLE TRIGGER trg_no_delete_member';
+
+    DELETE FROM wallet_ledger          WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_l = ROW_COUNT;
+
+    DELETE FROM wallet_balances        WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_b = ROW_COUNT;
+
+    DELETE FROM points_ledger          WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_points_balance  WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_cards           WHERE member_id = ANY(v_member_ids);
+    DELETE FROM customer_line_aliases  WHERE member_id = ANY(v_member_ids);
+
+    DELETE FROM push_subscriptions     WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_push = ROW_COUNT;
+
+    DELETE FROM members                WHERE id = ANY(v_member_ids);
+    v_n_members := array_length(v_member_ids, 1);
+
+    -- 恢復
+    EXECUTE 'ALTER TABLE wallet_ledger ENABLE TRIGGER trg_no_delete_wallet';
+    EXECUTE 'ALTER TABLE points_ledger ENABLE TRIGGER USER';
+    EXECUTE 'ALTER TABLE members       ENABLE TRIGGER trg_no_delete_member';
+  END IF;
+
+  DELETE FROM member_imports WHERE tenant_id = v_tenant;
+  GET DIAGNOSTICS v_n_imports = ROW_COUNT;
+
+  DELETE FROM stores
+   WHERE tenant_id = v_tenant
+     AND code LIKE 'LELE-%';
+  GET DIAGNOSTICS v_n_stores = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'members_deleted',         v_n_members,
+    'wallet_ledger_deleted',   v_n_wallet_l,
+    'wallet_balances_deleted', v_n_wallet_b,
+    'push_subs_deleted',       v_n_push,
+    'imports_deleted',         v_n_imports,
+    'stores_deleted',          v_n_stores
+  );
+END;
+$$;

--- a/supabase/migrations/20260613000120_rpc_purge_lele_imports_v4.sql
+++ b/supabase/migrations/20260613000120_rpc_purge_lele_imports_v4.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- v4: 補 members 的 trg_no_delete_member 也要暫關
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_admin_purge_lele_imports()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  v_member_ids BIGINT[];
+  v_n_members  INT := 0;
+  v_n_stores   INT := 0;
+  v_n_imports  INT := 0;
+  v_n_wallet_l INT := 0;
+  v_n_wallet_b INT := 0;
+  v_n_push     INT := 0;
+BEGIN
+  SELECT array_agg(id) INTO v_member_ids
+    FROM members
+   WHERE tenant_id = v_tenant
+     AND external_source = 'lele';
+
+  IF v_member_ids IS NOT NULL AND array_length(v_member_ids, 1) > 0 THEN
+    EXECUTE 'ALTER TABLE wallet_ledger DISABLE TRIGGER trg_no_delete_wallet';
+    EXECUTE 'ALTER TABLE points_ledger DISABLE TRIGGER USER';
+    EXECUTE 'ALTER TABLE members       DISABLE TRIGGER trg_no_delete_member';
+
+    DELETE FROM wallet_ledger          WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_l = ROW_COUNT;
+
+    DELETE FROM wallet_balances        WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_b = ROW_COUNT;
+
+    DELETE FROM points_ledger          WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_points_balance  WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_cards           WHERE member_id = ANY(v_member_ids);
+    DELETE FROM customer_line_aliases  WHERE member_id = ANY(v_member_ids);
+
+    DELETE FROM push_subscriptions     WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_push = ROW_COUNT;
+
+    DELETE FROM members                WHERE id = ANY(v_member_ids);
+    v_n_members := array_length(v_member_ids, 1);
+
+    EXECUTE 'ALTER TABLE wallet_ledger ENABLE TRIGGER trg_no_delete_wallet';
+    EXECUTE 'ALTER TABLE points_ledger ENABLE TRIGGER USER';
+    EXECUTE 'ALTER TABLE members       ENABLE TRIGGER trg_no_delete_member';
+  END IF;
+
+  DELETE FROM member_imports WHERE tenant_id = v_tenant;
+  GET DIAGNOSTICS v_n_imports = ROW_COUNT;
+
+  DELETE FROM stores
+   WHERE tenant_id = v_tenant
+     AND code LIKE 'LELE-%';
+  GET DIAGNOSTICS v_n_stores = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'members_deleted',         v_n_members,
+    'wallet_ledger_deleted',   v_n_wallet_l,
+    'wallet_balances_deleted', v_n_wallet_b,
+    'push_subs_deleted',       v_n_push,
+    'imports_deleted',         v_n_imports,
+    'stores_deleted',          v_n_stores
+  );
+END;
+$$;

--- a/supabase/migrations/20260613000130_rpc_purge_lele_imports_v5.sql
+++ b/supabase/migrations/20260613000130_rpc_purge_lele_imports_v5.sql
@@ -1,0 +1,73 @@
+-- ============================================================
+-- v5: chunked purge，每 call 刪 p_limit 個 members
+-- client 端 while loop 直到 members_deleted = 0
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_admin_purge_lele_imports(
+  p_limit INT DEFAULT 500
+) RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  v_member_ids BIGINT[];
+  v_n_members  INT := 0;
+  v_n_stores   INT := 0;
+  v_n_imports  INT := 0;
+  v_n_wallet_l INT := 0;
+  v_n_wallet_b INT := 0;
+  v_n_push     INT := 0;
+BEGIN
+  SELECT array_agg(id) INTO v_member_ids
+    FROM (
+      SELECT id FROM members
+       WHERE tenant_id = v_tenant AND external_source = 'lele'
+       LIMIT p_limit
+    ) sub;
+
+  IF v_member_ids IS NOT NULL AND array_length(v_member_ids, 1) > 0 THEN
+    EXECUTE 'ALTER TABLE wallet_ledger DISABLE TRIGGER trg_no_delete_wallet';
+    EXECUTE 'ALTER TABLE points_ledger DISABLE TRIGGER USER';
+    EXECUTE 'ALTER TABLE members       DISABLE TRIGGER trg_no_delete_member';
+
+    DELETE FROM wallet_ledger          WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_l = ROW_COUNT;
+
+    DELETE FROM wallet_balances        WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_b = ROW_COUNT;
+
+    DELETE FROM points_ledger          WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_points_balance  WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_cards           WHERE member_id = ANY(v_member_ids);
+    DELETE FROM customer_line_aliases  WHERE member_id = ANY(v_member_ids);
+
+    DELETE FROM push_subscriptions     WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_push = ROW_COUNT;
+
+    DELETE FROM members                WHERE id = ANY(v_member_ids);
+    v_n_members := array_length(v_member_ids, 1);
+
+    EXECUTE 'ALTER TABLE wallet_ledger ENABLE TRIGGER trg_no_delete_wallet';
+    EXECUTE 'ALTER TABLE points_ledger ENABLE TRIGGER USER';
+    EXECUTE 'ALTER TABLE members       ENABLE TRIGGER trg_no_delete_member';
+  END IF;
+
+  -- 只在 chunk 0 members 時清 staging + stores（避免每 chunk 重跑）
+  IF v_n_members = 0 THEN
+    DELETE FROM member_imports WHERE tenant_id = v_tenant;
+    GET DIAGNOSTICS v_n_imports = ROW_COUNT;
+
+    DELETE FROM stores
+     WHERE tenant_id = v_tenant
+       AND code LIKE 'LELE-%';
+    GET DIAGNOSTICS v_n_stores = ROW_COUNT;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'members_deleted',         v_n_members,
+    'wallet_ledger_deleted',   v_n_wallet_l,
+    'wallet_balances_deleted', v_n_wallet_b,
+    'push_subs_deleted',       v_n_push,
+    'imports_deleted',         v_n_imports,
+    'stores_deleted',          v_n_stores
+  );
+END;
+$$;

--- a/supabase/migrations/20260613000140_member_import_upsert.sql
+++ b/supabase/migrations/20260613000140_member_import_upsert.sql
@@ -1,0 +1,180 @@
+-- ============================================================
+-- 改 commit RPC 為 upsert：external_id 既有 → UPDATE 而非 skip
+-- 觸發條件：member_imports.validation_status IN ('ok', 'duplicate_existing')
+--   ok                 → INSERT 新 member
+--   duplicate_existing → UPDATE 既有 member (resolved_member_id)
+-- 樂樂 CSV 沒帶的欄位（phone / email / line_user_id）不覆蓋
+-- wallet 用差額 ledger 紀錄變動
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_commit_member_import(
+  p_batch_id TEXT,
+  p_limit    INT DEFAULT 500
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant             UUID := public._current_tenant_id();
+  v_uid                UUID := auth.uid();
+  v_row                member_imports%ROWTYPE;
+  v_committed          INT := 0;
+  v_updated            INT := 0;
+  v_skipped            INT := 0;
+  v_wallet_initialized INT := 0;
+  v_wallet_updated     INT := 0;
+  v_last_no            INT;
+  v_member_no          TEXT;
+  v_new_id             BIGINT;
+  v_old_balance        NUMERIC(18,2);
+  v_diff               NUMERIC(18,2);
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM member_imports
+     WHERE tenant_id = v_tenant AND batch_id = p_batch_id
+  ) THEN
+    RAISE EXCEPTION 'batch % not found', p_batch_id;
+  END IF;
+
+  SELECT COALESCE(MAX((SUBSTRING(member_no FROM '^M(\d{1,9})$'))::INT), 0)
+    INTO v_last_no
+    FROM members
+   WHERE tenant_id = v_tenant
+     AND member_no ~ '^M\d{1,9}$';
+
+  FOR v_row IN
+    SELECT * FROM member_imports
+     WHERE tenant_id = v_tenant
+       AND batch_id  = p_batch_id
+       AND validation_status IN ('ok', 'duplicate_existing')
+     ORDER BY row_index FOR UPDATE
+     LIMIT COALESCE(p_limit, 500)
+  LOOP
+    BEGIN
+      IF v_row.validation_status = 'ok' THEN
+        -- ============ INSERT 新 member ============
+        v_last_no := v_last_no + 1;
+        v_member_no := 'M' || lpad(v_last_no::text, 6, '0');
+
+        INSERT INTO members (
+          tenant_id, member_no,
+          external_source, external_id,
+          name, status,
+          takeout_store_name_hint, home_store_id,
+          joined_at, last_visit_at, notes,
+          created_by, updated_by
+        ) VALUES (
+          v_tenant, v_member_no,
+          v_row.source, v_row.parsed_external_id,
+          v_row.parsed_name, 'active',
+          v_row.parsed_takeout_store_name_hint, v_row.parsed_home_store_id,
+          COALESCE(v_row.parsed_joined_at, NOW()),
+          v_row.parsed_last_visit_at,
+          v_row.parsed_notes,
+          v_uid, v_uid
+        ) RETURNING id INTO v_new_id;
+
+        v_committed := v_committed + 1;
+      ELSE
+        -- ============ UPDATE 既有 member ============
+        v_new_id := v_row.resolved_member_id;
+        IF v_new_id IS NULL THEN
+          -- shouldn't happen, but safe guard
+          v_skipped := v_skipped + 1;
+          CONTINUE;
+        END IF;
+
+        -- 只更新樂樂 CSV 有的欄位；phone / email / line_user_id 保留
+        -- home_store_id 變動沒 open orders 才改（避免拖開單流程）
+        UPDATE members SET
+          name                    = COALESCE(v_row.parsed_name, name),
+          takeout_store_name_hint = v_row.parsed_takeout_store_name_hint,
+          home_store_id           = CASE
+            WHEN v_row.parsed_home_store_id IS NOT NULL
+             AND home_store_id IS DISTINCT FROM v_row.parsed_home_store_id
+             AND NOT EXISTS (
+               SELECT 1 FROM customer_orders
+                WHERE tenant_id = v_tenant
+                  AND member_id = members.id
+                  AND status NOT IN ('completed','cancelled','expired')
+             )
+            THEN v_row.parsed_home_store_id
+            ELSE home_store_id
+          END,
+          joined_at               = COALESCE(v_row.parsed_joined_at, joined_at),
+          last_visit_at           = COALESCE(v_row.parsed_last_visit_at, last_visit_at),
+          updated_by              = v_uid
+        WHERE id = v_new_id AND tenant_id = v_tenant;
+
+        v_updated := v_updated + 1;
+      END IF;
+
+      -- ============ Wallet 處理 ============
+      IF v_row.parsed_wallet_balance IS NOT NULL THEN
+        SELECT balance INTO v_old_balance
+          FROM wallet_balances
+         WHERE tenant_id = v_tenant AND member_id = v_new_id;
+        v_old_balance := COALESCE(v_old_balance, 0);
+        v_diff := v_row.parsed_wallet_balance - v_old_balance;
+
+        IF v_diff <> 0 THEN
+          INSERT INTO wallet_ledger (
+            tenant_id, member_id, change, balance_after,
+            type, source_type, source_id, reason, operator_id
+          ) VALUES (
+            v_tenant, v_new_id, v_diff, v_row.parsed_wallet_balance,
+            'adjust', 'import_lele', v_row.id,
+            CASE WHEN v_old_balance = 0
+              THEN '樂樂 CSV 匯入初始錢包餘額'
+              ELSE format('樂樂 CSV 重匯：%s → %s', v_old_balance, v_row.parsed_wallet_balance)
+            END,
+            v_uid
+          );
+
+          INSERT INTO wallet_balances (
+            tenant_id, member_id, balance, version, last_movement_at, updated_at
+          ) VALUES (
+            v_tenant, v_new_id, v_row.parsed_wallet_balance, 1, NOW(), NOW()
+          )
+          ON CONFLICT (tenant_id, member_id) DO UPDATE
+            SET balance          = EXCLUDED.balance,
+                version          = wallet_balances.version + 1,
+                last_movement_at = NOW(),
+                updated_at       = NOW();
+
+          IF v_old_balance = 0 THEN
+            v_wallet_initialized := v_wallet_initialized + 1;
+          ELSE
+            v_wallet_updated := v_wallet_updated + 1;
+          END IF;
+        END IF;
+      END IF;
+
+      UPDATE member_imports
+         SET validation_status  = 'committed',
+             resolved_member_id = v_new_id,
+             updated_by         = v_uid
+       WHERE id = v_row.id;
+    EXCEPTION
+      WHEN unique_violation THEN
+        UPDATE member_imports
+           SET validation_status = 'error_at_commit',
+               validation_errors = validation_errors || jsonb_build_array(
+                 jsonb_build_object('field','commit','code','unique_violation','message',SQLERRM)
+               ),
+               updated_by = v_uid
+         WHERE id = v_row.id;
+        v_skipped := v_skipped + 1;
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'batch_id',           p_batch_id,
+    'committed',          v_committed,
+    'updated',            v_updated,
+    'skipped',            v_skipped,
+    'wallet_initialized', v_wallet_initialized,
+    'wallet_updated',     v_wallet_updated
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_commit_member_import(TEXT, INT) TO authenticated;


### PR DESCRIPTION
## Summary

兩個 feature 在同 PR：

### A. 樂樂顧客 CSV 匯入
從樂樂團購訂單管理系統「顧客管理」匯出的 CSV 批次匯入 13k+ 會員 + 錢包餘額。實測 dev DB 完整跑過 12,397 筆，stage ~11s / commit ~8s。

### B. 員工權限管理 v1
admin UI 管理 auth.users + raw_app_meta_data 的 role / stores，無自建員工表，無邀請流（v2 再做）。

### C. 順帶修
CampaignForm 編輯 modal 的「收單時間」改可編 + 修掉誤導的「依商品自動帶入」說明文字。

---

## A. 樂樂會員 CSV 匯入

### 資料層
- `members` 加 `external_source` + `UNIQUE (tenant_id, external_source, external_id)` partial index
- 新表 `member_imports` (staging：raw + parsed + validation_status)
- 三個 RPC：`rpc_stage_member_import` / `rpc_commit_member_import` / `rpc_cancel_member_import`
- Helper：`_parse_lele_name` (regex 抽「#代號 : 【名字】後綴」) / `_resolve_or_create_takeout_store` / `_parse_lele_timestamp`
- **upsert by external_id**：同代號重 import 改 UPDATE，wallet 用差額 ledger
- **取貨店自動建**：標籤「永和」對不到既有 stores → 自動建「永和店」(code=`LELE-永和`)
- **錢包餘額**：> 0 寫 `wallet_ledger(type='adjust', source_type='import_lele')`
- **chunked stage/commit**：每 500 row 一個 RPC call + UI 進度條（避免 12k 筆 timeout）
- **commit perf**：chunk 開始算一次 max(member_no)、後續記憶體 +1（O(n²) → O(n)）

### Admin UI
- `/members/import` 頁 + parseLeleMemberCsv lib
- `/members` 列表：加「樂樂」chip、「取貨店」欄、整 row clickable → detail、多 column 排序

---

## B. 員工權限管理 v1

### 資料層 (4 個 SECURITY DEFINER RPC)
- `rpc_list_staff()` — 列出 tenant 全 users（含 email / display_name / role / stores / disabled / last_sign_in_at）
- `rpc_update_staff_role(p_user_id, p_role)` — 改 role
- `rpc_update_staff_stores(p_user_id, p_store_names TEXT[])` — 綁店（store name 陣列，'總倉' magic 也允許）
- helper: `_is_valid_staff_role` / `_caller_can_manage_staff` / `_caller_is_owner`

### 防鎖死 / 防越權（Node smoke test 全綠）
- ✓ 任何 caller 不能改自己 role / 自己 store
- ✓ admin 不能 grant owner / 不能改 owner
- ✓ 保留至少 1 個 owner（target=owner 改非 owner 時 check count）
- ✓ store name 必須存在 stores 表或為 '總倉' magic
- ✓ 跨 tenant 一律 reject

### 停用機制
- 軟刪除 = role='disabled'（既有 RLS 自然擋）
- 不改動任何既有 RLS policy（範圍可控）

### Admin UI
- `/staff` 列表 — 員工 / 角色 chip / 綁店 chip / 操作按鈕
- 「改角色」/「綁店」/「停用」/「啟用」modal
- 自己 row 的「改角色」「停用」按鈕 disabled + tooltip
- `RoleChip` 共用 component（中文 label：擁有者 / 系統管理員 / 總部經理 / 店長 ...）
- sidebar 新「設定」group → 員工管理（只 owner/admin 看得到）

### Out of scope (v2+)
- 邀請新員工（要 Edge Function + service_role 操作 auth.users）
- 自建 staff_members 表（員工編號 / 部門 / 離職紀錄）
- 操作日誌 / 細粒度權限

---

## C. CampaignForm 收單時間 fix

之前「收單時間」input 只在快團顯示，常規 / 限量團隱藏；說明文字寫「依商品自動帶入」但商品根本沒這欄位（收單時間是商品多選開團時填的 campaign 自己欄位）。

改：收單時間 input 永遠可編；說明文字拿掉誤導項。

---

## Migrations 一覽 (19 個)

樂樂會員匯入: `20260613000010~140`（含 chunked / wallet / upsert / cleanup 等多次迭代）
員工權限: `20260613000150~170`（主 + fix + dev reset）

---

## Test plan

- [x] dev DB push 全部 migrations 成功
- [x] 樂樂匯入 Node integration tests 全綠（名字 regex / dedupe / store fuzzy / wallet / upsert / chunked）
- [x] 12,397 筆 CSV end-to-end stage + commit 跑通
- [x] `/members/import` UI mount 無 console error、進度條顯示
- [x] `/members` 列表「樂樂」chip / 取貨店欄 / row click / column sort 全綠
- [x] 員工權限 Node smoke test 全綠（防鎖死 / 防越權 / 跨 tenant reject）
- [x] CampaignForm「收單時間」eval 驗證顯示且可編
- [ ] `/staff` UI 視覺驗證（自動填登入表被安全機制擋，待 reviewer 自己登入確認）
- [ ] `pnpm --filter admin build` (CI 跑)

🤖 Generated with [Claude Code](https://claude.com/claude-code)