### PR TITLE
security: 移除 repo 內寫死的 prod DB 密碼，改讀環境變數

### DIFF
--- a/docs/HANDOFF-2026-05-10-e2e-next-session.md
+++ b/docs/HANDOFF-2026-05-10-e2e-next-session.md
@@ -77,7 +77,8 @@ mv supabase/migrations supabase/migrations.bak
 supabase start  # empty DB
 # (如果有 backup) docker cp scripts/e2e/backups/prod-schema-*.sql <container>:/tmp/schema.sql
 # 或重新 dump remote dev schema：
-supabase db dump --db-url "postgresql://postgres.anfyoeviuhmzzrhilwtm:%40Ss0929283575@aws-1-ap-southeast-1.pooler.supabase.com:5432/postgres" --schema public -f scripts/e2e/backups/dev-schema.sql
+# set SUPABASE_DB_PASSWORD first (URL-encode if it has special chars)
+supabase db dump --db-url "postgresql://postgres.anfyoeviuhmzzrhilwtm:${SUPABASE_DB_PASSWORD}@aws-1-ap-southeast-1.pooler.supabase.com:5432/postgres" --schema public -f scripts/e2e/backups/dev-schema.sql
 docker cp scripts/e2e/backups/dev-schema*.sql <container>:/tmp/schema.sql
 docker exec <container> psql -U postgres -d postgres -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO postgres; GRANT ALL ON SCHEMA public TO public;"
 docker exec <container> psql -U postgres -d postgres -f /tmp/schema.sql
@@ -86,7 +87,7 @@ mv supabase/migrations.bak supabase/migrations
 # 4. 建 test auth user
 TENANT_ID=$(uuidgen)
 docker exec <container> psql -U postgres -d postgres -c \
-  "INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, raw_app_meta_data, created_at, updated_at) VALUES (gen_random_uuid(), '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'cktalex@gmail.com', crypt('s0929283575', gen_salt('bf')), NOW(), jsonb_build_object('tenant_id', '$TENANT_ID', 'role', 'owner'), NOW(), NOW());"
+  "INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, raw_app_meta_data, created_at, updated_at) VALUES (gen_random_uuid(), '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'cktalex@gmail.com', crypt('<TEST_USER_PASSWORD>', gen_salt('bf')), NOW(), jsonb_build_object('tenant_id', '$TENANT_ID', 'role', 'owner'), NOW(), NOW());"
 
 # 5. 建 .env.e2e
 # Option A — local Supabase（推薦給 UI debug 跟 fresh fixture 跑）
@@ -105,7 +106,7 @@ E2E_DB_HOST=aws-1-ap-southeast-1.pooler.supabase.com
 E2E_DB_PORT=5432
 E2E_DB_USER=postgres.anfyoeviuhmzzrhilwtm
 E2E_DB_NAME=postgres
-E2E_DB_PASSWORD=@Ss0929283575
+E2E_DB_PASSWORD=<set-your-db-password>
 E2E_EXPECTED_HOST=anfyoeviuhmzzrhilwtm
 EOF
 
@@ -129,7 +130,7 @@ NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<paste from supabase status Publishable key>
 NEXT_PUBLIC_BASE_PATH=
 ADMIN_EMAIL=cktalex@gmail.com
-ADMIN_PASSWORD=s0929283575
+ADMIN_PASSWORD=<set-your-db-password>
 EOF
 
 # 開發

--- a/scripts/apply-liff-migrations.mjs
+++ b/scripts/apply-liff-migrations.mjs
@@ -9,11 +9,12 @@ const files = [
   '20260429160002_v_customer_order_summary.sql',
 ];
 
+if (!process.env.SUPABASE_DB_PASSWORD) { console.error('Set SUPABASE_DB_PASSWORD env var'); process.exit(2); }
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com',
   port: 5432,
   user: 'postgres.anfyoeviuhmzzrhilwtm',
-  password: '@Ss0929283575',
+  password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres',
   ssl: { rejectUnauthorized: false },
 });

--- a/scripts/apply_one_migration.cjs
+++ b/scripts/apply_one_migration.cjs
@@ -2,11 +2,12 @@ const { Client } = require('pg');
 const fs = require('fs');
 const path = process.argv[2];
 if (!path) { console.error('usage: node scripts/apply_one_migration.cjs <sql_path>'); process.exit(2); }
+if (!process.env.SUPABASE_DB_PASSWORD) { console.error('Set SUPABASE_DB_PASSWORD env var'); process.exit(2); }
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com',
   port: 5432,
   user: 'postgres.anfyoeviuhmzzrhilwtm',
-  password: '@Ss0929283575',
+  password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres',
   ssl: { rejectUnauthorized: false }
 });

--- a/scripts/e2e/check_air.mjs
+++ b/scripts/e2e/check_air.mjs
@@ -1,7 +1,8 @@
 import { Client } from 'pg';
