### PR TITLE
Remove English subtitle from pickup list print page

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -159,7 +159,6 @@ function Body() {
 
         <div className="text-center">
           <div className="text-[22px] font-bold">取貨清單</div>
-          <div className="text-[12px] text-zinc-500">picking list (待確認)</div>
         </div>
 
         <div className="mt-2 border-y border-dashed border-black py-1.5">


### PR DESCRIPTION
## Summary
Removed the English subtitle "picking list (待確認)" from the pickup list print page header.

## Changes
- Removed the subtitle line displaying "picking list (待確認)" from the print layout
- The page now displays only the Chinese title "取貨清單" as the header

## Details
This simplifies the print page header by removing the secondary English text, keeping only the primary Chinese title for the pickup list.

https://claude.ai/code/session_01JdmK3qZa9vVGyQFfX5AvWq