### PR TITLE
feat(admin/campaigns): 清單多選批次發 FB

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -14,6 +14,7 @@ import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/compone
 import { CampaignThumb } from "@/components/CampaignThumb";
 import { campaignCoverUrl, type CampaignCoverItem } from "@/lib/campaignCover";
 import FbPublishModal from "@/components/FbPublishModal";
+import FbBulkPublishModal from "@/components/FbBulkPublishModal";
 import { useRole, isAdmin } from "@/lib/role";
 
 // 共用: chunked fetch — bypass PostgREST max-rows 1000 cap
@@ -128,6 +129,7 @@ export default function CampaignsListPage() {
   const [reloadTick, setReloadTick] = useState(0);
   const [resyncTick, setResyncTick] = useState(0);
   const [fbPublishId, setFbPublishId] = useState<number | null>(null);
+  const [bulkFbOpen, setBulkFbOpen] = useState(false);
   const [closingId, setClosingId] = useState<number | null>(null);
   const [finalizingId, setFinalizingId] = useState<number | null>(null);
 
@@ -664,6 +666,15 @@ export default function CampaignsListPage() {
           >
             批次設定收單時間
           </SpinButton>
+          {showAdminActions && (
+            <SpinButton
+              onClick={() => setBulkFbOpen(true)}
+              disabled={bulkBusy !== null}
+              className="rounded-md bg-sky-100 px-3 py-1.5 text-sm font-medium text-sky-800 hover:bg-sky-200 disabled:opacity-50 dark:bg-sky-950 dark:text-sky-300 dark:hover:bg-sky-900"
+            >
+              批次發 FB
+            </SpinButton>
+          )}
           <SpinButton
             onClick={() => setSelectedIds(new Set())}
             className="ml-auto text-xs text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200"
@@ -935,6 +946,13 @@ export default function CampaignsListPage() {
         open={fbPublishId !== null}
         campaignId={fbPublishId}
         onClose={() => setFbPublishId(null)}
+      />
+
+      <FbBulkPublishModal
+        open={bulkFbOpen}
+        campaignIds={Array.from(selectedIds)}
+        onClose={() => setBulkFbOpen(false)}
+        onCompleted={() => setReloadTick((t) => t + 1)}
       />
     </div>
   );

--- a/apps/admin/src/components/FbBulkPublishModal.tsx
+++ b/apps/admin/src/components/FbBulkPublishModal.tsx
@@ -1,0 +1,410 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Modal } from "@/components/Modal";
+import SpinButton from "@/components/SpinButton";
+import { getSupabase } from "@/lib/supabase";
+
+const PRODUCTS_BUCKET = "products";
+const MEMBER_APP_URL = (process.env.NEXT_PUBLIC_MEMBER_APP_URL ?? "https://new-erp-admin.vercel.app").replace(/\/$/, "");
+
+type FbPage = {
+  id: number;
+  page_id: string;
+  name: string;
+  sort_order: number;
+};
+
+type CampaignDraft = {
+  id: number;
+  name: string;
+  description: string | null;
+  cover_image_url: string | null;
+  imageUrls: string[];
+  message: string;
+};
+
+type PairStatus = "pending" | "running" | "success" | "failed";
+
+type PairResult = {
+  campaignId: number;
+  campaignName: string;
+  fbPageId: number;
+  pageName: string;
+  status: PairStatus;
+  permalink?: string | null;
+  error?: string;
+};
+
+type Props = {
+  open: boolean;
+  campaignIds: number[];
+  onClose: () => void;
+  onCompleted?: () => void;
+};
+
+function resolveImagePath(p: string): string {
+  if (/^https?:\/\//i.test(p)) return p;
+  return getSupabase().storage.from(PRODUCTS_BUCKET).getPublicUrl(p).data.publicUrl;
+}
+
+function buildDefaultMessage(name: string, description: string | null, campaignId: number): string {
+  const link = `${MEMBER_APP_URL}/shop/c/${campaignId}`;
+  const parts: string[] = [];
+  parts.push(`【開團】${name}`);
+  if (description) {
+    const plain = description
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/p>/gi, "\n")
+      .replace(/<[^>]+>/g, "")
+      .trim();
+    if (plain) parts.push(plain);
+  }
+  parts.push(`\n👉 立即下單：${link}`);
+  return parts.join("\n\n");
+}
+
+export default function FbBulkPublishModal({ open, campaignIds, onClose, onCompleted }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [campaigns, setCampaigns] = useState<CampaignDraft[]>([]);
+  const [pages, setPages] = useState<FbPage[]>([]);
+  const [selectedPageIds, setSelectedPageIds] = useState<Set<number>>(new Set());
+  const [results, setResults] = useState<PairResult[] | null>(null);
+
+  useEffect(() => {
+    if (!open || campaignIds.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      setResults(null);
+      try {
+        const sb = getSupabase();
+        const [campRes, pagesRes] = await Promise.all([
+          sb
+            .from("group_buy_campaigns")
+            .select(
+              "id, name, description, cover_image_url, campaign_items(sort_order, sku:skus(product:products(images)))",
+            )
+            .in("id", campaignIds),
+          sb
+            .from("fb_pages")
+            .select("id, page_id, name, sort_order")
+            .eq("is_active", true)
+            .order("sort_order", { ascending: true }),
+        ]);
+        if (cancelled) return;
+        if (campRes.error) throw campRes.error;
+        if (pagesRes.error) throw pagesRes.error;
+
+        const camps = (campRes.data ?? []) as Array<{
+          id: number;
+          name: string;
+          description: string | null;
+          cover_image_url: string | null;
+          campaign_items?: Array<{
+            sort_order: number;
+            sku?: { product?: { images?: string[] } | null } | null;
+          }>;
+        }>;
+
+        const drafts: CampaignDraft[] = camps
+          .sort((a, b) => campaignIds.indexOf(a.id) - campaignIds.indexOf(b.id))
+          .map((c) => {
+            const imageSet = new Set<string>();
+            if (c.cover_image_url) imageSet.add(resolveImagePath(c.cover_image_url));
+            const items = (c.campaign_items ?? []).slice().sort((a, b) => a.sort_order - b.sort_order);
+            for (const it of items) {
+              const imgs = it.sku?.product?.images ?? [];
+              for (const p of imgs) if (typeof p === "string" && p) imageSet.add(resolveImagePath(p));
+            }
+            return {
+              id: c.id,
+              name: c.name,
+              description: c.description ?? null,
+              cover_image_url: c.cover_image_url ?? null,
+              imageUrls: [...imageSet],
+              message: buildDefaultMessage(c.name, c.description ?? null, c.id),
+            };
+          });
+
+        setCampaigns(drafts);
+        setPages(pagesRes.data ?? []);
+        setSelectedPageIds(new Set());
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, campaignIds]);
+
+  const togglePage = (id: number) => {
+    setSelectedPageIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const totalPairs = campaigns.length * selectedPageIds.size;
+
+  async function handleSubmit() {
+    if (campaigns.length === 0 || selectedPageIds.size === 0) return;
+
+    const pageList = pages.filter((p) => selectedPageIds.has(p.id));
+    const initial: PairResult[] = [];
+    for (const c of campaigns) {
+      for (const p of pageList) {
+        initial.push({
+          campaignId: c.id,
+          campaignName: c.name,
+          fbPageId: p.id,
+          pageName: p.name,
+          status: "pending",
+        });
+      }
+    }
+    setResults(initial);
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const sb = getSupabase();
+      const { data: { session } } = await sb.auth.getSession();
+      if (!session) throw new Error("尚未登入");
+
+      for (const c of campaigns) {
+        // mark this campaign's pairs as running
+        setResults((prev) => prev?.map((r) =>
+          r.campaignId === c.id ? { ...r, status: "running" } : r
+        ) ?? null);
+
+        try {
+          const resp = await fetch(
+            `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/campaign-publish-facebook`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${session.access_token}`,
+              },
+              body: JSON.stringify({
+                campaign_id: c.id,
+                fb_page_ids: [...selectedPageIds],
+                message: c.message,
+                image_urls: c.imageUrls,
+              }),
+            },
+          );
+          const data = await resp.json();
+          if (!resp.ok) throw new Error(data?.error || data?.detail || `HTTP ${resp.status}`);
+          const perPage = new Map<number, { status: "success" | "failed"; permalink?: string | null; error?: string }>();
+          for (const r of (data.results ?? []) as Array<{
+            fb_page_id: number;
+            status: "success" | "failed";
+            permalink?: string | null;
+            error?: string;
+          }>) {
+            perPage.set(r.fb_page_id, {
+              status: r.status,
+              permalink: r.permalink,
+              error: r.error,
+            });
+          }
+          setResults((prev) => prev?.map((r) => {
+            if (r.campaignId !== c.id) return r;
+            const got = perPage.get(r.fbPageId);
+            if (!got) return { ...r, status: "failed", error: "edge function 未回此粉絲團結果" };
+            return { ...r, status: got.status, permalink: got.permalink ?? null, error: got.error };
+          }) ?? null);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          setResults((prev) => prev?.map((r) =>
+            r.campaignId === c.id && r.status === "running"
+              ? { ...r, status: "failed", error: msg }
+              : r
+          ) ?? null);
+        }
+      }
+      onCompleted?.();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const summary = useMemo(() => {
+    if (!results) return null;
+    const success = results.filter((r) => r.status === "success").length;
+    const failed = results.filter((r) => r.status === "failed").length;
+    const remaining = results.length - success - failed;
+    return { success, failed, remaining, total: results.length };
+  }, [results]);
+
+  return (
+    <Modal open={open} onClose={onClose} title={`批次發佈到 FB 粉絲團（${campaignIds.length} 個開團）`} maxWidth="max-w-5xl">
+      {loading ? (
+        <div className="py-10 text-center text-sm text-zinc-500">載入中…</div>
+      ) : campaigns.length === 0 ? (
+        <div className="py-10 text-center text-sm text-red-600">{error ?? "找不到開團資料"}</div>
+      ) : (
+        <div className="space-y-5">
+          <section>
+            <div className="mb-2 text-xs font-medium text-zinc-500">
+              粉絲團（{selectedPageIds.size}/{pages.length}）
+            </div>
+            {pages.length === 0 ? (
+              <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
+                目前沒有啟用中的粉絲團設定。請先在資料庫的 fb_pages 表新增資料。
+              </div>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {pages.map((p) => {
+                  const selected = selectedPageIds.has(p.id);
+                  return (
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => togglePage(p.id)}
+                      disabled={submitting}
+                      className={`rounded-full border px-3 py-1 text-xs transition ${
+                        selected
+                          ? "border-blue-500 bg-blue-500 text-white"
+                          : "border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300"
+                      }`}
+                    >
+                      {p.name}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <div className="mb-2 text-xs font-medium text-zinc-500">預覽（共 {campaigns.length} 個開團）</div>
+            <div className="max-h-[420px] space-y-3 overflow-y-auto rounded border border-zinc-200 p-2 dark:border-zinc-800">
+              {campaigns.map((c) => (
+                <div key={c.id} className="rounded border border-zinc-200 bg-white p-3 text-sm dark:border-zinc-800 dark:bg-zinc-900">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate font-semibold">{c.name}</div>
+                      <a
+                        href={`${MEMBER_APP_URL}/shop/c/${c.id}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                      >
+                        {MEMBER_APP_URL}/shop/c/{c.id}
+                      </a>
+                    </div>
+                    <span className="shrink-0 text-xs text-zinc-400">{c.imageUrls.length} 張圖</span>
+                  </div>
+                  <pre className="mt-2 max-h-32 overflow-y-auto whitespace-pre-wrap rounded bg-zinc-50 p-2 text-xs text-zinc-700 dark:bg-zinc-950 dark:text-zinc-300">
+{c.message}
+                  </pre>
+                  {c.imageUrls.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {c.imageUrls.slice(0, 8).map((url) => (
+                        <div key={url} className="h-12 w-12 overflow-hidden rounded border border-zinc-200 dark:border-zinc-700">
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img src={url} alt="" className="h-full w-full object-cover" />
+                        </div>
+                      ))}
+                      {c.imageUrls.length > 8 && (
+                        <div className="flex h-12 w-12 items-center justify-center rounded border border-zinc-200 text-xs text-zinc-500 dark:border-zinc-700">
+                          +{c.imageUrls.length - 8}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {results && (
+            <section>
+              <div className="mb-1 flex items-center justify-between text-xs font-medium text-zinc-500">
+                <span>發送進度</span>
+                {summary && (
+                  <span>
+                    完成 {summary.success + summary.failed}/{summary.total}（成功 {summary.success}、失敗 {summary.failed}{summary.remaining > 0 ? `、剩 ${summary.remaining}` : ""}）
+                  </span>
+                )}
+              </div>
+              <div className="max-h-64 space-y-1 overflow-y-auto rounded border border-zinc-200 p-2 text-xs dark:border-zinc-800">
+                {results.map((r, idx) => (
+                  <div key={`${r.campaignId}-${r.fbPageId}-${idx}`} className="flex items-center gap-2">
+                    <StatusPill status={r.status} />
+                    <span className="truncate font-medium">{r.campaignName}</span>
+                    <span className="text-zinc-400">→</span>
+                    <span className="text-zinc-600 dark:text-zinc-400">{r.pageName}</span>
+                    {r.permalink && (
+                      <a
+                        href={r.permalink}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-blue-600 hover:underline dark:text-blue-400"
+                      >
+                        看貼文
+                      </a>
+                    )}
+                    {r.error && (
+                      <span className="truncate text-red-600 dark:text-red-400" title={r.error}>
+                        ({r.error.slice(0, 60)}{r.error.length > 60 ? "…" : ""})
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {error && (
+            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+              {error}
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-2 border-t border-zinc-200 pt-3 dark:border-zinc-800">
+            <SpinButton
+              onClick={onClose}
+              disabled={submitting}
+              className="rounded border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800 disabled:opacity-50"
+            >
+              關閉
+            </SpinButton>
+            <SpinButton
+              onClick={handleSubmit}
+              disabled={submitting || pages.length === 0 || selectedPageIds.size === 0 || campaigns.length === 0}
+              className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? "發送中…" : `發送 ${campaigns.length} × ${selectedPageIds.size} = ${totalPairs} 筆`}
+            </SpinButton>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function StatusPill({ status }: { status: PairStatus }) {
+  const cfg: Record<PairStatus, { label: string; cls: string }> = {
+    pending: { label: "待發", cls: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400" },
+    running: { label: "發送中", cls: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300" },
+    success: { label: "成功", cls: "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300" },
+    failed: { label: "失敗", cls: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" },
+  };
+  const { label, cls } = cfg[status];
+  return <span className={`inline-flex shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}>{label}</span>;
+}

--- a/docs/TEST-FB-BULK-PUBLISH.md
+++ b/docs/TEST-FB-BULK-PUBLISH.md
@@ -1,0 +1,45 @@
+# TEST — 開團清單多選批次發 FB
+
+## 範圍
+- 後台 `/campaigns` 列表 view：勾選多個開團 → bulk toolbar 上「批次發 FB (N)」按鈕
+- 點按鈕開 `FbBulkPublishModal`：
+  - 載入所有選中 campaigns 詳情（name、cover、items→skus→products.images）
+  - 統一選粉絲團（fb_pages 啟用中的）
+  - 每個 campaign 預覽：標題、shop link、自動產生文案、所有圖片縮圖
+  - 「發送 N campaigns × M pages」按鈕 → 逐個 campaign 呼叫 `campaign-publish-facebook`
+  - 每個 (campaign × page) 結果即時顯示（pending / success / failed + error_message + permalink）
+- 共用既有 edge function `campaign-publish-facebook`、`campaign_fb_posts` 表寫紀錄
+
+## UI 行為
+- [ ] 沒勾選任何 campaign → toolbar 不顯示「批次發 FB」按鈕
+- [ ] 勾 1 個以上 → 顯示「批次發 FB (N)」按鈕（admin/owner/hq_manager 才可見，沿用 `showAdminActions`）
+- [ ] 點按鈕 → modal 開啟、自動載入所有勾選 campaigns 詳情
+- [ ] modal 顯示每個 campaign 一塊區域，包含 name、shop link、auto-message 預覽、image thumbs
+- [ ] 粉絲團多選 chip（沿用 single modal 樣式）
+- [ ] 「發送」按鈕在 `selectedPageIds.size === 0` 時 disabled
+- [ ] 進度區即時顯示每個 (campaign, page) pair 狀態（pending → success / failed）
+- [ ] 全部完成後顯示總結：N campaigns × M pages → X success / Y failed
+- [ ] 關閉 modal 後勾選自動清空、列表 reload
+
+## 資料正確性
+- [ ] 對單一 campaign 來說：bulk 跑出來的 `campaign_fb_posts` row 與 single modal 跑的格式一致
+- [ ] 自動文案 = `【開團】<name>\n\n<description plain text>\n\n👉 立即下單：<MEMBER_APP_URL>/shop/c/<id>`
+- [ ] image_urls = `[cover_image_url, ...campaign_items.sku.product.images]`（dedupe + resolve PublicUrl）
+- [ ] 含 cover_image_url 為 null 的情境：只發 items 圖片
+- [ ] 含完全無圖的 campaign：純文字發文（imageUrls = []，走 `/feed`）
+
+## 錯誤處理
+- [ ] 任一 campaign 失敗不影響其他 campaign 繼續發送（不是 fail-fast）
+- [ ] 同個 page 對同個 campaign 失敗時：error_message 顯示在進度區
+- [ ] FB token 整體過期：每個 (campaign × page) 都會失敗、各自顯示錯誤
+- [ ] 沒啟用粉絲團（fb_pages 全 inactive）→ modal 顯示警示、按鈕 disabled
+
+## 角色 / 權限
+- [ ] 一般 store_owner / staff 看不到「批次發 FB」（同 row level「發 FB」邏輯）
+- [ ] owner / admin / hq_manager 看得到
+- [ ] edge function 後端 role check 仍會擋（雙保險）
+
+## 回歸
+- [ ] 既有 single「發 FB」按鈕仍可用、modal 沒被影響
+- [ ] 既有「批次開團 / 批次結單 / 批次取消 / 批次設定收單時間」仍可用
+- [ ] 勾選操作（單行 checkbox / 全選 checkbox / 跨頁清除）正常


### PR DESCRIPTION
## Summary
- 開團清單的多選 toolbar 加「批次發 FB」按鈕（admin/owner/hq_manager 限定）
- 新增 `FbBulkPublishModal`：一次發多個開團 × 多個粉絲團；統一選粉絲團 chip、每個開團走自動文案 + 全部圖片，可預覽
- 進度區（campaign × page）即時狀態 pending/running/success/failed + permalink/error
- 不改 edge function `campaign-publish-facebook`、不改 schema；逐個 campaign 呼叫既有後端

## Test plan
測試清單見 `docs/TEST-FB-BULK-PUBLISH.md`。重點：

- [ ] 一般 store user 看不到「批次發 FB」按鈕；admin/owner/hq_manager 看得到
- [ ] 勾 N 個 campaigns → 開 modal → 統一選 M 個粉絲團 → 「發送 N × M = K 筆」按鈕生效
- [ ] 預覽區顯示每個 campaign 的 name、shop link、自動文案、最多 8 張縮圖
- [ ] 任一 campaign 失敗不影響其他 campaign 繼續
- [ ] 全部完成後總結 X 成功 / Y 失敗 + 列表 reload
- [ ] 既有 single「發 FB」按鈕仍正常運作
- [ ] 既有批次開團/結單/取消/設定收單時間都正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)