### PR TITLE
feat(members+stores): 樂樂名字不切割 + /stores 設定頁 + branch user sidebar 收斂

### DIFF
--- a/docs/TEST-member-import-no-split.md
+++ b/docs/TEST-member-import-no-split.md
@@ -1,0 +1,104 @@
+# 樂樂 CSV 匯入 — 名字不切割 / 整段塞入 members.name
+
+**對應 migration（待建）：** `supabase/migrations/20260613000180_member_import_name_no_split.sql`
+
+**動機：** 樂樂 CSV「名字」欄典型內容：
+
+```
+#15627428 : 【Vicky Hsu】209785-松山
+#15417025 : 【Alex Chen】297810-松山
+```
+
+目前 `_parse_lele_name` 用 regex `^#(\d+)\s*[:：]\s*【(.+?)】\s*(.*)$` 切成 `name=Vicky Hsu`、`suffix=209785-松山`，
+寫進 `members.name` 後使用者搜尋 `15627428` / `松山` / `209785` 全部都搜不到，違反「會員列表用整段字串搜尋」需求。
+
+**修改：** `_parse_lele_name` 改成 **`name = TRIM(p_raw)`、`suffix = NULL`**（永遠不切割）。
+既有 `external_source='lele'` 會員 + `member_imports` 一併回補（只動沒被手動編輯過的）。
+
+---
+
+## 0. 影響範圍
+
+- `_parse_lele_name(TEXT)` immutable function 重新定義
+- `rpc_stage_member_import` 不改 signature，但其呼叫 `_parse_lele_name` 後 `v_name = 整段`、`v_name_suffix = NULL`
+  - 之後 `parsed_name = 整段` 寫進 staging
+  - `parsed_notes = v_name_suffix = NULL`（之前是寫 suffix）
+  - 之後 commit 寫進 `members.name = 整段`、`members.notes = NULL`
+- 既有 lele 會員 / staging row 用 raw_data 回補
+- UI 不動：`/members/import` 預覽 `parsed_name_suffix` 為 null 時自動 hide
+
+---
+
+## 1. Migration / Function 層
+
+### 1.1 `_parse_lele_name` 不切割
+- [ ] `SELECT _parse_lele_name('#15627428 : 【Vicky Hsu】209785-松山')` →
+      `{"name":"#15627428 : 【Vicky Hsu】209785-松山","suffix":null}`
+- [ ] `SELECT _parse_lele_name('  #1 : 【A】suf  ')` → `name = '#1 : 【A】suf'`（外圍空白 trim 掉）
+- [ ] `SELECT _parse_lele_name(NULL)` → `{"name":null,"suffix":null}`
+- [ ] `SELECT _parse_lele_name('   ')` → `{"name":null,"suffix":null}`
+- [ ] `SELECT _parse_lele_name('純文字無格式')` → `{"name":"純文字無格式","suffix":null}`
+
+### 1.2 既有 lele 會員回補
+- [ ] 跑前 `SELECT count(*) FROM members WHERE external_source='lele' AND name !~ '^#\\d+'`（被切過的）
+- [ ] 跑後同 query → 應降為 0（除非被手動編輯）
+- [ ] 抽樣：對既匯入過的 external_id，`members.name` 與 `member_imports.raw_data->>'name_raw'` trim 後相同
+- [ ] **未動到** 被手動編輯過的會員（`members.name <> 當初 parsed_name`）
+- [ ] 抽樣：跑前後 `members.phone`、`members.member_no` 完全不變
+
+### 1.3 既有 member_imports 回補
+- [ ] `SELECT count(*) FROM member_imports WHERE source='lele' AND parsed_name !~ '^#\\d+'`（被切過）
+- [ ] 跑後同 query → 應降為 0
+- [ ] 抽樣：`parsed_name = TRIM(raw_data->>'name_raw')`、`parsed_name_suffix IS NULL`、`parsed_notes IS NULL`
+- [ ] `validation_status` 不被動
+
+### 1.4 不影響非 lele
+- [ ] `member_imports WHERE source <> 'lele'` 0 row 被 UPDATE（lele 專用）
+- [ ] `members WHERE external_source IS DISTINCT FROM 'lele'` 0 row 被動
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 stage 新 row：整段塞 parsed_name
+**情境：** stage `[{"external_id":"99999001","name_raw":"#99999001 : 【測試】123-松山","label":"松山","joined_at":"2026-05-13","last_visit_at":"","wallet_balance":""}]`
+**預期：** `parsed_name = '#99999001 : 【測試】123-松山'`、`parsed_name_suffix IS NULL`、`parsed_notes IS NULL`
+
+### 2.2 stage：name_raw 為空仍標 error
+**情境：** `name_raw = ''` / NULL
+**預期：** `validation_status='error'`、`validation_errors` 含 `{field:'name',code:'required'}`
+
+### 2.3 commit 新 member：members.name 為整段
+**情境：** 接 §2.1 commit
+**預期：** `members.name = '#99999001 : 【測試】123-松山'`、`members.notes IS NULL`、`takeout_store_name_hint = '松山'`、`home_store_id` 對應到 / 自動建的 store
+
+### 2.4 commit 更新既有 member（upsert）：name 用整段覆寫
+**情境：** 既有 `members.name='Vicky Hsu'`（之前被切過的）+ external_id 衝突，重 stage + commit
+**預期：** name 被覆寫為整段 `#... : 【Vicky Hsu】...`
+
+### 2.5 搜尋
+**情境：** `/members?q=15627428` / `q=松山` / `q=209785` / `q=Vicky`
+**預期：** 全部 hit 同一筆會員
+
+---
+
+## 3. UI 行為（preview 互動，可選）
+
+- [ ] `/members/import` 上傳新檔，預覽欄「姓名」顯示整段，不再出現 `／後綴` 灰字
+- [ ] `/members` 列表搜尋 `15627428` 能找到對應會員
+
+---
+
+## 4. Regression
+
+- [ ] `_parse_lele_timestamp` 不動
+- [ ] `_resolve_or_create_takeout_store` 不動
+- [ ] `rpc_stage_member_import` 其他欄位（external_id / store / joined_at / wallet）行為不變
+- [ ] `rpc_commit_member_import` upsert 流程不變（只是 name 改成整段）
+- [ ] 非 lele 來源（pinduoduo / 1688 / manual）走 stage 時 `_parse_lele_name` 仍 trim 整段（不影響也不切割）
+
+---
+
+## 5. 驗收門檻
+
+§1-§4 全勾、`supabase db push` 成功、跑一次新樂樂 CSV 端到端確認 `members.name` 整段、`/members` 用 `15627428` / `松山` 搜得到。

