### PR TITLE
perf(orders): 訂單頁首聚合改伺服端 RPC，加速讀取

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -166,7 +166,6 @@ function OrdersListContent() {
 
   // KPI trend (當月 1 號 ~ 今天 每日 + 本月累計、套 filter 開團+店家、排除 transferred_out)
   const [trend, setTrend] = useState<TrendData | null>(null);
-  const [trendTruncated, setTrendTruncated] = useState(false);
 
   useEffect(() => { setPage(1); }, [campaignIds, tab, storeId, keyword]);
 
@@ -317,159 +316,72 @@ function OrdersListContent() {
     return () => { cancelled = true; };
   }, [campaignIds, tab, storeId, page, reloadOrders, keyword]);
 
-  // 各 tab 數量 — 切 tab 不重抓,只在其他 filter / reload 時更新
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const sb = getSupabase();
-      const kwOr = await buildKeywordOr(keyword);
-      if (cancelled) return;
-      const buildBase = () => {
-        let q = sb.from("customer_orders").select("id", { count: "exact", head: true });
-        if (campaignIds.length === 1) q = q.eq("campaign_id", Number(campaignIds[0]));
-        else if (campaignIds.length > 1) q = q.in("campaign_id", campaignIds.map((x) => Number(x)));
-        if (storeId) q = q.eq("pickup_store_id", Number(storeId));
-        if (kwOr) q = q.or(kwOr);
-        return q;
-      };
-      const [p, pc, c, x, tr] = await Promise.all([
-        buildBase().in("status", PENDING_STATUSES),
-        buildBase().eq("status", "partially_completed"),
-        buildBase().eq("status", "completed"),
-        buildBase().in("status", CANCELLED_STATUSES),
-        buildBase().eq("status", "transferred_out"),
-      ]);
-      if (cancelled) return;
-      setTabCounts({
-        pending: p.count ?? 0,
-        partially: pc.count ?? 0,
-        completed: c.count ?? 0,
-        cancelled: x.count ?? 0,
-        transferred: tr.count ?? 0,
-      });
-    })();
-    return () => { cancelled = true; };
-  }, [campaignIds, storeId, reloadOrders, keyword]);
-
-  // KPI Trend — 當月 1 號到今天每日 (套 filter 開團+店家, 排除 transferred_out)
+  // 頁首聚合（tab 數量 + 月趨勢）— 單一伺服端 RPC rpc_order_overview
+  // 取代之前 client 端「5 個 count:exact 全表掃描」+「搬整月訂單+全部明細
+  // 回瀏覽器做聚合」的做法（後者一個月幾萬筆訂單時是主要的慢點）。
+  // 切 tab 不重抓,只在 campaign / 店家 / keyword / reload 變動時更新。
   useEffect(() => {
     let cancelled = false;
     setTrend(null);
-    setTrendTruncated(false);
     (async () => {
       const sb = getSupabase();
       const today = new Date();
       const startDate = new Date(today.getFullYear(), today.getMonth(), 1);
 
-      // Chunked fetch — bypass PostgREST max-rows cap (預設 1000)
-      // 用 id range pagination、可疊到 50K rows
-      const orders: { id: number; member_id: number | null; created_at: string }[] = [];
-      const PAGE = 1000;
-      const MAX_PAGES = 50;
-      let truncated = false;
-      for (let p = 0; p < MAX_PAGES; p++) {
-        let pq = sb
-          .from("customer_orders")
-          .select("id, member_id, created_at")
-          // 營收 KPI 不計：取消 / 逾期 / 轉出（皆非有效成交）
-          .not("status", "in", "(cancelled,expired,transferred_out)")
-          .gte("created_at", startDate.toISOString())
-          .order("id", { ascending: true });
-        if (campaignIds.length === 1) pq = pq.eq("campaign_id", Number(campaignIds[0]));
-        else if (campaignIds.length > 1)
-          pq = pq.in("campaign_id", campaignIds.map((x) => Number(x)));
-        if (storeId) pq = pq.eq("pickup_store_id", Number(storeId));
-        pq = pq.range(p * PAGE, (p + 1) * PAGE - 1);
-        const { data: pData, error: pErr } = await pq;
-        if (cancelled) return;
-        if (pErr) {
-          setTrend({ days: buildEmptyTrend(today), total: { orders: 0, amount: 0, members: 0, aov: 0 } });
-          return;
-        }
-        const rows = (pData ?? []) as typeof orders;
-        orders.push(...rows);
-        if (rows.length < PAGE) break;
-        if (p === MAX_PAGES - 1) truncated = true;
-      }
-      setTrendTruncated(truncated);
-
-      // 本月累計 — orders 每筆 id 唯一、members 跨日 distinct
-      const monthMemberIds = new Set<number>();
-      for (const o of orders) {
-        if (o.member_id != null) monthMemberIds.add(o.member_id);
-      }
-
-      // 每日 buckets — key = 台北日 YYYY-MM-DD（不能用 created_at.slice(0,10)，
-      // 那是 UTC 日，會把台北凌晨的訂單錯誤歸到前一天）
-      const tpeFmt = new Intl.DateTimeFormat("en-CA", {
-        timeZone: "Asia/Taipei",
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
+      const { data, error: rpcErr } = await sb.rpc("rpc_order_overview", {
+        p_campaign_ids: campaignIds.length ? campaignIds.map((x) => Number(x)) : null,
+        p_store_id: storeId ? Number(storeId) : null,
+        p_keyword: keyword || null,
+        p_month_start: startDate.toISOString(),
       });
-      const buckets = new Map<
-        string,
-        { orderIds: Set<number>; memberIds: Set<number>; amount: number }
-      >();
-      const orderDay = new Map<number, string>();
-      for (const o of orders) {
-        const ymd = tpeFmt.format(new Date(o.created_at));
-        orderDay.set(o.id, ymd);
-        let b = buckets.get(ymd);
-        if (!b) {
-          b = { orderIds: new Set(), memberIds: new Set(), amount: 0 };
-          buckets.set(ymd, b);
-        }
-        b.orderIds.add(o.id);
-        if (o.member_id != null) b.memberIds.add(o.member_id);
-      }
-
-      const orderIds = orders.map((o) => o.id);
-      if (orderIds.length > 0) {
-        for (let i = 0; i < orderIds.length; i += 1000) {
-          const chunk = orderIds.slice(i, i + 1000);
-          const { data: iData } = await sb
-            .from("customer_order_items")
-            .select("order_id, qty, unit_price")
-            .in("order_id", chunk);
-          if (cancelled) return;
-          for (const it of (iData as
-            | { order_id: number; qty: number; unit_price: number }[]
-            | null) ?? []) {
-            const ymd = orderDay.get(it.order_id);
-            if (!ymd) continue;
-            const b = buckets.get(ymd);
-            if (b) b.amount += Number(it.qty) * Number(it.unit_price);
-          }
-        }
-      }
       if (cancelled) return;
 
-      // 補齊當月 1 號 ~ 今天每一日 (沒資料補 0)
-      let monthOrders = 0;
-      let monthAmount = 0;
+      type Overview = {
+        tab_counts: { pending: number; partially: number; completed: number; cancelled: number; transferred: number };
+        trend_days: { ymd: string; orders: number; members: number; amount: number }[];
+        trend_total: { orders: number; members: number; amount: number };
+      };
+      if (rpcErr || !data) {
+        setTabCounts(null);
+        setTrend({ days: buildEmptyTrend(today), total: { orders: 0, amount: 0, members: 0, aov: 0 } });
+        return;
+      }
+      const ov = data as Overview;
+      setTabCounts({
+        pending: ov.tab_counts.pending ?? 0,
+        partially: ov.tab_counts.partially ?? 0,
+        completed: ov.tab_counts.completed ?? 0,
+        cancelled: ov.tab_counts.cancelled ?? 0,
+        transferred: ov.tab_counts.transferred ?? 0,
+      });
+
+      // 把 RPC 回的每日聚合補齊成「當月 1 號 ~ 今天」連續序列（沒資料補 0）
+      const dayMap = new Map<string, { orders: number; members: number; amount: number }>();
+      for (const d of ov.trend_days ?? []) {
+        dayMap.set(d.ymd, { orders: Number(d.orders), members: Number(d.members), amount: Number(d.amount) });
+      }
       const days: DayTrend[] = [];
       const cur = new Date(startDate);
       while (cur <= today) {
         const ymd = `${cur.getFullYear()}-${String(cur.getMonth() + 1).padStart(2, "0")}-${String(cur.getDate()).padStart(2, "0")}`;
-        const b = buckets.get(ymd);
-        const orderCnt = b?.orderIds.size ?? 0;
+        const b = dayMap.get(ymd);
+        const orderCnt = b?.orders ?? 0;
         const amt = b?.amount ?? 0;
         days.push({
           ymd,
           orders: orderCnt,
           amount: amt,
-          members: b?.memberIds.size ?? 0,
+          members: b?.members ?? 0,
           aov: orderCnt > 0 ? amt / orderCnt : 0,
         });
-        monthOrders += orderCnt;
-        monthAmount += amt;
         cur.setDate(cur.getDate() + 1);
       }
+      const monthOrders = Number(ov.trend_total?.orders ?? 0);
+      const monthAmount = Number(ov.trend_total?.amount ?? 0);
       const total: MonthAgg = {
         orders: monthOrders,
         amount: monthAmount,
-        members: monthMemberIds.size,
+        members: Number(ov.trend_total?.members ?? 0),
         aov: monthOrders > 0 ? monthAmount / monthOrders : 0,
       };
       setTrend({ days, total });
@@ -477,7 +389,7 @@ function OrdersListContent() {
     return () => {
       cancelled = true;
     };
-  }, [campaignIds, storeId, reloadOrders]);
+  }, [campaignIds, storeId, reloadOrders, keyword]);
 
   const campaignMap = useMemo(() => new Map(campaigns.map((c) => [c.id, c])), [campaigns]);
   const storeMap = useMemo(() => new Map(stores.map((s) => [s.id, s])), [stores]);
@@ -637,7 +549,6 @@ function OrdersListContent() {
           getDaily={(d) => d.amount}
           fmt={(v) => `$${Math.round(v).toLocaleString("zh-TW")}`}
           subLabel="日均"
-          hint={trendTruncated ? "已截斷 20000 筆" : undefined}
         />
         <TrendCard
           label="本月訂單數"

--- a/supabase/migrations/20260708000010_rpc_order_overview.sql
+++ b/supabase/migrations/20260708000010_rpc_order_overview.sql
@@ -1,0 +1,133 @@
+-- ============================================================
+-- rpc_order_overview — admin /orders 頁首聚合（tab 數量 + 月趨勢）
+--
+-- 動機：/orders 頁讀取很慢。根因是頁面 mount 時瀏覽器端做兩件重活：
+--   (1) KPI 趨勢卡：chunked fetch 把「整月所有訂單(最多 5 萬筆) + 全部
+--       order_items」搬回瀏覽器再 client 聚合 → 數 MB 傳輸 + 大量計算。
+--   (2) Tab 數量：5 個 count:exact 全表掃描並發跑。
+--
+-- 修法：照 rpc_orders_pivot (20260621000030) 的 RETURNS jsonb 範本，把
+--   tab 數量 + 每日趨勢 + 本月累計合併成單一伺服端聚合、一次 round-trip。
+--   jsonb 單一 row 不受 PostgREST max_rows=1000 截斷。
+--
+-- 篩選與既有 client 邏輯對齊：
+--   * campaign / 取貨店 篩選
+--   * keyword：與 buildKeywordOr 同語意 — 每個 token 都要在
+--     members.name/phone/member_no 命中(token-AND)，或整串命中
+--     customer_orders.order_no/nickname_snapshot
+--   * 趨勢只計有效成交（排除 cancelled/expired/transferred_out），
+--     日界以 Asia/Taipei 切（與 client tpeFmt 一致）
+--   * tab 分組沿用 PENDING/CANCELLED 狀態集合
+--
+-- 基底版本：無（全新 function）
+-- rollback：DROP FUNCTION rpc_order_overview(bigint[], bigint, text, timestamptz);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_order_overview(
+  p_campaign_ids bigint[],
+  p_store_id     bigint,
+  p_keyword      text,
+  p_month_start  timestamptz
+)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH kw AS (
+    -- 與 buildKeywordOr 一致：先把 %,() 換成空白避免當成 ILIKE 萬用字元
+    SELECT NULLIF(btrim(regexp_replace(COALESCE(p_keyword, ''), '[%,()]', ' ', 'g')), '') AS q
+  ),
+  toks AS (
+    SELECT ARRAY(
+      SELECT t FROM unnest(regexp_split_to_array((SELECT q FROM kw), '[\s+]+')) AS t
+      WHERE t <> ''
+    ) AS arr
+  ),
+  qualified_members AS (
+    -- token-AND：每個 token 都要在 name/phone/member_no 至少一欄命中
+    SELECT m.id
+    FROM members m
+    WHERE (SELECT q FROM kw) IS NOT NULL
+      AND m.status <> 'deleted'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM unnest((SELECT arr FROM toks)) AS tok
+        WHERE NOT (
+          m.name      ILIKE '%' || tok || '%'
+          OR m.phone     ILIKE '%' || tok || '%'
+          OR m.member_no ILIKE '%' || tok || '%'
+        )
+      )
+  ),
+  filtered AS (
+    SELECT o.id, o.member_id, o.created_at, o.status
+    FROM customer_orders o
+    WHERE (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      AND (
+        (SELECT q FROM kw) IS NULL
+        OR o.order_no          ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.nickname_snapshot ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.member_id IN (SELECT id FROM qualified_members)
+      )
+  ),
+  tab_counts AS (
+    SELECT
+      count(*) FILTER (WHERE status IN ('pending','confirmed','shipping','ready')) AS pending,
+      count(*) FILTER (WHERE status = 'partially_completed')                       AS partially,
+      count(*) FILTER (WHERE status = 'completed')                                 AS completed,
+      count(*) FILTER (WHERE status IN ('cancelled','expired'))                    AS cancelled,
+      count(*) FILTER (WHERE status = 'transferred_out')                           AS transferred
+    FROM filtered
+  ),
+  trend_orders AS (
+    SELECT
+      f.id,
+      f.member_id,
+      to_char((f.created_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd
+    FROM filtered f
+    WHERE f.status NOT IN ('cancelled','expired','transferred_out')
+      AND f.created_at >= p_month_start
+  ),
+  order_amt AS (
+    SELECT i.order_id, SUM(i.qty * i.unit_price)::numeric AS amount
+    FROM customer_order_items i
+    JOIN trend_orders t ON t.id = i.order_id
+    GROUP BY i.order_id
+  ),
+  day_agg AS (
+    SELECT
+      t.ymd,
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+    GROUP BY t.ymd
+  ),
+  total_agg AS (
+    SELECT
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+  )
+  SELECT jsonb_build_object(
+    'tab_counts', (SELECT to_jsonb(tab_counts.*) FROM tab_counts),
+    'trend_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'members', members, 'amount', amount
+                ) ORDER BY ymd)
+       FROM day_agg),
+      '[]'::jsonb
+    ),
+    'trend_total', (SELECT to_jsonb(total_agg.*) FROM total_agg)
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_order_overview(bigint[], bigint, text, timestamptz) TO authenticated;


### PR DESCRIPTION
## 問題
訂單頁（`/orders`）讀取很慢。

## 根因
頁面 mount 時瀏覽器端做兩件重活：
1. **KPI 趨勢卡** — chunked fetch 把「整月所有訂單（最多 5 萬筆）+ 全部 `order_items`」搬回瀏覽器再 client 聚合，一個月幾千～幾萬筆訂單時是數 MB 傳輸 + 大量計算，並跟列表查詢搶連線/頻寬。
2. **Tab 數量** — 5 個 `count:exact` 全表掃描並發跑。

## 修法
照 `rpc_orders_pivot` 的 `RETURNS jsonb` 範本，新增 **`rpc_order_overview`**，把 tab 數量 + 每日趨勢 + 本月累計合併成**單一伺服端聚合、一次 round-trip**（jsonb 單一 row 不受 PostgREST `max_rows=1000` 截斷）。瀏覽器不再搬原始資料。

對齊既有 client 行為（輸出數字不變）：
- campaign / 取貨店 篩選
- keyword：與 `buildKeywordOr` 同語意（每 token 都要在 name/phone/member_no 命中的 token-AND，或整串命中 order_no/nickname_snapshot）
- 趨勢只計有效成交（排除 cancelled/expired/transferred_out），日界以 Asia/Taipei 切
- 移除已無意義的「已截斷 20000 筆」警示（伺服端聚合無 row cap）

## 部署 / 驗證
- migration `20260708000010_rpc_order_overview.sql` **已套上 prod**
- REST anon probe：`POST /rest/v1/rpc/rpc_order_overview` → HTTP 200，JSON shape 正確（anon 受 RLS 回 0，符合預期）
- `tsc --noEmit`：`orders/page.tsx` 無錯誤
- RPC 與既有 list/pivot 走相同 RLS 路徑（無 SECURITY DEFINER），admin 取數一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)