### PR TITLE
feat(admin/campaigns): 編輯開團 popup 內訂單列可點開訂單明細

### DIFF
--- a/apps/admin/src/components/CampaignOrdersPanel.tsx
+++ b/apps/admin/src/components/CampaignOrdersPanel.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 import { orderStatusLabel } from "@/lib/orderStatus";
+import { Modal } from "@/components/Modal";
+import { OrderDetail } from "@/components/OrderDetail";
 
 type OrderRow = {
   id: number;
@@ -40,6 +42,9 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
   const [storeFilter, setStoreFilter] = useState<string>("");
   useDefaultStoreFromUser(stores, storeFilter, setStoreFilter);
   const [error, setError] = useState<string | null>(null);
+  const [detailId, setDetailId] = useState<number | null>(null);
+  const [detailNo, setDetailNo] = useState<string>("");
+  const [reloadTick, setReloadTick] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -68,7 +73,7 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
     return () => {
       cancelled = true;
     };
-  }, [campaignId]);
+  }, [campaignId, reloadTick]);
 
   const storeCount = useMemo(() => {
     const m = new Map<number, number>();
@@ -178,7 +183,12 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
                   return (
                     <tr
                       key={r.id}
-                      className={`${isOffset ? "bg-red-50/40 dark:bg-red-950/20" : ""} ${isCancelled ? "opacity-50" : ""} hover:bg-zinc-50 dark:hover:bg-zinc-900`}
+                      onClick={() => {
+                        setDetailId(r.id);
+                        setDetailNo(r.order_no);
+                      }}
+                      className={`cursor-pointer ${isOffset ? "bg-red-50/40 dark:bg-red-950/20" : ""} ${isCancelled ? "opacity-50" : ""} hover:bg-zinc-50 dark:hover:bg-zinc-900`}
+                      title="點此查看訂單明細"
                     >
                       <td className="px-3 py-1.5 font-mono">
                         {r.order_no}
@@ -192,6 +202,7 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
                         {r.member?.name ? (
                           <Link
                             href={`/members?id=${r.member.id}`}
+                            onClick={(e) => e.stopPropagation()}
                             className="hover:underline"
                           >
                             {r.member.name}
@@ -238,6 +249,26 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
           </div>
         </>
       )}
+
+      <Modal
+        open={detailId !== null}
+        onClose={() => {
+          setDetailId(null);
+          setReloadTick((n) => n + 1);
+        }}
+        title={`訂單明細 ${detailNo}`}
+        maxWidth="max-w-4xl"
+      >
+        {detailId !== null && (
+          <OrderDetail
+            orderId={detailId}
+            onNavigate={(id, no) => {
+              setDetailId(id);
+              setDetailNo(no);
+            }}
+          />
+        )}
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 開團編輯彈窗的「本團訂單」表格列原本只是純文字，使用者要看單還得另開「完整訂單頁 →」，多繞一步。
- 改為整列可點直接開訂單明細 popup，沿用 /orders 頁既有的 `Modal` + `OrderDetail` 模式（OrderDetail 本身已嵌套多個子 modal，nested modal 是專案既有慣例）。
- 關閉明細時順手 bump reloadTick 重抓列表，把明細內可能改過的數量／折扣／取消狀態同步回團頁。

## Changes
- [apps/admin/src/components/CampaignOrdersPanel.tsx](apps/admin/src/components/CampaignOrdersPanel.tsx)
  - import `Modal` + `OrderDetail`
  - 新增 `detailId / detailNo / reloadTick` state
  - `<tr>` 改 `cursor-pointer` + `onClick`，title 提示「點此查看訂單明細」
  - 會員欄 `<Link>` 加 `e.stopPropagation()`，仍可獨立跳 `/members?id=`
  - `OrderDetail` 的 `onNavigate` 接上，轉出後可直接跳新訂單不必關掉再開

## Test plan
- [ ] 進「開團 → 編輯」彈窗，捲到「本團訂單」，點任意一列 → 開出訂單明細 popup
- [ ] popup 內按右上 ✕ 關閉 → 列表應自動刷新（在 popup 內改數量／取消後可看到狀態變動）
- [ ] 點會員姓名 → 跳 `/members?id=...`，不會誤開訂單明細 popup
- [ ] 在 popup 內按「轉出此訂單」→ 跳轉到新訂單頁時 popup 內容直接切換、不需重開

## Notes
- 沙箱無法登入 admin（[reference_admin_preview_sandbox_block](../memory/reference_admin_preview_sandbox_block.md)），browser preview 跳過，請使用者自審。
- `npx tsc --noEmit` 對本檔 clean；唯二 TS error 在 `parseLeleMemberCsv.ts`（papaparse 缺型別，與本 PR 無關、早就存在）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)