### PR TITLE
fix(member/shop): 「已訂購 N 件」字色提一級（淡灰→次標籤灰）

### DIFF
--- a/apps/member/src/components/CampaignCard.tsx
+++ b/apps/member/src/components/CampaignCard.tsx
@@ -153,7 +153,7 @@ export default function CampaignCard({
             </span>
           </div>
           {campaign.ordered_qty > 0 && (
-            <div className="text-right text-[14px] font-medium text-[var(--tertiary-label)]">
+            <div className="text-right text-[14px] font-medium text-[var(--secondary-label)]">
               已訂購 {campaign.ordered_qty.toLocaleString()} 件
             </div>
           )}
@@ -219,7 +219,7 @@ export default function CampaignCard({
             {priceText}
           </div>
           {campaign.ordered_qty > 0 && (
-            <div className="text-[12px] font-medium text-[var(--tertiary-label)]">
+            <div className="text-[12px] font-medium text-[var(--secondary-label)]">
               已訂購 {campaign.ordered_qty.toLocaleString()} 件
             </div>
           )}


### PR DESCRIPTION
## 需求
使用者:「已訂購 N 件」字色再明顯一點點,但不用太多。

## 改動（純前端、1 檔、2 token）
`CampaignCard.tsx` grid + hero 兩處 `已訂購 N 件`:
`text-[var(--tertiary-label)]`(0.3 alpha,最淡灰) → `text-[var(--secondary-label)]`(0.6 alpha,標準次要文字)。size / weight / 對齊不變。

## 部署
純前端,merge 後 Vercel 自動上,無需 db/edge 部署。

## Test plan
- [x] `tsc --noEmit`（清快取）0 錯
- [x] grep 確認兩處皆為 `--secondary-label`
- [ ] ⚠️ `/shop` 需登入 + 截圖工具失效,未附截圖;merge 上線後手機看「已訂購 N 件」是否清楚一點但不搶眼

🤖 Generated with [Claude Code](https://claude.com/claude-code)