### PR TITLE
refactor(purchase/campaign): PR/PO 正名 + 開團新增 locked 狀態

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -5,6 +5,11 @@ import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
 import { PR_TERM_ZH } from "@/lib/prStatus";
+import {
+  CAMPAIGN_STATUS_LABEL,
+  CAMPAIGN_STATUS_BADGE,
+  type CampaignStatus,
+} from "@/lib/campaignStatus";
 import { Modal } from "@/components/Modal";
 import { CampaignForm, type CampaignFormValues } from "@/components/CampaignForm";
 import { CampaignOrdersPanel } from "@/components/CampaignOrdersPanel";
@@ -32,8 +37,7 @@ async function fetchAll<T>(builder: () => any, pageSize = 1000, maxPages = 50): 
   return all;
 }
 
-type Status =
-  | "draft" | "open" | "closed" | "ordered" | "receiving" | "ready" | "completed" | "cancelled";
+type Status = CampaignStatus;
 
 type CloseType = "regular" | "fast" | "limited";
 
@@ -51,10 +55,7 @@ type Row = {
   campaign_items: CampaignCoverItem[] | null;
 };
 
-const STATUS_LABEL: Record<Status, string> = {
-  draft: "草稿", open: "開團中", closed: "已收單", ordered: "已下訂",
-  receiving: "到貨中", ready: "可取貨", completed: "已完成", cancelled: "已取消",
-};
+const STATUS_LABEL = CAMPAIGN_STATUS_LABEL;
 
 const CLOSE_TYPE_LABEL: Record<CloseType, string> = {
   regular: "常規",
@@ -509,7 +510,7 @@ export default function CampaignsListPage() {
           {closingId === r.id ? "結單中…" : "結單"}
         </SpinButton>
       )}
