### PR TITLE
fix(db): 商品改名自動同步 skus.product_name (denorm)

### DIFF
--- a/supabase/migrations/20260628000010_sync_product_name_to_skus.sql
+++ b/supabase/migrations/20260628000010_sync_product_name_to_skus.sql
@@ -1,0 +1,69 @@
+-- ============================================================
+-- 同步 products.name → skus.product_name (denorm 欄位)
+--
+-- 背景：
+--   skus.product_name 是 products.name 的反正規化快照，rpc_upsert_sku 建立／更新
+--   SKU 時會帶過去；但 rpc_upsert_product 改名只動 products.name，沒 cascade，
+--   導致訂單明細 / 揀貨單等讀 skus.product_name 的畫面顯示舊名（例如 LINE 匯入
+--   殘留的 "(emoji)..." 即使在 products 改乾淨了還是出現在訂單裡）。
+--
+--   `_sync_product_name_to_campaigns` 已處理 group_buy_campaigns.name，這裡補做
+--   skus.product_name 對等的同步。
+--
+-- Scope: 加 trigger function + trigger + backfill；不動既有表 / RPC
+-- Rollback:
+--   DROP TRIGGER IF EXISTS trg_products_sync_sku_name ON products;
+--   DROP FUNCTION IF EXISTS public._sync_product_name_to_skus();
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public._sync_product_name_to_skus()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.name IS NOT DISTINCT FROM OLD.name THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE skus
+     SET product_name = NEW.name,
+         updated_at   = NOW()
+   WHERE tenant_id   = NEW.tenant_id
+     AND product_id  = NEW.id
+     AND product_name IS DISTINCT FROM NEW.name;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_products_sync_sku_name ON products;
+CREATE TRIGGER trg_products_sync_sku_name
+  AFTER UPDATE OF name ON products
+  FOR EACH ROW
+  EXECUTE FUNCTION public._sync_product_name_to_skus();
+
+COMMENT ON FUNCTION public._sync_product_name_to_skus() IS
+  'Auto-sync product.name → skus.product_name (denorm snapshot) when product name changes.';
+
+-- ----------------------------------------------------------------
+-- 一次性 backfill：把目前 stale 的 skus.product_name 補成 products.name
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  cnt INT;
+BEGIN
+  WITH updated AS (
+    UPDATE skus s
+       SET product_name = p.name,
+           updated_at   = NOW()
+      FROM products p
+     WHERE s.product_id = p.id
+       AND s.tenant_id  = p.tenant_id
+       AND s.product_name IS DISTINCT FROM p.name
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO cnt FROM updated;
+  RAISE NOTICE 'Backfill: synced % skus.product_name to current products.name', cnt;
+END $$;


### PR DESCRIPTION
## Summary

訂單明細、揀貨單、異常表顯示的商品名是 `skus.product_name`（products.name 的反正規化快照）。`rpc_upsert_product` 改名時只動 `products.name`，沒 cascade，導致改名前的舊快照永遠卡在 SKU 上——典型現象是 LINE 匯入殘留的 `(emoji)...` 即使商品改乾淨後仍出現在歷史訂單。

`_sync_product_name_to_campaigns` trigger 早就處理了 `group_buy_campaigns.name`，本 PR 補做 `skus.product_name` 對等的同步。

## Changes

- 新增 `_sync_product_name_to_skus()` trigger function（SECURITY DEFINER，only updates 同 tenant 同 product_id 的 SKU）
- 綁 `trg_products_sync_sku_name` 在 `products` 的 `AFTER UPDATE OF name`
- 一次性 backfill：把所有 `skus.product_name IS DISTINCT FROM products.name` 的列補成最新

## Test plan

- [ ] Migration 套用後 `pg_trigger` 看得到 `trg_products_sync_sku_name`
- [ ] `SELECT ... WHERE s.product_name IS DISTINCT FROM p.name` 回 0 列（backfill 已清）
- [ ] 手動改一個 product 的 name，確認該 product 底下所有 SKU 的 `product_name` 跟 `updated_at` 都跟著動
- [ ] 訂單明細頁、揀貨單、`OrderDetail.tsx:671`、`PickupDialog.tsx:284`、`orders/page.tsx:822,916`、`ExceptionsContent.tsx:174,325` 顯示的商品名都是新名字
- [ ] 不會影響 1-campaign-1-product invariant trigger（`trg_campaign_items_check_product`）

https://claude.ai/code/session_01FovNwByjngG16QaeACMGBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01FovNwByjngG16QaeACMGBW)_