### PR TITLE
feat(member): LINE LIFF 直接進完整商店，不再限 PWA

### DIFF
--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -98,8 +98,11 @@ export default function LandingPage() {
     setStandalone(sa);
 
     // 已綁(有 memberId)才跳走;只有 token 沒 member_id 不跳,避免跟 /shop 互推產生
-    // redirect loop。PWA standalone → /shop;LINE / 一般瀏覽器 → /me
-    const landing = sa ? "/shop" : "/me";
+    // redirect loop。standalone PWA 與 LINE LIFF 內建瀏覽器 → /shop(完整商店);
+    // 一般外部瀏覽器 → /me
+    const isLine =
+      typeof navigator !== "undefined" && / Line\//i.test(navigator.userAgent);
+    const landing = sa || isLine ? "/shop" : "/me";
 
     const existing = getSession();
     if (existing && existing.memberId) {
@@ -505,7 +508,7 @@ async function runLiffSession(
   });
   if (data.line_name)    frag.set("line_name",    String(data.line_name));
   if (data.line_picture) frag.set("line_picture", String(data.line_picture));
-  // LIFF 自然登入(沒帶 pair) = 在 LINE webview 內,只停在 /me 會員中心。
-  // PWA 端的完整商店體驗在 standalone 才開放。
-  window.location.href = `/me#${frag.toString()}`;
+  // LIFF 自然登入(沒帶 pair) = 在 LINE webview 內。放行完整商店體驗:
+  // 直接進 /shop,跟 standalone PWA 一致(不再只停在 /me)。
+  window.location.href = `/shop#${frag.toString()}`;
 }

--- a/apps/member/src/components/MemberTabBar.tsx
+++ b/apps/member/src/components/MemberTabBar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useUnreadNotifications } from "@/lib/useUnreadNotifications";
@@ -60,24 +59,11 @@ const tabs: Tab[] = [
 
 export default function MemberTabBar() {
   const pathname = usePathname() ?? "";
-  const [hide, setHide] = useState(false);
   const { count: unreadCount } = useUnreadNotifications();
 
-  // 從 LINE app 的 LIFF webview 進來,不顯示 tab bar(整個 PWA 導航體驗只屬於
-  // 加入主畫面後的 standalone 模式)
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const ua = navigator.userAgent;
-    const isLine = /Line\//i.test(ua);
-    const isStandalone =
-      (window.navigator as { standalone?: boolean }).standalone === true ||
-      window.matchMedia("(display-mode: standalone)").matches;
-    setHide(isLine && !isStandalone);
-  }, []);
-
-  // 商品詳細頁有自己的 sticky 下單 bar、會跟 tab bar 打架,直接隱藏
+  // LINE LIFF 內建瀏覽器現在也走完整商店,tab bar 一律顯示(standalone / 一般瀏覽器 / LINE 皆同)。
+  // 商品詳細頁有自己的 sticky 下單 bar、會跟 tab bar 打架,直接隱藏。
   if (pathname.startsWith("/shop/c/")) return null;
-  if (hide) return null;
 
   return (
     <nav

--- a/apps/member/src/components/PageShell.tsx
+++ b/apps/member/src/components/PageShell.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import MemberTabBar from "./MemberTabBar";
 
@@ -27,16 +26,6 @@ export default function PageShell({
   const pathname = usePathname() ?? "";
   const showBack = !TOP_LEVEL_PATHS.has(pathname);
 
-  const [tabBarHidden, setTabBarHidden] = useState(false);
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const isLine = /Line\//i.test(navigator.userAgent);
-    const isStandalone =
-      (window.navigator as { standalone?: boolean }).standalone === true ||
-      window.matchMedia("(display-mode: standalone)").matches;
-    setTabBarHidden(isLine && !isStandalone);
-  }, []);
-
   // 點回上一頁: 有 history 就 back, 沒有 (深連結 / LINE 開新分頁) fallback 到 /shop
   const handleBack = () => {
     if (typeof window !== "undefined" && window.history.length > 1) {
@@ -50,9 +39,8 @@ export default function PageShell({
     <div
       className="relative min-h-[100dvh]"
       style={{
-        paddingBottom: tabBarHidden
-          ? "env(safe-area-inset-bottom)"
-          : "calc(92px + env(safe-area-inset-bottom))",
+        // tab bar 一律顯示(含 LINE LIFF),固定保留其高度
+        paddingBottom: "calc(92px + env(safe-area-inset-bottom))",
       }}
     >
       <main className="relative mx-auto w-full max-w-md">


### PR DESCRIPTION
## 背景

延續 #476（LINE LIFF 內建瀏覽器不載 PWA service worker）。原設計把完整商店 `/shop` 鎖給 standalone PWA，LINE 內建瀏覽器（LIFF）登入後只停在 `/me`，等於「非 PWA 進來會被擋在商店外」。本 PR 放行 LINE LIFF 走跟 PWA 一致的完整體驗。

## 變更

| 檔案 | 改動 |
|---|---|
| `apps/member/src/app/page.tsx`（landing） | standalone PWA **或** LINE（UA 含 `Line/`）一律導 `/shop`；一般外部瀏覽器維持 `/me` |
| `apps/member/src/app/page.tsx`（`runLiffSession`） | LIFF 自動登入完成後改跳 `/shop`（原本寫死 `/me`） |
| `apps/member/src/components/MemberTabBar.tsx` | 底部 tab bar 在 LINE 內也顯示（原本 `isLine && !standalone` 會整個藏掉導覽） |
| `apps/member/src/components/PageShell.tsx` | 對應保留 tab bar 高度的 bottom padding |

## 備註

- `/shop` 進站本就會 `consumeFragmentToSession()`，token 由 URL fragment 帶入，換落點不受影響。
- 這環境無法安裝依賴跑 build / lint，改動以靜態檢查確認（無殘留引用、無未用 import）。建議在 LINE 內實際開一次 LIFF 連結驗收。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHy4mobXmNM19q3ZZt4VjZ)_