### PR TITLE
fix(member): 文案清掉 HTML 標籤、金額逐位括號合併 $(2)(0)(0)→$200

### DIFF
--- a/apps/member/src/lib/text.ts
+++ b/apps/member/src/lib/text.ts
@@ -1,9 +1,9 @@
 /** 清理開團 / 商品文案，供會員端顯示。
  *  文案來源為後台 TipTap 編輯器（存成 HTML），且常夾帶 LINE 匯入殘留：
  *   1. 去除 HTML 標籤（區塊標籤轉換行）、還原常見 HTML entity。
- *   2. 移除「含金額 $ 的小括號」整段，例如
- *        「$69（原價對比：西X町$159／蝦皮最低$116）」→「$69」。
- *      其餘括號（如「(8小包)」「(係指未開封)」「（日本監製）」）一律保留。
+ *   2. 金額被「逐位數包小括號」的殘留：$ / ＄ 後面一連串 (數字) 去括號合併，例如
+ *        「$(2)(0)(0)」→「$200」、「$(1)(5)(9)」→「$159」。
+ *      其餘括號（「(8小包)」「(係指未開封)」「（日本監製）」、列點「(1)」、正常 $159 等）一律保留。
  *   3. 清掉 legacy LINE 佔位字 (emoji)/(heart)，並收斂多餘空白。
  *  收 null/undefined（名稱欄位多為 nullable），一律回字串。 */
 export function cleanCampaignText(raw: string | null | undefined): string {
@@ -19,8 +19,8 @@ export function cleanCampaignText(raw: string | null | undefined): string {
     .replace(/&gt;/gi, ">")
     .replace(/&quot;/gi, "\"")
     .replace(/(&#0*39;|&apos;)/gi, "'")
-    // --- 2. 移除「含金額 $ 的小括號」整段（半形 () 與全形（）），其餘括號保留 ---
-    .replace(/[（(][^（()）]*[$＄][^（()）]*[)）]/g, "")
+    // --- 2. 金額逐位括號合併：$(2)(0)(0) → $200（只動緊接 $/＄ 的 (數字) 串，其餘括號不碰）---
+    .replace(/([$＄])((?:\s*[（(]\s*[0-9]\s*[)）])+)/g, (_, sign, run) => sign + run.replace(/\D/g, ""))
     // --- 3. legacy LINE 佔位字 ---
     .replace(/\(heart\)/gi, "♥")
     .replace(/\(emoji\)/gi, "")

--- a/apps/member/src/lib/text.ts
+++ b/apps/member/src/lib/text.ts
@@ -1,12 +1,30 @@
-/** 清掉 legacy LINE 匯入殘留的佔位字 (emoji)/(heart)，並收斂多餘空白。
- *  開團名稱與描述都從候選池的 LINE 貼文文字帶出，常夾帶這兩個雜訊 token。
- *  刻意只動這兩個明確雜訊 —— (A)/(B)/($)/（暗色）等是有意義內容，不碰。
+/** 清理開團 / 商品文案，供會員端顯示。
+ *  文案來源為後台 TipTap 編輯器（存成 HTML），且常夾帶 LINE 匯入殘留：
+ *   1. 去除 HTML 標籤（區塊標籤轉換行）、還原常見 HTML entity。
+ *   2. 移除「含金額 $ 的小括號」整段，例如
+ *        「$69（原價對比：西X町$159／蝦皮最低$116）」→「$69」。
+ *      其餘括號（如「(8小包)」「(係指未開封)」「（日本監製）」）一律保留。
+ *   3. 清掉 legacy LINE 佔位字 (emoji)/(heart)，並收斂多餘空白。
  *  收 null/undefined（名稱欄位多為 nullable），一律回字串。 */
 export function cleanCampaignText(raw: string | null | undefined): string {
   if (!raw) return "";
   return raw
+    // --- 1. HTML（TipTap）→ 純文字 ---
+    .replace(/<\/(p|div|h[1-6]|li|tr|blockquote)\s*>/gi, "\n") // 區塊結束 → 換行
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")                                   // 去掉其餘所有標籤
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, "\"")
+    .replace(/(&#0*39;|&apos;)/gi, "'")
+    // --- 2. 移除「含金額 $ 的小括號」整段（半形 () 與全形（）），其餘括號保留 ---
+    .replace(/[（(][^（()）]*[$＄][^（()）]*[)）]/g, "")
+    // --- 3. legacy LINE 佔位字 ---
     .replace(/\(heart\)/gi, "♥")
     .replace(/\(emoji\)/gi, "")
+    // --- 收斂空白 ---
     .replace(/[ \t]{2,}/g, " ")
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")


### PR DESCRIPTION
## 摘要
修正會員端「開團 / 商品文案」顯示兩個問題：
1. **文案外露 HTML 標籤** — 文案來源是後台 TipTap 編輯器（存成 HTML，如 `<p>…</p>`），會員端原本當純文字顯示，導致 `<p>` 等標籤直接露給顧客看到。
2. **金額被逐位數包了小括號** — 例如 `$(2)(0)(0)` 應顯示成 `$200`。

## 修法（`apps/member/src/lib/text.ts` 的 `cleanCampaignText`）
- 去除 HTML 標籤：區塊標籤（`<p>`/`<br>`/`<li>`/`<h1-6>`…）轉換行、其餘標籤移除，並還原常見 HTML entity。
- **金額逐位括號合併**：只把緊接 `$`/`＄` 的一串 `(數字)` 去括號合併：
  - `$(2)(0)(0)` → `$200`
  - `$(1)(5)(9)` → `$159`
- **其餘括號全部保留**：`(8小包)`、`(係指未開封)`、`（日本監製）`、列點 `(1)`、正常 `$159` / `$299` 都不動。
- 沿用原本的 `(emoji)`/`(heart)` 佔位字清理與空白收斂。

## 驗證（實測）
| 輸入 | 輸出 |
|---|---|
| `$(2)(0)(0)` | `$200` |
| `$(1)(5)(9) 元` | `$159 元` |
| `<p>價格：$(6)(9)（原價對比：西X町$159）</p>` | `價格：$69（原價對比：西X町$159）` |
| `120g(8小包)` / `1年(係指未開封)` / `（日本監製）` / 列點 `(1)` | 原樣保留 |

- `npx tsc --noEmit`（member）通過、lint 乾淨。純前端顯示邏輯，無 DB 變更。

https://claude.ai/code/session_01PS9WWnDU282hEZDyHnEjgj