### PR TITLE
分店登入側欄「收貨」掛待收筆數 badge（同月結算 badge 做法）

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -82,6 +82,13 @@ export default function MutualAidPage() {
   const [offerModalOpen, setOfferModalOpen] = useState(false);
   const [threadPost, setThreadPost] = useState<Post | null>(null);
 
+  // 貼文數變動（發文/關貼/認領）後重載列表，並通知側欄「互助交流板」badge 重抓
+  // (見 layout AID_BADGE_REFRESH_EVENT)
+  function reloadAndRefreshBadge() {
+    setReloadTick((n) => n + 1);
+    window.dispatchEvent(new Event("aid-badge-refresh"));
+  }
+
   // 載入 stores 一次
   useEffect(() => {
     let cancelled = false;
@@ -253,7 +260,7 @@ export default function MutualAidPage() {
         stores={stores}
         onPosted={() => {
           setRequestModalOpen(false);
-          setReloadTick((n) => n + 1);
+          reloadAndRefreshBadge();
         }}
       />
 
@@ -263,7 +270,7 @@ export default function MutualAidPage() {
         stores={stores}
         onPosted={() => {
           setOfferModalOpen(false);
-          setReloadTick((n) => n + 1);
+          reloadAndRefreshBadge();
         }}
       />
 
@@ -274,7 +281,7 @@ export default function MutualAidPage() {
           onClose={() => setThreadPost(null)}
           onClosed={() => {
             setThreadPost(null);
-            setReloadTick((n) => n + 1);
+            reloadAndRefreshBadge();
           }}
         />
       )}

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -139,11 +139,13 @@ function filterNavForBranch(nav: NavGroup[]): NavGroup[] {
 export const SETTLEMENT_BADGE_REFRESH_EVENT = "settlement-badge-refresh";
 // 分店收貨待辦數（已派出 shipped、還沒收的調撥單）
 export const INBOUND_BADGE_REFRESH_EVENT = "inbound-badge-refresh";
+// 互助交流板進行中貼文數
+export const AID_BADGE_REFRESH_EVENT = "aid-badge-refresh";
 
 function useNavBadgeCount(
   enabled: boolean,
   pathname: string | null,
-  rpc: "rpc_settlement_action_count" | "rpc_inbound_pending_count",
+  rpc: "rpc_settlement_action_count" | "rpc_inbound_pending_count" | "rpc_aid_board_active_count",
   refreshEvent: string,
 ): number {
   const [count, setCount] = useState(0);
@@ -197,9 +199,14 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
   const inboundCount = useNavBadgeCount(
     !!session && branchUser, pathname, "rpc_inbound_pending_count", INBOUND_BADGE_REFRESH_EVENT,
   );
+  // 互助交流板 badge：分店帳號看到全 tenant 進行中貼文數（跨店佈告欄）
+  const aidCount = useNavBadgeCount(
+    !!session && branchUser, pathname, "rpc_aid_board_active_count", AID_BADGE_REFRESH_EVENT,
+  );
   const navBadges: Record<string, number> = {
     "/transfers/settlement": settlementCount,
     "/wms/inbound": inboundCount,
+    "/inventory/mutual-aid": aidCount,
   };
 
   // 載入 collapsed groups (localStorage)

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -134,11 +134,18 @@ function filterNavForBranch(nav: NavGroup[]): NavGroup[] {
     .filter((g) => g.items.length > 0);
 }
 
-// 月結對帳待辦數（分店：待核對+待匯款；總部：待處理爭議+待確認收款）。
-// 掛在「月結算」選單當通知小數字；換頁/回到視窗/對帳操作後重抓。
+// 側欄選單通知小數字：換頁/回到視窗/對應操作後（refreshEvent）重抓。
+// 月結對帳待辦數（分店：待核對+待匯款；總部：待處理爭議+待確認收款）
 export const SETTLEMENT_BADGE_REFRESH_EVENT = "settlement-badge-refresh";
+// 分店收貨待辦數（已派出 shipped、還沒收的調撥單）
+export const INBOUND_BADGE_REFRESH_EVENT = "inbound-badge-refresh";
 
-function useSettlementActionCount(enabled: boolean, pathname: string | null): number {
+function useNavBadgeCount(
+  enabled: boolean,
+  pathname: string | null,
+  rpc: "rpc_settlement_action_count" | "rpc_inbound_pending_count",
+  refreshEvent: string,
+): number {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
@@ -146,7 +153,7 @@ function useSettlementActionCount(enabled: boolean, pathname: string | null): nu
     let cancelled = false;
     const load = async () => {
       try {
-        const { data } = await getSupabase().rpc("rpc_settlement_action_count");
+        const { data } = await getSupabase().rpc(rpc);
         if (!cancelled && typeof data === "number") setCount(data);
       } catch {
         /* badge 失敗不影響操作 */
@@ -155,13 +162,13 @@ function useSettlementActionCount(enabled: boolean, pathname: string | null): nu
     void load();
     const onRefresh = () => { void load(); };
     window.addEventListener("focus", onRefresh);
-    window.addEventListener(SETTLEMENT_BADGE_REFRESH_EVENT, onRefresh);
+    window.addEventListener(refreshEvent, onRefresh);
     return () => {
       cancelled = true;
       window.removeEventListener("focus", onRefresh);
-      window.removeEventListener(SETTLEMENT_BADGE_REFRESH_EVENT, onRefresh);
+      window.removeEventListener(refreshEvent, onRefresh);
     };
-  }, [enabled, pathname]);
+  }, [enabled, pathname, rpc, refreshEvent]);
 
   return count;
 }
@@ -182,8 +189,18 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const tenantName = tenant?.name ?? getTenantName();
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
-  const settlementCount = useSettlementActionCount(!!session, pathname);
-  const navBadges: Record<string, number> = { "/transfers/settlement": settlementCount };
+  const branchUser = isBranchUser(user);
+  const settlementCount = useNavBadgeCount(
+    !!session, pathname, "rpc_settlement_action_count", SETTLEMENT_BADGE_REFRESH_EVENT,
+  );
+  // 收貨 badge 只服務分店帳號；HQ 在 /wms/inbound 看的是全分店監控，不掛通知
+  const inboundCount = useNavBadgeCount(
+    !!session && branchUser, pathname, "rpc_inbound_pending_count", INBOUND_BADGE_REFRESH_EVENT,
+  );
+  const navBadges: Record<string, number> = {
+    "/transfers/settlement": settlementCount,
+    "/wms/inbound": inboundCount,
+  };
 
   // 載入 collapsed groups (localStorage)
   useEffect(() => {
@@ -251,7 +268,6 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
     router.replace("/login");
   }
 
-  const branchUser = isBranchUser(user);
   const visibleNav = filterNavForRole(branchUser ? filterNavForBranch(NAV) : NAV, user);
 
   return (

--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -431,6 +431,12 @@ export default function TransfersInboxPage() {
     setSelected(new Set());
   }
 
+  // 收貨狀態變動後重載列表,並通知側欄「收貨」badge 重抓(見 layout INBOUND_BADGE_REFRESH_EVENT)
+  function reloadAndRefreshBadge() {
+    setReloadTick((n) => n + 1);
+    window.dispatchEvent(new Event("inbound-badge-refresh"));
+  }
+
   // 單筆全收 — 直接 confirm + RPC,跟批次邏輯一樣(p_lines=null)
   async function quickReceive(t: Transfer) {
     const dest = locations.get(t.dest_location) ?? `#${t.dest_location}`;
@@ -448,7 +454,7 @@ export default function TransfersInboxPage() {
         p_notes: null,
       });
       if (e) throw new Error(translateRpcError(e));
-      setReloadTick((n) => n + 1);
+      reloadAndRefreshBadge();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -479,7 +485,7 @@ export default function TransfersInboxPage() {
         p_notes: null,
       });
       if (e) throw new Error(translateRpcError(e));
-      setReloadTick((n) => n + 1);
+      reloadAndRefreshBadge();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -530,7 +536,7 @@ export default function TransfersInboxPage() {
         );
       }
       setSelected(new Set());
-      setReloadTick((t) => t + 1);
+      reloadAndRefreshBadge();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -914,7 +920,7 @@ export default function TransfersInboxPage() {
           onClose={() => setOpening(null)}
           onSubmitted={() => {
             setOpening(null);
-            setReloadTick((t) => t + 1);
+            reloadAndRefreshBadge();
           }}
         />
       )}

--- a/supabase/migrations/20260720000020_rpc_inbound_pending_count.sql
+++ b/supabase/migrations/20260720000020_rpc_inbound_pending_count.sql
@@ -1,0 +1,49 @@
+-- ============================================================
+-- 2026-07-20: 分店收貨待辦數 rpc_inbound_pending_count
+--
+-- 需求：分店登入時，若有已派出(shipped)還沒收的調撥單，側欄「收貨」
+--   選單要掛小數字當通知（同「月結算」badge 的做法，見
+--   20260715000130_rpc_settlement_action_count.sql）。
+--
+-- 口徑（對齊前端 /wms/inbound 的「待收」查詢與 layout isBranchUser）：
+--   - 分店帳號（app_metadata.stores 非空且不含「總倉」）：
+--     自己店（_jwt_store_location_ids()）為 dest_location、status='shipped'
+--     的 transfers 筆數。
+--   - HQ / 總倉 / 未綁店帳號 → 0（收貨 badge 只服務分店，總倉有自己的
+--     收件匣與進貨待辦）。
+--
+-- 新函式，無歷史版本（已 grep supabase/migrations/ 確認）。
+-- Rollback：DROP FUNCTION public.rpc_inbound_pending_count();
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_inbound_pending_count()
+RETURNS INTEGER
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH me AS (
+    SELECT ARRAY(
+      SELECT jsonb_array_elements_text(
+        COALESCE(auth.jwt() -> 'app_metadata' -> 'stores', '[]'::jsonb))
+    ) AS store_names
+  )
+  SELECT CASE
+    -- 分店帳號 = stores 非空且不含「總倉」，對齊前端 isBranchUser()
+    WHEN (SELECT cardinality(store_names) > 0
+             AND NOT ('總倉' = ANY (store_names))
+            FROM me) THEN (
+      SELECT COUNT(*)::int
+        FROM transfers t
+       WHERE t.tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND t.status = 'shipped'
+         AND t.dest_location = ANY (public._jwt_store_location_ids())
+    )
+    ELSE 0
+  END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_inbound_pending_count() TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_inbound_pending_count IS
+  '側欄「收貨」badge 用：分店帳號回自己店 status=shipped 的待收調撥筆數；'
+  'HQ/總倉/未綁店回 0。';

--- a/supabase/migrations/20260720000030_aid_board_badge_and_expiry_purge.sql
+++ b/supabase/migrations/20260720000030_aid_board_badge_and_expiry_purge.sql
@@ -1,0 +1,155 @@
+-- ============================================================
+-- 2026-07-20: 互助交流板側欄 badge + 到期自動清理
+--
+-- 需求：
+--   1. 分店登入時，互助板有進行中貼文就在側欄「互助交流板」掛小數字
+--      （同「收貨」badge，見 20260720000020_rpc_inbound_pending_count.sql）。
+--   2. 貼文到期（expires_at 過了）沒人認領 → 整筆自動刪除；
+--      有被部分認領過的到期貼文保留紀錄、標成 status='expired'。
+--
+-- 實作：
+--   - rpc_aid_board_active_count()：badge 用，分店帳號回全 tenant
+--     status='active' 貼文數（互助板是跨店佈告欄，看全部）；其他帳號回 0。
+--   - rpc_purge_expired_aid_board()：pg_cron 每 10 分鐘跑。
+--     「沒人認領」= qty_remaining = qty_available 且無 mutual_aid_claims
+--     （claims FK 無 cascade，有 legacy 認領紀錄的不刪以免 FK 炸）→ DELETE；
+--     其餘到期 active → status='expired'。
+--   - mutual_aid_replies 是 append-only（trg_no_mut_aid_replies 禁
+--     UPDATE/DELETE），board DELETE cascade 到 replies 會被擋 → 換成
+--     專用 trigger function forbid_aid_reply_mutation()：purge 交易內
+--     （app.aid_board_purge='on'，transaction-local）放行 DELETE，其他照禁。
+--
+-- 歷史：
+--   - trg_no_mut_aid_replies 建於 20260509000000（掛共用
+--     forbid_append_only_mutation），20260509000001 只有暫時 DISABLE/ENABLE，
+--     無其他改動 → 本檔改掛專用 function，共用的 forbid_append_only_mutation
+--     不動（其他稽核表還在用）。
+--   - rpc_aid_board_active_count / rpc_purge_expired_aid_board 為新函式，
+--     無歷史版本（已 grep supabase/migrations/ 確認）。
+--
+-- Rollback：
+--   SELECT cron.unschedule('purge-expired-aid-board');
+--   DROP FUNCTION public.rpc_purge_expired_aid_board();
+--   DROP FUNCTION public.rpc_aid_board_active_count();
+--   DROP TRIGGER trg_no_mut_aid_replies ON mutual_aid_replies;
+--   CREATE TRIGGER trg_no_mut_aid_replies BEFORE UPDATE OR DELETE ON mutual_aid_replies
+--     FOR EACH ROW EXECUTE FUNCTION forbid_append_only_mutation();
+--   DROP FUNCTION public.forbid_aid_reply_mutation();
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. 側欄 badge：rpc_aid_board_active_count
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_aid_board_active_count()
+RETURNS INTEGER
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH me AS (
+    SELECT ARRAY(
+      SELECT jsonb_array_elements_text(
+        COALESCE(auth.jwt() -> 'app_metadata' -> 'stores', '[]'::jsonb))
+    ) AS store_names
+  )
+  SELECT CASE
+    -- 分店帳號 = stores 非空且不含「總倉」，對齊前端 isBranchUser()
+    WHEN (SELECT cardinality(store_names) > 0
+             AND NOT ('總倉' = ANY (store_names))
+            FROM me) THEN (
+      SELECT COUNT(*)::int
+        FROM mutual_aid_board b
+       WHERE b.tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND b.status = 'active'
+    )
+    ELSE 0
+  END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_aid_board_active_count() TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_aid_board_active_count IS
+  '側欄「互助交流板」badge 用：分店帳號回全 tenant status=active 貼文數'
+  '（跨店佈告欄，含自己店的貼文）；HQ/總倉/未綁店回 0。';
+
+-- ----------------------------------------------------------------
+-- 2. replies append-only trigger 換專用 function：purge 時放行 cascade DELETE
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.forbid_aid_reply_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- 只有互助板到期 purge（rpc_purge_expired_aid_board 交易內）允許
+  -- board DELETE cascade 帶掉留言；其他 UPDATE / DELETE 照樣禁止
+  IF TG_OP = 'DELETE'
+     AND current_setting('app.aid_board_purge', true) = 'on' THEN
+    RETURN OLD;
+  END IF;
+  RAISE EXCEPTION '% is append-only', TG_TABLE_NAME;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_no_mut_aid_replies ON mutual_aid_replies;
+CREATE TRIGGER trg_no_mut_aid_replies BEFORE UPDATE OR DELETE ON mutual_aid_replies
+  FOR EACH ROW EXECUTE FUNCTION public.forbid_aid_reply_mutation();
+
+COMMENT ON FUNCTION public.forbid_aid_reply_mutation IS
+  'mutual_aid_replies 專用 append-only 守門：僅 rpc_purge_expired_aid_board '
+  '交易內（app.aid_board_purge=on）放行 DELETE cascade，其他一律禁。';
+
+-- ----------------------------------------------------------------
+-- 3. 到期清理：rpc_purge_expired_aid_board
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_purge_expired_aid_board()
+RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_deleted INT;
+  v_expired INT;
+BEGIN
+  -- transaction-local flag：讓 replies 的 append-only trigger 放行 cascade DELETE
+  PERFORM set_config('app.aid_board_purge', 'on', true);
+
+  -- 沒人認領的到期貼文整筆刪除（含留言 cascade）：
+  --   qty 沒被扣過（qty_remaining = qty_available，rpc_consume_aid_board /
+  --   legacy rpc_claim_aid 都會扣量）且無 claims 紀錄（該 FK 無 cascade）
+  WITH doomed AS (
+    DELETE FROM mutual_aid_board b
+     WHERE b.status = 'active'
+       AND b.expires_at < NOW()
+       AND b.qty_remaining = b.qty_available
+       AND NOT EXISTS (SELECT 1 FROM mutual_aid_claims c WHERE c.board_id = b.id)
+    RETURNING b.id
+  )
+  SELECT COUNT(*) INTO v_deleted FROM doomed;
+
+  PERFORM set_config('app.aid_board_purge', '', true);
+
+  -- 有被認領過（部分成交）的到期貼文保留紀錄，標成 expired 下板
+  WITH marked AS (
+    UPDATE mutual_aid_board b
+       SET status = 'expired'
+     WHERE b.status = 'active'
+       AND b.expires_at < NOW()
+    RETURNING b.id
+  )
+  SELECT COUNT(*) INTO v_expired FROM marked;
+
+  RETURN jsonb_build_object('deleted', v_deleted, 'marked_expired', v_expired);
+END;
+$$;
+
+-- 只給 cron / service_role 跑，不開放前端
+REVOKE EXECUTE ON FUNCTION public.rpc_purge_expired_aid_board FROM authenticated, anon, public;
+GRANT EXECUTE ON FUNCTION public.rpc_purge_expired_aid_board TO service_role;
+
+COMMENT ON FUNCTION public.rpc_purge_expired_aid_board IS
+  '互助板到期清理（cron 每 10 分鐘）：沒人認領的到期貼文整筆刪除（含留言），'
+  '有部分認領的標 status=expired 保留紀錄。回 {deleted, marked_expired}。';
+
+-- 排程：每 10 分鐘（cron.schedule 同名 job 為 idempotent，重複 run migration 不會炸）
+SELECT cron.schedule(
+  'purge-expired-aid-board',
+  '*/10 * * * *',
+  $cron$ SELECT public.rpc_purge_expired_aid_board(); $cron$
+);


### PR DESCRIPTION
分店帳號登入時，若有已派出(shipped)還沒收的調撥單，側欄「收貨」
選單顯示紅色數字通知（>99 顯示 99+）。收貨/退回收貨/批次收貨後
即時重抓；HQ/總倉帳號不顯示、也不打 RPC。

- 新 RPC rpc_inbound_pending_count：分店(app_metadata.stores 非空
  且不含「總倉」)回自己店 dest_location、status=shipped 筆數，
  其他帳號回 0（已部署並用線上資料驗證四種情境）
- layout：useSettlementActionCount 一般化為 useNavBadgeCount，
  收貨 badge 只在分店帳號啟用
- /wms/inbound：收貨狀態變動後 dispatch inbound-badge-refresh

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018eaTF9nW47U9VusuVM9aJ7