### PR TITLE
Stage 4: Auto-lock campaigns and confirm orders when PR is created

### DIFF
--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -677,6 +677,10 @@ export function OrderDetail({
                           min={1}
                           onSave={async (v) => setItemDraft(it.id, { qty: v })}
                         />
+                      ) : canEdit && head?.status === "confirmed" ? (
+                        <span title="已被請購單鎖定,如需調整請聯絡總部" className="cursor-help text-zinc-500">
+                          {Number(it.qty)} 🔒
+                        </span>
                       ) : (
                         Number(it.qty)
                       )}

--- a/docs/TEST-campaign-locked-status.md
+++ b/docs/TEST-campaign-locked-status.md
@@ -1,0 +1,173 @@
+# 開團 locked 狀態 + PR 自動鎖團 測試項目
+
+**對應 migration:**
+- `supabase/migrations/20260623000000_campaign_status_locked.sql` (Stage 2:加 locked + RLS + 3 個 RPC/view 加白名單)
+- `supabase/migrations/20260625000000_pr_create_lock_campaign_and_orders.sql` (Stage 4:PR 建立時自動鎖團 + auto-confirm)
+
+**對應 UI:** `apps/admin/src/components/OrderDetail.tsx` (confirmed 訂單 qty 顯示 🔒)
+
+**對應 PRD:** `docs/PRD-採購模組.md`(請購單建立後鎖定需求)
+
+---
+
+## 1. 設計重點
+
+1. **PR 建立瞬間連動兩件事**(原子操作):
+   - 把該 close_date 下所有 `closed` campaigns → `locked`
+   - 把那些 campaigns 下的所有 `pending` 訂單 → `confirmed`、寫稽核 `auto-confirmed by PR #N`
+2. **觸發點明確**:只有 `rpc_create_pr_from_close_date` 跟 `rpc_append_campaign_to_pr` 兩條路。`rpc_approve_restock_to_pr`(補貨單)**不**觸發,因為訂單不在 pending。
+3. **不影響 LIFF**:顧客 App 只 SELECT `status='open'`,locked / confirmed 都看不到。
+4. **店家 RLS**:Stage 2 已加 locked 進 `gbc_store_read` 白名單,locked campaign 對店家可見。
+
+---
+
+## 2. RPC 行為(SQL 直測)
+
+### 2.1 rpc_create_pr_from_close_date 主流程
+
+**前置:**
+- 一個 close_date(例 `2026-07-01`)有 2 個 `closed` campaigns
+- 各 campaign 下有 pending 訂單若干、有 cancelled 訂單若干、有 1-2 個已被 HQ 手動 confirm 的訂單
+
+#### Case 2.1.1: 基本流程
+- Call `rpc_create_pr_from_close_date('2026-07-01', '<operator>')`
+- **預期:**
+  - 回傳 v_pr_id
+  - `purchase_requests` 多一筆 (status='draft')
+  - `purchase_request_items` 多筆(per SKU 加總)
+  - `purchase_request_campaigns` join 表多 2 筆(兩個 campaign 都 link 到此 PR)
+  - **兩個 campaigns 都從 `closed` → `locked`**
+  - **所有 pending 訂單都從 `pending` → `confirmed`、`confirmed_at` 填上、`updated_by=operator`**
+  - `customer_order_audit_log` 多 N 筆(每張被推進的訂單一筆):
+    - `entity_type='order', entity_id=NULL, field='status'`
+    - `before_value='"pending"', after_value='"confirmed"'`
+    - `edit_reason='auto-confirmed by PR #<v_pr_id>'`
+    - `operator_id=<operator>`
+  - **已被 HQ 手動 confirm 的訂單跳過**(因為 helper 用 `WHERE status='pending'` 過濾)
+  - **cancelled / expired / transferred_out 訂單跳過**
+
+#### Case 2.1.2: 沒有 closed campaign
+- p_close_date 上無 closed campaign
+- **預期:** RAISE `no closed campaigns on date %`
+
+#### Case 2.1.3: 有 closed campaign 但無訂單
+- **預期:** RAISE `no orders to aggregate for close_date %`
+
+### 2.2 rpc_append_campaign_to_pr
+
+**前置:** 一張 draft PR(source_close_date='2026-07-01')、另一個同 close_date 的 closed campaign 還沒被併入
+
+#### Case 2.2.1: 追加 campaign
+- Call `rpc_append_campaign_to_pr(pr_id, append_campaign_id, '<op>')`
+- **預期:**
+  - `purchase_request_items` 對應 SKU qty 累加 / 新增
+  - `purchase_request_campaigns` 多一筆 (pr_id, append_campaign_id)
+  - **該 campaign 從 `closed` → `locked`**
+  - **該 campaign 下的 pending 訂單推進到 confirmed,寫 audit log**
+  - 已被 create_pr_from_close_date 鎖過的其他 campaign 不受影響(維持 locked)
+
+#### Case 2.2.2: 追加 locked campaign(已被另一張 PR 鎖過)
+- 該 campaign 目前 status='locked'(別張 PR 已鎖)
+- **預期:** RAISE `campaign % not in closed status (current: locked)`(維持原守衛)
+
+#### Case 2.2.3: PR 不是 draft
+- PR 已 submitted / fully_ordered
+- **預期:** RAISE `PR % is not in draft status`
+
+### 2.3 _lock_orders_after_pr_aggregation helper 直測
+
+#### Case 2.3.1: 空陣列
+- Call `_lock_orders_after_pr_aggregation('{}', '<op>', 999)`
+- **預期:** 回傳 0,無副作用
+
+#### Case 2.3.2: 跨 tenant 安全
+- p_campaign_ids 包含他 tenant 的 campaign
+- **預期:** 該 campaign 的訂單**不**被推進(WHERE tenant_id = current_tenant 過濾掉)
+
+#### Case 2.3.3: 已 confirmed 訂單跳過
+- 訂單 status='confirmed'
+- **預期:** 跳過,不重複寫 audit log
+
+---
+
+## 3. UI 行為
+
+### 3.1 開團列表 `/campaigns`
+- locked campaign 在 filter dropdown 出現「已鎖定」選項
+- Badge 顯示 rose 色「已鎖定」
+- 可結算按鈕對 locked campaign 顯示(rpc_finalize_campaign 允許從 locked)
+- 發 FB 按鈕對 locked campaign 顯示(維持業務連續性)
+- 批次操作按鈕**不**讓選 locked target(rpc_bulk_set_campaign_status 故意不擴充)
+
+### 3.2 訂單詳情 `/orders/<id>` 或 inbox drawer
+
+#### Case 3.2.1: pending + canEdit
+- qty 顯示為可編輯輸入框
+- 改完按存檔 → 成功
+
+#### Case 3.2.2: confirmed + canEdit(被 PR 鎖定後)
+- qty 顯示為 `<數字> 🔒` + hover tooltip「已被請購單鎖定,如需調整請聯絡總部」
+- 不可編輯
+
+#### Case 3.2.3: 其他終態(shipping / ready / completed / ...)
+- qty 顯示為純數字(沒 🔒,因為不是被 PR 鎖,是流程已進下游)
+
+### 3.3 加單流程
+
+#### Case 3.3.1: locked campaign 嘗試加單
+- `/campaigns/order-entry` 選 locked campaign
+- 試圖 call `rpc_create_customer_orders`
+- **預期:** RAISE `campaign % is locked; only open/closed campaigns accept manual entry`
+- UI 翻譯:「此團狀態為「已鎖定」,僅「開團中」或「已收單」可以加單。」
+
+---
+
+## 4. e2e 完整情境
+
+### 情境 A:完整流程
+1. 建一個 open campaign,放 2 筆顧客訂單(各 1 個 SKU,qty=3)
+2. `rpc_close_campaign(campaign_id, op)` → campaign 變 closed,訂單仍 pending
+3. 店家進 OrderDetail 改其中一筆 qty 從 3 → 5
+   - 看到 OrderAuditDrawer 多一筆 `field='qty', before=3, after=5`
+4. `rpc_create_pr_from_close_date(close_date, op)` → 看到:
+   - campaign 變 locked、UI 顯示 rose 色 badge
+   - 兩筆訂單 status 都變 confirmed、confirmed_at 都有時間
+   - OrderAuditDrawer 各多一筆 `field='status', reason='auto-confirmed by PR #N'`
+   - purchase_request_items 反映改後 qty(其中一個 SKU 是 5 不是 3)
+5. 嘗試再改 qty → 跳「訂單狀態為「已確認」,僅「待確認」訂單可改數量。」
+6. 嘗試對該 campaign 加單 → 跳「此團狀態為「已鎖定」,僅「開團中」或「已收單」可以加單。」
+
+### 情境 B:多 campaign 同日
+1. 建 2 個 open campaigns 同 close_date,各放 1 筆訂單
+2. 結團 campaign A → A 變 closed
+3. 結團 campaign B → B 變 closed
+4. `rpc_create_pr_from_close_date` → A 跟 B 都變 locked、所有訂單都 confirmed
+5. PR 內 SKU 是 A+B 的加總(per SKU 合併)
+
+### 情境 C:緩衝期補加單
+1. campaign 已 closed(App 已隱藏),店家發現有客人漏單
+2. 店家在 `/campaigns/order-entry` 選 closed campaign 加單成功(Stage 3 放寬閘)
+3. HQ 還沒開 PR,訂單可在 OrderDetail 改 qty
+4. HQ 開 PR → 該補的訂單也一起被推進到 confirmed
+
+### 情境 D:已先手動 confirm
+1. pending 訂單 → HQ 手動點「→ 已確認」(`rpc_advance_order_status`)→ confirmed
+2. HQ 開 PR → 該訂單**已**在 confirmed,helper 用 `WHERE status='pending'` 跳過,不重複寫 audit log
+3. PR 內仍包含該訂單的 SKU(因為 PR 彙總是看 `co.status NOT IN cancelled/expired/transferred_out`,confirmed 不被排除)
+
+### 情境 E:回歸補貨流程(不應觸發)
+1. 從 hq inbox 把 shortage 補貨單轉成 PR(`rpc_approve_restock_to_pr`)
+2. **預期:** 該 PR 建立成功,但**不**觸發 lock+auto-confirm(因為走的是 restock 路徑,訂單不在 pending)
+3. 補貨單對應的 campaigns 維持原狀,不被誤鎖
+
+---
+
+## 5. 回歸風險
+
+| 風險點 | 緩解 |
+|--------|------|
+| audit log CHECK constraint 擴充影響既有寫入 | 只是放寬,不會擋掉既有 field 值 |
+| `_lock_orders_after_pr_aggregation` 同時鎖多訂單可能 deadlock | 用 `FOR UPDATE` + 順序 id ascending(預設行為),deadlock 風險低 |
+| 一個 campaign 在 helper 跑完前 race condition 加新訂單 | helper 在 RPC 末段執行,前面已把 campaign 推到 locked,new order RPC 會被 status 閘擋下 |
+| confirmed_at 既有 NULL 訂單 | Stage 2 已修 rpc_advance_order_status;Stage 4 helper 在 INSERT 時補上,雙路徑一致 |
+| Stage 3 / Stage 4 migration 應用順序 | 20260624 → 20260625,Stage 3 寫 field='qty' 在 Stage 4 擴充 CHECK 後才實際被允許寫;production 部署兩支一起跑,中間不會有窗口期 |

