### PR TITLE
feat(pickup): 取貨單改用「小白單」80mm 熱感版型

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
@@ -55,7 +55,7 @@ function hasLineDisc(it: Item): boolean {
 
 export default function PickupPrintPage() {
   return (
-    <Suspense fallback={<div className="p-6 text-sm">載入中…</div>}>
+    <Suspense fallback={<div className="p-4 text-sm text-zinc-500">載入中…</div>}>
       <Body />
     </Suspense>
   );
@@ -115,321 +115,151 @@ function Body() {
     }
   }, [receipts]);
 
-  if (error) return <div className="p-6 text-sm text-red-700">{error}</div>;
-  if (!receipts) return <div className="p-6 text-sm text-zinc-500">載入中…</div>;
+  if (error) return <div className="p-4 text-sm text-red-700">{error}</div>;
+  if (!receipts) return <div className="p-4 text-sm text-zinc-500">載入中…</div>;
+  if (receipts.length === 0) return <div className="p-4 text-sm text-zinc-500">無取貨記錄</div>;
 
-  const combined = receipts.length > 1;
+  // 80mm 小白單版型（對齊「取貨清單」）—— 同一會員的多張訂單共用 1 個表頭
+  const member = receipts[0]?.order?.member;
+  const store = receipts[0]?.order?.store;
+  const headerEvent = receipts[0]?.event;
+
+  const orderSub = (r: { items: Item[] }) => r.items.reduce((a, it) => a + lineSub(it), 0);
   // payable 四捨五入到整數 NTD
