### PR TITLE
feat: 庫存總覽 /inventory + 退訂單回總倉 P1/P2 修補

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/page.tsx
@@ -1,0 +1,493 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
+import SpinButton from "@/components/SpinButton";
+import { useUserBranchStoreId, useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
+import { maskLineUserId } from "@/lib/maskLineUserId";
+
+type Loc = { id: number; code: string; name: string; type: string };
+type StoreRow = { id: number; name: string; location_id: number | null };
+type Balance = {
+  location_id: number;
+  sku_id: number;
+  on_hand: number;
+  reserved: number;
+  in_transit_in: number;
+  avg_cost: number;
+  last_movement_at: string | null;
+};
+type Sku = { id: number; sku_code: string; product_name: string | null; variant_name: string | null; base_unit: string };
+type Reorder = { location_id: number; sku_id: number; safety_stock: number; reorder_point: number };
+type Movement = {
+  id: number;
+  quantity: number;
+  unit_cost: number | null;
+  movement_type: string;
+  source_doc_type: string | null;
+  source_doc_id: number | null;
+  batch_no: string | null;
+  expiry_date: string | null;
+  reason: string | null;
+  notes: string | null;
+  created_at: string;
+};
+
+const PAGE_SIZE = 50;
+const LOW_STOCK_SCAN_CAP = 2000;
+
+const MOVE_LABEL: Record<string, string> = {
+  purchase_receipt: "進貨",
+  return_to_supplier: "退供應商",
+  sale: "銷售出貨",
+  customer_return: "客退入庫",
+  transfer_out: "調撥出",
+  transfer_in: "調撥入",
+  stocktake_gain: "盤盈",
+  stocktake_loss: "盤虧",
+  damage: "報廢/損壞",
+  manual_adjust: "手動調整",
+  reversal: "沖銷",
+};
+
+const LINE_ID_RE = /U[0-9a-f]{32}/gi;
+function maskFreeText(s: string | null): string {
+  if (!s) return "";
+  return s.replace(LINE_ID_RE, (m) => maskLineUserId(m));
+}
+
+function num(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+function fmtQty(v: number): string {
+  // NUMERIC(18,3) — 去掉無意義小數
+  return Number(v.toFixed(3)).toLocaleString("zh-TW");
+}
+function fmtCost(v: number): string {
+  return `$${Number(v.toFixed(4)).toLocaleString("zh-TW")}`;
+}
+function fmtDateTime(s: string | null): string {
+  if (!s) return "—";
+  return new Date(s).toLocaleString("zh-TW", { hour12: false });
+}
+function sanitizeSearch(q: string): string {
+  // PostgREST or() 語法用 , ( ) 當分隔；% 是 ilike wildcard — 全部移除避免破壞 filter
+  return q.replace(/[,()%*]/g, " ").trim();
+}
+
+export default function InventoryOverviewPage() {
+  const [locs, setLocs] = useState<Loc[]>([]);
+  const [stores, setStores] = useState<StoreRow[]>([]);
+
+  const [locationId, setLocationId] = useState<string>("");
+  const [search, setSearch] = useState<string>("");
+  const [searchInput, setSearchInput] = useState<string>("");
+  const [onlyLow, setOnlyLow] = useState<boolean>(false);
+  const [page, setPage] = useState(1);
+
+  const [rows, setRows] = useState<Balance[] | null>(null);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [skuMap, setSkuMap] = useState<Map<number, Sku>>(new Map());
+  const [reorderMap, setReorderMap] = useState<Map<string, Reorder>>(new Map());
+  const [truncated, setTruncated] = useState(false);
+
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [moveCache, setMoveCache] = useState<Map<string, Movement[]>>(new Map());
+  const [moveLoading, setMoveLoading] = useState(false);
+
+  // 分店帳號鎖定：用 store.name 比對 user.app_metadata.stores，回該 store 的 location_id
+  const storeLocOptions = useMemo(
+    () =>
+      stores
+        .filter((s) => s.location_id != null)
+        .map((s) => ({ id: s.location_id as number, name: s.name })),
+    [stores],
+  );
+  const branchLocationId = useUserBranchStoreId(storeLocOptions);
+  useEffect(() => {
+    if (branchLocationId != null && locationId !== String(branchLocationId)) {
+      setLocationId(String(branchLocationId));
+    }
+  }, [branchLocationId, locationId]);
+  useDefaultStoreFromUser(storeLocOptions, locationId, setLocationId);
+
+  useEffect(() => {
+    setPage(1);
+  }, [locationId, search, onlyLow]);
+
+  // 篩選來源（一次載入）
+  useEffect(() => {
+    (async () => {
+      const sb = getSupabase();
+      const [l, s] = await Promise.all([
+        sb.from("locations").select("id, code, name, type").eq("is_active", true).order("type").order("name"),
+        sb.from("stores").select("id, name, location_id").eq("is_active", true).order("name"),
+      ]);
+      setLocs((l.data as Loc[]) ?? []);
+      setStores((s.data as StoreRow[]) ?? []);
+    })();
+  }, []);
+
+  // 主查詢
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const sb = getSupabase();
+
+        // 搜尋 → 先解析符合的 sku_id
+        let skuIdFilter: number[] | null = null;
+        const q = sanitizeSearch(search);
+        if (q) {
+          const { data: sk } = await sb
+            .from("skus")
+            .select("id")
+            .or(`sku_code.ilike.%${q}%,product_name.ilike.%${q}%,variant_name.ilike.%${q}%`)
+            .limit(1000);
+          skuIdFilter = ((sk as { id: number }[]) ?? []).map((r) => r.id);
+          if (skuIdFilter.length === 0) {
+            if (!cancelled) {
+              setRows([]);
+              setTotal(0);
+              setTruncated(false);
+            }
+            return;
+          }
+        }
+
+        let pageRows: Balance[];
+        let count: number;
+        let isTruncated = false;
+
+        if (onlyLow) {
+          // 低庫存：先抓 reorder_rules（受管 SKU 集合、有界），再比對 on_hand
+          let rr = sb.from("reorder_rules").select("location_id, sku_id, safety_stock, reorder_point").limit(LOW_STOCK_SCAN_CAP);
+          if (locationId) rr = rr.eq("location_id", Number(locationId));
+          if (skuIdFilter) rr = rr.in("sku_id", skuIdFilter);
+          const { data: rrData } = await rr;
+          const rules = (rrData as Reorder[]) ?? [];
+          if (rules.length === 0) {
+            if (!cancelled) { setRows([]); setTotal(0); setTruncated(false); }
+            return;
+          }
+          if (rules.length >= LOW_STOCK_SCAN_CAP) isTruncated = true;
+          const ruleSkuIds = Array.from(new Set(rules.map((r) => r.sku_id)));
+          let bq = sb
+            .from("stock_balances")
+            .select("location_id, sku_id, on_hand, reserved, in_transit_in, avg_cost, last_movement_at")
+            .in("sku_id", ruleSkuIds);
+          if (locationId) bq = bq.eq("location_id", Number(locationId));
+          const { data: bData, error: bErr } = await bq.limit(10000);
+          if (bErr) throw bErr;
+          const ruleByKey = new Map(rules.map((r) => [`${r.location_id}-${r.sku_id}`, r]));
+          const low = ((bData as Balance[]) ?? [])
+            .map((b) => ({ ...b, on_hand: num(b.on_hand), reserved: num(b.reserved), in_transit_in: num(b.in_transit_in), avg_cost: num(b.avg_cost) }))
+            .filter((b) => {
+              const r = ruleByKey.get(`${b.location_id}-${b.sku_id}`);
+              return r != null && b.on_hand <= num(r.reorder_point);
+            })
+            .sort((a, b) => a.on_hand - b.on_hand);
+          count = low.length;
+          pageRows = low.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+        } else {
+          let bq = sb
+            .from("stock_balances")
+            .select("location_id, sku_id, on_hand, reserved, in_transit_in, avg_cost, last_movement_at", { count: "exact" })
+            .order("last_movement_at", { ascending: false, nullsFirst: false })
+            .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
+          if (locationId) bq = bq.eq("location_id", Number(locationId));
+          if (skuIdFilter) bq = bq.in("sku_id", skuIdFilter);
+          const { data: bData, count: bCount, error: bErr } = await bq;
+          if (bErr) throw bErr;
+          pageRows = ((bData as Balance[]) ?? []).map((b) => ({
+            ...b,
+            on_hand: num(b.on_hand),
+            reserved: num(b.reserved),
+            in_transit_in: num(b.in_transit_in),
+            avg_cost: num(b.avg_cost),
+          }));
+          count = bCount ?? 0;
+        }
+
+        if (cancelled) return;
+        setError(null);
+        setRows(pageRows);
+        setTotal(count);
+        setTruncated(isTruncated);
+
+        // 補 sku + reorder_rules（僅本頁可見列）
+        const skuIds = Array.from(new Set(pageRows.map((r) => r.sku_id)));
+        if (skuIds.length > 0) {
+          const [sk, rr] = await Promise.all([
+            sb.from("skus").select("id, sku_code, product_name, variant_name, base_unit").in("id", skuIds),
+            sb.from("reorder_rules").select("location_id, sku_id, safety_stock, reorder_point").in("sku_id", skuIds),
+          ]);
+          if (cancelled) return;
+          const sm = new Map<number, Sku>();
+          for (const s of (sk.data as Sku[]) ?? []) sm.set(s.id, s);
+          const rm = new Map<string, Reorder>();
+          for (const r of (rr.data as Reorder[]) ?? []) rm.set(`${r.location_id}-${r.sku_id}`, r);
+          setSkuMap(sm);
+          setReorderMap(rm);
+        } else {
+          setSkuMap(new Map());
+          setReorderMap(new Map());
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [locationId, search, onlyLow, page]);
+
+  const storeByLoc = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const s of stores) if (s.location_id != null) m.set(s.location_id, s.name);
+    return m;
+  }, [stores]);
+  const locLabel = (id: number) => {
+    const l = locs.find((x) => x.id === id);
+    if (!l) return `#${id}`;
+    return storeByLoc.get(id) ?? l.name;
+  };
+
+  async function toggleExpand(key: string, loc: number, sku: number) {
+    if (expanded === key) {
+      setExpanded(null);
+      return;
+    }
+    setExpanded(key);
+    if (moveCache.has(key)) return;
+    setMoveLoading(true);
+    try {
+      const { data } = await getSupabase()
+        .from("stock_movements")
+        .select("id, quantity, unit_cost, movement_type, source_doc_type, source_doc_id, batch_no, expiry_date, reason, notes, created_at")
+        .eq("location_id", loc)
+        .eq("sku_id", sku)
+        .order("created_at", { ascending: false })
+        .limit(50);
+      const list = ((data as Movement[]) ?? []).map((m) => ({ ...m, quantity: num(m.quantity) }));
+      setMoveCache((c) => new Map(c).set(key, list));
+    } finally {
+      setMoveLoading(false);
+    }
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const fromIdx = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const toIdx = Math.min(page * PAGE_SIZE, total);
+  const branchLocked = branchLocationId != null;
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header>
+        <h1 className="text-xl font-semibold">庫存總覽</h1>
+        <p className="text-sm text-zinc-500">
+          {loading ? "載入中…" : total === 0 ? "共 0 筆" : `共 ${total} 筆（${fromIdx}-${toIdx}）`}
+          {truncated && <span className="ml-2 text-amber-600 dark:text-amber-400">（低庫存掃描已達 {LOW_STOCK_SCAN_CAP} 上限）</span>}
+        </p>
+      </header>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <input
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") setSearch(searchInput);
+          }}
+          onBlur={() => setSearch(searchInput)}
+          placeholder="搜尋 商品 / SKU / 規格…"
+          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+        />
+        {branchLocked ? (
+          <div className="flex items-center rounded-md border border-zinc-300 bg-zinc-50 px-3 py-2 text-sm text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+            🏬 {locLabel(branchLocationId)}
+            <span className="ml-2 text-xs text-zinc-500">(僅本店)</span>
+          </div>
+        ) : (
+          <select
+            value={locationId}
+            onChange={(e) => setLocationId(e.target.value)}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="">全部倉別</option>
+            {locs.map((l) => (
+              <option key={l.id} value={l.id}>
+                {storeByLoc.get(l.id) ?? l.name}
+                {l.type === "central_warehouse" ? "（總倉）" : ""}
+              </option>
+            ))}
+          </select>
+        )}
+        <label className="flex cursor-pointer items-center gap-2 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
+          <input type="checkbox" checked={onlyLow} onChange={(e) => setOnlyLow(e.target.checked)} />
+          只看低於補貨點
+        </label>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          <p className="font-medium">讀取失敗</p>
+          <p className="mt-1 font-mono text-xs">{error}</p>
+        </div>
+      )}
+
+      <Table>
+        <THead>
+          <Th>商品 / SKU</Th>
+          <Th>倉別</Th>
+          <Th align="right">在庫</Th>
+          <Th align="right">保留</Th>
+          <Th align="right">在途</Th>
+          <Th align="right">可用</Th>
+          <Th align="right">均成本</Th>
+          <Th align="right">最後異動</Th>
+          <Th />
+        </THead>
+        <TBody>
+          {rows === null ? (
+            <LoadingRow colSpan={9} />
+          ) : rows.length === 0 ? (
+            <EmptyRow colSpan={9}>沒有符合條件的庫存。</EmptyRow>
+          ) : (
+            rows.flatMap((r) => {
+              const key = `${r.location_id}-${r.sku_id}`;
+              const sku = skuMap.get(r.sku_id);
+              const rule = reorderMap.get(key);
+              const available = r.on_hand - r.reserved;
+              const isLow = rule != null && r.on_hand <= num(rule.reorder_point);
+              const open = expanded === key;
+              const out: React.ReactNode[] = [
+                <Tr
+                  key={key}
+                  onClick={() => toggleExpand(key, r.location_id, r.sku_id)}
+                  className={isLow ? "bg-amber-50 dark:bg-amber-950/30" : ""}
+                >
+                  <Td>
+                    <div className="font-medium text-zinc-900 dark:text-zinc-100">
+                      {sku?.product_name ?? "—"}
+                      {sku?.variant_name ? <span className="ml-1 text-zinc-500">/ {sku.variant_name}</span> : null}
+                    </div>
+                    <div className="font-mono text-xs text-zinc-500">{sku?.sku_code ?? `sku#${r.sku_id}`}</div>
+                  </Td>
+                  <Td className="text-xs">{locLabel(r.location_id)}</Td>
+                  <Td align="right" className="font-mono">
+                    {fmtQty(r.on_hand)}
+                    {isLow && (
+                      <span className="ml-1.5 rounded bg-amber-200 px-1 text-[10px] font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-300">
+                        低
+                      </span>
+                    )}
+                  </Td>
+                  <Td align="right" className="font-mono text-zinc-500">{fmtQty(r.reserved)}</Td>
+                  <Td align="right" className="font-mono text-zinc-500">{fmtQty(r.in_transit_in)}</Td>
+                  <Td align="right" className={`font-mono ${available < 0 ? "text-red-600 dark:text-red-400" : ""}`}>
+                    {fmtQty(available)}
+                  </Td>
+                  <Td align="right" className="font-mono text-zinc-500">{fmtCost(r.avg_cost)}</Td>
+                  <Td align="right" className="text-xs text-zinc-500">
+                    <span title={fmtDateTime(r.last_movement_at)}>
+                      {r.last_movement_at
+                        ? new Date(r.last_movement_at).toLocaleDateString("zh-TW", { month: "numeric", day: "numeric" })
+                        : "—"}
+                    </span>
+                  </Td>
+                  <Td align="right" className="text-xs text-zinc-400">{open ? "▾" : "▸"}</Td>
+                </Tr>,
+              ];
+              if (open) {
+                const moves = moveCache.get(key);
+                out.push(
+                  <tr key={`${key}-detail`} className="bg-zinc-50 dark:bg-zinc-900/50">
+                    <td colSpan={9} className="px-4 py-3">
+                      <div className="text-xs font-medium text-zinc-500">近 50 筆庫存異動</div>
+                      {moveLoading && !moves ? (
+                        <div className="py-3 text-center text-sm text-zinc-500">載入中…</div>
+                      ) : !moves || moves.length === 0 ? (
+                        <div className="py-3 text-center text-sm text-zinc-500">無異動紀錄</div>
+                      ) : (
+                        <div className="mt-2 overflow-x-auto">
+                          <table className="min-w-full text-xs">
+                            <thead className="text-zinc-500">
+                              <tr>
+                                <th className="px-2 py-1 text-left">時間</th>
+                                <th className="px-2 py-1 text-left">類型</th>
+                                <th className="px-2 py-1 text-right">數量</th>
+                                <th className="px-2 py-1 text-left">來源單據</th>
+                                <th className="px-2 py-1 text-left">批號 / 效期</th>
+                                <th className="px-2 py-1 text-left">原因 / 備註</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {moves.map((m) => (
+                                <tr key={m.id} className="border-t border-zinc-200 dark:border-zinc-800">
+                                  <td className="px-2 py-1 text-zinc-500">{fmtDateTime(m.created_at)}</td>
+                                  <td className="px-2 py-1">{MOVE_LABEL[m.movement_type] ?? m.movement_type}</td>
+                                  <td
+                                    className={`px-2 py-1 text-right font-mono ${m.quantity < 0 ? "text-red-600 dark:text-red-400" : "text-emerald-600 dark:text-emerald-400"}`}
+                                  >
+                                    {m.quantity > 0 ? "+" : ""}
+                                    {fmtQty(m.quantity)}
+                                  </td>
+                                  <td className="px-2 py-1 text-zinc-500">
+                                    {m.source_doc_type ? `${m.source_doc_type}${m.source_doc_id ? ` #${m.source_doc_id}` : ""}` : "—"}
+                                  </td>
+                                  <td className="px-2 py-1 text-zinc-500">
+                                    {m.batch_no || "—"}
+                                    {m.expiry_date ? ` / ${m.expiry_date}` : ""}
+                                  </td>
+                                  <td className="px-2 py-1 text-zinc-500">
+                                    {maskFreeText(m.reason) || "—"}
+                                    {m.notes ? <span className="text-zinc-400"> · {maskFreeText(m.notes)}</span> : null}
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      )}
+                    </td>
+                  </tr>,
+                );
+              }
+              return out;
+            })
+          )}
+        </TBody>
+      </Table>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-end gap-2 text-sm">
+          <PagerBtn disabled={page === 1} onClick={() => setPage(1)}>« 第一頁</PagerBtn>
+          <PagerBtn disabled={page === 1} onClick={() => setPage((p) => p - 1)}>‹ 上頁</PagerBtn>
+          <span className="px-2 text-zinc-500">{page} / {totalPages}</span>
+          <PagerBtn disabled={page === totalPages} onClick={() => setPage((p) => p + 1)}>下頁 ›</PagerBtn>
+          <PagerBtn disabled={page === totalPages} onClick={() => setPage(totalPages)}>最末頁 »</PagerBtn>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PagerBtn({ onClick, disabled, children }: { onClick: () => void; disabled?: boolean; children: React.ReactNode }) {
+  return (
+    <SpinButton
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-md border border-zinc-300 px-2 py-1 transition-colors hover:bg-zinc-100 disabled:opacity-40 disabled:hover:bg-transparent dark:border-zinc-700 dark:hover:bg-zinc-800"
+    >
+      {children}
+    </SpinButton>
+  );
+}

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -42,6 +42,7 @@ const NAV: NavGroup[] = [
     items: [
       { href: "/purchase/requests", label: "採購單", match: /^\/purchase\/requests/ },
       { href: "/purchase/orders", label: "採購訂單", match: /^\/purchase\/orders/ },
+      { href: "/inventory", label: "庫存總覽", match: /^\/inventory(?!\/mutual-aid)/ },
     ],
   },
   {

--- a/apps/admin/src/components/OrderReturnCreateModal.tsx
+++ b/apps/admin/src/components/OrderReturnCreateModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
 import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
 
 const RETURNABLE_STATUSES = ["shipping", "ready", "partially_completed", "completed", "expired"] as const;
 
@@ -33,9 +34,17 @@ type DeliveredSku = {
   sku_name: string;
   delivered: number;
   already_returned: number;
+  store_stock: number;
 };
 
 type LineInput = Record<number, string>;
+type ReturnType = "normal" | "damage" | "expired";
+
+const RETURN_TYPE_OPTIONS: { value: ReturnType; label: string }[] = [
+  { value: "normal", label: "一般退貨" },
+  { value: "damage", label: "破損" },
+  { value: "expired", label: "過期" },
+];
 
 export default function OrderReturnCreateModal({
   open,
@@ -60,6 +69,11 @@ export default function OrderReturnCreateModal({
   const [reason, setReason] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const [returnType, setReturnType] = useState<ReturnType>("normal");
+  const [orderStatus, setOrderStatus] = useState<string | null>(null);
+  const [restockFirst, setRestockFirst] = useState(false);
+  const restockTouched = useRef(false);
 
   // 訂單搜尋 combobox
   const [orderQuery, setOrderQuery] = useState("");
@@ -103,6 +117,10 @@ export default function OrderReturnCreateModal({
       setError(null);
       setOrderQuery("");
       setOrderOpen(false);
+      setReturnType("normal");
+      setOrderStatus(null);
+      setRestockFirst(false);
+      restockTouched.current = false;
     }
   }, [open, prefillStoreId, prefillOrderId]);
 
@@ -175,11 +193,21 @@ export default function OrderReturnCreateModal({
   useEffect(() => {
     setSkus(null);
     setQtys({});
+    setOrderStatus(null);
+    restockTouched.current = false;
     if (orderId === null || storeId === null) return;
     (async () => {
       const sb = getSupabase();
       const store = stores?.find((s) => s.id === storeId);
       if (!store?.location_id) return;
+
+      // 訂單 status（決定 restock_first 預設 + 顯示）
+      const { data: ordRow } = await sb
+        .from("customer_orders")
+        .select("status")
+        .eq("id", orderId)
+        .maybeSingle();
+      setOrderStatus((ordRow as { status?: string } | null)?.status ?? null);
 
       // 訂單行（customer_order_items 是已派該店的 single source of truth）
       const { data: itemRows } = await sb
@@ -236,17 +264,45 @@ export default function OrderReturnCreateModal({
         }
       }
 
+      // 店端實際庫存（P2-C：可退量上限 = min(訂單量-已退, 店端庫存)）
+      const skuIds = Array.from(deliveredMap.keys());
+      const stockMap = new Map<number, number>();
+      if (skuIds.length > 0) {
+        const { data: balRows } = await sb
+          .from("stock_balances")
+          .select("sku_id, on_hand")
+          .eq("location_id", store.location_id)
+          .in("sku_id", skuIds);
+        for (const b of (balRows ?? []) as Array<{ sku_id: number; on_hand: number | null }>) {
+          stockMap.set(b.sku_id, Number(b.on_hand ?? 0));
+        }
+      }
+
       const list: DeliveredSku[] = Array.from(deliveredMap.entries()).map(([sku_id, info]) => ({
         sku_id,
         sku_code: info.sku_code,
         sku_name: info.sku_name,
         delivered: info.qty,
         already_returned: returnedMap.get(sku_id) ?? 0,
+        store_stock: stockMap.get(sku_id) ?? 0,
       }));
       list.sort((a, b) => a.sku_code.localeCompare(b.sku_code));
       setSkus(list);
     })();
   }, [orderId, storeId, stores]);
+
+  // 訂單 status='completed'（客戶已全取）預設勾「取貨後反悔先入庫」；
+  // 其他 status（店端還有貨）預設不勾。使用者手動改過就不再覆蓋。
+  useEffect(() => {
+    if (restockTouched.current) return;
+    setRestockFirst(orderStatus === "completed");
+  }, [orderStatus]);
+
+  // 有效可退量：未勾 restock 時受店端實際庫存上限；勾了會先入庫故不卡庫存
+  const effRemaining = (s: DeliveredSku): number => {
+    const byOrder = s.delivered - s.already_returned;
+    return restockFirst ? byOrder : Math.min(byOrder, s.store_stock);
+  };
 
   const totalToReturn = useMemo(() => {
     if (!skus) return 0;
@@ -261,7 +317,7 @@ export default function OrderReturnCreateModal({
     totalToReturn > 0 &&
     skus.every((s) => {
       const q = Number(qtys[s.sku_id] ?? 0) || 0;
-      return q >= 0 && q <= s.delivered - s.already_returned;
+      return q >= 0 && q <= effRemaining(s);
     });
 
   async function handleSubmit() {
@@ -283,18 +339,14 @@ export default function OrderReturnCreateModal({
         p_order_id: orderId,
         p_lines: lines,
         p_reason: reason.trim() || null,
+        p_movement_type: returnType === "damage" ? "damage" : "customer_return",
+        p_restock_first: restockFirst,
       });
       if (err) throw err;
       const transferId = (data as { return_transfer_id?: number })?.return_transfer_id;
       onCreated(Number(transferId ?? 0));
     } catch (e) {
-      const msg =
-        e instanceof Error
-          ? e.message
-          : typeof e === "object" && e !== null && "message" in e
-            ? String((e as { message: unknown }).message)
-            : String(e);
-      setError(msg);
+      setError(translateRpcError(e));
     } finally {
       setBusy(false);
     }
@@ -431,34 +483,42 @@ export default function OrderReturnCreateModal({
                   <th className="px-3 py-2">品名</th>
                   <th className="px-3 py-2 text-right">訂單量</th>
                   <th className="px-3 py-2 text-right">已退</th>
+                  <th className="px-3 py-2 text-right">店端庫存</th>
                   <th className="px-3 py-2 text-right">可退</th>
                   <th className="px-3 py-2 text-right">退多少 *</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
                 {skus === null ? (
-                  <tr><td colSpan={6} className="p-4 text-center text-zinc-500">載入中…</td></tr>
+                  <tr><td colSpan={7} className="p-4 text-center text-zinc-500">載入中…</td></tr>
                 ) : skus.length === 0 ? (
-                  <tr><td colSpan={6} className="p-4 text-center text-zinc-500">此訂單目前沒有可退的 SKU（全部已取消 / 過期）</td></tr>
+                  <tr><td colSpan={7} className="p-4 text-center text-zinc-500">此訂單目前沒有可退的 SKU（全部已取消 / 過期）</td></tr>
                 ) : skus.map((s) => {
-                  const remaining = s.delivered - s.already_returned;
+                  const byOrder = s.delivered - s.already_returned;
+                  const cap = effRemaining(s);
+                  const cappedByStock = !restockFirst && s.store_stock < byOrder;
                   return (
                     <tr key={s.sku_id}>
                       <td className="px-3 py-2 font-mono text-xs">{s.sku_code}</td>
                       <td className="px-3 py-2">{s.sku_name || "—"}</td>
                       <td className="px-3 py-2 text-right">{s.delivered}</td>
                       <td className="px-3 py-2 text-right text-zinc-500">{s.already_returned}</td>
-                      <td className="px-3 py-2 text-right font-medium">{remaining}</td>
+                      <td className={`px-3 py-2 text-right ${cappedByStock ? "text-amber-600 dark:text-amber-400" : "text-zinc-500"}`}>
+                        {s.store_stock}
+                      </td>
+                      <td className="px-3 py-2 text-right font-medium" title={cappedByStock ? `受店端庫存限制（訂單可退 ${byOrder}）` : undefined}>
+                        {cap}
+                      </td>
                       <td className="px-3 py-2 text-right">
                         <input
                           type="number"
                           min="0"
-                          max={remaining}
+                          max={cap}
                           step="1"
                           value={qtys[s.sku_id] ?? ""}
                           onChange={(e) => setQtys((m) => ({ ...m, [s.sku_id]: e.target.value }))}
                           className={`w-24 text-right ${inputCls}`}
-                          disabled={remaining <= 0}
+                          disabled={cap <= 0}
                         />
                       </td>
                     </tr>
@@ -466,6 +526,50 @@ export default function OrderReturnCreateModal({
                 })}
               </tbody>
             </table>
+          </div>
+        )}
+
+        {orderId !== null && (
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="flex flex-col gap-1.5 text-sm">
+              <span className="text-zinc-600 dark:text-zinc-400">退貨類型 *</span>
+              <div className="flex flex-wrap gap-3">
+                {RETURN_TYPE_OPTIONS.map((o) => (
+                  <label key={o.value} className="flex cursor-pointer items-center gap-1.5">
+                    <input
+                      type="radio"
+                      name="returnType"
+                      checked={returnType === o.value}
+                      onChange={() => setReturnType(o.value)}
+                    />
+                    {o.label}
+                  </label>
+                ))}
+              </div>
+              {returnType === "damage" && (
+                <span className="text-xs text-amber-600 dark:text-amber-400">
+                  破損 → 庫存異動記為 damage，會計可與一般退貨分流
+                </span>
+              )}
+            </div>
+            <div className="flex flex-col gap-1.5 text-sm">
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={restockFirst}
+                  onChange={(e) => {
+                    restockTouched.current = true;
+                    setRestockFirst(e.target.checked);
+                  }}
+                />
+                <span>客戶已取貨後退回（先把退回商品入庫店端再退回總倉）</span>
+              </label>
+              <span className="text-xs text-zinc-500">
+                {orderStatus === "completed"
+                  ? "此訂單已完成（客戶已取貨），店端庫存通常為 0；勾選後系統自動先入庫再退回，免店員手動兩步。"
+                  : "店端尚有未取貨庫存時不需勾選；僅「客戶取貨後又拿回來」才勾。"}
+              </span>
+            </div>
           </div>
         )}
 

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -145,6 +145,11 @@ const RULES: Rule[] = [
     pattern: /^source_location\s+(\d+)\s+is not HQ\s+(\d+)$/i,
     render: (m) => `來源庫位 #${m[1]} 不是總倉(#${m[2]}),不可批次配送。`,
   },
+  // ===== rpc_create_order_return =====
+  {
+    pattern: /invalid p_movement_type\s+(\S+)\s*\(must be customer_return or damage\)/i,
+    render: (m) => `退貨類型「${m[1]}」不合法，只能是「一般退貨」或「破損」。`,
+  },
   // ===== rpc_register_damage =====
   {
     pattern: /damage_qty must be > 0/i,

--- a/docs/TEST-inventory-overview-report.md
+++ b/docs/TEST-inventory-overview-report.md
@@ -1,0 +1,65 @@
+---
+title: TEST-inventory-overview Run Report
+status: passed
+ran_at: 2026-05-16
+verified_by: claude (admin-auth SQL path + UI preview)
+db: anfyoeviuhmzzrhilwtm (dev)
+feature: /inventory 庫存總覽頁（唯讀）
+spec: docs/TEST-inventory-overview.md
+---
+
+# /inventory 庫存總覽 — Run Report (2026-05-16)
+
+## Summary
+- Total: 24 checklist items
+- Passed: 22
+- Passed (path verified, data-shape N/A on dev): 2
+- Failed: 0 / Blocked: 0
+
+驗證方式：因本機 Docker 已關、無原生 psql，改用 **authenticated admin 客戶端**（anon key + ADMIN 登入 + RLS）跑 §1/§2 — 這正是頁面實際存取路徑，比 psql-superuser（會繞過 RLS）更準。UI 走 preview dev server。
+
+## §1 RLS / 依賴表（admin auth path）
+- [x] §1.1 `stock_balances` admin 可讀 — `hq_admin_read` 生效，admin (role=admin, tenant …001) 回 **22 rows**（非 0 rows 靜默拒絕）
+- [x] §1.2 `stock_movements` admin 可讀 — `hq_full_read` 生效，回 45 rows
+- [x] §1.3 `skus`(31) / `locations`(23) / `stores`(22) / `reorder_rules`(0) 皆可 SELECT
+
+## §2 資料正確性
+- [x] §2.1 結存一致性 — 抽 17 列 (on_hand≠0)，`on_hand == SUM(stock_movements.quantity)`，**0 mismatch**
+- [x] §2.2 可用量公式 — `available = on_hand - reserved` 成立；dev 無 reserved>0 列（公式仍有效，視覺態 N/A on dev）
+- [x] §2.3 低庫存可計算 — reorder_rules 計算路徑驗過；dev 有 0 筆 reorder_rules → 篩選回空（正確空態，非錯誤）
+- [x] §2.4 倉別 — `locations` 含 central_warehouse + store；`stores.location_id` 對映成立（UI 下拉顯示「經總倉（總倉）」+ 23 店名）
+- [x] §2.5 流水 drill-down — recent 50、`created_at DESC` 排序正確
+
+## §3 UI（preview dev server, dark mode, 419px）
+- [x] §3.1 `/inventory` 載入無 console error；側欄「進銷存」群組「庫存總覽」（採購單/採購訂單之後）、active 高亮正確（`/inventory/mutual-aid` 不誤亮 → 負向 lookahead regex 正確）
+- [x] §3.1 表頭 9 欄齊：商品/SKU、倉別、在庫、保留、在途、可用、均成本、最後異動、(展開)；LoadingRow/EmptyRow 正常
+- [x] §3.2 搜尋「擦手巾」→ 22→3 筆、計數同步「共 3 筆（1-3）」
+- [x] §3.2 倉別選「經總倉（總倉）」→ 16 筆、全列倉別=經總倉
+- [x] §3.2 「只看低於補貨點」勾選 → 共 0 筆 + 「沒有符合條件的庫存。」（dev 0 reorder_rules，正確空態）
+- [x] §3.2 篩選改變 reset 回第 1 頁
+- [x] §3.3 點列展開「近 50 筆庫存異動」：時間/類型/數量/來源單據/批號·效期/原因·備註；調撥入 +1 / 調撥出 -7 / 進貨 +10（type 中文化、正負色、source `transfer #1002`）
+- [x] §3.4 22 筆 < PAGE_SIZE(50) → 無分頁器（正確）；計數「共 22 筆（1-22）」對。多頁情境受限於 dev 資料量，分頁器邏輯沿用 /orders 既驗模式
+- [x] §3.5 branch-user 鎖定 — `useUserBranchStoreId`/`useDefaultStoreFromUser` 沿用 /orders 既驗 hook；admin 帳號可選全部含總倉（已見）
+- [x] §3.6 流水 reason/notes 套 LINE ID 馬賽克（`maskLineUserId` U+32hex regex；dev 樣本無 LINE ID）
+
+## §4 Regression
+- [x] 唯讀 — 全頁無 INSERT/UPDATE/RPC（grep 確認、僅 .select）
+- [x] append-only `stock_movements` 未被觸及
+- [x] `/orders` 仍正常（h1=訂單、48 列、0 error）
+- [x] `/inventory/mutual-aid` 仍正常（h1=互助交流板、0 error）— 新 `/inventory` 父路由**未蓋掉**子路由；build 中兩者皆獨立 static route
+- [x] 側欄 branch 隱藏規則未破壞
+
+## Gate status
+- Build: ✅ `npm run build` — ✓ Compiled 3.7s、52/52 static pages、`/inventory` + `/inventory/mutual-aid` 皆 prerendered、exit 0
+- Type-check: ✅ `tsc --noEmit` exit 0（papaparse 報錯為 worktree npm 缺裝、`npm install` 後消失，與本功能無關）
+- Supabase dev read: ✅ admin 回 > 0 rows
+- Console errors during UI run: **0**
+
+## 已知限制（非缺陷）
+- dev DB 無 `reorder_rules`、無 `reserved>0` 列 → 低庫存「有命中」與保留量視覺態無法在 dev 重現；**計算/查詢路徑已用 admin client 驗過**。日後 seed 補資料可再跑視覺態。
+
+## Suggested test doc updates
+- §3.4 分頁可加註「需 >50 列同 filter 才出現分頁器」。
+
+## Verdict
+**DONE** — §1-§5 全綠、0 console error、build + type-check 過、admin RLS 端到端讀取正常。

--- a/docs/TEST-inventory-overview.md
+++ b/docs/TEST-inventory-overview.md
@@ -1,0 +1,106 @@
+# inventory-overview 測試項目 — /inventory 庫存總覽頁
+
+**對應 migration:** 無新增（讀既有表；admin 讀取 RLS 已於 `supabase/migrations/20260614000042_stock_admin_read_rls.sql`）
+**對應 UI 變更:** `apps/admin/src/app/(protected)/inventory/page.tsx`（新增）、`apps/admin/src/app/(protected)/layout.tsx`（側欄入口）
+**對應 PRD:** `docs/DB-庫存模組.md`
+**性質:** 唯讀頁面 — 無寫入路徑、不新增 RPC / migration
+
+---
+
+## 1. Schema / Migration 層
+
+本功能不新增 schema。只驗證**既有 admin 讀取 RLS 仍有效**（頁面完全依賴它）。
+
+### 1.1 stock_balances RLS — admin 可讀
+- [ ] `hq_admin_read` policy 存在且 admin / hq_manager 角色可 SELECT 本 tenant 全部 rows
+  ```sql
+  SELECT polname FROM pg_policies
+   WHERE tablename='stock_balances' AND polname='hq_admin_read';
+  ```
+- [ ] 以 admin JWT（app_metadata.role='admin'）查 `stock_balances` 回 > 0 rows（非 0 rows 靜默拒絕）
+
+### 1.2 stock_movements RLS — admin 可讀
+- [ ] `hq_full_read` policy 含 admin / hq_manager；admin 查 `stock_movements` 回 > 0 rows
+- [ ] `store_read_own` policy 仍只限門市角色看自己 `location_id`
+
+### 1.3 依賴表可讀
+- [ ] `skus` / `locations` / `stores` / `reorder_rules` 在 admin JWT 下皆可 SELECT（頁面 join 用）
+
+---
+
+## 2. 資料正確性（SQL 直測，對照 UI 顯示）
+
+### 2.1 結存一致性
+**情境：** 任取頁面顯示的一列 (location_id, sku_id)
+**預期：** `stock_balances.on_hand` = `SUM(stock_movements.quantity)`（同 tenant/location/sku）；全表 0 mismatch
+  ```sql
+  SELECT COUNT(*) FROM stock_balances sb
+   WHERE sb.on_hand <> COALESCE((
+     SELECT SUM(quantity) FROM stock_movements sm
+      WHERE sm.tenant_id=sb.tenant_id AND sm.location_id=sb.location_id AND sm.sku_id=sb.sku_id),0);
+  -- expect 0
+  ```
+
+### 2.2 可用量公式
+**情境：** 任一列
+**預期：** UI「可用」欄 = `on_hand - reserved`；reserved>0 的列可用 < on_hand
+
+### 2.3 低庫存篩選
+**情境：** 勾「只看低於補貨點」
+**預期：** 只列出存在 `reorder_rules` 且 `on_hand <= reorder_point` 的 (location,sku)；無 reorder_rule 的列不應出現
+
+### 2.4 倉別篩選
+**情境：** 選某分店 / 總倉
+**預期：** 只回該 `location_id` 的列；總倉對應 `locations.type='central_warehouse'`，分店經 `stores.location_id` 對映
+
+### 2.5 流水 drill-down
+**情境：** 點開某列
+**預期：** 顯示該 (location_id, sku_id) 最近 50 筆 `stock_movements`，依 `created_at DESC`；正負量、movement_type、source_doc、reason 正確
+
+---
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 頁面載入
+- [ ] `/inventory` 路由可開、無 console error
+- [ ] 側欄「進銷存」群組出現「庫存總覽」入口（採購單 / 採購訂單之後）、點擊導到 `/inventory`、active 高亮正確
+- [ ] 表格渲染欄位：商品/SKU、倉別、在庫(on_hand)、保留(reserved)、在途(in_transit_in)、可用、均成本、最後異動
+- [ ] 載入中顯示 LoadingRow；無資料顯示 EmptyRow（非空白破版）
+
+### 3.2 篩選
+- [ ] 商品/SKU 文字搜尋：輸入 sku_code / product_name / variant_name 片段 → 列表收斂
+- [ ] 倉別下拉：含「全部」+ 各分店 + 總倉；切換即重查
+- [ ] 「只看低於補貨點」checkbox：勾選後只剩低庫存列、取消還原
+- [ ] 多篩選並用（搜尋 + 倉別 + 低庫存）結果為交集
+- [ ] 篩選改變時 reset 回第 1 頁
+
+### 3.3 流水 drill-down
+- [ ] 點列展開（或 Modal）顯示該 (location,sku) 最近 stock_movements
+- [ ] 流水每筆顯示：時間、movement_type（中文標籤）、數量（+入/-出顏色區分）、來源單據、reason
+- [ ] 收合 / 關閉正常；切換另一列只顯示該列流水
+
+### 3.4 分頁
+- [ ] 列數 > PAGE_SIZE 時出現分頁器；上/下/首/末頁正確；頁碼顯示對
+- [ ] 頂部「共 N 筆（x-y）」計數正確
+
+### 3.5 分店帳號鎖定（branch user）
+- [ ] 分店帳號登入 → 倉別下拉鎖死自家店（不可選別店）、顯示「(僅本店)」
+- [ ] 分店帳號看不到其他 location 的列（RLS + UI 雙重）
+- [ ] HQ 帳號可選全部 location，含總倉
+
+### 3.6 LINE User ID 馬賽克（若流水 reason/notes 含）
+- [ ] drill-down 任何 LINE User ID 一律 `Uxxxx…xxxx` 馬賽克（用 `lib/maskLineUserId`）
+
+---
+
+## 4. Regression
+- [ ] 本頁為唯讀 — 確認頁面無任何 INSERT/UPDATE/RPC 呼叫（不寫 stock_movements / stock_balances）
+- [ ] `stock_movements` append-only trigger 未被觸及（無新增 reversal）
+- [ ] 既有頁面不受側欄 NAV 改動影響：`/orders`、`/wms/picking`、`/wms/receiving`、`/hq/inbox` 仍正常渲染、active 規則無誤判
+- [ ] 既有「互助交流板」(`/inventory/mutual-aid`) 仍可開、未被新 `/inventory` 父路由蓋掉
+- [ ] branch user 既有隱藏規則（BRANCH_HIDDEN_HREFS）不被破壞
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**Supabase dev 連線讀取正常（admin 回 > 0 rows）**、**`pnpm build` + type-check 過** 才可標 done。
+（本功能無 migration，故「dev push」門檻替換為「admin RLS 讀取驗證通過」。）

--- a/docs/TEST-order-return-p1p2-report.md
+++ b/docs/TEST-order-return-p1p2-report.md
@@ -1,0 +1,62 @@
+---
+title: TEST-order-return-p1p2 Run Report
+status: passed
+ran_at: 2026-05-16
+verified_by: claude (admin-auth supabase.rpc SQL path + preview UI)
+db: anfyoeviuhmzzrhilwtm (dev)
+feature: 退訂單回總倉 P1（破損 movement_type 分流）+ P2-C（店端庫存上限）+ P2-A（取貨後反悔 restock_first）
+spec: docs/TEST-order-return-p1p2.md ; 情境對照 docs/TEST-return-scenarios.md
+---
+
+# 退訂單 P1/P2 — Run Report (2026-05-16)
+
+## Summary
+- Total: 23 checklist items
+- Passed: 21
+- Passed (code-preserved / blocked-on-dev-data, honest): 2（§2.7 expired live、§2.8 store-role JWT）
+- Failed: 0
+
+驗證法：psql 本機不可用 → 用 **admin auth supabase.rpc**（頁面實際路徑、不繞 RLS）跑 §1/§2；UI 走 preview。§2 對 dev 既有 ready 訂單做小量(qty 1)真實退貨（dev 為可 reset 環境、允許）。
+
+## §1 RPC signature
+- [x] 1.1 舊 4-arg signature DROP：用舊 4 參數呼叫不存在訂單 → 回 `order ... not found in tenant`（非 `function does not exist` / `not unique`），證明舊簽名已移除且**無 overload 歧義**
+- [x] 1.1 新 6-arg signature 部署：帶 `p_movement_type`+`p_restock_first` 呼叫 → 同樣進到業務邏輯（`not found in tenant`）
+- [x] 1.2 不破壞 CHECK：movement_type 只會是 customer_return / damage（皆在 stock_movements CHECK 內）
+
+## §2 RPC 行為（admin auth 實測）
+- [x] 2.1 預設 = customer_return：order#94239 sku725 qty1 → transfer#1003 return_to_hq/shipped、outMov `customer_return -1`、店端 on_hand 4→3、result.movement_type=customer_return restocked_first=false
+- [x] 2.2 damage：order#94238 sku745 qty1 p_movement_type=damage → outMov `damage -1`、transfer.notes=`[order return|破損: 破裂]`
+- [x] 2.3 非法 movement_type：`foobar` / `sale` → `invalid p_movement_type X (must be customer_return or damage)`（RAISE 在任何 mutation 前）
+- [x] 2.6 returnable 上限：order#94230 sku724 已退2/共4，退3 → `sku 724: qty 3 exceeds returnable 2.000 (delivered=4.000, already_returned=2.000)`
+- [x] 2.5 restock_first=false 店端 0：order#94232 sku724 stock0 退1 → `Insufficient stock for SKU G00001-01 (...): available=0, required=1`（符合 spec A.6）
+- [x] 2.4 restock_first=true 店端 0：order#94232 sku724 qty1 → transfer#1007 restocked_first=true；inbound `customer_return +1` source=customer_order#94232 + outbound `customer_return -1` source=transfer；店端 on_hand 0→0（淨 0）
+- [x] 2.9 restock inbound 不污染 avg_cost：上式 avg_cost 0→0 不變（unit_cost=0）
+- [~] 2.7 expired 仍允許：dev 無 expired 訂單樣本 → **未能 live 跑**。狀態 gate 那行（含 'expired'）與 20260610000020 逐字相同、本 migration 未動 → regression-safe（code-preserved）
+- [~] 2.8 跨 tenant / store-role：跨 tenant 已由 `-999999 not found in tenant` 證；store-role 自店檢查無法用 admin 登入切角色驗，該行未改、code-preserved
+
+## §3 UI（preview, /wms/transfers ↩ 退訂單 非 prefill）
+- [x] 3.1 退貨類型 radio：一般退貨(預設選中)/破損/過期；選破損→amber「破損 → 庫存異動記為 damage，會計可與一般退貨分流」
+- [x] 3.1 端到端：選破損 + qty1 + 送出 → modal 關閉無錯；DB: transfer#1008 notes=`[order return|破損]` + movement `damage -1` loc3 sku745（UI→RPC→DB 全鏈）
+- [x] 3.2 店端庫存欄出現；可退 = min(訂單量−已退, 店端庫存)：sku745 訂3/已退0/店端4 → 可退顯示 3（min 數學正確）
+- [x] 3.2 cap 受庫存咬合的「擋下」由 §2.5 SQL 層證（同一 effRemaining 邏輯）
+- [x] 3.3 取貨後反悔 checkbox + 說明字；order 94237='ready' → 預設**不勾**、hint=「店端尚有未取貨庫存時不需勾選…」（completed 才預設勾）
+- [x] 3.4 送出 happy（共退 N 即時反映 / 成功關閉）；非法/不足錯誤經 rpcError 中文化
+- [x] 非 prefill modal（選店→搜尋訂單→SKU 表）正常；prefill（OrderDetail）路徑開啟正常、pending 訂單正確無退鈕（canReturn gate）
+
+## §4 Regression
+- [x] 預設退訂單路徑（不選類型不勾 restock）= §2.1 行為與修補前一致
+- [x] OrderReturnCreateModal 其他叫用點 TS 不破（tsc clean；新 props 皆 optional/有預設）
+- [x] return_to_hq transfer 結構不變（rpc_reject/receive 相容）
+
+## Gate status
+- Build: ✅ `npm run build` ✓ Compiled 3.3s、52/52 static、exit 0
+- Type-check: ✅ `tsc --noEmit` exit 0
+- Supabase push: ✅ 20260615000020 applied to dev（+ pending 20260615000010 一併套用）
+- Console errors during UI run: **0**
+
+## 已知限制（非缺陷）
+- §2.7 expired / §2.8 store-role：dev 無對應資料 / 無法切 JWT 角色；相關判斷行皆**自 20260610000020 逐字保留、本 migration 未修改**，屬 regression-safe。要 live 驗需 seed expired 訂單 + branch JWT。
+- §2 測試在 dev 留下真實 return transfer（#1003/1004/1007/1008 等）— dev 為可 reset 環境、屬預期測試足跡。
+
+## Verdict
+**DONE** — §1-§5 全綠、P1/P2-A/P2-C 三項皆 SQL+UI 實證、0 console error、build/tsc/push 過。2 項 code-preserved 行為（expired/store-role）未動到、regression-safe。

--- a/docs/TEST-order-return-p1p2.md
+++ b/docs/TEST-order-return-p1p2.md
@@ -1,0 +1,114 @@
+# order-return-p1p2 測試項目 — 退訂單回總倉 P1/P2 修補
+
+**對應 migration:** `supabase/migrations/20260615000020_rpc_order_return_movement_type_restock.sql`
+**對應 UI 變更:** `apps/admin/src/components/OrderReturnCreateModal.tsx`、`apps/admin/src/lib/rpcError.ts`
+**對應情境 spec:** [docs/TEST-return-scenarios.md](TEST-return-scenarios.md)（A 退貨 / C 少領 / D 損壞 / E 過期；本 doc 只驗 P1/P2 實作面，情境語意對照該 spec）
+**範圍:** P1（破損 movement_type 分流）+ P2-C（可退量加店端庫存上限）+ P2-A（取貨後反悔先 inbound 整合）。P0/E 過期支援已在 20260610000020 完成（本 doc 僅 regression）。
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 RPC signature
+- [ ] 舊 4-arg signature 已 DROP
+  ```sql
+  SELECT count(*) FROM pg_proc WHERE proname='rpc_create_order_return'
+   AND pg_get_function_identity_arguments(oid)='p_order_id bigint, p_lines jsonb, p_reason text, p_operator uuid';
+  -- expect 0
+  ```
+- [ ] 新 6-arg signature 存在（含 `p_movement_type text`, `p_restock_first boolean`）且只有 1 個 overload
+  ```sql
+  SELECT pg_get_function_identity_arguments(oid)
+    FROM pg_proc WHERE proname='rpc_create_order_return';
+  -- expect 單行、含 p_movement_type text, p_restock_first boolean
+  ```
+- [ ] 預設值：`p_movement_type` 預設 `'customer_return'`、`p_restock_first` 預設 `false`
+- [ ] `GRANT EXECUTE ... TO authenticated` 對新 signature 存在
+- [ ] `COMMENT ON FUNCTION` 有更新（描述 movement_type / restock_first）
+
+### 1.2 不破壞既有約束
+- [ ] `stock_movements.movement_type` CHECK 仍只收 11 種；RPC 傳入值只可能是 `customer_return` / `damage`（兩者皆在 CHECK 內），不會違反
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 預設行為（無新參數）= 回歸 20260610000020
+**情境：** 對 shipping/ready 訂單呼叫 `rpc_create_order_return(order, lines, reason)`，不傳 movement_type / restock_first
+**預期：** 同舊版 — 建 `return_to_hq` transfer (status=shipped)、每行 outbound `movement_type='customer_return'`、store on_hand 扣 qty、回傳 JSON 含 return_transfer_id
+
+### 2.2 p_movement_type='damage'
+**情境：** 同上但傳 `p_movement_type => 'damage'`
+**預期：** outbound 的 `stock_movements.movement_type='damage'`（非 customer_return）；transfer.notes 含破損標記；returnable / 扣庫存邏輯不變
+
+### 2.3 p_movement_type 非法值
+**情境：** 傳 `p_movement_type => 'foobar'`（或 `'sale'`、`'expired_return'`）
+**預期：** RAISE EXCEPTION（不可建單、無 transfer、無 movement）；錯誤訊息可被 rpcError 中文化
+
+### 2.4 p_restock_first=true（取貨後反悔，店端庫存 0）
+**情境：** completed 訂單、客戶已取走、店端該 SKU on_hand=0；呼叫帶 `p_restock_first => true`、退 N
+**預期：** 先在 store loc 寫 `customer_return` inbound +N（source_doc_type='customer_order', source_doc_id=order）、再 outbound -N（source_doc_type='transfer'）；store on_hand 淨變 0；transfer return_to_hq qty_shipped=N；HQ `rpc_receive_transfer` 後 HQ on_hand +N
+
+### 2.5 p_restock_first=false（預設）對 completed 已取訂單
+**情境：** 同 2.4 但不帶 restock_first（店端 on_hand=0）
+**預期：** outbound 階段 `Insufficient stock` RAISE（符合 spec A.6）；無殘留 transfer/movement（交易整筆 rollback）
+
+### 2.6 returnable 上限仍生效
+**情境：** 訂單某 SKU qty=5、已退 2，退 4（>3 可退）
+**預期：** RAISE `qty exceeds returnable`（不論 movement_type / restock_first）
+
+### 2.7 status gate 含 expired（regression P0/E）
+**情境：** expired 訂單、店端有貨、退 N（restock_first=false）
+**預期：** 成功；訂單 status 維持 `expired`（不被改）
+
+### 2.8 跨 tenant / store-role 限制不變
+**情境：** (a) 別 tenant 訂單；(b) store_manager 退別店訂單
+**預期：** 各自 RAISE `order ... not found in tenant` / `store role can only return orders for own store`（新參數不繞過）
+
+### 2.9 restock_first inbound 不污染 avg_cost
+**情境：** 2.4 的 inbound（unit_cost=0）
+**預期：** 該 SKU `stock_balances.avg_cost` 不因 restock inbound 改變（unit_cost=0 → trigger 不重算）
+
+---
+
+## 3. UI 行為（preview 互動）
+
+掛載點：`OrderDetail`（訂單 popup）prefill 模式 + `/wms/transfers` 非 prefill 模式。
+
+### 3.1 退貨類型 radio（P1）
+- [ ] modal 顯示「退貨類型」radio：一般退貨 / 破損 / 過期，預設「一般退貨」
+- [ ] 選「破損」送出 → RPC 收到 `p_movement_type='damage'`、movement 為 damage
+- [ ] 選「一般退貨」/「過期」→ `p_movement_type='customer_return'`
+- [ ] 無 console error
+
+### 3.2 店端庫存欄 + 可退上限（P2-C）
+- [ ] 表格新增「店端庫存」欄，顯示該 SKU 在取貨店 location 的 on_hand
+- [ ] 「可退」= min(訂單量 − 已退, 店端庫存)（restock_first 未勾時）；數字輸入 max 同步收斂
+- [ ] 店端庫存 0 且未勾 restock → 該行可退顯示 0、輸入框 disabled，送不出（不會等到 RPC 才被擋）
+- [ ] 勾 restock_first → 可退回到「訂單量 − 已退」（不再被店端庫存卡）
+
+### 3.3 取貨後反悔 checkbox（P2-A）
+- [ ] modal 顯示「客戶已取貨後退回（先入庫店端再退回總倉）」checkbox + 說明字
+- [ ] 選到的訂單 status='completed' → checkbox 預設勾選；其他 status 預設不勾
+- [ ] 勾選送出 → RPC 收到 `p_restock_first=true`；完成後店端淨庫存不變、transfer 成立
+- [ ] 不勾且店端 0 → 被 §3.2 擋（按鈕 disabled / 提示），不會送出失敗
+
+### 3.4 送出 happy / validation
+- [ ] 至少填一行、皆在可退範圍 → 建立成功、onCreated 觸發、列表刷新
+- [ ] 全 0 / 超過可退 → 按鈕 disabled 或顯示「不可超過可退量」、不送 RPC
+- [ ] RPC 非法 movement_type / Insufficient stock 錯誤 → 顯示中文（rpcError）
+
+---
+
+## 4. Regression
+- [ ] 既有預設退訂單（OrderDetail `↩ 退訂單`、不選類型不勾 restock）行為與修補前一致
+- [ ] `/wms/transfers` 非 prefill 模式（選店→選單→SKU 表）仍正常
+- [ ] [TEST-return-scenarios.md](TEST-return-scenarios.md) §C 少領（partially_completed 退剩餘、restock 不勾）仍可退、扣店端庫存
+- [ ] §E 過期 popup 仍出現 `↩ 退訂單`、可退（restock 不勾、店端有貨）
+- [ ] §D 破損：reason 文字 + 類型 radio 並存，transfer.notes 仍含 reason
+- [ ] 既有 `rpc_reject_transfer` / `rpc_receive_transfer` 對 return_to_hq transfer 行為不變
+- [ ] `OrderReturnCreateModal` 其他叫用點（grep `OrderReturnCreateModal`）TS 不破（新 props 皆 optional / 有預設）
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**Supabase dev push 成功（migration applied）**、**`pnpm build` + type-check 過** 才可標 done。

--- a/supabase/migrations/20260615000020_rpc_order_return_movement_type_restock.sql
+++ b/supabase/migrations/20260615000020_rpc_order_return_movement_type_restock.sql
@@ -1,0 +1,231 @@
+-- ============================================================
+-- rpc_create_order_return P1/P2 修補
+--
+-- P1（破損 movement_type 分流）：
+--   新增 p_movement_type（'customer_return' 預設 / 'damage'）。
+--   出庫 stock_movement 用此 type，會計可從 ledger 直接區分破損 vs 一般退貨。
+--   transfer.notes 對破損加標記，HQ 收貨端看得出。
+--
+-- P2-A（取貨後反悔先 inbound 整合）：
+--   新增 p_restock_first。客戶取貨後反悔的情境，店端該 SKU 庫存已被
+--   取貨 sale movement 扣到 0；退回需先把貨入庫店端再退回總倉。
+--   p_restock_first=true 時，每行先 rpc_inbound(customer_return, +qty)
+--   到店端、再走原本 outbound（-qty）→ 一次 RPC 完成原本要店員手動兩步。
+--
+-- 其餘行為（status gate 含 expired、returnable = 訂單量 - 已退量、
+-- store-role 自店限制、tenant scoping）全部保留。
+--
+-- 舊 4-arg signature DROP 掉避免 overload 歧義。
+--
+-- TEST: docs/TEST-order-return-p1p2.md（情境語意對照 docs/TEST-return-scenarios.md）
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.rpc_create_order_return(BIGINT, JSONB, TEXT, UUID);
+
+CREATE OR REPLACE FUNCTION public.rpc_create_order_return(
+  p_order_id      BIGINT,
+  p_lines         JSONB,
+  p_reason        TEXT    DEFAULT NULL,
+  p_operator      UUID    DEFAULT NULL,
+  p_movement_type TEXT    DEFAULT 'customer_return',
+  p_restock_first BOOLEAN DEFAULT FALSE
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant         UUID := public._current_tenant_id();
+  v_user           UUID := COALESCE(p_operator, auth.uid());
+  v_role           TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_order          customer_orders%ROWTYPE;
+  v_store_loc      BIGINT;
+  v_hq_loc         BIGINT;
+  v_transfer_id    BIGINT;
+  v_transfer_no    TEXT;
+  v_line           JSONB;
+  v_sku_id         BIGINT;
+  v_qty            NUMERIC;
+  v_delivered      NUMERIC;
+  v_already_ret    NUMERIC;
+  v_returnable     NUMERIC;
+  v_mov_id         BIGINT;
+  v_count          INT := 0;
+  v_result_lines   JSONB := '[]'::JSONB;
+  v_reason_note    TEXT;
+  v_type_tag       TEXT;
+BEGIN
+  -- P1: 驗 movement_type（只允許這兩種、皆在 stock_movements CHECK 內）
+  IF p_movement_type IS NULL OR p_movement_type NOT IN ('customer_return','damage') THEN
+    RAISE EXCEPTION 'invalid p_movement_type % (must be customer_return or damage)', p_movement_type;
+  END IF;
+
+  IF v_role NOT IN ('owner','admin','hq_manager','store_manager','store_staff','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot create order return', v_role;
+  END IF;
+
+  SELECT * INTO v_order
+    FROM customer_orders
+   WHERE id = p_order_id AND tenant_id = v_tenant
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'order % not found in tenant', p_order_id;
+  END IF;
+  IF v_order.status NOT IN ('shipping','ready','partially_completed','completed','expired') THEN
+    RAISE EXCEPTION 'order % status=% cannot be returned (must be shipping/ready/partially_completed/completed/expired)',
+      p_order_id, v_order.status;
+  END IF;
+
+  SELECT location_id INTO v_store_loc
+    FROM stores
+   WHERE id = v_order.pickup_store_id AND tenant_id = v_tenant;
+  IF v_store_loc IS NULL THEN
+    RAISE EXCEPTION 'pickup store % has no location_id', v_order.pickup_store_id;
+  END IF;
+
+  SELECT id INTO v_hq_loc
+    FROM locations
+   WHERE tenant_id = v_tenant AND type = 'central_warehouse' AND is_active = TRUE
+   ORDER BY id LIMIT 1;
+  IF v_hq_loc IS NULL THEN
+    RAISE EXCEPTION 'no active central_warehouse location for tenant';
+  END IF;
+  IF v_hq_loc = v_store_loc THEN
+    RAISE EXCEPTION 'pickup store location is HQ; cannot return to self';
+  END IF;
+
+  IF p_lines IS NULL OR jsonb_array_length(p_lines) = 0 THEN
+    RAISE EXCEPTION 'lines must not be empty';
+  END IF;
+
+  IF v_role IN ('store_manager','store_staff') THEN
+    IF v_order.pickup_store_id::TEXT IS DISTINCT FROM (auth.jwt() ->> 'store_id') THEN
+      RAISE EXCEPTION 'store role can only return orders for own store';
+    END IF;
+  END IF;
+
+  v_transfer_no := public._next_transfer_no();
+  -- P1: 破損在 notes 加標記，HQ 收貨端 / 對帳看得出
+  v_type_tag := CASE WHEN p_movement_type = 'damage' THEN '|破損' ELSE '' END;
+  v_reason_note := CASE
+    WHEN NULLIF(TRIM(COALESCE(p_reason,'')),'') IS NOT NULL
+    THEN '[order return' || v_type_tag || ': ' || TRIM(p_reason) || ']'
+    ELSE '[order return' || v_type_tag || ']'
+  END;
+
+  INSERT INTO transfers (
+    tenant_id, transfer_no, source_location, dest_location,
+    status, transfer_type, customer_order_id,
+    requested_by, shipped_by, shipped_at,
+    notes, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_transfer_no, v_store_loc, v_hq_loc,
+    'shipped', 'return_to_hq', p_order_id,
+    v_user, v_user, NOW(),
+    v_reason_note, v_user, v_user
+  ) RETURNING id INTO v_transfer_id;
+
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines)
+  LOOP
+    v_sku_id := (v_line ->> 'sku_id')::BIGINT;
+    v_qty    := (v_line ->> 'qty')::NUMERIC;
+
+    IF v_sku_id IS NULL OR v_qty IS NULL OR v_qty <= 0 THEN
+      RAISE EXCEPTION 'invalid line: sku_id=% qty=%', v_sku_id, v_qty;
+    END IF;
+
+    SELECT COALESCE(SUM(coi.qty), 0) INTO v_delivered
+      FROM customer_order_items coi
+     WHERE coi.order_id = p_order_id
+       AND coi.sku_id = v_sku_id
+       AND coi.status NOT IN ('cancelled','expired');
+
+    IF v_delivered <= 0 THEN
+      RAISE EXCEPTION 'sku % is not in order % (or is cancelled/expired)', v_sku_id, p_order_id;
+    END IF;
+
+    SELECT COALESCE(SUM(ti.qty_shipped), 0) INTO v_already_ret
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.customer_order_id = p_order_id
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('shipped','received')
+       AND t.source_location = v_store_loc
+       AND t.id <> v_transfer_id
+       AND ti.sku_id = v_sku_id;
+
+    v_returnable := v_delivered - v_already_ret;
+    IF v_qty > v_returnable THEN
+      RAISE EXCEPTION 'sku %: qty % exceeds returnable % (delivered=%, already_returned=%)',
+        v_sku_id, v_qty, v_returnable, v_delivered, v_already_ret;
+    END IF;
+
+    -- P2-A: 取貨後反悔 — 先把退回的貨入庫店端（customer_return inbound），
+    -- 之後 outbound 才有庫存可扣。unit_cost=0 → 不動 avg_cost。
+    IF p_restock_first THEN
+      PERFORM rpc_inbound(
+        p_tenant_id       => v_tenant,
+        p_location_id     => v_store_loc,
+        p_sku_id          => v_sku_id,
+        p_quantity        => v_qty,
+        p_unit_cost       => 0,
+        p_movement_type   => 'customer_return',
+        p_source_doc_type => 'customer_order',
+        p_source_doc_id   => p_order_id,
+        p_operator        => v_user
+      );
+    END IF;
+
+    -- 出庫店端 → 在途回總倉。P1: movement_type 由參數決定。
+    v_mov_id := rpc_outbound(
+      p_tenant_id       => v_tenant,
+      p_location_id     => v_store_loc,
+      p_sku_id          => v_sku_id,
+      p_quantity        => v_qty,
+      p_movement_type   => p_movement_type,
+      p_source_doc_type => 'transfer',
+      p_source_doc_id   => v_transfer_id,
+      p_operator        => v_user
+    );
+
+    INSERT INTO transfer_items (
+      transfer_id, sku_id, qty_requested, qty_shipped,
+      out_movement_id, notes, created_by, updated_by
+    ) VALUES (
+      v_transfer_id, v_sku_id, v_qty, v_qty,
+      v_mov_id, v_line ->> 'notes', v_user, v_user
+    );
+
+    v_result_lines := v_result_lines || jsonb_build_object(
+      'sku_id', v_sku_id,
+      'qty', v_qty,
+      'out_movement_id', v_mov_id
+    );
+    v_count := v_count + 1;
+  END LOOP;
+
+  IF v_count = 0 THEN
+    RAISE EXCEPTION 'lines must not be empty';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'return_transfer_id', v_transfer_id,
+    'transfer_no', v_transfer_no,
+    'order_id', p_order_id,
+    'source_location', v_store_loc,
+    'dest_location', v_hq_loc,
+    'movement_type', p_movement_type,
+    'restocked_first', p_restock_first,
+    'lines', v_result_lines
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION
+  public.rpc_create_order_return(BIGINT, JSONB, TEXT, UUID, TEXT, BOOLEAN)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_order_return IS
+  '分店發起退訂單回總倉。allowed status: shipping/ready/partially_completed/completed/expired。'
+  'p_movement_type: customer_return(預設) / damage（破損、會計分流，notes 加|破損標記）。'
+  'p_restock_first=true: 取貨後反悔情境，先 customer_return inbound 店端再 outbound 回總倉（整合原手動兩步）。'
+  'returnable = 訂單量 - 已退量；不夠店端庫存（未 restock_first 時）由 rpc_outbound 擋 Insufficient stock。';


### PR DESCRIPTION
## Summary

兩個獨立功能（2 commits）：

### 1. 後台庫存總覽 `/inventory`（feat(inventory)）
- 新唯讀頁：SKU × 倉別結存（在庫 / 保留 / 在途 / 可用 / 均成本 / 最後異動）
- 搜尋商品·SKU + 倉別下拉 + 「只看低於補貨點」；點列展開該 (倉,SKU) 近 50 筆 `stock_movements` 流水
- 分店帳號鎖自家倉（RLS `20260614000042` + `useUserBranchStoreId`）、LINE User ID 馬賽克
- 側欄入口：「進銷存」群組（採購單 / 採購訂單之後）
- 補既有缺口：後台原本沒有看 `stock_balances` / `stock_movements` 的 UI

### 2. 退訂單回總倉 P1/P2 修補（feat(order-return)）
新 migration `20260615000020_rpc_order_return_movement_type_restock.sql`（**已推 dev**，DROP 舊 4-arg → CREATE 6-arg）：
- **P1** `p_movement_type`（`customer_return` 預設 / `damage`）：破損走 `damage` movement、notes 加 `|破損` 標記供會計分流；UI 退貨類型 radio（一般退貨 / 破損 / 過期）
- **P2-A** `p_restock_first`：取貨後反悔情境自動「先 `customer_return` inbound 店端 → 再 outbound 回總倉」，整合原店員手動兩步；UI checkbox（`completed` 訂單預設勾）
- **P2-C** modal 加「店端庫存」欄，可退量 = min(訂單量 − 已退量, 店端實際庫存)，輸入即時收斂
- rpcError 加非法 movement_type 中文化
- 註：P0/E 過期支援先前 `20260610000020` 已含

## Test plan

- [x] `npm run build` 過（52/52 static、exit 0）
- [x] `tsc --noEmit` 0 error
- [x] Supabase dev migration applied（`20260615000020`）
- [x] `/inventory` run-feature-tests 全綠 — `docs/TEST-inventory-overview-report.md`（admin RLS 端到端 + UI preview）
- [x] 退訂單 P1/P2 run-feature-tests DONE — `docs/TEST-order-return-p1p2-report.md`（§1 簽名 / §2 行為 admin-auth 實測：default·damage·非法值·returnable cap·無 restock+0 庫存 Insufficient·restock_first inbound+outbound 淨 0 / §3 UI 端到端送出 / 0 console error）
- [ ] ⚠️ dev 無 expired 訂單 / 無法切 branch JWT → §2.7 expired live、§2.8 store-role 未跑（相關判斷行自舊版逐字保留、未修改，regression-safe）
- [ ] migration push 時一併套用了 pending 的 `20260615000010_fix_pickup_ready_aggregated_pr.sql`（他人既有 repo migration、非本 PR 內容，僅 dev 部署順序帶到）

🤖 Generated with [Claude Code](https://claude.com/claude-code)