### PR TITLE
fix(wms): 收貨頁品項名走分頁抓，避免最新 wave 被 1000 列上限截掉

### DIFF
--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -14,6 +14,7 @@ import {
 import SpinButton from "@/components/SpinButton";
 import { translateRpcError } from "@/lib/rpcError";
 import { useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
+import { fetchAllRows } from "@/lib/fetchAllRows";
 
 type Location = { id: number; name: string };
 type StoreLite = { id: number; location_id: number | null };
@@ -138,19 +139,24 @@ export default function TransfersInboxPage() {
         const summary = new Map<number, ItemSummary>();
         if (rows.length > 0) {
           const transferIds = rows.map((r) => r.id);
-          const { data: tiRows } = await sb
-            .from("transfer_items")
-            .select("transfer_id, sku_id, qty_shipped")
-            .in("transfer_id", transferIds);
-          const items = (tiRows ?? []) as { transfer_id: number; sku_id: number; qty_shipped: number }[];
+          // 走 fetchAllRows 分頁：待收 transfer 數不設限，×每張多列品項很容易破
+          // PostgREST 1000 列上限；不分頁的話最新 wave（transfer_id 最大、排在尾端）
+          // 的品項會整批被截掉 → summary.lines=0 → 品名全變「—」。
+          const items = await fetchAllRows<{ transfer_id: number; sku_id: number; qty_shipped: number }>(
+            () =>
+              sb
+                .from("transfer_items")
+                .select("transfer_id, sku_id, qty_shipped")
+                .in("transfer_id", transferIds)
+                .order("id"),
+          );
           const skuIds = Array.from(new Set(items.map((it) => it.sku_id)));
           const skuNameMap = new Map<number, string>();
           if (skuIds.length > 0) {
-            const { data: skuRows } = await sb
-              .from("skus")
-              .select("id, product_name, variant_name")
-              .in("id", skuIds);
-            for (const s of (skuRows ?? []) as { id: number; product_name: string | null; variant_name: string | null }[]) {
+            const skuRows = await fetchAllRows<{ id: number; product_name: string | null; variant_name: string | null }>(
+              () => sb.from("skus").select("id, product_name, variant_name").in("id", skuIds).order("id"),
+            );
+            for (const s of skuRows) {
               const label = `${s.product_name ?? ""}${s.variant_name ? ` / ${s.variant_name}` : ""}`.trim() || `#${s.id}`;
               skuNameMap.set(s.id, label);
             }


### PR DESCRIPTION
## 問題

WMS「📦 收貨待辦」頁（`wms/inbound`）最新一個 wave（例：WV260701000412）底下每一列的品項名稱全部消失，只剩一個看起來像「一」的 `—` 佔位符。

## 根因

該列顯示 `—` 代表那張 transfer 的 `summary.lines === 0`——品項一列都沒抓到。

載入邏輯抓 `transfer_items`（及後續 `skus`）時用了**無上限**的 `.in("transfer_id", transferIds)`，沒有分頁。Supabase/PostgREST 單次 select 預設最多回 **1000 列**：

- 待收（shipped）transfer 數量不設限，×每張多列品項 → 很容易破千
- 被截掉的是排在尾端的列，而**最新 wave 的 transfer_id 最大→排在尾端**
- 於是最新 wave 的品項整批被砍 → `summary.lines=0` → 品名全變 `—`
- 較舊的 wave（id 較小、落在 1000 列內）品名正常

這與 `apps/admin/src/lib/fetchAllRows.ts` 註解描述的既有雷點同一類（「最新到貨的 PO 被截在 1000 列外整張消失」）。

## 修法

把收貨頁的 `transfer_items` 與 `skus` 兩支查詢都改走既有的 `fetchAllRows` 分頁 helper，各帶 `.order("id")` 給分頁一個穩定排序。不管待收多少張都不會再被 1000 列截斷。

## Reviewer 注意

- 純前端資料載入改動，無 schema / RPC 變更。
- 邏輯等價，只是把單次查詢換成分頁；`fetchAllRows` 已在 campaigns / picking 等頁使用。
- worktree 未 `npm install`，未跑 build/tsc；型別已依下游實際用到的 shape 標註（`items` / `skuRows` 泛型）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)