### PR TITLE
fix(rpc_search_skus_for_campaign): 加單品項排除已下架商品

### DIFF
--- a/supabase/migrations/20260620000050_search_skus_filter_inactive_product.sql
+++ b/supabase/migrations/20260620000050_search_skus_filter_inactive_product.sql
@@ -1,0 +1,111 @@
+-- ============================================================
+-- rpc_search_skus_for_campaign：加單時排除「下架的商品」
+--
+-- 既有問題：siblings CTE 只 filter s.status = 'active'，但沒 check
+-- products.status。實際 prod 有 27 筆商品 product.status='inactive'
+-- 但對應 SKU 仍 'active'，導致加單時下架商品還是出現在 picker。
+--
+-- 修法：siblings 撈 SKU 時也要求 products.status='active'。
+-- in_campaign CTE 不動 — 那是「已加進 campaign 的 items」，保留可
+-- 讓既有列項目顯示。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_search_skus_for_campaign(
+  p_campaign_id BIGINT,
+  p_term        TEXT,
+  p_limit       INT DEFAULT 20
+) RETURNS TABLE (
+  campaign_item_id BIGINT,
+  sku_id           BIGINT,
+  sku_code         TEXT,
+  product_name     TEXT,
+  variant_name     TEXT,
+  unit_price       NUMERIC,
+  cap_qty          NUMERIC
+)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_term   TEXT := COALESCE(NULLIF(TRIM(p_term), ''), NULL);
+  v_lim    INT  := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+BEGIN
+  PERFORM 1 FROM group_buy_campaigns WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id; END IF;
+
+  RETURN QUERY
+  WITH campaign_products AS (
+    SELECT DISTINCT s.product_id
+      FROM campaign_items ci
+      JOIN skus s ON s.id = ci.sku_id
+     WHERE ci.tenant_id = v_tenant
+       AND ci.campaign_id = p_campaign_id
+  ),
+  in_campaign AS (
+    SELECT ci.id          AS x_ci_id,
+           s.id           AS x_sku_id,
+           s.sku_code     AS x_sku_code,
+           COALESCE(s.product_name, p.name) AS x_product_name,
+           s.variant_name AS x_variant_name,
+           ci.unit_price  AS x_unit_price,
+           ci.cap_qty     AS x_cap_qty,
+           ci.sort_order  AS x_sort_order,
+           p.name         AS x_p_name
+      FROM campaign_items ci
+      JOIN skus s     ON s.id = ci.sku_id
+      JOIN products p ON p.id = s.product_id
+     WHERE ci.tenant_id   = v_tenant
+       AND ci.campaign_id = p_campaign_id
+  ),
+  siblings AS (
+    SELECT NULL::BIGINT   AS x_ci_id,
+           s.id           AS x_sku_id,
+           s.sku_code     AS x_sku_code,
+           COALESCE(s.product_name, p.name) AS x_product_name,
+           s.variant_name AS x_variant_name,
+           COALESCE((
+             SELECT pr.price
+               FROM prices pr
+              WHERE pr.tenant_id = v_tenant
+                AND pr.sku_id = s.id
+                AND pr.scope = 'retail'
+                AND pr.effective_to IS NULL
+              ORDER BY pr.effective_from DESC
+              LIMIT 1
+           ), 0)::NUMERIC AS x_unit_price,
+           NULL::NUMERIC  AS x_cap_qty,
+           999999::INT    AS x_sort_order,
+           p.name         AS x_p_name
+      FROM skus s
+      JOIN products p ON p.id = s.product_id
+     WHERE s.tenant_id = v_tenant
+       AND s.status = 'active'
+       AND p.status = 'active'        -- ★ 新增：排除已下架/已停產商品
+       AND s.product_id IN (SELECT product_id FROM campaign_products)
+       AND NOT EXISTS (
+         SELECT 1 FROM campaign_items ci
+          WHERE ci.tenant_id = v_tenant
+            AND ci.campaign_id = p_campaign_id
+            AND ci.sku_id = s.id
+       )
+  ),
+  combined AS (
+    SELECT * FROM in_campaign
+    UNION ALL
+    SELECT * FROM siblings
+  )
+  SELECT c.x_ci_id, c.x_sku_id, c.x_sku_code, c.x_product_name,
+         c.x_variant_name, c.x_unit_price, c.x_cap_qty
+    FROM combined c
+   WHERE (
+     v_term IS NULL
+     OR c.x_sku_code     ILIKE '%' || v_term || '%'
+     OR c.x_variant_name ILIKE '%' || v_term || '%'
+     OR c.x_p_name       ILIKE '%' || v_term || '%'
+     OR c.x_product_name ILIKE '%' || v_term || '%'
+   )
+   ORDER BY (c.x_ci_id IS NULL), c.x_sort_order, c.x_product_name
+   LIMIT v_lim;
+END;
+$$;


### PR DESCRIPTION
## Summary
加單品項 picker（`rpc_search_skus_for_campaign`）排除「已下架的商品」。

## 既有問題
`siblings` CTE 只 filter `s.status = 'active'`，但沒 check `products.status`。
prod 實際 dataset：

| product_status | sku_status | rows |
| --- | --- | --- |
| discontinued | discontinued | 7 |
| discontinued | draft | 1 |
| **inactive** | **active** | **27** ← 問題在這 |
| inactive | discontinued | 3 |

管理員下架商品時通常只動 `products.status`、不動 SKU。結果這 27 筆下架商品仍在加單時跑出來讓人選。

## 修法
`siblings` 撈 SKU 時也要求 `products.status = 'active'`。  
`in_campaign` CTE 不動 — 那是「已加進 campaign 的 items」，若管理員後來下架商品，campaign 仍要看得到既有 items 才能操作。

## 部署狀態
- ✅ Migration 已在 prod 跑過、ledger 已登記（`20260620000050`）
- 本 PR 把改動推回 repo，未來 redeploy / 新環境 setup 才會跟上

## Test plan
- [ ] 後台「加單」→ 搜尋商品，下架商品（product.status=inactive）不應出現
- [ ] 既有 campaign_items 仍可見（in_campaign CTE 不受影響）
- [ ] discontinued 商品也不會出現（同樣被 `p.status = 'active'` 擋掉）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3y8guQqBisy2uXvRD5sdC)_