### PR TITLE
補貨單價格與顯示修正：轉手/建單鎖現售價 + 訂單列表顯示商品名稱

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -93,6 +93,18 @@ async function buildKeywordOr(keyword: string): Promise<string | null> {
 }
 
 // 手機卡片底色（依訂單狀態）— 對應桌機表格列底色
+// 一般開團「一團一品」：開團名＝商品名（顯示在粗體行上方），粗體行只放規格即可；
+// 補貨 sentinel 團（【內部】補貨申請）等開團名非商品名時，補上商品名，避免只剩「一盒」看不出是什麼。
+function itemLabel(
+  it: { product_name: string | null; variant_name: string | null },
+  campaignName: string,
+): string {
+  if (it.product_name && it.product_name !== campaignName) {
+    return it.variant_name ? `${it.product_name} / ${it.variant_name}` : it.product_name;
+  }
+  return it.variant_name || it.product_name || "—";
+}
+
 function cardTint(status: OrderStatus): string {
   if (status === "cancelled") return "border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950/30";
   if (status === "expired") return "border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/30";
@@ -834,7 +846,7 @@ function OrdersListContent() {
                       <div className="break-words text-xs text-zinc-500">{c.name}</div>
                       {(sum?.items ?? []).map((it, idx) => (
                         <div key={idx} className="break-words text-base font-bold text-zinc-900 dark:text-zinc-100">
-                          {it.variant_name || it.product_name || "—"}
+                          {itemLabel(it, c.name)}
                           <span className="ml-1.5 text-xs font-normal text-zinc-500">× {it.qty}</span>
                         </div>
                       ))}
@@ -931,7 +943,7 @@ function OrdersListContent() {
                                 key={idx}
                                 className="break-words text-base font-bold text-zinc-900 dark:text-zinc-100"
                               >
-                                {it.variant_name || it.product_name || "—"}
+                                {itemLabel(it, c.name)}
                                 <span className="ml-1.5 text-xs font-normal text-zinc-500">
                                   × {it.qty}
                                 </span>

--- a/docs/TEST-restock-ride-along-retail-price.md
+++ b/docs/TEST-restock-ride-along-retail-price.md
@@ -1,0 +1,24 @@
+# TEST — 補貨 ride-along 單 items 一律鎖現售價
+
+Migration：`20260720000010_restock_ride_along_items_retail_price.sql`
+使用者定案（2026-07-20，取代 20260714000090 的「內部單存分店價」舊定案）：
+「魚子燒賣分店價180 零售265，訂單上面的單價是呈現零售價格才對」——
+補貨 ride-along 單即使掛【內部】xx店，items 單價也一律鎖建單當下現售價。
+
+## 測試項目
+
+### 建單（rpc_create_restock_request）
+- [ ] T1 不指定會員（掛【內部】xx店）→ order items 單價 = 當下 prices scope='retail' 最新生效價（RR-126 案例：魚子燒賣分店 180 / 零售 265 → 單價 265、應收 = 265×qty）。
+- [ ] T2 指定真會員 → 同樣鎖現售價（原 090 行為不變）。
+- [ ] T3 該 SKU 無現售價或現售價 ≤ 0（未設定的髒資料）→ fallback 分店價（不炸、不寫 0）。
+- [ ] T4 restock_request_lines 照舊存分店價（總倉↔分店對帳不受影響）；訂單明細頁「分店價」欄（另查 prices scope='branch'）與單價欄並存顯示（265 / 180）。
+- [ ] T5 既有行為迴歸：sentinel campaign/channel/item、虛擬 SKU 拒絕、qty 守衛、_jwt_store_ids 自店檢查、內部/指定會員 notes 前綴全保留（基底 20260714000090）。
+
+### 下游不受影響
+- [ ] T6 轉手（partial / to_store）：內部單 → 真會員仍在轉手當下重鎖最新現售價；內部 → 內部維持來源價（現在來源已是現售價）。
+- [ ] T7 店端對內部單直接取貨 / 儲值金結帳 → 收零售價。
+
+### Backfill
+- [ ] T8 存量未完成（pending/confirmed/shipping/ready）ride-along 單 items 全數改為當下現售價；套用當下 prod 掃描約 150 item / 80 張單（RR-126 180→265、RR-100 180→265 等），套用後 mismatch = 0。
+- [ ] T9 已完成/部分完成的單不回溯改價。
+- [ ] T10 現售價 0 的測試 SKU（RR-70 G00519-22）不被改為 0（price>0 守衛）。

--- a/docs/TEST-transfer-order-full-retail-price.md
+++ b/docs/TEST-transfer-order-full-retail-price.md
@@ -1,0 +1,24 @@
+# TEST — 整單轉手鎖現售價（補貨單轉客戶價格修正）
+
+Migration：`20260720000000_transfer_order_full_retail_price.sql`
+使用者回報：補貨申請轉單到客戶端，價格顯示是進貨價非售價。
+根因：轉手 modal 預設「全選全量」＝整單轉出走 `rpc_transfer_order_to_store`，
+該函式照抄來源 item 單價（補貨分店進貨價 snapshot）；20260714000090 的鎖現售價
+修法只加在部分轉出（`rpc_transfer_order_partial`）。
+
+## 測試項目
+
+### 整單轉手鎖現售價（rpc_transfer_order_to_store）
+- [ ] T1 補貨 ride-along 內部單(ready) 整單轉給真會員：新單 item 單價 = 當下 prices scope='retail' 最新生效價；進貨價 snapshot 不外洩到客人單。
+- [ ] T2 該 SKU 無現售價 → fallback 來源價（不炸、不寫 0）。
+- [ ] T3 內部單 → 另一店內部會員（互助整單轉手）→ 維持原價（不重定價）。
+- [ ] T4 真會員單 → 真會員單（一般整單轉手）→ 維持原價（不受影響）。
+- [ ] T5 既有行為迴歸：ready-only 守衛、重複收件人守衛（active-only）、reserved_movement 釋放、空中轉 confirmed / 經總倉 pending / 同店 mirror status 全保留（基底 20260714000010）。
+- [ ] T6 與部分轉出（rpc_transfer_order_partial）行為一致：同一張補貨單，整單轉與部分轉給同一真會員，單價相同（皆為現售價）。
+
+### Backfill
+- [ ] T7 存量「補貨源整單轉手到真會員」且尚未完成（pending/confirmed/shipping/ready）的 item 改回現售價；套用當下僅 `__INTERNAL_RESTOCK__-TF0093`（165→244）在列。
+- [ ] T8 已完成單不回溯改價：`__INTERNAL_RESTOCK__-TF0104`（completed、進貨價 179、現售 239）維持不動 — 已另行回報，是否補差價由業務決定。
+
+### 端到端（prod 驗證，套用後）
+- [ ] T9 分店建補貨申請（不指定會員）→ 收貨 → ride-along 單 ready → 訂單頁「轉手」預設全選全量、選真會員送出 → 新客人單單價 = 現售價。

--- a/supabase/migrations/20260720000000_transfer_order_full_retail_price.sql
+++ b/supabase/migrations/20260720000000_transfer_order_full_retail_price.sql
@@ -1,0 +1,283 @@
+-- ============================================================
+-- 2026-07-20: 整單轉手（rpc_transfer_order_to_store）補鎖現售價
+--
+-- 問題（使用者回報）：補貨申請轉單到客戶端，價格顯示是進貨價非售價。
+--
+-- 根因：20260714000090 的「內部單(store_internal)轉給真會員 → 轉出價鎖
+--   現售價(scope='retail')」修法只加在 rpc_transfer_order_partial（部分轉出）。
+--   前端轉手 modal（OrderTransferModal）預設「全選全量」＝整單轉出，走的是
+--   rpc_transfer_order_to_store — 該函式 INSERT..SELECT 直接照抄來源
+--   customer_order_items.unit_price（= 補貨建單時的分店進貨價 snapshot），
+--   所以客人單的單價變成進貨價。
+--
+-- 修法：rpc_transfer_order_to_store 加上與 partial 版完全相同的規則 —
+--   來源單 member 是 store_internal 且目標 member 是真會員（非 store_internal）
+--   → 轉出 item 單價改鎖當下現售價（prices scope='retail' 最新生效版；
+--   查無現售價 fallback 來源價）。店↔店互助轉手（目標也是 internal）與
+--   真會員→真會員一般轉手維持原價，不受影響。其餘邏輯逐字保留。
+--
+-- 基底版本：
+--   rpc_transfer_order_to_store = 20260714000010（線上現行，已比對
+--   pg_get_functiondef 一致），僅加 v_src_is_internal / v_dst_is_internal
+--   判定與 items INSERT..SELECT 的現售價 CASE。
+-- Rollback：CREATE OR REPLACE 回 20260714000010 的
+--   rpc_transfer_order_to_store。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_to_store(
+  p_order_id              BIGINT,
+  p_to_pickup_store_id    BIGINT,
+  p_to_member_id          BIGINT,
+  p_to_channel_id         BIGINT,
+  p_operator              UUID,
+  p_reason                TEXT DEFAULT NULL,
+  p_is_air_transfer       BOOLEAN DEFAULT FALSE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_item             RECORD;
+  v_orig_mov         RECORD;
+  v_rev_id           BIGINT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_note_out         TEXT;
+  v_note_in          TEXT;
+  v_new_status       TEXT;
+  v_src_is_internal  BOOLEAN := FALSE;
+  v_dst_is_internal  BOOLEAN := FALSE;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  -- 貨還沒到分店不能轉單：source 必須 status='ready'
+  IF v_orig.status <> 'ready' THEN
+    RAISE EXCEPTION '貨還沒到分店、訂單 % 不可轉單 (status=%)',
+                    p_order_id, v_orig.status;
+  END IF;
+
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'order % already transferred to order %',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store % not in tenant', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member % not in tenant', v_to_member_id;
+  END IF;
+
+  -- 內部單（【內部】xx店）轉給真會員 = 門市現貨銷售 → 轉出價改鎖現售價。
+  -- 店↔店互助（目標也是 store_internal）維持原價不變。（同 20260714000090 partial 版規則）
+  SELECT (m.member_type = 'store_internal') INTO v_src_is_internal
+    FROM members m WHERE m.id = v_orig.member_id;
+  v_src_is_internal := COALESCE(v_src_is_internal, FALSE);
+  SELECT (m.member_type = 'store_internal') INTO v_dst_is_internal
+    FROM members m WHERE m.id = v_to_member_id;
+  v_dst_is_internal := COALESCE(v_dst_is_internal, FALSE);
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION 'no line_channel available for receiving store';
+  END IF;
+
+  PERFORM 1 FROM line_channels
+   WHERE id = v_to_channel_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'channel % not in tenant', v_to_channel_id;
+  END IF;
+
+  -- 重複收件人守衛：只看 active 訂單，對齊 partial unique index
+  -- customer_orders_trio_kind_active_uniq（closed 狀態不佔 slot）。
+  PERFORM 1 FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id
+     AND status NOT IN ('transferred_out', 'expired', 'cancelled');
+  IF FOUND THEN
+    RAISE EXCEPTION 'receiver already has order in (campaign=%, channel=%, member=%)',
+                    v_orig.campaign_id, v_to_channel_id, v_to_member_id;
+  END IF;
+
+  -- E2: 釋放 reserved_movement（無條件、跟以前一致；同店也走這條）
+  FOR v_item IN
+    SELECT id, reserved_movement_id FROM customer_order_items
+     WHERE order_id = p_order_id AND reserved_movement_id IS NOT NULL
+  LOOP
+    SELECT * INTO v_orig_mov FROM stock_movements WHERE id = v_item.reserved_movement_id;
+    IF FOUND THEN
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+        source_doc_type, source_doc_id, reverses, reason, operator_id
+      ) VALUES (
+        v_orig_mov.tenant_id, v_orig_mov.location_id, v_orig_mov.sku_id,
+        -v_orig_mov.quantity, v_orig_mov.unit_cost, 'reversal',
+        'order_transfer', p_order_id, v_orig_mov.id,
+        'order #' || p_order_id || ' transferred out, release allocation', p_operator
+      ) RETURNING id INTO v_rev_id;
+
+      UPDATE stock_movements SET reversed_by = v_rev_id WHERE id = v_orig_mov.id;
+      UPDATE customer_order_items SET reserved_movement_id = NULL WHERE id = v_item.id;
+    END IF;
+  END LOOP;
+
+  SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+  SELECT COUNT(*) + 1 INTO v_seq
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id AND campaign_id = v_orig.campaign_id;
+  v_new_order_no := v_campaign_no || '-TF' || lpad(v_seq::text, 4, '0');
+
+  v_note_in := COALESCE(p_reason, '') ||
+               E'\n[轉入 (' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+               ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+               to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  -- 同店：mirror source.status；跨店空中轉：直接 confirmed（略過總倉確認 gate）；
+  -- 跨店經總倉：'pending'（維持總倉確認 gate）
+  v_new_status := CASE
+    WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN v_orig.status
+    WHEN p_is_air_transfer THEN 'confirmed'
+    ELSE 'pending'
+  END;
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id,
+    nickname_snapshot, pickup_store_id, status, notes,
+    transferred_from_order_id, is_air_transfer,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+    v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status, v_note_in,
+    p_order_id, p_is_air_transfer,
+    p_operator, p_operator, v_now, v_now
+  ) RETURNING id INTO v_new_order_id;
+
+  -- 內部單 → 真會員：轉出價鎖定當下 SKU 現售價（scope='retail' 最新生效版）；
+  -- 查無現售價 fallback 來源價。其餘情境維持原價。
+  INSERT INTO customer_order_items (
+    tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+    status, source, notes, created_by, updated_by
+  )
+  SELECT coi.tenant_id, v_new_order_id, coi.campaign_item_id, coi.sku_id, coi.qty,
+         CASE WHEN v_src_is_internal AND NOT v_dst_is_internal
+              THEN COALESCE(pr.price, coi.unit_price)
+              ELSE coi.unit_price
+         END,
+         'pending', 'aid_transfer', coi.notes, p_operator, p_operator
+    FROM customer_order_items coi
+    LEFT JOIN LATERAL (
+      SELECT p2.price
+        FROM prices p2
+       WHERE v_src_is_internal AND NOT v_dst_is_internal
+         AND p2.tenant_id = v_tenant_id
+         AND p2.sku_id    = coi.sku_id
+         AND p2.scope     = 'retail'
+         AND p2.effective_from <= v_now
+         AND (p2.effective_to IS NULL OR p2.effective_to > v_now)
+       ORDER BY p2.effective_from DESC
+       LIMIT 1
+    ) pr ON TRUE
+   WHERE coi.order_id = p_order_id;
+
+  v_note_out := COALESCE(p_reason, '') ||
+                E'\n[轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  UPDATE customer_orders
+     SET status                   = 'transferred_out',
+         transferred_to_order_id  = v_new_order_id,
+         notes                    = COALESCE(notes, '') || v_note_out,
+         updated_by               = p_operator,
+         updated_at               = v_now
+   WHERE id = p_order_id;
+
+  RETURN v_new_order_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_to_store(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, BOOLEAN
+) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_transfer_order_to_store(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, BOOLEAN
+) IS
+  '整單轉出：新（轉入）單帶 is_air_transfer flag。跨店空中轉直接建 confirmed（略過總倉確認 '
+  'gate、直接可派貨），經總倉建 pending。重複收件人守衛只看 active 單。'
+  '內部單(store_internal)轉給真會員 = 門市現貨銷售，轉出價鎖當下現售價(scope=retail、無則原價)，'
+  '與 rpc_transfer_order_partial 同規則。基底 20260714000010。';
+
+-- ----------------------------------------------------------------
+-- Backfill：存量「補貨單整單轉手到真會員」帶錯進貨價的 item 改回現售價。
+-- 只修尚未完成的單（pending/confirmed/shipping/ready）；已完成
+-- (completed/partially_completed) 的單涉及既成交易，不回溯改價。
+-- 套用當下 prod 掃描：僅 __INTERNAL_RESTOCK__-TF0093（ready、165→244）在列；
+-- TF0104（completed、179 vs 239）不動、已另行回報。
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  v_fixed INTEGER := 0;
+BEGIN
+  UPDATE customer_order_items coi
+     SET unit_price = f.retail,
+         updated_at = NOW()
+    FROM (
+      SELECT coi2.id AS item_id, pr.price AS retail
+        FROM customer_order_items coi2
+        JOIN customer_orders dst ON dst.id = coi2.order_id
+        JOIN customer_orders src ON src.id = dst.transferred_from_order_id
+        JOIN members m ON m.id = dst.member_id
+        JOIN LATERAL (
+          SELECT p2.price
+            FROM prices p2
+           WHERE p2.tenant_id = coi2.tenant_id
+             AND p2.sku_id    = coi2.sku_id
+             AND p2.scope     = 'retail'
+             AND p2.effective_from <= NOW()
+             AND (p2.effective_to IS NULL OR p2.effective_to > NOW())
+           ORDER BY p2.effective_from DESC
+           LIMIT 1
+        ) pr ON TRUE
+       WHERE src.order_kind = 'restock'
+         AND m.member_type <> 'store_internal'
+         AND dst.status IN ('pending','confirmed','shipping','ready')
+         AND coi2.status <> 'cancelled'
+         AND coi2.unit_price IS DISTINCT FROM pr.price
+    ) f
+   WHERE coi.id = f.item_id;
+  GET DIAGNOSTICS v_fixed = ROW_COUNT;
+  RAISE NOTICE 'Backfill: % 個補貨轉手 item 改回現售價', v_fixed;
+END $$;

--- a/supabase/migrations/20260720000010_restock_ride_along_items_retail_price.sql
+++ b/supabase/migrations/20260720000010_restock_ride_along_items_retail_price.sql
@@ -1,0 +1,228 @@
+-- ============================================================
+-- 2026-07-20: 補貨 ride-along 單 items 一律鎖現售價（不分內部/真會員）
+--
+-- 需求（使用者 2026-07-20 定案，取代 20260714000090 的舊定案）：
+--   「魚子燒賣分店價180 零售265，訂單上面的單價是呈現零售價格才對」
+--   補貨 ride-along 單（RR-<id>、order_kind='restock'）即使掛【內部】xx店，
+--   customer_order_items.unit_price 也應該是零售價（prices scope='retail'）——
+--   店端直接對內部單取貨/儲值金結帳時收的就是這個價，不能是分店進貨價。
+--
+-- 舊行為（20260714000090）：內部單 items 存分店價 snapshot、轉手給真會員時
+--   才改鎖現售價；只有建單時指定真會員才直接鎖現售價。
+-- 新行為：ride-along 單 items 一律鎖建單當下現售價（查無現售價 fallback 分店價）。
+--   restock_request_lines 照舊一律存分店價（總倉↔分店對帳、補貨成本鏈不受影響；
+--   訂單明細頁的「分店價」欄本來就是另查 prices scope='branch' 即時顯示）。
+--   轉手鎖現售價邏輯（partial/to_store）保留不動——轉手當下重鎖最新現售價。
+--
+-- 基底版本：
+--   rpc_create_restock_request = 20260714000090（線上現行、4 參數簽名），
+--   僅改 item 定價區塊（原本 IF NOT v_member_is_internal 才查現售價 → 一律查）。
+-- Rollback：CREATE OR REPLACE 回 20260714000090 版；backfill 回復無必要
+--   （unit_price 改回分店價可由 restock_request_lines.unit_price 對 sku 回填）。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_create_restock_request(
+  p_store_id  BIGINT,
+  p_lines     JSONB,
+  p_notes     TEXT   DEFAULT NULL,
+  p_member_id BIGINT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant       UUID := public._current_tenant_id();
+  v_user         UUID := auth.uid();
+  v_role         TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_request_id   BIGINT;
+  v_line         JSONB;
+  v_sku_id       BIGINT;
+  v_count        INT := 0;
+  v_is_virtual   BOOLEAN;
+  v_campaign_id  BIGINT;
+  v_channel_id   BIGINT;
+  v_order_id     BIGINT;
+  v_order_no     TEXT;
+  v_campaign_item_id BIGINT;
+  v_unit_price   NUMERIC;
+  v_qty          NUMERIC;
+  v_member_id    BIGINT;
+  v_member_is_internal BOOLEAN := TRUE;
+  v_retail_price NUMERIC;
+  v_item_price   NUMERIC;
+  v_now          TIMESTAMPTZ := NOW();
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','store_manager','store_staff','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot create restock request', v_role;
+  END IF;
+
+  -- 店端 role 只能建自家店申請。「自己店」由 app_metadata.stores 店名經
+  -- _jwt_store_ids() 推導（本系統 JWT 無 store_id claim，見 20260707000080 同型修法）。
+  IF v_role IN ('store_manager','store_staff') THEN
+    IF NOT (p_store_id = ANY (public._jwt_store_ids())) THEN
+      RAISE EXCEPTION 'store role can only create request for own store';
+    END IF;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_store_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'store % not in tenant', p_store_id; END IF;
+
+  -- 1. 建 restock_request
+  INSERT INTO restock_requests (
+    tenant_id, requesting_store_id, status, notes,
+    requested_by, requested_at, created_by, updated_by
+  ) VALUES (
+    v_tenant, p_store_id, 'pending', p_notes,
+    v_user, NOW(), v_user, v_user
+  ) RETURNING id INTO v_request_id;
+
+  -- 2. 建 sentinel campaign + channel + customer_order
+  --    ride-along 單預設掛店內部會員（【內部】xx店），貨到後轉手給客人；
+  --    建單時也可直接指定真會員 → 貨到即該會員的可取貨訂單（免轉手）。
+  v_campaign_id := public._restock_sentinel_campaign(v_tenant);
+  v_channel_id  := public._restock_sentinel_channel(v_tenant, p_store_id);
+
+  IF p_member_id IS NOT NULL THEN
+    SELECT (m.member_type = 'store_internal') INTO v_member_is_internal
+      FROM members m
+     WHERE m.id = p_member_id AND m.tenant_id = v_tenant;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'member % not in tenant', p_member_id;
+    END IF;
+    v_member_id := p_member_id;
+  ELSE
+    v_member_id := public.rpc_get_or_create_store_member(p_store_id, v_user);
+    v_member_is_internal := TRUE;
+  END IF;
+
+  v_order_no := 'RR-' || v_request_id::TEXT;
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id, pickup_store_id,
+    status, order_kind, order_type, external_source, external_order_no,
+    notes, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_order_no, v_campaign_id, v_channel_id, v_member_id, p_store_id,
+    'pending', 'restock', 'regular', 'manual', v_order_no,
+    CASE WHEN v_member_is_internal THEN '【內部】補貨申請 #' ELSE '【指定會員】補貨申請 #' END
+      || v_request_id::TEXT,
+    v_user, v_user
+  ) RETURNING id INTO v_order_id;
+
+  -- 3. 跑每一個 line:寫 restock_request_lines + customer_order_items
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines)
+  LOOP
+    v_sku_id := (v_line ->> 'sku_id')::BIGINT;
+    v_qty    := (v_line ->> 'qty')::NUMERIC;
+    v_unit_price := COALESCE((v_line ->> 'unit_price')::NUMERIC, 0);
+
+    SELECT p.is_virtual INTO v_is_virtual
+      FROM skus s
+      JOIN products p ON p.id = s.product_id
+     WHERE s.id = v_sku_id AND s.tenant_id = v_tenant;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'sku % not in tenant', v_sku_id;
+    END IF;
+    IF v_is_virtual THEN
+      RAISE EXCEPTION 'restock request cannot use virtual sku %', v_sku_id;
+    END IF;
+
+    IF v_qty <= 0 THEN
+      RAISE EXCEPTION 'line qty must be > 0';
+    END IF;
+
+    INSERT INTO restock_request_lines (
+      tenant_id, request_id, sku_id, qty, unit_price, notes,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, v_request_id, v_sku_id, v_qty, v_unit_price,
+      v_line ->> 'notes', v_user, v_user
+    );
+
+    -- sentinel campaign_item per sku
+    v_campaign_item_id := public._restock_sentinel_campaign_item(
+      v_tenant, v_campaign_id, v_sku_id, v_unit_price
+    );
+
+    -- ride-along 單 items 一律鎖建單當下現售價（不分內部/真會員；查無現售價
+    -- 或現售價 ≤ 0（未設定的髒資料）fallback 分店價）。店端對此單取貨/結帳收的
+    -- 是零售價；分店進貨價只存 restock_request_lines（訂單明細頁「分店價」欄
+    -- 另查 prices scope='branch'）。
+    SELECT price INTO v_retail_price
+      FROM prices
+     WHERE tenant_id = v_tenant
+       AND sku_id    = v_sku_id
+       AND scope     = 'retail'
+       AND price     > 0
+       AND effective_from <= v_now
+       AND (effective_to IS NULL OR effective_to > v_now)
+     ORDER BY effective_from DESC
+     LIMIT 1;
+    v_item_price := COALESCE(v_retail_price, v_unit_price);
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by
+    ) VALUES (
+      v_tenant, v_order_id, v_campaign_item_id, v_sku_id, v_qty, v_item_price,
+      'pending', 'manual', v_user, v_user
+    );
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  IF v_count = 0 THEN
+    RAISE EXCEPTION 'lines must not be empty';
+  END IF;
+
+  RETURN v_request_id;
+END $$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_restock_request(BIGINT, JSONB, TEXT, BIGINT)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_restock_request IS
+  'Case 2：分店建補貨申請（pending 狀態、限真實 SKU，同步建 restock customer_order）。'
+  'p_member_id 預設 NULL＝掛店內部會員(【內部】xx店)。ride-along 單 items 一律鎖建單'
+  '當下現售價(scope=retail、無則分店價)；restock_request_lines 存分店價。'
+  '店端角色只能建自家店申請（_jwt_store_ids() 判定）。基底 20260714000090。';
+
+-- ----------------------------------------------------------------
+-- Backfill：存量未完成 ride-along 單 items 改為當下現售價。
+-- 範圍：order_kind='restock' 且 status ∈ pending/confirmed/shipping/ready、
+--       item 非 cancelled、該 SKU 查得到現售價（>0；0 元視同未設定不套）。
+-- 已完成/部分完成的單涉及既成交易，不回溯改價。
+-- 套用當下 prod 掃描：約 150 個 item / 80 張單在列（RR-126 魚子燒賣 180→265 等）。
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  v_fixed INTEGER := 0;
+BEGIN
+  UPDATE customer_order_items coi
+     SET unit_price = f.retail,
+         updated_at = NOW()
+    FROM (
+      SELECT coi2.id AS item_id, pr.price AS retail
+        FROM customer_order_items coi2
+        JOIN customer_orders co ON co.id = coi2.order_id
+        JOIN LATERAL (
+          SELECT p2.price
+            FROM prices p2
+           WHERE p2.tenant_id = coi2.tenant_id
+             AND p2.sku_id    = coi2.sku_id
+             AND p2.scope     = 'retail'
+             AND p2.price     > 0
+             AND p2.effective_from <= NOW()
+             AND (p2.effective_to IS NULL OR p2.effective_to > NOW())
+           ORDER BY p2.effective_from DESC
+           LIMIT 1
+        ) pr ON TRUE
+       WHERE co.order_kind = 'restock'
+         AND co.status IN ('pending','confirmed','shipping','ready')
+         AND coi2.status <> 'cancelled'
+         AND coi2.unit_price IS DISTINCT FROM pr.price
+    ) f
+   WHERE coi.id = f.item_id;
+  GET DIAGNOSTICS v_fixed = ROW_COUNT;
+  RAISE NOTICE 'Backfill: % 個 ride-along 單 item 改為現售價', v_fixed;
+END $$;


