### PR TITLE
fix(admin/orders/order-entry): 加單下拉排除已軟刪 SKU / 下架商品

### DIFF
--- a/docs/TEST-search-skus-exclude-discontinued.md
+++ b/docs/TEST-search-skus-exclude-discontinued.md
@@ -1,0 +1,52 @@
+# TEST — 加單下拉排除「已軟刪 SKU / 下架商品」
+
+## 背景
+
+`rpc_search_skus_for_campaign` 兩個 CTE：
+
+| CTE | 用途 | 既有狀態 filter |
+| --- | --- | --- |
+| `in_campaign` | 已加進 campaign_items 的 SKU | ❌ 都沒 filter |
+| `siblings`    | 同商品但未加進 campaign 的 SKU | ✅ `s.status='active' AND p.status='active'` |
+
+實例：開團 `GB20260522-C000315` 內含 SKU `G00127-01`（已 `rpc_delete_sku` → `status='discontinued'`），仍在 admin 加單 picker 顯示為 `$0` 選項。
+
+## 修法
+
+`in_campaign` 也加上 `s.status='active' AND p.status='active'` 條件。
+
+## 測試清單
+
+### Schema / RPC 層
+
+- [ ] **T1**：開團含一個 `status='discontinued'` 的 SKU（campaign_items 仍存在）→ `rpc_search_skus_for_campaign(campaign, '', 50)` 結果**不含**該 SKU。
+- [ ] **T2**：開團含一個 `s.status='active'` 但 `p.status='inactive'` 的 SKU → 結果**不含**該 SKU。
+- [ ] **T3**：開團含一個 active SKU + 一個 discontinued SKU（同 product）→ 結果只回 active 那筆。
+- [ ] **T4**：開團含一個 SKU 但同 product 另有兄弟 SKU 為 discontinued → siblings 不出兄弟 discontinued（既有行為，不應 regress）。
+- [ ] **T5**：跨 tenant 不外洩（既有行為，不應 regress）。
+- [ ] **T6**：return shape 不變（campaign_item_id / sku_id / sku_code / product_name / variant_name / unit_price / cap_qty）。
+
+### UI 層（admin /campaigns/order-entry?id=...）
+
+- [ ] **T7**：用上述 GB20260522-C000315 進 picker，搜尋空字串 → dropdown 沒有 G00127-01。
+- [ ] **T8**：「+ 加商品」select option 也沒有 G00127-01。
+- [ ] **T9**：搜尋字串包含 G00127-01 sku_code → 仍不出現。
+
+### 回溯影響
+
+- [ ] **T10**：既有訂單 `customer_order_items` 已參照 discontinued SKU 的 campaign_item → 訂單詳情頁仍可正常顯示 `sku_label`（picker 不影響顯示）。
+- [ ] **T11**：「為分店叫貨 / 庫存抵減單」mode 同一個 RPC → 也排除 discontinued。
+- [ ] **T12**：order-entry 進入時 `useEffect` 一次性撈 SKUs 那段（line 161）→ 不會把 discontinued 帶進 `campaignSkus`，dropdown 即時可用。
+
+## 驗證手段
+
+- T1–T6：prod Studio 跑 SQL：
+  ```sql
+  SELECT * FROM rpc_search_skus_for_campaign(
+    (SELECT id FROM group_buy_campaigns WHERE campaign_no='GB20260522-C000315'),
+    '', 50
+  );
+  ```
+  確認回傳列中沒有 G00127-01。
+- T7–T9, T11–T12：使用者於 admin 加單頁自審截圖。
+- T10：訂單列表→詳情頁觀察。

