### PR TITLE
採購單頁面加上「刪除」與「斷貨」按鈕

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/orders/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/edit/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { SendPOModal } from "@/components/SendPOModal";
 import SpinButton from "@/components/SpinButton";
@@ -33,6 +33,8 @@ type POHeader = {
   sent_at: string | null;
   sent_by: string | null;
   sent_channel: string | null;
+  stockout_at: string | null;
+  stockout_reason: string | null;
   created_by: string | null;
   created_at: string | null;
   updated_at: string | null;
@@ -64,6 +66,7 @@ export default function EditPurchaseOrderPage() {
 }
 
 function PageContent() {
+  const router = useRouter();
   const params = useSearchParams();
   const idStr = params.get("id");
   const id = idStr ? Number(idStr) : null;
@@ -84,7 +87,7 @@ function PageContent() {
         supabase
           .from("purchase_orders")
           .select(
-            "id, po_no, status, supplier_id, dest_location_id, order_date, expected_date, subtotal, total, payment_terms, notes, sent_at, sent_by, sent_channel, created_by, created_at, updated_at",
+            "id, po_no, status, supplier_id, dest_location_id, order_date, expected_date, subtotal, total, payment_terms, notes, sent_at, sent_by, sent_channel, stockout_at, stockout_reason, created_by, created_at, updated_at",
           )
           .eq("id", id)
           .maybeSingle(),
@@ -172,6 +175,61 @@ function PageContent() {
 
   const editable = header?.status === "draft";
   const canSend = header?.status === "draft";
+  const canStockout =
+    header?.status === "sent" || header?.status === "partially_received";
+  const canDelete =
+    header?.status === "draft" ||
+    header?.status === "sent" ||
+    header?.status === "cancelled";
+
+  async function markStockout() {
+    if (!header) return;
+    const reason = window.prompt(
+      `將 ${header.po_no} 標記為「斷貨」？\n供應商無法供貨時使用：未到貨的數量不再等待，單據直接結掉。\n\n可填寫斷貨原因（可留空）：`,
+    );
+    if (reason === null) return;
+    try {
+      const supabase = getSupabase();
+      const { data: userData } = await supabase.auth.getUser();
+      const { error: rpcErr } = await supabase.rpc(
+        "rpc_stockout_purchase_order",
+        {
+          p_po_id: header.id,
+          p_operator: userData.user?.id,
+          p_reason: reason || null,
+        },
+      );
+      if (rpcErr) throw new Error(rpcErr.message);
+      await reload();
+    } catch (e) {
+      alert(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function deletePO() {
+    if (!header) return;
+    if (
+      !window.confirm(
+        `確定要刪除 ${header.po_no}？\n刪除後無法復原；來源請購單的品項會解除連結、可重新拆單。`,
+      )
+    )
+      return;
+    try {
+      const supabase = getSupabase();
+      const { data: userData } = await supabase.auth.getUser();
+      const { error: rpcErr } = await supabase.rpc(
+        "rpc_delete_purchase_order",
+        {
+          p_po_id: header.id,
+          p_operator: userData.user?.id,
+        },
+      );
+      if (rpcErr) throw new Error(rpcErr.message);
+      router.replace("/purchase/orders");
+    } catch (e) {
+      alert(e instanceof Error ? e.message : String(e));
+    }
+  }
   const totalReceived = items.reduce((s, r) => s + r.qty_received, 0);
   const totalOrdered = items.reduce((s, r) => s + r.qty_ordered, 0);
   const recvPct = totalOrdered > 0 ? (totalReceived / totalOrdered) * 100 : 0;
@@ -248,7 +306,34 @@ function PageContent() {
                   {header.sent_at && new Date(header.sent_at).toLocaleString("zh-TW")}
                 </div>
               )}
-              {!editable && !canSend && (
+              {canStockout && (
+                <SpinButton
+                  onClick={markStockout}
+                  className="rounded-md border border-amber-400 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-300 dark:hover:bg-amber-900"
+                >
+                  ⛔ 標記斷貨
+                </SpinButton>
+              )}
+              {canDelete && (
+                <SpinButton
+                  onClick={deletePO}
+                  className="rounded-md border border-red-400 bg-red-50 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-100 dark:border-red-700 dark:bg-red-950 dark:text-red-300 dark:hover:bg-red-900"
+                >
+                  🗑 刪除{PO_TERM_ZH}
+                </SpinButton>
+              )}
+              {header.stockout_at && (
+                <div className="rounded-md border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
+                  ⛔ 已斷貨：{new Date(header.stockout_at).toLocaleString("zh-TW")}
+                  {header.stockout_reason && (
+                    <>
+                      <br />
+                      原因：{header.stockout_reason}
+                    </>
+                  )}
+                </div>
+              )}
+              {!editable && !canSend && !canStockout && !canDelete && (
                 <p className="text-xs text-zinc-500">此{PO_TERM_ZH}已 {STATUS_LABEL(header.status)}。</p>
               )}
             </div>

--- a/apps/admin/src/app/(protected)/purchase/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/page.tsx
@@ -43,6 +43,7 @@ type PO = {
   expected_date: string | null;
   sent_at: string | null;
   sent_channel: string | null;
+  stockout_at: string | null;
   created_at: string;
   updated_at: string;
   pr_id: number | null;
@@ -106,7 +107,7 @@ export default function PurchaseOrdersListPage() {
         const { data: poData, error: poErr } = await supabase
           .from("purchase_orders")
           .select(
-            "id, po_no, supplier_id, status, total, expected_date, sent_at, sent_channel, created_at, updated_at, suppliers(name)",
+            "id, po_no, supplier_id, status, total, expected_date, sent_at, sent_channel, stockout_at, created_at, updated_at, suppliers(name)",
           )
           .order("updated_at", { ascending: false })
           .limit(500);
@@ -122,6 +123,7 @@ export default function PurchaseOrdersListPage() {
           expected_date: string | null;
           sent_at: string | null;
           sent_channel: string | null;
+          stockout_at: string | null;
           created_at: string;
           updated_at: string;
           suppliers: { name: string } | { name: string }[] | null;
@@ -138,6 +140,7 @@ export default function PurchaseOrdersListPage() {
             expected_date: r.expected_date,
             sent_at: r.sent_at,
             sent_channel: r.sent_channel,
+            stockout_at: r.stockout_at,
             created_at: r.created_at,
             updated_at: r.updated_at,
             pr_id: null,
@@ -449,6 +452,53 @@ export default function PurchaseOrdersListPage() {
     }
   }
 
+  async function markStockout(po: PO) {
+    const reason = window.prompt(
+      `將 ${po.po_no} 標記為「斷貨」？\n供應商無法供貨時使用：未到貨的數量不再等待，單據直接結掉。\n\n可填寫斷貨原因（可留空）：`,
+    );
+    if (reason === null) return;
+    try {
+      const supabase = getSupabase();
+      const { data: userData } = await supabase.auth.getUser();
+      const { error: rpcErr } = await supabase.rpc(
+        "rpc_stockout_purchase_order",
+        {
+          p_po_id: po.id,
+          p_operator: userData.user?.id,
+          p_reason: reason || null,
+        },
+      );
+      if (rpcErr) throw new Error(rpcErr.message);
+      setReloadKey((k) => k + 1);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function deletePO(po: PO) {
+    if (
+      !window.confirm(
+        `確定要刪除 ${po.po_no}？\n刪除後無法復原；來源${PR_TERM_ZH}的品項會解除連結、可重新拆單。`,
+      )
+    )
+      return;
+    try {
+      const supabase = getSupabase();
+      const { data: userData } = await supabase.auth.getUser();
+      const { error: rpcErr } = await supabase.rpc(
+        "rpc_delete_purchase_order",
+        {
+          p_po_id: po.id,
+          p_operator: userData.user?.id,
+        },
+      );
+      if (rpcErr) throw new Error(rpcErr.message);
+      setReloadKey((k) => k + 1);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : String(e));
+    }
+  }
+
   function setSort(col: SortCol) {
     if (sortBy === col) {
       setSortDir((d) => (d === "asc" ? "desc" : "asc"));
@@ -703,6 +753,8 @@ export default function PurchaseOrdersListPage() {
                     key={p.id}
                     po={p}
                     onSend={openSendModal}
+                    onStockout={markStockout}
+                    onDelete={deletePO}
                     sendBusyId={sendBusyId}
                   />
                 )),
@@ -713,6 +765,8 @@ export default function PurchaseOrdersListPage() {
                   key={p.id}
                   po={p}
                   onSend={openSendModal}
+                  onStockout={markStockout}
+                  onDelete={deletePO}
                   sendBusyId={sendBusyId}
                 />
               ))
@@ -820,10 +874,14 @@ function KpiCard({
 function PORow({
   po,
   onSend,
+  onStockout,
+  onDelete,
   sendBusyId,
 }: {
   po: PO;
   onSend: (p: PO) => void;
+  onStockout: (p: PO) => Promise<void>;
+  onDelete: (p: PO) => Promise<void>;
   sendBusyId: number | null;
 }) {
   const overdue =
@@ -859,6 +917,14 @@ function PORow({
         >
           {STATUS_LABEL[po.status]}
         </span>
+        {po.stockout_at && (
+          <span
+            className="ml-1 inline-flex rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+            title={`斷貨於 ${new Date(po.stockout_at).toLocaleString("zh-TW")}`}
+          >
+            ⛔ 斷貨
+          </span>
+        )}
       </Td>
       <Td className="max-w-[220px]">
         {po.product_names.length === 0 ? (
@@ -940,6 +1006,18 @@ function PORow({
             >
               進貨
             </Link>
+          )}
+          {(po.status === "sent" || po.status === "partially_received") && (
+            <RowAction variant="warning" onClick={() => onStockout(po)}>
+              斷貨
+            </RowAction>
+          )}
+          {(po.status === "draft" ||
+            po.status === "sent" ||
+            po.status === "cancelled") && (
+            <RowAction variant="danger" onClick={() => onDelete(po)}>
+              刪除
+            </RowAction>
           )}
         </div>
       </Td>

--- a/supabase/migrations/20260702010000_po_delete_and_stockout.sql
+++ b/supabase/migrations/20260702010000_po_delete_and_stockout.sql
@@ -1,0 +1,167 @@
+-- ============================================================
+-- 採購單「刪除」+「斷貨」
+--
+-- 背景：
+--   1. 重複開到一樣的採購單，需要可以刪掉（draft / sent / cancelled、
+--      且尚無任何進貨紀錄時才允許）。
+--   2. 供應商斷貨時，未到貨的量不再等待，要能直接把 PO 結掉。
+--
+-- 基底版本：
+--   - rpc_delete_purchase_order / rpc_stockout_purchase_order 為全新函式，
+--     無既有版本（已 grep supabase/migrations/ 確認）。
+--   - purchase_orders 斷貨欄位為新增（stockout_at / stockout_by / stockout_reason）。
+--
+-- Rollback：
+--   DROP FUNCTION IF EXISTS public.rpc_delete_purchase_order(BIGINT, UUID);
+--   DROP FUNCTION IF EXISTS public.rpc_stockout_purchase_order(BIGINT, UUID, TEXT);
+--   ALTER TABLE purchase_orders
+--     DROP COLUMN IF EXISTS stockout_at,
+--     DROP COLUMN IF EXISTS stockout_by,
+--     DROP COLUMN IF EXISTS stockout_reason;
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. purchase_orders 斷貨欄位
+-- ------------------------------------------------------------
+
+ALTER TABLE purchase_orders
+  ADD COLUMN IF NOT EXISTS stockout_at     TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS stockout_by     UUID,
+  ADD COLUMN IF NOT EXISTS stockout_reason TEXT;
+
+COMMENT ON COLUMN purchase_orders.stockout_at IS
+  '標記斷貨的時間；NULL = 未斷貨。斷貨後 status 會轉 closed（已有部分到貨）或 cancelled（完全沒到貨）';
+
+-- ------------------------------------------------------------
+-- 2. RPC: rpc_delete_purchase_order
+--    硬刪除 PO（限 draft / sent / cancelled、且無任何進貨單）。
+--    來源 PR 品項解除 po_item_id 連結、PR 狀態回算，方便重新拆單。
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_delete_purchase_order(
+  p_po_id    BIGINT,
+  p_operator UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_po         purchase_orders%ROWTYPE;
+  v_gr_count   INTEGER;
+  v_wave_count INTEGER;
+  v_pr_ids     BIGINT[];
+BEGIN
+  SELECT * INTO v_po FROM purchase_orders WHERE id = p_po_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '找不到採購單 #%', p_po_id;
+  END IF;
+
+  IF v_po.status NOT IN ('draft','sent','cancelled') THEN
+    RAISE EXCEPTION '採購單 % 狀態為「%」、不可刪除（僅限草稿 / 已發送 / 已取消）',
+      v_po.po_no, v_po.status;
+  END IF;
+
+  SELECT COUNT(*) INTO v_gr_count FROM goods_receipts WHERE po_id = p_po_id;
+  IF v_gr_count > 0 THEN
+    RAISE EXCEPTION '採購單 % 已有 % 筆進貨紀錄、不可刪除', v_po.po_no, v_gr_count;
+  END IF;
+
+  SELECT COUNT(*) INTO v_wave_count FROM picking_waves WHERE source_po_id = p_po_id;
+  IF v_wave_count > 0 THEN
+    RAISE EXCEPTION '採購單 % 已建立 % 張撿貨單、不可刪除', v_po.po_no, v_wave_count;
+  END IF;
+
+  -- 解除來源 PR 品項連結（先記下受影響的 PR、稍後回算狀態）
+  SELECT ARRAY_AGG(DISTINCT pri.pr_id) INTO v_pr_ids
+    FROM purchase_request_items pri
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+   WHERE poi.po_id = p_po_id;
+
+  UPDATE purchase_request_items pri
+     SET po_item_id = NULL,
+         updated_by = p_operator,
+         updated_at = NOW()
+    FROM purchase_order_items poi
+   WHERE poi.id = pri.po_item_id
+     AND poi.po_id = p_po_id;
+
+  -- PR 狀態回算：還有其他 PO 連結 → partially_ordered；全無 → submitted
+  IF v_pr_ids IS NOT NULL THEN
+    UPDATE purchase_requests pr
+       SET status = CASE
+             WHEN EXISTS (
+               SELECT 1 FROM purchase_request_items x
+                WHERE x.pr_id = pr.id AND x.po_item_id IS NOT NULL
+             ) THEN 'partially_ordered'
+             ELSE 'submitted'
+           END,
+           updated_by = p_operator,
+           updated_at = NOW()
+     WHERE pr.id = ANY(v_pr_ids)
+       AND pr.status IN ('partially_ordered','fully_ordered');
+  END IF;
+
+  BEGIN
+    -- purchase_order_items 由 FK ON DELETE CASCADE 一併刪除
+    DELETE FROM purchase_orders WHERE id = p_po_id;
+  EXCEPTION WHEN foreign_key_violation THEN
+    RAISE EXCEPTION '採購單 % 已被其他單據引用（帳款 / 需求單等）、無法刪除', v_po.po_no;
+  END;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_delete_purchase_order TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_delete_purchase_order IS
+  '硬刪除 PO（限 draft/sent/cancelled、無進貨單與撿貨單）；解除來源 PR 品項連結並回算 PR 狀態';
+
+-- ------------------------------------------------------------
+-- 3. RPC: rpc_stockout_purchase_order
+--    供應商斷貨：未到貨的量不再等待。
+--    已有部分到貨 → closed；完全沒到貨 → cancelled。
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_stockout_purchase_order(
+  p_po_id    BIGINT,
+  p_operator UUID,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_po         purchase_orders%ROWTYPE;
+  v_received   NUMERIC(18,3);
+  v_new_status TEXT;
+BEGIN
+  SELECT * INTO v_po FROM purchase_orders WHERE id = p_po_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '找不到採購單 #%', p_po_id;
+  END IF;
+
+  IF v_po.status NOT IN ('sent','partially_received') THEN
+    RAISE EXCEPTION '採購單 % 狀態為「%」、不可標記斷貨（需為「已發送」或「部分到貨」）',
+      v_po.po_no, v_po.status;
+  END IF;
+
+  SELECT COALESCE(SUM(qty_received), 0) INTO v_received
+    FROM purchase_order_items
+   WHERE po_id = p_po_id;
+
+  v_new_status := CASE WHEN v_received > 0 THEN 'closed' ELSE 'cancelled' END;
+
+  UPDATE purchase_orders
+     SET status          = v_new_status,
+         stockout_at     = NOW(),
+         stockout_by     = p_operator,
+         stockout_reason = NULLIF(BTRIM(p_reason), ''),
+         updated_by      = p_operator,
+         updated_at      = NOW()
+   WHERE id = p_po_id;
+
+  RETURN jsonb_build_object('po_no', v_po.po_no, 'new_status', v_new_status);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_stockout_purchase_order TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_stockout_purchase_order IS
+  '供應商斷貨：sent/partially_received 的 PO 直接結掉（有到貨→closed、無到貨→cancelled），記錄 stockout_at/by/reason';


### PR DESCRIPTION
- 刪除：重複開單時可整張刪掉。限 draft/sent/cancelled 且無進貨、
  撿貨紀錄；來源 PR 品項解除連結並回算 PR 狀態，可重新拆單。
- 斷貨：供應商無法供貨時，未到貨數量不再等待直接結單
  （有部分到貨→closed、完全沒到貨→cancelled），記錄時間與原因。
- 列表頁 row actions + 明細頁動作面板都加上按鈕；
  斷貨的 PO 在狀態欄與明細頁顯示 ⛔ 斷貨標記與原因。
- 新 RPC：rpc_delete_purchase_order / rpc_stockout_purchase_order
  （migration 已透過 Management API 套到線上 DB）。

https://claude.ai/code/session_01CLFHxpo5jpSD6wUJ6HfiKd