### PR TITLE
修總倉收件匣清單按鈕跑版：內容區補 flex-1，動作按鈕每列貼右對齊

### DIFF
--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -2547,7 +2547,8 @@ function MailRow({
       onClick={handleRowClick}
       className={`flex flex-col gap-2 border-b border-l-4 px-4 py-3 transition hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-950 sm:flex-row sm:items-start sm:gap-3 ${accent} ${row.source === "shortage" ? "bg-rose-50/30 dark:bg-rose-950/20" : ""} ${selected ? "bg-blue-50 dark:bg-blue-950/30" : ""} ${rowClickable ? "cursor-pointer" : ""}`}
     >
-      <div className="flex items-start gap-3">
+      {/* min-w-0 flex-1:內容區撐滿剩餘寬度,右側 400px 動作區才會每列貼右對齊(不然按鈕跟著內容長短跑) */}
+      <div className="flex min-w-0 flex-1 items-start gap-3">
         {/* checkbox */}
         <div className="w-5 shrink-0 pt-1">
           {showCheckbox && batchable ? (


### PR DESCRIPTION
總倉回報：#545 上線後，收件匣清單列的動作按鈕在桌面版每列位置亂飄（手機版正常）。

## 原因

`MailRow` 的內容區塊（店名＋摘要）少了 `flex-1`，寬度跟著每列文字長短跑，右側固定 400px 的動作區（派貨／下訂單／轉候補／拒絕）就每列左右飄。這是清單原本就潛藏的結構問題，#545 加了第四顆「⏳ 轉候補」按鈕後變得明顯。

## 修法

一行修正：內容區補上 `min-w-0 flex-1` 撐滿剩餘寬度，按鈕、階段 chip、時間每列固定貼右對齊。

## 驗證

Playwright + fixture 實跑頁面（無真實登入）：
- 桌機 1440px：待處理／候補 tab 各列按鈕全部貼右對齊
- 手機 390px：排版不變、不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqmJLHPkDJsmocznibbEct

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqmJLHPkDJsmocznibbEct)_