### PR TITLE
Make unit price read-only in restock form

### DIFF
--- a/apps/admin/src/app/(protected)/restock/new/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/new/page.tsx
@@ -126,7 +126,7 @@ export default function RestockNewPage() {
             <tr className="text-left text-xs uppercase tracking-wide text-zinc-500">
               <th className="px-3 py-2">商品 / 規格 *</th>
               <th className="px-3 py-2 text-right">數量 *</th>
-              <th className="px-3 py-2 text-right">單價 *</th>
+              <th className="px-3 py-2 text-right">單價</th>
               <th className="px-3 py-2">備註</th>
               <th className="px-3 py-2"></th>
             </tr>
@@ -277,7 +277,7 @@ function LineRow({
         )}
       </td>
       <td className="px-3 py-2"><input type="number" min="0" step="1" value={line.qty} onChange={(e) => onChange({ qty: e.target.value })} className="w-24 rounded border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800" /></td>
-      <td className="px-3 py-2"><input type="number" min="0" step="1" value={line.unit_price} onChange={(e) => onChange({ unit_price: e.target.value })} className="w-24 rounded border border-zinc-300 bg-white px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800" /></td>
+      <td className="px-3 py-2 text-right font-mono text-sm text-zinc-700 dark:text-zinc-300">${line.unit_price}</td>
       <td className="px-3 py-2"><input value={line.notes} onChange={(e) => onChange({ notes: e.target.value })} placeholder="（選填）" className="w-full rounded border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800" /></td>
       <td className="px-3 py-2">
         {onRemove && (


### PR DESCRIPTION
## Summary
Changed the unit price field in the restock form from an editable input to a read-only display field.

## Changes
- Removed the asterisk (*) from the "單價" (Unit Price) column header to indicate it's no longer a required input field
- Converted the unit price input field to a read-only display that shows the price with a dollar sign prefix
- Applied consistent styling (monospace font, right-aligned, muted text color) to match the design system

## Implementation Details
The unit price is now displayed as static text (`${line.unit_price}`) instead of an editable number input. This suggests the unit price is either:
- Fetched from product data and not meant to be manually overridden
- Calculated automatically based on other fields
- Managed elsewhere in the workflow

The read-only display maintains visual consistency with the form's dark mode support through appropriate text color classes.

https://claude.ai/code/session_01AMXLQqZU1HVfvWgSQcNizD