### PR TITLE
feat(transfers/orders): 自由轉貨 / 訂單 KPI / sentinel 過濾一波

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -252,7 +252,9 @@ export default function CampaignsListPage() {
         let q = getSupabase()
           .from("group_buy_campaigns")
           .select("id, campaign_no, name, status, close_type, start_at, end_at, pickup_deadline, updated_at", { count: "exact" })
-          .order("updated_at", { ascending: false })
+          .neq("campaign_no", "__INTERNAL_RESTOCK__")
+          .order("start_at", { ascending: false, nullsFirst: false })
+          .order("id", { ascending: false })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
         if (query.trim()) {
           const safe = query.replace(/[%,()]/g, " ").trim();
@@ -332,6 +334,7 @@ export default function CampaignsListPage() {
       const { data, error } = await getSupabase()
         .from("group_buy_campaigns")
         .select("id, campaign_no, name, status, close_type, start_at, display_order")
+        .neq("campaign_no", "__INTERNAL_RESTOCK__")
         .gte("start_at", from.toISOString())
         .lt("start_at", to.toISOString())
         .order("start_at", { ascending: true })

--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -2140,16 +2140,23 @@ function MailRow({
   } as const)[row.source];
 
   // source chip:transfer 依 transfer_type 細分,其他用 SOURCE_LABEL/COLOR
+  // 註：互助訂單派貨實際走 hq_to_store + store_to_store（transfer_no 前綴 AT-），
+  // 不是 aid_handoff。aid_handoff transfer_type 目前沒任何 RPC 產生，故不放 mapping。
   let sourceCls = SOURCE_COLOR[row.source];
   let sourceText: string = SOURCE_LABEL[row.source];
   let sourceTitle: string | undefined;
   if (row.source === "transfer") {
     const t = row.raw;
     const isOrderReturn = isOrderReturnTransfer(t.notes);
+    const isAidTransfer = t.transfer_no.startsWith("AT-");
     if (isOrderReturn) {
       sourceCls = "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300";
       sourceText = "🔁 退訂單";
       sourceTitle = "由客戶退訂單建立";
+    } else if (isAidTransfer) {
+      sourceCls = "bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-950 dark:text-fuchsia-300";
+      sourceText = "🤝 互助派貨";
+      sourceTitle = "互助訂單派貨（rpc_ship_aid_order 產生）";
     } else {
       switch (t.transfer_type) {
         case "store_to_store":
@@ -2166,11 +2173,6 @@ function MailRow({
           sourceCls = "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300";
           sourceText = "🚚 總倉派貨";
           sourceTitle = "總倉派貨到分店（撿貨單 wave）";
-          break;
-        case "aid_handoff":
-          sourceCls = "bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-950 dark:text-fuchsia-300";
-          sourceText = "🤝 互助轉移";
-          sourceTitle = "互助訂單轉移";
           break;
       }
     }

--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -2094,9 +2094,7 @@ function MailRow({
   onToggleSelect: () => void;
 }) {
   const isPending = row.stage === "pending";
-  const sourceCls = SOURCE_COLOR[row.source];
   const stageCls = STAGE_COLOR[row.stage];
-  const sourceText = SOURCE_LABEL[row.source];
   const stageText = STAGE_LABEL[row.stage];
   const accent = ({
     restock: "border-l-indigo-500",
@@ -2105,6 +2103,43 @@ function MailRow({
     shortage: "border-l-rose-500",
     picking: "border-l-emerald-500",
   } as const)[row.source];
+
+  // source chip:transfer 依 transfer_type 細分,其他用 SOURCE_LABEL/COLOR
+  let sourceCls = SOURCE_COLOR[row.source];
+  let sourceText: string = SOURCE_LABEL[row.source];
+  let sourceTitle: string | undefined;
+  if (row.source === "transfer") {
+    const t = row.raw;
+    const isOrderReturn = isOrderReturnTransfer(t.notes);
+    if (isOrderReturn) {
+      sourceCls = "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300";
+      sourceText = "🔁 退訂單";
+      sourceTitle = "由客戶退訂單建立";
+    } else {
+      switch (t.transfer_type) {
+        case "store_to_store":
+          sourceCls = "bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-300";
+          sourceText = "🔄 自由轉貨";
+          sourceTitle = "店與店之間自由轉貨（虛擬 SKU + 備註）";
+          break;
+        case "return_to_hq":
+          sourceCls = "bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-300";
+          sourceText = "↩ 退貨回總倉";
+          sourceTitle = "店端發起退貨回總倉";
+          break;
+        case "hq_to_store":
+          sourceCls = "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300";
+          sourceText = "🚚 總倉派貨";
+          sourceTitle = "總倉派貨到分店（撿貨單 wave）";
+          break;
+        case "aid_handoff":
+          sourceCls = "bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-950 dark:text-fuchsia-300";
+          sourceText = "🤝 互助轉移";
+          sourceTitle = "互助訂單轉移";
+          break;
+      }
+    }
+  }
 
   let idText: string;
   let title: React.ReactNode;
@@ -2154,55 +2189,9 @@ function MailRow({
     const t = row.raw;
     const isOrderReturn = isOrderReturnTransfer(t.notes);
     idText = t.transfer_no;
-    // 類別 chip：退訂單 / 自由轉貨 / 退貨回總倉 / 總倉派貨 / 互助
-    const kindChip = (() => {
-      if (isOrderReturn) {
-        return {
-          cls: "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300",
-          label: "🔁 退訂單",
-          title: "由客戶退訂單建立",
-        };
-      }
-      switch (t.transfer_type) {
-        case "store_to_store":
-          return {
-            cls: "bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-300",
-            label: "🔄 自由轉貨",
-            title: "店與店之間自由轉貨（虛擬 SKU + 備註）",
-          };
-        case "return_to_hq":
-          return {
-            cls: "bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-300",
-            label: "↩ 退貨回總倉",
-            title: "店端發起退貨回總倉",
-          };
-        case "hq_to_store":
-          return {
-            cls: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
-            label: "🚚 總倉派貨",
-            title: "總倉派貨到分店（撿貨單 wave）",
-          };
-        case "aid_handoff":
-          return {
-            cls: "bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-950 dark:text-fuchsia-300",
-            label: "🤝 互助轉移",
-            title: "互助訂單轉移",
-          };
-        default:
-          return null;
-      }
-    })();
     title = (
       <>
         {t.source_name} <span className="text-zinc-400 mx-1">→</span> {t.dest_name}
-        {kindChip && (
-          <span
-            className={`ml-2 inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${kindChip.cls}`}
-            title={kindChip.title}
-          >
-            {kindChip.label}
-          </span>
-        )}
       </>
     );
     subtitle = (
@@ -2382,8 +2371,11 @@ function MailRow({
       </div>
 
       {/* source chip + 未讀 dot (sm+) */}
-      <div className="hidden sm:block w-24 shrink-0 pt-0.5">
-        <span className={`inline-flex w-fit items-center gap-1 rounded px-2 py-0.5 text-[10px] font-medium ${sourceCls}`}>
+      <div className="hidden sm:block w-28 shrink-0 pt-0.5">
+        <span
+          className={`inline-flex w-fit items-center gap-1 rounded px-2 py-0.5 text-[10px] font-medium ${sourceCls}`}
+          title={sourceTitle}
+        >
           {isPending && <span className="h-1.5 w-1.5 rounded-full bg-current opacity-80" aria-hidden />}
           {sourceText}
         </span>

--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -392,6 +392,7 @@ async function fetchTransferRows(
   page: number,
   dateFrom: string,
   dateTo: string,
+  transferKind: "all" | "store_to_store" | "return_to_hq" | "hq_to_store" | "aid_handoff" = "all",
 ): Promise<{ rows: Row[]; total: number }> {
   let q = sb
     .from("transfers")
@@ -411,6 +412,7 @@ async function fetchTransferRows(
   } else if (stage) {
     q = q.in("status", TRANSFER_STATUS_BY_STAGE[stage]);
   }
+  if (transferKind !== "all") q = q.eq("transfer_type", transferKind);
   if (dateFrom) q = q.gte("created_at", `${dateFrom}T00:00:00`);
   if (dateTo) q = q.lte("created_at", `${dateTo}T23:59:59.999`);
   const start = (page - 1) * PAGE_SIZE;
@@ -940,6 +942,9 @@ function HqInboxContent() {
   // Aid 專屬篩選 (source=aid 時才顯示)
   const [aidModeFilter, setAidModeFilter] = useState<"all" | "air" | "via_warehouse">("all");
   const [aidStatusFilter, setAidStatusFilter] = useState<string>("");
+  // Transfer 專屬篩選 (source=transfer 時才顯示)
+  type TransferKind = "all" | "store_to_store" | "return_to_hq" | "hq_to_store" | "aid_handoff";
+  const [transferKindFilter, setTransferKindFilter] = useState<TransferKind>("all");
   const [page, setPage] = useState(1);
 
   // server-side counts: per source × per stage(badge / tab 用)
@@ -1072,7 +1077,7 @@ function HqInboxContent() {
           if (sourceFilter === "restock") {
             res = await fetchRestockRows(sb, stageArg, page, dateFrom, dateTo);
           } else if (sourceFilter === "transfer") {
-            res = await fetchTransferRows(sb, stageArg, page, dateFrom, dateTo);
+            res = await fetchTransferRows(sb, stageArg, page, dateFrom, dateTo, transferKindFilter);
           } else if (sourceFilter === "aid") {
             res = await fetchAidRows(sb, stageArg, page, dateFrom, dateTo, aidModeFilter, aidStatusFilter);
           } else if (sourceFilter === "picking") {
@@ -1097,7 +1102,7 @@ function HqInboxContent() {
     return () => {
       cancelled = true;
     };
-  }, [sourceFilter, stage, page, dateFrom, dateTo, aidModeFilter, aidStatusFilter, reloadTick]);
+  }, [sourceFilter, stage, page, dateFrom, dateTo, aidModeFilter, aidStatusFilter, transferKindFilter, reloadTick]);
 
   // stage tab counts:依當前 sourceFilter,從 cached counts 算出
   const stageCounts = useMemo(() => {
@@ -1164,7 +1169,7 @@ function HqInboxContent() {
   // 任何 server 端篩選變動 → 回到第 1 頁(避免 page 超出範圍)
   useEffect(() => {
     setPage(1);
-  }, [stage, sourceFilter, aidModeFilter, aidStatusFilter, dateFrom, dateTo]);
+  }, [stage, sourceFilter, aidModeFilter, aidStatusFilter, transferKindFilter, dateFrom, dateTo]);
 
   // 計算 group key for each row
   function getGroupKey(r: Row): { key: string; label: string } {
@@ -1729,6 +1734,37 @@ function HqInboxContent() {
               清除
             </SpinButton>
           )}
+        </div>
+      )}
+
+      {/* Transfer 專屬篩選 — 選 轉貨單 才出現 */}
+      {sourceFilter === "transfer" && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs dark:border-blue-900 dark:bg-blue-950/30">
+          <span className="font-semibold text-blue-700 dark:text-blue-300">類型:</span>
+          {(
+            [
+              { v: "all", label: "全部" },
+              { v: "hq_to_store", label: "🚚 總倉派貨" },
+              { v: "store_to_store", label: "🔄 自由轉貨" },
+              { v: "return_to_hq", label: "↩ 退貨回總倉" },
+              { v: "aid_handoff", label: "🤝 互助轉移" },
+            ] as { v: typeof transferKindFilter; label: string }[]
+          ).map((opt) => {
+            const active = transferKindFilter === opt.v;
+            return (
+              <SpinButton
+                key={opt.v}
+                onClick={() => setTransferKindFilter(opt.v)}
+                className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
+                  active
+                    ? "border-blue-700 bg-blue-700 text-white"
+                    : "border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                }`}
+              >
+                {opt.label}
+              </SpinButton>
+            );
+          })}
         </div>
       )}
 

--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -1747,7 +1747,6 @@ function HqInboxContent() {
               { v: "hq_to_store", label: "🚚 總倉派貨" },
               { v: "store_to_store", label: "🔄 自由轉貨" },
               { v: "return_to_hq", label: "↩ 退貨回總倉" },
-              { v: "aid_handoff", label: "🤝 互助轉移" },
             ] as { v: typeof transferKindFilter; label: string }[]
           ).map((opt) => {
             const active = transferKindFilter === opt.v;

--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -200,6 +200,14 @@ const TRANSFER_STATUS_BY_STAGE: Record<Stage, string[]> = {
   done: ["received"],
   rejected: ["cancelled"],
 };
+const TRANSFER_STATUS_LABEL: Record<string, string> = {
+  draft: "草稿",
+  confirmed: "已確認",
+  shipped: "已出貨",
+  received: "已收貨",
+  cancelled: "已取消",
+  closed: "已結案",
+};
 const AID_STATUS_BY_STAGE: Record<Stage, AidStatus[]> = {
   pending: ["pending", "confirmed"],
   in_transit: ["shipping"],
@@ -226,18 +234,30 @@ type SBClient = ReturnType<typeof getSupabase>;
 
 // 撈某張表（restock_request_lines / transfer_items / customer_order_items / picking_wave_items）
 // 對應每張單的 items 摘要：「品名×qty、品名×qty…」（最多前 4 個 SKU，其餘 +N）
+// 對 transfer_items 傳 includeFreeFormCols=true：自由轉貨行用 description 取代 sku label，並把估價附在後面
 async function fetchItemsSummaryMap(
   sb: SBClient,
   table: string,
   idCol: string,
   ids: number[],
   qtyCol: string,
+  includeFreeFormCols = false,
 ): Promise<Map<number, string>> {
   if (ids.length === 0) return new Map();
-  const { data } = await sb.from(table).select(`${idCol}, sku_id, ${qtyCol}`).in(idCol, ids);
-  const lines = (data ?? []) as unknown as Record<string, number | null>[];
+  const cols = includeFreeFormCols
+    ? `${idCol}, sku_id, ${qtyCol}, description, estimated_amount`
+    : `${idCol}, sku_id, ${qtyCol}`;
+  const { data } = await sb.from(table).select(cols).in(idCol, ids);
+  type Line = Record<string, number | string | null>;
+  const lines = (data ?? []) as unknown as Line[];
   const skuIds = Array.from(
-    new Set(lines.map((l) => Number(l.sku_id)).filter((x) => Number.isFinite(x)))
+    new Set(
+      lines
+        // 自由轉貨行有 description 就不靠 sku label
+        .filter((l) => !includeFreeFormCols || !l.description)
+        .map((l) => Number(l.sku_id))
+        .filter((x) => Number.isFinite(x))
+    )
   );
   let skuLabelMap = new Map<number, string>();
   if (skuIds.length > 0) {
@@ -264,12 +284,21 @@ async function fetchItemsSummaryMap(
   const partsMap = new Map<number, string[]>();
   for (const l of lines) {
     const id = Number(l[idCol]);
-    const skuId = Number(l.sku_id);
     const qty = Number(l[qtyCol] ?? 0);
-    if (!Number.isFinite(id) || !Number.isFinite(skuId)) continue;
-    const label = skuLabelMap.get(skuId) ?? `#${skuId}`;
+    if (!Number.isFinite(id)) continue;
+    let label: string;
+    let suffix = "";
+    if (includeFreeFormCols && typeof l.description === "string" && l.description) {
+      label = l.description;
+      const est = Number(l.estimated_amount ?? 0);
+      if (est > 0) suffix = `（估 $${est.toFixed(0)}）`;
+    } else {
+      const skuId = Number(l.sku_id);
+      if (!Number.isFinite(skuId)) continue;
+      label = skuLabelMap.get(skuId) ?? `#${skuId}`;
+    }
     const arr = partsMap.get(id) ?? [];
-    arr.push(`${label}×${qty}`);
+    arr.push(`${label}×${qty}${suffix}`);
     partsMap.set(id, arr);
   }
   const result = new Map<number, string>();
@@ -405,7 +434,7 @@ async function fetchTransferRows(
     }
   }
 
-  const itemsMap = await fetchItemsSummaryMap(sb, "transfer_items", "transfer_id", tIds, "qty_shipped");
+  const itemsMap = await fetchItemsSummaryMap(sb, "transfer_items", "transfer_id", tIds, "qty_shipped", true);
 
   const rows: Row[] = trs.map((t) => ({
     key: `transfer-${t.id}`,
@@ -733,7 +762,7 @@ async function fetchTransferRowsByIds(sb: SBClient, ids: number[]): Promise<Row[
       tLineMap.set(it.transfer_id, (tLineMap.get(it.transfer_id) ?? 0) + 1);
     }
   }
-  const itemsMap = await fetchItemsSummaryMap(sb, "transfer_items", "transfer_id", trs.map((t) => t.id), "qty_shipped");
+  const itemsMap = await fetchItemsSummaryMap(sb, "transfer_items", "transfer_id", trs.map((t) => t.id), "qty_shipped", true);
   return trs.map((t) => ({
     key: `transfer-${t.id}`,
     source: "transfer" as const,
@@ -2125,15 +2154,53 @@ function MailRow({
     const t = row.raw;
     const isOrderReturn = isOrderReturnTransfer(t.notes);
     idText = t.transfer_no;
+    // 類別 chip：退訂單 / 自由轉貨 / 退貨回總倉 / 總倉派貨 / 互助
+    const kindChip = (() => {
+      if (isOrderReturn) {
+        return {
+          cls: "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300",
+          label: "🔁 退訂單",
+          title: "由客戶退訂單建立",
+        };
+      }
+      switch (t.transfer_type) {
+        case "store_to_store":
+          return {
+            cls: "bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-300",
+            label: "🔄 自由轉貨",
+            title: "店與店之間自由轉貨（虛擬 SKU + 備註）",
+          };
+        case "return_to_hq":
+          return {
+            cls: "bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-300",
+            label: "↩ 退貨回總倉",
+            title: "店端發起退貨回總倉",
+          };
+        case "hq_to_store":
+          return {
+            cls: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+            label: "🚚 總倉派貨",
+            title: "總倉派貨到分店（撿貨單 wave）",
+          };
+        case "aid_handoff":
+          return {
+            cls: "bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-950 dark:text-fuchsia-300",
+            label: "🤝 互助轉移",
+            title: "互助訂單轉移",
+          };
+        default:
+          return null;
+      }
+    })();
     title = (
       <>
         {t.source_name} <span className="text-zinc-400 mx-1">→</span> {t.dest_name}
-        {isOrderReturn && (
+        {kindChip && (
           <span
-            className="ml-2 inline-block rounded bg-rose-100 px-1.5 py-0.5 text-[10px] font-medium text-rose-700 dark:bg-rose-950 dark:text-rose-300"
-            title="由客戶退訂單建立"
+            className={`ml-2 inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${kindChip.cls}`}
+            title={kindChip.title}
           >
-            🔁 退訂單
+            {kindChip.label}
           </span>
         )}
       </>
@@ -2143,7 +2210,7 @@ function MailRow({
         {t.line_count} 項
         {t.is_air_transfer && <span className="ml-1">· ✈ 空運</span>}
         {t.shipping_temp && <span className="ml-1">· {t.shipping_temp}</span>}
-        <span className="ml-1 text-[10px] text-zinc-400">· {t.status}</span>
+        <span className="ml-1 text-[10px] text-zinc-400">· {TRANSFER_STATUS_LABEL[t.status] ?? t.status}</span>
       </>
     );
     timeIso = t.created_at;

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -291,14 +291,21 @@ function OrdersListContent() {
         if (o.member_id != null) monthMemberIds.add(o.member_id);
       }
 
-      // 每日 buckets (key = YYYY-MM-DD, 用 local timezone 推, 跟 created_at 直接 slice 一致)
+      // 每日 buckets — key = 台北日 YYYY-MM-DD（不能用 created_at.slice(0,10)，
+      // 那是 UTC 日，會把台北凌晨的訂單錯誤歸到前一天）
+      const tpeFmt = new Intl.DateTimeFormat("en-CA", {
+        timeZone: "Asia/Taipei",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      });
       const buckets = new Map<
         string,
         { orderIds: Set<number>; memberIds: Set<number>; amount: number }
       >();
       const orderDay = new Map<number, string>();
       for (const o of orders) {
-        const ymd = o.created_at.slice(0, 10);
+        const ymd = tpeFmt.format(new Date(o.created_at));
         orderDay.set(o.id, ymd);
         let b = buckets.get(ymd);
         if (!b) {

--- a/apps/admin/src/app/(protected)/products/page.tsx
+++ b/apps/admin/src/app/(protected)/products/page.tsx
@@ -429,6 +429,7 @@ function PageContent() {
           .select("id, product_code, name, short_name, status, brand_id, category_id, updated_at", {
             count: "exact",
           })
+          .eq("is_virtual", false)
           .order(sortBy, { ascending: sortDir === "asc" })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -219,6 +219,7 @@ export default function PurchaseRequestsListPage() {
           .from("group_buy_campaigns")
           .select("id, name, end_at")
           .eq("status", "closed")
+          .neq("campaign_no", "__INTERNAL_RESTOCK__")
           .gte("end_at", since.toISOString())
           .order("end_at", { ascending: false });
 
@@ -362,6 +363,7 @@ export default function PurchaseRequestsListPage() {
         .from("group_buy_campaigns")
         .select("id, name, end_at")
         .eq("status", "closed")
+        .neq("campaign_no", "__INTERNAL_RESTOCK__")
         .gte("end_at", since.toISOString())
         .order("end_at", { ascending: false });
 

--- a/apps/admin/src/app/(protected)/wms/transfers/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/transfers/page.tsx
@@ -29,6 +29,8 @@ type TransferRow = {
   created_at: string;
   shipped_at: string | null;
   received_at: string | null;
+  items_summary: string;       // 「描述×qty、…」或「SKU×qty、…」
+  total_estimated: number;     // 自由轉貨 estimated_amount 加總（0 表非自由轉貨或都未估）
 };
 
 const STATUS_LABEL: Record<string, string> = {
@@ -70,14 +72,72 @@ export default function InternalTransfersPage() {
           .order("id", { ascending: false })
           .limit(200);
         if (e) throw new Error(e.message);
-        const rows = (data ?? []) as TransferRow[];
+        const baseRows = (data ?? []) as Omit<TransferRow, "items_summary" | "total_estimated">[];
 
-        const locIds = Array.from(new Set(rows.flatMap((r) => [r.source_location, r.dest_location])));
+        const locIds = Array.from(new Set(baseRows.flatMap((r) => [r.source_location, r.dest_location])));
         const locMap = new Map<number, Loc>();
         if (locIds.length > 0) {
           const { data: lr } = await sb.from("locations").select("id, name, type").in("id", locIds);
           for (const l of (lr ?? []) as Loc[]) locMap.set(l.id, l);
         }
+
+        // 撈每張 transfer 的 items：自由轉貨用 description，退訂單用 sku
+        const tIds = baseRows.map((r) => r.id);
+        const itemsAgg = new Map<number, { parts: string[]; total: number }>();
+        if (tIds.length > 0) {
+          const { data: tis } = await sb
+            .from("transfer_items")
+            .select("transfer_id, sku_id, qty_shipped, description, estimated_amount")
+            .in("transfer_id", tIds);
+          const allTis = (tis ?? []) as {
+            transfer_id: number; sku_id: number; qty_shipped: number;
+            description: string | null; estimated_amount: number | null;
+          }[];
+
+          // 對沒 description 的 SKU 行（退訂單）需另外撈 sku_code + product name
+          const realSkuIds = Array.from(new Set(
+            allTis.filter((it) => !it.description).map((it) => it.sku_id).filter((x) => x != null)
+          ));
+          let skuLabelMap = new Map<number, string>();
+          if (realSkuIds.length > 0) {
+            const { data: skus } = await sb
+              .from("skus")
+              .select("id, sku_code, product_id")
+              .in("id", realSkuIds);
+            const arr = (skus ?? []) as { id: number; sku_code: string; product_id: number | null }[];
+            const prodIds = Array.from(new Set(arr.map((s) => s.product_id).filter((x): x is number => x != null)));
+            let prodMap = new Map<number, string>();
+            if (prodIds.length > 0) {
+              const { data: ps } = await sb.from("products").select("id, name").in("id", prodIds);
+              prodMap = new Map(((ps ?? []) as { id: number; name: string }[]).map((p) => [p.id, p.name]));
+            }
+            skuLabelMap = new Map(
+              arr.map((s) => [s.id, s.product_id != null ? (prodMap.get(s.product_id) ?? s.sku_code) : s.sku_code])
+            );
+          }
+
+          for (const it of allTis) {
+            const slot = itemsAgg.get(it.transfer_id) ?? { parts: [] as string[], total: 0 };
+            const qty = Number(it.qty_shipped ?? 0);
+            if (it.description) {
+              slot.parts.push(`${it.description}×${qty}`);
+              slot.total += Number(it.estimated_amount ?? 0);
+            } else {
+              const label = skuLabelMap.get(it.sku_id) ?? `#${it.sku_id}`;
+              slot.parts.push(`${label}×${qty}`);
+            }
+            itemsAgg.set(it.transfer_id, slot);
+          }
+        }
+
+        const MAX = 4;
+        const rows: TransferRow[] = baseRows.map((r) => {
+          const agg = itemsAgg.get(r.id) ?? { parts: [] as string[], total: 0 };
+          const summary = agg.parts.length <= MAX
+            ? agg.parts.join("、")
+            : agg.parts.slice(0, MAX).join("、") + ` +${agg.parts.length - MAX}`;
+          return { ...r, items_summary: summary, total_estimated: agg.total };
+        });
 
         if (!cancelled) {
           setTransfers(rows);
@@ -217,15 +277,17 @@ export default function InternalTransfersPage() {
               <th className="px-3 py-2">轉貨單號</th>
               <th className="px-3 py-2">時間</th>
               <th className="px-3 py-2">來源 → 目的</th>
+              <th className="px-3 py-2">品項 / 描述</th>
+              <th className="px-3 py-2 text-right">估價</th>
               <th className="px-3 py-2">狀態</th>
               <th className="px-3 py-2">備註</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {transfers === null ? (
-              <tr><td colSpan={5} className="p-6 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={7} className="p-6 text-center text-zinc-500">載入中…</td></tr>
             ) : filtered.length === 0 ? (
-              <tr><td colSpan={5} className="p-6 text-center text-zinc-500">目前沒有資料</td></tr>
+              <tr><td colSpan={7} className="p-6 text-center text-zinc-500">目前沒有資料</td></tr>
             ) : filtered.map((t) => {
               const src = locs.get(t.source_location)?.name ?? `#${t.source_location}`;
               const dst = locs.get(t.dest_location)?.name ?? `#${t.dest_location}`;
@@ -246,6 +308,12 @@ export default function InternalTransfersPage() {
                   </td>
                   <td className="px-3 py-2 text-xs text-zinc-500">{new Date(t.created_at).toLocaleString("zh-TW")}</td>
                   <td className="px-3 py-2 text-xs">{src} → {dst}</td>
+                  <td className="px-3 py-2 text-xs text-zinc-600 dark:text-zinc-300 max-w-md">
+                    <span title={t.items_summary} className="line-clamp-2">{t.items_summary || "—"}</span>
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-xs">
+                    {t.total_estimated > 0 ? `$${t.total_estimated.toFixed(0)}` : <span className="text-zinc-300">—</span>}
+                  </td>
                   <td className="px-3 py-2"><span className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${STATUS_COLOR[t.status] ?? STATUS_COLOR.draft}`}>{STATUS_LABEL[t.status] ?? t.status}</span></td>
                   <td className="px-3 py-2 text-xs text-zinc-500" title={t.notes ?? undefined}>{formatNote(t.notes)}</td>
                 </tr>

--- a/apps/admin/src/components/ExceptionsContent.tsx
+++ b/apps/admin/src/components/ExceptionsContent.tsx
@@ -429,8 +429,8 @@ export default function ExceptionsContent({
               <tr><td colSpan={8} className="p-6 text-center text-zinc-500">沒有異常,系統運作正常 ✓</td></tr>
             ) : filtered.map((r) => (
               <tr key={r.key} className="hover:bg-zinc-50 dark:hover:bg-zinc-950">
-                <td className="px-3 py-2">
-                  <span className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${
+                <td className="px-3 py-2 whitespace-nowrap">
+                  <span className={`inline-flex whitespace-nowrap rounded px-2 py-0.5 text-xs font-medium ${
                     r.type === "po_shortage" ? "bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-300" :
                     r.type === "po_damage" ? "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300" :
                     r.type === "po_over" ? "bg-purple-100 text-purple-800 dark:bg-purple-950 dark:text-purple-300" :
@@ -438,19 +438,19 @@ export default function ExceptionsContent({
                     "bg-fuchsia-100 text-fuchsia-800 dark:bg-fuchsia-950 dark:text-fuchsia-300"
                   }`}>{TAB_LABEL[r.type]}</span>
                 </td>
-                <td className="px-3 py-2 font-mono text-xs">{r.doc_no}</td>
-                <td className="px-3 py-2 text-xs">
+                <td className="px-3 py-2 font-mono text-xs whitespace-nowrap">{r.doc_no}</td>
+                <td className="px-3 py-2 text-xs min-w-[220px]">
                   {r.sku_code && <div className="font-mono text-[10px] text-zinc-500">{r.sku_code}</div>}
                   <div>{r.sku_label}</div>
                 </td>
-                <td className="px-3 py-2 text-right font-mono text-xs">{r.expected}</td>
-                <td className="px-3 py-2 text-right font-mono text-xs">{r.actual}</td>
-                <td className="px-3 py-2 text-right font-mono text-xs font-bold text-rose-600">{r.diff > 0 ? `-${r.diff}` : `+${Math.abs(r.diff)}`}</td>
+                <td className="px-3 py-2 text-right font-mono text-xs whitespace-nowrap">{r.expected}</td>
+                <td className="px-3 py-2 text-right font-mono text-xs whitespace-nowrap">{r.actual}</td>
+                <td className="px-3 py-2 text-right font-mono text-xs font-bold text-rose-600 whitespace-nowrap">{r.diff > 0 ? `-${r.diff}` : `+${Math.abs(r.diff)}`}</td>
                 <td className="px-3 py-2 text-xs text-zinc-500">
-                  {r.reason && <div className="text-amber-700 dark:text-amber-400">⚠ {r.reason}</div>}
-                  <div>{r.extra}</div>
+                  {r.reason && <div className="text-amber-700 dark:text-amber-400 whitespace-nowrap">⚠ {r.reason}</div>}
+                  <div className="whitespace-nowrap">{r.extra}</div>
                 </td>
-                <td className="px-3 py-2 text-xs">
+                <td className="px-3 py-2 text-xs whitespace-nowrap">
                   {r.type === "transfer_short" && r.shortage_ctx ? (
                     <SpinButton
                       onClick={() => setResolveCtx(r.shortage_ctx ?? null)}
@@ -462,7 +462,7 @@ export default function ExceptionsContent({
                     r.shortage_resolution ? (
                       <Link href={r.doc_link} className="text-blue-600 hover:underline dark:text-blue-400">看訂單 →</Link>
                     ) : (
-                      <div className="flex flex-wrap justify-end gap-1">
+                      <div className="flex flex-nowrap justify-end gap-1">
                         <SpinButton
                           onClick={() => handleCustomerShortageAction(r.customer_order_id!, "notified")}
                           disabled={busy === r.customer_order_id}

--- a/apps/admin/src/components/FreeTransferCreateForm.tsx
+++ b/apps/admin/src/components/FreeTransferCreateForm.tsx
@@ -102,7 +102,7 @@ export default function FreeTransferCreateForm({
       )}
 
       <p className="text-sm text-zinc-500">
-        沒 catalog 的東西跨店搬貨；用備註描述實際品名 / 規格。
+        店與店之間搬運「商品檔裡沒有的東西」（例如借用的器具、樣品、零碼），在備註欄寫實際品名 / 規格即可。
         <span className="text-amber-700 dark:text-amber-400">退貨回總倉請用「+ 退訂單」（必須關聯顧客訂單）</span>
       </p>
 

--- a/apps/admin/src/components/TransferDetailModal.tsx
+++ b/apps/admin/src/components/TransferDetailModal.tsx
@@ -31,6 +31,8 @@ type Item = {
   sku_code: string;
   sku_name: string;
   variant_name: string | null;
+  description: string | null;       // 自由轉貨用
+  estimated_amount: number | null;  // 自由轉貨估價
 };
 
 const TYPE_LABEL: Record<string, string> = {
@@ -88,7 +90,7 @@ export default function TransferDetailModal({
         sb.from("locations").select("id, name").in("id", [tData.source_location, tData.dest_location]),
         sb
           .from("transfer_items")
-          .select("id, sku_id, qty_requested, qty_shipped, qty_received")
+          .select("id, sku_id, qty_requested, qty_shipped, qty_received, description, estimated_amount")
           .eq("transfer_id", transferId)
           .order("id"),
       ]);
@@ -107,6 +109,8 @@ export default function TransferDetailModal({
         qty_requested: number | null;
         qty_shipped: number | null;
         qty_received: number | null;
+        description: string | null;
+        estimated_amount: number | null;
       };
       const tiRows = (tis ?? []) as ApiItem[];
 
@@ -150,6 +154,8 @@ export default function TransferDetailModal({
           sku_code: sku?.code ?? `#${r.sku_id}`,
           sku_name: sku?.name ?? "",
           variant_name: sku?.variant ?? null,
+          description: r.description,
+          estimated_amount: r.estimated_amount == null ? null : Number(r.estimated_amount),
         };
       });
       setItems(rows);
@@ -196,31 +202,50 @@ export default function TransferDetailModal({
             <table className="w-full text-sm">
               <thead className="bg-zinc-50 dark:bg-zinc-900">
                 <tr className="text-left text-xs uppercase tracking-wide text-zinc-500">
-                  <th className="px-3 py-2">SKU</th>
+                  <th className="px-3 py-2">SKU / 描述</th>
                   <th className="px-3 py-2">品名 / 規格</th>
                   <th className="px-3 py-2 text-right">應出</th>
                   <th className="px-3 py-2 text-right">已出</th>
                   <th className="px-3 py-2 text-right">已收</th>
+                  <th className="px-3 py-2 text-right">估價</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
                 {items === null ? (
-                  <tr><td colSpan={5} className="p-4 text-center text-zinc-500">載入中…</td></tr>
+                  <tr><td colSpan={6} className="p-4 text-center text-zinc-500">載入中…</td></tr>
                 ) : items.length === 0 ? (
-                  <tr><td colSpan={5} className="p-4 text-center text-zinc-500">無明細</td></tr>
+                  <tr><td colSpan={6} className="p-4 text-center text-zinc-500">無明細</td></tr>
                 ) : (
-                  items.map((it) => (
-                    <tr key={it.id}>
-                      <td className="px-3 py-2 font-mono text-xs">{it.sku_code}</td>
-                      <td className="px-3 py-2 text-xs">
-                        {it.sku_name || "—"}
-                        {it.variant_name && <span className="ml-1 text-zinc-500">/ {it.variant_name}</span>}
-                      </td>
-                      <td className="px-3 py-2 text-right font-mono">{it.qty_requested}</td>
-                      <td className="px-3 py-2 text-right font-mono">{it.qty_shipped}</td>
-                      <td className="px-3 py-2 text-right font-mono">{it.qty_received ?? "—"}</td>
-                    </tr>
-                  ))
+                  items.map((it) => {
+                    const isFree = !!it.description;
+                    return (
+                      <tr key={it.id}>
+                        <td className="px-3 py-2 font-mono text-xs">
+                          {isFree ? (
+                            <span className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-950 dark:text-blue-300">自由轉貨</span>
+                          ) : (
+                            it.sku_code
+                          )}
+                        </td>
+                        <td className="px-3 py-2 text-xs">
+                          {isFree ? (
+                            <span className="text-zinc-900 dark:text-zinc-100">{it.description}</span>
+                          ) : (
+                            <>
+                              {it.sku_name || "—"}
+                              {it.variant_name && <span className="ml-1 text-zinc-500">/ {it.variant_name}</span>}
+                            </>
+                          )}
+                        </td>
+                        <td className="px-3 py-2 text-right font-mono">{it.qty_requested}</td>
+                        <td className="px-3 py-2 text-right font-mono">{it.qty_shipped}</td>
+                        <td className="px-3 py-2 text-right font-mono">{it.qty_received ?? "—"}</td>
+                        <td className="px-3 py-2 text-right font-mono">
+                          {it.estimated_amount != null ? `$${it.estimated_amount.toFixed(0)}` : <span className="text-zinc-300">—</span>}
+                        </td>
+                      </tr>
+                    );
+                  })
                 )}
               </tbody>
             </table>

--- a/supabase/migrations/20260614000060_reseed_misc_virtual_sku.sql
+++ b/supabase/migrations/20260614000060_reseed_misc_virtual_sku.sql
@@ -1,0 +1,61 @@
+-- ============================================================
+-- 2026-06-14: 補種 MISC 虛擬商品 / MISC-01 SKU
+--
+-- 原本 20260515000000 的 seed DO block 在某些 tenant 漏跑（migration apply 順序 + RLS
+-- 在 DO block 內的行為造成 SELECT DISTINCT 拿不到 tenant_id）。
+-- 結果 rpc_create_free_transfer 報「MISC virtual SKU not found for tenant」。
+--
+-- 這條 migration 直接對每個既有 tenant 重跑同樣的 seed（idempotent）。
+-- ============================================================
+
+DO $$
+DECLARE
+  t        RECORD;
+  v_pid    BIGINT;
+  cnt_p    INT := 0;
+  cnt_s    INT := 0;
+BEGIN
+  -- 同時涵蓋有 product 的 tenant 和有 location 的 tenant（避免 RLS 影響）
+  FOR t IN
+    SELECT DISTINCT tenant_id FROM (
+      SELECT tenant_id FROM products
+      UNION
+      SELECT tenant_id FROM locations
+    ) x
+    WHERE tenant_id IS NOT NULL
+  LOOP
+    SELECT id INTO v_pid
+      FROM products
+     WHERE tenant_id = t.tenant_id AND product_code = 'MISC';
+
+    IF v_pid IS NULL THEN
+      INSERT INTO products (
+        tenant_id, product_code, name, short_name, status, is_virtual
+      ) VALUES (
+        t.tenant_id, 'MISC', '虛擬轉貨商品', '虛擬轉貨', 'active', TRUE
+      ) RETURNING id INTO v_pid;
+      cnt_p := cnt_p + 1;
+    ELSE
+      UPDATE products SET is_virtual = TRUE
+       WHERE id = v_pid AND is_virtual = FALSE;
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM skus
+       WHERE tenant_id = t.tenant_id AND product_id = v_pid AND sku_code = 'MISC-01'
+    ) THEN
+      INSERT INTO skus (
+        tenant_id, product_id, sku_code, variant_name, spec, base_unit, tax_rate, status,
+        product_name
+      ) VALUES (
+        t.tenant_id, v_pid, 'MISC-01', NULL, '{}'::jsonb, '件', 0.0500, 'active',
+        '虛擬轉貨商品'
+      );
+      INSERT INTO sku_packs (sku_id, unit, qty_in_base, is_default_sale)
+      SELECT id, '件', 1, TRUE FROM skus
+       WHERE tenant_id = t.tenant_id AND product_id = v_pid AND sku_code = 'MISC-01';
+      cnt_s := cnt_s + 1;
+    END IF;
+  END LOOP;
+  RAISE NOTICE 'Reseed MISC: % products, % skus added', cnt_p, cnt_s;
+END $$;


### PR DESCRIPTION
## Summary

延伸 [#226](https://github.com/lt-foods/new_erp/pull/226) 的後續改動：
- **自由轉貨**：補種 MISC 虛擬 SKU、列表 + detail modal 顯示描述/估價、hq/inbox row 分類 chip
- **訂單 KPI**：修「日 bucket 用 UTC、loop 用台北 local」的時區邊界 bug
- **Sentinel 過濾**：開團 / 採購單 / 商品列表不顯示 `__INTERNAL_RESTOCK__` campaign 和 MISC product

## 改動列表

### Migration
- **`20260614000060` rpc_create_free_transfer fix** — 重新 seed MISC 虛擬商品 + MISC-01 SKU（原 `20260515000000` seed DO block 對某些 tenant 漏跑、idempotent）

### Transfer / 內部調撥
- **wms/transfers 列表** 新增「品項 / 描述」+「估價」兩欄，fetch transfer_items 聚合 description × qty / sku label × qty 摘要 + estimated_amount 加總
- **TransferDetailModal** 明細加「估價」欄，自由轉貨行顯示「自由轉貨」chip + description
- **hq/inbox 轉貨單 row**：
  - 加分類 chip：🔁 退訂單 / 🔄 自由轉貨 / ↩ 退貨回總倉 / 🚚 總倉派貨 / 🤝 互助轉移
  - subtitle 自由轉貨摘要顯示 `description×qty（估 $X）`
  - 英文狀態翻中文（draft → 草稿、shipped → 已出貨…）

### 其他
- **開團列表** 改用開團時間 `start_at desc` 排序（原 `updated_at desc`）
- **開團列表 / 採購單建單 modal / 月曆 view** 過濾 `__INTERNAL_RESTOCK__` sentinel campaign
- **商品列表** 過濾 `is_virtual=false`（不顯示 MISC sentinel product）
- **FreeTransferCreateForm 文案** 從「沒 catalog 的東西跨店搬貨」改成「店與店之間搬運『商品檔裡沒有的東西』（例如借用的器具、樣品、零碼）」
- **訂單 KPI trend 時區 bug**：日 bucket key 從 `created_at.slice(0, 10)` (UTC) 改用 `Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Taipei" })`（台北日），解掉台北 5/15 凌晨訂單被歸到 5/14 bucket 的問題

## Test plan

- [ ] `rpc_create_free_transfer` 對任一 tenant 不再報「MISC virtual SKU not found」
- [ ] 內部調撥列表「店 ↔ 店」tab 顯示描述 + 估價、TransferDetailModal 自由轉貨行有 chip + description
- [ ] 總倉收件匣轉貨單 tab 每張 transfer 有對應分類 chip、狀態為中文
- [ ] 開團列表只顯示真實 campaign（無 `__INTERNAL_RESTOCK__`），按 `start_at desc` 排序
- [ ] 商品列表不顯示 MISC（虛擬轉貨商品）
- [ ] 訂單頁 KPI trend：台北 5/15 凌晨訂單正確進 5/15 bucket（驗證「今日客單價 / 訂單數」非 0）
- [ ] 採購單建單 modal 候選團清單不出現 `__INTERNAL_RESTOCK__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)