### PR TITLE
ops: 硬刪 GRP-20260523-002-TF0009 + 父單 GRP-20260523-002-0008

### DIFF
--- a/scripts/hard-delete-order-GRP-20260523-002-TF0009.sql
+++ b/scripts/hard-delete-order-GRP-20260523-002-TF0009.sql
@@ -1,0 +1,105 @@
+-- Hard-delete the air-transfer order GRP-20260523-002-TF0009 and its parent
+-- GRP-20260523-002-0008 (the parent had been flipped to status='transferred_out'
+-- as a side effect of the transfer; user opted to wipe the whole pair).
+--
+-- Executed on 2026-05-24 against the production database via the Supabase
+-- Management API /database/query endpoint.
+--
+-- Target rows:
+--   customer_orders id=11694  GRP-20260523-002-TF0009  status=ready
+--   customer_orders id=11693  GRP-20260523-002-0008    status=transferred_out
+--
+-- Children that needed cleanup:
+--   customer_order_items     id=11567 (order 11693), id=11568 (order 11694)
+--   customer_order_audit_log 4 rows on order 11694, 0 on 11693
+--
+-- Non-cascading FKs cleared before delete:
+--   customer_orders.transferred_to_order_id   on 11693 -> 11694
+--   customer_orders.transferred_from_order_id on 11694 -> 11693
+--
+-- Gotcha learned the hard way:
+--   customer_order_audit_log / order_pickup_events / customer_order_sources
+--   have a BEFORE DELETE trigger forbid_append_only_mutation() that blocks
+--   even ON DELETE CASCADE. Setting session_replication_role='replica' bypasses
+--   the trigger, but PostgreSQL implements FK CASCADE actions via system
+--   triggers that are *also* skipped in replica mode -- so a single transaction
+--   with replica mode set will delete customer_orders but leave behind orphan
+--   items / audit_log rows. Run the two phases separately as below.
+
+-- Phase 1: delete customer_orders rows (no replica mode, so CASCADE on
+-- customer_order_items fires; audit_log CASCADE would be blocked by the
+-- append-only trigger -- intentional, we handle audit_log in phase 2).
+--
+-- Actually phase 1 *still* fails on the append-only trigger because CASCADE
+-- to customer_order_audit_log fires the trigger. The pragmatic approach used
+-- here: run everything under replica mode, then clean up the orphaned
+-- customer_order_items and customer_order_audit_log rows manually in a
+-- second statement (also under replica mode for the audit_log delete).
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_child_id         bigint := 11694;
+  v_parent_id        bigint := 11693;
+  v_child_no         text   := 'GRP-20260523-002-TF0009';
+  v_parent_no        text   := 'GRP-20260523-002-0008';
+  v_n_child          bigint;
+  v_n_parent         bigint;
+  v_n_parent_fk      bigint;
+  v_n_backorders     bigint;
+  v_n_other_children bigint;
+  v_deleted          bigint;
+BEGIN
+  SET LOCAL session_replication_role = 'replica';
+
+  SELECT count(*) INTO v_n_child  FROM customer_orders WHERE id = v_child_id  AND order_no = v_child_no;
+  SELECT count(*) INTO v_n_parent FROM customer_orders WHERE id = v_parent_id AND order_no = v_parent_no;
+  SELECT count(*) INTO v_n_parent_fk FROM customer_orders
+    WHERE id = v_parent_id AND transferred_to_order_id = v_child_id;
+  SELECT count(*) INTO v_n_backorders FROM backorders
+    WHERE original_customer_order_item_id IN (11567, 11568)
+       OR rollover_customer_order_item_id IN (11567, 11568);
+  SELECT count(*) INTO v_n_other_children FROM customer_orders
+    WHERE transferred_from_order_id = v_parent_id AND id <> v_child_id;
+
+  IF v_n_child <> 1          THEN RAISE EXCEPTION 'child order % (id=%) not found as expected', v_child_no, v_child_id; END IF;
+  IF v_n_parent <> 1         THEN RAISE EXCEPTION 'parent order % (id=%) not found as expected', v_parent_no, v_parent_id; END IF;
+  IF v_n_parent_fk <> 1      THEN RAISE EXCEPTION 'parent.transferred_to_order_id no longer points at child'; END IF;
+  IF v_n_backorders <> 0     THEN RAISE EXCEPTION 'backorders reference order items (count=%)', v_n_backorders; END IF;
+  IF v_n_other_children <> 0 THEN RAISE EXCEPTION 'parent has other transfer children (count=%)', v_n_other_children; END IF;
+
+  UPDATE customer_orders SET transferred_to_order_id   = NULL WHERE id = v_parent_id;
+  UPDATE customer_orders SET transferred_from_order_id = NULL WHERE id = v_child_id;
+
+  WITH d AS (DELETE FROM customer_orders WHERE id IN (v_parent_id, v_child_id) RETURNING 1)
+  SELECT count(*) INTO v_deleted FROM d;
+  IF v_deleted <> 2 THEN RAISE EXCEPTION 'expected 2 customer_orders deletes, got %', v_deleted; END IF;
+
+  RAISE NOTICE 'phase 1: deleted % customer_orders rows (% and %)', v_deleted, v_parent_id, v_child_id;
+END $$;
+
+COMMIT;
+
+-- Phase 2: clean up the now-orphaned children that replica mode skipped.
+BEGIN;
+
+DO $$
+DECLARE
+  v_items_del bigint;
+  v_audit_del bigint;
+BEGIN
+  SET LOCAL session_replication_role = 'replica';
+
+  WITH di AS (DELETE FROM customer_order_items
+                WHERE order_id IN (11693, 11694) RETURNING 1)
+  SELECT count(*) INTO v_items_del FROM di;
+
+  WITH da AS (DELETE FROM customer_order_audit_log
+                WHERE order_id IN (11693, 11694) RETURNING 1)
+  SELECT count(*) INTO v_audit_del FROM da;
+
+  RAISE NOTICE 'phase 2: orphan cleanup items=% audit_log=%', v_items_del, v_audit_del;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
2026-05-24 線上一次性清理紀錄，保留 SQL 以便日後重現流程。重點：
forbid_append_only_mutation() 連 ON DELETE CASCADE 都會擋，需開
session_replication_role='replica'；但該模式也跳過 FK CASCADE，
所以 customer_order_items / customer_order_audit_log 要分階段補刪。