### PR TITLE
feat: 開團「延長結單時間」（rpc_extend_campaign_deadline + 按鈕）

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -145,6 +145,14 @@ function fmtDateTime(iso: string | null): string {
   return `${yyyy}/${mm}/${dd} ${hh}:${mi}`;
 }
 
+// ISO → <input type="datetime-local"> 需要的本地時間字串（YYYY-MM-DDTHH:mm）
+function toDatetimeLocal(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 export default function CampaignsListPage() {
   const role = useRole();
   const showAdminActions = isAdmin(role);
@@ -181,6 +189,11 @@ export default function CampaignsListPage() {
   const [endAtOpen, setEndAtOpen] = useState(false);
   const [bulkEndAt, setBulkEndAt] = useState("");
   const [endAtErr, setEndAtErr] = useState<string | null>(null);
+
+  // 單筆「延長結單」（open 限定，只能往後延）
+  const [extendTarget, setExtendTarget] = useState<{ id: number; name: string; endAt: string | null } | null>(null);
+  const [extendVal, setExtendVal] = useState("");
+  const [extendErr, setExtendErr] = useState<string | null>(null);
 
   const [view, setView] = useState<View>(() => {
     if (typeof window === "undefined") return "list";
@@ -250,6 +263,25 @@ export default function CampaignsListPage() {
       }
     } catch (e) {
       setEndAtErr(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function extendDeadline() {
+    if (!extendTarget) return;
+    setExtendErr(null);
+    if (!extendVal) { setExtendErr("請選擇新的收單時間"); return; }
+    const iso = new Date(extendVal).toISOString();
+    try {
+      const { error: rpcErr } = await getSupabase().rpc("rpc_extend_campaign_deadline", {
+        p_campaign_id: extendTarget.id,
+        p_new_end_at: iso,
+      });
+      if (rpcErr) throw rpcErr;
+      setExtendTarget(null);
+      setExtendVal("");
+      setReloadTick((t) => t + 1);
+    } catch (e) {
+      setExtendErr(e instanceof Error ? e.message : String(e));
     }
   }
 
@@ -628,6 +660,18 @@ export default function CampaignsListPage() {
           className="text-xs text-amber-600 hover:underline disabled:opacity-50 dark:text-amber-400"
         >
           {closingId === r.id ? "結單中…" : "結單"}
+        </SpinButton>
+      )}
+      {showAdminActions && r.status === "open" && (
+        <SpinButton
+          onClick={() => {
+            setExtendTarget({ id: r.id, name: r.name, endAt: r.end_at });
+            setExtendVal(toDatetimeLocal(r.end_at));
+            setExtendErr(null);
+          }}
+          className="text-xs text-teal-600 hover:underline dark:text-teal-400"
+        >
+          延長結單
         </SpinButton>
       )}
       {showAdminActions && (["open", "closed", "locked", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
@@ -1051,6 +1095,47 @@ export default function CampaignsListPage() {
                 className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900"
               >
                 確定套用
+              </SpinButton>
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      <Modal
+        open={!!extendTarget}
+        onClose={() => setExtendTarget(null)}
+        title={extendTarget ? `延長結單時間｜${extendTarget.name}` : ""}
+        maxWidth="max-w-md"
+      >
+        {extendTarget && (
+          <div className="space-y-4">
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+              目前收單時間：<span className="font-semibold">{fmtDateTime(extendTarget.endAt)}</span>。
+              新時間必須晚於目前、且在未來；僅「開團中」可延長。
+            </p>
+            <label className="block text-sm">
+              <span className="text-zinc-600 dark:text-zinc-400">新收單時間</span>
+              <input
+                type="datetime-local"
+                value={extendVal}
+                onChange={(e) => setExtendVal(e.target.value)}
+                className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                aria-label="新收單時間"
+              />
+            </label>
+            {extendErr && <p className="text-xs text-rose-600">{extendErr}</p>}
+            <div className="flex justify-end gap-2 pt-2">
+              <SpinButton
+                onClick={() => setExtendTarget(null)}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              >
+                取消
+              </SpinButton>
+              <SpinButton
+                onClick={extendDeadline}
+                className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900"
+              >
+                確定延長
               </SpinButton>
             </div>
           </div>

--- a/docs/TEST-extend-campaign-deadline.md
+++ b/docs/TEST-extend-campaign-deadline.md
@@ -1,0 +1,91 @@
+# extend-campaign-deadline 測試項目 — 延長開團結單時間 RPC
+
+**對應 migration:** `supabase/migrations/20260707000050_rpc_extend_campaign_deadline.sql`
+**對應 UI 變更:** `apps/admin/src/app/(protected)/campaigns/page.tsx`（「延長結單」按鈕 + datetime modal）
+
+---
+
+## 1. Schema / Migration 層
+
+### 1.1 RPC signature + grants
+- [ ] `rpc_extend_campaign_deadline(BIGINT, TIMESTAMPTZ)` 存在、`SECURITY DEFINER`、`RETURNS timestamptz`
+  ```sql
+  SELECT prosecdef, pg_get_function_result(oid)
+    FROM pg_proc WHERE proname = 'rpc_extend_campaign_deadline';
+  ```
+- [ ] `PUBLIC` 已 REVOKE、`authenticated` 有 EXECUTE
+  ```sql
+  SELECT grantee, privilege_type FROM information_schema.role_routine_grants
+   WHERE routine_name = 'rpc_extend_campaign_deadline';
+  ```
+- [ ] 無新增 table / enum / index / column（僅 function）
+
+---
+
+## 2. RPC 行為（SQL 直測）
+
+> 每個情境＝交易內 `set_config('request.jwt.claims', …, true)` 切身份 + seed 一筆 campaign，呼叫 RPC，觀察結果，結尾 `ROLLBACK`。
+
+### 2.1 happy path — open 團往後延
+**情境：** owner 身份，campaign status='open'、end_at = 明天；呼叫 RPC 把 end_at 改成 後天。
+**預期：** 回傳新 end_at；該列 `end_at` = 後天、`updated_by` = 呼叫者 uid、`updated_at` 被刷新。
+
+### 2.2 reject — 非 owner/admin
+**情境：** role = 'staff'（或缺 app_metadata.role），open 團，新時間合法。
+**預期：** RAISE `權限不足`（SQLSTATE 42501）；end_at 不變。
+
+### 2.3 reject — 活動不存在 / 跨 tenant
+**情境：** owner，但 p_campaign_id 屬於別的 tenant（或不存在）。
+**預期：** RAISE `找不到開團或不在目前 tenant`；無任何列被改。
+
+### 2.4 reject — status 非 open
+**情境：** owner，campaign status='closed'（再測 'draft' / 'cancelled' 各一）。
+**預期：** RAISE `僅「開團中」可延長`；end_at 不變（確認 closed 後快照不被動到）。
+
+### 2.5 reject — 新時間在過去
+**情境：** owner，open 團，p_new_end_at = 昨天。
+**預期：** RAISE `新收單時間必須在未來`；end_at 不變。
+
+### 2.6 reject — 新時間不晚於目前 end_at
+**情境：** owner，open 團 end_at = 後天，p_new_end_at = 明天（早於目前但仍在未來）。
+**預期：** RAISE `新收單時間必須晚於目前收單時間`；end_at 不變。
+
+### 2.7 reject — p_new_end_at 為 NULL
+**情境：** owner，open 團，p_new_end_at = NULL。
+**預期：** RAISE `p_new_end_at is required`。
+
+### 2.8 邊界 — 只動到目標那一筆
+**情境：** 同 tenant 另有一筆 open 團；對第一筆呼叫 RPC。
+**預期：** 第二筆 end_at / updated_at 完全不變（無誤傷）。
+
+---
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 按鈕可見性
+- [ ] status='open' 且具 admin 權限 → row 操作區出現「延長結單」（teal 色）
+- [ ] status≠open（draft/closed/…）→ 不出現「延長結單」
+- [ ] 非 admin 角色 → 不出現（與其他 admin 操作鈕一致）
+
+### 3.2 modal 互動
+- [ ] 點「延長結單」開 modal，標題帶活動名稱，datetime 預填目前 end_at
+- [ ] 未選時間按「確定延長」→ 顯示「請選擇新的收單時間」、不送出
+- [ ] 選一個晚於目前的時間 → 送出成功、modal 關閉、列表 end_at 更新
+- [ ] 後端 reject（如選過去時間）→ 錯誤訊息顯示在 modal 內、modal 不關
+
+### 3.3 無 console error
+- [ ] 開關 modal、送出全程 console 無 error
+
+---
+
+## 4. Regression
+- [ ] campaigns 列表頁正常載入、分頁/篩選不受影響
+- [ ] 既有 bulk「批次設定收單時間」modal 仍正常（共用 `fmtDateTime` / `Modal` / `SpinButton`）
+- [ ] 結單（rpc_close_campaign）、結算、刪除等同列操作鈕不受影響
+- [ ] `rpc_bulk_set_campaign_end_at` 行為不變（本 RPC 為新增、未動既有 function）
+
+---
+
+## 5. 驗收門檻
+
+全部 §1–§4 勾完、**無 console error**、**RPC 已部署 prod 且 anon REST probe 確認存在**、**build + type-check 過** 才可標 done。

--- a/scripts/test-extend-campaign-deadline.sql
+++ b/scripts/test-extend-campaign-deadline.sql
@@ -1,0 +1,218 @@
+-- 測試 rpc_extend_campaign_deadline（延長開團結單時間）
+-- 跑法（拋棄式 postgres 容器，~20s）：
+--   {  prelude(role/stub/minimal table) ; cat migration ; cat this } | docker exec -i <pg> psql ...
+-- 本檔假設 prelude 已建 authenticated role + auth.jwt/auth.uid/_current_tenant_id stub
+-- + 精簡 group_buy_campaigns，且受測 migration 已載入 rpc_extend_campaign_deadline。
+-- 身份：owner uid=000…001、tenantA=111…、tenantB=222…。
+
+CREATE TEMP TABLE _results(name text, pass boolean, detail text);
+
+-- ---- §1 Schema / grants -------------------------------------------------
+DO $$
+DECLARE v_secdef BOOLEAN; v_ret TEXT;
+BEGIN
+  SELECT prosecdef, pg_get_function_result(oid) INTO v_secdef, v_ret
+    FROM pg_proc WHERE proname = 'rpc_extend_campaign_deadline';
+  INSERT INTO _results VALUES ('1.1 SECURITY DEFINER + returns timestamptz',
+    (v_secdef IS TRUE AND lower(v_ret) LIKE '%timestamp%'),
+    format('secdef=%s ret=%s', v_secdef, v_ret));
+END $$;
+
+DO $$
+DECLARE v_auth BOOLEAN;
+BEGIN
+  v_auth := has_function_privilege('authenticated',
+    'public.rpc_extend_campaign_deadline(bigint, timestamp with time zone)', 'EXECUTE');
+  INSERT INTO _results VALUES ('1.2 authenticated has EXECUTE', v_auth,
+    format('authenticated_execute=%s', v_auth));
+END $$;
+
+-- ---- §2 RPC behavior ----------------------------------------------------
+
+-- 2.1 happy path: owner, open 團往後延
+DO $$
+DECLARE v_camp BIGINT; v_ret TIMESTAMPTZ; v_end TIMESTAMPTZ; v_by UUID;
+BEGIN
+  DELETE FROM public.group_buy_campaigns;
+  PERFORM set_config('request.jwt.claims',
+    '{"sub":"00000000-0000-0000-0000-000000000001","app_metadata":{"role":"owner","tenant_id":"11111111-1111-1111-1111-111111111111"}}', true);
+  INSERT INTO public.group_buy_campaigns(tenant_id, name, status, end_at)
+    VALUES ('11111111-1111-1111-1111-111111111111', 't', 'open', NOW() + INTERVAL '1 day')
+    RETURNING id INTO v_camp;
+  v_ret := public.rpc_extend_campaign_deadline(v_camp, NOW() + INTERVAL '2 day');
+  SELECT end_at, updated_by INTO v_end, v_by FROM public.group_buy_campaigns WHERE id = v_camp;
+  INSERT INTO _results VALUES ('2.1 happy path (owner, open 往後延)',
+    (v_end = NOW() + INTERVAL '2 day'
+     AND v_by = '00000000-0000-0000-0000-000000000001'::uuid
+     AND v_ret = NOW() + INTERVAL '2 day'),
+    format('end_at=%s updated_by=%s', v_end, v_by));
+END $$;
+
+-- 2.2 admin 同樣可用
+DO $$
+DECLARE v_camp BIGINT; v_end TIMESTAMPTZ;
+BEGIN
+  DELETE FROM public.group_buy_campaigns;
+  PERFORM set_config('request.jwt.claims',
+    '{"sub":"00000000-0000-0000-0000-000000000001","app_metadata":{"role":"admin","tenant_id":"11111111-1111-1111-1111-111111111111"}}', true);
+  INSERT INTO public.group_buy_campaigns(tenant_id, name, status, end_at)
+    VALUES ('11111111-1111-1111-1111-111111111111', 't', 'open', NOW() + INTERVAL '1 day')
+    RETURNING id INTO v_camp;
+  PERFORM public.rpc_extend_campaign_deadline(v_camp, NOW() + INTERVAL '3 day');
+  SELECT end_at INTO v_end FROM public.group_buy_campaigns WHERE id = v_camp;
+  INSERT INTO _results VALUES ('2.2 admin 也可延長',
+    (v_end = NOW() + INTERVAL '3 day'), format('end_at=%s', v_end));
+END $$;
+
+-- 2.3 reject 非 owner/admin
+DO $$
+DECLARE v_camp BIGINT; v_before TIMESTAMPTZ; v_after TIMESTAMPTZ; v_err TEXT := NULL;
+BEGIN
+  DELETE FROM public.group_buy_campaigns;
+  PERFORM set_config('request.jwt.claims',
+    '{"sub":"00000000-0000-0000-0000-000000000001","app_metadata":{"role":"staff","tenant_id":"11111111-1111-1111-1111-111111111111"}}', true);
+  INSERT INTO public.group_buy_campaigns(tenant_id, name, status, end_at)
+    VALUES ('11111111-1111-1111-1111-111111111111', 't', 'open', NOW() + INTERVAL '1 day')
+    RETURNING id INTO v_camp;
+  v_before := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_camp);
+  BEGIN
+    PERFORM public.rpc_extend_campaign_deadline(v_camp, NOW() + INTERVAL '2 day');
+  EXCEPTION WHEN OTHERS THEN v_err := SQLERRM;
+  END;
+  v_after := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_camp);
+  INSERT INTO _results VALUES ('2.3 reject 非 owner/admin',
+    (v_err LIKE '%權限不足%' AND v_after = v_before),
+    format('err=%s unchanged=%s', v_err, v_after = v_before));
+END $$;
+
+-- 2.4 reject 跨 tenant / 不存在
+DO $$
+DECLARE v_camp BIGINT; v_before TIMESTAMPTZ; v_after TIMESTAMPTZ; v_err TEXT := NULL;
+BEGIN
+  DELETE FROM public.group_buy_campaigns;
+  -- 活動屬 tenantA，但呼叫者是 tenantB 的 owner → _current_tenant_id 不符
+  INSERT INTO public.group_buy_campaigns(tenant_id, name, status, end_at)
+    VALUES ('11111111-1111-1111-1111-111111111111', 't', 'open', NOW() + INTERVAL '1 day')
+    RETURNING id INTO v_camp;
+  v_before := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_camp);
+  PERFORM set_config('request.jwt.claims',
+    '{"sub":"00000000-0000-0000-0000-000000000001","app_metadata":{"role":"owner","tenant_id":"22222222-2222-2222-2222-222222222222"}}', true);
+  BEGIN
+    PERFORM public.rpc_extend_campaign_deadline(v_camp, NOW() + INTERVAL '2 day');
+  EXCEPTION WHEN OTHERS THEN v_err := SQLERRM;
+  END;
+  v_after := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_camp);
+  INSERT INTO _results VALUES ('2.4 reject 跨 tenant / 不存在',
+    (v_err LIKE '%找不到開團%' AND v_after = v_before),
+    format('err=%s unchanged=%s', v_err, v_after = v_before));
+END $$;
+
+-- 2.5 reject status≠open（draft / closed / cancelled）
+DO $$
+DECLARE s TEXT; v_camp BIGINT; v_before TIMESTAMPTZ; v_after TIMESTAMPTZ; v_ok BOOLEAN := true; v_detail TEXT := '';
+BEGIN
+  FOREACH s IN ARRAY ARRAY['draft','closed','cancelled'] LOOP
+    DELETE FROM public.group_buy_campaigns;
+    PERFORM set_config('request.jwt.claims',
+      '{"sub":"00000000-0000-0000-0000-000000000001","app_metadata":{"role":"owner","tenant_id":"11111111-1111-1111-1111-111111111111"}}', true);
+    INSERT INTO public.group_buy_campaigns(tenant_id, name, status, end_at)
+      VALUES ('11111111-1111-1111-1111-111111111111', 't', s, NOW() + INTERVAL '1 day')
+      RETURNING id INTO v_camp;
+    v_before := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_camp);
+    BEGIN
+      PERFORM public.rpc_extend_campaign_deadline(v_camp, NOW() + INTERVAL '2 day');
+      v_ok := false; v_detail := v_detail || s || ':no-raise ';
+    EXCEPTION WHEN OTHERS THEN
+      IF SQLERRM NOT LIKE '%開團中%' THEN v_ok := false; v_detail := v_detail || s || ':' || SQLERRM || ' '; END IF;
+    END;
+    v_after := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_camp);
+    IF v_after <> v_before THEN v_ok := false; v_detail := v_detail || s || ':mutated '; END IF;
+  END LOOP;
+  INSERT INTO _results VALUES ('2.5 reject status≠open (draft/closed/cancelled)',
+    v_ok, COALESCE(NULLIF(v_detail, ''), 'all rejected & unchanged'));
+END $$;
+
+-- 2.6 reject 新時間在過去
+DO $$
+DECLARE v_camp BIGINT; v_before TIMESTAMPTZ; v_after TIMESTAMPTZ; v_err TEXT := NULL;
+BEGIN
+  DELETE FROM public.group_buy_campaigns;
+  PERFORM set_config('request.jwt.claims',
+    '{"sub":"00000000-0000-0000-0000-000000000001","app_metadata":{"role":"owner","tenant_id":"11111111-1111-1111-1111-111111111111"}}', true);
+  INSERT INTO public.group_buy_campaigns(tenant_id, name, status, end_at)
+    VALUES ('11111111-1111-1111-1111-111111111111', 't', 'open', NOW() + INTERVAL '1 day')
+    RETURNING id INTO v_camp;
+  v_before := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_camp);
+  BEGIN
+    PERFORM public.rpc_extend_campaign_deadline(v_camp, NOW() - INTERVAL '1 day');
+  EXCEPTION WHEN OTHERS THEN v_err := SQLERRM;
+  END;
+  v_after := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_camp);
+  INSERT INTO _results VALUES ('2.6 reject 新時間在過去',
+    (v_err LIKE '%必須在未來%' AND v_after = v_before),
+    format('err=%s', v_err));
+END $$;
+
+-- 2.7 reject 新時間不晚於目前 end_at
+DO $$
+DECLARE v_camp BIGINT; v_before TIMESTAMPTZ; v_after TIMESTAMPTZ; v_err TEXT := NULL;
+BEGIN
+  DELETE FROM public.group_buy_campaigns;
+  PERFORM set_config('request.jwt.claims',
+    '{"sub":"00000000-0000-0000-0000-000000000001","app_metadata":{"role":"owner","tenant_id":"11111111-1111-1111-1111-111111111111"}}', true);
+  INSERT INTO public.group_buy_campaigns(tenant_id, name, status, end_at)
+    VALUES ('11111111-1111-1111-1111-111111111111', 't', 'open', NOW() + INTERVAL '2 day')
+    RETURNING id INTO v_camp;
+  v_before := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_camp);
+  BEGIN
+    PERFORM public.rpc_extend_campaign_deadline(v_camp, NOW() + INTERVAL '1 day');
+  EXCEPTION WHEN OTHERS THEN v_err := SQLERRM;
+  END;
+  v_after := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_camp);
+  INSERT INTO _results VALUES ('2.7 reject 不晚於目前 end_at',
+    (v_err LIKE '%晚於目前%' AND v_after = v_before),
+    format('err=%s', v_err));
+END $$;
+
+-- 2.8 reject p_new_end_at = NULL
+DO $$
+DECLARE v_camp BIGINT; v_err TEXT := NULL;
+BEGIN
+  DELETE FROM public.group_buy_campaigns;
+  PERFORM set_config('request.jwt.claims',
+    '{"sub":"00000000-0000-0000-0000-000000000001","app_metadata":{"role":"owner","tenant_id":"11111111-1111-1111-1111-111111111111"}}', true);
+  INSERT INTO public.group_buy_campaigns(tenant_id, name, status, end_at)
+    VALUES ('11111111-1111-1111-1111-111111111111', 't', 'open', NOW() + INTERVAL '1 day')
+    RETURNING id INTO v_camp;
+  BEGIN
+    PERFORM public.rpc_extend_campaign_deadline(v_camp, NULL);
+  EXCEPTION WHEN OTHERS THEN v_err := SQLERRM;
+  END;
+  INSERT INTO _results VALUES ('2.8 reject NULL 新時間',
+    (v_err LIKE '%required%'), format('err=%s', v_err));
+END $$;
+
+-- 2.9 isolation：只動到目標那一筆
+DO $$
+DECLARE v_a BIGINT; v_b BIGINT; v_b_before TIMESTAMPTZ; v_b_after TIMESTAMPTZ;
+BEGIN
+  DELETE FROM public.group_buy_campaigns;
+  PERFORM set_config('request.jwt.claims',
+    '{"sub":"00000000-0000-0000-0000-000000000001","app_metadata":{"role":"owner","tenant_id":"11111111-1111-1111-1111-111111111111"}}', true);
+  INSERT INTO public.group_buy_campaigns(tenant_id, name, status, end_at)
+    VALUES ('11111111-1111-1111-1111-111111111111', 'A', 'open', NOW() + INTERVAL '1 day') RETURNING id INTO v_a;
+  INSERT INTO public.group_buy_campaigns(tenant_id, name, status, end_at)
+    VALUES ('11111111-1111-1111-1111-111111111111', 'B', 'open', NOW() + INTERVAL '1 day') RETURNING id INTO v_b;
+  v_b_before := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_b);
+  PERFORM public.rpc_extend_campaign_deadline(v_a, NOW() + INTERVAL '5 day');
+  v_b_after := (SELECT end_at FROM public.group_buy_campaigns WHERE id = v_b);
+  INSERT INTO _results VALUES ('2.9 isolation：只動目標筆',
+    (v_b_after = v_b_before), format('B unchanged=%s', v_b_after = v_b_before));
+END $$;
+
+-- ---- 報表 ---------------------------------------------------------------
+SELECT name, CASE WHEN pass THEN 'PASS' ELSE 'FAIL' END AS result, detail
+  FROM _results ORDER BY name;
+SELECT count(*) FILTER (WHERE pass) AS passed, count(*) AS total,
+       CASE WHEN count(*) FILTER (WHERE pass) = count(*) THEN '✅ ALL GREEN' ELSE '❌ HAS FAILURES' END AS verdict
+  FROM _results;

