### PR TITLE
feat(purchase): 採購單搜尋新增「產品名稱」支援

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/page.tsx
@@ -301,7 +301,7 @@ export default function PurchaseOrdersListPage() {
       if (dateTo && (p.created_at ?? "") > `${dateTo}T23:59:59.999`)
         return false;
       if (q) {
-        const hits = [p.po_no, p.supplier_name, p.pr_no]
+        const hits = [p.po_no, p.supplier_name, p.pr_no, ...p.product_names]
           .filter((x): x is string => !!x)
           .some((x) => x.toLowerCase().includes(q));
         if (!hits) return false;
@@ -613,7 +613,7 @@ export default function PurchaseOrdersListPage() {
         <input
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="🔍 搜尋 單號 / 供應商 / PR"
+          placeholder="🔍 搜尋 單號 / 供應商 / PR / 產品"
           className="flex-1 min-w-[180px] rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900"
         />
         <select


### PR DESCRIPTION
## 變更內容

採購單（PO）列表頁的搜尋欄現在支援搜尋**商品名稱**。

- 搜尋邏輯加入 `product_names` 陣列，與既有的單號 / 供應商 / PR 搜尋合併在同一個搜尋框
- 搜尋欄 placeholder 從「🔍 搜尋 單號 / 供應商 / PR」更新為「🔍 搜尋 單號 / 供應商 / PR / 產品」

## 為什麼

採購單列表常需要依「某項商品在哪些 PO 出現」來找單。原本搜尋框只認單號 / 供應商 / PR，使用者要找特定商品的採購單只能逐頁翻。`product_names` 已經在 client 端組好（用於商品欄顯示），直接納入搜尋比對即可，零額外查詢成本。

## Reviewer 須知

- 改動集中在 `apps/admin/src/app/(protected)/purchase/orders/page.tsx` 的 `filtered` useMemo 與搜尋框 placeholder
- 搜尋為純 client 端比對（list 已一次撈 500 筆），不影響任何 RPC / DB
- 已驗證：單號 / 供應商 / PR / 產品名稱 四種搜尋字串皆能正確命中，不符字串正確排除；TypeScript 類型檢查無誤

🤖 Generated with [Claude Code](https://claude.com/claude-code)