### PR TITLE
feat(admin/staff): 員工管理頁可直接新增員工

### DIFF
--- a/apps/admin/src/app/(protected)/staff/page.tsx
+++ b/apps/admin/src/app/(protected)/staff/page.tsx
@@ -24,6 +24,7 @@ type StaffRow = {
 type Store = { id: number; code: string; name: string };
 
 type Modal =
+  | { mode: "create" }
   | { mode: "role"; row: StaffRow }
   | { mode: "stores"; row: StaffRow }
   | { mode: "disable"; row: StaffRow }
@@ -81,11 +82,19 @@ export default function StaffPage() {
         <div>
           <h1 className="text-lg font-semibold">員工管理</h1>
           <p className="mt-1 text-xs text-zinc-500">
-            管理員工角色與綁定店家。員工帳號需先由 Supabase Dashboard 建立後才會在此列出。
+            管理員工角色與綁定店家。可直接「新增員工」建立帳號，系統會產生一次性臨時密碼交付給對方。
           </p>
         </div>
-        <div className="text-xs text-zinc-500">
-          目前身份：<RoleChip role={role} />
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-zinc-500">
+            目前身份：<RoleChip role={role} />
+          </span>
+          <SpinButton
+            onClick={() => setModal({ mode: "create" })}
+            className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900"
+          >
+            新增員工
+          </SpinButton>
         </div>
       </header>
 
@@ -187,6 +196,14 @@ export default function StaffPage() {
         </TBody>
       </Table>
 
+      {modal?.mode === "create" && (
+        <CreateStaffModal
+          stores={stores}
+          isOwnerCaller={isOwner}
+          onClose={() => setModal(null)}
+          onSaved={() => { setModal(null); reload(); }}
+        />
+      )}
       {modal?.mode === "role" && (
         <RoleModal
           row={modal.row}
@@ -356,6 +373,159 @@ function DisableModal({
         <div className="flex justify-end gap-2 pt-2">
           <SpinButton onClick={onClose} className="rounded-md border border-zinc-300 px-3 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800">取消</SpinButton>
           <SpinButton onClick={confirm} className="rounded-md bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-700">確認停用</SpinButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function CreateStaffModal({
+  stores, isOwnerCaller, onClose, onSaved,
+}: {
+  stores: Store[]; isOwnerCaller: boolean;
+  onClose: () => void; onSaved: () => void;
+}) {
+  const grantable = ALL_ROLES.filter((r) => {
+    if (r === "disabled") return false;
+    if (!isOwnerCaller && r === "owner") return false;
+    return true;
+  });
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [newRole, setNewRole] = useState<StaffRole>(
+    (grantable.find((r) => r === "store_staff") ?? grantable[0]) as StaffRole,
+  );
+  const [sel, setSel] = useState<Set<string>>(new Set());
+  const [err, setErr] = useState<string | null>(null);
+  const [result, setResult] = useState<{ email: string; temp_password: string } | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  function toggle(name: string) {
+    setSel((s) => {
+      const n = new Set(s);
+      if (n.has(name)) n.delete(name); else n.add(name);
+      return n;
+    });
+  }
+
+  async function save() {
+    setErr(null);
+    const e = email.trim().toLowerCase();
+    if (!e || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e)) { setErr("請輸入有效 Email"); return; }
+    if (!displayName.trim()) { setErr("請輸入顯示名"); return; }
+    const { data, error } = await getSupabase().functions.invoke<{
+      ok?: boolean; error?: string; email?: string; temp_password?: string;
+    }>("staff-create", {
+      body: { email: e, display_name: displayName.trim(), role: newRole, stores: Array.from(sel) },
+    });
+    if (error) {
+      let msg = error.message ?? "建立失敗";
+      try {
+        const ctx = (error as { context?: Response }).context;
+        if (ctx && typeof ctx.json === "function") {
+          const j = await ctx.json();
+          if (j?.error) msg = j.error as string;
+        }
+      } catch { /* 保留原訊息 */ }
+      setErr(msg);
+      return;
+    }
+    if (!data?.ok || !data.temp_password) { setErr(data?.error ?? "建立失敗"); return; }
+    setResult({ email: data.email ?? e, temp_password: data.temp_password });
+  }
+
+  async function copyPw() {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(result.temp_password);
+      setCopied(true);
+    } catch { /* 使用者可手動選取複製 */ }
+  }
+
+  if (result) {
+    return (
+      <Modal open onClose={onSaved} title="員工已建立" maxWidth="max-w-md">
+        <div className="space-y-3 p-5">
+          <p className="text-sm text-zinc-700 dark:text-zinc-300">
+            <b>{result.email}</b> 帳號已建立。請把以下一次性臨時密碼交付給對方，
+            <b className="text-rose-600">只顯示這一次</b>，關閉後無法再查看。
+          </p>
+          <div className="flex items-center gap-2 rounded-md border border-zinc-300 bg-zinc-50 px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800">
+            <code className="flex-1 select-all break-all font-mono text-sm">{result.temp_password}</code>
+            <button
+              type="button"
+              onClick={copyPw}
+              className="shrink-0 rounded border border-zinc-300 px-2 py-1 text-xs hover:bg-white dark:border-zinc-600 dark:hover:bg-zinc-700"
+            >
+              {copied ? "已複製" : "複製"}
+            </button>
+          </div>
+          <p className="text-[11px] text-zinc-500">
+            員工用此 Email + 臨時密碼登入後台；建議首次登入後盡快重設密碼。改完角色/綁店員工需重新登入才會生效。
+          </p>
+          <div className="flex justify-end pt-2">
+            <SpinButton onClick={onSaved} className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900">完成</SpinButton>
+          </div>
+        </div>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal open onClose={onClose} title="新增員工" maxWidth="max-w-md">
+      <div className="space-y-3 p-5">
+        <label className="block text-sm">
+          <span className="text-zinc-600 dark:text-zinc-400">Email</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="staff@example.com"
+            className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="text-zinc-600 dark:text-zinc-400">顯示名</span>
+          <input
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="王小明"
+            className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="text-zinc-600 dark:text-zinc-400">角色</span>
+          <select
+            value={newRole}
+            onChange={(e) => setNewRole(e.target.value as StaffRole)}
+            className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            {grantable.map((r) => <option key={r} value={r}>{roleLabel(r)}</option>)}
+          </select>
+        </label>
+        <div className="text-sm">
+          <span className="text-zinc-600 dark:text-zinc-400">綁定店</span>
+          <label className="mt-1 flex items-center gap-2 rounded-md border border-zinc-200 px-3 py-2 dark:border-zinc-700">
+            <input type="checkbox" checked={sel.has("總倉")} onChange={() => toggle("總倉")} className="h-4 w-4" />
+            <span className="font-medium">總倉</span>
+            <span className="text-[11px] text-zinc-500">（HQ 帳號 — 可看全部）</span>
+          </label>
+          <div className="mt-2 grid max-h-56 grid-cols-2 gap-2 overflow-y-auto">
+            {stores.map((s) => (
+              <label key={s.id} className="flex items-center gap-2 rounded-md border border-zinc-200 px-3 py-2 dark:border-zinc-700">
+                <input type="checkbox" checked={sel.has(s.name)} onChange={() => toggle(s.name)} className="h-4 w-4" />
+                <span>{s.name}</span>
+                <span className="ml-auto text-[10px] text-zinc-400">{s.code}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+        <p className="text-[11px] text-zinc-500">建立後系統會產生一次性臨時密碼（下一步顯示）。</p>
+        {err && <p className="text-xs text-rose-600">{err}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <SpinButton onClick={onClose} className="rounded-md border border-zinc-300 px-3 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800">取消</SpinButton>
+          <SpinButton onClick={save} className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900">建立</SpinButton>
         </div>
       </div>
     </Modal>

--- a/docs/TEST-staff-create.md
+++ b/docs/TEST-staff-create.md
@@ -1,0 +1,100 @@
+# staff-create 測試項目 — 員工管理「新增員工」
+
+**對應 Edge Function:** `supabase/functions/staff-create/index.ts`（新增）
+**對應 UI 變更:** `apps/admin/src/app/(protected)/staff/page.tsx`（新增「新增員工」按鈕 + `CreateStaffModal`）
+**對應 PRD / 決策:** `docs/decisions/2026-04-23-系統立場-混合型.md`；解除 `20260613000150_staff_permissions.sql` 標註的 *v1 不做：邀請新員工*
+**無 SQL migration**：沿用 `auth.users` + `raw_app_meta_data`，service_role 直驗 `stores` 表。
+
+> 說明：建立 staff 必須用 service_role（Auth Admin API），無法做成 client RPC，故無 §1 Schema/§2 SQL-RPC，改為 §1 Edge Function 合約 + §2 Edge Function 行為。
+
+## 1. Edge Function 合約
+
+- [ ] 函式 `staff-create` 已部署；`supabase/config.toml` **無** `[functions.staff-create]` 區塊（沿用 `verify_jwt = true` 預設，與 `admin-notify` 一致）
+- [ ] 只需內建 secret `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`，未新增其他 secret
+- [ ] `OPTIONS` 回 CORS（`_shared/cors.ts`）；非 `POST` 回 405
+- [ ] 缺 `Authorization` header → 401
+- [ ] Request body：`{ email, display_name, role, stores: string[] }`
+- [ ] 成功 response：`{ ok: true, user_id, email, temp_password }`，HTTP 200
+- [ ] service_role key 僅存在於函式端，**不**出現在任何 client bundle / response（除 `temp_password` 外）/ log
+
+## 2. Edge Function 行為
+
+### 2.1 caller 未認證 / 非授權
+**情境：** 無 token、或一般 `store_staff`、或 `app_metadata` 無 `tenant_id` 的帳號呼叫
+**預期：** 分別回 401 / 403；不建立任何 auth user
+
+### 2.2 owner 建立一般員工（happy path）
+**情境：** owner 帶合法 `email`、`display_name`、`role='store_manager'`、`stores=['平鎮店']`
+**預期：** 回 200 + `temp_password`；`auth.users` 新增一筆，`raw_app_meta_data` 含 `tenant_id`(=caller tenant)、`role`、`stores`，`raw_user_meta_data.display_name` 正確，`email_confirmed_at` 非空
+
+### 2.3 admin 建立一般員工
+**情境：** admin（非 owner）建立 `role='hq_accountant'`
+**預期：** 成功，tenant 同 caller
+
+### 2.4 角色升權防護（admin 不可建 owner）
+**情境：** admin caller 帶 `role='owner'`
+**預期：** 403（對齊 `rpc_update_staff_role`「admin cannot grant owner」），不建立帳號
+
+### 2.5 owner 可建 owner
+**情境：** owner caller 帶 `role='owner'`
+**預期：** 成功
+
+### 2.6 非法 role
+**情境：** `role='superuser'`（不在合法集）或 `role='disabled'`（不可用建立方式產生停用帳號）
+**預期：** 400/422，不建立帳號
+
+### 2.7 store 名稱驗證
+**情境一：** `stores=['不存在的店']` → 預期 reject，不建立
+**情境二：** `stores=['總倉']`（magic value）→ 預期允許
+**情境三：** `stores=[]` 或未帶 → 預期允許（空綁定）
+**情境四：** 帶其他 tenant 的 store 名稱 → 預期 reject（tenant 隔離）
+
+### 2.8 Email 重複
+**情境：** `email` 已存在於 `auth.users`
+**預期：** 回 409 + 可讀訊息（如「此 Email 已有帳號」），不覆寫既有帳號
+
+### 2.9 Email 格式 / 必填
+**情境：** 缺 `email`、空 `display_name`、`email` 非 email 格式
+**預期：** 400，不建立帳號
+
+### 2.10 tenant 注入防護
+**情境：** body 夾帶 `tenant_id` 試圖指定其他 tenant
+**預期：** 一律以 caller 的 `app_metadata.tenant_id` 為準（body 的 tenant 被忽略）
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 入口與權限
+- [ ] `/staff` 以 owner/admin 登入：header 出現「新增員工」按鈕
+- [ ] 過時副標題（「需先由 Supabase Dashboard 建立」）已更新為新流程描述
+- [ ] 非 owner/admin 仍被 `router.replace("/")` 導離（沿用既有 `canManage` 防線）
+
+### 3.2 CreateStaffModal 欄位
+- [ ] 點「新增員工」開 modal，欄位齊全：Email、顯示名、角色 select、綁定店（含「總倉」）
+- [ ] 角色 select 不含 `disabled`
+- [ ] caller 為 admin 時角色 select **不含** `owner`；caller 為 owner 時 **含** `owner`（沿用 `RoleModal` grantable 邏輯）
+- [ ] 綁定店 checkbox 沿用 `StoresModal` 樣式（總倉 + stores 兩欄格）
+
+### 3.3 送出 happy path
+- [ ] 填妥 → 送出 → 成功面板顯示一次性臨時密碼，可一鍵複製，文案標明「只顯示一次」
+- [ ] 關閉成功面板 → 清單 reload，新員工出現（email/顯示名/角色/綁定店正確、建立時間為今天）
+- [ ] 用該 Email + 臨時密碼可登入 admin（`last_sign_in_at` 後續會更新）
+
+### 3.4 送出 validation / 錯誤
+- [ ] Email 空 / 顯示名空 → 前端擋或函式回錯，錯誤訊息顯示於 modal
+- [ ] 重複 Email → modal 顯示「此 Email 已有帳號」類訊息，不關閉、不 reload
+- [ ] 送出中 SpinButton 轉圈、無「送出中…」文字（沿用 `feedback_loading_spinner_no_text`）
+
+## 4. Regression
+
+- [ ] `rpc_list_staff` 清單仍正常載入、排序（owner→…→disabled）不變
+- [ ] 既有「改角色」Modal 正常（含 admin 不能改 owner、不能改自己）
+- [ ] 既有「綁店」Modal 正常（`rpc_update_staff_stores` TEXT[]）
+- [ ] 既有「停用 / 啟用」正常
+- [ ] `admin-notify` 等其他 Edge Function 未受影響（共用 `_shared/cors.ts` 未改）
+- [ ] `staff/page.tsx` 其餘排版（DataTable、RoleChip）未跑版；dark mode 正常
+- [ ] admin build / type-check 通過；無 console error
+
+## 5. 驗收門檻
+
+全部 §1–§4 勾完、**無 console error**、**Edge Function 部署成功**、**admin build + type-check 過** 才可標 done。
+（執行階段需 owner/admin session + 已部署函式；sandbox 受限項目由使用者於實機驗證。）

--- a/supabase/functions/staff-create/index.ts
+++ b/supabase/functions/staff-create/index.ts
@@ -1,0 +1,147 @@
+// staff-create — 由 owner/admin 建立新員工 auth 帳號
+//
+// 建立 staff 必須用 service_role（Supabase Auth Admin API），無法做成 client RPC，
+// 故沿用 admin-notify 的骨架：service_role client + getUser(caller token) 驗身份。
+//
+// 規則對齊 rpc_update_staff_role / rpc_update_staff_stores：
+//   - caller 必須 owner/admin 且有 tenant_id
+//   - admin 不可建立 owner（只有 owner 可以）
+//   - 新帳號 tenant_id 強制 = caller tenant（忽略 body 夾帶的 tenant）
+//   - stores 名稱必須屬於該 tenant 或 '總倉' magic value
+//   - 'disabled' 不可作為建立角色（停用走既有「停用」流程）
+//
+// 只需內建 secret SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY，未新增其他 secret。
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.8";
+import { corsHeaders } from "../_shared/cors.ts";
+
+function requireEnv(name: string): string {
+  const v = Deno.env.get(name);
+  if (!v) throw new Error(`missing env ${name}`);
+  return v;
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+// 對齊 public._is_valid_staff_role，但刻意排除 'disabled'
+const VALID_ROLES = [
+  "owner", "admin", "hq_manager", "hq_accountant",
+  "purchaser", "assistant", "store_manager", "store_staff",
+];
+
+const HQ_WAREHOUSE = "總倉";
+
+function genTempPassword(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  const b64 = btoa(s).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+  // 前綴確保含大小寫與符號，滿足常見密碼規則；亂度由 16 bytes 提供
+  return `Lt-${b64}`;
+}
+
+function isEmail(s: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s);
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+
+  try {
+    const authHeader = req.headers.get("authorization");
+    if (!authHeader) return json({ error: "missing authorization" }, 401);
+
+    const sb = createClient(
+      requireEnv("SUPABASE_URL"),
+      requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+      { auth: { persistSession: false } },
+    );
+
+    const token = authHeader.replace(/^Bearer\s+/i, "");
+    const { data: { user: caller }, error: authErr } = await sb.auth.getUser(token);
+    if (authErr || !caller) {
+      return json({ error: "invalid token", detail: authErr?.message }, 401);
+    }
+
+    const callerRole = (caller.app_metadata?.role as string | undefined) ?? "";
+    const tenantId = caller.app_metadata?.tenant_id as string | undefined;
+    if (!tenantId) return json({ error: "caller has no tenant_id" }, 403);
+    if (callerRole !== "owner" && callerRole !== "admin") {
+      return json({ error: "permission denied: requires owner/admin role" }, 403);
+    }
+
+    const body = (await req.json().catch(() => null)) as
+      | { email?: unknown; display_name?: unknown; role?: unknown; stores?: unknown }
+      | null;
+    if (!body) return json({ error: "invalid json body" }, 400);
+
+    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+    const displayName = typeof body.display_name === "string" ? body.display_name.trim() : "";
+    const role = typeof body.role === "string" ? body.role : "";
+    const stores = Array.isArray(body.stores)
+      ? body.stores
+          .filter((x): x is string => typeof x === "string")
+          .map((x) => x.trim())
+          .filter(Boolean)
+      : [];
+
+    if (!email || !isEmail(email)) return json({ error: "invalid email" }, 400);
+    if (!displayName) return json({ error: "display_name required" }, 400);
+    if (!VALID_ROLES.includes(role)) return json({ error: `invalid role: ${role}` }, 422);
+    if (role === "owner" && callerRole !== "owner") {
+      return json({ error: "admin cannot create owner" }, 403);
+    }
+
+    // store 名稱驗證：每個非「總倉」名稱必須存在於 caller tenant 的 stores
+    const nonMagic = stores.filter((n) => n !== HQ_WAREHOUSE);
+    if (nonMagic.length > 0) {
+      const { data: storeRows, error: storeErr } = await sb
+        .from("stores")
+        .select("name")
+        .eq("tenant_id", tenantId)
+        .in("name", nonMagic);
+      if (storeErr) return json({ error: storeErr.message }, 500);
+      const known = new Set((storeRows ?? []).map((r: { name: string }) => r.name));
+      const invalid = nonMagic.filter((n) => !known.has(n));
+      if (invalid.length > 0) {
+        return json({ error: `store not in tenant: ${invalid.join(", ")}` }, 422);
+      }
+    }
+
+    const tempPassword = genTempPassword();
+    const { data: created, error: createErr } = await sb.auth.admin.createUser({
+      email,
+      password: tempPassword,
+      email_confirm: true,
+      user_metadata: { display_name: displayName },
+      app_metadata: { tenant_id: tenantId, role, stores },
+    });
+
+    if (createErr) {
+      const msg = createErr.message ?? String(createErr);
+      const code = (createErr as { code?: string }).code ?? "";
+      if (code === "email_exists" || /already.*regist|already.*exist|duplicate/i.test(msg)) {
+        return json({ error: "此 Email 已有帳號", detail: msg }, 409);
+      }
+      return json({ error: msg }, 400);
+    }
+
+    return json({
+      ok: true,
+      user_id: created.user?.id,
+      email: created.user?.email,
+      temp_password: tempPassword,
+    });
+  } catch (e) {
+    // 不要 log body / 密碼
+    console.error("staff-create error:", e);
+    return json({ error: "internal", detail: String(e) }, 500);
+  }
+});


### PR DESCRIPTION
## Summary
員工管理頁 (`/staff`) 新增「新增員工」功能，**解除** `20260613000150_staff_permissions.sql` 標註的 *v1 不做：邀請新員工（需 Edge Function + service_role）*。

- **新 Edge Function `supabase/functions/staff-create/index.ts`**（沿用 `admin-notify` 骨架）
  - 收 admin session JWT → service_role client `getUser(token)` 驗 caller
  - 規則對齊既有 `rpc_update_staff_role`：caller 必須 `owner/admin` 且有 `tenant_id`；**admin 不可建立 `owner`**；`role` 須合法（排除 `disabled`）；`stores` 名稱須屬該 tenant 或 `總倉`
  - `auth.admin.createUser` 帶 `app_metadata{tenant_id(強制=caller),role,stores}` + `user_metadata{display_name}` + `email_confirm:true`
  - 回一次性臨時密碼；Email 重複回 **409**；不 log 密碼
- **`apps/admin/src/app/(protected)/staff/page.tsx`**：header 加「新增員工」鈕 + `CreateStaffModal`（Email／顯示名／角色 select／綁店 checkbox，沿用 `RoleModal`/`StoresModal` 樣式）；成功後顯示臨時密碼**一次**可複製→reload；修正過時副標題（不再需 Supabase Dashboard 建帳號）
- **無 SQL migration**（沿用 `auth.users`+`raw_app_meta_data`，service_role 直驗 `stores`）

## 設計取捨（可重新指示）
建立機制選 **建立即用 + 一次性臨時密碼回傳**（`email_confirm:true`），不依賴 SMTP、即可登入、對齊內部後台慣例。若改要 **Email 邀請信**（`inviteUserByEmail`，需 Supabase SMTP），把函式那一行換掉即可——說一聲我改。

## ⚠️ 需使用者部署（agent 無法部署 prod）
```bash
supabase functions deploy staff-create
```
僅用內建 `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`，**無新 secret**、無 migration、`config.toml` 不需改（沿用 `verify_jwt=true` 預設，與 admin-notify 一致）。

## 驗證
- `tsc --noEmit`（apps/admin）通過。Edge Function 沙箱無 deno 無法 `deno check`，已對照已部署的 `admin-notify`（相同 imports/helpers/auth pattern）靜態審查。
- 沙箱無法跑 admin 登入 + 未部署函式 → 執行階段驗證見測試清單，由你部署後自驗。

## Test plan
見 `docs/TEST-staff-create.md`（§1 Edge Function 合約、§2 行為含權限/tenant 隔離/admin 不可建 owner/store 驗證/Email 重複、§3 UI、§4 回歸：list/改角色/綁店/停用）。重點：
- [ ] 部署 `staff-create` 後，owner 建一般員工 → 拿到臨時密碼 → 該員工用 Email+密碼可登入後台
- [ ] admin 建 `owner` 被擋（403）；非 owner/admin 無法呼叫
- [ ] 重複 Email 顯示「此 Email 已有帳號」
- [ ] 不存在 / 跨 tenant 的 store 名稱被擋
- [ ] 臨時密碼只顯示一次；既有改角色/綁店/停用不回歸

🤖 Generated with [Claude Code](https://claude.com/claude-code)