### PR TITLE
fix(admin/members): 來源會員有訂單則禁止合併，訂單不再搬移

### DIFF
--- a/apps/admin/src/components/MemberMergeModal.tsx
+++ b/apps/admin/src/components/MemberMergeModal.tsx
@@ -4,7 +4,8 @@
 // 兩個方向共用同一支 rpc_merge_member（RPC 守衛：source.line_user_id IS NULL）
 // - direction="guest-to-real":   從未綁 LINE 端開（既有「合併到實體會員」按鈕）
 // - direction="real-from-guest": 從已綁 LINE 端開（新「合併進來」按鈕）
-// rpc_merge_member 會搬：訂單 / 卡片 / 點數 / 儲值 / 標籤 / 暱稱對應 / 流水
+// rpc_merge_member 會搬：卡片 / 點數 / 儲值 / 標籤 / 暱稱對應 / 流水
+//   訂單「不搬」（個別是個別的、留在原會員）；來源有任何訂單則 RPC 擋下不准合併
 
 import { useEffect, useState } from "react";
 import { Modal } from "@/components/Modal";
@@ -149,13 +150,15 @@ export function MemberMergeModal({
               </>
             ) : (
               <>
-                <b>目標（此筆已綁 LINE 的會員，訂單會搬來這）：</b>{anchor.name ?? "—"}
+                <b>目標（此筆已綁 LINE 的會員，資料會併來這）：</b>{anchor.name ?? "—"}
                 <span className="ml-1 font-mono">{anchor.member_no}</span>
                 {anchor.phone && <span className="ml-1 font-mono">{anchor.phone}</span>}
               </>
             )}
             <br />
-            合併後來源會被標為「已合併」，所有訂單 / 儲值 / 點數 / 卡片 / 標籤都會搬到目標，不可還原。
+            合併後來源會被標為「已合併」，儲值 / 點數 / 卡片 / 標籤 / 暱稱對應都會搬到目標，不可還原。
+            <br />
+            <b>訂單不會搬移</b>（個別是個別的、仍掛在原會員）；若來源有任何訂單則無法合併，請先處理該會員的訂單。
           </div>
         </div>
 

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -197,6 +197,20 @@ const RULES: Rule[] = [
     pattern: /campaign \d+ not found/i,
     render: () => "找不到此開團（可能已被刪除）。",
   },
