### PR TITLE
feat(admin/campaigns): 同步上架 FB 粉絲團 v1

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -8,3 +8,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=<from Supabase dashboard → Project Settings → 
 # e.g. /new_erp (when deployed to www161616.github.io/new_erp/)
 # Leave empty for root deploy / custom domain.
 NEXT_PUBLIC_BASE_PATH=
+
+# 會員端 shop 的對外網址，用於同步 FB 粉絲團時把 /shop/c/{id} 拼進貼文
+# 末尾不要加斜線；未設定時預設 https://shop.lt-foods.tw
+NEXT_PUBLIC_MEMBER_APP_URL=https://shop.lt-foods.tw

--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -13,6 +13,7 @@ import SpinButton from "@/components/SpinButton";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 import { CampaignThumb } from "@/components/CampaignThumb";
 import { campaignCoverUrl, type CampaignCoverItem } from "@/lib/campaignCover";
+import FbPublishModal from "@/components/FbPublishModal";
 
 // 共用: chunked fetch — bypass PostgREST max-rows 1000 cap
 // builder: 回 fresh query builder 的 factory (因為 .range() 後不能 reuse)
@@ -112,6 +113,7 @@ export default function CampaignsListPage() {
   const [modal, setModal] = useState<{ mode: "edit"; values: CampaignFormValues } | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
   const [resyncTick, setResyncTick] = useState(0);
+  const [fbPublishId, setFbPublishId] = useState<number | null>(null);
   const [closingId, setClosingId] = useState<number | null>(null);
   const [finalizingId, setFinalizingId] = useState<number | null>(null);
 
@@ -486,6 +488,14 @@ export default function CampaignsListPage() {
           className="text-xs text-amber-600 hover:underline disabled:opacity-50 dark:text-amber-400"
         >
           {closingId === r.id ? "結單中…" : "結單"}
+        </SpinButton>
+      )}
+      {(["open", "closed", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
+        <SpinButton
+          onClick={() => setFbPublishId(r.id)}
+          className="text-xs text-sky-600 hover:underline dark:text-sky-400"
+        >
+          發 FB
         </SpinButton>
       )}
       {(["closed", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
@@ -901,6 +911,12 @@ export default function CampaignsListPage() {
           <PagerBtn disabled={page === totalPages} onClick={() => setPage(totalPages)}>最末頁 »</PagerBtn>
         </div>
       )}
+
+      <FbPublishModal
+        open={fbPublishId !== null}
+        campaignId={fbPublishId}
+        onClose={() => setFbPublishId(null)}
+      />
     </div>
   );
 }

--- a/apps/admin/src/components/FbPublishModal.tsx
+++ b/apps/admin/src/components/FbPublishModal.tsx
@@ -1,0 +1,453 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Modal } from "@/components/Modal";
+import SpinButton from "@/components/SpinButton";
+import { getSupabase } from "@/lib/supabase";
+
+const PRODUCTS_BUCKET = "products";
+const MEMBER_APP_URL = (process.env.NEXT_PUBLIC_MEMBER_APP_URL ?? "https://shop.lt-foods.tw").replace(/\/$/, "");
+
+type FbPage = {
+  id: number;
+  page_id: string;
+  name: string;
+  sort_order: number;
+};
+
+type CampaignDetail = {
+  id: number;
+  name: string;
+  description: string | null;
+  cover_image_url: string | null;
+};
+
+type PreviousPost = {
+  id: number;
+  fb_page_id: number;
+  fb_post_id: string | null;
+  permalink: string | null;
+  status: string;
+  error_message: string | null;
+  posted_at: string | null;
+  created_at: string;
+};
+
+type PublishResult = {
+  fb_page_id: number;
+  page_name: string;
+  status: "success" | "failed";
+  fb_post_id?: string;
+  permalink?: string | null;
+  error?: string;
+};
+
+type Props = {
+  open: boolean;
+  campaignId: number | null;
+  onClose: () => void;
+};
+
+function resolveImagePath(p: string): string {
+  if (/^https?:\/\//i.test(p)) return p;
+  return getSupabase().storage.from(PRODUCTS_BUCKET).getPublicUrl(p).data.publicUrl;
+}
+
+export default function FbPublishModal({ open, campaignId, onClose }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [campaign, setCampaign] = useState<CampaignDetail | null>(null);
+  const [allImages, setAllImages] = useState<string[]>([]);
+  const [pages, setPages] = useState<FbPage[]>([]);
+  const [previous, setPrevious] = useState<PreviousPost[]>([]);
+
+  const [message, setMessage] = useState("");
+  const [selectedImageUrls, setSelectedImageUrls] = useState<Set<string>>(new Set());
+  const [selectedPageIds, setSelectedPageIds] = useState<Set<number>>(new Set());
+
+  const [results, setResults] = useState<PublishResult[] | null>(null);
+
+  const sentPageIds = useMemo(() => {
+    return new Set(previous.filter((p) => p.status === "success").map((p) => p.fb_page_id));
+  }, [previous]);
+
+  useEffect(() => {
+    if (!open || !campaignId) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      setResults(null);
+      try {
+        const sb = getSupabase();
+        const [campRes, pagesRes, prevRes] = await Promise.all([
+          sb
+            .from("group_buy_campaigns")
+            .select(
+              "id, name, description, cover_image_url, campaign_items(sort_order, sku:skus(product:products(images)))",
+            )
+            .eq("id", campaignId)
+            .maybeSingle(),
+          sb
+            .from("fb_pages")
+            .select("id, page_id, name, sort_order")
+            .eq("is_active", true)
+            .order("sort_order", { ascending: true }),
+          sb
+            .from("campaign_fb_posts")
+            .select("id, fb_page_id, fb_post_id, permalink, status, error_message, posted_at, created_at")
+            .eq("campaign_id", campaignId)
+            .order("created_at", { ascending: false }),
+        ]);
+        if (cancelled) return;
+        if (campRes.error) throw campRes.error;
+        if (pagesRes.error) throw pagesRes.error;
+        if (prevRes.error) throw prevRes.error;
+
+        const camp = campRes.data as (CampaignDetail & {
+          campaign_items?: Array<{
+            sort_order: number;
+            sku?: { product?: { images?: string[] } | null } | null;
+          }>;
+        }) | null;
+        if (!camp) throw new Error("找不到開團資料");
+
+        const imageSet = new Set<string>();
+        if (camp.cover_image_url) imageSet.add(resolveImagePath(camp.cover_image_url));
+        const items = (camp.campaign_items ?? []).slice().sort((a, b) => a.sort_order - b.sort_order);
+        for (const it of items) {
+          const imgs = it.sku?.product?.images ?? [];
+          for (const p of imgs) if (typeof p === "string" && p) imageSet.add(resolveImagePath(p));
+        }
+        const imgList = [...imageSet];
+
+        setCampaign({
+          id: camp.id,
+          name: camp.name,
+          description: camp.description ?? null,
+          cover_image_url: camp.cover_image_url ?? null,
+        });
+        setAllImages(imgList);
+        setSelectedImageUrls(new Set(imgList));
+        setPages(pagesRes.data ?? []);
+        setSelectedPageIds(new Set());
+        setPrevious(prevRes.data ?? []);
+        setMessage(buildDefaultMessage(camp.name, camp.description ?? null, camp.id));
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, campaignId]);
+
+  const togglePage = (id: number) => {
+    setSelectedPageIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleImage = (url: string) => {
+    setSelectedImageUrls((prev) => {
+      const next = new Set(prev);
+      if (next.has(url)) next.delete(url);
+      else next.add(url);
+      return next;
+    });
+  };
+
+  async function handleSubmit() {
+    if (!campaignId || !campaign) return;
+    if (selectedPageIds.size === 0) {
+      setError("請選擇至少一個粉絲團");
+      return;
+    }
+    if (!message.trim()) {
+      setError("貼文內容不可為空");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    setResults(null);
+    try {
+      const sb = getSupabase();
+      const { data: { session } } = await sb.auth.getSession();
+      if (!session) throw new Error("尚未登入");
+
+      const resp = await fetch(
+        `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/campaign-publish-facebook`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${session.access_token}`,
+          },
+          body: JSON.stringify({
+            campaign_id: campaignId,
+            fb_page_ids: [...selectedPageIds],
+            message: message.trim(),
+            image_urls: allImages.filter((u) => selectedImageUrls.has(u)),
+          }),
+        },
+      );
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data?.error || data?.detail || `HTTP ${resp.status}`);
+      setResults(data.results ?? []);
+
+      // refresh previous posts so badges update
+      const { data: prev } = await sb
+        .from("campaign_fb_posts")
+        .select("id, fb_page_id, fb_post_id, permalink, status, error_message, posted_at, created_at")
+        .eq("campaign_id", campaignId)
+        .order("created_at", { ascending: false });
+      setPrevious(prev ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const allFailed = !!results && results.length > 0 && results.every((r) => r.status === "failed");
+  const allSuccess = !!results && results.length > 0 && results.every((r) => r.status === "success");
+
+  return (
+    <Modal open={open} onClose={onClose} title="發佈到 FB 粉絲團" maxWidth="max-w-4xl">
+      {loading ? (
+        <div className="py-10 text-center text-sm text-zinc-500">載入中…</div>
+      ) : !campaign ? (
+        <div className="py-10 text-center text-sm text-red-600">{error ?? "資料不可用"}</div>
+      ) : (
+        <div className="space-y-5">
+          <section>
+            <div className="text-xs font-medium text-zinc-500">開團</div>
+            <div className="mt-1 text-sm font-semibold">{campaign.name}</div>
+            <a
+              href={`${MEMBER_APP_URL}/shop/c/${campaign.id}`}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {MEMBER_APP_URL}/shop/c/{campaign.id}
+            </a>
+          </section>
+
+          <section>
+            <label className="block text-xs font-medium text-zinc-500">貼文內容</label>
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              rows={8}
+              className="mt-1 w-full rounded border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+              disabled={submitting}
+            />
+          </section>
+
+          <section>
+            <div className="mb-2 text-xs font-medium text-zinc-500">
+              圖片（{selectedImageUrls.size}/{allImages.length}）
+            </div>
+            {allImages.length === 0 ? (
+              <div className="text-xs text-zinc-400">此開團沒有圖片，將只發文字</div>
+            ) : (
+              <div className="grid grid-cols-3 gap-2 sm:grid-cols-5">
+                {allImages.map((url) => {
+                  const selected = selectedImageUrls.has(url);
+                  return (
+                    <button
+                      key={url}
+                      type="button"
+                      onClick={() => toggleImage(url)}
+                      disabled={submitting}
+                      className={`relative aspect-square overflow-hidden rounded border-2 transition ${
+                        selected
+                          ? "border-blue-500 ring-2 ring-blue-200 dark:ring-blue-900"
+                          : "border-zinc-200 opacity-50 dark:border-zinc-700"
+                      }`}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img src={url} alt="" className="h-full w-full object-cover" />
+                      {selected && (
+                        <span className="absolute right-1 top-1 rounded-full bg-blue-500 px-1.5 py-0.5 text-[10px] font-medium text-white">
+                          ✓
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <div className="mb-2 text-xs font-medium text-zinc-500">
+              粉絲團（{selectedPageIds.size}/{pages.length}）
+            </div>
+            {pages.length === 0 ? (
+              <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
+                目前沒有啟用中的粉絲團設定。請先在資料庫的 fb_pages 表新增資料。
+              </div>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {pages.map((p) => {
+                  const selected = selectedPageIds.has(p.id);
+                  const sent = sentPageIds.has(p.id);
+                  return (
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => togglePage(p.id)}
+                      disabled={submitting}
+                      className={`rounded-full border px-3 py-1 text-xs transition ${
+                        selected
+                          ? "border-blue-500 bg-blue-500 text-white"
+                          : "border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300"
+                      }`}
+                    >
+                      {p.name}
+                      {sent && (
+                        <span
+                          className={`ml-1 rounded-full px-1 text-[10px] ${
+                            selected ? "bg-white/30" : "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300"
+                          }`}
+                          title="此粉絲團已發過"
+                        >
+                          已發
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          {previous.length > 0 && (
+            <section>
+              <div className="mb-1 text-xs font-medium text-zinc-500">發送紀錄</div>
+              <ul className="space-y-1 text-xs">
+                {previous.slice(0, 5).map((p) => {
+                  const pg = pages.find((x) => x.id === p.fb_page_id);
+                  return (
+                    <li key={p.id} className="flex items-center gap-2">
+                      <span
+                        className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                          p.status === "success"
+                            ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+                            : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300"
+                        }`}
+                      >
+                        {p.status === "success" ? "成功" : "失敗"}
+                      </span>
+                      <span className="text-zinc-500">{pg?.name ?? `page #${p.fb_page_id}`}</span>
+                      <span className="text-zinc-400">{p.posted_at ?? p.created_at}</span>
+                      {p.permalink && (
+                        <a
+                          href={p.permalink}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-blue-600 hover:underline dark:text-blue-400"
+                        >
+                          看貼文
+                        </a>
+                      )}
+                      {p.error_message && (
+                        <span className="text-red-600 dark:text-red-400" title={p.error_message}>
+                          ({p.error_message.slice(0, 40)}{p.error_message.length > 40 ? "…" : ""})
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          )}
+
+          {error && (
+            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+              {error}
+            </div>
+          )}
+
+          {results && (
+            <div
+              className={`rounded border px-3 py-2 text-xs ${
+                allSuccess
+                  ? "border-green-200 bg-green-50 text-green-800 dark:border-green-900 dark:bg-green-950/30 dark:text-green-300"
+                  : allFailed
+                  ? "border-red-200 bg-red-50 text-red-800 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300"
+                  : "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300"
+              }`}
+            >
+              <div className="font-medium">
+                {allSuccess ? "全部發送成功" : allFailed ? "全部發送失敗" : "部分發送成功"}
+              </div>
+              <ul className="mt-1 space-y-0.5">
+                {results.map((r) => (
+                  <li key={r.fb_page_id}>
+                    {r.status === "success" ? "✓" : "✕"} {r.page_name}
+                    {r.error ? `：${r.error}` : ""}
+                    {r.permalink && (
+                      <>
+                        {" "}
+                        <a
+                          href={r.permalink}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-blue-600 hover:underline dark:text-blue-400"
+                        >
+                          看貼文
+                        </a>
+                      </>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 border-t border-zinc-200 pt-3 dark:border-zinc-800">
+            <SpinButton
+              onClick={onClose}
+              disabled={submitting}
+              className="rounded border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800 disabled:opacity-50"
+            >
+              關閉
+            </SpinButton>
+            <SpinButton
+              onClick={handleSubmit}
+              disabled={submitting || pages.length === 0 || selectedPageIds.size === 0}
+              className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? "發送中…" : `發送到 ${selectedPageIds.size} 個粉絲團`}
+            </SpinButton>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function buildDefaultMessage(name: string, description: string | null, campaignId: number): string {
+  const link = `${MEMBER_APP_URL}/shop/c/${campaignId}`;
+  const parts: string[] = [];
+  parts.push(`【開團】${name}`);
+  if (description) {
+    const plain = description
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/p>/gi, "\n")
+      .replace(/<[^>]+>/g, "")
+      .trim();
+    if (plain) parts.push(plain);
+  }
+  parts.push(`\n👉 立即下單：${link}`);
+  return parts.join("\n\n");
+}

--- a/supabase/functions/campaign-publish-facebook/index.ts
+++ b/supabase/functions/campaign-publish-facebook/index.ts
@@ -1,0 +1,267 @@
+// 同步上架 FB 粉絲團：把 group_buy_campaign 的內容發到指定的 FB Pages
+//
+// 流程：
+//   1. 驗證 JWT、角色（owner/admin/hq_manager）、tenant_id
+//   2. 讀 fb_pages 拿 access_token（service_role 旁路 RLS）
+//   3. 依圖片數量分流呼叫 FB Graph：
+//        0 張 → POST /{page-id}/feed { message }
+//        1 張 → POST /{page-id}/photos { url, message }（會自動建 feed post）
+//        n 張 → 先逐張 POST /{page-id}/photos?published=false 拿 media_fbid，
+//               再 POST /{page-id}/feed { message, attached_media[] }
+//   4. 不論成功/失敗都寫一筆 campaign_fb_posts
+//
+// 注意 `link` 參數在 v3.3 之後對非審核 App 不可靠，所以 URL 直接拼進 message body。
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.8";
+import { corsHeaders } from "../_shared/cors.ts";
+
+const FB_API_VERSION = "v19.0";
+const FB_BASE = `https://graph.facebook.com/${FB_API_VERSION}`;
+
+type FbPage = {
+  id: number;
+  page_id: string;
+  name: string;
+  access_token: string;
+  is_active: boolean;
+};
+
+function requireEnv(name: string): string {
+  const v = Deno.env.get(name);
+  if (!v) throw new Error(`missing env ${name}`);
+  return v;
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+async function fbCall(
+  path: string,
+  params: Record<string, string>,
+): Promise<Record<string, unknown>> {
+  const form = new URLSearchParams(params);
+  const r = await fetch(`${FB_BASE}${path}`, { method: "POST", body: form });
+  const text = await r.text();
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = { raw: text };
+  }
+  if (!r.ok) {
+    const errObj = parsed?.error as { message?: string } | undefined;
+    throw new Error(errObj?.message || text || `HTTP ${r.status}`);
+  }
+  return parsed;
+}
+
+async function fbFetchPermalink(
+  fbPostId: string,
+  accessToken: string,
+): Promise<string | null> {
+  try {
+    const u = new URL(`${FB_BASE}/${fbPostId}`);
+    u.searchParams.set("fields", "permalink_url");
+    u.searchParams.set("access_token", accessToken);
+    const r = await fetch(u.toString());
+    if (!r.ok) return null;
+    const d = await r.json();
+    return typeof d.permalink_url === "string" ? d.permalink_url : null;
+  } catch {
+    return null;
+  }
+}
+
+async function publishToPage(
+  page: FbPage,
+  message: string,
+  imageUrls: string[],
+): Promise<{ fb_post_id: string; permalink: string | null }> {
+  let fbPostId: string;
+
+  if (imageUrls.length === 0) {
+    const res = await fbCall(`/${page.page_id}/feed`, {
+      message,
+      access_token: page.access_token,
+    });
+    fbPostId = String(res.id);
+  } else if (imageUrls.length === 1) {
+    const res = await fbCall(`/${page.page_id}/photos`, {
+      url: imageUrls[0],
+      message,
+      access_token: page.access_token,
+    });
+    // /photos 回傳 { id, post_id }，post_id 才是 feed 上的貼文
+    fbPostId = String(res.post_id ?? res.id);
+  } else {
+    const mediaIds: string[] = [];
+    for (const url of imageUrls) {
+      const res = await fbCall(`/${page.page_id}/photos`, {
+        url,
+        published: "false",
+        access_token: page.access_token,
+      });
+      mediaIds.push(String(res.id));
+    }
+    const params: Record<string, string> = {
+      message,
+      access_token: page.access_token,
+    };
+    mediaIds.forEach((mid, i) => {
+      params[`attached_media[${i}]`] = JSON.stringify({ media_fbid: mid });
+    });
+    const res = await fbCall(`/${page.page_id}/feed`, params);
+    fbPostId = String(res.id);
+  }
+
+  const permalink = await fbFetchPermalink(fbPostId, page.access_token);
+  return { fb_post_id: fbPostId, permalink };
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+
+  try {
+    const auth = req.headers.get("authorization");
+    if (!auth) return json({ error: "missing authorization" }, 401);
+
+    const sb = createClient(
+      requireEnv("SUPABASE_URL"),
+      requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+      { auth: { persistSession: false } },
+    );
+
+    const token = auth.replace(/^Bearer\s+/i, "");
+    const { data: { user }, error: authErr } = await sb.auth.getUser(token);
+    if (authErr || !user) {
+      return json({ error: "invalid token", detail: authErr?.message }, 401);
+    }
+
+    const tenantId = user.app_metadata?.tenant_id as string | undefined;
+    const role = user.app_metadata?.role as string | undefined;
+    if (!tenantId) return json({ error: "user has no tenant_id" }, 403);
+    if (!role || !["owner", "admin", "hq_manager"].includes(role)) {
+      return json({ error: "forbidden" }, 403);
+    }
+
+    const body = await req.json();
+    const campaignId = Number(body?.campaign_id);
+    const fbPageIds = Array.isArray(body?.fb_page_ids)
+      ? body.fb_page_ids.map((x: unknown) => Number(x)).filter((n: number) => Number.isFinite(n))
+      : [];
+    const messageInput = typeof body?.message === "string" ? body.message : "";
+    const imageUrls: string[] = Array.isArray(body?.image_urls)
+      ? body.image_urls.filter((u: unknown) => typeof u === "string" && u.length > 0) as string[]
+      : [];
+
+    if (!Number.isFinite(campaignId) || campaignId <= 0) {
+      return json({ error: "campaign_id required" }, 400);
+    }
+    if (fbPageIds.length === 0) {
+      return json({ error: "fb_page_ids required" }, 400);
+    }
+    const message = messageInput.trim();
+    if (!message) return json({ error: "message required" }, 400);
+
+    const { data: campaign, error: cErr } = await sb
+      .from("group_buy_campaigns")
+      .select("id, tenant_id, name")
+      .eq("id", campaignId)
+      .eq("tenant_id", tenantId)
+      .maybeSingle();
+    if (cErr) return json({ error: cErr.message }, 500);
+    if (!campaign) return json({ error: "campaign not found" }, 404);
+
+    const { data: pages, error: pErr } = await sb
+      .from("fb_pages")
+      .select("id, page_id, name, access_token, is_active")
+      .eq("tenant_id", tenantId)
+      .in("id", fbPageIds);
+    if (pErr) return json({ error: pErr.message }, 500);
+    if (!pages || pages.length === 0) {
+      return json({ error: "no valid fb pages" }, 400);
+    }
+
+    const results: Array<{
+      fb_page_id: number;
+      page_name: string;
+      status: "success" | "failed";
+      fb_post_id?: string;
+      permalink?: string | null;
+      error?: string;
+    }> = [];
+
+    for (const p of pages as FbPage[]) {
+      if (!p.is_active) {
+        await sb.from("campaign_fb_posts").insert({
+          tenant_id: tenantId,
+          campaign_id: campaignId,
+          fb_page_id: p.id,
+          status: "failed",
+          message,
+          image_urls: imageUrls,
+          error_message: "page is inactive",
+          posted_by: user.id,
+        });
+        results.push({
+          fb_page_id: p.id,
+          page_name: p.name,
+          status: "failed",
+          error: "page is inactive",
+        });
+        continue;
+      }
+
+      try {
+        const { fb_post_id, permalink } = await publishToPage(p, message, imageUrls);
+        await sb.from("campaign_fb_posts").insert({
+          tenant_id: tenantId,
+          campaign_id: campaignId,
+          fb_page_id: p.id,
+          fb_post_id,
+          permalink,
+          status: "success",
+          message,
+          image_urls: imageUrls,
+          posted_by: user.id,
+          posted_at: new Date().toISOString(),
+        });
+        results.push({
+          fb_page_id: p.id,
+          page_name: p.name,
+          status: "success",
+          fb_post_id,
+          permalink,
+        });
+      } catch (e) {
+        const errMsg = e instanceof Error ? e.message : String(e);
+        await sb.from("campaign_fb_posts").insert({
+          tenant_id: tenantId,
+          campaign_id: campaignId,
+          fb_page_id: p.id,
+          status: "failed",
+          message,
+          image_urls: imageUrls,
+          error_message: errMsg,
+          posted_by: user.id,
+        });
+        results.push({
+          fb_page_id: p.id,
+          page_name: p.name,
+          status: "failed",
+          error: errMsg,
+        });
+      }
+    }
+
+    return json({ ok: true, results });
+  } catch (e) {
+    console.error("campaign-publish-facebook error:", e);
+    return json({ error: "internal", detail: String(e) }, 500);
+  }
+});

--- a/supabase/migrations/20260620000030_fb_pages_and_campaign_fb_posts.sql
+++ b/supabase/migrations/20260620000030_fb_pages_and_campaign_fb_posts.sql
@@ -1,0 +1,62 @@
+-- 同步上架 FB 粉絲團：粉絲團設定 + 發文紀錄
+--
+-- 設計重點：
+--   * fb_pages 存「Page ID + 長效 Page Access Token」，client 不應直接讀 access_token
+--     （RLS 允許 admin 角色讀寫，但 UI 用 .select("id,name,page_id,...") 不撈 token）
+--   * campaign_fb_posts 一次發送一個 (campaign_id, fb_page_id) 對應一筆，重發會新增另一筆
+--   * tenant_id 全程帶上，沿用既有 RLS / RBAC 模式
+
+CREATE TABLE fb_pages (
+  id            BIGSERIAL PRIMARY KEY,
+  tenant_id     UUID NOT NULL,
+  page_id       TEXT NOT NULL,
+  name          TEXT NOT NULL,
+  access_token  TEXT NOT NULL,
+  sort_order    INTEGER NOT NULL DEFAULT 0,
+  is_active     BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, page_id)
+);
+
+COMMENT ON TABLE fb_pages IS 'FB 粉絲團設定（Page Access Token 存這裡，限 admin role 讀寫）';
+COMMENT ON COLUMN fb_pages.access_token IS '長效 Page Access Token；client 不應 select 此欄';
+
+CREATE INDEX idx_fb_pages_tenant_active ON fb_pages (tenant_id, sort_order)
+  WHERE is_active;
+
+CREATE TABLE campaign_fb_posts (
+  id             BIGSERIAL PRIMARY KEY,
+  tenant_id      UUID NOT NULL,
+  campaign_id    BIGINT NOT NULL REFERENCES group_buy_campaigns(id) ON DELETE CASCADE,
+  fb_page_id     BIGINT NOT NULL REFERENCES fb_pages(id),
+  fb_post_id     TEXT,
+  permalink      TEXT,
+  status         TEXT NOT NULL CHECK (status IN ('success','failed')),
+  message        TEXT,
+  image_urls     JSONB NOT NULL DEFAULT '[]'::jsonb,
+  error_message  TEXT,
+  posted_by      UUID,
+  posted_at      TIMESTAMPTZ,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE campaign_fb_posts IS '開團發 FB 紀錄（成功/失敗皆記錄；重發新增一筆）';
+
+CREATE INDEX idx_cfp_campaign ON campaign_fb_posts (campaign_id, created_at DESC);
+CREATE INDEX idx_cfp_tenant_status ON campaign_fb_posts (tenant_id, status);
+
+ALTER TABLE fb_pages          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE campaign_fb_posts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY fb_pages_hq_all ON fb_pages
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );
+
+CREATE POLICY cfp_hq_all ON campaign_fb_posts
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (auth.jwt() ->> 'role') IN ('owner','admin','hq_manager')
+  );


### PR DESCRIPTION
## Summary
- 為 `/admin/campaigns` 加上「發 FB」按鈕，把開團一鍵同步到多個 FB 粉絲團
- 支援多粉絲團勾選；圖片自動從 cover + 各 SKU `products.images` 聚合，可單張取消；文案預設帶入「開團名 + description + shop 連結」，發送前可自由編輯
- 既往發送結果（成功 / 失敗 / 貼文連結）顯示在 modal 中，方便重發與排錯

## v1 Scope
- 後端：1 個 migration、1 個 edge function
- 前端：1 個 modal 元件 + 開團列表 1 顆按鈕
- 粉絲團管理採 SQL 手動建（v1 不做管理頁，未來再加）

## 資料模型

```
fb_pages
  id, tenant_id, page_id, name, access_token,
  sort_order, is_active, created_at, updated_at
  UNIQUE (tenant_id, page_id)

campaign_fb_posts
  id, tenant_id, campaign_id, fb_page_id,
  fb_post_id, permalink, status (success|failed),
  message, image_urls, error_message,
  posted_by, posted_at, created_at
```

兩張表都帶 tenant RLS，限 `owner / admin / hq_manager`。

## FB Graph 流程
- 0 張圖 → `POST /{page-id}/feed { message }`
- 1 張圖 → `POST /{page-id}/photos { url, message }`（自動建立 feed post）
- n 張圖 → 逐張 `POST /{page-id}/photos?published=false` 取得 `media_fbid` → `POST /{page-id}/feed` 帶 `attached_media[]`

連結用拼進 `message` 的方式（FB 對非審核 App 的 `link` 參數不可靠）。

## 上線設定
1. Migration：`supabase db push`
2. 部署 edge function：`supabase functions deploy campaign-publish-facebook`
3. 建粉絲團（SQL）：
   ```sql
   INSERT INTO fb_pages (tenant_id, page_id, name, access_token, sort_order)
   VALUES ('<tenant-uuid>', '<fb-page-id>', '北部團', '<long-lived-token>', 1);
   ```
4. admin `.env.local` 設 `NEXT_PUBLIC_MEMBER_APP_URL`（預設 `https://shop.lt-foods.tw`）

## Test plan
- [ ] Migration 跑得起來，RLS 政策建立成功
- [ ] 手動 `INSERT` 一筆 `fb_pages`，modal 看得到該粉絲團選項
- [ ] 點「發 FB」→ 文案 / 圖片 / 粉絲團勾選正確
- [ ] 0 / 1 / 多張圖三種路徑都能成功發 FB 並回傳 `permalink`
- [ ] 發送失敗（例如 token 過期）會寫 `campaign_fb_posts` 並在 modal 顯示錯誤
- [ ] 同一開團重發後「已發」標記正確顯示
- [ ] 非 admin 角色呼叫 edge function 會被 403 擋下

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3y8guQqBisy2uXvRD5sdC)_