### PR TITLE
feat(admin/orders,pickup): 已收貨單一鍵導向退貨回總倉

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
+import OrderReturnCreateModal from "@/components/OrderReturnCreateModal";
 import { translateRpcError } from "@/lib/rpcError";
 import { withBasePath } from "@/lib/basePath";
 import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
@@ -137,6 +138,7 @@ function OrdersListContent() {
   const [pickupReady, setPickupReady] = useState<Map<number, boolean>>(new Map());
   const [detailId, setDetailId] = useState<number | null>(null);
   const [detailNo, setDetailNo] = useState<string>("");
+  const [returnTarget, setReturnTarget] = useState<{ orderId: number; storeId: number } | null>(null);
   const [reloadOrders, setReloadOrders] = useState(0);
 
   // KPI trend (當月 1 號 ~ 今天 每日 + 本月累計、套 filter 開團+店家、排除 transferred_out)
@@ -773,6 +775,15 @@ function OrdersListContent() {
                           已轉出
                         </SpinButton>
                       )}
+                      {["ready", "partially_completed", "completed", "expired"].includes(r.status) && (
+                        <SpinButton
+                          onClick={() => setReturnTarget({ orderId: r.id, storeId: r.pickup_store_id })}
+                          title="已收貨/已取貨，無法取消；點此退貨回總倉（反向回收已派庫存）"
+                          className="rounded-md border border-orange-300 px-2 py-1 text-[11px] font-medium text-orange-700 hover:bg-orange-50 dark:border-orange-800 dark:text-orange-300 dark:hover:bg-orange-950"
+                        >
+                          ↩ 退貨
+                        </SpinButton>
+                      )}
                     </div>
                   </Td>
                 </tr>
@@ -798,6 +809,14 @@ function OrdersListContent() {
           />
         )}
       </Modal>
+
+      <OrderReturnCreateModal
+        open={returnTarget !== null}
+        onClose={() => setReturnTarget(null)}
+        onCreated={() => { setReturnTarget(null); setReloadOrders((n) => n + 1); }}
+        prefillOrderId={returnTarget?.orderId ?? null}
+        prefillStoreId={returnTarget?.storeId ?? null}
+      />
 
       {totalPages > 1 && (
         <div className="flex items-center justify-end gap-2 text-sm">

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { PickupDialog } from "@/components/PickupDialog";
+import OrderReturnCreateModal from "@/components/OrderReturnCreateModal";
 import { withBasePath } from "@/lib/basePath";
 import SpinButton from "@/components/SpinButton";
 import { getPickupRecents, recordPickupRecent, type RecentCustomer } from "@/lib/pickupRecents";
@@ -77,6 +78,7 @@ function PickupPageContent() {
   const autoSearchedRef = useRef(false);
 
   const [pickup, setPickup] = useState<{ orderId: number; orderNo: string } | null>(null);
+  const [returnTarget, setReturnTarget] = useState<{ orderId: number; storeId: number | null } | null>(null);
   const [recents, setRecents] = useState<RecentCustomer[]>([]);
   const [bulking, setBulking] = useState<number | null>(null);
   const [bulkConfirm, setBulkConfirm] = useState<Member | null>(null);
@@ -503,6 +505,15 @@ function PickupPageContent() {
                             >
                               ✅ 取貨
                             </SpinButton>
+                            {["ready", "partially_completed"].includes(o.status) && (
+                              <SpinButton
+                                onClick={() => setReturnTarget({ orderId: o.id, storeId: o.pickup_store_id ?? o.store?.id ?? null })}
+                                title="已收貨，無法取消；點此退貨回總倉（反向回收已派庫存）"
+                                className="rounded-md border border-orange-300 px-2 py-2 text-xs font-medium text-orange-700 hover:bg-orange-50 dark:border-orange-800 dark:text-orange-300 dark:hover:bg-orange-950"
+                              >
+                                ↩ 退貨
+                              </SpinButton>
+                            )}
                           </li>
                         );
                       })}
@@ -528,6 +539,14 @@ function PickupPageContent() {
           }}
         />
       )}
+
+      <OrderReturnCreateModal
+        open={returnTarget !== null}
+        onClose={() => setReturnTarget(null)}
+        onCreated={() => { setReturnTarget(null); setReloadTick((n) => n + 1); }}
+        prefillOrderId={returnTarget?.orderId ?? null}
+        prefillStoreId={returnTarget?.storeId ?? null}
+      />
 
       <Modal
         open={bulkConfirm !== null}

