### PR TITLE
fix(member/shop): 美食列車群組 banner 點擊改連清單頁

### DIFF
--- a/apps/member/src/app/shop/page.tsx
+++ b/apps/member/src/app/shop/page.tsx
@@ -311,7 +311,7 @@ function FoodTrainStackBanner({ campaigns }: { campaigns: CampaignSummary[] }) {
 
   return (
     <Link
-      href={`/shop/c/${current.id}`}
+      href="/shop/food-train"
       className="block overflow-hidden rounded-2xl shadow-[0_10px_28px_-10px_rgba(5,150,105,0.5)] transition-transform duration-200 active:scale-[0.985]"
     >
       <div className="relative aspect-[16/8] w-full bg-gradient-to-br from-emerald-500 via-emerald-600 to-teal-700">


### PR DESCRIPTION
跟限時專區一致 — FlashGroupBanner 點下去是 /shop/flash 清單,
但 FoodTrainStackBanner 之前是連到當下輪詢顯示那團的詳情頁,
造成同一張 banner 不同秒點下去會進到不同的團, 體感雜亂。
改成統一連到 /shop/food-train 清單頁。