### PR TITLE
feat(admin/campaigns): 開團編輯頁可直接改團名

### DIFF
--- a/apps/admin/src/components/CampaignForm.tsx
+++ b/apps/admin/src/components/CampaignForm.tsx
@@ -108,8 +108,8 @@ export function CampaignForm({
         }
       }
 
-      // 名稱 / 描述 / 收單時間 / 取貨截止 / 取貨天數 / 總量上限 / 備註
-      // 都從商品 / RPC 自動帶入；UI 不可編輯，保留原值送回。
+      // 團名由此表單直接編輯；描述 / 取貨截止 / 取貨天數 / 備註
+      // 仍從商品 / RPC 自動帶入，UI 不編輯、保留原值送回。
       const { data, error: err } = await getSupabase().rpc("rpc_upsert_campaign", {
         p_id: v.id,
         p_campaign_no: v.campaign_no.trim(),
@@ -138,6 +138,15 @@ export function CampaignForm({
   return (
     <form onSubmit={onSubmit} className="space-y-4" noValidate>
       <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="團名" className="sm:col-span-2">
+          <input
+            type="text"
+            value={v.name}
+            onChange={(e) => update("name", e.target.value)}
+            placeholder="顧客在 LIFF /shop 看到的開團標題"
+            className={inputCls}
+          />
+        </Field>
         <Field label="團號">
           <div className={`${inputCls} bg-zinc-50 text-zinc-500 dark:bg-zinc-900 select-all`}>{v.campaign_no || "（自動產生）"}</div>
         </Field>
@@ -239,7 +248,8 @@ export function CampaignForm({
       </div>
 
       <p className="text-xs text-zinc-500 dark:text-zinc-400">
-        名稱、描述、取貨截止 / 天數 在商品多選開團時設定；如需調整請至商品編輯頁。
+        描述、取貨截止 / 天數 在商品多選開團時設定；如需調整請至商品編輯頁。
+        單一商品開團的團名會跟著商品名稱自動更新；多商品開團則以此處填的為準。
       </p>
 
       {error && (

--- a/docs/TEST-campaign-name-editable.md
+++ b/docs/TEST-campaign-name-editable.md
@@ -1,0 +1,54 @@
+# campaign-name-editable 測試項目 — 後台「編輯開團」可直接編輯團名
+
+**對應 migration:** 無（純前端，後端 `rpc_upsert_campaign` 既有 `name = COALESCE(p_name, name)` 已支援）
+**對應 UI 變更:** `apps/admin/src/components/CampaignForm.tsx`
+**對應 PRD:** 無（沿用既有開團 CRUD；補上原刻意未開放的團名編輯）
+
+## 1. Schema / Migration 層
+
+- [ ] N/A — 本功能不含任何 migration / enum / 欄位 / index / RPC 簽章變更。
+      確認 `git diff main...HEAD --stat` 只有 `apps/admin/...` 與 `docs/TEST-...`，無 `supabase/migrations/*`。
+
+## 2. RPC 行為（SQL 直測）
+
+無新增 / 變更 RPC。僅複用既有 `public.rpc_upsert_campaign`；以下為「確認既有行為仍正確」的回歸性直測：
+
+### 2.1 既有 RPC 仍會寫入 name（UPDATE 分支）
+**情境：** 任取一筆 `status IN ('draft','open')` 的開團，記下原 `name`，呼叫 `rpc_upsert_campaign(p_id := <id>, p_name := '手動測試團名', ...其餘帶原值)`。
+**預期：** `group_buy_campaigns.name` 變為「手動測試團名」，`updated_by` = 當前 admin，其餘欄位（status / close_type / 時間 / cap / notes）不變。
+
+### 2.2 name 傳 NULL 不會清空（COALESCE 保護）
+**情境：** 對同一筆開團呼叫 RPC 但 `p_name := NULL`。
+**預期：** `name` 維持上一步的值（COALESCE 命中 `name`），不被設為 NULL。
+
+## 3. UI 行為（preview 互動 / 使用者自審）
+
+> admin live-preview 於 Claude 沙箱被網路阻擋（見專案慣例），§3 以 build + type-check + 碼審為自動驗證，互動項標記給使用者自審。
+
+### 3.1 編輯開團 modal — 團名輸入框渲染
+- [ ] 開團列表頁點任一列「編輯」→ modal 開啟，**新增「團名」文字輸入框**且帶入該開團現有名稱（含 legacy `(emoji)` 等原始值，未被前端清洗 — 編輯頁顯示原始 DB 值才能改）。
+- [ ] 團名輸入框可正常輸入 / 刪改中文與 emoji；無 maxLength 異常截斷（若加 maxLength 需與後端一致）。
+- [ ] 原本那行說明文字不再宣稱「名稱…請至商品編輯頁」（已移除/改寫，描述/取貨等仍維持原說明）。
+
+### 3.2 提交 happy path（既有開團改名）
+- [ ] 改團名後按「儲存」→ 無 console error、modal 關閉、列表該列名稱即時更新為新值。
+- [ ] 重新整理 / 重開編輯 → 新團名持續存在（DB 已落地，非僅前端 state）。
+- [ ] 會員端 LIFF /shop 對應開團卡 / 詳情標題顯示新團名（經 `cleanCampaignText` 仍會刷掉 `(emoji)`，但管理者輸入的乾淨名稱應原樣顯示）。
+
+### 3.3 空團名邊界
+- [ ] 團名清空後儲存：沿用既有 `(v.name || "(open campaign)").trim()` 行為 — 不報錯、落地為占位字（確認不是寫入空字串造成列表空白）。或依實作決定改為阻擋空字串並提示，二擇一但需與呈現一致。
+
+### 3.4 建立開團路徑不退化
+- [ ] 從商品多選開團（order-entry / 候選池排日期）建立的開團，團名仍正確帶入（單一商品＝商品名；多商品＝既有命名邏輯），新欄位不影響建立流程。
+
+## 4. Regression
+
+- [ ] 開團列表頁（桌機表格 + 手機卡片）名稱欄、modal title `編輯開團 #<no>｜<name>` 仍正常。
+- [ ] 行事曆（週/月）視圖點卡片開同一編輯 modal — 共用 `openEdit`，團名欄一致顯示且可編。
+- [ ] 單一商品 draft/open 開團：改動「商品名稱」後，trigger `trg_products_sync_campaign_name` 仍把 product.name 同步覆蓋到 campaign.name（**已知且刻意**的既有行為，非本功能 bug；測試僅確認未被破壞）。
+- [ ] 多商品開團：改商品名稱**不**覆蓋手動設定的團名（既有刻意行為仍成立）。
+- [ ] `closeCampaign` / `finalizeCampaign` / `deleteCampaign` 等列操作不受表單欄位新增影響。
+
+## 5. 驗收門檻
+
+全部 §1–§4 勾完、**無 console error**、**build + type-check 過**（admin `next build`）、且 §3 互動項經使用者自審通過，才可標 done。本功能無 migration，故「Supabase dev push」一項以「確認無 migration 變更」替代。


### PR DESCRIPTION
## 背景
顧客端看到的開團標題（如 `(emoji)廠商5/20收單`）來自候選池 LINE 貼文文字。#296 已在會員端顯示層刷掉 `(emoji)`/`(heart)` 雜訊，但**後台沒有任何地方能直接改團名** —— `CampaignForm` 的說明文字甚至寫「名稱…請至商品編輯頁」。

## 內容
純前端補上原本刻意未開放的團名編輯：

- `CampaignForm.tsx` 新增「團名」文字輸入框（grid 最上方、跨兩欄）。
- 後端早已支援，**無 migration / 無 RPC 變更**：
  - `rpc_upsert_campaign` UPDATE 分支 `name = COALESCE(p_name, name)`（`supabase/migrations/20260425120000_core_crud_rpcs.sql:404`）
  - `campaigns/page.tsx` `openEdit` 已把 `name` 載進 modal values
  - 表單原本就把 `v.name` 回傳給 RPC，只是沒 input
- 改寫原誤導說明文字，點出既有 trigger 行為：單一商品 draft/open 開團的團名仍會被 `trg_products_sync_campaign_name` 跟著商品名同步；多商品開團以此處填的為準（刻意行為，本 PR 不動 trigger）。
- 附測試清單 `docs/TEST-campaign-name-editable.md`。

## Test plan
- [x] `npm run build`（admin）：通過、輸出完整靜態 route 表（type-check 含在 build 內）
- [ ] 開團列表 / 行事曆點「編輯」→ 團名輸入框帶入現值、可改、儲存後列表與 DB 即時更新（admin preview 於沙箱被擋，留使用者自審）
- [ ] 單一商品開團改商品名仍會 trigger 同步覆蓋；多商品開團不被覆蓋（回歸，既有刻意行為）
- [ ] 空團名沿用既有 `(open campaign)` 占位行為，不寫入空字串

詳見 `docs/TEST-campaign-name-editable.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)