### PR TITLE
Monthly settlement e-statement flow: online review, dispute, remittance

### DIFF
--- a/apps/admin/src/app/(protected)/finance/receivables/print/page.tsx
+++ b/apps/admin/src/app/(protected)/finance/receivables/print/page.tsx
@@ -45,8 +45,13 @@ const ENTRY_TYPE_LABEL: Record<SettlementItem["entry_type"], string> = {
   return_out: "退貨沖回",
 };
 
+// 分店版（預設）：給店家的對帳單，只列分店價，不露總倉成本。
+// 內部版：加列成本單價/成本小計與口徑差額（總部毛利），總部對帳用。
+type PrintView = "store" | "internal";
+
 export default function PrintSettlementPage() {
   const [settlementId, setSettlementId] = useState<number | null>(null);
+  const [view, setView] = useState<PrintView>("store");
   const [settlement, setSettlement] = useState<Settlement | null>(null);
   const [store, setStore] = useState<Store | null>(null);
   const [items, setItems] = useState<SettlementItem[]>([]);
@@ -56,11 +61,13 @@ export default function PrintSettlementPage() {
   const [receivable, setReceivable] = useState<Receivable | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // 從 query 抓 settlement_id
+  // 從 query 抓 settlement_id + view
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const id = new URLSearchParams(window.location.search).get("settlement_id");
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get("settlement_id");
     if (id) setSettlementId(Number(id));
+    if (params.get("view") === "internal") setView("internal");
   }, []);
 
   useEffect(() => {
@@ -142,19 +149,24 @@ export default function PrintSettlementPage() {
   }
 
   const monthLabel = settlement.settlement_month?.slice(0, 7);
-  const total = items.reduce((s, it) => s + Number(it.line_amount), 0);
+  const totalCost = items.reduce((s, it) => s + Number(it.line_amount), 0);
   const totalBranch = items.reduce((s, it) => s + Number(it.branch_amount ?? 0), 0);
   const today = new Date().toLocaleDateString("zh-TW");
+  const internal = view === "internal";
 
   return (
     <>
       <style jsx global>{`
         @media print {
-          @page { size: A4; margin: 12mm; }
+          @page { size: A4; margin: 10mm; }
           .no-print { display: none !important; }
           .sheet { page-break-after: always; }
           .sheet:last-child { page-break-after: auto; }
           body { background: white !important; }
+          .stmt-table { font-size: 10px; }
+          .stmt-table th, .stmt-table td { padding: 2px 4px; }
+          .stmt-table thead { display: table-header-group; }
+          .stmt-table tr { break-inside: avoid; }
         }
       `}</style>
 
@@ -165,6 +177,20 @@ export default function PrintSettlementPage() {
           <span className="text-sm text-zinc-500">
             {store.name} / {monthLabel} / 應付總倉 ${Number(settlement.payable_amount).toLocaleString()}
           </span>
+          <div className="flex overflow-hidden rounded-md border border-zinc-300 text-sm">
+            <SpinButton
+              onClick={() => setView("store")}
+              className={`px-3 py-1.5 ${!internal ? "bg-zinc-900 font-semibold text-white" : "bg-white text-zinc-600 hover:bg-zinc-100"}`}
+            >
+              分店版（給店家）
+            </SpinButton>
+            <SpinButton
+              onClick={() => setView("internal")}
+              className={`px-3 py-1.5 ${internal ? "bg-zinc-900 font-semibold text-white" : "bg-white text-zinc-600 hover:bg-zinc-100"}`}
+            >
+              內部版（含成本）
+            </SpinButton>
+          </div>
           <SpinButton
             onClick={() => window.print()}
             className="ml-auto rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-blue-700"
@@ -204,13 +230,16 @@ export default function PrintSettlementPage() {
               </div>
             </div>
             <div className="text-right">
-              <div className="text-xs text-zinc-500">應付總倉金額（成本價口徑）</div>
+              <div className="text-xs text-zinc-500">應付總倉金額{internal && "（分店價口徑）"}</div>
               <div className="text-lg font-semibold text-rose-600">
                 ${Number(settlement.payable_amount).toLocaleString()}
               </div>
-              <div className="mt-0.5 text-xs text-zinc-600">
-                分店價口徑：<span className="font-mono font-semibold">${Number(settlement.branch_amount ?? 0).toLocaleString()}</span>
-              </div>
+              {internal && (
+                <div className="mt-0.5 text-xs text-zinc-600">
+                  成本口徑：<span className="font-mono font-semibold">${Number(settlement.cost_amount ?? 0).toLocaleString()}</span>
+                  <span className="ml-2">總部毛利：<span className="font-mono font-semibold">${(Number(settlement.branch_amount ?? 0) - Number(settlement.cost_amount ?? 0)).toLocaleString()}</span></span>
+                </div>
+              )}
               {receivable && (
                 <div className="mt-0.5 text-xs text-zinc-500">到期日：{receivable.due_date}</div>
               )}
@@ -218,7 +247,7 @@ export default function PrintSettlementPage() {
           </div>
 
           {/* 商品明細表 */}
-          <table className="w-full border-collapse text-xs">
+          <table className="stmt-table w-full border-collapse text-xs">
             <thead>
               <tr className="border-b-2 border-zinc-900">
                 <th className="border border-zinc-400 px-2 py-1.5 text-left">#</th>
@@ -228,24 +257,28 @@ export default function PrintSettlementPage() {
                 <th className="border border-zinc-400 px-2 py-1.5 text-left">商品編號</th>
                 <th className="border border-zinc-400 px-2 py-1.5 text-left">品名</th>
                 <th className="border border-zinc-400 px-2 py-1.5 text-right">數量</th>
-                <th className="border border-zinc-400 px-2 py-1.5 text-right">成本單價</th>
-                <th className="border border-zinc-400 px-2 py-1.5 text-right">成本小計</th>
-                <th className="border border-zinc-400 px-2 py-1.5 text-right">分店單價</th>
-                <th className="border border-zinc-400 px-2 py-1.5 text-right">分店小計</th>
+                {internal && (
+                  <>
+                    <th className="border border-zinc-400 px-2 py-1.5 text-right">成本單價</th>
+                    <th className="border border-zinc-400 px-2 py-1.5 text-right">成本小計</th>
+                  </>
+                )}
+                <th className="border border-zinc-400 px-2 py-1.5 text-right">{internal ? "分店單價" : "單價"}</th>
+                <th className="border border-zinc-400 px-2 py-1.5 text-right">{internal ? "分店小計" : "小計"}</th>
               </tr>
             </thead>
             <tbody>
               {items.map((it, i) => {
                 const tx = transfers.get(it.transfer_id);
                 const sku = skus.get(it.sku_id);
-                const isNeg = Number(it.line_amount) < 0;
+                const isFree = it.description != null; // 自由轉貨行：估價入帳、無單價
                 return (
                   <tr key={it.id}>
                     <td className="border border-zinc-400 px-2 py-1">{i + 1}</td>
-                    <td className="border border-zinc-400 px-2 py-1">{new Date(it.received_at).toLocaleDateString("zh-TW")}</td>
-                    <td className="border border-zinc-400 px-2 py-1">{ENTRY_TYPE_LABEL[it.entry_type]}</td>
-                    <td className="border border-zinc-400 px-2 py-1 font-mono">{tx?.transfer_no ?? `#${it.transfer_id}`}</td>
-                    <td className="border border-zinc-400 px-2 py-1 font-mono">{sku?.sku_code ?? "—"}</td>
+                    <td className="border border-zinc-400 px-2 py-1 whitespace-nowrap">{new Date(it.received_at).toLocaleDateString("zh-TW")}</td>
+                    <td className="border border-zinc-400 px-2 py-1 whitespace-nowrap">{ENTRY_TYPE_LABEL[it.entry_type]}</td>
+                    <td className="border border-zinc-400 px-2 py-1 font-mono whitespace-nowrap">{tx?.transfer_no ?? `#${it.transfer_id}`}</td>
+                    <td className="border border-zinc-400 px-2 py-1 font-mono whitespace-nowrap">{sku?.sku_code ?? "—"}</td>
                     <td className="border border-zinc-400 px-2 py-1">
                       {it.description ? (
                         <span>{it.description}</span>
@@ -257,12 +290,20 @@ export default function PrintSettlementPage() {
                       )}
                     </td>
                     <td className="border border-zinc-400 px-2 py-1 text-right font-mono">{Number(it.qty_received).toLocaleString()}</td>
-                    <td className="border border-zinc-400 px-2 py-1 text-right font-mono">${Number(it.unit_cost).toFixed(2)}</td>
-                    <td className={`border border-zinc-400 px-2 py-1 text-right font-mono ${isNeg ? "text-amber-600" : ""}`}>
-                      ${Number(it.line_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                    {internal && (
+                      <>
+                        <td className="border border-zinc-400 px-2 py-1 text-right font-mono whitespace-nowrap">
+                          {isFree ? "—" : `$${Number(it.unit_cost).toFixed(2)}`}
+                        </td>
+                        <td className={`border border-zinc-400 px-2 py-1 text-right font-mono whitespace-nowrap ${Number(it.line_amount) < 0 ? "text-amber-600" : ""}`}>
+                          ${Number(it.line_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                        </td>
+                      </>
+                    )}
+                    <td className="border border-zinc-400 px-2 py-1 text-right font-mono whitespace-nowrap">
+                      {isFree ? "—" : `$${Number(it.unit_branch_price ?? 0).toFixed(2)}`}
                     </td>
-                    <td className="border border-zinc-400 px-2 py-1 text-right font-mono">${Number(it.unit_branch_price ?? 0).toFixed(2)}</td>
-                    <td className={`border border-zinc-400 px-2 py-1 text-right font-mono ${Number(it.branch_amount ?? 0) < 0 ? "text-amber-600" : ""}`}>
+                    <td className={`border border-zinc-400 px-2 py-1 text-right font-mono whitespace-nowrap ${Number(it.branch_amount ?? 0) < 0 ? "text-amber-600" : ""}`}>
                       ${Number(it.branch_amount ?? 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                     </td>
                   </tr>
@@ -270,12 +311,17 @@ export default function PrintSettlementPage() {
               })}
               {/* 合計列 */}
               <tr className="bg-zinc-100 font-semibold">
-                <td colSpan={8} className="border border-zinc-400 px-2 py-1.5 text-right">合計</td>
-                <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono text-rose-600">
-                  ${total.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
-                </td>
+                <td colSpan={7} className="border border-zinc-400 px-2 py-1.5 text-right">合計</td>
+                {internal && (
+                  <>
+                    <td className="border border-zinc-400 px-2 py-1.5"></td>
+                    <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono whitespace-nowrap">
+                      ${totalCost.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                    </td>
+                  </>
+                )}
                 <td className="border border-zinc-400 px-2 py-1.5"></td>
-                <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono">
+                <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono whitespace-nowrap text-rose-600">
                   ${totalBranch.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                 </td>
               </tr>
@@ -285,9 +331,13 @@ export default function PrintSettlementPage() {
           {/* 說明 */}
           <div className="mt-3 text-[10px] text-zinc-500">
             ※ 類型說明：HQ 進貨 = 總倉直接出貨給本店；空中轉入 = 別店空中轉來（加應付）；空中轉出 = 空中轉去別店（減應付）；
-            自由轉入／轉出 = 店間自由轉貨（估價入帳）；退貨沖回 = 退貨回總倉（減應付）。
-            <br />
-            ※ 價格口徑：成本單價 = 出貨當下成本；分店單價 = 收貨當下生效之分店價；兩口徑分開計算。自由轉貨行以估價入帳、兩口徑同額。
+            自由轉入／轉出 = 店間自由轉貨（轉貨時申報金額入帳）；退貨沖回 = 退貨回總倉（減應付）。
+            {internal && (
+              <>
+                <br />
+                ※ 價格口徑：成本單價 = 出貨當下成本；分店單價 = 收貨當下生效之分店價。應付金額以分店價口徑計，成本口徑供總倉毛利參考。
+              </>
+            )}
           </div>
 
           {/* 簽收區 */}

--- a/apps/admin/src/app/(protected)/finance/receivables/print/page.tsx
+++ b/apps/admin/src/app/(protected)/finance/receivables/print/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import { useRole, canSeeCost } from "@/lib/role";
 
 type Settlement = {
   id: number;
@@ -50,6 +51,9 @@ const ENTRY_TYPE_LABEL: Record<SettlementItem["entry_type"], string> = {
 type PrintView = "store" | "internal";
 
 export default function PrintSettlementPage() {
+  const role = useRole();
+  // 分店帳號只能看分店版（不含成本）
+  const costAllowed = canSeeCost(role);
   const [settlementId, setSettlementId] = useState<number | null>(null);
   const [view, setView] = useState<PrintView>("store");
   const [settlement, setSettlement] = useState<Settlement | null>(null);
@@ -152,7 +156,7 @@ export default function PrintSettlementPage() {
   const totalCost = items.reduce((s, it) => s + Number(it.line_amount), 0);
   const totalBranch = items.reduce((s, it) => s + Number(it.branch_amount ?? 0), 0);
   const today = new Date().toLocaleDateString("zh-TW");
-  const internal = view === "internal";
+  const internal = view === "internal" && costAllowed;
 
   return (
     <>
@@ -177,20 +181,22 @@ export default function PrintSettlementPage() {
           <span className="text-sm text-zinc-500">
             {store.name} / {monthLabel} / 應付總倉 ${Number(settlement.payable_amount).toLocaleString()}
           </span>
-          <div className="flex overflow-hidden rounded-md border border-zinc-300 text-sm">
-            <SpinButton
-              onClick={() => setView("store")}
-              className={`px-3 py-1.5 ${!internal ? "bg-zinc-900 font-semibold text-white" : "bg-white text-zinc-600 hover:bg-zinc-100"}`}
-            >
-              分店版（給店家）
-            </SpinButton>
-            <SpinButton
-              onClick={() => setView("internal")}
-              className={`px-3 py-1.5 ${internal ? "bg-zinc-900 font-semibold text-white" : "bg-white text-zinc-600 hover:bg-zinc-100"}`}
-            >
-              內部版（含成本）
-            </SpinButton>
-          </div>
+          {costAllowed && (
+            <div className="flex overflow-hidden rounded-md border border-zinc-300 text-sm">
+              <SpinButton
+                onClick={() => setView("store")}
+                className={`px-3 py-1.5 ${!internal ? "bg-zinc-900 font-semibold text-white" : "bg-white text-zinc-600 hover:bg-zinc-100"}`}
+              >
+                分店版（給店家）
+              </SpinButton>
+              <SpinButton
+                onClick={() => setView("internal")}
+                className={`px-3 py-1.5 ${internal ? "bg-zinc-900 font-semibold text-white" : "bg-white text-zinc-600 hover:bg-zinc-100"}`}
+              >
+                內部版（含成本）
+              </SpinButton>
+            </div>
+          )}
           <SpinButton
             onClick={() => window.print()}
             className="ml-auto rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-blue-700"

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -8,6 +8,7 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 import { ReleaseNotesProvider, ReleaseNotesBell } from "@/components/ReleaseNotes";
 import { TrialBanner, TrialExpiredScreen } from "@/components/TrialGate";
 import { getTenantName } from "@/lib/tenant";
+import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 
 type NavItem = { href: string; label: string; match: RegExp };
@@ -125,9 +126,53 @@ function filterNavForBranch(nav: NavGroup[]): NavGroup[] {
     .filter((g) => !g.title || !BRANCH_HIDDEN_GROUPS.has(g.title))
     .map((g) => ({
       ...g,
-      items: g.items.filter((it) => !BRANCH_HIDDEN_HREFS.has(it.href)),
+      items: g.items
+        .filter((it) => !BRANCH_HIDDEN_HREFS.has(it.href))
+        // 分店帳號看到的是店家核對介面，選單改叫「月結對帳」
+        .map((it) => (it.href === "/transfers/settlement" ? { ...it, label: "月結對帳" } : it)),
     }))
     .filter((g) => g.items.length > 0);
+}
+
+// 月結對帳待辦數（分店：待核對+待匯款；總部：待處理爭議+待確認收款）。
+// 掛在「月結算」選單當通知小數字；換頁/回到視窗/對帳操作後重抓。
+export const SETTLEMENT_BADGE_REFRESH_EVENT = "settlement-badge-refresh";
+
+function useSettlementActionCount(enabled: boolean, pathname: string | null): number {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const { data } = await getSupabase().rpc("rpc_settlement_action_count");
+        if (!cancelled && typeof data === "number") setCount(data);
+      } catch {
+        /* badge 失敗不影響操作 */
+      }
+    };
+    void load();
+    const onRefresh = () => { void load(); };
+    window.addEventListener("focus", onRefresh);
+    window.addEventListener(SETTLEMENT_BADGE_REFRESH_EVENT, onRefresh);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("focus", onRefresh);
+      window.removeEventListener(SETTLEMENT_BADGE_REFRESH_EVENT, onRefresh);
+    };
+  }, [enabled, pathname]);
+
+  return count;
+}
+
+function NavBadge({ count }: { count: number }) {
+  if (count <= 0) return null;
+  return (
+    <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold leading-none text-white">
+      {count > 99 ? "99+" : count}
+    </span>
+  );
 }
 
 export default function ProtectedLayout({ children }: { children: ReactNode }) {
@@ -137,6 +182,8 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const tenantName = tenant?.name ?? getTenantName();
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const settlementCount = useSettlementActionCount(!!session, pathname);
+  const navBadges: Record<string, number> = { "/transfers/settlement": settlementCount };
 
   // 載入 collapsed groups (localStorage)
   useEffect(() => {
@@ -255,7 +302,10 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
                             }
                           >
                             <span>{it.label}</span>
-                            {active && <span className="text-xs opacity-60">›</span>}
+                            <span className="flex items-center gap-1.5">
+                              <NavBadge count={navBadges[it.href] ?? 0} />
+                              {active && <span className="text-xs opacity-60">›</span>}
+                            </span>
                           </Link>
                         </li>
                       );
@@ -362,7 +412,10 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
                                 }
                               >
                                 <span>{it.label}</span>
-                                {active && <span className="text-xs opacity-60">›</span>}
+                                <span className="flex items-center gap-1.5">
+                                  <NavBadge count={navBadges[it.href] ?? 0} />
+                                  {active && <span className="text-xs opacity-60">›</span>}
+                                </span>
                               </Link>
                             </li>
                           );

--- a/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
@@ -127,7 +127,7 @@ export default function SettlementPage() {
         <h1 className="text-xl font-semibold">月結算</h1>
         <p className="text-sm text-zinc-500">
           總倉對各分店：賣斷制、依 hq_to_store 已收貨 transfers 計算貨款（含空中轉調整）。
-          每筆分錄同時帶成本價與分店價兩個口徑分開計算。
+          應付金額以分店價口徑計；成本口徑另計、供總倉毛利參考。
         </p>
       </header>
 
@@ -210,7 +210,7 @@ function HqToStoreTab() {
       if (e) throw new Error(e.message);
       const r = data as { stores_count?: number; total_cost_amount?: number; total_branch_amount?: number };
       setGenResult(
-        `已產生 ${r?.stores_count ?? 0} 家分店 ${genMonth} 月結算（成本價口徑 $${r?.total_cost_amount?.toLocaleString?.() ?? 0}／分店價口徑 $${r?.total_branch_amount?.toLocaleString?.() ?? 0}）。`,
+        `已產生 ${r?.stores_count ?? 0} 家分店 ${genMonth} 月結算（應付合計（分店價口徑）$${r?.total_branch_amount?.toLocaleString?.() ?? 0}／成本口徑 $${r?.total_cost_amount?.toLocaleString?.() ?? 0}）。`,
       );
       setReloadTick((t) => t + 1);
     } catch (err) {
@@ -221,7 +221,7 @@ function HqToStoreTab() {
   }
 
   const totalPayable = rows?.reduce((sum, r) => sum + Number(r.payable_amount), 0) ?? 0;
-  const totalBranch = rows?.reduce((sum, r) => sum + Number(r.branch_amount ?? 0), 0) ?? 0;
+  const totalCost = rows?.reduce((sum, r) => sum + Number(r.cost_amount ?? 0), 0) ?? 0;
 
   return (
     <>
@@ -288,8 +288,8 @@ function HqToStoreTab() {
             <tr>
               <Th>月份</Th>
               <Th>分店</Th>
-              <Th className="text-right">應付總倉（成本價）</Th>
-              <Th className="text-right">分店價口徑</Th>
+              <Th className="text-right">應付總倉（分店價）</Th>
+              <Th className="text-right">成本口徑（參考）</Th>
               <Th className="text-right">調撥單數</Th>
               <Th className="text-right">商品行數</Th>
               <Th>狀態</Th>
@@ -312,7 +312,7 @@ function HqToStoreTab() {
                     <span className="text-zinc-700 dark:text-zinc-200">{s?.name ?? `#${r.store_id}`}</span>
                   </Td>
                   <Td className="text-right font-mono text-rose-600">${Number(r.payable_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}</Td>
-                  <Td className="text-right font-mono text-sky-700 dark:text-sky-400">${Number(r.branch_amount ?? 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}</Td>
+                  <Td className="text-right font-mono text-zinc-500">${Number(r.cost_amount ?? 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}</Td>
                   <Td className="text-right font-mono">{r.transfer_count}</Td>
                   <Td className="text-right font-mono">{r.item_count}</Td>
                   <Td><span className={`inline-block rounded px-2 py-0.5 text-xs ${STATUS_COLOR[r.status]}`}>{STATUS_LABEL[r.status]}</span></Td>
@@ -335,8 +335,8 @@ function HqToStoreTab() {
                 <td className="px-3 py-2 text-right font-mono font-medium text-rose-600">
                   ${totalPayable.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                 </td>
-                <td className="px-3 py-2 text-right font-mono font-medium text-sky-700 dark:text-sky-400">
-                  ${totalBranch.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                <td className="px-3 py-2 text-right font-mono font-medium text-zinc-500">
+                  ${totalCost.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                 </td>
                 <td colSpan={4}></td>
               </tr>
@@ -353,12 +353,14 @@ function HqToStoreTab() {
       >
         {detail && (
           <HqToStoreDetail
+            key={detail.id}
             settlement={detail}
             store={stores.get(detail.store_id) ?? null}
             onConfirmed={() => {
               setDetail(null);
               setReloadTick((t) => t + 1);
             }}
+            onChanged={() => setReloadTick((t) => t + 1)}
           />
         )}
       </Modal>
@@ -370,21 +372,41 @@ function HqToStoreDetail({
   settlement,
   store,
   onConfirmed,
+  onChanged,
 }: {
   settlement: HqToStoreSettlement;
   store: Store | null;
   onConfirmed: () => void;
+  onChanged: () => void;
 }) {
   const [items, setItems] = useState<HqToStoreItem[] | null>(null);
   const [transfers, setTransfers] = useState<Map<number, Transfer>>(new Map());
   const [skus, setSkus] = useState<Map<number, Sku>>(new Map());
   const [confirming, setConfirming] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  // 改估價後整個月的 draft 會重算，明細與表頭金額都要重抓
+  const [refreshTick, setRefreshTick] = useState(0);
+  const [header, setHeader] = useState<HqToStoreSettlement>(settlement);
+
+  // 自由轉貨行改估價
+  const [editItem, setEditItem] = useState<HqToStoreItem | null>(null);
+  const [editAmount, setEditAmount] = useState("");
+  const [editReason, setEditReason] = useState("");
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       const sb = getSupabase();
+      if (refreshTick > 0) {
+        const { data: h } = await sb
+          .from("store_monthly_settlements")
+          .select("id, settlement_month, store_id, payable_amount, cost_amount, branch_amount, transfer_count, item_count, status, confirmed_at, settled_at, generated_receivable_id, notes, updated_at")
+          .eq("id", settlement.id)
+          .maybeSingle();
+        if (cancelled) return;
+        if (h) setHeader(h as HqToStoreSettlement);
+      }
       const { data, error } = await sb
         .from("store_monthly_settlement_items")
         .select("id, transfer_id, transfer_item_id, sku_id, qty_received, unit_cost, line_amount, unit_branch_price, branch_amount, received_at, entry_type, description")
@@ -411,7 +433,37 @@ function HqToStoreDetail({
       setSkus(skMap);
     })();
     return () => { cancelled = true; };
-  }, [settlement.id]);
+  }, [settlement.id, refreshTick]);
+
+  async function onSaveEstimate() {
+    if (!editItem) return;
+    const amt = Number(editAmount);
+    if (!Number.isFinite(amt) || amt < 0) { setErr("估價需為 >= 0 的數字"); return; }
+    setSaving(true);
+    setErr(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) throw new Error("尚未登入");
+      const { error } = await sb.rpc("rpc_update_free_transfer_amount", {
+        p_transfer_item_id: editItem.transfer_item_id,
+        p_new_amount: amt,
+        p_operator: operator,
+        p_reason: editReason.trim() || null,
+      });
+      if (error) throw new Error(error.message);
+      setEditItem(null);
+      setEditAmount("");
+      setEditReason("");
+      setRefreshTick((t) => t + 1);
+      onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
 
   async function onConfirm() {
     if (!confirm("確認此月結算？確認後將自動產生應付帳款單入帳。")) return;
@@ -435,23 +487,25 @@ function HqToStoreDetail({
     }
   }
 
+  const isDraft = header.status === "draft";
+
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-3 gap-3 text-sm">
-        <Stat label="分店" value={store?.name ?? `#${settlement.store_id}`} />
-        <Stat label="月份" value={settlement.settlement_month?.slice(0, 7)} />
-        <Stat label="狀態" value={STATUS_LABEL[settlement.status]} />
-        <Stat label="應付金額（成本價口徑）" value={`$${Number(settlement.payable_amount).toLocaleString("zh-TW")}`} accent="negative" />
-        <Stat label="分店價口徑金額" value={`$${Number(settlement.branch_amount ?? 0).toLocaleString("zh-TW")}`} accent="info" />
-        <Stat label="口徑差額（總部毛利）" value={`$${(Number(settlement.branch_amount ?? 0) - Number(settlement.cost_amount ?? settlement.payable_amount)).toLocaleString("zh-TW")}`} />
-        <Stat label="調撥單數" value={String(settlement.transfer_count)} />
-        <Stat label="商品行數" value={String(settlement.item_count)} />
+        <Stat label="分店" value={store?.name ?? `#${header.store_id}`} />
+        <Stat label="月份" value={header.settlement_month?.slice(0, 7)} />
+        <Stat label="狀態" value={STATUS_LABEL[header.status]} />
+        <Stat label="應付金額（分店價口徑）" value={`$${Number(header.payable_amount).toLocaleString("zh-TW")}`} accent="negative" />
+        <Stat label="成本口徑金額（參考）" value={`$${Number(header.cost_amount ?? 0).toLocaleString("zh-TW")}`} />
+        <Stat label="口徑差額（總部毛利）" value={`$${(Number(header.branch_amount ?? 0) - Number(header.cost_amount ?? 0)).toLocaleString("zh-TW")}`} accent="info" />
+        <Stat label="調撥單數" value={String(header.transfer_count)} />
+        <Stat label="商品行數" value={String(header.item_count)} />
       </div>
 
       <div className="flex items-center justify-between gap-2">
         <div className="text-xs text-zinc-500">
-          {settlement.generated_receivable_id && (
-            <span>已產生 HQ 應收單 #{settlement.generated_receivable_id}</span>
+          {header.generated_receivable_id && (
+            <span>已產生 HQ 應收單 #{header.generated_receivable_id}</span>
           )}
         </div>
         <a
@@ -468,8 +522,54 @@ function HqToStoreDetail({
         <div className="mb-2 text-sm font-medium">出貨明細（{items?.length ?? 0} 筆）</div>
         <p className="mb-2 text-xs text-zinc-500">
           📦 HQ 進貨：總倉送來；✈️ 空中轉入：別店空中轉來（加應付）；✈️ 空中轉出：空中轉去別店（減應付，金額負）。
-          每行同時列成本價（出貨當下成本）與分店價（收貨當下生效分店價）兩個口徑分開計算；自由轉貨行以估價入帳、兩口徑同額。
+          應付以分店價口徑計、成本口徑供毛利參考；自由轉貨行以轉貨時申報的估價入帳、兩口徑同額，
+          {isDraft ? "金額回報錯誤可按行內「改估價」修正（兩邊分店的 draft 會一起重算）。" : "已確認的結算不可再改估價。"}
         </p>
+
+        {editItem && (
+          <div className="mb-2 rounded-md border border-violet-300 bg-violet-50 p-3 text-sm dark:border-violet-800 dark:bg-violet-950">
+            <div className="mb-2 text-xs text-violet-800 dark:text-violet-300">
+              修改自由轉貨估價：<span className="font-medium">{editItem.description ?? `#${editItem.transfer_item_id}`}</span>
+              （目前 ${Math.abs(Number(editItem.line_amount)).toLocaleString("zh-TW")}）
+            </div>
+            <div className="flex flex-wrap items-end gap-2">
+              <label className="text-xs">
+                <span className="mb-1 block text-zinc-500">新估價（總額）</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={editAmount}
+                  onChange={(e) => setEditAmount(e.target.value)}
+                  className="w-32 rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                />
+              </label>
+              <label className="flex-1 text-xs">
+                <span className="mb-1 block text-zinc-500">修正原因（選填）</span>
+                <input
+                  value={editReason}
+                  onChange={(e) => setEditReason(e.target.value)}
+                  placeholder="例：店端回報金額與實際分店價不符"
+                  className="w-full rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                />
+              </label>
+              <SpinButton
+                onClick={onSaveEstimate}
+                disabled={saving}
+                className="rounded-md bg-violet-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-violet-800 disabled:opacity-50"
+              >
+                {saving ? "儲存中…" : "儲存並重算"}
+              </SpinButton>
+              <SpinButton
+                onClick={() => { setEditItem(null); setErr(null); }}
+                disabled={saving}
+                className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700"
+              >
+                取消
+              </SpinButton>
+            </div>
+          </div>
+        )}
         <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
           <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
             <thead className="bg-zinc-50 dark:bg-zinc-900">
@@ -483,17 +583,19 @@ function HqToStoreDetail({
                 <Th className="text-right">成本小計</Th>
                 <Th className="text-right">分店單價</Th>
                 <Th className="text-right">分店小計</Th>
+                {isDraft && <Th className="text-right">操作</Th>}
               </tr>
             </thead>
             <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
               {items === null ? (
-                <tr><td colSpan={9} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+                <tr><td colSpan={isDraft ? 10 : 9} className="p-3 text-center text-zinc-500">載入中…</td></tr>
               ) : items.length === 0 ? (
-                <tr><td colSpan={9} className="p-3 text-center text-zinc-500">無明細。</td></tr>
+                <tr><td colSpan={isDraft ? 10 : 9} className="p-3 text-center text-zinc-500">無明細。</td></tr>
               ) : items.map((it) => {
                 const tx = transfers.get(it.transfer_id);
                 const sku = skus.get(it.sku_id);
                 const isNeg = Number(it.line_amount) < 0;
+                const isFree = it.entry_type === "free_in" || it.entry_type === "free_out";
                 return (
                   <tr key={it.id}>
                     <Td>
@@ -524,6 +626,23 @@ function HqToStoreDetail({
                     <Td className={`text-right font-mono ${Number(it.branch_amount ?? 0) < 0 ? "text-amber-600" : "text-sky-700 dark:text-sky-400"}`}>
                       ${Number(it.branch_amount ?? 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                     </Td>
+                    {isDraft && (
+                      <Td className="text-right">
+                        {isFree && (
+                          <SpinButton
+                            onClick={() => {
+                              setEditItem(it);
+                              setEditAmount(String(Math.abs(Number(it.line_amount))));
+                              setEditReason("");
+                              setErr(null);
+                            }}
+                            className="rounded-md border border-violet-300 px-2 py-1 text-xs text-violet-700 hover:bg-violet-50 dark:border-violet-800 dark:text-violet-300 dark:hover:bg-violet-950"
+                          >
+                            改估價
+                          </SpinButton>
+                        )}
+                      </Td>
+                    )}
                   </tr>
                 );
               })}
@@ -532,13 +651,14 @@ function HqToStoreDetail({
               <tfoot className="bg-zinc-50 dark:bg-zinc-900">
                 <tr>
                   <td colSpan={6} className="px-3 py-2 text-right text-xs text-zinc-500">合計</td>
-                  <td className="px-3 py-2 text-right font-mono font-medium text-rose-600">
+                  <td className="px-3 py-2 text-right font-mono font-medium text-zinc-500">
                     ${items.reduce((sum, it) => sum + Number(it.line_amount), 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                   </td>
                   <td></td>
                   <td className="px-3 py-2 text-right font-mono font-medium text-sky-700 dark:text-sky-400">
                     ${items.reduce((sum, it) => sum + Number(it.branch_amount ?? 0), 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                   </td>
+                  {isDraft && <td></td>}
                 </tr>
               </tfoot>
             )}
@@ -552,7 +672,7 @@ function HqToStoreDetail({
         </div>
       )}
 
-      {settlement.status === "draft" && (
+      {isDraft && (
         <div className="flex justify-end">
           <SpinButton
             onClick={onConfirm}

--- a/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
@@ -408,8 +408,12 @@ function HqToStoreTab() {
             onConfirmed={() => {
               setDetail(null);
               setReloadTick((t) => t + 1);
+              window.dispatchEvent(new Event("settlement-badge-refresh"));
             }}
-            onChanged={() => setReloadTick((t) => t + 1)}
+            onChanged={() => {
+              setReloadTick((t) => t + 1);
+              window.dispatchEvent(new Event("settlement-badge-refresh"));
+            }}
           />
         )}
       </Modal>

--- a/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
@@ -5,9 +5,11 @@ import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { withBasePath } from "@/lib/basePath";
 import SpinButton from "@/components/SpinButton";
+import { useRole, isHqRole } from "@/lib/role";
+import StoreSettlementReview from "@/components/StoreSettlementReview";
 
 type SettlementStatus = "draft" | "confirmed" | "settled" | "disputed";
-type SettlementStatusExt = SettlementStatus | "cancelled";
+type SettlementStatusExt = SettlementStatus | "cancelled" | "sent" | "remitted";
 
 type StoreToStoreSettlement = {
   id: number;
@@ -40,7 +42,33 @@ type HqToStoreSettlement = {
   generated_receivable_id: number | null;
   notes: string | null;
   updated_at: string;
+  sent_at: string | null;
+  store_agreed_at: string | null;
+  remitted_at: string | null;
+  remit_note: string | null;
 };
+
+type SettlementDispute = {
+  id: number;
+  settlement_id: number;
+  transfer_item_id: number;
+  item_snapshot: {
+    entry_type?: string;
+    description?: string | null;
+    sku_id?: number;
+    qty_received?: number;
+    branch_amount?: number;
+    received_at?: string;
+  };
+  reason: string;
+  status: "open" | "resolved";
+  raised_at: string;
+  resolved_at: string | null;
+  resolution_note: string | null;
+};
+
+const SETTLEMENT_SELECT =
+  "id, settlement_month, store_id, payable_amount, cost_amount, branch_amount, transfer_count, item_count, status, confirmed_at, settled_at, generated_receivable_id, notes, updated_at, sent_at, store_agreed_at, remitted_at, remit_note";
 
 type Store = { id: number; code: string; name: string };
 
@@ -95,16 +123,20 @@ type Sku = { id: number; sku_code: string | null; product_name: string | null; v
 
 const STATUS_LABEL: Record<SettlementStatusExt, string> = {
   draft: "草稿",
-  confirmed: "已確認",
-  settled: "已結清",
-  disputed: "爭議中",
+  sent: "已送店家核對",
+  disputed: "店家有爭議",
+  confirmed: "已鎖定待匯款",
+  remitted: "店家已匯款",
+  settled: "已結案",
   cancelled: "已取消",
 };
 const STATUS_COLOR: Record<SettlementStatusExt, string> = {
   draft: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
-  confirmed: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
-  settled: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+  sent: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
   disputed: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+  confirmed: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  remitted: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
+  settled: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
   cancelled: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400",
 };
 
@@ -121,6 +153,24 @@ function monthToDate(m: string): string {
 // 註：「店間互調」tab (StoreToStoreTab) 隱藏中 — 目前所有調撥都走 HQ 中轉、
 // 直接店間互調 transfer 一直為 0。component 保留以備未來啟用、schema/RPC 不動。
 export default function SettlementPage() {
+  const role = useRole();
+
+  // 分店帳號：走店家對帳流程（線上核對/畫押/爭議/已匯款），不見成本口徑
+  if (role !== null && !isHqRole(role)) {
+    return (
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <header>
+          <h1 className="text-xl font-semibold">月結對帳</h1>
+          <p className="text-sm text-zinc-500">
+            總部送來的月結對帳單：逐筆核對，有問題的行按「有問題」附備註送出爭議；
+            全部無誤按「同意畫押」鎖定，匯款後回來按「我已匯款」。
+          </p>
+        </header>
+        <StoreSettlementReview />
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
       <header>
@@ -128,6 +178,7 @@ export default function SettlementPage() {
         <p className="text-sm text-zinc-500">
           總倉對各分店：賣斷制、依 hq_to_store 已收貨 transfers 計算貨款（含空中轉調整）。
           應付金額以分店價口徑計；成本口徑另計、供總倉毛利參考。
+          流程：產生 → 送店家核對 → （爭議處理）→ 雙方同意鎖定 → 店家匯款 → 收款結案。
         </p>
       </header>
 
@@ -163,9 +214,7 @@ function HqToStoreTab() {
         const sb = getSupabase();
         let q = sb
           .from("store_monthly_settlements")
-          .select(
-            "id, settlement_month, store_id, payable_amount, cost_amount, branch_amount, transfer_count, item_count, status, confirmed_at, settled_at, generated_receivable_id, notes, updated_at",
-          )
+          .select(SETTLEMENT_SELECT)
           .order("settlement_month", { ascending: false })
           .order("store_id", { ascending: true })
           .limit(200);
@@ -382,9 +431,11 @@ function HqToStoreDetail({
   const [items, setItems] = useState<HqToStoreItem[] | null>(null);
   const [transfers, setTransfers] = useState<Map<number, Transfer>>(new Map());
   const [skus, setSkus] = useState<Map<number, Sku>>(new Map());
+  const [disputes, setDisputes] = useState<SettlementDispute[]>([]);
   const [confirming, setConfirming] = useState(false);
+  const [acting, setActing] = useState(false);
   const [err, setErr] = useState<string | null>(null);
-  // 改估價後整個月的 draft 會重算，明細與表頭金額都要重抓
+  // 改估價/流程操作後表頭與明細都要重抓
   const [refreshTick, setRefreshTick] = useState(0);
   const [header, setHeader] = useState<HqToStoreSettlement>(settlement);
 
@@ -401,19 +452,28 @@ function HqToStoreDetail({
       if (refreshTick > 0) {
         const { data: h } = await sb
           .from("store_monthly_settlements")
-          .select("id, settlement_month, store_id, payable_amount, cost_amount, branch_amount, transfer_count, item_count, status, confirmed_at, settled_at, generated_receivable_id, notes, updated_at")
+          .select(SETTLEMENT_SELECT)
           .eq("id", settlement.id)
           .maybeSingle();
         if (cancelled) return;
-        if (h) setHeader(h as HqToStoreSettlement);
+        if (h) setHeader(h as unknown as HqToStoreSettlement);
       }
-      const { data, error } = await sb
-        .from("store_monthly_settlement_items")
-        .select("id, transfer_id, transfer_item_id, sku_id, qty_received, unit_cost, line_amount, unit_branch_price, branch_amount, received_at, entry_type, description")
-        .eq("settlement_id", settlement.id)
-        .order("entry_type", { ascending: true })
-        .order("received_at", { ascending: true });
+      const [{ data, error }, { data: dData }] = await Promise.all([
+        sb
+          .from("store_monthly_settlement_items")
+          .select("id, transfer_id, transfer_item_id, sku_id, qty_received, unit_cost, line_amount, unit_branch_price, branch_amount, received_at, entry_type, description")
+          .eq("settlement_id", settlement.id)
+          .order("entry_type", { ascending: true })
+          .order("received_at", { ascending: true }),
+        sb
+          .from("store_settlement_disputes")
+          .select("id, settlement_id, transfer_item_id, item_snapshot, reason, status, raised_at, resolved_at, resolution_note")
+          .eq("settlement_id", settlement.id)
+          .order("status", { ascending: false })
+          .order("raised_at", { ascending: true }),
+      ]);
       if (cancelled) return;
+      setDisputes((dData ?? []) as SettlementDispute[]);
       if (error) { setErr(error.message); setItems([]); return; }
       const list = (data ?? []) as HqToStoreItem[];
       setItems(list);
@@ -466,7 +526,7 @@ function HqToStoreDetail({
   }
 
   async function onConfirm() {
-    if (!confirm("確認此月結算？確認後將自動產生應付帳款單入帳。")) return;
+    if (!confirm("直接確認此月結算（跳過店家線上核對）？確認後鎖定並自動產生應付帳款單。")) return;
     setConfirming(true);
     setErr(null);
     try {
@@ -487,7 +547,66 @@ function HqToStoreDetail({
     }
   }
 
+  // 通用流程動作（送單 / 處理爭議 / 收款結案）
+  async function runFlowAction(fn: (operator: string) => Promise<void>) {
+    setActing(true);
+    setErr(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) throw new Error("尚未登入");
+      await fn(operator);
+      setRefreshTick((t) => t + 1);
+      onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setActing(false);
+    }
+  }
+
+  function onSendToStore() {
+    const isResend = header.status === "disputed";
+    if (!confirm(isResend ? "爭議已處理完，重新送店家核對？" : "送出對帳單給店家線上核對？")) return;
+    void runFlowAction(async (operator) => {
+      const { error } = await getSupabase().rpc("rpc_send_settlement_to_store", {
+        p_settlement_id: settlement.id,
+        p_operator: operator,
+      });
+      if (error) throw new Error(error.message);
+    });
+  }
+
+  function onResolveDispute(d: SettlementDispute) {
+    const note = window.prompt("處理說明（選填，例：已修正估價為 $280）", "");
+    if (note === null) return;
+    void runFlowAction(async (operator) => {
+      const { error } = await getSupabase().rpc("rpc_resolve_settlement_dispute", {
+        p_dispute_id: d.id,
+        p_operator: operator,
+        p_note: note.trim() || null,
+      });
+      if (error) throw new Error(error.message);
+    });
+  }
+
+  function onSettle() {
+    if (!confirm("確認已收到店家匯款？結案後應收單將自動入帳，不可再改。")) return;
+    void runFlowAction(async (operator) => {
+      const { error } = await getSupabase().rpc("rpc_settle_store_monthly_settlement", {
+        p_settlement_id: settlement.id,
+        p_operator: operator,
+        p_note: null,
+      });
+      if (error) throw new Error(error.message);
+    });
+  }
+
   const isDraft = header.status === "draft";
+  // 鎖定（confirmed）前都可修估價；生成器會同步重建 draft/sent/disputed
+  const canEditEst = ["draft", "sent", "disputed"].includes(header.status);
+  const openDisputes = disputes.filter((d) => d.status === "open");
 
   return (
     <div className="space-y-4">
@@ -501,6 +620,72 @@ function HqToStoreDetail({
         <Stat label="調撥單數" value={String(header.transfer_count)} />
         <Stat label="商品行數" value={String(header.item_count)} />
       </div>
+
+      {/* 流程狀態列 */}
+      {header.status === "sent" && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
+          📨 已送店家核對（{header.sent_at ? new Date(header.sent_at).toLocaleString("zh-TW") : "—"}），等待店家同意畫押或提出爭議。
+        </div>
+      )}
+      {header.status === "confirmed" && (
+        <div className="rounded-md border border-blue-300 bg-blue-50 p-3 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300">
+          🔒 雙方已同意鎖定{header.store_agreed_at ? `（店家畫押：${new Date(header.store_agreed_at).toLocaleString("zh-TW")}）` : "（總部直接確認）"}，等待店家匯款。
+        </div>
+      )}
+      {header.status === "remitted" && (
+        <div className="rounded-md border border-indigo-300 bg-indigo-50 p-3 text-sm text-indigo-800 dark:border-indigo-800 dark:bg-indigo-950 dark:text-indigo-300">
+          💸 店家已回報匯款（{header.remitted_at ? new Date(header.remitted_at).toLocaleString("zh-TW") : "—"}）
+          {header.remit_note && <>，備註：<span className="font-medium">{header.remit_note}</span></>}
+          。請核對入帳後按「確認收款結案」。
+        </div>
+      )}
+      {header.status === "settled" && (
+        <div className="rounded-md border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+          ✅ 已結案{header.settled_at ? `（${new Date(header.settled_at).toLocaleString("zh-TW")}）` : ""}。
+        </div>
+      )}
+
+      {/* 爭議清單 */}
+      {disputes.length > 0 && (
+        <div className="rounded-md border border-red-200 dark:border-red-900">
+          <div className="border-b border-red-200 bg-red-50 px-3 py-2 text-sm font-medium text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            店家爭議（未處理 {openDisputes.length}／共 {disputes.length} 筆）
+            {header.status === "disputed" && openDisputes.length > 0 && (
+              <span className="ml-2 font-normal">— 修正或說明後逐筆「標記已處理」，全部處理完才能重新送單</span>
+            )}
+          </div>
+          <ul className="divide-y divide-red-100 dark:divide-red-950">
+            {disputes.map((d) => (
+              <li key={d.id} className="flex items-start gap-3 px-3 py-2 text-sm">
+                <span className={`mt-0.5 inline-block rounded px-2 py-0.5 text-xs ${d.status === "open" ? "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300" : "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"}`}>
+                  {d.status === "open" ? "未處理" : "已處理"}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="text-xs text-zinc-500">
+                    {ENTRY_TYPE_LABEL[(d.item_snapshot?.entry_type ?? "hq_inbound") as HqToStoreItem["entry_type"]] ?? d.item_snapshot?.entry_type}
+                    {" · "}
+                    {d.item_snapshot?.description ?? `SKU #${d.item_snapshot?.sku_id ?? "?"}`}
+                    {" · "}${Number(d.item_snapshot?.branch_amount ?? 0).toLocaleString("zh-TW")}
+                  </div>
+                  <div className="break-words">🗣 {d.reason}</div>
+                  {d.resolution_note && (
+                    <div className="text-xs text-emerald-700 dark:text-emerald-400">↳ 總部：{d.resolution_note}</div>
+                  )}
+                </div>
+                {d.status === "open" && (
+                  <SpinButton
+                    onClick={() => onResolveDispute(d)}
+                    disabled={acting}
+                    className="shrink-0 rounded-md border border-emerald-300 px-2 py-1 text-xs text-emerald-700 hover:bg-emerald-50 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-950"
+                  >
+                    標記已處理
+                  </SpinButton>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <div className="flex items-center justify-between gap-2">
         <div className="text-xs text-zinc-500">
@@ -523,7 +708,7 @@ function HqToStoreDetail({
         <p className="mb-2 text-xs text-zinc-500">
           📦 HQ 進貨：總倉送來；✈️ 空中轉入：別店空中轉來（加應付）；✈️ 空中轉出：空中轉去別店（減應付，金額負）。
           應付以分店價口徑計、成本口徑供毛利參考；自由轉貨行以轉貨時申報的估價入帳、兩口徑同額，
-          {isDraft ? "金額回報錯誤可按行內「改估價」修正（兩邊分店的 draft 會一起重算）。" : "已確認的結算不可再改估價。"}
+          {canEditEst ? "金額回報錯誤可按行內「改估價」修正（兩邊分店未鎖定的結算會一起重算）。" : "已鎖定的結算不可再改估價。"}
         </p>
 
         {editItem && (
@@ -583,14 +768,14 @@ function HqToStoreDetail({
                 <Th className="text-right">成本小計</Th>
                 <Th className="text-right">分店單價</Th>
                 <Th className="text-right">分店小計</Th>
-                {isDraft && <Th className="text-right">操作</Th>}
+                {canEditEst && <Th className="text-right">操作</Th>}
               </tr>
             </thead>
             <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
               {items === null ? (
-                <tr><td colSpan={isDraft ? 10 : 9} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+                <tr><td colSpan={canEditEst ? 10 : 9} className="p-3 text-center text-zinc-500">載入中…</td></tr>
               ) : items.length === 0 ? (
-                <tr><td colSpan={isDraft ? 10 : 9} className="p-3 text-center text-zinc-500">無明細。</td></tr>
+                <tr><td colSpan={canEditEst ? 10 : 9} className="p-3 text-center text-zinc-500">無明細。</td></tr>
               ) : items.map((it) => {
                 const tx = transfers.get(it.transfer_id);
                 const sku = skus.get(it.sku_id);
@@ -626,7 +811,7 @@ function HqToStoreDetail({
                     <Td className={`text-right font-mono ${Number(it.branch_amount ?? 0) < 0 ? "text-amber-600" : "text-sky-700 dark:text-sky-400"}`}>
                       ${Number(it.branch_amount ?? 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                     </Td>
-                    {isDraft && (
+                    {canEditEst && (
                       <Td className="text-right">
                         {isFree && (
                           <SpinButton
@@ -658,7 +843,7 @@ function HqToStoreDetail({
                   <td className="px-3 py-2 text-right font-mono font-medium text-sky-700 dark:text-sky-400">
                     ${items.reduce((sum, it) => sum + Number(it.branch_amount ?? 0), 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                   </td>
-                  {isDraft && <td></td>}
+                  {canEditEst && <td></td>}
                 </tr>
               </tfoot>
             )}
@@ -672,17 +857,46 @@ function HqToStoreDetail({
         </div>
       )}
 
-      {isDraft && (
-        <div className="flex justify-end">
+      <div className="flex flex-wrap justify-end gap-2">
+        {isDraft && (
+          <>
+            <SpinButton
+              onClick={onSendToStore}
+              disabled={acting}
+              className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
+            >
+              {acting ? "送出中…" : "📨 送店家線上核對"}
+            </SpinButton>
+            <SpinButton
+              onClick={onConfirm}
+              disabled={confirming}
+              className="rounded-md border border-zinc-300 px-4 py-2 text-sm transition hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              {confirming ? "確認中…" : "直接確認（跳過店家核對）"}
+            </SpinButton>
+          </>
+        )}
+        {header.status === "disputed" && (
           <SpinButton
-            onClick={onConfirm}
-            disabled={confirming}
-            className="rounded-md bg-zinc-900 px-4 py-2 text-sm text-white transition hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
+            onClick={onSendToStore}
+            disabled={acting || openDisputes.length > 0}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
           >
-            {confirming ? "確認中…" : "確認此結算（產生應付帳款單）"}
+            {openDisputes.length > 0
+              ? `還有 ${openDisputes.length} 筆爭議未處理`
+              : acting ? "送出中…" : "📨 重新送店家核對"}
           </SpinButton>
-        </div>
-      )}
+        )}
+        {header.status === "remitted" && (
+          <SpinButton
+            onClick={onSettle}
+            disabled={acting}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {acting ? "處理中…" : "✅ 確認收款結案（應收單入帳）"}
+          </SpinButton>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/admin/src/components/StoreSettlementReview.tsx
+++ b/apps/admin/src/components/StoreSettlementReview.tsx
@@ -1,0 +1,553 @@
+"use client";
+
+// 分店端「月結對帳」：總部送單後線上核對。
+// - 逐行核對，有問題的行按「有問題」+ 必填備註 → 送出爭議（換總部處理）
+// - 全部無誤 → 同意畫押（鎖定、產生應付帳款）
+// - 匯款後按「我已匯款」（可附帳號後五碼），等總部確認收款結案
+// 只顯示分店價口徑（單價/小計），不顯示總倉成本。
+
+import { useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { useAuth } from "@/components/AuthProvider";
+import { Modal } from "@/components/Modal";
+import SpinButton from "@/components/SpinButton";
+
+type StoreRow = { id: number; code: string; name: string };
+
+type Settlement = {
+  id: number;
+  settlement_month: string;
+  store_id: number;
+  payable_amount: number;
+  item_count: number;
+  status: "sent" | "disputed" | "confirmed" | "remitted" | "settled" | "draft" | "cancelled";
+  sent_at: string | null;
+  store_agreed_at: string | null;
+  remitted_at: string | null;
+  remit_note: string | null;
+  settled_at: string | null;
+};
+
+type Item = {
+  id: number;
+  transfer_id: number;
+  transfer_item_id: number;
+  sku_id: number;
+  qty_received: number;
+  unit_branch_price: number;
+  branch_amount: number;
+  received_at: string;
+  entry_type: "hq_inbound" | "air_in" | "air_out" | "free_in" | "free_out" | "return_out";
+  description: string | null;
+};
+
+type Dispute = {
+  id: number;
+  transfer_item_id: number;
+  reason: string;
+  status: "open" | "resolved";
+  resolution_note: string | null;
+};
+
+type Transfer = { id: number; transfer_no: string };
+type Sku = { id: number; sku_code: string | null; product_name: string | null; variant_name: string | null };
+
+const ENTRY_TYPE_LABEL: Record<Item["entry_type"], string> = {
+  hq_inbound: "總倉進貨",
+  air_in: "空中轉入",
+  air_out: "空中轉出",
+  free_in: "自由轉入",
+  free_out: "自由轉出",
+  return_out: "退貨沖回",
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  sent: "待核對",
+  disputed: "爭議處理中",
+  confirmed: "已同意待匯款",
+  remitted: "已匯款待總部確認",
+  settled: "已結案",
+};
+const STATUS_COLOR: Record<string, string> = {
+  sent: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  disputed: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+  confirmed: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  remitted: "bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300",
+  settled: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+};
+
+export default function StoreSettlementReview() {
+  const { user } = useAuth();
+  const [stores, setStores] = useState<StoreRow[]>([]);
+  const [pickedStoreId, setPickedStoreId] = useState<number | null>(null);
+  const [rows, setRows] = useState<Settlement[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadTick, setReloadTick] = useState(0);
+  const [detail, setDetail] = useState<Settlement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data } = await getSupabase().from("stores").select("id, code, name").order("name");
+      if (cancelled) return;
+      setStores((data ?? []) as StoreRow[]);
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // 帳號綁定的店（app_metadata.stores 店名 → stores 列）
+  const myStores = useMemo(() => {
+    const userStores = user?.app_metadata?.stores as unknown;
+    if (!Array.isArray(userStores)) return [];
+    return stores.filter((s) => userStores.includes(s.name));
+  }, [user, stores]);
+  const storeId = pickedStoreId ?? myStores[0]?.id ?? null;
+
+  useEffect(() => {
+    if (storeId === null) return;
+    let cancelled = false;
+    (async () => {
+      const { data, error: e } = await getSupabase()
+        .from("store_monthly_settlements")
+        .select("id, settlement_month, store_id, payable_amount, item_count, status, sent_at, store_agreed_at, remitted_at, remit_note, settled_at")
+        .eq("store_id", storeId)
+        .in("status", ["sent", "disputed", "confirmed", "remitted", "settled"])
+        .order("settlement_month", { ascending: false })
+        .limit(24);
+      if (cancelled) return;
+      if (e) { setError(e.message); setRows([]); return; }
+      setError(null);
+      setRows((data ?? []) as Settlement[]);
+    })();
+    return () => { cancelled = true; };
+  }, [storeId, reloadTick]);
+
+  if (user && myStores.length === 0 && stores.length > 0) {
+    return (
+      <p className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
+        此帳號未綁定分店，請聯絡總部設定。
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {myStores.length > 1 && (
+        <label className="text-sm">
+          <span className="mb-1 block text-xs text-zinc-500">分店</span>
+          <select
+            value={storeId ?? ""}
+            onChange={(e) => setPickedStoreId(Number(e.target.value) || null)}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            {myStores.map((s) => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          <p className="font-mono text-xs">{error}</p>
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+        <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+          <thead className="bg-zinc-50 dark:bg-zinc-900">
+            <tr>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">月份</th>
+              <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">應付金額</th>
+              <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">明細行數</th>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">狀態</th>
+              <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">動作</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+            {rows === null ? (
+              <tr><td colSpan={5} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+            ) : rows.length === 0 ? (
+              <tr><td colSpan={5} className="p-6 text-center text-zinc-500">目前沒有待處理的對帳單。</td></tr>
+            ) : rows.map((r) => (
+              <tr key={r.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
+                <td className="px-3 py-2 font-mono text-xs">{r.settlement_month?.slice(0, 7)}</td>
+                <td className="px-3 py-2 text-right font-mono text-rose-600">
+                  ${Number(r.payable_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                </td>
+                <td className="px-3 py-2 text-right font-mono">{r.item_count}</td>
+                <td className="px-3 py-2">
+                  <span className={`inline-block rounded px-2 py-0.5 text-xs ${STATUS_COLOR[r.status] ?? ""}`}>
+                    {STATUS_LABEL[r.status] ?? r.status}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-right">
+                  <SpinButton
+                    onClick={() => setDetail(r)}
+                    className={`rounded-md px-3 py-1 text-xs ${
+                      r.status === "sent" || r.status === "confirmed"
+                        ? "bg-blue-600 font-medium text-white hover:bg-blue-700"
+                        : "border border-zinc-300 hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                    }`}
+                  >
+                    {r.status === "sent" ? "核對" : r.status === "confirmed" ? "回報匯款" : "查看"}
+                  </SpinButton>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <Modal
+        open={detail !== null}
+        onClose={() => setDetail(null)}
+        title={detail ? `${detail.settlement_month?.slice(0, 7)} 月結對帳單` : ""}
+        maxWidth="max-w-3xl"
+      >
+        {detail && (
+          <ReviewDetail
+            key={detail.id}
+            settlement={detail}
+            onChanged={() => {
+              setDetail(null);
+              setReloadTick((t) => t + 1);
+            }}
+          />
+        )}
+      </Modal>
+    </div>
+  );
+}
+
+function ReviewDetail({ settlement, onChanged }: { settlement: Settlement; onChanged: () => void }) {
+  const [items, setItems] = useState<Item[] | null>(null);
+  const [disputes, setDisputes] = useState<Dispute[]>([]);
+  const [transfers, setTransfers] = useState<Map<number, Transfer>>(new Map());
+  const [skus, setSkus] = useState<Map<number, Sku>>(new Map());
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // 有問題的行：transfer_item_id → 備註
+  const [flags, setFlags] = useState<Map<number, string>>(new Map());
+  const [remitNote, setRemitNote] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const [{ data, error }, { data: dData }] = await Promise.all([
+        sb
+          .from("store_monthly_settlement_items")
+          .select("id, transfer_id, transfer_item_id, sku_id, qty_received, unit_branch_price, branch_amount, received_at, entry_type, description")
+          .eq("settlement_id", settlement.id)
+          .order("entry_type", { ascending: true })
+          .order("received_at", { ascending: true }),
+        sb
+          .from("store_settlement_disputes")
+          .select("id, transfer_item_id, reason, status, resolution_note")
+          .eq("settlement_id", settlement.id)
+          .order("raised_at", { ascending: true }),
+      ]);
+      if (cancelled) return;
+      if (error) { setErr(error.message); setItems([]); return; }
+      setDisputes((dData ?? []) as Dispute[]);
+      const list = (data ?? []) as Item[];
+      setItems(list);
+
+      const txIds = Array.from(new Set(list.map((it) => it.transfer_id)));
+      const skuIds = Array.from(new Set(list.map((it) => it.sku_id)));
+      const [{ data: tx }, { data: sk }] = await Promise.all([
+        txIds.length ? sb.from("transfers").select("id, transfer_no").in("id", txIds) : Promise.resolve({ data: [] as Transfer[] }),
+        skuIds.length ? sb.from("skus").select("id, sku_code, product_name, variant_name").in("id", skuIds) : Promise.resolve({ data: [] as Sku[] }),
+      ]);
+      if (cancelled) return;
+      const tm = new Map<number, Transfer>();
+      for (const t of (tx ?? []) as Transfer[]) tm.set(t.id, t);
+      setTransfers(tm);
+      const sm = new Map<number, Sku>();
+      for (const s of (sk ?? []) as Sku[]) sm.set(s.id, s);
+      setSkus(sm);
+    })();
+    return () => { cancelled = true; };
+  }, [settlement.id]);
+
+  const disputeByItem = useMemo(() => {
+    const m = new Map<number, Dispute>();
+    for (const d of disputes) {
+      const prev = m.get(d.transfer_item_id);
+      if (!prev || d.status === "open") m.set(d.transfer_item_id, d);
+    }
+    return m;
+  }, [disputes]);
+
+  // 爭議行排最上方
+  const sortedItems = useMemo(() => {
+    if (!items) return null;
+    const rank = (it: Item) => {
+      const d = disputeByItem.get(it.transfer_item_id);
+      if (d?.status === "open") return 0;
+      if (d) return 1;
+      return 2;
+    };
+    return [...items].sort((a, b) => rank(a) - rank(b));
+  }, [items, disputeByItem]);
+
+  const isSent = settlement.status === "sent";
+  const flaggedCount = flags.size;
+  const allReasonsFilled = Array.from(flags.values()).every((v) => v.trim().length > 0);
+  const total = (items ?? []).reduce((s, it) => s + Number(it.branch_amount ?? 0), 0);
+
+  async function callRpc(fn: string, params: Record<string, unknown>) {
+    setBusy(true);
+    setErr(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) throw new Error("尚未登入");
+      const { error } = await sb.rpc(fn, { ...params, p_operator: operator });
+      if (error) throw new Error(error.message);
+      onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function onAgree() {
+    if (flaggedCount > 0) return;
+    if (!confirm("確認整份對帳單無誤並同意畫押？同意後金額鎖定、產生應付帳款，不可再提出爭議。")) return;
+    void callRpc("rpc_store_review_settlement", {
+      p_settlement_id: settlement.id,
+      p_agree: true,
+      p_disputes: null,
+    });
+  }
+
+  function onSubmitDisputes() {
+    if (flaggedCount === 0 || !allReasonsFilled) return;
+    if (!confirm(`送出 ${flaggedCount} 筆爭議給總部處理？`)) return;
+    void callRpc("rpc_store_review_settlement", {
+      p_settlement_id: settlement.id,
+      p_agree: false,
+      p_disputes: Array.from(flags.entries()).map(([transfer_item_id, reason]) => ({
+        transfer_item_id,
+        reason: reason.trim(),
+      })),
+    });
+  }
+
+  function onRemit() {
+    if (!confirm("確認已匯款給總部？")) return;
+    void callRpc("rpc_mark_settlement_remitted", {
+      p_settlement_id: settlement.id,
+      p_note: remitNote.trim() || null,
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="text-sm">
+          應付總部金額：
+          <span className="ml-1 font-mono text-lg font-semibold text-rose-600">
+            ${Number(settlement.payable_amount).toLocaleString("zh-TW")}
+          </span>
+        </div>
+        <span className={`inline-block rounded px-2 py-0.5 text-xs ${STATUS_COLOR[settlement.status] ?? ""}`}>
+          {STATUS_LABEL[settlement.status] ?? settlement.status}
+        </span>
+      </div>
+
+      {settlement.status === "disputed" && (
+        <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          已送出爭議，等總部處理後會重新送來核對。爭議行列在最上方。
+        </div>
+      )}
+      {settlement.status === "confirmed" && (
+        <div className="rounded-md border border-blue-300 bg-blue-50 p-3 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300">
+          🔒 對帳單已同意鎖定。請匯款 <span className="font-mono font-semibold">${Number(settlement.payable_amount).toLocaleString("zh-TW")}</span> 給總部後，回來按「我已匯款」。
+        </div>
+      )}
+      {settlement.status === "remitted" && (
+        <div className="rounded-md border border-indigo-300 bg-indigo-50 p-3 text-sm text-indigo-800 dark:border-indigo-800 dark:bg-indigo-950 dark:text-indigo-300">
+          已回報匯款{settlement.remit_note ? `（備註：${settlement.remit_note}）` : ""}，等總部確認收款結案。
+        </div>
+      )}
+      {settlement.status === "settled" && (
+        <div className="rounded-md border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-800 dark:border-emerald-950 dark:bg-emerald-950 dark:text-emerald-300">
+          ✅ 本月對帳已結案，謝謝。
+        </div>
+      )}
+      {isSent && (
+        <p className="text-xs text-zinc-500">
+          逐行核對：金額有問題的行按「有問題」並填原因；全部無誤直接按「同意畫押」。
+        </p>
+      )}
+
+      <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+        <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+          <thead className="bg-zinc-50 dark:bg-zinc-900">
+            <tr>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">類型</th>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">收貨日</th>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">調撥單</th>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">商品</th>
+              <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">數量</th>
+              <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">單價</th>
+              <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">小計</th>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">核對</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+            {sortedItems === null ? (
+              <tr><td colSpan={8} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+            ) : sortedItems.length === 0 ? (
+              <tr><td colSpan={8} className="p-3 text-center text-zinc-500">無明細。</td></tr>
+            ) : sortedItems.map((it) => {
+              const tx = transfers.get(it.transfer_id);
+              const sku = skus.get(it.sku_id);
+              const isFree = it.description != null;
+              const d = disputeByItem.get(it.transfer_item_id);
+              const flagged = flags.has(it.transfer_item_id);
+              return (
+                <tr key={it.id} className={d?.status === "open" ? "bg-red-50 dark:bg-red-950/40" : flagged ? "bg-amber-50 dark:bg-amber-950/40" : ""}>
+                  <td className="whitespace-nowrap px-3 py-2 text-xs">{ENTRY_TYPE_LABEL[it.entry_type] ?? it.entry_type}</td>
+                  <td className="whitespace-nowrap px-3 py-2 text-xs">{new Date(it.received_at).toLocaleDateString("zh-TW")}</td>
+                  <td className="whitespace-nowrap px-3 py-2 font-mono text-xs">{tx?.transfer_no ?? `#${it.transfer_id}`}</td>
+                  <td className="px-3 py-2 text-xs">
+                    {it.description ? (
+                      <span className="break-words">{it.description}</span>
+                    ) : (
+                      <>
+                        <span className="font-mono text-zinc-500">{sku?.sku_code ?? "—"}</span>{" "}
+                        <span>{sku?.product_name ?? "—"}</span>
+                        {sku?.variant_name && <span className="ml-1 text-zinc-400">/ {sku.variant_name}</span>}
+                      </>
+                    )}
+                    {d && (
+                      <div className="mt-1 text-xs text-red-700 dark:text-red-400">
+                        🗣 {d.reason}
+                        {d.status === "resolved" && (
+                          <span className="ml-1 text-emerald-700 dark:text-emerald-400">
+                            （總部已處理{d.resolution_note ? `：${d.resolution_note}` : ""}）
+                          </span>
+                        )}
+                      </div>
+                    )}
+                    {flagged && (
+                      <input
+                        value={flags.get(it.transfer_item_id) ?? ""}
+                        onChange={(e) =>
+                          setFlags((m) => new Map(m).set(it.transfer_item_id, e.target.value))
+                        }
+                        placeholder="請填原因（必填），例：實際金額應為 $280"
+                        className="mt-1 w-full rounded-md border border-amber-400 bg-white px-2 py-1 text-xs dark:border-amber-700 dark:bg-zinc-800"
+                      />
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono">{Number(it.qty_received).toLocaleString()}</td>
+                  <td className="whitespace-nowrap px-3 py-2 text-right font-mono text-zinc-500">
+                    {isFree ? "—" : `$${Number(it.unit_branch_price ?? 0).toFixed(2)}`}
+                  </td>
+                  <td className={`whitespace-nowrap px-3 py-2 text-right font-mono ${Number(it.branch_amount ?? 0) < 0 ? "text-amber-600" : ""}`}>
+                    ${Number(it.branch_amount ?? 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                  </td>
+                  <td className="px-3 py-2">
+                    {isSent ? (
+                      <SpinButton
+                        onClick={() =>
+                          setFlags((m) => {
+                            const next = new Map(m);
+                            if (next.has(it.transfer_item_id)) next.delete(it.transfer_item_id);
+                            else next.set(it.transfer_item_id, "");
+                            return next;
+                          })
+                        }
+                        className={`whitespace-nowrap rounded-md px-2 py-1 text-xs ${
+                          flagged
+                            ? "bg-amber-500 font-medium text-white"
+                            : "border border-zinc-300 text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        }`}
+                      >
+                        {flagged ? "↩ 取消" : "有問題"}
+                      </SpinButton>
+                    ) : d?.status === "open" ? (
+                      <span className="text-xs text-red-600 dark:text-red-400">爭議中</span>
+                    ) : null}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+          {items && items.length > 0 && (
+            <tfoot className="bg-zinc-50 dark:bg-zinc-900">
+              <tr>
+                <td colSpan={6} className="px-3 py-2 text-right text-xs text-zinc-500">合計</td>
+                <td className="px-3 py-2 text-right font-mono font-medium text-rose-600">
+                  ${total.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                </td>
+                <td></td>
+              </tr>
+            </tfoot>
+          )}
+        </table>
+      </div>
+
+      {err && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          <p className="font-mono text-xs">{err}</p>
+        </div>
+      )}
+
+      {isSent && (
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {flaggedCount > 0 ? (
+            <>
+              {!allReasonsFilled && (
+                <span className="text-xs text-amber-700 dark:text-amber-400">每筆有問題的行都要填原因</span>
+              )}
+              <SpinButton
+                onClick={onSubmitDisputes}
+                disabled={busy || !allReasonsFilled}
+                className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {busy ? "送出中…" : `⚠️ 送出爭議（${flaggedCount} 筆）`}
+              </SpinButton>
+            </>
+          ) : (
+            <SpinButton
+              onClick={onAgree}
+              disabled={busy}
+              className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+            >
+              {busy ? "送出中…" : "✅ 全部無誤，同意畫押"}
+            </SpinButton>
+          )}
+        </div>
+      )}
+
+      {settlement.status === "confirmed" && (
+        <div className="flex flex-wrap items-end justify-end gap-2">
+          <label className="text-xs">
+            <span className="mb-1 block text-zinc-500">匯款備註（選填，例：帳號後五碼）</span>
+            <input
+              value={remitNote}
+              onChange={(e) => setRemitNote(e.target.value)}
+              className="w-56 rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </label>
+          <SpinButton
+            onClick={onRemit}
+            disabled={busy}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {busy ? "送出中…" : "💸 我已匯款"}
+          </SpinButton>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/components/StoreSettlementReview.tsx
+++ b/apps/admin/src/components/StoreSettlementReview.tsx
@@ -212,6 +212,7 @@ export default function StoreSettlementReview() {
             onChanged={() => {
               setDetail(null);
               setReloadTick((t) => t + 1);
+              window.dispatchEvent(new Event("settlement-badge-refresh"));
             }}
           />
         )}

--- a/docs/TEST-settlement-estatement-flow.md
+++ b/docs/TEST-settlement-estatement-flow.md
@@ -59,9 +59,17 @@ Migration：`20260715000120_settlement_estatement_flow.sql`
 - [x] T22 rollback 測試後線上無殘留（#47 仍 draft、無 dispute/receivable rows）。
 - [x] T23 HQ 直接確認（跳過核對）路徑保留（confirm v2 接受 draft）。
 
+### 側欄選單通知小數字（migration 20260715000130，追加）
+- [x] T24 `rpc_settlement_action_count()`（線上 rollback 測試）：
+      分店＝自己店 sent+confirmed 筆數（sent=1／confirmed=1／別店 remitted 不算=0）；
+      總部＝全 tenant disputed+remitted（=2）；無 tenant claim=0。
+- [x] T25 側欄「月結算」掛紅色數字（桌機＋手機 drawer 都有）；分店帳號選單
+      改名「月結對帳」；count=0 不顯示。換頁／視窗 focus／對帳操作
+      （settlement-badge-refresh 事件）後重抓。Playwright 3/3 通過。
+
 ## 待辦 / 已知限制
-- [ ] 送單後無推播通知店家（現有 notifications 表是 member/LIFF 導向；店家開
-      月結對帳頁看到「待核對」）。要推播需另做 staff 通知管道。
+- [x] ~~送單後無推播通知店家~~ → 已用側欄選單小數字當通知
+      （rpc_settlement_action_count + layout badge）。真推播（LINE/push）仍未做。
 - [ ] store_monthly_settlement_items 的 RLS 仍 tenant 全讀（歷史政策 auth_read_smsi），
       分店帳號技術上可從 REST 讀到 unit_cost 欄位——UI 已全面隱藏，
       要 API 層鎖成本欄需另開 column-level view migration。

--- a/docs/TEST-settlement-estatement-flow.md
+++ b/docs/TEST-settlement-estatement-flow.md
@@ -1,0 +1,67 @@
+# TEST — 月結電子對帳流程（線上送單／畫押／爭議／匯款／結案）
+
+來源：1688 群組拍板（Alex + 楊小胖，2026-07-15）：「還是不要列印了，都電子化」。
+流程：總部核對無誤線上送單 → 店家線上核對（不同意款項排最上方給備註）→
+店家送出爭議申請 → 總部 review 修正 → 兩邊都按同意就鎖住 → 店家按已匯款 →
+總部按收到款項就結案。
+
+Migration：`20260715000120_settlement_estatement_flow.sql`
+- status 擴充：draft → **sent** → (disputed ⇄ sent) → confirmed → **remitted** → settled。
+- 新表 `store_settlement_disputes`（錨 transfer_item_id、item_snapshot、open/resolved；
+  RLS：HQ 全 tenant 讀、店家只讀自己店；寫入只走 RPC）。
+- 新 RPC：`rpc_send_settlement_to_store` / `rpc_store_review_settlement` /
+  `rpc_resolve_settlement_dispute` / `rpc_mark_settlement_remitted` /
+  `rpc_settle_store_monthly_settlement`；
+  角色 gate：`_settlement_caller_is_hq()`（app_metadata.role ∈ HQ tier，'' = legacy admin）、
+  `_settlement_caller_in_store()`（store_manager/store_staff × `_jwt_store_ids()`）。
+- 生成器 v4：重算範圍 draft → **draft/sent/disputed**（鎖定前跟著來源資料走），
+  跳過 confirmed/settled/remitted/cancelled（順修舊版 disputed/cancelled 列會
+  NULL-crash 的潛在 bug）。
+- confirm v2：接受 draft（總部直接確認）與 sent（店家畫押）。
+- 估價修正 v2：鎖定判斷改 confirmed/remitted/settled（sent/disputed 仍可修）。
+- 結案時應收單同步：未收餘額經 `rpc_record_store_receivable_payment` 一次入帳。
+
+## 測試項目
+
+### RPC 全生命週期（線上 DO block + RAISE 強制 rollback，2026-07-15，永和店 #47 實資料）
+- [x] T1 送單 draft→sent、sent_at/sent_by 記錄。
+- [x] T2 他店 store_manager JWT（中和店）核對永和店單 → 擋（僅該分店或總部）。
+- [x] T3 店家（永和店 JWT）提出爭議 → disputed、dispute row 建立（快照+原因）。
+- [x] T4 有 open 爭議不能重送 →「尚有 1 筆爭議未處理」。
+- [x] T5 disputed 狀態修自由轉貨估價（$250→$280）→ 兩邊重算
+      （payable 18,229.5→18,199.5）、status 保持 disputed、爭議行存活（錨 transfer_item_id）。
+- [x] T6 標記已處理 → open_remaining=0 → 重新送單成功。
+- [x] T7 店家同意畫押 sent→confirmed：store_agreed_at 記錄、產生應收單
+      SR-202607-40-1 金額 = 修正後 18,199.5。
+- [x] T8 鎖定後改估價 → 擋「已鎖定…請走爭議流程」。
+- [x] T9 鎖定後生成器重跑 → 跳過（金額/狀態不變）。
+- [x] T10 店家按已匯款 confirmed→remitted（備註後五碼）；店家不能結案（僅總部）。
+- [x] T11 總部結案 remitted→settled：應收單自動全額入帳
+      （payment SRP-…、status=paid、paid=18,199.5）。
+
+### UI（Playwright fixture，23/23 通過）
+- [x] T12 HQ draft：modal 有「送店家線上核對」＋「直接確認（跳過店家核對）」。
+- [x] T13 HQ disputed：爭議面板（原因/快照/未處理計數）、「標記已處理」帶說明、
+      重送鈕鎖住顯示剩餘筆數、行內「改估價」仍可用（draft/sent/disputed）。
+- [x] T14 HQ remitted：顯示匯款備註、「確認收款結案」呼叫結案 RPC。
+- [x] T15 分店帳號（store_manager+stores 店名）進 /transfers/settlement →
+      自動切「月結對帳」店家介面；只列自己店、狀態 sent 起（看不到 draft）。
+- [x] T16 店家核對 modal：**全版面無「成本」字樣**（單價/小計＝分店價）；
+      逐行「有問題」+ 原因必填才能送出；送出爭議 RPC 參數
+      [{transfer_item_id, reason}] 正確。
+- [x] T17 無標記行時「同意畫押」→ p_agree=true。
+- [x] T18 disputed：爭議行排最上方、顯示總部處理註記。
+- [x] T19 confirmed：「我已匯款」帶備註呼叫 remit RPC。
+- [x] T20 分店帳號開列印頁 `?view=internal` 仍強制分店版、無切換鈕（canSeeCost gate）。
+
+### 迴歸
+- [x] T21 tsc --noEmit 通過；eslint 僅既有 5 筆 baseline finding（無新增）。
+- [x] T22 rollback 測試後線上無殘留（#47 仍 draft、無 dispute/receivable rows）。
+- [x] T23 HQ 直接確認（跳過核對）路徑保留（confirm v2 接受 draft）。
+
+## 待辦 / 已知限制
+- [ ] 送單後無推播通知店家（現有 notifications 表是 member/LIFF 導向；店家開
+      月結對帳頁看到「待核對」）。要推播需另做 staff 通知管道。
+- [ ] store_monthly_settlement_items 的 RLS 仍 tenant 全讀（歷史政策 auth_read_smsi），
+      分店帳號技術上可從 REST 讀到 unit_cost 欄位——UI 已全面隱藏，
+      要 API 層鎖成本欄需另開 column-level view migration。

--- a/docs/TEST-settlement-store-print-and-free-amount-fix.md
+++ b/docs/TEST-settlement-store-print-and-free-amount-fix.md
@@ -1,0 +1,53 @@
+# TEST — 月結對帳單分店版＋自由轉貨估價修正＋應付口徑補正
+
+來源：永和店 2026-07 月結對帳回報（LINE 群）：
+1. 給店家的對帳單印出「我們的實際成本」（成本單價/成本小計欄）。
+2. 自由轉貨行金額是店端轉貨時手填的估價，跟實際分店價對不上，要能事後修正。
+3. 列印出來頁數太多（類型欄被擠成直排、每列高四行）。
+
+Migrations：
+- `20260715000100_settlement_payable_branch_basis.sql` — 補 repo/線上落差：
+  線上 `rpc_generate_hq_to_store_settlement` 已改 `payable = 分店價口徑`
+  （賣斷制、跟分店收分店價），但當時只打了 Management API 沒留 migration。
+  本檔函式本體逐字取自線上 pg_get_functiondef，對線上套用為 no-op。
+- `20260715000110_rpc_update_free_transfer_amount.sql` — 自由轉貨估價事後修正。
+
+## 測試項目
+
+### rpc_update_free_transfer_amount（線上 DO block + RAISE 強制 rollback 驗證，2026-07-15）
+- [x] T1 修正 item 8350（TR2607040153「阿美嬤紅茶奶-紅茶牛奶」$250→$280）：
+      transfer_items.estimated_amount 更新、notes append「[估價修正 …] $250 → $280（原因）」。
+- [x] T2 兩邊鏡像分錄一起重算：free_in +250→+280、free_out −250→−280；
+      出貨店（永和）payable 18,229.5→18,199.5、收貨店 67,342.14→67,372.14（差額 ±30）。
+- [x] T3 護欄：該月任一邊已 confirmed/settled → EXCEPTION
+      「2026-07 月結算已確認：永和店（confirmed）…」。
+- [x] T4 護欄：非自由轉貨行（hq_to_store）→ EXCEPTION「不是自由轉貨」。
+- [x] T5 未收貨的行只改估價、不觸發月結重算（settlements_regenerated=false）。
+      （程式路徑；received_at IS NULL 分支）
+- [x] T6 confirmed/settled 的其他店 draft 不受重算影響（生成器本來就跳過）。
+
+### 列印對帳單（finance/receivables/print）— Playwright fixture 驗證 25/25 通過
+- [x] T7 預設「分店版（給店家）」：整張不出現任何「成本」字樣、無成本欄，
+      單價/小計＝分店價口徑；自由轉貨行單價顯示「—」、品名帶描述。
+- [x] T8 「內部版（含成本）」切換：成本單價/成本小計欄、表頭
+      應付總倉金額（分店價口徑）＋成本口徑＋總部毛利；`?view=internal` 直開。
+- [x] T9 表頭標籤修正：應付金額不再誤標「成本價口徑」（線上 payable 已是分店價，
+      舊標籤造成兩個口徑顯示同數字的困惑）。
+- [x] T10 列印壓縮：類型/日期/調撥單/金額欄 nowrap（修直排爆高）、
+      print 字級 10px + padding 2/4px、@page margin 12mm→10mm、
+      thead 跨頁重複、tr break-inside avoid。
+
+### 月結算頁（transfers/settlement）
+- [x] T11 列表欄名：「應付總倉（分店價）」＋「成本口徑（參考）」（原第二欄顯示
+      branch_amount 與 payable 恆同值，改顯 cost_amount）；footer 合計同步。
+- [x] T12 明細 modal 統計卡：應付金額（分店價口徑）／成本口徑金額（參考）／
+      口徑差額（總部毛利）。
+- [x] T13 draft 狀態自由轉入/轉出行有「改估價」鈕（其他類型無）；面板送出
+      rpc_update_free_transfer_amount（帶 transfer_item_id/新估價/原因），
+      成功後明細與表頭金額重抓、列表 reload；confirmed/settled 無鈕。
+- [x] T14 產生結果訊息改「應付合計（分店價口徑）$X／成本口徑 $Y」。
+
+### 迴歸
+- [x] T15 tsc --noEmit 通過；eslint 與 HEAD 基線相同（無新增 finding）。
+- [x] T16 確認 RPC（rpc_confirm_store_monthly_settlement）不動：入
+      store_receivables 金額仍 = payable_amount（現＝分店價口徑）。

--- a/supabase/migrations/20260715000100_settlement_payable_branch_basis.sql
+++ b/supabase/migrations/20260715000100_settlement_payable_branch_basis.sql
@@ -1,0 +1,412 @@
+-- ============================================================
+-- 2026-07-15: 月結應付改「分店價口徑」（補 repo/線上落差）
+--
+-- ⚠️ 本 migration 是把「線上已生效」的版本補進 repo：
+--    線上 DB 的 rpc_generate_hq_to_store_settlement 已被改成
+--    v_payable := v_branch_total（賣斷制：總倉出給分店、跟分店收
+--    「分店價」；成本口徑僅供總倉毛利參考），但該次改動只打了
+--    Management API、沒有留 migration。以下函式本體逐字取自線上
+--    pg_get_functiondef（2026-07-15 dump），對線上套用等於 no-op。
+--
+-- 與 20260715000000（repo 前一版）的差異：
+--   1. v_payable := v_branch_total（原：成本口徑合計）
+--   2. header cost_amount 寫入 v_cost_total（原：誤與 payable 同值）
+--   3. 回傳 JSON total_cost_amount 改累計真成本口徑 v_total_cost
+--      （原：回傳 v_total_amount）
+--   confirm RPC 不動：入 store_receivables 的仍是 payable_amount，
+--   語義隨本版變為分店價口徑。
+--
+-- 基底版本：20260715000000_settlement_dual_price_basis.sql
+-- Rollback：CREATE OR REPLACE 回 20260715000000 版本
+--   （draft 重跑生成器即回成本口徑；confirmed/settled 不受影響）。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_generate_hq_to_store_settlement(p_month date, p_operator uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_tenant         UUID;
+  v_month_start    DATE := DATE_TRUNC('month', p_month)::DATE;
+  v_month_end      DATE := (DATE_TRUNC('month', p_month) + INTERVAL '1 month')::DATE;
+  v_store          RECORD;
+  v_settlement_id  BIGINT;
+  v_hq_inbound     NUMERIC(18,4);
+  v_air_in         NUMERIC(18,4);
+  v_air_out        NUMERIC(18,4);
+  v_free_in        NUMERIC(18,4);
+  v_free_out       NUMERIC(18,4);
+  v_return_out     NUMERIC(18,4);
+  v_hq_inbound_b   NUMERIC(18,4);  -- 分店價口徑
+  v_air_in_b       NUMERIC(18,4);
+  v_air_out_b      NUMERIC(18,4);
+  v_return_out_b   NUMERIC(18,4);
+  v_cost_total     NUMERIC(18,4);
+  v_branch_total   NUMERIC(18,4);
+  v_payable        NUMERIC(18,4);
+  v_xfer_count     INTEGER;
+  v_item_count     INTEGER;
+  v_total_stores   INTEGER := 0;
+  v_total_amount   NUMERIC(18,4) := 0;
+  v_total_cost     NUMERIC(18,4) := 0;
+  v_total_branch   NUMERIC(18,4) := 0;
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM stores LIMIT 1;
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'no stores found, cannot infer tenant_id';
+  END IF;
+
+  FOR v_store IN
+    SELECT s.id, s.code, s.name, s.location_id
+      FROM stores s
+     WHERE s.tenant_id = v_tenant
+       AND s.location_id IS NOT NULL
+  LOOP
+    -- 跳過已 confirmed/settled
+    IF EXISTS (
+      SELECT 1 FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status IN ('confirmed','settled')
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    -- A) hq_inbound: 從 HQ 收貨（成本口徑 + 分店價口徑）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_hq_inbound, v_hq_inbound_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- B) air_in: 空中轉收進來（該店是 dest）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_air_in, v_air_in_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- C) air_out: 空中轉送出去（該店是 source）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_air_out, v_air_out_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- D) free_in: 自由轉貨收進來（該店是 dest；無訂單 FK；估價入帳、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_in
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out: 自由轉貨送出去（該店是 source；估價入帳、貸記、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_out
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out: 退貨回總倉（該店是 source、總倉已收；沖回）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_return_out, v_return_out_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    v_cost_total   := v_hq_inbound   + v_air_in   - v_air_out   + v_free_in - v_free_out - v_return_out;
+    v_branch_total := v_hq_inbound_b + v_air_in_b - v_air_out_b + v_free_in - v_free_out - v_return_out_b;
+    -- 賣斷制：總倉出給分店、跟分店收「分店價」；成本口徑僅供總倉毛利參考
+    v_payable      := v_branch_total;
+
+    -- 沒任何活動就 skip + 砍 draft（兩口徑皆 0 才算無活動）
+    IF v_hq_inbound = 0 AND v_air_in = 0 AND v_air_out = 0
+       AND v_free_in = 0 AND v_free_out = 0 AND v_return_out = 0
+       AND v_hq_inbound_b = 0 AND v_air_in_b = 0 AND v_air_out_b = 0
+       AND v_return_out_b = 0 THEN
+      DELETE FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status = 'draft';
+      CONTINUE;
+    END IF;
+
+    -- 計 transfer_count + item_count
+    SELECT
+      COUNT(DISTINCT t.id), COUNT(ti.id)
+      INTO v_xfer_count, v_item_count
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.status IN ('received','closed')
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0
+       AND (
+         (t.transfer_type = 'hq_to_store' AND t.dest_location = v_store.location_id)
+         OR
+         (t.transfer_type = 'store_to_store'
+          AND (t.dest_location = v_store.location_id OR t.source_location = v_store.location_id))
+         OR
+         (t.transfer_type = 'return_to_hq' AND t.source_location = v_store.location_id)
+       );
+
+    -- upsert (draft only)
+    INSERT INTO store_monthly_settlements (
+      tenant_id, settlement_month, store_id,
+      payable_amount, cost_amount, branch_amount,
+      transfer_count, item_count,
+      status, created_by, updated_by
+    ) VALUES (
+      v_tenant, v_month_start, v_store.id,
+      v_payable, v_cost_total, v_branch_total,
+      v_xfer_count, v_item_count,
+      'draft', p_operator, p_operator
+    )
+    ON CONFLICT (tenant_id, settlement_month, store_id)
+    DO UPDATE SET
+      payable_amount = EXCLUDED.payable_amount,
+      cost_amount    = EXCLUDED.cost_amount,
+      branch_amount  = EXCLUDED.branch_amount,
+      transfer_count = EXCLUDED.transfer_count,
+      item_count     = EXCLUDED.item_count,
+      updated_by     = p_operator,
+      updated_at     = NOW()
+    WHERE store_monthly_settlements.status = 'draft'
+    RETURNING id INTO v_settlement_id;
+
+    -- 重建 items
+    DELETE FROM store_monthly_settlement_items WHERE settlement_id = v_settlement_id;
+
+    -- A) hq_inbound items
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      ti.qty_received * COALESCE(sm.unit_cost, 0),
+      t.received_at, 'hq_inbound',
+      bp.p, ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- B) air_in items
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      ti.qty_received * COALESCE(sm.unit_cost, 0),
+      t.received_at, 'air_in',
+      bp.p, ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- C) air_out items（兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      -1 * ti.qty_received * COALESCE(sm.unit_cost, 0),  -- 負值
+      t.received_at, 'air_out',
+      bp.p, -1 * ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- D) free_in items（估價入帳、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      COALESCE(ti.estimated_amount, 0),
+      t.received_at, 'free_in', ti.description,
+      0, COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out items（估價入帳、負值、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      -1 * COALESCE(ti.estimated_amount, 0),  -- 負值
+      t.received_at, 'free_out', ti.description,
+      0, -1 * COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out items（沖回、兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      -1 * ti.qty_received * COALESCE(sm.unit_cost, 0),  -- 負值
+      t.received_at, 'return_out',
+      bp.p, -1 * ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    v_total_stores := v_total_stores + 1;
+    v_total_amount := v_total_amount + v_payable;
+    v_total_cost   := v_total_cost + v_cost_total;
+    v_total_branch := v_total_branch + v_branch_total;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'month',               to_char(v_month_start, 'YYYY-MM'),
+    'stores_count',        v_total_stores,
+    'total_amount',        v_total_amount,
+    'total_cost_amount',   v_total_cost,
+    'total_branch_amount', v_total_branch
+  );
+END;
+$function$
+
+;
+
+COMMENT ON FUNCTION public.rpc_generate_hq_to_store_settlement IS
+  'HQ→店月結算（總倉當清算中心）：每筆分錄雙口徑 cost_amount / branch_amount。'
+  'payable = 分店價口徑（賣斷制：跟分店收分店價；成本口徑僅供總倉毛利參考）。'
+  '自由轉貨以估價入帳（兩店鏡像同額、兩口徑同額）、退貨回總倉沖回。'
+  'draft 重建、confirmed/settled 跳過。';

--- a/supabase/migrations/20260715000110_rpc_update_free_transfer_amount.sql
+++ b/supabase/migrations/20260715000110_rpc_update_free_transfer_amount.sql
@@ -1,0 +1,110 @@
+-- ============================================================
+-- 2026-07-15: 自由轉貨估價事後修正 rpc_update_free_transfer_amount
+--
+-- 需求（永和店月結對帳回報）：自由轉貨行的金額是店端轉貨當下手填的
+-- 估價，月結對帳時發現跟實際分店價對不上；要能事後修正。
+--
+-- 設計：
+--   - 只允許「自由轉貨」行（transfer_type='store_to_store' 且
+--     customer_order_id IS NULL；估價入帳的那種）。
+--   - 來源真相是 transfer_items.estimated_amount：月結生成器
+--     （rpc_generate_hq_to_store_settlement，現行版 20260715000100）
+--     重建 draft 時直接讀這個欄位，所以改這裡＋重跑生成器，
+--     兩邊店（free_in / free_out 鏡像分錄）的 draft 會一起更新。
+--   - 護欄：該行已收貨入帳的月份，只要出貨店或收貨店任一邊月結
+--     已 confirmed/settled 就擋下（要改請走爭議流程，不能繞過已
+--     確認的帳）。
+--   - 修正軌跡：append 到 transfer_items.notes（[估價修正 日期]
+--     $舊 → $新（原因）），updated_by 記操作人。
+--   - 已收貨的行改完自動重跑該月生成器重建 draft；未收貨的行
+--     （尚未入帳）只改估價、不動月結。
+--
+-- 新函式，無歷史版本。
+-- Rollback：DROP FUNCTION public.rpc_update_free_transfer_amount(BIGINT, NUMERIC, UUID, TEXT);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_update_free_transfer_amount(
+  p_transfer_item_id BIGINT,
+  p_new_amount       NUMERIC,
+  p_operator         UUID,
+  p_reason           TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_ti     RECORD;
+  v_t      RECORD;
+  v_month  DATE;
+  v_old    NUMERIC;
+  v_locked TEXT;
+  v_regen  BOOLEAN := FALSE;
+BEGIN
+  IF p_new_amount IS NULL OR p_new_amount < 0 THEN
+    RAISE EXCEPTION '估價需 >= 0（收到 %）', p_new_amount;
+  END IF;
+
+  SELECT * INTO v_ti FROM transfer_items WHERE id = p_transfer_item_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transfer_item % 不存在', p_transfer_item_id;
+  END IF;
+
+  SELECT * INTO v_t FROM transfers WHERE id = v_ti.transfer_id;
+
+  -- 僅自由轉貨行可修：店↔店、無訂單 FK（有訂單的是空中轉、走成本入帳）
+  IF v_t.transfer_type <> 'store_to_store' OR v_t.customer_order_id IS NOT NULL THEN
+    RAISE EXCEPTION '調撥單 % 不是自由轉貨（type=%），此行不可修估價',
+      v_t.transfer_no, v_t.transfer_type;
+  END IF;
+
+  v_old := COALESCE(v_ti.estimated_amount, 0);
+
+  -- 已入帳月份任一邊已確認 → 擋
+  IF v_t.status IN ('received','closed') AND v_t.received_at IS NOT NULL THEN
+    v_month := DATE_TRUNC('month', v_t.received_at)::DATE;
+    SELECT string_agg(st.name || '（' || s.status || '）', '、')
+      INTO v_locked
+      FROM store_monthly_settlements s
+      JOIN stores st ON st.id = s.store_id
+     WHERE s.tenant_id = v_t.tenant_id
+       AND s.settlement_month = v_month
+       AND s.status IN ('confirmed', 'settled')
+       AND st.location_id IN (v_t.source_location, v_t.dest_location);
+    IF v_locked IS NOT NULL THEN
+      RAISE EXCEPTION '% 月結算已確認：%。已確認的帳不可改估價，請走爭議流程。',
+        to_char(v_month, 'YYYY-MM'), v_locked;
+    END IF;
+  END IF;
+
+  UPDATE transfer_items
+     SET estimated_amount = p_new_amount,
+         notes = TRIM(BOTH E'\n' FROM
+           COALESCE(notes || E'\n', '')
+           || '[估價修正 ' || to_char(NOW(), 'YYYY-MM-DD') || '] $'
+           || trim_scale(v_old)::TEXT || ' → $' || trim_scale(p_new_amount)::TEXT
+           || COALESCE('（' || NULLIF(TRIM(p_reason), '') || '）', '')),
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_transfer_item_id;
+
+  -- 已收貨 → 重跑該月生成器重建兩邊 draft（confirmed/settled 本來就跳過）
+  IF v_month IS NOT NULL THEN
+    PERFORM public.rpc_generate_hq_to_store_settlement(v_month, p_operator);
+    v_regen := TRUE;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'transfer_item_id',        p_transfer_item_id,
+    'transfer_no',             v_t.transfer_no,
+    'old_amount',              v_old,
+    'new_amount',              p_new_amount,
+    'month',                   CASE WHEN v_month IS NULL THEN NULL
+                                    ELSE to_char(v_month, 'YYYY-MM') END,
+    'settlements_regenerated', v_regen
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_update_free_transfer_amount IS
+  '修正自由轉貨行估價（transfer_items.estimated_amount）：僅限店↔店無訂單 FK 的'
+  '自由轉貨行；該月任一邊月結已 confirmed/settled 則擋下；已收貨的行改完自動'
+  '重跑該月 rpc_generate_hq_to_store_settlement 重建兩邊 draft；修正軌跡 append'
+  '到 notes。';

--- a/supabase/migrations/20260715000120_settlement_estatement_flow.sql
+++ b/supabase/migrations/20260715000120_settlement_estatement_flow.sql
@@ -1,0 +1,1004 @@
+-- ============================================================
+-- 2026-07-15: 月結電子對帳流程（不再列印、線上送單/畫押/爭議/匯款/結案）
+--
+-- 需求（1688 群組拍板，Alex + 楊小胖）：
+--   1. 總部核對無誤後「線上送單」給店家（取代列印）。
+--   2. 店家線上核對：全部無誤 → 按同意畫押；有問題 → 逐行提出爭議
+--      （爭議行排最上方、附備註），送出後換總部 review。
+--   3. 總部處理爭議（例：用 rpc_update_free_transfer_amount 修自由轉貨
+--      估價）、標記已處理，再重新送店家核對。
+--   4. 兩邊都同意 → 鎖住（= 既有 confirmed，產生應收單）。
+--   5. 店家匯款後按「已匯款」；總部收到款按「確認收款」→ 結案（settled，
+--      同時把應收單入帳）。
+--
+-- 狀態機（store_monthly_settlements.status）：
+--   draft ──送單──▶ sent ──店家全同意──▶ confirmed ──店家已匯款──▶ remitted
+--     ▲               │店家提爭議                                      │
+--     │               ▼                                               │總部確認收款
+--     └(重算)      disputed ──總部全部處理+重新送單──▶ sent            ▼
+--                                                                  settled
+--   * cancelled 保留（無流程進入）。
+--   * 「鎖住」= confirmed 起：月結生成器與估價修正都不再動它。
+--
+-- 生成器重算範圍調整：draft/sent/disputed 都重建（送單後、鎖定前內容
+--   跟著來源資料走 —— 爭議修正才會反映到兩邊店的帳），confirmed/
+--   settled/remitted/cancelled 跳過。爭議列錨定 transfer_item_id（重建
+--   不失聯）。同時修一個潛在 bug：舊版 loop 只跳過 confirmed/settled，
+--   若出現 disputed/cancelled 列，upsert 的 WHERE status='draft' 會讓
+--   RETURNING 回 NULL → items INSERT 炸 NOT NULL。
+--
+-- 角色 gate（in-RPC、SECURITY DEFINER）：
+--   HQ  = app_metadata.role IN ('','owner','admin','hq_manager','hq_accountant')
+--         （'' = legacy/dev admin，對齊 role.ts HQ_ROLES 與 wallet RPC gate）
+--   店家 = role IN ('store_manager','store_staff') 且 settlement.store_id ∈
+--         _jwt_store_ids()（app_metadata.stores 店名 → id，20260707000070）。
+--         HQ 也可代店家操作（現場電話確認等情境）。
+--
+-- 基底版本：
+--   rpc_generate_hq_to_store_settlement ← 20260715000100（payable=分店價口徑）
+--   rpc_confirm_store_monthly_settlement ← 20260512000015（唯一版本）
+--   rpc_update_free_transfer_amount ← 20260715000110（唯一版本）
+-- Rollback：
+--   各函式 CREATE OR REPLACE 回上列基底版本；
+--   DROP FUNCTION rpc_send_settlement_to_store, rpc_store_review_settlement,
+--     rpc_resolve_settlement_dispute, rpc_mark_settlement_remitted,
+--     rpc_settle_store_monthly_settlement, _settlement_caller_is_hq,
+--     _settlement_caller_in_store;
+--   DROP TABLE store_settlement_disputes;
+--   ALTER TABLE store_monthly_settlements
+--     DROP CONSTRAINT sms_status_check_v2（重建舊 CHECK），
+--     DROP COLUMN sent_at, sent_by, store_agreed_at, store_agreed_by,
+--       remitted_at, remitted_by, remit_note, settled_by;
+--   （已進 sent/remitted 的列需先手動歸回 draft/settled）
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. status CHECK 擴充 + 流程欄位
+-- ------------------------------------------------------------
+ALTER TABLE public.store_monthly_settlements
+  DROP CONSTRAINT IF EXISTS store_monthly_settlements_status_check;
+ALTER TABLE public.store_monthly_settlements
+  DROP CONSTRAINT IF EXISTS sms_status_check_v2;
+ALTER TABLE public.store_monthly_settlements
+  ADD CONSTRAINT sms_status_check_v2
+    CHECK (status IN ('draft','sent','disputed','confirmed','remitted','settled','cancelled'));
+
+ALTER TABLE public.store_monthly_settlements
+  ADD COLUMN IF NOT EXISTS sent_at         TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS sent_by         UUID,
+  ADD COLUMN IF NOT EXISTS store_agreed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS store_agreed_by UUID,
+  ADD COLUMN IF NOT EXISTS remitted_at     TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS remitted_by     UUID,
+  ADD COLUMN IF NOT EXISTS remit_note      TEXT,
+  ADD COLUMN IF NOT EXISTS settled_by      UUID;
+
+COMMENT ON COLUMN store_monthly_settlements.status IS
+  '月結流程：draft=總部工作中；sent=已送店家核對；disputed=店家提出爭議待總部處理；'
+  'confirmed=雙方同意鎖定(產生應收單)；remitted=店家已匯款；settled=總部確認收款結案；cancelled=作廢';
+COMMENT ON COLUMN store_monthly_settlements.remit_note IS '店家按已匯款時填的備註（例：帳號後五碼）';
+
+-- ------------------------------------------------------------
+-- 2. 爭議表（錨定 transfer_item_id，月結 items 重建不失聯）
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.store_settlement_disputes (
+  id               BIGSERIAL PRIMARY KEY,
+  tenant_id        UUID NOT NULL,
+  settlement_id    BIGINT NOT NULL REFERENCES public.store_monthly_settlements(id) ON DELETE CASCADE,
+  transfer_item_id BIGINT NOT NULL,
+  item_snapshot    JSONB NOT NULL,   -- 提出當下的行快照 {entry_type, description, sku_id, qty_received, branch_amount, received_at}
+  reason           TEXT NOT NULL,
+  status           TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open','resolved')),
+  raised_by        UUID NOT NULL,
+  raised_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resolved_by      UUID,
+  resolved_at      TIMESTAMPTZ,
+  resolution_note  TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ssd_settlement ON public.store_settlement_disputes (settlement_id, status);
+-- 同一行同時只能有一筆 open 爭議
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ssd_open_per_item
+  ON public.store_settlement_disputes (settlement_id, transfer_item_id)
+  WHERE status = 'open';
+
+COMMENT ON TABLE store_settlement_disputes IS
+  '月結對帳爭議：店家對單一明細行（以 transfer_item_id 錨定）提出的異議；'
+  '總部處理後標 resolved，全部 resolved 才能重新送單。';
+
+ALTER TABLE public.store_settlement_disputes ENABLE ROW LEVEL SECURITY;
+
+-- 讀：HQ 全 tenant；店家只看自己店的（寫入全部走 SECURITY DEFINER RPC，不開放直寫）
+DROP POLICY IF EXISTS ssd_select ON public.store_settlement_disputes;
+CREATE POLICY ssd_select ON public.store_settlement_disputes
+  FOR SELECT TO authenticated USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+    AND (
+      COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+        IN ('', 'owner', 'admin', 'hq_manager', 'hq_accountant')
+      OR EXISTS (
+        SELECT 1 FROM store_monthly_settlements s
+         WHERE s.id = settlement_id
+           AND s.store_id = ANY (public._jwt_store_ids())
+      )
+    )
+  );
+
+-- ------------------------------------------------------------
+-- 3. caller gate helpers
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._settlement_caller_is_hq()
+RETURNS BOOLEAN LANGUAGE sql STABLE AS $$
+  -- '' = legacy/dev admin（app_metadata.role 未設），對齊 role.ts HQ_ROLES
+  SELECT COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+         IN ('', 'owner', 'admin', 'hq_manager', 'hq_accountant');
+$$;
+
+CREATE OR REPLACE FUNCTION public._settlement_caller_in_store(p_store_id BIGINT)
+RETURNS BOOLEAN LANGUAGE sql STABLE AS $$
+  SELECT COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+         IN ('store_manager', 'store_staff')
+     AND p_store_id = ANY (public._jwt_store_ids());
+$$;
+
+-- ------------------------------------------------------------
+-- 4. 生成器 v3：draft/sent/disputed 重建；confirmed/settled/remitted/cancelled 跳過
+--    （其餘與 20260715000100 逐字相同）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_generate_hq_to_store_settlement(p_month date, p_operator uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_tenant         UUID;
+  v_month_start    DATE := DATE_TRUNC('month', p_month)::DATE;
+  v_month_end      DATE := (DATE_TRUNC('month', p_month) + INTERVAL '1 month')::DATE;
+  v_store          RECORD;
+  v_settlement_id  BIGINT;
+  v_hq_inbound     NUMERIC(18,4);
+  v_air_in         NUMERIC(18,4);
+  v_air_out        NUMERIC(18,4);
+  v_free_in        NUMERIC(18,4);
+  v_free_out       NUMERIC(18,4);
+  v_return_out     NUMERIC(18,4);
+  v_hq_inbound_b   NUMERIC(18,4);  -- 分店價口徑
+  v_air_in_b       NUMERIC(18,4);
+  v_air_out_b      NUMERIC(18,4);
+  v_return_out_b   NUMERIC(18,4);
+  v_cost_total     NUMERIC(18,4);
+  v_branch_total   NUMERIC(18,4);
+  v_payable        NUMERIC(18,4);
+  v_xfer_count     INTEGER;
+  v_item_count     INTEGER;
+  v_total_stores   INTEGER := 0;
+  v_total_amount   NUMERIC(18,4) := 0;
+  v_total_cost     NUMERIC(18,4) := 0;
+  v_total_branch   NUMERIC(18,4) := 0;
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM stores LIMIT 1;
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'no stores found, cannot infer tenant_id';
+  END IF;
+
+  FOR v_store IN
+    SELECT s.id, s.code, s.name, s.location_id
+      FROM stores s
+     WHERE s.tenant_id = v_tenant
+       AND s.location_id IS NOT NULL
+  LOOP
+    -- 跳過已鎖定/結案/作廢（confirmed 起不再重算；cancelled 舊版會 NULL crash，一併跳過）
+    IF EXISTS (
+      SELECT 1 FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status IN ('confirmed','settled','remitted','cancelled')
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    -- A) hq_inbound: 從 HQ 收貨（成本口徑 + 分店價口徑）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_hq_inbound, v_hq_inbound_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- B) air_in: 空中轉收進來（該店是 dest）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_air_in, v_air_in_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- C) air_out: 空中轉送出去（該店是 source）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_air_out, v_air_out_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- D) free_in: 自由轉貨收進來（估價入帳、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_in
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out: 自由轉貨送出去（估價入帳、貸記、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_out
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out: 退貨回總倉（成本沖回 + 分店價沖回）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_return_out, v_return_out_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    v_cost_total   := v_hq_inbound   + v_air_in   - v_air_out   + v_free_in - v_free_out - v_return_out;
+    v_branch_total := v_hq_inbound_b + v_air_in_b - v_air_out_b + v_free_in - v_free_out - v_return_out_b;
+    -- 賣斷制：總倉出給分店、跟分店收「分店價」；成本口徑僅供總倉毛利參考
+    v_payable      := v_branch_total;
+
+    -- 沒任何活動就 skip + 砍 draft（兩口徑皆 0 才算無活動；只砍 draft，
+    -- sent/disputed 已進流程不自動刪）
+    IF v_hq_inbound = 0 AND v_air_in = 0 AND v_air_out = 0
+       AND v_free_in = 0 AND v_free_out = 0 AND v_return_out = 0
+       AND v_hq_inbound_b = 0 AND v_air_in_b = 0 AND v_air_out_b = 0
+       AND v_return_out_b = 0 THEN
+      DELETE FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status = 'draft';
+      CONTINUE;
+    END IF;
+
+    -- 計 transfer_count + item_count
+    SELECT
+      COUNT(DISTINCT t.id), COUNT(ti.id)
+      INTO v_xfer_count, v_item_count
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.status IN ('received','closed')
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0
+       AND (
+         (t.transfer_type = 'hq_to_store' AND t.dest_location = v_store.location_id)
+         OR
+         (t.transfer_type = 'store_to_store'
+          AND (t.dest_location = v_store.location_id OR t.source_location = v_store.location_id))
+         OR
+         (t.transfer_type = 'return_to_hq' AND t.source_location = v_store.location_id)
+       );
+
+    -- upsert（鎖定前狀態 draft/sent/disputed 都重算；status 本身不動）
+    INSERT INTO store_monthly_settlements (
+      tenant_id, settlement_month, store_id,
+      payable_amount, cost_amount, branch_amount,
+      transfer_count, item_count,
+      status, created_by, updated_by
+    ) VALUES (
+      v_tenant, v_month_start, v_store.id,
+      v_payable, v_cost_total, v_branch_total,
+      v_xfer_count, v_item_count,
+      'draft', p_operator, p_operator
+    )
+    ON CONFLICT (tenant_id, settlement_month, store_id)
+    DO UPDATE SET
+      payable_amount = EXCLUDED.payable_amount,
+      cost_amount    = EXCLUDED.cost_amount,
+      branch_amount  = EXCLUDED.branch_amount,
+      transfer_count = EXCLUDED.transfer_count,
+      item_count     = EXCLUDED.item_count,
+      updated_by     = p_operator,
+      updated_at     = NOW()
+    WHERE store_monthly_settlements.status IN ('draft','sent','disputed')
+    RETURNING id INTO v_settlement_id;
+
+    -- 重建 items
+    DELETE FROM store_monthly_settlement_items WHERE settlement_id = v_settlement_id;
+
+    -- A) hq_inbound items（雙口徑）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      ti.qty_received * COALESCE(sm.unit_cost, 0),
+      t.received_at, 'hq_inbound',
+      bp.p, ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- B) air_in items（雙口徑）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      ti.qty_received * COALESCE(sm.unit_cost, 0),
+      t.received_at, 'air_in',
+      bp.p, ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- C) air_out items（兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      -1 * ti.qty_received * COALESCE(sm.unit_cost, 0),  -- 負值
+      t.received_at, 'air_out',
+      bp.p, -1 * ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- D) free_in items（估價入帳、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      COALESCE(ti.estimated_amount, 0),
+      t.received_at, 'free_in', ti.description,
+      0, COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out items（估價入帳、負值、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      -1 * COALESCE(ti.estimated_amount, 0),  -- 負值
+      t.received_at, 'free_out', ti.description,
+      0, -1 * COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out items（沖回、兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      -1 * ti.qty_received * COALESCE(sm.unit_cost, 0),  -- 負值
+      t.received_at, 'return_out',
+      bp.p, -1 * ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    v_total_stores := v_total_stores + 1;
+    v_total_amount := v_total_amount + v_payable;
+    v_total_cost   := v_total_cost + v_cost_total;
+    v_total_branch := v_total_branch + v_branch_total;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'month',               to_char(v_month_start, 'YYYY-MM'),
+    'stores_count',        v_total_stores,
+    'total_amount',        v_total_amount,
+    'total_cost_amount',   v_total_cost,
+    'total_branch_amount', v_total_branch
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_generate_hq_to_store_settlement IS
+  'HQ→店月結算（總倉當清算中心）：每筆分錄雙口徑 cost_amount / branch_amount。'
+  'payable = 分店價口徑（賣斷制）。draft/sent/disputed 重建、'
+  'confirmed/settled/remitted/cancelled 跳過（confirmed 起鎖定）。';
+
+-- ------------------------------------------------------------
+-- 5. confirm v2：接受 draft（總部直接確認）與 sent（店家同意畫押）
+--    （其餘與 20260512000015 逐字相同）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_confirm_store_monthly_settlement(p_settlement_id bigint, p_operator uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_s              store_monthly_settlements%ROWTYPE;
+  v_recv_id        BIGINT;
+  v_recv_no        TEXT;
+  v_now            TIMESTAMPTZ := NOW();
+BEGIN
+  SELECT * INTO v_s FROM store_monthly_settlements
+   WHERE id = p_settlement_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'settlement % not found', p_settlement_id;
+  END IF;
+  IF v_s.status NOT IN ('draft', 'sent') THEN
+    RAISE EXCEPTION 'settlement % not draft/sent (current: %)', p_settlement_id, v_s.status;
+  END IF;
+  IF v_s.payable_amount <= 0 THEN
+    RAISE EXCEPTION 'settlement % amount must be > 0 (got %)',
+      p_settlement_id, v_s.payable_amount;
+  END IF;
+
+  -- 產 receivable_no（格式：SR-YYYYMM-{store}-{seq}）
+  v_recv_no := 'SR-' || to_char(v_s.settlement_month, 'YYYYMM')
+            || '-' || v_s.store_id::text
+            || '-' || nextval('store_receivables_id_seq')::text;
+
+  -- 建 store_receivable
+  INSERT INTO store_receivables (
+    tenant_id, receivable_no, store_id,
+    source_type, source_id,
+    bill_date, due_date, amount,
+    status, currency, notes,
+    created_by, updated_by
+  ) VALUES (
+    v_s.tenant_id, v_recv_no, v_s.store_id,
+    'store_monthly_settlement', v_s.id,
+    (v_s.settlement_month + INTERVAL '1 month' - INTERVAL '1 day')::DATE,  -- 月底
+    (v_s.settlement_month + INTERVAL '2 month' - INTERVAL '1 day')::DATE,  -- 次月底
+    v_s.payable_amount,
+    'pending', 'TWD',
+    format('店月結算 %s %s', to_char(v_s.settlement_month, 'YYYY-MM'),
+           (SELECT name FROM stores WHERE id = v_s.store_id)),
+    p_operator, p_operator
+  ) RETURNING id INTO v_recv_id;
+
+  -- 更新 settlement 狀態 + FK
+  UPDATE store_monthly_settlements
+     SET status                  = 'confirmed',
+         confirmed_at            = v_now,
+         confirmed_by            = p_operator,
+         generated_receivable_id = v_recv_id,
+         updated_by              = p_operator,
+         updated_at              = v_now
+   WHERE id = p_settlement_id;
+
+  RETURN jsonb_build_object(
+    'settlement_id', p_settlement_id,
+    'receivable_id', v_recv_id,
+    'receivable_no', v_recv_no,
+    'store_id',      v_s.store_id,
+    'amount',        v_s.payable_amount
+  );
+END;
+$function$;
+
+-- ------------------------------------------------------------
+-- 6. 估價修正 v2：鎖定判斷 confirmed/settled → confirmed/remitted/settled
+--    （sent/disputed 仍可修，配合生成器 v3 重建；其餘與 20260715000110 相同）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_update_free_transfer_amount(
+  p_transfer_item_id BIGINT,
+  p_new_amount       NUMERIC,
+  p_operator         UUID,
+  p_reason           TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_ti     RECORD;
+  v_t      RECORD;
+  v_month  DATE;
+  v_old    NUMERIC;
+  v_locked TEXT;
+  v_regen  BOOLEAN := FALSE;
+BEGIN
+  IF p_new_amount IS NULL OR p_new_amount < 0 THEN
+    RAISE EXCEPTION '估價需 >= 0（收到 %）', p_new_amount;
+  END IF;
+
+  SELECT * INTO v_ti FROM transfer_items WHERE id = p_transfer_item_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transfer_item % 不存在', p_transfer_item_id;
+  END IF;
+
+  SELECT * INTO v_t FROM transfers WHERE id = v_ti.transfer_id;
+
+  -- 僅自由轉貨行可修：店↔店、無訂單 FK（有訂單的是空中轉、走成本入帳）
+  IF v_t.transfer_type <> 'store_to_store' OR v_t.customer_order_id IS NOT NULL THEN
+    RAISE EXCEPTION '調撥單 % 不是自由轉貨（type=%），此行不可修估價',
+      v_t.transfer_no, v_t.transfer_type;
+  END IF;
+
+  v_old := COALESCE(v_ti.estimated_amount, 0);
+
+  -- 已入帳月份任一邊已鎖定（confirmed 起）→ 擋
+  IF v_t.status IN ('received','closed') AND v_t.received_at IS NOT NULL THEN
+    v_month := DATE_TRUNC('month', v_t.received_at)::DATE;
+    SELECT string_agg(st.name || '（' || s.status || '）', '、')
+      INTO v_locked
+      FROM store_monthly_settlements s
+      JOIN stores st ON st.id = s.store_id
+     WHERE s.tenant_id = v_t.tenant_id
+       AND s.settlement_month = v_month
+       AND s.status IN ('confirmed', 'remitted', 'settled')
+       AND st.location_id IN (v_t.source_location, v_t.dest_location);
+    IF v_locked IS NOT NULL THEN
+      RAISE EXCEPTION '% 月結算已鎖定：%。鎖定後不可改估價，請走爭議流程。',
+        to_char(v_month, 'YYYY-MM'), v_locked;
+    END IF;
+  END IF;
+
+  UPDATE transfer_items
+     SET estimated_amount = p_new_amount,
+         notes = TRIM(BOTH E'\n' FROM
+           COALESCE(notes || E'\n', '')
+           || '[估價修正 ' || to_char(NOW(), 'YYYY-MM-DD') || '] $'
+           || trim_scale(v_old)::TEXT || ' → $' || trim_scale(p_new_amount)::TEXT
+           || COALESCE('（' || NULLIF(TRIM(p_reason), '') || '）', '')),
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_transfer_item_id;
+
+  -- 已收貨 → 重跑該月生成器重建兩邊 draft/sent/disputed（鎖定的本來就跳過）
+  IF v_month IS NOT NULL THEN
+    PERFORM public.rpc_generate_hq_to_store_settlement(v_month, p_operator);
+    v_regen := TRUE;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'transfer_item_id',        p_transfer_item_id,
+    'transfer_no',             v_t.transfer_no,
+    'old_amount',              v_old,
+    'new_amount',              p_new_amount,
+    'month',                   CASE WHEN v_month IS NULL THEN NULL
+                                    ELSE to_char(v_month, 'YYYY-MM') END,
+    'settlements_regenerated', v_regen
+  );
+END;
+$$;
+
+-- ------------------------------------------------------------
+-- 7. 送單：draft/disputed → sent（disputed 需全部爭議已處理）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_send_settlement_to_store(
+  p_settlement_id BIGINT,
+  p_operator      UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_s    store_monthly_settlements%ROWTYPE;
+  v_open INTEGER;
+BEGIN
+  IF NOT public._settlement_caller_is_hq() THEN
+    RAISE EXCEPTION '僅總部帳號可送單（role=%）',
+      COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  END IF;
+
+  SELECT * INTO v_s FROM store_monthly_settlements WHERE id = p_settlement_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'settlement % not found', p_settlement_id;
+  END IF;
+  IF v_s.status NOT IN ('draft', 'disputed') THEN
+    RAISE EXCEPTION '狀態 % 不可送單（僅 draft / 爭議已全部處理的 disputed）', v_s.status;
+  END IF;
+
+  IF v_s.status = 'disputed' THEN
+    SELECT COUNT(*) INTO v_open
+      FROM store_settlement_disputes
+     WHERE settlement_id = p_settlement_id AND status = 'open';
+    IF v_open > 0 THEN
+      RAISE EXCEPTION '尚有 % 筆爭議未處理，處理完才能重新送單', v_open;
+    END IF;
+  END IF;
+
+  UPDATE store_monthly_settlements
+     SET status     = 'sent',
+         sent_at    = NOW(),
+         sent_by    = p_operator,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_settlement_id;
+
+  RETURN jsonb_build_object(
+    'settlement_id', p_settlement_id,
+    'status',        'sent',
+    'was',           v_s.status
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_send_settlement_to_store IS
+  '總部把月結對帳單送給店家線上核對：draft→sent；disputed（爭議全部 resolved 後）→sent。';
+
+-- ------------------------------------------------------------
+-- 8. 店家核對：同意畫押（→confirmed）或逐行提出爭議（→disputed）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_store_review_settlement(
+  p_settlement_id BIGINT,
+  p_operator      UUID,
+  p_agree         BOOLEAN,
+  p_disputes      JSONB DEFAULT NULL   -- [{transfer_item_id, reason}, ...]（p_agree=false 必填）
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_s        store_monthly_settlements%ROWTYPE;
+  v_d        JSONB;
+  v_item_id  BIGINT;
+  v_reason   TEXT;
+  v_item     RECORD;
+  v_count    INTEGER := 0;
+  v_confirm  JSONB;
+BEGIN
+  SELECT * INTO v_s FROM store_monthly_settlements WHERE id = p_settlement_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'settlement % not found', p_settlement_id;
+  END IF;
+
+  -- 店家本人（store_manager/store_staff 且綁該店）或總部代操作
+  IF NOT (public._settlement_caller_in_store(v_s.store_id) OR public._settlement_caller_is_hq()) THEN
+    RAISE EXCEPTION '僅該分店帳號（或總部代操作）可核對此對帳單';
+  END IF;
+
+  IF v_s.status <> 'sent' THEN
+    RAISE EXCEPTION '狀態 % 不可核對（需為 sent 已送核對）', v_s.status;
+  END IF;
+
+  IF p_agree THEN
+    UPDATE store_monthly_settlements
+       SET store_agreed_at = NOW(),
+           store_agreed_by = p_operator,
+           updated_by      = p_operator,
+           updated_at      = NOW()
+     WHERE id = p_settlement_id;
+
+    -- 兩邊都同意 → 鎖定（沿用 confirm：產生應收單）
+    v_confirm := public.rpc_confirm_store_monthly_settlement(p_settlement_id, p_operator);
+
+    RETURN jsonb_build_object(
+      'settlement_id', p_settlement_id,
+      'status',        'confirmed',
+      'receivable_no', v_confirm ->> 'receivable_no',
+      'amount',        v_confirm -> 'amount'
+    );
+  END IF;
+
+  -- 提出爭議
+  IF p_disputes IS NULL OR jsonb_typeof(p_disputes) <> 'array' OR jsonb_array_length(p_disputes) = 0 THEN
+    RAISE EXCEPTION '不同意時需至少提出一筆爭議（p_disputes）';
+  END IF;
+
+  FOR v_d IN SELECT * FROM jsonb_array_elements(p_disputes)
+  LOOP
+    v_item_id := (v_d ->> 'transfer_item_id')::BIGINT;
+    v_reason  := NULLIF(TRIM(v_d ->> 'reason'), '');
+    IF v_item_id IS NULL OR v_reason IS NULL THEN
+      RAISE EXCEPTION '每筆爭議需含 transfer_item_id 與 reason（收到 %）', v_d;
+    END IF;
+
+    SELECT i.entry_type, i.description, i.sku_id, i.qty_received,
+           i.branch_amount, i.received_at
+      INTO v_item
+      FROM store_monthly_settlement_items i
+     WHERE i.settlement_id = p_settlement_id
+       AND i.transfer_item_id = v_item_id
+     LIMIT 1;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'transfer_item % 不在此對帳單明細內', v_item_id;
+    END IF;
+
+    INSERT INTO store_settlement_disputes (
+      tenant_id, settlement_id, transfer_item_id, item_snapshot, reason, raised_by
+    ) VALUES (
+      v_s.tenant_id, p_settlement_id, v_item_id,
+      jsonb_build_object(
+        'entry_type',    v_item.entry_type,
+        'description',   v_item.description,
+        'sku_id',        v_item.sku_id,
+        'qty_received',  v_item.qty_received,
+        'branch_amount', v_item.branch_amount,
+        'received_at',   v_item.received_at
+      ),
+      v_reason, p_operator
+    )
+    ON CONFLICT (settlement_id, transfer_item_id) WHERE status = 'open'
+    DO NOTHING;
+    v_count := v_count + 1;
+  END LOOP;
+
+  UPDATE store_monthly_settlements
+     SET status     = 'disputed',
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_settlement_id;
+
+  RETURN jsonb_build_object(
+    'settlement_id', p_settlement_id,
+    'status',        'disputed',
+    'disputes',      v_count
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_store_review_settlement IS
+  '店家線上核對月結對帳單：p_agree=true 同意畫押（→confirmed、產生應收單）；'
+  'false 逐行提出爭議（→disputed，換總部處理）。店家本人或總部代操作。';
+
+-- ------------------------------------------------------------
+-- 9. 總部處理爭議
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_resolve_settlement_dispute(
+  p_dispute_id BIGINT,
+  p_operator   UUID,
+  p_note       TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_d    store_settlement_disputes%ROWTYPE;
+  v_open INTEGER;
+BEGIN
+  IF NOT public._settlement_caller_is_hq() THEN
+    RAISE EXCEPTION '僅總部帳號可處理爭議';
+  END IF;
+
+  SELECT * INTO v_d FROM store_settlement_disputes WHERE id = p_dispute_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'dispute % not found', p_dispute_id;
+  END IF;
+  IF v_d.status <> 'open' THEN
+    RAISE EXCEPTION 'dispute % 已處理過（%）', p_dispute_id, v_d.status;
+  END IF;
+
+  UPDATE store_settlement_disputes
+     SET status          = 'resolved',
+         resolved_by     = p_operator,
+         resolved_at     = NOW(),
+         resolution_note = NULLIF(TRIM(p_note), ''),
+         updated_at      = NOW()
+   WHERE id = p_dispute_id;
+
+  SELECT COUNT(*) INTO v_open
+    FROM store_settlement_disputes
+   WHERE settlement_id = v_d.settlement_id AND status = 'open';
+
+  RETURN jsonb_build_object(
+    'dispute_id',     p_dispute_id,
+    'settlement_id',  v_d.settlement_id,
+    'open_remaining', v_open
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_resolve_settlement_dispute IS
+  '總部標記單筆對帳爭議已處理（修正金額/說明後）；全部 resolved 才能重新送單。';
+
+-- ------------------------------------------------------------
+-- 10. 店家已匯款 / 總部確認收款結案
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_mark_settlement_remitted(
+  p_settlement_id BIGINT,
+  p_operator      UUID,
+  p_note          TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_s store_monthly_settlements%ROWTYPE;
+BEGIN
+  SELECT * INTO v_s FROM store_monthly_settlements WHERE id = p_settlement_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'settlement % not found', p_settlement_id;
+  END IF;
+  IF NOT (public._settlement_caller_in_store(v_s.store_id) OR public._settlement_caller_is_hq()) THEN
+    RAISE EXCEPTION '僅該分店帳號（或總部代操作）可標記已匯款';
+  END IF;
+  IF v_s.status <> 'confirmed' THEN
+    RAISE EXCEPTION '狀態 % 不可標記已匯款（需為 confirmed 已鎖定）', v_s.status;
+  END IF;
+
+  UPDATE store_monthly_settlements
+     SET status      = 'remitted',
+         remitted_at = NOW(),
+         remitted_by = p_operator,
+         remit_note  = NULLIF(TRIM(p_note), ''),
+         updated_by  = p_operator,
+         updated_at  = NOW()
+   WHERE id = p_settlement_id;
+
+  RETURN jsonb_build_object('settlement_id', p_settlement_id, 'status', 'remitted');
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_mark_settlement_remitted IS
+  '店家匯款後按「已匯款」：confirmed→remitted，備註可填匯款帳號後五碼等。';
+
+CREATE OR REPLACE FUNCTION public.rpc_settle_store_monthly_settlement(
+  p_settlement_id BIGINT,
+  p_operator      UUID,
+  p_note          TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_s         store_monthly_settlements%ROWTYPE;
+  v_r         store_receivables%ROWTYPE;
+  v_remaining NUMERIC;
+  v_payment   JSONB;
+BEGIN
+  IF NOT public._settlement_caller_is_hq() THEN
+    RAISE EXCEPTION '僅總部帳號可確認收款結案';
+  END IF;
+
+  SELECT * INTO v_s FROM store_monthly_settlements WHERE id = p_settlement_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'settlement % not found', p_settlement_id;
+  END IF;
+  -- 正常流程 remitted → settled；店家忘按已匯款但款已到，允許 confirmed 直接結案
+  IF v_s.status NOT IN ('remitted', 'confirmed') THEN
+    RAISE EXCEPTION '狀態 % 不可結案（需為 remitted / confirmed）', v_s.status;
+  END IF;
+
+  -- 同步應收單：把未收餘額一次入帳（沿用既有付款 RPC，含 paid/partially_paid 邏輯）
+  IF v_s.generated_receivable_id IS NOT NULL THEN
+    SELECT * INTO v_r FROM store_receivables WHERE id = v_s.generated_receivable_id;
+    IF FOUND AND v_r.status IN ('pending', 'partially_paid') THEN
+      v_remaining := v_r.amount - COALESCE(v_r.paid_amount, 0);
+      IF v_remaining > 0 THEN
+        v_payment := public.rpc_record_store_receivable_payment(
+          v_r.id, v_remaining, 'bank_transfer', CURRENT_DATE, p_operator,
+          TRIM(COALESCE('月結結案收款確認', '') || COALESCE('；' || NULLIF(TRIM(p_note), ''), ''))
+        );
+      END IF;
+    END IF;
+  END IF;
+
+  UPDATE store_monthly_settlements
+     SET status     = 'settled',
+         settled_at = NOW(),
+         settled_by = p_operator,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_settlement_id;
+
+  RETURN jsonb_build_object(
+    'settlement_id', p_settlement_id,
+    'status',        'settled',
+    'payment',       v_payment
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_settle_store_monthly_settlement IS
+  '總部確認收到店家匯款 → 結案：remitted（或 confirmed 補按）→settled，'
+  '並把對應應收單未收餘額入帳（rpc_record_store_receivable_payment）。';

--- a/supabase/migrations/20260715000130_rpc_settlement_action_count.sql
+++ b/supabase/migrations/20260715000130_rpc_settlement_action_count.sql
@@ -1,0 +1,43 @@
+-- ============================================================
+-- 2026-07-15: 月結對帳待辦數 rpc_settlement_action_count
+--
+-- 需求：電子對帳沒有推播，改在側欄「月結算」選單掛小數字當通知。
+-- 口徑（依 caller 角色，讀 auth.jwt()）：
+--   - 分店（store_manager / store_staff）：自己店（_jwt_store_ids()）
+--     status IN ('sent','confirmed') —— 待核對 + 待匯款，都是店家要動作的。
+--     （disputed 是等總部處理、remitted 是等總部收款，不算店家待辦）
+--   - 總部（_settlement_caller_is_hq()，含 '' legacy admin）：全 tenant
+--     status IN ('disputed','remitted') —— 待處理爭議 + 待確認收款。
+--   - 其他 → 0。
+--
+-- 新函式，無歷史版本。
+-- Rollback：DROP FUNCTION public.rpc_settlement_action_count();
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_settlement_action_count()
+RETURNS INTEGER
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  SELECT CASE
+    WHEN COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+         IN ('store_manager', 'store_staff') THEN (
+      SELECT COUNT(*)::int
+        FROM store_monthly_settlements s
+       WHERE s.tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND s.store_id = ANY (public._jwt_store_ids())
+         AND s.status IN ('sent', 'confirmed')
+    )
+    WHEN public._settlement_caller_is_hq() THEN (
+      SELECT COUNT(*)::int
+        FROM store_monthly_settlements s
+       WHERE s.tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND s.status IN ('disputed', 'remitted')
+    )
+    ELSE 0
+  END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_settlement_action_count() TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_settlement_action_count IS
+  '側欄月結算 badge 用：分店回自己店 sent+confirmed 筆數（待核對/待匯款）；'
+  '總部回全 tenant disputed+remitted 筆數（待處理爭議/待確認收款）。';


### PR DESCRIPTION
## Summary

Implements the complete electronic monthly settlement workflow, replacing paper-based processes. Stores can now review settlement statements online, raise disputes on individual line items, and confirm remittance status. HQ can send statements, resolve disputes, and confirm receipt for final settlement.

## Key Changes

**Database Schema** (`20260715000120_settlement_estatement_flow.sql`):
- Extended `store_monthly_settlements.status` to include `sent`, `disputed`, `remitted` states (full flow: draft → sent → disputed ⇄ sent → confirmed → remitted → settled)
- Added tracking columns: `sent_at`, `sent_by`, `store_agreed_at`, `store_agreed_by`, `remitted_at`, `remitted_by`, `remit_note`, `settled_by`
- New `store_settlement_disputes` table to track line-item disputes anchored by `transfer_item_id` with `item_snapshot`, `reason`, and resolution tracking
- RLS policy on disputes table: HQ sees all tenant disputes; stores see only their own

**Settlement Generator v4** (`rpc_generate_hq_to_store_settlement`):
- Changed recalculation scope: now rebuilds `draft/sent/disputed` (pre-lock states follow source data changes), skips `confirmed/settled/remitted/cancelled` (prevents overwriting locked records)
- Fixes latent bug where `disputed`/`cancelled` rows would cause NULL crash in upsert RETURNING clause
- Dispute rows anchor to `transfer_item_id` so rebuilds don't lose line-item references

**New RPC Functions**:
- `rpc_send_settlement_to_store()` — HQ sends draft settlement to store (status: draft → sent)
- `rpc_store_review_settlement()` — Store reviews and either agrees (confirmed) or raises disputes (disputed)
- `rpc_resolve_settlement_dispute()` — HQ resolves individual disputes, marks resolved, resends to store
- `rpc_mark_settlement_remitted()` — Store confirms remittance with optional note (status: confirmed → remitted)
- `rpc_settle_store_monthly_settlement()` — HQ confirms receipt and finalizes (status: remitted → settled, generates receivable)
- `_settlement_caller_is_hq()` / `_settlement_caller_in_store()` — Role-based access gates (HQ: owner/admin/hq_manager/hq_accountant/legacy; Store: store_manager/store_staff with `_jwt_store_ids()`)

**UI Components**:
- New `StoreSettlementReview` component for store-side review interface (line-by-line dispute flagging, remittance confirmation)
- Updated settlement page to show store view (no cost basis) vs HQ view (full dual-price basis)
- Settlement list now displays new status states with appropriate colors and action buttons

**Supporting Changes**:
- `rpc_update_free_transfer_amount()` (`20260715000110`) — Allows post-hoc correction of free-transfer estimated amounts before settlement lock, with audit trail in notes
- `rpc_settlement_action_count()` (`20260715000130`) — Returns pending action count per caller role (stores: sent/confirmed; HQ: disputed/remitted)
- Payable amount basis corrected to branch price (`20260715000100`) — aligns repo with production (賣斷制: HQ charges store at branch price, cost basis for reference only)

**Navigation**:
- Settlement menu label changes to "月結對帳" (Monthly Settlement Review) for store accounts
- Store accounts see only the review interface, not HQ generation/confirmation views

## Implementation Details

- All RPC functions use `SECURITY DEFINER` with role-based gates to prevent unauthorized state transitions
- Dispute resolution maintains full audit trail: `raised_by/raised_at`, `resolved_by/resolved_at`, `resolution_note`
- Free-transfer amount corrections trigger automatic regeneration of affected month's draft settlement for both source and destination stores
- Settlement lock (confirmed state) prevents further generator recalculation and free-transfer corrections (must use dispute flow)
- Print view supports

https://claude.ai/code/session_016i7VbUfjDEVJoAvB8hu34n