### PR TITLE
feat(admin/products): 新增刪除商品功能（軟刪除停產；上架中／有訂單不可刪）

### DIFF
--- a/apps/admin/src/app/(protected)/products/page.tsx
+++ b/apps/admin/src/app/(protected)/products/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
 import { Modal } from "@/components/Modal";
 import { ProductForm, type ProductFormValues } from "@/components/ProductForm";
 import { ProductSkuSection, type ProductSkuSectionHandle } from "@/components/ProductSkuSection";
@@ -368,6 +369,32 @@ function PageContent() {
     }
   }
 
+  // 刪除商品（軟刪除：product + 規格 → 停產，連動清掉草稿開團）
+  // 守門：上架中不可刪（鈕已隱藏）、有訂單不可刪（RPC 擋下並回中文）
+  async function deleteProduct(id: number, name: string) {
+    if (
+      !window.confirm(
+        `確定刪除商品「${name}」？\n\n` +
+          `此操作會將商品與其所有規格設為「停產」，並自動從草稿開團中移除。\n` +
+          `（上架中或已有顧客訂單的商品無法刪除；已開團／已下訂的歷史不受影響）`
+      )
+    )
+      return;
+    setError(null);
+    try {
+      const { error: err } = await getSupabase().rpc("rpc_delete_product", { p_id: id });
+      if (err) throw err;
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      setReloadTick((t) => t + 1);
+    } catch (e) {
+      setError(translateRpcError(e));
+    }
+  }
+
   // open 開團 modal: fetch storage_type for selected product ids
   async function openCampaignModal() {
     const ids = Array.from(selectedIds);
@@ -675,12 +702,22 @@ function PageContent() {
                     {new Date(r.updated_at).toLocaleString("zh-TW")}
                   </Td>
                   <Td>
-                    <SpinButton
-                      onClick={() => openEdit(r.id)}
-                      className="text-xs text-blue-600 hover:underline dark:text-blue-400"
-                    >
-                      編輯
-                    </SpinButton>
+                    <div className="flex items-center gap-3">
+                      <SpinButton
+                        onClick={() => openEdit(r.id)}
+                        className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                      >
+                        編輯
+                      </SpinButton>
+                      {r.status !== "active" && (
+                        <SpinButton
+                          onClick={() => deleteProduct(r.id, r.name)}
+                          className="text-xs text-red-600 hover:underline disabled:opacity-50 dark:text-red-400"
+                        >
+                          刪除
+                        </SpinButton>
+                      )}
+                    </div>
                   </Td>
                 </Tr>
               ))

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -189,6 +189,19 @@ const RULES: Rule[] = [
     render: (m) =>
       `損壞數量 ${fmt(m[1])} 超過可登記量 ${fmt(Number(m[2]) - Number(m[3]) + "")}(已收 ${fmt(m[2])}、已登記損壞 ${fmt(m[3])})。`,
   },
