### PR TITLE
feat: 會員刪除（GDPR 軟刪除）後台 UI

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -524,7 +524,14 @@ function MembersListBody() {
         maxWidth={modal?.mode === "detail" ? "max-w-4xl" : "max-w-3xl"}
       >
         {modal?.mode === "detail" ? (
-          <MemberDetail memberId={modal.memberId} />
+          <MemberDetail
+            memberId={modal.memberId}
+            onDeleted={() => {
+              setModal(null);
+              setReloadTick((t) => t + 1);
+              if (idFromUrl) router.replace("/members");
+            }}
+          />
         ) : modal ? (
           <MemberForm
             initial={modal.mode === "edit" ? modal.values : undefined}

--- a/apps/admin/src/components/MemberDeleteModal.tsx
+++ b/apps/admin/src/components/MemberDeleteModal.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+// 會員刪除（GDPR 軟刪除）— 呼叫 rpc_member_gdpr_delete
+// 後端行為（見 supabase/migrations/20260618000040_rpc_member_gdpr_delete.sql）：
+//   - members：清 PII（姓名 / 電話 / email / 生日 / LINE / 大頭照）、status='deleted'
+//   - member_cards：全部退卡（retired）
+//   - member_tags：全部刪除
+//   - points_ledger / wallet_ledger / 訂單 / sales：保留（稅捐稽徵法 7 年留存）
+//   - 不可還原；冪等（已刪除再按為 no-op）
+//
+// 權限：RPC 為 SECURITY DEFINER 不自帶 role gate（與 rpc_merge_member 同慣例，
+//   由呼叫端把關）。本 modal 只在 isAdmin(role) 時於 MemberDetail 掛出，
+//   並要求「輸入會員編號二次確認」避免誤刪。
+
+import { useState } from "react";
+import { Modal } from "@/components/Modal";
+import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
+import SpinButton from "@/components/SpinButton";
+
+export function MemberDeleteModal({
+  open,
+  onClose,
+  member,
+  onDeleted,
+}: {
+  open: boolean;
+  onClose: () => void;
+  member: { id: number; member_no: string; name: string | null };
+  onDeleted: () => void;
+}) {
+  const [confirmText, setConfirmText] = useState("");
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // 二次確認：必須完整輸入會員編號
+  const confirmed = confirmText.trim() === member.member_no;
+
+  function reset() {
+    setConfirmText("");
+    setReason("");
+    setErr(null);
+  }
+
+  async function submit() {
+    if (!confirmed) {
+      setErr("請正確輸入會員編號以確認刪除");
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+
+      const { error } = await sb.rpc("rpc_member_gdpr_delete", {
+        p_member_id: member.id,
+        p_reason: reason.trim() || null,
+        p_operator: operator ?? null,
+      });
+      if (error) {
+        setErr(translateRpcError(error));
+        return;
+      }
+      alert(`已刪除會員 #${member.member_no}（個資已清除，歷史交易紀錄依稅務規定保留）`);
+      reset();
+      onDeleted();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={() => {
+        if (busy) return;
+        reset();
+        onClose();
+      }}
+      title="刪除會員"
+      maxWidth="max-w-lg"
+    >
+      <div className="space-y-4 text-sm">
+        <div className="rounded-md border border-red-300 bg-red-50 p-3 dark:border-red-800 dark:bg-red-950/40">
+          <div className="font-medium text-red-800 dark:text-red-300">
+            ⚠️ 此動作不可還原
+          </div>
+          <div className="mt-1 text-xs text-red-700 dark:text-red-300">
+            即將刪除會員：
+            <b className="mx-1">{member.name ?? "—"}</b>
+            <span className="font-mono">#{member.member_no}</span>
+          </div>
+        </div>
+
+        <div className="rounded-md border border-zinc-200 p-3 text-xs text-zinc-600 dark:border-zinc-800 dark:text-zinc-400">
+          <div className="mb-1 font-medium text-zinc-700 dark:text-zinc-300">刪除後：</div>
+          <ul className="list-disc space-y-0.5 pl-4">
+            <li>清除個資（姓名 / 電話 / Email / 生日 / LINE 綁定 / 大頭照）</li>
+            <li>會員卡全部退卡、標籤全部移除</li>
+            <li>會員將從列表消失、無法再以電話 / 卡號查詢</li>
+            <li>
+              <b>積分 / 儲值流水、訂單、銷售紀錄會保留</b>（依稅捐稽徵法需留存 7 年）
+            </li>
+          </ul>
+        </div>
+
+        <label className="block">
+          <span className="mb-1 block text-xs text-zinc-500">刪除原因（選填，會記入稽核紀錄）</span>
+          <input
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="如：會員要求刪除個資 / 重複建檔"
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-xs text-zinc-500">
+            請輸入會員編號 <span className="font-mono text-zinc-700 dark:text-zinc-300">{member.member_no}</span> 以確認
+          </span>
+          <input
+            value={confirmText}
+            onChange={(e) => setConfirmText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && confirmed) {
+                e.preventDefault();
+                submit();
+              }
+            }}
+            placeholder={member.member_no}
+            autoComplete="off"
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 font-mono text-sm focus:border-red-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900"
+          />
+        </label>
+
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {err}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <SpinButton
+            onClick={() => {
+              if (busy) return;
+              reset();
+              onClose();
+            }}
+            disabled={busy}
+            className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            取消
+          </SpinButton>
+          <SpinButton
+            onClick={submit}
+            disabled={busy || !confirmed}
+            className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+          >
+            {busy ? "刪除中…" : "🗑️ 確認刪除（不可還原）"}
+          </SpinButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { MemberMergeModal } from "@/components/MemberMergeModal";
+import { MemberDeleteModal } from "@/components/MemberDeleteModal";
 import { WalletActionModal, type WalletActionMode } from "@/components/WalletActionModal";
 import { translateRpcError } from "@/lib/rpcError";
-import { canAdjustWallet, useRole } from "@/lib/role";
+import { canAdjustWallet, isAdmin, useRole } from "@/lib/role";
 import { walletLedgerTypeLabel, walletPaymentMethodLabel } from "@/lib/walletLedger";
 import { maskLineUserId } from "@/lib/maskLineUserId";
 import SpinButton from "@/components/SpinButton";
@@ -69,7 +70,7 @@ type WalletEntry = {
   created_at: string;
 };
 
-export function MemberDetail({ memberId }: { memberId: number }) {
+export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDeleted?: () => void }) {
   const [member, setMember] = useState<Member | null>(null);
   const [tier, setTier] = useState<Tier | null>(null);
   const [stores, setStores] = useState<Store[]>([]);
@@ -82,6 +83,7 @@ export function MemberDetail({ memberId }: { memberId: number }) {
   const [sending, setSending] = useState(false);
   const [reloadTick, setReloadTick] = useState(0);
   const [mergeOpen, setMergeOpen] = useState<false | "guest-to-real" | "real-from-guest">(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const [mergedFrom, setMergedFrom] = useState<MergedFrom[]>([]);
   const [savingFlags, setSavingFlags] = useState(false);
   const [draftAdminNote, setDraftAdminNote] = useState("");
@@ -252,11 +254,14 @@ export function MemberDetail({ memberId }: { memberId: number }) {
   if (!member) return <div className="text-sm text-zinc-500">載入中…</div>;
 
   const isMerged = member.status === "merged";
+  const isDeleted = member.status === "deleted";
   const hasLine = !!member.line_user_id;
   // 「合併到已綁 LINE 會員」：自己未綁 LINE + status≠merged 才出現
-  const canMergeOut = !hasLine && !isMerged;
+  const canMergeOut = !hasLine && !isMerged && !isDeleted;
   // 「合併未綁 LINE 會員進來」：自己已綁 LINE + status≠merged 才出現
-  const canAbsorbGuest = hasLine && !isMerged;
+  const canAbsorbGuest = hasLine && !isMerged && !isDeleted;
+  // 刪除（GDPR 軟刪除）：僅管理員，且非已合併 / 已刪除
+  const canDelete = isAdmin(role) && !isMerged && !isDeleted;
 
   return (
     <div className="space-y-5">
@@ -303,7 +308,22 @@ export function MemberDetail({ memberId }: { memberId: number }) {
             📥 合併舊會員進來
           </SpinButton>
         )}
+        {canDelete && (
+          <SpinButton
+            onClick={() => setDeleteOpen(true)}
+            className="rounded-md border border-red-300 px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950"
+            title="刪除會員：清除個資、退卡、移除標籤；流水 / 訂單依稅務規定保留（不可還原）"
+          >
+            🗑️ 刪除會員
+          </SpinButton>
+        )}
       </div>
+
+      {isDeleted && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          此會員已刪除（個資已清除）。歷史交易 / 流水紀錄依稅務規定保留。
+        </div>
+      )}
 
       {/* 黑名單 / 管理員備註 */}
       <div className="rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
@@ -424,6 +444,17 @@ export function MemberDetail({ memberId }: { memberId: number }) {
           ? { id: member.id, name: member.name, phone: member.phone, member_no: member.member_no }
           : undefined}
         onMerged={() => { setMergeOpen(false); setReloadTick((n) => n + 1); }}
+      />
+
+      <MemberDeleteModal
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        member={{ id: member.id, member_no: member.member_no, name: member.name }}
+        onDeleted={() => {
+          setDeleteOpen(false);
+          setReloadTick((n) => n + 1);
+          onDeleted?.();
+        }}
       />
 
       {walletAction && tenantId && (

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -236,6 +236,11 @@ const RULES: Rule[] = [
     pattern: /source member \d+ is already merged/i,
     render: () => "來源會員已經合併過了。",
   },
+  // ===== rpc_member_gdpr_delete（會員刪除） =====
+  {
+    pattern: /member \d+ not found/i,
+    render: () => "找不到此會員（可能已被刪除）。",
+  },
   // ===== rpc_register_damage =====
   {
     pattern: /damage_qty must be > 0/i,


### PR DESCRIPTION
後端 rpc_member_gdpr_delete 早已存在（軟刪除 + 清 PII、退卡、移除標籤、
流水/訂單依稅務保留），但一直沒有觸發入口。本次補上後台操作介面：

- 新增 MemberDeleteModal：二次確認（須輸入會員編號）、選填刪除原因、
  清楚列出刪除後行為與「不可還原」警告，呼叫 rpc_member_gdpr_delete
- MemberDetail 加上「🗑️ 刪除會員」按鈕，僅 isAdmin 顯示，
  且 status 為 merged / deleted 時隱藏；已刪除會員顯示提示橫幅
- 會員列表在刪除成功後關閉明細並重新整理
- rpcError 補上 "member N not found" 中文化

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X7AE7cLG7nJQ6bpr4wTHQ1