### PR TITLE
chore(data): 硬刪 3 個測試開團全鏈路紀錄 (prod) + 留刪除腳本

### DIFF
--- a/scripts/delete-campaign-GRP-20260531-002.sql
+++ b/scripts/delete-campaign-GRP-20260531-002.sql
@@ -1,0 +1,119 @@
+-- ============================================================
+-- Tier-3 硬刪 campaign 2205 / GRP-20260531-002「🍂包子媽生鮮小舖🍂」全部相關紀錄
+-- （含採購 PR/PO/GRN）+ 重算受影響庫存。
+--
+-- 2026-06-03 應使用者要求對 production 執行。備份見
+--   backups/PROD-delete-GRP-20260531-002-20260603.json（含被刪所有 row + 刪前餘額）。
+--
+-- 刪除清單（已對 prod 列舉確認）：
+--   group_buy_campaigns 2205 + campaign_items×6
+--   customer_orders×11 (17763,17764,17766..17774) + items×22 + audit×7 + pickup_events×1
+--   picking_waves×6 (5,6,7,8,11,12) + wave_items×20 + wave_audit×14
+--   transfers×8 (16,20,21,22,24,25,32,33) + transfer_items×8
+--   goods_receipts×2 (4,5) + goods_receipt_items×6
+--   purchase_orders×2 (4,5) + po_items×6
+--   purchase_requests×2 (8,9) + pr_items×12 + pr_campaigns×2
+--   stock_movements×20 (45-50 進貨 + 51,52,53,56,57,59,80-85,103,104 出入/取貨)
+--
+-- 庫存：刪 20 筆 movement 後，對 10 個受影響 (location,sku) 重算 on_hand =
+--   GREATEST(0, SUM(殘存 movement))。跨團共用導致 loc1/sku1030(G00123-06) 殘存 -1,
+--   依使用者決定 clamp 成 0。
+--
+-- 設計約束：stock_movements 與 *_audit_log / order_pickup_events 都有 append-only
+--   forbid trigger（含 forbid_movement_mutation），故整段在 session_replication_role
+--   ='replica' 下執行以繞過；replica 模式同時停用 FK 強制，因此採顯式 child-first 刪除、
+--   不依賴 CASCADE（沿用 scripts/hard-delete-order-GRP-20260523-002-TF0009.sql 教訓）。
+--
+-- Rollback：用 backups/PROD-delete-GRP-20260531-002-20260603.json 逐表 re-insert，
+--   並把 stock_balances 還原成該檔 stock_balances_before。
+-- ============================================================
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_campaign bigint := 2205;
+  v_oids  bigint[] := ARRAY[17763,17764,17766,17767,17768,17769,17770,17771,17772,17773,17774];
+  v_waves bigint[] := ARRAY[5,6,7,8,11,12];
+  v_xfers bigint[] := ARRAY[16,20,21,22,24,25,32,33];
+  v_grns  bigint[] := ARRAY[4,5];
+  v_pos   bigint[] := ARRAY[4,5];
+  v_prs   bigint[] := ARRAY[8,9];
+  v_movs  bigint[] := ARRAY[45,46,47,48,49,50,51,52,53,56,57,59,80,81,82,83,84,85,103,104];
+  n bigint;
+BEGIN
+  -- ---- 前置守衛：確認目標就是這團、規模相符 ----
+  PERFORM 1 FROM group_buy_campaigns WHERE id = v_campaign AND campaign_no = 'GRP-20260531-002';
+  IF NOT FOUND THEN RAISE EXCEPTION '中止：campaign 2205 / GRP-20260531-002 不存在'; END IF;
+
+  SELECT count(*) INTO n FROM customer_orders WHERE campaign_id = v_campaign;
+  IF n <> 11 THEN RAISE EXCEPTION '中止：campaign 2205 訂單數應為 11，實際 %', n; END IF;
+
+  SELECT count(*) INTO n FROM stock_movements WHERE id = ANY(v_movs);
+  IF n <> 20 THEN RAISE EXCEPTION '中止：待刪 stock_movements 應為 20，實際 %', n; END IF;
+
+  SET LOCAL session_replication_role = 'replica';
+
+  -- ---- 履約子表 ----
+  DELETE FROM customer_order_audit_log WHERE order_id = ANY(v_oids);
+  DELETE FROM order_pickup_events      WHERE order_id = ANY(v_oids);
+  DELETE FROM customer_order_items     WHERE order_id = ANY(v_oids);
+
+  -- ---- 撿貨子表 ----
+  DELETE FROM picking_wave_audit_log WHERE wave_id = ANY(v_waves);
+  DELETE FROM picking_wave_items     WHERE wave_id = ANY(v_waves);
+
+  -- ---- transfer 子表 ----
+  DELETE FROM transfer_items WHERE transfer_id = ANY(v_xfers);
+
+  -- ---- 進貨子表 ----
+  DELETE FROM goods_receipt_items WHERE gr_id = ANY(v_grns);
+
+  -- ---- 採購子表 ----
+  DELETE FROM purchase_order_items      WHERE po_id = ANY(v_pos);
+  DELETE FROM purchase_request_items    WHERE pr_id = ANY(v_prs);
+  DELETE FROM purchase_request_campaigns WHERE pr_id = ANY(v_prs);
+
+  -- ---- 開團子表 ----
+  DELETE FROM campaign_items WHERE campaign_id = v_campaign;
+
+  -- ---- stock_movements（須在 transfer_items / goods_receipt_items 之後，因 FK 由其指向）----
+  DELETE FROM stock_movements WHERE id = ANY(v_movs);
+
+  -- ---- 父表 / 表頭 ----
+  DELETE FROM transfers          WHERE id = ANY(v_xfers);
+  DELETE FROM goods_receipts     WHERE id = ANY(v_grns);
+  DELETE FROM picking_waves      WHERE id = ANY(v_waves);
+  DELETE FROM customer_orders    WHERE id = ANY(v_oids);
+  DELETE FROM purchase_orders    WHERE id = ANY(v_pos);
+  DELETE FROM purchase_requests  WHERE id = ANY(v_prs);
+  DELETE FROM group_buy_campaigns WHERE id = v_campaign;
+
+  -- ---- 重算受影響 (location,sku) 餘額：on_hand = max(0, Σ殘存 movement) ----
+  UPDATE stock_balances sb
+     SET on_hand = GREATEST(0, COALESCE((
+           SELECT SUM(m.quantity) FROM stock_movements m
+            WHERE m.location_id = sb.location_id AND m.sku_id = sb.sku_id
+         ), 0)),
+         updated_at = NOW()
+   WHERE (sb.location_id = 1  AND sb.sku_id IN (1026,1027,1028,1029,1030,1031))
+      OR (sb.location_id = 18 AND sb.sku_id IN (1027,1028,1030,1031));
+
+  -- ---- 後置守衛：確認全清空 ----
+  SELECT count(*) INTO n FROM customer_orders WHERE campaign_id = v_campaign;
+  IF n <> 0 THEN RAISE EXCEPTION '殘留 customer_orders %', n; END IF;
+  SELECT count(*) INTO n FROM group_buy_campaigns WHERE id = v_campaign;
+  IF n <> 0 THEN RAISE EXCEPTION '殘留 group_buy_campaigns %', n; END IF;
+  SELECT count(*) INTO n FROM picking_wave_items WHERE wave_id = ANY(v_waves);
+  IF n <> 0 THEN RAISE EXCEPTION '殘留 picking_wave_items %', n; END IF;
+  SELECT count(*) INTO n FROM transfer_items WHERE transfer_id = ANY(v_xfers);
+  IF n <> 0 THEN RAISE EXCEPTION '殘留 transfer_items %', n; END IF;
+  SELECT count(*) INTO n FROM stock_movements WHERE id = ANY(v_movs);
+  IF n <> 0 THEN RAISE EXCEPTION '殘留 stock_movements %', n; END IF;
+  SELECT count(*) INTO n FROM purchase_orders WHERE id = ANY(v_pos);
+  IF n <> 0 THEN RAISE EXCEPTION '殘留 purchase_orders %', n; END IF;
+
+  RAISE NOTICE 'Tier3 全刪完成：campaign 2205 / GRP-20260531-002 已清除，庫存已重算（loc1/sku1030 clamp 0）';
+END $$;
+
+COMMIT;

