### PR TITLE
fix(admin/purchase/requests): 採購單品項依 sku_code 排序，同商品規格相鄰

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -347,6 +347,12 @@ function PageContent() {
           };
         });
 
+        // 依 sku_code 排序，讓同商品（同 G00022-* prefix）的不同規格相鄰；
+        // numeric:true 確保 G00018-10 排在 G00018-2 之後而不是字典序排前面
+        merged.sort((a, b) =>
+          a.sku_code.localeCompare(b.sku_code, undefined, { numeric: true, sensitivity: "base" }),
+        );
+
         setItems(merged);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));

--- a/apps/admin/src/app/(protected)/purchase/requests/print/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/print/page.tsx
@@ -204,6 +204,12 @@ function PageContent() {
       g.rows.push(r);
       g.subtotal += r.qty_requested * r.unit_cost;
     }
+    // 群組內：依 sku_code 排序，讓同商品的不同規格相鄰
+    for (const g of m.values()) {
+      g.rows.sort((a, b) =>
+        a.sku_code.localeCompare(b.sku_code, undefined, { numeric: true, sensitivity: "base" }),
+      );
+    }
     // 未指派排最後
     return Array.from(m.values()).sort((a, b) => {
       if (a.supplier_id === null) return 1;


### PR DESCRIPTION
## Summary

採購單品項顯示順序原本是按 id（插入順序），同一商品不同規格如果不是一次加進來就會分散：

| 之前 | 之後 |
| --- | --- |
| 5: G00022-01 (M 號) | 5: G00018-02 |
| 6: G00023-01 | 6: G00018-03 |
| 7: G00024-01 | 7: G00018-05 |
| 8: G00018-02 | 8: G00022-01 (M 號) |
| 11: G00022-02 (L 號) | 9: G00022-02 (L 號) |
| 12: G00022-03 (XL 號) | 10: G00022-03 (XL 號) |

改用 `sku_code.localeCompare(..., { numeric: true })`：
- 同 product prefix（G00022-*）自然排在一起
- numeric 模式避免 G00018-10 排在 G00018-2 之前

### 改動
- `/purchase/requests/edit`：載入後對 `merged` 排序再 `setItems`
- `/purchase/requests/print`：每個供應商群組內的 `rows` 排序（供應商之間順序不變）

## Test plan

- [ ] `/purchase/requests/edit?id=<PR>` 開有「同商品多規格但分批加入」的 PR → 同 product 的 sku 變相鄰
- [ ] `/purchase/requests/print?id=<PR>` 同上、每個供應商區塊內 sku 也照 sku_code 排序
- [ ] 跨 product 順序合理（G00018-* < G00022-*）

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxH4XzqNHQ8aX3oGBsPHeB)_