### PR TITLE
feat(products): 商品列表顯示品項數 + 規格編號改唯讀

### DIFF
--- a/apps/admin/src/app/(protected)/products/page.tsx
+++ b/apps/admin/src/app/(protected)/products/page.tsx
@@ -254,6 +254,7 @@ function PageContent() {
 
   const [rows, setRows] = useState<ProductRow[] | null>(null);
   const [total, setTotal] = useState(0);
+  const [skuCounts, setSkuCounts] = useState<Map<number, number>>(new Map());
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -473,8 +474,27 @@ function PageContent() {
         if (cancelled) return;
         if (error) { setError(error.message); return; }
         setError(null);
-        setRows((data ?? []) as ProductRow[]);
+        const productRows = (data ?? []) as ProductRow[];
+        setRows(productRows);
         setTotal(count ?? 0);
+
+        // 撈每個商品的非停產 SKU 數
+        if (productRows.length > 0) {
+          const ids = productRows.map((p) => p.id);
+          const { data: skuRows } = await getSupabase()
+            .from("skus")
+            .select("product_id")
+            .in("product_id", ids)
+            .neq("status", "discontinued");
+          if (cancelled) return;
+          const counts = new Map<number, number>();
+          for (const row of (skuRows ?? []) as { product_id: number }[]) {
+            counts.set(row.product_id, (counts.get(row.product_id) ?? 0) + 1);
+          }
+          setSkuCounts(counts);
+        } else {
+          setSkuCounts(new Map());
+        }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       } finally {
@@ -686,7 +706,12 @@ function PageContent() {
                   </Td>
                   <Td className="font-mono">{r.product_code}</Td>
                   <Td>
-                    <div>{r.name}</div>
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                      <span>{r.name}</span>
+                      <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                        {skuCounts.get(r.id) ?? 0} 品項
+                      </span>
+                    </div>
                     {r.short_name && <div className="text-xs text-zinc-500">{r.short_name}</div>}
                   </Td>
                   <Td className="text-xs text-zinc-600 dark:text-zinc-400">

--- a/apps/admin/src/components/ProductSkuSection.tsx
+++ b/apps/admin/src/components/ProductSkuSection.tsx
@@ -155,10 +155,22 @@ export function ProductSkuSection({
         if (pending.length === 0) return;
         const sb = getSupabase();
         for (const p of pending) {
+          let code = p.sku_code;
+          if (!code.trim()) {
+            const { data: next, error: codeErr } = await sb.rpc(
+              "rpc_next_sku_code",
+              { p_product_id: newId }
+            );
+            if (codeErr) throw codeErr;
+            if (typeof next !== "string" || !next) {
+              throw new Error("無法產生規格編號");
+            }
+            code = next;
+          }
           const { data: skuId, error: rpcErr } = await sb.rpc("rpc_upsert_sku", {
             p_id: null,
             p_product_id: newId,
-            p_sku_code: p.sku_code,
+            p_sku_code: code,
             p_variant_name: p.variant_name || null,
             p_spec: {},
             p_base_unit: p.base_unit || "個",
@@ -258,7 +270,9 @@ export function ProductSkuSection({
     if (!draft) return;
     setError(null);
 
-    if (!draft.sku_code.trim()) {
+    // 規格編號為 readonly：對既有商品 startNew() 已預填、編輯既有 SKU 用原本 code；
+    // 只有 pending（新商品）允許空字串，flush() 會在商品建立後自動產生。
+    if (!isPending && !draft.sku_code.trim()) {
       setError("規格編號必填");
       return;
     }
@@ -370,6 +384,7 @@ export function ProductSkuSection({
               saving={saving}
               showCost={showCost}
               showBranch={showBranch}
+              isPending={isPending}
             />
           ) : (
             <SkuCard
@@ -395,6 +410,7 @@ export function ProductSkuSection({
               saving={saving}
               showCost={showCost}
               showBranch={showBranch}
+              isPending={isPending}
             />
           ) : (
             <PendingCard
@@ -417,6 +433,7 @@ export function ProductSkuSection({
             saving={saving}
             showCost={showCost}
             showBranch={showBranch}
+            isPending={isPending}
           />
         )}
 
@@ -571,6 +588,7 @@ function DraftCard({
   saving,
   showCost,
   showBranch,
+  isPending,
 }: {
   draft: Draft;
   setDraft: (d: Draft) => void;
@@ -579,6 +597,7 @@ function DraftCard({
   saving: boolean;
   showCost: boolean;
   showBranch: boolean;
+  isPending: boolean;
 }) {
   function set<K extends keyof Draft>(key: K, value: Draft[K]) {
     setDraft({ ...draft, [key]: value });
@@ -590,16 +609,17 @@ function DraftCard({
         <Field label="規格編號" required>
           <input
             value={draft.sku_code}
-            onChange={(e) => set("sku_code", e.target.value)}
-            placeholder="例：A001-100"
-            className={inputClass}
+            readOnly
+            tabIndex={-1}
+            placeholder={isPending ? "建立商品後自動產生" : ""}
+            className={`${inputClass} cursor-not-allowed bg-zinc-100 text-zinc-600 dark:bg-zinc-800/60 dark:text-zinc-400`}
           />
         </Field>
-        <Field label="變體名">
+        <Field label="規格 / 品項名稱">
           <input
             value={draft.variant_name}
             onChange={(e) => set("variant_name", e.target.value)}
-            placeholder="例：100 入"
+            placeholder="例：100 入 / (A)胡椒木"
             className={inputClass}
           />
         </Field>


### PR DESCRIPTION
## Summary
- 商品列表「名稱」欄旁加灰色 pill「N 品項」，方便一眼看到每個商品底下掛了幾個 SKU
- 規格編輯卡的「規格編號」改 `readOnly`：避免使用者手動編輯造成斷號／不一致
  - 既有商品：startNew() 原本就呼叫 `rpc_next_sku_code` 自動產生
  - 新商品 pending 模式：placeholder 顯示「建立商品後自動產生」、flush() 在 product 建立後補呼 `rpc_next_sku_code` 取真實 code
- 「變體名」label → 「規格 / 品項名稱」、placeholder 改成「例：100 入 / (A)胡椒木」更貼合實際用法

## 實作細節

**SKU count**（`apps/admin/src/app/(protected)/products/page.tsx`）
- 每次 fetch products page 後追加一次 `IN (product_ids)` 撈該頁所有非 discontinued 的 `sku.product_id`，client 端用 Map 算 count
- 篩掉 `status='discontinued'`，跟 ProductSkuSection 既有的 SKU 列表口徑一致
- 沒撈到顯示「0 品項」，方便發現空商品

**規格編號 readonly**（`apps/admin/src/components/ProductSkuSection.tsx`）
- `<input readOnly tabIndex={-1}>` + 灰底樣式 + 不可編輯 cursor
- `save()` 的「規格編號必填」檢查改成只擋既有商品；pending 模式允許空字串走 flush() 自動產生路線
- `DraftCard` 新增 `isPending` prop 控制 placeholder 文案

## Test plan
- [ ] 既有商品 → 點「+ 新增規格」→ 規格編號欄已預填 `{product_code}-{NN}` 且為灰底唯讀，無法手改
- [ ] 既有商品 → 編輯既有 SKU → 規格編號維持原 code 灰底唯讀
- [ ] 新增商品 → 規格編號欄顯示 placeholder「建立商品後自動產生」、加 1~3 個 pending SKU、儲存商品 → 自動依序得到 `{product_code}-01/-02/-03`
- [ ] 商品列表 → 名稱旁灰色 pill 顯示「N 品項」、與該商品打開後 ProductSkuSection 顯示的 SKU 筆數一致
- [ ] 翻頁時 SKU 數正確跟著當頁商品更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)