### PR TITLE
月結雙價格口徑：每筆分錄同時帶成本價與分店價分開計算

### DIFF
--- a/apps/admin/src/app/(protected)/finance/receivables/print/page.tsx
+++ b/apps/admin/src/app/(protected)/finance/receivables/print/page.tsx
@@ -9,6 +9,8 @@ type Settlement = {
   settlement_month: string;
   store_id: number;
   payable_amount: number;
+  cost_amount: number;
+  branch_amount: number;
   transfer_count: number;
   item_count: number;
   status: string;
@@ -22,8 +24,11 @@ type SettlementItem = {
   qty_received: number;
   unit_cost: number;
   line_amount: number;
+  unit_branch_price: number;
+  branch_amount: number;
   received_at: string;
-  entry_type: "hq_inbound" | "air_in" | "air_out";
+  entry_type: "hq_inbound" | "air_in" | "air_out" | "free_in" | "free_out" | "return_out";
+  description: string | null;
 };
 
 type Store = { id: number; code: string; name: string };
@@ -35,6 +40,9 @@ const ENTRY_TYPE_LABEL: Record<SettlementItem["entry_type"], string> = {
   hq_inbound: "HQ 進貨",
   air_in: "空中轉入",
   air_out: "空中轉出",
+  free_in: "自由轉入",
+  free_out: "自由轉出",
+  return_out: "退貨沖回",
 };
 
 export default function PrintSettlementPage() {
@@ -63,7 +71,7 @@ export default function PrintSettlementPage() {
         const sb = getSupabase();
         const { data: s, error: e1 } = await sb
           .from("store_monthly_settlements")
-          .select("id, settlement_month, store_id, payable_amount, transfer_count, item_count, status, generated_receivable_id")
+          .select("id, settlement_month, store_id, payable_amount, cost_amount, branch_amount, transfer_count, item_count, status, generated_receivable_id")
           .eq("id", settlementId)
           .maybeSingle();
         if (e1) throw new Error(e1.message);
@@ -75,7 +83,7 @@ export default function PrintSettlementPage() {
         const [{ data: storeData }, { data: itemRows }, { data: tenantData }] = await Promise.all([
           sb.from("stores").select("id, code, name").eq("id", sd.store_id).maybeSingle(),
           sb.from("store_monthly_settlement_items")
-            .select("id, transfer_id, sku_id, qty_received, unit_cost, line_amount, received_at, entry_type")
+            .select("id, transfer_id, sku_id, qty_received, unit_cost, line_amount, unit_branch_price, branch_amount, received_at, entry_type, description")
             .eq("settlement_id", settlementId)
             .order("entry_type")
             .order("received_at"),
@@ -135,6 +143,7 @@ export default function PrintSettlementPage() {
 
   const monthLabel = settlement.settlement_month?.slice(0, 7);
   const total = items.reduce((s, it) => s + Number(it.line_amount), 0);
+  const totalBranch = items.reduce((s, it) => s + Number(it.branch_amount ?? 0), 0);
   const today = new Date().toLocaleDateString("zh-TW");
 
   return (
@@ -195,9 +204,12 @@ export default function PrintSettlementPage() {
               </div>
             </div>
             <div className="text-right">
-              <div className="text-xs text-zinc-500">應付總倉金額</div>
+              <div className="text-xs text-zinc-500">應付總倉金額（成本價口徑）</div>
               <div className="text-lg font-semibold text-rose-600">
                 ${Number(settlement.payable_amount).toLocaleString()}
+              </div>
+              <div className="mt-0.5 text-xs text-zinc-600">
+                分店價口徑：<span className="font-mono font-semibold">${Number(settlement.branch_amount ?? 0).toLocaleString()}</span>
               </div>
               {receivable && (
                 <div className="mt-0.5 text-xs text-zinc-500">到期日：{receivable.due_date}</div>
@@ -216,8 +228,10 @@ export default function PrintSettlementPage() {
                 <th className="border border-zinc-400 px-2 py-1.5 text-left">商品編號</th>
                 <th className="border border-zinc-400 px-2 py-1.5 text-left">品名</th>
                 <th className="border border-zinc-400 px-2 py-1.5 text-right">數量</th>
-                <th className="border border-zinc-400 px-2 py-1.5 text-right">單價</th>
-                <th className="border border-zinc-400 px-2 py-1.5 text-right">小計</th>
+                <th className="border border-zinc-400 px-2 py-1.5 text-right">成本單價</th>
+                <th className="border border-zinc-400 px-2 py-1.5 text-right">成本小計</th>
+                <th className="border border-zinc-400 px-2 py-1.5 text-right">分店單價</th>
+                <th className="border border-zinc-400 px-2 py-1.5 text-right">分店小計</th>
               </tr>
             </thead>
             <tbody>
@@ -233,13 +247,23 @@ export default function PrintSettlementPage() {
                     <td className="border border-zinc-400 px-2 py-1 font-mono">{tx?.transfer_no ?? `#${it.transfer_id}`}</td>
                     <td className="border border-zinc-400 px-2 py-1 font-mono">{sku?.sku_code ?? "—"}</td>
                     <td className="border border-zinc-400 px-2 py-1">
-                      {sku?.product_name ?? "—"}
-                      {sku?.variant_name && <span className="ml-1 text-zinc-500">/ {sku.variant_name}</span>}
+                      {it.description ? (
+                        <span>{it.description}</span>
+                      ) : (
+                        <>
+                          {sku?.product_name ?? "—"}
+                          {sku?.variant_name && <span className="ml-1 text-zinc-500">/ {sku.variant_name}</span>}
+                        </>
+                      )}
                     </td>
                     <td className="border border-zinc-400 px-2 py-1 text-right font-mono">{Number(it.qty_received).toLocaleString()}</td>
                     <td className="border border-zinc-400 px-2 py-1 text-right font-mono">${Number(it.unit_cost).toFixed(2)}</td>
                     <td className={`border border-zinc-400 px-2 py-1 text-right font-mono ${isNeg ? "text-amber-600" : ""}`}>
                       ${Number(it.line_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                    </td>
+                    <td className="border border-zinc-400 px-2 py-1 text-right font-mono">${Number(it.unit_branch_price ?? 0).toFixed(2)}</td>
+                    <td className={`border border-zinc-400 px-2 py-1 text-right font-mono ${Number(it.branch_amount ?? 0) < 0 ? "text-amber-600" : ""}`}>
+                      ${Number(it.branch_amount ?? 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                     </td>
                   </tr>
                 );
@@ -250,13 +274,20 @@ export default function PrintSettlementPage() {
                 <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono text-rose-600">
                   ${total.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                 </td>
+                <td className="border border-zinc-400 px-2 py-1.5"></td>
+                <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono">
+                  ${totalBranch.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                </td>
               </tr>
             </tbody>
           </table>
 
           {/* 說明 */}
           <div className="mt-3 text-[10px] text-zinc-500">
-            ※ 類型說明：HQ 進貨 = 總倉直接出貨給本店；空中轉入 = 別店空中轉來（加應付）；空中轉出 = 空中轉去別店（減應付）。
+            ※ 類型說明：HQ 進貨 = 總倉直接出貨給本店；空中轉入 = 別店空中轉來（加應付）；空中轉出 = 空中轉去別店（減應付）；
+            自由轉入／轉出 = 店間自由轉貨（估價入帳）；退貨沖回 = 退貨回總倉（減應付）。
+            <br />
+            ※ 價格口徑：成本單價 = 出貨當下成本；分店單價 = 收貨當下生效之分店價；兩口徑分開計算。自由轉貨行以估價入帳、兩口徑同額。
           </div>
 
           {/* 簽收區 */}

--- a/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
@@ -30,6 +30,8 @@ type HqToStoreSettlement = {
   settlement_month: string;
   store_id: number;
   payable_amount: number;
+  cost_amount: number;
+  branch_amount: number;
   transfer_count: number;
   item_count: number;
   status: SettlementStatusExt;
@@ -58,6 +60,8 @@ type HqToStoreItem = {
   qty_received: number;
   unit_cost: number;
   line_amount: number;
+  unit_branch_price: number;
+  branch_amount: number;
   received_at: string;
   entry_type: "hq_inbound" | "air_in" | "air_out" | "free_in" | "free_out" | "return_out";
   description: string | null;
@@ -123,6 +127,7 @@ export default function SettlementPage() {
         <h1 className="text-xl font-semibold">月結算</h1>
         <p className="text-sm text-zinc-500">
           總倉對各分店：賣斷制、依 hq_to_store 已收貨 transfers 計算貨款（含空中轉調整）。
+          每筆分錄同時帶成本價與分店價兩個口徑分開計算。
         </p>
       </header>
 
@@ -159,7 +164,7 @@ function HqToStoreTab() {
         let q = sb
           .from("store_monthly_settlements")
           .select(
-            "id, settlement_month, store_id, payable_amount, transfer_count, item_count, status, confirmed_at, settled_at, generated_receivable_id, notes, updated_at",
+            "id, settlement_month, store_id, payable_amount, cost_amount, branch_amount, transfer_count, item_count, status, confirmed_at, settled_at, generated_receivable_id, notes, updated_at",
           )
           .order("settlement_month", { ascending: false })
           .order("store_id", { ascending: true })
@@ -203,8 +208,10 @@ function HqToStoreTab() {
         p_operator: operator,
       });
       if (e) throw new Error(e.message);
-      const r = data as { stores_count?: number; total_amount?: number };
-      setGenResult(`已產生 ${r?.stores_count ?? 0} 家分店 ${genMonth} 月結算（總額 $${r?.total_amount?.toLocaleString?.() ?? 0}）。`);
+      const r = data as { stores_count?: number; total_cost_amount?: number; total_branch_amount?: number };
+      setGenResult(
+        `已產生 ${r?.stores_count ?? 0} 家分店 ${genMonth} 月結算（成本價口徑 $${r?.total_cost_amount?.toLocaleString?.() ?? 0}／分店價口徑 $${r?.total_branch_amount?.toLocaleString?.() ?? 0}）。`,
+      );
       setReloadTick((t) => t + 1);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -214,6 +221,7 @@ function HqToStoreTab() {
   }
 
   const totalPayable = rows?.reduce((sum, r) => sum + Number(r.payable_amount), 0) ?? 0;
+  const totalBranch = rows?.reduce((sum, r) => sum + Number(r.branch_amount ?? 0), 0) ?? 0;
 
   return (
     <>
@@ -280,7 +288,8 @@ function HqToStoreTab() {
             <tr>
               <Th>月份</Th>
               <Th>分店</Th>
-              <Th className="text-right">應付總倉</Th>
+              <Th className="text-right">應付總倉（成本價）</Th>
+              <Th className="text-right">分店價口徑</Th>
               <Th className="text-right">調撥單數</Th>
               <Th className="text-right">商品行數</Th>
               <Th>狀態</Th>
@@ -289,9 +298,9 @@ function HqToStoreTab() {
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={7} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={8} className="p-3 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={7} className="p-6 text-center text-zinc-500">{loading ? "載入中…" : "尚無結算紀錄。先用上方「產生 / 重算 draft」。"}</td></tr>
+              <tr><td colSpan={8} className="p-6 text-center text-zinc-500">{loading ? "載入中…" : "尚無結算紀錄。先用上方「產生 / 重算 draft」。"}</td></tr>
             ) : rows.map((r) => {
               const s = stores.get(r.store_id);
               const month = r.settlement_month?.slice(0, 7);
@@ -303,6 +312,7 @@ function HqToStoreTab() {
                     <span className="text-zinc-700 dark:text-zinc-200">{s?.name ?? `#${r.store_id}`}</span>
                   </Td>
                   <Td className="text-right font-mono text-rose-600">${Number(r.payable_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}</Td>
+                  <Td className="text-right font-mono text-sky-700 dark:text-sky-400">${Number(r.branch_amount ?? 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}</Td>
                   <Td className="text-right font-mono">{r.transfer_count}</Td>
                   <Td className="text-right font-mono">{r.item_count}</Td>
                   <Td><span className={`inline-block rounded px-2 py-0.5 text-xs ${STATUS_COLOR[r.status]}`}>{STATUS_LABEL[r.status]}</span></Td>
@@ -324,6 +334,9 @@ function HqToStoreTab() {
                 <td colSpan={2} className="px-3 py-2 text-right text-xs text-zinc-500">合計</td>
                 <td className="px-3 py-2 text-right font-mono font-medium text-rose-600">
                   ${totalPayable.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                </td>
+                <td className="px-3 py-2 text-right font-mono font-medium text-sky-700 dark:text-sky-400">
+                  ${totalBranch.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                 </td>
                 <td colSpan={4}></td>
               </tr>
@@ -374,7 +387,7 @@ function HqToStoreDetail({
       const sb = getSupabase();
       const { data, error } = await sb
         .from("store_monthly_settlement_items")
-        .select("id, transfer_id, transfer_item_id, sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description")
+        .select("id, transfer_id, transfer_item_id, sku_id, qty_received, unit_cost, line_amount, unit_branch_price, branch_amount, received_at, entry_type, description")
         .eq("settlement_id", settlement.id)
         .order("entry_type", { ascending: true })
         .order("received_at", { ascending: true });
@@ -428,7 +441,9 @@ function HqToStoreDetail({
         <Stat label="分店" value={store?.name ?? `#${settlement.store_id}`} />
         <Stat label="月份" value={settlement.settlement_month?.slice(0, 7)} />
         <Stat label="狀態" value={STATUS_LABEL[settlement.status]} />
-        <Stat label="應付金額" value={`$${Number(settlement.payable_amount).toLocaleString("zh-TW")}`} accent="negative" />
+        <Stat label="應付金額（成本價口徑）" value={`$${Number(settlement.payable_amount).toLocaleString("zh-TW")}`} accent="negative" />
+        <Stat label="分店價口徑金額" value={`$${Number(settlement.branch_amount ?? 0).toLocaleString("zh-TW")}`} accent="info" />
+        <Stat label="口徑差額（總部毛利）" value={`$${(Number(settlement.branch_amount ?? 0) - Number(settlement.cost_amount ?? settlement.payable_amount)).toLocaleString("zh-TW")}`} />
         <Stat label="調撥單數" value={String(settlement.transfer_count)} />
         <Stat label="商品行數" value={String(settlement.item_count)} />
       </div>
@@ -452,7 +467,8 @@ function HqToStoreDetail({
       <div>
         <div className="mb-2 text-sm font-medium">出貨明細（{items?.length ?? 0} 筆）</div>
         <p className="mb-2 text-xs text-zinc-500">
-          📦 HQ 進貨：總倉送來；✈️ 空中轉入：別店空中轉來（加應付）；✈️ 空中轉出：空中轉去別店（減應付，金額負）
+          📦 HQ 進貨：總倉送來；✈️ 空中轉入：別店空中轉來（加應付）；✈️ 空中轉出：空中轉去別店（減應付，金額負）。
+          每行同時列成本價（出貨當下成本）與分店價（收貨當下生效分店價）兩個口徑分開計算；自由轉貨行以估價入帳、兩口徑同額。
         </p>
         <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
           <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
@@ -463,15 +479,17 @@ function HqToStoreDetail({
                 <Th>調撥單</Th>
                 <Th>商品</Th>
                 <Th className="text-right">數量</Th>
-                <Th className="text-right">單價</Th>
-                <Th className="text-right">小計</Th>
+                <Th className="text-right">成本單價</Th>
+                <Th className="text-right">成本小計</Th>
+                <Th className="text-right">分店單價</Th>
+                <Th className="text-right">分店小計</Th>
               </tr>
             </thead>
             <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
               {items === null ? (
-                <tr><td colSpan={7} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+                <tr><td colSpan={9} className="p-3 text-center text-zinc-500">載入中…</td></tr>
               ) : items.length === 0 ? (
-                <tr><td colSpan={7} className="p-3 text-center text-zinc-500">無明細。</td></tr>
+                <tr><td colSpan={9} className="p-3 text-center text-zinc-500">無明細。</td></tr>
               ) : items.map((it) => {
                 const tx = transfers.get(it.transfer_id);
                 const sku = skus.get(it.sku_id);
@@ -502,6 +520,10 @@ function HqToStoreDetail({
                     <Td className={`text-right font-mono ${isNeg ? "text-amber-600" : ""}`}>
                       ${Number(it.line_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                     </Td>
+                    <Td className="text-right font-mono text-zinc-500">${Number(it.unit_branch_price ?? 0).toFixed(2)}</Td>
+                    <Td className={`text-right font-mono ${Number(it.branch_amount ?? 0) < 0 ? "text-amber-600" : "text-sky-700 dark:text-sky-400"}`}>
+                      ${Number(it.branch_amount ?? 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                    </Td>
                   </tr>
                 );
               })}
@@ -512,6 +534,10 @@ function HqToStoreDetail({
                   <td colSpan={6} className="px-3 py-2 text-right text-xs text-zinc-500">合計</td>
                   <td className="px-3 py-2 text-right font-mono font-medium text-rose-600">
                     ${items.reduce((sum, it) => sum + Number(it.line_amount), 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                  </td>
+                  <td></td>
+                  <td className="px-3 py-2 text-right font-mono font-medium text-sky-700 dark:text-sky-400">
+                    ${items.reduce((sum, it) => sum + Number(it.branch_amount ?? 0), 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                   </td>
                 </tr>
               </tfoot>
@@ -923,10 +949,11 @@ function TabBtn({ active, onClick, children }: { active: boolean; onClick: () =>
   );
 }
 
-function Stat({ label, value, accent }: { label: string; value: string; accent?: "positive" | "negative" | "neutral" }) {
+function Stat({ label, value, accent }: { label: string; value: string; accent?: "positive" | "negative" | "neutral" | "info" }) {
   const cls =
     accent === "positive" ? "text-emerald-600" :
     accent === "negative" ? "text-rose-600" :
+    accent === "info" ? "text-sky-700 dark:text-sky-400" :
     "text-zinc-700 dark:text-zinc-200";
   return (
     <div className="rounded-md border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">

--- a/docs/TEST-settlement-dual-price-basis.md
+++ b/docs/TEST-settlement-dual-price-basis.md
@@ -1,0 +1,46 @@
+# TEST — 月結雙價格口徑（成本價＋分店價分開計算）
+
+Migration：`20260715000000_settlement_dual_price_basis.sql`
+需求：月結算每筆分錄同時帶「成本價」與「分店價」兩個口徑分開計算。
+公式：
+- `cost_amount`（成本口徑）＝ 既有 payable 算法（movement.unit_cost；自由轉貨以估價計）
+- `branch_amount`（分店價口徑）＝ 同六種分錄、但以 `prices scope='branch'` 收貨當下生效價計（自由轉貨仍以估價計）
+- `payable_amount` 語義不變（＝成本口徑；confirm 入 store_receivables 的金額不受此次變更影響）
+
+## 測試項目
+
+### 分錄產生（rpc_generate_hq_to_store_settlement）
+- [x] T1 hq_inbound：每行 `unit_branch_price` = 收貨當下生效分店價、`branch_amount` = qty × 分店價；`unit_cost`/`line_amount`（成本口徑）與舊版完全一致（迴歸）。
+- [x] T2 air_in / air_out：雙口徑鏡像同額（收方正、出方負），總倉淨額兩口徑皆 0。
+- [x] T3 free_in / free_out：無真 SKU 可查價 → 兩口徑同用估價（`unit_branch_price`=0、`branch_amount`=±estimated_amount）。
+- [x] T4 return_out：兩口徑皆負值沖回；分店價口徑 = −qty × 收貨當下分店價。
+- [x] T5 header `cost_amount` = Σ items.line_amount、`branch_amount` = Σ items.branch_amount、`payable_amount` = `cost_amount`（2026-07 線上 14 店全數一致）。
+- [ ] T6 分店價改價後收貨 → 取「收貨當下生效」版本，非現行價（prices effective_from/effective_to 落點）。
+- [ ] T7 收貨早於首次設分店價的舊資料 → fallback 現行分店價；完全無分店價 → 0（真 SKU 行 `unit_branch_price`=0 可辨識缺價）。
+- [x] T8 「無活動 skip」擴成兩口徑皆 0 才 skip；confirmed/settled 不重算（沿用既有行為）。
+
+### 既有資料
+- [x] T9 header `cost_amount` 回填 = 舊 `payable_amount`；items 為 append-only 不回填，draft 重跑生成器即補齊。
+- [x] T10 回傳 JSON 加 `total_cost_amount` / `total_branch_amount`；`total_amount` 保留（= 成本口徑，向下相容）。
+
+### UI（transfers/settlement）
+- [ ] T11 列表：「應付總倉（成本價）」與「分店價口徑」兩欄並列、footer 各自合計。
+- [ ] T12 明細 modal：成本單價/成本小計/分店單價/分店小計四欄；統計卡多「分店價口徑金額」「口徑差額（總部毛利）」。
+- [ ] T13 產生結果訊息顯示兩口徑總額。
+
+### UI（finance/receivables/print 對帳單）
+- [ ] T14 明細表雙口徑欄位、合計列兩個總額；表頭顯示成本口徑（應付）＋分店價口徑。
+- [ ] T15 補 #524 缺口：free_in/free_out/return_out 類型標籤與自由轉貨行描述正常顯示（先前只認三種 entry_type）。
+
+## 線上驗證（2026-07-13）
+
+`rpc_generate_hq_to_store_settlement('2026-07-01')` 重跑後：
+
+| entry_type | 行數 | 成本口徑 | 分店價口徑 |
+|---|---|---|---|
+| hq_inbound | 3393 | 1,413,460.53 | 1,617,410.38 |
+| air_in / air_out | 1 / 1 | +1,150 / −1,150 | +1,250 / −1,250 |
+| free_in / free_out | 17 / 19 | +940 / −940 | +940 / −940 |
+| return_out | 7 | −700 | −773 |
+
+14 家店 header 與 items 加總全數一致；真 SKU 行無缺分店價（`unit_branch_price`=0）者。

--- a/supabase/migrations/20260715000000_settlement_dual_price_basis.sql
+++ b/supabase/migrations/20260715000000_settlement_dual_price_basis.sql
@@ -1,0 +1,507 @@
+-- ============================================================
+-- 2026-07-13: 月結雙價格口徑 — 每筆分錄同時帶「成本價」與「分店價」分開計算
+--
+-- 需求（使用者）：「月結算應該都要帶到分店價跟成本價兩個來分開計算」。
+--
+-- 現況缺口（rpc_generate_hq_to_store_settlement = 20260714000100 現行版）：
+--   月結所有分錄只有一個金額基準 — 出貨當下 stock_movements.unit_cost
+--   （成本價口徑）。分店價（prices scope='branch'，總部賣給加盟店的價格）
+--   完全沒進月結，看不到兩個口徑的差額（= 總部毛利），也無從對帳。
+--
+-- 修法：
+--   1. store_monthly_settlements 加兩欄，分開累計兩個口徑：
+--      - cost_amount   成本價口徑總額（＝既有 payable_amount 的算法）
+--      - branch_amount 分店價口徑總額
+--      payable_amount 語義不變（＝成本口徑、confirm 後入 store_receivables
+--      的金額），避免無預警改動實際請款金額；要切換請款口徑時只需把
+--      confirm RPC 的取值換成 branch_amount。
+--   2. store_monthly_settlement_items 每行加：
+--      - unit_branch_price 分店價單價（收貨當下生效的 branch 價快照）
+--      - branch_amount     分店價口徑行金額（正負號同 line_amount）
+--   3. helper _branch_price_at(tenant, sku, at)：取「at 時點生效」的
+--      分店價（prices scope='branch'、scope_id IS NULL、price > 0）；
+--      該時點查無（收貨早於首次設價）則 fallback 現行價；再無則 NULL。
+--   4. 重寫 rpc_generate_hq_to_store_settlement：六種 entry_type 全部
+--      雙口徑計算。
+--
+-- 各 entry_type 的分店價基準：
+--   - hq_inbound / air_in / air_out / return_out：真 SKU →
+--     qty_received × _branch_price_at(sku, received_at)，air_out/return_out 取負。
+--   - free_in / free_out：自由轉貨行是 MISC 虛擬 SKU + 估價、無真 SKU 可查價
+--     → 兩個口徑同用 transfer_items.estimated_amount（unit_branch_price = 0）。
+--   「無活動 skip」判斷擴成兩口徑皆 0 才 skip：0 成本入庫（防呆前舊資料）
+--   但分店價有值的月份不會被誤刪。
+--
+-- 既有資料回填：
+--   - header cost_amount 回填 = payable_amount（舊算法即成本口徑）。
+--   - items 為 append-only（forbid_append_only_mutation），不回填；
+--     draft 重跑生成器即補齊，confirmed/settled 維持原樣（branch 欄為 0）。
+--
+-- 基底版本：rpc_generate_hq_to_store_settlement = 20260714000100（線上現行）；
+--   逐字複製僅追加分店價口徑欄位與計算。
+-- Rollback：
+--   CREATE OR REPLACE 回 20260714000100 版本；
+--   DROP FUNCTION public._branch_price_at(UUID, BIGINT, TIMESTAMPTZ);
+--   新欄位可留（無害），或
+--   ALTER TABLE store_monthly_settlements DROP COLUMN cost_amount, DROP COLUMN branch_amount;
+--   ALTER TABLE store_monthly_settlement_items DROP COLUMN unit_branch_price, DROP COLUMN branch_amount;
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. 主檔加雙口徑總額
+-- ------------------------------------------------------------
+ALTER TABLE public.store_monthly_settlements
+  ADD COLUMN IF NOT EXISTS cost_amount   NUMERIC(18,4) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS branch_amount NUMERIC(18,4) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN store_monthly_settlements.cost_amount IS
+  '成本價口徑總額（出貨當下 movement.unit_cost；自由轉貨以估價計）— 與 payable_amount 同基準';
+COMMENT ON COLUMN store_monthly_settlements.branch_amount IS
+  '分店價口徑總額（prices scope=branch 收貨當下生效價；自由轉貨以估價計）';
+
+-- 既有資料回填：舊 payable_amount 即成本口徑
+UPDATE public.store_monthly_settlements
+   SET cost_amount = payable_amount
+ WHERE cost_amount = 0
+   AND payable_amount <> 0;
+
+-- ------------------------------------------------------------
+-- 2. 明細加分店價欄位
+-- ------------------------------------------------------------
+ALTER TABLE public.store_monthly_settlement_items
+  ADD COLUMN IF NOT EXISTS unit_branch_price NUMERIC(18,4) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS branch_amount     NUMERIC(18,4) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN store_monthly_settlement_items.unit_branch_price IS
+  '分店價單價（收貨當下生效的 prices scope=branch 快照）；自由轉貨行為 0';
+COMMENT ON COLUMN store_monthly_settlement_items.branch_amount IS
+  '分店價口徑行金額（正負號同 line_amount）；自由轉貨行 = ±estimated_amount';
+
+-- ------------------------------------------------------------
+-- 3. helper：取指定時點生效的分店價
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._branch_price_at(
+  p_tenant UUID,
+  p_sku_id BIGINT,
+  p_at     TIMESTAMPTZ
+) RETURNS NUMERIC
+LANGUAGE sql STABLE
+AS $$
+  SELECT COALESCE(
+    -- p_at 時點生效的版本
+    (SELECT pr.price
+       FROM public.prices pr
+      WHERE pr.tenant_id    = p_tenant
+        AND pr.sku_id       = p_sku_id
+        AND pr.scope        = 'branch'
+        AND pr.scope_id     IS NULL
+        AND pr.price        > 0
+        AND pr.effective_from <= p_at
+        AND (pr.effective_to IS NULL OR pr.effective_to > p_at)
+      ORDER BY pr.effective_from DESC
+      LIMIT 1),
+    -- fallback：現行價（收貨早於首次設價的舊資料）
+    (SELECT pr.price
+       FROM public.prices pr
+      WHERE pr.tenant_id    = p_tenant
+        AND pr.sku_id       = p_sku_id
+        AND pr.scope        = 'branch'
+        AND pr.scope_id     IS NULL
+        AND pr.price        > 0
+        AND pr.effective_to IS NULL
+      ORDER BY pr.effective_from DESC
+      LIMIT 1)
+  )
+$$;
+
+COMMENT ON FUNCTION public._branch_price_at(UUID, BIGINT, TIMESTAMPTZ) IS
+  '取 p_at 時點生效的分店價（prices scope=branch, scope_id NULL, price>0）；'
+  '該時點查無則 fallback 現行價；再無則 NULL。月結雙口徑計算用。';
+
+-- ------------------------------------------------------------
+-- 4. rpc_generate_hq_to_store_settlement — 雙口徑計算
+--    基底 20260714000100 逐字保留，追加分店價口徑。
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_generate_hq_to_store_settlement(
+  p_month    DATE,
+  p_operator UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant         UUID;
+  v_month_start    DATE := DATE_TRUNC('month', p_month)::DATE;
+  v_month_end      DATE := (DATE_TRUNC('month', p_month) + INTERVAL '1 month')::DATE;
+  v_store          RECORD;
+  v_settlement_id  BIGINT;
+  v_hq_inbound     NUMERIC(18,4);
+  v_air_in         NUMERIC(18,4);
+  v_air_out        NUMERIC(18,4);
+  v_free_in        NUMERIC(18,4);
+  v_free_out       NUMERIC(18,4);
+  v_return_out     NUMERIC(18,4);
+  v_hq_inbound_b   NUMERIC(18,4);  -- 分店價口徑
+  v_air_in_b       NUMERIC(18,4);
+  v_air_out_b      NUMERIC(18,4);
+  v_return_out_b   NUMERIC(18,4);
+  v_payable        NUMERIC(18,4);
+  v_branch_total   NUMERIC(18,4);
+  v_xfer_count     INTEGER;
+  v_item_count     INTEGER;
+  v_total_stores   INTEGER := 0;
+  v_total_amount   NUMERIC(18,4) := 0;
+  v_total_branch   NUMERIC(18,4) := 0;
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM stores LIMIT 1;
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'no stores found, cannot infer tenant_id';
+  END IF;
+
+  FOR v_store IN
+    SELECT s.id, s.code, s.name, s.location_id
+      FROM stores s
+     WHERE s.tenant_id = v_tenant
+       AND s.location_id IS NOT NULL
+  LOOP
+    -- 跳過已 confirmed/settled
+    IF EXISTS (
+      SELECT 1 FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status IN ('confirmed','settled')
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    -- A) hq_inbound: 從 HQ 收貨（成本口徑 + 分店價口徑）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_hq_inbound, v_hq_inbound_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- B) air_in: 空中轉收進來（該店是 dest）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_air_in, v_air_in_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- C) air_out: 空中轉送出去（該店是 source）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_air_out, v_air_out_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- D) free_in: 自由轉貨收進來（該店是 dest；無訂單 FK；估價入帳、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_in
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out: 自由轉貨送出去（該店是 source；估價入帳、貸記、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_out
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out: 退貨回總倉（該店是 source、總倉已收；沖回）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_return_out, v_return_out_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    v_payable      := v_hq_inbound   + v_air_in   - v_air_out   + v_free_in - v_free_out - v_return_out;
+    v_branch_total := v_hq_inbound_b + v_air_in_b - v_air_out_b + v_free_in - v_free_out - v_return_out_b;
+
+    -- 沒任何活動就 skip + 砍 draft（兩口徑皆 0 才算無活動）
+    IF v_hq_inbound = 0 AND v_air_in = 0 AND v_air_out = 0
+       AND v_free_in = 0 AND v_free_out = 0 AND v_return_out = 0
+       AND v_hq_inbound_b = 0 AND v_air_in_b = 0 AND v_air_out_b = 0
+       AND v_return_out_b = 0 THEN
+      DELETE FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status = 'draft';
+      CONTINUE;
+    END IF;
+
+    -- 計 transfer_count + item_count
+    SELECT
+      COUNT(DISTINCT t.id), COUNT(ti.id)
+      INTO v_xfer_count, v_item_count
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.status IN ('received','closed')
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0
+       AND (
+         (t.transfer_type = 'hq_to_store' AND t.dest_location = v_store.location_id)
+         OR
+         (t.transfer_type = 'store_to_store'
+          AND (t.dest_location = v_store.location_id OR t.source_location = v_store.location_id))
+         OR
+         (t.transfer_type = 'return_to_hq' AND t.source_location = v_store.location_id)
+       );
+
+    -- upsert (draft only)
+    INSERT INTO store_monthly_settlements (
+      tenant_id, settlement_month, store_id,
+      payable_amount, cost_amount, branch_amount,
+      transfer_count, item_count,
+      status, created_by, updated_by
+    ) VALUES (
+      v_tenant, v_month_start, v_store.id,
+      v_payable, v_payable, v_branch_total,
+      v_xfer_count, v_item_count,
+      'draft', p_operator, p_operator
+    )
+    ON CONFLICT (tenant_id, settlement_month, store_id)
+    DO UPDATE SET
+      payable_amount = EXCLUDED.payable_amount,
+      cost_amount    = EXCLUDED.cost_amount,
+      branch_amount  = EXCLUDED.branch_amount,
+      transfer_count = EXCLUDED.transfer_count,
+      item_count     = EXCLUDED.item_count,
+      updated_by     = p_operator,
+      updated_at     = NOW()
+    WHERE store_monthly_settlements.status = 'draft'
+    RETURNING id INTO v_settlement_id;
+
+    -- 重建 items
+    DELETE FROM store_monthly_settlement_items WHERE settlement_id = v_settlement_id;
+
+    -- A) hq_inbound items
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      ti.qty_received * COALESCE(sm.unit_cost, 0),
+      t.received_at, 'hq_inbound',
+      bp.p, ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- B) air_in items
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      ti.qty_received * COALESCE(sm.unit_cost, 0),
+      t.received_at, 'air_in',
+      bp.p, ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- C) air_out items（兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      -1 * ti.qty_received * COALESCE(sm.unit_cost, 0),  -- 負值
+      t.received_at, 'air_out',
+      bp.p, -1 * ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- D) free_in items（估價入帳、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      COALESCE(ti.estimated_amount, 0),
+      t.received_at, 'free_in', ti.description,
+      0, COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out items（估價入帳、負值、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      -1 * COALESCE(ti.estimated_amount, 0),  -- 負值
+      t.received_at, 'free_out', ti.description,
+      0, -1 * COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out items（沖回、兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      -1 * ti.qty_received * COALESCE(sm.unit_cost, 0),  -- 負值
+      t.received_at, 'return_out',
+      bp.p, -1 * ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    v_total_stores := v_total_stores + 1;
+    v_total_amount := v_total_amount + v_payable;
+    v_total_branch := v_total_branch + v_branch_total;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'month',               to_char(v_month_start, 'YYYY-MM'),
+    'stores_count',        v_total_stores,
+    'total_amount',        v_total_amount,
+    'total_cost_amount',   v_total_amount,
+    'total_branch_amount', v_total_branch
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_generate_hq_to_store_settlement IS
+  'HQ→店月結算（雙價格口徑）：每筆分錄同時計成本價（movement.unit_cost）與'
+  '分店價（prices scope=branch 收貨當下生效價）兩口徑，分開累計到 '
+  'cost_amount / branch_amount。payable = 成本口徑（hq_inbound + air_in - air_out '
+  '+ free_in - free_out - return_out）；自由轉貨兩口徑同用估價。'
+  '已 confirmed/settled 不重算。';


### PR DESCRIPTION
- store_monthly_settlements 加 cost_amount / branch_amount 兩欄，
  兩個口徑分開累計；payable_amount 語義不變（成本口徑、入應收金額不受影響）
- store_monthly_settlement_items 每行加 unit_branch_price / branch_amount
- 新 helper _branch_price_at：取收貨當下生效的分店價（prices scope=branch），
  查無 fallback 現行價
- rpc_generate_hq_to_store_settlement（基底 20260714000100）六種分錄
  全部雙口徑計算；自由轉貨兩口徑同用估價；「無活動 skip」擴成兩口徑皆 0
- 既有 header cost_amount 回填 = payable_amount；draft 重跑即補 items
- 月結頁/對帳單列印頁：成本單價/成本小計/分店單價/分店小計並列、
  雙口徑合計、口徑差額（總部毛利）；列印頁順帶補 #524 漏掉的
  free/return 類型標籤與描述顯示

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ShYzK6BhcdGMBPr1qdi2V9