### PR TITLE
fix(member): 返回列表頁不再整頁 reload（client cache staleTimes）

### DIFF
--- a/apps/member/next.config.ts
+++ b/apps/member/next.config.ts
@@ -8,6 +8,15 @@ const withSerwist = withSerwistInit({
 
 const nextConfig: NextConfig = {
   images: { unoptimized: true },
+  // 進商品詳情頁再返回時，列表頁（/shop、/orders 等 client 端 fetch 的頁）
+  // 不要整頁重抓 + 捲動歸零。Next 15+ 把 client cache 的 staleTimes.dynamic
+  // 預設改成 0（一離開該頁 segment 就丟棄），返回時 component remount→
+  // useEffect 重抓→skeleton→scroll reset，就是使用者看到的「又 reload 一次」。
+  // 設成正值 → 返回時沿用 client cache 內「已渲染的頁面」（含 React state
+  // 與捲動位置），不再 reload。資料新鮮度交給下拉刷新 / 詳情頁自身 fetch。
+  experimental: {
+    staleTimes: { dynamic: 300, static: 300 },
+  },
   // 解決 Next.js 16+ Turbopack 與 Serwist (Webpack) 的衝突
   // 透過設定空物件來告訴 Next.js 即使有自定義 webpack 配置也要繼續建置
   // 在某些版本中這會讓建置退回到 Webpack，這對 Serwist 是必要的


### PR DESCRIPTION
## 問題
會員端瀏覽商品：`/shop` → 點進商品詳情 `/shop/c/[id]` → 返回，列表頁會「又 reload 一次」（skeleton 重跑、捲動位置歸零）。`/orders` 等其他 client 端 fetch 的列表頁同樣症狀。

## 根因
這些頁是 `"use client"`，在 `useEffect` 抓資料、存進 `useState`。Next.js v15 起把 Client Cache 的 `experimental.staleTimes.dynamic` **預設值從 30s 改為 0s**（見 Next 16 內附文件 `staleTimes.md` Version History）。`dynamic: 0` = 一離開該頁，segment 立即從 Client Cache 丟棄；返回（history pop）時 Next 重建頁面 → client component **remount** → `useState` 重置 → `useEffect` 重抓 → skeleton + 捲動歸零。

## 修法
`apps/member/next.config.ts` 加：

```ts
experimental: { staleTimes: { dynamic: 300, static: 300 } }
```

返回時沿用 Client Cache 內「已渲染的頁面樹」（含 React state 與捲動位置），不再 remount/重抓。**一處設定、全 app 生效**（/shop、/orders、/notifications… 的「進詳情再返回」都受惠），無需逐頁改。

## 取捨
- 列表卡片的彙總數字（如「已訂購 N 件」）在返回後最多 5 分鐘內可能略舊；已有下拉刷新可手動更新，詳情頁本身仍每次 fresh fetch。值可調（縮短即更即時、但越短越容易又 reload）。
- `staleTimes` 為 Next 官方 `experimental` 設定（Next 16 仍是此介面），非 hack。
- 不影響 Serwist PWA 快取（Service Worker 與 router Client Cache 各自獨立）。

## Test plan
- [x] `npm run build`（member）：通過、TypeScript clean、無 next.config 驗證警告、14 route 全產出
- [ ] 裝置實測（LINE webview / 加主畫面 PWA）：/shop 捲到中段 → 進某商品詳情 → 返回 → **不再 skeleton 重跑、停在原捲動位置**（沙箱無法跑 LIFF/PWA，留使用者實機自審）
- [ ] /orders → 訂單詳情 → 返回 同樣不 reload
- [ ] 下拉刷新仍會重抓最新；於詳情頁下單後返回，彙總數字最遲下拉刷新即更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)