### PR TITLE
feat(admin/pickup): 取貨列印改隱藏 iframe 直接列印，不跳新分頁

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -7,6 +7,7 @@ import { Modal } from "@/components/Modal";
 import { PickupDialog } from "@/components/PickupDialog";
 import OrderReturnCreateModal from "@/components/OrderReturnCreateModal";
 import { withBasePath } from "@/lib/basePath";
+import { printViaIframe } from "@/lib/printIframe";
 import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
 import { getPickupRecents, recordPickupRecent, type RecentCustomer } from "@/lib/pickupRecents";
@@ -218,10 +219,10 @@ function PickupPageContent() {
       }
       if (errors.length > 0) setError(errors.join("\n"));
       if (eventIds.length > 0) {
-        // 自動開列印 — 大張取貨單 + 熱感應小白單
-        window.open(withBasePath(`/pickup/print?event_ids=${eventIds.join(",")}`), "_blank");
+        // 自動列印 — 大張取貨單 + 熱感應小白單（隱藏 iframe,不跳新分頁;依序印）
+        printViaIframe(withBasePath(`/pickup/print?event_ids=${eventIds.join(",")}`));
         const okOrderIds = memberOrders.map((o) => o.id).join(",");
-        window.open(withBasePath(`/pickup/print-list?order_ids=${okOrderIds}`), "_blank");
+        printViaIframe(withBasePath(`/pickup/print-list?order_ids=${okOrderIds}`));
       }
       alert(`完成 ${okCount}/${memberOrders.length} 張取貨${errors.length > 0 ? `\n失敗 ${errors.length} 張：\n${errors.join("\n")}` : ""}`);
       setReloadTick((t) => t + 1);
@@ -645,10 +646,7 @@ function PickupPageContent() {
                 <SpinButton
                   onClick={() => {
                     const ids = memberOrders.map((o) => o.id).join(",");
-                    window.open(
-                      withBasePath(`/pickup/print-list?order_ids=${ids}`),
-                      "_blank",
-                    );
+                    printViaIframe(withBasePath(`/pickup/print-list?order_ids=${ids}`));
                   }}
                   className="rounded-md border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:border-zinc-300 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
                 >

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { withBasePath } from "@/lib/basePath";
+import { printViaIframe } from "@/lib/printIframe";
 import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
 import { EditableDiscount, deriveDiscount, type DiscountValue } from "@/components/EditableDiscount";
@@ -161,7 +162,7 @@ export function PickupDialog({
       const params = new URLSearchParams({ order_ids: String(orderId) });
       const wPrev = Number(walletAmount) || 0;
       if (wPrev > 0) params.set("wallet_preview", String(wPrev));
-      window.open(withBasePath(`/pickup/print-list?${params.toString()}`), "_blank");
+      printViaIframe(withBasePath(`/pickup/print-list?${params.toString()}`));
     } finally {
       setBusy(false);
     }
@@ -201,11 +202,11 @@ export function PickupDialog({
       });
       if (error) { setErr(error.message); return; }
       const result = data as { event_id: number; new_order_status: string; picked_count: number; active_remaining: number };
-      // 取貨單一定印（收據）
-      window.open(withBasePath(`/pickup/print?event_ids=${result.event_id}`), "_blank");
+      // 取貨單一定印（收據）— 隱藏 iframe,不跳新分頁
+      printViaIframe(withBasePath(`/pickup/print?event_ids=${result.event_id}`));
       // 取貨清單只在「部分取貨」時印（提醒客人剩下未取的 items）；全取完省略
       if (result.active_remaining > 0) {
-        window.open(withBasePath(`/pickup/print-list?order_ids=${orderId}`), "_blank");
+        printViaIframe(withBasePath(`/pickup/print-list?order_ids=${orderId}`));
       }
       onPickedUp(result);
     } finally {

--- a/apps/admin/src/lib/printIframe.ts
+++ b/apps/admin/src/lib/printIframe.ts
@@ -1,0 +1,52 @@
+// Print a same-origin page (e.g. /pickup/print, /pickup/print-list) WITHOUT
+// opening a new browser tab/window. The target pages already fetch their own
+// data and call window.print() once loaded — hosting them in a hidden iframe
+// scopes that print() to the iframe document, so the browser's print dialog
+// appears directly with no visible page jumping out.
+//
+// Calls are serialized: when two slips are printed back-to-back (取貨單 +
+// 取貨清單), the second iframe only loads after the first one's print dialog
+// has closed, so the two dialogs never clobber each other.
+
+let chain: Promise<void> = Promise.resolve();
+
+export function printViaIframe(url: string): Promise<void> {
+  if (typeof document === "undefined") return Promise.resolve();
+  chain = chain.then(() => printOnce(url)).catch(() => {});
+  return chain;
+}
+
+function printOnce(url: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const iframe = document.createElement("iframe");
+    iframe.setAttribute("aria-hidden", "true");
+    iframe.style.cssText =
+      "position:fixed;right:0;bottom:0;width:0;height:0;border:0;visibility:hidden;";
+
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      // 延遲移除：確保列印工作已送進佇列再拆掉 iframe
+      window.setTimeout(() => iframe.remove(), 1000);
+      resolve();
+    };
+
+    iframe.onload = () => {
+      // 目標頁資料載入後會自行 window.print()（在 iframe 內＝印 iframe 內容）。
+      // afterprint 在列印對話框關閉（送印或取消）時觸發 → 收尾並放行下一張。
+      try {
+        iframe.contentWindow?.addEventListener("afterprint", finish, { once: true });
+      } catch {
+        // same-origin 理論上不會進這裡；保險 timeout 仍會收尾
+      }
+      // 保險：頁面載入錯誤（沒資料 → 不會呼叫 print）時不會有 afterprint，
+      // 用較長 timeout 收尾,避免永久卡住串行 chain（同時夠長,不會在
+      // 使用者還在選印表機時誤觸發）。
+      window.setTimeout(finish, 45000);
+    };
+
+    iframe.src = url;
+    document.body.appendChild(iframe);
+  });
+}

