### PR TITLE
fix(admin/orders): 訂單樞紐表 — 取消/逾期/轉出 以負數計入

### DIFF
--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -100,7 +100,10 @@ function fmtMD(iso: string | null): string {
 }
 
 function fmtAmount(n: number): string {
-  return `$${Math.round(n).toLocaleString("zh-TW")}`;
+  const r = Math.round(n);
+  return r < 0
+    ? `-$${Math.abs(r).toLocaleString("zh-TW")}`
+    : `$${r.toLocaleString("zh-TW")}`;
 }
 
 export default function OrdersPivotPage() {
@@ -188,11 +191,7 @@ function PivotContent() {
           if (m) setDateTo(m);
         }
         if (Array.isArray(saved.status) && saved.status.length > 0) {
-          // 清洗舊 LS：取消/逾期/轉出不計入統計，丟掉這些舊選取
-          const allowed = (saved.status as OrderStatus[]).filter((s) =>
-            DEFAULT_INCLUDED.includes(s),
-          );
-          setStatusSet(new Set(allowed.length > 0 ? allowed : DEFAULT_INCLUDED));
+          setStatusSet(new Set(saved.status));
         }
         if (!searchParams.get("storeId") && typeof saved.storeId === "string") {
           setStoreId(saved.storeId);
@@ -279,9 +278,7 @@ function PivotContent() {
           .select(
             "id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, created_at",
           )
-          .in("status", statusArr)
-          // 取消/逾期/轉出永不計入統計（與訂單 KPI 一致；防 LS/狀態殘留）
-          .not("status", "in", "(cancelled,expired,transferred_out)");
+          .in("status", statusArr);
 
         // 日期過濾 (月為單位): from = month start, to = next month start (exclusive)
         // viewBy="campaign" 時不對訂單日期過濾, 但仍套日期範圍到 campaign.end_at (見下方 client filter)
@@ -359,7 +356,12 @@ function PivotContent() {
 
   // 樞紐 aggregate (generic groupKey based on viewBy)
   // cell: orderIds (distinct order count), qtySum (品項數量加總), amount (qty × unit_price 加總)
-  type CellAgg = { orderIds: Set<number>; qtySum: number; amount: number };
+  type CellAgg = {
+    posOrders: Set<number>; // 有效訂單
+    negOrders: Set<number>; // 取消/逾期/轉出（扣抵）
+    qtySum: number;
+    amount: number;
+  };
   type SkuEntry = { name: string; perStore: Map<number, CellAgg> };
   type Group = {
     key: string;
@@ -428,13 +430,19 @@ function PivotContent() {
       storeIdsUsed.add(sid);
       let cell = entry.perStore.get(sid);
       if (!cell) {
-        cell = { orderIds: new Set(), qtySum: 0, amount: 0 };
+        cell = { posOrders: new Set(), negOrders: new Set(), qtySum: 0, amount: 0 };
         entry.perStore.set(sid, cell);
       }
+      // 取消/逾期/轉出 視為扣抵 → 數量/金額/訂單數皆以負數計入
+      const dead =
+        o.status === "cancelled" ||
+        o.status === "expired" ||
+        o.status === "transferred_out";
+      const sign = dead ? -1 : 1;
       const qty = Number(it.qty);
-      cell.orderIds.add(o.id);
-      cell.qtySum += qty;
-      cell.amount += qty * Number(it.unit_price);
+      (dead ? cell.negOrders : cell.posOrders).add(o.id);
+      cell.qtySum += sign * qty;
+      cell.amount += sign * qty * Number(it.unit_price);
     }
 
     const groupArr = Array.from(groups.values()).sort((a, b) =>
@@ -450,10 +458,14 @@ function PivotContent() {
   }, [items, orderMap, campaignMap, storeMap, viewBy, dateFrom, dateTo]);
 
   // metric 取值 helper
+  // 訂單數淨值＝有效訂單數 − 取消/逾期/轉出 訂單數
+  const cellOrderCount = (c: CellAgg): number => c.posOrders.size - c.negOrders.size;
+  const cellTouched = (c: CellAgg): number => c.posOrders.size + c.negOrders.size;
+  const cellAllOrderIds = (c: CellAgg): number[] => [...c.posOrders, ...c.negOrders];
   const cellValue = (cell: CellAgg | undefined): number => {
     if (!cell) return 0;
     if (metric === "item_qty") return cell.qtySum;
-    if (metric === "order_count") return cell.orderIds.size;
+    if (metric === "order_count") return cellOrderCount(cell);
     return cell.amount;
   };
   const fmtCellValue = (v: number): string => {
@@ -477,7 +489,7 @@ function PivotContent() {
             metric === "item_qty"
               ? cell.qtySum
               : metric === "order_count"
-              ? cell.orderIds.size
+              ? cell.posOrders.size - cell.negOrders.size
               : cell.amount;
           perStore.set(sid, (perStore.get(sid) ?? 0) + v);
           grand += v;
@@ -493,7 +505,8 @@ function PivotContent() {
     for (const g of pivot.groups) {
       for (const [, entry] of g.skus) {
         for (const [, cell] of entry.perStore) {
-          for (const id of cell.orderIds) ids.add(id);
+          for (const id of cell.posOrders) ids.add(id);
+          for (const id of cell.negOrders) ids.add(id);
         }
       }
     }
@@ -501,12 +514,12 @@ function PivotContent() {
   }, [pivot]);
 
   function onCellClick(group: Group, skuId: number, sid: number, cell: CellAgg) {
-    if (cell.orderIds.size === 0) return;
+    if (cellTouched(cell) === 0) return;
     const sku = group.skus.get(skuId);
     const skuName = sku?.name ?? `SKU#${skuId}`;
     const storeName = storeMap.get(sid)?.name ?? `店#${sid}`;
     const title = `${group.label}${group.subLabel ? "（" + group.subLabel + "）" : ""} / ${skuName} / ${storeName}`;
-    setCellModal({ title, orderIds: Array.from(cell.orderIds), skuId });
+    setCellModal({ title, orderIds: cellAllOrderIds(cell), skuId });
   }
 
   return (
@@ -640,11 +653,11 @@ function PivotContent() {
             className="flex w-full items-center justify-between rounded-md border border-zinc-300 bg-white px-3 py-2 text-left text-sm dark:border-zinc-700 dark:bg-zinc-800"
           >
             <span className="truncate">
-              {statusSet.size === DEFAULT_INCLUDED.length
+              {statusSet.size === ORDER_STATUSES.length
                 ? "全部狀態"
                 : statusSet.size === 0
                 ? "未選狀態"
-                : `已選 ${statusSet.size} / ${DEFAULT_INCLUDED.length} 狀態`}
+                : `已選 ${statusSet.size} / ${ORDER_STATUSES.length} 狀態`}
             </span>
             <span className="ml-2 text-zinc-400">▾</span>
           </SpinButton>
@@ -658,7 +671,7 @@ function PivotContent() {
                   預設
                 </SpinButton>
                 <SpinButton
-                  onClick={() => setStatusSet(new Set(DEFAULT_INCLUDED))}
+                  onClick={() => setStatusSet(new Set(ORDER_STATUSES))}
                   className="text-blue-600 hover:underline dark:text-blue-400"
                 >
                   全選
@@ -670,7 +683,7 @@ function PivotContent() {
                   關閉
                 </SpinButton>
               </div>
-              {DEFAULT_INCLUDED.map((s) => {
+              {ORDER_STATUSES.map((s) => {
                 const checked = statusSet.has(s);
                 return (
                   <label
@@ -842,7 +855,7 @@ function PivotContent() {
                             const cell = entry.perStore.get(sid);
                             const v = cellValue(cell);
                             rowTotal += v;
-                            if (!cell || cell.orderIds.size === 0) {
+                            if (!cell || cellTouched(cell) === 0) {
                               return (
                                 <td
                                   key={sid}
@@ -858,7 +871,7 @@ function PivotContent() {
                                   type="button"
                                   onClick={() => onCellClick(group, skuId, sid, cell)}
                                   className="rounded px-1.5 py-0.5 font-mono font-semibold text-blue-700 hover:bg-blue-50 hover:underline dark:text-blue-300 dark:hover:bg-blue-950"
-                                  title={`點看 ${cell.orderIds.size} 筆訂單`}
+                                  title={`點看 ${cellTouched(cell)} 筆訂單`}
                                 >
                                   {fmtCellValue(v)}
                                 </SpinButton>

--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -188,7 +188,11 @@ function PivotContent() {
           if (m) setDateTo(m);
         }
         if (Array.isArray(saved.status) && saved.status.length > 0) {
-          setStatusSet(new Set(saved.status));
+          // 清洗舊 LS：取消/逾期/轉出不計入統計，丟掉這些舊選取
+          const allowed = (saved.status as OrderStatus[]).filter((s) =>
+            DEFAULT_INCLUDED.includes(s),
+          );
+          setStatusSet(new Set(allowed.length > 0 ? allowed : DEFAULT_INCLUDED));
         }
         if (!searchParams.get("storeId") && typeof saved.storeId === "string") {
           setStoreId(saved.storeId);
@@ -275,7 +279,9 @@ function PivotContent() {
           .select(
             "id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, created_at",
           )
-          .in("status", statusArr);
+          .in("status", statusArr)
+          // 取消/逾期/轉出永不計入統計（與訂單 KPI 一致；防 LS/狀態殘留）
+          .not("status", "in", "(cancelled,expired,transferred_out)");
 
         // 日期過濾 (月為單位): from = month start, to = next month start (exclusive)
         // viewBy="campaign" 時不對訂單日期過濾, 但仍套日期範圍到 campaign.end_at (見下方 client filter)
@@ -634,11 +640,11 @@ function PivotContent() {
             className="flex w-full items-center justify-between rounded-md border border-zinc-300 bg-white px-3 py-2 text-left text-sm dark:border-zinc-700 dark:bg-zinc-800"
           >
             <span className="truncate">
-              {statusSet.size === ORDER_STATUSES.length
+              {statusSet.size === DEFAULT_INCLUDED.length
                 ? "全部狀態"
                 : statusSet.size === 0
                 ? "未選狀態"
-                : `已選 ${statusSet.size} / ${ORDER_STATUSES.length} 狀態`}
+                : `已選 ${statusSet.size} / ${DEFAULT_INCLUDED.length} 狀態`}
             </span>
             <span className="ml-2 text-zinc-400">▾</span>
           </SpinButton>
@@ -652,7 +658,7 @@ function PivotContent() {
                   預設
                 </SpinButton>
                 <SpinButton
-                  onClick={() => setStatusSet(new Set(ORDER_STATUSES))}
+                  onClick={() => setStatusSet(new Set(DEFAULT_INCLUDED))}
                   className="text-blue-600 hover:underline dark:text-blue-400"
                 >
                   全選
@@ -664,7 +670,7 @@ function PivotContent() {
                   關閉
                 </SpinButton>
               </div>
-              {ORDER_STATUSES.map((s) => {
+              {DEFAULT_INCLUDED.map((s) => {
                 const checked = statusSet.has(s);
                 return (
                   <label


### PR DESCRIPTION
## 需求演進

最初：取消單被算進樞紐統計 → 先做成「不可選 + 硬排除」。
**最終需求（本 PR）**：取消/逾期/轉出的訂單**可勾選**，勾了就以**負數**計入統計（視為扣抵）。本 PR 已改為此做法（含還原前一版的排除邏輯）。

## 行為

- 狀態多選恢復可勾 `cancelled / expired / transferred_out`（picker、「全選」、localStorage、查詢都還原）。
- **預設選取仍只含有效狀態**（`DEFAULT_INCLUDED`）→ 預設畫面不變、不會突然冒負數；要看扣抵需自行勾選。
- 勾選後，該類訂單對 cell / 小計 / 總計的貢獻為負：
  - `CellAgg` 改 `posOrders` / `negOrders` 雙集合
  - 品項數 `qtySum`、金額 `amount` 帶符號累加
  - 訂單數 = 有效訂單數 − 取消類訂單數（可為負）
- 同一 cell 混合有效＋取消 → 顯示淨值（扣抵後）。
- `共 X 筆訂單` 表頭與點格 drill-down 仍列全部（含取消，方便核對）。
- `fmtAmount` 負值顯示 `-$1,234`（原會變 `$-1,234`）。

## Test plan

- [ ] 預設（未動狀態）→ 與現況一致，無負數
- [ ] 勾選「取消」→ 純取消的 cell/小計/總計顯示負值（品項數/訂單數/金額三種 metric 都對）
- [ ] 有效 5 + 取消 2 同品項同店 → 訂單數顯示 3、品項數/金額為淨值
- [ ] 「全選」含取消/逾期/轉出；點負值格 drill-down 可列出該些訂單
- [ ] 金額負值顯示為 -$X,XXX

🤖 Generated with [Claude Code](https://claude.com/claude-code)