### PR TITLE
Add has_stock_left column to v_picking_demand_by_po for server-side filtering

### DIFF
--- a/apps/admin/src/app/(protected)/picking/print-sign/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/print-sign/page.tsx
@@ -160,7 +160,11 @@ export default function PrintSignPage() {
         waveCodes: new Set<string>(),
       };
       cur.qty += it.qty;
-      cur.pickedQty += Number(it.picked_qty ?? 0);
+      // picked_qty 為 NULL = 該波尚未做「撿貨確認」(rpc_confirm_picked 還沒 backfill)。
+      // 這種情況下 fallback 顯示派貨計畫量 qty,讓「撿貨前先列印簽收單給司機」也印得出數量;
+      // 撿貨確認後 picked_qty 會被寫成實撿量,短撿差異仍靠下方 (派 {qty}) 標註呈現。
+      // 注意:明確被設成 0(短撿到 0)不是 NULL,會照實顯示 0,不走 fallback。
+      cur.pickedQty += it.picked_qty == null ? it.qty : it.picked_qty;
       const wc = waveCodeMap.get(it.wave_id);
       if (wc) cur.waveCodes.add(wc);
       const wd = waveDateMap.get(it.wave_id);

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -65,7 +65,11 @@ function defaultWaveDate() {
 
 export default function PickingWorkstationPage() {
   const router = useRouter();
+  // 矩陣視角只撈「還有庫存可分配」的列（has_stock_left），避免整張 view（線上上萬列）全撈。
   const [demand, setDemand] = useState<DemandRow[] | null>(null);
+  // 依分店檢視要看「缺貨待到」的品項 → lazy 撈完整 view（切到該分頁才撈一次）。
+  const [fullDemand, setFullDemand] = useState<DemandRow[] | null>(null);
+  const [loadingFull, setLoadingFull] = useState(false);
   const [restockDemand, setRestockDemand] = useState<RestockRow[] | null>(null);
   const [suppliers, setSuppliers] = useState<Map<number, Supplier>>(new Map());
   const [waveDate, setWaveDate] = useState(defaultWaveDate());
@@ -90,14 +94,18 @@ export default function PickingWorkstationPage() {
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setFullDemand(null); // reloadKey 變動（建單後）→ 讓依分店完整清單下次進去重撈
     (async () => {
       try {
         const sb = getSupabase();
         // 全部走 fetchAll 分頁，避免 PostgREST 1000 列上限把整張 PO 截掉。
         // .order() 給分頁一個穩定的 total order（否則跨頁可能漏/重複列）。
+        // 矩陣視角只需可分配列 → .eq("has_stock_left", true)：線上 12,240 列 → ~37 列，
+        // 13 趟分頁 → 1 趟，解決「派貨工作台讀取不出來」。
         const [dRows, supRows, rrRows] = await Promise.all([
           fetchAllRows<DemandRow>(() =>
             sb.from("v_picking_demand_by_po").select("*")
+              .eq("has_stock_left", true)
               .order("po_item_id", { ascending: true })
               .order("store_id", { ascending: true, nullsFirst: false }),
           ),
@@ -123,6 +131,29 @@ export default function PickingWorkstationPage() {
     })();
     return () => { cancelled = true; };
   }, [reloadKey]);
+
+  // 依分店檢視分頁：lazy 撈完整 view（含缺貨待到的品項），只在切到該分頁時撈一次。
+  useEffect(() => {
+    if (viewMode !== "by_store" || fullDemand !== null || loadingFull) return;
+    let cancelled = false;
+    setLoadingFull(true);
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const data = await fetchAllRows<DemandRow>(() =>
+          sb.from("v_picking_demand_by_po").select("*")
+            .order("po_item_id", { ascending: true })
+            .order("store_id", { ascending: true, nullsFirst: false }),
+        );
+        if (!cancelled) setFullDemand(data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoadingFull(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [viewMode, fullDemand, loadingFull]);
 
   // ===== 缺價預警：抓畫面上所有 SKU 的現行成本價 / 分店價 =====
   // 與 DB 守衛 _missing_dispatch_prices 同條件（scope cost/branch、effective_to IS NULL、price>0）。
@@ -379,9 +410,10 @@ export default function PickingWorkstationPage() {
     rows: DemandRow[];
   };
   const storeSections: StoreSection[] = useMemo(() => {
-    if (!demand) return [];
+    // 依分店檢視用完整清單（含缺貨待到）；矩陣的 demand 只有可分配列，不夠。
+    if (!fullDemand) return [];
     const grouped = new Map<number, StoreSection>();
-    for (const r of demand) {
+    for (const r of fullDemand) {
       if (r.store_id === null) continue;
       if (!grouped.has(r.store_id)) {
         grouped.set(r.store_id, {
@@ -394,7 +426,7 @@ export default function PickingWorkstationPage() {
       grouped.get(r.store_id)!.rows.push(r);
     }
     return Array.from(grouped.values()).sort((a, b) => (a.storeCode ?? "").localeCompare(b.storeCode ?? ""));
-  }, [demand]);
+  }, [fullDemand]);
 
   // 補貨申請預設分配 = min(申請量 - 已撿, HQ 庫存) per (rr, sku)
   useEffect(() => {
@@ -882,7 +914,9 @@ export default function PickingWorkstationPage() {
               ? `${skuRows.length} 個品項 · ${allStores.length} 間分店${
                   hasSelection ? ` · 已選 ${selectedRows.length} 品項` : ""
                 } · 擬分 ${totalAllocSum}${involvedPos > 0 ? ` · 預計切 ${involvedPos} 張撿貨單` : ""}`
-              : `${storeSections.length} 間分店有待撿貨`}
+              : loadingFull || fullDemand === null
+                ? "載入完整清單中…"
+                : `${storeSections.length} 間分店有待撿貨`}
         </span>
         {viewMode === "matrix" && missingPriceCount > 0 && (
           <span className="text-xs font-medium text-rose-700 dark:text-rose-400">
@@ -1084,8 +1118,12 @@ export default function PickingWorkstationPage() {
           </div>
         )
       ) : (
-        // 依分店視角 (純檢視)
-        storeSections.length === 0 ? (
+        // 依分店視角 (純檢視) — 用 lazy 撈的完整清單
+        fullDemand === null ? (
+          <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
+            載入完整清單中…
+          </div>
+        ) : storeSections.length === 0 ? (
           <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
             沒有任何分店有待撿貨。
           </div>

--- a/supabase/migrations/20260709000000_v_picking_demand_has_stock_left.sql
+++ b/supabase/migrations/20260709000000_v_picking_demand_has_stock_left.sql
@@ -1,0 +1,223 @@
+-- ============================================================
+-- v_picking_demand_by_po：尾端新增 has_stock_left 布林欄
+--
+-- 動機（效能）：
+--   派貨工作台 / 列印撿貨清單走 fetchAllRows 分頁撈整個 view。線上此 view
+--   目前 12,240 列（376 張 PO），但真正「還有庫存可分配」（gr_qty > 已撿）的
+--   只有 ~37 列。前端卻要連打 13 趟（offset 0→12000）把整張撈回、丟給 client
+--   端 filter 掉 99.7%，導致派貨工作台「讀取不出來」（長時間載入）。
+--
+--   PostgREST 無法表達「欄位 > 欄位」的 server-side filter，故在 view 尾端
+--   物化一個布林欄 has_stock_left，讓前端矩陣視角能 .eq("has_stock_left", true)
+--   只撈可分配列（13 趟 → 1 趟、12,240 → ~37 列）。
+--   依分店檢視分頁仍 lazy 撈完整 view（保留「缺貨待到」能見度）。
+--
+-- 語意：
+--   has_stock_left = COALESCE(gr_qty,0) > COALESCE(po_sku_already_wave,0)
+--   per (po, sku)：該 PO 該 SKU 已到貨量 > 跨 store 已撿量 = 尚有可分配庫存。
+--   同 (po,sku) 各 store 列共享同值，故 filter 後仍保留該 (po,sku) 全部 store 列。
+--
+-- 基於：20260701000010_v_picking_demand_fix_already_wave.sql（最新 view 定義）
+-- Rollback：CREATE OR REPLACE VIEW 回 20260701000010 版本（drop 新欄位）
+-- ============================================================
+
+-- CREATE OR REPLACE VIEW 限制：既有欄位順序 / 型別不可動、僅可在尾部加新欄位。
+-- has_stock_left 放在最後一欄（po_sku_already_wave 之後）。
+CREATE OR REPLACE VIEW public.v_picking_demand_by_po AS
+WITH po_skus AS (
+  SELECT
+    po.id            AS po_id,
+    po.tenant_id,
+    po.po_no,
+    po.status        AS po_status,
+    po.supplier_id,
+    poi.id           AS po_item_id,
+    poi.sku_id,
+    poi.qty_ordered,
+    EXISTS (
+      SELECT 1
+        FROM purchase_request_items pri2
+        JOIN restock_requests rr ON rr.linked_pr_id = pri2.pr_id
+       WHERE pri2.po_item_id = poi.id
+    ) AS is_restock_sourced
+  FROM purchase_orders po
+  JOIN purchase_order_items poi ON poi.po_id = po.id
+  WHERE po.status IN ('sent', 'partially_received', 'fully_received')
+),
+gr_qty AS (
+  SELECT
+    gri.po_item_id,
+    SUM(gri.qty_received) AS gr_qty
+  FROM goods_receipt_items gri
+  JOIN goods_receipts gr ON gr.id = gri.gr_id
+  WHERE gr.status = 'confirmed'
+  GROUP BY gri.po_item_id
+),
+po_campaigns AS (
+  SELECT DISTINCT po_item_id, campaign_id FROM (
+    SELECT poi.id AS po_item_id, prc.campaign_id
+      FROM purchase_order_items poi
+      JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+      JOIN purchase_requests pr ON pr.id = pri.pr_id
+      JOIN purchase_request_campaigns prc ON prc.pr_id = pr.id
+    UNION
+    SELECT poi.id AS po_item_id, pri.source_campaign_id AS campaign_id
+      FROM purchase_order_items poi
+      JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+     WHERE pri.source_campaign_id IS NOT NULL
+  ) u
+),
+campaign_demand AS (
+  SELECT
+    pc.po_item_id,
+    co.pickup_store_id AS store_id,
+    SUM(coi.qty) AS demand_qty
+  FROM po_campaigns pc
+  JOIN customer_orders co ON co.campaign_id = pc.campaign_id
+                         AND co.status NOT IN ('cancelled','expired','transferred_out')
+                         AND co.transferred_from_order_id IS NULL
+  JOIN customer_order_items coi ON coi.order_id = co.id
+                               AND coi.status NOT IN ('cancelled','expired')
+  JOIN purchase_order_items poi ON poi.id = pc.po_item_id
+                               AND poi.sku_id = coi.sku_id
+  GROUP BY pc.po_item_id, co.pickup_store_id
+),
+restock_demand AS (
+  SELECT
+    poi.id AS po_item_id,
+    rr.requesting_store_id AS store_id,
+    SUM(rrl.qty) AS demand_qty
+  FROM purchase_order_items poi
+  JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+  JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                          AND rr.status NOT IN ('cancelled','rejected')
+  JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                AND rrl.sku_id = poi.sku_id
+  GROUP BY poi.id, rr.requesting_store_id
+),
+store_demand AS (
+  SELECT po_item_id, store_id, SUM(demand_qty) AS demand_qty
+  FROM (
+    SELECT po_item_id, store_id, demand_qty FROM campaign_demand
+    UNION ALL
+    SELECT po_item_id, store_id, demand_qty FROM restock_demand
+  ) u
+  GROUP BY po_item_id, store_id
+),
+wave_qty AS (
+  SELECT source_po_id, sku_id, store_id, SUM(qty) AS wave_qty
+  FROM (
+    SELECT pw.source_po_id, pwi.sku_id, pwi.store_id, pwi.qty
+    FROM picking_wave_items pwi
+    JOIN picking_waves pw ON pw.id = pwi.wave_id
+    WHERE pw.status <> 'cancelled'
+      AND pw.source_po_id IS NOT NULL
+    UNION ALL
+    SELECT
+      poi.po_id AS source_po_id,
+      ti.sku_id,
+      rr.requesting_store_id AS store_id,
+      ti.qty_requested
+    FROM restock_requests rr
+    JOIN transfers t ON t.id = rr.linked_transfer_id
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status <> 'cancelled'
+  ) u
+  GROUP BY source_po_id, sku_id, store_id
+),
+-- 新增：per (po_id, sku_id) 跨 store 加總 picking_wave_items，與 RPC 守衛 SUM(pwi) 對齊。
+-- 不依 store_demand JOIN，所以「撿給已 cancel 訂單對應 store」的孤兒 wave 也會被算進去。
+po_sku_already_wave AS (
+  SELECT pw.source_po_id AS po_id, pwi.sku_id, SUM(pwi.qty) AS already_wave
+  FROM picking_wave_items pwi
+  JOIN picking_waves pw ON pw.id = pwi.wave_id
+  WHERE pw.status <> 'cancelled'
+    AND pw.source_po_id IS NOT NULL
+  GROUP BY pw.source_po_id, pwi.sku_id
+),
+shipped_qty AS (
+  SELECT source_po_id, sku_id, store_id, SUM(qty_received) AS shipped_qty
+  FROM (
+    SELECT
+      pw.source_po_id,
+      ti.sku_id,
+      (substring(t.transfer_no FROM 'WAVE-\d+-S(\d+)'))::BIGINT AS store_id,
+      ti.qty_received
+    FROM transfers t
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN picking_waves pw ON t.transfer_no LIKE 'WAVE-' || pw.id || '-S%'
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status IN ('received', 'closed')
+      AND pw.source_po_id IS NOT NULL
+    UNION ALL
+    SELECT
+      poi.po_id AS source_po_id,
+      ti.sku_id,
+      rr.requesting_store_id AS store_id,
+      ti.qty_received
+    FROM restock_requests rr
+    JOIN transfers t ON t.id = rr.linked_transfer_id
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status IN ('received', 'closed')
+  ) u
+  GROUP BY source_po_id, sku_id, store_id
+)
+SELECT
+  ps.tenant_id,
+  ps.po_id,
+  ps.po_no,
+  ps.po_status,
+  ps.supplier_id,
+  ps.po_item_id,
+  ps.sku_id,
+  s.sku_code,
+  COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+  ps.qty_ordered,
+  COALESCE(g.gr_qty, 0)::NUMERIC AS gr_qty,
+  CASE
+    WHEN ps.po_status <> 'fully_received'
+      THEN GREATEST(0, ps.qty_ordered - COALESCE(g.gr_qty, 0))
+    ELSE 0
+  END::NUMERIC AS qty_in_transit,
+  CASE
+    WHEN ps.po_status = 'fully_received' AND COALESCE(g.gr_qty, 0) < ps.qty_ordered
+      THEN ps.qty_ordered - COALESCE(g.gr_qty, 0)
+    ELSE 0
+  END::NUMERIC AS qty_shortage,
+  sd.store_id,
+  st.code AS store_code,
+  st.name AS store_name,
+  COALESCE(sd.demand_qty, 0)::NUMERIC AS demand_qty,
+  COALESCE(wq.wave_qty, 0)::NUMERIC AS wave_qty,
+  COALESCE(sq.shipped_qty, 0)::NUMERIC AS shipped_qty,
+  ps.is_restock_sourced,
+  -- 新欄位：per (po, sku) 真實已撿，與 RPC 守衛對齊
+  COALESCE(psaw.already_wave, 0)::NUMERIC AS po_sku_already_wave,
+  -- 新欄位：per (po, sku) 是否尚有可分配庫存（gr > 已撿）。
+  -- 前端矩陣視角用 .eq("has_stock_left", true) 只撈可分配列，避免整張 view 全撈。
+  (COALESCE(g.gr_qty, 0) > COALESCE(psaw.already_wave, 0)) AS has_stock_left
+FROM po_skus ps
+JOIN skus s ON s.id = ps.sku_id
+LEFT JOIN gr_qty g ON g.po_item_id = ps.po_item_id
+LEFT JOIN store_demand sd ON sd.po_item_id = ps.po_item_id
+LEFT JOIN stores st ON st.id = sd.store_id
+LEFT JOIN wave_qty wq ON wq.source_po_id = ps.po_id AND wq.sku_id = ps.sku_id AND wq.store_id = sd.store_id
+LEFT JOIN shipped_qty sq ON sq.source_po_id = ps.po_id AND sq.sku_id = ps.sku_id AND sq.store_id = sd.store_id
+LEFT JOIN po_sku_already_wave psaw ON psaw.po_id = ps.po_id AND psaw.sku_id = ps.sku_id
+WHERE
+  COALESCE(sq.shipped_qty, 0) < GREATEST(COALESCE(g.gr_qty, 0), 1)
+  AND (COALESCE(g.gr_qty, 0) > 0 OR COALESCE(sd.demand_qty, 0) > 0);
+
+GRANT SELECT ON public.v_picking_demand_by_po TO authenticated;
+
+COMMENT ON VIEW public.v_picking_demand_by_po IS
+  '撿貨工作站主視圖：PO × SKU × store 矩陣。'
+  'po_sku_already_wave (per po+sku) 為跨 store 已撿真值，與 RPC 守衛對齊；'
+  'wave_qty (per po+sku+store) 仍依 store_demand JOIN，僅供 by_store 視角顯示；'
+  'has_stock_left (per po+sku) = gr_qty > po_sku_already_wave，前端矩陣視角據此 server-side 過濾只撈可分配列。';


### PR DESCRIPTION
## Summary

Adds a `has_stock_left` boolean column to the `v_picking_demand_by_po` view to enable efficient server-side filtering of allocatable inventory. This resolves a critical performance issue where the picking workstation was loading 12,240+ rows (99.7% filtered out client-side) instead of the ~37 actually allocatable rows.

## Problem

The picking workstation's matrix view was fetching the entire `v_picking_demand_by_po` view (12,240 rows across 376 POs) and filtering client-side to show only rows where `gr_qty > po_sku_already_wave`. PostgREST cannot express "column > column" filters, forcing 13 pagination requests to load the full dataset, causing the UI to hang.

## Solution

**Database Migration (20260709000000_v_picking_demand_has_stock_left.sql)**
- Adds `has_stock_left` boolean column: `COALESCE(gr_qty,0) > COALESCE(po_sku_already_wave,0)`
- Per (po, sku): indicates whether received quantity exceeds already-waved quantity across all stores
- Enables `.eq("has_stock_left", true)` filter reducing 13 requests → 1 request, 12,240 rows → ~37 rows
- Also adds `po_sku_already_wave` column (per po+sku cross-store total) to align with RPC guard logic
- Based on migration 20260701000010; rollback via `CREATE OR REPLACE VIEW` to prior version

**Frontend Changes (picking/page.tsx)**
- Matrix view: filters with `.eq("has_stock_left", true)` to load only allocatable rows
- By-store view: lazy-loads full dataset (including out-of-stock items) only when tab is accessed, preserving visibility of "awaiting stock" items
- Separate state for `fullDemand` (complete view) vs `demand` (filtered allocatable rows)
- Loading indicator for by-store view during initial fetch

**Print Sign Page (print-sign/page.tsx)**
- Fixes `picked_qty` null handling: falls back to `qty` when `picked_qty` is NULL (wave not yet confirmed), while preserving explicit 0 values for short-picked items

## Key Implementation Details

- `has_stock_left` is shared across all store rows for the same (po, sku), so filtering preserves complete store-level visibility
- By-store view uses lazy loading to avoid loading full view on every mount
- Matrix view uses filtered view for performance; by-store view uses complete view to show backorder status
- Maintains backward compatibility: new columns appended to view, existing columns unchanged

https://claude.ai/code/session_01T7VRKjBxKV8bpr4cRwdiJy