+if (!process.env.SUPABASE_DB_PASSWORD) { console.error('Set SUPABASE_DB_PASSWORD env var'); process.exit(2); }
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com', port: 5432,
-  user: 'postgres.anfyoeviuhmzzrhilwtm', password: '@Ss0929283575',
+  user: 'postgres.anfyoeviuhmzzrhilwtm', password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres', ssl: { rejectUnauthorized: false },
 });
 await c.connect();

--- a/scripts/e2e/check_order7.mjs
+++ b/scripts/e2e/check_order7.mjs
@@ -1,7 +1,8 @@
 import { Client } from 'pg';
+if (!process.env.SUPABASE_DB_PASSWORD) { console.error('Set SUPABASE_DB_PASSWORD env var'); process.exit(2); }
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com', port: 5432,
-  user: 'postgres.anfyoeviuhmzzrhilwtm', password: '@Ss0929283575',
+  user: 'postgres.anfyoeviuhmzzrhilwtm', password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres', ssl: { rejectUnauthorized: false },
 });
 await c.connect();

--- a/scripts/e2e/check_po28.mjs
+++ b/scripts/e2e/check_po28.mjs
@@ -1,7 +1,8 @@
 import { Client } from 'pg';
+if (!process.env.SUPABASE_DB_PASSWORD) { console.error('Set SUPABASE_DB_PASSWORD env var'); process.exit(2); }
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com', port: 5432,
-  user: 'postgres.anfyoeviuhmzzrhilwtm', password: '@Ss0929283575',
+  user: 'postgres.anfyoeviuhmzzrhilwtm', password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres', ssl: { rejectUnauthorized: false },
 });
 await c.connect();

--- a/scripts/e2e/check_pr34.mjs
+++ b/scripts/e2e/check_pr34.mjs
@@ -1,7 +1,8 @@
 import { Client } from 'pg';
+if (!process.env.SUPABASE_DB_PASSWORD) { console.error('Set SUPABASE_DB_PASSWORD env var'); process.exit(2); }
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com', port: 5432,
-  user: 'postgres.anfyoeviuhmzzrhilwtm', password: '@Ss0929283575',
+  user: 'postgres.anfyoeviuhmzzrhilwtm', password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres', ssl: { rejectUnauthorized: false },
 });
 await c.connect();

--- a/scripts/e2e/check_tf0003.mjs
+++ b/scripts/e2e/check_tf0003.mjs
@@ -1,7 +1,8 @@
 import { Client } from 'pg';
+if (!process.env.SUPABASE_DB_PASSWORD) { console.error('Set SUPABASE_DB_PASSWORD env var'); process.exit(2); }
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com', port: 5432,
-  user: 'postgres.anfyoeviuhmzzrhilwtm', password: '@Ss0929283575',
+  user: 'postgres.anfyoeviuhmzzrhilwtm', password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres', ssl: { rejectUnauthorized: false },
 });
 await c.connect();

--- a/scripts/e2e/cleanup_receivables.mjs
+++ b/scripts/e2e/cleanup_receivables.mjs
@@ -1,7 +1,8 @@
 import { Client } from 'pg';
+if (!process.env.SUPABASE_DB_PASSWORD) { console.error('Set SUPABASE_DB_PASSWORD env var'); process.exit(2); }
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com', port: 5432,
-  user: 'postgres.anfyoeviuhmzzrhilwtm', password: '@Ss0929283575',
+  user: 'postgres.anfyoeviuhmzzrhilwtm', password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres', ssl: { rejectUnauthorized: false },
 });
 await c.connect();

--- a/scripts/e2e/full_chain/_db.cjs
+++ b/scripts/e2e/full_chain/_db.cjs
@@ -6,11 +6,15 @@ const TENANT = '00000000-0000-0000-0000-000000000001';
 const ADMIN_UID = '39fd694d-3af6-4978-beab-6e826dff7246'; // cktalex@gmail.com
 
 function newClient() {
+  if (!process.env.SUPABASE_DB_PASSWORD) {
+    console.error('Set SUPABASE_DB_PASSWORD env var');
+    process.exit(2);
+  }
   return new Client({
     host: 'aws-1-ap-southeast-1.pooler.supabase.com',
     port: 5432,
     user: 'postgres.anfyoeviuhmzzrhilwtm',
-    password: '@Ss0929283575',
+    password: process.env.SUPABASE_DB_PASSWORD,
     database: 'postgres',
     ssl: { rejectUnauthorized: false },
   });

--- a/scripts/e2e/nuclear_cleanup.cjs
+++ b/scripts/e2e/nuclear_cleanup.cjs
@@ -28,11 +28,15 @@ const { Client } = require('pg');
 const YES = process.argv.includes('--yes');
 const TENANT = '00000000-0000-0000-0000-000000000001';
 
+if (!process.env.SUPABASE_DB_PASSWORD) {
+  console.error('Set SUPABASE_DB_PASSWORD env var');
+  process.exit(2);
+}
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com',
   port: 5432,
   user: 'postgres.anfyoeviuhmzzrhilwtm',
-  password: '@Ss0929283575',
+  password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres',
   ssl: { rejectUnauthorized: false },
 });

