### PR TITLE
feat(order-entry): 會員被小幫手加單後自動發通知

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx
@@ -102,6 +102,54 @@ function emptyItem(): ItemRow {
   return { campaign_item_id: null, sku_label: "", qty: "", unit_price: 0 };
 }
 
+// 加單成功後通知被加單的會員（僅 customer 模式：internal 是合成店家 member、offset 是庫存抵減，皆不通知）。
+// 沿用取貨/轉運既有的 admin-notify fanout；best-effort，推播失敗不影響已建立的訂單。
+async function fanoutOrderAddedNotifications(
+  rows: { member_id: number | null; items: { qty: number }[] }[],
+  campaignName: string,
+): Promise<void> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!supabaseUrl) return;
+
+  // 依會員彙總件數（同一會員多列合併成一則通知）
+  const qtyByMember = new Map<number, number>();
+  for (const r of rows) {
+    if (!r.member_id) continue;
+    const q = r.items.reduce((s, it) => s + (Number(it.qty) || 0), 0);
+    if (q <= 0) continue;
+    qtyByMember.set(r.member_id, (qtyByMember.get(r.member_id) ?? 0) + q);
+  }
+  if (qtyByMember.size === 0) return;
+
+  const sb = getSupabase();
+  const { data: sess } = await sb.auth.getSession();
+  const token = sess.session?.access_token;
+  if (!token) return;
+
+  await Promise.allSettled(
+    [...qtyByMember.entries()].map(async ([memberId, qty]) => {
+      try {
+        await fetch(`${supabaseUrl}/functions/v1/admin-notify`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            member_id: memberId,
+            title: "您有一筆新訂單",
+            message: `「${campaignName}」已為您加入 ${qty} 件商品，點此查看`,
+            url: "/orders",
+            category: "order_added",
+          }),
+        });
+      } catch (e) {
+        console.warn(`order-added push to member ${memberId} failed:`, e);
+      }
+    }),
+  );
+}
+
 export default function OrderEntryPage() {
   return (
     <Suspense fallback={<div className="p-6 text-sm text-zinc-500">載入中…</div>}>
@@ -362,6 +410,8 @@ function PageContent() {
       if (err) { setError(err.message); return; }
       const created = (data as { out_order_id: number; out_order_no: string; out_item_count: number }[]) ?? [];
       setToast(`已建立/更新 ${created.length} 筆訂單`);
+      // 通知被加單的會員（best-effort，不 await 以免拖慢表單重置）
+      void fanoutOrderAddedNotifications(rows, campaign?.name ?? "");
       setEntries([newEntry()]);
       localStorage.removeItem(draftKey);
       setTimeout(() => setToast(null), 3000);

--- a/docs/TEST-order-added-notification.md
+++ b/docs/TEST-order-added-notification.md
@@ -1,0 +1,56 @@
+# TEST — 會員被加單時發通知
+
+功能：後台「小幫手加單」(`campaigns/order-entry`) 於 **customer 模式**成功建立/更新訂單後，
+自動通知每一位被加單的會員（in-app notification + web push），沿用既有 `admin-notify` edge function。
+
+改動範圍：純前端 `apps/admin/src/app/(protected)/campaigns/order-entry/page.tsx`
+（新增 `fanoutOrderAddedNotifications` + 在 `handleSubmit` customer 分支呼叫）。
+**不需 migration、不需改 edge function**（`admin-notify` 單人模式已會寫 `notifications` 表並推 web push）。
+
+---
+
+## 1. 觸發正確性
+
+- [ ] **customer 模式加單成功 → 該會員收到通知**
+  - 加單頁選一個真實會員 + 商品，送出成功後：
+    - `notifications` 表新增一列：`member_id` = 該會員、`category = 'order_added'`、
+      `title = '您有一筆新訂單'`、`body` 含團名與件數、`url = '/orders'`。
+    - 若該會員有 `push_subscriptions` → 裝置收到 web push。
+- [ ] **多會員一次送出 → 每位各收一則**（依 member_id 去重/彙總，不重複轟炸）。
+- [ ] **同一會員多列 → 合併成一則**，件數為各列加總。
+- [ ] **通知 body 件數正確**：等於該會員本次送出所有 items 的 qty 總和。
+
+## 2. 不該觸發的情境
+
+- [ ] **internal 模式（分店叫貨）不發通知** — 對象是合成的 `store_internal` member，非真人。
+- [ ] **offset 模式（庫存抵減單）不發通知** — 純庫存調整。
+- [ ] **送出失敗（RPC error）不發通知** — 只有 `rpc_create_customer_orders` 成功後才 fanout。
+- [ ] **沒有有效訂單列（rows 為空）不發** — 提早 return，helper 不被呼叫。
+
+## 3. 韌性 / 不影響主流程
+
+- [ ] **推播失敗不影響訂單建立** — 訂單已建立、toast 正常顯示、表單已重置；
+      admin-notify 掛掉只在 console.warn，不 setError、不 rollback。
+- [ ] **會員無 push 訂閱** → 仍寫入 in-app notification（admin-notify 既有行為），
+      會員端 `/notifications` 頁看得到。
+- [ ] **fanout 不 await** → 表單重置與 toast 不被推播延遲卡住。
+
+## 4. 會員端顯示
+
+- [ ] 會員端 `/notifications` 出現該通知，點擊導到 `/orders`。
+- [ ] `NotificationCard` 對 `order_added` category 正常渲染（不依 category 分流，無需改）。
+- [ ] 未讀紅點 (`useUnreadNotifications`) +1。
+
+## 5. Regression
+
+- [ ] 加單三模式（customer / internal / offset）主流程皆正常送出。
+- [ ] 既有取貨/轉運/美食列車推播不受影響（共用 admin-notify，未改該 fn）。
+- [ ] `tsc --noEmit`：order-entry/page.tsx 無新增型別錯誤。
+
+---
+
+### 驗證備註
+- Admin live preview 從沙箱被網路阻擋（連不到本地 Supabase），登入流程跑不完 →
+  觸發面驗證交由使用者在自己的環境自審；程式面以 tsc + code review 為準。
+- 快速 DB 檢核：加單後對 prod/本機查
+  `select category,title,body,url from notifications order by created_at desc limit 5;`


### PR DESCRIPTION
## 目的
會員被後台「小幫手加單」加入訂單時，主動通知該會員（讓會員能核對「有人幫我下了單」）。

## 做法
- 加單頁 `campaigns/order-entry` 在 **customer 模式**成功建立/更新訂單後，依會員彙總件數、去重，best-effort fan-out 呼叫既有 `admin-notify` edge function。
- `admin-notify` 單人模式既有行為：寫入 `notifications` 表（會員端 `/notifications` 看得到）+ 對有訂閱的裝置發 web push。
- 通知內容：title「您有一筆新訂單」、body 含團名與件數、`url=/orders`、`category=order_added`。

## 刻意不觸發
- **internal**（分店叫貨）：對象是合成的 `store_internal` member，非真人。
- **offset**（庫存抵減單）：純庫存調整。
- RPC 失敗、無有效訂單列：不發。

## 韌性
- fanout 不 `await`，不拖慢表單重置；推播失敗只 `console.warn`，**不影響已建立的訂單**。
- 會員無 push 訂閱時仍會寫入 in-app 通知。

## 範圍
- 純前端改動，複用既有通知基礎設施，**無 migration、未改 edge function**。
- 測試清單見 `docs/TEST-order-added-notification.md`。

## 驗證
- `tsc`：order-entry 檔案無新增型別錯誤（既有的 papaparse/.next validator 錯誤與本 PR 無關）。
- Admin live preview 從沙箱被網路阻擋，觸發面驗證交由自審。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
