### PR TITLE
fix(order-transfer): 整單轉單重複收件人守衛只看 active 單

### DIFF
--- a/supabase/migrations/20260714000000_transfer_dedup_guard_active_only.sql
+++ b/supabase/migrations/20260714000000_transfer_dedup_guard_active_only.sql
@@ -1,0 +1,216 @@
+-- ============================================================
+-- rpc_transfer_order_to_store：重複收件人守衛改「只看 active 訂單」
+--
+-- Bug：整單轉出的重複守衛（PERFORM 1 FROM customer_orders WHERE trio 相同）
+--      不分 status，只要 (tenant, campaign, channel, member) 撞到「任何」既有
+--      訂單就 RAISE 'receiver already has order ...' 擋掉。
+--
+--      但 DB 端的唯一鍵早在 20260509000006 / 20260516000000 就改成 partial：
+--        customer_orders_trio_kind_active_uniq
+--          ... WHERE status NOT IN ('transferred_out','expired','cancelled')
+--      —— closed 訂單「不佔 slot」，正是為了讓「曾被取消/轉出過的收件店」還能
+--      再收一張新的 active 轉入單。
+--
+--      → 應用層守衛比 DB 約束更嚴，形成 false positive：收件店只要有一張
+--        cancelled / transferred_out / expired 的殘單，就永遠無法再被轉入。
+--
+--      實例：order 23959 (campaign 2321) 轉入 48 三峽店 (channel 8, store_internal
+--      member 66916) 被擋，因為 66916 名下有 41789 (GRP-20260605-015-TF0054,
+--      status='cancelled') —— 一張早就取消的舊轉入單。DB 其實會接受 INSERT。
+--
+-- 修法：守衛加上 `AND status NOT IN ('transferred_out','expired','cancelled')`，
+--      與 partial unique index 的述詞對齊。其餘邏輯完全不動。
+--
+-- 基底：20260712000000_transfer_order_to_store_air.sql（rpc_transfer_order_to_store
+--      時間最新版，7-arg 含 p_is_air_transfer）。
+-- Rollback：CREATE OR REPLACE 回 20260712000000 的版本（把守衛的 status 過濾拿掉）。
+--
+-- 註：rpc_transfer_order_partial（部分轉出）不受影響 —— 它在 20260509000004 已
+--    改成 upsert，用 `SELECT ... status NOT IN ('expired','cancelled','transferred_out')`
+--    找 active 單來追加，本來就只看 active（見 20260629000040:286）。本次只動整單這支。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_to_store(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT DEFAULT NULL,
+  p_is_air_transfer       BOOLEAN DEFAULT FALSE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_item             RECORD;
+  v_orig_mov         RECORD;
+  v_rev_id           BIGINT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_note_out         TEXT;
+  v_note_in          TEXT;
+  v_new_status       TEXT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  -- 貨還沒到分店不能轉單：source 必須 status='ready'
+  IF v_orig.status <> 'ready' THEN
+    RAISE EXCEPTION '貨還沒到分店、訂單 % 不可轉單 (status=%)',
+                    p_order_id, v_orig.status;
+  END IF;
+
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  PERFORM 1 FROM line_channels
+   WHERE id = v_to_channel_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'channel % not in tenant', v_to_channel_id;
+  END IF;
+
+  -- 重複收件人守衛：只看 active 訂單，對齊 partial unique index
+  -- customer_orders_trio_kind_active_uniq（closed 狀態不佔 slot）。
+  -- 否則收件店只要有一張 cancelled/transferred_out/expired 殘單就永遠擋掉再轉入。
+  PERFORM 1 FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id
+     AND status NOT IN ('transferred_out', 'expired', 'cancelled');
+  IF FOUND THEN
+    RAISE EXCEPTION 'receiver already has order in (campaign=%, channel=%, member=%)',
+                    v_orig.campaign_id, v_to_channel_id, v_to_member_id;
+  END IF;
+
+  -- E2: 釋放 reserved_movement（無條件、跟以前一致；同店也走這條）
+  FOR v_item IN
+    SELECT id, reserved_movement_id FROM customer_order_items
+     WHERE order_id = p_order_id AND reserved_movement_id IS NOT NULL
+  LOOP
+    SELECT * INTO v_orig_mov FROM stock_movements WHERE id = v_item.reserved_movement_id;
+    IF FOUND THEN
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+        source_doc_type, source_doc_id, reverses, reason, operator_id
+      ) VALUES (
+        v_orig_mov.tenant_id, v_orig_mov.location_id, v_orig_mov.sku_id,
+        -v_orig_mov.quantity, v_orig_mov.unit_cost, 'reversal',
+        'order_transfer', p_order_id, v_orig_mov.id,
+        'order #' || p_order_id || ' transferred out, release allocation', p_operator
+      ) RETURNING id INTO v_rev_id;
+
+      UPDATE stock_movements SET reversed_by = v_rev_id WHERE id = v_orig_mov.id;
+      UPDATE customer_order_items SET reserved_movement_id = NULL WHERE id = v_item.id;
+    END IF;
+  END LOOP;
+
+  SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+  SELECT COUNT(*) + 1 INTO v_seq
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+  v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+  v_note_in := COALESCE(p_reason, '') ||
+               E'\n[轉入 (' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+               ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+               to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  -- 同店：mirror source.status；跨店：'pending'
+  v_new_status := CASE
+    WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN v_orig.status
+    ELSE 'pending'
+  END;
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id,
+    nickname_snapshot, pickup_store_id, status, notes,
+    transferred_from_order_id, is_air_transfer,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+    v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status, v_note_in,
+    p_order_id, p_is_air_transfer,
+    p_operator, p_operator, v_now, v_now
+  ) RETURNING id INTO v_new_order_id;
+
+  INSERT INTO customer_order_items (
+    tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+    status, source, notes, created_by, updated_by
+  )
+  SELECT tenant_id, v_new_order_id, campaign_item_id, sku_id, qty, unit_price,
+         'pending', 'aid_transfer', notes, p_operator, p_operator
+    FROM customer_order_items
+   WHERE order_id = p_order_id;
+
+  v_note_out := COALESCE(p_reason, '') ||
+                E'\n[轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  UPDATE customer_orders
+     SET status                   = 'transferred_out',
+         transferred_to_order_id  = v_new_order_id,
+         notes                    = COALESCE(notes, '') || v_note_out,
+         updated_by               = p_operator,
+         updated_at               = v_now
+   WHERE id = p_order_id;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_to_store(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, BOOLEAN
+) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_transfer_order_to_store(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, BOOLEAN
+) IS
+  '整單轉出：新（轉入）單帶 is_air_transfer flag（true=空中轉不經總倉、false=經總倉中轉）；'
+  '下游 rpc_ship_aid_order 依此建 1 段 / 2 段 transfer chain。重複收件人守衛只看 active 訂單'
+  '（對齊 customer_orders_trio_kind_active_uniq）。基底 20260712000000。';


