### PR TITLE
列表頁載入態全面改用 spinner（訂單/收貨/調撥/補貨/開團/商品/供應商/PR）

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -18,6 +18,7 @@ import { CampaignItemsTable } from "@/components/CampaignItemsTable";
 import { DatePicker } from "@/components/DatePicker";
 import SpinButton from "@/components/SpinButton";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
+import Spinner, { LoadingBlock } from "@/components/Spinner";
 import { CampaignThumb } from "@/components/CampaignThumb";
 import { campaignCoverUrl, type CampaignCoverItem } from "@/lib/campaignCover";
 import FbPublishModal from "@/components/FbPublishModal";
@@ -663,7 +664,13 @@ export default function CampaignsListPage() {
         <div>
           <h1 className="text-xl font-semibold">開團</h1>
           <p className="text-sm text-zinc-500">
-            {loading ? "載入中…" : total === 0 ? "共 0 筆" : `共 ${total} 筆（${fromIdx}-${toIdx}）`}
+            {loading ? (
+              <Spinner size={14} className="inline-block align-[-2px]" />
+            ) : total === 0 ? (
+              "共 0 筆"
+            ) : (
+              `共 ${total} 筆（${fromIdx}-${toIdx}）`
+            )}
           </p>
         </div>
         {showAdminActions && (
@@ -743,7 +750,7 @@ export default function CampaignsListPage() {
             >今天</SpinButton>
           </div>
           <span className="text-sm text-zinc-500">
-            {calRows === null ? "載入中…" : `${calRows.length} 場`}
+            {calRows === null ? <Spinner size={14} className="inline-block align-[-2px]" /> : `${calRows.length} 場`}
           </span>
         </div>
       )}
@@ -822,7 +829,11 @@ export default function CampaignsListPage() {
       {/* 手機：每筆開團一張卡片（桌機改用下方表格） */}
       <div className="space-y-2 sm:hidden">
         {rows === null ? (
-          <div className="rounded-md border border-zinc-200 p-6 text-center text-sm text-zinc-500 dark:border-zinc-800">載入中…</div>
+          <div className="rounded-md border border-zinc-200 p-6 dark:border-zinc-800">
+            <div className="flex justify-center text-zinc-400">
+              <Spinner size={20} />
+            </div>
+          </div>
         ) : rows.length === 0 ? (
           <div className="rounded-md border border-zinc-200 p-6 text-center text-sm text-zinc-500 dark:border-zinc-800">
             {total === 0 && !query && !status ? "還沒有開團，按「新增開團」開始。" : "沒有符合條件的開團。"}
@@ -1129,7 +1140,7 @@ function CalendarView({
   showEdit: boolean;
 }) {
   if (rows === null) {
-    return <div className="p-6 text-center text-sm text-zinc-500">載入中…</div>;
+    return <LoadingBlock />;
   }
   // 按日期分桶（key = YYYY-MM-DD）
   const buckets = new Map<string, CalRow[]>();

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
+import Spinner, { LoadingBlock } from "@/components/Spinner";
 import OrderReturnCreateModal from "@/components/OrderReturnCreateModal";
 import { translateRpcError } from "@/lib/rpcError";
 import { withBasePath } from "@/lib/basePath";
@@ -99,7 +100,7 @@ function cardTint(status: OrderStatus): string {
 
 export default function OrdersListPage() {
   return (
-    <Suspense fallback={<div className="p-6 text-sm text-zinc-500">載入中…</div>}>
+    <Suspense fallback={<LoadingBlock />}>
       <OrdersListContent />
     </Suspense>
   );
@@ -596,7 +597,13 @@ function OrdersListContent() {
         <div>
           <h1 className="text-xl font-semibold">訂單</h1>
           <p className="text-sm text-zinc-500">
-            {loading ? "載入中…" : total === 0 ? "共 0 筆" : `共 ${total} 筆（${fromIdx}-${toIdx}）`}
+            {loading ? (
+              <Spinner size={14} className="inline-block align-[-2px]" />
+            ) : total === 0 ? (
+              "共 0 筆"
+            ) : (
+              `共 ${total} 筆（${fromIdx}-${toIdx}）`
+            )}
           </p>
         </div>
         <Link
@@ -815,7 +822,11 @@ function OrdersListContent() {
       {/* 手機：每筆訂單一張卡片（桌機改用下方表格） */}
       <div className="space-y-2 sm:hidden">
         {rows === null ? (
-          <div className="rounded-md border border-zinc-200 p-6 text-center text-sm text-zinc-500 dark:border-zinc-800">載入中…</div>
+          <div className="rounded-md border border-zinc-200 p-6 dark:border-zinc-800">
+            <div className="flex justify-center text-zinc-400">
+              <Spinner size={20} />
+            </div>
+          </div>
         ) : rows.length === 0 ? (
           <div className="rounded-md border border-zinc-200 p-6 text-center text-sm text-zinc-500 dark:border-zinc-800">
             {total === 0 && campaignIds.length === 0 && !storeId && !keyword ? "此 tab 下尚無訂單。" : "沒有符合條件的訂單。"}
@@ -901,7 +912,7 @@ function OrdersListContent() {
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={9} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={9}><LoadingBlock /></td></tr>
             ) : rows.length === 0 ? (
               <tr><td colSpan={9} className="p-6 text-center text-zinc-500">{total === 0 && campaignIds.length === 0 && !storeId && !keyword ? `此 tab 下尚無訂單。` : "沒有符合條件的訂單。"}</td></tr>
             ) : rows.map((r) => {

--- a/apps/admin/src/app/(protected)/products/page.tsx
+++ b/apps/admin/src/app/(protected)/products/page.tsx
@@ -12,6 +12,7 @@ import { ProductCampaignsPanel } from "@/components/ProductCampaignsPanel";
 import { CreateCampaignModal, type SelectedProduct, type StorageType } from "@/components/CreateCampaignModal";
 import SpinButton from "@/components/SpinButton";
 import SearchSpinner from "@/components/SearchSpinner";
+import Spinner, { LoadingBlock } from "@/components/Spinner";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow } from "@/components/DataTable";
 
 type Status = "draft" | "active" | "inactive" | "discontinued";
@@ -45,7 +46,7 @@ const PAGE_SIZE = 20;
 // ============================================================
 export default function ProductListPage() {
   return (
-    <Suspense fallback={<div className="p-6 text-sm text-zinc-500">載入中…</div>}>
+    <Suspense fallback={<LoadingBlock />}>
       <PageContent />
     </Suspense>
   );
@@ -364,11 +365,13 @@ function PageContent() {
         <div>
           <h1 className="text-xl font-semibold">商品</h1>
           <p className="text-sm text-zinc-500">
-            {loading
-              ? "載入中…"
-              : total === 0
-                ? "共 0 筆"
-                : `共 ${total} 筆（顯示 ${fromIdx}-${toIdx}）`}
+            {loading ? (
+              <Spinner size={14} className="inline-block align-[-2px]" />
+            ) : total === 0 ? (
+              "共 0 筆"
+            ) : (
+              `共 ${total} 筆（顯示 ${fromIdx}-${toIdx}）`
+            )}
           </p>
         </div>
         <SpinButton

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import { RowAction } from "@/components/RowAction";
+import Spinner, { LoadingBlock } from "@/components/Spinner";
 import {
   PR_STATUS_LABEL,
   PR_REVIEW_LABEL,
@@ -664,7 +665,11 @@ export default function PurchaseRequestsListPage() {
         <div>
           <h1 className="text-xl font-semibold">{PR_TERM_ZH}（PR）</h1>
           <p className="text-sm text-zinc-500">
-            {rows === null ? "載入中…" : `共 ${rows.length} 筆`}
+            {rows === null ? (
+              <Spinner size={14} className="inline-block align-[-2px]" />
+            ) : (
+              `共 ${rows.length} 筆`
+            )}
           </p>
         </div>
         <div className="flex gap-2">
@@ -870,9 +875,11 @@ export default function PurchaseRequestsListPage() {
           </SpinButton>
         )}
         <span className="ml-auto text-xs text-zinc-500">
-          {rows === null
-            ? "載入中…"
-            : `符合 ${total} 筆${total > PAGE_SIZE ? ` · 第 ${page}/${totalPages} 頁` : ""}`}
+          {rows === null ? (
+            <Spinner size={14} className="inline-block align-[-2px]" />
+          ) : (
+            `符合 ${total} 筆${total > PAGE_SIZE ? ` · 第 ${page}/${totalPages} 頁` : ""}`
+          )}
         </span>
       </div>
 
@@ -922,8 +929,8 @@ export default function PurchaseRequestsListPage() {
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
               <tr>
-                <td colSpan={10} className="p-6 text-center text-zinc-500">
-                  載入中…
+                <td colSpan={10}>
+                  <LoadingBlock />
                 </td>
               </tr>
             ) : pageRows.length === 0 ? (
@@ -1059,8 +1066,8 @@ export default function PurchaseRequestsListPage() {
             </div>
             <div className="max-h-[60vh] overflow-y-auto p-4">
               {closedCampaigns === null ? (
-                <div className="text-center text-sm text-zinc-500">
-                  載入中…
+                <div className="flex justify-center py-4 text-zinc-400">
+                  <Spinner size={20} />
                 </div>
               ) : closedCampaigns.length === 0 ? (
                 <div className="text-center text-sm text-zinc-500">

--- a/apps/admin/src/app/(protected)/restock/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/page.tsx
@@ -6,6 +6,7 @@ import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 import RestockDetailModal from "@/components/RestockDetailModal";
+import Spinner from "@/components/Spinner";
 
 const PAGE_SIZE = 20;
 
@@ -164,7 +165,7 @@ export default function RestockListPage() {
       <header className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold">補貨申請</h1>
-          <p className="text-sm text-zinc-500">{rows === null ? "載入中…" : `共 ${rows.length} 筆`}</p>
+          <p className="text-sm text-zinc-500">{rows === null ? <Spinner size={14} className="inline-block align-[-2px]" /> : `共 ${rows.length} 筆`}</p>
         </div>
         <Link href="/restock/new" className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900">
           + 建立申請

--- a/apps/admin/src/app/(protected)/transfers/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/page.tsx
@@ -2,11 +2,12 @@
 
 import { Suspense, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { LoadingBlock } from "@/components/Spinner";
 
 // 已整合到 /wms/transfers + /hq/inbox — 此頁僅做 redirect
 export default function TransfersListRedirect() {
   return (
-    <Suspense fallback={<div className="p-6 text-sm text-zinc-500">載入中…</div>}>
+    <Suspense fallback={<LoadingBlock />}>
       <RedirectInner />
     </Suspense>
   );

--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import Spinner from "@/components/Spinner";
 import {
   TransferReceiveModal,
   TRANSFER_TYPE_LABEL,
@@ -406,13 +407,15 @@ export default function TransfersInboxPage() {
         <div>
           <h1 className="text-xl font-semibold">📦 收貨待辦</h1>
           <p className="text-sm text-zinc-500">
-            {transfers === null
-              ? "載入中…"
-              : (() => {
-                  const pending = filtered.filter((t) => t.status === "shipped").length;
-                  const done = filtered.length - pending;
-                  return `待收 ${pending} · 已收 ${done}`;
-                })()}
+            {transfers === null ? (
+              <Spinner size={14} className="inline-block align-[-2px]" />
+            ) : (
+              (() => {
+                const pending = filtered.filter((t) => t.status === "shipped").length;
+                const done = filtered.length - pending;
+                return `待收 ${pending} · 已收 ${done}`;
+              })()
+            )}
           </p>
         </div>
         {branchLocationId == null && (

--- a/apps/admin/src/app/(protected)/wms/transfers/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/transfers/page.tsx
@@ -10,6 +10,7 @@
 //   D. 互助訂單 — 走 customer_orders,在 /transfers/aid
 
 import { useEffect, useMemo, useState } from "react";
+import { LoadingBlock } from "@/components/Spinner";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import FreeTransferCreateModal from "@/components/FreeTransferCreateModal";
@@ -292,7 +293,7 @@ export default function InternalTransfersPage() {
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {transfers === null ? (
-              <tr><td colSpan={8} className="p-6 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={8}><LoadingBlock /></td></tr>
             ) : filtered.length === 0 ? (
               <tr><td colSpan={8} className="p-6 text-center text-zinc-500">目前沒有資料</td></tr>
             ) : filtered.map((t) => {

--- a/apps/admin/src/components/DataTable.tsx
+++ b/apps/admin/src/components/DataTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { MouseEventHandler, ReactNode } from "react";
+import Spinner from "./Spinner";
 
 type Align = "left" | "center" | "right";
 
@@ -131,8 +132,12 @@ export function LoadingRow({
 }) {
   return (
     <tr>
-      <td colSpan={colSpan} className="p-3 text-center text-sm text-zinc-500">
-        {children ?? "載入中…"}
+      <td colSpan={colSpan} className="p-3 text-zinc-400">
+        {children ?? (
+          <div className="flex justify-center">
+            <Spinner size={20} />
+          </div>
+        )}
       </td>
     </tr>
   );


### PR DESCRIPTION
## 變更內容

延續 #425（採購單頁），把**其餘列表頁**首次載入時的「載入中…」純文字，全部改成轉圈 spinner，沿用 `components/Spinner.tsx` 的 `Spinner` / `LoadingBlock`。

| 標籤 | 路由 | 改的位置 |
|------|------|----------|
| 訂單 | `/orders` | Suspense fallback、標題筆數、手機卡片、表格 body |
| 收貨待辦 | `/wms/inbound`（h1=「📦 收貨待辦」）| 標題筆數 |
| 內部調撥 | `/wms/transfers` | 表格 body |
| （內部調撥舊路由）| `/transfers` redirect | Suspense fallback |
| 補貨申請 | `/restock` | 標題筆數（表格走共用 `LoadingRow`）|
| 開團 | `/campaigns` | 標題筆數、週曆筆數、手機卡片、月曆子元件 |
| 商品 | `/products` | Suspense fallback、標題筆數 |
| 供應商 | `/suppliers` | 由共用 `LoadingRow` 一併處理（無需改檔）|
| 請購單 PR | `/purchase/requests` | 標題筆數、筆數列、表格 body、結團子面板 |

## 高槓桿：共用 `DataTable.LoadingRow`

`components/DataTable.tsx` 的 `LoadingRow` 由「載入中…」文字改成置中 spinner。這個元件被 11 個頁面共用，所以這一處就涵蓋了供應商、補貨申請、開團等所有用 `LoadingRow` 的表格載入態（也順手讓 stores / inventory / hq-inbox / fb-pages 等非本次點名頁面的表格載入態一致）。

`EmptyRow`（「目前沒有資料」）維持文字 —— 空狀態不是載入態。

## 為什麼

符合既定 UX 偏好：**載入態只轉圈、不要「載入中／…中」文字**（`aria-label` 不可見字樣保留）。

## Reviewer 注意

- 純前端、純呈現：文字節點換成 SVG spinner，不動任何資料邏輯 / query。
- spinner 走 `currentColor`，深淺色模式跟著 `text-zinc-400/500`。
- 樣式分工：行內筆數 → `<Spinner size={14}>`；整塊 / 表格 / Suspense → `<LoadingBlock>`；手機卡片保留外框、內置置中 spinner。
- 本批**未**動各種列印 / 編輯 / detail 子頁與 modal（如 `orders/pivot`、`purchase/requests/print`、`hq/inbox`、各 Modal）——它們不在點名清單內，之後要的話可再掃一輪。
- 驗證：worktree 未裝 deps（無 `tsc`）＋後台 preview 登入在沙箱被擋，故以逐檔 diff 碼審確認（ternary 括號、tag 收尾、import 皆有被用到）；實機畫面留給 reviewer 自審。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
