### PR TITLE
feat(member/shop): 商品詳細頁圖片點擊放大（lightbox）

### DIFF
--- a/apps/member/src/app/shop/c/[id]/page.tsx
+++ b/apps/member/src/app/shop/c/[id]/page.tsx
@@ -339,6 +339,7 @@ export default function CampaignDetailPage() {
 function HeroCarousel({ images }: { images: string[] }) {
   const ref = useRef<HTMLDivElement | null>(null);
   const [idx, setIdx] = useState(0);
+  const [zoomSrc, setZoomSrc] = useState<string | null>(null);
 
   useEffect(() => {
     const el = ref.current;
@@ -408,7 +409,8 @@ function HeroCarousel({ images }: { images: string[] }) {
             <img
               src={url}
               alt=""
-              className="absolute inset-0 h-full w-full object-cover"
+              onClick={() => setZoomSrc(url)}
+              className="absolute inset-0 h-full w-full cursor-zoom-in object-cover"
             />
           </div>
         ))}
@@ -426,6 +428,31 @@ function HeroCarousel({ images }: { images: string[] }) {
           ))}
         </div>
       )}
+      <Portal enabled={!!zoomSrc}>
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/90"
+          onClick={() => setZoomSrc(null)}
+        >
+          <button
+            type="button"
+            aria-label="關閉"
+            onClick={() => setZoomSrc(null)}
+            className="absolute right-4 flex h-9 w-9 items-center justify-center rounded-full bg-white/15 text-[20px] text-white backdrop-blur"
+            style={{ top: "calc(env(safe-area-inset-top) + 12px)" }}
+          >
+            ✕
+          </button>
+          {zoomSrc && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={zoomSrc}
+              alt=""
+              onClick={(e) => e.stopPropagation()}
+              className="max-h-[90vh] max-w-[94vw] object-contain"
+            />
+          )}
+        </div>
+      </Portal>
     </>
   );
 }


### PR DESCRIPTION
## 需求
商品詳細頁的圖片點了要能放大顯示。

## 改動（純前端、1 檔 `shop/c/[id]/page.tsx`，僅 HeroCarousel）
- 輪播圖加 `onClick` → 開全螢幕 lightbox；圖片加 `cursor-zoom-in`。
- Lightbox：透過檔內既有 `Portal`（render 到 `document.body`，保證相對 viewport）→ `fixed inset-0 z-[60] bg-black/90`，圖片 `object-contain max-h-[90vh] max-w-[94vw]`（完整放大、不裁切）。
- 關閉：右上 ✕（含 `safe-area-inset-top`）或點背景；點圖片本身 `stopPropagation` 不誤關。
- 新增 `zoomSrc` state（HeroCarousel 內，自包含）。

## 與 #248 的關係
本 PR 只改 HeroCarousel（~339+ 區）；#248（未合併）改的是標題列「已訂購 N 件」（行 38 / 191-195），**不同區段、3-way merge 不衝突**，兩者獨立、合併順序皆可。

## 部署
純前端，merge 後 Vercel 自動上，無需 db/edge。

## Test plan
- [x] `tsc --noEmit`（清快取）0 錯
- [x] grep 確認 lightbox 片段（zoomSrc / cursor-zoom-in / Portal / z-[60] / object-contain）皆到位
- [ ] ⚠️ `/shop/c/[id]` 需登入 + 截圖工具失效，未附截圖；merge 上線後手機登入：點商品圖應全螢幕放大、✕/點背景可關、不影響左右滑動切圖

🤖 Generated with [Claude Code](https://claude.com/claude-code)