### PR TITLE
fix(campaigns): 本團訂單會員欄改用 members.name

### DIFF
--- a/apps/admin/src/components/CampaignOrdersPanel.tsx
+++ b/apps/admin/src/components/CampaignOrdersPanel.tsx
@@ -15,6 +15,7 @@ type OrderRow = {
   notes: string | null;
   order_kind: string | null;
   created_at: string;
+  member: { id: number; name: string | null } | null;
   customer_order_items: { qty: number; unit_price: number }[];
 };
 
@@ -49,7 +50,7 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
           sb
             .from("customer_orders")
             .select(
-              "id, order_no, status, pickup_store_id, nickname_snapshot, notes, order_kind, created_at, customer_order_items(qty, unit_price)",
+              "id, order_no, status, pickup_store_id, nickname_snapshot, notes, order_kind, created_at, member:members(id, name), customer_order_items(qty, unit_price)",
             )
             .eq("campaign_id", campaignId)
             .order("created_at", { ascending: false }),
@@ -187,7 +188,20 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
                           </span>
                         )}
                       </td>
-                      <td className="px-3 py-1.5">{r.nickname_snapshot ?? "—"}</td>
+                      <td className="px-3 py-1.5">
+                        {r.member?.name ? (
+                          <Link
+                            href={`/members?id=${r.member.id}`}
+                            className="hover:underline"
+                          >
+                            {r.member.name}
+                          </Link>
+                        ) : r.nickname_snapshot ? (
+                          <span className="text-zinc-500">({r.nickname_snapshot})</span>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
                       <td className="px-3 py-1.5 text-zinc-600 dark:text-zinc-400">{store?.name ?? "—"}</td>
                       <td className="px-3 py-1.5">
                         <span className={`inline-block rounded px-1.5 py-0.5 ${STATUS_BADGE[r.status] ?? STATUS_BADGE.pending}`}>


### PR DESCRIPTION
## Summary
- `CampaignOrdersPanel`（活動編輯頁的「本團訂單」面板）只 select `nickname_snapshot` 顯示會員，外部匯入訂單（lt-erp / 樂樂 CSV 路徑沒填這欄）整列就變「—」一片，看不出是誰下的單
- 改成跟 [/orders 完整訂單頁](apps/admin/src/app/(protected)/orders/page.tsx) 一致 — 用 Supabase nested select `member:members(id, name)` join 出真正的會員，顯示優先序：`members.name` → `nickname_snapshot`（小灰括號表示「只是當時暱稱、不是真正會員」）→ `—`
- `members.name` 加 link 到 `/members?id=` 方便點進去看會員卡

## Test plan
- [ ] 開一個有訂單的活動編輯頁，本團訂單表「會員」欄顯示會員姓名（之前是「—」的那批）
- [ ] 真的沒掛 member 的訂單仍顯示 `—`、只有 nickname 沒 member 的顯示灰色 `(nickname)`
- [ ] 點會員名能跳到 `/members?id=…`
- [ ] 切換門市篩選後會員欄仍正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)