### PR TITLE
feat(admin/community-candidates/calendar): 改成日 × 時段 grid

### DIFF
--- a/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
+++ b/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
@@ -30,6 +30,7 @@ type CalendarCandidate = {
   id: number;
   product_name_hint: string | null;
   scheduled_open_at: string | null;
+  scheduled_slot_index: number | null;
   scheduled_sort_order: number | null;
   owner_action: string;
   created_at: string;
@@ -56,6 +57,21 @@ const ACTION_COLOR: Record<string, string> = {
 
 const WEEKDAYS = ["日", "一", "二", "三", "四", "五", "六"];
 
+// 09:00 → 21:00 共 13 個整點時段
+const SLOT_COUNT = 13;
+const SLOT_START_HOUR = 9;
+
+function slotTime(idx: number): string {
+  return `${String(SLOT_START_HOUR + idx).padStart(2, "0")}:00`;
+}
+
+function clampSlot(idx: number | null | undefined): number {
+  if (idx === null || idx === undefined) return 0;
+  if (idx < 0) return 0;
+  if (idx > SLOT_COUNT - 1) return SLOT_COUNT - 1;
+  return idx;
+}
+
 function formatDate(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
@@ -63,11 +79,15 @@ function formatDate(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
-function suggestedTime(idx: number): string {
-  const total = 9 * 60 + idx * 30;
-  const h = Math.floor(total / 60);
-  const m = total % 60;
-  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+// droppable id 格式：YYYY-MM-DD#slotIdx
+function cellId(dayKey: string, slotIdx: number): string {
+  return `${dayKey}#${slotIdx}`;
+}
+
+function parseCellId(id: string): { day: string; slot: number } | null {
+  const m = id.match(/^(\d{4}-\d{2}-\d{2})#(\d+)$/);
+  if (!m) return null;
+  return { day: m[1], slot: parseInt(m[2], 10) };
 }
 
 export default function CommunityCandidatesCalendarPage() {
@@ -91,12 +111,13 @@ export default function CommunityCandidatesCalendarPage() {
     const { data, error: err } = await getSupabase()
       .from("community_product_candidates")
       .select(
-        "id, product_name_hint, scheduled_open_at, scheduled_sort_order, owner_action, created_at, adopted_supplier_name, adopted_cost, adopted_sale_price"
+        "id, product_name_hint, scheduled_open_at, scheduled_slot_index, scheduled_sort_order, owner_action, created_at, adopted_supplier_name, adopted_cost, adopted_sale_price"
       )
       .not("scheduled_open_at", "is", null)
       .gte("scheduled_open_at", startStr)
       .lte("scheduled_open_at", endStr)
       .order("scheduled_open_at", { ascending: true })
+      .order("scheduled_slot_index", { ascending: true, nullsFirst: true })
       .order("scheduled_sort_order", { ascending: true, nullsFirst: false })
       .order("created_at", { ascending: true });
     if (err) setError(err.message);
@@ -110,19 +131,25 @@ export default function CommunityCandidatesCalendarPage() {
     reload();
   }, [reload]);
 
-  // Local mirror of byDate so drag can produce optimistic updates
-  const [localByDate, setLocalByDate] = useState<Record<string, CalendarCandidate[]>>({});
+  // Local mirror keyed by `${dayKey}#${slotIdx}` so drag can produce optimistic updates
+  const [localByCell, setLocalByCell] = useState<Record<string, CalendarCandidate[]>>({});
 
   useEffect(() => {
     const map: Record<string, CalendarCandidate[]> = {};
-    for (const d of days) map[formatDate(d)] = [];
-    for (const r of rows ?? []) {
-      if (r.scheduled_open_at) {
-        const key = r.scheduled_open_at.slice(0, 10);
-        if (map[key]) map[key].push(r);
+    for (const d of days) {
+      const dayKey = formatDate(d);
+      for (let s = 0; s < SLOT_COUNT; s++) {
+        map[cellId(dayKey, s)] = [];
       }
     }
-    setLocalByDate(map);
+    for (const r of rows ?? []) {
+      if (!r.scheduled_open_at) continue;
+      const dayKey = r.scheduled_open_at.slice(0, 10);
+      const slot = clampSlot(r.scheduled_slot_index);
+      const k = cellId(dayKey, slot);
+      if (map[k]) map[k].push(r);
+    }
+    setLocalByCell(map);
   }, [rows, days]);
 
   const handleRemove = async (r: CalendarCandidate) => {
@@ -135,6 +162,7 @@ export default function CommunityCandidatesCalendarPage() {
         .update({
           owner_action: "none",
           scheduled_open_at: null,
+          scheduled_slot_index: null,
           scheduled_sort_order: null,
           updated_at: new Date().toISOString(),
         })
@@ -157,16 +185,14 @@ export default function CommunityCandidatesCalendarPage() {
   );
 
   function findContainer(id: number | string): string | null {
-    if (typeof id === "string" && days.some((d) => formatDate(d) === id)) return id;
+    if (typeof id === "string" && parseCellId(id)) return id;
     const numId = Number(id);
-    for (const [day, cards] of Object.entries(localByDate)) {
-      if (cards.some((c) => c.id === numId)) return day;
+    for (const [cell, cards] of Object.entries(localByCell)) {
+      if (cards.some((c) => c.id === numId)) return cell;
     }
     return null;
   }
 
-  // 自訂 collision detection：優先 pointerWithin（指標真的進入 column 才命中），
-  // 沒命中再退回 rectIntersection / closestCorners。這樣空 column 也能被命中。
   const collisionDetection: CollisionDetection = useCallback((args) => {
     const pointerCollisions = pointerWithin(args);
     if (pointerCollisions.length > 0) return pointerCollisions;
@@ -177,7 +203,7 @@ export default function CommunityCandidatesCalendarPage() {
 
   const onDragStart = (e: DragStartEvent) => {
     const id = Number(e.active.id);
-    for (const cards of Object.values(localByDate)) {
+    for (const cards of Object.values(localByCell)) {
       const c = cards.find((c) => c.id === id);
       if (c) {
         setActiveCard(c);
@@ -195,13 +221,12 @@ export default function CommunityCandidatesCalendarPage() {
     if (!activeContainer || !overContainer) return;
     if (activeContainer === overContainer) return;
 
-    setLocalByDate((prev) => {
+    setLocalByCell((prev) => {
       const src = [...(prev[activeContainer] ?? [])];
       const dst = [...(prev[overContainer] ?? [])];
       const idx = src.findIndex((c) => c.id === activeId);
       if (idx < 0) return prev;
       const [card] = src.splice(idx, 1);
-      // figure out target index: drop above the over card, or end of list
       const overIdx =
         typeof over.id === "number"
           ? dst.findIndex((c) => c.id === Number(over.id))
@@ -218,16 +243,17 @@ export default function CommunityCandidatesCalendarPage() {
     if (!over || !card) return;
     const activeId = Number(active.id);
     const overContainer = findContainer(over.id as number | string);
-    const originalContainer = card.scheduled_open_at?.slice(0, 10) ?? null;
+    const originalDay = card.scheduled_open_at?.slice(0, 10) ?? null;
+    const originalSlot = clampSlot(card.scheduled_slot_index);
+    const originalContainer = originalDay ? cellId(originalDay, originalSlot) : null;
     if (!overContainer) return;
 
-    // Determine current container after onDragOver moves
     const currentContainer = findContainer(activeId);
     if (!currentContainer) return;
 
     if (currentContainer === originalContainer) {
-      // Same-day reorder: arrayMove + persist
-      const items = localByDate[currentContainer] ?? [];
+      // Same-cell reorder
+      const items = localByCell[currentContainer] ?? [];
       const oldIdx = items.findIndex((c) => c.id === activeId);
       const newIdx =
         typeof over.id === "number"
@@ -235,17 +261,17 @@ export default function CommunityCandidatesCalendarPage() {
           : items.length - 1;
       if (oldIdx < 0 || newIdx < 0 || oldIdx === newIdx) return;
       const newItems = arrayMove(items, oldIdx, newIdx);
-      setLocalByDate((p) => ({ ...p, [currentContainer]: newItems }));
-      await persistDay(currentContainer, newItems);
+      setLocalByCell((p) => ({ ...p, [currentContainer]: newItems }));
+      await persistCell(currentContainer, newItems);
       await reload();
     } else {
-      // Cross-day move: source already updated in onDragOver
-      const srcItems = localByDate[originalContainer ?? ""] ?? [];
-      const dstItems = localByDate[currentContainer] ?? [];
+      // Cross-cell move: source already updated in onDragOver
+      const srcItems = originalContainer ? localByCell[originalContainer] ?? [] : [];
+      const dstItems = localByCell[currentContainer] ?? [];
       setBusy(true);
       try {
-        await persistDay(currentContainer, dstItems);
-        if (originalContainer) await persistDay(originalContainer, srcItems);
+        await persistCell(currentContainer, dstItems);
+        if (originalContainer) await persistCell(originalContainer, srcItems);
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
       } finally {
@@ -255,7 +281,10 @@ export default function CommunityCandidatesCalendarPage() {
     }
   };
 
-  async function persistDay(dayKey: string, items: CalendarCandidate[]) {
+  async function persistCell(cellKey: string, items: CalendarCandidate[]) {
+    const parsed = parseCellId(cellKey);
+    if (!parsed) return;
+    const { day, slot } = parsed;
     const sb = getSupabase();
     const now = new Date().toISOString();
     const { data: userRes } = await sb.auth.getUser();
@@ -265,18 +294,19 @@ export default function CommunityCandidatesCalendarPage() {
       const { error: err } = await sb
         .from("community_product_candidates")
         .update({
-          scheduled_open_at: dayKey,
+          scheduled_open_at: day,
+          scheduled_slot_index: slot,
           scheduled_sort_order: order,
           updated_at: now,
         })
         .eq("id", items[i].id);
       if (err) throw new Error(err.message);
 
-      // 同步更新對應 campaign（透過 RPC 繞過 RLS — admin 客戶端 JWT role claim 可能為 null）
       if (operator) {
         const { error: rpcErr } = await sb.rpc("rpc_reorder_candidate_campaign", {
           p_candidate_id: items[i].id,
-          p_day_key: dayKey,
+          p_day_key: day,
+          p_slot_index: slot,
           p_order: order,
           p_operator: operator,
         });
@@ -292,7 +322,7 @@ export default function CommunityCandidatesCalendarPage() {
       <header className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold">選品週曆</h1>
-          <p className="mt-0.5 text-sm text-zinc-500">未來 7 天 · 拖拉卡片排序或換日</p>
+          <p className="mt-0.5 text-sm text-zinc-500">未來 7 天 · 每整點時段（09:00–21:00）可放多商品 · 拖拉換時段或換日</p>
         </div>
         <Link
           href="/community-candidates"
@@ -320,32 +350,37 @@ export default function CommunityCandidatesCalendarPage() {
         >
           <div className="flex gap-2 overflow-x-auto pb-2 lg:grid lg:grid-cols-7 lg:overflow-x-visible lg:pb-0">
             {days.map((d) => {
-              const key = formatDate(d);
-              const isToday = key === todayStr;
-              const cards = localByDate[key] ?? [];
+              const dayKey = formatDate(d);
+              const isToday = dayKey === todayStr;
               return (
-                <DayColumn key={key} dayKey={key} day={d} isToday={isToday} cards={cards}>
-                  <SortableContext
-                    id={key}
-                    items={cards.map((c) => c.id)}
-                    strategy={verticalListSortingStrategy}
-                  >
-                    {cards.length === 0 ? (
-                      <div className="rounded border border-dashed border-zinc-200 px-2 py-4 text-center text-[10px] text-zinc-400 dark:border-zinc-800">
-                        無排程
-                      </div>
-                    ) : (
-                      cards.map((r, idx) => (
-                        <SortableCard
-                          key={r.id}
-                          card={r}
-                          idx={idx}
-                          busy={busy}
-                          onRemove={handleRemove}
-                        />
-                      ))
-                    )}
-                  </SortableContext>
+                <DayColumn key={dayKey} day={d} isToday={isToday}>
+                  {Array.from({ length: SLOT_COUNT }, (_, slotIdx) => {
+                    const k = cellId(dayKey, slotIdx);
+                    const cards = localByCell[k] ?? [];
+                    return (
+                      <SlotCell
+                        key={k}
+                        cellKey={k}
+                        time={slotTime(slotIdx)}
+                        empty={cards.length === 0}
+                      >
+                        <SortableContext
+                          id={k}
+                          items={cards.map((c) => c.id)}
+                          strategy={verticalListSortingStrategy}
+                        >
+                          {cards.map((r) => (
+                            <SortableCard
+                              key={r.id}
+                              card={r}
+                              busy={busy}
+                              onRemove={handleRemove}
+                            />
+                          ))}
+                        </SortableContext>
+                      </SlotCell>
+                    );
+                  })}
                 </DayColumn>
               );
             })}
@@ -359,29 +394,16 @@ export default function CommunityCandidatesCalendarPage() {
 }
 
 function DayColumn({
-  dayKey,
   day,
   isToday,
-  cards,
   children,
 }: {
-  dayKey: string;
   day: Date;
   isToday: boolean;
-  cards: CalendarCandidate[];
   children: React.ReactNode;
 }) {
-  // useDroppable so empty columns can accept drops
-  const { setNodeRef, isOver } = useDroppable({ id: dayKey });
   return (
-    <div
-      ref={setNodeRef}
-      className={`flex min-h-[200px] w-[200px] shrink-0 flex-col gap-2 rounded-md p-1 transition lg:w-auto lg:min-w-0 ${
-        isOver
-          ? "bg-amber-50 ring-2 ring-amber-300 dark:bg-amber-950/30 dark:ring-amber-700"
-          : ""
-      }`}
-    >
+    <div className="flex w-[220px] shrink-0 flex-col gap-1 lg:w-auto lg:min-w-0">
       <div
         className={`rounded-md px-2 py-1.5 text-center text-xs font-semibold ${
           isToday
@@ -394,19 +416,54 @@ function DayColumn({
         </div>
         <div className="text-[10px] font-normal opacity-70">週{WEEKDAYS[day.getDay()]}</div>
       </div>
-      {children}
+      <div className="flex flex-col gap-0.5">{children}</div>
+    </div>
+  );
+}
+
+function SlotCell({
+  cellKey,
+  time,
+  empty,
+  children,
+}: {
+  cellKey: string;
+  time: string;
+  empty: boolean;
+  children: React.ReactNode;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: cellKey });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex gap-1.5 rounded-md p-1 transition ${
+        isOver
+          ? "bg-amber-50 ring-1 ring-amber-300 dark:bg-amber-950/30 dark:ring-amber-700"
+          : ""
+      }`}
+    >
+      <div className="w-9 shrink-0 pt-1 text-right font-mono text-[10px] font-medium text-zinc-400 dark:text-zinc-500">
+        {time}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        {empty ? (
+          <div className="rounded border border-dashed border-zinc-200 px-2 py-2 text-center text-[10px] text-zinc-300 dark:border-zinc-800 dark:text-zinc-600">
+            —
+          </div>
+        ) : (
+          children
+        )}
+      </div>
     </div>
   );
 }
 
 function SortableCard({
   card: r,
-  idx,
   busy,
   onRemove,
 }: {
   card: CalendarCandidate;
-  idx: number;
   busy: boolean;
   onRemove: (r: CalendarCandidate) => void;
 }) {
@@ -434,8 +491,8 @@ function SortableCard({
           {...attributes}
           {...listeners}
           role="button"
-          aria-label="拖拉排序或換日"
-          title="拖拉排序 / 換日"
+          aria-label="拖拉排序或換時段"
+          title="拖拉排序 / 換時段"
           className="flex w-9 shrink-0 cursor-grab touch-none select-none items-center justify-center rounded-md border border-zinc-200 bg-zinc-50 text-zinc-400 transition hover:border-zinc-300 hover:bg-zinc-100 hover:text-zinc-600 active:cursor-grabbing active:bg-zinc-200 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-500 dark:hover:bg-zinc-700 dark:hover:text-zinc-300 lg:w-5 lg:rounded"
         >
           <svg
@@ -453,9 +510,6 @@ function SortableCard({
           </svg>
         </span>
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span className="font-mono text-[10px] font-semibold text-zinc-400 dark:text-zinc-500">
-            {suggestedTime(idx)}
-          </span>
           <Link
             href={`/community-candidates?highlight=${r.id}`}
             className="font-medium leading-snug hover:underline"

--- a/supabase/migrations/20260620000040_calendar_slot_index.sql
+++ b/supabase/migrations/20260620000040_calendar_slot_index.sql
@@ -1,0 +1,92 @@
+-- ============================================================
+-- 週曆從「一日一條清單、時間=index 推算」改成「日 × 時段 grid」
+--
+-- 新增 scheduled_slot_index：0 = 09:00、1 = 10:00、…、12 = 21:00
+--   - 同日同 slot 可以有多筆（同時段多商品並列）
+--   - slot 可以跳號（中間時段不塞商品）
+--   - scheduled_sort_order 變成「同 day + slot 內的順序」
+--
+-- 既有資料 best-effort migration：以前 30 分一格，現在 1 小時一格 =
+-- 2 個舊格塞進 1 個新格 → slot_index = floor((sort_order - 1) / 2)
+-- ============================================================
+
+ALTER TABLE community_product_candidates
+  ADD COLUMN IF NOT EXISTS scheduled_slot_index SMALLINT;
+
+COMMENT ON COLUMN community_product_candidates.scheduled_slot_index IS
+'排程時段索引：0 = 09:00、1 = 10:00、…、12 = 21:00。NULL 表示未排程或未指定時段。';
+
+-- 1) 既有資料 best-effort：把 30 分鐘 idx 壓縮成小時 slot
+UPDATE community_product_candidates
+   SET scheduled_slot_index = LEAST(
+         GREATEST(((COALESCE(scheduled_sort_order, 1) - 1) / 2)::SMALLINT, 0::SMALLINT),
+         12::SMALLINT
+       )
+ WHERE scheduled_open_at IS NOT NULL
+   AND scheduled_slot_index IS NULL;
+
+-- 2) 把 scheduled_sort_order 重新編號為「同 day + slot 內的順序」
+WITH r AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY tenant_id, scheduled_open_at, scheduled_slot_index
+           ORDER BY scheduled_sort_order NULLS LAST, created_at
+         ) AS rn
+    FROM community_product_candidates
+   WHERE scheduled_open_at IS NOT NULL
+)
+UPDATE community_product_candidates c
+   SET scheduled_sort_order = r.rn
+  FROM r
+ WHERE c.id = r.id;
+
+-- 3) RPC 簽名變更：rpc_reorder_candidate_campaign 加 p_slot_index
+--    start_at = day_key + (slot_index + 9) 小時，跟 UI 上顯示的時段對齊
+DROP FUNCTION IF EXISTS rpc_reorder_candidate_campaign(BIGINT, DATE, INTEGER, UUID);
+
+CREATE OR REPLACE FUNCTION rpc_reorder_candidate_campaign(
+  p_candidate_id BIGINT,
+  p_day_key      DATE,
+  p_slot_index   SMALLINT,
+  p_order        INTEGER,
+  p_operator     UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant      UUID;
+  v_campaign_id BIGINT;
+  v_new_no      TEXT;
+  v_pad_id      TEXT := lpad(p_candidate_id::TEXT, 6, '0');
+  v_start_at    TIMESTAMPTZ;
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM community_product_candidates WHERE id = p_candidate_id;
+  IF v_tenant IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  v_new_no := 'GB' || to_char(p_day_key, 'YYYYMMDD') || '-C' || v_pad_id;
+  v_start_at := (p_day_key::TIMESTAMP + ((COALESCE(p_slot_index, 0::SMALLINT) + 9) || ' hours')::INTERVAL)::TIMESTAMPTZ;
+
+  SELECT id INTO v_campaign_id
+    FROM group_buy_campaigns
+   WHERE tenant_id = v_tenant
+     AND campaign_no LIKE '%-C' || v_pad_id
+   LIMIT 1;
+
+  IF v_campaign_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  UPDATE group_buy_campaigns SET
+    display_order = p_order,
+    start_at      = v_start_at,
+    campaign_no   = v_new_no,
+    updated_by    = p_operator,
+    updated_at    = NOW()
+  WHERE id = v_campaign_id;
+
+  RETURN v_campaign_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_reorder_candidate_campaign(BIGINT, DATE, SMALLINT, INTEGER, UUID) TO authenticated;


### PR DESCRIPTION
## Summary
- 選品週曆從「一日一條卡片清單、時間由 index 推算」改成「日 × 時段 grid」
- 同一時段可放多個商品；中間時段可留空
- 同時段內仍可上下拖拉排序，跨時段 / 跨日拖拉沿用

## 改動原因
舊版每張卡片時間是 `09:00 + index × 30min` 自動算出來的，導致：
- 同一時段只能塞一個商品
- 中間想跳過某個時段也做不到（一定接著上一張卡）

## 資料模型
新增 `scheduled_slot_index` (smallint)：
- `0 = 09:00`、`1 = 10:00`、…、`12 = 21:00`（共 13 個整點時段）
- 同 `tenant_id + scheduled_open_at + scheduled_slot_index` 可有多筆（無 UNIQUE）
- `NULL` 表示未排程或未指定時段（UI 上會 fallback 顯示在 09:00）

`scheduled_sort_order` 語意變更：原本是「同日內的全域順序」，現在是「同 day + slot 內的順序」。

### 既有資料 backfill
30 分鐘 idx 壓成 1 小時 slot：
```sql
slot_index = floor((sort_order - 1) / 2)
```
也就是舊「09:00、09:30」會一起併進新「09:00」slot；「10:00、10:30」會一起併進「10:00」。

## RPC 簽名變更
`rpc_reorder_candidate_campaign` 加 `p_slot_index SMALLINT`，並把 `campaign.start_at` 改為：
```sql
start_at = day_key + (slot_index + 9) hours
```
讓 campaign 的 `start_at` 跟 UI 上的時段對齊。

**舊簽名 `(BIGINT, DATE, INTEGER, UUID)` 已 DROP** — 目前看只有 `community-candidates/calendar/page.tsx` 在呼叫，已一併更新。

## UI 變化
- 每日一欄，欄內 13 個整點 slot row
- 每個 slot row 是 droppable + 內部 SortableContext，支援同槽上下拖拉
- 空 slot 顯示淡色 `—` 虛線框，讓使用者直觀看到「這個時段沒排」

## 上線步驟
1. `supabase db push` — migration 會自動 backfill 既有資料
2. 部署 admin app

## Test plan
- [ ] Migration 跑得起來，既有排程資料 `scheduled_slot_index` 都有值
- [ ] 開週曆，舊排程出現在合理的整點 slot
- [ ] 同一 slot 拖入第二張卡片 → 並列、上下排序正確
- [ ] 跨 slot / 跨日拖拉 → `scheduled_open_at`、`scheduled_slot_index`、`scheduled_sort_order` 都更新
- [ ] 對應 campaign 的 `start_at` 也跟著變（例如拖到「週四 14:00」slot → start_at 變 14:00）
- [ ] 中間時段刻意留空 → 顯示虛線 `—` 不會被擠掉
- [ ] 「移出」按鈕能把 slot_index、sort_order、open_at 全部 reset 為 NULL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3y8guQqBisy2uXvRD5sdC)_