### PR TITLE
總倉收件匣異常清單:伺服器端真分頁

### DIFF
--- a/apps/admin/src/components/ExceptionsContent.tsx
+++ b/apps/admin/src/components/ExceptionsContent.tsx
@@ -6,11 +6,14 @@
 //   2. 進貨破損 — GR qty_damaged > 0
 //   3. 過量進貨 — GR cumulative qty_received > qty_ordered
 //   4. 收貨短少 — Transfer received 但 qty_received < qty_shipped
+//   5. 訂單短少 — v_order_shortage 聚合到 order 維度
+//
+// 資料與分頁:全部走 server-side。rpc_hq_exceptions(type, page, page_size)
+// 後端 union 5 來源(v_hq_exceptions)做真分頁,一次回傳 { total, counts(各 tab), rows(當前頁) }。
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
-import { fetchAllRows } from "@/lib/fetchAllRows";
 import SpinButton from "./SpinButton";
 import { TransferShortageResolveModal, type ShortageContext } from "./TransferShortageResolveModal";
 
@@ -25,19 +28,14 @@ const TAB_LABEL: Record<Tab, string> = {
   customer_shortage: "訂單短少",
 };
 
-const RESOLUTION_LABEL: Record<string, string> = {
-  notified: "✓ 已通知客戶",
-  cancelled: "✓ 已取消退款",
-  reallocated: "✓ 已改派",
-  waiting_next_po: "⏳ 等下批 PO",
-};
-
-// 與 /hq/inbox 其他來源一致的每頁筆數(client-side 分頁,資料已全撈在前端)
+// 與 /hq/inbox 其他來源一致的每頁筆數
 const PAGE_SIZE = 20;
