### PR TITLE
refactor(food-train): 美食列車改成 close_type 第 4 值

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -39,8 +39,7 @@ async function fetchAll<T>(builder: () => any, pageSize = 1000, maxPages = 50): 
 
 type Status = CampaignStatus;
 
-type CloseType = "regular" | "fast" | "limited";
-type Category = "food_train" | null;
+type CloseType = "regular" | "fast" | "limited" | "food_train";
 
 type Row = {
   id: number;
@@ -48,7 +47,6 @@ type Row = {
   name: string;
   status: Status;
   close_type: CloseType;
-  category: Category;
   start_at: string | null;
   end_at: string | null;
   pickup_deadline: string | null;
@@ -63,19 +61,13 @@ const CLOSE_TYPE_LABEL: Record<CloseType, string> = {
   regular: "常規",
   fast: "快團",
   limited: "限量",
+  food_train: "美食列車",
 };
 
 const CLOSE_TYPE_BADGE: Record<CloseType, string> = {
   regular: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
   fast: "bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-300",
   limited: "bg-pink-100 text-pink-800 dark:bg-pink-950 dark:text-pink-300",
-};
-
-const CATEGORY_LABEL: Record<"food_train", string> = {
-  food_train: "美食列車",
-};
-
-const CATEGORY_BADGE: Record<"food_train", string> = {
   food_train: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
 };
 
@@ -133,7 +125,7 @@ export default function CampaignsListPage() {
   const [queryDraft, setQueryDraft] = useState("");
   const [query, setQuery] = useState("");
   const [status, setStatus] = useState<string>("");
-  const [categoryFilter, setCategoryFilter] = useState<string>(""); // ""=全部 / "food_train" / "none"
+  const [closeTypeFilter, setCloseTypeFilter] = useState<string>(""); // ""=全部 / regular / fast / limited / food_train
   const [page, setPage] = useState(1);
 
   const [itemCounts, setItemCounts] = useState<Map<number, number>>(new Map());
@@ -309,7 +301,7 @@ export default function CampaignsListPage() {
   async function openEdit(id: number) {
     const { data, error: err } = await getSupabase()
       .from("group_buy_campaigns")
-      .select("id, campaign_no, name, description, status, close_type, category, start_at, end_at, pickup_deadline, pickup_days, total_cap_qty, notes")
+      .select("id, campaign_no, name, description, status, close_type, start_at, end_at, pickup_deadline, pickup_days, total_cap_qty, notes")
       .eq("id", id).maybeSingle();
     if (err || !data) { setError(err?.message ?? "找不到開團"); return; }
     setModal({
@@ -321,7 +313,6 @@ export default function CampaignsListPage() {
         description: data.description,
         status: data.status as CampaignFormValues["status"],
         close_type: data.close_type as CampaignFormValues["close_type"],
-        category: (data.category ?? null) as CampaignFormValues["category"],
         start_at: data.start_at,
         end_at: data.end_at,
         pickup_deadline: data.pickup_deadline,
@@ -338,7 +329,7 @@ export default function CampaignsListPage() {
   }, [queryDraft]);
 
   useEffect(() => { setPage(1); }, [status]);
-  useEffect(() => { setPage(1); }, [categoryFilter]);
+  useEffect(() => { setPage(1); }, [closeTypeFilter]);
 
   useEffect(() => {
     let cancelled = false;
@@ -347,7 +338,7 @@ export default function CampaignsListPage() {
       try {
         let q = getSupabase()
           .from("group_buy_campaigns")
-          .select("id, campaign_no, name, status, close_type, category, start_at, end_at, pickup_deadline, updated_at, cover_image_url, campaign_items(sort_order, sku:skus(product:products(images)))", { count: "exact" })
+          .select("id, campaign_no, name, status, close_type, start_at, end_at, pickup_deadline, updated_at, cover_image_url, campaign_items(sort_order, sku:skus(product:products(images)))", { count: "exact" })
           .neq("campaign_no", "__INTERNAL_RESTOCK__")
           .order("start_at", { ascending: false, nullsFirst: false })
           .order("id", { ascending: false })
@@ -357,8 +348,7 @@ export default function CampaignsListPage() {
           q = q.or(`name.ilike.%${safe}%,campaign_no.ilike.%${safe}%`);
         }
         if (status) q = q.eq("status", status);
-        if (categoryFilter === "food_train") q = q.eq("category", "food_train");
-        else if (categoryFilter === "none") q = q.is("category", null);
+        if (closeTypeFilter) q = q.eq("close_type", closeTypeFilter);
 
         const { data, count, error } = await q;
         if (cancelled) return;
@@ -414,7 +404,7 @@ export default function CampaignsListPage() {
       }
     })();
     return () => { cancelled = true; };
-  }, [query, status, categoryFilter, page, reloadTick]);
+  }, [query, status, closeTypeFilter, page, reloadTick]);
 
   // Calendar (week / month) 取資料：依視圖決定範圍
   useEffect(() => {
@@ -604,12 +594,14 @@ export default function CampaignsListPage() {
             <option value="">全部狀態</option>
             {Object.entries(STATUS_LABEL).map(([v, l]) => <option key={v} value={v}>{l}</option>)}
           </select>
-          <select value={categoryFilter} onChange={(e) => setCategoryFilter(e.target.value)}
+          <select value={closeTypeFilter} onChange={(e) => setCloseTypeFilter(e.target.value)}
             className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-            aria-label="類別篩選">
-            <option value="">全部類別</option>
+            aria-label="收單類型篩選">
+            <option value="">全部類型</option>
+            <option value="regular">常規</option>
+            <option value="fast">快團</option>
+            <option value="limited">限量</option>
             <option value="food_train">美食列車</option>
-            <option value="none">一般（無類別）</option>
           </select>
         </div>
       )}
@@ -740,11 +732,6 @@ export default function CampaignsListPage() {
                   <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CLOSE_TYPE_BADGE[r.close_type]}`}>
                     {CLOSE_TYPE_LABEL[r.close_type]}
                   </span>
-                  {r.category && (
-                    <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CATEGORY_BADGE[r.category]}`}>
-                      {CATEGORY_LABEL[r.category]}
-                    </span>
-                  )}
                 </div>
               </div>
             </div>
@@ -828,16 +815,9 @@ export default function CampaignsListPage() {
                 <Td className="min-w-[14rem]">{r.name}</Td>
                 <Td className="whitespace-nowrap"><StatusBadge s={r.status} /></Td>
                 <Td>
-                  <div className="flex flex-wrap items-center gap-1">
-                    <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CLOSE_TYPE_BADGE[r.close_type]}`}>
-                      {CLOSE_TYPE_LABEL[r.close_type]}
-                    </span>
-                    {r.category && (
-                      <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CATEGORY_BADGE[r.category]}`}>
-                        {CATEGORY_LABEL[r.category]}
-                      </span>
-                    )}
-                  </div>
+                  <span className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${CLOSE_TYPE_BADGE[r.close_type]}`}>
+                    {CLOSE_TYPE_LABEL[r.close_type]}
+                  </span>
                 </Td>
                 <Td className="whitespace-nowrap text-xs text-zinc-500">
                   {fmtDateTime(r.start_at)}

--- a/apps/admin/src/components/CampaignForm.tsx
+++ b/apps/admin/src/components/CampaignForm.tsx
@@ -8,12 +8,7 @@ import { useRole, isAdmin } from "@/lib/role";
 import { CAMPAIGN_STATUS_LABEL, type CampaignStatus } from "@/lib/campaignStatus";
 
 export type { CampaignStatus };
-export type CloseType = "regular" | "fast" | "limited";
-export type CampaignCategory = "food_train" | null;
-
-export const CATEGORY_LABEL: Record<"food_train", string> = {
-  food_train: "美食列車",
-};
+export type CloseType = "regular" | "fast" | "limited" | "food_train";
 
 export type CampaignFormValues = {
   id: number | null;
@@ -22,7 +17,6 @@ export type CampaignFormValues = {
   description: string | null;
   status: CampaignStatus;
   close_type: CloseType;
-  category: CampaignCategory;
   start_at: string | null;
   end_at: string | null;
   pickup_deadline: string | null;
@@ -38,7 +32,6 @@ export const emptyCampaignValues: CampaignFormValues = {
   description: null,
   status: "draft",
   close_type: "regular",
-  category: null,
   start_at: null,
   end_at: null,
   pickup_deadline: null,
@@ -129,14 +122,13 @@ export function CampaignForm({
         p_pickup_days: v.pickup_days,
         p_total_cap_qty: v.total_cap_qty,
         p_notes: v.notes,
-        p_category: v.category,
       });
       if (err) throw err;
       const newId = Number(data);
 
       // 美食列車且 status 從非 open → open 時, 廣播推播給全 tenant 顧客
       // (失敗不阻擋儲存; 顯示警告但仍視為成功)
-      if (v.category === "food_train" && v.status === "open" && !wasOpen) {
+      if (v.close_type === "food_train" && v.status === "open" && !wasOpen) {
         try {
           await broadcastFoodTrainOpen({
             campaignId: newId,
@@ -191,18 +183,9 @@ export function CampaignForm({
             <option value="regular">常規</option>
             <option value="fast">快團</option>
             <option value="limited">限量</option>
-          </select>
-        </Field>
-        <Field label="類別">
-          <select
-            value={v.category ?? ""}
-            onChange={(e) => update("category", (e.target.value || null) as CampaignCategory)}
-            className={inputCls}
-          >
-            <option value="">無</option>
             <option value="food_train">美食列車</option>
           </select>
-          {v.category === "food_train" && v.status === "open" && (initial?.status ?? null) !== "open" && (
+          {v.close_type === "food_train" && v.status === "open" && (initial?.status ?? null) !== "open" && (
             <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400">
               儲存後將推播給所有未取消通知的顧客。
             </p>

--- a/apps/member/src/app/shop/food-train/page.tsx
+++ b/apps/member/src/app/shop/food-train/page.tsx
@@ -25,7 +25,7 @@ export default function FoodTrainPage() {
       try {
         const d = await callLiffApi<{ campaigns: CampaignSummary[] }>(s.token, {
           action: "list_active_campaigns",
-          category: "food_train",
+          close_type: "food_train",
         });
         setCampaigns(d.campaigns);
       } catch (e) {

--- a/apps/member/src/app/shop/page.tsx
+++ b/apps/member/src/app/shop/page.tsx
@@ -126,9 +126,9 @@ export default function ShopPage() {
   // find 取到的就是最快結單的快閃團。
   const hero = visible.find((c) => c.close_type === "fast");
 
-  // 美食列車專區：有任何 category='food_train' 的開團時顯示綠色 banner
-  const foodTrainHero = visible.find((c) => c.category === "food_train");
-  const foodTrainCount = visible.filter((c) => c.category === "food_train").length;
+  // 美食列車專區：close_type='food_train' 的開團時顯示綠色 banner
+  const foodTrainHero = visible.find((c) => c.close_type === "food_train");
+  const foodTrainCount = visible.filter((c) => c.close_type === "food_train").length;
 
   // 排序：最新(id 大→小，無 created_at 用 id 近似) / 最熱銷(全分店訂單數)
   // / 近期售出(近 7 天訂單數)。tie-break 回退 id desc 保持穩定。

--- a/apps/member/src/components/CampaignCard.tsx
+++ b/apps/member/src/components/CampaignCard.tsx
@@ -10,9 +10,7 @@ export type CampaignSummary = {
   name: string;
   description: string | null;
   cover_image_url: string | null;
-  close_type: "regular" | "fast" | "limited" | string;
-  /** 主題分類; NULL=一般, food_train=美食列車 */
-  category?: "food_train" | null;
+  close_type: "regular" | "fast" | "limited" | "food_train" | string;
   total_cap_qty: number | null;
   ordered_qty: number;
   /** 全分店訂單數（最熱銷排序用）。後端未部署前可能為 0。 */
@@ -26,25 +24,13 @@ export type CampaignSummary = {
   max_price: number;
 };
 
-/** 美食列車專屬 badge (與「限時/限量」分開,可同時出現) */
-function FoodTrainBadge({ size = "sm" }: { size?: "sm" | "lg" }) {
-  return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-full bg-emerald-600/95 font-semibold text-white shadow-sm backdrop-blur ${
-        size === "lg" ? "px-3 py-1 text-[14px]" : "px-2 py-0.5 text-[11px]"
-      }`}
-    >
-      美食列車
-    </span>
-  );
-}
-
 /** 依 close_type + total_cap_qty 算出短標籤。
  *  「限時」只給真正的快閃團（close_type='fast'，即限時專區那種）。
  *  一般團幾乎都有結單日(end_at)，有結單日 ≠ 限時，否則每張卡都被貼標、
  *  標籤就失去意義（卡片本來就會單獨顯示倒數）。 */
 export function campaignBadgeLabel(c: CampaignSummary): string | null {
   const hasCap = (c.total_cap_qty ?? 0) > 0;
+  if (c.close_type === "food_train") return "美食列車";
   if (c.close_type === "fast" && hasCap) return "限量限時";
   if (c.close_type === "fast") return "限時";
   if (c.close_type === "limited" || hasCap) return "限量";
@@ -135,10 +121,14 @@ export default function CampaignCard({
             const soldOut = campaignSoldOut(campaign);
             if (!label && !campaign.end_at) return null;
             const isLimited = label?.includes("限量");
+            const isFoodTrain = campaign.close_type === "food_train";
             return (
               <div
                 className={`absolute left-3 top-3 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-[14px] font-semibold text-white shadow-sm backdrop-blur ${
-                  soldOut ? "bg-zinc-700/85" : isLimited ? "bg-[var(--ios-red)]/90" : "bg-black/55"
+                  soldOut ? "bg-zinc-700/85"
+                  : isFoodTrain ? "bg-emerald-600/95"
+                  : isLimited ? "bg-[var(--ios-red)]/90"
+                  : "bg-black/55"
                 }`}
               >
                 {soldOut ? (
@@ -146,7 +136,7 @@ export default function CampaignCard({
                 ) : (
                   <>
                     {label && <span>{label}</span>}
-                    {campaign.end_at && <Countdown target={campaign.end_at} compact />}
+                    {campaign.end_at && !isFoodTrain && <Countdown target={campaign.end_at} compact />}
                     {isLimited && remaining !== null && (
                       <span className="text-[12px] opacity-90">· 剩 {remaining} 份</span>
                     )}
@@ -155,11 +145,6 @@ export default function CampaignCard({
               </div>
             );
           })()}
-          {campaign.category === "food_train" && (
-            <div className="absolute right-3 top-3">
-              <FoodTrainBadge size="lg" />
-            </div>
-          )}
         </div>
         <div className="space-y-1.5 px-4 py-3.5">
           <h3 className="text-[22px] font-bold leading-tight text-[var(--foreground)]">
@@ -211,21 +196,19 @@ export default function CampaignCard({
           }
           if (!label) return null;
           const isLimited = label?.includes("限量");
+          const isFoodTrain = campaign.close_type === "food_train";
           return (
             <span
               className={`absolute left-2 top-2 rounded-full px-2 py-0.5 text-[11px] font-semibold text-white shadow-sm backdrop-blur ${
-                isLimited ? "bg-[var(--ios-red)]/90" : "bg-[var(--ios-orange)]/90"
+                isFoodTrain ? "bg-emerald-600/95"
+                : isLimited ? "bg-[var(--ios-red)]/90"
+                : "bg-[var(--ios-orange)]/90"
               }`}
             >
               {label}
             </span>
           );
         })()}
-        {campaign.category === "food_train" && (
-          <span className="absolute right-2 top-2">
-            <FoodTrainBadge size="sm" />
-          </span>
-        )}
       </div>
       <div className="space-y-1 px-3 py-2.5">
         <h3 className="line-clamp-2 min-h-[2.6em] text-[16px] font-semibold leading-tight text-[var(--foreground)]">

--- a/docs/TEST-food-train.md
+++ b/docs/TEST-food-train.md
@@ -1,7 +1,12 @@
 # food-train 測試項目 — 開團「美食列車」類別 + /shop 置頂專區 + 上架推播廣播
 
-**對應 migration:** `supabase/migrations/<new>_food_train_category.sql`
-**對應 RPC 變更:** `rpc_upsert_campaign` 加 `p_category`
+> **設計變更（2026-05-23）：** 美食列車最終定案為 **`close_type` 第 4 個值**
+> (`regular`/`fast`/`limited`/`food_train`)，不再使用獨立的 `category` 欄位。
+> 以下檢查項目若提到「category 欄位」或「p_category 參數」，請改讀為
+> 「`close_type='food_train'` 篩選」。下方測試會在下個版本重整。
+
+**對應 migration:** `supabase/migrations/20260626000000_food_train_category.sql`
+**對應 RPC 變更:** `rpc_upsert_campaign` 不變（沿用 `p_close_type` 傳 `'food_train'`）
 **對應 Edge Function 變更:** `supabase/functions/admin-notify/index.ts` 加 broadcast mode
 **對應 liff-api 變更:** `list_active_campaigns` 加 category 回傳 + filter
 **對應 UI 變更:**

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -293,18 +293,17 @@ async function listMySettlements(sb: any, tenantId: string, _storeId: number, me
   return json({ settlements: data ?? [] });
 }
 
-async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string | null, category?: string | null, memberId?: number | null) {
+async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string | null, memberId?: number | null) {
   // end_at IS NULL 表示「無到期日」(管理員未設),也算進行中,要保留
   let q = sb
     .from("group_buy_campaigns")
-    .select("id, campaign_no, name, description, cover_image_url, close_type, category, total_cap_qty, end_at, pickup_deadline, campaign_items(unit_price, sort_order, sku:skus(product:products(images)))")
+    .select("id, campaign_no, name, description, cover_image_url, close_type, total_cap_qty, end_at, pickup_deadline, campaign_items(unit_price, sort_order, sku:skus(product:products(images)))")
     .eq("tenant_id", tenantId)
     .eq("status", "open")
     // 排除內部 sentinel 活動(補貨申請),不應出現在顧客商店
     .neq("campaign_no", "__INTERNAL_RESTOCK__")
     .or(`end_at.is.null,end_at.gt.${new Date().toISOString()}`);
   if (closeType) q = q.eq("close_type", closeType);
-  if (category) q = q.eq("category", category);
   // 不加 limit：曾經 .limit(50) 在 open 團數超過 50 時把最晚結單的整批截掉
   // （end_at ASC NULLS LAST + 截 50），顧客端整個團就消失。PostgREST 仍有
   // db-max-rows=1000 兜底，55 個團也才一頁。
@@ -371,7 +370,6 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
       description: c.description,
       cover_image_url: cover,
       close_type: c.close_type,
-      category: c.category ?? null,
       total_cap_qty: c.total_cap_qty,
       ordered_qty: orderedMap.get(Number(c.id)) ?? 0,
       order_count: countMap.get(Number(c.id)) ?? 0,
@@ -782,7 +780,7 @@ Deno.serve(async (req) => {
       case "get_my_unread_notification_count": if (!memberId) return json({ error: "no member_id" }, 401); return await getMyUnreadNotificationCount(sb, tenantId, memberId);
       case "mark_notification_read": if (!memberId) return json({ error: "no member_id" }, 401); return await markNotificationRead(sb, tenantId, memberId, body);
       case "generate_pwa_auth_code": if (!memberId) return json({ error: "no member_id" }, 401); return await generatePwaAuthCode(sb, tenantId, memberId, claims, token, body);
-      case "list_active_campaigns": return await listActiveCampaigns(sb, tenantId, typeof body.close_type === "string" ? body.close_type : null, typeof body.category === "string" ? body.category : null, memberId);
+      case "list_active_campaigns": return await listActiveCampaigns(sb, tenantId, typeof body.close_type === "string" ? body.close_type : null, memberId);
       case "get_campaign_detail": return await getCampaignDetail(sb, tenantId, Number(body.campaign_id ?? 0));
       case "place_member_order": if (!memberId) return json({ error: "no member_id" }, 401); return await placeMemberOrder(sb, tenantId, memberId, body);
       default: return json({ error: `unknown action: ${action}` }, 400);

--- a/supabase/migrations/20260626100000_food_train_into_close_type.sql
+++ b/supabase/migrations/20260626100000_food_train_into_close_type.sql
@@ -1,0 +1,114 @@
+-- ============================================================================
+-- 美食列車從獨立 category 欄位改成 close_type 第 4 值
+--
+-- 為何另開 migration:
+--   #340 把 category 欄位 + 14 參數 rpc_upsert_campaign 已 merge 進 main 並
+--   apply 到 prod。實際使用後決定不另闢類別維度，直接放進收單類型下拉
+--   (regular / fast / limited / food_train)。本 migration 收斂:
+--     1. close_type CHECK 放寬含 'food_train'
+--     2. 把 category='food_train' 的既有開團搬到 close_type='food_train'
+--     3. DROP category 欄位 + group_buy_campaigns_category_chk constraint
+--     4. rpc_upsert_campaign 收回 13 參數 (移除 p_category)
+--   全 idempotent: 對「prod 已套舊版」或「乾淨環境」皆安全。
+-- ============================================================================
+
+-- ── 1. close_type CHECK 放寬, 含 'food_train' ──────────────────────────────
+ALTER TABLE group_buy_campaigns
+  DROP CONSTRAINT IF EXISTS group_buy_campaigns_close_type_check;
+
+ALTER TABLE group_buy_campaigns
+  ADD CONSTRAINT group_buy_campaigns_close_type_check
+  CHECK (close_type IN ('regular','fast','limited','food_train'));
+
+COMMENT ON COLUMN group_buy_campaigns.close_type IS
+  '開團類型: regular=常規, fast=快團(強制 end_at), limited=限量, food_train=美食列車(專區)';
+
+-- ── 2. 把短暫存在的 category='food_train' 搬到 close_type ──────────────────
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_name = 'group_buy_campaigns' AND column_name = 'category'
+  ) THEN
+    UPDATE group_buy_campaigns
+       SET close_type = 'food_train'
+     WHERE category = 'food_train' AND close_type != 'food_train';
+  END IF;
+END $$;
+
+-- ── 3. DROP category 欄位 + CHECK constraint ───────────────────────────────
+ALTER TABLE group_buy_campaigns
+  DROP CONSTRAINT IF EXISTS group_buy_campaigns_category_chk;
+
+ALTER TABLE group_buy_campaigns
+  DROP COLUMN IF EXISTS category;
+
+-- ── 4. rpc_upsert_campaign 收回 13 參數 (拿掉 p_category) ──────────────────
+-- 用動態 DROP 處理所有 overload (13 / 14 參數版本都清掉, 避免 ambiguous)
+DO $$
+DECLARE r RECORD;
+BEGIN
+  FOR r IN
+    SELECT oid::regprocedure::text AS sig
+      FROM pg_proc WHERE proname = 'rpc_upsert_campaign'
+  LOOP
+    EXECUTE 'DROP FUNCTION ' || r.sig;
+  END LOOP;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.rpc_upsert_campaign(
+  p_id               BIGINT,
+  p_campaign_no      TEXT,
+  p_name             TEXT,
+  p_description      TEXT        DEFAULT NULL,
+  p_cover_image_url  TEXT        DEFAULT NULL,
+  p_status           TEXT        DEFAULT 'draft',
+  p_close_type       TEXT        DEFAULT 'regular',
+  p_start_at         TIMESTAMPTZ DEFAULT NULL,
+  p_end_at           TIMESTAMPTZ DEFAULT NULL,
+  p_pickup_deadline  DATE        DEFAULT NULL,
+  p_pickup_days      INTEGER     DEFAULT NULL,
+  p_total_cap_qty    NUMERIC     DEFAULT NULL,
+  p_notes            TEXT        DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_id     BIGINT;
+BEGIN
+  IF p_id IS NULL THEN
+    INSERT INTO group_buy_campaigns (
+      tenant_id, campaign_no, name, description, cover_image_url,
+      status, close_type, start_at, end_at, pickup_deadline, pickup_days,
+      total_cap_qty, notes, created_by, updated_by
+    ) VALUES (
+      v_tenant, p_campaign_no, p_name, p_description, p_cover_image_url,
+      COALESCE(p_status,'draft'), COALESCE(p_close_type,'regular'),
+      p_start_at, p_end_at, p_pickup_deadline, p_pickup_days,
+      p_total_cap_qty, p_notes, auth.uid(), auth.uid()
+    ) RETURNING id INTO v_id;
+  ELSE
+    UPDATE group_buy_campaigns SET
+      campaign_no = COALESCE(p_campaign_no, campaign_no),
+      name = COALESCE(p_name, name),
+      description = p_description,
+      cover_image_url = p_cover_image_url,
+      status = COALESCE(p_status, status),
+      close_type = COALESCE(p_close_type, close_type),
+      start_at = p_start_at,
+      end_at = p_end_at,
+      pickup_deadline = p_pickup_deadline,
+      pickup_days = p_pickup_days,
+      total_cap_qty = p_total_cap_qty,
+      notes = p_notes,
+      updated_by = auth.uid()
+    WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'campaign % not in tenant', p_id; END IF;
+  END IF;
+  RETURN v_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_upsert_campaign TO authenticated;


### PR DESCRIPTION
## Summary
承接 [#340](https://github.com/lt-foods/new_erp/pull/340)（已 merge，含 category 欄位設計）。實際使用後決定不另闢類別維度，「美食列車」直接放進**收單類型**下拉，與 regular/fast/limited 並列，簡化資料模型。

## Schema 變更（新 migration）
[supabase/migrations/20260626100000_food_train_into_close_type.sql](supabase/migrations/20260626100000_food_train_into_close_type.sql) — **全 idempotent**，對 prod 已套舊版 / 乾淨環境皆安全：
1. `close_type` CHECK 放寬含 `'food_train'`
2. 把短暫存在的 `category='food_train'` 開團搬到 `close_type='food_train'`
3. DROP `category` 欄位 + `group_buy_campaigns_category_chk` constraint
4. `rpc_upsert_campaign` 收回 13 參數（移除 `p_category`），用動態 DROP 清掉所有 overload 避免 ambiguous

> 不動 [supabase/migrations/20260626000000_food_train_category.sql](supabase/migrations/20260626000000_food_train_category.sql)（已 merge），新檔做 forward rollback。

## 前端變更
**Admin**:
- CampaignForm 拿掉「類別」下拉；收單類型加第 4 項「美食列車」
- 列表 `CLOSE_TYPE_LABEL`/`CLOSE_TYPE_BADGE` 加 `food_train`（emerald 色）
- 篩選器：類別維度 → 改成「收單類型」維度
- broadcast 觸發條件：`v.category` → `v.close_type === 'food_train'`

**Member**:
- liff-api `list_active_campaigns` 拿掉 `category` 篩選 / 回傳欄位
  - 保留 [#341](https://github.com/lt-foods/new_erp/pull/341) 拿掉 `.limit(50)` 的修正
- `/shop` foodTrainHero / count 改用 `close_type === 'food_train'`
- `/shop/food-train` 全列表頁改 close_type filter
- CampaignCard 拿掉右上角獨立的 `FoodTrainBadge`；在既有 left-top badge 用 emerald 色顯示「美食列車」
- `campaignBadgeLabel` 加 `food_train → "美食列車"`

## 部署步驟（merge 後）
1. **DB migration**：套 [supabase/migrations/20260626100000_food_train_into_close_type.sql](supabase/migrations/20260626100000_food_train_into_close_type.sql)（Studio 貼或 `apply_one_migration.cjs`）
2. **Edge Function**：`supabase functions deploy liff-api --project-ref anfyoeviuhmzzrhilwtm`
   - admin-notify 不用重 deploy（這個 PR 沒動）
3. **前端**：admin + member 下次 build 自動帶入

## Test plan
- [ ] migration 在 prod 套用成功；`SELECT column_name FROM information_schema.columns WHERE table_name='group_buy_campaigns' AND column_name='category'` 回 0 列
- [ ] `pg_proc` 內 `rpc_upsert_campaign` 只剩 1 個 13 參數 overload
- [ ] admin 編輯開團 → 收單類型下拉看到 4 項（包含「美食列車」）
- [ ] 選「美食列車」+ status=open 儲存 → 觸發 broadcast，顧客收到推播
- [ ] /shop 頂部綠色「美食列車」banner 出現（在 carousel 內，跟「限時專區」並排）
- [ ] /shop/food-train 全列表頁正常顯示 close_type='food_train' 的開團
- [ ] CampaignCard badge 顯示「美食列車」emerald 色
- [ ] 既有 regular / fast / limited 開團不受影響（regression）
- [ ] #341 拿掉 .limit(50) 的修正仍在（55+ 團不被截掉）

🤖 Generated with [Claude Code](https://claude.com/claude-code)