### PR TITLE
fix(admin/campaigns/fb-publish): 清掉文案裡 LINE 殘留的 (emoji) 佔位字

### DIFF
--- a/apps/admin/src/components/FbBulkPublishModal.tsx
+++ b/apps/admin/src/components/FbBulkPublishModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
 import { getSupabase } from "@/lib/supabase";
+import { cleanCampaignText } from "@/lib/text";
 
 const PRODUCTS_BUCKET = "products";
 const MEMBER_APP_URL = (process.env.NEXT_PUBLIC_MEMBER_APP_URL ?? "https://new-erp-admin.vercel.app").replace(/\/$/, "");
@@ -51,13 +52,14 @@ function resolveImagePath(p: string): string {
 function buildDefaultMessage(name: string, description: string | null, campaignId: number): string {
   const link = `${MEMBER_APP_URL}/shop/c/${campaignId}`;
   const parts: string[] = [];
-  parts.push(`【開團】${name}`);
+  parts.push(`【開團】${cleanCampaignText(name)}`);
   if (description) {
-    const plain = description
-      .replace(/<br\s*\/?>/gi, "\n")
-      .replace(/<\/p>/gi, "\n")
-      .replace(/<[^>]+>/g, "")
-      .trim();
+    const plain = cleanCampaignText(
+      description
+        .replace(/<br\s*\/?>/gi, "\n")
+        .replace(/<\/p>/gi, "\n")
+        .replace(/<[^>]+>/g, ""),
+    );
     if (plain) parts.push(plain);
   }
   parts.push(`\n👉 立即下單：${link}`);

--- a/apps/admin/src/components/FbPublishModal.tsx
+++ b/apps/admin/src/components/FbPublishModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
 import { getSupabase } from "@/lib/supabase";
+import { cleanCampaignText } from "@/lib/text";
 
 const PRODUCTS_BUCKET = "products";
 const MEMBER_APP_URL = (process.env.NEXT_PUBLIC_MEMBER_APP_URL ?? "https://new-erp-admin.vercel.app").replace(/\/$/, "");
@@ -439,13 +440,14 @@ export default function FbPublishModal({ open, campaignId, onClose }: Props) {
 function buildDefaultMessage(name: string, description: string | null, campaignId: number): string {
   const link = `${MEMBER_APP_URL}/shop/c/${campaignId}`;
   const parts: string[] = [];
-  parts.push(`【開團】${name}`);
+  parts.push(`【開團】${cleanCampaignText(name)}`);
   if (description) {
-    const plain = description
-      .replace(/<br\s*\/?>/gi, "\n")
-      .replace(/<\/p>/gi, "\n")
-      .replace(/<[^>]+>/g, "")
-      .trim();
+    const plain = cleanCampaignText(
+      description
+        .replace(/<br\s*\/?>/gi, "\n")
+        .replace(/<\/p>/gi, "\n")
+        .replace(/<[^>]+>/g, ""),
+    );
     if (plain) parts.push(plain);
   }
   parts.push(`\n👉 立即下單：${link}`);

--- a/apps/admin/src/lib/text.ts
+++ b/apps/admin/src/lib/text.ts
@@ -1,0 +1,35 @@
+/** 清掉 legacy LINE 匯入殘留的 emoji 佔位字，並收斂多餘空白。
+ *  開團名稱／描述常從 LINE 候選池貼文帶出，夾帶 (emoji)/(heart)/(cool) 這類雜訊 token。
+ *  有對應 Unicode 的就還原，純佔位的 (emoji) 直接拿掉。
+ *  收 null/undefined（名稱欄位多為 nullable），一律回字串。 */
+const LINE_SHORTCODES: Array<[RegExp, string]> = [
+  [/\(heart\)/gi, "♥"],
+  [/\(cool\)/gi, "😎"],
+  [/\(joy\)/gi, "😂"],
+  [/\(smile\)/gi, "😊"],
+  [/\(grin\)/gi, "😁"],
+  [/\(wink\)/gi, "😉"],
+  [/\(sad\)/gi, "😢"],
+  [/\(cry\)/gi, "😭"],
+  [/\(angry\)/gi, "😠"],
+  [/\(love\)/gi, "😍"],
+  [/\(kiss\)/gi, "😘"],
+  [/\(ok\)/gi, "👌"],
+  [/\(thumbsup\)/gi, "👍"],
+  [/\(clap\)/gi, "👏"],
+  [/\(fire\)/gi, "🔥"],
+  [/\(star\)/gi, "⭐"],
+  [/\(sparkle\)/gi, "✨"],
+  [/\(emoji\)/gi, ""],
+];
+
+export function cleanCampaignText(raw: string | null | undefined): string {
+  if (!raw) return "";
+  let s = raw;
+  for (const [re, rep] of LINE_SHORTCODES) s = s.replace(re, rep);
+  return s
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/apps/admin/src/lib/text.ts
+++ b/apps/admin/src/lib/text.ts
@@ -1,8 +1,10 @@
 /** 清掉 legacy LINE 匯入殘留的 emoji 佔位字，並收斂多餘空白。
  *  開團名稱／描述常從 LINE 候選池貼文帶出，夾帶 (emoji)/(heart)/(cool) 這類雜訊 token。
- *  有對應 Unicode 的就還原，純佔位的 (emoji) 直接拿掉。
+ *  有對應 Unicode 的就還原，純佔位的 (emoji) 直接拿掉；單字元的 LINE 客製貼圖
+ *  ($)/(0-9)/(/) 多半是文字內容（價格、日期），剝掉括號保留字元。
  *  收 null/undefined（名稱欄位多為 nullable），一律回字串。 */
 const LINE_SHORTCODES: Array<[RegExp, string]> = [
+  // 有名字的 → Unicode emoji
   [/\(heart\)/gi, "♥"],
   [/\(cool\)/gi, "😎"],
   [/\(joy\)/gi, "😂"],
@@ -15,12 +17,45 @@ const LINE_SHORTCODES: Array<[RegExp, string]> = [
   [/\(love\)/gi, "😍"],
   [/\(kiss\)/gi, "😘"],
   [/\(ok\)/gi, "👌"],
+  [/\(ng\)/gi, "🙅"],
   [/\(thumbsup\)/gi, "👍"],
+  [/\(thumbsdown\)/gi, "👎"],
   [/\(clap\)/gi, "👏"],
+  [/\(pray\)/gi, "🙏"],
+  [/\(muscle\)/gi, "💪"],
+  [/\(hi\)/gi, "👋"],
+  [/\(bye\)/gi, "👋"],
   [/\(fire\)/gi, "🔥"],
   [/\(star\)/gi, "⭐"],
   [/\(sparkle\)/gi, "✨"],
-  [/\(emoji\)/gi, ""],
+  [/\(sparkles\)/gi, "✨"],
+  [/\(check\)/gi, "✅"],
+  [/\(cross\)/gi, "❌"],
+  [/\(warn\)/gi, "⚠️"],
+  [/\(sun\)/gi, "☀️"],
+  [/\(moon\)/gi, "🌙"],
+  [/\(cloud\)/gi, "☁️"],
+  [/\(rain\)/gi, "🌧️"],
+  [/\(coffee\)/gi, "☕"],
+  [/\(cake\)/gi, "🍰"],
+  [/\(gift\)/gi, "🎁"],
+  [/\(party\)/gi, "🎉"],
+  [/\(music\)/gi, "🎵"],
+  [/\(phone\)/gi, "📱"],
+  [/\(mail\)/gi, "📧"],
+  [/\(pin\)/gi, "📌"],
+  [/\(memo\)/gi, "📝"],
+  [/\(calendar\)/gi, "📅"],
+  [/\(clock\)/gi, "⏰"],
+  [/\(bell\)/gi, "🔔"],
+  [/\(point\)/gi, "👉"],
+  [/\(arrow\)/gi, "➡️"],
+  // 單字元 LINE 客製貼圖（多半是文字內容如 $1850、5/24） → 剝掉括號保留字元
+  [/\(\$\)/g, "$"],
+  [/\(([0-9])\)/g, "$1"],
+  [/\(\/\)/g, "/"],
+  // 純佔位、無法還原；順手吃掉一個尾隨空白（避免 `(emoji) 條列` 拿掉後留 ` 條列`）
+  [/\(emoji\)[ \t]?/gi, ""],
 ];
 
 export function cleanCampaignText(raw: string | null | undefined): string {


### PR DESCRIPTION
## Summary

修正開團發 FB 時，文案會出現 `(emoji)`、`(cool)`、`($)(1)(8)(5)` 這類佔位字的問題。

**根因**：LINE 匯入的開團描述夾帶 LINE 客製貼圖／emoji 的文字佔位 token；`FbPublishModal` / `FbBulkPublishModal` 的 `buildDefaultMessage` 之前只剝 HTML tag，token 就原樣帶到 FB。

**改動**：
- 新增 `apps/admin/src/lib/text.ts` 的 `cleanCampaignText`（member 端早就有同名 helper，但兩個 app 沒共用 package，這裡複製一份並擴充字典）
- 在兩個 FB 發文 Modal 的 `buildDefaultMessage` 套用 cleaner，name 與 description 都跑過
- 字典涵蓋 30+ 個常見 LINE shortcode：
  - **named** → Unicode：cool/joy/smile/heart/fire/coffee/pin/calendar… 等
  - **單字元** `($)/(0-9)/(/)` → 剝括號保留字元（截圖中 `($)(1)(8)(5)` 其實是價格 `$185`、`(5)(/)(2)(4)` 是日期 `5/24`）
  - 純 `(emoji)` → 拿掉，順手吃一個尾隨空白避免條列開頭留空

## Test plan

- [ ] 開團 → 點「發佈到 FB 粉絲團」，預設文案不再出現 `(emoji)`/`(cool)` 等 token
- [ ] 文字裡的價格 `($)(1)(8)(5)` 變成 `$185`，日期 `(5)(/)(2)(4)` 變成 `5/24`
- [ ] 批次發 FB（FbBulkPublishModal）同樣套用
- [ ] textarea 仍可手動微調再送出

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3da64fF9g8EEPy1A1udir)_