### PR TITLE
feat(member): 全站載入改 iOS 風 spinner 畫面

### DIFF
--- a/apps/member/src/app/install/page.tsx
+++ b/apps/member/src/app/install/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { LoadingScreen } from "@/components/Spinner";
 
 type Env =
   | "loading"
@@ -99,9 +100,7 @@ export default function InstallPage() {
         <p className="text-[14px] text-zinc-500">把 App 加入你的手機,讓下單更方便</p>
       </div>
 
-      {env === "loading" && (
-        <p className="text-zinc-400">載入中…</p>
-      )}
+      {env === "loading" && <LoadingScreen className="py-16" />}
 
       {env === "standalone" && (
         <Card>

--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -246,8 +246,7 @@ export default function MePage() {
                 disabled={generating}
                 className="flex flex-shrink-0 items-center gap-1.5 rounded-full bg-[var(--ios-blue)] px-3 py-1.5 text-[13px] font-medium text-white active:opacity-80 disabled:opacity-50"
               >
-                {generating && <Spinner size={13} onColor />}
-                {generating ? "處理中" : "PWA 碼"}
+                {generating ? <Spinner size={15} onColor /> : "PWA 碼"}
               </button>
             ) : pushState.isSupported && !pushState.subscription ? (
               <button
@@ -472,8 +471,7 @@ export default function MePage() {
                 disabled={saving}
                 className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-[var(--ios-blue)] py-3 text-[16px] font-semibold text-white active:opacity-80 disabled:opacity-50"
               >
-                {saving && <Spinner size={16} onColor />}
-                {saving ? "儲存中…" : "儲存"}
+                {saving ? <Spinner size={18} onColor /> : "儲存"}
               </button>
             </div>
           </form>

--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
+import Spinner, { LoadingScreen } from "@/components/Spinner";
 import { PushNotificationManager } from "@/components/PushNotificationManager";
 import { usePushNotification } from "@/lib/usePushNotification";
 
@@ -168,7 +169,7 @@ export default function MePage() {
   if (loading) {
     return (
       <PageShell title="會員中心">
-        <p className="px-5 pt-4 text-[15px] text-[var(--tertiary-label)]">載入中…</p>
+        <LoadingScreen />
       </PageShell>
     );
   }
@@ -243,9 +244,10 @@ export default function MePage() {
               <button
                 onClick={generatePwaCode}
                 disabled={generating}
-                className="flex-shrink-0 rounded-full bg-[var(--ios-blue)] px-3 py-1.5 text-[13px] font-medium text-white active:opacity-80 disabled:opacity-50"
+                className="flex flex-shrink-0 items-center gap-1.5 rounded-full bg-[var(--ios-blue)] px-3 py-1.5 text-[13px] font-medium text-white active:opacity-80 disabled:opacity-50"
               >
-                {generating ? "..." : "PWA 碼"}
+                {generating && <Spinner size={13} onColor />}
+                {generating ? "處理中" : "PWA 碼"}
               </button>
             ) : pushState.isSupported && !pushState.subscription ? (
               <button
@@ -468,8 +470,9 @@ export default function MePage() {
               <button
                 type="submit"
                 disabled={saving}
-                className="flex-1 rounded-xl bg-[var(--ios-blue)] py-3 text-[16px] font-semibold text-white active:opacity-80 disabled:opacity-50"
+                className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-[var(--ios-blue)] py-3 text-[16px] font-semibold text-white active:opacity-80 disabled:opacity-50"
               >
+                {saving && <Spinner size={16} onColor />}
                 {saving ? "儲存中…" : "儲存"}
               </button>
             </div>

--- a/apps/member/src/app/notifications/page.tsx
+++ b/apps/member/src/app/notifications/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
+import { LoadingScreen } from "@/components/Spinner";
 import NotificationCard, { type NotificationRow } from "@/components/NotificationCard";
 
 export default function NotificationsPage() {
@@ -44,9 +45,7 @@ export default function NotificationsPage() {
   return (
     <PageShell title="通知">
       <div className="space-y-3 px-4 pt-3 pb-6">
-        {loading && (
-          <p className="px-1 text-[15px] text-[var(--tertiary-label)]">載入中…</p>
-        )}
+        {loading && <LoadingScreen />}
         {err && (
           <div className="rounded-2xl bg-[var(--ios-red)]/10 p-3 text-[14px] text-[#c4271d]">
             {err}

--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
+import { LoadingScreen } from "@/components/Spinner";
 import SubTabs from "@/components/SubTabs";
 import OrderCard, { type OrderRow } from "@/components/OrderCard";
 
@@ -61,9 +62,7 @@ export default function OrdersPage() {
       />
 
       <div className="space-y-3 px-4 pt-3 pb-6">
-        {loading && (
-          <p className="px-1 text-[15px] text-[var(--tertiary-label)]">載入中…</p>
-        )}
+        {loading && <LoadingScreen />}
 
         {err && (
           <div className="rounded-2xl bg-[var(--ios-red)]/10 p-3 text-[14px] text-[#c4271d]">

--- a/apps/member/src/app/overview/page.tsx
+++ b/apps/member/src/app/overview/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
+import { LoadingScreen } from "@/components/Spinner";
 import { PushNotificationManager } from "@/components/PushNotificationManager";
 import { usePushNotification } from "@/lib/usePushNotification";
 
@@ -65,9 +66,7 @@ export default function OverviewPage() {
   return (
     <PageShell title={data?.store.name ?? "總覽"}>
       <div className="space-y-4 px-4 pt-2 pb-6">
-        {loading && (
-          <p className="px-1 text-[15px] text-[var(--tertiary-label)]">載入中…</p>
-        )}
+        {loading && <LoadingScreen />}
 
         {err && (
           <div className="rounded-2xl bg-[#ff3b30]/10 p-3 text-[14px] text-[#c4271d]">

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { lineOauthStartUrl, callLiffApi } from "@/lib/supabase";
 import { loadLiff } from "@/lib/liff";
 import { clearSession, getSession, listenForSession } from "@/lib/session";
+import Spinner, { LoadingScreen } from "@/components/Spinner";
 
 type Status = "loading" | "idle" | "liff_auth" | "pair_done" | "error";
 
@@ -301,14 +302,10 @@ export default function LandingPage() {
       </div>
 
       <div className="mt-9 w-full">
-        {status === "loading" && (
-          <p className="text-center text-[15px] text-[var(--tertiary-label)]">載入中…</p>
-        )}
+        {status === "loading" && <LoadingScreen className="py-14" />}
 
         {status === "liff_auth" && (
-          <p className="text-center text-[15px] text-[var(--secondary-label)]">
-            LINE 驗證中…請稍候
-          </p>
+          <LoadingScreen className="py-14" label="LINE 驗證中…請稍候" />
         )}
 
         {status === "pair_done" && (
@@ -428,9 +425,10 @@ export default function LandingPage() {
                         <button
                           type="submit"
                           disabled={syncCode.length !== 6 || syncing}
-                          className="rounded-xl brand-gradient px-5 py-2.5 text-[15px] font-semibold text-white transition active:scale-[0.97] disabled:opacity-40"
+                          className="flex items-center justify-center gap-2 rounded-xl brand-gradient px-5 py-2.5 text-[15px] font-semibold text-white transition active:scale-[0.97] disabled:opacity-40"
                         >
-                          {syncing ? "..." : "驗證"}
+                          {syncing && <Spinner size={15} onColor />}
+                          {syncing ? "驗證中" : "驗證"}
                         </button>
                       </form>
                     </div>

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -304,9 +304,7 @@ export default function LandingPage() {
       <div className="mt-9 w-full">
         {status === "loading" && <LoadingScreen className="py-14" />}
 
-        {status === "liff_auth" && (
-          <LoadingScreen className="py-14" label="LINE 驗證中…請稍候" />
-        )}
+        {status === "liff_auth" && <LoadingScreen className="py-14" />}
 
         {status === "pair_done" && (
           <div className="card p-6 text-center">
@@ -427,8 +425,7 @@ export default function LandingPage() {
                           disabled={syncCode.length !== 6 || syncing}
                           className="flex items-center justify-center gap-2 rounded-xl brand-gradient px-5 py-2.5 text-[15px] font-semibold text-white transition active:scale-[0.97] disabled:opacity-40"
                         >
-                          {syncing && <Spinner size={15} onColor />}
-                          {syncing ? "驗證中" : "驗證"}
+                          {syncing ? <Spinner size={16} onColor /> : "驗證"}
                         </button>
                       </form>
                     </div>

--- a/apps/member/src/app/register/page.tsx
+++ b/apps/member/src/app/register/page.tsx
@@ -209,8 +209,13 @@ export default function RegisterPage() {
           disabled={submitting}
           className="mt-2 flex items-center justify-center gap-2 rounded-md bg-[#06C755] px-4 py-3 text-base font-medium text-white shadow hover:bg-[#05b04c] disabled:opacity-50"
         >
-          {submitting && <Spinner size={16} onColor />}
-          {submitting ? "處理中…" : lookup ? "確認綁定此 LINE" : "建立會員並綁定 LINE"}
+          {submitting ? (
+            <Spinner size={18} onColor />
+          ) : lookup ? (
+            "確認綁定此 LINE"
+          ) : (
+            "建立會員並綁定 LINE"
+          )}
         </button>
 
         <p className="text-center text-sm text-zinc-400">

--- a/apps/member/src/app/register/page.tsx
+++ b/apps/member/src/app/register/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { consumeFragmentToSession, getSession } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
+import Spinner, { LoadingScreen } from "@/components/Spinner";
 
 type LookupRow = {
   member_id: number;
@@ -99,7 +100,11 @@ export default function RegisterPage() {
   if (!ready) {
     return (
       <main className="mx-auto max-w-md p-6">
-        {error ? <p className="text-base text-red-700">{error}</p> : <p className="text-base text-zinc-500">載入中…</p>}
+        {error ? (
+          <p className="text-base text-red-700">{error}</p>
+        ) : (
+          <LoadingScreen className="py-24" />
+        )}
       </main>
     );
   }
@@ -202,8 +207,9 @@ export default function RegisterPage() {
         <button
           type="submit"
           disabled={submitting}
-          className="mt-2 rounded-md bg-[#06C755] px-4 py-3 text-base font-medium text-white shadow hover:bg-[#05b04c] disabled:opacity-50"
+          className="mt-2 flex items-center justify-center gap-2 rounded-md bg-[#06C755] px-4 py-3 text-base font-medium text-white shadow hover:bg-[#05b04c] disabled:opacity-50"
         >
+          {submitting && <Spinner size={16} onColor />}
           {submitting ? "處理中…" : lookup ? "確認綁定此 LINE" : "建立會員並綁定 LINE"}
         </button>
 

--- a/apps/member/src/app/settlements/page.tsx
+++ b/apps/member/src/app/settlements/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
+import { LoadingScreen } from "@/components/Spinner";
 import SubTabs from "@/components/SubTabs";
 import SettlementCard, { type SettlementRow } from "@/components/SettlementCard";
 
@@ -53,9 +54,7 @@ export default function SettlementsPage() {
       />
 
       <div className="space-y-3 px-4 pt-3 pb-6">
-        {loading && (
-          <p className="px-1 text-[15px] text-[var(--tertiary-label)]">載入中…</p>
-        )}
+        {loading && <LoadingScreen />}
 
         {err && (
           <div className="rounded-2xl bg-[var(--ios-red)]/10 p-3 text-[14px] text-[#c4271d]">

--- a/apps/member/src/app/shop/c/[id]/page.tsx
+++ b/apps/member/src/app/shop/c/[id]/page.tsx
@@ -665,8 +665,13 @@ function BuySheet({
               disabled={submitting || totalQty === 0}
               className="flex flex-1 items-center justify-center gap-2 rounded-full brand-gradient py-3.5 text-[18px] font-bold text-white shadow-[0_8px_20px_-8px_rgba(158,47,80,0.6)] transition-transform active:scale-[0.99] disabled:opacity-40 disabled:shadow-none"
             >
-              {submitting && <Spinner size={18} onColor />}
-              {submitting ? "送出中…" : totalQty === 0 ? "請先選擇商品" : "送出訂單"}
+              {submitting ? (
+                <Spinner size={20} onColor />
+              ) : totalQty === 0 ? (
+                "請先選擇商品"
+              ) : (
+                "送出訂單"
+              )}
             </button>
           </div>
         </div>

--- a/apps/member/src/app/shop/c/[id]/page.tsx
+++ b/apps/member/src/app/shop/c/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
+import Spinner, { LoadingScreen } from "@/components/Spinner";
 import Countdown from "@/components/Countdown";
 
 /** 清掉 legacy LINE 匯入殘留的佔位字 (emoji)/(heart)，並收斂多餘空白。
@@ -149,9 +150,7 @@ export default function CampaignDetailPage() {
   return (
     <PageShell title={campaign?.name ?? "商品"}>
       <div className="space-y-4 px-0 pb-[160px]">
-        {loading && (
-          <p className="px-5 pt-2 text-[16px] text-[var(--tertiary-label)]">載入中…</p>
-        )}
+        {loading && <LoadingScreen />}
 
         {err && (
           <div className="mx-4 rounded-2xl bg-[#ff3b30]/10 p-3 text-[15px] text-[#c4271d]">
@@ -664,8 +663,9 @@ function BuySheet({
             <button
               onClick={onSubmit}
               disabled={submitting || totalQty === 0}
-              className="flex-1 rounded-full brand-gradient py-3.5 text-[18px] font-bold text-white shadow-[0_8px_20px_-8px_rgba(158,47,80,0.6)] transition-transform active:scale-[0.99] disabled:opacity-40 disabled:shadow-none"
+              className="flex flex-1 items-center justify-center gap-2 rounded-full brand-gradient py-3.5 text-[18px] font-bold text-white shadow-[0_8px_20px_-8px_rgba(158,47,80,0.6)] transition-transform active:scale-[0.99] disabled:opacity-40 disabled:shadow-none"
             >
+              {submitting && <Spinner size={18} onColor />}
               {submitting ? "送出中…" : totalQty === 0 ? "請先選擇商品" : "送出訂單"}
             </button>
           </div>

--- a/apps/member/src/app/shop/flash/page.tsx
+++ b/apps/member/src/app/shop/flash/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
+import { LoadingScreen } from "@/components/Spinner";
 import CampaignCard, {
   campaignBadgeLabel,
   campaignRemaining,
@@ -60,9 +61,7 @@ export default function FlashPage() {
       )}
 
       <div className="space-y-3 px-4 pt-3 pb-6">
-        {loading && (
-          <p className="px-1 text-[16px] text-[var(--tertiary-label)]">載入中…</p>
-        )}
+        {loading && <LoadingScreen />}
 
         {err && (
           <div className="rounded-2xl bg-[#ff3b30]/10 p-3 text-[15px] text-[#c4271d]">

--- a/apps/member/src/app/wallet/page.tsx
+++ b/apps/member/src/app/wallet/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
+import Spinner, { LoadingScreen } from "@/components/Spinner";
 
 type WalletInfo = {
   balance: number;
@@ -98,9 +99,7 @@ export default function WalletPage() {
   return (
     <PageShell title="儲值金">
       <div className="space-y-4 px-4 pt-3 pb-6">
-        {loading && (
-          <p className="px-1 text-[15px] text-[var(--tertiary-label)]">載入中…</p>
-        )}
+        {loading && <LoadingScreen />}
 
         {err && (
           <div className="rounded-2xl bg-[#ff3b30]/10 p-3 text-[14px] text-[#c4271d]">{err}</div>
@@ -178,8 +177,9 @@ export default function WalletPage() {
               <button
                 onClick={loadMore}
                 disabled={loadingMore}
-                className="block w-full border-t border-[var(--separator)] px-4 py-3 text-center text-[15px] text-[var(--brand-strong)] active:bg-[#76768033] disabled:opacity-50"
+                className="flex w-full items-center justify-center gap-2 border-t border-[var(--separator)] px-4 py-3 text-center text-[15px] text-[var(--brand-strong)] active:bg-[#76768033] disabled:opacity-50"
               >
+                {loadingMore && <Spinner size={16} />}
                 {loadingMore ? "載入中…" : "載入更多"}
               </button>
             )}

--- a/apps/member/src/app/wallet/page.tsx
+++ b/apps/member/src/app/wallet/page.tsx
@@ -179,8 +179,7 @@ export default function WalletPage() {
                 disabled={loadingMore}
                 className="flex w-full items-center justify-center gap-2 border-t border-[var(--separator)] px-4 py-3 text-center text-[15px] text-[var(--brand-strong)] active:bg-[#76768033] disabled:opacity-50"
               >
-                {loadingMore && <Spinner size={16} />}
-                {loadingMore ? "載入中…" : "載入更多"}
+                {loadingMore ? <Spinner size={18} /> : "載入更多"}
               </button>
             )}
           </div>

--- a/apps/member/src/components/PullToRefresh.tsx
+++ b/apps/member/src/components/PullToRefresh.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import RingSpinner from "./Spinner";
 
 const THRESHOLD = 64;
 const MAX_PULL = 110;
@@ -126,17 +127,7 @@ function Spinner({
   ready: boolean;
 }) {
   if (spinning) {
-    return (
-      <svg className="h-5 w-5 animate-spin" viewBox="0 0 24 24" fill="none">
-        <circle cx="12" cy="12" r="9" stroke="#7676801f" strokeWidth="2.5" />
-        <path
-          d="M12 3a9 9 0 0 1 9 9"
-          stroke="var(--brand-strong)"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-        />
-      </svg>
-    );
+    return <RingSpinner size={20} />;
   }
   // 拉動時:箭頭在到達閾值時翻轉
   return (

--- a/apps/member/src/components/Spinner.tsx
+++ b/apps/member/src/components/Spinner.tsx
@@ -1,0 +1,58 @@
+/**
+ * 全站統一的 iOS 風 spinner：淡灰底環 + 品牌色弧線旋轉。
+ * - 一般淺底用 default（品牌玫瑰弧）
+ * - 彩色 CTA 鈕內用 onColor（白弧），避免品牌色壓在品牌漸層上看不清
+ */
+export default function Spinner({
+  size = 20,
+  onColor = false,
+  className = "",
+}: {
+  size?: number;
+  onColor?: boolean;
+  className?: string;
+}) {
+  const track = onColor ? "rgba(255,255,255,0.4)" : "#7676801f";
+  const arc = onColor ? "#ffffff" : "var(--brand-strong)";
+  return (
+    <svg
+      className={`animate-spin ${className}`}
+      style={{ width: size, height: size }}
+      viewBox="0 0 24 24"
+      fill="none"
+      role="status"
+      aria-label="載入中"
+    >
+      <circle cx="12" cy="12" r="9" stroke={track} strokeWidth="2.5" />
+      <path
+        d="M12 3a9 9 0 0 1 9 9"
+        stroke={arc}
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+/**
+ * 整頁 / 區塊置中的載入畫面（取代裸文字「載入中…」），讓首屏更像原生 App。
+ * 預設不帶文字 —— 原生 App 多半只轉圈不寫字；需要語境時才傳 label。
+ */
+export function LoadingScreen({
+  label,
+  className = "min-h-[55vh]",
+}: {
+  label?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center gap-3 ${className}`}
+    >
+      <Spinner size={30} />
+      {label ? (
+        <p className="text-[14px] text-[var(--secondary-label)]">{label}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/docs/TEST-member-loading-spinner.md
+++ b/docs/TEST-member-loading-spinner.md
@@ -29,19 +29,23 @@
 - [ ] `/shop/flash` 同上
 - [ ] `/shop/c/[id]` 同上
 - [ ] `/me` 首次載入整頁 spinner（仍包在 PageShell；`!me` 錯誤態文案不變）
-- [ ] `/`（landing）`status==="loading"` → spinner；`status==="liff_auth"` → spinner + 「LINE 驗證中…請稍候」
+- [ ] `/`（landing）`status==="loading"` → 純 spinner；`status==="liff_auth"` → 純 spinner（無文字）
 - [ ] `/register` `!ready` 載入 → spinner（`error` 分支文案不變）
 - [ ] `/install` `env==="loading"` → spinner
 - [ ] `/shop` 維持既有 skeleton（內容網格的原生佔位模式，刻意不換 spinner）
 
-## 3. Async 按鈕 inline spinner
+## 3. Async 按鈕 busy 態 = 純 spinner（無文字）
 
-- [ ] `/shop/c/[id]` BuySheet 送出鈕：`submitting` 時白 spinner + 「送出中…」
-- [ ] `/me` 儲存鈕：`saving` 時白 spinner + 「儲存中…」
-- [ ] `/me` PWA 碼鈕：`generating` 時白 spinner +「處理中」（原本只有「...」）
-- [ ] `/`（landing）驗證鈕：`syncing` 時白 spinner +「驗證中」（原本只有「...」）
-- [ ] `/wallet` 載入更多：`loadingMore` 時 spinner + 「載入中…」
-- [ ] `/register` 送出鈕：`submitting` 時白 spinner + 「處理中…」
+> 使用者回饋「不要用載入中那個方式」：busy 時**只轉圈、不顯示任何「…中」文字**；
+> idle 標籤維持原樣。
+
+- [ ] `/shop/c/[id]` BuySheet 送出鈕：`submitting` → 只白 spinner（無「送出中…」）；idle = 請先選擇商品 / 送出訂單
+- [ ] `/me` 儲存鈕：`saving` → 只白 spinner；idle =「儲存」
+- [ ] `/me` PWA 碼鈕：`generating` → 只白 spinner；idle =「PWA 碼」
+- [ ] `/`（landing）驗證鈕：`syncing` → 只白 spinner；idle =「驗證」
+- [ ] `/wallet` 載入更多：`loadingMore` → 只 spinner；idle =「載入更多」
+- [ ] `/register` 送出鈕：`submitting` → 只白 spinner；idle = 確認綁定 / 建立會員
+- [ ] 全站無可見「載入中 / 驗證中 / 送出中 / 儲存中 / 處理中」文字（`Spinner` 的 `aria-label="載入中"` 為螢幕報讀、不可見，保留）
 
 ## 4. 回歸 / 品質
 

--- a/docs/TEST-member-loading-spinner.md
+++ b/docs/TEST-member-loading-spinner.md
@@ -1,0 +1,52 @@
+# 測試項目 — member App 全站 spin loading 畫面
+
+**範圍:** 純前端 UI。把 `apps/member` 各頁裸文字「載入中…」換成 iOS 風 spinner 載入畫面，並在 async 動作按鈕加 inline spinner，讓 App 更像原生。
+
+**對應變更:**
+- 新增 `apps/member/src/components/Spinner.tsx`（`Spinner` + `LoadingScreen`）
+- `apps/member/src/components/PullToRefresh.tsx`（改用共用 Spinner）
+- 11 頁 page-level loader + 5 個 async 按鈕 inline spinner
+
+**驗證方式（無 schema / RPC，照 reference_member_preview_verify 走輕量驗證）:** `tsc --noEmit` + `next build` + grep 全站無殘留裸 loader + 逐頁 code review。
+
+---
+
+## 1. 共用元件
+
+- [ ] `Spinner` 預設 20px、淡灰底環 `#7676801f` + 品牌色 `--brand-strong` 弧、`animate-spin`
+- [ ] `Spinner` `onColor` 變體 = 白弧 + 半透明白底環（給品牌漸層 / 藍 / LINE 綠等彩色鈕用）
+- [ ] `Spinner` 有 `role="status"` + `aria-label="載入中"`（無障礙）
+- [ ] `LoadingScreen` = 置中 30px spinner，預設無文字；可選 `label`、可覆寫 `className`（預設 `min-h-[55vh]`）
+- [ ] `PullToRefresh` 旋轉態改用共用 `Spinner`，下拉箭頭態邏輯不變
+
+## 2. Page-level loader（裸「載入中…」→ `<LoadingScreen />`）
+
+- [ ] `/orders` 載入中顯示置中 spinner（非文字）
+- [ ] `/overview` 同上
+- [ ] `/notifications` 同上
+- [ ] `/settlements` 同上
+- [ ] `/wallet` 同上
+- [ ] `/shop/flash` 同上
+- [ ] `/shop/c/[id]` 同上
+- [ ] `/me` 首次載入整頁 spinner（仍包在 PageShell；`!me` 錯誤態文案不變）
+- [ ] `/`（landing）`status==="loading"` → spinner；`status==="liff_auth"` → spinner + 「LINE 驗證中…請稍候」
+- [ ] `/register` `!ready` 載入 → spinner（`error` 分支文案不變）
+- [ ] `/install` `env==="loading"` → spinner
+- [ ] `/shop` 維持既有 skeleton（內容網格的原生佔位模式，刻意不換 spinner）
+
+## 3. Async 按鈕 inline spinner
+
+- [ ] `/shop/c/[id]` BuySheet 送出鈕：`submitting` 時白 spinner + 「送出中…」
+- [ ] `/me` 儲存鈕：`saving` 時白 spinner + 「儲存中…」
+- [ ] `/me` PWA 碼鈕：`generating` 時白 spinner +「處理中」（原本只有「...」）
+- [ ] `/`（landing）驗證鈕：`syncing` 時白 spinner +「驗證中」（原本只有「...」）
+- [ ] `/wallet` 載入更多：`loadingMore` 時 spinner + 「載入中…」
+- [ ] `/register` 送出鈕：`submitting` 時白 spinner + 「處理中…」
+
+## 4. 回歸 / 品質
+
+- [ ] `grep` 全 `apps/member/src`：無殘留裸 page-level「載入中…」`<p>`（只剩按鈕標籤 + Spinner aria/doc）
+- [ ] `tsc --noEmit` 0 error
+- [ ] `next build` 成功（static export，全頁 prerender 不報錯）
+- [ ] 彩色鈕上 spinner 對比足夠（onColor 白弧），淺底 spinner 用品牌玫瑰弧
+- [ ] 無新增 `eslint` error


### PR DESCRIPTION
## Summary
- member App 各頁裸文字「載入中…」全面換成 iOS 風 spin loading 畫面，整體更像原生 App
- 新增共用 `Spinner`（淡灰底環 + 品牌色弧、`animate-spin`、`role=status` 無障礙）與 `LoadingScreen`（置中、預設無文字、可選 label）
- 11 頁 page-level loader：orders / overview / notifications / settlements / wallet / shop/flash / shop/c/[id] / me（整頁）/ landing（loading + LINE 驗證中）/ register / install
- 6 個 async 鈕加 inline spinner（彩色鈕用白弧 `onColor`）：下單送出 / me 儲存 / me PWA 碼 / landing 驗證 / wallet 載入更多 / register 送出
- `PullToRefresh` 旋轉態改用共用 `Spinner`（消重複 SVG），下拉箭頭態邏輯不變
- `/shop` **刻意保留** 既有 skeleton（內容網格的原生佔位模式，換 spinner 反而退步）

## Test plan
驗收清單見 `docs/TEST-member-loading-spinner.md`。純前端、無 schema / RPC，免部署。

- [x] `tsc --noEmit` 0 error
- [x] `next build`（webpack / static export）14 頁全 prerender 綠
- [x] grep 全 `apps/member/src`：無殘留裸 page-level「載入中…」`<p>`（僅剩按鈕標籤 + Spinner aria/doc）
- [x] 改動檔 eslint 無「新增」error（既有 `react-hooks/set-state-in-effect` / `sw.ts` 為 main 既有 baseline，非本 PR 引入）
- [ ] 使用者於 member App 實機 / preview 自審：彩色鈕白弧對比、首屏 spinner 觀感

🤖 Generated with [Claude Code](https://claude.com/claude-code)