### PR TITLE
feat(rpc_set_member_flags): 開放店長設定黑名單 / admin_note

### DIFF
--- a/supabase/migrations/20260620000070_member_flags_allow_store_manager.sql
+++ b/supabase/migrations/20260620000070_member_flags_allow_store_manager.sql
@@ -1,0 +1,55 @@
+-- ============================================================
+-- rpc_set_member_flags：權限放寬到店長
+--
+-- 既有 gate：owner / admin / hq_manager / hq_accountant / ''（HQ tier）
+-- 使用者要求（2026-05-20）：店長也應該能設黑名單 / admin_note，
+-- 不然第一線遇到狀況沒辦法即時擋。
+--
+-- 加 store_manager 進允許名單。store_staff 暫不開放（先看店長使用情形）。
+--
+-- 其餘 RPC 簽名 / 行為 / RETURNING 完全不變。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_set_member_flags(
+  p_member_id        BIGINT,
+  p_no_notify_pickup BOOLEAN,
+  p_no_new_order     BOOLEAN,
+  p_admin_note       TEXT,
+  p_operator         UUID DEFAULT NULL
+) RETURNS members
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant   UUID := (auth.jwt() ->> 'tenant_id')::uuid;
+  v_role     TEXT := COALESCE(
+                       NULLIF(auth.jwt() -> 'app_metadata' ->> 'role', ''),
+                       NULLIF(auth.jwt() ->> 'role', 'authenticated'),
+                       ''
+                     );
+  v_operator UUID := COALESCE(p_operator, auth.uid());
+  v_row      members;
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+  IF v_role NOT IN ('owner','admin','hq_manager','hq_accountant','store_manager','') THEN
+    RAISE EXCEPTION 'permission denied: only HQ tier or store_manager can edit member flags';
+  END IF;
+
+  UPDATE members
+     SET no_notify_pickup = p_no_notify_pickup,
+         no_new_order     = p_no_new_order,
+         admin_note       = NULLIF(TRIM(COALESCE(p_admin_note, '')), ''),
+         updated_by       = v_operator,
+         updated_at       = NOW()
+   WHERE id = p_member_id AND tenant_id = v_tenant
+   RETURNING * INTO v_row;
+
+  IF v_row.id IS NULL THEN
+    RAISE EXCEPTION 'member % not found in tenant %', p_member_id, v_tenant;
+  END IF;
+  RETURN v_row;
+END;
+$$;


### PR DESCRIPTION
## Summary
`rpc_set_member_flags` 加 `store_manager` 進允許角色名單。店長現在可以設黑名單（`no_notify_pickup` / `no_new_order`）和 `admin_note`。

## 為什麼
店長在會員明細頁勾「黑名單：禁止此會員加新訂單」儲存時被擋：

> 儲存失敗：permission denied: only HQ tier can edit member flags

第一線狀況（奧客、惡意下單等）需要店長即時擋下，不該每次都要等總部處理。

## 修法
唯一變動 — `IF v_role NOT IN (...)` 名單從：
```sql
('owner','admin','hq_manager','hq_accountant','')
```
變成：
```sql
('owner','admin','hq_manager','hq_accountant','store_manager','')
```

並把對應 error 文字從 `only HQ tier can edit member flags` 改成 `only HQ tier or store_manager can edit member flags`。

`store_staff` 暫不開放（先看店長使用情形）。其他 RPC 簽名 / 行為 / RETURNING 完全不變。

## 部署狀態
- ✅ Migration `20260620000070` 已在 prod 跑過、ledger 已登記
- 本 PR 把改動推回 repo

## 後續權限整理（已記下、本 PR 不處理）
之前 explore 出整個 codebase 25+ RPC + 12+ RLS 的權限檢查散在各檔，狀態混亂（例如 `purchaser` 角色只用在採購、`warehouse` 只用在盤點、wallet_adjust 允許 store_manager 但 set_member_flags 不允許等）。等之後一次性整合到員工權限設定頁時再統一處理。

## Test plan
- [ ] 店長帳號（role=store_manager）登入 admin，去任一會員明細勾黑名單儲存 → 成功
- [ ] 店員（store_staff）操作仍應被擋
- [ ] HQ tier 操作行為不變
- [ ] admin_note 儲存也走同樣權限

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3y8guQqBisy2uXvRD5sdC)_