### PR TITLE
feat: 推廣頁定價改主打年繳 NT$799

### DIFF
--- a/apps/admin/src/app/welcome/page.tsx
+++ b/apps/admin/src/app/welcome/page.tsx
@@ -93,9 +93,9 @@ const PLANS: { name: string; price: string; note: string; points: string[]; high
   },
   {
     name: "正式方案",
-    price: "NT$999",
-    note: "／月・年繳 NT$799／月",
-    points: ["訂單數量與金額不限", "開團、採購、庫存、財務全模組", "一個總倉＋門市", "Email 支援"],
+    price: "NT$799",
+    note: "／月（年繳）・單月 NT$999",
+    points: ["年繳省 NT$2,400", "訂單數量與金額不限", "開團、採購、庫存、財務全模組", "一個總倉＋門市・Email 支援"],
     highlight: true,
   },
   {


### PR DESCRIPTION
## 改動

推廣頁 `/welcome` 定價區「正式方案」原本把 **NT$999（單月）** 放大主打、799 縮在備註。改成倒過來，主打比較划算的 **NT$799（年繳月費）**：

- 主價：`NT$799 ／月（年繳）`，單月 NT$999 退到備註
- 首點加「**年繳省 NT$2,400**」強化年繳划算感

純文案／定價呈現調整，無邏輯變動。

https://claude.ai/code/session_01Q8eHsgQDL8c3QY17jb2vzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8eHsgQDL8c3QY17jb2vzR)_