### PR TITLE
feat(admin): 商品 detail 顯示關聯開團 + 開/關 switch

### DIFF
--- a/apps/admin/src/app/(protected)/products/page.tsx
+++ b/apps/admin/src/app/(protected)/products/page.tsx
@@ -7,6 +7,7 @@ import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { ProductForm, type ProductFormValues } from "@/components/ProductForm";
 import { ProductSkuSection, type ProductSkuSectionHandle } from "@/components/ProductSkuSection";
+import { ProductCampaignsPanel } from "@/components/ProductCampaignsPanel";
 import { DatePicker } from "@/components/DatePicker";
 import SpinButton from "@/components/SpinButton";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow } from "@/components/DataTable";
@@ -720,16 +721,23 @@ function PageContent() {
           />
         )}
         {modal?.mode === "edit" && (
-          <ProductForm
-            initial={modal.values}
-            onSaved={() => { setModal(null); setReloadTick((t) => t + 1); }}
-            onCancel={() => setModal(null)}
-            midSlot={
-              modal.values.id !== null ? (
-                <ProductSkuSection productId={modal.values.id} />
-              ) : null
-            }
-          />
+          <div className="space-y-6">
+            <ProductForm
+              initial={modal.values}
+              onSaved={() => { setModal(null); setReloadTick((t) => t + 1); }}
+              onCancel={() => setModal(null)}
+              midSlot={
+                modal.values.id !== null ? (
+                  <ProductSkuSection productId={modal.values.id} />
+                ) : null
+              }
+            />
+            {modal.values.id !== null && (
+              <div className="border-t border-zinc-200 pt-4 dark:border-zinc-800">
+                <ProductCampaignsPanel productId={modal.values.id} />
+              </div>
+            )}
+          </div>
         )}
       </Modal>
 

