### PR TITLE
月結明細表格列加 hover 底色，寬表逐行閱讀較不易看錯行

### DIFF
--- a/apps/admin/src/app/(protected)/transfers/settlement/detail/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/detail/page.tsx
@@ -494,7 +494,7 @@ export default function HqSettlementDetailPage() {
                 const isNeg = Number(it.line_amount) < 0;
                 const isFree = it.entry_type === "free_in" || it.entry_type === "free_out";
                 return (
-                  <tr key={it.id}>
+                  <tr key={it.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
                     <Td>
                       <span className={`inline-block whitespace-nowrap rounded px-2 py-0.5 text-xs ${ENTRY_TYPE_COLOR[it.entry_type] ?? ENTRY_TYPE_COLOR.hq_inbound}`}>
                         {ENTRY_TYPE_LABEL[it.entry_type] ?? it.entry_type}

--- a/apps/admin/src/app/(protected)/transfers/settlement/review/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/review/page.tsx
@@ -406,7 +406,7 @@ export default function SettlementReviewPage() {
                 d?.status === "open" ? "bg-red-50 dark:bg-red-950/40"
                 : flagged ? "bg-amber-50 dark:bg-amber-950/40"
                 : isChecked ? "bg-emerald-50/60 dark:bg-emerald-950/30"
-                : "";
+                : "hover:bg-zinc-50 dark:hover:bg-zinc-900";
               return (
                 <tr key={it.id} className={rowCls}>
                   <td className="whitespace-nowrap px-3 py-2 text-xs">{ENTRY_TYPE_LABEL[it.entry_type] ?? it.entry_type}</td>


### PR DESCRIPTION
## Summary

月結明細是十欄寬表，逐行核對時容易看錯行，明細列加上滑鼠 hover 底色：

- **總倉明細頁**（`/transfers/settlement/detail`）：明細列 hover 亮底。
- **分店核對頁**（`/transfers/settlement/review`）：未標記的列 hover 亮底；已核對（綠）／有問題（黃）／爭議中（紅）的列保留原狀態底色、不被 hover 蓋掉。

純樣式，2 行改動。`tsc` 乾淨、eslint 無 finding。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016i7VbUfjDEVJoAvB8hu34n

---
_Generated by [Claude Code](https://claude.ai/code/session_016i7VbUfjDEVJoAvB8hu34n)_