### PR TITLE
派貨工作台：修「已撿/可分配」漏算孤兒 wave 導致 submit 爆

### DIFF
--- a/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
@@ -24,6 +24,9 @@ type DemandRow = {
   demand_qty: number;
   wave_qty: number;
   shipped_qty: number;
+  // per (po, sku) 跨 store 已撿真值（與 RPC 守衛對齊）。
+  // 同 (po, sku) 各 row 共享同值；NULL fallback 給未套 migration 環境。
+  po_sku_already_wave?: number | null;
 };
 
 type StoreInfo = { store_id: number; store_code: string | null; store_name: string };
@@ -100,10 +103,12 @@ export default function PrintPickListPage() {
         poSkuSeen.add(poSkuKey);
         s.totalOrdered += Number(r.qty_ordered);
         s.totalGr += Number(r.gr_qty);
+        // 用 view 新欄位 po_sku_already_wave：per (po, sku) 跨 store 真值，
+        // 與 RPC 守衛 SUM(pwi) 對齊。fallback 給未套 migration 的本地環境（會偏低）。
+        s.totalAlreadyWave += Number(r.po_sku_already_wave ?? 0);
       }
       s.storeDemand.set(r.store_id, (s.storeDemand.get(r.store_id) ?? 0) + Number(r.demand_qty));
       s.storeWave.set(r.store_id, (s.storeWave.get(r.store_id) ?? 0) + Number(r.wave_qty));
-      s.totalAlreadyWave += Number(r.wave_qty);
     }
     for (const s of skuMap.values()) {
       s.totalAvailable = Math.max(0, s.totalGr - s.totalAlreadyWave);

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -31,6 +31,9 @@ type DemandRow = {
   wave_qty: number;
   shipped_qty: number;
   is_restock_sourced?: boolean;
+  // per (po_id, sku_id) 跨 store 已撿真值（與 RPC 守衛對齊）。
+  // 同 (po, sku) 各 row 共享同值；NULL fallback 給未套 migration 的本地環境（會偏低，但不會 crash）。
+  po_sku_already_wave?: number | null;
 };
 
 type Supplier = { id: number; code: string; name: string };
@@ -170,7 +173,9 @@ export default function PickingWorkstationPage() {
           qty_ordered: Number(r.qty_ordered),
           qty_in_transit: inTransit,
           qty_shortage: shortage,
-          already_wave_for_sku: 0,
+          // 用 view 新欄位 po_sku_already_wave：per (po, sku) 跨 store 真值，
+          // 與 RPC 守衛 SUM(pwi) 對齊。fallback 給未套 migration 的本地環境（會偏低）。
+          already_wave_for_sku: Number(r.po_sku_already_wave ?? 0),
           is_restock_sourced: !!r.is_restock_sourced,
         });
         s.totalOrdered += Number(r.qty_ordered);
