### PR TITLE
總倉收件匣補貨申請加「候補區」：轉候補按鈕 + 候補 stage tab

### DIFF
--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -18,11 +18,13 @@ import RestockDetailModal from "@/components/RestockDetailModal";
 import RestockToPrModal from "@/components/RestockToPrModal";
 import { ORDER_STATUS_LABEL as AID_STATUS_LABEL, type OrderStatus as AidStatus } from "@/lib/orderStatus";
 
-type Stage = "pending" | "in_transit" | "done" | "rejected";
+// standby(候補)目前只有 restock 來源會用到:pending + standby_at 有值 = 等貨源、先不佔待處理
+type Stage = "pending" | "standby" | "in_transit" | "done" | "rejected";
 type SourceTag = "restock" | "transfer" | "aid" | "air" | "shortage" | "picking" | "exception";
 
 const STAGE_LABEL: Record<Stage, string> = {
   pending: "待處理",
+  standby: "候補",
   in_transit: "在途",
   done: "已完成",
   rejected: "已拒絕 / 取消",
@@ -30,10 +32,13 @@ const STAGE_LABEL: Record<Stage, string> = {
 
 const STAGE_COLOR: Record<Stage, string> = {
   pending: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  standby: "bg-violet-100 text-violet-800 dark:bg-violet-950 dark:text-violet-300",
   in_transit: "bg-cyan-100 text-cyan-800 dark:bg-cyan-950 dark:text-cyan-300",
   done: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
   rejected: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
 };
+
+const ALL_STAGES: Stage[] = ["pending", "standby", "in_transit", "done", "rejected"];
 
 const SOURCE_LABEL: Record<SourceTag, string> = {
   restock: "補貨申請",
@@ -68,6 +73,9 @@ type RestockRaw = {
   notes: string | null;
   rejected_reason: string | null;
   stockout_at: string | null;
+  standby_at: string | null;
+  /** 已開請購單的明細（品相）數；pending 但 >0 = 部分開單 */
+  pr_line_count: number;
   linked_transfer_id: number | null;
   linked_pr_id: number | null;
   linked_transfer_no: string | null;
@@ -151,8 +159,8 @@ type Row =
   | { key: string; source: "shortage"; ts: number; stage: Stage; raw: ShortageRaw }
   | { key: string; source: "picking"; ts: number; stage: Stage; raw: PickingRaw };
 
-function classifyRestock(s: RestockRaw["status"]): Stage {
-  if (s === "pending") return "pending";
+function classifyRestock(s: RestockRaw["status"], standbyAt: string | null): Stage {
+  if (s === "pending") return standbyAt ? "standby" : "pending";
   if (s === "approved_transfer" || s === "approved_pr" || s === "shipped") return "in_transit";
   if (s === "received") return "done";
   return "rejected";
@@ -194,14 +202,17 @@ function classifyPicking(s: PickingRaw["status"]): Stage {
 }
 
 // === Status → Stage 對應(server-side 過濾用)===
+// restock 的 pending / standby 不能只靠 status 分——fetchRestockRows 會再依 standby_at 過濾
 const RESTOCK_STATUS_BY_STAGE: Record<Stage, string[]> = {
   pending: ["pending"],
+  standby: ["pending"],
   in_transit: ["approved_transfer", "approved_pr", "shipped"],
   done: ["received"],
   rejected: ["rejected", "cancelled"],
 };
 const TRANSFER_STATUS_BY_STAGE: Record<Stage, string[]> = {
   pending: ["draft", "confirmed"],
+  standby: [], // 轉貨單沒有候補概念
   in_transit: ["shipped"],
   done: ["received"],
   rejected: ["cancelled"],
@@ -216,18 +227,21 @@ const TRANSFER_STATUS_LABEL: Record<string, string> = {
 };
 const AID_STATUS_BY_STAGE: Record<Stage, AidStatus[]> = {
   pending: ["pending", "confirmed"],
+  standby: [],
   in_transit: ["shipping"],
   done: ["ready", "completed", "partially_completed"],
   rejected: ["cancelled"],
 };
 const PICKING_STATUS_BY_STAGE: Record<Stage, string[]> = {
   pending: ["draft", "picking", "picked"],
+  standby: [],
   in_transit: [], // 撿貨單沒有「在途」概念,出貨後直接 done
   done: ["shipped"],
   rejected: ["cancelled"],
 };
 const SHORTAGE_RESOLUTION_BY_STAGE: Record<Stage, string[] | null> = {
   pending: null, // resolution IS NULL
+  standby: [],
   in_transit: ["notified", "waiting_next_po"],
   done: ["cancelled", "reallocated"],
   rejected: [], // never
@@ -328,11 +342,14 @@ async function fetchRestockRows(
   let q = sb
     .from("restock_requests")
     .select(
-      "id, status, notes, rejected_reason, stockout_at, linked_transfer_id, linked_pr_id, requested_at, stores!inner(name)",
+      "id, status, notes, rejected_reason, stockout_at, standby_at, linked_transfer_id, linked_pr_id, requested_at, stores!inner(name)",
       { count: "exact" },
     )
     .order("requested_at", { ascending: false });
-  if (stage) q = q.in("status", RESTOCK_STATUS_BY_STAGE[stage]);
+  // pending / standby 都是 status='pending',差在 standby_at 有沒有值
+  if (stage === "pending") q = q.eq("status", "pending").is("standby_at", null);
+  else if (stage === "standby") q = q.eq("status", "pending").not("standby_at", "is", null);
+  else if (stage) q = q.in("status", RESTOCK_STATUS_BY_STAGE[stage]);
   if (dateFrom) q = q.gte("requested_at", `${dateFrom}T00:00:00`);
   if (dateTo) q = q.lte("requested_at", `${dateTo}T23:59:59.999`);
   const start = (page - 1) * PAGE_SIZE;
@@ -342,16 +359,17 @@ async function fetchRestockRows(
   const rsRows = (data ?? []) as unknown as Array<RestockRaw & { stores?: { name: string } }>;
 
   const reqIds = rsRows.map((r) => r.id);
-  const lineMap = new Map<number, { count: number; total: number }>();
+  const lineMap = new Map<number, { count: number; total: number; prCount: number }>();
   if (reqIds.length > 0) {
     const { data: lineData } = await sb
       .from("restock_request_lines")
-      .select("request_id, qty, unit_price")
+      .select("request_id, qty, unit_price, linked_pr_id")
       .in("request_id", reqIds);
-    for (const l of (lineData ?? []) as { request_id: number; qty: number; unit_price: number }[]) {
-      const slot = lineMap.get(l.request_id) ?? { count: 0, total: 0 };
+    for (const l of (lineData ?? []) as { request_id: number; qty: number; unit_price: number; linked_pr_id: number | null }[]) {
+      const slot = lineMap.get(l.request_id) ?? { count: 0, total: 0, prCount: 0 };
       slot.count += 1;
       slot.total += Number(l.qty) * Number(l.unit_price);
+      if (l.linked_pr_id != null) slot.prCount += 1;
       lineMap.set(l.request_id, slot);
     }
   }
@@ -374,13 +392,14 @@ async function fetchRestockRows(
     key: `restock-${r.id}`,
     source: "restock" as const,
     ts: new Date(r.requested_at).getTime(),
-    stage: classifyRestock(r.status),
+    stage: classifyRestock(r.status, r.standby_at),
     raw: {
       id: r.id,
       status: r.status,
       notes: r.notes,
       rejected_reason: r.rejected_reason,
       stockout_at: r.stockout_at,
+      standby_at: r.standby_at,
       linked_transfer_id: r.linked_transfer_id,
       linked_pr_id: r.linked_pr_id,
       linked_transfer_no: r.linked_transfer_id ? xferNoMap.get(r.linked_transfer_id) ?? null : null,
@@ -389,6 +408,7 @@ async function fetchRestockRows(
       requested_at: r.requested_at,
       line_count: lineMap.get(r.id)?.count ?? 0,
       total_amount: lineMap.get(r.id)?.total ?? 0,
+      pr_line_count: lineMap.get(r.id)?.prCount ?? 0,
       items_summary: itemsMap.get(r.id) ?? "",
     },
   }));
@@ -403,6 +423,7 @@ async function fetchTransferRows(
   dateTo: string,
   transferKind: "all" | "store_to_store" | "return_to_hq" | "hq_to_store" | "aid_handoff" = "all",
 ): Promise<{ rows: Row[]; total: number }> {
+  if (stage === "standby") return { rows: [], total: 0 }; // 只有 restock 有候補
   let q = sb
     .from("transfers")
     .select(
@@ -474,6 +495,7 @@ async function fetchAidRows(
   airMode: "aid" | "air",
   aidStatus: string,
 ): Promise<{ rows: Row[]; total: number }> {
+  if (stage === "standby") return { rows: [], total: 0 }; // 只有 restock 有候補
   let q = sb
     .from("customer_orders")
     .select(
@@ -698,21 +720,22 @@ async function fetchRestockRowsByIds(sb: SBClient, ids: number[]): Promise<Row[]
   const { data, error } = await sb
     .from("restock_requests")
     .select(
-      "id, status, notes, rejected_reason, stockout_at, linked_transfer_id, linked_pr_id, requested_at, stores!inner(name)",
+      "id, status, notes, rejected_reason, stockout_at, standby_at, linked_transfer_id, linked_pr_id, requested_at, stores!inner(name)",
     )
     .in("id", ids);
   if (error) throw new Error("restock: " + error.message);
   const rsRows = (data ?? []) as unknown as Array<RestockRaw & { stores?: { name: string } }>;
-  const lineMap = new Map<number, { count: number; total: number }>();
+  const lineMap = new Map<number, { count: number; total: number; prCount: number }>();
   if (rsRows.length > 0) {
     const { data: lineData } = await sb
       .from("restock_request_lines")
-      .select("request_id, qty, unit_price")
+      .select("request_id, qty, unit_price, linked_pr_id")
       .in("request_id", rsRows.map((r) => r.id));
-    for (const l of (lineData ?? []) as { request_id: number; qty: number; unit_price: number }[]) {
-      const slot = lineMap.get(l.request_id) ?? { count: 0, total: 0 };
+    for (const l of (lineData ?? []) as { request_id: number; qty: number; unit_price: number; linked_pr_id: number | null }[]) {
+      const slot = lineMap.get(l.request_id) ?? { count: 0, total: 0, prCount: 0 };
       slot.count += 1;
       slot.total += Number(l.qty) * Number(l.unit_price);
+      if (l.linked_pr_id != null) slot.prCount += 1;
       lineMap.set(l.request_id, slot);
     }
   }
@@ -733,13 +756,14 @@ async function fetchRestockRowsByIds(sb: SBClient, ids: number[]): Promise<Row[]
     key: `restock-${r.id}`,
     source: "restock" as const,
     ts: new Date(r.requested_at).getTime(),
-    stage: classifyRestock(r.status),
+    stage: classifyRestock(r.status, r.standby_at),
     raw: {
       id: r.id,
       status: r.status,
       notes: r.notes,
       rejected_reason: r.rejected_reason,
       stockout_at: r.stockout_at,
+      standby_at: r.standby_at,
       linked_transfer_id: r.linked_transfer_id,
       linked_pr_id: r.linked_pr_id,
       linked_transfer_no: r.linked_transfer_id ? xferNoMap.get(r.linked_transfer_id) ?? null : null,
@@ -748,6 +772,7 @@ async function fetchRestockRowsByIds(sb: SBClient, ids: number[]): Promise<Row[]
       requested_at: r.requested_at,
       line_count: lineMap.get(r.id)?.count ?? 0,
       total_amount: lineMap.get(r.id)?.total ?? 0,
+      pr_line_count: lineMap.get(r.id)?.prCount ?? 0,
       items_summary: itemsMap.get(r.id) ?? "",
     },
   }));
@@ -951,6 +976,11 @@ function HqInboxContent() {
     }
   }, [searchParams]);
 
+  // 「候補」stage 只屬於補貨申請;來源不是 restock 時(例如 ?source= URL 直接切走)
+  // 一律視為「待處理」,不改 state、純 derive,避免 effect 裡 setState
+  const effectiveStage: Stage | "all" =
+    stage === "standby" && sourceFilter !== "restock" ? "pending" : stage;
+
   // 共用日期區間(所有來源)
   const [dateFrom, setDateFrom] = useState<string>("");
   const [dateTo, setDateTo] = useState<string>("");
@@ -1010,7 +1040,7 @@ function HqInboxContent() {
     (async () => {
       try {
         const sb = getSupabase();
-        const fallback: Record<Stage, number> = { pending: 0, in_transit: 0, done: 0, rejected: 0 };
+        const fallback: Record<Stage, number> = { pending: 0, standby: 0, in_transit: 0, done: 0, rejected: 0 };
         const [{ data, error }, pickingCounts, airCounts] = await Promise.all([
           sb.rpc("rpc_inbox_counts"),
           // picking 還沒進 rpc_inbox_counts(server-side migration 待 deploy),先 client-side 算
@@ -1046,6 +1076,7 @@ function HqInboxContent() {
         // aid 扣掉 air(server 端 aid 尚含空中轉)
         const aidCounts: Record<Stage, number> = {
           pending: Math.max(0, serverAid.pending - airCounts.pending),
+          standby: 0,
           in_transit: Math.max(0, serverAid.in_transit - airCounts.in_transit),
           done: Math.max(0, serverAid.done - airCounts.done),
           rejected: Math.max(0, serverAid.rejected - airCounts.rejected),
@@ -1077,7 +1108,7 @@ function HqInboxContent() {
     (async () => {
       try {
         const sb = getSupabase();
-        const stageArg: Stage | null = stage === "all" ? null : stage;
+        const stageArg: Stage | null = effectiveStage === "all" ? null : effectiveStage;
 
         let resultRows: Row[] = [];
         let resultTotal = 0;
@@ -1144,18 +1175,18 @@ function HqInboxContent() {
     return () => {
       cancelled = true;
     };
-  }, [sourceFilter, stage, page, dateFrom, dateTo, aidStatusFilter, transferKindFilter, reloadTick]);
+  }, [sourceFilter, effectiveStage, page, dateFrom, dateTo, aidStatusFilter, transferKindFilter, reloadTick]);
 
   // stage tab counts:依當前 sourceFilter,從 cached counts 算出
   const stageCounts = useMemo(() => {
-    const c: Record<Stage, number> = { pending: 0, in_transit: 0, done: 0, rejected: 0 };
+    const c: Record<Stage, number> = { pending: 0, standby: 0, in_transit: 0, done: 0, rejected: 0 };
     if (!counts) return c;
     const sources: SourceTag[] = sourceFilter === "all"
       ? ["restock", "transfer", "aid", "shortage"]
       : [sourceFilter];
     for (const s of sources) {
-      for (const stg of ["pending", "in_transit", "done", "rejected"] as Stage[]) {
-        c[stg] += counts[s][stg];
+      for (const stg of ALL_STAGES) {
+        c[stg] += counts[s][stg] ?? 0;
       }
     }
     return c;
@@ -1165,14 +1196,12 @@ function HqInboxContent() {
   const sourceCounts = useMemo(() => {
     const c: Record<SourceTag, number> = { restock: 0, transfer: 0, aid: 0, air: 0, shortage: 0, picking: 0, exception: 0 };
     if (!counts) return c;
-    const stages: Stage[] = stage === "all"
-      ? ["pending", "in_transit", "done", "rejected"]
-      : [stage];
+    const stages: Stage[] = effectiveStage === "all" ? ALL_STAGES : [effectiveStage];
     for (const s of ["restock", "transfer", "aid", "air", "shortage", "picking", "exception"] as SourceTag[]) {
-      for (const stg of stages) c[s] += counts[s][stg];
+      for (const stg of stages) c[s] += counts[s][stg] ?? 0;
     }
     return c;
-  }, [counts, stage]);
+  }, [counts, effectiveStage]);
 
   // server-side 已過濾 source / stage / 日期 / Aid filters,client-side 只做 search(限當前頁)
   const filtered = useMemo(() => {
@@ -1272,6 +1301,23 @@ function HqInboxContent() {
     setRestockPrId(id);
   }
 
+  // 轉入 / 轉出候補區(status 維持 pending,只掛 standby_at 旗標;可隨時反悔,不跳 confirm)
+  async function setStandby(id: number, standby: boolean) {
+    setBusy(`restock-${id}-standby`);
+    try {
+      const { error: err } = await getSupabase().rpc("rpc_restock_set_standby", {
+        p_request_id: id,
+        p_standby: standby,
+      });
+      if (err) throw err;
+      setReloadTick((t) => t + 1);
+    } catch (e) {
+      setError(translateRpcError(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
   async function shipPrReceived(id: number) {
     if (!confirm("確定 PR 已到貨、現在從 HQ 派貨到分店？")) return;
     setBusy(`restock-${id}-ship`);
@@ -1326,6 +1372,9 @@ function HqInboxContent() {
         if (sourceFilter === "transfer") {
           return r.stage === "pending" || r.stage === "in_transit";
         }
+        if (sourceFilter === "restock") {
+          return r.stage === "pending" || r.stage === "standby";
+        }
         return r.stage === "pending";
       })
       .map((r) => r.key);
@@ -1350,7 +1399,12 @@ function HqInboxContent() {
           }
         : sourceFilter === "picking"
           ? { "派貨出倉": ["pending"], "取消": ["pending"] }
-          : {};
+          : sourceFilter === "restock"
+            ? {
+                "派貨": ["pending", "standby"], "下訂單": ["pending", "standby"],
+                "轉候補": ["pending"], "取消候補": ["standby"],
+              }
+            : {};
     const allowedStages = validStages[action] ?? (["pending"] as Stage[]);
     let items = paginatedRows.filter(
       (r) => selected.has(r.key) && allowedStages.includes(r.stage),
@@ -1467,6 +1521,8 @@ function HqInboxContent() {
           if (action === "派貨") return sb.rpc("rpc_approve_restock_to_transfer", { p_request_id: id });
           // 批次下訂單＝整張申請開一張請購單；要依品相分張請用單筆列的「下訂單」
           if (action === "下訂單") return sb.rpc("rpc_approve_restock_to_pr", { p_request_id: id });
+          if (action === "轉候補") return sb.rpc("rpc_restock_set_standby", { p_request_id: id, p_standby: true });
+          if (action === "取消候補") return sb.rpc("rpc_restock_set_standby", { p_request_id: id, p_standby: false });
         }
         if (r.source === "aid") {
           const id = r.raw.id;
@@ -1721,7 +1777,12 @@ function HqInboxContent() {
             <SpinButton
               key={s}
               // 空中轉自動出貨、無 pending 單;選它時跳「全部」stage 才看得到紀錄
-              onClick={() => { setSourceFilter(s); if (s === "air") setStage("all"); }}
+              // 「候補」stage 只有補貨申請有,切走時退回「待處理」
+              onClick={() => {
+                setSourceFilter(s);
+                if (s === "air") setStage("all");
+                else if (stage === "standby" && s !== "restock") setStage("pending");
+              }}
               className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition ${
                 active
                   ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
@@ -1842,14 +1903,17 @@ function HqInboxContent() {
             </label>
           </div>
 
-          {/* Stage tabs (套用在當前資料夾) */}
+          {/* Stage tabs (套用在當前資料夾;「候補」只有補貨申請有) */}
           <div className="flex flex-wrap gap-1 border-b border-zinc-200 dark:border-zinc-800">
-            {(["pending", "in_transit", "done", "rejected", "all"] as const).map((s) => {
+            {(sourceFilter === "restock"
+              ? (["pending", "standby", "in_transit", "done", "rejected", "all"] as const)
+              : (["pending", "in_transit", "done", "rejected", "all"] as const)
+            ).map((s) => {
               const label = s === "all" ? "全部" : STAGE_LABEL[s];
               const count = s === "all"
                 ? Object.values(stageCounts).reduce((a, b) => a + b, 0)
                 : stageCounts[s];
-              const active = stage === s;
+              const active = effectiveStage === s;
               return (
                 <SpinButton
                   key={s}
@@ -1902,6 +1966,12 @@ function HqInboxContent() {
                     <>
                       <RowAction variant="success" onClick={() => batchAction("派貨")} disabled={batchBusy}>派貨 ({selected.size})</RowAction>
                       <RowAction variant="indigo" onClick={() => batchAction("下訂單")} disabled={batchBusy}>下訂單 ({selected.size})</RowAction>
+                      {effectiveStage === "pending" && (
+                        <RowAction variant="warning" onClick={() => batchAction("轉候補")} disabled={batchBusy}>⏳ 轉候補 ({selected.size})</RowAction>
+                      )}
+                      {effectiveStage === "standby" && (
+                        <RowAction variant="neutral" onClick={() => batchAction("取消候補")} disabled={batchBusy}>取消候補 ({selected.size})</RowAction>
+                      )}
                     </>
                   )}
                   {sourceFilter === "aid" && (
@@ -1989,6 +2059,7 @@ function HqInboxContent() {
                   return (
                     <MailRow key={r.key} row={r} busy={busy}
                       onApproveTransfer={approveToTransfer} onApprovePr={approveToPr} onShipPrReceived={shipPrReceived}
+                      onSetStandby={setStandby}
                       onOpenReject={(id) => setRejectModal({ id, reason: "" })}
                       onOpenAidDetail={setAidDetailId} onAidChanged={() => setReloadTick((t) => t + 1)}
                       onOpenTransferDetail={setTransferDetailId} onOpenRestockDetail={setRestockDetailId}
@@ -2126,6 +2197,7 @@ function MailRow({
   onApproveTransfer,
   onApprovePr,
   onShipPrReceived,
+  onSetStandby,
   onOpenReject,
   onOpenAidDetail,
   onAidChanged,
@@ -2148,6 +2220,7 @@ function MailRow({
   onApproveTransfer: (id: number) => Promise<void>;
   onApprovePr: (id: number) => Promise<void>;
   onShipPrReceived: (id: number) => Promise<void>;
+  onSetStandby: (id: number, standby: boolean) => Promise<void>;
   onOpenReject: (id: number) => void;
   onOpenAidDetail: (id: number) => void;
   onAidChanged: () => void;
@@ -2229,6 +2302,12 @@ function MailRow({
     subtitle = (
       <>
         急補 {s.line_count} 項 · NT${s.total_amount.toFixed(0)}
+        {/* 部分品相已開請購單、整張還掛 pending/候補 → 標出來,不然看不出「到底訂了沒」 */}
+        {s.status === "pending" && s.pr_line_count > 0 && (
+          <span className="ml-2 font-medium text-indigo-600 dark:text-indigo-400">
+            · 已開單 {s.pr_line_count}/{s.line_count} 品相
+          </span>
+        )}
         {s.linked_pr_id && (
           <Link href={`/purchase/requests/edit?id=${s.linked_pr_id}`} className="ml-2 font-mono text-blue-600 hover:underline dark:text-blue-400">
             · {s.linked_pr_no ?? `${PR_TERM_ZH} #${s.linked_pr_id}`}
@@ -2249,11 +2328,22 @@ function MailRow({
     );
     timeIso = s.requested_at;
     if (s.status === "pending") {
+      const isBusy = busy?.startsWith(`restock-${s.id}`) ?? false;
+      const inStandby = s.standby_at !== null;
       actions = (
         <>
-          <RowAction variant="success" onClick={() => onApproveTransfer(s.id)} disabled={busy?.startsWith(`restock-${s.id}`) ?? false}>派貨</RowAction>
-          <RowAction variant="indigo" onClick={() => onApprovePr(s.id)} disabled={busy?.startsWith(`restock-${s.id}`) ?? false}>下訂單</RowAction>
-          <RowAction variant="danger" onClick={() => onOpenReject(s.id)} disabled={busy?.startsWith(`restock-${s.id}`) ?? false}>拒絕</RowAction>
+          <RowAction variant="success" onClick={() => onApproveTransfer(s.id)} disabled={isBusy}>派貨</RowAction>
+          <RowAction variant="indigo" onClick={() => onApprovePr(s.id)} disabled={isBusy}>下訂單</RowAction>
+          {inStandby ? (
+            <RowAction variant="neutral" onClick={() => onSetStandby(s.id, false)} disabled={isBusy} title="移回「待處理」">
+              取消候補
+            </RowAction>
+          ) : (
+            <RowAction variant="warning" onClick={() => onSetStandby(s.id, true)} disabled={isBusy} title="等貨源、先移到「候補」分類（不佔待處理）">
+              ⏳ 轉候補
+            </RowAction>
+          )}
+          <RowAction variant="danger" onClick={() => onOpenReject(s.id)} disabled={isBusy}>拒絕</RowAction>
         </>
       );
     } else if (s.status === "approved_pr") {

--- a/apps/admin/src/app/(protected)/restock/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/inbox/page.tsx
@@ -25,6 +25,7 @@ type Row = {
   approved_at: string | null;
   rejected_at: string | null;
   stockout_at: string | null;
+  standby_at: string | null;
   line_count: number;
   total_amount: number;
   /** 已開請購單的明細（品相）數；pending 但 >0 = 部分開單 */
@@ -67,7 +68,7 @@ export default function RestockInboxPage() {
       const sb = getSupabase();
       const { data, error: err } = await sb
         .from("restock_requests")
-        .select("id, requesting_store_id, status, notes, rejected_reason, linked_transfer_id, linked_pr_id, created_at, requested_at, approved_at, rejected_at, stockout_at, stores!inner(name)")
+        .select("id, requesting_store_id, status, notes, rejected_reason, linked_transfer_id, linked_pr_id, created_at, requested_at, approved_at, rejected_at, stockout_at, standby_at, stores!inner(name)")
         .order("created_at", { ascending: false })
         .limit(200);
       if (err) { setError(err.message); return; }
@@ -138,6 +139,19 @@ export default function RestockInboxPage() {
     setBusy(id);
     try {
       const { error: err } = await getSupabase().rpc("rpc_ship_restock_pr_received", { p_request_id: id });
+      if (err) throw err;
+      setReload((t) => t + 1);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function setStandby(id: number, standby: boolean) {
+    setBusy(id);
+    try {
+      const { error: err } = await getSupabase().rpc("rpc_restock_set_standby", { p_request_id: id, p_standby: standby });
       if (err) throw err;
       setReload((t) => t + 1);
     } catch (e) {
@@ -240,6 +254,13 @@ export default function RestockInboxPage() {
                     >
                       ⛔ 斷貨
                     </span>
+                  ) : r.status === "pending" && r.standby_at ? (
+                    <span
+                      title={`轉入候補於 ${new Date(r.standby_at).toLocaleString("zh-TW")}`}
+                      className="inline-flex rounded bg-violet-100 px-2 py-0.5 text-xs font-medium text-violet-800 dark:bg-violet-950 dark:text-violet-300"
+                    >
+                      ⏳ 候補中
+                    </span>
                   ) : (
                     <span className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${STATUS_COLOR[r.status]}`}>{STATUS_LABEL[r.status]}</span>
                   )}
@@ -253,6 +274,11 @@ export default function RestockInboxPage() {
                           <SpinButton onClick={() => approveToTransfer(r.id)} disabled={busy === r.id} className="rounded border border-blue-400 bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 disabled:opacity-50 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300">派貨</SpinButton>
                         )}
                         <SpinButton onClick={() => setPrModalId(r.id)} disabled={busy === r.id} className="rounded border border-indigo-400 bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-100 disabled:opacity-50 dark:border-indigo-700 dark:bg-indigo-950 dark:text-indigo-300">下訂單</SpinButton>
+                        {r.standby_at ? (
+                          <SpinButton onClick={() => setStandby(r.id, false)} disabled={busy === r.id} className="rounded border border-zinc-300 bg-white px-2 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">取消候補</SpinButton>
+                        ) : (
+                          <SpinButton onClick={() => setStandby(r.id, true)} disabled={busy === r.id} title="等貨源、先移入候補" className="rounded border border-violet-400 bg-violet-50 px-2 py-1 text-xs font-medium text-violet-700 hover:bg-violet-100 disabled:opacity-50 dark:border-violet-700 dark:bg-violet-950 dark:text-violet-300">⏳ 轉候補</SpinButton>
+                        )}
                         {r.pr_line_count === 0 && (
                           <SpinButton onClick={() => setRejectModal({ id: r.id, reason: "" })} disabled={busy === r.id} className="rounded border border-red-400 bg-red-50 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-100 disabled:opacity-50 dark:border-red-700 dark:bg-red-950 dark:text-red-300">拒絕</SpinButton>
                         )}

--- a/apps/admin/src/app/(protected)/restock/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/page.tsx
@@ -30,6 +30,7 @@ type Row = {
   linked_pr_no: string | null;
   created_at: string;
   stockout_at: string | null;
+  standby_at: string | null;
   line_count: number;
   total_amount: number;
   item_groups: ItemGroup[];
@@ -74,7 +75,7 @@ export default function RestockListPage() {
       const sb = getSupabase();
       const { data, error: err } = await sb
         .from("restock_requests")
-        .select("id, requesting_store_id, status, notes, rejected_reason, linked_transfer_id, linked_pr_id, created_at, stockout_at, stores!inner(name)")
+        .select("id, requesting_store_id, status, notes, rejected_reason, linked_transfer_id, linked_pr_id, created_at, stockout_at, standby_at, stores!inner(name)")
         .order("created_at", { ascending: false })
         .limit(100);
       if (err) { setError(err.message); return; }
@@ -283,6 +284,13 @@ export default function RestockListPage() {
                               className="inline-flex rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-950 dark:text-red-300"
                             >
                               ⛔ 斷貨
+                            </span>
+                          ) : r.status === "pending" && r.standby_at ? (
+                            <span
+                              title={`總倉已排入候補（等貨源）於 ${new Date(r.standby_at).toLocaleString("zh-TW")}`}
+                              className="inline-flex rounded bg-violet-100 px-2 py-0.5 text-xs font-medium text-violet-800 dark:bg-violet-950 dark:text-violet-300"
+                            >
+                              ⏳ 候補中
                             </span>
                           ) : (
                             <span className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${STATUS_COLOR[r.status]}`}>

--- a/apps/admin/src/components/RestockDetailModal.tsx
+++ b/apps/admin/src/components/RestockDetailModal.tsx
@@ -18,6 +18,7 @@ type RestockRow = {
   approved_at: string | null;
   rejected_at: string | null;
   stockout_at: string | null;
+  standby_at: string | null;
   linked_transfer_id: number | null;
   linked_pr_id: number | null;
   linked_transfer_no: string | null;
@@ -77,7 +78,7 @@ export default function RestockDetailModal({
       const { data: rData, error: rErr } = await sb
         .from("restock_requests")
         .select(
-          "id, requesting_store_id, status, notes, rejected_reason, requested_at, approved_at, rejected_at, stockout_at, linked_transfer_id, linked_pr_id, " +
+          "id, requesting_store_id, status, notes, rejected_reason, requested_at, approved_at, rejected_at, stockout_at, standby_at, linked_transfer_id, linked_pr_id, " +
             "stores(name), transfers(transfer_no, status, shipped_at, received_at), purchase_requests(pr_no, status)"
         )
         .eq("id", restockId)
@@ -100,6 +101,7 @@ export default function RestockDetailModal({
         approved_at: string | null;
         rejected_at: string | null;
         stockout_at: string | null;
+        standby_at: string | null;
         linked_transfer_id: number | null;
         linked_pr_id: number | null;
         stores: { name?: string } | { name?: string }[] | null;
@@ -125,6 +127,7 @@ export default function RestockDetailModal({
         approved_at: r.approved_at,
         rejected_at: r.rejected_at,
         stockout_at: r.stockout_at,
+        standby_at: r.standby_at,
         linked_transfer_id: r.linked_transfer_id,
         linked_pr_id: r.linked_pr_id,
         linked_transfer_no: txObj?.transfer_no ?? null,
@@ -201,7 +204,14 @@ export default function RestockDetailModal({
         <div className="space-y-4">
           <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
             <Field label="申請門市" value={hd.store_name ?? `#${hd.requesting_store_id}`} />
-            <Field label="狀態" value={STATUS_LABEL[hd.status] ?? hd.status} />
+            <Field
+              label="狀態"
+              value={
+                hd.status === "pending" && hd.standby_at
+                  ? `待處理（⏳ 候補中，${new Date(hd.standby_at).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" })} 轉入）`
+                  : STATUS_LABEL[hd.status] ?? hd.status
+              }
+            />
             <Field label="申請時間" value={new Date(hd.requested_at).toLocaleString("zh-TW")} />
             <Field
               label="核可時間"

--- a/supabase/migrations/20260722000020_restock_standby_zone.sql
+++ b/supabase/migrations/20260722000020_restock_standby_zone.sql
@@ -1,0 +1,173 @@
+-- ============================================================
+-- 補貨申請「候補區」：總倉收件匣可把 pending 申請轉入候補，
+-- 待處理列表不再被「等貨源」的申請刷整排，也不會漏掉真的要補的。
+--
+-- 需求（總倉 2026/7/22 回報）：
+--   1. 收件匣 restock 卡片加「轉候補」按鈕（可再轉回待處理）
+--   2. stage tab 多一個「候補」分類，候補中的申請不算在「待處理」
+--
+-- 設計：不動 status state machine（pending 照舊），只加 standby_at 旗標。
+--   候補中的申請 status 仍是 'pending'，所有既有 RPC
+--   （派貨 / 下訂單 / 拒絕 / 刪除 / 斷貨 propagation / picking demand）
+--   都不用改、照樣可以直接對候補中的申請操作。
+--
+-- 內容：
+--   1. restock_requests + standby_at / standby_by 欄位
+--   2. rpc_restock_set_standby(p_request_id, p_standby) — HQ 轉入 / 轉出候補
+--   3. v_hq_inbox：restock 的 pending + standby_at → stage='standby'
+--      （基底：20260612000050_v_hq_inbox_return_to_hq_pending.sql，
+--        保留 return_to_hq+shipped 算 pending 的修正；其他 source 不動）
+--   4. rpc_inbox_counts：stage grid 加 'standby'
+--      （基底：20260608000010_hq_inbox_view_and_counts.sql）
+--   rpc_hq_inbox_keys 不用改：p_stage 直接透傳 'standby' 即可。
+--
+-- Rollback:
+--   DROP FUNCTION rpc_restock_set_standby(BIGINT, BOOLEAN);
+--   ALTER TABLE restock_requests DROP COLUMN standby_at, DROP COLUMN standby_by;
+--   v_hq_inbox 還原 20260612000050 版本；rpc_inbox_counts 還原 20260608000010 版本。
+-- ============================================================
+
+ALTER TABLE restock_requests
+  ADD COLUMN IF NOT EXISTS standby_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS standby_by UUID;
+
+COMMENT ON COLUMN restock_requests.standby_at IS
+  '候補區旗標：非 NULL 且 status=pending = 候補中（等貨源，先不出現在待處理）。approve/reject 後不清、只看 pending 判斷。';
+
+-- ----------------------------------------------------------------
+-- rpc_restock_set_standby — HQ 把 pending 申請轉入 / 轉出候補
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_restock_set_standby(
+  p_request_id BIGINT,
+  p_standby    BOOLEAN DEFAULT TRUE
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_user   UUID := auth.uid();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_req    RECORD;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot set restock standby', v_role;
+  END IF;
+
+  SELECT * INTO v_req FROM restock_requests
+   WHERE id = p_request_id AND tenant_id = v_tenant FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'request % not found', p_request_id; END IF;
+  IF v_req.status <> 'pending' THEN
+    RAISE EXCEPTION 'request % already processed (status=%)', p_request_id, v_req.status;
+  END IF;
+
+  UPDATE restock_requests
+     SET standby_at = CASE WHEN p_standby THEN NOW() ELSE NULL END,
+         standby_by = CASE WHEN p_standby THEN v_user ELSE NULL END,
+         updated_by = v_user
+   WHERE id = p_request_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_restock_set_standby(BIGINT, BOOLEAN)
+  TO authenticated;
+
+-- ----------------------------------------------------------------
+-- v_hq_inbox — restock 加 'standby' stage（其他 source 照舊）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE VIEW public.v_hq_inbox AS
+SELECT
+  'restock-' || id::text                                AS row_key,
+  'restock'::text                                       AS source,
+  CASE
+    WHEN status = 'pending' AND standby_at IS NOT NULL                          THEN 'standby'
+    WHEN status = 'pending'                                                     THEN 'pending'
+    WHEN status IN ('approved_transfer','approved_pr','shipped')                THEN 'in_transit'
+    WHEN status = 'received'                                                    THEN 'done'
+    ELSE 'rejected'
+  END                                                   AS stage,
+  requested_at                                          AS ts,
+  id                                                    AS source_id
+FROM public.restock_requests
+
+UNION ALL
+
+SELECT
+  'transfer-' || id::text,
+  'transfer',
+  CASE
+    WHEN status IN ('draft','confirmed')                       THEN 'pending'
+    WHEN status = 'shipped' AND transfer_type = 'return_to_hq' THEN 'pending'
+    WHEN status = 'shipped'                                    THEN 'in_transit'
+    WHEN status = 'received'                                   THEN 'done'
+    ELSE 'rejected'
+  END,
+  created_at,
+  id
+FROM public.transfers
+
+UNION ALL
+
+SELECT
+  'aid-' || co.id::text,
+  'aid',
+  CASE
+    WHEN co.status IN ('pending','confirmed')                     THEN 'pending'
+    WHEN co.status = 'shipping'                                   THEN 'in_transit'
+    WHEN co.status IN ('ready','completed','partially_completed') THEN 'done'
+    ELSE 'rejected'
+  END,
+  co.updated_at,
+  co.id
+FROM public.customer_orders co
+WHERE EXISTS (
+  SELECT 1 FROM public.customer_order_items coi
+  WHERE coi.order_id = co.id AND coi.source = 'aid_transfer'
+)
+
+UNION ALL
+
+SELECT DISTINCT
+  'shortage-' || order_id::text,
+  'shortage',
+  CASE
+    WHEN shortage_resolution IS NULL                              THEN 'pending'
+    WHEN shortage_resolution IN ('notified','waiting_next_po')    THEN 'in_transit'
+    WHEN shortage_resolution IN ('cancelled','reallocated')       THEN 'done'
+    ELSE 'pending'
+  END,
+  order_updated_at,
+  order_id
+FROM public.v_order_shortage;
+
+-- ----------------------------------------------------------------
+-- rpc_inbox_counts — stage grid 加 'standby'（目前只有 restock 會有值）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_inbox_counts()
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH src(source) AS (VALUES ('restock'),('transfer'),('aid'),('shortage')),
+       stg(stage)  AS (VALUES ('pending'),('standby'),('in_transit'),('done'),('rejected')),
+       grid AS (SELECT s.source, st.stage FROM src s CROSS JOIN stg st),
+       counts AS (
+         SELECT v.source, v.stage, COUNT(*)::int AS cnt
+         FROM v_hq_inbox v
+         GROUP BY v.source, v.stage
+       )
+  SELECT jsonb_object_agg(g.source, stages_obj)
+  FROM (
+    SELECT
+      g.source,
+      jsonb_object_agg(g.stage, COALESCE(c.cnt, 0)) AS stages_obj
+    FROM grid g
+    LEFT JOIN counts c ON c.source = g.source AND c.stage = g.stage
+    GROUP BY g.source
+  ) g;
+$$;
+
+COMMENT ON FUNCTION public.rpc_inbox_counts() IS
+  'HQ 收件匣計數:一次回傳 4 來源 × 5 階段(含 standby 候補)的數字(JSONB)。';


### PR DESCRIPTION
總倉回報：等貨源的補貨申請掛在待處理會刷整排，按了處理又怕漏掉、
也看不出到底訂了沒。

- restock_requests 加 standby_at/standby_by（status 維持 pending，
  既有派貨/下訂單/拒絕/刪除/斷貨 propagation 全部不用改）
- 新 RPC rpc_restock_set_standby：HQ 角色把 pending 申請轉入/轉出候補
- v_hq_inbox / rpc_inbox_counts：restock pending+standby_at → stage='standby'
- /hq/inbox：補貨申請資料夾多「候補」tab（含計數）；卡片加「⏳ 轉候補 /
  取消候補」按鈕；候補列照樣可直接派貨/下訂單/拒絕；批次支援轉候補/取消候補；
  部分開單顯示「已開單 x/y 品相」
- /restock（分店端）與 RestockDetailModal：pending+候補顯示「⏳ 候補中」
- /restock/inbox（無入口舊頁）：同步候補 badge + 轉候補按鈕

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XqmJLHPkDJsmocznibbEct