### PR TITLE
取貨單列印隱藏轉單內部標記，客人備註照常顯示

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
+import { stripTransferNotes } from "@/lib/orderNotes";
 import SpinButton from "@/components/SpinButton";
 
 type Order = {
@@ -182,11 +183,12 @@ function Body() {
             const pay = orderPay(o);
             // pctDed 倒推（subtotal − pct − amt = payable，所以 pctDed = subtotal − payable − amt）
             const pctDed = Math.max(0, sub - pay - disc);
+            const orderNotes = stripTransferNotes(o.notes);
             return (
               <div key={o.id} className="border-b border-dashed border-zinc-400 pb-1">
                 <div className="text-[13px]">{o.campaign?.name ?? "(未知活動)"}</div>
-                {o.notes && (
-                  <div className="text-[13px] italic">📝 {o.notes}</div>
+                {orderNotes && (
+                  <div className="text-[13px] italic">📝 {orderNotes}</div>
                 )}
                 {active.map((it) => {
                   const subtotal = lineSub(it);

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
+import { stripTransferNotes } from "@/lib/orderNotes";
 import SpinButton from "@/components/SpinButton";
 
 type PickupEvent = {
@@ -183,11 +184,12 @@ function Body() {
             const pay = orderPay(r);
             // pctDed 倒推（subtotal − pct − amt = payable，所以 pctDed = subtotal − payable − amt）
             const pctDed = Math.max(0, sub - pay - disc);
+            const orderNotes = stripTransferNotes(r.order?.notes);
             return (
               <div key={r.event.id} className="border-b border-dashed border-zinc-400 pb-1">
                 <div className="text-[13px]">{r.order?.campaign?.name ?? "(未知活動)"}</div>
-                {r.order?.notes && (
-                  <div className="text-[13px] italic">📝 {r.order.notes}</div>
+                {orderNotes && (
+                  <div className="text-[13px] italic">📝 {orderNotes}</div>
                 )}
                 {r.items.map((it) => {
                   const subtotal = lineSub(it);

--- a/apps/admin/src/lib/orderNotes.ts
+++ b/apps/admin/src/lib/orderNotes.ts
@@ -1,0 +1,17 @@
+// 轉單 RPC（rpc_transfer_order_to_store / rpc_transfer_order_partial）會把內部
+// 流程標記 append 到 customer_orders.notes，每個標記獨立一行、以 [ 開頭，例：
+//   [轉入 (部分, 經總倉) ← 訂單 #36612 (GB20260522-C000325-TF0054)] 2026-07-21 08:10:39
+//   [追加轉入 (空中轉) ← 訂單 #123 (GB...)] 2026-07-21 08:10:39 / 原因
+//   [轉出 → 訂單 #456 (GB...)] / [全部轉出 → ...] / [部分轉出 → ...] / [部分追加 → ...]
+// 這些是內部轉單流程訊息，客人拿到的取貨單不該出現 —— 列印前整行剔除。
+const TRANSFER_MARKER_LINE = /^\s*\[(?:追加轉入|轉入|全部轉出|部分轉出|部分追加|轉出)[^\]]*\]/;
+
+export function stripTransferNotes(notes: string | null | undefined): string | null {
+  if (!notes) return null;
+  const kept = notes
+    .split("\n")
+    .filter((line) => !TRANSFER_MARKER_LINE.test(line))
+    .join("\n")
+    .trim();
+  return kept || null;
+}


### PR DESCRIPTION
轉單 RPC 會把 [轉入/轉出/追加轉入/部分轉出…] 流程標記 append 到
customer_orders.notes，客人拿到的取貨小白單跟著印出內部轉單資訊。
新增 stripTransferNotes() 在 /pickup/print 與 /pickup/print-list
列印前整行剔除標記行，非標記的客人備註不受影響。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KNSUQoihtoLTmP8qUbiDPa