### PR TITLE
feat(admin/campaigns): 開團「重新同步商品/價格」按鈕 + resync RPC

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -111,6 +111,7 @@ export default function CampaignsListPage() {
   const [listOrderCounts, setListOrderCounts] = useState<Map<number, { normalQty: number; offsetQty: number }>>(new Map());
   const [modal, setModal] = useState<{ mode: "edit"; values: CampaignFormValues } | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
+  const [resyncTick, setResyncTick] = useState(0);
   const [closingId, setClosingId] = useState<number | null>(null);
   const [finalizingId, setFinalizingId] = useState<number | null>(null);
 
@@ -872,7 +873,11 @@ export default function CampaignsListPage() {
       >
         {modal && (
           <div className="space-y-6">
-            <CampaignItemsTable campaignId={modal.values.id!} />
+            <CampaignItemsTable
+              campaignId={modal.values.id!}
+              status={modal.values.status}
+              onResynced={() => { setResyncTick((t) => t + 1); setReloadTick((t) => t + 1); }}
+            />
             <div className="border-t border-zinc-200 pt-4 dark:border-zinc-800">
               <CampaignForm
                 initial={modal.values}
@@ -881,7 +886,7 @@ export default function CampaignsListPage() {
               />
             </div>
             <div className="border-t border-zinc-200 pt-4 dark:border-zinc-800">
-              <CampaignOrdersPanel campaignId={modal.values.id!} />
+              <CampaignOrdersPanel key={resyncTick} campaignId={modal.values.id!} />
             </div>
           </div>
         )}

--- a/apps/admin/src/components/CampaignItemsTable.tsx
+++ b/apps/admin/src/components/CampaignItemsTable.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
+import { Modal } from "@/components/Modal";
+import SpinButton from "@/components/SpinButton";
+import { translateRpcError } from "@/lib/rpcError";
 
 type Row = {
   id: number;
@@ -19,9 +22,34 @@ type Row = {
   locked_at: string | null;
 };
 
-export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
+type ResyncPreview = {
+  campaign_no: string;
+  name_before: string;
+  name_after: string;
+  name_changed: boolean;
+  items: { sku_id: number; sku_code: string; old_price: number; new_price: number }[];
+  items_repriced: number;
+  skus_added: number;
+  pending_orders: number;
+  pending_order_lines: number;
+  amount_before: number;
+  amount_after: number;
+};
+
+export function CampaignItemsTable({
+  campaignId,
+  status,
+  onResynced,
+}: {
+  campaignId: number;
+  status?: string;
+  onResynced?: () => void;
+}) {
   const [rows, setRows] = useState<Row[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<ResyncPreview | null>(null);
+  const [resyncErr, setResyncErr] = useState<string | null>(null);
+  const canResync = status === "draft" || status === "open";
 
   const reload = async () => {
     // products.name 是 source of truth；skus.product_name 是 denorm 可能過期、不用它
@@ -58,6 +86,35 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
 
   useEffect(() => { reload(); }, [campaignId]);
 
+  const runPreview = async () => {
+    setResyncErr(null);
+    const { data, error: err } = await getSupabase().rpc(
+      "rpc_resync_campaign_from_product",
+      { p_campaign_id: campaignId, p_dry_run: true },
+    );
+    if (err) { setResyncErr(translateRpcError(err)); return; }
+    setPreview(data as ResyncPreview);
+  };
+
+  const runApply = async () => {
+    setResyncErr(null);
+    const { error: err } = await getSupabase().rpc(
+      "rpc_resync_campaign_from_product",
+      { p_campaign_id: campaignId, p_dry_run: false },
+    );
+    if (err) { setResyncErr(translateRpcError(err)); return; }
+    setPreview(null);
+    await reload();
+    onResynced?.();
+  };
+
+  const hasChanges = !!preview && (
+    preview.name_changed ||
+    preview.items_repriced > 0 ||
+    preview.skus_added > 0 ||
+    preview.pending_order_lines > 0
+  );
+
   const anyLocked = (rows ?? []).some((r) => !!r.locked_at);
   const earliestLock = (rows ?? [])
     .map((r) => r.locked_at)
@@ -78,8 +135,23 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
             </span>
           )}
         </div>
-        <span className="text-xs text-zinc-500">{rows?.length ?? 0} 項</span>
+        <div className="flex items-center gap-3">
+          {canResync && (
+            <SpinButton
+              onClick={runPreview}
+              title="從商品現行零售價重新同步開團名稱、單價，並回填本團『待確認』訂單金額"
+              className="rounded-md border border-blue-300 px-2.5 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50 dark:border-blue-800 dark:text-blue-300 dark:hover:bg-blue-950"
+            >
+              重新同步商品/價格
+            </SpinButton>
+          )}
+          <span className="text-xs text-zinc-500">{rows?.length ?? 0} 項</span>
+        </div>
       </div>
+
+      {resyncErr && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">{resyncErr}</div>
+      )}
 
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">{error}</div>
@@ -126,6 +198,101 @@ export function CampaignItemsTable({ campaignId }: { campaignId: number }) {
           </tbody>
         </table>
       </div>
+
+      <Modal
+        open={!!preview}
+        onClose={() => setPreview(null)}
+        title="重新同步商品/價格 — 預覽"
+        maxWidth="max-w-2xl"
+      >
+        {preview && (
+          <div className="space-y-4 text-sm">
+            {resyncErr && (
+              <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">{resyncErr}</div>
+            )}
+            <p className="text-xs text-zinc-500">
+              從商品現行零售價同步開團 #{preview.campaign_no}。確認前不會寫入任何資料。
+            </p>
+
+            {preview.name_changed && (
+              <div className="rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
+                <div className="mb-1 text-xs font-medium text-zinc-500">開團名稱</div>
+                <div className="line-through text-zinc-400">{preview.name_before}</div>
+                <div className="font-semibold">{preview.name_after}</div>
+              </div>
+            )}
+
+            {preview.items.length > 0 && (
+              <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+                <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+                  <thead className="bg-zinc-50 dark:bg-zinc-900">
+                    <tr>
+                      <Th>規格</Th>
+                      <Th className="text-right">原單價</Th>
+                      <Th className="text-right">新單價</Th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                    {preview.items.map((it) => (
+                      <tr key={it.sku_id}>
+                        <Td className="font-mono">{it.sku_code}</Td>
+                        <Td className="text-right font-mono text-zinc-400 line-through">
+                          ${Number(it.old_price)}
+                        </Td>
+                        <Td className="text-right font-mono font-semibold">
+                          ${Number(it.new_price)}
+                        </Td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            <ul className="space-y-1 text-xs text-zinc-600 dark:text-zinc-300">
+              <li>商品明細重新定價：<b>{preview.items_repriced}</b> 項</li>
+              <li>補上缺漏的 active 規格：<b>{preview.skus_added}</b> 項</li>
+              <li>
+                回填「待確認」訂單：<b>{preview.pending_orders}</b> 筆訂單／
+                <b>{preview.pending_order_lines}</b> 項明細
+              </li>
+              <li>
+                待確認訂單金額：
+                <span className="font-mono text-zinc-400 line-through">
+                  ${Number(preview.amount_before).toLocaleString()}
+                </span>
+                {" → "}
+                <span className="font-mono font-semibold">
+                  ${Number(preview.amount_after).toLocaleString()}
+                </span>
+              </li>
+            </ul>
+
+            {!hasChanges && (
+              <div className="rounded-md border border-emerald-200 bg-emerald-50 p-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300">
+                已是最新，無需變更。
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 border-t border-zinc-200 pt-3 dark:border-zinc-800">
+              <SpinButton
+                onClick={() => setPreview(null)}
+                className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              >
+                取消
+              </SpinButton>
+              {hasChanges && (
+                <SpinButton
+                  onClick={runApply}
+                  className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+                >
+                  確認同步
+                </SpinButton>
+              )}
+            </div>
+          </div>
+        )}
+      </Modal>
     </div>
   );
 }

--- a/docs/TEST-campaign-resync.md
+++ b/docs/TEST-campaign-resync.md
@@ -1,0 +1,116 @@
+# campaign-resync 測試項目 — 開團「重新同步商品/價格」按鈕 + RPC
+
+**對應 migration:** `supabase/migrations/20260620000010_rpc_resync_campaign_from_product.sql`
+**對應 UI 變更:** `apps/admin/src/components/CampaignItemsTable.tsx`、`apps/admin/src/app/(protected)/campaigns/page.tsx`
+**背景:** 開團後 `campaign_items` 價格被 `locked_at` 鎖定、零售價變動不再 sync；忘記輸入售價時訂單會以 $0 快照成立。本功能提供 HQ 手動重新同步開團名稱/價格、並回填「待確認」訂單。
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 RPC signature
+- [ ] `rpc_resync_campaign_from_product(BIGINT, BOOLEAN, UUID)` 存在、`prosecdef = true`（SECURITY DEFINER）、`proconfig` 含 `search_path=public`
+  ```sql
+  select proname, prosecdef, proconfig,
+         pg_get_function_arguments(oid) args, pg_get_function_result(oid) ret
+    from pg_proc where proname='rpc_resync_campaign_from_product';
+  ```
+  預期：1 列、`prosecdef=t`、args `p_campaign_id bigint, p_dry_run boolean DEFAULT true, p_operator uuid DEFAULT NULL`、ret `jsonb`
+- [ ] `GRANT EXECUTE ... TO authenticated` 已下
+  ```sql
+  select grantee, privilege_type from information_schema.routine_privileges
+   where routine_name='rpc_resync_campaign_from_product';
+  ```
+- [ ] migration 重跑冪等（`CREATE OR REPLACE FUNCTION`）— 連續 apply 兩次不報錯
+
+### 1.2 不新增表 / 欄位
+- [ ] 本 migration 只 `CREATE OR REPLACE FUNCTION` + `GRANT`，無 `ALTER TABLE` / `CREATE TABLE`（稽核沿用既有 `customer_order_audit_log`）
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+> 測試前置：找一個 `status='open'` 且 `product_id` 有值的開團，準備 (a) 1 個 active SKU 有零售價 (b) 該團數筆 `status='pending'` 訂單（含 unit_price=0 與非 0 各一）(c) 1 筆 `status='confirmed'` 訂單 (d) 1 筆 `status='cancelled'` 訂單。
+
+### 2.1 dry_run 預覽不寫入
+**情境：** `p_dry_run=true` 呼叫。
+**預期：** 回傳 JSONB 含 `dry_run=true`、`name_before/name_after`、`items[]`（每 SKU `sku_code/old_price/new_price`）、`pending_orders`、`pending_order_lines`、待確認訂單 `amount_before/amount_after`；呼叫後 `campaign_items`、`customer_order_items`、`group_buy_campaigns.name`、`customer_order_audit_log` **完全沒有變動**。
+
+### 2.2 實跑：開團名稱同步
+**情境：** product.name 與 campaign.name 不同，`p_dry_run=false`。
+**預期：** `group_buy_campaigns.name` = products.name、`updated_at` 更新；回傳 `name_changed=true`。
+
+### 2.3 實跑：campaign_items 重新定價
+**情境：** campaign_items.unit_price 與現行零售價不同（含 =0 與非 0）。
+**預期：** 該 active SKU 的 `campaign_items.unit_price` = 現行零售價、`updated_at` 更新；`locked_at` **不變**（不解鎖、不被阻擋）；回傳 `items_repriced` 計數正確。
+
+### 2.4 實跑：補缺漏 active SKU
+**情境：** product 底下有 active SKU 尚未在 campaign_items。
+**預期：** 新增 campaign_items 列（unit_price=現行零售價、sort_order=999）；已存在的不重複（ON CONFLICT DO NOTHING）；回傳 `skus_added` 計數。
+
+### 2.5 實跑：待確認訂單明細回填（含非 0 覆蓋）
+**情境：** 該團 `status='pending'` 訂單，明細 unit_price 有 =0 也有非 0（與新售價不同）。
+**預期：** 兩者皆被改為現行零售價；每筆變動寫一列 `customer_order_audit_log`（entity_type='item'、field='unit_price'、before/after 正確、operator_id 非 NULL、edit_reason 非空）；回傳 `pending_order_lines_updated`、`pending_orders_affected` 正確。
+
+### 2.6 不動非待確認訂單
+**情境：** 同團存在 `confirmed` / `completed` / `cancelled` / `reserved` / `ready` 訂單，明細 unit_price 為舊值。
+**預期：** 這些訂單明細 unit_price **完全不變**、無對應 audit log。
+
+### 2.7 守門：active SKU 無有效零售價 → 拒跑
+**情境：** 該團某 active SKU 無 `prices(scope='retail', effective_to IS NULL)` 或解析價 ≤ 0。
+**預期：** `RAISE EXCEPTION`（訊息含缺價 SKU 數/代碼）；整個交易 rollback，**campaign_items / 訂單 / 名稱 / audit 皆無變動**（dry_run 與實跑都要擋）。
+
+### 2.8 守門：開團狀態限制
+**情境：** campaign.status ∈ {closed, ordered, receiving, ready, completed, cancelled}。
+**預期：** `RAISE EXCEPTION`「只有草稿/開團中…（目前為 X）」；無任何變動。draft / open 才放行。
+
+### 2.9 權限：非 HQ 拒絕
+**情境：** JWT role = 店家（非 owner/admin/hq_manager/hq_accountant、非 NULL）。
+**預期：** `RAISE EXCEPTION` 權限不足；role 為 NULL（admin user）視同 HQ → 放行。
+
+### 2.10 租戶隔離
+**情境：** `p_campaign_id` 屬於別 tenant。
+**預期：** `RAISE EXCEPTION` campaign not found in tenant；無變動。
+
+### 2.11 product_id 為 NULL 的舊團
+**情境：** campaign.product_id IS NULL。
+**預期：** 不做名稱同步、不補 SKU，但仍正常重新定價既有 campaign_items 與待確認訂單；不報錯。
+
+### 2.12 冪等
+**情境：** 連續實跑兩次。
+**預期：** 第二次 `items_repriced=0`、`pending_order_lines_updated=0`、`name_changed=false`、不再寫 audit log（值相同即跳過）。
+
+---
+
+## 3. UI 行為（preview 互動 — 留使用者自審）
+
+> Admin live-preview 沙箱被網路阻擋（見 memory），UI 項目以程式碼審查 + build/type-check 為主，實際點擊互動交付使用者在 prod/本機自審。
+
+### 3.1 按鈕顯示條件
+- [ ] 編輯開團 Modal 內 `CampaignItemsTable` 出現「重新同步商品/價格」按鈕
+- [ ] 僅 `status ∈ {draft, open}` 顯示；closed/ordered/.../cancelled 不顯示
+- [ ] `🔒 已鎖定` 標記同時存在時，按鈕仍可按（locked_at 不阻擋）
+
+### 3.2 預覽 → 確認流程
+- [ ] 按按鈕先呼叫 RPC `p_dry_run=true`，跳出 Modal 顯示：名稱 old→new、各 SKU old→new 表、待確認訂單金額 before→after、影響筆數
+- [ ] 載入態為純 spinner（無「載入中」字樣）
+- [ ] 「確認」呼叫 RPC `p_dry_run=false`；「取消」關閉 Modal、無任何寫入
+- [ ] 守門 / 權限 RAISE EXCEPTION 經 `translateRpcError` 顯示可讀錯誤、不 crash
+
+### 3.3 成功後刷新
+- [ ] 實跑成功後 `CampaignItemsTable.reload()` 觸發、單價即時更新
+- [ ] `onResynced` 回呼使外層 `CampaignOrdersPanel` / 列表金額一併刷新（不需重開 Modal）
+
+---
+
+## 4. Regression
+- [ ] `/campaigns` 列表（含行內 開團/結單/整單結算/刪除）行為不變
+- [ ] 編輯開團 Modal 既有 `CampaignForm` 存檔、`CampaignItemsTable` 顯示、`CampaignOrdersPanel` 統計不受影響
+- [ ] `_lock_campaign_prices_on_open` / `_sync_retail_price_to_campaigns` / `_sync_product_name_to_campaigns` / 1-campaign-1-product invariant trigger 行為不變（resync 不繞過 invariant：補 SKU 必同 product）
+- [ ] `rpc_create_customer_orders` 加單仍快照 campaign_items.unit_price（未被本功能改壞）
+- [ ] `customer_order_audit_log` append-only trigger 仍擋 UPDATE/DELETE；本 RPC 僅 INSERT
+- [ ] `v_customer_order_summary` / `CampaignOrdersPanel` 金額（qty×unit_price）回填後正確、結單/應收下游連動正確
+
+## 5. 驗收門檻
+
+全部 §1–§4 勾完、**無 console error**、**Supabase dev push 成功（或 prod Studio 套用成功）**、**admin build + type-check 過** 才可標 done。

--- a/supabase/migrations/20260620000010_rpc_resync_campaign_from_product.sql
+++ b/supabase/migrations/20260620000010_rpc_resync_campaign_from_product.sql
@@ -1,0 +1,296 @@
+-- ============================================================
+-- rpc_resync_campaign_from_product
+--   開團「重新同步商品/價格」按鈕後端
+--
+--   開團 open 後 campaign_items 價格被 locked_at 鎖定、零售價變動不再
+--   自動 sync；忘記輸入售價時訂單會以 $0 快照成立。本 RPC 讓 HQ 手動：
+--     1. 開團名稱 ← products.name（campaign.product_id；1:1 invariant）
+--     2. campaign_items.unit_price ← 該 active SKU 現行零售價
+--        （prices scope='retail' effective_to IS NULL 最新一筆）
+--     3. 補 product 底下尚未在 campaign_items 的 active SKU（且有有效零售價）
+--     4. 本團 status='pending'（待確認）訂單明細 unit_price 一律改為現行
+--        零售價（即使原本非 0）；confirmed/completed/cancelled… 不動
+--        每筆寫一列 customer_order_audit_log
+--
+--   守門：
+--     - 權限 HQ（owner/admin/hq_manager/hq_accountant，role NULL 視同 admin）
+--     - 開團狀態僅 draft / open（已收單後 PR/PO 已快照、不給按）
+--     - 任一「已在 campaign_items 的 active SKU」解析零售價 <= 0
+--       → RAISE EXCEPTION 拒跑（絕不回填成 0）
+--     - locked_at 不阻擋（這正是手動覆寫的入口）
+--
+--   p_dry_run=TRUE（預設）：只回傳預覽 JSON，不寫入任何表
+--
+--   Scope: 僅 CREATE OR REPLACE FUNCTION + GRANT（沿用既有
+--          customer_order_audit_log，無 ALTER/CREATE TABLE）
+--   Rollback: DROP FUNCTION public.rpc_resync_campaign_from_product(BIGINT,BOOLEAN,UUID);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_resync_campaign_from_product(
+  p_campaign_id BIGINT,
+  p_dry_run     BOOLEAN DEFAULT TRUE,
+  p_operator    UUID    DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant    UUID := (auth.jwt() ->> 'tenant_id')::uuid;
+  v_role      TEXT := COALESCE(auth.jwt() ->> 'role','');
+  v_op        UUID := COALESCE(p_operator, auth.uid());
+  v_camp      group_buy_campaigns%ROWTYPE;
+  v_prod_name TEXT;
+  v_bad_cnt   INT;
+  v_bad_list  TEXT;
+  v_name_changed   BOOLEAN := FALSE;
+  v_items_repriced INT := 0;
+  v_skus_added     INT := 0;
+  v_orders         INT := 0;
+  v_lines          INT := 0;
+  v_amt_before     NUMERIC := 0;
+  v_amt_after      NUMERIC := 0;
+  v_items_json     JSONB;
+  v_result         JSONB;
+BEGIN
+  -- ---------- 權限 ----------
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+  IF v_role NOT IN ('owner','admin','hq_manager','hq_accountant','') THEN
+    RAISE EXCEPTION 'permission denied: role % 無權重新同步開團', v_role;
+  END IF;
+
+  -- ---------- 開團 + 狀態守門 ----------
+  SELECT * INTO v_camp
+    FROM group_buy_campaigns
+   WHERE id = p_campaign_id AND tenant_id = v_tenant
+   FOR UPDATE;
+  IF v_camp.id IS NULL THEN
+    RAISE EXCEPTION 'campaign % 不在 tenant 內', p_campaign_id;
+  END IF;
+  IF v_camp.status NOT IN ('draft','open') THEN
+    RAISE EXCEPTION '只有草稿/開團中的開團可以重新同步（目前狀態：%）', v_camp.status;
+  END IF;
+
+  -- ---------- 守門：已在 campaign_items 的 active SKU 必須都有有效零售價 ----------
+  SELECT COUNT(*),
+         string_agg(s.sku_code, ', ' ORDER BY s.sku_code)
+    INTO v_bad_cnt, v_bad_list
+    FROM campaign_items ci
+    JOIN skus s ON s.id = ci.sku_id AND s.tenant_id = ci.tenant_id
+   WHERE ci.campaign_id = p_campaign_id
+     AND ci.tenant_id   = v_tenant
+     AND s.status = 'active'
+     AND COALESCE((
+           SELECT pr.price FROM prices pr
+            WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+              AND pr.scope = 'retail' AND pr.effective_to IS NULL
+            ORDER BY pr.effective_from DESC LIMIT 1
+         ), 0) <= 0;
+  IF v_bad_cnt > 0 THEN
+    RAISE EXCEPTION '仍有 % 個 active SKU 沒有有效零售價，請先到商品頁設定售價（避免回填成 0）：%',
+      v_bad_cnt, v_bad_list;
+  END IF;
+
+  -- ---------- 名稱 ----------
+  IF v_camp.product_id IS NOT NULL THEN
+    SELECT name INTO v_prod_name
+      FROM products WHERE id = v_camp.product_id AND tenant_id = v_tenant;
+  END IF;
+  v_name_changed := (v_prod_name IS NOT NULL AND v_prod_name IS DISTINCT FROM v_camp.name);
+
+  -- ---------- 預覽數字（mutation 前算好，預覽 / 實跑共用）----------
+  -- 重新定價的 active campaign_items（價格有變者）
+  SELECT COUNT(*),
+         jsonb_agg(jsonb_build_object(
+           'sku_id', t.sku_id, 'sku_code', t.sku_code,
+           'old_price', t.old_price, 'new_price', t.new_price
+         ) ORDER BY t.sku_code)
+    INTO v_items_repriced, v_items_json
+    FROM (
+      SELECT ci.sku_id, s.sku_code, ci.unit_price AS old_price,
+             (SELECT pr.price FROM prices pr
+               WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+                 AND pr.scope = 'retail' AND pr.effective_to IS NULL
+               ORDER BY pr.effective_from DESC LIMIT 1) AS new_price
+        FROM campaign_items ci
+        JOIN skus s ON s.id = ci.sku_id AND s.tenant_id = ci.tenant_id
+       WHERE ci.campaign_id = p_campaign_id AND ci.tenant_id = v_tenant
+         AND s.status = 'active'
+    ) t
+   WHERE t.old_price IS DISTINCT FROM t.new_price;
+
+  -- 待補的 active SKU（product 底下、尚未在 campaign_items、且有有效零售價）
+  SELECT COUNT(*) INTO v_skus_added
+    FROM skus s
+   WHERE v_camp.product_id IS NOT NULL
+     AND s.tenant_id  = v_tenant
+     AND s.product_id = v_camp.product_id
+     AND s.status     = 'active'
+     AND NOT EXISTS (SELECT 1 FROM campaign_items ci
+                      WHERE ci.campaign_id = p_campaign_id
+                        AND ci.tenant_id = v_tenant AND ci.sku_id = s.id)
+     AND COALESCE((
+           SELECT pr.price FROM prices pr
+            WHERE pr.tenant_id = v_tenant AND pr.sku_id = s.id
+              AND pr.scope = 'retail' AND pr.effective_to IS NULL
+            ORDER BY pr.effective_from DESC LIMIT 1
+         ), 0) > 0;
+
+  -- 受影響的「待確認」訂單：明細數 / 訂單數 / 金額 before-after
+  -- （只算「單價真的會變」的明細與其所屬訂單，避免預覽數字灌水）
+  SELECT COUNT(DISTINCT co.id) FILTER (
+           WHERE coi.unit_price IS DISTINCT FROM rc.new_price),
+         COUNT(*) FILTER (
+           WHERE coi.unit_price IS DISTINCT FROM rc.new_price)
+    INTO v_orders, v_lines
+    FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+    JOIN LATERAL (
+      SELECT (SELECT pr.price FROM prices pr
+                WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+                  AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                ORDER BY pr.effective_from DESC LIMIT 1) AS new_price
+    ) rc ON TRUE
+    JOIN skus s ON s.id = coi.sku_id AND s.tenant_id = co.tenant_id AND s.status = 'active'
+   WHERE co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending';
+
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price), 0),
+    COALESCE(SUM(coi.qty * COALESCE(
+       CASE WHEN s.status = 'active' THEN
+         (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1)
+       END, coi.unit_price)), 0)
+    INTO v_amt_before, v_amt_after
+    FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+    JOIN skus s ON s.id = coi.sku_id AND s.tenant_id = co.tenant_id
+   WHERE co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending';
+
+  v_result := jsonb_build_object(
+    'dry_run',             p_dry_run,
+    'campaign_id',         p_campaign_id,
+    'campaign_no',         v_camp.campaign_no,
+    'campaign_status',     v_camp.status,
+    'name_before',         v_camp.name,
+    'name_after',          COALESCE(v_prod_name, v_camp.name),
+    'name_changed',        v_name_changed,
+    'items',               COALESCE(v_items_json, '[]'::jsonb),
+    'items_repriced',      v_items_repriced,
+    'skus_added',          v_skus_added,
+    'pending_orders',      v_orders,
+    'pending_order_lines', v_lines,
+    'amount_before',       v_amt_before,
+    'amount_after',        v_amt_after
+  );
+
+  IF p_dry_run THEN
+    RETURN v_result;
+  END IF;
+
+  -- ================= 實跑（單一交易，出錯全 rollback）=================
+
+  -- 1. 開團名稱
+  IF v_name_changed THEN
+    UPDATE group_buy_campaigns
+       SET name = v_prod_name, updated_at = NOW()
+     WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  END IF;
+
+  -- 2. campaign_items 重新定價（active SKU、價格有變者）
+  UPDATE campaign_items ci
+     SET unit_price = (SELECT pr.price FROM prices pr
+                         WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+                           AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                         ORDER BY pr.effective_from DESC LIMIT 1),
+         updated_at = NOW(),
+         updated_by = v_op
+    FROM skus s
+   WHERE ci.sku_id = s.id AND s.tenant_id = ci.tenant_id
+     AND ci.campaign_id = p_campaign_id AND ci.tenant_id = v_tenant
+     AND s.status = 'active'
+     AND ci.unit_price IS DISTINCT FROM (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1);
+
+  -- 3. 補缺漏 active SKU（有有效零售價者）
+  INSERT INTO campaign_items
+    (tenant_id, campaign_id, sku_id, unit_price, sort_order, created_by, updated_by)
+  SELECT v_tenant, p_campaign_id, s.id,
+         (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = s.id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1),
+         999, v_op, v_op
+    FROM skus s
+   WHERE v_camp.product_id IS NOT NULL
+     AND s.tenant_id  = v_tenant
+     AND s.product_id = v_camp.product_id
+     AND s.status     = 'active'
+     AND NOT EXISTS (SELECT 1 FROM campaign_items ci
+                      WHERE ci.campaign_id = p_campaign_id
+                        AND ci.tenant_id = v_tenant AND ci.sku_id = s.id)
+     AND COALESCE((SELECT pr.price FROM prices pr
+                    WHERE pr.tenant_id = v_tenant AND pr.sku_id = s.id
+                      AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                    ORDER BY pr.effective_from DESC LIMIT 1), 0) > 0
+  ON CONFLICT (campaign_id, sku_id) DO NOTHING;
+
+  -- 4a. 先寫稽核（讀 mutation 前的 before 值）
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  SELECT co.tenant_id, co.id, 'item', coi.id, 'unit_price',
+         to_jsonb(coi.unit_price),
+         to_jsonb((SELECT pr.price FROM prices pr
+                     WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+                       AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                     ORDER BY pr.effective_from DESC LIMIT 1)),
+         '開團「重新同步商品/價格」批次回填（待確認訂單）',
+         COALESCE(v_op, co.updated_by, co.created_by, v_camp.created_by)
+    FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+    JOIN skus s ON s.id = coi.sku_id AND s.tenant_id = co.tenant_id AND s.status = 'active'
+   WHERE co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending'
+     AND coi.unit_price IS DISTINCT FROM (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1);
+
+  -- 4b. 再回填待確認訂單明細單價
+  UPDATE customer_order_items coi
+     SET unit_price = (SELECT pr.price FROM prices pr
+                         WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+                           AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                         ORDER BY pr.effective_from DESC LIMIT 1),
+         updated_at = NOW(),
+         updated_by = v_op
+    FROM customer_orders co, skus s
+   WHERE coi.order_id = co.id
+     AND s.id = coi.sku_id AND s.tenant_id = co.tenant_id AND s.status = 'active'
+     AND co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending'
+     AND coi.unit_price IS DISTINCT FROM (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1);
+
+  RETURN v_result || jsonb_build_object('applied', TRUE);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION
+  public.rpc_resync_campaign_from_product(BIGINT, BOOLEAN, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_resync_campaign_from_product(BIGINT, BOOLEAN, UUID) IS
+  '開團重新同步：名稱←product、campaign_items 單價←現行零售價、補 active SKU、'
+  '回填 status=pending 訂單明細並寫 customer_order_audit_log。'
+  'draft/open 限定、HQ 限定、active SKU 缺有效零售價則拒跑、p_dry_run 預設只預覽。';


### PR DESCRIPTION
Closes #300

## 背景
開團 `open` 後 `campaign_items` 價格被 `locked_at` 鎖定、零售價變動不再自動 sync。忘記輸入售價時，訂單會以 `$0` 快照成立（例：GB20260518-C000098 的 5 筆「待確認」單），事後沒有 UI 可修正。本 PR 提供 HQ 一鍵重新同步入口。

## Summary
- **新 RPC** `rpc_resync_campaign_from_product(p_campaign_id, p_dry_run=true, p_operator=null)` — `SECURITY DEFINER`
  - HQ 限定（owner/admin/hq_manager/hq_accountant，role NULL 視同 admin）
  - **draft / open 開團限定**（已收單後 PR/PO 已快照、不給按）
  - 守門：任一 active SKU 解析現行零售價 ≤ 0 → `RAISE EXCEPTION` 拒跑（**絕不回填成 0**），dry-run 與實跑都擋
  - 行為：開團名稱←`products.name`、`campaign_items.unit_price`←現行零售價、補 product 缺漏的 active SKU、**本團 `status='pending'`（待確認）訂單明細單價一律改為現行零售價（即使原本非 0）**，每筆寫一列 `customer_order_audit_log`
  - confirmed / completed / cancelled 訂單不動；`p_dry_run=true` 只回傳預覽 JSON 不寫入
- **UI** `CampaignItemsTable`：加「重新同步商品/價格」按鈕（限 draft/open 顯示）→ 先 dry-run → 預覽 Modal（名稱、各 SKU old→new、待確認訂單金額 before→after、影響筆數）→ 確認才實跑 → `reload()` + 連動刷新訂單面板/列表
- `docs/TEST-campaign-resync.md` 測試清單

## 為什麼覆蓋非 0 的待確認單
依需求：待確認＝尚未成交，應一律對齊重新同步後的活動價；confirmed 之後才視為定價凍結。

## Test plan
- [ ] Supabase Studio（prod）套用 migration `20260620000010`
- [ ] 對 GB20260518-C000098 先 `p_dry_run=true` 看預覽，再實跑，確認 5 筆待確認單金額更新、已取消單不動、`customer_order_audit_log` 有紀錄
- [ ] 守門：無零售價 SKU → 拒跑且零寫入；非 draft/open → 拒跑；非 HQ → 拒絕
- [ ] 冪等：連跑兩次第二次 0 變更
- [ ] UI：draft/open 才出現按鈕、預覽→確認流程、SpinButton 純 spinner、確認後即時刷新
- [ ] 回歸：列表/編輯 Modal/CampaignForm/1-product invariant/加單快照不受影響

⚠️ 既有無關問題（非本 PR 範圍）：`apps/admin/src/lib/parseLeleMemberCsv.ts` 因 #217 缺 `papaparse`/`@types` 在本 worktree type-check 報錯。

🤖 Generated with [Claude Code](https://claude.com/claude-code)