### PR TITLE
fix(restock): 補貨申請商品搜尋補回 product_name，中文商品名搜得到

### DIFF
--- a/apps/admin/src/app/(protected)/restock/new/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/new/page.tsx
@@ -197,7 +197,7 @@ function LineRow({
           .eq("products.is_virtual", false)
           .limit(15);
         const safe = term.replace(/[%,()]/g, " ").trim();
-        if (safe) q = q.or(`sku_code.ilike.%${safe}%,variant_name.ilike.%${safe}%`);
+        if (safe) q = q.or(`sku_code.ilike.%${safe}%,product_name.ilike.%${safe}%,variant_name.ilike.%${safe}%`);
         const { data } = await q;
         const ids = (data ?? []).map((r) => r.id);
         let priceMap = new Map<number, { retail?: number; branch?: number }>();


### PR DESCRIPTION
## 問題

補貨申請頁（`/restock/new`）的品項搜尋打**中文商品名找不到**，只有打料號（如 G00863）才有結果。

## 根因

品項搜尋的 `.or()` 只比對了 `sku_code` 與 `variant_name`，**漏掉 `product_name`**：

```
q.or(`sku_code.ilike.%${safe}%,variant_name.ilike.%${safe}%`)
```

所以商品名（例：耗材）不在搜尋條件內，中文商品名一律搜不到。

## 修法

補回 `product_name.ilike`，對齊站內其他四個商品搜尋頁（盤點 / 補貨規則 / 庫存總覽 / 互助調撥）一致的三欄搜尋：

```
q.or(`sku_code.ilike.%${safe}%,product_name.ilike.%${safe}%,variant_name.ilike.%${safe}%`)
```

`skus` 表已有 denormalized 的 `product_name` 欄位（那幾頁都直接用），因此不需改動 `products` join，一行搞定。

## Reviewer 注意

- 純前端查詢條件修正，無 schema / RPC 變動。
- admin live-preview 從沙箱連不到本地 Supabase（既有已知限制），本輪走碼審對齊，preview 留給人工自審。

🤖 Generated with [Claude Code](https://claude.com/claude-code)