### PR TITLE
feat(order-transfer): 轉出訂單可勾「空中轉」（不經總倉、只需接收店收貨）

### DIFF
--- a/apps/admin/src/components/OrderTransferModal.tsx
+++ b/apps/admin/src/components/OrderTransferModal.tsx
@@ -61,6 +61,8 @@ export function OrderTransferModal({
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchWrapRef = useRef<HTMLDivElement | null>(null);
   const [reason, setReason] = useState("");
+  // 空中轉：直接店對店、不經總倉；不勾 = 經總倉中轉（總倉需確認到貨再配送）
+  const [isAir, setIsAir] = useState(false);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   // 每個品項的轉移勾選 + 數量（預設全選、全量 = 整單轉出）
@@ -73,6 +75,7 @@ export function OrderTransferModal({
     const next: Record<number, { checked: boolean; qty: string }> = {};
     for (const it of items) next[it.id] = { checked: true, qty: String(it.qty) };
     setPicks(next);
+    setIsAir(false);
   }
 
   useEffect(() => {
@@ -162,6 +165,8 @@ export function OrderTransferModal({
     if (toStore === currentPickupStoreId) {
       if (!confirm("接收店與原店相同（同店換客人）。確定繼續？")) return;
     }
+    // 空中轉僅對跨店有意義；同店換客人沒有物理配送、一律非空中轉
+    const airFlag = isAir && toStore !== currentPickupStoreId;
     setBusy(true);
     setErr(null);
     try {
@@ -176,6 +181,7 @@ export function OrderTransferModal({
           p_to_channel_id: null,
           p_operator: user?.id,
           p_reason: reason || null,
+          p_is_air_transfer: airFlag,
         });
         if (e) throw new Error(e.message);
         newId = data as number;
@@ -194,7 +200,7 @@ export function OrderTransferModal({
           p_operator: user?.id,
           p_reason: reason || null,
           p_items: pItems,
-          p_is_air_transfer: false,
+          p_is_air_transfer: airFlag,
         });
         if (e) throw new Error(e.message);
         newId = data as number;
@@ -420,6 +426,25 @@ export function OrderTransferModal({
             預設全選全量 = 整單轉出；取消勾選或減少數量 = 部分轉出（原單保留剩餘）
           </span>
         </div>
+
+        {toStore !== "" && toStore !== currentPickupStoreId && (
+          <div className="flex flex-col gap-1">
+            <label className="flex items-start gap-2 rounded-md border border-zinc-200 p-2 dark:border-zinc-700">
+              <input
+                type="checkbox"
+                checked={isAir}
+                onChange={(e) => setIsAir(e.target.checked)}
+                className="mt-0.5 h-4 w-4"
+              />
+              <span className="min-w-0 flex-1">
+                <span className="font-medium">空中轉（直接店對店、不經總倉）</span>
+                <span className="mt-0.5 block text-[11px] text-zinc-400">
+                  勾選 = 轉出店直接配送到接收店、只需接收店收貨；不勾 = 經總倉中轉，總倉需確認到貨再配送
+                </span>
+              </span>
+            </label>
+          </div>
+        )}
 
         <label className="flex flex-col gap-1">
           <span className="text-zinc-500">轉出原因</span>

--- a/docs/TEST-order-transfer-air.md
+++ b/docs/TEST-order-transfer-air.md
@@ -1,0 +1,63 @@
+# TEST — 轉出訂單「空中轉」勾選
+
+功能：在「轉出訂單」modal 讓操作員勾選**空中轉**（直接店對店、不經總倉），
+flag 寫入轉入訂單 `customer_orders.is_air_transfer`，下游 `rpc_ship_aid_order`
+依此建 1 段（空中轉）或 2 段（經總倉）transfer chain。
+
+改動檔：
+- `supabase/migrations/20260712000000_transfer_order_to_store_air.sql`
+  （`rpc_transfer_order_to_store` 加 `p_is_air_transfer`）
+- `apps/admin/src/components/OrderTransferModal.tsx`（勾選 UI + 傳參）
+
+---
+
+## Schema / RPC 層
+
+- [ ] **S1** migration 部署後，`rpc_transfer_order_to_store` 簽章為 7 args
+      （尾參 `p_is_air_transfer BOOLEAN DEFAULT FALSE`）；舊 6-arg 版已 DROP，
+      不存在 overload（`\df rpc_transfer_order_to_store` 只有一列）。
+- [ ] **S2** 6 個具名參數呼叫（不帶 `p_is_air_transfer`）仍可執行、預設 `false`。
+- [ ] **S3** 整單轉出（跨店）帶 `p_is_air_transfer=true` → 新訂單
+      `is_air_transfer=true`、notes 標「(空中轉)」。
+- [ ] **S4** 整單轉出帶 `false` → 新訂單 `is_air_transfer=false`、notes 標「(經總倉)」。
+- [ ] **S5** 部分轉出（`rpc_transfer_order_partial`）帶 `true` / `false` 同樣正確寫入。
+- [ ] **S6** 來源訂單非 `ready` → 兩支 RPC 皆 raise「貨還沒到分店…不可轉單」（F2 保留）。
+- [ ] **S7** 同店轉出：即使呼叫端誤傳 `true`，UI 已 guard 成 `false`（見 U5）；
+      RPC 層同店仍 mirror source.status（既有行為不變）。
+
+## 下游派貨 chain（rpc_ship_aid_order）
+
+- [ ] **D1** 空中轉訂單 confirmed → 派貨：只建 **1 段** transfer
+      （`transfer_type='store_to_store'`, `source=轉出店`, `dest=接收店`,
+      `status='shipped'`, `customer_order_id=本單`, `next_transfer_id=NULL`），
+      轉出店即時 outbound。**不建 HQ leg**。
+- [ ] **D2** 經總倉訂單 confirmed → 派貨：建 **2 段**
+      （Leg-1 source→HQ shipped、Leg-2 HQ→dest draft，chained）。
+- [ ] **D3** 空中轉：接收店在收貨頁 `rpc_receive_transfer` 收 Leg-1 →
+      訂單 `shipping → ready`，**過程無總倉任何動作**。
+- [ ] **D4** 經總倉：需總倉收 Leg-1（到倉）→ 自動 ship Leg-2 → 接收店收 Leg-2 → ready。
+
+## UI 層（OrderTransferModal）
+
+- [ ] **U1** 選跨店接收店後才出現「空中轉」勾選框；未選店 / 同店時不顯示。
+- [ ] **U2** 勾選後整單轉出 → 送 `p_is_air_transfer=true`；不勾 → `false`。
+- [ ] **U3** 勾選後部分轉出（取消勾選部分品項或改量）→ 送 `p_is_air_transfer=true`。
+- [ ] **U4** 重新開窗 / 換訂單 → 勾選重置為未勾（`setIsAir(false)`）。
+- [ ] **U5** 先選跨店並勾空中轉、再改回同店 → 送出時 `airFlag` 被 guard 成 `false`。
+- [ ] **U6** 勾選框文案清楚：勾=直接配送到接收店只需接收店收貨；不勾=經總倉中轉。
+
+## Regression
+
+- [ ] **R1** 既有整單/部分轉出（不勾空中轉）行為完全不變（等同 `false`）。
+- [ ] **R2** `tsc --noEmit` 通過（已驗證 ✅）。
+- [ ] **R3** mutual-aid 頁沿用同一 modal，勾選框在該頁跨店情境亦正常出現。
+- [ ] **R4** 結算：空中轉的成本調整（`20260512000012_settlement_air_transfer_adjustment`）
+      不受影響（本次未動結算鏈）。
+
+---
+
+### 驗證狀態（本輪）
+- ✅ `tsc --noEmit`（apps/admin）通過
+- ✅ SQL 靜態審查：基於最新版 20260629000040 擴寫，保留 F2/同店 mirror/reserved 釋放
+- ⏳ S/D 系列需 migration 部署到 DB 後以真資料跑（admin live preview 於沙箱被阻擋，
+  走 DB 直驗）

--- a/supabase/migrations/20260712000000_transfer_order_to_store_air.sql
+++ b/supabase/migrations/20260712000000_transfer_order_to_store_air.sql
@@ -1,0 +1,208 @@
+-- ============================================================
+-- rpc_transfer_order_to_store 加 p_is_air_transfer
+--
+-- 背景：轉出訂單（整單）在 UI 上要能勾「空中轉」。之前只有部分轉出
+-- (rpc_transfer_order_partial) 支援 p_is_air_transfer，整單這支完全沒有
+-- 這個參數、新單一律以 column default (FALSE) 寫入 → 整單轉出永遠被當成
+-- 「經總倉」，下游 rpc_ship_aid_order 一律建 2 段 chain、要總倉確認。
+--
+-- 兩種轉單實體流（跟 partial 一致、由下游 rpc_ship_aid_order 依此 flag 分流）：
+--   空中轉 (is_air_transfer=true)：轉出店 → 分店收貨 → 顧客取貨（不經總倉）
+--   經總倉 (false)              ：轉出店 → 總倉(收到) → 配送 → 分店收貨 → 顧客取貨
+--
+-- 改動：DROP 舊 6-arg 版、CREATE 7-arg 版（尾加 p_is_air_transfer BOOLEAN
+--      DEFAULT FALSE），把 flag 寫入新（轉入）訂單的 is_air_transfer 欄。
+--      其餘邏輯（F2 只允 'ready'、同店 mirror source.status、釋放 reserved、
+--      整單轉出把來源設 transferred_out）完全保留。
+--
+-- 基底：20260629000040_transfer_require_ready_status.sql 的
+--      rpc_transfer_order_to_store（時間最新版）。
+-- Rollback：DROP 本 7-arg 版、CREATE OR REPLACE 回 20260629000040 的 6-arg 版
+--          （GRANT 也指回 6-arg 簽章）。
+-- ============================================================
+
+-- 舊 6-arg 版要先 DROP，否則 7-arg（含 DEFAULT）會與其成為 overload、
+-- 6 個具名參數的呼叫變 ambiguous。
+DROP FUNCTION IF EXISTS public.rpc_transfer_order_to_store(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT
+);
+
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_to_store(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT DEFAULT NULL,
+  p_is_air_transfer       BOOLEAN DEFAULT FALSE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_item             RECORD;
+  v_orig_mov         RECORD;
+  v_rev_id           BIGINT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_note_out         TEXT;
+  v_note_in          TEXT;
+  v_new_status       TEXT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  -- 貨還沒到分店不能轉單：source 必須 status='ready'
+  IF v_orig.status <> 'ready' THEN
+    RAISE EXCEPTION '貨還沒到分店、訂單 % 不可轉單 (status=%)',
+                    p_order_id, v_orig.status;
+  END IF;
+
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  PERFORM 1 FROM line_channels
+   WHERE id = v_to_channel_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'channel % not in tenant', v_to_channel_id;
+  END IF;
+
+  PERFORM 1 FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id;
+  IF FOUND THEN
+    RAISE EXCEPTION 'receiver already has order in (campaign=%, channel=%, member=%)',
+                    v_orig.campaign_id, v_to_channel_id, v_to_member_id;
+  END IF;
+
+  -- E2: 釋放 reserved_movement（無條件、跟以前一致；同店也走這條）
+  FOR v_item IN
+    SELECT id, reserved_movement_id FROM customer_order_items
+     WHERE order_id = p_order_id AND reserved_movement_id IS NOT NULL
+  LOOP
+    SELECT * INTO v_orig_mov FROM stock_movements WHERE id = v_item.reserved_movement_id;
+    IF FOUND THEN
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+        source_doc_type, source_doc_id, reverses, reason, operator_id
+      ) VALUES (
+        v_orig_mov.tenant_id, v_orig_mov.location_id, v_orig_mov.sku_id,
+        -v_orig_mov.quantity, v_orig_mov.unit_cost, 'reversal',
+        'order_transfer', p_order_id, v_orig_mov.id,
+        'order #' || p_order_id || ' transferred out, release allocation', p_operator
+      ) RETURNING id INTO v_rev_id;
+
+      UPDATE stock_movements SET reversed_by = v_rev_id WHERE id = v_orig_mov.id;
+      UPDATE customer_order_items SET reserved_movement_id = NULL WHERE id = v_item.id;
+    END IF;
+  END LOOP;
+
+  SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+  SELECT COUNT(*) + 1 INTO v_seq
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+  v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+  v_note_in := COALESCE(p_reason, '') ||
+               E'\n[轉入 (' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+               ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+               to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  -- 同店：mirror source.status；跨店：'pending'
+  v_new_status := CASE
+    WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN v_orig.status
+    ELSE 'pending'
+  END;
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id,
+    nickname_snapshot, pickup_store_id, status, notes,
+    transferred_from_order_id, is_air_transfer,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+    v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status, v_note_in,
+    p_order_id, p_is_air_transfer,
+    p_operator, p_operator, v_now, v_now
+  ) RETURNING id INTO v_new_order_id;
+
+  INSERT INTO customer_order_items (
+    tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+    status, source, notes, created_by, updated_by
+  )
+  SELECT tenant_id, v_new_order_id, campaign_item_id, sku_id, qty, unit_price,
+         'pending', 'aid_transfer', notes, p_operator, p_operator
+    FROM customer_order_items
+   WHERE order_id = p_order_id;
+
+  v_note_out := COALESCE(p_reason, '') ||
+                E'\n[轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  UPDATE customer_orders
+     SET status                   = 'transferred_out',
+         transferred_to_order_id  = v_new_order_id,
+         notes                    = COALESCE(notes, '') || v_note_out,
+         updated_by               = p_operator,
+         updated_at               = v_now
+   WHERE id = p_order_id;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_to_store(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, BOOLEAN
+) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_transfer_order_to_store(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, BOOLEAN
+) IS
+  '整單轉出：新（轉入）單帶 is_air_transfer flag（true=空中轉不經總倉、false=經總倉中轉）；'
+  '下游 rpc_ship_aid_order 依此建 1 段 / 2 段 transfer chain。基底 20260629000040。';


### PR DESCRIPTION
## 需求
訂單轉單分兩種實體流：
- **空中轉**：轉出店 → 接收店收貨（不經總倉、不用總倉確認）
- **一般轉單**：轉出店 → 總倉確認到貨 → 配送 → 接收店收貨

要在「轉出訂單」頁面能勾選「空中轉」。

## 現況缺口
下游 `rpc_ship_aid_order` 早就依 `customer_orders.is_air_transfer` 分流建
1 段（空中轉，store→store 直送）或 2 段（經總倉，chained）transfer chain。
但「轉出當下」設不到這個 flag：
- 整單 `rpc_transfer_order_to_store` **完全沒有** `is_air_transfer` 參數 → 永遠 default `false`（被當經總倉）。
- 部分 `rpc_transfer_order_partial` 有參數，但 UI **hardcode `false`**。

## 改動
- **migration `20260712000000`**：`rpc_transfer_order_to_store` DROP 舊 6-arg、CREATE 7-arg（尾加 `p_is_air_transfer BOOLEAN DEFAULT FALSE`），寫入新（轉入）訂單。基底＝最新版 `20260629000040`，保留 F2 只允 `ready`、同店 mirror source.status、reserved 釋放。
- **`OrderTransferModal.tsx`**：跨店時顯示「空中轉」勾選框；整單/部分兩條路徑都傳 `airFlag`（同店 guard 成 `false`；開窗/換單重置）。
- **`docs/TEST-order-transfer-air.md`**：測試清單。

未動 HQ inbox：空中轉 leg 是 store→store 在途，HQ 到倉/出貨鈕本就（dest≠HQ）隱藏、頁面另有 air/via_warehouse 篩選，語意已正確。

## 驗證
- ✅ `tsc --noEmit`（apps/admin）通過
- ✅ SQL 靜態審查（基於最新版擴寫、保留所有 prior fix）
- ⏳ S/D 系列（RPC + 派貨 chain）需 migration 部署後以真資料跑 — admin live preview 於沙箱被阻擋，走 DB 直驗

🤖 Generated with [Claude Code](https://claude.com/claude-code)