### PR TITLE
perf(wms): 進貨待辦清單改伺服端 RPC，加速讀取

### DIFF
--- a/apps/admin/src/app/(protected)/wms/receiving/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/receiving/page.tsx
@@ -58,86 +58,25 @@ export default function ReceivingWorkbenchPage() {
     let cancelled = false;
     (async () => {
       try {
+        // 單一伺服端聚合 RPC（取代之前瀏覽器端跨 6 表 client join + 撈整張
+        // restock_requests）。回傳已算好的 PORow[]，一次 round-trip。
         const sb = getSupabase();
-        const { data: poData, error: e } = await sb
-          .from("purchase_orders")
-          .select("id, po_no, status, sent_at, supplier_id")
-          .in("status", ["sent", "partially_received", "fully_received"])
-          .order("sent_at", { ascending: false, nullsFirst: false })
-          .limit(200);
+        const { data, error: e } = await sb.rpc("rpc_receiving_workbench");
         if (e) throw new Error(e.message);
-        const pos = (poData ?? []) as Array<Pick<PORow, "id" | "po_no" | "status" | "sent_at" | "supplier_id">>;
-
-        if (pos.length === 0) {
-          if (!cancelled) { setRows([]); setError(null); }
-          return;
-        }
-
-        const poIds = pos.map((p) => p.id);
-        const supplierIds = Array.from(new Set(pos.map((p) => p.supplier_id)));
-
-        const [{ data: supRows }, { data: poiRows }, { data: griRows }] = await Promise.all([
-          sb.from("suppliers").select("id, code, name").in("id", supplierIds),
-          sb.from("purchase_order_items").select("id, po_id, qty_ordered").in("po_id", poIds),
-          sb.from("goods_receipt_items")
-            .select("po_item_id, qty_received, gr:goods_receipts!inner(po_id, status)")
-            .in("gr.po_id", poIds)
-            .eq("gr.status", "confirmed"),
-        ]);
-        // 偵測 restock-sourced
-        const { data: restockPos } = await sb
-          .from("restock_requests")
-          .select("linked_pr_id")
-          .not("linked_pr_id", "is", null);
-        const restockPrIds = new Set(((restockPos ?? []) as { linked_pr_id: number }[]).map((r) => r.linked_pr_id));
-        const { data: priRows } = await sb
-          .from("purchase_request_items")
-          .select("po_item_id, pr_id")
-          .in("po_item_id", (poiRows ?? []).map((p: { id: number }) => p.id));
-        const restockPoItemIds = new Set(
-          ((priRows ?? []) as { po_item_id: number | null; pr_id: number }[])
-            .filter((r) => r.po_item_id !== null && restockPrIds.has(r.pr_id))
-            .map((r) => r.po_item_id as number),
-        );
-
-        const supMap = new Map<number, { code: string | null; name: string }>();
-        for (const s of (supRows ?? []) as { id: number; code: string | null; name: string }[]) supMap.set(s.id, { code: s.code, name: s.name });
-
-        const poiByPo = new Map<number, { id: number; qty_ordered: number }[]>();
-        for (const it of (poiRows ?? []) as { id: number; po_id: number; qty_ordered: number }[]) {
-          const arr = poiByPo.get(it.po_id) ?? [];
-          arr.push(it);
-          poiByPo.set(it.po_id, arr);
-        }
-
-        const grByPoItem = new Map<number, number>();
-        for (const it of ((griRows ?? []) as Array<{ po_item_id: number; qty_received: number }>)) {
-          grByPoItem.set(it.po_item_id, (grByPoItem.get(it.po_item_id) ?? 0) + Number(it.qty_received));
-        }
-
-        const result: PORow[] = pos.map((po) => {
-          const items = poiByPo.get(po.id) ?? [];
-          const totalOrdered = items.reduce((s, i) => s + Number(i.qty_ordered), 0);
-          const totalReceived = items.reduce((s, i) => s + (grByPoItem.get(i.id) ?? 0), 0);
-          const isRestock = items.some((i) => restockPoItemIds.has(i.id));
-          const sup = supMap.get(po.supplier_id);
-          return {
-            id: po.id,
-            po_no: po.po_no,
-            status: po.status as POStatus,
-            sent_at: po.sent_at,
-            supplier_id: po.supplier_id,
-            supplier_name: sup?.name ?? `#${po.supplier_id}`,
-            supplier_code: sup?.code ?? null,
-            total_qty_ordered: totalOrdered,
-            total_qty_received: totalReceived,
-            line_count: items.length,
-            is_restock: isRestock,
-          };
-        });
-
         if (!cancelled) {
-          setRows(result);
+          setRows(((data ?? []) as Array<Record<string, unknown>>).map((r) => ({
+            id: Number(r.id),
+            po_no: String(r.po_no),
+            status: r.status as POStatus,
+            sent_at: (r.sent_at as string | null) ?? null,
+            supplier_id: Number(r.supplier_id),
+            supplier_name: String(r.supplier_name),
+            supplier_code: (r.supplier_code as string | null) ?? null,
+            total_qty_ordered: Number(r.total_qty_ordered),
+            total_qty_received: Number(r.total_qty_received),
+            line_count: Number(r.line_count),
+            is_restock: Boolean(r.is_restock),
+          })));
           setError(null);
         }
       } catch (err) {

--- a/supabase/migrations/20260708000020_rpc_receiving_workbench.sql
+++ b/supabase/migrations/20260708000020_rpc_receiving_workbench.sql
@@ -1,0 +1,102 @@
+-- ============================================================
+-- rpc_receiving_workbench — admin /wms/receiving 進貨待辦清單聚合
+--
+-- 動機：進貨待辦頁讀取很慢。根因與 /orders 同源 — mount 時瀏覽器端跨
+--   6 張表做 client join、4 個 sequential round-trip 波次，其中
+--   restock_requests 是「無任何篩選撈整張表」(只為算 is_restock)，隨
+--   營運累積越來越慢。
+--
+-- 修法：照 rpc_orders_pivot / rpc_order_overview 的 RETURNS jsonb 範本，
+--   把整個聚合搬到伺服端、一次 round-trip 回傳 ready-to-render 列。
+--   jsonb 單一 row 不受 PostgREST max_rows=1000 截斷。
+--
+-- 與既有 client 邏輯對齊（輸出不變）：
+--   * 取 status IN (sent, partially_received, fully_received)，sent_at desc，上限 200
+--   * total_qty_received = 來自 status='confirmed' 的 goods_receipt_items 加總
+--     （沿用頁面的 authoritative 算法，不直接讀 poi.qty_received 避免漂移）
+--   * is_restock = PO 任一 po_item 經 purchase_request_items 連到某 pr，
+--     且該 pr 是 restock_requests.linked_pr_id
+--   * 期間 / 狀態 filter 仍由前端對回傳列做（資料量小、即時切換）
+--
+-- 不下 SECURITY DEFINER：沿用 invoker RLS（與既有 client 查詢同一條
+--   tenant 隔離路徑，與 rpc_orders_pivot 一致）。
+--
+-- 基底版本：無（全新 function）
+-- rollback：DROP FUNCTION rpc_receiving_workbench();
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_receiving_workbench()
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH po AS (
+    SELECT p.id, p.po_no, p.status, p.sent_at, p.supplier_id
+    FROM purchase_orders p
+    WHERE p.status IN ('sent','partially_received','fully_received')
+    ORDER BY p.sent_at DESC NULLS LAST
+    LIMIT 200
+  ),
+  poi AS (
+    SELECT i.id, i.po_id, i.qty_ordered
+    FROM purchase_order_items i
+    JOIN po ON po.id = i.po_id
+  ),
+  received AS (
+    -- 已到 = 已確認進貨單的明細加總（po_item 為單位）
+    SELECT gi.po_item_id, SUM(gi.qty_received)::numeric AS qty
+    FROM goods_receipt_items gi
+    JOIN goods_receipts g ON g.id = gi.gr_id
+    JOIN poi ON poi.id = gi.po_item_id
+    WHERE g.status = 'confirmed'
+    GROUP BY gi.po_item_id
+  ),
+  restock_poi AS (
+    -- 來自補貨申請的 po_item（pr 被某 restock_requests linked_pr_id 指向）
+    SELECT DISTINCT pri.po_item_id
+    FROM purchase_request_items pri
+    JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+    WHERE pri.po_item_id IS NOT NULL
+  ),
+  agg AS (
+    SELECT
+      po.id,
+      po.po_no,
+      po.status,
+      po.sent_at,
+      po.supplier_id,
+      s.name                                            AS supplier_name,
+      s.code                                            AS supplier_code,
+      COALESCE(SUM(poi.qty_ordered), 0)::numeric        AS total_qty_ordered,
+      COALESCE(SUM(r.qty), 0)::numeric                  AS total_qty_received,
+      COUNT(poi.id)                                     AS line_count,
+      bool_or(rp.po_item_id IS NOT NULL)                AS is_restock
+    FROM po
+    LEFT JOIN suppliers s ON s.id = po.supplier_id
+    LEFT JOIN poi ON poi.po_id = po.id
+    LEFT JOIN received r ON r.po_item_id = poi.id
+    LEFT JOIN restock_poi rp ON rp.po_item_id = poi.id
+    GROUP BY po.id, po.po_no, po.status, po.sent_at, po.supplier_id, s.name, s.code
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', id,
+        'po_no', po_no,
+        'status', status,
+        'sent_at', sent_at,
+        'supplier_id', supplier_id,
+        'supplier_name', COALESCE(supplier_name, '#' || supplier_id::text),
+        'supplier_code', supplier_code,
+        'total_qty_ordered', total_qty_ordered,
+        'total_qty_received', total_qty_received,
+        'line_count', line_count,
+        'is_restock', COALESCE(is_restock, false)
+      )
+      ORDER BY sent_at DESC NULLS LAST
+    ),
+    '[]'::jsonb
+  )
+  FROM agg;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_receiving_workbench() TO authenticated;


### PR DESCRIPTION
## 問題
進貨待辦頁（`/wms/receiving`）讀取很慢。

## 根因
頁面 mount 時瀏覽器端跨 **6 張表做 client join**，且分成 **4 個 sequential round-trip 波次**。最毒的一段是：

```js
sb.from("restock_requests").select("linked_pr_id").not("linked_pr_id","is",null)  // 無任何篩選 → 撈整張表
```

只為了算每張 PO 的 `is_restock` 標記，就把整張 `restock_requests` 拉到瀏覽器，隨營運累積越來越慢。

## 修法
照 `rpc_order_overview` / `rpc_orders_pivot` 的 `RETURNS jsonb` 範本，新增 **`rpc_receiving_workbench`**，把整個聚合搬到伺服端、**一次 round-trip** 回傳 ready-to-render 的 PO 列。

對齊既有行為（輸出不變）：
- 取 `status IN (sent, partially_received, fully_received)`、`sent_at desc`、上限 200
- `total_qty_received` 沿用 `status='confirmed'` 的 `goods_receipt_items` 加總（authoritative，不直接讀 `poi.qty_received` 避免漂移）
- `is_restock` 走 `purchase_request_items → restock_requests.linked_pr_id` 的 bounded join（不再撈整表）
- 期間 / 狀態 filter 仍由前端對回傳列即時切換

## 部署 / 驗證
- migration `20260708000020_rpc_receiving_workbench.sql` **已套上 prod**
- REST anon probe：`POST /rest/v1/rpc/rpc_receiving_workbench` → HTTP 200（anon 受 RLS 回 `[]`，符合預期）
- `tsc --noEmit`：`wms/receiving/page.tsx` 無錯誤
- RPC 不下 SECURITY DEFINER，沿用 invoker RLS（與既有 client 查詢同一條 tenant 隔離路徑）

🤖 Generated with [Claude Code](https://claude.com/claude-code)