### PR TITLE
feat(admin/campaigns): 開團列表頁「批次建立 / 從商品開團」也鎖管理員

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -543,17 +543,19 @@ export default function CampaignsListPage() {
             {loading ? "載入中…" : total === 0 ? "共 0 筆" : `共 ${total} 筆（${fromIdx}-${toIdx}）`}
           </p>
         </div>
-        <div className="flex gap-2">
-          <SpinButton
-            onClick={() => setShowRecurring(true)}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm font-medium hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
-          >
-            🔁 批次建立
-          </SpinButton>
-          <Link href="/products?mode=campaign" className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200">
-            + 從商品開團
-          </Link>
-        </div>
+        {showAdminActions && (
+          <div className="flex gap-2">
+            <SpinButton
+              onClick={() => setShowRecurring(true)}
+              className="rounded-md border border-zinc-300 px-3 py-2 text-sm font-medium hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              🔁 批次建立
+            </SpinButton>
+            <Link href="/products?mode=campaign" className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200">
+              + 從商品開團
+            </Link>
+          </div>
+        )}
       </header>
 
       <div className="flex gap-1 border-b border-zinc-200 dark:border-zinc-800">


### PR DESCRIPTION
## Summary
開團列表頁 header 兩顆建立鈕加 `showAdminActions = isAdmin(role)` gate：
- 🔁 批次建立
- + 從商品開團

## Why
- 頁內其它管理動作（編輯 / 結單 / 發 FB / 批次結單 / 批次取消 / 月曆編輯）都已 admin-gated，header 兩顆漏了
- 店長 / 店員看得到但點下去 RPC 會被擋，補上後一致、避免無效按鈕誤點
- 對齊「店長店員不能開團」的權限預期

## 背景
這 commit 原本是 #320 的第二顆 commit，使用者 squash-merge 時 #320 只帶了第一顆（商品明細 SKU 連結），這顆漏掉了 — 從最新 main 重開單獨 PR。

## 改了哪些 role
- ✅ owner / admin / 空字串(legacy)：兩顆鈕仍可見、行為不變
- ❌ store_manager / store_staff / hq_manager / hq_accountant / assistant：兩顆鈕隱藏（沿用同頁 `isAdmin(role)` gate）

## Test plan
- [ ] owner / admin 進 /campaigns → header 看得到「🔁 批次建立」「+ 從商品開團」
- [ ] store_manager / store_staff 進 /campaigns → header 兩顆鈕消失
- [ ] hq_manager 進 /campaigns → 兩顆鈕也不顯示（跟頁內現有編輯/結單 gate 行為一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)