### PR TITLE
fix(order-entry): 已綁定會員在加單搜尋不再冒出「+綁」

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
@@ -905,6 +905,8 @@ function CustomerSearch({
   const [open, setOpen] = useState(false);
   const [members, setMembers] = useState<MemberRow[]>([]);
   const [aliases, setAliases] = useState<AliasRow[]>([]);
+  // 本頻道已綁定的 member ids（不受搜尋字串限制，用來收起已綁會員的「+綁」按鈕）
+  const [boundMemberIds, setBoundMemberIds] = useState<Set<number>>(new Set());
   const [searching, setSearching] = useState(false);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -932,8 +934,20 @@ function CustomerSearch({
             ? sb.rpc("rpc_search_aliases", { p_channel_id: channelId, p_term: term, p_limit: 8 })
             : Promise.resolve({ data: [], error: null }),
         ]);
-        setMembers((mRes.data as MemberRow[]) ?? []);
+        const memberRows = (mRes.data as MemberRow[]) ?? [];
+        setMembers(memberRows);
         setAliases((aRes.data as AliasRow[]) ?? []);
+
+        // 這批會員裡，哪些已在本頻道綁過暱稱（與搜尋字串無關）→ 收起「+綁」避免重複綁定
+        if (channelId && memberRows.length > 0) {
+          const { data: bound } = await sb.rpc("rpc_channel_bound_member_ids", {
+            p_channel_id: channelId,
+            p_member_ids: memberRows.map((m) => m.id),
+          });
+          setBoundMemberIds(new Set(((bound as { member_id: number }[]) ?? []).map((b) => b.member_id)));
+        } else {
+          setBoundMemberIds(new Set());
+        }
       } finally {
         setSearching(false);
       }
@@ -1016,7 +1030,7 @@ function CustomerSearch({
             <div>
               <div className="px-2 py-1 text-xs font-medium text-zinc-400">會員</div>
               {members.map((m) => {
-                const aliased = aliases.some((a) => a.member_id === m.id);
+                const aliased = boundMemberIds.has(m.id) || aliases.some((a) => a.member_id === m.id);
                 const dup = pickedMemberIds.has(m.id);
                 const noStore = m.home_store_id == null;
                 const blacklisted = !!m.no_new_order;

--- a/supabase/migrations/20260712000000_rpc_channel_bound_member_ids.sql
+++ b/supabase/migrations/20260712000000_rpc_channel_bound_member_ids.sql
@@ -1,0 +1,58 @@
+-- ============================================================
+-- rpc_channel_bound_member_ids：回傳「這批會員裡，已在指定 LINE 頻道綁過暱稱」的會員 id。
+--
+-- 為什麼要另開一支：小幫手加單頁的 rpc_search_aliases 是用「暱稱 ILIKE 搜尋字串」在濾，
+-- 所以當店員用會員編號 / 姓名（例：259405）搜尋、而該會員綁定的暱稱不含這串字時，
+-- 該 alias 不會被回傳，前端 `aliased` 判斷失準，導致「+綁」按鈕對「已綁定」的會員又冒出來，
+-- 再按下去就會產生重複綁定。這支 RPC 不吃搜尋字串，只針對「當前結果的 member ids」查是否已綁，
+-- 讓前端能穩定地把已綁會員的「+綁」按鈕收起來。
+--
+-- 併檔處理：alias.member_id 可能指向已被合併的舊檔，沿 merged_into_member_id 追到 active 目標
+-- （最多 5 跳），與 rpc_search_members / rpc_search_aliases 的解法一致，回傳解算後的目標 id。
+--
+-- 基底：無（全新 function）。rollback：DROP FUNCTION public.rpc_channel_bound_member_ids(BIGINT, BIGINT[]);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_channel_bound_member_ids(
+  p_channel_id BIGINT,
+  p_member_ids BIGINT[]
+) RETURNS TABLE (member_id BIGINT)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+BEGIN
+  IF p_channel_id IS NULL
+     OR p_member_ids IS NULL
+     OR COALESCE(array_length(p_member_ids, 1), 0) = 0 THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH RECURSIVE aliased AS (
+    SELECT a.member_id AS source_id, m.id AS target_id,
+           m.status, m.merged_into_member_id, 0 AS hop
+      FROM customer_line_aliases a
+      JOIN members m ON m.id = a.member_id
+     WHERE a.tenant_id  = v_tenant
+       AND a.channel_id = p_channel_id
+    UNION ALL
+    SELECT r.source_id, m.id, m.status, m.merged_into_member_id, r.hop + 1
+      FROM aliased r
+      JOIN members m ON m.id = r.merged_into_member_id
+     WHERE r.status = 'merged'
+       AND r.merged_into_member_id IS NOT NULL
+       AND r.hop < 5
+  ),
+  resolved AS (
+    SELECT DISTINCT ON (source_id) target_id, status
+      FROM aliased
+     ORDER BY source_id, hop DESC
+  )
+  SELECT DISTINCT r.target_id
+    FROM resolved r
+   WHERE r.status NOT IN ('merged', 'deleted')
+     AND r.target_id = ANY(p_member_ids);
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_channel_bound_member_ids TO authenticated;


### PR DESCRIPTION
小幫手加單頁用會員編號 / 姓名（例 259405）搜尋時，若該會員在本頻道
綁定的暱稱不含搜尋字串，rpc_search_aliases（暱稱 ILIKE 濾）就不會回傳
該 alias，前端 `aliased` 判斷失準，導致已綁定會員又冒出「+綁」按鈕，
再按下去會產生重複綁定。

新增 rpc_channel_bound_member_ids(channel, member_ids[])：不吃搜尋字串，
只針對當前結果的 member ids 查是否已在本頻道綁過（沿 merged_into_member_id
解算併檔，與既有 search RPC 一致）。前端據此穩定收起已綁會員的「+綁」。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PzVFwtR5N6f4cG4L7Wn6HU