### PR TITLE
Fix batch inbound transfer timeout by server-side serialization

### DIFF
--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -365,28 +365,25 @@ export default function TransfersInboxPage() {
       if (!operator) throw new Error("尚未登入");
 
       const ids = Array.from(selected);
-      const results = await Promise.allSettled(
-        ids.map((id) =>
-          sb.rpc("rpc_receive_transfer", {
-            p_transfer_id: id,
-            p_lines: null,
-            p_operator: operator,
-            p_notes: "批次收貨",
-          }),
-        ),
-      );
-
-      let okCount = 0;
-      const failures: { id: number; error: string }[] = [];
-      results.forEach((r, i) => {
-        if (r.status === "fulfilled" && !r.value.error) okCount += 1;
-        else {
-          const errMsg = r.status === "fulfilled"
-            ? translateRpcError(r.value.error)
-            : (r.reason instanceof Error ? r.reason.message : String(r.reason));
-          failures.push({ id: ids[i], error: errMsg });
-        }
+      // 單一 round-trip 伺服端批次：序列處理避免 N 筆並行搶同店 row lock /
+      // 重複跑 pickup_ready 造成的 statement timeout（見
+      // 20260710000000_rpc_receive_transfer_batch.sql）。
+      const { data, error: e } = await sb.rpc("rpc_receive_transfer_batch", {
+        p_transfer_ids: ids,
+        p_operator: operator,
+        p_notes: "批次收貨",
       });
+      if (e) throw new Error(translateRpcError(e));
+
+      const res = (data ?? {}) as {
+        ok_count?: number;
+        failed?: { id: number; error: string }[];
+      };
+      const okCount = res.ok_count ?? 0;
+      const failures = (res.failed ?? []).map((f) => ({
+        id: f.id,
+        error: translateRpcError(f.error),
+      }));
 
       if (failures.length === 0) {
         alert(`✅ 批次收貨完成:${okCount} 筆`);

--- a/supabase/migrations/20260710000000_rpc_receive_transfer_batch.sql
+++ b/supabase/migrations/20260710000000_rpc_receive_transfer_batch.sql
@@ -1,0 +1,78 @@
+-- ============================================================
+-- 2026-07-10: 批次收貨伺服端 RPC（修「批次收貨 5 筆以上 timeout」）
+--
+-- 問題：
+--   收貨待辦（wms/inbound）的「批次收貨」原本在瀏覽器端用
+--   Promise.allSettled 對每張 transfer 各打一次 rpc_receive_transfer，
+--   N 筆 = N 個並行 HTTP／DB 交易。每個 rpc_receive_transfer（hq_to_store
+--   邏輯 C）都會 UPDATE 該分店「所有 shipping 訂單」並對每張逐一跑昂貴的
+--   is_order_pickup_ready()。多筆並行時：
+--     - 這些交易搶同一批 customer_orders row lock（同店），彼此互卡；
+--     - 每筆又各自重跑一次昂貴的 pickup_ready 判定；
+--     - PostgREST 連線池 / statement_timeout 一超過就整批失敗。
+--   實測 5 筆以上就會踩到 statement timeout。
+--
+-- 修法：
+--   新增 rpc_receive_transfer_batch(p_transfer_ids, p_operator, p_notes)，
+--   在「單一交易、單一 round-trip」內序列處理每張 transfer，直接複用現行
+--   rpc_receive_transfer（p_lines=NULL＝全收，與原批次語意一致）。序列化後
+--   同店訂單的 row lock 不再互卡、pickup_ready 判定不重疊，避免 timeout。
+--   每張用 BEGIN…EXCEPTION 子區塊（savepoint）包起來，單張失敗只回滾該張、
+--   不影響其餘，維持原本 Promise.allSettled 的「部分成功」語意。
+--
+--   風格比照 20260515000005_distribute_batch_any_source.sql 的
+--   rpc_transfer_distribute_batch（succeeded / failed 收集）。
+--
+-- 基底版本：rpc_receive_transfer = 20260703000000（線上現行版，不改動）。
+-- Rollback：DROP FUNCTION public.rpc_receive_transfer_batch(BIGINT[], UUID, TEXT);
+--           前端改回逐筆 Promise.allSettled 即可（見同 PR 之 inbound/page.tsx）。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_receive_transfer_batch(
+  p_transfer_ids BIGINT[],
+  p_operator     UUID,
+  p_notes        TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+-- 序列處理整批可能比單張久；覆寫 PostgREST 預設的 statement_timeout（8s），
+-- 讓大批次（一個波次數十家分店）也不會中途被 timeout 砍斷。
+SET statement_timeout TO '180000'
+AS $$
+DECLARE
+  v_id        BIGINT;
+  v_ok_count  INTEGER := 0;
+  v_succeeded BIGINT[] := ARRAY[]::BIGINT[];
+  v_failed    JSONB    := '[]'::jsonb;
+  v_err       TEXT;
+BEGIN
+  IF p_transfer_ids IS NULL OR array_length(p_transfer_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_transfer_ids is empty';
+  END IF;
+
+  FOREACH v_id IN ARRAY p_transfer_ids LOOP
+    BEGIN
+      -- 序列呼叫現行單張收貨（全收：p_lines=NULL）。子區塊＝savepoint，
+      -- 單張失敗只回滾該張、CONTINUE 處理下一張。
+      PERFORM public.rpc_receive_transfer(v_id, NULL, p_operator, p_notes);
+      v_ok_count  := v_ok_count + 1;
+      v_succeeded := v_succeeded || v_id;
+    EXCEPTION WHEN OTHERS THEN
+      v_err    := SQLERRM;
+      v_failed := v_failed || jsonb_build_object('id', v_id, 'error', v_err);
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'processed', array_length(p_transfer_ids, 1),
+    'ok_count',  v_ok_count,
+    'succeeded', v_succeeded,
+    'failed',    v_failed
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_receive_transfer_batch(BIGINT[], UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_receive_transfer_batch(BIGINT[], UUID, TEXT) IS
+  '批次收貨：單一交易序列呼叫 rpc_receive_transfer（全收），取代前端並行打 N 次'
+  '造成的 row-lock 互卡 / statement timeout。單張失敗以 savepoint 隔離，回傳 succeeded / failed。';


### PR DESCRIPTION
## Summary

Fixes the "batch receive transfer timeout" issue (5+ transfers) by moving from client-side parallel RPC calls to a new server-side batch function that processes transfers sequentially in a single transaction.

## Problem

The inbound batch receive feature (`wms/inbound`) was calling `rpc_receive_transfer` once per transfer in parallel via `Promise.allSettled`, causing:
- Multiple concurrent transactions competing for the same `customer_orders` row locks (per store)
- Redundant `is_order_pickup_ready()` evaluation across parallel calls
- PostgREST statement timeout failures when processing 5+ transfers

## Solution

**New RPC function:** `rpc_receive_transfer_batch(p_transfer_ids, p_operator, p_notes)`
- Processes all transfers sequentially in a single transaction (180s timeout)
- Reuses existing `rpc_receive_transfer` logic (with `p_lines=NULL` for full receipt)
- Each transfer wrapped in a `BEGIN…EXCEPTION` savepoint block for isolation
- Single transfer failure only rolls back that transfer, not the entire batch
- Returns aggregated result: `{ processed, ok_count, succeeded[], failed[] }`

**Frontend change:** Replace `Promise.allSettled` loop with single `rpc_receive_transfer_batch` call
- Simplified error handling and result collection
- Maintains "partial success" semantics of the original implementation

## Implementation Details

- Migration: `20260710000000_rpc_receive_transfer_batch.sql`
- Based on `rpc_receive_transfer` v20260703000000 (current production version, unchanged)
- Follows the pattern of `rpc_transfer_distribute_batch` (20260515000005) for batch result collection
- Rollback: Drop function and revert frontend to `Promise.allSettled` pattern

https://claude.ai/code/session_016wNt497xgQhrPxiv589unj