### PR TITLE
fix(admin/fb-publish): 修正 FB 貼文 base URL fallback 為 vercel 網址

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -10,5 +10,5 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=<from Supabase dashboard → Project Settings → 
 NEXT_PUBLIC_BASE_PATH=
 
 # 會員端 shop 的對外網址，用於同步 FB 粉絲團時把 /shop/c/{id} 拼進貼文
-# 末尾不要加斜線；未設定時預設 https://shop.lt-foods.tw
-NEXT_PUBLIC_MEMBER_APP_URL=https://shop.lt-foods.tw
+# 末尾不要加斜線；未設定時預設 https://new-erp-admin.vercel.app
+NEXT_PUBLIC_MEMBER_APP_URL=https://new-erp-admin.vercel.app

--- a/apps/admin/src/components/FbPublishModal.tsx
+++ b/apps/admin/src/components/FbPublishModal.tsx
@@ -6,7 +6,7 @@ import SpinButton from "@/components/SpinButton";
 import { getSupabase } from "@/lib/supabase";
 
 const PRODUCTS_BUCKET = "products";
-const MEMBER_APP_URL = (process.env.NEXT_PUBLIC_MEMBER_APP_URL ?? "https://shop.lt-foods.tw").replace(/\/$/, "");
+const MEMBER_APP_URL = (process.env.NEXT_PUBLIC_MEMBER_APP_URL ?? "https://new-erp-admin.vercel.app").replace(/\/$/, "");
 
 type FbPage = {
   id: number;


### PR DESCRIPTION
## Summary
- `FbPublishModal` 跟 `.env.example` 的 `NEXT_PUBLIC_MEMBER_APP_URL` fallback 從 \`https://shop.lt-foods.tw\` 改成 \`https://new-erp-admin.vercel.app\`
- 後者才是會員端 shop 實際對外網址；前者連結會 404

## 影響
- FB 同步上架時若 admin 部署沒設 \`NEXT_PUBLIC_MEMBER_APP_URL\` env var，貼出去的 \`/shop/c/{id}\` 連結現在會指向正確網址
- 已設 env var 的部署不受影響

## Test plan
- [ ] \`/campaigns\` 列表開「發 FB」modal，預覽連結顯示 \`https://new-erp-admin.vercel.app/shop/c/{id}\`
- [ ] 實發一篇到測試粉絲團，貼文內連結可正確開啟 shop 商品頁

🤖 Generated with [Claude Code](https://claude.com/claude-code)