### PR TITLE
fix(admin): 開團列表欄位逐字斷行

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -550,7 +550,7 @@ export default function CampaignsListPage() {
               className="cursor-pointer"
             />
           </Th>
-          <Th className="w-20">{""}</Th><Th>名稱</Th><Th>狀態</Th><Th>收單</Th><Th>開團/收單</Th><Th>取貨截止</Th><Th align="right">商品數</Th><Th align="right">下單總數</Th><Th align="right">更新</Th><Th>{""}</Th>
+          <Th className="w-20">{""}</Th><Th className="min-w-[14rem]">名稱</Th><Th className="whitespace-nowrap">狀態</Th><Th className="whitespace-nowrap">收單</Th><Th className="whitespace-nowrap">開團/收單</Th><Th className="whitespace-nowrap">取貨截止</Th><Th align="right" className="whitespace-nowrap">商品數</Th><Th align="right" className="whitespace-nowrap">下單總數</Th><Th align="right" className="whitespace-nowrap">更新</Th><Th>{""}</Th>
         </THead>
         <TBody>
           {rows === null ? (
@@ -571,19 +571,19 @@ export default function CampaignsListPage() {
                 <Td className="w-20">
                   <CampaignThumb url={campaignCoverUrl(r.cover_image_url, r.campaign_items)} name={r.name} />
                 </Td>
-                <Td>{r.name}</Td>
-                <Td><StatusBadge s={r.status} /></Td>
+                <Td className="min-w-[14rem]">{r.name}</Td>
+                <Td className="whitespace-nowrap"><StatusBadge s={r.status} /></Td>
                 <Td>
                   <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CLOSE_TYPE_BADGE[r.close_type]}`}>
                     {CLOSE_TYPE_LABEL[r.close_type]}
                   </span>
                 </Td>
-                <Td className="text-xs text-zinc-500">
+                <Td className="whitespace-nowrap text-xs text-zinc-500">
                   {r.start_at ? new Date(r.start_at).toLocaleDateString("zh-TW") : "—"}
                   {" → "}
                   {r.end_at ? new Date(r.end_at).toLocaleDateString("zh-TW") : "—"}
                 </Td>
-                <Td className="text-xs">{r.pickup_deadline ?? "—"}</Td>
+                <Td className="whitespace-nowrap text-xs">{r.pickup_deadline ?? "—"}</Td>
                 <Td align="right" className="font-mono">{itemCounts.get(r.id) ?? 0}</Td>
                 <Td align="right">
                   {(() => {
@@ -611,8 +611,8 @@ export default function CampaignsListPage() {
                     );
                   })()}
                 </Td>
-                <Td align="right" className="text-xs text-zinc-500">{new Date(r.updated_at).toLocaleString("zh-TW")}</Td>
-                <Td>
+                <Td align="right" className="whitespace-nowrap text-xs text-zinc-500">{new Date(r.updated_at).toLocaleString("zh-TW")}</Td>
+                <Td className="whitespace-nowrap">
                   <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
                     <SpinButton
                       onClick={() => openEdit(r.id)}

--- a/docs/TEST-campaign-list-layout-fix.md
+++ b/docs/TEST-campaign-list-layout-fix.md
@@ -1,0 +1,37 @@
+# campaign-list-layout-fix 測試項目 — 開團列表欄位斷行修正
+
+**對應 UI 變更:** `apps/admin/src/app/(protected)/campaigns/page.tsx`（list 視圖：非名稱欄加 `whitespace-nowrap`、名稱欄 `min-w-[14rem]`）
+**對應後端 / migration / RPC:** 無（純 CSS class）
+
+> 症狀：auto table-layout 下，動作（編輯/加單/結單）、更新時間、表頭等中文被壓成「逐字直排」。改為非名稱欄不換行 + 名稱欄保底寬度 → 超寬時由既有 `overflow-x-auto` 水平捲動，不再擠壓斷字。
+
+## 1. Schema / Migration / RPC
+- [ ] N/A — 無變更
+
+## 2. UI 行為（preview / 使用者實機）
+- [ ] `/campaigns` 列表載入無 console error
+- [ ] 動作欄「編輯 / 加單 / 結單 / 結算」單列水平排列，**不再逐字直排**
+- [ ] 「更新」時間單行顯示（不折成兩行）
+- [ ] 表頭「狀態/收單/開團-收單/取貨截止/商品數/下單總數/更新」不逐字斷行
+- [ ] 「開團/收單」「取貨截止」日期單行
+- [ ] 名稱欄維持可換行（長品名多行 OK），但欄寬不被壓到過窄（min 14rem）
+- [ ] 視窗較窄時整表水平捲動（`overflow-x-auto`），不出現直排擠壓
+- [ ] 縮圖（#255/#261）、勾選/批次列、點列進編輯、加單連結、分頁 行為不變
+
+## 3. Regression
+- [ ] 週/月曆視圖不受影響（未改）
+- [ ] 其他用 DataTable 的頁面不受影響（只改本頁 cell className，未動共用 `DataTable` 元件）
+
+## 4. 驗收門檻
+§2-§3 勾完、無 console error、build + type-check 過 才可標 done。（無 migration）
+
+---
+
+## 驗證結果（2026-05-18）
+- [x] **Type-check** `tsc --noEmit` apps/admin → exit 0
+- [x] **Build** `npm run build` apps/admin → exit 0
+- [x] **路由執行期** dev server `GET /campaigns/ 200`、server/console 零錯誤（class 變更無語法/執行期問題）
+- [x] **碼審** 僅本頁 `<Th>/<Td>` className 加 `whitespace-nowrap` / `min-w-[14rem]`；未動共用 `DataTable`、未動邏輯/資料/縮圖；`overflow-x-auto` 為既有 → 超寬改水平捲動而非斷字
+- [ ] ⏸ 真實資料目視（斷行消失、捲動）— Claude 沙箱連不到後端登入（見 reference_admin_preview_sandbox_block）；**使用者實機回報的就是此頁，reload 即可自審**
+
+**Verdict:** 可 SHIP — 純 CSS、零失敗、自動化全綠；視覺由回報者本機 reload 確認。


### PR DESCRIPTION
## Summary
- 修正 `/campaigns` 列表視圖版面：auto table-layout 下，動作鈕（編輯/加單/結單）、更新時間、表頭中文被壓成「逐字直排」
- 非名稱欄（狀態/收單/開團-收單/取貨截止/商品數/下單總數/更新/動作）加 `whitespace-nowrap`；名稱欄加 `min-w-[14rem]` 保底
- 超寬時由**既有** `overflow-x-auto`（DataTable）水平捲動，而非擠壓斷字
- 僅改本頁 `<Th>/<Td>` className；**未動共用 `DataTable` 元件**、未動邏輯/資料/縮圖（#255/#261）

## Test plan
- [x] `tsc --noEmit` → exit 0
- [x] `npm run build` → exit 0
- [x] dev server `GET /campaigns/` → 200、server/console 零錯誤
- [x] 碼審：scope 僅本頁 cell className，無回歸面
- [ ] ⏸ 真實資料目視（斷行消失/水平捲動）— Claude 沙箱連不到後端；回報者本機 reload `/campaigns` 即可確認

測試/報告：`docs/TEST-campaign-list-layout-fix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)