### PR TITLE
Disable Service Worker in LINE LIFF in-app browser

### DIFF
--- a/apps/member/src/components/ServiceWorkerRegister.tsx
+++ b/apps/member/src/components/ServiceWorkerRegister.tsx
@@ -2,9 +2,37 @@
 
 import { useEffect } from "react";
 
+/**
+ * 是否在 LINE app 內建瀏覽器（LIFF in-client webview）。
+ * LINE 內建瀏覽器的 UA 會帶 "Line/x.x.x"（外部瀏覽器開 LIFF 不會）。
+ * 這裡只靠 UA 判斷，因為要在 LIFF SDK init 之前就決定「要不要載 SW」。
+ */
+function isLineInAppBrowser(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return / Line\//i.test(navigator.userAgent);
+}
+
 export default function ServiceWorkerRegister() {
   useEffect(() => {
     if (!("serviceWorker" in navigator)) return;
+
+    // LINE LIFF 內建瀏覽器不要載 PWA：
+    // Serwist SW 會 precache + runtime cache，在 LINE webview 內會回舊的快取頁面，
+    // 造成 LIFF 卡在載入 / 看到過期內容。推播又只有 standalone PWA 才能用，
+    // 所以在 LINE 內完全不需要 SW。順手把先前殘留的 SW 與 cache 清掉，確保走網路。
+    if (isLineInAppBrowser()) {
+      navigator.serviceWorker
+        .getRegistrations()
+        .then((regs) => Promise.all(regs.map((r) => r.unregister())))
+        .catch(() => {});
+      if (typeof caches !== "undefined") {
+        caches
+          .keys()
+          .then((keys) => Promise.all(keys.map((k) => caches.delete(k))))
+          .catch(() => {});
+      }
+      return;
+    }
 
     try { localStorage.removeItem("sw_register_error"); } catch {}
 


### PR DESCRIPTION
## Summary
Prevent Service Worker registration and clean up existing caches when the app is running inside LINE's built-in LIFF browser, as PWA features (caching and push notifications) are not compatible with the LIFF environment.

## Changes
- Added `isLineInAppBrowser()` utility function that detects LINE's in-app browser via User-Agent string
- Added early return in `ServiceWorkerRegister` component to skip SW registration when running in LINE LIFF
- Implemented cleanup logic to unregister any existing Service Workers and clear all caches when detected in LINE environment

## Implementation Details
The detection happens before LIFF SDK initialization by checking the User-Agent for the "Line/" pattern, which is only present in LINE's built-in webview (not when opening LIFF from external browsers).

When in LINE LIFF:
- Service Worker registration is skipped
- Any previously registered Service Workers are unregistered
- All cached data is cleared to ensure the app always fetches fresh content from the network

This prevents stale cached pages from being served in the LIFF environment, which could cause the app to appear stuck or display outdated content.

https://claude.ai/code/session_01VHy4mobXmNM19q3ZZt4VjZ