### PR TITLE
fix(purchase): 請購單無法建立採購單 — 移除品項未落庫、DB 權限被收、預設供應商未帶入

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -91,6 +91,9 @@ function PageContent() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<"save" | "submit" | "split" | "reopen" | "delete" | null>(null);
   const [destLocationId, setDestLocationId] = useState<number | null>(null);
+  // UI 上被移除、但尚未存檔的品項 id — saveDraft 時才真正從 DB 刪除。
+  // 之前只從 state filter 掉，DB 列還在 → 送審後拆 PO 被「未指派供應商」殘列擋死。
+  const [removedIds, setRemovedIds] = useState<number[]>([]);
 
   // 頂部「一次套用到全部品項」工具列的暫存值（空字串＝不套用該欄）
   const [bulkSupplier, setBulkSupplier] = useState<number | null>(null);
@@ -402,7 +405,11 @@ function PageContent() {
   }
 
   function removeItem(idx: number) {
-    setItems((cur) => cur.filter((_, i) => i !== idx));
+    setItems((cur) => {
+      const target = cur[idx];
+      if (target) setRemovedIds((ids) => (ids.includes(target.id) ? ids : [...ids, target.id]));
+      return cur.filter((_, i) => i !== idx);
+    });
   }
 
   // 把頂部工具列的值一次套用到所有品項；留空的欄位不動，避免誤清既有值
@@ -433,12 +440,21 @@ function PageContent() {
     );
   }
 
