### PR TITLE
feat(admin/orders/pivot): 移除取貨日 + 凍結 thead + 加「只看已收單」filter

### DIFF
--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -57,12 +57,12 @@ type PivotRow = {
 };
 
 type ViewBy = "order_date" | "campaign";
-type Metric = "item_qty" | "order_count" | "amount";
+type Metric = "item_qty" | "amount";
 
-// 把舊 LS 的 "count" 視為 "item_qty" (用戶真正想要的、之前命名誤導)
+// 把舊 LS / URL 殘留的 "count" / "order_count" 視為 "item_qty"
 function normalizeMetric(v: string | undefined | null): Metric | null {
-  if (v === "item_qty" || v === "order_count" || v === "amount") return v;
-  if (v === "count") return "item_qty"; // legacy migration
+  if (v === "item_qty" || v === "amount") return v;
+  if (v === "count" || v === "order_count") return "item_qty"; // legacy
   return null;
 }
 
@@ -444,24 +444,17 @@ function PivotContent() {
   }, [pivot]);
 
   // metric 取值 helper
-  // 訂單數淨值＝有效訂單數 − 取消/逾期/轉出 訂單數
-  const cellOrderCount = (c: CellAgg): number => c.posOrders.size - c.negOrders.size;
   const cellTouched = (c: CellAgg): number => c.posOrders.size + c.negOrders.size;
   const cellAllOrderIds = (c: CellAgg): number[] => [...c.posOrders, ...c.negOrders];
   const cellValue = (cell: CellAgg | undefined): number => {
     if (!cell) return 0;
-    if (metric === "item_qty") return cell.qtySum;
-    if (metric === "order_count") return cellOrderCount(cell);
-    return cell.amount;
+    return metric === "item_qty" ? cell.qtySum : cell.amount;
   };
   const fmtCellValue = (v: number): string => {
     if (metric === "amount") return fmtAmount(v);
-    // item_qty / order_count 都顯示數字 (qty 可能小數、round 2 位後去 trailing 0)
-    if (metric === "item_qty") {
-      const r = Math.round(v * 100) / 100;
-      return String(r);
-    }
-    return String(v);
+    // item_qty 可能小數、round 2 位後去 trailing 0
+    const r = Math.round(v * 100) / 100;
+    return String(r);
   };
 
   // Grand totals — 依 metric 取值
