### PR TITLE
Allow zero unit cost in purchase request validation

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -433,13 +433,14 @@ function PageContent() {
   async function submitForReview() {
     if (!id) return;
     // 送審前驗：每行必須填妥成本 / 分店價 / 售價 + 數量 + 供應商
-    // 並且要符合 成本 < 分店價 < 售價 三段遞增關係
+    // 成本可為 0（如贈品 / 無償樣品進貨，整張請購單金額可為零），但不可為負
+    // 並且要符合 成本 ≤ 分店價 < 售價 的遞增關係
     const incomplete: string[] = [];
     const priceIssues: string[] = [];
     for (const r of items) {
       const issues: string[] = [];
       if (!r.qty_requested || r.qty_requested <= 0) issues.push("數量");
-      if (!r.unit_cost || r.unit_cost <= 0) issues.push("成本");
+      if (r.unit_cost === null || r.unit_cost === undefined || Number.isNaN(r.unit_cost) || r.unit_cost < 0) issues.push("成本");
       if (r.franchise_price === null || r.franchise_price === undefined) issues.push("分店價");
       if (r.retail_price === null || r.retail_price === undefined) issues.push("售價");
       if (!r.suggested_supplier_id) issues.push("供應商");
@@ -450,7 +451,7 @@ function PageContent() {
       const cost = Number(r.unit_cost);
       const branch = Number(r.franchise_price);
       const retail = Number(r.retail_price);
-      if (!(cost < branch && branch < retail)) {
+      if (!(cost <= branch && branch < retail)) {
         priceIssues.push(`${r.sku_code}：成本 $${cost} / 分店價 $${branch} / 售價 $${retail}`);
       }
     }
@@ -459,7 +460,7 @@ function PageContent() {
       return;
     }
     if (priceIssues.length > 0) {
-      setError(`價格必須符合 成本 < 分店價 < 售價：\n${priceIssues.join("\n")}`);
+      setError(`價格必須符合 成本 ≤ 分店價 < 售價：\n${priceIssues.join("\n")}`);
       return;
     }
     if (!confirm("確定送出審核？")) {


### PR DESCRIPTION
## Summary
Updated purchase request submission validation to allow zero unit cost for items like complimentary goods or free samples, while maintaining price hierarchy constraints.

## Changes
- **Unit cost validation**: Changed from requiring `unit_cost > 0` to allowing `unit_cost >= 0`, with explicit null/undefined/NaN checks to catch invalid values
- **Price hierarchy**: Updated the relationship from `cost < branch < retail` to `cost ≤ branch < retail`, allowing cost and branch price to be equal
- **Error messages**: Updated validation error messages to reflect the new `≤` relationship instead of strict `<`
- **Documentation**: Added inline comments clarifying that zero cost is valid for complimentary items and that the entire purchase order can have zero total amount

## Implementation Details
The validation now:
1. Rejects negative costs while accepting zero
2. Allows cost to equal branch price (useful for zero-margin items)
3. Maintains the requirement that branch price must be strictly less than retail price
4. Provides clear error messaging aligned with the new business rules

https://claude.ai/code/session_01Y3S63GWWw2KDFwYanqXnMQ