### PR TITLE
派貨工作台:已派量納入補貨直派+需求派完自動下架

### DIFF
--- a/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
@@ -26,7 +26,7 @@ type DemandRow = {
   demand_qty: number;
   wave_qty: number;
   shipped_qty: number;
-  // per (po, sku) 跨 store 已撿真值（與 RPC 守衛對齊）。
+  // per (po, sku) 跨 store 已派真值（wave ＋ 補貨直派 transfer，與 RPC 守衛對齊）。
   // 同 (po, sku) 各 row 共享同值；NULL fallback 給未套 migration 環境。
   po_sku_already_wave?: number | null;
 };
@@ -40,8 +40,9 @@ type SkuRow = {
   totalGr: number;
   totalAlreadyWave: number;
   totalAvailable: number;
+  demandLeft: number;              // 各店未派需求加總 = Σ max(0, demand − wave)
   storeDemand: Map<number, number>;
-  storeWave: Map<number, number>;  // 每店「已撿」量（wave_qty）
+  storeWave: Map<number, number>;  // 每店「已派」量（wave_qty，含補貨直派）
 };
 
 export default function PrintPickListPage() {
@@ -96,6 +97,7 @@ export default function PrintPickListPage() {
           totalGr: 0,
           totalAlreadyWave: 0,
           totalAvailable: 0,
+          demandLeft: 0,
           storeDemand: new Map(),
           storeWave: new Map(),
         };
@@ -106,8 +108,9 @@ export default function PrintPickListPage() {
         poSkuSeen.add(poSkuKey);
         s.totalOrdered += Number(r.qty_ordered);
         s.totalGr += Number(r.gr_qty);
-        // 用 view 新欄位 po_sku_already_wave：per (po, sku) 跨 store 真值，
-        // 與 RPC 守衛 SUM(pwi) 對齊。fallback 給未套 migration 的本地環境（會偏低）。
+        // 用 view 欄位 po_sku_already_wave：per (po, sku) 跨 store 已派真值
+        // （wave ＋ 補貨直派 transfer），與 RPC 守衛對齊。
+        // fallback 給未套 migration 的本地環境（會偏低）。
         s.totalAlreadyWave += Number(r.po_sku_already_wave ?? 0);
       }
       s.storeDemand.set(r.store_id, (s.storeDemand.get(r.store_id) ?? 0) + Number(r.demand_qty));
@@ -115,13 +118,18 @@ export default function PrintPickListPage() {
     }
     for (const s of skuMap.values()) {
       s.totalAvailable = Math.max(0, s.totalGr - s.totalAlreadyWave);
+      // 各店未派需求 = Σ max(0, demand − wave)；wave 已含補貨直派 → 派完(含直派)的品項不再列印
+      for (const [storeId, d] of s.storeDemand) {
+        s.demandLeft += Math.max(0, d - (s.storeWave.get(storeId) ?? 0));
+      }
     }
     const stores = Array.from(storeMap.values()).sort((a, b) =>
       (a.store_code ?? "").localeCompare(b.store_code ?? "")
     );
     const skuRows = Array.from(skuMap.values())
-      // 隱藏「已到貨且全部撿完」的 SKU
-      .filter((s) => !(s.totalGr > 0 && s.totalAvailable === 0))
+      // 隱藏「已到貨且全部派完」與「需求已全數派完（含補貨直派）」的 SKU —
+      // 與派貨工作台矩陣的 has_stock_left + has_demand_left 過濾同語意
+      .filter((s) => !(s.totalGr > 0 && s.totalAvailable === 0) && s.demandLeft > 0)
       .sort((a, b) => (a.sku_code ?? "").localeCompare(b.sku_code ?? ""));
     return { skuRows, stores };
   }, [demand]);
