### PR TITLE
feat(admin/campaigns): 新增刪除開團功能（草稿限定，實體刪除）

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
 import { Modal } from "@/components/Modal";
 import { CampaignForm, type CampaignFormValues } from "@/components/CampaignForm";
 import { CampaignOrdersPanel } from "@/components/CampaignOrdersPanel";
@@ -213,6 +214,34 @@ export default function CampaignsListPage() {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setFinalizingId(null);
+    }
+  }
+
+  // 刪除開團（僅草稿；實體刪除，連帶 campaign_items/channels/audit）
+  async function deleteCampaign(id: number, name: string) {
+    if (
+      !confirm(
+        `確定刪除草稿開團「${name}」？\n\n` +
+          `將一併刪除其商品明細與頻道設定，此操作無法復原。\n` +
+          `（只有「草稿」可刪除；已開團 / 已收單請改用「批次取消」）`
+      )
+    )
+      return;
+    setError(null);
+    try {
+      const { error: rpcErr } = await getSupabase().rpc("rpc_delete_campaign", {
+        p_campaign_id: id,
+        p_operator: (await getSupabase().auth.getUser()).data.user?.id,
+      });
+      if (rpcErr) throw rpcErr;
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      setReloadTick((t) => t + 1);
+    } catch (e) {
+      setError(translateRpcError(e));
     }
   }
 
@@ -436,6 +465,14 @@ export default function CampaignsListPage() {
           className="text-xs text-purple-600 hover:underline disabled:opacity-50 dark:text-purple-400"
         >
           {finalizingId === r.id ? "結算中…" : "結算"}
+        </SpinButton>
+      )}
+      {r.status === "draft" && (
+        <SpinButton
+          onClick={() => deleteCampaign(r.id, r.name)}
+          className="text-xs text-red-600 hover:underline disabled:opacity-50 dark:text-red-400"
+        >
+          刪除
         </SpinButton>
       )}
     </>

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -13,6 +13,18 @@ const TRANSFER_STATUS_ZH: Record<string, string> = {
 };
 const tStatus = (s: string) => TRANSFER_STATUS_ZH[s] ?? s;
 
