### PR TITLE
fix(returns): 退貨上限改為依是否已取貨分流，杜絕收貨後超量退回

### DIFF
--- a/apps/admin/src/components/OrderReturnCreateModal.tsx
+++ b/apps/admin/src/components/OrderReturnCreateModal.tsx
@@ -5,6 +5,7 @@ import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
+import { parseReturnNote } from "@/lib/returnNote";
 
 const RETURNABLE_STATUSES = ["shipping", "ready", "partially_completed", "completed", "expired"] as const;
 
@@ -32,8 +33,10 @@ type DeliveredSku = {
   sku_id: number;
   sku_code: string;
   sku_name: string;
-  delivered: number;
-  already_returned: number;
+  delivered: number; // R：已收(訂單)量（含已取貨）
+  picked: number; // P：已取貨量（status='picked_up'）
+  returned_unpicked: number; // 已退量：一般退貨（未帶 |取貨後退回 tag）
+  returned_picked: number; // 已退量：取貨後退回（帶 |取貨後退回 tag）
   store_stock: number;
 };
 
@@ -216,12 +219,14 @@ export default function OrderReturnCreateModal({
         .eq("order_id", orderId)
         .not("status", "in", "(cancelled,expired)");
 
-      const deliveredMap = new Map<number, { qty: number; sku_code: string; sku_name: string }>();
+      // deliveredMap.qty = 已收(訂單)量（含已取貨）；picked = 已取貨量（status='picked_up'）
+      const deliveredMap = new Map<number, { qty: number; picked: number; sku_code: string; sku_name: string }>();
       // Supabase 自動 typegen 對 FK relation 一律當 array，雖然這裡實際是 1:1。
       // 用 unknown 中轉 cast，再對 array 取 [0]。
       type ItemRow = {
         sku_id: number;
         qty: number | null;
+        status: string | null;
         skus: { sku_code: string; products: { name?: string } | { name?: string }[] | null } | Array<{
           sku_code: string;
           products: { name?: string } | { name?: string }[] | null;
@@ -240,27 +245,32 @@ export default function OrderReturnCreateModal({
         const qty = Number(row.qty ?? 0);
         deliveredMap.set(row.sku_id, {
           qty: (prev?.qty ?? 0) + qty,
+          picked: (prev?.picked ?? 0) + (row.status === "picked_up" ? qty : 0),
           sku_code: skuObj?.sku_code ?? prev?.sku_code ?? "",
           sku_name: prodObj?.name ?? prev?.sku_name ?? "",
         });
       }
 
-      // 已退量（先前的 return_to_hq transfer 累加）
+      // 已退量（先前的 return_to_hq transfer 累加），依 notes |取貨後退回 tag 分兩池
       const { data: returnedRows } = await sb
         .from("transfers")
-        .select("id, transfer_type, status, source_location, transfer_items(sku_id, qty_shipped)")
+        .select("id, transfer_type, status, source_location, notes, transfer_items(sku_id, qty_shipped)")
         .eq("customer_order_id", orderId)
         .eq("transfer_type", "return_to_hq")
         .in("status", ["shipped", "received"])
         .eq("source_location", store.location_id);
 
-      const returnedMap = new Map<number, number>();
+      const returnedUnpickedMap = new Map<number, number>();
+      const returnedPickedMap = new Map<number, number>();
       for (const t of (returnedRows ?? []) as Array<{
+        notes: string | null;
         transfer_items: Array<{ sku_id: number; qty_shipped: number | null }>;
       }>) {
+        const isRestock = parseReturnNote(t.notes).isRestock;
+        const target = isRestock ? returnedPickedMap : returnedUnpickedMap;
         for (const ti of t.transfer_items ?? []) {
           if (ti.sku_id == null) continue;
-          returnedMap.set(ti.sku_id, (returnedMap.get(ti.sku_id) ?? 0) + Number(ti.qty_shipped ?? 0));
+          target.set(ti.sku_id, (target.get(ti.sku_id) ?? 0) + Number(ti.qty_shipped ?? 0));
         }
       }
 
@@ -283,7 +293,9 @@ export default function OrderReturnCreateModal({
         sku_code: info.sku_code,
         sku_name: info.sku_name,
         delivered: info.qty,
-        already_returned: returnedMap.get(sku_id) ?? 0,
+        picked: info.picked,
+        returned_unpicked: returnedUnpickedMap.get(sku_id) ?? 0,
+        returned_picked: returnedPickedMap.get(sku_id) ?? 0,
         store_stock: stockMap.get(sku_id) ?? 0,
       }));
       list.sort((a, b) => a.sku_code.localeCompare(b.sku_code));
@@ -298,10 +310,13 @@ export default function OrderReturnCreateModal({
     setRestockFirst(orderStatus === "completed");
   }, [orderStatus]);
 
-  // 有效可退量：未勾 restock 時受店端實際庫存上限；勾了會先入庫故不卡庫存
+  // 有效可退量：依是否「客戶已取貨後退回」分流
+  //   勾 restock：客戶取走又拿回 → 上限 = 已取貨量 − 已退(取貨後)量
+  //   不勾：退店端未取貨的貨 → 上限 = (已收 − 已取) − 已退(一般)量，再受店端實際庫存限制
   const effRemaining = (s: DeliveredSku): number => {
-    const byOrder = s.delivered - s.already_returned;
-    return restockFirst ? byOrder : Math.min(byOrder, s.store_stock);
+    if (restockFirst) return Math.max(0, s.picked - s.returned_picked);
+    const unpicked = s.delivered - s.picked - s.returned_unpicked;
+    return Math.max(0, Math.min(unpicked, s.store_stock));
   };
 
   const totalToReturn = useMemo(() => {
@@ -365,7 +380,8 @@ export default function OrderReturnCreateModal({
         )}
 
         <p className="text-sm text-zinc-500">
-          以訂單的 SKU 為準，退量不可超過訂單量 - 已退量；若店端庫存不足會被擋下。
+          退量上限依是否「客戶已取貨後退回」分流：未勾 → 退店端「未取貨」的貨（上限 = 已收 − 已取 − 已退，受店端庫存限制）；
+          勾選 → 客戶取走又拿回（上限 = 已取貨量 − 已退）。
         </p>
 
         {!isPrefilled && (
@@ -482,6 +498,7 @@ export default function OrderReturnCreateModal({
                   <th className="px-3 py-2">SKU</th>
                   <th className="px-3 py-2">品名</th>
                   <th className="px-3 py-2 text-right">訂單量</th>
+                  <th className="px-3 py-2 text-right">已取</th>
                   <th className="px-3 py-2 text-right">已退</th>
                   <th className="px-3 py-2 text-right">店端庫存</th>
                   <th className="px-3 py-2 text-right">可退</th>
@@ -490,23 +507,27 @@ export default function OrderReturnCreateModal({
               </thead>
               <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
                 {skus === null ? (
-                  <tr><td colSpan={7} className="p-4 text-center text-zinc-500">載入中…</td></tr>
+                  <tr><td colSpan={8} className="p-4 text-center text-zinc-500">載入中…</td></tr>
                 ) : skus.length === 0 ? (
-                  <tr><td colSpan={7} className="p-4 text-center text-zinc-500">此訂單目前沒有可退的 SKU（全部已取消 / 過期）</td></tr>
+                  <tr><td colSpan={8} className="p-4 text-center text-zinc-500">此訂單目前沒有可退的 SKU（全部已取消 / 過期）</td></tr>
                 ) : skus.map((s) => {
-                  const byOrder = s.delivered - s.already_returned;
+                  // 顯示的已退量依當前模式（取貨後退回 / 一般）對應的那一池
+                  const shownReturned = restockFirst ? s.returned_picked : s.returned_unpicked;
+                  // 未勾 restock 時，可退量受店端實際庫存限制（訂單上未取貨量 vs 實庫存）
+                  const unpicked = s.delivered - s.picked - s.returned_unpicked;
                   const cap = effRemaining(s);
-                  const cappedByStock = !restockFirst && s.store_stock < byOrder;
+                  const cappedByStock = !restockFirst && s.store_stock < unpicked;
                   return (
                     <tr key={s.sku_id}>
                       <td className="px-3 py-2 font-mono text-xs">{s.sku_code}</td>
                       <td className="px-3 py-2">{s.sku_name || "—"}</td>
                       <td className="px-3 py-2 text-right">{s.delivered}</td>
-                      <td className="px-3 py-2 text-right text-zinc-500">{s.already_returned}</td>
+                      <td className="px-3 py-2 text-right text-zinc-500">{s.picked}</td>
+                      <td className="px-3 py-2 text-right text-zinc-500">{shownReturned}</td>
                       <td className={`px-3 py-2 text-right ${cappedByStock ? "text-amber-600 dark:text-amber-400" : "text-zinc-500"}`}>
                         {s.store_stock}
                       </td>
-                      <td className="px-3 py-2 text-right font-medium" title={cappedByStock ? `受店端庫存限制（訂單可退 ${byOrder}）` : undefined}>
+                      <td className="px-3 py-2 text-right font-medium" title={cappedByStock ? `受店端庫存限制（訂單未取貨可退 ${unpicked}）` : undefined}>
                         {cap}
                       </td>
                       <td className="px-3 py-2 text-right">

--- a/supabase/migrations/20260707000060_rpc_order_return_cap_unpicked.sql
+++ b/supabase/migrations/20260707000060_rpc_order_return_cap_unpicked.sql
@@ -1,0 +1,273 @@
+-- ============================================================
+-- rpc_create_order_return：退貨上限改為「依是否已取貨分流」
+--
+-- 動機（店家誤出貨情境）：分店「收貨」（收進貨 / 收調撥）後，貨已在店端但
+--   客戶尚未取貨。原本退貨上限 = 訂單量 − 已退量，沒有把「客戶已取走的量」
+--   扣掉，導致兩個問題：
+--     1. 已取貨後退回 (restock_first) 的上限用整張訂單量，會超賣（可退到比
+--        客戶實際取走的還多 → inbound 出幽靈庫存）。
+--     2. 一般退貨（店端未取貨的庫存退回總倉）的上限把「已取貨後退回」也算進
+--        已退量，互相吃額度。
+--
+-- 新規則（與 PM 確認的兩情境一致）：
+--   收了 R 個、客戶已取走 P 個（status='picked_up' 的品項量）：
+--     · 一般退貨（p_restock_first=false，退店端「未取貨」的貨）
+--         上限 = (R − P) − 已退量(未帶|取貨後退回 tag)
+--         例：收 10 取 0 → 可退 10；收 10 取 5 → 可退 5。
+--     · 已取貨後退回（p_restock_first=true，客戶取走又拿回來）
+--         上限 = P − 已退量(帶|取貨後退回 tag)
+--         例：取 5 → 最多退這 5 個；沒取過(P=0) → 不能走此路。
+--   已退量依 transfers.notes 是否含 '|取貨後退回' tag 分兩池，互不吃額度。
+--   非 restock 路徑仍由 rpc_outbound 擋實體庫存不足當最後防線。
+--
+-- 其餘行為（status gate 含 expired、movement_type 驗證、|破損 / |取貨後退回
+--   notes tag、restock_first 的 inbound→outbound、store-role 自店限制、
+--   tenant scoping）全部與基底版本逐字保留。
+--
+-- 基底版本：20260704000010_rpc_order_return_tag_restock.sql（線上現行、
+--   6-arg signature）。
+-- Rollback：CREATE OR REPLACE 回 20260704000010 版本
+--   （returnable 改回 v_delivered − v_already_ret、不分 picked / tag）。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_create_order_return(
+  p_order_id      BIGINT,
+  p_lines         JSONB,
+  p_reason        TEXT    DEFAULT NULL,
+  p_operator      UUID    DEFAULT NULL,
+  p_movement_type TEXT    DEFAULT 'customer_return',
+  p_restock_first BOOLEAN DEFAULT FALSE
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant         UUID := public._current_tenant_id();
+  v_user           UUID := COALESCE(p_operator, auth.uid());
+  v_role           TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_order          customer_orders%ROWTYPE;
+  v_store_loc      BIGINT;
+  v_hq_loc         BIGINT;
+  v_transfer_id    BIGINT;
+  v_transfer_no    TEXT;
+  v_line           JSONB;
+  v_sku_id         BIGINT;
+  v_qty            NUMERIC;
+  v_delivered      NUMERIC;  -- R：該 SKU 已收(訂單)量（含已取貨）
+  v_picked         NUMERIC;  -- P：該 SKU 已取貨量（status='picked_up'）
+  v_ret_unpicked   NUMERIC;  -- 已退量：一般退貨（未帶 |取貨後退回 tag）
+  v_ret_picked     NUMERIC;  -- 已退量：取貨後退回（帶 |取貨後退回 tag）
+  v_returnable     NUMERIC;
+  v_mov_id         BIGINT;
+  v_count          INT := 0;
+  v_result_lines   JSONB := '[]'::JSONB;
+  v_reason_note    TEXT;
+  v_type_tag       TEXT;
+BEGIN
+  -- P1: 驗 movement_type（只允許這兩種、皆在 stock_movements CHECK 內）
+  IF p_movement_type IS NULL OR p_movement_type NOT IN ('customer_return','damage') THEN
+    RAISE EXCEPTION 'invalid p_movement_type % (must be customer_return or damage)', p_movement_type;
+  END IF;
+
+  IF v_role NOT IN ('owner','admin','hq_manager','store_manager','store_staff','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot create order return', v_role;
+  END IF;
+
+  SELECT * INTO v_order
+    FROM customer_orders
+   WHERE id = p_order_id AND tenant_id = v_tenant
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'order % not found in tenant', p_order_id;
+  END IF;
+  IF v_order.status NOT IN ('shipping','ready','partially_completed','completed','expired') THEN
+    RAISE EXCEPTION 'order % status=% cannot be returned (must be shipping/ready/partially_completed/completed/expired)',
+      p_order_id, v_order.status;
+  END IF;
+
+  SELECT location_id INTO v_store_loc
+    FROM stores
+   WHERE id = v_order.pickup_store_id AND tenant_id = v_tenant;
+  IF v_store_loc IS NULL THEN
+    RAISE EXCEPTION 'pickup store % has no location_id', v_order.pickup_store_id;
+  END IF;
+
+  SELECT id INTO v_hq_loc
+    FROM locations
+   WHERE tenant_id = v_tenant AND type = 'central_warehouse' AND is_active = TRUE
+   ORDER BY id LIMIT 1;
+  IF v_hq_loc IS NULL THEN
+    RAISE EXCEPTION 'no active central_warehouse location for tenant';
+  END IF;
+  IF v_hq_loc = v_store_loc THEN
+    RAISE EXCEPTION 'pickup store location is HQ; cannot return to self';
+  END IF;
+
+  IF p_lines IS NULL OR jsonb_array_length(p_lines) = 0 THEN
+    RAISE EXCEPTION 'lines must not be empty';
+  END IF;
+
+  IF v_role IN ('store_manager','store_staff') THEN
+    IF v_order.pickup_store_id::TEXT IS DISTINCT FROM (auth.jwt() ->> 'store_id') THEN
+      RAISE EXCEPTION 'store role can only return orders for own store';
+    END IF;
+  END IF;
+
+  v_transfer_no := public._next_transfer_no();
+  -- 在 notes 加標記（HQ 收貨端 / 對帳 / 訂單退貨記錄看得出退貨情境）：
+  --   破損 → |破損；客戶已取貨後退回 (restock_first) → |取貨後退回
+  v_type_tag := '';
+  IF p_movement_type = 'damage' THEN
+    v_type_tag := v_type_tag || '|破損';
+  END IF;
+  IF p_restock_first THEN
+    v_type_tag := v_type_tag || '|取貨後退回';
+  END IF;
+  v_reason_note := CASE
+    WHEN NULLIF(TRIM(COALESCE(p_reason,'')),'') IS NOT NULL
+    THEN '[order return' || v_type_tag || ': ' || TRIM(p_reason) || ']'
+    ELSE '[order return' || v_type_tag || ']'
+  END;
+
+  INSERT INTO transfers (
+    tenant_id, transfer_no, source_location, dest_location,
+    status, transfer_type, customer_order_id,
+    requested_by, shipped_by, shipped_at,
+    notes, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_transfer_no, v_store_loc, v_hq_loc,
+    'shipped', 'return_to_hq', p_order_id,
+    v_user, v_user, NOW(),
+    v_reason_note, v_user, v_user
+  ) RETURNING id INTO v_transfer_id;
+
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines)
+  LOOP
+    v_sku_id := (v_line ->> 'sku_id')::BIGINT;
+    v_qty    := (v_line ->> 'qty')::NUMERIC;
+
+    IF v_sku_id IS NULL OR v_qty IS NULL OR v_qty <= 0 THEN
+      RAISE EXCEPTION 'invalid line: sku_id=% qty=%', v_sku_id, v_qty;
+    END IF;
+
+    -- R：該 SKU 已收(訂單)量（含已取貨；single source of truth = customer_order_items）
+    SELECT COALESCE(SUM(coi.qty), 0) INTO v_delivered
+      FROM customer_order_items coi
+     WHERE coi.order_id = p_order_id
+       AND coi.sku_id = v_sku_id
+       AND coi.status NOT IN ('cancelled','expired');
+
+    IF v_delivered <= 0 THEN
+      RAISE EXCEPTION 'sku % is not in order % (or is cancelled/expired)', v_sku_id, p_order_id;
+    END IF;
+
+    -- P：該 SKU 已取貨量（部分取貨會拆出獨立的 picked_up 行）
+    SELECT COALESCE(SUM(coi.qty), 0) INTO v_picked
+      FROM customer_order_items coi
+     WHERE coi.order_id = p_order_id
+       AND coi.sku_id = v_sku_id
+       AND coi.status = 'picked_up';
+
+    -- 已退量分兩池（依 notes 是否含 |取貨後退回 tag），本筆 transfer 還沒含進來
+    SELECT
+      COALESCE(SUM(ti.qty_shipped) FILTER (WHERE t.notes LIKE '%|取貨後退回%'), 0),
+      COALESCE(SUM(ti.qty_shipped) FILTER (WHERE t.notes IS NULL OR t.notes NOT LIKE '%|取貨後退回%'), 0)
+      INTO v_ret_picked, v_ret_unpicked
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.customer_order_id = p_order_id
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('shipped','received')
+       AND t.source_location = v_store_loc
+       AND t.id <> v_transfer_id
+       AND ti.sku_id = v_sku_id;
+
+    -- 退貨上限：依是否「已取貨後退回」分流
+    IF p_restock_first THEN
+      -- 客戶取走又拿回來：上限 = 已取貨量 − 已退(取貨後)量
+      v_returnable := v_picked - v_ret_picked;
+      IF v_qty > v_returnable THEN
+        RAISE EXCEPTION 'sku %: 取貨後退回 qty % exceeds picked-up returnable % (picked=%, already_returned_after_pickup=%)',
+          v_sku_id, v_qty, v_returnable, v_picked, v_ret_picked;
+      END IF;
+    ELSE
+      -- 退店端「未取貨」的貨：上限 = (已收 − 已取) − 已退(一般)量
+      v_returnable := (v_delivered - v_picked) - v_ret_unpicked;
+      IF v_qty > v_returnable THEN
+        RAISE EXCEPTION 'sku %: qty % exceeds returnable % (delivered=%, picked_up=%, already_returned=%)',
+          v_sku_id, v_qty, v_returnable, v_delivered, v_picked, v_ret_unpicked;
+      END IF;
+    END IF;
+
+    -- P2-A: 取貨後反悔 — 先把退回的貨入庫店端（customer_return inbound），
+    -- 之後 outbound 才有庫存可扣。unit_cost=0 → 不動 avg_cost。
+    IF p_restock_first THEN
+      PERFORM rpc_inbound(
+        p_tenant_id       => v_tenant,
+        p_location_id     => v_store_loc,
+        p_sku_id          => v_sku_id,
+        p_quantity        => v_qty,
+        p_unit_cost       => 0,
+        p_movement_type   => 'customer_return',
+        p_source_doc_type => 'customer_order',
+        p_source_doc_id   => p_order_id,
+        p_operator        => v_user
+      );
+    END IF;
+
+    -- 出庫店端 → 在途回總倉。P1: movement_type 由參數決定。
+    v_mov_id := rpc_outbound(
+      p_tenant_id       => v_tenant,
+      p_location_id     => v_store_loc,
+      p_sku_id          => v_sku_id,
+      p_quantity        => v_qty,
+      p_movement_type   => p_movement_type,
+      p_source_doc_type => 'transfer',
+      p_source_doc_id   => v_transfer_id,
+      p_operator        => v_user
+    );
+
+    INSERT INTO transfer_items (
+      transfer_id, sku_id, qty_requested, qty_shipped,
+      out_movement_id, notes, created_by, updated_by
+    ) VALUES (
+      v_transfer_id, v_sku_id, v_qty, v_qty,
+      v_mov_id, v_line ->> 'notes', v_user, v_user
+    );
+
+    v_result_lines := v_result_lines || jsonb_build_object(
+      'sku_id', v_sku_id,
+      'qty', v_qty,
+      'out_movement_id', v_mov_id
+    );
+    v_count := v_count + 1;
+  END LOOP;
+
+  IF v_count = 0 THEN
+    RAISE EXCEPTION 'lines must not be empty';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'return_transfer_id', v_transfer_id,
+    'transfer_no', v_transfer_no,
+    'order_id', p_order_id,
+    'source_location', v_store_loc,
+    'dest_location', v_hq_loc,
+    'movement_type', p_movement_type,
+    'restocked_first', p_restock_first,
+    'lines', v_result_lines
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION
+  public.rpc_create_order_return(BIGINT, JSONB, TEXT, UUID, TEXT, BOOLEAN)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_order_return IS
+  '分店發起退訂單回總倉。allowed status: shipping/ready/partially_completed/completed/expired。'
+  'p_movement_type: customer_return(預設) / damage（破損、會計分流，notes 加|破損標記）。'
+  'p_restock_first=true: 取貨後反悔情境，先 customer_return inbound 店端再 outbound 回總倉；notes 加 |取貨後退回 標記。'
+  '退貨上限分流：restock_first=true → 已取貨量 − 已退(取貨後)量；'
+  'restock_first=false → (已收 − 已取) − 已退(一般)量。已退量依 notes |取貨後退回 tag 分兩池。'
+  '非 restock 路徑不夠店端庫存時由 rpc_outbound 擋 Insufficient stock。';


### PR DESCRIPTION
## 背景

店家「分店收貨」（收進貨／收調撥）後、客戶尚未取貨的誤出貨情境下，退貨視窗會卡住或可超量退回。原本退貨上限 = `訂單量 − 已退量`，沒有把「客戶已取走的量」扣掉，導致：

1. **已取貨後退回 (`restock_first`)** 用整張訂單量當上限 → 可超賣（`inbound` 灌出幽靈庫存）。
2. **一般退貨**把「取貨後退回」也算進已退量，兩種退法互相吃額度。

## 新規則（與 PM 確認的兩情境一致）

設某 SKU 已收 `R` 個、客戶已取 `P` 個（`status='picked_up'` 的品項量）：

| 情境 | 退貨上限 |
|---|---|
| 一般退貨（未勾「已取貨後退回」）＝ 退店端**未取貨**的貨 | `(R − P) − 已退(一般)`，仍由 `rpc_outbound` 擋實體庫存 |
| 已取貨後退回（勾選）＝ 客戶取走又拿回 | `P − 已退(取貨後)`；沒取過則不能走此路 |

- 收 10 取 0 → 可退 10；收 10 取 5 → 一般退貨可退 5，已取的 5 走「已取貨後退回」。
- 已退量依 `transfers.notes` 是否含 `|取貨後退回` tag **分兩池、互不吃額度**。

## 變更內容

- **`supabase/migrations/20260707000060_rpc_order_return_cap_unpicked.sql`** — 改寫 `rpc_create_order_return`（後端把關，signature 不變）。基底為 `20260704000010_rpc_order_return_tag_restock.sql`；rollback 指回該版。
  - ⚠️ 此 migration **已透過 Supabase Management API 部署到線上**（已驗證 `has_v_picked=true`），舊版定義已備份。
- **`apps/admin/src/components/OrderReturnCreateModal.tsx`** — 前端同步：新增「已取」欄、可退量依模式分流計算、頂部說明文字更新。此前端變更**尚未上線**，需走 admin app 的部署流程。

## 驗證

- `tsc --noEmit` 通過。
- ESLint 僅剩兩個既有的 `set-state-in-effect`（prefill effect，非本次改動範圍）。
- 線上以實單 `GB20260519-C000152-0012`（松山店）核對：庫存與可退量計算正確，無 regression。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tg4tHkgd4DY4BJRbPJffDK)_