-  const orderPayable = (r: { order: Order; items: Item[] }) => {
-    const sub = r.items.reduce((a, it) => a + lineSub(it), 0);
+  const orderPay = (r: { order: Order; items: Item[] }) => {
+    const sub = orderSub(r);
     const pct = Number(r.order?.discount_percent ?? 0);
     return Math.max(0, Math.round(sub * (1 - pct / 100) - Number(r.order?.discount_amount ?? 0)));
   };
-  const grandTotal = receipts.reduce((s, r) => s + orderPayable(r), 0);
+  const grandSubtotal = receipts.reduce((s, r) => s + orderSub(r), 0);
+  const grandTotal = receipts.reduce((s, r) => s + orderPay(r), 0);
+  const totalOrderDisc = grandSubtotal - grandTotal; // 倒推、含取整誤差
   const grandWalletPaid = receipts.reduce((s, r) => s + Number(r.order?.wallet_paid_amount ?? 0), 0);
   const grandBalanceDue = Math.max(0, grandTotal - grandWalletPaid);
+  const totalQty = receipts.reduce((s, r) => s + r.items.reduce((a, it) => a + Number(it.qty), 0), 0);
 
   return (
     <>
       <style jsx global>{`
         @media print {
-          @page { margin: 8mm; }
+          @page { margin: 3mm; size: 80mm auto; }
           body { background: white !important; }
           .no-print { display: none !important; }
-          .receipt-single { page-break-inside: avoid; }
-          .order-block { page-break-inside: avoid; }
         }
+        body { background: #f0f0f0; }
       `}</style>
-      <div className="mx-auto max-w-2xl p-6">
-        <div className="no-print mb-4 flex justify-end gap-2">
-          <SpinButton onClick={() => window.print()} className="rounded-md bg-zinc-900 px-4 py-2 text-sm text-white hover:bg-zinc-700">🖨️ 列印</SpinButton>
-          <SpinButton onClick={() => window.close()} className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100">關閉</SpinButton>
+      <div className="mx-auto my-4 max-w-[80mm] bg-white p-3 font-mono text-[14px] leading-tight text-black shadow print:my-0 print:shadow-none">
+        <div className="no-print mb-3 flex justify-end gap-2">
+          <SpinButton onClick={() => window.print()} className="rounded bg-zinc-900 px-3 py-1 text-xs text-white">🖨️ 列印</SpinButton>
+          <SpinButton onClick={() => window.close()} className="rounded border border-zinc-300 px-3 py-1 text-xs">關閉</SpinButton>
         </div>
 
-        {combined ? (
-          /* 整合單模式 — 多筆訂單共用 1 個 header / 1 組簽名,各訂單緊湊排列 */
-          <div className="bg-white text-zinc-900">
-            <div className="mb-3 border-b-2 border-zinc-700 pb-2 text-center">
-              <h1 className="text-xl font-bold">取貨整合單</h1>
-              <div className="mt-0.5 text-xs text-zinc-600">
-                共 {receipts.length} 張訂單 · 列印時間 {new Date().toLocaleString("zh-TW")} · 合計 $
-                {grandTotal.toLocaleString()}
-              </div>
+        <div className="text-center">
+          <div className="text-[22px] font-bold">取貨單</div>
+          {headerEvent && (
+            <div className="text-[12px] text-zinc-500">
+              {headerEvent.event_type === "picked_up" ? "全部取貨" : "部分取貨"}
             </div>
+          )}
+        </div>
 
-            {receipts.map((r, idx) => {
-              const sub = r.items.reduce((s, it) => s + lineSub(it), 0);
-              const disc = Number(r.order?.discount_amount ?? 0);
-              const pct = Number(r.order?.discount_percent ?? 0);
-              const pay = Math.max(0, Math.round(sub * (1 - pct / 100) - disc));
-              const pctDed = Math.max(0, sub - pay - disc);
-              const walletPaid = Number(r.order?.wallet_paid_amount ?? 0);
-              const balanceDue = Math.max(0, pay - walletPaid);
-              return (
-                <div
-                  key={r.event.id}
-                  className={`order-block ${idx > 0 ? "mt-3 border-t border-dashed border-zinc-400 pt-3" : ""}`}
-                >
-                  <div className="mb-1.5 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5 text-xs">
-                    <span className="font-mono text-sm font-bold">{r.order?.order_no ?? "—"}</span>
-                    <span>
-                      {r.order?.member?.name ?? "—"}
-                      {r.order?.member?.phone && (
-                        <span className="ml-1 font-mono text-zinc-600">{r.order.member.phone}</span>
-                      )}
-                    </span>
-                    <span className="text-zinc-600">{r.order?.store?.name ?? "—"}</span>
-                    <span className="text-zinc-600">{r.order?.campaign?.name ?? "—"}</span>
-                  </div>
-                  <table className="w-full border-collapse text-xs">
-                    <tbody>
-                      {r.items.map((it) => {
-                        const itSub = lineSub(it);
-                        const itGross = lineGross(it);
-                        const discounted = hasLineDisc(it);
-                        return (
-                          <Fragment key={it.id}>
-                            <tr className={it.notes ? "" : "border-b border-zinc-200"}>
-                              <td className="px-1 py-0.5">
-                                <span className="font-medium">
-                                  {it.sku?.variant_name ?? it.sku?.product_name ?? "—"}
-                                </span>
-                                {it.sku?.sku_code && (
-                                  <span className="ml-1 font-mono text-[9px] text-zinc-500">
-                                    {it.sku.sku_code}
-                                  </span>
-                                )}
-                                {discounted && (
-                                  <span className="ml-1 rounded bg-red-100 px-1 text-[9px] font-bold text-red-700">
-                                    {Number(it.discount_percent ?? 0) > 0 ? `${it.discount_percent}%` : `減$${it.discount_amount}`}
-                                  </span>
-                                )}
-                              </td>
-                              <td className="px-1 py-0.5 text-right font-mono">× {Number(it.qty)}</td>
-                              <td className="px-1 py-0.5 text-right font-mono text-zinc-500">
-                                ${Number(it.unit_price)}
-                              </td>
-                              <td className="px-1 py-0.5 text-right font-mono">
-                                {discounted ? (
-                                  <>
-                                    <span className="mr-1 text-zinc-400 line-through">${itGross}</span>
-                                    <span className="font-bold text-red-700">${itSub}</span>
-                                  </>
-                                ) : (
-                                  <>${itSub}</>
-                                )}
-                              </td>
-                            </tr>
-                            {it.notes && (
-                              <tr className="border-b border-zinc-200">
-                                <td colSpan={4} className="px-1 pb-1 text-[10px] italic text-zinc-600">
-                                  ↳ 備註：{it.notes}
-                                </td>
-                              </tr>
-                            )}
-                          </Fragment>
-                        );
-                      })}
-                      <tr>
-                        <td colSpan={3} className="px-1 py-0.5 text-right text-zinc-600">本單小計</td>
-                        <td className="px-1 py-0.5 text-right font-mono">${sub}</td>
-                      </tr>
-                      {pct > 0 && (
-                        <tr>
-                          <td colSpan={3} className="px-1 py-0.5 text-right text-zinc-600">− 折扣 {pct}%</td>
-                          <td className="px-1 py-0.5 text-right font-mono">−${pctDed}</td>
-                        </tr>
-                      )}
-                      {disc > 0 && (
-                        <tr>
-                          <td colSpan={3} className="px-1 py-0.5 text-right text-zinc-600">− 折扣金額</td>
-                          <td className="px-1 py-0.5 text-right font-mono">−${disc}</td>
-                        </tr>
-                      )}
-                      <tr className="font-bold">
-                        <td colSpan={3} className="px-1 py-0.5 text-right">本單應收</td>
-                        <td className="px-1 py-0.5 text-right font-mono">${pay}</td>
-                      </tr>
-                      {walletPaid > 0 && (
-                        <>
-                          <tr>
-                            <td colSpan={3} className="px-1 py-0.5 text-right text-zinc-600">− 已用儲值金</td>
-                            <td className="px-1 py-0.5 text-right font-mono">−${walletPaid}</td>
-                          </tr>
-                          <tr className="font-bold">
-                            <td colSpan={3} className="px-1 py-0.5 text-right">
-                              {balanceDue === 0 ? "✅ 已付清" : "應付剩餘"}
-                            </td>
-                            <td className="px-1 py-0.5 text-right font-mono">${balanceDue}</td>
-                          </tr>
-                        </>
-                      )}
-                    </tbody>
-                  </table>
-                  {r.order?.notes && (
-                    <div className="mt-1 text-[10px] text-zinc-700">📝 訂單備註：{r.order.notes}</div>
-                  )}
-                  {r.event.notes && (
-                    <div className="mt-1 text-[10px] text-zinc-600">取貨備註：{r.event.notes}</div>
-                  )}
-                </div>
-              );
-            })}
-
-            <div className="mt-3 border-t-2 border-zinc-700 pt-2 text-right text-sm">
-              <div className="font-bold">合計 ${grandTotal.toLocaleString()}</div>
-              {grandWalletPaid > 0 && (
-                <>
-                  <div className="text-zinc-600">− 已用儲值金 ${grandWalletPaid.toLocaleString()}</div>
-                  <div className="font-bold">
-                    {grandBalanceDue === 0
-                      ? "✅ 已付清"
-                      : <>應付剩餘 ${grandBalanceDue.toLocaleString()}</>}
-                  </div>
-                </>
-              )}
-            </div>
+        <div className="mt-2 border-y border-dashed border-black py-1.5">
+          <div className="text-[18px] font-bold">{member?.name ?? "—"}</div>
+          <div className="text-[13px]">
+            {member?.member_no}
+            {member?.phone && <span className="ml-2">{member.phone}</span>}
           </div>
-        ) : (
-          /* 單筆模式 — 維持原本格式 */
-          receipts.map((r) => (
-            <div key={r.event.id} className="receipt-single bg-white p-4 text-zinc-900">
-              <div className="mb-3 text-center">
-                <h1 className="text-3xl font-bold">取貨單</h1>
-                <div className="text-base text-zinc-500">
-                  {r.event.event_type === "picked_up" ? "全部取貨" : "部分取貨"}
-                </div>
+          {store && <div className="text-[13px]">取貨店：{store.name}</div>}
+          <div className="text-[12px] text-zinc-500">
+            {headerEvent ? new Date(headerEvent.created_at).toLocaleString("zh-TW", { hour12: false }) : ""}
+          </div>
+        </div>
+
+        <div className="mt-2 space-y-2">
+          {receipts.map((r) => {
+            const disc = Number(r.order?.discount_amount ?? 0);
+            const pct = Number(r.order?.discount_percent ?? 0);
+            const sub = orderSub(r);
+            const pay = orderPay(r);
+            // pctDed 倒推（subtotal − pct − amt = payable，所以 pctDed = subtotal − payable − amt）
+            const pctDed = Math.max(0, sub - pay - disc);
+            return (
+              <div key={r.event.id} className="border-b border-dashed border-zinc-400 pb-1">
+                <div className="text-[13px]">{r.order?.campaign?.name ?? "(未知活動)"}</div>
+                {r.order?.notes && (
+                  <div className="text-[13px] italic">📝 {r.order.notes}</div>
+                )}
+                {r.items.map((it) => {
+                  const subtotal = lineSub(it);
+                  const gross = lineGross(it);
+                  const discounted = hasLineDisc(it);
+                  return (
+                    <div key={it.id}>
+                      <div className="flex items-baseline justify-between gap-2">
+                        <span className="min-w-0 flex-1 break-words text-[16px] font-bold">
+                          {it.sku?.variant_name || it.sku?.product_name || "—"}
+                        </span>
+                        <span className="whitespace-nowrap text-[15px]">
+                          × {Number(it.qty)}
+                          {discounted ? (
+                            <>
+                              <span className="ml-1.5 text-[13px] line-through">${gross}</span>
+                              <span className="ml-1 text-[15px] font-bold">${subtotal}</span>
+                            </>
+                          ) : (
+                            <span className="ml-1.5 text-[15px]">${subtotal}</span>
+                          )}
+                        </span>
+                      </div>
+                      {discounted && (
+                        <div className="pl-2 text-[13px] font-bold text-red-700">
+                          ↳ 折扣 {Number(it.discount_percent ?? 0) > 0
+                            ? `${it.discount_percent}% (= -$${Math.round(gross * Number(it.discount_percent)) / 100})`
+                            : `-$${it.discount_amount}`}
+                        </div>
+                      )}
+                      {it.notes && (
+                        <div className="pl-2 text-[13px] italic">↳ 備註：{it.notes}</div>
+                      )}
+                    </div>
+                  );
+                })}
+                {pct > 0 && (
+                  <div className="text-right text-[13px]">
+                    <span className="text-zinc-600">本單{pct}%折扣 </span>
+                    <span>−${pctDed}</span>
+                  </div>
+                )}
+                {disc > 0 && (
+                  <div className="text-right text-[13px]">
+                    <span className="text-zinc-600">本單折扣金額 </span>
+                    <span>−${disc}</span>
+                  </div>
+                )}
+                {r.event.notes && (
+                  <div className="text-[12px] text-zinc-500">取貨備註：{r.event.notes}</div>
+                )}
               </div>
+            );
+          })}
+        </div>
 
-              <div className="mb-3 grid grid-cols-2 gap-x-4 gap-y-1.5 text-base">
-                <Field label="訂單號" value={<span className="font-mono font-semibold">{r.order?.order_no ?? "—"}</span>} />
-                <Field label="取貨時間" value={new Date(r.event.created_at).toLocaleString("zh-TW")} />
-                <Field label="會員" value={r.order?.member ? `${r.order.member.name ?? "—"} (${r.order.member.member_no})` : "—"} />
-                <Field label="電話" value={r.order?.member?.phone ?? "—"} />
-                <Field label="取貨店" value={r.order?.store?.name ?? "—"} />
-                <Field label="開團" value={r.order?.campaign ? `${r.order.campaign.campaign_no} ${r.order.campaign.name}` : "—"} />
+        <div className="mt-2 border-t-2 border-black pt-1.5 text-right text-[14px]">
+          <div>小計 $ {grandSubtotal.toLocaleString()}</div>
+          {totalOrderDisc > 0 && <div>− 整單折扣 $ {totalOrderDisc.toLocaleString()}</div>}
+          <div className="text-[20px] font-bold">合計 {totalQty} 項　$ {grandTotal.toLocaleString()}</div>
+          {grandWalletPaid > 0 && (
+            <>
+              <div className="mt-1">− 已用儲值金 $ {grandWalletPaid.toLocaleString()}</div>
+              <div className="text-[17px] font-bold">
+                {grandBalanceDue === 0
+                  ? "✅ 已付清"
+                  : <>應收現金 $ {grandBalanceDue.toLocaleString()}</>}
               </div>
-
-              <table className="mb-2 w-full border-collapse text-base">
-                <thead>
-                  <tr className="border-b-2 border-zinc-400">
-                    <th className="px-2 py-1 text-left">商品</th>
-                    <th className="px-2 py-1 text-right">數量</th>
-                    <th className="px-2 py-1 text-right">單價</th>
-                    <th className="px-2 py-1 text-right">小計</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {r.items.map((it) => {
-                    const sub = lineSub(it);
-                    const gross = lineGross(it);
-                    const discounted = hasLineDisc(it);
-                    return (
-                      <Fragment key={it.id}>
-                        <tr className={it.notes ? "" : "border-b border-zinc-200"}>
-                          <td className="px-2 py-1">
-                            <span className="font-medium">{it.sku?.variant_name ?? it.sku?.product_name ?? "—"}</span>
-                            {it.sku?.sku_code && <span className="ml-1 font-mono text-xs text-zinc-500">{it.sku.sku_code}</span>}
-                            {discounted && (
-                              <span className="ml-1 rounded bg-red-100 px-1 text-[11px] font-bold text-red-700">
-                                {Number(it.discount_percent ?? 0) > 0 ? `${it.discount_percent}%` : `減$${it.discount_amount}`}
-                              </span>
-                            )}
-                          </td>
-                          <td className="px-2 py-1 text-right font-mono">{Number(it.qty)}</td>
-                          <td className="px-2 py-1 text-right font-mono">${Number(it.unit_price)}</td>
-                          <td className="px-2 py-1 text-right font-mono">
-                            {discounted ? (
-                              <>
-                                <span className="mr-1 text-zinc-400 line-through">${gross}</span>
-                                <span className="font-bold text-red-700">${sub}</span>
-                              </>
-                            ) : (
-                              <>${sub}</>
-                            )}
-                          </td>
-                        </tr>
-                        {it.notes && (
-                          <tr className="border-b border-zinc-200">
-                            <td colSpan={4} className="px-2 pb-1 text-xs italic text-zinc-600">
-                              ↳ 備註：{it.notes}
-                            </td>
-                          </tr>
-                        )}
-                      </Fragment>
-                    );
-                  })}
-                </tbody>
-                <tfoot>
-                  {(() => {
-                    const sub = r.items.reduce((s, it) => s + lineSub(it), 0);
-                    const disc = Number(r.order?.discount_amount ?? 0);
-                    const pct = Number(r.order?.discount_percent ?? 0);
-                    const pay = Math.max(0, Math.round(sub * (1 - pct / 100) - disc));
-                    const pctDed = Math.max(0, sub - pay - disc);
-                    const walletPaid = Number(r.order?.wallet_paid_amount ?? 0);
-                    const balanceDue = Math.max(0, pay - walletPaid);
-                    return (
-                      <>
-                        <tr className="border-t border-zinc-300">
-                          <td colSpan={3} className="px-2 py-1 text-right text-sm text-zinc-600">小計</td>
-                          <td className="px-2 py-1 text-right font-mono">${sub}</td>
-                        </tr>
-                        {pct > 0 && (
-                          <tr>
-                            <td colSpan={3} className="px-2 py-1 text-right text-sm text-zinc-600">− 折扣 {pct}%</td>
-                            <td className="px-2 py-1 text-right font-mono">−${pctDed}</td>
-                          </tr>
-                        )}
-                        {disc > 0 && (
-                          <tr>
-                            <td colSpan={3} className="px-2 py-1 text-right text-sm text-zinc-600">− 折扣金額</td>
-                            <td className="px-2 py-1 text-right font-mono">−${disc}</td>
-                          </tr>
-                        )}
-                        <tr className="border-t-2 border-zinc-400 text-xl font-bold">
-                          <td colSpan={3} className="px-2 py-2 text-right">應收</td>
-                          <td className="px-2 py-2 text-right font-mono">${pay}</td>
-                        </tr>
-                        {walletPaid > 0 && (
-                          <>
-                            <tr>
-                              <td colSpan={3} className="px-2 py-1 text-right text-sm text-zinc-600">− 已用儲值金</td>
-                              <td className="px-2 py-1 text-right font-mono">−${walletPaid}</td>
-                            </tr>
-                            <tr className="border-t border-zinc-300 font-bold">
-                              <td colSpan={3} className="px-2 py-1 text-right">
-                                {balanceDue === 0 ? "✅ 已付清" : "應付剩餘"}
-                              </td>
-                              <td className="px-2 py-1 text-right font-mono">${balanceDue}</td>
-                            </tr>
-                          </>
-                        )}
-                      </>
-                    );
-                  })()}
-                </tfoot>
-              </table>
-
-              {r.order?.notes && (
-                <div className="mb-1 text-sm text-zinc-700">📝 訂單備註：{r.order.notes}</div>
-              )}
-              {r.event.notes && (
-                <div className="mb-2 text-sm text-zinc-600">取貨備註：{r.event.notes}</div>
-              )}
-            </div>
-          ))
-        )}
+            </>
+          )}
+        </div>
       </div>
     </>
-  );
-}
-
-function Field({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div>
-      <span className="text-sm text-zinc-500">{label}：</span>
-      <span>{value}</span>
-    </div>
   );
 }


