### PR TITLE
feat(campaigns): 新增「美食列車」開團類別 + 顧客端置頂專區 + 上架推播

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -40,6 +40,7 @@ async function fetchAll<T>(builder: () => any, pageSize = 1000, maxPages = 50): 
 type Status = CampaignStatus;
 
 type CloseType = "regular" | "fast" | "limited";
+type Category = "food_train" | null;
 
 type Row = {
   id: number;
@@ -47,6 +48,7 @@ type Row = {
   name: string;
   status: Status;
   close_type: CloseType;
+  category: Category;
   start_at: string | null;
   end_at: string | null;
   pickup_deadline: string | null;
@@ -67,6 +69,14 @@ const CLOSE_TYPE_BADGE: Record<CloseType, string> = {
   regular: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
   fast: "bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-300",
   limited: "bg-pink-100 text-pink-800 dark:bg-pink-950 dark:text-pink-300",
+};
+
+const CATEGORY_LABEL: Record<"food_train", string> = {
+  food_train: "美食列車",
+};
+
+const CATEGORY_BADGE: Record<"food_train", string> = {
+  food_train: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
 };
 
 const PAGE_SIZE = 20;
@@ -123,6 +133,7 @@ export default function CampaignsListPage() {
   const [queryDraft, setQueryDraft] = useState("");
   const [query, setQuery] = useState("");
   const [status, setStatus] = useState<string>("");
+  const [categoryFilter, setCategoryFilter] = useState<string>(""); // ""=全部 / "food_train" / "none"
   const [page, setPage] = useState(1);
 
   const [itemCounts, setItemCounts] = useState<Map<number, number>>(new Map());
@@ -298,7 +309,7 @@ export default function CampaignsListPage() {
   async function openEdit(id: number) {
     const { data, error: err } = await getSupabase()
       .from("group_buy_campaigns")
-      .select("id, campaign_no, name, description, status, close_type, start_at, end_at, pickup_deadline, pickup_days, total_cap_qty, notes")
+      .select("id, campaign_no, name, description, status, close_type, category, start_at, end_at, pickup_deadline, pickup_days, total_cap_qty, notes")
       .eq("id", id).maybeSingle();
     if (err || !data) { setError(err?.message ?? "找不到開團"); return; }
     setModal({
@@ -310,6 +321,7 @@ export default function CampaignsListPage() {
         description: data.description,
         status: data.status as CampaignFormValues["status"],
         close_type: data.close_type as CampaignFormValues["close_type"],
+        category: (data.category ?? null) as CampaignFormValues["category"],
         start_at: data.start_at,
         end_at: data.end_at,
         pickup_deadline: data.pickup_deadline,
@@ -326,6 +338,7 @@ export default function CampaignsListPage() {
   }, [queryDraft]);
 
   useEffect(() => { setPage(1); }, [status]);
+  useEffect(() => { setPage(1); }, [categoryFilter]);
 
   useEffect(() => {
     let cancelled = false;
@@ -334,7 +347,7 @@ export default function CampaignsListPage() {
       try {
         let q = getSupabase()
           .from("group_buy_campaigns")
-          .select("id, campaign_no, name, status, close_type, start_at, end_at, pickup_deadline, updated_at, cover_image_url, campaign_items(sort_order, sku:skus(product:products(images)))", { count: "exact" })
+          .select("id, campaign_no, name, status, close_type, category, start_at, end_at, pickup_deadline, updated_at, cover_image_url, campaign_items(sort_order, sku:skus(product:products(images)))", { count: "exact" })
           .neq("campaign_no", "__INTERNAL_RESTOCK__")
           .order("start_at", { ascending: false, nullsFirst: false })
           .order("id", { ascending: false })
@@ -344,6 +357,8 @@ export default function CampaignsListPage() {
           q = q.or(`name.ilike.%${safe}%,campaign_no.ilike.%${safe}%`);
         }
         if (status) q = q.eq("status", status);
+        if (categoryFilter === "food_train") q = q.eq("category", "food_train");
+        else if (categoryFilter === "none") q = q.is("category", null);
 
         const { data, count, error } = await q;
         if (cancelled) return;
@@ -399,7 +414,7 @@ export default function CampaignsListPage() {
       }
     })();
     return () => { cancelled = true; };
-  }, [query, status, page, reloadTick]);
+  }, [query, status, categoryFilter, page, reloadTick]);
 
   // Calendar (week / month) 取資料：依視圖決定範圍
   useEffect(() => {
@@ -579,7 +594,7 @@ export default function CampaignsListPage() {
       </div>
 
       {view === "list" && (
-        <div className="grid gap-3 sm:grid-cols-2">
+        <div className="grid gap-3 sm:grid-cols-3">
           <input
             type="search" placeholder="搜尋 團號 / 名稱" value={queryDraft} onChange={(e) => setQueryDraft(e.target.value)}
             className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
@@ -588,6 +603,13 @@ export default function CampaignsListPage() {
             className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
             <option value="">全部狀態</option>
             {Object.entries(STATUS_LABEL).map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+          </select>
+          <select value={categoryFilter} onChange={(e) => setCategoryFilter(e.target.value)}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+            aria-label="類別篩選">
+            <option value="">全部類別</option>
+            <option value="food_train">美食列車</option>
+            <option value="none">一般（無類別）</option>
           </select>
         </div>
       )}
@@ -718,6 +740,11 @@ export default function CampaignsListPage() {
                   <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CLOSE_TYPE_BADGE[r.close_type]}`}>
                     {CLOSE_TYPE_LABEL[r.close_type]}
                   </span>
+                  {r.category && (
+                    <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CATEGORY_BADGE[r.category]}`}>
+                      {CATEGORY_LABEL[r.category]}
+                    </span>
+                  )}
                 </div>
               </div>
             </div>
@@ -801,9 +828,16 @@ export default function CampaignsListPage() {
                 <Td className="min-w-[14rem]">{r.name}</Td>
                 <Td className="whitespace-nowrap"><StatusBadge s={r.status} /></Td>
                 <Td>
-                  <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CLOSE_TYPE_BADGE[r.close_type]}`}>
-                    {CLOSE_TYPE_LABEL[r.close_type]}
-                  </span>
+                  <div className="flex flex-wrap items-center gap-1">
+                    <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CLOSE_TYPE_BADGE[r.close_type]}`}>
+                      {CLOSE_TYPE_LABEL[r.close_type]}
+                    </span>
+                    {r.category && (
+                      <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CATEGORY_BADGE[r.category]}`}>
+                        {CATEGORY_LABEL[r.category]}
+                      </span>
+                    )}
+                  </div>
                 </Td>
                 <Td className="whitespace-nowrap text-xs text-zinc-500">
                   {fmtDateTime(r.start_at)}

--- a/apps/admin/src/components/CampaignForm.tsx
+++ b/apps/admin/src/components/CampaignForm.tsx
@@ -9,6 +9,11 @@ import { CAMPAIGN_STATUS_LABEL, type CampaignStatus } from "@/lib/campaignStatus
 
 export type { CampaignStatus };
 export type CloseType = "regular" | "fast" | "limited";
+export type CampaignCategory = "food_train" | null;
+
+export const CATEGORY_LABEL: Record<"food_train", string> = {
+  food_train: "美食列車",
+};
 
 export type CampaignFormValues = {
   id: number | null;
@@ -17,6 +22,7 @@ export type CampaignFormValues = {
   description: string | null;
   status: CampaignStatus;
   close_type: CloseType;
+  category: CampaignCategory;
   start_at: string | null;
   end_at: string | null;
   pickup_deadline: string | null;
@@ -32,6 +38,7 @@ export const emptyCampaignValues: CampaignFormValues = {
   description: null,
   status: "draft",
   close_type: "regular",
+  category: null,
   start_at: null,
   end_at: null,
   pickup_deadline: null,
@@ -108,6 +115,7 @@ export function CampaignForm({
 
       // 團名由此表單直接編輯；描述 / 取貨截止 / 取貨天數 / 備註
       // 仍從商品 / RPC 自動帶入，UI 不編輯、保留原值送回。
+      const wasOpen = (initial?.status ?? null) === "open";
       const { data, error: err } = await getSupabase().rpc("rpc_upsert_campaign", {
         p_id: v.id,
         p_campaign_no: v.campaign_no.trim(),
@@ -121,9 +129,27 @@ export function CampaignForm({
         p_pickup_days: v.pickup_days,
         p_total_cap_qty: v.total_cap_qty,
         p_notes: v.notes,
+        p_category: v.category,
       });
       if (err) throw err;
       const newId = Number(data);
+
+      // 美食列車且 status 從非 open → open 時, 廣播推播給全 tenant 顧客
+      // (失敗不阻擋儲存; 顯示警告但仍視為成功)
+      if (v.category === "food_train" && v.status === "open" && !wasOpen) {
+        try {
+          await broadcastFoodTrainOpen({
+            campaignId: newId,
+            campaignName: (v.name || "美食列車").trim(),
+          });
+        } catch (broadcastErr) {
+          console.error("food_train broadcast failed:", broadcastErr);
+          setError(
+            `儲存成功；但推播廣播失敗：${broadcastErr instanceof Error ? broadcastErr.message : String(broadcastErr)}`,
+          );
+        }
+      }
+
       if (onSaved) onSaved(newId);
       else router.replace(`/campaigns`);
     } catch (e) {
@@ -166,6 +192,21 @@ export function CampaignForm({
             <option value="fast">快團</option>
             <option value="limited">限量</option>
           </select>
+        </Field>
+        <Field label="類別">
+          <select
+            value={v.category ?? ""}
+            onChange={(e) => update("category", (e.target.value || null) as CampaignCategory)}
+            className={inputCls}
+          >
+            <option value="">無</option>
+            <option value="food_train">美食列車</option>
+          </select>
+          {v.category === "food_train" && v.status === "open" && (initial?.status ?? null) !== "open" && (
+            <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400">
+              儲存後將推播給所有未取消通知的顧客。
+            </p>
+          )}
         </Field>
         <Field
           label={v.close_type === "fast" ? "開團期間（開團 → 收單，快團必填收單）" : "開團期間（開團 → 收單）"}
@@ -384,3 +425,36 @@ function Field({ label, children, className = "" }: { label: string; children: R
 
 const inputCls =
   "rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800";
+
+// 美食列車開團上架時, 廣播給全 tenant 顧客
+async function broadcastFoodTrainOpen({
+  campaignId,
+  campaignName,
+}: {
+  campaignId: number;
+  campaignName: string;
+}): Promise<void> {
+  const sb = getSupabase();
+  const { data: { session } } = await sb.auth.getSession();
+  if (!session) throw new Error("尚未登入");
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!supabaseUrl) throw new Error("NEXT_PUBLIC_SUPABASE_URL 未設定");
+  const resp = await fetch(`${supabaseUrl}/functions/v1/admin-notify`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.access_token}`,
+    },
+    body: JSON.stringify({
+      broadcast: true,
+      category: "food_train",
+      title: "美食列車新團上架",
+      message: campaignName,
+      url: `/shop/c/${campaignId}`,
+    }),
+  });
+  if (!resp.ok) {
+    const detail = await resp.text().catch(() => "");
+    throw new Error(`HTTP ${resp.status} ${detail}`.trim());
+  }
+}

--- a/apps/member/src/app/shop/food-train/page.tsx
+++ b/apps/member/src/app/shop/food-train/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { consumeFragmentToSession, getSession } from "@/lib/session";
+import { callLiffApi } from "@/lib/supabase";
+import PageShell from "@/components/PageShell";
+import { LoadingScreen } from "@/components/Spinner";
+import CampaignCard, { type CampaignSummary } from "@/components/CampaignCard";
+
+export default function FoodTrainPage() {
+  const router = useRouter();
+  const [campaigns, setCampaigns] = useState<CampaignSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    consumeFragmentToSession();
+    const s = getSession();
+    if (!s || !s.memberId) {
+      router.replace("/");
+      return;
+    }
+    (async () => {
+      try {
+        const d = await callLiffApi<{ campaigns: CampaignSummary[] }>(s.token, {
+          action: "list_active_campaigns",
+          category: "food_train",
+        });
+        setCampaigns(d.campaigns);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [router]);
+
+  // 前端防線：擋掉內部 sentinel 活動，與 /shop 一致
+  const visible = campaigns.filter((c) => !c.campaign_no.startsWith("__"));
+  const hero = visible[0];
+
+  return (
+    <PageShell title="美食列車">
+      <div className="space-y-3 px-4 pt-3 pb-6">
+        {loading && <LoadingScreen />}
+
+        {err && (
+          <div className="rounded-2xl bg-[#ff3b30]/10 p-3 text-[15px] text-[#c4271d]">
+            {err}
+          </div>
+        )}
+
+        {!loading && !err && visible.length === 0 && (
+          <div className="overflow-hidden rounded-2xl bg-gradient-to-br from-emerald-500/10 to-teal-500/10 p-6 text-center">
+            <div className="text-5xl">🚂</div>
+            <h2 className="mt-3 text-[18px] font-semibold text-[var(--foreground)]">
+              目前沒有美食列車
+            </h2>
+            <p className="mt-2 whitespace-pre-line text-[15px] leading-relaxed text-[var(--secondary-label)]">
+              店長正在挑下一波美食中{"\n"}新團上架會即時通知你
+            </p>
+            <a
+              href="/shop"
+              className="mt-5 inline-block rounded-full bg-emerald-600 px-5 py-2 text-[15px] font-medium text-white active:opacity-80"
+            >
+              先看看其他商品 →
+            </a>
+          </div>
+        )}
+
+        {hero && <CampaignCard campaign={hero} variant="hero" />}
+
+        {visible.slice(1).length > 0 && (
+          <div className="grid grid-cols-2 gap-3 pt-1">
+            {visible.slice(1).map((c) => (
+              <CampaignCard key={c.id} campaign={c} />
+            ))}
+          </div>
+        )}
+      </div>
+    </PageShell>
+  );
+}

--- a/apps/member/src/app/shop/page.tsx
+++ b/apps/member/src/app/shop/page.tsx
@@ -118,6 +118,10 @@ export default function ShopPage() {
   // find 取到的就是最快結單的快閃團。
   const hero = visible.find((c) => c.close_type === "fast");
 
+  // 美食列車專區：有任何 category='food_train' 的開團時顯示綠色 banner
+  const foodTrainHero = visible.find((c) => c.category === "food_train");
+  const foodTrainCount = visible.filter((c) => c.category === "food_train").length;
+
   // 排序：最新(id 大→小，無 created_at 用 id 近似) / 最熱銷(全分店訂單數)
   // / 近期售出(近 7 天訂單數)。tie-break 回退 id desc 保持穩定。
   const sorted = [...visible].sort((a, b) => {
@@ -171,6 +175,41 @@ export default function ShopPage() {
               下拉重新整理，新團開跑會在這裡出現
             </p>
           </div>
+        )}
+
+        {/* 美食列車 banner — 永遠在最上方,點進 /shop/food-train 全列表 */}
+        {foodTrainHero && (
+          <Link
+            href="/shop/food-train"
+            className="block overflow-hidden rounded-2xl shadow-[0_10px_28px_-10px_rgba(5,150,105,0.5)] transition-transform duration-200 active:scale-[0.985]"
+          >
+            <div className="relative aspect-[16/8] w-full bg-gradient-to-br from-emerald-500 via-emerald-600 to-teal-600">
+              {foodTrainHero.cover_image_url && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={foodTrainHero.cover_image_url}
+                  alt=""
+                  className="absolute inset-0 h-full w-full object-cover opacity-30 mix-blend-overlay"
+                />
+              )}
+              <div className="absolute inset-0 bg-[radial-gradient(120%_80%_at_100%_0%,rgba(255,255,255,0.35)_0%,transparent_55%)]" />
+              <div className="absolute inset-0 flex flex-col justify-between p-4">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex items-center gap-1.5 rounded-full bg-white/22 px-3 py-1 backdrop-blur">
+                    <span className="text-[16px]">🚂</span>
+                    <span className="text-[16px] font-bold text-white">美食列車</span>
+                  </span>
+                </div>
+                <div className="space-y-0.5">
+                  <div className="text-[13px] font-medium text-white/90">嚴選美食 · 限時開團</div>
+                  <div className="text-[22px] font-bold text-white drop-shadow">
+                    {foodTrainCount} 團熱賣中
+                  </div>
+                </div>
+              </div>
+              <div className="absolute right-4 top-1/2 -translate-y-1/2 text-[28px] text-white/85">›</div>
+            </div>
+          </Link>
         )}
 
         {/* 限時專區 banner */}

--- a/apps/member/src/app/shop/page.tsx
+++ b/apps/member/src/app/shop/page.tsx
@@ -9,6 +9,7 @@ import PageShell from "@/components/PageShell";
 import PullToRefresh from "@/components/PullToRefresh";
 import CampaignCard, { type CampaignSummary } from "@/components/CampaignCard";
 import Countdown from "@/components/Countdown";
+import ShopBannerCarousel from "@/components/ShopBannerCarousel";
 
 type SortKey = "new" | "hot" | "recent";
 
@@ -24,6 +25,7 @@ type ShopCache = {
   campaigns: CampaignSummary[];
   sortBy: SortKey;
   scrollY: number;
+  pendingPickupCount: number;
   ts: number;
 };
 let shopCache: ShopCache | null = null;
@@ -40,6 +42,9 @@ export default function ShopPage() {
   const [campaigns, setCampaigns] = useState<CampaignSummary[]>(
     () => shopCache?.campaigns ?? [],
   );
+  const [pendingPickupCount, setPendingPickupCount] = useState<number>(
+    () => shopCache?.pendingPickupCount ?? 0,
+  );
   const [loading, setLoading] = useState(() => shopCache == null);
   const [err, setErr] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<SortKey>(
@@ -55,14 +60,17 @@ export default function ShopPage() {
       }
       if (!silent) setErr(null);
       try {
-        const d = await callLiffApi<{ campaigns: CampaignSummary[] }>(s.token, {
+        const d = await callLiffApi<{ campaigns: CampaignSummary[]; pending_pickup_count?: number }>(s.token, {
           action: "list_active_campaigns",
         });
         setCampaigns(d.campaigns);
+        const pickupCount = d.pending_pickup_count ?? 0;
+        setPendingPickupCount(pickupCount);
         shopCache = {
           campaigns: d.campaigns,
           sortBy: shopCache?.sortBy ?? "new",
           scrollY: shopCache?.scrollY ?? 0,
+          pendingPickupCount: pickupCount,
           ts: Date.now(),
         };
       } catch (e) {
@@ -177,78 +185,104 @@ export default function ShopPage() {
           </div>
         )}
 
-        {/* 美食列車 banner — 永遠在最上方,點進 /shop/food-train 全列表 */}
-        {foodTrainHero && (
+        {/* 取貨提醒條 — 該會員有 status='ready' 的訂單時才出現 */}
+        {pendingPickupCount > 0 && (
           <Link
-            href="/shop/food-train"
-            className="block overflow-hidden rounded-2xl shadow-[0_10px_28px_-10px_rgba(5,150,105,0.5)] transition-transform duration-200 active:scale-[0.985]"
+            href="/orders"
+            className="flex items-center gap-3 rounded-2xl bg-amber-50 px-4 py-3 text-amber-900 shadow-[0_2px_8px_-4px_rgba(245,158,11,0.4)] active:opacity-80 dark:bg-amber-950 dark:text-amber-100"
           >
-            <div className="relative aspect-[16/8] w-full bg-gradient-to-br from-emerald-500 via-emerald-600 to-teal-600">
-              {foodTrainHero.cover_image_url && (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={foodTrainHero.cover_image_url}
-                  alt=""
-                  className="absolute inset-0 h-full w-full object-cover opacity-30 mix-blend-overlay"
-                />
-              )}
-              <div className="absolute inset-0 bg-[radial-gradient(120%_80%_at_100%_0%,rgba(255,255,255,0.35)_0%,transparent_55%)]" />
-              <div className="absolute inset-0 flex flex-col justify-between p-4">
-                <div className="flex items-center gap-2">
-                  <span className="inline-flex items-center gap-1.5 rounded-full bg-white/22 px-3 py-1 backdrop-blur">
-                    <span className="text-[16px]">🚂</span>
-                    <span className="text-[16px] font-bold text-white">美食列車</span>
-                  </span>
-                </div>
-                <div className="space-y-0.5">
-                  <div className="text-[13px] font-medium text-white/90">嚴選美食 · 限時開團</div>
-                  <div className="text-[22px] font-bold text-white drop-shadow">
-                    {foodTrainCount} 團熱賣中
-                  </div>
-                </div>
-              </div>
-              <div className="absolute right-4 top-1/2 -translate-y-1/2 text-[28px] text-white/85">›</div>
-            </div>
+            <span className="text-[20px]">🎁</span>
+            <span className="flex-1 text-[15px] font-semibold">
+              你有 {pendingPickupCount} 筆訂單可取貨
+            </span>
+            <span className="text-[20px] text-amber-700/70 dark:text-amber-300/70">›</span>
           </Link>
         )}
 
-        {/* 限時專區 banner */}
-        {hero && (
-          <Link
-            href="/shop/flash"
-            className="block overflow-hidden rounded-2xl shadow-[0_10px_28px_-10px_rgba(158,47,80,0.5)] transition-transform duration-200 active:scale-[0.985]"
-          >
-            <div className="relative">
-              <div className="relative aspect-[16/8] w-full brand-gradient">
-                {hero.cover_image_url && (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={hero.cover_image_url}
-                    alt=""
-                    className="absolute inset-0 h-full w-full object-cover opacity-35 mix-blend-overlay"
-                  />
-                )}
-                {/* 光澤 */}
-                <div className="absolute inset-0 bg-[radial-gradient(120%_80%_at_100%_0%,rgba(255,255,255,0.35)_0%,transparent_55%)]" />
-                <div className="absolute inset-0 flex flex-col justify-between p-4">
-                  <div className="flex items-center gap-2">
-                    <span className="inline-flex items-center gap-1.5 rounded-full bg-white/22 px-3 py-1 backdrop-blur">
-                      <span className="text-[16px]">⚡</span>
-                      <span className="text-[16px] font-bold text-white">限時專區</span>
-                    </span>
-                  </div>
-                  <div className="space-y-0.5">
-                    <div className="text-[13px] font-medium text-white/90">最快結單 · 手刀搶</div>
-                    <div className="text-[26px] font-bold tabular-nums text-white drop-shadow">
-                      {hero.end_at ? <Countdown target={hero.end_at} compact /> : "—"}
-                    </div>
-                  </div>
-                </div>
-                <div className="absolute right-4 top-1/2 -translate-y-1/2 text-[28px] text-white/85">›</div>
-              </div>
-            </div>
-          </Link>
-        )}
+        {/* 主題 banner 跑馬燈 — 美食列車 / 限時專區 並排可滑, auto-play 4s */}
+        <ShopBannerCarousel
+          banners={[
+            ...(foodTrainHero
+              ? [{
+                  key: "food_train",
+                  node: (
+                    <Link
+                      href="/shop/food-train"
+                      className="block overflow-hidden rounded-2xl shadow-[0_10px_28px_-10px_rgba(5,150,105,0.5)] transition-transform duration-200 active:scale-[0.985]"
+                    >
+                      <div className="relative aspect-[16/8] w-full bg-gradient-to-br from-emerald-500 via-emerald-600 to-teal-600">
+                        {foodTrainHero.cover_image_url && (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={foodTrainHero.cover_image_url}
+                            alt=""
+                            className="absolute inset-0 h-full w-full object-cover opacity-30 mix-blend-overlay"
+                          />
+                        )}
+                        <div className="absolute inset-0 bg-[radial-gradient(120%_80%_at_100%_0%,rgba(255,255,255,0.35)_0%,transparent_55%)]" />
+                        <div className="absolute inset-0 flex flex-col justify-between p-4">
+                          <div className="flex items-center gap-2">
+                            <span className="inline-flex items-center gap-1.5 rounded-full bg-white/22 px-3 py-1 backdrop-blur">
+                              <span className="text-[16px]">🚂</span>
+                              <span className="text-[16px] font-bold text-white">美食列車</span>
+                            </span>
+                          </div>
+                          <div className="space-y-0.5">
+                            <div className="text-[13px] font-medium text-white/90">嚴選美食 · 限時開團</div>
+                            <div className="text-[22px] font-bold text-white drop-shadow">
+                              {foodTrainCount} 團熱賣中
+                            </div>
+                          </div>
+                        </div>
+                        <div className="absolute right-4 top-1/2 -translate-y-1/2 text-[28px] text-white/85">›</div>
+                      </div>
+                    </Link>
+                  ),
+                }]
+              : []),
+            ...(hero
+              ? [{
+                  key: "flash",
+                  node: (
+                    <Link
+                      href="/shop/flash"
+                      className="block overflow-hidden rounded-2xl shadow-[0_10px_28px_-10px_rgba(158,47,80,0.5)] transition-transform duration-200 active:scale-[0.985]"
+                    >
+                      <div className="relative">
+                        <div className="relative aspect-[16/8] w-full brand-gradient">
+                          {hero.cover_image_url && (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                              src={hero.cover_image_url}
+                              alt=""
+                              className="absolute inset-0 h-full w-full object-cover opacity-35 mix-blend-overlay"
+                            />
+                          )}
+                          {/* 光澤 */}
+                          <div className="absolute inset-0 bg-[radial-gradient(120%_80%_at_100%_0%,rgba(255,255,255,0.35)_0%,transparent_55%)]" />
+                          <div className="absolute inset-0 flex flex-col justify-between p-4">
+                            <div className="flex items-center gap-2">
+                              <span className="inline-flex items-center gap-1.5 rounded-full bg-white/22 px-3 py-1 backdrop-blur">
+                                <span className="text-[16px]">⚡</span>
+                                <span className="text-[16px] font-bold text-white">限時專區</span>
+                              </span>
+                            </div>
+                            <div className="space-y-0.5">
+                              <div className="text-[13px] font-medium text-white/90">最快結單 · 手刀搶</div>
+                              <div className="text-[26px] font-bold tabular-nums text-white drop-shadow">
+                                {hero.end_at ? <Countdown target={hero.end_at} compact /> : "—"}
+                              </div>
+                            </div>
+                          </div>
+                          <div className="absolute right-4 top-1/2 -translate-y-1/2 text-[28px] text-white/85">›</div>
+                        </div>
+                      </div>
+                    </Link>
+                  ),
+                }]
+              : []),
+          ]}
+        />
 
         {/* 團購商品 + 排序 */}
         {visible.length > 0 && (

--- a/apps/member/src/components/CampaignCard.tsx
+++ b/apps/member/src/components/CampaignCard.tsx
@@ -11,6 +11,8 @@ export type CampaignSummary = {
   description: string | null;
   cover_image_url: string | null;
   close_type: "regular" | "fast" | "limited" | string;
+  /** 主題分類; NULL=一般, food_train=美食列車 */
+  category?: "food_train" | null;
   total_cap_qty: number | null;
   ordered_qty: number;
   /** 全分店訂單數（最熱銷排序用）。後端未部署前可能為 0。 */
@@ -23,6 +25,19 @@ export type CampaignSummary = {
   min_price: number;
   max_price: number;
 };
+
+/** 美食列車專屬 badge (與「限時/限量」分開,可同時出現) */
+function FoodTrainBadge({ size = "sm" }: { size?: "sm" | "lg" }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full bg-emerald-600/95 font-semibold text-white shadow-sm backdrop-blur ${
+        size === "lg" ? "px-3 py-1 text-[14px]" : "px-2 py-0.5 text-[11px]"
+      }`}
+    >
+      美食列車
+    </span>
+  );
+}
 
 /** 依 close_type + total_cap_qty 算出短標籤。
  *  「限時」只給真正的快閃團（close_type='fast'，即限時專區那種）。
@@ -140,6 +155,11 @@ export default function CampaignCard({
               </div>
             );
           })()}
+          {campaign.category === "food_train" && (
+            <div className="absolute right-3 top-3">
+              <FoodTrainBadge size="lg" />
+            </div>
+          )}
         </div>
         <div className="space-y-1.5 px-4 py-3.5">
           <h3 className="text-[22px] font-bold leading-tight text-[var(--foreground)]">
@@ -201,6 +221,11 @@ export default function CampaignCard({
             </span>
           );
         })()}
+        {campaign.category === "food_train" && (
+          <span className="absolute right-2 top-2">
+            <FoodTrainBadge size="sm" />
+          </span>
+        )}
       </div>
       <div className="space-y-1 px-3 py-2.5">
         <h3 className="line-clamp-2 min-h-[2.6em] text-[16px] font-semibold leading-tight text-[var(--foreground)]">

--- a/apps/member/src/components/ShopBannerCarousel.tsx
+++ b/apps/member/src/components/ShopBannerCarousel.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Banner = {
+  /** 唯一 key, 用來 React 渲染 + dots 識別 */
+  key: string;
+  /** 整個 banner 卡片內容 (含 Link / Image / 文案) */
+  node: React.ReactNode;
+};
+
+/**
+ * /shop 頂部 banner 跑馬燈。
+ * - 0 張 → 不渲染
+ * - 1 張 → 單張顯示, 不啟用 scroll/auto-play/dots
+ * - 2+ 張 → horizontal scroll-snap, auto-play 4s, 觸碰暫停 8s
+ *
+ * scroll-snap-x mandatory + 每張寬 88% 露出右邊一點點提示可滑。
+ */
+export default function ShopBannerCarousel({ banners }: { banners: Banner[] }) {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const pausedUntilRef = useRef<number>(0);
+
+  // 用 scroll 事件 + 卡片寬度算出 active index (給 dots 同步)
+  useEffect(() => {
+    if (banners.length <= 1) return;
+    const el = scrollerRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const slide = el.querySelector<HTMLDivElement>("[data-slide]");
+      if (!slide) return;
+      const slideWidth = slide.offsetWidth + 12; // 12 = gap
+      const idx = Math.round(el.scrollLeft / slideWidth);
+      setActiveIdx(Math.max(0, Math.min(banners.length - 1, idx)));
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [banners.length]);
+
+  // Auto-play: 每 4s 切到下一張 (循環); 觸碰時暫停 8s
+  useEffect(() => {
+    if (banners.length <= 1) return;
+    const el = scrollerRef.current;
+    if (!el) return;
+    const id = setInterval(() => {
+      if (Date.now() < pausedUntilRef.current) return;
+      const slide = el.querySelector<HTMLDivElement>("[data-slide]");
+      if (!slide) return;
+      const slideWidth = slide.offsetWidth + 12;
+      const currentIdx = Math.round(el.scrollLeft / slideWidth);
+      const nextIdx = (currentIdx + 1) % banners.length;
+      el.scrollTo({ left: nextIdx * slideWidth, behavior: "smooth" });
+    }, 4000);
+    return () => clearInterval(id);
+  }, [banners.length]);
+
+  // 觸碰 / 拖曳時暫停 auto-play 8s
+  useEffect(() => {
+    if (banners.length <= 1) return;
+    const el = scrollerRef.current;
+    if (!el) return;
+    const pause = () => { pausedUntilRef.current = Date.now() + 8000; };
+    el.addEventListener("pointerdown", pause);
+    el.addEventListener("touchstart", pause, { passive: true });
+    return () => {
+      el.removeEventListener("pointerdown", pause);
+      el.removeEventListener("touchstart", pause);
+    };
+  }, [banners.length]);
+
+  if (banners.length === 0) return null;
+
+  // 單張 → 直接渲染, 不做 carousel
+  if (banners.length === 1) {
+    return <div className="block">{banners[0].node}</div>;
+  }
+
+  return (
+    <div className="-mx-1">
+      <div
+        ref={scrollerRef}
+        className="flex gap-3 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+        style={{ scrollSnapType: "x mandatory" }}
+      >
+        {banners.map((b) => (
+          <div
+            key={b.key}
+            data-slide
+            className="w-[88%] shrink-0"
+            style={{ scrollSnapAlign: "center" }}
+          >
+            {b.node}
+          </div>
+        ))}
+      </div>
+      {/* dots indicator */}
+      <div className="mt-2 flex justify-center gap-1.5">
+        {banners.map((b, i) => (
+          <button
+            key={b.key}
+            type="button"
+            aria-label={`切換到第 ${i + 1} 張`}
+            onClick={() => {
+              pausedUntilRef.current = Date.now() + 8000;
+              const el = scrollerRef.current;
+              const slide = el?.querySelector<HTMLDivElement>("[data-slide]");
+              if (!el || !slide) return;
+              const slideWidth = slide.offsetWidth + 12;
+              el.scrollTo({ left: i * slideWidth, behavior: "smooth" });
+            }}
+            className={`h-1.5 rounded-full transition-all ${
+              activeIdx === i
+                ? "w-6 bg-[var(--brand-strong)]"
+                : "w-1.5 bg-zinc-300 dark:bg-zinc-700"
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/PLAN-shop-top-region.md
+++ b/docs/PLAN-shop-top-region.md
@@ -1,0 +1,229 @@
+# /shop 頂部進入區 layout 規劃
+
+**對應頁面：** [apps/member/src/app/shop/page.tsx](apps/member/src/app/shop/page.tsx)
+**現況截圖：** 使用者於 2026-05-23 提供（PageShell「商品」title → 直接到「團購商品 💕 / 50 團」+ tab + grid，**中間無任何 banner / 入口**）
+**規劃目標：** 把「進入區」(PageShell title → 「團購商品」section 之間) 重新設計，留出空間給 banner、捷徑、公告，但不犧牲商品 grid 的可見性。
+
+---
+
+## 1. 現況 vs 期望
+
+### 1.1 現況（截圖）
+```
+┌─────────────────────────────────┐
+│ 🐱 商品                          │  ← PageShell sticky header (32px bold)
+├─────────────────────────────────┤
+│                                  │
+│ 團購商品 💕              50 團  │  ← 直接接 grid section
+│ [最新] [最熱銷] [近期售出]      │
+│ ┌────┬────┐                      │
+│ │商品│商品│                      │
+└─────────────────────────────────┘
+```
+
+問題：頂部沒有「主題 / 行銷 / 個人化」入口，使用者只能在 50 團 grid 裡平面瀏覽，缺：
+- 主題開團（美食列車、未來其他類別）的優先曝光
+- 限時搶購的緊迫感入口
+- 公告／取貨提醒等任務型訊息
+
+### 1.2 期望（本規劃完成後）
+```
+┌─────────────────────────────────┐
+│ 🐱 商品                    🔔3  │  ← header 右側加通知鈴 (P1)
+├─────────────────────────────────┤
+│ 🎁 你有 1 筆訂單可取貨 →        │  ← 取貨提醒條 (P1, 有才出現)
+├─────────────────────────────────┤
+│ 📢 母親節活動 5/10 -- 5/12 →   │  ← 公告跑馬燈 (P2, 有才出現)
+├─────────────────────────────────┤
+│ ┌─────────────────────────────┐ │
+│ │ 🚂 美食列車                  │ │  ← P0 (剛 ship,有 food_train 才出現)
+│ │   嚴選美食 · 限時開團 5 團   │ │
+│ │                          ›  │ │
+│ └─────────────────────────────┘ │
+│ ┌─────────────────────────────┐ │
+│ │ ⚡ 限時專區                  │ │  ← P0 (既有,有 fast 才出現)
+│ │   最快結單 · 01:19:39       │ │
+│ │                          ›  │ │
+│ └─────────────────────────────┘ │
+├─────────────────────────────────┤
+│ 團購商品 💕              50 團 │
+│ [最新] [最熱銷] [近期售出]     │
+│ ┌────┬────┐                     │
+└─────────────────────────────────┘
+```
+
+---
+
+## 2. 候選元素清單
+
+| # | 元素 | 用途 | 出現條件 | 資料來源 | 期別 |
+|---|------|------|----------|----------|------|
+| A | **美食列車 banner**（綠） | 主題專區入口 | tenant 有 ≥1 個 `category='food_train' AND status='open'` | `list_active_campaigns` payload 含 category | **P0** ✅ 已做 |
+| B | **限時專區 banner**（紅/橘倒數） | 限時搶購入口 | tenant 有 ≥1 個 `close_type='fast' AND status='open'` | 同上 close_type | **P0** ✅ 既有 |
+| C | **取貨提醒條** | 提醒會員去取貨 | 該會員有 status='ready' 的 customer_orders（已到貨待取） | liff-api 新 action `get_pending_pickups` | **P1** |
+| D | **公告跑馬燈** | 店家後台發公告（活動 / 休團 / 系統） | 有 active 公告且未過期 | 新表 `announcements` + liff-api 新 action | **P2** |
+| E | **通知未讀鈴**（header rightAction） | 未讀通知導去 /notifications | 未讀 count > 0 顯示紅點 | 既有 `useUnreadNotifications` hook（底部 tab 已用） | **P1** |
+| F | **分類 icon grid**（4x2） | 蝦皮式分類入口 | 需要先設計「分類」schema（本期只有 food_train 一類） | TBD | **P2**（等多類別後） |
+| G | **搜尋列** | 商品 / 團名搜尋 | 永遠出現（但 PWA 可先不做、用底部 tab + grid 取代） | 既有 `list_active_campaigns` + 前端 filter | **P2** |
+| H | **熱門商品橫向 carousel** | 跟「最熱銷」tab 重疊 | 跟既有 tab 重複，不建議 | — | **不做** |
+| I | **新會員 / 生日專區** | 個人化行銷 | 該會員符合條件 | TBD（profile + 生日邏輯） | **P3** |
+
+---
+
+## 3. 推薦排版（從上到下）
+
+**原則**：任務型 > 行銷型 > 瀏覽型。任務型在前讓使用者「先做事再逛」。
+
+| 位置 | 元素 | 出現條件 | 高度估算 |
+|------|------|----------|----------|
+| 0 | PageShell 標題 + 通知鈴 (E) | 永遠 | sticky 64px + safe-area |
+| 1 | **取貨提醒條** (C) | 有待取訂單 | 44px（單行） |
+| 2 | **公告跑馬燈** (D) | 有公告 | 36px（單行） |
+| 3 | **美食列車 banner** (A) | 有 food_train | 16:8 比例 ≈ 195px |
+| 4 | **限時專區 banner** (B) | 有 fast | 16:8 比例 ≈ 195px |
+| 5 | 「團購商品」section + tab + grid（既有） | 永遠 | 滾動到底 |
+
+**首屏（375x812 iPhone）能看到**：標題 + 1 個提醒/公告 + 1 個 banner + 「團購商品」section 標題上緣。**第二屏**：第二個 banner + grid 第一排。
+
+### 3.1 雙 banner 都存在時的折衷
+- 兩個都顯示（不互斥），總高 ≈ 400px → 滑一下就看到 grid，使用者習慣可接受
+- 排序固定：美食列車 在上（綠色，主題行銷更主動）、限時專區 在下（紅色高 contrast 仍醒目）
+- 若未來有第 3 個主題 banner 出現，要改 horizontal scroll 卡片條，不能上下繼續疊
+
+### 3.2 視覺 contrast 避撞色
+| Banner | 主色 | 次要識別 |
+|--------|------|----------|
+| 美食列車 | emerald-500 → teal-600 漸層 + 🚂 | 永遠不放倒數（用「N 團熱賣中」靜態文字） |
+| 限時專區 | brand-gradient(玫紅) + ⚡ | 動態倒數（最快結單時間） |
+
+→ 兩者用「動 vs 靜」+「色相」雙軸區分，不會混淆。
+
+---
+
+## 4. 每區塊規格細節
+
+### 4.1 取貨提醒條（C, P1）
+```
+┌──────────────────────────────────────┐
+│ 🎁 你有 1 筆訂單可取貨 → /orders?tab=ready │
+└──────────────────────────────────────┘
+```
+- 樣式：`bg-amber-50` + `text-amber-900`，圓角 12px，44px 高
+- 出現條件：`SELECT COUNT(*) FROM customer_orders WHERE member_id=$ AND status='ready'` > 0
+- 0 筆時整條不渲染（不留空白）
+- 點擊 → `/orders?tab=ready`
+- 顯示文案：`你有 N 筆訂單可取貨`（N 來自 RPC）
+- 資料新鮮度：跟 campaign list 同次 fetch（liff-api action 加 `with_pending_pickups: true` 一起回）
+
+### 4.2 公告跑馬燈（D, P2）
+```
+┌──────────────────────────────────────┐
+│ 📢 母親節活動 5/10 -- 5/12 全店滿千... │  ← marquee 或單行截斷
+└──────────────────────────────────────┘
+```
+- 樣式：`bg-zinc-100` + `text-zinc-700`，36px 高
+- 出現條件：有 active 且未過期的公告（取最新一筆 or marquee 輪播）
+- 需先建 schema：
+  ```sql
+  CREATE TABLE announcements (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id UUID NOT NULL,
+    title TEXT NOT NULL,
+    url TEXT,                            -- 可選, 點擊跳轉
+    starts_at TIMESTAMPTZ DEFAULT NOW(),
+    ends_at TIMESTAMPTZ,                 -- NULL=永久
+    priority INT DEFAULT 0,              -- 排序
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  );
+  ```
+- admin 後台需配套 CRUD 頁
+- liff-api action `list_announcements`
+
+### 4.3 通知未讀鈴（E, P1）
+```
+header right slot:
+  🔔 (右上紅點數字: 3)
+```
+- 用 PageShell 既有 `rightAction` prop（不用改 PageShell）
+- 取既有 hook `useUnreadNotifications`（已存在於底部 tab）
+- 點 → `/notifications`
+- count=0 顯示灰色鈴、無紅點；count > 0 顯示品牌色 + 紅點數字（>9 顯示「9+」）
+- 提醒：iOS PWA 通知是底部 tab 也有，這裡是「主動位置」入口；不衝突，但要 audit 是否真的需要兩處（可能只在 /shop 加，其他頁不加）
+
+### 4.4 美食列車 banner（A, P0 - 已 ship）
+- 維持目前實作（剛 merge 的 PR）
+- 文案：`{N} 團熱賣中`，N = `visible.filter(c => c.category === 'food_train').length`
+- 點 → `/shop/food-train`
+
+### 4.5 限時專區 banner（B, P0 - 既有）
+- 維持目前實作
+- 點 → `/shop/flash`
+
+### 4.6 分類 icon grid（F, P2 — 等多分類）
+**先不做**。理由：目前只有 food_train 一個分類，做 grid 沒意義（一格 icon vs 一個 banner，banner 資訊密度高、視覺更突出）。等 category enum 累積到 ≥4 個值（如生鮮、衣物、節慶...）再轉成 grid。
+
+到時的 mock：
+```
+┌────┬────┬────┬────┐
+│ 🚂 │ 🥬 │ 👕 │ 🎉 │
+│美食│生鮮│衣物│節慶│
+├────┼────┼────┼────┤
+│ ⚡ │ 🎁 │ 🏷 │ ··· │
+│限時│優惠│折扣│更多│
+└────┴────┴────┴────┘
+```
+
+---
+
+## 5. Edge cases / 0-data 狀態
+
+| 場景 | 表現 |
+|------|------|
+| 完全沒 open campaign | 標題 → 既有 empty state（🛒「目前沒有進行中的團購」）；P1/P2 元素仍可出現 |
+| 只有食物列車、無 fast | 美食列車 banner 出現、限時 banner 不出現；grid 顯示食物列車那團 |
+| 只有 fast、無食物列車 | 反之 |
+| 兩個 banner 同時、加公告加取貨 | 進入區 ≈ 1.5 屏；可接受（使用者預期滾動） |
+| 無公告無待取訂單 | 進入區只剩 banner，乾淨 |
+| Loading | 既有 skeleton 處理（每個區塊獨立 skeleton；現況 banner 沒 skeleton，本期可加） |
+| 推播載入失敗 | 任一區塊 fetch error → 該區塊不渲染（silent），不能整頁紅字 |
+
+---
+
+## 6. 性能考量
+
+- **首屏 LCP**：banner 圖片用 `loading="eager"` + `decoding="async"`；其他 banner 圖 lazy
+- **資料合併**：取貨提醒、公告、開團列表合進**一次** liff-api 呼叫（新 action `get_shop_home` 包 3 個 payload），避免瀑布
+- **快取**：保留現有 `shopCache` SPA 快取機制（剛 PR 加的「進詳情再返回不 reload」）；新欄位也納入快取 key
+
+---
+
+## 7. 分期實作建議
+
+### Phase 1 — 已 ship（[PR #340](https://github.com/lt-foods/new_erp/pull/340)）
+- ✅ **A. 美食列車 banner**
+- ✅ **B. 限時專區 banner** → **改 horizontal carousel**（scroll-snap + dots + auto-play 4s + 觸碰暫停 8s）
+- ✅ **C. 取貨提醒條**（有 status='ready' 訂單才出現；amber 條置頂；點擊到 /orders）
+
+### Phase 2（之後再說）
+- **D. 公告跑馬燈** — 不做（用 LINE 群組 / OA 取代）
+- **E. 通知未讀鈴** — 不做（底部 tab 已 cover）
+- liff-api 合併 `get_shop_home` 多 payload — 半天（性能優化，需要時再做）
+
+### Phase 3（多分類後）
+- **F. 分類 icon grid** — 等 category 累積到 ≥4 個值
+
+### 不做（明確 out of scope）
+- **G. 搜尋列**：底部 tab 已 cover 主要 nav，grid 50 團內可滾，不急
+- **H. 熱門 carousel**：跟「最熱銷」tab 重疊
+- **I. 新會員 / 生日**：個人化複雜度高、目前 ROI 不明
+
+---
+
+## 8. 一些待你拍板的點
+
+1. **通知鈴位置**：要不要做？底部 tab 已有「通知」tab + 紅點 badge。多一個 header 鈴是 redundancy（好處：在 /shop 不用視線移到底部）
+2. **取貨提醒條**：是「滿足條件才出現」還是「永遠在最上方、0 時顯示『目前無待取貨』」？前者乾淨、後者更主動
+3. **雙 banner 順序**：「美食列車 在上、限時 在下」可接受嗎？還是反過來（限時通常更急迫）
+4. **公告跑馬燈**：需要嗎？團購店家常用群組 LINE 發公告，不一定要進 app
+
+請挑要做的、要刪的，下一輪我把 P1 那批做掉。

--- a/docs/TEST-food-train.md
+++ b/docs/TEST-food-train.md
@@ -1,0 +1,220 @@
+# food-train 測試項目 — 開團「美食列車」類別 + /shop 置頂專區 + 上架推播廣播
+
+**對應 migration:** `supabase/migrations/<new>_food_train_category.sql`
+**對應 RPC 變更:** `rpc_upsert_campaign` 加 `p_category`
+**對應 Edge Function 變更:** `supabase/functions/admin-notify/index.ts` 加 broadcast mode
+**對應 liff-api 變更:** `list_active_campaigns` 加 category 回傳 + filter
+**對應 UI 變更:**
+- `apps/admin/src/components/CampaignForm.tsx`（類別下拉）
+- `apps/admin/src/app/(protected)/campaigns/page.tsx`（badge + 篩選 + 觸發廣播）
+- `apps/member/src/app/shop/page.tsx`（頂部 banner）
+- `apps/member/src/app/shop/food-train/page.tsx`（新全列表頁）
+- `apps/member/src/components/CampaignCard.tsx`（badge）
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 group_buy_campaigns.category 欄位
+- [ ] 欄位存在、TEXT、NULL 可空、預設 NULL
+  ```sql
+  SELECT column_name, data_type, is_nullable, column_default
+    FROM information_schema.columns
+   WHERE table_name='group_buy_campaigns' AND column_name='category';
+  -- 預期: category | text | YES | NULL
+  ```
+- [ ] CHECK constraint 限定值（NULL 或 'food_train'）
+  ```sql
+  SELECT conname, pg_get_constraintdef(oid)
+    FROM pg_constraint
+   WHERE conrelid='group_buy_campaigns'::regclass
+     AND pg_get_constraintdef(oid) ILIKE '%category%';
+  -- 預期含: CHECK (category IS NULL OR category IN ('food_train'))
+  ```
+- [ ] 既有 campaign 的 category 一律為 NULL（migration 不該回填）
+  ```sql
+  SELECT COUNT(*) FROM group_buy_campaigns WHERE category IS NOT NULL;
+  -- migration 後預期: 0
+  ```
+
+### 1.2 rpc_upsert_campaign signature
+- [ ] 新 signature 含 `p_category TEXT DEFAULT NULL`，舊版本若 OR REPLACE 同 in/out 維持
+  ```sql
+  SELECT pg_get_function_arguments(oid)
+    FROM pg_proc WHERE proname='rpc_upsert_campaign';
+  -- 應含 "p_category text default null"
+  ```
+- [ ] EXECUTE grant 維持給 authenticated
+  ```sql
+  SELECT has_function_privilege('authenticated',
+    'rpc_upsert_campaign(bigint,text,text,text,text,text,timestamptz,timestamptz,timestamptz,integer,integer,text,text)',
+    'EXECUTE');
+  ```
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 新建 food_train campaign
+**情境：** 以 owner JWT 呼叫 `rpc_upsert_campaign(p_id:=NULL, p_category:='food_train', …)`
+**預期：** row 寫入、`category='food_train'`、`status='draft'`、無 CHECK 例外。
+
+### 2.2 新建 NULL category（向後相容）
+**情境：** 呼叫 `rpc_upsert_campaign(…, p_category:=NULL)`（或不傳）
+**預期：** row 寫入、`category IS NULL`、行為與既有完全一致。
+
+### 2.3 CHECK constraint 拒絕無效值
+**情境：** 直接 SQL `INSERT … category='kitchen_train'`
+**預期：** 23514 check_violation。
+
+### 2.4 編輯時不傳 p_category 維持原值（COALESCE）
+**情境：** food_train campaign 存在 → 呼叫 `rpc_upsert_campaign(p_id:=X)`（其餘欄位）不帶 p_category
+**預期：** category 維持 'food_train'，不被清成 NULL。
+
+### 2.5 編輯時 p_category=NULL 顯式清除
+**情境：** food_train campaign → 呼叫帶 `p_category:=NULL`
+**預期：** 視 RPC 實作而定 — 若沿用 COALESCE 則維持原值（測這個分支）。決策：MVP 不支援「清除回 NULL」，僅可在新建時設定；測試應驗證「重編輯 NULL 不蓋掉」。
+
+### 2.6 close_type 與 category 正交
+**情境：** 建立 `close_type='fast' + category='food_train'`
+**預期：** 同時存在；/shop 該團應同時出現在限時專區 hero 與美食列車區塊（前端兩處都看到）。
+
+### 2.7 跨 tenant 隔離
+**情境：** tenant A 建 food_train、tenant B 呼叫 listActiveCampaigns
+**預期：** B 看不到 A 的 food_train（RLS / tenant_id 過濾）。
+
+### 2.8 listActiveCampaigns 回傳 category
+**情境：** liff-api action='list_active_campaigns'
+**預期：** 每個 campaign payload 含 `category` 欄位（值為 NULL 或 'food_train'）。
+
+### 2.9 listActiveCampaigns 用 category 篩選
+**情境：** liff-api action='list_active_campaigns', `category:='food_train'`
+**預期：** 只回 category='food_train' 的 open 團，其他被濾掉。
+
+---
+
+## 3. admin-notify broadcast mode（Edge Function 直測）
+
+### 3.1 broadcast=true 全 tenant 廣播
+**情境：** POST admin-notify `{ broadcast:true, title:'美食列車新團', message:'XXX 開團了', url:'/shop/food-train' }`，tenant 內有 3 個 member、皆有 push subscription、皆 no_new_order=false
+**預期：** `notifications` 表新增 3 筆、每筆 member_id 對應；webpush 送 3 筆、回傳 `{ ok:true, sent:3 }`。
+
+### 3.2 broadcast 排除 no_new_order=true
+**情境：** 3 個 member 中 1 個 `no_new_order=true`
+**預期：** `notifications` 新增 2 筆、push 送 2 筆；不通知的那位 notifications 表查不到本次新 row。
+
+### 3.3 broadcast 排除 status≠'active'
+**情境：** 1 個 member status='inactive' 或 GDPR 軟刪
+**預期：** 不寫 notifications、不送 push。
+
+### 3.4 broadcast 對 0 push subscription 也 ok
+**情境：** 某 member 已寫 notifications 但無 push_subscriptions row
+**預期：** notifications 仍新增、push 該 member 跳過、整體 200、`sent` 計數不含該員、無 5xx。
+
+### 3.5 既有 single-member 模式不受影響
+**情境：** POST `{ member_id: X, title, message }`（無 broadcast 欄位）
+**預期：** 行為與 PR #257 取貨通知一致；`pickup notify` 既有流程仍綠。
+
+### 3.6 broadcast 需 hq / owner / admin role
+**情境：** 以 store_clerk JWT 呼叫 broadcast
+**預期：** 401/403 拒絕；不寫 notifications、不送 push。
+
+### 3.7 verify_jwt 設定確認
+- [ ] config.toml `[functions.admin-notify]` 維持預設（或顯式 verify_jwt=true）；admin 走 supabase session JWT 呼叫
+- [ ] member 端 LIFF 不能呼叫此函式（前端應無此呼叫路徑）
+
+---
+
+## 4. Admin UI 行為（preview 互動）
+
+### 4.1 CampaignForm「類別」下拉
+- [ ] `/campaigns` → 「新增開團」modal 開啟，類別下拉 render，選項：「無」/「美食列車」
+- [ ] 預設值為「無」（NULL）
+- [ ] 選「美食列車」後儲存 → DB `category='food_train'`
+- [ ] 編輯既有 food_train campaign → 下拉回顯「美食列車」
+- [ ] 編輯既有 NULL campaign → 下拉回顯「無」
+
+### 4.2 列表頁 badge
+- [ ] `/campaigns` 列表，food_train 列顯示綠色（或品牌色）「美食列車」badge
+- [ ] NULL category 列不顯示 badge（不能誤渲染空 badge）
+- [ ] 月曆 / 週曆視圖（如已存在）也帶 badge
+
+### 4.3 列表頁類別篩選
+- [ ] 篩選器加「類別」維度（全部 / 美食列車 / 一般）
+- [ ] 篩選「美食列車」→ 只剩 food_train 列
+
+### 4.4 儲存觸發廣播
+- [ ] 新建 food_train 並直接 status='open' → 儲存後 admin-notify broadcast 被呼叫一次
+  - [ ] 觀察 Network panel 有 POST `/functions/v1/admin-notify` 200
+  - [ ] `notifications` 表收到對應筆數
+- [ ] draft → open 編輯儲存（food_train）→ 觸發廣播一次
+- [ ] 已 open 的 food_train 再次儲存（其他欄位變更）→ **不**再觸發廣播
+- [ ] 非 food_train（NULL category）的 draft → open 儲存 → **不**觸發廣播
+- [ ] 廣播失敗（網路/權限）→ UI 顯示警告但不阻擋儲存成功（避免儲存失敗丟資料）
+
+### 4.5 跨頁 regression
+- [ ] 編輯 regular / fast / limited 既有團（皆 NULL category），下拉維持「無」、儲存後其餘欄位不變
+
+---
+
+## 5. Member /shop UI
+
+### 5.1 /shop 頂部「美食列車」banner
+- [ ] 有 ≥1 個 open + food_train → banner 渲染
+- [ ] banner 在「限時專區」banner **之上**
+- [ ] banner 樣式（綠或品牌色，與限時專區可分辨）
+- [ ] 點 banner → 導向 `/shop/food-train`
+- [ ] 0 個 food_train open → banner **不**渲染
+- [ ] 同時有 fast + food_train → 兩個 banner 都顯示
+
+### 5.2 /shop/food-train 全列表頁
+- [ ] 頁面渲染（PageShell title="美食列車"）
+- [ ] 列表只顯示 category='food_train' 且 status='open'
+- [ ] 空狀態文案（仿 /shop/flash）
+- [ ] 列表項目樣式（hero + row，或同 /shop/flash pattern）
+- [ ] 點商品卡 → 進 `/shop/c/[id]` 詳情頁
+
+### 5.3 CampaignCard food_train badge
+- [ ] grid variant 顯示 badge
+- [ ] hero variant 顯示 badge
+- [ ] NULL category 不顯示
+
+### 5.4 推播落地（顧客端）
+- [ ] 觸發 broadcast 後，顧客 `/notifications` 出現該筆
+- [ ] 點通知 → 跳轉 `/shop/food-train`
+- [ ] PWA 已訂閱推播 → 收到系統通知（iOS PWA 16.4+ 測，依 [[reference_ios_pwa_push_gotchas]]）
+
+---
+
+## 6. Regression
+
+- [ ] `/shop` 限時專區 banner 仍正常（無 food_train 時不被新邏輯影響）
+- [ ] `/shop/flash` 頁面仍綠
+- [ ] 既有 regular / fast / limited campaign 編輯保存後 category 一律維持 NULL
+- [ ] `rpc_upsert_campaign` 既有所有呼叫處（finalize、rpc_schedule_candidate、restock）皆能不傳 p_category 正常編譯與執行
+- [ ] admin-notify 取貨通知（apps/admin/src/app/(protected)/pickup/page.tsx）single member 模式 send=1 仍綠
+- [ ] CampaignThumb / CampaignOrdersPanel 不受 category 影響
+
+---
+
+## 7. RLS / 顧客可讀
+
+- [ ] anon JWT（或 liff-api 走 service_role 後過濾 tenant）能 select category
+  ```sql
+  SET LOCAL ROLE anon;
+  SET LOCAL request.jwt.claims = '{"tenant_id":"<T>"}';
+  SELECT id, category FROM group_buy_campaigns LIMIT 1;
+  ```
+- [ ] 跨 tenant 仍被 RLS 擋
+
+---
+
+## 驗收門檻
+
+全部 §1-§7 勾完、**無 console error**、**Supabase prod SQL 套用成功**、**admin build + tsc 過**、**run-feature-tests 報告全綠** 才可標 done。
+
+**Out of scope（未來再做）：**
+- 推播排程（指定時間發）
+- 多個 category 值（如 生鮮 / 衣物）— 本期僅 food_train 一值
+- broadcast 取消按鈕 / 補發按鈕
+- 美食列車「限定商品」或專屬定價規則

--- a/supabase/functions/admin-notify/index.ts
+++ b/supabase/functions/admin-notify/index.ts
@@ -45,17 +45,103 @@ Deno.serve(async (req) => {
     }
 
     const body = await req.json();
-    const { member_id, title, message, url, category } = body;
+    const { member_id, title, message, url, category, broadcast } = body;
 
+    const payloadTitle = title || "通知";
+    const payloadBody = message ?? null;
+    const notifCategory = typeof category === "string" && category ? category : "general";
+
+    webpush.setVapidDetails(
+      "mailto:admin@new-erp.com",
+      requireEnv("VAPID_PUBLIC_KEY"),
+      requireEnv("VAPID_PRIVATE_KEY")
+    );
+
+    // ── Broadcast mode: 對整 tenant 的 active 會員發 ─────────────────────────
+    if (broadcast === true) {
+      const role = user.app_metadata?.role;
+      if (role !== "owner" && role !== "admin" && role !== "hq") {
+        return json({ error: "broadcast requires owner/admin/hq role" }, 403);
+      }
+
+      const { data: members, error: memErr } = await sb
+        .from("members")
+        .select("id")
+        .eq("tenant_id", tenantId)
+        .eq("status", "active")
+        .or("no_new_order.is.null,no_new_order.eq.false")
+        .is("merged_into_member_id", null);
+
+      if (memErr) return json({ error: memErr.message }, 500);
+      const memberIds = (members ?? []).map((m: { id: number }) => m.id);
+      if (memberIds.length === 0) {
+        return json({ ok: true, sent: 0, recipients: 0, message: "no eligible members" });
+      }
+
+      // Bulk insert notifications
+      const notifRows = memberIds.map((mid) => ({
+        tenant_id: tenantId,
+        member_id: mid,
+        category: notifCategory,
+        title: payloadTitle,
+        body: payloadBody,
+        url: url ?? null,
+      }));
+      const { error: notifErr } = await sb.from("notifications").insert(notifRows);
+      if (notifErr) console.error("broadcast notifications insert failed:", notifErr.message);
+
+      // Fetch subscriptions for these members
+      const { data: subs, error: subErr } = await sb
+        .from("push_subscriptions")
+        .select("endpoint, p256dh, auth, member_id")
+        .eq("tenant_id", tenantId)
+        .in("member_id", memberIds);
+      if (subErr) return json({ error: subErr.message }, 500);
+
+      const subList = subs ?? [];
+      if (subList.length === 0) {
+        return json({
+          ok: true,
+          sent: 0,
+          recipients: memberIds.length,
+          message: "notifications recorded; no active push subscriptions",
+        });
+      }
+
+      const pushPayload = JSON.stringify({
+        title: payloadTitle,
+        body: payloadBody ?? "",
+        url: url || "/",
+      });
+      const results = await Promise.allSettled(
+        subList.map((s: any) =>
+          webpush.sendNotification(
+            { endpoint: s.endpoint, keys: { p256dh: s.p256dh, auth: s.auth } },
+            pushPayload
+          )
+        )
+      );
+      const successCount = results.filter((r) => r.status === "fulfilled").length;
+      const failCount = results.filter((r) => r.status === "rejected").length;
+      return json({
+        ok: true,
+        sent: successCount,
+        failed: failCount,
+        recipients: memberIds.length,
+        subscriptions: subList.length,
+      });
+    }
+
+    // ── Single-member mode (既有行為, 不變) ─────────────────────────────────
     if (!member_id) return json({ error: "member_id is required" }, 400);
 
     // 寫一筆 in-app notification(就算沒 push subscription 也要寫,顧客還是看得到)
     const { error: notifErr } = await sb.from("notifications").insert({
       tenant_id: tenantId,
       member_id,
-      category: typeof category === "string" && category ? category : "general",
-      title: title || "通知",
-      body: message ?? null,
+      category: notifCategory,
+      title: payloadTitle,
+      body: payloadBody,
       url: url ?? null,
     });
     if (notifErr) console.error("notifications insert failed:", notifErr.message);
@@ -72,12 +158,6 @@ Deno.serve(async (req) => {
       return json({ ok: true, sent: 0, message: "Notification recorded; no active PWA subscriptions to push" });
     }
 
-    webpush.setVapidDetails(
-      "mailto:admin@new-erp.com",
-      requireEnv("VAPID_PUBLIC_KEY"),
-      requireEnv("VAPID_PRIVATE_KEY")
-    );
-
     const results = await Promise.allSettled(
       subs.map((s: any) =>
         webpush.sendNotification(
@@ -86,8 +166,8 @@ Deno.serve(async (req) => {
             keys: { p256dh: s.p256dh, auth: s.auth },
           },
           JSON.stringify({
-            title: title || "測試通知",
-            body: message || "這是一則來自管理員的測試通知。",
+            title: payloadTitle,
+            body: payloadBody ?? "",
             url: url || "/",
           })
         )
@@ -96,9 +176,6 @@ Deno.serve(async (req) => {
 
     const successCount = results.filter((r) => r.status === "fulfilled").length;
     const failCount = results.filter((r) => r.status === "rejected").length;
-
-    // Optional: Cleanup failed subscriptions (e.g. 410 Gone)
-    // For a test button, we might just report back.
 
     return json({
       ok: true,

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -293,7 +293,7 @@ async function listMySettlements(sb: any, tenantId: string, _storeId: number, me
   return json({ settlements: data ?? [] });
 }
 
-async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string | null, category?: string | null) {
+async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string | null, category?: string | null, memberId?: number | null) {
   // end_at IS NULL 表示「無到期日」(管理員未設),也算進行中,要保留
   let q = sb
     .from("group_buy_campaigns")
@@ -381,7 +381,20 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
       max_price: prices.length > 0 ? Math.max(...prices) : 0,
     };
   });
-  return json({ campaigns });
+
+  // 取貨提醒: 該會員「已備貨可取」(status='ready') 的訂單數
+  let pendingPickupCount = 0;
+  if (memberId) {
+    const { count } = await sb
+      .from("customer_orders")
+      .select("id", { count: "exact", head: true })
+      .eq("tenant_id", tenantId)
+      .eq("member_id", memberId)
+      .eq("status", "ready");
+    pendingPickupCount = count ?? 0;
+  }
+
+  return json({ campaigns, pending_pickup_count: pendingPickupCount });
 }
 
 async function getCampaignDetail(sb: any, tenantId: string, campaignId: number) {
@@ -767,7 +780,7 @@ Deno.serve(async (req) => {
       case "get_my_unread_notification_count": if (!memberId) return json({ error: "no member_id" }, 401); return await getMyUnreadNotificationCount(sb, tenantId, memberId);
       case "mark_notification_read": if (!memberId) return json({ error: "no member_id" }, 401); return await markNotificationRead(sb, tenantId, memberId, body);
       case "generate_pwa_auth_code": if (!memberId) return json({ error: "no member_id" }, 401); return await generatePwaAuthCode(sb, tenantId, memberId, claims, token, body);
-      case "list_active_campaigns": return await listActiveCampaigns(sb, tenantId, typeof body.close_type === "string" ? body.close_type : null, typeof body.category === "string" ? body.category : null);
+      case "list_active_campaigns": return await listActiveCampaigns(sb, tenantId, typeof body.close_type === "string" ? body.close_type : null, typeof body.category === "string" ? body.category : null, memberId);
       case "get_campaign_detail": return await getCampaignDetail(sb, tenantId, Number(body.campaign_id ?? 0));
       case "place_member_order": if (!memberId) return json({ error: "no member_id" }, 401); return await placeMemberOrder(sb, tenantId, memberId, body);
       default: return json({ error: `unknown action: ${action}` }, 400);

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -293,17 +293,18 @@ async function listMySettlements(sb: any, tenantId: string, _storeId: number, me
   return json({ settlements: data ?? [] });
 }
 
-async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string | null) {
+async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string | null, category?: string | null) {
   // end_at IS NULL 表示「無到期日」(管理員未設),也算進行中,要保留
   let q = sb
     .from("group_buy_campaigns")
-    .select("id, campaign_no, name, description, cover_image_url, close_type, total_cap_qty, end_at, pickup_deadline, campaign_items(unit_price, sort_order, sku:skus(product:products(images)))")
+    .select("id, campaign_no, name, description, cover_image_url, close_type, category, total_cap_qty, end_at, pickup_deadline, campaign_items(unit_price, sort_order, sku:skus(product:products(images)))")
     .eq("tenant_id", tenantId)
     .eq("status", "open")
     // 排除內部 sentinel 活動(補貨申請),不應出現在顧客商店
     .neq("campaign_no", "__INTERNAL_RESTOCK__")
     .or(`end_at.is.null,end_at.gt.${new Date().toISOString()}`);
   if (closeType) q = q.eq("close_type", closeType);
+  if (category) q = q.eq("category", category);
   const { data, error } = await q
     .order("end_at", { ascending: true, nullsFirst: false })
     .limit(50);
@@ -368,6 +369,7 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
       description: c.description,
       cover_image_url: cover,
       close_type: c.close_type,
+      category: c.category ?? null,
       total_cap_qty: c.total_cap_qty,
       ordered_qty: orderedMap.get(Number(c.id)) ?? 0,
       order_count: countMap.get(Number(c.id)) ?? 0,
@@ -765,7 +767,7 @@ Deno.serve(async (req) => {
       case "get_my_unread_notification_count": if (!memberId) return json({ error: "no member_id" }, 401); return await getMyUnreadNotificationCount(sb, tenantId, memberId);
       case "mark_notification_read": if (!memberId) return json({ error: "no member_id" }, 401); return await markNotificationRead(sb, tenantId, memberId, body);
       case "generate_pwa_auth_code": if (!memberId) return json({ error: "no member_id" }, 401); return await generatePwaAuthCode(sb, tenantId, memberId, claims, token, body);
-      case "list_active_campaigns": return await listActiveCampaigns(sb, tenantId, typeof body.close_type === "string" ? body.close_type : null);
+      case "list_active_campaigns": return await listActiveCampaigns(sb, tenantId, typeof body.close_type === "string" ? body.close_type : null, typeof body.category === "string" ? body.category : null);
       case "get_campaign_detail": return await getCampaignDetail(sb, tenantId, Number(body.campaign_id ?? 0));
       case "place_member_order": if (!memberId) return json({ error: "no member_id" }, 401); return await placeMemberOrder(sb, tenantId, memberId, body);
       default: return json({ error: `unknown action: ${action}` }, 400);

--- a/supabase/migrations/20260626000000_food_train_category.sql
+++ b/supabase/migrations/20260626000000_food_train_category.sql
@@ -1,0 +1,97 @@
+-- ============================================================================
+-- 開團「美食列車」類別
+--   group_buy_campaigns 新增 category 欄位 (主題分類, 與 close_type 正交)
+--   rpc_upsert_campaign 加 p_category 參數 (COALESCE 維持向後相容)
+--
+-- 為何不用 DB trigger 觸發推播:
+--   1. broadcast 放大效應大 (整 tenant 會員), 在 DB 觸發失敗排查困難
+--   2. 避免 pg_net 依賴; admin 端 client-side 觸發更可控
+--   3. 失敗時 admin UI 可顯示 toast, 不阻擋儲存
+-- ============================================================================
+
+-- ── 1. group_buy_campaigns.category 欄位 ────────────────────────────────────
+ALTER TABLE group_buy_campaigns
+  ADD COLUMN IF NOT EXISTS category TEXT NULL;
+
+-- CHECK constraint: NULL 或 'food_train' (未來擴充再加新值)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'group_buy_campaigns'::regclass
+       AND conname = 'group_buy_campaigns_category_chk'
+  ) THEN
+    ALTER TABLE group_buy_campaigns
+      ADD CONSTRAINT group_buy_campaigns_category_chk
+      CHECK (category IS NULL OR category IN ('food_train'));
+  END IF;
+END $$;
+
+COMMENT ON COLUMN group_buy_campaigns.category IS
+  '開團主題分類 (與 close_type 正交); NULL=一般, food_train=美食列車';
+
+-- ── 2. rpc_upsert_campaign 加 p_category 參數 ──────────────────────────────
+-- PostgreSQL 加 DEFAULT 參數會形成 overload, 先 DROP 舊 signature 再重建
+DROP FUNCTION IF EXISTS public.rpc_upsert_campaign(
+  BIGINT, TEXT, TEXT, TEXT, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ,
+  DATE, INTEGER, NUMERIC, TEXT
+);
+
+CREATE OR REPLACE FUNCTION public.rpc_upsert_campaign(
+  p_id               BIGINT,
+  p_campaign_no      TEXT,
+  p_name             TEXT,
+  p_description      TEXT        DEFAULT NULL,
+  p_cover_image_url  TEXT        DEFAULT NULL,
+  p_status           TEXT        DEFAULT 'draft',
+  p_close_type       TEXT        DEFAULT 'regular',
+  p_start_at         TIMESTAMPTZ DEFAULT NULL,
+  p_end_at           TIMESTAMPTZ DEFAULT NULL,
+  p_pickup_deadline  DATE        DEFAULT NULL,
+  p_pickup_days      INTEGER     DEFAULT NULL,
+  p_total_cap_qty    NUMERIC     DEFAULT NULL,
+  p_notes            TEXT        DEFAULT NULL,
+  p_category         TEXT        DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_id     BIGINT;
+BEGIN
+  IF p_id IS NULL THEN
+    INSERT INTO group_buy_campaigns (
+      tenant_id, campaign_no, name, description, cover_image_url,
+      status, close_type, start_at, end_at, pickup_deadline, pickup_days,
+      total_cap_qty, notes, category, created_by, updated_by
+    ) VALUES (
+      v_tenant, p_campaign_no, p_name, p_description, p_cover_image_url,
+      COALESCE(p_status,'draft'), COALESCE(p_close_type,'regular'),
+      p_start_at, p_end_at, p_pickup_deadline, p_pickup_days,
+      p_total_cap_qty, p_notes, p_category, auth.uid(), auth.uid()
+    ) RETURNING id INTO v_id;
+  ELSE
+    UPDATE group_buy_campaigns SET
+      campaign_no = COALESCE(p_campaign_no, campaign_no),
+      name = COALESCE(p_name, name),
+      description = p_description,
+      cover_image_url = p_cover_image_url,
+      status = COALESCE(p_status, status),
+      close_type = COALESCE(p_close_type, close_type),
+      start_at = p_start_at,
+      end_at = p_end_at,
+      pickup_deadline = p_pickup_deadline,
+      pickup_days = p_pickup_days,
+      total_cap_qty = p_total_cap_qty,
+      notes = p_notes,
+      category = COALESCE(p_category, category),  -- 不傳則維持原值, 顯式清回 NULL 不支援
+      updated_by = auth.uid()
+    WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'campaign % not in tenant', p_id; END IF;
+  END IF;
+  RETURN v_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_upsert_campaign TO authenticated;


### PR DESCRIPTION
## Summary
- 新增開團「主題分類」維度 `category`，本期僅 `food_train`（美食列車）一值；與既有 `close_type`（regular/fast/limited）正交，可組合
- 後台儲存「美食列車 + status 跨越 → open」時，自動推播給整個 tenant 的會員（in-app notification + Web Push 雙軌）
- 顧客 PWA `/shop` 最上方新增綠色「美食列車」banner（在限時專區之上），點進新 `/shop/food-train` 全列表頁

## 改動範圍
- **DB**: `group_buy_campaigns.category TEXT NULL` + CHECK；`rpc_upsert_campaign` 加 `p_category`（COALESCE 維持原值，避免編輯時誤清）
- **Edge Functions**:
  - `admin-notify` 新增 broadcast mode（`body.broadcast=true`）：排除 `no_new_order=true` / 非 active / 已軟刪會員；角色守門 owner/admin/hq
  - `liff-api` `list_active_campaigns` 回傳 `category` + 新增 `category` 篩選參數
- **Admin UI**: `CampaignForm` 加類別下拉、`/campaigns` 列表加 badge + 類別篩選器；儲存後若達到推播條件呼叫 admin-notify broadcast（失敗不阻擋儲存，僅警告）
- **Member UI**: `/shop` 頂部 banner、新 `/shop/food-train` 頁、`CampaignCard` food_train badge（hero + grid）
- **Tests**: [docs/TEST-food-train.md](docs/TEST-food-train.md) 48 項測試清單分 7 段（schema / RPC / broadcast / admin / member / regression / RLS）

## 推播觸發點（不用 DB trigger 的原因）
- 廣播放大效應大（整 tenant 會員），DB 端失敗排查困難
- 避免 pg_net 依賴
- admin client 端觸發失敗時可以 toast 警告但不阻擋儲存

## 部署步驟（merge 後）
1. **DB migration**：套用 [supabase/migrations/20260626000000_food_train_category.sql](supabase/migrations/20260626000000_food_train_category.sql)（Studio 貼 SQL 或 \`apply_one_migration.cjs\`）
2. **Edge Functions** 部署：
   - \`supabase functions deploy admin-notify\`
   - \`supabase functions deploy liff-api\`
3. **前端**：admin + member 隨下次 build 一起出
4. 確認 VAPID 環境變數已設（既有，本 PR 未動）

## Test plan
- [ ] DB migration 在 prod 套用成功；既有 campaign 全部 category=NULL
- [ ] 新建 food_train 開團、status=open 儲存 → 收到 in-app notification + Web Push
- [ ] 同一筆食物列車重複儲存 status=open → **不**重複觸發推播
- [ ] 非 food_train 開團 status→open 儲存 → 不觸發推播
- [ ] `/shop` 有 ≥1 個 food_train 時，頂部綠色 banner 出現在限時專區之上
- [ ] `/shop/food-train` 全列表頁正常渲染；空狀態 fallback 正常
- [ ] CampaignCard 在 hero / grid 兩 variant 都顯示綠色「美食列車」badge
- [ ] 限時專區 / `/shop/flash` 既有行為無 regression
- [ ] 取貨通知（admin-notify single member 模式）無 regression
- [ ] 走完 [docs/TEST-food-train.md](docs/TEST-food-train.md) 全部 48 項

🤖 Generated with [Claude Code](https://claude.com/claude-code)