### PR TITLE
fix(member): 正確解析帶路徑的 liff.state，避免掉 store 被踢去選店頁

### DIFF
--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -27,6 +27,16 @@ function genPairToken(): string {
   ).join("");
 }
 
+/**
+ * LIFF 會把原始 query 包進 liff.state，而且常帶著路徑，格式可能是：
+ *   "?store=1"、"/?store=1"、"/shop?store=1"、或純 "store=1"。
+ * 一律抓「第一個 ? 之後」的部分當 query 解析（沒有 ? 就整串當 query）。
+ */
+function liffStateParams(raw: string): URLSearchParams {
+  const q = raw.indexOf("?");
+  return new URLSearchParams(q >= 0 ? raw.slice(q + 1) : raw);
+}
+
 function readPairFromUrl(): string | null {
   if (typeof window === "undefined") return null;
   const sp = new URLSearchParams(window.location.search);
@@ -34,10 +44,7 @@ function readPairFromUrl(): string | null {
   if (direct) return direct;
   // LIFF 把 query 包進 liff.state
   const ls = sp.get("liff.state");
-  if (ls) {
-    const inner = new URLSearchParams(ls.startsWith("?") ? ls.slice(1) : ls);
-    return inner.get("pair");
-  }
+  if (ls) return liffStateParams(ls).get("pair");
   return null;
 }
 
@@ -460,10 +467,7 @@ function readStore(): string | null {
   const s = sp.get("store");
   if (s) return s;
   const raw = sp.get("liff.state");
-  if (raw) {
-    const inner = new URLSearchParams(raw.startsWith("?") ? raw.slice(1) : raw);
-    return inner.get("store");
-  }
+  if (raw) return liffStateParams(raw).get("store");
   return null;
 }
 


### PR DESCRIPTION
## 問題

帶了 `?store=1` 的 LIFF 連結，使用者仍被踢到「選擇門市」頁。

根因：LINE 開 LIFF 時會把原始 query 包進 `liff.state`，而且常帶著路徑，例如 `/shop?store=1` 或 `/?store=1`。前端 `readStore()` / `readPairFromUrl()` 原本只處理開頭是 `?` 的值：

```js
const inner = new URLSearchParams(raw.startsWith("?") ? raw.slice(1) : raw);
```

遇到帶路徑的 `liff.state`（如 `/shop?store=1`）會 parse 失敗（key 變成 `/shop?store`），`store` 讀成 `null` → 後端 `liff-session` 收不到 store → 對尚未綁定的帳號回 `store_required` → 使用者被踢到選店頁（即使連結已帶 `?store=1`）。

## 變更

`apps/member/src/app/page.tsx`：新增共用 helper `liffStateParams()`，抓 `liff.state` 裡「第一個 `?` 之後」的字串當 query，涵蓋 `?q` / `/?q` / `/path?q` / `q` 全部格式。`readStore()` 與 `readPairFromUrl()` 一起套用。

## 備註

- `URLSearchParams.get("liff.state")` 已先做一次 URL 解碼，帶進來的路徑格式正好對得上。
- 這環境無法安裝依賴跑 build / lint，改動以靜態檢查確認。建議部署後在 LINE 內用 `?store=1` 連結實測不再被踢去選店。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHy4mobXmNM19q3ZZt4VjZ)_