### PR TITLE
請購單：頂部「一次套用全部」工具列（供應商／價格批次填入）

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -433,13 +433,14 @@ function PageContent() {
   async function submitForReview() {
     if (!id) return;
     // 送審前驗：每行必須填妥成本 / 分店價 / 售價 + 數量 + 供應商
-    // 並且要符合 成本 < 分店價 < 售價 三段遞增關係
+    // 成本可為 0（如贈品 / 無償樣品進貨，整張請購單金額可為零），但不可為負
+    // 並且要符合 成本 ≤ 分店價 < 售價 的遞增關係
     const incomplete: string[] = [];
     const priceIssues: string[] = [];
     for (const r of items) {
       const issues: string[] = [];
       if (!r.qty_requested || r.qty_requested <= 0) issues.push("數量");
-      if (!r.unit_cost || r.unit_cost <= 0) issues.push("成本");
+      if (r.unit_cost === null || r.unit_cost === undefined || Number.isNaN(r.unit_cost) || r.unit_cost < 0) issues.push("成本");
       if (r.franchise_price === null || r.franchise_price === undefined) issues.push("分店價");
       if (r.retail_price === null || r.retail_price === undefined) issues.push("售價");
       if (!r.suggested_supplier_id) issues.push("供應商");
@@ -450,7 +451,7 @@ function PageContent() {
       const cost = Number(r.unit_cost);
       const branch = Number(r.franchise_price);
       const retail = Number(r.retail_price);
-      if (!(cost < branch && branch < retail)) {
+      if (!(cost <= branch && branch < retail)) {
         priceIssues.push(`${r.sku_code}：成本 $${cost} / 分店價 $${branch} / 售價 $${retail}`);
       }
     }
@@ -459,7 +460,7 @@ function PageContent() {
       return;
     }
     if (priceIssues.length > 0) {
-      setError(`價格必須符合 成本 < 分店價 < 售價：\n${priceIssues.join("\n")}`);
+      setError(`價格必須符合 成本 ≤ 分店價 < 售價：\n${priceIssues.join("\n")}`);
       return;
     }
     if (!confirm("確定送出審核？")) {

--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -92,6 +92,12 @@ function PageContent() {
   const [busy, setBusy] = useState<"save" | "submit" | "split" | "reopen" | null>(null);
   const [destLocationId, setDestLocationId] = useState<number | null>(null);
 
+  // 頂部「一次套用到全部品項」工具列的暫存值（空字串＝不套用該欄）
+  const [bulkSupplier, setBulkSupplier] = useState<number | null>(null);
+  const [bulkCost, setBulkCost] = useState<string>("");
+  const [bulkBranch, setBulkBranch] = useState<string>("");
+  const [bulkRetail, setBulkRetail] = useState<string>("");
+
   useEffect(() => {
     if (!id) {
       setLoading(false);
@@ -392,6 +398,34 @@ function PageContent() {
 
   function removeItem(idx: number) {
     setItems((cur) => cur.filter((_, i) => i !== idx));
+  }
+
+  // 把頂部工具列的值一次套用到所有品項；留空的欄位不動，避免誤清既有值
+  function bulkApply() {
+    const costNum = bulkCost.trim() === "" ? null : Number(bulkCost);
+    const branchNum = bulkBranch.trim() === "" ? null : Number(bulkBranch);
+    const retailNum = bulkRetail.trim() === "" ? null : Number(bulkRetail);
+    const hasSupplier = bulkSupplier !== null;
+    if (
+      !hasSupplier &&
+      costNum === null &&
+      branchNum === null &&
+      retailNum === null
+    ) {
+      return;
+    }
+    setItems((cur) =>
+      cur.map((r) => {
+        const next = { ...r };
+        if (hasSupplier) next.suggested_supplier_id = bulkSupplier;
+        if (costNum !== null && !Number.isNaN(costNum)) next.unit_cost = costNum;
+        if (branchNum !== null && !Number.isNaN(branchNum)) next.franchise_price = branchNum;
+        if (retailNum !== null && !Number.isNaN(retailNum)) next.retail_price = retailNum;
+        next.line_subtotal = next.qty_requested * next.unit_cost;
+        next.dirty = true;
+        return next;
+      }),
+    );
   }
 
   async function saveDraft() {
@@ -736,6 +770,63 @@ function PageContent() {
               *成本=廠商給的價格，售價=ERP 商品價格
             </span>
           </div>
+          {editable && items.length > 0 && (
+            <div className="flex flex-wrap items-end gap-2 border-b border-zinc-200 bg-zinc-50 px-4 py-2 dark:border-zinc-800 dark:bg-zinc-900/50">
+              <span className="self-center text-xs font-medium text-zinc-500">一次套用全部：</span>
+              <label className="flex flex-col gap-0.5">
+                <span className="text-[10px] uppercase tracking-wide text-zinc-400">供應商</span>
+                <div className="w-44">
+                  <SupplierPicker
+                    value={bulkSupplier}
+                    suppliers={suppliers}
+                    usage={supplierUsage}
+                    onChange={setBulkSupplier}
+                  />
+                </div>
+              </label>
+              <label className="flex flex-col gap-0.5">
+                <span className="text-[10px] uppercase tracking-wide text-zinc-400">成本</span>
+                <input
+                  type="number"
+                  step="1"
+                  value={bulkCost}
+                  onChange={(e) => setBulkCost(e.target.value)}
+                  placeholder="—"
+                  className="w-20 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                />
+              </label>
+              <label className="flex flex-col gap-0.5">
+                <span className="text-[10px] uppercase tracking-wide text-zinc-400">分店價</span>
+                <input
+                  type="number"
+                  step="1"
+                  value={bulkBranch}
+                  onChange={(e) => setBulkBranch(e.target.value)}
+                  placeholder="—"
+                  className="w-20 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                />
+              </label>
+              <label className="flex flex-col gap-0.5">
+                <span className="text-[10px] uppercase tracking-wide text-zinc-400">售價</span>
+                <input
+                  type="number"
+                  step="1"
+                  value={bulkRetail}
+                  onChange={(e) => setBulkRetail(e.target.value)}
+                  placeholder="—"
+                  className="w-20 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={bulkApply}
+                className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-500"
+              >
+                套用到 {items.length} 項
+              </button>
+              <span className="self-center text-[11px] text-zinc-400">留空的欄位不會被覆寫</span>
+            </div>
+          )}
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
@@ -771,12 +862,12 @@ function PageContent() {
               </tr>
             ) : (
               items.map((r, idx) => {
-                // 成本 < 分店價 < 售價 必須遞增，三值有任一缺則不檢查（送審前才擋）
+                // 成本 ≤ 分店價 < 售價 必須遞增，三值有任一缺則不檢查（送審前才擋）
                 const cost = Number(r.unit_cost);
                 const branch = r.franchise_price != null ? Number(r.franchise_price) : null;
                 const retail = r.retail_price != null ? Number(r.retail_price) : null;
                 const priceBad =
-                  cost > 0 && branch != null && retail != null && !(cost < branch && branch < retail);
+                  branch != null && retail != null && !(cost <= branch && branch < retail);
                 const cellWarn = priceBad
                   ? "border-rose-400 bg-rose-50 dark:border-rose-700 dark:bg-rose-950"
                   : "border-zinc-300 dark:border-zinc-700";
@@ -788,7 +879,7 @@ function PageContent() {
                     <div className="font-mono text-xs text-zinc-500">{r.sku_code}</div>
                     {priceBad && (
                       <div className="mt-0.5 text-[11px] font-medium text-rose-600 dark:text-rose-400">
-                        ⚠ 成本 &lt; 分店價 &lt; 售價 順序錯
+                        ⚠ 成本 ≤ 分店價 &lt; 售價 順序錯
                       </div>
                     )}
                   </Td>


### PR DESCRIPTION
## 摘要

在請購單編輯頁的「內部採購清單」上方新增一條工具列，讓使用者可以**一次選供應商、填成本／分店價／售價並套用到所有品項**，不必逐行重複輸入。

接續 #388（允許成本／金額為零）之後的 UX 改善。

## 變更內容

- **頂部批次工具列**（僅編輯草稿時顯示，且有品項時才出現）
  - 供應商：沿用既有的 `SupplierPicker`（含搜尋、常用排序）
  - 成本／分店價／售價：各一個數字輸入框
  - 「套用到 N 項」按鈕：把填入的值灌進每一行，並重算 `line_subtotal`
- **留空欄位不覆寫**：只填部分欄位時，其餘欄位維持各行原值，避免誤清成 0
- 套用後各行標記 `dirty`，需再按「存為草稿」或「送出審核」才會寫入 DB
- 行內價格警示對齊送審規則，放寬為 `成本 ≤ 分店價 < 售價`（原本為嚴格 `<`，與送審驗證不一致）

## 測試

- 純前端 state 操作，無 schema／RPC 變更
- 容器內未安裝 node_modules，無法跑完整 typecheck；改動為單純且型別安全的 React/TS

https://claude.ai/code/session_01Y3S63GWWw2KDFwYanqXnMQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3S63GWWw2KDFwYanqXnMQ)_