### PR TITLE
feat(products): 整行可點開編輯 + 暫停出貨改 switch

### DIFF
--- a/apps/admin/src/app/(protected)/products/page.tsx
+++ b/apps/admin/src/app/(protected)/products/page.tsx
@@ -672,21 +672,19 @@ function PageContent() {
             rows.map((r) => (
               <Tr
                 key={r.id}
+                onClick={() => openEdit(r.id)}
                 className={selectedIds.has(r.id) ? "bg-blue-50 dark:bg-blue-950/30" : ""}
               >
                   <Td className="w-10">
                     <input
                       type="checkbox"
                       checked={selectedIds.has(r.id)}
+                      onClick={(e) => e.stopPropagation()}
                       onChange={() => toggleSelect(r.id)}
                       className="cursor-pointer"
                     />
                   </Td>
-                  <Td className="font-mono">
-                    <SpinButton onClick={() => openEdit(r.id)} className="hover:underline">
-                      {r.product_code}
-                    </SpinButton>
-                  </Td>
+                  <Td className="font-mono">{r.product_code}</Td>
                   <Td>
                     <div>{r.name}</div>
                     {r.short_name && <div className="text-xs text-zinc-500">{r.short_name}</div>}
@@ -702,7 +700,7 @@ function PageContent() {
                     {new Date(r.updated_at).toLocaleString("zh-TW")}
                   </Td>
                   <Td>
-                    <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-3" onClick={(e) => e.stopPropagation()}>
                       <SpinButton
                         onClick={() => openEdit(r.id)}
                         className="text-xs text-blue-600 hover:underline dark:text-blue-400"

--- a/apps/admin/src/components/ProductForm.tsx
+++ b/apps/admin/src/components/ProductForm.tsx
@@ -307,11 +307,17 @@ export function ProductForm({
 
       {midSlot}
 
-      <div className="flex flex-wrap gap-4">
-        <Checkbox
-          label="暫停出貨"
+      <div className="flex items-start justify-between gap-3 rounded-md border border-zinc-200 px-3 py-2.5 dark:border-zinc-700">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-sm font-medium text-zinc-700 dark:text-zinc-200">暫停出貨</span>
+          <span className="text-[11px] text-zinc-500 dark:text-zinc-400">
+            開啟後本商品仍會在後台顯示,但採購 / 出貨流程會跳過。
+          </span>
+        </div>
+        <SwitchToggle
           checked={values.stop_shipping}
-          onChange={(v) => set("stop_shipping", v)}
+          onToggle={() => set("stop_shipping", !values.stop_shipping)}
+          ariaLabel="暫停出貨"
         />
       </div>
 
@@ -450,24 +456,31 @@ function Field({
   );
 }
 
-function Checkbox({
-  label,
+function SwitchToggle({
   checked,
-  onChange,
+  onToggle,
+  ariaLabel,
 }: {
-  label: string;
   checked: boolean;
-  onChange: (v: boolean) => void;
+  onToggle: () => void;
+  ariaLabel?: string;
 }) {
   return (
-    <label className="inline-flex cursor-pointer select-none items-center gap-2 text-sm">
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        className="h-4 w-4 rounded border-zinc-300 dark:border-zinc-700"
+    <SpinButton
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={onToggle}
+      className={`inline-flex h-6 w-11 shrink-0 items-center rounded-full align-middle transition-colors ${
+        checked ? "bg-green-600" : "bg-zinc-300 dark:bg-zinc-700"
+      }`}
+    >
+      <span
+        className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+          checked ? "translate-x-[22px]" : "translate-x-[2px]"
+        }`}
       />
-      <span>{label}</span>
-    </label>
+    </SpinButton>
   );
 }


### PR DESCRIPTION
## Summary

- 商品列表整列點下去就會打開編輯 popup,不用瞄商品編號或「編輯」按鈕。checkbox / 編輯 / 刪除按鈕加 `stopPropagation` 不被誤觸。
- 商品編號欄不再是按鈕,變純文字 (整列都能點)。
- 編輯 popup 內的「暫停出貨」也從 checkbox 換成 switch,跟 #355 開團那邊的「上架個人賣場」用同款綠色 toggle 樣式。

## Test plan

- [ ] `/products` 點任一列 → 開啟編輯 popup
- [ ] 點選列 checkbox 不會誤開 popup,正確切換多選狀態
- [ ] 點「編輯」/「刪除」按鈕不會額外開 popup,行為跟原本一樣
- [ ] 編輯 popup 內「暫停出貨」是 switch,點擊能切換 on/off 並儲存


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjjWyy8NLnJsVgYbEparah)_