### PR TITLE
fix(admin): RPC 失敗改顯示後端訊息，修正 alert 顯示 [object Object]

### DIFF
--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -207,8 +207,34 @@ function fmt(s: string): string {
   return Number.isInteger(n) ? String(n) : String(n);
 }
 
+// supabase-js's PostgrestError shape varies across SDK versions: <=2.104 returns
+// a plain object { message, details, hint, code }; >=2.105 returns an Error
+// subclass. Plus auth/fetch wrappers throw { error: ... }. Extract a usable
+// string from any of these instead of letting String(obj) produce "[object Object]".
+function extractErrorMessage(raw: unknown): string {
+  if (raw == null) return String(raw);
+  if (typeof raw === "string") return raw;
+  if (raw instanceof Error) return raw.message;
+  if (typeof raw === "object") {
+    const o = raw as Record<string, unknown>;
+    if (typeof o.message === "string" && o.message) return o.message;
+    if (typeof o.error === "string" && o.error) return o.error;
+    if (o.error && typeof o.error === "object") {
+      const inner = o.error as Record<string, unknown>;
+      if (typeof inner.message === "string" && inner.message) return inner.message;
+    }
+    try {
+      const j = JSON.stringify(o);
+      if (j && j !== "{}") return j;
+    } catch {
+      /* circular — fall through */
+    }
+  }
+  return String(raw);
+}
+
 export function translateRpcError(raw: unknown): string {
-  const msg = raw instanceof Error ? raw.message : String(raw);
+  const msg = extractErrorMessage(raw);
   for (const r of RULES) {
     const m = msg.match(r.pattern);
     if (m) return r.render(m);


### PR DESCRIPTION
## 問題

後台操作（例：會員改取貨店 `rpc_set_member_home_store`）失敗時，alert 顯示 `儲存失敗：[object Object]`，看不到後端真正的錯誤訊息。

實際 RPC 回傳是正常的：
```json
{"code":"P0001","message":"會員仍有 4 筆未取貨訂單，請先處理完才能改取貨店"}
```

## 根因

`apps/admin/src/lib/rpcError.ts` 的 `translateRpcError`：

```ts
const msg = raw instanceof Error ? raw.message : String(raw);
```

- 部署版用 `@supabase/supabase-js@2.104.0`（package.json pin `^2.104.0`，瀏覽器 header `supabase-js-web/2.104.0`），失敗 RPC 回傳的 `PostgrestError` 是**純物件** `{message,details,hint,code}`。
- `instanceof Error` → `false` → 走 `String(obj)` → `"[object Object]"`。
- 本機裝的是 2.105.3（已改成 `extends Error`），所以**本機重現不出來**，只在線上發生。

## 修正

新增 `extractErrorMessage()`，兼容：純物件 `.message`、`Error` 子類、巢狀 `{error:{message}}`、`{error:"..."}`，最後才 fallback。`translateRpcError` 是 **19 個呼叫端的共用節點**，一次修好全站 RPC 錯誤顯示。

## 驗證

- Node 模擬 2.104 純物件 / 2.105 Error 子類 / 巢狀 / 字串 四種 shape → 全部正確回傳中文訊息；舊碼對 2.104 shape 確實重現 `[object Object]`。
- `eslint src/lib/rpcError.ts` 通過、`tsc --noEmit` 無 rpcError 相關錯誤。
- 注意：因本機 SDK 版本（2.105.3）與線上（2.104.0）不同，此 bug 無法在本機 preview 重現，故未做瀏覽器驗證（preview 證明不了差異）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)