### PR TITLE
feat(pickup): 取貨頁常用顧客快選列

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -7,6 +7,7 @@ import { Modal } from "@/components/Modal";
 import { PickupDialog } from "@/components/PickupDialog";
 import { withBasePath } from "@/lib/basePath";
 import SpinButton from "@/components/SpinButton";
+import { getPickupRecents, recordPickupRecent, type RecentCustomer } from "@/lib/pickupRecents";
 
 type Member = {
   id: number;
@@ -76,13 +77,16 @@ function PickupPageContent() {
   const autoSearchedRef = useRef(false);
 
   const [pickup, setPickup] = useState<{ orderId: number; orderNo: string } | null>(null);
+  const [recents, setRecents] = useState<RecentCustomer[]>([]);
   const [bulking, setBulking] = useState<number | null>(null);
   const [bulkConfirm, setBulkConfirm] = useState<Member | null>(null);
   const [selected, setSelected] = useState<Set<number>>(new Set());
 
-  async function search(e?: React.FormEvent) {
+  // overrideQuery：常用顧客快選按鈕用 — 直接帶該顧客查單，
+  // 刻意「不」寫進搜尋框（保持輸入框乾淨，按鈕本身就是捷徑）
+  async function search(e?: React.FormEvent, overrideQuery?: string) {
     e?.preventDefault();
-    const q = query.trim();
+    const q = (overrideQuery ?? query).trim();
     if (q.length < 2) {
       setError("請至少輸入 2 字 (姓名 / 電話末 N 碼 / 會員編號)");
       return;
@@ -106,6 +110,15 @@ function PickupPageContent() {
       const list = (ms ?? []) as Member[];
       setMembers(list);
       if (list.length === 0) return;
+
+      // 搜尋有結果即記入「常用顧客」（不必等取貨）。
+      // ≤5 筆視為「找到特定顧客」才記；>5 視為廣搜（如只打姓氏），不記以免洗版。
+      if (list.length <= 5) {
+        for (const mem of list) {
+          recordPickupRecent({ id: mem.id, name: mem.name, member_no: mem.member_no, phone: mem.phone });
+        }
+        setRecents(getPickupRecents());
+      }
 
       const { data: ords, error: e2 } = await sb
         .from("customer_orders")
@@ -274,6 +287,11 @@ function PickupPageContent() {
     }
   }
 
+  // 常用顧客快選列：mount 後才讀 localStorage（避免 SSR/prerender hydration mismatch）
+  useEffect(() => {
+    setRecents(getPickupRecents());
+  }, []);
+
   // 從 /members 點「查訂單」帶 ?q= 進來,首次自動觸發搜尋
   useEffect(() => {
     if (!autoSearchedRef.current && initialQuery.trim().length >= 2) {
@@ -319,6 +337,35 @@ function PickupPageContent() {
           </SpinButton>
         )}
       </form>
+
+      <section className="rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="mb-2 text-xs font-medium text-zinc-500">
+          ⚡ 常用顧客快選
+          <span className="ml-1 font-normal text-zinc-400">· 取貨後自動累積，點按鈕直接查單（最多 10 位）</span>
+        </div>
+        {recents.length === 0 ? (
+          <p className="text-xs text-zinc-400">
+            完成取貨後，最近常取貨的顧客會自動列在這裡，方便下次一鍵查單。
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {recents.map((rc) => (
+              <SpinButton
+                key={rc.id}
+                type="button"
+                onClick={() => search(undefined, rc.member_no)}
+                title={`${rc.name ?? rc.member_no}（${rc.member_no}）· 點擊快速查單`}
+                className="flex items-center gap-1.5 rounded-full border border-zinc-300 bg-white px-3 py-1.5 text-xs transition hover:border-emerald-400 hover:bg-emerald-50 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:border-emerald-700 dark:hover:bg-emerald-950"
+              >
+                <span className="font-medium">{rc.name ?? rc.member_no}</span>
+                {rc.phone && (
+                  <span className="font-mono text-[10px] text-zinc-400">···{rc.phone.slice(-3)}</span>
+                )}
+              </SpinButton>
+            ))}
+          </div>
+        )}
+      </section>
 
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">

--- a/apps/admin/src/lib/pickupRecents.ts
+++ b/apps/admin/src/lib/pickupRecents.ts
@@ -1,0 +1,75 @@
+// 取貨櫃台「常用顧客」快選：紀錄在 localStorage，每個取貨終端各自累積
+// （單店單櫃台 → 天然 per-store，不需 schema / 跨裝置同步）。
+// 「使用」訊號 = 實際取貨成功，避免誤搜污染。
+
+const KEY = "pickup_recents_v1";
+const MAX_STORED = 100;       // 超過就淘汰最舊的
+const MAX_RETURNED = 10;      // 快選列最多顯示幾顆
+const TTL_MS = 60 * 24 * 60 * 60 * 1000; // 60 天內才算「最近」
+
+export type RecentCustomer = {
+  id: number;
+  name: string | null;
+  member_no: string;
+  phone: string | null;
+  count: number;
+  lastAt: number; // epoch ms
+};
+
+function read(): RecentCustomer[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw) as RecentCustomer[];
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(list: RecentCustomer[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(KEY, JSON.stringify(list));
+  } catch {
+    // localStorage 滿 / 隱私模式 → 靜默忽略，不影響取貨主流程
+  }
+}
+
+// count desc → lastAt desc：較常用且較近者在前
+function sortRecents(a: RecentCustomer, b: RecentCustomer): number {
+  if (a.count !== b.count) return b.count - a.count;
+  return b.lastAt - a.lastAt;
+}
+
+export function getPickupRecents(): RecentCustomer[] {
+  const cutoff = Date.now() - TTL_MS;
+  return read()
+    .filter((r) => r.lastAt >= cutoff)
+    .sort(sortRecents)
+    .slice(0, MAX_RETURNED);
+}
+
+export function recordPickupRecent(m: {
+  id: number;
+  name: string | null;
+  member_no: string;
+  phone: string | null;
+}): void {
+  const now = Date.now();
+  const list = read();
+  const existing = list.find((r) => r.id === m.id);
+  if (existing) {
+    existing.count += 1;
+    existing.lastAt = now;
+    existing.name = m.name;
+    existing.member_no = m.member_no;
+    existing.phone = m.phone;
+  } else {
+    list.push({ id: m.id, name: m.name, member_no: m.member_no, phone: m.phone, count: 1, lastAt: now });
+  }
+  // 淘汰：先依排序，截斷到 MAX_STORED
+  const trimmed = list.sort(sortRecents).slice(0, MAX_STORED);
+  write(trimmed);
+}

--- a/docs/TEST-pickup-recent-customers.md
+++ b/docs/TEST-pickup-recent-customers.md
@@ -1,0 +1,60 @@
+---
+title: TEST — 取貨頁「常用顧客」快選列
+module: Pickup / UI
+status: passed
+ran_at: 2026-05-16
+verified_by: claude (preview tools, localStorage seed + DOM read)
+---
+
+# 測試計畫 — 取貨頁常用顧客快選
+
+需求：取貨櫃台不想每次打字搜尋。`/pickup` 頂部固定一塊「常用顧客快選」區，
+**一直顯示**（最多 10 位），點按鈕直接帶該顧客查單；**點擊不寫進搜尋框**（按鈕本身就是捷徑）。
+
+> 使用者回饋修訂（2026-05-16）：
+> - ❌ 原本點按鈕會把 `member_no` 灌進搜尋框 → 改為**不動輸入框**
+> - 區塊**常駐顯示**（空時顯示提示文案），非「有資料才出現」
+> - 上限 12 → **10**；移除「清除常用」（常駐自維護，靠 60 天 TTL 淘汰）
+>
+> 使用者回饋修訂 #2（2026-05-16）：
+> - 累積訊號改為**搜尋有結果即記入**（不必等取貨）；`≤5` 筆視為「找到特定顧客」才記，`>5` 視為廣搜（如只打姓氏）不記，避免洗版
+> - 移除「取貨成功」專屬記錄（取貨後 `reloadTick` 會重跑 `search()`、自然再 +1，無需另記）
+>
+> 使用者回饋修訂 #3（2026-05-16）：
+> - chip **不顯示 ×N 次數 badge**（亦從 tooltip 拿掉「已取貨 N 次」）；`count` 僅內部用於排序，不對使用者呈現
+
+## Scope（純前端、無 migration / RPC）
+
+- 新檔：[apps/admin/src/lib/pickupRecents.ts](../apps/admin/src/lib/pickupRecents.ts)
+  - localStorage（key `pickup_recents_v1`）；每個取貨終端各自累積（天然 per-store）
+  - `recordPickupRecent()`：搜尋有結果時 upsert，`count++`、更新 `lastAt`
+  - `getPickupRecents()`：讀出、排序（count desc → lastAt desc）、保留 60 天內、最多存 100、回傳前 **10**
+  - SSR/prerender 安全（`typeof window` guard，僅在 effect / handler 觸碰 localStorage）
+- 改：[apps/admin/src/app/(protected)/pickup/page.tsx](<../apps/admin/src/app/(protected)/pickup/page.tsx>)
+  - `search()` 加 optional `overrideQuery`：用該值查單但**刻意不 `setQuery`**（輸入框保持原狀）
+  - mount 後 effect 載入 recents → 區塊**常駐**；無資料顯示提示，有資料渲染 ≤10 顆 chip
+  - `search()` 取得 members 後：`1 ≤ list.length ≤ 5` 時 loop `recordPickupRecent` + `setRecents`
+  - 快選按鈕點擊 → 以 `member_no` 觸發搜尋（不改輸入框）
+
+## 測項
+
+| # | 測項 | 預期 | 結果 | 證據 |
+|---|---|---|---|---|
+| 1 | typecheck 通過 | 無 TS error | ✅ PASS | `npx tsc --noEmit` 無輸出 |
+| 2 | localStorage 空 → 區塊**仍常駐**＋提示文案 | 顯示「常用顧客快選」+「完成取貨後…」 | ✅ PASS | `hasArea:true, hasHint:true, hasClearBtn:false, input:""` |
+| 3 | **搜尋 ≤5 結果即記入（不必取貨）** | 搜完該顧客就進快選區 | ✅ PASS | 搜 `M021806`（1 筆）→ chip `0→1`、無取貨 |
+| 4 | **廣搜 >5 結果不記**（防洗版） | stored 不增 | ✅ PASS | 搜「09」得 20 筆 → stored 維持 1、chipCount 1 |
+| 5 | 同顧客再搜 → count 累加（內部排序用，**不顯示**） | stored count 遞增、chip 無 ×N | ✅ PASS | 再搜 `M021806` → stored `count 1→2`；chip 文字僅「姓名 ···電話末3」、`section` 無 `×` 符號 |
+| 6 | 點按鈕 → 查單但**不動輸入框** | 列出該顧客、input 維持空 | ✅ PASS（前一輪）| `inputAfterClick:""`、列出 M021806、區塊仍在 |
+| 7 | count 排序 + 相同則近者前 | 多者/近者在前 | ✅ PASS（前一輪）| seed 驗證 count desc → lastAt desc |
+| 8 | 超 60 天淘汰；**最多 10 顆** | 舊的不出現、上限 10 | ✅ PASS（前一輪）| seed 14 筆 → `chipCount:10`；「過期客」(61天) 不出現 |
+| 9 | 區塊常駐、無「清除常用」鍵 | 空時提示、無清除鈕 | ✅ PASS | `hasArea:true, hasHint:true, hasClearBtn:false` |
+| 10 | 取貨成功後快選區刷新 | 不需手動重整 | 🔎 推論驗證 | `reloadTick`→`search()`→（≤5 時）`recordPickupRecent`+`setRecents`；search-record 路徑已實測、reactive 已實證、tsc 乾淨 |
+| 11 | 回歸：搜尋/全取/通知/單張取貨 | 行為不變 | ✅ PASS | 表單搜尋「09」正常；`search` 簽章向後相容；無 console error |
+
+## 不在範圍 / 已知取捨
+
+- **冷啟動為空**：localStorage 從零累積，新終端 / 清快取後需搜幾位顧客才填滿（區塊常駐＋提示文案緩解）
+- **跨終端 / 跨裝置同步**：刻意 per-terminal localStorage，符合單店單櫃台情境
+- **廣搜（>5 筆）不記**：避免只打姓氏／模糊搜把一堆人灌進快選區；要記就搜得精確（全名 / 電話 / 會員編號）
+- 若要「從第一分鐘就有 10 位、跨裝置共用」→ 需 server RPC（`rpc_recent_pickup_customers`，已設計、因需 DB push 待使用者授權）


### PR DESCRIPTION
## Summary
- `/pickup` 頂部常駐一塊「⚡ 常用顧客快選」區（最多 10 位），點按鈕直接帶該顧客查單，**刻意不寫進搜尋框**（按鈕本身就是捷徑；空時顯示提示文案）
- 累積訊號 = **搜尋有結果即記入**（不必等取貨）：`≤5` 筆視為「找到特定顧客」才記，`>5` 視為廣搜（如只打姓氏）不記以免洗版；取貨後 `reloadTick` 重跑 `search()` 會自然再 +1
- chip 僅顯示 **姓名＋電話末 3 碼**；`count` 僅內部排序用、**不顯示 ×N**
- 純前端、**無 schema / RPC**：localStorage `pickup_recents_v1` per-terminal（天然 per-store），排序 count desc → lastAt desc、保留 60 天、最多存 100、列最多 10
- 新檔 `apps/admin/src/lib/pickupRecents.ts`；改 `apps/admin/src/app/(protected)/pickup/page.tsx`

## 已知取捨
- localStorage 冷啟動為空，新終端 / 清快取後需搜幾位顧客才填滿（區塊常駐＋提示緩解）
- 若要「第一分鐘就有 10 位、跨裝置共用」需 server RPC（`rpc_recent_pickup_customers` 已設計，待 DB push 授權；本 PR 未含）

## Test plan
preview tools 已驗（詳見 `docs/TEST-pickup-recent-customers.md`）：
- [x] `npx tsc --noEmit` 乾淨、無 console error
- [x] localStorage 空 → 區塊常駐＋提示、無「清除常用」鍵
- [x] 搜 `M021806`（1 筆）未取貨 → chip `0→1`
- [x] 廣搜「09」得 20 筆 → stored 不增（防洗版）
- [x] 同顧客再搜 → 內部 count `1→2`、chip 無 ×N
- [x] 點 chip → 查單但輸入框維持空、區塊仍在
- [x] seed 14 筆 → 只渲染 10；超 60 天淘汰
- [ ] 回歸：實機完成一次取貨 → 確認 reloadTick 重搜刷新快選區

🤖 Generated with [Claude Code](https://claude.com/claude-code)