### PR TITLE
fix(rpc_resync_campaign_from_product): resync 時移除 discontinued SKU 殘留 item

### DIFF
--- a/supabase/migrations/20260620000060_resync_remove_discontinued_items.sql
+++ b/supabase/migrations/20260620000060_resync_remove_discontinued_items.sql
@@ -1,0 +1,314 @@
+-- ============================================================
+-- rpc_resync_campaign_from_product：resync 時順手移除 discontinued SKU 的 campaign_items
+--
+-- 既有 bug pattern：當 SKU 被停產（status='discontinued'），既有
+-- campaign_items 不會被處理（reprice / add 兩條邏輯都 require status='active'），
+-- 結果 discontinued SKU 一直掛在 campaign 上、unit_price 還是舊值（常見 0），
+-- 顯示在顧客頁面變「0 元商品」。
+--
+-- prod 已用手動 cleanup 清過 5 筆受影響 row，本 migration 把 RPC 邏輯補上，
+-- 之後 resync 會自動處理。
+--
+-- 邏輯：
+--   - 預覽（dry_run）：算「discontinued sku + 在此 campaign + 沒有 customer_order_items
+--     引用」的 campaign_items 數量與 sku_code，回傳 items_removed / items_removed_count
+--   - 實跑：apply 階段先 DELETE 這些 row（reprice / add 之前；reprice / add 用 status='active'
+--     filter 本來就不會碰它們，順序不重要但邏輯比較清楚）
+--   - 有訂單引用的 discontinued sku 仍保留，需要管理員手動處理（避免破壞既有訂單明細）
+--
+-- 其餘邏輯與 20260620000020 完全相同。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_resync_campaign_from_product(
+  p_campaign_id BIGINT,
+  p_dry_run     BOOLEAN DEFAULT TRUE,
+  p_operator    UUID    DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant    UUID := (auth.jwt() ->> 'tenant_id')::uuid;
+  v_role      TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_op        UUID := COALESCE(p_operator, auth.uid());
+  v_camp      group_buy_campaigns%ROWTYPE;
+  v_prod_name TEXT;
+  v_bad_cnt   INT;
+  v_bad_list  TEXT;
+  v_name_changed       BOOLEAN := FALSE;
+  v_items_repriced     INT := 0;
+  v_items_removed_cnt  INT := 0;
+  v_items_removed_json JSONB;
+  v_skus_added         INT := 0;
+  v_orders             INT := 0;
+  v_lines              INT := 0;
+  v_amt_before         NUMERIC := 0;
+  v_amt_after          NUMERIC := 0;
+  v_items_json         JSONB;
+  v_result             JSONB;
+BEGIN
+  -- ---------- 權限：僅管理員 ----------
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+  IF v_role NOT IN ('owner','admin','') THEN
+    RAISE EXCEPTION '權限不足：僅管理員可重新同步開團（role=%）', v_role;
+  END IF;
+
+  -- ---------- 開團 + 狀態守門 ----------
+  SELECT * INTO v_camp
+    FROM group_buy_campaigns
+   WHERE id = p_campaign_id AND tenant_id = v_tenant
+   FOR UPDATE;
+  IF v_camp.id IS NULL THEN
+    RAISE EXCEPTION 'campaign % 不在 tenant 內', p_campaign_id;
+  END IF;
+  IF v_camp.status NOT IN ('draft','open') THEN
+    RAISE EXCEPTION '只有草稿/開團中的開團可以重新同步（目前狀態：%）', v_camp.status;
+  END IF;
+
+  -- ---------- 守門：已在 campaign_items 的 active SKU 必須都有有效零售價 ----------
+  SELECT COUNT(*),
+         string_agg(s.sku_code, ', ' ORDER BY s.sku_code)
+    INTO v_bad_cnt, v_bad_list
+    FROM campaign_items ci
+    JOIN skus s ON s.id = ci.sku_id AND s.tenant_id = ci.tenant_id
+   WHERE ci.campaign_id = p_campaign_id
+     AND ci.tenant_id   = v_tenant
+     AND s.status = 'active'
+     AND COALESCE((
+           SELECT pr.price FROM prices pr
+            WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+              AND pr.scope = 'retail' AND pr.effective_to IS NULL
+            ORDER BY pr.effective_from DESC LIMIT 1
+         ), 0) <= 0;
+  IF v_bad_cnt > 0 THEN
+    RAISE EXCEPTION '仍有 % 個 active SKU 沒有有效零售價，請先到商品頁設定售價（避免回填成 0）：%',
+      v_bad_cnt, v_bad_list;
+  END IF;
+
+  -- ---------- 名稱 ----------
+  IF v_camp.product_id IS NOT NULL THEN
+    SELECT name INTO v_prod_name
+      FROM products WHERE id = v_camp.product_id AND tenant_id = v_tenant;
+  END IF;
+  v_name_changed := (v_prod_name IS NOT NULL AND v_prod_name IS DISTINCT FROM v_camp.name);
+
+  -- ---------- 預覽：reprice 列表 ----------
+  SELECT COUNT(*),
+         jsonb_agg(jsonb_build_object(
+           'sku_id', t.sku_id, 'sku_code', t.sku_code,
+           'old_price', t.old_price, 'new_price', t.new_price
+         ) ORDER BY t.sku_code)
+    INTO v_items_repriced, v_items_json
+    FROM (
+      SELECT ci.sku_id, s.sku_code, ci.unit_price AS old_price,
+             (SELECT pr.price FROM prices pr
+               WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+                 AND pr.scope = 'retail' AND pr.effective_to IS NULL
+               ORDER BY pr.effective_from DESC LIMIT 1) AS new_price
+        FROM campaign_items ci
+        JOIN skus s ON s.id = ci.sku_id AND s.tenant_id = ci.tenant_id
+       WHERE ci.campaign_id = p_campaign_id AND ci.tenant_id = v_tenant
+         AND s.status = 'active'
+    ) t
+   WHERE t.old_price IS DISTINCT FROM t.new_price;
+
+  -- ---------- 預覽：將被移除的 discontinued SKU items（無訂單引用）----------
+  SELECT COUNT(*),
+         jsonb_agg(jsonb_build_object(
+           'ci_id', t.ci_id, 'sku_id', t.sku_id, 'sku_code', t.sku_code,
+           'unit_price', t.unit_price
+         ) ORDER BY t.sku_code)
+    INTO v_items_removed_cnt, v_items_removed_json
+    FROM (
+      SELECT ci.id AS ci_id, ci.sku_id, s.sku_code, ci.unit_price
+        FROM campaign_items ci
+        JOIN skus s ON s.id = ci.sku_id AND s.tenant_id = ci.tenant_id
+       WHERE ci.campaign_id = p_campaign_id AND ci.tenant_id = v_tenant
+         AND s.status = 'discontinued'
+         AND NOT EXISTS (
+           SELECT 1 FROM customer_order_items coi WHERE coi.campaign_item_id = ci.id
+         )
+    ) t;
+
+  -- ---------- 預覽：補進的新 active SKU ----------
+  SELECT COUNT(*) INTO v_skus_added
+    FROM skus s
+   WHERE v_camp.product_id IS NOT NULL
+     AND s.tenant_id  = v_tenant
+     AND s.product_id = v_camp.product_id
+     AND s.status     = 'active'
+     AND NOT EXISTS (SELECT 1 FROM campaign_items ci
+                      WHERE ci.campaign_id = p_campaign_id
+                        AND ci.tenant_id = v_tenant AND ci.sku_id = s.id)
+     AND COALESCE((
+           SELECT pr.price FROM prices pr
+            WHERE pr.tenant_id = v_tenant AND pr.sku_id = s.id
+              AND pr.scope = 'retail' AND pr.effective_to IS NULL
+            ORDER BY pr.effective_from DESC LIMIT 1
+         ), 0) > 0;
+
+  -- 受影響的「待確認」訂單
+  SELECT COUNT(DISTINCT co.id) FILTER (
+           WHERE coi.unit_price IS DISTINCT FROM rc.new_price),
+         COUNT(*) FILTER (
+           WHERE coi.unit_price IS DISTINCT FROM rc.new_price)
+    INTO v_orders, v_lines
+    FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+    JOIN LATERAL (
+      SELECT (SELECT pr.price FROM prices pr
+                WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+                  AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                ORDER BY pr.effective_from DESC LIMIT 1) AS new_price
+    ) rc ON TRUE
+    JOIN skus s ON s.id = coi.sku_id AND s.tenant_id = co.tenant_id AND s.status = 'active'
+   WHERE co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending';
+
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price), 0),
+    COALESCE(SUM(coi.qty * COALESCE(
+       CASE WHEN s.status = 'active' THEN
+         (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1)
+       END, coi.unit_price)), 0)
+    INTO v_amt_before, v_amt_after
+    FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+    JOIN skus s ON s.id = coi.sku_id AND s.tenant_id = co.tenant_id
+   WHERE co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending';
+
+  v_result := jsonb_build_object(
+    'dry_run',             p_dry_run,
+    'campaign_id',         p_campaign_id,
+    'campaign_no',         v_camp.campaign_no,
+    'campaign_status',     v_camp.status,
+    'name_before',         v_camp.name,
+    'name_after',          COALESCE(v_prod_name, v_camp.name),
+    'name_changed',        v_name_changed,
+    'items',               COALESCE(v_items_json, '[]'::jsonb),
+    'items_repriced',      v_items_repriced,
+    'items_removed',       COALESCE(v_items_removed_json, '[]'::jsonb),
+    'items_removed_count', v_items_removed_cnt,
+    'skus_added',          v_skus_added,
+    'pending_orders',      v_orders,
+    'pending_order_lines', v_lines,
+    'amount_before',       v_amt_before,
+    'amount_after',        v_amt_after
+  );
+
+  IF p_dry_run THEN
+    RETURN v_result;
+  END IF;
+
+  -- ================= 實跑（單一交易，出錯全 rollback）=================
+
+  IF v_name_changed THEN
+    UPDATE group_buy_campaigns
+       SET name = v_prod_name, updated_at = NOW()
+     WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  END IF;
+
+  -- 移除 discontinued SKU 的 campaign_items（無訂單引用的才動）
+  DELETE FROM campaign_items ci
+   USING skus s
+   WHERE ci.sku_id = s.id AND s.tenant_id = ci.tenant_id
+     AND ci.campaign_id = p_campaign_id AND ci.tenant_id = v_tenant
+     AND s.status = 'discontinued'
+     AND NOT EXISTS (
+       SELECT 1 FROM customer_order_items coi WHERE coi.campaign_item_id = ci.id
+     );
+
+  UPDATE campaign_items ci
+     SET unit_price = (SELECT pr.price FROM prices pr
+                         WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+                           AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                         ORDER BY pr.effective_from DESC LIMIT 1),
+         updated_at = NOW(),
+         updated_by = v_op
+    FROM skus s
+   WHERE ci.sku_id = s.id AND s.tenant_id = ci.tenant_id
+     AND ci.campaign_id = p_campaign_id AND ci.tenant_id = v_tenant
+     AND s.status = 'active'
+     AND ci.unit_price IS DISTINCT FROM (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1);
+
+  INSERT INTO campaign_items
+    (tenant_id, campaign_id, sku_id, unit_price, sort_order, created_by, updated_by)
+  SELECT v_tenant, p_campaign_id, s.id,
+         (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = s.id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1),
+         999, v_op, v_op
+    FROM skus s
+   WHERE v_camp.product_id IS NOT NULL
+     AND s.tenant_id  = v_tenant
+     AND s.product_id = v_camp.product_id
+     AND s.status     = 'active'
+     AND NOT EXISTS (SELECT 1 FROM campaign_items ci
+                      WHERE ci.campaign_id = p_campaign_id
+                        AND ci.tenant_id = v_tenant AND ci.sku_id = s.id)
+     AND COALESCE((SELECT pr.price FROM prices pr
+                    WHERE pr.tenant_id = v_tenant AND pr.sku_id = s.id
+                      AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                    ORDER BY pr.effective_from DESC LIMIT 1), 0) > 0
+  ON CONFLICT (campaign_id, sku_id) DO NOTHING;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  SELECT co.tenant_id, co.id, 'item', coi.id, 'unit_price',
+         to_jsonb(coi.unit_price),
+         to_jsonb((SELECT pr.price FROM prices pr
+                     WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+                       AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                     ORDER BY pr.effective_from DESC LIMIT 1)),
+         '開團「重新同步商品/價格」批次回填（待確認訂單）',
+         COALESCE(v_op, co.updated_by, co.created_by, v_camp.created_by)
+    FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+    JOIN skus s ON s.id = coi.sku_id AND s.tenant_id = co.tenant_id AND s.status = 'active'
+   WHERE co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending'
+     AND coi.unit_price IS DISTINCT FROM (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1);
+
+  UPDATE customer_order_items coi
+     SET unit_price = (SELECT pr.price FROM prices pr
+                         WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+                           AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                         ORDER BY pr.effective_from DESC LIMIT 1),
+         updated_at = NOW(),
+         updated_by = v_op
+    FROM customer_orders co, skus s
+   WHERE coi.order_id = co.id
+     AND s.id = coi.sku_id AND s.tenant_id = co.tenant_id AND s.status = 'active'
+     AND co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending'
+     AND coi.unit_price IS DISTINCT FROM (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1);
+
+  RETURN v_result || jsonb_build_object('applied', TRUE);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION
+  public.rpc_resync_campaign_from_product(BIGINT, BOOLEAN, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_resync_campaign_from_product(BIGINT, BOOLEAN, UUID) IS
+  '開團重新同步：名稱←product、campaign_items 單價←現行零售價、補 active SKU、'
+  '移除 discontinued SKU（無訂單引用者）、回填 status=pending 訂單明細並寫 customer_order_audit_log。'
+  'draft/open 限定、僅管理員(owner/admin) 限定、active SKU 缺有效零售價則拒跑、p_dry_run 預設只預覽。';


### PR DESCRIPTION
## Summary
`rpc_resync_campaign_from_product` 補上「移除已停產 SKU 在 campaign 上的殘留 item」邏輯，dry_run 預覽也回報。

## 既有 bug 觀察

回報 case: `GB20260520-C000179` 顧客頁面跑出一個 **0 元商品**。

查 prod 全資料庫，相同 pattern 共 5 個 campaigns 都有「`sku.status='discontinued'` + `unit_price=0` + 完全沒任何 customer_order_items 引用」的殘留 item：

| campaign_no | ci_id | sku_code |
| --- | --- | --- |
| GB20260511-C000009 | 1594 | G00008-01 |
| GB20260511-C000010 | 1595 | G00009-01 |
| GB20260511-C000011 | 1596 | G00010-01 |
| GB20260520-C000179 | 1762 | G00065-01 |
| GB20260520-C000237 | 1784 | G00087-01 |

這 5 筆 prod 已手動 `DELETE` 清掉。本 PR 修 RPC 邏輯防止下次再發生。

## 根因
原本 resync 的兩條 SQL — `UPDATE campaign_items` (reprice) 跟 `INSERT INTO campaign_items` (add new SKU) — 都帶 `WHERE s.status = 'active'`。SKU 被停產後，既有 campaign_item 因為 sku 已非 active 而被兩條邏輯跳過，**永遠不會被處理或清掉**，靜靜地掛在 campaign 上。

## 修法
- **Preview (dry_run)**：算「`s.status='discontinued'` + `NOT EXISTS customer_order_items` ref」的 campaign_items 數量與 sku_code，加進 JSONB response 的 `items_removed` / `items_removed_count`
- **Apply**：apply 階段先 `DELETE` 這些 row（在 reprice / add 前，符合邏輯順序）
- **保留 with 訂單引用的**：有 customer_order_items 引用的 discontinued SKU 仍留，避免破壞既有訂單明細；需要 admin 手動處理

## 部署狀態
- ✅ Migration `20260620000060` 已在 prod 跑過、ledger 已登記
- 5 筆既有 bad row 早些手動清過
- 本 PR 把改動推回 repo

## Test plan
- [ ] Dry-run resync 一個有 discontinued sku 的 campaign，response 應帶 `items_removed_count > 0` 跟 `items_removed: [{ci_id, sku_id, sku_code, unit_price}, ...]`
- [ ] Apply resync 該 campaign，再查 `campaign_items`，那些 row 應消失
- [ ] 故意建一個 campaign_item → 在它上面建 customer_order_item 引用 → 把 sku 設為 discontinued → resync。該 row 應**保留**（有訂單引用）
- [ ] 沒 discontinued sku 的 campaign，行為跟舊 RPC 完全一樣

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3y8guQqBisy2uXvRD5sdC)_