### PR TITLE
修部分取貨後剩餘品項無法再取

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -52,7 +52,10 @@ const ACTIVE_STATUSES = ["pending", "confirmed", "reserved", "ready", "partially
 const INACTIVE_ITEM_STATUSES = new Set(["cancelled", "picked_up", "expired"]);
 
 function isPickable(order: OpenOrder): boolean {
-  return order.status === "ready";
+  // ready 可取；partially_completed（部分取貨後）只要還有 active 品項也可繼續取剩餘
+  if (order.status === "ready") return true;
+  if (order.status === "partially_completed") return activeItems(order).length > 0;
+  return false;
 }
 function activeItems(order: OpenOrder) {
   return order.items.filter((it) => !INACTIVE_ITEM_STATUSES.has(it.status));

--- a/supabase/migrations/20260630000040_pickup_ready_allow_partially_completed.sql
+++ b/supabase/migrations/20260630000040_pickup_ready_allow_partially_completed.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- 2026-06-30: is_order_pickup_ready 放寬 — partially_completed 仍可取剩餘品項
+--
+-- 問題：部分取貨（分品項或分數量）後，訂單 status 變 'partially_completed'，
+-- 但 is_order_pickup_ready 只認 status='ready'（20260629000030 thin-alias 版），
+-- 導致剩餘 active 品項再也無法取貨（前端顯示「分店尚未收貨，無法取貨」，
+-- 實際上貨早到了）。rpc_record_pickup 進入時也會被 is_order_pickup_ready 擋下。
+--
+-- 修法：放寬成「status='ready'，或 status='partially_completed' 且還有 active
+-- 品項(pending/reserved/ready)」。partially_completed 一定是先 ready 過、被
+-- 取走部分才產生的狀態，本來就代表「分店已收貨」，故可安全視為可繼續取。
+--
+-- 影響面：is_order_pickup_ready 的唯一 caller 是 rpc_record_pickup + 衍生
+-- view v_order_pickup_ready。放寬後 partially_completed 訂單的剩餘品項能再次
+-- 進入取貨流程，符合預期。
+--
+-- 基底版本：20260629000030_unify_pickup_ready_to_status.sql（thin alias）。
+-- Rollback：CREATE OR REPLACE 回 20260629000030 的單行 status='ready' 版本。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.is_order_pickup_ready(p_order_id bigint)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT EXISTS (
+    SELECT 1 FROM customer_orders co
+     WHERE co.id = p_order_id
+       AND (
+         co.status = 'ready'
+         OR (
+           co.status = 'partially_completed'
+           AND EXISTS (
+             SELECT 1 FROM customer_order_items coi
+              WHERE coi.order_id = co.id
+                AND coi.status IN ('pending','reserved','ready')
+           )
+         )
+       )
+  );
+$function$;
+
+COMMENT ON FUNCTION public.is_order_pickup_ready(bigint) IS
+  'Alias for customer_orders.status=''ready'' 或 (''partially_completed'' 且還有 '
+  'active 品項)。20260630 放寬：部分取貨後剩餘品項仍可繼續取貨。';


### PR DESCRIPTION
## 問題

部分取貨（分品項或分數量）後，訂單 `status` 變 `partially_completed`，但「能不能取貨」的判斷——後端 `is_order_pickup_ready` 與前端 `isPickable` **都只認 `status='ready'`**——導致剩餘的 active 品項再也無法取貨，UI 顯示「分店尚未收貨，無法取貨」（實際上貨早到了）。

實例：訂單 `17128`（會員 297810 / Alex Chen）部分取貨後，剩餘 `品項2 × 2`（仍為 `pending`）被卡住無法取。

這是**既有流程**就有的洞，不是 #377 分批取貨造成的；#377 的分數量取貨只是更容易觸發它。

## 修法（放寬可取判斷，兩層）

1. **後端** `migration 20260630000040`：`is_order_pickup_ready` 放寬為「`status='ready'`，或 `status='partially_completed'` 且還有 active 品項(pending/reserved/ready)」。基底為 `20260629000030`（thin-alias 版）。
2. **前端** `pickup/page.tsx` 的 `isPickable` 同步放寬。

`partially_completed` 一定是先 `ready` 過、被取走部分才產生的狀態，本來就代表「分店已收貨」，故可安全視為可繼續取。

## 部署狀態
- ✅ 此 migration 內容**已透過 Management API 套到線上 DB** 並驗證：訂單 `17128` 現在 `is_order_pickup_ready = true`，一般 `completed` 訂單仍為 `false`（沒有誤放寬）；PostgREST schema cache 已 reload。
- 此分支只含 2 個檔（`pickup/page.tsx` + 新 migration），乾淨基於最新 `main`（含 #377/#378）。
- ⚠️ 此 worktree 未裝 `node_modules`，前端 `tsc` 未跑，型別為人工檢查。

## 影響面
`is_order_pickup_ready` 的唯一 DB caller 是 `rpc_record_pickup`，加上衍生 view `v_order_pickup_ready`。放寬後 `partially_completed` 訂單的剩餘品項能再次進入取貨流程。

https://claude.ai/code/session_011AdmFNDfzTywBo4BepbBzL

---
_Generated by [Claude Code](https://claude.ai/code/session_011AdmFNDfzTywBo4BepbBzL)_