--- a/supabase/migrations/20260613000180_member_import_name_no_split.sql
+++ b/supabase/migrations/20260613000180_member_import_name_no_split.sql
@@ -1,0 +1,71 @@
+-- ============================================================
+-- 樂樂 CSV 名字「不切割」：整段塞 members.name + parsed_name
+--
+-- 原本 _parse_lele_name 用 regex 抽出 `【...】` 中間段當 name、後綴存 suffix；
+-- 但樂樂顧客代號 + 取貨店 hint 都在原始字串裡，切掉後使用者搜尋
+--   「15627428」/「松山」/「209785」 全部都搜不到。
+--
+-- 改成：name = TRIM(p_raw)、suffix = NULL，整段都留在 name 欄位。
+-- 既有 lele 會員 + member_imports 一併用 raw_data 回補（只動沒被手動編輯過的）。
+-- ============================================================
+
+-- 1. _parse_lele_name 不再切割
+CREATE OR REPLACE FUNCTION public._parse_lele_name(p_raw TEXT)
+RETURNS JSONB LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+  v_trim TEXT;
+BEGIN
+  v_trim := NULLIF(TRIM(p_raw), '');
+  RETURN jsonb_build_object('name', v_trim, 'suffix', NULL);
+END;
+$$;
+
+COMMENT ON FUNCTION public._parse_lele_name(TEXT) IS
+  '樂樂名字整段 trim 後當 name；不切「#代號 : 【姓名】後綴」，方便整段搜尋。';
+
+-- ------------------------------------------------------------
+-- 2. 回補既有 members.name
+--    順序很重要：先 members（用舊 mi.parsed_name 判斷未編輯）、再 member_imports。
+--    條件：member.name = 當初 stage 切出來的 parsed_name 才覆寫，
+--    意即沒被手動編輯過的；手動改過的（如 admin 在 UI 改成「Vicky」）保留。
+-- ------------------------------------------------------------
+WITH src AS (
+  SELECT DISTINCT ON (mi.resolved_member_id)
+    mi.resolved_member_id AS member_id,
+    mi.tenant_id,
+    mi.parsed_name        AS old_parsed_name,
+    TRIM(mi.raw_data->>'name_raw') AS full_name
+  FROM member_imports mi
+  WHERE mi.source = 'lele'
+    AND mi.resolved_member_id IS NOT NULL
+    AND mi.raw_data ? 'name_raw'
+    AND TRIM(COALESCE(mi.raw_data->>'name_raw','')) <> ''
+  ORDER BY mi.resolved_member_id, mi.updated_at DESC
+)
+UPDATE members m SET
+  name       = src.full_name,
+  updated_at = NOW()
+FROM src
+WHERE m.id = src.member_id
+  AND m.tenant_id = src.tenant_id
+  AND m.external_source = 'lele'
+  AND m.name = src.old_parsed_name   -- 未被手動編輯
+  AND m.name IS DISTINCT FROM src.full_name;
+
+-- ------------------------------------------------------------
+-- 3. 回補既有 member_imports.parsed_name（lele 來源 + 切過的）
+--    要在 §2 之後跑，因為 §2 用到舊 parsed_name。
+-- ------------------------------------------------------------
+UPDATE member_imports SET
+  parsed_name        = TRIM(raw_data->>'name_raw'),
+  parsed_name_suffix = NULL,
+  parsed_notes       = NULL,
+  updated_at         = NOW()
+WHERE source = 'lele'
+  AND raw_data ? 'name_raw'
+  AND TRIM(COALESCE(raw_data->>'name_raw','')) <> ''
+  AND (
+    parsed_name IS DISTINCT FROM TRIM(raw_data->>'name_raw')
+    OR parsed_name_suffix IS NOT NULL
+    OR parsed_notes IS NOT NULL
+  );

