### PR TITLE
取貨頁：排版/破圖/金額修正 + 依數量分批取貨

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -447,16 +447,17 @@ function PickupPageContent() {
                         const discAmt = Number(o.discount_amount ?? 0);
                         const totalAmt = Math.max(0, subAmt - discAmt);
                         return (
-                          <li key={o.id} className={`flex items-center gap-3 rounded-md border p-3 ${selected.has(o.id) ? "border-emerald-400 bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-950" : "border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950"}`}>
+                          <li key={o.id} className={`flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-center ${selected.has(o.id) ? "border-emerald-400 bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-950" : "border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950"}`}>
+                            <div className="flex min-w-0 flex-1 items-start gap-3">
                             <input
                               type="checkbox"
                               checked={selected.has(o.id)}
                               onChange={() => toggleSelect(o.id)}
                               disabled={!canPickup || pickableCount === 0}
-                              className="h-4 w-4"
+                              className="mt-1 h-4 w-4 shrink-0"
                             />
                             <OrderThumb order={o} />
-                            <div className="flex-1 text-sm">
+                            <div className="min-w-0 flex-1 text-sm">
                               <div className="flex items-baseline gap-2">
                                 <span>{o.campaign?.name ?? "(未知活動)"}</span>
                                 {o.status === "partially_completed" && (
@@ -487,16 +488,15 @@ function PickupPageContent() {
                                   <span className="ml-2 text-zinc-400">⏳ 未到貨</span>
                                 )}
                                 {o.pickup_deadline && <span className="ml-2">截止：{o.pickup_deadline}</span>}
+                                {/* 訂單金額一律顯示（含未到貨的單），方便核帳 */}
+                                <span className="ml-2 font-mono font-semibold text-zinc-700 dark:text-zinc-200">${totalAmt}</span>
+                                {discAmt > 0 && (
+                                  <span className="ml-1 text-[10px] text-red-600 dark:text-red-400" title={`小計 $${subAmt} − 折扣 $${discAmt}`}>
+                                    (含 ${discAmt} 折扣)
+                                  </span>
+                                )}
                                 {canPickup ? (
-                                  <>
-                                    <span className="ml-2">{pickableCount} 項可取</span>
-                                    <span className="ml-2 font-mono text-zinc-700 dark:text-zinc-200">${totalAmt}</span>
-                                    {discAmt > 0 && (
-                                      <span className="ml-1 text-[10px] text-red-600 dark:text-red-400" title={`小計 $${subAmt} − 折扣 $${discAmt}`}>
-                                        (含 ${discAmt} 折扣)
-                                      </span>
-                                    )}
-                                  </>
+                                  <span className="ml-2">{pickableCount} 項可取</span>
                                 ) : (
                                   <span className="ml-2 text-amber-600 dark:text-amber-400">⏳ 分店尚未收貨，無法取貨</span>
                                 )}
@@ -507,6 +507,8 @@ function PickupPageContent() {
                                 )}
                               </div>
                             </div>
+                            </div>
+                            <div className="flex flex-wrap gap-2 sm:shrink-0">
                             <SpinButton
                               onClick={() => notifyPickup(m, o)}
                               disabled={!canPickup || notifyingId === o.id || m.no_notify_pickup}
@@ -540,6 +542,7 @@ function PickupPageContent() {
                                 取消訂單
                               </SpinButton>
                             )}
+                            </div>
                           </li>
                         );
                       })}
