### PR TITLE
feat(orders): 未到貨訂單可從訂單列表 / 明細列印小白單

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -9,6 +9,7 @@ import { OrderDetail } from "@/components/OrderDetail";
 import OrderReturnCreateModal from "@/components/OrderReturnCreateModal";
 import { translateRpcError } from "@/lib/rpcError";
 import { withBasePath } from "@/lib/basePath";
+import { printViaIframe } from "@/lib/printIframe";
 import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 import { ORDER_STATUS_LABEL as STATUS_LABEL, type OrderStatus } from "@/lib/orderStatus";
 import SpinButton from "@/components/SpinButton";
@@ -479,6 +480,17 @@ function OrdersListContent() {
   // 操作按鈕（去取貨 / 取消 / ↩退貨 / 狀態鈕）— 桌機表格與手機卡片共用，單一維護點
   const orderActions = (r: Row, m: Member | null | undefined) => (
     <>
+      {PENDING_STATUSES.includes(r.status) && (
+        <SpinButton
+          onClick={() =>
+            printViaIframe(withBasePath(`/pickup/print-list?order_ids=${r.id}`))
+          }
+          title="列印小白單（picking list / 取貨清單，貨還沒到也可印）"
+          className="rounded-md border border-zinc-300 px-2 py-1 text-[11px] font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+        >
+          🖨️ 小白單
+        </SpinButton>
+      )}
       {!["completed","expired","cancelled","transferred_out"].includes(r.status) && (() => {
         const canPickup = r.status === "ready";
         // 訂單頁本身不執行取貨,只導向 /pickup (帶會員編號自動搜尋)

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -14,6 +14,7 @@ import { useAuth } from "@/components/AuthProvider";
 import { useRole } from "@/lib/role";
 import { orderStatusLabel as statusLabel, canPayWithWallet } from "@/lib/orderStatus";
 import { withBasePath } from "@/lib/basePath";
+import { printViaIframe } from "@/lib/printIframe";
 import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
 
@@ -349,6 +350,8 @@ export function OrderDetail({
   // 貨還沒到分店不能轉單：source 必須 status='ready' (跟 DB rpc_transfer_order_* 一致)
   const canTransfer = head.status === "ready";
   const canCancel = ["pending", "confirmed", "shipping"].includes(head.status);
+  // 還沒到貨（pending/confirmed/shipping）也可以列印小白單；ready 透過 PickupDialog 已有入口
+  const canPrintSlip = ["pending", "confirmed", "shipping", "ready"].includes(head.status);
   // 一般顧客訂單退回總倉（rpc_create_order_return）— 互助單不走這條（貨應退回原 source 店）
   const canReturn = !isAidOrder && ["shipping", "ready", "partially_completed", "completed", "expired"].includes(head.status);
   // 互助單已收貨未取貨（status=ready）退單：退回原 source 店（rpc_return_aid_order，#234）
@@ -456,8 +459,19 @@ export function OrderDetail({
           </SpinButton>
         </div>
       )}
-      {(canTransfer || canPickup || canCancel || canReturn || canAidReturn || isTransferredOut) && (
+      {(canPrintSlip || canTransfer || canPickup || canCancel || canReturn || canAidReturn || isTransferredOut) && (
         <div className="flex items-center justify-end gap-2">
+          {canPrintSlip && (
+            <SpinButton
+              onClick={() =>
+                printViaIframe(withBasePath(`/pickup/print-list?order_ids=${head.id}`))
+              }
+              title="列印小白單（picking list / 取貨清單，貨還沒到也可印）"
+              className="rounded-md border border-zinc-300 px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              🖨️ 列印小白單
+            </SpinButton>
+          )}
           {canPickup && (
             <SpinButton
               onClick={() => setPickupOpen(true)}


### PR DESCRIPTION
訂單頁 (pending/confirmed/shipping/ready) 與 OrderDetail 加上「🖨️ 小白單」
按鈕，沿用既有 /pickup/print-list?order_ids= 與 printViaIframe（隱藏 iframe
靜默列印，不跳新分頁）。原本只有 ready 透過 PickupDialog 取貨流程才能印，
這裡把入口提前，貨還沒到分店時就能先印 picking list 給客人或備料。

https://claude.ai/code/session_019MFUJMc2pEvd6nhN4KXf8Z