### PR TITLE
收件匣 RPC 錯誤顯示 [object Object] → 改用 translateRpcError 顯示原始訊息

### DIFF
--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -1167,7 +1167,7 @@ function HqInboxContent() {
         setTotal(resultTotal);
         setError(null);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        if (!cancelled) setError(translateRpcError(e));
       } finally {
         if (!cancelled) setLoadingRows(false);
       }
@@ -1290,7 +1290,7 @@ function HqInboxContent() {
       if (err) throw err;
       setReloadTick((t) => t + 1);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setBusy(null);
     }
@@ -1326,7 +1326,7 @@ function HqInboxContent() {
       if (err) throw err;
       setReloadTick((t) => t + 1);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setBusy(null);
     }
@@ -1344,7 +1344,7 @@ function HqInboxContent() {
       setRejectModal(null);
       setReloadTick((t) => t + 1);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setBusy(null);
     }
@@ -1620,7 +1620,7 @@ function HqInboxContent() {
       }
       setReloadTick((t) => t + 1);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setBusy(null);
     }
@@ -1649,7 +1649,7 @@ function HqInboxContent() {
       // TODO: action='notified' 觸發 PWA push edge function
       setReloadTick((t) => t + 1);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setBusy(null);
     }

--- a/apps/admin/src/app/(protected)/restock/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/restock/inbox/page.tsx
@@ -6,6 +6,7 @@ import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import RestockToPrModal from "@/components/RestockToPrModal";
 import { PR_TERM_ZH } from "@/lib/prStatus";
+import { translateRpcError } from "@/lib/rpcError";
 
 type Status = "pending" | "approved_transfer" | "approved_pr" | "shipped" | "received" | "rejected" | "cancelled";
 
@@ -128,7 +129,7 @@ export default function RestockInboxPage() {
       if (err) throw err;
       setReload((t) => t + 1);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setBusy(null);
     }
@@ -142,7 +143,7 @@ export default function RestockInboxPage() {
       if (err) throw err;
       setReload((t) => t + 1);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setBusy(null);
     }
@@ -155,7 +156,7 @@ export default function RestockInboxPage() {
       if (err) throw err;
       setReload((t) => t + 1);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setBusy(null);
     }
@@ -173,7 +174,7 @@ export default function RestockInboxPage() {
       setRejectModal(null);
       setReload((t) => t + 1);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(translateRpcError(e));
     } finally {
       setBusy(null);
     }


### PR DESCRIPTION
RESTOCK#114 按「PO 到貨建轉貨單」時，rpc_ship_restock_pr_received 的
價格守衛正確擋下（SKU G01023-01 缺成本價）並回傳中文錯誤，但
hq/inbox 與 restock/inbox 的 catch 用 `e instanceof Error ? e.message
: String(e)`，PostgrestError 不是 Error instance，String() 後變成
[object Object]，使用者看不到「請先補成本價」的指引。

兩頁所有 setError 的 raw pattern 統一改走 @/lib/rpcError 的
translateRpcError（同檔其他 handler 既有用法）。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EVezQiVFuVeSxsW2ESZyBh