### PR TITLE
Enforce campaign boundaries in wave picking to prevent cross-campaign contamination

### DIFF
--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -388,6 +388,15 @@ export default function PickingWorkstationPage() {
       }
       if (overSkus.length > 0) throw new Error("超過可分配量：\n" + overSkus.join("\n"));
 
+      // 該 (po, sku, store) 是否「確實有需求」— 來自 v_picking_demand_by_po 的列。
+      // view 只在某店對某 PO 對應的開團 / 補貨有需求時，才會產生該 (po,sku,store) 列，
+      // 所以「有列 = 有需求」。FIFO 只倒給有需求的 PO，避免把別團需求撿到別團的 PO
+      // （對齊後端 rpc_create_wave_from_po 的跨團守衛）。
+      const demandPoSkuStore = new Set<string>();
+      for (const r of demand) {
+        if (r.store_id !== null) demandPoSkuStore.add(`${r.po_id}:${r.sku_id}:${r.store_id}`);
+      }
+
       // 建可消耗的 PO 容量表 perPoSkuLeft.get(`${po}:${sku}`) = 該 PO 該 SKU 還可分配
       const perPoSkuLeft = new Map<string, number>();
       for (const sk of skuRows) {
@@ -407,6 +416,8 @@ export default function PickingWorkstationPage() {
           let remaining = qty;
           for (const po of sk.poList) {
             if (remaining <= 0) break;
+            // 只撿給「該店在此 PO 確實有需求」的 PO（尊重開團邊界，別把別團需求倒給最舊的 PO）
+            if (!demandPoSkuStore.has(`${po.po_id}:${sk.sku_id}:${st.store_id}`)) continue;
             const k = `${po.po_id}:${sk.sku_id}`;
             const av = perPoSkuLeft.get(k) ?? 0;
             if (av <= 0) continue;
@@ -484,23 +495,38 @@ export default function PickingWorkstationPage() {
   }, [allocs]);
 
   const involvedPos = useMemo(() => {
+    if (!demand) return 0;
+    // 與 submitAll 同邏輯：逐 (sku, store) FIFO，且只算「該店在此 PO 確實有需求」的 PO
+    const demandPoSkuStore = new Set<string>();
+    for (const r of demand) {
+      if (r.store_id !== null) demandPoSkuStore.add(`${r.po_id}:${r.sku_id}:${r.store_id}`);
+    }
+    const perPoSkuLeft = new Map<string, number>();
+    for (const sk of skuRows) {
+      for (const po of sk.poList) {
+        perPoSkuLeft.set(`${po.po_id}:${sk.sku_id}`, Math.max(0, po.gr_qty - po.already_wave_for_sku));
+      }
+    }
     const set = new Set<number>();
     for (const sk of skuRows) {
-      const skuAlloc = getSkuAllocTotal(sk);
-      if (skuAlloc <= 0) continue;
-      // 模擬 FIFO 估算會涉及哪幾張 PO
-      let remaining = skuAlloc;
-      for (const po of sk.poList) {
-        if (remaining <= 0) break;
-        const av = Math.max(0, po.gr_qty - po.already_wave_for_sku);
-        if (av <= 0) continue;
-        const take = Math.min(remaining, av);
-        if (take > 0) set.add(po.po_id);
-        remaining -= take;
+      for (const st of allStores) {
+        let remaining = getAlloc(sk.sku_id, st.store_id);
+        if (remaining <= 0) continue;
+        for (const po of sk.poList) {
+          if (remaining <= 0) break;
+          if (!demandPoSkuStore.has(`${po.po_id}:${sk.sku_id}:${st.store_id}`)) continue;
+          const k = `${po.po_id}:${sk.sku_id}`;
+          const av = perPoSkuLeft.get(k) ?? 0;
+          if (av <= 0) continue;
+          const take = Math.min(remaining, av);
+          if (take > 0) set.add(po.po_id);
+          perPoSkuLeft.set(k, av - take);
+          remaining -= take;
+        }
       }
     }
     return set.size;
-  }, [skuRows, allocs]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [skuRows, allStores, demand, allocs]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ===== 補貨申請(無 PO 來源)分組 =====
   type RestockGroup = {

--- a/supabase/migrations/20260702000000_wave_from_po_campaign_scoped.sql
+++ b/supabase/migrations/20260702000000_wave_from_po_campaign_scoped.sql
@@ -1,0 +1,237 @@
+-- ============================================================
+-- rpc_create_wave_from_po：撿貨單尊重「開團邊界」，不准把別團需求撿到別團的 PO
+--
+-- 背景／真實案例 (GRP-20260531-002-0005 / 訂單 #17768)：
+--   同一家賣場「包子媽生鮮小舖」連兩週各開一團、品項相同：
+--     956 GRP-20260523-002 (05/23) → PR#4 → PO#1
+--     2205 GRP-20260531-002 (05/31) → PR#9 → PO#5
+--   PR/PO 其實已按開團分開。但撿貨工作站 (wms/picking) 把需求「按 sku 跨 PO
+--   合併」、提交時用 FIFO 依 po_id 由小到大吃 PO 容量。於是 2205/忠順店(51) 的
+--   1029/1030 需求被倒進「最舊的」PO#1（956）→ 產生 wave 9/10 → WAVE-9-S51。
+--   接著本函式舊版第 6 步只取「該 PO 最小 campaign_id」當代表蓋到所有 wave item
+--   → wave item 掛 956 → 2205 訂單被孤立：歷程查不到那張 transfer、status 也沒人
+--   推 → 卡 pending、不能取貨。
+--
+-- 根因：撿貨是 campaign-blind，但團購訂單的「收貨→可取貨／歷程」是 campaign-scoped。
+--   兩個同時進行、共用 SKU 的開團一出現就互相污染。
+--
+-- 修法（伺服器端強制分開，UI 繞不過去）：
+--   1) 移除第 6 步「單一代表 campaign」。
+--   2) 第 7 步逐 (sku, store) 解析 campaign_id：
+--      在「此 PO 對應的開團」裡，找對該 (store, sku) 確實有訂單需求的那一團來蓋。
+--   3) 若該 (store, sku) 在此 PO 的開團「都沒有需求」：
+--      - 有補貨 (restock) 需求 → 允許，campaign_id 掛 NULL（沿用既有 restock 行為）。
+--      - 兩者皆無 → 直接 RAISE，擋掉跨團誤撿（貨屬別團，請改用該店所屬開團的 PO）。
+--
+-- 前端 (wms/picking) 同批改成 FIFO 只倒給「該 (po,sku,store) 確實有需求」的 PO，
+--   讓 UI 不會再產生本函式會擋掉的分配。
+--
+-- 基於：20260609000001_picking_wave_code_seq.sql（最新／線上版本，wave_code 用 seq）。
+-- Rollback：CREATE OR REPLACE 回 20260609000001 版本（恢復第 6 步單一代表 campaign、
+--           移除逐行 campaign 解析與守衛）。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_create_wave_from_po(
+  p_po_id        BIGINT,
+  p_wave_date    DATE,
+  p_allocations  JSONB,
+  p_operator     UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_po                purchase_orders%ROWTYPE;
+  v_tenant            UUID;
+  v_wave_id           BIGINT;
+  v_wave_code         TEXT;
+  v_alloc             JSONB;
+  v_sku_id            BIGINT;
+  v_store_id          BIGINT;
+  v_qty               NUMERIC(18,3);
+  v_line_campaign_id  BIGINT;
+  v_total_qty         NUMERIC(18,3) := 0;
+  v_item_count        INTEGER := 0;
+  v_store_count       INTEGER := 0;
+  v_over              RECORD;
+BEGIN
+  -- 1. PO 守衛
+  SELECT * INTO v_po FROM purchase_orders WHERE id = p_po_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '找不到採購單 #%', p_po_id;
+  END IF;
+  IF v_po.status NOT IN ('sent','partially_received','fully_received') THEN
+    RAISE EXCEPTION '採購單 % 狀態為「%」、不可建撿貨單（需為「已發送」/「部分進貨」/「全部進貨」）', v_po.po_no, v_po.status;
+  END IF;
+  v_tenant := v_po.tenant_id;
+
+  -- 2. allocations 守衛
+  IF p_allocations IS NULL OR jsonb_array_length(p_allocations) = 0 THEN
+    RAISE EXCEPTION '請先填寫各分店分配量、不可全為空';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('wave:po:' || p_po_id::text));
+
+  -- 3. 守衛：每個分配 qty > 0
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations) LOOP
+    v_qty := (v_alloc->>'qty')::NUMERIC;
+    IF v_qty IS NULL OR v_qty <= 0 THEN
+      RAISE EXCEPTION '分配數量必須 > 0';
+    END IF;
+  END LOOP;
+
+  -- 4. 守衛：每 sku 的總分配量 ≤ (GR 量 − 已 wave 量)
+  WITH alloc_agg AS (
+    SELECT
+      (a->>'sku_id')::BIGINT  AS sku_id,
+      SUM((a->>'qty')::NUMERIC) AS total_alloc
+    FROM jsonb_array_elements(p_allocations) a
+    GROUP BY (a->>'sku_id')::BIGINT
+  ),
+  po_sku_state AS (
+    SELECT
+      poi.sku_id,
+      COALESCE(SUM(gri.qty_received) FILTER (WHERE gr.status = 'confirmed'), 0) AS gr_qty,
+      COALESCE((
+        SELECT SUM(pwi.qty)
+          FROM picking_wave_items pwi
+          JOIN picking_waves pw ON pw.id = pwi.wave_id
+         WHERE pw.source_po_id = p_po_id
+           AND pwi.sku_id = poi.sku_id
+           AND pw.status <> 'cancelled'
+      ), 0) AS already_wave
+    FROM purchase_order_items poi
+    LEFT JOIN goods_receipt_items gri ON gri.po_item_id = poi.id
+    LEFT JOIN goods_receipts gr ON gr.id = gri.gr_id
+    WHERE poi.po_id = p_po_id
+    GROUP BY poi.sku_id
+  )
+  SELECT
+    s.sku_code,
+    COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+    aa.total_alloc, ps.gr_qty, ps.already_wave,
+    (ps.gr_qty - ps.already_wave) AS available
+  INTO v_over
+  FROM alloc_agg aa
+  JOIN po_sku_state ps ON ps.sku_id = aa.sku_id
+  JOIN skus s ON s.id = aa.sku_id
+  WHERE aa.total_alloc > (ps.gr_qty - ps.already_wave)
+  LIMIT 1;
+
+  IF v_over.sku_code IS NOT NULL THEN
+    RAISE EXCEPTION 'SKU「% %」分配 % 超過可分配量 %（進貨 %、已撿 %）',
+      v_over.sku_code, v_over.sku_label,
+      v_over.total_alloc, v_over.available, v_over.gr_qty, v_over.already_wave;
+  END IF;
+
+  -- 5. wave header — 用 sequence 產 code,避免同秒撞單
+  v_wave_code := 'WV'
+              || to_char(NOW() AT TIME ZONE 'Asia/Taipei', 'YYMMDD')
+              || LPAD(nextval('public.picking_wave_code_seq')::TEXT, 6, '0');
+
+  INSERT INTO picking_waves (
+    tenant_id, wave_code, wave_date, status, source_po_id,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_wave_code, p_wave_date, 'draft', p_po_id,
+    p_operator, p_operator
+  ) RETURNING id INTO v_wave_id;
+
+  -- 6 + 7. 逐 (sku, store) 解析「實際有需求的那一團」當 campaign_id，並擋跨團誤撿
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations) LOOP
+    v_sku_id   := (v_alloc->>'sku_id')::BIGINT;
+    v_store_id := (v_alloc->>'store_id')::BIGINT;
+    v_qty      := (v_alloc->>'qty')::NUMERIC;
+
+    -- 在「此 PO 對應的開團」裡，挑對該 (store, sku) 確實有訂單需求的一團。
+    -- 涵蓋兩條 PO→campaign 路徑（purchase_request_campaigns 與 source_campaign_id），
+    -- 與 v_picking_demand_by_po 的 po_campaigns 對齊。
+    SELECT cand.campaign_id
+      INTO v_line_campaign_id
+      FROM (
+        SELECT prc.campaign_id
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+          JOIN purchase_request_campaigns prc ON prc.pr_id = pri.pr_id
+         WHERE poi.po_id = p_po_id
+        UNION
+        SELECT pri.source_campaign_id AS campaign_id
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+         WHERE poi.po_id = p_po_id
+           AND pri.source_campaign_id IS NOT NULL
+      ) cand
+     WHERE EXISTS (
+       SELECT 1
+         FROM customer_orders co
+         JOIN customer_order_items coi ON coi.order_id = co.id
+        WHERE co.campaign_id = cand.campaign_id
+          AND co.pickup_store_id = v_store_id
+          AND co.status NOT IN ('cancelled','expired','transferred_out')
+          AND co.transferred_from_order_id IS NULL
+          AND coi.sku_id = v_sku_id
+          AND coi.status NOT IN ('cancelled','expired')
+     )
+     ORDER BY cand.campaign_id
+     LIMIT 1;
+
+    IF v_line_campaign_id IS NULL THEN
+      -- 此 (store, sku) 在這張 PO 的開團都沒有需求。
+      -- 只有「補貨 (restock) 來源」才允許（campaign_id 掛 NULL，沿用既有行為）。
+      IF NOT EXISTS (
+        SELECT 1
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+          JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                                  AND rr.requesting_store_id = v_store_id
+                                  AND rr.status NOT IN ('cancelled','rejected')
+          JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                        AND rrl.sku_id = v_sku_id
+         WHERE poi.po_id = p_po_id
+           AND poi.sku_id = v_sku_id
+      ) THEN
+        RAISE EXCEPTION
+          '分店「%」在採購單「%」對應的開團沒有 SKU「%」的訂單需求，不能撿到這批貨（這批屬於別團，請改用該店所屬開團的採購單撿貨）',
+          COALESCE((SELECT name FROM stores WHERE id = v_store_id), '#' || v_store_id),
+          v_po.po_no,
+          COALESCE((SELECT sku_code FROM skus WHERE id = v_sku_id), '#' || v_sku_id);
+      END IF;
+    END IF;
+
+    INSERT INTO picking_wave_items (
+      tenant_id, wave_id, sku_id, store_id, qty, campaign_id,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, v_wave_id, v_sku_id, v_store_id, v_qty, v_line_campaign_id,
+      p_operator, p_operator
+    )
+    ON CONFLICT (wave_id, sku_id, store_id) DO UPDATE
+      SET qty = picking_wave_items.qty + EXCLUDED.qty,
+          updated_by = p_operator,
+          updated_at = NOW();
+  END LOOP;
+
+  -- 8. 統計 wave header
+  SELECT COUNT(*), COUNT(DISTINCT store_id), COALESCE(SUM(qty), 0)
+    INTO v_item_count, v_store_count, v_total_qty
+    FROM picking_wave_items WHERE wave_id = v_wave_id;
+
+  UPDATE picking_waves
+     SET item_count = v_item_count,
+         store_count = v_store_count,
+         total_qty = v_total_qty,
+         updated_at = NOW()
+   WHERE id = v_wave_id;
+
+  RETURN jsonb_build_object(
+    'wave_id', v_wave_id,
+    'wave_code', v_wave_code,
+    'item_count', v_item_count,
+    'store_count', v_store_count,
+    'total_qty', v_total_qty
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_create_wave_from_po IS
+  '按 PO 建撿貨單；wave item 的 campaign_id 逐 (sku,store) 取「此 PO 對應開團裡確實有該店該 SKU 需求」的那一團；'
+  '若無開團需求且非補貨來源則 RAISE（擋跨團誤撿）。wave_code 用 sequence 避免同秒撞單。';

--- a/supabase/migrations/20260702000010_v_picking_wave_campaign_mismatch.sql
+++ b/supabase/migrations/20260702000010_v_picking_wave_campaign_mismatch.sql
@@ -1,0 +1,99 @@
+-- ============================================================
+-- v_picking_wave_campaign_mismatch：撿貨單「跨開團誤撿 / 無需求超撿」偵測視圖（唯讀防呆）
+--
+-- 背景：
+--   同一賣場每週重開一團（product_id 相同、SKU 相同）是正常營運模式，不能硬擋。
+--   真正的風險是「某店某 SKU 被撿到一張『其開團對該店該 SKU 根本沒有訂單需求』的
+--   PO 上」——也就是把 A 團的貨撿去服務 B 團的訂單（GRP-20260531-002-0005 即此類）。
+--   rpc_create_wave_from_po 已在「建撿貨單」時擋掉這種跨團誤撿；本視圖負責把
+--   「已經發生」的存量撈出來給人複核 / 清理。
+--
+-- 判定（與 rpc_create_wave_from_po 守衛同一條不變式）：
+--   一筆 picking_wave_item（wave 非 cancelled、有 source_po_id），若
+--     (a) 其來源 PO 對應的「任何開團」都沒有該 (store, sku) 的活訂單需求，且
+--     (b) 也沒有對應的補貨 (restock) 需求
+--   → 列為 mismatch。
+--
+-- demand_actually_in：該 (store, sku) 實際有活訂單、但不在此 PO 開團清單內的開團編號。
+--   - 有值 → 跨團誤撿，這批貨其實屬於該開團的訂單（victim）。
+--   - NULL → 該店該 SKU 任何開團都沒需求 → 純超撿 / 訂單已取消，需人工確認。
+--
+-- 用途：純診斷，不阻擋任何流程。Rollback：DROP VIEW。
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.v_picking_wave_campaign_mismatch AS
+SELECT
+  p.tenant_id,
+  p.wave_id,
+  pw.wave_code,
+  pw.status        AS wave_status,
+  pw.source_po_id  AS po_id,
+  po.po_no,
+  p.store_id,
+  st.name          AS store_name,
+  p.sku_id,
+  s.sku_code,
+  COALESCE(s.product_name,'') || COALESCE(' ' || NULLIF(s.variant_name,''),'') AS sku_label,
+  p.qty,
+  p.campaign_id    AS tagged_campaign_id,
+  ( SELECT string_agg(DISTINCT c2.campaign_no, ', ' ORDER BY c2.campaign_no)
+      FROM customer_orders co2
+      JOIN customer_order_items coi2 ON coi2.order_id = co2.id
+      JOIN group_buy_campaigns c2 ON c2.id = co2.campaign_id
+     WHERE co2.pickup_store_id = p.store_id
+       AND coi2.sku_id = p.sku_id
+       AND co2.status NOT IN ('cancelled','expired','transferred_out')
+       AND co2.transferred_from_order_id IS NULL
+       AND coi2.status NOT IN ('cancelled','expired')
+  ) AS demand_actually_in
+FROM picking_wave_items p
+JOIN picking_waves pw ON pw.id = p.wave_id
+JOIN purchase_orders po ON po.id = pw.source_po_id
+JOIN skus s ON s.id = p.sku_id
+LEFT JOIN stores st ON st.id = p.store_id
+WHERE pw.status <> 'cancelled'
+  AND pw.source_po_id IS NOT NULL
+  -- (a) 此 PO 的開團都沒有該 (store, sku) 的活訂單需求
+  AND NOT EXISTS (
+    SELECT 1
+    FROM (
+      SELECT prc.campaign_id
+        FROM purchase_order_items poi
+        JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+        JOIN purchase_request_campaigns prc ON prc.pr_id = pri.pr_id
+       WHERE poi.po_id = pw.source_po_id
+      UNION
+      SELECT pri.source_campaign_id
+        FROM purchase_order_items poi
+        JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+       WHERE poi.po_id = pw.source_po_id
+         AND pri.source_campaign_id IS NOT NULL
+    ) cand
+    JOIN customer_orders co ON co.campaign_id = cand.campaign_id
+                           AND co.pickup_store_id = p.store_id
+                           AND co.status NOT IN ('cancelled','expired','transferred_out')
+                           AND co.transferred_from_order_id IS NULL
+    JOIN customer_order_items coi ON coi.order_id = co.id
+                                 AND coi.sku_id = p.sku_id
+                                 AND coi.status NOT IN ('cancelled','expired')
+  )
+  -- (b) 也不是補貨來源
+  AND NOT EXISTS (
+    SELECT 1
+      FROM purchase_order_items poi
+      JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+      JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                              AND rr.requesting_store_id = p.store_id
+                              AND rr.status NOT IN ('cancelled','rejected')
+      JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                    AND rrl.sku_id = p.sku_id
+     WHERE poi.po_id = pw.source_po_id
+       AND poi.sku_id = p.sku_id
+  );
+
+GRANT SELECT ON public.v_picking_wave_campaign_mismatch TO authenticated;
+
+COMMENT ON VIEW public.v_picking_wave_campaign_mismatch IS
+  '撿貨單跨開團誤撿 / 無需求超撿偵測（唯讀）。某 (store,sku) 被撿到一張其開團對該店該 '
+  'SKU 沒有訂單需求、也非補貨來源的 PO 上即列出；demand_actually_in 指出這批貨實際該屬於哪些開團'
+  '（NULL=任何開團都無需求，純超撿/訂單已取消）。與 rpc_create_wave_from_po 的跨團守衛同一不變式。';


### PR DESCRIPTION
## Summary

Fixes a critical issue where picking waves could incorrectly allocate SKUs across campaign boundaries, causing orders from one campaign to be fulfilled by purchase orders from another campaign. This resulted in orphaned orders that couldn't be tracked or fulfilled.

The root cause was that the picking workstation (WMS) operated campaign-blind and used FIFO allocation by PO, while group-buy orders are campaign-scoped. When two campaigns from the same vendor ran concurrently with identical SKUs, allocations would contaminate each other.

## Changes

### Database Migrations

**`20260702000000_wave_from_po_campaign_scoped.sql`** — Rewrites `rpc_create_wave_from_po()` function:
- Removes the old approach of selecting a single representative campaign for all wave items
- Implements per-(SKU, store) campaign resolution: for each allocation, finds the campaign (among those linked to the PO) that actually has customer order demand for that store/SKU combination
- Adds server-side guard: if a (store, SKU) has no order demand in any of the PO's campaigns AND is not a restock source, raises an exception to prevent cross-campaign picking
- Uses sequence-based wave code generation to avoid same-second collisions

**`20260702000010_v_picking_wave_campaign_mismatch.sql`** — New diagnostic view:
- Detects existing picking wave items that violate the campaign boundary invariant
- Identifies whether mismatches are cross-campaign contamination (shows which campaign actually has the demand) or pure over-picking
- Read-only, for manual review and cleanup of existing data

### Frontend Changes

**`apps/admin/src/app/(protected)/wms/picking/page.tsx`**:
- Updates allocation logic to respect campaign boundaries during FIFO distribution
- Builds a set of valid (PO, SKU, store) combinations from the demand view (which only includes rows where the store has actual demand in that PO's campaigns)
- Skips allocation to a PO if the (PO, SKU, store) combination is not in the valid set
- Updates `involvedPos` calculation to use the same logic, ensuring the UI accurately reflects which POs will be involved

## Implementation Details

- The campaign resolution query checks both `purchase_request_campaigns` and `source_campaign_id` paths to cover all ways a PO can be linked to campaigns
- Restock requests are explicitly allowed with `campaign_id = NULL` to preserve existing restock behavior
- The guard is enforced at wave creation time (server-side), making it impossible for the UI to bypass
- Frontend FIFO allocation now aligns with backend validation, preventing the UI from generating allocations that would be rejected

https://claude.ai/code/session_01UkmrUtv4nLE8AqwWoZqYUi