### PR TITLE
Fix pivot data loading infinite loop by removing pivotLoading from deps

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/page.tsx
@@ -274,8 +274,12 @@ export default function PurchaseOrdersListPage() {
   }, [reloadKey]);
 
   // 樞紐資料：lazy 撈「已下單 + 部分到貨」PO 的品項（訂購量 / 已到量），切到樞紐才撈一次。
+  // 注意：pivotLoading 不可放進本 effect 的依賴陣列，也不可拿來當守衛條件。
+  // 否則 setPivotLoading(true) 會立刻改動依賴 → React 先跑 cleanup 把 cancelled 設 true
+  // → 進行中的查詢回來時所有 setState（含 finally 的 setPivotLoading(false)）都被 !cancelled 擋掉
+  // → 樞紐永遠停在「載入中」。重入保護改由 pivotItems !== null 負責（載入完成/失敗都會離開 null）。
   useEffect(() => {
-    if (viewMode !== "pivot" || pivotItems !== null || pivotLoading || !pos) return;
+    if (viewMode !== "pivot" || pivotItems !== null || !pos) return;
     let cancelled = false;
     setPivotLoading(true);
     (async () => {
@@ -381,7 +385,7 @@ export default function PurchaseOrdersListPage() {
     return () => {
       cancelled = true;
     };
-  }, [viewMode, pivotItems, pivotLoading, pos]);
+  }, [viewMode, pivotItems, pos]);
 
   // === KPI 統計 ===
   const today = new Date().toISOString().slice(0, 10);


### PR DESCRIPTION
## Summary
Fixed a React dependency issue in the pivot view data loading effect that caused the loading state to get stuck indefinitely. The problem was `pivotLoading` being included in the effect's dependency array, which created a circular dependency pattern.

## Key Changes
- Removed `pivotLoading` from the `useEffect` dependency array for pivot data loading
- Updated the re-entrance guard condition to rely solely on `pivotItems !== null` instead of also checking `pivotLoading`
- Added detailed comments explaining why `pivotLoading` cannot be used as a dependency or guard condition

## Implementation Details
The issue occurred because:
1. When `setPivotLoading(true)` was called, it updated the dependency
2. React would run the cleanup function, setting `cancelled = true`
3. When the async query completed, all `setState` calls (including `setPivotLoading(false)` in finally) were blocked by the `!cancelled` guard
4. This left the pivot view permanently in a loading state

The fix uses `pivotItems !== null` as the re-entrance guard since this value is set to a non-null value on both successful completion and error, providing the same protection without the circular dependency issue.

https://claude.ai/code/session_018HriZfcHd8fYt1uC2Wk5aQ