### PR DESCRIPTION
## 問題

整單轉出 `rpc_transfer_order_to_store` 的「重複收件人」守衛不分 status，只要收件店的 store member 名下有**任何**一張同 `(campaign, channel, member)` 的訂單就 `RAISE 'receiver already has order ...'`——即使那是早就 **cancelled / transferred_out / expired** 的殘單。

但 DB 端唯一鍵 [`customer_orders_trio_kind_active_uniq`](../blob/main/supabase/migrations/20260516000000_allow_negative_order_qty.sql) 早已改成 **partial**（`status NOT IN ('transferred_out','expired','cancelled')`），closed 單**不佔 slot**——正是為了讓「曾被取消/轉出過的收件店」還能再收新單。應用層守衛比 DB 約束嚴，形成 **false positive**。

### 實例
`order 23959` (campaign 2321) 轉入 48 三峽店 (channel 8, store_internal member 66916) 被擋，因為 66916 名下有 `41789` (`GRP-20260605-015-TF0054`, status=`cancelled`)——一張早就取消的舊轉入單。DB 其實會接受這個 INSERT。

## 修法

守衛加 `AND status NOT IN ('transferred_out','expired','cancelled')`，與 partial unique index 述詞對齊。其餘邏輯完全不動。

- 基底：`20260712000000`（7-arg 含 `p_is_air_transfer`，PR #491）
- Rollback：CREATE OR REPLACE 回 20260712000000

## 不受影響

`rpc_transfer_order_partial`（部分轉出）自 `20260509000004` 起已改成 upsert，用 `SELECT ... status NOT IN (三個 closed 狀態)` 找 active 單追加，本來就只看 active——**無需修改**。

## 部署狀態

⚠️ 本修正**已直接套上 prod**（`apply_one_migration.cjs`，並以 `pg_get_functiondef` 驗證守衛已含 `status NOT IN`）。此 PR 讓版控追平 prod。

🤖 Generated with [Claude Code](https://claude.com/claude-code)