### PR TITLE
revert(admin/community-candidates/calendar): 退回「日 × 時段 grid」、改回一個 item 一個 slot

### DIFF
--- a/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
+++ b/apps/admin/src/app/(protected)/community-candidates/calendar/page.tsx
@@ -30,7 +30,6 @@ type CalendarCandidate = {
   id: number;
   product_name_hint: string | null;
   scheduled_open_at: string | null;
-  scheduled_slot_index: number | null;
   scheduled_sort_order: number | null;
   owner_action: string;
   created_at: string;
@@ -57,21 +56,6 @@ const ACTION_COLOR: Record<string, string> = {
 
 const WEEKDAYS = ["日", "一", "二", "三", "四", "五", "六"];
 
-// 09:00 → 21:00 共 13 個整點時段
-const SLOT_COUNT = 13;
-const SLOT_START_HOUR = 9;
-
-function slotTime(idx: number): string {
-  return `${String(SLOT_START_HOUR + idx).padStart(2, "0")}:00`;
-}
-
-function clampSlot(idx: number | null | undefined): number {
-  if (idx === null || idx === undefined) return 0;
-  if (idx < 0) return 0;
-  if (idx > SLOT_COUNT - 1) return SLOT_COUNT - 1;
-  return idx;
-}
-
 function formatDate(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
@@ -79,15 +63,11 @@ function formatDate(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
-// droppable id 格式：YYYY-MM-DD#slotIdx
-function cellId(dayKey: string, slotIdx: number): string {
-  return `${dayKey}#${slotIdx}`;
-}
-
-function parseCellId(id: string): { day: string; slot: number } | null {
-  const m = id.match(/^(\d{4}-\d{2}-\d{2})#(\d+)$/);
-  if (!m) return null;
-  return { day: m[1], slot: parseInt(m[2], 10) };
+function suggestedTime(idx: number): string {
+  const total = 9 * 60 + idx * 30;
+  const h = Math.floor(total / 60);
+  const m = total % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
 }
 
 export default function CommunityCandidatesCalendarPage() {
@@ -111,13 +91,12 @@ export default function CommunityCandidatesCalendarPage() {
     const { data, error: err } = await getSupabase()
       .from("community_product_candidates")
       .select(
-        "id, product_name_hint, scheduled_open_at, scheduled_slot_index, scheduled_sort_order, owner_action, created_at, adopted_supplier_name, adopted_cost, adopted_sale_price"
+        "id, product_name_hint, scheduled_open_at, scheduled_sort_order, owner_action, created_at, adopted_supplier_name, adopted_cost, adopted_sale_price"
       )
       .not("scheduled_open_at", "is", null)
       .gte("scheduled_open_at", startStr)
       .lte("scheduled_open_at", endStr)
       .order("scheduled_open_at", { ascending: true })
-      .order("scheduled_slot_index", { ascending: true, nullsFirst: true })
       .order("scheduled_sort_order", { ascending: true, nullsFirst: false })
       .order("created_at", { ascending: true });
     if (err) setError(err.message);
@@ -131,25 +110,19 @@ export default function CommunityCandidatesCalendarPage() {
     reload();
   }, [reload]);
 
-  // Local mirror keyed by `${dayKey}#${slotIdx}` so drag can produce optimistic updates
-  const [localByCell, setLocalByCell] = useState<Record<string, CalendarCandidate[]>>({});
+  // Local mirror of byDate so drag can produce optimistic updates
+  const [localByDate, setLocalByDate] = useState<Record<string, CalendarCandidate[]>>({});
 
   useEffect(() => {
     const map: Record<string, CalendarCandidate[]> = {};
-    for (const d of days) {
-      const dayKey = formatDate(d);
-      for (let s = 0; s < SLOT_COUNT; s++) {
-        map[cellId(dayKey, s)] = [];
+    for (const d of days) map[formatDate(d)] = [];
+    for (const r of rows ?? []) {
+      if (r.scheduled_open_at) {
+        const key = r.scheduled_open_at.slice(0, 10);
+        if (map[key]) map[key].push(r);
       }
     }
-    for (const r of rows ?? []) {
-      if (!r.scheduled_open_at) continue;
-      const dayKey = r.scheduled_open_at.slice(0, 10);
-      const slot = clampSlot(r.scheduled_slot_index);
-      const k = cellId(dayKey, slot);
-      if (map[k]) map[k].push(r);
-    }
-    setLocalByCell(map);
+    setLocalByDate(map);
   }, [rows, days]);
 
   const handleRemove = async (r: CalendarCandidate) => {
@@ -162,7 +135,6 @@ export default function CommunityCandidatesCalendarPage() {
         .update({
           owner_action: "none",
           scheduled_open_at: null,
-          scheduled_slot_index: null,
           scheduled_sort_order: null,
           updated_at: new Date().toISOString(),
         })
@@ -185,14 +157,16 @@ export default function CommunityCandidatesCalendarPage() {
   );
 
   function findContainer(id: number | string): string | null {
-    if (typeof id === "string" && parseCellId(id)) return id;
+    if (typeof id === "string" && days.some((d) => formatDate(d) === id)) return id;
     const numId = Number(id);
-    for (const [cell, cards] of Object.entries(localByCell)) {
-      if (cards.some((c) => c.id === numId)) return cell;
+    for (const [day, cards] of Object.entries(localByDate)) {
+      if (cards.some((c) => c.id === numId)) return day;
     }
     return null;
   }
 
+  // 自訂 collision detection：優先 pointerWithin（指標真的進入 column 才命中），
+  // 沒命中再退回 rectIntersection / closestCorners。這樣空 column 也能被命中。
   const collisionDetection: CollisionDetection = useCallback((args) => {
     const pointerCollisions = pointerWithin(args);
     if (pointerCollisions.length > 0) return pointerCollisions;
@@ -203,7 +177,7 @@ export default function CommunityCandidatesCalendarPage() {
 
   const onDragStart = (e: DragStartEvent) => {
     const id = Number(e.active.id);
-    for (const cards of Object.values(localByCell)) {
+    for (const cards of Object.values(localByDate)) {
       const c = cards.find((c) => c.id === id);
       if (c) {
         setActiveCard(c);
@@ -221,12 +195,13 @@ export default function CommunityCandidatesCalendarPage() {
     if (!activeContainer || !overContainer) return;
     if (activeContainer === overContainer) return;
 
-    setLocalByCell((prev) => {
+    setLocalByDate((prev) => {
       const src = [...(prev[activeContainer] ?? [])];
       const dst = [...(prev[overContainer] ?? [])];
       const idx = src.findIndex((c) => c.id === activeId);
       if (idx < 0) return prev;
       const [card] = src.splice(idx, 1);
+      // figure out target index: drop above the over card, or end of list
       const overIdx =
         typeof over.id === "number"
           ? dst.findIndex((c) => c.id === Number(over.id))
@@ -243,17 +218,16 @@ export default function CommunityCandidatesCalendarPage() {
     if (!over || !card) return;
     const activeId = Number(active.id);
     const overContainer = findContainer(over.id as number | string);
-    const originalDay = card.scheduled_open_at?.slice(0, 10) ?? null;
-    const originalSlot = clampSlot(card.scheduled_slot_index);
-    const originalContainer = originalDay ? cellId(originalDay, originalSlot) : null;
+    const originalContainer = card.scheduled_open_at?.slice(0, 10) ?? null;
     if (!overContainer) return;
 
+    // Determine current container after onDragOver moves
     const currentContainer = findContainer(activeId);
     if (!currentContainer) return;
 
     if (currentContainer === originalContainer) {
-      // Same-cell reorder
-      const items = localByCell[currentContainer] ?? [];
+      // Same-day reorder: arrayMove + persist
+      const items = localByDate[currentContainer] ?? [];
       const oldIdx = items.findIndex((c) => c.id === activeId);
       const newIdx =
         typeof over.id === "number"
@@ -261,17 +235,17 @@ export default function CommunityCandidatesCalendarPage() {
           : items.length - 1;
       if (oldIdx < 0 || newIdx < 0 || oldIdx === newIdx) return;
       const newItems = arrayMove(items, oldIdx, newIdx);
-      setLocalByCell((p) => ({ ...p, [currentContainer]: newItems }));
-      await persistCell(currentContainer, newItems);
+      setLocalByDate((p) => ({ ...p, [currentContainer]: newItems }));
+      await persistDay(currentContainer, newItems);
       await reload();
     } else {
-      // Cross-cell move: source already updated in onDragOver
-      const srcItems = originalContainer ? localByCell[originalContainer] ?? [] : [];
-      const dstItems = localByCell[currentContainer] ?? [];
+      // Cross-day move: source already updated in onDragOver
+      const srcItems = localByDate[originalContainer ?? ""] ?? [];
+      const dstItems = localByDate[currentContainer] ?? [];
       setBusy(true);
       try {
-        await persistCell(currentContainer, dstItems);
-        if (originalContainer) await persistCell(originalContainer, srcItems);
+        await persistDay(currentContainer, dstItems);
+        if (originalContainer) await persistDay(originalContainer, srcItems);
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
       } finally {
@@ -281,10 +255,7 @@ export default function CommunityCandidatesCalendarPage() {
     }
   };
 
-  async function persistCell(cellKey: string, items: CalendarCandidate[]) {
-    const parsed = parseCellId(cellKey);
-    if (!parsed) return;
-    const { day, slot } = parsed;
+  async function persistDay(dayKey: string, items: CalendarCandidate[]) {
     const sb = getSupabase();
     const now = new Date().toISOString();
     const { data: userRes } = await sb.auth.getUser();
@@ -294,19 +265,18 @@ export default function CommunityCandidatesCalendarPage() {
       const { error: err } = await sb
         .from("community_product_candidates")
         .update({
-          scheduled_open_at: day,
-          scheduled_slot_index: slot,
+          scheduled_open_at: dayKey,
           scheduled_sort_order: order,
           updated_at: now,
         })
         .eq("id", items[i].id);
       if (err) throw new Error(err.message);
 
+      // 同步更新對應 campaign（透過 RPC 繞過 RLS — admin 客戶端 JWT role claim 可能為 null）
       if (operator) {
         const { error: rpcErr } = await sb.rpc("rpc_reorder_candidate_campaign", {
           p_candidate_id: items[i].id,
-          p_day_key: day,
-          p_slot_index: slot,
+          p_day_key: dayKey,
           p_order: order,
           p_operator: operator,
         });
@@ -322,7 +292,7 @@ export default function CommunityCandidatesCalendarPage() {
       <header className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold">選品週曆</h1>
-          <p className="mt-0.5 text-sm text-zinc-500">未來 7 天 · 每整點時段（09:00–21:00）可放多商品 · 拖拉換時段或換日</p>
+          <p className="mt-0.5 text-sm text-zinc-500">未來 7 天 · 拖拉卡片排序或換日</p>
         </div>
         <Link
           href="/community-candidates"
@@ -350,37 +320,32 @@ export default function CommunityCandidatesCalendarPage() {
         >
           <div className="flex gap-2 overflow-x-auto pb-2 lg:grid lg:grid-cols-7 lg:overflow-x-visible lg:pb-0">
             {days.map((d) => {
-              const dayKey = formatDate(d);
-              const isToday = dayKey === todayStr;
+              const key = formatDate(d);
+              const isToday = key === todayStr;
+              const cards = localByDate[key] ?? [];
               return (
-                <DayColumn key={dayKey} day={d} isToday={isToday}>
-                  {Array.from({ length: SLOT_COUNT }, (_, slotIdx) => {
-                    const k = cellId(dayKey, slotIdx);
-                    const cards = localByCell[k] ?? [];
-                    return (
-                      <SlotCell
-                        key={k}
-                        cellKey={k}
-                        time={slotTime(slotIdx)}
-                        empty={cards.length === 0}
-                      >
-                        <SortableContext
-                          id={k}
-                          items={cards.map((c) => c.id)}
-                          strategy={verticalListSortingStrategy}
-                        >
-                          {cards.map((r) => (
-                            <SortableCard
-                              key={r.id}
-                              card={r}
-                              busy={busy}
-                              onRemove={handleRemove}
-                            />
-                          ))}
-                        </SortableContext>
-                      </SlotCell>
-                    );
-                  })}
+                <DayColumn key={key} dayKey={key} day={d} isToday={isToday} cards={cards}>
+                  <SortableContext
+                    id={key}
+                    items={cards.map((c) => c.id)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    {cards.length === 0 ? (
+                      <div className="rounded border border-dashed border-zinc-200 px-2 py-4 text-center text-[10px] text-zinc-400 dark:border-zinc-800">
+                        無排程
+                      </div>
+                    ) : (
+                      cards.map((r, idx) => (
+                        <SortableCard
+                          key={r.id}
+                          card={r}
+                          idx={idx}
+                          busy={busy}
+                          onRemove={handleRemove}
+                        />
+                      ))
+                    )}
+                  </SortableContext>
                 </DayColumn>
               );
             })}
@@ -394,16 +359,29 @@ export default function CommunityCandidatesCalendarPage() {
 }
 
 function DayColumn({
+  dayKey,
   day,
   isToday,
+  cards,
   children,
 }: {
+  dayKey: string;
   day: Date;
   isToday: boolean;
+  cards: CalendarCandidate[];
   children: React.ReactNode;
 }) {
+  // useDroppable so empty columns can accept drops
+  const { setNodeRef, isOver } = useDroppable({ id: dayKey });
   return (
-    <div className="flex w-[220px] shrink-0 flex-col gap-1 lg:w-auto lg:min-w-0">
+    <div
+      ref={setNodeRef}
+      className={`flex min-h-[200px] w-[200px] shrink-0 flex-col gap-2 rounded-md p-1 transition lg:w-auto lg:min-w-0 ${
+        isOver
+          ? "bg-amber-50 ring-2 ring-amber-300 dark:bg-amber-950/30 dark:ring-amber-700"
+          : ""
+      }`}
+    >
       <div
         className={`rounded-md px-2 py-1.5 text-center text-xs font-semibold ${
           isToday
@@ -416,54 +394,19 @@ function DayColumn({
         </div>
         <div className="text-[10px] font-normal opacity-70">週{WEEKDAYS[day.getDay()]}</div>
       </div>
-      <div className="flex flex-col gap-0.5">{children}</div>
-    </div>
-  );
-}
-
-function SlotCell({
-  cellKey,
-  time,
-  empty,
-  children,
-}: {
-  cellKey: string;
-  time: string;
-  empty: boolean;
-  children: React.ReactNode;
-}) {
-  const { setNodeRef, isOver } = useDroppable({ id: cellKey });
-  return (
-    <div
-      ref={setNodeRef}
-      className={`flex gap-1.5 rounded-md p-1 transition ${
-        isOver
-          ? "bg-amber-50 ring-1 ring-amber-300 dark:bg-amber-950/30 dark:ring-amber-700"
-          : ""
-      }`}
-    >
-      <div className="w-9 shrink-0 pt-1 text-right font-mono text-[10px] font-medium text-zinc-400 dark:text-zinc-500">
-        {time}
-      </div>
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        {empty ? (
-          <div className="rounded border border-dashed border-zinc-200 px-2 py-2 text-center text-[10px] text-zinc-300 dark:border-zinc-800 dark:text-zinc-600">
-            —
-          </div>
-        ) : (
-          children
-        )}
-      </div>
+      {children}
     </div>
   );
 }
 
 function SortableCard({
   card: r,
+  idx,
   busy,
   onRemove,
 }: {
   card: CalendarCandidate;
+  idx: number;
   busy: boolean;
   onRemove: (r: CalendarCandidate) => void;
 }) {
@@ -491,8 +434,8 @@ function SortableCard({
           {...attributes}
           {...listeners}
           role="button"
-          aria-label="拖拉排序或換時段"
-          title="拖拉排序 / 換時段"
+          aria-label="拖拉排序或換日"
+          title="拖拉排序 / 換日"
           className="flex w-9 shrink-0 cursor-grab touch-none select-none items-center justify-center rounded-md border border-zinc-200 bg-zinc-50 text-zinc-400 transition hover:border-zinc-300 hover:bg-zinc-100 hover:text-zinc-600 active:cursor-grabbing active:bg-zinc-200 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-500 dark:hover:bg-zinc-700 dark:hover:text-zinc-300 lg:w-5 lg:rounded"
         >
           <svg
@@ -510,6 +453,9 @@ function SortableCard({
           </svg>
         </span>
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="font-mono text-[10px] font-semibold text-zinc-400 dark:text-zinc-500">
+            {suggestedTime(idx)}
+          </span>
           <Link
             href={`/community-candidates?highlight=${r.id}`}
             className="font-medium leading-snug hover:underline"

--- a/supabase/migrations/20260620000090_revert_calendar_slot_index.sql
+++ b/supabase/migrations/20260620000090_revert_calendar_slot_index.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- Revert 20260620000040_calendar_slot_index.sql
+--
+-- 週曆退回「一天一欄、欄內每個 item 一列」（一個 item 一個 slot 的舊樣式），
+-- 不再用日 × 整點時段 grid。
+--
+-- 1) scheduled_sort_order 重編號為「同 day 內順序」
+--    （先依 slot_index、再依舊 sort_order、再依 created_at 平手）
+-- 2) DROP scheduled_slot_index 欄位
+-- 3) DROP 5-參數版本 rpc_reorder_candidate_campaign、重建 4-參數版本
+--    （回到 20260516000004 的簽名與 body，start_at = day 0 點）
+-- ============================================================
+
+-- 1) 重新編號 sort_order 為「同 day 內順序」
+WITH r AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY tenant_id, scheduled_open_at
+           ORDER BY scheduled_slot_index NULLS LAST,
+                    scheduled_sort_order NULLS LAST,
+                    created_at,
+                    id
+         ) AS rn
+    FROM community_product_candidates
+   WHERE scheduled_open_at IS NOT NULL
+)
+UPDATE community_product_candidates c
+   SET scheduled_sort_order = r.rn
+  FROM r
+ WHERE c.id = r.id;
+
+-- 2) DROP scheduled_slot_index
+ALTER TABLE community_product_candidates
+  DROP COLUMN IF EXISTS scheduled_slot_index;
+
+-- 3) DROP 5-參數版本、重建 4-參數版本
+DROP FUNCTION IF EXISTS rpc_reorder_candidate_campaign(BIGINT, DATE, SMALLINT, INTEGER, UUID);
+
+CREATE OR REPLACE FUNCTION rpc_reorder_candidate_campaign(
+  p_candidate_id BIGINT,
+  p_day_key      DATE,
+  p_order        INTEGER,
+  p_operator     UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant      UUID;
+  v_campaign_id BIGINT;
+  v_new_no      TEXT;
+  v_pad_id      TEXT := lpad(p_candidate_id::TEXT, 6, '0');
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM community_product_candidates WHERE id = p_candidate_id;
+  IF v_tenant IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  v_new_no := 'GB' || to_char(p_day_key, 'YYYYMMDD') || '-C' || v_pad_id;
+
+  SELECT id INTO v_campaign_id
+    FROM group_buy_campaigns
+   WHERE tenant_id = v_tenant
+     AND campaign_no LIKE '%-C' || v_pad_id
+   LIMIT 1;
+
+  IF v_campaign_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  UPDATE group_buy_campaigns SET
+    display_order = p_order,
+    start_at      = p_day_key::TIMESTAMPTZ,
+    campaign_no   = v_new_no,
+    updated_by    = p_operator,
+    updated_at    = NOW()
+  WHERE id = v_campaign_id;
+
+  RETURN v_campaign_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_reorder_candidate_campaign(BIGINT, DATE, INTEGER, UUID) TO authenticated;


### PR DESCRIPTION
## Summary
- 回滾 #308：使用者要求週曆退回前一版的單欄樣式（每日一欄、欄內每個候選一列、一個 item 一個 slot）
- `page.tsx` 還原到 c1b83f5^ 的內容：用 `scheduled_sort_order` 排序、無時段切分
- 反向 migration `20260620000090_revert_calendar_slot_index.sql`：
  - 重新編號 `scheduled_sort_order` 為「同 day 內順序」（依舊 slot_index、sort_order、created_at 平手）
  - `DROP COLUMN scheduled_slot_index`
  - `DROP` 5 參數版 `rpc_reorder_candidate_campaign`、重建 4 參數版本（與 20260516000004 一致）

## Test plan
- [ ] Studio 跑 migration `20260620000090`：欄位 drop 成功、`rpc_reorder_candidate_campaign(BIGINT, DATE, INTEGER, UUID)` 存在
- [ ] 後台 `/community-candidates/calendar`：7 天欄 layout、無 09:00–21:00 整點 slot
- [ ] 拖拉同一天內排序 → `scheduled_sort_order` 更新、`group_buy_campaigns.display_order` 同步
- [ ] 拖拉跨日 → `scheduled_open_at` 改、`campaign_no` 重新編、`start_at` 改成新日 00:00
- [ ] 候選池 → 排程到週曆仍可運作（不依賴 slot_index）

🤖 Generated with [Claude Code](https://claude.com/claude-code)