### PR TITLE
fix(picking): 撿貨工作台分頁撈取 v_picking_demand_by_po，修正破千列被截斷導致到貨 PO 看不到

### DIFF
--- a/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
@@ -7,6 +7,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { fetchAllRows } from "@/lib/fetchAllRows";
 import SpinButton from "@/components/SpinButton";
 import { getTenantName } from "@/lib/tenant";
 
@@ -57,10 +58,14 @@ export default function PrintPickListPage() {
     (async () => {
       try {
         const sb = getSupabase();
-        const { data, error: e } = await sb.from("v_picking_demand_by_po").select("*");
+        // 走分頁，避免 PostgREST 1000 列上限把最新到貨的 PO 截掉（與派貨工作台同源）。
+        const data = await fetchAllRows<DemandRow>(() =>
+          sb.from("v_picking_demand_by_po").select("*")
+            .order("po_item_id", { ascending: true })
+            .order("store_id", { ascending: true, nullsFirst: false }),
+        );
         if (cancelled) return;
-        if (e) { setError(e.message); return; }
-        setDemand((data ?? []) as DemandRow[]);
+        setDemand(data);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err));
       }

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
+import { fetchAllRows } from "@/lib/fetchAllRows";
 import { DatePicker } from "@/components/DatePicker";
 import SpinButton from "@/components/SpinButton";
 
@@ -83,19 +84,27 @@ export default function PickingWorkstationPage() {
     (async () => {
       try {
         const sb = getSupabase();
-        const [{ data: dRows, error: e1 }, { data: supRows }, { data: rrRows, error: e3 }] = await Promise.all([
-          sb.from("v_picking_demand_by_po").select("*"),
-          sb.from("suppliers").select("id, code, name"),
-          sb.from("v_picking_demand_no_po").select("*"),
+        // 全部走 fetchAll 分頁，避免 PostgREST 1000 列上限把整張 PO 截掉。
+        // .order() 給分頁一個穩定的 total order（否則跨頁可能漏/重複列）。
+        const [dRows, supRows, rrRows] = await Promise.all([
+          fetchAllRows<DemandRow>(() =>
+            sb.from("v_picking_demand_by_po").select("*")
+              .order("po_item_id", { ascending: true })
+              .order("store_id", { ascending: true, nullsFirst: false }),
+          ),
+          fetchAllRows<Supplier>(() => sb.from("suppliers").select("id, code, name").order("id", { ascending: true })),
+          fetchAllRows<RestockRow>(() =>
+            sb.from("v_picking_demand_no_po").select("*")
+              .order("restock_request_id", { ascending: true })
+              .order("sku_id", { ascending: true }),
+          ),
         ]);
         if (cancelled) return;
-        if (e1) { setError(e1.message); return; }
-        if (e3) { setError(e3.message); return; }
         setError(null);
-        setDemand((dRows ?? []) as DemandRow[]);
-        setRestockDemand((rrRows ?? []) as RestockRow[]);
+        setDemand(dRows);
+        setRestockDemand(rrRows);
         const sm = new Map<number, Supplier>();
-        for (const s of (supRows ?? []) as Supplier[]) sm.set(s.id, s);
+        for (const s of supRows) sm.set(s.id, s);
         setSuppliers(sm);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err));

--- a/apps/admin/src/components/ExceptionsContent.tsx
+++ b/apps/admin/src/components/ExceptionsContent.tsx
@@ -10,6 +10,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { fetchAllRows } from "@/lib/fetchAllRows";
 import SpinButton from "./SpinButton";
 import { TransferShortageResolveModal, type ShortageContext } from "./TransferShortageResolveModal";
 
@@ -114,10 +115,15 @@ export default function ExceptionsContent({
           .eq("gr.status", "confirmed");
         if (e2) throw new Error("po_damage: " + e2.message);
 
-        const { data: overRows, error: e3 } = await sb
-          .from("v_picking_demand_by_po")
-          .select("po_id, po_no, po_status, sku_id, sku_code, sku_label, qty_ordered, gr_qty");
-        if (e3) throw new Error("po_over: " + e3.message);
+        // 無 filter 撈整張 v_picking_demand_by_po（PO×SKU×store 矩陣，會破千列），
+        // 必須分頁，否則 PostgREST 1000 列上限會漏掉部分 PO 的過量進貨異常。
+        // 依 view grain (po_item_id, store_id) 排序給分頁穩定 total order。
+        const overRows = await fetchAllRows<{ po_id: number; po_no: string; po_status: string; sku_id: number; sku_code: string | null; sku_label: string; qty_ordered: number; gr_qty: number }>(() =>
+          sb.from("v_picking_demand_by_po")
+            .select("po_id, po_no, po_status, sku_id, sku_code, sku_label, qty_ordered, gr_qty")
+            .order("po_item_id", { ascending: true })
+            .order("store_id", { ascending: true, nullsFirst: false }),
+        );
 
         const { data: tShortRows, error: e4 } = await sb
           .from("transfer_items")

--- a/apps/admin/src/lib/fetchAllRows.ts
+++ b/apps/admin/src/lib/fetchAllRows.ts
@@ -1,0 +1,24 @@
+// Chunked fetch — bypass PostgREST 的 max-rows 1000 列上限。
+//
+// PostgREST/Supabase 單次 select 預設最多回 1000 列。撿貨工作台的
+// v_picking_demand_by_po 是 PO×SKU×store 矩陣，多張未結 PO 時很容易破千列
+// （實測 58 張 PO = 1811 列）；不分頁的話最新到貨的 PO 會被截在 1000 列之外、
+// 整張在工作台 / 列印清單裡消失。凡是「要拿回整個 view」的查詢都該走這支。
+//
+// builder 必須回 fresh query builder（PostgREST builder 在 .range() 之後不可 reuse），
+// 且查詢應帶 .order() 給分頁一個穩定的 total order，否則跨頁可能漏列或重複列。
+export async function fetchAllRows<T>(
+  builder: () => any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  pageSize = 1000,
+  maxPages = 50,
+): Promise<T[]> {
+  const all: T[] = [];
+  for (let p = 0; p < maxPages; p++) {
+    const { data, error } = await builder().range(p * pageSize, (p + 1) * pageSize - 1);
+    if (error) throw error;
+    const rows = (data ?? []) as T[];
+    all.push(...rows);
+    if (rows.length < pageSize) break;
+  }
+  return all;
+}


### PR DESCRIPTION
問題：PO2606030374 全部到貨後，派貨工作台 / 列印撿貨清單看不到可撿的品項。

根因：v_picking_demand_by_po 是 PO×SKU×store 矩陣，多張未結 PO 時列數很容易破千
（實測 58 張 PO = 1811 列）。前端用 sb.from(...).select("*") 無 limit / range / order，
PostgREST 預設 max-rows 1000 把結果截在第 1000 列，最新到貨的 PO（po_item_id 較大、
排在尾端）整張落在視窗外 → 前端沒收到 → 工作台不顯示。

修法：
- 新增共用 fetchAllRows()（src/lib/fetchAllRows.ts）做 chunked fetch 繞過 1000 列上限，
  並以 .order() 給分頁穩定 total order，避免跨頁漏列 / 重複列。
- 派貨工作台 (wms/picking) 的 v_picking_demand_by_po / v_picking_demand_no_po / suppliers
  改走 fetchAllRows，依 (po_item_id, store_id) 排序。
- 列印撿貨清單 (picking/print-pick-list) 同源查詢一併修正。
- 異常處理 (ExceptionsContent) 的「過量進貨」無 filter 全表查詢同樣會被截斷，一併改分頁。

https://claude.ai/code/session_0132ubfuujq1Pr3c83GXAAt8