### PR TITLE
feat(admin/campaigns): 開團時間 input 加整點 chip

### DIFF
--- a/apps/admin/src/components/CampaignForm.tsx
+++ b/apps/admin/src/components/CampaignForm.tsx
@@ -176,33 +176,39 @@ export function CampaignForm({
           label={v.close_type === "fast" ? "開團期間（開團 → 收單，快團必填收單）" : "開團期間（開團 → 收單）"}
           className="sm:col-span-2"
         >
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <input
-              type="datetime-local"
-              value={toDtLocal(v.start_at)}
-              onChange={(e) => {
-                const startIso = e.target.value ? new Date(e.target.value).toISOString() : null;
-                setV((prev) => {
-                  const next: CampaignFormValues = { ...prev, start_at: startIso };
-                  if (startIso && prev.end_at && new Date(prev.end_at) <= new Date(startIso)) {
-                    next.end_at = null;
-                  }
-                  return next;
-                });
-              }}
-              className={`${inputCls} flex-1`}
-              aria-label="開團時間"
-            />
-            <span className="text-center text-xs text-zinc-400 sm:px-1">→</span>
-            <input
-              type="datetime-local"
-              required={v.close_type === "fast"}
-              value={toDtLocal(v.end_at)}
-              min={toDtLocal(v.start_at) || undefined}
-              onChange={(e) => update("end_at", e.target.value ? new Date(e.target.value).toISOString() : null)}
-              className={`${inputCls} flex-1`}
-              aria-label="收單時間"
-            />
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
+            <div className="flex flex-1 flex-col gap-1">
+              <input
+                type="datetime-local"
+                value={toDtLocal(v.start_at)}
+                onChange={(e) => {
+                  const startIso = e.target.value ? new Date(e.target.value).toISOString() : null;
+                  setV((prev) => {
+                    const next: CampaignFormValues = { ...prev, start_at: startIso };
+                    if (startIso && prev.end_at && new Date(prev.end_at) <= new Date(startIso)) {
+                      next.end_at = null;
+                    }
+                    return next;
+                  });
+                }}
+                className={inputCls}
+                aria-label="開團時間"
+              />
+              <TimeSnapRow field="start_at" setV={setV} />
+            </div>
+            <span className="text-center text-xs text-zinc-400 sm:px-1 sm:pt-2">→</span>
+            <div className="flex flex-1 flex-col gap-1">
+              <input
+                type="datetime-local"
+                required={v.close_type === "fast"}
+                value={toDtLocal(v.end_at)}
+                min={toDtLocal(v.start_at) || undefined}
+                onChange={(e) => update("end_at", e.target.value ? new Date(e.target.value).toISOString() : null)}
+                className={inputCls}
+                aria-label="收單時間"
+              />
+              <TimeSnapRow field="end_at" setV={setV} />
+            </div>
           </div>
           <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[11px] text-zinc-500">
             <span>快速：</span>
@@ -271,6 +277,55 @@ export function CampaignForm({
         <SpinButton type="button" onClick={() => onCancel ? onCancel() : router.push("/campaigns")} className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800">取消</SpinButton>
       </div>
     </form>
+  );
+}
+
+const TIME_PRESETS: { label: string; hh: number; mm: number }[] = [
+  { label: "00:00", hh: 0, mm: 0 },
+  { label: "08:00", hh: 8, mm: 0 },
+  { label: "12:00", hh: 12, mm: 0 },
+  { label: "20:00", hh: 20, mm: 0 },
+  { label: "23:59", hh: 23, mm: 59 },
+];
+
+function snapTime(
+  setV: React.Dispatch<React.SetStateAction<CampaignFormValues>>,
+  field: "start_at" | "end_at",
+  hh: number,
+  mm: number,
+) {
+  setV((prev) => {
+    const base = prev[field] ? new Date(prev[field]!) : new Date();
+    base.setHours(hh, mm, 0, 0);
+    const iso = base.toISOString();
+    const next: CampaignFormValues = { ...prev, [field]: iso };
+    if (field === "start_at" && prev.end_at && new Date(prev.end_at) <= new Date(iso)) {
+      next.end_at = null;
+    }
+    return next;
+  });
+}
+
+function TimeSnapRow({
+  field,
+  setV,
+}: {
+  field: "start_at" | "end_at";
+  setV: React.Dispatch<React.SetStateAction<CampaignFormValues>>;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {TIME_PRESETS.map((t) => (
+        <SpinButton
+          key={t.label}
+          type="button"
+          onClick={() => snapTime(setV, field, t.hh, t.mm)}
+          className="rounded border border-zinc-200 px-1.5 py-0.5 font-mono text-[11px] text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+        >
+          {t.label}
+        </SpinButton>
+      ))}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
編輯 modal 的「開團期間」每個 datetime input 下方加一排小 chip：`00:00 / 08:00 / 12:00 / 20:00 / 23:59`。

點 chip 後保留現有日期、只把時間 snap 到該整點，省去原生 datetime picker 滑時/分的麻煩，整點時間（尤其 00:00）視覺上也比較好辨識。

## 行為
- 若該欄位已有值：保留日期、只覆蓋時間
- 若該欄位為空：用「今天」當基準
- 點 start_at chip 後若 end_at ≤ start_at，自動清掉 end_at（沿用原本 onChange 邏輯）

## 影響範圍
僅 `apps/admin/src/components/CampaignForm.tsx`（編輯開團 modal 內的時間選擇 UI）。

## Test plan
- [ ] 開「編輯開團」modal，每個 datetime input 下方各有 5 顆 chip
- [ ] 該欄位已選日期時，點 chip 只改時間（日期不變）
- [ ] 該欄位空白時，點 chip 帶入今天 + 指定時間
- [ ] 點 start_at 的 chip 把 start 拉到 end 之後，end 被清空
- [ ] 非 admin 不影響（這只是 input 的輔助 UI，admin gate 在 #315）

## 關聯
與 [#315](https://github.com/lt-foods/new_erp/pull/315) 主題相關（同一輪改開團 UX），但獨立 PR 互不阻塞。

🤖 Generated with [Claude Code](https://claude.com/claude-code)