### PR TITLE
fix(member/shop): 進詳情再返回真正不 reload（模組快取＋還原捲動）

### DIFF
--- a/apps/member/next.config.ts
+++ b/apps/member/next.config.ts
@@ -8,15 +8,6 @@ const withSerwist = withSerwistInit({
 
 const nextConfig: NextConfig = {
   images: { unoptimized: true },
-  // 進商品詳情頁再返回時，列表頁（/shop、/orders 等 client 端 fetch 的頁）
-  // 不要整頁重抓 + 捲動歸零。Next 15+ 把 client cache 的 staleTimes.dynamic
-  // 預設改成 0（一離開該頁 segment 就丟棄），返回時 component remount→
-  // useEffect 重抓→skeleton→scroll reset，就是使用者看到的「又 reload 一次」。
-  // 設成正值 → 返回時沿用 client cache 內「已渲染的頁面」（含 React state
-  // 與捲動位置），不再 reload。資料新鮮度交給下拉刷新 / 詳情頁自身 fetch。
-  experimental: {
-    staleTimes: { dynamic: 300, static: 300 },
-  },
   // 解決 Next.js 16+ Turbopack 與 Serwist (Webpack) 的衝突
   // 透過設定空物件來告訴 Next.js 即使有自定義 webpack 配置也要繼續建置
   // 在某些版本中這會讓建置退回到 Webpack，這對 Serwist 是必要的

--- a/apps/member/src/app/shop/page.tsx
+++ b/apps/member/src/app/shop/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession } from "@/lib/session";
@@ -10,37 +10,102 @@ import PullToRefresh from "@/components/PullToRefresh";
 import CampaignCard, { type CampaignSummary } from "@/components/CampaignCard";
 import Countdown from "@/components/Countdown";
 
+type SortKey = "new" | "hot" | "recent";
+
+/**
+ * 模組層快取：client 端 SPA 導航（/shop ↔ /shop/c/[id]）期間都存活，
+ * 「進詳情再返回」時列表瞬間還原（資料 + 排序 + 捲動位置）——不 remount
+ * 重抓、不閃 skeleton、不歸零。整頁 hard reload 才清空（屆時本就該抓新）。
+ *
+ * 為何不是 next.config 的 staleTimes：那只快取 server payload，不保留
+ * client 端 useState；返回仍會 remount→useEffect 重抓，治不了這個症狀。
+ */
+type ShopCache = {
+  campaigns: CampaignSummary[];
+  sortBy: SortKey;
+  scrollY: number;
+  ts: number;
+};
+let shopCache: ShopCache | null = null;
+// 返回時若資料已超過這個毫秒數，背景靜默重抓（不擋畫面、不動捲動）。
+const SHOP_REVALIDATE_MS = 60_000;
+
+// useLayoutEffect 在 SSR/prerender 會噪 warning；只有 client 端用它，
+// 才能在 paint 前還原捲動（避免先閃到頂端再跳）。
+const useIsoLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
 export default function ShopPage() {
   const router = useRouter();
-  const [campaigns, setCampaigns] = useState<CampaignSummary[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [campaigns, setCampaigns] = useState<CampaignSummary[]>(
+    () => shopCache?.campaigns ?? [],
+  );
+  const [loading, setLoading] = useState(() => shopCache == null);
   const [err, setErr] = useState<string | null>(null);
-  const [sortBy, setSortBy] = useState<"new" | "hot" | "recent">("new");
+  const [sortBy, setSortBy] = useState<SortKey>(
+    () => shopCache?.sortBy ?? "new",
+  );
 
-  const fetchCampaigns = useCallback(async () => {
-    const s = getSession();
-    if (!s || !s.memberId) {
-      router.replace("/");
-      return;
-    }
-    setErr(null);
-    try {
-      const d = await callLiffApi<{ campaigns: CampaignSummary[] }>(s.token, {
-        action: "list_active_campaigns",
-      });
-      setCampaigns(d.campaigns);
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e));
-    }
-  }, [router]);
+  const fetchCampaigns = useCallback(
+    async (silent = false) => {
+      const s = getSession();
+      if (!s || !s.memberId) {
+        router.replace("/");
+        return;
+      }
+      if (!silent) setErr(null);
+      try {
+        const d = await callLiffApi<{ campaigns: CampaignSummary[] }>(s.token, {
+          action: "list_active_campaigns",
+        });
+        setCampaigns(d.campaigns);
+        shopCache = {
+          campaigns: d.campaigns,
+          sortBy: shopCache?.sortBy ?? "new",
+          scrollY: shopCache?.scrollY ?? 0,
+          ts: Date.now(),
+        };
+      } catch (e) {
+        // 背景重抓失敗時不蓋掉已顯示的快取內容
+        if (!silent) setErr(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [router],
+  );
 
+  // 首次進站才抓 + 顯示 skeleton；從詳情返回時用快取瞬間還原，
+  // 只有資料偏舊才背景靜默更新。
   useEffect(() => {
     consumeFragmentToSession();
-    (async () => {
-      await fetchCampaigns();
-      setLoading(false);
-    })();
+    if (shopCache == null) {
+      (async () => {
+        await fetchCampaigns();
+        setLoading(false);
+      })();
+    } else if (Date.now() - shopCache.ts > SHOP_REVALIDATE_MS) {
+      void fetchCampaigns(true);
+    }
   }, [fetchCampaigns]);
+
+  // 返回時把捲動位置還原到離開前（paint 前做，無閃動）。
+  useIsoLayoutEffect(() => {
+    if (shopCache && shopCache.campaigns.length > 0) {
+      window.scrollTo(0, shopCache.scrollY);
+    }
+  }, []);
+
+  // 持續記錄捲動位置與排序，供下次返回還原。
+  useEffect(() => {
+    const onScroll = () => {
+      if (shopCache) shopCache.scrollY = window.scrollY;
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  useEffect(() => {
+    if (shopCache) shopCache.sortBy = sortBy;
+  }, [sortBy]);
 
   // 前端防線：擋掉內部 sentinel 活動（campaign_no 以 __ 開頭，如
   // __INTERNAL_RESTOCK__「【內部】補貨申請」）。後端 liff-api 也有濾，


### PR DESCRIPTION
## 為何需要這個（#298 修錯了）
#298 設了 `next.config` 的 `experimental.staleTimes`，但使用者回報「**還是會 reload 回到最頂部**」。原因：`staleTimes` 只快取 **server payload**，不保留 client 端 `useState`。`/shop` 是 `"use client"`、在 `useEffect` 抓資料存 `useState` 的頁；返回（history pop）時 Next 仍會 **remount** 這個 component → `useState` 重置 → `useEffect` 重抓 → skeleton + 捲動歸零。Router cache 治不了 client state。

## 這次的修法（對症、且不依賴 Next router 內部行為）
**1. 還原 #298**：移除 `experimental.staleTimes`。它無效，又讓全站 forward 導航資料多 5 分鐘舊、無正當理由。

**2. `apps/member/src/app/shop/page.tsx` 模組層快取**：
- 把 `campaigns` + `sortBy` + `scrollY` + `ts` 存進模組層變數（client SPA 導航 `/shop ↔ /shop/c/[id]` 期間同一 JS context，必然存活）。
- `useState` 由快取**同步初始化** → 返回時第一個 render 就是完整列表（高度正確）、`loading` 初值為 false → **不閃 skeleton、不重抓**。
- `useLayoutEffect`（client-only，paint 前）`window.scrollTo(0, scrollY)` → **不歸零**，停在離開前的位置。已確認 `/shop` 捲動在 `window`（見 `PullToRefresh` 用 `window.scrollY`），卡片用 CSS aspect-ratio 固定高，圖未載入也不影響還原精度。
- 逾 `60s` 才**背景靜默重抓**（不擋畫面、不動捲動）；下拉刷新仍即時更新；背景重抓失敗不蓋掉已顯示內容。

不依賴 staleTimes / Next 的 scroll restoration —— 由我們自己持有資料與捲動並還原，**by construction** 成立。整頁 hard reload 才清空快取（屆時本就該抓新）。

## 範圍
僅 `/shop`（使用者回報的瀏覽商品流程）。`/orders` 等同樣 pattern，可比照後續處理，本 PR 不擴大範圍。

## Test plan
- [x] `npm run build`（member）：通過、TypeScript / ESLint clean、14 route 全產出
- [ ] 實機（LINE webview / 加主畫面 PWA）：/shop 捲到中段 → 進某商品詳情 → 返回 → **無 skeleton、停在原捲動位置**
- [ ] 連續進不同商品再返回多次仍保持；切換排序後進詳情返回，排序與位置都在
- [ ] 下拉刷新照常抓最新；於詳情頁下單返回，逾 60s 會背景靜默更新數字
- [ ] 首次冷啟動（無快取）仍正常顯示 skeleton → 列表

> 沙箱無法跑 LIFF/PWA，實機體感留使用者自審。若仍 reload 到頂，代表 LINE webview 對返回是「整份文件重載」（另一種根因），下一步改用 sessionStorage 承載快取。

🤖 Generated with [Claude Code](https://claude.com/claude-code)