### PR TITLE
feat(orders/pickup): 會員搜尋也改 Google 式多 token

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -70,7 +70,6 @@ function MembersListBody() {
   const [sortBy, setSortBy] = useState<SortKey>("updated_at");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [page, setPage] = useState(1);
-  const [showMerged, setShowMerged] = useState(false);
 
   const [stores, setStores] = useState<Store[]>([]);
   useDefaultStoreFromUser(stores, storeId, setStoreId);
@@ -108,7 +107,7 @@ function MembersListBody() {
 
   useEffect(() => {
     setPage(1);
-  }, [storeId, sortBy, sortDir, showMerged]);
+  }, [storeId, sortBy, sortDir]);
 
   useEffect(() => {
     let cancelled = false;
@@ -141,12 +140,15 @@ function MembersListBody() {
           .order(sortBy, { ascending: sortDir === "asc" })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 
-        if (query.trim()) {
-          const safe = query.replace(/[%,()]/g, " ").trim();
-          q = q.or(`name.ilike.%${safe}%,phone.ilike.%${safe}%,member_no.ilike.%${safe}%`);
+        // Google 式：空白 / + 拆 token，每個 token 都要在 name / phone / member_no 至少一個欄位命中
+        const tokens = query.replace(/[%,()]/g, " ").split(/[\s+]+/).filter(Boolean);
+        for (const tok of tokens) {
+          q = q.or(`name.ilike.%${tok}%,phone.ilike.%${tok}%,member_no.ilike.%${tok}%`);
         }
         if (storeId) q = q.eq("home_store_id", Number(storeId));
-        if (!showMerged) q = q.not("status", "in", "(merged,deleted)");
+        // 沒輸入搜尋字串時，預設只看活躍會員；有搜尋字串時連 merged/deleted 一起撈，
+        // 避免找不到已合併的會員（UI 會用灰色 + 「已合併」標籤標示）
+        if (tokens.length === 0) q = q.not("status", "in", "(merged,deleted)");
 
         const { data, count, error } = await q;
         if (cancelled) return;
@@ -221,7 +223,7 @@ function MembersListBody() {
     return () => {
       cancelled = true;
     };
-  }, [query, storeId, sortBy, sortDir, page, reloadTick, showMerged]);
+  }, [query, storeId, sortBy, sortDir, page, reloadTick]);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const fromIdx = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
@@ -281,16 +283,6 @@ function MembersListBody() {
           ))}
         </select>
       </div>
