### PR TITLE
收貨待辦：自由轉貨顯示實際品名，移除英文 transfer 字樣

### DIFF
--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -171,11 +171,18 @@ export default function TransfersInboxPage() {
           // 走 fetchAllRows 分頁：待收 transfer 數不設限，×每張多列品項很容易破
           // PostgREST 1000 列上限；不分頁的話最新 wave（transfer_id 最大、排在尾端）
           // 的品項會整批被截掉 → summary.lines=0 → 品名全變「—」。
-          const items = await fetchAllRows<{ transfer_id: number; sku_id: number; qty_shipped: number }>(
+          // description = 自由轉貨（店轉店）的實際品名；有值時掛在虛擬 SKU（MISC-01
+          // 「虛擬轉貨商品」）上，顯示要用 description 而不是虛擬 SKU 的佔位名稱。
+          const items = await fetchAllRows<{
+            transfer_id: number;
+            sku_id: number;
+            qty_shipped: number;
+            description: string | null;
+          }>(
             () =>
               sb
                 .from("transfer_items")
-                .select("transfer_id, sku_id, qty_shipped")
+                .select("transfer_id, sku_id, qty_shipped, description")
                 .in("transfer_id", transferIds)
                 .order("id"),
           );
@@ -210,7 +217,9 @@ export default function TransfersInboxPage() {
             const cur = summary.get(it.transfer_id) ?? { lines: 0, totalQty: 0, names: [], codes: [] };
             cur.lines += 1;
             cur.totalQty += Number(it.qty_shipped);
-            cur.names.push(`${skuNameMap.get(it.sku_id) ?? `#${it.sku_id}`} × ${Number(it.qty_shipped)}`);
+            const name =
+              it.description?.trim() || (skuNameMap.get(it.sku_id) ?? `#${it.sku_id}`);
+            cur.names.push(`${name} × ${Number(it.qty_shipped)}`);
             const code = skuCodeMap.get(it.sku_id);
             if (code) cur.codes.push(code);
             summary.set(it.transfer_id, cur);
@@ -330,7 +339,7 @@ export default function TransfersInboxPage() {
       if (!entry) {
         const w = wid !== null ? waves.get(wid) : undefined;
         entry = {
-          label: w?.wave_code ?? (wid !== null ? `WAVE-${wid}` : "其他 transfer"),
+          label: w?.wave_code ?? (wid !== null ? `WAVE-${wid}` : "其他調撥"),
           subLabel: w ? `配送日 ${w.wave_date}` : "",
           transfers: [],
           // 排序鍵＝撿貨單號（wave_code）；wave_code 已內含日期，字串遞減即最新在前
@@ -343,7 +352,7 @@ export default function TransfersInboxPage() {
     return Array.from(map.entries())
       .map(([key, v]) => ({ key, ...v }))
       .sort((a, b) => {
-        // 「其他 transfer」永遠墊底，其餘依撿貨單號遞減
+        // 「其他調撥」永遠墊底，其餘依撿貨單號遞減
         if (a.key === "other") return 1;
         if (b.key === "other") return -1;
         return b.sortCode.localeCompare(a.sortCode);
@@ -707,7 +716,7 @@ export default function TransfersInboxPage() {
 
       {transfers !== null && groups.length === 0 && (
         <div className="rounded-md border border-zinc-200 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900">
-          沒有符合條件的 transfer。
+          沒有符合條件的調撥單。
         </div>
       )}
 

--- a/apps/admin/src/components/TransferReceiveModal.tsx
+++ b/apps/admin/src/components/TransferReceiveModal.tsx
@@ -97,6 +97,8 @@ type TransferItem = {
   qty_requested: number;
   qty_shipped: number;
   qty_received: number;
+  // 自由轉貨（店轉店）的實際品名；有值時掛在虛擬 SKU 上，顯示要用它取代虛擬 SKU 名稱
+  description: string | null;
 };
 
 type Sku = {
@@ -147,7 +149,7 @@ export function TransferReceiveModal({
         const sb = getSupabase();
         const { data: itemRows, error: e } = await sb
           .from("transfer_items")
-          .select("id, transfer_id, sku_id, qty_requested, qty_shipped, qty_received")
+          .select("id, transfer_id, sku_id, qty_requested, qty_shipped, qty_received, description")
           .eq("transfer_id", transfer.id)
           .order("id");
         if (e) throw new Error(e.message);
@@ -385,11 +387,22 @@ export function TransferReceiveModal({
                     return (
                       <tr key={it.id}>
                         <td className="px-3 py-2">
-                          <div className="font-medium">{sku?.product_name ?? "—"}</div>
-                          <div className="text-xs text-zinc-500">
-                            {sku?.sku_code}
-                            {sku?.variant_name ? ` / ${sku.variant_name}` : ""}
-                          </div>
+                          {it.description ? (
+                            <>
+                              <div className="font-medium">{it.description}</div>
+                              <div className="text-xs text-zinc-500">
+                                <span className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-950 dark:text-blue-300">自由轉貨</span>
+                              </div>
+                            </>
+                          ) : (
+                            <>
+                              <div className="font-medium">{sku?.product_name ?? "—"}</div>
+                              <div className="text-xs text-zinc-500">
+                                {sku?.sku_code}
+                                {sku?.variant_name ? ` / ${sku.variant_name}` : ""}
+                              </div>
+                            </>
+                          )}
                         </td>
                         <td className="px-3 py-2 text-right font-mono text-zinc-600 dark:text-zinc-300">
                           {it.qty_shipped}


### PR DESCRIPTION
- /wms/inbound 列表與收貨 modal 的自由轉貨（店轉店）項目原本顯示虛擬
  SKU 佔位名「虛擬轉貨商品」，改為顯示 transfer_items.description 的
  實際品名（沿用 TransferDetailModal 既有慣例，modal 加「自由轉貨」標籤）
- 群組標題「其他 transfer」→「其他調撥」、空狀態「沒有符合條件的
  transfer」→「沒有符合條件的調撥單」

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CAFapuGPv3J4yaNaRXomaT