### PR TITLE
fix(admin): 修正 Modal 在手機瀏覽器底部被工具列遮住

### DIFF
--- a/apps/admin/src/components/Modal.tsx
+++ b/apps/admin/src/components/Modal.tsx
@@ -31,7 +31,7 @@ export function Modal({
       role="dialog"
     >
       <div
-        className={`flex w-full ${maxWidth} max-h-[calc(100vh-2rem)] flex-col rounded-lg border border-zinc-200 bg-white shadow-2xl dark:border-zinc-800 dark:bg-zinc-900 sm:max-h-[calc(100vh-4rem)]`}
+        className={`flex w-full ${maxWidth} max-h-[calc(100dvh-2rem)] flex-col rounded-lg border border-zinc-200 bg-white shadow-2xl dark:border-zinc-800 dark:bg-zinc-900 sm:max-h-[calc(100dvh-4rem)]`}
       >
         <div className="flex shrink-0 items-center justify-between border-b border-zinc-200 px-5 py-3 dark:border-zinc-800">
           <h2 className="text-base font-semibold">{title}</h2>


### PR DESCRIPTION
Modal 高度原本用 calc(100vh-...) 限制。iOS Safari 的 100vh 指的是
工具列收起時的最大 viewport，當底部工具列顯示時 popup 底部會延伸到
工具列後方被遮住、無法捲到/看到。改用 dvh（dynamic viewport height），
高度會跟著目前可見 viewport 變動，popup 底部就不會被遮住。