### PR TITLE
fix(transfer): unify pickup status + require ready to transfer</title>
<parameter name="body">test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+專案層級的給 Claude 的 standing rules，**在這個 repo 裡的每個 Claude session 一進來就會載到 context**。
+新規則靠經驗累積、踩雷後寫進來；別寫一般性建議，只寫「不寫進來就會再犯一次」的事。
+
+---
+
+## Supabase / DB
+
+### 部署 migration 走 Management API，不要戳 pooler TCP
+
+直連 pooler 的 5432 / 6543 TCP 在這個環境被擋。要對線上 DB 跑 SQL（包含套 migration）統一走 Supabase Management API：
+
+```
+POST https://api.supabase.com/v1/projects/{ref}/database/query
+Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}
+Content-Type: application/json
+{ "query": "<sql>" }
+```
+
+不要再嘗試 `psql postgresql://...pooler...`、`supabase db push` 直連、Node `pg` client 等等 — 都會卡在 network，浪費時間。
+
+### 重寫 function 前，先 grep 歷史 migration
+
+`supabase/migrations/` 是 append-only，同一支 function / view 常被多支 migration 用 `CREATE OR REPLACE` 修過。若直接基於「最早建立的版本」改寫，會把後面散落的多個修法整個蓋掉，產生 regression。
+
+改一支 function 之前，**一律先**：
+
+```bash
+grep -rn "<function_name>" supabase/migrations/
+```
+
+把每一個動過該 function 的 migration 都讀過，基於**時間最新**那個版本擴寫，確保所有 prior fix 都保留。
+新 migration 檔頭註解務必列出「以哪個版本為基底」、「rollback 指回哪個版本」。

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -526,7 +526,7 @@ function OfferModal({
           items:customer_order_items(campaign_item_id, sku_id, qty, status, sku:skus(sku_code, product_name, variant_name))
         `)
         .eq("pickup_store_id", storeId)
-        .in("status", ["pending", "confirmed", "reserved"])
+        .eq("status", "ready")
         .order("id", { ascending: false })
         .limit(50);
       if (cancelled) return;
@@ -1120,7 +1120,7 @@ function FulfillRequestDialog({
           items:customer_order_items!inner(sku_id, qty, status, sku:skus(sku_code, product_name, variant_name))
         `)
         .eq("pickup_store_id", myStore)
-        .in("status", ["pending", "confirmed", "reserved"])
+        .eq("status", "ready")
         .eq("items.sku_id", post.sku_id)
         .not("items.status", "in", "(cancelled,expired,picked_up)")
         .order("id", { ascending: false })

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -149,7 +149,6 @@ function OrdersListContent() {
       }
     >
   >(new Map());
-  const [pickupReady, setPickupReady] = useState<Map<number, boolean>>(new Map());
   const [detailId, setDetailId] = useState<number | null>(null);
   const [detailNo, setDetailNo] = useState<string>("");
   const [returnTarget, setReturnTarget] = useState<{ orderId: number; storeId: number } | null>(null);
@@ -258,16 +257,13 @@ function OrdersListContent() {
 
         const ids = (data ?? []).map((r) => r.id);
         const memIds = Array.from(new Set((data ?? []).map((r) => r.member_id).filter((x): x is number => x != null)));
-        const [ic, ms, pr] = await Promise.all([
+        const [ic, ms] = await Promise.all([
           ids.length
             ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price, sku:skus(product_name, variant_name)").in("order_id", ids)
             : Promise.resolve({ data: [] as { order_id: number; qty: number; unit_price: number; sku: { product_name: string | null; variant_name: string | null } | null }[] }),
           memIds.length
             ? getSupabase().from("members").select("id, name, phone, member_no, avatar_url").in("id", memIds)
             : Promise.resolve({ data: [] as Member[] }),
-          ids.length
-            ? getSupabase().from("v_order_pickup_ready").select("order_id, pickup_ready").in("order_id", ids)
-            : Promise.resolve({ data: [] as { order_id: number; pickup_ready: boolean }[] }),
         ]);
         const im = new Map<number, { lineCount: number; totalQty: number; totalAmount: number; items: { product_name: string | null; variant_name: string | null; qty: number }[] }>();
         for (const id of ids) im.set(id, { lineCount: 0, totalQty: 0, totalAmount: 0, items: [] });
@@ -285,11 +281,7 @@ function OrdersListContent() {
         }
         const mm = new Map<number, Member>();
         for (const m of (ms.data as Member[]) ?? []) mm.set(m.id, m);
-        const prMap = new Map<number, boolean>();
-        for (const row of (pr.data as { order_id: number; pickup_ready: boolean }[]) ?? []) {
-          prMap.set(row.order_id, row.pickup_ready);
-        }
-        if (!cancelled) { setItemSummary(im); setMembers(mm); setPickupReady(prMap); }
+        if (!cancelled) { setItemSummary(im); setMembers(mm); }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       } finally {
@@ -488,8 +480,7 @@ function OrdersListContent() {
   const orderActions = (r: Row, m: Member | null | undefined) => (
     <>
       {!["completed","expired","cancelled","transferred_out"].includes(r.status) && (() => {
-        // 取貨判斷改用 v_order_pickup_ready
-        const canPickup = pickupReady.get(r.id) === true;
+        const canPickup = r.status === "ready";
         // 訂單頁本身不執行取貨,只導向 /pickup (帶會員編號自動搜尋)
         if (canPickup && m?.member_no) {
           return (

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -32,7 +32,6 @@ type OpenOrder = {
   ready_at: string | null;       // 到貨時間 (shipping → ready 自動寫入)
   last_notify_pickup_at: string | null;
   notify_pickup_count: number;
-  pickup_ready?: boolean; // 從 v_order_pickup_ready merge 進來
   campaign: { id: number; campaign_no: string; name: string } | null;
   store: { id: number; name: string } | null;
   items: {
@@ -51,10 +50,8 @@ type OpenOrder = {
 const ACTIVE_STATUSES = ["pending", "confirmed", "reserved", "ready", "partially_ready", "partially_completed", "shipping"];
 const INACTIVE_ITEM_STATUSES = new Set(["cancelled", "picked_up", "expired"]);
 
-// 取貨判斷改用 v_order_pickup_ready (基於分店收貨 transfer 實際狀態)
-// 不再依賴 customer_orders.status === 'ready'（status 同步可能漏推）
 function isPickable(order: OpenOrder): boolean {
-  return order.pickup_ready === true;
+  return order.status === "ready";
 }
 function activeItems(order: OpenOrder) {
   return order.items.filter((it) => !INACTIVE_ITEM_STATUSES.has(it.status));
@@ -143,29 +140,19 @@ function PickupPageContent() {
         .order("updated_at", { ascending: false });
       if (e2) { setError(e2.message); return; }
 
-      // 一次撈所有訂單的 pickup_ready
-      const orderIds = (ords ?? []).map((o) => o.id);
-      const { data: prData } = orderIds.length > 0
-        ? await sb.from("v_order_pickup_ready").select("order_id, pickup_ready").in("order_id", orderIds)
-        : { data: [] as { order_id: number; pickup_ready: boolean }[] };
-      const prMap = new Map<number, boolean>();
-      for (const row of (prData as { order_id: number; pickup_ready: boolean }[]) ?? []) {
-        prMap.set(row.order_id, row.pickup_ready);
-      }
-
       const m = new Map<number, OpenOrder[]>();
       for (const r of (ords ?? []) as unknown as (OpenOrder & { member_id: number })[]) {
-        // merge pickup_ready 進每筆 order
-        r.pickup_ready = prMap.get(r.id) ?? false;
         const arr = m.get(r.member_id) ?? [];
         arr.push(r);
         m.set(r.member_id, arr);
       }
       // 依「可取貨」優先 + 到貨時間久的優先（催客人取貨）
-      // pickup_ready=true 在前；group 內 ready_at ASC NULLS LAST；末層 updated_at DESC
+      // status='ready' 在前；group 內 ready_at ASC NULLS LAST；末層 updated_at DESC
       for (const arr of m.values()) {
         arr.sort((a, b) => {
-          if (a.pickup_ready !== b.pickup_ready) return a.pickup_ready ? -1 : 1;
+          const aReady = a.status === "ready";
+          const bReady = b.status === "ready";
+          if (aReady !== bReady) return aReady ? -1 : 1;
           const aT = a.ready_at ? Date.parse(a.ready_at) : Number.POSITIVE_INFINITY;
           const bT = b.ready_at ? Date.parse(b.ready_at) : Number.POSITIVE_INFINITY;
           if (aT !== bT) return aT - bT;
@@ -274,7 +261,7 @@ function PickupPageContent() {
       alert(`${member.name ?? member.member_no} 已設「不通知」，無法發送取貨通知。`);
       return;
     }
-    if (!order.pickup_ready) {
+    if (order.status !== "ready") {
       alert("此訂單尚未到貨，無法通知");
       return;
     }

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -121,7 +121,6 @@ export function OrderDetail({
   const [items, setItems] = useState<ItemRow[] | null>(null);
   const [timeline, setTimeline] = useState<TimelineStep[] | null>(null);
   const [staffNames, setStaffNames] = useState<Map<string, string>>(new Map());
-  const [pickupReady, setPickupReady] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
   const [transferOpen, setTransferOpen] = useState(false);
@@ -207,15 +206,6 @@ export function OrderDetail({
       const tl = await buildTimeline(headData, skuIds, onNavigate);
       if (!cancelled) setTimeline(tl);
 
-      // ========== 載入 pickup_ready (基於分店收貨 transfer 實際狀態) ==========
-      const { data: prData } = await sb
-        .from("v_order_pickup_ready")
-        .select("pickup_ready")
-        .eq("order_id", orderId)
-        .maybeSingle();
-      if (!cancelled) {
-        setPickupReady(((prData as { pickup_ready: boolean } | null)?.pickup_ready) ?? false);
-      }
     })();
     return () => { cancelled = true; };
   }, [orderId, reloadTick]);
@@ -420,11 +410,7 @@ export function OrderDetail({
     setReloadTick((n) => n + 1);
   }
   const pickableItems = items.filter((it) => ["pending", "reserved", "ready"].includes(it.status));
-  // 取貨判斷改用 v_order_pickup_ready (基於分店收貨 transfer 實際狀態)
-  // 不再依賴 customer_orders.status === 'ready'（status 同步可能漏推）
-  const canPickup = pickableItems.length > 0
-    && !["completed","expired","cancelled","transferred_out"].includes(head.status)
-    && pickupReady;
+  const canPickup = pickableItems.length > 0 && head.status === "ready";
   const memberLabel = head.member
     ? `${head.member.name ?? "—"} (${head.member.member_no})`
     : `(${head.nickname_snapshot ?? "—"})`;

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -346,7 +346,8 @@ export function OrderDetail({
 
   // 互助單：有來源單 + 至少一個 aid_transfer 品項（對齊 rpc_return_aid_order 的判定）
   const isAidOrder = head.transferred_from_order_id != null && items.some((it) => it.source === "aid_transfer");
-  const canTransfer = ["pending", "confirmed", "reserved", "ready"].includes(head.status);
+  // 貨還沒到分店不能轉單：source 必須 status='ready' (跟 DB rpc_transfer_order_* 一致)
+  const canTransfer = head.status === "ready";
   const canCancel = ["pending", "confirmed", "shipping"].includes(head.status);
   // 一般顧客訂單退回總倉（rpc_create_order_return）— 互助單不走這條（貨應退回原 source 店）
   const canReturn = !isAidOrder && ["shipping", "ready", "partially_completed", "completed", "expired"].includes(head.status);

--- a/supabase/migrations/20260629000020_fix_same_store_transfer_force_ready.sql
+++ b/supabase/migrations/20260629000020_fix_same_store_transfer_force_ready.sql
@@ -1,0 +1,554 @@
+-- ============================================================
+-- Fix: 同店互轉訂單不應被強制設為 'ready'
+--
+-- 背景：
+-- 20260508140000_transfer_same_store_skip_status.sql 為了「同店互轉時庫存沒
+-- 移動」的 use case，在 rpc_transfer_order_to_store / rpc_transfer_order_partial
+-- 把同店 (p_to_pickup_store_id == v_orig.pickup_store_id) 的新訂單 status 一律
+-- 強制設為 'ready'，並補 4 筆 audit log (pending→confirmed→reserved→shipping
+-- →ready, edit_reason='同店互轉自動推進')。
+--
+-- Bug 案例：GRP-20260523-002-0007 (member Peggy, 松山店, status=pending、
+-- items pending、無 reserved_movement) → 轉到同店的 store_internal member
+-- (松山店 自己的虛擬會員) → 新單 GRP-20260523-002-TF0008 (id=11703)。同店 →
+-- 被強制設為 status='ready'，UI 直接讀 status='ready' 翻成「可取貨」。但
+-- campaign 956 (GRP-20260523-002) 還 open、wave 都沒產生，物理上根本沒收貨。
+--
+-- Root cause：同店強制 'ready' 假設「庫存已經在這個店」，但對 source.status='pending'
+-- 的訂單來說，根本沒收貨、沒 wave、沒 allocation。force ready 是錯的。
+--
+-- 修法：
+-- 1. rpc_transfer_order_to_store / rpc_transfer_order_partial：
+--    - 同店：新訂單 status 改成 mirror source 的 status (v_orig.status)
+--    - 跨店：維持 'pending'（原本就是）
+--    - 刪掉同店那 4 筆假的 audit log（沒有實際 transition、純粹是 audit noise）
+-- 2. is_order_pickup_ready（修正 20260629000010 過嚴的副作用）：
+--    - aid_transfer + 跨店 (transferred_from.pickup_store != co.pickup_store)：
+--      只認 Path A (transfers FK 收貨)
+--    - aid_transfer + 同店：放回 Path A/B/C（因為 campaign 的 wave 進到該店即算）
+--    - 非 aid_transfer 訂單：Path A/B/C 維持
+--    - 移除 20260629000010 的 `co.status='ready'` 逃生口 — 修了 RPC 後不再需要
+-- 3. Backfill：把過去被同店強制設為 'ready' 但實際 pickup_ready=false 的訂單
+--    退回 'pending'，並寫 1 筆修正 audit log。
+--
+-- Rollback: 把這 3 支 function CREATE OR REPLACE 回 20260629000010 的版本，
+-- 並把這次 backfill UPDATE 的訂單手動改回 'ready'（可從本 migration 的
+-- NOTICE 量觀察）。
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. is_order_pickup_ready
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_order_pickup_ready(p_order_id bigint)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT EXISTS (
+    SELECT 1
+      FROM customer_orders co
+     WHERE co.id = p_order_id
+       AND co.status NOT IN ('completed','expired','cancelled','transferred_out')
+       AND CASE
+         -- Aid-transfer + 跨店：只認自己的 transfer 被收貨 (Path A)
+         WHEN EXISTS (
+                SELECT 1 FROM customer_order_items coi
+                 WHERE coi.order_id = co.id AND coi.source = 'aid_transfer'
+              )
+              AND co.transferred_from_order_id IS NOT NULL
+              AND (
+                SELECT src.pickup_store_id FROM customer_orders src
+                 WHERE src.id = co.transferred_from_order_id
+              ) IS DISTINCT FROM co.pickup_store_id
+         THEN
+           EXISTS (
+             SELECT 1 FROM transfers t
+              WHERE t.customer_order_id = co.id
+                AND t.tenant_id = co.tenant_id
+                AND t.status IN ('received','closed')
+           )
+         ELSE (
+           -- aid_transfer 同店、或非 aid 訂單：維持 Path A / B / C
+           -- Path A：互助訂單 — transfer 直接 FK 到 order
+           EXISTS (
+             SELECT 1 FROM transfers t
+              WHERE t.customer_order_id = co.id
+                AND t.tenant_id = co.tenant_id
+                AND t.status IN ('received','closed')
+           )
+           OR
+           -- Path B：普通團購 (per-camp PR) — wave_items.campaign_id 匹配
+           EXISTS (
+             SELECT 1
+               FROM picking_wave_items pwi
+               JOIN transfers t
+                 ON t.tenant_id = pwi.tenant_id
+                AND t.transfer_type = 'hq_to_store'
+                AND t.transfer_no = 'WAVE-' || pwi.wave_id || '-S' || co.pickup_store_id
+                AND t.status IN ('received','closed')
+              WHERE pwi.tenant_id = co.tenant_id
+                AND pwi.campaign_id = co.campaign_id
+                AND pwi.store_id = co.pickup_store_id
+           )
+           OR
+           -- Path C：close_date aggregated PR fallback
+           -- 不檢 campaign_id 嚴格相等、改檢「所有 active items 的 (sku, store)
+           -- 都有對應 received transfer」即算 ready。
+           NOT EXISTS (
+             SELECT 1 FROM customer_order_items coi
+              WHERE coi.order_id = co.id
+                AND coi.status NOT IN ('picked_up', 'cancelled', 'expired')
+                AND NOT EXISTS (
+                  SELECT 1
+                    FROM picking_wave_items pwi
+                    JOIN transfers t
+                      ON t.tenant_id = pwi.tenant_id
+                     AND t.transfer_type = 'hq_to_store'
+                     AND t.transfer_no = 'WAVE-' || pwi.wave_id || '-S' || co.pickup_store_id
+                     AND t.status IN ('received','closed')
+                   WHERE pwi.tenant_id = co.tenant_id
+                     AND pwi.store_id = co.pickup_store_id
+                     AND pwi.sku_id = coi.sku_id
+                )
+           )
+         )
+       END
+  );
+$function$;
+
+COMMENT ON FUNCTION public.is_order_pickup_ready(bigint) IS
+  'aid_transfer 訂單依「跨店 vs 同店」分流：跨店只認 Path A (transfers FK 收貨)、'
+  '同店維持 Path A/B/C（campaign wave 到該店即算）。非 aid 訂單一律 Path A/B/C。';
+
+-- ----------------------------------------------------------------
+-- 2. rpc_transfer_order_to_store — 同店改 mirror source.status
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_to_store(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_item             RECORD;
+  v_orig_mov         RECORD;
+  v_rev_id           BIGINT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_note_out         TEXT;
+  v_note_in          TEXT;
+  v_new_status       TEXT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  IF v_orig.status NOT IN ('pending','confirmed','reserved','ready') THEN
+    RAISE EXCEPTION 'order % status=%, only pending/confirmed/reserved/ready can be transferred',
+                    p_order_id, v_orig.status;
+  END IF;
+
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  PERFORM 1 FROM line_channels
+   WHERE id = v_to_channel_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'channel % not in tenant', v_to_channel_id;
+  END IF;
+
+  PERFORM 1 FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id;
+  IF FOUND THEN
+    RAISE EXCEPTION 'receiver already has order in (campaign=%, channel=%, member=%)',
+                    v_orig.campaign_id, v_to_channel_id, v_to_member_id;
+  END IF;
+
+  -- E2: 釋放 reserved_movement（無條件、跟以前一致；同店也走這條）
+  FOR v_item IN
+    SELECT id, reserved_movement_id FROM customer_order_items
+     WHERE order_id = p_order_id AND reserved_movement_id IS NOT NULL
+  LOOP
+    SELECT * INTO v_orig_mov FROM stock_movements WHERE id = v_item.reserved_movement_id;
+    IF FOUND THEN
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+        source_doc_type, source_doc_id, reverses, reason, operator_id
+      ) VALUES (
+        v_orig_mov.tenant_id, v_orig_mov.location_id, v_orig_mov.sku_id,
+        -v_orig_mov.quantity, v_orig_mov.unit_cost, 'reversal',
+        'order_transfer', p_order_id, v_orig_mov.id,
+        'order #' || p_order_id || ' transferred out, release allocation', p_operator
+      ) RETURNING id INTO v_rev_id;
+
+      UPDATE stock_movements SET reversed_by = v_rev_id WHERE id = v_orig_mov.id;
+      UPDATE customer_order_items SET reserved_movement_id = NULL WHERE id = v_item.id;
+    END IF;
+  END LOOP;
+
+  SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+  SELECT COUNT(*) + 1 INTO v_seq
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+  v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+  v_note_in := COALESCE(p_reason, '') ||
+               E'\n[轉入 ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+               to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  -- 同店：mirror source.status；跨店：'pending'
+  v_new_status := CASE
+    WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN v_orig.status
+    ELSE 'pending'
+  END;
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id,
+    nickname_snapshot, pickup_store_id, status, notes,
+    transferred_from_order_id,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+    v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status, v_note_in,
+    p_order_id,
+    p_operator, p_operator, v_now, v_now
+  ) RETURNING id INTO v_new_order_id;
+
+  INSERT INTO customer_order_items (
+    tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+    status, source, notes, created_by, updated_by
+  )
+  SELECT tenant_id, v_new_order_id, campaign_item_id, sku_id, qty, unit_price,
+         'pending', 'aid_transfer', notes, p_operator, p_operator
+    FROM customer_order_items
+   WHERE order_id = p_order_id;
+
+  v_note_out := COALESCE(p_reason, '') ||
+                E'\n[轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  UPDATE customer_orders
+     SET status                   = 'transferred_out',
+         transferred_to_order_id  = v_new_order_id,
+         notes                    = COALESCE(notes, '') || v_note_out,
+         updated_by               = p_operator,
+         updated_at               = v_now
+   WHERE id = p_order_id;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_to_store(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT) TO authenticated;
+
+-- ----------------------------------------------------------------
+-- 3. rpc_transfer_order_partial — 同店改 mirror source.status
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_partial(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT,
+  p_items                 JSONB,
+  p_is_air_transfer       BOOLEAN DEFAULT FALSE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_p_item           JSONB;
+  v_p_sku_id         BIGINT;
+  v_p_qty            NUMERIC;
+  v_src_item_id      BIGINT;
+  v_src_item_qty     NUMERIC;
+  v_src_item_ci      BIGINT;
+  v_src_item_price   NUMERIC;
+  v_src_item_reserved BIGINT;
+  v_remaining_count  INT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_existing_order   BIGINT;
+  v_appended         BOOLEAN := FALSE;
+  v_new_status       TEXT;
+BEGIN
+  IF p_items IS NULL OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'p_items is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  IF v_orig.status NOT IN ('pending','confirmed','reserved','ready') THEN
+    RAISE EXCEPTION 'order % status=%, only pending/confirmed/reserved/ready can be transferred',
+                    p_order_id, v_orig.status;
+  END IF;
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  SELECT id INTO v_existing_order
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id
+     AND status NOT IN ('expired','cancelled','transferred_out');
+
+  IF v_existing_order IS NOT NULL THEN
+    v_new_order_id := v_existing_order;
+    v_appended := TRUE;
+    SELECT order_no INTO v_new_order_no FROM customer_orders WHERE id = v_existing_order;
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[追加轉入 (' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+                   ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS') ||
+                   COALESCE(' / ' || p_reason, ''),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = v_new_order_id;
+  ELSE
+    SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+    SELECT COUNT(*) + 1 INTO v_seq
+      FROM customer_orders
+     WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+    v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+    -- 同店：mirror source.status；跨店：'pending'
+    v_new_status := CASE
+      WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN v_orig.status
+      ELSE 'pending'
+    END;
+
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id,
+      nickname_snapshot, pickup_store_id, status, notes,
+      transferred_from_order_id, is_air_transfer,
+      created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+      v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status,
+      COALESCE(p_reason, '') ||
+        E'\n[轉入 (部分, ' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+        ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+        to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+      p_order_id, p_is_air_transfer,
+      p_operator, p_operator, v_now, v_now
+    ) RETURNING id INTO v_new_order_id;
+  END IF;
+
+  FOR v_p_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_p_sku_id := (v_p_item ->> 'sku_id')::BIGINT;
+    v_p_qty    := (v_p_item ->> 'qty')::NUMERIC;
+    IF v_p_qty IS NULL OR v_p_qty <= 0 THEN
+      RAISE EXCEPTION 'p_items: qty must be > 0';
+    END IF;
+
+    SELECT id, qty, campaign_item_id, unit_price, reserved_movement_id
+      INTO v_src_item_id, v_src_item_qty, v_src_item_ci, v_src_item_price, v_src_item_reserved
+      FROM customer_order_items
+     WHERE order_id = p_order_id
+       AND sku_id   = v_p_sku_id
+       AND status   != 'cancelled'
+     ORDER BY id
+     LIMIT 1
+     FOR UPDATE;
+    IF v_src_item_id IS NULL THEN
+      RAISE EXCEPTION 'sku % not in order % (or already cancelled)', v_p_sku_id, p_order_id;
+    END IF;
+    IF v_src_item_reserved IS NOT NULL THEN
+      RAISE EXCEPTION 'sku % already allocated (reserved_movement_id=%); release first',
+                      v_p_sku_id, v_src_item_reserved;
+    END IF;
+    IF v_src_item_qty < v_p_qty THEN
+      RAISE EXCEPTION 'sku % insufficient qty: source=%, requested=%',
+                      v_p_sku_id, v_src_item_qty, v_p_qty;
+    END IF;
+
+    IF v_src_item_qty = v_p_qty THEN
+      UPDATE customer_order_items
+         SET status = 'cancelled', updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    ELSE
+      UPDATE customer_order_items
+         SET qty = qty - v_p_qty, updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    END IF;
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by
+    ) VALUES (
+      v_tenant_id, v_new_order_id, v_src_item_ci, v_p_sku_id, v_p_qty, v_src_item_price,
+      'pending', 'aid_transfer', p_operator, p_operator
+    );
+  END LOOP;
+
+  SELECT COUNT(*) INTO v_remaining_count
+    FROM customer_order_items
+   WHERE order_id = p_order_id AND status != 'cancelled';
+
+  IF v_remaining_count = 0 THEN
+    UPDATE customer_orders
+       SET status = 'transferred_out',
+           transferred_to_order_id = v_new_order_id,
+           notes = COALESCE(notes, '') ||
+                   E'\n[全部轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  ELSE
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[' || CASE WHEN v_appended THEN '部分追加' ELSE '部分轉出' END ||
+                   ' → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  END IF;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_partial(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB, BOOLEAN) TO authenticated;
+
+-- ----------------------------------------------------------------
+-- 4. Backfill：把過去被同店強制設為 'ready'、但實際 pickup_ready=false 的
+--    訂單退回 'pending'，並寫 1 筆 audit log。
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  v_uid       UUID;
+  v_reverted  INTEGER := 0;
+  v_rec       RECORD;
+BEGIN
+  SELECT id INTO v_uid FROM auth.users ORDER BY created_at LIMIT 1;
+
+  FOR v_rec IN
+    SELECT co.id
+      FROM customer_orders co
+     WHERE co.status = 'ready'
+       AND EXISTS (
+         SELECT 1 FROM customer_order_audit_log al
+          WHERE al.order_id = co.id
+            AND al.field = 'status'
+            AND al.edit_reason LIKE '同店互轉自動推進%'
+       )
+       AND NOT public.is_order_pickup_ready(co.id)
+  LOOP
+    UPDATE customer_orders
+       SET status     = 'pending',
+           ready_at   = NULL,
+           updated_by = v_uid,
+           updated_at = NOW()
+     WHERE id = v_rec.id;
+
+    PERFORM rpc_log_order_status_change(
+      v_rec.id, 'ready', 'pending', v_uid,
+      '修正：同店互轉曾被誤強制設為 ready；實際無收貨、退回 pending'
+    );
+    v_reverted := v_reverted + 1;
+  END LOOP;
+
+  RAISE NOTICE 'Backfill: reverted % orders from ready→pending (同店互轉誤判)', v_reverted;
+END $$;

--- a/supabase/migrations/20260629000030_unify_pickup_ready_to_status.sql
+++ b/supabase/migrations/20260629000030_unify_pickup_ready_to_status.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- 統一兩條 status 來源：is_order_pickup_ready 改成 customer_orders.status='ready'
+-- 的 thin alias。
+--
+-- 背景：
+-- 系統內「訂單是否可取貨」歷史上有兩條獨立來源並存：
+--   (1) customer_orders.status (text enum)：UI 的 status badge / label / timeline
+--       全用這個，orderStatusLabel('ready')='可取貨'
+--   (2) v_order_pickup_ready.pickup_ready (boolean，is_order_pickup_ready() 衍生)：
+--       OrderDetail 的「取貨按鈕能不能按」用這個，從 transfers / picking_wave_items
+--       實際收貨狀態算出
+--
+-- 兩條並存的歷史原因 (20260512000008 註解)：
+--   「不依賴 customer_orders.status 同步」
+-- — 當時 RPC 推進 status 不可靠。但現在 ship/receive 流程已成熟
+-- (rpc_ship_aid_order, rpc_receive_transfer, rpc_mark_orders_shipping)、
+-- status 是被妥善維護的。spot-check 結果 (此 migration 前) ：
+--   - status='ready' 但 is_order_pickup_ready=false: 0 張
+--   - is_order_pickup_ready=true 但 status!='ready': 0 張
+-- 兩條來源實際完全一致 → 衍生函式已成 noise。
+--
+-- 過去兩個 bug (GRP-20260523-002-TF0008 / TF0009) 都是這兩條 diverge 造成
+-- (一邊對、一邊錯、UI 看哪邊取決於畫面位置)。改 alias 後永遠不會 diverge。
+--
+-- 修法：is_order_pickup_ready 改成單行 SELECT status = 'ready'。
+-- v_order_pickup_ready 是 wraps 函式、不需要動。
+--
+-- Rollback：CREATE OR REPLACE 回 20260629000020 / 20260615000010 的 Path A/B/C
+-- 完整版本。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.is_order_pickup_ready(p_order_id bigint)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT EXISTS (
+    SELECT 1 FROM customer_orders
+     WHERE id = p_order_id AND status = 'ready'
+  );
+$function$;
+
+COMMENT ON FUNCTION public.is_order_pickup_ready(bigint) IS
+  'Alias for customer_orders.status = ''ready''。20260630 起 status 是 single '
+  'source of truth；本函式僅為向後相容保留 (v_order_pickup_ready / 既有 caller)。';

--- a/supabase/migrations/20260629000040_transfer_require_ready_status.sql
+++ b/supabase/migrations/20260629000040_transfer_require_ready_status.sql
@@ -1,0 +1,414 @@
+-- ============================================================
+-- Rule: 貨還沒到分店不能轉單
+--
+-- 來源：使用者明確要求 — 訂單必須先到貨到原本的取貨店 (即 status='ready')、
+-- 才能執行轉單 (整單 / 部分)。避免把還沒到貨的訂單轉給別人，因為轉單前提是
+-- 物理上有貨在店裡可以再分配。
+--
+-- 之前 F2 check 允許 pending/confirmed/reserved/ready 都能轉，這次收緊到只有
+-- 'ready' 可以。配合 Phase B 已把 is_order_pickup_ready 簡化成 status='ready'
+-- 的 alias，新規則跟 pickup_ready 語意一致。
+--
+-- 改動：rpc_transfer_order_to_store / rpc_transfer_order_partial 的 F2 check
+--      只允 'ready'。其餘邏輯不動 (full CREATE OR REPLACE 基於 20260629000020
+--      已部署到 DB 的版本)。
+--
+-- Rollback：CREATE OR REPLACE 回 20260629000020 的版本 (status NOT IN
+--          ('pending','confirmed','reserved','ready'))。
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- rpc_transfer_order_to_store
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_to_store(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_item             RECORD;
+  v_orig_mov         RECORD;
+  v_rev_id           BIGINT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_note_out         TEXT;
+  v_note_in          TEXT;
+  v_new_status       TEXT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  -- 貨還沒到分店不能轉單：source 必須 status='ready'
+  IF v_orig.status <> 'ready' THEN
+    RAISE EXCEPTION '貨還沒到分店、訂單 % 不可轉單 (status=%)',
+                    p_order_id, v_orig.status;
+  END IF;
+
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  PERFORM 1 FROM line_channels
+   WHERE id = v_to_channel_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'channel % not in tenant', v_to_channel_id;
+  END IF;
+
+  PERFORM 1 FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id;
+  IF FOUND THEN
+    RAISE EXCEPTION 'receiver already has order in (campaign=%, channel=%, member=%)',
+                    v_orig.campaign_id, v_to_channel_id, v_to_member_id;
+  END IF;
+
+  -- E2: 釋放 reserved_movement（無條件、跟以前一致；同店也走這條）
+  FOR v_item IN
+    SELECT id, reserved_movement_id FROM customer_order_items
+     WHERE order_id = p_order_id AND reserved_movement_id IS NOT NULL
+  LOOP
+    SELECT * INTO v_orig_mov FROM stock_movements WHERE id = v_item.reserved_movement_id;
+    IF FOUND THEN
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+        source_doc_type, source_doc_id, reverses, reason, operator_id
+      ) VALUES (
+        v_orig_mov.tenant_id, v_orig_mov.location_id, v_orig_mov.sku_id,
+        -v_orig_mov.quantity, v_orig_mov.unit_cost, 'reversal',
+        'order_transfer', p_order_id, v_orig_mov.id,
+        'order #' || p_order_id || ' transferred out, release allocation', p_operator
+      ) RETURNING id INTO v_rev_id;
+
+      UPDATE stock_movements SET reversed_by = v_rev_id WHERE id = v_orig_mov.id;
+      UPDATE customer_order_items SET reserved_movement_id = NULL WHERE id = v_item.id;
+    END IF;
+  END LOOP;
+
+  SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+  SELECT COUNT(*) + 1 INTO v_seq
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+  v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+  v_note_in := COALESCE(p_reason, '') ||
+               E'\n[轉入 ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+               to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  -- 同店：mirror source.status；跨店：'pending'
+  v_new_status := CASE
+    WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN v_orig.status
+    ELSE 'pending'
+  END;
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id,
+    nickname_snapshot, pickup_store_id, status, notes,
+    transferred_from_order_id,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+    v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status, v_note_in,
+    p_order_id,
+    p_operator, p_operator, v_now, v_now
+  ) RETURNING id INTO v_new_order_id;
+
+  INSERT INTO customer_order_items (
+    tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+    status, source, notes, created_by, updated_by
+  )
+  SELECT tenant_id, v_new_order_id, campaign_item_id, sku_id, qty, unit_price,
+         'pending', 'aid_transfer', notes, p_operator, p_operator
+    FROM customer_order_items
+   WHERE order_id = p_order_id;
+
+  v_note_out := COALESCE(p_reason, '') ||
+                E'\n[轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  UPDATE customer_orders
+     SET status                   = 'transferred_out',
+         transferred_to_order_id  = v_new_order_id,
+         notes                    = COALESCE(notes, '') || v_note_out,
+         updated_by               = p_operator,
+         updated_at               = v_now
+   WHERE id = p_order_id;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_to_store(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT) TO authenticated;
+
+
+-- ----------------------------------------------------------------
+-- rpc_transfer_order_partial
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_partial(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT,
+  p_items                 JSONB,
+  p_is_air_transfer       BOOLEAN DEFAULT FALSE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_p_item           JSONB;
+  v_p_sku_id         BIGINT;
+  v_p_qty            NUMERIC;
+  v_src_item_id      BIGINT;
+  v_src_item_qty     NUMERIC;
+  v_src_item_ci      BIGINT;
+  v_src_item_price   NUMERIC;
+  v_src_item_reserved BIGINT;
+  v_remaining_count  INT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_existing_order   BIGINT;
+  v_appended         BOOLEAN := FALSE;
+  v_new_status       TEXT;
+BEGIN
+  IF p_items IS NULL OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'p_items is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  -- 貨還沒到分店不能轉單：source 必須 status='ready'
+  IF v_orig.status <> 'ready' THEN
+    RAISE EXCEPTION '貨還沒到分店、訂單 % 不可轉單 (status=%)',
+                    p_order_id, v_orig.status;
+  END IF;
+
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  SELECT id INTO v_existing_order
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id
+     AND status NOT IN ('expired','cancelled','transferred_out');
+
+  IF v_existing_order IS NOT NULL THEN
+    v_new_order_id := v_existing_order;
+    v_appended := TRUE;
+    SELECT order_no INTO v_new_order_no FROM customer_orders WHERE id = v_existing_order;
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[追加轉入 (' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+                   ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS') ||
+                   COALESCE(' / ' || p_reason, ''),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = v_new_order_id;
+  ELSE
+    SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+    SELECT COUNT(*) + 1 INTO v_seq
+      FROM customer_orders
+     WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+    v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+    -- 同店：mirror source.status；跨店：'pending'
+    v_new_status := CASE
+      WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN v_orig.status
+      ELSE 'pending'
+    END;
+
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id,
+      nickname_snapshot, pickup_store_id, status, notes,
+      transferred_from_order_id, is_air_transfer,
+      created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+      v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status,
+      COALESCE(p_reason, '') ||
+        E'\n[轉入 (部分, ' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+        ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+        to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+      p_order_id, p_is_air_transfer,
+      p_operator, p_operator, v_now, v_now
+    ) RETURNING id INTO v_new_order_id;
+  END IF;
+
+  FOR v_p_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_p_sku_id := (v_p_item ->> 'sku_id')::BIGINT;
+    v_p_qty    := (v_p_item ->> 'qty')::NUMERIC;
+    IF v_p_qty IS NULL OR v_p_qty <= 0 THEN
+      RAISE EXCEPTION 'p_items: qty must be > 0';
+    END IF;
+
+    SELECT id, qty, campaign_item_id, unit_price, reserved_movement_id
+      INTO v_src_item_id, v_src_item_qty, v_src_item_ci, v_src_item_price, v_src_item_reserved
+      FROM customer_order_items
+     WHERE order_id = p_order_id
+       AND sku_id   = v_p_sku_id
+       AND status   != 'cancelled'
+     ORDER BY id
+     LIMIT 1
+     FOR UPDATE;
+    IF v_src_item_id IS NULL THEN
+      RAISE EXCEPTION 'sku % not in order % (or already cancelled)', v_p_sku_id, p_order_id;
+    END IF;
+    IF v_src_item_reserved IS NOT NULL THEN
+      RAISE EXCEPTION 'sku % already allocated (reserved_movement_id=%); release first',
+                      v_p_sku_id, v_src_item_reserved;
+    END IF;
+    IF v_src_item_qty < v_p_qty THEN
+      RAISE EXCEPTION 'sku % insufficient qty: source=%, requested=%',
+                      v_p_sku_id, v_src_item_qty, v_p_qty;
+    END IF;
+
+    IF v_src_item_qty = v_p_qty THEN
+      UPDATE customer_order_items
+         SET status = 'cancelled', updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    ELSE
+      UPDATE customer_order_items
+         SET qty = qty - v_p_qty, updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    END IF;
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by
+    ) VALUES (
+      v_tenant_id, v_new_order_id, v_src_item_ci, v_p_sku_id, v_p_qty, v_src_item_price,
+      'pending', 'aid_transfer', p_operator, p_operator
+    );
+  END LOOP;
+
+  SELECT COUNT(*) INTO v_remaining_count
+    FROM customer_order_items
+   WHERE order_id = p_order_id AND status != 'cancelled';
+
+  IF v_remaining_count = 0 THEN
+    UPDATE customer_orders
+       SET status = 'transferred_out',
+           transferred_to_order_id = v_new_order_id,
+           notes = COALESCE(notes, '') ||
+                   E'\n[全部轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  ELSE
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[' || CASE WHEN v_appended THEN '部分追加' ELSE '部分轉出' END ||
+                   ' → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  END IF;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_partial(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB, BOOLEAN) TO authenticated;


### PR DESCRIPTION
## Summary

接續 #360 — 後續發現 GRP-20260523-002-TF0008 同店互轉後 status 仍被強制設成 `ready`、UI 顯示「可取貨」。挖到根因是「兩條 status 來源並存」(`customer_orders.status` vs `is_order_pickup_ready` 衍生 boolean)，加上同店互轉 RPC 一律強制 ready 兩個問題疊加。

四個 commit：

### 1. `docs: add project-level CLAUDE.md` (cb36c5a)
把過去踩雷的兩條規則寫進 `CLAUDE.md`，之後每個 session 一進來就會載：
- 部署 migration 走 Supabase Management API（pooler TCP 被擋）
- 改 function 前先 `grep -rn <fn> supabase/migrations/`、基於最新版擴寫

### 2. `fix(db): 同店互轉不再強制 status=ready` (9529da6)
- `rpc_transfer_order_to_store` / `rpc_transfer_order_partial`：同店改 mirror `v_orig.status`；跨店維持 `pending`；刪掉 4 筆假的「同店互轉自動推進」audit log
- `is_order_pickup_ready`：aid_transfer + 跨店只認 Path A；aid_transfer + 同店 / 一般訂單維持 Path A/B/C
- Backfill：把過去被強制設為 ready 但實際 `pickup_ready=false` 的訂單退回 `pending`（撈到 1 張 = TF0008）
- 用 Management API 在線上 DB 驗證 TF0008 變 `status=pending, pickup_ready=false`

### 3. `refactor: 統一訂單可取貨來源` (79f04b3)
歷史上「可取貨」有兩條獨立來源（status='ready' vs `v_order_pickup_ready.pickup_ready`），兩條 diverge 是 TF0008 / TF0009 兩個 bug 的根因。Spot-check 確認現在 `status` 推進已可靠：
- DB: `is_order_pickup_ready` 簡化成 `(status='ready')` 的 thin alias
- Frontend: 3 個 caller (`OrderDetail` / `orders` 列表 / `pickup` 頁) 改直接讀 `head.status`，刪掉 `v_order_pickup_ready` select 與 `pickupReady` state

### 4. `feat(transfer): 貨還沒到分店不能轉單` (abbbcad)
新業務規則：source 必須 `status='ready'` 才能轉單。
- DB: 兩支 RPC 的 F2 check 從 `pending/confirmed/reserved/ready` 收緊到 `'ready'`，錯誤訊息 `'貨還沒到分店、訂單 X 不可轉單 (status=Y)'`
- Frontend: `OrderDetail.canTransfer` 改 `head.status === 'ready'`；mutual-aid 頁兩處訂單篩選改 `.eq('status','ready')`
- Dry-run 驗 ID=1230 (pending) 被擋下

## Test plan

DB 修改已透過 Management API 全部部署、線上即時生效：

- [x] TF0008 線上查 `status=pending, pickup_ready=false`
- [x] 兩支 RPC 含 `'貨還沒到分店'` 字串（`pg_get_functiondef` 驗證）
- [ ] UI 重整 CampaignOrdersPanel + OrderDetail，TF0008 badge 應從綠「可取貨」變回「待確認」、「轉單」按鈕應消失
- [ ] 用任一 `status='pending'` 訂單試轉 → 應跳 `'貨還沒到分店、訂單 X 不可轉單 (status=pending)'`
- [ ] 用任一 `status='ready'` 訂單試轉 → 應如常成功
- [ ] mutual-aid 頁挑選店：訂單清單應只列 ready 的

https://claude.ai/code/session_01KLWWd2MCCHA6XNy8eb8qdj