+  // ===== rpc_merge_member（會員合併守門） =====
+  {
+    pattern: /source member \d+ has orders, cannot merge/i,
+    render: () =>
+      "來源會員仍有訂單，無法合併。訂單個別獨立、不會搬移；請先處理（取消／轉移）來源會員的訂單後再合併。",
+  },
+  {
+    pattern: /source member \d+ is already bound to LINE/i,
+    render: () => "來源會員已綁定 LINE，請改以「未綁 LINE 的那筆」為來源。",
+  },
+  {
+    pattern: /source member \d+ is already merged/i,
+    render: () => "來源會員已經合併過了。",
+  },
   // ===== rpc_register_damage =====
   {
     pattern: /damage_qty must be > 0/i,

--- a/docs/TEST-member-merge-block-if-orders.md
+++ b/docs/TEST-member-merge-block-if-orders.md
@@ -1,0 +1,52 @@
+# 測試項目 — 會員合併：來源有訂單則禁止合併
+
+**對應 migration:** `supabase/migrations/20260618000030_rpc_merge_member_block_if_guest_has_orders.sql`
+**對應 UI:** `apps/admin/src/components/MemberMergeModal.tsx`、`apps/admin/src/lib/rpcError.ts`
+
+> 決策（使用者 2026-05-18）：合併只在「來源(未綁 LINE / 虛擬)會員身上**沒有任何 `customer_orders`**」時才允許。
+> 訂單**個別是個別的、永遠不搬移**（移除原本 `UPDATE customer_orders SET member_id`）。
+> 儲值金 / 點數 / 卡片 / 標籤 / 暱稱對應 / 流水等「其他」資料**照舊** merge 搬到正式會員。
+
+## 1. RPC 層（`rpc_merge_member`）
+
+### 1.1 守門：來源有訂單 → 擋
+- [ ] 來源會員有 ≥1 筆 `customer_orders`（任何狀態，含 cancelled）→ 呼叫 RAISE `source member % has orders, cannot merge`
+- [ ] 擋下時**完全無副作用**：來源仍 `status<>'merged'`、`member_cards`/`points_ledger`/`wallet_ledger`/`member_tags`/`customer_line_aliases` 都沒被改、無 `member_merges` 新列、餘額未動
+
+### 1.2 正常流程：來源無訂單 → 合併（訂單以外照搬）
+- [ ] 來源會員 0 筆 `customer_orders` → 合併成功不報錯
+- [ ] `customer_line_aliases` / `member_tags` / `member_cards` / `points_ledger` / `wallet_ledger` 的 member_id 由來源改為目標
+- [ ] 點數 / 儲值金餘額併入目標（UPSERT 相加），來源餘額列刪除
+- [ ] 來源 `status='merged'`、`merged_into_member_id=目標`，寫一筆 `member_merges`
+- [ ] **`customer_orders` 完全不被觸碰**（本來就 0 筆；確認函式內已無 `UPDATE customer_orders`）
+
+### 1.3 既有守門不回歸
+- [ ] 來源已綁 LINE（line_user_id 不為 null）→ RAISE already bound
+- [ ] 來源已 merged → RAISE already merged
+- [ ] guest_id = real_id → RAISE must differ
+- [ ] 來源不存在 → RAISE not found
+- [ ] 跨 tenant：守門查 `customer_orders` 帶 `tenant_id=v_tenant`，不會誤判別 tenant 的訂單
+
+### 1.4 驗證 SQL（Supabase Studio，auto 模式無法 push、SQL 交使用者跑）
+```sql
+-- 函式已無搬訂單那行
+SELECT pg_get_functiondef('rpc_merge_member(bigint,bigint,uuid,text)'::regprocedure)
+  NOT LIKE '%UPDATE customer_orders%SET member_id%' AS orders_move_removed;  -- 期望 true
+-- 守門：建一個有訂單的 guest，呼叫應 raise
+-- 正常：建一個無訂單的 guest，呼叫應成功且 customer_orders 不變
+```
+
+## 2. UI 層（MemberMergeModal）
+
+- [ ] 兩個方向（guest-to-real / real-from-guest）合併彈窗文案：**不再**出現「訂單會搬」；改為「訂單不會搬移、有訂單則無法合併」
+- [ ] 來源有訂單時按「合併」→ 紅框錯誤顯示中文「來源會員仍有訂單，無法合併。訂單個別獨立、不會搬移；請先處理…」（經 `translateRpcError`，非 raw 英文 / 非 `[object Object]`）
+- [ ] 來源無訂單 → 合併成功 alert + `onMerged()` 刷新
+- [ ] 既有錯誤（已綁 LINE / 已合併）也都有中文
+
+## 3. 回歸
+- [ ] 會員列表 / MemberDetail「已合併 → #x」標記、guest 標記顯示不變
+- [ ] 既有「已 merged」歷史資料不受影響（本 migration 只改函式、不回填）
+
+## 驗證方式
+- RPC：上述 SQL 於 Supabase Studio 實跑
+- UI：`next build` 綠；preview 互動由使用者自審（沙箱阻擋 admin 登入）

--- a/supabase/migrations/20260618000030_rpc_merge_member_block_if_guest_has_orders.sql
+++ b/supabase/migrations/20260618000030_rpc_merge_member_block_if_guest_has_orders.sql
@@ -1,0 +1,122 @@
+-- ============================================================================
+-- 2026-05-18: rpc_merge_member — 來源(虛擬/未綁 LINE)會員有訂單則禁止合併
+-- ----------------------------------------------------------------------------
+-- 決策（使用者 2026-05-18）：合併只在「來源會員身上沒有任何 customer_orders」
+-- 時才允許。訂單個別是個別的、永遠不搬移（避免搬 member_id 撞同團同頻道
+-- 唯一索引、避免破壞訂單歷史）。儲值金 / 點數 / 卡片 / 標籤 / 暱稱對應 /
+-- 流水等「其他」資料照舊 merge 搬到正式會員。
+--
+-- 變更（相對 20260507130000）：
+--   1. 新增守門：guest 有任何 customer_orders → RAISE，整個合併中止。
+--   2. 移除原本的 `UPDATE customer_orders SET member_id = p_real_id ...`
+--      （守門後此句必為 0 列、且與「訂單不搬」原則矛盾）。
+--   其餘邏輯逐字保留。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION rpc_merge_member(
+  p_guest_id BIGINT,
+  p_real_id  BIGINT,
+  p_operator UUID DEFAULT NULL,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant      UUID;
+  v_operator    UUID;
+  v_points      NUMERIC(18,2) := 0;
+  v_wallet      NUMERIC(18,2) := 0;
+  v_cards       INTEGER       := 0;
+  v_src_line    TEXT;
+  v_src_status  TEXT;
+BEGIN
+  v_operator := COALESCE(p_operator, auth.uid(), '00000000-0000-0000-0000-000000000000'::uuid);
+
+  SELECT tenant_id, line_user_id, status
+    INTO v_tenant, v_src_line, v_src_status
+    FROM members WHERE id = p_guest_id;
+
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'source member % not found', p_guest_id;
+  END IF;
+
+  IF v_src_line IS NOT NULL THEN
+    RAISE EXCEPTION 'source member % is already bound to LINE — pick the unbound one as source', p_guest_id;
+  END IF;
+
+  IF v_src_status = 'merged' THEN
+    RAISE EXCEPTION 'source member % is already merged', p_guest_id;
+  END IF;
+
+  IF p_guest_id = p_real_id THEN
+    RAISE EXCEPTION 'source and target must differ';
+  END IF;
+
+  -- 守門：來源會員有任何訂單就禁止合併（訂單個別是個別的、不搬移）
+  PERFORM 1 FROM customer_orders
+    WHERE member_id = p_guest_id AND tenant_id = v_tenant
+    LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'source member % has orders, cannot merge', p_guest_id;
+  END IF;
+
+  -- 訂單不搬移（刻意：留在原會員）；以下「其他」資料照舊 merge
+  UPDATE customer_line_aliases  SET member_id = p_real_id WHERE member_id = p_guest_id;
+  UPDATE member_tags            SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  SELECT COUNT(*) INTO v_cards FROM member_cards WHERE member_id = p_guest_id;
+  v_cards := COALESCE(v_cards, 0);
+  UPDATE member_cards SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  SELECT COALESCE(balance, 0) INTO v_points
+    FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  v_points := COALESCE(v_points, 0);
+
+  SELECT COALESCE(balance, 0) INTO v_wallet
+    FROM wallet_balances       WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  v_wallet := COALESCE(v_wallet, 0);
+
+  UPDATE points_ledger  SET member_id = p_real_id WHERE member_id = p_guest_id;
+  UPDATE wallet_ledger  SET member_id = p_real_id WHERE member_id = p_guest_id;
+
+  IF v_points > 0 THEN
+    INSERT INTO member_points_balance (tenant_id, member_id, balance, version, updated_at)
+    VALUES (v_tenant, p_real_id, v_points, 1, NOW())
+    ON CONFLICT (tenant_id, member_id) DO UPDATE
+      SET balance          = member_points_balance.balance + EXCLUDED.balance,
+          version          = member_points_balance.version + 1,
+          last_movement_at = NOW(),
+          updated_at       = NOW();
+  END IF;
+
+  IF v_wallet > 0 THEN
+    INSERT INTO wallet_balances (tenant_id, member_id, balance, version, updated_at)
+    VALUES (v_tenant, p_real_id, v_wallet, 1, NOW())
+    ON CONFLICT (tenant_id, member_id) DO UPDATE
+      SET balance          = wallet_balances.balance + EXCLUDED.balance,
+          version          = wallet_balances.version + 1,
+          last_movement_at = NOW(),
+          updated_at       = NOW();
+  END IF;
+
+  DELETE FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  DELETE FROM wallet_balances        WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+
+  UPDATE members
+     SET status                = 'merged',
+         merged_into_member_id = p_real_id,
+         updated_at            = NOW(),
+         updated_by            = v_operator
+   WHERE id = p_guest_id;
+
+  INSERT INTO member_merges (
+    tenant_id, primary_member_id, merged_member_id,
+    points_moved, wallet_moved, cards_moved, reason, operator_id
+  ) VALUES (
+    v_tenant, p_real_id, p_guest_id,
+    v_points, v_wallet, v_cards, p_reason, v_operator
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION rpc_merge_member(BIGINT, BIGINT, UUID, TEXT) IS
+  '會員合併：來源(未綁 LINE)有任何 customer_orders 即禁止；訂單不搬（個別是個別的），其餘卡片/點數/儲值/標籤/暱稱/流水照搬至正式會員。';


### PR DESCRIPTION
## 背景
原 `rpc_merge_member` 會 `UPDATE customer_orders SET member_id = 正式會員 WHERE member_id = 來源`，把虛擬/未綁 LINE 會員的訂單搬到正式會員。這帶來兩個風險：同團同頻道唯一索引撞單（整個合併 raw duplicate key 回滾）、以及訂單歷史被動到。

## 決策（使用者 2026-05-18）
- 合併**只在「來源(未綁 LINE)會員身上沒有任何 `customer_orders`」時才允許**。
- 訂單**個別是個別的、永遠不搬移**。
- 儲值金 / 點數 / 卡片 / 標籤 / 暱稱對應 / 流水等「其他」資料**照舊** merge 搬到正式會員（行為不變）。

## 變更
- `supabase/migrations/20260618000030_rpc_merge_member_block_if_guest_has_orders.sql`
  - 新增守門：`guest` 有任何 `customer_orders`（同 tenant、任何狀態）→ `RAISE 'source member % has orders, cannot merge'`，整個合併中止、零副作用。
  - **移除**原本的 `UPDATE customer_orders SET member_id=...`（守門後必為 0 列，且與「訂單不搬」原則矛盾）。
  - 其餘邏輯逐字保留（基底 = 最新 `20260507130000`）。
- `apps/admin/src/lib/rpcError.ts` — 來源有訂單 / 已綁 LINE / 已合併 三條中文化規則。
- `apps/admin/src/components/MemberMergeModal.tsx` — 修正 3 處「訂單會搬」文案：改為「訂單不搬移、有訂單則無法合併」。
- `docs/TEST-member-merge-block-if-orders.md` — 測試項目。

## 已知不在本 PR 範圍
- `order_waitlist`（候補）member_id 合併時仍未搬移（既有獨立缺口；使用者本次明確只針對「訂單」，未要求一併處理）。可另案再決定。

## Test plan
- [ ] migration SQL 於 Supabase Studio 套用（auto 模式無法 push，SQL 交使用者執行）
- [ ] 來源有訂單 → RAISE、零副作用（status/cards/ledger/tags/aliases/餘額/member_merges 皆不變）
- [ ] 來源無訂單 → 合併成功；卡片/點數/儲值/標籤/暱稱/流水搬移；`customer_orders` 完全不被觸碰
- [ ] 既有守門（已綁 LINE / 已 merged / 同 id / not found / 跨 tenant）不回歸
- [ ] UI：兩方向彈窗文案不再說「訂單會搬」；來源有訂單時顯示中文錯誤
- `next build` 綠（已驗）；preview 互動由使用者自審（沙箱阻擋 admin 登入）

🤖 Generated with [Claude Code](https://claude.com/claude-code)