--- a/docs/TEST-pickup-print-no-popup.md
+++ b/docs/TEST-pickup-print-no-popup.md
@@ -1,0 +1,47 @@
+# 測試項目 — 取貨列印不跳新分頁（隱藏 iframe 直接列印）
+
+**範圍:** 純前端 UI 行為。取貨相關列印（大張取貨單 + 熱感小白單）原本 `window.open(..., "_blank")` 開新分頁再自動 `window.print()`，改成用隱藏 iframe 載入既有列印頁、直接叫出瀏覽器列印對話框,不再跳出新分頁/視窗。
+
+**對應變更:**
+- 新增 `apps/admin/src/lib/printIframe.ts` — `printViaIframe(url)`：建立隱藏 iframe 載入同源列印頁；列印頁本身（`/pickup/print`、`/pickup/print-list`）資料載入後自會 `window.print()`，在 iframe 內即印 iframe 內容。多筆列印用 promise chain 串行（避免兩個列印對話框互相蓋掉）。`afterprint` + 保險 timeout 清掉 iframe。
+- `apps/admin/src/app/(protected)/pickup/page.tsx`：3 處 `window.open` → `printViaIframe`（L222 大張取貨單 / L224 小白單 / L648 modal「列印小白單」）
+- `apps/admin/src/components/PickupDialog.tsx`：3 處 `window.open` → `printViaIframe`（L164 列印小白單預覽 / L205 取貨單收據 / L208 部分取貨清單）
+- **列印頁本身（`pickup/print/page.tsx`、`pickup/print-list/page.tsx`）不動** —— 完整重用既有資料抓取與排版。
+
+**驗證方式（無 schema / RPC；admin live preview 受沙箱阻擋無法跑登入/列印,照 reference_admin_preview_sandbox_block 走）:** `tsc --noEmit` + `next build` + 碼審；**列印對話框實際行為需使用者本機自審**（沙箱無印表機、無法驅動列印對話框）。
+
+---
+
+## 1. printIframe helper（碼審）
+
+- [ ] `printViaIframe(url)` 建立的 iframe 為離屏隱藏（`position:fixed; width/height:0; visibility:hidden; border:0`）、`aria-hidden`
+- [ ] iframe 同源（指向 `withBasePath('/pickup/print*')`）→ 可存取 `contentWindow` 掛 `afterprint`
+- [ ] 多次呼叫串行（promise chain）：前一張 `afterprint`（或保險 timeout）後才載入下一張，不會兩個列印對話框同時彈
+- [ ] `afterprint` 後延遲移除 iframe（確保列印工作已送出）；錯誤/未列印有保險 timeout 收尾,不會永久卡住 chain
+- [ ] SSR/prerender 安全：`document` 僅在函式內存取(client 事件觸發),有 `typeof document === "undefined"` 保護
+- [ ] 單一錯誤不會 reject 卡住整條 chain（`.catch` 吞掉續跑）
+
+## 2. 呼叫點全數轉換（碼審 — grep 無殘留）
+
+- [ ] `apps/admin` 內 `window.open(` + `pickup/print` 已無殘留（全部走 `printViaIframe`）
+- [ ] `pickup/page.tsx` `bulkPickAllConfirmed`：大張取貨單 + 小白單兩張依序印（不跳分頁）
+- [ ] `pickup/page.tsx` bulkConfirm modal「🖨️ 列印小白單」：不跳分頁直接印
+- [ ] `PickupDialog.tsx` `printSlip()`：含 `wallet_preview` / 折扣存檔後印小白單,不跳分頁
+- [ ] `PickupDialog.tsx` `submit()`：取貨單一定印；`active_remaining > 0` 才追加取貨清單；兩張依序、不跳分頁
+- [ ] `withBasePath` 保留（GH Pages basePath 正確）；移除多餘 `"_blank"`
+
+## 3. 使用者本機自審（沙箱無法驗，列清單交付）
+
+- [ ] 單筆取貨 → 只彈一次列印對話框、無新分頁；列印內容＝取貨單收據
+- [ ] 部分取貨 → 依序彈兩次（取貨單 → 取貨清單）、皆無新分頁
+- [ ] 一次全取（bulk）→ 依序彈兩次（大張取貨單 → 熱感小白單 80mm）、皆無新分頁
+- [ ] 列印對話框按「取消」→ 不殘留隱藏 iframe、不卡住下一張
+- [ ] 熱感小白單 80mm 版面、折扣/儲值金/預覽金額顯示與改版前一致
+- [ ] 列印完頁面停留在原取貨頁（搜尋結果/常用顧客不變）
+
+## 4. 回歸 / 品質
+
+- [ ] `tsc --noEmit` 0 error
+- [ ] `next build`（admin, static export）成功
+- [ ] 無新增 `eslint` error
+- [ ] 列印頁 `/pickup/print`、`/pickup/print-list` 直接開網址仍可用（未破壞既有路由 / 自動列印）


