### PR TITLE
fix(admin/orders): 樞紐表 — 表頭不黏、開團欄加寬、水平改箭頭鈕導覽

### DIFF
--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -780,7 +780,7 @@ function PivotContent() {
         </div>
       </div>
 
-      <div className="max-h-[70vh] overflow-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
         {loading && pivot.groups.length === 0 ? (
           <p className="p-6 text-center text-sm text-zinc-500">載入中…</p>
         ) : pivot.groups.length === 0 ? (
@@ -789,22 +789,22 @@ function PivotContent() {
           <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
             <thead className="bg-zinc-50 dark:bg-zinc-900">
               <tr>
-                <th className="sticky left-0 top-0 z-30 w-44 bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
+                <th className="sticky left-0 z-20 w-64 bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
                   {viewBy === "campaign" ? "開團" : "日期"}
                 </th>
-                <th className="sticky left-44 top-0 z-30 min-w-[180px] bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
+                <th className="sticky left-64 z-20 min-w-[180px] bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
                   商品品項
                 </th>
                 {pivot.storeIds.map((sid) => (
                   <th
                     key={sid}
-                    className="sticky top-0 z-20 min-w-[80px] bg-zinc-50 px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900"
+                    className="min-w-[80px] px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500"
                     title={storeMap.get(sid)?.code ?? ""}
                   >
                     {storeMap.get(sid)?.name ?? `店#${sid}`}
                   </th>
                 ))}
-                <th className="sticky top-0 z-20 bg-zinc-50 px-3 py-2 text-right text-xs font-bold uppercase tracking-wide text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+                <th className="px-3 py-2 text-right text-xs font-bold uppercase tracking-wide text-zinc-700 dark:text-zinc-300">
                   合計
                 </th>
               </tr>
@@ -836,7 +836,7 @@ function PivotContent() {
                               : ""
                           }
                         >
-                          <td className="sticky left-0 z-10 w-44 bg-white px-3 py-1.5 align-top text-xs text-zinc-700 dark:bg-zinc-950 dark:text-zinc-300">
+                          <td className="sticky left-0 z-10 w-64 bg-white px-3 py-1.5 align-top text-xs text-zinc-700 dark:bg-zinc-950 dark:text-zinc-300">
                             {i === 0 ? (
                               <div>
                                 <div className="font-medium">{group.label}</div>
@@ -850,7 +850,7 @@ function PivotContent() {
                               ""
                             )}
                           </td>
-                          <td className="sticky left-44 z-10 min-w-[180px] bg-white px-3 py-1.5 dark:bg-zinc-950">{entry.name}</td>
+                          <td className="sticky left-64 z-10 min-w-[180px] bg-white px-3 py-1.5 dark:bg-zinc-950">{entry.name}</td>
                           {pivot.storeIds.map((sid) => {
                             const cell = entry.perStore.get(sid);
                             const v = cellValue(cell);
@@ -886,8 +886,8 @@ function PivotContent() {
                     })}
                     {viewBy !== "campaign" && (
                       <tr className="bg-zinc-50 font-semibold dark:bg-zinc-900">
-                        <td className="sticky left-0 z-10 w-44 bg-zinc-50 px-3 py-1.5 text-xs text-zinc-500 dark:bg-zinc-900">小計</td>
-                        <td className="sticky left-44 z-10 bg-zinc-50 px-3 py-1.5 text-xs text-zinc-500 dark:bg-zinc-900">{group.label}</td>
+                        <td className="sticky left-0 z-10 w-64 bg-zinc-50 px-3 py-1.5 text-xs text-zinc-500 dark:bg-zinc-900">小計</td>
+                        <td className="sticky left-64 z-10 bg-zinc-50 px-3 py-1.5 text-xs text-zinc-500 dark:bg-zinc-900">{group.label}</td>
                         {pivot.storeIds.map((sid) => {
                           const v = groupTotalsPerStore.get(sid) ?? 0;
                           return (

--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Fragment, Suspense, useEffect, useMemo, useState } from "react";
+import { Fragment, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
@@ -161,6 +161,16 @@ function PivotContent() {
   } | null>(null);
   const [detailId, setDetailId] = useState<number | null>(null);
   const [detailNo, setDetailNo] = useState<string>("");
+
+  // 水平導覽：用 header 旁的箭頭鈕捲動（捲軸已隱藏）
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollL, setCanScrollL] = useState(false);
+  const [canScrollR, setCanScrollR] = useState(false);
+  function scrollX(dir: 1 | -1) {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollBy({ left: dir * Math.max(240, el.clientWidth * 0.8), behavior: "smooth" });
+  }
 
   // 從 localStorage 載入 filter (URL params 優先級高於 LS)
   useEffect(() => {
@@ -456,6 +466,23 @@ function PivotContent() {
     });
     return { groups: groupArr, storeIds };
   }, [items, orderMap, campaignMap, storeMap, viewBy, dateFrom, dateTo]);
+
+  // 追蹤可否再往左/右捲（決定箭頭鈕 disabled）
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const update = () => {
+      setCanScrollL(el.scrollLeft > 1);
+      setCanScrollR(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+    };
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+    return () => {
+      el.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, [pivot]);
 
   // metric 取值 helper
   // 訂單數淨值＝有效訂單數 − 取消/逾期/轉出 訂單數
@@ -778,9 +805,34 @@ function PivotContent() {
             訂單金額
           </SpinButton>
         </div>
+
+        <div className="ml-auto flex items-center gap-1">
+          <span className="hidden text-xs text-zinc-400 sm:inline">店別欄</span>
+          <SpinButton
+            onClick={() => scrollX(-1)}
+            disabled={!canScrollL}
+            aria-label="往左捲動店別欄"
+            title="往左"
+            className="rounded-md border border-zinc-300 px-2.5 py-1 text-sm hover:bg-zinc-100 disabled:opacity-30 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            ◀
+          </SpinButton>
+          <SpinButton
+            onClick={() => scrollX(1)}
+            disabled={!canScrollR}
+            aria-label="往右捲動店別欄"
+            title="往右"
+            className="rounded-md border border-zinc-300 px-2.5 py-1 text-sm hover:bg-zinc-100 disabled:opacity-30 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            ▶
+          </SpinButton>
+        </div>
       </div>
 
-      <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+      <div
+        ref={scrollRef}
+        className="no-scrollbar overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950"
+      >
         {loading && pivot.groups.length === 0 ? (
           <p className="p-6 text-center text-sm text-zinc-500">載入中…</p>
         ) : pivot.groups.length === 0 ? (

--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -24,3 +24,12 @@ body {
   background: var(--background);
   color: var(--foreground);
 }
+
+/* 隱藏水平捲軸（仍可程式 / 觸控捲動）— 用於以箭頭鈕導覽的寬表 */
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
針對 [#281](https://github.com/lt-foods/new_erp/pull/281) 合併後的使用者回饋，兩輪調整（純 UI、同一未 merge 分支）：

## 第一輪
> 「上面的 header 不用黏了，開團的 column 可以寬一點，水平的也被遮住了」
- 容器 `max-h-[70vh] overflow-auto` → `overflow-x-auto`（移除有界捲動 + `thead sticky top-0`；水平捲軸回正常位置）。
- 開團/日期欄 `w-44` → `w-64`（176→256px）；第二欄 sticky 偏移 `left-44` → `left-64` 對齊。
- 保留左側「開團／商品品項」橫向捲動凍結。

## 第二輪
> 「水平的不用 scrollbar，用一個箭頭在 header 那邊可以往左往右」
- `globals.css` 新增 `.no-scrollbar`（隱藏水平捲軸，仍可程式 / 觸控板捲動）。
- 樞紐表容器套 `.no-scrollbar` + `ref`。
- 「數值：」控制列右側新增 **◀ ▶ 箭頭鈕**：`scrollBy` 平滑捲動（每次約一個可視寬度），依 `scrollLeft / scrollWidth` 在最左 / 最右自動 disable。

## 變更
- `apps/admin/src/app/(protected)/orders/pivot/page.tsx`
- `apps/admin/src/app/globals.css`
- （`(protected)/layout.tsx` 的 `min-w-0` 來自 #281，未動）

## Test plan
- [ ] `/orders/pivot` 多店：**無水平捲軸**；按 ◀ ▶ 平滑左右捲動
- [ ] 捲到最左 ◀ disabled、最右 ▶ disabled；切換篩選/數值後狀態正確
- [ ] 表頭不黏（隨頁面捲走）；開團欄明顯變寬；左側兩欄橫捲仍凍結、第二欄不重疊
- [ ] 觸控板 / Shift+滾輪 仍可水平捲（捲軸只是隱藏）；窄螢幕「店別欄」字樣自動隱藏
- [ ] 其他寬表頁面無回歸
- `next build` 綠（已驗）；視覺由使用者自審（沙箱無法跑 admin 登入 preview）

🤖 Generated with [Claude Code](https://claude.com/claude-code)