### PR TITLE
feat: 訂單品項刪除（限待確認單，刪到最後一項自動取消整單）

### DIFF
--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -505,6 +505,36 @@ export function OrderDetail({
     setReloadTick((n) => n + 1);
   }
 
+  // 刪除 pending 訂單裡的單一品項（rpc_delete_order_item：軟刪 status->cancelled）。
+  // 權限/狀態閘與「改數量」一致（canEditQty）；刪到最後一項會自動取消整單。
+  async function deleteItem(it: ItemRow) {
+    if (!head) return;
+    const label = it.sku
+      ? `${it.sku.product_name ?? it.sku.sku_code}${it.sku.variant_name ? ` / ${it.sku.variant_name}` : ""}`
+      : `#${it.id}`;
+    const onlyActive = (items ?? []).filter((x) => !["cancelled", "expired"].includes(x.status)).length <= 1;
+    const reason = prompt(
+      `刪除品項：${label}（${head.order_no}）` +
+        (onlyActive ? "\n\n⚠️ 這是訂單最後一個品項，刪除後整單會一併取消。" : "") +
+        "\n請輸入刪除原因：",
+    );
+    if (reason === null) return;
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id ?? null;
+    if (!operator) { alert("尚未登入"); return; }
+    const { data, error: rpcErr } = await sb.rpc("rpc_delete_order_item", {
+      p_order_id: head.id,
+      p_item_id: it.id,
+      p_operator: operator,
+      p_reason: reason.trim() === "" ? null : reason.trim(),
+    });
+    if (rpcErr) { alert(`刪除失敗：${translateRpcError(rpcErr)}`); return; }
+    const cancelled = !!(data as { order_cancelled?: boolean } | null)?.order_cancelled;
+    alert(cancelled ? "已刪除品項，整單已一併取消" : "已刪除品項");
+    setReloadTick((n) => n + 1);
+  }
+
   async function aidReturn() {
     if (!head) return;
     const walletPaid = Number(head.wallet_paid_amount ?? 0);
@@ -854,11 +884,12 @@ export function OrderDetail({
                 <th className="px-3 py-2 text-left font-medium text-zinc-500">備註</th>
                 <th className="px-3 py-2 text-left font-medium text-zinc-500">第一次加</th>
                 <th className="px-3 py-2 text-left font-medium text-zinc-500">最後更新</th>
+                {canEditQty && <th className="px-3 py-2 text-right font-medium text-zinc-500">操作</th>}
               </tr>
             </thead>
             <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
               {items.length === 0 ? (
-                <tr><td colSpan={9} className="p-4 text-center text-zinc-500">尚無明細</td></tr>
+                <tr><td colSpan={canEditQty ? 10 : 9} className="p-4 text-center text-zinc-500">尚無明細</td></tr>
               ) : items.map((it) => {
                 const eff = itemEffective(it);
                 const sub = computeLineSubtotal(Number(eff.qty), eff.unit_price, eff.discount);
@@ -947,6 +978,19 @@ export function OrderDetail({
                       {fmtDt(it.updated_at)}<br />
                       <span className="text-[10px]">by {staffLabel(it.updated_by, staffNames)}</span>
                     </td>
+                    {canEditQty && (
+                      <td className="px-3 py-2 text-right">
+                        {!["cancelled", "expired"].includes(it.status) && !isPicked ? (
+                          <SpinButton
+                            onClick={() => deleteItem(it)}
+                            title="刪除此品項（待確認訂單，刪到最後一項會自動取消整單）"
+                            className="rounded-md border border-red-300 px-2 py-1 text-[11px] font-medium text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
+                          >
+                            刪除
+                          </SpinButton>
+                        ) : null}
+                      </td>
+                    )}
                   </tr>
                 );
               })}

--- a/supabase/migrations/20260707000040_rpc_delete_order_item.sql
+++ b/supabase/migrations/20260707000040_rpc_delete_order_item.sql
@@ -1,0 +1,130 @@
+-- ============================================================
+-- rpc_delete_order_item — 店家/HQ 刪除 pending 訂單裡的單一品項
+--
+-- 背景：
+--   店家可改顧客訂單品項數量（rpc_update_order_item_qty），但無法「刪掉
+--   某個品項」。schema CHECK qty > 0 讓「改成 0」也做不到，只能整單取消。
+--   實際需求是顧客改單想拿掉其中一項，本 RPC 補上單品項刪除。
+--
+-- 設計（刻意對齊既有慣例，不另開新 status 值）：
+--   - 軟刪：品項 status -> 'cancelled'（與「斷貨連動」同一機制，所有既有
+--     view / RPC 的 `status NOT IN ('cancelled','expired')` 過濾自動正確），
+--     stockout_at 維持 NULL 代表「人工刪除」而非斷貨，UI 顯示「已取消」。
+--   - 狀態閘：僅 pending。與 rpc_update_order_item_qty 同閘
+--     （confirmed 之後訂單被 PR 鎖定，數量/品項都不該再動）。
+--   - 權限：沿用 _check_order_edit_qty_perm
+--     （HQ tier 全部 / 店長限 app_metadata.stores 含訂單 pickup_store；含 FOR UPDATE）。
+--   - 稽核：寫 customer_order_audit_log field='status'
+--     （該值由 20260625000000 擴充 CHECK 後合法）。
+--   - 刪到最後一個 active 品項 → 自動取消整單，條件對齊斷貨連動
+--     （未付款 + 未用儲值金才自動取消；有金流的留人工退款處理）。
+--
+-- 基底依賴：
+--   - _check_order_edit_qty_perm：20260629000010_rpc_order_qty_store_manager.sql
+--   - customer_order_items.stockout_at：20260702020000_stockout_propagation.sql
+--   - audit_log field CHECK 含 'status'：20260625000000_pr_create_lock_campaign_and_orders.sql
+--
+-- Rollback：DROP FUNCTION public.rpc_delete_order_item(BIGINT, BIGINT, UUID, TEXT);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_delete_order_item(
+  p_order_id BIGINT,
+  p_item_id  BIGINT,
+  p_operator UUID,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order           customer_orders%ROWTYPE;
+  v_old_status      TEXT;
+  v_remaining       INTEGER;
+  v_order_cancelled BOOLEAN := FALSE;
+BEGIN
+  -- 1. 權限 + 鎖訂單（HQ 全部 / 店長限自家 pickup_store）
+  v_order := _check_order_edit_qty_perm(p_order_id);
+
+  -- 2. 狀態閘：僅 pending（confirmed 後被 PR 鎖定，與改數量同閘）
+  IF v_order.status <> 'pending' THEN
+    RAISE EXCEPTION '訂單狀態為 %,僅 待確認 訂單可刪除品項', v_order.status;
+  END IF;
+
+  -- 3. 取品項並上鎖
+  SELECT status INTO v_old_status
+    FROM customer_order_items
+   WHERE id = p_item_id AND order_id = p_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'item % not in order %', p_item_id, p_order_id;
+  END IF;
+
+  -- 4. 已取消/已過期視為已刪，no-op 短路
+  IF v_old_status IN ('cancelled', 'expired') THEN
+    RETURN jsonb_build_object(
+      'item_id', p_item_id, 'already_removed', TRUE, 'order_cancelled', FALSE
+    );
+  END IF;
+
+  -- 5. 軟刪：標記 cancelled（stockout_at 保持 NULL = 人工刪除）
+  UPDATE customer_order_items
+     SET status     = 'cancelled',
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_item_id;
+
+  -- 6. 稽核
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'item', p_item_id, 'status',
+     to_jsonb(v_old_status), to_jsonb('cancelled'::TEXT), p_reason, p_operator);
+
+  -- 7. 刪到最後一個 active 品項 → 自動取消整單
+  --    條件對齊斷貨連動：未付款 + 未用儲值金才自動取消
+  SELECT COUNT(*) INTO v_remaining
+    FROM customer_order_items
+   WHERE order_id = p_order_id
+     AND status NOT IN ('cancelled', 'expired');
+
+  IF v_remaining = 0
+     AND COALESCE(v_order.payment_status, 'unpaid') <> 'paid'
+     AND COALESCE(v_order.wallet_paid_amount, 0) = 0
+  THEN
+    UPDATE customer_orders
+       SET status       = 'cancelled',
+           cancelled_at = NOW(),
+           updated_by   = p_operator,
+           updated_at   = NOW()
+     WHERE id = p_order_id
+       AND status = 'pending';
+    v_order_cancelled := TRUE;
+
+    INSERT INTO customer_order_audit_log
+      (tenant_id, order_id, entity_type, entity_id, field,
+       before_value, after_value, edit_reason, operator_id)
+    VALUES
+      (v_order.tenant_id, p_order_id, 'order', p_order_id, 'status',
+       to_jsonb('pending'::TEXT), to_jsonb('cancelled'::TEXT),
+       COALESCE(NULLIF(BTRIM(p_reason), '') || ' / ', '') || '刪除最後一個品項自動取消整單',
+       p_operator);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'item_id',         p_item_id,
+    'already_removed', FALSE,
+    'order_cancelled', v_order_cancelled,
+    'remaining_items', v_remaining
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_delete_order_item(BIGINT, BIGINT, UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_delete_order_item IS
+  '刪除 pending 訂單的單一品項（軟刪：status->cancelled，stockout_at 留 NULL 代表人工刪除）。'
+  'HQ tier 全部 / 店長限 app_metadata.stores 含訂單 pickup_store；訂單須為 pending；'
+  '寫 customer_order_audit_log；刪到最後一個 active 品項且未付款/未用儲值金時自動取消整單。';


### PR DESCRIPTION
店家／HQ 可刪除 pending 訂單裡的單一品項，補上原本只能整單取消的缺口
（顧客改單想拿掉其中一項、或想把數量改成 0 的需求）。

- 後端 rpc_delete_order_item：軟刪 status->cancelled（沿用斷貨連動同一慣例，
  既有 view/RPC 的 status NOT IN ('cancelled','expired') 過濾自動正確；
  stockout_at 留 NULL 代表人工刪除而非斷貨）。
  狀態閘與 rpc_update_order_item_qty 一致（僅 pending）；權限沿用
  _check_order_edit_qty_perm（HQ 全部／店長限自家 pickup_store）；寫稽核 log；
  刪到最後一個 active 品項且未付款/未用儲值金時自動取消整單。
- 前端 OrderDetail：品項列加「刪除」鈕，僅 canEditQty（pending + 有權限）顯示，
  已取消/已過期/已取貨不顯示；刪最後一項時提示會一併取消整單。