### PR TITLE
change(picking): 派貨工作台配送日預設改為隔天

### DIFF
--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -59,7 +59,7 @@ type RestockRow = {
 
 function defaultWaveDate() {
   const d = new Date();
-  d.setDate(d.getDate() + 2);
+  d.setDate(d.getDate() + 1); // 預設配送日 = 隔天
   return d.toLocaleDateString("sv-SE");
 }
 


### PR DESCRIPTION
## 變更

派貨工作台（`wms/picking`）進入時的「配送日」預設值，從 **+2 天** 改為 **+1 天（隔天）**。

- 只影響進工作台時的預設值；使用者仍可用日期選擇器改成任意日期。
- 單一改動：`defaultWaveDate()` 的 `getDate() + 2` → `getDate() + 1`。

## 背景

從 PR #465 拆出來的獨立改動——#465 已合併（簽收單數量 fallback + 派貨工作台效能），此配送日調整與那些議題無關，故單獨開 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7VRKjBxKV8bpr4cRwdiJy)_