--- a/supabase/migrations/20260707000050_rpc_extend_campaign_deadline.sql
+++ b/supabase/migrations/20260707000050_rpc_extend_campaign_deadline.sql
@@ -1,0 +1,76 @@
+-- ============================================================
+-- 2026-07-07: rpc_extend_campaign_deadline
+--   單筆延長「開團中」活動的收單時間 end_at（campaigns 頁「延長結單」按鈕）。
+--   基底 = 20260618000040_rpc_bulk_set_campaign_end_at（最新動到 end_at 的 RPC）骨架，
+--   收緊為：單筆 / 限 status='open' / 只能往後延 / 僅 owner|admin。
+--   守門：
+--     1) 角色：僅 owner / admin。讀 app_metadata.role —— 頂層 auth.jwt()->>'role'
+--        在這套一律是 'authenticated'，讀錯路徑會連 owner 都被擋（踩過雷）。
+--     2) 同 tenant（_current_tenant_id）且活動存在。
+--     3) 僅 status='open' 可延長；closed 之後 end_at 已被結單流程（rpc_close_campaign
+--        以 end_at 當收單日決定 PR 連動）快照，不可再改。
+--     4) 新時間必須在未來、且嚴格晚於目前 end_at（只能延後、不能提前）。
+--   self-contained：僅依賴 group_buy_campaigns + _current_tenant_id() + auth.uid()/auth.jwt()。
+--   回傳：更新後的 end_at。
+--   rollback：DROP FUNCTION public.rpc_extend_campaign_deadline(BIGINT, TIMESTAMPTZ);
+--            （本檔為首次建立，無前一版本）
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.rpc_extend_campaign_deadline(
+  p_campaign_id BIGINT,
+  p_new_end_at  TIMESTAMPTZ
+) RETURNS TIMESTAMPTZ
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant  UUID := public._current_tenant_id();
+  v_role    TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_status  TEXT;
+  v_cur_end TIMESTAMPTZ;
+BEGIN
+  -- (1) 權限：僅 owner / admin
+  IF v_role NOT IN ('owner', 'admin') THEN
+    RAISE EXCEPTION '權限不足：僅 owner/admin 可延長結單時間'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_new_end_at IS NULL THEN
+    RAISE EXCEPTION 'p_new_end_at is required';
+  END IF;
+
+  -- (2) 同 tenant 取目標活動
+  SELECT status, end_at INTO v_status, v_cur_end
+    FROM group_buy_campaigns
+   WHERE id = p_campaign_id AND tenant_id = v_tenant;
+
+  IF v_status IS NULL THEN
+    RAISE EXCEPTION '找不到開團或不在目前 tenant：%', p_campaign_id;
+  END IF;
+
+  -- (3) 僅開團中可延長
+  IF v_status <> 'open' THEN
+    RAISE EXCEPTION '僅「開團中」可延長結單時間（目前狀態：%）', v_status;
+  END IF;
+
+  -- (4) 只能往後延：新時間需在未來且嚴格晚於目前 end_at
+  IF p_new_end_at <= NOW() THEN
+    RAISE EXCEPTION '新收單時間必須在未來';
+  END IF;
+  IF v_cur_end IS NOT NULL AND p_new_end_at <= v_cur_end THEN
+    RAISE EXCEPTION '新收單時間必須晚於目前收單時間（目前：%）', v_cur_end;
+  END IF;
+
+  UPDATE group_buy_campaigns
+     SET end_at     = p_new_end_at,
+         updated_by = auth.uid(),
+         updated_at = NOW()
+   WHERE id = p_campaign_id AND tenant_id = v_tenant;
+
+  RETURN p_new_end_at;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_extend_campaign_deadline(BIGINT, TIMESTAMPTZ) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_extend_campaign_deadline(BIGINT, TIMESTAMPTZ) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_extend_campaign_deadline(BIGINT, TIMESTAMPTZ) IS
+  '單筆延長開團收單時間 end_at。僅 owner/admin、同 tenant、status=open、只能往後延。回傳更新後的 end_at。';


