### PR TITLE
ui(campaign): 開團列表「加單」按鈕加粗加大

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -598,7 +598,7 @@ export default function CampaignsListPage() {
     r.status === "open" ? (
       <Link
         href={`/campaigns/order-entry?id=${r.id}`}
-        className="text-xs text-green-600 hover:underline dark:text-green-400"
+        className="text-sm font-bold text-green-600 hover:underline dark:text-green-400"
       >
         加單
       </Link>


### PR DESCRIPTION
## Summary
- 桌機開團列表的「加單」連結 className 由 `text-xs` 改為 `text-sm font-bold`
- 與週邊 `text-xs` 操作鈕（編輯 / 結單 / 刪除）形成明顯視覺層級

## Why
密集列表中原本 `text-xs` 的加單與其他操作鈕大小一致，使用者較難一眼定位主要操作。配合 [#400](https://github.com/lt-foods/new_erp/pull/400) 已把加單移到編輯前，這次再放大加粗讓它真的「跳出來」。

## Files
- [apps/admin/src/app/(protected)/campaigns/page.tsx:601](apps/admin/src/app/(protected)/campaigns/page.tsx#L601)

## Test plan
- [ ] /campaigns 桌機列表：每筆 status=open 的開團，左側「加單」明顯比編輯/結單/刪除大且粗
- [ ] status≠open 的列不出現加單（既有行為不變）
- [ ] 點擊加單仍正常導去 /campaigns/order-entry?id=...
- [ ] dark mode 文字色不變（`dark:text-green-400`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)