### PR DESCRIPTION
「**取貨單**」（取貨時一定印的那張收據）改成跟「**取貨清單 / 小白單**」一樣的乾淨大字版型。

> 接續 [#426](https://github.com/lt-foods/new_erp/pull/426)：該 PR 早一步 merge，只進了「字級放大」版；後續的小白單改版未進 main，故依慣例 off 最新 main 另開本 PR。

## 做法

把 `/pickup/print`（取貨單）整頁重寫，對齊 `/pickup/print-list`（取貨清單）的 **80mm 熱感版型**：

- `@page { size: 80mm auto }`、`font-mono`、虛線分隔
- **表頭**：會員姓名（大粗體）+ 會員編號 / 電話 + 取貨店 + 取貨時間（取實際 `event.created_at`）
- **品項**：團名 → 大粗體品項名　× 數量　\$小計（含品項層級折扣 / 備註）
- **結尾**：小計 / 整單折扣 / **合計 N 項 \$總額** / 已用儲值金 / 應收現金（或 ✅ 已付清）
- 保留「取貨單」標題 + 「全部取貨 / 部分取貨」標記（與取貨清單區分）
- 同一會員多張訂單（bulk 一次全取）共用單一表頭

## 不動的部分

- **金額計算**沿用原本 `orderPayable` 邏輯，完全未更動；只改版面與標籤。
- **列印流程不變、兩張單不合併**：
  - 取貨單（`print`，本次取走的收據）— 取貨時一定印
  - 取貨清單（`print-list`，剩餘未取的提醒）— 只在「部分取貨」時印
  - 兩者內容不同、時機不同，現在只是視覺風格一致。

## 驗證

- 靜態檢視：版型直接沿用已上線的 `print-list` 寫法（相同 Tailwind / 結構），imports 皆有使用、JSX 平衡、金額邏輯未變。
- 實際 80mm 熱感列印效果請於本機自審（admin 列印頁需實際取貨資料才能 render）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)