### PR TITLE
feat(admin/members): 狀態改用文字 tag + 移除列表「編號」欄

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -15,7 +15,7 @@ import type { OrderStatus } from "@/lib/orderStatus";
 const PENDING_STATUSES: OrderStatus[] = ["pending", "confirmed", "shipping", "ready"];
 
 type Status = "active" | "inactive" | "blocked" | "merged" | "deleted";
-type SortKey = "updated_at" | "member_no" | "name" | "home_store_id" | "joined_at" | "last_visit_at" | "external_source";
+type SortKey = "updated_at" | "name" | "home_store_id" | "joined_at" | "last_visit_at" | "external_source";
 type SortDir = "asc" | "desc";
 
 type MemberRow = {
@@ -301,7 +301,6 @@ function MembersListBody() {
 
       <Table>
         <THead>
-          <ThSort label="編號" col="member_no" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
           <ThSort label="姓名" col="name" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
           <ThSort label="取貨店" col="home_store_id" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
           <Th>手機</Th>
@@ -315,9 +314,9 @@ function MembersListBody() {
         </THead>
         <TBody>
           {rows === null ? (
-            <SkeletonRows cols={11} />
+            <SkeletonRows cols={10} />
           ) : rows.length === 0 ? (
-            <EmptyRow colSpan={11}>
+            <EmptyRow colSpan={10}>
               {total === 0 && !query ? "還沒有會員，按「新增會員」開始建立。" : "沒有符合條件的會員。"}
             </EmptyRow>
           ) : (
@@ -330,20 +329,6 @@ function MembersListBody() {
                   onClick={() => setModal({ mode: "detail", memberId: r.id, memberNo: r.member_no })}
                   className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
                 >
-                  <Td className="font-mono">
-                    <SpinButton
-                      onClick={() => setModal({ mode: "detail", memberId: r.id, memberNo: r.member_no })}
-                      className={r.status === "merged" || r.status === "deleted" ? "text-zinc-400 hover:underline" : "hover:underline"}
-                    >
-                      {r.member_no}
-                    </SpinButton>
-                    {r.status === "merged" && (
-                      <span className="ml-2 rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-normal text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">已合併</span>
-                    )}
-                    {r.status === "deleted" && (
-                      <span className="ml-2 rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-normal text-red-700 dark:bg-red-950 dark:text-red-300">已刪除</span>
-                    )}
-                  </Td>
                   <Td>
                     <div className="flex items-center gap-2">
                       {r.avatar_url ? (
@@ -354,39 +339,38 @@ function MembersListBody() {
                           {r.name?.[0] ?? "?"}
                         </div>
                       )}
-                      <span>{r.name ?? "—"}</span>
+                      <span className={r.status === "merged" || r.status === "deleted" ? "text-zinc-400" : ""}>
+                        {r.name ?? "—"}
+                      </span>
                       {r.external_source === "lele" && (
                         <span
                           title={r.external_id ? `樂樂顧客代號 ${r.external_id}` : "樂樂匯入"}
-                          className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-normal text-amber-700 dark:bg-amber-950 dark:text-amber-300"
+                          className="whitespace-nowrap rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-normal text-amber-700 dark:bg-amber-950 dark:text-amber-300"
                         >
                           樂樂
-                        </span>
-                      )}
-                      {pushSet.has(r.id) && (
-                        <span
-                          title="已安裝 App 並開啟通知"
-                          aria-label="已安裝 App 並開啟通知"
-                          className="text-[12px] leading-none"
-                        >
-                          🔔
                         </span>
                       )}
                       {r.line_user_id && (
                         <span
                           title="已綁定 LINE"
-                          aria-label="已綁定 LINE"
-                          className="inline-flex shrink-0 leading-none"
+                          className="whitespace-nowrap rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-normal text-green-700 dark:bg-green-950 dark:text-green-300"
                         >
-                          <svg
-                            viewBox="0 0 24 24"
-                            className="h-4 w-4"
-                            fill="#06C755"
-                            aria-hidden
-                          >
-                            <path d="M12 2C6.486 2 2 5.65 2 10.137c0 4.022 3.558 7.39 8.363 8.026.326.07.769.215.881.494.101.252.066.646.032.901 0 0-.117.705-.142.853-.043.252-.2.986.864.538 1.064-.449 5.74-3.38 7.831-5.787C21.276 13.49 22 11.91 22 10.137 22 5.65 17.514 2 12 2z" />
-                          </svg>
+                          LINE
                         </span>
+                      )}
+                      {pushSet.has(r.id) && (
+                        <span
+                          title="已安裝 App 並開啟通知"
+                          className="whitespace-nowrap rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-normal text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+                        >
+                          通知
+                        </span>
+                      )}
+                      {r.status === "merged" && (
+                        <span className="whitespace-nowrap rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-normal text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">已合併</span>
+                      )}
+                      {r.status === "deleted" && (
+                        <span className="whitespace-nowrap rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-normal text-red-700 dark:bg-red-950 dark:text-red-300">已刪除</span>
                       )}
                     </div>
                   </Td>

--- a/docs/TEST-member-line-icon.md
+++ b/docs/TEST-member-line-icon.md
@@ -1,55 +1,48 @@
-# member-line-icon 測試項目 — 後台會員列表已綁 LINE 顯示 icon
+# member-status-tags 測試項目 — 後台會員列表狀態用文字 tag + 移除「編號」欄
 
 **對應 UI 變更:** `apps/admin/src/app/(protected)/members/page.tsx`
-**判斷依據:** `members.line_user_id` 非空（與 `apps/admin/src/components/MemberDetail.tsx:255` `hasLine = !!member.line_user_id` 一致）
-**無 migration / 無 RPC：** §1、§2 不適用（純前端顯示，沿用既有 `members` select 加 `line_user_id` 欄）
+**設計演進:** 原 #302 的 LINE icon（SVG）改為文字 tag；🔔 push emoji 改為「通知」tag；列表移除「編號」欄
+**判斷依據:** LINE = `members.line_user_id` 非空（與 `MemberDetail.tsx` `hasLine` 一致）；通知 = `rpc_members_with_push`
+**無 migration / 無 RPC：** §1、§2 不適用（純前端顯示）
 
 ## 0. 資料前置（read-only sanity）
 
-- [ ] `members` 表存在 `line_user_id` 欄
-  ```sql
-  select column_name from information_schema.columns
-  where table_name='members' and column_name='line_user_id';
-  ```
-- [ ] 至少有 1 筆 `line_user_id` 非空、且 1 筆為空的會員，icon 有/無兩態才可測
-  ```sql
-  select
-    count(*) filter (where line_user_id is not null) as bound,
-    count(*) filter (where line_user_id is null)     as unbound
-  from members where status not in ('merged','deleted');
-  ```
+- [ ] 至少 1 筆 `line_user_id` 非空、1 筆為空 → LINE tag 有/無兩態可測
+- [ ] 至少 1 筆有 web push 訂閱 → 通知 tag 可測
+- [ ] 視需要 1 筆 `status='merged'`、1 筆 `'deleted'` → 驗證標籤搬遷後仍正確
 
 ## 3. UI 行為（preview / 碼審）
 
 ### 3.1 列表載入
 - [ ] `/members` 載入無 console error
-- [ ] `members` select 已含 `line_user_id`，列表筆數 / 分頁數不變（與改動前一致）
+- [ ] 表頭欄位為：姓名 / 取貨店 / 手機 / 訂單數 / 未取貨金額 / 儲值 / 加入時間 / 最後登入 / 更新 /（操作）—— **無「編號」欄**
+- [ ] 每列 `<Td>` 數 = 表頭欄數 = 10；骨架列 / 空狀態 colSpan = 10（不錯位）
 
-### 3.2 已綁 LINE 會員
-- [ ] `line_user_id` 非空的會員，姓名列顯示 LINE icon（綠底官方色）
-- [ ] icon 位於姓名旁，與既有「樂樂」badge、🔔 push icon 並排，排版不換行、不擠壓
+### 3.2 狀態以文字 tag 呈現（非 icon / emoji）
+- [ ] 已綁 LINE：姓名旁顯示綠色「LINE」tag；未綁不顯示
+- [ ] 已開啟通知：顯示藍色「通知」tag（hover title「已安裝 App 並開啟通知」）；無訂閱不顯示
+- [ ] 既有「樂樂」amber tag 不受影響
+- [ ] 不再出現 LINE SVG icon、不再出現 🔔 emoji
+- [ ] tag 不換行（whitespace-nowrap），多 tag 並排不擠壓姓名
 
-### 3.3 未綁 LINE 會員
-- [ ] `line_user_id` 為空的會員，**不**顯示 LINE icon
+### 3.3 編號欄移除後的連帶
+- [ ] `已合併` / `已刪除` 標籤改顯示在姓名列（原在編號欄），顏色不變、語意不變
+- [ ] merged/deleted 會員姓名以灰字（text-zinc-400）呈現
+- [ ] 點該列仍可開「會員明細」modal（列 onClick 仍在）
+- [ ] modal 標題仍顯示 `#會員編號`（member_no 仍存在資料層）
+- [ ] 「編輯」「🔎 查訂單」按鈕仍正常（`?q=<member_no>` 連結未壞、`stopPropagation` 正常）
 
-### 3.4 安全（呼應「LINE User ID 一律馬賽克」記憶）
-- [ ] icon 不渲染 LINE User ID 本身；DOM / title / aria-label 皆不得出現原始 `Uxxxx...` 字串
-- [ ] icon 有可存取名稱（aria-label，如「已綁定 LINE」），但內容不含 ID
-
-### 3.5 互動不受影響
-- [ ] 點該列仍可開「會員明細」modal
-- [ ] 「編輯」「🔎 查訂單」按鈕仍正常、`stopPropagation` 未被破壞
+### 3.4 安全（「LINE User ID 一律馬賽克」記憶）
+- [ ] LINE tag 不含原始 `Uxxxx...`；DOM / title 皆無 LINE User ID
 
 ## 4. Regression
-
-- [ ] 搜尋（會員編號 / 姓名 / 手機）仍正常
-- [ ] 門市篩選、排序（各欄）、分頁仍正常
+- [ ] 搜尋（會員編號 / 姓名 / 手機）仍正常 —— 編號雖不顯示，搜尋條件保留
+- [ ] 門市篩選、排序（姓名/取貨店/加入/最後登入/更新）、分頁仍正常；排序不再有「編號」選項
 - [ ] 「顯示已合併 / 已刪除」勾選仍正常
 - [ ] `?id=N` 直接開 detail modal 仍正常
-- [ ] 訂單數 / 未取貨金額 / 儲值 / 🔔 push icon / 樂樂 badge 全部不受影響（新增欄位未動既有資料流）
-- [ ] `MemberDetail` 的 LINE User ID 顯示仍為馬賽克（未被本次改動波及）
+- [ ] 訂單數 / 未取貨金額 / 儲值 不受影響
+- [ ] `MemberDetail` LINE User ID 仍為馬賽克（未被本次波及）
 
 ## 5. 驗收門檻
-
-§0 資料前置確認、§3-§4 全勾、**無 console error**、**build + type-check 過** 才可標 done。
+§0 確認、§3-§4 全勾、**無 console error**、**build + type-check 過** 才可標 done。
 （本功能無 migration，Supabase dev push 不適用。）


### PR DESCRIPTION
依使用者回饋（icon「有點難看」）：把 #302 的 LINE SVG icon 與 🔔 push emoji 改成文字 pill tag，並移除會員列表「編號」欄。

## Summary
- **LINE 綁定**：綠色「LINE」tag（取代原 SVG icon）
- **已開啟通知**：藍色「通知」tag（取代 🔔 emoji，hover title「已安裝 App 並開啟通知」）
- 沿用既有「樂樂」amber pill 樣式，僅換色（green / blue / zinc / red）
- **移除「編號」欄**：`已合併`/`已刪除` 標籤改掛在姓名列、merged/deleted 姓名灰字；`member_no` 仍保留在資料層（搜尋 / 編輯 / `?q=` 連結 / modal 標題不受影響）
- 表頭與每列同步調整為 10 欄（骨架 / 空狀態 colSpan=10）
- 不再渲染 LINE User ID 本身（title 僅「已綁定 LINE」）— 符合馬賽克規範

## 驗證
- ✅ `tsc --noEmit`（apps/admin）通過
- ✅ `npm run build`（admin workspace）通過，全路由靜態預渲染
- 測試清單：`docs/TEST-member-line-icon.md`（已更新為 tag + 移欄版；無 migration/RPC）
- ⚠️ Admin live-preview 沙箱被網路阻擋；UI 兩態 / console 無錯請本機自審（測試文件 §3-§4）

## Test plan
- [ ] 已綁 LINE → 綠「LINE」tag；未綁不顯示
- [ ] 有推播訂閱 → 藍「通知」tag；無則不顯示
- [ ] 無「編號」欄；已合併/已刪除 標籤在姓名列、姓名灰字
- [ ] 點列開明細、編輯、🔎查訂單、搜尋（含會員編號）、排序、分頁皆正常
- [ ] DOM/title 不含原始 LINE User ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)