--- a/supabase/migrations/20260613000190_rpc_purge_lele_imports_v6.sql
+++ b/supabase/migrations/20260613000190_rpc_purge_lele_imports_v6.sql
@@ -1,0 +1,92 @@
+-- ============================================================
+-- v6: purge 跳過已被 customer_orders 連到的 lele 會員（FK protect）
+-- 用 NOT EXISTS subquery 過濾 candidate ids；其餘流程同 v5。
+-- 為了讓 client while-loop 能停下來，新增 skipped_with_orders 在每 chunk 回傳。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_admin_purge_lele_imports(
+  p_limit INT DEFAULT 500
+) RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  v_member_ids BIGINT[];
+  v_n_members  INT := 0;
+  v_n_stores   INT := 0;
+  v_n_imports  INT := 0;
+  v_n_wallet_l INT := 0;
+  v_n_wallet_b INT := 0;
+  v_n_push     INT := 0;
+  v_n_skipped  INT := 0;
+BEGIN
+  SELECT array_agg(id) INTO v_member_ids
+    FROM (
+      SELECT m.id FROM members m
+       WHERE m.tenant_id = v_tenant
+         AND m.external_source = 'lele'
+         AND NOT EXISTS (
+           SELECT 1 FROM customer_orders co
+            WHERE co.member_id = m.id
+         )
+       LIMIT p_limit
+    ) sub;
+
+  IF v_member_ids IS NOT NULL AND array_length(v_member_ids, 1) > 0 THEN
+    EXECUTE 'ALTER TABLE wallet_ledger DISABLE TRIGGER trg_no_delete_wallet';
+    EXECUTE 'ALTER TABLE points_ledger DISABLE TRIGGER USER';
+    EXECUTE 'ALTER TABLE members       DISABLE TRIGGER trg_no_delete_member';
+
+    DELETE FROM wallet_ledger          WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_l = ROW_COUNT;
+
+    DELETE FROM wallet_balances        WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_wallet_b = ROW_COUNT;
+
+    DELETE FROM points_ledger          WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_points_balance  WHERE member_id = ANY(v_member_ids);
+    DELETE FROM member_cards           WHERE member_id = ANY(v_member_ids);
+    DELETE FROM customer_line_aliases  WHERE member_id = ANY(v_member_ids);
+
+    DELETE FROM push_subscriptions     WHERE member_id = ANY(v_member_ids);
+    GET DIAGNOSTICS v_n_push = ROW_COUNT;
+
+    DELETE FROM members                WHERE id = ANY(v_member_ids);
+    v_n_members := array_length(v_member_ids, 1);
+
+    EXECUTE 'ALTER TABLE wallet_ledger ENABLE TRIGGER trg_no_delete_wallet';
+    EXECUTE 'ALTER TABLE points_ledger ENABLE TRIGGER USER';
+    EXECUTE 'ALTER TABLE members       ENABLE TRIGGER trg_no_delete_member';
+  END IF;
+
+  -- 計算還剩多少帶 orders 跳過（每 chunk 都回，client 知何時停）
+  SELECT COUNT(*) INTO v_n_skipped
+    FROM members m
+   WHERE m.tenant_id = v_tenant
+     AND m.external_source = 'lele'
+     AND EXISTS (SELECT 1 FROM customer_orders co WHERE co.member_id = m.id);
+
+  -- 只在 chunk 0 members 時清 staging + stores
+  IF v_n_members = 0 THEN
+    DELETE FROM member_imports WHERE tenant_id = v_tenant;
+    GET DIAGNOSTICS v_n_imports = ROW_COUNT;
+
+    DELETE FROM stores
+     WHERE tenant_id = v_tenant
+       AND code LIKE 'LELE-%'
+       AND NOT EXISTS (
+         SELECT 1 FROM members m
+          WHERE m.home_store_id = stores.id
+       );
+    GET DIAGNOSTICS v_n_stores = ROW_COUNT;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'members_deleted',         v_n_members,
+    'wallet_ledger_deleted',   v_n_wallet_l,
+    'wallet_balances_deleted', v_n_wallet_b,
+    'push_subs_deleted',       v_n_push,
+    'imports_deleted',         v_n_imports,
+    'stores_deleted',          v_n_stores,
+    'skipped_with_orders',     v_n_skipped
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary

