### PR TITLE
fix(member/shop): 商品卡倒數字級調小

### DIFF
--- a/apps/member/src/components/CampaignCard.tsx
+++ b/apps/member/src/components/CampaignCard.tsx
@@ -213,8 +213,8 @@ export default function CampaignCard({
           {priceText}
         </div>
         {campaign.end_at && (
-          <div className="inline-flex items-center gap-1 rounded-md bg-[var(--brand-soft)] px-2 py-1 text-[14px] font-bold tabular-nums text-[var(--brand-strong)]">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2} className="h-3.5 w-3.5 shrink-0">
+          <div className="inline-flex items-center gap-1 rounded-md bg-[var(--brand-soft)] px-1.5 py-0.5 text-[12px] font-semibold tabular-nums text-[var(--brand-strong)]">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2} className="h-3 w-3 shrink-0">
               <circle cx="12" cy="12" r="9" />
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 7.5V12l3 2" />
             </svg>


### PR DESCRIPTION
## Summary
商品卡倒數膠囊先前為了從「淡灰小字」改成顯眼，做成 14px 粗體 + 較大 padding，實機偏大搶版面。微調：

- `text-[14px] font-bold` → `text-[12px] font-semibold`
- padding `px-2 py-1` → `px-1.5 py-0.5`，時鐘 icon `h-3.5` → `h-3`
- 保留品牌色膠囊樣式（`brand-soft` 底 + `brand-strong` 字 + 時鐘 icon），只是縮小

純 className 調整，無邏輯變更。

## Test plan
- [x] `tsc --noEmit`（清快取）0 錯
- [x] dev server `/shop` HTTP 200
- [ ] ⚠️ `/shop` 需登入 + 截圖工具本環境失效 → 未附視覺截圖，reviewer 本機登入確認字級

🤖 Generated with [Claude Code](https://claude.com/claude-code)