### PR TITLE
補貨申請：店長登入時 TR/PR 連結改純文字不可點

### DIFF
--- a/apps/admin/src/app/(protected)/restock/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
+import { useRole, isHqRole } from "@/lib/role";
 import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
@@ -58,6 +59,9 @@ export default function RestockListPage() {
   const [tab, setTab] = useState<Tab>("pending");
   const [page, setPage] = useState(1);
   const [detailId, setDetailId] = useState<number | null>(null);
+  const role = useRole();
+  // 分店角色（店長 / 店員）不可點 TR / PR 連結進總倉頁面，只顯示純文字編號
+  const canFollowLinks = isHqRole(role);
 
   useEffect(() => { setPage(1); }, [tab]);
 
@@ -244,22 +248,30 @@ export default function RestockListPage() {
               </Td>
               <Td className="text-xs">
                 {r.linked_transfer_no && (
-                  <Link
-                    href={`/hq/inbox?source=transfer&id=${r.linked_transfer_id}`}
-                    onClick={(e) => e.stopPropagation()}
-                    className="font-mono text-blue-600 hover:underline dark:text-blue-400"
-                  >
-                    → {r.linked_transfer_no}
-                  </Link>
+                  canFollowLinks ? (
+                    <Link
+                      href={`/hq/inbox?source=transfer&id=${r.linked_transfer_id}`}
+                      onClick={(e) => e.stopPropagation()}
+                      className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      → {r.linked_transfer_no}
+                    </Link>
+                  ) : (
+                    <span className="font-mono text-zinc-600 dark:text-zinc-300">→ {r.linked_transfer_no}</span>
+                  )
                 )}
                 {r.linked_pr_no && (
-                  <Link
-                    href={`/purchase/requests/edit?id=${r.linked_pr_id}`}
-                    onClick={(e) => e.stopPropagation()}
-                    className="font-mono text-blue-600 hover:underline dark:text-blue-400"
-                  >
-                    → {r.linked_pr_no}
-                  </Link>
+                  canFollowLinks ? (
+                    <Link
+                      href={`/purchase/requests/edit?id=${r.linked_pr_id}`}
+                      onClick={(e) => e.stopPropagation()}
+                      className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      → {r.linked_pr_no}
+                    </Link>
+                  ) : (
+                    <span className="font-mono text-zinc-600 dark:text-zinc-300">→ {r.linked_pr_no}</span>
+                  )
                 )}
                 {r.status === "rejected" && r.rejected_reason && <span className="text-red-600">拒絕：{r.rejected_reason}</span>}
               </Td>

--- a/apps/admin/src/lib/role.ts
+++ b/apps/admin/src/lib/role.ts
@@ -31,6 +31,13 @@ export function canSeeCost(role: Role | null): boolean {
   return HQ_ROLES.includes(role);
 }
 
+// 總倉層級：可進入總倉收件匣 / 採購請購單等總倉專屬頁面。
+// 分店角色（store_manager / store_staff）不屬於此群，看到的 TR/PR 編號應為純文字、不可點。
+export function isHqRole(role: Role | null): boolean {
+  if (role === null) return false;
+  return HQ_ROLES.includes(role);
+}
+
 export function canSeeBranch(role: Role | null): boolean {
   if (role === null) return false;
   return BRANCH_ROLES.includes(role);


### PR DESCRIPTION
## 問題

補貨申請列表（`/restock`）「連結 / 拒絕原因」欄的 TR 單、PR 單為藍色可點連結，會導向總倉專屬頁面（`/hq/inbox`、採購請購單編輯頁）。店長（分店角色）登入時不應能點進這些總倉頁面。

## 變更

- **`apps/admin/src/lib/role.ts`** — 新增 `isHqRole()` helper，沿用既有 `HQ_ROLES`（owner / admin / hq_manager / hq_accountant / 空字串 legacy admin）；`store_manager`、`store_staff` 不在內。
- **`apps/admin/src/app/(protected)/restock/page.tsx`** — 連結欄依角色分流：
  - 總倉角色 → 維持原本藍色 `<Link>`（→ TR…、→ PR…），可點導頁。
  - 分店角色 → 改為灰色純文字 `<span>`，不可點、不導頁。
  - 用 `useRole()` 判定；role 尚未 resolve（`null`）時 `isHqRole` 回 `false`（預設不可點），避免載入瞬間讓分店誤點。

## Reviewer notes

- 純前端變更，走 GH Pages 部署，無 migration。
- `RestockDetailModal`（點列開的明細視窗）本來就沒有 TR/PR 連結，不需一併改。
- 本地 `tsc` 僅剩無關舊錯誤（`parseLeleMemberCsv.ts` 缺 `papaparse`，此 worktree 未完整 npm install）；本次改動兩檔零錯誤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)