### PR TITLE
feat(admin/campaigns): 開團列表手機改卡片版（桌機維持表格）

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -403,6 +403,44 @@ export default function CampaignsListPage() {
   const fromIdx = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
   const toIdx = Math.min(page * PAGE_SIZE, total);
 
+  // 操作鈕（編輯 / 加單 / 結單 / 結算）— 桌機表格與手機卡片共用，單一維護點
+  const campaignActions = (r: Row) => (
+    <>
+      <SpinButton
+        onClick={() => openEdit(r.id)}
+        className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+      >
+        編輯
+      </SpinButton>
+      {r.status === "open" && (
+        <Link
+          href={`/campaigns/order-entry?id=${r.id}`}
+          className="text-xs text-green-600 hover:underline dark:text-green-400"
+        >
+          加單
+        </Link>
+      )}
+      {r.status === "open" && (
+        <SpinButton
+          onClick={() => closeCampaign(r.id, r.name)}
+          disabled={closingId === r.id}
+          className="text-xs text-amber-600 hover:underline disabled:opacity-50 dark:text-amber-400"
+        >
+          {closingId === r.id ? "結單中…" : "結單"}
+        </SpinButton>
+      )}
+      {(["closed", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
+        <SpinButton
+          onClick={() => finalizeCampaign(r.id, r.name)}
+          disabled={finalizingId === r.id}
+          className="text-xs text-purple-600 hover:underline disabled:opacity-50 dark:text-purple-400"
+        >
+          {finalizingId === r.id ? "結算中…" : "結算"}
+        </SpinButton>
+      )}
+    </>
+  );
+
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
       <header className="flex items-center justify-between">
@@ -533,6 +571,79 @@ export default function CampaignsListPage() {
       )}
 
       {view === "list" && (
+      <>
+      {/* 手機：每筆開團一張卡片（桌機改用下方表格） */}
+      <div className="space-y-2 sm:hidden">
+        {rows === null ? (
+          <div className="rounded-md border border-zinc-200 p-6 text-center text-sm text-zinc-500 dark:border-zinc-800">載入中…</div>
+        ) : rows.length === 0 ? (
+          <div className="rounded-md border border-zinc-200 p-6 text-center text-sm text-zinc-500 dark:border-zinc-800">
+            {total === 0 && !query && !status ? "還沒有開團，按「新增開團」開始。" : "沒有符合條件的開團。"}
+          </div>
+        ) : rows.map((r) => (
+          <div
+            key={r.id}
+            onClick={() => openEdit(r.id)}
+            className={`cursor-pointer rounded-lg border p-3 ${selectedIds.has(r.id) ? "border-blue-300 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30" : "border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950"}`}
+          >
+            <div className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={selectedIds.has(r.id)}
+                onChange={() => toggleSelect(r.id)}
+                onClick={(e) => e.stopPropagation()}
+                className="mt-1 cursor-pointer"
+              />
+              <CampaignThumb url={campaignCoverUrl(r.cover_image_url, r.campaign_items)} name={r.name} />
+              <div className="min-w-0 flex-1">
+                <div className="break-words text-base font-bold text-zinc-900 dark:text-zinc-100">{r.name}</div>
+                <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                  <StatusBadge s={r.status} />
+                  <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CLOSE_TYPE_BADGE[r.close_type]}`}>
+                    {CLOSE_TYPE_LABEL[r.close_type]}
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500">
+              <span>
+                {r.start_at ? new Date(r.start_at).toLocaleDateString("zh-TW") : "—"}
+                {" → "}
+                {r.end_at ? new Date(r.end_at).toLocaleDateString("zh-TW") : "—"}
+              </span>
+              <span>取貨截止 {r.pickup_deadline ?? "—"}</span>
+              <span>商品 {itemCounts.get(r.id) ?? 0}</span>
+              {(() => {
+                const oc = listOrderCounts.get(r.id) ?? { normalQty: 0, offsetQty: 0 };
+                if (oc.normalQty === 0 && oc.offsetQty === 0) return <span>下單 0</span>;
+                return (
+                  <Link
+                    href={`/orders?campaignId=${r.id}`}
+                    onClick={(e) => e.stopPropagation()}
+                    className="inline-flex items-center gap-1 font-mono text-blue-700 hover:underline dark:text-blue-400"
+                  >
+                    下單 {oc.normalQty}
+                    {oc.offsetQty !== 0 && (
+                      <span className="rounded bg-red-100 px-1 text-[11px] text-red-800 dark:bg-red-950 dark:text-red-300">
+                        {oc.offsetQty}
+                      </span>
+                    )}
+                  </Link>
+                );
+              })()}
+              <span className="ml-auto">更新 {new Date(r.updated_at).toLocaleDateString("zh-TW")}</span>
+            </div>
+            <div
+              className="mt-2 flex flex-wrap items-center gap-2 border-t border-zinc-200/70 pt-2 dark:border-zinc-800"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {campaignActions(r)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="hidden sm:block">
       <Table>
         <THead>
           <Th className="w-10">
@@ -614,44 +725,15 @@ export default function CampaignsListPage() {
                 <Td align="right" className="whitespace-nowrap text-xs text-zinc-500">{new Date(r.updated_at).toLocaleString("zh-TW")}</Td>
                 <Td className="whitespace-nowrap">
                   <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
-                    <SpinButton
-                      onClick={() => openEdit(r.id)}
-                      className="text-xs text-blue-600 hover:underline dark:text-blue-400"
-                    >
-                      編輯
-                    </SpinButton>
-                    {r.status === "open" && (
-                      <Link
-                        href={`/campaigns/order-entry?id=${r.id}`}
-                        className="text-xs text-green-600 hover:underline dark:text-green-400"
-                      >
-                        加單
-                      </Link>
-                    )}
-                    {r.status === "open" && (
-                      <SpinButton
-                        onClick={() => closeCampaign(r.id, r.name)}
-                        disabled={closingId === r.id}
-                        className="text-xs text-amber-600 hover:underline disabled:opacity-50 dark:text-amber-400"
-                      >
-                        {closingId === r.id ? "結單中…" : "結單"}
-                      </SpinButton>
-                    )}
-                    {(["closed", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
-                      <SpinButton
-                        onClick={() => finalizeCampaign(r.id, r.name)}
-                        disabled={finalizingId === r.id}
-                        className="text-xs text-purple-600 hover:underline disabled:opacity-50 dark:text-purple-400"
-                      >
-                        {finalizingId === r.id ? "結算中…" : "結算"}
-                      </SpinButton>
-                    )}
+                    {campaignActions(r)}
                   </div>
                 </Td>
             </Tr>
           ))}
         </TBody>
       </Table>
+      </div>
+      </>
       )}
 
       <Modal

--- a/docs/TEST-campaigns-mobile-cards.md
+++ b/docs/TEST-campaigns-mobile-cards.md
@@ -1,0 +1,34 @@
+# campaigns-mobile-cards 測試項目 — 開團列表手機改卡片版
+
+**對應 migration:** 無（純前端）
+**對應 UI 變更:** `apps/admin/src/app/(protected)/campaigns/page.tsx`
+
+> 同 #269（訂單列表手機卡片版）的處理，套到開團列表「列表」view：手機 `< sm` 每筆開團一張卡片，桌機 `≥ sm` 維持原 DataTable。操作鈕（編輯/加單/結單/結算）抽成共用 `campaignActions(r)` 單一維護點。「未來 7 天 / 月曆」view 不動。
+
+## 1. Schema / RPC
+- [ ] 無 migration / RPC 變更（`git diff origin/main...HEAD` 僅 `campaigns/page.tsx` + 本文件）
+
+## 2. 行為共用性
+- [ ] 操作鈕抽成單一 `campaignActions(r)`，桌機表格與手機卡片共用；gate 與改動前完全相同（編輯一律有；加單/結單僅 open；結算僅 closed/ordered/receiving/ready；結單中/結算中 disable 文案不變）
+- [ ] 卡片點空白處 → `openEdit(r.id)`（同表格 Tr onClick）；checkbox / 操作鈕 / 下單 Link `stopPropagation` 不誤觸編輯
+
+## 3. 桌機回歸（≥ sm，1280）
+- [ ] 「列表」view 顯示原 DataTable（11 欄）、卡片清單 `display:none`
+- [ ] 表頭/欄位/勾選全選/排序/分頁/批次/新增開團/編輯 Modal 與改動前一致
+- [ ] 編輯/加單/結單/結算 行為不變（沿用 `campaignActions`）
+- [ ] 「未來 7 天」「月曆」view 完全不受影響
+
+## 4. 手機版面（375）
+- [ ] 「列表」view：DataTable 容器 `display:none`，**卡片清單顯示**
+- [ ] 每張卡：checkbox＋封面縮圖＋開團名（粗體）＋狀態 badge＋團型 badge；日期（開團→收單、取貨截止）、商品數、下單數（含抵減）、更新日；操作鈕列
+- [ ] 卡片可點開編輯；勾選卡片 highlight；操作鈕可 wrap、可點且不誤觸卡片點擊
+- [ ] 載入中 / 無資料 兩態在卡片版也有對應顯示
+- [ ] 無逐字直排、卡寬不溢出、整頁可上下捲動
+
+## 5. 量測驗證（沙箱無法登入 admin，依 reference_admin_preview_sandbox_block：inject + getComputedStyle/Rect + resize）
+- [ ] 375：卡片 wrapper（`space-y-2 sm:hidden`）`display` 非 none、Table wrapper（`hidden sm:block`）`display:none`；卡寬 ≤ viewport
+- [ ] 1280：Table wrapper `display:block`、卡片 wrapper `display:none`
+- [ ] 操作鈕容器 `flex-wrap: wrap`
+
+## 6. 驗收門檻
+§2-§5 勾完、**無 console error**、**`next build` exit 0**。無 migration/RPC，§1 僅確認無變更。


### PR DESCRIPTION
## Summary
- 延續 #269：開團列表「列表」view 手機（`< sm`）改成**每筆一張卡片**（checkbox＋封面＋開團名＋狀態/團型 badge＋日期·商品數·下單數·更新＋操作鈕），桌機（`≥ sm`）維持原 DataTable
- 操作鈕（編輯/加單/結單/結算）抽成共用 `campaignActions(r)` 單一維護點 → 表格與卡片共用、gate **與改動前完全相同**
- 卡片點空白 → 編輯（同表格 Tr onClick）；checkbox / 操作鈕 / 下單 Link `stopPropagation` 不誤觸
- 「未來 7 天 / 月曆」view 不動；無 migration / RPC

## Verification（沙箱無法登入 admin，依慣例 inject + getComputedStyle/Rect + resize）
- **375**：卡片清單 `display:block`、Table 容器 `display:none`；卡寬 351 不溢出；長開團名折 2 行；操作鈕 `flex-wrap:wrap`
- **1280**：卡片清單 `display:none`、Table `display:block`（1256px）→ 桌機與改動前一致
- `next build` exit 0、無 type error

## Test plan
詳見 `docs/TEST-campaigns-mobile-cards.md`
- [ ] 手機：卡片版顯示完整、可點開編輯、勾選、操作鈕可用
- [ ] 桌機回歸：DataTable 11 欄/全選/排序/分頁/批次/編輯 Modal 不變、campaignActions 行為不變
- [ ] 未來7天 / 月曆 view 不受影響

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)