### PR TITLE
Add hard delete for pending restock requests

### DIFF
--- a/apps/admin/src/app/(protected)/restock/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 import RestockDetailModal from "@/components/RestockDetailModal";
@@ -160,6 +161,23 @@ export default function RestockListPage() {
     [filtered, page],
   );
 
+  async function handleDelete(r: Row) {
+    const ok = window.confirm(
+      `確定刪除補貨申請 #${r.id}（${r.store_name ?? "—"}）？\n\n` +
+      `共 ${r.line_count} 個品項、$${r.total_amount.toFixed(0)}。\n` +
+      `刪除後無法復原；只有「待處理」的申請可以刪除。`,
+    );
+    if (!ok) return;
+    try {
+      const { error: err } = await getSupabase().rpc("rpc_delete_restock_request", { p_request_id: r.id });
+      if (err) throw err;
+      setError(null);
+      setRows((prev) => (prev ?? []).filter((x) => x.id !== r.id));
+    } catch (e) {
+      setError(translateRpcError(e));
+    }
+  }
+
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
       <header className="flex items-center justify-between">
@@ -199,12 +217,13 @@ export default function RestockListPage() {
           <Th>狀態</Th>
           <Th>連結 / 拒絕原因</Th>
           <Th>備註</Th>
+          <Th align="right">操作</Th>
         </THead>
         <TBody>
           {rows === null ? (
-            <LoadingRow colSpan={8} />
+            <LoadingRow colSpan={9} />
           ) : filtered.length === 0 ? (
-            <EmptyRow colSpan={8}>沒有符合條件的申請</EmptyRow>
+            <EmptyRow colSpan={9}>沒有符合條件的申請</EmptyRow>
           ) : paginated.map((r) => (
             <Tr
               key={r.id}
@@ -246,6 +265,16 @@ export default function RestockListPage() {
               </Td>
               <Td className="max-w-xs text-xs text-zinc-500">
                 <span title={r.notes ?? ""}>{r.notes ? r.notes.slice(0, 30) + (r.notes.length > 30 ? "…" : "") : "—"}</span>
+              </Td>
+              <Td align="right">
+                {r.status === "pending" && (
+                  <SpinButton
+                    onClick={(e) => { e.stopPropagation(); return handleDelete(r); }}
+                    className="rounded-md border border-red-300 px-2 py-1 text-xs text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
+                  >
+                    刪除
+                  </SpinButton>
+                )}
               </Td>
             </Tr>
           ))}

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -16,6 +16,17 @@ const TRANSFER_STATUS_ZH: Record<string, string> = {
 };
 const tStatus = (s: string) => TRANSFER_STATUS_ZH[s] ?? s;
 
+const RESTOCK_STATUS_ZH: Record<string, string> = {
+  pending: "待處理",
+  approved_transfer: "已派貨",
+  approved_pr: "已轉採購",
+  shipped: "已出貨",
+  received: "已收貨",
+  rejected: "已拒絕",
+  cancelled: "已取消",
+};
+const restockStatus = (s: string) => RESTOCK_STATUS_ZH[s] ?? s;
+
 const cStatus = campaignStatusLabel;
 const oStatus = orderStatusLabel;
 
@@ -276,6 +287,23 @@ const RULES: Rule[] = [
     pattern: /product \d+ still referenced by other records, cannot delete/i,
     render: () =>
       "此商品仍被其他資料（如庫存／採購／調撥）參照，無法刪除。請先解除關聯後再試。",
+  },
+  // ===== rpc_delete_restock_request（補貨申請刪除守門） =====
+  {
+    pattern: /restock request \d+ is (\w+), only pending can be deleted/i,
+    render: (m) => `此補貨申請狀態為「${restockStatus(m[1])}」，只有「待處理」可以刪除。`,
+  },
+  {
+    pattern: /restock request \d+ already has picking waves, cannot delete/i,
+    render: () => "此補貨申請已建立撿貨單，無法刪除。請先處理撿貨單後再試。",
+  },
+  {
+    pattern: /restock request \d+ (?:internal order )?still referenced(?: by other records)?, cannot delete/i,
+    render: () => "此補貨申請仍被其他資料參照，無法刪除。請先解除關聯後再試。",
+  },
+  {
+    pattern: /restock request \d+ not found/i,
+    render: () => "找不到此補貨申請（可能已被刪除）。",
   },
   {
     pattern: /product \d+ not found/i,

--- a/supabase/migrations/20260714000020_rpc_delete_restock_request.sql
+++ b/supabase/migrations/20260714000020_rpc_delete_restock_request.sql
@@ -1,0 +1,95 @@
+-- ============================================================================
+-- 2026-07-14: rpc_delete_restock_request — 補貨申請刪除（限 pending、實體硬刪）
+-- ----------------------------------------------------------------------------
+-- 需求：補貨申請在「待處理」（pending）狀態要可以刪除（建錯單想直接清掉，
+--       不想留一筆 cancelled / rejected 佔列表）。
+--
+-- 難點：rpc_create_restock_request（20260612000020 版）建單時有副作用 ——
+--   同時建一張內部 sentinel customer_order（order_kind='restock'、
+--   external_order_no='RR-{id}'）+ customer_order_items，供派貨工作台當需求來源。
+--   只刪 restock_requests 本體會留下孤兒 RR- 訂單，繼續出現在
+--   v_picking_demand 等需求彙總裡。故刪除時必須連帶刪掉該內部訂單。
+--
+-- 設計（守門順序）：
+--   role 守門（owner/admin/hq_manager；空字串放行，對齊 rpc_reject_restock）→
+--   not found / 跨 tenant → 非 pending 擋（已進派貨/採購流程的單走各自流程）→
+--   已有 picking_wave 引用擋（pending 理論上不會有，防資料不一致的雙重保險）→
+--   刪內部 RR- 訂單（customer_order_items 為 ON DELETE CASCADE 自動連帶）→
+--   實體刪 restock_requests（restock_request_lines 為 ON DELETE CASCADE）。
+--
+-- 基底慣例：rpc_delete_pr（20260706000000）— 守門 + 硬刪 + 殘參照丟可讀訊息。
+-- 本 function 為新建（無歷史版本）；狀態守門對齊 rpc_reject_restock
+-- （20260515000002，僅 pending 可操作）。
+-- 依賴：restock_request_lines.request_id / customer_order_items.order_id
+--       均為 ON DELETE CASCADE；picking_waves.source_restock_request_id 無 CASCADE。
+-- Rollback：DROP FUNCTION public.rpc_delete_restock_request(BIGINT);
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_delete_restock_request(
+  p_request_id BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_req    RECORD;
+  v_waves  INTEGER;
+BEGIN
+  -- role 守門：HQ 職能（空字串放行 — 對齊既有 restock RPC）
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot delete restock request', v_role;
+  END IF;
+
+  SELECT * INTO v_req FROM restock_requests
+   WHERE id = p_request_id AND tenant_id = v_tenant
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'restock request % not found', p_request_id;
+  END IF;
+
+  -- 守門 1：只有 pending 可刪 — 已派貨/已轉採購的單有下游單據，走各自流程
+  IF v_req.status <> 'pending' THEN
+    RAISE EXCEPTION 'restock request % is %, only pending can be deleted',
+      p_request_id, v_req.status;
+  END IF;
+
+  -- 守門 2：雙重保險 — 已有撿貨波引用（正常 pending 不會有；建波會把狀態
+  -- 推到 approved_transfer，這裡防的是資料不一致）
+  SELECT COUNT(*) INTO v_waves
+    FROM picking_waves
+   WHERE source_restock_request_id = p_request_id;
+  IF v_waves > 0 THEN
+    RAISE EXCEPTION 'restock request % already has picking waves, cannot delete', p_request_id;
+  END IF;
+
+  -- 連帶刪內部 sentinel 訂單 RR-{id}（items 為 ON DELETE CASCADE）。
+  -- 舊資料（20260612000020 之前建的申請）沒有 RR- 訂單，刪 0 筆是正常的。
+  BEGIN
+    DELETE FROM customer_orders
+     WHERE tenant_id = v_tenant
+       AND order_kind = 'restock'
+       AND external_order_no = 'RR-' || p_request_id::TEXT;
+  EXCEPTION WHEN foreign_key_violation THEN
+    RAISE EXCEPTION 'restock request % internal order still referenced, cannot delete', p_request_id;
+  END;
+
+  -- 實體硬刪：restock_request_lines 為 ON DELETE CASCADE
+  BEGIN
+    DELETE FROM restock_requests
+     WHERE id = p_request_id AND tenant_id = v_tenant;
+  EXCEPTION WHEN foreign_key_violation THEN
+    RAISE EXCEPTION 'restock request % still referenced by other records, cannot delete', p_request_id;
+  END;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_delete_restock_request(BIGINT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_delete_restock_request(BIGINT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_delete_restock_request(BIGINT) IS
+  '補貨申請刪除（硬刪）：限 pending 且無撿貨波引用；'
+  '連帶刪建單時自動掛的內部 RR-{id} customer_order（items 為 CASCADE）；'
+  'lines 由 ON DELETE CASCADE 連帶刪；同 tenant；owner/admin/hq_manager。';


### PR DESCRIPTION
## Summary
Implements hard deletion capability for restock requests in "pending" status, allowing users to remove incorrectly created requests without leaving orphaned records in the system.

## Key Changes

**Database Migration** (`20260714000020_rpc_delete_restock_request.sql`)
- New RPC function `rpc_delete_restock_request(BIGINT)` with multi-layer validation:
  - Role gating: `owner`, `admin`, `hq_manager` (empty string allowed for consistency with existing restock RPCs)
  - Status guard: only `pending` requests can be deleted
  - Referential integrity check: prevents deletion if picking waves reference the request
  - Cascading cleanup: deletes associated internal sentinel `customer_order` (with `order_kind='restock'` and `external_order_no='RR-{id}'`) and its items
  - Hard delete of `restock_requests` and cascading `restock_request_lines`
- Comprehensive error handling with user-readable messages for each guard condition
- Rollback procedure documented

**Frontend** (`apps/admin/src/app/(protected)/restock/page.tsx`)
- Added `handleDelete()` function with confirmation dialog showing request details (ID, store, line count, total amount)
- Delete button rendered in new "操作" (Actions) column, visible only for `pending` status requests
- Error handling via `translateRpcError()` utility
- Optimistic UI update: removes deleted row from table immediately
- Updated table column count from 8 to 9

**Error Translation** (`apps/admin/src/lib/rpcError.ts`)
- Added `RESTOCK_STATUS_ZH` mapping for Chinese status labels
- Four new error rules for `rpc_delete_restock_request`:
  - Status validation failure (shows current status in Chinese)
  - Picking wave reference conflict
  - Other referential integrity violations
  - Not found (already deleted)

## Implementation Notes
- Follows existing pattern from `rpc_delete_pr` (20260706000000) for guard ordering and error handling
- Status guard aligns with `rpc_reject_restock` (20260515000002) — only `pending` is operable
- Handles legacy data: requests created before 20260612000020 may lack internal RR- orders (deleting 0 rows is normal)
- Double-safety check for picking waves prevents deletion of requests with downstream dependencies

https://claude.ai/code/session_01MGNVaysDsWNYMXBg5WSz4G