### PR TITLE
feat(admin/members): 新增會員表單調整（編號自動產生／手機非必填／隱藏等級·email）

### DIFF
--- a/apps/admin/src/components/MemberForm.tsx
+++ b/apps/admin/src/components/MemberForm.tsx
@@ -23,7 +23,6 @@ export type MemberFormValues = {
   notes: string | null;
 };
 
-type Tier = { id: number; code: string; name: string };
 type Store = { id: number; code: string; name: string };
 
 export const emptyMemberValues: MemberFormValues = {
@@ -51,20 +50,15 @@ export function MemberForm({
 }) {
   const router = useRouter();
   const [v, setV] = useState<MemberFormValues>(initial ?? emptyMemberValues);
-  const [tiers, setTiers] = useState<Tier[]>([]);
   const [stores, setStores] = useState<Store[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
-      const sb = getSupabase();
-      const [t, s] = await Promise.all([
-        sb.from("member_tiers").select("id, code, name").order("sort_order"),
-        sb.from("stores").select("id, code, name").eq("is_active", true).order("name"),
-      ]);
-      if (t.data) setTiers(t.data as Tier[]);
-      if (s.data) setStores(s.data as Store[]);
+      const { data } = await getSupabase()
+        .from("stores").select("id, code, name").eq("is_active", true).order("name");
+      if (data) setStores(data as Store[]);
     })();
   }, []);
 
