### PR TITLE
fix(admin/orders/pivot): RPC 改 RETURNS jsonb 避免全部店模式漏團

### DIFF
--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -295,7 +295,12 @@ function PivotContent() {
   // 透過 server-side RPC 拉 aggregate（rpc_orders_pivot）
   // 取代之前 client 撈 raw orders+items 再 group by 的做法 — 那做法 items
   // 一次 .in('order_id', ...) 沒分頁，會被 PostgREST max_rows=1000 截斷，
-  // 導致跨多店時數字偏低（甚至出現「單店 > 全部」的反直覺結果）
+  // 導致跨多店時數字偏低（甚至出現「單店 > 全部」的反直覺結果）。
+  //
+  // RPC 本身在 v3 (20260621000030) 改回 jsonb 而非 setof — setof 一樣
+  // 被 max_rows=1000 cap、cell 數 = group × sku × store、全部店模式
+  // 容易爆 1000，導致某些開團整筆從表內消失（GRP-20260521-001 是案例）。
+  // jsonb 是單一 row、不受 row cap 限制；data 解出來仍是 PivotRow[]。
   useEffect(() => {
     if (!hydrated) return;
     let cancelled = false;

--- a/docs/TEST-orders-pivot-jsonb.md
+++ b/docs/TEST-orders-pivot-jsonb.md
@@ -1,0 +1,90 @@
+---
+title: TEST — rpc_orders_pivot returns jsonb（避開 PostgREST max_rows=1000 截斷）
+module: admin / orders / pivot
+status: pending
+ran_at: 2026-05-21
+verified_by: alex.chen
+---
+
+# Bug: 樞紐表選「全部店」時、某些開團整個從表內消失
+
+## 症狀
+
+`/admin/orders/pivot`：
+
+| 操作 | 結果 |
+|---|---|
+| 取貨店 filter = 「松山店」 | 開團 `GRP-20260521-001` 出現、cell 數量正確 |
+| 取貨店 filter = 「全部取貨店」 | 開團 `GRP-20260521-001` 整筆從表內消失 |
+
+選「全部店」反而比選單店看到的少（單店是全部的子集，理應出現）— 顯然某些 row 被丟掉。
+
+## 根因
+
+`supabase/config.toml` `max_rows = 1000` 是 PostgREST 對所有 GET / RPC `setof` 結果的硬上限。
+
+[`rpc_orders_pivot`](../supabase/migrations/20260621000020_rpc_orders_pivot_closed_filter.sql) 雖是 server-side aggregate（PR #318 引入避免 client 撈 items 時被截斷），但它本身回的是 `RETURNS TABLE(...)`（setof rows），**這個 setof 一樣被 max_rows cap 在 1000**。
+
+- 每一筆 RPC row = `(group × sku × pickup_store)` 一個 cell
+- 選單一店時 cell 數 = 團 × SKU，通常 < 1000 → 不截
+- 選全部店時 cell 數 = 團 × SKU × 店，輕鬆爆 1000 → 截斷
+- RPC 內沒 `ORDER BY`，被砍掉的是哪幾筆是 DB 隨機決定 → 任何開團都可能消失
+
+## 修法
+
+新 migration `supabase/migrations/20260621000030_rpc_orders_pivot_jsonb.sql`：
+
+- DROP 舊的 `rpc_orders_pivot(text, date, date, bigint[], bigint, text[], boolean)` setof 版
+- CREATE 新版 `RETURNS jsonb`，內部用 `jsonb_agg(to_jsonb(t))` 包成單 row
+- 單 row 不受 `max_rows = 1000` 限制（PostgREST cap 算 row 數、不算 jsonb array 內元素）
+
+Client 端 [`apps/admin/src/app/(protected)/orders/pivot/page.tsx`](../apps/admin/src/app/(protected)/orders/pivot/page.tsx)：
+
+- `sb.rpc("rpc_orders_pivot", ...)` 回值改為 `jsonb` （在 supabase-js 中就是 JS array/object）
+- `setPivotRows(data ?? [])` 改 cast 為 `PivotRow[]`（jsonb array 解出來就是 PivotRow array）
+
+## 驗證
+
+### Schema 層
+
+| 測項 | 期待 |
+|---|---|
+| 新 migration 內有 `DROP FUNCTION IF EXISTS rpc_orders_pivot(...)`（舊 signature） | ✓ |
+| 新 migration `CREATE OR REPLACE FUNCTION rpc_orders_pivot(...) RETURNS jsonb` | ✓ |
+| `GRANT EXECUTE` 給 `authenticated` | ✓ |
+| Migration `\i` 進 local DB 後 `\df rpc_orders_pivot` 顯示 return type = `jsonb` | ✓ |
+
+### RPC 層
+
+prod 部署後（user 貼 Studio）：
+
+| 測項 | 期待 |
+|---|---|
+| `SELECT rpc_orders_pivot('campaign', '2026-05-01'::date, '2026-06-01'::date, NULL, NULL, ARRAY['confirmed','submitted','pending'], NULL)` 回 jsonb array | ✓ |
+| array length（用 `SELECT jsonb_array_length(rpc_orders_pivot(...))`）符合預期 group×sku×store cell 數 | ✓ |
+| 該 jsonb 內含 `group_id = <GRP-20260521-001 的 id>` 的元素 | ✓ |
+
+### UI 層
+
+| 測項 | 期待 |
+|---|---|
+| `/admin/orders/pivot` 取貨店 = 「松山店」 → `GRP-20260521-001` row 出現 | ✓ |
+| 同上 = 「全部取貨店」 → **`GRP-20260521-001` row 仍出現**（修前消失） | ✓ |
+| 同上、cell 數量加總（松山店欄）等於修前單選松山店時看到的數量 | ✓ |
+| 切「品項數 / 訂單金額」、月份範圍、closed_only filter 全正常 | ✓ |
+| 點 cell 跳 drill-down modal 訂單清單正常 | ✓ |
+| Console 零 error | ✓ |
+
+### Regression
+
+| 測項 | 期待 |
+|---|---|
+| 樞紐表內其他既有開團 row 數量／金額不變 | ✓ |
+| `/orders` 列表不受影響（沒共用 RPC） | ✓ |
+| `tsc` / `npm run lint` 全綠 | ✓ |
+
+## 邊界 / 後續
+
+- jsonb 單 row 大小理論上 1 GB cap，但 PG 實務 toast 後 10 MB 就會變慢；目前 cell 數預估 < 100K（30 團 × 30 SKU × 100 店），單 jsonb < 5 MB，OK
+- 若未來 cell 數爆增、可考慮 RPC 加 `LIMIT` + `OFFSET` 參數做分頁；不過 cell 數真到 100K UI 也吃不下，要先 redesign
+- 不動 `config.toml` 的 `max_rows = 1000`（全域改動風險大，個別 RPC 自己處理較乾淨）

--- a/supabase/migrations/20260621000030_rpc_orders_pivot_jsonb.sql
+++ b/supabase/migrations/20260621000030_rpc_orders_pivot_jsonb.sql
@@ -1,0 +1,125 @@
+-- ============================================================
+-- rpc_orders_pivot v3 — RETURNS jsonb
+--
+-- 修 bug：admin /orders/pivot 在「取貨店 = 全部」時、某些開團整筆 row 消失
+-- （單選某店反而看得到，因為 row 數較少未撞上限）。
+--
+-- 根因：PostgREST `max_rows = 1000`（supabase/config.toml）對所有
+--   GET / RPC setof 結果套上 row 上限。v2 的 RPC 雖然 server-side
+--   aggregate，但回的是 setof，每一 row = (group × sku × store) 一個
+--   cell，全部店模式輕鬆破 1000、被靜默截斷。RPC 內部沒 ORDER BY，
+--   截斷後留哪幾筆是 DB 隨機決定 → 任何開團都可能消失。
+--
+-- 修法：改 `RETURNS jsonb`、外層 `jsonb_agg(to_jsonb(t))` 包成單一 row。
+--   PostgREST max_rows 算 row 數、不算 jsonb array 內元素 → 不再被截斷。
+--
+-- 邏輯主體與 v2 (20260621000020) 完全一致。
+-- PG 不能 CREATE OR REPLACE 改 return type → DROP + CREATE。
+-- ============================================================
+
+DROP FUNCTION IF EXISTS rpc_orders_pivot(text, date, date, bigint[], bigint, text[], boolean);
+
+CREATE OR REPLACE FUNCTION rpc_orders_pivot(
+  p_view_by      text,
+  p_date_from    date,
+  p_date_to      date,
+  p_campaign_ids bigint[],
+  p_store_id     bigint,
+  p_statuses     text[],
+  p_closed_only  boolean DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH filtered AS (
+    SELECT o.*
+    FROM customer_orders o
+    LEFT JOIN group_buy_campaigns c ON c.id = o.campaign_id
+    WHERE o.status = ANY(p_statuses)
+      AND (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      AND (
+        p_closed_only IS NULL
+        OR (p_closed_only IS TRUE
+            AND c.status IN ('closed','ordered','receiving','ready','completed'))
+        OR (p_closed_only IS FALSE
+            AND c.status NOT IN ('closed','ordered','receiving','ready','completed'))
+      )
+      AND CASE p_view_by
+        WHEN 'pickup_date' THEN
+          (p_date_from IS NULL OR o.pickup_deadline >= p_date_from)
+          AND (p_date_to IS NULL OR o.pickup_deadline <  p_date_to)
+        WHEN 'order_date' THEN
+          (p_date_from IS NULL OR o.created_at >= p_date_from::timestamptz)
+          AND (p_date_to IS NULL OR o.created_at <  p_date_to::timestamptz)
+        WHEN 'campaign' THEN
+          c.end_at IS NULL
+          OR (
+            (p_date_from IS NULL OR c.end_at >= p_date_from::timestamptz)
+            AND (p_date_to IS NULL OR c.end_at <  p_date_to::timestamptz)
+          )
+        ELSE TRUE
+      END
+  ),
+  base AS (
+    SELECT
+      CASE p_view_by
+        WHEN 'campaign'    THEN 'c' || f.campaign_id::text
+        WHEN 'pickup_date' THEN 'd' || to_char(COALESCE(f.pickup_deadline, f.created_at::date), 'YYYY-MM-DD')
+        WHEN 'order_date'  THEN 'd' || to_char(f.created_at::date, 'YYYY-MM-DD')
+      END                                              AS group_key,
+      CASE WHEN p_view_by = 'campaign' THEN f.campaign_id ELSE NULL::bigint END
+                                                       AS group_id,
+      i.sku_id,
+      s.product_name                                   AS sku_product_name,
+      s.variant_name                                   AS sku_variant_name,
+      f.pickup_store_id,
+      f.id                                             AS order_id,
+      f.status,
+      i.qty,
+      i.unit_price
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    LEFT JOIN skus s ON s.id = i.sku_id
+  ),
+  agg AS (
+    SELECT
+      b.group_key,
+      b.group_id,
+      b.sku_id,
+      b.sku_product_name,
+      b.sku_variant_name,
+      b.pickup_store_id,
+      SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+               THEN (-b.qty) ELSE b.qty END)::numeric                          AS qty_sum,
+      SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+               THEN (-b.qty) * b.unit_price ELSE b.qty * b.unit_price END)::numeric
+                                                                                AS amount,
+      COALESCE(
+        ARRAY_AGG(DISTINCT b.order_id)
+          FILTER (WHERE b.status NOT IN ('cancelled','expired','transferred_out')),
+        '{}'::bigint[]
+      )                                                                         AS pos_order_ids,
+      COALESCE(
+        ARRAY_AGG(DISTINCT b.order_id)
+          FILTER (WHERE b.status IN ('cancelled','expired','transferred_out')),
+        '{}'::bigint[]
+      )                                                                         AS neg_order_ids
+    FROM base b
+    GROUP BY
+      b.group_key,
+      b.group_id,
+      b.sku_id,
+      b.sku_product_name,
+      b.sku_variant_name,
+      b.pickup_store_id
+  )
+  SELECT COALESCE(jsonb_agg(to_jsonb(agg.*)), '[]'::jsonb)
+  FROM agg;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_orders_pivot(text, date, date, bigint[], bigint, text[], boolean) TO authenticated;


### PR DESCRIPTION
## Summary

- `rpc_orders_pivot` (PR #318 引入) 雖是 server-side aggregate，但回的是 setof rows，**一樣被 `supabase/config.toml` `max_rows = 1000` cap 限制**。
- 每筆 RPC row = `(group × sku × pickup_store)` 一個 cell：選單店時 row 數 = 團×SKU 通常 < 1000，選**全部店**時 row 數 = 團×SKU×店 輕鬆破 1000、被靜默截斷。RPC 內無 `ORDER BY` → 被砍的是哪幾筆 DB 隨機決定，**任何開團都可能消失**。
- 案例：今天開的 `GRP-20260521-001`，選松山店看得到、選「全部取貨店」就整筆消失（子集 > 超集的反直覺結果）。
- 修法：新 migration `20260621000030`，RPC 改 `RETURNS jsonb`，外層 `jsonb_agg(to_jsonb(t))` 包成單一 row。PostgREST cap 算 row 數、不算 jsonb array 內元素，從此不再截斷。
- Client 端 [`page.tsx`](apps/admin/src/app/(protected)/orders/pivot/page.tsx) supabase-js `data` 解出仍是 `PivotRow[]`，cast 不變、只更新註解。

## Files

- 新 [`supabase/migrations/20260621000030_rpc_orders_pivot_jsonb.sql`](supabase/migrations/20260621000030_rpc_orders_pivot_jsonb.sql) — DROP 舊 setof signature + CREATE returns jsonb，邏輯主體與 v2 完全一致
- 新 [`docs/TEST-orders-pivot-jsonb.md`](docs/TEST-orders-pivot-jsonb.md) — schema / RPC / UI / regression 四層測試項目
- 改 [`apps/admin/src/app/(protected)/orders/pivot/page.tsx`](apps/admin/src/app/(protected)/orders/pivot/page.tsx) — 註解補上 v3 修法緣由（無邏輯變更）

## Prod 部署

merge 後請把 `supabase/migrations/20260621000030_rpc_orders_pivot_jsonb.sql` 整段貼進 Supabase Studio 跑（PG 不能 CREATE OR REPLACE 改 return type，所以 DROP + CREATE 順序很重要、Studio 一次貼整段即可）。

## Test plan

- [ ] Studio 跑完 migration、`\df rpc_orders_pivot` 顯示 return type = `jsonb`
- [ ] `/admin/orders/pivot` 取貨店 = 「全部取貨店」→ `GRP-20260521-001` row **出現**（修前消失）
- [ ] 同上、松山店欄 cell 數量 = 修前單選松山店看到的數量（一致性）
- [ ] 切月份 / 分組 / closed_only / 品項數＆訂單金額 toggle 全正常
- [ ] 點 cell 跳 drill-down modal 訂單清單正常
- [ ] Console 零 error
- [ ] `/orders` 列表（未共用此 RPC）行為不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)