### PR TITLE
feat(member/shop): 排序頁籤 + 訂單數 RPC + 補回 #229 漏合 shop 修正

### DIFF
--- a/apps/member/src/app/shop/flash/page.tsx
+++ b/apps/member/src/app/shop/flash/page.tsx
@@ -42,13 +42,16 @@ export default function FlashPage() {
     })();
   }, [router]);
 
-  const hero = campaigns[0];
+  // 前端防線：擋掉內部 sentinel 活動（__INTERNAL_RESTOCK__ 等），
+  // 與 /shop 一致；後端 liff-api 也有濾。
+  const visible = campaigns.filter((c) => !c.campaign_no.startsWith("__"));
+  const hero = visible[0];
 
   return (
     <PageShell title="限時專區">
       {/* 結束於 sticky banner */}
       {hero && hero.end_at && (
-        <div className="sticky top-[78px] z-10 -mt-1 flex items-center justify-between gap-3 bg-gradient-to-r from-[#ff3b30] to-[#ff9500] px-4 py-2.5 text-white shadow">
+        <div className="sticky top-[78px] z-10 -mt-1 flex items-center justify-between gap-3 brand-gradient px-4 py-2.5 text-white shadow">
           <div className="text-[15px] font-medium">最快結束於</div>
           <div className="text-[20px] font-bold">
             <Countdown target={hero.end_at} compact className="text-white" />
@@ -67,7 +70,7 @@ export default function FlashPage() {
           </div>
         )}
 
-        {!loading && !err && campaigns.length === 0 && (
+        {!loading && !err && visible.length === 0 && (
           <div className="overflow-hidden rounded-2xl bg-gradient-to-br from-[#ff3b30]/8 to-[#ff9500]/8 p-6 text-center">
             <div className="text-5xl">📣</div>
             <h2 className="mt-3 text-[18px] font-semibold text-[var(--foreground)]">
@@ -89,7 +92,7 @@ export default function FlashPage() {
           <CampaignCard campaign={hero} variant="hero" />
         )}
 
-        {campaigns.slice(1).map((c) => (
+        {visible.slice(1).map((c) => (
           <FlashRow key={c.id} campaign={c} />
         ))}
       </div>

--- a/apps/member/src/app/shop/page.tsx
+++ b/apps/member/src/app/shop/page.tsx
@@ -15,6 +15,7 @@ export default function ShopPage() {
   const [campaigns, setCampaigns] = useState<CampaignSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<"new" | "hot" | "recent">("new");
 
   const fetchCampaigns = useCallback(async () => {
     const s = getSession();
@@ -41,8 +42,24 @@ export default function ShopPage() {
     })();
   }, [fetchCampaigns]);
 
-  // 結單最近的那張當 hero(限時專區封面)
-  const hero = campaigns[0];
+  // 前端防線：擋掉內部 sentinel 活動（campaign_no 以 __ 開頭，如
+  // __INTERNAL_RESTOCK__「【內部】補貨申請」）。後端 liff-api 也有濾，
+  // 這層確保即使 edge function 還沒部署也不會外漏給顧客。
+  const visible = campaigns.filter((c) => !c.campaign_no.startsWith("__"));
+
+  // 「限時專區」banner 只在真的有快閃團(close_type='fast')時才出現。
+  // /shop/flash 那頁只撈 close_type='fast'，若這裡用 visible[0](任何團)
+  // 當 hero，會出現 banner 但點進去是空的。清單已 by end_at asc 排序，
+  // find 取到的就是最快結單的快閃團。
+  const hero = visible.find((c) => c.close_type === "fast");
+
+  // 排序：最新(id 大→小，無 created_at 用 id 近似) / 最熱銷(全分店訂單數)
+  // / 近期售出(近 7 天訂單數)。tie-break 回退 id desc 保持穩定。
+  const sorted = [...visible].sort((a, b) => {
+    if (sortBy === "hot") return (b.order_count - a.order_count) || (b.id - a.id);
+    if (sortBy === "recent") return (b.recent_order_count - a.recent_order_count) || (b.id - a.id);
+    return b.id - a.id;
+  });
 
   return (
     <PageShell title="商品">
@@ -71,7 +88,7 @@ export default function ShopPage() {
           </div>
         )}
 
-        {!loading && !err && campaigns.length === 0 && (
+        {!loading && !err && visible.length === 0 && (
           <div className="flex flex-col items-center py-20 text-center">
             <div
               className="flex h-24 w-24 items-center justify-center rounded-full text-5xl"
@@ -95,10 +112,10 @@ export default function ShopPage() {
         {hero && (
           <Link
             href="/shop/flash"
-            className="block overflow-hidden rounded-2xl shadow-[0_10px_28px_-10px_rgba(255,59,48,0.55)] transition-transform duration-200 active:scale-[0.985]"
+            className="block overflow-hidden rounded-2xl shadow-[0_10px_28px_-10px_rgba(158,47,80,0.5)] transition-transform duration-200 active:scale-[0.985]"
           >
             <div className="relative">
-              <div className="relative aspect-[16/8] w-full bg-gradient-to-br from-[#ff5a4f] via-[#ff3b30] to-[#ff9500]">
+              <div className="relative aspect-[16/8] w-full brand-gradient">
                 {hero.cover_image_url && (
                   // eslint-disable-next-line @next/next/no-img-element
                   <img
@@ -129,20 +146,41 @@ export default function ShopPage() {
           </Link>
         )}
 
-        {/* 進行中商品 grid */}
-        {campaigns.length > 0 && (
+        {/* 團購商品 + 排序 */}
+        {visible.length > 0 && (
           <section>
-            <div className="flex items-baseline justify-between px-1 pb-3">
-              <h2 className="flex items-center gap-2 text-[20px] font-bold text-[var(--foreground)]">
-                <span className="h-5 w-1 rounded-full brand-gradient" aria-hidden />
-                進行中商品
+            <div className="flex items-baseline justify-between px-1 pb-2.5">
+              <h2 className="text-[22px] font-bold tracking-tight text-[var(--foreground)]">
+                團購商品 💕
               </h2>
               <span className="text-[13px] font-medium text-[var(--secondary-label)]">
-                {campaigns.length} 團
+                {visible.length} 團
               </span>
             </div>
+            <div className="flex gap-2 px-1 pb-3">
+              {([
+                ["new", "最新"],
+                ["hot", "最熱銷"],
+                ["recent", "近期售出"],
+              ] as const).map(([v, label]) => {
+                const active = sortBy === v;
+                return (
+                  <button
+                    key={v}
+                    onClick={() => setSortBy(v)}
+                    className={`rounded-full px-4 py-1.5 text-[14px] transition-colors ${
+                      active
+                        ? "brand-gradient font-bold text-white shadow-[0_6px_14px_-6px_rgba(158,47,80,0.6)]"
+                        : "border border-[var(--separator)] bg-[var(--card-bg)] font-medium text-[var(--secondary-label)] active:bg-[var(--brand-soft)]/40"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
             <div className="grid grid-cols-2 gap-3">
-              {campaigns.map((c, i) => (
+              {sorted.map((c, i) => (
                 <div
                   key={c.id}
                   className="animate-in"

--- a/apps/member/src/components/CampaignCard.tsx
+++ b/apps/member/src/components/CampaignCard.tsx
@@ -12,6 +12,10 @@ export type CampaignSummary = {
   close_type: "regular" | "fast" | "limited" | string;
   total_cap_qty: number | null;
   ordered_qty: number;
+  /** 全分店訂單數（最熱銷排序用）。後端未部署前可能為 0。 */
+  order_count: number;
+  /** 近 7 天訂單數（近期售出排序用）。 */
+  recent_order_count: number;
   end_at: string | null;
   pickup_deadline: string | null;
   item_count: number;
@@ -19,12 +23,14 @@ export type CampaignSummary = {
   max_price: number;
 };
 
-/** 依 close_type + end_at + total_cap_qty 算出短標籤 */
+/** 依 close_type + total_cap_qty 算出短標籤。
+ *  「限時」只給真正的快閃團（close_type='fast'，即限時專區那種）。
+ *  一般團幾乎都有結單日(end_at)，有結單日 ≠ 限時，否則每張卡都被貼標、
+ *  標籤就失去意義（卡片本來就會單獨顯示倒數）。 */
 export function campaignBadgeLabel(c: CampaignSummary): string | null {
   const hasCap = (c.total_cap_qty ?? 0) > 0;
-  const hasEnd = !!c.end_at;
   if (c.close_type === "fast" && hasCap) return "限量限時";
-  if (c.close_type === "fast" || hasEnd) return "限時";
+  if (c.close_type === "fast") return "限時";
   if (c.close_type === "limited" || hasCap) return "限量";
   return null;
 }
@@ -207,8 +213,12 @@ export default function CampaignCard({
           {priceText}
         </div>
         {campaign.end_at && (
-          <div className="text-[13px] text-[var(--secondary-label)]">
-            <Countdown target={campaign.end_at} />
+          <div className="inline-flex items-center gap-1 rounded-md bg-[var(--brand-soft)] px-2 py-1 text-[14px] font-bold tabular-nums text-[var(--brand-strong)]">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2} className="h-3.5 w-3.5 shrink-0">
+              <circle cx="12" cy="12" r="9" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 7.5V12l3 2" />
+            </svg>
+            <Countdown target={campaign.end_at} compact />
           </div>
         )}
       </div>

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -326,6 +326,20 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
       orderedMap.set(Number(o.campaign_id), (orderedMap.get(Number(o.campaign_id)) ?? 0) + sum);
     }
   }
+
+  // 全分店訂單數 + 近 7 天訂單數（顧客端排序用：最熱銷 / 近期售出）。
+  // 走 SQL 聚合 RPC，避免訂單列數超過 PostgREST 1000 上限被截斷而計數失準。
+  const countMap = new Map<number, number>();
+  const recentMap = new Map<number, number>();
+  const { data: cntRows } = await sb.rpc("rpc_member_campaign_order_counts", {
+    p_tenant: tenantId,
+    p_recent_days: 7,
+  });
+  for (const r of cntRows ?? []) {
+    countMap.set(Number(r.campaign_id), Number(r.order_count ?? 0));
+    recentMap.set(Number(r.campaign_id), Number(r.recent_order_count ?? 0));
+  }
+
   if (error) return json({ error: error.message }, 500);
 
   const supabaseUrl = requireEnv("SUPABASE_URL");
@@ -355,6 +369,8 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
       close_type: c.close_type,
       total_cap_qty: c.total_cap_qty,
       ordered_qty: orderedMap.get(Number(c.id)) ?? 0,
+      order_count: countMap.get(Number(c.id)) ?? 0,
+      recent_order_count: recentMap.get(Number(c.id)) ?? 0,
       end_at: c.end_at,
       pickup_deadline: c.pickup_deadline,
       item_count: prices.length,

--- a/supabase/migrations/20260616000010_rpc_member_campaign_order_counts.sql
+++ b/supabase/migrations/20260616000010_rpc_member_campaign_order_counts.sql
@@ -1,0 +1,41 @@
+-- 顧客端商品排序（最熱銷 / 近期售出）用：每個團購活動「所有分店」的訂單數，
+-- 含近 N 天的訂單數。
+--
+-- 為什麼用 SQL 聚合 RPC 而不在 edge function 撈訂單再 JS count：
+-- PostgREST 預設單次最多回 1000 列，busy 店（100 分店 × 數十團）訂單列數會
+-- 超過上限被截斷，導致計數失準（本專案先前已踩過 row-limit 雷）。SQL 端
+-- GROUP BY 聚合一次回每團一列，正確且快。
+--
+-- 計數口徑對齊 liff-api listActiveCampaigns 既有邏輯：
+--   排除 status in (cancelled, expired)；只算 order_kind 為 normal/NULL
+--   （排除 offset 抵減單、restock 補貨單）。不分門市 = 全分店加總。
+
+CREATE OR REPLACE FUNCTION public.rpc_member_campaign_order_counts(
+  p_tenant UUID,
+  p_recent_days INT DEFAULT 7
+)
+RETURNS TABLE (
+  campaign_id BIGINT,
+  order_count BIGINT,
+  recent_order_count BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    co.campaign_id,
+    COUNT(*) AS order_count,
+    COUNT(*) FILTER (
+      WHERE co.created_at >= now() - make_interval(days => GREATEST(p_recent_days, 0))
+    ) AS recent_order_count
+  FROM customer_orders co
+  WHERE co.tenant_id = p_tenant
+    AND co.status NOT IN ('cancelled', 'expired')
+    AND COALESCE(co.order_kind, 'normal') = 'normal'
+  GROUP BY co.campaign_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_member_campaign_order_counts(UUID, INT)
+  TO anon, authenticated, service_role;


### PR DESCRIPTION
## 背景
#229 squash 只帶進視覺改版第一版。經比對 `git diff origin/main..(原 branch)`，發現 `[id]` Shopee 下單流程、`liff-api` sentinel 過濾**已在 main**，但 `shop/page.tsx`、`shop/flash/page.tsx`、`CampaignCard.tsx` 的後續修正**沒進 main**。本 PR 從**最新 main 乾淨重做**（單一 commit、乾淨 diff，不被 squash 汙染），一次補齊並加上新排序功能。

## 補回（原本沒合進 main）
- 限時專區 banner 橘 → **品牌粉**漸層（`/shop` hero + `/shop/flash` sticky）
- **前端擋內部 sentinel 活動**（`campaign_no` 以 `__` 開頭，如「【內部】補貨申請」）— `/shop`、`/shop/flash` 的 hero / 計數 / 列表都用過濾後清單
- 商品卡**倒數**改品牌色膠囊 + 時鐘 icon，明顯許多
- **「限時」標只給** `close_type='fast'`（快閃團）— 不再每個有結單日的團都被貼

## 新增
- 「團購商品」區**三頁籤排序**：最新 / 最熱銷 / 近期售出
- 限時專區 banner **只在真的有快閃團時出現**（否則點進 `/shop/flash` 是空的）
- 新 RPC `rpc_member_campaign_order_counts`：SQL 聚合每團「**全分店**」訂單數 + 近 7 天數（避開 PostgREST 1000 列上限導致計數失準）；`liff-api` `listActiveCampaigns` 回傳 `order_count` / `recent_order_count`

## 部署（需手動，使用者自理）
- `supabase db push`（新 migration `20260616000010_rpc_member_campaign_order_counts.sql`）
- `supabase functions deploy liff-api`（edge function 改動）
- 未部署前：`最新` 排序純前端可用；`最熱銷`/`近期售出` 會 tie-break 回退 id desc（資料 0）

## Test plan
- [x] `tsc --noEmit`（清快取）0 錯
- [x] dev server `/shop`、`/shop/flash` HTTP 200，`preview_logs` 無 server error
- [x] 合併後 grep 驗證:sentinel 過濾 / 粉色 banner / 倒數膠囊 / 排序 / RPC 呼叫 全部到位
- [ ] ⚠️ `/shop*` 需登入 session + 截圖工具本環境失效 → 未附視覺截圖；排序實際效果需 db push + edge deploy 後才有真資料，請 reviewer 部署後本機登入實測

🤖 Generated with [Claude Code](https://claude.com/claude-code)