@@ -74,11 +68,11 @@ export function MemberForm({
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!v.member_no || !v.phone || !v.name) {
-      setError("會員編號、手機、姓名 必填");
+    if (!v.name) {
+      setError("姓名 必填");
       return;
     }
-    if (!/^[0-9+\-\s]{6,}$/.test(v.phone)) {
+    if (v.phone && !/^[0-9+\-\s]{6,}$/.test(v.phone)) {
       setError("手機格式錯誤");
       return;
     }
@@ -87,8 +81,8 @@ export function MemberForm({
     try {
       const { data, error: err } = await getSupabase().rpc("rpc_upsert_member", {
         p_id: v.id,
-        p_member_no: v.member_no.trim(),
-        p_phone: v.phone.trim(),
+        p_member_no: v.member_no ? v.member_no.trim() : null,
+        p_phone: v.phone ? v.phone.trim() : null,
         p_name: v.name.trim(),
         p_gender: v.gender,
         p_birthday: v.birthday,
@@ -112,13 +106,14 @@ export function MemberForm({
   return (
     <form onSubmit={onSubmit} className="space-y-4" noValidate>
       <div className="grid gap-4 sm:grid-cols-2">
-        <Field label="會員編號 *">
-          <input
-            value={v.member_no}
-            onChange={(e) => update("member_no", e.target.value)}
-            className={inputCls}
-            required
-          />
+        <Field label="會員編號">
+          {v.id ? (
+            <input value={v.member_no} className={inputCls} readOnly disabled />
+          ) : (
+            <div className={`${inputCls} text-zinc-400 dark:text-zinc-500`}>
+              系統自動產生
+            </div>
+          )}
         </Field>
         <Field label="狀態">
           <select value={v.status} onChange={(e) => update("status", e.target.value as MemberStatus)} className={inputCls}>
@@ -131,12 +126,11 @@ export function MemberForm({
         <Field label="姓名 *">
           <input value={v.name} onChange={(e) => update("name", e.target.value)} className={inputCls} required />
         </Field>
-        <Field label="手機 *">
+        <Field label="手機">
           <input
             value={v.phone}
             onChange={(e) => update("phone", e.target.value)}
             className={inputCls}
-            required
             inputMode="tel"
           />
         </Field>
@@ -159,29 +153,6 @@ export function MemberForm({
             onChange={(s) => update("birthday", s || null)}
             className={inputCls}
           />
-        </Field>
-
-        <Field label="Email">
-          <input
-            type="email"
-            value={v.email ?? ""}
-            onChange={(e) => update("email", e.target.value || null)}
-            className={inputCls}
-          />
-        </Field>
-        <Field label="等級">
-          <select
-            value={v.tier_id ?? ""}
-            onChange={(e) => update("tier_id", e.target.value ? Number(e.target.value) : null)}
-            className={inputCls}
-          >
-            <option value="">—</option>
-            {tiers.map((t) => (
-              <option key={t.id} value={t.id}>
-                {t.name} ({t.code})
-              </option>
-            ))}
-          </select>
         </Field>
 
         <Field label="主要店家">

--- a/supabase/migrations/20260617000010_rpc_upsert_member_autogen_member_no.sql
+++ b/supabase/migrations/20260617000010_rpc_upsert_member_autogen_member_no.sql
@@ -1,0 +1,150 @@
+-- ============================================================
+-- 新增會員：會員編號系統自動產生 + 手機改非必填
+--
+-- rpc_upsert_member：
+--  1) INSERT 未指定 member_no（NULL/空白）→ 沿用 rpc_next_member_no()
+--     規則自動產號（M + 6 碼流水），對 UNIQUE(tenant_id, member_no)
+--     衝突自動重試（併發保護）。仍接受外部指定編號（匯入等），
+--     指定值衝突則明確報錯。
+--  2) 手機非必填：移除 phone required 檢查；空白手機正規化為 NULL，
+--     phone_hash 僅在有手機時計算。
+--  姓名仍為必填。編輯路徑其餘行為不變。
+--
+-- 註：自帶 rpc_next_member_no()（與 20260613000020 同定義、idempotent），
+-- 使本 migration 自足、不依賴 member_import 系列是否已套用。
+-- ============================================================
+
+-- 會員編號流水：M + 6 碼，忽略時間戳形式的舊編號（避免 INT 溢位）
+CREATE OR REPLACE FUNCTION public.rpc_next_member_no()
+RETURNS TEXT LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_next   INT;
+BEGIN
+  SELECT COALESCE(MAX((SUBSTRING(member_no FROM '^M(\d{1,9})$'))::INT), 0) + 1
+    INTO v_next
+    FROM members
+   WHERE tenant_id = v_tenant
+     AND member_no ~ '^M\d{1,9}$';
+  RETURN 'M' || lpad(v_next::text, 6, '0');
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_next_member_no TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_upsert_member(
+  p_id            BIGINT,
+  p_member_no     TEXT,
+  p_phone         TEXT,
+  p_name          TEXT,
+  p_gender        TEXT DEFAULT NULL,
+  p_birthday      DATE DEFAULT NULL,
+  p_email         TEXT DEFAULT NULL,
+  p_tier_id       BIGINT DEFAULT NULL,
+  p_home_store_id BIGINT DEFAULT NULL,
+  p_status        TEXT DEFAULT 'active',
+  p_notes         TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant      UUID := public._current_tenant_id();
+  v_id          BIGINT;
+  v_phone       TEXT := NULLIF(btrim(p_phone), '');
+  v_phone_hash  TEXT;
+  v_email_hash  TEXT;
+  v_birth_md    TEXT;
+  v_old_store   BIGINT;
+  v_open_orders INT;
+BEGIN
+  IF p_name IS NULL OR p_name = '' THEN
+    RAISE EXCEPTION 'name is required';
+  END IF;
+
+  v_phone_hash := CASE WHEN v_phone IS NOT NULL
+                       THEN encode(digest(v_phone, 'sha256'), 'hex')
+                  END;
+  v_email_hash := CASE WHEN p_email IS NOT NULL AND p_email <> ''
+                       THEN encode(digest(lower(p_email), 'sha256'), 'hex')
+                  END;
+  v_birth_md   := CASE WHEN p_birthday IS NOT NULL
+                       THEN to_char(p_birthday, 'MM-DD')
+                  END;
+
+  IF p_tier_id IS NOT NULL THEN
+    PERFORM 1 FROM member_tiers WHERE id = p_tier_id AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'tier % not in tenant', p_tier_id; END IF;
+  END IF;
+
+  IF p_id IS NULL THEN
+    DECLARE
+      v_member_no TEXT    := NULLIF(btrim(p_member_no), '');
+      v_explicit  BOOLEAN := NULLIF(btrim(p_member_no), '') IS NOT NULL;
+      v_try       INT     := 0;
+    BEGIN
+      LOOP
+        IF v_member_no IS NULL THEN
+          v_member_no := public.rpc_next_member_no();
+        END IF;
+        BEGIN
+          INSERT INTO members (
+            tenant_id, member_no, phone_hash, phone, email_hash, email,
+            name, birthday, birth_md, gender, tier_id, home_store_id,
+            status, notes, created_by, updated_by
+          ) VALUES (
+            v_tenant, v_member_no, v_phone_hash, v_phone, v_email_hash, p_email,
+            p_name, p_birthday, v_birth_md, p_gender, p_tier_id, p_home_store_id,
+            COALESCE(p_status, 'active'), p_notes, auth.uid(), auth.uid()
+          ) RETURNING id INTO v_id;
+          EXIT;
+        EXCEPTION WHEN unique_violation THEN
+          IF v_explicit THEN
+            RAISE EXCEPTION '會員編號 % 已存在', v_member_no
+              USING ERRCODE = 'unique_violation';
+          END IF;
+          v_try := v_try + 1;
+          IF v_try > 10 THEN RAISE; END IF;
+          v_member_no := NULL;  -- 重新自動產號重試
+        END;
+      END LOOP;
+    END;
+  ELSE
+    SELECT home_store_id INTO v_old_store FROM members
+     WHERE id = p_id AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'member % not in tenant', p_id; END IF;
+
+    IF v_old_store IS DISTINCT FROM p_home_store_id THEN
+      SELECT COUNT(*) INTO v_open_orders FROM customer_orders
+       WHERE tenant_id = v_tenant
+         AND member_id = p_id
+         AND status NOT IN ('completed','cancelled','expired','transferred_out');
+      IF v_open_orders > 0 THEN
+        RAISE EXCEPTION '會員仍有 % 筆未取貨訂單，請先處理完才能改取貨店', v_open_orders;
+      END IF;
+    END IF;
+
+    UPDATE members SET
+      member_no     = COALESCE(p_member_no, member_no),
+      phone_hash    = v_phone_hash,
+      phone         = v_phone,
+      email_hash    = v_email_hash,
+      email         = p_email,
+      name          = COALESCE(p_name, name),
+      birthday      = p_birthday,
+      birth_md      = v_birth_md,
+      gender        = p_gender,
+      tier_id       = p_tier_id,
+      home_store_id = p_home_store_id,
+      status        = COALESCE(p_status, status),
+      notes         = p_notes,
+      updated_by    = auth.uid()
+    WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'member % not in tenant', p_id; END IF;
+  END IF;
+
+  RETURN v_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_upsert_member TO authenticated;


### PR DESCRIPTION
## 需求（本輪 3 項，皆動到 MemberForm + rpc_upsert_member，故合併一個 PR）

1. 會員編號 → 系統自動產生
2. 手機 → 非必填
3. 等級、email 欄位 → 隱藏

## 後端 `rpc_upsert_member`（migration `20260617000010`）

- **自動產號**：INSERT 未指定 `member_no`（NULL/空白）→ 沿用 `rpc_next_member_no()`（`M`+6 碼流水，忽略時間戳形式舊號）；對 `UNIQUE(tenant_id, member_no)` 衝突自動重試（併發保護）。仍接受外部指定編號（匯入等舊呼叫端），指定值衝突則明確報「會員編號 X 已存在」。
- **手機非必填**：移除 phone-required；空白手機正規化為 `NULL`，`phone_hash` 僅在有手機時計算。**姓名仍必填**。
- **自帶** `rpc_next_member_no()`（與 `20260613000020` 同定義、`CREATE OR REPLACE` idempotent）→ migration 自足，不依賴 member_import 系列是否已套（本機原本就沒有該 fn）。
- 編輯路徑與其餘行為不變。

## 前端 `MemberForm.tsx`

- 會員編號：新增顯示「系統自動產生」、編輯唯讀（不可改）
- 手機：去星號/required，可留空；格式檢查僅在有填時才跑
- 隱藏「等級」「email」欄位 —— **值仍保留於 state 並照常送 RPC**，故編輯既有會員不會清掉原本的 email/tier
- 清掉因移除等級而變死碼的 tiers state / member_tiers 查詢 / Tier type

## ⚠️ 部署相依（重要）

前端新增會員會送 `p_member_no: null`；**舊版 prod RPC 會因 `member_no NOT NULL` 直接失敗**。故：
- migration 必須先（或同時）套到 admin 連線的 DB，新增才不會壞。
- migration 對其他呼叫端**向後相容**（明確編號仍可、手機仍可帶），可安全早於前端合併部署以降風險。

## 驗證

本機已套用 + 交易內煙霧測試（結束 rollback）：
- 自動連號 `M000001`/`M000002`、空白手機→`NULL`、`phone_hash` 隨之 `NULL`
- 明確編號 `CUST999` 沿用、手機有填時正常 hash
- 空姓名仍被擋（`name is required`）

沙箱 admin 連不到 Supabase（已知限制），UI 由你的環境自審。

## Test plan

- [ ] 新增會員：只填姓名 → 成功，會員編號自動產生（M+6 碼、連號）
- [ ] 新增會員：手機留空 → 成功；手機亂填非數字 → 擋「手機格式錯誤」
- [ ] 新增不顯示 等級/email 欄位；編輯既有會員不顯示但原 email/tier 不被清空
- [ ] 編輯會員：會員編號唯讀不可改
- [ ] prod 套 migration 後再驗一次新增（部署相依）

🤖 Generated with [Claude Code](https://claude.com/claude-code)