### PR TITLE
fix(admin/orders): 訂單頁手機版面（逐字直排改水平捲動 + sparkline 手機隱藏）

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -624,7 +624,7 @@ function OrdersListContent() {
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr>
-              <Th>開團</Th><Th>會員 / 暱稱</Th><Th>取貨店</Th><Th className="text-right">項數</Th><Th className="text-right">總數量</Th><Th className="text-right">總金額</Th><Th className="text-right">日期</Th><Th className="text-right">操作</Th>
+              <Th className="min-w-[14rem]">開團</Th><Th className="whitespace-nowrap">會員 / 暱稱</Th><Th className="whitespace-nowrap">取貨店</Th><Th className="whitespace-nowrap text-right">項數</Th><Th className="whitespace-nowrap text-right">總數量</Th><Th className="whitespace-nowrap text-right">總金額</Th><Th className="whitespace-nowrap text-right">日期</Th><Th className="whitespace-nowrap text-right">操作</Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
@@ -649,7 +649,7 @@ function OrdersListContent() {
                       : "odd:bg-white even:bg-zinc-50 hover:bg-zinc-100 dark:odd:bg-zinc-950 dark:even:bg-zinc-900 dark:hover:bg-zinc-800"
                   }
                 >
-                  <Td>
+                  <Td className="min-w-[14rem]">
                     <SpinButton
                       onClick={() => { setDetailId(r.id); setDetailNo(r.order_no); }}
                       className="block w-full text-left hover:underline"
@@ -676,7 +676,7 @@ function OrdersListContent() {
                       ) : "—"}
                     </SpinButton>
                   </Td>