--- a/apps/admin/src/components/ProductCampaignsPanel.tsx
+++ b/apps/admin/src/components/ProductCampaignsPanel.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import SpinButton from "@/components/SpinButton";
+
+type CampaignStatus =
+  | "draft" | "open" | "closed" | "ordered"
+  | "receiving" | "ready" | "completed" | "cancelled";
+
+type CampaignRow = {
+  id: number;
+  campaign_no: string;
+  name: string;
+  status: CampaignStatus;
+  start_at: string | null;
+  end_at: string | null;
+};
+
+const STATUS_LABEL: Record<CampaignStatus, string> = {
+  draft: "草稿", open: "開團中", closed: "已收單", ordered: "已下訂",
+  receiving: "到貨中", ready: "可取貨", completed: "已完成", cancelled: "已取消",
+};
+
+const STATUS_BADGE: Record<CampaignStatus, string> = {
+  draft: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+  open: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
+  closed: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  ordered: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  receiving: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
+  ready: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+  completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
+  cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+};
+
+function fmtDate(s: string | null) {
+  return s ? new Date(s).toLocaleDateString("zh-TW") : "—";
+}
+
+// 開團狀態機是單向的（draft →open→ closed →cancelled，無 open→draft / closed→open）。
+// 故 switch 僅 draft / open 可切：draft(關)→開團(open)、open(開)→收單(closed)。
+// 其餘狀態鎖定（已收單不可逆、已取消、或已進採購/到貨流程）。
+type ToggleInfo =
+  | { kind: "off" }
+  | { kind: "on" }
+  | { kind: "locked"; checked: boolean; reason: string };
+
+function toggleInfo(status: CampaignStatus): ToggleInfo {
+  if (status === "open") return { kind: "on" };
+  if (status === "draft") return { kind: "off" };
+  if (status === "closed") return { kind: "locked", checked: false, reason: "已收單，無法切回開團中" };
+  if (status === "cancelled") return { kind: "locked", checked: false, reason: "已取消" };
+  return { kind: "locked", checked: true, reason: "已進入採購／到貨流程，無法切換" };
+}
+
+export function ProductCampaignsPanel({ productId }: { productId: number }) {
+  const [rows, setRows] = useState<CampaignRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    const sb = getSupabase();
+    const { data: skuRows, error: skuErr } = await sb
+      .from("skus").select("id").eq("product_id", productId);
+    if (skuErr) { setError(skuErr.message); setRows([]); return; }
+    const skuIds = (skuRows ?? []).map((s) => s.id as number);
+    if (skuIds.length === 0) { setRows([]); return; }
+
+    const { data: ciRows, error: ciErr } = await sb
+      .from("campaign_items").select("campaign_id").in("sku_id", skuIds);
+    if (ciErr) { setError(ciErr.message); setRows([]); return; }
+    const campaignIds = Array.from(
+      new Set((ciRows ?? []).map((c) => c.campaign_id as number))
+    );
+    if (campaignIds.length === 0) { setRows([]); return; }
+
+    const { data: cRows, error: cErr } = await sb
+      .from("group_buy_campaigns")
+      .select("id, campaign_no, name, status, start_at, end_at")
+      .in("id", campaignIds)
+      .neq("campaign_no", "__INTERNAL_RESTOCK__")
+      .order("start_at", { ascending: false, nullsFirst: false })
+      .order("id", { ascending: false });
+    if (cErr) { setError(cErr.message); setRows([]); return; }
+    setRows((cRows ?? []) as CampaignRow[]);
+  }, [productId]);
+
+  useEffect(() => { setRows(null); load(); }, [load]);
+
+  async function setStatus(row: CampaignRow, target: "open" | "closed") {
+    setError(null);
+    setNote(null);
+    const confirmMsg =
+      target === "open"
+        ? `確定要開團「${row.name}」？開團後顧客即可下單。`
+        : `確定要將「${row.name}」收單？收單後無法再轉回開團中。`;
+    if (!window.confirm(confirmMsg)) return;
+    const { data, error: err } = await getSupabase().rpc("rpc_bulk_set_campaign_status", {
+      p_ids: [row.id],
+      p_status: target,
+    });
+    if (err) { setError(err.message); return; }
+    const changed = typeof data === "number" ? data : 0;
+    if (changed === 0) {
+      setNote(
+        target === "open"
+          ? `「${row.name}」未開團（可能尚無商品品項或不允許的狀態轉換）`
+          : `「${row.name}」狀態未變更`,
+      );
+    }
+    await load();
+  }
+
+  return (
+    <section className="space-y-2">
+      <h3 className="text-sm font-semibold">關聯開團</h3>
+      <p className="text-xs text-zinc-500">
+        含此商品任一規格的開團。開關：開＝開團中（顧客可下單），關＝收單（不可逆）。
+      </p>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+      {note && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
+          {note}
+        </div>
+      )}
+
+      {rows === null ? (
+        <div className="flex justify-center py-6 text-zinc-400">
+          <svg className="h-5 w-5 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden>
+            <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+            <path d="M4 12a8 8 0 0 1 8-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+          </svg>
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="rounded-md border border-dashed border-zinc-300 px-3 py-6 text-center text-sm text-zinc-500 dark:border-zinc-700">
+          此商品尚無關聯開團
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+          <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+            <thead className="bg-zinc-50 dark:bg-zinc-900">
+              <tr className="text-left text-xs font-medium uppercase tracking-wide text-zinc-500">
+                <th className="px-3 py-2">團名</th>
+                <th className="px-3 py-2">狀態</th>
+                <th className="px-3 py-2">開團 / 收單</th>
+                <th className="px-3 py-2 text-right">開團開關</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {rows.map((r) => {
+                const info = toggleInfo(r.status);
+                const checked =
+                  info.kind === "on" ? true : info.kind === "off" ? false : info.checked;
+                const locked = info.kind === "locked";
+                return (
+                  <tr key={r.id}>
+                    <td className="px-3 py-2">{r.name}</td>
+                    <td className="px-3 py-2">
+                      <span className={`inline-block rounded px-2 py-0.5 text-xs ${STATUS_BADGE[r.status]}`}>
+                        {STATUS_LABEL[r.status]}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-xs text-zinc-500">
+                      {fmtDate(r.start_at)} → {fmtDate(r.end_at)}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <SwitchToggle
+                        checked={checked}
+                        disabled={locked}
+                        title={locked ? info.reason : checked ? "點擊收單" : "點擊開團"}
+                        onToggle={() => setStatus(r, info.kind === "off" ? "open" : "closed")}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SwitchToggle({
+  checked, disabled, title, onToggle,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  title?: string;
+  onToggle: () => unknown;
+}) {
+  return (
+    <SpinButton
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      title={title}
+      onClick={onToggle}
+      className={`inline-flex h-6 w-11 items-center rounded-full align-middle transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+        checked ? "bg-green-600" : "bg-zinc-300 dark:bg-zinc-700"
+      }`}
+    >
+      <span
+        className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+          checked ? "translate-x-[22px]" : "translate-x-[2px]"
+        }`}
+      />
+    </SpinButton>
+  );
+}

--- a/docs/TEST-product-detail-campaigns-report.md
+++ b/docs/TEST-product-detail-campaigns-report.md
@@ -1,0 +1,39 @@
+# product-detail-campaigns Test Run — 2026-05-18
+
+對應測試文件：`docs/TEST-product-detail-campaigns.md`
+變更檔：`apps/admin/src/components/ProductCampaignsPanel.tsx`（新）、`apps/admin/src/app/(protected)/products/page.tsx`（編輯 modal 掛入面板）
+
+### Summary
+- Total: 約 26 項
+- Passed: 11（自動化 + 路由執行期 + 程式碼／RPC 語意審查）
+- Blocked: 15（需登入的真實資料 live preview — Claude 沙箱連不到 127.0.0.1:54321，見 reference_admin_preview_sandbox_block）
+- Failed: 0
+
+### §1
+- ✅ N/A — 無 schema / migration 變更
+
+### §2 RPC 語意（複用既有 `rpc_bulk_set_campaign_status`，已讀 migration 20260514000012 逐條核對）
+- ✅ 合法轉換僅 `draft→open`（需 campaign_items）/ `open→closed`（+ →cancelled / draft→cancelled / closed→cancelled）；**無 open→draft / closed→open** → 面板據此把 closed/cancelled/已採購狀態 switch 設為 disabled，UI 不會送出會被 RPC 跳過的請求
+- ✅ RPC 回傳「實際變更筆數」；面板對 `changed===0`（如 draft 無 items）顯示提示、不誤報成功
+- ✅ RPC error 透傳 `err.message` 顯示（不吞錯、非 [object Object]）
+- ⏸ §2 各情境 SQL 直測（draft→open 有/無 items、open→closed、closed→open 跳過、跨 tenant）— Blocked：沙箱無 DB 連線；語意已由 migration 原始碼逐條確認，UI 僅送 open/closed 兩值
+
+### §3 UI
+- ✅ **§3.1 路由執行期** — dev server（Next 16.2.4 Turbopack）`GET /products/ 200`（application-code 149ms），server log / browser console **零錯誤**；證明新 `ProductCampaignsPanel` import、modal 結構改寫（ProductForm + 面板包進 `space-y-6`）執行期可編譯不丟例外。隨後無 session 轉址 `/login`（預期）
+- ✅ **設計符合慣例（碼審）** — 載入態為純 spinner 無「載入中」文字（依 `feedback_loading_spinner_no_text`）；switch 用既有 `SpinButton`（async onClick 自動 spinner、disable 防重複點）；切換前 `window.confirm`（與 campaigns 頁狀態變更一致）；收單方向明示「不可逆」
+- ✅ **關聯查詢正確（碼審）** — skus(product_id)→ids → campaign_items(sku_id in ids)→campaign_id 去重 → group_buy_campaigns（排除 `__INTERNAL_RESTOCK__`、start_at desc）；多 SKU 對應同團去重
+- ⏸ §3.1/§3.2/§3.3 真實資料互動（面板出現、關聯列表、switch 三狀態、confirm、refetch）— Blocked：protected route 需登入，沙箱不可達後端。**使用者本機可自審**
+
+### §4 Regression（碼審）
+- ✅ ProductForm 本體（欄位/上架驗證/儲存/SKU 區/圖片/進階）未動；面板加在 ProductForm **之外**、edit 且 id!=null 才掛、new 模式不掛
+- ✅ 商品列表搜尋/篩選/排序/分頁/批次/開團 modal 未動
+- ✅ 與 `/campaigns` 共用同一 `rpc_bulk_set_campaign_status`、不改其行為；會員端後端未動
+
+### Gate status
+- Type-check（`tsc --noEmit` apps/admin）：✅ exit 0
+- Build（`npm run build` apps/admin）：✅ exit 0
+- Supabase push：N/A（無 migration）
+- Console / server errors during `/products` route run：0
+
+### Verdict
+**可 SHIP（自動化全綠 + RPC 語意逐條核對 + 路由執行期 200）** — 0 失敗。switch 嚴格對齊既有單向狀態機（不做會被後端默默跳過的假雙向）。唯需登入的真實資料互動被沙箱網路阻擋（非程式問題），使用者本機可即時自審 §3.1–§3.3。

--- a/docs/TEST-product-detail-campaigns.md
+++ b/docs/TEST-product-detail-campaigns.md
@@ -1,0 +1,53 @@
+# product-detail-campaigns 測試項目 — 商品 detail 顯示關聯開團 + 開/關 switch
+
+**對應 UI 變更:**
+- 新增 `apps/admin/src/components/ProductCampaignsPanel.tsx`（商品關聯開團清單 + 每列 open/close switch）
+- `apps/admin/src/app/(protected)/products/page.tsx`：編輯（detail）modal 於 ProductForm 下方加入 `ProductCampaignsPanel`（僅既有商品 / id != null）
+
+**對應後端:** 無新 migration — 切換狀態複用既有 `rpc_bulk_set_campaign_status(BIGINT[], TEXT)`（單元素陣列）
+**對應狀態機（既有，不改）:** `draft →(open)→ open →(closed)→ closed →(cancelled)`；**無 open→draft / closed→open 反向**
+
+> Switch 語意：ON ⇔ status='open'。draft(OFF)→ON 設 open；open(ON)→OFF 設 closed(收單)。closed/cancelled/ordered/receiving/ready/completed 一律 disabled（不可逆 / 已進採購流程）。
+
+## 1. Schema / Migration 層
+- [ ] N/A — 無 schema / migration 變更
+
+## 2. RPC 行為（既有 rpc_bulk_set_campaign_status，SQL 直測複核語意）
+- [ ] draft→open：有 campaign_items → 成功（回傳 1）；無 items → 跳過（回傳 0）
+- [ ] open→closed：成功（回傳 1）
+- [ ] closed→open：被 RPC 視為不合法轉換、跳過（回傳 0）— 故 UI 對 closed 必須 disable，不可送這個請求
+- [ ] 跨 tenant id → 跳過（回傳 0）
+- [ ] p_status 非 draft/open/closed/cancelled → RAISE EXCEPTION（UI 只會送 open/closed，不應觸發）
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 商品 detail（`/products` → 點商品「編輯」開 modal）
+- [ ] 頁面 / modal 載入無 console error
+- [ ] 既有商品（id != null）modal 在 ProductForm（含 SKU 區）下方出現「關聯開團」面板；新增商品（mode=new）**不**出現
+- [ ] 面板載入態為**純 spinner、無「載入中」文字**（依專案慣例）
+- [ ] 關聯判定正確：列出所有「含此商品任一 SKU 之 campaign_item」的開團；`__INTERNAL_RESTOCK__` 不列；依 start_at 新→舊排序
+- [ ] 無關聯開團時顯示空狀態（簡短、不破版）
+- [ ] 每列顯示：團號（mono）、團名、狀態 badge、開團/收單日期、switch
+
+### 3.2 Switch 行為
+- [ ] status=open → switch 呈現 ON；status=draft → OFF 且可點
+- [ ] status ∈ {closed, cancelled, ordered, receiving, ready, completed} → switch disabled，hover/title 說明原因
+- [ ] draft→ON：confirm 後呼叫 rpc('open')，成功後該列變 開團中、switch 變 ON
+- [ ] open→OFF：confirm（明示「收單後無法轉回開團中」）後呼叫 rpc('closed')，成功後該列變 已收單、switch 變 OFF 且 disabled
+- [ ] 切換進行中 switch 顯示 spinner 並 disable，避免重複點擊
+- [ ] RPC 回傳 0（未變更，如 draft 無 items）：顯示簡短提示、列狀態不變、不誤報成功
+- [ ] RPC error：顯示後端訊息（不吞錯、不顯示 [object Object]）
+- [ ] 取消 confirm → 不送請求、狀態不變
+
+### 3.3 一致性 / 資料同步
+- [ ] switch 成功後面板資料 refetch，狀態與 badge 一致
+- [ ] 同一商品多 SKU 對應同一開團 → 該開團只出現一列（去重）
+
+## 4. Regression
+- [ ] ProductForm 既有欄位 / 上架驗證 / 儲存 / SKU 區（ProductSkuSection）/ 圖片 / 進階設定 完全不受影響
+- [ ] 商品列表頁搜尋 / 篩選 / 排序 / 分頁 / 批次上下架 / 開團 modal 不受影響
+- [ ] 開團列表頁（`/campaigns`）狀態、批次切換、縮圖（#255/#261）不受影響；本面板與其用同一 `rpc_bulk_set_campaign_status`
+- [ ] 會員端 `/shop` 不受影響（後端未動）
+
+## 5. 驗收門檻
+全部 §2-§4 勾完、**無 console error**、**build + type-check 過** 才可標 done.（無 migration，dev push 門檻不適用）


### PR DESCRIPTION
## Summary
- 商品編輯（detail）modal 於 ProductForm（含 SKU 區）下方新增 **「關聯開團」面板**：列出所有「含此商品任一 SKU 之 campaign_item」的開團（團名 · 狀態 · 開團/收單日），每列一個 **switch** 切換開團狀態
- 切換複用既有 `rpc_bulk_set_campaign_status`（單元素陣列）— **無新 migration**
- switch 嚴格對齊既有**單向**狀態機（`draft→open→closed→cancelled`，無反向）：
  - `draft`（關）→ 切 ON = 開團 `open`
  - `open`（開）→ 切 OFF = 收單 `closed`（confirm 明示不可逆）
  - `closed / cancelled / ordered / receiving / ready / completed` → switch **disabled**，title 說明原因（不做會被後端默默跳過的假雙向）
- 切換前 `window.confirm`；`changed===0`（如 draft 無品項）顯示提示不誤報；RPC error 透傳訊息；載入/忙碌為純 spinner（依專案慣例）；僅既有商品（id != null）顯示，新增模式不顯示

## Test plan
- [x] `tsc --noEmit`（apps/admin）→ exit 0
- [x] `npm run build`（apps/admin）→ exit 0
- [x] dev server `GET /products/` → 200、server/console 零錯誤（新面板 import + modal 結構改寫執行期可編譯）
- [x] RPC 語意逐條核對 migration `20260514000012`（合法轉換、changed 計數、error 透傳）
- [x] 關聯查詢 / 回歸 程式碼審查（詳見 `docs/TEST-product-detail-campaigns-report.md`）
- [ ] ⏸ §3 真實資料互動（面板出現 / 關聯列表 / switch 三狀態 / confirm / refetch）— Claude 沙箱連不到後端，使用者本機可即時自審

測試文件：`docs/TEST-product-detail-campaigns.md`；報告：`docs/TEST-product-detail-campaigns-report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)