### PR TITLE
fix(member): 開團名稱清掉 legacy LINE (emoji)/(heart) 佔位字

### DIFF
--- a/apps/member/src/app/shop/c/[id]/page.tsx
+++ b/apps/member/src/app/shop/c/[id]/page.tsx
@@ -8,18 +8,7 @@ import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
 import Spinner, { LoadingScreen } from "@/components/Spinner";
 import Countdown from "@/components/Countdown";
-
-/** 清掉 legacy LINE 匯入殘留的佔位字 (emoji)/(heart)，並收斂多餘空白。
- *  刻意只動這兩個明確雜訊 token —— (A)/(B)/($)/（暗色）等是有意義內容，不碰。 */
-function cleanDescription(raw: string): string {
-  return raw
-    .replace(/\(heart\)/gi, "♥")
-    .replace(/\(emoji\)/gi, "")
-    .replace(/[ \t]{2,}/g, " ")
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
+import { cleanCampaignText } from "@/lib/text";
 
 /** 把 children 渲染到 document.body（保證 fixed 相對 viewport）。 */
 function Portal({ enabled, children }: { enabled: boolean; children: React.ReactNode }) {
@@ -148,7 +137,7 @@ export default function CampaignDetailPage() {
   };
 
   return (
-    <PageShell title={campaign?.name ?? "商品"}>
+    <PageShell title={cleanCampaignText(campaign?.name) || "商品"}>
       <div className="space-y-4 px-0 pb-[160px]">
         {loading && <LoadingScreen />}
 
@@ -184,7 +173,7 @@ export default function CampaignDetailPage() {
             <div className="space-y-2 px-4">
               <div className="flex items-start justify-between gap-3">
                 <h1 className="flex-1 text-[26px] font-bold leading-tight text-[var(--foreground)]">
-                  {campaign.name}
+                  {cleanCampaignText(campaign.name)}
                 </h1>
                 {(() => {
                   const orderedQty = items.reduce(
@@ -200,7 +189,7 @@ export default function CampaignDetailPage() {
                 })()}
               </div>
               {campaign.description && (() => {
-                const desc = cleanDescription(campaign.description);
+                const desc = cleanCampaignText(campaign.description);
                 if (!desc) return null;
                 return (
                   <div className="rounded-2xl bg-[var(--card-bg)] p-4 shadow-[var(--shadow-card)]">
@@ -297,7 +286,7 @@ export default function CampaignDetailPage() {
       {/* Shopee 式選購 sheet — 規格 + 數量 + 大鈕送出，全在這個彈窗 */}
       <Portal enabled={mounted && sheetOpen && !!campaign}>
         <BuySheet
-          campaignName={campaign?.name ?? ""}
+          campaignName={cleanCampaignText(campaign?.name)}
           items={items}
           qtyMap={qtyMap}
           onQty={setQty}

--- a/apps/member/src/app/shop/flash/page.tsx
+++ b/apps/member/src/app/shop/flash/page.tsx
@@ -13,6 +13,7 @@ import CampaignCard, {
   type CampaignSummary,
 } from "@/components/CampaignCard";
 import Countdown from "@/components/Countdown";
+import { cleanCampaignText } from "@/lib/text";
 
 export default function FlashPage() {
   const router = useRouter();
@@ -144,7 +145,7 @@ function FlashRow({ campaign }: { campaign: CampaignSummary }) {
       </div>
       <div className="min-w-0 flex-1 space-y-1">
         <h3 className="line-clamp-2 text-[17px] font-semibold leading-tight text-[var(--foreground)]">
-          {campaign.name}
+          {cleanCampaignText(campaign.name)}
         </h3>
         <div className="flex items-baseline gap-2">
           <div className="text-[24px] font-bold tabular-nums text-[var(--brand-strong)] leading-none">

--- a/apps/member/src/components/CampaignCard.tsx
+++ b/apps/member/src/components/CampaignCard.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import Countdown from "./Countdown";
+import { cleanCampaignText } from "@/lib/text";
 
 export type CampaignSummary = {
   id: number;
@@ -142,7 +143,7 @@ export default function CampaignCard({
         </div>
         <div className="space-y-1.5 px-4 py-3.5">
           <h3 className="text-[22px] font-bold leading-tight text-[var(--foreground)]">
-            {campaign.name}
+            {cleanCampaignText(campaign.name)}
           </h3>
           <div className="flex items-baseline justify-between gap-2">
             <span className="brand-gradient-text text-[28px] font-extrabold tabular-nums leading-none">
@@ -203,7 +204,7 @@ export default function CampaignCard({
       </div>
       <div className="space-y-1 px-3 py-2.5">
         <h3 className="line-clamp-2 min-h-[2.6em] text-[16px] font-semibold leading-tight text-[var(--foreground)]">
-          {campaign.name}
+          {cleanCampaignText(campaign.name)}
         </h3>
         {(() => {
           const remaining = campaignRemaining(campaign);

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -1,3 +1,5 @@
+import { cleanCampaignText } from "@/lib/text";
+
 export type OrderItem = {
   id: number;
   sku_id: number;
@@ -51,7 +53,7 @@ function fmtDate(iso: string | null | undefined): string {
 
 export default function OrderCard({ order }: { order: OrderRow }) {
   const totalQty = order.items.reduce((s, i) => s + Number(i.qty ?? 0), 0);
-  const title = order.campaign_name ?? "訂單";
+  const title = cleanCampaignText(order.campaign_name) || "訂單";
 
   return (
     <article className="card overflow-hidden">

--- a/apps/member/src/lib/text.ts
+++ b/apps/member/src/lib/text.ts
@@ -1,0 +1,14 @@
+/** 清掉 legacy LINE 匯入殘留的佔位字 (emoji)/(heart)，並收斂多餘空白。
+ *  開團名稱與描述都從候選池的 LINE 貼文文字帶出，常夾帶這兩個雜訊 token。
+ *  刻意只動這兩個明確雜訊 —— (A)/(B)/($)/（暗色）等是有意義內容，不碰。
+ *  收 null/undefined（名稱欄位多為 nullable），一律回字串。 */
+export function cleanCampaignText(raw: string | null | undefined): string {
+  if (!raw) return "";
+  return raw
+    .replace(/\(heart\)/gi, "♥")
+    .replace(/\(emoji\)/gi, "")
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}


### PR DESCRIPTION
## 問題
開團名稱（`campaign.name`）從候選池的 LINE 貼文文字帶出，LINE 匯出會把 emoji 換成字面 `(emoji)`、愛心換成 `(heart)`，所以資料庫存的名稱長這樣：`(emoji)廠商5/20收單`。

`cleanDescription()` 這個清洗器**只清描述、且 private 卡在開團詳情頁**，標題完全沒套 → 顧客端 7 個顯示點全裸渲染這串雜訊。後台商品編輯正常是因為那是另一個欄位（商品名稱），有人手動清過。

## 修法（顯示層，沿用 codebase 既有「render 時刷掉這兩個 token」的刻意決策）
- 新增共用 helper `apps/member/src/lib/text.ts` → `cleanCampaignText()`，收 `string | null | undefined`。
- 套進全部 7 個開團名稱顯示點：
  - `shop/c/[id]/page.tsx` ×4（`<h1>`、分頁標題、購買 sheet header，並把舊的 local `cleanDescription` 收斂掉）
  - `components/CampaignCard.tsx` ×2（grid + hero 卡）
  - `components/OrderCard.tsx` ×1（訂單卡標題）
  - `shop/flash/page.tsx` ×1（限時卡）
- 一次修好現有 live 開團與未來所有開團，無需資料遷移。

## 不在本 PR 範圍（已另開 follow-up）
DB 仍存原始 `(emoji)` → 後台開團列表 / LINE 推播模板仍會露出。屬資料層問題，另案處理（建團 RPC 落地清洗 + 既有 row backfill）。

## Test plan
- [x] `npm run build`（member）：`✓ Compiled successfully` + `Finished TypeScript` 零錯、14 頁全產出
- [ ] 顧客端 /shop 列表、限時專區、開團詳情、訂單頁：`(emoji)廠商5/20收單` → 顯示為 `廠商5/20收單`
- [ ] `(heart)` → `♥`、連續空白收斂；`(A)/(B)/($)` 等有意義字串不被動到
- [ ] 名稱為 null 的訂單卡仍 fallback 顯示「訂單」

🤖 Generated with [Claude Code](https://claude.com/claude-code)