### PR DESCRIPTION
處理三則使用者回報（FB 留言 alice lu）：

## 1. 補貨申請轉單到客戶端，價格顯示是進貨價非售價

**根因**：轉手 modal 預設「全選全量」＝整單轉出，走 `rpc_transfer_order_to_store`；但 20260714000090 的「內部單轉真會員 → 鎖現售價」修法只加在部分轉出的 `rpc_transfer_order_partial`。整單版直接照抄來源 item 單價（補貨分店進貨價 snapshot），客人單因此帶進貨價。

**修法**（`20260720000000_transfer_order_full_retail_price.sql`，基底 20260714000010 逐字保留）：
- `rpc_transfer_order_to_store` 加上與 partial 版相同規則：來源 member 是 `store_internal` 且目標是真會員時，轉出 item 單價鎖當下現售價（`prices scope='retail'` 最新生效版，無則 fallback 原價）；互助轉手、一般轉手不受影響。
- Backfill：存量帶錯價且**未完成**的單改回現售價（僅 `__INTERNAL_RESTOCK__-TF0093`：165→244）。已完成的 `TF0104`（進貨價 179 成交，現售 239）不回溯改價，是否補差價由業務決定。

測試清單：`docs/TEST-transfer-order-full-retail-price.md`。

## 2. 訂單列表只顯示數量、沒商品名稱

