### PR TITLE
feat(pickup): 取貨擋板改品項層級 — 部分到貨可先取已到品項

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -51,12 +51,6 @@ type OpenOrder = {
 const ACTIVE_STATUSES = ["pending", "confirmed", "reserved", "ready", "partially_ready", "partially_completed", "shipping"];
 const INACTIVE_ITEM_STATUSES = new Set(["cancelled", "picked_up", "expired"]);
 
-function isPickable(order: OpenOrder): boolean {
-  // ready 可取；partially_completed（部分取貨後）只要還有 active 品項也可繼續取剩餘
-  if (order.status === "ready") return true;
-  if (order.status === "partially_completed") return activeItems(order).length > 0;
-  return false;
-}
 function activeItems(order: OpenOrder) {
   return order.items.filter((it) => !INACTIVE_ITEM_STATUSES.has(it.status));
 }
@@ -76,9 +70,26 @@ function PickupPageContent() {
   const [searching, setSearching] = useState(false);
   const [members, setMembers] = useState<Member[] | null>(null);
   const [orders, setOrders] = useState<Map<number, OpenOrder[]>>(new Map());
+  // item.id → 該品項是否已到貨可取（v_order_item_pickup_ready）。
+  // 部分到貨的 shipping 單靠這個讓「已到的品項」可先取。
+  const [itemReady, setItemReady] = useState<Map<number, boolean>>(new Map());
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
   const autoSearchedRef = useRef(false);
+
+  // 可取貨品項：ready 單＝全部 active 品項；shipping / partially_completed 單＝
+  // 逐品項看到貨狀態（部分到貨的單可先取已到的品項）。
+  // itemReady 查無資料時的 fallback 沿用舊行為：partially_completed 可取、shipping 不可取。
+  function pickableItems(order: OpenOrder) {
+    const act = activeItems(order);
+    if (order.status === "ready") return act;
+    if (order.status === "partially_completed") return act.filter((it) => itemReady.get(it.id) !== false);
+    if (order.status === "shipping") return act.filter((it) => itemReady.get(it.id) === true);
+    return [];
+  }
+  function isPickable(order: OpenOrder): boolean {
+    return pickableItems(order).length > 0;
+  }
 
   const [pickup, setPickup] = useState<{ orderId: number; orderNo: string } | null>(null);
   const [returnTarget, setReturnTarget] = useState<{ orderId: number; storeId: number | null } | null>(null);
@@ -144,6 +155,20 @@ function PickupPageContent() {
         .order("updated_at", { ascending: false });
       if (e2) { setError(e2.message); return; }
 
+      // 品項到貨狀態（部分到貨的 shipping 單要逐品項判斷哪些可先取）
+      const orderIds = (ords ?? []).map((r) => (r as { id: number }).id);
+      const readyMap = new Map<number, boolean>();
+      if (orderIds.length > 0) {
+        const { data: irs } = await sb
+          .from("v_order_item_pickup_ready")
+          .select("item_id, pickup_ready")
+          .in("order_id", orderIds);
+        for (const r of (irs ?? []) as { item_id: number; pickup_ready: boolean }[]) {
+          readyMap.set(r.item_id, !!r.pickup_ready);
+        }
+      }
+      setItemReady(readyMap);
+
       const m = new Map<number, OpenOrder[]>();
       for (const r of (ords ?? []) as unknown as (OpenOrder & { member_id: number })[]) {
         const arr = m.get(r.member_id) ?? [];
@@ -179,9 +204,7 @@ function PickupPageContent() {
 
   async function bulkPickAllConfirmed(member: Member) {
     const memberId = member.id;
-    const allMemberOrders = (orders.get(memberId) ?? []).filter((o) =>
-      isPickable(o) && activeItems(o).length > 0,
-    );
+    const allMemberOrders = (orders.get(memberId) ?? []).filter((o) => isPickable(o));
     // 若有勾選 → 只取勾選的（且可取貨）；無勾選 → 全取
     const memberSelected = allMemberOrders.filter((o) => selected.has(o.id));
     const memberOrders = memberSelected.length > 0 ? memberSelected : allMemberOrders;
@@ -198,7 +221,8 @@ function PickupPageContent() {
       const errors: string[] = [];
       const eventIds: number[] = [];
       for (const o of memberOrders) {
-        const itemIds = activeItems(o).map((it) => it.id);
+        // 只取已到貨的品項（部分到貨的單，未到品項留待補貨後續取）
+        const itemIds = pickableItems(o).map((it) => it.id);
         const { data, error: e } = await sb.rpc("rpc_record_pickup", {
           p_order_id: o.id,
           p_item_ids: itemIds,
@@ -423,7 +447,7 @@ function PickupPageContent() {
                     <span className="font-mono text-xs text-zinc-500">{m.member_no}</span>
                     <span className="font-mono text-sm text-zinc-700 dark:text-zinc-300">{m.phone ?? "—"}</span>
                     {memberOrders.length > 0 && (() => {
-                      const pickableOrders = memberOrders.filter((o) => isPickable(o) && activeItems(o).length > 0);
+                      const pickableOrders = memberOrders.filter((o) => isPickable(o));
                       const selectedHere = pickableOrders.filter((o) => selected.has(o.id));
                       const useSel = selectedHere.length > 0;
                       const count = useSel ? selectedHere.length : pickableOrders.length;
@@ -444,9 +468,13 @@ function PickupPageContent() {
                   ) : (
                     <ul className="space-y-2">
                       {memberOrders.map((o) => {
-                        const canPickup = isPickable(o);
                         const active = activeItems(o);
-                        const pickableCount = canPickup ? active.length : 0;
+                        const pickable = pickableItems(o);
+                        const pickableIds = new Set(pickable.map((it) => it.id));
+                        const pickableCount = pickable.length;
+                        const canPickup = pickableCount > 0;
+                        // 部分到貨：有品項可取、但還有 active 品項未到
+                        const partialArrival = canPickup && pickableCount < active.length;
                         const subAmt = active.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0);
                         const discAmt = Number(o.discount_amount ?? 0);
                         const totalAmt = Math.max(0, subAmt - discAmt);
@@ -457,7 +485,7 @@ function PickupPageContent() {
                               type="checkbox"
                               checked={selected.has(o.id)}
                               onChange={() => toggleSelect(o.id)}
-                              disabled={!canPickup || pickableCount === 0}
+                              disabled={!canPickup}
                               className="mt-1 h-4 w-4 shrink-0"
                             />
                             <OrderThumb order={o} />
@@ -471,16 +499,23 @@ function PickupPageContent() {
                                 )}
                               </div>
                               <ul className="mt-0.5 space-y-0.5 text-xs text-zinc-700 dark:text-zinc-300">
-                                {activeItems(o).map((it) => (
+                                {active.map((it) => (
                                   <li key={it.id} className="flex items-baseline gap-1.5">
                                     <span className="font-bold">{it.sku?.variant_name || it.sku?.product_name || "—"}</span>
                                     <span className="font-mono text-zinc-500">× {Number(it.qty)}</span>
+                                    {partialArrival && !pickableIds.has(it.id) && (
+                                      <span className="rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">⏳ 未到貨</span>
+                                    )}
                                   </li>
                                 ))}
                               </ul>
                               <div className="mt-1 text-xs text-zinc-500">
                                 取貨店：{o.store?.name ?? "—"}
-                                {o.ready_at ? (
+                                {partialArrival ? (
+                                  <span className="ml-2 font-semibold text-amber-700 dark:text-amber-400">
+                                    🚚 部分到貨
+                                  </span>
+                                ) : o.ready_at ? (
                                   <span className="ml-2 font-semibold text-emerald-700 dark:text-emerald-400">
                                     到貨：{new Date(o.ready_at).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" })}
                                   </span>
@@ -500,7 +535,7 @@ function PickupPageContent() {
                                   </span>
                                 )}
                                 {canPickup ? (
-                                  <span className="ml-2">{pickableCount} 項可取</span>
+                                  <span className="ml-2">{partialArrival ? `${pickableCount}/${active.length} 項可取` : `${pickableCount} 項可取`}</span>
                                 ) : (
                                   <span className="ml-2 text-amber-600 dark:text-amber-400">⏳ 分店尚未收貨，無法取貨</span>
                                 )}
@@ -515,15 +550,15 @@ function PickupPageContent() {
                             <div className="flex flex-wrap gap-2 sm:shrink-0">
                             <SpinButton
                               onClick={() => notifyPickup(m, o)}
-                              disabled={!canPickup || notifyingId === o.id || m.no_notify_pickup}
-                              title={m.no_notify_pickup ? "此會員已設「不通知」" : !canPickup ? "尚未到貨無法通知" : "通知顧客來取貨（推播 + 站內訊息）"}
+                              disabled={o.status !== "ready" || notifyingId === o.id || m.no_notify_pickup}
+                              title={m.no_notify_pickup ? "此會員已設「不通知」" : o.status !== "ready" ? "尚未全部到貨無法通知" : "通知顧客來取貨（推播 + 站內訊息）"}
                               className="rounded-md border border-blue-300 px-2 py-2 text-xs font-medium text-blue-700 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-800 dark:text-blue-300 dark:hover:bg-blue-950"
                             >
                               {notifyingId === o.id ? "⌛" : "🔔 通知"}
                             </SpinButton>
                             <SpinButton
                               onClick={() => setPickup({ orderId: o.id, orderNo: o.order_no })}
-                              disabled={!canPickup || pickableCount === 0}
+                              disabled={!canPickup}
                               className="rounded-md bg-emerald-600 px-3 py-2 text-xs font-medium text-white transition hover:bg-emerald-700 disabled:opacity-50"
                             >
                               ✅ 取貨
@@ -588,14 +623,12 @@ function PickupPageContent() {
         maxWidth="max-w-2xl"
       >
         {bulkConfirm && (() => {
-          const allMemberOrders = (orders.get(bulkConfirm.id) ?? []).filter((o) =>
-            isPickable(o) && activeItems(o).length > 0,
-          );
+          const allMemberOrders = (orders.get(bulkConfirm.id) ?? []).filter((o) => isPickable(o));
           const selectedHere = allMemberOrders.filter((o) => selected.has(o.id));
           const memberOrders = selectedHere.length > 0 ? selectedHere : allMemberOrders;
-          const totalItems = memberOrders.reduce((s, o) => s + activeItems(o).length, 0);
+          const totalItems = memberOrders.reduce((s, o) => s + pickableItems(o).length, 0);
           const totalSubtotal = memberOrders.reduce(
-            (s, o) => s + activeItems(o).reduce((ss, it) => ss + Number(it.qty) * Number(it.unit_price), 0),
+            (s, o) => s + pickableItems(o).reduce((ss, it) => ss + Number(it.qty) * Number(it.unit_price), 0),
             0,
           );
           const totalDiscount = memberOrders.reduce((s, o) => s + Number(o.discount_amount ?? 0), 0);
@@ -615,7 +648,7 @@ function PickupPageContent() {
               </p>
               <div className="max-h-80 space-y-3 overflow-y-auto rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
                 {memberOrders.map((o) => {
-                  const pickItems = activeItems(o);
+                  const pickItems = pickableItems(o);
                   return (
                     <div key={o.id} className="text-sm">
                       <div className="mb-1">

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -54,6 +54,9 @@ export function PickupDialog({
   const [items, setItems] = useState<PickableItem[] | null>(null);
   // item.id → 已退數量（return_to_hq transfer 依 SKU 聚合後分攤到各品項行）
   const [returnedByItem, setReturnedByItem] = useState<Map<number, number>>(new Map());
+  // item.id → 是否已到貨（v_order_item_pickup_ready）。未到貨品項鎖住不可勾，
+  // 後端 rpc_record_pickup 也會逐品項擋，這裡是前端提示。查無資料時當已到貨（交給後端把關）。
+  const [readyByItem, setReadyByItem] = useState<Map<number, boolean>>(new Map());
   const [discountValue, setDiscountValue] = useState<DiscountValue>({ kind: "amount", value: 0 });
   const [originalDiscount, setOriginalDiscount] = useState<{ amount: number; percent: number }>({ amount: 0, percent: 0 });
   const [memberId, setMemberId] = useState<number | null>(null);
@@ -73,7 +76,7 @@ export function PickupDialog({
     let cancelled = false;
     (async () => {
       const sb = getSupabase();
-      const [iRes, hRes, rRes] = await Promise.all([
+      const [iRes, hRes, rRes, arvRes] = await Promise.all([
         sb.from("customer_order_items")
           .select("id, qty, unit_price, discount_amount, discount_percent, status, sku:skus(id, sku_code, product_name, variant_name)")
           .eq("order_id", orderId)
@@ -89,6 +92,10 @@ export function PickupDialog({
           .eq("customer_order_id", orderId)
           .eq("transfer_type", "return_to_hq")
           .in("status", ["shipped", "received"]),
+        // 品項到貨狀態 — 未到貨（分店實收 0）的品項不可取
+        sb.from("v_order_item_pickup_ready")
+          .select("item_id, pickup_ready")
+          .eq("order_id", orderId),
       ]);
       if (cancelled) return;
       if (iRes.error) { setErr(iRes.error.message); return; }
@@ -114,10 +121,17 @@ export function PickupDialog({
       }
       setReturnedByItem(allocMap);
 
+      const arrivedMap = new Map<number, boolean>();
+      for (const r of (arvRes.data ?? []) as { item_id: number; pickup_ready: boolean }[]) {
+        arrivedMap.set(r.item_id, !!r.pickup_ready);
+      }
+      setReadyByItem(arrivedMap);
+      const arrived = (it: PickableItem) => arrivedMap.get(it.id) !== false;
+
       setItems(list);
-      // 預設勾選 + 全取：只含「扣掉已退後仍有可取量」的品項
+      // 預設勾選 + 全取：只含「已到貨、且扣掉已退後仍有可取量」的品項
       const pickableQty = (it: PickableItem) => Math.max(0, Number(it.qty) - (allocMap.get(it.id) ?? 0));
-      setPicked(new Set(list.filter((it) => pickableQty(it) > 0).map((it) => it.id)));
+      setPicked(new Set(list.filter((it) => pickableQty(it) > 0 && arrived(it)).map((it) => it.id)));
       setPickQty(new Map(list.map((it) => [it.id, String(pickableQty(it))])));
       const head = hRes.data;
       const headAmt = Number(head?.discount_amount ?? 0);
@@ -140,7 +154,7 @@ export function PickupDialog({
           if (isPaid) {
             setWalletAmount("");
           } else {
-            const itemSubtotal = list.reduce((s, it) => s + lineSubQty(it, pickableQty(it)), 0);
+            const itemSubtotal = list.reduce((s, it) => s + (arrived(it) ? lineSubQty(it, pickableQty(it)) : 0), 0);
             const dpct = Number(head?.discount_percent ?? 0);
             const damt = Number(head?.discount_amount ?? 0);
             const initialPayable = Math.max(0, Math.round(itemSubtotal * (1 - dpct / 100) - damt));
@@ -168,6 +182,10 @@ export function PickupDialog({
   // 該品項已退回總倉量 / 仍可取量（= 訂購量 − 已退量）
   function returnedOf(it: PickableItem): number {
     return returnedByItem.get(it.id) ?? 0;
+  }
+  // 該品項是否未到貨（分店實收 0）— 未到貨不可勾選取貨
+  function notArrived(it: PickableItem): boolean {
+    return readyByItem.get(it.id) === false;
   }
   function pickableOf(it: PickableItem): number {
     return Math.max(0, Number(it.qty) - returnedOf(it));
@@ -349,19 +367,20 @@ export function PickupDialog({
                   const returned = returnedOf(it);
                   const pickable = pickableOf(it);
                   const fullyReturned = pickable <= 0;
+                  const blocked = fullyReturned || notArrived(it);
                   const take = effQty(it);
                   const sub = lineSubQty(it, take);
                   const partial = take < pickable;
                   const isPicked = picked.has(it.id);
                   const hasLineDisc = Number(it.discount_amount ?? 0) > 0 || Number(it.discount_percent ?? 0) > 0;
                   return (
-                    <tr key={it.id} className={fullyReturned ? "opacity-50" : isPicked ? "bg-emerald-50 dark:bg-emerald-950" : ""}>
+                    <tr key={it.id} className={blocked ? "opacity-50" : isPicked ? "bg-emerald-50 dark:bg-emerald-950" : ""}>
                       <td className="px-3 py-2">
                         <input
                           type="checkbox"
                           checked={isPicked}
                           onChange={() => toggle(it.id)}
-                          disabled={fullyReturned}
+                          disabled={blocked}
                           className="h-4 w-4 disabled:opacity-40"
                         />
                       </td>
@@ -390,12 +409,12 @@ export function PickupDialog({
                             step="1"
                             value={pickQty.get(it.id) ?? String(pickable)}
                             onChange={(e) => setQty(it.id, e.target.value)}
-                            disabled={!isPicked || fullyReturned}
+                            disabled={!isPicked || blocked}
                             className="w-14 rounded-md border border-zinc-300 px-2 py-1 text-right font-mono text-sm disabled:opacity-40 dark:border-zinc-700 dark:bg-zinc-800"
                           />
                           <span className="font-mono text-[10px] text-zinc-400">/{pickable}</span>
                         </div>
-                        {partial && isPicked && !fullyReturned && (
+                        {partial && isPicked && !blocked && (
                           <div className="mt-0.5 text-[10px] text-amber-600 dark:text-amber-400">剩 {pickable - take} 留待下次</div>
                         )}
                       </td>
@@ -404,7 +423,9 @@ export function PickupDialog({
                       <td className="px-3 py-2 text-xs text-zinc-500">
                         {fullyReturned
                           ? <span className="rounded bg-orange-100 px-1.5 py-0.5 font-medium text-orange-800 dark:bg-orange-950 dark:text-orange-300">已退貨・不能取貨</span>
-                          : orderItemStatusLabel(it.status)}
+                          : notArrived(it)
+                            ? <span className="rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">⏳ 未到貨・不能取貨</span>
+                            : orderItemStatusLabel(it.status)}
                       </td>
                     </tr>
                   );

--- a/supabase/migrations/20260704000000_item_level_pickup_gate.sql
+++ b/supabase/migrations/20260704000000_item_level_pickup_gate.sql
@@ -1,0 +1,382 @@
+-- ============================================================
+-- 2026-07-04: 取貨擋板改品項層級 — 已到貨品項可先取，未到貨品項個別擋
+--
+-- 回報案例：
+--   訂單 GRP-20260609-025-0001 (id=25237, campaign 2386, 忠順店 store 51)：
+--   WAVE-15-S51 (transfer 67) 收貨時 G00123-02 (sku 1026) 短收
+--   qty_shipped=3 / qty_received=0，G00123-07 (sku 1031) 2 收 1。
+--   20260703000000 的嚴格版 is_order_pickup_ready 是「整單」判定：
+--   任一 active 品項 SKU 實收 0 → 整單 false → rpc_record_pickup 全擋，
+--   連已實際到店的另外 5 項也不能先給會員取。
+--
+-- 修法：
+--   1. 新增 is_order_item_pickup_ready(p_item_id)：把 20260703000000 的
+--      Path A/B/C 判定逐字搬到「單一品項」粒度：
+--        - Path A：aid 單 transfer FK 收貨（aid 跨店只認 Path A，沿用 20260629000020）。
+--        - Path B：該品項 (campaign, store, sku) 有對齊波次且該 line qty_received>0。
+--        - Path C：僅當該 (campaign, store, sku) 完全無對齊波次（彙整 PR）
+--          才退用 store+sku 實收 qty_received>0（沿用 20260615000010 注意事項）。
+--   2. is_order_pickup_ready 改寫為聚合：「仍有 active 品項，且所有 active
+--      品項皆 item-ready」。與 20260703000000 語義完全等價
+--      （∀item (PathA ∨ B(i) ∨ C(i)) ⟺ PathA ∨ ∀item (B(i) ∨ C(i))，
+--      因 Path A 與 aid 跨店判定皆與 item 無關），單一事實來源避免兩份邏輯漂移。
+--      shipping→ready 的整單推進（rpc_receive_transfer 邏輯 C）行為不變：
+--      仍須「全到齊」才轉 ready。
+--   3. rpc_record_pickup：整單 is_order_pickup_ready 擋板改為迴圈內逐品項
+--      is_order_item_pickup_ready 擋板 — 未到貨品項擋（報品項名稱），
+--      已到貨品項放行。部分取完後訂單照原邏輯轉 partially_completed，
+--      剩餘品項待補到貨後可續取（UI 對 partially_completed 本就開放續取）。
+--   4. 新增 v_order_item_pickup_ready view 給 UI 顯示品項到貨狀態
+--      （比照 20260512000008 的 v_order_pickup_ready 模式）。
+--
+-- 基底版本：
+--   - is_order_pickup_ready：20260703000000_strict_pickup_ready_shortage_aware.sql
+--     （線上現行版，Path A/B/C 邏輯逐字搬入 item 版）。
+--   - rpc_record_pickup：20260630000010_pickup_partial_qty_split.sql
+--     （5-arg 拆行版；已 dump 線上確認一致；僅把整單擋板換成逐品項擋板）。
+-- Rollback：
+--   - is_order_pickup_ready：CREATE OR REPLACE 回 20260703000000 版本。
+--   - rpc_record_pickup：CREATE OR REPLACE 回 20260630000010 版本。
+--   - DROP VIEW v_order_item_pickup_ready;
+--     DROP FUNCTION is_order_item_pickup_ready(bigint);
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. is_order_item_pickup_ready — 單一品項的到貨判定 (Path A/B/C)
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_order_item_pickup_ready(p_item_id bigint)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT EXISTS (
+    SELECT 1
+      FROM customer_order_items coi
+      JOIN customer_orders co ON co.id = coi.order_id
+     WHERE coi.id = p_item_id
+       AND co.status NOT IN ('completed','expired','cancelled','transferred_out')
+       -- 只有未取的 active item 才有「可取貨」可言
+       AND coi.status IN ('pending','reserved','ready')
+       AND CASE
+         -- aid_transfer + 跨店：只認自己的 transfer 被收貨 (Path A)
+         WHEN EXISTS (
+                SELECT 1 FROM customer_order_items x
+                 WHERE x.order_id = co.id AND x.source = 'aid_transfer'
+              )
+              AND co.transferred_from_order_id IS NOT NULL
+              AND (
+                SELECT src.pickup_store_id FROM customer_orders src
+                 WHERE src.id = co.transferred_from_order_id
+              ) IS DISTINCT FROM co.pickup_store_id
+         THEN EXISTS (
+           SELECT 1 FROM transfers t
+            WHERE t.customer_order_id = co.id
+              AND t.tenant_id = co.tenant_id
+              AND t.status IN ('received','closed')
+         )
+         ELSE (
+           -- Path A：aid 單 transfer FK 收貨
+           EXISTS (
+             SELECT 1 FROM transfers t
+              WHERE t.customer_order_id = co.id
+                AND t.tenant_id = co.tenant_id
+                AND t.status IN ('received','closed')
+           )
+           OR
+           -- Path B：campaign 對齊且該波次該 SKU 實收 qty>0
+           EXISTS (
+             SELECT 1
+               FROM picking_wave_items pwi
+               JOIN transfers t ON t.id = pwi.generated_transfer_id
+               JOIN transfer_items ti ON ti.transfer_id = t.id
+                                     AND ti.sku_id = coi.sku_id
+              WHERE pwi.tenant_id   = co.tenant_id
+                AND pwi.campaign_id = co.campaign_id
+                AND pwi.store_id    = co.pickup_store_id
+                AND pwi.sku_id      = coi.sku_id
+                AND t.status IN ('received','closed')
+                AND ti.qty_received > 0
+           )
+           OR
+           -- Path C：該 (campaign,store,sku) 完全無對齊波次（彙整 PR）才退用 store+sku 實收
+           (
+             NOT EXISTS (
+               SELECT 1 FROM picking_wave_items pwi
+                WHERE pwi.tenant_id   = co.tenant_id
+                  AND pwi.campaign_id = co.campaign_id
+                  AND pwi.store_id    = co.pickup_store_id
+                  AND pwi.sku_id      = coi.sku_id
+             )
+             AND EXISTS (
+               SELECT 1
+                 FROM stores st
+                 JOIN transfers t ON t.transfer_type = 'hq_to_store'
+                                 AND t.dest_location = st.location_id
+                                 AND t.tenant_id     = co.tenant_id
+                                 AND t.status IN ('received','closed')
+                 JOIN transfer_items ti ON ti.transfer_id = t.id
+                                       AND ti.sku_id = coi.sku_id
+                                       AND ti.qty_received > 0
+                WHERE st.id = co.pickup_store_id
+             )
+           )
+         )
+       END
+  );
+$function$;
+
+COMMENT ON FUNCTION public.is_order_item_pickup_ready(bigint) IS
+  '單一品項是否已到貨可取（Path A/B/C，shortage-aware）。'
+  '20260703000000 的整單判定搬到品項粒度：未到貨品項個別擋、已到貨可先取。';
+
+GRANT EXECUTE ON FUNCTION public.is_order_item_pickup_ready(bigint) TO authenticated;
+
+-- ----------------------------------------------------------------
+-- 2. is_order_pickup_ready — 改寫為 item 版聚合（語義等價 20260703000000）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_order_pickup_ready(p_order_id bigint)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT EXISTS (
+    SELECT 1
+      FROM customer_orders co
+     WHERE co.id = p_order_id
+       AND co.status NOT IN ('completed','expired','cancelled','transferred_out')
+       -- 必須還有未取的 active item，否則無從「取貨」
+       AND EXISTS (
+         SELECT 1 FROM customer_order_items coi
+          WHERE coi.order_id = co.id
+            AND coi.status IN ('pending','reserved','ready')
+       )
+       -- 所有 active item 都到貨才算整單 ready（shipping→ready 推進維持「全到齊」）
+       AND NOT EXISTS (
+         SELECT 1 FROM customer_order_items coi
+          WHERE coi.order_id = co.id
+            AND coi.status IN ('pending','reserved','ready')
+            AND NOT public.is_order_item_pickup_ready(coi.id)
+       )
+  );
+$function$;
+
+COMMENT ON FUNCTION public.is_order_pickup_ready(bigint) IS
+  '整單是否可取貨＝仍有 active 品項且所有 active 品項皆 is_order_item_pickup_ready。'
+  '與 20260703000000 嚴格版語義等價；品項粒度邏輯統一在 is_order_item_pickup_ready。';
+
+-- ----------------------------------------------------------------
+-- 3. rpc_record_pickup — 整單擋板 → 逐品項擋板
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_record_pickup(
+  p_order_id  bigint,
+  p_item_ids  bigint[],
+  p_operator  uuid,
+  p_notes     text  DEFAULT NULL,
+  p_item_qtys jsonb DEFAULT NULL   -- {"<item_id>": <取貨數量>}；缺項或 >=qty 視為整行取
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_pickup_loc       BIGINT;
+  v_item             RECORD;
+  v_take             NUMERIC;
+  v_picked_disc      NUMERIC;
+  v_movement_id      BIGINT;
+  v_new_item_id      BIGINT;
+  v_picked_item_id   BIGINT;
+  v_picked_count     INT := 0;
+  v_event_item_ids   BIGINT[] := ARRAY[]::BIGINT[];
+  v_active_remaining INT;
+  v_new_status       TEXT;
+  v_event_type       TEXT;
+  v_event_id         BIGINT;
+  v_sku_label        TEXT;
+  v_now              TIMESTAMPTZ := NOW();
+BEGIN
+  IF p_item_ids IS NULL OR array_length(p_item_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_item_ids is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_pickup:' || p_order_id::text));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION '找不到訂單 %', p_order_id;
+  END IF;
+
+  IF v_order.status IN ('completed','expired','cancelled','transferred_out') THEN
+    RAISE EXCEPTION '訂單 % 目前狀態為「%」，無法取貨', p_order_id, v_order.status;
+  END IF;
+
+  SELECT location_id INTO v_pickup_loc
+    FROM stores
+   WHERE id = v_order.pickup_store_id;
+
+  IF v_pickup_loc IS NULL THEN
+    RAISE EXCEPTION '分店 % 未設定倉庫位置 (location_id)、無法寫 stock_movement', v_order.pickup_store_id;
+  END IF;
+
+  -- 逐品項：判斷整行取 or 拆行部分取
+  FOR v_item IN
+    SELECT id, sku_id, qty, unit_price, status, source, campaign_item_id,
+           tenant_id, notes, discount_amount, discount_percent, created_by
+      FROM customer_order_items
+     WHERE id = ANY(p_item_ids)
+       AND order_id = p_order_id
+     ORDER BY id
+     FOR UPDATE
+  LOOP
+    IF v_item.status NOT IN ('pending','reserved','ready') THEN
+      RAISE EXCEPTION '品項 % 狀態 % 不可取貨', v_item.id, v_item.status;
+    END IF;
+
+    -- 逐品項到貨擋板（取代舊的整單 is_order_pickup_ready 擋板）：
+    -- 未到貨（該 SKU 分店實收 0）的品項個別擋，已到貨的品項放行先取
+    IF NOT public.is_order_item_pickup_ready(v_item.id) THEN
+      SELECT COALESCE(s.variant_name, s.product_name, s.sku_code)
+        INTO v_sku_label FROM skus s WHERE s.id = v_item.sku_id;
+      RAISE EXCEPTION '品項「%」分店尚未實收到貨，無法取貨（請取消勾選該品項，其餘已到貨品項可先取）',
+        COALESCE(v_sku_label, v_item.sku_id::text);
+    END IF;
+
+    -- 本次取多少：p_item_qtys 指定則用之，否則整行取
+    v_take := COALESCE((p_item_qtys ->> v_item.id::text)::numeric, v_item.qty);
+    IF v_take IS NULL OR v_take <= 0 THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 不合法（須 > 0）', v_item.id, v_take;
+    END IF;
+    IF v_take > v_item.qty THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 超過待取數量 %', v_item.id, v_take, v_item.qty;
+    END IF;
+
+    IF v_take = v_item.qty THEN
+      -- ── 整行取：沿用舊邏輯，直接標 picked_up ──
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_item.id,
+        format('顧客取貨 order=%s item=%s', p_order_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      UPDATE customer_order_items
+         SET status = 'picked_up',
+             pickup_movement_id = v_movement_id,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_item.id;
+    ELSE
+      -- ── 部分取：拆行。新建 picked_up 行，原行扣量留待下次 ──
+      -- line-level 折扣金額按取貨比例分攤，確保兩行小計加總 = 原行
+      v_picked_disc := round(COALESCE(v_item.discount_amount, 0) * v_take / v_item.qty);
+
+      -- 1) 先建 picked_up 行（暫不填 movement，先拿 id）
+      INSERT INTO customer_order_items (
+        tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+        status, source, reserved_movement_id, pickup_movement_id, notes,
+        discount_amount, discount_percent, created_by, updated_by, created_at, updated_at
+      ) VALUES (
+        v_item.tenant_id, p_order_id, v_item.campaign_item_id, v_item.sku_id, v_take, v_item.unit_price,
+        'picked_up', v_item.source, NULL, NULL, v_item.notes,
+        v_picked_disc, v_item.discount_percent, v_item.created_by, p_operator, v_now, v_now
+      ) RETURNING id INTO v_new_item_id;
+
+      -- 2) sale movement 指向新行
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_new_item_id,
+        format('顧客部分取貨 order=%s item=%s (split from %s)', p_order_id, v_new_item_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      -- 3) 回填新行 movement
+      UPDATE customer_order_items
+         SET pickup_movement_id = v_movement_id
+       WHERE id = v_new_item_id;
+
+      -- 4) 原行扣量、保持 active 狀態，剩餘留待下次取
+      UPDATE customer_order_items
+         SET qty = qty - v_take,
+             discount_amount = COALESCE(discount_amount, 0) - v_picked_disc,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_new_item_id;
+    END IF;
+
+    -- event 記錄「被取走」那一行的 id（拆行時是新行）→ 收據查到正確的 qty
+    v_event_item_ids := v_event_item_ids || v_picked_item_id;
+    v_picked_count := v_picked_count + 1;
+  END LOOP;
+
+  IF v_picked_count = 0 THEN
+    RAISE EXCEPTION 'no items picked (check p_item_ids belongs to order %)', p_order_id;
+  END IF;
+
+  -- 重算 order status（剩餘 active 行 → partially_completed；全取完 → completed）
+  SELECT COUNT(*) INTO v_active_remaining
+    FROM customer_order_items
+   WHERE order_id = p_order_id
+     AND status IN ('pending','reserved','ready');
+
+  IF v_active_remaining = 0 THEN
+    v_new_status := 'completed';
+    v_event_type := 'picked_up';
+  ELSE
+    v_new_status := 'partially_completed';
+    v_event_type := 'partial_pickup';
+  END IF;
+
+  UPDATE customer_orders
+     SET status       = v_new_status,
+         completed_at = CASE WHEN v_new_status = 'completed' THEN v_now ELSE NULL END,
+         updated_by   = p_operator,
+         updated_at   = v_now
+   WHERE id = p_order_id;
+
+  INSERT INTO order_pickup_events (
+    tenant_id, order_id, pickup_store_id, event_type, item_ids, notes, created_by
+  ) VALUES (
+    v_order.tenant_id, p_order_id, v_order.pickup_store_id, v_event_type,
+    to_jsonb(v_event_item_ids), p_notes, p_operator
+  ) RETURNING id INTO v_event_id;
+
+  RETURN jsonb_build_object(
+    'event_id',        v_event_id,
+    'event_type',      v_event_type,
+    'picked_count',    v_picked_count,
+    'active_remaining', v_active_remaining,
+    'new_status',      v_new_status
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) IS
+  '取貨記帳。p_item_qtys={"<item_id>":<取貨數量>} 可指定部分取貨（拆行）。'
+  '到貨擋板為品項層級（is_order_item_pickup_ready）：未到貨品項個別擋、已到貨可先取。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) TO authenticated;
+
+-- ----------------------------------------------------------------
+-- 4. v_order_item_pickup_ready — UI 顯示品項到貨狀態
+-- ----------------------------------------------------------------
+CREATE OR REPLACE VIEW public.v_order_item_pickup_ready AS
+SELECT
+  coi.id AS item_id,
+  coi.order_id,
+  coi.tenant_id,
+  public.is_order_item_pickup_ready(coi.id) AS pickup_ready
+FROM customer_order_items coi;
+
+GRANT SELECT ON public.v_order_item_pickup_ready TO authenticated;
+
+COMMENT ON VIEW public.v_order_item_pickup_ready IS
+  '品項可取貨判斷 view（item_id, order_id, pickup_ready），UI 取貨頁/對話框顯示哪些品項已到貨可取';


### PR DESCRIPTION
短收場景（如 GRP-20260609-025-0001：A-王董 出 3 實收 0）下，
20260703000000 的整單嚴格判定會連已到貨品項一起擋住不能取。

DB（已套線上）：
- 新增 is_order_item_pickup_ready(item_id)：Path A/B/C 搬到品項粒度
- is_order_pickup_ready 改寫為 item 版聚合（語義等價，全訂單比對 0 差異；
  shipping→ready 整單推進仍須全到齊）
- rpc_record_pickup：整單擋板 → 迴圈內逐品項擋板，未到貨品項報名稱個別擋
- 新增 v_order_item_pickup_ready view 供 UI 查品項到貨狀態

UI（取貨頁 + PickupDialog）：
- shipping 單有品項到貨即可取（顯示「🚚 部分到貨」「x/y 項可取」）
- 未到貨品項鎖勾選、標「⏳ 未到貨・不能取貨」，一次全取/批次取只送已到品項
- 取已到品項後訂單轉 partially_completed，剩餘品項補到貨後可續取

https://claude.ai/code/session_01HsAXQ5cGrPo3gNaKLWhygv