### PR TITLE
補貨申請詳情：加進度時間軸（申請→核可→出貨→收貨）

### DIFF
--- a/apps/admin/src/components/RestockDetailModal.tsx
+++ b/apps/admin/src/components/RestockDetailModal.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Modal } from "@/components/Modal";
 import { getSupabase } from "@/lib/supabase";
-import { PR_TERM_ZH } from "@/lib/prStatus";
+import { PR_TERM_ZH, prStatusLabel } from "@/lib/prStatus";
+import { transferStatusLabel } from "@/lib/transferStatus";
 
 type RestockRow = {
   id: number;
@@ -20,6 +21,11 @@ type RestockRow = {
   linked_pr_id: number | null;
   linked_transfer_no: string | null;
   linked_pr_no: string | null;
+  // 進度時間軸用：出貨/收貨時間只有轉貨單有，restock 表沒有這兩個時間戳
+  transfer_status: string | null;
+  transfer_shipped_at: string | null;
+  transfer_received_at: string | null;
+  pr_status: string | null;
 };
 
 type Line = {
@@ -70,7 +76,7 @@ export default function RestockDetailModal({
         .from("restock_requests")
         .select(
           "id, requesting_store_id, status, notes, rejected_reason, requested_at, approved_at, rejected_at, linked_transfer_id, linked_pr_id, " +
-            "stores(name), transfers(transfer_no), purchase_requests(pr_no)"
+            "stores(name), transfers(transfer_no, status, shipped_at, received_at), purchase_requests(pr_no, status)"
         )
         .eq("id", restockId)
         .maybeSingle();
@@ -94,8 +100,11 @@ export default function RestockDetailModal({
         linked_transfer_id: number | null;
         linked_pr_id: number | null;
         stores: { name?: string } | { name?: string }[] | null;
-        transfers: { transfer_no?: string } | { transfer_no?: string }[] | null;
-        purchase_requests: { pr_no?: string } | { pr_no?: string }[] | null;
+        transfers:
+          | { transfer_no?: string; status?: string; shipped_at?: string | null; received_at?: string | null }
+          | { transfer_no?: string; status?: string; shipped_at?: string | null; received_at?: string | null }[]
+          | null;
+        purchase_requests: { pr_no?: string; status?: string } | { pr_no?: string; status?: string }[] | null;
       };
       const r = rData as unknown as ApiR;
       setErr(null);
@@ -116,6 +125,10 @@ export default function RestockDetailModal({
         linked_pr_id: r.linked_pr_id,
         linked_transfer_no: txObj?.transfer_no ?? null,
         linked_pr_no: prObj?.pr_no ?? null,
+        transfer_status: txObj?.status ?? null,
+        transfer_shipped_at: txObj?.shipped_at ?? null,
+        transfer_received_at: txObj?.received_at ?? null,
+        pr_status: prObj?.status ?? null,
       });
 
       const { data: lData } = await sb
@@ -191,26 +204,36 @@ export default function RestockDetailModal({
             {hd.linked_transfer_id != null && (
               <div className="col-span-2">
                 <dt className="text-xs text-zinc-500">轉貨單</dt>
-                <dd className="text-sm">
+                <dd className="flex items-center gap-2 text-sm">
                   <Link
                     href={`/hq/inbox?source=transfer&id=${hd.linked_transfer_id}`}
                     className="font-mono text-blue-600 hover:underline dark:text-blue-400"
                   >
                     {hd.linked_transfer_no ?? `#${hd.linked_transfer_id}`}
                   </Link>
+                  {hd.transfer_status && (
+                    <span className="inline-flex rounded bg-zinc-100 px-1.5 py-0.5 text-xs text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+                      {transferStatusLabel(hd.transfer_status)}
+                    </span>
+                  )}
                 </dd>
               </div>
             )}
             {hd.linked_pr_id != null && (
               <div className="col-span-2">
                 <dt className="text-xs text-zinc-500">{PR_TERM_ZH}</dt>
-                <dd className="text-sm">
+                <dd className="flex items-center gap-2 text-sm">
                   <Link
                     href={`/purchase/requests/edit?id=${hd.linked_pr_id}`}
                     className="font-mono text-blue-600 hover:underline dark:text-blue-400"
                   >
                     {hd.linked_pr_no ?? `#${hd.linked_pr_id}`}
                   </Link>
+                  {hd.pr_status && (
+                    <span className="inline-flex rounded bg-zinc-100 px-1.5 py-0.5 text-xs text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+                      {prStatusLabel(hd.pr_status)}
+                    </span>
+                  )}
                 </dd>
               </div>
             )}
@@ -219,6 +242,8 @@ export default function RestockDetailModal({
             )}
             {hd.notes && <Field label="備註" value={hd.notes} full />}
           </dl>
+
+          <ProgressTimeline hd={hd} />
 
           <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
             <table className="w-full text-sm">
@@ -283,4 +308,118 @@ function Field({ label, value, full = false }: { label: string; value: string; f
       <dd className="text-sm text-zinc-900 dark:text-zinc-100 whitespace-pre-wrap">{value}</dd>
     </div>
   );
+}
+
+// ---------------------------------------------------------------
+// 進度時間軸：申請 → 核可 → 出貨 → 收貨
+// 出貨/收貨時間只有轉貨單有（restock 表沒這兩個時間戳），
+// 完成度取 restock.status 與 transfer.status 的較高者。
+// ---------------------------------------------------------------
+type StepState = "done" | "current" | "todo" | "reject" | "cancel";
+type Step = { key: string; label: string; at: string | null; state: StepState; note?: string };
+
+function ProgressTimeline({ hd }: { hd: RestockRow }) {
+  const st = hd.status;
+
+  // 終端狀態：拒絕 / 取消 → 申請 + 終端節點
+  if (st === "rejected" || st === "cancelled") {
+    const steps: Step[] = [
+      { key: "requested", label: "申請", at: hd.requested_at, state: "done" },
+      st === "rejected"
+        ? { key: "terminal", label: "已拒絕", at: hd.rejected_at, state: "reject", note: hd.rejected_reason ?? undefined }
+        : { key: "terminal", label: "已取消", at: null, state: "cancel" },
+    ];
+    return <Timeline steps={steps} />;
+  }
+
+  // reached level = max(restock, transfer)
+  const restockLevel =
+    st === "received" ? 3 : st === "shipped" ? 2 : st === "approved_transfer" || st === "approved_pr" ? 1 : 0;
+  const ts = hd.transfer_status;
+  const transferLevel = ts === "received" || ts === "closed" ? 3 : ts === "shipped" ? 2 : ts === "confirmed" ? 1 : 0;
+  const reached = Math.max(restockLevel, transferLevel);
+  const stateOf = (level: number): StepState => (level <= reached ? "done" : level === reached + 1 ? "current" : "todo");
+
+  // 核可方式：派庫存 / 採購 / 兩者
+  const approveNote =
+    hd.linked_transfer_id != null && hd.linked_pr_id != null
+      ? "派庫存 + 採購"
+      : hd.linked_transfer_id != null
+        ? "派庫存"
+        : hd.linked_pr_id != null
+          ? "採購"
+          : undefined;
+
+  const steps: Step[] = [
+    { key: "requested", label: "申請", at: hd.requested_at, state: "done" },
+    { key: "approved", label: "核可", at: hd.approved_at, state: stateOf(1), note: approveNote },
+    { key: "shipped", label: "出貨", at: hd.transfer_shipped_at, state: stateOf(2) },
+    { key: "received", label: "收貨", at: hd.transfer_received_at, state: stateOf(3) },
+  ];
+  return <Timeline steps={steps} />;
+}
+
+function Timeline({ steps }: { steps: Step[] }) {
+  return (
+    <div className="rounded-md border border-zinc-200 p-4 dark:border-zinc-800">
+      <div className="mb-3 text-xs font-medium uppercase tracking-wide text-zinc-500">進度</div>
+      <ol>
+        {steps.map((s, i) => {
+          const last = i === steps.length - 1;
+          return (
+            <li key={s.key} className="flex gap-3">
+              <div className="flex flex-col items-center">
+                <span className={dotCls(s.state)} />
+                {!last && (
+                  <span
+                    className={`w-px flex-1 ${s.state === "done" ? "bg-emerald-400 dark:bg-emerald-600" : "bg-zinc-200 dark:bg-zinc-700"}`}
+                  />
+                )}
+              </div>
+              <div className={last ? "pb-0" : "pb-5"}>
+                <div className="flex flex-wrap items-baseline gap-x-2">
+                  <span className={labelCls(s.state)}>{s.label}</span>
+                  <span className="text-xs text-zinc-400">
+                    {s.at ? new Date(s.at).toLocaleString("zh-TW") : s.state === "current" ? "目前" : ""}
+                  </span>
+                </div>
+                {s.note && <div className="mt-0.5 text-xs text-zinc-500">{s.note}</div>}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
+function dotCls(state: StepState): string {
+  const base = "mt-1 h-2.5 w-2.5 shrink-0 rounded-full ring-4 ring-white dark:ring-zinc-900 ";
+  switch (state) {
+    case "done":
+      return base + "bg-emerald-500";
+    case "current":
+      return base + "bg-blue-500 ring-blue-100 dark:ring-blue-950";
+    case "reject":
+      return base + "bg-red-500";
+    case "cancel":
+      return base + "bg-zinc-400";
+    default:
+      return base + "bg-zinc-300 dark:bg-zinc-600";
+  }
+}
+
+function labelCls(state: StepState): string {
+  switch (state) {
+    case "current":
+      return "text-sm font-semibold text-blue-700 dark:text-blue-300";
+    case "todo":
+      return "text-sm text-zinc-400";
+    case "reject":
+      return "text-sm font-semibold text-red-600 dark:text-red-400";
+    case "cancel":
+      return "text-sm font-medium text-zinc-500";
+    default:
+      return "text-sm font-medium text-zinc-900 dark:text-zinc-100";
+  }
 }

--- a/apps/admin/src/lib/transferStatus.ts
+++ b/apps/admin/src/lib/transferStatus.ts
@@ -1,0 +1,21 @@
+// ============================================================
+// 轉貨單 (transfers.status) 中文 label 中央定義
+//
+// Single source of truth — 對齊 wms/transfers 與 hq/inbox 既有用字。
+// 新增 status 時同步 supabase migration 的 CHECK constraint。
+// ============================================================
+
+export const TRANSFER_STATUS_LABEL: Record<string, string> = {
+  draft: "草稿",
+  confirmed: "已確認",
+  shipped: "已出貨",
+  received: "已收貨",
+  cancelled: "已取消",
+  closed: "已結案",
+};
+
+/** 取中文 label；未知 status 直接 fallback 原字串。 */
+export function transferStatusLabel(s: string | null | undefined): string {
+  if (!s) return "—";
+  return TRANSFER_STATUS_LABEL[s] ?? s;
+}

--- a/docs/TEST-restock-progress-timeline.md
+++ b/docs/TEST-restock-progress-timeline.md
@@ -1,0 +1,54 @@
+# TEST — 補貨申請詳情：進度時間軸
+
+功能：`RestockDetailModal` 加入「申請 → 核可 → 出貨 → 收貨」進度時間軸，
+並在轉貨單／請購單連結旁顯示各自目前狀態。
+
+資料來源（皆為既有欄位，無 schema 變動）：
+- `restock_requests.requested_at / approved_at / rejected_at / status`
+- `restock_requests.linked_transfer_id / linked_pr_id`
+- `transfers.status / shipped_at / received_at`（出貨、收貨時間的唯一可靠來源）
+- `purchase_requests.status`
+
+## 進度階段判定（reachedLevel = max(restock, transfer)）
+
+| 來源 | 對應 level |
+|---|---|
+| restock `pending` | 0 |
+| restock `approved_transfer` / `approved_pr` | 1 |
+| restock `shipped` | 2 |
+| restock `received` | 3 |
+| transfer `confirmed` | 1 |
+| transfer `shipped` | 2 |
+| transfer `received` / `closed` | 3 |
+
+階段狀態：`level <= reached` → done；`level == reached+1` → current；其餘 → todo。
+
+## 測試項目
+
+### 顯示層
+- [ ] T1 一般（pending）：只有「申請」為 done、時間 = requested_at；「核可」為 current；出貨/收貨為 todo（灰空心點）。
+- [ ] T2 approved_transfer（尚未出貨）：申請/核可 done、核可時間 = approved_at；出貨 current；收貨 todo。核可副標顯示「派庫存」。
+- [ ] T3 approved_pr：同 T2，但核可副標顯示「採購」。
+- [ ] T4 同時掛 TR + PR（即 RESTOCK#18 型）：核可副標顯示「派庫存 + 採購」。
+- [ ] T5 shipped：申請/核可/出貨 done；出貨時間 = transfer.shipped_at；收貨 current。
+- [ ] T6 received：四階段全 done；出貨 = shipped_at、收貨 = received_at。
+- [ ] T7 rejected：申請 done → 終端紅點「已拒絕」＋ rejected_at ＋ 原因；不顯示出貨/收貨。
+- [ ] T8 cancelled：申請 done → 終端灰點「已取消」；不顯示出貨/收貨。
+- [ ] T9 shipped 但 linked_transfer_id 為 null：出貨仍判 done（靠 restock.status），但時間顯示 —（不炸）。
+
+### 狀態徽章
+- [ ] T10 轉貨單連結旁顯示 transferStatusLabel（例：已出貨），未知 status fallback 原字串。
+- [ ] T11 請購單連結旁顯示 prStatusLabel（例：全部轉單）。
+- [ ] T12 無 linked_transfer_id / linked_pr_id 時該列整段不顯示（沿用既有條件）。
+
+### 迴歸
+- [ ] T13 明細表（SKU / 品名+規格 / 數量 / 單價 / 小計 / 合計）維持不變。
+- [ ] T14 已刪除 line 的 line-through 與「已刪除」標記維持；合計仍排除 cancelled line。
+- [ ] T15 換單（restockId 改變）/ 關閉再開，timeline 依新單資料重算，不殘留上一單。
+- [ ] T16 載入態不出現新的「載入中」文字（沿用既有；spinner 規範）。
+
+### 型別 / 建置
+- [ ] T17 `next build`（admin）通過、無型別錯誤。
+
+> 實機驗證（登入 admin、開 RESTOCK#18 等各狀態單）因沙箱連不到 Supabase 由使用者於 GH Pages preview 自審；
+> agent 側以 build/typecheck + 邏輯逐項核對為主。


### PR DESCRIPTION
## 需求

在補貨申請詳情彈窗加「進度時間軸」,讓使用者能直接追一張補貨申請走到哪(起因:RESTOCK#18 只看得到「已出貨」,看不出各腿進度)。

## 改動

詳情彈窗(`RestockDetailModal`)新增:

- **進度時間軸**:申請 → 核可 → 出貨 → 收貨 的垂直步驟,已完成帶時間戳、目前步驟藍色高亮、未到灰色空心點
  - 完成度 = `max(restock.status level, transfer.status level)`
  - **出貨/收貨時間取自轉貨單** `shipped_at`／`received_at`(restock 表沒有這兩個時間戳)
  - 核可副標顯示核可方式:`派庫存`／`採購`／`派庫存 + 採購`(依掛 TR/PR)
  - 拒絕 → 終端紅點 +原因;取消 → 終端灰點
- **狀態徽章**:轉貨單、請購單連結旁各顯示目前狀態(`transferStatusLabel` / `prStatusLabel`)
- 新增 `lib/transferStatus.ts` 中央 label(對齊 wms/transfers、hq/inbox 既有用字,與既有 `poStatus`/`prStatus` 同套路)

## 資料
- 全用既有欄位,**無 schema／RPC 變動**;header 查詢多帶 `transfers(status, shipped_at, received_at)`、`purchase_requests(status)`。

## 驗證
- 測試清單:`docs/TEST-restock-progress-timeline.md`(T1–T17)
- `tsc --noEmit`(admin)通過、無型別錯誤
- 實機(登入 admin 開各狀態單、RESTOCK#18)因沙箱連不到 Supabase,請於 GH Pages preview 自審

🤖 Generated with [Claude Code](https://claude.com/claude-code)