@@ -181,9 +186,6 @@ export default function PickingWorkstationPage() {
       s.storeDemand.set(r.store_id, (s.storeDemand.get(r.store_id) ?? 0) + Number(r.demand_qty));
       s.storeWave.set(r.store_id, (s.storeWave.get(r.store_id) ?? 0) + Number(r.wave_qty));
       s.storeShipped.set(r.store_id, (s.storeShipped.get(r.store_id) ?? 0) + Number(r.shipped_qty));
-      // already_wave per (po, sku) 累加（跨 store）
-      const poEntry = s.poList.find((p) => p.po_id === r.po_id)!;
-      poEntry.already_wave_for_sku += Number(r.wave_qty);
     }
     // 計算 totals
     for (const s of grouped.values()) {

--- a/docs/TEST-picking-already-wave-fix.md
+++ b/docs/TEST-picking-already-wave-fix.md
@@ -1,0 +1,119 @@
+---
+title: TEST — 派貨工作台「已撿」/「可分配」與 RPC 守衛對齊
+module: WMS / Picking workstation
+status: pending
+ran_at:
+verified_by:
+---
+
+# 派貨工作台「已撿」/「可分配」與 RPC 守衛對齊
+
+## 背景
+
+使用者截圖回報「派貨工作台 數量怪怪的」：
+
+- G00123-02：UI 顯示 已到 15 / **已撿 3 / 可分配 7**（合計擬分 5）
+- 按「建立撿貨單」失敗：「PO2605250317: SKU『G00123-02 包子媽生鮮小舖 A-王董』分配 5 超過可分配量 0.000（**進貨 10.000、已撿 10.000**）」
+
+UI 算的 totalAlreadyWave = 3，但 RPC 守衛 `SUM(picking_wave_items.qty)` per (po, sku) = 10、差距 7。
+
+## 根因
+
+`v_picking_demand_by_po` 的 wave_qty 算法：
+
+```sql
+LEFT JOIN store_demand sd ON sd.po_item_id = ps.po_item_id
+LEFT JOIN wave_qty wq ON wq.source_po_id = ps.po_id
+                     AND wq.sku_id = ps.sku_id
+                     AND wq.store_id = sd.store_id   -- ← 強制對齊 store_demand 的 store
+```
+
+若 `picking_wave_items` 撿給某 store，但對應的 `customer_orders` 後來 cancel / transferred_out
+→ store_demand 不含該 store → view 不會吐這筆 wave_qty。
+
+FE `apps/admin/src/app/(protected)/wms/picking/page.tsx` 從 row 加總 `wave_qty` 算 `totalAlreadyWave`：
+- 偏低 → `totalAvailable = totalGr - totalAlreadyWave` 偏高 → UI「可分配」誤報
+- FIFO 切貨切到「FE 認為還有空但實際滿了」的 PO → RPC 守衛擋下、報「進貨 X、已撿 X、可分配 0」
+
+`apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx` 同樣模式、同樣偏低。
+
+## 修法
+
+| 改動 | 檔案 |
+|---|---|
+| view 加欄位 `po_sku_already_wave`（per po_id+sku_id 跨 store 加總 `picking_wave_items`，**不依 sd.store_id**） | `supabase/migrations/20260701000010_v_picking_demand_fix_already_wave.sql` |
+| `wms/picking/page.tsx`：`DemandRow` 加 `po_sku_already_wave`；`skuRows` useMemo 用該欄位設 `already_wave_for_sku`、不再 `+= r.wave_qty` | `apps/admin/src/app/(protected)/wms/picking/page.tsx` |
+| `print-pick-list/page.tsx`：同上 | `apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx` |
+
+`wave_qty`（per store）欄位保留不動 — by_store 視角 + 「店欄位 small 字」仍用它顯示。
+
+## 驗證
+
+### A. 復現孤兒 wave（SQL）
+
+找實際出問題的 PO×SKU：
+
+```sql
+WITH pwi_sum AS (
+  SELECT pw.source_po_id AS po_id, pwi.sku_id, SUM(pwi.qty) AS pwi_total
+  FROM picking_wave_items pwi
+  JOIN picking_waves pw ON pw.id = pwi.wave_id
+  WHERE pw.status <> 'cancelled' AND pw.source_po_id IS NOT NULL
+  GROUP BY pw.source_po_id, pwi.sku_id
+),
+view_sum AS (
+  SELECT po_id, sku_id, SUM(wave_qty) AS view_total
+  FROM v_picking_demand_by_po
+  GROUP BY po_id, sku_id
+)
+SELECT p.po_id, p.sku_id, p.pwi_total, COALESCE(v.view_total,0) AS view_total,
+       p.pwi_total - COALESCE(v.view_total,0) AS missing
+FROM pwi_sum p
+LEFT JOIN view_sum v ON v.po_id = p.po_id AND v.sku_id = p.sku_id
+WHERE p.pwi_total <> COALESCE(v.view_total, 0)
+ORDER BY missing DESC;
+```
+
+修法前：截圖 PO 應該至少出現一筆 `missing > 0`（孤兒 wave）。
+
+### B. 修補後對齊（SQL）
+
+```sql
+SELECT
+  po_id, sku_id,
+  MAX(po_sku_already_wave) AS already_wave_new_column,  -- per (po, sku) 常數
+  SUM(wave_qty) AS wave_qty_sum_per_store               -- 可能偏低
+FROM v_picking_demand_by_po
+WHERE po_id IN (<截圖 PO 們>) GROUP BY po_id, sku_id;
+```
+
+`already_wave_new_column` 應該 = `SUM(picking_wave_items.qty)` per (po, sku) — 不受孤兒 wave 影響。
+
+### C. UI 驗收（admin 派貨工作台）
+
+進 `/wms/picking`：
+
+- [ ] G00123-02（或目前出問題的 SKU）「已撿」欄顯示 = SUM(pwi) per (sku)、跨多 PO 加總（如截圖案例：應為 ≥10）
+- [ ] 「可分配」 = totalGr - totalAlreadyWave - 已分配。修補後若 PO_A 已滿，可分配只算另一張 PO 剩下的量
+- [ ] 分配 < 可分配後按「建立撿貨單」**不再爆**「分配 X 超過可分配量 0」
+- [ ] 分配 = 可分配時可成功建立撿貨單
+- [ ] 「跨 2 張 PO」tooltip 顯示每張 PO 的「撿」 = per (po, sku) 真值（從 view 新欄位）
+
+### D. UI 驗收（撿貨清單列印）
+
+進 `/picking/print-pick-list`：
+
+- [ ] 已撿總量同 admin 派貨工作台、與 SUM(pwi) per (sku) 對齊
+
+### E. Regression — RPC 守衛仍能擋過量分配
+
+- [ ] 故意把某 SKU 分配 > 可分配 → 仍報錯（中文 message 不變）
+
+## Rollback
+
+```sql
+-- view 回 20260614000010 版本（drop 新欄位 po_sku_already_wave）
+-- FE 改檔 revert
+```
+
+注意：rollback 後 bug 復現、UI 數字繼續對不上。

--- a/supabase/migrations/20260701000010_v_picking_demand_fix_already_wave.sql
+++ b/supabase/migrations/20260701000010_v_picking_demand_fix_already_wave.sql
@@ -1,0 +1,223 @@
+-- ============================================================
+-- 修：v_picking_demand_by_po 漏算「沒需求 store 已撿的 wave」
+--
+-- 背景：
+--   原 view 的 wave_qty 用 LEFT JOIN store_demand sd → LEFT JOIN wave_qty wq
+--   ON wq.store_id = sd.store_id，依賴 store_demand 才能對到 wave。
+--   若 picking_wave_items 撿給某 store，但該 store 對應的 customer_orders 後來
+--   cancel / transferred_out → store_demand 不含該 store → wave_qty 在 view 中
+--   不會出現 → FE 從 row 加總 wave_qty 算 totalAlreadyWave 偏低 →
+--   「可分配」誤報 → FIFO 切到滿張 PO → RPC 守衛 SUM(pwi) 算真值報錯
+--   「進貨 X、已撿 X、可分配 0」。
+--
+--   截圖回報 PO2605250317 SKU G00123-02：UI 已撿 3 / 可分配 7，
+--   實際 RPC 已撿 10 / 可分配 0，差異 7 = 撿給已 cancel/transferred_out 訂單對應 store 的 wave。
+--
+-- 修法：
+--   1) view 在 SELECT 尾部新增一欄 po_sku_already_wave (per po_id+sku_id 跨 store
+--      加總 picking_wave_items 的 qty)，不依 sd.store_id JOIN — 與 RPC 守衛對齊。
+--   2) wave_qty (per po+sku+store) 保留不動，by_store 視角 + 「店欄位 small 字」
+--      仍用它顯示原樣。
+--
+--   FE 改用 po_sku_already_wave 算 totalAvailable / FIFO （見 PR 同批 commit）。
+--
+-- 基於：20260614000010_fix_pr_campaigns_sync.sql 版本（最新 view 定義）
+-- Rollback：CREATE OR REPLACE VIEW 回 20260614000010 版本（drop 新欄位）
+-- ============================================================
+
+-- CREATE OR REPLACE VIEW 限制：既有欄位順序 / 型別不可動、僅可在尾部加新欄位。
+-- 這裡新增的 po_sku_already_wave 放在最後一欄（is_restock_sourced 之後）。
+CREATE OR REPLACE VIEW public.v_picking_demand_by_po AS
+WITH po_skus AS (
+  SELECT
+    po.id            AS po_id,
+    po.tenant_id,
+    po.po_no,
+    po.status        AS po_status,
+    po.supplier_id,
+    poi.id           AS po_item_id,
+    poi.sku_id,
+    poi.qty_ordered,
+    EXISTS (
+      SELECT 1
+        FROM purchase_request_items pri2
+        JOIN restock_requests rr ON rr.linked_pr_id = pri2.pr_id
+       WHERE pri2.po_item_id = poi.id
+    ) AS is_restock_sourced
+  FROM purchase_orders po
+  JOIN purchase_order_items poi ON poi.po_id = po.id
+  WHERE po.status IN ('sent', 'partially_received', 'fully_received')
+),
+gr_qty AS (
+  SELECT
+    gri.po_item_id,
+    SUM(gri.qty_received) AS gr_qty
+  FROM goods_receipt_items gri
+  JOIN goods_receipts gr ON gr.id = gri.gr_id
+  WHERE gr.status = 'confirmed'
+  GROUP BY gri.po_item_id
+),
+po_campaigns AS (
+  SELECT DISTINCT po_item_id, campaign_id FROM (
+    SELECT poi.id AS po_item_id, prc.campaign_id
+      FROM purchase_order_items poi
+      JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+      JOIN purchase_requests pr ON pr.id = pri.pr_id
+      JOIN purchase_request_campaigns prc ON prc.pr_id = pr.id
+    UNION
+    SELECT poi.id AS po_item_id, pri.source_campaign_id AS campaign_id
+      FROM purchase_order_items poi
+      JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+     WHERE pri.source_campaign_id IS NOT NULL
+  ) u
+),
+campaign_demand AS (
+  SELECT
+    pc.po_item_id,
+    co.pickup_store_id AS store_id,
+    SUM(coi.qty) AS demand_qty
+  FROM po_campaigns pc
+  JOIN customer_orders co ON co.campaign_id = pc.campaign_id
+                         AND co.status NOT IN ('cancelled','expired','transferred_out')
+                         AND co.transferred_from_order_id IS NULL
+  JOIN customer_order_items coi ON coi.order_id = co.id
+                               AND coi.status NOT IN ('cancelled','expired')
+  JOIN purchase_order_items poi ON poi.id = pc.po_item_id
+                               AND poi.sku_id = coi.sku_id
+  GROUP BY pc.po_item_id, co.pickup_store_id
+),
+restock_demand AS (
+  SELECT
+    poi.id AS po_item_id,
+    rr.requesting_store_id AS store_id,
+    SUM(rrl.qty) AS demand_qty
+  FROM purchase_order_items poi
+  JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+  JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                          AND rr.status NOT IN ('cancelled','rejected')
+  JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                AND rrl.sku_id = poi.sku_id
+  GROUP BY poi.id, rr.requesting_store_id
+),
+store_demand AS (
+  SELECT po_item_id, store_id, SUM(demand_qty) AS demand_qty
+  FROM (
+    SELECT po_item_id, store_id, demand_qty FROM campaign_demand
+    UNION ALL
+    SELECT po_item_id, store_id, demand_qty FROM restock_demand
+  ) u
+  GROUP BY po_item_id, store_id
+),
+wave_qty AS (
+  SELECT source_po_id, sku_id, store_id, SUM(qty) AS wave_qty
+  FROM (
+    SELECT pw.source_po_id, pwi.sku_id, pwi.store_id, pwi.qty
+    FROM picking_wave_items pwi
+    JOIN picking_waves pw ON pw.id = pwi.wave_id
+    WHERE pw.status <> 'cancelled'
+      AND pw.source_po_id IS NOT NULL
+    UNION ALL
+    SELECT
+      poi.po_id AS source_po_id,
+      ti.sku_id,
+      rr.requesting_store_id AS store_id,
+      ti.qty_requested
+    FROM restock_requests rr
+    JOIN transfers t ON t.id = rr.linked_transfer_id
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status <> 'cancelled'
+  ) u
+  GROUP BY source_po_id, sku_id, store_id
+),
+-- 新增：per (po_id, sku_id) 跨 store 加總 picking_wave_items，與 RPC 守衛 SUM(pwi) 對齊。
+-- 不依 store_demand JOIN，所以「撿給已 cancel 訂單對應 store」的孤兒 wave 也會被算進去。
+po_sku_already_wave AS (
+  SELECT pw.source_po_id AS po_id, pwi.sku_id, SUM(pwi.qty) AS already_wave
+  FROM picking_wave_items pwi
+  JOIN picking_waves pw ON pw.id = pwi.wave_id
+  WHERE pw.status <> 'cancelled'
+    AND pw.source_po_id IS NOT NULL
+  GROUP BY pw.source_po_id, pwi.sku_id
+),
+shipped_qty AS (
+  SELECT source_po_id, sku_id, store_id, SUM(qty_received) AS shipped_qty
+  FROM (
+    SELECT
+      pw.source_po_id,
+      ti.sku_id,
+      (substring(t.transfer_no FROM 'WAVE-\d+-S(\d+)'))::BIGINT AS store_id,
+      ti.qty_received
+    FROM transfers t
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN picking_waves pw ON t.transfer_no LIKE 'WAVE-' || pw.id || '-S%'
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status IN ('received', 'closed')
+      AND pw.source_po_id IS NOT NULL
+    UNION ALL
+    SELECT
+      poi.po_id AS source_po_id,
+      ti.sku_id,
+      rr.requesting_store_id AS store_id,
+      ti.qty_received
+    FROM restock_requests rr
+    JOIN transfers t ON t.id = rr.linked_transfer_id
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status IN ('received', 'closed')
+  ) u
+  GROUP BY source_po_id, sku_id, store_id
+)
+SELECT
+  ps.tenant_id,
+  ps.po_id,
+  ps.po_no,
+  ps.po_status,
+  ps.supplier_id,
+  ps.po_item_id,
+  ps.sku_id,
+  s.sku_code,
+  COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+  ps.qty_ordered,
+  COALESCE(g.gr_qty, 0)::NUMERIC AS gr_qty,
+  CASE
+    WHEN ps.po_status <> 'fully_received'
+      THEN GREATEST(0, ps.qty_ordered - COALESCE(g.gr_qty, 0))
+    ELSE 0
+  END::NUMERIC AS qty_in_transit,
+  CASE
+    WHEN ps.po_status = 'fully_received' AND COALESCE(g.gr_qty, 0) < ps.qty_ordered
+      THEN ps.qty_ordered - COALESCE(g.gr_qty, 0)
+    ELSE 0
+  END::NUMERIC AS qty_shortage,
+  sd.store_id,
+  st.code AS store_code,
+  st.name AS store_name,
+  COALESCE(sd.demand_qty, 0)::NUMERIC AS demand_qty,
+  COALESCE(wq.wave_qty, 0)::NUMERIC AS wave_qty,
+  COALESCE(sq.shipped_qty, 0)::NUMERIC AS shipped_qty,
+  ps.is_restock_sourced,
+  -- 新欄位：per (po, sku) 真實已撿，與 RPC 守衛對齊
+  COALESCE(psaw.already_wave, 0)::NUMERIC AS po_sku_already_wave
+FROM po_skus ps
+JOIN skus s ON s.id = ps.sku_id
+LEFT JOIN gr_qty g ON g.po_item_id = ps.po_item_id
+LEFT JOIN store_demand sd ON sd.po_item_id = ps.po_item_id
+LEFT JOIN stores st ON st.id = sd.store_id
+LEFT JOIN wave_qty wq ON wq.source_po_id = ps.po_id AND wq.sku_id = ps.sku_id AND wq.store_id = sd.store_id
+LEFT JOIN shipped_qty sq ON sq.source_po_id = ps.po_id AND sq.sku_id = ps.sku_id AND sq.store_id = sd.store_id
+LEFT JOIN po_sku_already_wave psaw ON psaw.po_id = ps.po_id AND psaw.sku_id = ps.sku_id
+WHERE
+  COALESCE(sq.shipped_qty, 0) < GREATEST(COALESCE(g.gr_qty, 0), 1)
+  AND (COALESCE(g.gr_qty, 0) > 0 OR COALESCE(sd.demand_qty, 0) > 0);
+
+GRANT SELECT ON public.v_picking_demand_by_po TO authenticated;
+
+COMMENT ON VIEW public.v_picking_demand_by_po IS
+  '撿貨工作站主視圖：PO × SKU × store 矩陣。'
+  'po_sku_already_wave (per po+sku) 為跨 store 已撿真值，與 RPC 守衛對齊；'
+  'wave_qty (per po+sku+store) 仍依 store_demand JOIN，僅供 by_store 視角顯示。';


