### PR TITLE
hq/inbox 移除無作用的 eslint-disable；重新觸發 Pages 部署

### DIFF
--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -1324,7 +1324,6 @@ function HqInboxContent() {
         return r.stage === "pending";
       })
       .map((r) => r.key);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [paginatedRows, sourceFilter]);
 
   function selectAllVisible() {


### PR DESCRIPTION
## 目的

#507 的 GitHub Pages 發佈步驟再次吃到暫時性錯誤（`Deployment failed, try again later`）— build 成功、只有發佈失敗。GitHub App 權限無法 rerun workflow，用這個小 commit 重新觸發 push→deploy。

## 變更

- `/hq/inbox` 移除一個 lint 回報 unused 的 `eslint-disable-next-line react-hooks/exhaustive-deps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8K8eVPYgifjt36cPvMfTu

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8K8eVPYgifjt36cPvMfTu)_