### PR TITLE
feat(admin/fb-pages): 新增粉絲團 CRUD + sidebar 入口

### DIFF
--- a/apps/admin/src/app/(protected)/fb-pages/page.tsx
+++ b/apps/admin/src/app/(protected)/fb-pages/page.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import SpinButton from "@/components/SpinButton";
+import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
+
+const PAGE_SIZE = 20;
+
+type FbPage = {
+  id: number;
+  page_id: string;
+  name: string;
+  sort_order: number;
+  is_active: boolean;
+  updated_at: string;
+};
+
+type FormValues = {
+  id: number | null;
+  page_id: string;
+  name: string;
+  access_token: string;
+  sort_order: number;
+  is_active: boolean;
+};
+
+const EMPTY: FormValues = {
+  id: null,
+  page_id: "",
+  name: "",
+  access_token: "",
+  sort_order: 0,
+  is_active: true,
+};
+
+export default function FbPagesPage() {
+  const [rows, setRows] = useState<FbPage[] | null>(null);
+  const [queryDraft, setQueryDraft] = useState("");
+  const [query, setQuery] = useState("");
+  const [showActive, setShowActive] = useState<"all" | "active">("active");
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<FbPage | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    const t = setTimeout(() => setQuery(queryDraft), 250);
+    return () => clearTimeout(t);
+  }, [queryDraft]);
+
+  useEffect(() => { setPage(1); }, [query, showActive]);
+
+  const totalPages = Math.max(1, Math.ceil((rows?.length ?? 0) / PAGE_SIZE));
+  const paginated = useMemo(
+    () => (rows ?? []).slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
+    [rows, page],
+  );
+
+  const reload = async () => {
+    let q = getSupabase()
+      .from("fb_pages")
+      .select("id, page_id, name, sort_order, is_active, updated_at")
+      .order("sort_order", { ascending: true })
+      .order("updated_at", { ascending: false })
+      .limit(200);
+    if (query.trim()) {
+      const safe = query.replace(/[%,()]/g, " ").trim();
+      q = q.or(`page_id.ilike.%${safe}%,name.ilike.%${safe}%`);
+    }
+    if (showActive === "active") q = q.eq("is_active", true);
+    const { data, error: err } = await q;
+    if (err) setError(err.message);
+    else { setError(null); setRows((data as FbPage[]) ?? []); }
+  };
+  useEffect(() => { reload(); }, [query, showActive]);
+
+  async function save(v: FormValues) {
+    try {
+      const { error: err } = await getSupabase().rpc("rpc_upsert_fb_page", {
+        p_id: v.id ?? null,
+        p_page_id: v.page_id.trim(),
+        p_name: v.name.trim(),
+        p_access_token: v.access_token.trim() || null,
+        p_sort_order: v.sort_order,
+        p_is_active: v.is_active,
+      });
+      if (err) throw err;
+      setEditing(null); setCreating(false); setError(null);
+      await reload();
+    } catch (e) { setError(e instanceof Error ? e.message : String(e)); }
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">FB 粉絲團</h1>
+          <p className="text-sm text-zinc-500">
+            共 {rows?.length ?? 0} 筆 · 用於同步上架到 Facebook
+          </p>
+        </div>
+        {!creating && !editing && (
+          <SpinButton
+            onClick={() => setCreating(true)}
+            className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            新增粉絲團
+          </SpinButton>
+        )}
+      </header>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {creating && (
+        <FbPageForm
+          initial={EMPTY}
+          title="新增"
+          isNew
+          onCancel={() => setCreating(false)}
+          onSave={(v) => save({ ...v, id: null })}
+        />
+      )}
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <input
+          type="search" value={queryDraft} onChange={(e) => setQueryDraft(e.target.value)}
+          placeholder="搜尋 page_id / 名稱"
+          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
+        />
+        <select value={showActive} onChange={(e) => setShowActive(e.target.value as "all" | "active")}
+          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
+          <option value="active">僅啟用中</option>
+          <option value="all">全部</option>
+        </select>
+      </div>
+
+      <Table>
+        <THead>
+          <Th>名稱</Th>
+          <Th>Page ID</Th>
+          <Th>排序</Th>
+          <Th>狀態</Th>
+          <Th>{""}</Th>
+        </THead>
+        <TBody>
+          {rows === null ? (
+            <LoadingRow colSpan={5} />
+          ) : rows.length === 0 ? (
+            <EmptyRow colSpan={5}>尚無粉絲團設定</EmptyRow>
+          ) : paginated.map((r) => editing?.id === r.id ? (
+            <tr key={r.id}>
+              <td colSpan={5} className="p-0">
+                <FbPageForm
+                  initial={{
+                    id: r.id,
+                    page_id: r.page_id,
+                    name: r.name,
+                    access_token: "",
+                    sort_order: r.sort_order,
+                    is_active: r.is_active,
+                  }}
+                  title="編輯"
+                  isNew={false}
+                  onCancel={() => setEditing(null)}
+                  onSave={(v) => save({ ...v, id: r.id })}
+                />
+              </td>
+            </tr>
+          ) : (
+            <Tr key={r.id}>
+              <Td>{r.name}</Td>
+              <Td className="font-mono text-xs">{r.page_id}</Td>
+              <Td className="text-xs">{r.sort_order}</Td>
+              <Td>
+                <span className={`inline-block rounded px-2 py-0.5 text-xs ${r.is_active ? "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300" : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"}`}>
+                  {r.is_active ? "啟用" : "停用"}
+                </span>
+              </Td>
+              <Td>
+                <SpinButton onClick={() => setEditing(r)} className="text-xs text-blue-600 hover:underline dark:text-blue-400">編輯</SpinButton>
+              </Td>
+            </Tr>
+          ))}
+        </TBody>
+      </Table>
+
+      {(rows?.length ?? 0) > PAGE_SIZE && (
+        <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
+          <span className="text-xs text-zinc-500">
+            共 {rows?.length ?? 0} 筆 · 顯示 {(page - 1) * PAGE_SIZE + 1} - {Math.min(page * PAGE_SIZE, rows?.length ?? 0)}
+          </span>
+          <SpinButton onClick={() => setPage(1)} disabled={page === 1} className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">« 第一頁</SpinButton>
+          <SpinButton onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1} className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">‹ 上頁</SpinButton>
+          <span className="text-xs text-zinc-500">{page} / {totalPages}</span>
+          <SpinButton onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages} className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">下頁 ›</SpinButton>
+          <SpinButton onClick={() => setPage(totalPages)} disabled={page === totalPages} className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">最末頁 »</SpinButton>
+        </div>
+      )}
+
+      <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+        <div className="mb-1 font-medium text-zinc-700 dark:text-zinc-300">如何取得 Page Access Token？</div>
+        <ol className="list-decimal space-y-0.5 pl-4">
+          <li>到 <a href="https://developers.facebook.com/tools/explorer/" target="_blank" rel="noreferrer" className="text-blue-600 hover:underline dark:text-blue-400">Graph API Explorer</a></li>
+          <li>選擇 App、按「Get User Access Token」勾 `pages_manage_posts`、`pages_read_engagement`</li>
+          <li>用 user token 呼叫 `GET /me/accounts`，取得對應 Page 的 long-lived page token</li>
+          <li>page_id 在 Page 設定的「關於」分頁底</li>
+        </ol>
+      </div>
+    </div>
+  );
+}
+
+function FbPageForm({
+  initial, title, isNew, onSave, onCancel,
+}: {
+  initial: FormValues;
+  title: string;
+  isNew: boolean;
+  onSave: (v: FormValues) => void;
+  onCancel: () => void;
+}) {
+  const [v, setV] = useState(initial);
+  function up<K extends keyof typeof v>(k: K, val: typeof v[K]) { setV({ ...v, [k]: val }); }
+
+  return (
+    <form
+      onSubmit={(e) => { e.preventDefault(); onSave(v); }}
+      className="space-y-3 border-l-4 border-blue-400 bg-blue-50/40 p-4 dark:bg-blue-950/20"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">{title}</h3>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-4">
+        <F label="名稱 *" className="sm:col-span-2">
+          <input value={v.name} onChange={(e) => up("name", e.target.value)} required className={inputCls} placeholder="樂樂團購 - 永和店" />
+        </F>
+        <F label="Page ID *">
+          <input value={v.page_id} onChange={(e) => up("page_id", e.target.value)} required className={inputCls} placeholder="100012345678901" />
+        </F>
+        <F label="排序">
+          <input
+            type="number" value={v.sort_order}
+            onChange={(e) => up("sort_order", Number(e.target.value) || 0)}
+            className={inputCls}
+          />
+        </F>
+
+        <F label={isNew ? "Page Access Token *" : "Page Access Token（留空＝保留現值）"} className="sm:col-span-4">
+          <input
+            type="password"
+            value={v.access_token}
+            onChange={(e) => up("access_token", e.target.value)}
+            required={isNew}
+            className={inputCls}
+            placeholder={isNew ? "EAAB...（長字串）" : "留空表示沿用現有 token"}
+            autoComplete="off"
+          />
+        </F>
+
+        <F label="啟用">
+          <label className="flex items-center gap-2 pt-1.5 text-sm">
+            <input type="checkbox" checked={v.is_active} onChange={(e) => up("is_active", e.target.checked)} />
+            <span>{v.is_active ? "啟用中" : "停用"}</span>
+          </label>
+        </F>
+      </div>
+      <div className="flex items-center gap-2">
+        <SpinButton type="submit" className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200">儲存</SpinButton>
+        <SpinButton type="button" onClick={onCancel} className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800">取消</SpinButton>
+      </div>
+    </form>
+  );
+}
+
+function F({ label, children, className = "" }: { label: string; children: React.ReactNode; className?: string }) {
+  return (
+    <label className={`flex flex-col gap-1 text-sm ${className}`}>
+      <span className="text-xs text-zinc-500">{label}</span>
+      {children}
+    </label>
+  );
+}
+const inputCls =
+  "rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800";

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -74,6 +74,7 @@ const NAV: NavGroup[] = [
     items: [
       { href: "/staff", label: "員工管理", match: /^\/staff/ },
       { href: "/stores", label: "門市", match: /^\/stores/ },
+      { href: "/fb-pages", label: "FB 粉絲團", match: /^\/fb-pages/ },
     ],
   },
 ];
