### PR TITLE
fix(member): LINE 內 OAuth 登入後直接進商店，跳過安裝/取碼頁

### DIFF
--- a/apps/member/src/app/auth/success/page.tsx
+++ b/apps/member/src/app/auth/success/page.tsx
@@ -12,26 +12,26 @@ export default function AuthSuccessPage() {
   });
 
   useEffect(() => {
-    // 從 hash 抓 code / paired 旗標 (line-oauth-callback 把全部塞進 fragment)
-    const hash = window.location.hash.replace(/^#/, "");
-    if (hash) {
-      const hp = new URLSearchParams(hash);
-      const c = hp.get("code");
-      if (c) setCode(c);
-      if (hp.get("paired") === "1") setPaired(true);
-    }
-
-    // 備援: query string
+    // 從 hash / query 抓 code / paired 旗標 (line-oauth-callback 把全部塞進 fragment)
+    const hp = new URLSearchParams(window.location.hash.replace(/^#/, ""));
     const sp = new URLSearchParams(window.location.search);
-    const qc = sp.get("code");
-    if (qc) setCode(qc);
-    if (sp.get("paired") === "1") setPaired(true);
+    const isPaired = hp.get("paired") === "1" || sp.get("paired") === "1";
 
-    // 把 fragment 寫進 localStorage 並清 URL；同時抓 LINE 個資顯示
+    // 把 fragment 寫進 localStorage 並清 URL（會回傳 session）
     const session = consumeFragmentToSession();
-    if (session) {
-      setProfile({ name: session.lineName, picture: session.linePicture });
+
+    // LINE webview 內、且不是 PWA 配對回流 → 直接進商店,不停在這個「安裝/取碼」頁。
+    // (PWA 配對 paired=1 要留在這頁提示回桌面；桌機取碼流程也維持原樣)
+    const isLine = typeof navigator !== "undefined" && / Line\//i.test(navigator.userAgent);
+    if (session && session.memberId && isLine && !isPaired) {
+      window.location.replace("/shop");
+      return;
     }
+
+    const c = hp.get("code") ?? sp.get("code");
+    if (c) setCode(c);
+    if (isPaired) setPaired(true);
+    if (session) setProfile({ name: session.lineName, picture: session.linePicture });
   }, []);
 
   return (

--- a/apps/member/src/lib/session.ts
+++ b/apps/member/src/lib/session.ts
@@ -30,7 +30,9 @@ export function consumeFragmentToSession(): Session | null {
   const store = p.get("store");
   if (!token || !store) return null;
 
-  const memberId    = p.get("member_id") ? Number(p.get("member_id")) : null;
+  // OAuth callback 的 fragment 只帶 token(沒 member_id),LIFF 流程才帶 member_id。
+  // 兩條都能拿到 memberId → 從 JWT 補。
+  const memberId    = p.get("member_id") ? Number(p.get("member_id")) : memberIdFromJwt(token);
   const bound       = p.get("bound") === "1";
   const lineUserId  = p.get("line_user_id");
   const lineName    = p.get("line_name");
@@ -66,18 +68,31 @@ export function consumeFragmentToSession(): Session | null {
   return session;
 }
 
-/** 解 JWT payload 的 exp(秒)。失敗或沒 exp → null。不驗簽,只是給 client 判過期用 */
-function jwtExpSeconds(token: string): number | null {
+/** 解 JWT payload。失敗回 null。不驗簽,只給 client 讀 exp / member_id 用 */
+function decodeJwtClaims(token: string): { exp?: number; member_id?: number; sub?: string } | null {
   const parts = token.split(".");
   if (parts.length !== 3) return null;
   try {
     const padded = parts[1].replace(/-/g, "+").replace(/_/g, "/");
     const json = atob(padded + "==".slice(0, (4 - padded.length % 4) % 4));
-    const claims = JSON.parse(json) as { exp?: number };
-    return typeof claims.exp === "number" ? claims.exp : null;
+    return JSON.parse(json);
   } catch {
     return null;
   }
+}
+
+function jwtExpSeconds(token: string): number | null {
+  const exp = decodeJwtClaims(token)?.exp;
+  return typeof exp === "number" ? exp : null;
+}
+
+/** 從 JWT 取 member_id(OAuth callback 的 fragment 沒帶 member_id,只有 token → 從裡面補) */
+function memberIdFromJwt(token: string): number | null {
+  const claims = decodeJwtClaims(token);
+  if (!claims) return null;
+  if (typeof claims.member_id === "number") return claims.member_id;
+  const n = claims.sub != null ? Number(claims.sub) : NaN;
+  return Number.isFinite(n) ? n : null;
 }
 
 export function getSession(): Session | null {
@@ -95,11 +110,12 @@ export function getSession(): Session | null {
   }
 
   const mid = localStorage.getItem(MEMBER_KEY);
+  const memberId = mid ? Number(mid) : memberIdFromJwt(token);
   return {
     token,
     storeId,
-    memberId: mid ? Number(mid) : null,
-    bound: !!mid,
+    memberId,
+    bound: memberId != null,
     lineUserId:  localStorage.getItem(LINE_UID_KEY),
     lineName:    localStorage.getItem(LINE_NAME_KEY),
     linePicture: localStorage.getItem(LINE_PIC_KEY),


### PR DESCRIPTION
## 問題

LINE 內開連結、用 LINE 登入後，停在 `/auth/success`（「LINE 驗證成功 → 前往安裝步驟」＋ 6 位數 PWA 驗證碼），無法直接進商店。

根因有兩層：

1. **LIFF 自動登入沒啟用**（部署環境 `NEXT_PUBLIC_LIFF_ID` 未生效），LINE 內改走 OAuth，callback 一律落在 `auth/success`（那頁是為 PWA 安裝/跨視窗取碼設計的，對只想在 LINE 內逛的人是死路）。
2. **`line-oauth-callback` 的 redirect fragment 只帶 `token`、沒帶 `member_id`**。`/shop` 需要 `memberId`，否則會被彈回 `/`，所以即使想從這頁前進也進不去商店。

## 變更（純前端，不需重新部署 edge function）

| 檔案 | 改動 |
|---|---|
| `apps/member/src/lib/session.ts` | 新增 `memberIdFromJwt()`，從 JWT payload 補 `member_id`（token 內本就有）。`consumeFragmentToSession()` 與 `getSession()` 在 fragment/localStorage 沒有 member_id 時都用它補齊 |
| `apps/member/src/app/auth/success/page.tsx` | 在 LINE webview（UA 含 `Line/`）且非 PWA 配對回流（`paired != 1`）時，拿到含 `memberId` 的 session 後直接 `location.replace('/shop')`，跳過本頁 |

## 保留不動的路徑

- **PWA 配對回流**（`paired=1`）：仍停在本頁提示「回桌面開 PWA」。
- **桌機/一般瀏覽器取碼**：仍顯示 6 位數驗證碼供 PWA 手動輸入。

## 備註

- 這只解決「登入完成後的死路」。若要連「用 LINE 登入」那一下都免、真正做到開連結即自動登入，需要在 Vercel 設好 `NEXT_PUBLIC_LIFF_ID` 並**重新部署**（`NEXT_PUBLIC_*` 是 build 時編入）。
- 環境無法跑 build / lint，改動以靜態檢查確認（無殘留引用、無未用變數）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHy4mobXmNM19q3ZZt4VjZ)_