### PR TITLE
月結＝總倉當清算中心:自由轉貨兩邊記帳 + 退貨回總倉沖回

### DIFF
--- a/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
@@ -59,18 +59,25 @@ type HqToStoreItem = {
   unit_cost: number;
   line_amount: number;
   received_at: string;
-  entry_type: "hq_inbound" | "air_in" | "air_out";
+  entry_type: "hq_inbound" | "air_in" | "air_out" | "free_in" | "free_out" | "return_out";
+  description: string | null;
 };
 
 const ENTRY_TYPE_LABEL: Record<HqToStoreItem["entry_type"], string> = {
   hq_inbound: "HQ 進貨",
   air_in: "空中轉入",
   air_out: "空中轉出",
+  free_in: "自由轉入",
+  free_out: "自由轉出",
+  return_out: "退貨沖回",
 };
 const ENTRY_TYPE_COLOR: Record<HqToStoreItem["entry_type"], string> = {
   hq_inbound: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
   air_in: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
   air_out: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  free_in: "bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-300",
+  free_out: "bg-violet-100 text-violet-800 dark:bg-violet-950 dark:text-violet-300",
+  return_out: "bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-300",
 };
 
 type Transfer = {
@@ -367,7 +374,7 @@ function HqToStoreDetail({
       const sb = getSupabase();
       const { data, error } = await sb
         .from("store_monthly_settlement_items")
-        .select("id, transfer_id, transfer_item_id, sku_id, qty_received, unit_cost, line_amount, received_at, entry_type")
+        .select("id, transfer_id, transfer_item_id, sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description")
         .eq("settlement_id", settlement.id)
         .order("entry_type", { ascending: true })
         .order("received_at", { ascending: true });
@@ -479,9 +486,16 @@ function HqToStoreDetail({
                     <Td className="text-xs">{new Date(it.received_at).toLocaleDateString("zh-TW")}</Td>
                     <Td className="font-mono text-xs">{tx?.transfer_no ?? `#${it.transfer_id}`}</Td>
                     <Td className="text-xs">
-                      <span className="font-mono text-zinc-500">{sku?.sku_code ?? "—"}</span>{" "}
-                      <span>{sku?.product_name ?? "—"}</span>
-                      {sku?.variant_name && <span className="ml-1 text-zinc-400">/ {sku.variant_name}</span>}
+                      {it.description ? (
+                        // 自由轉貨行：無真 SKU，顯示轉貨時填的描述
+                        <span className="break-words">{it.description}</span>
+                      ) : (
+                        <>
+                          <span className="font-mono text-zinc-500">{sku?.sku_code ?? "—"}</span>{" "}
+                          <span>{sku?.product_name ?? "—"}</span>
+                          {sku?.variant_name && <span className="ml-1 text-zinc-400">/ {sku.variant_name}</span>}
+                        </>
+                      )}
                     </Td>
                     <Td className="text-right font-mono">{Number(it.qty_received).toLocaleString()}</Td>
                     <Td className="text-right font-mono text-zinc-500">${Number(it.unit_cost).toFixed(2)}</Td>

--- a/docs/TEST-settlement-free-transfer-clearinghouse.md
+++ b/docs/TEST-settlement-free-transfer-clearinghouse.md
@@ -1,0 +1,33 @@
+# TEST — 月結清算中心（自由轉貨兩邊記帳 + 退貨回總倉沖回）
+
+Migration：`20260714000100_settlement_free_transfer_and_return.sql`
+公式：`payable = hq_inbound + air_in − air_out + free_in − free_out − return_out`
+
+## 測試項目
+
+### 分錄產生（rpc_generate_hq_to_store_settlement）
+- [ ] T1 自由轉貨（店A→店B、已收貨、估價 $100）→ 店B 月結 `free_in +100`、店A 月結 `free_out −100`；兩邊鏡像同額（總倉淨額 0）。
+- [ ] T2 估價空值的自由轉貨行 → 兩邊各記 0 元分錄（金額不動、明細可見）。
+- [ ] T3 草稿/已出貨未收貨的自由轉貨 → 不入帳（只認 received/closed、received_at 落在該月）。
+- [ ] T4 退貨回總倉（店→HQ、HQ 已收）→ 該店 `return_out` 負分錄，金額 = qty_received × 出庫 unit_cost（與 hq_inbound 同基準）。
+- [ ] T5 互助/轉手腿（store_to_store 有訂單 FK）仍走 air_in/air_out，**不會**同時被 free 系列重複計（customer_order_id IS NULL 互斥）。
+- [ ] T6 既有 hq_inbound / air_in / air_out 金額與 20260512000012 版完全一致（迴歸）。
+- [ ] T7 該店該月只有自由轉出（無其他活動）→ 仍產生月結（負額 = 貸方餘額），不會被「無活動 skip」誤刪。
+- [ ] T8 confirmed/settled 的月結不被重算；draft 重跑生成器 → 金額更新、items 重建。
+
+### 明細
+- [ ] T9 free_in/free_out 明細列帶 description（自由轉貨的描述），unit_cost=0、line_amount=±估價。
+- [ ] T10 return_out 明細列為真 SKU、line_amount 為負。
+- [ ] T11 transfer_count / item_count 含自由轉貨與退貨腿。
+
+### UI（transfers/settlement）
+- [ ] T12 明細表新 chip：自由轉入(sky)/自由轉出(violet)/退貨沖回(rose)；負額顯示既有 amber 樣式。
+- [ ] T13 自由轉貨行「商品」欄顯示描述文字（不再是 MISC 雜項）。
+- [ ] T14 合計 = 各分錄加總 = 表頭應付金額。
+
+### 約束
+- [ ] T15 entry_type CHECK 換新版（六值）；舊三值資料不受影響。
+- [ ] T16 items.description 欄新增成功、既有列為 NULL。
+
+### 部署後（prod）
+- [ ] T17 對 7 月重跑生成器（draft 範圍），抽一張有自由轉貨的店對帳：free_in/free_out 對得上內部調撥頁的估價。

--- a/supabase/migrations/20260714000100_settlement_free_transfer_and_return.sql
+++ b/supabase/migrations/20260714000100_settlement_free_transfer_and_return.sql
@@ -1,0 +1,401 @@
+-- ============================================================
+-- 2026-07-12: 月結＝總倉當清算中心 — 自由轉貨兩邊記帳 + 退貨回總倉沖回
+--
+-- 需求（使用者）：「月結總倉要當交易所幫我們紀錄金額」。
+--
+-- 現況缺口（rpc_generate_hq_to_store_settlement = 20260512000012 現行版）：
+--   只有三種分錄 hq_inbound / air_in / air_out，且 air 系列只認
+--   customer_order_id IS NOT NULL 的 store_to_store（互助/轉手腿）。
+--   1. 自由轉貨（store_to_store、無訂單 FK）完全不入帳：
+--      收貨店白拿、出貨店白給，兩店之間的金額沒人記。
+--   2. 退貨回總倉（transfer_type='return_to_hq'）沒有沖回：
+--      店收貨時被記應付（hq_inbound），把貨退回總倉卻不退錢。
+--
+-- 修法：entry_type 加三種，payable 公式擴成：
+--   payable = hq_inbound + air_in - air_out + free_in - free_out - return_out
+--   - free_in ：自由轉貨收進（該店是 dest）  → 應付 +
+--   - free_out：自由轉貨送出（該店是 source）→ 應付 −（貸記）
+--   - return_out：退貨回總倉（該店是 source、總倉已收）→ 應付 −（沖回）
+--
+-- 金額基準：
+--   - free_in / free_out：自由轉貨的行是「MISC 虛擬 SKU + 描述 + 估價」、
+--     不動庫存、沒有成本分錄 → 以 transfer_items.estimated_amount（行總額）
+--     入帳；估價空值以 0 計（＝該行不產生金額，店端要記帳就要填估價）。
+--   - return_out：真 SKU、有出庫 movement → qty_received × 出貨當下
+--     unit_cost（與 hq_inbound / air 系列同基準）。
+--   兩店分錄鏡像同額，總倉純過帳（淨額 0）、只當交易所。
+--
+--   items 表加 description 欄：自由轉貨行只有描述沒有真 SKU，
+--   月結明細沒有描述會全部顯示成 MISC 雜項。
+--
+-- 基底版本：rpc_generate_hq_to_store_settlement = 20260512000012（線上現行，
+--   20260705000000 僅註解提及未改動）；逐字複製僅追加 D/E/F 分錄。
+-- Rollback：
+--   CREATE OR REPLACE 回 20260512000012 版本；
+--   ALTER TABLE store_monthly_settlement_items DROP CONSTRAINT smsi_entry_type_check_v2;
+--   （舊 CHECK 名 store_monthly_settlement_items_entry_type_check 需重建）；
+--   description 欄可留（無害）。已生成的 draft 月結重跑生成器即回舊口徑；
+--   confirmed/settled 不受影響（生成器本來就跳過）。
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. entry_type CHECK 擴充 + items 加 description
+-- ------------------------------------------------------------
+ALTER TABLE public.store_monthly_settlement_items
+  DROP CONSTRAINT IF EXISTS store_monthly_settlement_items_entry_type_check;
+ALTER TABLE public.store_monthly_settlement_items
+  DROP CONSTRAINT IF EXISTS smsi_entry_type_check_v2;
+ALTER TABLE public.store_monthly_settlement_items
+  ADD CONSTRAINT smsi_entry_type_check_v2
+    CHECK (entry_type IN ('hq_inbound','air_in','air_out','free_in','free_out','return_out'));
+
+ALTER TABLE public.store_monthly_settlement_items
+  ADD COLUMN IF NOT EXISTS description TEXT;
+
+COMMENT ON COLUMN store_monthly_settlement_items.entry_type IS
+  '結算明細類型：hq_inbound=從 HQ 收貨；air_in=空中轉收進；air_out=空中轉送出（負）；'
+  'free_in=自由轉貨收進；free_out=自由轉貨送出（負）；return_out=退貨回總倉沖回（負）';
+
+COMMENT ON COLUMN store_monthly_settlement_items.description IS
+  '自由轉貨行的描述（MISC 虛擬 SKU 無品名可查）；真 SKU 行為 NULL';
+
+-- ------------------------------------------------------------
+-- 2. rpc_generate_hq_to_store_settlement — 加 free_in / free_out / return_out
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_generate_hq_to_store_settlement(
+  p_month    DATE,
+  p_operator UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant         UUID;
+  v_month_start    DATE := DATE_TRUNC('month', p_month)::DATE;
+  v_month_end      DATE := (DATE_TRUNC('month', p_month) + INTERVAL '1 month')::DATE;
+  v_store          RECORD;
+  v_settlement_id  BIGINT;
+  v_hq_inbound     NUMERIC(18,4);
+  v_air_in         NUMERIC(18,4);
+  v_air_out        NUMERIC(18,4);
+  v_free_in        NUMERIC(18,4);
+  v_free_out       NUMERIC(18,4);
+  v_return_out     NUMERIC(18,4);
+  v_payable        NUMERIC(18,4);
+  v_xfer_count     INTEGER;
+  v_item_count     INTEGER;
+  v_total_stores   INTEGER := 0;
+  v_total_amount   NUMERIC(18,4) := 0;
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM stores LIMIT 1;
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'no stores found, cannot infer tenant_id';
+  END IF;
+
+  FOR v_store IN
+    SELECT s.id, s.code, s.name, s.location_id
+      FROM stores s
+     WHERE s.tenant_id = v_tenant
+       AND s.location_id IS NOT NULL
+  LOOP
+    -- 跳過已 confirmed/settled
+    IF EXISTS (
+      SELECT 1 FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status IN ('confirmed','settled')
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    -- A) hq_inbound: 從 HQ 收貨
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0)
+      INTO v_hq_inbound
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- B) air_in: 空中轉收進來（該店是 dest）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0)
+      INTO v_air_in
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- C) air_out: 空中轉送出去（該店是 source）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0)
+      INTO v_air_out
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- D) free_in: 自由轉貨收進來（該店是 dest；無訂單 FK；估價入帳）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_in
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out: 自由轉貨送出去（該店是 source；估價入帳、貸記）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_out
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out: 退貨回總倉（該店是 source、總倉已收；成本沖回）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0)
+      INTO v_return_out
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    v_payable := v_hq_inbound + v_air_in - v_air_out + v_free_in - v_free_out - v_return_out;
+
+    -- 沒任何活動就 skip + 砍 draft
+    IF v_hq_inbound = 0 AND v_air_in = 0 AND v_air_out = 0
+       AND v_free_in = 0 AND v_free_out = 0 AND v_return_out = 0 THEN
+      DELETE FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status = 'draft';
+      CONTINUE;
+    END IF;
+
+    -- 計 transfer_count + item_count
+    SELECT
+      COUNT(DISTINCT t.id), COUNT(ti.id)
+      INTO v_xfer_count, v_item_count
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.status IN ('received','closed')
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0
+       AND (
+         (t.transfer_type = 'hq_to_store' AND t.dest_location = v_store.location_id)
+         OR
+         (t.transfer_type = 'store_to_store'
+          AND (t.dest_location = v_store.location_id OR t.source_location = v_store.location_id))
+         OR
+         (t.transfer_type = 'return_to_hq' AND t.source_location = v_store.location_id)
+       );
+
+    -- upsert (draft only)
+    INSERT INTO store_monthly_settlements (
+      tenant_id, settlement_month, store_id,
+      payable_amount, transfer_count, item_count,
+      status, created_by, updated_by
+    ) VALUES (
+      v_tenant, v_month_start, v_store.id,
+      v_payable, v_xfer_count, v_item_count,
+      'draft', p_operator, p_operator
+    )
+    ON CONFLICT (tenant_id, settlement_month, store_id)
+    DO UPDATE SET
+      payable_amount = EXCLUDED.payable_amount,
+      transfer_count = EXCLUDED.transfer_count,
+      item_count     = EXCLUDED.item_count,
+      updated_by     = p_operator,
+      updated_at     = NOW()
+    WHERE store_monthly_settlements.status = 'draft'
+    RETURNING id INTO v_settlement_id;
+
+    -- 重建 items
+    DELETE FROM store_monthly_settlement_items WHERE settlement_id = v_settlement_id;
+
+    -- A) hq_inbound items
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      ti.qty_received * COALESCE(sm.unit_cost, 0),
+      t.received_at, 'hq_inbound'
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- B) air_in items
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      ti.qty_received * COALESCE(sm.unit_cost, 0),
+      t.received_at, 'air_in'
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- C) air_out items（line_amount 用負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      -1 * ti.qty_received * COALESCE(sm.unit_cost, 0),  -- 負值
+      t.received_at, 'air_out'
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- D) free_in items（估價入帳；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      COALESCE(ti.estimated_amount, 0),
+      t.received_at, 'free_in', ti.description
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out items（估價入帳、負值；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      -1 * COALESCE(ti.estimated_amount, 0),  -- 負值
+      t.received_at, 'free_out', ti.description
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out items（成本沖回、負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      -1 * ti.qty_received * COALESCE(sm.unit_cost, 0),  -- 負值
+      t.received_at, 'return_out'
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    v_total_stores := v_total_stores + 1;
+    v_total_amount := v_total_amount + v_payable;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'month',         to_char(v_month_start, 'YYYY-MM'),
+    'stores_count',  v_total_stores,
+    'total_amount',  v_total_amount
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_generate_hq_to_store_settlement IS
+  'HQ→店月結算（總倉當清算中心）：payable = hq_inbound + air_in - air_out '
+  '+ free_in - free_out - return_out。自由轉貨以估價入帳（兩店鏡像同額、總倉淨額 0）、'
+  '退貨回總倉以成本沖回。已 confirmed/settled 不重算。';


