### PR TITLE
Remove limit(50) from listActiveCampaigns query

### DIFF
--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -305,9 +305,11 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
     .or(`end_at.is.null,end_at.gt.${new Date().toISOString()}`);
   if (closeType) q = q.eq("close_type", closeType);
   if (category) q = q.eq("category", category);
+  // 不加 limit：曾經 .limit(50) 在 open 團數超過 50 時把最晚結單的整批截掉
+  // （end_at ASC NULLS LAST + 截 50），顧客端整個團就消失。PostgREST 仍有
+  // db-max-rows=1000 兜底，55 個團也才一頁。
   const { data, error } = await q
-    .order("end_at", { ascending: true, nullsFirst: false })
-    .limit(50);
+    .order("end_at", { ascending: true, nullsFirst: false });
 
   // 算出 campaign 已下單總量 (排除取消/逾期 + 排除負數抵減單),
   // 給前端算「剩 N 份」、「搶購一空」或顯示「已售出 N 份」


### PR DESCRIPTION
## Summary
Removed the `.limit(50)` constraint from the `listActiveCampaigns` function to prevent active campaigns from being unexpectedly truncated when there are more than 50 open campaigns.

## Key Changes
- Removed `.limit(50)` from the campaign query in `listActiveCampaigns()`
- Kept the `.order("end_at", { ascending: true, nullsFirst: false })` ordering to maintain consistent campaign ordering
- Added explanatory comments documenting why the limit was removed

## Implementation Details
The previous implementation with `.limit(50)` was causing entire campaign batches to disappear from the customer-facing interface when the number of open campaigns exceeded 50. This occurred because the limit was applied after ordering by `end_at ASC NULLS LAST`, which would truncate the latest closing campaigns.

The PostgREST API has a built-in safety limit (`db-max-rows=1000`), which provides adequate protection. With 55 campaigns fitting within a single page, removing the explicit limit is safe while preventing the data loss issue.

https://claude.ai/code/session_01LRDVnnFrqZCQdpqJBD5qmA