### PR TITLE
feat(print-sign): 分店簽收單表格拆出訂購數量／配發數量兩欄

### DIFF
--- a/apps/admin/src/app/(protected)/picking/print-sign/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/print-sign/page.tsx
@@ -386,7 +386,8 @@ export default function PrintSignPage() {
                   <th className="border border-zinc-400 px-2 py-1.5 text-left text-xs">#</th>
                   <th className="border border-zinc-400 px-2 py-1.5 text-left text-xs">商品編號</th>
                   <th className="border border-zinc-400 px-2 py-1.5 text-left text-xs">品名</th>
-                  <th className="border border-zinc-400 px-2 py-1.5 text-right text-xs">數量</th>
+                  <th className="border border-zinc-400 px-2 py-1.5 text-right text-xs">訂購數量</th>
+                  <th className="border border-zinc-400 px-2 py-1.5 text-right text-xs">配發數量</th>
                   <th className="border border-zinc-400 px-2 py-1.5 text-center text-xs">收貨確認</th>
                 </tr>
               </thead>
@@ -404,12 +405,12 @@ export default function PrintSignPage() {
                       )}
                     </td>
                     <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono">
-                      {r.pickedQty}
-                      {r.pickedQty < r.qty && (
-                        <span className="ml-1 text-[10px] text-rose-600" title={`原派 ${r.qty}、實撿 ${r.pickedQty}`}>
-                          (派 {r.qty})
-                        </span>
-                      )}
+                      {r.qty}
+                    </td>
+                    <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono">
+                      <span className={r.pickedQty < r.qty ? "text-rose-600" : ""} title={r.pickedQty < r.qty ? `配發 ${r.pickedQty} 少於訂購 ${r.qty}` : undefined}>
+                        {r.pickedQty}
+                      </span>
                     </td>
                     <td className="border border-zinc-400 px-2 py-1.5 text-center">
                       <span className="text-zinc-300">□</span>
@@ -424,12 +425,16 @@ export default function PrintSignPage() {
                     <td className="border border-zinc-400 px-2 py-3"></td>
                     <td className="border border-zinc-400 px-2 py-3"></td>
                     <td className="border border-zinc-400 px-2 py-3"></td>
+                    <td className="border border-zinc-400 px-2 py-3"></td>
                   </tr>
                 ))}
                 {/* 合計列 */}
                 <tr className="bg-zinc-100 font-semibold">
                   <td colSpan={3} className="border border-zinc-400 px-2 py-1.5 text-right">
                     合計
+                  </td>
+                  <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono">
+                    {sheet.rows.reduce((s, r) => s + r.qty, 0)}
                   </td>
                   <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono">
                     {sheet.totalPicked}


### PR DESCRIPTION
## 變更

分店簽收單（`picking/print-sign`）的商品表從 5 欄擴為 6 欄：

| # | 商品編號 | 品名 | **訂購數量** | **配發數量** | 收貨確認 |
|---|---|---|---|---|---|

- **訂購數量** = `qty`（該波派貨計畫量）
- **配發數量** = `picked_qty`（實際配發／實撿量）；配發 < 訂購時標紅
- 移除原本擠在同格的 `(派 X)` 小字註記，改由兩欄直接對照
- 合計列同步拆成「訂購合計 / 配發合計」

## 口徑說明

「訂購數量」取的是該波的**派貨計畫量**（`picking_wave_items.qty`），非顧客原始訂購量——簽收單頁僅接 `picking_waves` 資料。若需顯示真正的顧客需求量，需另 join 需求視圖（未包含在本 PR）。

## 備註

本 PR 由已合併的 #465 之後的後續工作構成（#465 內容:簽收單數量 fallback + 派貨工作台效能），為獨立新 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7VRKjBxKV8bpr4cRwdiJy)_