### PR TITLE
feat(stores+nav): /stores 門市設定頁 + branch user 隱藏商品 sidebar

### DIFF
--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -70,6 +70,7 @@ const NAV: NavGroup[] = [
     title: "設定",
     items: [
       { href: "/staff", label: "員工管理", match: /^\/staff/ },
+      { href: "/stores", label: "門市", match: /^\/stores/ },
     ],
   },
 ];
@@ -99,6 +100,7 @@ const BRANCH_HIDDEN_HREFS = new Set([
   "/wms/picking",         // 派貨工作台
   // /wms/inbound 跟 /wms/transfers 不在這裡 — 分店要用,屬於分店業務
   "/finance/receivables", // HQ 應收
+  "/stores",              // 門市設定 (HQ 管理)
 ]);
 const BRANCH_HIDDEN_GROUPS = new Set([
   "社群選品", // 整個 group 隱藏

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -93,6 +93,7 @@ const NAV_COLLAPSE_KEY = "new_erp-nav-collapsed";
 // 分店帳號 (app_metadata.stores 有值且不含「總倉」) 隱藏的項目
 const BRANCH_HIDDEN_HREFS = new Set([
   "/hq/inbox",            // 總倉收件匣
+  "/products",            // 商品主檔 (HQ 管理)
   "/suppliers",           // 供應商 (HQ 管理)
   "/purchase/requests",   // 採購單
   "/purchase/orders",     // 採購訂單

--- a/apps/admin/src/app/(protected)/stores/page.tsx
+++ b/apps/admin/src/app/(protected)/stores/page.tsx
@@ -1,0 +1,464 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import SpinButton from "@/components/SpinButton";
+import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
+
+const PAGE_SIZE = 20;
+
+type PaymentMethod = "cash" | "credit_card" | "transfer" | "line_pay" | "wallet";
+const PAYMENT_LABELS: Record<PaymentMethod, string> = {
+  cash: "現金",
+  credit_card: "信用卡",
+  transfer: "轉帳",
+  line_pay: "LINE Pay",
+  wallet: "儲值金",
+};
+const PAYMENT_OPTIONS: PaymentMethod[] = ["cash", "credit_card", "transfer", "line_pay", "wallet"];
+
+type Store = {
+  id: number;
+  code: string;
+  name: string;
+  location_id: number | null;
+  pickup_window_days: number;
+  allowed_payment_methods: PaymentMethod[];
+  is_active: boolean;
+  notes: string | null;
+  updated_at: string;
+};
+
+type Location = { id: number; code: string; name: string };
+
+type StoreFormValues = Omit<Store, "id" | "updated_at"> & { id: number | null };
+
+const EMPTY: Omit<Store, "id" | "updated_at"> = {
+  code: "",
+  name: "",
+  location_id: null,
+  pickup_window_days: 5,
+  allowed_payment_methods: ["cash"],
+  is_active: true,
+  notes: null,
+};
+
+type ActiveFilter = "active" | "all";
+type LeleFilter = "all" | "lele_only" | "exclude_lele";
+
+export default function StoresPage() {
+  const [rows, setRows] = useState<Store[] | null>(null);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [queryDraft, setQueryDraft] = useState("");
+  const [query, setQuery] = useState("");
+  const [activeFilter, setActiveFilter] = useState<ActiveFilter>("active");
+  const [leleFilter, setLeleFilter] = useState<LeleFilter>("all");
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<Store | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    const t = setTimeout(() => setQuery(queryDraft), 250);
+    return () => clearTimeout(t);
+  }, [queryDraft]);
+
+  useEffect(() => { setPage(1); }, [query, activeFilter, leleFilter]);
+
+  // 載入 locations (供下拉)
+  useEffect(() => {
+    (async () => {
+      const { data, error: err } = await getSupabase()
+        .from("locations")
+        .select("id, code, name")
+        .eq("type", "store")
+        .eq("is_active", true)
+        .order("name");
+      if (err) setError(err.message);
+      else setLocations((data ?? []) as Location[]);
+    })();
+  }, []);
+
+  async function reload() {
+    let q = getSupabase()
+      .from("stores")
+      .select("id, code, name, location_id, pickup_window_days, allowed_payment_methods, is_active, notes, updated_at")
+      .order("updated_at", { ascending: false })
+      .limit(500);
+    if (query.trim()) {
+      const safe = query.replace(/[%,()]/g, " ").trim();
+      q = q.or(`code.ilike.%${safe}%,name.ilike.%${safe}%`);
+    }
+    if (activeFilter === "active") q = q.eq("is_active", true);
+    if (leleFilter === "lele_only") q = q.like("code", "LELE-%");
+    else if (leleFilter === "exclude_lele") q = q.not("code", "like", "LELE-%");
+    const { data, error: err } = await q;
+    if (err) { setError(err.message); return; }
+    setError(null);
+    setRows((data ?? []) as Store[]);
+  }
+  useEffect(() => { reload(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [query, activeFilter, leleFilter]);
+
+  const totalPages = Math.max(1, Math.ceil((rows?.length ?? 0) / PAGE_SIZE));
+  const paginated = useMemo(
+    () => (rows ?? []).slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
+    [rows, page],
+  );
+
+  async function save(v: StoreFormValues) {
+    try {
+      const { error: err } = await getSupabase().rpc("rpc_upsert_store", {
+        p_id: v.id ?? null,
+        p_code: v.code.trim(),
+        p_name: v.name.trim(),
+        p_location_id: v.location_id,
+        p_pickup_window_days: v.pickup_window_days,
+        p_allowed_payment_methods: v.allowed_payment_methods,
+        p_is_active: v.is_active,
+        p_notes: v.notes,
+      });
+      if (err) throw err;
+      setEditing(null);
+      setCreating(false);
+      setError(null);
+      await reload();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(/duplicate key|unique/.test(msg) ? `代碼 ${v.code} 已存在` : msg);
+    }
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">門市</h1>
+          <p className="text-sm text-zinc-500">共 {rows?.length ?? 0} 筆</p>
+        </div>
+        {!creating && !editing && (
+          <SpinButton
+            onClick={() => setCreating(true)}
+            className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            新增門市
+          </SpinButton>
+        )}
+      </header>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {creating && (
+        <StoreForm
+          initial={{ ...EMPTY, id: null }}
+          title="新增"
+          locations={locations}
+          onCancel={() => setCreating(false)}
+          onSave={(v) => save({ ...v, id: null })}
+        />
+      )}
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <input
+          type="search"
+          value={queryDraft}
+          onChange={(e) => setQueryDraft(e.target.value)}
+          placeholder="搜尋 代碼 / 名稱"
+          className={inputCls}
+        />
+        <select
+          value={activeFilter}
+          onChange={(e) => setActiveFilter(e.target.value as ActiveFilter)}
+          className={inputCls}
+        >
+          <option value="active">僅啟用中</option>
+          <option value="all">全部（含停用）</option>
+        </select>
+        <select
+          value={leleFilter}
+          onChange={(e) => setLeleFilter(e.target.value as LeleFilter)}
+          className={inputCls}
+        >
+          <option value="all">全部來源</option>
+          <option value="lele_only">僅樂樂自動建</option>
+          <option value="exclude_lele">排除樂樂自動建</option>
+        </select>
+      </div>
+
+      <Table>
+        <THead>
+          <Th>代碼</Th>
+          <Th>名稱</Th>
+          <Th>對應 location</Th>
+          <Th align="right">取貨窗 (天)</Th>
+          <Th>付款方式</Th>
+          <Th>狀態</Th>
+          <Th>更新</Th>
+          <Th>{""}</Th>
+        </THead>
+        <TBody>
+          {rows === null ? (
+            <LoadingRow colSpan={8} />
+          ) : rows.length === 0 ? (
+            <EmptyRow colSpan={8}>沒有符合條件的門市</EmptyRow>
+          ) : (
+            paginated.map((r) =>
+              editing?.id === r.id ? (
+                <tr key={r.id}>
+                  <td colSpan={8} className="p-0">
+                    <StoreForm
+                      initial={{ ...r, id: r.id }}
+                      title="編輯"
+                      locations={locations}
+                      onCancel={() => setEditing(null)}
+                      onSave={(v) => save({ ...v, id: r.id })}
+                    />
+                  </td>
+                </tr>
+              ) : (
+                <Tr key={r.id}>
+                  <Td className="font-mono text-xs">
+                    <div className="flex items-center gap-1.5">
+                      <span>{r.code}</span>
+                      {r.code.startsWith("LELE-") && (
+                        <span
+                          title="樂樂 CSV 匯入時自動建立"
+                          className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-normal text-amber-700 dark:bg-amber-950 dark:text-amber-300"
+                        >
+                          樂樂
+                        </span>
+                      )}
+                    </div>
+                  </Td>
+                  <Td>{r.name}</Td>
+                  <Td className="text-xs text-zinc-500">
+                    {r.location_id
+                      ? locations.find((l) => l.id === r.location_id)?.name ?? `#${r.location_id}`
+                      : "—"}
+                  </Td>
+                  <Td align="right" className="font-mono text-xs">{r.pickup_window_days}</Td>
+                  <Td className="text-xs">
+                    {(r.allowed_payment_methods ?? []).length
+                      ? r.allowed_payment_methods.map((m) => PAYMENT_LABELS[m] ?? m).join("、")
+                      : "—"}
+                  </Td>
+                  <Td>
+                    <span
+                      className={`inline-block rounded px-2 py-0.5 text-xs ${
+                        r.is_active
+                          ? "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300"
+                          : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+                      }`}
+                    >
+                      {r.is_active ? "啟用" : "停用"}
+                    </span>
+                  </Td>
+                  <Td className="whitespace-nowrap text-xs text-zinc-500">
+                    {new Date(r.updated_at).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" })}
+                  </Td>
+                  <Td>
+                    <SpinButton
+                      onClick={() => setEditing(r)}
+                      className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      編輯
+                    </SpinButton>
+                  </Td>
+                </Tr>
+              ),
+            )
+          )}
+        </TBody>
+      </Table>
+
+      {(rows?.length ?? 0) > PAGE_SIZE && (
+        <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
+          <span className="text-xs text-zinc-500">
+            共 {rows?.length ?? 0} 筆 · 顯示 {(page - 1) * PAGE_SIZE + 1} - {Math.min(page * PAGE_SIZE, rows?.length ?? 0)}
+          </span>
+          <PagerBtn onClick={() => setPage(1)} disabled={page === 1}>« 第一頁</PagerBtn>
+          <PagerBtn onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>‹ 上頁</PagerBtn>
+          <span className="text-xs text-zinc-500">{page} / {totalPages}</span>
+          <PagerBtn onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages}>下頁 ›</PagerBtn>
+          <PagerBtn onClick={() => setPage(totalPages)} disabled={page === totalPages}>最末頁 »</PagerBtn>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PagerBtn({
+  onClick,
+  disabled,
+  children,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <SpinButton
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+    >
+      {children}
+    </SpinButton>
+  );
+}
+
+function StoreForm({
+  initial,
+  title,
+  locations,
+  onSave,
+  onCancel,
+}: {
+  initial: StoreFormValues;
+  title: string;
+  locations: Location[];
+  onSave: (v: StoreFormValues) => void;
+  onCancel: () => void;
+}) {
+  const [v, setV] = useState<StoreFormValues>(initial);
+  function up<K extends keyof typeof v>(k: K, val: typeof v[K]) {
+    setV({ ...v, [k]: val });
+  }
+  function togglePayment(m: PaymentMethod) {
+    const cur = new Set(v.allowed_payment_methods ?? []);
+    if (cur.has(m)) cur.delete(m);
+    else cur.add(m);
+    up("allowed_payment_methods", Array.from(cur) as PaymentMethod[]);
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSave(v);
+      }}
+      className="space-y-3 border-l-4 border-blue-400 bg-blue-50/40 p-4 dark:bg-blue-950/20"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">{title}</h3>
+        {v.code.startsWith("LELE-") && (
+          <span className="rounded bg-amber-100 px-2 py-0.5 text-[10px] text-amber-700 dark:bg-amber-950 dark:text-amber-300">
+            樂樂自動建立
+          </span>
+        )}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-4">
+        <F label="代碼 *">
+          <input
+            value={v.code}
+            onChange={(e) => up("code", e.target.value)}
+            required
+            className={inputCls}
+          />
+        </F>
+        <F label="名稱 *">
+          <input
+            value={v.name}
+            onChange={(e) => up("name", e.target.value)}
+            required
+            className={inputCls}
+          />
+        </F>
+        <F label="對應 location (倉別)">
+          <select
+            value={v.location_id ?? ""}
+            onChange={(e) => up("location_id", e.target.value ? Number(e.target.value) : null)}
+            className={inputCls}
+          >
+            <option value="">— 未設定 —</option>
+            {locations.map((l) => (
+              <option key={l.id} value={l.id}>
+                {l.name} ({l.code})
+              </option>
+            ))}
+          </select>
+        </F>
+        <F label="取貨窗 (天)">
+          <input
+            type="number"
+            min={1}
+            value={v.pickup_window_days}
+            onChange={(e) => up("pickup_window_days", Math.max(1, Number(e.target.value) || 1))}
+            className={inputCls}
+          />
+        </F>
+
+        <F label="付款方式" className="sm:col-span-3">
+          <div className="flex flex-wrap gap-3 pt-1.5">
+            {PAYMENT_OPTIONS.map((m) => (
+              <label key={m} className="flex items-center gap-1.5 text-sm">
+                <input
+                  type="checkbox"
+                  checked={(v.allowed_payment_methods ?? []).includes(m)}
+                  onChange={() => togglePayment(m)}
+                />
+                <span>{PAYMENT_LABELS[m]}</span>
+              </label>
+            ))}
+          </div>
+        </F>
+        <F label="啟用">
+          <label className="flex items-center gap-2 pt-1.5 text-sm">
+            <input
+              type="checkbox"
+              checked={v.is_active}
+              onChange={(e) => up("is_active", e.target.checked)}
+            />
+            <span>{v.is_active ? "啟用中" : "停用"}</span>
+          </label>
+        </F>
+
+        <F label="備註" className="sm:col-span-4">
+          <textarea
+            value={v.notes ?? ""}
+            onChange={(e) => up("notes", e.target.value || null)}
+            className={`${inputCls} min-h-16`}
+          />
+        </F>
+      </div>
+      <div className="flex items-center gap-2">
+        <SpinButton
+          type="submit"
+          className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          儲存
+        </SpinButton>
+        <SpinButton
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          取消
+        </SpinButton>
+      </div>
+    </form>
+  );
+}
+
+function F({
+  label,
+  children,
+  className = "",
+}: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <label className={`flex flex-col gap-1 text-sm ${className}`}>
+      <span className="text-xs text-zinc-500">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+const inputCls =
+  "rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800";

--- a/docs/TEST-stores-settings.md
+++ b/docs/TEST-stores-settings.md
@@ -1,0 +1,99 @@
+# 門市設定頁 `/stores`
+
+**對應頁面：** `apps/admin/src/app/(protected)/stores/page.tsx`（新增）
+**對應 RPC：** `rpc_upsert_store` (`supabase/migrations/20260425120000_core_crud_rpcs.sql:273`)
+**對應 schema：** `stores` (`supabase/migrations/20260423120000_stores_order_schema.sql:13`)
+
+**動機：** 樂樂 CSV 匯入會自動建 `LELE-{標籤}` store，加上原有手動建的 store，目前管理介面沒有列表頁
+能瀏覽 / 編輯 / 停用，需要一個簡易設定頁。
+
+---
+
+## 0. 範圍
+
+**v1（本次）**
+- 列表：code / 名稱 / location 對應 / 取貨窗 / 付款方式 / 狀態
+- 搜尋：code + name ilike
+- 過濾：是否啟用、是否樂樂自動建 (`code LIKE 'LELE-%'`)
+- inline 編輯：code、name、location_id、pickup_window_days、allowed_payment_methods、is_active、notes
+- 新增
+
+**v1 不做**
+- LINE OA 設定（線下另行處理；`line_oa_*` 欄位有加密 BYTEA）
+- 公休日 `off_days`（JSON 編輯器需要另設 UI）
+- `notification_mode`（屬通知模組）
+- supplier_id（AP 模組自動填）
+- 刪除（用「停用」代替）
+
+---
+
+## 1. 列表行為
+
+### 1.1 預設載入
+- [ ] `/stores` 載入無 console error
+- [ ] 預設只顯示 `is_active = TRUE`
+- [ ] 排序：updated_at desc
+
+### 1.2 搜尋
+- [ ] 搜「松山」→ name 含松山 hit
+- [ ] 搜「LELE-永和」→ code hit
+- [ ] 250ms debounce
+
+### 1.3 篩選
+- [ ] 「全部 / 僅啟用」切換正常
+- [ ] 「全部 / 僅樂樂自動建 / 排除樂樂自動建」三段切換
+
+### 1.4 樂樂 chip
+- [ ] `code LIKE 'LELE-%'` 顯示「樂樂自動建」amber chip
+- [ ] 一般 store 不顯示 chip
+
+### 1.5 分頁
+- [ ] 多於 20 筆出現 pager
+- [ ] 切頁切換正常
+
+---
+
+## 2. 編輯行為
+
+### 2.1 新增
+- [ ] 點「新增門市」→ 出現 inline 表單
+- [ ] code、name 必填
+- [ ] location 為 select（從 `locations WHERE type='store' AND is_active`）；可留空
+- [ ] pickup_window_days 預設 5、min 1
+- [ ] allowed_payment_methods 預設 `['cash']`，可 checkbox 勾 cash/credit_card/transfer/line_pay/wallet
+- [ ] 儲存呼叫 `rpc_upsert_store(p_id=NULL,...)` 成功
+
+### 2.2 編輯
+- [ ] 點「編輯」→ inline 表單帶入既有值
+- [ ] 修改 name、儲存後列表立即更新
+- [ ] 取消不寫入
+
+### 2.3 停用
+- [ ] 編輯時取消「啟用」checkbox → 儲存 → `is_active=false`
+- [ ] 篩「僅啟用」時不顯示
+
+### 2.4 錯誤處理
+- [ ] code 重複 → 紅字「已存在」（unique violation）
+- [ ] 沒輸入必填 → HTML required 擋下
+
+---
+
+## 3. 權限
+
+- [ ] 只 owner / admin / hq_manager 看得到（沿用 stores 表 RLS）
+- [ ] sidebar 該連結放「設定」group（已是 admin-only）
+- [ ] 分店帳號（branch user）看不到 sidebar 連結（加進 `BRANCH_HIDDEN_HREFS`）
+
+---
+
+## 4. Regression
+
+- [ ] `/members` 列表的「取貨店」select 不受影響（用同 stores 表）
+- [ ] `/campaigns/order-entry` 的店家 dropdown 不變
+- [ ] 樂樂 CSV `/members/import` 仍能自動建 store
+- [ ] HQ Inbox 載入 stores 不變
+
+---
+
+## 5. 驗收門檻
+全勾 + dev server 啟動 + preview 列表能載 + 編輯一筆能存 + 新增一筆能存。


### PR DESCRIPTION
## Summary

兩件事，從 PR #219 拆出來獨立 review。

### 1. `/stores` 門市設定頁 (commit 2fba399)
- 新頁面 `/stores`：列表 + 搜尋（code/name ilike, 250ms debounce）+ 兩段篩選（啟用 / 樂樂自動建）
- inline 編輯 / 新增（複用 `/suppliers` pattern）
- 透過既有 `rpc_upsert_store` 寫入
- Sidebar「設定」group 加連結（owner/admin only，branch 隱藏）
- 樂樂自動建的 `code LIKE 'LELE-%'` 顯示 amber chip

**未做（v1 範圍外）：** LINE OA 設定（線下，含加密欄位）、公休日 `off_days`、`notification_mode`、`supplier_id`、實刪除

### 2. Branch user 隱藏「商品」(commit 3ccb5a1)
- `/products` 加進 `BRANCH_HIDDEN_HREFS`
- 店長 / 店員（`app_metadata.stores` 不含「總倉」）sidebar 看不到「商品」
- 路由層**沒擋**（硬打 URL 還能進）；硬擋等另案

## 不影響 schema

純前端 + 用既有 RPC，沒新 migration。

## Test plan

- [x] TypeScript compile passes (`tsc --noEmit`)
- [x] `/stores` 路由 server-side 回 200
- [ ] Browser preview — 沒做（worktree 沒 `.env.local`、sandbox 擋複製）
- [ ] HQ 帳號看到 sidebar「設定 → 門市」連結
- [ ] 分店帳號 sidebar 沒「商品」和「門市」
- [ ] `/stores` 列表能載入、能新增 / 編輯
- [ ] 樂樂篩選器：剩 2 個 `LELE-*` store（保留會員的 home_store）

## 相關

- 依賴：PR #219（樂樂 CSV 名字不切割 + purge）merge 後 main 才有正確的會員資料供測試
- 測試清單：[docs/TEST-stores-settings.md](https://github.com/lt-foods/new_erp/blob/claude/stores-settings-page/docs/TEST-stores-settings.md)
- Wiki：[訂單取貨模組#門市管理頁-stores](https://github.com/lt-foods/new_erp/wiki/訂單取貨模組#門市管理頁-stores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)