### PR TITLE
fix: 建立新開團帶入文案（修開團在會員 App 沒文案）

### DIFF
--- a/apps/admin/src/components/CreateCampaignModal.tsx
+++ b/apps/admin/src/components/CreateCampaignModal.tsx
@@ -70,6 +70,8 @@ export function CreateCampaignModal({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [campaignNo, setCampaignNo] = useState<string>("（產生中…）");
+  // 文案：預設帶入「商品文案」(products.description)，可編輯
+  const [description, setDescription] = useState("");
 
   // fetch preview campaign_no
   useEffect(() => {
@@ -77,6 +79,22 @@ export function CreateCampaignModal({
       if (data) setCampaignNo(data as string);
     });
   }, []);
+
+  // 預設帶入商品文案（1 campaign : 1 product，取第一個商品的 description）
+  useEffect(() => {
+    const pid = products[0]?.id;
+    if (!pid) return;
+    let alive = true;
+    getSupabase()
+      .from("products")
+      .select("description")
+      .eq("id", pid)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (alive && data?.description) setDescription(data.description as string);
+      });
+    return () => { alive = false; };
+  }, [products]);
 
   // auto-update pickup_deadline when end_at changes
   function handleEndAtChange(val: string) {
@@ -102,6 +120,7 @@ export function CreateCampaignModal({
         p_end_at: new Date(endAt).toISOString(),
         p_pickup_deadline: pickupDeadline || null,
         p_product_id: products[0].id,
+        p_description: description.trim() || null,
       });
       if (err) throw err;
       onCreated(Number(data));
@@ -141,6 +160,20 @@ export function CreateCampaignModal({
         <label className="flex flex-col gap-1 text-sm sm:col-span-2">
           <span className="text-zinc-600 dark:text-zinc-400">團名稱 <span className="text-red-500">*</span></span>
           <input value={name} onChange={(e) => setName(e.target.value)} className={inputCls} />
+        </label>
+
+        <label className="flex flex-col gap-1 text-sm sm:col-span-2">
+          <span className="text-zinc-600 dark:text-zinc-400">
+            文案
+            <span className="ml-1 text-xs text-zinc-400">（會顯示在會員 App，預設帶入商品文案，可修改）</span>
+          </span>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={4}
+            placeholder="輸入要顯示給顧客看的開團文案…"
+            className={`${inputCls} resize-y whitespace-pre-wrap`}
+          />
         </label>
 
         <label className="flex flex-col gap-1 text-sm">

--- a/supabase/migrations/20260701040000_campaign_from_product_with_description.sql
+++ b/supabase/migrations/20260701040000_campaign_from_product_with_description.sql
@@ -1,0 +1,118 @@
+-- ============================================================================
+-- 2026-07-01: rpc_create_campaign_from_product — 開團帶入文案(description)
+-- ----------------------------------------------------------------------------
+-- 以哪個版本為基底：20260514000010_rpc_singular_product.sql（rpc_create_campaign_from_product 最新定義）
+-- rollback 指回　 ：20260514000010_rpc_singular_product.sql
+--   （還原時：DROP 本檔的 5 參數版，重跑 20260514000010 的 4 參數版定義與 GRANT。）
+--
+-- 問題：從商品詳情頁「建立新開團」走 rpc_create_campaign_from_product，INSERT 沒寫
+--   description，導致開團的「文案」為 NULL，會員 App 不顯示文案。
+--   （對照：從候選池 rpc_schedule_candidate 進的團會把 raw_text 寫進 description，故有文案。）
+--
+-- 變更：
+--   1. rpc_create_campaign_from_product 新增 p_description 參數（DEFAULT NULL）。
+--      description = COALESCE(p_description, 該商品 products.description)
+--      → 呼叫端（建立新開團視窗）會帶入「商品文案」當預設、可編輯；未帶時退回商品文案。
+--   2. 既有「沒文案」的開團，一次性用其商品 products.description 回填。
+--   其餘（產團號、塞 active SKU 進 campaign_items）逐字保留。
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.rpc_create_campaign_from_product(TEXT, TIMESTAMPTZ, DATE, BIGINT);
+
+CREATE OR REPLACE FUNCTION public.rpc_create_campaign_from_product(
+  p_name            TEXT,
+  p_end_at          TIMESTAMPTZ,
+  p_pickup_deadline DATE,
+  p_product_id      BIGINT,
+  p_description     TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant      UUID := public._current_tenant_id();
+  v_no          TEXT;
+  v_campaign_id BIGINT;
+  v_desc        TEXT;
+  v_sort        INT  := 1;
+  r             RECORD;
+BEGIN
+  -- 確認 product 在同 tenant
+  PERFORM 1 FROM products WHERE id = p_product_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'product % not in tenant', p_product_id;
+  END IF;
+
+  -- 文案：優先用呼叫端傳入的 p_description；未提供(NULL)時退回商品本身的 description
+  v_desc := COALESCE(
+    p_description,
+    (SELECT description FROM products WHERE id = p_product_id AND tenant_id = v_tenant)
+  );
+
+  v_no := public.rpc_next_campaign_no();
+
+  INSERT INTO group_buy_campaigns (
+    tenant_id, campaign_no, name, description, status, product_id,
+    start_at, end_at, pickup_deadline,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_no, p_name, v_desc, 'open', p_product_id,
+    NOW(), p_end_at, p_pickup_deadline,
+    auth.uid(), auth.uid()
+  ) RETURNING id INTO v_campaign_id;
+
+  -- 對該 product 的所有 active SKU 補進 campaign_items
+  FOR r IN
+    SELECT
+      s.id AS sku_id,
+      COALESCE(
+        (SELECT p.price
+           FROM prices p
+          WHERE p.sku_id    = s.id
+            AND p.scope     = 'retail'
+            AND p.tenant_id = v_tenant
+            AND p.effective_to IS NULL
+          ORDER BY p.effective_from DESC
+          LIMIT 1),
+        0
+      ) AS unit_price
+    FROM skus s
+   WHERE s.product_id = p_product_id
+     AND s.tenant_id  = v_tenant
+     AND s.status     = 'active'
+   ORDER BY s.id
+  LOOP
+    INSERT INTO campaign_items (
+      tenant_id, campaign_id, sku_id, unit_price, sort_order,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, v_campaign_id, r.sku_id, r.unit_price, v_sort,
+      auth.uid(), auth.uid()
+    )
+    ON CONFLICT (campaign_id, sku_id) DO NOTHING;
+    v_sort := v_sort + 1;
+  END LOOP;
+
+  RETURN v_campaign_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_campaign_from_product(TEXT, TIMESTAMPTZ, DATE, BIGINT, TEXT)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_campaign_from_product(TEXT, TIMESTAMPTZ, DATE, BIGINT, TEXT) IS
+  '從單一商品建團（1:1 invariant）：自動產生團號、設 product_id、塞入所有 active SKU；'
+  '文案 description = COALESCE(p_description, 商品 description)。';
+
+-- ----------------------------------------------------------------------------
+-- 一次性回填：既有「沒文案」的開團，用其商品的 description 補上（冪等：只補空白者）
+-- ----------------------------------------------------------------------------
+UPDATE group_buy_campaigns c
+   SET description = p.description,
+       updated_at  = NOW()
+  FROM products p
+ WHERE c.product_id = p.id
+   AND c.tenant_id  = p.tenant_id
+   AND (c.description IS NULL OR btrim(c.description) = '')
+   AND p.description IS NOT NULL
+   AND btrim(p.description) <> '';


### PR DESCRIPTION
## 摘要
修正：從**商品詳情頁「建立新開團」**開的團，在會員 App **沒有文案**。

### 根因
該路徑走 `rpc_create_campaign_from_product`，INSERT 沒寫 `description`，導致開團文案為 NULL（會員 App 讀 `description`，NULL 就不顯示）。對照從候選池排程的團會把 `raw_text` 寫進 `description`，故那些有文案。

### 修法（預設帶入商品文案＋可編輯、並回填舊團）
- **migration `20260701040000`**（以 `20260514000010` 為基底，rollback 指回該檔）：
  - `rpc_create_campaign_from_product` 新增 `p_description` 參數；`description = COALESCE(p_description, 商品 products.description)`
  - 一次性**回填**既有「沒文案」的開團（用其商品 `products.description`，冪等、只補空白）
- **`CreateCampaignModal`**：新增「文案」textarea，載入時自動帶入商品文案、可修改，建團時帶 `p_description`

## 注意
- migration 需另行套用（此環境無法連 Supabase Management API）：請在 Dashboard SQL Editor 跑該檔，或走既有部署流程。
- 回填來源是「商品文案」；若商品本身也沒文案，回填後仍為空（需手動補商品文案）。

## 驗證
- `npx tsc --noEmit` 通過、lint 乾淨。

https://claude.ai/code/session_01PS9WWnDU282hEZDyHnEjgj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PS9WWnDU282hEZDyHnEjgj)_