### PR TITLE
fix(staff-create): verify_jwt=false 修「Failed to send a request to the Edge Function」

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -419,3 +419,10 @@ verify_jwt = false
 # liff-session 不需要 Supabase 預設 JWT 驗（我們自己驗 LINE id_token）
 [functions.liff-session]
 verify_jwt = false
+
+# staff-create 由 admin 瀏覽器 functions.invoke 呼叫；函式內自行驗 caller JWT
+# (sb.auth.getUser) + owner/admin + tenant 檢查。Supabase 預設 verify_jwt=true
+# 會在 gateway 擋掉不帶 Authorization 的 CORS preflight(OPTIONS)，導致前端
+# 收到 "Failed to send a request to the Edge Function"。
+[functions.staff-create]
+verify_jwt = false


### PR DESCRIPTION
## 問題
新增員工按「建立」→ `Failed to send a request to the Edge Function`。

這是 supabase-js 的 **`FunctionsFetchError`** — request 根本沒送達函式（不是函式回 4xx/5xx）。

## 根因（#286 帶進來的缺陷）
`staff-create` 由 admin 瀏覽器 `functions.invoke` 呼叫，但 #286 漏了 `supabase/config.toml` 的 entry → 沿用 Supabase 預設 **`verify_jwt = true`**。瀏覽器送 cross-origin POST 前會先發 **CORS preflight `OPTIONS`，而 OPTIONS 不帶 `Authorization`**，於是 Supabase gateway 在進到函式前就把 preflight 401 掉 → 瀏覽器擋下實際請求 → 前端報這個錯。

> 我當初是照 `admin-notify` 寫的（它也沒 config entry），但 `admin-notify` 並非由瀏覽器 invoke，所以從沒踩到。本專案所有「瀏覽器會呼叫、函式內自驗」的 function（`liff-api` / `liff-session` / `line-oauth-*`）都設 `verify_jwt = false`（`liff-api` 註解就寫「Supabase 預設驗會擋」）。

## 修法
`supabase/config.toml` 加：
```toml
[functions.staff-create]
verify_jwt = false
```
**安全性不變**：函式本來就 (a) 處理 `OPTIONS` 回 CORS、(b) `sb.auth.getUser(token)` 驗 caller JWT、(c) owner/admin + tenant 檢查。`verify_jwt=false` 只是把「平台 gateway 預檢」關掉、改由函式自驗 —— 與 `liff-api` 完全同模式。無函式程式碼變更。

## ⚠️ 需使用者操作（agent 無法部署 prod）
`verify_jwt` 在**部署當下**決定，改 config.toml 後一定要**重新部署**：
```bash
supabase functions deploy staff-create
```
或 Supabase Dashboard → Edge Functions → `staff-create` → 關掉 **Verify JWT**。

順帶確認：若先前根本沒部署過 `staff-create`，同樣會出現此錯 —— 請先確定 `supabase functions list` 有它。

## 驗收
- [ ] redeploy 後，owner/admin 在 `/staff` 新增員工 → 不再 `Failed to send a request...`
- [ ] 成功回一次性臨時密碼；該員工可用 Email+密碼登入
- [ ] 缺 Authorization / 非 owner-admin / 重複 Email 仍各自回 401/403/409（函式自驗仍有效）

🤖 Generated with [Claude Code](https://claude.com/claude-code)