### PR TITLE
feat(admin/calendar): 選品週曆卡片拖拉把手放大、手機更易拖拉

### DIFF
--- a/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
+++ b/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
@@ -429,21 +429,40 @@ function SortableCard({
       style={style}
       className="flex flex-col gap-1.5 rounded-md border border-zinc-200 bg-white p-2 text-xs shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
     >
-      <div className="flex items-baseline gap-1.5">
+      <div className="flex items-stretch gap-2">
         <span
           {...attributes}
           {...listeners}
-          className="cursor-grab select-none touch-none font-mono text-[10px] font-semibold text-zinc-400 hover:text-zinc-700 active:cursor-grabbing dark:text-zinc-500 dark:hover:text-zinc-200"
+          role="button"
+          aria-label="拖拉排序或換日"
           title="拖拉排序 / 換日"
+          className="flex w-9 shrink-0 cursor-grab touch-none select-none items-center justify-center rounded-md border border-zinc-200 bg-zinc-50 text-zinc-400 transition hover:border-zinc-300 hover:bg-zinc-100 hover:text-zinc-600 active:cursor-grabbing active:bg-zinc-200 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-500 dark:hover:bg-zinc-700 dark:hover:text-zinc-300 lg:w-5 lg:rounded"
         >
-          ⋮⋮ {suggestedTime(idx)}
+          <svg
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+            className="h-5 w-5 lg:h-3.5 lg:w-3.5"
+          >
+            <circle cx="9" cy="6" r="1.6" />
+            <circle cx="15" cy="6" r="1.6" />
+            <circle cx="9" cy="12" r="1.6" />
+            <circle cx="15" cy="12" r="1.6" />
+            <circle cx="9" cy="18" r="1.6" />
+            <circle cx="15" cy="18" r="1.6" />
+          </svg>
         </span>
-        <Link
-          href={`/community-candidates?highlight=${r.id}`}
-          className="font-medium leading-snug hover:underline"
-        >
-          {r.product_name_hint ?? "（無商品名）"}
-        </Link>
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="font-mono text-[10px] font-semibold text-zinc-400 dark:text-zinc-500">
+            {suggestedTime(idx)}
+          </span>
+          <Link
+            href={`/community-candidates?highlight=${r.id}`}
+            className="font-medium leading-snug hover:underline"
+          >
+            {r.product_name_hint ?? "（無商品名）"}
+          </Link>
+        </div>
       </div>
       <div className="flex flex-wrap gap-1">
         <span


### PR DESCRIPTION
## Summary
- 選品週曆（`/community-candidates/calendar`）卡片的拖拉目標原本只是 `text-[10px]` 的灰色「⋮⋮ 時間」文字，手機上不明顯也不好按。
- 改為獨立的拖拉握把：六點 grip 圖示（沿用 app 既有 inline SVG 慣例）+ 邊框底色，明顯可抓。
- 響應式尺寸：手機 `w-9` 並 `items-stretch` 撐滿整列高度（好按）；桌機 `lg:w-5` 維持 7 欄精簡（對齊本檔既有 `lg` 斷點）。
- 建議時間（`09:00`…）改放商品名旁當資訊標籤，仍顯示但不再是唯一拖拉目標。
- 加 `aria-label`、hover/active 視覺回饋；保留 `touch-none`/`select-none`/`cursor-grab` 與 dnd-kit `{...attributes} {...listeners}` — 拖拉／排序／換日邏輯完全不變。

## Test plan
- [ ] `cd apps/admin && npm install && npm run dev`
- [ ] 開 `/community-candidates/calendar`，視窗縮到手機寬度：握把為明顯的帶框 grip 區塊、易於拖拉
- [ ] 手機上拖拉卡片可同日排序、跨日換日（與改動前一致）
- [ ] 桌機 `lg` 7 欄版面下握把縮小、版面不爆
- [ ] 深色模式握把配色正常
- [ ] 商品名連結、移出按鈕、徽章顯示均不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)