### PR TITLE
fix(admin): DataTable Td 支援 onClick，修 campaigns build 失敗

### DIFF
--- a/apps/admin/src/components/DataTable.tsx
+++ b/apps/admin/src/components/DataTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import type { MouseEventHandler, ReactNode } from "react";
 
 type Align = "left" | "center" | "right";
 
@@ -84,14 +84,23 @@ export function Td({
   className = "",
   colSpan,
   align,
+  onClick,
+  title,
 }: {
   children?: ReactNode;
   className?: string;
   colSpan?: number;
   align?: Align;
+  onClick?: MouseEventHandler<HTMLTableCellElement>;
+  title?: string;
 }) {
   return (
-    <td colSpan={colSpan} className={`px-4 py-3 ${alignCls(align)} ${className}`}>
+    <td
+      colSpan={colSpan}
+      title={title}
+      onClick={onClick}
+      className={`px-4 py-3 ${alignCls(align)} ${className}`}
+    >
       {children}
     </td>
   );


### PR DESCRIPTION
## 問題
`next build` 在 `apps/admin/src/app/(protected)/campaigns/page.tsx:926` 型別錯誤而失敗：
```
Property 'onClick' does not exist on type '... { children?, className?, colSpan?, align? }'.
```
該頁對 `<Td>` 傳了 `onClick={(e) => e.stopPropagation()}`（避免點到那格時觸發整列的 row click），但 `@/components/DataTable` 的 `Td` 型別沒有 `onClick`。

## 修法
為 `DataTable` 的 `Td` 加上 `onClick?: MouseEventHandler<HTMLTableCellElement>` 與 `title?`，並轉發到底層 `<td>`。其餘行為不變。

## 驗證
- `npx tsc --noEmit -p tsconfig.json`（admin）通過（exit 0）。

https://claude.ai/code/session_01PS9WWnDU282hEZDyHnEjgj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PS9WWnDU282hEZDyHnEjgj)_