### PR TITLE
請購單依廠商分組 + 樞紐檢視，採購單／請購單列表改 server-side

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/page.tsx
@@ -107,11 +107,26 @@ const PAGE_SIZE = 30;
 
 type SortCol = "updated_at" | "expected_date" | "total" | "po_no" | "supplier";
 
+// rpc_po_list 的回傳形狀（server-side 篩選 / 排序 / 分頁）
+type ListResp = {
+  total: number;
+  counts: Record<StatusTab, number>;
+  kpi: { draft: number; pending_arrival: number; overdue: number; pending_amount: number };
+  suppliers: { id: number; name: string }[];
+  rows: PO[];
+};
+
+const EMPTY_COUNTS: Record<StatusTab, number> = {
+  all: 0, draft: 0, sent: 0, partially_received: 0, fully_received: 0, closed: 0, cancelled: 0,
+};
+
 export default function PurchaseOrdersListPage() {
-  const [pos, setPos] = useState<PO[] | null>(null);
+  const [data, setData] = useState<ListResp | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState<StatusTab>("all");
+  // search 是輸入框當下的值；dSearch 是進 DB 查詢的 debounce 值（打字不會每個字一次查詢）
   const [search, setSearch] = useState("");
+  const [dSearch, setDSearch] = useState("");
   const [supplierFilter, setSupplierFilter] = useState<number | "all">("all");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
@@ -129,163 +144,34 @@ export default function PurchaseOrdersListPage() {
   const [pivotItems, setPivotItems] = useState<PivotItem[] | null>(null);
   const [pivotLoading, setPivotLoading] = useState(false);
 
+  // 搜尋 debounce：打字停 300ms 才進 DB
+  useEffect(() => {
+    const t = setTimeout(() => setDSearch(search), 300);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  // === 清單資料：全部交給 rpc_po_list（篩選 / 排序 / 分頁 / 計數都在 DB 算）===
+  // 前端只收當頁 PAGE_SIZE 筆。原本是「全撈再前端篩」，線上 778 張時
+  // 搜舊單會搜不到（曾寫死 .limit(500)），且傳輸量隨單數線性長。
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const supabase = getSupabase();
-
-        type RawPO = {
-          id: number;
-          po_no: string;
-          supplier_id: number;
-          status: POStatus;
-          total: number;
-          expected_date: string | null;
-          sent_at: string | null;
-          sent_channel: string | null;
-          stockout_at: string | null;
-          created_at: string;
-          updated_at: string;
-          suppliers: { name: string } | { name: string }[] | null;
-        };
-        // 1. 撈 POs — 全部撈回來，篩選 / 搜尋 / KPI 都是前端算的。
-        //    原本是 .limit(500) 取最近更新的 500 張：超出的 PO 不只翻不到，
-        //    連搜單號都找不到（實測 778 張時，第 501 張之後全部搜不到），
-        //    而且狀態頁籤數字與 KPI 也會少算。改用 fetchAllRows 分頁拿完整清單。
-        //    updated_at 會有同值，補 id 當 tiebreaker 給分頁一個穩定的 total order。
-        const poData = await fetchAllRows<RawPO>(() =>
-          supabase
-            .from("purchase_orders")
-            .select(
-              "id, po_no, supplier_id, status, total, expected_date, sent_at, sent_channel, stockout_at, created_at, updated_at, suppliers(name)",
-            )
-            .order("updated_at", { ascending: false })
-            .order("id", { ascending: false }),
-        );
-        if (cancelled) return;
-
-        const baseList: PO[] = poData.map((r) => {
-          const sup = Array.isArray(r.suppliers) ? r.suppliers[0] : r.suppliers;
-          return {
-            id: r.id,
-            po_no: r.po_no,
-            supplier_id: r.supplier_id,
-            supplier_name: sup?.name ?? null,
-            status: r.status,
-            total: Number(r.total),
-            expected_date: r.expected_date,
-            sent_at: r.sent_at,
-            sent_channel: r.sent_channel,
-            stockout_at: r.stockout_at,
-            created_at: r.created_at,
-            updated_at: r.updated_at,
-            pr_id: null,
-            pr_no: null,
-            product_names: [],
-            item_count: 0,
-          };
+        const { data: resp, error: rpcErr } = await getSupabase().rpc("rpc_po_list", {
+          p_status: tab === "all" ? null : tab,
+          p_supplier_id: supplierFilter === "all" ? null : supplierFilter,
+          p_search: dSearch.trim() || null,
+          p_date_from: dateFrom || null,
+          p_date_to: dateTo || null,
+          p_sort: sortBy,
+          p_dir: sortDir,
+          p_page: page,
+          p_page_size: PAGE_SIZE,
         });
-
-        // 2. 透過 purchase_order_items + purchase_request_items 找來源 PR + 商品/品項
-        // 500 張 PO 的品項列數很容易破 PostgREST 1000 列上限，且一次 .in() 塞幾百個
-        // id 會撐爆 URL — 一律 chunk + fetchAllRows 分頁（同下方樞紐檢視的作法）。
-        const chunk = <T,>(arr: T[], n: number): T[][] => {
-          const out: T[][] = [];
-          for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
-          return out;
-        };
-        const poIds = baseList.map((p) => p.id);
-        const poToPR = new Map<number, number>();
-        const poItemMap = new Map<number, number[]>(); // po_id -> sku_ids[]
-        {
-          const poiRows: { id: number; po_id: number; sku_id: number }[] = [];
-          for (const c of chunk(poIds, 200)) {
-            const rows = await fetchAllRows<{ id: number; po_id: number; sku_id: number }>(
-              () =>
-                supabase
-                  .from("purchase_order_items")
-                  .select("id, po_id, sku_id")
-                  .in("po_id", c)
-                  .order("id", { ascending: true }),
-            );
-            poiRows.push(...rows);
-          }
-          const poiToPo = new Map<number, number>();
-          for (const r of poiRows) {
-            poiToPo.set(r.id, r.po_id);
-            if (!poItemMap.has(r.po_id)) poItemMap.set(r.po_id, []);
-            poItemMap.get(r.po_id)!.push(r.sku_id);
-          }
-          const poiIds = poiRows.map((r) => r.id);
-          for (const c of chunk(poiIds, 200)) {
-            const priRows = await fetchAllRows<{ po_item_id: number | null; pr_id: number | null }>(
-              () =>
-                supabase
-                  .from("purchase_request_items")
-                  .select("po_item_id, pr_id")
-                  .in("po_item_id", c)
-                  .order("po_item_id", { ascending: true }),
-            );
-            for (const r of priRows) {
-              const po = r.po_item_id ? poiToPo.get(r.po_item_id) : null;
-              if (po && r.pr_id) poToPR.set(po, r.pr_id);
-            }
-          }
-        }
-
-        // 3. 撈 SKU -> product name(批次)
-        const allSkuIds = Array.from(
-          new Set(Array.from(poItemMap.values()).flat()),
-        );
-        const skuToProduct = new Map<number, string>();
-        for (const c of chunk(allSkuIds, 300)) {
-          const { data: skuRows, error: skuErr } = await supabase
-            .from("skus")
-            .select("id, products!inner(name)")
-            .in("id", c);
-          if (skuErr) throw new Error(skuErr.message);
-          type SkuLite = {
-            id: number;
-            products: { name: string } | { name: string }[] | null;
-          };
-          for (const s of (skuRows as SkuLite[] | null) ?? []) {
-            const prod = Array.isArray(s.products) ? s.products[0] : s.products;
-            if (prod?.name) skuToProduct.set(s.id, prod.name);
-          }
-        }
-        for (const p of baseList) {
-          const skuIds = poItemMap.get(p.id) ?? [];
-          p.item_count = skuIds.length;
-          const nameSet = new Set<string>();
-          for (const sid of skuIds) {
-            const name = skuToProduct.get(sid);
-            if (name) nameSet.add(name);
-          }
-          p.product_names = Array.from(nameSet);
-        }
-        const prIds = Array.from(new Set(Array.from(poToPR.values())));
-        const prMap = new Map<number, string>();
-        for (const c of chunk(prIds, 200)) {
-          const { data: prRows, error: prErr } = await supabase
-            .from("purchase_requests")
-            .select("id, pr_no")
-            .in("id", c);
-          if (prErr) throw new Error(prErr.message);
-          for (const r of prRows ?? []) prMap.set(r.id, r.pr_no);
-        }
-        for (const p of baseList) {
-          const prId = poToPR.get(p.id);
-          if (prId) {
-            p.pr_id = prId;
-            p.pr_no = prMap.get(prId) ?? null;
-          }
-        }
-
-        if (!cancelled) {
-          setPos(baseList);
-          setError(null);
-        }
+        if (cancelled) return;
+        if (rpcErr) throw new Error(rpcErr.message);
+        setData(resp as ListResp);
+        setError(null);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       }
@@ -293,8 +179,7 @@ export default function PurchaseOrdersListPage() {
     return () => {
       cancelled = true;
     };
-  }, [reloadKey]);
-
+  }, [tab, supplierFilter, dSearch, dateFrom, dateTo, sortBy, sortDir, page, reloadKey]);
   // 資料重載（reloadKey 變動）→ 讓樞紐下次進去重撈
   useEffect(() => {
     setPivotItems(null);
@@ -306,7 +191,7 @@ export default function PurchaseOrdersListPage() {
   // → 進行中的查詢回來時所有 setState（含 finally 的 setPivotLoading(false)）都被 !cancelled 擋掉
   // → 樞紐永遠停在「載入中」。重入保護改由 pivotItems !== null 負責（載入完成/失敗都會離開 null）。
   useEffect(() => {
-    if (viewMode !== "pivot" || pivotItems !== null || !pos) return;
+    if (viewMode !== "pivot" || pivotItems !== null) return;
     let cancelled = false;
     setPivotLoading(true);
     (async () => {
@@ -317,11 +202,36 @@ export default function PurchaseOrdersListPage() {
           for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
           return out;
         };
-        const targetPos = pos.filter(
-          (p) => p.status === "sent" || p.status === "partially_received",
+        // 樞紐看的是「全部已下單 / 部分到貨」的 PO，不受清單分頁影響 → 自己查一次
+        type PivotPO = {
+          id: number;
+          po_no: string;
+          supplier_id: number;
+          status: POStatus;
+          suppliers: { name: string } | { name: string }[] | null;
+        };
+        const targetRows = await fetchAllRows<PivotPO>(() =>
+          sb
+            .from("purchase_orders")
+            .select("id, po_no, supplier_id, status, suppliers(name)")
+            .in("status", ["sent", "partially_received"])
+            .order("id", { ascending: true }),
         );
-        const poMeta = new Map(targetPos.map((p) => [p.id, p]));
-        const poIds = targetPos.map((p) => p.id);
+        const poMeta = new Map(
+          targetRows.map((p) => {
+            const sup = Array.isArray(p.suppliers) ? p.suppliers[0] : p.suppliers;
+            return [
+              p.id,
+              {
+                po_no: p.po_no,
+                supplier_id: p.supplier_id,
+                supplier_name: sup?.name ?? null,
+                status: p.status,
+              },
+            ] as const;
+          }),
+        );
+        const poIds = targetRows.map((p) => p.id);
         if (poIds.length === 0) {
           if (!cancelled) setPivotItems([]);
           return;
@@ -384,9 +294,11 @@ export default function PurchaseOrdersListPage() {
             skuLabel.set(s.id, s.variant_name ? `${base} / ${s.variant_name}` : base);
           }
         }
-        const items: PivotItem[] = poiRows.map((r) => {
-          const p = poMeta.get(r.po_id)!;
-          return {
+        // 查不到對應 PO 的品項直接略過，不要用 non-null assertion
+        const items: PivotItem[] = poiRows.flatMap((r) => {
+          const p = poMeta.get(r.po_id);
+          if (!p) return [];
+          return [{
             po_id: r.po_id,
             po_no: p.po_no,
             supplier_id: p.supplier_id,
@@ -396,7 +308,7 @@ export default function PurchaseOrdersListPage() {
             sku_label: skuLabel.get(r.sku_id) ?? `#${r.sku_id}`,
             ordered: Number(r.qty_ordered),
             received: recvByItem.get(r.id) ?? 0,
-          };
+          }];
         });
         if (!cancelled) setPivotItems(items);
       } catch (e) {
@@ -412,117 +324,25 @@ export default function PurchaseOrdersListPage() {
     return () => {
       cancelled = true;
     };
-  }, [viewMode, pivotItems, pos]);
+  }, [viewMode, pivotItems]);
 
-  // === KPI 統計 ===
-  const today = new Date().toISOString().slice(0, 10);
-
-  const stats = useMemo(() => {
-    const acc = {
-      draft: 0,
-      sent: 0,
-      partially_received: 0,
-      fully_received: 0,
-      closed: 0,
-      cancelled: 0,
-      overdue: 0,
-      pendingAmount: 0,
-    };
-    for (const p of pos ?? []) {
-      acc[p.status] += 1;
-      const inFlight =
-        p.status === "sent" || p.status === "partially_received";
-      if (inFlight) acc.pendingAmount += p.total;
-      if (inFlight && p.expected_date && p.expected_date < today) {
-        acc.overdue += 1;
-      }
-    }
-    return acc;
-  }, [pos, today]);
-
-  // 供應商下拉選項
-  const supplierOptions = useMemo(() => {
-    const set = new Map<number, string>();
-    for (const p of pos ?? []) {
-      if (p.supplier_id && p.supplier_name) {
-        set.set(p.supplier_id, p.supplier_name);
-      }
-    }
-    return Array.from(set.entries()).sort((a, b) => a[1].localeCompare(b[1]));
-  }, [pos]);
-
-  // tab counts
-  const tabCounts = useMemo(
-    () => ({
-      all: pos?.length ?? 0,
-      draft: stats.draft,
-      sent: stats.sent,
-      partially_received: stats.partially_received,
-      fully_received: stats.fully_received,
-      closed: stats.closed,
-      cancelled: stats.cancelled,
-    }),
-    [pos, stats],
+  // === 統計 / 選項 / 當頁資料：全部來自 rpc_po_list，前端不再自己算 ===
+  const stats = {
+    draft: data?.kpi.draft ?? 0,
+    pendingArrival: data?.kpi.pending_arrival ?? 0,
+    overdue: data?.kpi.overdue ?? 0,
+    pendingAmount: Number(data?.kpi.pending_amount ?? 0),
+  };
+  const tabCounts = data?.counts ?? EMPTY_COUNTS;
+  const supplierOptions: [number, string][] = useMemo(
+    () => (data?.suppliers ?? []).map((s) => [s.id, s.name] as [number, string]),
+    [data],
   );
-
-  // filter
-  const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    return (pos ?? []).filter((p) => {
-      if (tab !== "all" && p.status !== tab) return false;
-      if (supplierFilter !== "all" && p.supplier_id !== supplierFilter)
-        return false;
-      if (dateFrom && (p.created_at ?? "") < `${dateFrom}T00:00:00`)
-        return false;
-      if (dateTo && (p.created_at ?? "") > `${dateTo}T23:59:59.999`)
-        return false;
-      if (q) {
-        const hits = [p.po_no, p.supplier_name, p.pr_no, ...p.product_names]
-          .filter((x): x is string => !!x)
-          .some((x) => x.toLowerCase().includes(q));
-        if (!hits) return false;
-      }
-      return true;
-    });
-  }, [pos, tab, supplierFilter, dateFrom, dateTo, search]);
-
-  // sort
-  const sorted = useMemo(() => {
-    const arr = [...filtered];
-    arr.sort((a, b) => {
-      let av: string | number;
-      let bv: string | number;
-      if (sortBy === "total") {
-        av = a.total;
-        bv = b.total;
-      } else if (sortBy === "po_no") {
-        av = a.po_no;
-        bv = b.po_no;
-      } else if (sortBy === "expected_date") {
-        av = a.expected_date ?? "";
-        bv = b.expected_date ?? "";
-      } else if (sortBy === "supplier") {
-        av = a.supplier_name ?? "";
-        bv = b.supplier_name ?? "";
-      } else {
-        av = a.updated_at;
-        bv = b.updated_at;
-      }
-      if (av < bv) return sortDir === "asc" ? -1 : 1;
-      if (av > bv) return sortDir === "asc" ? 1 : -1;
-      return 0;
-    });
-    return arr;
-  }, [filtered, sortBy, sortDir]);
-
-  // 篩選變動 → 重置到第 1 頁
-  useEffect(() => {
-    setPage(1);
-  }, [tab, search, supplierFilter, dateFrom, dateTo, sortBy, sortDir, groupBy]);
-
-  const total = sorted.length;
+  // rows 已經是 DB 篩選 + 排序 + 分頁後的當前頁
+  const pageRows = useMemo(() => data?.rows ?? [], [data]);
+  const loaded = data !== null;
+  const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-  const pageRows = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   // group
   const grouped = useMemo(() => {
@@ -758,10 +578,10 @@ export default function PurchaseOrdersListPage() {
         <div>
           <h1 className="text-xl font-semibold">{PO_TERM_ZH}（PO）</h1>
           <p className="text-sm text-zinc-500">
-            {pos === null ? (
+            {!loaded ? (
               <Spinner size={14} className="inline-block align-[-2px]" />
             ) : (
-              `共 ${pos.length} 張 PO`
+              `共 ${tabCounts.all} 張 PO`
             )}
           </p>
         </div>
@@ -792,7 +612,7 @@ export default function PurchaseOrdersListPage() {
         <KpiCard
           label="待到貨"
           hint="已發送 + 部分到貨"
-          value={stats.sent + stats.partially_received}
+          value={stats.pendingArrival}
           accent="text-blue-700 dark:text-blue-400"
           active={tab === "sent" || tab === "partially_received"}
           onClick={() =>
@@ -935,7 +755,7 @@ export default function PurchaseOrdersListPage() {
           </SpinButton>
         )}
         <span className="ml-auto text-xs text-zinc-500">
-          {pos === null ? (
+          {!loaded ? (
             <Spinner size={14} className="inline-block align-[-2px]" />
           ) : (
             `符合 ${total} 筆${total > PAGE_SIZE ? ` · 第 ${page}/${totalPages} 頁` : ""}`
@@ -995,7 +815,7 @@ export default function PurchaseOrdersListPage() {
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
-            {pos === null ? (
+            {!loaded ? (
               <tr>
                 <td colSpan={10}>
                   <LoadingBlock />

--- a/apps/admin/src/app/(protected)/purchase/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/orders/page.tsx
@@ -135,17 +135,6 @@ export default function PurchaseOrdersListPage() {
       try {
         const supabase = getSupabase();
 
-        // 1. 撈 POs(拉多一點以利 KPI 計算與分頁)
-        const { data: poData, error: poErr } = await supabase
-          .from("purchase_orders")
-          .select(
-            "id, po_no, supplier_id, status, total, expected_date, sent_at, sent_channel, stockout_at, created_at, updated_at, suppliers(name)",
-          )
-          .order("updated_at", { ascending: false })
-          .limit(500);
-        if (poErr) throw new Error(poErr.message);
-        if (cancelled) return;
-
         type RawPO = {
           id: number;
           po_no: string;
@@ -160,7 +149,23 @@ export default function PurchaseOrdersListPage() {
           updated_at: string;
           suppliers: { name: string } | { name: string }[] | null;
         };
-        const baseList: PO[] = ((poData as RawPO[] | null) ?? []).map((r) => {
+        // 1. 撈 POs — 全部撈回來，篩選 / 搜尋 / KPI 都是前端算的。
+        //    原本是 .limit(500) 取最近更新的 500 張：超出的 PO 不只翻不到，
+        //    連搜單號都找不到（實測 778 張時，第 501 張之後全部搜不到），
+        //    而且狀態頁籤數字與 KPI 也會少算。改用 fetchAllRows 分頁拿完整清單。
+        //    updated_at 會有同值，補 id 當 tiebreaker 給分頁一個穩定的 total order。
+        const poData = await fetchAllRows<RawPO>(() =>
+          supabase
+            .from("purchase_orders")
+            .select(
+              "id, po_no, supplier_id, status, total, expected_date, sent_at, sent_channel, stockout_at, created_at, updated_at, suppliers(name)",
+            )
+            .order("updated_at", { ascending: false })
+            .order("id", { ascending: false }),
+        );
+        if (cancelled) return;
+
+        const baseList: PO[] = poData.map((r) => {
           const sup = Array.isArray(r.suppliers) ? r.suppliers[0] : r.suppliers;
           return {
             id: r.id,

--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -7,7 +7,7 @@ import { getSupabase } from "@/lib/supabase";
 import { PrPipelineStepper, type PrStepEvents, type POSummary, type TransferSummary } from "@/components/PrPipelineStepper";
 import SpinButton from "@/components/SpinButton";
 import { prStatusLabel, prReviewLabel, PR_TERM_ZH } from "@/lib/prStatus";
-import { PO_TERM_ZH } from "@/lib/poStatus";
+import { PO_TERM_ZH, poStatusLabel } from "@/lib/poStatus";
 
 type PRHeader = {
   id: number;
@@ -32,6 +32,7 @@ type DerivedPO = {
   id: number;
   po_no: string;
   status: string;
+  supplier_id: number | null;
   created_at: string | null;
   created_by: string | null;
   sent_at: string | null;
@@ -56,8 +57,18 @@ type ItemRow = {
   retail_price: number | null;     // PR snapshot，可手動覆寫
   franchise_price: number | null;  // PR snapshot，可手動覆寫
   purchased_so_far: number;        // 同 (campaign, sku) 在其他已通過 PR 的累積採購量
+  po_id: number | null;            // 此列被拆進哪一張 PO（未拆單為 null）
   dirty: boolean;
 };
+
+// 依 PO 分組後的清單；rows 帶 idx 是為了讓 patchItem / removeItem 仍能吃到
+// items 陣列的原始 index（分組只是顯示層的重排，不改 state 結構）
+type PoGroup = { po: DerivedPO | null; rows: { r: ItemRow; idx: number }[] };
+
+// 表格渲染序列的元素：分組標題列或品項列
+type RenderEntry =
+  | { kind: "group"; key: string; group: PoGroup }
+  | { kind: "item"; key: string; r: ItemRow; idx: number; seq: number };
 
 const STATUS_LABEL = prStatusLabel;
 const REVIEW_LABEL = prReviewLabel;
@@ -100,6 +111,8 @@ function PageContent() {
   const [bulkCost, setBulkCost] = useState<string>("");
   const [bulkBranch, setBulkBranch] = useState<string>("");
   const [bulkRetail, setBulkRetail] = useState<string>("");
+  // 品項清單是否依「拆出的採購單」分組顯示（拆過 PO 才有意義，預設開）
+  const [groupByPo, setGroupByPo] = useState(true);
 
   useEffect(() => {
     if (!id) {
@@ -153,21 +166,26 @@ function PageContent() {
         setDestLocationId(prData.source_location_id ?? locRow?.id ?? null);
 
         // 抓拆出的 PO（透過 PR items 反查）
+        // poItemToPo：po_item_id → po_id，讓每一列 PR 品項知道自己被拆進哪張 PO
+        const poItemToPo = new Map<number, number>();
         const itemIds = (itemRows ?? [])
           .map((r) => r.po_item_id)
           .filter((x): x is number => x !== null && x !== undefined);
         if (itemIds.length) {
           const { data: poiRows } = await supabase
             .from("purchase_order_items")
-            .select("po_id")
+            .select("id, po_id")
             .in("id", itemIds);
-          const poIds = Array.from(
-            new Set((poiRows ?? []).map((r) => r.po_id).filter((x): x is number => !!x)),
-          );
+          for (const r of ((poiRows ?? []) as { id: number; po_id: number | null }[])) {
+            if (r.po_id) poItemToPo.set(r.id, r.po_id);
+          }
+          const poIds = Array.from(new Set(poItemToPo.values()));
           if (poIds.length) {
             const { data: pos } = await supabase
               .from("purchase_orders")
-              .select("id, po_no, status, created_at, created_by, sent_at, sent_by, sent_channel")
+              .select(
+                "id, po_no, status, supplier_id, created_at, created_by, sent_at, sent_by, sent_channel",
+              )
               .in("id", poIds)
               .order("id");
             setDerivedPOs((pos ?? []) as DerivedPO[]);
@@ -353,6 +371,7 @@ function PageContent() {
             retail_price: retail,
             franchise_price: branch,
             purchased_so_far: purchasedMap.get(r.sku_id) ?? 0,
+            po_id: r.po_item_id ? poItemToPo.get(r.po_item_id) ?? null : null,
             // 若用了 fallback、標 dirty 讓 UI 提示「儲存後 PR 留紀錄」
             dirty: usedFallback,
           };
@@ -392,6 +411,56 @@ function PageContent() {
   }, [items]);
 
   const unassignedCount = items.filter((r) => !r.suggested_supplier_id).length;
+
+  const poById = useMemo(() => new Map(derivedPOs.map((p) => [p.id, p])), [derivedPOs]);
+  const supplierNameById = useMemo(
+    () => new Map(suppliers.map((s) => [s.id, s.name])),
+    [suppliers],
+  );
+  // 已拆出 PO 才顯示「採購單」欄與分組
+  const hasPos = derivedPOs.length > 0;
+
+  // 依 PO 分組：有 PO 的照 po_no 排在前，未拆單的一組排最後
+  const poGroups: PoGroup[] = useMemo(() => {
+    const map = new Map<number | null, PoGroup>();
+    items.forEach((r, idx) => {
+      const key = r.po_id ?? null;
+      let g = map.get(key);
+      if (!g) {
+        g = { po: key === null ? null : poById.get(key) ?? null, rows: [] };
+        map.set(key, g);
+      }
+      g.rows.push({ r, idx });
+    });
+    return Array.from(map.values()).sort((a, b) => {
+      if (!a.po && !b.po) return 0;
+      if (!a.po) return 1;
+      if (!b.po) return -1;
+      return a.po.po_no.localeCompare(b.po.po_no, undefined, { numeric: true });
+    });
+  }, [items, poById]);
+
+  // 攤平成「分組標題列 + 品項列」的渲染序列；關掉分組時就是原本的平鋪順序。
+  // seq 是畫面上的連續序號（跨組不重來），idx 仍是 items 的原始 index。
+  const displayRows: RenderEntry[] = useMemo(() => {
+    if (!groupByPo || !hasPos) {
+      return items.map((r, idx) => ({ kind: "item" as const, key: `i${r.id}`, r, idx, seq: idx + 1 }));
+    }
+    const out: RenderEntry[] = [];
+    let seq = 0;
+    for (const g of poGroups) {
+      out.push({ kind: "group", key: `g${g.po?.id ?? "none"}`, group: g });
+      for (const { r, idx } of g.rows) {
+        seq += 1;
+        out.push({ kind: "item", key: `i${r.id}`, r, idx, seq });
+      }
+    }
+    return out;
+  }, [groupByPo, hasPos, items, poGroups]);
+
+  const colCount = hasPos ? 12 : 11;
+  // 實際生效的分組（沒拆過 PO 時就算勾了也不分組）
+  const grouped = groupByPo && hasPos;
 
   function patchItem(idx: number, patch: Partial<ItemRow>) {
     setItems((cur) =>
@@ -732,6 +801,7 @@ function PageContent() {
                   0
                 )}
               </Row>
+              {hasPos && <Row label={PO_TERM_ZH}>{derivedPOs.length}</Row>}
               <div className="my-2 border-t border-zinc-200 dark:border-zinc-700" />
               <Row label="總計">
                 <span className="text-lg font-semibold text-blue-600 dark:text-blue-400">
@@ -823,11 +893,24 @@ function PageContent() {
 
         {/* 右側採購清單 */}
         <div className="flex flex-col rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
-          <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
             <h3 className="text-sm font-semibold">📋 內部採購清單</h3>
-            <span className="text-xs text-zinc-500">
-              *成本=廠商給的價格，售價=ERP 商品價格
-            </span>
+            <div className="flex items-center gap-3">
+              {hasPos && (
+                <label className="flex cursor-pointer items-center gap-1.5 text-xs text-zinc-600 dark:text-zinc-300">
+                  <input
+                    type="checkbox"
+                    checked={groupByPo}
+                    onChange={(e) => setGroupByPo(e.target.checked)}
+                    className="h-3.5 w-3.5 accent-blue-600"
+                  />
+                  依{PO_TERM_ZH}分組（{derivedPOs.length} 張）
+                </label>
+              )}
+              <span className="text-xs text-zinc-500">
+                *成本=廠商給的價格，售價=ERP 商品價格
+              </span>
+            </div>
           </div>
           {editable && items.length > 0 && (
             <div className="flex flex-wrap items-end gap-2 border-b border-zinc-200 bg-zinc-50 px-4 py-2 dark:border-zinc-800 dark:bg-zinc-900/50">
@@ -892,6 +975,7 @@ function PageContent() {
             <tr>
               <Th>#</Th>
               <Th>品名</Th>
+              {hasPos && <Th>{PO_TERM_ZH}</Th>}
               <Th>供應商</Th>
               <Th>單位</Th>
               <Th className="text-right">已採購</Th>
@@ -906,7 +990,7 @@ function PageContent() {
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {items.length === 0 ? (
               <tr>
-                <td colSpan={11} className="p-6 text-center text-zinc-500">
+                <td colSpan={colCount} className="p-6 text-center text-zinc-500">
                   {header?.source_type === "manual" ? (
                     <div className="space-y-1">
                       <div>無品項</div>
@@ -920,7 +1004,44 @@ function PageContent() {
                 </td>
               </tr>
             ) : (
-              items.map((r, idx) => {
+              displayRows.map((entry) => {
+                if (entry.kind === "group") {
+                  const g = entry.group;
+                  const sub = g.rows.reduce((s, x) => s + x.r.qty_requested * x.r.unit_cost, 0);
+                  // 供應商優先取 PO 上的；PO 尚未建立（未轉單組）才退回第一列的建議供應商
+                  const supId = g.po?.supplier_id ?? g.rows[0]?.r.suggested_supplier_id ?? null;
+                  const supName = supId != null ? supplierNameById.get(supId) : null;
+                  return (
+                    <tr key={entry.key} className="bg-zinc-100/80 dark:bg-zinc-800/60">
+                      <td colSpan={colCount} className="px-3 py-1.5">
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+                          {g.po ? (
+                            <>
+                              <Link
+                                href={`/purchase/orders/edit?id=${g.po.id}`}
+                                className="font-mono text-sm font-semibold text-blue-600 hover:underline dark:text-blue-400"
+                              >
+                                📦 {g.po.po_no}
+                              </Link>
+                              <span className="rounded bg-white px-1.5 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-900 dark:text-zinc-300">
+                                {poStatusLabel(g.po.status)}
+                              </span>
+                            </>
+                          ) : (
+                            <span className="text-sm font-semibold text-zinc-500">
+                              尚未轉{PO_TERM_ZH}
+                            </span>
+                          )}
+                          <span className="text-zinc-600 dark:text-zinc-300">{supName ?? "—"}</span>
+                          <span className="text-zinc-500">{g.rows.length} 項</span>
+                          <span className="font-mono text-zinc-500">${sub.toFixed(0)}</span>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                }
+                const { r, idx, seq } = entry;
+                const rowPo = r.po_id != null ? poById.get(r.po_id) ?? null : null;
                 // 成本 ≤ 分店價 < 售價 必須遞增，三值有任一缺則不檢查（送審前才擋）
                 const cost = Number(r.unit_cost);
                 const branch = r.franchise_price != null ? Number(r.franchise_price) : null;
@@ -931,8 +1052,8 @@ function PageContent() {
                   ? "border-rose-400 bg-rose-50 dark:border-rose-700 dark:bg-rose-950"
                   : "border-zinc-300 dark:border-zinc-700";
                 return (
-                <tr key={r.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
-                  <Td className="text-zinc-500">{idx + 1}</Td>
+                <tr key={entry.key} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
+                  <Td className="text-zinc-500">{seq}</Td>
                   <Td>
                     <div>{r.product_name}{r.variant_name ? `-${r.variant_name}` : ""}</div>
                     <div className="font-mono text-xs text-zinc-500">{r.sku_code}</div>
@@ -942,6 +1063,32 @@ function PageContent() {
                       </div>
                     )}
                   </Td>
+                  {hasPos && (
+                    <Td>
+                      {rowPo ? (
+                        <>
+                          <Link
+                            href={`/purchase/orders/edit?id=${rowPo.id}`}
+                            className={`font-mono text-xs hover:underline ${
+                              grouped
+                                ? "text-zinc-400 dark:text-zinc-500"
+                                : "text-blue-600 dark:text-blue-400"
+                            }`}
+                          >
+                            {rowPo.po_no}
+                          </Link>
+                          {/* 分組時狀態已在群組標題列，不重複 */}
+                          {!grouped && (
+                            <div className="text-[11px] text-zinc-500">
+                              {poStatusLabel(rowPo.status)}
+                            </div>
+                          )}
+                        </>
+                      ) : (
+                        <span className="text-xs text-zinc-400">未轉單</span>
+                      )}
+                    </Td>
+                  )}
                   <Td>
                     {editable ? (
                       <SupplierPicker

--- a/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/edit/page.tsx
@@ -61,13 +61,17 @@ type ItemRow = {
   dirty: boolean;
 };
 
-// 依 PO 分組後的清單；rows 帶 idx 是為了讓 patchItem / removeItem 仍能吃到
+// 依廠商分組後的清單；rows 帶 idx 是為了讓 patchItem / removeItem 仍能吃到
 // items 陣列的原始 index（分組只是顯示層的重排，不改 state 結構）
-type PoGroup = { po: DerivedPO | null; rows: { r: ItemRow; idx: number }[] };
+type SupplierGroup = {
+  supplier_id: number | null;
+  supplier_name: string;
+  rows: { r: ItemRow; idx: number }[];
+};
 
 // 表格渲染序列的元素：分組標題列或品項列
 type RenderEntry =
-  | { kind: "group"; key: string; group: PoGroup }
+  | { kind: "group"; key: string; group: SupplierGroup }
   | { kind: "item"; key: string; r: ItemRow; idx: number; seq: number };
 
 const STATUS_LABEL = prStatusLabel;
@@ -111,8 +115,9 @@ function PageContent() {
   const [bulkCost, setBulkCost] = useState<string>("");
   const [bulkBranch, setBulkBranch] = useState<string>("");
   const [bulkRetail, setBulkRetail] = useState<string>("");
-  // 品項清單是否依「拆出的採購單」分組顯示（拆過 PO 才有意義，預設開）
-  const [groupByPo, setGroupByPo] = useState(true);
+  // 品項清單是否依廠商分組。null = 交給下面的預設規則：草稿不分組（指派供應商時
+  // 該列會立刻跳到別組、很難連續作業），已送審／已轉單則預設分組。
+  const [groupBySupplier, setGroupBySupplier] = useState<boolean | null>(null);
 
   useEffect(() => {
     if (!id) {
@@ -405,6 +410,8 @@ function PageContent() {
     header?.status === "submitted" ||
     header?.status === "cancelled";
 
+  const grouped = groupBySupplier ?? !editable;
+
   const totals = useMemo(() => {
     const subtotal = items.reduce((s, r) => s + r.qty_requested * r.unit_cost, 0);
     return { subtotal };
@@ -417,50 +424,53 @@ function PageContent() {
     () => new Map(suppliers.map((s) => [s.id, s.name])),
     [suppliers],
   );
-  // 已拆出 PO 才顯示「採購單」欄與分組
+  // 已拆出 PO 才顯示「採購單」欄
   const hasPos = derivedPOs.length > 0;
 
-  // 依 PO 分組：有 PO 的照 po_no 排在前，未拆單的一組排最後
-  const poGroups: PoGroup[] = useMemo(() => {
-    const map = new Map<number | null, PoGroup>();
+  // 依廠商分組（PO 本來就是一家廠商一張，所以同組通常也就是同一張 PO）；
+  // 未指派供應商的一組固定排最後，方便草稿階段一眼看到還缺誰。
+  const supplierGroups: SupplierGroup[] = useMemo(() => {
+    const map = new Map<number | null, SupplierGroup>();
     items.forEach((r, idx) => {
-      const key = r.po_id ?? null;
+      const key = r.suggested_supplier_id ?? null;
       let g = map.get(key);
       if (!g) {
-        g = { po: key === null ? null : poById.get(key) ?? null, rows: [] };
+        g = {
+          supplier_id: key,
+          supplier_name:
+            key === null ? "未指派供應商" : supplierNameById.get(key) ?? `#${key}`,
+          rows: [],
+        };
         map.set(key, g);
       }
       g.rows.push({ r, idx });
     });
     return Array.from(map.values()).sort((a, b) => {
-      if (!a.po && !b.po) return 0;
-      if (!a.po) return 1;
-      if (!b.po) return -1;
-      return a.po.po_no.localeCompare(b.po.po_no, undefined, { numeric: true });
+      if (a.supplier_id === null) return 1;
+      if (b.supplier_id === null) return -1;
+      return pinyinCollator.compare(a.supplier_name, b.supplier_name);
     });
-  }, [items, poById]);
+  }, [items, supplierNameById]);
 
   // 攤平成「分組標題列 + 品項列」的渲染序列；關掉分組時就是原本的平鋪順序。
   // seq 是畫面上的連續序號（跨組不重來），idx 仍是 items 的原始 index。
   const displayRows: RenderEntry[] = useMemo(() => {
-    if (!groupByPo || !hasPos) {
+    if (!grouped) {
       return items.map((r, idx) => ({ kind: "item" as const, key: `i${r.id}`, r, idx, seq: idx + 1 }));
     }
     const out: RenderEntry[] = [];
     let seq = 0;
-    for (const g of poGroups) {
-      out.push({ kind: "group", key: `g${g.po?.id ?? "none"}`, group: g });
+    for (const g of supplierGroups) {
+      out.push({ kind: "group", key: `g${g.supplier_id ?? "none"}`, group: g });
       for (const { r, idx } of g.rows) {
         seq += 1;
         out.push({ kind: "item", key: `i${r.id}`, r, idx, seq });
       }
     }
     return out;
-  }, [groupByPo, hasPos, items, poGroups]);
+  }, [grouped, items, supplierGroups]);
 
   const colCount = hasPos ? 12 : 11;
-  // 實際生效的分組（沒拆過 PO 時就算勾了也不分組）
-  const grouped = groupByPo && hasPos;
 
   function patchItem(idx: number, patch: Partial<ItemRow>) {
     setItems((cur) =>
@@ -896,15 +906,15 @@ function PageContent() {
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
             <h3 className="text-sm font-semibold">📋 內部採購清單</h3>
             <div className="flex items-center gap-3">
-              {hasPos && (
+              {items.length > 0 && (
                 <label className="flex cursor-pointer items-center gap-1.5 text-xs text-zinc-600 dark:text-zinc-300">
                   <input
                     type="checkbox"
-                    checked={groupByPo}
-                    onChange={(e) => setGroupByPo(e.target.checked)}
+                    checked={grouped}
+                    onChange={(e) => setGroupBySupplier(e.target.checked)}
                     className="h-3.5 w-3.5 accent-blue-600"
                   />
-                  依{PO_TERM_ZH}分組（{derivedPOs.length} 張）
+                  依廠商分組（{supplierGroups.length} 家）
                 </label>
               )}
               <span className="text-xs text-zinc-500">
@@ -1008,33 +1018,45 @@ function PageContent() {
                 if (entry.kind === "group") {
                   const g = entry.group;
                   const sub = g.rows.reduce((s, x) => s + x.r.qty_requested * x.r.unit_cost, 0);
-                  // 供應商優先取 PO 上的；PO 尚未建立（未轉單組）才退回第一列的建議供應商
-                  const supId = g.po?.supplier_id ?? g.rows[0]?.r.suggested_supplier_id ?? null;
-                  const supName = supId != null ? supplierNameById.get(supId) : null;
+                  const qty = g.rows.reduce((s, x) => s + x.r.qty_requested, 0);
+                  // 這家廠商的品項落在哪幾張 PO（一家通常一張，補單時可能多張）
+                  const groupPos = Array.from(
+                    new Map(
+                      g.rows
+                        .map((x) => (x.r.po_id != null ? poById.get(x.r.po_id) : null))
+                        .filter((p): p is DerivedPO => !!p)
+                        .map((p) => [p.id, p]),
+                    ).values(),
+                  ).sort((a, b) => a.po_no.localeCompare(b.po_no, undefined, { numeric: true }));
                   return (
                     <tr key={entry.key} className="bg-zinc-100/80 dark:bg-zinc-800/60">
                       <td colSpan={colCount} className="px-3 py-1.5">
                         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-                          {g.po ? (
-                            <>
+                          <span
+                            className={`text-sm font-semibold ${
+                              g.supplier_id === null
+                                ? "text-red-600 dark:text-red-400"
+                                : "text-zinc-800 dark:text-zinc-100"
+                            }`}
+                          >
+                            🏭 {g.supplier_name}
+                          </span>
+                          <span className="text-zinc-500">{g.rows.length} 項</span>
+                          <span className="font-mono text-zinc-500">數量 {qty}</span>
+                          <span className="font-mono text-zinc-500">${sub.toFixed(0)}</span>
+                          {groupPos.map((p) => (
+                            <span key={p.id} className="inline-flex items-center gap-1">
                               <Link
-                                href={`/purchase/orders/edit?id=${g.po.id}`}
-                                className="font-mono text-sm font-semibold text-blue-600 hover:underline dark:text-blue-400"
+                                href={`/purchase/orders/edit?id=${p.id}`}
+                                className="font-mono text-blue-600 hover:underline dark:text-blue-400"
                               >
-                                📦 {g.po.po_no}
+                                📦 {p.po_no}
                               </Link>
                               <span className="rounded bg-white px-1.5 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-900 dark:text-zinc-300">
-                                {poStatusLabel(g.po.status)}
+                                {poStatusLabel(p.status)}
                               </span>
-                            </>
-                          ) : (
-                            <span className="text-sm font-semibold text-zinc-500">
-                              尚未轉{PO_TERM_ZH}
                             </span>
-                          )}
-                          <span className="text-zinc-600 dark:text-zinc-300">{supName ?? "—"}</span>
-                          <span className="text-zinc-500">{g.rows.length} 項</span>
-                          <span className="font-mono text-zinc-500">${sub.toFixed(0)}</span>
+                          ))}
                         </div>
                       </td>
                     </tr>

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
-import { fetchAllRows } from "@/lib/fetchAllRows";
 import SpinButton from "@/components/SpinButton";
 import { RowAction } from "@/components/RowAction";
 import Spinner, { LoadingBlock } from "@/components/Spinner";
@@ -71,36 +70,40 @@ type ClosedCampaignRow = {
 type StatusTab = "all" | PRStatus;
 
 // === 樞紐（依廠商彙整品項）===
-// 每一列是「某張 PR 的某個品項」，扁平化後在前端 group by 廠商 → SKU。
-type PivotItem = {
-  pr_id: number;
-  pr_no: string;
-  supplier_id: number | null;
-  supplier_name: string | null;
-  sku_id: number;
-  sku_label: string;
-  qty: number;
-  amount: number;
-  ordered: boolean; // 已轉成 PO 品項
-};
-
-// prs: pr_id -> pr_no（保留 id 讓來源 PR 可連回詳細頁）
+// 形狀直接對應 rpc_pr_supplier_pivot 的回傳（聚合已在 DB 算完）
 type PivotSkuAgg = {
   sku_id: number;
   label: string;
   qty: number;
-  orderedQty: number;
+  ordered_qty: number;
   amount: number;
-  prs: Map<number, string>;
+  prs: { id: number; pr_no: string }[];
 };
 type PivotGroup = {
   supplier_id: number | null;
   supplier_name: string;
   skus: PivotSkuAgg[];
   qty: number;
-  orderedQty: number;
+  ordered_qty: number;
   amount: number;
-  prCount: number;
+  pr_count: number;
+};
+
+// rpc_pr_list 的回傳形狀（server-side 篩選 / 排序 / 分頁）
+type ListResp = {
+  total: number;
+  counts: Record<StatusTab, number>;
+  kpi: {
+    pending_review: number;
+    to_split: number;
+    amount_in_flight: number;
+    unassigned: number;
+  };
+  rows: (Row & Progress)[];
+};
+
+const EMPTY_COUNTS: Record<StatusTab, number> = {
+  all: 0, draft: 0, submitted: 0, partially_ordered: 0, fully_ordered: 0, cancelled: 0,
 };
 
 const STATUS_LABEL = PR_STATUS_LABEL;
@@ -143,7 +146,6 @@ type SortCol = "updated_at" | "source_close_date" | "total_amount" | "pr_no";
 
 export default function PurchaseRequestsListPage() {
   const router = useRouter();
-  const [rows, setRows] = useState<Row[] | null>(null);
   const [pendingDates, setPendingDates] = useState<CloseDateGroup[] | null>(
     null,
   );
@@ -180,83 +182,54 @@ export default function PurchaseRequestsListPage() {
   );
   const [campaignQuery, setCampaignQuery] = useState("");
   const [creatingMulti, setCreatingMulti] = useState(false);
-  const [progressById, setProgressById] = useState<Map<number, Progress>>(
-    new Map(),
-  );
+  const [data, setData] = useState<ListResp | null>(null);
 
   // 檢視模式：清單（原本）/ 樞紐（把篩選出的 PR 品項依廠商彙整）
   const [viewMode, setViewMode] = useState<"list" | "pivot">("list");
   // 樞紐子篩選：全部品項 / 只看還沒轉成 PO 的品項（＝還要去跟廠商下單的量）
   const [pivotOnlyUnordered, setPivotOnlyUnordered] = useState(false);
-  // 樞紐資料連同抓取當下的 reloadTick 一起存，tick 對不上就是過期 → 重撈。
-  // （用「資料自帶版本」取代 effect 裡同步 setState 清快取 / 開 loading）
-  const [pivotData, setPivotData] = useState<{ tick: number; list: PivotItem[] } | null>(
-    null,
-  );
-  const pivotReady = pivotData !== null && pivotData.tick === reloadTick;
-  const pivotItems = pivotReady ? pivotData.list : null;
+  // 樞紐資料連同抓取當下的條件指紋一起存，指紋對不上就是過期 → 重撈
+  const [pivotData, setPivotData] = useState<{ tick: string; groups: PivotGroup[] } | null>(null);
+
+  // search 是輸入框當下的值；dSearch 是進 DB 查詢的 debounce 值
+  const [dSearch, setDSearch] = useState("");
+
+  // 樞紐快取鍵：任一篩選條件或資料重載都會讓既有彙總過期
+  const pivotTick = JSON.stringify([
+    reloadTick, tab, reviewFilter, sourceFilter, dSearch, dateFrom, dateTo, pivotOnlyUnordered,
+  ]);
+  const pivotReady = pivotData !== null && pivotData.tick === pivotTick;
+  const pivotGroups = pivotReady ? pivotData.groups : [];
   const pivotLoading = viewMode === "pivot" && !pivotReady;
 
-  // ============== 載入既有 PRs ==============
+  // 搜尋 debounce：打字停 300ms 才進 DB
+  useEffect(() => {
+    const t = setTimeout(() => setDSearch(search), 300);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  // ============== 清單資料：全部交給 rpc_pr_list ==============
+  // 篩選 / 排序 / 分頁 / 計數 / 進度都在 DB 算完，前端只收當頁 PAGE_SIZE 筆。
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        // 全部撈回來 — 篩選 / 搜尋 / KPI 都是前端算的，截斷會讓超出的單
-        // 連搜單號都搜不到（採購單頁就是這樣漏掉第 500 張之後的 PO）。
-        // updated_at 有同值，補 id 當 tiebreaker 給分頁一個穩定的 total order。
-        const prRows = await fetchAllRows<Row>(() =>
-          getSupabase()
-            .from("purchase_requests")
-            .select(
-              "id, pr_no, source_type, source_close_date, status, review_status, total_amount, notes, updated_at",
-            )
-            .order("updated_at", { ascending: false })
-            .order("id", { ascending: false }),
-        );
+        const { data: resp, error: err } = await getSupabase().rpc("rpc_pr_list", {
+          p_status: tab === "all" ? null : tab,
+          p_review: reviewFilter || null,
+          p_source: sourceFilter || null,
+          p_search: dSearch.trim() || null,
+          p_date_from: dateFrom || null,
+          p_date_to: dateTo || null,
+          p_sort: sortBy,
+          p_dir: sortDir,
+          p_page: page,
+          p_page_size: PAGE_SIZE,
+        });
         if (cancelled) return;
+        if (err) throw new Error(err.message);
+        setData(resp as ListResp);
         setError(null);
-        setRows(prRows);
-
-        const ids = prRows.map((r) => r.id);
-        if (ids.length) {
-          // 一次 .in() 塞幾百個 id 會撐爆 URL → chunk；progress 一張單一列，
-          // 破千張時也需要分頁
-          type ProgRow = Progress & { pr_id: number };
-          const prog: ProgRow[] = [];
-          for (let i = 0; i < ids.length; i += 200) {
-            const c = ids.slice(i, i + 200);
-            const part = await fetchAllRows<ProgRow>(() =>
-              getSupabase()
-                .from("v_pr_progress")
-                .select(
-                  "pr_id, po_total, po_sent, po_received_fully, transfer_total, transfer_shipped, transfer_delivered, item_count, unassigned_supplier_count, all_campaigns_finalized",
-                )
-                .in("pr_id", c)
-                .order("pr_id", { ascending: true }),
-            );
-            prog.push(...part);
-          }
-          if (!cancelled) {
-            const m = new Map<number, Progress>();
-            for (const p of prog) {
-              m.set(p.pr_id, {
-                po_total: Number(p.po_total),
-                po_sent: Number(p.po_sent),
-                po_received_fully: Number(p.po_received_fully),
-                transfer_total: Number(p.transfer_total),
-                transfer_shipped: Number(p.transfer_shipped),
-                transfer_delivered: Number(p.transfer_delivered),
-                item_count: Number(p.item_count),
-                unassigned_supplier_count: Number(p.unassigned_supplier_count),
-                all_campaigns_finalized: !!p.all_campaigns_finalized,
-              });
-            }
-            setProgressById(m);
-          }
-        } else {
-          setProgressById(new Map());
-        }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       }
@@ -264,119 +237,43 @@ export default function PurchaseRequestsListPage() {
     return () => {
       cancelled = true;
     };
-  }, [reloadTick]);
+  }, [tab, reviewFilter, sourceFilter, dSearch, dateFrom, dateTo, sortBy, sortDir, page, reloadTick]);
 
   // ============== 樞紐資料（lazy）==============
-  // 切到樞紐才撈一次：所有未作廢 PR 的品項 + SKU 標籤 + 廠商名。
-  // 篩選（頁籤 / 搜尋 / 日期…）一律在前端套用，打字搜尋不會重打 API。
-  // 重入保護靠 pivotReady：抓取期間它維持 false 但依賴陣列不變，所以不會
-  // 重複發查詢；抓完（或失敗塞空陣列）才翻成 true 離開這個 effect。
+  // 聚合直接在 DB 做（rpc_pr_supplier_pivot），前端只收各廠商的彙總結果。
+  // 重入保護靠 pivotReady：抓取期間維持 false 但依賴不變，不會重複發查詢。
   useEffect(() => {
-    if (viewMode !== "pivot" || pivotReady || !rows) return;
+    if (viewMode !== "pivot" || pivotReady) return;
     let cancelled = false;
     (async () => {
       try {
-        const sb = getSupabase();
-        const chunk = <T,>(arr: T[], n: number): T[][] => {
-          const out: T[][] = [];
-          for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
-          return out;
-        };
-        const targetPrs = rows.filter((r) => r.status !== "cancelled");
-        const prMeta = new Map(targetPrs.map((r) => [r.id, r]));
-        const prIds = targetPrs.map((r) => r.id);
-        if (prIds.length === 0) {
-          if (!cancelled) setPivotData({ tick: reloadTick, list: [] });
-          return;
-        }
-
-        type PrItemRow = {
-          pr_id: number;
-          sku_id: number;
-          qty_requested: number;
-          unit_cost: number;
-          suggested_supplier_id: number | null;
-          po_item_id: number | null;
-        };
-        // fetchAllRows 分頁：PR 品項很容易破 PostgREST 的 1000 列上限
-        const itemRows: PrItemRow[] = [];
-        for (const c of chunk(prIds, 200)) {
-          const part = await fetchAllRows<PrItemRow>(() =>
-            sb
-              .from("purchase_request_items")
-              .select(
-                "id, pr_id, sku_id, qty_requested, unit_cost, suggested_supplier_id, po_item_id",
-              )
-              .in("pr_id", c)
-              .order("id", { ascending: true }),
-          );
-          itemRows.push(...part);
-        }
-
-        // SKU 標籤
-        const skuIds = Array.from(new Set(itemRows.map((r) => r.sku_id)));
-        const skuLabel = new Map<number, string>();
-        for (const c of chunk(skuIds, 300)) {
-          const { data } = await sb
-            .from("skus")
-            .select("id, sku_code, variant_name, products!inner(name)")
-            .in("id", c);
-          type SkuLite = {
-            id: number;
-            sku_code: string | null;
-            variant_name: string | null;
-            products: { name: string } | { name: string }[] | null;
-          };
-          for (const s of (data as SkuLite[] | null) ?? []) {
-            const prod = Array.isArray(s.products) ? s.products[0] : s.products;
-            const base = prod?.name ?? s.sku_code ?? `#${s.id}`;
-            skuLabel.set(s.id, s.variant_name ? `${base} / ${s.variant_name}` : base);
-          }
-        }
-
-        // 廠商名
-        const supName = new Map<number, string>();
-        {
-          const { data } = await sb.from("suppliers").select("id, name");
-          for (const s of ((data ?? []) as { id: number; name: string }[])) {
-            supName.set(s.id, s.name);
-          }
-        }
-
-        // 查不到對應 PR 的品項直接略過（例：撈到一半那張 PR 被作廢 / 刪掉），
-        // 不要用 non-null assertion — 一個孤兒列就會讓整個樞紐炸成空白。
-        const list: PivotItem[] = itemRows.flatMap((r) => {
-          const pr = prMeta.get(r.pr_id);
-          if (!pr) return [];
-          const qty = Number(r.qty_requested) || 0;
-          return [{
-            pr_id: r.pr_id,
-            pr_no: pr.pr_no,
-            supplier_id: r.suggested_supplier_id,
-            supplier_name:
-              r.suggested_supplier_id !== null
-                ? supName.get(r.suggested_supplier_id) ?? null
-                : null,
-            sku_id: r.sku_id,
-            sku_label: skuLabel.get(r.sku_id) ?? `#${r.sku_id}`,
-            qty,
-            amount: qty * (Number(r.unit_cost) || 0),
-            ordered: r.po_item_id !== null,
-          }];
+        const { data: resp, error: err } = await getSupabase().rpc("rpc_pr_supplier_pivot", {
+          p_status: tab === "all" ? null : tab,
+          p_review: reviewFilter || null,
+          p_source: sourceFilter || null,
+          p_search: dSearch.trim() || null,
+          p_date_from: dateFrom || null,
+          p_date_to: dateTo || null,
+          p_only_unordered: pivotOnlyUnordered,
         });
-        if (!cancelled) setPivotData({ tick: reloadTick, list });
+        if (cancelled) return;
+        if (err) throw new Error(err.message);
+        setPivotData({
+          tick: pivotTick,
+          groups: ((resp as { groups: PivotGroup[] } | null)?.groups ?? []),
+        });
       } catch (e) {
-        // 設成空陣列避免「載入中」卡死；錯誤原因由上方 error banner 呈現。
+        // 塞空陣列避免「載入中」卡死；錯誤原因由上方 error banner 呈現
         if (!cancelled) {
           setError(e instanceof Error ? e.message : String(e));
-          setPivotData({ tick: reloadTick, list: [] });
+          setPivotData({ tick: pivotTick, groups: [] });
         }
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [viewMode, pivotReady, rows, reloadTick]);
+  }, [viewMode, pivotReady, pivotTick, tab, reviewFilter, sourceFilter, dSearch, dateFrom, dateTo, pivotOnlyUnordered]);
 
   // ============== 載入「結單日待開單」cards ==============
   useEffect(() => {
@@ -749,119 +646,23 @@ export default function PurchaseRequestsListPage() {
     }
   }
 
-  // === KPI 統計 ===
-  const stats = useMemo(() => {
-    const acc = {
-      draft: 0,
-      submitted: 0,
-      partially_ordered: 0,
-      fully_ordered: 0,
-      cancelled: 0,
-      pending_review: 0,
-      to_split: 0, // approved + draft + submitted, status not fully/cancelled
-      total_amount_in_flight: 0,
-      unassigned: 0,
-    };
-    for (const r of rows ?? []) {
-      acc[r.status] += 1;
-      if (r.review_status === "pending_review") acc.pending_review += 1;
-      const inFlight =
-        r.review_status === "approved" &&
-        r.status !== "fully_ordered" &&
-        r.status !== "cancelled";
-      if (inFlight) {
-        acc.to_split += 1;
-        acc.total_amount_in_flight += Number(r.total_amount) || 0;
-      }
-      const p = progressById.get(r.id);
-      if (p) acc.unassigned += p.unassigned_supplier_count;
-    }
-    return acc;
-  }, [rows, progressById]);
-
-  // tab counts
-  const tabCounts = useMemo(
-    () => ({
-      all: rows?.length ?? 0,
-      draft: stats.draft,
-      submitted: stats.submitted,
-      partially_ordered: stats.partially_ordered,
-      fully_ordered: stats.fully_ordered,
-      cancelled: stats.cancelled,
-    }),
-    [rows, stats],
-  );
-
-  // 篩選變動 → 重置到第 1 頁
-  useEffect(() => {
-    setPage(1);
-  }, [
-    tab,
-    reviewFilter,
-    sourceFilter,
-    search,
-    dateFrom,
-    dateTo,
-    sortBy,
-    sortDir,
-    groupBy,
-  ]);
-
-  const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    return (rows ?? []).filter((r) => {
-      if (tab !== "all" && r.status !== tab) return false;
-      if (reviewFilter && r.review_status !== reviewFilter) return false;
-      if (sourceFilter && r.source_type !== sourceFilter) return false;
-      if (
-        dateFrom &&
-        (!r.source_close_date || r.source_close_date < dateFrom)
-      )
-        return false;
-      if (dateTo && (!r.source_close_date || r.source_close_date > dateTo))
-        return false;
-      if (q) {
-        const hits = [r.pr_no, r.notes]
-          .filter((x): x is string => !!x)
-          .some((x) => x.toLowerCase().includes(q));
-        if (!hits) return false;
-      }
-      return true;
-    });
-  }, [rows, tab, reviewFilter, sourceFilter, search, dateFrom, dateTo]);
-
-  const sorted = useMemo(() => {
-    const arr = [...filtered];
-    arr.sort((a, b) => {
-      let av: string | number;
-      let bv: string | number;
-      if (sortBy === "total_amount") {
-        av = Number(a.total_amount) || 0;
-        bv = Number(b.total_amount) || 0;
-      } else if (sortBy === "pr_no") {
-        av = a.pr_no;
-        bv = b.pr_no;
-      } else if (sortBy === "source_close_date") {
-        av = a.source_close_date ?? "";
-        bv = b.source_close_date ?? "";
-      } else {
-        av = a.updated_at;
-        bv = b.updated_at;
-      }
-      if (av < bv) return sortDir === "asc" ? -1 : 1;
-      if (av > bv) return sortDir === "asc" ? 1 : -1;
-      return 0;
-    });
-    return arr;
-  }, [filtered, sortBy, sortDir]);
-
-  const total = sorted.length;
+  // === 統計 / 當頁資料：全部來自 rpc_pr_list，前端不再自己算 ===
+  const stats = {
+    pending_review: data?.kpi.pending_review ?? 0,
+    to_split: data?.kpi.to_split ?? 0,
+    unassigned: data?.kpi.unassigned ?? 0,
+    amountInFlight: Number(data?.kpi.amount_in_flight ?? 0),
+  };
+  const tabCounts = data?.counts ?? EMPTY_COUNTS;
+  // rows 已經是 DB 篩選 + 排序 + 分頁後的當前頁，且每列自帶進度欄位
+  const pageRows = useMemo(() => data?.rows ?? [], [data]);
+  const loaded = data !== null;
+  const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-  const pageRows = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   const grouped = useMemo(() => {
     if (groupBy === "none") return null;
-    const map = new Map<string, { label: string; rows: Row[] }>();
+    const map = new Map<string, { label: string; rows: (Row & Progress)[] }>();
     for (const r of pageRows) {
       let key = "—";
       let label = "—";
@@ -890,84 +691,6 @@ export default function PurchaseRequestsListPage() {
       })
       .map(([k, v]) => ({ key: k, ...v }));
   }, [pageRows, groupBy]);
-
-  // 樞紐分組：依廠商 → SKU 彙整（請購量 / 已轉單 / 未轉單 / 金額）。
-  // 只納入目前篩選結果（filtered）裡的 PR，所以頁籤、搜尋、日期都自然生效。
-  const pivotGroups: PivotGroup[] = useMemo(() => {
-    if (!pivotItems) return [];
-    const visiblePrIds = new Set(filtered.map((r) => r.id));
-    const q = search.trim().toLowerCase();
-    const bySup = new Map<
-      number | null,
-      {
-        supplier_id: number | null;
-        supplier_name: string;
-        skus: Map<number, PivotSkuAgg>;
-        prIds: Set<number>;
-      }
-    >();
-    for (const it of pivotItems) {
-      if (!visiblePrIds.has(it.pr_id)) continue;
-      if (pivotOnlyUnordered && it.ordered) continue;
-      // filtered 只比對過 PR 單號 / 備註，樞紐再多讓廠商、品名也能命中
-      if (q) {
-        const hit = [it.pr_no, it.supplier_name, it.sku_label]
-          .filter((x): x is string => !!x)
-          .some((x) => x.toLowerCase().includes(q));
-        if (!hit) continue;
-      }
-      let sup = bySup.get(it.supplier_id);
-      if (!sup) {
-        sup = {
-          supplier_id: it.supplier_id,
-          supplier_name:
-            it.supplier_name ??
-            (it.supplier_id === null ? "未指派供應商" : `#${it.supplier_id}`),
-          skus: new Map(),
-          prIds: new Set(),
-        };
-        bySup.set(it.supplier_id, sup);
-      }
-      sup.prIds.add(it.pr_id);
-      let sk = sup.skus.get(it.sku_id);
-      if (!sk) {
-        sk = {
-          sku_id: it.sku_id,
-          label: it.sku_label,
-          qty: 0,
-          orderedQty: 0,
-          amount: 0,
-          prs: new Map(),
-        };
-        sup.skus.set(it.sku_id, sk);
-      }
-      sk.qty += it.qty;
-      if (it.ordered) sk.orderedQty += it.qty;
-      sk.amount += it.amount;
-      sk.prs.set(it.pr_id, it.pr_no);
-    }
-    return Array.from(bySup.values())
-      .map((sup) => {
-        const skus = Array.from(sup.skus.values()).sort((a, b) =>
-          a.label.localeCompare(b.label),
-        );
-        return {
-          supplier_id: sup.supplier_id,
-          supplier_name: sup.supplier_name,
-          skus,
-          qty: skus.reduce((s, r) => s + r.qty, 0),
-          orderedQty: skus.reduce((s, r) => s + r.orderedQty, 0),
-          amount: skus.reduce((s, r) => s + r.amount, 0),
-          prCount: sup.prIds.size,
-        };
-      })
-      .sort((a, b) => {
-        // 未指派供應商排最前面（最需要處理）
-        if (a.supplier_id === null) return -1;
-        if (b.supplier_id === null) return 1;
-        return a.supplier_name.localeCompare(b.supplier_name);
-      });
-  }, [pivotItems, filtered, search, pivotOnlyUnordered]);
 
   function setSort(col: SortCol) {
     if (sortBy === col) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
@@ -1000,10 +723,10 @@ export default function PurchaseRequestsListPage() {
         <div>
           <h1 className="text-xl font-semibold">{PR_TERM_ZH}（PR）</h1>
           <p className="text-sm text-zinc-500">
-            {rows === null ? (
+            {!loaded ? (
               <Spinner size={14} className="inline-block align-[-2px]" />
             ) : (
-              `共 ${rows.length} 筆`
+              `共 ${tabCounts.all} 筆`
             )}
           </p>
         </div>
@@ -1283,7 +1006,7 @@ export default function PurchaseRequestsListPage() {
           </SpinButton>
         )}
         <span className="ml-auto text-xs text-zinc-500">
-          {rows === null ? (
+          {!loaded ? (
             <Spinner size={14} className="inline-block align-[-2px]" />
           ) : (
             `符合 ${total} 筆${total > PAGE_SIZE ? ` · 第 ${page}/${totalPages} 頁` : ""}`
@@ -1340,7 +1063,7 @@ export default function PurchaseRequestsListPage() {
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
-            {rows === null ? (
+            {!loaded ? (
               <tr>
                 <td colSpan={10}>
                   <LoadingBlock />
@@ -1372,7 +1095,7 @@ export default function PurchaseRequestsListPage() {
                   <PRRow
                     key={r.id}
                     row={r}
-                    progress={progressById.get(r.id)}
+                    progress={r}
                     busyId={busyId}
                     onApprove={approve}
                     onReject={reject}
@@ -1385,7 +1108,7 @@ export default function PurchaseRequestsListPage() {
                 <PRRow
                   key={r.id}
                   row={r}
-                  progress={progressById.get(r.id)}
+                  progress={r}
                   busyId={busyId}
                   onApprove={approve}
                   onReject={reject}
@@ -1641,7 +1364,7 @@ function PrPivot({
     );
   }
   const totQty = groups.reduce((s, g) => s + g.qty, 0);
-  const totOrdered = groups.reduce((s, g) => s + g.orderedQty, 0);
+  const totOrdered = groups.reduce((s, g) => s + g.ordered_qty, 0);
   const totAmount = groups.reduce((s, g) => s + g.amount, 0);
   return (
     <div className="flex flex-col gap-4">
@@ -1650,7 +1373,7 @@ function PrPivot({
         {totQty - totOrdered} · 金額 ${Math.round(totAmount).toLocaleString()}
       </div>
       {groups.map((g) => {
-        const outstanding = g.qty - g.orderedQty;
+        const outstanding = g.qty - g.ordered_qty;
         return (
           <div
             key={g.supplier_id ?? "none"}
@@ -1664,11 +1387,11 @@ function PrPivot({
               >
                 {g.supplier_name}
                 <span className="ml-2 text-xs font-normal text-zinc-500">
-                  {g.prCount} 張 {PR_TERM_ZH} · {g.skus.length} 品項
+                  {g.pr_count} 張 {PR_TERM_ZH} · {g.skus.length} 品項
                 </span>
               </div>
               <div className="text-xs text-zinc-500">
-                請購 {g.qty} · 已轉單 {g.orderedQty} ·{" "}
+                請購 {g.qty} · 已轉單 {g.ordered_qty} ·{" "}
                 <span className={outstanding > 0 ? "text-amber-600 dark:text-amber-400" : ""}>
                   未轉單 {outstanding}
                 </span>{" "}
@@ -1691,12 +1414,12 @@ function PrPivot({
                 </thead>
                 <tbody>
                   {g.skus.map((s) => {
-                    const left = s.qty - s.orderedQty;
+                    const left = s.qty - s.ordered_qty;
                     return (
                       <tr key={s.sku_id} className="border-b border-zinc-100 dark:border-zinc-800/60">
                         <td className="px-3 py-1.5">{s.label}</td>
                         <td className="px-3 py-1.5 text-right font-mono">{s.qty}</td>
-                        <td className="px-3 py-1.5 text-right font-mono">{s.orderedQty}</td>
+                        <td className="px-3 py-1.5 text-right font-mono">{s.ordered_qty}</td>
                         <td
                           className={`px-3 py-1.5 text-right font-mono ${
                             left > 0 ? "text-amber-600 dark:text-amber-400" : "text-zinc-400"
@@ -1720,7 +1443,7 @@ function PrPivot({
             {/* 手機：每個品項一張堆疊卡片 */}
             <ul className="divide-y divide-zinc-100 sm:hidden dark:divide-zinc-800/60">
               {g.skus.map((s) => {
-                const left = s.qty - s.orderedQty;
+                const left = s.qty - s.ordered_qty;
                 return (
                   <li key={s.sku_id} className="px-3 py-2">
                     <div className="text-sm">{s.label}</div>
@@ -1732,7 +1455,7 @@ function PrPivot({
                       <span>
                         已轉單{" "}
                         <span className="font-mono text-zinc-800 dark:text-zinc-200">
-                          {s.orderedQty}
+                          {s.ordered_qty}
                         </span>
                       </span>
                       <span>
@@ -1762,8 +1485,11 @@ function PrPivot({
 }
 
 // 樞紐裡的來源 PR 單號清單：每個單號連到 PR 詳細頁
-function PrLinks({ prs }: { prs: Map<number, string> }) {
-  const entries = Array.from(prs.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+function PrLinks({ prs }: { prs: { id: number; pr_no: string }[] }) {
+  // 同一 SKU 可能來自多張 PR；去重後照單號排序
+  const entries = Array.from(new Map(prs.map((p) => [p.id, p.pr_no])).entries()).sort(
+    (a, b) => a[1].localeCompare(b[1]),
+  );
   return (
     <>
       {entries.map(([id, no], i) => (

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -202,34 +202,44 @@ export default function PurchaseRequestsListPage() {
     let cancelled = false;
     (async () => {
       try {
-        const { data, error: err } = await getSupabase()
-          .from("purchase_requests")
-          .select(
-            "id, pr_no, source_type, source_close_date, status, review_status, total_amount, notes, updated_at",
-          )
-          .order("updated_at", { ascending: false })
-          .limit(500);
+        // 全部撈回來 — 篩選 / 搜尋 / KPI 都是前端算的，截斷會讓超出的單
+        // 連搜單號都搜不到（採購單頁就是這樣漏掉第 500 張之後的 PO）。
+        // updated_at 有同值，補 id 當 tiebreaker 給分頁一個穩定的 total order。
+        const prRows = await fetchAllRows<Row>(() =>
+          getSupabase()
+            .from("purchase_requests")
+            .select(
+              "id, pr_no, source_type, source_close_date, status, review_status, total_amount, notes, updated_at",
+            )
+            .order("updated_at", { ascending: false })
+            .order("id", { ascending: false }),
+        );
         if (cancelled) return;
-        if (err) {
-          setError(err.message);
-          return;
-        }
         setError(null);
-        const prRows = (data ?? []) as Row[];
         setRows(prRows);
 
         const ids = prRows.map((r) => r.id);
         if (ids.length) {
-          const { data: prog } = await getSupabase()
-            .from("v_pr_progress")
-            .select(
-              "pr_id, po_total, po_sent, po_received_fully, transfer_total, transfer_shipped, transfer_delivered, item_count, unassigned_supplier_count, all_campaigns_finalized",
-            )
-            .in("pr_id", ids);
+          // 一次 .in() 塞幾百個 id 會撐爆 URL → chunk；progress 一張單一列，
+          // 破千張時也需要分頁
+          type ProgRow = Progress & { pr_id: number };
+          const prog: ProgRow[] = [];
+          for (let i = 0; i < ids.length; i += 200) {
+            const c = ids.slice(i, i + 200);
+            const part = await fetchAllRows<ProgRow>(() =>
+              getSupabase()
+                .from("v_pr_progress")
+                .select(
+                  "pr_id, po_total, po_sent, po_received_fully, transfer_total, transfer_shipped, transfer_delivered, item_count, unassigned_supplier_count, all_campaigns_finalized",
+                )
+                .in("pr_id", c)
+                .order("pr_id", { ascending: true }),
+            );
+            prog.push(...part);
+          }
           if (!cancelled) {
             const m = new Map<number, Progress>();
-            type ProgRow = Progress & { pr_id: number };
-            for (const p of (prog as ProgRow[] | null) ?? []) {
+            for (const p of prog) {
               m.set(p.pr_id, {
                 po_total: Number(p.po_total),
                 po_sent: Number(p.po_sent),

--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
+import { fetchAllRows } from "@/lib/fetchAllRows";
 import SpinButton from "@/components/SpinButton";
 import { RowAction } from "@/components/RowAction";
 import Spinner, { LoadingBlock } from "@/components/Spinner";
@@ -14,6 +15,7 @@ import {
   type PRStatus,
   type PRReviewStatus,
 } from "@/lib/prStatus";
+import { PO_TERM_ZH } from "@/lib/poStatus";
 
 const PAGE_SIZE = 20;
 
@@ -67,6 +69,39 @@ type ClosedCampaignRow = {
 };
 
 type StatusTab = "all" | PRStatus;
+
+// === 樞紐（依廠商彙整品項）===
+// 每一列是「某張 PR 的某個品項」，扁平化後在前端 group by 廠商 → SKU。
+type PivotItem = {
+  pr_id: number;
+  pr_no: string;
+  supplier_id: number | null;
+  supplier_name: string | null;
+  sku_id: number;
+  sku_label: string;
+  qty: number;
+  amount: number;
+  ordered: boolean; // 已轉成 PO 品項
+};
+
+// prs: pr_id -> pr_no（保留 id 讓來源 PR 可連回詳細頁）
+type PivotSkuAgg = {
+  sku_id: number;
+  label: string;
+  qty: number;
+  orderedQty: number;
+  amount: number;
+  prs: Map<number, string>;
+};
+type PivotGroup = {
+  supplier_id: number | null;
+  supplier_name: string;
+  skus: PivotSkuAgg[];
+  qty: number;
+  orderedQty: number;
+  amount: number;
+  prCount: number;
+};
 
 const STATUS_LABEL = PR_STATUS_LABEL;
 const REVIEW_LABEL = PR_REVIEW_LABEL;
@@ -149,6 +184,19 @@ export default function PurchaseRequestsListPage() {
     new Map(),
   );
 
+  // 檢視模式：清單（原本）/ 樞紐（把篩選出的 PR 品項依廠商彙整）
+  const [viewMode, setViewMode] = useState<"list" | "pivot">("list");
+  // 樞紐子篩選：全部品項 / 只看還沒轉成 PO 的品項（＝還要去跟廠商下單的量）
+  const [pivotOnlyUnordered, setPivotOnlyUnordered] = useState(false);
+  // 樞紐資料連同抓取當下的 reloadTick 一起存，tick 對不上就是過期 → 重撈。
+  // （用「資料自帶版本」取代 effect 裡同步 setState 清快取 / 開 loading）
+  const [pivotData, setPivotData] = useState<{ tick: number; list: PivotItem[] } | null>(
+    null,
+  );
+  const pivotReady = pivotData !== null && pivotData.tick === reloadTick;
+  const pivotItems = pivotReady ? pivotData.list : null;
+  const pivotLoading = viewMode === "pivot" && !pivotReady;
+
   // ============== 載入既有 PRs ==============
   useEffect(() => {
     let cancelled = false;
@@ -207,6 +255,118 @@ export default function PurchaseRequestsListPage() {
       cancelled = true;
     };
   }, [reloadTick]);
+
+  // ============== 樞紐資料（lazy）==============
+  // 切到樞紐才撈一次：所有未作廢 PR 的品項 + SKU 標籤 + 廠商名。
+  // 篩選（頁籤 / 搜尋 / 日期…）一律在前端套用，打字搜尋不會重打 API。
+  // 重入保護靠 pivotReady：抓取期間它維持 false 但依賴陣列不變，所以不會
+  // 重複發查詢；抓完（或失敗塞空陣列）才翻成 true 離開這個 effect。
+  useEffect(() => {
+    if (viewMode !== "pivot" || pivotReady || !rows) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const chunk = <T,>(arr: T[], n: number): T[][] => {
+          const out: T[][] = [];
+          for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
+          return out;
+        };
+        const targetPrs = rows.filter((r) => r.status !== "cancelled");
+        const prMeta = new Map(targetPrs.map((r) => [r.id, r]));
+        const prIds = targetPrs.map((r) => r.id);
+        if (prIds.length === 0) {
+          if (!cancelled) setPivotData({ tick: reloadTick, list: [] });
+          return;
+        }
+
+        type PrItemRow = {
+          pr_id: number;
+          sku_id: number;
+          qty_requested: number;
+          unit_cost: number;
+          suggested_supplier_id: number | null;
+          po_item_id: number | null;
+        };
+        // fetchAllRows 分頁：PR 品項很容易破 PostgREST 的 1000 列上限
+        const itemRows: PrItemRow[] = [];
+        for (const c of chunk(prIds, 200)) {
+          const part = await fetchAllRows<PrItemRow>(() =>
+            sb
+              .from("purchase_request_items")
+              .select(
+                "id, pr_id, sku_id, qty_requested, unit_cost, suggested_supplier_id, po_item_id",
+              )
+              .in("pr_id", c)
+              .order("id", { ascending: true }),
+          );
+          itemRows.push(...part);
+        }
+
+        // SKU 標籤
+        const skuIds = Array.from(new Set(itemRows.map((r) => r.sku_id)));
+        const skuLabel = new Map<number, string>();
+        for (const c of chunk(skuIds, 300)) {
+          const { data } = await sb
+            .from("skus")
+            .select("id, sku_code, variant_name, products!inner(name)")
+            .in("id", c);
+          type SkuLite = {
+            id: number;
+            sku_code: string | null;
+            variant_name: string | null;
+            products: { name: string } | { name: string }[] | null;
+          };
+          for (const s of (data as SkuLite[] | null) ?? []) {
+            const prod = Array.isArray(s.products) ? s.products[0] : s.products;
+            const base = prod?.name ?? s.sku_code ?? `#${s.id}`;
+            skuLabel.set(s.id, s.variant_name ? `${base} / ${s.variant_name}` : base);
+          }
+        }
+
+        // 廠商名
+        const supName = new Map<number, string>();
+        {
+          const { data } = await sb.from("suppliers").select("id, name");
+          for (const s of ((data ?? []) as { id: number; name: string }[])) {
+            supName.set(s.id, s.name);
+          }
+        }
+
+        // 查不到對應 PR 的品項直接略過（例：撈到一半那張 PR 被作廢 / 刪掉），
+        // 不要用 non-null assertion — 一個孤兒列就會讓整個樞紐炸成空白。
+        const list: PivotItem[] = itemRows.flatMap((r) => {
+          const pr = prMeta.get(r.pr_id);
+          if (!pr) return [];
+          const qty = Number(r.qty_requested) || 0;
+          return [{
+            pr_id: r.pr_id,
+            pr_no: pr.pr_no,
+            supplier_id: r.suggested_supplier_id,
+            supplier_name:
+              r.suggested_supplier_id !== null
+                ? supName.get(r.suggested_supplier_id) ?? null
+                : null,
+            sku_id: r.sku_id,
+            sku_label: skuLabel.get(r.sku_id) ?? `#${r.sku_id}`,
+            qty,
+            amount: qty * (Number(r.unit_cost) || 0),
+            ordered: r.po_item_id !== null,
+          }];
+        });
+        if (!cancelled) setPivotData({ tick: reloadTick, list });
+      } catch (e) {
+        // 設成空陣列避免「載入中」卡死；錯誤原因由上方 error banner 呈現。
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e));
+          setPivotData({ tick: reloadTick, list: [] });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [viewMode, pivotReady, rows, reloadTick]);
 
   // ============== 載入「結單日待開單」cards ==============
   useEffect(() => {
@@ -721,6 +881,84 @@ export default function PurchaseRequestsListPage() {
       .map(([k, v]) => ({ key: k, ...v }));
   }, [pageRows, groupBy]);
 
+  // 樞紐分組：依廠商 → SKU 彙整（請購量 / 已轉單 / 未轉單 / 金額）。
+  // 只納入目前篩選結果（filtered）裡的 PR，所以頁籤、搜尋、日期都自然生效。
+  const pivotGroups: PivotGroup[] = useMemo(() => {
+    if (!pivotItems) return [];
+    const visiblePrIds = new Set(filtered.map((r) => r.id));
+    const q = search.trim().toLowerCase();
+    const bySup = new Map<
+      number | null,
+      {
+        supplier_id: number | null;
+        supplier_name: string;
+        skus: Map<number, PivotSkuAgg>;
+        prIds: Set<number>;
+      }
+    >();
+    for (const it of pivotItems) {
+      if (!visiblePrIds.has(it.pr_id)) continue;
+      if (pivotOnlyUnordered && it.ordered) continue;
+      // filtered 只比對過 PR 單號 / 備註，樞紐再多讓廠商、品名也能命中
+      if (q) {
+        const hit = [it.pr_no, it.supplier_name, it.sku_label]
+          .filter((x): x is string => !!x)
+          .some((x) => x.toLowerCase().includes(q));
+        if (!hit) continue;
+      }
+      let sup = bySup.get(it.supplier_id);
+      if (!sup) {
+        sup = {
+          supplier_id: it.supplier_id,
+          supplier_name:
+            it.supplier_name ??
+            (it.supplier_id === null ? "未指派供應商" : `#${it.supplier_id}`),
+          skus: new Map(),
+          prIds: new Set(),
+        };
+        bySup.set(it.supplier_id, sup);
+      }
+      sup.prIds.add(it.pr_id);
+      let sk = sup.skus.get(it.sku_id);
+      if (!sk) {
+        sk = {
+          sku_id: it.sku_id,
+          label: it.sku_label,
+          qty: 0,
+          orderedQty: 0,
+          amount: 0,
+          prs: new Map(),
+        };
+        sup.skus.set(it.sku_id, sk);
+      }
+      sk.qty += it.qty;
+      if (it.ordered) sk.orderedQty += it.qty;
+      sk.amount += it.amount;
+      sk.prs.set(it.pr_id, it.pr_no);
+    }
+    return Array.from(bySup.values())
+      .map((sup) => {
+        const skus = Array.from(sup.skus.values()).sort((a, b) =>
+          a.label.localeCompare(b.label),
+        );
+        return {
+          supplier_id: sup.supplier_id,
+          supplier_name: sup.supplier_name,
+          skus,
+          qty: skus.reduce((s, r) => s + r.qty, 0),
+          orderedQty: skus.reduce((s, r) => s + r.orderedQty, 0),
+          amount: skus.reduce((s, r) => s + r.amount, 0),
+          prCount: sup.prIds.size,
+        };
+      })
+      .sort((a, b) => {
+        // 未指派供應商排最前面（最需要處理）
+        if (a.supplier_id === null) return -1;
+        if (b.supplier_id === null) return 1;
+        return a.supplier_name.localeCompare(b.supplier_name);
+      });
+  }, [pivotItems, filtered, search, pivotOnlyUnordered]);
+
   function setSort(col: SortCol) {
     if (sortBy === col) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
     else {
@@ -903,6 +1141,40 @@ export default function PurchaseRequestsListPage() {
         </section>
       )}
 
+      {/* === 檢視切換：清單 / 樞紐 === */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="inline-flex rounded-md border border-zinc-300 p-0.5 dark:border-zinc-700">
+          <SpinButton
+            onClick={() => setViewMode("list")}
+            className={`rounded px-3 py-1 text-sm ${viewMode === "list" ? "bg-blue-600 font-semibold text-white" : "text-zinc-600 dark:text-zinc-300"}`}
+          >
+            清單
+          </SpinButton>
+          <SpinButton
+            onClick={() => setViewMode("pivot")}
+            className={`rounded px-3 py-1 text-sm ${viewMode === "pivot" ? "bg-blue-600 font-semibold text-white" : "text-zinc-600 dark:text-zinc-300"}`}
+          >
+            樞紐（依廠商）
+          </SpinButton>
+        </div>
+        {viewMode === "pivot" && (
+          <>
+            <label className="flex cursor-pointer items-center gap-1.5 text-sm text-zinc-600 dark:text-zinc-300">
+              <input
+                type="checkbox"
+                checked={pivotOnlyUnordered}
+                onChange={(e) => setPivotOnlyUnordered(e.target.checked)}
+                className="h-3.5 w-3.5 accent-amber-500"
+              />
+              只看未轉{PO_TERM_ZH}的品項
+            </label>
+            <span className="text-xs text-zinc-400">
+              彙整範圍＝目前篩選出的 {total} 張{PR_TERM_ZH}（不含已作廢）
+            </span>
+          </>
+        )}
+      </div>
+
       {/* === 狀態 tabs === */}
       <div className="flex flex-wrap gap-1 border-b border-zinc-200 dark:border-zinc-800">
         {STATUS_TAB_ORDER.map((s) => {
@@ -1009,7 +1281,12 @@ export default function PurchaseRequestsListPage() {
         </span>
       </div>
 
+      {viewMode === "pivot" && (
+        <PrPivot groups={pivotGroups} loading={pivotLoading} onlyUnordered={pivotOnlyUnordered} />
+      )}
+
       {/* === 主表格 === */}
+      {viewMode === "list" && (
       <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
@@ -1109,9 +1386,10 @@ export default function PurchaseRequestsListPage() {
           </tbody>
         </table>
       </div>
+      )}
 
       {/* === 分頁 === */}
-      {total > PAGE_SIZE && (
+      {viewMode === "list" && total > PAGE_SIZE && (
         <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
           <span className="text-xs text-zinc-500">
             共 {total} 筆 · 顯示 {(page - 1) * PAGE_SIZE + 1} -{" "}
@@ -1323,6 +1601,173 @@ function KpiCard({
       <div className={`mt-0.5 text-2xl font-semibold ${accent}`}>{value}</div>
       {hint && <div className="mt-0.5 text-[10px] text-zinc-400">{hint}</div>}
     </Wrapper>
+  );
+}
+
+// 樞紐：依廠商彙整篩選範圍內所有 PR 的品項，一家一張卡片。
+function PrPivot({
+  groups,
+  loading,
+  onlyUnordered,
+}: {
+  groups: PivotGroup[];
+  loading: boolean;
+  onlyUnordered: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
+        載入樞紐資料中…
+      </div>
+    );
+  }
+  if (groups.length === 0) {
+    return (
+      <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
+        {onlyUnordered
+          ? `目前篩選範圍內沒有「尚未轉${PO_TERM_ZH}」的品項。`
+          : "目前篩選範圍內沒有品項。"}
+      </div>
+    );
+  }
+  const totQty = groups.reduce((s, g) => s + g.qty, 0);
+  const totOrdered = groups.reduce((s, g) => s + g.orderedQty, 0);
+  const totAmount = groups.reduce((s, g) => s + g.amount, 0);
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="text-xs text-zinc-500">
+        {groups.length} 家廠商 · 請購合計 {totQty} · 已轉單 {totOrdered} · 未轉單{" "}
+        {totQty - totOrdered} · 金額 ${Math.round(totAmount).toLocaleString()}
+      </div>
+      {groups.map((g) => {
+        const outstanding = g.qty - g.orderedQty;
+        return (
+          <div
+            key={g.supplier_id ?? "none"}
+            className="overflow-hidden rounded-md border border-zinc-200 dark:border-zinc-800"
+          >
+            <div className="flex flex-wrap items-baseline justify-between gap-2 bg-zinc-50 px-3 py-2 dark:bg-zinc-900">
+              <div
+                className={`font-semibold ${
+                  g.supplier_id === null ? "text-red-600 dark:text-red-400" : ""
+                }`}
+              >
+                {g.supplier_name}
+                <span className="ml-2 text-xs font-normal text-zinc-500">
+                  {g.prCount} 張 {PR_TERM_ZH} · {g.skus.length} 品項
+                </span>
+              </div>
+              <div className="text-xs text-zinc-500">
+                請購 {g.qty} · 已轉單 {g.orderedQty} ·{" "}
+                <span className={outstanding > 0 ? "text-amber-600 dark:text-amber-400" : ""}>
+                  未轉單 {outstanding}
+                </span>{" "}
+                · <span className="font-mono">${Math.round(g.amount).toLocaleString()}</span>
+              </div>
+            </div>
+
+            {/* 桌機：表格 */}
+            <div className="hidden overflow-x-auto sm:block">
+              <table className="min-w-full text-sm">
+                <thead className="text-xs text-zinc-500">
+                  <tr className="border-b border-zinc-200 dark:border-zinc-800">
+                    <th className="px-3 py-1.5 text-left font-medium">品項</th>
+                    <th className="px-3 py-1.5 text-right font-medium">請購</th>
+                    <th className="px-3 py-1.5 text-right font-medium">已轉單</th>
+                    <th className="px-3 py-1.5 text-right font-medium">未轉單</th>
+                    <th className="px-3 py-1.5 text-right font-medium">金額</th>
+                    <th className="px-3 py-1.5 text-left font-medium">來源 {PR_TERM_ZH}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {g.skus.map((s) => {
+                    const left = s.qty - s.orderedQty;
+                    return (
+                      <tr key={s.sku_id} className="border-b border-zinc-100 dark:border-zinc-800/60">
+                        <td className="px-3 py-1.5">{s.label}</td>
+                        <td className="px-3 py-1.5 text-right font-mono">{s.qty}</td>
+                        <td className="px-3 py-1.5 text-right font-mono">{s.orderedQty}</td>
+                        <td
+                          className={`px-3 py-1.5 text-right font-mono ${
+                            left > 0 ? "text-amber-600 dark:text-amber-400" : "text-zinc-400"
+                          }`}
+                        >
+                          {left}
+                        </td>
+                        <td className="px-3 py-1.5 text-right font-mono">
+                          ${Math.round(s.amount).toLocaleString()}
+                        </td>
+                        <td className="px-3 py-1.5 font-mono text-xs">
+                          <PrLinks prs={s.prs} />
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            {/* 手機：每個品項一張堆疊卡片 */}
+            <ul className="divide-y divide-zinc-100 sm:hidden dark:divide-zinc-800/60">
+              {g.skus.map((s) => {
+                const left = s.qty - s.orderedQty;
+                return (
+                  <li key={s.sku_id} className="px-3 py-2">
+                    <div className="text-sm">{s.label}</div>
+                    <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-0.5 text-xs text-zinc-500">
+                      <span>
+                        請購{" "}
+                        <span className="font-mono text-zinc-800 dark:text-zinc-200">{s.qty}</span>
+                      </span>
+                      <span>
+                        已轉單{" "}
+                        <span className="font-mono text-zinc-800 dark:text-zinc-200">
+                          {s.orderedQty}
+                        </span>
+                      </span>
+                      <span>
+                        未轉單{" "}
+                        <span
+                          className={`font-mono ${
+                            left > 0 ? "text-amber-600 dark:text-amber-400" : "text-zinc-400"
+                          }`}
+                        >
+                          {left}
+                        </span>
+                      </span>
+                      <span className="font-mono">${Math.round(s.amount).toLocaleString()}</span>
+                    </div>
+                    <div className="mt-0.5 font-mono text-[11px] text-zinc-400">
+                      {PR_TERM_ZH} <PrLinks prs={s.prs} />
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// 樞紐裡的來源 PR 單號清單：每個單號連到 PR 詳細頁
+function PrLinks({ prs }: { prs: Map<number, string> }) {
+  const entries = Array.from(prs.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+  return (
+    <>
+      {entries.map(([id, no], i) => (
+        <span key={id}>
+          {i > 0 && <span className="text-zinc-400">、</span>}
+          <Link
+            href={`/purchase/requests/edit?id=${id}`}
+            className="text-blue-600 hover:underline dark:text-blue-400"
+          >
+            {no}
+          </Link>
+        </span>
+      ))}
+    </>
   );
 }
 

--- a/supabase/migrations/20260729000000_po_pr_list_server_side.sql
+++ b/supabase/migrations/20260729000000_po_pr_list_server_side.sql
@@ -1,0 +1,470 @@
+-- ============================================================
+-- 採購單 / 請購單列表：server-side 篩選 + 分頁 + 計數
+--
+-- 背景：
+--   兩張列表頁原本都是「前端全撈再自己篩」。採購單頁寫死 .limit(500)
+--   取最近更新的 500 張 —— 線上已 778 張 PO，搜 PO2606180538（依
+--   updated_at desc 排第 714 名）根本搜不到，狀態頁籤與 KPI 也少算。
+--   把 limit 拿掉只是把問題延後：單數再長下去首屏傳輸量會失控。
+--
+-- 解法：比照 rpc_hq_exceptions 的慣例，改成 server-side RPC，
+--   一次回傳 { total, counts, kpi, rows(當前頁) }，前端只收當頁資料。
+--   搜尋在 DB 用 ILIKE 比對，跨表條件（來源請購單單號、商品名）走 EXISTS，
+--   不再受「前端載了多少筆」限制。
+--
+--   1. rpc_po_list           採購單列表
+--   2. rpc_pr_list           請購單列表
+--   3. rpc_pr_supplier_pivot 請購單樞紐（依廠商彙整品項，直接在 DB 聚合）
+--
+-- 慣例對齊：
+--   - SECURITY DEFINER + 自行用 public._current_tenant_id() 綁租戶
+--     （同 rpc_hq_exceptions：admin JWT 的 role claim 可能為 NULL，
+--      走 RLS 會讀不到；因此改由函式內明確過濾 tenant_id）
+--   - 回傳 jsonb { total, counts, ... }，GRANT EXECUTE TO authenticated
+--   - 排序欄位以白名單映射後才進 format()，不接受任意字串
+--
+-- 基於：無前身（這三支都是新函式，未動任何既有 view / function）。
+-- Rollback:
+--   DROP FUNCTION public.rpc_po_list(text,bigint,text,date,date,text,text,int,int);
+--   DROP FUNCTION public.rpc_pr_list(text,text,text,text,date,date,text,text,int,int);
+--   DROP FUNCTION public.rpc_pr_supplier_pivot(text,text,text,text,date,date,boolean);
+-- ============================================================
+
+
+-- ----------------------------------------------------------------
+-- 1. rpc_po_list — 採購單列表
+-- ----------------------------------------------------------------
+-- 回傳：
+--   {
+--     "total":     <套用篩選後的張數>,
+--     "counts":    { "all": N, "draft": N, ... },   -- 狀態頁籤；只綁租戶，不受其他篩選影響（同原前端行為）
+--     "kpi":       { "draft", "pending_arrival", "overdue", "pending_amount" },
+--     "suppliers": [ { "id", "name" } ],            -- 廠商下拉選項（全租戶，不受分頁影響）
+--     "rows":      [ { ...含 supplier_name / pr_no / item_count / product_names... } ]
+--   }
+-- p_status = NULL / 'all' → 不分狀態。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_po_list(
+  p_status      text   DEFAULT NULL,
+  p_supplier_id bigint DEFAULT NULL,
+  p_search      text   DEFAULT NULL,
+  p_date_from   date   DEFAULT NULL,
+  p_date_to     date   DEFAULT NULL,
+  p_sort        text   DEFAULT 'updated_at',
+  p_dir         text   DEFAULT 'desc',
+  p_page        int    DEFAULT 1,
+  p_page_size   int    DEFAULT 30
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_tenant uuid := public._current_tenant_id();
+  v_sort   text;
+  v_dir    text;
+  v_size   int  := GREATEST(1, LEAST(COALESCE(p_page_size, 30), 200));
+  v_offset int;
+  v_rows   jsonb;
+  v_total  bigint;
+BEGIN
+  -- 排序欄位白名單（絕不把 p_sort 原字串塞進 SQL）
+  v_sort := CASE lower(COALESCE(p_sort, 'updated_at'))
+              WHEN 'po_no'         THEN 'b.po_no'
+              WHEN 'total'         THEN 'b.total'
+              WHEN 'expected_date' THEN 'b.expected_date'
+              WHEN 'supplier'      THEN 'b.supplier_name'
+              ELSE                      'b.updated_at'
+            END;
+  v_dir    := CASE WHEN lower(COALESCE(p_dir, 'desc')) = 'asc' THEN 'ASC' ELSE 'DESC' END;
+  v_offset := GREATEST(0, (GREATEST(1, COALESCE(p_page, 1)) - 1) * v_size);
+
+  EXECUTE format($q$
+    WITH base AS (
+      -- 篩選條件只寫一次；只取 id + 排序鍵，撐不大
+      SELECT po.id, po.po_no, po.total, po.expected_date, po.updated_at,
+             s.name AS supplier_name
+      FROM purchase_orders po
+      LEFT JOIN suppliers s ON s.id = po.supplier_id
+      WHERE po.tenant_id = $1
+        AND ($2 IS NULL OR $2 = 'all' OR po.status = $2)
+        AND ($3 IS NULL OR po.supplier_id = $3)
+        AND ($4 IS NULL OR po.created_at >= $4::timestamptz)
+        AND ($5 IS NULL OR po.created_at < ($5::date + 1)::timestamptz)
+        AND ($6 IS NULL OR (
+              po.po_no ILIKE '%%' || $6 || '%%'
+           OR s.name   ILIKE '%%' || $6 || '%%'
+           OR EXISTS (
+                SELECT 1 FROM purchase_order_items poi
+                JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+                JOIN purchase_requests pr       ON pr.id = pri.pr_id
+                WHERE poi.po_id = po.id AND pr.pr_no ILIKE '%%' || $6 || '%%')
+           OR EXISTS (
+                SELECT 1 FROM purchase_order_items poi
+                JOIN skus sk     ON sk.id = poi.sku_id
+                JOIN products pd ON pd.id = sk.product_id
+                WHERE poi.po_id = po.id AND pd.name ILIKE '%%' || $6 || '%%')
+        ))
+    ),
+    picked AS (
+      SELECT b.id, row_number() OVER (ORDER BY %s %s NULLS LAST, b.id DESC) AS rn
+      FROM base b
+      ORDER BY %s %s NULLS LAST, b.id DESC
+      LIMIT $7 OFFSET $8
+    ),
+    -- 只對「當前頁」做昂貴的 lateral 補值（品項數 / 商品名 / 來源 PR）
+    page AS (
+      SELECT
+        po.id, po.po_no, po.supplier_id, s.name AS supplier_name, po.status,
+        po.total, po.expected_date, po.sent_at, po.sent_channel, po.stockout_at,
+        po.created_at, po.updated_at,
+        src.pr_id, src.pr_no,
+        COALESCE(it.item_count, 0)                  AS item_count,
+        COALESCE(it.product_names, ARRAY[]::text[]) AS product_names,
+        pk.rn
+      FROM picked pk
+      JOIN purchase_orders po ON po.id = pk.id
+      LEFT JOIN suppliers s   ON s.id = po.supplier_id
+      LEFT JOIN LATERAL (
+        SELECT count(*) AS item_count,
+               array_agg(DISTINCT pd.name) FILTER (WHERE pd.name IS NOT NULL) AS product_names
+        FROM purchase_order_items poi
+        LEFT JOIN skus sk     ON sk.id = poi.sku_id
+        LEFT JOIN products pd ON pd.id = sk.product_id
+        WHERE poi.po_id = po.id
+      ) it ON true
+      LEFT JOIN LATERAL (
+        SELECT pr.id AS pr_id, pr.pr_no
+        FROM purchase_order_items poi
+        JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+        JOIN purchase_requests pr       ON pr.id = pri.pr_id
+        WHERE poi.po_id = po.id
+        LIMIT 1
+      ) src ON true
+    )
+    SELECT
+      (SELECT count(*) FROM base),
+      COALESCE((SELECT jsonb_agg(to_jsonb(page) - 'rn' ORDER BY page.rn) FROM page), '[]'::jsonb)
+  $q$, v_sort, v_dir, v_sort, v_dir)
+  INTO v_total, v_rows
+  USING v_tenant, p_status, p_supplier_id, p_date_from, p_date_to,
+        NULLIF(btrim(COALESCE(p_search, '')), ''), v_size, v_offset;
+
+  RETURN jsonb_build_object(
+    'total', v_total,
+    'counts', (
+      SELECT jsonb_build_object(
+        'all',                count(*),
+        'draft',              count(*) FILTER (WHERE status = 'draft'),
+        'sent',               count(*) FILTER (WHERE status = 'sent'),
+        'partially_received', count(*) FILTER (WHERE status = 'partially_received'),
+        'fully_received',     count(*) FILTER (WHERE status = 'fully_received'),
+        'closed',             count(*) FILTER (WHERE status = 'closed'),
+        'cancelled',          count(*) FILTER (WHERE status = 'cancelled')
+      )
+      FROM purchase_orders WHERE tenant_id = v_tenant
+    ),
+    'kpi', (
+      SELECT jsonb_build_object(
+        'draft',           count(*) FILTER (WHERE status = 'draft'),
+        'pending_arrival', count(*) FILTER (WHERE status IN ('sent','partially_received')),
+        -- 逾期＝已發送/部分到貨且預計到貨日已過（對齊原前端：只看在途單）
+        'overdue',         count(*) FILTER (
+                             WHERE status IN ('sent','partially_received')
+                               AND expected_date IS NOT NULL
+                               AND expected_date < current_date),
+        'pending_amount',  COALESCE(sum(total) FILTER (
+                             WHERE status IN ('sent','partially_received')), 0)
+      )
+      FROM purchase_orders WHERE tenant_id = v_tenant
+    ),
+    'suppliers', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object('id', d.id, 'name', d.name) ORDER BY d.name), '[]'::jsonb)
+      FROM (
+        SELECT DISTINCT s.id, s.name
+        FROM purchase_orders po
+        JOIN suppliers s ON s.id = po.supplier_id
+        WHERE po.tenant_id = v_tenant
+      ) d
+    ),
+    'rows', v_rows
+  );
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.rpc_po_list(text,bigint,text,date,date,text,text,int,int) IS
+  '採購單列表 server-side 篩選/排序/分頁：回傳 { total, counts, kpi, suppliers, rows(當前頁) }。搜尋以 ILIKE 比對單號/廠商/來源請購單單號/商品名。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_po_list(text,bigint,text,date,date,text,text,int,int) TO authenticated;
+
+
+-- ----------------------------------------------------------------
+-- 2. rpc_pr_list — 請購單列表
+-- ----------------------------------------------------------------
+-- 回傳：
+--   {
+--     "total":  <套用篩選後的張數>,
+--     "counts": { "all", "draft", "submitted", "partially_ordered", "fully_ordered", "cancelled" },
+--     "kpi":    { "pending_review", "to_split", "amount_in_flight", "unassigned" },
+--     "rows":   [ { ...PR 欄位 + v_pr_progress 進度欄位... } ]
+--   }
+-- 搜尋比對：單號 / 備註（同原前端）。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_pr_list(
+  p_status    text DEFAULT NULL,
+  p_review    text DEFAULT NULL,
+  p_source    text DEFAULT NULL,
+  p_search    text DEFAULT NULL,
+  p_date_from date DEFAULT NULL,
+  p_date_to   date DEFAULT NULL,
+  p_sort      text DEFAULT 'updated_at',
+  p_dir       text DEFAULT 'desc',
+  p_page      int  DEFAULT 1,
+  p_page_size int  DEFAULT 20
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_tenant uuid := public._current_tenant_id();
+  v_sort   text;
+  v_dir    text;
+  v_size   int  := GREATEST(1, LEAST(COALESCE(p_page_size, 20), 200));
+  v_offset int;
+  v_rows   jsonb;
+  v_total  bigint;
+BEGIN
+  v_sort := CASE lower(COALESCE(p_sort, 'updated_at'))
+              WHEN 'pr_no'             THEN 'b.pr_no'
+              WHEN 'total_amount'      THEN 'b.total_amount'
+              WHEN 'source_close_date' THEN 'b.source_close_date'
+              ELSE                          'b.updated_at'
+            END;
+  v_dir    := CASE WHEN lower(COALESCE(p_dir, 'desc')) = 'asc' THEN 'ASC' ELSE 'DESC' END;
+  v_offset := GREATEST(0, (GREATEST(1, COALESCE(p_page, 1)) - 1) * v_size);
+
+  EXECUTE format($q$
+    WITH base AS (
+      SELECT pr.id, pr.pr_no, pr.total_amount, pr.source_close_date, pr.updated_at
+      FROM purchase_requests pr
+      WHERE pr.tenant_id = $1
+        AND ($2 IS NULL OR $2 = 'all' OR pr.status = $2)
+        AND ($3 IS NULL OR pr.review_status = $3)
+        AND ($4 IS NULL OR pr.source_type = $4)
+        AND ($5 IS NULL OR (pr.source_close_date IS NOT NULL AND pr.source_close_date >= $5))
+        AND ($6 IS NULL OR (pr.source_close_date IS NOT NULL AND pr.source_close_date <= $6))
+        AND ($7 IS NULL OR (
+              pr.pr_no ILIKE '%%' || $7 || '%%'
+           OR COALESCE(pr.notes, '') ILIKE '%%' || $7 || '%%'
+        ))
+    ),
+    picked AS (
+      SELECT b.id, row_number() OVER (ORDER BY %s %s NULLS LAST, b.id DESC) AS rn
+      FROM base b
+      ORDER BY %s %s NULLS LAST, b.id DESC
+      LIMIT $8 OFFSET $9
+    ),
+    page AS (
+      SELECT
+        pr.id, pr.pr_no, pr.source_type, pr.source_close_date, pr.status,
+        pr.review_status, pr.total_amount, pr.notes, pr.updated_at,
+        COALESCE(vp.po_total, 0)                  AS po_total,
+        COALESCE(vp.po_sent, 0)                   AS po_sent,
+        COALESCE(vp.po_received_fully, 0)         AS po_received_fully,
+        COALESCE(vp.transfer_total, 0)            AS transfer_total,
+        COALESCE(vp.transfer_shipped, 0)          AS transfer_shipped,
+        COALESCE(vp.transfer_delivered, 0)        AS transfer_delivered,
+        COALESCE(vp.item_count, 0)                AS item_count,
+        COALESCE(vp.unassigned_supplier_count, 0) AS unassigned_supplier_count,
+        COALESCE(vp.all_campaigns_finalized, false) AS all_campaigns_finalized,
+        pk.rn
+      FROM picked pk
+      JOIN purchase_requests pr ON pr.id = pk.id
+      LEFT JOIN v_pr_progress vp ON vp.pr_id = pr.id
+    )
+    SELECT
+      (SELECT count(*) FROM base),
+      COALESCE((SELECT jsonb_agg(to_jsonb(page) - 'rn' ORDER BY page.rn) FROM page), '[]'::jsonb)
+  $q$, v_sort, v_dir, v_sort, v_dir)
+  INTO v_total, v_rows
+  USING v_tenant, p_status, p_review, p_source, p_date_from, p_date_to,
+        NULLIF(btrim(COALESCE(p_search, '')), ''), v_size, v_offset;
+
+  RETURN jsonb_build_object(
+    'total', v_total,
+    'counts', (
+      SELECT jsonb_build_object(
+        'all',               count(*),
+        'draft',             count(*) FILTER (WHERE status = 'draft'),
+        'submitted',         count(*) FILTER (WHERE status = 'submitted'),
+        'partially_ordered', count(*) FILTER (WHERE status = 'partially_ordered'),
+        'fully_ordered',     count(*) FILTER (WHERE status = 'fully_ordered'),
+        'cancelled',         count(*) FILTER (WHERE status = 'cancelled')
+      )
+      FROM purchase_requests WHERE tenant_id = v_tenant
+    ),
+    'kpi', jsonb_build_object(
+      'pending_review', (
+        SELECT count(*) FROM purchase_requests
+        WHERE tenant_id = v_tenant AND review_status = 'pending_review'),
+      'to_split', (
+        SELECT count(*) FROM purchase_requests
+        WHERE tenant_id = v_tenant AND review_status = 'approved'
+          AND status NOT IN ('fully_ordered','cancelled')),
+      'amount_in_flight', (
+        SELECT COALESCE(sum(total_amount), 0) FROM purchase_requests
+        WHERE tenant_id = v_tenant AND review_status = 'approved'
+          AND status NOT IN ('fully_ordered','cancelled')),
+      -- 待指派供應商＝所有 PR 品項中 suggested_supplier_id 為空的列數（同原前端加總）
+      'unassigned', (
+        SELECT count(*)
+        FROM purchase_request_items pri
+        JOIN purchase_requests pr ON pr.id = pri.pr_id
+        WHERE pr.tenant_id = v_tenant AND pri.suggested_supplier_id IS NULL)
+    ),
+    'rows', v_rows
+  );
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.rpc_pr_list(text,text,text,text,date,date,text,text,int,int) IS
+  '請購單列表 server-side 篩選/排序/分頁：回傳 { total, counts, kpi, rows(當前頁，含 v_pr_progress 進度) }。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_pr_list(text,text,text,text,date,date,text,text,int,int) TO authenticated;
+
+
+-- ----------------------------------------------------------------
+-- 3. rpc_pr_supplier_pivot — 請購單樞紐（依廠商彙整品項）
+-- ----------------------------------------------------------------
+-- 與 rpc_pr_list 吃同一組篩選（狀態 / 審核 / 來源 / 結單日），
+-- 差別在搜尋：樞紐是品項視角，所以搜尋同時比對
+-- 單號 / 備註 / 廠商名 / 商品名，避免「搜商品名卻整個樞紐空掉」。
+-- 已作廢的 PR 一律不納入。
+--
+-- 回傳：
+--   { "groups": [ { supplier_id, supplier_name, qty, ordered_qty, amount, pr_count,
+--                   skus: [ { sku_id, label, qty, ordered_qty, amount,
+--                             prs: [ { id, pr_no } ] } ] } ] }
+-- p_only_unordered = true → 只算尚未轉成 PO 品項的列。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_pr_supplier_pivot(
+  p_status         text    DEFAULT NULL,
+  p_review         text    DEFAULT NULL,
+  p_source         text    DEFAULT NULL,
+  p_search         text    DEFAULT NULL,
+  p_date_from      date    DEFAULT NULL,
+  p_date_to        date    DEFAULT NULL,
+  p_only_unordered boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+  WITH q AS (
+    SELECT NULLIF(btrim(COALESCE(p_search, '')), '') AS kw,
+           public._current_tenant_id()               AS tenant
+  ),
+  items AS (
+    SELECT
+      pri.pr_id,
+      pr.pr_no,
+      pri.suggested_supplier_id                       AS supplier_id,
+      s.name                                          AS supplier_name,
+      pri.sku_id,
+      COALESCE(
+        NULLIF(TRIM(COALESCE(pd.name, sk.sku_code, '') ||
+                    COALESCE(' / ' || NULLIF(sk.variant_name, ''), '')), ''),
+        '品項#' || pri.sku_id::text
+      )                                               AS sku_label,
+      COALESCE(pri.qty_requested, 0)                  AS qty,
+      COALESCE(pri.qty_requested, 0) * COALESCE(pri.unit_cost, 0) AS amount,
+      (pri.po_item_id IS NOT NULL)                    AS ordered
+    FROM purchase_request_items pri
+    JOIN purchase_requests pr ON pr.id = pri.pr_id
+    CROSS JOIN q
+    LEFT JOIN suppliers s  ON s.id  = pri.suggested_supplier_id
+    LEFT JOIN skus sk      ON sk.id = pri.sku_id
+    LEFT JOIN products pd  ON pd.id = sk.product_id
+    WHERE pr.tenant_id = q.tenant
+      AND pr.status <> 'cancelled'
+      AND (p_status    IS NULL OR p_status = 'all' OR pr.status = p_status)
+      AND (p_review    IS NULL OR pr.review_status = p_review)
+      AND (p_source    IS NULL OR pr.source_type = p_source)
+      AND (p_date_from IS NULL OR (pr.source_close_date IS NOT NULL AND pr.source_close_date >= p_date_from))
+      AND (p_date_to   IS NULL OR (pr.source_close_date IS NOT NULL AND pr.source_close_date <= p_date_to))
+      AND (NOT p_only_unordered OR pri.po_item_id IS NULL)
+      AND (q.kw IS NULL OR (
+            pr.pr_no ILIKE '%' || q.kw || '%'
+         OR COALESCE(pr.notes, '') ILIKE '%' || q.kw || '%'
+         OR COALESCE(s.name, '')   ILIKE '%' || q.kw || '%'
+         OR COALESCE(pd.name, '')  ILIKE '%' || q.kw || '%'
+         OR COALESCE(sk.sku_code, '') ILIKE '%' || q.kw || '%'
+      ))
+  ),
+  by_sku AS (
+    SELECT
+      supplier_id,
+      MAX(supplier_name)                          AS supplier_name,
+      sku_id,
+      MAX(sku_label)                              AS label,
+      SUM(qty)                                    AS qty,
+      SUM(qty) FILTER (WHERE ordered)             AS ordered_qty,
+      SUM(amount)                                 AS amount,
+      jsonb_agg(DISTINCT jsonb_build_object('id', pr_id, 'pr_no', pr_no)) AS prs
+    FROM items
+    GROUP BY supplier_id, sku_id
+  ),
+  by_supplier AS (
+    SELECT
+      k.supplier_id,
+      COALESCE(MAX(k.supplier_name), '未指派供應商') AS supplier_name,
+      SUM(k.qty)                                     AS qty,
+      COALESCE(SUM(k.ordered_qty), 0)                AS ordered_qty,
+      SUM(k.amount)                                  AS amount,
+      (SELECT count(DISTINCT i.pr_id) FROM items i
+        WHERE i.supplier_id IS NOT DISTINCT FROM k.supplier_id) AS pr_count,
+      jsonb_agg(
+        jsonb_build_object(
+          'sku_id',      k.sku_id,
+          'label',       k.label,
+          'qty',         k.qty,
+          'ordered_qty', COALESCE(k.ordered_qty, 0),
+          'amount',      k.amount,
+          'prs',         k.prs
+        ) ORDER BY k.label
+      ) AS skus
+    FROM by_sku k
+    GROUP BY k.supplier_id
+  )
+  SELECT jsonb_build_object(
+    'groups',
+    COALESCE(
+      (SELECT jsonb_agg(
+         jsonb_build_object(
+           'supplier_id',   supplier_id,
+           'supplier_name', supplier_name,
+           'qty',           qty,
+           'ordered_qty',   ordered_qty,
+           'amount',        amount,
+           'pr_count',      pr_count,
+           'skus',          skus
+         )
+         -- 未指派供應商排最前面（最需要處理）
+         ORDER BY (supplier_id IS NOT NULL), supplier_name
+       )
+       FROM by_supplier),
+      '[]'::jsonb)
+  );
+$fn$;
+
+COMMENT ON FUNCTION public.rpc_pr_supplier_pivot(text,text,text,text,date,date,boolean) IS
+  '請購單樞紐：依廠商 → SKU 聚合請購量 / 已轉單量 / 金額 / 來源請購單，全部在 DB 算完。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_pr_supplier_pivot(text,text,text,text,date,date,boolean) TO authenticated;


### PR DESCRIPTION
## 這包在做什麼

從「請購單品項看不出對應哪張採購單」開始，一路修到「採購單搜尋搜不到舊單」的根因。

### 1. 請購單編輯頁：品項依廠商分組

- 一家廠商一組，群組標題列顯示 **廠商 / 項數 / 數量 / 小計**，後面接該組落在哪幾張 PO（含狀態、可點進去）
- 新增「採購單」欄（已拆單才出現），每列都看得到自己被拆進哪張 PO
- 未指派供應商獨立成一組排最後，草稿階段一眼看得出還缺誰
- 草稿預設不分組（指派供應商時該列會跳到別組，連續作業很難做），已送審／已轉單預設分組；勾選框隨時可切
- 分組純粹是顯示層重排：群組內保留 `items` 原始 index，`patchItem` / `removeItem` 行為不變

### 2. 請購單列表頁：新增「清單／樞紐（依廠商）」

比照採購單列表既有的切換：

- 樞紐把篩選範圍內所有請購單的品項依 `廠商 → SKU` 彙整：請購 / 已轉單 / 未轉單 / 金額 / 來源請購單（可點回該張 PR），同一 SKU 跨多張 PR 會合併加總
- 子開關「只看未轉採購單的品項」＝還要去跟廠商下單的量
- 未指派供應商那組排最前面

### 3. 修 bug：採購單搜尋找不到 PO2606180538

該 PO 存在（id 222、已發送），問題是列表寫死 `.limit(500)` 只取最近更新的 500 張 —— 線上 778 張，這張依 `updated_at desc` 排第 **714** 名，根本沒被載進畫面。第 501 張之後的 278 張全部搜不到，狀態頁籤與 KPI 也少算，而標題還寫「共 500 張 PO」看起來像完整的。

### 4. 兩張列表改 server-side

拿掉 limit 只是把問題延後（傳輸量隨單數線性長），所以改成比照 `rpc_hq_exceptions` 的慣例走 RPC。

新 migration `20260729000000_po_pr_list_server_side.sql`，三支都是**新函式，未動任何既有 view / function**：

| RPC | 用途 |
| --- | --- |
| `rpc_po_list` | 採購單清單。單號 / 廠商 / 來源請購單單號 / 商品名以 ILIKE 比對，跨表條件走 EXISTS；回傳 `{ total, counts, kpi, suppliers, rows(當頁) }`。昂貴的 lateral 補值只對當頁 30 筆做 |
| `rpc_pr_list` | 請購單清單，rows 直接帶 `v_pr_progress` 的進度欄位 |
| `rpc_pr_supplier_pivot` | 樞紐的「依廠商 → SKU」聚合改在 DB 算完，前端只收彙總結果 |

- 排序欄位一律先過白名單再進 `format()`，其餘條件全走參數
- `SECURITY DEFINER` + 自行以 `_current_tenant_id()` 綁租戶（同 `rpc_hq_exceptions` 的理由：admin JWT 的 role claim 可能為 NULL，走 RLS 讀不到）
- 前端搜尋 300ms debounce 才進 DB
- 採購單樞紐改自己查「已下單 / 部分到貨」的 PO，不再依賴清單載了哪些

## 驗證

**SQL 直接對線上 DB 驗**（Management API）：

- 搜 `PO2606180538` → 回 1 筆，帶齊供應商「金鑽」、來源 `PR2606180397`、2 個品項的商品名
- 搜來源單號 `PR2606180397` → 14 張 PO（與該 PR 畫面上的 14 張一致）；搜廠商名 → 21 張；搜商品名 → 2 張
- 分頁 / 排序 / 狀態篩選各自回不同結果，`counts.all` = 778 與 `count(*)` 相符
- 樞紐交叉比對 PR 39 原始資料：14 家廠商、總量 2597、金額 $141,158，**與 raw SQL 完全一致**

**UI 用「線上實際回傳的 RPC 結果」當 fixture 跑 Playwright**：

- 採購單：共 778 張、頁籤 314/68/367/9/20、26 頁、KPI $3,247,295.9；搜 `PO2606180538` ✅ 找到且 `p_search` 確實送進 DB
- 請購單：共 166 筆、待指派供應商 251；樞紐 14 家廠商 $141,158，切「只看未轉單」→ 8 家、未轉單 9190
- 請購單編輯頁：已轉單 PR 依廠商分組正確（跨兩張 PO 的組會同時列出兩張）；草稿 PR 預設平鋪、勾選後分組，供應商 picker／數量成本輸入／刪列鈕都正常
- 四種情境皆無 console error

**回歸驗證**：用會照 PostgREST 規則處理 `?limit=` 與 `Range` 的 stub 做出線上規模（778 張、目標 PO 第 714 名）—— 修改前載入 500/778、搜尋 ❌ 找不到（成功重現）；修改後 ✅ 找到。

`tsc --noEmit` 全綠；兩個列表頁 eslint 從基準的 4 個 error 降到 2 個（皆為既有 pattern），無新增 warning。

## 注意

migration 已透過 Management API 部署到線上（三支 RPC 都在跑，上述驗證即是打線上函式）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDr81d3BAsjEUNj2bwch5J)_