### PR TITLE
補貨申請可依品相分張開請購單

### DIFF
--- a/apps/admin/src/app/(protected)/restock/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/inbox/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import RestockToPrModal from "@/components/RestockToPrModal";
 import { PR_TERM_ZH } from "@/lib/prStatus";
 
 type Status = "pending" | "approved_transfer" | "approved_pr" | "shipped" | "received" | "rejected" | "cancelled";
@@ -25,6 +26,10 @@ type Row = {
   rejected_at: string | null;
   line_count: number;
   total_amount: number;
+  /** 已開請購單的明細（品相）數；pending 但 >0 = 部分開單 */
+  pr_line_count: number;
+  /** 明細層開出的請購單（依品相分張） */
+  line_prs: { id: number; no: string | null }[];
 };
 
 const STATUS_LABEL: Record<Status, string> = {
@@ -53,6 +58,7 @@ export default function RestockInboxPage() {
   const [tab, setTab] = useState<"pending" | "history">("pending");
   const [busy, setBusy] = useState<number | null>(null);
   const [rejectModal, setRejectModal] = useState<{ id: number; reason: string } | null>(null);
+  const [prModalId, setPrModalId] = useState<number | null>(null);
   const [reload, setReload] = useState(0);
 
   useEffect(() => {
@@ -66,19 +72,26 @@ export default function RestockInboxPage() {
       if (err) { setError(err.message); return; }
       const reqRows = (data ?? []) as unknown as Array<Row & { stores?: { name: string } }>;
       const ids = reqRows.map((r) => r.id);
-      const lineMap = new Map<number, { count: number; total: number }>();
+      const lineMap = new Map<number, { count: number; total: number; prCount: number; prIds: number[] }>();
       if (ids.length > 0) {
-        const { data: lineData } = await sb.from("restock_request_lines").select("request_id, qty, unit_price").in("request_id", ids);
-        for (const l of (lineData ?? []) as { request_id: number; qty: number; unit_price: number }[]) {
-          const slot = lineMap.get(l.request_id) ?? { count: 0, total: 0 };
+        const { data: lineData } = await sb.from("restock_request_lines").select("request_id, qty, unit_price, linked_pr_id").in("request_id", ids);
+        for (const l of (lineData ?? []) as { request_id: number; qty: number; unit_price: number; linked_pr_id: number | null }[]) {
+          const slot = lineMap.get(l.request_id) ?? { count: 0, total: 0, prCount: 0, prIds: [] };
           slot.count += 1;
           slot.total += Number(l.qty) * Number(l.unit_price);
+          if (l.linked_pr_id != null) {
+            slot.prCount += 1;
+            if (!slot.prIds.includes(l.linked_pr_id)) slot.prIds.push(l.linked_pr_id);
+          }
           lineMap.set(l.request_id, slot);
         }
       }
-      // 取 transfer_no / pr_no
+      // 取 transfer_no / pr_no（header 連結 + 明細層依品相開出的 PR）
       const transferIds = reqRows.map((r) => r.linked_transfer_id).filter((x): x is number => !!x);
-      const prIds = reqRows.map((r) => r.linked_pr_id).filter((x): x is number => !!x);
+      const prIds = Array.from(new Set([
+        ...reqRows.map((r) => r.linked_pr_id).filter((x): x is number => !!x),
+        ...Array.from(lineMap.values()).flatMap((s) => s.prIds),
+      ]));
       const xferMap = new Map<number, string>();
       const prMap = new Map<number, string>();
       if (transferIds.length > 0) {
@@ -95,6 +108,8 @@ export default function RestockInboxPage() {
         store_name: r.stores?.name ?? null,
         line_count: lineMap.get(r.id)?.count ?? 0,
         total_amount: lineMap.get(r.id)?.total ?? 0,
+        pr_line_count: lineMap.get(r.id)?.prCount ?? 0,
+        line_prs: (lineMap.get(r.id)?.prIds ?? []).map((id) => ({ id, no: prMap.get(id) ?? null })),
         linked_transfer_no: r.linked_transfer_id ? xferMap.get(r.linked_transfer_id) ?? null : null,
         linked_pr_no: r.linked_pr_id ? prMap.get(r.linked_pr_id) ?? null : null,
       })));
@@ -106,20 +121,6 @@ export default function RestockInboxPage() {
     setBusy(id);
     try {
       const { error: err } = await getSupabase().rpc("rpc_approve_restock_to_transfer", { p_request_id: id });
-      if (err) throw err;
-      setReload((t) => t + 1);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(null);
-    }
-  }
-
-  async function approveToPr(id: number) {
-    if (!confirm(`確定下訂單？此動作會獨立建立一張新的${PR_TERM_ZH}。`)) return;
-    setBusy(id);
-    try {
-      const { error: err } = await getSupabase().rpc("rpc_approve_restock_to_pr", { p_request_id: id });
       if (err) throw err;
       setReload((t) => t + 1);
     } catch (e) {
@@ -231,18 +232,39 @@ export default function RestockInboxPage() {
                 <td className="max-w-xs px-3 py-3 text-xs text-zinc-500">{r.notes ?? "—"}</td>
                 <td className="px-3 py-3">
                   {r.status === "pending" ? (
-                    <div className="flex flex-wrap gap-1">
-                      <SpinButton onClick={() => approveToTransfer(r.id)} disabled={busy === r.id} className="rounded border border-blue-400 bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 disabled:opacity-50 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300">派貨</SpinButton>
-                      <SpinButton onClick={() => approveToPr(r.id)} disabled={busy === r.id} className="rounded border border-indigo-400 bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-100 disabled:opacity-50 dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-300">下訂單</SpinButton>
-                      <SpinButton onClick={() => setRejectModal({ id: r.id, reason: "" })} disabled={busy === r.id} className="rounded border border-red-400 bg-red-50 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-100 disabled:opacity-50 dark:border-red-700 dark:bg-red-950 dark:text-red-300">拒絕</SpinButton>
+                    <div className="flex flex-col gap-1">
+                      <div className="flex flex-wrap gap-1">
+                        {r.pr_line_count === 0 && (
+                          <SpinButton onClick={() => approveToTransfer(r.id)} disabled={busy === r.id} className="rounded border border-blue-400 bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 disabled:opacity-50 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300">派貨</SpinButton>
+                        )}
+                        <SpinButton onClick={() => setPrModalId(r.id)} disabled={busy === r.id} className="rounded border border-indigo-400 bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-100 disabled:opacity-50 dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-300">下訂單</SpinButton>
+                        {r.pr_line_count === 0 && (
+                          <SpinButton onClick={() => setRejectModal({ id: r.id, reason: "" })} disabled={busy === r.id} className="rounded border border-red-400 bg-red-50 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-100 disabled:opacity-50 dark:border-red-700 dark:bg-red-950 dark:text-red-300">拒絕</SpinButton>
+                        )}
+                      </div>
+                      {r.pr_line_count > 0 && (
+                        <div className="flex flex-col gap-0.5 text-xs">
+                          <span className="text-indigo-600 dark:text-indigo-400">已開單 {r.pr_line_count}/{r.line_count} 品相</span>
+                          {r.line_prs.map((p) => (
+                            <Link key={p.id} href={`/purchase/requests/edit?id=${p.id}`} className="font-mono text-blue-600 hover:underline dark:text-blue-400">
+                              → {p.no ?? `${PR_TERM_ZH} #${p.id}`}
+                            </Link>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   ) : (
                     <div className="flex flex-col gap-1 text-xs">
-                      {r.linked_pr_id && (
-                        <Link href={`/purchase/requests/edit?id=${r.linked_pr_id}`} className="font-mono text-blue-600 hover:underline dark:text-blue-400">
-                          → {r.linked_pr_no ?? `${PR_TERM_ZH} #${r.linked_pr_id}`}
+                      {(r.line_prs.length > 0
+                        ? r.line_prs
+                        : r.linked_pr_id
+                          ? [{ id: r.linked_pr_id, no: r.linked_pr_no }]
+                          : []
+                      ).map((p) => (
+                        <Link key={p.id} href={`/purchase/requests/edit?id=${p.id}`} className="font-mono text-blue-600 hover:underline dark:text-blue-400">
+                          → {p.no ?? `${PR_TERM_ZH} #${p.id}`}
                         </Link>
-                      )}
+                      ))}
                       {r.linked_transfer_id && (
                         <Link href={`/hq/inbox?source=transfer&id=${r.linked_transfer_id}`} className="font-mono text-blue-600 hover:underline dark:text-blue-400">
                           → {r.linked_transfer_no ?? `轉貨單 #${r.linked_transfer_id}`}
@@ -266,6 +288,13 @@ export default function RestockInboxPage() {
           </tbody>
         </table>
       </div>
+
+      <RestockToPrModal
+        open={prModalId !== null}
+        restockId={prModalId}
+        onClose={() => setPrModalId(null)}
+        onDone={() => setReload((t) => t + 1)}
+      />
 
       {rejectModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">

--- a/apps/admin/src/components/RestockDetailModal.tsx
+++ b/apps/admin/src/components/RestockDetailModal.tsx
@@ -30,6 +30,8 @@ type Line = {
   sku_code: string;
   sku_name: string;
   variant_name: string | null;
+  linked_pr_id: number | null;
+  linked_pr_no: string | null;
 };
 
 const STATUS_LABEL: Record<string, string> = {
@@ -111,7 +113,7 @@ export default function RestockDetailModal({
 
       const { data: lData } = await sb
         .from("restock_request_lines")
-        .select("id, sku_id, qty, unit_price, skus(sku_code, variant_name, products(name))")
+        .select("id, sku_id, qty, unit_price, linked_pr_id, purchase_requests(pr_no), skus(sku_code, variant_name, products(name))")
         .eq("request_id", restockId)
         .order("id");
       if (cancelled) return;
@@ -120,6 +122,8 @@ export default function RestockDetailModal({
         sku_id: number;
         qty: number;
         unit_price: number;
+        linked_pr_id: number | null;
+        purchase_requests: { pr_no?: string } | { pr_no?: string }[] | null;
         skus:
           | { sku_code: string; variant_name: string | null; products: { name?: string } | { name?: string }[] | null }
           | Array<{ sku_code: string; variant_name: string | null; products: { name?: string } | { name?: string }[] | null }>
@@ -128,6 +132,7 @@ export default function RestockDetailModal({
       const rows: Line[] = ((lData ?? []) as unknown as ApiL[]).map((row) => {
         const skuObj = Array.isArray(row.skus) ? row.skus[0] : row.skus;
         const prodObj = skuObj ? (Array.isArray(skuObj.products) ? skuObj.products[0] : skuObj.products) : null;
+        const prObj = Array.isArray(row.purchase_requests) ? row.purchase_requests[0] : row.purchase_requests;
         return {
           id: row.id,
           sku_id: row.sku_id,
@@ -136,6 +141,8 @@ export default function RestockDetailModal({
           sku_code: skuObj?.sku_code ?? `#${row.sku_id}`,
           sku_name: prodObj?.name ?? "",
           variant_name: skuObj?.variant_name ?? null,
+          linked_pr_id: row.linked_pr_id ?? null,
+          linked_pr_no: prObj?.pr_no ?? null,
         };
       });
       setLines(rows);
@@ -222,6 +229,16 @@ export default function RestockDetailModal({
                         <td className="px-3 py-2 text-xs">
                           {l.sku_name || "—"}
                           {l.variant_name && <span className="ml-1 text-zinc-500">/ {l.variant_name}</span>}
+                          {l.linked_pr_id != null && (
+                            <div>
+                              <Link
+                                href={`/purchase/requests/edit?id=${l.linked_pr_id}`}
+                                className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                              >
+                                → {l.linked_pr_no ?? `${PR_TERM_ZH} #${l.linked_pr_id}`}
+                              </Link>
+                            </div>
+                          )}
                         </td>
                         <td className="px-3 py-2 text-right font-mono">{l.qty}</td>
                         <td className="px-3 py-2 text-right font-mono">${l.unit_price}</td>

--- a/apps/admin/src/components/RestockToPrModal.tsx
+++ b/apps/admin/src/components/RestockToPrModal.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Modal } from "@/components/Modal";
+import { getSupabase } from "@/lib/supabase";
+import SpinButton from "@/components/SpinButton";
+import { PR_TERM_ZH } from "@/lib/prStatus";
+
+type Line = {
+  id: number;
+  sku_id: number;
+  qty: number;
+  unit_price: number;
+  sku_code: string;
+  sku_name: string;
+  variant_name: string | null;
+  linked_pr_id: number | null;
+  linked_pr_no: string | null;
+};
+
+/**
+ * 補貨申請「下訂單」品相選擇 Modal：
+ * 勾選要開請購單的品相（明細），可分次為不同品相各開一張 PR。
+ * 已開單的品相鎖定顯示其 PR 連結。
+ */
+export default function RestockToPrModal({
+  open,
+  restockId,
+  onClose,
+  onDone,
+}: {
+  open: boolean;
+  restockId: number | null;
+  onClose: () => void;
+  /** 建單成功後呼叫（呼叫端 reload 列表） */
+  onDone: () => void;
+}) {
+  // 以 restockId 為 key 存載入結果：換單/關閉不需同步 reset state（react-hooks/set-state-in-effect）
+  const [loaded, setLoaded] = useState<{ restockId: number; lines: Line[] } | null>(null);
+  const [checked, setChecked] = useState<Set<number>>(new Set());
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
+
+  const lines = open && restockId != null && loaded?.restockId === restockId ? loaded.lines : null;
+
+  useEffect(() => {
+    if (!open || restockId == null) return;
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data, error } = await sb
+        .from("restock_request_lines")
+        .select("id, sku_id, qty, unit_price, linked_pr_id, purchase_requests(pr_no), skus(sku_code, variant_name, products(name))")
+        .eq("request_id", restockId)
+        .order("id");
+      if (cancelled) return;
+      if (error) {
+        setErr(error.message);
+        setLoaded({ restockId, lines: [] });
+        return;
+      }
+      type ApiL = {
+        id: number;
+        sku_id: number;
+        qty: number;
+        unit_price: number;
+        linked_pr_id: number | null;
+        purchase_requests: { pr_no?: string } | { pr_no?: string }[] | null;
+        skus:
+          | { sku_code: string; variant_name: string | null; products: { name?: string } | { name?: string }[] | null }
+          | Array<{ sku_code: string; variant_name: string | null; products: { name?: string } | { name?: string }[] | null }>
+          | null;
+      };
+      const rows: Line[] = ((data ?? []) as unknown as ApiL[]).map((row) => {
+        const skuObj = Array.isArray(row.skus) ? row.skus[0] : row.skus;
+        const prodObj = skuObj ? (Array.isArray(skuObj.products) ? skuObj.products[0] : skuObj.products) : null;
+        const prObj = Array.isArray(row.purchase_requests) ? row.purchase_requests[0] : row.purchase_requests;
+        return {
+          id: row.id,
+          sku_id: row.sku_id,
+          qty: Number(row.qty),
+          unit_price: Number(row.unit_price),
+          sku_code: skuObj?.sku_code ?? `#${row.sku_id}`,
+          sku_name: prodObj?.name ?? "",
+          variant_name: skuObj?.variant_name ?? null,
+          linked_pr_id: row.linked_pr_id,
+          linked_pr_no: prObj?.pr_no ?? null,
+        };
+      });
+      setErr(null);
+      setLoaded({ restockId, lines: rows });
+      // 預設全選尚未開單的品相
+      setChecked(new Set(rows.filter((l) => l.linked_pr_id === null).map((l) => l.id)));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, restockId, reload]);
+
+  const openable = useMemo(() => (lines ?? []).filter((l) => l.linked_pr_id === null), [lines]);
+  const selectedTotal = useMemo(
+    () => (lines ?? []).filter((l) => checked.has(l.id)).reduce((acc, l) => acc + l.qty * l.unit_price, 0),
+    [lines, checked]
+  );
+
+  function toggle(id: number) {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function submit() {
+    if (restockId == null || checked.size === 0) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const { error } = await getSupabase().rpc("rpc_approve_restock_lines_to_pr", {
+        p_request_id: restockId,
+        p_line_ids: Array.from(checked),
+      });
+      if (error) throw error;
+      onDone();
+      // 還有品相沒開單 → 留在 modal 續開下一張；全開完 → 關閉
+      if (checked.size < openable.length) {
+        setReload((t) => t + 1);
+      } else {
+        onClose();
+      }
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title={`📝 開${PR_TERM_ZH} — 補貨申請 #${restockId ?? ""}`} maxWidth="max-w-2xl">
+      <div className="space-y-3">
+        <p className="text-sm text-zinc-500">
+          勾選要下訂的品相：勾選的品項會建成一張新的{PR_TERM_ZH}；可分次為不同品相各開一張。
+        </p>
+
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {err}
+          </div>
+        )}
+
+        <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
+          <table className="w-full text-sm">
+            <thead className="bg-zinc-50 dark:bg-zinc-900">
+              <tr className="text-left text-xs uppercase tracking-wide text-zinc-500">
+                <th className="w-8 px-3 py-2" />
+                <th className="px-3 py-2">SKU</th>
+                <th className="px-3 py-2">品名 / 品相</th>
+                <th className="px-3 py-2 text-right">數量</th>
+                <th className="px-3 py-2 text-right">小計</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
+              {lines === null ? (
+                <tr><td colSpan={5} className="p-4 text-center text-zinc-500">載入中…</td></tr>
+              ) : lines.length === 0 ? (
+                <tr><td colSpan={5} className="p-4 text-center text-zinc-500">無明細</td></tr>
+              ) : (
+                lines.map((l) => {
+                  const ordered = l.linked_pr_id !== null;
+                  return (
+                    <tr key={l.id} className={ordered ? "opacity-60" : "cursor-pointer"} onClick={() => !ordered && toggle(l.id)}>
+                      <td className="px-3 py-2">
+                        {ordered ? (
+                          <span title="已開單">✅</span>
+                        ) : (
+                          <input
+                            type="checkbox"
+                            checked={checked.has(l.id)}
+                            onChange={() => toggle(l.id)}
+                            onClick={(e) => e.stopPropagation()}
+                          />
+                        )}
+                      </td>
+                      <td className="px-3 py-2 font-mono text-xs">{l.sku_code}</td>
+                      <td className="px-3 py-2 text-xs">
+                        {l.sku_name || "—"}
+                        {l.variant_name && <span className="ml-1 text-zinc-500">/ {l.variant_name}</span>}
+                        {ordered && (
+                          <span className="ml-2">
+                            →{" "}
+                            <Link
+                              href={`/purchase/requests/edit?id=${l.linked_pr_id}`}
+                              className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              {l.linked_pr_no ?? `${PR_TERM_ZH} #${l.linked_pr_id}`}
+                            </Link>
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono">{l.qty}</td>
+                      <td className="px-3 py-2 text-right font-mono">${(l.qty * l.unit_price).toFixed(0)}</td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-zinc-500">
+            已選 {checked.size} / {openable.length} 個未開單品相 · 小計 ${selectedTotal.toFixed(0)}
+          </span>
+          <div className="flex gap-2">
+            <SpinButton onClick={onClose} className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700">
+              取消
+            </SpinButton>
+            <SpinButton
+              onClick={submit}
+              disabled={busy || checked.size === 0}
+              className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+            >
+              {busy ? "建立中…" : `為勾選品相開一張${PR_TERM_ZH}`}
+            </SpinButton>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/docs/TEST-store-self-service.md
+++ b/docs/TEST-store-self-service.md
@@ -141,6 +141,20 @@ SELECT proname, pg_get_function_arguments(oid) FROM pg_proc
 
 **預期：** 成功（自家店 only）
 
+### 2.14 rpc_approve_restock_lines_to_pr — 依品相分張開請購單（20260714000040）
+**情境：** pending request 有 2 個品相（不同 SKU），HQ 先只選品相 A 呼叫
+`rpc_approve_restock_lines_to_pr(req_id, ARRAY[line_a])`，再呼叫第二次（p_line_ids=NULL）
+
+**預期：**
+- 第一次：新 draft PR 只含品相 A、line_a.linked_pr_id 寫入；request 停留 'pending'、
+  header linked_pr_id 記第一張 PR、approved_at 仍 NULL
+- 部分開單期間：rpc_approve_restock_to_transfer / rpc_reject_restock /
+  rpc_delete_restock_request 全部 RAISE（不可整張派貨/拒絕/刪除）
+- 重複開同一明細 → RAISE '已開過請購單'；別張申請的明細 id → RAISE '不屬於補貨申請'
+- 第二次（NULL = 全部剩餘品相）：第二張獨立 PR；全明細開單 → status='approved_pr'、
+  approved_by/at 寫入、header linked_pr_id 仍為第一張
+- 舊 rpc_approve_restock_to_pr(req_id) 為薄包裝（= 全部剩餘品相一張 PR），行為不變
+
 ---
 
 ## 3. UI 行為（preview 互動）

--- a/supabase/migrations/20260714000040_restock_pr_by_variant.sql
+++ b/supabase/migrations/20260714000040_restock_pr_by_variant.sql
@@ -1,0 +1,422 @@
+-- ============================================================================
+-- 2026-07-14: 補貨申請可依「品相」（明細 SKU）分開開請購單
+-- ----------------------------------------------------------------------------
+-- 需求（cktalex 2026-07-03 回報）：
+--   一張補貨申請常混多個品相（同商品不同規格/等級，例 (A)250g-300g、
+--   (B)300g-350g），不同品相對不同供應商。HQ Inbox 的「下訂單」目前
+--   一鍵把整張申請鏡像成一張請購單，無法依品相分張。
+--
+-- 變更：
+--   Part 0  restock_request_lines 加 linked_pr_id（每條明細記自己進了哪張 PR）。
+--   Part 1  新 RPC rpc_approve_restock_lines_to_pr(p_request_id, p_line_ids)：
+--     - 為「選取的明細」建一張新 draft PR 並鏡像 lines、stamp 明細 linked_pr_id。
+--     - p_line_ids = NULL → 全部尚未開單的明細（= 舊整張下訂單行為）。
+--     - 可重複呼叫：每次選不同品相 → 各自成一張 PR。
+--     - 全部明細都開單後 → 申請 status='approved_pr'（header linked_pr_id
+--       停留在第一張 PR，明細層 linked_pr_id 才是完整對照）。
+--     - 部分開單時申請停留 pending，HQ Inbox 可繼續處理剩餘品相。
+--   Part 2  rpc_approve_restock_to_pr 改為薄包裝：呼叫 Part 1（p_line_ids=NULL）。
+--     行為與 20260606000050 版一致（整張建新 PR），另外多 stamp 明細。
+--   Part 3  rpc_approve_restock_to_transfer 加守衛：已有品相開過請購單的申請
+--     不可再整張「派貨」（避免已下訂的品相被重複派庫存；剩餘品相請繼續開 PR）。
+--     派貨工作台 wave 流只吃 approved_transfer，經此守衛後不會出現
+--     「部分品相已開 PR 又進 wave」的狀態，v_picking_demand_no_po /
+--     rpc_create_wave_from_restock 不需要動。
+--   Part 4  rpc_delete_restock_request 加守衛：已有品相開過請購單的 pending
+--     申請不可刪（明細 CASCADE 硬刪會讓已建的 PR 失去來源對照）。
+--   Part 5  rpc_reject_restock 加守衛：已有品相開過請購單的申請不可整張拒絕
+--     （已下訂的品相會照常進貨，rejected 狀態會與事實矛盾）。
+--
+-- 基底版本（依 CLAUDE.md 規則 grep 全歷史、以時間最新版擴寫）：
+--   rpc_approve_restock_to_pr       ← 20260606000050_rpc_approve_restock_to_pr_always_new.sql
+--   rpc_approve_restock_to_transfer ← 20260612000040_approve_restock_via_picking_workstation.sql
+--   rpc_delete_restock_request      ← 20260714000030_rpc_delete_restock_request_store_scope.sql
+--   rpc_reject_restock              ← 20260515000002_rpc_store_self_service.sql（唯一版本）
+--   （suggested_supplier fallback 由 20260709000030 的 BEFORE INSERT trigger
+--    trg_pri_fill_default_supplier 覆蓋，本檔 insert 不需帶供應商。）
+--
+-- Rollback：
+--   DROP FUNCTION public.rpc_approve_restock_lines_to_pr(BIGINT, BIGINT[]);
+--   rpc_approve_restock_to_pr       → 重跑 20260606000050 的 CREATE OR REPLACE。
+--   rpc_approve_restock_to_transfer → 重跑 20260612000040 的對應區塊。
+--   rpc_delete_restock_request      → 重跑 20260714000030 的 CREATE OR REPLACE。
+--   rpc_reject_restock              → 重跑 20260515000002 的 CREATE OR REPLACE。
+--   ALTER TABLE restock_request_lines DROP COLUMN linked_pr_id;
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- Part 0: 明細層 PR 對照欄位
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.restock_request_lines
+  ADD COLUMN IF NOT EXISTS linked_pr_id BIGINT REFERENCES public.purchase_requests(id);
+
+COMMENT ON COLUMN public.restock_request_lines.linked_pr_id IS
+  '此明細（品相）被鏡像進哪張請購單；NULL = 尚未開單。'
+  '整張申請可拆多張 PR — header 的 linked_pr_id 只記第一張，這裡才是完整對照。';
+
+CREATE INDEX IF NOT EXISTS idx_restock_lines_linked_pr
+  ON public.restock_request_lines (linked_pr_id)
+  WHERE linked_pr_id IS NOT NULL;
+
+-- 既有 approved_pr 申請 backfill：整張都進了 header 那張 PR
+UPDATE public.restock_request_lines l
+   SET linked_pr_id = r.linked_pr_id
+  FROM public.restock_requests r
+ WHERE r.id = l.request_id
+   AND r.linked_pr_id IS NOT NULL
+   AND l.linked_pr_id IS NULL;
+
+-- ----------------------------------------------------------------------------
+-- Part 1: rpc_approve_restock_lines_to_pr — 依品相（明細）開請購單
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_approve_restock_lines_to_pr(
+  p_request_id BIGINT,
+  p_line_ids   BIGINT[] DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant    UUID := public._current_tenant_id();
+  v_user      UUID := auth.uid();
+  v_role      TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_req       RECORD;
+  v_pr_id     BIGINT;
+  v_hq_loc    BIGINT;
+  v_no        TEXT;
+  v_selected  BIGINT[];
+  v_bad       BIGINT;
+  v_remaining INTEGER;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot approve restock', v_role;
+  END IF;
+
+  SELECT * INTO v_req FROM restock_requests
+   WHERE id = p_request_id AND tenant_id = v_tenant FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'request % not found', p_request_id; END IF;
+  IF v_req.status <> 'pending' THEN
+    RAISE EXCEPTION 'request % already processed (status=%)', p_request_id, v_req.status;
+  END IF;
+
+  -- 選取明細：未指定 → 全部尚未開單的明細
+  IF p_line_ids IS NULL OR COALESCE(array_length(p_line_ids, 1), 0) = 0 THEN
+    SELECT array_agg(id) INTO v_selected
+      FROM restock_request_lines
+     WHERE request_id = p_request_id AND tenant_id = v_tenant
+       AND linked_pr_id IS NULL;
+  ELSE
+    -- 守衛：每個 id 都必須屬於本申請
+    SELECT t.id INTO v_bad
+      FROM unnest(p_line_ids) AS t(id)
+     WHERE NOT EXISTS (
+             SELECT 1 FROM restock_request_lines l
+              WHERE l.id = t.id
+                AND l.request_id = p_request_id
+                AND l.tenant_id  = v_tenant
+           )
+     LIMIT 1;
+    IF v_bad IS NOT NULL THEN
+      RAISE EXCEPTION '明細 #% 不屬於補貨申請 #%', v_bad, p_request_id;
+    END IF;
+
+    -- 守衛：不可重複開單
+    SELECT l.id INTO v_bad
+      FROM restock_request_lines l
+     WHERE l.id = ANY (p_line_ids)
+       AND l.linked_pr_id IS NOT NULL
+     LIMIT 1;
+    IF v_bad IS NOT NULL THEN
+      RAISE EXCEPTION '明細 #% 已開過請購單，不可重複開單', v_bad;
+    END IF;
+
+    SELECT array_agg(DISTINCT t.id) INTO v_selected
+      FROM unnest(p_line_ids) AS t(id);
+  END IF;
+
+  IF v_selected IS NULL OR COALESCE(array_length(v_selected, 1), 0) = 0 THEN
+    RAISE EXCEPTION '補貨申請 #% 沒有可開請購單的品項', p_request_id;
+  END IF;
+
+  SELECT id INTO v_hq_loc FROM locations
+   WHERE tenant_id = v_tenant AND type = 'central_warehouse' AND is_active = TRUE
+   ORDER BY id LIMIT 1;
+
+  -- 每次呼叫都建新 PR（沿用 20260606000050「不 append 既有 draft」原則）
+  v_no := public.rpc_next_pr_no();
+  INSERT INTO purchase_requests (
+    tenant_id, pr_no, source_location_id, status, raw_line_text,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_no, v_hq_loc, 'draft',
+    'restock request #' || p_request_id::TEXT,
+    v_user, v_user
+  ) RETURNING id INTO v_pr_id;
+
+  -- 鏡像選取的明細進 PR（suggested_supplier 由 trg_pri_fill_default_supplier 補）
+  INSERT INTO purchase_request_items (
+    pr_id, sku_id, qty_requested, raw_line, notes, created_by, updated_by
+  )
+  SELECT v_pr_id, l.sku_id, l.qty,
+         'restock #' || p_request_id::TEXT,
+         l.notes, v_user, v_user
+    FROM restock_request_lines l
+   WHERE l.id = ANY (v_selected);
+
+  -- stamp 明細層對照
+  UPDATE restock_request_lines
+     SET linked_pr_id = v_pr_id,
+         updated_by   = v_user
+   WHERE id = ANY (v_selected);
+
+  SELECT COUNT(*) INTO v_remaining
+    FROM restock_request_lines
+   WHERE request_id = p_request_id AND linked_pr_id IS NULL;
+
+  IF v_remaining = 0 THEN
+    -- 全品相都開單 → 申請完成，進 approved_pr
+    UPDATE restock_requests
+       SET status       = 'approved_pr',
+           linked_pr_id = COALESCE(linked_pr_id, v_pr_id),
+           approved_by  = v_user,
+           approved_at  = NOW(),
+           updated_by   = v_user
+     WHERE id = p_request_id;
+  ELSE
+    -- 部分開單 → 停留 pending，header 記第一張 PR 方便 Inbox 連結
+    UPDATE restock_requests
+       SET linked_pr_id = COALESCE(linked_pr_id, v_pr_id),
+           updated_by   = v_user
+     WHERE id = p_request_id;
+  END IF;
+
+  RETURN v_pr_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_approve_restock_lines_to_pr(BIGINT, BIGINT[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_approve_restock_lines_to_pr(BIGINT, BIGINT[]) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_approve_restock_lines_to_pr(BIGINT, BIGINT[]) IS
+  '補貨申請依品相開請購單：為選取明細建新 draft PR 並 stamp 明細 linked_pr_id；'
+  'p_line_ids=NULL → 全部未開單明細。可重複呼叫分多張 PR；'
+  '全明細開單後申請進 approved_pr，否則停留 pending。';
+
+-- ----------------------------------------------------------------------------
+-- Part 2: rpc_approve_restock_to_pr — 薄包裝（整張 = 全部剩餘品相）
+--         （基底 20260606000050；對外行為不變：整張建一張新 PR）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_approve_restock_to_pr(
+  p_request_id BIGINT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN public.rpc_approve_restock_lines_to_pr(p_request_id, NULL);
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_approve_restock_to_pr(BIGINT) IS
+  '把補貨申請 approve_pr 化：整張（剩餘全部品相）建一張新 draft PR。'
+  '自 20260714000040 起為 rpc_approve_restock_lines_to_pr 的薄包裝。';
+
+-- ----------------------------------------------------------------------------
+-- Part 3: rpc_approve_restock_to_transfer — 守衛已部分開單的申請
+--         （基底 20260612000040，僅插入一段守衛，其餘逐字保留）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_approve_restock_to_transfer(p_request_id BIGINT)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_user   UUID := auth.uid();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_req    RECORD;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot approve restock', v_role;
+  END IF;
+
+  SELECT * INTO v_req FROM restock_requests
+   WHERE id = p_request_id AND tenant_id = v_tenant FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'request % not found', p_request_id; END IF;
+  IF v_req.status <> 'pending' THEN
+    RAISE EXCEPTION 'request % already processed (status=%)', p_request_id, v_req.status;
+  END IF;
+
+  -- 20260714000040 守衛：已有品相開過請購單 → 不可整張派貨（會重複供貨）
+  IF EXISTS (
+    SELECT 1 FROM restock_request_lines
+     WHERE request_id = p_request_id AND linked_pr_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION '補貨申請 #% 已有品相開立請購單，不可再整張派貨；剩餘品相請繼續以請購單處理',
+      p_request_id;
+  END IF;
+
+  -- 只更新狀態:後續由派貨工作台 rpc_create_wave_from_restock 接手
+  UPDATE restock_requests
+     SET status = 'approved_transfer',
+         linked_transfer_id = NULL,
+         approved_by = v_user,
+         approved_at = NOW(),
+         updated_by  = v_user,
+         updated_at  = NOW()
+   WHERE id = p_request_id;
+
+  RETURN p_request_id;
+END $$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_approve_restock_to_transfer(BIGINT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_approve_restock_to_transfer(BIGINT) IS
+  '審核通過補貨申請、轉派貨工作台處理(不直接建 transfer)。實際 transfer 由 wave 流產出。'
+  '已有品相開立請購單的申請不可整張派貨（20260714000040）。';
+
+-- ----------------------------------------------------------------------------
+-- Part 4: rpc_delete_restock_request — 守衛已部分開單的申請
+--         （基底 20260714000030，僅插入守門 3，其餘逐字保留）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_delete_restock_request(
+  p_request_id BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_req    RECORD;
+  v_waves  INTEGER;
+  v_pr_lines INTEGER;
+BEGIN
+  -- role 守門：HQ 職能 + 門市職能（空字串放行 — 對齊既有 restock RPC）
+  IF v_role NOT IN ('owner','admin','hq_manager','store_manager','store_staff','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot delete restock request', v_role;
+  END IF;
+
+  SELECT * INTO v_req FROM restock_requests
+   WHERE id = p_request_id AND tenant_id = v_tenant
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'restock request % not found', p_request_id;
+  END IF;
+
+  -- 門市角色只能刪自己店的申請（店名 claim → store id，見 20260707000070）
+  IF v_role IN ('store_manager','store_staff')
+     AND NOT (v_req.requesting_store_id = ANY (public._jwt_store_ids())) THEN
+    RAISE EXCEPTION 'store role can only delete request for own store';
+  END IF;
+
+  -- 守門 1：只有 pending 可刪 — 已派貨/已轉採購的單有下游單據，走各自流程
+  IF v_req.status <> 'pending' THEN
+    RAISE EXCEPTION 'restock request % is %, only pending can be deleted',
+      p_request_id, v_req.status;
+  END IF;
+
+  -- 守門 2：雙重保險 — 已有撿貨波引用（正常 pending 不會有；建波會把狀態
+  -- 推到 approved_transfer，這裡防的是資料不一致）
+  SELECT COUNT(*) INTO v_waves
+    FROM picking_waves
+   WHERE source_restock_request_id = p_request_id;
+  IF v_waves > 0 THEN
+    RAISE EXCEPTION 'restock request % already has picking waves, cannot delete', p_request_id;
+  END IF;
+
+  -- 守門 3（20260714000040）：pending 但已有品相開立請購單 → 不可刪
+  -- （明細 CASCADE 硬刪會讓已建的 PR 失去來源對照）
+  SELECT COUNT(*) INTO v_pr_lines
+    FROM restock_request_lines
+   WHERE request_id = p_request_id AND linked_pr_id IS NOT NULL;
+  IF v_pr_lines > 0 THEN
+    RAISE EXCEPTION 'restock request % already has lines sent to purchase request, cannot delete', p_request_id;
+  END IF;
+
+  -- 連帶刪內部 sentinel 訂單 RR-{id}（items 為 ON DELETE CASCADE）。
+  -- 舊資料（20260612000020 之前建的申請）沒有 RR- 訂單，刪 0 筆是正常的。
+  BEGIN
+    DELETE FROM customer_orders
+     WHERE tenant_id = v_tenant
+       AND order_kind = 'restock'
+       AND external_order_no = 'RR-' || p_request_id::TEXT;
+  EXCEPTION WHEN foreign_key_violation THEN
+    RAISE EXCEPTION 'restock request % internal order still referenced, cannot delete', p_request_id;
+  END;
+
+  -- 實體硬刪：restock_request_lines 為 ON DELETE CASCADE
+  BEGIN
+    DELETE FROM restock_requests
+     WHERE id = p_request_id AND tenant_id = v_tenant;
+  EXCEPTION WHEN foreign_key_violation THEN
+    RAISE EXCEPTION 'restock request % still referenced by other records, cannot delete', p_request_id;
+  END;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_delete_restock_request(BIGINT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_delete_restock_request(BIGINT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_delete_restock_request(BIGINT) IS
+  '補貨申請刪除（硬刪）：限 pending、無撿貨波引用、無品相已開請購單；'
+  '連帶刪建單時自動掛的內部 RR-{id} customer_order（items 為 CASCADE）；'
+  'lines 由 ON DELETE CASCADE 連帶刪；同 tenant；'
+  'HQ 職能全刪、門市職能限自己店（_jwt_store_ids）。';
+
+-- ----------------------------------------------------------------------------
+-- Part 5: rpc_reject_restock — 守衛已部分開單的申請
+--         （基底 20260515000002，僅插入一段守衛，其餘逐字保留）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_reject_restock(
+  p_request_id BIGINT,
+  p_reason     TEXT
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_user   UUID := auth.uid();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_req    RECORD;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot reject restock', v_role;
+  END IF;
+
+  IF NULLIF(TRIM(p_reason), '') IS NULL THEN
+    RAISE EXCEPTION 'rejection reason required';
+  END IF;
+
+  SELECT * INTO v_req FROM restock_requests
+   WHERE id = p_request_id AND tenant_id = v_tenant FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'request % not found', p_request_id; END IF;
+  IF v_req.status <> 'pending' THEN
+    RAISE EXCEPTION 'request % already processed (status=%)', p_request_id, v_req.status;
+  END IF;
+
+  -- 20260714000040 守衛：已有品相開立請購單 → 不可整張拒絕
+  IF EXISTS (
+    SELECT 1 FROM restock_request_lines
+     WHERE request_id = p_request_id AND linked_pr_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION '補貨申請 #% 已有品相開立請購單，不可整張拒絕；剩餘品相請繼續以請購單處理',
+      p_request_id;
+  END IF;
+
+  UPDATE restock_requests
+     SET status = 'rejected',
+         rejected_by = v_user,
+         rejected_at = NOW(),
+         rejected_reason = TRIM(p_reason),
+         updated_by = v_user
+   WHERE id = p_request_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_reject_restock(BIGINT, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_reject_restock(BIGINT, TEXT) IS
+  'HQ 拒絕補貨申請（reason 必填）；已有品相開立請購單的申請不可整張拒絕（20260714000040）。';


### PR DESCRIPTION
## 需求

一張補貨申請常混多個品相（同商品不同規格/等級，例 (A)250g-300g、(B)300g-350g），不同品相對不同供應商。HQ Inbox 的「下訂單」原本一鍵把整張申請鏡像成一張請購單，無法依品相分張。

## 變更

### DB（`20260714000040_restock_pr_by_variant.sql`，**已套到線上**）
- `restock_request_lines` 加 `linked_pr_id`：明細層記各品相進了哪張 PR；既有 approved_pr 申請已 backfill
- 新 RPC `rpc_approve_restock_lines_to_pr(request_id, line_ids)`：為選取品相建新 draft PR、stamp 明細；可重複呼叫分多張；全品相開單後申請進 `approved_pr`，部分開單停留 `pending`
- `rpc_approve_restock_to_pr` 改為薄包裝（NULL = 全部剩餘品相），對外行為不變
- 守衛：部分開單的申請不可整張派貨 / 拒絕 / 刪除（避免重複供貨、孤兒 PR）

### UI
- 新 `RestockToPrModal`：HQ Inbox「下訂單」改開品相勾選視窗，已開單品相鎖定顯示 PR 連結，可分次為不同品相各開一張
- HQ Inbox：pending 列顯示「已開單 n/m 品相」與各 PR 連結；歷史列列出明細層全部 PR
- `RestockDetailModal`：明細列顯示各品相的請購單連結

## 測試

- scratch Postgres 重放全部 migrations 後 SQL 直測：分次開單、狀態轉換、重複開單/跨單明細/派貨/拒絕/刪除守衛、舊整張路徑 regression — 全數通過
- 測試案例補進 `docs/TEST-store-self-service.md` §2.14
- `tsc --noEmit` / ESLint 乾淨

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8K8eVPYgifjt36cPvMfTu

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8K8eVPYgifjt36cPvMfTu)_