### PR TITLE
補貨申請列表：品項欄同時顯示品名與品相

### DIFF
--- a/apps/admin/src/app/(protected)/restock/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/page.tsx
@@ -101,10 +101,13 @@ export default function RestockListPage() {
             prodNameMap = new Map(((prods ?? []) as { id: number; name: string }[]).map((p) => [p.id, p.name]));
           }
           skuLabelMap = new Map(
-            skuArr.map((s) => [
-              s.id,
-              s.product_id != null ? prodNameMap.get(s.product_id) ?? s.sku_code : s.sku_code,
-            ])
+            skuArr.map((s) => {
+              // 品名 + 品相一起顯示（品相有值才接，無則退回 sku_code）
+              const prodName = s.product_id != null ? prodNameMap.get(s.product_id) ?? null : null;
+              const base = prodName ?? s.sku_code;
+              const label = s.variant_name ? `${base} / ${s.variant_name}` : base;
+              return [s.id, label];
+            })
           );
         }
 


### PR DESCRIPTION
## 問題

補貨申請列表的「品項」欄標籤只用了**商品名**，`variant_name`（品相／規格）其實有撈進來卻被丟掉，導致品相看不到。

## 改動

`skuLabelMap` 組標籤時把品相接上，對齊詳情 modal 與建立頁的「品名 / 規格」格式：

- 品相有值 → `品名 / 品相`（例：`六甲媽咪 純天然手洗愛玉 / 1000g盒裝 ×2`）
- 品相為空 → 只顯示品名；無品名時退回 `sku_code`（維持原本 fallback）

品項欄本來就是 `line-clamp-2`（#515 已改雙行），加品相不會爆版；`title` tooltip 也帶完整內容。

僅前端顯示調整，無 schema／RPC 變動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)