### PR TITLE
fix(pickup): 取貨對話框狀態欄顯示中文（pending → 待取貨…）

### DIFF
--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -8,6 +8,7 @@ import { printViaIframe } from "@/lib/printIframe";
 import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
 import { EditableDiscount, deriveDiscount, type DiscountValue } from "@/components/EditableDiscount";
+import { orderItemStatusLabel } from "@/lib/orderStatus";
 
 type PickableItem = {
   id: number;
@@ -403,7 +404,7 @@ export function PickupDialog({
                       <td className="px-3 py-2 text-xs text-zinc-500">
                         {fullyReturned
                           ? <span className="rounded bg-orange-100 px-1.5 py-0.5 font-medium text-orange-800 dark:bg-orange-950 dark:text-orange-300">已退貨・不能取貨</span>
-                          : it.status}
+                          : orderItemStatusLabel(it.status)}
                       </td>
                     </tr>
                   );

--- a/apps/admin/src/lib/orderStatus.ts
+++ b/apps/admin/src/lib/orderStatus.ts
@@ -46,6 +46,23 @@ export function orderStatusLabel(s: string | null | undefined): string {
   return ORDER_STATUS_LABEL[s as OrderStatus] ?? s;
 }
 
+// customer_order_items.status 的中文 label（與 orders.status 是不同集合）。
+// pending/reserved/ready 都是「尚未取貨」的細分；picked_up=已取貨。
+export const ORDER_ITEM_STATUS_LABEL: Record<string, string> = {
+  pending:   "待取貨",
+  reserved:  "已備貨",
+  ready:     "可取貨",
+  picked_up: "已取貨",
+  cancelled: "已取消",
+  expired:   "已過期",
+};
+
+/** customer_order_items.status 取中文 label；未知直接 fallback 原字串。 */
+export function orderItemStatusLabel(s: string | null | undefined): string {
+  if (!s) return "—";
+  return ORDER_ITEM_STATUS_LABEL[s] ?? s;
+}
+
 const TERMINAL_STATUSES = new Set<string>([
   "completed",
   "cancelled",


### PR DESCRIPTION
## 內容（承 #417，已 merge）
取貨對話框狀態欄原本直接印 `customer_order_items.status` 英文原值。

- 新增 `orderItemStatusLabel`（[`orderStatus.ts`](apps/admin/src/lib/orderStatus.ts)，single source of truth）：`pending`=待取貨 / `reserved`=已備貨 / `ready`=可取貨 / `picked_up`=已取貨 / `cancelled`=已取消 / `expired`=已過期
- 狀態欄不再顯示英文；全退品項維持「已退貨・不能取貨」

## Test plan
- [ ] 取貨對話框狀態欄顯示「待取貨」等中文、不再是 pending
- [ ] 全退品項仍顯示「已退貨・不能取貨」
- [ ] tsc ✅（基於最新 main）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