+
+type ExceptionType = "po_shortage" | "po_damage" | "po_over" | "transfer_short" | "customer_shortage";
 
 type ExceptionRow = {
   key: string;
-  type: "po_shortage" | "po_damage" | "po_over" | "transfer_short" | "customer_shortage";
+  type: ExceptionType;
   ts: string;
   doc_no: string;
   doc_link: string;
@@ -54,6 +52,45 @@ type ExceptionRow = {
   shortage_resolution?: string | null;
 };
 
+// rpc_hq_exceptions 回傳的單列(= v_hq_exceptions 扁平欄位)
+type ViewRow = {
+  type: ExceptionType;
+  row_key: string;
+  ts: string | null;
+  doc_no: string;
+  sku_code: string | null;
+  sku_label: string;
+  expected: number | string;
+  actual: number | string;
+  diff: number | string;
+  reason: string | null;
+  extra: string;
+  transfer_item_id: number | null;
+  transfer_id: number | null;
+  transfer_no: string | null;
+  sku_id: number | null;
+  qty_shipped: number | string | null;
+  qty_received: number | string | null;
+  shortage_qty: number | string | null;
+  dest_location: number | null;
+  dest_store_id: number | null;
+  dest_store_name: string | null;
+  customer_order_id: number | null;
+  shortage_resolution: string | null;
+};
+
+type ExceptionCounts = Record<Tab, number>;
+
+const EMPTY_COUNTS: ExceptionCounts = {
+  all: 0, po_shortage: 0, po_damage: 0, po_over: 0, transfer_short: 0, customer_shortage: 0,
+};
+
+function docLinkFor(r: ViewRow): string {
+  if (r.type === "customer_shortage") return `/orders?id=${r.customer_order_id}`;
+  if (r.type === "transfer_short") return `/wms/inbound`;
+  return `/wms/receiving`;
+}
+
 export default function ExceptionsContent({
   showHeader = true,
   onCountChange,
@@ -62,6 +99,8 @@ export default function ExceptionsContent({
   onCountChange?: (count: number) => void;
 }) {
   const [rows, setRows] = useState<ExceptionRow[] | null>(null);
+  const [counts, setCounts] = useState<ExceptionCounts | null>(null);
+  const [total, setTotal] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState<Tab>("all");
   const [resolveCtx, setResolveCtx] = useState<ShortageContext | null>(null);
@@ -101,299 +140,97 @@ export default function ExceptionsContent({
     }
   }
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const sb = getSupabase();
-
-        const { data: pickingDemand, error: e1 } = await sb
-          .from("v_picking_demand_by_po")
-          .select("po_id, po_no, po_status, sku_id, sku_code, sku_label, qty_ordered, gr_qty, qty_shortage")
-          .gt("qty_shortage", 0);
-        if (e1) throw new Error("po_shortage: " + e1.message);
-
-        const { data: damageRows, error: e2 } = await sb
-          .from("goods_receipt_items")
-          .select("id, gr_id, sku_id, qty_received, qty_damaged, variance_reason, gr:goods_receipts!inner(id, gr_no, po_id, status, created_at)")
-          .gt("qty_damaged", 0)
-          .eq("gr.status", "confirmed");
-        if (e2) throw new Error("po_damage: " + e2.message);
-
-        // 無 filter 撈整張 v_picking_demand_by_po（PO×SKU×store 矩陣，會破千列），
-        // 必須分頁，否則 PostgREST 1000 列上限會漏掉部分 PO 的過量進貨異常。
-        // 依 view grain (po_item_id, store_id) 排序給分頁穩定 total order。
-        const overRows = await fetchAllRows<{ po_id: number; po_no: string; po_status: string; sku_id: number; sku_code: string | null; sku_label: string; qty_ordered: number; gr_qty: number }>(() =>
-          sb.from("v_picking_demand_by_po")
-            .select("po_id, po_no, po_status, sku_id, sku_code, sku_label, qty_ordered, gr_qty")
-            .order("po_item_id", { ascending: true })
-            .order("store_id", { ascending: true, nullsFirst: false }),
-        );
-
-        const { data: tShortRows, error: e4 } = await sb
-          .from("transfer_items")
-          .select("id, transfer_id, sku_id, qty_shipped, qty_received, damage_qty, shortage_resolution, transfer:transfers!inner(id, transfer_no, status, dest_location)")
-          .eq("transfer.status", "received")
-          .is("shortage_resolution", null);
-        if (e4) throw new Error("transfer_short: " + e4.message);
-
-        // 5. 客戶訂單短少 — v_order_shortage,以 order_id 聚合
-        const { data: custShortRows, error: e5 } = await sb
-          .from("v_order_shortage")
-          .select(
-            "order_id, order_no, member_id, store_name, order_status, shortage_resolution, shortage_notified_at, sku_id, product_name, variant_name, sku_code, order_qty, demand_unfulfillable, order_updated_at",
-          )
-          .limit(20000);
-        if (e5) throw new Error("customer_shortage: " + e5.message);
-
-        const destLocs = Array.from(new Set(((tShortRows ?? []) as Array<{ transfer: { dest_location: number } | { dest_location: number }[] }>)
-          .map((r) => Array.isArray(r.transfer) ? r.transfer[0]?.dest_location : r.transfer?.dest_location)
-          .filter((x): x is number => typeof x === "number")));
-        const destStoreMap = new Map<number, { id: number; name: string; loc_name: string }>();
-        if (destLocs.length > 0) {
-          const [{ data: lr }, { data: sr }] = await Promise.all([
-            sb.from("locations").select("id, name").in("id", destLocs),
-            sb.from("stores").select("id, name, location_id").in("location_id", destLocs),
-          ]);
-          const locNameMap = new Map<number, string>();
-          for (const l of (lr ?? []) as Array<{ id: number; name: string }>) locNameMap.set(l.id, l.name);
-          for (const s of (sr ?? []) as Array<{ id: number; name: string; location_id: number | null }>) {
-            if (s.location_id !== null) {
-              destStoreMap.set(s.location_id, { id: s.id, name: s.name, loc_name: locNameMap.get(s.location_id) ?? `#${s.location_id}` });
-            }
-          }
-          for (const lid of destLocs) {
-            if (!destStoreMap.has(lid)) {
-              destStoreMap.set(lid, { id: 0, name: locNameMap.get(lid) ?? `#${lid}`, loc_name: locNameMap.get(lid) ?? `#${lid}` });
-            }
-          }
-        }
-
-        const skuIds = new Set<number>();
-        for (const r of (damageRows ?? []) as Array<{ sku_id: number }>) skuIds.add(r.sku_id);
-        for (const r of (tShortRows ?? []) as Array<{ sku_id: number }>) skuIds.add(r.sku_id);
-        const skuMap = new Map<number, { sku_code: string | null; product_name: string | null; variant_name: string | null }>();
-        if (skuIds.size > 0) {
-          const { data: sk } = await sb.from("skus").select("id, sku_code, product_name, variant_name").in("id", Array.from(skuIds));
-          for (const r of (sk ?? []) as Array<{ id: number; sku_code: string | null; product_name: string | null; variant_name: string | null }>) {
-            skuMap.set(r.id, { sku_code: r.sku_code, product_name: r.product_name, variant_name: r.variant_name });
-          }
-        }
-        function skuLabel(id: number): { code: string | null; label: string } {
-          const s = skuMap.get(id);
-          if (!s) return { code: null, label: `品項#${id}` };
-          const lbl = `${s.product_name ?? ""}${s.variant_name ? ` / ${s.variant_name}` : ""}`.trim() || `品項#${id}`;
-          return { code: s.sku_code, label: lbl };
-        }
-
-        const all: ExceptionRow[] = [];
-
-        const poShortageSeen = new Set<string>();
-        for (const r of ((pickingDemand ?? []) as Array<{ po_id: number; po_no: string; po_status: string; sku_id: number; sku_code: string | null; sku_label: string; qty_ordered: number; gr_qty: number; qty_shortage: number }>)) {
-          const k = `${r.po_id}:${r.sku_id}`;
-          if (poShortageSeen.has(k)) continue;
-          poShortageSeen.add(k);
-          all.push({
-            key: `po-short-${k}`,
-            type: "po_shortage",
-            ts: "—",
-            doc_no: r.po_no,
-            doc_link: `/wms/receiving`,
-            sku_code: r.sku_code,
-            sku_label: r.sku_label,
-            expected: Number(r.qty_ordered),
-            actual: Number(r.gr_qty),
-            diff: Number(r.qty_shortage),
-            reason: null,
-            extra: "PO 已關單,差額不會到",
-          });
-        }
-
-        for (const r of ((damageRows ?? []) as Array<{ id: number; gr_id: number; sku_id: number; qty_received: number; qty_damaged: number; variance_reason: string | null; gr: { id: number; gr_no: string; po_id: number; status: string; created_at: string } | { id: number; gr_no: string; po_id: number; status: string; created_at: string }[] }>)) {
-          const gr = Array.isArray(r.gr) ? r.gr[0] : r.gr;
-          const sl = skuLabel(r.sku_id);
-          all.push({
-            key: `po-dmg-${r.id}`,
-            type: "po_damage",
-            ts: gr?.created_at ?? "—",
-            doc_no: gr?.gr_no ?? "—",
-            doc_link: `/wms/receiving`,
-            sku_code: sl.code,
-            sku_label: sl.label,
-            expected: Number(r.qty_received),
-            actual: Number(r.qty_received) - Number(r.qty_damaged),
-            diff: Number(r.qty_damaged),
-            reason: r.variance_reason,
-            extra: `已收 ${r.qty_received} 含瑕疵 ${r.qty_damaged}`,
-          });
-        }
-
-        const overSeen = new Set<string>();
-        for (const r of ((overRows ?? []) as Array<{ po_id: number; po_no: string; sku_id: number; sku_code: string | null; sku_label: string; qty_ordered: number; gr_qty: number }>)) {
-          if (Number(r.gr_qty) <= Number(r.qty_ordered)) continue;
-          const k = `${r.po_id}:${r.sku_id}`;
-          if (overSeen.has(k)) continue;
-          overSeen.add(k);
-          all.push({
-            key: `po-over-${k}`,
-            type: "po_over",
-            ts: "—",
-            doc_no: r.po_no,
-            doc_link: `/wms/receiving`,
-            sku_code: r.sku_code,
-            sku_label: r.sku_label,
-            expected: Number(r.qty_ordered),
-            actual: Number(r.gr_qty),
-            diff: Number(r.gr_qty) - Number(r.qty_ordered),
-            reason: null,
-            extra: "供應商多送或重複入庫",
-          });
-        }
-
-        for (const r of ((tShortRows ?? []) as Array<{ id: number; transfer_id: number; sku_id: number; qty_shipped: number; qty_received: number; damage_qty: number | null; transfer: { id: number; transfer_no: string; status: string; dest_location: number } | { id: number; transfer_no: string; status: string; dest_location: number }[] }>)) {
-          if (Number(r.qty_received) >= Number(r.qty_shipped)) continue;
-          const tr = Array.isArray(r.transfer) ? r.transfer[0] : r.transfer;
-          const sl = skuLabel(r.sku_id);
-          const diff = Number(r.qty_shipped) - Number(r.qty_received);
-          const destInfo = tr?.dest_location ? destStoreMap.get(tr.dest_location) : undefined;
-          all.push({
-            key: `tshort-${r.id}`,
-            type: "transfer_short",
-            ts: "—",
-            doc_no: tr?.transfer_no ?? "—",
-            doc_link: `/wms/inbound`,
-            sku_code: sl.code,
-            sku_label: sl.label,
-            expected: Number(r.qty_shipped),
-            actual: Number(r.qty_received),
-            diff,
-            reason: null,
-            extra: r.damage_qty && Number(r.damage_qty) > 0 ? `含破損 ${r.damage_qty}` : "分店少收或運送中遺失",
-            shortage_ctx: {
-              transfer_item_id: r.id,
-              transfer_id: r.transfer_id,
-              transfer_no: tr?.transfer_no ?? `#${r.transfer_id}`,
-              sku_id: r.sku_id,
-              sku_code: sl.code,
-              sku_label: sl.label,
-              qty_shipped: Number(r.qty_shipped),
-              qty_received: Number(r.qty_received),
-              shortage_qty: diff,
-              dest_location: tr?.dest_location ?? 0,
-              dest_store_id: destInfo && destInfo.id > 0 ? destInfo.id : null,
-              dest_store_name: destInfo?.name ?? `位置 #${tr?.dest_location ?? "?"}`,
-            },
-          });
-        }
-
-        // 5. 客戶訂單短少 — aggregate by order_id
-        type CustShortRaw = {
-          order_id: number;
-          order_no: string;
-          member_id: number | null;
-          store_name: string | null;
-          order_status: string;
-          shortage_resolution: string | null;
-          shortage_notified_at: string | null;
-          sku_id: number;
-          product_name: string | null;
-          variant_name: string | null;
-          sku_code: string | null;
-          order_qty: number;
-          demand_unfulfillable: number;
-          order_updated_at: string;
-        };
-        type CustShortAgg = {
-          order_id: number;
-          order_no: string;
-          member_id: number | null;
-          store_name: string | null;
-          shortage_resolution: string | null;
-          shortage_notified_at: string | null;
-          short_items: { sku_label: string; demand_unfulfillable: number }[];
-          total_unfulfillable: number;
-          total_ordered: number;
-          ts: string;
-        };
-        const custByOrder = new Map<number, CustShortAgg>();
-        for (const r of (custShortRows ?? []) as CustShortRaw[]) {
-          let s = custByOrder.get(r.order_id);
-          if (!s) {
-            s = {
-              order_id: r.order_id,
-              order_no: r.order_no,
-              member_id: r.member_id,
-              store_name: r.store_name,
-              shortage_resolution: r.shortage_resolution,
-              shortage_notified_at: r.shortage_notified_at,
-              short_items: [],
-              total_unfulfillable: 0,
-              total_ordered: 0,
-              ts: r.order_updated_at,
-            };
-            custByOrder.set(r.order_id, s);
-          }
-          const lbl = `${r.product_name ?? ""}${r.variant_name ? ` / ${r.variant_name}` : ""}`.trim() || `品項#${r.sku_id}`;
-          s.short_items.push({
-            sku_label: r.sku_code ? `${r.sku_code} ${lbl}` : lbl,
-            demand_unfulfillable: Number(r.demand_unfulfillable),
-          });
-          s.total_unfulfillable += Number(r.demand_unfulfillable);
-          s.total_ordered += Number(r.order_qty);
-        }
-        for (const s of custByOrder.values()) {
-          all.push({
-            key: `custshort-${s.order_id}`,
-            type: "customer_shortage",
-            ts: s.ts,
-            doc_no: s.order_no,
-            doc_link: `/orders?id=${s.order_id}`,
-            sku_code: null,
-            sku_label: s.short_items.map((it) => it.sku_label).join("、"),
-            expected: s.total_ordered,
-            actual: Math.max(0, s.total_ordered - s.total_unfulfillable),
-            diff: s.total_unfulfillable,
-            reason: s.shortage_resolution ? RESOLUTION_LABEL[s.shortage_resolution] ?? s.shortage_resolution : null,
-            extra: `${s.store_name ?? "—"} · 會員 #${s.member_id ?? "—"} · ${s.short_items.length} 樣品項短少`,
-            customer_order_id: s.order_id,
-            shortage_resolution: s.shortage_resolution,
-          });
-        }
-
-        if (!cancelled) {
-          setRows(all);
-          setError(null);
-          if (onCountChange) onCountChange(all.length);
-        }
-      } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [reloadTick, onCountChange]);
-
-  const counts = useMemo(() => {
-    const c: Record<Tab, number> = { all: 0, po_shortage: 0, po_damage: 0, po_over: 0, transfer_short: 0, customer_shortage: 0 };
-    for (const r of rows ?? []) {
-      c.all += 1;
-      c[r.type] += 1;
-    }
-    return c;
-  }, [rows]);
-
-  const filtered = useMemo(() => (rows ?? []).filter((r) => tab === "all" || r.type === tab), [rows, tab]);
-
   // 切換分頁籤 → 回第 1 頁(render 階段調整 state,非 effect → 不觸發 set-state-in-effect,也不會 flash 舊頁)
   if (prevTab !== tab) {
     setPrevTab(tab);
     setPage(1);
   }
 
-  // client-side 分頁(currentPage 由 page clamp 進有效範圍,避免處理後列表縮短導致超頁)
-  const total = filtered.length;
+  // server-side 抓當前 tab + page(rpc_hq_exceptions 一次回 total / 各 tab counts / 當頁 rows)
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data, error: err } = await sb.rpc("rpc_hq_exceptions", {
+          p_type: tab,
+          p_page: page,
+          p_page_size: PAGE_SIZE,
+        });
+        if (err) throw err;
+        if (cancelled) return;
+
+        const resp = (data ?? { total: 0, counts: {}, rows: [] }) as {
+          total: number;
+          counts: Partial<ExceptionCounts>;
+          rows: ViewRow[];
+        };
+
+        const mapped: ExceptionRow[] = (resp.rows ?? []).map((r) => ({
+          key: r.row_key,
+          type: r.type,
+          ts: r.ts ?? "—",
+          doc_no: r.doc_no,
+          doc_link: docLinkFor(r),
+          sku_code: r.sku_code,
+          sku_label: r.sku_label,
+          expected: Number(r.expected),
+          actual: Number(r.actual),
+          diff: Number(r.diff),
+          reason: r.reason,
+          extra: r.extra,
+          shortage_ctx:
+            r.type === "transfer_short" && r.transfer_item_id != null
+              ? {
+                  transfer_item_id: r.transfer_item_id,
+                  transfer_id: r.transfer_id ?? 0,
+                  transfer_no: r.transfer_no ?? `#${r.transfer_id}`,
+                  sku_id: r.sku_id ?? 0,
+                  sku_code: r.sku_code,
+                  sku_label: r.sku_label,
+                  qty_shipped: Number(r.qty_shipped),
+                  qty_received: Number(r.qty_received),
+                  shortage_qty: Number(r.shortage_qty),
+                  dest_location: r.dest_location ?? 0,
+                  dest_store_id: r.dest_store_id,
+                  dest_store_name: r.dest_store_name ?? `位置 #${r.dest_location ?? "?"}`,
+                }
+              : undefined,
+          customer_order_id: r.customer_order_id ?? undefined,
+          shortage_resolution: r.shortage_resolution,
+        }));
+
+        const cnts: ExceptionCounts = {
+          all: resp.counts?.all ?? 0,
+          po_shortage: resp.counts?.po_shortage ?? 0,
+          po_damage: resp.counts?.po_damage ?? 0,
+          po_over: resp.counts?.po_over ?? 0,
+          transfer_short: resp.counts?.transfer_short ?? 0,
+          customer_shortage: resp.counts?.customer_shortage ?? 0,
+        };
+
+        setRows(mapped);
+        setTotal(resp.total ?? 0);
+        setCounts(cnts);
+        setError(null);
+        if (onCountChange) onCountChange(cnts.all);
+
+        // 處理掉項目後列表縮短 → 修正超出範圍的頁碼(在 async 內、非 effect body,不觸發 set-state-in-effect)
+        if (mapped.length === 0 && page > 1 && (resp.total ?? 0) > 0) {
+          setPage(Math.max(1, Math.ceil((resp.total ?? 0) / PAGE_SIZE)));
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tab, page, reloadTick, onCountChange]);
+
+  const c = counts ?? EMPTY_COUNTS;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const currentPage = Math.min(page, totalPages);
-  const paginated = filtered.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
 
   return (
     <div className="flex flex-1 flex-col gap-4">
@@ -401,7 +238,7 @@ export default function ExceptionsContent({
         <header>
           <h1 className="text-xl font-semibold">⚠️ 異常處理</h1>
           <p className="text-sm text-zinc-500">
-            {rows === null ? "載入中…" : `共 ${rows.length} 筆異常 · 進貨短少 ${counts.po_shortage} / 進貨破損 ${counts.po_damage} / 過量 ${counts.po_over} / 收貨短少 ${counts.transfer_short} / 訂單短少 ${counts.customer_shortage}`}
+            {counts === null ? "載入中…" : `共 ${c.all} 筆異常 · 進貨短少 ${c.po_shortage} / 進貨破損 ${c.po_damage} / 過量 ${c.po_over} / 收貨短少 ${c.transfer_short} / 訂單短少 ${c.customer_shortage}`}
           </p>
         </header>
       )}
@@ -425,7 +262,7 @@ export default function ExceptionsContent({
                   : "border-transparent text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
               }`}
             >
-              {TAB_LABEL[t]} <span className="ml-1 text-xs text-zinc-400">{counts[t]}</span>
+              {TAB_LABEL[t]} <span className="ml-1 text-xs text-zinc-400">{c[t]}</span>
             </SpinButton>
           );
         })}
@@ -448,9 +285,9 @@ export default function ExceptionsContent({
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
               <tr><td colSpan={8} className="p-6 text-center text-zinc-500">載入中…</td></tr>
-            ) : filtered.length === 0 ? (
+            ) : rows.length === 0 ? (
               <tr><td colSpan={8} className="p-6 text-center text-zinc-500">沒有異常,系統運作正常 ✓</td></tr>
-            ) : paginated.map((r) => (
+            ) : rows.map((r) => (
               <tr key={r.key} className="hover:bg-zinc-50 dark:hover:bg-zinc-950">
                 <td className="px-3 py-2 whitespace-nowrap">
                   <span className={`inline-flex whitespace-nowrap rounded px-2 py-0.5 text-xs font-medium ${
@@ -526,7 +363,7 @@ export default function ExceptionsContent({
         </table>
       </div>
 
-      {/* 分頁 — client-side(資料已全撈),樣式對齊 /hq/inbox 其他來源 */}
+      {/* 分頁 — server-side(rpc_hq_exceptions),樣式對齊 /hq/inbox 其他來源 */}
       {rows !== null && total > PAGE_SIZE && (
         <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
           <span className="text-xs text-zinc-500">

--- a/supabase/migrations/20260704000020_hq_exceptions_view_and_pagination.sql
+++ b/supabase/migrations/20260704000020_hq_exceptions_view_and_pagination.sql
@@ -1,0 +1,294 @@
+-- ============================================================
+-- 總倉收件匣「異常」清單:伺服器端分頁
+--
+-- 背景:
+--   ExceptionsContent 原本把 5 種異常來源在「前端」各自全撈
+--   (其中 customer_shortage 走 v_order_shortage .limit(20000)),
+--   合併後一次塞進單一表格 — 線上已 857 筆,難捲動、傳輸量大,
+--   且非真正分頁(只是前端切片)。
+--
+-- 解法:把 5 來源 union 成單一 flat view v_hq_exceptions,
+--   再用 rpc_hq_exceptions(type, page, page_size) 做 server-side
+--   分頁 + 一次回傳各 tab 計數,前端只收當頁 20 筆。
+--
+-- 5 種異常來源(與舊前端邏輯逐欄對齊):
+--   1. po_shortage       進貨短少  v_picking_demand_by_po qty_shortage>0(去重 po×sku)
+--   2. po_damage         進貨破損  goods_receipt_items qty_damaged>0 + gr.confirmed
+--   3. po_over           過量進貨  v_picking_demand_by_po gr_qty>qty_ordered(去重 po×sku)
+--   4. transfer_short    收貨短少  transfer_items(transfer received / 未解決 / 收<出)
+--   5. customer_shortage 訂單短少  v_order_shortage 聚合到 order 維度
+--
+-- 慣例對齊:
+--   - 純 view + GRANT SELECT TO authenticated(同 v_order_shortage / v_hq_inbox)
+--   - 計數 / 分頁走 SECURITY DEFINER RPC(admin JWT role 可能 NULL,同 rpc_hq_inbox_keys)
+--
+-- 基於:無前身(此清單原為純前端計算),依賴最新
+--   v_picking_demand_by_po(20260701000010)、v_order_shortage(20260607000020)。
+-- Rollback:DROP FUNCTION public.rpc_hq_exceptions(text,int,int);
+--           DROP VIEW public.v_hq_exceptions;
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. v_hq_exceptions — 5 來源 union 的扁平異常 view
+-- ----------------------------------------------------------------
+DROP VIEW IF EXISTS public.v_hq_exceptions CASCADE;
+
+CREATE VIEW public.v_hq_exceptions AS
+-- 1. 進貨短少
+SELECT
+  'po_shortage'::text                                        AS type,
+  'po-short-' || pd.po_id::text || ':' || pd.sku_id::text    AS row_key,
+  po.created_at                                              AS ts,
+  pd.po_no                                                   AS doc_no,
+  pd.sku_code                                                AS sku_code,
+  pd.sku_label                                               AS sku_label,
+  pd.qty_ordered::numeric                                    AS expected,
+  pd.gr_qty::numeric                                         AS actual,
+  pd.qty_shortage::numeric                                   AS diff,
+  NULL::text                                                 AS reason,
+  'PO 已關單,差額不會到'::text                                AS extra,
+  NULL::bigint                                               AS transfer_item_id,
+  NULL::bigint                                               AS transfer_id,
+  NULL::text                                                 AS transfer_no,
+  pd.sku_id::bigint                                          AS sku_id,
+  NULL::numeric                                              AS qty_shipped,
+  NULL::numeric                                              AS qty_received,
+  NULL::numeric                                              AS shortage_qty,
+  NULL::bigint                                               AS dest_location,
+  NULL::bigint                                               AS dest_store_id,
+  NULL::text                                                 AS dest_store_name,
+  NULL::bigint                                               AS customer_order_id,
+  NULL::text                                                 AS shortage_resolution
+FROM (
+  SELECT DISTINCT po_id, sku_id, po_no, sku_code, sku_label, qty_ordered, gr_qty, qty_shortage
+  FROM public.v_picking_demand_by_po
+  WHERE qty_shortage > 0
+) pd
+LEFT JOIN public.purchase_orders po ON po.id = pd.po_id
+
+UNION ALL
+
+-- 2. 進貨破損
+SELECT
+  'po_damage'::text,
+  'po-dmg-' || gri.id::text,
+  gr.created_at,
+  gr.gr_no,
+  s.sku_code,
+  COALESCE(NULLIF(TRIM(COALESCE(s.product_name,'') || COALESCE(' / ' || NULLIF(s.variant_name,''), '')), ''), '品項#' || gri.sku_id::text),
+  gri.qty_received::numeric,
+  (gri.qty_received - gri.qty_damaged)::numeric,
+  gri.qty_damaged::numeric,
+  gri.variance_reason,
+  '已收 ' || gri.qty_received::text || ' 含瑕疵 ' || gri.qty_damaged::text,
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  gri.sku_id::bigint,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  NULL::bigint,
+  NULL::text
+FROM public.goods_receipt_items gri
+JOIN public.goods_receipts gr ON gr.id = gri.gr_id
+LEFT JOIN public.skus s ON s.id = gri.sku_id
+WHERE gri.qty_damaged > 0
+  AND gr.status = 'confirmed'
+
+UNION ALL
+
+-- 3. 過量進貨
+SELECT
+  'po_over'::text,
+  'po-over-' || pd.po_id::text || ':' || pd.sku_id::text,
+  po.created_at,
+  pd.po_no,
+  pd.sku_code,
+  pd.sku_label,
+  pd.qty_ordered::numeric,
+  pd.gr_qty::numeric,
+  (pd.gr_qty - pd.qty_ordered)::numeric,
+  NULL::text,
+  '供應商多送或重複入庫'::text,
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  pd.sku_id::bigint,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  NULL::bigint,
+  NULL::text
+FROM (
+  SELECT DISTINCT po_id, sku_id, po_no, sku_code, sku_label, qty_ordered, gr_qty
+  FROM public.v_picking_demand_by_po
+  WHERE gr_qty > qty_ordered
+) pd
+LEFT JOIN public.purchase_orders po ON po.id = pd.po_id
+
+UNION ALL
+
+-- 4. 收貨短少(轉貨 received 但實收 < 出貨,且尚未解決)
+SELECT
+  'transfer_short'::text,
+  'tshort-' || ti.id::text,
+  COALESCE(t.received_at, t.created_at),
+  t.transfer_no,
+  s.sku_code,
+  COALESCE(NULLIF(TRIM(COALESCE(s.product_name,'') || COALESCE(' / ' || NULLIF(s.variant_name,''), '')), ''), '品項#' || ti.sku_id::text),
+  ti.qty_shipped::numeric,
+  ti.qty_received::numeric,
+  (ti.qty_shipped - ti.qty_received)::numeric,
+  NULL::text,
+  CASE WHEN COALESCE(ti.damage_qty, 0) > 0 THEN '含破損 ' || ti.damage_qty::text ELSE '分店少收或運送中遺失' END,
+  ti.id::bigint,
+  ti.transfer_id::bigint,
+  t.transfer_no,
+  ti.sku_id::bigint,
+  ti.qty_shipped::numeric,
+  ti.qty_received::numeric,
+  (ti.qty_shipped - ti.qty_received)::numeric,
+  t.dest_location::bigint,
+  (SELECT ds.id FROM public.stores ds WHERE ds.location_id = t.dest_location ORDER BY ds.id LIMIT 1)::bigint,
+  COALESCE(
+    (SELECT ds.name FROM public.stores ds WHERE ds.location_id = t.dest_location ORDER BY ds.id LIMIT 1),
+    (SELECT l.name FROM public.locations l WHERE l.id = t.dest_location),
+    '位置 #' || COALESCE(t.dest_location::text, '?')
+  ),
+  NULL::bigint,
+  NULL::text
+FROM public.transfer_items ti
+JOIN public.transfers t ON t.id = ti.transfer_id
+LEFT JOIN public.skus s ON s.id = ti.sku_id
+WHERE t.status = 'received'
+  AND ti.shortage_resolution IS NULL
+  AND ti.qty_received < ti.qty_shipped
+
+UNION ALL
+
+-- 5. 訂單短少(v_order_shortage order×sku → 聚合到 order)
+SELECT
+  'customer_shortage'::text,
+  'custshort-' || agg.order_id::text,
+  agg.ts,
+  agg.order_no,
+  NULL::text,
+  agg.sku_label,
+  agg.expected::numeric,
+  GREATEST(0, agg.expected - agg.total_unfulfillable)::numeric,
+  agg.total_unfulfillable::numeric,
+  CASE agg.shortage_resolution
+    WHEN 'notified'        THEN '✓ 已通知客戶'
+    WHEN 'cancelled'       THEN '✓ 已取消退款'
+    WHEN 'reallocated'     THEN '✓ 已改派'
+    WHEN 'waiting_next_po' THEN '⏳ 等下批 PO'
+    ELSE NULL
+  END,
+  COALESCE(agg.store_name, '—') || ' · 會員 #' || COALESCE(agg.member_id::text, '—') || ' · ' || agg.short_item_count::text || ' 樣品項短少',
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  NULL::bigint,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  agg.order_id::bigint,
+  agg.shortage_resolution
+FROM (
+  SELECT
+    vos.order_id,
+    MAX(vos.order_no)            AS order_no,
+    MAX(vos.member_id)           AS member_id,
+    MAX(vos.store_name)          AS store_name,
+    MAX(vos.shortage_resolution) AS shortage_resolution,
+    MAX(vos.order_updated_at)    AS ts,
+    SUM(vos.order_qty)           AS expected,
+    SUM(vos.demand_unfulfillable) AS total_unfulfillable,
+    COUNT(*)                     AS short_item_count,
+    string_agg(
+      CASE
+        WHEN vos.sku_code IS NOT NULL AND vos.sku_code <> ''
+          THEN vos.sku_code || ' ' || COALESCE(NULLIF(TRIM(COALESCE(vos.product_name,'') || COALESCE(' / ' || NULLIF(vos.variant_name,''), '')), ''), '品項#' || vos.sku_id::text)
+        ELSE COALESCE(NULLIF(TRIM(COALESCE(vos.product_name,'') || COALESCE(' / ' || NULLIF(vos.variant_name,''), '')), ''), '品項#' || vos.sku_id::text)
+      END,
+      '、' ORDER BY vos.sku_id
+    )                            AS sku_label
+  FROM public.v_order_shortage vos
+  GROUP BY vos.order_id
+) agg;
+
+GRANT SELECT ON public.v_hq_exceptions TO authenticated;
+
+COMMENT ON VIEW public.v_hq_exceptions IS
+  '總倉收件匣異常統一 view:union 進貨短少/破損/過量/收貨短少/訂單短少 5 來源為扁平列,'
+  '供 rpc_hq_exceptions 做 server-side 分頁與計數。';
+
+-- ----------------------------------------------------------------
+-- 2. rpc_hq_exceptions — server-side 分頁 + 各 tab 計數(一次回傳)
+-- ----------------------------------------------------------------
+-- 回傳:
+--   {
+--     "total":  <當前 type 篩選後的總筆數>,
+--     "counts": { "all": N, "po_shortage": N, ..., "customer_shortage": N },
+--     "rows":   [ { ...v_hq_exceptions 整列... }, ... ]  -- 僅當前頁
+--   }
+-- p_type = NULL / 'all' → 不分類型;否則只回該 type。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_hq_exceptions(
+  p_type      text DEFAULT NULL,
+  p_page      int  DEFAULT 1,
+  p_page_size int  DEFAULT 20
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH ex AS MATERIALIZED (
+    SELECT * FROM public.v_hq_exceptions
+  ),
+  filtered AS (
+    SELECT * FROM ex
+    WHERE (p_type IS NULL OR p_type = 'all' OR ex.type = p_type)
+  ),
+  page AS (
+    SELECT * FROM filtered
+    ORDER BY ts DESC NULLS LAST, row_key
+    LIMIT  GREATEST(1, p_page_size)
+    OFFSET GREATEST(0, (p_page - 1) * p_page_size)
+  )
+  SELECT jsonb_build_object(
+    'total', (SELECT COUNT(*) FROM filtered),
+    'counts', (
+      SELECT jsonb_build_object(
+        'all',               COUNT(*),
+        'po_shortage',       COUNT(*) FILTER (WHERE type = 'po_shortage'),
+        'po_damage',         COUNT(*) FILTER (WHERE type = 'po_damage'),
+        'po_over',           COUNT(*) FILTER (WHERE type = 'po_over'),
+        'transfer_short',    COUNT(*) FILTER (WHERE type = 'transfer_short'),
+        'customer_shortage', COUNT(*) FILTER (WHERE type = 'customer_shortage')
+      )
+      FROM ex
+    ),
+    'rows', (
+      SELECT COALESCE(jsonb_agg(to_jsonb(page) ORDER BY ts DESC NULLS LAST, row_key), '[]'::jsonb)
+      FROM page
+    )
+  );
+$$;
+
+COMMENT ON FUNCTION public.rpc_hq_exceptions(text, int, int) IS
+  '總倉收件匣異常 server-side 分頁:回傳 { total, counts(各 tab), rows(當前頁) }。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_hq_exceptions(text, int, int) TO authenticated;


### PR DESCRIPTION
## 變更

把總倉收件匣「異常」清單(`ExceptionsContent`)從**前端切片**換成**伺服器端真分頁** — 每頁只跟 DB 要 20 筆。

> 接續 #429:那支合進 main 的是前端切片版(資料仍一次全撈、`v_order_shortage` `.limit(20000)`,只是少渲染 DOM),經回饋「沒有做實際分頁」。本 PR 才是真正的分頁。

## 怎麼做

**DB**(migration `20260704000020_hq_exceptions_view_and_pagination.sql`)
- `v_hq_exceptions` — 把 5 種異常來源 union 成一張扁平 view,逐欄對齊原前端輸出:
  進貨短少 / 進貨破損 / 過量進貨 / 收貨短少 / 訂單短少(後者由 `v_order_shortage` 以 `string_agg` 聚合到 order 維度)。純 view + `GRANT SELECT TO authenticated`,慣例同 `v_order_shortage` / `v_hq_inbox`。
- `rpc_hq_exceptions(p_type, p_page, p_page_size)` `SECURITY DEFINER` → 一次回 `{ total, counts(各 tab), rows(當前頁) }`。`MATERIALIZED` CTE 只算一次 union,`ORDER BY ts DESC NULLS LAST, row_key` 穩定排序。對齊既有 `rpc_hq_inbox_keys` / `rpc_inbox_counts`。

**前端**(`ExceptionsContent.tsx`)
- 改呼叫 `rpc_hq_exceptions(tab, page, 20)`,每頁只收 20 筆,移除前端全撈 + 聚合。
- tab 計數由 RPC 全域回傳(不受目前 type 篩選影響);切 tab 回第 1 頁(render 階段調整、非 effect,避免 `set-state-in-effect`);處理掉項目使列表縮短時自動修正超界頁碼。
- 分頁控制列樣式對齊 `/hq/inbox` 既有來源(`« 第一頁 / ‹ 上頁 / x / N / 下頁 › / 最末頁 »`)。

## ⚠️ 部署(需先套用 migration,本頁才會運作)

sandbox 連不到 prod(pooler 被擋、無 Management API token),故由你套用:

```
SUPABASE_DB_PASSWORD='<prod 密碼>' node scripts/apply_one_migration.cjs \
  supabase/migrations/20260704000020_hq_exceptions_view_and_pagination.sql
```

或把該檔整段貼進 Supabase Studio SQL Editor。部署前前端會出現「function not found」。

## 驗證

```sql
SELECT type, count(*) FROM public.v_hq_exceptions GROUP BY type;
-- 預期:customer_shortage 856、transfer_short 1、其餘 0(對得上截圖的 857)
SELECT public.rpc_hq_exceptions('all', 1, 20);  -- total 應 857
```
前端:`tsc --noEmit` 與 `eslint` 對 `ExceptionsContent.tsx` 皆 0 error。

小前提:view 用 `purchase_orders.created_at` 當排序時間戳(進貨短少/過量),為主檔標準稽核欄。

🤖 Generated with [Claude Code](https://claude.com/claude-code)