### PR TITLE
fix(member/shop): 商品詳細頁標題改顯示「已訂購 N 件」非「N 筆訂單」

### DIFF
--- a/apps/member/src/app/shop/c/[id]/page.tsx
+++ b/apps/member/src/app/shop/c/[id]/page.tsx
@@ -35,7 +35,6 @@ type CampaignDetail = {
   status: string;
   end_at: string | null;
   pickup_deadline: string | null;
-  order_count: number;
 };
 
 type Item = {
@@ -188,11 +187,18 @@ export default function CampaignDetailPage() {
                 <h1 className="flex-1 text-[26px] font-bold leading-tight text-[var(--foreground)]">
                   {campaign.name}
                 </h1>
-                {campaign.order_count > 0 && (
-                  <div className="mt-1.5 shrink-0 rounded-lg bg-[var(--tertiary-label)]/10 px-2 py-1 text-[13px] font-semibold text-[var(--secondary-label)]">
-                    {campaign.order_count} 筆訂單
-                  </div>
-                )}
+                {(() => {
+                  const orderedQty = items.reduce(
+                    (s, it) => s + Number(it.ordered_qty ?? 0),
+                    0,
+                  );
+                  if (orderedQty <= 0) return null;
+                  return (
+                    <div className="mt-1.5 shrink-0 rounded-lg bg-[var(--tertiary-label)]/10 px-2 py-1 text-[13px] font-semibold text-[var(--secondary-label)]">
+                      已訂購 {orderedQty.toLocaleString()} 件
+                    </div>
+                  );
+                })()}
               </div>
               {campaign.description && (() => {
                 const desc = cleanDescription(campaign.description);


### PR DESCRIPTION
## 需求
商品詳細頁標題旁顯示「5 筆訂單」(order_count)。使用者要求跟卡片一致 —— 顯示**訂購數量**「已訂購 N 件」,不是訂單數。

## 改動（純前端、1 檔 `shop/c/[id]/page.tsx`）
- 標題旁的 `{campaign.order_count} 筆訂單` → 由 `items[].ordered_qty` **加總**算總件數,顯示 `已訂購 {N} 件`（`> 0` 才顯示,沿用原 pill 樣式 + `--secondary-label`，與卡片一致）。
- 移除已無用的 `CampaignDetail.order_count` 型別欄位。
- 詳細頁 `items` 本來就帶 `ordered_qty`（per-SKU「已售出 N」用），加總即campaign總件數 → **不需動 edge / 不需部署**。
- per-SKU 的「已售出 N」維持原樣（使用者未反映、屬不同層級資訊）。

## Test plan
- [x] `tsc --noEmit`（清快取）0 錯
- [x] grep 確認詳細頁已無 `order_count` / `筆訂單`，僅餘 `已訂購 N 件`
- [ ] ⚠️ `/shop/c/[id]` 需登入 + 截圖工具失效,未附截圖;merge 上線後手機登入確認標題旁顯示「已訂購 N 件」

🤖 Generated with [Claude Code](https://claude.com/claude-code)