### PR TITLE
fix(pickup): 訂單頁/訂單明細的取貨入口跟上品項層級判定

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -156,6 +156,8 @@ function OrdersListContent() {
       }
     >
   >(new Map());
+  // shipping 單是否有品項已到貨可先取（v_order_item_pickup_ready；部分到貨單開放「去取貨」）
+  const [hasArrivedItem, setHasArrivedItem] = useState<Map<number, boolean>>(new Map());
   const [detailId, setDetailId] = useState<number | null>(null);
   const [detailNo, setDetailNo] = useState<string>("");
   const [returnTarget, setReturnTarget] = useState<{ orderId: number; storeId: number } | null>(null);
@@ -270,13 +272,18 @@ function OrdersListContent() {
 
         const ids = (data ?? []).map((r) => r.id);
         const memIds = Array.from(new Set((data ?? []).map((r) => r.member_id).filter((x): x is number => x != null)));
-        const [ic, ms] = await Promise.all([
+        // shipping 單查品項到貨狀態（pickup_ready=true 隱含該品項 active 且已到貨）
+        const shippingIds = (data ?? []).filter((r) => r.status === "shipping").map((r) => r.id);
+        const [ic, ms, rdy] = await Promise.all([
           ids.length
             ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price, source, sku:skus(product_name, variant_name)").in("order_id", ids)
             : Promise.resolve({ data: [] as { order_id: number; qty: number; unit_price: number; source: string; sku: { product_name: string | null; variant_name: string | null } | null }[] }),
           memIds.length
             ? getSupabase().from("members").select("id, name, phone, member_no, avatar_url").in("id", memIds)
             : Promise.resolve({ data: [] as Member[] }),
+          shippingIds.length
+            ? getSupabase().from("v_order_item_pickup_ready").select("order_id, pickup_ready").in("order_id", shippingIds).eq("pickup_ready", true)
+            : Promise.resolve({ data: [] as { order_id: number; pickup_ready: boolean }[] }),
         ]);
         const im = new Map<number, { lineCount: number; totalQty: number; totalAmount: number; items: { product_name: string | null; variant_name: string | null; qty: number }[]; sources: string[] }>();
         for (const id of ids) im.set(id, { lineCount: 0, totalQty: 0, totalAmount: 0, items: [], sources: [] });
@@ -295,7 +302,11 @@ function OrdersListContent() {
         }
         const mm = new Map<number, Member>();
         for (const m of (ms.data as Member[]) ?? []) mm.set(m.id, m);
-        if (!cancelled) { setItemSummary(im); setMembers(mm); }
+        const arrived = new Map<number, boolean>();
+        for (const r of ((rdy.data ?? []) as { order_id: number; pickup_ready: boolean }[])) {
+          if (r.pickup_ready) arrived.set(r.order_id, true);
+        }
+        if (!cancelled) { setItemSummary(im); setMembers(mm); setHasArrivedItem(arrived); }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       } finally {
@@ -507,7 +518,9 @@ function OrdersListContent() {
         </SpinButton>
       )}
       {!["completed","expired","cancelled","transferred_out"].includes(r.status) && (() => {
-        const canPickup = r.status === "ready" || r.status === "partially_completed";
+        // shipping 單部分到貨（≥1 品項已實收）也開放去取貨 — 已到品項可先取
+        const canPickup = r.status === "ready" || r.status === "partially_completed"
+          || (r.status === "shipping" && hasArrivedItem.get(r.id) === true);
         // 訂單頁本身不執行取貨,只導向 /pickup (帶會員編號自動搜尋)
         if (canPickup && m?.member_no) {
           return (

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -159,6 +159,8 @@ export function OrderDetail({
   const [head, setHead] = useState<OrderHead | null>(null);
   const [items, setItems] = useState<ItemRow[] | null>(null);
   const [returns, setReturns] = useState<ReturnTransfer[] | null>(null);
+  // item.id → 是否已到貨可取（v_order_item_pickup_ready）。shipping 單部分到貨時，已到品項可先取
+  const [itemReady, setItemReady] = useState<Map<number, boolean>>(new Map());
   const [returnDetailId, setReturnDetailId] = useState<number | null>(null);
   const [timeline, setTimeline] = useState<TimelineStep[] | null>(null);
   const [staffNames, setStaffNames] = useState<Map<string, string>>(new Map());
@@ -210,7 +212,7 @@ export function OrderDetail({
     let cancelled = false;
     (async () => {
       const sb = getSupabase();
-      const [hRes, iRes, rRes] = await Promise.all([
+      const [hRes, iRes, rRes, arvRes] = await Promise.all([
         sb.from("customer_orders")
           .select("id, order_no, status, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, transferred_from_order_id, is_air_transfer, discount_amount, discount_percent, wallet_paid_amount, payment_status, paid_at, notes, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .eq("id", orderId).maybeSingle(),
@@ -224,6 +226,9 @@ export function OrderDetail({
           .eq("transfer_type", "return_to_hq")
           .in("status", ["shipped", "received"])
           .order("shipped_at", { ascending: false }),
+        sb.from("v_order_item_pickup_ready")
+          .select("item_id, pickup_ready")
+          .eq("order_id", orderId),
       ]);
       if (cancelled) return;
       if (hRes.error) { setError(hRes.error.message); return; }
@@ -232,6 +237,12 @@ export function OrderDetail({
       if (iRes.error) { setError(iRes.error.message); return; }
       const itemsData = (iRes.data ?? []) as unknown as ItemRow[];
       setItems(itemsData);
+
+      const arrivedMap = new Map<number, boolean>();
+      for (const r of (arvRes.data ?? []) as { item_id: number; pickup_ready: boolean }[]) {
+        arrivedMap.set(r.item_id, !!r.pickup_ready);
+      }
+      setItemReady(arrivedMap);
 
       // ========== 整理退貨單（return_to_hq transfer）==========
       type RetRow = {
@@ -515,7 +526,12 @@ export function OrderDetail({
     setReloadTick((n) => n + 1);
   }
   const pickableItems = items.filter((it) => ["pending", "reserved", "ready"].includes(it.status));
-  const canPickup = pickableItems.length > 0 && head.status === "ready";
+  // ready 單全可取；shipping / partially_completed 單看品項到貨狀態（部分到貨可先取已到品項）
+  const canPickup =
+    head.status === "ready"
+      ? pickableItems.length > 0
+      : ["shipping", "partially_completed"].includes(head.status) &&
+        pickableItems.some((it) => itemReady.get(it.id) === true);
   const memberLabel = head.member
     ? `${head.member.name ?? "—"} (${head.member.member_no})`
     : `(${head.nickname_snapshot ?? "—"})`;


### PR DESCRIPTION
#423 只改了取貨頁，訂單列表「去取貨」與訂單明細「確認取貨」
仍要求 status=ready，導致部分到貨的 shipping 單（如
GRP-20260609-025-0001）從這兩個入口看仍顯示不能取貨。

- orders/page.tsx：shipping 單查 v_order_item_pickup_ready， 有品項已實收即開放「去取貨」導向取貨頁
- OrderDetail.tsx：shipping / partially_completed 單有已到貨品項 即顯示「確認取貨」（PickupDialog 內已會鎖未到貨品項）

https://claude.ai/code/session_01HsAXQ5cGrPo3gNaKLWhygv