-  async function saveDraft() {
-    if (!id) return;
+  async function saveDraft(): Promise<boolean> {
+    if (!id) return false;
     setBusy("save");
     setError(null);
     try {
       const supabase = getSupabase();
+      // 先把 UI 上移除的品項真正從 DB 刪掉，避免殘列卡住送審後的拆 PO
+      if (removedIds.length > 0) {
+        const { error: delErr } = await supabase
+          .from("purchase_request_items")
+          .delete()
+          .in("id", removedIds);
+        if (delErr) throw new Error(delErr.message);
+        setRemovedIds([]);
+      }
       const dirtyRows = items.filter((r) => r.dirty);
       for (const r of dirtyRows) {
         const { error: err } = await supabase
@@ -462,8 +478,10 @@ function PageContent() {
         if (hErr) throw new Error(hErr.message);
       }
       setItems((cur) => cur.map((r) => ({ ...r, dirty: false })));
+      return true;
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
+      return false;
     } finally {
       setBusy(null);
     }
@@ -505,7 +523,8 @@ function PageContent() {
     if (!confirm("確定送出審核？")) {
       return;
     }
-    await saveDraft();
+    // 存檔失敗（含刪除移除列失敗）就中止送審，避免 DB 與畫面不一致下送出
+    if (!(await saveDraft())) return;
     setBusy("submit");
     setError(null);
     try {

--- a/supabase/migrations/20260709000010_rpc_submit_pr_item_guards.sql
+++ b/supabase/migrations/20260709000010_rpc_submit_pr_item_guards.sql
@@ -1,0 +1,100 @@
+-- ============================================================================
+-- 2026-07-02: rpc_submit_pr — 送審加品項守衛（禁空單、禁未指派供應商）
+-- ----------------------------------------------------------------------------
+-- 背景（PR2607020421 / pr_id=63 實案）：
+--   編輯頁的「✕ 移除品項」只從前端 state 過濾、從未刪 DB 列（本次一併修前端），
+--   使用者移除唯一品項後畫面看起來乾淨，前端送審驗證掃的是 state → 全過，
+--   rpc_submit_pr 又無任何品項驗證，total=0 低於 threshold → 自動 approved。
+--   結果：DB 裡殘留一列 suggested_supplier_id IS NULL 的品項，
+--   rpc_split_pr_to_pos 的 unassigned 守衛把拆 PO 擋死，而 submitted 狀態下
+--   品項已不可編輯 → 使用者「沒辦法建立採購單」，只能靠退回草稿自救。
+--
+-- 修法：送審時在 DB 端直接驗（不再只信前端 state）：
+--   1. PR 至少要有 1 個品項
+--   2. 所有品項都要已指派供應商（suggested_supplier_id NOT NULL）
+--   兩者正是 rpc_split_pr_to_pos 的拆單前置條件，在送審關口就擋下，
+--   避免核准後才發現拆不了單。
+--
+-- 基底版本：20260428120000_campaign_to_purchase.sql 的 rpc_submit_pr
+--   （唯一動過此 function 的 migration；已比對線上定義一致）。
+-- Rollback：重跑 20260428120000 內的 rpc_submit_pr 定義即可。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_submit_pr(
+  p_pr_id    BIGINT,
+  p_operator UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant       UUID;
+  v_status       TEXT;
+  v_review       TEXT;
+  v_item_count   INTEGER;
+  v_unassigned   INTEGER;
+  v_total        NUMERIC(18,4);
+  v_threshold    NUMERIC(18,4);
+  v_new_review   TEXT;
+BEGIN
+  SELECT tenant_id, status, review_status INTO v_tenant, v_status, v_review
+    FROM purchase_requests
+   WHERE id = p_pr_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PR % not found', p_pr_id;
+  END IF;
+
+  IF v_status <> 'draft' THEN
+    RAISE EXCEPTION 'PR % already submitted (status: %)', p_pr_id, v_status;
+  END IF;
+
+  -- 品項守衛：DB 實際列為準（前端 state 可能與 DB 不同步）
+  SELECT COUNT(*),
+         COUNT(*) FILTER (WHERE suggested_supplier_id IS NULL)
+    INTO v_item_count, v_unassigned
+    FROM purchase_request_items
+   WHERE pr_id = p_pr_id;
+
+  IF v_item_count = 0 THEN
+    RAISE EXCEPTION '請購單沒有任何品項，無法送審；若整張不需要了請直接刪除請購單';
+  END IF;
+
+  IF v_unassigned > 0 THEN
+    RAISE EXCEPTION '有 % 個品項未指派供應商，無法送審；請先指派供應商（若畫面上看不到該品項，請重新整理頁面）', v_unassigned;
+  END IF;
+
+  -- 重算 total（考慮使用者已編輯 unit_cost / qty）
+  SELECT COALESCE(SUM(line_subtotal), 0) INTO v_total
+    FROM purchase_request_items WHERE pr_id = p_pr_id;
+
+  -- 套 global threshold（簡化：先支援 global scope）
+  SELECT MIN(threshold_amount) INTO v_threshold
+    FROM purchase_approval_thresholds
+   WHERE tenant_id = v_tenant
+     AND active = TRUE
+     AND scope = 'global'
+     AND scope_id IS NULL;
+
+  IF v_threshold IS NOT NULL AND v_total >= v_threshold THEN
+    v_new_review := 'pending_review';
+  ELSE
+    v_new_review := 'approved';
+  END IF;
+
+  UPDATE purchase_requests
+     SET status = 'submitted',
+         submitted_at = NOW(),
+         total_amount = v_total,
+         review_status = v_new_review,
+         review_threshold_amount = v_threshold,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_pr_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_submit_pr TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_submit_pr IS
+  'PR 送審：驗品項（非空、供應商已指派）→ 重算 total → 比 threshold → 設 review_status (approved / pending_review)';

--- a/supabase/migrations/20260709000020_restore_authenticated_table_dml.sql
+++ b/supabase/migrations/20260709000020_restore_authenticated_table_dml.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- 2026-07-02: 恢復 authenticated 對 public tables 的 INSERT/UPDATE/DELETE
+-- ----------------------------------------------------------------------------
+-- 事故（PR2607020424 實案，PR2607020421 同因）：
+--   線上 DB 在 2026-06-29 ~ 2026-07-02 之間被人以手動方式（無對應 migration）
+--   REVOKE 了 anon / authenticated 對 public 全部 141 張 table 的
+--   INSERT / UPDATE / DELETE / TRUNCATE（service_role 未動）。
+--   admin 前端大量頁面（含請購單編輯頁 saveDraft）是以 authenticated 身分
+--   直接 .update() / .insert() 寫 table，全數靜默失敗：
+--   使用者在畫面上指派供應商 → 存檔被 permission denied 擋下 →
+--   舊版前端把錯誤吞掉繼續送審 → DB 裡品項仍是未指派 → 拆 PO / 送審被守衛擋死。
+--   （佐證：purchase_request_items 最後一筆成功更新停在 2026-06-29 08:44）
+--
+-- 修法：把 INSERT / UPDATE / DELETE 還給 authenticated。
+--   - 安全性由 RLS 承擔（public 122 張實體表僅 2 張 _backup_ 快照未開 RLS，
+--     其餘全數 enabled，且各表已有 tenant + role 的 policy）— 即回到
+--     2026-06-29 前的已知良好狀態。
+--   - anon 不還（前端 member/liff 無直寫，維持收緊後的狀態）。
+--   - TRUNCATE 不還（前端不可能需要）。
+--   - _backup_% 快照表不還（未開 RLS，不該讓前端寫）。
+--   - 未來新表由 default privileges 覆蓋（查核過 pg_default_acl 完好未動）。
+--
+-- Rollback：
+--   REVOKE INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public FROM authenticated;
+--   （即回到事故狀態，不建議）
+-- ============================================================================
+
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT c.relname
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'public'
+       AND c.relkind = 'r'
+       AND c.relname NOT LIKE E'\\_backup\\_%'
+  LOOP
+    EXECUTE format(
+      'GRANT INSERT, UPDATE, DELETE ON public.%I TO authenticated',
+      r.relname
+    );
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260709000030_pri_default_supplier_fallback.sql
+++ b/supabase/migrations/20260709000030_pri_default_supplier_fallback.sql
@@ -1,0 +1,110 @@
+-- ============================================================================
+-- 2026-07-02: PR 品項自動帶入預設供應商（trigger fallback + draft backfill）
+-- ----------------------------------------------------------------------------
+-- 需求（PR2607020424 實案）：
+--   產品主檔有設「預設供應商」（products.default_supplier_id，ProductForm 維護），
+--   但所有建 PR 的 RPC（close_date / campaigns / 單團 / 補貨）帶供應商時
+--   只查 supplier_skus.is_preferred；該 SKU 若沒建 supplier_skus 對照
+--   （例：sku 2497 櫻桃，產品預設供應商=包子媽，supplier_skus 0 筆），
+--   suggested_supplier_id 就是 NULL，使用者每張單都要手動指派。
+--
+-- 修法：BEFORE INSERT trigger on purchase_request_items —
+--   插入時若 suggested_supplier_id IS NULL：
+--     1) 先查 supplier_skus 的 is_preferred 供應商（維持既有優先序）
+--     2) 再 fallback 產品主檔 products.default_supplier_id
+--   兩者都限 suppliers.is_active = TRUE。
+--   選 trigger 而非逐支改 RPC：一次覆蓋全部現有與未來的建單路徑，
+--   也避免 CREATE OR REPLACE 疊改多支函式的覆蓋回歸風險
+--   （rpc_create_pr_from_close_date / rpc_append_campaign_to_pr 最新版在
+--    20260625000000、rpc_create_pr_from_campaigns 在 20260513000001、
+--    單團與 blank 在 20260505000000、補貨在 20260606000050 — 全部不動）。
+--   既有 RPC 已自帶 supplier_skus 查詢者，查得到就不會進 trigger 的 WHEN。
+--
+-- Backfill：現存 draft 狀態 PR 的未指派品項，以同一 fallback 鏈補上
+--   （只動 draft — submitted/cancelled 不碰；suggested_ 本來就是草稿階段可改的建議值）。
+--
+-- Rollback：
+--   DROP TRIGGER trg_pri_fill_default_supplier ON public.purchase_request_items;
+--   DROP FUNCTION public.trg_pri_fill_default_supplier();
+--   （backfill 不可逆，但只影響 draft 的建議值，可在 UI 改回）
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.trg_pri_fill_default_supplier()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID;
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM purchase_requests WHERE id = NEW.pr_id;
+
+  -- 1) supplier_skus 偏好供應商（維持既有優先序）
+  SELECT ss.supplier_id INTO NEW.suggested_supplier_id
+    FROM supplier_skus ss
+    JOIN suppliers sup ON sup.id = ss.supplier_id AND sup.is_active
+   WHERE ss.tenant_id = v_tenant
+     AND ss.sku_id = NEW.sku_id
+     AND ss.is_preferred = TRUE
+   LIMIT 1;
+
+  -- 2) fallback：產品主檔預設供應商
+  IF NEW.suggested_supplier_id IS NULL THEN
+    SELECT p.default_supplier_id INTO NEW.suggested_supplier_id
+      FROM skus s
+      JOIN products p ON p.id = s.product_id
+      JOIN suppliers sup ON sup.id = p.default_supplier_id AND sup.is_active
+     WHERE s.id = NEW.sku_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_pri_fill_default_supplier ON public.purchase_request_items;
+CREATE TRIGGER trg_pri_fill_default_supplier
+BEFORE INSERT ON public.purchase_request_items
+FOR EACH ROW
+WHEN (NEW.suggested_supplier_id IS NULL)
+EXECUTE FUNCTION public.trg_pri_fill_default_supplier();
+
+COMMENT ON FUNCTION public.trg_pri_fill_default_supplier() IS
+  'PR 品項插入時自動帶預設供應商：supplier_skus.is_preferred → products.default_supplier_id（皆限 active）';
+
+-- ============================================================================
+-- Backfill：draft PR 的未指派品項補建議供應商（同一 fallback 鏈）
+-- ============================================================================
+UPDATE purchase_request_items pri
+   SET suggested_supplier_id = COALESCE(
+         (SELECT ss.supplier_id
+            FROM supplier_skus ss
+            JOIN suppliers sup ON sup.id = ss.supplier_id AND sup.is_active
+           WHERE ss.tenant_id = pr.tenant_id
+             AND ss.sku_id = pri.sku_id
+             AND ss.is_preferred = TRUE
+           LIMIT 1),
+         (SELECT p.default_supplier_id
+            FROM skus s
+            JOIN products p ON p.id = s.product_id
+            JOIN suppliers sup ON sup.id = p.default_supplier_id AND sup.is_active
+           WHERE s.id = pri.sku_id)
+       )
+  FROM purchase_requests pr
+ WHERE pr.id = pri.pr_id
+   AND pr.status = 'draft'
+   AND pri.suggested_supplier_id IS NULL
+   -- 只動真的補得到值的列，避免無效 UPDATE 空轉 updated_at
+   AND (
+     EXISTS (SELECT 1
+               FROM supplier_skus ss
+               JOIN suppliers sup ON sup.id = ss.supplier_id AND sup.is_active
+              WHERE ss.tenant_id = pr.tenant_id
+                AND ss.sku_id = pri.sku_id
+                AND ss.is_preferred = TRUE)
+     OR EXISTS (SELECT 1
+                  FROM skus s
+                  JOIN products p ON p.id = s.product_id
+                  JOIN suppliers sup ON sup.id = p.default_supplier_id AND sup.is_active
+                 WHERE s.id = pri.sku_id)
+   );


### PR DESCRIPTION
## 問題

實案 PR2607020421 / PR2607020424「沒辦法建立採購單」，追查出三層互相疊加的問題：

1. **編輯頁「✕ 移除品項」只改前端 state，從未刪 DB 列**：送審驗證掃的是 state，DB 殘留未指派供應商的品項，`rpc_split_pr_to_pos` 的守衛把拆 PO 擋死，而 submitted 狀態下品項又不可編輯 — 使用者卡死。
2. **線上 DB 在 6/29–7/2 間被手動（無 migration 紀錄）REVOKE 掉 anon/authenticated 對全部 public tables 的 DML**：admin 前端所有直寫頁面（含請購單存檔）靜默失敗 — 使用者在畫面上指派供應商，實際上根本沒存進去（佐證：`purchase_request_items` 最後一筆成功更新停在 2026-06-29 08:44）。舊前端又把存檔錯誤吞掉繼續送審，才會連續出現「未指派供應商」卡單。
3. **產品主檔的預設供應商從未被帶進請購單**：建 PR 的 RPC 只查 `supplier_skus.is_preferred`，沒 fallback 到 `products.default_supplier_id`，SKU 沒建對照表就每張單都要手動指派。

## 修法

**前端（`purchase/requests/edit/page.tsx`）**
- `removeItem` 記錄被移除的品項 id，`saveDraft` 時真正 `DELETE`
- `saveDraft` 失敗（含刪除失敗）時中止送審，不再吞錯續送

**DB migrations（三支皆已透過 Management API 套用至線上並驗證）**
- `20260709000010_rpc_submit_pr_item_guards.sql`：`rpc_submit_pr` 加守衛 — 禁空單送審、禁品項未指派供應商就送審（正是拆 PO 的前置條件，提前在送審關口擋下）。基底 20260428120000（唯一動過此函式的 migration，已與線上定義比對一致）。
- `20260709000020_restore_authenticated_table_dml.sql`：恢復 `authenticated` 的 INSERT/UPDATE/DELETE（安全由 RLS 承擔，122 張實體表僅 2 張 `_backup_` 快照未開 RLS、不還）；`anon` 與 TRUNCATE 維持收緊不還。**若這次 REVOKE 是團隊刻意的加固，請先討論** — 正確路徑是先把前端直寫改成 RPC 再收權限。
- `20260709000030_pri_default_supplier_fallback.sql`：`purchase_request_items` 加 BEFORE INSERT trigger — 供應商為空時依序帶入 `supplier_skus.is_preferred` → `products.default_supplier_id`（皆限 active）。選 trigger 而非逐支改 RPC，一次覆蓋所有建單路徑、避免疊改多支函式的覆蓋回歸。一併 backfill 現存 draft PR 未指派品項（33 列補上）。

## 驗證

- `tsc --noEmit` 通過；eslint 僅剩該檔既有問題（與本次改動無關，stash 比對確認）
- 送審守衛：臨時資料實測空單、未指派兩個 case 都正確擋下（交易 rollback 未留痕）
- 權限：`SET ROLE authenticated` 實測 UPDATE 不再 permission denied
- Trigger：對 draft PR 插入不帶供應商的品項，正確自動帶入產品預設供應商（交易 rollback）
- 實案 PR2607020424 品項已自動補上預設供應商「包子媽」

## 注意

6/29 至 7/2 期間 admin 上所有「編輯後存檔」類操作都可能靜默失敗（不只採購模組），建議抽查該期間改過的資料是否真的有存進去。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DkUnM5Q1CYkY8okTceHcJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011DkUnM5Q1CYkY8okTceHcJ)_