### PR TITLE
fix(admin/orders): 樞紐表移除左欄凍結（不再遮住最左邊的店）

### DIFF
--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -841,10 +841,10 @@ function PivotContent() {
           <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
             <thead className="bg-zinc-50 dark:bg-zinc-900">
               <tr>
-                <th className="sticky left-0 z-20 w-64 bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
+                <th className="w-64 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">
                   {viewBy === "campaign" ? "開團" : "日期"}
                 </th>
-                <th className="sticky left-64 z-20 min-w-[180px] bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
+                <th className="min-w-[180px] px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">
                   商品品項
                 </th>
                 {pivot.storeIds.map((sid) => (
@@ -888,7 +888,7 @@ function PivotContent() {
                               : ""
                           }
                         >
-                          <td className="sticky left-0 z-10 w-64 bg-white px-3 py-1.5 align-top text-xs text-zinc-700 dark:bg-zinc-950 dark:text-zinc-300">
+                          <td className="w-64 px-3 py-1.5 align-top text-xs text-zinc-700 dark:text-zinc-300">
                             {i === 0 ? (
                               <div>
                                 <div className="font-medium">{group.label}</div>
@@ -902,7 +902,7 @@ function PivotContent() {
                               ""
                             )}
                           </td>
-                          <td className="sticky left-64 z-10 min-w-[180px] bg-white px-3 py-1.5 dark:bg-zinc-950">{entry.name}</td>
+                          <td className="min-w-[180px] px-3 py-1.5">{entry.name}</td>
                           {pivot.storeIds.map((sid) => {
                             const cell = entry.perStore.get(sid);
                             const v = cellValue(cell);
@@ -938,8 +938,8 @@ function PivotContent() {
                     })}
                     {viewBy !== "campaign" && (
                       <tr className="bg-zinc-50 font-semibold dark:bg-zinc-900">
-                        <td className="sticky left-0 z-10 w-64 bg-zinc-50 px-3 py-1.5 text-xs text-zinc-500 dark:bg-zinc-900">小計</td>
-                        <td className="sticky left-64 z-10 bg-zinc-50 px-3 py-1.5 text-xs text-zinc-500 dark:bg-zinc-900">{group.label}</td>
+                        <td className="w-64 px-3 py-1.5 text-xs text-zinc-500">小計</td>
+                        <td className="px-3 py-1.5 text-xs text-zinc-500">{group.label}</td>
                         {pivot.storeIds.map((sid) => {
                           const v = groupTotalsPerStore.get(sid) ?? 0;
                           return (
@@ -958,7 +958,7 @@ function PivotContent() {
                 );
               })}
               <tr className="border-t-4 border-zinc-900 bg-zinc-100 font-bold dark:border-zinc-100 dark:bg-zinc-800">
-                <td className="sticky left-0 z-10 bg-zinc-100 px-3 py-2 dark:bg-zinc-800" colSpan={2}>
+                <td className="px-3 py-2" colSpan={2}>
                   總計
                 </td>
                 {pivot.storeIds.map((sid) => (


### PR DESCRIPTION
## 回饋
> 三峽店還是被擋到了，他在最左邊

#282 把開團/商品品項做 sticky-left 凍結後，往右捲動時最左邊的店（如三峽店）會滑進凍結欄底下被蓋住。

## 修法（`orders/pivot/page.tsx`，純 UI）
- 移除全部 sticky-left 凍結（表頭 / 資料 / 小計 / 總計四種列型的 `sticky left-* z-* bg-*`）。
- 整張表純用既有 ◀▶ 箭頭水平捲動、不凍結任何欄；所有店（含最左的三峽店）捲到即完整可見、不再被遮。
- 保留 `w-64` 開團欄寬與 ◀▶ 箭頭導覽、表頭不黏、隱藏捲軸（均來自 #281/#282）。

## Test plan
- [ ] `/orders/pivot` 多店：按 ◀▶ 左右捲，最左邊的店完整顯示、不被任何欄蓋住
- [ ] 表頭不黏、無捲軸；開團欄仍較寬
- [ ] 小計/總計列對齊正常；其他寬表頁面無回歸
- `next build` 綠（已驗）；視覺由使用者自審（沙箱無法跑 admin 登入 preview）

🤖 Generated with [Claude Code](https://claude.com/claude-code)