--- a/docs/TEST-order-return-entry.md
+++ b/docs/TEST-order-return-entry.md
@@ -1,0 +1,58 @@
+# order-return-entry 測試項目 — 已收貨單一鍵導向退貨回總倉
+
+**對應 migration:** 無（沿用既有 `rpc_create_order_return`，`OrderReturnCreateModal` 已上線）
+**對應 UI 變更:** `apps/admin/src/app/(protected)/orders/page.tsx`、`apps/admin/src/app/(protected)/pickup/page.tsx`
+**對應 PRD:** `docs/PRD-LIFF前端.md`（銷售/退貨）
+
+> 背景：使用者反映 `GB20260511-C000003-0001` 這類**已收貨/已到貨**團購單「為什麼不能取消」。取消規則刻意不開放已收貨單（避免取消已派/已取貨）；正解是走既有「退貨回總倉」。本功能**不改取消規則**，只在訂單頁/取貨頁對這類單顯示原因並一鍵帶到既有 `OrderReturnCreateModal`（prefill 該單）。
+
+## 1. Schema / Migration 層
+
+- [ ] 無新增 migration（`git diff origin/main...HEAD -- supabase/migrations/` 為空）
+- [ ] 無新增 / 變更 RPC（沿用 `rpc_create_order_return`）
+
+## 2. RPC 行為（沿用既有，僅複核）
+
+> 不新增 RPC。複核 `OrderReturnCreateModal` 仍以 prefill 的 order/store 正常呼叫 `rpc_create_order_return`：
+
+### 2.1 prefill 帶入
+**情境：** 從訂單頁/取貨頁某 `ready` 單按「↩ 退貨」。
+**預期：** modal 開啟即定在該單（跳過 store/order picker），SKU 表顯示 delivered / already_returned / returnable。
+
+### 2.2 既有 guardrail 不變
+**情境：** 送出退貨。
+**預期：** 沿用 `rpc_create_order_return` 既有限制（status ∈ shipping/ready/partially_completed/completed/expired；qty ≤ delivered − already_returned），錯誤照舊經 `translateRpcError` 顯示。
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 訂單頁 — ↩ 退貨 鈕 gating
+- [ ] `ready` / `partially_completed` 單：操作欄出現「↩ 退貨」鈕（與「去取貨」並存）
+- [ ] `completed` 單：「已完成」灰標旁出現「↩ 退貨」
+- [ ] `expired` 單：「已逾期」灰標旁出現「↩ 退貨」
+- [ ] `pending` / `confirmed` / `shipping`：**不出現**「↩ 退貨」（這些走「取消」）
+- [ ] `cancelled` / `transferred_out`：**不出現**「↩ 退貨」（不可退）
+- [ ] 「↩ 退貨」鈕 hover tooltip 明確說明：已收貨/已取貨，無法取消，點此退貨回總倉
+
+### 3.2 訂單頁 — 一鍵開 modal
+- [ ] 按「↩ 退貨」→ `OrderReturnCreateModal` 開啟且 prefill 該 `orderId` + `pickup_store_id`
+- [ ] modal 內成功送出退貨 → modal 關閉、訂單列表 reload
+- [ ] modal「取消/關閉」→ 不送出、回列表，原訂單狀態不變
+
+### 3.3 取貨頁 — ↩ 退貨 鈕
+- [ ] `ready` / `partially_completed` 單：在「🔔 通知 / ✅ 取貨」旁出現「↩ 退貨」
+- [ ] `pending` / `confirmed` / `reserved` / `partially_ready` / `shipping`：**不出現**「↩ 退貨」
+- [ ] 按下 → prefill 該單開 modal；成功送出 → reload 搜尋
+
+### 3.4 GB20260511-C000003-0001 情境
+- [ ] 該團購單若為 ready/partially_completed/completed/expired → 訂單頁搜尋後可見「↩ 退貨」，一鍵進退貨流程（不再「卡住無路可走」）
+
+## 4. Regression
+- [ ] 取消規則**完全未動**：`rpc_cancel_aid_order` 與訂單頁/取貨頁既有「取消」鈕 gating（pending/confirmed/shipping）行為不變
+- [ ] `OrderDetail` 內既有「↩ 退訂單」鈕、其 `OrderReturnCreateModal`（prefill）行為不變
+- [ ] 訂單頁：搜尋(若 #257 已併)、開團/取貨店 filter、明細 Modal、分頁、去取貨、KPI 卡不受影響
+- [ ] 取貨頁：搜尋、常用顧客、通知、PickupDialog 取貨、一次全取、列印不受影響
+- [ ] `wms/transfers` 頁的退貨入口不受影響（共用同一 modal 元件）
+
+## 5. 驗收門檻
+
+全部 §3-§4 勾完、**無 console error**、**build + type-check 過** 才可標 done。（無 migration / 新 RPC，§1-§2 僅複核。）


### PR DESCRIPTION
## Summary
- 接續使用者「`GB20260511-C000003-0001` 為什麼不能取消」的診斷：已收貨/已到貨單**刻意不可取消**，正解走既有退貨回總倉
- **不改取消規則**。訂單頁/取貨頁對 `ready` / `partially_completed` / `completed` / `expired` 的單顯示「↩ 退貨」鈕 + tooltip 說明原因，一鍵開既有 `OrderReturnCreateModal`（prefill 該單，跳過 store/order picker）
- 訂單頁 gate：ready/partially_completed/completed/expired（pending/confirmed/shipping 仍走「取消」，cancelled/transferred_out 不可退）
- 取貨頁 gate：ready/partially_completed
- 沿用 `rpc_create_order_return`，**無新增 migration / RPC**；`next build` exit 0；run-feature-tests DONE 0 fail

## Merge note
此分支開在 `main`、diff 乾淨；但仍 open 的 **#258** 也在 `pickup/page.tsx` 取貨鈕後插入按鈕，兩者一起 merge 時該 `<li>` 會有 trivial 相鄰插入衝突——保留兩塊即可（狀態 gate 互斥：#258=pending/confirmed/shipping，本 PR=ready/partially_completed）。

## Test plan
詳見 `docs/TEST-order-return-entry.md`
- [ ] 訂單頁/取貨頁 ↩退貨 鈕只在 received/done 狀態出現；tooltip 說明原因
- [ ] 一鍵開 modal 已 prefill 該單；送出成功後 reload
- [ ] regression：取消規則、OrderDetail 退訂單、wms/transfers 入口、兩頁既有流程不變
- [ ] GB20260511-C000003-0001 依其狀態可循 ↩退貨 入退貨流程

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)