### PR TITLE
feat(campaigns): 「上架個人賣場」從商品搬到開團,改用 switch

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -301,7 +301,7 @@ export default function CampaignsListPage() {
   async function openEdit(id: number) {
     const { data, error: err } = await getSupabase()
       .from("group_buy_campaigns")
-      .select("id, campaign_no, name, description, status, close_type, start_at, end_at, pickup_deadline, pickup_days, total_cap_qty, notes")
+      .select("id, campaign_no, name, description, status, close_type, start_at, end_at, pickup_deadline, pickup_days, total_cap_qty, notes, is_for_shop")
       .eq("id", id).maybeSingle();
     if (err || !data) { setError(err?.message ?? "找不到開團"); return; }
     setModal({
@@ -319,6 +319,7 @@ export default function CampaignsListPage() {
         pickup_days: data.pickup_days,
         total_cap_qty: data.total_cap_qty != null ? Number(data.total_cap_qty) : null,
         notes: data.notes,
+        is_for_shop: data.is_for_shop ?? true,
       },
     });
   }

--- a/apps/admin/src/components/CampaignForm.tsx
+++ b/apps/admin/src/components/CampaignForm.tsx
@@ -23,6 +23,7 @@ export type CampaignFormValues = {
   pickup_days: number | null;
   total_cap_qty: number | null;
   notes: string | null;
+  is_for_shop: boolean;
 };
 
 export const emptyCampaignValues: CampaignFormValues = {
@@ -38,6 +39,7 @@ export const emptyCampaignValues: CampaignFormValues = {
   pickup_days: null,
   total_cap_qty: null,
   notes: null,
+  is_for_shop: true,
 };
 
 // 使用者可手動切換的狀態僅 3 個；ordered / receiving / ready / completed / cancelled
@@ -122,6 +124,7 @@ export function CampaignForm({
         p_pickup_days: v.pickup_days,
         p_total_cap_qty: v.total_cap_qty,
         p_notes: v.notes,
+        p_is_for_shop: v.is_for_shop,
       });
       if (err) throw err;
       const newId = Number(data);
@@ -275,6 +278,20 @@ export function CampaignForm({
         )}
       </div>
 
+      <div className="flex items-start justify-between gap-3 rounded-md border border-zinc-200 px-3 py-2.5 dark:border-zinc-700">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-sm font-medium text-zinc-700 dark:text-zinc-200">上架個人賣場</span>
+          <span className="text-[11px] text-zinc-500 dark:text-zinc-400">
+            開啟後本團才會出現在會員 App / LIFF 商店。關掉可用於私下測試或內部團。
+          </span>
+        </div>
+        <SwitchToggle
+          checked={v.is_for_shop}
+          onToggle={() => update("is_for_shop", !v.is_for_shop)}
+          ariaLabel="上架個人賣場"
+        />
+      </div>
+
       <p className="text-xs text-zinc-500 dark:text-zinc-400">
         描述、取貨截止 / 天數 在商品多選開團時設定；如需調整請至商品編輯頁。
         單一商品開團的團名會跟著商品名稱自動更新；多商品開團則以此處填的為準。
@@ -403,6 +420,33 @@ function Field({ label, children, className = "" }: { label: string; children: R
       <span className="text-zinc-600 dark:text-zinc-400">{label}</span>
       {children}
     </label>
+  );
+}
+
+function SwitchToggle({
+  checked, onToggle, ariaLabel,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+  ariaLabel?: string;
+}) {
+  return (
+    <SpinButton
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={onToggle}
+      className={`inline-flex h-6 w-11 shrink-0 items-center rounded-full align-middle transition-colors ${
+        checked ? "bg-green-600" : "bg-zinc-300 dark:bg-zinc-700"
+      }`}
+    >
+      <span
+        className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+          checked ? "translate-x-[22px]" : "translate-x-[2px]"
+        }`}
+      />
+    </SpinButton>
   );
 }
 

--- a/apps/admin/src/components/ProductForm.tsx
+++ b/apps/admin/src/components/ProductForm.tsx
@@ -309,11 +309,6 @@ export function ProductForm({
 
       <div className="flex flex-wrap gap-4">
         <Checkbox
-          label="上架個人賣場"
-          checked={values.is_for_shop}
-          onChange={(v) => set("is_for_shop", v)}
-        />
-        <Checkbox
           label="暫停出貨"
           checked={values.stop_shipping}
           onChange={(v) => set("stop_shipping", v)}

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -300,6 +300,8 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
     .select("id, campaign_no, name, description, cover_image_url, close_type, total_cap_qty, end_at, pickup_deadline, campaign_items(unit_price, sort_order, sku:skus(product:products(images)))")
     .eq("tenant_id", tenantId)
     .eq("status", "open")
+    // 開團設定「上架個人賣場」=false 時不出現在 App / LIFF /shop
+    .eq("is_for_shop", true)
     // 排除內部 sentinel 活動(補貨申請),不應出現在顧客商店
     .neq("campaign_no", "__INTERNAL_RESTOCK__")
     .or(`end_at.is.null,end_at.gt.${new Date().toISOString()}`);

--- a/supabase/migrations/20260629000000_campaign_is_for_shop.sql
+++ b/supabase/migrations/20260629000000_campaign_is_for_shop.sql
@@ -1,0 +1,88 @@
+-- ============================================================================
+-- 開團「上架個人賣場」搬到 campaign 維度
+--
+-- 原本 products.is_for_shop 控制商品是否在會員 App / LIFF /shop 出現,
+-- 但實務上同一商品在不同團期會想分別決定要不要曝光 (例如:測試團、
+-- 內部團、員購團…). 改成放在 group_buy_campaigns 上,以團為單位控制。
+-- DEFAULT TRUE 保持向後相容,既有團不會被隱藏。
+-- ============================================================================
+
+-- ── 1. 加欄位 ────────────────────────────────────────────────────────────────
+ALTER TABLE group_buy_campaigns
+  ADD COLUMN IF NOT EXISTS is_for_shop BOOLEAN NOT NULL DEFAULT TRUE;
+
+COMMENT ON COLUMN group_buy_campaigns.is_for_shop IS
+  'TRUE = 在會員 App / LIFF /shop 中顯示此團 (預設 TRUE)';
+
+-- ── 2. rpc_upsert_campaign 收入 14 參數 (加 p_is_for_shop) ────────────────
+-- 用動態 DROP 處理所有 overload (13 / 14 參數版本都清掉, 避免 ambiguous)
+DO $$
+DECLARE r RECORD;
+BEGIN
+  FOR r IN
+    SELECT oid::regprocedure::text AS sig
+      FROM pg_proc WHERE proname = 'rpc_upsert_campaign'
+  LOOP
+    EXECUTE 'DROP FUNCTION ' || r.sig;
+  END LOOP;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.rpc_upsert_campaign(
+  p_id               BIGINT,
+  p_campaign_no      TEXT,
+  p_name             TEXT,
+  p_description      TEXT        DEFAULT NULL,
+  p_cover_image_url  TEXT        DEFAULT NULL,
+  p_status           TEXT        DEFAULT 'draft',
+  p_close_type       TEXT        DEFAULT 'regular',
+  p_start_at         TIMESTAMPTZ DEFAULT NULL,
+  p_end_at           TIMESTAMPTZ DEFAULT NULL,
+  p_pickup_deadline  DATE        DEFAULT NULL,
+  p_pickup_days      INTEGER     DEFAULT NULL,
+  p_total_cap_qty    NUMERIC     DEFAULT NULL,
+  p_notes            TEXT        DEFAULT NULL,
+  p_is_for_shop      BOOLEAN     DEFAULT TRUE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_id     BIGINT;
+BEGIN
+  IF p_id IS NULL THEN
+    INSERT INTO group_buy_campaigns (
+      tenant_id, campaign_no, name, description, cover_image_url,
+      status, close_type, start_at, end_at, pickup_deadline, pickup_days,
+      total_cap_qty, notes, is_for_shop, created_by, updated_by
+    ) VALUES (
+      v_tenant, p_campaign_no, p_name, p_description, p_cover_image_url,
+      COALESCE(p_status,'draft'), COALESCE(p_close_type,'regular'),
+      p_start_at, p_end_at, p_pickup_deadline, p_pickup_days,
+      p_total_cap_qty, p_notes, COALESCE(p_is_for_shop, TRUE),
+      auth.uid(), auth.uid()
+    ) RETURNING id INTO v_id;
+  ELSE
+    UPDATE group_buy_campaigns SET
+      campaign_no = COALESCE(p_campaign_no, campaign_no),
+      name = COALESCE(p_name, name),
+      description = p_description,
+      cover_image_url = p_cover_image_url,
+      status = COALESCE(p_status, status),
+      close_type = COALESCE(p_close_type, close_type),
+      start_at = p_start_at,
+      end_at = p_end_at,
+      pickup_deadline = p_pickup_deadline,
+      pickup_days = p_pickup_days,
+      total_cap_qty = p_total_cap_qty,
+      notes = p_notes,
+      is_for_shop = COALESCE(p_is_for_shop, is_for_shop),
+      updated_by = auth.uid()
+    WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'campaign % not in tenant', p_id; END IF;
+  END IF;
+  RETURN v_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_upsert_campaign TO authenticated;


### PR DESCRIPTION
商品原本的 is_for_shop 改放到 group_buy_campaigns,以團為單位控制是否
在會員 App / LIFF /shop 出現 (預設 TRUE,既有團不會被隱藏)。同一商品
不同團期可以分別決定要不要曝光 (內部團、測試團、員購團)。

- migration: 新增 group_buy_campaigns.is_for_shop + rpc_upsert_campaign
  收入 p_is_for_shop 參數
- liff-api listActiveCampaigns 加 .eq("is_for_shop", true) 過濾
- CampaignForm 加 Switch UI、emptyCampaignValues 預設 true、openEdit
  載入欄位
- ProductForm 移除「上架個人賣場」checkbox (DB 欄位保留, 不再從 UI 編輯)