### PR TITLE
feat(stores): 門市一鍵可刪，不用先手動停用

### DIFF
--- a/apps/admin/src/app/(protected)/stores/page.tsx
+++ b/apps/admin/src/app/(protected)/stores/page.tsx
@@ -119,8 +119,8 @@ export default function StoresPage() {
   async function handleDelete(r: Store) {
     const ok = window.confirm(
       `確定刪除門市「${r.name}」(${r.code})？\n\n` +
-      `刪除後從預設列表消失（可在「僅已刪除」找到並還原）。\n` +
-      `若有進行中訂單或補貨申請、或還在啟用中，後端會拒絕。`,
+      `刪除會同時停用該門市、並從預設列表消失（可在「僅已刪除」找到並還原）。\n` +
+      `若有進行中訂單或補貨申請，後端會拒絕。`,
     );
     if (!ok) return;
     try {
@@ -322,7 +322,7 @@ export default function StoresPage() {
                           編輯
                         </SpinButton>
                       )}
-                      {!r.deleted_at && !r.is_active && (
+                      {!r.deleted_at && (
                         <SpinButton
                           onClick={() => handleDelete(r)}
                           className="text-xs text-red-600 hover:underline dark:text-red-400"

--- a/supabase/migrations/20260713000000_rpc_delete_store_allow_active.sql
+++ b/supabase/migrations/20260713000000_rpc_delete_store_allow_active.sql
@@ -1,0 +1,96 @@
+-- ============================================================
+-- rpc_delete_store：放寬「必須先停用才能刪」，改成一鍵可刪（刪時兼停用）
+--
+-- 基底：20260620000080_rpc_delete_store.sql（唯一動過此函式的版本）
+-- rollback：指回 20260620000080 版本（含 is_active 守門）即可
+--
+-- 動機：
+--   原設計要求 is_active=false 才能刪，是兩段式（先停用→再刪）。實務上
+--   後台門市多半是啟用中，導致刪除鈕（前端 !is_active 才顯示）根本按不到，
+--   使用者以為「線上沒這功能」。刪除本就是軟刪 + 可還原，先停用只是儀式。
+--
+-- 變更：
+--   1. 移除「門市還在啟用中，請先停用才能刪除」的 guard
+--   2. UPDATE 時一併設 is_active=false（刪除本就代表下線）
+--   3. 其餘守門全部保留：owner/admin、已刪防重複、進行中訂單、進行中補貨
+--
+-- 反悔：UPDATE stores SET deleted_at = NULL WHERE id = X（還原後仍為停用）
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_delete_store(
+  p_id       BIGINT,
+  p_operator UUID DEFAULT NULL
+) RETURNS stores
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant   UUID := (auth.jwt() ->> 'tenant_id')::uuid;
+  v_role     TEXT := COALESCE(
+                       NULLIF(auth.jwt() -> 'app_metadata' ->> 'role', ''),
+                       NULLIF(auth.jwt() ->> 'role', 'authenticated'),
+                       ''
+                     );
+  v_operator UUID := COALESCE(p_operator, auth.uid());
+  v_store    stores;
+  v_open_orders   INT;
+  v_open_restocks INT;
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+  IF v_role NOT IN ('owner','admin','') THEN
+    RAISE EXCEPTION 'permission denied: only owner/admin can delete stores';
+  END IF;
+
+  SELECT * INTO v_store FROM stores
+   WHERE id = p_id AND tenant_id = v_tenant FOR UPDATE;
+  IF v_store.id IS NULL THEN
+    RAISE EXCEPTION 'store % not found', p_id;
+  END IF;
+
+  IF v_store.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION '門市 % 已被刪除（deleted_at=%）', v_store.code, v_store.deleted_at;
+  END IF;
+
+  -- （移除「必須先停用」的 guard；刪除時於下方一併停用）
+
+  -- 守門：進行中的訂單
+  SELECT COUNT(*) INTO v_open_orders
+    FROM customer_orders
+   WHERE tenant_id = v_tenant
+     AND pickup_store_id = p_id
+     AND status NOT IN ('cancelled','expired','completed');
+  IF v_open_orders > 0 THEN
+    RAISE EXCEPTION '門市 % 仍有 % 筆進行中訂單（非 cancelled/expired/completed），不能刪除',
+      v_store.code, v_open_orders;
+  END IF;
+
+  -- 守門：進行中的補貨申請
+  SELECT COUNT(*) INTO v_open_restocks
+    FROM restock_requests
+   WHERE tenant_id = v_tenant
+     AND requesting_store_id = p_id
+     AND status NOT IN ('cancelled','received','rejected');
+  IF v_open_restocks > 0 THEN
+    RAISE EXCEPTION '門市 % 仍有 % 筆進行中補貨申請，不能刪除',
+      v_store.code, v_open_restocks;
+  END IF;
+
+  UPDATE stores
+     SET deleted_at = NOW(),
+         is_active  = FALSE,   -- 刪除即下線，取代原本「先手動停用」的要求
+         updated_by = v_operator,
+         updated_at = NOW()
+   WHERE id = p_id AND tenant_id = v_tenant
+   RETURNING * INTO v_store;
+
+  RETURN v_store;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_delete_store(BIGINT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION rpc_delete_store(BIGINT, UUID) IS
+  '軟刪除門市（一鍵可刪，刪時兼停用）。守門：owner/admin、無進行中訂單與補貨申請。設定 deleted_at + is_active=false。';


### PR DESCRIPTION
## 背景

門市刪除功能其實早已存在（`rpc_delete_store` + 前端 UI，PR 已 merged、prod RPC 也在），但**啟用中的門市看不到刪除鈕**：前端刪除鈕限 `!is_active` 才顯示、後端也擋「還在啟用中不能刪」。實務上後台門市多為啟用中 → 按不到 → 使用者以為「線上沒這功能」。

## 變更

- **後端** `supabase/migrations/20260713000000_rpc_delete_store_allow_active.sql`（基底 = 20260620000080）
  - 移除「門市還在啟用中，請先停用才能刪除」guard
  - `UPDATE` 時一併 `is_active = FALSE`（刪除即下線，取代原「先手動停用」）
  - 其餘守門全部保留：owner/admin、已刪防重複、進行中訂單、進行中補貨
  - ✅ 已部署 prod（apply_one_migration，非破壞性 CREATE OR REPLACE）
- **前端** `apps/admin/src/app/(protected)/stores/page.tsx`
  - 刪除鈕改為所有未刪門市皆可見（移除 `&& !r.is_active`）
  - 確認文案改為「刪除會同時停用該門市」

軟刪語意不變：設 `deleted_at`、從預設列表消失、可在「僅已刪除」還原。

🤖 Generated with [Claude Code](https://claude.com/claude-code)