### PR TITLE
店長店員可編輯自店訂單備註（單頭+品項）

### DIFF
--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -198,7 +198,7 @@ export function OrderDetail({
   const { user } = useAuth();
   const role = useRole();
   const userStores = (user?.app_metadata?.stores as unknown[] | undefined) ?? [];
-  // 整單編輯（單價/折扣/備註）— 限 HQ tier 或總倉成員
+  // 整單編輯（單價/折扣）— 限 HQ tier 或總倉成員
   const canEdit = useMemo(() => {
     if (role === null) return false;
     if (HQ_ROLES.has(role)) return true;
@@ -213,6 +213,9 @@ export function OrderDetail({
 
   // qty 只有 pending 訂單可改;一旦被 PR 鎖定變 confirmed 就唯讀
   const canEditQty = (canEdit || isStoreOfThisOrder) && head?.status === "pending";
+
+  // 備註（單頭/品項）：店長店員也可編自店訂單，對齊 _check_order_edit_notes_perm
+  const canEditNotes = canEdit || isStoreOfThisOrder;
 
   useEffect(() => {
     let cancelled = false;
@@ -812,7 +815,7 @@ export function OrderDetail({
           value={
             <EditableText
               value={orderNotesValue}
-              disabled={!canEdit}
+              disabled={!canEditNotes}
               placeholder="（點此加備註）"
               onSave={async (v) => setOrderDraft({ notes: v })}
               multiline
@@ -965,7 +968,7 @@ export function OrderDetail({
                     <td className="px-3 py-2">
                       <EditableText
                         value={eff.notes}
-                        disabled={!canEdit}
+                        disabled={!canEditNotes}
                         placeholder="（點此加備註）"
                         onSave={async (v) => setItemDraft(it.id, { notes: v })}
                       />

--- a/docs/TEST-orders-edit.md
+++ b/docs/TEST-orders-edit.md
@@ -193,6 +193,28 @@
 
 ---
 
+## 3.6 店長店員編輯備註（2026-07-28 `20260728000000_order_notes_store_edit.sql`）
+
+> 備註 RPC 權限自 `_check_order_edit_perm`（認 `store_id`，實際 staff 帳號沒有此欄）
+> 改為 `_check_order_edit_notes_perm`（認 `app_metadata.stores[]` 店名，同 qty 編輯）。
+> §2.9 / §3.4 的 store_id 矩陣對備註兩支 RPC 已不適用，以下取代：
+
+| 角色 | rpc_update_order_notes / rpc_update_order_item_notes | 預期 |
+|---|---|---|
+| HQ owner / admin / hq_manager / hq_accountant / role NULL | 兩支 | 成功 |
+| stores[] 含 '總倉' | 兩支 | 成功 |
+| store_manager / store_staff，stores[] 含訂單取貨店名 | 兩支 | 成功 |
+| store_manager / store_staff，stores[] 不含訂單取貨店名 | 兩支 | RAISE `permission denied` |
+| 單價 / 折扣 4 支 RPC | 權限不變 | 店長店員仍被拒 |
+
+- [ ] 店長帳號開自店訂單 → 單頭備註 + 品項備註可點擊編輯、儲存後 reload 還在
+- [ ] 店員帳號開自店訂單 → 同上
+- [ ] 店長/店員開**他店**訂單 → 備註純文字、無 input
+- [ ] 店長/店員開自店訂單 → 單價、折扣欄仍唯讀
+- [ ] 備註修改寫入 audit log，店家帳號在「查看編輯歷史」看得到
+
+---
+
 ## 4. Regression
 
 - [ ] LIFF `/orders/:id` 顧客端的 `payable_amount` 仍正確（直接讀 `v_customer_order_summary` 不應壞）

--- a/supabase/migrations/20260728000000_order_notes_store_edit.sql
+++ b/supabase/migrations/20260728000000_order_notes_store_edit.sql
@@ -1,0 +1,195 @@
+-- ============================================================
+-- 店長/店員可編輯訂單備註（單頭 notes + 品項 notes）— 限自店
+--
+-- 背景：
+--   ERP staff 帳號的 store 歸屬存在 app_metadata.stores (TEXT[]，店名)，
+--   沒有 store_id。rpc_update_order_notes / rpc_update_order_item_notes
+--   沿用 _check_order_edit_perm（認 app_metadata.store_id BIGINT），
+--   店長/店員一律 permission denied；前端 OrderDetail 也以 canEdit
+--   (HQ/總倉) 把備註欄鎖成唯讀。
+--
+-- 本次：
+--   1. 新增 _check_order_edit_notes_perm：判斷邏輯同 20260629000010 的
+--      _check_order_edit_qty_perm（HQ tier 全過 / stores[] 含 '總倉' 全過 /
+--      其他比對 stores[] 是否含訂單 pickup_store 店名），僅錯誤訊息不同。
+--   2. rpc_update_order_notes / rpc_update_order_item_notes 改呼叫新 helper，
+--      其餘（no-op 短路 / audit log / updated_by）不動。
+--      基底版本：20260605000002_rpc_edit_order_price_and_notes.sql
+--      （兩支 RPC 至今唯一版本，grep migrations 確認無後續修改）。
+--   3. price / discount RPC 維持 _check_order_edit_perm，權限不變。
+--   （店家可讀自店訂單 audit log 的 coa_store_read policy 已在
+--    20260629000010 改用 stores[] 比對，本次不需再動。）
+--
+-- Rollback：把兩支 RPC 還原成 20260605000002 版（呼叫 _check_order_edit_perm），
+--   再 DROP FUNCTION _check_order_edit_notes_perm(BIGINT)。
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. 備註權限 helper：HQ 全過 / 總倉全過 / 店家限 stores[] 內店名
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._check_order_edit_notes_perm(p_order_id BIGINT)
+RETURNS customer_orders
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order      customer_orders%ROWTYPE;
+  v_tenant     UUID    := (auth.jwt() ->> 'tenant_id')::uuid;
+  v_role       TEXT    := COALESCE(
+                            NULLIF(auth.jwt() -> 'app_metadata' ->> 'role', ''),
+                            NULLIF(auth.jwt() ->> 'role', 'authenticated'),
+                            ''
+                          );
+  v_stores     TEXT[];
+  v_store_name TEXT;
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+
+  SELECT * INTO v_order
+    FROM customer_orders
+   WHERE id = p_order_id AND tenant_id = v_tenant
+   FOR UPDATE;
+
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found in tenant %', p_order_id, v_tenant;
+  END IF;
+
+  -- HQ tier（含 role NULL/空字串/'authenticated' 視為 admin tier）
+  IF v_role IN ('owner','admin','hq_manager','hq_accountant','') THEN
+    RETURN v_order;
+  END IF;
+
+  -- 讀 app_metadata.stores（JSON array of store names）→ TEXT[]
+  SELECT COALESCE(
+           ARRAY(SELECT jsonb_array_elements_text(auth.jwt() -> 'app_metadata' -> 'stores')),
+           ARRAY[]::TEXT[]
+         )
+    INTO v_stores;
+
+  -- 總倉 magic value：總倉成員可編任何店訂單備註
+  IF '總倉' = ANY(v_stores) THEN
+    RETURN v_order;
+  END IF;
+
+  -- 比對訂單 pickup_store 名稱是否在 stores[] 內
+  SELECT name INTO v_store_name
+    FROM stores
+   WHERE id = v_order.pickup_store_id
+     AND tenant_id = v_tenant;
+
+  IF v_store_name IS NOT NULL AND v_store_name = ANY(v_stores) THEN
+    RETURN v_order;
+  END IF;
+
+  RAISE EXCEPTION 'permission denied: role=% stores=% cannot edit notes of order %',
+    v_role, v_stores::text, p_order_id;
+END;
+$$;
+
+-- ----------------------------------------------------------------
+-- 2a. order header notes（基底 20260605000002；僅換權限 helper）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION rpc_update_order_notes(
+  p_order_id  BIGINT,
+  p_new_notes TEXT,
+  p_operator  UUID,
+  p_reason    TEXT DEFAULT NULL
+) RETURNS customer_orders
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order customer_orders%ROWTYPE;
+  v_old   TEXT;
+  v_row   customer_orders;
+BEGIN
+  v_order := _check_order_edit_notes_perm(p_order_id);
+
+  v_old := v_order.notes;
+
+  IF v_old IS NOT DISTINCT FROM p_new_notes THEN
+    RETURN v_order;
+  END IF;
+
+  UPDATE customer_orders
+     SET notes      = p_new_notes,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_order_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'order', NULL, 'order_notes',
+     to_jsonb(v_old), to_jsonb(p_new_notes), p_reason, p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+-- ----------------------------------------------------------------
+-- 2b. line item notes（基底 20260605000002；僅換權限 helper）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION rpc_update_order_item_notes(
+  p_order_id  BIGINT,
+  p_item_id   BIGINT,
+  p_new_notes TEXT,
+  p_operator  UUID,
+  p_reason    TEXT DEFAULT NULL
+) RETURNS customer_order_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order customer_orders%ROWTYPE;
+  v_old   TEXT;
+  v_row   customer_order_items;
+BEGIN
+  v_order := _check_order_edit_notes_perm(p_order_id);
+
+  SELECT notes INTO v_old
+    FROM customer_order_items
+   WHERE id = p_item_id AND order_id = p_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'item % not in order %', p_item_id, p_order_id;
+  END IF;
+
+  IF v_old IS NOT DISTINCT FROM p_new_notes THEN
+    SELECT * INTO v_row FROM customer_order_items WHERE id = p_item_id;
+    RETURN v_row;
+  END IF;
+
+  UPDATE customer_order_items
+     SET notes      = p_new_notes,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_item_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'item', p_item_id, 'item_notes',
+     to_jsonb(v_old), to_jsonb(p_new_notes), p_reason, p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_update_order_notes IS
+  '編輯訂單單頭備註。HQ tier 全部 / 店長店員限 app_metadata.stores 含訂單 '
+  'pickup_store.name（或含 ''總倉''）；寫 customer_order_audit_log，no-op 不寫。';
+
+COMMENT ON FUNCTION public.rpc_update_order_item_notes IS
+  '編輯訂單品項備註。HQ tier 全部 / 店長店員限 app_metadata.stores 含訂單 '
+  'pickup_store.name（或含 ''總倉''）；寫 customer_order_audit_log，no-op 不寫。';


### PR DESCRIPTION
- 新增 _check_order_edit_notes_perm：認 app_metadata.stores[] 店名
  （同 qty 編輯的 helper 邏輯），HQ/總倉全過、店家限自店訂單
- rpc_update_order_notes / rpc_update_order_item_notes 改用新 helper
  （基底 20260605000002；單價/折扣 RPC 權限不變）
- OrderDetail 前端備註欄改用 canEditNotes = canEdit || isStoreOfThisOrder
- TEST-orders-edit.md 補 §3.6 新權限矩陣與測項

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0198FGaPMsiyzcPEUPHWU5ng