### PR TITLE
收件匣：品項摘要同時顯示品名與品相

### DIFF
--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -280,10 +280,12 @@ async function fetchItemsSummaryMap(
       prodMap = new Map(((ps ?? []) as { id: number; name: string }[]).map((p) => [p.id, p.name]));
     }
     skuLabelMap = new Map(
-      arr.map((s) => [
-        s.id,
-        s.product_id != null ? (prodMap.get(s.product_id) ?? s.sku_code) : s.sku_code,
-      ])
+      arr.map((s) => {
+        // 品名 + 品相一起顯示（品相有值才接，無則退回 sku_code）
+        const prodName = s.product_id != null ? (prodMap.get(s.product_id) ?? null) : null;
+        const base = prodName ?? s.sku_code;
+        return [s.id, s.variant_name ? `${base} / ${s.variant_name}` : base];
+      })
     );
   }
   const partsMap = new Map<number, string[]>();


### PR DESCRIPTION
## 問題

收件匣（`hq/inbox`）每筆的 `📦 品項摘要` 由共用 helper `loadItemsSummary` 產生，該 helper 的 `skuLabelMap` 只用了**商品名**，`variant_name`（品相／規格）有撈進來卻被丟掉，導致補貨／轉貨／互助／波次各來源的摘要都看不到品相。

與 #515／#516 是同一個原始 bug（品相被丟）。

## 改動

`skuLabelMap` 組標籤時把品相接上，格式對齊 #516：

- 品相有值 → `品名 / 品相`
- 品相為空 → 只顯示品名；無品名時退回 `sku_code`

改的是共用 helper，一次修好收件匣所有來源類型的摘要。

僅前端顯示調整，無 schema／RPC 變動。

## 其他頁面已檢查
- `restock/inbox`：無品項欄，不受影響
- `wms/picking`：品項欄的 `sku_label` 由後端 view 提供、本來就含品名+品相，不需改

🤖 Generated with [Claude Code](https://claude.com/claude-code)