### PR TITLE
會員可徹底刪除：新增 rpc_member_purge[_bulk] 硬刪除 + 刪除 modal 雙模式

### DIFF
--- a/apps/admin/src/components/MemberBulkDeleteModal.tsx
+++ b/apps/admin/src/components/MemberBulkDeleteModal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-// 會員批次刪除（GDPR 軟刪除）— 呼叫 rpc_member_gdpr_delete_bulk
-// 行為與單筆版（MemberDeleteModal）相同，只是一次處理多筆：
-//   清 PII / 退卡 / 移除標籤 / 流水訂單保留；不可還原；已刪除/已合併會被後端略過。
+// 會員批次刪除 — 兩種模式（與單筆版 MemberDeleteModal 相同）：
+//   徹底刪除（預設）— rpc_member_purge_bulk：實體刪除會員與附屬資料，
+//     訂單等單據保留但解除會員連結；分店內部會員（store_internal）自動略過。
+//   保留紀錄刪除 — rpc_member_gdpr_delete_bulk：清 PII / 退卡 / 移除標籤，
+//     流水訂單保留；已刪除／已合併會被後端略過。
 // 二次確認：須輸入「刪除」二字，避免誤刪一整批。
 
 import { useState } from "react";
@@ -12,6 +14,8 @@ import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
 
 const CONFIRM_WORD = "刪除";
+
+type DeleteMode = "purge" | "gdpr";
 
 export type BulkDeleteTarget = { id: number; member_no: string; name: string | null };
 
