### PR TITLE
總倉收件匣（/hq/inbox）下訂單也接品相勾選視窗

### DIFF
--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -15,6 +15,7 @@ import { PickModal, type PickWave } from "@/components/PickModal";
 import ExceptionsContent from "@/components/ExceptionsContent";
 import TransferDetailModal from "@/components/TransferDetailModal";
 import RestockDetailModal from "@/components/RestockDetailModal";
+import RestockToPrModal from "@/components/RestockToPrModal";
 import { ORDER_STATUS_LABEL as AID_STATUS_LABEL, type OrderStatus as AidStatus } from "@/lib/orderStatus";
 
 type Stage = "pending" | "in_transit" | "done" | "rejected";
@@ -970,6 +971,7 @@ function HqInboxContent() {
   const [aidDetailId, setAidDetailId] = useState<number | null>(null);
   const [transferDetailId, setTransferDetailId] = useState<number | null>(null);
   const [restockDetailId, setRestockDetailId] = useState<number | null>(null);
+  const [restockPrId, setRestockPrId] = useState<number | null>(null);
   const [editingWave, setEditingWave] = useState<PickWave | null>(null);
   const [dispatchingWaveId, setDispatchingWaveId] = useState<number | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -1260,18 +1262,9 @@ function HqInboxContent() {
     }
   }
 
+  // 下訂單改開品相勾選視窗（RestockToPrModal），可依品相分張開請購單
   async function approveToPr(id: number) {
-    if (!confirm(`確定下訂單？此動作會獨立建立一張新的${PR_TERM_ZH}。`)) return;
-    setBusy(`restock-${id}-pr`);
-    try {
-      const { error: err } = await getSupabase().rpc("rpc_approve_restock_to_pr", { p_request_id: id });
-      if (err) throw err;
-      setReloadTick((t) => t + 1);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(null);
-    }
+    setRestockPrId(id);
   }
 
   async function shipPrReceived(id: number) {
@@ -2097,6 +2090,12 @@ function HqInboxContent() {
         open={restockDetailId !== null}
         restockId={restockDetailId}
         onClose={() => setRestockDetailId(null)}
+      />
+      <RestockToPrModal
+        open={restockPrId !== null}
+        restockId={restockPrId}
+        onClose={() => setRestockPrId(null)}
+        onDone={() => setReloadTick((t) => t + 1)}
       />
 
       {editingWave && (


### PR DESCRIPTION
## 問題

#503 只把 `RestockToPrModal` 接到 `/restock/inbox`，但實際日常操作的總倉收件匣 `/hq/inbox` 有自己的「下訂單」按鈕，仍直接整張呼叫 `rpc_approve_restock_to_pr` — 所以看不到品相勾選視窗。

## 變更

- `/hq/inbox` 單筆「下訂單」改開 `RestockToPrModal`（可依品相分張開請購單）
- 批次下訂單維持整張行為（wrapper RPC 語意不變）

## 測試

- `tsc --noEmit` 乾淨；eslint 僅剩該頁既有的 3 個 pre-existing 錯誤（此次未觸碰的行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8K8eVPYgifjt36cPvMfTu

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8K8eVPYgifjt36cPvMfTu)_