@@ -220,7 +228,7 @@ export default function PrintPickListPage() {
                 <tr>
                   <th className="frozen-col">訂購</th>
                   <th className="frozen-col">已到</th>
-                  <th className="frozen-col">已撿</th>
+                  <th className="frozen-col">已派</th>
                   <th className="frozen-col">可分配</th>
                   {stores.map((s) => (
                     <th key={s.store_id} className="store-col">

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -32,9 +32,11 @@ type DemandRow = {
   wave_qty: number;
   shipped_qty: number;
   is_restock_sourced?: boolean;
-  // per (po_id, sku_id) 跨 store 已撿真值（與 RPC 守衛對齊）。
+  // per (po_id, sku_id) 跨 store 已派真值（wave ＋ 補貨直派 transfer，與 RPC 守衛對齊）。
   // 同 (po, sku) 各 row 共享同值；NULL fallback 給未套 migration 的本地環境（會偏低，但不會 crash）。
   po_sku_already_wave?: number | null;
+  // per (po_id, sku_id) 是否還有任一分店「需求 > 已派」。矩陣視角 server-side 過濾用。
+  has_demand_left?: boolean;
 };
 
 type Supplier = { id: number; code: string; name: string };
@@ -102,10 +104,13 @@ export default function PickingWorkstationPage() {
         // .order() 給分頁一個穩定的 total order（否則跨頁可能漏/重複列）。
         // 矩陣視角只需可分配列 → .eq("has_stock_left", true)：線上 12,240 列 → ~37 列，
         // 13 趟分頁 → 1 趟，解決「派貨工作台讀取不出來」。
+        // 再疊 .eq("has_demand_left", true)：需求全派完（含補貨直派、門市已收貨）的
+        // 列自動下架 — 補貨帶囤貨的 PO（訂 51 件、需求 1 件）不再永遠掛在工作台。
         const [dRows, supRows, rrRows] = await Promise.all([
           fetchAllRows<DemandRow>(() =>
             sb.from("v_picking_demand_by_po").select("*")
               .eq("has_stock_left", true)
+              .eq("has_demand_left", true)
               .order("po_item_id", { ascending: true })
               .order("store_id", { ascending: true, nullsFirst: false }),
           ),
@@ -360,8 +365,9 @@ export default function PickingWorkstationPage() {
           qty_ordered: Number(r.qty_ordered),
           qty_in_transit: inTransit,
           qty_shortage: shortage,
-          // 用 view 新欄位 po_sku_already_wave：per (po, sku) 跨 store 真值，
-          // 與 RPC 守衛 SUM(pwi) 對齊。fallback 給未套 migration 的本地環境（會偏低）。
+          // 用 view 欄位 po_sku_already_wave：per (po, sku) 跨 store 已派真值
+          // （wave ＋ 補貨直派 transfer），與 RPC 守衛對齊。
+          // fallback 給未套 migration 的本地環境（會偏低）。
           already_wave_for_sku: Number(r.po_sku_already_wave ?? 0),
           is_restock_sourced: !!r.is_restock_sourced,
         });
@@ -446,24 +452,25 @@ export default function PickingWorkstationPage() {
     });
   }, [restockDemand]);
 
-  // 預設分配 = max(0, demand - wave - shipped) per (sku, store)
+  // 預設分配 = max(0, demand - wave) per (sku, store)
+  // wave_qty 已含撿貨單與補貨直派 transfer（不論是否已收貨），
+  // shipped 是 wave 的子集合（已收貨的部分），再減會重複扣 → 不減。
   useEffect(() => {
     if (!demand) return;
     setAllocs((prev) => {
       const next = new Map(prev);
-      const agg = new Map<AllocKey, { demand: number; wave: number; shipped: number }>();
+      const agg = new Map<AllocKey, { demand: number; wave: number }>();
       for (const r of demand) {
         if (r.store_id === null) continue;
         const k: AllocKey = `${r.sku_id}:${r.store_id}`;
-        const slot = agg.get(k) ?? { demand: 0, wave: 0, shipped: 0 };
+        const slot = agg.get(k) ?? { demand: 0, wave: 0 };
         slot.demand += Number(r.demand_qty);
         slot.wave += Number(r.wave_qty);
-        slot.shipped += Number(r.shipped_qty);
         agg.set(k, slot);
       }
       for (const [k, v] of agg.entries()) {
         if (!next.has(k)) {
-          next.set(k, Math.max(0, v.demand - v.wave - v.shipped));
+          next.set(k, Math.max(0, v.demand - v.wave));
         }
       }
       return next;
@@ -505,8 +512,15 @@ export default function PickingWorkstationPage() {
     for (const st of allStores) sum += getAlloc(skuRow.sku_id, st.store_id);
     return sum;
   }
-  // 「⚖ 平均」自動分配:把 totalAvailable 平均分到「需求 > 0」的店,cap 在各店 demand。
-  // 若有店 demand 不足分到的份額,剩餘量會在下一輪重新平均。
+  // 各店尚未派的需求 = max(0, demand − wave)。wave 已含撿貨單與補貨直派。
+  function storeDemandLeft(sku: SkuRow, storeId: number): number {
+    return Math.max(
+      0,
+      (sku.storeDemand.get(storeId) ?? 0) - (sku.storeWave.get(storeId) ?? 0),
+    );
+  }
+  // 「⚖ 平均」自動分配:把 totalAvailable 平均分到「未派需求 > 0」的店,cap 在各店未派需求。
+  // 若有店需求不足分到的份額,剩餘量會在下一輪重新平均。
   function autoDistribute(sku: SkuRow) {
     const stores = allStores;
     let pool = sku.totalAvailable;
@@ -514,22 +528,20 @@ export default function PickingWorkstationPage() {
     for (const s of stores) give.set(s.store_id, 0);
     for (let iter = 0; iter < 10 && pool > 0; iter += 1) {
       const eligible = stores.filter((s) => {
-        const d = sku.storeDemand.get(s.store_id) ?? 0;
+        const d = storeDemandLeft(sku, s.store_id);
         const cur = give.get(s.store_id) ?? 0;
         return cur < d;
       });
       if (eligible.length === 0) break;
       const base = Math.floor(pool / eligible.length);
       if (base === 0) {
-        // pool < eligible 數量,依 demand 大小排序給 +1
+        // pool < eligible 數量,依未派需求大小排序給 +1
         const sorted = [...eligible].sort(
-          (a, b) =>
-            (sku.storeDemand.get(b.store_id) ?? 0) -
-            (sku.storeDemand.get(a.store_id) ?? 0),
+          (a, b) => storeDemandLeft(sku, b.store_id) - storeDemandLeft(sku, a.store_id),
         );
         for (let i = 0; i < pool && i < sorted.length; i += 1) {
           const s = sorted[i];
-          const d = sku.storeDemand.get(s.store_id) ?? 0;
+          const d = storeDemandLeft(sku, s.store_id);
           const cur = give.get(s.store_id) ?? 0;
           if (cur < d) give.set(s.store_id, cur + 1);
         }
@@ -538,7 +550,7 @@ export default function PickingWorkstationPage() {
       }
       let givenThisRound = 0;
       for (const s of eligible) {
-        const d = sku.storeDemand.get(s.store_id) ?? 0;
+        const d = storeDemandLeft(sku, s.store_id);
         const cur = give.get(s.store_id) ?? 0;
         const add = Math.min(base, d - cur);
         give.set(s.store_id, cur + add);
@@ -859,7 +871,7 @@ export default function PickingWorkstationPage() {
         <div>
           <h1 className="text-xl font-semibold">🚦 派貨工作台</h1>
           <p className="text-sm text-zinc-500">
-            合併所有未派完 PO 為一張矩陣 — 直接針對 品項 × 分店分配,提交時依 PO 自動切分。包含客戶訂單派貨與補貨申請(📦)。
+            合併所有還有分店需求未派的 PO 為一張矩陣 — 直接針對 品項 × 分店分配,提交時依 PO 自動切分。包含客戶訂單派貨與補貨申請(📦);需求派完的品項會自動下架。
           </p>
         </div>
         <Link
@@ -968,7 +980,7 @@ export default function PickingWorkstationPage() {
       ) : viewMode === "matrix" ? (
         skuRows.length === 0 ? (
           <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
-            目前沒有可分配的品項(已到貨的都派完了,在途的等收貨後再回來)。
+            目前沒有待派的品項(該派的都派完了;在途的等收貨後、新需求進來後會自動回來)。
           </div>
         ) : (
           // 只保留水平(左右)捲軸:拿掉高度上限,表格整高展開、跟著整頁一起垂直捲動,
@@ -1006,7 +1018,7 @@ export default function PickingWorkstationPage() {
                   <Th className="text-center">已到</Th>
                   <Th className="text-center" title="PO 還沒結、還會繼續到的數量">在途</Th>
                   <Th className="text-center" title="PO 結了但供應商少給的數量(永遠不會到)">短少</Th>
-                  <Th className="text-center">已撿</Th>
+                  <Th className="text-center" title="已派出的數量(含撿貨單與補貨直派)">已派</Th>
                   <Th className="text-center">可分配</Th>
                   <Th className="text-center">合計</Th>
                   {allStores.map((st) => (
@@ -1057,7 +1069,7 @@ export default function PickingWorkstationPage() {
                             type="button"
                             onClick={() => autoDistribute(sk)}
                             disabled={sk.totalAvailable === 0}
-                            title={`依可分配 ${sk.totalAvailable} 平均分到各店(cap 在各店需求量)`}
+                            title={`依可分配 ${sk.totalAvailable} 平均分到各店(cap 在各店未派需求量)`}
                             className="shrink-0 self-center rounded border border-blue-300 bg-blue-50 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 hover:bg-blue-100 disabled:opacity-40 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
                           >
                             ⚖ 平均
@@ -1089,6 +1101,7 @@ export default function PickingWorkstationPage() {
                       {allStores.map((st) => {
                         const value = getAlloc(sk.sku_id, st.store_id);
                         const demandQty = sk.storeDemand.get(st.store_id) ?? 0;
+                        const demandLeft = storeDemandLeft(sk, st.store_id);
                         const maxForCell = value + Math.max(0, sk.totalAvailable - allocSum);
                         return (
                           <td key={st.store_id} className="px-2 py-1.5 text-center align-top">
@@ -1099,14 +1112,21 @@ export default function PickingWorkstationPage() {
                               min={0}
                               max={maxForCell}
                               step={1}
-                              title={`需 ${demandQty} · 此格最多可填 ${maxForCell}`}
+                              title={`未派需求 ${demandLeft}（原始需求 ${demandQty}）· 此格最多可填 ${maxForCell}`}
                               className={`w-full max-w-[68px] rounded border px-1 py-0.5 text-center font-mono text-sm font-medium tabular-nums dark:bg-zinc-800 ${
                                 value === 0
                                   ? "border-zinc-200 text-zinc-300 dark:border-zinc-700"
                                   : "border-blue-300 text-blue-700 dark:border-blue-700 dark:text-blue-300"
                               }`}
                             />
-                            <div className="mt-0.5 text-[10px] text-zinc-400">需 {demandQty}</div>
+                            {/* 需 = 尚未派的需求（demand − 已派，含補貨直派）；派完顯示 ✓，別再邀請使用者重複派 */}
+                            <div className="mt-0.5 text-[10px] text-zinc-400">
+                              {demandLeft > 0
+                                ? `需 ${demandLeft}`
+                                : demandQty > 0
+                                  ? <span className="text-emerald-600 dark:text-emerald-500">✓ 已派</span>
+                                  : "需 0"}
+                            </div>
                           </td>
                         );
                       })}

--- a/docs/TEST-picking-dispatched-demand-left.md
+++ b/docs/TEST-picking-dispatched-demand-left.md
@@ -1,0 +1,88 @@
+---
+title: TEST — 派貨工作台：已派量納入補貨直派 + 需求派完自動下架
+module: WMS / Picking workstation
+status: verified (SQL on live)
+ran_at: 2026-07-13
+verified_by: Claude (session)
+---
+
+# 派貨工作台：已派量納入補貨直派 + 需求派完自動下架
+
+## 背景
+
+使用者截圖回報（PO2607070725 / PO2607070726，品項掛 📦補貨標籤）：
+
+> 已經派貨跟收貨 但是工作台一直顯示
+
+線上還原事實鏈（RR-51 / RR-53，龍潭店，各 SKU 申請 1 件）：
+
+1. 補貨申請 → PR#81/#82 → PO#409/#410。採購時數量加碼囤總倉
+   （PR 訂 51 / 101 / 11 / 21 … 全部尾數 1 = 補貨 1 件 + 整數囤貨量）。
+2. PO 全數到貨（fully_received）。
+3. 07-13 03:13–03:40：使用者在派貨工作台對龍潭店連建 **7 輪 1 件的 wave**
+   （因為「需 1」一直掛著、列一直不消失）。
+4. 07-13 03:41：又走收件匣「派貨」→ `rpc_ship_restock_pr_received` 建直派
+   transfer TR2607130188/0189（各 SKU 1 件）→ 門市收貨 → RR 變 `received`。
+5. 工作台矩陣**仍然顯示**這些品項，可分配 44 / 94 / 4 / 14。
+   同一筆 1 件的補貨，實際出了 8–9 次貨。
+
+## 根因（兩個）
+
+1. **補貨直派沒被算進「已派」**：`v_picking_demand_by_po` 的 per-store
+   `wave_qty` 有算 `rr.linked_transfer_id` 直派分支（20260611000020），但
+   per (po,sku) 的 `po_sku_already_wave` 與 `rpc_create_wave_from_po` 第 4 步
+   守衛都只算 `picking_wave_items` → 「可分配」比總倉真實庫存多
+   （G00100-01：view 說可分配 4、總倉 on_hand 只有 3）→ 有超派風險。
+2. **矩陣顯示條件純庫存驅動**：`has_stock_left = gr > 已撿`，且格子「需 N」
+   顯示原始 `demand_qty`、不扣已派量。補貨帶囤貨的 PO 永遠 gr > 已撿 →
+   列永遠不消失、「需 1」永遠掛著 → 邀請使用者重複派貨。
+
+## 修法
+
+| 改動 | 檔案 |
+|---|---|
+| view `po_sku_already_wave` 加 UNION 分支（補貨直派 transfer，與 per-store wave_qty 第二分支同構）；尾端新增 `has_demand_left`（逐店 GREATEST(0, demand−wave) 加總 > 0） | `supabase/migrations/20260715000010_picking_dispatched_includes_direct_transfer_and_demand_left.sql` |
+| `rpc_create_wave_from_po` 第 4 步守衛 already_wave 同步加直派量（view / RPC 對齊原則見 docs/TEST-picking-already-wave-fix.md） | 同上 |
+| 矩陣視角 fetch 疊 `.eq("has_demand_left", true)`；格子「需」改顯示未派需求（demand−wave，派完顯示 ✓ 已派）；「⚖ 平均」cap 改未派需求；預設分配改 max(0, demand−wave)（shipped 是 wave 子集合、不再重複扣）；「已撿」欄改名「已派」 | `apps/admin/src/app/(protected)/wms/picking/page.tsx` |
+| 列印撿貨清單：加 `demandLeft` 過濾（與矩陣同語意）、「已撿」欄改名「已派」 | `apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx` |
+
+## 驗證（線上 SQL，2026-07-13）
+
+### A. 回報的 PO：已派補上直派量、需求派完 → 下架
+
+```sql
+SELECT po_no, sku_code, gr_qty, po_sku_already_wave, has_stock_left, has_demand_left
+FROM v_picking_demand_by_po
+WHERE po_id IN (409,410)
+GROUP BY 1,2,3,4,5,6;
+```
+
+結果：8 個 SKU 全部 `po_sku_already_wave` +1（例 F00005-01：7→8，
+可分配 44→43 = 總倉 on_hand），全部 `has_demand_left = false`
+→ 矩陣、列印清單都不再顯示。✅
+
+### B. 矩陣只剩真正待派的品項
+
+```sql
+SELECT COUNT(DISTINCT (po_id, sku_id)) FROM v_picking_demand_by_po
+WHERE has_stock_left AND has_demand_left;
+```
+
+40 →（套 demand filter 後）**8** 個 (PO×SKU)，逐筆抽查全部
+demand_sum > wave_sum 且有庫存 — 沒有誤藏。✅
+
+### C. RPC 守衛已納入直派
+
+```sql
+SELECT pg_get_functiondef('public.rpc_create_wave_from_po(bigint,date,jsonb,uuid)'::regprocedure)
+       LIKE '%linked_transfer_id%';  -- true ✅
+```
+
+## 已知殘留（follow-up，不在本修範圍）
+
+- **收件匣直派路徑不知道 wave 已派過**：`rpc_ship_restock_pr_received` 照
+  restock lines 全量建 transfer，不扣已透過工作台 wave 派出的量。工作台這頭
+  修好後（派完就下架），反向的重複派貨入口只剩收件匣「派貨」鈕 — 該 RPC
+  應改成只派「申請量 − 已 wave 量」或全派完時直接擋下。
+- 「依分店（檢視）」分頁維持完整清單（含已派完的列，有 已撿/已派 進度欄），
+  未套 demand filter — 屬檢視性質，保留全貌。

--- a/docs/TEST-picking-dispatched-demand-left.md
+++ b/docs/TEST-picking-dispatched-demand-left.md
@@ -78,11 +78,30 @@ SELECT pg_get_functiondef('public.rpc_create_wave_from_po(bigint,date,jsonb,uuid
        LIKE '%linked_transfer_id%';  -- true ✅
 ```
 
-## 已知殘留（follow-up，不在本修範圍）
+## D. 補貨重複派貨守衛（20260715000020，同日追加）
 
-- **收件匣直派路徑不知道 wave 已派過**：`rpc_ship_restock_pr_received` 照
-  restock lines 全量建 transfer，不扣已透過工作台 wave 派出的量。工作台這頭
-  修好後（派完就下架），反向的重複派貨入口只剩收件匣「派貨」鈕 — 該 RPC
-  應改成只派「申請量 − 已 wave 量」或全派完時直接擋下。
+三個出貨入口全改成「只派剩餘量、派完就擋」，歸屬原則：
+「已派給此補貨」= campaign_id IS NULL 的 wave items（補貨 justification）
+＋ 補貨直派 transfer；campaign_id 非 NULL 的 wave 屬客戶訂單、不抵補貨。
+
+| 入口 | 改動 |
+|---|---|
+| `rpc_ship_restock_pr_received`（收件匣「派貨」直派） | 逐 line 只出「申請量 − 已 wave 量」；全部為 0 → RAISE「已全數透過撿貨單派出」 |
+| `rpc_create_wave_from_po`（工作台矩陣） | 補貨 justification 的分配加上限 = 剩餘補貨需求（申請 − wave(campaign NULL) − 直派）；要多推庫存 → 引導走內部調撥 |
+| `rpc_create_wave_from_restock`（amber 區塊） | 守衛改累計：單次分配 ≤ 申請量 − 該申請已 wave 量 |
+
+### 驗證（線上，2026-07-13）
+
+- 對已派完的 RR-51 品項再從矩陣派 1 件（PO#409 / F00005-01 / 龍潭店）：
+  RAISE「補貨需求只剩 0 件未派（申請 1、已派 8，含撿貨單與直派），本次分配 1
+  超過」，且無殘留 wave（PO#409 wave 數維持 7）。✅
+- 模擬 `rpc_ship_restock_pr_received` 對 RR-51 的逐 line 計算：全部
+  would_ship = 0 → 會 RAISE、不再重複直派。✅
+- `pg_get_functiondef` 確認三支函式皆為新版（waved_agg / v_ship_qty）。✅
+
+## 設計取捨備忘
+
 - 「依分店（檢視）」分頁維持完整清單（含已派完的列，有 已撿/已派 進度欄），
   未套 demand filter — 屬檢視性質，保留全貌。
+- 龍潭店已多收的 7–8 件貨（重複派貨造成、已入店庫存）屬營運資料，
+  需人工決定調撥回總倉或留店銷售 — 程式端不代為沖帳。

--- a/supabase/migrations/20260715000010_picking_dispatched_includes_direct_transfer_and_demand_left.sql
+++ b/supabase/migrations/20260715000010_picking_dispatched_includes_direct_transfer_and_demand_left.sql
@@ -1,0 +1,504 @@
+-- ============================================================
+-- 派貨工作台：已派量納入補貨直派 transfer + 新增 has_demand_left（需求派完就下架）
+--
+-- 使用者回報（截圖 PO2607070725 / PO2607070726）：
+--   補貨申請（RR-51 / RR-53，各 SKU 申請 1 件）已經派貨、門市也收貨了，
+--   但派貨工作台矩陣「一直顯示」這些品項，「需 1」也一直掛著。
+--   使用者因此對同一筆 1 件的補貨重複建單 — 線上實際查到龍潭店被派了
+--   7 張 1 件的 wave ＋ 1 張補貨直派 transfer（TR2607130189），同一需求出了 9 次貨。
+--
+-- 根因（兩個）：
+--   1) 補貨直派沒被算進「已派」：
+--      rpc_ship_restock_pr_received 走 restock_requests.linked_transfer_id 直接建
+--      hq_to_store transfer，不經 picking_waves。view 的 per-store wave_qty 有算
+--      這條路（20260611000020 加的 UNION 分支），但 per (po,sku) 的
+--      po_sku_already_wave 與 rpc_create_wave_from_po 的守衛都只算
+--      picking_wave_items → 「可分配」比總倉真實庫存多（例：G00100-01 view 說
+--      可分配 4、總倉 on_hand 只有 3），有超派風險。
+--   2) 矩陣的顯示條件是純庫存驅動（has_stock_left = gr > 已撿）：
+--      補貨帶囤貨的 PO（訂 51 件、補貨需求只有 1 件，其餘囤總倉）永遠
+--      gr > 已撿 → 列永遠不消失；且格子的「需 N」顯示原始 demand_qty、
+--      不扣已派量 → 邀請使用者重複派貨。
+--
+-- 修法：
+--   A) po_sku_already_wave 加 UNION ALL 分支：補貨直派 transfer
+--      （rr.linked_transfer_id → transfer_items.qty_requested，歸屬到
+--      linked_pr → po_item 的 PO），與 per-store wave_qty 的第二分支完全同構。
+--      has_stock_left 隨之變成 gr > (wave + 直派)。
+--   B) view 尾端新增布林欄 has_demand_left：per (po,sku) 是否還有任一分店
+--      「需求 > 已派」（demand_qty − wave_qty per store，floor 0 後加總 > 0）。
+--      前端矩陣視角改抓 has_stock_left AND has_demand_left → 需求派完
+--      （含門市已收貨）的列自動下架，總倉囤貨不再永遠掛在工作台。
+--   C) rpc_create_wave_from_po 第 4 步守衛的 already_wave 同步加上直派量，
+--      與 view 對齊（對齊原則見 docs/TEST-picking-already-wave-fix.md —
+--      view 與 RPC 守衛不同步就會出現「UI 說可以、送出被擋」）。
+--
+-- CREATE OR REPLACE VIEW 限制：既有欄位順序/型別不可動，新欄位只能加在尾端；
+-- has_demand_left 放在 has_stock_left 之後（最後一欄）。
+--
+-- 基於：
+--   view — 20260709000000_v_picking_demand_has_stock_left.sql（最新版）
+--   rpc_create_wave_from_po — 20260702000000_wave_from_po_campaign_scoped.sql（最新版）
+-- Rollback：
+--   view — CREATE OR REPLACE 回 20260709000000 版本（新欄位無法 drop，改回
+--          恆為 gr>wave 的舊語意即可；或 DROP VIEW 後用 20260709000000 重建）
+--   rpc  — CREATE OR REPLACE 回 20260702000000 版本
+-- TEST: docs/TEST-picking-dispatched-demand-left.md
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.v_picking_demand_by_po AS
+WITH po_skus AS (
+  SELECT
+    po.id            AS po_id,
+    po.tenant_id,
+    po.po_no,
+    po.status        AS po_status,
+    po.supplier_id,
+    poi.id           AS po_item_id,
+    poi.sku_id,
+    poi.qty_ordered,
+    EXISTS (
+      SELECT 1
+        FROM purchase_request_items pri2
+        JOIN restock_requests rr ON rr.linked_pr_id = pri2.pr_id
+       WHERE pri2.po_item_id = poi.id
+    ) AS is_restock_sourced
+  FROM purchase_orders po
+  JOIN purchase_order_items poi ON poi.po_id = po.id
+  WHERE po.status IN ('sent', 'partially_received', 'fully_received')
+),
+gr_qty AS (
+  SELECT
+    gri.po_item_id,
+    SUM(gri.qty_received) AS gr_qty
+  FROM goods_receipt_items gri
+  JOIN goods_receipts gr ON gr.id = gri.gr_id
+  WHERE gr.status = 'confirmed'
+  GROUP BY gri.po_item_id
+),
+po_campaigns AS (
+  SELECT DISTINCT po_item_id, campaign_id FROM (
+    SELECT poi.id AS po_item_id, prc.campaign_id
+      FROM purchase_order_items poi
+      JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+      JOIN purchase_requests pr ON pr.id = pri.pr_id
+      JOIN purchase_request_campaigns prc ON prc.pr_id = pr.id
+    UNION
+    SELECT poi.id AS po_item_id, pri.source_campaign_id AS campaign_id
+      FROM purchase_order_items poi
+      JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+     WHERE pri.source_campaign_id IS NOT NULL
+  ) u
+),
+campaign_demand AS (
+  SELECT
+    pc.po_item_id,
+    co.pickup_store_id AS store_id,
+    SUM(coi.qty) AS demand_qty
+  FROM po_campaigns pc
+  JOIN customer_orders co ON co.campaign_id = pc.campaign_id
+                         AND co.status NOT IN ('cancelled','expired','transferred_out')
+                         AND co.transferred_from_order_id IS NULL
+  JOIN customer_order_items coi ON coi.order_id = co.id
+                               AND coi.status NOT IN ('cancelled','expired')
+  JOIN purchase_order_items poi ON poi.id = pc.po_item_id
+                               AND poi.sku_id = coi.sku_id
+  GROUP BY pc.po_item_id, co.pickup_store_id
+),
+restock_demand AS (
+  SELECT
+    poi.id AS po_item_id,
+    rr.requesting_store_id AS store_id,
+    SUM(rrl.qty) AS demand_qty
+  FROM purchase_order_items poi
+  JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+  JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                          AND rr.status NOT IN ('cancelled','rejected')
+  JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                AND rrl.sku_id = poi.sku_id
+  GROUP BY poi.id, rr.requesting_store_id
+),
+store_demand AS (
+  SELECT po_item_id, store_id, SUM(demand_qty) AS demand_qty
+  FROM (
+    SELECT po_item_id, store_id, demand_qty FROM campaign_demand
+    UNION ALL
+    SELECT po_item_id, store_id, demand_qty FROM restock_demand
+  ) u
+  GROUP BY po_item_id, store_id
+),
+wave_qty AS (
+  SELECT source_po_id, sku_id, store_id, SUM(qty) AS wave_qty
+  FROM (
+    SELECT pw.source_po_id, pwi.sku_id, pwi.store_id, pwi.qty
+    FROM picking_wave_items pwi
+    JOIN picking_waves pw ON pw.id = pwi.wave_id
+    WHERE pw.status <> 'cancelled'
+      AND pw.source_po_id IS NOT NULL
+    UNION ALL
+    SELECT
+      poi.po_id AS source_po_id,
+      ti.sku_id,
+      rr.requesting_store_id AS store_id,
+      ti.qty_requested
+    FROM restock_requests rr
+    JOIN transfers t ON t.id = rr.linked_transfer_id
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status <> 'cancelled'
+  ) u
+  GROUP BY source_po_id, sku_id, store_id
+),
+-- per (po_id, sku_id) 跨 store 的「已派」真值，與 RPC 守衛對齊。
+-- 本次修改：加第二分支 = 補貨直派 transfer（不經 wave 的
+-- rpc_ship_restock_pr_received 路徑），與上面 wave_qty 的第二分支同構。
+po_sku_already_wave AS (
+  SELECT po_id, sku_id, SUM(qty) AS already_wave
+  FROM (
+    SELECT pw.source_po_id AS po_id, pwi.sku_id, pwi.qty
+    FROM picking_wave_items pwi
+    JOIN picking_waves pw ON pw.id = pwi.wave_id
+    WHERE pw.status <> 'cancelled'
+      AND pw.source_po_id IS NOT NULL
+    UNION ALL
+    SELECT poi.po_id, ti.sku_id, ti.qty_requested AS qty
+    FROM restock_requests rr
+    JOIN transfers t ON t.id = rr.linked_transfer_id
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status <> 'cancelled'
+  ) u
+  GROUP BY po_id, sku_id
+),
+-- 新增：per (po_id, sku_id) 還有任一分店「需求 > 已派」嗎？
+-- 已派用 per-store wave_qty（含 wave 與補貨直派），逐店 floor 0 再加總，
+-- 避免某店超派的量去抵銷別店未滿足的需求。
+po_sku_demand_left AS (
+  SELECT
+    ps.po_id,
+    ps.sku_id,
+    SUM(GREATEST(0, COALESCE(sd.demand_qty, 0) - COALESCE(wq.wave_qty, 0))) AS demand_left
+  FROM po_skus ps
+  JOIN store_demand sd ON sd.po_item_id = ps.po_item_id
+  LEFT JOIN wave_qty wq ON wq.source_po_id = ps.po_id
+                       AND wq.sku_id = ps.sku_id
+                       AND wq.store_id = sd.store_id
+  GROUP BY ps.po_id, ps.sku_id
+),
+shipped_qty AS (
+  SELECT source_po_id, sku_id, store_id, SUM(qty_received) AS shipped_qty
+  FROM (
+    SELECT
+      pw.source_po_id,
+      ti.sku_id,
+      (substring(t.transfer_no FROM 'WAVE-\d+-S(\d+)'))::BIGINT AS store_id,
+      ti.qty_received
+    FROM transfers t
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN picking_waves pw ON t.transfer_no LIKE 'WAVE-' || pw.id || '-S%'
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status IN ('received', 'closed')
+      AND pw.source_po_id IS NOT NULL
+    UNION ALL
+    SELECT
+      poi.po_id AS source_po_id,
+      ti.sku_id,
+      rr.requesting_store_id AS store_id,
+      ti.qty_received
+    FROM restock_requests rr
+    JOIN transfers t ON t.id = rr.linked_transfer_id
+    JOIN transfer_items ti ON ti.transfer_id = t.id
+    JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+    JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+    WHERE t.transfer_type = 'hq_to_store'
+      AND t.status IN ('received', 'closed')
+  ) u
+  GROUP BY source_po_id, sku_id, store_id
+)
+SELECT
+  ps.tenant_id,
+  ps.po_id,
+  ps.po_no,
+  ps.po_status,
+  ps.supplier_id,
+  ps.po_item_id,
+  ps.sku_id,
+  s.sku_code,
+  COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+  ps.qty_ordered,
+  COALESCE(g.gr_qty, 0)::NUMERIC AS gr_qty,
+  CASE
+    WHEN ps.po_status <> 'fully_received'
+      THEN GREATEST(0, ps.qty_ordered - COALESCE(g.gr_qty, 0))
+    ELSE 0
+  END::NUMERIC AS qty_in_transit,
+  CASE
+    WHEN ps.po_status = 'fully_received' AND COALESCE(g.gr_qty, 0) < ps.qty_ordered
+      THEN ps.qty_ordered - COALESCE(g.gr_qty, 0)
+    ELSE 0
+  END::NUMERIC AS qty_shortage,
+  sd.store_id,
+  st.code AS store_code,
+  st.name AS store_name,
+  COALESCE(sd.demand_qty, 0)::NUMERIC AS demand_qty,
+  COALESCE(wq.wave_qty, 0)::NUMERIC AS wave_qty,
+  COALESCE(sq.shipped_qty, 0)::NUMERIC AS shipped_qty,
+  ps.is_restock_sourced,
+  -- per (po, sku) 已派（wave ＋ 補貨直派），與 RPC 守衛對齊
+  COALESCE(psaw.already_wave, 0)::NUMERIC AS po_sku_already_wave,
+  -- per (po, sku) 是否尚有可分配庫存（gr > 已派）。
+  (COALESCE(g.gr_qty, 0) > COALESCE(psaw.already_wave, 0)) AS has_stock_left,
+  -- 新欄位：per (po, sku) 是否還有任一分店需求未派完。
+  -- 前端矩陣視角 .eq("has_stock_left", true).eq("has_demand_left", true)：
+  -- 需求全部派完（含補貨直派）的列自動下架，總倉囤貨不再永遠掛在工作台。
+  (COALESCE(dl.demand_left, 0) > 0) AS has_demand_left
+FROM po_skus ps
+JOIN skus s ON s.id = ps.sku_id
+LEFT JOIN gr_qty g ON g.po_item_id = ps.po_item_id
+LEFT JOIN store_demand sd ON sd.po_item_id = ps.po_item_id
+LEFT JOIN stores st ON st.id = sd.store_id
+LEFT JOIN wave_qty wq ON wq.source_po_id = ps.po_id AND wq.sku_id = ps.sku_id AND wq.store_id = sd.store_id
+LEFT JOIN shipped_qty sq ON sq.source_po_id = ps.po_id AND sq.sku_id = ps.sku_id AND sq.store_id = sd.store_id
+LEFT JOIN po_sku_already_wave psaw ON psaw.po_id = ps.po_id AND psaw.sku_id = ps.sku_id
+LEFT JOIN po_sku_demand_left dl ON dl.po_id = ps.po_id AND dl.sku_id = ps.sku_id
+WHERE
+  COALESCE(sq.shipped_qty, 0) < GREATEST(COALESCE(g.gr_qty, 0), 1)
+  AND (COALESCE(g.gr_qty, 0) > 0 OR COALESCE(sd.demand_qty, 0) > 0);
+
+GRANT SELECT ON public.v_picking_demand_by_po TO authenticated;
+
+COMMENT ON VIEW public.v_picking_demand_by_po IS
+  '撿貨工作站主視圖：PO × SKU × store 矩陣。'
+  'po_sku_already_wave (per po+sku) = 已派真值（picking_wave_items ＋ 補貨直派 transfer），與 RPC 守衛對齊；'
+  'wave_qty (per po+sku+store) 依 store_demand JOIN，含 wave 與補貨直派，供 by_store 視角與需求淨額計算；'
+  'has_stock_left (per po+sku) = gr_qty > po_sku_already_wave；'
+  'has_demand_left (per po+sku) = 尚有分店需求未派完（逐店 GREATEST(0, demand−wave) 加總 > 0），'
+  '前端矩陣視角同時過濾兩者，需求派完的列自動下架。';
+
+-- ============================================================
+-- rpc_create_wave_from_po：第 4 步守衛的 already_wave 同步納入補貨直派 transfer
+-- （其餘邏輯與 20260702000000 完全相同）
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.rpc_create_wave_from_po(
+  p_po_id        BIGINT,
+  p_wave_date    DATE,
+  p_allocations  JSONB,
+  p_operator     UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_po                purchase_orders%ROWTYPE;
+  v_tenant            UUID;
+  v_wave_id           BIGINT;
+  v_wave_code         TEXT;
+  v_alloc             JSONB;
+  v_sku_id            BIGINT;
+  v_store_id          BIGINT;
+  v_qty               NUMERIC(18,3);
+  v_line_campaign_id  BIGINT;
+  v_total_qty         NUMERIC(18,3) := 0;
+  v_item_count        INTEGER := 0;
+  v_store_count       INTEGER := 0;
+  v_over              RECORD;
+BEGIN
+  -- 1. PO 守衛
+  SELECT * INTO v_po FROM purchase_orders WHERE id = p_po_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '找不到採購單 #%', p_po_id;
+  END IF;
+  IF v_po.status NOT IN ('sent','partially_received','fully_received') THEN
+    RAISE EXCEPTION '採購單 % 狀態為「%」、不可建撿貨單（需為「已發送」/「部分進貨」/「全部進貨」）', v_po.po_no, v_po.status;
+  END IF;
+  v_tenant := v_po.tenant_id;
+
+  -- 2. allocations 守衛
+  IF p_allocations IS NULL OR jsonb_array_length(p_allocations) = 0 THEN
+    RAISE EXCEPTION '請先填寫各分店分配量、不可全為空';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('wave:po:' || p_po_id::text));
+
+  -- 3. 守衛：每個分配 qty > 0
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations) LOOP
+    v_qty := (v_alloc->>'qty')::NUMERIC;
+    IF v_qty IS NULL OR v_qty <= 0 THEN
+      RAISE EXCEPTION '分配數量必須 > 0';
+    END IF;
+  END LOOP;
+
+  -- 4. 守衛：每 sku 的總分配量 ≤ (GR 量 − 已派量)
+  --    已派量 = picking_wave_items ＋ 補貨直派 transfer（linked_transfer_id 路徑），
+  --    與 v_picking_demand_by_po.po_sku_already_wave 對齊。
+  WITH alloc_agg AS (
+    SELECT
+      (a->>'sku_id')::BIGINT  AS sku_id,
+      SUM((a->>'qty')::NUMERIC) AS total_alloc
+    FROM jsonb_array_elements(p_allocations) a
+    GROUP BY (a->>'sku_id')::BIGINT
+  ),
+  po_sku_state AS (
+    SELECT
+      poi.sku_id,
+      COALESCE(SUM(gri.qty_received) FILTER (WHERE gr.status = 'confirmed'), 0) AS gr_qty,
+      COALESCE((
+        SELECT SUM(pwi.qty)
+          FROM picking_wave_items pwi
+          JOIN picking_waves pw ON pw.id = pwi.wave_id
+         WHERE pw.source_po_id = p_po_id
+           AND pwi.sku_id = poi.sku_id
+           AND pw.status <> 'cancelled'
+      ), 0)
+      + COALESCE((
+        SELECT SUM(ti.qty_requested)
+          FROM restock_requests rr
+          JOIN transfers t ON t.id = rr.linked_transfer_id
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+          JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+          JOIN purchase_order_items poi2 ON poi2.id = pri.po_item_id AND poi2.sku_id = ti.sku_id
+         WHERE poi2.po_id = p_po_id
+           AND poi2.sku_id = poi.sku_id
+           AND t.transfer_type = 'hq_to_store'
+           AND t.status <> 'cancelled'
+      ), 0) AS already_wave
+    FROM purchase_order_items poi
+    LEFT JOIN goods_receipt_items gri ON gri.po_item_id = poi.id
+    LEFT JOIN goods_receipts gr ON gr.id = gri.gr_id
+    WHERE poi.po_id = p_po_id
+    GROUP BY poi.sku_id
+  )
+  SELECT
+    s.sku_code,
+    COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+    aa.total_alloc, ps.gr_qty, ps.already_wave,
+    (ps.gr_qty - ps.already_wave) AS available
+  INTO v_over
+  FROM alloc_agg aa
+  JOIN po_sku_state ps ON ps.sku_id = aa.sku_id
+  JOIN skus s ON s.id = aa.sku_id
+  WHERE aa.total_alloc > (ps.gr_qty - ps.already_wave)
+  LIMIT 1;
+
+  IF v_over.sku_code IS NOT NULL THEN
+    RAISE EXCEPTION 'SKU「% %」分配 % 超過可分配量 %（進貨 %、已派 %，含撿貨單與補貨直派）',
+      v_over.sku_code, v_over.sku_label,
+      v_over.total_alloc, v_over.available, v_over.gr_qty, v_over.already_wave;
+  END IF;
+
+  -- 5. wave header — 用 sequence 產 code,避免同秒撞單
+  v_wave_code := 'WV'
+              || to_char(NOW() AT TIME ZONE 'Asia/Taipei', 'YYMMDD')
+              || LPAD(nextval('public.picking_wave_code_seq')::TEXT, 6, '0');
+
+  INSERT INTO picking_waves (
+    tenant_id, wave_code, wave_date, status, source_po_id,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_wave_code, p_wave_date, 'draft', p_po_id,
+    p_operator, p_operator
+  ) RETURNING id INTO v_wave_id;
+
+  -- 6 + 7. 逐 (sku, store) 解析「實際有需求的那一團」當 campaign_id，並擋跨團誤撿
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations) LOOP
+    v_sku_id   := (v_alloc->>'sku_id')::BIGINT;
+    v_store_id := (v_alloc->>'store_id')::BIGINT;
+    v_qty      := (v_alloc->>'qty')::NUMERIC;
+
+    -- 在「此 PO 對應的開團」裡，挑對該 (store, sku) 確實有訂單需求的一團。
+    -- 涵蓋兩條 PO→campaign 路徑（purchase_request_campaigns 與 source_campaign_id），
+    -- 與 v_picking_demand_by_po 的 po_campaigns 對齊。
+    SELECT cand.campaign_id
+      INTO v_line_campaign_id
+      FROM (
+        SELECT prc.campaign_id
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+          JOIN purchase_request_campaigns prc ON prc.pr_id = pri.pr_id
+         WHERE poi.po_id = p_po_id
+        UNION
+        SELECT pri.source_campaign_id AS campaign_id
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+         WHERE poi.po_id = p_po_id
+           AND pri.source_campaign_id IS NOT NULL
+      ) cand
+     WHERE EXISTS (
+       SELECT 1
+         FROM customer_orders co
+         JOIN customer_order_items coi ON coi.order_id = co.id
+        WHERE co.campaign_id = cand.campaign_id
+          AND co.pickup_store_id = v_store_id
+          AND co.status NOT IN ('cancelled','expired','transferred_out')
+          AND co.transferred_from_order_id IS NULL
+          AND coi.sku_id = v_sku_id
+          AND coi.status NOT IN ('cancelled','expired')
+     )
+     ORDER BY cand.campaign_id
+     LIMIT 1;
+
+    IF v_line_campaign_id IS NULL THEN
+      -- 此 (store, sku) 在這張 PO 的開團都沒有需求。
+      -- 只有「補貨 (restock) 來源」才允許（campaign_id 掛 NULL，沿用既有行為）。
+      IF NOT EXISTS (
+        SELECT 1
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+          JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                                  AND rr.requesting_store_id = v_store_id
+                                  AND rr.status NOT IN ('cancelled','rejected')
+          JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                        AND rrl.sku_id = v_sku_id
+         WHERE poi.po_id = p_po_id
+           AND poi.sku_id = v_sku_id
+      ) THEN
+        RAISE EXCEPTION
+          '分店「%」在採購單「%」對應的開團沒有 SKU「%」的訂單需求，不能撿到這批貨（這批屬於別團，請改用該店所屬開團的採購單撿貨）',
+          COALESCE((SELECT name FROM stores WHERE id = v_store_id), '#' || v_store_id),
+          v_po.po_no,
+          COALESCE((SELECT sku_code FROM skus WHERE id = v_sku_id), '#' || v_sku_id);
+      END IF;
+    END IF;
+
+    INSERT INTO picking_wave_items (
+      tenant_id, wave_id, sku_id, store_id, qty, campaign_id,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, v_wave_id, v_sku_id, v_store_id, v_qty, v_line_campaign_id,
+      p_operator, p_operator
+    )
+    ON CONFLICT (wave_id, sku_id, store_id) DO UPDATE
+      SET qty = picking_wave_items.qty + EXCLUDED.qty,
+          updated_by = p_operator,
+          updated_at = NOW();
+  END LOOP;
+
+  -- 8. 統計 wave header
+  SELECT COUNT(*), COUNT(DISTINCT store_id), COALESCE(SUM(qty), 0)
+    INTO v_item_count, v_store_count, v_total_qty
+    FROM picking_wave_items WHERE wave_id = v_wave_id;
+
+  UPDATE picking_waves
+     SET item_count = v_item_count,
+         store_count = v_store_count,
+         total_qty = v_total_qty,
+         updated_at = NOW()
+   WHERE id = v_wave_id;
+
+  RETURN jsonb_build_object(
+    'wave_id', v_wave_id,
+    'wave_code', v_wave_code,
+    'item_count', v_item_count,
+    'store_count', v_store_count,
+    'total_qty', v_total_qty
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_create_wave_from_po IS
+  '按 PO 建撿貨單；wave item 的 campaign_id 逐 (sku,store) 取「此 PO 對應開團裡確實有該店該 SKU 需求」的那一團；'
+  '若無開團需求且非補貨來源則 RAISE（擋跨團誤撿）。可分配守衛 = GR − (wave ＋ 補貨直派 transfer)，'
+  '與 v_picking_demand_by_po.po_sku_already_wave 對齊。wave_code 用 sequence 避免同秒撞單。';

--- a/supabase/migrations/20260715000020_restock_dispatch_dedup_guards.sql
+++ b/supabase/migrations/20260715000020_restock_dispatch_dedup_guards.sql
@@ -1,0 +1,659 @@
+-- ============================================================
+-- 補貨重複派貨守衛：三個出貨入口都改成「只派剩餘量、派完就擋」
+--
+-- 背景：20260715000010 修了派貨工作台「需求派完仍一直顯示」後，
+--   工作台不再邀請使用者重複派貨；但 RPC 層仍有三個入口對同一筆補貨
+--   放行重複出貨（實際案例：RR-51/53 每 SKU 申請 1 件，龍潭店被派了
+--   7 張 wave ＋ 1 張直派，共出貨 8–9 次）：
+--
+--   1) rpc_ship_restock_pr_received（收件匣「派貨」→ 直派 transfer）：
+--      照 restock lines 全量出貨，不知道已透過工作台 wave 派出的量。
+--   2) rpc_create_wave_from_po（工作台矩陣建單）：
+--      補貨來源的分配只驗「有沒有需求」（EXISTS），不驗「剩多少沒派」，
+--      同一筆 1 件補貨可以無限次各派 1 件。
+--   3) rpc_create_wave_from_restock（工作台補貨 amber 區塊建單）：
+--      守衛只驗「單次分配 ≤ 申請量」，跨多次呼叫不累計 — 連按兩次
+--      各派全量也放行。
+--
+-- 修法（歸屬原則）：
+--   「已派給此補貨」= 撿貨單裡 campaign_id IS NULL 的 wave items
+--   （rpc_create_wave_from_po 只在該 (store,sku) 無開團需求、僅補貨
+--   justification 時才掛 NULL）＋ 補貨直派 transfer（linked_transfer_id）。
+--   campaign_id 非 NULL 的 wave 屬客戶訂單需求，不能拿來抵補貨 —
+--   寧可保守多派、不可誤扣訂單的貨。
+--
+--   1) rpc_ship_restock_pr_received：逐 line 只出「申請量 − 已派量」，
+--      全部為 0 時 RAISE（已全數透過撿貨單派出）。
+--   2) rpc_create_wave_from_po：補貨 justification 的分配（campaign NULL）
+--      加上限 = 該 (store,sku) 剩餘補貨需求（申請 − wave(campaign NULL) − 直派）。
+--      刻意要多推庫存給分店 → 引導走內部調撥（wms/transfers）。
+--   3) rpc_create_wave_from_restock：守衛改「累計」— 單次分配 ≤
+--      申請量 − 該申請已 wave 量。
+--
+-- 基於（各函式最新版本）：
+--   rpc_ship_restock_pr_received — 20260705000000_dispatch_price_guard.sql Part 3
+--   rpc_create_wave_from_po      — 20260715000010（守衛含直派版）
+--   rpc_create_wave_from_restock — 20260612000040_approve_restock_via_picking_workstation.sql
+-- Rollback：CREATE OR REPLACE 各函式回上列基底版本
+-- TEST: docs/TEST-picking-dispatched-demand-left.md（追加 §D）
+-- ============================================================
+
+-- ----------------------------------------------------------------------------
+-- Part 1: rpc_ship_restock_pr_received — 只直派「申請量 − 已 wave 量」
+-- 基底：20260705000000 逐字保留（role/狀態機/價格守衛/outbound + shipped）。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_ship_restock_pr_received(
+  p_request_id BIGINT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant      UUID := public._current_tenant_id();
+  v_user        UUID := auth.uid();
+  v_role        TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_req         RECORD;
+  v_hq_loc      BIGINT;
+  v_dest_loc    BIGINT;
+  v_transfer_id BIGINT;
+  v_no          TEXT;
+  v_line        RECORD;
+  v_out_mov_id  BIGINT;
+  v_missing     TEXT;
+  v_fallback    NUMERIC;
+  v_waved       NUMERIC;
+  v_ship_qty    NUMERIC;
+  v_shipped_any BOOLEAN := FALSE;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot ship restock', v_role;
+  END IF;
+
+  SELECT * INTO v_req FROM restock_requests
+   WHERE id = p_request_id AND tenant_id = v_tenant FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'request % not found', p_request_id; END IF;
+  IF v_req.status <> 'approved_pr' THEN
+    RAISE EXCEPTION 'request % must be in approved_pr (current: %)', p_request_id, v_req.status;
+  END IF;
+  IF v_req.linked_pr_id IS NULL THEN
+    RAISE EXCEPTION 'request % missing linked_pr_id', p_request_id;
+  END IF;
+  IF v_req.linked_transfer_id IS NOT NULL THEN
+    RAISE EXCEPTION 'request % already shipped (transfer #%)', p_request_id, v_req.linked_transfer_id;
+  END IF;
+
+  SELECT id INTO v_hq_loc FROM locations
+   WHERE tenant_id = v_tenant AND type = 'central_warehouse' AND is_active = TRUE
+   ORDER BY id LIMIT 1;
+  IF v_hq_loc IS NULL THEN RAISE EXCEPTION 'no active central_warehouse'; END IF;
+
+  SELECT location_id INTO v_dest_loc FROM stores
+   WHERE id = v_req.requesting_store_id AND tenant_id = v_tenant;
+  IF v_dest_loc IS NULL THEN
+    RAISE EXCEPTION 'requesting store % has no location_id', v_req.requesting_store_id;
+  END IF;
+
+  -- 出貨價格防呆（同 generate_transfer_from_wave）
+  SELECT public._missing_dispatch_prices(
+           v_tenant,
+           (SELECT array_agg(DISTINCT sku_id)
+              FROM restock_request_lines
+             WHERE request_id = p_request_id AND tenant_id = v_tenant))
+    INTO v_missing;
+
+  IF v_missing IS NOT NULL THEN
+    RAISE EXCEPTION '無法派貨：以下品項尚未設定成本價／分店價，請先補價再出貨（商品頁 SKU 區塊或派貨工作台可直接補）→ %', v_missing;
+  END IF;
+
+  v_no := public._next_transfer_no();
+
+  INSERT INTO transfers (
+    tenant_id, transfer_no, source_location, dest_location,
+    status, transfer_type,
+    requested_by, shipped_by, shipped_at,
+    notes, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_no, v_hq_loc, v_dest_loc,
+    'shipped', 'hq_to_store',
+    v_user, v_user, NOW(),
+    'restock #' || p_request_id::TEXT || ' / PR #' || v_req.linked_pr_id::TEXT,
+    v_user, v_user
+  ) RETURNING id INTO v_transfer_id;
+
+  FOR v_line IN
+    SELECT sku_id, qty, notes FROM restock_request_lines
+     WHERE request_id = p_request_id AND tenant_id = v_tenant
+  LOOP
+    -- 已透過撿貨單派給此補貨的量：
+    --   a) amber 區塊建的 wave（source_restock_request_id = 本申請）
+    --   b) 工作台矩陣建的 wave（source_po_id ∈ 本申請 PR 拆出的 PO、
+    --      派給申請分店、campaign_id IS NULL = 補貨 justification）
+    -- campaign_id 非 NULL 的 wave 屬客戶訂單需求，不抵補貨。
+    SELECT COALESCE(SUM(pwi.qty), 0) INTO v_waved
+      FROM picking_wave_items pwi
+      JOIN picking_waves pw ON pw.id = pwi.wave_id
+     WHERE pw.status <> 'cancelled'
+       AND pwi.sku_id = v_line.sku_id
+       AND pwi.store_id = v_req.requesting_store_id
+       AND (
+         pw.source_restock_request_id = p_request_id
+         OR (
+           pwi.campaign_id IS NULL
+           AND pw.source_po_id IN (
+             SELECT DISTINCT poi.po_id
+               FROM purchase_request_items pri
+               JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+              WHERE pri.pr_id = v_req.linked_pr_id
+           )
+         )
+       );
+
+    v_ship_qty := GREATEST(0, v_line.qty - v_waved);
+    IF v_ship_qty = 0 THEN
+      CONTINUE;  -- 這條 line 已透過撿貨單派完，跳過
+    END IF;
+    v_shipped_any := TRUE;
+
+    v_fallback := public._current_cost_price(v_tenant, v_line.sku_id);
+
+    v_out_mov_id := public.rpc_outbound(
+      p_tenant_id          => v_tenant,
+      p_location_id        => v_hq_loc,
+      p_sku_id             => v_line.sku_id,
+      p_quantity           => v_ship_qty,
+      p_movement_type      => 'transfer_out',
+      p_source_doc_type    => 'transfer',
+      p_source_doc_id      => v_transfer_id,
+      p_operator           => v_user,
+      p_allow_negative     => FALSE,
+      p_fallback_unit_cost => v_fallback
+    );
+
+    INSERT INTO transfer_items (
+      transfer_id, sku_id, qty_requested, qty_shipped,
+      out_movement_id, notes, created_by, updated_by
+    ) VALUES (
+      v_transfer_id, v_line.sku_id, v_ship_qty, v_ship_qty,
+      v_out_mov_id, v_line.notes, v_user, v_user
+    );
+  END LOOP;
+
+  IF NOT v_shipped_any THEN
+    -- 整張申請都已透過撿貨單派完 → 不留空 transfer、直接擋下
+    RAISE EXCEPTION '補貨申請 #% 的品項已全數透過撿貨單派出，無需再直派（若要補送額外庫存請走內部調撥）',
+      p_request_id;
+  END IF;
+
+  UPDATE restock_requests
+     SET status = 'shipped',
+         linked_transfer_id = v_transfer_id,
+         updated_by = v_user
+   WHERE id = p_request_id;
+
+  RETURN v_transfer_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_ship_restock_pr_received(BIGINT) TO authenticated;
+COMMENT ON FUNCTION public.rpc_ship_restock_pr_received(BIGINT) IS
+  'restock approved_pr → 收貨後派貨：建 shipped transfer + outbound HQ 庫存；'
+  '20260705 起：出貨前守衛缺成本價/分店價，avg_cost=0 時出庫以現行成本價計價；'
+  '20260715 起：只直派「申請量 − 已 wave 量」，全數已派時 RAISE（防重複派貨）。';
+
+-- ----------------------------------------------------------------------------
+-- Part 2: rpc_create_wave_from_po — 補貨 justification 的分配加「剩餘補貨需求」上限
+-- 基底：20260715000010 逐字保留，只在 campaign NULL 分支追加數量上限守衛。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_wave_from_po(
+  p_po_id        BIGINT,
+  p_wave_date    DATE,
+  p_allocations  JSONB,
+  p_operator     UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_po                purchase_orders%ROWTYPE;
+  v_tenant            UUID;
+  v_wave_id           BIGINT;
+  v_wave_code         TEXT;
+  v_alloc             JSONB;
+  v_sku_id            BIGINT;
+  v_store_id          BIGINT;
+  v_qty               NUMERIC(18,3);
+  v_line_campaign_id  BIGINT;
+  v_total_qty         NUMERIC(18,3) := 0;
+  v_item_count        INTEGER := 0;
+  v_store_count       INTEGER := 0;
+  v_over              RECORD;
+  v_restock_demand    NUMERIC;
+  v_restock_dispatched NUMERIC;
+  v_restock_left      NUMERIC;
+BEGIN
+  -- 1. PO 守衛
+  SELECT * INTO v_po FROM purchase_orders WHERE id = p_po_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '找不到採購單 #%', p_po_id;
+  END IF;
+  IF v_po.status NOT IN ('sent','partially_received','fully_received') THEN
+    RAISE EXCEPTION '採購單 % 狀態為「%」、不可建撿貨單（需為「已發送」/「部分進貨」/「全部進貨」）', v_po.po_no, v_po.status;
+  END IF;
+  v_tenant := v_po.tenant_id;
+
+  -- 2. allocations 守衛
+  IF p_allocations IS NULL OR jsonb_array_length(p_allocations) = 0 THEN
+    RAISE EXCEPTION '請先填寫各分店分配量、不可全為空';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('wave:po:' || p_po_id::text));
+
+  -- 3. 守衛：每個分配 qty > 0
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations) LOOP
+    v_qty := (v_alloc->>'qty')::NUMERIC;
+    IF v_qty IS NULL OR v_qty <= 0 THEN
+      RAISE EXCEPTION '分配數量必須 > 0';
+    END IF;
+  END LOOP;
+
+  -- 4. 守衛：每 sku 的總分配量 ≤ (GR 量 − 已派量)
+  --    已派量 = picking_wave_items ＋ 補貨直派 transfer（linked_transfer_id 路徑），
+  --    與 v_picking_demand_by_po.po_sku_already_wave 對齊。
+  WITH alloc_agg AS (
+    SELECT
+      (a->>'sku_id')::BIGINT  AS sku_id,
+      SUM((a->>'qty')::NUMERIC) AS total_alloc
+    FROM jsonb_array_elements(p_allocations) a
+    GROUP BY (a->>'sku_id')::BIGINT
+  ),
+  po_sku_state AS (
+    SELECT
+      poi.sku_id,
+      COALESCE(SUM(gri.qty_received) FILTER (WHERE gr.status = 'confirmed'), 0) AS gr_qty,
+      COALESCE((
+        SELECT SUM(pwi.qty)
+          FROM picking_wave_items pwi
+          JOIN picking_waves pw ON pw.id = pwi.wave_id
+         WHERE pw.source_po_id = p_po_id
+           AND pwi.sku_id = poi.sku_id
+           AND pw.status <> 'cancelled'
+      ), 0)
+      + COALESCE((
+        SELECT SUM(ti.qty_requested)
+          FROM restock_requests rr
+          JOIN transfers t ON t.id = rr.linked_transfer_id
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+          JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+          JOIN purchase_order_items poi2 ON poi2.id = pri.po_item_id AND poi2.sku_id = ti.sku_id
+         WHERE poi2.po_id = p_po_id
+           AND poi2.sku_id = poi.sku_id
+           AND t.transfer_type = 'hq_to_store'
+           AND t.status <> 'cancelled'
+      ), 0) AS already_wave
+    FROM purchase_order_items poi
+    LEFT JOIN goods_receipt_items gri ON gri.po_item_id = poi.id
+    LEFT JOIN goods_receipts gr ON gr.id = gri.gr_id
+    WHERE poi.po_id = p_po_id
+    GROUP BY poi.sku_id
+  )
+  SELECT
+    s.sku_code,
+    COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+    aa.total_alloc, ps.gr_qty, ps.already_wave,
+    (ps.gr_qty - ps.already_wave) AS available
+  INTO v_over
+  FROM alloc_agg aa
+  JOIN po_sku_state ps ON ps.sku_id = aa.sku_id
+  JOIN skus s ON s.id = aa.sku_id
+  WHERE aa.total_alloc > (ps.gr_qty - ps.already_wave)
+  LIMIT 1;
+
+  IF v_over.sku_code IS NOT NULL THEN
+    RAISE EXCEPTION 'SKU「% %」分配 % 超過可分配量 %（進貨 %、已派 %，含撿貨單與補貨直派）',
+      v_over.sku_code, v_over.sku_label,
+      v_over.total_alloc, v_over.available, v_over.gr_qty, v_over.already_wave;
+  END IF;
+
+  -- 5. wave header — 用 sequence 產 code,避免同秒撞單
+  v_wave_code := 'WV'
+              || to_char(NOW() AT TIME ZONE 'Asia/Taipei', 'YYMMDD')
+              || LPAD(nextval('public.picking_wave_code_seq')::TEXT, 6, '0');
+
+  INSERT INTO picking_waves (
+    tenant_id, wave_code, wave_date, status, source_po_id,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_wave_code, p_wave_date, 'draft', p_po_id,
+    p_operator, p_operator
+  ) RETURNING id INTO v_wave_id;
+
+  -- 6 + 7. 逐 (sku, store) 解析「實際有需求的那一團」當 campaign_id，並擋跨團誤撿
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations) LOOP
+    v_sku_id   := (v_alloc->>'sku_id')::BIGINT;
+    v_store_id := (v_alloc->>'store_id')::BIGINT;
+    v_qty      := (v_alloc->>'qty')::NUMERIC;
+
+    -- 在「此 PO 對應的開團」裡，挑對該 (store, sku) 確實有訂單需求的一團。
+    -- 涵蓋兩條 PO→campaign 路徑（purchase_request_campaigns 與 source_campaign_id），
+    -- 與 v_picking_demand_by_po 的 po_campaigns 對齊。
+    SELECT cand.campaign_id
+      INTO v_line_campaign_id
+      FROM (
+        SELECT prc.campaign_id
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+          JOIN purchase_request_campaigns prc ON prc.pr_id = pri.pr_id
+         WHERE poi.po_id = p_po_id
+        UNION
+        SELECT pri.source_campaign_id AS campaign_id
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+         WHERE poi.po_id = p_po_id
+           AND pri.source_campaign_id IS NOT NULL
+      ) cand
+     WHERE EXISTS (
+       SELECT 1
+         FROM customer_orders co
+         JOIN customer_order_items coi ON coi.order_id = co.id
+        WHERE co.campaign_id = cand.campaign_id
+          AND co.pickup_store_id = v_store_id
+          AND co.status NOT IN ('cancelled','expired','transferred_out')
+          AND co.transferred_from_order_id IS NULL
+          AND coi.sku_id = v_sku_id
+          AND coi.status NOT IN ('cancelled','expired')
+     )
+     ORDER BY cand.campaign_id
+     LIMIT 1;
+
+    IF v_line_campaign_id IS NULL THEN
+      -- 此 (store, sku) 在這張 PO 的開團都沒有需求。
+      -- 只有「補貨 (restock) 來源」才允許（campaign_id 掛 NULL，沿用既有行為）。
+      IF NOT EXISTS (
+        SELECT 1
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+          JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                                  AND rr.requesting_store_id = v_store_id
+                                  AND rr.status NOT IN ('cancelled','rejected')
+          JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                        AND rrl.sku_id = v_sku_id
+         WHERE poi.po_id = p_po_id
+           AND poi.sku_id = v_sku_id
+      ) THEN
+        RAISE EXCEPTION
+          '分店「%」在採購單「%」對應的開團沒有 SKU「%」的訂單需求，不能撿到這批貨（這批屬於別團，請改用該店所屬開團的採購單撿貨）',
+          COALESCE((SELECT name FROM stores WHERE id = v_store_id), '#' || v_store_id),
+          v_po.po_no,
+          COALESCE((SELECT sku_code FROM skus WHERE id = v_sku_id), '#' || v_sku_id);
+      END IF;
+
+      -- 20260715 新增：補貨分配不可超過「剩餘補貨需求」= 申請量 − 已派量。
+      -- 申請量：此 PO 對應補貨申請對該 (store, sku) 的 lines 加總。
+      SELECT COALESCE(SUM(rrl.qty), 0) INTO v_restock_demand
+        FROM purchase_order_items poi
+        JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+        JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                                AND rr.requesting_store_id = v_store_id
+                                AND rr.status NOT IN ('cancelled','rejected')
+        JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                      AND rrl.sku_id = v_sku_id
+       WHERE poi.po_id = p_po_id
+         AND poi.sku_id = v_sku_id;
+
+      -- 已派量：此 PO 的 campaign NULL wave items（含本 wave 前面 loop 已插入的列，
+      -- 同批重複 (sku,store) 會累計）＋ 補貨直派 transfer。
+      SELECT
+        COALESCE((
+          SELECT SUM(pwi.qty)
+            FROM picking_wave_items pwi
+            JOIN picking_waves pw ON pw.id = pwi.wave_id
+           WHERE pw.source_po_id = p_po_id
+             AND pw.status <> 'cancelled'
+             AND pwi.sku_id = v_sku_id
+             AND pwi.store_id = v_store_id
+             AND pwi.campaign_id IS NULL
+        ), 0)
+        + COALESCE((
+          SELECT SUM(ti.qty_requested)
+            FROM restock_requests rr
+            JOIN transfers t ON t.id = rr.linked_transfer_id
+            JOIN transfer_items ti ON ti.transfer_id = t.id AND ti.sku_id = v_sku_id
+            JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+            JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = v_sku_id
+           WHERE poi.po_id = p_po_id
+             AND rr.requesting_store_id = v_store_id
+             AND t.transfer_type = 'hq_to_store'
+             AND t.status <> 'cancelled'
+        ), 0)
+      INTO v_restock_dispatched;
+
+      v_restock_left := GREATEST(0, v_restock_demand - v_restock_dispatched);
+      IF v_qty > v_restock_left THEN
+        RAISE EXCEPTION
+          '分店「%」SKU「%」的補貨需求只剩 % 件未派（申請 %、已派 %，含撿貨單與直派），本次分配 % 超過。若要額外補庫存給分店，請走內部調撥。',
+          COALESCE((SELECT name FROM stores WHERE id = v_store_id), '#' || v_store_id),
+          COALESCE((SELECT sku_code FROM skus WHERE id = v_sku_id), '#' || v_sku_id),
+          v_restock_left, v_restock_demand, v_restock_dispatched, v_qty;
+      END IF;
+    END IF;
+
+    INSERT INTO picking_wave_items (
+      tenant_id, wave_id, sku_id, store_id, qty, campaign_id,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, v_wave_id, v_sku_id, v_store_id, v_qty, v_line_campaign_id,
+      p_operator, p_operator
+    )
+    ON CONFLICT (wave_id, sku_id, store_id) DO UPDATE
+      SET qty = picking_wave_items.qty + EXCLUDED.qty,
+          updated_by = p_operator,
+          updated_at = NOW();
+  END LOOP;
+
+  -- 8. 統計 wave header
+  SELECT COUNT(*), COUNT(DISTINCT store_id), COALESCE(SUM(qty), 0)
+    INTO v_item_count, v_store_count, v_total_qty
+    FROM picking_wave_items WHERE wave_id = v_wave_id;
+
+  UPDATE picking_waves
+     SET item_count = v_item_count,
+         store_count = v_store_count,
+         total_qty = v_total_qty,
+         updated_at = NOW()
+   WHERE id = v_wave_id;
+
+  RETURN jsonb_build_object(
+    'wave_id', v_wave_id,
+    'wave_code', v_wave_code,
+    'item_count', v_item_count,
+    'store_count', v_store_count,
+    'total_qty', v_total_qty
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_create_wave_from_po IS
+  '按 PO 建撿貨單；wave item 的 campaign_id 逐 (sku,store) 取「此 PO 對應開團裡確實有該店該 SKU 需求」的那一團；'
+  '若無開團需求且非補貨來源則 RAISE（擋跨團誤撿）。可分配守衛 = GR − (wave ＋ 補貨直派 transfer)，'
+  '與 v_picking_demand_by_po.po_sku_already_wave 對齊。'
+  '補貨 justification 的分配另有上限 = 剩餘補貨需求（申請 − 已派），防重複派貨。'
+  'wave_code 用 sequence 避免同秒撞單。';
+
+-- ----------------------------------------------------------------------------
+-- Part 3: rpc_create_wave_from_restock — 守衛改累計（申請量 − 已 wave 量）
+-- 基底：20260612000040 逐字保留，只把 line_agg 上限改成扣掉既有 wave。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_wave_from_restock(
+  p_restock_request_id BIGINT,
+  p_wave_date          DATE,
+  p_allocations        JSONB,
+  p_operator           UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_request      restock_requests%ROWTYPE;
+  v_tenant       UUID;
+  v_wave_id      BIGINT;
+  v_wave_code    TEXT;
+  v_alloc        JSONB;
+  v_sku_id       BIGINT;
+  v_store_id     BIGINT;
+  v_qty          NUMERIC(18,3);
+  v_total_qty    NUMERIC(18,3) := 0;
+  v_item_count   INTEGER := 0;
+  v_store_count  INTEGER := 0;
+  v_hq_location  BIGINT;
+  v_short        RECORD;
+BEGIN
+  SELECT * INTO v_request FROM restock_requests
+    WHERE id = p_restock_request_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '找不到補貨申請 #%', p_restock_request_id;
+  END IF;
+  -- 收緊:只接受 approved_transfer(必經 inbox 審核)
+  IF v_request.status <> 'approved_transfer' THEN
+    RAISE EXCEPTION '補貨申請狀態為「%」、不可建撿貨單(需先在總倉收件匣點「派貨」)',
+      v_request.status;
+  END IF;
+  IF v_request.linked_transfer_id IS NOT NULL THEN
+    RAISE EXCEPTION '補貨申請 #% 已有直派 transfer(legacy),不可重複建單',
+      p_restock_request_id;
+  END IF;
+  v_tenant := v_request.tenant_id;
+
+  IF p_allocations IS NULL OR jsonb_array_length(p_allocations) = 0 THEN
+    RAISE EXCEPTION '請先填寫各分店分配量、不可全為空';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('wave:restock:' || p_restock_request_id::TEXT));
+
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations) LOOP
+    v_qty := (v_alloc->>'qty')::NUMERIC;
+    v_store_id := (v_alloc->>'store_id')::BIGINT;
+    IF v_qty IS NULL OR v_qty <= 0 THEN
+      RAISE EXCEPTION '分配數量必須 > 0';
+    END IF;
+    IF v_store_id <> v_request.requesting_store_id THEN
+      RAISE EXCEPTION '補貨申請只能派給申請分店 #%、不可派往其他店',
+        v_request.requesting_store_id;
+    END IF;
+  END LOOP;
+
+  SELECT id INTO v_hq_location FROM locations
+    WHERE tenant_id = v_tenant AND type = 'central_warehouse'
+    ORDER BY id LIMIT 1;
+  IF v_hq_location IS NULL THEN
+    RAISE EXCEPTION '找不到總倉 location(type=central_warehouse)';
+  END IF;
+
+  -- 20260715 改：上限從「申請量」改成「申請量 − 該申請已 wave 量」（累計守衛）。
+  -- 原版只驗單次分配 ≤ 申請量，連按兩次各派全量也放行 → 重複派貨。
+  WITH alloc_agg AS (
+    SELECT (a->>'sku_id')::BIGINT AS sku_id,
+           SUM((a->>'qty')::NUMERIC) AS total_alloc
+    FROM jsonb_array_elements(p_allocations) a
+    GROUP BY (a->>'sku_id')::BIGINT
+  ),
+  line_agg AS (
+    SELECT sku_id, SUM(qty) AS line_qty
+    FROM restock_request_lines
+    WHERE request_id = p_restock_request_id
+    GROUP BY sku_id
+  ),
+  waved_agg AS (
+    SELECT pwi.sku_id, SUM(pwi.qty) AS waved_qty
+    FROM picking_wave_items pwi
+    JOIN picking_waves pw ON pw.id = pwi.wave_id
+    WHERE pw.source_restock_request_id = p_restock_request_id
+      AND pw.status <> 'cancelled'
+    GROUP BY pwi.sku_id
+  )
+  SELECT
+    s.sku_code,
+    COALESCE(s.product_name,'') || COALESCE(' ' || NULLIF(s.variant_name,''),'') AS sku_label,
+    aa.total_alloc,
+    COALESCE(la.line_qty, 0) AS line_qty,
+    COALESCE(wa.waved_qty, 0) AS waved_qty,
+    GREATEST(0, COALESCE(la.line_qty, 0) - COALESCE(wa.waved_qty, 0)) AS line_left,
+    COALESCE(sb.on_hand, 0) AS on_hand
+  INTO v_short
+  FROM alloc_agg aa
+  JOIN skus s ON s.id = aa.sku_id
+  LEFT JOIN line_agg la ON la.sku_id = aa.sku_id
+  LEFT JOIN waved_agg wa ON wa.sku_id = aa.sku_id
+  LEFT JOIN stock_balances sb
+    ON sb.tenant_id = v_tenant
+   AND sb.location_id = v_hq_location
+   AND sb.sku_id = aa.sku_id
+  WHERE
+    aa.total_alloc > GREATEST(0, COALESCE(la.line_qty, 0) - COALESCE(wa.waved_qty, 0))
+    OR aa.total_alloc > COALESCE(sb.on_hand, 0)
+  LIMIT 1;
+
+  IF v_short.sku_code IS NOT NULL THEN
+    IF v_short.total_alloc > v_short.line_left THEN
+      RAISE EXCEPTION 'SKU「% %」分配 % 超過剩餘申請量 %（申請 %、已撿 %）',
+        v_short.sku_code, v_short.sku_label, v_short.total_alloc,
+        v_short.line_left, v_short.line_qty, v_short.waved_qty;
+    ELSE
+      RAISE EXCEPTION 'SKU「% %」分配 % 超過總倉庫存 %',
+        v_short.sku_code, v_short.sku_label, v_short.total_alloc, v_short.on_hand;
+    END IF;
+  END IF;
+
+  v_wave_code := 'WV'
+              || to_char(NOW() AT TIME ZONE 'Asia/Taipei', 'YYMMDD')
+              || LPAD(nextval('public.picking_wave_code_seq')::TEXT, 6, '0');
+
+  INSERT INTO picking_waves (
+    tenant_id, wave_code, wave_date, status, source_restock_request_id,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_wave_code, p_wave_date, 'draft', p_restock_request_id,
+    p_operator, p_operator
+  ) RETURNING id INTO v_wave_id;
+
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations) LOOP
+    v_sku_id   := (v_alloc->>'sku_id')::BIGINT;
+    v_store_id := (v_alloc->>'store_id')::BIGINT;
+    v_qty      := (v_alloc->>'qty')::NUMERIC;
+
+    INSERT INTO picking_wave_items (
+      tenant_id, wave_id, sku_id, store_id, qty, campaign_id,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, v_wave_id, v_sku_id, v_store_id, v_qty, NULL,
+      p_operator, p_operator
+    )
+    ON CONFLICT (wave_id, sku_id, store_id) DO UPDATE
+      SET qty = picking_wave_items.qty + EXCLUDED.qty,
+          updated_by = p_operator,
+          updated_at = NOW();
+  END LOOP;
+
+  SELECT COUNT(*), COUNT(DISTINCT store_id), COALESCE(SUM(qty), 0)
+    INTO v_item_count, v_store_count, v_total_qty
+    FROM picking_wave_items WHERE wave_id = v_wave_id;
+
+  UPDATE picking_waves
+    SET item_count = v_item_count,
+        store_count = v_store_count,
+        total_qty = v_total_qty,
+        updated_at = NOW()
+   WHERE id = v_wave_id;
+
+  RETURN jsonb_build_object(
+    'wave_id', v_wave_id,
+    'wave_code', v_wave_code,
+    'item_count', v_item_count,
+    'store_count', v_store_count,
+    'total_qty', v_total_qty
+  );
+END $$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_wave_from_restock(BIGINT, DATE, JSONB, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_wave_from_restock(BIGINT, DATE, JSONB, UUID) IS
+  '補貨申請（無 PO 來源）建撿貨單；只接受 approved_transfer、只可派給申請分店；'
+  '20260715 起：分配上限 = 申請量 − 該申請已 wave 量（累計守衛，防重複派貨）。';


### PR DESCRIPTION
使用者回報「已經派貨跟收貨 但是工作台一直顯示」(PO2607070725/26):
補貨直派 transfer(rpc_ship_restock_pr_received 的 linked_transfer_id 路徑)
沒被算進 per(po,sku) 已派量,且矩陣顯示條件純庫存驅動(gr>已撿),
補貨帶囤貨的 PO 永遠不下架、「需 1」永遠掛著,使用者因此對同一筆
1 件補貨重複派了 8-9 次貨。

- view po_sku_already_wave 加補貨直派分支(與 per-store wave_qty 第二分支同構),
  可分配不再比總倉庫存多(G00100-01: 4→3)
- view 尾端新增 has_demand_left:逐店 GREATEST(0,demand−wave) 加總>0;
  矩陣視角疊 .eq("has_demand_left",true),需求派完的列自動下架(線上 40→8 個 PO×SKU)
- rpc_create_wave_from_po 守衛同步納入直派量(view/RPC 對齊,
  防「UI 說可以、送出被擋」regression)
- 矩陣格子「需」改顯示未派需求(派完顯示 ✓ 已派)、平均分配 cap 改未派需求、
  預設分配不再重複扣 shipped;列印撿貨清單同語意過濾

TEST: docs/TEST-picking-dispatched-demand-left.md(線上 SQL 驗證通過)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018wFpE2VvUKwpNCQfeP8dPc