--- a/supabase/migrations/20260622000030_search_skus_exclude_discontinued_in_campaign.sql
+++ b/supabase/migrations/20260622000030_search_skus_exclude_discontinued_in_campaign.sql
@@ -1,0 +1,116 @@
+-- ============================================================
+-- rpc_search_skus_for_campaign：in_campaign CTE 也排除「已軟刪 SKU / 下架商品」
+--
+-- 既有問題：siblings CTE 已 filter s.status='active' AND p.status='active'，
+-- 但 in_campaign CTE（已加進 campaign 的 items）沒過濾 SKU/商品狀態。
+-- 結果：SKU 在 rpc_delete_sku 後（status='discontinued'）若 campaign_items
+-- 仍存在（因有 customer_order_items 引用而無法被 resync 刪掉），admin 加單
+-- 下拉仍會出現該 SKU，可能讓使用者誤加到新訂單。
+--
+-- 實例：GB20260522-C000315 含 G00127-01（已軟刪）顯示為 $0 選項。
+--
+-- 修法：in_campaign 也要求 s.status='active' AND p.status='active'。
+-- 既有訂單明細不受影響（訂單列項 sku_label 已固化、不靠這個 RPC 顯示）。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_search_skus_for_campaign(
+  p_campaign_id BIGINT,
+  p_term        TEXT,
+  p_limit       INT DEFAULT 20
+) RETURNS TABLE (
+  campaign_item_id BIGINT,
+  sku_id           BIGINT,
+  sku_code         TEXT,
+  product_name     TEXT,
+  variant_name     TEXT,
+  unit_price       NUMERIC,
+  cap_qty          NUMERIC
+)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_term   TEXT := COALESCE(NULLIF(TRIM(p_term), ''), NULL);
+  v_lim    INT  := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+BEGIN
+  PERFORM 1 FROM group_buy_campaigns WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id; END IF;
+
+  RETURN QUERY
+  WITH campaign_products AS (
+    SELECT DISTINCT s.product_id
+      FROM campaign_items ci
+      JOIN skus s ON s.id = ci.sku_id
+     WHERE ci.tenant_id = v_tenant
+       AND ci.campaign_id = p_campaign_id
+  ),
+  in_campaign AS (
+    SELECT ci.id          AS x_ci_id,
+           s.id           AS x_sku_id,
+           s.sku_code     AS x_sku_code,
+           COALESCE(s.product_name, p.name) AS x_product_name,
+           s.variant_name AS x_variant_name,
+           ci.unit_price  AS x_unit_price,
+           ci.cap_qty     AS x_cap_qty,
+           ci.sort_order  AS x_sort_order,
+           p.name         AS x_p_name
+      FROM campaign_items ci
+      JOIN skus s     ON s.id = ci.sku_id
+      JOIN products p ON p.id = s.product_id
+     WHERE ci.tenant_id   = v_tenant
+       AND ci.campaign_id = p_campaign_id
+       AND s.status = 'active'        -- ★ 新增：排除軟刪 SKU
+       AND p.status = 'active'        -- ★ 新增：排除下架商品
+  ),
+  siblings AS (
+    SELECT NULL::BIGINT   AS x_ci_id,
+           s.id           AS x_sku_id,
+           s.sku_code     AS x_sku_code,
+           COALESCE(s.product_name, p.name) AS x_product_name,
+           s.variant_name AS x_variant_name,
+           COALESCE((
+             SELECT pr.price
+               FROM prices pr
+              WHERE pr.tenant_id = v_tenant
+                AND pr.sku_id = s.id
+                AND pr.scope = 'retail'
+                AND pr.effective_to IS NULL
+              ORDER BY pr.effective_from DESC
+              LIMIT 1
+           ), 0)::NUMERIC AS x_unit_price,
+           NULL::NUMERIC  AS x_cap_qty,
+           999999::INT    AS x_sort_order,
+           p.name         AS x_p_name
+      FROM skus s
+      JOIN products p ON p.id = s.product_id
+     WHERE s.tenant_id = v_tenant
+       AND s.status = 'active'
+       AND p.status = 'active'
+       AND s.product_id IN (SELECT product_id FROM campaign_products)
+       AND NOT EXISTS (
+         SELECT 1 FROM campaign_items ci
+          WHERE ci.tenant_id = v_tenant
+            AND ci.campaign_id = p_campaign_id
+            AND ci.sku_id = s.id
+       )
+  ),
+  combined AS (
+    SELECT * FROM in_campaign
+    UNION ALL
+    SELECT * FROM siblings
+  )
+  SELECT c.x_ci_id, c.x_sku_id, c.x_sku_code, c.x_product_name,
+         c.x_variant_name, c.x_unit_price, c.x_cap_qty
+    FROM combined c
+   WHERE (
+     v_term IS NULL
+     OR c.x_sku_code     ILIKE '%' || v_term || '%'
+     OR c.x_variant_name ILIKE '%' || v_term || '%'
+     OR c.x_p_name       ILIKE '%' || v_term || '%'
+     OR c.x_product_name ILIKE '%' || v_term || '%'
+   )
+   ORDER BY (c.x_ci_id IS NULL), c.x_sort_order, c.x_product_name
+   LIMIT v_lim;
+END;
+$$;


### PR DESCRIPTION
## Summary
- `rpc_search_skus_for_campaign` 的 `in_campaign` CTE 加上 `s.status='active' AND p.status='active'`，與 `siblings` CTE 對齊
- 實例：GB20260522-C000315 含 G00127-01（已軟刪）原本仍顯示為 \$0 可選，修後不出現
- migration 已 push 到 prod

## 為什麼之前會漏
- `rpc_delete_sku` = 軟刪 `status='discontinued'`
- `rpc_resync_campaign_from_product` 會嘗試移除 discontinued 的 campaign_items，但若有 `customer_order_items` 引用就**保留**避免破壞既有訂單
- picker 的 `in_campaign` CTE 沒過濾 status → 該 SKU 仍出現在下拉
- 既有訂單明細顯示靠 sku_label 已固化，**不靠這個 RPC**，所以前端顯示不受影響

## Test plan
測試清單：[docs/TEST-search-skus-exclude-discontinued.md](docs/TEST-search-skus-exclude-discontinued.md)
- [ ] T1：discontinued SKU 不出現在 picker
- [ ] T2：inactive product 的 SKU 不出現
- [ ] T3：同 product 一個 active + 一個 discontinued → 只回 active
- [ ] T7：admin 進 GB20260522-C000315 加單，下拉沒有 G00127-01
- [ ] T10：既有訂單詳情仍可正常顯示已選的 SKU label

🤖 Generated with [Claude Code](https://claude.com/claude-code)