--- a/scripts/delete-campaigns-956-2204.sql
+++ b/scripts/delete-campaigns-956-2204.sql
@@ -1,0 +1,138 @@
+-- ============================================================
+-- Tier-3 硬刪 campaign 956 (GRP-20260523-002) + 2204 (GRP-20260531-001)
+-- 全部相關紀錄（含採購 PR/PO/GRN）+ 重算受影響庫存（負數 clamp 0）。
+--
+-- 2026-06-03 應使用者要求對 production 執行（2204 為 open 活團，已二次確認）。
+-- 備份：backups/PROD-delete-GRP-956-2204-20260603.json（被刪所有 row + 刪前餘額）。
+--
+-- 刪除清單（已對 prod 列舉 + 閉包驗證）：
+--   campaigns 956, 2204 + campaign_items×7
+--   customer_orders×13 (956:4738,4739,4740,4741,11546,11547  2204:17596,17599,17600,17601,17632,17762,19395)
+--     + items×17 + audit×8 + pickup_events×5
+--   picking_waves×5 (956:1,2,9,10  2204:4) + wave_items×28 + wave_audit×26
+--   transfers×18：956:4,5,6,7,17,18,19,23,26,27,28,29,30
+--                 2204:11,12,13,14,15（含訂單轉手鏈 14→13、return_to_hq 15）
+--     + transfer_items×28
+--   goods_receipts×2 (1,3) + gr_items×5
+--   purchase_orders×2 (1,3) + po_items×5
+--   purchase_requests×2 (4,6) + pr_items×5 + pr_campaigns×2
+--   stock_movements×57（GRN 1,3 進貨 + 18 transfer 出入/退 + 13 訂單 sale）
+--
+-- 訂單轉手 FK：17601.transferred_to_order_id→17762、17762.transferred_from_order_id→17601 先清。
+-- 庫存：刪 movement 後對「受影響 (location,sku)」重算 on_hand=GREATEST(0,Σ殘存)。
+--   PO1/GRN1 共用 SKU(1026,1027,1029,1030) 扣掉已刪的 2205 後僅 956 在消耗，
+--   重算後總倉歸 0（含解消上次殘留的 1030 = -1）；無新增負數。in_transit_in 全 0。
+-- 設計約束同前：append-only(stock_movements/*_audit/pickup_events) 走 replica 繞過，
+--   顯式 child-first，不依賴 CASCADE。
+-- Rollback：用備份 JSON 逐表 re-insert + 還原 stock_balances_before。
+-- ============================================================
+
+BEGIN;
+
+-- ---- 前置守衛 ----
+DO $$
+DECLARE n bigint;
+BEGIN
+  PERFORM 1 FROM group_buy_campaigns WHERE id=956  AND campaign_no='GRP-20260523-002';
+  IF NOT FOUND THEN RAISE EXCEPTION '中止：campaign 956 / GRP-20260523-002 不存在'; END IF;
+  PERFORM 1 FROM group_buy_campaigns WHERE id=2204 AND campaign_no='GRP-20260531-001';
+  IF NOT FOUND THEN RAISE EXCEPTION '中止：campaign 2204 / GRP-20260531-001 不存在'; END IF;
+
+  SELECT count(*) INTO n FROM customer_orders WHERE campaign_id=956;
+  IF n<>6 THEN RAISE EXCEPTION '中止：956 訂單應 6，實際 %', n; END IF;
+  SELECT count(*) INTO n FROM customer_orders WHERE campaign_id=2204;
+  IF n<>7 THEN RAISE EXCEPTION '中止：2204 訂單應 7，實際 %', n; END IF;
+
+  SELECT count(*) INTO n FROM stock_movements
+   WHERE (source_doc_type='goods_receipt' AND source_doc_id IN (1,3))
+      OR (source_doc_type='transfer' AND source_doc_id IN (4,5,6,7,17,18,19,23,26,27,28,29,30,11,12,13,14,15))
+      OR (source_doc_type='customer_order' AND source_doc_id IN (4738,4739,4740,4741,11546,11547,17596,17599,17600,17601,17632,17762,19395));
+  IF n<>57 THEN RAISE EXCEPTION '中止：待刪 stock_movements 應 57，實際 %', n; END IF;
+END $$;
+
+SET LOCAL session_replication_role = 'replica';
+
+-- ---- 快照受影響 (location,sku)（刪 movement 前）----
+CREATE TEMP TABLE _affected ON COMMIT DROP AS
+  SELECT DISTINCT location_id, sku_id FROM stock_movements
+   WHERE (source_doc_type='goods_receipt' AND source_doc_id IN (1,3))
+      OR (source_doc_type='transfer' AND source_doc_id IN (4,5,6,7,17,18,19,23,26,27,28,29,30,11,12,13,14,15))
+      OR (source_doc_type='customer_order' AND source_doc_id IN (4738,4739,4740,4741,11546,11547,17596,17599,17600,17601,17632,17762,19395));
+
+-- ---- 履約子表 ----
+DELETE FROM customer_order_audit_log WHERE order_id IN (4738,4739,4740,4741,11546,11547,17596,17599,17600,17601,17632,17762,19395);
+DELETE FROM order_pickup_events      WHERE order_id IN (4738,4739,4740,4741,11546,11547,17596,17599,17600,17601,17632,17762,19395);
+DELETE FROM customer_order_items     WHERE order_id IN (4738,4739,4740,4741,11546,11547,17596,17599,17600,17601,17632,17762,19395);
+
+-- ---- 撿貨子表 ----
+DELETE FROM picking_wave_audit_log WHERE wave_id IN (1,2,9,10,4);
+DELETE FROM picking_wave_items     WHERE wave_id IN (1,2,9,10,4);
+
+-- ---- transfer 子表 ----
+DELETE FROM transfer_items WHERE transfer_id IN (4,5,6,7,17,18,19,23,26,27,28,29,30,11,12,13,14,15);
+
+-- ---- 進貨子表 ----
+DELETE FROM goods_receipt_items WHERE gr_id IN (1,3);
+
+-- ---- 採購子表 ----
+DELETE FROM purchase_order_items       WHERE po_id IN (1,3);
+DELETE FROM purchase_request_items     WHERE pr_id IN (4,6);
+DELETE FROM purchase_request_campaigns WHERE pr_id IN (4,6);
+
+-- ---- 開團子表 ----
+DELETE FROM campaign_items WHERE campaign_id IN (956,2204);
+
+-- ---- 清訂單轉手自參照 FK（17601 ↔ 17762）----
+UPDATE customer_orders SET transferred_to_order_id   = NULL WHERE id = 17601;
+UPDATE customer_orders SET transferred_from_order_id = NULL WHERE id = 17762;
+
+-- ---- stock_movements（須在 transfer_items / goods_receipt_items 之後）----
+DELETE FROM stock_movements
+   WHERE (source_doc_type='goods_receipt' AND source_doc_id IN (1,3))
+      OR (source_doc_type='transfer' AND source_doc_id IN (4,5,6,7,17,18,19,23,26,27,28,29,30,11,12,13,14,15))
+      OR (source_doc_type='customer_order' AND source_doc_id IN (4738,4739,4740,4741,11546,11547,17596,17599,17600,17601,17632,17762,19395));
+
+-- ---- 父表 / 表頭 ----
+DELETE FROM transfers          WHERE id IN (4,5,6,7,17,18,19,23,26,27,28,29,30,11,12,13,14,15);
+DELETE FROM goods_receipts     WHERE id IN (1,3);
+DELETE FROM picking_waves      WHERE id IN (1,2,9,10,4);
+DELETE FROM customer_orders    WHERE id IN (4738,4739,4740,4741,11546,11547,17596,17599,17600,17601,17632,17762,19395);
+DELETE FROM purchase_orders    WHERE id IN (1,3);
+DELETE FROM purchase_requests  WHERE id IN (4,6);
+DELETE FROM group_buy_campaigns WHERE id IN (956,2204);
+
+-- ---- 重算受影響 (location,sku)：on_hand = max(0, Σ殘存 movement) ----
+UPDATE stock_balances sb
+   SET on_hand = GREATEST(0, COALESCE((
+         SELECT SUM(m.quantity) FROM stock_movements m
+          WHERE m.location_id = sb.location_id AND m.sku_id = sb.sku_id
+       ), 0)),
+       updated_at = NOW()
+  FROM _affected a
+ WHERE sb.location_id = a.location_id AND sb.sku_id = a.sku_id;
+
+-- ---- 後置守衛 ----
+DO $$
+DECLARE n bigint;
+BEGIN
+  SELECT count(*) INTO n FROM customer_orders WHERE campaign_id IN (956,2204);
+  IF n<>0 THEN RAISE EXCEPTION '殘留 customer_orders %', n; END IF;
+  SELECT count(*) INTO n FROM group_buy_campaigns WHERE id IN (956,2204);
+  IF n<>0 THEN RAISE EXCEPTION '殘留 group_buy_campaigns %', n; END IF;
+  SELECT count(*) INTO n FROM transfers WHERE id IN (4,5,6,7,17,18,19,23,26,27,28,29,30,11,12,13,14,15);
+  IF n<>0 THEN RAISE EXCEPTION '殘留 transfers %', n; END IF;
+  SELECT count(*) INTO n FROM transfer_items WHERE transfer_id IN (4,5,6,7,17,18,19,23,26,27,28,29,30,11,12,13,14,15);
+  IF n<>0 THEN RAISE EXCEPTION '殘留 transfer_items %', n; END IF;
+  SELECT count(*) INTO n FROM picking_waves WHERE id IN (1,2,9,10,4);
+  IF n<>0 THEN RAISE EXCEPTION '殘留 picking_waves %', n; END IF;
+  SELECT count(*) INTO n FROM purchase_orders WHERE id IN (1,3);
+  IF n<>0 THEN RAISE EXCEPTION '殘留 purchase_orders %', n; END IF;
+  SELECT count(*) INTO n FROM stock_movements
+   WHERE (source_doc_type='goods_receipt' AND source_doc_id IN (1,3))
+      OR (source_doc_type='transfer' AND source_doc_id IN (4,5,6,7,17,18,19,23,26,27,28,29,30,11,12,13,14,15))
+      OR (source_doc_type='customer_order' AND source_doc_id IN (4738,4739,4740,4741,11546,11547,17596,17599,17600,17601,17632,17762,19395));
+  IF n<>0 THEN RAISE EXCEPTION '殘留 stock_movements %', n; END IF;
+  RAISE NOTICE 'Tier3 全刪完成：campaign 956 + 2204 已清除，庫存已重算（負數 clamp 0）';
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## 摘要

應使用者要求，對 **production** 全刪三個測試開團「產生的所有紀錄」(Tier-3，含採購 PR/PO/GRN)，並重算受影響庫存。此 PR 收錄**刪除腳本**作為稽核 / 還原依據（受影響 row 的 JSON 備份在 `backups/`，已 gitignore、留本地）。

> ⚠️ 這些 SQL **已對 prod 執行完畢並驗證**，本 PR 是把操作紀錄入版控，非待執行的 migration。

## 刪除範圍

| 開團 | 訂單 | 波次 | transfer | 採購 |
|---|---|---|---|---|
| 2205 `GRP-20260531-002` | 11 | 6 | 8 | PR/PO/GRN |
| 956 `GRP-20260523-002` | 6 | 4 | 13 | PR/PO/GRN |
| 2204 `GRP-20260531-001`（open 活團，二次確認） | 7 | 1 | 5 | PR/PO/GRN |

- 2205 另含 20 stock_movement；956+2204 合計 57 stock_movement
- 2204 含**訂單轉手兩段鏈**（`AT-O17762` L1→L2，transfer 14→13）與 **return_to_hq** leg（transfer 15）

## 做法 / 為何這樣寫

- `stock_movements` / `*_audit_log` / `order_pickup_events` 都有 append-only forbid trigger（含 `forbid_movement_mutation`）→ 全程 `session_replication_role='replica'` 繞過；replica 同時停 FK 強制，故採**顯式 child-first 刪除、不依賴 CASCADE**（沿用 `scripts/hard-delete-order-GRP-20260523-002-TF0009.sql` 教訓）。
- 庫存：刪 movement 後對受影響 `(location, sku)` 重算 `on_hand = GREATEST(0, Σ殘存 movement)`。跨團共用的 GRN1（sku 1026/1027/1029/1030）扣掉已刪的 2205 後僅 956 在消耗，重算後總倉乾淨歸 0（含解消上次殘留的 G00123-06 ledger −1）。
- 每段 SQL 含**前後守衛斷言**（campaign 存在、訂單 / movement 數相符、刪後歸零）。

## 驗證結果

- 相關表全部歸零；**全庫零負庫存**；無孤兒指標（next_transfer / customer_order_id / 訂單轉手自參照 FK 全 0）；別團 `2196`（PO2 / wave3）完好。

## Reviewer 注意

- 兩支腳本各自檔頭有完整 rollback 說明（用 `backups/PROD-delete-*.json` 逐表 re-insert + 還原 `stock_balances_before`）。
- 備份 JSON 含 `member_id` 等資料，刻意不進版控（`backups/` 在 .gitignore），僅存於操作機本地。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
