### PR TITLE
補貨申請：部分開單後剩餘品相可刪除（不再補貨）

### DIFF
--- a/apps/admin/src/app/(protected)/restock/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/inbox/page.tsx
@@ -74,11 +74,13 @@ export default function RestockInboxPage() {
       const ids = reqRows.map((r) => r.id);
       const lineMap = new Map<number, { count: number; total: number; prCount: number; prIds: number[] }>();
       if (ids.length > 0) {
-        const { data: lineData } = await sb.from("restock_request_lines").select("request_id, qty, unit_price, linked_pr_id").in("request_id", ids);
-        for (const l of (lineData ?? []) as { request_id: number; qty: number; unit_price: number; linked_pr_id: number | null }[]) {
+        const { data: lineData } = await sb.from("restock_request_lines").select("request_id, qty, unit_price, linked_pr_id, cancelled_at").in("request_id", ids);
+        for (const l of (lineData ?? []) as { request_id: number; qty: number; unit_price: number; linked_pr_id: number | null; cancelled_at: string | null }[]) {
           const slot = lineMap.get(l.request_id) ?? { count: 0, total: 0, prCount: 0, prIds: [] };
-          slot.count += 1;
-          slot.total += Number(l.qty) * Number(l.unit_price);
+          if (l.cancelled_at === null) {
+            slot.count += 1;
+            slot.total += Number(l.qty) * Number(l.unit_price);
+          }
           if (l.linked_pr_id != null) {
             slot.prCount += 1;
             if (!slot.prIds.includes(l.linked_pr_id)) slot.prIds.push(l.linked_pr_id);

--- a/apps/admin/src/components/RestockDetailModal.tsx
+++ b/apps/admin/src/components/RestockDetailModal.tsx
@@ -32,6 +32,7 @@ type Line = {
   variant_name: string | null;
   linked_pr_id: number | null;
   linked_pr_no: string | null;
+  cancelled: boolean;
 };
 
 const STATUS_LABEL: Record<string, string> = {
@@ -53,12 +54,15 @@ export default function RestockDetailModal({
   restockId: number | null;
   onClose: () => void;
 }) {
-  const [hd, setHd] = useState<RestockRow | null>(null);
-  const [lines, setLines] = useState<Line[] | null>(null);
-  const [err, setErr] = useState<string | null>(null);
+  const [hdState, setHd] = useState<RestockRow | null>(null);
+  const [linesState, setLines] = useState<Line[] | null>(null);
+  const [errState, setErr] = useState<string | null>(null);
+  // 以 restockId 為 key 判斷載入結果是否屬於目前開啟的申請：
+  // 換單/關閉不需同步 reset state（react-hooks/set-state-in-effect）
+  const [loadedFor, setLoadedFor] = useState<number | null>(null);
 
   useEffect(() => {
-    if (!open || restockId == null) { setHd(null); setLines(null); setErr(null); return; }
+    if (!open || restockId == null) return;
     let cancelled = false;
     (async () => {
       const sb = getSupabase();
@@ -74,6 +78,8 @@ export default function RestockDetailModal({
       if (rErr || !rData) {
         setErr(rErr?.message ?? "找不到此補貨申請");
         setHd(null);
+        setLines(null);
+        setLoadedFor(restockId);
         return;
       }
       type ApiR = {
@@ -92,6 +98,7 @@ export default function RestockDetailModal({
         purchase_requests: { pr_no?: string } | { pr_no?: string }[] | null;
       };
       const r = rData as unknown as ApiR;
+      setErr(null);
       const storeObj = Array.isArray(r.stores) ? r.stores[0] : r.stores;
       const txObj = Array.isArray(r.transfers) ? r.transfers[0] : r.transfers;
       const prObj = Array.isArray(r.purchase_requests) ? r.purchase_requests[0] : r.purchase_requests;
@@ -113,7 +120,7 @@ export default function RestockDetailModal({
 
       const { data: lData } = await sb
         .from("restock_request_lines")
-        .select("id, sku_id, qty, unit_price, linked_pr_id, purchase_requests(pr_no), skus(sku_code, variant_name, products(name))")
+        .select("id, sku_id, qty, unit_price, linked_pr_id, cancelled_at, purchase_requests(pr_no), skus(sku_code, variant_name, products(name))")
         .eq("request_id", restockId)
         .order("id");
       if (cancelled) return;
@@ -123,6 +130,7 @@ export default function RestockDetailModal({
         qty: number;
         unit_price: number;
         linked_pr_id: number | null;
+        cancelled_at: string | null;
         purchase_requests: { pr_no?: string } | { pr_no?: string }[] | null;
         skus:
           | { sku_code: string; variant_name: string | null; products: { name?: string } | { name?: string }[] | null }
@@ -143,16 +151,23 @@ export default function RestockDetailModal({
           variant_name: skuObj?.variant_name ?? null,
           linked_pr_id: row.linked_pr_id ?? null,
           linked_pr_no: prObj?.pr_no ?? null,
+          cancelled: row.cancelled_at !== null,
         };
       });
       setLines(rows);
+      setLoadedFor(restockId);
     })();
     return () => {
       cancelled = true;
     };
   }, [open, restockId]);
 
-  const total = (lines ?? []).reduce((acc, l) => acc + l.qty * l.unit_price, 0);
+  const ready = open && restockId != null && loadedFor === restockId;
+  const hd = ready ? hdState : null;
+  const lines = ready ? linesState : null;
+  const err = ready ? errState : null;
+
+  const total = (lines ?? []).filter((l) => !l.cancelled).reduce((acc, l) => acc + l.qty * l.unit_price, 0);
   const title = hd ? `📦 補貨申請 RESTOCK#${hd.id}` : "補貨申請";
 
   return (
@@ -226,9 +241,10 @@ export default function RestockDetailModal({
                     {lines.map((l) => (
                       <tr key={l.id}>
                         <td className="px-3 py-2 font-mono text-xs">{l.sku_code}</td>
-                        <td className="px-3 py-2 text-xs">
+                        <td className={`px-3 py-2 text-xs ${l.cancelled ? "line-through opacity-60" : ""}`}>
                           {l.sku_name || "—"}
                           {l.variant_name && <span className="ml-1 text-zinc-500">/ {l.variant_name}</span>}
+                          {l.cancelled && <span className="ml-2 text-red-600 no-underline dark:text-red-400">已刪除</span>}
                           {l.linked_pr_id != null && (
                             <div>
                               <Link

--- a/apps/admin/src/components/RestockToPrModal.tsx
+++ b/apps/admin/src/components/RestockToPrModal.tsx
@@ -17,12 +17,13 @@ type Line = {
   variant_name: string | null;
   linked_pr_id: number | null;
   linked_pr_no: string | null;
+  cancelled: boolean;
 };
 
 /**
  * 補貨申請「下訂單」品相選擇 Modal：
  * 勾選要開請購單的品相（明細），可分次為不同品相各開一張 PR。
- * 已開單的品相鎖定顯示其 PR 連結。
+ * 已開單的品相鎖定顯示其 PR 連結；已有品相開單後，剩餘品相可刪除（不再補貨）。
  */
 export default function RestockToPrModal({
   open,
@@ -52,7 +53,7 @@ export default function RestockToPrModal({
       const sb = getSupabase();
       const { data, error } = await sb
         .from("restock_request_lines")
-        .select("id, sku_id, qty, unit_price, linked_pr_id, purchase_requests(pr_no), skus(sku_code, variant_name, products(name))")
+        .select("id, sku_id, qty, unit_price, linked_pr_id, cancelled_at, purchase_requests(pr_no), skus(sku_code, variant_name, products(name))")
         .eq("request_id", restockId)
         .order("id");
       if (cancelled) return;
@@ -67,6 +68,7 @@ export default function RestockToPrModal({
         qty: number;
         unit_price: number;
         linked_pr_id: number | null;
+        cancelled_at: string | null;
         purchase_requests: { pr_no?: string } | { pr_no?: string }[] | null;
         skus:
           | { sku_code: string; variant_name: string | null; products: { name?: string } | { name?: string }[] | null }
@@ -87,19 +89,21 @@ export default function RestockToPrModal({
           variant_name: skuObj?.variant_name ?? null,
           linked_pr_id: row.linked_pr_id,
           linked_pr_no: prObj?.pr_no ?? null,
+          cancelled: row.cancelled_at !== null,
         };
       });
       setErr(null);
       setLoaded({ restockId, lines: rows });
-      // 預設全選尚未開單的品相
-      setChecked(new Set(rows.filter((l) => l.linked_pr_id === null).map((l) => l.id)));
+      // 預設全選尚未開單且未刪除的品相
+      setChecked(new Set(rows.filter((l) => l.linked_pr_id === null && !l.cancelled).map((l) => l.id)));
     })();
     return () => {
       cancelled = true;
     };
   }, [open, restockId, reload]);
 
-  const openable = useMemo(() => (lines ?? []).filter((l) => l.linked_pr_id === null), [lines]);
+  const openable = useMemo(() => (lines ?? []).filter((l) => l.linked_pr_id === null && !l.cancelled), [lines]);
+  const hasOrdered = useMemo(() => (lines ?? []).some((l) => l.linked_pr_id !== null), [lines]);
   const selectedTotal = useMemo(
     () => (lines ?? []).filter((l) => checked.has(l.id)).reduce((acc, l) => acc + l.qty * l.unit_price, 0),
     [lines, checked]
@@ -125,7 +129,31 @@ export default function RestockToPrModal({
       });
       if (error) throw error;
       onDone();
-      // 還有品相沒開單 → 留在 modal 續開下一張；全開完 → 關閉
+      // 還有品相沒處理 → 留在 modal 續處理；全處理完 → 關閉
+      if (checked.size < openable.length) {
+        setReload((t) => t + 1);
+      } else {
+        onClose();
+      }
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function cancelLines() {
+    if (restockId == null || checked.size === 0) return;
+    if (!confirm(`確定刪除勾選的 ${checked.size} 個品相？刪除後不再補貨、無法復原。`)) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const { error } = await getSupabase().rpc("rpc_cancel_restock_lines", {
+        p_request_id: restockId,
+        p_line_ids: Array.from(checked),
+      });
+      if (error) throw error;
+      onDone();
       if (checked.size < openable.length) {
         setReload((t) => t + 1);
       } else {
@@ -143,6 +171,7 @@ export default function RestockToPrModal({
       <div className="space-y-3">
         <p className="text-sm text-zinc-500">
           勾選要下訂的品相：勾選的品項會建成一張新的{PR_TERM_ZH}；可分次為不同品相各開一張。
+          {hasOrdered && "剩餘不補貨的品相可勾選後刪除。"}
         </p>
 
         {err && (
@@ -170,11 +199,14 @@ export default function RestockToPrModal({
               ) : (
                 lines.map((l) => {
                   const ordered = l.linked_pr_id !== null;
+                  const locked = ordered || l.cancelled;
                   return (
-                    <tr key={l.id} className={ordered ? "opacity-60" : "cursor-pointer"} onClick={() => !ordered && toggle(l.id)}>
+                    <tr key={l.id} className={locked ? "opacity-60" : "cursor-pointer"} onClick={() => !locked && toggle(l.id)}>
                       <td className="px-3 py-2">
                         {ordered ? (
                           <span title="已開單">✅</span>
+                        ) : l.cancelled ? (
+                          <span title="已刪除（不再補貨）">🗑️</span>
                         ) : (
                           <input
                             type="checkbox"
@@ -185,9 +217,10 @@ export default function RestockToPrModal({
                         )}
                       </td>
                       <td className="px-3 py-2 font-mono text-xs">{l.sku_code}</td>
-                      <td className="px-3 py-2 text-xs">
+                      <td className={`px-3 py-2 text-xs ${l.cancelled ? "line-through" : ""}`}>
                         {l.sku_name || "—"}
                         {l.variant_name && <span className="ml-1 text-zinc-500">/ {l.variant_name}</span>}
+                        {l.cancelled && <span className="ml-2 text-red-600 no-underline dark:text-red-400">已刪除</span>}
                         {ordered && (
                           <span className="ml-2">
                             →{" "}
@@ -219,12 +252,21 @@ export default function RestockToPrModal({
             <SpinButton onClick={onClose} className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700">
               取消
             </SpinButton>
+            {hasOrdered && (
+              <SpinButton
+                onClick={cancelLines}
+                disabled={busy || checked.size === 0}
+                className="rounded-md border border-red-400 bg-red-50 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-100 disabled:opacity-50 dark:border-red-700 dark:bg-red-950 dark:text-red-300"
+              >
+                刪除勾選品相
+              </SpinButton>
+            )}
             <SpinButton
               onClick={submit}
               disabled={busy || checked.size === 0}
               className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
             >
-              {busy ? "建立中…" : `為勾選品相開一張${PR_TERM_ZH}`}
+              {busy ? "處理中…" : `為勾選品相開一張${PR_TERM_ZH}`}
             </SpinButton>
           </div>
         </div>

--- a/docs/TEST-store-self-service.md
+++ b/docs/TEST-store-self-service.md
@@ -155,6 +155,19 @@ SELECT proname, pg_get_function_arguments(oid) FROM pg_proc
   approved_by/at 寫入、header linked_pr_id 仍為第一張
 - 舊 rpc_approve_restock_to_pr(req_id) 為薄包裝（= 全部剩餘品相一張 PR），行為不變
 
+### 2.15 rpc_cancel_restock_lines — 剩餘品相刪除（不再補貨）（20260714000050）
+**情境：** 品相 A 已開請購單的 pending request，HQ 對品相 B 呼叫
+`rpc_cancel_restock_lines(req_id, ARRAY[line_b])`，之後再開單/刪除剩餘品相
+
+**預期：**
+- 未開任何請購單前呼叫 → RAISE '請用「拒絕」'（整張不補貨走既有拒絕流程）
+- 刪 B：line_b.cancelled_at 寫入、sentinel RR- 訂單對應 sku 明細 status='cancelled'；
+  還有品相未處理 → request 停留 'pending'
+- 已開單品相不可刪、已刪品相不可再刪、已刪品相不可開請購單 → 各自 RAISE
+- 開單 NULL（全部剩餘）會排除已刪品相；全品相處理完（開單或刪除）→
+  status='approved_pr'、approved_by/at 寫入
+- 「刪除全部剩餘品相」也會直接結案（至少一個品相已開單 → approved_pr）
+
 ---
 
 ## 3. UI 行為（preview 互動）

--- a/supabase/migrations/20260714000050_restock_cancel_remaining_lines.sql
+++ b/supabase/migrations/20260714000050_restock_cancel_remaining_lines.sql
@@ -1,0 +1,319 @@
+-- ============================================================================
+-- 2026-07-14: 補貨申請部分開單後，剩餘品相可「刪除、不再補貨」
+-- ----------------------------------------------------------------------------
+-- 需求（cktalex 2026-07-04 回報，接續 20260714000040）：
+--   依品相分張開請購單後，沒開單的品相可能根本不想補了。原本申請會卡在
+--   pending 直到「全品相都開單」；現在允許把剩餘品相刪除（不再補貨），
+--   刪完若全品相都已處理（開單或刪除）→ 申請直接結案 approved_pr。
+--
+-- 變更：
+--   Part 0  restock_request_lines 加 cancelled_at / cancelled_by（軟刪，
+--     保留稽核；硬刪會讓 qty/金額歷史消失）。
+--   Part 1  新 RPC rpc_cancel_restock_lines(p_request_id, p_line_ids)：
+--     - 只在申請已有品相開過請購單時可用（整張不補貨走既有「拒絕」）。
+--     - p_line_ids = NULL → 全部尚未開單且未刪除的品相。
+--     - 已開請購單 / 已刪除的品相不可再刪。
+--     - 同步把 sentinel RR-{id} customer_order 對應 sku 的 pending 明細
+--       標 'cancelled'（報表/需求彙總不再看到這筆需求）。
+--     - 刪完若無剩餘品相 → status='approved_pr'（header linked_pr_id 在
+--       第一張 PR 開立時已寫入，CHECK 約束滿足）。
+--   Part 2  rpc_approve_restock_lines_to_pr 改版（基底 20260714000040）：
+--     - 預設選取（NULL）排除已刪除品相
+--     - 明確指定已刪除品相 → RAISE
+--     - 「全開單完成」判斷改為「無 未開單且未刪除 的品相」
+--
+-- 基底版本（依 CLAUDE.md 規則 grep 全歷史、以時間最新版擴寫）：
+--   rpc_approve_restock_lines_to_pr ← 20260714000040_restock_pr_by_variant.sql（唯一版本）
+--
+-- Rollback：
+--   DROP FUNCTION public.rpc_cancel_restock_lines(BIGINT, BIGINT[]);
+--   rpc_approve_restock_lines_to_pr → 重跑 20260714000040 的 CREATE OR REPLACE。
+--   ALTER TABLE restock_request_lines DROP COLUMN cancelled_at, DROP COLUMN cancelled_by;
+--   （已標 cancelled 的 customer_order_items 不自動還原）
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- Part 0: 明細層軟刪欄位
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.restock_request_lines
+  ADD COLUMN IF NOT EXISTS cancelled_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS cancelled_by UUID;
+
+COMMENT ON COLUMN public.restock_request_lines.cancelled_at IS
+  '品相刪除（不再補貨）時間；NULL = 有效明細。'
+  '與 linked_pr_id 互斥 — 已開請購單的品相不可刪。';
+
+-- ----------------------------------------------------------------------------
+-- Part 1: rpc_cancel_restock_lines — 刪除剩餘品相（不再補貨）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_cancel_restock_lines(
+  p_request_id BIGINT,
+  p_line_ids   BIGINT[] DEFAULT NULL
+) RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant    UUID := public._current_tenant_id();
+  v_user      UUID := auth.uid();
+  v_role      TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_req       RECORD;
+  v_selected  BIGINT[];
+  v_bad       BIGINT;
+  v_remaining INTEGER;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot cancel restock lines', v_role;
+  END IF;
+
+  SELECT * INTO v_req FROM restock_requests
+   WHERE id = p_request_id AND tenant_id = v_tenant FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'request % not found', p_request_id; END IF;
+  IF v_req.status <> 'pending' THEN
+    RAISE EXCEPTION 'request % already processed (status=%)', p_request_id, v_req.status;
+  END IF;
+
+  -- 只服務「依品相分張」流程的收尾；整張不補貨走既有「拒絕」（留 reason 稽核）
+  IF NOT EXISTS (
+    SELECT 1 FROM restock_request_lines
+     WHERE request_id = p_request_id AND linked_pr_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION '補貨申請 #% 尚未開立任何請購單；整張不補貨請用「拒絕」', p_request_id;
+  END IF;
+
+  -- 選取明細：未指定 → 全部尚未開單且未刪除的品相
+  IF p_line_ids IS NULL OR COALESCE(array_length(p_line_ids, 1), 0) = 0 THEN
+    SELECT array_agg(id) INTO v_selected
+      FROM restock_request_lines
+     WHERE request_id = p_request_id AND tenant_id = v_tenant
+       AND linked_pr_id IS NULL AND cancelled_at IS NULL;
+  ELSE
+    SELECT t.id INTO v_bad
+      FROM unnest(p_line_ids) AS t(id)
+     WHERE NOT EXISTS (
+             SELECT 1 FROM restock_request_lines l
+              WHERE l.id = t.id
+                AND l.request_id = p_request_id
+                AND l.tenant_id  = v_tenant
+           )
+     LIMIT 1;
+    IF v_bad IS NOT NULL THEN
+      RAISE EXCEPTION '明細 #% 不屬於補貨申請 #%', v_bad, p_request_id;
+    END IF;
+
+    SELECT l.id INTO v_bad
+      FROM restock_request_lines l
+     WHERE l.id = ANY (p_line_ids) AND l.linked_pr_id IS NOT NULL
+     LIMIT 1;
+    IF v_bad IS NOT NULL THEN
+      RAISE EXCEPTION '明細 #% 已開請購單，不可刪除', v_bad;
+    END IF;
+
+    SELECT l.id INTO v_bad
+      FROM restock_request_lines l
+     WHERE l.id = ANY (p_line_ids) AND l.cancelled_at IS NOT NULL
+     LIMIT 1;
+    IF v_bad IS NOT NULL THEN
+      RAISE EXCEPTION '明細 #% 已刪除', v_bad;
+    END IF;
+
+    SELECT array_agg(DISTINCT t.id) INTO v_selected
+      FROM unnest(p_line_ids) AS t(id);
+  END IF;
+
+  IF v_selected IS NULL OR COALESCE(array_length(v_selected, 1), 0) = 0 THEN
+    RAISE EXCEPTION '補貨申請 #% 沒有可刪除的品項', p_request_id;
+  END IF;
+
+  UPDATE restock_request_lines
+     SET cancelled_at = NOW(),
+         cancelled_by = v_user,
+         updated_by   = v_user
+   WHERE id = ANY (v_selected);
+
+  -- 同步取消 sentinel RR-{id} 訂單的對應明細（需求彙總/報表不再列入）
+  UPDATE customer_order_items coi
+     SET status     = 'cancelled',
+         updated_by = v_user,
+         updated_at = NOW()
+    FROM customer_orders co
+   WHERE co.id = coi.order_id
+     AND co.tenant_id = v_tenant
+     AND co.order_kind = 'restock'
+     AND co.external_order_no = 'RR-' || p_request_id::TEXT
+     AND coi.status = 'pending'
+     AND coi.sku_id IN (
+           SELECT sku_id FROM restock_request_lines WHERE id = ANY (v_selected)
+         );
+
+  SELECT COUNT(*) INTO v_remaining
+    FROM restock_request_lines
+   WHERE request_id = p_request_id
+     AND linked_pr_id IS NULL AND cancelled_at IS NULL;
+
+  IF v_remaining = 0 THEN
+    -- 全品相都處理完（開單或刪除）→ 結案；linked_pr_id 於第一張 PR 已寫入
+    UPDATE restock_requests
+       SET status      = 'approved_pr',
+           approved_by = v_user,
+           approved_at = NOW(),
+           updated_by  = v_user
+     WHERE id = p_request_id;
+  END IF;
+
+  RETURN COALESCE(array_length(v_selected, 1), 0);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_cancel_restock_lines(BIGINT, BIGINT[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_cancel_restock_lines(BIGINT, BIGINT[]) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_cancel_restock_lines(BIGINT, BIGINT[]) IS
+  '補貨申請剩餘品相刪除（不再補貨，軟刪）：限已有品相開過請購單的 pending 申請；'
+  'p_line_ids=NULL → 全部未開單品相。同步取消 sentinel RR- 訂單對應明細；'
+  '刪完無剩餘品相 → 申請結案 approved_pr。';
+
+-- ----------------------------------------------------------------------------
+-- Part 2: rpc_approve_restock_lines_to_pr — 排除已刪除品相
+--         （基底 20260714000040，改動：預設選取/驗證/完成判斷排除 cancelled）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_approve_restock_lines_to_pr(
+  p_request_id BIGINT,
+  p_line_ids   BIGINT[] DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant    UUID := public._current_tenant_id();
+  v_user      UUID := auth.uid();
+  v_role      TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_req       RECORD;
+  v_pr_id     BIGINT;
+  v_hq_loc    BIGINT;
+  v_no        TEXT;
+  v_selected  BIGINT[];
+  v_bad       BIGINT;
+  v_remaining INTEGER;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot approve restock', v_role;
+  END IF;
+
+  SELECT * INTO v_req FROM restock_requests
+   WHERE id = p_request_id AND tenant_id = v_tenant FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'request % not found', p_request_id; END IF;
+  IF v_req.status <> 'pending' THEN
+    RAISE EXCEPTION 'request % already processed (status=%)', p_request_id, v_req.status;
+  END IF;
+
+  -- 選取明細：未指定 → 全部尚未開單且未刪除的明細
+  IF p_line_ids IS NULL OR COALESCE(array_length(p_line_ids, 1), 0) = 0 THEN
+    SELECT array_agg(id) INTO v_selected
+      FROM restock_request_lines
+     WHERE request_id = p_request_id AND tenant_id = v_tenant
+       AND linked_pr_id IS NULL AND cancelled_at IS NULL;
+  ELSE
+    -- 守衛：每個 id 都必須屬於本申請
+    SELECT t.id INTO v_bad
+      FROM unnest(p_line_ids) AS t(id)
+     WHERE NOT EXISTS (
+             SELECT 1 FROM restock_request_lines l
+              WHERE l.id = t.id
+                AND l.request_id = p_request_id
+                AND l.tenant_id  = v_tenant
+           )
+     LIMIT 1;
+    IF v_bad IS NOT NULL THEN
+      RAISE EXCEPTION '明細 #% 不屬於補貨申請 #%', v_bad, p_request_id;
+    END IF;
+
+    -- 守衛：不可重複開單
+    SELECT l.id INTO v_bad
+      FROM restock_request_lines l
+     WHERE l.id = ANY (p_line_ids)
+       AND l.linked_pr_id IS NOT NULL
+     LIMIT 1;
+    IF v_bad IS NOT NULL THEN
+      RAISE EXCEPTION '明細 #% 已開過請購單，不可重複開單', v_bad;
+    END IF;
+
+    -- 守衛（20260714000050）：已刪除的品相不可開單
+    SELECT l.id INTO v_bad
+      FROM restock_request_lines l
+     WHERE l.id = ANY (p_line_ids)
+       AND l.cancelled_at IS NOT NULL
+     LIMIT 1;
+    IF v_bad IS NOT NULL THEN
+      RAISE EXCEPTION '明細 #% 已刪除，不可開請購單', v_bad;
+    END IF;
+
+    SELECT array_agg(DISTINCT t.id) INTO v_selected
+      FROM unnest(p_line_ids) AS t(id);
+  END IF;
+
+  IF v_selected IS NULL OR COALESCE(array_length(v_selected, 1), 0) = 0 THEN
+    RAISE EXCEPTION '補貨申請 #% 沒有可開請購單的品項', p_request_id;
+  END IF;
+
+  SELECT id INTO v_hq_loc FROM locations
+   WHERE tenant_id = v_tenant AND type = 'central_warehouse' AND is_active = TRUE
+   ORDER BY id LIMIT 1;
+
+  -- 每次呼叫都建新 PR（沿用 20260606000050「不 append 既有 draft」原則）
+  v_no := public.rpc_next_pr_no();
+  INSERT INTO purchase_requests (
+    tenant_id, pr_no, source_location_id, status, raw_line_text,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_no, v_hq_loc, 'draft',
+    'restock request #' || p_request_id::TEXT,
+    v_user, v_user
+  ) RETURNING id INTO v_pr_id;
+
+  -- 鏡像選取的明細進 PR（suggested_supplier 由 trg_pri_fill_default_supplier 補）
+  INSERT INTO purchase_request_items (
+    pr_id, sku_id, qty_requested, raw_line, notes, created_by, updated_by
+  )
+  SELECT v_pr_id, l.sku_id, l.qty,
+         'restock #' || p_request_id::TEXT,
+         l.notes, v_user, v_user
+    FROM restock_request_lines l
+   WHERE l.id = ANY (v_selected);
+
+  -- stamp 明細層對照
+  UPDATE restock_request_lines
+     SET linked_pr_id = v_pr_id,
+         updated_by   = v_user
+   WHERE id = ANY (v_selected);
+
+  SELECT COUNT(*) INTO v_remaining
+    FROM restock_request_lines
+   WHERE request_id = p_request_id
+     AND linked_pr_id IS NULL AND cancelled_at IS NULL;
+
+  IF v_remaining = 0 THEN
+    -- 全品相都處理完（開單或刪除）→ 申請完成，進 approved_pr
+    UPDATE restock_requests
+       SET status       = 'approved_pr',
+           linked_pr_id = COALESCE(linked_pr_id, v_pr_id),
+           approved_by  = v_user,
+           approved_at  = NOW(),
+           updated_by   = v_user
+     WHERE id = p_request_id;
+  ELSE
+    -- 部分開單 → 停留 pending，header 記第一張 PR 方便 Inbox 連結
+    UPDATE restock_requests
+       SET linked_pr_id = COALESCE(linked_pr_id, v_pr_id),
+           updated_by   = v_user
+     WHERE id = p_request_id;
+  END IF;
+
+  RETURN v_pr_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_approve_restock_lines_to_pr(BIGINT, BIGINT[]) IS
+  '補貨申請依品相開請購單：為選取明細建新 draft PR 並 stamp 明細 linked_pr_id；'
+  'p_line_ids=NULL → 全部未開單且未刪除明細。可重複呼叫分多張 PR；'
+  '全品相處理完（開單或刪除）後申請進 approved_pr，否則停留 pending。';


### PR DESCRIPTION
## 需求

依品相分張開請購單（#503/#505）後，沒開單的品相可能不想補了；原本申請會卡在 pending 直到全品相開完單。現在剩餘品相可刪除（不再補貨），刪完直接結案。

## 變更

### DB（`20260714000050_restock_cancel_remaining_lines.sql`，**已套到線上**）
- `restock_request_lines` 加 `cancelled_at` / `cancelled_by`（軟刪留稽核）
- 新 RPC `rpc_cancel_restock_lines(request_id, line_ids)`：限已有品相開過請購單的 pending 申請（整張不補貨走既有「拒絕」）；同步取消 sentinel RR- 訂單對應明細；刪完無剩餘品相 → 申請結案 `approved_pr`
- `rpc_approve_restock_lines_to_pr`：預設選取 / 完成判斷排除已刪品相，已刪品相不可開單

### UI
- `RestockToPrModal`：已開單後出現「刪除勾選品相」按鈕（confirm 後不可復原）；已刪品相鎖定顯示刪除線與「已刪除」
- Inbox 項數/金額、詳情合計排除已刪品相
- `RestockDetailModal` 改 keyed-state 載入（修 react-hooks lint）

## 測試

- scratch Postgres 重放全部 migrations 後 SQL 直測：未開單前不可刪、刪後停留 pending、sentinel 明細同步 cancelled、已開單/已刪守衛、開單排除已刪品相、刪除全部剩餘直接結案 — 全數通過（`docs/TEST-store-self-service.md` §2.15）
- `tsc --noEmit` / ESLint 乾淨

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8K8eVPYgifjt36cPvMfTu

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8K8eVPYgifjt36cPvMfTu)_