### PR TITLE
Fix restock request store scope check for branch staff

### DIFF
--- a/apps/admin/src/app/(protected)/restock/new/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/new/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { useRole, canSeeBranch } from "@/lib/role";
+import { useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 import SpinButton from "@/components/SpinButton";
 import SearchSpinner from "@/components/SearchSpinner";
 
@@ -44,17 +45,15 @@ export default function RestockNewPage() {
   useEffect(() => {
     (async () => {
       const sb = getSupabase();
-      const [{ data: storeData }, { data: sess }] = await Promise.all([
-        sb.from("stores").select("id, code, name").eq("is_active", true).order("code"),
-        sb.auth.getSession(),
-      ]);
+      const { data: storeData } = await sb
+        .from("stores").select("id, code, name").eq("is_active", true).order("code");
       setStores((storeData ?? []) as Store[]);
-      // 分店 role 自動帶 store_id
-      const meta = sess.session?.user?.app_metadata as Record<string, unknown> | undefined;
-      const sId = meta?.store_id ? Number(meta.store_id) : null;
-      if (sId) setStoreId(sId);
     })();
   }, []);
+
+  // 分店 role 未手動選店時自動帶自己店（app_metadata.stores 店名比對；JWT 沒有 store_id claim）
+  const branchStoreId = useUserBranchStoreId(stores);
+  const effectiveStoreId = storeId ?? branchStoreId;
 
   const setLine = <K extends keyof Line>(idx: number, key: K, value: Line[K]) => {
     setLines((arr) => arr.map((l, i) => (i === idx ? { ...l, [key]: value } : l)));
@@ -63,20 +62,20 @@ export default function RestockNewPage() {
   const removeLine = (idx: number) => setLines((arr) => arr.filter((_, i) => i !== idx));
 
   const valid =
-    storeId !== null &&
+    effectiveStoreId !== null &&
     lines.length > 0 &&
     lines.every((l) => l.sku_id !== null && Number(l.qty) > 0 && Number(l.unit_price) >= 0);
 
   async function handleSubmit() {
     setError(null);
-    if (!valid || storeId === null) {
+    if (!valid || effectiveStoreId === null) {
       setError("請選分店、每行需挑商品 + 填數量");
       return;
     }
     setBusy(true);
     try {
       const { data, error: err } = await getSupabase().rpc("rpc_create_restock_request", {
-        p_store_id: storeId,
+        p_store_id: effectiveStoreId,
         p_lines: lines.map((l) => ({
           sku_id: l.sku_id,
           qty: Number(l.qty),
@@ -112,7 +111,7 @@ export default function RestockNewPage() {
 
       <label className="flex flex-col gap-1 text-sm sm:max-w-md">
         <span className="text-zinc-600 dark:text-zinc-400">收貨分店 *</span>
-        <select value={storeId ?? ""} onChange={(e) => setStoreId(Number(e.target.value) || null)} className={inputCls}>
+        <select value={effectiveStoreId ?? ""} onChange={(e) => setStoreId(Number(e.target.value) || null)} className={inputCls}>
           <option value="">— 請選 —</option>
           {stores.map((s) => (
             <option key={s.id} value={s.id}>{s.code} {s.name}</option>

--- a/supabase/migrations/20260714000020_restock_store_scope_fix.sql
+++ b/supabase/migrations/20260714000020_restock_store_scope_fix.sql
@@ -1,0 +1,175 @@
+-- ============================================================
+-- rpc_create_restock_request + restock_requests RLS：修店端(store role)自店檢查
+--
+-- 問題：店端角色的「只能建自家店申請」檢查比對 auth.jwt() ->> 'store_id'，
+--   但本系統 store_manager / store_staff 帳號 JWT **沒有 store_id claim**
+--   （只有 app_metadata.stores 店名陣列），導致該檢查恆為 DISTINCT →
+--   店長建補貨申請一律被擋「store role can only create request for own store」。
+--   restock_requests 的 restock_select RLS 也比對同一個不存在的 claim，
+--   店端連自家申請都讀不到。
+--
+-- 修法：與 20260707000080（rpc_create_order_return 同型 bug）一致，改用
+--   20260707000070 的 _jwt_store_ids()（app_metadata.stores 店名 → store_id），
+--   檢查「p_store_id / requesting_store_id 是否在店端管理的店清單內」。
+--
+-- 其餘行為（sentinel campaign/channel/campaign_item、customer_orders +
+-- items 同步建立、虛擬 SKU 拒絕、qty 守衛等）與基底版本逐字保留。
+--
+-- 基底版本：rpc_create_restock_request → 20260612000020_restock_creates_customer_order.sql（線上現行）；
+--          restock_select policy    → 20260515000001_restock_requests_schema.sql（線上現行）。
+-- Rollback：CREATE OR REPLACE 回 20260612000020 版本（店端檢查改回比對 jwt.store_id）；
+--          DROP POLICY restock_select 後建回 20260515000001 版本。
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. rpc_create_restock_request — 店端自店檢查改走 _jwt_store_ids()
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_restock_request(
+  p_store_id BIGINT,
+  p_lines    JSONB,
+  p_notes    TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant       UUID := public._current_tenant_id();
+  v_user         UUID := auth.uid();
+  v_role         TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_request_id   BIGINT;
+  v_line         JSONB;
+  v_sku_id       BIGINT;
+  v_count        INT := 0;
+  v_is_virtual   BOOLEAN;
+  v_campaign_id  BIGINT;
+  v_channel_id   BIGINT;
+  v_order_id     BIGINT;
+  v_order_no     TEXT;
+  v_campaign_item_id BIGINT;
+  v_unit_price   NUMERIC;
+  v_qty          NUMERIC;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','store_manager','store_staff','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot create restock request', v_role;
+  END IF;
+
+  -- 店端 role 只能建自家店申請。「自己店」由 app_metadata.stores 店名經
+  -- _jwt_store_ids() 推導（本系統 JWT 無 store_id claim，見 20260707000080 同型修法）。
+  IF v_role IN ('store_manager','store_staff') THEN
+    IF NOT (p_store_id = ANY (public._jwt_store_ids())) THEN
+      RAISE EXCEPTION 'store role can only create request for own store';
+    END IF;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_store_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'store % not in tenant', p_store_id; END IF;
+
+  -- 1. 建 restock_request
+  INSERT INTO restock_requests (
+    tenant_id, requesting_store_id, status, notes,
+    requested_by, requested_at, created_by, updated_by
+  ) VALUES (
+    v_tenant, p_store_id, 'pending', p_notes,
+    v_user, NOW(), v_user, v_user
+  ) RETURNING id INTO v_request_id;
+
+  -- 2. 建 sentinel campaign + channel + customer_order
+  v_campaign_id := public._restock_sentinel_campaign(v_tenant);
+  v_channel_id  := public._restock_sentinel_channel(v_tenant, p_store_id);
+  v_order_no := 'RR-' || v_request_id::TEXT;
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id, pickup_store_id,
+    status, order_kind, order_type, external_source, external_order_no,
+    notes, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_order_no, v_campaign_id, v_channel_id, NULL, p_store_id,
+    'pending', 'restock', 'regular', 'manual', v_order_no,
+    '【內部】補貨申請 #' || v_request_id::TEXT,
+    v_user, v_user
+  ) RETURNING id INTO v_order_id;
+
+  -- 3. 跑每一個 line:寫 restock_request_lines + customer_order_items
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines)
+  LOOP
+    v_sku_id := (v_line ->> 'sku_id')::BIGINT;
+    v_qty    := (v_line ->> 'qty')::NUMERIC;
+    v_unit_price := COALESCE((v_line ->> 'unit_price')::NUMERIC, 0);
+
+    SELECT p.is_virtual INTO v_is_virtual
+      FROM skus s
+      JOIN products p ON p.id = s.product_id
+     WHERE s.id = v_sku_id AND s.tenant_id = v_tenant;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'sku % not in tenant', v_sku_id;
+    END IF;
+    IF v_is_virtual THEN
+      RAISE EXCEPTION 'restock request cannot use virtual sku %', v_sku_id;
+    END IF;
+
+    IF v_qty <= 0 THEN
+      RAISE EXCEPTION 'line qty must be > 0';
+    END IF;
+
+    INSERT INTO restock_request_lines (
+      tenant_id, request_id, sku_id, qty, unit_price, notes,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, v_request_id, v_sku_id, v_qty, v_unit_price,
+      v_line ->> 'notes', v_user, v_user
+    );
+
+    -- sentinel campaign_item per sku
+    v_campaign_item_id := public._restock_sentinel_campaign_item(
+      v_tenant, v_campaign_id, v_sku_id, v_unit_price
+    );
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by
+    ) VALUES (
+      v_tenant, v_order_id, v_campaign_item_id, v_sku_id, v_qty, v_unit_price,
+      'pending', 'manual', v_user, v_user
+    );
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  IF v_count = 0 THEN
+    RAISE EXCEPTION 'lines must not be empty';
+  END IF;
+
+  RETURN v_request_id;
+END $$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_restock_request(BIGINT, JSONB, TEXT)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_restock_request IS
+  'Case 2：分店建補貨申請（pending 狀態、限真實 SKU，同步建 restock customer_order）。'
+  '店端角色只能建自家店申請，自己店由 app_metadata.stores 經 _jwt_store_ids() 判定。';
+
+-- ----------------------------------------------------------------
+-- 2. restock_select RLS — 店端讀自家店申請改走 _jwt_store_ids()
+-- ----------------------------------------------------------------
+DROP POLICY IF EXISTS restock_select ON restock_requests;
+CREATE POLICY restock_select ON restock_requests
+  FOR SELECT
+  USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (
+      -- HQ role 全看
+      COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+        = ANY (ARRAY['owner','admin','hq_manager','hq_accountant','assistant',''])
+      OR
+      -- 分店 role 只看自家店（app_metadata.stores 店名 → store_id）
+      (
+        COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+          = ANY (ARRAY['store_manager','store_staff'])
+        AND requesting_store_id = ANY (public._jwt_store_ids())
+      )
+    )
+  );
+
+COMMENT ON POLICY restock_select ON restock_requests IS
+  'HQ role 全看；門市角色只看自家店申請，自己店由 app_metadata.stores 店名經 _jwt_store_ids() 推導。';


### PR DESCRIPTION
## Summary

Fix a critical bug where branch staff (store_manager/store_staff roles) could not create restock requests due to an incorrect JWT claim check. The system was comparing against a non-existent `store_id` claim instead of deriving store IDs from the `app_metadata.stores` array.

## Changes

### Database Migration (`20260714000020_restock_store_scope_fix.sql`)
- **rpc_create_restock_request**: Updated store scope validation for branch roles to use `_jwt_store_ids()` helper function instead of checking the non-existent `auth.jwt() ->> 'store_id'` claim
- **restock_select RLS policy**: Updated the SELECT policy on `restock_requests` table to use `_jwt_store_ids()` for branch role filtering, allowing branch staff to read their own store's requests
- Preserved all other behavior (sentinel campaign/channel creation, customer_order sync, virtual SKU rejection, quantity validation)
- Added comprehensive comments documenting the fix, base versions, and rollback procedure

### Frontend (`apps/admin/src/app/(protected)/restock/new/page.tsx`)
- Removed direct JWT `store_id` claim extraction (which was always null for branch staff)
- Added `useUserBranchStoreId()` hook to derive the user's store from `app_metadata.stores` and the available stores list
- Updated store selection logic to auto-populate the branch staff's own store when not manually selected
- Updated form validation and submission to use the effective store ID (manual selection or auto-populated)

## Implementation Details

This fix follows the same pattern as the prior `rpc_create_order_return` fix (migration 20260707000080). The core issue is that the system's JWT tokens for branch staff contain `app_metadata.stores` (array of store names) but not a `store_id` claim, requiring the use of the `_jwt_store_ids()` helper to map store names back to their IDs for authorization checks.

https://claude.ai/code/session_01FshDDjHDPNHjqsmMgYm5Ns