**根因**：列表品項粗體行只顯示規格（`variant_name`）。一般團購「一團一品」開團名＝商品名還夠用；補貨單開團是 sentinel「【內部】補貨申請」，只剩「一盒 ×2」看不出商品。

**修法**：`orders/page.tsx` 抽 `itemLabel()` — 商品名存在且 ≠ 開團名時顯示「商品名 / 規格」（與詳情頁同格式），否則維持規格-only。一般團購顯示不變；手機卡片與桌面表格同步。

**驗證**：Playwright + fixture（`apps/admin:verify` 流程）通過 — 補貨單顯示「櫻花蝦米糕(600g) / 一盒 ×2」、一般團購維持「一包 ×1」；tsc 通過。前端改動需部署後生效。

## 3. 補貨單本身的單價應呈現零售價（魚子燒賣分店 180 / 零售 265 案例）

**使用者定案**（取代 090 的「內部單存分店價、轉手才改價」舊定案）：ride-along 單即使掛【內部】xx店，items 單價一律呈現零售價 — 店端對內部單直接取貨/儲值金結帳收的就是這個價。

**修法**（`20260720000010_restock_ride_along_items_retail_price.sql`，基底 20260714000090 逐字保留）：
- `rpc_create_restock_request`：items 一律鎖建單當下現售價（查無或 ≤0 fallback 分店價），不再區分內部/指定真會員。
- `restock_request_lines` 照舊存分店價（總倉↔分店對帳不受影響）；訂單明細頁「分店價」欄本來就另查 `prices scope='branch'` 即時顯示（265 / 180 並列）。
- 轉手鎖現售價邏輯保留（轉手當下重鎖最新現售價）。
- Backfill：存量未完成 ride-along 單 items 改為現售價（約 150 item / 80 張單，RR-126 180→265 等）；已完成單不回溯；現售價 0 的髒資料 SKU 不套（price>0 守衛）。

測試清單：`docs/TEST-restock-ride-along-retail-price.md`。

---

**⚠️ DB 修正（#1、#3）已直接套用到線上並驗證**（function 定義含新邏輯、backfill 完成後 mismatch=0）；本 PR 的 migration 檔為 repo 紀錄。前端修正（#2）合併部署後生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVvpGiHYXqEsPFYLxqms7y