### PR TITLE
feat(hq/orders/wms): UX + 流程修補一波

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -95,6 +95,10 @@ export default function CampaignsListPage() {
   const [closingId, setClosingId] = useState<number | null>(null);
   const [finalizingId, setFinalizingId] = useState<number | null>(null);
 
+  // 多選 + 批次操作
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState<"open" | "closed" | "cancelled" | null>(null);
+
   const [view, setView] = useState<View>(() => {
     if (typeof window === "undefined") return "list";
     const saved = window.localStorage.getItem("campaigns:view");
@@ -113,6 +117,52 @@ export default function CampaignsListPage() {
   const [calOrderCounts, setCalOrderCounts] = useState<Map<number, number>>(new Map());
   const [calOffsetCounts, setCalOffsetCounts] = useState<Map<number, number>>(new Map());
   const [monthAnchor, setMonthAnchor] = useState<Date>(() => startOfDay(new Date()));
+
+  async function bulkSetStatus(target: "open" | "closed" | "cancelled", label: string) {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+    if (!confirm(`確定將已選的 ${ids.length} 個開團設為「${label}」？\n（系統會自動跳過狀態不合法、無商品或已是此狀態的）`)) return;
+    setBulkBusy(target);
+    setError(null);
+    try {
+      const { data, error: err } = await getSupabase().rpc("rpc_bulk_set_campaign_status", {
+        p_ids: ids,
+        p_status: target,
+      });
+      if (err) throw err;
+      const changed = typeof data === "number" ? data : 0;
+      const skipped = ids.length - changed;
+      setSelectedIds(new Set());
+      setReloadTick((t) => t + 1);
+      if (skipped > 0) {
+        console.info(`bulk_set_campaign_status: ${changed} updated, ${skipped} skipped`);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBulkBusy(null);
+    }
+  }
+
+  function toggleSelect(id: number) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleAllOnPage() {
+    if (!rows) return;
+    const idsOnPage = rows.map((r) => r.id);
+    const allSelected = idsOnPage.every((id) => selectedIds.has(id));
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allSelected) idsOnPage.forEach((id) => next.delete(id));
+      else idsOnPage.forEach((id) => next.add(id));
+      return next;
+    });
+  }
 
   async function closeCampaign(id: number, name: string) {
     if (!confirm(`確定結單「${name}」？結單後可從採購單頁面「帶入該日商品」產生 PR。`)) return;
@@ -415,18 +465,74 @@ export default function CampaignsListPage() {
         />
       )}
 
+      {view === "list" && selectedIds.size > 0 && (
+        <div className="flex flex-wrap items-center gap-3 rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900">
+          <span className="text-zinc-600 dark:text-zinc-400">已選 <span className="font-semibold">{selectedIds.size}</span> 個開團</span>
+          <SpinButton
+            onClick={() => bulkSetStatus("open", "開團中")}
+            disabled={bulkBusy !== null}
+            className="rounded-md bg-green-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-600 disabled:opacity-50"
+          >
+            {bulkBusy === "open" ? "啟動中…" : "批次開團"}
+          </SpinButton>
+          <SpinButton
+            onClick={() => bulkSetStatus("closed", "已收單")}
+            disabled={bulkBusy !== null}
+            className="rounded-md bg-amber-100 px-3 py-1.5 text-sm font-medium text-amber-800 hover:bg-amber-200 disabled:opacity-50 dark:bg-amber-950 dark:text-amber-300 dark:hover:bg-amber-900"
+          >
+            {bulkBusy === "closed" ? "結單中…" : "批次結單"}
+          </SpinButton>
+          <SpinButton
+            onClick={() => bulkSetStatus("cancelled", "已取消")}
+            disabled={bulkBusy !== null}
+            className="rounded-md bg-red-100 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-200 disabled:opacity-50 dark:bg-red-950 dark:text-red-300 dark:hover:bg-red-900"
+          >
+            {bulkBusy === "cancelled" ? "取消中…" : "批次取消"}
+          </SpinButton>
+          <SpinButton
+            onClick={() => setSelectedIds(new Set())}
+            className="ml-auto text-xs text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200"
+          >
+            清除選取
+          </SpinButton>
+        </div>
+      )}
+
       {view === "list" && (
       <Table>
         <THead>
+          <Th className="w-10">
+            <input
+              type="checkbox"
+              checked={!!rows && rows.length > 0 && rows.every((r) => selectedIds.has(r.id))}
+              ref={(el) => {
+                if (el && rows) {
+                  const allSel = rows.length > 0 && rows.every((r) => selectedIds.has(r.id));
+                  const someSel = rows.some((r) => selectedIds.has(r.id));
+                  el.indeterminate = !allSel && someSel;
+                }
+              }}
+              onChange={toggleAllOnPage}
+              className="cursor-pointer"
+            />
+          </Th>
           <Th>團號</Th><Th>名稱</Th><Th>狀態</Th><Th>收單</Th><Th>開團/收單</Th><Th>取貨截止</Th><Th align="right">商品數</Th><Th align="right">下單總數</Th><Th align="right">更新</Th><Th>{""}</Th>
         </THead>
         <TBody>
           {rows === null ? (
-            <LoadingRow colSpan={10} />
+            <LoadingRow colSpan={11} />
           ) : rows.length === 0 ? (
-            <EmptyRow colSpan={10}>{total === 0 && !query && !status ? "還沒有開團，按「新增開團」開始。" : "沒有符合條件的開團。"}</EmptyRow>
+            <EmptyRow colSpan={11}>{total === 0 && !query && !status ? "還沒有開團，按「新增開團」開始。" : "沒有符合條件的開團。"}</EmptyRow>
           ) : rows.map((r) => (
-            <Tr key={r.id}>
+            <Tr key={r.id} className={selectedIds.has(r.id) ? "bg-blue-50 dark:bg-blue-950/30" : ""}>
+                <Td className="w-10">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.has(r.id)}
+                    onChange={() => toggleSelect(r.id)}
+                    className="cursor-pointer"
+                  />
+                </Td>
                 <Td className="font-mono">
                   <SpinButton onClick={() => openEdit(r.id)} className="hover:underline">{r.campaign_no}</SpinButton>
                 </Td>

--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -12,6 +12,8 @@ import { Modal } from "@/components/Modal";
 import { AidOrderStatusActions } from "@/components/AidOrderStatusActions";
 import { PickModal, type PickWave } from "@/components/PickModal";
 import ExceptionsContent from "@/components/ExceptionsContent";
+import TransferDetailModal from "@/components/TransferDetailModal";
+import RestockDetailModal from "@/components/RestockDetailModal";
 import { ORDER_STATUS_LABEL as AID_STATUS_LABEL, type OrderStatus as AidStatus } from "@/lib/orderStatus";
 
 type Stage = "pending" | "in_transit" | "done" | "rejected";
@@ -69,6 +71,7 @@ type RestockRaw = {
   requested_at: string;
   line_count: number;
   total_amount: number;
+  items_summary: string;
 };
 
 type TransferRaw = {
@@ -88,6 +91,7 @@ type TransferRaw = {
   dest_name: string;
   line_count: number;
   notes: string | null;
+  items_summary: string;
 };
 
 type AidRaw = {
@@ -100,6 +104,7 @@ type AidRaw = {
   campaign_no: string | null;
   updated_at: string;
   line_count: number;
+  items_summary: string;
 };
 
 type ShortageRaw = {
@@ -130,6 +135,7 @@ type PickingRaw = {
   source_po_no: string | null;
   note: string | null;
   created_at: string;
+  items_summary: string;
 };
 
 type Row =
@@ -218,6 +224,63 @@ const PAGE_SIZE = 20;
 // === 各來源的 server-side fetcher(回 { rows, total })===
 type SBClient = ReturnType<typeof getSupabase>;
 
+// 撈某張表（restock_request_lines / transfer_items / customer_order_items / picking_wave_items）
+// 對應每張單的 items 摘要：「品名×qty、品名×qty…」（最多前 4 個 SKU，其餘 +N）
+async function fetchItemsSummaryMap(
+  sb: SBClient,
+  table: string,
+  idCol: string,
+  ids: number[],
+  qtyCol: string,
+): Promise<Map<number, string>> {
+  if (ids.length === 0) return new Map();
+  const { data } = await sb.from(table).select(`${idCol}, sku_id, ${qtyCol}`).in(idCol, ids);
+  const lines = (data ?? []) as unknown as Record<string, number | null>[];
+  const skuIds = Array.from(
+    new Set(lines.map((l) => Number(l.sku_id)).filter((x) => Number.isFinite(x)))
+  );
+  let skuLabelMap = new Map<number, string>();
+  if (skuIds.length > 0) {
+    const { data: skus } = await sb
+      .from("skus")
+      .select("id, sku_code, variant_name, product_id")
+      .in("id", skuIds);
+    const arr = (skus ?? []) as {
+      id: number; sku_code: string; variant_name: string | null; product_id: number | null;
+    }[];
+    const prodIds = Array.from(new Set(arr.map((s) => s.product_id).filter((x): x is number => x != null)));
+    let prodMap = new Map<number, string>();
+    if (prodIds.length > 0) {
+      const { data: ps } = await sb.from("products").select("id, name").in("id", prodIds);
+      prodMap = new Map(((ps ?? []) as { id: number; name: string }[]).map((p) => [p.id, p.name]));
+    }
+    skuLabelMap = new Map(
+      arr.map((s) => [
+        s.id,
+        s.product_id != null ? (prodMap.get(s.product_id) ?? s.sku_code) : s.sku_code,
+      ])
+    );
+  }
+  const partsMap = new Map<number, string[]>();
+  for (const l of lines) {
+    const id = Number(l[idCol]);
+    const skuId = Number(l.sku_id);
+    const qty = Number(l[qtyCol] ?? 0);
+    if (!Number.isFinite(id) || !Number.isFinite(skuId)) continue;
+    const label = skuLabelMap.get(skuId) ?? `#${skuId}`;
+    const arr = partsMap.get(id) ?? [];
+    arr.push(`${label}×${qty}`);
+    partsMap.set(id, arr);
+  }
+  const result = new Map<number, string>();
+  const MAX = 4;
+  for (const [id, parts] of partsMap) {
+    if (parts.length <= MAX) result.set(id, parts.join("、"));
+    else result.set(id, parts.slice(0, MAX).join("、") + ` +${parts.length - MAX}`);
+  }
+  return result;
+}
+
 async function fetchRestockRows(
   sb: SBClient,
   stage: Stage | null,
@@ -268,6 +331,8 @@ async function fetchRestockRows(
     for (const p of (ps ?? []) as { id: number; pr_no: string }[]) prNoMap.set(p.id, p.pr_no);
   }
 
+  const itemsMap = await fetchItemsSummaryMap(sb, "restock_request_lines", "request_id", reqIds, "qty");
+
   const rows: Row[] = rsRows.map((r) => ({
     key: `restock-${r.id}`,
     source: "restock" as const,
@@ -286,6 +351,7 @@ async function fetchRestockRows(
       requested_at: r.requested_at,
       line_count: lineMap.get(r.id)?.count ?? 0,
       total_amount: lineMap.get(r.id)?.total ?? 0,
+      items_summary: itemsMap.get(r.id) ?? "",
     },
   }));
   return { rows, total: count ?? 0 };
@@ -339,6 +405,8 @@ async function fetchTransferRows(
     }
   }
 
+  const itemsMap = await fetchItemsSummaryMap(sb, "transfer_items", "transfer_id", tIds, "qty_shipped");
+
   const rows: Row[] = trs.map((t) => ({
     key: `transfer-${t.id}`,
     source: "transfer" as const,
@@ -349,6 +417,7 @@ async function fetchTransferRows(
       source_name: locNameMap.get(t.source_location) ?? `#${t.source_location}`,
       dest_name: locNameMap.get(t.dest_location) ?? `#${t.dest_location}`,
       line_count: tLineMap.get(t.id) ?? 0,
+      items_summary: itemsMap.get(t.id) ?? "",
     },
   }));
   return { rows, total: count ?? 0 };
@@ -397,6 +466,9 @@ async function fetchAidRows(
     items?: { id: number }[];
   }>;
 
+  const aidIds = aidRows.map((a) => a.id);
+  const itemsMap = await fetchItemsSummaryMap(sb, "customer_order_items", "order_id", aidIds, "qty");
+
   const rows: Row[] = aidRows.map((a) => ({
     key: `aid-${a.id}`,
     source: "aid" as const,
@@ -412,6 +484,7 @@ async function fetchAidRows(
       campaign_no: a.campaign?.campaign_no ?? null,
       updated_at: a.updated_at,
       line_count: a.items?.length ?? 0,
+      items_summary: itemsMap.get(a.id) ?? "",
     },
   }));
   return { rows, total: count ?? 0 };
@@ -556,6 +629,8 @@ async function fetchPickingRows(
       .in("id", poIds);
     for (const p of (poRows as { id: number; po_no: string }[] | null) ?? []) poNoMap.set(p.id, p.po_no);
   }
+  const itemsMap = await fetchItemsSummaryMap(sb, "picking_wave_items", "wave_id", ids, "qty");
+
   const rows: Row[] = waveRows.map((w) => ({
     key: `picking-${w.id}`,
     source: "picking" as const,
@@ -568,6 +643,7 @@ async function fetchPickingRows(
       actual_total: totals.get(w.id)?.actual ?? 0,
       item_count: totals.get(w.id)?.skus.size ?? w.item_count,
       source_po_no: w.source_po_id ? (poNoMap.get(w.source_po_id) ?? null) : null,
+      items_summary: itemsMap.get(w.id) ?? "",
     },
   }));
   return { rows, total: count ?? 0 };
@@ -610,6 +686,7 @@ async function fetchRestockRowsByIds(sb: SBClient, ids: number[]): Promise<Row[]
     const { data: ps } = await sb.from("purchase_requests").select("id, pr_no").in("id", prIds);
     for (const p of (ps ?? []) as { id: number; pr_no: string }[]) prNoMap.set(p.id, p.pr_no);
   }
+  const itemsMap = await fetchItemsSummaryMap(sb, "restock_request_lines", "request_id", rsRows.map((r) => r.id), "qty");
   return rsRows.map((r) => ({
     key: `restock-${r.id}`,
     source: "restock" as const,
@@ -628,6 +705,7 @@ async function fetchRestockRowsByIds(sb: SBClient, ids: number[]): Promise<Row[]
       requested_at: r.requested_at,
       line_count: lineMap.get(r.id)?.count ?? 0,
       total_amount: lineMap.get(r.id)?.total ?? 0,
+      items_summary: itemsMap.get(r.id) ?? "",
     },
   }));
 }
@@ -655,6 +733,7 @@ async function fetchTransferRowsByIds(sb: SBClient, ids: number[]): Promise<Row[
       tLineMap.set(it.transfer_id, (tLineMap.get(it.transfer_id) ?? 0) + 1);
     }
   }
+  const itemsMap = await fetchItemsSummaryMap(sb, "transfer_items", "transfer_id", trs.map((t) => t.id), "qty_shipped");
   return trs.map((t) => ({
     key: `transfer-${t.id}`,
     source: "transfer" as const,
@@ -665,6 +744,7 @@ async function fetchTransferRowsByIds(sb: SBClient, ids: number[]): Promise<Row[
       source_name: locNameMap.get(t.source_location) ?? `#${t.source_location}`,
       dest_name: locNameMap.get(t.dest_location) ?? `#${t.dest_location}`,
       line_count: tLineMap.get(t.id) ?? 0,
+      items_summary: itemsMap.get(t.id) ?? "",
     },
   }));
 }
@@ -693,6 +773,7 @@ async function fetchAidRowsByIds(sb: SBClient, ids: number[]): Promise<Row[]> {
     store?: { id: number; name: string } | null;
     items?: { id: number }[];
   }>;
+  const itemsMap = await fetchItemsSummaryMap(sb, "customer_order_items", "order_id", aidRows.map((a) => a.id), "qty");
   return aidRows.map((a) => ({
     key: `aid-${a.id}`,
     source: "aid" as const,
@@ -708,6 +789,7 @@ async function fetchAidRowsByIds(sb: SBClient, ids: number[]): Promise<Row[]> {
       campaign_no: a.campaign?.campaign_no ?? null,
       updated_at: a.updated_at,
       line_count: a.items?.length ?? 0,
+      items_summary: itemsMap.get(a.id) ?? "",
     },
   }));
 }
@@ -843,6 +925,8 @@ function HqInboxContent() {
   const [busy, setBusy] = useState<string | null>(null);
   const [rejectModal, setRejectModal] = useState<{ id: number; reason: string } | null>(null);
   const [aidDetailId, setAidDetailId] = useState<number | null>(null);
+  const [transferDetailId, setTransferDetailId] = useState<number | null>(null);
+  const [restockDetailId, setRestockDetailId] = useState<number | null>(null);
   const [editingWave, setEditingWave] = useState<PickWave | null>(null);
   const [dispatchingWaveId, setDispatchingWaveId] = useState<number | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -1190,18 +1274,37 @@ function HqInboxContent() {
   // 批次動作 — 依 sourceFilter 跑對應 RPC
   async function batchAction(action: string) {
     // transfer source 可以批次的 row 含 pending 與 in_transit;其他 source 只 pending
+    // 「確認入倉 / 退訂單取消」是退訂單 (shipped + return_to_hq) 專屬、stage='pending'
     const validStages: Record<string, Stage[]> =
       sourceFilter === "transfer"
-        ? { "配送": ["pending"], "刪除": ["pending"], "到倉": ["in_transit"] }
+        ? {
+            "配送": ["pending"], "刪除": ["pending"], "到倉": ["in_transit"],
+            "確認入倉": ["pending"], "退訂單取消": ["pending"],
+          }
         : sourceFilter === "picking"
           ? { "派貨出倉": ["pending"], "取消": ["pending"] }
           : {};
     const allowedStages = validStages[action] ?? (["pending"] as Stage[]);
-    const items = paginatedRows.filter(
+    let items = paginatedRows.filter(
       (r) => selected.has(r.key) && allowedStages.includes(r.stage),
     );
+    // 退訂單專屬動作要再過濾 transfer_type
+    if (sourceFilter === "transfer" && (action === "確認入倉" || action === "退訂單取消")) {
+      items = items.filter((r) => r.source === "transfer" && isOrderReturnTransfer((r.raw as TransferRaw).notes));
+    } else if (sourceFilter === "transfer" && (action === "配送" || action === "刪除")) {
+      // 一般 pending 動作排除退訂單（退訂單不該被「配送/刪除」）
+      items = items.filter((r) => r.source === "transfer" && !isOrderReturnTransfer((r.raw as TransferRaw).notes));
+    }
     if (items.length === 0) return;
-    if (!confirm(`確認對選中的 ${items.length} 筆執行「${action}」?`)) return;
+
+    // 「退訂單取消」要先輸入原因（與單筆 reject 對齊、走 audit log）
+    let reason: string | null = null;
+    if (action === "退訂單取消") {
+      reason = prompt(`取消原因(必填、會留 audit log，將套用到全部 ${items.length} 筆)：`);
+      if (!reason || !reason.trim()) return;
+    } else {
+      if (!confirm(`確認對選中的 ${items.length} 筆執行「${action}」?`)) return;
+    }
     setBatchBusy(true);
     try {
       const sb = getSupabase();
@@ -1214,13 +1317,50 @@ function HqInboxContent() {
         const ids = items
           .filter((r) => r.source === "transfer")
           .map((r) => (r.raw as TransferRaw).id);
+
+        // 退訂單取消沒有 batch RPC，逐筆呼叫 rpc_reject_transfer
+        if (action === "退訂單取消") {
+          const settles = await Promise.allSettled(
+            ids.map((id) =>
+              sb.rpc("rpc_reject_transfer", {
+                p_transfer_id: id,
+                p_reason: reason,
+                p_operator: operator,
+              }),
+            ),
+          );
+          let ok = 0;
+          const fails: { id: number; reason: string }[] = [];
+          settles.forEach((s, i) => {
+            if (s.status === "fulfilled" && !s.value.error) ok += 1;
+            else {
+              const msg = s.status === "rejected"
+                ? String(s.reason)
+                : translateRpcError(s.value.error);
+              fails.push({ id: ids[i], reason: msg });
+            }
+          });
+          if (fails.length === 0) {
+            alert(`✅ 取消 ${ok} 筆退訂單`);
+          } else {
+            const lines = fails.slice(0, 5).map((f) => `  #${f.id}: ${f.reason}`);
+            alert(
+              `成功 ${ok} / 失敗 ${fails.length}\n\n${lines.join("\n")}` +
+                (fails.length > 5 ? `\n…(還有 ${fails.length - 5} 筆)` : ""),
+            );
+          }
+          setSelected(new Set());
+          setReloadTick((t) => t + 1);
+          return;
+        }
+
         let rpcName: string;
         let params: Record<string, unknown>;
         if (action === "配送") {
           if (hqLocId === null) throw new Error("找不到 HQ location");
           rpcName = "rpc_transfer_distribute_batch";
           params = { p_transfer_ids: ids, p_hq_location_id: hqLocId, p_operator: operator };
-        } else if (action === "到倉") {
+        } else if (action === "到倉" || action === "確認入倉") {
           if (hqLocId === null) throw new Error("找不到 HQ location");
           rpcName = "rpc_transfer_arrive_at_hq_batch";
           params = { p_transfer_ids: ids, p_hq_location_id: hqLocId, p_operator: operator };
@@ -1699,17 +1839,32 @@ function HqInboxContent() {
                   )}
                   {sourceFilter === "transfer" && (() => {
                     // 只有當所選 row 全部同 stage 才顯示對應動作(避免混 batch)
+                    // pending 還要再細分「退訂單」vs「一般 draft」— 兩者動作完全不同
                     const sel = paginatedRows.filter((r) => selected.has(r.key) && r.source === "transfer");
                     const stages = new Set(sel.map((r) => r.stage));
                     const allPending = stages.size === 1 && stages.has("pending");
                     const allInTransit = stages.size === 1 && stages.has("in_transit");
+                    const pendingTypes = new Set(
+                      sel.map((r) => (isOrderReturnTransfer((r.raw as TransferRaw).notes) ? "return" : "normal"))
+                    );
+                    const allPendingReturn = allPending && pendingTypes.size === 1 && pendingTypes.has("return");
+                    const allPendingNormal = allPending && pendingTypes.size === 1 && pendingTypes.has("normal");
                     return (
                       <>
-                        {allPending && (
+                        {allPendingNormal && (
                           <>
                             <RowAction variant="success" onClick={() => batchAction("配送")} disabled={batchBusy}>配送 ({selected.size})</RowAction>
                             <RowAction variant="danger" onClick={() => batchAction("刪除")} disabled={batchBusy}>刪除 ({selected.size})</RowAction>
                           </>
+                        )}
+                        {allPendingReturn && (
+                          <>
+                            <RowAction variant="primary" onClick={() => batchAction("確認入倉")} disabled={batchBusy}>確認入倉 ({selected.size})</RowAction>
+                            <RowAction variant="danger" onClick={() => batchAction("退訂單取消")} disabled={batchBusy}>取消 ({selected.size})</RowAction>
+                          </>
+                        )}
+                        {allPending && !allPendingReturn && !allPendingNormal && (
+                          <span className="self-center text-xs text-zinc-500">已混合退訂單與一般轉貨、無法批次</span>
                         )}
                         {allInTransit && (
                           <RowAction variant="primary" onClick={() => batchAction("到倉")} disabled={batchBusy}>到倉 ({selected.size})</RowAction>
@@ -1741,6 +1896,7 @@ function HqInboxContent() {
                       onApproveTransfer={approveToTransfer} onApprovePr={approveToPr} onShipPrReceived={shipPrReceived}
                       onOpenReject={(id) => setRejectModal({ id, reason: "" })}
                       onOpenAidDetail={setAidDetailId} onAidChanged={() => setReloadTick((t) => t + 1)}
+                      onOpenTransferDetail={setTransferDetailId} onOpenRestockDetail={setRestockDetailId}
                       onShortageAction={handleShortageAction} onTransferAction={handleTransferAction}
                       onPickingDispatch={dispatchWave} onPickingEdit={openWaveEdit} onPickingCancel={cancelWave}
                       dispatchingWaveId={dispatchingWaveId}
@@ -1835,6 +1991,17 @@ function HqInboxContent() {
         {aidDetailId !== null && <OrderDetail orderId={aidDetailId} />}
       </Modal>
 
+      <TransferDetailModal
+        open={transferDetailId !== null}
+        transferId={transferDetailId}
+        onClose={() => setTransferDetailId(null)}
+      />
+      <RestockDetailModal
+        open={restockDetailId !== null}
+        restockId={restockDetailId}
+        onClose={() => setRestockDetailId(null)}
+      />
+
       {editingWave && (
         <PickModal
           wave={editingWave}
@@ -1861,6 +2028,8 @@ function MailRow({
   onOpenReject,
   onOpenAidDetail,
   onAidChanged,
+  onOpenTransferDetail,
+  onOpenRestockDetail,
   onShortageAction,
   onTransferAction,
   onPickingDispatch,
@@ -1881,6 +2050,8 @@ function MailRow({
   onOpenReject: (id: number) => void;
   onOpenAidDetail: (id: number) => void;
   onAidChanged: () => void;
+  onOpenTransferDetail: (id: number) => void;
+  onOpenRestockDetail: (id: number) => void;
   onShortageAction: (orderId: number, action: "notified" | "cancelled" | "waiting_next_po" | "reallocated") => Promise<void>;
   onTransferAction: (transferId: number, action: "ship" | "arrive_at_hq" | "delete" | "reject") => Promise<void>;
   onPickingDispatch: (w: PickingRaw) => Promise<void>;
@@ -2117,14 +2288,18 @@ function MailRow({
 
   const time = new Date(timeIso).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" });
 
-  // 點 row 任意空白處開明細(僅 picking / aid 兩種 row 有完整 modal 體驗)
-  const rowClickable = row.source === "picking" || row.source === "aid";
+  // 點 row 任意空白處開明細
+  const rowClickable =
+    row.source === "picking" || row.source === "aid" ||
+    row.source === "transfer" || row.source === "restock";
   const handleRowClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!rowClickable) return;
     const target = e.target as HTMLElement;
     if (target.closest("button, a, input, select, textarea, label")) return;
     if (row.source === "picking") onPickingEdit(row.raw);
     else if (row.source === "aid") onOpenAidDetail(row.raw.id);
+    else if (row.source === "transfer") onOpenTransferDetail(row.raw.id);
+    else if (row.source === "restock") onOpenRestockDetail(row.raw.id);
   };
 
   return (
@@ -2157,6 +2332,18 @@ function MailRow({
           </span>
         </div>
         <div className="mt-0.5 truncate text-xs text-zinc-500">{subtitle}</div>
+        {row.source !== "shortage" && (() => {
+          const summary = (row.raw as { items_summary?: string }).items_summary;
+          if (!summary) return null;
+          return (
+            <div
+              className="mt-0.5 truncate text-[11px] text-zinc-600 dark:text-zinc-400"
+              title={summary}
+            >
+              📦 {summary}
+            </div>
+          );
+        })()}
       </div>
 
       {/* 階段 chip 直接放在動作區左邊(時間移到動作下方右下) */}

--- a/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+// 撿貨清單列印 — SKU × 店家 矩陣，給現場撿貨用
+// 列 = SKU；前幾欄 = 訂購/已到/已撿/可分配；之後是各店家需求數量。
+// 開啟方式：從 /wms/picking 點「📄 列印撿貨清單」開新分頁。
+// data source: 與派貨工作台同 v_picking_demand_by_po。
+
+import { useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import SpinButton from "@/components/SpinButton";
+import { getTenantName } from "@/lib/tenant";
+
+type DemandRow = {
+  po_id: number;
+  po_no: string;
+  sku_id: number;
+  sku_code: string | null;
+  sku_label: string;
+  qty_ordered: number;
+  gr_qty: number;
+  store_id: number | null;
+  store_code: string | null;
+  store_name: string | null;
+  demand_qty: number;
+  wave_qty: number;
+  shipped_qty: number;
+};
+
+type StoreInfo = { store_id: number; store_code: string | null; store_name: string };
+type SkuRow = {
+  sku_id: number;
+  sku_code: string | null;
+  sku_label: string;
+  totalOrdered: number;
+  totalGr: number;
+  totalAlreadyWave: number;
+  totalAvailable: number;
+  storeDemand: Map<number, number>;
+  storeWave: Map<number, number>;  // 每店「已撿」量（wave_qty）
+};
+
+export default function PrintPickListPage() {
+  const [demand, setDemand] = useState<DemandRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tenantName, setTenantName] = useState("");
+  const [printedAt] = useState(() => new Date());
+
+  useEffect(() => {
+    setTenantName(getTenantName());
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data, error: e } = await sb.from("v_picking_demand_by_po").select("*");
+        if (cancelled) return;
+        if (e) { setError(e.message); return; }
+        setDemand((data ?? []) as DemandRow[]);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const { skuRows, stores } = useMemo(() => {
+    const empty = { skuRows: [] as SkuRow[], stores: [] as StoreInfo[] };
+    if (!demand) return empty;
+    const skuMap = new Map<number, SkuRow>();
+    const storeMap = new Map<number, StoreInfo>();
+    const poSkuSeen = new Set<string>();
+    for (const r of demand) {
+      if (r.store_id == null) continue;
+      if (!storeMap.has(r.store_id)) {
+        storeMap.set(r.store_id, {
+          store_id: r.store_id,
+          store_code: r.store_code,
+          store_name: r.store_name ?? `#${r.store_id}`,
+        });
+      }
+      let s = skuMap.get(r.sku_id);
+      if (!s) {
+        s = {
+          sku_id: r.sku_id,
+          sku_code: r.sku_code,
+          sku_label: r.sku_label,
+          totalOrdered: 0,
+          totalGr: 0,
+          totalAlreadyWave: 0,
+          totalAvailable: 0,
+          storeDemand: new Map(),
+          storeWave: new Map(),
+        };
+        skuMap.set(r.sku_id, s);
+      }
+      const poSkuKey = `${r.po_id}:${r.sku_id}`;
+      if (!poSkuSeen.has(poSkuKey)) {
+        poSkuSeen.add(poSkuKey);
+        s.totalOrdered += Number(r.qty_ordered);
+        s.totalGr += Number(r.gr_qty);
+      }
+      s.storeDemand.set(r.store_id, (s.storeDemand.get(r.store_id) ?? 0) + Number(r.demand_qty));
+      s.storeWave.set(r.store_id, (s.storeWave.get(r.store_id) ?? 0) + Number(r.wave_qty));
+      s.totalAlreadyWave += Number(r.wave_qty);
+    }
+    for (const s of skuMap.values()) {
+      s.totalAvailable = Math.max(0, s.totalGr - s.totalAlreadyWave);
+    }
+    const stores = Array.from(storeMap.values()).sort((a, b) =>
+      (a.store_code ?? "").localeCompare(b.store_code ?? "")
+    );
+    const skuRows = Array.from(skuMap.values())
+      // 隱藏「已到貨且全部撿完」的 SKU
+      .filter((s) => !(s.totalGr > 0 && s.totalAvailable === 0))
+      .sort((a, b) => (a.sku_code ?? "").localeCompare(b.sku_code ?? ""));
+    return { skuRows, stores };
+  }, [demand]);
+
+  return (
+    <>
+      <style>{`
+        @media print {
+          @page {
+            size: A4 landscape;
+            margin: 8mm;
+          }
+          .no-print { display: none !important; }
+          body { background: white !important; }
+          .pick-table { font-size: 10px; }
+        }
+        .pick-table { border-collapse: collapse; width: 100%; font-size: 12px; }
+        .pick-table th, .pick-table td {
+          border: 1px solid #cbd5e1;
+          padding: 4px 6px;
+          text-align: center;
+        }
+        .pick-table thead { background: #f1f5f9; }
+        .pick-table .sku-cell { text-align: left; }
+        .pick-table .num-cell { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+        .pick-table .frozen-col {
+          background: #fef3c7;
+          font-weight: 600;
+        }
+        .pick-table .store-col { background: #ffffff; }
+        .pick-table tbody tr:nth-child(even) td.store-col { background: #f8fafc; }
+        .pick-table tbody tr:nth-child(even) td.sku-cell { background: #f8fafc; }
+        .pick-table .zero { color: #cbd5e1; }
+        .pick-table .picked-tag {
+          display: block;
+          font-size: 10px;
+          color: #047857;  /* green-700 — 已撿 */
+        }
+        .pick-table .picked-partial { color: #b45309; }  /* amber-700 — 部分撿 */
+        .pick-table .picked-zero { color: #b91c1c; }     /* red-700 — 還沒撿 */
+      `}</style>
+
+      <div className="bg-white text-zinc-900 print:bg-white">
+        {/* 控制列（列印時隱藏）*/}
+        <div className="no-print sticky top-0 z-20 flex flex-wrap items-center gap-3 border-b border-zinc-200 bg-zinc-50 p-3 print:hidden">
+          <h1 className="text-base font-semibold">📄 撿貨清單列印</h1>
+          <span className="text-sm text-zinc-500">
+            {demand === null
+              ? "載入中…"
+              : skuRows.length === 0
+                ? "（無資料）"
+                : `${skuRows.length} 個 SKU × ${stores.length} 間分店`}
+          </span>
+          <SpinButton
+            onClick={() => window.print()}
+            disabled={skuRows.length === 0}
+            className="ml-auto rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            🖨️ 列印
+          </SpinButton>
+        </div>
+
+        {error && (
+          <div className="no-print m-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+            {error}
+          </div>
+        )}
+
+        {skuRows.length === 0 && demand !== null && (
+          <div className="no-print p-6 text-center text-sm text-zinc-500">
+            目前沒有待撿項目。
+          </div>
+        )}
+
+        {skuRows.length > 0 && (
+          <div className="mx-auto p-4 print:p-0">
+            <div className="mb-3 flex items-end justify-between border-b-2 border-zinc-900 pb-2">
+              <div>
+                <div className="text-xl font-bold">撿貨清單</div>
+                {tenantName && <div className="mt-0.5 text-xs text-zinc-500">{tenantName}</div>}
+              </div>
+              <div className="text-right text-xs text-zinc-600">
+                <div>列印時間：{printedAt.toLocaleString("zh-TW")}</div>
+                <div>共 {skuRows.length} 個 SKU、{stores.length} 間分店</div>
+              </div>
+            </div>
+
+            <table className="pick-table">
+              <thead>
+                <tr>
+                  <th rowSpan={2} className="sku-cell">SKU</th>
+                  <th rowSpan={2} className="sku-cell">品名 / 規格</th>
+                  <th colSpan={4}>HQ 統計</th>
+                  <th colSpan={stores.length}>各店家需求</th>
+                </tr>
+                <tr>
+                  <th className="frozen-col">訂購</th>
+                  <th className="frozen-col">已到</th>
+                  <th className="frozen-col">已撿</th>
+                  <th className="frozen-col">可分配</th>
+                  {stores.map((s) => (
+                    <th key={s.store_id} className="store-col">
+                      <div className="font-mono text-[10px] text-zinc-500">{s.store_code ?? "—"}</div>
+                      <div>{s.store_name}</div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {skuRows.map((s) => (
+                  <tr key={s.sku_id}>
+                    <td className="sku-cell num-cell">{s.sku_code ?? `#${s.sku_id}`}</td>
+                    <td className="sku-cell">{s.sku_label}</td>
+                    <td className="frozen-col num-cell">{s.totalOrdered}</td>
+                    <td className="frozen-col num-cell">{s.totalGr}</td>
+                    <td className="frozen-col num-cell">{s.totalAlreadyWave}</td>
+                    <td className="frozen-col num-cell">{s.totalAvailable}</td>
+                    {stores.map((store) => {
+                      const q = s.storeDemand.get(store.store_id) ?? 0;
+                      const picked = s.storeWave.get(store.store_id) ?? 0;
+                      if (q === 0 && picked === 0) {
+                        return (
+                          <td key={store.store_id} className="store-col num-cell zero">·</td>
+                        );
+                      }
+                      // 已撿 tag 樣式：足量綠色 / 部分黃色 / 還沒撿紅色
+                      const tagCls =
+                        picked === 0 ? "picked-tag picked-zero" :
+                        picked >= q ? "picked-tag" :
+                        "picked-tag picked-partial";
+                      const tagText =
+                        picked === 0 ? "撿 0" :
+                        picked >= q ? `✓ 撿 ${picked}` :
+                        `撿 ${picked}`;
+                      return (
+                        <td key={store.store_id} className="store-col num-cell">
+                          {q || "—"}
+                          {q > 0 && <span className={tagCls}>{tagText}</span>}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td colSpan={2} className="sku-cell text-right text-xs text-zinc-500">合計</td>
+                  <td className="frozen-col num-cell">{skuRows.reduce((a, s) => a + s.totalOrdered, 0)}</td>
+                  <td className="frozen-col num-cell">{skuRows.reduce((a, s) => a + s.totalGr, 0)}</td>
+                  <td className="frozen-col num-cell">{skuRows.reduce((a, s) => a + s.totalAlreadyWave, 0)}</td>
+                  <td className="frozen-col num-cell">{skuRows.reduce((a, s) => a + s.totalAvailable, 0)}</td>
+                  {stores.map((store) => {
+                    const sum = skuRows.reduce((a, s) => a + (s.storeDemand.get(store.store_id) ?? 0), 0);
+                    const sumPicked = skuRows.reduce((a, s) => a + (s.storeWave.get(store.store_id) ?? 0), 0);
+                    return (
+                      <td key={store.store_id} className={`store-col num-cell ${sum === 0 && sumPicked === 0 ? "zero" : ""}`}>
+                        {sum === 0 && sumPicked === 0 ? "·" : sum}
+                        {sum > 0 && (
+                          <span className={`picked-tag ${sumPicked === 0 ? "picked-zero" : sumPicked >= sum ? "" : "picked-partial"}`}>
+                            {sumPicked === 0 ? "撿 0" : sumPicked >= sum ? `✓ 撿 ${sumPicked}` : `撿 ${sumPicked}`}
+                          </span>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/admin/src/app/(protected)/products/page.tsx
+++ b/apps/admin/src/app/(protected)/products/page.tsx
@@ -274,6 +274,7 @@ function PageContent() {
   // multi-select for 開團
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [campaignModal, setCampaignModal] = useState<SelectedProduct[] | null>(null);
+  const [bulkUpdating, setBulkUpdating] = useState<Status | null>(null);
 
   // product edit modal
   const [modal, setModal] = useState<
@@ -335,6 +336,35 @@ function PageContent() {
         vip_level_min: d.vip_level_min ?? 0,
       },
     });
+  }
+
+  // 批次切換商品狀態
+  async function bulkUpdateStatus(target: Status, label: string) {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+    if (!window.confirm(`確定要將已選的 ${ids.length} 項商品設為「${label}」？`)) return;
+    setBulkUpdating(target);
+    setError(null);
+    try {
+      const { data, error: err } = await getSupabase().rpc("rpc_bulk_update_product_status", {
+        p_ids: ids,
+        p_status: target,
+        p_reason: null,
+      });
+      if (err) throw err;
+      setSelectedIds(new Set());
+      setReloadTick((t) => t + 1);
+      const changed = typeof data === "number" ? data : 0;
+      const skipped = ids.length - changed;
+      if (skipped > 0) {
+        // 不擋流程：用 console + 一行訊息提示，避免 UX 中斷
+        console.info(`bulk_update_product_status: ${changed} updated, ${skipped} skipped (already ${target} or cross-tenant)`);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBulkUpdating(null);
+    }
   }
 
   // open 開團 modal: fetch storage_type for selected product ids
@@ -498,7 +528,7 @@ function PageContent() {
 
       {/* 多選工具列 */}
       {selectedIds.size > 0 && (
-        <div className="flex items-center gap-3 rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900">
+        <div className="flex flex-wrap items-center gap-3 rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900">
           <span className="text-zinc-600 dark:text-zinc-400">已選 <span className="font-semibold">{selectedIds.size}</span> 項商品</span>
           <SpinButton
             onClick={openCampaignModal}
@@ -506,6 +536,25 @@ function PageContent() {
           >
             開團
           </SpinButton>
+          {!campaignMode && (
+            <>
+              <span className="mx-1 h-5 w-px bg-zinc-300 dark:bg-zinc-700" />
+              <SpinButton
+                onClick={() => bulkUpdateStatus("active", "上架")}
+                disabled={bulkUpdating !== null}
+                className="rounded-md bg-green-100 px-3 py-1.5 text-sm font-medium text-green-800 hover:bg-green-200 disabled:opacity-50 dark:bg-green-950 dark:text-green-300 dark:hover:bg-green-900"
+              >
+                {bulkUpdating === "active" ? "上架中…" : "批次上架"}
+              </SpinButton>
+              <SpinButton
+                onClick={() => bulkUpdateStatus("inactive", "下架")}
+                disabled={bulkUpdating !== null}
+                className="rounded-md bg-amber-100 px-3 py-1.5 text-sm font-medium text-amber-800 hover:bg-amber-200 disabled:opacity-50 dark:bg-amber-950 dark:text-amber-300 dark:hover:bg-amber-900"
+              >
+                {bulkUpdating === "inactive" ? "下架中…" : "批次下架"}
+              </SpinButton>
+            </>
+          )}
           <SpinButton
             onClick={() => setSelectedIds(new Set())}
             className="ml-auto text-xs text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200"

--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -425,7 +425,9 @@ function PageContent() {
   async function submitForReview() {
     if (!id) return;
     // 送審前驗：每行必須填妥成本 / 分店價 / 售價 + 數量 + 供應商
+    // 並且要符合 成本 < 分店價 < 售價 三段遞增關係
     const incomplete: string[] = [];
+    const priceIssues: string[] = [];
     for (const r of items) {
       const issues: string[] = [];
       if (!r.qty_requested || r.qty_requested <= 0) issues.push("數量");
@@ -435,10 +437,21 @@ function PageContent() {
       if (!r.suggested_supplier_id) issues.push("供應商");
       if (issues.length > 0) {
         incomplete.push(`${r.sku_code}：${issues.join("、")}`);
+        continue;
+      }
+      const cost = Number(r.unit_cost);
+      const branch = Number(r.franchise_price);
+      const retail = Number(r.retail_price);
+      if (!(cost < branch && branch < retail)) {
+        priceIssues.push(`${r.sku_code}：成本 $${cost} / 分店價 $${branch} / 售價 $${retail}`);
       }
     }
     if (incomplete.length > 0) {
       setError(`送審前需補完所有欄位：\n${incomplete.join("\n")}`);
+      return;
+    }
+    if (priceIssues.length > 0) {
+      setError(`價格必須符合 成本 < 分店價 < 售價：\n${priceIssues.join("\n")}`);
       return;
     }
     if (!confirm("確定送出審核？")) {
@@ -597,28 +610,6 @@ function PageContent() {
         </div>
       )}
 
-      {missingCampaigns.length > 0 && (
-        <div className="flex items-start justify-between gap-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
-          <div>
-            <div className="font-semibold">⚠ 偵測到 {missingCampaigns.length} 個同日結單但未納入本採購單的團：</div>
-            <ul className="mt-1 list-disc pl-5 text-xs">
-              {missingCampaigns.map((c) => (
-                <li key={c.id}>
-                  <span className="font-mono">{c.campaign_no}</span>　{c.name}
-                </li>
-              ))}
-            </ul>
-          </div>
-          <SpinButton
-            onClick={appendMissing}
-            disabled={appending}
-            className="shrink-0 rounded-md bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-500 disabled:opacity-50"
-          >
-            {appending ? "併入中…" : "📥 全部併入"}
-          </SpinButton>
-        </div>
-      )}
-
       {/* Timeline stepper（hover 顯示誰+何時）*/}
       <div className="rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
         <PrPipelineStepper
@@ -771,12 +762,27 @@ function PageContent() {
                 </td>
               </tr>
             ) : (
-              items.map((r, idx) => (
+              items.map((r, idx) => {
+                // 成本 < 分店價 < 售價 必須遞增，三值有任一缺則不檢查（送審前才擋）
+                const cost = Number(r.unit_cost);
+                const branch = r.franchise_price != null ? Number(r.franchise_price) : null;
+                const retail = r.retail_price != null ? Number(r.retail_price) : null;
+                const priceBad =
+                  cost > 0 && branch != null && retail != null && !(cost < branch && branch < retail);
+                const cellWarn = priceBad
+                  ? "border-rose-400 bg-rose-50 dark:border-rose-700 dark:bg-rose-950"
+                  : "border-zinc-300 dark:border-zinc-700";
+                return (
                 <tr key={r.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
                   <Td className="text-zinc-500">{idx + 1}</Td>
                   <Td>
                     <div>{r.product_name}{r.variant_name ? `-${r.variant_name}` : ""}</div>
                     <div className="font-mono text-xs text-zinc-500">{r.sku_code}</div>
+                    {priceBad && (
+                      <div className="mt-0.5 text-[11px] font-medium text-rose-600 dark:text-rose-400">
+                        ⚠ 成本 &lt; 分店價 &lt; 售價 順序錯
+                      </div>
+                    )}
                   </Td>
                   <Td>
                     {editable ? (
@@ -834,7 +840,7 @@ function PageContent() {
                         step="1"
                         value={r.unit_cost}
                         onChange={(e) => patchItem(idx, { unit_cost: Number(e.target.value) })}
-                        className="w-24 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                        className={`w-24 rounded-md border bg-white px-2 py-1 text-right text-sm dark:bg-zinc-800 ${cellWarn}`}
                       />
                     ) : (
                       r.unit_cost.toFixed(4)
@@ -851,7 +857,7 @@ function PageContent() {
                             franchise_price: e.target.value === "" ? null : Number(e.target.value),
                           })
                         }
-                        className="w-20 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                        className={`w-20 rounded-md border bg-white px-2 py-1 text-right text-sm dark:bg-zinc-800 ${cellWarn}`}
                       />
                     ) : r.franchise_price !== null ? (
                       `$${r.franchise_price.toFixed(0)}`
@@ -870,7 +876,7 @@ function PageContent() {
                             retail_price: e.target.value === "" ? null : Number(e.target.value),
                           })
                         }
-                        className="w-20 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                        className={`w-20 rounded-md border bg-white px-2 py-1 text-right text-sm dark:bg-zinc-800 ${cellWarn}`}
                       />
                     ) : r.retail_price !== null ? (
                       `$${r.retail_price.toFixed(0)}`
@@ -892,7 +898,8 @@ function PageContent() {
                     )}
                   </Td>
                 </tr>
-              ))
+                );
+              })
             )}
           </tbody>
         </table>

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -141,6 +141,7 @@ export default function PurchaseRequestsListPage() {
   const [selectedCampaignIds, setSelectedCampaignIds] = useState<Set<number>>(
     new Set(),
   );
+  const [campaignQuery, setCampaignQuery] = useState("");
   const [creatingMulti, setCreatingMulti] = useState(false);
   const [progressById, setProgressById] = useState<Map<number, Progress>>(
     new Map(),
@@ -1029,6 +1030,7 @@ export default function PurchaseRequestsListPage() {
           onClick={() => {
             setShowCampaignModal(false);
             setSelectedCampaignIds(new Set());
+            setCampaignQuery("");
           }}
         >
           <div
@@ -1046,11 +1048,22 @@ export default function PurchaseRequestsListPage() {
                 onClick={() => {
                   setShowCampaignModal(false);
                   setSelectedCampaignIds(new Set());
+                  setCampaignQuery("");
                 }}
                 className="text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100"
               >
                 ✕
               </SpinButton>
+            </div>
+            <div className="border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
+              <input
+                type="search"
+                value={campaignQuery}
+                onChange={(e) => setCampaignQuery(e.target.value)}
+                placeholder="搜尋團名 / 結單日 (YYYY-MM-DD)"
+                autoFocus
+                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
+              />
             </div>
             <div className="max-h-[60vh] overflow-y-auto p-4">
               {closedCampaigns === null ? (
@@ -1061,45 +1074,61 @@ export default function PurchaseRequestsListPage() {
                 <div className="text-center text-sm text-zinc-500">
                   過去 60 天無已結單團購
                 </div>
-              ) : (
-                <ul className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                  {closedCampaigns.map((c) => {
-                    const checked = selectedCampaignIds.has(c.id);
-                    return (
-                      <li
-                        key={c.id}
-                        className="flex cursor-pointer items-center gap-3 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800"
-                        onClick={() => toggleCampaignSelect(c.id)}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={checked}
-                          onChange={() => toggleCampaignSelect(c.id)}
-                          onClick={(e) => e.stopPropagation()}
-                          className="h-4 w-4 rounded border-zinc-300 text-blue-600 focus:ring-blue-500"
-                        />
-                        <div className="min-w-0 flex-1">
-                          <div className="truncate text-sm font-medium">
-                            {c.name}
+              ) : (() => {
+                const q = campaignQuery.trim().toLowerCase();
+                const filtered = q
+                  ? closedCampaigns.filter((c) =>
+                      c.name.toLowerCase().includes(q) ||
+                      c.close_date.toLowerCase().includes(q)
+                    )
+                  : closedCampaigns;
+                if (filtered.length === 0) {
+                  return (
+                    <div className="text-center text-sm text-zinc-500">
+                      沒有符合「{campaignQuery}」的團
+                    </div>
+                  );
+                }
+                return (
+                  <ul className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                    {filtered.map((c) => {
+                      const checked = selectedCampaignIds.has(c.id);
+                      return (
+                        <li
+                          key={c.id}
+                          className="flex cursor-pointer items-center gap-3 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                          onClick={() => toggleCampaignSelect(c.id)}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleCampaignSelect(c.id)}
+                            onClick={(e) => e.stopPropagation()}
+                            className="h-4 w-4 rounded border-zinc-300 text-blue-600 focus:ring-blue-500"
+                          />
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-sm font-medium">
+                              {c.name}
+                            </div>
+                            <div className="mt-0.5 text-xs text-zinc-500">
+                              結單日 {c.close_date}
+                              {c.existing_pr_id !== null && (
+                                <Link
+                                  href={`/purchase/requests/edit?id=${c.existing_pr_id}`}
+                                  onClick={(e) => e.stopPropagation()}
+                                  className="ml-2 text-amber-600 hover:underline dark:text-amber-400"
+                                >
+                                  · 已有採購單 #{c.existing_pr_id}（補單會新建）
+                                </Link>
+                              )}
+                            </div>
                           </div>
-                          <div className="mt-0.5 text-xs text-zinc-500">
-                            結單日 {c.close_date}
-                            {c.existing_pr_id !== null && (
-                              <Link
-                                href={`/purchase/requests/edit?id=${c.existing_pr_id}`}
-                                onClick={(e) => e.stopPropagation()}
-                                className="ml-2 text-amber-600 hover:underline dark:text-amber-400"
-                              >
-                                · 已有採購單 #{c.existing_pr_id}（補單會新建）
-                              </Link>
-                            )}
-                          </div>
-                        </div>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                );
+              })()}
             </div>
             {closedCampaigns && closedCampaigns.length > 0 && (
               <div className="flex items-center justify-between gap-3 border-t border-zinc-200 px-4 py-3 dark:border-zinc-800">
@@ -1111,6 +1140,7 @@ export default function PurchaseRequestsListPage() {
                     onClick={() => {
                       setShowCampaignModal(false);
                       setSelectedCampaignIds(new Set());
+                      setCampaignQuery("");
                     }}
                     className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
                   >

--- a/apps/admin/src/app/(protected)/restock/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
+import RestockDetailModal from "@/components/RestockDetailModal";
 
 const PAGE_SIZE = 20;
 
@@ -24,6 +25,7 @@ type Row = {
   created_at: string;
   line_count: number;
   total_amount: number;
+  items_summary: string;
 };
 
 const STATUS_LABEL: Record<Status, string> = {
@@ -53,6 +55,7 @@ export default function RestockListPage() {
   const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState<Tab>("pending");
   const [page, setPage] = useState(1);
+  const [detailId, setDetailId] = useState<number | null>(null);
 
   useEffect(() => { setPage(1); }, [tab]);
 
@@ -67,15 +70,52 @@ export default function RestockListPage() {
       if (err) { setError(err.message); return; }
       const reqRows = (data ?? []) as unknown as Array<Row & { stores?: { name: string } }>;
       const ids = reqRows.map((r) => r.id);
-      // 取 line count + total
-      const lineMap = new Map<number, { count: number; total: number }>();
+      // 取 line count + total + items summary（含 sku_code + 商品名）
+      const lineMap = new Map<number, { count: number; total: number; summary: string }>();
       if (ids.length > 0) {
-        const { data: lineData } = await sb.from("restock_request_lines").select("request_id, qty, unit_price").in("request_id", ids);
-        for (const l of (lineData ?? []) as { request_id: number; qty: number; unit_price: number }[]) {
-          const slot = lineMap.get(l.request_id) ?? { count: 0, total: 0 };
+        const { data: lineData } = await sb
+          .from("restock_request_lines")
+          .select("request_id, sku_id, qty, unit_price")
+          .in("request_id", ids);
+        const lines = (lineData ?? []) as { request_id: number; sku_id: number; qty: number; unit_price: number }[];
+
+        // 撈 SKU + 商品名（restock_request_lines.sku_id 有 FK 但兩階段 fetch 較穩）
+        const skuIds = Array.from(new Set(lines.map((l) => l.sku_id))).filter((x) => x != null);
+        let skuLabelMap = new Map<number, string>();
+        if (skuIds.length > 0) {
+          const { data: skus } = await sb
+            .from("skus")
+            .select("id, sku_code, variant_name, product_id")
+            .in("id", skuIds);
+          const skuArr = (skus ?? []) as { id: number; sku_code: string; variant_name: string | null; product_id: number | null }[];
+          const prodIds = Array.from(new Set(skuArr.map((s) => s.product_id).filter((x): x is number => x != null)));
+          let prodNameMap = new Map<number, string>();
+          if (prodIds.length > 0) {
+            const { data: prods } = await sb.from("products").select("id, name").in("id", prodIds);
+            prodNameMap = new Map(((prods ?? []) as { id: number; name: string }[]).map((p) => [p.id, p.name]));
+          }
+          skuLabelMap = new Map(
+            skuArr.map((s) => [
+              s.id,
+              s.product_id != null ? prodNameMap.get(s.product_id) ?? s.sku_code : s.sku_code,
+            ])
+          );
+        }
+
+        const partsMap = new Map<number, string[]>();
+        for (const l of lines) {
+          const slot = lineMap.get(l.request_id) ?? { count: 0, total: 0, summary: "" };
           slot.count += 1;
           slot.total += Number(l.qty) * Number(l.unit_price);
           lineMap.set(l.request_id, slot);
+          const label = skuLabelMap.get(l.sku_id) ?? `#${l.sku_id}`;
+          const parts = partsMap.get(l.request_id) ?? [];
+          parts.push(`${label}×${Number(l.qty)}`);
+          partsMap.set(l.request_id, parts);
+        }
+        for (const [rid, parts] of partsMap) {
+          const slot = lineMap.get(rid);
+          if (slot) slot.summary = parts.join("、");
         }
       }
       // 取 transfer / pr 編號
@@ -97,6 +137,7 @@ export default function RestockListPage() {
         store_name: r.stores?.name ?? null,
         line_count: lineMap.get(r.id)?.count ?? 0,
         total_amount: lineMap.get(r.id)?.total ?? 0,
+        items_summary: lineMap.get(r.id)?.summary ?? "",
         linked_transfer_no: r.linked_transfer_id ? xferMap.get(r.linked_transfer_id) ?? null : null,
         linked_pr_no: r.linked_pr_id ? prMap.get(r.linked_pr_id) ?? null : null,
       })));
@@ -152,6 +193,7 @@ export default function RestockListPage() {
           <Th>日期</Th>
           <Th>店</Th>
           <Th align="right">商品數</Th>
+          <Th>品項</Th>
           <Th align="right">總金額</Th>
           <Th>狀態</Th>
           <Th>連結 / 拒絕原因</Th>
@@ -159,14 +201,21 @@ export default function RestockListPage() {
         </THead>
         <TBody>
           {rows === null ? (
-            <LoadingRow colSpan={7} />
+            <LoadingRow colSpan={8} />
           ) : filtered.length === 0 ? (
-            <EmptyRow colSpan={7}>沒有符合條件的申請</EmptyRow>
+            <EmptyRow colSpan={8}>沒有符合條件的申請</EmptyRow>
           ) : paginated.map((r) => (
-            <Tr key={r.id}>
+            <Tr
+              key={r.id}
+              onClick={() => setDetailId(r.id)}
+              className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-950"
+            >
               <Td className="whitespace-nowrap text-xs text-zinc-500">{new Date(r.created_at).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" })}</Td>
               <Td>{r.store_name ?? "—"}</Td>
               <Td align="right" className="font-mono">{r.line_count}</Td>
+              <Td className="max-w-md text-xs text-zinc-600 dark:text-zinc-300">
+                <span title={r.items_summary} className="line-clamp-2">{r.items_summary || "—"}</span>
+              </Td>
               <Td align="right" className="font-mono">${r.total_amount.toFixed(0)}</Td>
               <Td>
                 <span className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${STATUS_COLOR[r.status]}`}>
@@ -175,12 +224,20 @@ export default function RestockListPage() {
               </Td>
               <Td className="text-xs">
                 {r.linked_transfer_no && (
-                  <Link href={`/hq/inbox?source=transfer&id=${r.linked_transfer_id}`} className="font-mono text-blue-600 hover:underline dark:text-blue-400">
+                  <Link
+                    href={`/hq/inbox?source=transfer&id=${r.linked_transfer_id}`}
+                    onClick={(e) => e.stopPropagation()}
+                    className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                  >
                     → {r.linked_transfer_no}
                   </Link>
                 )}
                 {r.linked_pr_no && (
-                  <Link href={`/purchase/requests/edit?id=${r.linked_pr_id}`} className="font-mono text-blue-600 hover:underline dark:text-blue-400">
+                  <Link
+                    href={`/purchase/requests/edit?id=${r.linked_pr_id}`}
+                    onClick={(e) => e.stopPropagation()}
+                    className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                  >
                     → {r.linked_pr_no}
                   </Link>
                 )}
@@ -193,6 +250,12 @@ export default function RestockListPage() {
           ))}
         </TBody>
       </Table>
+
+      <RestockDetailModal
+        open={detailId !== null}
+        restockId={detailId}
+        onClose={() => setDetailId(null)}
+      />
 
       {filtered.length > PAGE_SIZE && (
         <div className="flex flex-wrap items-center justify-end gap-2 text-sm">

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -655,7 +655,14 @@ export default function PickingWorkstationPage() {
         </span>
 
         {viewMode === "matrix" && skuRows.length > 0 && (
-          <div className="ml-auto">
+          <div className="ml-auto flex flex-wrap gap-2">
+            <Link
+              href="/picking/print-pick-list"
+              target="_blank"
+              className="rounded-md border border-blue-300 bg-blue-50 px-3 py-2 text-sm font-medium text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
+            >
+              📄 列印撿貨清單
+            </Link>
             <SpinButton
               onClick={submitAll}
               disabled={submitting || totalAllocSum === 0}

--- a/apps/admin/src/app/(protected)/wms/transfers/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/transfers/page.tsx
@@ -14,6 +14,7 @@ import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import FreeTransferCreateModal from "@/components/FreeTransferCreateModal";
 import OrderReturnCreateModal from "@/components/OrderReturnCreateModal";
+import TransferDetailModal from "@/components/TransferDetailModal";
 
 type Loc = { id: number; name: string; type: string };
 
@@ -54,6 +55,7 @@ export default function InternalTransfersPage() {
   const [tab, setTab] = useState<"store_to_store" | "store_to_hq" | "all">("store_to_store");
   const [showCreate, setShowCreate] = useState(false);
   const [showReturn, setShowReturn] = useState(false);
+  const [detailId, setDetailId] = useState<number | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
@@ -177,6 +179,11 @@ export default function InternalTransfersPage() {
           setReloadKey((k) => k + 1);
         }}
       />
+      <TransferDetailModal
+        open={detailId !== null}
+        transferId={detailId}
+        onClose={() => setDetailId(null)}
+      />
 
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
@@ -224,7 +231,11 @@ export default function InternalTransfersPage() {
               const dst = locs.get(t.dest_location)?.name ?? `#${t.dest_location}`;
               const isReturn = isStoreToHq(t);
               return (
-                <tr key={t.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-950">
+                <tr
+                  key={t.id}
+                  onClick={() => setDetailId(t.id)}
+                  className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-950"
+                >
                   <td className="px-3 py-2 font-mono text-xs">
                     {t.transfer_no}
                     {isOrderReturn(t.notes) ? (

--- a/apps/admin/src/components/CampaignForm.tsx
+++ b/apps/admin/src/components/CampaignForm.tsx
@@ -153,9 +153,6 @@ export function CampaignForm({
           </select>
         </Field>
 
-        <Field label="開團時間">
-          <input type="datetime-local" value={toDtLocal(v.start_at)} onChange={(e) => update("start_at", e.target.value ? new Date(e.target.value).toISOString() : null)} className={inputCls} />
-        </Field>
         <Field label="收單類型">
           <select value={v.close_type} onChange={(e) => update("close_type", e.target.value as CloseType)} className={inputCls}>
             <option value="regular">常規</option>
@@ -164,16 +161,55 @@ export function CampaignForm({
           </select>
         </Field>
         <Field
-          label={v.close_type === "fast" ? "收單時間（快團必填）" : "收單時間"}
+          label={v.close_type === "fast" ? "開團期間（開團 → 收單，快團必填收單）" : "開團期間（開團 → 收單）"}
           className="sm:col-span-2"
         >
-          <input
-            type="datetime-local"
-            required={v.close_type === "fast"}
-            value={toDtLocal(v.end_at)}
-            onChange={(e) => update("end_at", e.target.value ? new Date(e.target.value).toISOString() : null)}
-            className={inputCls}
-          />
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <input
+              type="datetime-local"
+              value={toDtLocal(v.start_at)}
+              onChange={(e) => {
+                const startIso = e.target.value ? new Date(e.target.value).toISOString() : null;
+                setV((prev) => {
+                  const next: CampaignFormValues = { ...prev, start_at: startIso };
+                  if (startIso && prev.end_at && new Date(prev.end_at) <= new Date(startIso)) {
+                    next.end_at = null;
+                  }
+                  return next;
+                });
+              }}
+              className={`${inputCls} flex-1`}
+              aria-label="開團時間"
+            />
+            <span className="text-center text-xs text-zinc-400 sm:px-1">→</span>
+            <input
+              type="datetime-local"
+              required={v.close_type === "fast"}
+              value={toDtLocal(v.end_at)}
+              min={toDtLocal(v.start_at) || undefined}
+              onChange={(e) => update("end_at", e.target.value ? new Date(e.target.value).toISOString() : null)}
+              className={`${inputCls} flex-1`}
+              aria-label="收單時間"
+            />
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[11px] text-zinc-500">
+            <span>快速：</span>
+            {QUICK_RANGES.map((q) => (
+              <SpinButton
+                key={q.label}
+                type="button"
+                onClick={() => applyQuickRange(setV, q.startOffsetH, q.durationH)}
+                className="rounded-md border border-zinc-200 px-2 py-0.5 text-[11px] hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              >
+                {q.label}
+              </SpinButton>
+            ))}
+            {v.start_at && v.end_at && (
+              <span className="ml-2 text-zinc-400">
+                時長 {formatDuration(v.start_at, v.end_at)}
+              </span>
+            )}
+          </div>
           {v.close_type === "fast" && (
             <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400">
               快團需有明確收單時間，PWA 限時專區會顯示倒數計時。
@@ -226,6 +262,47 @@ function toDtLocal(iso: string | null): string {
   if (Number.isNaN(d.getTime())) return "";
   const pad = (n: number) => String(n).padStart(2, "0");
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+// 快速設定開團期間
+// startOffsetH = 從現在偏移幾小時起算（0 = 立刻、24 = 明天）
+// durationH    = 收單時間 = 開團時間 + N 小時
+type QuickRange = { label: string; startOffsetH: number; durationH: number };
+const QUICK_RANGES: QuickRange[] = [
+  { label: "立即→3 天", startOffsetH: 0, durationH: 72 },
+  { label: "立即→7 天", startOffsetH: 0, durationH: 168 },
+  { label: "明早 8 點→3 天", startOffsetH: -1, durationH: 72 },
+  { label: "明早 8 點→7 天", startOffsetH: -1, durationH: 168 },
+];
+
+function applyQuickRange(
+  setV: React.Dispatch<React.SetStateAction<CampaignFormValues>>,
+  startOffsetH: number,
+  durationH: number,
+) {
+  let start: Date;
+  if (startOffsetH === -1) {
+    // 明早 8 點
+    start = new Date();
+    start.setDate(start.getDate() + 1);
+    start.setHours(8, 0, 0, 0);
+  } else {
+    start = new Date();
+    start.setMinutes(0, 0, 0);
+    start.setHours(start.getHours() + startOffsetH);
+  }
+  const end = new Date(start.getTime() + durationH * 3600 * 1000);
+  setV((prev) => ({ ...prev, start_at: start.toISOString(), end_at: end.toISOString() }));
+}
+
+function formatDuration(startIso: string, endIso: string): string {
+  const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
+  if (ms <= 0) return "—";
+  const hours = Math.round(ms / 3600 / 1000);
+  if (hours < 24) return `${hours} 小時`;
+  const days = Math.round(hours / 24);
+  if (days <= 14) return `${days} 天`;
+  return `${days} 天（約 ${Math.round(days / 7)} 週）`;
 }
 
 function Field({ label, children, className = "" }: { label: string; children: React.ReactNode; className?: string }) {

--- a/apps/admin/src/components/CampaignItemsTable.tsx
+++ b/apps/admin/src/components/CampaignItemsTable.tsx
@@ -8,6 +8,7 @@ type Row = {
   id: number;
   sku_id: number;
   sku_code: string;
+  sku_status: string;
   product_id: number;
   product_name: string | null;
   variant_name: string | null;
@@ -24,9 +25,11 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
 
   const reload = async () => {
     // products.name 是 source of truth；skus.product_name 是 denorm 可能過期、不用它
+    // 過濾 sku.status='discontinued'：已下架的規格不該在開團裡（draft 由 trigger 清掉，
+    // open / closed 留 row 不破壞訂單，但 UI 不顯示）
     const { data, error: err } = await getSupabase()
       .from("campaign_items")
-      .select("id, sku_id, unit_price, cap_qty, sort_order, notes, locked_at, skus!inner(id, sku_code, product_id, variant_name, products!inner(id, name))")
+      .select("id, sku_id, unit_price, cap_qty, sort_order, notes, locked_at, skus!inner(id, sku_code, status, product_id, variant_name, products!inner(id, name))")
       .eq("campaign_id", campaignId)
       .order("sort_order");
     if (err) { setError(err.message); return; }
@@ -34,17 +37,22 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
       (data as unknown as Array<{
         id: number; sku_id: number; unit_price: number; cap_qty: number | null;
         sort_order: number; notes: string | null; locked_at: string | null;
-        skus: { id: number; sku_code: string; product_id: number; variant_name: string | null;
+        skus: { id: number; sku_code: string; status: string; product_id: number; variant_name: string | null;
           products: { id: number; name: string };
         };
-      }>).map((r) => ({
-        id: r.id, sku_id: r.sku_id, sku_code: r.skus.sku_code,
-        product_id: r.skus.product_id,
-        product_name: r.skus.products?.name ?? null,
-        variant_name: r.skus.variant_name,
-        unit_price: Number(r.unit_price), cap_qty: r.cap_qty != null ? Number(r.cap_qty) : null,
-        sort_order: r.sort_order, notes: r.notes, locked_at: r.locked_at,
-      }))
+      }>)
+        // 已下架（discontinued）規格不該顯示在開團裡。draft 開團由 trigger 清掉、
+        // open/closed 仍保留 row（避免破壞既有訂單），但 UI 不顯示。
+        .filter((r) => r.skus.status !== "discontinued")
+        .map((r) => ({
+          id: r.id, sku_id: r.sku_id, sku_code: r.skus.sku_code,
+          sku_status: r.skus.status,
+          product_id: r.skus.product_id,
+          product_name: r.skus.products?.name ?? null,
+          variant_name: r.skus.variant_name,
+          unit_price: Number(r.unit_price), cap_qty: r.cap_qty != null ? Number(r.cap_qty) : null,
+          sort_order: r.sort_order, notes: r.notes, locked_at: r.locked_at,
+        }))
     );
   };
 

--- a/apps/admin/src/components/OrderReturnCreateModal.tsx
+++ b/apps/admin/src/components/OrderReturnCreateModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
 import { getSupabase } from "@/lib/supabase";
@@ -24,6 +24,7 @@ type OrderRow = {
   pickup_store_id: number;
   nickname_snapshot: string | null;
   created_at: string;
+  items_summary: string;
 };
 
 type DeliveredSku = {
@@ -60,6 +61,22 @@ export default function OrderReturnCreateModal({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // 訂單搜尋 combobox
+  const [orderQuery, setOrderQuery] = useState("");
+  const [orderOpen, setOrderOpen] = useState(false);
+  const orderBoxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!orderOpen) return;
+    function onAway(e: MouseEvent) {
+      if (orderBoxRef.current && !orderBoxRef.current.contains(e.target as Node)) {
+        setOrderOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onAway);
+    return () => document.removeEventListener("mousedown", onAway);
+  }, [orderOpen]);
+
   useEffect(() => {
     if (!open) return;
     (async () => {
@@ -84,6 +101,8 @@ export default function OrderReturnCreateModal({
       setQtys({});
       setReason("");
       setError(null);
+      setOrderQuery("");
+      setOrderOpen(false);
     }
   }, [open, prefillStoreId, prefillOrderId]);
 
@@ -95,14 +114,61 @@ export default function OrderReturnCreateModal({
     setQtys({});
     if (storeId === null) return;
     (async () => {
+      // 一併撈每張訂單的 items（含 sku_code + 商品名）以便下拉直接顯示品項
       const { data } = await getSupabase()
         .from("customer_orders")
-        .select("id, order_no, status, pickup_store_id, nickname_snapshot, created_at")
+        .select(
+          "id, order_no, status, pickup_store_id, nickname_snapshot, created_at, " +
+            "customer_order_items(sku_id, qty, status, skus(sku_code, products(name)))"
+        )
         .eq("pickup_store_id", storeId)
         .in("status", RETURNABLE_STATUSES as unknown as string[])
         .order("id", { ascending: false })
         .limit(100);
-      setOrders((data ?? []) as OrderRow[]);
+
+      type ApiItem = {
+        sku_id: number | null;
+        qty: number | null;
+        status: string | null;
+        skus:
+          | { sku_code: string; products: { name?: string } | { name?: string }[] | null }
+          | Array<{ sku_code: string; products: { name?: string } | { name?: string }[] | null }>
+          | null;
+      };
+      type ApiOrder = {
+        id: number;
+        order_no: string;
+        status: string;
+        pickup_store_id: number;
+        nickname_snapshot: string | null;
+        created_at: string;
+        customer_order_items: ApiItem[] | null;
+      };
+
+      const rows = ((data ?? []) as unknown as ApiOrder[]).map((o) => {
+        const parts: string[] = [];
+        for (const it of o.customer_order_items ?? []) {
+          if (it.status === "cancelled" || it.status === "expired") continue;
+          const skuObj = Array.isArray(it.skus) ? it.skus[0] : it.skus;
+          if (!skuObj) continue;
+          const prodObj = Array.isArray(skuObj.products) ? skuObj.products[0] : skuObj.products;
+          const code = skuObj.sku_code ?? `#${it.sku_id}`;
+          const name = prodObj?.name ?? "";
+          const qty = Number(it.qty ?? 0);
+          parts.push(name ? `${code}×${qty}（${name}）` : `${code}×${qty}`);
+        }
+        return {
+          id: o.id,
+          order_no: o.order_no,
+          status: o.status,
+          pickup_store_id: o.pickup_store_id,
+          nickname_snapshot: o.nickname_snapshot,
+          created_at: o.created_at,
+          items_summary: parts.join("、"),
+        } as OrderRow;
+      });
+
+      setOrders(rows);
     })();
   }, [storeId, isPrefilled]);
 
@@ -266,31 +332,93 @@ export default function OrderReturnCreateModal({
               ))}
             </select>
           </label>
-          <label className="flex flex-col gap-1 text-sm">
+          <div className="flex flex-col gap-1 text-sm">
             <span className="text-zinc-600 dark:text-zinc-400">訂單 *</span>
-            <select
-              value={orderId ?? ""}
-              onChange={(e) => setOrderId(Number(e.target.value) || null)}
-              className={inputCls}
-              disabled={orders === null}
-            >
-              <option value="">
-                {orders === null
-                  ? storeId === null
-                    ? "請先選分店"
-                    : "載入中…"
-                  : orders.length === 0
-                    ? "此店無可退訂單"
-                    : "— 請選 —"}
-              </option>
-              {(orders ?? []).map((o) => (
-                <option key={o.id} value={o.id}>
-                  {o.order_no} · {STATUS_LABEL[o.status] ?? o.status}
-                  {o.nickname_snapshot ? ` · ${o.nickname_snapshot}` : ""}
-                </option>
-              ))}
-            </select>
-          </label>
+            <div className="relative" ref={orderBoxRef}>
+              <input
+                type="text"
+                value={orderOpen ? orderQuery : (() => {
+                  if (orderId === null) return "";
+                  const o = orders?.find((x) => x.id === orderId);
+                  if (!o) return "";
+                  return `${o.order_no} · ${STATUS_LABEL[o.status] ?? o.status}${o.nickname_snapshot ? ` · ${o.nickname_snapshot}` : ""}`;
+                })()}
+                onFocus={() => { setOrderOpen(true); setOrderQuery(""); }}
+                onChange={(e) => { setOrderOpen(true); setOrderQuery(e.target.value); }}
+                placeholder={
+                  orders === null
+                    ? storeId === null
+                      ? "請先選分店"
+                      : "載入中…"
+                    : orders.length === 0
+                      ? "此店無可退訂單"
+                      : "搜尋訂單號 / 人名 / 商品名稱…"
+                }
+                disabled={orders === null || (orders ?? []).length === 0}
+                className={`${inputCls} w-full pr-8`}
+                aria-label="訂單搜尋"
+              />
+              {orderId !== null && !orderOpen && (
+                <button
+                  type="button"
+                  onClick={() => { setOrderId(null); setOrderQuery(""); setOrderOpen(true); }}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200"
+                  aria-label="清除選擇"
+                >
+                  ×
+                </button>
+              )}
+
+              {orderOpen && (orders?.length ?? 0) > 0 && (() => {
+                const q = orderQuery.trim().toLowerCase();
+                const filtered = q
+                  ? (orders ?? []).filter((o) =>
+                      o.order_no.toLowerCase().includes(q) ||
+                      (o.nickname_snapshot ?? "").toLowerCase().includes(q) ||
+                      (o.items_summary ?? "").toLowerCase().includes(q)
+                    )
+                  : (orders ?? []);
+                return (
+                  <ul
+                    role="listbox"
+                    className="absolute z-10 mt-1 max-h-72 w-full overflow-y-auto rounded-md border border-zinc-300 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
+                  >
+                    {filtered.length === 0 ? (
+                      <li className="px-3 py-2 text-xs text-zinc-500">沒有符合的訂單</li>
+                    ) : (
+                      filtered.map((o) => (
+                        <li
+                          key={o.id}
+                          role="option"
+                          aria-selected={orderId === o.id}
+                          onMouseDown={(e) => {
+                            // mousedown 而非 click：避免 input blur 衝突
+                            e.preventDefault();
+                            setOrderId(o.id);
+                            setOrderOpen(false);
+                            setOrderQuery("");
+                          }}
+                          className={`cursor-pointer px-3 py-2 text-xs hover:bg-zinc-100 dark:hover:bg-zinc-800 ${
+                            orderId === o.id ? "bg-blue-50 dark:bg-blue-950/40" : ""
+                          }`}
+                        >
+                          <div className="font-mono text-zinc-900 dark:text-zinc-100">
+                            {o.order_no} · <span className="text-zinc-500">{STATUS_LABEL[o.status] ?? o.status}</span>
+                          </div>
+                          {o.nickname_snapshot && (
+                            <div className="text-zinc-600 dark:text-zinc-400">{o.nickname_snapshot}</div>
+                          )}
+                          {o.items_summary && (
+                            <div className="text-zinc-500">{o.items_summary}</div>
+                          )}
+                        </li>
+                      ))
+                    )}
+                  </ul>
+                );
+              })()}
+            </div>
+          </div>
         </div>
         )}
 

--- a/apps/admin/src/components/ProductForm.tsx
+++ b/apps/admin/src/components/ProductForm.tsx
@@ -270,8 +270,6 @@ export function ProductForm({
         </Field>
       </Grid>
 
-      {midSlot}
-
       <Grid>
         <Field label="儲存溫層">
           <select
@@ -306,6 +304,8 @@ export function ProductForm({
           </select>
         </Field>
       </Grid>
+
+      {midSlot}
 
       <div className="flex flex-wrap gap-4">
         <Checkbox

--- a/apps/admin/src/components/RestockDetailModal.tsx
+++ b/apps/admin/src/components/RestockDetailModal.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Modal } from "@/components/Modal";
+import { getSupabase } from "@/lib/supabase";
+
+type RestockRow = {
+  id: number;
+  requesting_store_id: number;
+  store_name: string | null;
+  status: string;
+  notes: string | null;
+  rejected_reason: string | null;
+  requested_at: string;
+  approved_at: string | null;
+  rejected_at: string | null;
+  linked_transfer_id: number | null;
+  linked_pr_id: number | null;
+  linked_transfer_no: string | null;
+  linked_pr_no: string | null;
+};
+
+type Line = {
+  id: number;
+  sku_id: number;
+  qty: number;
+  unit_price: number;
+  sku_code: string;
+  sku_name: string;
+  variant_name: string | null;
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  pending: "待處理",
+  approved_transfer: "已派庫存",
+  approved_pr: "已下訂",
+  shipped: "已出貨",
+  received: "已收貨",
+  rejected: "已拒絕",
+  cancelled: "已取消",
+};
+
+export default function RestockDetailModal({
+  open,
+  restockId,
+  onClose,
+}: {
+  open: boolean;
+  restockId: number | null;
+  onClose: () => void;
+}) {
+  const [hd, setHd] = useState<RestockRow | null>(null);
+  const [lines, setLines] = useState<Line[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || restockId == null) { setHd(null); setLines(null); setErr(null); return; }
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data: rData, error: rErr } = await sb
+        .from("restock_requests")
+        .select(
+          "id, requesting_store_id, status, notes, rejected_reason, requested_at, approved_at, rejected_at, linked_transfer_id, linked_pr_id, " +
+            "stores(name), transfers(transfer_no), purchase_requests(pr_no)"
+        )
+        .eq("id", restockId)
+        .maybeSingle();
+      if (cancelled) return;
+      if (rErr || !rData) {
+        setErr(rErr?.message ?? "找不到此補貨申請");
+        setHd(null);
+        return;
+      }
+      type ApiR = {
+        id: number;
+        requesting_store_id: number;
+        status: string;
+        notes: string | null;
+        rejected_reason: string | null;
+        requested_at: string;
+        approved_at: string | null;
+        rejected_at: string | null;
+        linked_transfer_id: number | null;
+        linked_pr_id: number | null;
+        stores: { name?: string } | { name?: string }[] | null;
+        transfers: { transfer_no?: string } | { transfer_no?: string }[] | null;
+        purchase_requests: { pr_no?: string } | { pr_no?: string }[] | null;
+      };
+      const r = rData as unknown as ApiR;
+      const storeObj = Array.isArray(r.stores) ? r.stores[0] : r.stores;
+      const txObj = Array.isArray(r.transfers) ? r.transfers[0] : r.transfers;
+      const prObj = Array.isArray(r.purchase_requests) ? r.purchase_requests[0] : r.purchase_requests;
+      setHd({
+        id: r.id,
+        requesting_store_id: r.requesting_store_id,
+        store_name: storeObj?.name ?? null,
+        status: r.status,
+        notes: r.notes,
+        rejected_reason: r.rejected_reason,
+        requested_at: r.requested_at,
+        approved_at: r.approved_at,
+        rejected_at: r.rejected_at,
+        linked_transfer_id: r.linked_transfer_id,
+        linked_pr_id: r.linked_pr_id,
+        linked_transfer_no: txObj?.transfer_no ?? null,
+        linked_pr_no: prObj?.pr_no ?? null,
+      });
+
+      const { data: lData } = await sb
+        .from("restock_request_lines")
+        .select("id, sku_id, qty, unit_price, skus(sku_code, variant_name, products(name))")
+        .eq("request_id", restockId)
+        .order("id");
+      if (cancelled) return;
+      type ApiL = {
+        id: number;
+        sku_id: number;
+        qty: number;
+        unit_price: number;
+        skus:
+          | { sku_code: string; variant_name: string | null; products: { name?: string } | { name?: string }[] | null }
+          | Array<{ sku_code: string; variant_name: string | null; products: { name?: string } | { name?: string }[] | null }>
+          | null;
+      };
+      const rows: Line[] = ((lData ?? []) as unknown as ApiL[]).map((row) => {
+        const skuObj = Array.isArray(row.skus) ? row.skus[0] : row.skus;
+        const prodObj = skuObj ? (Array.isArray(skuObj.products) ? skuObj.products[0] : skuObj.products) : null;
+        return {
+          id: row.id,
+          sku_id: row.sku_id,
+          qty: Number(row.qty),
+          unit_price: Number(row.unit_price),
+          sku_code: skuObj?.sku_code ?? `#${row.sku_id}`,
+          sku_name: prodObj?.name ?? "",
+          variant_name: skuObj?.variant_name ?? null,
+        };
+      });
+      setLines(rows);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, restockId]);
+
+  const total = (lines ?? []).reduce((acc, l) => acc + l.qty * l.unit_price, 0);
+  const title = hd ? `📦 補貨申請 RESTOCK#${hd.id}` : "補貨申請";
+
+  return (
+    <Modal open={open} onClose={onClose} title={title} maxWidth="max-w-3xl">
+      {err && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {err}
+        </div>
+      )}
+      {!hd && !err && <p className="text-sm text-zinc-500">載入中…</p>}
+      {hd && (
+        <div className="space-y-4">
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+            <Field label="申請門市" value={hd.store_name ?? `#${hd.requesting_store_id}`} />
+            <Field label="狀態" value={STATUS_LABEL[hd.status] ?? hd.status} />
+            <Field label="申請時間" value={new Date(hd.requested_at).toLocaleString("zh-TW")} />
+            <Field
+              label="核可時間"
+              value={hd.approved_at ? new Date(hd.approved_at).toLocaleString("zh-TW") : "—"}
+            />
+            {hd.linked_transfer_id != null && (
+              <div className="col-span-2">
+                <dt className="text-xs text-zinc-500">轉貨單</dt>
+                <dd className="text-sm">
+                  <Link
+                    href={`/hq/inbox?source=transfer&id=${hd.linked_transfer_id}`}
+                    className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {hd.linked_transfer_no ?? `#${hd.linked_transfer_id}`}
+                  </Link>
+                </dd>
+              </div>
+            )}
+            {hd.linked_pr_id != null && (
+              <div className="col-span-2">
+                <dt className="text-xs text-zinc-500">採購單</dt>
+                <dd className="text-sm">
+                  <Link
+                    href={`/purchase/requests/edit?id=${hd.linked_pr_id}`}
+                    className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {hd.linked_pr_no ?? `#${hd.linked_pr_id}`}
+                  </Link>
+                </dd>
+              </div>
+            )}
+            {hd.status === "rejected" && hd.rejected_reason && (
+              <Field label="拒絕原因" value={hd.rejected_reason} full />
+            )}
+            {hd.notes && <Field label="備註" value={hd.notes} full />}
+          </dl>
+
+          <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
+            <table className="w-full text-sm">
+              <thead className="bg-zinc-50 dark:bg-zinc-900">
+                <tr className="text-left text-xs uppercase tracking-wide text-zinc-500">
+                  <th className="px-3 py-2">SKU</th>
+                  <th className="px-3 py-2">品名 / 規格</th>
+                  <th className="px-3 py-2 text-right">數量</th>
+                  <th className="px-3 py-2 text-right">單價</th>
+                  <th className="px-3 py-2 text-right">小計</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                {lines === null ? (
+                  <tr><td colSpan={5} className="p-4 text-center text-zinc-500">載入中…</td></tr>
+                ) : lines.length === 0 ? (
+                  <tr><td colSpan={5} className="p-4 text-center text-zinc-500">無明細</td></tr>
+                ) : (
+                  <>
+                    {lines.map((l) => (
+                      <tr key={l.id}>
+                        <td className="px-3 py-2 font-mono text-xs">{l.sku_code}</td>
+                        <td className="px-3 py-2 text-xs">
+                          {l.sku_name || "—"}
+                          {l.variant_name && <span className="ml-1 text-zinc-500">/ {l.variant_name}</span>}
+                        </td>
+                        <td className="px-3 py-2 text-right font-mono">{l.qty}</td>
+                        <td className="px-3 py-2 text-right font-mono">${l.unit_price}</td>
+                        <td className="px-3 py-2 text-right font-mono">${(l.qty * l.unit_price).toFixed(0)}</td>
+                      </tr>
+                    ))}
+                    <tr className="bg-zinc-50 dark:bg-zinc-900">
+                      <td colSpan={4} className="px-3 py-2 text-right text-xs text-zinc-500">合計</td>
+                      <td className="px-3 py-2 text-right font-mono font-semibold">${total.toFixed(0)}</td>
+                    </tr>
+                  </>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function Field({ label, value, full = false }: { label: string; value: string; full?: boolean }) {
+  return (
+    <div className={full ? "col-span-2" : ""}>
+      <dt className="text-xs text-zinc-500">{label}</dt>
+      <dd className="text-sm text-zinc-900 dark:text-zinc-100 whitespace-pre-wrap">{value}</dd>
+    </div>
+  );
+}

--- a/apps/admin/src/components/TransferDetailModal.tsx
+++ b/apps/admin/src/components/TransferDetailModal.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Modal } from "@/components/Modal";
+import { getSupabase } from "@/lib/supabase";
+
+type TransferRow = {
+  id: number;
+  transfer_no: string;
+  source_location: number;
+  dest_location: number;
+  status: string;
+  transfer_type: string;
+  notes: string | null;
+  shipping_temp: string | null;
+  is_air_transfer: boolean | null;
+  customer_order_id: number | null;
+  shipped_at: string | null;
+  received_at: string | null;
+  created_at: string;
+  source_name: string | null;
+  dest_name: string | null;
+};
+
+type Item = {
+  id: number;
+  sku_id: number;
+  qty_requested: number;
+  qty_shipped: number;
+  qty_received: number | null;
+  sku_code: string;
+  sku_name: string;
+  variant_name: string | null;
+};
+
+const TYPE_LABEL: Record<string, string> = {
+  hq_to_store: "總倉派貨",
+  store_to_store: "店轉店",
+  store_to_hq: "店退總倉",
+  return_to_hq: "退貨回總倉",
+  aid_handoff: "互助轉移",
+};
+const STATUS_LABEL: Record<string, string> = {
+  draft: "草稿",
+  confirmed: "已確認",
+  shipped: "已出貨",
+  received: "已收貨",
+  cancelled: "已取消",
+  closed: "已結案",
+};
+
+export default function TransferDetailModal({
+  open,
+  transferId,
+  onClose,
+}: {
+  open: boolean;
+  transferId: number | null;
+  onClose: () => void;
+}) {
+  const [tx, setTx] = useState<TransferRow | null>(null);
+  const [items, setItems] = useState<Item[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || transferId == null) { setTx(null); setItems(null); setErr(null); return; }
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      // 用 join locations 取名稱
+      const { data: tDataRaw, error: tErr } = await sb
+        .from("transfers")
+        .select(
+          "id, transfer_no, source_location, dest_location, status, transfer_type, notes, " +
+            "shipping_temp, is_air_transfer, customer_order_id, shipped_at, received_at, created_at"
+        )
+        .eq("id", transferId)
+        .maybeSingle();
+      if (cancelled) return;
+      if (tErr || !tDataRaw) {
+        setErr(tErr?.message ?? "找不到此單");
+        setTx(null);
+        return;
+      }
+      const tData = tDataRaw as unknown as Omit<TransferRow, "source_name" | "dest_name">;
+
+      const [{ data: locs }, { data: tis }] = await Promise.all([
+        sb.from("locations").select("id, name").in("id", [tData.source_location, tData.dest_location]),
+        sb
+          .from("transfer_items")
+          .select("id, sku_id, qty_requested, qty_shipped, qty_received")
+          .eq("transfer_id", transferId)
+          .order("id"),
+      ]);
+      if (cancelled) return;
+      const locArr = (locs ?? []) as { id: number; name: string }[];
+      const locMap = new Map<number, string>(locArr.map((l) => [l.id, l.name]));
+      setTx({
+        ...tData,
+        source_name: locMap.get(tData.source_location) ?? null,
+        dest_name: locMap.get(tData.dest_location) ?? null,
+      });
+
+      type ApiItem = {
+        id: number;
+        sku_id: number;
+        qty_requested: number | null;
+        qty_shipped: number | null;
+        qty_received: number | null;
+      };
+      const tiRows = (tis ?? []) as ApiItem[];
+
+      // transfer_items.sku_id 沒設 FK，所以分開撈 skus + products
+      const skuIds = Array.from(new Set(tiRows.map((r) => r.sku_id))).filter((x) => x != null);
+      type SkuJoined = {
+        id: number;
+        sku_code: string;
+        variant_name: string | null;
+        product_id: number | null;
+      };
+      let skuMap = new Map<number, { code: string; variant: string | null; name: string }>();
+      if (skuIds.length > 0) {
+        const { data: skuRows } = await sb
+          .from("skus")
+          .select("id, sku_code, variant_name, product_id")
+          .in("id", skuIds);
+        const skus = (skuRows ?? []) as SkuJoined[];
+        const prodIds = Array.from(new Set(skus.map((s) => s.product_id).filter((x): x is number => x != null)));
+        let prodMap = new Map<number, string>();
+        if (prodIds.length > 0) {
+          const { data: prods } = await sb.from("products").select("id, name").in("id", prodIds);
+          prodMap = new Map(((prods ?? []) as { id: number; name: string }[]).map((p) => [p.id, p.name]));
+        }
+        skuMap = new Map(skus.map((s) => [s.id, {
+          code: s.sku_code,
+          variant: s.variant_name,
+          name: s.product_id != null ? (prodMap.get(s.product_id) ?? "") : "",
+        }]));
+      }
+      if (cancelled) return;
+
+      const rows: Item[] = tiRows.map((r) => {
+        const sku = skuMap.get(r.sku_id);
+        return {
+          id: r.id,
+          sku_id: r.sku_id,
+          qty_requested: Number(r.qty_requested ?? 0),
+          qty_shipped: Number(r.qty_shipped ?? 0),
+          qty_received: r.qty_received == null ? null : Number(r.qty_received),
+          sku_code: sku?.code ?? `#${r.sku_id}`,
+          sku_name: sku?.name ?? "",
+          variant_name: sku?.variant ?? null,
+        };
+      });
+      setItems(rows);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, transferId]);
+
+  const title = tx ? `🚚 ${tx.transfer_no}` : "轉貨單";
+
+  return (
+    <Modal open={open} onClose={onClose} title={title} maxWidth="max-w-3xl">
+      {err && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {err}
+        </div>
+      )}
+      {!tx && !err && <p className="text-sm text-zinc-500">載入中…</p>}
+      {tx && (
+        <div className="space-y-4">
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+            <Field label="類型" value={TYPE_LABEL[tx.transfer_type] ?? tx.transfer_type} />
+            <Field label="狀態" value={STATUS_LABEL[tx.status] ?? tx.status} />
+            <Field label="來源" value={tx.source_name ?? `#${tx.source_location}`} />
+            <Field label="目的" value={tx.dest_name ?? `#${tx.dest_location}`} />
+            <Field label="建立時間" value={new Date(tx.created_at).toLocaleString("zh-TW")} />
+            <Field
+              label="出貨時間"
+              value={tx.shipped_at ? new Date(tx.shipped_at).toLocaleString("zh-TW") : "—"}
+            />
+            <Field
+              label="收貨時間"
+              value={tx.received_at ? new Date(tx.received_at).toLocaleString("zh-TW") : "—"}
+            />
+            <Field label="溫層 / 空運" value={`${tx.shipping_temp ?? "—"}${tx.is_air_transfer ? " · ✈ 空運" : ""}`} />
+            {tx.customer_order_id != null && (
+              <Field label="關聯訂單" value={`#${tx.customer_order_id}`} />
+            )}
+            {tx.notes && <Field label="備註" value={tx.notes} full />}
+          </dl>
+
+          <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
+            <table className="w-full text-sm">
+              <thead className="bg-zinc-50 dark:bg-zinc-900">
+                <tr className="text-left text-xs uppercase tracking-wide text-zinc-500">
+                  <th className="px-3 py-2">SKU</th>
+                  <th className="px-3 py-2">品名 / 規格</th>
+                  <th className="px-3 py-2 text-right">應出</th>
+                  <th className="px-3 py-2 text-right">已出</th>
+                  <th className="px-3 py-2 text-right">已收</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                {items === null ? (
+                  <tr><td colSpan={5} className="p-4 text-center text-zinc-500">載入中…</td></tr>
+                ) : items.length === 0 ? (
+                  <tr><td colSpan={5} className="p-4 text-center text-zinc-500">無明細</td></tr>
+                ) : (
+                  items.map((it) => (
+                    <tr key={it.id}>
+                      <td className="px-3 py-2 font-mono text-xs">{it.sku_code}</td>
+                      <td className="px-3 py-2 text-xs">
+                        {it.sku_name || "—"}
+                        {it.variant_name && <span className="ml-1 text-zinc-500">/ {it.variant_name}</span>}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono">{it.qty_requested}</td>
+                      <td className="px-3 py-2 text-right font-mono">{it.qty_shipped}</td>
+                      <td className="px-3 py-2 text-right font-mono">{it.qty_received ?? "—"}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function Field({ label, value, full = false }: { label: string; value: string; full?: boolean }) {
+  return (
+    <div className={full ? "col-span-2" : ""}>
+      <dt className="text-xs text-zinc-500">{label}</dt>
+      <dd className="text-sm text-zinc-900 dark:text-zinc-100">{value}</dd>
+    </div>
+  );
+}

--- a/supabase/migrations/20260514000011_rpc_bulk_update_product_status.sql
+++ b/supabase/migrations/20260514000011_rpc_bulk_update_product_status.sql
@@ -1,0 +1,65 @@
+-- ============================================================
+-- 2026-05-14: rpc_bulk_update_product_status
+-- ------------------------------------------------------------
+-- 批次切換商品狀態（上架 / 下架 / 草稿 / 停產）。
+-- 走 SECURITY DEFINER：admin JWT 沒 role claim 也可改；同 tenant 才允許；
+-- 每筆都進 product_audit_log（action = 'status_change'）。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_bulk_update_product_status(
+  p_ids    BIGINT[],
+  p_status TEXT,
+  p_reason TEXT DEFAULT NULL
+) RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant   UUID := public._current_tenant_id();
+  v_user     UUID := auth.uid();
+  v_id       BIGINT;
+  v_before   JSONB;
+  v_after    JSONB;
+  v_count    INTEGER := 0;
+BEGIN
+  IF p_ids IS NULL OR array_length(p_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+  IF p_status NOT IN ('draft','active','inactive','discontinued') THEN
+    RAISE EXCEPTION 'invalid product status: %', p_status;
+  END IF;
+
+  FOREACH v_id IN ARRAY p_ids LOOP
+    SELECT to_jsonb(p) INTO v_before FROM products p
+      WHERE p.id = v_id AND p.tenant_id = v_tenant;
+    IF v_before IS NULL THEN
+      -- 跨 tenant 或不存在 → 跳過（不 raise，讓批次能完成其他項）
+      CONTINUE;
+    END IF;
+    IF v_before->>'status' = p_status THEN
+      -- 已是目標狀態 → 不寫 audit、不更新
+      CONTINUE;
+    END IF;
+
+    UPDATE products
+       SET status = p_status,
+           updated_by = v_user,
+           updated_at = NOW()
+     WHERE id = v_id AND tenant_id = v_tenant;
+
+    SELECT to_jsonb(p) INTO v_after FROM products p WHERE p.id = v_id;
+    PERFORM public._log_product_audit(
+      v_tenant, 'product', v_id, 'status_change',
+      v_before, v_after, p_reason
+    );
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_bulk_update_product_status(BIGINT[], TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_bulk_update_product_status(BIGINT[], TEXT, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_bulk_update_product_status(BIGINT[], TEXT, TEXT) IS
+  '批次切換 products.status；同 tenant 才生效；每筆寫 product_audit_log status_change。回傳實際變更筆數。';

--- a/supabase/migrations/20260514000012_cleanup_sku_on_deactivate_and_bulk_campaign_status.sql
+++ b/supabase/migrations/20260514000012_cleanup_sku_on_deactivate_and_bulk_campaign_status.sql
@@ -1,0 +1,134 @@
+-- ============================================================
+-- 2026-05-14: 兩件事
+--   A. SKU 從 active → 非 active (inactive/discontinued) 時，
+--      自動清掉所有 status='draft' 的 campaign_items（已下架的 SKU
+--      不該出現在草稿開團中）。open / closed 以後不動，避免破壞已產生
+--      的訂單/採購。
+--   B. rpc_bulk_set_campaign_status：列表頁批次切換開團狀態
+--      （draft → open / open → closed），維持既有 trigger
+--      (`_lock_campaign_prices_on_open`) 行為。
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- A. _cleanup_sku_from_draft_campaigns trigger
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._cleanup_sku_from_draft_campaigns()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- 只在 active → 非 active 那一刻動作
+  IF OLD.status = 'active' AND NEW.status IS DISTINCT FROM 'active' THEN
+    DELETE FROM campaign_items ci
+     USING group_buy_campaigns gbc
+     WHERE ci.campaign_id = gbc.id
+       AND ci.sku_id      = NEW.id
+       AND gbc.tenant_id  = NEW.tenant_id
+       AND gbc.status     = 'draft';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_skus_cleanup_draft_campaigns ON skus;
+CREATE TRIGGER trg_skus_cleanup_draft_campaigns
+  AFTER UPDATE OF status ON skus
+  FOR EACH ROW
+  EXECUTE FUNCTION public._cleanup_sku_from_draft_campaigns();
+
+COMMENT ON FUNCTION public._cleanup_sku_from_draft_campaigns() IS
+  'SKU active→非 active 時，從同 tenant 的 draft 開團移除對應 campaign_items。';
+
+-- ----------------------------------------------------------------
+-- A.1 Backfill：現存「draft 開團 + 已下架 SKU」也清乾淨
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  v_deleted INTEGER;
+BEGIN
+  WITH del AS (
+    DELETE FROM campaign_items ci
+     USING group_buy_campaigns gbc, skus s
+     WHERE ci.campaign_id = gbc.id
+       AND ci.sku_id      = s.id
+       AND gbc.status     = 'draft'
+       AND s.status       <> 'active'
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO v_deleted FROM del;
+  RAISE NOTICE 'Backfill: removed % campaign_items where draft campaign × non-active sku', v_deleted;
+END $$;
+
+-- ----------------------------------------------------------------
+-- B. rpc_bulk_set_campaign_status — 列表頁批次操作用
+--    走 UPDATE 觸發 `_lock_campaign_prices_on_open`；同 tenant 限制；
+--    驗證合法狀態轉換：draft↔open / open→closed。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_bulk_set_campaign_status(
+  p_ids    BIGINT[],
+  p_status TEXT
+) RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_id     BIGINT;
+  v_cur    TEXT;
+  v_count  INTEGER := 0;
+BEGIN
+  IF p_ids IS NULL OR array_length(p_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+  IF p_status NOT IN ('draft','open','closed','cancelled') THEN
+    RAISE EXCEPTION 'invalid bulk target status: %', p_status;
+  END IF;
+
+  FOREACH v_id IN ARRAY p_ids LOOP
+    SELECT status INTO v_cur FROM group_buy_campaigns
+      WHERE id = v_id AND tenant_id = v_tenant;
+    IF v_cur IS NULL THEN
+      CONTINUE; -- 跨 tenant / 不存在
+    END IF;
+    IF v_cur = p_status THEN
+      CONTINUE; -- 已是目標
+    END IF;
+
+    -- 合法轉換：
+    --   draft → open / cancelled
+    --   open  → closed / cancelled
+    --   closed → cancelled
+    IF NOT (
+         (v_cur = 'draft'  AND p_status IN ('open','cancelled'))
+      OR (v_cur = 'open'   AND p_status IN ('closed','cancelled'))
+      OR (v_cur = 'closed' AND p_status = 'cancelled')
+    ) THEN
+      CONTINUE; -- 跳過不合法的轉換
+    END IF;
+
+    -- 額外保護：draft→open 前要有 campaign_items
+    IF v_cur = 'draft' AND p_status = 'open' THEN
+      PERFORM 1 FROM campaign_items WHERE campaign_id = v_id LIMIT 1;
+      IF NOT FOUND THEN
+        CONTINUE;
+      END IF;
+    END IF;
+
+    UPDATE group_buy_campaigns
+       SET status     = p_status,
+           updated_by = auth.uid(),
+           updated_at = NOW()
+     WHERE id = v_id AND tenant_id = v_tenant;
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_bulk_set_campaign_status(BIGINT[], TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_bulk_set_campaign_status(BIGINT[], TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_bulk_set_campaign_status(BIGINT[], TEXT) IS
+  '批次切換開團狀態（draft/open/closed/cancelled）。同 tenant、合法轉換、有 items 才放行。回傳實際變更筆數。';

--- a/supabase/migrations/20260614000040_strict_order_pickup_ready.sql
+++ b/supabase/migrations/20260614000040_strict_order_pickup_ready.sql
@@ -1,0 +1,98 @@
+-- ============================================================
+-- 2026-06-14: is_order_pickup_ready 路徑 B 改 strict 版
+--
+-- 舊版本 bug：路徑 B 只檢查「campaign+store 有任一個 wave received」
+-- 就回 true，沒檢查訂單需要的 SKU 是否在那個 received 的 wave 中。
+-- 結果：wave 部分收貨 → 整批訂單被推到 'ready' 並發取貨通知，
+-- 顧客來店才發現某些 SKU 沒實際入庫。
+--
+-- 新邏輯：訂單每個 active item (status IN pending/reserved/ready) 的 SKU
+--   都必須至少有一筆 picking_wave_items
+--   (campaign+store+sku 對齊 AND generated_transfer received/closed)。
+--
+-- 額外動作：
+--   1. Backfill 把 status='ready' 但 strict 版回 false 的訂單退回 'shipping'，
+--      並清 ready_at（last_notify_pickup_at 是 audit 不清）。
+--   2. partially_completed 已部分取貨、狀態不可逆，不動。
+--   3. rpc_record_pickup 不用改，它自動就用 is_order_pickup_ready（已是 CREATE OR REPLACE）。
+--
+-- Rollback: CREATE OR REPLACE 回 20260512000008 的版本。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.is_order_pickup_ready(p_order_id BIGINT)
+RETURNS BOOLEAN
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  SELECT EXISTS (
+    SELECT 1
+      FROM customer_orders co
+     WHERE co.id = p_order_id
+       AND co.status NOT IN ('completed','expired','cancelled','transferred_out')
+       AND (
+         -- 路徑 A：互助訂單 — transfer FK 直連 order
+         EXISTS (
+           SELECT 1 FROM transfers t
+            WHERE t.customer_order_id = co.id
+              AND t.tenant_id = co.tenant_id
+              AND t.status IN ('received','closed')
+         )
+         OR
+         -- 路徑 B（strict）：訂單每個 active item 的 SKU 都要有
+         --   picking_wave_items (campaign+store+sku 對齊) 已 received
+         (
+           co.campaign_id IS NOT NULL
+           AND EXISTS (
+             SELECT 1 FROM customer_order_items coi
+              WHERE coi.order_id = co.id
+                AND coi.status IN ('pending','reserved','ready')
+           )
+           AND NOT EXISTS (
+             SELECT 1 FROM customer_order_items coi
+              WHERE coi.order_id = co.id
+                AND coi.status IN ('pending','reserved','ready')
+                AND NOT EXISTS (
+                  SELECT 1
+                    FROM picking_wave_items pwi
+                    JOIN transfers t ON t.id = pwi.generated_transfer_id
+                   WHERE pwi.tenant_id   = co.tenant_id
+                     AND pwi.campaign_id = co.campaign_id
+                     AND pwi.store_id    = co.pickup_store_id
+                     AND pwi.sku_id      = coi.sku_id
+                     AND t.status IN ('received','closed')
+                )
+           )
+         )
+       )
+  );
+$$;
+
+COMMENT ON FUNCTION public.is_order_pickup_ready IS
+  '訂單是否可取貨：strict 版 — 訂單每個 active item 的 SKU 都要有 picking_wave_items 對應 transfer received。';
+
+-- ----------------------------------------------------------------
+-- Backfill：誤判 ready 的訂單退回 shipping
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  v_fixed INTEGER;
+  v_uid   UUID;
+BEGIN
+  SELECT id INTO v_uid FROM auth.users ORDER BY created_at LIMIT 1;
+
+  WITH bad AS (
+    SELECT co.id
+      FROM customer_orders co
+     WHERE co.status = 'ready'
+       AND NOT public.is_order_pickup_ready(co.id)
+  ),
+  upd AS (
+    UPDATE customer_orders co
+       SET status     = 'shipping',
+           ready_at   = NULL,
+           updated_by = v_uid,
+           updated_at = NOW()
+     WHERE co.id IN (SELECT id FROM bad)
+    RETURNING co.id
+  )
+  SELECT COUNT(*) INTO v_fixed FROM upd;
+  RAISE NOTICE 'Backfill: reverted % orders from ready→shipping (mis-flagged by old loose pickup_ready logic)', v_fixed;
+END $$;

--- a/supabase/migrations/20260614000041_diag_stock_movements_balances.sql
+++ b/supabase/migrations/20260614000041_diag_stock_movements_balances.sql
@@ -1,0 +1,77 @@
+-- ============================================================
+-- 診斷用 migration（一次性、不改任何資料）：
+-- 1. 確認 stock_movements 14952/14953 存在嗎？實際 location/sku/quantity？
+-- 2. 對 transfer 965 全部 transfer_items 的 in_movement_id 抓 movement
+-- 3. 對 location=7 + sku in (729,735,736) 看 stock_balances
+-- 4. 對 location=7 看所有 stock_movements 統計
+-- 結果走 RAISE NOTICE。
+-- ============================================================
+
+DO $$
+DECLARE
+  r RECORD;
+  v_count INTEGER;
+BEGIN
+  RAISE NOTICE '=== A. stock_movements 14952/14953 ===';
+  FOR r IN
+    SELECT id, location_id, sku_id, movement_type, quantity, source_doc_type, source_doc_id, created_at
+      FROM stock_movements
+     WHERE id IN (14952, 14953)
+     ORDER BY id
+  LOOP
+    RAISE NOTICE '  mov %: loc=% sku=% type=% qty=% src=%:% at=%',
+      r.id, r.location_id, r.sku_id, r.movement_type, r.quantity,
+      r.source_doc_type, r.source_doc_id, r.created_at;
+  END LOOP;
+
+  RAISE NOTICE '=== B. transfer 965 transfer_items + in_movement ===';
+  FOR r IN
+    SELECT ti.id AS item_id, ti.sku_id, ti.qty_shipped, ti.qty_received,
+           ti.in_movement_id,
+           sm.id AS sm_id, sm.location_id AS sm_loc, sm.quantity AS sm_qty, sm.movement_type AS sm_type
+      FROM transfer_items ti
+      LEFT JOIN stock_movements sm ON sm.id = ti.in_movement_id
+     WHERE ti.transfer_id = 965
+     ORDER BY ti.id
+  LOOP
+    RAISE NOTICE '  item % sku=% ship=% recv=% in_mov_id=% (sm_id=% loc=% qty=% type=%)',
+      r.item_id, r.sku_id, r.qty_shipped, r.qty_received, r.in_movement_id,
+      r.sm_id, r.sm_loc, r.sm_qty, r.sm_type;
+  END LOOP;
+
+  RAISE NOTICE '=== C. stock_balances loc=7 sku in (729,735,736) ===';
+  v_count := 0;
+  FOR r IN
+    SELECT sku_id, on_hand, reserved, in_transit_in, last_movement_at
+      FROM stock_balances
+     WHERE location_id = 7 AND sku_id IN (729, 735, 736)
+     ORDER BY sku_id
+  LOOP
+    RAISE NOTICE '  sku=% on_hand=% reserved=% in_transit_in=% last_mov=%',
+      r.sku_id, r.on_hand, r.reserved, r.in_transit_in, r.last_movement_at;
+    v_count := v_count + 1;
+  END LOOP;
+  IF v_count = 0 THEN
+    RAISE NOTICE '  (NONE) — stock_balances 對 location 7 + 這些 sku 0 筆';
+  END IF;
+
+  RAISE NOTICE '=== D. stock_movements loc=7 sku in (729,735,736) 共幾筆 ===';
+  SELECT COUNT(*) INTO v_count FROM stock_movements
+   WHERE location_id = 7 AND sku_id IN (729, 735, 736);
+  RAISE NOTICE '  count = %', v_count;
+
+  RAISE NOTICE '=== E. stock_balances loc=7 全部統計 ===';
+  SELECT COUNT(*) INTO v_count FROM stock_balances WHERE location_id = 7;
+  RAISE NOTICE '  rows = %', v_count;
+
+  RAISE NOTICE '=== F. stock_movements loc=7 全部統計 + type 分佈 ===';
+  FOR r IN
+    SELECT movement_type, COUNT(*) AS c, SUM(quantity) AS sum_qty
+      FROM stock_movements
+     WHERE location_id = 7
+     GROUP BY movement_type
+     ORDER BY movement_type
+  LOOP
+    RAISE NOTICE '  type=% count=% sum_qty=%', r.movement_type, r.c, r.sum_qty;
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260614000042_stock_admin_read_rls.sql
+++ b/supabase/migrations/20260614000042_stock_admin_read_rls.sql
@@ -1,0 +1,55 @@
+-- ============================================================
+-- 補 stock_balances / stock_movements 的 SELECT policy
+--
+-- 既有狀況：
+--   - stock_balances：只有 owner/purchaser/warehouse/reporter (hq_full_read)
+--     + store_manager/clerk own location (store_read_own)
+--     → admin role 看不到（policy 沒包含）→ 後台庫存頁面讀回 0 rows
+--   - stock_movements：RLS enabled 但完全沒 policy → deny all SELECT
+--     → admin 後台所有庫存異動報表都壞
+--
+-- 對照：20260430160000_picking_auth_read_rls 已把 transfers/transfer_items/
+-- picking_waves/picking_wave_items/goods_receipts/goods_receipt_items 開給
+-- authenticated read。stock_balances 和 stock_movements 是這層補丁的遺漏。
+--
+-- 策略：
+--   1. stock_balances：新增 admin role policy（看本 tenant 全部）；既有
+--      hq_full_read / store_read_own 保留
+--   2. stock_movements：新增與 stock_balances 對等的 3 條 policy
+--      (hq_full_read 包含 admin / store_read_own / 預留)
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. stock_balances admin policy（不動既有 policy，避免影響其他角色）
+-- ----------------------------------------------------------------
+CREATE POLICY hq_admin_read ON stock_balances
+  FOR SELECT TO authenticated USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', auth.jwt() ->> 'role', '')
+        IN ('admin','hq_manager')
+  );
+
+-- ----------------------------------------------------------------
+-- 2. stock_movements policy (HQ-side + admin + store own)
+-- ----------------------------------------------------------------
+CREATE POLICY hq_full_read ON stock_movements
+  FOR SELECT TO authenticated USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', auth.jwt() ->> 'role', '')
+        IN ('owner','admin','hq_manager','purchaser','warehouse','reporter')
+  );
+
+CREATE POLICY store_read_own ON stock_movements
+  FOR SELECT TO authenticated USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', auth.jwt() ->> 'role', '')
+        IN ('store_manager','store_staff','clerk')
+    AND location_id = NULLIF(auth.jwt() ->> 'location_id', '')::bigint
+  );
+
+COMMENT ON POLICY hq_admin_read ON stock_balances IS
+  'admin / hq_manager 角色讀本 tenant 全部庫存結存。';
+COMMENT ON POLICY hq_full_read ON stock_movements IS
+  'HQ-side (owner/admin/hq_manager/purchaser/warehouse/reporter) 讀本 tenant 全部庫存異動。';
+COMMENT ON POLICY store_read_own ON stock_movements IS
+  '門市角色只讀自己 location 的庫存異動。';

--- a/supabase/migrations/20260614000050_fix_mark_orders_shipping_use_campaign_id.sql
+++ b/supabase/migrations/20260614000050_fix_mark_orders_shipping_use_campaign_id.sql
@@ -1,0 +1,117 @@
+-- ============================================================
+-- 2026-06-14: 修 rpc_mark_orders_shipping_for_wave —
+--   舊版用 `DATE(campaign.end_at @ Taipei) = wave.wave_date` 當 join
+--   條件，但 wave_date 是排撿貨的日期、不一定等於 campaign 結單日。
+--   結果：campaign.end_at = 2026-05-17 但 wave.wave_date = 2026-05-16
+--   → join 不上 → 訂單留在 'pending'。
+--
+--   後續 rpc_receive_transfer 邏輯 C 只推 status='shipping' 的訂單到
+--   'ready'，所以這些訂單永遠卡 pending → 顧客取不到貨、退貨流程
+--   也找不到（modal 過濾 returnable 不含 pending）。
+--
+--   新邏輯：picking_wave_items.campaign_id 已經是真實對應，直接用
+--   它對 customer_orders.campaign_id + store_id 即可，不需經 wave_date。
+--
+--   Backfill：
+--     1. 對所有 wave (status IN shipped/received) 重跑 mark_shipping
+--     2. 對所有 status='shipping' 且 strict is_order_pickup_ready=true
+--        的訂單，再推到 'ready'（補 rpc_receive_transfer 漏跑的部分）
+-- ============================================================
+
+DROP FUNCTION IF EXISTS rpc_mark_orders_shipping_for_wave(BIGINT, UUID);
+
+CREATE OR REPLACE FUNCTION rpc_mark_orders_shipping_for_wave(
+  p_wave_id  BIGINT,
+  p_operator UUID
+) RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant_id UUID;
+  v_updated   INTEGER;
+BEGIN
+  SELECT tenant_id INTO v_tenant_id FROM picking_waves WHERE id = p_wave_id;
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'wave % not found', p_wave_id;
+  END IF;
+
+  WITH affected AS (
+    UPDATE customer_orders co
+       SET status     = 'shipping',
+           updated_at = NOW(),
+           updated_by = p_operator
+     WHERE co.tenant_id = v_tenant_id
+       AND co.status IN ('pending','confirmed','reserved')
+       AND EXISTS (
+         SELECT 1 FROM picking_wave_items pwi
+          WHERE pwi.wave_id    = p_wave_id
+            AND pwi.picked_qty > 0
+            AND pwi.campaign_id  = co.campaign_id
+            AND pwi.store_id     = co.pickup_store_id
+       )
+    RETURNING co.id
+  )
+  SELECT COUNT(*) INTO v_updated FROM affected;
+
+  RETURN v_updated;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_mark_orders_shipping_for_wave(BIGINT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION rpc_mark_orders_shipping_for_wave IS
+  '把 wave 涉及的訂單（同 campaign + 同 store）從 pending/confirmed/reserved 推到 shipping。改用 picking_wave_items.campaign_id 直接對齊，不再依賴 wave_date = end_at 日。';
+
+-- ----------------------------------------------------------------
+-- Backfill A：對 status IN ('picked','shipped','received') 的 wave 重跑 mark_shipping
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  r RECORD;
+  v_uid UUID;
+  v_total INTEGER := 0;
+  v_one   INTEGER;
+BEGIN
+  SELECT id INTO v_uid FROM auth.users ORDER BY created_at LIMIT 1;
+
+  FOR r IN
+    SELECT id FROM picking_waves
+     WHERE status IN ('picked','shipped','received')
+     ORDER BY id
+  LOOP
+    v_one := rpc_mark_orders_shipping_for_wave(r.id, v_uid);
+    v_total := v_total + COALESCE(v_one, 0);
+  END LOOP;
+
+  RAISE NOTICE 'Backfill A: pushed % orders from pending/confirmed/reserved → shipping', v_total;
+END $$;
+
+-- ----------------------------------------------------------------
+-- Backfill B：status='shipping' 且 strict pickup_ready=true → 推到 'ready'
+--   （補 rpc_receive_transfer 漏跑的 status='shipping' → 'ready' 那段）
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  v_uid   UUID;
+  v_fixed INTEGER;
+BEGIN
+  SELECT id INTO v_uid FROM auth.users ORDER BY created_at LIMIT 1;
+
+  WITH bad AS (
+    SELECT co.id
+      FROM customer_orders co
+     WHERE co.status = 'shipping'
+       AND public.is_order_pickup_ready(co.id)
+  ),
+  upd AS (
+    UPDATE customer_orders co
+       SET status     = 'ready',
+           ready_at   = NOW(),
+           updated_by = v_uid,
+           updated_at = NOW()
+     WHERE co.id IN (SELECT id FROM bad)
+    RETURNING co.id
+  )
+  SELECT COUNT(*) INTO v_fixed FROM upd;
+
+  RAISE NOTICE 'Backfill B: pushed % orders from shipping → ready (strict pickup_ready=true)', v_fixed;
+END $$;


### PR DESCRIPTION
## Summary

UI 大批改進 + DB 流程修補：
- **UX**：總倉收件匣 4 tab row 顯示品項摘要 / row 點跳 detail（新增 Transfer + Restock detail modal）、退訂單 popup combobox 搜尋、退訂單批次「確認入倉/取消」、開團/採購單一系列搜尋+多選+inline validation、撿貨清單列印頁
- **後端**：strict `is_order_pickup_ready` 解掉 wave 部分收貨就推 ready 的誤判、`rpc_mark_orders_shipping_for_wave` 改用 picking_wave_items.campaign_id 對齊（不再依賴 wave_date = end_at）、stock RLS 補 admin、退訂單 SKU 自動清理 trigger、批次切商品/開團狀態 RPC

## UI 改動

- 內部調撥 / 補貨申請 / 轉貨單 row 點跳 detail（新增 `TransferDetailModal` + `RestockDetailModal`）
- 總倉收件匣 4 個 tab 加「📦 品項摘要」
- 退訂單 modal：訂單下拉改 combobox（人名/訂單號/商品名）、option 帶品項
- 退訂單批次按鈕：全選退訂單時顯示「確認入倉 / 取消」（取代「配送 / 刪除」）
- 派貨工作台：新增「📄 列印撿貨清單」(SKU × 店家 + 已撿量、A4 橫向)，放在「建立撿貨單」旁
- 商品列表批次「上架 / 下架」+ 商品 Form 儲存溫層上移
- 開團列表多選批次「開團 / 結單 / 取消」+ 開團期間 range UI
- 採購單建單 modal 加搜尋 + 編輯頁拿掉「偵測到 X 個同日結單」banner + 成本<分店價<售價 inline 紅框 + 送審攔截
- 補貨申請列表加「品項」欄

## Migration

- `20260514000011` rpc_bulk_update_product_status：批次切商品狀態
- `20260514000012` _cleanup_sku_from_draft_campaigns trigger + rpc_bulk_set_campaign_status
- `20260614000040` is_order_pickup_ready strict 版 + backfill 退誤判 ready 訂單
- `20260614000041` 一次性 NOTICE 診斷（確認 stock 同步正常、RLS 假象）
- `20260614000042` stock_balances / stock_movements 補 admin 讀 policy
- `20260614000050` rpc_mark_orders_shipping_for_wave 用 campaign_id 對齊 + backfill 推進孤兒訂單

## Test plan

- [ ] 總倉收件匣 4 tab row 點擊 → 對應 detail modal 開啟、品項摘要正確
- [ ] 退訂單 modal 搜「人名 / 訂單號 / 商品名」過濾正常
- [ ] 撿貨工作台「📄 列印撿貨清單」→ SKU × 店家矩陣 + 各店「撿 N」標籤顯示
- [ ] 全選退訂單 → 工具列顯示「確認入倉 / 取消」、實際呼叫 rpc_reject_transfer 沒 break
- [ ] 採購單建單 modal 搜尋過濾 + 編輯頁 banner 消失 + 成本>=分店價 → 紅框 + 擋送審
- [ ] 跑 wave 完整鏈路（pick → ship → receive）後對應訂單從 pending → shipping → ready
- [ ] 商品/開團列表批次操作（上架/下架、開團/結單）正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)