### PR TITLE
採購單列表頁載入態改用 spinner（取代「載入中…」文字）

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import { SendPOModal } from "@/components/SendPOModal";
 import SpinButton from "@/components/SpinButton";
+import Spinner, { LoadingBlock } from "@/components/Spinner";
 import { RowAction } from "@/components/RowAction";
 import { PO_STATUS_LABEL, PO_TERM_ZH, type POStatus } from "@/lib/poStatus";
 import { PR_TERM_ZH } from "@/lib/prStatus";
@@ -529,7 +530,11 @@ export default function PurchaseOrdersListPage() {
         <div>
           <h1 className="text-xl font-semibold">{PO_TERM_ZH}（PO）</h1>
           <p className="text-sm text-zinc-500">
-            {pos === null ? "載入中…" : `共 ${pos.length} 張 PO`}
+            {pos === null ? (
+              <Spinner size={14} className="inline-block align-[-2px]" />
+            ) : (
+              `共 ${pos.length} 張 PO`
+            )}
           </p>
         </div>
         <Link
@@ -663,9 +668,11 @@ export default function PurchaseOrdersListPage() {
           </SpinButton>
         )}
         <span className="ml-auto text-xs text-zinc-500">
-          {pos === null
-            ? "載入中…"
-            : `符合 ${total} 筆${total > PAGE_SIZE ? ` · 第 ${page}/${totalPages} 頁` : ""}`}
+          {pos === null ? (
+            <Spinner size={14} className="inline-block align-[-2px]" />
+          ) : (
+            `符合 ${total} 筆${total > PAGE_SIZE ? ` · 第 ${page}/${totalPages} 頁` : ""}`
+          )}
         </span>
       </div>
 
@@ -722,8 +729,8 @@ export default function PurchaseOrdersListPage() {
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {pos === null ? (
               <tr>
-                <td colSpan={11} className="p-6 text-center text-zinc-500">
-                  載入中…
+                <td colSpan={11}>
+                  <LoadingBlock />
                 </td>
               </tr>
             ) : pageRows.length === 0 ? (

--- a/apps/admin/src/components/Spinner.tsx
+++ b/apps/admin/src/components/Spinner.tsx
@@ -1,0 +1,55 @@
+/**
+ * 後台統一的 inline spinner（取代裸文字「載入中…」）。
+ * 用 currentColor —— 放在哪就繼承該處文字色（多半 text-zinc-400/500），
+ * 與 SearchSpinner 視覺一致。需要區塊置中時用 <LoadingBlock />。
+ */
+export default function Spinner({
+  size = 16,
+  className = "",
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      className={`animate-spin ${className}`}
+      style={{ width: size, height: size }}
+      viewBox="0 0 24 24"
+      fill="none"
+      role="status"
+      aria-label="載入中"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="3"
+        className="opacity-25"
+      />
+      <path
+        d="M4 12a8 8 0 0 1 8-8"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+/** 區塊置中的載入態（表格 body / 卡片區），純轉圈不帶文字。 */
+export function LoadingBlock({
+  size = 24,
+  className = "",
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`flex items-center justify-center p-6 text-zinc-400 ${className}`}
+    >
+      <Spinner size={size} />
+    </div>
+  );
+}


### PR DESCRIPTION
## 變更內容

採購單列表頁（`purchase/orders`）一進來、資料還沒回來時（`pos === null`）的三處「載入中…」**純文字**，全部改成轉圈 spinner：

| 位置 | 原本 | 現在 |
|------|------|------|
| 標題副標（`共 N 張 PO`） | 載入中… | 14px inline spinner |
| 右上筆數列（`符合 N 筆`） | 載入中… | 14px inline spinner |
| 表格 body | 載入中… | 24px 置中 spinner |

三處都是首次載入狀態，無遺漏；此頁是純表格、沒有獨立的手機卡片載入分支。

## 為什麼

符合既定 UX 偏好——**載入態只轉圈、不要「載入中／…中」文字**（aria-label 不可見可留）。

## 新增元件

`apps/admin/src/components/Spinner.tsx`（後台先前只有 `SearchSpinner`／`SpinButton`，缺通用 spinner）：

- `Spinner`：inline 轉圈，用 `currentColor` 繼承所在文字色，視覺對齊既有的 `SearchSpinner`
- `LoadingBlock`：區塊置中載入（表格／卡片用），純轉圈不帶字

兩者皆可被其他後台列表頁複用。

## Reviewer 注意

- 純前端、純呈現變更：把文字節點換成 SVG spinner，**不動任何資料邏輯／query**。
- spinner 用 `currentColor`，深淺色模式都跟著 `text-zinc-400/500` 走。
- 驗證方式：此 worktree 未裝 deps（無 `tsc`）＋後台 preview 登入在沙箱被擋，故以碼審確認（JSX ternary 形式正確、import 沿用 `@/components/*` 慣例、鏡像兩個現役 spinner 元件）；實機畫面留給 reviewer 自審。
- 本次**只動截圖指到的採購單列表頁**；其他後台列表頁（orders／members／wms…）也有同樣「載入中…」文字，可後續用新元件一併替換。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
