### PR TITLE
fix(purchase): 請購單移除品項未寫回 DB，殘列卡死拆採購單

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -91,6 +91,9 @@ function PageContent() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<"save" | "submit" | "split" | "reopen" | "delete" | null>(null);
   const [destLocationId, setDestLocationId] = useState<number | null>(null);
+  // UI 上被移除、但尚未存檔的品項 id — saveDraft 時才真正從 DB 刪除。
+  // 之前只從 state filter 掉，DB 列還在 → 送審後拆 PO 被「未指派供應商」殘列擋死。
+  const [removedIds, setRemovedIds] = useState<number[]>([]);
 
   // 頂部「一次套用到全部品項」工具列的暫存值（空字串＝不套用該欄）
   const [bulkSupplier, setBulkSupplier] = useState<number | null>(null);
@@ -402,7 +405,11 @@ function PageContent() {
   }
 
   function removeItem(idx: number) {
-    setItems((cur) => cur.filter((_, i) => i !== idx));
+    setItems((cur) => {
+      const target = cur[idx];
+      if (target) setRemovedIds((ids) => (ids.includes(target.id) ? ids : [...ids, target.id]));
+      return cur.filter((_, i) => i !== idx);
+    });
   }
 
   // 把頂部工具列的值一次套用到所有品項；留空的欄位不動，避免誤清既有值
@@ -433,12 +440,21 @@ function PageContent() {
     );
   }
 
