### PR TITLE
feat(member): 搜尋命中已合併舊檔時翻譯成新會員

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -34,7 +34,11 @@ type MemberRow = {
   line_user_id: string | null;
   home_store_id: number | null;
   takeout_store_name_hint: string | null;
+  merged_into_member_id: number | null;
 };
+
+const MEMBER_SELECT_COLS =
+  "id, member_no, name, phone, avatar_url, tier_id, status, updated_at, joined_at, last_visit_at, external_source, external_id, line_user_id, home_store_id, takeout_store_name_hint, merged_into_member_id";
 
 /** 顯示手機，若是 LIFF auto-register 的 placeholder (line:Uxxxx) 則視為未填 */
 function displayPhone(p: string | null): string {
@@ -136,7 +140,7 @@ function MembersListBody() {
       try {
         let q = getSupabase()
           .from("members")
-          .select("id, member_no, name, phone, avatar_url, tier_id, status, updated_at, joined_at, last_visit_at, external_source, external_id, line_user_id, home_store_id, takeout_store_name_hint", { count: "exact" })
+          .select(MEMBER_SELECT_COLS, { count: "exact" })
           .order(sortBy, { ascending: sortDir === "asc" })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 
@@ -146,9 +150,11 @@ function MembersListBody() {
           q = q.or(`name.ilike.%${tok}%,phone.ilike.%${tok}%,member_no.ilike.%${tok}%`);
         }
         if (storeId) q = q.eq("home_store_id", Number(storeId));
-        // 沒輸入搜尋字串時，預設只看活躍會員；有搜尋字串時連 merged/deleted 一起撈，
-        // 避免找不到已合併的會員（UI 會用灰色 + 「已合併」標籤標示）
+        // 沒輸入搜尋字串時：只看活躍會員。
+        // 有搜尋字串時：把 merged 也撈出來（之後會把命中的「已合併舊檔」翻譯成它被併進去的新會員）；
+        // deleted 永遠不顯示
         if (tokens.length === 0) q = q.not("status", "in", "(merged,deleted)");
+        else q = q.neq("status", "deleted");
 
         const { data, count, error } = await q;
         if (cancelled) return;
@@ -156,11 +162,59 @@ function MembersListBody() {
           setError(error.message);
           return;
         }
+
+        // 把命中的 merged 舊檔翻譯成 merged_into 的新會員（追隨 chain 直到 active；最多 5 跳）
+        let resolved = (data ?? []) as MemberRow[];
+        const targetsToFetch = new Set<number>();
+        for (const r of resolved) {
+          if (r.status === "merged" && r.merged_into_member_id != null) {
+            targetsToFetch.add(r.merged_into_member_id);
+          }
+        }
+        const fetched = new Map<number, MemberRow>();
+        let hop = 0;
+        while (targetsToFetch.size > 0 && hop < 5) {
+          const ids = [...targetsToFetch].filter((id) => !fetched.has(id));
+          targetsToFetch.clear();
+          if (ids.length === 0) break;
+          const { data: ts } = await getSupabase()
+            .from("members")
+            .select(MEMBER_SELECT_COLS)
+            .in("id", ids);
+          for (const t of (ts ?? []) as MemberRow[]) {
+            fetched.set(t.id, t);
+            if (t.status === "merged" && t.merged_into_member_id != null && !fetched.has(t.merged_into_member_id)) {
+              targetsToFetch.add(t.merged_into_member_id);
+            }
+          }
+          hop += 1;
+        }
+        const resolveChain = (m: MemberRow): MemberRow | null => {
+          let cur: MemberRow | undefined = m;
+          let i = 0;
+          while (cur && cur.status === "merged" && cur.merged_into_member_id != null && i < 5) {
+            cur = fetched.get(cur.merged_into_member_id);
+            i += 1;
+          }
+          if (!cur || cur.status === "merged" || cur.status === "deleted") return null;
+          return cur;
+        };
+        if (tokens.length > 0) {
+          const seen = new Set<number>();
+          const out: MemberRow[] = [];
+          for (const r of resolved) {
+            const target = r.status === "merged" ? resolveChain(r) : r;
+            if (!target || seen.has(target.id)) continue;
+            seen.add(target.id);
+            out.push(target);
+          }
+          resolved = out;
+        }
         setError(null);
-        setRows((data ?? []) as MemberRow[]);
+        setRows(resolved);
         setTotal(count ?? 0);
 
-        const ids = (data ?? []).map((r) => r.id);
+        const ids = resolved.map((r) => r.id);
         if (ids.length) {
           const [ord, wal, push] = await Promise.all([
             getSupabase()

--- a/supabase/migrations/20260628000000_search_members_resolve_merged.sql
+++ b/supabase/migrations/20260628000000_search_members_resolve_merged.sql
@@ -1,0 +1,162 @@
+-- ============================================================
+-- rpc_search_members / rpc_search_aliases：搜尋命中已合併的舊檔時，
+-- 翻譯成它被併進去的新會員（沿著 merged_into_member_id 最多 5 跳追到 active）。
+-- 舊檔本身不再回傳；如果新會員的查詢結果中已經包含它，會自動去重。
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.rpc_search_members(TEXT, INT);
+DROP FUNCTION IF EXISTS public.rpc_search_aliases(BIGINT, TEXT, INT);
+
+CREATE OR REPLACE FUNCTION public.rpc_search_members(
+  p_term  TEXT,
+  p_limit INT DEFAULT 20
+) RETURNS TABLE (
+  id                BIGINT,
+  member_no         TEXT,
+  name              TEXT,
+  phone             TEXT,
+  avatar_url        TEXT,
+  home_store_id     BIGINT,
+  home_store_name   TEXT,
+  no_new_order      BOOLEAN,
+  no_notify_pickup  BOOLEAN,
+  admin_note        TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID   := public._current_tenant_id();
+  v_tokens TEXT[] := ARRAY(
+    SELECT t
+      FROM regexp_split_to_table(COALESCE(p_term, ''), '[\s+]+') AS t
+     WHERE t <> ''
+  );
+  v_lim    INT    := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+BEGIN
+  RETURN QUERY
+  WITH RECURSIVE matches AS (
+    SELECT m.id, m.status, m.merged_into_member_id, m.created_at
+      FROM members m
+     WHERE m.tenant_id = v_tenant
+       AND m.status <> 'deleted'
+       AND (
+         COALESCE(array_length(v_tokens, 1), 0) = 0
+         OR NOT EXISTS (
+           SELECT 1
+             FROM unnest(v_tokens) AS tok
+            WHERE NOT (
+              m.name      ILIKE '%' || tok || '%'
+              OR m.member_no ILIKE '%' || tok || '%'
+              OR m.phone     ILIKE '%' || tok || '%'
+            )
+         )
+       )
+  ),
+  resolved AS (
+    SELECT id AS source_id, id AS target_id, status, merged_into_member_id, 0 AS hop, created_at
+      FROM matches
+    UNION ALL
+    SELECT r.source_id, m.id, m.status, m.merged_into_member_id, r.hop + 1, m.created_at
+      FROM resolved r
+      JOIN members m ON m.id = r.merged_into_member_id
+     WHERE r.status = 'merged'
+       AND r.merged_into_member_id IS NOT NULL
+       AND r.hop < 5
+  ),
+  finals AS (
+    SELECT DISTINCT ON (source_id) source_id, target_id, status, created_at
+      FROM resolved
+     ORDER BY source_id, hop DESC
+  )
+  SELECT m.id, m.member_no, m.name, m.phone, m.avatar_url,
+         m.home_store_id, s.name,
+         m.no_new_order, m.no_notify_pickup, m.admin_note
+    FROM (
+      SELECT DISTINCT ON (target_id) target_id, created_at
+        FROM finals
+       WHERE status NOT IN ('merged', 'deleted')
+       ORDER BY target_id, created_at DESC
+    ) f
+    JOIN members m ON m.id = f.target_id
+    LEFT JOIN stores s ON s.id = m.home_store_id
+   ORDER BY f.created_at DESC
+   LIMIT v_lim;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_search_members TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_search_aliases(
+  p_channel_id BIGINT,
+  p_term       TEXT,
+  p_limit      INT DEFAULT 20
+) RETURNS TABLE (
+  alias_id          BIGINT,
+  nickname          TEXT,
+  member_id         BIGINT,
+  member_no         TEXT,
+  member_name       TEXT,
+  phone             TEXT,
+  avatar_url        TEXT,
+  home_store_id     BIGINT,
+  home_store_name   TEXT,
+  no_new_order      BOOLEAN,
+  no_notify_pickup  BOOLEAN,
+  admin_note        TEXT
+)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID   := public._current_tenant_id();
+  v_tokens TEXT[] := ARRAY(
+    SELECT t
+      FROM regexp_split_to_table(COALESCE(p_term, ''), '[\s+]+') AS t
+     WHERE t <> ''
+  );
+  v_lim    INT    := LEAST(GREATEST(COALESCE(p_limit, 20), 1), 50);
+BEGIN
+  RETURN QUERY
+  WITH RECURSIVE matches AS (
+    SELECT a.id AS alias_id, a.nickname, a.member_id, a.updated_at,
+           m.status, m.merged_into_member_id
+      FROM customer_line_aliases a
+      JOIN members m ON m.id = a.member_id
+     WHERE a.tenant_id  = v_tenant
+       AND a.channel_id = p_channel_id
+       AND m.status <> 'deleted'
+       AND (
+         COALESCE(array_length(v_tokens, 1), 0) = 0
+         OR NOT EXISTS (
+           SELECT 1
+             FROM unnest(v_tokens) AS tok
+            WHERE NOT (a.nickname ILIKE '%' || tok || '%')
+         )
+       )
+  ),
+  resolved AS (
+    SELECT alias_id, nickname, member_id AS target_id, status, merged_into_member_id, 0 AS hop, updated_at
+      FROM matches
+    UNION ALL
+    SELECT r.alias_id, r.nickname, m.id, m.status, m.merged_into_member_id, r.hop + 1, r.updated_at
+      FROM resolved r
+      JOIN members m ON m.id = r.merged_into_member_id
+     WHERE r.status = 'merged'
+       AND r.merged_into_member_id IS NOT NULL
+       AND r.hop < 5
+  ),
+  finals AS (
+    SELECT DISTINCT ON (alias_id) alias_id, nickname, target_id, status, updated_at
+      FROM resolved
+     ORDER BY alias_id, hop DESC
+  )
+  SELECT f.alias_id, f.nickname, m.id, m.member_no, m.name, m.phone, m.avatar_url,
+         m.home_store_id, s.name,
+         m.no_new_order, m.no_notify_pickup, m.admin_note
+    FROM finals f
+    JOIN members m ON m.id = f.target_id
+    LEFT JOIN stores s ON s.id = m.home_store_id
+   WHERE f.status NOT IN ('merged', 'deleted')
+   ORDER BY f.updated_at DESC
+   LIMIT v_lim;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_search_aliases TO authenticated;


### PR DESCRIPTION
## Summary
之前搜「楊小胖 439558」只會列出**已合併的舊檔**（灰字、「已合併」標籤），但這位客人實際的活躍會員已經被併到另一筆新會員身上、姓名不含「楊小胖」也不含「439558」。使用者找不到真正能操作的會員。

改成：搜尋命中 `status='merged'` 的舊檔時，沿著 `merged_into_member_id` 一路追到 active 的新會員（最多 5 跳避免無窮迴圈），用新會員取代舊檔顯示。舊檔本身不再出現。

## 改動
- `apps/admin/src/app/(protected)/members/page.tsx`
  - `SELECT` 帶上 `merged_into_member_id`
  - 有搜尋字串時把 `merged` 也撈出來（`deleted` 永遠排除），抓回來後沿著 chain 翻譯成 active；若新會員自身也在原查詢結果裡會自動去重
  - 沒輸入搜尋字串時行為不變：只看活躍會員
- `supabase/migrations/20260628000000_search_members_resolve_merged.sql`
  - `rpc_search_members` 與 `rpc_search_aliases` 改用 `WITH RECURSIVE` CTE 做相同翻譯（最多 5 跳）
  - 影響 order-entry 下單、LINE 暱稱對應流程：用客人舊名也找得到他現在的活躍會員

## Test plan
- [ ] `/members` 搜尋「楊小胖 439558」應列出該客人**新的活躍會員**，舊的已合併檔不再出現
- [ ] `/members` 不輸入搜尋字串時清單仍只看活躍會員
- [ ] order-entry 下單頁搜尋已合併客人的舊資訊（姓名/電話/編號）應能找到新會員
- [ ] LINE 暱稱搜尋（rpc_search_aliases）若 alias 對應的會員已合併，會回傳新會員資料
- [ ] 同一條 merge chain 上的多個舊檔同時命中 → 不會重複顯示新會員（DISTINCT）

https://claude.ai/code/session_013mw8PNC9Ssfbkii2VCeqkn

---
_Generated by [Claude Code](https://claude.ai/code/session_013mw8PNC9Ssfbkii2VCeqkn)_