### PR TITLE
fix(ci): CampaignOrdersPanel member join TS 型別 cast

### DIFF
--- a/apps/admin/src/components/CampaignOrdersPanel.tsx
+++ b/apps/admin/src/components/CampaignOrdersPanel.tsx
@@ -59,7 +59,7 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
         if (cancelled) return;
         if (ordersRes.error) throw ordersRes.error;
         if (storesRes.error) throw storesRes.error;
-        setRows((ordersRes.data ?? []) as OrderRow[]);
+        setRows((ordersRes.data ?? []) as unknown as OrderRow[]);
         setStores((storesRes.data ?? []) as Store[]);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));


### PR DESCRIPTION
## Summary
- PR #222 加 `member:members(id, name)` join 後，CI TypeScript build 紅燈（main 也紅）
- PostgREST 在無 generated DB types 時把多對一推論成 `{ id, name }[]`，跟 OrderRow 宣告（單一物件）撞型別
- 走專案既有 pattern：`as unknown as OrderRow[]` 雙重 cast（OrderDetail / pickup print / mutual-aid 都這樣處理）

## CI error 原文
```
./src/components/CampaignOrdersPanel.tsx:62:17
Type error: Conversion of type ... may be a mistake because neither type sufficiently overlaps with the other.
If this was intentional, convert the expression to 'unknown' first.
```

## Test plan
- [x] `npx tsc --noEmit`（apps/admin）綠
- [ ] CI PR build pass
- [ ] merge 後 main CI 恢復綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)