### PR TITLE
fix(admin): 選品週曆手機版面跑掉，改水平捲動、桌機保留七欄

### DIFF
--- a/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
+++ b/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
@@ -318,7 +318,7 @@ export default function CommunityCandidatesCalendarPage() {
           onDragOver={onDragOver}
           onDragEnd={onDragEnd}
         >
-          <div className="grid grid-cols-7 gap-2 overflow-x-auto">
+          <div className="flex gap-2 overflow-x-auto pb-2 lg:grid lg:grid-cols-7 lg:overflow-x-visible lg:pb-0">
             {days.map((d) => {
               const key = formatDate(d);
               const isToday = key === todayStr;
@@ -376,7 +376,7 @@ function DayColumn({
   return (
     <div
       ref={setNodeRef}
-      className={`flex min-h-[200px] min-w-[120px] flex-col gap-2 rounded-md p-1 transition ${
+      className={`flex min-h-[200px] w-[200px] shrink-0 flex-col gap-2 rounded-md p-1 transition lg:w-auto lg:min-w-0 ${
         isOver
           ? "bg-amber-50 ring-2 ring-amber-300 dark:bg-amber-950/30 dark:ring-amber-700"
           : ""


### PR DESCRIPTION
## 問題

選品週曆（`/community-candidates/calendar`）在手機上版面跑掉：`grid grid-cols-7` 把 7 欄壓進 ~375px（每欄約 50px），但每個 `DayColumn` 有 `min-w-[120px]`，導致欄位溢出自己的 grid cell、彼此**重疊**，卡片與日期標頭擠成一團。

## 修正

- **手機 / 平板**：容器改 `flex + overflow-x-auto`，每個日欄固定 `w-[200px] shrink-0` → 變成乾淨的水平捲動，欄位不再重疊、卡片內容好讀。
- **桌機 (`lg:`)**：維持原本 `grid grid-cols-7` 滿版七欄，行為不變。
- 跨日拖拉（換日）在兩種版面皆可運作（dnd-kit 於容器邊緣自動捲動）。

僅 2 行 Tailwind class 變更，無邏輯 / schema / RPC 異動。

## 驗證

本機 Docker（Supabase）未啟動，受保護頁無法登入、screenshot pipeline 卡在 hang 住的 auth 請求，故無法附截圖。改以 dev server 載入實際編譯後的 Tailwind bundle，對**完全相同的 class** 做 DOM 量測（重現使用者情境：今日欄 4 張卡 + 其餘「無排程」）：

| | display | 欄數 / 寬 | 水平捲動 | 相鄰欄重疊 |
|---|---|---|---|---|
| 手機 375px | `flex` | 7 × 200px | 是（scrollWidth 1448 > 327）| **否** |
| 桌機 1280px | `grid` | 7 × 169px（均分）| 否 | **否** |

重疊 bug 已消除；桌機維持原樣。

🤖 Generated with [Claude Code](https://claude.com/claude-code)