### PR TITLE
fix(admin/orders): 取貨店篩選不再鎖分店、可選任一店/全部

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -9,7 +9,7 @@ import { OrderDetail } from "@/components/OrderDetail";
 import OrderReturnCreateModal from "@/components/OrderReturnCreateModal";
 import { translateRpcError } from "@/lib/rpcError";
 import { withBasePath } from "@/lib/basePath";
-import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
+import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 import { ORDER_STATUS_LABEL as STATUS_LABEL, type OrderStatus } from "@/lib/orderStatus";
 import SpinButton from "@/components/SpinButton";
 
@@ -155,14 +155,8 @@ function OrdersListContent() {
 
   useEffect(() => { setPage(1); }, [campaignIds, tab, storeId, keyword]);
 
-  // 分店帳號鎖死到自家店 (不只是預設,連選都不能選別店)
-  const branchStoreId = useUserBranchStoreId(stores);
-  useEffect(() => {
-    if (branchStoreId != null && storeId !== String(branchStoreId)) {
-      setStoreId(String(branchStoreId));
-    }
-  }, [branchStoreId, storeId]);
-  // HQ 帳號維持原本預設(空 = 全部)
+  // 取貨店篩選不鎖分店：所有帳號都可自由選任一店 / 全部
+  // （僅保留軟性預設選中自家店，使用者可自行切換到別店或「全部」）
   useDefaultStoreFromUser(stores, storeId, setStoreId);
 
   useEffect(() => {
@@ -666,18 +660,11 @@ function OrdersListContent() {
             </div>
           )}
         </div>
-        {branchStoreId != null ? (
-          <div className="flex items-center rounded-md border border-zinc-300 bg-zinc-50 px-3 py-2 text-sm text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
-            🏬 {stores.find((s) => Number(s.id) === branchStoreId)?.name ?? "—"}
-            <span className="ml-2 text-xs text-zinc-500">(僅本店)</span>
-          </div>
-        ) : (
-          <select value={storeId} onChange={(e) => setStoreId(e.target.value)}
-            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
-            <option value="">全部取貨店</option>
-            {stores.map((s) => <option key={s.id} value={s.id}>{s.name} ({s.code})</option>)}
-          </select>
-        )}
+        <select value={storeId} onChange={(e) => setStoreId(e.target.value)}
+          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
+          <option value="">全部取貨店</option>
+          {stores.map((s) => <option key={s.id} value={s.id}>{s.name} ({s.code})</option>)}
+        </select>
         <form
           onSubmit={(e) => { e.preventDefault(); setKeyword(kwInput.trim()); }}
           className="flex gap-2"


### PR DESCRIPTION
## 需求
> 把訂單頁面的取貨店下拉選單不要限制只有該店可以看

## 變更（`apps/admin/src/app/(protected)/orders/page.tsx`，純前端）
- 移除分店帳號硬鎖：原本 `useUserBranchStoreId` + 一個 effect 會把 `storeId` 強制重設回自家店、並把下拉換成唯讀「🏬 店名（僅本店）」chip（連選都不能選別店）。
- 現在一律渲染完整 `<select>`：「全部取貨店」+ 各店，所有帳號都能自由切換。
- 保留 `useDefaultStoreFromUser`（軟性預設仍預選自家店，但可自行切到別店或「全部」）。
- 移除已不再使用的 `useUserBranchStoreId` import；無殘留未使用變數。

## 注意（資料層 RLS，未更動）
此 PR 只解前端下拉限制。實際能否看到他店訂單，仍取決於該帳號 JWT 角色的 RLS：
- `owner / admin / hq_manager`（`corders_hq_all`）→ 看得到全部，本 PR 即完整生效。
- 純分店角色（`corders_store_access`，JWT 綁 `store_id`）→ DB 仍只回自家店資料，選別店會是空的。
若你要連這種帳號也能跨店看，那是 RLS policy 變更（資安敏感），需另外明確指示，本 PR 不動。

## Test plan
- [ ] 分店帳號登入訂單頁：取貨店為**可選下拉**（非唯讀 chip），含「全部取貨店」+ 各店
- [ ] 可切到別店 / 全部，不會被自動彈回自家店
- [ ] HQ 帳號行為不變（預設空＝全部，可選）
- [ ] 軟性預設仍預選自家店、但可改；切換後查詢/分頁正常
- [ ] 角色為 HQ 者可實際看到他店訂單；純分店角色受 RLS 限制（預期、已於說明標注）
- `next build` 綠（已驗）；視覺由使用者自審（沙箱無法跑 admin 登入 preview）

🤖 Generated with [Claude Code](https://claude.com/claude-code)