### PR DESCRIPTION
## 摘要

新增「單筆延長開團收單時間」功能。campaigns 列表頁的 open 團多一個「延長結單」按鈕，呼叫新 RPC 把該團 `end_at` 往後延。

## 變更

- **migration `20260707000050_rpc_extend_campaign_deadline.sql`**
  `rpc_extend_campaign_deadline(p_campaign_id BIGINT, p_new_end_at TIMESTAMPTZ)`，`SECURITY DEFINER`，回傳更新後 `end_at`。基底＝最新的 `rpc_bulk_set_campaign_end_at`（`20260618000040`）骨架，收緊為單筆版。
  4 條守門：
  1. 僅 `owner` / `admin`（讀 `app_metadata.role`，避開頂層 `auth.jwt()->>'role'` 永遠是 `authenticated` 的雷）
  2. 同 tenant（`_current_tenant_id`）且活動存在
  3. 僅 `status='open'` 可延長（closed 後 `end_at` 已被結單流程快照）
  4. 新時間必須在未來、且嚴格晚於目前 `end_at`（只能往後延）
  寫 `updated_by` / `updated_at`。
- **`apps/admin/.../campaigns/page.tsx`**：open 團列加「延長結單」按鈕 + datetime modal（仿既有 bulk 收單時間 modal，沿用 `SpinButton` / `Modal` / `fmtDateTime`）。

## 測試

`docs/TEST-extend-campaign-deadline.md` 測試清單 + `scripts/test-extend-campaign-deadline.sql` 直測腳本（拋棄式 postgres 容器）：

- **11 / 11 全綠**：SECDEF + grant、happy（owner / admin）、reject（非 owner/admin、跨 tenant、status≠open ×3、過去時間、不晚於目前、NULL）、isolation 只動目標筆。
- `tsc --noEmit` 通過。

## 部署

RPC 已套用至 prod（Supabase Studio）；anon REST probe 由 `404 PGRST202` → `400`（function 內部守門觸發）確認上線。按鈕已在 prod 後台實機渲染確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)