### PR TITLE
feat(admin/members): LINE/通知 tag 移到 avatar 前

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -331,6 +331,24 @@ function MembersListBody() {
                 >
                   <Td>
                     <div className="flex items-center gap-2">
+                      <span className="flex w-12 shrink-0 flex-col items-end gap-0.5">
+                        {r.line_user_id && (
+                          <span
+                            title="已綁定 LINE"
+                            className="whitespace-nowrap rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-normal text-green-700 dark:bg-green-950 dark:text-green-300"
+                          >
+                            LINE
+                          </span>
+                        )}
+                        {pushSet.has(r.id) && (
+                          <span
+                            title="已安裝 App 並開啟通知"
+                            className="whitespace-nowrap rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-normal text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+                          >
+                            通知
+                          </span>
+                        )}
+                      </span>
                       {r.avatar_url ? (
                         // eslint-disable-next-line @next/next/no-img-element
                         <img src={r.avatar_url} alt="" className="h-7 w-7 rounded-full object-cover" />
@@ -348,22 +366,6 @@ function MembersListBody() {
                           className="whitespace-nowrap rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-normal text-amber-700 dark:bg-amber-950 dark:text-amber-300"
                         >
                           樂樂
-                        </span>
-                      )}
-                      {r.line_user_id && (
-                        <span
-                          title="已綁定 LINE"
-                          className="whitespace-nowrap rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-normal text-green-700 dark:bg-green-950 dark:text-green-300"
-                        >
-                          LINE
-                        </span>
-                      )}
-                      {pushSet.has(r.id) && (
-                        <span
-                          title="已安裝 App 並開啟通知"
-                          className="whitespace-nowrap rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-normal text-blue-700 dark:bg-blue-950 dark:text-blue-300"
-                        >
-                          通知
                         </span>
                       )}
                       {r.status === "merged" && (

--- a/docs/TEST-member-line-icon.md
+++ b/docs/TEST-member-line-icon.md
@@ -18,12 +18,14 @@
 - [ ] 表頭欄位為：姓名 / 取貨店 / 手機 / 訂單數 / 未取貨金額 / 儲值 / 加入時間 / 最後登入 / 更新 /（操作）—— **無「編號」欄**
 - [ ] 每列 `<Td>` 數 = 表頭欄數 = 10；骨架列 / 空狀態 colSpan = 10（不錯位）
 
-### 3.2 狀態以文字 tag 呈現（非 icon / emoji）
-- [ ] 已綁 LINE：姓名旁顯示綠色「LINE」tag；未綁不顯示
-- [ ] 已開啟通知：顯示藍色「通知」tag（hover title「已安裝 App 並開啟通知」）；無訂閱不顯示
-- [ ] 既有「樂樂」amber tag 不受影響
-- [ ] 不再出現 LINE SVG icon、不再出現 🔔 emoji
-- [ ] tag 不換行（whitespace-nowrap），多 tag 並排不擠壓姓名
+### 3.2 狀態以文字 tag 呈現（非 icon / emoji），位置在 avatar 前
+- [ ] LINE / 通知 tag 位於 **avatar 左側**（固定寬度 gutter，w-12 右對齊垂直堆疊）
+- [ ] 跨列 avatar 對齊：有/無/單一 tag 的列，avatar 起始 x 一致（不參差）
+- [ ] 已綁 LINE：顯示綠色「LINE」tag；未綁不顯示
+- [ ] 已開啟通知：藍色「通知」tag（hover title「已安裝 App 並開啟通知」）；無訂閱不顯示
+- [ ] 既有「樂樂」amber tag 維持在姓名後、不受影響
+- [ ] 不再出現 LINE SVG icon、不再出現 🔔 emoji；**未新增 checkbox 欄**
+- [ ] tag 不換行（whitespace-nowrap）
 
 ### 3.3 編號欄移除後的連帶
 - [ ] `已合併` / `已刪除` 標籤改顯示在姓名列（原在編號欄），顏色不變、語意不變


### PR DESCRIPTION
依使用者回饋（參照 lt-erp 會員列表觀感）：把 #304 的 LINE / 通知 文字 tag 從「姓名後」移到「avatar 前」。

## Summary
- LINE / 通知 tag 放進 avatar 左側的固定寬度 gutter（`w-12`、右對齊、垂直堆疊）
- 有/無/單一 tag 的列，avatar 起始位置一致（跨列對齊，不參差）
- 維持文字 tag 樣式（沿用既有 amber「樂樂」pill 規格，只換色）；**未新增 checkbox 欄**
- 樂樂 / 已合併 / 已刪除 維持在姓名後，不變
- 純位置調整：資料流、搜尋、排序、欄數（10）皆不變

## 驗證
- ✅ `tsc --noEmit`（apps/admin）通過
- ✅ `npm run build`（admin workspace）通過，全路由靜態預渲染
- 測試清單 `docs/TEST-member-line-icon.md` 已更新（§3.2 改為 avatar 前 + 對齊驗證）
- ⚠️ Admin live-preview 沙箱被阻擋；tag 位置 / avatar 對齊 / 兩態請本機自審

## Test plan
- [ ] LINE / 通知 tag 在 avatar 左側固定欄
- [ ] 跨列 avatar 對齊（有/無 tag 都一致）
- [ ] 已綁/未綁、有/無推播 兩態正確
- [ ] 樂樂 / 已合併 / 已刪除 仍在姓名後、樣式不變
- [ ] 點列開明細、編輯、查訂單、搜尋、排序、分頁皆正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)