### PR TITLE
perf(wms): 收貨待辦消除 N+1（campaign 查詢改批次 RPC）

### DIFF
--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -172,18 +172,21 @@ export default function TransfersInboxPage() {
         }
 
         // 抓每張 transfer 涵蓋的 campaign_ids（用於 /orders link 多選 filter）
+        // 批次：一次傳全部 transfer id、回 { transfer_id: [campaign_ids] }，
+        // 取代之前每張 transfer 各打一次 RPC（N+1，開頁 ~50+ round-trip）。
         const tcMap = new Map<number, number[]>();
-        await Promise.allSettled(
-          rows.map(async (r) => {
-            const { data: cs } = await sb.rpc("rpc_get_campaigns_for_transfer", {
-              p_transfer_id: r.id,
-            });
-            const ids = ((cs as { campaign_id: number }[] | null) ?? [])
-              .map((x) => Number(x.campaign_id))
+        if (rows.length > 0) {
+          const { data: tcData } = await sb.rpc("rpc_get_campaigns_for_transfers", {
+            p_transfer_ids: rows.map((r) => r.id),
+          });
+          const obj = (tcData as Record<string, unknown> | null) ?? {};
+          for (const [tid, cids] of Object.entries(obj)) {
+            const ids = (Array.isArray(cids) ? cids : [])
+              .map((x) => Number(x))
               .filter((x) => Number.isFinite(x));
-            tcMap.set(r.id, ids);
-          }),
-        );
+            tcMap.set(Number(tid), ids);
+          }
+        }
 
         if (!cancelled) {
           setTransfers(rows);

--- a/supabase/migrations/20260708000030_rpc_campaigns_for_transfers_batch.sql
+++ b/supabase/migrations/20260708000030_rpc_campaigns_for_transfers_batch.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- rpc_get_campaigns_for_transfers — rpc_get_campaigns_for_transfer 的批次版
+--
+-- 動機：/wms/inbound（📦 收貨待辦）讀取很慢。根因是 client 對每張 transfer
+--   各打一次 rpc_get_campaigns_for_transfer（N+1，開頁 ~50+ round-trip）。
+--   改成一次傳全部 transfer id、回 { transfer_id: [campaign_ids] }，併成 1 次。
+--
+-- 邏輯與 rpc_get_campaigns_for_transfer v2 (20260516000007) 完全一致，
+-- 只是把單筆改成依 transfer 分組的批次：
+--   路徑1：dest store + 該 transfer 的 sku → customer_orders.campaign_id
+--   路徑2：aid transfer 直接帶 customer_order_id → campaign_id
+-- 同樣 SECURITY DEFINER（與單筆版同等暴露面；前端只傳自己 RLS 撈到的 transfer）。
+--
+-- 基底版本：rpc_get_campaigns_for_transfer v2 (20260516000007) 的查詢邏輯
+-- rollback：DROP FUNCTION rpc_get_campaigns_for_transfers(bigint[]);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_get_campaigns_for_transfers(
+  p_transfer_ids BIGINT[]
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  WITH t AS (
+    SELECT id, customer_order_id, dest_location, tenant_id
+      FROM transfers
+     WHERE id = ANY(p_transfer_ids)
+  ),
+  ti AS (
+    SELECT DISTINCT transfer_id, sku_id
+      FROM transfer_items
+     WHERE transfer_id = ANY(p_transfer_ids)
+  ),
+  from_co_match AS (
+    -- 從 dest store + 該 transfer 的 sku 對到的 customer_orders.campaign_id
+    SELECT DISTINCT t.id AS transfer_id, co.campaign_id
+      FROM t
+      JOIN stores s
+        ON s.location_id = t.dest_location AND s.tenant_id = t.tenant_id
+      JOIN customer_orders co
+        ON co.pickup_store_id = s.id
+       AND COALESCE(co.order_kind, 'normal') = 'normal'
+      JOIN customer_order_items coi ON coi.order_id = co.id
+      JOIN ti ON ti.transfer_id = t.id AND ti.sku_id = coi.sku_id
+     WHERE co.campaign_id IS NOT NULL
+  ),
+  from_aid AS (
+    -- aid transfer 直接帶 customer_order_id
+    SELECT DISTINCT t.id AS transfer_id, co.campaign_id
+      FROM t
+      JOIN customer_orders co ON co.id = t.customer_order_id
+     WHERE co.campaign_id IS NOT NULL
+  ),
+  unioned AS (
+    SELECT transfer_id, campaign_id FROM from_co_match
+    UNION
+    SELECT transfer_id, campaign_id FROM from_aid
+  ),
+  per_transfer AS (
+    SELECT transfer_id, jsonb_agg(DISTINCT campaign_id) AS cids
+      FROM unioned
+     GROUP BY transfer_id
+  )
+  SELECT COALESCE(jsonb_object_agg(transfer_id::text, cids), '{}'::jsonb)
+    FROM per_transfer;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_get_campaigns_for_transfers(BIGINT[]) TO authenticated;


### PR DESCRIPTION
## 問題
`/wms/inbound`（📦 **收貨待辦**）開頁很慢——這才是當初「收貨頁很慢」真正指的頁面。

## 根因（N+1）
資料載入時對**每一張 transfer 各打一次** `rpc_get_campaigns_for_transfer`：

```js
await Promise.allSettled(
  rows.map((r) => sb.rpc("rpc_get_campaigns_for_transfer", { p_transfer_id: r.id }))
);
```

待收 + 已收一開頁就 ~50+ 筆 → **50+ 個 RPC round-trip**。

## 修法
新增批次版 **`rpc_get_campaigns_for_transfers(bigint[])`**，一次傳全部 transfer id、回 `{ transfer_id: [campaign_ids] }`，client 改成**單一呼叫**。50+ round-trip → 1 次。

- 查詢邏輯與單筆版 v2（`20260516000007`）**完全一致**：dest store + 該 transfer 的 sku → `customer_orders.campaign_id`，以及 aid transfer 直帶 `customer_order_id` 兩條路徑，依 transfer 分組。
- 同 `SECURITY DEFINER`（與單筆版同等暴露面）。

## 部署 / 驗證
- migration `20260708000030_rpc_campaigns_for_transfers_batch.sql` **已套上 prod**
- REST anon probe：`POST /rest/v1/rpc/rpc_get_campaigns_for_transfers` → HTTP 200
- `tsc --noEmit`：`wms/inbound/page.tsx` 無錯誤

## 與其他 PR 的關係
- 與 [#462](https://github.com/lt-foods/new_erp/pull/462)（本頁分頁）改的是同檔不同區段（本 PR 改資料載入、#462 改 UI/篩選），兩者 base 都是 `main`、可獨立 merge（合併時自動 3-way merge，不衝突）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)