### PR TITLE
feat(wms): 收貨待辦頁面加入搜尋（PO 編號 / 供應商）

### DIFF
--- a/apps/admin/src/app/(protected)/wms/receiving/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/receiving/page.tsx
@@ -54,6 +54,7 @@ export default function ReceivingWorkbenchPage() {
   const [rows, setRows] = useState<PORow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<Filter>("this_week");
+  const [search, setSearch] = useState("");
   // 分頁：未收(sent+部分收) / 已收(全收)，預設未收
   const [tab, setTab] = useState<ReceiveTab>("unreceived");
   const [detailPoId, setDetailPoId] = useState<number | null>(null);
@@ -91,7 +92,7 @@ export default function ReceivingWorkbenchPage() {
     return () => { cancelled = true; };
   }, []);
 
-  // 先套期間 filter（分頁數量與列表都基於同一份期間集合）
+  // 先套期間 + 搜尋 filter（分頁數量與列表都基於同一份集合）
   const periodFiltered = useMemo(() => {
     if (!rows) return [];
     const now = new Date();
@@ -99,6 +100,7 @@ export default function ReceivingWorkbenchPage() {
     const weekAgo = new Date(now);
     weekAgo.setDate(weekAgo.getDate() - 7);
     const weekAgoStr = weekAgo.toISOString().slice(0, 10);
+    const q = search.trim().toLowerCase();
 
     return rows.filter((r) => {
       if (filter === "today") {
@@ -109,9 +111,15 @@ export default function ReceivingWorkbenchPage() {
         const dateRef = r.sent_at?.slice(0, 10) ?? "";
         if (!dateRef || dateRef < weekAgoStr) return false;
       }
+      if (q) {
+        const haystack = [r.po_no, r.supplier_name, r.supplier_code ?? ""]
+          .join(" ")
+          .toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
       return true;
     });
-  }, [rows, filter]);
+  }, [rows, filter, search]);
 
   // 分頁數量（反映目前期間）
   const tabCounts = useMemo(() => {
@@ -200,6 +208,14 @@ export default function ReceivingWorkbenchPage() {
           );
         })}
       </div>
+
+      {/* 搜尋 */}
+      <input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="🔍 搜尋 PO 編號 / 供應商"
+        className="w-full min-w-[180px] rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+      />
 
       {/* Filter */}
       <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## 摘要

在收貨待辦頁面（進貨待辦，`/wms/receiving`）加入搜尋功能，方便從一堆 PO 中快速找到目標。

## 改動內容

- 在期間 filter 上方新增搜尋框「🔍 搜尋 PO 編號 / 供應商」
- 即時過濾 **PO 編號、供應商名稱、供應商代碼**（不分大小寫）
- 搜尋條件併入 `periodFiltered` 的 `useMemo`，套在期間 filter 之上
- 未收／已收分頁的數量會同步反映搜尋結果，與現有邏輯一致

## 實作備註

- 沿用既有 `purchase/orders/page.tsx` 的搜尋樣式與寫法，保持一致
- 此頁資料源自 `rpc_receiving_workbench`，為 PO 層級欄位（無逐項商品名），故搜尋範圍為單號／供應商

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjAUPGNuynPKSLtStcjZ23)_