### PR TITLE
fix(liff-api): channel lookup fallback + 詳細 member not found error

### DIFF
--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -483,7 +483,12 @@ async function placeMemberOrder(
     .eq("tenant_id", tenantId)
     .eq("id", memberId)
     .single();
-  if (mErr || !member) return json({ error: "member not found" }, 404);
+  if (mErr || !member) {
+    return json({
+      error: "member not found",
+      detail: `memberId=${memberId} tenantId=${tenantId} dbErr=${mErr?.message ?? "no rows"}`,
+    }, 404);
+  }
 
   const pickupStoreId = Number(p.pickup_store_id ?? member.home_store_id ?? 0);
   if (!pickupStoreId) return json({ error: "pickup_store_id required" }, 400);
@@ -501,8 +506,12 @@ async function placeMemberOrder(
     return json({ error: "campaign already ended" }, 400);
   }
 
-  // 找 pickup store 對應的 channel(取第一個 active 的)
-  const { data: channel } = await sb
+  // 找下單用 line_channel：
+  //   1) 優先：pickup store 自己的 active channel
+  //   2) 退回：tenant 任一 active channel（系統常見 setup 是「全店共用一個 LINE bot 下單入口」，
+  //      只有少數店建了自己專屬 channel；中和店等只有「補貨申請」channel 的店會走這條 fallback）
+  let channel: { id: number } | null = null;
+  const { data: storeChannel } = await sb
     .from("line_channels")
     .select("id")
     .eq("tenant_id", tenantId)
@@ -511,7 +520,19 @@ async function placeMemberOrder(
     .order("id", { ascending: true })
     .limit(1)
     .maybeSingle();
-  if (!channel) return json({ error: "no active channel for pickup store" }, 400);
+  if (storeChannel) channel = storeChannel;
+  if (!channel) {
+    const { data: anyChannel } = await sb
+      .from("line_channels")
+      .select("id")
+      .eq("tenant_id", tenantId)
+      .eq("is_active", true)
+      .order("id", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    if (anyChannel) channel = anyChannel;
+  }
+  if (!channel) return json({ error: "no active channel for tenant" }, 400);
 
   // 找既有訂單 or 新建(unique: tenant+campaign+channel+member)
   const { data: existing } = await sb


### PR DESCRIPTION
## Summary
- `placeMemberOrder` 的 line_channel 撿選邏輯加 fallback：先找 pickup store 自己的，沒有再退回 tenant 任一 active channel
- 「member not found」error 加 `detail` 字串（帶 memberId / tenantId / DB error message），方便定位 stale JWT 之類問題

## 為什麼修

舊邏輯：

```ts
.from("line_channels")
.eq("home_store_id", pickupStoreId)
.eq("is_active", true)
```

要求 pickup store 必須有自己的 active channel。但 prod 大多數店實際共用同一個 LINE bot 入口 `channel_id=7`（「【內部】補貨申請-1」），只有少數店（湖口店 channel 17、泰山店 channel 24）建了自己專屬的下單 channel。

中和店 (store 45) 的情況更糟：只有一個 active line_channel `id=9` 名稱「【內部】補貨申請-45」— 是內部補貨 bot、不是顧客下單 channel。`placeMemberOrder` 會撿到它，後續 INSERT 訂單的 `channel_id=9` 就跟其他既有訂單（全部走 `channel_id=7`）對不上。

實測資料：過去 24h customer_orders 分佈
| pickup_store | orders | channel 用到的 |
| --- | --- | --- |
| 松山店 / 文山店 / 永和店 / 中和店 / ... | 99% | channel 7（共用） |
| 湖口店 | 3/26 | channel 17（自己的） |
| 泰山店 | 2/82 | channel 24（自己的） |

## 修法

```ts
// 1) 先試 pickup store 自己的 active channel
let channel = await findChannel({ tenant, home_store_id: pickupStoreId });
// 2) 沒有 → 退回 tenant 任一 active channel（min id，通常是共用 LINE bot）
if (!channel) channel = await findChannel({ tenant });
```

對湖口店 / 泰山店 行為不變（仍撿到自己的 channel 17/24）。對中和店等沒有自己 ordering channel 的店，會退回 channel 7，跟既有訂單分佈一致。

## 為什麼也加 error detail

回報：會員 M20260517151222515（66817）下單時收到「member not found」。實際 DB row 在、binding 正常、SQL 直查也找得到。最可能是前端 cache stale JWT。加 detail 讓下次再壞時不用猜，response body 就會告訴我 JWT 帶的 memberId / tenantId 跟 DB 結果，直接定位。

## 部署狀態

- ✅ 已在 prod 跑 `supabase functions deploy liff-api`（不等 PR merge）
- 本 PR 把改動推回 repo，下次 redeploy 不會被覆蓋

## Test plan
- [ ] 中和店會員 LIFF 開團下單能成功（之前壞掉的場景）
- [ ] 湖口店 / 泰山店會員下單仍用自己的 channel 17 / 24（不該被 fallback 改掉）
- [ ] 萬一還是「member not found」，response body 帶 `detail: memberId=X tenantId=Y dbErr=...`
- [ ] 沒任何 active channel 的 tenant 應回 400 `no active channel for tenant`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3y8guQqBisy2uXvRD5sdC)_