### PR TITLE
fix(admin): 寬表可水平捲動 + 樞紐表前兩欄/表頭凍結

### DIFF
--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -375,7 +375,8 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
         </div>
       )}
 
-      <main className="flex flex-1 flex-col">{children}</main>
+      {/* min-w-0：允許 main 在 flex row 內收縮，寬表才會在自己的 overflow-x-auto 容器內出現水平捲軸，而非把整頁撐爆 */}
+      <main className="flex min-w-0 flex-1 flex-col">{children}</main>
     </div>
   );
 }

--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -789,10 +789,10 @@ function PivotContent() {
           <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
             <thead className="bg-zinc-50 dark:bg-zinc-900">
               <tr>
-                <th className="w-44 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">
+                <th className="sticky left-0 z-20 w-44 bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
                   {viewBy === "campaign" ? "開團" : "日期"}
                 </th>
-                <th className="min-w-[180px] px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">
+                <th className="sticky left-44 z-20 min-w-[180px] bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
                   商品品項
                 </th>
                 {pivot.storeIds.map((sid) => (
@@ -836,7 +836,7 @@ function PivotContent() {
                               : ""
                           }
                         >
-                          <td className="w-44 px-3 py-1.5 align-top text-xs text-zinc-700 dark:text-zinc-300">
+                          <td className="sticky left-0 z-10 w-44 bg-white px-3 py-1.5 align-top text-xs text-zinc-700 dark:bg-zinc-950 dark:text-zinc-300">
                             {i === 0 ? (
                               <div>
                                 <div className="font-medium">{group.label}</div>
@@ -850,7 +850,7 @@ function PivotContent() {
                               ""
                             )}
                           </td>
-                          <td className="min-w-[180px] px-3 py-1.5">{entry.name}</td>
+                          <td className="sticky left-44 z-10 min-w-[180px] bg-white px-3 py-1.5 dark:bg-zinc-950">{entry.name}</td>
                           {pivot.storeIds.map((sid) => {
                             const cell = entry.perStore.get(sid);
                             const v = cellValue(cell);
@@ -886,8 +886,8 @@ function PivotContent() {
                     })}
                     {viewBy !== "campaign" && (
                       <tr className="bg-zinc-50 font-semibold dark:bg-zinc-900">
-                        <td className="w-44 px-3 py-1.5 text-xs text-zinc-500">小計</td>
-                        <td className="px-3 py-1.5 text-xs text-zinc-500">{group.label}</td>
+                        <td className="sticky left-0 z-10 w-44 bg-zinc-50 px-3 py-1.5 text-xs text-zinc-500 dark:bg-zinc-900">小計</td>
+                        <td className="sticky left-44 z-10 bg-zinc-50 px-3 py-1.5 text-xs text-zinc-500 dark:bg-zinc-900">{group.label}</td>
                         {pivot.storeIds.map((sid) => {
                           const v = groupTotalsPerStore.get(sid) ?? 0;
                           return (
@@ -906,7 +906,7 @@ function PivotContent() {
                 );
               })}
               <tr className="border-t-4 border-zinc-900 bg-zinc-100 font-bold dark:border-zinc-100 dark:bg-zinc-800">
-                <td className="px-3 py-2" colSpan={2}>
+                <td className="sticky left-0 z-10 bg-zinc-100 px-3 py-2 dark:bg-zinc-800" colSpan={2}>
                   總計
                 </td>
                 {pivot.storeIds.map((sid) => (

--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -780,7 +780,7 @@ function PivotContent() {
         </div>
       </div>
 
-      <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="max-h-[70vh] overflow-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
         {loading && pivot.groups.length === 0 ? (
           <p className="p-6 text-center text-sm text-zinc-500">載入中…</p>
         ) : pivot.groups.length === 0 ? (
@@ -789,22 +789,22 @@ function PivotContent() {
           <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
             <thead className="bg-zinc-50 dark:bg-zinc-900">
               <tr>
-                <th className="sticky left-0 z-20 w-44 bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
+                <th className="sticky left-0 top-0 z-30 w-44 bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
                   {viewBy === "campaign" ? "開團" : "日期"}
                 </th>
-                <th className="sticky left-44 z-20 min-w-[180px] bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
+                <th className="sticky left-44 top-0 z-30 min-w-[180px] bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
                   商品品項
                 </th>
                 {pivot.storeIds.map((sid) => (
                   <th
                     key={sid}
-                    className="min-w-[80px] px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500"
+                    className="sticky top-0 z-20 min-w-[80px] bg-zinc-50 px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900"
                     title={storeMap.get(sid)?.code ?? ""}
                   >
                     {storeMap.get(sid)?.name ?? `店#${sid}`}
                   </th>
                 ))}
-                <th className="px-3 py-2 text-right text-xs font-bold uppercase tracking-wide text-zinc-700 dark:text-zinc-300">
+                <th className="sticky top-0 z-20 bg-zinc-50 px-3 py-2 text-right text-xs font-bold uppercase tracking-wide text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
                   合計
                 </th>
               </tr>


### PR DESCRIPTION
訂單樞紐表（`/orders/pivot`）橫向捲動 UX 一次到位（使用者要求逐項加上、同一 PR）：

## 1. 寬表不再撐爆整頁（`(protected)/layout.tsx`）
`<main className="flex flex-1 flex-col">` 是 flex row 子項、預設 `min-width:auto`，寬內容把 `<main>` 撐過視窗、整頁溢出，內部 `overflow` 容器拿不到比內容窄的寬度 → 加 `min-w-0` 讓 main 可收縮；寬表即在自身容器內水平捲動。順帶修正所有同結構寬表頁面。

## 2. 前兩欄凍結（`orders/pivot/page.tsx`）
「開團／日期」「商品品項」兩欄 `sticky left`（`w-44`↔`left-44`，Tailwind v4 同 11rem），表頭/資料/小計/總計四種列型皆對位 + 底色遮罩。

## 3. 表頭列凍結 + 有界捲動（`orders/pivot/page.tsx`）
水平 sticky 已使容器 `overflow-y` 計算成 `auto`，window 捲動的 `sticky top` 不會生效 → 表格容器改 `max-h-[70vh] overflow-auto` 成**有界捲動區**，`thead` 各欄 `sticky top-0`；左上兩角同時 `sticky left+top`、`z-30` 最高。捲動任一方向，表頭列與前兩欄都固定。順帶解決長樞紐表內容跑出頁面外的問題。

z 分層：左上角 z-30 > 表頭列 z-20 > 內文凍結欄 z-10 > 一般捲動格。

## 變更
- `apps/admin/src/app/(protected)/layout.tsx` — `<main>` 加 `min-w-0`
- `apps/admin/src/app/(protected)/orders/pivot/page.tsx` — 容器 `max-h-[70vh] overflow-auto`、前兩欄 + 表頭 sticky（4 種列型）

## Test plan
- [ ] `/orders/pivot` 多店：表格區塊內可水平 + 垂直捲動；整頁不爆版、不外溢
- [ ] 垂直捲動：表頭列固定；水平捲動：前兩欄固定；兩者交叉時左上角恆定
- [ ] 表頭 / 小計 / 總計 sticky 底色正確、捲動不透出後方數字
- [ ] 列數少時無多餘捲軸；行動版（filter grid 多行、aside 隱藏）無回歸
- [ ] 其他寬表頁面（調撥、庫存清單等）不再爆版
- `next build` 綠（已驗）；視覺由使用者自審（沙箱無法跑 admin 登入 preview）

🤖 Generated with [Claude Code](https://claude.com/claude-code)