### PR TITLE
feat(admin/candidates): 候選池手機卡片選取放大、加已選狀態，更好勾選

### DIFF
--- a/apps/admin/src/app/(protected)/community-candidates/page.tsx
+++ b/apps/admin/src/app/(protected)/community-candidates/page.tsx
@@ -763,28 +763,41 @@ export default function CommunityCandidatesPage() {
                 ref={(el) => {
                   if (r.id === highlightId) highlightRowRef.current = el;
                 }}
-                className={`rounded-lg border bg-white p-3 dark:bg-zinc-900 ${
+                className={`rounded-lg border p-3 transition ${
                   r.id === highlightId
-                    ? "border-amber-300 ring-2 ring-amber-300 dark:border-amber-700 dark:ring-amber-700"
-                    : "border-zinc-200 dark:border-zinc-800"
+                    ? "border-amber-300 bg-white ring-2 ring-amber-300 dark:border-amber-700 dark:bg-zinc-900 dark:ring-amber-700"
+                    : selected.has(r.id)
+                    ? "border-amber-400 bg-amber-50/60 ring-1 ring-amber-300 dark:border-amber-700 dark:bg-amber-950/20 dark:ring-amber-800"
+                    : "border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
                 }`}
               >
                 <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      checked={selected.has(r.id)}
-                      disabled={!isSelectable(r)}
-                      onChange={() => toggleOne(r.id)}
-                      className="h-4 w-4 cursor-pointer disabled:cursor-not-allowed disabled:opacity-30"
-                    />
+                  {isSelectable(r) ? (
+                    <label className="-m-1.5 flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md p-1.5 active:bg-amber-50 dark:active:bg-amber-950/30">
+                      <input
+                        type="checkbox"
+                        checked={selected.has(r.id)}
+                        onChange={() => toggleOne(r.id)}
+                        className="h-5 w-5 shrink-0 cursor-pointer accent-amber-600"
+                      />
+                      <span className="shrink-0 text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                        {selected.has(r.id) ? "已選取" : "選取"}
+                      </span>
+                      <span
+                        className={`inline-flex shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${ACTION_COLOR[r.owner_action] ?? ACTION_COLOR.none}`}
+                      >
+                        {ACTION_LABEL[r.owner_action] ?? r.owner_action}
+                      </span>
+                    </label>
+                  ) : (
                     <span
                       className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-medium ${ACTION_COLOR[r.owner_action] ?? ACTION_COLOR.none}`}
+                      title="已排程或已採用，不可批次排程"
                     >
                       {ACTION_LABEL[r.owner_action] ?? r.owner_action}
                     </span>
-                  </div>
-                  <span className="text-[11px] text-zinc-400">{fmt(r.created_at)}</span>
+                  )}
+                  <span className="shrink-0 text-[11px] text-zinc-400">{fmt(r.created_at)}</span>
                 </div>
 
                 <div className="mt-2 flex items-baseline gap-1.5">


### PR DESCRIPTION
## Summary
選品候選池（`/community-candidates`）手機卡片版的勾選不好按、選了也看不出來。本 PR 只動手機卡片版（`md:hidden`），桌機表格版不動：

- **大片可點選取區**：可排程的列，整個卡片頭做成 `<label>`（含 20px checkbox + 「選取／已選取」文字 + 狀態徽章），點整片都能切換 — 不再只能戳 16px 的小框。
- **明顯已選狀態**：選取後整張卡片 amber 邊框＋底色＋ring 高亮（沿用批次排程的 amber 主題）。highlight（從週曆跳轉）優先級高於 selected。
- **不可選取更清楚**：已排程／已採用的列不再顯示停用的小勾選框，改為只顯示狀態徽章並附 `title` 說明原因。
- checkbox 加 `accent-amber-600`、`active:` 觸感回饋。批次排程工具列、`toggleOne`/`isSelectable` 邏輯完全不變。

## Test plan
- [ ] `cd apps/admin && npm install && npm run dev`
- [ ] 開 `/community-candidates`，視窗縮到手機寬度（`< md`）
- [ ] 點卡片頭任一處（勾選框／「選取」字／狀態徽章）皆能勾選；卡片變 amber 高亮、文字變「已選取」
- [ ] 選多筆 → 上方批次排日期工具列出現、批次排程正常
- [ ] 已排程／已採用的列只顯示狀態徽章、無勾選框，長按 title 顯示原因
- [ ] 從選品週曆點商品名跳轉帶 `?highlight=` 時，highlight 樣式仍優先且會捲動定位
- [ ] 深色模式選取／高亮配色正常；桌機 `md` 表格版完全不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)