@@ -27,6 +31,7 @@ export function MemberBulkDeleteModal({
   /** 後端回傳實際刪除筆數 */
   onDeleted: (deletedCount: number) => void;
 }) {
+  const [mode, setMode] = useState<DeleteMode>("purge");
   const [confirmText, setConfirmText] = useState("");
   const [reason, setReason] = useState("");
   const [busy, setBusy] = useState(false);
@@ -36,6 +41,7 @@ export function MemberBulkDeleteModal({
   const confirmed = confirmText.trim() === CONFIRM_WORD;
 
   function reset() {
+    setMode("purge");
     setConfirmText("");
     setReason("");
     setErr(null);
@@ -51,18 +57,39 @@ export function MemberBulkDeleteModal({
     setErr(null);
     try {
       const sb = getSupabase();
-      const { error, data } = await sb.rpc("rpc_member_gdpr_delete_bulk", {
-        p_member_ids: members.map((m) => m.id),
-        p_reason: reason.trim() || null,
-      });
-      if (error) {
-        setErr(translateRpcError(error));
-        return;
+
+      if (mode === "purge") {
+        const { error, data } = await sb.rpc("rpc_member_purge_bulk", {
+          p_member_ids: members.map((m) => m.id),
+          p_reason: reason.trim() || null,
+        });
+        if (error) {
+          setErr(translateRpcError(error));
+          return;
+        }
+        const result = (data ?? {}) as { purged?: number; skipped_internal?: number };
+        const purged = result.purged ?? count;
+        const skippedInternal = result.skipped_internal ?? 0;
+        alert(
+          `已徹底刪除 ${purged} 位會員（會員資料與點數／儲值紀錄已完全移除）` +
+            (skippedInternal > 0 ? `\n略過 ${skippedInternal} 位分店內部會員（無法刪除）` : ""),
+        );
+        reset();
+        onDeleted(purged);
+      } else {
+        const { error, data } = await sb.rpc("rpc_member_gdpr_delete_bulk", {
+          p_member_ids: members.map((m) => m.id),
+          p_reason: reason.trim() || null,
+        });
+        if (error) {
+          setErr(translateRpcError(error));
+          return;
+        }
+        const deleted = typeof data === "number" ? data : count;
+        alert(`已刪除 ${deleted} 位會員（個資已清除，歷史交易紀錄依稅務規定保留）`);
+        reset();
+        onDeleted(deleted);
       }
-      const deleted = typeof data === "number" ? data : count;
-      alert(`已刪除 ${deleted} 位會員（個資已清除，歷史交易紀錄依稅務規定保留）`);
-      reset();
-      onDeleted(deleted);
     } finally {
       setBusy(false);
     }
@@ -97,16 +124,41 @@ export function MemberBulkDeleteModal({
           </ul>
         </div>
 
-        <div className="rounded-md border border-zinc-200 p-3 text-xs text-zinc-600 dark:border-zinc-800 dark:text-zinc-400">
-          <div className="mb-1 font-medium text-zinc-700 dark:text-zinc-300">刪除後：</div>
-          <ul className="list-disc space-y-0.5 pl-4">
-            <li>清除個資（姓名 / 電話 / Email / 生日 / LINE 綁定 / 大頭照）</li>
-            <li>會員卡全部退卡、標籤全部移除</li>
-            <li>
-              <b>積分 / 儲值流水、訂單、銷售紀錄會保留</b>（依稅捐稽徵法需留存 7 年）
-            </li>
-            <li>已刪除 / 已合併的會員會自動略過</li>
-          </ul>
+        <div className="space-y-2">
+          <label className="flex cursor-pointer items-start gap-2 rounded-md border border-zinc-200 p-3 has-[:checked]:border-red-400 has-[:checked]:bg-red-50/50 dark:border-zinc-800 dark:has-[:checked]:border-red-800 dark:has-[:checked]:bg-red-950/20">
+            <input
+              type="radio"
+              name="bulk-delete-mode"
+              checked={mode === "purge"}
+              onChange={() => setMode("purge")}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="block font-medium">徹底刪除</span>
+              <span className="mt-0.5 block text-xs text-zinc-500">
+                會員資料完全從系統移除：個資、積分／儲值流水、會員卡、標籤、LINE
+                綁定、推播訂閱全數刪除。訂單等營運單據保留，但不再掛在會員名下。
+                分店內部會員會自動略過。
+              </span>
+            </span>
+          </label>
+          <label className="flex cursor-pointer items-start gap-2 rounded-md border border-zinc-200 p-3 has-[:checked]:border-red-400 has-[:checked]:bg-red-50/50 dark:border-zinc-800 dark:has-[:checked]:border-red-800 dark:has-[:checked]:bg-red-950/20">
+            <input
+              type="radio"
+              name="bulk-delete-mode"
+              checked={mode === "gdpr"}
+              onChange={() => setMode("gdpr")}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="block font-medium">保留紀錄刪除</span>
+              <span className="mt-0.5 block text-xs text-zinc-500">
+                清除個資（姓名／電話／Email／生日／LINE／大頭照）、退卡、移除標籤；
+                <b>積分／儲值流水、訂單、銷售紀錄保留</b>（依稅捐稽徵法留存 7 年）。
+                已刪除／已合併的會員自動略過。
+              </span>
+            </span>
+          </label>
         </div>
 
         <label className="block">
@@ -161,7 +213,11 @@ export function MemberBulkDeleteModal({
             disabled={busy || !confirmed || count === 0}
             className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
           >
-            {busy ? "刪除中…" : `🗑️ 確認刪除 ${count} 筆（不可還原）`}
+            {busy
+              ? "刪除中…"
+              : mode === "purge"
+                ? `🗑️ 徹底刪除 ${count} 筆（不可還原）`
+                : `🗑️ 確認刪除 ${count} 筆（不可還原）`}
           </SpinButton>
         </div>
       </div>

--- a/apps/admin/src/components/MemberDeleteModal.tsx
+++ b/apps/admin/src/components/MemberDeleteModal.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-// 會員刪除（GDPR 軟刪除）— 呼叫 rpc_member_gdpr_delete
-// 後端行為（見 supabase/migrations/20260618000040_rpc_member_gdpr_delete.sql）：
-//   - members：清 PII（姓名 / 電話 / email / 生日 / LINE / 大頭照）、status='deleted'
-//   - member_cards：全部退卡（retired）
-//   - member_tags：全部刪除
-//   - points_ledger / wallet_ledger / 訂單 / sales：保留（稅捐稽徵法 7 年留存）
-//   - 不可還原；冪等（已刪除再按為 no-op）
+// 會員刪除 — 兩種模式：
+//   徹底刪除（預設）— 呼叫 rpc_member_purge（20260728000010）：
+//     members 資料列連同點數/儲值流水、卡片、標籤、LINE 綁定、推播訂閱實體刪除，
+//     會員完全消失；訂單/候補/欠品僅解除會員連結（單據保留）。
+//     分店內部會員（store_internal）後端會擋。
+//   保留紀錄刪除 — 呼叫 rpc_member_gdpr_delete（20260618000040）：
+//     清 PII、status='deleted'、退卡、移除標籤；流水/訂單保留（稅捐稽徵法 7 年）。
 //
 // 權限：RPC 為 SECURITY DEFINER 不自帶 role gate（與 rpc_merge_member 同慣例，
 //   由呼叫端把關）。本 modal 只在 isAdmin(role) 時於 MemberDetail 掛出，
@@ -17,6 +17,8 @@ import { Modal } from "@/components/Modal";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
+
+type DeleteMode = "purge" | "gdpr";
 
 export function MemberDeleteModal({
   open,
@@ -29,6 +31,7 @@ export function MemberDeleteModal({
   member: { id: number; member_no: string; name: string | null };
   onDeleted: () => void;
 }) {
+  const [mode, setMode] = useState<DeleteMode>("purge");
   const [confirmText, setConfirmText] = useState("");
   const [reason, setReason] = useState("");
   const [busy, setBusy] = useState(false);
@@ -38,6 +41,7 @@ export function MemberDeleteModal({
   const confirmed = confirmText.trim() === member.member_no;
 
   function reset() {
+    setMode("purge");
     setConfirmText("");
     setReason("");
     setErr(null);
@@ -52,19 +56,31 @@ export function MemberDeleteModal({
     setErr(null);
     try {
       const sb = getSupabase();
-      const { data: sess } = await sb.auth.getSession();
-      const operator = sess.session?.user?.id;
 
-      const { error } = await sb.rpc("rpc_member_gdpr_delete", {
-        p_member_id: member.id,
-        p_reason: reason.trim() || null,
-        p_operator: operator ?? null,
-      });
-      if (error) {
-        setErr(translateRpcError(error));
-        return;
+      if (mode === "purge") {
+        const { error } = await sb.rpc("rpc_member_purge", {
+          p_member_id: member.id,
+          p_reason: reason.trim() || null,
+        });
+        if (error) {
+          setErr(translateRpcError(error));
+          return;
+        }
+        alert(`已徹底刪除會員 #${member.member_no}（會員資料與點數／儲值紀錄已完全移除）`);
+      } else {
+        const { data: sess } = await sb.auth.getSession();
+        const operator = sess.session?.user?.id;
+        const { error } = await sb.rpc("rpc_member_gdpr_delete", {
+          p_member_id: member.id,
+          p_reason: reason.trim() || null,
+          p_operator: operator ?? null,
+        });
+        if (error) {
+          setErr(translateRpcError(error));
+          return;
+        }
+        alert(`已刪除會員 #${member.member_no}（個資已清除，歷史交易紀錄依稅務規定保留）`);
       }
-      alert(`已刪除會員 #${member.member_no}（個資已清除，歷史交易紀錄依稅務規定保留）`);
       reset();
       onDeleted();
     } finally {
@@ -95,16 +111,39 @@ export function MemberDeleteModal({
           </div>
         </div>
 
-        <div className="rounded-md border border-zinc-200 p-3 text-xs text-zinc-600 dark:border-zinc-800 dark:text-zinc-400">
-          <div className="mb-1 font-medium text-zinc-700 dark:text-zinc-300">刪除後：</div>
-          <ul className="list-disc space-y-0.5 pl-4">
-            <li>清除個資（姓名 / 電話 / Email / 生日 / LINE 綁定 / 大頭照）</li>
-            <li>會員卡全部退卡、標籤全部移除</li>
-            <li>會員將從列表消失、無法再以電話 / 卡號查詢</li>
-            <li>
-              <b>積分 / 儲值流水、訂單、銷售紀錄會保留</b>（依稅捐稽徵法需留存 7 年）
-            </li>
-          </ul>
+        <div className="space-y-2">
+          <label className="flex cursor-pointer items-start gap-2 rounded-md border border-zinc-200 p-3 has-[:checked]:border-red-400 has-[:checked]:bg-red-50/50 dark:border-zinc-800 dark:has-[:checked]:border-red-800 dark:has-[:checked]:bg-red-950/20">
+            <input
+              type="radio"
+              name="delete-mode"
+              checked={mode === "purge"}
+              onChange={() => setMode("purge")}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="block font-medium">徹底刪除</span>
+              <span className="mt-0.5 block text-xs text-zinc-500">
+                會員資料完全從系統移除：個資、積分／儲值流水、會員卡、標籤、LINE
+                綁定、推播訂閱全數刪除。訂單等營運單據保留，但不再掛在此會員名下。
+              </span>
+            </span>
+          </label>
+          <label className="flex cursor-pointer items-start gap-2 rounded-md border border-zinc-200 p-3 has-[:checked]:border-red-400 has-[:checked]:bg-red-50/50 dark:border-zinc-800 dark:has-[:checked]:border-red-800 dark:has-[:checked]:bg-red-950/20">
+            <input
+              type="radio"
+              name="delete-mode"
+              checked={mode === "gdpr"}
+              onChange={() => setMode("gdpr")}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="block font-medium">保留紀錄刪除</span>
+              <span className="mt-0.5 block text-xs text-zinc-500">
+                清除個資（姓名／電話／Email／生日／LINE／大頭照）、退卡、移除標籤；
+                <b>積分／儲值流水、訂單、銷售紀錄保留</b>（依稅捐稽徵法留存 7 年）。
+              </span>
+            </span>
+          </label>
         </div>
 
         <label className="block">
@@ -159,7 +198,11 @@ export function MemberDeleteModal({
             disabled={busy || !confirmed}
             className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
           >
-            {busy ? "刪除中…" : "🗑️ 確認刪除（不可還原）"}
+            {busy
+              ? "刪除中…"
+              : mode === "purge"
+                ? "🗑️ 徹底刪除（不可還原）"
+                : "🗑️ 確認刪除（不可還原）"}
           </SpinButton>
         </div>
       </div>

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -253,7 +253,11 @@ const RULES: Rule[] = [
     pattern: /source member \d+ is already merged/i,
     render: () => "來源會員已經合併過了。",
   },
-  // ===== rpc_member_gdpr_delete（會員刪除） =====
+  // ===== rpc_member_gdpr_delete / rpc_member_purge（會員刪除） =====
+  {
+    pattern: /member \d+ is a store-internal member, cannot purge/i,
+    render: () => "此為分店內部會員（補貨／叫貨用），無法刪除。",
+  },
   {
     pattern: /member \d+ not found/i,
     render: () => "找不到此會員（可能已被刪除）。",

--- a/supabase/migrations/20260728000010_rpc_member_purge.sql
+++ b/supabase/migrations/20260728000010_rpc_member_purge.sql
@@ -1,0 +1,204 @@
+-- ============================================================================
+-- 2026-07-28: rpc_member_purge / rpc_member_purge_bulk — 會員「徹底刪除」（硬刪除）
+-- ----------------------------------------------------------------------------
+-- 背景：既有「刪除會員」= rpc_member_gdpr_delete（20260618000040）軟刪除：
+--       清 PII + status='deleted'，members 資料列與點數/儲值流水都留在 DB。
+--       使用者需求「會員要可以徹底刪除」→ 補硬刪除路徑：members 資料列
+--       連同所有會員附屬資料一併實體 DELETE，會員完全消失。
+--
+-- 與 GDPR 軟刪除並存：前端刪除 modal 提供兩種模式（徹底刪除 / 保留紀錄刪除），
+-- 本檔不動 rpc_member_gdpr_delete[_bulk]，兩條路徑互不影響。
+--
+-- 刪除範圍（依 FK 盤點，指向 members 的表全數處理）：
+--   實體 DELETE（會員附屬資料，隨會員一起消失）：
+--     points_ledger / member_points_balance（暫關 trg_no_delete_points）
+--     wallet_ledger / wallet_balances（暫關 trg_no_delete_wallet）
+--     member_cards / member_tags
+--     member_line_bindings / customer_line_aliases / push_subscriptions
+--     member_merges（primary 或 merged 指到被刪會員的紀錄）
+--     notifications（FK ON DELETE CASCADE，自動）
+--     members 本體（暫關 trg_no_delete_member）
+--   解除連結（營運/庫存/稅務紀錄，單據本身保留）：
+--     customer_orders.member_id → NULL（訂單掛庫存移動與結算，不可刪）
+--     order_waitlist.member_id  → NULL
+--     backorders.member_id      → NULL
+--     members.merged_into_member_id → NULL（其他會員指向被刪會員的合併殘影）
+--     member_imports.resolved_member_id（FK ON DELETE SET NULL，自動）
+--
+-- 守門：
+--   - 只刪自己 tenant（_current_tenant_id，含試用到期守門）
+--   - member_type='store_internal'（分店內部會員，補貨/叫貨鏈依賴）一律拒刪：
+--     單筆版 RAISE、批次版略過並回報 skipped_internal
+--   - 權限沿用會員刪除慣例：SECURITY DEFINER 不自帶 role gate，
+--     UI 端以 isAdmin 把關 + 輸入確認（同 rpc_member_gdpr_delete_bulk）
+--
+-- 觸發器暫關安全性：ALTER TABLE DISABLE TRIGGER 在本函式交易內執行，
+-- 對該表取得 ACCESS EXCLUSIVE 鎖直到 commit，期間其他連線無法寫入，
+-- 不存在「別人趁 trigger 關閉時偷刪 ledger」的窗口（同 rpc_admin_purge_lele_imports 前例）。
+--
+-- 稽核：刪除前對每筆會員寫 member_audit_log action='purge'，只記非 PII
+-- 中繼資訊（member_no / member_type / prev_status / 有無姓名電話 LINE），
+-- 與 gdpr_delete 的隱私原則一致。
+--
+-- 冪等：已不存在的 id 批次版略過（單筆版 RAISE not found），可安全重跑。
+-- 基底版本：首建（無歷史版本）。
+-- Rollback：
+--   DROP FUNCTION public.rpc_member_purge(BIGINT, TEXT);
+--   DROP FUNCTION public.rpc_member_purge_bulk(BIGINT[], TEXT);
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_member_purge_bulk(
+  p_member_ids BIGINT[],
+  p_reason     TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant           UUID := public._current_tenant_id();
+  v_operator         UUID := COALESCE(auth.uid(), '00000000-0000-0000-0000-000000000000'::uuid);
+  v_ids              BIGINT[];
+  v_input            INTEGER := COALESCE(array_length(p_member_ids, 1), 0);
+  v_skipped_internal INTEGER := 0;
+  v_purged           INTEGER := 0;
+  v_orders_unlinked  INTEGER := 0;
+  v_points_deleted   INTEGER := 0;
+  v_wallet_deleted   INTEGER := 0;
+  v_cards_deleted    INTEGER := 0;
+BEGIN
+  IF v_input = 0 THEN
+    RETURN jsonb_build_object('purged', 0, 'skipped_internal', 0, 'skipped_missing', 0);
+  END IF;
+
+  -- 同 tenant、排除分店內部會員
+  SELECT array_agg(id) INTO v_ids
+    FROM members
+   WHERE id = ANY(p_member_ids)
+     AND tenant_id = v_tenant
+     AND member_type IS DISTINCT FROM 'store_internal';
+
+  SELECT COUNT(*) INTO v_skipped_internal
+    FROM members
+   WHERE id = ANY(p_member_ids)
+     AND tenant_id = v_tenant
+     AND member_type = 'store_internal';
+
+  IF v_ids IS NULL OR array_length(v_ids, 1) IS NULL THEN
+    RETURN jsonb_build_object(
+      'purged', 0,
+      'skipped_internal', v_skipped_internal,
+      'skipped_missing',  v_input - v_skipped_internal
+    );
+  END IF;
+  v_purged := array_length(v_ids, 1);
+
+  -- 稽核：刪除前寫入，只記非 PII 中繼資訊
+  INSERT INTO member_audit_log (
+    tenant_id, entity_type, entity_id, action,
+    before_value, after_value, reason, operator_id
+  )
+  SELECT v_tenant, 'member', m.id, 'purge',
+         jsonb_build_object(
+           'member_no',   m.member_no,
+           'member_type', m.member_type,
+           'prev_status', m.status,
+           'had_name',    m.name IS NOT NULL,
+           'had_phone',   m.phone_hash IS NOT NULL AND m.phone_hash NOT LIKE 'DELETED\_%',
+           'had_line',    m.line_user_id IS NOT NULL
+         ),
+         jsonb_build_object('purged', true),
+         p_reason, v_operator
+    FROM members m
+   WHERE m.id = ANY(v_ids);
+
+  -- 營運單據保留、解除會員連結
+  UPDATE customer_orders SET member_id = NULL WHERE member_id = ANY(v_ids);
+  GET DIAGNOSTICS v_orders_unlinked = ROW_COUNT;
+  UPDATE order_waitlist  SET member_id = NULL WHERE member_id = ANY(v_ids);
+  UPDATE backorders      SET member_id = NULL WHERE member_id = ANY(v_ids);
+  UPDATE members         SET merged_into_member_id = NULL
+   WHERE merged_into_member_id = ANY(v_ids) AND NOT (id = ANY(v_ids));
+
+  -- 會員附屬資料實體刪除
+  DELETE FROM member_merges
+   WHERE primary_member_id = ANY(v_ids) OR merged_member_id = ANY(v_ids);
+  DELETE FROM member_line_bindings  WHERE member_id = ANY(v_ids);
+  DELETE FROM customer_line_aliases WHERE member_id = ANY(v_ids);
+  DELETE FROM push_subscriptions    WHERE member_id = ANY(v_ids);
+
+  EXECUTE 'ALTER TABLE points_ledger DISABLE TRIGGER trg_no_delete_points';
+  EXECUTE 'ALTER TABLE wallet_ledger DISABLE TRIGGER trg_no_delete_wallet';
+  EXECUTE 'ALTER TABLE members       DISABLE TRIGGER trg_no_delete_member';
+
+  DELETE FROM points_ledger WHERE member_id = ANY(v_ids);
+  GET DIAGNOSTICS v_points_deleted = ROW_COUNT;
+  DELETE FROM member_points_balance WHERE member_id = ANY(v_ids);
+
+  DELETE FROM wallet_ledger WHERE member_id = ANY(v_ids);
+  GET DIAGNOSTICS v_wallet_deleted = ROW_COUNT;
+  DELETE FROM wallet_balances WHERE member_id = ANY(v_ids);
+
+  DELETE FROM member_cards WHERE member_id = ANY(v_ids);
+  GET DIAGNOSTICS v_cards_deleted = ROW_COUNT;
+  DELETE FROM member_tags WHERE member_id = ANY(v_ids);
+
+  -- notifications 由 FK CASCADE、member_imports.resolved_member_id 由 SET NULL 自動處理
+  DELETE FROM members WHERE id = ANY(v_ids);
+
+  EXECUTE 'ALTER TABLE points_ledger ENABLE TRIGGER trg_no_delete_points';
+  EXECUTE 'ALTER TABLE wallet_ledger ENABLE TRIGGER trg_no_delete_wallet';
+  EXECUTE 'ALTER TABLE members       ENABLE TRIGGER trg_no_delete_member';
+
+  RETURN jsonb_build_object(
+    'purged',                v_purged,
+    'skipped_internal',      v_skipped_internal,
+    'skipped_missing',       v_input - v_skipped_internal - v_purged,
+    'orders_unlinked',       v_orders_unlinked,
+    'points_ledger_deleted', v_points_deleted,
+    'wallet_ledger_deleted', v_wallet_deleted,
+    'cards_deleted',         v_cards_deleted
+  );
+END;
+$$;
+
+-- Supabase default privileges 會另外給 anon EXECUTE，須明確 REVOKE（雖然
+-- 函式內 _current_tenant_id 會擋無 tenant claim 的呼叫，仍不留 anon 入口）
+REVOKE ALL ON FUNCTION public.rpc_member_purge_bulk(BIGINT[], TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_member_purge_bulk(BIGINT[], TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_member_purge_bulk(BIGINT[], TEXT) IS
+  '會員徹底刪除（硬刪除，批次）：實體刪除 members 及點數/儲值流水、卡片、標籤、LINE 綁定、'
+  '推播訂閱；訂單/候補/欠品僅解除會員連結保留單據。store_internal 會員略過。回傳各項筆數 JSONB。';
+
+-- ----------------------------------------------------------------------------
+-- 單筆版：守門用 RAISE（前端可翻譯錯誤），實刪委派批次版
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_member_purge(
+  p_member_id BIGINT,
+  p_reason    TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_type   TEXT;
+BEGIN
+  SELECT member_type INTO v_type
+    FROM members
+   WHERE id = p_member_id AND tenant_id = v_tenant;
+
+  IF v_type IS NULL THEN
+    RAISE EXCEPTION 'member % not found', p_member_id;
+  END IF;
+  IF v_type = 'store_internal' THEN
+    RAISE EXCEPTION 'member % is a store-internal member, cannot purge', p_member_id;
+  END IF;
+
+  RETURN public.rpc_member_purge_bulk(ARRAY[p_member_id], p_reason);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_member_purge(BIGINT, TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_member_purge(BIGINT, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_member_purge(BIGINT, TEXT) IS
+  '會員徹底刪除（硬刪除，單筆）：委派 rpc_member_purge_bulk。不存在 / store_internal 會 RAISE。';


### PR DESCRIPTION
- 新 RPC rpc_member_purge / rpc_member_purge_bulk：實體刪除 members 及
  點數/儲值流水、卡片、標籤、LINE 綁定、推播訂閱；訂單/候補/欠品僅解除
  會員連結保留單據。store_internal 內部會員拒刪（批次略過、單筆 RAISE），
  同 tenant 守門、刪前寫非 PII 稽核（action='purge'）。
- MemberDeleteModal / MemberBulkDeleteModal 加「徹底刪除（預設）/ 保留紀錄
  刪除（GDPR 軟刪除）」模式選擇，二次確認流程不變。
- rpcError 補 store-internal 拒刪訊息翻譯。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ax7W4Uv1awvunNJzHJ2kgx