### PR DESCRIPTION
## 背景
取貨時的「列印白單」（大張取貨單 + 80mm 熱感小白單）原本用 `window.open(..., "_blank")` 開新分頁，分頁載入後自動 `window.print()`。店員每次取貨都得回頭手動關掉那個分頁，很煩。

使用者要求：**直接就列印，不要跳出畫面。**

## 做法
新增 `apps/admin/src/lib/printIframe.ts` 的 `printViaIframe(url)`：

- 用**離屏隱藏 iframe** 載入同源列印頁。列印頁本身資料載入後就會自呼 `window.print()`，在 iframe 內 = 直接印 iframe 內容 → 瀏覽器列印對話框直接彈出，**不開新分頁/視窗**，畫面停留在取貨頁。
- 多張串行：兩張一起印時（取貨單＋取貨清單）用 promise chain,第二張等第一張列印對話框關閉才載入,**兩個對話框不會互相蓋掉**。
- `afterprint`（送印或取消都觸發）後延遲移除 iframe；錯誤/未列印有保險 timeout 收尾,不卡住串行。SSR 安全。
- **列印頁 `/pickup/print`、`/pickup/print-list` 完全不動** —— 完整重用既有資料抓取與排版（含折扣 / 儲值金 / `wallet_preview`）。

共 6 處 `window.open` → `printViaIframe`：
- `pickup/page.tsx`：bulk 一次全取（大張取貨單 + 小白單）、bulkConfirm modal「列印小白單」
- `PickupDialog.tsx`：`printSlip()` 小白單預覽、`submit()` 取貨單收據 + 部分取貨清單

## 測試
測試清單見 `docs/TEST-pickup-print-no-popup.md`。

⚠️ 本 worktree 未裝依賴（`npm install` 經使用者中斷），故 `tsc`/`next build` 未在此跑；變更為純 DOM/TS、已逐處碼審。**列印對話框實際行為（不跳分頁、依序彈、取消不殘留 iframe、80mm 版面）需在本機自審** —— 沙箱無印表機、admin live preview 亦受網路阻擋無法驅動。

## Test plan
- [ ] 單筆取貨 → 只彈一次列印對話框、無新分頁
- [ ] 部分取貨 → 依序彈兩次（取貨單 → 取貨清單）、皆無新分頁
- [ ] 一次全取 → 依序彈兩次（大張取貨單 → 熱感小白單 80mm）、皆無新分頁
- [ ] 列印對話框按「取消」→ 不殘留隱藏 iframe、不卡下一張
- [ ] 小白單折扣 / 儲值金 / 預覽金額顯示與改版前一致
- [ ] `tsc --noEmit` + `next build`（admin）綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)