### PR TITLE
補回 #521 squash 漏掉的:訂購會員預設內部 chip + 090 索引排除 restock

### DIFF
--- a/apps/admin/src/app/(protected)/restock/new/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/new/page.tsx
@@ -140,7 +140,12 @@ export default function RestockNewPage() {
         </select>
       </label>
 
-      <MemberField member={member} onChange={setMember} inputCls={inputCls} />
+      <MemberField
+        member={member}
+        onChange={setMember}
+        inputCls={inputCls}
+        storeName={stores.find((s) => s.id === effectiveStoreId)?.name ?? null}
+      />
 
 
       <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
@@ -188,33 +193,36 @@ export default function RestockNewPage() {
   );
 }
 
-// 訂購會員欄：預設【內部】店庫存；搜尋指定真會員（貨到即該會員的可取貨訂單、單價鎖現售價）
+// 訂購會員欄：預設已選【內部】該店（送出 p_member_id=null、RPC 端解析內部會員）；
+// 點「指定會員」切到搜尋，指定真會員＝貨到即該會員的可取貨訂單（單價鎖現售價）
 function MemberField({
   member,
   onChange,
   inputCls,
+  storeName,
 }: {
   member: MemberHit | null;
   onChange: (m: MemberHit | null) => void;
   inputCls: string;
+  storeName: string | null;
 }) {
-  const [open, setOpen] = useState(false);
+  const [picking, setPicking] = useState(false);
   const [term, setTerm] = useState("");
   const [hits, setHits] = useState<MemberHit[]>([]);
   const [searching, setSearching] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (!open) return;
+    if (!picking) return;
     const onDown = (e: MouseEvent) => {
-      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+      if (!wrapRef.current?.contains(e.target as Node)) setPicking(false);
     };
     document.addEventListener("mousedown", onDown);
     return () => document.removeEventListener("mousedown", onDown);
-  }, [open]);
+  }, [picking]);
 
   useEffect(() => {
-    if (!open) {
+    if (!picking) {
       setSearching(false);
       return;
     }
@@ -231,49 +239,63 @@ function MemberField({
       }
     }, 200);
     return () => clearTimeout(t);
-  }, [term, open]);
+  }, [term, picking]);
+
+  const chipCls =
+    "flex items-center justify-between gap-2 rounded-md border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800";
+  const btnCls =
+    "shrink-0 rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-700";
 
   return (
     <div ref={wrapRef} className="relative flex flex-col gap-1 text-sm sm:max-w-md">
       <span className="text-zinc-600 dark:text-zinc-400">訂購會員</span>
       {member ? (
-        <div className="flex items-center justify-between gap-2 rounded-md border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800">
+        // 已指定真會員
+        <div className={chipCls}>
           <div className="min-w-0 flex-1 text-sm">
             <span className="font-medium">{member.name ?? "—"}</span>
             <span className="ml-2 font-mono text-xs text-zinc-500">{member.member_no}</span>
           </div>
-          <SpinButton
-            type="button"
-            onClick={() => { onChange(null); setTerm(""); }}
-            className="shrink-0 rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-700"
-          >
+          <SpinButton type="button" onClick={() => { onChange(null); setTerm(""); setPicking(false); }} className={btnCls}>
             改回內部
           </SpinButton>
         </div>
-      ) : (
+      ) : picking ? (
+        // 搜尋模式
         <div className="relative">
           <input
+            autoFocus
             value={term}
-            onFocus={() => setOpen(true)}
-            onChange={(e) => { setTerm(e.target.value); setOpen(true); }}
-            placeholder="預設：【內部】店庫存 — 搜尋會員可直接指定"
+            onChange={(e) => setTerm(e.target.value)}
+            placeholder="搜尋 會員編號 / 姓名 / 手機"
             className={`${inputCls} w-full pr-8`}
           />
           <SearchSpinner active={searching} />
         </div>
+      ) : (
+        // 預設：已選內部該店（送出 p_member_id=null，RPC 端解析/自動建立內部會員）
+        <div className={chipCls}>
+          <div className="min-w-0 flex-1 text-sm">
+            <span className="font-medium">【內部】{storeName ?? "該店"}</span>
+            <span className="ml-2 text-xs text-zinc-500">店庫存</span>
+          </div>
+          <SpinButton type="button" onClick={() => { setPicking(true); setTerm(""); }} className={btnCls}>
+            指定會員
+          </SpinButton>
+        </div>
       )}
       {!member && (
         <p className="text-xs text-zinc-400">
-          不指定＝貨到掛店庫存，之後再轉單給客人；指定會員＝貨到即為該會員的可取貨訂單（單價鎖現售價）
+          內部＝貨到掛店庫存，之後再轉單給客人；指定會員＝貨到即為該會員的可取貨訂單（單價鎖現售價）
         </p>
       )}
-      {open && !member && hits.length > 0 && (
+      {picking && !member && hits.length > 0 && (
         <div className="absolute left-0 top-full z-10 mt-1 max-h-60 w-full overflow-y-auto rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800">
           {hits.map((h) => (
             <SpinButton
               key={h.id}
               type="button"
-              onClick={() => { onChange(h); setOpen(false); setTerm(""); }}
+              onClick={() => { onChange(h); setPicking(false); setTerm(""); }}
               className="block w-full px-3 py-1.5 text-left text-xs hover:bg-zinc-100 dark:hover:bg-zinc-700"
             >
               <span className="font-medium">{h.name ?? "—"}</span>

--- a/docs/TEST-restock-internal-member-retail-transfer.md
+++ b/docs/TEST-restock-internal-member-retail-transfer.md
@@ -12,7 +12,7 @@ Migration：`20260714000090_restock_order_internal_member_and_retail_transfer.sq
 - [ ] T3a 指定真會員 → ride-along 單掛該會員、notes 前綴【指定會員】、items 單價 = 當下現售價（scope='retail'，無則 fallback 分店價）；restock_request_lines 仍存分店價。
 - [ ] T3b 指定會員不在 tenant → 擋。
 - [ ] T3c 舊 3 參數簽名已 DROP：前端 3 參數呼叫（不帶 p_member_id）走 DEFAULT NULL 正常；PostgREST 無 overload 歧義。
-- [ ] T3d 建單頁 UI：訂購會員欄預設「內部店庫存」提示；搜尋選會員後顯示姓名+編號、可「改回內部」；送出帶 p_member_id。
+- [ ] T3d 建單頁 UI：訂購會員欄**預設即已選【內部】該店**（chip 顯示、隨收貨分店連動店名）；點「指定會員」切搜尋、選定顯示姓名+編號、可「改回內部」；內部送 p_member_id=null（RPC 端解析）、指定送該會員 id。
 - [ ] T3e 指定真會員的單收貨後直接 ready → 該會員在取貨頁可取（免轉手）。
 
 ### 收貨（rpc_receive_transfer 邏輯 D 擴充）

--- a/supabase/migrations/20260714000090_restock_order_internal_member_and_retail_transfer.sql
+++ b/supabase/migrations/20260714000090_restock_order_internal_member_and_retail_transfer.sql
@@ -27,7 +27,11 @@
 --      目標 member 是真會員（非 store_internal）→ 轉出 item 單價改用
 --      當下現售價（prices scope='retail' 最新生效版；查無現售價 fallback 來源價）。
 --      店↔店互助轉手（目標也是 internal）不受影響、維持原價。
---   4. Backfill：存量 ride-along 單補掛內部會員；linked transfer 已收貨的
+--   4. customer_orders_trio_kind_active_uniq 排除 order_kind='restock'：
+--      同店多張併行補貨的 ride-along 單共用 (sentinel campaign, sentinel channel,
+--      內部會員, 'restock')，掛上內部會員後必撞唯一鍵（prod 實測撞出）。
+--      RR 單唯一性由 order_no='RR-<id>' 保證；一般單/offset 的 dedup 語意不變。
+--   5. Backfill：存量 ride-along 單補掛內部會員；linked transfer 已收貨的
 --      ride-along 單補推 ready（RESTOCK#18 的 RR-18 在列）。
 --
 -- 基底版本：
@@ -38,7 +42,8 @@
 --   rpc_transfer_order_partial  = 20260714000010（逐字保留僅加內部單→真會員的現售價改寫）
 -- Rollback：CREATE OR REPLACE 回上列各基底版本（rpc_create_restock_request 因簽名
 --   變更需先 DROP FUNCTION public.rpc_create_restock_request(BIGINT,JSONB,TEXT,BIGINT)
---   再建回 20260714000020 的 3 參數版）；backfill 回復：
+--   再建回 20260714000020 的 3 參數版）；索引回復＝重建 20260516000000 版
+--   （注意：須先清掉同 trio 多張 active restock 單否則建不回去）；backfill 回復：
 --   UPDATE customer_orders SET member_id=NULL WHERE order_kind='restock';（不建議）
 -- ============================================================
 
@@ -955,7 +960,26 @@ COMMENT ON FUNCTION public.rpc_transfer_order_partial(BIGINT, BIGINT, BIGINT, BI
   '基底 20260714000010。';
 
 -- ----------------------------------------------------------------
--- 5. Backfill
+-- 5. 唯一索引排除 restock ride-along 單
+--    基底 20260516000000：key=(tenant,campaign,channel,member,order_kind)、
+--    WHERE 排除 closed。加排 order_kind='restock'：同店多張併行補貨單
+--    共用 sentinel trio + 內部會員，本來就該允許共存（唯一性由 order_no 保證）。
+-- ----------------------------------------------------------------
+DROP INDEX IF EXISTS customer_orders_trio_kind_active_uniq;
+
+CREATE UNIQUE INDEX customer_orders_trio_kind_active_uniq
+  ON customer_orders (tenant_id, campaign_id, channel_id, member_id, order_kind)
+  WHERE status NOT IN ('transferred_out', 'expired', 'cancelled')
+    AND order_kind <> 'restock';
+
+COMMENT ON INDEX customer_orders_trio_kind_active_uniq IS
+  '同 (tenant, campaign, channel, member, order_kind) 只允許一筆 active 訂單；'
+  'closed (transferred_out/expired/cancelled) 不佔 slot。'
+  '加 order_kind 是為了讓 store_internal member 可同時有 normal 與 offset 兩張單。'
+  'order_kind=restock 的 ride-along 單排除在外（同店可多張併行補貨，唯一性由 order_no=RR-<id> 保證）。';
+
+-- ----------------------------------------------------------------
+-- 6. Backfill
 -- ----------------------------------------------------------------
 DO $$
 DECLARE


### PR DESCRIPTION
## 背景

#521 在最後兩個 commit 推上分支前被 squash-merge,該兩個 commit 被漏掉(與 #516→#517 同型情況)。本 PR off 最新 main 補回 delta。

## 補回的內容

**1. 建單頁:訂購會員欄預設即選定【內部】該店**(eba46ed)
- 原 merge 進 main 的版本是空搜尋框 + placeholder 暗示內部
- 改成預設渲染已選 chip「【內部】{店名}·店庫存」,隨收貨分店連動店名;點「指定會員」才切到搜尋模式(選定可「改回內部」)
- 內部狀態仍送 `p_member_id: null`,由 RPC 端解析/自動建立內部會員(頁面載入零副作用)

**2. migration 090:唯一索引排除 `order_kind='restock'`**(8e35135)
- **prod 實測撞鍵**:`customer_orders_trio_kind_active_uniq` 的 key 含 order_kind,同店多張併行補貨的 ride-along 單共用(sentinel 團、sentinel 頻道、內部會員、'restock'),backfill 掛上內部會員即撞;新流程下同店第二張補貨也必撞
- predicate 加排 `order_kind <> 'restock'`:RR 單唯一性由 `order_no='RR-<id>'` 保證,同店多張併行補貨合法;一般單/offset 的 dedup 語意不變

## 部署狀態

**090 已於 2026-07-12 以本 PR 的最終版套 prod 並唯讀驗證全綠**(索引 predicate、4 參數簽名、RR 單掛內部會員、RR-18=ready)。本 PR 純粹讓 repo 對齊 prod,merge 後無需再跑 SQL;前端 chip UI 需 merge 觸發 GH Pages。

- admin `tsc --noEmit` 通過(於原分支驗過,檔案終態相同)

🤖 Generated with [Claude Code](https://claude.com/claude-code)