--- a/scripts/e2e/reset_and_regen.mjs
+++ b/scripts/e2e/reset_and_regen.mjs
@@ -1,7 +1,8 @@
 import { Client } from 'pg';
+if (!process.env.SUPABASE_DB_PASSWORD) { console.error('Set SUPABASE_DB_PASSWORD env var'); process.exit(2); }
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com', port: 5432,
-  user: 'postgres.anfyoeviuhmzzrhilwtm', password: '@Ss0929283575',
+  user: 'postgres.anfyoeviuhmzzrhilwtm', password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres', ssl: { rejectUnauthorized: false },
 });
 await c.connect();

--- a/scripts/e2e/run-reset.mjs
+++ b/scripts/e2e/run-reset.mjs
@@ -17,11 +17,12 @@ function prepSql(raw) {
     .replace(/:'tenant_id'/g, `'${TENANT_ID}'`);
 }
 
+if (!process.env.SUPABASE_DB_PASSWORD) { console.error('Set SUPABASE_DB_PASSWORD env var'); process.exit(2); }
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com',
   port: 5432,
   user: 'postgres.anfyoeviuhmzzrhilwtm',
-  password: '@Ss0929283575',
+  password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres',
   ssl: { rejectUnauthorized: false },
 });

--- a/scripts/e2e/week_simulation/00_backfill_stores.cjs
+++ b/scripts/e2e/week_simulation/00_backfill_stores.cjs
@@ -10,11 +10,15 @@ const { Client } = require('pg');
 const TENANT = '00000000-0000-0000-0000-000000000001';
 const ADMIN = '39fd694d-3af6-4978-beab-6e826dff7246';
 
+if (!process.env.SUPABASE_DB_PASSWORD) {
+  console.error('Set SUPABASE_DB_PASSWORD env var');
+  process.exit(2);
+}
 const c = new Client({
   host: 'aws-1-ap-southeast-1.pooler.supabase.com',
   port: 5432,
   user: 'postgres.anfyoeviuhmzzrhilwtm',
-  password: '@Ss0929283575',
+  password: process.env.SUPABASE_DB_PASSWORD,
   database: 'postgres',
   ssl: { rejectUnauthorized: false },
 });

--- a/scripts/e2e/week_simulation/_db.cjs
+++ b/scripts/e2e/week_simulation/_db.cjs
@@ -6,11 +6,15 @@ const ADMIN_UID = '39fd694d-3af6-4978-beab-6e826dff7246';
 const CHANNEL_ID = 1; // LC-MAIN — 主社群
 
 function newClient() {
+  if (!process.env.SUPABASE_DB_PASSWORD) {
+    console.error('Set SUPABASE_DB_PASSWORD env var');
+    process.exit(2);
+  }
   return new Client({
     host: 'aws-1-ap-southeast-1.pooler.supabase.com',
     port: 5432,
     user: 'postgres.anfyoeviuhmzzrhilwtm',
-    password: '@Ss0929283575',
+    password: process.env.SUPABASE_DB_PASSWORD,
     database: 'postgres',
     ssl: { rejectUnauthorized: false },
   });


### PR DESCRIPTION
## 問題
`scripts/` 下多支部署 / e2e 腳本（含我這次部署用到的 `apply_one_migration.cjs`）與一份 handoff doc，把**正式 Supabase DB 密碼明文寫死並 commit 進版控** —— 等同憑證外洩。

## 修正（15 檔，+45/-18）
- **14 支 Node 腳本**：硬編碼 `password:` 字面值 → `process.env.SUPABASE_DB_PASSWORD`，並在連線前加 guard（未設即明確報錯退出）。`host/user/port/database` 未動，腳本功能不變，只需先設 `SUPABASE_DB_PASSWORD`。
- **docs/HANDOFF-2026-05-10**：連線字串改 `${SUPABASE_DB_PASSWORD}` + 提示；`crypt('...')` 測試種子密碼、範例 env 值改占位符。
- 變更檔：`scripts/apply_one_migration.cjs`、`scripts/apply-liff-migrations.mjs`、`scripts/e2e/**`（含 `full_chain/_db.cjs`、`week_simulation/_db.cjs` 等共用 helper）、`docs/HANDOFF-2026-05-10-e2e-next-session.md`。

## 驗證
- 全 repo（排除 node_modules / gitignore）內容掃描該密碼字串：**0 命中**
- 所有改動的 .cjs/.mjs `node --check`：**全通過**
- `scripts/e2e/.env.e2e.example` 原本就用 `REPLACE_ME`，未動

## ⚠️ 仍需人工處理（不在此 PR）
1. **輪換 DB 密碼**：git 歷史仍含舊密碼（改寫歷史不在範圍），改 code 救不了已外洩的舊值 —— 請到 Supabase 後台改密碼。
2. 本機 gitignored 檔（`.env.local`、`.claude/settings.local.json`）仍有舊密碼供本機工具用，未 commit、不受影響；輪換後一併更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)