@@ -659,10 +662,18 @@ function PickupPageContent() {
 }
 
 function OrderThumb({ order }: { order: OpenOrder }) {
-  // 取第一個 active item 的 product 第一張 image
-  const firstImg = order.items
+  // 取第一個 active item 的 product 第一張 image。
+  // DB 存的是 storage 相對路徑，必須經 productImageUrl 轉成 public URL，
+  // 否則 <img> 直接吃相對路徑會壞圖（顯示破圖 ?）。
+  const rawImg = order.items
     .map((it) => it.sku?.product?.images?.[0])
     .find((u): u is string => typeof u === "string" && !!u);
+  // DB 存的是 storage 物件 key，需轉 public URL（已是完整 URL 則原樣使用）
+  const firstImg = rawImg
+    ? /^https?:\/\//i.test(rawImg)
+      ? rawImg
+      : getSupabase().storage.from("products").getPublicUrl(rawImg).data.publicUrl
+    : null;
   if (!firstImg) {
     return (
       <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-zinc-200 text-xs text-zinc-500 dark:bg-zinc-800">

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -11,6 +11,7 @@ import { printViaIframe } from "@/lib/printIframe";
 import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
 import { getPickupRecents, recordPickupRecent, type RecentCustomer } from "@/lib/pickupRecents";
+import { publicProductUrl } from "@/lib/campaignCover";
 
 type Member = {
   id: number;
@@ -668,12 +669,9 @@ function OrderThumb({ order }: { order: OpenOrder }) {
   const rawImg = order.items
     .map((it) => it.sku?.product?.images?.[0])
     .find((u): u is string => typeof u === "string" && !!u);
-  // DB 存的是 storage 物件 key，需轉 public URL（已是完整 URL 則原樣使用）
-  const firstImg = rawImg
-    ? /^https?:\/\//i.test(rawImg)
-      ? rawImg
-      : getSupabase().storage.from("products").getPublicUrl(rawImg).data.publicUrl
-    : null;
+  // DB 存的是 storage 物件 key，需轉成 products bucket 的 public URL（已是完整 URL 則原樣使用）。
+  // 原本直接把相對路徑塞進 <img src> 導致破圖（顯示 ?）。
+  const firstImg = publicProductUrl(rawImg);
   if (!firstImg) {
     return (
       <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-zinc-200 text-xs text-zinc-500 dark:bg-zinc-800">

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -27,10 +27,17 @@ type OrderHead = {
   payment_status: string | null;
 };
 
-function lineSub(it: PickableItem): number {
-  const gross = Number(it.qty) * Number(it.unit_price);
+// 以指定數量計算小計（line-level 折扣金額按比例分攤，對齊後端拆行邏輯）
+function lineSubQty(it: PickableItem, qty: number): number {
+  const fullQty = Number(it.qty) || 0;
+  const ratio = fullQty > 0 ? qty / fullQty : 0;
+  const gross = qty * Number(it.unit_price);
   const afterPct = gross * (1 - Number(it.discount_percent ?? 0) / 100);
-  return Math.max(0, Math.round(afterPct * 10000) / 10000 - Number(it.discount_amount ?? 0));
+  const discAmt = Number(it.discount_amount ?? 0) * ratio;
+  return Math.max(0, Math.round(afterPct * 10000) / 10000 - discAmt);
+}
+function lineSub(it: PickableItem): number {
+  return lineSubQty(it, Number(it.qty));
 }
 
 export function PickupDialog({
@@ -55,6 +62,8 @@ export function PickupDialog({
   const [walletBalance, setWalletBalance] = useState<number | null>(null);
   const [walletAmount, setWalletAmount] = useState("");
   const [picked, setPicked] = useState<Set<number>>(new Set());
+  // 每個 item 本次取貨數量（預設 = 全取）。key=item.id, value=數量字串（允許編輯中暫空）
+  const [pickQty, setPickQty] = useState<Map<number, string>>(new Map());
   const [notes, setNotes] = useState("");
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -80,6 +89,8 @@ export function PickupDialog({
       const list = (iRes.data ?? []) as unknown as PickableItem[];
       setItems(list);
       setPicked(new Set(list.map((it) => it.id)));
+      // 預設每項全取
+      setPickQty(new Map(list.map((it) => [it.id, String(Number(it.qty))])));
       const head = hRes.data;
       const headAmt = Number(head?.discount_amount ?? 0);
       const headPct = Number(head?.discount_percent ?? 0);
@@ -122,6 +133,21 @@ export function PickupDialog({
     setPicked((s) => {
       const next = new Set(s);
       if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  // 取得某 item 本次有效取貨數量（clamp 到 1..qty；空字串/非法 → 全取）
+  function effQty(it: PickableItem): number {
+    const raw = pickQty.get(it.id);
+    const n = Number(raw);
+    if (raw === "" || raw == null || !Number.isFinite(n) || n <= 0) return Number(it.qty);
+    return Math.min(Number(it.qty), Math.max(1, n));
+  }
+  function setQty(id: number, value: string) {
+    setPickQty((m) => {
+      const next = new Map(m);
+      next.set(id, value);
       return next;
     });
   }
@@ -193,12 +219,22 @@ export function PickupDialog({
         if (wErr) { setErr(`儲值金扣款失敗：${translateRpcError(wErr)}`); return; }
       }
 
-      // Step 2：寫 pickup
+      // Step 2：寫 pickup。只帶「部分取」的數量；整取的省略 → 後端視為整行取
+      const itemQtys: Record<string, number> = {};
+      if (items) {
+        for (const it of items) {
+          if (!picked.has(it.id)) continue;
+          const take = effQty(it);
+          if (take < Number(it.qty)) itemQtys[String(it.id)] = take;
+        }
+      }
+      const hasPartial = Object.keys(itemQtys).length > 0;
       const { data, error } = await sb.rpc("rpc_record_pickup", {
         p_order_id: orderId,
         p_item_ids: Array.from(picked),
         p_operator: operator,
         p_notes: notes || null,
+        ...(hasPartial ? { p_item_qtys: itemQtys } : {}),
       });
       if (error) { setErr(error.message); return; }
       const result = data as { event_id: number; new_order_status: string; picked_count: number; active_remaining: number };
@@ -215,7 +251,7 @@ export function PickupDialog({
   }
 
   const subtotal = items
-    ? items.filter((it) => picked.has(it.id)).reduce((s, it) => s + lineSub(it), 0)
+    ? items.filter((it) => picked.has(it.id)).reduce((s, it) => s + lineSubQty(it, effQty(it)), 0)
     : 0;
   const discountPercent = discountValue.kind === "percent" ? Number(discountValue.value) : 0;
   const discount = discountValue.kind === "amount" ? Number(discountValue.value) : 0;
@@ -268,14 +304,17 @@ export function PickupDialog({
               </thead>
               <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
                 {items.map((it) => {
-                  const sub = lineSub(it);
+                  const take = effQty(it);
+                  const sub = lineSubQty(it, take);
+                  const partial = take < Number(it.qty);
+                  const isPicked = picked.has(it.id);
                   const hasLineDisc = Number(it.discount_amount ?? 0) > 0 || Number(it.discount_percent ?? 0) > 0;
                   return (
-                    <tr key={it.id} className={picked.has(it.id) ? "bg-emerald-50 dark:bg-emerald-950" : ""}>
+                    <tr key={it.id} className={isPicked ? "bg-emerald-50 dark:bg-emerald-950" : ""}>
                       <td className="px-3 py-2">
                         <input
                           type="checkbox"
-                          checked={picked.has(it.id)}
+                          checked={isPicked}
                           onChange={() => toggle(it.id)}
                           className="h-4 w-4"
                         />
@@ -291,7 +330,24 @@ export function PickupDialog({
                           </span>
                         )}
                       </td>
-                      <td className="px-3 py-2 text-right font-mono">{Number(it.qty)}</td>
+                      <td className="px-3 py-2 text-right">
+                        <div className="flex items-center justify-end gap-1">
+                          <input
+                            type="number"
+                            min={1}
+                            max={Number(it.qty)}
+                            step="1"
+                            value={pickQty.get(it.id) ?? String(Number(it.qty))}
+                            onChange={(e) => setQty(it.id, e.target.value)}
+                            disabled={!isPicked}
+                            className="w-14 rounded-md border border-zinc-300 px-2 py-1 text-right font-mono text-sm disabled:opacity-40 dark:border-zinc-700 dark:bg-zinc-800"
+                          />
+                          <span className="font-mono text-[10px] text-zinc-400">/{Number(it.qty)}</span>
+                        </div>
+                        {partial && isPicked && (
+                          <div className="mt-0.5 text-[10px] text-amber-600 dark:text-amber-400">剩 {Number(it.qty) - take} 留待下次</div>
+                        )}
+                      </td>
                       <td className="px-3 py-2 text-right font-mono text-zinc-500">${Number(it.unit_price)}</td>
                       <td className="px-3 py-2 text-right font-mono">${sub}</td>
                       <td className="px-3 py-2 text-xs text-zinc-500">{it.status}</td>

--- a/supabase/migrations/20260630000010_pickup_partial_qty_split.sql
+++ b/supabase/migrations/20260630000010_pickup_partial_qty_split.sql
@@ -1,0 +1,221 @@
+-- ============================================================
+-- 2026-06-30: rpc_record_pickup 支援「依數量分批取貨」（拆行法）
+--
+-- 需求：一個品項訂 10 個，這次只取 3 個、剩 7 個留著下次再取。
+--
+-- 設計（拆行 split-line）：
+--   取部分數量時，把原品項行拆成兩行——
+--     · 新建一行 qty=已取數量、status='picked_up'（連動 stock_movement）
+--     · 原行 qty 扣掉已取數量、狀態保持 active（pending/reserved/ready）留待下次
+--   整行取（take = qty）時完全沿用舊邏輯，零行為變化。
+--
+--   優點：拆完每一行仍是「整取」語義，所以收據(print)、小白單(print-list)、
+--   退貨(rpc_create_order_return)、金額 view 全都不用改——它們看的是「行」，
+--   而每行 qty 已經是正確的已取/待取數量。
+--
+-- 介面變更：新增可選參數 p_item_qtys jsonb = {"<item_id>": <取貨數量>, ...}。
+--   未列入或值 >= 該品項 qty 者視為整行取。舊 caller（不傳 p_item_qtys）
+--   行為完全不變。
+--   ⚠️ 因為加參數會改 signature，先 DROP 舊的 4-arg 版再建 5-arg 版，
+--      避免 PostgREST 重載歧義；末尾重新 GRANT。
+--
+-- 基底版本：20260614000030_fix_pickup_stock_movement.sql 的 rpc_record_pickup
+--   （已 dump 線上確認一致；含 stock_movement 扣帳 + pickup_movement_id 回填）。
+-- Rollback：DROP FUNCTION rpc_record_pickup(bigint,bigint[],uuid,text,jsonb);
+--   再 CREATE OR REPLACE 回 20260614000030 的 4-arg 版本即可。
+--   （拆出來的 picked_up 行與其 stock_movement 是正常取貨資料、不需回收。）
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.rpc_record_pickup(bigint, bigint[], uuid, text);
+
+CREATE OR REPLACE FUNCTION public.rpc_record_pickup(
+  p_order_id  bigint,
+  p_item_ids  bigint[],
+  p_operator  uuid,
+  p_notes     text  DEFAULT NULL,
+  p_item_qtys jsonb DEFAULT NULL   -- {"<item_id>": <取貨數量>}；缺項或 >=qty 視為整行取
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_pickup_loc       BIGINT;
+  v_item             RECORD;
+  v_take             NUMERIC;
+  v_picked_disc      NUMERIC;
+  v_movement_id      BIGINT;
+  v_new_item_id      BIGINT;
+  v_picked_item_id   BIGINT;
+  v_picked_count     INT := 0;
+  v_event_item_ids   BIGINT[] := ARRAY[]::BIGINT[];
+  v_active_remaining INT;
+  v_new_status       TEXT;
+  v_event_type       TEXT;
+  v_event_id         BIGINT;
+  v_now              TIMESTAMPTZ := NOW();
+BEGIN
+  IF p_item_ids IS NULL OR array_length(p_item_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_item_ids is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_pickup:' || p_order_id::text));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION '找不到訂單 %', p_order_id;
+  END IF;
+
+  IF v_order.status IN ('completed','expired','cancelled','transferred_out') THEN
+    RAISE EXCEPTION '訂單 % 目前狀態為「%」，無法取貨', p_order_id, v_order.status;
+  END IF;
+
+  IF NOT public.is_order_pickup_ready(p_order_id) THEN
+    RAISE EXCEPTION '訂單 % 對應的分店尚未確認收到出倉單，無法取貨', p_order_id;
+  END IF;
+
+  SELECT location_id INTO v_pickup_loc
+    FROM stores
+   WHERE id = v_order.pickup_store_id;
+
+  IF v_pickup_loc IS NULL THEN
+    RAISE EXCEPTION '分店 % 未設定倉庫位置 (location_id)、無法寫 stock_movement', v_order.pickup_store_id;
+  END IF;
+
+  -- 逐品項：判斷整行取 or 拆行部分取
+  FOR v_item IN
+    SELECT id, sku_id, qty, unit_price, status, source, campaign_item_id,
+           tenant_id, notes, discount_amount, discount_percent, created_by
+      FROM customer_order_items
+     WHERE id = ANY(p_item_ids)
+       AND order_id = p_order_id
+     ORDER BY id
+     FOR UPDATE
+  LOOP
+    IF v_item.status NOT IN ('pending','reserved','ready') THEN
+      RAISE EXCEPTION '品項 % 狀態 % 不可取貨', v_item.id, v_item.status;
+    END IF;
+
+    -- 本次取多少：p_item_qtys 指定則用之，否則整行取
+    v_take := COALESCE((p_item_qtys ->> v_item.id::text)::numeric, v_item.qty);
+    IF v_take IS NULL OR v_take <= 0 THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 不合法（須 > 0）', v_item.id, v_take;
+    END IF;
+    IF v_take > v_item.qty THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 超過待取數量 %', v_item.id, v_take, v_item.qty;
+    END IF;
+
+    IF v_take = v_item.qty THEN
+      -- ── 整行取：沿用舊邏輯，直接標 picked_up ──
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_item.id,
+        format('顧客取貨 order=%s item=%s', p_order_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      UPDATE customer_order_items
+         SET status = 'picked_up',
+             pickup_movement_id = v_movement_id,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_item.id;
+    ELSE
+      -- ── 部分取：拆行。新建 picked_up 行，原行扣量留待下次 ──
+      -- line-level 折扣金額按取貨比例分攤，確保兩行小計加總 = 原行
+      v_picked_disc := round(COALESCE(v_item.discount_amount, 0) * v_take / v_item.qty);
+
+      -- 1) 先建 picked_up 行（暫不填 movement，先拿 id）
+      INSERT INTO customer_order_items (
+        tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+        status, source, reserved_movement_id, pickup_movement_id, notes,
+        discount_amount, discount_percent, created_by, updated_by, created_at, updated_at
+      ) VALUES (
+        v_item.tenant_id, p_order_id, v_item.campaign_item_id, v_item.sku_id, v_take, v_item.unit_price,
+        'picked_up', v_item.source, NULL, NULL, v_item.notes,
+        v_picked_disc, v_item.discount_percent, v_item.created_by, p_operator, v_now, v_now
+      ) RETURNING id INTO v_new_item_id;
+
+      -- 2) sale movement 指向新行
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_new_item_id,
+        format('顧客部分取貨 order=%s item=%s (split from %s)', p_order_id, v_new_item_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      -- 3) 回填新行 movement
+      UPDATE customer_order_items
+         SET pickup_movement_id = v_movement_id
+       WHERE id = v_new_item_id;
+
+      -- 4) 原行扣量、保持 active 狀態，剩餘留待下次取
+      UPDATE customer_order_items
+         SET qty = qty - v_take,
+             discount_amount = COALESCE(discount_amount, 0) - v_picked_disc,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_new_item_id;
+    END IF;
+
+    -- event 記錄「被取走」那一行的 id（拆行時是新行）→ 收據查到正確的 qty
+    v_event_item_ids := v_event_item_ids || v_picked_item_id;
+    v_picked_count := v_picked_count + 1;
+  END LOOP;
+
+  IF v_picked_count = 0 THEN
+    RAISE EXCEPTION 'no items picked (check p_item_ids belongs to order %)', p_order_id;
+  END IF;
+
+  -- 重算 order status（剩餘 active 行 → partially_completed；全取完 → completed）
+  SELECT COUNT(*) INTO v_active_remaining
+    FROM customer_order_items
+   WHERE order_id = p_order_id
+     AND status IN ('pending','reserved','ready');
+
+  IF v_active_remaining = 0 THEN
+    v_new_status := 'completed';
+    v_event_type := 'picked_up';
+  ELSE
+    v_new_status := 'partially_completed';
+    v_event_type := 'partial_pickup';
+  END IF;
+
+  UPDATE customer_orders
+     SET status       = v_new_status,
+         completed_at = CASE WHEN v_new_status = 'completed' THEN v_now ELSE NULL END,
+         updated_by   = p_operator,
+         updated_at   = v_now
+   WHERE id = p_order_id;
+
+  INSERT INTO order_pickup_events (
+    tenant_id, order_id, pickup_store_id, event_type, item_ids, notes, created_by
+  ) VALUES (
+    v_order.tenant_id, p_order_id, v_order.pickup_store_id, v_event_type,
+    to_jsonb(v_event_item_ids), p_notes, p_operator
+  ) RETURNING id INTO v_event_id;
+
+  RETURN jsonb_build_object(
+    'event_id',        v_event_id,
+    'event_type',      v_event_type,
+    'picked_count',    v_picked_count,
+    'active_remaining', v_active_remaining,
+    'new_status',      v_new_status
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) IS
+  '取貨記帳。p_item_qtys={"<item_id>":<取貨數量>} 可指定部分取貨：拆行——'
+  '新建 picked_up 行(該數量)、原行扣量留待下次。未指定者整行取(沿用舊邏輯)。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) TO authenticated;


### PR DESCRIPTION
## 摘要

取貨頁一系列調整，分三個 commit：

### 1. 排版 / 破圖 / 訂單金額（`4426cb0`, `c6b4710`）
- **修破圖**：`OrderThumb` 原本直接把 DB 的 storage 相對路徑塞進 `<img src>` 導致破圖。改用既有共用 helper `publicProductUrl()`（`@/lib/campaignCover`）轉成 products bucket 的 public URL，與商品/開團封面走同一套邏輯。
- **訂單金額**：原本只在「可取貨(ready)」的單顯示金額，改成**所有訂單一律顯示** `$金額`（含未到貨的單），方便核帳；有折扣時附註「(含 $X 折扣)」。
- **手機版排版**：窄螢幕下卡片改為上下排版（內容在上、按鈕在下換行），內容區加 `min-w-0` 避免長文字被擠成一字一行。

### 2. 依數量分批取貨（`9b61bdd`）
需求：一個品項訂 10 個，這次只取 3 個、剩 7 個留著下次再取。

採**拆行法**，只動 2 個檔：
- **Migration** `20260630000010_pickup_partial_qty_split.sql`：`rpc_record_pickup` 新增可選參數 `p_item_qtys = {"<item_id>": 取貨數量}`。
  - 整行取（未指定數量）→ 完全沿用舊邏輯，行為零變化。
  - 部分取 → **拆行**：新建一行 `qty=已取` 標 `picked_up`（連動 `stock_movement` 扣帳），原行扣量保持 active 留待下次。line-level 折扣按比例分攤，兩行小計加總＝原行。
  - `order_pickup_events` 記「被取走那一行」的 id（拆行時記新行）→ 收據查到的 `qty` 正好是本次數量。
  - 因加參數改 signature，先 `DROP` 4-arg 版再建 5-arg 版，末尾重新 `GRANT`。
- **`PickupDialog.tsx`**：每項加數量輸入框（預設全取，範圍 1～訂購量），小計按本次數量即時計算，部分取時顯示「剩 N 留待下次」，submit 只把部分取的數量帶給 RPC。

**為什麼其他都不用改**：拆行後每一行仍是「整取」語義，收據頁 / 小白單 / 退貨 RPC / 金額 view 看到的每行 `qty` 都已是正確的已取/待取數量。

## 部署狀態
- ✅ Migration `20260630000010` 已透過 Management API 套到線上 DB，並驗證：單一 5-arg overload、grants 正常、PostgREST schema cache 已 reload。
- ⚠️ 此 worktree 未安裝 `node_modules`，前端 `tsc` 未跑，型別為人工檢查。

## 測試建議
- 取貨彈窗：單項全取 / 單項部分取 / 多項混合 → 確認拆行後 `customer_order_items` 數量、`stock_movements` 扣帳、收據與小白單金額正確。
- 部分取後該訂單狀態應為 `partially_completed`，剩餘行仍可再次取貨。

https://claude.ai/code/session_011AdmFNDfzTywBo4BepbBzL

---
_Generated by [Claude Code](https://claude.ai/code/session_011AdmFNDfzTywBo4BepbBzL)_