### PR TITLE
fix(member/shop): 攤平模式美食列車也用 stack banner 進清單頁

### DIFF
--- a/apps/member/src/app/shop/page.tsx
+++ b/apps/member/src/app/shop/page.tsx
@@ -198,7 +198,7 @@ export default function ShopPage() {
           </Link>
         )}
 
-        {/* 主題 banner 跑馬燈 — 兩類同時有就群組總覽, 只有一類就攤平每團一張, auto-play 4s */}
+        {/* 主題 banner 跑馬燈 — 美食列車一律 stack banner (點進清單), 快團攤平每團一張 */}
         <ShopBannerCarousel
           banners={
             groupMode
@@ -213,10 +213,12 @@ export default function ShopPage() {
                   },
                 ]
               : foodTrains.length > 0
-                ? foodTrains.map((c) => ({
-                    key: `food_train_${c.id}`,
-                    node: <FoodTrainItemBanner campaign={c} />,
-                  }))
+                ? [
+                    {
+                      key: "food_train_stack",
+                      node: <FoodTrainStackBanner campaigns={foodTrains} />,
+                    },
+                  ]
                 : flashes.map((c) => ({
                     key: `flash_${c.id}`,
                     node: <FlashItemBanner campaign={c} />,
@@ -409,50 +411,6 @@ function FlashGroupBanner({ hero }: { hero: CampaignSummary }) {
           </div>
         </div>
         <div className="absolute right-4 top-1/2 -translate-y-1/2 text-[28px] text-white/85">›</div>
-      </div>
-    </Link>
-  );
-}
-
-function FoodTrainItemBanner({ campaign }: { campaign: CampaignSummary }) {
-  return (
-    <Link
-      href={`/shop/c/${campaign.id}`}
-      className="block overflow-hidden rounded-2xl shadow-[0_10px_28px_-10px_rgba(5,150,105,0.5)] transition-transform duration-200 active:scale-[0.985]"
-    >
-      <div className="relative aspect-[16/8] w-full bg-gradient-to-br from-emerald-500 via-emerald-600 to-teal-600">
-        {campaign.cover_image_url && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={campaign.cover_image_url}
-            alt=""
-            className="absolute inset-0 h-full w-full object-cover opacity-55"
-          />
-        )}
-        <div className="absolute inset-0 bg-gradient-to-t from-emerald-950/75 via-emerald-900/15 to-transparent" />
-        <div className="absolute inset-0 flex flex-col justify-between p-4">
-          <div className="flex items-center gap-2">
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-600/85 px-3 py-1 shadow-sm backdrop-blur">
-              <span className="text-[15px]">🚂</span>
-              <span className="text-[14px] font-bold text-white">美食列車</span>
-            </span>
-          </div>
-          <div className="flex items-end justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              <div className="line-clamp-1 text-[17px] font-bold text-white drop-shadow">
-                {cleanCampaignText(campaign.name)}
-              </div>
-              <div className="text-[24px] font-extrabold tabular-nums text-white drop-shadow">
-                {priceText(campaign)}
-              </div>
-            </div>
-            {campaign.end_at && (
-              <div className="shrink-0 rounded-full bg-black/35 px-2.5 py-1 text-[13px] font-semibold tabular-nums text-white backdrop-blur">
-                <Countdown target={campaign.end_at} compact />
-              </div>
-            )}
-          </div>
-        </div>
       </div>
     </Link>
   );


### PR DESCRIPTION
## Summary

把攤平模式（只有美食列車、沒有快團）的美食列車 banner 也改成 stack banner，跟群組模式一致。

之前：
- 群組模式（兩類同時有）：1 張 stack banner，內部 crossfade 輪詢，點下去進 `/shop/food-train`（#347）
- 攤平模式（只有美食列車）：N 張獨立 banner，外部 swipe，點下去進該團詳情 ← 不一致

現在不論模式，只要有多團美食列車一律 stack banner（一張、內部輪詢、底部 dots、點下去進 `/shop/food-train`）。順手刪掉沒用到的 `FoodTrainItemBanner`。

## Base

base = `claude/food-train-banner-link-fix`（#347），因為這個 fix 依賴 #347 的「stack banner 連到 `/shop/food-train`」改動。等 #347 merge 後 base 會自動切到 main。

## Test plan

- [ ] 只有美食列車、沒快團 → 上方只有 1 張 banner，內部輪詢所有列車團
- [ ] 點該 banner → 進 `/shop/food-train`（不是某團詳情）
- [ ] 兩類同時有 → 行為跟 #347 一樣，外部 2 張（美食列車 stack + 快團 summary）
- [ ] 只有快團 → 行為不變（每團一張，點進該團詳情）

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACSnMdbRHFgq8zrae5QoAf)_