@@ -471,12 +464,7 @@ function PivotContent() {
     for (const g of pivot.groups) {
       for (const [, entry] of g.skus) {
         for (const [sid, cell] of entry.perStore) {
-          const v =
-            metric === "item_qty"
-              ? cell.qtySum
-              : metric === "order_count"
-              ? cell.posOrders.size - cell.negOrders.size
-              : cell.amount;
+          const v = metric === "item_qty" ? cell.qtySum : cell.amount;
           perStore.set(sid, (perStore.get(sid) ?? 0) + v);
           grand += v;
         }
@@ -713,7 +701,7 @@ function PivotContent() {
         </div>
       )}
 
-      {/* Metric toggle: 品項數 / 訂單數 / 訂單金額 */}
+      {/* Metric toggle: 品項數 / 訂單金額 */}
       <div className="flex items-center gap-2 text-sm">
         <span className="text-zinc-500">數值：</span>
         <div className="inline-flex rounded-md border border-zinc-300 dark:border-zinc-700">
@@ -727,17 +715,6 @@ function PivotContent() {
             title="該品項數量加總 (Σ qty)"
           >
             品項數
-          </SpinButton>
-          <SpinButton
-            onClick={() => setMetric("order_count")}
-            className={`border-l border-zinc-300 px-3 py-1.5 text-sm transition-colors dark:border-zinc-700 ${
-              metric === "order_count"
-                ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
-                : "bg-white text-zinc-700 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-900"
-            }`}
-            title="不重複訂單數 (COUNT DISTINCT order_id)"
-          >
-            訂單數
           </SpinButton>
           <SpinButton
             onClick={() => setMetric("amount")}
@@ -945,8 +922,6 @@ function PivotContent() {
         說明：Cell 為「該 group × 該品項 × 該店」的
         {metric === "item_qty"
           ? "品項數量加總（Σ qty）"
-          : metric === "order_count"
-          ? "不重複訂單數（COUNT DISTINCT order_id）"
           : "金額合計（Σ qty × unit_price）"}
         ，點數字看訂單清單。
       </p>

--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -56,13 +56,20 @@ type PivotRow = {
   neg_order_ids: number[];
 };
 
-type ViewBy = "pickup_date" | "order_date" | "campaign";
+type ViewBy = "order_date" | "campaign";
 type Metric = "item_qty" | "order_count" | "amount";
 
 // 把舊 LS 的 "count" 視為 "item_qty" (用戶真正想要的、之前命名誤導)
 function normalizeMetric(v: string | undefined | null): Metric | null {
   if (v === "item_qty" || v === "order_count" || v === "amount") return v;
   if (v === "count") return "item_qty"; // legacy migration
+  return null;
+}
+
+// 「取貨日」分組已下架（2026-05-21）— 舊 LS / URL 殘留 fallback 到 campaign
+function normalizeViewBy(v: string | undefined | null): ViewBy | null {
+  if (v === "order_date" || v === "campaign") return v;
+  if (v === "pickup_date") return "campaign";
   return null;
 }
 
@@ -140,7 +147,7 @@ function PivotContent() {
 
   const [campaignIds, setCampaignIds] = useState<string[]>(initialCampaignIds);
   const [viewBy, setViewBy] = useState<ViewBy>(
-    (searchParams.get("viewBy") as ViewBy) || "campaign",
+    normalizeViewBy(searchParams.get("viewBy")) ?? "campaign",
   );
   const [dateFrom, setDateFrom] = useState(
     normalizeMonth(searchParams.get("from")) ?? def.from,
@@ -200,8 +207,9 @@ function PivotContent() {
         if (!searchParams.get("campaignIds") && Array.isArray(saved.campaignIds)) {
           setCampaignIds(saved.campaignIds);
         }
-        if (!searchParams.get("viewBy") && saved.viewBy) {
-          setViewBy(saved.viewBy);
+        if (!searchParams.get("viewBy")) {
+          const v = normalizeViewBy(saved.viewBy);
+          if (v) setViewBy(v);
         }
         if (!searchParams.get("from")) {
           const m = normalizeMonth(saved.dateFrom);
@@ -564,14 +572,13 @@ function PivotContent() {
           )}
         </div>
 
-        {/* viewBy: 取貨日 / 訂單日 / 開團 */}
+        {/* viewBy: 訂單日 / 開團 */}
         <select
           value={viewBy}
           onChange={(e) => setViewBy(e.target.value as ViewBy)}
           className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
           title="樞紐表 row 的分組維度"
         >
-          <option value="pickup_date">分組：取貨日</option>
           <option value="order_date">分組：訂單日</option>
           <option value="campaign">分組：開團（收單期間）</option>
         </select>
@@ -582,8 +589,6 @@ function PivotContent() {
           title={
             viewBy === "campaign"
               ? "依開團模式：套用至 campaign 收單月份 (end_at)"
-              : viewBy === "pickup_date"
-              ? "依取貨日：套用至訂單 pickup_deadline 月份"
               : "依訂單日：套用至訂單 created_at 月份"
           }
         >

--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -158,6 +158,9 @@ function PivotContent() {
   const [metric, setMetric] = useState<Metric>(
     normalizeMetric(searchParams.get("metric")) ?? "item_qty",
   );
+  const [closedOnly, setClosedOnly] = useState<boolean>(
+    searchParams.get("closedOnly") === "1",
+  );
 
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [stores, setStores] = useState<Store[]>([]);
@@ -203,6 +206,7 @@ function PivotContent() {
           status: OrderStatus[];
           storeId: string;
           metric: Metric;
+          closedOnly: boolean;
         }>;
         if (!searchParams.get("campaignIds") && Array.isArray(saved.campaignIds)) {
           setCampaignIds(saved.campaignIds);
@@ -229,6 +233,9 @@ function PivotContent() {
           const m = normalizeMetric(saved.metric);
           if (m) setMetric(m);
         }
+        if (!searchParams.get("closedOnly") && typeof saved.closedOnly === "boolean") {
+          setClosedOnly(saved.closedOnly);
+        }
       }
     } catch {
       /* noop */
@@ -251,12 +258,13 @@ function PivotContent() {
           status: Array.from(statusSet),
           storeId,
           metric,
+          closedOnly,
         }),
       );
     } catch {
       /* noop */
     }
-  }, [hydrated, campaignIds, viewBy, dateFrom, dateTo, statusSet, storeId, metric]);
+  }, [hydrated, campaignIds, viewBy, dateFrom, dateTo, statusSet, storeId, metric, closedOnly]);
 
   // 分店帳號鎖
   const branchStoreId = useUserBranchStoreId(stores);
@@ -311,6 +319,7 @@ function PivotContent() {
           p_campaign_ids: campaignIds.length ? campaignIds.map((x) => Number(x)) : null,
           p_store_id: storeId ? Number(storeId) : null,
           p_statuses: statusArr,
+          p_closed_only: closedOnly ? true : null,
         });
         if (cancelled) return;
         if (rpcErr) {
@@ -330,7 +339,7 @@ function PivotContent() {
     return () => {
       cancelled = true;
     };
-  }, [hydrated, campaignIds, viewBy, dateFrom, dateTo, statusSet, storeId]);
+  }, [hydrated, campaignIds, viewBy, dateFrom, dateTo, statusSet, storeId, closedOnly]);
 
   const storeMap = useMemo(() => new Map(stores.map((s) => [s.id, s])), [stores]);
   const campaignMap = useMemo(() => new Map(campaigns.map((c) => [c.id, c])), [campaigns]);