-      {showAdminActions && (["open", "closed", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
+      {showAdminActions && (["open", "closed", "locked", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
         <SpinButton
           onClick={() => setFbPublishId(r.id)}
           className="text-xs text-sky-600 hover:underline dark:text-sky-400"
@@ -517,7 +518,7 @@ export default function CampaignsListPage() {
           發 FB
         </SpinButton>
       )}
-      {(["closed", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
+      {(["closed", "locked", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
         <SpinButton
           onClick={() => finalizeCampaign(r.id, r.name)}
           disabled={finalizingId === r.id}
@@ -963,17 +964,7 @@ function PagerBtn({ onClick, disabled, children }: { onClick: () => void; disabl
   return <SpinButton onClick={onClick} disabled={disabled} className="rounded-md border border-zinc-300 px-2 py-1 hover:bg-zinc-100 disabled:opacity-40 disabled:hover:bg-transparent dark:border-zinc-700 dark:hover:bg-zinc-800 dark:disabled:hover:bg-transparent">{children}</SpinButton>;
 }
 function StatusBadge({ s }: { s: Status }) {
-  const st: Record<Status, string> = {
-    draft: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
-    open: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
-    closed: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
-    ordered: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
-    receiving: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
-    ready: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
-    completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
-    cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
-  };
-  return <span className={`inline-block rounded px-2 py-0.5 text-xs ${st[s]}`}>{STATUS_LABEL[s]}</span>;
+  return <span className={`inline-block rounded px-2 py-0.5 text-xs ${CAMPAIGN_STATUS_BADGE[s]}`}>{STATUS_LABEL[s]}</span>;
 }
 
 // ============================================================
@@ -1454,22 +1445,14 @@ function CampaignCard({
     draft: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-200",
     open: "bg-green-200 text-green-800 dark:bg-green-900 dark:text-green-200",
     closed: "bg-amber-200 text-amber-800 dark:bg-amber-900 dark:text-amber-200",
+    locked: "bg-rose-200 text-rose-800 dark:bg-rose-900 dark:text-rose-200",
     ordered: "bg-blue-200 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
     receiving: "bg-indigo-200 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200",
     ready: "bg-emerald-200 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200",
     completed: "bg-zinc-300 text-zinc-700 dark:bg-zinc-600 dark:text-zinc-200",
     cancelled: "bg-red-200 text-red-800 dark:bg-red-900 dark:text-red-200",
   };
-  const compactBg: Record<Status, string> = {
-    draft: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
-    open: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
-    closed: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
-    ordered: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
-    receiving: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
-    ready: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
-    completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
-    cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
-  };
+  const compactBg = CAMPAIGN_STATUS_BADGE;
 
   if (compact) {
     return (

--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
+import { PR_TERM_ZH } from "@/lib/prStatus";
 import { Modal } from "@/components/Modal";
 import { CampaignForm, type CampaignFormValues } from "@/components/CampaignForm";
 import { CampaignOrdersPanel } from "@/components/CampaignOrdersPanel";
@@ -232,7 +233,7 @@ export default function CampaignsListPage() {
   }
 
   async function closeCampaign(id: number, name: string) {
-    if (!confirm(`確定結單「${name}」？結單後可從採購單頁面「帶入該日商品」產生 PR。`)) return;
+    if (!confirm(`確定結單「${name}」？結單後可從${PR_TERM_ZH}頁面「帶入該日商品」產生 PR。`)) return;
     setClosingId(id);
     try {
       const { error: rpcErr } = await getSupabase().rpc("rpc_close_campaign", {

--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -5,6 +5,7 @@ import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
+import { PR_TERM_ZH } from "@/lib/prStatus";
 import SpinButton from "@/components/SpinButton";
 import { RowAction } from "@/components/RowAction";
 import { OrderDetail } from "@/components/OrderDetail";
@@ -1226,7 +1227,7 @@ function HqInboxContent() {
   }
 
   async function approveToPr(id: number) {
-    if (!confirm("確定下訂單？此動作會獨立建立一張新的採購單。")) return;
+    if (!confirm(`確定下訂單？此動作會獨立建立一張新的${PR_TERM_ZH}。`)) return;
     setBusy(`restock-${id}-pr`);
     try {
       const { error: err } = await getSupabase().rpc("rpc_approve_restock_to_pr", { p_request_id: id });
@@ -2193,7 +2194,7 @@ function MailRow({
         急補 {s.line_count} 項 · NT${s.total_amount.toFixed(0)}
         {s.linked_pr_id && (
           <Link href={`/purchase/requests/edit?id=${s.linked_pr_id}`} className="ml-2 font-mono text-blue-600 hover:underline dark:text-blue-400">
-            · {s.linked_pr_no ?? `採購單 #${s.linked_pr_id}`}
+            · {s.linked_pr_no ?? `${PR_TERM_ZH} #${s.linked_pr_id}`}
           </Link>
         )}
         {s.linked_transfer_id && (

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -40,8 +40,8 @@ const NAV: NavGroup[] = [
   {
     title: "進銷存",
     items: [
-      { href: "/purchase/requests", label: "採購單", match: /^\/purchase\/requests/ },
-      { href: "/purchase/orders", label: "採購訂單", match: /^\/purchase\/orders/ },
+      { href: "/purchase/requests", label: "請購單", match: /^\/purchase\/requests/ },
+      { href: "/purchase/orders", label: "採購單", match: /^\/purchase\/orders/ },
       { href: "/inventory", label: "庫存總覽", match: /^\/inventory(?!\/mutual-aid|\/reorder-rules|\/stocktake)/ },
       { href: "/inventory/reorder-rules", label: "補貨規則", match: /^\/inventory\/reorder-rules/ },
       { href: "/inventory/stocktake", label: "盤點", match: /^\/inventory\/stocktake/ },
@@ -99,8 +99,8 @@ const BRANCH_HIDDEN_HREFS = new Set([
   "/hq/inbox",            // 總倉收件匣
   "/products",            // 商品主檔 (HQ 管理)
   "/suppliers",           // 供應商 (HQ 管理)
-  "/purchase/requests",   // 採購單
-  "/purchase/orders",     // 採購訂單
+  "/purchase/requests",   // 請購單 (PR)
+  "/purchase/orders",     // 採購單 (PO)
   "/wms/receiving",       // 進貨待辦 (HQ)
   "/wms/picking",         // 派貨工作台
   // /wms/inbound 跟 /wms/transfers 不在這裡 — 分店要用,屬於分店業務

--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -8,10 +8,8 @@ import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
 import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 import { ORDER_STATUSES, ORDER_STATUS_LABEL, type OrderStatus } from "@/lib/orderStatus";
+import { type CampaignStatus } from "@/lib/campaignStatus";
 import SpinButton from "@/components/SpinButton";
-
-type CampaignStatus =
-  | "draft" | "open" | "closed" | "ordered" | "receiving" | "ready" | "completed" | "cancelled";
 
 type Campaign = {
   id: number;
@@ -22,9 +20,9 @@ type Campaign = {
   end_at: string | null;
 };
 
-// 已過收單階段的狀態（在 pivot 視覺上標「已結單」tag + 底色）
+// 已過收單階段的狀態（pivot 視覺上標「已結單」tag + 底色）
 const CLOSED_STATUSES: ReadonlySet<CampaignStatus> = new Set([
-  "closed", "ordered", "receiving", "ready", "completed",
+  "closed", "locked", "ordered", "receiving", "ready", "completed",
 ]);
 type Store = { id: number; code: string; name: string };
 
@@ -842,7 +840,7 @@ function PivotContent() {
           </SpinButton>
         </div>
 
-        {/* 只看已收單 toggle — campaign.status ∈ closed/ordered/receiving/ready/completed */}
+        {/* 只看已收單 toggle — campaign.status ∈ closed/locked/ordered/receiving/ready/completed */}
         <SpinButton
           onClick={() => setClosedOnly((v) => !v)}
           className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
@@ -850,7 +848,7 @@ function PivotContent() {
               ? "border-amber-300 bg-amber-100 text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-300"
               : "border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-900"
           }`}
-          title="只看已過收單階段（closed / ordered / receiving / ready / completed）的開團"
+          title="只看已過收單階段(closed / locked / ordered / receiving / ready / completed)的開團"
         >
           只看已收單
         </SpinButton>

--- a/apps/admin/src/app/(protected)/purchase/orders/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/edit/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { SendPOModal } from "@/components/SendPOModal";
 import SpinButton from "@/components/SpinButton";
+import { poStatusLabel, PO_TERM_ZH } from "@/lib/poStatus";
 
 type Supplier = {
   id: number;
@@ -52,14 +53,7 @@ type Item = {
   notes: string | null;
 };
 
-const STATUS_LABEL: Record<string, string> = {
-  draft: "草稿",
-  sent: "已發送",
-  partially_received: "部分到貨",
-  fully_received: "全部到貨",
-  closed: "已結案",
-  cancelled: "已取消",
-};
+const STATUS_LABEL = poStatusLabel;
 
 export default function EditPurchaseOrderPage() {
   return (
@@ -100,7 +94,7 @@ function PageContent() {
           .eq("po_id", id)
           .order("id"),
       ]);
-      if (poErr || !poData) throw new Error(poErr?.message ?? "找不到採購訂單");
+      if (poErr || !poData) throw new Error(poErr?.message ?? `找不到${PO_TERM_ZH}`);
       if (itemErr) throw new Error(itemErr.message);
       setHeader(poData as POHeader);
 
@@ -185,21 +179,21 @@ function PageContent() {
   if (!id) {
     return (
       <div className="p-6 text-sm text-zinc-500">
-        缺少 id 參數。請從 <Link href="/purchase/orders" className="text-blue-600 underline">採購訂單列表</Link> 進入。
+        缺少 id 參數。請從 <Link href="/purchase/orders" className="text-blue-600 underline">{PO_TERM_ZH}列表</Link> 進入。
       </div>
     );
   }
   if (loading) return <div className="p-6 text-sm text-zinc-500">載入中…</div>;
-  if (!header) return <div className="p-6 text-sm text-red-600">{error ?? "找不到採購訂單"}</div>;
+  if (!header) return <div className="p-6 text-sm text-red-600">{error ?? `找不到${PO_TERM_ZH}`}</div>;
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-xl font-semibold">
-            採購訂單 {header.po_no}
+            {PO_TERM_ZH} {header.po_no}
             <span className="ml-3 inline-block rounded bg-zinc-100 px-2 py-0.5 text-xs font-normal dark:bg-zinc-800">
-              {STATUS_LABEL[header.status] ?? header.status}
+              {STATUS_LABEL(header.status)}
             </span>
           </h1>
           <p className="text-sm text-zinc-500">
@@ -256,7 +250,7 @@ function PageContent() {
                 </div>
               )}
               {!editable && !canSend && (
-                <p className="text-xs text-zinc-500">此採購訂單已 {STATUS_LABEL[header.status]}。</p>
+                <p className="text-xs text-zinc-500">此{PO_TERM_ZH}已 {STATUS_LABEL(header.status)}。</p>
               )}
             </div>
           </section>

--- a/apps/admin/src/app/(protected)/purchase/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/page.tsx
@@ -6,6 +6,8 @@ import { getSupabase } from "@/lib/supabase";
 import { SendPOModal } from "@/components/SendPOModal";
 import SpinButton from "@/components/SpinButton";
 import { RowAction } from "@/components/RowAction";
+import { PO_STATUS_LABEL, PO_TERM_ZH, type POStatus } from "@/lib/poStatus";
+import { PR_TERM_ZH } from "@/lib/prStatus";
 
 type Supplier = {
   id: number;
@@ -31,14 +33,6 @@ type SendCtx = {
   total: number;
 };
 
-type POStatus =
-  | "draft"
-  | "sent"
-  | "partially_received"
-  | "fully_received"
-  | "closed"
-  | "cancelled";
-
 type PO = {
   id: number;
   po_no: string;
@@ -59,14 +53,7 @@ type PO = {
 
 type StatusTab = "all" | POStatus;
 
-const STATUS_LABEL: Record<POStatus, string> = {
-  draft: "草稿",
-  sent: "已發送",
-  partially_received: "部分到貨",
-  fully_received: "全部到貨",
-  closed: "已結案",
-  cancelled: "已取消",
-};
+const STATUS_LABEL = PO_STATUS_LABEL;
 
 const STATUS_BADGE: Record<POStatus, string> = {
   draft: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
@@ -367,7 +354,7 @@ export default function PurchaseOrdersListPage() {
       if (groupBy === "pr") {
         if (p.pr_id) {
           key = `pr-${p.pr_id}`;
-          label = `採購單 ${p.pr_no ?? `#${p.pr_id}`}`;
+          label = `${PR_TERM_ZH} ${p.pr_no ?? `#${p.pr_id}`}`;
         } else {
           key = "manual";
           label = "手動建立 / 無來源 PR";
@@ -490,7 +477,7 @@ export default function PurchaseOrdersListPage() {
     <div className="flex flex-1 flex-col gap-4 p-6">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="text-xl font-semibold">採購訂單（PO）</h1>
+          <h1 className="text-xl font-semibold">{PO_TERM_ZH}（PO）</h1>
           <p className="text-sm text-zinc-500">
             {pos === null ? "載入中…" : `共 ${pos.length} 張 PO`}
           </p>
@@ -499,7 +486,7 @@ export default function PurchaseOrdersListPage() {
           href="/purchase/requests"
           className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
         >
-          ← 採購單
+          ← {PR_TERM_ZH}
         </Link>
       </header>
 
@@ -613,7 +600,7 @@ export default function PurchaseOrdersListPage() {
             className="rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-900"
           >
             <option value="none">不分組</option>
-            <option value="pr">依採購單</option>
+            <option value="pr">依{PR_TERM_ZH}</option>
             <option value="supplier">依供應商</option>
           </select>
         </label>
@@ -692,7 +679,7 @@ export default function PurchaseOrdersListPage() {
             ) : pageRows.length === 0 ? (
               <tr>
                 <td colSpan={11} className="p-6 text-center text-zinc-500">
-                  {filtersActive ? "沒有符合條件的 PO" : "尚無採購訂單"}
+                  {filtersActive ? "沒有符合條件的 PO" : `尚無${PO_TERM_ZH}`}
                 </td>
               </tr>
             ) : grouped ? (

--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -6,6 +6,8 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { PrPipelineStepper, type PrStepEvents, type POSummary, type TransferSummary } from "@/components/PrPipelineStepper";
 import SpinButton from "@/components/SpinButton";
+import { prStatusLabel, prReviewLabel, PR_TERM_ZH } from "@/lib/prStatus";
+import { PO_TERM_ZH } from "@/lib/poStatus";
 
 type PRHeader = {
   id: number;
@@ -57,19 +59,8 @@ type ItemRow = {
   dirty: boolean;
 };
 
-const REVIEW_LABEL: Record<string, string> = {
-  approved: "已通過",
-  pending_review: "待審核",
-  rejected: "已退回",
-};
-
-const STATUS_LABEL: Record<string, string> = {
-  draft: "草稿",
-  submitted: "已送審",
-  partially_ordered: "部分轉單",
-  fully_ordered: "全部轉單",
-  cancelled: "已取消",
-};
+const STATUS_LABEL = prStatusLabel;
+const REVIEW_LABEL = prReviewLabel;
 
 export default function EditPurchaseRequestPage() {
   return (
@@ -138,7 +129,7 @@ function PageContent() {
         ]);
 
         if (cancelled) return;
-        if (prErr || !prData) throw new Error(prErr?.message ?? "找不到採購單");
+        if (prErr || !prData) throw new Error(prErr?.message ?? `找不到${PR_TERM_ZH}`);
         if (itemErr) throw new Error(itemErr.message);
 
         setHeader(prData as PRHeader);
@@ -527,7 +518,7 @@ function PageContent() {
       !confirm(
         `要把 ${missingCampaigns.length} 個同日結單但未納入的團（${missingCampaigns
           .map((c) => c.campaign_no)
-          .join(", ")}）併入本採購單嗎？`,
+          .join(", ")}）併入本${PR_TERM_ZH}嗎？`,
       )
     )
       return;
@@ -559,7 +550,7 @@ function PageContent() {
       setError(`有 ${unassignedCount} 行未指派供應商，無法拆 PO`);
       return;
     }
-    if (!confirm("確定建立採購訂單？建立後可逐一發給各供應商。")) return;
+    if (!confirm(`確定建立${PO_TERM_ZH}？建立後可逐一發給各供應商。`)) return;
     setBusy("split");
     setError(null);
     try {
@@ -571,7 +562,7 @@ function PageContent() {
         p_operator: userData.user?.id,
       });
       if (rpcErr) throw new Error(rpcErr.message);
-      alert(`已產生 ${(poIds as number[]).length} 張採購訂單`);
+      alert(`已產生 ${(poIds as number[]).length} 張${PO_TERM_ZH}`);
       router.push("/purchase/orders");
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -583,22 +574,22 @@ function PageContent() {
   if (!id) {
     return (
       <div className="p-6 text-sm text-zinc-500">
-        缺少 id 參數。請從 <Link href="/purchase/requests" className="text-blue-600 underline">採購單列表</Link> 進入。
+        缺少 id 參數。請從 <Link href="/purchase/requests" className="text-blue-600 underline">{PR_TERM_ZH}列表</Link> 進入。
       </div>
     );
   }
 
   if (loading) return <div className="p-6 text-sm text-zinc-500">載入中…</div>;
-  if (!header) return <div className="p-6 text-sm text-red-600">{error ?? "找不到採購單"}</div>;
+  if (!header) return <div className="p-6 text-sm text-red-600">{error ?? `找不到${PR_TERM_ZH}`}</div>;
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-xl font-semibold">
-            採購單 {header.pr_no}
+            {PR_TERM_ZH} {header.pr_no}
             <span className="ml-3 inline-block rounded bg-zinc-100 px-2 py-0.5 text-xs font-normal dark:bg-zinc-800">
-              {STATUS_LABEL[header.status] ?? header.status}
+              {STATUS_LABEL(header.status)}
             </span>
             <span
               className={`ml-2 inline-block rounded px-2 py-0.5 text-xs font-normal ${
@@ -609,7 +600,7 @@ function PageContent() {
                     : "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
               }`}
             >
-              {REVIEW_LABEL[header.review_status] ?? header.review_status}
+              {REVIEW_LABEL(header.review_status)}
             </span>
           </h1>
           <p className="text-sm text-zinc-500">
@@ -704,7 +695,7 @@ function PageContent() {
                   className="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50"
                   title={unassignedCount > 0 ? "有未指派供應商" : ""}
                 >
-                  {busy === "split" ? "建立中…" : "📦 建立採購訂單"}
+                  {busy === "split" ? "建立中…" : `📦 建立${PO_TERM_ZH}`}
                 </SpinButton>
               )}
               {canReopen && (
@@ -718,7 +709,7 @@ function PageContent() {
                 </SpinButton>
               )}
               {!editable && !canSplit && !canReopen && (
-                <p className="text-xs text-zinc-500">此採購單已 {STATUS_LABEL[header.status]}，無可用動作。</p>
+                <p className="text-xs text-zinc-500">此{PR_TERM_ZH}已 {STATUS_LABEL(header.status)}，無可用動作。</p>
               )}
             </div>
           </section>

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -6,16 +6,17 @@ import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import { RowAction } from "@/components/RowAction";
+import {
+  PR_STATUS_LABEL,
+  PR_REVIEW_LABEL,
+  PR_TERM_ZH,
+  type PRStatus,
+  type PRReviewStatus,
+} from "@/lib/prStatus";
 
 const PAGE_SIZE = 20;
 
-type PRStatus =
-  | "draft"
-  | "submitted"
-  | "partially_ordered"
-  | "fully_ordered"
-  | "cancelled";
-type ReviewStatus = "pending_review" | "approved" | "rejected";
+type ReviewStatus = PRReviewStatus;
 type SourceType = "close_date" | "campaign" | "manual";
 
 type Row = {
@@ -59,19 +60,8 @@ type ClosedCampaignRow = {
 
 type StatusTab = "all" | PRStatus;
 
-const STATUS_LABEL: Record<PRStatus, string> = {
-  draft: "草稿",
-  submitted: "已送審",
-  partially_ordered: "部分轉單",
-  fully_ordered: "全部轉單",
-  cancelled: "已取消",
-};
-
-const REVIEW_LABEL: Record<ReviewStatus, string> = {
-  approved: "已通過",
-  pending_review: "待審核",
-  rejected: "已退回",
-};
+const STATUS_LABEL = PR_STATUS_LABEL;
+const REVIEW_LABEL = PR_REVIEW_LABEL;
 
 const SOURCE_LABEL: Record<SourceType, string> = {
   close_date: "結單日帶入",
@@ -672,7 +662,7 @@ export default function PurchaseRequestsListPage() {
     <div className="flex flex-1 flex-col gap-4 p-6">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="text-xl font-semibold">採購單（PR）</h1>
+          <h1 className="text-xl font-semibold">{PR_TERM_ZH}（PR）</h1>
           <p className="text-sm text-zinc-500">
             {rows === null ? "載入中…" : `共 ${rows.length} 筆`}
           </p>
@@ -690,7 +680,7 @@ export default function PurchaseRequestsListPage() {
             disabled={creatingBlank}
             className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
           >
-            {creatingBlank ? "建立中…" : "+ 空白採購單"}
+            {creatingBlank ? "建立中…" : `+ 空白${PR_TERM_ZH}`}
           </SpinButton>
         </div>
       </header>
@@ -939,7 +929,7 @@ export default function PurchaseRequestsListPage() {
             ) : pageRows.length === 0 ? (
               <tr>
                 <td colSpan={10} className="p-6 text-center text-zinc-500">
-                  {filtersActive ? "沒有符合條件的採購單" : "尚無採購單"}
+                  {filtersActive ? `沒有符合條件的${PR_TERM_ZH}` : `尚無${PR_TERM_ZH}`}
                 </td>
               </tr>
             ) : grouped ? (
@@ -1041,7 +1031,7 @@ export default function PurchaseRequestsListPage() {
           >
             <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
               <div>
-                <h3 className="text-base font-semibold">針對團購建採購單</h3>
+                <h3 className="text-base font-semibold">針對團購建{PR_TERM_ZH}</h3>
                 <p className="mt-0.5 text-xs text-zinc-500">
                   可多選、同團購可重複開單（補單）
                 </p>
@@ -1120,7 +1110,7 @@ export default function PurchaseRequestsListPage() {
                                   onClick={(e) => e.stopPropagation()}
                                   className="ml-2 text-amber-600 hover:underline dark:text-amber-400"
                                 >
-                                  · 已有採購單 #{c.existing_pr_id}（補單會新建）
+                                  · 已有{PR_TERM_ZH} #{c.existing_pr_id}（補單會新建）
                                 </Link>
                               )}
                             </div>
@@ -1155,7 +1145,7 @@ export default function PurchaseRequestsListPage() {
                   >
                     {creatingMulti
                       ? "建立中…"
-                      : `📋 建立採購單（${selectedCampaignIds.size}）`}
+                      : `📋 建立${PR_TERM_ZH}（${selectedCampaignIds.size}）`}
                   </SpinButton>
                 </div>
               </div>

--- a/apps/admin/src/app/(protected)/purchase/requests/print/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/print/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import { PR_TERM_ZH } from "@/lib/prStatus";
 
 type PRHeader = {
   id: number;
@@ -93,7 +94,7 @@ function PageContent() {
         ]);
 
         if (cancelled) return;
-        if (prErr || !prData) throw new Error(prErr?.message ?? "找不到採購單");
+        if (prErr || !prData) throw new Error(prErr?.message ?? `找不到${PR_TERM_ZH}`);
         if (itemErr) throw new Error(itemErr.message);
 
         setHeader(prData as PRHeader);
@@ -248,7 +249,7 @@ function PageContent() {
 
       <header className="mb-4 text-center">
         <h1 className="text-2xl font-bold">
-          {warehouseName || "總倉"} - 內部採購單
+          {warehouseName || "總倉"} - 內部{PR_TERM_ZH}
         </h1>
         <div className="mt-1 text-sm text-zinc-600">
           單號 {header.pr_no}　·　結單日 {header.source_close_date ?? "—"}

--- a/apps/admin/src/app/(protected)/restock/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/inbox/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import { PR_TERM_ZH } from "@/lib/prStatus";
 
 type Status = "pending" | "approved_transfer" | "approved_pr" | "shipped" | "received" | "rejected" | "cancelled";
 
@@ -115,7 +116,7 @@ export default function RestockInboxPage() {
   }
 
   async function approveToPr(id: number) {
-    if (!confirm("確定下訂單？此動作會獨立建立一張新的採購單。")) return;
+    if (!confirm(`確定下訂單？此動作會獨立建立一張新的${PR_TERM_ZH}。`)) return;
     setBusy(id);
     try {
       const { error: err } = await getSupabase().rpc("rpc_approve_restock_to_pr", { p_request_id: id });
@@ -239,7 +240,7 @@ export default function RestockInboxPage() {
                     <div className="flex flex-col gap-1 text-xs">
                       {r.linked_pr_id && (
                         <Link href={`/purchase/requests/edit?id=${r.linked_pr_id}`} className="font-mono text-blue-600 hover:underline dark:text-blue-400">
-                          → {r.linked_pr_no ?? `採購單 #${r.linked_pr_id}`}
+                          → {r.linked_pr_no ?? `${PR_TERM_ZH} #${r.linked_pr_id}`}
                         </Link>
                       )}
                       {r.linked_transfer_id && (

--- a/apps/admin/src/app/(protected)/wms/receiving/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/receiving/page.tsx
@@ -10,6 +10,7 @@ import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import { Modal } from "@/components/Modal";
 import { POReceiptTimeline } from "@/components/POReceiptTimeline";
+import { PO_TERM_ZH } from "@/lib/poStatus";
 
 type POStatus = "draft" | "sent" | "partially_received" | "fully_received" | "cancelled";
 
@@ -198,7 +199,7 @@ export default function ReceivingWorkbenchPage() {
           href="/purchase/orders"
           className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
         >
-          採購訂單列表 →
+          {PO_TERM_ZH}列表 →
         </Link>
       </header>
 
@@ -336,7 +337,7 @@ export default function ReceivingWorkbenchPage() {
       <Modal
         open={detailPoId !== null}
         onClose={() => setDetailPoId(null)}
-        title={`採購單到貨進度 ${detailPoNo}`}
+        title={`${PO_TERM_ZH}到貨進度 ${detailPoNo}`}
         maxWidth="max-w-4xl"
       >
         {detailPoId !== null && <POReceiptTimeline poId={detailPoId} />}

--- a/apps/admin/src/components/CampaignForm.tsx
+++ b/apps/admin/src/components/CampaignForm.tsx
@@ -5,9 +5,9 @@ import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import { useRole, isAdmin } from "@/lib/role";
+import { CAMPAIGN_STATUS_LABEL, type CampaignStatus } from "@/lib/campaignStatus";
 
-export type CampaignStatus =
-  | "draft" | "open" | "closed" | "ordered" | "receiving" | "ready" | "completed" | "cancelled";
+export type { CampaignStatus };
 export type CloseType = "regular" | "fast" | "limited";
 
 export type CampaignFormValues = {
@@ -48,13 +48,8 @@ const STATUS_OPT: { v: CampaignStatus; label: string }[] = [
   { v: "closed", label: "已收單" },
 ];
 
-const DOWNSTREAM_LABEL: Record<string, string> = {
-  ordered: "已下訂",
-  receiving: "到貨中",
-  ready: "可取貨",
-  completed: "已完成",
-  cancelled: "已取消",
-};
+// 下游(系統推進)狀態的中文 label — 復用共用字典
+const DOWNSTREAM_LABEL = CAMPAIGN_STATUS_LABEL;
 
 export function CampaignForm({
   initial,

--- a/apps/admin/src/components/PrPipelineStepper.tsx
+++ b/apps/admin/src/components/PrPipelineStepper.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { PO_TERM_ZH } from "@/lib/poStatus";
 
 type StepState = "done" | "current" | "pending" | "rejected" | "skipped";
 
@@ -80,14 +81,14 @@ export function PrPipelineStepper({
   else if (isCancelled) steps.push({ key: "review", label: "審核完成", state: "skipped" });
   else steps.push({ key: "review", label: "審核通過", state: "done" });
 
-  // S5 建立採購訂單
+  // S5 建立採購單
   if (status === "fully_ordered")
-    steps.push({ key: "split", label: "建立採購訂單", state: "done" });
+    steps.push({ key: "split", label: `建立${PO_TERM_ZH}`, state: "done" });
   else if (status === "partially_ordered")
     steps.push({ key: "split", label: "部分建立", state: "current" });
   else if (isRejected || isCancelled)
-    steps.push({ key: "split", label: "建立採購訂單", state: "skipped" });
-  else steps.push({ key: "split", label: "建立採購訂單", state: "pending" });
+    steps.push({ key: "split", label: `建立${PO_TERM_ZH}`, state: "skipped" });
+  else steps.push({ key: "split", label: `建立${PO_TERM_ZH}`, state: "pending" });
 
   // S6 發送供應商
   if (isRejected || isCancelled)

--- a/apps/admin/src/components/ProductCampaignsPanel.tsx
+++ b/apps/admin/src/components/ProductCampaignsPanel.tsx
@@ -3,10 +3,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
-
-type CampaignStatus =
-  | "draft" | "open" | "closed" | "ordered"
-  | "receiving" | "ready" | "completed" | "cancelled";
+import {
+  CAMPAIGN_STATUS_LABEL,
+  CAMPAIGN_STATUS_BADGE,
+  type CampaignStatus,
+} from "@/lib/campaignStatus";
 
 type CampaignRow = {
   id: number;
@@ -17,21 +18,8 @@ type CampaignRow = {
   end_at: string | null;
 };
 
-const STATUS_LABEL: Record<CampaignStatus, string> = {
-  draft: "草稿", open: "開團中", closed: "已收單", ordered: "已下訂",
-  receiving: "到貨中", ready: "可取貨", completed: "已完成", cancelled: "已取消",
-};
-
-const STATUS_BADGE: Record<CampaignStatus, string> = {
-  draft: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
-  open: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
-  closed: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
-  ordered: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
-  receiving: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
-  ready: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
-  completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
-  cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
-};
+const STATUS_LABEL = CAMPAIGN_STATUS_LABEL;
+const STATUS_BADGE = CAMPAIGN_STATUS_BADGE;
 
 function fmtDate(s: string | null) {
   return s ? new Date(s).toLocaleDateString("zh-TW") : "—";

--- a/apps/admin/src/components/RestockDetailModal.tsx
+++ b/apps/admin/src/components/RestockDetailModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Modal } from "@/components/Modal";
 import { getSupabase } from "@/lib/supabase";
+import { PR_TERM_ZH } from "@/lib/prStatus";
 
 type RestockRow = {
   id: number;
@@ -180,7 +181,7 @@ export default function RestockDetailModal({
             )}
             {hd.linked_pr_id != null && (
               <div className="col-span-2">
-                <dt className="text-xs text-zinc-500">採購單</dt>
+                <dt className="text-xs text-zinc-500">{PR_TERM_ZH}</dt>
                 <dd className="text-sm">
                   <Link
                     href={`/purchase/requests/edit?id=${hd.linked_pr_id}`}

--- a/apps/admin/src/components/SendPOModal.tsx
+++ b/apps/admin/src/components/SendPOModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Modal } from "@/components/Modal";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import { PO_TERM_ZH } from "@/lib/poStatus";
 
 type Supplier = {
   id: number;
@@ -55,7 +56,7 @@ export function SendPOModal({
   const lineText = useMemo(() => {
     if (!supplier) return "";
     const lines: string[] = [];
-    lines.push(`【採購單 ${poNo}】`);
+    lines.push(`【${PO_TERM_ZH} ${poNo}】`);
     lines.push(`供應商：${supplier.name}`);
     lines.push(`下單日：${new Date().toLocaleDateString("zh-TW")}`);
     lines.push("");
@@ -71,7 +72,7 @@ export function SendPOModal({
 
   const mailtoHref = useMemo(() => {
     if (!supplier?.email) return null;
-    const subject = encodeURIComponent(`採購單 ${poNo} - ${supplier.name}`);
+    const subject = encodeURIComponent(`${PO_TERM_ZH} ${poNo} - ${supplier.name}`);
     const body = encodeURIComponent(lineText);
     return `mailto:${supplier.email}?subject=${subject}&body=${body}`;
   }, [supplier, poNo, lineText]);
@@ -109,7 +110,7 @@ export function SendPOModal({
   }
 
   return (
-    <Modal open={open} onClose={onClose} title={`發送採購訂單 ${poNo}`} maxWidth="max-w-3xl">
+    <Modal open={open} onClose={onClose} title={`發送${PO_TERM_ZH} ${poNo}`} maxWidth="max-w-3xl">
       {!supplier ? (
         <div className="text-sm text-zinc-500">載入中…</div>
       ) : (

--- a/apps/admin/src/lib/campaignStatus.ts
+++ b/apps/admin/src/lib/campaignStatus.ts
@@ -1,0 +1,71 @@
+// ============================================================
+// 開團 (group_buy_campaigns.status) 中央定義
+//
+// Single source of truth — 所有 admin 端 status 中文 label / badge
+// 都從這裡 import。新增 status 時：
+//   1. 加到 CAMPAIGN_STATUSES tuple
+//   2. 加到 CAMPAIGN_STATUS_LABEL
+//   3. 加到 CAMPAIGN_STATUS_BADGE
+//   4. 同步 supabase migration 的 CHECK constraint
+//
+// 狀態語意（簡述，完整流程見 docs）：
+//   draft     - 草稿，App 不顯示
+//   open      - 開團中，App 顯示，顧客可下單
+//   closed    - 已收單，App 隱藏，HQ/店家仍可補加單/改 qty
+//   locked    - 已鎖定，請購單已建，所有訂單自動 confirmed，不可加單/改 qty
+//   ordered   - 已下訂，採購單已發給供應商（目前無 RPC 自動推進）
+//   receiving - 到貨中（目前無 RPC 自動推進）
+//   ready     - 可取貨（目前無 RPC 自動推進）
+//   completed - 已完成（rpc_finalize_campaign）
+//   cancelled - 已取消，任何階段都可手動取消
+// ============================================================
+
+export const CAMPAIGN_STATUSES = [
+  "draft",
+  "open",
+  "closed",
+  "locked",
+  "ordered",
+  "receiving",
+  "ready",
+  "completed",
+  "cancelled",
+] as const;
+
+export type CampaignStatus = (typeof CAMPAIGN_STATUSES)[number];
+
+export const CAMPAIGN_STATUS_LABEL: Record<CampaignStatus, string> = {
+  draft:     "草稿",
+  open:      "開團中",
+  closed:    "已收單",
+  locked:    "已鎖定",
+  ordered:   "已下訂",
+  receiving: "到貨中",
+  ready:     "可取貨",
+  completed: "已完成",
+  cancelled: "已取消",
+};
+
+export const CAMPAIGN_STATUS_BADGE: Record<CampaignStatus, string> = {
+  draft:     "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+  open:      "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
+  closed:    "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  locked:    "bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-300",
+  ordered:   "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  receiving: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
+  ready:     "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+  completed: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
+  cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+};
+
+/** 取中文 label；未知 status 直接 fallback 原字串。 */
+export function campaignStatusLabel(s: string | null | undefined): string {
+  if (!s) return "—";
+  return CAMPAIGN_STATUS_LABEL[s as CampaignStatus] ?? s;
+}
+
+/** 取 badge className；未知 status 用 zinc fallback。 */
+export function campaignStatusBadge(s: string | null | undefined): string {
+  if (!s) return CAMPAIGN_STATUS_BADGE.draft;
+  return CAMPAIGN_STATUS_BADGE[s as CampaignStatus] ?? CAMPAIGN_STATUS_BADGE.draft;
+}

--- a/apps/admin/src/lib/poStatus.ts
+++ b/apps/admin/src/lib/poStatus.ts
@@ -1,0 +1,42 @@
+// ============================================================
+// 採購單 (purchase_orders.status) 中央定義
+//
+// Single source of truth — 所有 admin 端 status 中文 label
+// 都從這裡 import。新增 status 時：
+//   1. 加到 PO_STATUSES tuple
+//   2. 加到 PO_STATUS_LABEL
+//   3. 同步 supabase migration 的 CHECK constraint
+//
+// 命名術語：
+//   PO = Purchase Order   = 採購單（對供應商正式下訂）
+//   PR = Purchase Request = 請購單（內部需求單，見 prStatus.ts）
+// ============================================================
+
+export const PO_STATUSES = [
+  "draft",
+  "sent",
+  "partially_received",
+  "fully_received",
+  "closed",
+  "cancelled",
+] as const;
+
+export type POStatus = (typeof PO_STATUSES)[number];
+
+export const PO_STATUS_LABEL: Record<POStatus, string> = {
+  draft:              "草稿",
+  sent:               "已發送",
+  partially_received: "部分到貨",
+  fully_received:     "全部到貨",
+  closed:             "已結案",
+  cancelled:          "已取消",
+};
+
+/** 取中文 label；未知 status 直接 fallback 原字串。 */
+export function poStatusLabel(s: string | null | undefined): string {
+  if (!s) return "—";
+  return PO_STATUS_LABEL[s as POStatus] ?? s;
+}
+
+/** 顯示用的單據名稱（中文）。 */
+export const PO_TERM_ZH = "採購單";

--- a/apps/admin/src/lib/prStatus.ts
+++ b/apps/admin/src/lib/prStatus.ts
@@ -1,0 +1,59 @@
+// ============================================================
+// 請購單 (purchase_requests.status / review_status) 中央定義
+//
+// Single source of truth — 所有 admin 端 status 中文 label
+// 都從這裡 import。新增 status 時：
+//   1. 加到 PR_STATUSES tuple
+//   2. 加到 PR_STATUS_LABEL
+//   3. 同步 supabase migration 的 CHECK constraint
+//
+// 命名術語：
+//   PR = Purchase Request = 請購單（內部需求單）
+//   PO = Purchase Order   = 採購單（對供應商正式下訂，見 poStatus.ts）
+// ============================================================
+
+export const PR_STATUSES = [
+  "draft",
+  "submitted",
+  "partially_ordered",
+  "fully_ordered",
+  "cancelled",
+] as const;
+
+export type PRStatus = (typeof PR_STATUSES)[number];
+
+export const PR_STATUS_LABEL: Record<PRStatus, string> = {
+  draft:             "草稿",
+  submitted:         "已送審",
+  partially_ordered: "部分轉單",
+  fully_ordered:     "全部轉單",
+  cancelled:         "已取消",
+};
+
+export const PR_REVIEW_STATUSES = [
+  "pending_review",
+  "approved",
+  "rejected",
+] as const;
+
+export type PRReviewStatus = (typeof PR_REVIEW_STATUSES)[number];
+
+export const PR_REVIEW_LABEL: Record<PRReviewStatus, string> = {
+  pending_review: "待審核",
+  approved:       "已通過",
+  rejected:       "已退回",
+};
+
+/** 取中文 label；未知 status 直接 fallback 原字串。 */
+export function prStatusLabel(s: string | null | undefined): string {
+  if (!s) return "—";
+  return PR_STATUS_LABEL[s as PRStatus] ?? s;
+}
+
+export function prReviewLabel(s: string | null | undefined): string {
+  if (!s) return "—";
+  return PR_REVIEW_LABEL[s as PRReviewStatus] ?? s;
+}
+
+/** 顯示用的單據名稱（中文）。 */
+export const PR_TERM_ZH = "請購單";

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -1,6 +1,8 @@
 // Map known Postgres RAISE EXCEPTION messages → Chinese.
 // Add patterns as more surface in production.
 
+import { campaignStatusLabel } from "@/lib/campaignStatus";
+
 type Rule = { pattern: RegExp; render: (m: RegExpMatchArray) => string };
 
 const TRANSFER_STATUS_ZH: Record<string, string> = {
@@ -13,17 +15,7 @@ const TRANSFER_STATUS_ZH: Record<string, string> = {
 };
 const tStatus = (s: string) => TRANSFER_STATUS_ZH[s] ?? s;
 
-const CAMPAIGN_STATUS_ZH: Record<string, string> = {
-  draft: "草稿",
-  open: "開團中",
-  closed: "已收單",
-  ordered: "已下訂",
-  receiving: "到貨中",
-  ready: "可取貨",
-  completed: "已完成",
-  cancelled: "已取消",
-};
-const cStatus = (s: string) => CAMPAIGN_STATUS_ZH[s] ?? s;
+const cStatus = campaignStatusLabel;
 
 const RULES: Rule[] = [
   {

--- a/docs/PRD-WMS-倉儲管理工作台.md
+++ b/docs/PRD-WMS-倉儲管理工作台.md
@@ -241,7 +241,7 @@ WHERE shortage_qty > 0
    訂單 / 取貨 / 會員 / 互助交流板
 
 📦 進銷存
-   採購單 / 採購訂單 / 補貨申請 / 補貨申請(HQ)
+   請購單 / 採購單 / 補貨申請 / 補貨申請(HQ)
 
 🏬 倉儲(WMS)
    📥 進貨待辦       /wms/receiving       (新)
@@ -384,7 +384,7 @@ E. 退貨回總倉     Store → HQ    return      (待設計:可能透過 free 
 ## 12. Out of scope (本文件不負責)
 
 - 庫存準確性、移動平均成本、盤點 — 見 [[PRD-庫存模組]]
-- 採購單(PR/PO)的撰寫流程 — 見 [[PRD-採購模組]]
+- 請購單 / 採購單(PR/PO)的撰寫流程 — 見 [[PRD-採購模組]]
 - 客戶取貨流程(LIFF / 分店端取貨)— 見 [[PRD-訂單取貨模組]]
 - 補貨申請(restock_requests)流程 — 見 [[PRD-訂單取貨模組-v0.2-addendum]]
 - 互助訂單(aid_transfer)— 見 [[PRD-訂單取貨模組-v0.2-addendum]]

--- a/docs/TEST-campaign-to-purchase.md
+++ b/docs/TEST-campaign-to-purchase.md
@@ -1,9 +1,9 @@
-# campaign-to-purchase 測試項目 — 結單日 → 內部採購單 → 拆 PO 全流程
+# campaign-to-purchase 測試項目 — 結單日 → 內部請購單 → 拆 PO 全流程
 
 **對應 migration:** `supabase/migrations/20260428120000_campaign_to_purchase.sql`（待建）
 **對應 UI 變更:**
 - `apps/admin/src/app/(protected)/campaigns/page.tsx`（結單按鈕）
-- `apps/admin/src/app/(protected)/purchase/requests/new/page.tsx`（新建：採購單工作底稿、含「帶入該日商品」按鈕）
+- `apps/admin/src/app/(protected)/purchase/requests/new/page.tsx`（新建：請購單工作底稿、含「帶入該日商品」按鈕）
 - `apps/admin/src/app/(protected)/purchase/requests/page.tsx`（新建：PR 列表）
 - `apps/admin/src/app/(protected)/purchase/orders/page.tsx`（新建：PO 列表）
 - `apps/admin/src/components/PurchaseOrderEdit.tsx`（新建）

--- a/docs/TEST-inventory-overview.md
+++ b/docs/TEST-inventory-overview.md
@@ -63,7 +63,7 @@
 
 ### 3.1 頁面載入
 - [ ] `/inventory` 路由可開、無 console error
-- [ ] 側欄「進銷存」群組出現「庫存總覽」入口（採購單 / 採購訂單之後）、點擊導到 `/inventory`、active 高亮正確
+- [ ] 側欄「進銷存」群組出現「庫存總覽」入口（請購單 / 採購單之後）、點擊導到 `/inventory`、active 高亮正確
 - [ ] 表格渲染欄位：商品/SKU、倉別、在庫(on_hand)、保留(reserved)、在途(in_transit_in)、可用、均成本、最後異動
 - [ ] 載入中顯示 LoadingRow；無資料顯示 EmptyRow（非空白破版）
 

--- a/docs/TEST-pr-manual-creation.md
+++ b/docs/TEST-pr-manual-creation.md
@@ -80,13 +80,13 @@
 ## 4. 列表頁 UI（`/purchase/requests`）
 
 ### 4.1 兩顆建單按鈕
-- [ ] 右上角顯示「+ 空白採購單」「+ 針對團購建單」兩顆按鈕
-- [ ] 「+ 空白採購單」點擊 → 直接呼叫 `rpc_create_pr_blank` → 跳 `/purchase/requests/edit?id=N`
+- [ ] 右上角顯示「+ 空白請購單」「+ 針對團購建單」兩顆按鈕
+- [ ] 「+ 空白請購單」點擊 → 直接呼叫 `rpc_create_pr_blank` → 跳 `/purchase/requests/edit?id=N`
 - [ ] 「+ 針對團購建單」點擊 → 開 modal 選 closed campaign
 
 ### 4.2 Campaign 選擇 modal
 - [ ] modal 顯示：過去 60 天 closed campaign 列表
-- [ ] 已有未取消 campaign PR 的 campaign → 禁用 + 顯示「已有採購單」
+- [ ] 已有未取消 campaign PR 的 campaign → 禁用 + 顯示「已有請購單」
 - [ ] 已有同日 close_date PR 的 campaign → 不禁用（共存允許）+ 顯示「同日已有結單日 PR」提示
 - [ ] 選一個 → 呼叫 `rpc_create_pr_from_campaign` → 跳 edit page
 

--- a/supabase/migrations/20260623000000_campaign_status_locked.sql
+++ b/supabase/migrations/20260623000000_campaign_status_locked.sql
@@ -1,0 +1,291 @@
+-- ============================================================
+-- 開團新增 `locked` 狀態 + 連帶調整
+--
+-- 變更背景:
+--   原本 closed 同時代表「App 不顯示」+「不能加單 + 可開 PR」。
+--   實務上門市結團後仍需要補加單窗口,因此語意拆分:
+--     closed = App 不顯示,HQ/店家仍可補加單、改 qty
+--     locked = 請購單已建,需求鎖定,不可加單/改 qty
+--   locked 由 Stage 4 的 PR RPC 自動推進,不開放手動切。
+--
+-- 本 migration 內容:
+--   1. CHECK constraint 加入 'locked'
+--   2. RLS policy gbc_store_read 白名單加 'locked'
+--   3. rpc_finalize_campaign 接受從 'locked' 結案
+--   4. rpc_orders_pivot 的 closed-only filter 加 'locked'
+--   5. v_po_demand_by_store view 的 JOIN clause 加 'locked'
+--   6. 順手修 rpc_advance_order_status 從未設 confirmed_at 的 bug
+--
+-- 故意不動的:
+--   - rpc_bulk_set_campaign_status:維持只允許 draft/open/closed/cancelled
+--   - rpc_pr_from_campaigns:守衛保留,locked campaign 被拒(不能重複建 PR)
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. CHECK constraint 擴充
+-- ----------------------------------------------------------------
+ALTER TABLE group_buy_campaigns
+  DROP CONSTRAINT group_buy_campaigns_status_check;
+
+ALTER TABLE group_buy_campaigns
+  ADD CONSTRAINT group_buy_campaigns_status_check
+  CHECK (status IN (
+    'draft','open','closed',
+    'locked',
+    'ordered','receiving','ready','completed','cancelled'
+  ));
+
+COMMENT ON COLUMN group_buy_campaigns.status IS
+  'draft → open → closed → locked → ordered → receiving → ready → completed; '
+  'closed = App 不顯示,HQ/店家仍可補加單/改 qty; '
+  'locked = 請購單已建,所有訂單自動 confirmed,不可加單/改 qty; '
+  'ordered 以後 = 採購進行中(目前無 RPC 自動推進)';
+
+-- ----------------------------------------------------------------
+-- 2. RLS policy gbc_store_read 加 'locked'(店家可看到自家鎖定中的團)
+-- ----------------------------------------------------------------
+DROP POLICY IF EXISTS gbc_store_read ON group_buy_campaigns;
+
+CREATE POLICY gbc_store_read ON group_buy_campaigns
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND status IN ('open','closed','locked','ordered','receiving','ready','completed')
+  );
+
+-- ----------------------------------------------------------------
+-- 3. rpc_finalize_campaign:可結案的狀態集加 'locked'
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_finalize_campaign(
+  p_campaign_id BIGINT,
+  p_operator    UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_status      TEXT;
+  v_open_orders INTEGER;
+BEGIN
+  SELECT status INTO v_status
+    FROM group_buy_campaigns
+   WHERE id = p_campaign_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'campaign % not found', p_campaign_id;
+  END IF;
+
+  IF v_status NOT IN ('closed','locked','ordered','receiving','ready') THEN
+    RAISE EXCEPTION 'campaign % not in finalizable status (current: %)', p_campaign_id, v_status;
+  END IF;
+
+  -- 守衛:仍有未結案的顧客訂單
+  SELECT COUNT(*) INTO v_open_orders
+    FROM customer_orders
+   WHERE campaign_id = p_campaign_id
+     AND status NOT IN ('completed','expired','cancelled');
+
+  IF v_open_orders > 0 THEN
+    RAISE EXCEPTION 'campaign % has % unfinished customer orders', p_campaign_id, v_open_orders;
+  END IF;
+
+  UPDATE group_buy_campaigns
+     SET status = 'completed',
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_campaign_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_finalize_campaign IS
+  '整單結算:所有顧客訂單結案後 campaign 轉 completed(可從 closed/locked/ordered/receiving/ready 進入)';
+
+-- ----------------------------------------------------------------
+-- 4. rpc_orders_pivot:closed-only filter 加 'locked'
+--    (locked campaign 也屬於「post-收單」階段)
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION rpc_orders_pivot(
+  p_view_by      text,
+  p_date_from    date,
+  p_date_to      date,
+  p_campaign_ids bigint[],
+  p_store_id     bigint,
+  p_statuses     text[],
+  p_closed_only  boolean DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH filtered AS (
+    SELECT o.*
+    FROM customer_orders o
+    LEFT JOIN group_buy_campaigns c ON c.id = o.campaign_id
+    WHERE o.status = ANY(p_statuses)
+      AND (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      AND (
+        p_closed_only IS NULL
+        OR (p_closed_only IS TRUE
+            AND c.status IN ('closed','locked','ordered','receiving','ready','completed'))
+        OR (p_closed_only IS FALSE
+            AND c.status NOT IN ('closed','locked','ordered','receiving','ready','completed'))
+      )
+      AND CASE p_view_by
+        WHEN 'pickup_date' THEN
+          (p_date_from IS NULL OR o.pickup_deadline >= p_date_from)
+          AND (p_date_to IS NULL OR o.pickup_deadline <  p_date_to)
+        WHEN 'order_date' THEN
+          (p_date_from IS NULL OR o.created_at >= p_date_from::timestamptz)
+          AND (p_date_to IS NULL OR o.created_at <  p_date_to::timestamptz)
+        WHEN 'campaign' THEN
+          c.end_at IS NULL
+          OR (
+            (p_date_from IS NULL OR c.end_at >= p_date_from::timestamptz)
+            AND (p_date_to IS NULL OR c.end_at <  p_date_to::timestamptz)
+          )
+        ELSE TRUE
+      END
+  ),
+  base AS (
+    SELECT
+      CASE p_view_by
+        WHEN 'campaign'    THEN 'c' || f.campaign_id::text
+        WHEN 'pickup_date' THEN 'd' || to_char(COALESCE(f.pickup_deadline, f.created_at::date), 'YYYY-MM-DD')
+        WHEN 'order_date'  THEN 'd' || to_char(f.created_at::date, 'YYYY-MM-DD')
+      END                                              AS group_key,
+      CASE WHEN p_view_by = 'campaign' THEN f.campaign_id ELSE NULL::bigint END
+                                                       AS group_id,
+      i.sku_id,
+      s.product_name                                   AS sku_product_name,
+      s.variant_name                                   AS sku_variant_name,
+      f.pickup_store_id,
+      f.id                                             AS order_id,
+      f.status,
+      i.qty,
+      i.unit_price
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    LEFT JOIN skus s ON s.id = i.sku_id
+  ),
+  agg AS (
+    SELECT
+      b.group_key,
+      b.group_id,
+      b.sku_id,
+      b.sku_product_name,
+      b.sku_variant_name,
+      b.pickup_store_id,
+      SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+               THEN 0 ELSE b.qty END)::numeric                            AS qty_sum,
+      SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+               THEN 0 ELSE b.qty * b.unit_price END)::numeric             AS amount,
+      SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+               THEN b.qty ELSE 0 END)::numeric                            AS neg_qty_sum,
+      SUM(CASE WHEN b.status IN ('cancelled','expired','transferred_out')
+               THEN b.qty * b.unit_price ELSE 0 END)::numeric             AS neg_amount,
+      COALESCE(
+        ARRAY_AGG(DISTINCT b.order_id)
+          FILTER (WHERE b.status NOT IN ('cancelled','expired','transferred_out')),
+        '{}'::bigint[]
+      )                                                                   AS pos_order_ids,
+      COALESCE(
+        ARRAY_AGG(DISTINCT b.order_id)
+          FILTER (WHERE b.status IN ('cancelled','expired','transferred_out')),
+        '{}'::bigint[]
+      )                                                                   AS neg_order_ids
+    FROM base b
+    GROUP BY
+      b.group_key,
+      b.group_id,
+      b.sku_id,
+      b.sku_product_name,
+      b.sku_variant_name,
+      b.pickup_store_id
+  )
+  SELECT COALESCE(jsonb_agg(to_jsonb(agg.*)), '[]'::jsonb)
+  FROM agg;
+$$;
+
+-- ----------------------------------------------------------------
+-- 5. v_po_demand_by_store view:JOIN clause 加 'locked'
+--    (locked campaign 的訂單仍需被分配揀貨)
+-- ----------------------------------------------------------------
+CREATE OR REPLACE VIEW v_po_demand_by_store AS
+SELECT
+  po.id              AS po_id,
+  po.tenant_id,
+  poi.id             AS po_item_id,
+  poi.sku_id,
+  pr.source_close_date AS close_date,
+  co.pickup_store_id AS store_id,
+  s.code             AS store_code,
+  s.name             AS store_name,
+  SUM(coi.qty)       AS demand_qty
+FROM purchase_orders po
+JOIN purchase_order_items poi ON poi.po_id = po.id
+JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+JOIN purchase_requests pr ON pr.id = pri.pr_id AND pr.source_close_date IS NOT NULL
+JOIN group_buy_campaigns gbc
+  ON gbc.tenant_id = po.tenant_id
+ AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = pr.source_close_date
+ AND gbc.status IN ('closed','locked','ordered','receiving','ready','completed')
+JOIN customer_orders co ON co.campaign_id = gbc.id AND co.status NOT IN ('cancelled','expired')
+JOIN customer_order_items coi ON coi.order_id = co.id
+                              AND coi.sku_id = poi.sku_id
+                              AND coi.status NOT IN ('cancelled','expired')
+JOIN stores s ON s.id = co.pickup_store_id
+GROUP BY po.id, po.tenant_id, poi.id, poi.sku_id, pr.source_close_date,
+         co.pickup_store_id, s.code, s.name;
+
+COMMENT ON VIEW v_po_demand_by_store IS
+  '從 PO 反查同 close_date 各分店對該 PO SKU 的訂單需求量(撿貨分配參考);涵蓋 closed/locked/ordered/receiving/ready/completed 開團';
+
+-- ----------------------------------------------------------------
+-- 6. 順手修 rpc_advance_order_status:補 confirmed_at 設值
+--    歷史 bug — schema 有 confirmed_at 欄位但 RPC 從未設值
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION rpc_advance_order_status(
+  p_order_id   BIGINT,
+  p_new_status TEXT,
+  p_operator   UUID
+) RETURNS customer_orders
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig customer_orders%ROWTYPE;
+  v_ok   BOOLEAN := FALSE;
+BEGIN
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+
+  -- 驗合法 forward 轉移
+  v_ok := (v_orig.status = 'pending'   AND p_new_status = 'confirmed')
+       OR (v_orig.status = 'confirmed' AND p_new_status = 'shipping')
+       OR (v_orig.status = 'shipping'  AND p_new_status = 'ready')
+       OR (v_orig.status = 'ready'     AND p_new_status = 'completed');
+  IF NOT v_ok THEN
+    RAISE EXCEPTION 'invalid status transition: % → %', v_orig.status, p_new_status;
+  END IF;
+
+  UPDATE customer_orders
+     SET status = p_new_status,
+         updated_by = p_operator,
+         updated_at = NOW(),
+         confirmed_at = CASE
+           WHEN p_new_status = 'confirmed' AND confirmed_at IS NULL THEN NOW()
+           ELSE confirmed_at
+         END
+   WHERE id = p_order_id
+   RETURNING * INTO v_orig;
+
+  RETURN v_orig;
+END;
+$$;
+
+COMMENT ON FUNCTION rpc_advance_order_status IS
+  '訂單狀態 forward 推進(pending→confirmed→shipping→ready→completed),bypass RLS、驗合法轉移;'
+  '推進到 confirmed 會補 confirmed_at(若為 NULL)';


### PR DESCRIPTION
## Summary

四階段訂單流程改造的前兩階段。Stage 3 (店家可改待確認訂單 qty) 與 Stage 4 (PR 建立時自動鎖團 + auto-confirm) 之後另行 PR。

### Stage 1 — PR/PO 正名 (`3c74da9`)

UI 原本把 `purchase_requests` 稱「採購單」、`purchase_orders` 稱「採購訂單」,與台灣 ERP 標準術語相反。本次正名讓中文回到正確位置:

- `purchase_requests` → **請購單** (PR)
- `purchase_orders` → **採購單** (PO)

新增兩個共用 lib 集中定義:
- `apps/admin/src/lib/prStatus.ts` — 請購單 status / label / `PR_TERM_ZH`
- `apps/admin/src/lib/poStatus.ts` — 採購單 status / label / `PO_TERM_ZH`

13 個 admin UI 檔案 + 4 個 docs 同步正名。DB schema / 欄位 / URL / 識別字維持英文不變。

### Stage 2 — 開團新增 `locked` 狀態 (`5130d68`)

`closed` 原本同時代表「App 不顯示」+「不可加單/開 PR」,語意過載。本次拆分:
- **`closed`** = App 不顯示,HQ/店家仍可補加單、改 qty (緩衝期)
- **`locked`** = 請購單已建,需求鎖定,不可加單/改 qty (🆕 新增)

`locked` 由 Stage 4 的 PR RPC 自動推進,故意不開放手動切。

**Schema 變更** (`supabase/migrations/20260623000000_campaign_status_locked.sql`):
- `group_buy_campaigns.status` CHECK constraint 加入 `'locked'`
- RLS policy `gbc_store_read` 白名單加 `'locked'`(防店家盲區)
- `rpc_finalize_campaign` 允許從 `locked` 結案
- `rpc_orders_pivot` closed-only filter 加 `'locked'`
- `v_po_demand_by_store` JOIN 加 `'locked'`(揀貨需含 locked 訂單)
- 順手修 `rpc_advance_order_status` 從未設 `confirmed_at` 的歷史 bug

**前端**:
- 新增 `apps/admin/src/lib/campaignStatus.ts` 中央定義
- 4 處內聯 status 定義 (`campaigns/page.tsx`、`ProductCampaignsPanel.tsx`、`CampaignForm.tsx`、`pivot/page.tsx`) 改 import 共用檔
- `rpcError.ts` 內 `CAMPAIGN_STATUS_ZH` 改用共用 helper

## Test plan

### Stage 1
- [ ] 各頁面標題、按鈕、modal、錯誤訊息中文一致
- [ ] `grep -rn "採購訂單" apps/admin/src` 應為空
- [ ] 殘留的「採購單」字串全部都指 PO context(`po_no` / `purchase_orders`)

### Stage 2
- [ ] `npx tsc --noEmit` ✅(已驗)
- [ ] Migration 在開發環境跑成功
- [ ] `INSERT INTO group_buy_campaigns (..., status='locked', ...)` 可成功
- [ ] 店家 JWT SELECT 看得到 `status='locked'` 的自家 campaign(RLS)
- [ ] `rpc_finalize_campaign` 可從 `locked` 結案
- [ ] `rpc_bulk_set_campaign_status(..., 'locked')` 應被擋(維持手動不能設)
- [ ] `rpc_create_pr_from_campaigns` 對 locked campaign 應被擋(不能重複建 PR)
- [ ] `rpc_advance_order_status` 推到 confirmed 會補 `confirmed_at`
- [ ] `/campaigns` 頁 filter dropdown 出現「已鎖定」、badge 顯示 rose 色

## 未在本 PR 的後續工作

- Stage 3:店家可改待確認訂單 qty
- Stage 4:PR 建立時自動鎖團 + auto-confirm 訂單

https://claude.ai/code/session_01WrdgKG1YQdo7ysXmVtMhYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrdgKG1YQdo7ysXmVtMhYJ)_