### PR TITLE
fix(admin): favicon 補 basePath，修 GH Pages 分頁黑 icon

### DIFF
--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -22,21 +22,26 @@ const handScript = Caveat({
   weight: ["700"],
 });
 
+// Next 不會自動把 basePath 補到 metadata.icons 的字串 URL，靜態匯出 + GH Pages
+// （NEXT_PUBLIC_BASE_PATH=/new_erp）下會變成 /icons/... → 404 → 分頁退回預設黑 icon。
+// 一律手動補 prefix。
+const bp = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
 export const metadata: Metadata = {
   title: getAdminTitle(),
   description: `${getTenantName()} 管理後台`,
   icons: {
     icon: [
-      { url: "/icons/ios/32.png", sizes: "32x32", type: "image/png" },
-      { url: "/icons/ios/16.png", sizes: "16x16", type: "image/png" },
-      { url: "/icons/android/launchericon-192x192.png", sizes: "192x192", type: "image/png" },
-      { url: "/icons/android/launchericon-512x512.png", sizes: "512x512", type: "image/png" },
+      { url: `${bp}/icons/ios/32.png`, sizes: "32x32", type: "image/png" },
+      { url: `${bp}/icons/ios/16.png`, sizes: "16x16", type: "image/png" },
+      { url: `${bp}/icons/android/launchericon-192x192.png`, sizes: "192x192", type: "image/png" },
+      { url: `${bp}/icons/android/launchericon-512x512.png`, sizes: "512x512", type: "image/png" },
     ],
     apple: [
-      { url: "/icons/ios/120.png", sizes: "120x120" },
-      { url: "/icons/ios/152.png", sizes: "152x152" },
-      { url: "/icons/ios/167.png", sizes: "167x167" },
-      { url: "/icons/ios/180.png", sizes: "180x180" },
+      { url: `${bp}/icons/ios/120.png`, sizes: "120x120" },
+      { url: `${bp}/icons/ios/152.png`, sizes: "152x152" },
+      { url: `${bp}/icons/ios/167.png`, sizes: "167x167" },
+      { url: `${bp}/icons/ios/180.png`, sizes: "180x180" },
     ],
   },
 };


### PR DESCRIPTION
## 變更內容

修 admin 後台分頁 favicon 一直顯示**預設黑 icon** 的問題。

### 根因
`layout.tsx` 的 `metadata.icons` URL 寫死 `/icons/...`，但 Next **不會**自動把 basePath 補到 metadata icon 的字串 URL。GH Pages 部署 `NEXT_PUBLIC_BASE_PATH=/new_erp` 下，`<link rel=icon>` 變成 `/icons/ios/32.png`（少了 `/new_erp`）→ 404 → 瀏覽器退回預設黑塊。

實測：
- `https://lt-foods.github.io/icons/ios/32.png` → **404**
- `https://lt-foods.github.io/new_erp/icons/ios/32.png` → **200**

### 修法
以 `process.env.NEXT_PUBLIC_BASE_PATH` 前綴每個 icon URL。本地 dev（basePath 空）維持 `/icons/...` 不變。

## 背景
圖示本身（完整方形包子媽 logo）已隨 #456 進 main，但 #456 squash-merge 時漏掉了這個 basePath commit，故另開此 PR 補上。沒有這支，#456 換的圖在線上仍因 404 顯示不出來。

## Reviewer 須知
- 純 `layout.tsx` 一檔、13 行。
- member 未設 basePath、部署於根路徑，無此問題，未動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