### PR DESCRIPTION
## Summary

- 修補 `v_picking_demand_by_po` 漏算「撿給已 cancel/transferred_out 訂單對應 store」的 wave，導致 UI「可分配」誤報、submit 時 RPC 守衛擋下。
- view 加 `po_sku_already_wave` 欄位（per po+sku 跨 store 真值），FE 用它算 `totalAvailable` / FIFO，與 RPC `SUM(picking_wave_items)` 對齊。
- `wave_qty` (per store) 不動，by_store 視角 / 「店欄位 small 字」維持原樣。

## 根因

`v_picking_demand_by_po` 算 wave_qty：

```sql
LEFT JOIN store_demand sd ON sd.po_item_id = ps.po_item_id
LEFT JOIN wave_qty wq ON wq.source_po_id = ps.po_id
                     AND wq.sku_id = ps.sku_id
                     AND wq.store_id = sd.store_id   -- ← 強制對齊
```

若 `picking_wave_items` 撿給某 store、但對應 `customer_orders` 後來 cancel/transferred_out → store_demand 不含該 store → 那筆 wave 在 view 中消失。FE 從 row 加總 wave_qty 算 totalAlreadyWave 偏低 → 「可分配」誤報 → FIFO 切到滿張 PO → RPC 守衛 SUM(pwi) per (po, sku) 抓到真值報「進貨 X、已撿 X、可分配 0」。

