### PR TITLE
fix(picking): 派貨工作台改為只留水平(左右)捲軸

### DIFF
--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -726,10 +726,10 @@ export default function PickingWorkstationPage() {
             目前沒有可分配的品項(已到貨的都派完了,在途的等收貨後再回來)。
           </div>
         ) : (
-          // max-h + overflow-auto:讓 2D 表格在自己的 viewport 內捲動,
-          // 橫向 scrollbar 就一直停在可見區底部,不會被多列推到頁尾外。
-          // sticky thead/左欄保持表頭與品項欄可見。
-          <div className="max-h-[calc(100vh-260px)] overflow-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+          // 只保留水平(左右)捲軸:拿掉高度上限,表格整高展開、跟著整頁一起垂直捲動,
+          // 容器只在「店別欄超出寬度」時出現左右 scrollbar(overflow-x-auto),不再有內框垂直捲軸。
+          // sticky 左欄在橫向捲動時固定品項欄。
+          <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
             <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
               <colgroup>
                 <col className="w-[220px]" />


### PR DESCRIPTION
## 摘要

派貨工作台的全清單矩陣改為**只有水平（左右）捲軸**，移除內框的垂直捲軸。

回報：表格目前是垂直捲軸（內框），希望改成左右水平捲動。

## 原因

#408 為了讓橫向 scrollbar 不被多列推到頁尾外，用 `max-h-[calc(100vh-260px)] overflow-auto` 把表格框在固定高度的內框裡捲動 → 內框同時出現**垂直**捲軸。

## 變更

`apps/admin/src/app/(protected)/wms/picking/page.tsx` 表格容器：

```diff
- <div className="max-h-[calc(100vh-260px)] overflow-auto rounded-md ...">
+ <div className="overflow-x-auto rounded-md ...">
```

- 拿掉高度上限 → 表格整高展開，**跟著整頁一起垂直捲動**（不再有內框垂直捲軸）
- `overflow-x-auto` → 只在「店別欄超出寬度」時出現左右水平 scrollbar
- `sticky left-0` 品項欄在橫向捲動時仍固定；`sticky top-0` thead 失去內框可貼附對象（整頁捲動時會跟著走，屬預期）

## 驗證

- `npx tsc --noEmit -p apps/admin/tsconfig.json` ✓（純 className 變更，無邏輯/型別影響）
- 視覺請實機確認：店別欄多時，表格底部出現左右捲軸、無內框上下捲軸
  - admin live-preview 在沙箱被網路阻擋，未跑瀏覽器驗證

## 備註

- off 最新 merged main（#408），與 #409 / #410 不相疊；本檔改的容器 div 與 #410 改動區段不重疊，可各自 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