-                  <Td>
+                  <Td className="whitespace-nowrap">
                     {m ? (
                       <span className="flex items-center gap-2">
                         <Avatar src={m.avatar_url} name={m.name ?? r.nickname_snapshot ?? "?"} />
@@ -692,18 +692,18 @@ function OrdersListContent() {
                       </span>
                     ) : "—"}
                   </Td>
-                  <Td className="text-xs">{s?.name ?? "—"}</Td>
-                  <Td className="text-right font-mono">{itemSummary.get(r.id)?.lineCount ?? 0}</Td>
-                  <Td className="text-right font-mono">{itemSummary.get(r.id)?.totalQty ?? 0}</Td>
-                  <Td className="text-right font-mono">${itemSummary.get(r.id)?.totalAmount ?? 0}</Td>
+                  <Td className="whitespace-nowrap text-xs">{s?.name ?? "—"}</Td>
+                  <Td className="whitespace-nowrap text-right font-mono">{itemSummary.get(r.id)?.lineCount ?? 0}</Td>
+                  <Td className="whitespace-nowrap text-right font-mono">{itemSummary.get(r.id)?.totalQty ?? 0}</Td>
+                  <Td className="whitespace-nowrap text-right font-mono">${itemSummary.get(r.id)?.totalAmount ?? 0}</Td>
                   <Td
-                    className="text-right text-xs text-zinc-500"
+                    className="whitespace-nowrap text-right text-xs text-zinc-500"
                     title={`訂單日：${new Date(r.created_at).toLocaleString("zh-TW", { hour12: false })}\n更新日：${new Date(r.updated_at).toLocaleString("zh-TW", { hour12: false })}`}
                   >
                     <div>訂 {new Date(r.created_at).toLocaleDateString("zh-TW", { month: "numeric", day: "numeric" })}</div>
                     <div>更 {new Date(r.updated_at).toLocaleDateString("zh-TW", { month: "numeric", day: "numeric" })}</div>
                   </Td>
-                  <Td className="text-right">
+                  <Td className="whitespace-nowrap text-right">
                     <div className="flex items-center justify-end gap-1">
                       {!["completed","expired","cancelled","transferred_out"].includes(r.status) && (() => {
                         // 取貨判斷改用 v_order_pickup_ready
@@ -994,12 +994,14 @@ function TrendCard({
             {subLabel} {fmt(subValue)}
           </div>
         </div>
-        <Sparkline
-          values={dailyValues}
-          labels={trend.days.map((d) => fmtMD(d.ymd))}
-          fmt={fmt}
-          color={sparkColor}
-        />
+        <div className="hidden sm:block">
+          <Sparkline
+            values={dailyValues}
+            labels={trend.days.map((d) => fmtMD(d.ymd))}
+            fmt={fmt}
+            color={sparkColor}
+          />
+        </div>
       </div>
       {hint && <div className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">{hint}</div>}
     </div>

--- a/docs/TEST-orders-mobile-layout.md
+++ b/docs/TEST-orders-mobile-layout.md
@@ -1,0 +1,33 @@
+# orders-mobile-layout 測試項目 — 訂單頁手機版面修正
+
+**對應 migration:** 無（純前端 className）
+**對應 UI 變更:** `apps/admin/src/app/(protected)/orders/page.tsx`
+**對應 PRD:** —（沿用 #265 開團列表手機修正同一 pattern）
+
+> 問題：訂單頁在手機寬度下，表格欄位被 `auto` table-layout 壓成逐字直排（商品名「雙貓眼／人體感／應壁燈」一字一行）、表頭中文直排；KPI 卡因 sparkline 擠壓，數字/標籤糊在一起。
+> 作法（對齊 #265）：表格非名稱欄 `whitespace-nowrap`、開團（名稱）欄 `min-w-[14rem]`，超寬交給既有 `overflow-x-auto` 水平捲動；KPI 卡的 sparkline 在 `< sm` 隱藏，手機只顯示標籤＋大數字。桌機完全不變。
+
+## 1. Schema / RPC
+- [ ] 無 migration / 無 RPC 變更（`git diff origin/main...HEAD` 僅 `orders/page.tsx` + 本測試文件）
+
+## 2. 桌機回歸（≥ sm，1280）
+- [ ] 表格八欄與改動前視覺一致（開團/會員/取貨店/項數/總數量/總金額/日期/操作）
+- [ ] KPI 四卡含 sparkline、版面與改動前一致
+- [ ] 篩選列（開團 picker / 取貨店 / 搜尋 bar）一列三欄如舊
+- [ ] 排序/分頁/明細 Modal/取消/去取貨/↩退貨 行為不變
+
+## 3. 手機版面（375 寬）
+- [ ] 表格**不再逐字直排**：商品名在 ≥14rem 欄寬內正常折行（非一字一行）
+- [ ] 其餘欄（會員/取貨店/數字/日期/操作）`whitespace-nowrap`，整表靠 `overflow-x-auto` **水平捲動**而非壓縮
+- [ ] 表頭中文不直排
+- [ ] KPI 卡：手機隱藏 sparkline，僅標籤＋大數字＋副字，數字不被截到看不到、不重疊
+- [ ] 篩選列在窄寬堆疊（單欄），搜尋框可用、🔍/✕ 不脫版
+- [ ] 頁面整體無破版、可正常上下捲動
+
+## 4. 量測驗證（沙箱無法登入 admin，依 reference_admin_preview_sandbox_block 走 inject + getComputedStyle/Rect）
+- [ ] `preview_resize` 375 → 注入表格列實際 markup（用改後 class）→ 量開團 cell `getBoundingClientRect().width ≥ 224px(14rem)`、非名稱 cell `white-space: nowrap`
+- [ ] 注入 KPI 卡 markup → 375 下 sparkline `display:none`、數字元素 rect 可見且未 0 寬
+- [ ] `preview_resize` 1280 → 同元件 sparkline `display` 非 none（桌機保留）
+
+## 5. 驗收門檻
+§2-§4 勾完、**無 console error**、**`next build` exit 0**。無 migration/RPC，§1 僅確認無變更。


### PR DESCRIPTION
## Summary
- 訂單頁手機破版修正：表格欄位被壓成逐字直排、KPI 卡擠壓
- 對齊 **#265** 開團列表同一 pattern：表格非名稱欄 `whitespace-nowrap`、開團（名稱）欄 `min-w-[14rem]`，超寬由既有 `overflow-x-auto` 水平捲動，不再壓縮斷字
- KPI 卡 sparkline 於 `< sm` 隱藏（`hidden sm:block` 包住），手機只顯示標籤＋大數字
- **桌機完全不變**；僅改本頁 cell className + 一處 sparkline wrapper；無 migration / RPC

## Verification（沙箱無法登入 admin，依慣例走 inject + getComputedStyle/Rect）
- 375px：表 `scrollWidth 875 > wrap 350` → `overflow-x:auto` 水平捲動；開團 cell 224px；商品名 17 字折 **3 行（非 17 行）**；其餘欄 `white-space:nowrap`；sparkline `display:none`
- 1280px：sparkline `display:block` 復現、無水平捲動、開團欄 466px → 桌機與改動前一致
- `next build` exit 0

## Test plan
詳見 `docs/TEST-orders-mobile-layout.md`
- [ ] 手機：表格水平捲動、不逐字直排、KPI 卡可讀
- [ ] 桌機回歸：八欄/KPI/篩選/排序/分頁/Modal 不變

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)