### PR TITLE
fix(admin/members): 新增會員「主要店家」必填

### DIFF
--- a/apps/admin/src/components/MemberForm.tsx
+++ b/apps/admin/src/components/MemberForm.tsx
@@ -82,6 +82,10 @@ export function MemberForm({
       setError("手機格式錯誤");
       return;
     }
+    if (!v.id && !v.home_store_id) {
+      setError("主要店家 必填");
+      return;
+    }
     setSaving(true);
     setError(null);
     try {
@@ -184,11 +188,12 @@ export function MemberForm({
           </select>
         </Field>
 
-        <Field label="主要店家">
+        <Field label={`主要店家${v.id ? "" : " *"}`}>
           <select
             value={v.home_store_id ?? ""}
             onChange={(e) => update("home_store_id", e.target.value ? Number(e.target.value) : null)}
             className={inputCls}
+            required={!v.id}
           >
             <option value="">—</option>
             {stores.map((s) => (


### PR DESCRIPTION
## 需求

新增會員 modal 的「主要店家」要改為必填。

## 修正

`MemberForm.tsx`（新增/編輯共用元件）— 僅在**新增**（無 `v.id`）時要求 `home_store_id`：

- 欄位標題：新增時顯示「主要店家 *」，編輯時維持「主要店家」
- `<select required={!v.id}>`
- 送出前驗證：新增且未選店家 → 阻擋並回「主要店家 必填」

## 範圍 / 取捨

- **編輯既有會員不擋**：21k 匯入會員多數 `home_store_id` 為空，若編輯也強制會導致改個電話都得補店家。需求只提「新增」，故按 create/edit 軸線（`!v.id`）切。
- **不動 RPC / DB / 批次匯入**：純前端表單驗證，`rpc_upsert_member` 與 member import 路徑不受影響。
- 與其他 create 入口一致：MemberForm 被多處（含 order-entry 快速建會員）共用，依 `!v.id` 判斷對所有新增路徑生效，符合需求語意。

## Test plan

- [ ] 新增會員：不選主要店家 → 點建立會員 → 阻擋、顯示「主要店家 必填」、標題有 *
- [ ] 新增會員：選店家後 → 正常建立
- [ ] 編輯既有會員（含 home_store 為空者）：標題無 *、不選店家仍可儲存
- [ ] order-entry / 其他快速建會員入口：新增時同樣要求店家

🤖 Generated with [Claude Code](https://claude.com/claude-code)