### PR TITLE
feat(member/shop): 卡片只留「已訂購 N 件」靠右，移除其餘訂單數顯示

### DIFF
--- a/apps/member/src/components/CampaignCard.tsx
+++ b/apps/member/src/components/CampaignCard.tsx
@@ -131,9 +131,6 @@ export default function CampaignCard({
                   <>
                     {label && <span>{label}</span>}
                     {campaign.end_at && <Countdown target={campaign.end_at} compact />}
-                    {campaign.order_count > 0 && (
-                      <span className="text-[12px] opacity-90">· {campaign.order_count} 筆訂單</span>
-                    )}
                     {isLimited && remaining !== null && (
                       <span className="text-[12px] opacity-90">· 剩 {remaining} 份</span>
                     )}
@@ -148,20 +145,15 @@ export default function CampaignCard({
             {campaign.name}
           </h3>
           <div className="flex items-baseline justify-between gap-2">
-            <div className="flex items-baseline gap-2">
-              <span className="brand-gradient-text text-[28px] font-extrabold tabular-nums leading-none">
-                {priceText}
-              </span>
-              <span className="text-[14px] font-medium text-[var(--tertiary-label)]">
-                {campaign.order_count} 筆訂單
-              </span>
-            </div>
+            <span className="brand-gradient-text text-[28px] font-extrabold tabular-nums leading-none">
+              {priceText}
+            </span>
             <span className="text-[13px] text-[var(--secondary-label)]">
               共 {campaign.item_count} 項
             </span>
           </div>
           {campaign.ordered_qty > 0 && (
-            <div className="text-[14px] font-medium text-[var(--tertiary-label)]">
+            <div className="text-right text-[14px] font-medium text-[var(--tertiary-label)]">
               已訂購 {campaign.ordered_qty.toLocaleString()} 件
             </div>
           )}
@@ -196,7 +188,7 @@ export default function CampaignCard({
               </span>
             );
           }
-          if (!label && campaign.order_count <= 0) return null;
+          if (!label) return null;
           const isLimited = label?.includes("限量");
           return (
             <span
@@ -204,8 +196,7 @@ export default function CampaignCard({
                 isLimited ? "bg-[var(--ios-red)]/90" : "bg-[var(--ios-orange)]/90"
               }`}
             >
-              {label || "進行中"}
-              {campaign.order_count > 0 && ` · ${campaign.order_count} 筆訂單`}
+              {label}
             </span>
           );
         })()}
@@ -223,19 +214,16 @@ export default function CampaignCard({
             </div>
           );
         })()}
-        <div className="flex items-baseline gap-2">
+        <div className="flex items-baseline justify-between gap-2">
           <div className="brand-gradient-text text-[24px] font-extrabold tabular-nums leading-none">
             {priceText}
           </div>
-          <div className="text-[12px] font-medium text-[var(--tertiary-label)]">
-            {campaign.order_count} 筆訂單
-          </div>
+          {campaign.ordered_qty > 0 && (
+            <div className="text-[12px] font-medium text-[var(--tertiary-label)]">
+              已訂購 {campaign.ordered_qty.toLocaleString()} 件
+            </div>
+          )}
         </div>
-        {campaign.ordered_qty > 0 && (
-          <div className="text-[12px] font-medium text-[var(--tertiary-label)]">
-            已訂購 {campaign.ordered_qty.toLocaleString()} 件
-          </div>
-        )}
         {campaign.end_at && (
           <div className="inline-flex items-center gap-1 rounded-md bg-[var(--brand-soft)] px-1.5 py-0.5 text-[12px] font-semibold tabular-nums text-[var(--brand-strong)]">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2} className="h-3 w-3 shrink-0">


### PR DESCRIPTION
## 需求
使用者:商品卡只要留「已訂購 N 件」,其他訂單數顯示全拿掉,且靠右。

## 改動（純前端、1 檔 `CampaignCard.tsx`，grid + hero 一致）
- 移除影像狀態膠囊內的 `· N 筆訂單`；膠囊回歸只顯示真實狀態標籤（限時/限量/限量限時），grid 不再因 `order_count` 硬撐出「進行中」pill（`if (!label) return null`）
- 移除價格旁的 `N 筆訂單`
- 保留「已訂購 N 件」(維持 `ordered_qty > 0` 條件——`ordered_qty` 僅對限量團計算，非限量團恆 0，不顯示 0 以免誤導)，改放與價格同一列 `justify-between` → **靠右**；hero 額外加 `text-right`

`order_count` / `recent_order_count` 型別欄位**保留**(`/shop` 的「最熱銷 / 近期售出」排序仍依賴),只是卡片不再顯示。

## 部署
純前端,merge 後 Vercel 自動上,**不需** db push / functions deploy。

## Test plan
- [x] `tsc --noEmit`(清快取)0 錯
- [x] grep 確認:CampaignCard 已無「筆訂單」;「已訂購 N 件」grid/hero 各一、皆在 `justify-between` 行右側 / `text-right`
- [ ] ⚠️ `/shop` 需登入 + 截圖工具失效,未附截圖;merge 上線後手機登入確認:卡片只剩價格(左)+已訂購 N 件(右)、膠囊無「筆訂單」

🤖 Generated with [Claude Code](https://claude.com/claude-code)