### PR TITLE
採購單：移除含稅、成本欄標色（對齊請購單頁）

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/orders/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/edit/page.tsx
@@ -167,7 +167,7 @@ function PageContent() {
 
   const totals = useMemo(() => {
     const subtotal = items.reduce((s, r) => s + r.qty_ordered * r.unit_cost, 0);
-    return { subtotal, withTax: subtotal * 1.05 };
+    return { subtotal };
   }, [items]);
 
   const editable = header?.status === "draft";
@@ -221,10 +221,9 @@ function PageContent() {
               <Row label="已收貨量">{totalReceived}</Row>
               <Row label="到貨進度">{recvPct.toFixed(0)}%</Row>
               <div className="my-2 border-t border-zinc-200 dark:border-zinc-700" />
-              <Row label="未稅小計">${totals.subtotal.toFixed(0)}</Row>
-              <Row label="含稅總計">
+              <Row label="總計">
                 <span className="text-lg font-semibold text-blue-600 dark:text-blue-400">
-                  ${totals.withTax.toFixed(0)}
+                  ${totals.subtotal.toFixed(0)}
                 </span>
               </Row>
             </dl>
@@ -310,7 +309,7 @@ function PageContent() {
                       <Td className="text-right text-zinc-500">
                         {r.qty_returned > 0 ? r.qty_returned : "—"}
                       </Td>
-                      <Td className="text-right">${r.unit_cost.toFixed(0)}</Td>
+                      <Td className="text-right font-medium text-amber-600 dark:text-amber-400">${r.unit_cost.toFixed(0)}</Td>
                       <Td className="text-right font-mono">${(r.qty_ordered * r.unit_cost).toFixed(0)}</Td>
                     </tr>
                   ))


### PR DESCRIPTION
## 需求

接續 #382（請購單移除含稅），採購單（PO）明細頁也有同樣的含稅邏輯，一併拿掉並對齊成本欄樣式。

## 修法（純前端，1 檔）

`purchase/orders/edit/page.tsx`：

- **移除含稅**：`totals.withTax`（`subtotal × 1.05`）拿掉，摘要卡片由「未稅小計 + 含稅總計」改為單一「**總計**」= 未稅小計金額。（`totals.subtotal` 仍保留，PO 建立時的 `total` 欄位沿用此值，不受影響。）
- **成本欄標色**：成本欄加琥珀色（`text-amber-600`）凸顯，與請購單頁一致。（PO 成本本來就已是 `$` 格式，只補標色。）

## 範圍 / 部署
- 純顯示層，**無 SQL 變更**、不影響金額計算（成本×數量不變）。
- 乾淨基於最新 `main`，只動 1 個檔。
- ⚠️ 此 worktree 未裝 `node_modules`，前端 `tsc` 未跑，型別為人工檢查。

https://claude.ai/code/session_011AdmFNDfzTywBo4BepbBzL

---
_Generated by [Claude Code](https://claude.ai/code/session_011AdmFNDfzTywBo4BepbBzL)_