### PR TITLE
feat(orders): 訂單列表/明細顯示下單來源（App 下單 vs 小幫手）

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -12,6 +12,8 @@ import { withBasePath } from "@/lib/basePath";
 import { printViaIframe } from "@/lib/printIframe";
 import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 import { ORDER_STATUS_LABEL as STATUS_LABEL, type OrderStatus } from "@/lib/orderStatus";
+import { summarizeOrderSource } from "@/lib/orderSource";
+import { OrderSourceBadge } from "@/components/OrderSourceBadge";
 import SpinButton from "@/components/SpinButton";
 
 type Row = {
@@ -148,6 +150,7 @@ function OrdersListContent() {
         totalQty: number;
         totalAmount: number;
         items: { product_name: string | null; variant_name: string | null; qty: number }[];
+        sources: string[];
       }
     >
   >(new Map());
@@ -262,16 +265,16 @@ function OrdersListContent() {
         const memIds = Array.from(new Set((data ?? []).map((r) => r.member_id).filter((x): x is number => x != null)));
         const [ic, ms] = await Promise.all([
           ids.length
-            ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price, sku:skus(product_name, variant_name)").in("order_id", ids)
-            : Promise.resolve({ data: [] as { order_id: number; qty: number; unit_price: number; sku: { product_name: string | null; variant_name: string | null } | null }[] }),
+            ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price, source, sku:skus(product_name, variant_name)").in("order_id", ids)
+            : Promise.resolve({ data: [] as { order_id: number; qty: number; unit_price: number; source: string; sku: { product_name: string | null; variant_name: string | null } | null }[] }),
           memIds.length
             ? getSupabase().from("members").select("id, name, phone, member_no, avatar_url").in("id", memIds)
             : Promise.resolve({ data: [] as Member[] }),
         ]);
-        const im = new Map<number, { lineCount: number; totalQty: number; totalAmount: number; items: { product_name: string | null; variant_name: string | null; qty: number }[] }>();
-        for (const id of ids) im.set(id, { lineCount: 0, totalQty: 0, totalAmount: 0, items: [] });
-        for (const it of (ic.data as { order_id: number; qty: number; unit_price: number; sku: { product_name: string | null; variant_name: string | null } | null }[]) ?? []) {
-          const cur = im.get(it.order_id) ?? { lineCount: 0, totalQty: 0, totalAmount: 0, items: [] };
+        const im = new Map<number, { lineCount: number; totalQty: number; totalAmount: number; items: { product_name: string | null; variant_name: string | null; qty: number }[]; sources: string[] }>();
+        for (const id of ids) im.set(id, { lineCount: 0, totalQty: 0, totalAmount: 0, items: [], sources: [] });
+        for (const it of (ic.data as { order_id: number; qty: number; unit_price: number; source: string; sku: { product_name: string | null; variant_name: string | null } | null }[]) ?? []) {
+          const cur = im.get(it.order_id) ?? { lineCount: 0, totalQty: 0, totalAmount: 0, items: [], sources: [] };
           cur.lineCount += 1;
           cur.totalQty += Number(it.qty);
           cur.totalAmount += Number(it.qty) * Number(it.unit_price);
@@ -280,6 +283,7 @@ function OrdersListContent() {
             variant_name: it.sku?.variant_name ?? null,
             qty: Number(it.qty),
           });
+          if (it.source) cur.sources.push(it.source);
           im.set(it.order_id, cur);
         }
         const mm = new Map<number, Member>();
@@ -856,6 +860,9 @@ function OrdersListContent() {
 
               <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500">
                 <span>🏬 {s?.name ?? "—"}</span>
+                {sum && sum.sources.length > 0 && (
+                  <OrderSourceBadge summary={summarizeOrderSource(sum.sources)} />
+                )}
                 <span>{sum?.lineCount ?? 0} 項</span>
                 <span>共 {sum?.totalQty ?? 0} 件</span>
                 <span className="font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-100">${sum?.totalAmount ?? 0}</span>
@@ -879,14 +886,14 @@ function OrdersListContent() {
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr>
-              <Th className="min-w-[14rem]">開團</Th><Th className="whitespace-nowrap">會員 / 暱稱</Th><Th className="whitespace-nowrap">取貨店</Th><Th className="whitespace-nowrap text-right">項數</Th><Th className="whitespace-nowrap text-right">總數量</Th><Th className="whitespace-nowrap text-right">總金額</Th><Th className="whitespace-nowrap text-right">日期</Th><Th className="whitespace-nowrap text-right">操作</Th>
+              <Th className="min-w-[14rem]">開團</Th><Th className="whitespace-nowrap">會員 / 暱稱</Th><Th className="whitespace-nowrap">來源</Th><Th className="whitespace-nowrap">取貨店</Th><Th className="whitespace-nowrap text-right">項數</Th><Th className="whitespace-nowrap text-right">總數量</Th><Th className="whitespace-nowrap text-right">總金額</Th><Th className="whitespace-nowrap text-right">日期</Th><Th className="whitespace-nowrap text-right">操作</Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={8} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={9} className="p-3 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={8} className="p-6 text-center text-zinc-500">{total === 0 && campaignIds.length === 0 && !storeId && !keyword ? `此 tab 下尚無訂單。` : "沒有符合條件的訂單。"}</td></tr>
+              <tr><td colSpan={9} className="p-6 text-center text-zinc-500">{total === 0 && campaignIds.length === 0 && !storeId && !keyword ? `此 tab 下尚無訂單。` : "沒有符合條件的訂單。"}</td></tr>
             ) : rows.map((r) => {
               const m = r.member_id ? members.get(r.member_id) : null;
               const c = campaignMap.get(r.campaign_id);
@@ -946,6 +953,16 @@ function OrdersListContent() {
                         <span className="text-zinc-500">({r.nickname_snapshot})</span>
                       </span>
                     ) : "—"}
+                  </Td>
+                  <Td className="whitespace-nowrap">
+                    {(() => {
+                      const sum = itemSummary.get(r.id);
+                      return sum && sum.sources.length > 0 ? (
+                        <OrderSourceBadge summary={summarizeOrderSource(sum.sources)} />
+                      ) : (
+                        <span className="text-zinc-400">—</span>
+                      );
+                    })()}
                   </Td>
                   <Td className="whitespace-nowrap text-xs">{s?.name ?? "—"}</Td>
                   <Td className="whitespace-nowrap text-right font-mono">{itemSummary.get(r.id)?.lineCount ?? 0}</Td>

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -13,6 +13,8 @@ import { EditableDiscount, deriveDiscount, type DiscountValue } from "@/componen
 import { useAuth } from "@/components/AuthProvider";
 import { useRole } from "@/lib/role";
 import { orderStatusLabel as statusLabel, canPayWithWallet } from "@/lib/orderStatus";
+import { summarizeOrderSource } from "@/lib/orderSource";
+import { ItemSourceBadge, OrderSourceBadge } from "@/components/OrderSourceBadge";
 import { withBasePath } from "@/lib/basePath";
 import { printViaIframe } from "@/lib/printIframe";
 import { translateRpcError } from "@/lib/rpcError";
@@ -458,6 +460,10 @@ export function OrderDetail({
   const memberLabel = head.member
     ? `${head.member.name ?? "—"} (${head.member.member_no})`
     : `(${head.nickname_snapshot ?? "—"})`;
+  // 下單來源：由品項 source 推導（liff=App / manual=小幫手 …）
+  const orderSource = summarizeOrderSource(items.map((it) => it.source));
+  // 混合來源才逐品項標；單一來源整單已由「下單來源」欄表示，逐列重複反而吵
+  const showItemSource = orderSource.kind === "mixed";
 
   return (
     <div className="space-y-4 text-sm">
@@ -617,6 +623,16 @@ export function OrderDetail({
         />
         <Field label="開團" value={head.campaign ? `${head.campaign.campaign_no} ${head.campaign.name}` : "—"} />
         <Field label="取貨店" value={head.store?.name ?? "—"} />
+        <Field
+          label="下單來源"
+          value={
+            orderSource.kind === "none" ? (
+              <span className="text-zinc-400">—</span>
+            ) : (
+              <OrderSourceBadge summary={orderSource} />
+            )
+          }
+        />
         <Field label="建立" value={fmtDt(head.created_at)} />
         <Field label="最後更新" value={fmtDt(head.updated_at)} />
         <Field
@@ -727,6 +743,7 @@ export function OrderDetail({
                           {badge.label}
                         </span>
                       )}
+                      {showItemSource && <ItemSourceBadge source={it.source} className="ml-1.5" />}
                     </td>
                     <td className="px-3 py-2 text-right font-mono">
                       {isPicked ? (

--- a/apps/admin/src/components/OrderSourceBadge.tsx
+++ b/apps/admin/src/components/OrderSourceBadge.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { itemSourceMeta, type OrderSourceSummary } from "@/lib/orderSource";
+
+const BADGE_CLS =
+  "inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium whitespace-nowrap";
+
+/** 整單來源 badge（訂單列表用）— 吃 summarizeOrderSource() 的結果。 */
+export function OrderSourceBadge({
+  summary,
+  className = "",
+}: {
+  summary: OrderSourceSummary;
+  className?: string;
+}) {
+  if (summary.kind === "none") return <span className="text-zinc-400">—</span>;
+  return (
+    <span title={summary.label} className={`${BADGE_CLS} ${summary.cls} ${className}`}>
+      {summary.icon && <span aria-hidden>{summary.icon}</span>}
+      {summary.short}
+    </span>
+  );
+}
+
+/** 單一品項來源 badge（訂單明細的品項列用）。 */
+export function ItemSourceBadge({
+  source,
+  className = "",
+}: {
+  source: string | null | undefined;
+  className?: string;
+}) {
+  const meta = itemSourceMeta(source);
+  return (
+    <span title={meta.label} className={`${BADGE_CLS} ${meta.cls} ${className}`}>
+      {meta.icon && <span aria-hidden>{meta.icon}</span>}
+      {meta.short}
+    </span>
+  );
+}

--- a/apps/admin/src/lib/orderSource.ts
+++ b/apps/admin/src/lib/orderSource.ts
@@ -1,0 +1,99 @@
+// ============================================================
+// 顧客訂單品項來源 (customer_order_items.source) 中央定義
+//
+// Single source of truth — 「這張單是 App 下單還是小幫手代客」的判斷與 label
+// 都從這裡 import。
+//
+// source 是「品項層級」欄位（customer_order_items.source）：
+//   - 'liff'   → 顧客自己用 App（LIFF）下單     ＝ App 下單
+//   - 'manual' → 小幫手在後台代客 key 單         ＝ 小幫手
+//   其餘為系統/特殊流程產生（非人工通路）。
+//
+// 同一張訂單因為 UNIQUE(tenant, campaign, channel, member) 會合併，
+// 顧客 App 自助 + 小幫手在 closed 緩衝期補加可能落在同一張單，
+// 故需 summarizeOrderSource() 推導「整單來源」並處理「混合」。
+//
+// 新增 source 時：
+//   1. 加到 ORDER_ITEM_SOURCES tuple + ORDER_SOURCE_META
+//   2. 同步 supabase migration 的 CHECK constraint
+//      （現行：20260507000000_order_transfer_and_internal.sql）
+// ============================================================
+
+export const ORDER_ITEM_SOURCES = [
+  "liff",
+  "manual",
+  "screenshot_parse",
+  "csv",
+  "rollover",
+  "store_internal",
+  "aid_transfer",
+] as const;
+
+export type OrderItemSource = (typeof ORDER_ITEM_SOURCES)[number];
+
+export type SourceMeta = {
+  /** 完整中文 label（明細頁 / tooltip） */
+  label: string;
+  /** 精簡 label（列表 badge） */
+  short: string;
+  icon: string;
+  /** Tailwind badge 配色 */
+  cls: string;
+};
+
+export const ORDER_SOURCE_META: Record<OrderItemSource, SourceMeta> = {
+  liff:             { label: "App 下單", short: "App",    icon: "📱", cls: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300" },
+  manual:           { label: "小幫手",   short: "小幫手", icon: "🧑‍💼", cls: "bg-violet-100 text-violet-800 dark:bg-violet-950 dark:text-violet-300" },
+  screenshot_parse: { label: "截圖解析", short: "截圖",   icon: "🖼️", cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300" },
+  csv:              { label: "CSV 匯入", short: "CSV",    icon: "📄", cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300" },
+  rollover:         { label: "缺貨遞轉", short: "遞轉",   icon: "↪️", cls: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300" },
+  store_internal:   { label: "店長叫貨", short: "店叫",   icon: "🏬", cls: "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300" },
+  aid_transfer:     { label: "互助轉手", short: "互助",   icon: "🤝", cls: "bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-300" },
+};
+
+const MIXED_META: SourceMeta = {
+  label: "混合來源",
+  short: "混合",
+  icon: "🔀",
+  cls: "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300",
+};
+
+const UNKNOWN_META: SourceMeta = {
+  label: "—",
+  short: "—",
+  icon: "",
+  cls: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400",
+};
+
+/** 單一品項 source → 標籤 meta；未知值 fallback 成原字串。 */
+export function itemSourceMeta(source: string | null | undefined): SourceMeta {
+  if (!source) return UNKNOWN_META;
+  return ORDER_SOURCE_META[source as OrderItemSource] ?? { ...UNKNOWN_META, label: source, short: source };
+}
+
+export type OrderSourceSummary = SourceMeta & {
+  kind: "single" | "mixed" | "none";
+  /** 各別來源 meta（依首次出現順序）；混合時給細分顯示用。 */
+  parts: SourceMeta[];
+};
+
+/**
+ * 由一張訂單所有品項的 source 推導「整單來源」。
+ *   - 全部同一來源 → 該來源標籤（kind: "single"）
+ *   - 多種來源     → 「混合」，label 列出各別來源（e.g.「App + 小幫手」）
+ *   - 無品項       → kind: "none"
+ */
+export function summarizeOrderSource(sources: (string | null | undefined)[]): OrderSourceSummary {
+  const distinct: string[] = [];
+  for (const s of sources) {
+    if (!s) continue;
+    if (!distinct.includes(s)) distinct.push(s);
+  }
+  if (distinct.length === 0) return { ...UNKNOWN_META, kind: "none", parts: [] };
+  if (distinct.length === 1) {
+    const meta = itemSourceMeta(distinct[0]);
+    return { ...meta, kind: "single", parts: [meta] };
+  }
+  const parts = distinct.map(itemSourceMeta);
+  return { ...MIXED_META, label: parts.map((p) => p.short).join(" + "), kind: "mixed", parts };
+}


### PR DESCRIPTION
由 customer_order_items.source 推導每張訂單的下單來源並以 badge 呈現， 讓小幫手一眼分辨「顧客自己用 App 下單」(source=liff) 還是
「小幫手後台代客 key 單」(source=manual)。

- 新增 lib/orderSource.ts：source → label 中央定義 + summarizeOrderSource() 推導整單來源；因同團同會員會合併成一張單，App 自助與小幫手補加可能 混在同一張，故支援「混合」並列出各別來源。
- 新增 components/OrderSourceBadge.tsx：整單 / 單品項共用 badge。
- 訂單列表：桌機新增「來源」欄、手機卡片於 meta 列顯示來源 badge。
- 訂單明細：頁首新增「下單來源」欄；混合來源時逐品項標來源。

純前端衍生顯示，不改 DB schema，歷史訂單即時可見。

https://claude.ai/code/session_01BDYAkNt95GjBVCUHEAfqGs