### PR TITLE
請購單：結單日已建單後可「補單」（只帶新增未請購量）

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -51,6 +51,13 @@ type CloseDateGroup = {
   total_qty: number;
 };
 
+type SupplementableDate = {
+  close_date: string;
+  campaign_count: number;
+  remaining_skus: number;
+  remaining_qty: number;
+};
+
 type ClosedCampaignRow = {
   id: number;
   name: string;
@@ -105,6 +112,10 @@ export default function PurchaseRequestsListPage() {
   const [pendingDates, setPendingDates] = useState<CloseDateGroup[] | null>(
     null,
   );
+  const [supplementDates, setSupplementDates] = useState<
+    SupplementableDate[] | null
+  >(null);
+  const [busySuppDate, setBusySuppDate] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // 篩選 / 排序 / 分組
@@ -299,6 +310,58 @@ export default function PurchaseRequestsListPage() {
       cancelled = true;
     };
   }, [reloadTick]);
+
+  // ============== 載入「結單日補單」cards ==============
+  // 已建過 close_date PR、但該日仍有未請購量(delta>0)的結單日。
+  // delta 邏輯全在 rpc_list_supplementable_close_dates（單一真相）。
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data, error: err } = await getSupabase().rpc(
+          "rpc_list_supplementable_close_dates",
+        );
+        if (cancelled) return;
+        if (err) {
+          setSupplementDates([]);
+          return;
+        }
+        const list = ((data as SupplementableDate[] | null) ?? []).map((d) => ({
+          close_date: d.close_date,
+          campaign_count: Number(d.campaign_count),
+          remaining_skus: Number(d.remaining_skus),
+          remaining_qty: Number(d.remaining_qty),
+        }));
+        setSupplementDates(list);
+      } catch {
+        if (!cancelled) setSupplementDates([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadTick]);
+
+  async function handleSupplement(closeDate: string) {
+    setBusySuppDate(closeDate);
+    setError(null);
+    try {
+      const supabase = getSupabase();
+      const { data: userData } = await supabase.auth.getUser();
+      const { data: prId, error: rpcErr } = await supabase.rpc(
+        "rpc_create_supplementary_pr_from_close_date",
+        {
+          p_close_date: closeDate,
+          p_operator: userData.user?.id,
+        },
+      );
+      if (rpcErr) throw new Error(rpcErr.message);
+      router.push(`/purchase/requests/edit?id=${prId}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setBusySuppDate(null);
+    }
+  }
 
   async function handleImport(closeDate: string) {
     setBusyDate(closeDate);
@@ -794,6 +857,45 @@ export default function PurchaseRequestsListPage() {
                   className="w-full rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:opacity-50"
                 >
                   {busyDate === g.close_date ? "建立中…" : "📋 開始建立"}
+                </SpinButton>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* === 結單日補單 cards（已建單但仍有未請購量）=== */}
+      {supplementDates !== null && supplementDates.length > 0 && (
+        <section className="rounded-md border border-amber-200 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950/30">
+          <h2 className="mb-1 text-sm font-semibold text-amber-900 dark:text-amber-200">
+            🔁 結單日補單（{supplementDates.length}）
+          </h2>
+          <p className="mb-3 text-xs text-amber-800/80 dark:text-amber-300/70">
+            這些結單日已建過{PR_TERM_ZH}，但仍有尚未請購的數量。補單只會帶入「新增未請購量」，原單不受影響。
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {supplementDates.map((g) => (
+              <div
+                key={g.close_date}
+                className="rounded-md border border-amber-200 bg-white p-3 shadow-sm dark:border-amber-900 dark:bg-zinc-900"
+              >
+                <div className="mb-1 text-base font-semibold">
+                  {g.close_date}
+                </div>
+                <div className="mb-2 text-xs text-zinc-500">
+                  {g.campaign_count} 個團 · 尚缺 {g.remaining_skus} 個品項 · 補單量{" "}
+                  {g.remaining_qty}
+                </div>
+                <SpinButton
+                  onClick={() => handleSupplement(g.close_date)}
+                  disabled={busySuppDate !== null}
+                  className="flex w-full items-center justify-center rounded-md bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-500 disabled:opacity-50"
+                >
+                  {busySuppDate === g.close_date ? (
+                    <Spinner size={16} />
+                  ) : (
+                    "➕ 補單"
+                  )}
                 </SpinButton>
               </div>
             ))}

--- a/docs/TEST-supplementary-pr-close-date.md
+++ b/docs/TEST-supplementary-pr-close-date.md
@@ -1,0 +1,65 @@
+# TEST — 結單日補單（supplementary PR）
+
+## 背景 / 需求
+
+現況：對某結單日（例：7/4）建了請購單後，該日所有開團由 `closed → locked`，
+所有 PR 建立路徑（結單日待開單卡片、針對團購建單 modal、`rpc_create_pr_from_campaigns` 守衛）
+都只吃 `closed`，導致「7/4 不能再建單」。
+
+使用者要的行為（2026-07-06 決策，選項 B）：
+**保留原請購單，另開一張「補單」，只彙總「前次尚未請購的新增量」**
+（delta = 該結單日目前訂單需求 − 該結單日所有未取消請購單已請購量），
+原單與已拆 PO 一律不動。若某 SKU 已被前次請購涵蓋，delta ≤ 0 則不列入。
+
+實作：
+- migration `20260714000060_supplementary_pr_from_close_date.sql`
+  - `rpc_create_supplementary_pr_from_close_date(p_close_date, p_operator)` → 建補單
+  - `rpc_list_supplementable_close_dates()` → 列出「已建單但仍有未請購量」的結單日（前端顯示補單卡片用）
+- 前端 `apps/admin/.../purchase/requests/page.tsx` 新增「🔁 結單日補單」區塊
+
+---
+
+## A. RPC — `rpc_create_supplementary_pr_from_close_date`
+
+- [ ] A1 正常補單：某結單日原 PR 只請購了部分品相 → 補單只含剩餘 SKU，qty = 需求 − 已請購。
+- [ ] A2 delta 逐 SKU 正確：SKU 需求 10、前次已請購 7 → 補單該 SKU = 3。
+- [ ] A3 已涵蓋全部：所有 SKU 需求都 ≤ 已請購 → RAISE `no remaining demand`，不建空 PR、不留殘 header。
+- [ ] A4 尚未建過任何 PR 的結單日呼叫 → RAISE `no existing PR ... use rpc_create_pr_from_close_date`（引導走正常建單）。
+- [ ] A5 該結單日無 closed/locked 開團 → RAISE `no closed/locked campaigns`。
+- [ ] A6 原 PR 不受影響：補單建立後，原 PR 的 items / qty / status / 已拆 PO 完全不變。
+- [ ] A7 累積正確：連續補單兩次，第二次 delta 會扣掉第一次補單的 qty（不重複）。
+- [ ] A8 取消的 PR 不計入 already：把前次 PR 設 cancelled 後補單，delta 回到完整需求。
+- [ ] A9 join 表同步：`fn_check_pr_campaigns_consistency()` 對新補單回 0 孤兒。
+- [ ] A10 新加訂單場景：把某 locked 團解鎖回 closed、加新 pending 訂單、再補單 →
+      補單含新增量，且尾巴把該團重新 lock、新訂單 auto-confirm（寫稽核）。
+- [ ] A11 供應商帶入：補單品項 suggested_supplier_id 依 supplier_skus.is_preferred，
+      無則由 `trg_pri_fill_default_supplier` fallback products.default_supplier_id。
+- [ ] A12 total_amount snapshot：header total 正確加總補單 items line_subtotal。
+
+## B. RPC — `rpc_list_supplementable_close_dates`
+
+- [ ] B1 只回「已有未取消 close_date PR 且仍有 delta>0」的結單日。
+- [ ] B2 完全請購完的日期不出現。
+- [ ] B3 從未建 PR 的日期不出現（那些走「結單日待開單」卡）。
+- [ ] B4 remaining_skus / remaining_qty 數字與逐 SKU delta 加總一致。
+- [ ] B5 tenant 隔離：只回本 tenant。
+- [ ] B6 60 天窗：超過 60 天的結單日不列。
+
+## C. 前端
+
+- [ ] C1 有補單候選時顯示「🔁 結單日補單」區塊，每日一張卡（日期 / 團數 / 剩餘品項 / 剩餘量）。
+- [ ] C2 「補單」按鈕 → 呼叫 create RPC → 導到新 PR 的 edit 頁。
+- [ ] C3 無候選時整個區塊不顯示。
+- [ ] C4 建立中 spinner（純轉圈、無文字 — 對齊 feedback_loading_spinner_no_text）。
+- [ ] C5 既有「結單日待開單」「針對團購建單」「空白單」行為完全不變（回歸）。
+
+## D. 回歸 / 邊界
+
+- [ ] D1 `rpc_create_pr_from_close_date` / `rpc_create_pr_from_campaigns` / `rpc_append_campaign_to_pr` 未被本 migration 改動。
+- [ ] D2 `rpc_delete_pr` 對補單一樣可刪（draft、未拆 PO），刪後解鎖同結單日 locked 團。
+- [ ] D3 admin build（tsc + next build）綠。
+
+## 驗證方式
+
+- RPC 邏輯：本機切片 DB（reference_local_db_slice_testing）或 prod Studio 貼 SQL 驗（agent 只產 SQL）。
+- 前端：tsc/build + 碼審（admin live preview 沙箱被擋 — reference_admin_preview_sandbox_block）。

--- a/supabase/migrations/20260714000060_supplementary_pr_from_close_date.sql
+++ b/supabase/migrations/20260714000060_supplementary_pr_from_close_date.sql
@@ -1,0 +1,292 @@
+-- ============================================================================
+-- 2026-07-06: 結單日「補單」— 保留原請購單，另開一張只含新增未請購量的 PR
+-- ----------------------------------------------------------------------------
+-- 背景（使用者 2026-07-06 決策，選項 B）：
+--   對某結單日建了請購單後，該日開團 closed→locked（20260625000000 鎖團），
+--   所有建 PR 路徑（結單日待開單卡 / 針對團購建單 modal / rpc_create_pr_from_campaigns
+--   守衛）都只吃 'closed'，導致「7/4 不能再建單」。實務上結單後仍需補單
+--   （漏的品相 / 分張開單後的剩餘 / 解鎖後新加的訂單）。
+--
+--   要的行為：**保留原單，另開一張補單，只彙總「前次尚未請購的新增量」**：
+--     delta(sku) = 該結單日目前訂單需求(sku)
+--                − 該結單日所有『未取消 close_date PR』已請購量(sku)
+--     只列 delta > 0 的 SKU。原單、已拆 PO 一律不動；已涵蓋的 SKU 自動歸零剔除，
+--     避免重複下單。
+--
+-- 本 migration 內容：
+--   1. rpc_create_supplementary_pr_from_close_date(p_close_date, p_operator) → 建補單
+--   2. rpc_list_supplementable_close_dates() → 列「已建單但仍有 delta>0」的結單日
+--      （前端「🔁 結單日補單」卡片資料源；delta 邏輯只留在 SQL，單一真相）
+--
+-- 基底 / 對齊：
+--   - 建單彙總、鎖團尾巴 mirror rpc_create_pr_from_close_date 最新版（20260625000000）。
+--   - 供應商帶入交給 trg_pri_fill_default_supplier（20260709000030）+ supplier_skus。
+--   - join 表由 trg_pri_sync_campaigns（20260614000020）自動同步，另顯式補全日全部團。
+--
+-- 故意不動：rpc_create_pr_from_close_date / rpc_create_pr_from_campaigns /
+--   rpc_append_campaign_to_pr / 鎖團語意 — 本檔只『新增』兩支函式，零 CREATE OR REPLACE 既有邏輯。
+--
+-- Rollback：
+--   DROP FUNCTION public.rpc_create_supplementary_pr_from_close_date(DATE, UUID);
+--   DROP FUNCTION public.rpc_list_supplementable_close_dates();
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. 建補單：只含 delta>0 的品項
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_supplementary_pr_from_close_date(
+  p_close_date DATE,
+  p_operator   UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant         UUID := public._current_tenant_id();
+  v_pr_id          BIGINT;
+  v_pr_no          TEXT;
+  v_dest_loc       BIGINT;
+  v_campaign_count INTEGER;
+  v_delta_count    INTEGER;
+  v_campaign_ids   BIGINT[];
+BEGIN
+  -- 守衛 1：該結單日要有 closed/locked 開團
+  SELECT COUNT(*) INTO v_campaign_count
+    FROM group_buy_campaigns
+   WHERE tenant_id = v_tenant
+     AND status IN ('closed','locked')
+     AND DATE(end_at AT TIME ZONE 'Asia/Taipei') = p_close_date;
+
+  IF v_campaign_count = 0 THEN
+    RAISE EXCEPTION 'no closed/locked campaigns on date %', p_close_date;
+  END IF;
+
+  -- 守衛 2：必須已有一張未取消的 close_date PR（否則走正常建單，不是補單）
+  IF NOT EXISTS (
+    SELECT 1 FROM purchase_requests
+     WHERE tenant_id = v_tenant
+       AND source_type = 'close_date'
+       AND source_close_date = p_close_date
+       AND status <> 'cancelled'
+  ) THEN
+    RAISE EXCEPTION 'no existing PR for close_date % — use rpc_create_pr_from_close_date instead', p_close_date;
+  END IF;
+
+  SELECT id INTO v_dest_loc FROM locations
+   WHERE tenant_id = v_tenant
+   ORDER BY id LIMIT 1;
+
+  IF v_dest_loc IS NULL THEN
+    RAISE EXCEPTION 'no locations defined for tenant %', v_tenant;
+  END IF;
+
+  -- delta > 0 的品項（目前需求 − 該結單日所有未取消 PR 已請購量）先算進 temp，
+  -- 空的話直接 RAISE，不浪費 pr_no 序號、也不留殘 header。
+  CREATE TEMP TABLE _supp_delta ON COMMIT DROP AS
+  WITH demand AS (
+    SELECT
+      coi.sku_id,
+      SUM(coi.qty) AS qty,
+      MIN(gbc.id)  AS first_campaign_id
+      FROM group_buy_campaigns gbc
+      JOIN customer_orders co ON co.campaign_id = gbc.id
+      JOIN customer_order_items coi ON coi.order_id = co.id
+     WHERE gbc.tenant_id = v_tenant
+       AND gbc.status IN ('closed','locked')
+       AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = p_close_date
+       AND co.status  NOT IN ('cancelled','expired','transferred_out')
+       AND coi.status NOT IN ('cancelled','expired')
+     GROUP BY coi.sku_id
+  ),
+  already AS (
+    SELECT pri.sku_id, SUM(pri.qty_requested) AS qty
+      FROM purchase_requests pr
+      JOIN purchase_request_items pri ON pri.pr_id = pr.id
+     WHERE pr.tenant_id = v_tenant
+       AND pr.source_type = 'close_date'
+       AND pr.source_close_date = p_close_date
+       AND pr.status <> 'cancelled'
+     GROUP BY pri.sku_id
+  )
+  SELECT
+    d.sku_id,
+    d.first_campaign_id,
+    (d.qty - COALESCE(a.qty, 0)) AS delta_qty
+    FROM demand d
+    LEFT JOIN already a ON a.sku_id = d.sku_id
+   WHERE (d.qty - COALESCE(a.qty, 0)) > 0;
+
+  SELECT COUNT(*) INTO v_delta_count FROM _supp_delta;
+
+  IF v_delta_count = 0 THEN
+    -- 前次請購已涵蓋全部需求 → 無可補
+    RAISE EXCEPTION 'no remaining demand to supplement for close_date % (前次請購已涵蓋全部需求)', p_close_date;
+  END IF;
+
+  -- PR header
+  v_pr_no := public.rpc_next_pr_no();
+
+  INSERT INTO purchase_requests (
+    tenant_id, pr_no, source_type, source_close_date,
+    source_location_id, status, total_amount, notes,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_pr_no, 'close_date', p_close_date,
+    v_dest_loc, 'draft', 0,
+    format('補單：結單日 %s（僅新增未請購量，不含前次已請購）', p_close_date),
+    p_operator, p_operator
+  ) RETURNING id INTO v_pr_id;
+
+  INSERT INTO purchase_request_items (
+    pr_id, sku_id, qty_requested,
+    suggested_supplier_id, unit_cost, source_campaign_id,
+    created_by, updated_by
+  )
+  SELECT
+    v_pr_id,
+    dq.sku_id,
+    dq.delta_qty,
+    ss.supplier_id,
+    COALESCE(ss.default_unit_cost, 0),
+    dq.first_campaign_id,
+    p_operator,
+    p_operator
+  FROM _supp_delta dq
+  LEFT JOIN LATERAL (
+    SELECT supplier_id, default_unit_cost
+      FROM supplier_skus
+     WHERE tenant_id = v_tenant
+       AND sku_id = dq.sku_id
+       AND is_preferred = TRUE
+     LIMIT 1
+  ) ss ON TRUE;
+
+  -- join 表：補全該結單日所有 closed/locked 團（trigger 只補 first_campaign_id 那個）
+  INSERT INTO purchase_request_campaigns (pr_id, campaign_id, tenant_id)
+  SELECT v_pr_id, gbc.id, v_tenant
+    FROM group_buy_campaigns gbc
+   WHERE gbc.tenant_id = v_tenant
+     AND gbc.status IN ('closed','locked')
+     AND DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') = p_close_date
+  ON CONFLICT (pr_id, campaign_id) DO NOTHING;
+
+  -- total snapshot
+  UPDATE purchase_requests pr
+     SET total_amount = COALESCE((
+           SELECT SUM(line_subtotal) FROM purchase_request_items WHERE pr_id = v_pr_id
+         ), 0),
+         updated_at = NOW()
+   WHERE pr.id = v_pr_id;
+
+  -- 鎖團尾巴：把該結單日『尚 closed』的團（例：解鎖補單後）重新 lock + auto-confirm 其 pending 訂單。
+  -- 已 locked 的團 WHERE status='closed' 不命中、不受影響。
+  WITH locked_campaigns AS (
+    UPDATE group_buy_campaigns
+       SET status     = 'locked',
+           updated_by = p_operator,
+           updated_at = NOW()
+     WHERE tenant_id = v_tenant
+       AND status = 'closed'
+       AND DATE(end_at AT TIME ZONE 'Asia/Taipei') = p_close_date
+    RETURNING id
+  )
+  SELECT array_agg(id) INTO v_campaign_ids FROM locked_campaigns;
+
+  PERFORM public._lock_orders_after_pr_aggregation(v_campaign_ids, p_operator, v_pr_id);
+
+  RETURN v_pr_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_create_supplementary_pr_from_close_date(DATE, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_create_supplementary_pr_from_close_date(DATE, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_supplementary_pr_from_close_date(DATE, UUID) IS
+  '結單日補單：保留原請購單，另開一張只含 delta>0（目前需求 − 該結單日所有未取消 PR 已請購量）的 PR；'
+  '守衛 = 該日已有未取消 close_date PR；尾巴把尚 closed 的團 lock + auto-confirm；'
+  '前次已涵蓋全部需求則 RAISE、不留空單。';
+
+-- ----------------------------------------------------------------------------
+-- 2. 列出可補單的結單日（前端卡片資料源；delta 邏輯單一真相留 SQL）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_list_supplementable_close_dates()
+RETURNS TABLE(
+  close_date     DATE,
+  campaign_count INTEGER,
+  remaining_skus INTEGER,
+  remaining_qty  NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH t AS (SELECT public._current_tenant_id() AS tid),
+  demand AS (
+    SELECT
+      DATE(gbc.end_at AT TIME ZONE 'Asia/Taipei') AS d,
+      coi.sku_id,
+      SUM(coi.qty) AS qty
+      FROM group_buy_campaigns gbc
+      JOIN customer_orders co ON co.campaign_id = gbc.id
+      JOIN customer_order_items coi ON coi.order_id = co.id
+      CROSS JOIN t
+     WHERE gbc.tenant_id = t.tid
+       AND gbc.status IN ('closed','locked')
+       AND gbc.end_at >= NOW() - INTERVAL '60 days'
+       AND co.status  NOT IN ('cancelled','expired','transferred_out')
+       AND coi.status NOT IN ('cancelled','expired')
+     GROUP BY 1, 2
+  ),
+  already AS (
+    SELECT pr.source_close_date AS d, pri.sku_id, SUM(pri.qty_requested) AS qty
+      FROM purchase_requests pr
+      JOIN purchase_request_items pri ON pri.pr_id = pr.id
+      CROSS JOIN t
+     WHERE pr.tenant_id = t.tid
+       AND pr.source_type = 'close_date'
+       AND pr.source_close_date IS NOT NULL
+       AND pr.status <> 'cancelled'
+     GROUP BY 1, 2
+  ),
+  -- 只保留「已有未取消 close_date PR」的結單日
+  dates_with_pr AS (
+    SELECT DISTINCT pr.source_close_date AS d
+      FROM purchase_requests pr
+      CROSS JOIN t
+     WHERE pr.tenant_id = t.tid
+       AND pr.source_type = 'close_date'
+       AND pr.source_close_date IS NOT NULL
+       AND pr.status <> 'cancelled'
+  ),
+  delta AS (
+    SELECT
+      d.d,
+      d.sku_id,
+      (d.qty - COALESCE(a.qty, 0)) AS remaining
+      FROM demand d
+      JOIN dates_with_pr dwp ON dwp.d = d.d
+      LEFT JOIN already a ON a.d = d.d AND a.sku_id = d.sku_id
+  )
+  SELECT
+    del.d AS close_date,
+    (SELECT COUNT(*)::INTEGER
+       FROM group_buy_campaigns g CROSS JOIN t
+      WHERE g.tenant_id = t.tid
+        AND g.status IN ('closed','locked')
+        AND DATE(g.end_at AT TIME ZONE 'Asia/Taipei') = del.d) AS campaign_count,
+    COUNT(*) FILTER (WHERE del.remaining > 0)::INTEGER AS remaining_skus,
+    COALESCE(SUM(del.remaining) FILTER (WHERE del.remaining > 0), 0) AS remaining_qty
+  FROM delta del
+  GROUP BY del.d
+  HAVING COUNT(*) FILTER (WHERE del.remaining > 0) > 0
+  ORDER BY del.d DESC;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_list_supplementable_close_dates() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_list_supplementable_close_dates() TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_list_supplementable_close_dates() IS
+  '列近 60 天「已建 close_date PR 但仍有未請購量(delta>0)」的結單日；'
+  '供前端「結單日補單」卡片；remaining_qty = Σ delta>0。';


### PR DESCRIPTION
## 問題

對某結單日（例：**7/4**）建了請購單後，該日開團 `closed → locked`（20260625000000 鎖團）。之後**所有**建 PR 路徑都只吃 `closed`：
- 「🆕 結單日待開單」卡片（已排除有 PR 的日期）
- 「針對團購建單」modal（`openCampaignModal` 只查 `status='closed'`）
- `rpc_create_pr_from_campaigns` 守衛（`status NOT IN ('closed',...)` 拒 `locked`）

→ 7/4 從所有入口消失，**沒有任何 UI 能再對 7/4 建單**，補漏的品相無門。

## 決策（使用者 2026-07-06，選項 B）

**保留原請購單，另開一張「補單」，只彙總「前次尚未請購的新增量」：**

```
delta(sku) = 該結單日目前訂單需求(sku)
           − 該結單日所有『未取消 close_date PR』已請購量(sku)
```

只列 `delta > 0` 的 SKU。原單、已拆 PO 一律不動；已被前次涵蓋的 SKU 自動歸零剔除，**避免重複下單**。這也自然銜接「補貨依品相分張開單」（#504/#507）：第一張只開部分品相，補單接手剩下的。

## 變更

**Migration `20260714000060`（純新增兩支函式，零 `CREATE OR REPLACE` 既有邏輯）**
- `rpc_create_supplementary_pr_from_close_date(p_close_date, p_operator)` — 建補單；守衛=該日已有未取消 close_date PR + 有 closed/locked 團；無 delta 則 RAISE、不留空單；尾巴把尚 `closed` 的團 lock + auto-confirm（mirror 20260625000000，捕捉解鎖後新加的訂單）。
- `rpc_list_supplementable_close_dates()` — 列近 60 天「已建單但仍有 delta>0」的結單日；delta 邏輯單一真相留 SQL。

**前端 `apps/admin/.../purchase/requests/page.tsx`**
- 新增「🔁 結單日補單」卡片區塊（每日：團數 / 尚缺品項 / 補單量 + 「➕ 補單」鈕 → 導到新 PR edit 頁）。
- 既有三個建單入口行為不變。

**`docs/TEST-supplementary-pr-close-date.md`** — 測試清單（RPC delta / 累積 / 取消不計 / join 一致性 / 前端 / 回歸）。

## 部署

- ⚠️ Migration `20260714000060` **需套 prod**（走 Supabase Studio 貼 SQL / Management API）。前端合併後由 GH Pages 自動部署。
- 非破壞性：只新增函式，不動任何既有 RPC / 表 / 鎖團語意。

## 尚未驗證

worktree 無 node_modules（admin build 需 npm install）、admin live-preview 沙箱被擋、prod DB 唯 anon read。**RPC 尚未實跑**；套上 prod 後可用 REST 驗，或依 TEST 文件於 Studio 跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)