### PR TITLE
fix(admin/orders): pivot 取消單獨立標示 + 開團下拉可搜尋

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -26,7 +26,7 @@ type Row = {
   updated_at: string;
 };
 
-type Campaign = { id: number; campaign_no: string; name: string; cover_image_url: string | null };
+type Campaign = { id: number; campaign_no: string; name: string; cover_image_url: string | null; start_at: string | null };
 type Store = { id: number; code: string; name: string };
 type Member = { id: number; name: string | null; phone: string | null; member_no: string; avatar_url: string | null };
 
@@ -128,7 +128,11 @@ function OrdersListContent() {
   const [kwInput, setKwInput] = useState(initialKeyword);
   const [keyword, setKeyword] = useState(initialKeyword);
   const [campaignPickerOpen, setCampaignPickerOpen] = useState(false);
+  const [campaignSearch, setCampaignSearch] = useState("");
 
+  // dropdownIds: 目前下拉清單顯示的開團 id 序（最新 20 / 搜尋結果），由 effect 寫入
+  const [dropdownIds, setDropdownIds] = useState<number[]>([]);
+  // campaigns: 已知開團的 cache（包含下拉、訂單列、目前勾選），由 effect 累加
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [stores, setStores] = useState<Store[]>([]);
   const [members, setMembers] = useState<Map<number, Member>>(new Map());
@@ -159,17 +163,66 @@ function OrdersListContent() {
   // （僅保留軟性預設選中自家店，使用者可自行切換到別店或「全部」）
   useDefaultStoreFromUser(stores, storeId, setStoreId);
 
+  // 載入 stores 一次
   useEffect(() => {
     (async () => {
       const sb = getSupabase();
-      const [c, s] = await Promise.all([
-        sb.from("group_buy_campaigns").select("id, campaign_no, name, cover_image_url").order("updated_at", { ascending: false }).limit(200),
-        sb.from("stores").select("id, code, name").order("name"),
-      ]);
-      setCampaigns((c.data as Campaign[]) ?? []);
-      setStores((s.data as Store[]) ?? []);
+      const { data } = await sb.from("stores").select("id, code, name").order("name");
+      setStores((data as Store[]) ?? []);
     })();
   }, []);
+
+  // 累加開團到 cache（dedupe by id）
+  const mergeCampaigns = (list: Campaign[]) => {
+    if (list.length === 0) return;
+    setCampaigns((cur) => {
+      const map = new Map(cur.map((c) => [c.id, c]));
+      for (const c of list) map.set(c.id, c);
+      return Array.from(map.values());
+    });
+  };
+
+  // 下拉清單：預設 start_at desc 前 20 筆；有搜尋字串時 ilike + 50 筆
+  // 用 setTimeout 250ms debounce 避免每個字打進去都打一次 server
+  useEffect(() => {
+    const t = setTimeout(async () => {
+      const sb = getSupabase();
+      const kw = campaignSearch.trim();
+      let q = sb
+        .from("group_buy_campaigns")
+        .select("id, campaign_no, name, cover_image_url, start_at")
+        .order("start_at", { ascending: false, nullsFirst: false });
+      if (kw) {
+        const safe = kw.replace(/[%,()]/g, " ");
+        q = q.or(`name.ilike.%${safe}%,campaign_no.ilike.%${safe}%`).limit(50);
+      } else {
+        q = q.limit(20);
+      }
+      const { data } = await q;
+      const list = (data as Campaign[]) ?? [];
+      setDropdownIds(list.map((c) => c.id));
+      mergeCampaigns(list);
+    }, 250);
+    return () => clearTimeout(t);
+  }, [campaignSearch]);
+
+  // 把目前用到的開團（已勾選 + 訂單列引用）全部撈進 cache，
+  // 確保按鈕的開團名、訂單列封面/名稱在「不在前 20 名」也能正確顯示。
+  // mergeCampaigns dedupe，重複 id 不會重撈。
+  useEffect(() => {
+    const ids = new Set<number>();
+    for (const x of campaignIds) ids.add(Number(x));
+    for (const r of rows ?? []) ids.add(r.campaign_id);
+    if (ids.size === 0) return;
+    (async () => {
+      const sb = getSupabase();
+      const { data } = await sb
+        .from("group_buy_campaigns")
+        .select("id, campaign_no, name, cover_image_url, start_at")
+        .in("id", Array.from(ids));
+      mergeCampaigns((data as Campaign[]) ?? []);
+    })();
+  }, [campaignIds, rows]);
 
   useEffect(() => {
     let cancelled = false;
@@ -614,49 +667,84 @@ function OrdersListContent() {
               {campaignIds.length === 0
                 ? "全部開團"
                 : campaignIds.length === 1
-                ? campaigns.find((c) => String(c.id) === campaignIds[0])?.name ?? `團 ${campaignIds[0]}`
+                ? campaignMap.get(Number(campaignIds[0]))?.name ?? `團 ${campaignIds[0]}`
                 : `已選 ${campaignIds.length} 個開團`}
             </span>
             <span className="ml-2 text-zinc-400">▾</span>
           </SpinButton>
           {campaignPickerOpen && (
-            <div className="absolute z-20 mt-1 max-h-80 w-full overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
-              <div className="sticky top-0 flex justify-between border-b border-zinc-200 bg-white px-3 py-2 text-xs dark:border-zinc-800 dark:bg-zinc-900">
-                <SpinButton
-                  onClick={() => setCampaignIds([])}
-                  className="text-blue-600 hover:underline dark:text-blue-400"
-                >
-                  全部清除
-                </SpinButton>
-                <SpinButton
-                  onClick={() => setCampaignPickerOpen(false)}
-                  className="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400"
-                >
-                  關閉
-                </SpinButton>
-              </div>
-              {campaigns.map((c) => {
-                const checked = campaignIds.includes(String(c.id));
-                return (
-                  <label
-                    key={c.id}
-                    className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:hover:bg-zinc-950"
+            <div className="absolute z-20 mt-1 max-h-96 w-full overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+              <div className="sticky top-0 z-10 border-b border-zinc-200 bg-white px-3 py-2 dark:border-zinc-800 dark:bg-zinc-900">
+                <div className="flex justify-between text-xs">
+                  <SpinButton
+                    onClick={() => setCampaignIds([])}
+                    className="text-blue-600 hover:underline dark:text-blue-400"
                   >
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={(e) => {
-                        const id = String(c.id);
-                        setCampaignIds((cur) =>
-                          e.target.checked ? [...cur, id] : cur.filter((x) => x !== id),
-                        );
-                      }}
-                    />
-                    <span className="font-mono text-xs text-zinc-500">{c.campaign_no}</span>
-                    <span className="truncate">{c.name}</span>
-                  </label>
-                );
-              })}
+                    全部清除
+                  </SpinButton>
+                  <SpinButton
+                    onClick={() => setCampaignPickerOpen(false)}
+                    className="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400"
+                  >
+                    關閉
+                  </SpinButton>
+                </div>
+                <input
+                  type="search"
+                  value={campaignSearch}
+                  onChange={(e) => setCampaignSearch(e.target.value)}
+                  placeholder="搜尋開團編號 / 名稱"
+                  className="mt-2 w-full rounded border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                />
+              </div>
+              {(() => {
+                // 顯示順序：已勾選的開團釘在最上面（避免搜尋字串改變後不見），再放下拉結果
+                const seen = new Set<number>();
+                const ordered: Campaign[] = [];
+                for (const id of campaignIds) {
+                  const c = campaignMap.get(Number(id));
+                  if (c && !seen.has(c.id)) {
+                    ordered.push(c);
+                    seen.add(c.id);
+                  }
+                }
+                for (const id of dropdownIds) {
+                  const c = campaignMap.get(id);
+                  if (c && !seen.has(c.id)) {
+                    ordered.push(c);
+                    seen.add(c.id);
+                  }
+                }
+                if (ordered.length === 0) {
+                  return (
+                    <div className="px-3 py-6 text-center text-xs text-zinc-500">
+                      {campaignSearch ? "找不到符合的開團" : "無開團"}
+                    </div>
+                  );
+                }
+                return ordered.map((c) => {
+                  const checked = campaignIds.includes(String(c.id));
+                  return (
+                    <label
+                      key={c.id}
+                      className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:hover:bg-zinc-950"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={(e) => {
+                          const id = String(c.id);
+                          setCampaignIds((cur) =>
+                            e.target.checked ? [...cur, id] : cur.filter((x) => x !== id),
+                          );
+                        }}
+                      />
+                      <span className="font-mono text-xs text-zinc-500">{c.campaign_no}</span>
+                      <span className="truncate">{c.name}</span>
+                    </label>
+                  );
+                });
+              })()}
             </div>
           )}
         </div>

--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -43,6 +43,8 @@ type OrderRow = {
 type Member = { id: number; name: string | null; phone: string | null };
 
 // server-side aggregate row (rpc_orders_pivot)
+// v4 起：qty_sum / amount 只計「非取消」品項；neg_qty_sum / neg_amount
+// 為取消/逾期/轉出之絕對值，UI 在 cell 後面標 "取消 N 個"。
 type PivotRow = {
   group_key: string;
   group_id: number | null;        // campaign mode = campaign_id；date mode = null
@@ -52,6 +54,8 @@ type PivotRow = {
   pickup_store_id: number;
   qty_sum: number | string;       // numeric → string via postgrest
   amount: number | string;
+  neg_qty_sum: number | string;
+  neg_amount: number | string;
   pos_order_ids: number[];
   neg_order_ids: number[];
 };
@@ -353,9 +357,11 @@ function PivotContent() {
   // 每一列 = 一個 (group × sku × store) cell
   type CellAgg = {
     posOrders: Set<number>; // 有效訂單
-    negOrders: Set<number>; // 取消/逾期/轉出（扣抵）
-    qtySum: number;
-    amount: number;
+    negOrders: Set<number>; // 取消/逾期/轉出（單獨標示，不扣抵）
+    qtySum: number;         // 正單 qty
+    amount: number;         // 正單 amount
+    negQtySum: number;      // 取消單 qty（絕對值）
+    negAmount: number;      // 取消單 amount（絕對值）
   };
   type SkuEntry = { name: string; perStore: Map<number, CellAgg> };
   type Group = {
@@ -416,6 +422,8 @@ function PivotContent() {
         negOrders: new Set(r.neg_order_ids ?? []),
         qtySum: Number(r.qty_sum),
         amount: Number(r.amount),
+        negQtySum: Number(r.neg_qty_sum ?? 0),
+        negAmount: Number(r.neg_amount ?? 0),
       });
     }
 
@@ -455,27 +463,43 @@ function PivotContent() {
     if (!cell) return 0;
     return metric === "item_qty" ? cell.qtySum : cell.amount;
   };
+  const cellNegValue = (cell: CellAgg | undefined): number => {
+    if (!cell) return 0;
+    return metric === "item_qty" ? cell.negQtySum : cell.negAmount;
+  };
   const fmtCellValue = (v: number): string => {
     if (metric === "amount") return fmtAmount(v);
     // item_qty 可能小數、round 2 位後去 trailing 0
     const r = Math.round(v * 100) / 100;
     return String(r);
   };
+  const fmtNegSuffix = (neg: number): string => {
+    if (!neg) return "";
+    if (metric === "amount") return `取消 ${fmtAmount(neg)}`;
+    const r = Math.round(neg * 100) / 100;
+    return `取消 ${r} 個`;
+  };
 
   // Grand totals — 依 metric 取值
+  // 正單 / 取消單 各自加總；UI 顯示正單值、取消數另外標
   const grandTotals = useMemo(() => {
     const perStore = new Map<number, number>();
+    const negPerStore = new Map<number, number>();
     let grand = 0;
+    let negGrand = 0;
     for (const g of pivot.groups) {
       for (const [, entry] of g.skus) {
         for (const [sid, cell] of entry.perStore) {
           const v = metric === "item_qty" ? cell.qtySum : cell.amount;
+          const nv = metric === "item_qty" ? cell.negQtySum : cell.negAmount;
           perStore.set(sid, (perStore.get(sid) ?? 0) + v);
+          negPerStore.set(sid, (negPerStore.get(sid) ?? 0) + nv);
           grand += v;
+          negGrand += nv;
         }
       }
     }
-    return { perStore, grand };
+    return { perStore, grand, negPerStore, negGrand };
   }, [pivot, metric]);
 
   const visibleOrders = useMemo(() => {
@@ -808,18 +832,24 @@ function PivotContent() {
                   a[1].name.localeCompare(b[1].name, "zh-TW"),
                 );
                 const groupTotalsPerStore = new Map<number, number>();
+                const groupNegPerStore = new Map<number, number>();
                 let groupGrand = 0;
+                let groupNegGrand = 0;
                 for (const [, entry] of skuArr) {
                   for (const sid of pivot.storeIds) {
                     const v = cellValue(entry.perStore.get(sid));
+                    const nv = cellNegValue(entry.perStore.get(sid));
                     groupTotalsPerStore.set(sid, (groupTotalsPerStore.get(sid) ?? 0) + v);
+                    groupNegPerStore.set(sid, (groupNegPerStore.get(sid) ?? 0) + nv);
                     groupGrand += v;
+                    groupNegGrand += nv;
                   }
                 }
                 return (
                   <Fragment key={group.key}>
                     {skuArr.map(([skuId, entry], i) => {
                       let rowTotal = 0;
+                      let rowNegTotal = 0;
                       const rowCls = [
                         i === 0 ? "border-t-2 border-zinc-300 dark:border-zinc-700" : "",
                         group.closed ? "bg-amber-50/60 dark:bg-amber-950/30" : "",
@@ -856,7 +886,9 @@ function PivotContent() {
                           {pivot.storeIds.map((sid) => {
                             const cell = entry.perStore.get(sid);
                             const v = cellValue(cell);
+                            const negV = cellNegValue(cell);
                             rowTotal += v;
+                            rowNegTotal += negV;
                             if (!cell || cellTouched(cell) === 0) {
                               return (
                                 <td
@@ -867,6 +899,7 @@ function PivotContent() {
                                 </td>
                               );
                             }
+                            const negSuffix = fmtNegSuffix(negV);
                             return (
                               <td key={sid} className="px-3 py-1.5 text-right">
                                 <SpinButton
@@ -877,11 +910,21 @@ function PivotContent() {
                                 >
                                   {fmtCellValue(v)}
                                 </SpinButton>
+                                {negSuffix && (
+                                  <div className="mt-0.5 text-[10px] font-normal text-zinc-400 dark:text-zinc-500">
+                                    {negSuffix}
+                                  </div>
+                                )}
                               </td>
                             );
                           })}
                           <td className="px-3 py-1.5 text-right font-mono font-semibold">
                             {rowTotal ? fmtCellValue(rowTotal) : ""}
+                            {rowNegTotal > 0 && (
+                              <div className="mt-0.5 text-[10px] font-normal text-zinc-400 dark:text-zinc-500">
+                                {fmtNegSuffix(rowNegTotal)}
+                              </div>
+                            )}
                           </td>
                         </tr>
                       );
@@ -892,16 +935,29 @@ function PivotContent() {
                         <td className="px-3 py-1.5 text-xs text-zinc-500">{group.label}</td>
                         {pivot.storeIds.map((sid) => {
                           const v = groupTotalsPerStore.get(sid) ?? 0;
+                          const nv = groupNegPerStore.get(sid) ?? 0;
                           return (
                             <td
                               key={sid}
                               className="px-3 py-1.5 text-right font-mono text-zinc-700 dark:text-zinc-300"
                             >
                               {v ? fmtCellValue(v) : ""}
+                              {nv > 0 && (
+                                <div className="text-[10px] font-normal text-zinc-400 dark:text-zinc-500">
+                                  {fmtNegSuffix(nv)}
+                                </div>
+                              )}
                             </td>
                           );
                         })}
-                        <td className="px-3 py-1.5 text-right font-mono">{fmtCellValue(groupGrand)}</td>
+                        <td className="px-3 py-1.5 text-right font-mono">
+                          {fmtCellValue(groupGrand)}
+                          {groupNegGrand > 0 && (
+                            <div className="text-[10px] font-normal text-zinc-400 dark:text-zinc-500">
+                              {fmtNegSuffix(groupNegGrand)}
+                            </div>
+                          )}
+                        </td>
                       </tr>
                     )}
                   </Fragment>
@@ -911,12 +967,27 @@ function PivotContent() {
                 <td className="px-3 py-2" colSpan={2}>
                   總計
                 </td>
-                {pivot.storeIds.map((sid) => (
-                  <td key={sid} className="px-3 py-2 text-right font-mono">
-                    {fmtCellValue(grandTotals.perStore.get(sid) ?? 0)}
-                  </td>
-                ))}
-                <td className="px-3 py-2 text-right font-mono">{fmtCellValue(grandTotals.grand)}</td>
+                {pivot.storeIds.map((sid) => {
+                  const nv = grandTotals.negPerStore.get(sid) ?? 0;
+                  return (
+                    <td key={sid} className="px-3 py-2 text-right font-mono">
+                      {fmtCellValue(grandTotals.perStore.get(sid) ?? 0)}
+                      {nv > 0 && (
+                        <div className="text-[10px] font-normal text-zinc-400 dark:text-zinc-500">
+                          {fmtNegSuffix(nv)}
+                        </div>
+                      )}
+                    </td>
+                  );
+                })}
+                <td className="px-3 py-2 text-right font-mono">
+                  {fmtCellValue(grandTotals.grand)}
+                  {grandTotals.negGrand > 0 && (
+                    <div className="text-[10px] font-normal text-zinc-400 dark:text-zinc-500">
+                      {fmtNegSuffix(grandTotals.negGrand)}
+                    </div>
+                  )}
+                </td>
               </tr>
             </tbody>
           </table>

--- a/supabase/migrations/20260622000010_rpc_orders_pivot_split_cancelled.sql
+++ b/supabase/migrations/20260622000010_rpc_orders_pivot_split_cancelled.sql
@@ -1,0 +1,124 @@
+-- ============================================================
+-- rpc_orders_pivot v4 — 拆分「正單」與「取消單」聚合
+--
+-- 問題：使用者在 admin /orders/pivot 勾「已取消」狀態時，原本邏輯
+--   把取消單的 qty/amount 從正單裡「相減」（CASE WHEN cancelled THEN -qty）。
+--   這在 UI 上會看到一個淨值，無法分辨是正常出貨數 還是 被取消後的差額。
+--
+-- 修法：qty_sum / amount 只統計「非取消」品項；另外回傳
+--   neg_qty_sum / neg_amount 為「取消/逾期/轉出」的絕對值。
+--   前端 cell 顯示正單值，後面附註 「(取消 N 個)」/「(取消 $N)」。
+--   pos_order_ids / neg_order_ids 維持不變，drill-down 行為一致。
+--
+-- 改 return shape (jsonb 內欄位增加) → DROP + CREATE。
+-- ============================================================
+
+DROP FUNCTION IF EXISTS rpc_orders_pivot(text, date, date, bigint[], bigint, text[], boolean);
+
+CREATE OR REPLACE FUNCTION rpc_orders_pivot(
+  p_view_by      text,
+  p_date_from    date,
+  p_date_to      date,
+  p_campaign_ids bigint[],
+  p_store_id     bigint,
+  p_statuses     text[],
+  p_closed_only  boolean DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH filtered AS (
+    SELECT o.*
+    FROM customer_orders o
+    LEFT JOIN group_buy_campaigns c ON c.id = o.campaign_id
+    WHERE o.status = ANY(p_statuses)
+      AND (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      AND (
+        p_closed_only IS NULL
+        OR (p_closed_only IS TRUE
+            AND c.status IN ('closed','ordered','receiving','ready','completed'))
+        OR (p_closed_only IS FALSE
+            AND c.status NOT IN ('closed','ordered','receiving','ready','completed'))
+      )
+      AND CASE p_view_by
+        WHEN 'pickup_date' THEN
+          (p_date_from IS NULL OR o.pickup_deadline >= p_date_from)
+          AND (p_date_to IS NULL OR o.pickup_deadline <  p_date_to)
+        WHEN 'order_date' THEN
+          (p_date_from IS NULL OR o.created_at >= p_date_from::timestamptz)
+          AND (p_date_to IS NULL OR o.created_at <  p_date_to::timestamptz)
+        WHEN 'campaign' THEN
+          c.end_at IS NULL
+          OR (
+            (p_date_from IS NULL OR c.end_at >= p_date_from::timestamptz)
+            AND (p_date_to IS NULL OR c.end_at <  p_date_to::timestamptz)
+          )
+        ELSE TRUE
+      END
+  ),
+  base AS (
+    SELECT
+      CASE p_view_by
+        WHEN 'campaign'    THEN 'c' || f.campaign_id::text
+        WHEN 'pickup_date' THEN 'd' || to_char(COALESCE(f.pickup_deadline, f.created_at::date), 'YYYY-MM-DD')
+        WHEN 'order_date'  THEN 'd' || to_char(f.created_at::date, 'YYYY-MM-DD')
+      END                                              AS group_key,
+      CASE WHEN p_view_by = 'campaign' THEN f.campaign_id ELSE NULL::bigint END
+                                                       AS group_id,
+      i.sku_id,
+      s.product_name                                   AS sku_product_name,
+      s.variant_name                                   AS sku_variant_name,
+      f.pickup_store_id,
+      f.id                                             AS order_id,
+      f.status,
+      i.qty,
+      i.unit_price
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    LEFT JOIN skus s ON s.id = i.sku_id
+  ),
+  agg AS (
+    SELECT
+      b.group_key,
+      b.group_id,
+      b.sku_id,
+      b.sku_product_name,
+      b.sku_variant_name,
+      b.pickup_store_id,
+      SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+               THEN 0 ELSE b.qty END)::numeric                            AS qty_sum,
+      SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+               THEN 0 ELSE b.qty * b.unit_price END)::numeric             AS amount,
+      SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+               THEN b.qty ELSE 0 END)::numeric                            AS neg_qty_sum,
+      SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+               THEN b.qty * b.unit_price ELSE 0 END)::numeric             AS neg_amount,
+      COALESCE(
+        ARRAY_AGG(DISTINCT b.order_id)
+          FILTER (WHERE b.status NOT IN ('cancelled','expired','transferred_out')),
+        '{}'::bigint[]
+      )                                                                   AS pos_order_ids,
+      COALESCE(
+        ARRAY_AGG(DISTINCT b.order_id)
+          FILTER (WHERE b.status IN ('cancelled','expired','transferred_out')),
+        '{}'::bigint[]
+      )                                                                   AS neg_order_ids
+    FROM base b
+    GROUP BY
+      b.group_key,
+      b.group_id,
+      b.sku_id,
+      b.sku_product_name,
+      b.sku_variant_name,
+      b.pickup_store_id
+  )
+  SELECT COALESCE(jsonb_agg(to_jsonb(agg.*)), '[]'::jsonb)
+  FROM agg;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_orders_pivot(text, date, date, bigint[], bigint, text[], boolean) TO authenticated;


### PR DESCRIPTION
## Summary

兩個 admin/orders 區的改動：

### 1. `fix(admin/orders/pivot)` — 取消單改在 cell 後標「取消 N 個」、不再扣抵正單

之前 RPC 把 `cancelled / expired / transferred_out` 的 qty/amount 從正單裡相減，勾「已取消」狀態時 cell 顯示淨值無法分辨。改：

- **RPC v4** (`20260622000010_rpc_orders_pivot_split_cancelled.sql`)：
  - `qty_sum` / `amount` 只算「非取消」品項
  - 新增 `neg_qty_sum` / `neg_amount`（取消單絕對值）
  - `pos_order_ids` / `neg_order_ids` 不變，drill-down 行為一致
- **前端 `/orders/pivot`：** cell / 小計 / 總計顯示正單值，下方小字標 `取消 N 個`（amount 模式顯示 `取消 $N`）；沒勾「已取消」狀態時自然不會看到註記

### 2. `feat(admin/orders)` — 開團下拉支援搜尋、預設 start_at desc 前 20 筆

之前一次撈 200 筆 (updated_at desc) 塞進下拉，找舊團要捲很久。改：

- 預設 `start_at desc` 前 20 筆（開團時間由近到遠）
- 下拉內加搜尋框：250ms debounce、server-side `name / campaign_no ilike`、limit 50
- 已勾選的開團釘在清單最上面（避免搜尋字改變後不見）
- 用一個 effect 把「已勾選 ids + 訂單列 campaign_ids」補進 cache，按鈕標題和列上封面/名稱在不在前 20 也能正常顯示

## Test plan

- [ ] **DB migration**：在 Supabase 套上 `20260622000010_rpc_orders_pivot_split_cancelled.sql`
- [ ] `/orders/pivot` 不勾「已取消」 → 數字與舊版相同（沒有取消單註記）
- [ ] `/orders/pivot` 勾「已取消」 → cell 顯示正單值，下面有 `取消 N 個`；小計 / 總計 同步顯示
- [ ] `/orders/pivot` 切「品項數」/「訂單金額」 → 註記文字也跟著切（個 / $）
- [ ] `/orders/pivot` 點 cell drill-down → 仍能看到所有訂單（含取消）
- [ ] `/orders` 開團下拉打開 → 預設看到 20 筆，最新 start_at 在最上
- [ ] `/orders` 開團下拉輸入關鍵字 → 搜得到名稱 / 編號符合的開團
- [ ] `/orders` 勾選舊開團（不在前 20）→ 關閉下拉再開、按鈕標題、訂單列都顯示得到名字

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxH4XzqNHQ8aX3oGBsPHeB)_