### PR TITLE
feat(order-transfer): 互助單被取消/已收貨退回，貨退回原調出店

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -27,6 +27,7 @@ type Row = {
   pickup_store_id: number;
   pickup_deadline: string | null;
   status: OrderStatus;
+  transferred_from_order_id: number | null;
   created_at: string;
   updated_at: string;
 };
@@ -246,7 +247,7 @@ function OrdersListContent() {
       try {
         let q = getSupabase()
           .from("customer_orders")
-          .select("id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, created_at, updated_at", { count: "exact" })
+          .select("id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, transferred_from_order_id, created_at, updated_at", { count: "exact" })
           .order("updated_at", { ascending: false })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 
@@ -416,6 +417,29 @@ function OrdersListContent() {
     setReloadOrders((n) => n + 1);
   }
 
+  // 互助單已收貨(ready)退回原店：反向退回原調出店並還原來源單（rpc_return_aid_order）
+  async function returnAidToSource(orderId: number, orderNo: string) {
+    const reason = prompt(
+      `退回原店：${orderNo}\n會把已收貨品反向退回原調出店，並把來源單還原。請輸入原因：`,
+    );
+    if (reason === null) return;
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id ?? null;
+    if (!operator) { alert("尚未登入"); return; }
+    const { data, error: rpcErr } = await sb.rpc("rpc_return_aid_order", {
+      p_order_id: orderId,
+      p_reason: reason,
+      p_operator: operator,
+    });
+    if (rpcErr) { alert(`退回失敗：${translateRpcError(rpcErr)}`); return; }
+    const refunded = Number((data as { wallet_refunded?: number } | null)?.wallet_refunded ?? 0);
+    alert(refunded > 0
+      ? `已退回原店，已退回 $${refunded} 儲值金到會員餘額`
+      : "已退回原店，貨已退回原調出店");
+    setReloadOrders((n) => n + 1);
+  }
+
   // 操作按鈕（去取貨 / 取消 / ↩退貨 / 狀態鈕）— 桌機表格與手機卡片共用，單一維護點
   const orderActions = (r: Row, m: Member | null | undefined) => (
     <>
@@ -465,6 +489,16 @@ function OrdersListContent() {
           取消
         </SpinButton>
       )}
+      {/* 互助單已收貨（ready）：退回原調出店，而非退回總倉（貨源是分店不是總倉） */}
+      {r.status === "ready" && r.transferred_from_order_id != null && (
+        <SpinButton
+          onClick={() => returnAidToSource(r.id, r.order_no)}
+          title="互助單已收貨：反向退回原調出店並還原來源單"
+          className="rounded-md border border-orange-300 px-2 py-1 text-[11px] font-medium text-orange-700 hover:bg-orange-50 dark:border-orange-800 dark:text-orange-300 dark:hover:bg-orange-950"
+        >
+          ↩ 退回原店
+        </SpinButton>
+      )}
       {r.status === "cancelled" && (
         <SpinButton
           disabled
@@ -501,7 +535,8 @@ function OrdersListContent() {
           已轉出
         </SpinButton>
       )}
-      {["ready", "partially_completed", "completed", "expired"].includes(r.status) && (
+      {["ready", "partially_completed", "completed", "expired"].includes(r.status)
+        && !(r.status === "ready" && r.transferred_from_order_id != null) && (
         <SpinButton
           onClick={() => setReturnTarget({ orderId: r.id, storeId: r.pickup_store_id })}
           title="已收貨/已取貨，無法取消；點此退貨回總倉（反向回收已派庫存）"

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -31,6 +31,7 @@ type OpenOrder = {
   pickup_store_id: number | null;
   discount_amount: number;
   ready_at: string | null;       // 到貨時間 (shipping → ready 自動寫入)
+  transferred_from_order_id: number | null; // 互助轉入單才有；用來判斷是否走「退回原店」
   last_notify_pickup_at: string | null;
   notify_pickup_count: number;
   campaign: { id: number; campaign_no: string; name: string } | null;
@@ -143,7 +144,7 @@ function PickupPageContent() {
       const { data: ords, error: e2 } = await sb
         .from("customer_orders")
         .select(
-          `id, order_no, status, pickup_deadline, pickup_store_id, discount_amount, ready_at, last_notify_pickup_at, notify_pickup_count, member_id,
+          `id, order_no, status, pickup_deadline, pickup_store_id, discount_amount, ready_at, transferred_from_order_id, last_notify_pickup_at, notify_pickup_count, member_id,
            campaign:group_buy_campaigns(id, campaign_no, name),
            store:stores!customer_orders_pickup_store_id_fkey(id, name),
            items:customer_order_items(id, qty, unit_price, status, sku:skus(variant_name, product_name, product:products(images)))`,
@@ -299,6 +300,30 @@ function PickupPageContent() {
     });
     if (rpcErr) { alert(`取消失敗：${translateRpcError(rpcErr)}`); return; }
     alert("已取消");
+    setReloadTick((n) => n + 1);
+  }
+
+  // 互助單已收貨(ready)退回原店：反向退回原調出店並還原來源單（rpc_return_aid_order）。
+  // 貨源是分店不是總倉，所以不走「退貨回總倉」。
+  async function returnAidToSource(order: OpenOrder) {
+    const reason = prompt(
+      `退回原店：${order.order_no}\n會把已收貨品反向退回原調出店，並把來源單還原。請輸入原因：`,
+    );
+    if (reason === null) return;
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id ?? null;
+    if (!operator) { alert("尚未登入"); return; }
+    const { data, error: rpcErr } = await sb.rpc("rpc_return_aid_order", {
+      p_order_id: order.id,
+      p_reason: reason,
+      p_operator: operator,
+    });
+    if (rpcErr) { alert(`退回失敗：${translateRpcError(rpcErr)}`); return; }
+    const refunded = Number((data as { wallet_refunded?: number } | null)?.wallet_refunded ?? 0);
+    alert(refunded > 0
+      ? `已退回原店，已退回 $${refunded} 儲值金到會員餘額`
+      : "已退回原店，貨已退回原調出店");
     setReloadTick((n) => n + 1);
   }
 
@@ -600,13 +625,24 @@ function PickupPageContent() {
                             >
                               ✏️
                             </SpinButton>
-                            {["ready", "partially_completed"].includes(o.status) && (
+                            {["ready", "partially_completed"].includes(o.status)
+                              && !(o.status === "ready" && o.transferred_from_order_id != null) && (
                               <SpinButton
                                 onClick={() => setReturnTarget({ orderId: o.id, storeId: o.pickup_store_id ?? o.store?.id ?? null })}
                                 title="已收貨，無法取消；點此退貨回總倉（反向回收已派庫存）"
                                 className="rounded-md border border-orange-300 px-2 py-2 text-xs font-medium text-orange-700 hover:bg-orange-50 dark:border-orange-800 dark:text-orange-300 dark:hover:bg-orange-950"
                               >
                                 ↩ 退貨
+                              </SpinButton>
+                            )}
+                            {/* 互助單已收貨：退回原調出店（貨源是分店不是總倉） */}
+                            {o.status === "ready" && o.transferred_from_order_id != null && (
+                              <SpinButton
+                                onClick={() => returnAidToSource(o)}
+                                title="互助單已收貨：反向退回原調出店並還原來源單"
+                                className="rounded-md border border-orange-300 px-2 py-2 text-xs font-medium text-orange-700 hover:bg-orange-50 dark:border-orange-800 dark:text-orange-300 dark:hover:bg-orange-950"
+                              >
+                                ↩ 退回原店
                               </SpinButton>
                             )}
                             {["pending", "confirmed", "shipping"].includes(o.status) && (

--- a/apps/admin/src/components/AidOrderStatusActions.tsx
+++ b/apps/admin/src/components/AidOrderStatusActions.tsx
@@ -11,6 +11,7 @@ import { RowAction } from "@/components/RowAction";
 //   confirmed → shipping  (rpc_ship_aid_order — 派貨 + outbound 庫存 + 建 transfer chain)
 //   shipping → ready      (由店家在「收貨」代辦頁觸發,rpc_receive_transfer 內部自動推進)
 //   ready → completed     (由門市在「取貨」流程觸發、HQ 不需手動推進)
+//   ready → (退回原店)     (接收店已收貨但要退,rpc_return_aid_order 反向退回原調出店 + 還原來源單)
 const ADVANCE_NEXT: Partial<Record<OrderStatus, OrderStatus>> = {
   pending: "confirmed",
 };
@@ -25,6 +26,8 @@ export function AidOrderStatusActions({ order, onChanged }: AidOrderStatusAction
   const advanceNext = ADVANCE_NEXT[order.status];
   const isShipAction = order.status === "confirmed";
   const isCancellable = ["pending", "confirmed", "shipping"].includes(order.status);
+  // 已收貨(ready)不能走取消,要走「退回原店」— 反向退回原調出店並還原來源單
+  const isReturnable = order.status === "ready";
 
   async function getOperator(): Promise<string | null> {
     const sb = getSupabase();
@@ -89,6 +92,26 @@ export function AidOrderStatusActions({ order, onChanged }: AidOrderStatusAction
     }
   }
 
+  // 已收貨(ready)退回原店:反向退回原調出店、還原來源單(rpc_return_aid_order)
+  async function returnToSource() {
+    const reason = prompt("退回原店原因(會把已收貨品反向退回原調出店,並還原來源單):");
+    if (reason === null) return;
+    setBusy(true);
+    try {
+      const operator = await getOperator();
+      if (!operator) { alert("尚未登入"); return; }
+      const { error } = await getSupabase().rpc("rpc_return_aid_order", {
+        p_order_id: order.id,
+        p_reason: reason,
+        p_operator: operator,
+      });
+      if (error) { alert(`退回失敗:${translateRpcError(error)}`); return; }
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <>
       {advanceNext && (
@@ -109,6 +132,16 @@ export function AidOrderStatusActions({ order, onChanged }: AidOrderStatusAction
       {isCancellable && (
         <RowAction variant="danger" onClick={cancel} disabled={busy}>
           {order.status === "shipping" ? "撤回" : "取消"}
+        </RowAction>
+      )}
+      {isReturnable && (
+        <RowAction
+          variant="danger"
+          onClick={returnToSource}
+          disabled={busy}
+          title="已收貨:反向退回原調出店並還原來源單"
+        >
+          退回原店
         </RowAction>
       )}
     </>

--- a/docs/TEST-air-transfer-cancel-return.md
+++ b/docs/TEST-air-transfer-cancel-return.md
@@ -1,0 +1,60 @@
+# TEST — 空中轉/互助單被取消要退回原店
+
+需求：接收店端把轉入的互助單「取消」時,貨要退回原調出店(原店),而不是留在接收店或退回總倉。
+
+現況(本次改動前)：
+- 未收貨(pending/confirmed)、在途(shipping)取消 → `rpc_cancel_aid_order`(還原來源單→confirmed)。
+- 已收貨(ready)退回 → `rpc_return_aid_order`(反向 transfer 接收店→原店 + 還原來源單),**但只在訂單詳情頁有鈕**。
+
+本次改動：
+1. `supabase/migrations/20260713000000_stock_movements_allow_transfer_cancel.sql` — 補 `transfer_cancel` 進 movement_type CHECK,修好在途撤回的 abort bug。
+2. `AidOrderStatusActions.tsx` — ready 加「退回原店」動作。
+3. `orders/page.tsx`、`pickup/page.tsx` — ready 互助單加「↩ 退回原店」鈕,並把 ready+互助 從「↩ 退貨(回總倉)」排除。
+
+---
+
+## Schema / RPC 層
+
+- [ ] **S1** migration 部署後,`stock_movements_movement_type_check` 允許清單含 `transfer_cancel`(且原有 13 值全保留,只多這一個)。
+- [ ] **S2** 在途(shipping)互助單按撤回 → `rpc_cancel_aid_order` 不再撞 CHECK;貨以 `transfer_cancel` movement 退回原調出店 location,來源單 transferred_out→confirmed,aid 單→cancelled。
+- [ ] **S3** `transfer_cancel` movement 為正數量、unit_cost=0 → 原店 on_hand 回補、avg_cost 不變。
+- [ ] **S4** 已收貨(ready)互助單呼 `rpc_return_aid_order` → 建反向 store_to_store transfer(接收店→原店, status=received)、接收店 outbound + 原店 inbound、aid 單 cancelled、來源單→confirmed;有付儲值金則退回。
+- [ ] **S5** 空中轉 vs 經總倉都能退回原店(rpc_return_aid_order 以「該單已收貨的 dest-facing transfer」為錨、不看 chain 形狀)。
+- [ ] **S6** `rpc_return_aid_order` 對 pending/confirmed/shipping/completed 皆 RAISE(只認 ready);UI 因此只在 ready 顯示鈕。
+
+## UI 層 — 訂單列表 orders/page.tsx
+
+- [ ] **U1** ready 且 `transferred_from_order_id != null` 的互助單:顯示「↩ 退回原店」,**不**顯示「↩ 退貨(回總倉)」。
+- [ ] **U2** ready 的一般單(非互助):維持顯示「↩ 退貨(回總倉)」,不顯示退回原店。
+- [ ] **U3** partially_completed / completed / expired:維持原「↩ 退貨(回總倉)」行為(不受本次影響)。
+- [ ] **U4** 按「↩ 退回原店」→ prompt 原因 → 呼 `rpc_return_aid_order`;成功後列表 reload、該單消失,並提示(有退儲值金則顯示金額)。
+- [ ] **U5** 桌機表格與手機卡片共用 `orderActions`,兩版都出現此鈕。
+
+## UI 層 — 取貨頁 pickup/page.tsx
+
+- [ ] **U6** ready 互助單顯示「↩ 退回原店」、排除「↩ 退貨(回總倉)」;非互助維持「↩ 退貨」。
+- [ ] **U7** 退回成功後 reloadTick++,該單因轉 cancelled 離開列表。
+
+## UI 層 — 狀態列 AidOrderStatusActions.tsx（hq/inbox aid 區）
+
+- [ ] **U8** ready 的互助單狀態列出現「退回原店」;pending/confirmed/shipping 維持取消/撤回,不顯示退回原店。
+- [ ] **U9** 按下 → prompt 原因 → `rpc_return_aid_order` → onChanged() 重刷。
+
+## Regression
+
+- [ ] **R1** 非互助訂單的取消 / 退貨回總倉流程完全不變。
+- [ ] **R2** `tsc --noEmit`(apps/admin)通過(已驗證 ✅)。
+- [ ] **R3** 在途撤回(shipping)修好後,一般(經總倉)互助單撤回也一併正常(非空中轉專屬)。
+
+## 已知邊界 / 待產品確認（非本次修）
+
+- [ ] **B1** 結算雙計:`rpc_return_aid_order` 未把「原本已收貨的 transfer」翻成 cancelled,若之後重算 store_monthly_settlement,原 air_in/air_out 仍會計入、退回 transfer(customer_order_id=NULL)為中性 → 淨額未被沖回。與 cancel/reject 一致(刻意),但值得確認。
+- [ ] **B2** 退回原店的原店 inbound 用 unit_cost=0(對齊既有 return);若原店曾出清庫存,回補以 0 成本會壓低 avg_cost。
+- [ ] **B3** 同店空中轉(若存在)可能無可反向的 received transfer → `rpc_return_aid_order` RAISE;UI 以 alert 呈現錯誤。
+
+---
+
+### 驗證狀態（本輪）
+- ✅ `tsc --noEmit`（apps/admin）通過
+- ✅ SQL 靜態審查：constraint 為既有清單 + transfer_cancel(純擴大、非破壞)
+- ⏳ S 系列需 migration 部署 + 真資料跑(admin live preview 沙箱阻擋,走 DB 直驗)

--- a/supabase/migrations/20260713000000_stock_movements_allow_transfer_cancel.sql
+++ b/supabase/migrations/20260713000000_stock_movements_allow_transfer_cancel.sql
@@ -1,0 +1,42 @@
+-- ============================================================================
+-- stock_movements.movement_type 加入 'transfer_cancel'
+--
+-- Bug：rpc_cancel_aid_order（撤回派貨，shipping 狀態）在把在途貨反向退回原
+-- 調出店時，呼叫 rpc_inbound(..., p_movement_type => 'transfer_cancel')，但
+-- 'transfer_cancel' 不在 stock_movements_movement_type_check 允許清單裡
+-- （20260512000007 只補了 'transfer_reject'）。→ 空中轉/一般轉單在途被撤回時
+-- 會撞 CHECK、整筆 transaction abort，貨根本退不回原店。
+-- 註：此 latent bug 自 rpc_cancel_aid_order 初版（20260510000006）就存在，
+--    最新版（20260606000040 wallet_refund）沿用同一 branch，故一直沒被修到。
+--
+-- 修正：把 'transfer_cancel' 加入允許清單。語義對齊 'transfer_reject'（對方
+-- 拒收 / 撤回後回流源點），保留獨立 type 利於審計區分「撤回」與「拒收」。
+--
+-- 基底：20260512000007_stock_movements_allow_transfer_reject.sql 的清單（含
+--      transfer_reject），本次僅「新增」transfer_cancel，其餘值原封不動。
+-- Rollback：DROP 本 constraint、CREATE OR REPLACE 回 20260512000007 的清單
+--          （移除 transfer_cancel）。注意：回滾前需確認沒有已寫入的
+--          transfer_cancel movement，否則 constraint 會加不回去。
+-- ============================================================================
+
+ALTER TABLE public.stock_movements
+  DROP CONSTRAINT IF EXISTS stock_movements_movement_type_check;
+
+ALTER TABLE public.stock_movements
+  ADD CONSTRAINT stock_movements_movement_type_check CHECK (
+    movement_type = ANY (ARRAY[
+      'purchase_receipt',
+      'return_to_supplier',
+      'sale',
+      'customer_return',
+      'transfer_out',
+      'transfer_in',
+      'transfer_reject',
+      'transfer_cancel',
+      'stocktake_gain',
+      'stocktake_loss',
+      'damage',
+      'manual_adjust',
+      'reversal'
+    ])
+  );


### PR DESCRIPTION
## 需求
接收店把轉入的**互助單（含空中轉）**取消時，貨要退回**原調出店（原店）**，而不是留在接收店或退回總倉。

## 現況（後端大致已具備）
| 取消時機 | RPC | 退回原店? |
|---|---|---|
| 未收貨(pending/confirmed) | `rpc_cancel_aid_order` | ✅ 還原來源單→confirmed |
| 在途(shipping)撤回 | `rpc_cancel_aid_order` | ⚠️ **有 bug（下）** |
| 已收貨(ready) | `rpc_return_aid_order` | ✅ 反向 transfer 接收店→原店 + 還原來源單，**但鈕只在訂單詳情頁** |

## 改動
1. **fix — 在途撤回 bug**：`rpc_cancel_aid_order` 撤回 shipping 單時以 `movement_type='transfer_cancel'` 把在途貨退回原店，但該值不在 `stock_movements` 的 CHECK 允許清單（[20260512000007](supabase/migrations/20260512000007_stock_movements_allow_transfer_reject.sql) 只補了 `transfer_reject`）→ 在途撤回一律撞 CHECK abort、貨退不回原店。新增 migration `20260713000000` 補進 `transfer_cancel`（純擴大、非破壞）。此 latent bug 自 `rpc_cancel_aid_order` 初版（`20260510000006`）就在。
2. **feat — 補退回原店入口**：已收貨(ready)互助單的「退回原店」原本只在訂單詳情頁；補到 `orders` 訂單列表、`pickup` 取貨頁、`AidOrderStatusActions` 狀態列。`ready`+互助 從「↩退貨(回總倉)」排除（貨源是分店不是總倉），改顯示「↩ 退回原店」（呼叫既有 `rpc_return_aid_order`）。

「互助單」判定＝`transferred_from_order_id != null`（轉入單必同時有此欄與 `aid_transfer` 品項；RPC 再嚴格驗一次）。

## 驗證
- ✅ `tsc --noEmit`（apps/admin）通過
- ✅ Adversarial 多代理 review（17 raised / 13 confirmed，**無 blocker/high**）：migration 為清單 superset、四個 UI 入口全覆蓋、`orderActions` 桌機+手機共用、`hq/inbox` 可達、avg_cost 不受影響、`wallet_refunded` key 存在
- ⏳ RPC + 派貨/退回 chain 需 migration 部署後以真資料跑（admin live preview 沙箱阻擋）

## 已知（非本次修，待產品確認）
- **結算未反向**（medium，既有行為，對齊 cancel/reject）：`rpc_return_aid_order` 不動 `store_monthly_settlement`，退回後原 `air_in`(dest)/`air_out`(source) 仍計入、退回 transfer(`customer_order_id=NULL`)為中性 → 淨額未沖回。
- **同店互助 ready 單**：會顯示退回鈕，但 RPC 因無 received transfer 而 friendly-error（不會壞資料）。

詳見 [docs/TEST-air-transfer-cancel-return.md](docs/TEST-air-transfer-cancel-return.md)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)