+  // ===== rpc_delete_product（商品刪除守門） =====
+  {
+    pattern: /product \d+ is active, cannot delete/i,
+    render: () => "商品「上架中」無法刪除，請先將商品下架後再刪除。",
+  },
+  {
+    pattern: /product \d+ has orders, cannot delete/i,
+    render: () => "此商品已有顧客訂單，無法刪除。",
+  },
+  {
+    pattern: /product \d+ not found/i,
+    render: () => "找不到此商品（可能已被刪除）。",
+  },
   // ===== 撿貨單號碼衝突(同秒多筆提交時的 race) =====
   {
     pattern: /duplicate key value violates unique constraint "picking_waves_tenant_id_wave_code_key"/i,

--- a/docs/TEST-product-delete.md
+++ b/docs/TEST-product-delete.md
@@ -1,0 +1,71 @@
+# 測試項目 — 刪除商品（軟刪除 → 停產）
+
+**對應 migration:** `supabase/migrations/20260618000010_rpc_delete_product.sql`
+**對應 UI 變更:** `apps/admin/src/app/(protected)/products/page.tsx`
+
+> 設計決策：products / skus 有 `forbid_sku_delete` trigger（`BEFORE DELETE` 一律 raise）且被
+> campaign_items / customer_order_items / prices / barcodes 等 10+ 表 FK 參照，**實體刪除不可行**。
+> 沿用既有 `rpc_delete_sku` 慣例 → 「刪除商品」= 軟刪除：product + 其所有 sku 設 `status='discontinued'`。
+> SKU active→非active 會觸發 `_cleanup_sku_from_draft_campaigns`（自動把該 SKU 從草稿開團移除）。
+> 已開團 / 已下訂的歷史不受影響。
+>
+> **守門（2026-06-18 使用者要求）：**
+> 1. 商品「上架中」(`status='active'`) **不可刪除** — 列表鈕隱藏 + RPC raise。
+> 2. 商品只要有**任何顧客訂單**（`customer_order_items` 參照其 sku）**不可刪除** — RPC raise。
+
+## 1. RPC 層
+
+### 1.1 函式存在且權限正確
+- [ ] `rpc_delete_product(BIGINT)` 存在、`SECURITY DEFINER`
+- [ ] `authenticated` 有 EXECUTE、PUBLIC 無
+
+```sql
+SELECT proname, prosecdef FROM pg_proc WHERE proname = 'rpc_delete_product';
+SELECT has_function_privilege('authenticated','public.rpc_delete_product(bigint)','EXECUTE');
+```
+
+### 1.2 正常流程：軟刪除（非上架、無訂單）
+- [ ] 對一個 `inactive`（下架）且**無訂單**的商品（含 2 個 sku）呼叫 → 回傳 void、不報錯
+- [ ] 商品 `status` 變 `discontinued`，`updated_by` = 呼叫者
+- [ ] 該商品所有 sku `status` 全變 `discontinued`
+- [ ] `product_audit_log` 新增一筆 `action='delete'`，`before_value`/`after_value` 有值
+- [ ] `draft` 商品、`discontinued` 商品（再刪一次，冪等）同樣可呼叫不報錯
+
+### 1.2b 守門：上架中不可刪
+- [ ] 對 `status='active'` 商品呼叫 → RAISE `product % is active, cannot delete`
+- [ ] 商品狀態 / sku 狀態 / audit log **完全不變**
+
+### 1.2c 守門：有訂單不可刪
+- [ ] 商品某 sku 已存在於 `customer_order_items` → 呼叫 RAISE `product % has orders, cannot delete`
+- [ ] 即使商品已是 `inactive`/`draft`，只要有訂單仍被擋
+- [ ] 商品 / sku / audit **完全不變**
+
+### 1.3 草稿開團連動
+- [ ] 商品的某 sku 原本掛在一個 `draft` 開團的 `campaign_items` → 刪除商品後該 `campaign_items` 被自動移除
+- [ ] 該 sku 若掛在 `open`/`closed` 開團 → `campaign_items` **保留**（不破壞已開團）
+
+### 1.4 邊界 / 錯誤情境
+- [ ] 不存在的 id → RAISE `product % not found`（前端顯示中文）
+- [ ] 跨 tenant 的 id → 視為找不到，RAISE，不可動到別 tenant 資料
+- [ ] 呼叫後該商品 FK 參照（prices / barcodes / campaign_items(open)）**完全不變**（純軟刪、無實體 DELETE）
+
+## 2. UI 層（商品列表頁）
+
+### 2.1 刪除鈕（僅非上架列顯示）
+- [ ] `active`（上架）列：**不顯示**「刪除」鈕（只有「編輯」）
+- [ ] `draft` / `inactive` / `discontinued` 列：「編輯」旁顯示紅色「刪除」鈕
+- [ ] 點擊跳 `window.confirm`，文案說明「上架中或已有訂單無法刪除；將把商品與規格停產並從草稿開團移除」
+- [ ] 取消 confirm → 不執行、無 side effect
+- [ ] 確認（無訂單）→ 呼叫 `rpc_delete_product`，成功後列表自動 reload，該商品顯示「停產」badge
+- [ ] 確認（有訂單）→ RPC 擋下，`translateRpcError` 顯示「此商品已有顧客訂單，無法刪除。」
+- [ ] RPC 失敗 → 錯誤經 `translateRpcError` 顯示中文（非 `[object Object]`）
+- [ ] 刪除進行中鈕呈 spinner（純轉圈、無文字 — 依 loading 慣例）
+
+### 2.2 回歸
+- [ ] 「編輯」「開團」「批次上架/下架」「清除選取」皆不受影響
+- [ ] 將 active 商品「批次下架」後，該列即出現「刪除」鈕（狀態驅動）
+- [ ] 狀態篩選選「停產」可篩出被刪除的商品（資料仍在、可追溯）
+
+## 3. 驗證方式
+- RPC：上述 SQL 於 Supabase Studio 實跑（auto 模式 agent 無法 push，SQL 交使用者執行）
+- UI：`tsc --noEmit` + `next build` 綠；preview 互動由使用者自審（沙箱阻擋登入）

--- a/supabase/migrations/20260618000010_rpc_delete_product.sql
+++ b/supabase/migrations/20260618000010_rpc_delete_product.sql
@@ -1,0 +1,83 @@
+-- ============================================================
+-- 2026-06-18: rpc_delete_product — 商品刪除（軟刪除）
+-- ------------------------------------------------------------
+-- products / skus 有 forbid_sku_delete trigger（BEFORE DELETE 一律 raise）
+-- 且被 campaign_items / customer_order_items / prices / barcodes 等多表 FK
+-- 參照，實體刪除不可行。沿用 rpc_delete_sku 慣例 → 軟刪除：
+--   product + 其所有 sku 設 status='discontinued'。
+-- SKU active→非active 會觸發 _cleanup_sku_from_draft_campaigns
+-- （自動把該 SKU 從 draft 開團移除）；open/closed 開團與已下訂歷史不動。
+-- 走 SECURITY DEFINER：admin JWT 無 role claim 也可改；限同 tenant。
+--
+-- 守門（2026-06-18 使用者要求）：
+--   1. 商品「上架中」(status='active') 不可刪除 → 請先下架。
+--   2. 商品只要有任何顧客訂單（customer_order_items 參照其 sku）不可刪除。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_delete_product(
+  p_id BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_user   UUID := auth.uid();
+  v_status TEXT;
+  v_before JSONB;
+  v_after  JSONB;
+BEGIN
+  -- 上鎖（FOR UPDATE 只接純欄位，避免與 to_jsonb 併用的相容性疑慮）
+  SELECT status INTO v_status
+    FROM products
+   WHERE id = p_id AND tenant_id = v_tenant
+   FOR UPDATE;
+
+  IF v_status IS NULL THEN
+    RAISE EXCEPTION 'product % not found', p_id;
+  END IF;
+
+  -- 守門 1：上架中不可刪
+  IF v_status = 'active' THEN
+    RAISE EXCEPTION 'product % is active, cannot delete', p_id;
+  END IF;
+
+  -- 守門 2：有任何顧客訂單不可刪
+  IF EXISTS (
+    SELECT 1
+      FROM customer_order_items coi
+      JOIN skus s ON s.id = coi.sku_id
+     WHERE s.product_id = p_id
+       AND s.tenant_id  = v_tenant
+  ) THEN
+    RAISE EXCEPTION 'product % has orders, cannot delete', p_id;
+  END IF;
+
+  SELECT to_jsonb(p) INTO v_before FROM products p WHERE p.id = p_id;
+
+  UPDATE products
+     SET status     = 'discontinued',
+         updated_by = v_user,
+         updated_at = NOW()
+   WHERE id = p_id AND tenant_id = v_tenant;
+
+  -- 連動規格軟刪除：觸發 _cleanup_sku_from_draft_campaigns + touch_updated_at
+  UPDATE skus
+     SET status     = 'discontinued',
+         updated_by = v_user
+   WHERE product_id = p_id
+     AND tenant_id  = v_tenant
+     AND status    <> 'discontinued';
+
+  SELECT to_jsonb(p) INTO v_after FROM products p WHERE p.id = p_id;
+  PERFORM public._log_product_audit(
+    v_tenant, 'product', p_id, 'delete',
+    v_before, v_after, '商品刪除（軟刪除：停產，連動規格停產）'
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_delete_product(BIGINT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_delete_product(BIGINT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_delete_product(BIGINT) IS
+  '商品軟刪除：限非上架中且無任何顧客訂單；product + 其所有 sku 設 status=discontinued；同 tenant；寫 product_audit_log action=delete。';


### PR DESCRIPTION
## Summary
- 新增「刪除商品」功能。商品被 `forbid_sku_delete` trigger + campaign_items / customer_order_items / prices / barcodes 等多表 FK 參照，**無法實體刪除** → 沿用既有 `rpc_delete_sku` 慣例改為**軟刪除**：`product` 與其所有 `sku` 設為 `discontinued`（停產）。
- SKU `active → 非active` 連動既有 `_cleanup_sku_from_draft_campaigns` trigger，自動把該 SKU 從 **草稿開團** 移除；`open/closed` 開團與已下訂歷史不受影響。
- 寫 `product_audit_log` (`action='delete'`，含 before/after) 保留稽核。

## 守門（依使用者要求）
- **上架中不可刪**：`status='active'` 列表不顯示「刪除」鈕；`rpc_delete_product` 亦 raise `product % is active, cannot delete` 作後端保險。
- **有訂單不可刪**：RPC 檢查 `customer_order_items` 是否參照該商品任一 sku，若有則 raise `product % has orders, cannot delete`。
- 兩種錯誤 + not found 皆新增 `rpcError.ts` 規則轉中文（避免 `[object Object]`，對齊 #277）。

## 變更
- `supabase/migrations/20260618000010_rpc_delete_product.sql` — 新 RPC（SECURITY DEFINER、限同 tenant、FOR UPDATE lock、兩道守門、軟刪 product+sku、寫 audit）
- `apps/admin/src/app/(protected)/products/page.tsx` — 列表「刪除」鈕（非上架列才顯示）+ confirm + `translateRpcError`
- `apps/admin/src/lib/rpcError.ts` — 3 條商品刪除錯誤中文化規則
- `docs/TEST-product-delete.md` — 測試項目清單

## Test plan
- [ ] migration SQL 於 Supabase Studio 套用（auto 模式 agent 無法 push，SQL 交使用者執行）
- [ ] RPC：非上架且無訂單商品 → 軟刪成功、sku 連動停產、draft 開團 campaign_items 移除、audit 一筆
- [ ] RPC 守門：active 商品 / 有訂單商品 → raise，狀態完全不變
- [ ] RPC：not found / 跨 tenant → raise，不動別 tenant
- [ ] UI：active 列無刪除鈕；下架後出現；刪除成功列表 reload 顯示「停產」
- [ ] UI：有訂單商品刪除 → 顯示「此商品已有顧客訂單，無法刪除。」
- [ ] 回歸：編輯／開團／批次上下架／清除選取不受影響
- `next build` 綠（已驗）；preview 互動由使用者自審（沙箱阻擋 admin 登入）

🤖 Generated with [Claude Code](https://claude.com/claude-code)