### PR TITLE
訂單明細：已取品項鎖定單價與折扣不可編輯

### DIFF
--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -734,14 +734,14 @@ export function OrderDetail({
                         value={Number(eff.unit_price)}
                         min={0}
                         prefix="$"
-                        disabled={!canEdit}
+                        disabled={!canEdit || isPicked}
                         onSave={async (v) => setItemDraft(it.id, { unit_price: v })}
                       />
                     </td>
                     <td className="px-3 py-2 text-right font-mono">
                       <EditableDiscount
                         value={eff.discount}
-                        disabled={!canEdit}
+                        disabled={!canEdit || isPicked}
                         onChange={(v) => setItemDraft(it.id, { discount: v })}
                         compact
                         referenceAmount={Number(eff.qty) * Number(eff.unit_price)}


### PR DESCRIPTION
## 問題

訂單明細頁，已取貨（`picked_up`）的品項行仍可編輯單價與折扣。但這些行的金額已經結算完成（庫存扣帳 + 取貨收據都按當時金額產生），事後再改會跟已發生的帳對不上。

接續 #380（已取/待取狀態標籤 + 數量鎖定），本 PR 補上金額欄位的鎖定。

## 修法（純前端，`OrderDetail.tsx`）

已取行的：
- 單價 `EditableNumber` → `disabled={!canEdit || isPicked}`
- 折扣 `EditableDiscount` → `disabled={!canEdit || isPicked}`

備註不涉金額，維持可編輯。

合併後「已取」行為：單價 / 折扣 / 數量全鎖，只剩備註可改；待取行照常可編輯。

## 範圍
- 只動 `apps/admin/src/components/OrderDetail.tsx`，**無 SQL 變更**。
- ⚠️ 此 worktree 未裝 `node_modules`，前端 `tsc` 未跑，型別為人工檢查。

https://claude.ai/code/session_011AdmFNDfzTywBo4BepbBzL

---
_Generated by [Claude Code](https://claude.ai/code/session_011AdmFNDfzTywBo4BepbBzL)_