四件事：

### 1. 樂樂 CSV 名字不切割 (commit 5d7055f)
- `_parse_lele_name` 不再用 regex 切「`#代號 : 【姓名】後綴`」，整段 trim 後當 `members.name`
- 既有 21,875 筆 `external_source='lele'` 會員 + member_imports 用 raw_data 回補
- 動機：使用者要在 `/members` 搜「`15627428`」/「`松山`」/「`209785`」全部 hit

### 2. Purge RPC v6 (commit c0d669b)
- `rpc_admin_purge_lele_imports` 跳過有 `customer_orders` 連結的 lele 會員（FK protect）
- 用戶確認後實跑：刪 21,868 筆會員 + wallet_ledger / member_imports / 自動建的 LELE-* stores，保留 7 筆有 pending 訂單的

### 3. 門市設定頁 `/stores` (commit 173dd6f)
- 列表 + 搜尋 + 兩段篩選（啟用、樂樂自動建）+ inline 編輯/新增
- 透過既有 `rpc_upsert_store` 寫入
- Sidebar「設定」group 加連結（owner/admin only，branch 隱藏）
- 範疇外：LINE OA / off_days / notification_mode / supplier_id / 實刪除

### 4. Branch user 隱藏「商品」(commit 6e7e892)
- `/products` 加進 `BRANCH_HIDDEN_HREFS`
- 店長 / 店員（`app_metadata.stores` 不含「總倉」）sidebar 看不到商品連結
- 路由層沒擋（硬打 URL 還能進）；需要的話另案

## 影響範圍

- **DB：** 2 個新 migration (`20260613000180_member_import_name_no_split.sql` + `20260613000190_rpc_purge_lele_imports_v6.sql`)，已 push 到 prod
- **資料：** prod 已執行 21,868 筆 lele 會員 + 相關 wallet/imports/stores 刪除
- **UI：** 新增 `/stores` 頁、sidebar 加門市連結、商品連結對 branch user 隱藏

## 驗證

- [x] `_parse_lele_name('#15627428 : 【Vicky Hsu】209785-松山')` 回整段
- [x] 21,875 筆 lele 會員 name 全部 `^#\d+` 整段格式（回補完）
- [x] purge 跑完 prod 剩 7 筆有 pending 訂單的（FK protect）
- [x] `member_imports` 0、`stores LIKE 'LELE-%'` 剩 2 筆（保留會員的 home_store）
- [x] typescript 編譯通過
- [ ] `/stores` UI browser preview — 沒做（worktree 沒 `.env.local`、sandbox 擋下複製）

## Wiki + Issues

- Wiki 會員模組加樂樂 CSV 匯入章節 + 不切割原則
- Wiki 訂單取貨模組加門市管理頁章節
- Issue #41「會員資料遷移」加 comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)