### PR TITLE
fix(campaigns): 「結算」按鈕加管理員守門

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -524,7 +524,7 @@ export default function CampaignsListPage() {
           發 FB
         </SpinButton>
       )}
-      {(["closed", "locked", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
+      {showAdminActions && (["closed", "locked", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
         <SpinButton
           onClick={() => finalizeCampaign(r.id, r.name)}
           disabled={finalizingId === r.id}


### PR DESCRIPTION
## Summary
- 開團列表「結算」按鈕加 `showAdminActions &&` 守門，與同檔其他管理員動作（編輯/結單/發 FB）一致
- server 端 `rpc_finalize_campaign` 本來就會擋非管理員、這次只是把 server gate 對齊到前端顯示，避免店長/店員看到按下去會 403 的鈕

## Test plan
- [ ] 以 store_manager / store_staff 身份登入 → 開團列表（桌機表格 + 手機卡片）已收單/已下單/收貨中/可取貨 的開團 → 不再看到「結算」按鈕
- [ ] 以 owner / admin 登入 → 同樣的開團仍看得到「結算」按鈕、按下去正常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)