### PR TITLE
fix(admin/members): 會員表單錯誤顯示 [object Object]

### DIFF
--- a/apps/admin/src/components/MemberForm.tsx
+++ b/apps/admin/src/components/MemberForm.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
 import { DatePicker } from "@/components/DatePicker";
 import SpinButton from "@/components/SpinButton";
 
@@ -101,7 +102,7 @@ export function MemberForm({
       if (onSaved) onSaved(newId);
       else router.replace(`/members?id=${newId}`);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
## 問題

新增/編輯會員失敗時，畫面紅字顯示 `[object Object]`，看不到真正錯誤（截圖佐證）。

原因：`getSupabase().rpc(...)` 回傳的 `error` 是 Supabase `PostgrestError`（普通物件，**非 `Error` 實例**）。`onSubmit` catch 用 `e instanceof Error ? e.message : String(e)` → 走 `String(物件)` → `"[object Object]"`。

## 修正

改用專案既有的 `translateRpcError`（`@/lib/rpcError`）：會從物件取 `.message`、套中文翻譯規則、fallback 原訊息。與訂單頁等其他地方一致。

單檔 2 行（import + catch）。

## 附帶說明（非本 PR 範圍）

目前那筆錯誤的真實內容是 `member_no` not-null violation —— 即 **prod 尚未套 `20260617000010` migration**。本 PR 只修「錯誤顯示」；新增會員要能成功，仍需把該 migration 套上 prod（已另外回報，待手動執行）。修好顯示後，套 migration 前的失敗會顯示真正訊息而非 `[object Object]`。

## Test plan

- [ ] prod 未套 migration 時新增會員 → 紅字顯示真正錯誤訊息（非 [object Object]）
- [ ] 重複手機 / 其他 RPC 例外 → 顯示可讀（中文化）訊息
- [ ] 正常新增/編輯 → 無錯誤、流程不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)