### PR TITLE
請購單清單顯示每筆品項對應的採購單並依 PO 分組

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -7,7 +7,7 @@ import { getSupabase } from "@/lib/supabase";
 import { PrPipelineStepper, type PrStepEvents, type POSummary, type TransferSummary } from "@/components/PrPipelineStepper";
 import SpinButton from "@/components/SpinButton";
 import { prStatusLabel, prReviewLabel, PR_TERM_ZH } from "@/lib/prStatus";
-import { PO_TERM_ZH } from "@/lib/poStatus";
+import { PO_TERM_ZH, poStatusLabel } from "@/lib/poStatus";
 
 type PRHeader = {
   id: number;
@@ -32,6 +32,7 @@ type DerivedPO = {
   id: number;
   po_no: string;
   status: string;
+  supplier_id: number | null;
   created_at: string | null;
   created_by: string | null;
   sent_at: string | null;
@@ -56,8 +57,18 @@ type ItemRow = {
   retail_price: number | null;     // PR snapshot，可手動覆寫
   franchise_price: number | null;  // PR snapshot，可手動覆寫
   purchased_so_far: number;        // 同 (campaign, sku) 在其他已通過 PR 的累積採購量
+  po_id: number | null;            // 此列被拆進哪一張 PO（未拆單為 null）
   dirty: boolean;
 };
+
+// 依 PO 分組後的清單；rows 帶 idx 是為了讓 patchItem / removeItem 仍能吃到
+// items 陣列的原始 index（分組只是顯示層的重排，不改 state 結構）
+type PoGroup = { po: DerivedPO | null; rows: { r: ItemRow; idx: number }[] };
+
+// 表格渲染序列的元素：分組標題列或品項列
+type RenderEntry =
+  | { kind: "group"; key: string; group: PoGroup }
+  | { kind: "item"; key: string; r: ItemRow; idx: number; seq: number };
 
 const STATUS_LABEL = prStatusLabel;
 const REVIEW_LABEL = prReviewLabel;
@@ -100,6 +111,8 @@ function PageContent() {
   const [bulkCost, setBulkCost] = useState<string>("");
   const [bulkBranch, setBulkBranch] = useState<string>("");
   const [bulkRetail, setBulkRetail] = useState<string>("");
+  // 品項清單是否依「拆出的採購單」分組顯示（拆過 PO 才有意義，預設開）
+  const [groupByPo, setGroupByPo] = useState(true);
 
   useEffect(() => {
     if (!id) {
@@ -153,21 +166,26 @@ function PageContent() {
         setDestLocationId(prData.source_location_id ?? locRow?.id ?? null);
 
         // 抓拆出的 PO（透過 PR items 反查）
+        // poItemToPo：po_item_id → po_id，讓每一列 PR 品項知道自己被拆進哪張 PO
+        const poItemToPo = new Map<number, number>();
         const itemIds = (itemRows ?? [])
           .map((r) => r.po_item_id)
           .filter((x): x is number => x !== null && x !== undefined);
         if (itemIds.length) {
           const { data: poiRows } = await supabase
             .from("purchase_order_items")
-            .select("po_id")
+            .select("id, po_id")
             .in("id", itemIds);
-          const poIds = Array.from(
-            new Set((poiRows ?? []).map((r) => r.po_id).filter((x): x is number => !!x)),
-          );
+          for (const r of ((poiRows ?? []) as { id: number; po_id: number | null }[])) {
+            if (r.po_id) poItemToPo.set(r.id, r.po_id);
+          }
+          const poIds = Array.from(new Set(poItemToPo.values()));
           if (poIds.length) {
             const { data: pos } = await supabase
               .from("purchase_orders")
-              .select("id, po_no, status, created_at, created_by, sent_at, sent_by, sent_channel")
+              .select(
+                "id, po_no, status, supplier_id, created_at, created_by, sent_at, sent_by, sent_channel",
+              )
               .in("id", poIds)
               .order("id");
             setDerivedPOs((pos ?? []) as DerivedPO[]);
@@ -353,6 +371,7 @@ function PageContent() {
             retail_price: retail,
             franchise_price: branch,
             purchased_so_far: purchasedMap.get(r.sku_id) ?? 0,
+            po_id: r.po_item_id ? poItemToPo.get(r.po_item_id) ?? null : null,
             // 若用了 fallback、標 dirty 讓 UI 提示「儲存後 PR 留紀錄」
             dirty: usedFallback,
           };
@@ -392,6 +411,56 @@ function PageContent() {
   }, [items]);
 
   const unassignedCount = items.filter((r) => !r.suggested_supplier_id).length;
+
+  const poById = useMemo(() => new Map(derivedPOs.map((p) => [p.id, p])), [derivedPOs]);
+  const supplierNameById = useMemo(
+    () => new Map(suppliers.map((s) => [s.id, s.name])),
+    [suppliers],
+  );
+  // 已拆出 PO 才顯示「採購單」欄與分組
+  const hasPos = derivedPOs.length > 0;
+
+  // 依 PO 分組：有 PO 的照 po_no 排在前，未拆單的一組排最後
+  const poGroups: PoGroup[] = useMemo(() => {
+    const map = new Map<number | null, PoGroup>();
+    items.forEach((r, idx) => {
+      const key = r.po_id ?? null;
+      let g = map.get(key);
+      if (!g) {
+        g = { po: key === null ? null : poById.get(key) ?? null, rows: [] };
+        map.set(key, g);
+      }
+      g.rows.push({ r, idx });
+    });
+    return Array.from(map.values()).sort((a, b) => {
+      if (!a.po && !b.po) return 0;
+      if (!a.po) return 1;
+      if (!b.po) return -1;
+      return a.po.po_no.localeCompare(b.po.po_no, undefined, { numeric: true });
+    });
+  }, [items, poById]);
+
+  // 攤平成「分組標題列 + 品項列」的渲染序列；關掉分組時就是原本的平鋪順序。
+  // seq 是畫面上的連續序號（跨組不重來），idx 仍是 items 的原始 index。
+  const displayRows: RenderEntry[] = useMemo(() => {
+    if (!groupByPo || !hasPos) {
+      return items.map((r, idx) => ({ kind: "item" as const, key: `i${r.id}`, r, idx, seq: idx + 1 }));
+    }
+    const out: RenderEntry[] = [];
+    let seq = 0;
+    for (const g of poGroups) {
+      out.push({ kind: "group", key: `g${g.po?.id ?? "none"}`, group: g });
+      for (const { r, idx } of g.rows) {
+        seq += 1;
+        out.push({ kind: "item", key: `i${r.id}`, r, idx, seq });
+      }
+    }
+    return out;
+  }, [groupByPo, hasPos, items, poGroups]);
+
+  const colCount = hasPos ? 12 : 11;
+  // 實際生效的分組（沒拆過 PO 時就算勾了也不分組）
+  const grouped = groupByPo && hasPos;
 
   function patchItem(idx: number, patch: Partial<ItemRow>) {
     setItems((cur) =>
@@ -732,6 +801,7 @@ function PageContent() {
                   0
                 )}
               </Row>
+              {hasPos && <Row label={PO_TERM_ZH}>{derivedPOs.length}</Row>}
               <div className="my-2 border-t border-zinc-200 dark:border-zinc-700" />
               <Row label="總計">
                 <span className="text-lg font-semibold text-blue-600 dark:text-blue-400">
@@ -823,11 +893,24 @@ function PageContent() {
 
         {/* 右側採購清單 */}
         <div className="flex flex-col rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
-          <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
             <h3 className="text-sm font-semibold">📋 內部採購清單</h3>
-            <span className="text-xs text-zinc-500">
-              *成本=廠商給的價格，售價=ERP 商品價格
-            </span>
+            <div className="flex items-center gap-3">
+              {hasPos && (
+                <label className="flex cursor-pointer items-center gap-1.5 text-xs text-zinc-600 dark:text-zinc-300">
+                  <input
+                    type="checkbox"
+                    checked={groupByPo}
+                    onChange={(e) => setGroupByPo(e.target.checked)}
+                    className="h-3.5 w-3.5 accent-blue-600"
+                  />
+                  依{PO_TERM_ZH}分組（{derivedPOs.length} 張）
+                </label>
+              )}
+              <span className="text-xs text-zinc-500">
+                *成本=廠商給的價格，售價=ERP 商品價格
+              </span>
+            </div>
           </div>
           {editable && items.length > 0 && (
             <div className="flex flex-wrap items-end gap-2 border-b border-zinc-200 bg-zinc-50 px-4 py-2 dark:border-zinc-800 dark:bg-zinc-900/50">
@@ -892,6 +975,7 @@ function PageContent() {
             <tr>
               <Th>#</Th>
               <Th>品名</Th>
+              {hasPos && <Th>{PO_TERM_ZH}</Th>}
               <Th>供應商</Th>
               <Th>單位</Th>
               <Th className="text-right">已採購</Th>
@@ -906,7 +990,7 @@ function PageContent() {
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {items.length === 0 ? (
               <tr>
-                <td colSpan={11} className="p-6 text-center text-zinc-500">
+                <td colSpan={colCount} className="p-6 text-center text-zinc-500">
                   {header?.source_type === "manual" ? (
                     <div className="space-y-1">
                       <div>無品項</div>
@@ -920,7 +1004,44 @@ function PageContent() {
                 </td>
               </tr>
             ) : (
-              items.map((r, idx) => {
+              displayRows.map((entry) => {
+                if (entry.kind === "group") {
+                  const g = entry.group;
+                  const sub = g.rows.reduce((s, x) => s + x.r.qty_requested * x.r.unit_cost, 0);
+                  // 供應商優先取 PO 上的；PO 尚未建立（未轉單組）才退回第一列的建議供應商
+                  const supId = g.po?.supplier_id ?? g.rows[0]?.r.suggested_supplier_id ?? null;
+                  const supName = supId != null ? supplierNameById.get(supId) : null;
+                  return (
+                    <tr key={entry.key} className="bg-zinc-100/80 dark:bg-zinc-800/60">
+                      <td colSpan={colCount} className="px-3 py-1.5">
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+                          {g.po ? (
+                            <>
+                              <Link
+                                href={`/purchase/orders/edit?id=${g.po.id}`}
+                                className="font-mono text-sm font-semibold text-blue-600 hover:underline dark:text-blue-400"
+                              >
+                                📦 {g.po.po_no}
+                              </Link>
+                              <span className="rounded bg-white px-1.5 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-900 dark:text-zinc-300">
+                                {poStatusLabel(g.po.status)}
+                              </span>
+                            </>
+                          ) : (
+                            <span className="text-sm font-semibold text-zinc-500">
+                              尚未轉{PO_TERM_ZH}
+                            </span>
+                          )}
+                          <span className="text-zinc-600 dark:text-zinc-300">{supName ?? "—"}</span>
+                          <span className="text-zinc-500">{g.rows.length} 項</span>
+                          <span className="font-mono text-zinc-500">${sub.toFixed(0)}</span>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                }
+                const { r, idx, seq } = entry;
+                const rowPo = r.po_id != null ? poById.get(r.po_id) ?? null : null;
                 // 成本 ≤ 分店價 < 售價 必須遞增，三值有任一缺則不檢查（送審前才擋）
                 const cost = Number(r.unit_cost);
                 const branch = r.franchise_price != null ? Number(r.franchise_price) : null;
@@ -931,8 +1052,8 @@ function PageContent() {
                   ? "border-rose-400 bg-rose-50 dark:border-rose-700 dark:bg-rose-950"
                   : "border-zinc-300 dark:border-zinc-700";
                 return (
-                <tr key={r.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
-                  <Td className="text-zinc-500">{idx + 1}</Td>
+                <tr key={entry.key} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
+                  <Td className="text-zinc-500">{seq}</Td>
                   <Td>
                     <div>{r.product_name}{r.variant_name ? `-${r.variant_name}` : ""}</div>
                     <div className="font-mono text-xs text-zinc-500">{r.sku_code}</div>
@@ -942,6 +1063,32 @@ function PageContent() {
                       </div>
                     )}
                   </Td>
+                  {hasPos && (
+                    <Td>
+                      {rowPo ? (
+                        <>
+                          <Link
+                            href={`/purchase/orders/edit?id=${rowPo.id}`}
+                            className={`font-mono text-xs hover:underline ${
+                              grouped
+                                ? "text-zinc-400 dark:text-zinc-500"
+                                : "text-blue-600 dark:text-blue-400"
+                            }`}
+                          >
+                            {rowPo.po_no}
+                          </Link>
+                          {/* 分組時狀態已在群組標題列，不重複 */}
+                          {!grouped && (
+                            <div className="text-[11px] text-zinc-500">
+                              {poStatusLabel(rowPo.status)}
+                            </div>
+                          )}
+                        </>
+                      ) : (
+                        <span className="text-xs text-zinc-400">未轉單</span>
+                      )}
+                    </Td>
+                  )}
                   <Td>
                     {editable ? (
                       <SupplierPicker

--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -61,13 +61,17 @@ type ItemRow = {
   dirty: boolean;
 };
 
-// 依 PO 分組後的清單；rows 帶 idx 是為了讓 patchItem / removeItem 仍能吃到
+// 依廠商分組後的清單；rows 帶 idx 是為了讓 patchItem / removeItem 仍能吃到
 // items 陣列的原始 index（分組只是顯示層的重排，不改 state 結構）
-type PoGroup = { po: DerivedPO | null; rows: { r: ItemRow; idx: number }[] };
+type SupplierGroup = {
+  supplier_id: number | null;
+  supplier_name: string;
+  rows: { r: ItemRow; idx: number }[];
+};
 
 // 表格渲染序列的元素：分組標題列或品項列
 type RenderEntry =
-  | { kind: "group"; key: string; group: PoGroup }
+  | { kind: "group"; key: string; group: SupplierGroup }
   | { kind: "item"; key: string; r: ItemRow; idx: number; seq: number };
 
 const STATUS_LABEL = prStatusLabel;
@@ -111,8 +115,9 @@ function PageContent() {
   const [bulkCost, setBulkCost] = useState<string>("");
   const [bulkBranch, setBulkBranch] = useState<string>("");
   const [bulkRetail, setBulkRetail] = useState<string>("");
-  // 品項清單是否依「拆出的採購單」分組顯示（拆過 PO 才有意義，預設開）
-  const [groupByPo, setGroupByPo] = useState(true);
+  // 品項清單是否依廠商分組。null = 交給下面的預設規則：草稿不分組（指派供應商時
+  // 該列會立刻跳到別組、很難連續作業），已送審／已轉單則預設分組。
+  const [groupBySupplier, setGroupBySupplier] = useState<boolean | null>(null);
 
   useEffect(() => {
     if (!id) {
@@ -405,6 +410,8 @@ function PageContent() {
     header?.status === "submitted" ||
     header?.status === "cancelled";
 
+  const grouped = groupBySupplier ?? !editable;
+
   const totals = useMemo(() => {
     const subtotal = items.reduce((s, r) => s + r.qty_requested * r.unit_cost, 0);
     return { subtotal };
@@ -417,50 +424,53 @@ function PageContent() {
     () => new Map(suppliers.map((s) => [s.id, s.name])),
     [suppliers],
   );
-  // 已拆出 PO 才顯示「採購單」欄與分組
+  // 已拆出 PO 才顯示「採購單」欄
   const hasPos = derivedPOs.length > 0;
 
-  // 依 PO 分組：有 PO 的照 po_no 排在前，未拆單的一組排最後
-  const poGroups: PoGroup[] = useMemo(() => {
-    const map = new Map<number | null, PoGroup>();
+  // 依廠商分組（PO 本來就是一家廠商一張，所以同組通常也就是同一張 PO）；
+  // 未指派供應商的一組固定排最後，方便草稿階段一眼看到還缺誰。
+  const supplierGroups: SupplierGroup[] = useMemo(() => {
+    const map = new Map<number | null, SupplierGroup>();
     items.forEach((r, idx) => {
-      const key = r.po_id ?? null;
+      const key = r.suggested_supplier_id ?? null;
       let g = map.get(key);
       if (!g) {
-        g = { po: key === null ? null : poById.get(key) ?? null, rows: [] };
+        g = {
+          supplier_id: key,
+          supplier_name:
+            key === null ? "未指派供應商" : supplierNameById.get(key) ?? `#${key}`,
+          rows: [],
+        };
         map.set(key, g);
       }
       g.rows.push({ r, idx });
     });
     return Array.from(map.values()).sort((a, b) => {
-      if (!a.po && !b.po) return 0;
-      if (!a.po) return 1;
-      if (!b.po) return -1;
-      return a.po.po_no.localeCompare(b.po.po_no, undefined, { numeric: true });
+      if (a.supplier_id === null) return 1;
+      if (b.supplier_id === null) return -1;
+      return pinyinCollator.compare(a.supplier_name, b.supplier_name);
     });
-  }, [items, poById]);
+  }, [items, supplierNameById]);
 
   // 攤平成「分組標題列 + 品項列」的渲染序列；關掉分組時就是原本的平鋪順序。
   // seq 是畫面上的連續序號（跨組不重來），idx 仍是 items 的原始 index。
   const displayRows: RenderEntry[] = useMemo(() => {
-    if (!groupByPo || !hasPos) {
+    if (!grouped) {
       return items.map((r, idx) => ({ kind: "item" as const, key: `i${r.id}`, r, idx, seq: idx + 1 }));
     }
     const out: RenderEntry[] = [];
     let seq = 0;
-    for (const g of poGroups) {
-      out.push({ kind: "group", key: `g${g.po?.id ?? "none"}`, group: g });
+    for (const g of supplierGroups) {
+      out.push({ kind: "group", key: `g${g.supplier_id ?? "none"}`, group: g });
       for (const { r, idx } of g.rows) {
         seq += 1;
         out.push({ kind: "item", key: `i${r.id}`, r, idx, seq });
       }
     }
     return out;
-  }, [groupByPo, hasPos, items, poGroups]);
+  }, [grouped, items, supplierGroups]);
 
   const colCount = hasPos ? 12 : 11;
-  // 實際生效的分組（沒拆過 PO 時就算勾了也不分組）
-  const grouped = groupByPo && hasPos;
 
   function patchItem(idx: number, patch: Partial<ItemRow>) {
     setItems((cur) =>
@@ -896,15 +906,15 @@ function PageContent() {
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
             <h3 className="text-sm font-semibold">📋 內部採購清單</h3>
             <div className="flex items-center gap-3">
-              {hasPos && (
+              {items.length > 0 && (
                 <label className="flex cursor-pointer items-center gap-1.5 text-xs text-zinc-600 dark:text-zinc-300">
                   <input
                     type="checkbox"
-                    checked={groupByPo}
-                    onChange={(e) => setGroupByPo(e.target.checked)}
+                    checked={grouped}
+                    onChange={(e) => setGroupBySupplier(e.target.checked)}
                     className="h-3.5 w-3.5 accent-blue-600"
                   />
-                  依{PO_TERM_ZH}分組（{derivedPOs.length} 張）
+                  依廠商分組（{supplierGroups.length} 家）
                 </label>
               )}
               <span className="text-xs text-zinc-500">
@@ -1008,33 +1018,45 @@ function PageContent() {
                 if (entry.kind === "group") {
                   const g = entry.group;
                   const sub = g.rows.reduce((s, x) => s + x.r.qty_requested * x.r.unit_cost, 0);
-                  // 供應商優先取 PO 上的；PO 尚未建立（未轉單組）才退回第一列的建議供應商
-                  const supId = g.po?.supplier_id ?? g.rows[0]?.r.suggested_supplier_id ?? null;
-                  const supName = supId != null ? supplierNameById.get(supId) : null;
+                  const qty = g.rows.reduce((s, x) => s + x.r.qty_requested, 0);
+                  // 這家廠商的品項落在哪幾張 PO（一家通常一張，補單時可能多張）
+                  const groupPos = Array.from(
+                    new Map(
+                      g.rows
+                        .map((x) => (x.r.po_id != null ? poById.get(x.r.po_id) : null))
+                        .filter((p): p is DerivedPO => !!p)
+                        .map((p) => [p.id, p]),
+                    ).values(),
+                  ).sort((a, b) => a.po_no.localeCompare(b.po_no, undefined, { numeric: true }));
                   return (
                     <tr key={entry.key} className="bg-zinc-100/80 dark:bg-zinc-800/60">
                       <td colSpan={colCount} className="px-3 py-1.5">
                         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-                          {g.po ? (
-                            <>
+                          <span
+                            className={`text-sm font-semibold ${
+                              g.supplier_id === null
+                                ? "text-red-600 dark:text-red-400"
+                                : "text-zinc-800 dark:text-zinc-100"
+                            }`}
+                          >
+                            🏭 {g.supplier_name}
+                          </span>
+                          <span className="text-zinc-500">{g.rows.length} 項</span>
+                          <span className="font-mono text-zinc-500">數量 {qty}</span>
+                          <span className="font-mono text-zinc-500">${sub.toFixed(0)}</span>
+                          {groupPos.map((p) => (
+                            <span key={p.id} className="inline-flex items-center gap-1">
                               <Link
-                                href={`/purchase/orders/edit?id=${g.po.id}`}
-                                className="font-mono text-sm font-semibold text-blue-600 hover:underline dark:text-blue-400"
+                                href={`/purchase/orders/edit?id=${p.id}`}
+                                className="font-mono text-blue-600 hover:underline dark:text-blue-400"
                               >
-                                📦 {g.po.po_no}
+                                📦 {p.po_no}
                               </Link>
                               <span className="rounded bg-white px-1.5 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-900 dark:text-zinc-300">
-                                {poStatusLabel(g.po.status)}
+                                {poStatusLabel(p.status)}
                               </span>
-                            </>
-                          ) : (
-                            <span className="text-sm font-semibold text-zinc-500">
-                              尚未轉{PO_TERM_ZH}
                             </span>
-                          )}
-                          <span className="text-zinc-600 dark:text-zinc-300">{supName ?? "—"}</span>
-                          <span className="text-zinc-500">{g.rows.length} 項</span>
-                          <span className="font-mono text-zinc-500">${sub.toFixed(0)}</span>
+                          ))}
                         </div>
                       </td>
                     </tr>

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
+import { fetchAllRows } from "@/lib/fetchAllRows";
 import SpinButton from "@/components/SpinButton";
 import { RowAction } from "@/components/RowAction";
 import Spinner, { LoadingBlock } from "@/components/Spinner";
@@ -14,6 +15,7 @@ import {
   type PRStatus,
   type PRReviewStatus,
 } from "@/lib/prStatus";
+import { PO_TERM_ZH } from "@/lib/poStatus";
 
 const PAGE_SIZE = 20;
 
@@ -67,6 +69,39 @@ type ClosedCampaignRow = {
 };
 
 type StatusTab = "all" | PRStatus;
+
+// === 樞紐（依廠商彙整品項）===
+// 每一列是「某張 PR 的某個品項」，扁平化後在前端 group by 廠商 → SKU。
+type PivotItem = {
+  pr_id: number;
+  pr_no: string;
+  supplier_id: number | null;
+  supplier_name: string | null;
+  sku_id: number;
+  sku_label: string;
+  qty: number;
+  amount: number;
+  ordered: boolean; // 已轉成 PO 品項
+};
+
+// prs: pr_id -> pr_no（保留 id 讓來源 PR 可連回詳細頁）
+type PivotSkuAgg = {
+  sku_id: number;
+  label: string;
+  qty: number;
+  orderedQty: number;
+  amount: number;
+  prs: Map<number, string>;
+};
+type PivotGroup = {
+  supplier_id: number | null;
+  supplier_name: string;
+  skus: PivotSkuAgg[];
+  qty: number;
+  orderedQty: number;
+  amount: number;
+  prCount: number;
+};
 
 const STATUS_LABEL = PR_STATUS_LABEL;
 const REVIEW_LABEL = PR_REVIEW_LABEL;
@@ -149,6 +184,19 @@ export default function PurchaseRequestsListPage() {
     new Map(),
   );
 
+  // 檢視模式：清單（原本）/ 樞紐（把篩選出的 PR 品項依廠商彙整）
+  const [viewMode, setViewMode] = useState<"list" | "pivot">("list");
+  // 樞紐子篩選：全部品項 / 只看還沒轉成 PO 的品項（＝還要去跟廠商下單的量）
+  const [pivotOnlyUnordered, setPivotOnlyUnordered] = useState(false);
+  // 樞紐資料連同抓取當下的 reloadTick 一起存，tick 對不上就是過期 → 重撈。
+  // （用「資料自帶版本」取代 effect 裡同步 setState 清快取 / 開 loading）
+  const [pivotData, setPivotData] = useState<{ tick: number; list: PivotItem[] } | null>(
+    null,
+  );
+  const pivotReady = pivotData !== null && pivotData.tick === reloadTick;
+  const pivotItems = pivotReady ? pivotData.list : null;
+  const pivotLoading = viewMode === "pivot" && !pivotReady;
+
   // ============== 載入既有 PRs ==============
   useEffect(() => {
     let cancelled = false;
@@ -207,6 +255,118 @@ export default function PurchaseRequestsListPage() {
       cancelled = true;
     };
   }, [reloadTick]);
+
+  // ============== 樞紐資料（lazy）==============
+  // 切到樞紐才撈一次：所有未作廢 PR 的品項 + SKU 標籤 + 廠商名。
+  // 篩選（頁籤 / 搜尋 / 日期…）一律在前端套用，打字搜尋不會重打 API。
+  // 重入保護靠 pivotReady：抓取期間它維持 false 但依賴陣列不變，所以不會
+  // 重複發查詢；抓完（或失敗塞空陣列）才翻成 true 離開這個 effect。
+  useEffect(() => {
+    if (viewMode !== "pivot" || pivotReady || !rows) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const chunk = <T,>(arr: T[], n: number): T[][] => {
+          const out: T[][] = [];
+          for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
+          return out;
+        };
+        const targetPrs = rows.filter((r) => r.status !== "cancelled");
+        const prMeta = new Map(targetPrs.map((r) => [r.id, r]));
+        const prIds = targetPrs.map((r) => r.id);
+        if (prIds.length === 0) {
+          if (!cancelled) setPivotData({ tick: reloadTick, list: [] });
+          return;
+        }
+
+        type PrItemRow = {
+          pr_id: number;
+          sku_id: number;
+          qty_requested: number;
+          unit_cost: number;
+          suggested_supplier_id: number | null;
+          po_item_id: number | null;
+        };
+        // fetchAllRows 分頁：PR 品項很容易破 PostgREST 的 1000 列上限
+        const itemRows: PrItemRow[] = [];
+        for (const c of chunk(prIds, 200)) {
+          const part = await fetchAllRows<PrItemRow>(() =>
+            sb
+              .from("purchase_request_items")
+              .select(
+                "id, pr_id, sku_id, qty_requested, unit_cost, suggested_supplier_id, po_item_id",
+              )
+              .in("pr_id", c)
+              .order("id", { ascending: true }),
+          );
+          itemRows.push(...part);
+        }
+
+        // SKU 標籤
+        const skuIds = Array.from(new Set(itemRows.map((r) => r.sku_id)));
+        const skuLabel = new Map<number, string>();
+        for (const c of chunk(skuIds, 300)) {
+          const { data } = await sb
+            .from("skus")
+            .select("id, sku_code, variant_name, products!inner(name)")
+            .in("id", c);
+          type SkuLite = {
+            id: number;
+            sku_code: string | null;
+            variant_name: string | null;
+            products: { name: string } | { name: string }[] | null;
+          };
+          for (const s of (data as SkuLite[] | null) ?? []) {
+            const prod = Array.isArray(s.products) ? s.products[0] : s.products;
+            const base = prod?.name ?? s.sku_code ?? `#${s.id}`;
+            skuLabel.set(s.id, s.variant_name ? `${base} / ${s.variant_name}` : base);
+          }
+        }
+
+        // 廠商名
+        const supName = new Map<number, string>();
+        {
+          const { data } = await sb.from("suppliers").select("id, name");
+          for (const s of ((data ?? []) as { id: number; name: string }[])) {
+            supName.set(s.id, s.name);
+          }
+        }
+
+        // 查不到對應 PR 的品項直接略過（例：撈到一半那張 PR 被作廢 / 刪掉），
+        // 不要用 non-null assertion — 一個孤兒列就會讓整個樞紐炸成空白。
+        const list: PivotItem[] = itemRows.flatMap((r) => {
+          const pr = prMeta.get(r.pr_id);
+          if (!pr) return [];
+          const qty = Number(r.qty_requested) || 0;
+          return [{
+            pr_id: r.pr_id,
+            pr_no: pr.pr_no,
+            supplier_id: r.suggested_supplier_id,
+            supplier_name:
+              r.suggested_supplier_id !== null
+                ? supName.get(r.suggested_supplier_id) ?? null
+                : null,
+            sku_id: r.sku_id,
+            sku_label: skuLabel.get(r.sku_id) ?? `#${r.sku_id}`,
+            qty,
+            amount: qty * (Number(r.unit_cost) || 0),
+            ordered: r.po_item_id !== null,
+          }];
+        });
+        if (!cancelled) setPivotData({ tick: reloadTick, list });
+      } catch (e) {
+        // 設成空陣列避免「載入中」卡死；錯誤原因由上方 error banner 呈現。
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e));
+          setPivotData({ tick: reloadTick, list: [] });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [viewMode, pivotReady, rows, reloadTick]);
 
   // ============== 載入「結單日待開單」cards ==============
   useEffect(() => {
@@ -721,6 +881,84 @@ export default function PurchaseRequestsListPage() {
       .map(([k, v]) => ({ key: k, ...v }));
   }, [pageRows, groupBy]);
 
+  // 樞紐分組：依廠商 → SKU 彙整（請購量 / 已轉單 / 未轉單 / 金額）。
+  // 只納入目前篩選結果（filtered）裡的 PR，所以頁籤、搜尋、日期都自然生效。
+  const pivotGroups: PivotGroup[] = useMemo(() => {
+    if (!pivotItems) return [];
+    const visiblePrIds = new Set(filtered.map((r) => r.id));
+    const q = search.trim().toLowerCase();
+    const bySup = new Map<
+      number | null,
+      {
+        supplier_id: number | null;
+        supplier_name: string;
+        skus: Map<number, PivotSkuAgg>;
+        prIds: Set<number>;
+      }
+    >();
+    for (const it of pivotItems) {
+      if (!visiblePrIds.has(it.pr_id)) continue;
+      if (pivotOnlyUnordered && it.ordered) continue;
+      // filtered 只比對過 PR 單號 / 備註，樞紐再多讓廠商、品名也能命中
+      if (q) {
+        const hit = [it.pr_no, it.supplier_name, it.sku_label]
+          .filter((x): x is string => !!x)
+          .some((x) => x.toLowerCase().includes(q));
+        if (!hit) continue;
+      }
+      let sup = bySup.get(it.supplier_id);
+      if (!sup) {
+        sup = {
+          supplier_id: it.supplier_id,
+          supplier_name:
+            it.supplier_name ??
+            (it.supplier_id === null ? "未指派供應商" : `#${it.supplier_id}`),
+          skus: new Map(),
+          prIds: new Set(),
+        };
+        bySup.set(it.supplier_id, sup);
+      }
+      sup.prIds.add(it.pr_id);
+      let sk = sup.skus.get(it.sku_id);
+      if (!sk) {
+        sk = {
+          sku_id: it.sku_id,
+          label: it.sku_label,
+          qty: 0,
+          orderedQty: 0,
+          amount: 0,
+          prs: new Map(),
+        };
+        sup.skus.set(it.sku_id, sk);
+      }
+      sk.qty += it.qty;
+      if (it.ordered) sk.orderedQty += it.qty;
+      sk.amount += it.amount;
+      sk.prs.set(it.pr_id, it.pr_no);
+    }
+    return Array.from(bySup.values())
+      .map((sup) => {
+        const skus = Array.from(sup.skus.values()).sort((a, b) =>
+          a.label.localeCompare(b.label),
+        );
+        return {
+          supplier_id: sup.supplier_id,
+          supplier_name: sup.supplier_name,
+          skus,
+          qty: skus.reduce((s, r) => s + r.qty, 0),
+          orderedQty: skus.reduce((s, r) => s + r.orderedQty, 0),
+          amount: skus.reduce((s, r) => s + r.amount, 0),
+          prCount: sup.prIds.size,
+        };
+      })
+      .sort((a, b) => {
+        // 未指派供應商排最前面（最需要處理）
+        if (a.supplier_id === null) return -1;
+        if (b.supplier_id === null) return 1;
+        return a.supplier_name.localeCompare(b.supplier_name);
+      });
+  }, [pivotItems, filtered, search, pivotOnlyUnordered]);
+
   function setSort(col: SortCol) {
     if (sortBy === col) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
     else {
@@ -903,6 +1141,40 @@ export default function PurchaseRequestsListPage() {
         </section>
       )}
 
+      {/* === 檢視切換：清單 / 樞紐 === */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="inline-flex rounded-md border border-zinc-300 p-0.5 dark:border-zinc-700">
+          <SpinButton
+            onClick={() => setViewMode("list")}
+            className={`rounded px-3 py-1 text-sm ${viewMode === "list" ? "bg-blue-600 font-semibold text-white" : "text-zinc-600 dark:text-zinc-300"}`}
+          >
+            清單
+          </SpinButton>
+          <SpinButton
+            onClick={() => setViewMode("pivot")}
+            className={`rounded px-3 py-1 text-sm ${viewMode === "pivot" ? "bg-blue-600 font-semibold text-white" : "text-zinc-600 dark:text-zinc-300"}`}
+          >
+            樞紐（依廠商）
+          </SpinButton>
+        </div>
+        {viewMode === "pivot" && (
+          <>
+            <label className="flex cursor-pointer items-center gap-1.5 text-sm text-zinc-600 dark:text-zinc-300">
+              <input
+                type="checkbox"
+                checked={pivotOnlyUnordered}
+                onChange={(e) => setPivotOnlyUnordered(e.target.checked)}
+                className="h-3.5 w-3.5 accent-amber-500"
+              />
+              只看未轉{PO_TERM_ZH}的品項
+            </label>
+            <span className="text-xs text-zinc-400">
+              彙整範圍＝目前篩選出的 {total} 張{PR_TERM_ZH}（不含已作廢）
+            </span>
+          </>
+        )}
+      </div>
+
       {/* === 狀態 tabs === */}
       <div className="flex flex-wrap gap-1 border-b border-zinc-200 dark:border-zinc-800">
         {STATUS_TAB_ORDER.map((s) => {
@@ -1009,7 +1281,12 @@ export default function PurchaseRequestsListPage() {
         </span>
       </div>
 
+      {viewMode === "pivot" && (
+        <PrPivot groups={pivotGroups} loading={pivotLoading} onlyUnordered={pivotOnlyUnordered} />
+      )}
+
       {/* === 主表格 === */}
+      {viewMode === "list" && (
       <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
@@ -1109,9 +1386,10 @@ export default function PurchaseRequestsListPage() {
           </tbody>
         </table>
       </div>
+      )}
 
       {/* === 分頁 === */}
-      {total > PAGE_SIZE && (
+      {viewMode === "list" && total > PAGE_SIZE && (
         <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
           <span className="text-xs text-zinc-500">
             共 {total} 筆 · 顯示 {(page - 1) * PAGE_SIZE + 1} -{" "}
@@ -1323,6 +1601,173 @@ function KpiCard({
       <div className={`mt-0.5 text-2xl font-semibold ${accent}`}>{value}</div>
       {hint && <div className="mt-0.5 text-[10px] text-zinc-400">{hint}</div>}
     </Wrapper>
+  );
+}
+
+// 樞紐：依廠商彙整篩選範圍內所有 PR 的品項，一家一張卡片。
+function PrPivot({
+  groups,
+  loading,
+  onlyUnordered,
+}: {
+  groups: PivotGroup[];
+  loading: boolean;
+  onlyUnordered: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
+        載入樞紐資料中…
+      </div>
+    );
+  }
+  if (groups.length === 0) {
+    return (
+      <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
+        {onlyUnordered
+          ? `目前篩選範圍內沒有「尚未轉${PO_TERM_ZH}」的品項。`
+          : "目前篩選範圍內沒有品項。"}
+      </div>
+    );
+  }
+  const totQty = groups.reduce((s, g) => s + g.qty, 0);
+  const totOrdered = groups.reduce((s, g) => s + g.orderedQty, 0);
+  const totAmount = groups.reduce((s, g) => s + g.amount, 0);
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="text-xs text-zinc-500">
+        {groups.length} 家廠商 · 請購合計 {totQty} · 已轉單 {totOrdered} · 未轉單{" "}
+        {totQty - totOrdered} · 金額 ${Math.round(totAmount).toLocaleString()}
+      </div>
+      {groups.map((g) => {
+        const outstanding = g.qty - g.orderedQty;
+        return (
+          <div
+            key={g.supplier_id ?? "none"}
+            className="overflow-hidden rounded-md border border-zinc-200 dark:border-zinc-800"
+          >
+            <div className="flex flex-wrap items-baseline justify-between gap-2 bg-zinc-50 px-3 py-2 dark:bg-zinc-900">
+              <div
+                className={`font-semibold ${
+                  g.supplier_id === null ? "text-red-600 dark:text-red-400" : ""
+                }`}
+              >
+                {g.supplier_name}
+                <span className="ml-2 text-xs font-normal text-zinc-500">
+                  {g.prCount} 張 {PR_TERM_ZH} · {g.skus.length} 品項
+                </span>
+              </div>
+              <div className="text-xs text-zinc-500">
+                請購 {g.qty} · 已轉單 {g.orderedQty} ·{" "}
+                <span className={outstanding > 0 ? "text-amber-600 dark:text-amber-400" : ""}>
+                  未轉單 {outstanding}
+                </span>{" "}
+                · <span className="font-mono">${Math.round(g.amount).toLocaleString()}</span>
+              </div>
+            </div>
+
+            {/* 桌機：表格 */}
+            <div className="hidden overflow-x-auto sm:block">
+              <table className="min-w-full text-sm">
+                <thead className="text-xs text-zinc-500">
+                  <tr className="border-b border-zinc-200 dark:border-zinc-800">
+                    <th className="px-3 py-1.5 text-left font-medium">品項</th>
+                    <th className="px-3 py-1.5 text-right font-medium">請購</th>
+                    <th className="px-3 py-1.5 text-right font-medium">已轉單</th>
+                    <th className="px-3 py-1.5 text-right font-medium">未轉單</th>
+                    <th className="px-3 py-1.5 text-right font-medium">金額</th>
+                    <th className="px-3 py-1.5 text-left font-medium">來源 {PR_TERM_ZH}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {g.skus.map((s) => {
+                    const left = s.qty - s.orderedQty;
+                    return (
+                      <tr key={s.sku_id} className="border-b border-zinc-100 dark:border-zinc-800/60">
+                        <td className="px-3 py-1.5">{s.label}</td>
+                        <td className="px-3 py-1.5 text-right font-mono">{s.qty}</td>
+                        <td className="px-3 py-1.5 text-right font-mono">{s.orderedQty}</td>
+                        <td
+                          className={`px-3 py-1.5 text-right font-mono ${
+                            left > 0 ? "text-amber-600 dark:text-amber-400" : "text-zinc-400"
+                          }`}
+                        >
+                          {left}
+                        </td>
+                        <td className="px-3 py-1.5 text-right font-mono">
+                          ${Math.round(s.amount).toLocaleString()}
+                        </td>
+                        <td className="px-3 py-1.5 font-mono text-xs">
+                          <PrLinks prs={s.prs} />
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            {/* 手機：每個品項一張堆疊卡片 */}
+            <ul className="divide-y divide-zinc-100 sm:hidden dark:divide-zinc-800/60">
+              {g.skus.map((s) => {
+                const left = s.qty - s.orderedQty;
+                return (
+                  <li key={s.sku_id} className="px-3 py-2">
+                    <div className="text-sm">{s.label}</div>
+                    <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-0.5 text-xs text-zinc-500">
+                      <span>
+                        請購{" "}
+                        <span className="font-mono text-zinc-800 dark:text-zinc-200">{s.qty}</span>
+                      </span>
+                      <span>
+                        已轉單{" "}
+                        <span className="font-mono text-zinc-800 dark:text-zinc-200">
+                          {s.orderedQty}
+                        </span>
+                      </span>
+                      <span>
+                        未轉單{" "}
+                        <span
+                          className={`font-mono ${
+                            left > 0 ? "text-amber-600 dark:text-amber-400" : "text-zinc-400"
+                          }`}
+                        >
+                          {left}
+                        </span>
+                      </span>
+                      <span className="font-mono">${Math.round(s.amount).toLocaleString()}</span>
+                    </div>
+                    <div className="mt-0.5 font-mono text-[11px] text-zinc-400">
+                      {PR_TERM_ZH} <PrLinks prs={s.prs} />
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// 樞紐裡的來源 PR 單號清單：每個單號連到 PR 詳細頁
+function PrLinks({ prs }: { prs: Map<number, string> }) {
+  const entries = Array.from(prs.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+  return (
+    <>
+      {entries.map(([id, no], i) => (
+        <span key={id}>
+          {i > 0 && <span className="text-zinc-400">、</span>}
+          <Link
+            href={`/purchase/requests/edit?id=${id}`}
+            className="text-blue-600 hover:underline dark:text-blue-400"
+          >
+            {no}
+          </Link>
+        </span>
+      ))}
+    </>
   );
 }
 


### PR DESCRIPTION
請購單編輯頁只在 timeline 上列出「14 張 PO：PO...537, PO...538, ...」，
看不出哪一列品項被拆進哪一張採購單。48 項 / 14 張 PO 時完全無法對照。

- purchase_request_items 反查 PO 時多帶 po_item_id → po_id 的對應，
  讓每一列 ItemRow 帶上自己的 po_id（原本只用來湊出 PO 清單就丟掉）
- 清單新增「採購單」欄（已拆單才出現），點 PO 號可直接跳到該採購單
- 新增「依採購單分組」開關（預設開）：以 PO 為群組標題列，顯示
  PO 號 / 狀態 / 供應商 / 項數 / 該組小計；未拆單的品項歸到
  「尚未轉採購單」並排在最後
- 分組時列內的 PO 號轉為淡色且不重複顯示狀態，避免與群組標題重覆
- 摘要卡片加上「採購單」張數

分組只是顯示層重排：群組內仍保留 items 的原始 index，
patchItem / removeItem 行為不變（草稿仍可正常編輯、刪列）。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DDr81d3BAsjEUNj2bwch5J