### PR TITLE
feat(purchase): 請購單(PR)可刪除 — rpc_delete_pr + 解鎖團 + 列表/編輯頁刪除鈕

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -89,7 +89,7 @@ function PageContent() {
   const [appending, setAppending] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [busy, setBusy] = useState<"save" | "submit" | "split" | "reopen" | null>(null);
+  const [busy, setBusy] = useState<"save" | "submit" | "split" | "reopen" | "delete" | null>(null);
   const [destLocationId, setDestLocationId] = useState<number | null>(null);
 
   // 頂部「一次套用到全部品項」工具列的暫存值（空字串＝不套用該欄）
@@ -377,6 +377,11 @@ function PageContent() {
   const canSplit =
     header?.status === "submitted" && header?.review_status === "approved";
   const canReopen = header?.status === "submitted";
+  // 可刪：草稿/送審中/已作廢（已拆 PO 的 partially/fully_ordered 不在此列）
+  const canDelete =
+    header?.status === "draft" ||
+    header?.status === "submitted" ||
+    header?.status === "cancelled";
 
   const totals = useMemo(() => {
     const subtotal = items.reduce((s, r) => s + r.qty_requested * r.unit_cost, 0);
@@ -579,6 +584,31 @@ function PageContent() {
     }
   }
 
+  async function deletePr() {
+    if (!id) return;
+    if (
+      !confirm(
+        `確定刪除此${PR_TERM_ZH}？此動作無法復原。\n（若有鎖定中的團會一併解鎖回「已結單」狀態；顧客訂單不受影響）`,
+      )
+    )
+      return;
+    setBusy("delete");
+    setError(null);
+    try {
+      const supabase = getSupabase();
+      const { data: userData } = await supabase.auth.getUser();
+      const { error: rpcErr } = await supabase.rpc("rpc_delete_pr", {
+        p_pr_id: id,
+        p_operator: userData.user?.id,
+      });
+      if (rpcErr) throw new Error(rpcErr.message);
+      router.push("/purchase/requests");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setBusy(null);
+    }
+  }
+
   async function splitToPos() {
     if (!id || !destLocationId) return;
     if (unassignedCount > 0) {
@@ -742,8 +772,18 @@ function PageContent() {
                   {busy === "reopen" ? "退回中…" : "↩ 退回草稿"}
                 </SpinButton>
               )}
-              {!editable && !canSplit && !canReopen && (
+              {!editable && !canSplit && !canReopen && !canDelete && (
                 <p className="text-xs text-zinc-500">此{PR_TERM_ZH}已 {STATUS_LABEL(header.status)}，無可用動作。</p>
+              )}
+              {canDelete && (
+                <SpinButton
+                  onClick={deletePr}
+                  disabled={busy !== null}
+                  className="mt-1 rounded-md border border-red-400 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950"
+                  title="刪除請購單（已拆 PO 的不可刪）"
+                >
+                  🗑 刪除{PR_TERM_ZH}
+                </SpinButton>
               )}
             </div>
           </section>

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -492,6 +492,30 @@ export default function PurchaseRequestsListPage() {
     }
   }
 
+  async function deletePr(id: number) {
+    if (
+      !confirm(
+        `確定刪除${PR_TERM_ZH} #${id}？此動作無法復原。\n（若此單有鎖定中的團，會一併解鎖回「已結單」狀態；顧客訂單不受影響）`,
+      )
+    )
+      return;
+    setBusyId(id);
+    try {
+      const supabase = getSupabase();
+      const { data: userData } = await supabase.auth.getUser();
+      const { error: rpcErr } = await supabase.rpc("rpc_delete_pr", {
+        p_pr_id: id,
+        p_operator: userData.user?.id,
+      });
+      if (rpcErr) throw new Error(rpcErr.message);
+      setReloadTick((t) => t + 1);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
   // === KPI 統計 ===
   const stats = useMemo(() => {
     const acc = {
@@ -963,6 +987,7 @@ export default function PurchaseRequestsListPage() {
                     busyId={busyId}
                     onApprove={approve}
                     onReject={reject}
+                    onDelete={deletePr}
                   />
                 )),
               ])
@@ -975,6 +1000,7 @@ export default function PurchaseRequestsListPage() {
                   busyId={busyId}
                   onApprove={approve}
                   onReject={reject}
+                  onDelete={deletePr}
                 />
               ))
             )}
@@ -1204,13 +1230,19 @@ function PRRow({
   busyId,
   onApprove,
   onReject,
+  onDelete,
 }: {
   row: Row;
   progress: Progress | undefined;
   busyId: number | null;
   onApprove: (id: number) => void;
   onReject: (id: number) => void;
+  onDelete: (id: number) => void;
 }) {
+  // 可刪：草稿/送審中/已作廢，且尚未拆出任何 PO（雙重保險）
+  const canDelete =
+    ["draft", "submitted", "cancelled"].includes(row.status) &&
+    (!progress || progress.po_total === 0);
   return (
     <tr className="hover:bg-zinc-50 dark:hover:bg-zinc-900/60">
       <Td className="font-mono">
@@ -1280,13 +1312,23 @@ function PRRow({
                 通過
               </RowAction>
               <RowAction
-                variant="danger"
+                variant="warning"
                 disabled={busyId === row.id}
                 onClick={() => onReject(row.id)}
               >
                 退回
               </RowAction>
             </>
+          )}
+          {canDelete && (
+            <RowAction
+              variant="danger"
+              disabled={busyId === row.id}
+              onClick={() => onDelete(row.id)}
+              title="刪除請購單（已拆 PO 的不可刪）"
+            >
+              刪除
+            </RowAction>
           )}
         </div>
       </Td>

--- a/docs/TEST-pr-delete.md
+++ b/docs/TEST-pr-delete.md
@@ -1,0 +1,118 @@
+# pr-delete 測試項目 — 請購單(PR)刪除
+
+**對應 migration:** `supabase/migrations/20260706000000_rpc_delete_pr.sql`
+**對應 UI 變更:** `apps/admin/src/app/(protected)/purchase/requests/page.tsx`、`apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx`
+**基底慣例:** `rpc_delete_campaign`（20260630000020）— 守門 + 實體硬刪 + 殘參照丟可讀訊息
+
+> 決策（使用者拍板）：可刪狀態＝草稿/送審中/已作廢；已拆 PO 一律擋；
+> 刪除時**只解鎖團（locked→closed）**，**顧客訂單一律維持 confirmed 不動**。
+
+## 1. Schema / Migration 層
+
+### 1.1 RPC signature
+- [ ] `rpc_delete_pr(BIGINT, UUID)` 存在、RETURNS void、SECURITY DEFINER
+  ```sql
+  SELECT proname, prosecdef, pg_get_function_arguments(oid), pg_get_function_result(oid)
+    FROM pg_proc WHERE proname = 'rpc_delete_pr';
+  ```
+- [ ] 權限：`REVOKE ALL FROM PUBLIC` + `GRANT EXECUTE TO authenticated`
+  ```sql
+  SELECT grantee, privilege_type FROM information_schema.routine_privileges
+   WHERE routine_name = 'rpc_delete_pr';
+  -- 預期 authenticated/EXECUTE，無 PUBLIC
+  ```
+
+### 1.2 不動 schema
+- [ ] 本 migration 不新增/改任何表、欄位、CHECK、index、trigger（純 RPC）
+- [ ] 既有 FK 仍在：`purchase_request_items.pr_id` / `purchase_request_campaigns.pr_id` 為 ON DELETE CASCADE
+  ```sql
+  SELECT conname, confdeltype FROM pg_constraint
+   WHERE conrelid IN ('purchase_request_items'::regclass,'purchase_request_campaigns'::regclass)
+     AND contype='f' AND confrelid='purchase_requests'::regclass;
+  -- confdeltype = 'c' (CASCADE)
+  ```
+
+## 2. RPC 行為（SQL 直測）
+
+### 2.1 draft PR 可刪 + items 連帶 CASCADE
+**情境：** source_type=manual 的 draft PR，含 2 個 items（po_item_id 皆 NULL），無 campaign 關聯。
+**預期：** 呼叫成功；purchase_requests 該列消失；其 purchase_request_items 一併消失（CASCADE）。
+
+### 2.2 submitted PR 可刪
+**情境：** status=submitted、review_status=pending_review 或 approved、未拆 PO。
+**預期：** 刪除成功、列消失。
+
+### 2.3 cancelled PR 可刪
+**情境：** status=cancelled 的 PR。
+**預期：** 刪除成功。
+
+### 2.4 已拆 PO 擋下（status 守門）
+**情境：** status='partially_ordered'（或 'fully_ordered'）。
+**預期：** RAISE，訊息中文表示「已拆 PO 不可刪」；PR 與其 PO 皆不動。
+
+### 2.5 已拆 PO 擋下（po_item_id 雙重保險）
+**情境：** 人為把 status 留在 draft 但某 item.po_item_id 指向實際 PO item。
+**預期：** 仍 RAISE 擋下（不靠 status 單一條件）。
+
+### 2.6 解鎖團：關聯 locked campaign → closed，訂單不動
+**情境：** close_date PR 關聯 2 個 campaign（皆 status='locked'），各有 confirmed 訂單。
+**預期：** 刪 PR 後兩 campaign 變回 'closed'；customer_orders 仍為 confirmed（一筆都沒退回 pending）。
+
+### 2.7 解鎖只動 locked，不誤傷其他狀態
+**情境：** PR 關聯兩 campaign，一個 locked、一個已被推進到別的狀態（如 finalized/closed）。
+**預期：** 只有 locked 那個被改成 closed；另一個維持原狀態。
+
+### 2.8 manual/blank PR（無 campaign 關聯）直接刪
+**情境：** rpc_create_pr_blank 建的 PR，purchase_request_campaigns 無列、source_campaign_id NULL。
+**預期：** 解鎖步驟影響 0 列、PR 正常刪除、無錯誤。
+
+### 2.9 source_campaign_id（單一團 PR，非 join 表）也解鎖
+**情境：** source_type='campaign' 的 PR，campaign 關聯記在 purchase_requests.source_campaign_id（join 表可能無列），該 campaign locked。
+**預期：** 該 campaign 一樣被解鎖回 closed（解鎖來源涵蓋 join 表 UNION source_campaign_id）。
+
+### 2.10 restock 來源 PR 擋下
+**情境：** restock_requests.linked_pr_id 指向某 PR（補貨審核成 PR）。
+**預期：** RAISE，中文訊息引導「從補貨流程處理」；PR 不刪、restock_requests 不受影響。
+
+### 2.11 not found / 跨 tenant
+**情境：** 不存在的 p_pr_id；或他 tenant 的 PR id。
+**預期：** RAISE「not found」；跨 tenant 視為找不到、不刪到別 tenant 資料。
+
+### 2.12 role 守門
+**情境：** JWT app_metadata.role 為 store_staff/store_manager（非 owner/admin/hq_manager 且非空）。
+**預期：** RAISE permission denied；PR 不動。（空字串 role 放行，對齊既有 restock RPC pattern）
+
+### 2.13 殘留無 CASCADE 參照 → 可讀訊息
+**情境：** 人為製造一筆無 ON DELETE CASCADE 的殘參照指向該 PR（模擬未預期關聯）。
+**預期：** 捕捉 foreign_key_violation、RAISE 可讀中文訊息（非原始 FK 錯誤字串）。
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 列表動作欄「刪除」
+- [ ] /purchase/requests 載入無 console error
+- [ ] draft / submitted / cancelled 列：動作欄出現「刪除」(danger) 鈕
+- [ ] partially_ordered / fully_ordered 列、或 progress.po_total>0：**不顯示**刪除鈕
+- [ ] 點刪除 → confirm 對話框；取消則不動
+- [ ] 確認後呼叫 rpc_delete_pr → 該列從清單消失（reload）、KPI 數字更新
+- [ ] 刪除進行中為 spinner、無文字
+
+### 3.2 編輯頁刪除
+- [ ] /purchase/requests/edit?id=… 對可刪狀態顯示刪除鈕
+- [ ] 刪除成功 → 導回 /purchase/requests 列表
+- [ ] 對已拆 PO 的 PR：刪除鈕不顯示（或停用）
+
+### 3.3 錯誤回饋
+- [ ] 後端 RAISE（如競態下變成已拆 PO）→ 前端顯示中文錯誤、列表不破版
+
+## 4. Regression
+- [ ] PR 審核「通過/退回」(rpc_approve/reject_purchase_request) 照常
+- [ ] PR 退回草稿 rpc_pr_reopen 照常
+- [ ] 拆 PO rpc_split_pr_to_pos 照常；已拆 PO 的 PR 與其 PO 不被刪除功能影響
+- [ ] 解鎖回 closed 的 campaign 可再次被「結單日待開單 / 針對團購建單」重新彙總建 PR
+- [ ] 採購單列表 /purchase/orders 不受影響
+- [ ] 補貨 inbox（restock）流程不受影響（restock PR 擋在刪除外）
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**migration 套用成功**、**admin build + type-check 過** 才可標 done。
+（§3 UI 受 sandbox 限制時走 build + 碼審 + 使用者自審；§2 在拋棄式切片容器實跑。）

--- a/scripts/test-pr-delete.sql
+++ b/scripts/test-pr-delete.sql
@@ -1,0 +1,193 @@
+-- ============================================================
+-- TEST: pr-delete（docs/TEST-pr-delete.md §2）
+-- 前置（由 runner 先跑）：auth stub + _current_tenant_id stub + 精簡 schema
+--   （精確複製關鍵約束：items/campaigns join 的 ON DELETE CASCADE、
+--    group_buy_campaigns.status CHECK 含 locked/closed、restock linked_pr_id 無 CASCADE）
+--   + 灌 20260706000000_rpc_delete_pr.sql
+-- 本檔：BEGIN → fixtures → 各案 → 輸出 → ROLLBACK（不留資料）。
+-- ============================================================
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- admin + tenant 身份（rpc_delete_pr 讀 auth.jwt() app_metadata）
+SELECT set_config('request.jwt.claims',
+  '{"app_metadata":{"role":"admin","tenant_id":"a0000000-0000-4000-8000-0000000000aa"}}', true);
+
+CREATE TEMP TABLE _r (seq SERIAL, test TEXT, pass BOOLEAN, detail TEXT) ON COMMIT DROP;
+
+DO $$
+DECLARE
+  c_tenant CONSTANT UUID := 'a0000000-0000-4000-8000-0000000000aa';
+  c_op     CONSTANT UUID := 'b0000000-0000-4000-8000-0000000000bb';
+  v_camp1 BIGINT; v_camp2 BIGINT; v_camp_other BIGINT;
+  v_pr BIGINT; v_pr2 BIGINT; v_po BIGINT; v_poi BIGINT;
+  v_exists INT; v_st TEXT; v_orders INT;
+BEGIN
+  -- ============ 2.1 draft 可刪 + items CASCADE ============
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, source_type, created_by)
+  VALUES (c_tenant, 'PR-T1', 'draft', 'manual', c_op) RETURNING id INTO v_pr;
+  INSERT INTO purchase_request_items (pr_id, sku_id, qty_requested, created_by)
+  VALUES (v_pr, 1, 5, c_op), (v_pr, 2, 3, c_op);
+
+  PERFORM rpc_delete_pr(v_pr, c_op);
+  SELECT COUNT(*) INTO v_exists FROM purchase_requests WHERE id = v_pr;
+  SELECT COUNT(*) INTO v_orders FROM purchase_request_items WHERE pr_id = v_pr;
+  INSERT INTO _r(test,pass,detail) VALUES
+    ('2.1 draft 刪除成功 + items CASCADE', v_exists = 0 AND v_orders = 0,
+     'pr_left=' || v_exists || ' items_left=' || v_orders);
+
+  -- ============ 2.2 submitted 可刪 ============
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, review_status, source_type, created_by)
+  VALUES (c_tenant, 'PR-T2', 'submitted', 'pending_review', 'manual', c_op) RETURNING id INTO v_pr;
+  PERFORM rpc_delete_pr(v_pr, c_op);
+  SELECT COUNT(*) INTO v_exists FROM purchase_requests WHERE id = v_pr;
+  INSERT INTO _r(test,pass,detail) VALUES ('2.2 submitted 可刪', v_exists = 0, 'left=' || v_exists);
+
+  -- ============ 2.3 cancelled 可刪 ============
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, source_type, created_by)
+  VALUES (c_tenant, 'PR-T3', 'cancelled', 'manual', c_op) RETURNING id INTO v_pr;
+  PERFORM rpc_delete_pr(v_pr, c_op);
+  SELECT COUNT(*) INTO v_exists FROM purchase_requests WHERE id = v_pr;
+  INSERT INTO _r(test,pass,detail) VALUES ('2.3 cancelled 可刪', v_exists = 0, 'left=' || v_exists);
+
+  -- ============ 2.4 已拆 PO（status 守門）擋 ============
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, source_type, created_by)
+  VALUES (c_tenant, 'PR-T4', 'partially_ordered', 'manual', c_op) RETURNING id INTO v_pr;
+  BEGIN
+    PERFORM rpc_delete_pr(v_pr, c_op);
+    INSERT INTO _r(test,pass,detail) VALUES ('2.4 partially_ordered 擋', FALSE, '未擋');
+  EXCEPTION WHEN OTHERS THEN
+    SELECT COUNT(*) INTO v_exists FROM purchase_requests WHERE id = v_pr;
+    INSERT INTO _r(test,pass,detail) VALUES
+      ('2.4 partially_ordered 擋 + PR 留存', SQLERRM LIKE '%已拆採購單%' AND v_exists = 1, SQLERRM);
+  END;
+
+  -- ============ 2.5 po_item_id 雙重保險（draft 但 item 連到 PO item）============
+  INSERT INTO purchase_orders (tenant_id) VALUES (c_tenant) RETURNING id INTO v_po;
+  INSERT INTO purchase_order_items (po_id) VALUES (v_po) RETURNING id INTO v_poi;
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, source_type, created_by)
+  VALUES (c_tenant, 'PR-T5', 'draft', 'manual', c_op) RETURNING id INTO v_pr;
+  INSERT INTO purchase_request_items (pr_id, sku_id, qty_requested, po_item_id, created_by)
+  VALUES (v_pr, 1, 5, v_poi, c_op);
+  BEGIN
+    PERFORM rpc_delete_pr(v_pr, c_op);
+    INSERT INTO _r(test,pass,detail) VALUES ('2.5 po_item_id 雙重保險擋', FALSE, '未擋');
+  EXCEPTION WHEN OTHERS THEN
+    INSERT INTO _r(test,pass,detail) VALUES
+      ('2.5 po_item_id 雙重保險擋', SQLERRM LIKE '%已有品項拆成採購單%', SQLERRM);
+  END;
+
+  -- ============ 2.6 解鎖團 locked→closed + 訂單不動 ============
+  INSERT INTO group_buy_campaigns (tenant_id, campaign_no, status, updated_by)
+  VALUES (c_tenant, 'GB-L1', 'locked', c_op) RETURNING id INTO v_camp1;
+  INSERT INTO group_buy_campaigns (tenant_id, campaign_no, status, updated_by)
+  VALUES (c_tenant, 'GB-L2', 'locked', c_op) RETURNING id INTO v_camp2;
+  INSERT INTO customer_orders (tenant_id, campaign_id, status) VALUES
+    (c_tenant, v_camp1, 'confirmed'), (c_tenant, v_camp2, 'confirmed');
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, source_type, source_close_date, created_by)
+  VALUES (c_tenant, 'PR-T6', 'draft', 'close_date', DATE '2026-07-01', c_op) RETURNING id INTO v_pr;
+  INSERT INTO purchase_request_campaigns (pr_id, campaign_id, tenant_id) VALUES
+    (v_pr, v_camp1, c_tenant), (v_pr, v_camp2, c_tenant);
+
+  PERFORM rpc_delete_pr(v_pr, c_op);
+  SELECT COUNT(*) INTO v_exists FROM group_buy_campaigns
+    WHERE id IN (v_camp1, v_camp2) AND status = 'closed';
+  SELECT COUNT(*) INTO v_orders FROM customer_orders
+    WHERE campaign_id IN (v_camp1, v_camp2) AND status = 'confirmed';
+  INSERT INTO _r(test,pass,detail) VALUES
+    ('2.6 兩團解鎖 closed + 訂單維持 confirmed', v_exists = 2 AND v_orders = 2,
+     'closed=' || v_exists || ' confirmed_orders=' || v_orders);
+
+  -- ============ 2.7 只動 locked、不誤傷其他狀態 ============
+  INSERT INTO group_buy_campaigns (tenant_id, campaign_no, status, updated_by)
+  VALUES (c_tenant, 'GB-L3', 'locked', c_op) RETURNING id INTO v_camp1;
+  INSERT INTO group_buy_campaigns (tenant_id, campaign_no, status, updated_by)
+  VALUES (c_tenant, 'GB-R1', 'receiving', c_op) RETURNING id INTO v_camp_other;
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, source_type, created_by)
+  VALUES (c_tenant, 'PR-T7', 'draft', 'campaign', c_op) RETURNING id INTO v_pr;
+  INSERT INTO purchase_request_campaigns (pr_id, campaign_id, tenant_id) VALUES
+    (v_pr, v_camp1, c_tenant), (v_pr, v_camp_other, c_tenant);
+  PERFORM rpc_delete_pr(v_pr, c_op);
+  SELECT status INTO v_st FROM group_buy_campaigns WHERE id = v_camp_other;
+  SELECT status INTO v_st FROM group_buy_campaigns WHERE id = v_camp1;
+  INSERT INTO _r(test,pass,detail) VALUES
+    ('2.7 locked→closed、receiving 不動',
+     (SELECT status FROM group_buy_campaigns WHERE id=v_camp1)='closed'
+       AND (SELECT status FROM group_buy_campaigns WHERE id=v_camp_other)='receiving',
+     'L3=' || (SELECT status FROM group_buy_campaigns WHERE id=v_camp1)
+       || ' R1=' || (SELECT status FROM group_buy_campaigns WHERE id=v_camp_other));
+
+  -- ============ 2.8 manual/blank（無關聯）直接刪 ============
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, source_type, created_by)
+  VALUES (c_tenant, 'PR-T8', 'draft', 'manual', c_op) RETURNING id INTO v_pr;
+  PERFORM rpc_delete_pr(v_pr, c_op);
+  INSERT INTO _r(test,pass,detail) VALUES
+    ('2.8 manual 無關聯直接刪', (SELECT COUNT(*) FROM purchase_requests WHERE id=v_pr)=0, 'ok');
+
+  -- ============ 2.9 source_campaign_id（非 join 表）也解鎖 ============
+  INSERT INTO group_buy_campaigns (tenant_id, campaign_no, status, updated_by)
+  VALUES (c_tenant, 'GB-SC', 'locked', c_op) RETURNING id INTO v_camp1;
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, source_type, source_campaign_id, created_by)
+  VALUES (c_tenant, 'PR-T9', 'draft', 'campaign', v_camp1, c_op) RETURNING id INTO v_pr;
+  -- 故意不寫 join 表，只靠 source_campaign_id
+  PERFORM rpc_delete_pr(v_pr, c_op);
+  INSERT INTO _r(test,pass,detail) VALUES
+    ('2.9 source_campaign_id 解鎖', (SELECT status FROM group_buy_campaigns WHERE id=v_camp1)='closed',
+     'status=' || (SELECT status FROM group_buy_campaigns WHERE id=v_camp1));
+
+  -- ============ 2.10 restock 來源 PR 擋 ============
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, source_type, created_by)
+  VALUES (c_tenant, 'PR-T10', 'submitted', 'manual', c_op) RETURNING id INTO v_pr;
+  INSERT INTO restock_requests (tenant_id, linked_pr_id) VALUES (c_tenant, v_pr);
+  BEGIN
+    PERFORM rpc_delete_pr(v_pr, c_op);
+    INSERT INTO _r(test,pass,detail) VALUES ('2.10 restock 來源擋', FALSE, '未擋');
+  EXCEPTION WHEN OTHERS THEN
+    INSERT INTO _r(test,pass,detail) VALUES
+      ('2.10 restock 來源擋', SQLERRM LIKE '%補貨%' AND (SELECT COUNT(*) FROM purchase_requests WHERE id=v_pr)=1, SQLERRM);
+  END;
+
+  -- ============ 2.11 not found ============
+  BEGIN
+    PERFORM rpc_delete_pr(999999, c_op);
+    INSERT INTO _r(test,pass,detail) VALUES ('2.11 not found 擋', FALSE, '未擋');
+  EXCEPTION WHEN OTHERS THEN
+    INSERT INTO _r(test,pass,detail) VALUES ('2.11 not found 擋', SQLERRM LIKE '%找不到請購單%', SQLERRM);
+  END;
+
+  -- ============ 2.13 殘留無 CASCADE 參照 → 可讀訊息 ============
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, source_type, created_by)
+  VALUES (c_tenant, 'PR-T13', 'draft', 'manual', c_op) RETURNING id INTO v_pr;
+  INSERT INTO dummy_ref (pr_id) VALUES (v_pr);  -- 無 ON DELETE CASCADE 的殘參照
+  BEGIN
+    PERFORM rpc_delete_pr(v_pr, c_op);
+    INSERT INTO _r(test,pass,detail) VALUES ('2.13 殘參照可讀訊息', FALSE, '未擋');
+  EXCEPTION WHEN OTHERS THEN
+    INSERT INTO _r(test,pass,detail) VALUES
+      ('2.13 殘參照→可讀中文訊息', SQLERRM LIKE '%仍被其他紀錄參照%', SQLERRM);
+  END;
+END $$;
+
+-- ============ 2.12 role 守門（切 store_staff 身份）============
+SELECT set_config('request.jwt.claims',
+  '{"app_metadata":{"role":"store_staff","tenant_id":"a0000000-0000-4000-8000-0000000000aa"}}', true);
+DO $$
+DECLARE c_tenant CONSTANT UUID := 'a0000000-0000-4000-8000-0000000000aa';
+        c_op CONSTANT UUID := 'b0000000-0000-4000-8000-0000000000bb'; v_pr BIGINT;
+BEGIN
+  INSERT INTO purchase_requests (tenant_id, pr_no, status, source_type, created_by)
+  VALUES (c_tenant, 'PR-T12', 'draft', 'manual', c_op) RETURNING id INTO v_pr;
+  BEGIN
+    PERFORM rpc_delete_pr(v_pr, c_op);
+    INSERT INTO _r(test,pass,detail) VALUES ('2.12 role 守門擋 store_staff', FALSE, '未擋');
+  EXCEPTION WHEN OTHERS THEN
+    INSERT INTO _r(test,pass,detail) VALUES
+      ('2.12 role 守門擋 store_staff', SQLERRM LIKE '%權限不足%' AND (SELECT COUNT(*) FROM purchase_requests WHERE id=v_pr)=1, SQLERRM);
+  END;
+END $$;
+
+SELECT CASE WHEN pass THEN 'PASS' ELSE '*** FAIL ***' END AS result, test, LEFT(detail,150) AS detail
+  FROM _r ORDER BY seq;
+SELECT COUNT(*) FILTER (WHERE pass) || ' / ' || COUNT(*) AS passed FROM _r;
+
+ROLLBACK;

