### PR TITLE
feat(member/shop): 訂單數即使為 0 也顯示

### DIFF
--- a/apps/member/src/components/CampaignCard.tsx
+++ b/apps/member/src/components/CampaignCard.tsx
@@ -152,11 +152,9 @@ export default function CampaignCard({
               <span className="brand-gradient-text text-[28px] font-extrabold tabular-nums leading-none">
                 {priceText}
               </span>
-              {campaign.order_count > 0 && (
-                <span className="text-[14px] font-medium text-[var(--tertiary-label)]">
-                  {campaign.order_count} 筆訂單
-                </span>
-              )}
+              <span className="text-[14px] font-medium text-[var(--tertiary-label)]">
+                {campaign.order_count} 筆訂單
+              </span>
             </div>
             <span className="text-[13px] text-[var(--secondary-label)]">
               共 {campaign.item_count} 項
@@ -224,11 +222,9 @@ export default function CampaignCard({
           <div className="brand-gradient-text text-[24px] font-extrabold tabular-nums leading-none">
             {priceText}
           </div>
-          {campaign.order_count > 0 && (
-            <div className="text-[12px] font-medium text-[var(--tertiary-label)]">
-              {campaign.order_count} 筆訂單
-            </div>
-          )}
+          <div className="text-[12px] font-medium text-[var(--tertiary-label)]">
+            {campaign.order_count} 筆訂單
+          </div>
         </div>
         {campaign.end_at && (
           <div className="inline-flex items-center gap-1 rounded-md bg-[var(--brand-soft)] px-1.5 py-0.5 text-[12px] font-semibold tabular-nums text-[var(--brand-strong)]">


### PR DESCRIPTION
## 問題
`#239` 的「N 筆訂單」以 `campaign.order_count > 0` 為顯示條件。使用者環境多數團尚無真實顧客訂單 → `order_count` 為 0 → 整個被藏，導致回報「看不到 count」。

## 改動（純前端、1 檔）
`apps/member/src/components/CampaignCard.tsx`：
- **grid（商品列表）** 價格下方 + **hero（限時專區首張）** 價格旁的「{order_count} 筆訂單」改為**無條件顯示**（`order_count` 型別為 `number`，恆有值，0 即顯示「0 筆訂單」）。
- 影像上狀態膠囊內聯的 `· N 筆訂單`（`進行中/限時 · …`）**維持 `>0`**——膠囊內塞「· 0 筆訂單」視覺很差。

## 為何這也是診斷
edge `liff-api` 已回傳 `order_count`（恆為數字、預設 0），RPC 亦已套 prod。上線後：
- 全卡顯「0 筆訂單」→ 鏈路正常，只是該環境**真的沒有符合計數的顧客訂單**（非 cancelled/expired、order_kind normal）。下真實訂單即會變數字、最熱銷/近期售出也會排。
- 出現真實數字 → RPC/edge 正常。

## 部署
純前端，merge 後 Vercel 自動上，**不需** db push / functions deploy。

## Test plan
- [x] `tsc --noEmit`（清快取）0 錯
- [x] grep 確認兩變體已無 `order_count > 0` 包裹（行 156 / 226 無條件）
- [ ] ⚠️ `/shop` 需登入 + 截圖工具本環境失效，未附視覺截圖；merge 上線後手機登入確認每張卡價格下方都有「N 筆訂單」

🤖 Generated with [Claude Code](https://claude.com/claude-code)