### PR TITLE
Document Edge Function deployment via curl + Management API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,31 @@ Content-Type: application/json
 
 不要再嘗試 `psql postgresql://...pooler...`、`supabase db push` 直連、Node `pg` client 等等 — 都會卡在 network，浪費時間。
 
+### 部署 Edge Function 走 curl + Management API，不要用 supabase CLI
+
+`supabase functions deploy`（不論加不加 `--use-api`）在這個環境的 outbound proxy 下**一定失敗**，回 `{"code":"UnknownError","message":"failed to deploy function: TransportError"}`。原因是 CLI 的 Go HTTP client 過 proxy 做 streaming multipart POST 會炸（同一支 CLI 的 GET 正常，只有帶 body 的上傳掛掉）。別再花時間試 CLI / 裝 Docker / 調 `SSL_CERT_FILE`，都沒用。
+
+改用 `curl` 直打 Management API deploy 端點（`curl` 過 proxy 正常）：
+
+```bash
+REF="$SUPABASE_PROJECT_REF"; f="staff-create"
+EP="supabase/functions/$f/index.ts"
+META=$(printf '{"entrypoint_path":"%s","name":"%s","verify_jwt":false}' "$EP" "$f")
+curl -sS --cacert /root/.ccr/ca-bundle.crt \
+  -X POST "https://api.supabase.com/v1/projects/$REF/functions/deploy?slug=$f" \
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+  -F "metadata=$META;type=application/json" \
+  -F "file=@supabase/functions/$f/index.ts;filename=supabase/functions/$f/index.ts;type=application/typescript" \
+  -F "file=@supabase/functions/_shared/cors.ts;filename=supabase/functions/_shared/cors.ts;type=application/typescript"
+# 回 HTTP 201 + status:ACTIVE 即成功
+```
+
+重點：
+- 每個被 import 的 `_shared/*.ts` 都要當一個 `-F file=@...` 附上，且 `filename=` 要保留**原始相對路徑**（`supabase/functions/...`），這樣 entrypoint 裡的 `../_shared/cors.ts` 才解得到。
+- `verify_jwt` 要跟 `supabase/config.toml` 裡該函式的設定一致（例：`staff-create` / `trial-signup` / `tenant-purge` 都是 `false`，函式內自己驗 caller）。**config.toml 的 verify_jwt 只有部署時才會套用**，改了 config 沒重部署等於沒改。
+- 部署完務必驗證：`OPTIONS` preflight 回 200 帶 CORS、無 auth 的 `POST` 回函式自家的 401（代表函式真的在跑，不是 gateway 404）。gateway 404（`{"code":"NOT_FOUND"}`）在前端會被 supabase-js 包成 `Failed to send a request to the Edge Function` — 這句 = 函式**根本沒部署**，不是程式 bug。
+- 列出線上已部署函式：`GET https://api.supabase.com/v1/projects/$REF/functions`。repo 有 `supabase/functions/<x>/` 不代表線上有 — 新函式一定要手動部署。
+
 ### 重寫 function 前，先 grep 歷史 migration
 
 `supabase/migrations/` 是 append-only，同一支 function / view 常被多支 migration 用 `CREATE OR REPLACE` 修過。若直接基於「最早建立的版本」改寫，會把後面散落的多個修法整個蓋掉，產生 regression。

--- a/docs/TEST-staff-create.md
+++ b/docs/TEST-staff-create.md
@@ -9,7 +9,7 @@
 
 ## 1. Edge Function 合約
 
-- [ ] 函式 `staff-create` 已部署；`supabase/config.toml` **無** `[functions.staff-create]` 區塊（沿用 `verify_jwt = true` 預設，與 `admin-notify` 一致）
+- [ ] 函式 `staff-create` 已部署；`supabase/config.toml` **有** `[functions.staff-create] verify_jwt = false` 區塊。原設計沿用 `verify_jwt = true` 預設，但那會讓 gateway 擋掉不帶 Authorization 的 CORS preflight(OPTIONS)，前端收到 `Failed to send a request to the Edge Function`；函式內已自行驗 caller JWT（`sb.auth.getUser`）+ owner/admin + tenant，故改成 `verify_jwt = false`。**注意：config 改了要重新部署才生效**（部署方式見 `CLAUDE.md` §部署 Edge Function 走 curl + Management API）
 - [ ] 只需內建 secret `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`，未新增其他 secret
 - [ ] `OPTIONS` 回 CORS（`_shared/cors.ts`）；非 `POST` 回 405
 - [ ] 缺 `Authorization` header → 401


### PR DESCRIPTION
## Summary
Added comprehensive documentation for deploying Edge Functions using curl and the Supabase Management API, replacing the unreliable `supabase functions deploy` CLI command in this environment. Updated the `staff-create` function test checklist to reflect the new `verify_jwt = false` configuration requirement.

## Key Changes

- **CLAUDE.md**: Added new section "部署 Edge Function 走 curl + Management API，不要用 supabase CLI" documenting:
  - Why `supabase functions deploy` fails (Go HTTP client streaming multipart POST over proxy)
  - Complete curl command example with proper Management API endpoint
  - Critical implementation details:
    - How to include shared dependencies (`_shared/*.ts`) with correct relative paths
    - `verify_jwt` configuration must match `supabase/config.toml` and requires redeployment to take effect
    - Verification steps (CORS preflight, 401 response validation, gateway 404 distinction)
    - How to list deployed functions via Management API

- **docs/TEST-staff-create.md**: Updated function contract checklist:
  - Changed `staff-create` configuration from default `verify_jwt = true` to explicit `verify_jwt = false`
  - Added rationale: prevents gateway from blocking CORS preflight OPTIONS requests without Authorization header
  - Noted that function performs its own JWT validation internally
  - Added reminder that config changes require redeployment to take effect (with reference to new CLAUDE.md section)

## Implementation Details

The curl deployment approach uses multipart form data with:
- `metadata` field containing function configuration (entrypoint path, name, verify_jwt setting)
- Multiple `file` fields for the entrypoint and all imported shared modules
- Proper `filename=` preservation of original relative paths for import resolution
- Bearer token authentication via Management API

This workaround addresses a known limitation where the CLI's HTTP client fails to handle streaming multipart uploads through the environment's outbound proxy, while curl handles it correctly.

https://claude.ai/code/session_01STG1viU8kK5P3JDSdKCyRj