### PR TITLE
Allow shop staff to edit pending order item quantities

### DIFF
--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -76,6 +76,7 @@ function applyOrderDiscount(subtotal: number, d: DiscountValue): { deduction: nu
 }
 
 type ItemDraft = {
+  qty?: number;
   unit_price?: number;
   notes?: string | null;
   discount?: DiscountValue;
@@ -154,6 +155,9 @@ export function OrderDetail({
     if (head?.store?.name && Array.isArray(userStores) && userStores.includes(head.store.name)) return true;
     return false;
   }, [role, userStores, head?.store?.name]);
+
+  // qty 只有 pending 訂單可改;一旦被 PR 鎖定變 confirmed 就唯讀
+  const canEditQty = canEdit && head?.status === "pending";
 
   useEffect(() => {
     let cancelled = false;
@@ -286,10 +290,17 @@ export function OrderDetail({
           if (error) errors.push(`整單折扣$：${translateRpcError(error)}`);
         }
       }
-      // 商品 (unit_price / notes / discount)
+      // 商品 (qty / unit_price / notes / discount)
       for (const [itemId, d] of draft.items) {
         const it = items.find((x) => x.id === itemId);
         if (!it) continue;
+        if (d.qty !== undefined && Number(d.qty) !== Number(it.qty)) {
+          const { error } = await sb.rpc("rpc_update_order_item_qty", {
+            p_order_id: head.id, p_item_id: itemId,
+            p_new_qty: Number(d.qty), p_operator: operator, p_reason: reason,
+          });
+          if (error) errors.push(`#${itemId} 數量：${translateRpcError(error)}`);
+        }
         if (d.unit_price !== undefined && Number(d.unit_price) !== Number(it.unit_price)) {
           const { error } = await sb.rpc("rpc_update_order_item_price", {
             p_order_id: head.id, p_item_id: itemId,
@@ -659,7 +670,17 @@ export function OrderDetail({
                         </span>
                       ) : "—"}
                     </td>
-                    <td className="px-3 py-2 text-right font-mono">{Number(it.qty)}</td>
+                    <td className="px-3 py-2 text-right font-mono">
+                      {canEditQty ? (
+                        <EditableNumber
+                          value={Number(it.qty)}
+                          min={1}
+                          onSave={async (v) => setItemDraft(it.id, { qty: v })}
+                        />
+                      ) : (
+                        Number(it.qty)
+                      )}
+                    </td>
                     <td className="px-3 py-2 text-right font-mono">
                       <EditableNumber
                         value={Number(eff.unit_price)}

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -2,6 +2,7 @@
 // Add patterns as more surface in production.
 
 import { campaignStatusLabel } from "@/lib/campaignStatus";
+import { orderStatusLabel } from "@/lib/orderStatus";
 
 type Rule = { pattern: RegExp; render: (m: RegExpMatchArray) => string };
 
@@ -16,6 +17,7 @@ const TRANSFER_STATUS_ZH: Record<string, string> = {
 const tStatus = (s: string) => TRANSFER_STATUS_ZH[s] ?? s;
 
 const cStatus = campaignStatusLabel;
+const oStatus = orderStatusLabel;
 
 const RULES: Rule[] = [
   {
@@ -43,6 +45,20 @@ const RULES: Rule[] = [
   },
   { pattern: /Outbound quantity must be positive/i, render: () => "出庫數量必須大於 0" },
   { pattern: /Inbound quantity must be positive/i, render: () => "入庫數量必須大於 0" },
+  {
+    pattern: /^qty must be > 0$/i,
+    render: () => "數量必須大於 0（如需刪除品項請聯絡總部）",
+  },
+  {
+    pattern: /campaign \d+ is (\w+); only open\/closed campaigns accept manual entry/i,
+    render: (m) =>
+      `此團狀態為「${cStatus(m[1])}」，僅「開團中」或「已收單」可以加單。`,
+  },
+  {
+    pattern: /訂單狀態為\s+(\w+)[,，]?\s*僅\s*待確認\s*訂單可改數量/,
+    render: (m) =>
+      `訂單狀態為「${oStatus(m[1])}」，僅「待確認」訂單可改數量。`,
+  },
   {
     pattern: /store\s+(\d+)\s+has no location_id(?:\s+mapped)?/i,
     render: (m) =>

--- a/docs/TEST-orders-qty-edit.md
+++ b/docs/TEST-orders-qty-edit.md
@@ -1,0 +1,157 @@
+# 訂單 qty 編輯 測試項目
+
+**對應 migration:** `supabase/migrations/20260624000000_order_item_qty_edit.sql`
+
+**對應 UI:**
+- `apps/admin/src/components/OrderDetail.tsx`(qty cell 改為 inline editable + saveAllDraft 新增 qty 分支)
+- `apps/admin/src/lib/rpcError.ts`(新增 qty / campaign closed 的中文翻譯)
+
+**對應 PRD:** `docs/PRD-訂單取貨模組.md`(待確認訂單可改數量)
+
+---
+
+## 1. 設計重點
+
+1. **店家可改自家 pending 訂單 qty** — 沿用 `_check_order_edit_perm` helper(HQ 全部 / 店家限自家 pickup_store_id)
+2. **加單緩衝期** — `rpc_create_customer_orders` 從 `status='open'` 放寬為 `status IN ('open','closed')`,讓 closed 階段(App 已隱藏)HQ/店家仍可補加單
+3. **PR 鎖定後不能再改** — 訂單 status 變 confirmed 後 RPC 直接擋(Stage 4 PR RPC 自動推進到 confirmed)
+4. **qty > 0** — 配合 schema `CHECK (qty > 0)`,刪品項不在本 scope
+5. **稽核** — 寫 `customer_order_audit_log`,no-op 不寫
+
+---
+
+## 2. RPC 行為(SQL 直測複核語意)
+
+### 2.1 rpc_create_customer_orders 放寬閘
+
+**前置:** 一個 closed 狀態的 campaign,有對應 channel + member
+
+**情境 A:** 加單到 closed campaign
+- 直接呼叫 `rpc_create_customer_orders(campaign_id, channel_id, [{...}])`
+- **預期:** 成功,訂單 status='pending' 建立
+
+**情境 B:** 加單到 locked campaign
+- **預期:** RAISE `campaign X is locked; only open/closed campaigns accept manual entry`
+- UI 翻譯顯示「此團狀態為「已鎖定」,僅「開團中」或「已收單」可以加單。」
+
+**情境 C:** 加單到 cancelled / draft campaign
+- **預期:** 同上 RAISE
+
+### 2.2 rpc_update_order_item_qty 主流程
+
+**前置:** 一張 pending 訂單,品項 qty=3
+
+#### Case 2.2.1: HQ 改自家訂單
+- HQ user(role IN owner/admin/hq_manager/role NULL)
+- Call `rpc_update_order_item_qty(order_id, item_id, 5, op, '客人加碼')`
+- **預期:**
+  - 成功,回傳 row.qty=5
+  - `customer_order_items.qty` 變 5
+  - `customer_order_audit_log` 多一筆:`entity_type='item', field='qty', before_value=3, after_value=5, edit_reason='客人加碼'`
+
+#### Case 2.2.2: 店家改自家(同 pickup_store_id)
+- 店家 user(role NOT IN HQ tier,但 jwt.store_id 等於 order.pickup_store_id)
+- **預期:** 同上,成功
+
+#### Case 2.2.3: 店家改他店
+- 店家 user,jwt.store_id ≠ order.pickup_store_id
+- **預期:** RAISE `permission denied: role=store_manager store=X cannot edit order Y`
+
+#### Case 2.2.4: 訂單已 confirmed
+- 訂單 status='confirmed'(或任何非 pending)
+- **預期:** RAISE `訂單狀態為 confirmed,僅 待確認 訂單可改數量`
+- UI 翻譯顯示「訂單狀態為「已確認」,僅「待確認」訂單可改數量。」
+
+#### Case 2.2.5: qty=0 或負數
+- p_new_qty=0(或 -1)
+- **預期:** RAISE `qty must be > 0`
+- UI 翻譯顯示「數量必須大於 0(如需刪除品項請聯絡總部)」
+
+#### Case 2.2.6: qty=null
+- p_new_qty=null
+- **預期:** 同 2.2.5
+
+#### Case 2.2.7: item 不屬於 order
+- p_item_id 屬於別張訂單
+- **預期:** RAISE `item X not in order Y`
+
+#### Case 2.2.8: no-op(舊值=新值)
+- 訂單 qty=3,p_new_qty=3
+- **預期:** 成功(不報錯),回傳 row,但 `customer_order_audit_log` **不寫新紀錄**
+
+#### Case 2.2.9: 跨 tenant
+- order_id 屬於 tenant A,JWT 是 tenant B
+- **預期:** RAISE `order X not found in tenant Y`
+
+---
+
+## 3. UI(`/orders/<id>` 或 hq inbox / pivot OrderDetail drawer)
+
+### 3.1 qty cell 互動
+
+#### Case 3.1.1: pending + canEdit(HQ 或店家自家)
+- 進入 OrderDetail,品項列 qty 欄位
+- **預期:** 顯示為可點擊的 inline number 編輯框
+
+#### Case 3.1.2: pending 但無權限
+- 進入 OrderDetail,head.status='pending' 但 canEdit=false(其他店店家)
+- **預期:** qty 顯示為純文字,不可編輯
+
+#### Case 3.1.3: 非 pending(confirmed/shipping/ready/...)
+- **預期:** qty 顯示為純文字,不可編輯(因為 `canEditQty = canEdit && head.status === "pending"`)
+
+### 3.2 編輯流程
+
+#### Case 3.2.1: 改 qty + 存檔
+- pending 訂單,點 qty 5→7,離開焦點
+- 編輯區出現黃色 dirty 提示
+- 按「儲存」
+- **預期:**
+  - 成功 alert 或無錯誤
+  - 列表 qty 變 7
+  - 小計重算
+  - audit log 多一筆
+
+#### Case 3.2.2: 改 qty=0 或負
+- 輸入 0,按存檔
+- **預期:** 跳錯「數量必須大於 0(如需刪除品項請聯絡總部)」
+
+#### Case 3.2.3: 同時改 qty + 單價(同一品項)
+- pending 訂單,改 qty 3→5 + 改單價 100→90
+- 按存檔
+- **預期:** 兩支 RPC 各被呼叫一次,audit log 兩筆(qty + unit_price)
+
+#### Case 3.2.4: 改 qty 在 confirmed 訂單
+- 在已 confirmed 訂單,qty cell **不應該顯示為可編輯**(canEditQty=false)
+- 若繞過 UI 直接呼叫 RPC → 跳「訂單狀態為「已確認」,僅「待確認」訂單可改數量。」
+
+### 3.3 加單緩衝期(closed 階段)
+
+#### Case 3.3.1: closed campaign 走加單頁
+- campaign.status='closed'(已結團,App 隱藏)
+- 進入 `/campaigns/order-entry?id=<closed_campaign>`
+- 加單流程能完成
+- **預期:** 訂單成功建立,status='pending'
+
+---
+
+## 4. 與其他流程的相依性
+
+| 上游 | 行為 |
+|------|------|
+| `_check_order_edit_perm` | 沿用,跟其他 edit RPC 用同一個 helper(`20260605000002:10-48`) |
+| Stage 2 `confirmed_at` 修復 | 不直接相關,但完成後手動 confirm 也會寫 confirmed_at |
+| Stage 4 PR 自動 confirm | 完成後 pending→confirmed,本 RPC 直接擋,符合預期 |
+
+| 下游 | 行為 |
+|------|------|
+| `OrderAuditDrawer` | 自動顯示新 `field='qty'` 的稽核紀錄(不需改) |
+| `customer_orders.updated_at` | 由 trigger `trg_touch_corders` 自動更新 |
+
+---
+
+## 5. 回歸風險
+
+- 既有 rpc_update_order_item_price / notes / discount **不受影響**(共用 helper,獨立 update column)
+- 既有 rpc_create_customer_orders **行為微變**:closed 階段也可加單,但顧客 LIFF 不會看到 closed 團,所以對顧客流程無感
+- 沒有 schema 變動(只 CREATE OR REPLACE 既有函式 + 新增一支)

--- a/supabase/migrations/20260624000000_order_item_qty_edit.sql
+++ b/supabase/migrations/20260624000000_order_item_qty_edit.sql
@@ -1,0 +1,220 @@
+-- ============================================================
+-- Stage 3 — 店家可改待確認訂單數量
+--
+-- 1. 放寬 rpc_create_customer_orders:從 status='open' 放寬為 IN ('open','closed')
+--    讓 HQ/店家在 closed 緩衝期可補加單(顧客 App 已隱藏不會撞到)
+-- 2. 新增 rpc_update_order_item_qty:店家可改自家 pending 訂單 qty
+--    沿用 _check_order_edit_perm + customer_order_audit_log pattern
+--    (對齊 20260605000002_rpc_edit_order_price_and_notes.sql)
+--
+-- 設計:
+--   - 訂單狀態必須是 pending(被 PR 鎖定變 confirmed 後就擋下,Stage 4 自動觸發)
+--   - qty > 0(配合 schema CHECK,刪品項另走 RPC,不在本 scope)
+--   - no-op(新值=舊值)不寫 audit log
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. 放寬加單閘:rpc_create_customer_orders status='open' → IN ('open','closed')
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_customer_orders(
+  p_campaign_id BIGINT,
+  p_channel_id  BIGINT,
+  p_rows        JSONB
+) RETURNS TABLE (out_order_id BIGINT, out_order_no TEXT, out_item_count INT)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant       UUID := public._current_tenant_id();
+  v_user         UUID := auth.uid();
+  v_status       TEXT;
+  v_campaign_no  TEXT;
+  v_row          JSONB;
+  v_item         JSONB;
+  v_member_id    BIGINT;
+  v_pickup_store BIGINT;
+  v_nickname     TEXT;
+  v_order_id     BIGINT;
+  v_order_no     TEXT;
+  v_seq          INT;
+  v_ci_id        BIGINT;
+  v_ci_price     NUMERIC;
+  v_qty          NUMERIC;
+  v_ci_sku       BIGINT;
+  v_existing_qty NUMERIC;
+  v_count        INT;
+BEGIN
+  SELECT status, campaign_no INTO v_status, v_campaign_no
+    FROM group_buy_campaigns WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  IF v_status IS NULL THEN RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id; END IF;
+  -- 放寬:open(顧客可下單)+ closed(已隱藏但 HQ/店家補單緩衝期)
+  IF v_status NOT IN ('open','closed') THEN
+    RAISE EXCEPTION 'campaign % is %; only open/closed campaigns accept manual entry',
+                    p_campaign_id, v_status;
+  END IF;
+
+  PERFORM 1 FROM line_channels WHERE id = p_channel_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'channel % not in tenant', p_channel_id; END IF;
+
+  IF p_rows IS NULL OR jsonb_array_length(p_rows) = 0 THEN
+    RAISE EXCEPTION 'p_rows is empty';
+  END IF;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_rows)
+  LOOP
+    v_member_id    := (v_row ->> 'member_id')::BIGINT;
+    v_pickup_store := (v_row ->> 'pickup_store_id')::BIGINT;
+    v_nickname     := v_row ->> 'nickname';
+
+    IF v_member_id IS NULL THEN RAISE EXCEPTION 'member_id required'; END IF;
+    IF v_pickup_store IS NULL THEN RAISE EXCEPTION 'pickup_store_id required'; END IF;
+
+    PERFORM 1 FROM members WHERE id = v_member_id AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'member % not in tenant', v_member_id; END IF;
+    PERFORM 1 FROM stores WHERE id = v_pickup_store AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'store % not in tenant', v_pickup_store; END IF;
+
+    SELECT id INTO v_order_id FROM customer_orders
+     WHERE tenant_id = v_tenant
+       AND campaign_id = p_campaign_id
+       AND channel_id  = p_channel_id
+       AND member_id   = v_member_id;
+
+    IF v_order_id IS NULL THEN
+      SELECT COUNT(*) + 1 INTO v_seq FROM customer_orders
+       WHERE tenant_id = v_tenant AND campaign_id = p_campaign_id;
+      v_order_no := v_campaign_no || '-' || lpad(v_seq::text, 4, '0');
+
+      INSERT INTO customer_orders (
+        tenant_id, order_no, campaign_id, channel_id, member_id,
+        nickname_snapshot, pickup_store_id, status, created_by, updated_by
+      ) VALUES (
+        v_tenant, v_order_no, p_campaign_id, p_channel_id, v_member_id,
+        v_nickname, v_pickup_store, 'pending', v_user, v_user
+      ) RETURNING id INTO v_order_id;
+    ELSE
+      UPDATE customer_orders SET
+        nickname_snapshot = COALESCE(v_nickname, nickname_snapshot),
+        pickup_store_id   = v_pickup_store,
+        updated_by        = v_user
+      WHERE id = v_order_id
+      RETURNING order_no INTO v_order_no;
+    END IF;
+
+    FOR v_item IN SELECT * FROM jsonb_array_elements(v_row -> 'items')
+    LOOP
+      v_ci_id := (v_item ->> 'campaign_item_id')::BIGINT;
+      v_qty   := (v_item ->> 'qty')::NUMERIC;
+      IF v_qty IS NULL OR v_qty <= 0 THEN RAISE EXCEPTION 'qty must be > 0'; END IF;
+
+      SELECT unit_price, sku_id INTO v_ci_price, v_ci_sku
+        FROM campaign_items
+       WHERE id = v_ci_id AND tenant_id = v_tenant AND campaign_id = p_campaign_id;
+      IF v_ci_price IS NULL THEN
+        RAISE EXCEPTION 'campaign_item % not in campaign %', v_ci_id, p_campaign_id;
+      END IF;
+
+      SELECT coi.qty INTO v_existing_qty FROM customer_order_items coi
+       WHERE coi.order_id = v_order_id AND coi.campaign_item_id = v_ci_id;
+
+      IF v_existing_qty IS NULL THEN
+        INSERT INTO customer_order_items (
+          tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+          status, source, created_by, updated_by
+        ) VALUES (
+          v_tenant, v_order_id, v_ci_id, v_ci_sku, v_qty, v_ci_price,
+          'pending', 'manual', v_user, v_user
+        );
+      ELSE
+        UPDATE customer_order_items coi SET
+          qty        = v_existing_qty + v_qty,
+          updated_by = v_user
+        WHERE coi.order_id = v_order_id AND coi.campaign_item_id = v_ci_id;
+      END IF;
+    END LOOP;
+
+    SELECT COUNT(*) INTO v_count FROM customer_order_items coi WHERE coi.order_id = v_order_id;
+    out_order_id   := v_order_id;
+    out_order_no   := v_order_no;
+    out_item_count := v_count;
+    RETURN NEXT;
+  END LOOP;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_create_customer_orders IS
+  '小幫手代客 key 訂單。campaign 必須 status IN (open, closed);'
+  'closed 是 HQ/店家補加單緩衝期(顧客 App 已隱藏不會撞到)。'
+  '合併規則:同 (campaign, channel, member) → UPSERT,items 累加同 campaign_item_id';
+
+-- ----------------------------------------------------------------
+-- 2. rpc_update_order_item_qty:店家可改自家 pending 訂單 qty
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_update_order_item_qty(
+  p_order_id BIGINT,
+  p_item_id  BIGINT,
+  p_new_qty  NUMERIC,
+  p_operator UUID,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS customer_order_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order customer_orders%ROWTYPE;
+  v_old   NUMERIC;
+  v_row   customer_order_items;
+BEGIN
+  -- 1. 權限檢查(沿用 helper:HQ 全部 / 店家限自家 pickup_store_id)
+  v_order := _check_order_edit_perm(p_order_id);
+
+  -- 2. 訂單狀態閘:僅 pending(被 PR 鎖定變 confirmed 後就擋下)
+  IF v_order.status <> 'pending' THEN
+    RAISE EXCEPTION '訂單狀態為 %,僅 待確認 訂單可改數量', v_order.status;
+  END IF;
+
+  -- 3. 輸入驗證(配合 schema CHECK qty > 0,刪品項另走 RPC)
+  IF p_new_qty IS NULL OR p_new_qty <= 0 THEN
+    RAISE EXCEPTION 'qty must be > 0';
+  END IF;
+
+  SELECT qty INTO v_old
+    FROM customer_order_items
+   WHERE id = p_item_id AND order_id = p_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'item % not in order %', p_item_id, p_order_id;
+  END IF;
+
+  -- 4. no-op 短路
+  IF v_old = p_new_qty THEN
+    SELECT * INTO v_row FROM customer_order_items WHERE id = p_item_id;
+    RETURN v_row;
+  END IF;
+
+  UPDATE customer_order_items
+     SET qty        = p_new_qty,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_item_id
+   RETURNING * INTO v_row;
+
+  -- 5. 稽核
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'item', p_item_id, 'qty',
+     to_jsonb(v_old), to_jsonb(p_new_qty), p_reason, p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_update_order_item_qty(BIGINT, BIGINT, NUMERIC, UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_update_order_item_qty IS
+  '店家可改自家 pending 訂單品項 qty。'
+  'HQ 全部 / 店家限自家 pickup_store_id;訂單狀態必須是 pending;qty 必須 > 0;'
+  '寫 customer_order_audit_log,no-op 不寫';


### PR DESCRIPTION
## Summary
Implements Stage 3 of the order management feature, enabling shop staff to modify item quantities in pending orders. Also relaxes the order creation gate to allow manual entry during the "closed" campaign phase (HQ/shop buffer period after customer app is hidden).

## Key Changes

### Backend (SQL Migration)
- **Relaxed `rpc_create_customer_orders` gate**: Changed campaign status check from `status='open'` to `status IN ('open','closed')` to allow HQ/shop staff to add orders during the closed buffer period while customer app is hidden
- **New `rpc_update_order_item_qty` RPC**: Allows shop staff to modify item quantities in pending orders
  - Reuses `_check_order_edit_perm` helper for consistent permission model (HQ can edit all orders; shop staff limited to their own pickup_store_id)
  - Enforces order status must be `pending` (blocks editing once PR locks order to `confirmed` in Stage 4)
  - Validates qty > 0 (item deletion handled separately)
  - Writes to `customer_order_audit_log` with before/after values and edit reason
  - Skips audit log for no-op changes (new value equals old value)

### Frontend (Admin UI)
- **Inline editable qty field**: Added `EditableNumber` component for qty column in OrderDetail when `canEditQty` is true
  - Only editable for pending orders where user has edit permission
  - Automatically becomes read-only once order status changes to confirmed or higher
- **Updated save flow**: Extended `saveAllDraft` to handle qty changes alongside existing price/notes/discount edits
- **Error translations**: Added Chinese error messages for:
  - `qty must be > 0` → "數量必須大於 0（如需刪除品項請聯絡總部）"
  - Campaign status validation → "此團狀態為「{status}」，僅「開團中」或「已收單」可以加單。"
  - Order status validation → "訂單狀態為「{status}」，僅「待確認」訂單可改數量。"

### Testing & Documentation
- Added comprehensive test plan (`TEST-orders-qty-edit.md`) covering:
  - RPC behavior validation (permission checks, status gates, input validation)
  - UI interaction scenarios (inline editing, concurrent field edits, state transitions)
  - Integration with existing audit and workflow systems
  - Regression risk assessment

## Implementation Details
- Follows existing patterns from `rpc_update_order_item_price` (20260605000002) for consistency
- Uses `FOR UPDATE` lock on item row to prevent concurrent modification races
- Maintains audit trail for compliance and troubleshooting
- No schema changes required; only function replacements and new RPC

https://claude.ai/code/session_01WrdgKG1YQdo7ysXmVtMhYJ