@@ -743,6 +752,19 @@ function PivotContent() {
           </SpinButton>
         </div>
 
+        {/* 只看已收單 toggle — campaign.status ∈ closed/ordered/receiving/ready/completed */}
+        <SpinButton
+          onClick={() => setClosedOnly((v) => !v)}
+          className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
+            closedOnly
+              ? "border-amber-300 bg-amber-100 text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-300"
+              : "border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-900"
+          }`}
+          title="只看已過收單階段（closed / ordered / receiving / ready / completed）的開團"
+        >
+          只看已收單
+        </SpinButton>
+
         <div className="ml-auto flex items-center gap-1">
           <span className="hidden text-xs text-zinc-400 sm:inline">店別欄</span>
           <SpinButton
@@ -768,7 +790,7 @@ function PivotContent() {
 
       <div
         ref={scrollRef}
-        className="no-scrollbar overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950"
+        className="no-scrollbar max-h-[calc(100vh-280px)] overflow-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950"
       >
         {loading && pivot.groups.length === 0 ? (
           <p className="p-6 text-center text-sm text-zinc-500">載入中…</p>
@@ -776,24 +798,24 @@ function PivotContent() {
           <p className="p-6 text-center text-sm text-zinc-500">沒有符合條件的訂單。</p>
         ) : (
           <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
-            <thead className="bg-zinc-50 dark:bg-zinc-900">
+            <thead className="sticky top-0 z-10 bg-zinc-50 shadow-[0_1px_0_0_rgb(228_228_231)] dark:bg-zinc-900 dark:shadow-[0_1px_0_0_rgb(39_39_42)]">
               <tr>
-                <th className="w-64 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">
+                <th className="w-64 bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
                   {viewBy === "campaign" ? "開團" : "日期"}
                 </th>
-                <th className="min-w-[180px] px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">
+                <th className="min-w-[180px] bg-zinc-50 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900">
                   商品品項
                 </th>
                 {pivot.storeIds.map((sid) => (
                   <th
                     key={sid}
-                    className="min-w-[80px] px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500"
+                    className="min-w-[80px] bg-zinc-50 px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500 dark:bg-zinc-900"
                     title={storeMap.get(sid)?.code ?? ""}
                   >
                     {storeMap.get(sid)?.name ?? `店#${sid}`}
                   </th>
                 ))}
