### PR TITLE
fix(purchase/orders): 樞紐已到量改走收貨單、修樞紐資料跑不出來

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/page.tsx
@@ -308,17 +308,30 @@ export default function PurchaseOrdersListPage() {
           );
           poiRows.push(...rows);
         }
-        // 2. 已到量：confirmed 收貨的 goods_receipt_items，per po_item 加總（同樣分頁）
+        // 2. 已到量：先抓這些 PO 的 confirmed 收貨單，再依 gr_id 撈明細加總。
+        //    （不走 goods_receipts!inner 內嵌過濾 — 內嵌 join 在部分 RLS 下行為不穩，
+        //     直接兩段查詢較可靠，且收貨單數量遠少於品項數。）
+        const grIds: number[] = [];
+        for (const c of chunk(poIds, 200)) {
+          const rows = await fetchAllRows<{ id: number }>(
+            () =>
+              sb
+                .from("goods_receipts")
+                .select("id")
+                .eq("status", "confirmed")
+                .in("po_id", c)
+                .order("id", { ascending: true }),
+          );
+          grIds.push(...rows.map((r) => r.id));
+        }
         const recvByItem = new Map<number, number>();
-        const itemIds = poiRows.map((r) => r.id);
-        for (const c of chunk(itemIds, 200)) {
+        for (const c of chunk(grIds, 200)) {
           const rows = await fetchAllRows<{ po_item_id: number; qty_received: number }>(
             () =>
               sb
                 .from("goods_receipt_items")
-                .select("po_item_id, qty_received, goods_receipts!inner(status)")
-                .eq("goods_receipts.status", "confirmed")
-                .in("po_item_id", c)
+                .select("po_item_id, qty_received")
+                .in("gr_id", c)
                 .order("po_item_id", { ascending: true }),
           );
           for (const r of rows) {
@@ -356,7 +369,11 @@ export default function PurchaseOrdersListPage() {
         });
         if (!cancelled) setPivotItems(items);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        // 設成空陣列避免「載入中」卡死；錯誤原因由上方 error banner 呈現。
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e));
+          setPivotItems([]);
+        }
       } finally {
         if (!cancelled) setPivotLoading(false);
       }


### PR DESCRIPTION
## 問題

採購單「樞紐（依廠商）」檢視資料跑不出來（永遠停在「載入樞紐資料中…」）。

## 原因

樞紐「已到量」原本用內嵌 join 過濾查 `goods_receipt_items`：

```
.select("po_item_id, qty_received, goods_receipts!inner(status)")
.eq("goods_receipts.status", "confirmed")
```

內嵌 `!inner` join 在部分 RLS 情境下行為不穩，一旦查詢卡住／報錯，`pivotItems` 就一直維持 `null`，樞紐永遠停在載入中。

## 修法

改為兩段一般查詢（`goods_receipts` 有 `po_id` 欄）：

1. 先抓這些 PO 的 `confirmed` 收貨單 id。
2. 再依 `gr_id` 撈 `goods_receipt_items` 加總已到量。

沒有內嵌 join、請求數更少（線上僅 778 品項 / 81 張收貨單），更可靠；即使收貨明細讀不到也只是「已到量 0」，不會卡死。另外樞紐 fetch 失敗時改顯示錯誤並退出載入狀態，避免無限轉圈。

## 備註

延續已合併的 #468（採購單樞紐 + 手機版）。#468 合併時未含此修正，故獨立開 PR。四個查詢皆以線上 REST 驗證語法合法（HTTP 200）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7VRKjBxKV8bpr4cRwdiJy)_