### PR TITLE
請購單：移除含稅、成本欄統一加$並標色

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -374,7 +374,7 @@ function PageContent() {
 
   const totals = useMemo(() => {
     const subtotal = items.reduce((s, r) => s + r.qty_requested * r.unit_cost, 0);
-    return { subtotal, withTax: subtotal * 1.05 };
+    return { subtotal };
   }, [items]);
 
   const unassignedCount = items.filter((r) => !r.suggested_supplier_id).length;
@@ -649,10 +649,9 @@ function PageContent() {
                 )}
               </Row>
               <div className="my-2 border-t border-zinc-200 dark:border-zinc-700" />
-              <Row label="未稅小計">${totals.subtotal.toFixed(1)}</Row>
-              <Row label="含稅總計">
+              <Row label="總計">
                 <span className="text-lg font-semibold text-blue-600 dark:text-blue-400">
-                  ${totals.withTax.toFixed(1)}
+                  ${totals.subtotal.toFixed(1)}
                 </span>
               </Row>
             </dl>
@@ -839,7 +838,7 @@ function PageContent() {
                         className={`w-24 rounded-md border bg-white px-2 py-1 text-right text-sm dark:bg-zinc-800 ${cellWarn}`}
                       />
                     ) : (
-                      r.unit_cost.toFixed(4)
+                      <span className="font-medium text-amber-600 dark:text-amber-400">${r.unit_cost.toFixed(0)}</span>
                     )}
                   </Td>
                   <Td className="text-right">

--- a/apps/admin/src/app/(protected)/purchase/requests/print/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/print/page.tsx
@@ -220,7 +220,6 @@ function PageContent() {
   }, [items, supplierMap]);
 
   const grandTotal = groups.reduce((s, g) => s + g.subtotal, 0);
-  const grandWithTax = grandTotal * 1.05;
 
   if (!id) return <div className="p-6">缺少 id 參數</div>;
   if (error) return <div className="p-6 text-red-600">{error}</div>;
@@ -332,7 +331,7 @@ function PageContent() {
                       {r.qty_requested}
                       {r.unit_uom ?? ""}
                     </Td>
-                    <Td className="text-right">${r.unit_cost.toFixed(0)}</Td>
+                    <Td className="text-right font-medium text-amber-600">${r.unit_cost.toFixed(0)}</Td>
                     <Td className="text-right">
                       {r.retail_price !== null ? `$${r.retail_price.toFixed(0)}` : "—"}
                     </Td>
@@ -357,8 +356,7 @@ function PageContent() {
       ))}
 
       <div className="mt-6 border-t-2 border-zinc-700 pt-3 text-right">
-        <div className="text-sm text-zinc-600">未稅總計：${grandTotal.toFixed(1)}</div>
-        <div className="text-2xl font-bold">${grandWithTax.toFixed(1)}</div>
+        <div className="text-2xl font-bold">總計：${grandTotal.toFixed(1)}</div>
       </div>
 
       {header.notes && (


### PR DESCRIPTION
## 需求

請購單（PR）明細頁：
1. **不要含稅** — 金額本身是對的（成本 × 數量），但摘要與列印的「含稅總計」多收了 5%（×1.05），要拿掉。
2. **成本欄統一格式** — 唯讀顯示時成本是 `80.0000`（無 `$`、拖 4 位小數），跟分店價/售價的 `$90` 不一致；改成一樣加 `$`，並標色凸顯。

## 修法（純前端，2 檔）

`purchase/requests/edit/page.tsx` + `purchase/requests/print/page.tsx`：

- **移除含稅**：`totals.withTax` / `grandWithTax`（`subtotal × 1.05`）整個拿掉，摘要與列印頁改為單一「**總計**」= 未稅小計金額。
- **成本欄**：唯讀顯示 `unit_cost.toFixed(4)`（無 `$`）→ 改成 `$${unit_cost.toFixed(0)}`，與分店價/售價一致，並加**琥珀色**（`text-amber-600`）凸顯。列印頁成本欄也同步標色。

## 範圍 / 部署
- 純顯示層，**無 SQL 變更**、不影響金額計算本身（成本×數量不變）。
- ⚠️ 此 worktree 未裝 `node_modules`，前端 `tsc` 未跑，型別為人工檢查。

https://claude.ai/code/session_011AdmFNDfzTywBo4BepbBzL

---
_Generated by [Claude Code](https://claude.ai/code/session_011AdmFNDfzTywBo4BepbBzL)_