### PR TITLE
feat(admin): 所有後台搜尋框加上搜尋中轉圈圈 spinner

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 import { CampaignThumb } from "@/components/CampaignThumb";
 import { campaignCoverUrl, type CampaignCoverItem } from "@/lib/campaignCover";
 
@@ -904,6 +905,7 @@ function CustomerSearch({
   const [open, setOpen] = useState(false);
   const [members, setMembers] = useState<MemberRow[]>([]);
   const [aliases, setAliases] = useState<AliasRow[]>([]);
+  const [searching, setSearching] = useState(false);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
 
@@ -920,16 +922,21 @@ function CustomerSearch({
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (term.length < 1 && !open) return;
+    setSearching(true);
     debounceRef.current = setTimeout(async () => {
       const sb = getSupabase();
-      const [mRes, aRes] = await Promise.all([
-        sb.rpc("rpc_search_members", { p_term: term, p_limit: 8 }),
-        channelId
-          ? sb.rpc("rpc_search_aliases", { p_channel_id: channelId, p_term: term, p_limit: 8 })
-          : Promise.resolve({ data: [], error: null }),
-      ]);
-      setMembers((mRes.data as MemberRow[]) ?? []);
-      setAliases((aRes.data as AliasRow[]) ?? []);
+      try {
+        const [mRes, aRes] = await Promise.all([
+          sb.rpc("rpc_search_members", { p_term: term, p_limit: 8 }),
+          channelId
+            ? sb.rpc("rpc_search_aliases", { p_channel_id: channelId, p_term: term, p_limit: 8 })
+            : Promise.resolve({ data: [], error: null }),
+        ]);
+        setMembers((mRes.data as MemberRow[]) ?? []);
+        setAliases((aRes.data as AliasRow[]) ?? []);
+      } finally {
+        setSearching(false);
+      }
     }, 200);
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
   }, [term, channelId, open]);
@@ -959,8 +966,9 @@ function CustomerSearch({
           setOpen(true);
         }}
         placeholder="搜尋會員 / 暱稱 / 手機"
-        className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+        className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 pr-8 text-sm dark:border-zinc-700 dark:bg-zinc-800"
       />
+      <SearchSpinner active={searching} />
       {open && (members.length > 0 || aliases.length > 0) && (
         <div
           className="absolute left-0 right-0 top-full z-20 mt-1 max-h-96 overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
@@ -1080,6 +1088,7 @@ function ItemEditorRow({
   const [term, setTerm] = useState("");
   const [open, setOpen] = useState(false);
   const [opts, setOpts] = useState<SkuOption[]>([]);
+  const [searching, setSearching] = useState(false);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
   const wrapperRef = useRef<HTMLTableCellElement | null>(null);
 
@@ -1096,11 +1105,16 @@ function ItemEditorRow({
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (!open) return;
+    setSearching(true);
     debounceRef.current = setTimeout(async () => {
-      const { data } = await getSupabase().rpc("rpc_search_skus_for_campaign", {
-        p_campaign_id: campaignId, p_term: term, p_limit: 12,
-      });
-      setOpts((data as SkuOption[]) ?? []);
+      try {
+        const { data } = await getSupabase().rpc("rpc_search_skus_for_campaign", {
+          p_campaign_id: campaignId, p_term: term, p_limit: 12,
+        });
+        setOpts((data as SkuOption[]) ?? []);
+      } finally {
+        setSearching(false);
+      }
     }, 200);
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
   }, [term, campaignId, open]);
@@ -1123,8 +1137,9 @@ function ItemEditorRow({
             setOpen(true);
           }}
           placeholder="搜尋商品 / 品項"
-          className="w-full rounded border border-zinc-300 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+          className="w-full rounded border border-zinc-300 bg-white px-2 py-1 pr-7 text-xs dark:border-zinc-700 dark:bg-zinc-800"
         />
+        <SearchSpinner active={searching} className="right-1" />
         {open && opts.length > 0 && (
           <div
             className="absolute left-0 top-full z-10 mt-1 max-h-80 w-[420px] overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800"

--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -11,6 +11,7 @@ import {
   type CampaignStatus,
 } from "@/lib/campaignStatus";
 import { Modal } from "@/components/Modal";
+import SearchSpinner from "@/components/SearchSpinner";
 import { CampaignForm, type CampaignFormValues } from "@/components/CampaignForm";
 import { CampaignOrdersPanel } from "@/components/CampaignOrdersPanel";
 import { CampaignItemsTable } from "@/components/CampaignItemsTable";
@@ -154,6 +155,7 @@ export default function CampaignsListPage() {
 
   const [queryDraft, setQueryDraft] = useState(() => campaignsCache?.queryDraft ?? "");
   const [query, setQuery] = useState(() => campaignsCache?.query ?? "");
+  const [searching, setSearching] = useState(false);
   const [status, setStatus] = useState<string>(() => campaignsCache?.status ?? "");
   const [closeTypeFilter, setCloseTypeFilter] = useState<string>(() => campaignsCache?.closeTypeFilter ?? ""); // ""=全部 / regular / fast / limited / food_train
   const [page, setPage] = useState(() => campaignsCache?.page ?? 1);
@@ -360,9 +362,11 @@ export default function CampaignsListPage() {
 
   useEffect(() => {
     if (isInitialRunRef.current) return; // 從 cache 還原 → 別把 page reset 回 1
+    // 打字內容與已送出的 query 不同 → 有一筆 fetch 待觸發，轉圈圈到主 fetch 結束才停
+    if (queryDraft !== query) setSearching(true);
     const t = setTimeout(() => { setQuery(queryDraft); setPage(1); }, 250);
     return () => clearTimeout(t);
-  }, [queryDraft]);
+  }, [queryDraft, query]);
 
   useEffect(() => {
     if (isInitialRunRef.current) return;
@@ -486,6 +490,7 @@ export default function CampaignsListPage() {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       } finally {
         if (!cancelled && !silent) setLoading(false);
+        setSearching(false);
       }
     })();
     return () => { cancelled = true; };
@@ -694,10 +699,13 @@ export default function CampaignsListPage() {
 
       {view === "list" && (
         <div className="grid gap-3 sm:grid-cols-3">
-          <input
-            type="search" placeholder="搜尋 團號 / 名稱" value={queryDraft} onChange={(e) => setQueryDraft(e.target.value)}
-            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
-          />
+          <div className="relative">
+            <input
+              type="search" placeholder="搜尋 團號 / 名稱" value={queryDraft} onChange={(e) => setQueryDraft(e.target.value)}
+              className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 pr-8 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
+            />
+            <SearchSpinner active={searching} />
+          </div>
           <select value={status} onChange={(e) => setStatus(e.target.value)}
             className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
             <option value="">全部狀態</option>

--- a/apps/admin/src/app/(protected)/community-candidates/page.tsx
+++ b/apps/admin/src/app/(protected)/community-candidates/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { DatePicker } from "@/components/DatePicker";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 
 type Candidate = {
   id: number;
@@ -53,6 +54,7 @@ export default function CommunityCandidatesPage() {
   const [rows, setRows] = useState<Candidate[] | null>(null);
   const [queryDraft, setQueryDraft] = useState("");
   const [query, setQuery] = useState("");
+  const [searching, setSearching] = useState(false);
   const [tab, setTab] = useState<Tab>("pending");
   const [error, setError] = useState<string | null>(null);
   const [scheduling, setScheduling] = useState<number | null>(null);
@@ -89,9 +91,11 @@ export default function CommunityCandidatesPage() {
   }, []);
 
   useEffect(() => {
+    // 打字內容與已送出的 query 不同 → 有一筆 reload 待觸發，轉圈圈到 reload 結束才停
+    if (queryDraft !== query) setSearching(true);
     const t = setTimeout(() => setQuery(queryDraft), 300);
     return () => clearTimeout(t);
-  }, [queryDraft]);
+  }, [queryDraft, query]);
 
   useEffect(() => {
     if (highlightId && highlightRowRef.current) {
@@ -119,11 +123,15 @@ export default function CommunityCandidatesPage() {
       q = q.or(`product_name_hint.ilike.%${safe}%,raw_text.ilike.%${safe}%`);
     }
 
-    const { data, error: err } = await q;
-    if (err) setError(err.message);
-    else {
-      setError(null);
-      setRows((data as Candidate[]) ?? []);
+    try {
+      const { data, error: err } = await q;
+      if (err) setError(err.message);
+      else {
+        setError(null);
+        setRows((data as Candidate[]) ?? []);
+      }
+    } finally {
+      setSearching(false);
     }
   };
 
@@ -573,12 +581,15 @@ export default function CommunityCandidatesPage() {
 
       {/* Search */}
       <div className="flex gap-2">
-        <input
-          className="flex-1 rounded-md border border-zinc-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
-          placeholder="搜尋商品名稱或文案…"
-          value={queryDraft}
-          onChange={(e) => setQueryDraft(e.target.value)}
-        />
+        <div className="relative flex-1">
+          <input
+            className="w-full rounded-md border border-zinc-300 px-3 py-1.5 pr-8 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+            placeholder="搜尋商品名稱或文案…"
+            value={queryDraft}
+            onChange={(e) => setQueryDraft(e.target.value)}
+          />
+          <SearchSpinner active={searching} />
+        </div>
         {queryDraft && (
           <SpinButton
             onClick={() => setQueryDraft("")}

--- a/apps/admin/src/app/(protected)/fb-pages/page.tsx
+++ b/apps/admin/src/app/(protected)/fb-pages/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 
 const PAGE_SIZE = 20;
@@ -38,6 +39,7 @@ export default function FbPagesPage() {
   const [rows, setRows] = useState<FbPage[] | null>(null);
   const [queryDraft, setQueryDraft] = useState("");
   const [query, setQuery] = useState("");
+  const [searching, setSearching] = useState(false);
   const [showActive, setShowActive] = useState<"all" | "active">("active");
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState<FbPage | null>(null);
@@ -45,9 +47,11 @@ export default function FbPagesPage() {
   const [page, setPage] = useState(1);
 
   useEffect(() => {
+    // 打字內容與已送出的 query 不同 → 有一筆 reload 待觸發，轉圈圈到 reload 結束才停
+    if (queryDraft !== query) setSearching(true);
     const t = setTimeout(() => setQuery(queryDraft), 250);
     return () => clearTimeout(t);
-  }, [queryDraft]);
+  }, [queryDraft, query]);
 
   useEffect(() => { setPage(1); }, [query, showActive]);
 
@@ -69,9 +73,13 @@ export default function FbPagesPage() {
       q = q.or(`page_id.ilike.%${safe}%,name.ilike.%${safe}%`);
     }
     if (showActive === "active") q = q.eq("is_active", true);
-    const { data, error: err } = await q;
-    if (err) setError(err.message);
-    else { setError(null); setRows((data as FbPage[]) ?? []); }
+    try {
+      const { data, error: err } = await q;
+      if (err) setError(err.message);
+      else { setError(null); setRows((data as FbPage[]) ?? []); }
+    } finally {
+      setSearching(false);
+    }
   };
   useEffect(() => { reload(); }, [query, showActive]);
 
@@ -127,11 +135,14 @@ export default function FbPagesPage() {
       )}
 
       <div className="grid gap-3 sm:grid-cols-2">
-        <input
-          type="search" value={queryDraft} onChange={(e) => setQueryDraft(e.target.value)}
-          placeholder="搜尋 page_id / 名稱"
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
-        />
+        <div className="relative">
+          <input
+            type="search" value={queryDraft} onChange={(e) => setQueryDraft(e.target.value)}
+            placeholder="搜尋 page_id / 名稱"
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 pr-8 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <SearchSpinner active={searching} />
+        </div>
         <select value={showActive} onChange={(e) => setShowActive(e.target.value as "all" | "active")}
           className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
           <option value="active">僅啟用中</option>

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Modal } from "@/components/Modal";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 
 type Store = { id: number; code: string; name: string };
 type SkuOption = { id: number; sku_code: string; product_name: string; variant_name: string | null };
@@ -293,21 +294,27 @@ function SkuSearchInput({
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SkuOption[]>([]);
   const [open, setOpen] = useState(false);
+  const [searching, setSearching] = useState(false);
 
   useEffect(() => {
+    setSearching(true);
     const t = setTimeout(async () => {
-      let q = getSupabase()
-        .from("skus").select("id, sku_code, product_name, variant_name")
-        .eq("status", "active")
-        .order("updated_at", { ascending: false })
-        .limit(20);
-      const s = query.trim();
-      if (s) {
-        const safe = s.replace(/[%,()]/g, " ").trim();
-        q = q.or(`sku_code.ilike.%${safe}%,product_name.ilike.%${safe}%,variant_name.ilike.%${safe}%`);
+      try {
+        let q = getSupabase()
+          .from("skus").select("id, sku_code, product_name, variant_name")
+          .eq("status", "active")
+          .order("updated_at", { ascending: false })
+          .limit(20);
+        const s = query.trim();
+        if (s) {
+          const safe = s.replace(/[%,()]/g, " ").trim();
+          q = q.or(`sku_code.ilike.%${safe}%,product_name.ilike.%${safe}%,variant_name.ilike.%${safe}%`);
+        }
+        const { data } = await q;
+        setResults((data as SkuOption[]) ?? []);
+      } finally {
+        setSearching(false);
       }
-      const { data } = await q;
-      setResults((data as SkuOption[]) ?? []);
     }, query ? 250 : 0);
     return () => clearTimeout(t);
   }, [query]);
@@ -323,8 +330,9 @@ function SkuSearchInput({
           setOpen(true);
         }}
         placeholder="搜尋商品 / 品項"
-        className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+        className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 pr-7 dark:border-zinc-700 dark:bg-zinc-800"
       />
+      <SearchSpinner active={searching} className="right-1" />
       {open && results.length > 0 && !value && (
         <div
           className="absolute left-0 right-0 top-full z-20 mt-1 max-h-60 overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800"

--- a/apps/admin/src/app/(protected)/inventory/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 import { useUserBranchStoreId, useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 import { maskLineUserId } from "@/lib/maskLineUserId";
 
@@ -91,6 +92,7 @@ export default function InventoryOverviewPage() {
   const [rows, setRows] = useState<Balance[] | null>(null);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
+  const [searching, setSearching] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [skuMap, setSkuMap] = useState<Map<number, Sku>>(new Map());
@@ -138,6 +140,7 @@ export default function InventoryOverviewPage() {
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setSearching(true);
     (async () => {
       try {
         const sb = getSupabase();
@@ -243,7 +246,10 @@ export default function InventoryOverviewPage() {
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+          setSearching(false);
+        }
       }
     })();
     return () => {
@@ -309,16 +315,19 @@ export default function InventoryOverviewPage() {
       </header>
 
       <div className="grid gap-3 sm:grid-cols-3">
-        <input
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") setSearch(searchInput);
-          }}
-          onBlur={() => setSearch(searchInput)}
-          placeholder="搜尋 商品 / SKU / 規格…"
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-        />
+        <div className="relative">
+          <input
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") setSearch(searchInput);
+            }}
+            onBlur={() => setSearch(searchInput)}
+            placeholder="搜尋 商品 / SKU / 規格…"
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 pr-8 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <SearchSpinner active={searching} />
+        </div>
         {branchLocked ? (
           <div className="flex items-center rounded-md border border-zinc-300 bg-zinc-50 px-3 py-2 text-sm text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
             🏬 {locLabel(branchLocationId)}

--- a/apps/admin/src/app/(protected)/inventory/reorder-rules/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/reorder-rules/page.tsx
@@ -6,6 +6,7 @@ import { getSupabase } from "@/lib/supabase";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 import { useUserBranchStoreId, useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 import { translateRpcError } from "@/lib/rpcError";
 
@@ -40,6 +41,7 @@ export default function ReorderRulesPage() {
   const [rows, setRows] = useState<Rule[] | null>(null);
   const [skuMap, setSkuMap] = useState<Map<number, Sku>>(new Map());
   const [error, setError] = useState<string | null>(null);
+  const [searching, setSearching] = useState(false);
   const [reloadTick, setReloadTick] = useState(0);
 
   const [editOpen, setEditOpen] = useState(false);
@@ -71,6 +73,7 @@ export default function ReorderRulesPage() {
 
   useEffect(() => {
     let cancelled = false;
+    setSearching(true);
     (async () => {
       try {
         const sb = getSupabase();
@@ -120,6 +123,8 @@ export default function ReorderRulesPage() {
         } else setSkuMap(new Map());
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setSearching(false);
       }
     })();
     return () => { cancelled = true; };
@@ -162,14 +167,17 @@ export default function ReorderRulesPage() {
       </header>
 
       <div className="grid gap-3 sm:grid-cols-3">
-        <input
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") setSearch(searchInput); }}
-          onBlur={() => setSearch(searchInput)}
-          placeholder="搜尋 商品 / SKU / 規格…"
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-        />
+        <div className="relative">
+          <input
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") setSearch(searchInput); }}
+            onBlur={() => setSearch(searchInput)}
+            placeholder="搜尋 商品 / SKU / 規格…"
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 pr-8 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <SearchSpinner active={searching} />
+        </div>
         {branchLocked ? (
           <div className="flex items-center rounded-md border border-zinc-300 bg-zinc-50 px-3 py-2 text-sm text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
             🏬 {locLabel(branchLocationId)}<span className="ml-2 text-xs text-zinc-500">(僅本店)</span>
@@ -293,6 +301,7 @@ function RuleEditModal({
   const [skuResults, setSkuResults] = useState<Sku[]>([]);
   const [skuOpen, setSkuOpen] = useState(false);
   const [pickedSkuLabel, setPickedSkuLabel] = useState("");
+  const [searchingSku, setSearchingSku] = useState(false);
   const [ss, setSs] = useState("0");
   const [rp, setRp] = useState("0");
   const [ms, setMs] = useState("");
@@ -335,15 +344,20 @@ function RuleEditModal({
 
   useEffect(() => {
     const q = skuQuery.replace(/[,()%*]/g, " ").trim();
-    if (!skuOpen || q.length < 1) { setSkuResults([]); return; }
+    if (!skuOpen || q.length < 1) { setSkuResults([]); setSearchingSku(false); return; }
     let cancelled = false;
+    setSearchingSku(true);
     const t = setTimeout(async () => {
-      const { data } = await getSupabase()
-        .from("skus")
-        .select("id, sku_code, product_name, variant_name")
-        .or(`sku_code.ilike.%${q}%,product_name.ilike.%${q}%,variant_name.ilike.%${q}%`)
-        .limit(20);
-      if (!cancelled) setSkuResults((data as Sku[]) ?? []);
+      try {
+        const { data } = await getSupabase()
+          .from("skus")
+          .select("id, sku_code, product_name, variant_name")
+          .or(`sku_code.ilike.%${q}%,product_name.ilike.%${q}%,variant_name.ilike.%${q}%`)
+          .limit(20);
+        if (!cancelled) setSkuResults((data as Sku[]) ?? []);
+      } finally {
+        if (!cancelled) setSearchingSku(false);
+      }
     }, 250);
     return () => { cancelled = true; clearTimeout(t); };
   }, [skuQuery, skuOpen]);
@@ -418,8 +432,9 @@ function RuleEditModal({
                 onFocus={() => { setSkuOpen(true); setSkuQuery(""); }}
                 onChange={(e) => { setSkuOpen(true); setSkuQuery(e.target.value); }}
                 placeholder="搜尋 SKU / 商品名稱…"
-                className={`${inputCls} w-full`}
+                className={`${inputCls} w-full pr-8`}
               />
+              <SearchSpinner active={searchingSku} />
               {skuOpen && skuResults.length > 0 && (
                 <ul className="absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded-md border border-zinc-300 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
                   {skuResults.map((s) => (

--- a/apps/admin/src/app/(protected)/inventory/stocktake/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/stocktake/page.tsx
@@ -7,6 +7,7 @@ import { getSupabase } from "@/lib/supabase";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 import { useUserBranchStoreId, useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 import { translateRpcError } from "@/lib/rpcError";
 
@@ -208,6 +209,7 @@ function CreateStocktakeModal({
   const [picked, setPicked] = useState<Sku[]>([]);
   const [skuQuery, setSkuQuery] = useState("");
   const [skuResults, setSkuResults] = useState<Sku[]>([]);
+  const [searching, setSearching] = useState(false);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -217,13 +219,18 @@ function CreateStocktakeModal({
 
   useEffect(() => {
     const q = skuQuery.replace(/[,()%*]/g, " ").trim();
-    if (q.length < 1) { setSkuResults([]); return; }
+    if (q.length < 1) { setSkuResults([]); setSearching(false); return; }
     let cancelled = false;
+    setSearching(true);
     const t = setTimeout(async () => {
-      const { data } = await getSupabase().from("skus")
-        .select("id, sku_code, product_name, variant_name")
-        .or(`sku_code.ilike.%${q}%,product_name.ilike.%${q}%,variant_name.ilike.%${q}%`).limit(15);
-      if (!cancelled) setSkuResults((data as Sku[]) ?? []);
+      try {
+        const { data } = await getSupabase().from("skus")
+          .select("id, sku_code, product_name, variant_name")
+          .or(`sku_code.ilike.%${q}%,product_name.ilike.%${q}%,variant_name.ilike.%${q}%`).limit(15);
+        if (!cancelled) setSkuResults((data as Sku[]) ?? []);
+      } finally {
+        if (!cancelled) setSearching(false);
+      }
     }, 250);
     return () => { cancelled = true; clearTimeout(t); };
   }, [skuQuery]);
@@ -288,7 +295,10 @@ function CreateStocktakeModal({
                 ))}
               </div>
             )}
-            <input value={skuQuery} onChange={(e) => setSkuQuery(e.target.value)} placeholder="搜尋 SKU / 商品名稱…" className={inputCls} />
+            <div className="relative">
+              <input value={skuQuery} onChange={(e) => setSkuQuery(e.target.value)} placeholder="搜尋 SKU / 商品名稱…" className={`${inputCls} w-full pr-8`} />
+              <SearchSpinner active={searching} />
+            </div>
             {skuResults.length > 0 && (
               <ul className="max-h-48 overflow-y-auto rounded-md border border-zinc-300 dark:border-zinc-700">
                 {skuResults.filter((s) => !picked.some((p) => p.id === s.id)).map((s) => (

--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -9,6 +9,7 @@ import { Modal } from "@/components/Modal";
 import { MemberForm, type MemberFormValues } from "@/components/MemberForm";
 import { MemberDetail } from "@/components/MemberDetail";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow } from "@/components/DataTable";
 import type { OrderStatus } from "@/lib/orderStatus";
 
@@ -78,6 +79,7 @@ function MembersListBody() {
 
   const [queryDraft, setQueryDraft] = useState("");
   const [query, setQuery] = useState("");
+  const [searching, setSearching] = useState(false);
   const [storeId, setStoreId] = useState<string>("");
   const [sortBy, setSortBy] = useState<SortKey>("updated_at");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -110,12 +112,14 @@ function MembersListBody() {
   }, [idFromUrl]);
 
   useEffect(() => {
+    // 草稿與已套用的搜尋字串不同時，代表 debounce 後會觸發一次新查詢 → 開轉圈圈
+    setSearching((prev) => (queryDraft !== query ? true : prev));
     const t = setTimeout(() => {
       setQuery(queryDraft);
       setPage(1);
     }, 250);
     return () => clearTimeout(t);
-  }, [queryDraft]);
+  }, [queryDraft, query]);
 
   useEffect(() => {
     setPage(1);
@@ -279,7 +283,10 @@ function MembersListBody() {
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+          setSearching(false);
+        }
       }
     })();
     return () => {
@@ -325,13 +332,16 @@ function MembersListBody() {
       </header>
 
       <div className="grid gap-3 sm:grid-cols-2">
-        <input
-          type="search"
-          placeholder="搜尋 會員編號 / 姓名 / 手機"
-          value={queryDraft}
-          onChange={(e) => setQueryDraft(e.target.value)}
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
-        />
+        <div className="relative">
+          <input
+            type="search"
+            placeholder="搜尋 會員編號 / 姓名 / 手機"
+            value={queryDraft}
+            onChange={(e) => setQueryDraft(e.target.value)}
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 pr-8 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <SearchSpinner active={searching} />
+        </div>
         <select
           value={storeId}
           onChange={(e) => setStoreId(e.target.value)}

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -15,6 +15,7 @@ import { ORDER_STATUS_LABEL as STATUS_LABEL, type OrderStatus } from "@/lib/orde
 import { summarizeOrderSource } from "@/lib/orderSource";
 import { OrderSourceBadge } from "@/components/OrderSourceBadge";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 
 type Row = {
   id: number;
@@ -135,6 +136,7 @@ function OrdersListContent() {
   const [keyword, setKeyword] = useState(initialKeyword);
   const [campaignPickerOpen, setCampaignPickerOpen] = useState(false);
   const [campaignSearch, setCampaignSearch] = useState("");
+  const [searchingCampaign, setSearchingCampaign] = useState(false);
 
   // dropdownIds: 目前下拉清單顯示的開團 id 序（最新 20 / 搜尋結果），由 effect 寫入
   const [dropdownIds, setDropdownIds] = useState<number[]>([]);
@@ -191,23 +193,28 @@ function OrdersListContent() {
   // 下拉清單：預設 start_at desc 前 20 筆；有搜尋字串時 ilike + 50 筆
   // 用 setTimeout 250ms debounce 避免每個字打進去都打一次 server
   useEffect(() => {
+    setSearchingCampaign(true);
     const t = setTimeout(async () => {
-      const sb = getSupabase();
-      const kw = campaignSearch.trim();
-      let q = sb
-        .from("group_buy_campaigns")
-        .select("id, campaign_no, name, cover_image_url, start_at")
-        .order("start_at", { ascending: false, nullsFirst: false });
-      if (kw) {
-        const safe = kw.replace(/[%,()]/g, " ");
-        q = q.or(`name.ilike.%${safe}%,campaign_no.ilike.%${safe}%`).limit(50);
-      } else {
-        q = q.limit(20);
+      try {
+        const sb = getSupabase();
+        const kw = campaignSearch.trim();
+        let q = sb
+          .from("group_buy_campaigns")
+          .select("id, campaign_no, name, cover_image_url, start_at")
+          .order("start_at", { ascending: false, nullsFirst: false });
+        if (kw) {
+          const safe = kw.replace(/[%,()]/g, " ");
+          q = q.or(`name.ilike.%${safe}%,campaign_no.ilike.%${safe}%`).limit(50);
+        } else {
+          q = q.limit(20);
+        }
+        const { data } = await q;
+        const list = (data as Campaign[]) ?? [];
+        setDropdownIds(list.map((c) => c.id));
+        mergeCampaigns(list);
+      } finally {
+        setSearchingCampaign(false);
       }
-      const { data } = await q;
-      const list = (data as Campaign[]) ?? [];
-      setDropdownIds(list.map((c) => c.id));
-      mergeCampaigns(list);
     }, 250);
     return () => clearTimeout(t);
   }, [campaignSearch]);
@@ -702,13 +709,16 @@ function OrdersListContent() {
                     關閉
                   </SpinButton>
                 </div>
-                <input
-                  type="search"
-                  value={campaignSearch}
-                  onChange={(e) => setCampaignSearch(e.target.value)}
-                  placeholder="搜尋開團編號 / 名稱"
-                  className="mt-2 w-full rounded border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-                />
+                <div className="relative mt-2">
+                  <input
+                    type="search"
+                    value={campaignSearch}
+                    onChange={(e) => setCampaignSearch(e.target.value)}
+                    placeholder="搜尋開團編號 / 名稱"
+                    className="w-full rounded border border-zinc-300 bg-white px-2 py-1 pr-8 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                  />
+                  <SearchSpinner active={searchingCampaign} />
+                </div>
               </div>
               {(() => {
                 // 顯示順序：已勾選的開團釘在最上面（避免搜尋字串改變後不見），再放下拉結果

--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -10,6 +10,7 @@ import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultS
 import { ORDER_STATUSES, ORDER_STATUS_LABEL, type OrderStatus } from "@/lib/orderStatus";
 import { type CampaignStatus } from "@/lib/campaignStatus";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 
 type Campaign = {
   id: number;
@@ -173,6 +174,7 @@ function PivotContent() {
   const [campaignPickerOpen, setCampaignPickerOpen] = useState(false);
   const [statusPickerOpen, setStatusPickerOpen] = useState(false);
   const [campaignSearch, setCampaignSearch] = useState("");
+  const [searchingCampaign, setSearchingCampaign] = useState(false);
   // dropdownIds: 下拉清單顯示的 id 序（最新 20 / 搜尋結果）；campaigns 為已知 cache（dedupe）
   const [dropdownIds, setDropdownIds] = useState<number[]>([]);
 
@@ -301,23 +303,28 @@ function PivotContent() {
 
   // 下拉清單：預設 start_at desc 前 20 筆；有搜尋字串時 ilike + 50 筆（debounce 250ms）
   useEffect(() => {
+    setSearchingCampaign(true);
     const t = setTimeout(async () => {
-      const sb = getSupabase();
-      const kw = campaignSearch.trim();
-      let q = sb
-        .from("group_buy_campaigns")
-        .select("id, campaign_no, name, status, start_at, end_at")
-        .order("start_at", { ascending: false, nullsFirst: false });
-      if (kw) {
-        const safe = kw.replace(/[%,()]/g, " ");
-        q = q.or(`name.ilike.%${safe}%,campaign_no.ilike.%${safe}%`).limit(50);
-      } else {
-        q = q.limit(20);
+      try {
+        const sb = getSupabase();
+        const kw = campaignSearch.trim();
+        let q = sb
+          .from("group_buy_campaigns")
+          .select("id, campaign_no, name, status, start_at, end_at")
+          .order("start_at", { ascending: false, nullsFirst: false });
+        if (kw) {
+          const safe = kw.replace(/[%,()]/g, " ");
+          q = q.or(`name.ilike.%${safe}%,campaign_no.ilike.%${safe}%`).limit(50);
+        } else {
+          q = q.limit(20);
+        }
+        const { data } = await q;
+        const list = (data as Campaign[]) ?? [];
+        setDropdownIds(list.map((c) => c.id));
+        mergeCampaigns(list);
+      } finally {
+        setSearchingCampaign(false);
       }
-      const { data } = await q;
-      const list = (data as Campaign[]) ?? [];
-      setDropdownIds(list.map((c) => c.id));
-      mergeCampaigns(list);
     }, 250);
     return () => clearTimeout(t);
   }, [campaignSearch]);
@@ -620,13 +627,16 @@ function PivotContent() {
                     關閉
                   </SpinButton>
                 </div>
-                <input
-                  type="search"
-                  value={campaignSearch}
-                  onChange={(e) => setCampaignSearch(e.target.value)}
-                  placeholder="搜尋開團編號 / 名稱"
-                  className="mt-2 w-full rounded border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-                />
+                <div className="relative mt-2">
+                  <input
+                    type="search"
+                    value={campaignSearch}
+                    onChange={(e) => setCampaignSearch(e.target.value)}
+                    placeholder="搜尋開團編號 / 名稱"
+                    className="w-full rounded border border-zinc-300 bg-white px-2 py-1 pr-8 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                  />
+                  <SearchSpinner active={searchingCampaign} />
+                </div>
               </div>
               {(() => {
                 // 已勾選的開團釘在最上面（避免搜尋字串改變後不見），再放下拉結果

--- a/apps/admin/src/app/(protected)/products/page.tsx
+++ b/apps/admin/src/app/(protected)/products/page.tsx
@@ -11,6 +11,7 @@ import { ProductSkuSection, type ProductSkuSectionHandle } from "@/components/Pr
 import { ProductCampaignsPanel } from "@/components/ProductCampaignsPanel";
 import { CreateCampaignModal, type SelectedProduct, type StorageType } from "@/components/CreateCampaignModal";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow } from "@/components/DataTable";
 
 type Status = "draft" | "active" | "inactive" | "discontinued";
@@ -65,6 +66,7 @@ function PageContent() {
   // filters
   const [queryDraft, setQueryDraft] = useState("");
   const [query, setQuery] = useState("");
+  const [searching, setSearching] = useState(false);
   const [categoryId, setCategoryId] = useState<string>("");
   const [brandId, setBrandId] = useState<string>("");
   const [status, setStatus] = useState<string>("");
@@ -231,9 +233,11 @@ function PageContent() {
 
   // debounce search
   useEffect(() => {
+    // 草稿與已套用的搜尋字串不同時，代表 debounce 後會觸發一次新查詢 → 開轉圈圈
+    setSearching((prev) => (queryDraft !== query ? true : prev));
     const t = setTimeout(() => { setQuery(queryDraft); setPage(1); }, 250);
     return () => clearTimeout(t);
-  }, [queryDraft]);
+  }, [queryDraft, query]);
 
   // reset page when filter changes
   useEffect(() => { setPage(1); }, [categoryId, brandId, status, sortBy, sortDir]);
@@ -302,7 +306,10 @@ function PageContent() {
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+          setSearching(false);
+        }
       }
     })();
     return () => { cancelled = true; };
@@ -418,13 +425,16 @@ function PageContent() {
       )}
 
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <input
-          type="search"
-          placeholder="搜尋 編號 / 名稱 / 簡稱"
-          value={queryDraft}
-          onChange={(e) => setQueryDraft(e.target.value)}
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
-        />
+        <div className="relative">
+          <input
+            type="search"
+            placeholder="搜尋 編號 / 名稱 / 簡稱"
+            value={queryDraft}
+            onChange={(e) => setQueryDraft(e.target.value)}
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 pr-8 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <SearchSpinner active={searching} />
+        </div>
         <select
           value={categoryId}
           onChange={(e) => setCategoryId(e.target.value)}

--- a/apps/admin/src/app/(protected)/restock/new/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/new/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { useRole, canSeeBranch } from "@/lib/role";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 
 type Store = { id: number; code: string; name: string };
 
@@ -178,47 +179,56 @@ function LineRow({
   const [open, setOpen] = useState(false);
   const [term, setTerm] = useState("");
   const [opts, setOpts] = useState<SkuOption[]>([]);
+  const [searching, setSearching] = useState(false);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
     const t = setTimeout(async () => {
-      const sb = getSupabase();
-      let q = sb
-        .from("skus")
-        .select("id, sku_code, variant_name, product_id, products!inner(id, name, is_virtual)")
-        .eq("status", "active")
-        .eq("products.is_virtual", false)
-        .limit(15);
-      const safe = term.replace(/[%,()]/g, " ").trim();
-      if (safe) q = q.or(`sku_code.ilike.%${safe}%,variant_name.ilike.%${safe}%`);
-      const { data } = await q;
-      const ids = (data ?? []).map((r) => r.id);
-      let priceMap = new Map<number, { retail?: number; branch?: number }>();
-      if (ids.length > 0) {
-        const { data: priceRows } = await sb
-          .from("prices")
-          .select("sku_id, scope, price")
-          .in("sku_id", ids)
-          .in("scope", ["retail", "branch"])
-          .is("effective_to", null);
-        for (const p of (priceRows ?? []) as { sku_id: number; scope: string; price: number }[]) {
-          const slot = priceMap.get(p.sku_id) ?? {};
-          if (p.scope === "retail" && slot.retail === undefined) slot.retail = Number(p.price);
-          if (p.scope === "branch" && slot.branch === undefined) slot.branch = Number(p.price);
-          priceMap.set(p.sku_id, slot);
+      try {
+        const sb = getSupabase();
+        let q = sb
+          .from("skus")
+          .select("id, sku_code, variant_name, product_id, products!inner(id, name, is_virtual)")
+          .eq("status", "active")
+          .eq("products.is_virtual", false)
+          .limit(15);
+        const safe = term.replace(/[%,()]/g, " ").trim();
+        if (safe) q = q.or(`sku_code.ilike.%${safe}%,variant_name.ilike.%${safe}%`);
+        const { data } = await q;
+        const ids = (data ?? []).map((r) => r.id);
+        let priceMap = new Map<number, { retail?: number; branch?: number }>();
+        if (ids.length > 0) {
+          const { data: priceRows } = await sb
+            .from("prices")
+            .select("sku_id, scope, price")
+            .in("sku_id", ids)
+            .in("scope", ["retail", "branch"])
+            .is("effective_to", null);
+          for (const p of (priceRows ?? []) as { sku_id: number; scope: string; price: number }[]) {
+            const slot = priceMap.get(p.sku_id) ?? {};
+            if (p.scope === "retail" && slot.retail === undefined) slot.retail = Number(p.price);
+            if (p.scope === "branch" && slot.branch === undefined) slot.branch = Number(p.price);
+            priceMap.set(p.sku_id, slot);
+          }
         }
+        setOpts(
+          ((data ?? []) as unknown as Array<{
+            id: number; sku_code: string; variant_name: string | null; product_id: number;
+            products: { id: number; name: string; is_virtual: boolean };
+          }>).map((s) => ({
+            id: s.id, sku_code: s.sku_code, variant_name: s.variant_name,
+            product_id: s.product_id, product_name: s.products.name,
+            retail_price: priceMap.get(s.id)?.retail ?? null,
+            branch_price: priceMap.get(s.id)?.branch ?? null,
+          }))
+        );
+      } finally {
+        setSearching(false);
       }
-      setOpts(
-        ((data ?? []) as unknown as Array<{
-          id: number; sku_code: string; variant_name: string | null; product_id: number;
-          products: { id: number; name: string; is_virtual: boolean };
-        }>).map((s) => ({
-          id: s.id, sku_code: s.sku_code, variant_name: s.variant_name,
-          product_id: s.product_id, product_name: s.products.name,
-          retail_price: priceMap.get(s.id)?.retail ?? null,
-          branch_price: priceMap.get(s.id)?.branch ?? null,
-        }))
-      );
     }, 200);
     return () => clearTimeout(t);
   }, [term, open]);
@@ -235,8 +245,9 @@ function LineRow({
             setOpen(true);
           }}
           placeholder="搜尋商品 / 品項"
-          className="w-full rounded border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          className="w-full rounded border border-zinc-300 bg-white px-2 py-1 pr-8 text-sm dark:border-zinc-700 dark:bg-zinc-800"
         />
+        <SearchSpinner active={searching} />
         {open && opts.length > 0 && (
           <div className="absolute left-0 top-full z-10 mt-1 max-h-60 w-96 overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800" onMouseLeave={() => setOpen(false)}>
             {opts.map((o) => {

--- a/apps/admin/src/app/(protected)/stores/page.tsx
+++ b/apps/admin/src/app/(protected)/stores/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 
 const PAGE_SIZE = 20;
@@ -52,6 +53,7 @@ export default function StoresPage() {
   const [locations, setLocations] = useState<Location[]>([]);
   const [queryDraft, setQueryDraft] = useState("");
   const [query, setQuery] = useState("");
+  const [searching, setSearching] = useState(false);
   const [activeFilter, setActiveFilter] = useState<ActiveFilter>("active");
   const [leleFilter, setLeleFilter] = useState<LeleFilter>("all");
   const [error, setError] = useState<string | null>(null);
@@ -60,9 +62,11 @@ export default function StoresPage() {
   const [page, setPage] = useState(1);
 
   useEffect(() => {
+    // 草稿與已套用的搜尋字串不同時，代表 debounce 後會觸發一次新查詢 → 開轉圈圈
+    setSearching((prev) => (queryDraft !== query ? true : prev));
     const t = setTimeout(() => setQuery(queryDraft), 250);
     return () => clearTimeout(t);
-  }, [queryDraft]);
+  }, [queryDraft, query]);
 
   useEffect(() => { setPage(1); }, [query, activeFilter, leleFilter]);
 
@@ -95,10 +99,14 @@ export default function StoresPage() {
     else if (activeFilter === "deleted") q = q.not("deleted_at", "is", null);
     if (leleFilter === "lele_only") q = q.like("code", "LELE-%");
     else if (leleFilter === "exclude_lele") q = q.not("code", "like", "LELE-%");
-    const { data, error: err } = await q;
-    if (err) { setError(err.message); return; }
-    setError(null);
-    setRows((data ?? []) as Store[]);
+    try {
+      const { data, error: err } = await q;
+      if (err) { setError(err.message); return; }
+      setError(null);
+      setRows((data ?? []) as Store[]);
+    } finally {
+      setSearching(false);
+    }
   }
   useEffect(() => { reload(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [query, activeFilter, leleFilter]);
 
@@ -197,13 +205,16 @@ export default function StoresPage() {
       )}
 
       <div className="grid gap-3 sm:grid-cols-3">
-        <input
-          type="search"
-          value={queryDraft}
-          onChange={(e) => setQueryDraft(e.target.value)}
-          placeholder="搜尋 代碼 / 名稱"
-          className={inputCls}
-        />
+        <div className="relative">
+          <input
+            type="search"
+            value={queryDraft}
+            onChange={(e) => setQueryDraft(e.target.value)}
+            placeholder="搜尋 代碼 / 名稱"
+            className={`${inputCls} w-full pr-8`}
+          />
+          <SearchSpinner active={searching} />
+        </div>
         <select
           value={activeFilter}
           onChange={(e) => setActiveFilter(e.target.value as ActiveFilter)}

--- a/apps/admin/src/app/(protected)/suppliers/page.tsx
+++ b/apps/admin/src/app/(protected)/suppliers/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 
 const PAGE_SIZE = 20;
@@ -32,6 +33,7 @@ export default function SuppliersPage() {
   const [rows, setRows] = useState<Supplier[] | null>(null);
   const [queryDraft, setQueryDraft] = useState("");
   const [query, setQuery] = useState("");
+  const [searching, setSearching] = useState(false);
   const [showActive, setShowActive] = useState<"all" | "active">("active");
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState<Supplier | null>(null);
@@ -39,9 +41,11 @@ export default function SuppliersPage() {
   const [page, setPage] = useState(1);
 
   useEffect(() => {
+    // 草稿與已套用的搜尋字串不同時，代表 debounce 後會觸發一次新查詢 → 開轉圈圈
+    setSearching((prev) => (queryDraft !== query ? true : prev));
     const t = setTimeout(() => setQuery(queryDraft), 250);
     return () => clearTimeout(t);
-  }, [queryDraft]);
+  }, [queryDraft, query]);
 
   useEffect(() => { setPage(1); }, [query, showActive]);
 
@@ -62,9 +66,13 @@ export default function SuppliersPage() {
       q = q.or(`code.ilike.%${safe}%,name.ilike.%${safe}%`);
     }
     if (showActive === "active") q = q.eq("is_active", true);
-    const { data, error: err } = await q;
-    if (err) setError(err.message);
-    else { setError(null); setRows((data as Supplier[]) ?? []); }
+    try {
+      const { data, error: err } = await q;
+      if (err) setError(err.message);
+      else { setError(null); setRows((data as Supplier[]) ?? []); }
+    } finally {
+      setSearching(false);
+    }
   };
   useEffect(() => { reload(); }, [query, showActive]);
 
@@ -118,11 +126,14 @@ export default function SuppliersPage() {
       )}
 
       <div className="grid gap-3 sm:grid-cols-2">
-        <input
-          type="search" value={queryDraft} onChange={(e) => setQueryDraft(e.target.value)}
-          placeholder="搜尋 code / 名稱"
-          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
-        />
+        <div className="relative">
+          <input
+            type="search" value={queryDraft} onChange={(e) => setQueryDraft(e.target.value)}
+            placeholder="搜尋 code / 名稱"
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 pr-8 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <SearchSpinner active={searching} />
+        </div>
         <select value={showActive} onChange={(e) => setShowActive(e.target.value as "all" | "active")}
           className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
           <option value="active">僅啟用中</option>

--- a/apps/admin/src/components/OrderTransferModal.tsx
+++ b/apps/admin/src/components/OrderTransferModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { Modal } from "@/components/Modal";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
 
 type Store = { id: number; name: string; code: string };
 type MemberHit = {
@@ -41,6 +42,7 @@ export function OrderTransferModal({
   const [term, setTerm] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
   const [results, setResults] = useState<MemberHit[]>([]);
+  const [searching, setSearching] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchWrapRef = useRef<HTMLDivElement | null>(null);
   const [reason, setReason] = useState("");
@@ -77,14 +79,22 @@ export function OrderTransferModal({
   // debounced rpc_search_members (same RPC used by member page / order entry)
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (term.length < 1 && !searchOpen) return;
+    if (term.length < 1 && !searchOpen) {
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
     debounceRef.current = setTimeout(async () => {
-      const sb = getSupabase();
-      const { data } = await sb.rpc("rpc_search_members", {
-        p_term: term,
-        p_limit: 10,
-      });
-      setResults((data as MemberHit[] | null) ?? []);
+      try {
+        const sb = getSupabase();
+        const { data } = await sb.rpc("rpc_search_members", {
+          p_term: term,
+          p_limit: 10,
+        });
+        setResults((data as MemberHit[] | null) ?? []);
+      } finally {
+        setSearching(false);
+      }
     }, 200);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -182,8 +192,9 @@ export function OrderTransferModal({
                   setSearchOpen(true);
                 }}
                 placeholder="搜尋 會員編號 / 姓名 / 手機"
-                className="w-full rounded-md border border-zinc-300 bg-white px-2 py-1 dark:border-zinc-700 dark:bg-zinc-800"
+                className="w-full rounded-md border border-zinc-300 bg-white px-2 py-1 pr-8 dark:border-zinc-700 dark:bg-zinc-800"
               />
+              <SearchSpinner active={searching} />
               {searchOpen && (
                 <div className="absolute left-0 right-0 top-full z-20 mt-1 max-h-80 overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800">
                   <SpinButton

--- a/apps/admin/src/components/SearchSpinner.tsx
+++ b/apps/admin/src/components/SearchSpinner.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+/**
+ * 搜尋進行中的轉圈圈 indicator。
+ * 放在 `relative` 的搜尋輸入框容器內，預設貼齊右側垂直置中。
+ * active=false 時不渲染任何東西。
+ */
+export default function SearchSpinner({
+  active,
+  className = "",
+}: {
+  active: boolean;
+  className?: string;
+}) {
+  if (!active) return null;
+  return (
+    <span
+      className={`pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-zinc-400 ${className}`}
+      aria-label="搜尋中"
+      role="status"
+    >
+      <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden>
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="3"
+          className="opacity-25"
+        />
+        <path
+          d="M4 12a8 8 0 0 1 8-8"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+        />
+      </svg>
+    </span>
+  );
+}


### PR DESCRIPTION
新增可重用的 SearchSpinner 元件，套用到所有「打字觸發 async 後端查詢」的搜尋框：
加單（會員/暱稱/手機 + 商品）、會員、商品、廠商、分店、訂單/樞紐開團選擇、
開團、社團候選、FB 粉專、補貨、庫存/互助/補貨規則/盤點、轉單 modal。

搜尋發出查詢時顯示轉圈圈，查詢結束（finally）關閉，早退路徑一律清掉避免卡住。
純前端 filter 的搜尋框不加。