-                <th className="px-3 py-2 text-right text-xs font-bold uppercase tracking-wide text-zinc-700 dark:text-zinc-300">
+                <th className="bg-zinc-50 px-3 py-2 text-right text-xs font-bold uppercase tracking-wide text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
                   合計
                 </th>
               </tr>

--- a/supabase/migrations/20260621000020_rpc_orders_pivot_closed_filter.sql
+++ b/supabase/migrations/20260621000020_rpc_orders_pivot_closed_filter.sql
@@ -1,0 +1,126 @@
+-- ============================================================
+-- rpc_orders_pivot v2 — 加 p_closed_only filter
+--   讓 admin /orders/pivot 可以單獨看「已收單階段的開團」
+--   (campaign.status ∈ closed/ordered/receiving/ready/completed)
+--
+--   p_closed_only:
+--     NULL  = 全部開團都納入（預設）
+--     true  = 只看「已收單」階段以後的開團
+--     false = 只看「進行中」的開團（draft/open/cancelled）
+--
+--   PG 不能用 CREATE OR REPLACE 改 signature → DROP + CREATE
+-- ============================================================
+
+DROP FUNCTION IF EXISTS rpc_orders_pivot(text, date, date, bigint[], bigint, text[]);
+
+CREATE OR REPLACE FUNCTION rpc_orders_pivot(
+  p_view_by      text,
+  p_date_from    date,
+  p_date_to      date,
+  p_campaign_ids bigint[],
+  p_store_id     bigint,
+  p_statuses     text[],
+  p_closed_only  boolean DEFAULT NULL
+)
+RETURNS TABLE (
+  group_key        text,
+  group_id         bigint,
+  sku_id           bigint,
+  sku_product_name text,
+  sku_variant_name text,
+  pickup_store_id  bigint,
+  qty_sum          numeric,
+  amount           numeric,
+  pos_order_ids    bigint[],
+  neg_order_ids    bigint[]
+)
+LANGUAGE sql STABLE
+AS $$
+  WITH filtered AS (
+    SELECT o.*
+    FROM customer_orders o
+    LEFT JOIN group_buy_campaigns c ON c.id = o.campaign_id
+    WHERE o.status = ANY(p_statuses)
+      AND (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      AND (
+        p_closed_only IS NULL
+        OR (p_closed_only IS TRUE
+            AND c.status IN ('closed','ordered','receiving','ready','completed'))
+        OR (p_closed_only IS FALSE
+            AND c.status NOT IN ('closed','ordered','receiving','ready','completed'))
+      )
+      AND CASE p_view_by
+        WHEN 'pickup_date' THEN
+          (p_date_from IS NULL OR o.pickup_deadline >= p_date_from)
+          AND (p_date_to IS NULL OR o.pickup_deadline <  p_date_to)
+        WHEN 'order_date' THEN
+          (p_date_from IS NULL OR o.created_at >= p_date_from::timestamptz)
+          AND (p_date_to IS NULL OR o.created_at <  p_date_to::timestamptz)
+        WHEN 'campaign' THEN
+          c.end_at IS NULL
+          OR (
+            (p_date_from IS NULL OR c.end_at >= p_date_from::timestamptz)
+            AND (p_date_to IS NULL OR c.end_at <  p_date_to::timestamptz)
+          )
+        ELSE TRUE
+      END
+  ),
+  base AS (
+    SELECT
+      CASE p_view_by
+        WHEN 'campaign'    THEN 'c' || f.campaign_id::text
+        WHEN 'pickup_date' THEN 'd' || to_char(COALESCE(f.pickup_deadline, f.created_at::date), 'YYYY-MM-DD')
+        WHEN 'order_date'  THEN 'd' || to_char(f.created_at::date, 'YYYY-MM-DD')
+      END                                              AS group_key,
+      CASE WHEN p_view_by = 'campaign' THEN f.campaign_id ELSE NULL::bigint END
+                                                       AS group_id,
+      i.sku_id,
+      s.product_name                                   AS sku_product_name,
+      s.variant_name                                   AS sku_variant_name,
+      f.pickup_store_id,
+      f.id                                             AS order_id,
+      f.status,
+      i.qty,
+      i.unit_price
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    LEFT JOIN skus s ON s.id = i.sku_id
+  )
+  SELECT
+    b.group_key,
+    b.group_id,
+    b.sku_id,
+    b.sku_product_name,
+    b.sku_variant_name,
+    b.pickup_store_id,
+    SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+             THEN (-b.qty) ELSE b.qty END)::numeric                          AS qty_sum,
+    SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+             THEN (-b.qty) * b.unit_price ELSE b.qty * b.unit_price END)::numeric
+                                                                              AS amount,
+    COALESCE(
+      ARRAY_AGG(DISTINCT b.order_id)
+        FILTER (WHERE b.status NOT IN ('cancelled','expired','transferred_out')),
+      '{}'::bigint[]
+    )                                                                         AS pos_order_ids,
+    COALESCE(
+      ARRAY_AGG(DISTINCT b.order_id)
+        FILTER (WHERE b.status IN ('cancelled','expired','transferred_out')),
+      '{}'::bigint[]
+    )                                                                         AS neg_order_ids
+  FROM base b
+  GROUP BY
+    b.group_key,
+    b.group_id,
+    b.sku_id,
+    b.sku_product_name,
+    b.sku_variant_name,
+    b.pickup_store_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_orders_pivot(text, date, date, bigint[], bigint, text[], boolean) TO authenticated;


