### PR TITLE
fix(admin/datepicker): 手機選日期彈窗改置中、限制寬高不再爆版（桌機不變）

### DIFF
--- a/apps/admin/src/components/DatePicker.tsx
+++ b/apps/admin/src/components/DatePicker.tsx
@@ -65,20 +65,27 @@ export function DatePicker({
         {value || <span className="text-zinc-400">{placeholder}</span>}
       </SpinButton>
       {open && (
-        <div className="absolute left-0 top-full z-50 mt-1 rounded-md border border-zinc-200 bg-white p-2 shadow-lg dark:border-zinc-800 dark:bg-zinc-900">
-          <DayPicker
-            mode="single"
-            selected={selected}
-            onSelect={(d) => {
-              if (d) {
-                onChange(formatLocal(d));
-                setOpen(false);
-              }
-            }}
-            disabled={disabledMatchers.length > 0 ? disabledMatchers : undefined}
-            weekStartsOn={0}
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/20 sm:hidden"
+            aria-hidden="true"
+            onClick={() => setOpen(false)}
           />
-        </div>
+          <div className="fixed left-1/2 top-1/2 z-50 max-h-[85vh] max-w-[calc(100vw-1.5rem)] -translate-x-1/2 -translate-y-1/2 overflow-auto rounded-md border border-zinc-200 bg-white p-2 shadow-lg dark:border-zinc-800 dark:bg-zinc-900 sm:absolute sm:left-0 sm:right-auto sm:top-full sm:mt-1 sm:max-h-none sm:max-w-none sm:translate-x-0 sm:translate-y-0 sm:overflow-visible">
+            <DayPicker
+              mode="single"
+              selected={selected}
+              onSelect={(d) => {
+                if (d) {
+                  onChange(formatLocal(d));
+                  setOpen(false);
+                }
+              }}
+              disabled={disabledMatchers.length > 0 ? disabledMatchers : undefined}
+              weekStartsOn={0}
+            />
+          </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
共用 `DatePicker` 元件的日曆彈窗原本是 `absolute left-0` 且無視窗夾限。當觸發按鈕靠畫面右側時（例如選品候選池手機版的「批次排日期」工具列），日曆會往右溢出整個爆版（見回報截圖）。

- 手機（`< sm`）：彈窗改為 `fixed` 視窗置中、`max-w-[calc(100vw-1.5rem)]` + `max-h-[85vh]` 內部捲動，永不超出畫面；加半透明 backdrop，點 backdrop 即關閉。
- 桌機（`sm+`）：以 `sm:` 變體完整還原為原本 `absolute left-0 top-full mt-1` 下拉，行為與外觀不變。
- 不改任何邏輯（`onSelect` / 關閉 / Escape / 外點關閉皆照舊）。共用元件 → 候選池批次排程、單列「排日期」、其他使用處一併修好。

## Test plan
- [ ] `cd apps/admin && npm install && npm run dev`
- [ ] 手機寬度開 `/community-candidates`，勾選一筆 → 批次工具列「選擇日期」→ 日曆置中、完整可見、不溢出
- [ ] 月曆可正常選日；選後關閉並帶回日期
- [ ] 點 backdrop / 按 Esc / 點日曆外皆能關閉
- [ ] 單列「排日期 → 選擇日期」在手機同樣不爆版
- [ ] 桌機（`≥ sm`）下拉位置／外觀與修改前一致（CampaignForm 等其他使用處一併確認）
- [ ] 深色模式 backdrop 與面板配色正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)