### PR TITLE
feat(order-transfer): 空中轉後端全自動化（略過總倉確認 + 轉單即自動派貨）

### DIFF
--- a/supabase/migrations/20260714000010_air_transfer_skip_hq_confirm.sql
+++ b/supabase/migrations/20260714000010_air_transfer_skip_hq_confirm.sql
@@ -1,0 +1,447 @@
+-- ============================================================
+-- 空中轉略過「總倉確認」gate：轉入單直接建成 confirmed
+--
+-- 背景：互助/轉入單狀態機是 pending →(總倉在收件匣點「確認」)→ confirmed
+--      →(派貨)→ shipping → ready → completed。這道 pending→confirmed 的「確認」
+--      gate 對所有轉入單一視同仁、沒有 is_air_transfer 分支，所以空中轉（貨其實
+--      不經總倉）也要先讓總倉點一次「確認」才能派貨。
+--
+-- 決策（使用者 2026-07-02）：空中轉略過這道確認 gate、直接可派貨。
+--      → 跨店 + 空中轉的轉入單，status 直接建成 'confirmed'（而非 'pending'），
+--        總倉收件匣就只剩「派貨」一顆鈕。經總倉（is_air_transfer=false）維持
+--        'pending'、同店維持 mirror source.status，皆不變。
+--
+--      下游不受影響：rpc_ship_aid_order 只要 status='confirmed' 即可派貨，
+--      confirmed 在收件匣 classifyAid 仍歸「待處理」stage、rpc_inbox_counts 不變。
+--
+-- 改動：rpc_transfer_order_to_store（整單）與 rpc_transfer_order_partial（部分）
+--      的 v_new_status CASE 加一條 `WHEN p_is_air_transfer THEN 'confirmed'`。
+--      其餘邏輯完全保留。
+--
+-- 基底：
+--   rpc_transfer_order_to_store  ← 20260714000010 之前最新為 20260714000000
+--                                   （含 active-only dedup 守衛）。
+--   rpc_transfer_order_partial   ← 最新為 20260629000040（upsert + ready-only）。
+-- Rollback：
+--   to_store → CREATE OR REPLACE 回 20260714000000。
+--   partial  → CREATE OR REPLACE 回 20260629000040。
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- rpc_transfer_order_to_store（整單）
+-- 基底 20260714000000，僅改 v_new_status CASE。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_to_store(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT DEFAULT NULL,
+  p_is_air_transfer       BOOLEAN DEFAULT FALSE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_item             RECORD;
+  v_orig_mov         RECORD;
+  v_rev_id           BIGINT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_note_out         TEXT;
+  v_note_in          TEXT;
+  v_new_status       TEXT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  -- 貨還沒到分店不能轉單：source 必須 status='ready'
+  IF v_orig.status <> 'ready' THEN
+    RAISE EXCEPTION '貨還沒到分店、訂單 % 不可轉單 (status=%)',
+                    p_order_id, v_orig.status;
+  END IF;
+
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  PERFORM 1 FROM line_channels
+   WHERE id = v_to_channel_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'channel % not in tenant', v_to_channel_id;
+  END IF;
+
+  -- 重複收件人守衛：只看 active 訂單，對齊 partial unique index
+  -- customer_orders_trio_kind_active_uniq（closed 狀態不佔 slot）。
+  PERFORM 1 FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id
+     AND status NOT IN ('transferred_out', 'expired', 'cancelled');
+  IF FOUND THEN
+    RAISE EXCEPTION 'receiver already has order in (campaign=%, channel=%, member=%)',
+                    v_orig.campaign_id, v_to_channel_id, v_to_member_id;
+  END IF;
+
+  -- E2: 釋放 reserved_movement（無條件、跟以前一致；同店也走這條）
+  FOR v_item IN
+    SELECT id, reserved_movement_id FROM customer_order_items
+     WHERE order_id = p_order_id AND reserved_movement_id IS NOT NULL
+  LOOP
+    SELECT * INTO v_orig_mov FROM stock_movements WHERE id = v_item.reserved_movement_id;
+    IF FOUND THEN
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+        source_doc_type, source_doc_id, reverses, reason, operator_id
+      ) VALUES (
+        v_orig_mov.tenant_id, v_orig_mov.location_id, v_orig_mov.sku_id,
+        -v_orig_mov.quantity, v_orig_mov.unit_cost, 'reversal',
+        'order_transfer', p_order_id, v_orig_mov.id,
+        'order #' || p_order_id || ' transferred out, release allocation', p_operator
+      ) RETURNING id INTO v_rev_id;
+
+      UPDATE stock_movements SET reversed_by = v_rev_id WHERE id = v_orig_mov.id;
+      UPDATE customer_order_items SET reserved_movement_id = NULL WHERE id = v_item.id;
+    END IF;
+  END LOOP;
+
+  SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+  SELECT COUNT(*) + 1 INTO v_seq
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+  v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+  v_note_in := COALESCE(p_reason, '') ||
+               E'\n[轉入 (' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+               ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+               to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  -- 同店：mirror source.status；跨店空中轉：直接 confirmed（略過總倉確認 gate）；
+  -- 跨店經總倉：'pending'（維持總倉確認 gate）
+  v_new_status := CASE
+    WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN v_orig.status
+    WHEN p_is_air_transfer THEN 'confirmed'
+    ELSE 'pending'
+  END;
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id,
+    nickname_snapshot, pickup_store_id, status, notes,
+    transferred_from_order_id, is_air_transfer,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+    v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status, v_note_in,
+    p_order_id, p_is_air_transfer,
+    p_operator, p_operator, v_now, v_now
+  ) RETURNING id INTO v_new_order_id;
+
+  INSERT INTO customer_order_items (
+    tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+    status, source, notes, created_by, updated_by
+  )
+  SELECT tenant_id, v_new_order_id, campaign_item_id, sku_id, qty, unit_price,
+         'pending', 'aid_transfer', notes, p_operator, p_operator
+    FROM customer_order_items
+   WHERE order_id = p_order_id;
+
+  v_note_out := COALESCE(p_reason, '') ||
+                E'\n[轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  UPDATE customer_orders
+     SET status                   = 'transferred_out',
+         transferred_to_order_id  = v_new_order_id,
+         notes                    = COALESCE(notes, '') || v_note_out,
+         updated_by               = p_operator,
+         updated_at               = v_now
+   WHERE id = p_order_id;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_to_store(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, BOOLEAN
+) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_transfer_order_to_store(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, BOOLEAN
+) IS
+  '整單轉出：新（轉入）單帶 is_air_transfer flag。跨店空中轉直接建 confirmed（略過總倉確認 '
+  'gate、直接可派貨），經總倉建 pending。重複收件人守衛只看 active 單。基底 20260714000000。';
+
+
+-- ----------------------------------------------------------------
+-- rpc_transfer_order_partial（部分）
+-- 基底 20260629000040，僅改「新建轉入單」分支的 v_new_status CASE。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_partial(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT,
+  p_items                 JSONB,
+  p_is_air_transfer       BOOLEAN DEFAULT FALSE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_p_item           JSONB;
+  v_p_sku_id         BIGINT;
+  v_p_qty            NUMERIC;
+  v_src_item_id      BIGINT;
+  v_src_item_qty     NUMERIC;
+  v_src_item_ci      BIGINT;
+  v_src_item_price   NUMERIC;
+  v_src_item_reserved BIGINT;
+  v_remaining_count  INT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_existing_order   BIGINT;
+  v_appended         BOOLEAN := FALSE;
+  v_new_status       TEXT;
+BEGIN
+  IF p_items IS NULL OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'p_items is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  -- 貨還沒到分店不能轉單：source 必須 status='ready'
+  IF v_orig.status <> 'ready' THEN
+    RAISE EXCEPTION '貨還沒到分店、訂單 % 不可轉單 (status=%)',
+                    p_order_id, v_orig.status;
+  END IF;
+
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  SELECT id INTO v_existing_order
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id
+     AND status NOT IN ('expired','cancelled','transferred_out');
+
+  IF v_existing_order IS NOT NULL THEN
+    v_new_order_id := v_existing_order;
+    v_appended := TRUE;
+    SELECT order_no INTO v_new_order_no FROM customer_orders WHERE id = v_existing_order;
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[追加轉入 (' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+                   ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS') ||
+                   COALESCE(' / ' || p_reason, ''),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = v_new_order_id;
+  ELSE
+    SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+    SELECT COUNT(*) + 1 INTO v_seq
+      FROM customer_orders
+     WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+    v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+    -- 同店：mirror source.status；跨店空中轉：直接 confirmed（略過總倉確認 gate）；
+    -- 跨店經總倉：'pending'（維持總倉確認 gate）
+    v_new_status := CASE
+      WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN v_orig.status
+      WHEN p_is_air_transfer THEN 'confirmed'
+      ELSE 'pending'
+    END;
+
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id,
+      nickname_snapshot, pickup_store_id, status, notes,
+      transferred_from_order_id, is_air_transfer,
+      created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+      v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status,
+      COALESCE(p_reason, '') ||
+        E'\n[轉入 (部分, ' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+        ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+        to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+      p_order_id, p_is_air_transfer,
+      p_operator, p_operator, v_now, v_now
+    ) RETURNING id INTO v_new_order_id;
+  END IF;
+
+  FOR v_p_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_p_sku_id := (v_p_item ->> 'sku_id')::BIGINT;
+    v_p_qty    := (v_p_item ->> 'qty')::NUMERIC;
+    IF v_p_qty IS NULL OR v_p_qty <= 0 THEN
+      RAISE EXCEPTION 'p_items: qty must be > 0';
+    END IF;
+
+    SELECT id, qty, campaign_item_id, unit_price, reserved_movement_id
+      INTO v_src_item_id, v_src_item_qty, v_src_item_ci, v_src_item_price, v_src_item_reserved
+      FROM customer_order_items
+     WHERE order_id = p_order_id
+       AND sku_id   = v_p_sku_id
+       AND status   != 'cancelled'
+     ORDER BY id
+     LIMIT 1
+     FOR UPDATE;
+    IF v_src_item_id IS NULL THEN
+      RAISE EXCEPTION 'sku % not in order % (or already cancelled)', v_p_sku_id, p_order_id;
+    END IF;
+    IF v_src_item_reserved IS NOT NULL THEN
+      RAISE EXCEPTION 'sku % already allocated (reserved_movement_id=%); release first',
+                      v_p_sku_id, v_src_item_reserved;
+    END IF;
+    IF v_src_item_qty < v_p_qty THEN
+      RAISE EXCEPTION 'sku % insufficient qty: source=%, requested=%',
+                      v_p_sku_id, v_src_item_qty, v_p_qty;
+    END IF;
+
+    IF v_src_item_qty = v_p_qty THEN
+      UPDATE customer_order_items
+         SET status = 'cancelled', updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    ELSE
+      UPDATE customer_order_items
+         SET qty = qty - v_p_qty, updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    END IF;
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by
+    ) VALUES (
+      v_tenant_id, v_new_order_id, v_src_item_ci, v_p_sku_id, v_p_qty, v_src_item_price,
+      'pending', 'aid_transfer', p_operator, p_operator
+    );
+  END LOOP;
+
+  SELECT COUNT(*) INTO v_remaining_count
+    FROM customer_order_items
+   WHERE order_id = p_order_id AND status != 'cancelled';
+
+  IF v_remaining_count = 0 THEN
+    UPDATE customer_orders
+       SET status = 'transferred_out',
+           transferred_to_order_id = v_new_order_id,
+           notes = COALESCE(notes, '') ||
+                   E'\n[全部轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  ELSE
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[' || CASE WHEN v_appended THEN '部分追加' ELSE '部分轉出' END ||
+                   ' → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  END IF;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_partial(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB, BOOLEAN) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_transfer_order_partial(BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB, BOOLEAN) IS
+  '部分轉出：新建轉入單時，跨店空中轉直接建 confirmed（略過總倉確認 gate），經總倉建 pending；'
+  '同店 mirror source.status。追加到既有 active 單時不改其 status。基底 20260629000040。';


### PR DESCRIPTION
空中轉後端:略過總倉「確認」gate + 轉單當下自動派貨,貨直接進收件店收貨佇列,總倉零介入。**前端收件匣「✈️ 空中轉」chip 在獨立 PR #497。**

## Migrations（皆已套 prod）
- **20260714000010**(air→confirmed):跨店空中轉轉入單直接建 `confirmed`(略過 pending→confirmed 的總倉「確認」gate)。經總倉維持 `pending`、同店 mirror。
- **20260714000020**(auto-ship):承上,建好 `confirmed` 後立刻 `PERFORM rpc_ship_aid_order` → 來源店出庫 + 建 1 段 `store_to_store` `shipped` leg、單推 `shipping`。**轉單變原子操作**(來源店庫存不足 → RAISE → 整筆 rollback)。部分轉出「追加到既有 active 單」不重派;經總倉/同店不走這條。

## 驗證
- `20260714000020` 用 **prod 交易內 rollback smoke**（真單 39775 → 店1,零留存）驗過:轉入單 `shipping`、1 段 `store_to_store`/`shipped`、來源店已出庫、**無 `hq_to_store` 段**;事後確認來源單仍 `ready`、測試單不存在 → rollback 乾淨。
- `docs/TEST-air-transfer-auto-ship.md` 測試清單 + `scripts/smoke-air-autoship.sql` rollback smoke 腳本。

## 相關 PR
- 前端(收件匣獨立空中轉 chip):**#497**。backend 已在 prod → #497 merge 後即對上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)