### PR TITLE
fix(picking): 派貨工作台只列可分配品項 + 表格固定橫向捲軸

### DIFF
--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -203,8 +203,9 @@ export default function PickingWorkstationPage() {
       s.poList.sort((a, b) => a.po_id - b.po_id);
     }
     return Array.from(grouped.values())
-      // 隱藏「已到貨且全部撿完」的 SKU;到貨 0 (sent 在路上)的繼續顯示讓使用者看得到
-      .filter((s) => !(s.totalGr > 0 && s.totalAvailable === 0))
+      // 只看有數量可以分配的 SKU(totalAvailable > 0)。已派完 / 還在途的都先隱藏,
+      // 派貨工作台是「我現在可以分配什麼」,在途的等 PO 收貨後自然會回來。
+      .filter((s) => s.totalAvailable > 0)
       .sort((a, b) => (a.sku_code ?? "").localeCompare(b.sku_code ?? ""));
   }, [demand]);
 
@@ -722,10 +723,13 @@ export default function PickingWorkstationPage() {
       ) : viewMode === "matrix" ? (
         skuRows.length === 0 ? (
           <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
-            沒有待撿貨的品項(所有已進貨的都已派完)。
+            目前沒有可分配的品項(已到貨的都派完了,在途的等收貨後再回來)。
           </div>
         ) : (
-          <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+          // max-h + overflow-auto:讓 2D 表格在自己的 viewport 內捲動,
+          // 橫向 scrollbar 就一直停在可見區底部,不會被多列推到頁尾外。
+          // sticky thead/左欄保持表頭與品項欄可見。
+          <div className="max-h-[calc(100vh-260px)] overflow-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
             <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
               <colgroup>
                 <col className="w-[220px]" />
@@ -738,9 +742,9 @@ export default function PickingWorkstationPage() {
                 <col className="w-16" />
                 {allStores.map((st) => <col key={st.store_id} className="w-20" />)}
               </colgroup>
-              <thead className="bg-zinc-50 dark:bg-zinc-900">
+              <thead className="sticky top-0 z-10 bg-zinc-50 dark:bg-zinc-900">
                 <tr>
-                  <Th className="sticky left-0 bg-zinc-50 dark:bg-zinc-900">品項 / 來源 PO</Th>
+                  <Th className="sticky left-0 z-20 bg-zinc-50 dark:bg-zinc-900">品項 / 來源 PO</Th>
                   <Th className="text-center">訂購</Th>
                   <Th className="text-center">已到</Th>
                   <Th className="text-center" title="PO 還沒結、還會繼續到的數量">在途</Th>


### PR DESCRIPTION
## 背景

派貨工作台（`/wms/picking` 全清單矩陣）出現兩個問題：

1. **看到一堆不能派的品項** — 清單把「已到貨 0、全部還在途（PO 已送出未收貨）」的 SKU 也列出來，`可分配` 顯示負數（如 `-192`），但其實此刻沒有任何可分配庫存。使用者只想看「現在真的可以分配的」。
2. **橫向捲軸難用** — 分店欄多（20+ 間店）時表格很寬，但 `overflow-x-auto` 的橫向 scrollbar 在表格最底部，列數一多就被推到頁尾外，要先捲完所有列才搆得到，沒辦法平順看每間店的數量。

## 改動

`apps/admin/src/app/(protected)/wms/picking/page.tsx`

- **只列可分配品項**：`skuRows` filter 由「隱藏已到貨且撿完」改為 `s.totalAvailable > 0`。已派完 / 全在途的 SKU 都先隱藏；在途的等 PO 收貨後 `totalAvailable` 自然回正、重新出現。順帶解掉「全在途 SKU 因預設分配量 > 0、按建立會報『超過可分配 0』」這個 latent 行為。
- **固定橫向捲軸**：表格 wrapper 由 `overflow-x-auto` 改為 `max-h-[calc(100vh-260px)] overflow-auto` 的 2D 內部 viewport，橫向 scrollbar 穩定停在可見區底部；`thead` 加 `sticky top-0 z-10`、左上角 `Th` 加 `z-20`（既有左欄 `sticky left-0`），縱向捲動表頭固定、橫向捲動品項欄固定。
- **空狀態文案**對齊新 filter：「目前沒有可分配的品項(已到貨的都派完了,在途的等收貨後再回來)」。

## 不影響

- 「依分店（檢視）」分頁 — 純檢視，仍顯示所有店家需求（含在途），未動。
- 「補貨申請(無 PO 來源)📦」區塊 — 供給來自 HQ 即時庫存，機制不同，未動。
- `submitAll` / `involvedPos` FIFO 切 wave 邏輯不變，只是來源 `skuRows` 收斂到可分配集合。

## Reviewer notes

- 沙箱環境連不到本機 Supabase，未跑 live preview（沿用本 repo 既有限制），請在你本機 `/wms/picking` 視覺驗收：① 清單只剩可分配品項；② 表格右側分店欄可橫向捲動、捲軸在可見區底部、表頭與品項欄 sticky。
- 純前端 UI 改動，無 migration / RPC / schema 變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)