+const CAMPAIGN_STATUS_ZH: Record<string, string> = {
+  draft: "草稿",
+  open: "開團中",
+  closed: "已收單",
+  ordered: "已下訂",
+  receiving: "到貨中",
+  ready: "可取貨",
+  completed: "已完成",
+  cancelled: "已取消",
+};
+const cStatus = (s: string) => CAMPAIGN_STATUS_ZH[s] ?? s;
+
 const RULES: Rule[] = [
   {
     // 新版（含 SKU）：'Insufficient stock for SKU <code> (<name>): available=X, required=Y'
@@ -170,6 +182,20 @@ const RULES: Rule[] = [
   {
     pattern: /invalid p_movement_type\s+(\S+)\s*\(must be customer_return or damage\)/i,
     render: (m) => `退貨類型「${m[1]}」不合法，只能是「一般退貨」或「破損」。`,
+  },
+  // ===== rpc_delete_campaign（開團刪除守門） =====
+  {
+    pattern: /campaign \d+ is (\w+), only draft can be deleted/i,
+    render: (m) =>
+      `此開團目前為「${cStatus(m[1])}」，只有「草稿」可以刪除。已開團 / 已收單請改用「批次取消」。`,
+  },
+  {
+    pattern: /campaign \d+ has \d+ orders?, cannot delete/i,
+    render: () => "此開團已有顧客訂單，無法刪除。請先取消相關訂單，或改用「批次取消」。",
+  },
+  {
+    pattern: /campaign \d+ not found/i,
+    render: () => "找不到此開團（可能已被刪除）。",
   },
   // ===== rpc_register_damage =====
   {

--- a/docs/TEST-campaign-delete.md
+++ b/docs/TEST-campaign-delete.md
@@ -1,0 +1,64 @@
+# 測試項目 — 刪除開團（草稿限定，實體刪除）
+
+**對應 migration:** `supabase/migrations/20260618000020_rpc_delete_campaign.sql`
+**對應 UI 變更:** `apps/admin/src/app/(protected)/campaigns/page.tsx`, `apps/admin/src/lib/rpcError.ts`
+
+> 設計決策：開團狀態機嚴格單向（draft→open→closed→cancelled），`cancelled` 為軟取消終態。
+> `customer_orders` / `order_waitlist` / `customer_order_sources` / `purchase_request_items`
+> 皆以 **無 CASCADE** FK 參照開團 → 任何曾有訂單/PR 的開團實體刪除會被 RESTRICT 擋下。
+> 故 **只允許刪除 `draft` 開團**（draft 必無 orders / PR / waitlist），其他狀態要刪請走「批次取消」。
+> `campaign_items` / `campaign_channels` / `campaign_audit_log` 為 `ON DELETE CASCADE`；
+> 但 `campaign_audit_log` 有 `trg_no_mut_camp_audit` append-only BEFORE DELETE trigger，
+> 需仿 `rpc_delete_picking_wave` 暫時 DISABLE 該 trigger 再刪。
+
+## 1. RPC 層
+
+### 1.1 函式存在且權限正確
+- [ ] `rpc_delete_campaign(BIGINT, UUID)` 存在、`SECURITY DEFINER`
+- [ ] `authenticated` 有 EXECUTE、PUBLIC 無
+
+```sql
+SELECT proname, prosecdef FROM pg_proc WHERE proname = 'rpc_delete_campaign';
+SELECT has_function_privilege('authenticated','public.rpc_delete_campaign(bigint,uuid)','EXECUTE');
+```
+
+### 1.2 正常流程：刪除草稿開團
+- [ ] 建一個 `draft` 開團 + 2 個 `campaign_items`（必要時加 1 `campaign_channels`）
+- [ ] 編輯數次製造 `campaign_audit_log` 數筆
+- [ ] 呼叫 `rpc_delete_campaign(id, operator)` → 不報錯
+- [ ] `group_buy_campaigns` 該列消失
+- [ ] 對應 `campaign_items` / `campaign_channels` / `campaign_audit_log` 全消失（cascade）
+- [ ] `trg_no_mut_camp_audit` 刪除後**已重新 ENABLE**（再對任何 campaign_audit_log 做 UPDATE/DELETE 仍 raise `append-only`）
+
+### 1.3 狀態守門（核心安全）
+- [ ] `open` 開團 → RAISE `campaign % is open, only draft can be deleted`
+- [ ] `closed` / `ordered` / `receiving` / `ready` / `completed` / `cancelled` → 同樣被擋（各別測 cancelled + 一個中間態）
+- [ ] 防禦：draft 但被塞了 customer_orders（人工構造）→ RAISE，不可刪（belt-and-suspenders）
+
+### 1.4 邊界 / 錯誤
+- [ ] 不存在 id → RAISE `campaign % not found`
+- [ ] 跨 tenant id → 視為找不到，不可動別 tenant
+- [ ] 失敗時（任何 EXCEPTION）append-only trigger 一定被 re-enable（測：在 raise 後查 trigger 仍 enabled）
+- [ ] 同 tenant 其他開團、訂單、PR 完全不受影響
+
+## 2. UI 層（開團列表頁）
+
+### 2.1 刪除鈕（共用 `campaignActions`，桌機表格 + 手機卡片同步）
+- [ ] **僅** `status === 'draft'` 的列/卡片顯示紅色「刪除」鈕；其餘狀態不顯示
+- [ ] 點擊跳 `window.confirm`，文案說明「僅草稿可刪、刪除後無法復原」
+- [ ] 取消 → 無 side effect
+- [ ] 確認 → 呼叫 `rpc_delete_campaign`，成功後列表 reload，該開團消失
+- [ ] 失敗 → `translateRpcError` 顯示中文（含「只有草稿可以刪除」規則）
+- [ ] 進行中 disabled / spinner（純轉圈）
+
+### 2.2 rpcError 規則
+- [ ] `campaign \d+ is \w+, only draft can be deleted` → 中文「此開團目前為「<狀態>」，只有草稿可以刪除。」
+- [ ] `campaign \d+ has \d+ orders, cannot delete` → 中文提示先取消訂單
+
+### 2.3 回歸
+- [ ] 編輯 / 加單 / 結單 / 結算 鈕邏輯與顯示條件不變
+- [ ] 批次開團/結單/取消、月曆 / 週視圖不受影響
+
+## 3. 驗證方式
+- RPC：上述 SQL 於 Supabase Studio 實跑（SQL 交使用者執行）
+- UI：`tsc --noEmit` + `next build` 綠；preview 互動由使用者自審

--- a/supabase/migrations/20260618000020_rpc_delete_campaign.sql
+++ b/supabase/migrations/20260618000020_rpc_delete_campaign.sql
@@ -1,0 +1,77 @@
+-- ============================================================
+-- 2026-06-18: rpc_delete_campaign — 開團刪除（草稿限定，實體刪除）
+-- ------------------------------------------------------------
+-- 開團狀態機嚴格單向（draft→open→closed→cancelled）；cancelled 為軟取消終態。
+-- customer_orders / order_waitlist / customer_order_sources /
+-- purchase_request_items 皆以「無 CASCADE」FK 參照開團 → 任何曾有訂單/PR
+-- 的開團實體刪除會被 RESTRICT 擋下。故 **只允許刪除 draft 開團**
+-- （draft 必無 orders / PR / waitlist）；其他狀態請走「批次取消」。
+--
+-- campaign_items / campaign_channels / campaign_audit_log 為 ON DELETE
+-- CASCADE；但 campaign_audit_log 有 trg_no_mut_camp_audit append-only
+-- BEFORE DELETE trigger，cascade 仍會觸發 → 仿 rpc_delete_picking_wave
+-- 暫時 DISABLE 該 trigger 再刪、確保任何路徑都 ENABLE 回去。
+--
+-- 走 SECURITY DEFINER：admin JWT 無 role claim 也可刪；限同 tenant。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_delete_campaign(
+  p_campaign_id BIGINT,
+  p_operator    UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_status TEXT;
+  v_orders INTEGER;
+BEGIN
+  -- p_operator 為呼叫端對齊 close/finalize 簽章而保留；刪除後 row + audit
+  -- 皆不存在、無處可記，故不使用（與 rpc_delete_picking_wave 一致）。
+
+  SELECT status
+    INTO v_status
+    FROM group_buy_campaigns
+   WHERE id = p_campaign_id AND tenant_id = v_tenant
+   FOR UPDATE;
+
+  IF v_status IS NULL THEN
+    RAISE EXCEPTION 'campaign % not found', p_campaign_id;
+  END IF;
+
+  -- 守門 1：只有草稿可刪
+  IF v_status <> 'draft' THEN
+    RAISE EXCEPTION 'campaign % is %, only draft can be deleted', p_campaign_id, v_status;
+  END IF;
+
+  -- 守門 2：防禦 — 草稿理論上無訂單，仍 belt-and-suspenders
+  SELECT COUNT(*) INTO v_orders
+    FROM customer_orders
+   WHERE campaign_id = p_campaign_id AND tenant_id = v_tenant;
+  IF v_orders > 0 THEN
+    RAISE EXCEPTION 'campaign % has % orders, cannot delete', p_campaign_id, v_orders;
+  END IF;
+
+  -- 暫停 campaign_audit_log 的 append-only 保護（cascade 會觸發它）
+  ALTER TABLE campaign_audit_log DISABLE TRIGGER trg_no_mut_camp_audit;
+  BEGIN
+    DELETE FROM campaign_audit_log WHERE campaign_id = p_campaign_id;
+    -- order_waitlist 無 CASCADE，草稿應為 0 筆，仍防禦性清除
+    DELETE FROM order_waitlist
+     WHERE campaign_id = p_campaign_id AND tenant_id = v_tenant;
+    -- 刪開團本體：campaign_items / campaign_channels 由 FK CASCADE 連帶刪除
+    DELETE FROM group_buy_campaigns
+     WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  EXCEPTION WHEN OTHERS THEN
+    ALTER TABLE campaign_audit_log ENABLE TRIGGER trg_no_mut_camp_audit;
+    RAISE;
+  END;
+  ALTER TABLE campaign_audit_log ENABLE TRIGGER trg_no_mut_camp_audit;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_delete_campaign(BIGINT, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_delete_campaign(BIGINT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_delete_campaign(BIGINT, UUID) IS
+  '開團刪除：限 draft 且無訂單；實體刪除（campaign_items/channels/audit 連帶 CASCADE），暫停 audit append-only trigger；同 tenant。';


### PR DESCRIPTION
## Summary
- 新增「刪除開團」功能。開團狀態機**嚴格單向**（draft→open→closed→cancelled），且 `customer_orders` / `order_waitlist` / `customer_order_sources` / `purchase_request_items` 皆以 **無 CASCADE** FK 參照開團 → 任何曾有訂單/PR 的開團實體刪除會被 RESTRICT 擋下。
- 因此**只允許實體刪除 `draft` 開團**（draft 必無 orders / PR / waitlist）；其他狀態請續用「批次取消」（呼應既有單向狀態決策，不做 reopen / 放寬）。
- `campaign_items` / `campaign_channels` / `campaign_audit_log` 由 FK `ON DELETE CASCADE` 連帶刪除；其中 `campaign_audit_log` 有 append-only `trg_no_mut_camp_audit`，cascade 仍會觸發 → 仿既有 `rpc_delete_picking_wave` 暫時 `DISABLE` 該 trigger，任一路徑（含 EXCEPTION）都保證 `ENABLE` 回去。

## 守門
- **僅草稿可刪**：列表/卡片「刪除」鈕只在 `status='draft'` 顯示；`rpc_delete_campaign` 亦 raise `campaign % is %, only draft can be deleted`。
- **訂單防禦**：即使 draft，若 `customer_orders` 有參照仍 raise（belt-and-suspenders）。
- not found / 跨 tenant → raise；錯誤皆經 `translateRpcError` 轉中文。

## 變更
- `supabase/migrations/20260618000020_rpc_delete_campaign.sql` — 新 RPC（SECURITY DEFINER、限同 tenant、FOR UPDATE lock、draft 守門 + 訂單防禦、cascade、append-only trigger 收放）
- `apps/admin/src/app/(protected)/campaigns/page.tsx` — 共用 `campaignActions`（桌機表格 + 手機卡片同步）加「刪除」鈕（僅 draft）+ confirm + `translateRpcError`
- `apps/admin/src/lib/rpcError.ts` — 3 條開團刪除錯誤中文化規則 + `CAMPAIGN_STATUS_ZH`
- `docs/TEST-campaign-delete.md` — 測試項目清單

## 備註
- 月曆 / 週視圖的 `CampaignCard` 動作（編輯/加單）本切片未加刪除（list/卡片視圖已覆蓋草稿管理主路徑）；如需後續再補。
- 與 #278（刪除商品）為**獨立 sibling PR**，皆開在 `main`、互不 stack；兩者皆改 `rpcError.ts` 但插在不同區塊，預期可自動合併。

## Test plan
- [ ] migration SQL 於 Supabase Studio 套用（SQL 交使用者執行）
- [ ] RPC：draft 開團（含 items/channels + 多筆 audit）→ 刪除成功、關聯全 cascade 消失、`trg_no_mut_camp_audit` 已 ENABLE 回去
- [ ] RPC 守門：open/closed/cancelled 等 → raise；draft 但塞 orders → raise；not found / 跨 tenant → raise
- [ ] RPC：失敗（任何 EXCEPTION）後 append-only trigger 仍 enabled
- [ ] UI：僅 draft 列/卡片顯示「刪除」；確認後列表 reload 該開團消失；錯誤顯示中文
- [ ] 回歸：編輯/加單/結單/結算、批次操作、月曆/週視圖不受影響
- `next build` 綠（已驗）；preview 互動由使用者自審

🤖 Generated with [Claude Code](https://claude.com/claude-code)