### PR TITLE
feat(admin/members): 列表加「已安裝 App 並開啟通知」鈴鐺

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -74,6 +74,9 @@ function MembersListBody() {
   const [stores, setStores] = useState<Store[]>([]);
   useDefaultStoreFromUser(stores, storeId, setStoreId);
   const [balances, setBalances] = useState<Map<number, { unpicked: number; wallet: number; orderCount: number }>>(new Map());
+  // 有 web push 訂閱（=已安裝 PWA + 開啟通知）的 member id；走 SECURITY DEFINER RPC，
+  // 因 push_subscriptions RLS 對 admin（role 非 hq）會靜默回 0 列。
+  const [pushSet, setPushSet] = useState<Set<number>>(new Set());
   const [reloadTick, setReloadTick] = useState(0);
   const [modal, setModal] = useState<
     | { mode: "new" }
@@ -156,12 +159,13 @@ function MembersListBody() {
 
         const ids = (data ?? []).map((r) => r.id);
         if (ids.length) {
-          const [ord, wal] = await Promise.all([
+          const [ord, wal, push] = await Promise.all([
             getSupabase()
               .from("customer_orders")
               .select("id, member_id, status")
               .in("member_id", ids),
             getSupabase().from("wallet_balances").select("member_id, balance").in("member_id", ids),
+            getSupabase().rpc("rpc_members_with_push", { p_member_ids: ids }),
           ]);
           // 訂單數量 不計取消/過期/轉出（視為 void）
           const VOID_STATUSES = new Set<string>(["cancelled", "expired", "transferred_out"]);
@@ -195,9 +199,17 @@ function MembersListBody() {
             const cur = m.get(w.member_id)!;
             cur.wallet = Number(w.balance) || 0;
           }
-          if (!cancelled) setBalances(m);
+          const ps = new Set<number>();
+          for (const row of (push.data ?? []) as { member_id: number }[]) {
+            if (row?.member_id != null) ps.add(Number(row.member_id));
+          }
+          if (!cancelled) {
+            setBalances(m);
+            setPushSet(ps);
+          }
         } else {
           setBalances(new Map());
+          setPushSet(new Set());
         }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
@@ -348,6 +360,15 @@ function MembersListBody() {
                           className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-normal text-amber-700 dark:bg-amber-950 dark:text-amber-300"
                         >
                           樂樂
+                        </span>
+                      )}
+                      {pushSet.has(r.id) && (
+                        <span
+                          title="已安裝 App 並開啟通知"
+                          aria-label="已安裝 App 並開啟通知"
+                          className="text-[12px] leading-none"
+                        >
+                          🔔
                         </span>
                       )}
                     </div>

--- a/docs/TEST-admin-member-push-bell.md
+++ b/docs/TEST-admin-member-push-bell.md
@@ -1,0 +1,94 @@
+# admin-member-push-bell 測試項目 — 後台會員列表顯示「已安裝 App 並開啟通知」鈴鐺
+
+**對應 migration:** `supabase/migrations/20260619000010_rpc_members_with_push.sql`（新增 SECURITY DEFINER RPC）
+**對應 UI 變更:** `apps/admin/src/app/(protected)/members/page.tsx`
+**對應背景:** `supabase/migrations/20260520000000_web_push_subscriptions.sql`（push_subscriptions + RLS：member 自己 / role='hq'）、`20260603000000_push_subs_unique_per_member.sql`（UNIQUE(tenant_id, member_id)）
+
+> 重點：admin JWT role 非 `'hq'` → 直接 `select from push_subscriptions` 會被 RLS 靜默回 0 列（同 reference_admin_jwt_role_null 模式）。故必走 SECURITY DEFINER RPC。鈴鐺語意 = 該 member 有 push_subscriptions（一筆，因 PWA 安裝 + 授權通知 + 訂閱才會產生）。
+
+## 1. Schema / Migration 層
+
+### 1.1 RPC signature
+- [ ] `rpc_members_with_push(p_member_ids BIGINT[])` 存在、回傳 member_id 集合
+  ```sql
+  SELECT proname, prosecdef, pg_get_function_identity_arguments(oid)
+    FROM pg_proc WHERE proname = 'rpc_members_with_push';
+  ```
+- [ ] `prosecdef = true`（SECURITY DEFINER）
+- [ ] 有 `GRANT EXECUTE ... TO authenticated`
+  ```sql
+  SELECT grantee, privilege_type FROM information_schema.routine_privileges
+   WHERE routine_name = 'rpc_members_with_push';
+  ```
+- [ ] tenant 來源固定（JWT / `_current_tenant_id()`），參數不含 tenant，呼叫端無法跨租戶撈
+
+### 1.2 既有結構未動
+- [ ] `push_subscriptions` 表、RLS policy（push_subs_self_all / push_subs_hq_all）、UNIQUE(tenant_id, member_id) 皆未被本 migration 變更
+  ```sql
+  SELECT polname FROM pg_policy WHERE polrelid = 'push_subscriptions'::regclass;
+  ```
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 有訂閱的 member 會被回傳
+**情境：** tenant T 內 member A 有一筆 push_subscriptions；呼叫 `rpc_members_with_push(ARRAY[A])`
+**預期：** 結果含 A
+
+### 2.2 沒訂閱的 member 不回傳
+**情境：** member B 無 push_subscriptions；`rpc_members_with_push(ARRAY[B])`
+**預期：** 結果不含 B（空）
+
+### 2.3 混合輸入只回有訂閱者
+**情境：** `rpc_members_with_push(ARRAY[A,B,C])`，僅 A、C 有訂閱
+**預期：** 結果恰為 {A,C}，無重複（UNIQUE 保證每 member ≤1 列）
+
+### 2.4 空陣列
+**情境：** `rpc_members_with_push(ARRAY[]::bigint[])`
+**預期：** 回空、無錯
+
+### 2.5 不存在的 member id
+**情境：** 傳入從未存在的 id（如 99999999）
+**預期：** 忽略、無錯、不在結果
+
+### 2.6 跨 tenant 不外洩（關鍵）
+**情境：** 以 tenant T 身分呼叫，傳入屬於 tenant T2 且 T2 有訂閱的 member id
+**預期：** 不回傳該 id（RPC 內以呼叫端 tenant 過濾）
+
+### 2.7 admin 角色（role 非 'hq' / 可能 NULL）仍取得正確結果（本功能存在理由）
+**情境：** 以後台 admin 使用者 JWT（role 非 'hq'）呼叫 RPC，對象 member 有訂閱
+**預期：** 正常回傳該 member（SECURITY DEFINER 繞過 push_subscriptions RLS）；對照：同帳號直接 `select from push_subscriptions` 得 0 列
+
+### 2.8 大量 id
+**情境：** 傳入 ~200 個 member id（含部分有訂閱）
+**預期：** 正確回傳子集、無逾時（idx_push_subs_member 命中）
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 列表掛載
+- [ ] `/members` 正常載入、**無 console error**
+- [ ] 既有欄位（編號/姓名/取貨店/手機/訂單數/未取貨金額/儲值/時間）顯示如常
+
+### 3.2 鈴鐺顯示
+- [ ] 已知有訂閱的 member 該列姓名旁出現 🔔，hover/title 為「已安裝 App 並開啟通知」
+- [ ] 無訂閱的 member 該列**無** 🔔
+- [ ] 同列同時為樂樂匯入者：🔔 與「樂樂」badge 並存不重疊、不破版
+
+### 3.3 分頁 / 搜尋 / 排序後仍正確
+- [ ] 翻到第 2 頁：該頁 member 的 🔔 依該頁 id 重新查詢、正確
+- [ ] 搜尋過濾後：結果列的 🔔 對應正確 member
+- [ ] 切換排序：🔔 跟著該 member 列、不串列
+
+### 3.4 失敗降級
+- [ ] RPC 回空 / 失敗時：列表照常渲染（只是無 🔔），不報錯、不白頁
+
+## 4. Regression
+- [ ] 會員列表既有功能：關鍵字搜尋、門市篩選、各欄排序、分頁、顯示已合併/已刪除 toggle 全部不受影響
+- [ ] 訂單數 / 未取貨金額 / 儲值 三個既有批次查詢結果不變（新增的 push 查詢不干擾既有 Promise 群）
+- [ ] 會員明細 modal、編輯、新增 不受影響
+- [ ] member app `/me` #285 那顆鈴鐺與推播訂閱流程 **完全不動**（本功能僅新增後台唯讀 RPC，未碰 rpc_upsert_push_subscription / 寫入路徑）
+- [ ] 其他 SELECT push_subscriptions 的地方（推播發送）行為不變
+
+## 5. 驗收門檻
+
+全部 §1–§4 勾完、**無 console error**、**Supabase dev push 成功**、**build + type-check 過** 才可標 done。
+（沙箱限制：本機 docker / admin live preview 受阻時，§2 改以使用者貼 Supabase Studio 跑、§3 由使用者自審；agent 負責 tsc/build + 碼審 + 產驗證 SQL。）

--- a/supabase/migrations/20260619000010_rpc_members_with_push.sql
+++ b/supabase/migrations/20260619000010_rpc_members_with_push.sql
@@ -1,0 +1,30 @@
+-- ============================================================================
+-- 2026-05-19: rpc_members_with_push — 後台會員列表「已安裝 App 並開啟通知」鈴鐺
+-- ----------------------------------------------------------------------------
+-- push_subscriptions RLS 只允許 member 自己 / role='hq'；後台 admin JWT role
+-- 非 'hq'（owner/admin 等）→ 直接 select 會被 RLS 靜默回 0 列（同
+-- reference_admin_jwt_role_null 模式）。故包成 SECURITY DEFINER RPC：
+--   * 依呼叫端 tenant（_current_tenant_id(), 與 rpc_upsert_member 一致）過濾
+--   * 只回傳「給定 p_member_ids 中有 push 訂閱者」的 member_id
+--   * UNIQUE(tenant_id, member_id) 保證每人 ≤1 列；DISTINCT 為保險
+-- 純唯讀；不碰寫入路徑（rpc_upsert_push_subscription 不動）。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_members_with_push(p_member_ids BIGINT[])
+RETURNS TABLE (member_id BIGINT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT DISTINCT ps.member_id
+    FROM push_subscriptions ps
+   WHERE ps.tenant_id = public._current_tenant_id()
+     AND ps.member_id = ANY(p_member_ids);
+$$;
+
+COMMENT ON FUNCTION public.rpc_members_with_push(BIGINT[]) IS
+  '後台用：回傳給定 member_ids 中有 web push 訂閱者（=已安裝 PWA + 開啟通知）。'
+  ' SECURITY DEFINER 繞過 push_subscriptions RLS（admin JWT role 非 hq），依呼叫端 tenant 過濾。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_members_with_push(BIGINT[]) TO authenticated;


### PR DESCRIPTION
## 需求
後台會員列表要能看出哪些會員「已安裝 App 且開啟通知」（= 可被推播觸及）。原 #285 的鈴鐺只加在 member app `/me`，本 PR 補到 **admin 會員列表**。

## 關鍵：為何需要 RPC（不是純 UI）
`push_subscriptions` RLS 只允許 member 自己或 `role='hq'`（[20260520000000_web_push_subscriptions.sql:38](supabase/migrations/20260520000000_web_push_subscriptions.sql)）。後台 admin JWT role 非 `'hq'`（owner/admin 類）→ 直接 `select from push_subscriptions` 會被 RLS **靜默回 0 列**（同既有 reference_admin_jwt_role_null 模式）。故新增 SECURITY DEFINER RPC。

## 變更
- **新增 migration** `supabase/migrations/20260619000010_rpc_members_with_push.sql`
  - `rpc_members_with_push(p_member_ids BIGINT[]) RETURNS TABLE(member_id BIGINT)`，`STABLE SECURITY DEFINER`，`_current_tenant_id()` 依呼叫端 tenant 過濾，回傳傳入 ids 中有 push 訂閱者。`GRANT EXECUTE TO authenticated`。純唯讀，**不碰 rpc_upsert_push_subscription / 寫入路徑**。
- **UI** `apps/admin/src/app/(protected)/members/page.tsx`
  - 既有 orders/wallet 批次查詢 `Promise.all` 加一筆 `rpc_members_with_push`，建 `pushSet: Set<number>`。
  - 姓名旁（樂樂 badge 後）`pushSet.has(r.id)` 時渲染 🔔，`title`/`aria-label`「已安裝 App 並開啟通知」。
  - RPC 失敗/空 → 無 🔔、列表照常（graceful）。
- **測試清單** `docs/TEST-admin-member-push-bell.md`（schema/RPC/UI/regression 4 層）

## 不在範圍 / 不受影響
member app `/me` #285 鈴鐺與推播訂閱流程未動；會員列表既有搜尋/排序/分頁/樂樂 badge/訂單數/儲值/store 不變。

## 驗證狀態
- 碼審 + 型別審查通過（`getSupabase()` 未帶 Database 泛型，`.rpc()` 名稱不會型別報錯；`pushSet` 用法型別安全；無 unused）。
- 沙箱 worktree 無 node_modules 且連不到 DB → 完整 `next build` / live preview / SQL 直測未跑，留給有環境者：依 `docs/TEST-admin-member-push-bell.md` §1–§3 在 Supabase Studio 跑 RPC 驗證 SQL + admin 實機看鈴鐺。

## Test plan
- [ ] §1 RPC: 存在、SECURITY DEFINER、grant authenticated、tenant 不可由參數跨租戶
- [ ] §2 RPC 行為: 有/無訂閱、空陣列、跨 tenant 不外洩、admin(role≠hq) 仍取得正確結果
- [ ] §3 UI: 有訂閱列顯 🔔 + tooltip、無訂閱不顯、樂樂並存、分頁/搜尋/排序後正確、RPC 失敗降級
- [ ] §4 Regression: 列表既有功能、會員明細、member app #285、推播發送
- [ ] build + type-check 過、無 console error、Supabase dev push 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)