### PR TITLE
fix(member): 會員中心門市/未結金額改會員級（修正一律顯示「平鎮」、金額為 0）

### DIFF
--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -228,9 +228,11 @@ export default function MePage() {
                     🔔 已啟用通知
                   </span>
                 )}
-                {me.home_store_name && (
+                {/* 顯示目前所在門市（JWT store）；home_store_name 是註冊店、LIFF 不更新，
+                    用它會永遠顯示舊店。overview 失敗時才回退 home_store_name。 */}
+                {(overview?.store.name ?? me.home_store_name) && (
                   <span className="inline-flex items-center gap-1 rounded-full bg-[#7676801f] px-2.5 py-[3px] text-[12px] font-medium text-[var(--secondary-label)]">
-                    📍 {me.home_store_name}
+                    📍 {overview?.store.name ?? me.home_store_name}
                   </span>
                 )}
               </div>

--- a/docs/TEST-member-store-context.md
+++ b/docs/TEST-member-store-context.md
@@ -1,0 +1,57 @@
+# 測試項目 — apps/member 會員端跨店一致性修正
+
+**問題回報：**
+1. 登入時選了取貨店，會員中心仍一律顯示註冊店「平鎮」。
+2. 訂單的取貨店 ≠ 登入店時，「未結單金額 / 進行中訂單筆數」顯示 0（看不到數字），但點進「我的訂單」每張單都看得到。
+
+**對應變更：**
+- `supabase/functions/liff-api/index.ts` — `getOverview` 的未結金額 / 進行中筆數移除 `store_id` 過濾（改為會員級，與 `listMyOrders` 一致）。
+- `apps/member/src/app/me/page.tsx` — 頭像旁門市 chip 改顯示目前門市（`overview.store.name`），不再用永不更新的 `me.home_store_name`。
+
+---
+
+## 1. 根因確認（程式碼層）
+
+- [ ] `v_customer_order_summary.store_id` 等於 `customer_orders.pickup_store_id`
+      （migration `20260606000011_v_customer_order_summary_balance_due.sql` 第 16 行）
+- [ ] 修正前 `listMyOrders` 無 `store_id` 過濾（跨店、會員級）
+- [ ] 修正前 `getOverview` 有 `.eq("store_id", storeId)` → 與列表不一致（本次修掉）
+- [ ] 修正前 `/me` chip 綁 `me.home_store_name`（= `members.home_store_id`，LIFF 永不更新）
+
+## 2. Bug 2 — 未結金額 / 進行中筆數（DB 驗證）
+
+前置：找一個會員，其 `customer_orders.pickup_store_id` 與登入 JWT `store_id` 不同，且有未付款訂單。
+
+**驗證 SQL（會員級總額，應等於修正後 overview 回傳值）：**
+```sql
+-- 未結單金額（會員級，不分店）
+SELECT COALESCE(SUM(payable_amount),0) AS receivable
+  FROM v_customer_order_summary
+ WHERE tenant_id = :tenant AND member_id = :member
+   AND payment_status = 'unpaid'
+   AND status NOT IN ('cancelled','expired');
+
+-- 進行中訂單筆數（會員級，不分店）
+SELECT COUNT(*) AS active_cnt
+  FROM v_customer_order_summary
+ WHERE tenant_id = :tenant AND member_id = :member
+   AND status NOT IN ('completed','cancelled','expired');
+```
+
+- [ ] `get_overview` 回傳的 `receivable_amount` == 上面 receivable（跨店加總，> 0）
+- [ ] `get_overview` 回傳的 `active_orders_count` == 上面 active_cnt
+- [ ] `list_my_orders`（active）筆數 ≥ overview 的 active_orders_count（列表為 6 個月窗、overview 不設窗，方向一致即可）
+- [ ] 回歸：同店訂單情境，數字與修正前一致（未引入回歸）
+
+## 3. Bug 1 — 門市 chip 顯示目前門市（UI / 行為）
+
+- [ ] 登入店 = A、註冊店（home_store）= 平鎮：`/me` 頭像旁 chip 顯示「📍 A」而非「平鎮」
+- [ ] `get_overview` 失敗（catch → null）時，chip 回退顯示 `home_store_name`（不空白、不報錯）
+- [ ] `/overview` 頁標題與 `/me` chip 顯示同一家店（一致）
+- [ ] LIFF 回頭客（`liff-session` 將 JWT store 鎖定為 binding store）行為不在本次調整範圍 —
+      已知限制：此情境 chip = binding store（非本次選店）。記錄於 PR，不視為回歸。
+
+## 4. 驗證限制
+
+- [ ] `/me` preview 需 liff-api 已 serve + 有效 member session（記憶提示本地預設 503）；
+      若無法 preview，至少完成 §1、§2 的 SQL/程式碼層驗證並於 PR 說明。

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -250,9 +250,12 @@ async function getOverview(sb: any, tenantId: string, storeId: number, memberId:
   const { data: storeRow, error: sErr } = await sb.from("stores").select("id, code, name, banner_url, description, payment_methods_text, shipping_methods_text").eq("tenant_id", tenantId).eq("id", storeId).single();
   if (sErr || !storeRow) return json({ error: "store not found" }, 404);
   storeRow.banner_url = toPublicUrl(requireEnv("SUPABASE_URL"), "products", storeRow.banner_url);
-  const { data: unpaidRows } = await sb.from("v_customer_order_summary").select("payable_amount").eq("tenant_id", tenantId).eq("member_id", memberId).eq("store_id", storeId).eq("payment_status", "unpaid").not("status", "in", "(cancelled,expired)");
+  // 未結金額 / 進行中筆數依 member_id 會員級加總，不依 store_id 過濾：
+  // member_id 是 tenant 級、訂單 pickup 店可不同於登入店，需與 listMyOrders（跨店）一致，
+  // 否則訂單列表看得到、overview 金額卻 0。
+  const { data: unpaidRows } = await sb.from("v_customer_order_summary").select("payable_amount").eq("tenant_id", tenantId).eq("member_id", memberId).eq("payment_status", "unpaid").not("status", "in", "(cancelled,expired)");
   const receivable = (unpaidRows ?? []).reduce((s: number, r: any) => s + Number(r.payable_amount ?? 0), 0);
-  const { count: activeCount } = await sb.from("v_customer_order_summary").select("*", { count: "exact", head: true }).eq("tenant_id", tenantId).eq("member_id", memberId).eq("store_id", storeId).not("status", "in", "(completed,cancelled,expired)");
+  const { count: activeCount } = await sb.from("v_customer_order_summary").select("*", { count: "exact", head: true }).eq("tenant_id", tenantId).eq("member_id", memberId).not("status", "in", "(completed,cancelled,expired)");
   return json({ store: storeRow, receivable_amount: receivable, active_orders_count: activeCount ?? 0 });
 }
 


### PR DESCRIPTION
## 問題

使用者回報 apps/member 兩個現象：

1. **登入選了取貨店，會員中心仍一律顯示「平鎮」。**
2. **訂單不在登入店時，「未結單金額 / 進行中訂單筆數」看不到數字（顯示 0），但點進「我的訂單」每張單都看得到。**

兩者同源：會員端把「註冊店 / 登入店」當成資料過濾鍵，但會員（`member_id`）其實是 tenant 級、訂單的 `pickup_store_id` 可不同於登入店。

## 根因

- `v_customer_order_summary.store_id` = `customer_orders.pickup_store_id`（migration `20260606000011` 第 16 行）。
- **Bug 1**：`/me` 頭像旁門市 chip 綁 `me.home_store_name`，來自 `members.home_store_id`（註冊當下那家店，LIFF 端永不更新 — `liff-api/index.ts:208` 註明）。不論登入選哪家，永遠顯示舊註冊店。開發者原註解（`me/page.tsx:390`「取貨店已在頭像旁 chip 顯示」）也說明該 chip 本意是顯示目前門市，接錯欄位。
- **Bug 2**：`getOverview` 的未結金額 / 進行中筆數有 `.eq("store_id", storeId)` 過濾，但 `listMyOrders` 刻意**不**依店過濾（跨店、會員級，`liff-api/index.ts:261-262` 註明）。兩者不一致 → 列表看得到、overview 卻 0。

## 修正

- **liff-api `getOverview`**：移除未結金額與進行中筆數兩處 `.eq("store_id", storeId)`，改為會員級加總，與 `listMyOrders` 一致。店家資訊卡（banner/付款/出貨）仍依 `storeId`（屬「正在瀏覽哪家店」情境，正確、不變）。
- **`/me` 門市 chip**：改顯示 `overview.store.name`（目前 JWT 門市）；`overview` 取得失敗（catch→null）時回退 `home_store_name`，不空白不報錯。

## 已知限制（不在本次範圍）

LIFF 回頭客的 `liff-session` 會把 JWT `store_id` 鎖定為既有 binding 的 store（刻意設計，對應多 LINE OA／各加盟店獨立計費）。該情境下 chip = binding store，非本次登入所選店。屬既有架構決策，flip 它有跨店／計費影響，不在此 PR。

## 測試

- 測試清單：`docs/TEST-member-store-context.md`
- `tsc --noEmit` 通過；未引入新 lint 問題（既有 2 個 errors 落在未改動的行 100/181）。
- `/me` 即時 preview 受本地環境限制（liff-api 預設未 serve(503) + 需有效 member session），未能跑 UI preview；已完成程式碼／型別層與 SQL 邏輯層驗證。建議 reviewer 於有 member session 的環境照測試清單 §2/§3 驗收。

🤖 Generated with [Claude Code](https://claude.com/claude-code)