@@ -105,6 +106,7 @@ const BRANCH_HIDDEN_HREFS = new Set([
   // /wms/inbound 跟 /wms/transfers 不在這裡 — 分店要用,屬於分店業務
   "/finance/receivables", // HQ 應收
   "/stores",              // 門市設定 (HQ 管理)
+  "/fb-pages",            // 粉絲團設定 (HQ 管理)
 ]);
 const BRANCH_HIDDEN_GROUPS = new Set([
   "社群選品", // 整個 group 隱藏

--- a/docs/TEST-fb-pages-crud.md
+++ b/docs/TEST-fb-pages-crud.md
@@ -1,0 +1,97 @@
+# 粉絲團設定頁 `/fb-pages`
+
+**對應頁面：** `apps/admin/src/app/(protected)/fb-pages/page.tsx`（新增）
+**對應 RPC：** `rpc_upsert_fb_page`、`rpc_delete_fb_page`（新增於本次 migration）
+**對應 schema：** `fb_pages` (`supabase/migrations/20260620000030_fb_pages_and_campaign_fb_posts.sql:9`)
+
+**動機：** `FbPublishModal` 仰賴 `fb_pages` 表，但目前後台**完全沒有 CRUD UI**（modal 顯示 hint：「目前沒有啟用中的粉絲團設定。請先在資料庫的 fb_pages 表新增資料。」）。每次要加新粉絲團都得直接打 SQL，違反「管理操作走 UI」的習慣，且 access_token 是長字串敏感資料，貼 SQL 容易出錯。
+
+---
+
+## 0. 範圍
+
+**v1（本次）**
+- 列表：name / page_id / sort_order / 狀態
+- 搜尋：name + page_id ilike
+- 過濾：是否啟用
+- inline 編輯：name / page_id / access_token（留空＝沿用） / sort_order / is_active
+- 新增
+- 「停用」用 is_active toggle（不做硬刪——已被 campaign_fb_posts FK 引用）
+
+**v1 不做**
+- 「已發團數」欄位（PostgREST nested-filter 寫起來囉嗦，下版補）
+- 「測試 token 有效性」按鈕（call FB Graph /me 驗 token）— 後續再補
+- access_token 加密儲存（目前 plaintext，RLS 守門已足夠 v1）
+- 多 tenant 切換（沿用 user JWT tenant_id）
+
+---
+
+## 1. 列表行為
+
+### 1.1 預設載入
+- [ ] `/fb-pages` 載入無 console error
+- [ ] 預設只顯示 `is_active = TRUE`
+- [ ] 排序：sort_order asc, then updated_at desc
+- [ ] 列表 select **不含 access_token**（敏感欄位，client 端不取）
+
+### 1.2 搜尋
+- [ ] 搜「樂樂」→ name 含「樂樂」hit
+- [ ] 搜 page_id（一串純數字）→ exact-ish ilike hit
+- [ ] 250ms debounce
+
+### 1.3 篩選
+- [ ] 「全部 / 僅啟用」切換正常
+
+---
+
+## 2. 編輯行為
+
+### 2.1 新增
+- [ ] 點「新增粉絲團」→ 出現 inline 表單
+- [ ] name、page_id、access_token 必填
+- [ ] access_token 用 `type="password"`，且 placeholder 提示「Page Access Token」
+- [ ] sort_order 預設 0
+- [ ] is_active 預設 true
+- [ ] 儲存呼叫 `rpc_upsert_fb_page(p_id=NULL,...)` 成功
+- [ ] 儲存後列表新增該筆、access_token 不出現在 UI 任何地方
+
+### 2.2 編輯
+- [ ] 點「編輯」→ inline 表單帶入 name / page_id / sort_order / is_active（**access_token 欄位為空**）
+- [ ] access_token 留空 → 儲存後 DB 內 token 不變
+- [ ] access_token 重新填 → 儲存後 DB 內 token 更新
+- [ ] 取消不寫入
+
+### 2.3 停用
+- [ ] 編輯時取消「啟用」checkbox → 儲存 → `is_active=false`
+- [ ] 篩「僅啟用」時不顯示
+- [ ] `FbPublishModal` 開啟時不會出現停用的粉絲團（沿用 `.eq("is_active", true)`）
+
+### 2.4 錯誤處理
+- [ ] page_id 重複（同 tenant_id）→ 紅字提示 unique violation
+- [ ] 沒輸入必填 → HTML required 擋下
+- [ ] 新增時 access_token 空 → 守門（HTML required + RPC raise）
+
+---
+
+## 3. 權限 / 安全
+
+- [ ] 只 owner / admin / hq_manager 能進頁面（沿用 fb_pages RLS）
+- [ ] 一般 store_manager 帳號開頁 → 列表為空 + 操作觸發 RLS 拒絕
+- [ ] sidebar 「粉絲團」連結放「設定」group（已是 admin-only）
+- [ ] 分店帳號（branch user）看不到 sidebar 連結（加進 `BRANCH_HIDDEN_HREFS`）
+- [ ] access_token 不出現在 select 列表 / 不出現在 console / 不出現在 network 回傳
+- [ ] RPC `rpc_upsert_fb_page` 是 SECURITY DEFINER，內部守門 role IN ('owner','admin','hq_manager') + tenant_id 從 JWT 拿（非 client 傳）
+
+---
+
+## 4. Regression
+
+- [ ] `/campaigns` 列表「發 FB」按鈕仍正常開 `FbPublishModal`
+- [ ] `FbPublishModal` 內粉絲團 chip 仍能載入（用本頁新增的粉絲團）
+- [ ] `campaign-publish-facebook` Edge Function 仍能正常 select access_token + 發文
+- [ ] 既有的 `campaign_fb_posts` 紀錄沒受影響
+
+---
+
+## 5. 驗收門檻
+全勾 + `apps/admin` tsc 過 + build 過 + migration apply 後 RPC 可叫成功 + dev server 啟動列表能載 + 新增/編輯/停用 各一筆能存。

--- a/supabase/migrations/20260621000030_rpc_upsert_fb_page.sql
+++ b/supabase/migrations/20260621000030_rpc_upsert_fb_page.sql
@@ -1,0 +1,86 @@
+-- 粉絲團設定 CRUD：rpc_upsert_fb_page
+--
+-- 設計重點：
+--   * SECURITY DEFINER 跳過 RLS，內部自驗 role IN ('owner','admin','hq_manager')
+--   * tenant_id 從 JWT 拿（不從參數收），避免 client 偽造跨 tenant
+--   * access_token 屬機敏：UPDATE 時 p_access_token NULL/'' 視為「保留現值」，
+--     避免前端編輯時需要重新貼整串長 token
+--   * INSERT 時 p_access_token 必填，且不可為空白
+--   * v1 不提供 rpc_delete_fb_page，使用者只能 is_active=false 停用
+--     （fb_pages 被 campaign_fb_posts FK 引用，硬刪會破壞既有發文紀錄）
+
+CREATE OR REPLACE FUNCTION rpc_upsert_fb_page(
+  p_id            BIGINT,
+  p_page_id       TEXT,
+  p_name          TEXT,
+  p_access_token  TEXT,
+  p_sort_order    INTEGER,
+  p_is_active     BOOLEAN
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := (auth.jwt() ->> 'tenant_id')::uuid;
+  v_role   TEXT := COALESCE(
+                     NULLIF(auth.jwt() -> 'app_metadata' ->> 'role', ''),
+                     NULLIF(auth.jwt() ->> 'role', 'authenticated'),
+                     ''
+                   );
+  v_id     BIGINT;
+  v_token  TEXT := NULLIF(TRIM(COALESCE(p_access_token, '')), '');
+  v_name   TEXT := NULLIF(TRIM(COALESCE(p_name, '')), '');
+  v_pageid TEXT := NULLIF(TRIM(COALESCE(p_page_id, '')), '');
+  v_sort   INTEGER := COALESCE(p_sort_order, 0);
+  v_active BOOLEAN := COALESCE(p_is_active, TRUE);
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+  IF v_role NOT IN ('owner','admin','hq_manager') THEN
+    RAISE EXCEPTION 'permission denied: only owner/admin/hq_manager can manage fb pages';
+  END IF;
+  IF v_pageid IS NULL THEN
+    RAISE EXCEPTION 'page_id required';
+  END IF;
+  IF v_name IS NULL THEN
+    RAISE EXCEPTION 'name required';
+  END IF;
+
+  IF p_id IS NULL THEN
+    -- 新增：access_token 必填
+    IF v_token IS NULL THEN
+      RAISE EXCEPTION 'access_token required when creating a new fb page';
+    END IF;
+    INSERT INTO fb_pages (tenant_id, page_id, name, access_token, sort_order, is_active)
+    VALUES (v_tenant, v_pageid, v_name, v_token, v_sort, v_active)
+    RETURNING id INTO v_id;
+  ELSE
+    -- 更新：access_token NULL/空 → 保留原值，否則覆寫
+    UPDATE fb_pages
+       SET page_id      = v_pageid,
+           name         = v_name,
+           access_token = COALESCE(v_token, access_token),
+           sort_order   = v_sort,
+           is_active    = v_active,
+           updated_at   = NOW()
+     WHERE id = p_id
+       AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+
+    IF v_id IS NULL THEN
+      RAISE EXCEPTION 'fb_page % not found in this tenant', p_id;
+    END IF;
+  END IF;
+
+  RETURN v_id;
+END;
+$$;
+
+COMMENT ON FUNCTION rpc_upsert_fb_page IS
+  'Upsert fb_pages 主檔；UPDATE 時 p_access_token NULL/空字串視為保留原值。';
+
+REVOKE ALL ON FUNCTION rpc_upsert_fb_page(BIGINT, TEXT, TEXT, TEXT, INTEGER, BOOLEAN) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION rpc_upsert_fb_page(BIGINT, TEXT, TEXT, TEXT, INTEGER, BOOLEAN) TO authenticated;


### PR DESCRIPTION
## Summary
- 新增 admin 後台 `/fb-pages` 頁面，可列表/新增/編輯/停用粉絲團設定（之前完全沒有 UI、要手打 SQL）
- 新增 migration `20260621000030_rpc_upsert_fb_page`（SECURITY DEFINER + role/tenant 守門 + UPDATE 時 token 留空＝沿用原值）
- Sidebar「設定」group 加「FB 粉絲團」入口（HQ-only，分店帳號隱藏）

## 動機
`FbPublishModal` 仰賴 `fb_pages` 表，但目前後台**完全沒有 CRUD UI**，modal 自己顯示 hint：「請先在資料庫的 fb_pages 表新增資料」。每次要加新粉絲團都得直接打 SQL，access_token 又是長字串，貼 SQL 容易出錯。

## 設計重點
- **敏感欄位保護**：列表 `.select()` 不撈 `access_token`；form 用 `type="password"`；UPDATE 時 token 留空＝沿用原值（編輯時不用重貼整串）
- **權限**：RPC SECURITY DEFINER + 內部自驗 role IN `(owner, admin, hq_manager)`，tenant_id 從 JWT 拿（不從參數收）
- **v1 範圍**：CRUD + 啟用切換；硬刪不做（被 `campaign_fb_posts` FK 引用，停用即可）；測 token 有效性按鈕、加密儲存留 v2

## 測試文件
[docs/TEST-fb-pages-crud.md](docs/TEST-fb-pages-crud.md) 已附。

## Test plan
- [ ] Supabase Studio 貼 migration `20260621000030_rpc_upsert_fb_page.sql`
- [ ] 進 `/fb-pages` 列表載入無 console error
- [ ] 新增一筆粉絲團（name + page_id + access_token），列表立刻顯示
- [ ] 編輯該筆 → access_token 欄位為空 → 改 name 儲存 → DB 內 token 不變
- [ ] 編輯該筆 → 重填 access_token → 儲存 → DB 內 token 已更新
- [ ] 停用切換正常、篩「僅啟用」時不顯示
- [ ] 一般 store_manager 帳號開頁 → 列表空 + RPC 觸發 permission denied
- [ ] 分店帳號 sidebar 看不到「FB 粉絲團」連結
- [ ] `/campaigns` 列表「發 FB」開 `FbPublishModal` 後仍能載入新增的粉絲團

🤖 Generated with [Claude Code](https://claude.com/claude-code)