### PR TITLE
feat(admin/campaigns): 開團列表頁多選批次設定收單時間

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -117,6 +117,9 @@ export default function CampaignsListPage() {
   // 多選 + 批次操作
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [bulkBusy, setBulkBusy] = useState<"open" | "closed" | "cancelled" | null>(null);
+  const [endAtOpen, setEndAtOpen] = useState(false);
+  const [bulkEndAt, setBulkEndAt] = useState("");
+  const [endAtErr, setEndAtErr] = useState<string | null>(null);
 
   const [view, setView] = useState<View>(() => {
     if (typeof window === "undefined") return "list";
@@ -160,6 +163,32 @@ export default function CampaignsListPage() {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setBulkBusy(null);
+    }
+  }
+
+  async function bulkSetEndAt() {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+    setEndAtErr(null);
+    if (!bulkEndAt) { setEndAtErr("請選擇收單時間"); return; }
+    const iso = new Date(bulkEndAt).toISOString();
+    try {
+      const { data, error: err } = await getSupabase().rpc("rpc_bulk_set_campaign_end_at", {
+        p_ids: ids,
+        p_end_at: iso,
+      });
+      if (err) throw err;
+      const changed = typeof data === "number" ? data : 0;
+      const skipped = ids.length - changed;
+      setSelectedIds(new Set());
+      setEndAtOpen(false);
+      setBulkEndAt("");
+      setReloadTick((t) => t + 1);
+      if (skipped > 0) {
+        console.info(`bulk_set_campaign_end_at: ${changed} updated, ${skipped} skipped`);
+      }
+    } catch (e) {
+      setEndAtErr(e instanceof Error ? e.message : String(e));
     }
   }
 
@@ -599,6 +628,13 @@ export default function CampaignsListPage() {
             {bulkBusy === "cancelled" ? "取消中…" : "批次取消"}
           </SpinButton>
           <SpinButton
+            onClick={() => { setEndAtErr(null); setBulkEndAt(""); setEndAtOpen(true); }}
+            disabled={bulkBusy !== null}
+            className="rounded-md bg-blue-100 px-3 py-1.5 text-sm font-medium text-blue-800 hover:bg-blue-200 disabled:opacity-50 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
+          >
+            批次設定收單時間
+          </SpinButton>
+          <SpinButton
             onClick={() => setSelectedIds(new Set())}
             className="ml-auto text-xs text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200"
           >
@@ -784,6 +820,47 @@ export default function CampaignsListPage() {
             onClose={() => setShowRecurring(false)}
             onCreated={() => { setShowRecurring(false); setReloadTick((t) => t + 1); }}
           />
+        )}
+      </Modal>
+
+      <Modal
+        open={endAtOpen}
+        onClose={() => setEndAtOpen(false)}
+        title="批次設定收單時間"
+        maxWidth="max-w-md"
+      >
+        {endAtOpen && (
+          <div className="space-y-4">
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+              將套用到已選的 <span className="font-semibold">{selectedIds.size}</span> 個開團。
+              僅「草稿 / 開團中」會被更新；已收單（含之後）會自動略過。
+            </p>
+            <label className="block text-sm">
+              <span className="text-zinc-600 dark:text-zinc-400">新收單時間</span>
+              <input
+                type="datetime-local"
+                value={bulkEndAt}
+                onChange={(e) => setBulkEndAt(e.target.value)}
+                className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                aria-label="新收單時間"
+              />
+            </label>
+            {endAtErr && <p className="text-xs text-rose-600">{endAtErr}</p>}
+            <div className="flex justify-end gap-2 pt-2">
+              <SpinButton
+                onClick={() => setEndAtOpen(false)}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              >
+                取消
+              </SpinButton>
+              <SpinButton
+                onClick={bulkSetEndAt}
+                className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900"
+              >
+                確定套用
+              </SpinButton>
+            </div>
+          </div>
         )}
       </Modal>
 

--- a/docs/TEST-campaign-bulk-end-at.md
+++ b/docs/TEST-campaign-bulk-end-at.md
@@ -1,0 +1,90 @@
+# campaign-bulk-end-at 測試項目 — 開團列表頁「批次設定收單時間」
+
+**對應 migration:** `supabase/migrations/20260618000040_rpc_bulk_set_campaign_end_at.sql`
+**對應 UI 變更:** `apps/admin/src/app/(protected)/campaigns/page.tsx`
+**對應決策:** 開團狀態機單向（draft→open→closed→cancelled）— 收單時間僅收單階段可改
+
+> 無新表 / 無 enum / 無 index；僅新增一支 RPC + 沿用既有多選 UI。
+
+## 1. Schema / Migration 層
+
+### 1.1 RPC signature + grants
+- [ ] `rpc_bulk_set_campaign_end_at(p_ids BIGINT[], p_end_at TIMESTAMPTZ) RETURNS INTEGER` 存在、`SECURITY DEFINER`
+  ```sql
+  SELECT proname, prosecdef, pg_get_function_arguments(oid)
+    FROM pg_proc WHERE proname = 'rpc_bulk_set_campaign_end_at';
+  ```
+- [ ] `PUBLIC` 已 REVOKE、`authenticated` 有 EXECUTE
+  ```sql
+  SELECT grantee, privilege_type FROM information_schema.routine_privileges
+   WHERE routine_name = 'rpc_bulk_set_campaign_end_at';
+  ```
+- [ ] `COMMENT` 已設（說明同 tenant / 僅 draft|open / 回傳變更筆數）
+- [ ] Supabase dev push 成功（self-contained：僅依賴 `group_buy_campaigns` + `_current_tenant_id()`）
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 draft / open 正常更新
+**情境：** 同 tenant，2 個 `draft` + 1 個 `open` 開團，傳三者 id + 未來 `p_end_at`
+**預期：** 回傳 `3`；三筆 `end_at` = 傳入值、`updated_by` = caller、`updated_at` 已更新；其餘欄位（name/status/...）不變
+
+### 2.2 非收單階段一律略過
+**情境：** 各放一個 `closed` / `ordered` / `receiving` / `ready` / `completed` / `cancelled` 開團，連同一個 `open` 一起傳
+**預期：** 回傳 `1`（只有 open 被改）；其餘 6 筆 `end_at` / `updated_at` 不變
+
+### 2.3 跨 tenant / 不存在 id 略過
+**情境：** 傳入「他 tenant 的開團 id」+「不存在的 id」+ 本 tenant 1 個 draft
+**預期：** 回傳 `1`；他 tenant 開團完全未被觸碰（end_at / updated_at 不變）
+
+### 2.4 p_end_at = NULL 報錯
+**情境：** `p_end_at => NULL`
+**預期：** `RAISE EXCEPTION`（p_end_at is required）；無任何 UPDATE
+
+### 2.5 空 / NULL p_ids
+**情境：** `p_ids => '{}'` 或 `NULL`
+**預期：** 回傳 `0`，無副作用
+
+### 2.6 回傳筆數 = 實際變更數
+**情境：** 5 個 id，其中 2 個已是同一 `end_at`（值相同）、2 個 draft 改新值、1 個 closed
+**預期：** 回傳為「狀態合法且實際執行 UPDATE」筆數（draft/open 一律算，closed 不算）；以 caller 角度可重跑得一致
+
+### 2.7 anon 不可執行
+**情境：** 以未登入 / anon role 呼叫
+**預期：** 權限被拒（僅 `authenticated`）
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 入口
+- [ ] `/campaigns` 列表視圖勾選 ≥1 筆 → bulk bar 出現「批次設定收單時間」按鈕（藍色）
+- [ ] 未勾任何項目時 bulk bar 不顯示（按鈕不可達）
+- [ ] `bulkBusy`（批次開團/結單/取消進行中）時此按鈕 `disabled`
+
+### 3.2 Modal
+- [ ] 點按鈕 → 開「批次設定收單時間」Modal，顯示已選筆數
+- [ ] 文案說明「僅草稿/開團中會更新，已收單之後自動略過」
+- [ ] `datetime-local` 輸入可選日期時間
+- [ ] 未填時間按「確定套用」→ modal 內顯示「請選擇收單時間」，不送出
+- [ ] 「取消」關閉 modal、不改資料
+- [ ] 確定送出期間按鈕為純 spinner（無「…中」字樣）
+
+### 3.3 送出 happy path
+- [ ] 選 draft/open 多筆 → 設時間 → 確定 → modal 關閉、選取清空、列表 reload
+- [ ] 列表「收單」欄顯示為新時間
+- [ ] 單筆「編輯」開啟確認 end_at 已更新（與 RPC 一致）
+
+### 3.4 部分略過
+- [ ] 混選 draft/open + closed/cancelled → 確定後成功；`console.info` 記錄 `changed / skipped`；closed/cancelled 那幾筆時間未變
+- [ ] RPC 報錯（如 p_end_at NULL 邊界）→ 錯誤訊息顯示在 modal 內、選取不清空
+
+## 4. Regression
+- [ ] 既有「批次開團 / 批次結單 / 批次取消」仍正常（`rpc_bulk_set_campaign_status` 未動）
+- [ ] 全選 / 單選 / 清除選取、選取列高亮、跨分頁選取行為不變
+- [ ] 單筆編輯 `CampaignForm` 的 `end_at`（datetime-local）仍可存、與 list 一致
+- [ ] `rpc_close_campaign` 仍以結單當下 `end_at` 推 PR 連動（closed 後不被批次改動影響）
+- [ ] 月曆 / 未來 7 天視圖、搜尋 / 狀態篩選 / 分頁不受影響
+- [ ] admin build + type-check 通過；無 console error
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**Supabase dev push（或 prod 貼上）成功**、**build + type-check 過** 才可標 done。
+（沙箱無法跑 admin 登入 + 未套用 migration → 執行階段由使用者部署後依此清單自驗。）

--- a/supabase/migrations/20260618000040_rpc_bulk_set_campaign_end_at.sql
+++ b/supabase/migrations/20260618000040_rpc_bulk_set_campaign_end_at.sql
@@ -1,0 +1,59 @@
+-- ============================================================
+-- 2026-06-18: rpc_bulk_set_campaign_end_at
+--   列表頁多選 → 批次設定開團「收單時間」(group_buy_campaigns.end_at)
+--   對齊 rpc_bulk_set_campaign_status 的骨架：
+--     - 同 tenant 限制（_current_tenant_id）
+--     - 僅「還在收單」階段可改：status IN ('draft','open')
+--       一旦 closed/ordered/receiving/ready/completed/cancelled，
+--       end_at 已被結單流程（rpc_close_campaign 以 end_at 當收單日
+--       決定 PR 連動）快照，不可再被批次改動
+--     - 跨 tenant / 不存在 / 狀態不符 一律略過，回傳實際變更筆數
+--   self-contained：僅依賴 group_buy_campaigns + _current_tenant_id()
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.rpc_bulk_set_campaign_end_at(
+  p_ids    BIGINT[],
+  p_end_at TIMESTAMPTZ
+) RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_id     BIGINT;
+  v_cur    TEXT;
+  v_count  INTEGER := 0;
+BEGIN
+  IF p_ids IS NULL OR array_length(p_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+  IF p_end_at IS NULL THEN
+    RAISE EXCEPTION 'p_end_at is required';
+  END IF;
+
+  FOREACH v_id IN ARRAY p_ids LOOP
+    SELECT status INTO v_cur FROM group_buy_campaigns
+      WHERE id = v_id AND tenant_id = v_tenant;
+    IF v_cur IS NULL THEN
+      CONTINUE; -- 跨 tenant / 不存在
+    END IF;
+    -- 只有「草稿 / 開團中」可改收單時間
+    IF v_cur NOT IN ('draft','open') THEN
+      CONTINUE;
+    END IF;
+
+    UPDATE group_buy_campaigns
+       SET end_at     = p_end_at,
+           updated_by = auth.uid(),
+           updated_at = NOW()
+     WHERE id = v_id AND tenant_id = v_tenant;
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_bulk_set_campaign_end_at(BIGINT[], TIMESTAMPTZ) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_bulk_set_campaign_end_at(BIGINT[], TIMESTAMPTZ) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_bulk_set_campaign_end_at(BIGINT[], TIMESTAMPTZ) IS
+  '批次設定開團收單時間 end_at。同 tenant、僅 draft/open 可改（closed 之後 end_at 已被結單快照）。回傳實際變更筆數。';


### PR DESCRIPTION
## Summary
回答「在開團那邊可以勾選多個然後設定收單時間嗎」→ **可以**。開團列表頁的多選 + 批次操作 bar 本來就有（批次開團/結單/取消），這支補上缺的 **「批次設定收單時間」**。

- **新 RPC `rpc_bulk_set_campaign_end_at(p_ids BIGINT[], p_end_at TIMESTAMPTZ) RETURNS INTEGER`**（migration `20260618000040`）— 沿用 `rpc_bulk_set_campaign_status` 同骨架：`SECURITY DEFINER`、同 tenant（`_current_tenant_id`）、`p_end_at` NULL 報錯、跨 tenant/不存在/狀態不符一律略過、回傳實際變更筆數、`REVOKE PUBLIC` + `GRANT authenticated`
- **`apps/admin/.../campaigns/page.tsx`**：沿用既有 `selectedIds`/checkbox/bulk bar，新增「批次設定收單時間」按鈕 → `datetime-local` Modal → `bulkSetEndAt()`；成功清選取 + reload，回報 changed/skipped，錯誤顯示在 modal 內（純 spinner，無「…中」字）
- 無新表 / 無 enum / 無 index；單檔 UI（+77）

## 設計取捨（可重新指示）
**「收單時間」= `group_buy_campaigns.end_at`**（CampaignForm 該欄 `aria-label` 即「收單時間」）。**只有 `draft` / `open` 會被改**；`closed`/`ordered`/`receiving`/`ready`/`completed`/`cancelled` 自動略過 —— 因為 `rpc_close_campaign` 結單當下會把 `end_at` 當收單日快照去推 PR 連動，事後再改會 desync，且開團狀態機是單向的。若你要連已收單也能改，講一聲我放寬。

## ⚠️ 需使用者套用 migration（agent 無法部署 prod）
Supabase Studio → SQL 貼上（self-contained，僅依賴 `group_buy_campaigns` + `_current_tenant_id()`）：
```sql
CREATE OR REPLACE FUNCTION public.rpc_bulk_set_campaign_end_at(
  p_ids    BIGINT[],
  p_end_at TIMESTAMPTZ
) RETURNS INTEGER
LANGUAGE plpgsql SECURITY DEFINER
AS $$
DECLARE
  v_tenant UUID := public._current_tenant_id();
  v_id     BIGINT;
  v_cur    TEXT;
  v_count  INTEGER := 0;
BEGIN
  IF p_ids IS NULL OR array_length(p_ids, 1) IS NULL THEN
    RETURN 0;
  END IF;
  IF p_end_at IS NULL THEN
    RAISE EXCEPTION 'p_end_at is required';
  END IF;

  FOREACH v_id IN ARRAY p_ids LOOP
    SELECT status INTO v_cur FROM group_buy_campaigns
      WHERE id = v_id AND tenant_id = v_tenant;
    IF v_cur IS NULL THEN
      CONTINUE;
    END IF;
    IF v_cur NOT IN ('draft','open') THEN
      CONTINUE;
    END IF;

    UPDATE group_buy_campaigns
       SET end_at     = p_end_at,
           updated_by = auth.uid(),
           updated_at = NOW()
     WHERE id = v_id AND tenant_id = v_tenant;
    v_count := v_count + 1;
  END LOOP;

  RETURN v_count;
END;
$$;

REVOKE ALL ON FUNCTION public.rpc_bulk_set_campaign_end_at(BIGINT[], TIMESTAMPTZ) FROM PUBLIC;
GRANT EXECUTE ON FUNCTION public.rpc_bulk_set_campaign_end_at(BIGINT[], TIMESTAMPTZ) TO authenticated;

COMMENT ON FUNCTION public.rpc_bulk_set_campaign_end_at(BIGINT[], TIMESTAMPTZ) IS
  '批次設定開團收單時間 end_at。同 tenant、僅 draft/open 可改（closed 之後 end_at 已被結單快照）。回傳實際變更筆數。';
```

## 驗證
- `tsc --noEmit`（apps/admin）通過。Migration 為純 SQL，已對照已部署的 `rpc_bulk_set_campaign_status` 靜態審查（相同結構）。
- 沙箱無法跑 admin 登入 + 未套用 migration → 執行階段見測試清單，套用後自驗。

## Test plan
見 `docs/TEST-campaign-bulk-end-at.md`。重點：
- [ ] 套用 migration 後，多選 draft/open → 設時間 → list 收單欄更新；單筆編輯 end_at 一致
- [ ] 混選 closed/cancelled → 那幾筆不變，`console.info` 記 changed/skipped
- [ ] 跨 tenant / 不存在 id 略過；`p_end_at` NULL 報錯；anon 不可執行
- [ ] 既有 批次開團/結單/取消、單筆編輯 end_at 不回歸

🤖 Generated with [Claude Code](https://claude.com/claude-code)