### PR DESCRIPTION
## 需求

「月結總倉要當交易所幫我們紀錄金額」— 店↔店自由轉貨的金額要進月結,總倉當清算中心兩邊記帳。

## 現況缺口

月結生成器(20260512000012 現行版)只有 `hq_inbound / air_in / air_out` 三種分錄,且 air 系列只認**掛訂單的** store_to_store(互助/轉手腿):

1. **自由轉貨完全不入帳** — 收貨店白拿、出貨店白給,兩店金額沒人記
2. **退貨回總倉沒有沖回** — 店收貨時被記應付(`hq_inbound`),把貨退回總倉卻不退錢

## 修法(migration `20260714000100`)

新公式:
```
payable = hq_inbound + air_in − air_out + free_in − free_out − return_out
```

| 新分錄 | 對象 | 方向 | 金額基準 |
|---|---|---|---|
| `free_in` | 自由轉貨收貨店 | 應付 + | **估價**(`estimated_amount`) |
| `free_out` | 自由轉貨出貨店 | 貸記 − | 同上(兩店鏡像同額,總倉淨額 0) |
| `return_out` | 退貨回總倉的店 | 沖回 − | `qty_received × 出庫 unit_cost`(與 hq_inbound 同基準) |

**為什麼自由轉貨用估價**:自由轉貨的行是「MISC 虛擬 SKU + 描述 + 估價」、不動庫存、沒有成本分錄可查 — 估價是唯一金額來源。**估價空值以 0 計**(要記帳就要填估價;明細仍可見)。

其他:
- `entry_type` CHECK 換六值;items 加 `description` 欄(自由轉貨行只有描述沒有真 SKU,否則月結明細全顯示成 MISC 雜項)
- 「無活動 skip」、transfer_count/item_count 一併涵蓋新腿
- 互助/轉手腿(`customer_order_id IS NOT NULL`)與自由腿(`IS NULL`)互斥,不會重複計
- **confirmed/settled 不重算**(生成器本來就跳過),只影響 draft 月結
- UI(transfers/settlement):三種新分錄 chip(自由轉入/自由轉出/退貨沖回)+ 自由轉貨行顯示描述

## 基底

`rpc_generate_hq_to_store_settlement` = 20260512000012(線上現行;20260705000000 僅註解提及未改動),逐字複製僅追加 D/E/F 分錄。admin `tsc --noEmit` 通過。

## 測試

`docs/TEST-settlement-free-transfer-clearinghouse.md`(T1–T17)

⚠️ migration 待套 prod;套用後對本月重跑生成器,draft 月結即帶入新分錄。

🤖 Generated with [Claude Code](https://claude.com/claude-code)