### PR TITLE
feat(admin/community-candidates): 已採用項目可勾選重新排程到週曆

### DIFF
--- a/apps/admin/src/app/(protected)/community-candidates/page.tsx
+++ b/apps/admin/src/app/(protected)/community-candidates/page.tsx
@@ -68,8 +68,7 @@ export default function CommunityCandidatesPage() {
 
   const highlightRowRef = useRef<HTMLElement | null>(null);
 
-  const isSelectable = (r: Candidate) =>
-    r.owner_action !== "scheduled" && r.owner_action !== "adopted";
+  const isSelectable = (r: Candidate) => r.owner_action !== "scheduled";
 
   const toggleOne = (id: number) =>
     setSelected((prev) => {
@@ -252,7 +251,7 @@ export default function CommunityCandidatesPage() {
       return r && isSelectable(r);
     });
     if (ids.length === 0) {
-      setError("沒有可排程的候選（已排程或已採用的會略過）");
+      setError("沒有可排程的候選（已排程的會略過）");
       return;
     }
     setBusy(true);
@@ -503,7 +502,7 @@ export default function CommunityCandidatesPage() {
             收藏
           </SpinButton>
         )}
-        {r.owner_action !== "scheduled" && r.owner_action !== "adopted" && (
+        {r.owner_action !== "scheduled" && (
           <SpinButton
             onClick={() => {
               setScheduling(r.id);
@@ -702,7 +701,7 @@ export default function CommunityCandidatesPage() {
                       disabled={!isSelectable(r)}
                       onChange={() => toggleOne(r.id)}
                       className="h-4 w-4 cursor-pointer disabled:cursor-not-allowed disabled:opacity-30"
-                      title={isSelectable(r) ? "選取" : "已排程或已採用,不可批次排程"}
+                      title={isSelectable(r) ? "選取" : "已排程,不可重複排程"}
                     />
                   </td>
                   <td className="whitespace-nowrap px-3 py-3 text-zinc-500">{fmt(r.created_at)}</td>
@@ -792,7 +791,7 @@ export default function CommunityCandidatesPage() {
                   ) : (
                     <span
                       className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-medium ${ACTION_COLOR[r.owner_action] ?? ACTION_COLOR.none}`}
-                      title="已排程或已採用，不可批次排程"
+                      title="已排程，不可重複排程"
                     >
                       {ACTION_LABEL[r.owner_action] ?? r.owner_action}
                     </span>


### PR DESCRIPTION
## Summary
- 選品候選池中「已採用」狀態的項目原本無法被勾選，無法批次或單筆排程到週曆，造成只要採用過就「卡住」
- 放寬 `isSelectable`：只排除 `scheduled`，「已採用」也能勾選 / 點「排日期」
- 後端 RPC `rpc_schedule_candidate` 本就會在 candidate 已有 `adopted_product_id` 時沿用既有 product/SKU，搭配採用時填入的廠商／成本／售價來建 draft campaign，所以不會重複建立資料

## Changes
- `apps/admin/src/app/(protected)/community-candidates/page.tsx`
  - `isSelectable` 由「排除 scheduled + adopted」→「只排除 scheduled」
  - 單筆「排日期」按鈕對 `adopted` 項目也顯示
  - checkbox / 批次排程提示文案改為「已排程，不可重複排程」

## Test plan
- [ ] 將候選項目「採用」後，桌機表格的 checkbox 變為可勾選
- [ ] 手機卡片版「採用」項目顯示「選取」label 與 checkbox
- [ ] 勾選多筆「已採用」+ 設批次日期 → 全部進入週曆，且不重複建 product/SKU
- [ ] 單筆按「排日期」對已採用項目可正常選日期送出
- [ ] 「已排程」項目仍維持不可勾選、無「排日期」鈕

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3y8guQqBisy2uXvRD5sdC)_