### PR DESCRIPTION
## Summary

訂單樞紐表三項 UX 調整：

1. **移除「分組：取貨日」選項** — 只留「訂單日」「開團（收單期間）」兩種。舊 LS / URL `viewBy=pickup_date` 被 `normalizeViewBy` 自動 fallback 到 `campaign`。
2. **凍結 thead** — 表格容器加 `max-h + overflow-auto`，thead `sticky top-0`，往下捲時店名 column header 保持貼頂。
3. **加「只看已收單」filter** — toggle pill，on 時只看 `campaign.status ∈ closed/ordered/receiving/ready/completed` 的開團；LS 持久 + URL param。

需要新 RPC migration（**取代**之前 PR #318 的 v1，已合併到 main 但 prod 還沒 push）：`supabase/migrations/20260621000020_rpc_orders_pivot_closed_filter.sql` — 用 `DROP + CREATE` 加 `p_closed_only boolean DEFAULT NULL` 參數。

## Test plan

- [ ] Supabase Studio SQL Editor 跑 `20260621000020_rpc_orders_pivot_closed_filter.sql`（如果你 prod 還沒跑 v1，這個會直接建好；跑過 v1 也沒事，會 drop 再 create）
- [ ] /orders/pivot 分組下拉只剩兩個選項：訂單日 / 開團
- [ ] 表格往下捲時 thead 凍住、保持可見
- [ ] 「只看已收單」按鈕關 → 全部 / 開 → 只有已過收單階段的開團（amber tag）
- [ ] 「只看已收單」狀態在 reload 後保留（LS）

🤖 Generated with [Claude Code](https://claude.com/claude-code)