### PR TITLE
fix(member/me): 取貨店改抓 home_store，不再顯示 JWT/OA 店

### DIFF
--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -252,11 +252,13 @@ export default function MePage() {
                     🔔 已啟用通知
                   </span>
                 )}
-                {/* 顯示目前所在門市（JWT store）；home_store_name 是註冊店、LIFF 不更新，
-                    用它會永遠顯示舊店。overview 失敗時才回退 home_store_name。 */}
-                {(overview?.store.name ?? me.home_store_name) && (
+                {/* 取貨店 = members.home_store_id（admin 設、place_member_order 實際取貨依據）。
+                    刻意不用 overview/JWT store：那是「這次從哪個 OA 進來」，跟實際取貨店常不一致，
+                    且 admin 改店後永遠不同步、反而誤導會員。改抓 home_store_name 後，admin 改店、
+                    會員重開 /me（get_me 即時讀）就同步。 */}
+                {me.home_store_name && (
                   <span className="inline-flex items-center gap-1 rounded-full bg-[#7676801f] px-2.5 py-[3px] text-[12px] font-medium text-[var(--secondary-label)]">
-                    📍 {overview?.store.name ?? me.home_store_name}
+                    📍 取貨 {me.home_store_name}
                   </span>
                 )}
               </div>


### PR DESCRIPTION
## 問題
`/me` 的 📍「取貨店」chip 顯示 `overview.store`（= JWT/session 的 store，即會員這次從哪個 LINE OA / LIFF 連結進來的店）。後果：

- admin 改會員取貨店後，app `/me` **永遠不同步**（chip 綁 token、admin 改的是 `members.home_store_id`）。
- 顯示的店 ≠ `place_member_order` 實際取貨店（用 `members.home_store_id`），會員被誤導。

## 變更
- `apps/member/src/app/me/page.tsx`：📍 chip 由 `overview?.store.name ?? me.home_store_name` 改為 `me.home_store_name`（= `members.home_store_id`，admin 設、實際取貨依據），文字加「取貨」前綴避免被當成「目前位置」。
- `overview` 仍用於下方應收／進行中／店家 banner 區，未移除其抓取（無 unused-var）。
- `get_me` 每次開 /me 即時讀 DB、無快取 → admin 改店後會員重開 /me 即同步（不需重登）。

## 不在範圍
結帳頁「您的主要門市（自動配貨）」仍不顯示店名（本次只動 /me）。

## Test plan
- [ ] admin 改某會員取貨店 → 該會員 app 重開 /me → 📍 取貨 顯示新店
- [ ] 會員從 A 店 OA 進入但 home_store=B 店 → /me 顯示 B 店（取貨依據）
- [ ] home_store 為 null 的會員 → chip 不顯示、頁面不崩
- [ ] 下方店家資訊／應收／進行中區（仍用 overview）顯示正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)