--- a/supabase/migrations/20260625000000_pr_create_lock_campaign_and_orders.sql
+++ b/supabase/migrations/20260625000000_pr_create_lock_campaign_and_orders.sql
@@ -1,0 +1,382 @@
+-- ============================================================
+-- Stage 4 — 請購單建立時自動鎖團 + auto-confirm 訂單
+--
+-- 設計:
+--   PR 建立的瞬間,把所屬 closed campaigns 推進到 locked,
+--   並把那些 campaigns 下的所有 pending 訂單自動推進到 confirmed,
+--   寫 audit log 記錄 "auto-confirmed by PR #N"。
+--
+--   觸發點(兩條 PR 建立路徑):
+--     1. rpc_create_pr_from_close_date — 結單日批次建 PR
+--     2. rpc_append_campaign_to_pr — 後追加 campaign 到既有 PR
+--
+--   故意排除:
+--     - rpc_approve_restock_to_pr (補貨單 PR,訂單不在 pending)
+--     - 任何直接 INSERT INTO purchase_requests 的 ad-hoc script
+--
+-- 本 migration 內容:
+--   1. 擴充 customer_order_audit_log CHECK 加 'qty' (Stage 3 依賴) 與 'status' (本 stage)
+--   2. 新 helper _lock_orders_after_pr_aggregation
+--   3. CREATE OR REPLACE rpc_create_pr_from_close_date (尾巴加 lock 邏輯)
+--   4. CREATE OR REPLACE rpc_append_campaign_to_pr (尾巴加 lock 邏輯)
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. 擴充 customer_order_audit_log_field_check
+--    Stage 3 的 rpc_update_order_item_qty 寫 field='qty'
+--    本 stage 的 _lock_orders_after_pr_aggregation 寫 field='status'
+--    現有 CHECK 不含這兩個值,需擴充
+-- ----------------------------------------------------------------
+ALTER TABLE customer_order_audit_log DROP CONSTRAINT customer_order_audit_log_field_check;
+ALTER TABLE customer_order_audit_log
+  ADD CONSTRAINT customer_order_audit_log_field_check
+    CHECK (field IN (
+      'unit_price','item_notes','item_discount_amount','item_discount_percent',
+      'discount_amount','discount_percent','order_notes',
+      'qty',     -- Stage 3 (店家改 qty)
+      'status'   -- Stage 4 (PR auto-confirm)
+    ));
+
+-- ----------------------------------------------------------------
+-- 2. helper:_lock_orders_after_pr_aggregation
+--    把指定 campaigns 下的所有 pending 訂單推進到 confirmed,寫稽核
+--    不開放 GRANT,只給內部 RPC 用
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._lock_orders_after_pr_aggregation(
+  p_campaign_ids BIGINT[],
+  p_operator     UUID,
+  p_pr_id        BIGINT
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_count  INTEGER := 0;
+  r        RECORD;
+BEGIN
+  IF p_campaign_ids IS NULL OR array_length(p_campaign_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  FOR r IN
+    SELECT id FROM customer_orders
+     WHERE tenant_id   = v_tenant
+       AND campaign_id = ANY(p_campaign_ids)
+       AND status      = 'pending'
+     FOR UPDATE
+  LOOP
+    UPDATE customer_orders
+       SET status       = 'confirmed',
+           confirmed_at = NOW(),
+           updated_by   = p_operator,
+           updated_at   = NOW()
+     WHERE id = r.id;
+
+    INSERT INTO customer_order_audit_log
+      (tenant_id, order_id, entity_type, entity_id, field,
+       before_value, after_value, edit_reason, operator_id)
+    VALUES
+      (v_tenant, r.id, 'order', NULL, 'status',
+       to_jsonb('pending'::text), to_jsonb('confirmed'::text),
+       format('auto-confirmed by PR #%s', p_pr_id),
+       p_operator);
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN v_count;
+END;
+$$;
+
+COMMENT ON FUNCTION public._lock_orders_after_pr_aggregation IS
+  'PR 建立時自動把 campaigns 下的 pending 訂單推進到 confirmed,寫 audit log。'
+  '內部 helper,不開 GRANT;由 rpc_create_pr_from_close_date / rpc_append_campaign_to_pr 呼叫';
+
+-- ----------------------------------------------------------------
+-- 3. rpc_create_pr_from_close_date:尾巴加鎖團 + 鎖訂單
+--    完整 replace(20260614000010 版本之上加 step 5/6)
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_pr_from_close_date(p_close_date date, p_operator uuid)
+ RETURNS bigint
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_tenant         UUID := public._current_tenant_id();
+  v_pr_id          BIGINT;
+  v_pr_no          TEXT;
+  v_dest_loc       BIGINT;
+  v_campaign_count INTEGER;
+  v_demand_count   INTEGER;
+  v_campaign_ids   BIGINT[];
+BEGIN
+  SELECT COUNT(*) INTO v_campaign_count
+    FROM group_buy_campaigns
+   WHERE tenant_id = v_tenant
+     AND status = 'closed'
+     AND DATE(end_at AT TIME ZONE 'Asia/Taipei') = p_close_date;
+
+  IF v_campaign_count = 0 THEN
+    RAISE EXCEPTION 'no closed campaigns on date %', p_close_date;
+  END IF;
+
+  SELECT COUNT(*) INTO v_demand_count
+    FROM group_buy_campaigns gbc
+    JOIN customer_orders co ON co.campaign_id = gbc.id
+    JOIN customer_order_items coi ON coi.order_id = co.id
+   WHERE gbc.tenant_id = v_tenant
+     AND gbc.status = 'closed'
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = p_close_date
+     AND co.status NOT IN ('cancelled','expired','transferred_out')
+     AND coi.status NOT IN ('cancelled','expired');
+
+  IF v_demand_count = 0 THEN
+    RAISE EXCEPTION 'no orders to aggregate for close_date %', p_close_date;
+  END IF;
+
+  SELECT id INTO v_dest_loc FROM locations
+   WHERE tenant_id = v_tenant
+   ORDER BY id LIMIT 1;
+
+  IF v_dest_loc IS NULL THEN
+    RAISE EXCEPTION 'no locations defined for tenant %', v_tenant;
+  END IF;
+
+  v_pr_no := public.rpc_next_pr_no();
+
+  INSERT INTO purchase_requests (
+    tenant_id, pr_no, source_type, source_close_date,
+    source_location_id, status, total_amount,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_pr_no, 'close_date', p_close_date,
+    v_dest_loc, 'draft', 0,
+    p_operator, p_operator
+  ) RETURNING id INTO v_pr_id;
+
+  INSERT INTO purchase_request_items (
+    pr_id, sku_id, qty_requested,
+    suggested_supplier_id, unit_cost, source_campaign_id,
+    created_by, updated_by
+  )
+  SELECT
+    v_pr_id,
+    agg.sku_id,
+    agg.qty_total,
+    ss.supplier_id,
+    COALESCE(ss.default_unit_cost, 0),
+    agg.first_campaign_id,
+    p_operator,
+    p_operator
+  FROM (
+    SELECT
+      coi.sku_id,
+      SUM(coi.qty) AS qty_total,
+      MIN(gbc.id)  AS first_campaign_id
+      FROM group_buy_campaigns gbc
+      JOIN customer_orders co ON co.campaign_id = gbc.id
+      JOIN customer_order_items coi ON coi.order_id = co.id
+     WHERE gbc.tenant_id = v_tenant
+       AND gbc.status = 'closed'
+       AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = p_close_date
+       AND co.status NOT IN ('cancelled','expired','transferred_out')
+       AND coi.status NOT IN ('cancelled','expired')
+     GROUP BY coi.sku_id
+  ) agg
+  LEFT JOIN LATERAL (
+    SELECT supplier_id, default_unit_cost
+      FROM supplier_skus
+     WHERE tenant_id = v_tenant
+       AND sku_id = agg.sku_id
+       AND is_preferred = TRUE
+     LIMIT 1
+  ) ss ON TRUE;
+
+  -- sync purchase_request_campaigns join 表
+  INSERT INTO purchase_request_campaigns (pr_id, campaign_id, tenant_id)
+  SELECT v_pr_id, gbc.id, v_tenant
+    FROM group_buy_campaigns gbc
+   WHERE gbc.tenant_id = v_tenant
+     AND gbc.status = 'closed'
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = p_close_date
+  ON CONFLICT (pr_id, campaign_id) DO NOTHING;
+
+  UPDATE purchase_requests pr
+     SET total_amount = COALESCE((
+           SELECT SUM(line_subtotal) FROM purchase_request_items WHERE pr_id = v_pr_id
+         ), 0),
+         updated_at = NOW()
+   WHERE pr.id = v_pr_id;
+
+  -- *** Stage 4 新增:鎖團 + auto-confirm 訂單 ***
+  WITH locked_campaigns AS (
+    UPDATE group_buy_campaigns
+       SET status     = 'locked',
+           updated_by = p_operator,
+           updated_at = NOW()
+     WHERE tenant_id = v_tenant
+       AND status = 'closed'
+       AND DATE(end_at AT TIME ZONE 'Asia/Taipei') = p_close_date
+    RETURNING id
+  )
+  SELECT array_agg(id) INTO v_campaign_ids FROM locked_campaigns;
+
+  PERFORM public._lock_orders_after_pr_aggregation(v_campaign_ids, p_operator, v_pr_id);
+
+  RETURN v_pr_id;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_create_pr_from_close_date IS
+  '從結單日彙總所有 closed campaigns 建立 PR;'
+  '尾巴自動把這些 campaigns 推進到 locked、把 pending 訂單推進到 confirmed(寫稽核)';
+
+-- ----------------------------------------------------------------
+-- 4. rpc_append_campaign_to_pr:尾巴加鎖團 + 鎖訂單
+--    完整 replace(20260614000010 版本之上加最後一段)
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_append_campaign_to_pr(p_pr_id bigint, p_campaign_id bigint, p_operator uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_tenant      UUID;
+  v_pr_status   TEXT;
+  v_pr_close_date DATE;
+  v_camp_status TEXT;
+  v_camp_close_date DATE;
+  v_camp_tenant UUID;
+  v_inserted    INTEGER := 0;
+  v_updated     INTEGER := 0;
+  v_demand RECORD;
+BEGIN
+  SELECT tenant_id, status, source_close_date
+    INTO v_tenant, v_pr_status, v_pr_close_date
+    FROM purchase_requests
+   WHERE id = p_pr_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PR % not found', p_pr_id;
+  END IF;
+
+  IF v_pr_status <> 'draft' THEN
+    RAISE EXCEPTION 'PR % is not in draft status (current: %); cannot append',
+      p_pr_id, v_pr_status;
+  END IF;
+
+  SELECT tenant_id, status, DATE(end_at AT TIME ZONE 'Asia/Taipei')
+    INTO v_camp_tenant, v_camp_status, v_camp_close_date
+    FROM group_buy_campaigns
+   WHERE id = p_campaign_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'campaign % not found', p_campaign_id;
+  END IF;
+
+  IF v_camp_tenant <> v_tenant THEN
+    RAISE EXCEPTION 'tenant mismatch';
+  END IF;
+
+  IF v_camp_status <> 'closed' THEN
+    RAISE EXCEPTION 'campaign % not in closed status (current: %)',
+      p_campaign_id, v_camp_status;
+  END IF;
+
+  IF v_pr_close_date IS NOT NULL AND v_camp_close_date <> v_pr_close_date THEN
+    RAISE EXCEPTION 'close_date mismatch: PR=%, campaign=%',
+      v_pr_close_date, v_camp_close_date;
+  END IF;
+
+  FOR v_demand IN
+    SELECT
+      coi.sku_id,
+      SUM(coi.qty) AS qty_total
+      FROM customer_orders co
+      JOIN customer_order_items coi ON coi.order_id = co.id
+     WHERE co.campaign_id = p_campaign_id
+       AND co.tenant_id = v_tenant
+       AND co.status NOT IN ('cancelled','expired')
+       AND coi.status NOT IN ('cancelled','expired')
+     GROUP BY coi.sku_id
+  LOOP
+    UPDATE purchase_request_items
+       SET qty_requested = qty_requested + v_demand.qty_total,
+           updated_by = p_operator
+     WHERE pr_id = p_pr_id AND sku_id = v_demand.sku_id;
+
+    IF FOUND THEN
+      v_updated := v_updated + 1;
+    ELSE
+      INSERT INTO purchase_request_items (
+        pr_id, sku_id, qty_requested,
+        suggested_supplier_id, unit_cost,
+        retail_price, franchise_price,
+        source_campaign_id,
+        created_by, updated_by
+      )
+      SELECT
+        p_pr_id, v_demand.sku_id, v_demand.qty_total,
+        ss.supplier_id, COALESCE(ss.default_unit_cost, 0),
+        pr_retail.price, pr_franchise.price,
+        p_campaign_id, p_operator, p_operator
+      FROM (SELECT 1) dummy
+      LEFT JOIN LATERAL (
+        SELECT supplier_id, default_unit_cost
+          FROM supplier_skus
+         WHERE tenant_id = v_tenant
+           AND sku_id = v_demand.sku_id
+           AND is_preferred = TRUE
+         LIMIT 1
+      ) ss ON TRUE
+      LEFT JOIN LATERAL (
+        SELECT price FROM prices
+         WHERE sku_id = v_demand.sku_id AND scope = 'retail'
+         ORDER BY effective_from DESC NULLS LAST
+         LIMIT 1
+      ) pr_retail ON TRUE
+      LEFT JOIN LATERAL (
+        SELECT price FROM prices
+         WHERE sku_id = v_demand.sku_id AND scope = 'franchise'
+         ORDER BY effective_from DESC NULLS LAST
+         LIMIT 1
+      ) pr_franchise ON TRUE;
+
+      v_inserted := v_inserted + 1;
+    END IF;
+  END LOOP;
+
+  -- sync purchase_request_campaigns join 表
+  INSERT INTO purchase_request_campaigns (pr_id, campaign_id, tenant_id)
+  VALUES (p_pr_id, p_campaign_id, v_tenant)
+  ON CONFLICT (pr_id, campaign_id) DO NOTHING;
+
+  UPDATE purchase_requests pr
+     SET total_amount = COALESCE((
+           SELECT SUM(line_subtotal) FROM purchase_request_items WHERE pr_id = p_pr_id
+         ), 0),
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE pr.id = p_pr_id;
+
+  -- *** Stage 4 新增:鎖該 campaign + auto-confirm 訂單 ***
+  UPDATE group_buy_campaigns
+     SET status     = 'locked',
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_campaign_id AND status = 'closed';
+
+  PERFORM public._lock_orders_after_pr_aggregation(
+    ARRAY[p_campaign_id], p_operator, p_pr_id
+  );
+
+  RETURN jsonb_build_object('inserted', v_inserted, 'updated', v_updated);
+END;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_append_campaign_to_pr IS
+  '把指定 closed campaign 併入既有 draft PR;'
+  '尾巴自動把該 campaign 推進到 locked、把 pending 訂單推進到 confirmed(寫稽核)';


### PR DESCRIPTION
## ⚠️ Deployment Order

This PR ships migration `20260625000000_pr_create_lock_campaign_and_orders.sql`, which **must be deployed together with #335** (no time gap).

**Why**: PR #335 ships `rpc_update_order_item_qty` that writes `field='qty'` to `customer_order_audit_log`. The existing CHECK constraint on that table does **not** allow `'qty'` — this PR extends the constraint to add both `'qty'` (for #335) and `'status'` (for this PR's auto-confirm helper).

**Deploy order**:
1. `20260623000000_campaign_status_locked.sql` (PR #334)
2. `20260624000000_order_item_qty_edit.sql` (PR #335)
3. `20260625000000_pr_create_lock_campaign_and_orders.sql` (this PR) ← extends CHECK; must run before #335's RPC is called by users

If only #335 is deployed (without this PR's migration), shop staff editing qty will hit a `customer_order_audit_log_field_check` violation.

---

## Summary

Implements Stage 4 of the purchase request workflow: when a PR is created, automatically transition all associated closed campaigns to `locked` status and auto-confirm all pending orders within those campaigns, with audit trail logging.

## Key Changes

- **Expanded audit log constraint**: Extended `customer_order_audit_log_field_check` to include `'qty'` (Stage 3) and `'status'` (Stage 4) fields
- **New helper function `_lock_orders_after_pr_aggregation`**: Internal function that atomically transitions pending orders to confirmed status and writes audit logs with reason `auto-confirmed by PR #N`
- **Updated `rpc_create_pr_from_close_date`**: Added logic at the end to lock all closed campaigns for the given close_date and auto-confirm their pending orders
- **Updated `rpc_append_campaign_to_pr`**: Added logic at the end to lock the appended campaign and auto-confirm its pending orders
- **UI enhancement in OrderDetail**: Display locked icon (🔒) with tooltip for confirmed orders, preventing further qty edits with message about PR lock
- **Comprehensive test documentation**: Added `TEST-campaign-locked-status.md` covering design rationale, RPC behavior test cases, UI behavior, and e2e scenarios

## Implementation Details

- The locking is atomic: campaigns transition to `locked` and orders to `confirmed` in the same transaction as PR creation
- Only `rpc_create_pr_from_close_date` and `rpc_append_campaign_to_pr` trigger auto-locking; `rpc_approve_restock_to_pr` (restock flow) intentionally excluded
- Helper uses `FOR UPDATE` to prevent race conditions and `WHERE status='pending'` to skip already-confirmed orders
- Audit logs capture the PR number in `edit_reason` field for traceability
- Confirmed orders show qty as read-only with lock indicator in admin UI
- Customers cannot add orders to locked campaigns (enforced by existing RPC guards)

https://claude.ai/code/session_01WrdgKG1YQdo7ysXmVtMhYJ