### PR TITLE
feat(admin/campaigns): 列表整列可點開啟開團 detail

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -552,17 +552,18 @@ export default function CampaignsListPage() {
           ) : rows.length === 0 ? (
             <EmptyRow colSpan={11}>{total === 0 && !query && !status ? "還沒有開團，按「新增開團」開始。" : "沒有符合條件的開團。"}</EmptyRow>
           ) : rows.map((r) => (
-            <Tr key={r.id} className={selectedIds.has(r.id) ? "bg-blue-50 dark:bg-blue-950/30" : ""}>
+            <Tr key={r.id} onClick={() => openEdit(r.id)} className={selectedIds.has(r.id) ? "bg-blue-50 dark:bg-blue-950/30" : ""}>
                 <Td className="w-10">
                   <input
                     type="checkbox"
                     checked={selectedIds.has(r.id)}
                     onChange={() => toggleSelect(r.id)}
+                    onClick={(e) => e.stopPropagation()}
                     className="cursor-pointer"
                   />
                 </Td>
                 <Td className="font-mono">
-                  <SpinButton onClick={() => openEdit(r.id)} className="hover:underline">{r.campaign_no}</SpinButton>
+                  <SpinButton onClick={(e) => { e.stopPropagation(); openEdit(r.id); }} className="hover:underline">{r.campaign_no}</SpinButton>
                 </Td>
                 <Td>{r.name}</Td>
                 <Td><StatusBadge s={r.status} /></Td>
@@ -588,6 +589,7 @@ export default function CampaignsListPage() {
                     return (
                       <Link
                         href={`/orders?campaignId=${r.id}`}
+                        onClick={(e) => e.stopPropagation()}
                         className="inline-flex items-center gap-1 rounded font-mono hover:bg-zinc-100 px-1 dark:hover:bg-zinc-800"
                         title={`點擊查看此開團的訂單\n正常下單總量：${oc.normalQty} 件${oc.offsetQty !== 0 ? `\n抵減量：${oc.offsetQty} 件\n淨需求：${totalQty} 件` : ""}`}
                       >
@@ -605,7 +607,7 @@ export default function CampaignsListPage() {
                 </Td>
                 <Td align="right" className="text-xs text-zinc-500">{new Date(r.updated_at).toLocaleString("zh-TW")}</Td>
                 <Td>
-                  <div className="flex gap-2">
+                  <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
                     <SpinButton
                       onClick={() => openEdit(r.id)}
                       className="text-xs text-blue-600 hover:underline dark:text-blue-400"


### PR DESCRIPTION
## Summary
- 開團列表頁（列表 view）點整個 row 即開啟開團 detail modal（商品表 + 編輯表單 + 訂單面板），不必只點團號
- 勾選框 / 團號按鈕 / 下單總數連結 / 操作列（編輯·加單·結單·結算）各自 `stopPropagation`，原有行為完全不變
- 沿用既有慣例：`inventory/stocktake` 的 `<Tr onClick>` 整列點擊、`purchase/requests` 的 checkbox/Link/div `stopPropagation`
- 週/月曆 view 不受影響（原本就以卡片點擊開 detail）

變更範圍：1 file，+5/-3，無新增 lint error（檔內既有 lint 問題在未觸及的程式碼，依「一功能一乾淨 PR」原則不順手改）。

## Test plan
- [ ] 列表 view：點 row 任一空白處（名稱/狀態/收單/日期欄）→ 開啟該開團 detail modal
- [ ] 點勾選框 → 只切換多選，不開 modal
- [ ] 點團號 → 開 detail（不重複觸發）
- [ ] 點「下單總數」連結 → 導到 `/orders?campaignId=`，不開 modal
- [ ] 點操作列 編輯/加單/結單/結算 → 各自原行為，不額外開 detail modal
- [ ] hover row 顯示 `cursor-pointer`
- [ ] 週/月曆 view 行為無回歸

> 註：本機 Supabase 登入當下卡在 `Database error querying schema`（本機 DB 狀態問題、與此前端改動無關），故未做瀏覽器實測，留待 reviewer 自審。

🤖 Generated with [Claude Code](https://claude.com/claude-code)