### PR TITLE
fix(admin/orders): 訂單 KPI 排除取消/逾期（原僅排除轉出）

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -302,7 +302,8 @@ function OrdersListContent() {
         let pq = sb
           .from("customer_orders")
           .select("id, member_id, created_at")
-          .neq("status", "transferred_out")
+          // 營收 KPI 不計：取消 / 逾期 / 轉出（皆非有效成交）
+          .not("status", "in", "(cancelled,expired,transferred_out)")
           .gte("created_at", startDate.toISOString())
           .order("id", { ascending: true });
         if (campaignIds.length === 1) pq = pq.eq("campaign_id", Number(campaignIds[0]));


### PR DESCRIPTION
## 問題

訂單頁四個 KPI（本月營業額 / 本月訂單數 / 客單價 / 本月會員數）的趨勢查詢原本只 `.neq("status", "transferred_out")`，**把 `cancelled`（取消）和 `expired`（逾期）訂單也算進營收**。

實證：系統僅有 2 筆取消訂單（未取貨/已完成/轉出 tab 皆 0）時，KPI 仍顯示 訂單數 2、營業額 \$378、客單價 \$189。

## 修正

KPI trend 查詢改為 `not in (cancelled, expired, transferred_out)`，只計有效成交（pending/confirmed/shipping/ready/partially_completed/completed）。

與既有邏輯一致：
- `orders/pivot` 的 `DEFAULT_EXCLUDED = ["cancelled","expired","transferred_out"]`
- `CampaignOrdersPanel` 金額加總前已 `continue` 掉 cancelled/expired

## 範圍

- 單檔單行（+註解）：`apps/admin/src/app/(protected)/orders/page.tsx`
- tab 計數、列表本身不受影響（取消訂單仍在「取消」tab 正常顯示）
- 未變更：pending/未取貨 訂單仍計入營收（團購情境下下單即成交，與 pivot 頁一致）

## Test plan

- [ ] 一筆 cancelled + 一筆 expired + 一筆 pending（本月）→ KPI 訂單數=1、營業額=該 pending 金額
- [ ] 全部取消時 KPI 歸 0、客單價 0
- [ ] 「取消」tab 仍正確列出取消/逾期訂單、計數不變
- [ ] 開團 / 取貨店 filter 套用後 KPI 仍排除取消/逾期

🤖 Generated with [Claude Code](https://claude.com/claude-code)