### PR TITLE
feat(staff-create): 新增員工可自訂密碼（留空＝一次性臨時密碼）

### DIFF
--- a/apps/admin/src/app/(protected)/staff/page.tsx
+++ b/apps/admin/src/app/(protected)/staff/page.tsx
@@ -395,9 +395,10 @@ function CreateStaffModal({
   const [newRole, setNewRole] = useState<StaffRole>(
     (grantable.find((r) => r === "store_staff") ?? grantable[0]) as StaffRole,
   );
+  const [password, setPassword] = useState("");
   const [sel, setSel] = useState<Set<string>>(new Set());
   const [err, setErr] = useState<string | null>(null);
-  const [result, setResult] = useState<{ email: string; temp_password: string } | null>(null);
+  const [result, setResult] = useState<{ email: string; tempPassword: string | null } | null>(null);
   const [copied, setCopied] = useState(false);
 
   function toggle(name: string) {
@@ -413,10 +414,18 @@ function CreateStaffModal({
     const e = email.trim().toLowerCase();
     if (!e || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e)) { setErr("請輸入有效 Email"); return; }
     if (!displayName.trim()) { setErr("請輸入顯示名"); return; }
+    if (password.length > 0 && password.length < 6) { setErr("密碼至少 6 碼（留空則系統自動產生）"); return; }
     const { data, error } = await getSupabase().functions.invoke<{
       ok?: boolean; error?: string; email?: string; temp_password?: string;
+      password_source?: "admin" | "generated";
     }>("staff-create", {
-      body: { email: e, display_name: displayName.trim(), role: newRole, stores: Array.from(sel) },
+      body: {
+        email: e,
+        display_name: displayName.trim(),
+        role: newRole,
+        stores: Array.from(sel),
+        password,
+      },
     });
     if (error) {
       let msg = error.message ?? "建立失敗";
@@ -430,14 +439,16 @@ function CreateStaffModal({
       setErr(msg);
       return;
     }
-    if (!data?.ok || !data.temp_password) { setErr(data?.error ?? "建立失敗"); return; }
-    setResult({ email: data.email ?? e, temp_password: data.temp_password });
+    if (!data?.ok) { setErr(data?.error ?? "建立失敗"); return; }
+    const adminSet = data.password_source === "admin";
+    if (!adminSet && !data.temp_password) { setErr("建立成功但未取得臨時密碼，請改用重設密碼或重試"); return; }
+    setResult({ email: data.email ?? e, tempPassword: adminSet ? null : (data.temp_password ?? null) });
   }
 
   async function copyPw() {
-    if (!result) return;
+    if (!result?.tempPassword) return;
     try {
-      await navigator.clipboard.writeText(result.temp_password);
+      await navigator.clipboard.writeText(result.tempPassword);
       setCopied(true);
     } catch { /* 使用者可手動選取複製 */ }
   }
@@ -446,22 +457,30 @@ function CreateStaffModal({
     return (
       <Modal open onClose={onSaved} title="員工已建立" maxWidth="max-w-md">
         <div className="space-y-3 p-5">
-          <p className="text-sm text-zinc-700 dark:text-zinc-300">
-            <b>{result.email}</b> 帳號已建立。請把以下一次性臨時密碼交付給對方，
-            <b className="text-rose-600">只顯示這一次</b>，關閉後無法再查看。
-          </p>
-          <div className="flex items-center gap-2 rounded-md border border-zinc-300 bg-zinc-50 px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800">
-            <code className="flex-1 select-all break-all font-mono text-sm">{result.temp_password}</code>
-            <button
-              type="button"
-              onClick={copyPw}
-              className="shrink-0 rounded border border-zinc-300 px-2 py-1 text-xs hover:bg-white dark:border-zinc-600 dark:hover:bg-zinc-700"
-            >
-              {copied ? "已複製" : "複製"}
-            </button>
-          </div>
+          {result.tempPassword ? (
+            <>
+              <p className="text-sm text-zinc-700 dark:text-zinc-300">
+                <b>{result.email}</b> 帳號已建立。請把以下一次性臨時密碼交付給對方，
+                <b className="text-rose-600">只顯示這一次</b>，關閉後無法再查看。
+              </p>
+              <div className="flex items-center gap-2 rounded-md border border-zinc-300 bg-zinc-50 px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800">
+                <code className="flex-1 select-all break-all font-mono text-sm">{result.tempPassword}</code>
+                <button
+                  type="button"
+                  onClick={copyPw}
+                  className="shrink-0 rounded border border-zinc-300 px-2 py-1 text-xs hover:bg-white dark:border-zinc-600 dark:hover:bg-zinc-700"
+                >
+                  {copied ? "已複製" : "複製"}
+                </button>
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-zinc-700 dark:text-zinc-300">
+              <b>{result.email}</b> 帳號已建立。請用<b>你剛剛設定的密碼</b>通知對方登入。
+            </p>
+          )}
           <p className="text-[11px] text-zinc-500">
-            員工用此 Email + 臨時密碼登入後台；建議首次登入後盡快重設密碼。改完角色/綁店員工需重新登入才會生效。
+            員工用此 Email + 密碼登入後台；建議首次登入後盡快重設密碼。改完角色/綁店員工需重新登入才會生效。
           </p>
           <div className="flex justify-end pt-2">
             <SpinButton onClick={onSaved} className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900">完成</SpinButton>
@@ -495,6 +514,18 @@ function CreateStaffModal({
           />
         </label>
         <label className="block text-sm">
+          <span className="text-zinc-600 dark:text-zinc-400">密碼</span>
+          <input
+            type="text"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="留空＝系統自動產生一次性密碼"
+            autoComplete="new-password"
+            className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <span className="mt-1 block text-[11px] text-zinc-500">自訂則至少 6 碼；留空則建立後顯示一次性臨時密碼</span>
+        </label>
+        <label className="block text-sm">
           <span className="text-zinc-600 dark:text-zinc-400">角色</span>
           <select
             value={newRole}
@@ -521,7 +552,7 @@ function CreateStaffModal({
             ))}
           </div>
         </div>
-        <p className="text-[11px] text-zinc-500">建立後系統會產生一次性臨時密碼（下一步顯示）。</p>
+        <p className="text-[11px] text-zinc-500">未填密碼則建立後顯示一次性臨時密碼；有填則用你設定的密碼。</p>
         {err && <p className="text-xs text-rose-600">{err}</p>}
         <div className="flex justify-end gap-2 pt-2">
           <SpinButton onClick={onClose} className="rounded-md border border-zinc-300 px-3 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800">取消</SpinButton>

--- a/docs/TEST-staff-create.md
+++ b/docs/TEST-staff-create.md
@@ -61,6 +61,16 @@
 **情境：** body 夾帶 `tenant_id` 試圖指定其他 tenant
 **預期：** 一律以 caller 的 `app_metadata.tenant_id` 為準（body 的 tenant 被忽略）
 
+### 2.11 自訂密碼（password 選填）
+**情境一：** body 帶 `password='MyPass123'`（≥6 碼）
+**預期：** 成功；回應 `password_source='admin'` 且 **不含** `temp_password`；該帳號可用此密碼登入
+**情境二：** body 不帶 `password` 或 `password=''`
+**預期：** 成功；回應 `password_source='generated'` + `temp_password`（沿用舊行為）
+**情境三：** body 帶 `password='abc'`（<6 碼）
+**預期：** 422「密碼至少 6 碼」，不建立帳號
+**情境四：** `password` 含前後空白（如 `' a b 12 '`）
+**預期：** 不被 trim，原樣作為密碼（長度以原字串計）
+
 ## 3. UI 行為（preview 互動）
 
 ### 3.1 入口與權限
@@ -83,6 +93,13 @@
 - [ ] Email 空 / 顯示名空 → 前端擋或函式回錯，錯誤訊息顯示於 modal
 - [ ] 重複 Email → modal 顯示「此 Email 已有帳號」類訊息，不關閉、不 reload
 - [ ] 送出中 SpinButton 轉圈、無「送出中…」文字（沿用 `feedback_loading_spinner_no_text`）
+
+### 3.5 密碼欄（選填）
+- [ ] modal 有「密碼」欄，placeholder 提示「留空＝系統自動產生」
+- [ ] 留空送出 → 成功面板顯示一次性臨時密碼（可複製、標「只顯示這一次」）
+- [ ] 自訂 ≥6 碼送出 → 成功面板**不顯示密碼**，改顯示「請用你剛剛設定的密碼通知對方」
+- [ ] 自訂 <6 碼 → modal 內顯示「密碼至少 6 碼」，不送出
+- [ ] 自訂密碼建立後，用該 Email + 自訂密碼可登入 admin
 
 ## 4. Regression
 

--- a/supabase/functions/staff-create/index.ts
+++ b/supabase/functions/staff-create/index.ts
@@ -9,6 +9,8 @@
 //   - 新帳號 tenant_id 強制 = caller tenant（忽略 body 夾帶的 tenant）
 //   - stores 名稱必須屬於該 tenant 或 '總倉' magic value
 //   - 'disabled' 不可作為建立角色（停用走既有「停用」流程）
+//   - password 選填：有給就用（≥6 碼，對齊 auth.minimum_password_length），
+//     留空則系統產生一次性臨時密碼。自訂密碼不回傳（對方已知）。
 //
 // 只需內建 secret SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY，未新增其他 secret。
 
@@ -78,7 +80,7 @@ Deno.serve(async (req) => {
     }
 
     const body = (await req.json().catch(() => null)) as
-      | { email?: unknown; display_name?: unknown; role?: unknown; stores?: unknown }
+      | { email?: unknown; display_name?: unknown; role?: unknown; stores?: unknown; password?: unknown }
       | null;
     if (!body) return json({ error: "invalid json body" }, 400);
 
@@ -91,12 +93,17 @@ Deno.serve(async (req) => {
           .map((x) => x.trim())
           .filter(Boolean)
       : [];
+    // 不 trim 密碼（前後空白可能是刻意的）；空字串視為「未提供」→ 自動產生
+    const customPw = typeof body.password === "string" ? body.password : "";
 
     if (!email || !isEmail(email)) return json({ error: "invalid email" }, 400);
     if (!displayName) return json({ error: "display_name required" }, 400);
     if (!VALID_ROLES.includes(role)) return json({ error: `invalid role: ${role}` }, 422);
     if (role === "owner" && callerRole !== "owner") {
       return json({ error: "admin cannot create owner" }, 403);
+    }
+    if (customPw.length > 0 && customPw.length < 6) {
+      return json({ error: "密碼至少 6 碼" }, 422);
     }
 
     // store 名稱驗證：每個非「總倉」名稱必須存在於 caller tenant 的 stores
@@ -115,10 +122,11 @@ Deno.serve(async (req) => {
       }
     }
 
-    const tempPassword = genTempPassword();
+    const pwSource = customPw.length > 0 ? "admin" : "generated";
+    const password = customPw.length > 0 ? customPw : genTempPassword();
     const { data: created, error: createErr } = await sb.auth.admin.createUser({
       email,
-      password: tempPassword,
+      password,
       email_confirm: true,
       user_metadata: { display_name: displayName },
       app_metadata: { tenant_id: tenantId, role, stores },
@@ -137,7 +145,9 @@ Deno.serve(async (req) => {
       ok: true,
       user_id: created.user?.id,
       email: created.user?.email,
-      temp_password: tempPassword,
+      password_source: pwSource,
+      // 自動產生才回傳密碼；admin 自訂的不回傳（對方已知、不必反射 secret）
+      ...(pwSource === "generated" ? { temp_password: password } : {}),
     });
   } catch (e) {
     // 不要 log body / 密碼


### PR DESCRIPTION
## Summary
回應「新增員工密碼我要自己指定」。`staff-create` 加**選填密碼**:有填就用你設定的,留空則沿用原本系統產生的一次性臨時密碼(行為向後相容)。

- **Edge Function `staff-create`**:body 收選填 `password`。有值 → 用它(**≥6 碼**,對齊本專案 `auth.minimum_password_length = 6`,前後空白不 trim);空/未帶 → `genTempPassword()`。回應加 `password_source: "admin" | "generated"`;**自訂密碼不回傳**(你已知道、不必把 secret 反射回來),只有自動產生才回 `temp_password`。
- **CreateStaffModal**:Email/顯示名 之後加「密碼」欄(`type=text` 方便核對與口頭轉達,placeholder「留空＝系統自動產生」,前端 <6 碼擋)。成功畫面分流:
  - 留空 → 顯示一次性臨時密碼(可複製、標「只顯示這一次」)
  - 自訂 → 不顯示密碼,只提示「請用你剛剛設定的密碼通知對方」
- 更新 `docs/TEST-staff-create.md`(§2.11 函式 / §3.5 UI)。

## ⚠️ 依賴 & 部署
1. **此功能仍需 #288 的 `verify_jwt=false`**才連得到函式(本 PR 由 origin/main 開,不含 #288)。請先 merge **[#288](https://github.com/lt-foods/new_erp/pull/288)**(或 Dashboard 關掉 `staff-create` 的 Verify JWT)。
2. 函式有改 → merge 本 PR 後需**重新部署**:`supabase functions deploy staff-create`。
3. 無 migration、無新 secret。

## 驗收
- [ ] 留空密碼建立 → 成功畫面出現一次性臨時密碼,該員工可登入
- [ ] 自訂 ≥6 碼建立 → 成功畫面不顯示密碼;用該 Email + 你設定的密碼可登入
- [ ] 自訂 <6 碼 → modal 內擋「密碼至少 6 碼」
- [ ] 既有 權限/tenant 隔離/admin 不可建 owner/Email 重複 409 不回歸

🤖 Generated with [Claude Code](https://claude.com/claude-code)