### PR TITLE
feat(dispatch): 出貨價格防呆 — 成本/分店價未設定不能出倉

### DIFF
--- a/.claude-scripts/apply_via_mgmt_api.cjs
+++ b/.claude-scripts/apply_via_mgmt_api.cjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// 對 prod 跑 SQL — 走 Supabase Management API（pooler TCP 在本環境被擋，見 CLAUDE.md）。
+// 用法：
+//   node .claude-scripts/apply_via_mgmt_api.cjs <migration.sql>          # 套整檔
+//   node .claude-scripts/apply_via_mgmt_api.cjs --sql "SELECT ..."       # ad-hoc 查詢
+// 需要 SUPABASE_ACCESS_TOKEN（sbp_ 開頭的 personal access token）。
+const fs = require('fs');
+
+const PROJECT_REF = 'anfyoeviuhmzzrhilwtm';
+const token = process.env.SUPABASE_ACCESS_TOKEN;
+if (!token) {
+  console.error('Set SUPABASE_ACCESS_TOKEN env var (https://supabase.com/dashboard/account/tokens)');
+  process.exit(2);
+}
+
+let sql;
+if (process.argv[2] === '--sql') {
+  sql = process.argv[3];
+} else if (process.argv[2]) {
+  sql = fs.readFileSync(process.argv[2], 'utf8');
+}
+if (!sql) {
+  console.error('usage: apply_via_mgmt_api.cjs <sql_path> | --sql "<query>"');
+  process.exit(2);
+}
+
+(async () => {
+  const res = await fetch(`https://api.supabase.com/v1/projects/${PROJECT_REF}/database/query`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: sql }),
+  });
+  const body = await res.text();
+  if (!res.ok) {
+    console.error(`FAIL HTTP ${res.status}: ${body}`);
+    process.exit(1);
+  }
+  try {
+    console.log(JSON.stringify(JSON.parse(body), null, 2));
+  } catch {
+    console.log(body);
+  }
+})().catch((e) => { console.error('FAIL:', e.message); process.exit(1); });

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -40,6 +40,8 @@ type DemandRow = {
 type Supplier = { id: number; code: string; name: string };
 type AllocKey = string; // `${sku_id}:${store_id}`
 type ViewMode = "matrix" | "by_store";
+// 現行成本價 / 分店價是否已設定（出貨守衛 _missing_dispatch_prices 的前端預警）
+type PriceFlags = { cost: boolean; branch: boolean };
 
 type RestockRow = {
   restock_request_id: number;
@@ -79,6 +81,11 @@ export default function PickingWorkstationPage() {
   const [reloadKey, setReloadKey] = useState(0);
   // 勾選的品項（sku_id）。空集合 = 未篩選 → 建單時納入全部；非空 → 只建選取的品項。
   const [selectedSkus, setSelectedSkus] = useState<Set<number>>(new Set());
+  // 缺價預警：sku_id → 現行成本/分店價是否存在。null = 未載入或此 role 看不到價格（不顯示）。
+  const [priceFlags, setPriceFlags] = useState<Map<number, PriceFlags> | null>(null);
+  const [canFixPrices, setCanFixPrices] = useState(false);
+  const [priceEdit, setPriceEdit] = useState<{ skuId: number; scope: "cost" | "branch" } | null>(null);
+  const [priceDraft, setPriceDraft] = useState("");
 
   useEffect(() => {
     let cancelled = false;
@@ -116,6 +123,144 @@ export default function PickingWorkstationPage() {
     })();
     return () => { cancelled = true; };
   }, [reloadKey]);
+
+  // ===== 缺價預警：抓畫面上所有 SKU 的現行成本價 / 分店價 =====
+  // 與 DB 守衛 _missing_dispatch_prices 同條件（scope cost/branch、effective_to IS NULL、price>0）。
+  // 只有讀得到 cost/branch 價的 HQ role 才檢查 — 其他 role 被 RLS 濾掉會整片誤判缺價。
+  useEffect(() => {
+    if (!demand && !restockDemand) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data: sess } = await sb.auth.getSession();
+        const role =
+          ((sess.session?.user?.app_metadata as { role?: string } | undefined)?.role ?? "");
+        if (!["owner", "admin", "hq_manager", "hq_accountant"].includes(role)) {
+          if (!cancelled) { setCanFixPrices(false); setPriceFlags(null); }
+          return;
+        }
+        const ids = new Set<number>();
+        for (const r of demand ?? []) ids.add(r.sku_id);
+        for (const r of restockDemand ?? []) ids.add(r.sku_id);
+        const all = Array.from(ids);
+        const flags = new Map<number, PriceFlags>();
+        for (const id of all) flags.set(id, { cost: false, branch: false });
+        for (let i = 0; i < all.length; i += 150) {
+          const chunk = all.slice(i, i + 150);
+          const { data, error: e } = await sb
+            .from("prices")
+            .select("sku_id, scope, price")
+            .in("scope", ["cost", "branch"])
+            .is("effective_to", null)
+            .gt("price", 0)
+            .in("sku_id", chunk);
+          if (e) throw new Error(e.message);
+          for (const row of (data ?? []) as { sku_id: number; scope: "cost" | "branch" }[]) {
+            const f = flags.get(row.sku_id);
+            if (f) f[row.scope] = true;
+          }
+        }
+        if (!cancelled) { setCanFixPrices(true); setPriceFlags(flags); }
+      } catch {
+        // 缺價檢查失敗不影響工作台主流程，僅不顯示預警
+        if (!cancelled) { setCanFixPrices(false); setPriceFlags(null); }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [demand, restockDemand]);
+
+  // 補價：呼叫既有價格 wrapper RPC，成功後就地更新旗標（出貨守衛即放行）
+  async function savePrice(skuId: number, scope: "cost" | "branch") {
+    const val = Number(priceDraft);
+    if (!Number.isFinite(val) || val <= 0) return;
+    try {
+      const sb = getSupabase();
+      const { error: e } = await sb.rpc(
+        scope === "cost" ? "rpc_set_cost_price" : "rpc_set_branch_price",
+        { p_sku_id: skuId, p_price: val, p_reason: "派貨工作台補價" },
+      );
+      if (e) throw new Error(e.message);
+      setPriceFlags((prev) => {
+        if (!prev) return prev;
+        const next = new Map(prev);
+        const cur = next.get(skuId) ?? { cost: false, branch: false };
+        next.set(skuId, { ...cur, [scope]: true });
+        return next;
+      });
+      setPriceEdit(null);
+      setPriceDraft("");
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  // 缺價 pill（文字標籤）＋ 點擊 inline 補價
+  function renderPriceTags(skuId: number) {
+    if (!canFixPrices || !priceFlags) return null;
+    const f = priceFlags.get(skuId);
+    if (!f) return null;
+    const missing: ("cost" | "branch")[] = [];
+    if (!f.cost) missing.push("cost");
+    if (!f.branch) missing.push("branch");
+    if (missing.length === 0) return null;
+    return (
+      <>
+        {missing.map((scope) => {
+          const label = scope === "cost" ? "缺成本" : "缺分店價";
+          const isEditing = priceEdit?.skuId === skuId && priceEdit.scope === scope;
+          if (isEditing) {
+            const val = Number(priceDraft);
+            const valid = Number.isFinite(val) && val > 0;
+            return (
+              <span key={scope} className="inline-flex items-center gap-1">
+                <input
+                  type="number"
+                  min={0.01}
+                  step="0.01"
+                  autoFocus
+                  value={priceDraft}
+                  onChange={(e) => setPriceDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") { setPriceEdit(null); setPriceDraft(""); }
+                  }}
+                  placeholder={scope === "cost" ? "成本價" : "分店價"}
+                  aria-label={`輸入${scope === "cost" ? "成本價" : "分店價"}`}
+                  className="w-16 rounded border border-rose-300 px-1 py-0.5 font-mono text-[11px] tabular-nums dark:border-rose-700 dark:bg-zinc-800"
+                />
+                <SpinButton
+                  onClick={() => savePrice(skuId, scope)}
+                  disabled={!valid}
+                  className="rounded bg-rose-600 px-1.5 py-0.5 text-[10px] font-medium text-white hover:bg-rose-700 disabled:opacity-40"
+                >
+                  儲存
+                </SpinButton>
+                <button
+                  type="button"
+                  onClick={() => { setPriceEdit(null); setPriceDraft(""); }}
+                  className="rounded border border-zinc-300 px-1.5 py-0.5 text-[10px] text-zinc-500 hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                >
+                  取消
+                </button>
+              </span>
+            );
+          }
+          return (
+            <button
+              key={scope}
+              type="button"
+              onClick={() => { setPriceEdit({ skuId, scope }); setPriceDraft(""); }}
+              title={`此品項尚未設定${scope === "cost" ? "成本價" : "分店價"}，派貨會被擋下 — 點擊直接補價`}
+              className="rounded bg-rose-100 px-1 py-0.5 text-[9px] font-medium text-rose-800 hover:bg-rose-200 dark:bg-rose-950 dark:text-rose-300 dark:hover:bg-rose-900"
+            >
+              {label}
+            </button>
+          );
+        })}
+      </>
+    );
+  }
 
   // ===== 合併視角資料：每個 (sku, store) 一格，跨 PO 加總 =====
   type StoreInfo = { store_id: number; store_code: string | null; store_name: string };
@@ -575,6 +720,17 @@ export default function PickingWorkstationPage() {
     [effectiveSkuRows, allStores, demand, allocs], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
+  // 可分配清單中缺成本/分店價的品項數（派貨時會被 DB 守衛擋下）
+  const missingPriceCount = useMemo(() => {
+    if (!canFixPrices || !priceFlags) return 0;
+    let n = 0;
+    for (const sk of skuRows) {
+      const f = priceFlags.get(sk.sku_id);
+      if (f && (!f.cost || !f.branch)) n += 1;
+    }
+    return n;
+  }, [skuRows, priceFlags, canFixPrices]);
+
   // ===== 補貨申請(無 PO 來源)分組 =====
   type RestockGroup = {
     rrId: number;
@@ -728,6 +884,11 @@ export default function PickingWorkstationPage() {
                 } · 擬分 ${totalAllocSum}${involvedPos > 0 ? ` · 預計切 ${involvedPos} 張撿貨單` : ""}`
               : `${storeSections.length} 間分店有待撿貨`}
         </span>
+        {viewMode === "matrix" && missingPriceCount > 0 && (
+          <span className="text-xs font-medium text-rose-700 dark:text-rose-400">
+            缺價 {missingPriceCount} 品項 — 補價前派貨會被擋
+          </span>
+        )}
 
         {viewMode === "matrix" && skuRows.length > 0 && (
           <div className="ml-auto flex flex-wrap gap-2">
@@ -855,6 +1016,7 @@ export default function PickingWorkstationPage() {
                                   📦 補貨
                                 </span>
                               )}
+                              {renderPriceTags(sk.sku_id)}
                             </div>
                           </div>
                           <SpinButton
@@ -978,6 +1140,7 @@ export default function PickingWorkstationPage() {
                             <Td className="px-3 py-2 text-xs">
                               <div className="font-mono text-[11px] text-zinc-500">{r.sku_code ?? "—"}</div>
                               <div className="truncate" title={r.sku_label}>{r.sku_label}</div>
+                              <div className="mt-0.5 flex flex-wrap gap-1">{renderPriceTags(r.sku_id)}</div>
                             </Td>
                             <NumCell value={Number(r.demand_qty)} bold />
                             <NumCell value={Number(r.wave_qty)} muted />
@@ -1069,6 +1232,7 @@ export default function PickingWorkstationPage() {
                                 {ln.sku_code ?? "—"}
                               </div>
                               <div title={ln.sku_label}>{ln.sku_label}</div>
+                              <div className="mt-0.5 flex flex-wrap gap-1">{renderPriceTags(ln.sku_id)}</div>
                             </Td>
                             <NumCell value={Number(ln.demand_qty)} bold />
                             <NumCell

--- a/docs/TEST-dispatch-price-guard.md
+++ b/docs/TEST-dispatch-price-guard.md
@@ -1,0 +1,103 @@
+# dispatch-price-guard 測試項目 — 出貨價格防呆：成本/分店價未設定不能出倉
+
+**對應 migration:** `supabase/migrations/20260705000000_dispatch_price_guard.sql`
+**對應 UI 變更:** `apps/admin/src/app/(protected)/wms/picking/page.tsx`
+**背景:** 採購單 0 成本 0 分店價建單 → 收貨 avg_cost=0 → 一鍵派貨無人發現 → 月結 `qty × 0` 元。
+楊小胖 2026-06-11 回報：「派車出倉沒有可以修改金額的地方」「0 分店價不可出」。
+
+## 1. Schema / Migration 層
+
+### 1.1 守衛 helper
+- [ ] `_missing_dispatch_prices(uuid, bigint[])` 存在、回傳 TEXT
+  ```sql
+  SELECT proname, pg_get_function_arguments(oid) FROM pg_proc
+   WHERE proname = '_missing_dispatch_prices';
+  ```
+
+### 1.2 rpc_outbound 簽名替換（9 → 10 參數）
+- [ ] 舊 9 參數版已 DROP、只剩一個 10 參數版（`p_fallback_unit_cost NUMERIC DEFAULT NULL`）
+  ```sql
+  SELECT pronargs, pg_get_function_arguments(oid) FROM pg_proc WHERE proname = 'rpc_outbound';
+  -- 預期：恰好 1 列、pronargs = 10、最後一個參數 p_fallback_unit_cost numeric DEFAULT NULL
+  ```
+- [ ] GRANT EXECUTE 仍在（authenticated）
+
+### 1.3 三支出倉 RPC 重建 + 守衛
+- [ ] `generate_transfer_from_wave` / `rpc_ship_restock_pr_received` / `rpc_transfer_distribute_batch` 的 prosrc 都含 `_missing_dispatch_prices`
+  ```sql
+  SELECT proname FROM pg_proc
+   WHERE prosrc LIKE '%_missing_dispatch_prices%' AND proname <> '_missing_dispatch_prices';
+  ```
+- [ ] 三支 GRANT 不變；`generate_transfer_from_wave` 保留 20260511000002 全部行為（picked_qty NULL 自動補 qty、全 0 中文錯誤、advisory lock、store location 檢查、so_generated audit、張數核對）
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 wave 派貨 — 缺成本價擋下
+**情境：** SKU 無現行 cost 價（無 row 或 effective_to 已收掉），有 branch 價；wave status=picked。
+**預期：** `generate_transfer_from_wave` RAISE 中文錯誤、訊息含該 sku_code 與「缺成本價」；不建 transfers、不寫 stock_movements、wave 仍 picked。
+
+### 2.2 wave 派貨 — 缺分店價擋下
+**情境：** SKU 有 cost 價、無現行 branch 價。
+**預期：** 錯誤訊息含「缺分店價」；其餘同 2.1。
+
+### 2.3 wave 派貨 — 價格 = 0 視同缺
+**情境：** prices 有現行 row 但 price = 0（cost 或 branch）。
+**預期：** 一樣擋下（守衛條件 price > 0）。
+
+### 2.4 wave 派貨 — 兩價齊全放行 + avg_cost 正常計價
+**情境：** SKU avg_cost > 0、cost/branch 價齊全。
+**預期：** transfer 建立、出庫 movement.unit_cost = avg_cost（行為與改前完全一致）。
+
+### 2.5 wave 派貨 — avg_cost=0 時用現行成本價計費（fallback）
+**情境：** SKU 以 0 成本收貨（HQ avg_cost = 0），事後補 cost 價 = 50、branch 價 = 60，再派貨。
+**預期：** 出庫 movement.unit_cost = 50（非 0）；transfer 照常 shipped。
+
+### 2.6 月結金額不再 0 元（end-to-end）
+**情境：** 接 2.5，分店收貨後跑 `rpc_generate_hq_to_store_settlement(當月)`。
+**預期：** 該店月結 line：unit_cost = 50、line_amount = qty × 50；payable_amount 非 0。
+
+### 2.7 restock PR 到貨直派 — 守衛同樣生效
+**情境：** restock_requests status=approved_pr，行內 SKU 缺 branch 價，呼叫 `rpc_ship_restock_pr_received`。
+**預期：** 中文缺價錯誤、不建 transfer、request 狀態不變。
+
+### 2.8 待派發批次 — 只擋 hq_to_store
+**情境：** 兩張 draft transfer 一起 `rpc_transfer_distribute_batch`：A = hq_to_store 含缺價 SKU、B = 店↔店（free）同樣缺價。
+**預期：** A 進 failed[]、reason 為中文缺價訊息；B 照常 shipped（店間轉貨不檢查）。
+
+### 2.9 虛擬 SKU 跳過
+**情境：** hq_to_store transfer 內含 products.is_virtual=TRUE 的 SKU（無任何價格）。
+**預期：** 不因虛擬 SKU 被擋；出庫照 20260515000006 邏輯跳過 movement。
+
+### 2.10 rpc_outbound 既有呼叫端回歸（9 具名參數 → 單一函式 + default）
+**情境：** 各跑一次會觸發 rpc_outbound 的既有流程：訂單退貨回總倉（rpc_create_order_return）、互助單派貨（rpc_ship_aid_order）、取貨跨店 leg2（rpc_pickup 鏈）。
+**預期：** 全部正常、無「function is not unique」、movement.unit_cost 行為同舊（avg_cost）。
+
+### 2.11 守衛訊息一次列出全部缺價 SKU
+**情境：** wave 內 3 個 SKU 缺價（兩個缺成本、一個缺兩種）。
+**預期：** 一次 exception 列出 3 個 sku_code 與各自缺的價別（頓號分隔），不是只報第一個。
+
+## 3. UI 行為（/wms/picking 派貨工作台）
+
+- [ ] 頁面載入無 console error；矩陣/依分店/補貨 section 外觀與原本一致
+- [ ] 缺成本價的 SKU 列顯示紅字 pill「缺成本」；缺分店價顯示「缺分店價」；兩者都缺同時顯示（文字 pill、無 icon/emoji）
+- [ ] 價格齊全的 SKU 不顯示任何 pill
+- [ ] 點 pill → inline 輸入框；輸入 50 儲存 → 呼叫對應 rpc_set_cost_price / rpc_set_branch_price → pill 消失（價格重抓）
+- [ ] 儲存中為純 spinner、無「儲存中」文字
+- [ ] 輸入 0 / 空白 → 不送出（防呆，分店價 0 不可出的源頭就是這個）
+- [ ] 非 HQ 價格權限 role（無法讀 cost/branch prices 的 role）不顯示 pills（避免 RLS 讀不到誤判缺價）
+
+## 4. Regression
+
+- [ ] hq/inbox 撿貨單批次「派貨」：全有價 wave 照常成功；含缺價 wave 失敗訊息逐張顯示、其他 wave 不受牽連
+- [ ] 自由轉貨 店↔店：建單 → 派發 → 收貨 全程不受守衛影響
+- [ ] 訂單退貨回總倉（rpc_create_order_return）照常
+- [ ] 取貨（同店 / 跨店互助 leg）照常
+- [ ] e2e seed：seed 資料若缺 cost/branch 價，黃金路徑派貨步驟會被新守衛擋 — seed 腳本需同步補價（檢查 `supabase/seed*` / `scripts/`）
+- [ ] /wms/picking 原矩陣分配、⚖ 平均、FIFO 多 PO 切單、勾選品項建單、補貨 amber section 全部照舊
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**migration 套用成功（本機 docker 或 prod via Management API）**、**admin build + type-check 過** 才可標 done。
+
+> Prod 部署前置：先探測線上缺價覆蓋率（active SKU 缺 cost/branch 價的數量、HQ 在庫 avg_cost=0 清單），
+> 若大面積缺價，需先告知使用者並提供補價 SQL，避免守衛上線當下全倉派貨被擋死。

--- a/docs/TEST-dispatch-price-guard.report-2026-06-11.md
+++ b/docs/TEST-dispatch-price-guard.report-2026-06-11.md
@@ -1,0 +1,70 @@
+# dispatch-price-guard Test Run — 2026-06-11
+
+**執行環境：** 拋棄式 `supabase/postgres:17.6.1.134` 容器 + 依賴切片
+（product/member/inventory/purchase/sales/stores_order/inventory_v02/picking_waves/virtual_product
++ 20260514000000 prices scope 擴充 + 本次 `20260705000000_dispatch_price_guard.sql`），
+auth.uid()/auth.jwt() 以 stub 提供。測試腳本：`scripts/test-dispatch-price-guard.sql`（自帶 fixture、結尾 ROLLBACK）。
+> 為何不用 `supabase db reset` 全鏈：本機重放在 `20260508120000` 斷（timestamp 亂序引用
+> `rpc_transfer_order_partial` 8 參數版，該簽名 20260509000005 才建立）、`20260629000020` 亦有問題 —
+> 既有問題與本次無關，prod 不受影響（prod 按部署順序）。
+
+### Summary
+- Total: 29 items（§1×5、§2×11、§3×7、§4×6）
+- Passed: 16
+- Failed: 0
+- Blocked: 13（sandbox 無法跑 admin 登入 UI、prod token 缺、月結/restock 需完整鏈）
+
+### SQL 直測結果（18/18 PASS）
+
+```
+PASS 1.2  rpc_outbound 單一 overload、10 參數            | 10
+PASS 1.3  三支出倉 RPC prosrc 含 _missing_dispatch_prices
+PASS 2.1h 無價 SKU → 缺兩種        | TG-NP …【缺成本價、缺分店價】
+PASS 2.2h 只有成本 → 只缺分店價    | TG-CO …【缺分店價】
+PASS 2.3h 價格=0 視同缺
+PASS 2.4h 兩價齊全 → NULL
+PASS 2.9h 虛擬 SKU 跳過 → NULL
+PASS 2.11h 一次列出全部缺價 SKU    | TG-CO…【缺分店價】；TG-NP…【缺成本價、缺分店價】
+PASS 2.1  wave 缺價擋下＋中文訊息  | 無法派貨：…→ TG-NP 守衛測試商品（無價）【缺成本價、缺分店價】
+PASS 2.1b 擋下後 wave 仍 picked、無 transfer | picked / transfers=0
+PASS 2.4  補價後派貨成功、wave shipped | {"wave_id":1,"item_count":3,"store_count":1,"transfer_ids":[1]}
+PASS 2.5  avg=0 出庫用現行成本價   | np=45.0000 ok=50.0000
+PASS 2.5b avg>0 出庫仍用 avg_cost  | avg=7.0000
+PASS 2.8  batch：hq_to_store 缺價進 failed | failed=[{id:2, reason:"無法派貨：…【缺分店價】"}], succeeded=[3,4]
+PASS 2.8b 被擋 transfer 維持 draft、庫存未動
+PASS 2.8c 店↔店缺價不檢查、照常 shipped
+PASS 2.9  hq_to_store 虛擬 SKU 不擋、out_movement_id NULL
+PASS 2.10 9 參數具名呼叫照常 resolve（無 function-is-not-unique）
+```
+
+### 對應測試文件逐項
+
+| 項 | 結果 | 證據 / 備註 |
+|---|---|---|
+| §1.1 helper 存在 | ✅ | 直接呼叫成功（上表 2.xh 全組） |
+| §1.2 outbound 9→10、單一 overload | ✅ | pg_proc：1 列、pronargs=10 |
+| §1.2 GRANT | ✅* | 改前改後皆無顯式 GRANT（沿用 Supabase default ACL），posture 不變 |
+| §1.3 三支 prosrc 含守衛 + 既有行為保留 | ✅ | prosrc 檢查 + 2.4 全流程過（picked_qty 修補/audit/張數核對都在路徑上） |
+| §2.1/2.2/2.3/2.4/2.5/2.8/2.9/2.10/2.11 | ✅ | 上表 |
+| §2.6 月結 end-to-end | ⏸ Blocked | 月結函式未動；計費輸入＝出庫 movement.unit_cost 已驗（45/50/7）。prod 部署後建議抽一張實單對帳 |
+| §2.7 rpc_ship_restock_pr_received | ⏸ Blocked | 需 JWT context＋restock 完整鏈；守衛段與 wave 版逐字相同、prosrc 已確認含守衛 |
+| §3 UI（7 項） | ⏸ Blocked | sandbox 連不到本機 Supabase、admin 登入跑不完（既有限制）；build/type-check 綠、碼審過 → 留使用者 preview 自審 |
+| §4 hq/inbox 批次派貨 | ✅(RPC 層) | 2.8 failed[]/succeeded 語意即 inbox 批次的後端行為；UI 呈現留自審 |
+| §4 自由轉貨店↔店 | ✅ | 2.8c |
+| §4 退貨/取貨 leg | ⏸ Blocked | 未实跑；resolution 層已證（2.10），無 9 參數歧義 |
+| §4 e2e seed 缺 cost/branch | ✅ 已修 | `scripts/e2e/01-master.sql` 補 cost=retail×0.6 / branch=retail×0.8 |
+| §4 /wms/picking 原功能 | ⏸ Blocked | build 綠＋碼審（改動皆為附加 UI，不動原矩陣/FIFO 邏輯）；留自審 |
+
+### Gate status
+- Build（next build 含 type-check）: ✅
+- Migration 套用: ✅ 本機乾淨 DB；❌ prod 未部署（`SUPABASE_ACCESS_TOKEN` 不在環境，Management API 走不了）
+- Console errors during UI run: 未執行（sandbox 限制）
+
+### Verdict
+**NOT DONE** — 程式碼層全綠（SQL 18/18、build 綠），剩三件待辦：
+1. prod 部署（待 token；指令見 PR 描述）
+2. prod 缺價覆蓋率探測 + 必要時批次補價（部署前必做，避免上線當下全倉被擋）
+3. /wms/picking 缺價 pill＋補價 UI 使用者自審
+
+### Suggested test doc updates
+- §2.10 可加註：「resolution 層以 9 具名參數直呼驗證即可，全流程回歸交給各功能自身測試」

--- a/scripts/e2e/01-master.sql
+++ b/scripts/e2e/01-master.sql
@@ -221,6 +221,27 @@ SELECT :'tenant_id'::uuid, b.sku_id, 'member_tier', t.id,
        (SELECT id FROM any_user)
 FROM base b CROSS JOIN tiers t;
 
+-- ── cost / branch 價（出貨價格防呆 20260705000000：缺成本價/分店價不能出倉）──
+-- cost = retail × 0.6、branch = retail × 0.8；少這兩種價黃金路徑派貨會被守衛擋下
+WITH any_user AS (SELECT id FROM auth.users LIMIT 1),
+     base AS (
+       SELECT s.id AS sku_id, s.tenant_id,
+              (CASE s.sku_code
+                 WHEN 'SKU-001' THEN 135 WHEN 'SKU-002' THEN 80
+                 WHEN 'SKU-003' THEN 220 WHEN 'SKU-004' THEN 180
+                 WHEN 'SKU-005' THEN 95  WHEN 'SKU-006' THEN 350
+                 WHEN 'SKU-007' THEN 65  WHEN 'SKU-008' THEN 110
+                 WHEN 'SKU-009' THEN 90  WHEN 'SKU-010' THEN 480
+               END)::numeric AS retail
+       FROM skus s
+       WHERE s.tenant_id = :'tenant_id'::uuid
+     )
+INSERT INTO prices (tenant_id, sku_id, scope, scope_id, price, effective_from, created_by)
+SELECT b.tenant_id, b.sku_id, x.scope, NULL,
+       ROUND(b.retail * x.factor, 2), NOW(), (SELECT id FROM any_user)
+FROM base b
+CROSS JOIN (VALUES ('cost', 0.6::numeric), ('branch', 0.8::numeric)) AS x(scope, factor);
+
 -- ── expense_categories（5 筆 P&L 科目）────────────────────
 INSERT INTO expense_categories (tenant_id, code, name, default_pay_method) VALUES
   (:'tenant_id'::uuid, 'EC-RENT',    '租金',     'company_account'),

--- a/scripts/test-dispatch-price-guard.sql
+++ b/scripts/test-dispatch-price-guard.sql
@@ -1,0 +1,224 @@
+-- ============================================================
+-- TEST: dispatch-price-guard（docs/TEST-dispatch-price-guard.md §1/§2）
+-- 用法：docker exec -i supabase_db_xxx psql -U postgres -d postgres -f - < this
+-- 自帶 fixture、全程單一交易、結尾 ROLLBACK — 不留任何資料。
+-- ============================================================
+\set ON_ERROR_STOP on
+BEGIN;
+
+CREATE TEMP TABLE _t (seq SERIAL, test TEXT, pass BOOLEAN, detail TEXT) ON COMMIT DROP;
+
+-- §1.2 rpc_outbound 只剩一個 10 參數版
+INSERT INTO _t (test, pass, detail)
+SELECT '1.2 rpc_outbound 單一 overload、10 參數',
+       COUNT(*) = 1 AND MAX(pronargs) = 10,
+       string_agg(pronargs::TEXT, ',')
+  FROM pg_proc WHERE proname = 'rpc_outbound';
+
+-- §1.3 三支出倉 RPC 都含守衛
+INSERT INTO _t (test, pass, detail)
+SELECT '1.3 三支出倉 RPC prosrc 含 _missing_dispatch_prices',
+       COUNT(*) = 3, string_agg(proname, ',')
+  FROM pg_proc
+ WHERE proname IN ('generate_transfer_from_wave','rpc_ship_restock_pr_received','rpc_transfer_distribute_batch')
+   AND prosrc LIKE '%_missing_dispatch_prices%';
+
+DO $$
+DECLARE
+  c_tenant   CONSTANT UUID := 'a0000000-0000-4000-8000-00000000aaaa';
+  c_op       CONSTANT UUID := 'b0000000-0000-4000-8000-00000000bbbb';
+  v_hq_loc   BIGINT; v_s1_loc BIGINT; v_s2_loc BIGINT;
+  v_st1      BIGINT; v_st2 BIGINT;
+  v_prod     BIGINT; v_prod_v BIGINT;
+  v_sku_np   BIGINT;  -- 無任何價
+  v_sku_co   BIGINT;  -- 只有成本價
+  v_sku_z    BIGINT;  -- 兩價都存在但 price=0
+  v_sku_ok   BIGINT;  -- 兩價齊全、HQ avg_cost=0（fallback 案例）
+  v_sku_avg  BIGINT;  -- 兩價齊全、HQ avg_cost=7
+  v_sku_v    BIGINT;  -- 虛擬
+  v_wave     BIGINT;
+  v_msg      TEXT;
+  v_res      JSONB;
+  v_xa BIGINT; v_xb BIGINT; v_xc BIGINT;
+  v_cost_np NUMERIC; v_cost_ok NUMERIC; v_cost_avg NUMERIC;
+  v_status TEXT; v_cnt INT;
+BEGIN
+  -- ---------- fixtures ----------
+  INSERT INTO locations (tenant_id, code, name, type) VALUES
+    (c_tenant, 'TG-WH',  '守衛測試總倉', 'central_warehouse') RETURNING id INTO v_hq_loc;
+  INSERT INTO locations (tenant_id, code, name, type) VALUES
+    (c_tenant, 'TG-S1', '守衛測試店一', 'store') RETURNING id INTO v_s1_loc;
+  INSERT INTO locations (tenant_id, code, name, type) VALUES
+    (c_tenant, 'TG-S2', '守衛測試店二', 'store') RETURNING id INTO v_s2_loc;
+
+  INSERT INTO stores (tenant_id, code, name, location_id)
+  VALUES (c_tenant, 'TG-ST1', '守衛測試店一', v_s1_loc) RETURNING id INTO v_st1;
+  INSERT INTO stores (tenant_id, code, name, location_id)
+  VALUES (c_tenant, 'TG-ST2', '守衛測試店二', v_s2_loc) RETURNING id INTO v_st2;
+
+  INSERT INTO products (tenant_id, product_code, name, status)
+  VALUES (c_tenant, 'TG-P1', '守衛測試商品', 'active') RETURNING id INTO v_prod;
+  INSERT INTO products (tenant_id, product_code, name, status, is_virtual)
+  VALUES (c_tenant, 'TG-PV', '守衛測試虛擬商品', 'active', TRUE) RETURNING id INTO v_prod_v;
+
+  INSERT INTO skus (tenant_id, product_id, sku_code, variant_name, status, product_name) VALUES
+    (c_tenant, v_prod,   'TG-NP',  '無價',   'active', '守衛測試商品') RETURNING id INTO v_sku_np;
+  INSERT INTO skus (tenant_id, product_id, sku_code, variant_name, status, product_name) VALUES
+    (c_tenant, v_prod,   'TG-CO',  '只有成本', 'active', '守衛測試商品') RETURNING id INTO v_sku_co;
+  INSERT INTO skus (tenant_id, product_id, sku_code, variant_name, status, product_name) VALUES
+    (c_tenant, v_prod,   'TG-Z',   '零元價', 'active', '守衛測試商品') RETURNING id INTO v_sku_z;
+  INSERT INTO skus (tenant_id, product_id, sku_code, variant_name, status, product_name) VALUES
+    (c_tenant, v_prod,   'TG-OK',  '齊全0avg', 'active', '守衛測試商品') RETURNING id INTO v_sku_ok;
+  INSERT INTO skus (tenant_id, product_id, sku_code, variant_name, status, product_name) VALUES
+    (c_tenant, v_prod,   'TG-AVG', '齊全有avg', 'active', '守衛測試商品') RETURNING id INTO v_sku_avg;
+  INSERT INTO skus (tenant_id, product_id, sku_code, variant_name, status, product_name) VALUES
+    (c_tenant, v_prod_v, 'TG-V',   '虛擬',   'active', '守衛測試虛擬商品') RETURNING id INTO v_sku_v;
+
+  -- 價格：CO 只有 cost；Z 兩種都 0；OK/AVG 齊全
+  INSERT INTO prices (tenant_id, sku_id, scope, scope_id, price, created_by) VALUES
+    (c_tenant, v_sku_co,  'cost',   NULL, 50, c_op),
+    (c_tenant, v_sku_z,   'cost',   NULL,  0, c_op),
+    (c_tenant, v_sku_z,   'branch', NULL,  0, c_op),
+    (c_tenant, v_sku_ok,  'cost',   NULL, 50, c_op),
+    (c_tenant, v_sku_ok,  'branch', NULL, 60, c_op),
+    (c_tenant, v_sku_avg, 'cost',   NULL, 50, c_op),
+    (c_tenant, v_sku_avg, 'branch', NULL, 60, c_op);
+
+  -- HQ 庫存：NP/OK avg_cost=0（0 成本入庫情境）、AVG avg_cost=7；S1 給 CO 庫存（店間轉貨用）
+  INSERT INTO stock_balances (tenant_id, location_id, sku_id, on_hand, avg_cost) VALUES
+    (c_tenant, v_hq_loc, v_sku_np,  100, 0),
+    (c_tenant, v_hq_loc, v_sku_co,  100, 0),
+    (c_tenant, v_hq_loc, v_sku_ok,  100, 0),
+    (c_tenant, v_hq_loc, v_sku_avg, 100, 7),
+    (c_tenant, v_s1_loc, v_sku_co,   10, 0);
+
+  -- ---------- §2 helper 單元 ----------
+  v_msg := public._missing_dispatch_prices(c_tenant, ARRAY[v_sku_np]);
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.1h 無價 SKU → 缺兩種', v_msg LIKE '%缺成本價%' AND v_msg LIKE '%缺分店價%' AND v_msg LIKE '%TG-NP%', v_msg);
+
+  v_msg := public._missing_dispatch_prices(c_tenant, ARRAY[v_sku_co]);
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.2h 只有成本 → 只缺分店價', v_msg LIKE '%缺分店價%' AND v_msg NOT LIKE '%缺成本價%', v_msg);
+
+  v_msg := public._missing_dispatch_prices(c_tenant, ARRAY[v_sku_z]);
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.3h 價格=0 視同缺', v_msg LIKE '%缺成本價%' AND v_msg LIKE '%缺分店價%', v_msg);
+
+  v_msg := public._missing_dispatch_prices(c_tenant, ARRAY[v_sku_ok, v_sku_avg]);
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.4h 兩價齊全 → NULL', v_msg IS NULL, COALESCE(v_msg, '(null)'));
+
+  v_msg := public._missing_dispatch_prices(c_tenant, ARRAY[v_sku_v]);
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.9h 虛擬 SKU 跳過 → NULL', v_msg IS NULL, COALESCE(v_msg, '(null)'));
+
+  v_msg := public._missing_dispatch_prices(c_tenant, ARRAY[v_sku_np, v_sku_co, v_sku_ok]);
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.11h 一次列出全部缺價 SKU', v_msg LIKE '%TG-NP%' AND v_msg LIKE '%TG-CO%' AND v_msg NOT LIKE '%TG-OK%', v_msg);
+
+  -- ---------- §2 wave 派貨守衛 ----------
+  INSERT INTO picking_waves (tenant_id, wave_code, wave_date, status, created_by)
+  VALUES (c_tenant, 'TG-W1', CURRENT_DATE, 'picked', c_op) RETURNING id INTO v_wave;
+  INSERT INTO picking_wave_items (tenant_id, wave_id, sku_id, store_id, qty, picked_qty, created_by) VALUES
+    (c_tenant, v_wave, v_sku_np,  v_st1, 3, 3, c_op),
+    (c_tenant, v_wave, v_sku_ok,  v_st1, 2, 2, c_op),
+    (c_tenant, v_wave, v_sku_avg, v_st1, 1, 1, c_op);
+
+  BEGIN
+    PERFORM generate_transfer_from_wave(v_wave, v_hq_loc, c_op);
+    INSERT INTO _t (test, pass, detail) VALUES ('2.1 wave 缺價擋下', FALSE, '未擋（不該成功）');
+  EXCEPTION WHEN OTHERS THEN
+    INSERT INTO _t (test, pass, detail) VALUES
+      ('2.1 wave 缺價擋下＋中文訊息', SQLERRM LIKE '無法派貨%' AND SQLERRM LIKE '%TG-NP%' AND SQLERRM NOT LIKE '%TG-OK%', SQLERRM);
+  END;
+
+  SELECT status INTO v_status FROM picking_waves WHERE id = v_wave;
+  SELECT COUNT(*) INTO v_cnt FROM transfers WHERE tenant_id = c_tenant;
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.1b 擋下後 wave 仍 picked、無 transfer', v_status = 'picked' AND v_cnt = 0, v_status || ' / transfers=' || v_cnt);
+
+  -- 補價後重試 → 成功
+  INSERT INTO prices (tenant_id, sku_id, scope, scope_id, price, created_by) VALUES
+    (c_tenant, v_sku_np, 'cost',   NULL, 45, c_op),
+    (c_tenant, v_sku_np, 'branch', NULL, 55, c_op);
+
+  v_res := generate_transfer_from_wave(v_wave, v_hq_loc, c_op);
+  SELECT status INTO v_status FROM picking_waves WHERE id = v_wave;
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.4 補價後派貨成功、wave shipped', (v_res ->> 'store_count')::INT = 1 AND v_status = 'shipped', v_res::TEXT);
+
+  -- 出庫成本：avg=0 → 用現行成本價（NP=45, OK=50）；avg=7 → 維持 avg（AVG=7）
+  SELECT sm.unit_cost INTO v_cost_np
+    FROM transfer_items ti JOIN stock_movements sm ON sm.id = ti.out_movement_id
+   WHERE ti.sku_id = v_sku_np AND sm.tenant_id = c_tenant;
+  SELECT sm.unit_cost INTO v_cost_ok
+    FROM transfer_items ti JOIN stock_movements sm ON sm.id = ti.out_movement_id
+   WHERE ti.sku_id = v_sku_ok AND sm.tenant_id = c_tenant;
+  SELECT sm.unit_cost INTO v_cost_avg
+    FROM transfer_items ti JOIN stock_movements sm ON sm.id = ti.out_movement_id
+   WHERE ti.sku_id = v_sku_avg AND sm.tenant_id = c_tenant;
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.5 avg=0 出庫用現行成本價', v_cost_np = 45 AND v_cost_ok = 50, 'np=' || v_cost_np || ' ok=' || v_cost_ok);
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.5b avg>0 出庫仍用 avg_cost', v_cost_avg = 7, 'avg=' || v_cost_avg);
+
+  -- ---------- §2.8 / §2.9 distribute_batch ----------
+  -- A: hq_to_store 缺分店價 → failed；B: 店↔店同 SKU → 不檢查照常 shipped；C: hq_to_store 虛擬 → shipped
+  INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location, status, transfer_type, created_by)
+  VALUES (c_tenant, 'TG-XA', v_hq_loc, v_s2_loc, 'draft', 'hq_to_store', c_op) RETURNING id INTO v_xa;
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, created_by)
+  VALUES (v_xa, v_sku_co, 1, c_op);
+
+  INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location, status, transfer_type, created_by)
+  VALUES (c_tenant, 'TG-XB', v_s1_loc, v_s2_loc, 'draft', 'store_to_store', c_op) RETURNING id INTO v_xb;
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, created_by)
+  VALUES (v_xb, v_sku_co, 1, c_op);
+
+  INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location, status, transfer_type, created_by)
+  VALUES (c_tenant, 'TG-XC', v_hq_loc, v_s2_loc, 'draft', 'hq_to_store', c_op) RETURNING id INTO v_xc;
+  INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, created_by)
+  VALUES (v_xc, v_sku_v, 1, c_op);
+
+  v_res := rpc_transfer_distribute_batch(ARRAY[v_xa, v_xb, v_xc], v_hq_loc, c_op);
+
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.8 batch：hq_to_store 缺價進 failed、訊息中文',
+     (SELECT COUNT(*) FROM jsonb_array_elements(v_res -> 'failed') f
+       WHERE (f ->> 'id')::BIGINT = v_xa AND f ->> 'reason' LIKE '無法派貨%缺分店價%') = 1,
+     v_res::TEXT);
+  SELECT status INTO v_status FROM transfers WHERE id = v_xa;
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.8b 被擋的 transfer 維持 draft、庫存未動', v_status = 'draft'
+       AND (SELECT on_hand FROM stock_balances WHERE tenant_id = c_tenant AND location_id = v_hq_loc AND sku_id = v_sku_co) = 100,
+     v_status);
+  SELECT status INTO v_status FROM transfers WHERE id = v_xb;
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.8c 店↔店缺價不檢查、照常 shipped', v_status = 'shipped'
+       AND v_res -> 'succeeded' @> to_jsonb(v_xb), v_status);
+  SELECT status INTO v_status FROM transfers WHERE id = v_xc;
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.9 hq_to_store 虛擬 SKU 不擋、跳過庫存', v_status = 'shipped'
+       AND (SELECT out_movement_id FROM transfer_items WHERE transfer_id = v_xc) IS NULL, v_status);
+
+  -- ---------- §2.10 既有 9 參數呼叫端回歸（具名參數、不傳 fallback）----------
+  PERFORM rpc_outbound(
+    p_tenant_id       => c_tenant,
+    p_location_id     => v_hq_loc,
+    p_sku_id          => v_sku_avg,
+    p_quantity        => 1::NUMERIC,
+    p_movement_type   => 'sale',
+    p_source_doc_type => 'test',
+    p_source_doc_id   => 0,
+    p_operator        => c_op,
+    p_allow_negative  => FALSE
+  );
+  INSERT INTO _t (test, pass, detail) VALUES
+    ('2.10 9 參數具名呼叫照常 resolve', TRUE, 'no function-is-not-unique');
+END $$;
+
+SELECT CASE WHEN pass THEN 'PASS' ELSE '*** FAIL ***' END AS result, test, LEFT(detail, 160) AS detail
+  FROM _t ORDER BY seq;
+SELECT COUNT(*) FILTER (WHERE pass) || ' / ' || COUNT(*) AS passed FROM _t;
+
+ROLLBACK;

--- a/supabase/migrations/20260705000000_dispatch_price_guard.sql
+++ b/supabase/migrations/20260705000000_dispatch_price_guard.sql
@@ -1,0 +1,609 @@
+-- ============================================================================
+-- 2026-07-05: 出貨價格防呆 — 成本價/分店價未設定的品項不能出倉（HQ→店）
+-- ----------------------------------------------------------------------------
+-- 背景（楊小胖 2026-06-11 回報）：
+--   採購單可以 0 成本 / 0 分店價建單（先建後補價的工作流），但若沒人補價：
+--   收貨以 0 成本入庫 → HQ avg_cost = 0 → 派貨出庫 movement.unit_cost = 0
+--   → 月結 rpc_generate_hq_to_store_settlement 計 qty × 0 = 0 元，
+--   「一鍵派貨」過程完全沒有金額欄位，沒人會發現。
+--
+-- 變更：
+--   Part 0  helper：
+--     _missing_dispatch_prices(tenant, sku_ids[]) — 列出缺「現行成本價/分店價」
+--       (prices scope='cost'/'branch'、scope_id IS NULL、effective_to IS NULL、
+--        price > 0) 的非虛擬 SKU，全齊回 NULL。
+--     _current_cost_price(tenant, sku_id) — 現行成本價（無則 NULL）。
+--   Part 1  rpc_outbound 9 → 10 參數：加 p_fallback_unit_cost DEFAULT NULL。
+--     avg_cost 缺值(≤0)且呼叫端有給後備成本時，出庫 movement.unit_cost 改用
+--     後備值 — 已經以 0 成本入庫的存貨，補完成本價後派貨，月結才收得到錢。
+--     ※ 必須 DROP 舊 9 參數版再建：若留兩個 overload，既有 9 參數呼叫
+--       會撞 PostgreSQL「function is not unique」。其餘呼叫端（銷售/退貨/
+--       互助/取貨 leg）不傳新參數 → default NULL → 行為與舊版完全相同。
+--   Part 2  generate_transfer_from_wave：建 transfer 前守衛缺價（一鍵派貨主路徑）。
+--   Part 3  rpc_ship_restock_pr_received：補貨 PR 到貨直派，同守衛。
+--   Part 4  rpc_transfer_distribute_batch：僅 transfer_type='hq_to_store' 守衛；
+--     店↔店自由轉貨不受影響。缺價 transfer 進 failed[]、其他張照常。
+--
+-- 基底版本（依 CLAUDE.md 規則 grep 全歷史、以時間最新版擴寫）：
+--   rpc_outbound                 ← 20260510000001_rpc_outbound_sku_in_error.sql
+--   generate_transfer_from_wave  ← 20260511000002_generate_transfer_zh_errors.sql
+--   rpc_ship_restock_pr_received ← 20260515000004_restock_transfer_ship_immediate.sql
+--   rpc_transfer_distribute_batch← 20260515000006_skip_inventory_for_virtual_sku.sql
+-- Rollback：
+--   DROP FUNCTION public._missing_dispatch_prices(UUID, BIGINT[]);
+--   DROP FUNCTION public._current_cost_price(UUID, BIGINT);
+--   rpc_outbound：DROP 10 參數版、重跑 20260510000001。
+--   其餘三支：重跑各自基底 migration 的定義與 GRANT。
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- Part 0a: helper — 列出缺現行成本價/分店價的（非虛擬）SKU
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._missing_dispatch_prices(
+  p_tenant  UUID,
+  p_sku_ids BIGINT[]
+) RETURNS TEXT
+LANGUAGE sql STABLE
+AS $$
+  SELECT string_agg(
+           x.label || '【' || array_to_string(x.missing, '、') || '】',
+           '；' ORDER BY x.sku_code NULLS LAST)
+    FROM (
+      SELECT
+        s.sku_code,
+        COALESCE(NULLIF(s.sku_code, ''), '#' || s.id::TEXT)
+          || COALESCE(' ' || NULLIF(s.product_name, ''), '')
+          || COALESCE('（' || NULLIF(btrim(s.variant_name), '') || '）', '') AS label,
+        ARRAY_REMOVE(ARRAY[
+          CASE WHEN NOT EXISTS (
+            SELECT 1 FROM public.prices pr
+             WHERE pr.tenant_id    = p_tenant
+               AND pr.sku_id       = s.id
+               AND pr.scope        = 'cost'
+               AND pr.scope_id     IS NULL
+               AND pr.effective_to IS NULL
+               AND pr.price        > 0
+          ) THEN '缺成本價' END,
+          CASE WHEN NOT EXISTS (
+            SELECT 1 FROM public.prices pr
+             WHERE pr.tenant_id    = p_tenant
+               AND pr.sku_id       = s.id
+               AND pr.scope        = 'branch'
+               AND pr.scope_id     IS NULL
+               AND pr.effective_to IS NULL
+               AND pr.price        > 0
+          ) THEN '缺分店價' END
+        ], NULL) AS missing
+      FROM public.skus s
+      JOIN public.products p ON p.id = s.product_id
+     WHERE s.id = ANY(p_sku_ids)
+       AND s.tenant_id = p_tenant
+       AND COALESCE(p.is_virtual, FALSE) = FALSE
+    ) x
+   WHERE COALESCE(array_length(x.missing, 1), 0) > 0
+$$;
+
+COMMENT ON FUNCTION public._missing_dispatch_prices(UUID, BIGINT[]) IS
+  '出貨價格防呆 helper：回傳缺「現行成本價/分店價」(price>0, effective_to IS NULL) '
+  '的非虛擬 SKU 清單文字；全部齊全回 NULL。供 HQ→店出倉 RPC 守衛用。';
+
+-- ----------------------------------------------------------------------------
+-- Part 0b: helper — 現行成本價（無則 NULL）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._current_cost_price(
+  p_tenant UUID,
+  p_sku_id BIGINT
+) RETURNS NUMERIC
+LANGUAGE sql STABLE
+AS $$
+  SELECT pr.price
+    FROM public.prices pr
+   WHERE pr.tenant_id    = p_tenant
+     AND pr.sku_id       = p_sku_id
+     AND pr.scope        = 'cost'
+     AND pr.scope_id     IS NULL
+     AND pr.effective_to IS NULL
+     AND pr.price        > 0
+   ORDER BY pr.effective_from DESC
+   LIMIT 1
+$$;
+
+COMMENT ON FUNCTION public._current_cost_price(UUID, BIGINT) IS
+  '現行成本價（prices scope=cost, effective_to IS NULL, price>0）；無則 NULL。';
+
+-- ----------------------------------------------------------------------------
+-- Part 1: rpc_outbound — 加 p_fallback_unit_cost（10 參數）
+-- 基底：20260510000001（Insufficient stock 帶 SKU 識別）逐字保留。
+-- 先 DROP 舊 9 參數版，避免 default 參數造成 overload 歧義。
+-- ----------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS rpc_outbound(UUID, BIGINT, BIGINT, NUMERIC, TEXT, TEXT, BIGINT, UUID, BOOLEAN);
+
+CREATE OR REPLACE FUNCTION rpc_outbound(
+  p_tenant_id          UUID,
+  p_location_id        BIGINT,
+  p_sku_id             BIGINT,
+  p_quantity           NUMERIC,
+  p_movement_type      TEXT,
+  p_source_doc_type    TEXT,
+  p_source_doc_id      BIGINT,
+  p_operator           UUID,
+  p_allow_negative     BOOLEAN DEFAULT FALSE,
+  p_fallback_unit_cost NUMERIC DEFAULT NULL
+) RETURNS BIGINT AS $$
+DECLARE
+  v_available NUMERIC;
+  v_cost      NUMERIC;
+  v_id        BIGINT;
+  v_sku_code  TEXT;
+  v_sku_name  TEXT;
+BEGIN
+  IF p_quantity <= 0 THEN
+    RAISE EXCEPTION 'Outbound quantity must be positive';
+  END IF;
+
+  SELECT on_hand - reserved, avg_cost
+    INTO v_available, v_cost
+    FROM stock_balances
+   WHERE tenant_id = p_tenant_id
+     AND location_id = p_location_id
+     AND sku_id = p_sku_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    v_available := 0;
+    v_cost := 0;
+  END IF;
+
+  IF v_available < p_quantity AND NOT p_allow_negative THEN
+    SELECT s.sku_code, COALESCE(s.product_name, '')
+      INTO v_sku_code, v_sku_name
+      FROM skus s
+     WHERE s.id = p_sku_id;
+
+    RAISE EXCEPTION 'Insufficient stock for SKU % (%): available=%, required=%',
+      COALESCE(v_sku_code, p_sku_id::TEXT),
+      COALESCE(v_sku_name, ''),
+      v_available,
+      p_quantity;
+  END IF;
+
+  -- avg_cost 缺值（0 成本入庫的存貨）且呼叫端提供後備成本 → 以後備成本計價，
+  -- 讓下游（店月結等）拿得到非 0 金額。未提供後備值時行為與舊版完全相同。
+  IF (v_cost IS NULL OR v_cost <= 0)
+     AND COALESCE(p_fallback_unit_cost, 0) > 0 THEN
+    v_cost := p_fallback_unit_cost;
+  END IF;
+
+  INSERT INTO stock_movements
+    (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+     source_doc_type, source_doc_id, operator_id)
+  VALUES
+    (p_tenant_id, p_location_id, p_sku_id, -p_quantity, v_cost, p_movement_type,
+     p_source_doc_type, p_source_doc_id, p_operator)
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION rpc_outbound(UUID, BIGINT, BIGINT, NUMERIC, TEXT, TEXT, BIGINT, UUID, BOOLEAN, NUMERIC) IS
+  '出庫（含可用庫存檢查）。p_fallback_unit_cost：avg_cost ≤ 0 時的後備計價成本'
+  '（HQ→店出貨用現行成本價，避免月結 0 元）；NULL = 行為同舊版。';
+
+-- ----------------------------------------------------------------------------
+-- Part 2: generate_transfer_from_wave — 出倉前守衛缺價 + 出庫帶後備成本
+-- 基底：20260511000002 逐字保留（picked_qty 修補 / 中文錯誤 / advisory lock /
+--       store location 檢查 / so_generated audit / 張數核對 / 訂單狀態更新）。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION generate_transfer_from_wave(
+  p_wave_id        BIGINT,
+  p_hq_location_id BIGINT,
+  p_operator       UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_tenant_id            UUID;
+  v_wave_status          TEXT;
+  v_expected_store_count INTEGER;
+  v_expected_item_count  INTEGER;
+  v_actual_xfer_count    INTEGER;
+  v_store_rec            RECORD;
+  v_dest_location_id     BIGINT;
+  v_new_xfer_id          BIGINT;
+  v_inserted_items       INTEGER;
+  v_xfer_ids             BIGINT[] := ARRAY[]::BIGINT[];
+  v_pwi                  RECORD;
+  v_out_mov_id           BIGINT;
+  v_missing              TEXT;
+  v_fallback_cost        NUMERIC;
+BEGIN
+  PERFORM pg_advisory_xact_lock(p_wave_id);
+
+  SELECT tenant_id, status INTO v_tenant_id, v_wave_status
+    FROM picking_waves WHERE id = p_wave_id FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '找不到撿貨單 %', p_wave_id;
+  END IF;
+
+  IF v_wave_status <> 'picked' THEN
+    RAISE EXCEPTION '撿貨單 % 目前狀態為「%」，需先確認撿貨完成（picked）才能派貨', p_wave_id, v_wave_status;
+  END IF;
+
+  -- 防禦性修補：若有 picked_qty IS NULL（未手動填），補成 qty
+  UPDATE picking_wave_items
+     SET picked_qty = qty,
+         updated_by = p_operator
+   WHERE wave_id   = p_wave_id
+     AND picked_qty IS NULL;
+
+  -- 檢查是否有任何品項有撿貨量
+  SELECT COUNT(DISTINCT store_id), COUNT(*)
+    INTO v_expected_store_count, v_expected_item_count
+    FROM picking_wave_items
+   WHERE wave_id = p_wave_id AND picked_qty > 0;
+
+  IF v_expected_item_count = 0 THEN
+    -- 區分「根本沒有品項」vs「全部撿貨量為 0」
+    PERFORM 1 FROM picking_wave_items WHERE wave_id = p_wave_id LIMIT 1;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION '撿貨單 % 沒有任何品項，無法產生出倉單', p_wave_id;
+    ELSE
+      RAISE EXCEPTION '撿貨單 % 所有品項撿貨數量均為 0，無法產生出倉單。請先在「修正數量」輸入實際撿貨量再派貨。', p_wave_id;
+    END IF;
+  END IF;
+
+  -- 出貨價格防呆：要出的每個（非虛擬）SKU 必須已設定現行成本價 + 分店價，
+  -- 否則整張擋下 — 0 成本/0 分店價出貨會讓店月結算出 0 元、無人發現。
+  SELECT public._missing_dispatch_prices(
+           v_tenant_id,
+           (SELECT array_agg(DISTINCT sku_id)
+              FROM picking_wave_items
+             WHERE wave_id = p_wave_id AND picked_qty > 0))
+    INTO v_missing;
+
+  IF v_missing IS NOT NULL THEN
+    RAISE EXCEPTION '無法派貨：以下品項尚未設定成本價／分店價，請先補價再出貨（商品頁 SKU 區塊或派貨工作台可直接補）→ %', v_missing;
+  END IF;
+
+  FOR v_store_rec IN
+    SELECT DISTINCT pwi.store_id, s.location_id
+      FROM picking_wave_items pwi
+      JOIN stores s ON s.id = pwi.store_id
+     WHERE pwi.wave_id = p_wave_id AND pwi.picked_qty > 0
+  LOOP
+    v_dest_location_id := v_store_rec.location_id;
+    IF v_dest_location_id IS NULL THEN
+      RAISE EXCEPTION '分店 % 未設定倉庫位置（location_id）', v_store_rec.store_id;
+    END IF;
+
+    INSERT INTO transfers (tenant_id, transfer_no, source_location, dest_location,
+                           status, transfer_type, requested_by, shipped_by, shipped_at,
+                           created_by, updated_by)
+    VALUES (v_tenant_id,
+            'WAVE-' || p_wave_id || '-S' || v_store_rec.store_id,
+            p_hq_location_id, v_dest_location_id,
+            'shipped', 'hq_to_store', p_operator, p_operator, NOW(),
+            p_operator, p_operator)
+    RETURNING id INTO v_new_xfer_id;
+
+    FOR v_pwi IN
+      SELECT id, sku_id, picked_qty
+        FROM picking_wave_items
+       WHERE wave_id  = p_wave_id
+         AND store_id = v_store_rec.store_id
+         AND picked_qty > 0
+    LOOP
+      -- avg_cost = 0（0 成本入庫）時，出庫以現行成本價計價，月結才不會 0 元
+      v_fallback_cost := public._current_cost_price(v_tenant_id, v_pwi.sku_id);
+
+      v_out_mov_id := rpc_outbound(
+        p_tenant_id          => v_tenant_id,
+        p_location_id        => p_hq_location_id,
+        p_sku_id             => v_pwi.sku_id,
+        p_quantity           => v_pwi.picked_qty,
+        p_movement_type      => 'transfer_out',
+        p_source_doc_type    => 'transfer',
+        p_source_doc_id      => v_new_xfer_id,
+        p_operator           => p_operator,
+        p_allow_negative     => FALSE,
+        p_fallback_unit_cost => v_fallback_cost
+      );
+
+      INSERT INTO transfer_items (transfer_id, sku_id, qty_requested, qty_shipped,
+                                  out_movement_id, created_by, updated_by)
+      VALUES (v_new_xfer_id, v_pwi.sku_id, v_pwi.picked_qty, v_pwi.picked_qty,
+              v_out_mov_id, p_operator, p_operator);
+    END LOOP;
+
+    GET DIAGNOSTICS v_inserted_items = ROW_COUNT;
+
+    UPDATE picking_wave_items
+       SET generated_transfer_id = v_new_xfer_id, updated_by = p_operator
+     WHERE wave_id  = p_wave_id
+       AND store_id = v_store_rec.store_id
+       AND picked_qty > 0;
+
+    INSERT INTO picking_wave_audit_log (tenant_id, wave_id, action, after_value, created_by)
+    VALUES (v_tenant_id, p_wave_id, 'so_generated',
+            jsonb_build_object('transfer_id', v_new_xfer_id,
+                               'store_id', v_store_rec.store_id,
+                               'items_count', v_inserted_items),
+            p_operator);
+
+    v_xfer_ids := v_xfer_ids || v_new_xfer_id;
+  END LOOP;
+
+  UPDATE picking_waves SET status = 'shipped', updated_by = p_operator WHERE id = p_wave_id;
+
+  -- 呼叫訂單狀態更新（若 function 存在）
+  BEGIN
+    PERFORM rpc_mark_orders_shipping_for_wave(p_wave_id, p_operator);
+  EXCEPTION WHEN undefined_function THEN NULL;
+  END;
+
+  SELECT COUNT(DISTINCT generated_transfer_id)
+    INTO v_actual_xfer_count
+    FROM picking_wave_items
+   WHERE wave_id = p_wave_id AND picked_qty > 0 AND generated_transfer_id IS NOT NULL;
+
+  IF v_actual_xfer_count <> v_expected_store_count THEN
+    RAISE EXCEPTION '出倉單數量不符：預期 % 張，實際建立 % 張', v_expected_store_count, v_actual_xfer_count;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'wave_id',      p_wave_id,
+    'transfer_ids', to_jsonb(v_xfer_ids),
+    'store_count',  v_expected_store_count,
+    'item_count',   v_expected_item_count
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION generate_transfer_from_wave(BIGINT, BIGINT, UUID) TO authenticated;
+COMMENT ON FUNCTION generate_transfer_from_wave IS
+  '根據撿貨單產生分店出倉 transfer；需 status=picked 且至少一項 picked_qty > 0；'
+  '20260705 起：出貨前守衛缺成本價/分店價（非虛擬 SKU），avg_cost=0 時出庫以現行成本價計價。';
+
+-- ----------------------------------------------------------------------------
+-- Part 3: rpc_ship_restock_pr_received — 同守衛 + 後備成本
+-- 基底：20260515000004 逐字保留（role 檢查 / 狀態機 / 直接 shipped + outbound）。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_ship_restock_pr_received(
+  p_request_id BIGINT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant      UUID := public._current_tenant_id();
+  v_user        UUID := auth.uid();
+  v_role        TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_req         RECORD;
+  v_hq_loc      BIGINT;
+  v_dest_loc    BIGINT;
+  v_transfer_id BIGINT;
+  v_no          TEXT;
+  v_line        RECORD;
+  v_out_mov_id  BIGINT;
+  v_missing     TEXT;
+  v_fallback    NUMERIC;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot ship restock', v_role;
+  END IF;
+
+  SELECT * INTO v_req FROM restock_requests
+   WHERE id = p_request_id AND tenant_id = v_tenant FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'request % not found', p_request_id; END IF;
+  IF v_req.status <> 'approved_pr' THEN
+    RAISE EXCEPTION 'request % must be in approved_pr (current: %)', p_request_id, v_req.status;
+  END IF;
+  IF v_req.linked_pr_id IS NULL THEN
+    RAISE EXCEPTION 'request % missing linked_pr_id', p_request_id;
+  END IF;
+  IF v_req.linked_transfer_id IS NOT NULL THEN
+    RAISE EXCEPTION 'request % already shipped (transfer #%)', p_request_id, v_req.linked_transfer_id;
+  END IF;
+
+  SELECT id INTO v_hq_loc FROM locations
+   WHERE tenant_id = v_tenant AND type = 'central_warehouse' AND is_active = TRUE
+   ORDER BY id LIMIT 1;
+  IF v_hq_loc IS NULL THEN RAISE EXCEPTION 'no active central_warehouse'; END IF;
+
+  SELECT location_id INTO v_dest_loc FROM stores
+   WHERE id = v_req.requesting_store_id AND tenant_id = v_tenant;
+  IF v_dest_loc IS NULL THEN
+    RAISE EXCEPTION 'requesting store % has no location_id', v_req.requesting_store_id;
+  END IF;
+
+  -- 出貨價格防呆（同 generate_transfer_from_wave）
+  SELECT public._missing_dispatch_prices(
+           v_tenant,
+           (SELECT array_agg(DISTINCT sku_id)
+              FROM restock_request_lines
+             WHERE request_id = p_request_id AND tenant_id = v_tenant))
+    INTO v_missing;
+
+  IF v_missing IS NOT NULL THEN
+    RAISE EXCEPTION '無法派貨：以下品項尚未設定成本價／分店價，請先補價再出貨（商品頁 SKU 區塊或派貨工作台可直接補）→ %', v_missing;
+  END IF;
+
+  v_no := public._next_transfer_no();
+
+  INSERT INTO transfers (
+    tenant_id, transfer_no, source_location, dest_location,
+    status, transfer_type,
+    requested_by, shipped_by, shipped_at,
+    notes, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_no, v_hq_loc, v_dest_loc,
+    'shipped', 'hq_to_store',
+    v_user, v_user, NOW(),
+    'restock #' || p_request_id::TEXT || ' / PR #' || v_req.linked_pr_id::TEXT,
+    v_user, v_user
+  ) RETURNING id INTO v_transfer_id;
+
+  FOR v_line IN
+    SELECT sku_id, qty, notes FROM restock_request_lines
+     WHERE request_id = p_request_id AND tenant_id = v_tenant
+  LOOP
+    v_fallback := public._current_cost_price(v_tenant, v_line.sku_id);
+
+    v_out_mov_id := public.rpc_outbound(
+      p_tenant_id          => v_tenant,
+      p_location_id        => v_hq_loc,
+      p_sku_id             => v_line.sku_id,
+      p_quantity           => v_line.qty,
+      p_movement_type      => 'transfer_out',
+      p_source_doc_type    => 'transfer',
+      p_source_doc_id      => v_transfer_id,
+      p_operator           => v_user,
+      p_allow_negative     => FALSE,
+      p_fallback_unit_cost => v_fallback
+    );
+
+    INSERT INTO transfer_items (
+      transfer_id, sku_id, qty_requested, qty_shipped,
+      out_movement_id, notes, created_by, updated_by
+    ) VALUES (
+      v_transfer_id, v_line.sku_id, v_line.qty, v_line.qty,
+      v_out_mov_id, v_line.notes, v_user, v_user
+    );
+  END LOOP;
+
+  UPDATE restock_requests
+     SET status = 'shipped',
+         linked_transfer_id = v_transfer_id,
+         updated_by = v_user
+   WHERE id = p_request_id;
+
+  RETURN v_transfer_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_ship_restock_pr_received(BIGINT) TO authenticated;
+COMMENT ON FUNCTION public.rpc_ship_restock_pr_received(BIGINT) IS
+  'restock approved_pr → 收貨後派貨：建 shipped transfer + outbound HQ 庫存；'
+  '20260705 起：出貨前守衛缺成本價/分店價，avg_cost=0 時出庫以現行成本價計價。';
+
+-- ----------------------------------------------------------------------------
+-- Part 4: rpc_transfer_distribute_batch — 僅 hq_to_store 守衛缺價 + 後備成本
+-- 基底：20260515000006 逐字保留（任意 source / 虛擬 SKU 跳過 / 逐張 try-catch）。
+-- 店↔店自由轉貨（transfer_type ≠ hq_to_store）完全不受影響。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION rpc_transfer_distribute_batch(
+  p_transfer_ids   BIGINT[],
+  p_hq_location_id BIGINT,
+  p_operator       UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_id          BIGINT;
+  v_t           transfers%ROWTYPE;
+  v_ti          RECORD;
+  v_is_virtual  BOOLEAN;
+  v_out_id      BIGINT;
+  v_succeeded   BIGINT[] := ARRAY[]::BIGINT[];
+  v_failed      JSONB    := '[]'::jsonb;
+  v_err         TEXT;
+  v_missing     TEXT;
+  v_fallback    NUMERIC;
+BEGIN
+  IF p_transfer_ids IS NULL OR array_length(p_transfer_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_transfer_ids is empty';
+  END IF;
+
+  FOREACH v_id IN ARRAY p_transfer_ids LOOP
+    BEGIN
+      SELECT * INTO v_t FROM transfers WHERE id = v_id FOR UPDATE;
+
+      IF v_t.id IS NULL THEN
+        v_failed := v_failed || jsonb_build_object('id', v_id, 'reason', 'not found');
+        CONTINUE;
+      END IF;
+      IF v_t.status NOT IN ('draft','confirmed') THEN
+        v_failed := v_failed || jsonb_build_object('id', v_id, 'reason',
+          'status=' || v_t.status || ', expected draft/confirmed');
+        CONTINUE;
+      END IF;
+
+      -- 出貨價格防呆：僅 HQ→店（賣斷計費）守衛；店↔店自由轉貨不檢查
+      IF v_t.transfer_type = 'hq_to_store' THEN
+        SELECT public._missing_dispatch_prices(
+                 v_t.tenant_id,
+                 (SELECT array_agg(DISTINCT sku_id)
+                    FROM transfer_items WHERE transfer_id = v_id))
+          INTO v_missing;
+
+        IF v_missing IS NOT NULL THEN
+          RAISE EXCEPTION '無法派貨：以下品項尚未設定成本價／分店價，請先補價再出貨 → %', v_missing;
+        END IF;
+      END IF;
+
+      FOR v_ti IN
+        SELECT id AS ti_id, sku_id, qty_requested
+          FROM transfer_items
+         WHERE transfer_id = v_id
+      LOOP
+        SELECT p.is_virtual INTO v_is_virtual
+          FROM skus s JOIN products p ON p.id = s.product_id
+         WHERE s.id = v_ti.sku_id;
+
+        IF v_is_virtual THEN
+          -- 虛擬 SKU：不動庫存、out_movement_id 留 NULL
+          UPDATE transfer_items
+             SET qty_shipped = qty_requested,
+                 updated_by  = p_operator
+           WHERE id = v_ti.ti_id;
+        ELSE
+          -- 後備成本僅用於 HQ→店出貨（月結計費路徑）
+          v_fallback := CASE WHEN v_t.transfer_type = 'hq_to_store'
+                             THEN public._current_cost_price(v_t.tenant_id, v_ti.sku_id)
+                             ELSE NULL END;
+
+          v_out_id := rpc_outbound(
+            p_tenant_id          => v_t.tenant_id,
+            p_location_id        => v_t.source_location,
+            p_sku_id             => v_ti.sku_id,
+            p_quantity           => v_ti.qty_requested,
+            p_movement_type      => 'transfer_out',
+            p_source_doc_type    => 'transfer',
+            p_source_doc_id      => v_id,
+            p_operator           => p_operator,
+            p_allow_negative     => FALSE,
+            p_fallback_unit_cost => v_fallback
+          );
+          UPDATE transfer_items
+             SET qty_shipped     = qty_requested,
+                 out_movement_id = v_out_id,
+                 updated_by      = p_operator
+           WHERE id = v_ti.ti_id;
+        END IF;
+      END LOOP;
+
+      UPDATE transfers
+         SET status     = 'shipped',
+             shipped_by = p_operator,
+             shipped_at = NOW(),
+             updated_by = p_operator
+       WHERE id = v_id;
+
+      v_succeeded := v_succeeded || v_id;
+    EXCEPTION WHEN OTHERS THEN
+      v_err := SQLERRM;
+      v_failed := v_failed || jsonb_build_object('id', v_id, 'reason', v_err);
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'processed', array_length(p_transfer_ids, 1),
+    'succeeded', v_succeeded,
+    'failed', v_failed
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_transfer_distribute_batch(BIGINT[], BIGINT, UUID) TO authenticated;
+COMMENT ON FUNCTION rpc_transfer_distribute_batch(BIGINT[], BIGINT, UUID) IS
+  '批次派發 transfers（任意 source、虛擬 SKU 跳過庫存）；'
+  '20260705 起：hq_to_store 出貨前守衛缺成本價/分店價，avg_cost=0 時以現行成本價計價。';


### PR DESCRIPTION
## 背景（楊小胖 2026-06-11 LINE 回報）

> 派車出倉沒有可以修改金額的地方耶？
> 當初建立採購單 0 成本 0 分店價…可以再加上防呆嗎（0 分店價不可出）；如果分發貨沒有異動，一鍵派貨不會發現耶

**Root cause 鏈：** 採購單 0 成本建單 → 收貨以 0 成本入庫（HQ avg_cost=0）→ 派貨出庫 movement.unit_cost=0 → **店月結 `qty × 0 = 0 元`、全程無金額欄位無人發現**；分店價側：PR 審核只同步 `franchise_price > 0`，0 元永遠不會成為現行分店價。

## 設計

出倉只有 3 個咽喉點，守衛全加在 DB RPC（一鍵派貨繞不過）：

| RPC | 範圍 |
|---|---|
| `generate_transfer_from_wave` | 撿貨單派貨 / hq-inbox 一鍵派貨主路徑 |
| `rpc_ship_restock_pr_received` | 補貨 PR 到貨直派 |
| `rpc_transfer_distribute_batch` | 僅 `hq_to_store`；**店↔店自由轉貨不受影響** |

- 守衛條件＝缺「現行成本價」或「現行分店價」（`prices scope=cost/branch`、`effective_to IS NULL`、`price>0`），**虛擬 SKU 跳過**；中文錯誤一次列出全部缺價 SKU（仿 20260703000010 開團缺零售價 precedent）
- `rpc_outbound` 9→10 參數加 `p_fallback_unit_cost`（先 DROP 舊簽名避免 overload 歧義）：avg_cost≤0 時出庫以**現行成本價**計價 → 已經 0 成本入庫的存貨，補價後派貨**月結照樣收得到錢**；其他呼叫端不傳新參數、行為不變
- `/wms/picking` 派貨工作台：品項列「缺成本」「缺分店價」紅字 pill（文字、無 icon），**點 pill 直接 inline 補價**（走既有 `rpc_set_cost_price` / `rpc_set_branch_price`）→ 同時回應「沒有可以修改金額的地方」
- e2e seed 補 cost/branch 價（不補黃金路徑派貨會被新守衛擋）

## 驗證

- SQL 直測 **18/18 PASS**（乾淨 `supabase/postgres` 容器實跑；`scripts/test-dispatch-price-guard.sql`，報告見 `docs/TEST-dispatch-price-guard.report-2026-06-11.md`）：擋下＋中文清單、wave 維持 picked、補價後 shipped、avg=0 fallback 45/50、avg>0 維持 7、batch failed[]/succeeded、虛擬跳過、9 參數呼叫無歧義
- `next build`（含 type-check）✅
- 本機 `supabase db reset` 全鏈重放在 **20260508120000** 既有 timestamp 亂序處斷掉（與本 PR 無關，prod 不受影響）；故用依賴切片驗證

## ⚠️ 部署（merge 前先做，agent 環境缺 token 未能代跑）

```powershell
$env:SUPABASE_ACCESS_TOKEN='sbp_xxx'   # https://supabase.com/dashboard/account/tokens
# 1) 先探測缺價覆蓋率（避免上線當下全倉被擋）
node .claude-scripts/apply_via_mgmt_api.cjs --sql "SELECT COUNT(*) FILTER (WHERE miss_cost) AS missing_cost, COUNT(*) FILTER (WHERE miss_branch) AS missing_branch, COUNT(*) AS stocked_skus FROM (SELECT s.id, NOT EXISTS (SELECT 1 FROM prices p WHERE p.sku_id=s.id AND p.scope='cost' AND p.scope_id IS NULL AND p.effective_to IS NULL AND p.price>0) AS miss_cost, NOT EXISTS (SELECT 1 FROM prices p WHERE p.sku_id=s.id AND p.scope='branch' AND p.scope_id IS NULL AND p.effective_to IS NULL AND p.price>0) AS miss_branch FROM stock_balances sb JOIN locations l ON l.id=sb.location_id AND l.type='central_warehouse' JOIN skus s ON s.id=sb.sku_id JOIN products pr ON pr.id=s.product_id AND COALESCE(pr.is_virtual,FALSE)=FALSE WHERE sb.on_hand>0) x"
# 2) 套 migration
node .claude-scripts/apply_via_mgmt_api.cjs supabase/migrations/20260705000000_dispatch_price_guard.sql
```

若覆蓋率差（大量在庫 SKU 缺價），可先跑批次補價（cost←最近一次 GR 收貨成本、branch←最近一次 PR franchise_price）— SQL 我可以再產，**等你看完探測數字決定**。

## 自審清單（preview）

- [ ] /wms/picking 缺價 SKU 顯示「缺成本」「缺分店價」pill；點擊 inline 補價後消失
- [ ] 控制列「缺價 N 品項 — 補價前派貨會被擋」
- [ ] hq/inbox 對缺價 wave 按「派貨」→ 紅字中文錯誤列出 SKU
- [ ] 補完價重派 → 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