回報案例：PO2605250317 G00123-02 UI 已撿 3 / 可分配 7（合計擬分 5），RPC 實際進貨 10 / 已撿 10 / 可分配 0 → submit 失敗。

## 修法

| 改動 | 檔案 |
|---|---|
| view 加 `po_sku_already_wave` (per po+sku 跨 store 加總 picking_wave_items，不依 sd.store_id) | `supabase/migrations/20260701000010_v_picking_demand_fix_already_wave.sql` |
| 派貨工作台：`DemandRow` 加新欄位、`skuRows` 用它設 `already_wave_for_sku` | `apps/admin/src/app/(protected)/wms/picking/page.tsx` |
| 撿貨清單列印：同步用 `po_sku_already_wave` 算 totalAlreadyWave | `apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx` |

## Prod 套用 SQL

需要在 Supabase Studio SQL Editor 跑 `supabase/migrations/20260701000010_v_picking_demand_fix_already_wave.sql` 整段（純 `CREATE OR REPLACE VIEW`，非破壞性、可直接 rollback 回 20260614000010 版本）。

## Test plan

詳見 [docs/TEST-picking-already-wave-fix.md](docs/TEST-picking-already-wave-fix.md)。

- [ ] 套 migration 後跑驗證 SQL A：應該找到 `missing > 0` 的孤兒 wave 筆
- [ ] 跑驗證 SQL B：`po_sku_already_wave` 應等於 `SUM(picking_wave_items)` per (po, sku)
- [ ] 進 `/wms/picking`：之前出問題的 SKU「已撿」應顯示 = SUM(pwi)、「可分配」對得上
- [ ] 把分配 ≤ 可分配後按「建立撿貨單」應**不再爆**「分配 X 超過可分配量 0」
- [ ] Regression：故意把某 SKU 分配 > 可分配，仍然能被 RPC 擋下並中文化錯誤

## 本地驗證限制

Worktree 沙箱起不了 docker / supabase，無法直接套 migration 跑 SQL 驗證 + 進 admin 派貨工作台 UI 走流程。已驗證項目：

- TypeScript 編譯（`tsc --noEmit -p apps/admin/tsconfig.json`）通過
- admin Next.js dev server 起得來、`/wms/picking` 路由 200（redirect 到 login）
- 無 server / console error

prod 套 migration + UI 走一輪請使用者自審。

🤖 Generated with [Claude Code](https://claude.com/claude-code)