-  async function saveDraft() {
-    if (!id) return;
+  async function saveDraft(): Promise<boolean> {
+    if (!id) return false;
     setBusy("save");
     setError(null);
     try {
       const supabase = getSupabase();
+      // 先把 UI 上移除的品項真正從 DB 刪掉，避免殘列卡住送審後的拆 PO
+      if (removedIds.length > 0) {
+        const { error: delErr } = await supabase
+          .from("purchase_request_items")
+          .delete()
+          .in("id", removedIds);
+        if (delErr) throw new Error(delErr.message);
+        setRemovedIds([]);
+      }
       const dirtyRows = items.filter((r) => r.dirty);
       for (const r of dirtyRows) {
         const { error: err } = await supabase
@@ -462,8 +478,10 @@ function PageContent() {
         if (hErr) throw new Error(hErr.message);
       }
       setItems((cur) => cur.map((r) => ({ ...r, dirty: false })));
+      return true;
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
+      return false;
     } finally {
       setBusy(null);
     }
@@ -505,7 +523,8 @@ function PageContent() {
     if (!confirm("確定送出審核？")) {
       return;
     }
-    await saveDraft();
+    // 存檔失敗（含刪除移除列失敗）就中止送審，避免 DB 與畫面不一致下送出
+    if (!(await saveDraft())) return;
     setBusy("submit");
     setError(null);
     try {

--- a/supabase/migrations/20260709000010_rpc_submit_pr_item_guards.sql
+++ b/supabase/migrations/20260709000010_rpc_submit_pr_item_guards.sql
@@ -1,0 +1,100 @@
+-- ============================================================================
+-- 2026-07-02: rpc_submit_pr — 送審加品項守衛（禁空單、禁未指派供應商）
+-- ----------------------------------------------------------------------------
+-- 背景（PR2607020421 / pr_id=63 實案）：
+--   編輯頁的「✕ 移除品項」只從前端 state 過濾、從未刪 DB 列（本次一併修前端），
+--   使用者移除唯一品項後畫面看起來乾淨，前端送審驗證掃的是 state → 全過，
+--   rpc_submit_pr 又無任何品項驗證，total=0 低於 threshold → 自動 approved。
+--   結果：DB 裡殘留一列 suggested_supplier_id IS NULL 的品項，
+--   rpc_split_pr_to_pos 的 unassigned 守衛把拆 PO 擋死，而 submitted 狀態下
+--   品項已不可編輯 → 使用者「沒辦法建立採購單」，只能靠退回草稿自救。
+--
+-- 修法：送審時在 DB 端直接驗（不再只信前端 state）：
+--   1. PR 至少要有 1 個品項
+--   2. 所有品項都要已指派供應商（suggested_supplier_id NOT NULL）
+--   兩者正是 rpc_split_pr_to_pos 的拆單前置條件，在送審關口就擋下，
+--   避免核准後才發現拆不了單。
+--
+-- 基底版本：20260428120000_campaign_to_purchase.sql 的 rpc_submit_pr
+--   （唯一動過此 function 的 migration；已比對線上定義一致）。
+-- Rollback：重跑 20260428120000 內的 rpc_submit_pr 定義即可。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_submit_pr(
+  p_pr_id    BIGINT,
+  p_operator UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant       UUID;
+  v_status       TEXT;
+  v_review       TEXT;
+  v_item_count   INTEGER;
+  v_unassigned   INTEGER;
+  v_total        NUMERIC(18,4);
+  v_threshold    NUMERIC(18,4);
+  v_new_review   TEXT;
+BEGIN
+  SELECT tenant_id, status, review_status INTO v_tenant, v_status, v_review
+    FROM purchase_requests
+   WHERE id = p_pr_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PR % not found', p_pr_id;
+  END IF;
+
+  IF v_status <> 'draft' THEN
+    RAISE EXCEPTION 'PR % already submitted (status: %)', p_pr_id, v_status;
+  END IF;
+
+  -- 品項守衛：DB 實際列為準（前端 state 可能與 DB 不同步）
+  SELECT COUNT(*),
+         COUNT(*) FILTER (WHERE suggested_supplier_id IS NULL)
+    INTO v_item_count, v_unassigned
+    FROM purchase_request_items
+   WHERE pr_id = p_pr_id;
+
+  IF v_item_count = 0 THEN
+    RAISE EXCEPTION '請購單沒有任何品項，無法送審；若整張不需要了請直接刪除請購單';
+  END IF;
+
+  IF v_unassigned > 0 THEN
+    RAISE EXCEPTION '有 % 個品項未指派供應商，無法送審；請先指派供應商（若畫面上看不到該品項，請重新整理頁面）', v_unassigned;
+  END IF;
+
+  -- 重算 total（考慮使用者已編輯 unit_cost / qty）
+  SELECT COALESCE(SUM(line_subtotal), 0) INTO v_total
+    FROM purchase_request_items WHERE pr_id = p_pr_id;
+
+  -- 套 global threshold（簡化：先支援 global scope）
+  SELECT MIN(threshold_amount) INTO v_threshold
+    FROM purchase_approval_thresholds
+   WHERE tenant_id = v_tenant
+     AND active = TRUE
+     AND scope = 'global'
+     AND scope_id IS NULL;
+
+  IF v_threshold IS NOT NULL AND v_total >= v_threshold THEN
+    v_new_review := 'pending_review';
+  ELSE
+    v_new_review := 'approved';
+  END IF;
+
+  UPDATE purchase_requests
+     SET status = 'submitted',
+         submitted_at = NOW(),
+         total_amount = v_total,
+         review_status = v_new_review,
+         review_threshold_amount = v_threshold,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_pr_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_submit_pr TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_submit_pr IS
+  'PR 送審：驗品項（非空、供應商已指派）→ 重算 total → 比 threshold → 設 review_status (approved / pending_review)';


### PR DESCRIPTION
實案 PR2607020421：編輯頁「✕ 移除品項」只從前端 state 過濾、
從未刪 DB 列。使用者移除唯一品項後送審，前端驗證掃 state 全過，
total=0 低於 threshold 自動核准；DB 卻殘留一列未指派供應商的品項，
被 rpc_split_pr_to_pos 的 unassigned 守衛擋死，submitted 狀態下
又不可編輯 → 無法建立採購單。

修法（雙層）：
- 前端：removeItem 記錄被移除的品項 id，saveDraft 時真正 DELETE；
  saveDraft 失敗（含刪除失敗）時中止送審，避免畫面與 DB 不同步下送出
- DB：rpc_submit_pr 加品項守衛 — 禁止空單送審、禁止有品項未指派
  供應商就送審（正是拆 PO 的前置條件，在送審關口就擋下）

migration 已套用至線上（基底 20260428120000，與線上定義比對一致）。
卡住的 PR2607020421 可按「↩ 退回草稿」補供應商與價格後重走送審。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011DkUnM5Q1CYkY8okTceHcJ