-
-      <label className="flex items-center gap-2 text-xs text-zinc-500">
-        <input
-          type="checkbox"
-          checked={showMerged}
-          onChange={(e) => setShowMerged(e.target.checked)}
-          className="h-3.5 w-3.5"
-        />
-        <span>顯示已合併 / 已刪除（預設只看活躍會員）</span>
-      </label>
 
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -70,13 +70,15 @@ async function buildKeywordOr(keyword: string): Promise<string | null> {
   const t = keyword.trim();
   if (!t) return null;
   const safe = t.replace(/[%,()]/g, " ");
-  const { data } = await getSupabase()
-    .from("members")
-    .select("id")
-    .or(`name.ilike.%${safe}%,phone.ilike.%${safe}%,member_no.ilike.%${safe}%`)
-    .neq("status", "deleted")
-    .limit(300);
+  // Google 式：以空白 / + 拆 token，每個 token 都要在 name / phone / member_no 至少一欄命中
+  const tokens = safe.split(/[\s+]+/).filter(Boolean);
+  let memberQ = getSupabase().from("members").select("id").neq("status", "deleted").limit(300);
+  for (const tok of tokens) {
+    memberQ = memberQ.or(`name.ilike.%${tok}%,phone.ilike.%${tok}%,member_no.ilike.%${tok}%`);
+  }
+  const { data } = await memberQ;
   const ids = ((data ?? []) as { id: number }[]).map((m) => m.id);
+  // 整串 keyword 也允許出現在 order_no / nickname_snapshot（不拆 token，避免誤判）
   const ors = [`order_no.ilike.%${safe}%`, `nickname_snapshot.ilike.%${safe}%`];
   if (ids.length > 0) ors.push(`member_id.in.(${ids.join(",")})`);
   return ors.join(",");

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -101,15 +101,19 @@ function PickupPageContent() {
     setOrders(new Map());
     try {
       const sb = getSupabase();
-      // 一個關鍵字同時對 name / phone / member_no 做 ilike,任一命中皆列出
+      // Google 式：以空白 / + 拆 token，每個 token 都要在 name / phone / member_no 至少一欄命中
       const safe = q.replace(/[%,()]/g, " ");
-      const { data: ms, error: e1 } = await sb
+      const tokens = safe.split(/[\s+]+/).filter(Boolean);
+      let memberQ = sb
         .from("members")
         .select("id, member_no, name, phone, admin_note, no_notify_pickup, no_new_order")
-        .or(`name.ilike.%${safe}%,phone.ilike.%${safe}%,member_no.ilike.%${safe}%`)
         .neq("status", "deleted")
         .order("last_visit_at", { ascending: false, nullsFirst: false })
         .limit(20);
+      for (const tok of tokens) {
+        memberQ = memberQ.or(`name.ilike.%${tok}%,phone.ilike.%${tok}%,member_no.ilike.%${tok}%`);
+      }
+      const { data: ms, error: e1 } = await memberQ;
       if (e1) { setError(e1.message); return; }
       const list = (ms ?? []) as Member[];
       setMembers(list);

--- a/supabase/migrations/20260627000000_search_members_exclude_merged.sql
+++ b/supabase/migrations/20260627000000_search_members_exclude_merged.sql
@@ -1,6 +1,8 @@
 -- ============================================================
--- rpc_search_members / rpc_search_aliases：排除 已合併 / 已刪除 的會員
---   下單 / 取貨 / LINE 暱稱對應等流程不應該再選到 merged 會員
+-- rpc_search_members / rpc_search_aliases：
+--   1. 排除 已合併 / 已刪除 的會員
+--   2. Google 式多 token 搜尋：以空白 / + 拆字串，每個 token 都需在
+--      name / member_no / phone（aliases 用 nickname）任一欄命中
 -- ============================================================
 
 DROP FUNCTION IF EXISTS public.rpc_search_members(TEXT, INT);
@@ -24,9 +26,13 @@ CREATE OR REPLACE FUNCTION public.rpc_search_members(
 LANGUAGE plpgsql SECURITY DEFINER
 AS $$
 DECLARE
-  v_tenant UUID := public._current_tenant_id();
-  v_term   TEXT := COALESCE(NULLIF(TRIM(p_term), ''), NULL);
-  v_lim    INT  := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+  v_tenant UUID   := public._current_tenant_id();
+  v_tokens TEXT[] := ARRAY(
+    SELECT t
+      FROM regexp_split_to_table(COALESCE(p_term, ''), '[\s+]+') AS t
+     WHERE t <> ''
+  );
+  v_lim    INT    := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
 BEGIN
   RETURN QUERY
   SELECT m.id, m.member_no, m.name, m.phone, m.avatar_url,
@@ -37,10 +43,16 @@ BEGIN
    WHERE m.tenant_id = v_tenant
      AND m.status NOT IN ('merged', 'deleted')
      AND (
-       v_term IS NULL
-       OR m.name      ILIKE '%' || v_term || '%'
-       OR m.member_no ILIKE '%' || v_term || '%'
-       OR m.phone     ILIKE '%' || v_term || '%'
+       COALESCE(array_length(v_tokens, 1), 0) = 0
+       OR NOT EXISTS (
+         SELECT 1
+           FROM unnest(v_tokens) AS tok
+          WHERE NOT (
+            m.name      ILIKE '%' || tok || '%'
+            OR m.member_no ILIKE '%' || tok || '%'
+            OR m.phone     ILIKE '%' || tok || '%'
+          )
+       )
      )
    ORDER BY m.created_at DESC
    LIMIT v_lim;
@@ -69,9 +81,13 @@ CREATE OR REPLACE FUNCTION public.rpc_search_aliases(
 LANGUAGE plpgsql SECURITY DEFINER
 AS $$
 DECLARE
-  v_tenant UUID := public._current_tenant_id();
-  v_term   TEXT := COALESCE(NULLIF(TRIM(p_term), ''), NULL);
-  v_lim    INT  := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+  v_tenant UUID   := public._current_tenant_id();
+  v_tokens TEXT[] := ARRAY(
+    SELECT t
+      FROM regexp_split_to_table(COALESCE(p_term, ''), '[\s+]+') AS t
+     WHERE t <> ''
+  );
+  v_lim    INT    := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
 BEGIN
   RETURN QUERY
   SELECT a.id, a.nickname, m.id, m.member_no, m.name, m.phone, m.avatar_url,
@@ -83,7 +99,14 @@ BEGIN
    WHERE a.tenant_id  = v_tenant
      AND a.channel_id = p_channel_id
      AND m.status NOT IN ('merged', 'deleted')
-     AND (v_term IS NULL OR a.nickname ILIKE '%' || v_term || '%')
+     AND (
+       COALESCE(array_length(v_tokens, 1), 0) = 0
+       OR NOT EXISTS (
+         SELECT 1
+           FROM unnest(v_tokens) AS tok
+          WHERE NOT (a.nickname ILIKE '%' || tok || '%')
+       )
+     )
    ORDER BY a.updated_at DESC
    LIMIT v_lim;
 END;

--- a/supabase/migrations/20260627000000_search_members_exclude_merged.sql
+++ b/supabase/migrations/20260627000000_search_members_exclude_merged.sql
@@ -1,0 +1,91 @@
+-- ============================================================
+-- rpc_search_members / rpc_search_aliases：排除 已合併 / 已刪除 的會員
+--   下單 / 取貨 / LINE 暱稱對應等流程不應該再選到 merged 會員
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.rpc_search_members(TEXT, INT);
+DROP FUNCTION IF EXISTS public.rpc_search_aliases(BIGINT, TEXT, INT);
+
+CREATE OR REPLACE FUNCTION public.rpc_search_members(
+  p_term  TEXT,
+  p_limit INT DEFAULT 20
+) RETURNS TABLE (
+  id                BIGINT,
+  member_no         TEXT,
+  name              TEXT,
+  phone             TEXT,
+  avatar_url        TEXT,
+  home_store_id     BIGINT,
+  home_store_name   TEXT,
+  no_new_order      BOOLEAN,
+  no_notify_pickup  BOOLEAN,
+  admin_note        TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_term   TEXT := COALESCE(NULLIF(TRIM(p_term), ''), NULL);
+  v_lim    INT  := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+BEGIN
+  RETURN QUERY
+  SELECT m.id, m.member_no, m.name, m.phone, m.avatar_url,
+         m.home_store_id, s.name,
+         m.no_new_order, m.no_notify_pickup, m.admin_note
+    FROM members m
+    LEFT JOIN stores s ON s.id = m.home_store_id
+   WHERE m.tenant_id = v_tenant
+     AND m.status NOT IN ('merged', 'deleted')
+     AND (
+       v_term IS NULL
+       OR m.name      ILIKE '%' || v_term || '%'
+       OR m.member_no ILIKE '%' || v_term || '%'
+       OR m.phone     ILIKE '%' || v_term || '%'
+     )
+   ORDER BY m.created_at DESC
+   LIMIT v_lim;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_search_members TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_search_aliases(
+  p_channel_id BIGINT,
+  p_term       TEXT,
+  p_limit      INT DEFAULT 20
+) RETURNS TABLE (
+  alias_id          BIGINT,
+  nickname          TEXT,
+  member_id         BIGINT,
+  member_no         TEXT,
+  member_name       TEXT,
+  phone             TEXT,
+  avatar_url        TEXT,
+  home_store_id     BIGINT,
+  home_store_name   TEXT,
+  no_new_order      BOOLEAN,
+  no_notify_pickup  BOOLEAN,
+  admin_note        TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_term   TEXT := COALESCE(NULLIF(TRIM(p_term), ''), NULL);
+  v_lim    INT  := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+BEGIN
+  RETURN QUERY
+  SELECT a.id, a.nickname, m.id, m.member_no, m.name, m.phone, m.avatar_url,
+         m.home_store_id, s.name,
+         m.no_new_order, m.no_notify_pickup, m.admin_note
+    FROM customer_line_aliases a
+    JOIN members m ON m.id = a.member_id
+    LEFT JOIN stores s ON s.id = m.home_store_id
+   WHERE a.tenant_id  = v_tenant
+     AND a.channel_id = p_channel_id
+     AND m.status NOT IN ('merged', 'deleted')
+     AND (v_term IS NULL OR a.nickname ILIKE '%' || v_term || '%')
+   ORDER BY a.updated_at DESC
+   LIMIT v_lim;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_search_aliases TO authenticated;


### PR DESCRIPTION
## Summary
延續 #349 — 把同樣的「以空白 / + 拆 token，每個 token 都要在 `name` / `phone` / `member_no` 至少一欄命中」的 Google 式搜尋規則，套到 `/orders` 列表的關鍵字反查與 `/pickup` 取貨頁的會員搜尋。

- `apps/admin/src/app/(protected)/orders/page.tsx` — `buildKeywordOr` 改為多 token AND-of-OR；`order_no` / `nickname_snapshot` 仍用整串 keyword 比（拆字會誤判訂單號跟暱稱）
- `apps/admin/src/app/(protected)/pickup/page.tsx` — 取貨頁會員搜尋同樣的多 token 邏輯

四個位置的會員搜尋規則現在一致：`/members`、`rpc_search_members`（order-entry）、`rpc_search_aliases`（LINE 暱稱）、`/orders`、`/pickup`。

## Test plan
- [ ] `/orders` 搜尋「楊小胖 439558」應只列出名字含楊小胖且編號含 439558 的訂單
- [ ] `/orders` 單一 token 搜尋行為保持不變
- [ ] `/pickup` 搜尋「楊小胖 439558」應只列出名字+編號同時命中的會員
- [ ] 整串 keyword 仍可比對 `order_no` / `nickname_snapshot`（單詞輸入單欄訂單號要找得到）

https://claude.ai/code/session_013mw8PNC9Ssfbkii2VCeqkn

---
_Generated by [Claude Code](https://claude.ai/code/session_013mw8PNC9Ssfbkii2VCeqkn)_