--- a/supabase/migrations/20260706000000_rpc_delete_pr.sql
+++ b/supabase/migrations/20260706000000_rpc_delete_pr.sql
@@ -1,0 +1,117 @@
+-- ============================================================================
+-- 2026-07-06: rpc_delete_pr — 請購單(PR)刪除（實體硬刪 + 守門 + 解鎖團）
+-- ----------------------------------------------------------------------------
+-- 需求：請購單要可以刪除（建錯結單日 / 多選了團 / 作廢的單想清掉）。
+--
+-- 難點：PR 建立時有副作用（20260625000000）——
+--   1. 鎖團：closed campaigns → 'locked'
+--   2. auto-confirm 訂單：那些團的 pending 訂單 → 'confirmed'
+-- 若只刪 PR 本體，團會卡在 'locked'（rpc_create_pr* 要求 'closed' 才能再建單），
+-- 等於把自己鎖死。故刪除時必須把「該 PR 鎖的團」解鎖回 'closed'。
+--
+-- 使用者決策（2026-07-06）：
+--   - 可刪狀態 = draft / submitted / cancelled；已拆 PO（partially/fully_ordered）一律擋。
+--   - 顧客訂單一律「維持 confirmed 不動」（不退回 pending）——不驚動已確認訂單；
+--     團解鎖回 closed 後重新建單時，confirmed 訂單照樣納入彙總，無副作用。
+--
+-- 設計（守門順序）：
+--   role 守門（owner/admin/hq_manager；空字串放行，對齊既有 restock RPC）→
+--   not found / 跨 tenant → 已拆 PO（status）→ 已拆 PO（po_item_id 雙重保險）→
+--   補貨來源 PR（被 restock_requests.linked_pr_id 參照，走補貨流程不在此刪）→
+--   解鎖團（locked→closed，來源 = purchase_request_campaigns join ∪ source_campaign_id）→
+--   實體刪 purchase_requests（items / campaigns join 為 ON DELETE CASCADE 自動連帶）。
+--
+-- 關於 locked→closed 與「開團單向」決策：
+--   project 決策「開團狀態單向、reopen 不做」指的是 closed→open（重開放下單）。
+--   這裡是 locked→closed（解除採購鎖定、回到補單窗口），語意不同、是刪 PR 的必要還原，
+--   不違反該決策。group_buy_campaigns 僅有 CHECK 值域、無單向 transition trigger（20260623000000）。
+--
+-- 基底慣例：rpc_delete_campaign（20260630000020）— 守門 + 硬刪 + 殘參照丟可讀訊息。
+-- 依賴：purchase_request_items.pr_id / purchase_request_campaigns.pr_id 為 ON DELETE CASCADE。
+-- Rollback：DROP FUNCTION public.rpc_delete_pr(BIGINT, UUID);
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_delete_pr(
+  p_pr_id    BIGINT,
+  p_operator UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant   UUID := public._current_tenant_id();
+  v_role     TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_status   TEXT;
+  v_po_items INTEGER;
+  v_restock  INTEGER;
+BEGIN
+  -- role 守門：採購職能（空字串放行 — 本機/某些情境 role 為空，對齊 restock RPC）
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION '權限不足：角色 % 無法刪除請購單', v_role;
+  END IF;
+
+  SELECT status INTO v_status
+    FROM purchase_requests
+   WHERE id = p_pr_id AND tenant_id = v_tenant
+   FOR UPDATE;
+
+  IF v_status IS NULL THEN
+    RAISE EXCEPTION '找不到請購單 %', p_pr_id;
+  END IF;
+
+  -- 守門 1：已拆採購單(PO) 不可刪 — PO 可能已發給供應商
+  IF v_status IN ('partially_ordered','fully_ordered') THEN
+    RAISE EXCEPTION '請購單 % 已拆採購單(PO)，不可刪除（狀態：%）。請改在採購單端處理。', p_pr_id, v_status;
+  END IF;
+
+  -- 守門 2：雙重保險 — 任一品項已連到 PO item（即使 status 沒同步）
+  SELECT COUNT(*) INTO v_po_items
+    FROM purchase_request_items
+   WHERE pr_id = p_pr_id AND po_item_id IS NOT NULL;
+  IF v_po_items > 0 THEN
+    RAISE EXCEPTION '請購單 % 已有品項拆成採購單，不可刪除', p_pr_id;
+  END IF;
+
+  -- 守門 3：補貨來源 PR（被 restock_requests 參照）走補貨流程，不在此刪
+  SELECT COUNT(*) INTO v_restock
+    FROM restock_requests
+   WHERE linked_pr_id = p_pr_id AND tenant_id = v_tenant;
+  IF v_restock > 0 THEN
+    RAISE EXCEPTION '請購單 % 來自補貨申請，請從補貨流程處理，不可在此刪除', p_pr_id;
+  END IF;
+
+  -- 解鎖團：把該 PR 鎖的、目前 status='locked' 的 campaign 還原回 'closed'。
+  -- 訂單一律不動（維持 confirmed）。來源涵蓋 join 表 ∪ source_campaign_id（單一團 PR）。
+  UPDATE group_buy_campaigns gbc
+     SET status     = 'closed',
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE gbc.tenant_id = v_tenant
+     AND gbc.status = 'locked'
+     AND gbc.id IN (
+       SELECT prc.campaign_id
+         FROM purchase_request_campaigns prc
+        WHERE prc.pr_id = p_pr_id
+       UNION
+       SELECT pr.source_campaign_id
+         FROM purchase_requests pr
+        WHERE pr.id = p_pr_id AND pr.source_campaign_id IS NOT NULL
+     );
+
+  -- 實體硬刪：purchase_request_items / purchase_request_campaigns 為 ON DELETE CASCADE
+  BEGIN
+    DELETE FROM purchase_requests
+     WHERE id = p_pr_id AND tenant_id = v_tenant;
+  EXCEPTION WHEN foreign_key_violation THEN
+    RAISE EXCEPTION '請購單 % 仍被其他紀錄參照，無法刪除', p_pr_id;
+  END;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_delete_pr(BIGINT, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_delete_pr(BIGINT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_delete_pr(BIGINT, UUID) IS
+  '請購單刪除（硬刪）：限 draft/submitted/cancelled 且未拆 PO、非補貨來源；'
+  '刪前把該 PR 鎖的 locked 團還原回 closed（訂單維持 confirmed 不動）；'
+  'items/campaigns join 由 ON DELETE CASCADE 連帶刪；同 tenant；owner/admin/hq_manager。';


### PR DESCRIPTION
## 需求

> 請購單（PR）要可以刪除。

建錯結單日 / 多選了團 / 作廢的單想清掉 —— 目前 PR 列表完全沒有刪除或取消入口。

## 難點與設計

PR 建立時有副作用（20260625000000）：**鎖團（closed→locked）+ 自動確認訂單（pending→confirmed）**。若只刪 PR 本體，團會卡在 `locked`（`rpc_create_pr_*` 要求 `closed` 才能再建單），等於把自己鎖死。所以刪除必須把該 PR 鎖的團解鎖回 `closed`。

新增 `rpc_delete_pr(p_pr_id, p_operator)`，對齊 `rpc_delete_campaign` 慣例（守門 + 硬刪 + 殘參照丟可讀訊息）：

**守門**
| 條件 | 行為 |
|---|---|
| status ∈ partially_ordered / fully_ordered | 擋（PO 可能已發供應商）|
| 任一 item.po_item_id 非空 | 擋（雙重保險，不只靠 status）|
| 被 restock_requests.linked_pr_id 參照 | 擋（補貨來源 PR 走補貨流程）|
| role ∉ owner/admin/hq_manager | 擋 |
| not found / 跨 tenant | 擋 |

**可刪狀態**＝draft / submitted / cancelled（你拍板）。

**動作**
- 解鎖團：該 PR 鎖的、目前 `locked` 的 campaign → `closed`（來源＝`purchase_request_campaigns` join ∪ `purchase_requests.source_campaign_id`）。**只動 locked，不誤傷 receiving 等其他狀態。**
- **顧客訂單一律維持 confirmed 不動**（你拍板）—— 不驚動已確認訂單；團解鎖回 closed 後重新建單時 confirmed 訂單照樣納入彙總，無副作用。
- 實體硬刪 `purchase_requests`（items / campaigns join 為 ON DELETE CASCADE 連帶刪）；殘留無 CASCADE 參照 → 捕捉 foreign_key_violation 丟可讀中文。

> `locked→closed` 與「開團單向、reopen 不做」決策不衝突：那條指的是 `closed→open`（重開放下單）；這裡是解除採購鎖定回補單窗口，是刪 PR 的必要還原。group_buy_campaigns 僅有 CHECK 值域、無單向 transition trigger。

**UI**：PR 列表動作欄 +編輯頁動作卡片加「刪除」鈕，只對 draft/submitted/cancelled 且未拆 PO 顯示；確認對話框；刪後 reload / 導回列表。

## 驗證

- SQL 直測 **13/13 PASS**（乾淨 `supabase/postgres` 容器；`scripts/test-pr-delete.sql`）：
  draft/submitted/cancelled 可刪、items CASCADE、已拆 PO（status + po_item_id）各擋、
  解鎖兩團 + 訂單維持 confirmed、只動 locked 不動 receiving、manual 無關聯直接刪、
  source_campaign_id 解鎖、restock 擋、not found 擋、role 擋、殘參照可讀訊息。
- `next build`（含 type-check）✅
- 本機 `supabase db reset` 全鏈在既有 `20260508120000` timestamp 亂序處斷（與本 PR 無關），故用拋棄式切片容器驗證。

## ⚠️ 部署（agent 環境缺 token，未代跑）

```powershell
$env:SUPABASE_ACCESS_TOKEN='sbp_xxx'
node .claude-scripts/apply_via_mgmt_api.cjs supabase/migrations/20260706000000_rpc_delete_pr.sql
```
（純 RPC、無新表/欄位，套用即生效。）

## 自審清單（preview）

- [ ] PR 列表 draft/submitted/cancelled 列出現「刪除」鈕；partially/fully_ordered 不出現
- [ ] 刪 close_date PR → 關聯的 locked 團變回「已結單」、可再次建單；顧客訂單仍 confirmed
- [ ] 已拆 PO 的 PR 嘗試刪 → 中文錯誤、PR 與 PO 不動
- [ ] 編輯頁刪除 → 導回列表

🤖 Generated with [Claude Code](https://claude.com/claude-code)
