### PR TITLE
feat(admin/members): 已綁 LINE 會員列表顯示 LINE icon

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -31,6 +31,7 @@ type MemberRow = {
   last_visit_at: string | null;
   external_source: string | null;
   external_id: string | null;
+  line_user_id: string | null;
   home_store_id: number | null;
   takeout_store_name_hint: string | null;
 };
@@ -136,7 +137,7 @@ function MembersListBody() {
       try {
         let q = getSupabase()
           .from("members")
-          .select("id, member_no, name, phone, avatar_url, tier_id, status, updated_at, joined_at, last_visit_at, external_source, external_id, home_store_id, takeout_store_name_hint", { count: "exact" })
+          .select("id, member_no, name, phone, avatar_url, tier_id, status, updated_at, joined_at, last_visit_at, external_source, external_id, line_user_id, home_store_id, takeout_store_name_hint", { count: "exact" })
           .order(sortBy, { ascending: sortDir === "asc" })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 
@@ -369,6 +370,22 @@ function MembersListBody() {
                           className="text-[12px] leading-none"
                         >
                           🔔
+                        </span>
+                      )}
+                      {r.line_user_id && (
+                        <span
+                          title="已綁定 LINE"
+                          aria-label="已綁定 LINE"
+                          className="inline-flex shrink-0 leading-none"
+                        >
+                          <svg
+                            viewBox="0 0 24 24"
+                            className="h-4 w-4"
+                            fill="#06C755"
+                            aria-hidden
+                          >
+                            <path d="M12 2C6.486 2 2 5.65 2 10.137c0 4.022 3.558 7.39 8.363 8.026.326.07.769.215.881.494.101.252.066.646.032.901 0 0-.117.705-.142.853-.043.252-.2.986.864.538 1.064-.449 5.74-3.38 7.831-5.787C21.276 13.49 22 11.91 22 10.137 22 5.65 17.514 2 12 2z" />
+                          </svg>
                         </span>
                       )}
                     </div>

--- a/docs/TEST-member-line-icon.md
+++ b/docs/TEST-member-line-icon.md
@@ -1,0 +1,55 @@
+# member-line-icon 測試項目 — 後台會員列表已綁 LINE 顯示 icon
+
+**對應 UI 變更:** `apps/admin/src/app/(protected)/members/page.tsx`
+**判斷依據:** `members.line_user_id` 非空（與 `apps/admin/src/components/MemberDetail.tsx:255` `hasLine = !!member.line_user_id` 一致）
+**無 migration / 無 RPC：** §1、§2 不適用（純前端顯示，沿用既有 `members` select 加 `line_user_id` 欄）
+
+## 0. 資料前置（read-only sanity）
+
+- [ ] `members` 表存在 `line_user_id` 欄
+  ```sql
+  select column_name from information_schema.columns
+  where table_name='members' and column_name='line_user_id';
+  ```
+- [ ] 至少有 1 筆 `line_user_id` 非空、且 1 筆為空的會員，icon 有/無兩態才可測
+  ```sql
+  select
+    count(*) filter (where line_user_id is not null) as bound,
+    count(*) filter (where line_user_id is null)     as unbound
+  from members where status not in ('merged','deleted');
+  ```
+
+## 3. UI 行為（preview / 碼審）
+
+### 3.1 列表載入
+- [ ] `/members` 載入無 console error
+- [ ] `members` select 已含 `line_user_id`，列表筆數 / 分頁數不變（與改動前一致）
+
+### 3.2 已綁 LINE 會員
+- [ ] `line_user_id` 非空的會員，姓名列顯示 LINE icon（綠底官方色）
+- [ ] icon 位於姓名旁，與既有「樂樂」badge、🔔 push icon 並排，排版不換行、不擠壓
+
+### 3.3 未綁 LINE 會員
+- [ ] `line_user_id` 為空的會員，**不**顯示 LINE icon
+
+### 3.4 安全（呼應「LINE User ID 一律馬賽克」記憶）
+- [ ] icon 不渲染 LINE User ID 本身；DOM / title / aria-label 皆不得出現原始 `Uxxxx...` 字串
+- [ ] icon 有可存取名稱（aria-label，如「已綁定 LINE」），但內容不含 ID
+
+### 3.5 互動不受影響
+- [ ] 點該列仍可開「會員明細」modal
+- [ ] 「編輯」「🔎 查訂單」按鈕仍正常、`stopPropagation` 未被破壞
+
+## 4. Regression
+
+- [ ] 搜尋（會員編號 / 姓名 / 手機）仍正常
+- [ ] 門市篩選、排序（各欄）、分頁仍正常
+- [ ] 「顯示已合併 / 已刪除」勾選仍正常
+- [ ] `?id=N` 直接開 detail modal 仍正常
+- [ ] 訂單數 / 未取貨金額 / 儲值 / 🔔 push icon / 樂樂 badge 全部不受影響（新增欄位未動既有資料流）
+- [ ] `MemberDetail` 的 LINE User ID 顯示仍為馬賽克（未被本次改動波及）
+
+## 5. 驗收門檻
+
+§0 資料前置確認、§3-§4 全勾、**無 console error**、**build + type-check 過** 才可標 done。
+（本功能無 migration，Supabase dev push 不適用。）


### PR DESCRIPTION
## Summary
- 後台會員列表（`/members`）在「姓名」欄、已綁定 LINE 的會員旁顯示一個官方綠（#06C755）LINE icon
- 判斷依據：`members.line_user_id` 非空，與 `MemberDetail.tsx` 的 `hasLine = !!member.line_user_id` 一致
- 僅顯示 icon，**不渲染 LINE User ID 本身**（title/aria-label 為「已綁定 LINE」，無 ID）；沿用既有 members select 多取 `line_user_id` 欄
- icon 與既有「樂樂」badge、🔔 push icon 並排，push icon 原樣保留

## 驗證
- ✅ `tsc --noEmit`（apps/admin）通過
- ✅ `npm run build`（admin workspace）通過，全路由靜態預渲染成功
- 測試清單：`docs/TEST-member-line-icon.md`（無 migration / 無 RPC，§1/§2 不適用）
- ⚠️ Admin live-preview 於沙箱被網路阻擋，UI 互動 / console 無錯 / 有無兩態請於本機自審（見測試文件 §3-§4）

## Test plan
- [ ] 已綁 LINE 會員姓名旁出現綠色 LINE icon
- [ ] 未綁 LINE 會員不顯示 icon
- [ ] DOM / title / aria-label 不含原始 `Uxxxx...` LINE User ID
- [ ] 搜尋 / 篩選 / 排序 / 分頁 / detail modal / 編輯 不受影響
- [ ] 🔔 push icon、樂樂 badge 仍正常並存

🤖 Generated with [Claude Code](https://claude.com/claude-code)