### PR TITLE
配送日改到總倉收件匣撿貨單設定（派貨工作台移除選擇器）

### DIFF
--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -7,6 +7,7 @@ import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
 import { PR_TERM_ZH } from "@/lib/prStatus";
 import SpinButton from "@/components/SpinButton";
+import { DatePicker } from "@/components/DatePicker";
 import { RowAction } from "@/components/RowAction";
 import { OrderDetail } from "@/components/OrderDetail";
 import { Modal } from "@/components/Modal";
@@ -1716,6 +1717,30 @@ function HqInboxContent() {
     }
   }
 
+  // 配送日改在收件匣設定（派貨工作台建單只帶預設隔天）；shipped/cancelled 由 RPC 擋
+  async function changeWaveDate(w: PickingRaw, newDate: string) {
+    if (newDate === w.wave_date) return;
+    setBusy(`picking-${w.id}-date`);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) throw new Error("尚未登入");
+      const { error: e } = await sb.rpc("rpc_update_wave_date", {
+        p_wave_id: w.id,
+        p_new_date: newDate,
+        p_operator: operator,
+      });
+      if (e) throw new Error(translateRpcError(e));
+      setReloadTick((t) => t + 1);
+    } catch (e) {
+      setError(translateRpcError(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
   function openWaveEdit(w: PickingRaw) {
     // PickModal 需要的欄位跟 PickingRaw 完全相同(除了 source_po_no 在 outbound 是 null|string,picking 也是)
     setEditingWave({
@@ -2065,6 +2090,7 @@ function HqInboxContent() {
                       onOpenTransferDetail={setTransferDetailId} onOpenRestockDetail={setRestockDetailId}
                       onShortageAction={handleShortageAction} onTransferAction={handleTransferAction}
                       onPickingDispatch={dispatchWave} onPickingEdit={openWaveEdit} onPickingCancel={cancelWave}
+                      onPickingDateChange={changeWaveDate}
                       dispatchingWaveId={dispatchingWaveId}
                       hqLocId={hqLocId}
                       showCheckbox={showCheckbox} batchable={batchable}
@@ -2208,6 +2234,7 @@ function MailRow({
   onPickingDispatch,
   onPickingEdit,
   onPickingCancel,
+  onPickingDateChange,
   dispatchingWaveId,
   hqLocId,
   showCheckbox,
@@ -2231,6 +2258,7 @@ function MailRow({
   onPickingDispatch: (w: PickingRaw) => Promise<void>;
   onPickingEdit: (w: PickingRaw) => void;
   onPickingCancel: (w: PickingRaw) => Promise<void>;
+  onPickingDateChange: (w: PickingRaw, newDate: string) => Promise<void>;
   dispatchingWaveId: number | null;
   hqLocId: number | null;
   showCheckbox: boolean;
@@ -2409,11 +2437,30 @@ function MailRow({
     const diff = w.actual_total - w.expected_total;
     const completion = w.expected_total > 0 ? Math.round((w.actual_total / w.expected_total) * 100) : 0;
     idText = w.wave_code;
+    // 配送日在此設定（派貨工作台建單只帶預設隔天）；shipped/cancelled 唯讀
+    const dateEditable = w.status !== "shipped" && w.status !== "cancelled";
     title = (
       <>
-        <span className="inline-block rounded bg-blue-100 px-1.5 py-0.5 text-xs font-semibold text-blue-800 dark:bg-blue-950 dark:text-blue-300">
-          📅 配送日 {w.wave_date}
-        </span>
+        {dateEditable ? (
+          <div
+            className="inline-flex items-center gap-1 rounded bg-blue-100 px-1.5 py-0.5 text-xs font-semibold text-blue-800 dark:bg-blue-950 dark:text-blue-300"
+            title="點日期修改配送日"
+            onClick={(e) => e.stopPropagation()}
+          >
+            📅 配送日
+            <DatePicker
+              value={w.wave_date}
+              onChange={(d) => onPickingDateChange(w, d)}
+              popover="fixed"
+              disabled={busy === `picking-${w.id}-date`}
+              className="rounded border border-dashed border-blue-400 px-1 font-mono text-xs font-semibold text-blue-800 hover:bg-blue-200 disabled:opacity-50 dark:border-blue-600 dark:text-blue-300 dark:hover:bg-blue-900"
+            />
+          </div>
+        ) : (
+          <span className="inline-block rounded bg-blue-100 px-1.5 py-0.5 text-xs font-semibold text-blue-800 dark:bg-blue-950 dark:text-blue-300">
+            📅 配送日 {w.wave_date}
+          </span>
+        )}
         {w.source_po_no && (
           <span className="ml-2 text-[11px] text-zinc-500">← {w.source_po_no}</span>
         )}
@@ -2570,7 +2617,8 @@ function MailRow({
         {/* 主旨 + 摘要 */}
         <div className="min-w-0 flex-1">
           <div className={`flex flex-wrap items-baseline gap-x-2 ${isPending ? "font-semibold" : "text-zinc-700 dark:text-zinc-300"}`}>
-            <span className="truncate text-sm">{title}</span>
+            {/* div 不用 span:撿貨單 title 內含 DatePicker(根節點是 div),span 包 div 會觸發 React DOM nesting 警告 */}
+            <div className="truncate text-sm">{title}</div>
             <span className="font-mono text-[10px] text-zinc-500">{idText}</span>
             <span className={`sm:hidden inline-flex rounded px-1.5 py-0.5 text-[9px] font-medium ${sourceCls}`}>
               {sourceText}

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -9,7 +9,6 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { fetchAllRows } from "@/lib/fetchAllRows";
-import { DatePicker } from "@/components/DatePicker";
 import SpinButton from "@/components/SpinButton";
 
 type DemandRow = {
@@ -74,7 +73,6 @@ export default function PickingWorkstationPage() {
   const [loadingFull, setLoadingFull] = useState(false);
   const [restockDemand, setRestockDemand] = useState<RestockRow[] | null>(null);
   const [suppliers, setSuppliers] = useState<Map<number, Supplier>>(new Map());
-  const [waveDate, setWaveDate] = useState(defaultWaveDate());
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("matrix");
@@ -639,7 +637,8 @@ export default function PickingWorkstationPage() {
       if (insufficient.length > 0) throw new Error("可分配量不足：\n" + insufficient.join("\n"));
       if (perPoAllocs.size === 0) throw new Error("沒有任何分配 — 請先填數量");
 
-      // 對每個 PO 各發一次 RPC
+      // 對每個 PO 各發一次 RPC（配送日固定帶隔天，建單後可在總倉收件匣的撿貨單上調整）
+      const waveDate = defaultWaveDate();
       const results: { po_no: string; wave_id: number; wave_code: string }[] = [];
       const failures: { po_no: string; error: string }[] = [];
       for (const [poId, allocations] of perPoAllocs.entries()) {
@@ -837,7 +836,7 @@ export default function PickingWorkstationPage() {
       }
       const { data, error: e } = await sb.rpc("rpc_create_wave_from_restock", {
         p_restock_request_id: group.rrId,
-        p_wave_date: waveDate,
+        p_wave_date: defaultWaveDate(),
         p_allocations: allocations,
         p_operator: operator,
       });
@@ -911,14 +910,9 @@ export default function PickingWorkstationPage() {
 
       {/* 控制列 */}
       <div className="flex flex-wrap items-end gap-3 rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900">
-        <label className="text-sm">
-          <span className="mb-1 block text-xs text-zinc-500">配送日</span>
-          <DatePicker
-            value={waveDate}
-            onChange={setWaveDate}
-            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
-          />
-        </label>
+        <span className="text-xs text-zinc-500" title="建單後到「總倉收件匣 → 撿貨單」點配送日即可修改">
+          📅 配送日預設隔天，建單後可在總倉收件匣的撿貨單上調整
+        </span>
         <span className="text-xs text-zinc-500">
           {loading
             ? "載入中…"

--- a/apps/admin/src/components/DatePicker.tsx
+++ b/apps/admin/src/components/DatePicker.tsx
@@ -13,6 +13,8 @@ type DatePickerProps = {
   min?: string;
   max?: string;
   className?: string;
+  /** "fixed"：日曆彈層在所有斷點都固定置中（供 overflow-hidden 容器內使用，避免被裁切） */
+  popover?: "auto" | "fixed";
 };
 
 export function DatePicker({
@@ -23,6 +25,7 @@ export function DatePicker({
   min,
   max,
   className = "",
+  popover = "auto",
 }: DatePickerProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -67,11 +70,17 @@ export function DatePicker({
       {open && (
         <>
           <div
-            className="fixed inset-0 z-40 bg-black/20 sm:hidden"
+            className={`fixed inset-0 z-40 bg-black/20 ${popover === "fixed" ? "" : "sm:hidden"}`}
             aria-hidden="true"
             onClick={() => setOpen(false)}
           />
-          <div className="fixed left-1/2 top-1/2 z-50 max-h-[85vh] max-w-[calc(100vw-1.5rem)] -translate-x-1/2 -translate-y-1/2 overflow-auto rounded-md border border-zinc-200 bg-white p-2 shadow-lg dark:border-zinc-800 dark:bg-zinc-900 sm:absolute sm:left-0 sm:right-auto sm:top-full sm:mt-1 sm:max-h-none sm:max-w-none sm:translate-x-0 sm:translate-y-0 sm:overflow-visible">
+          <div
+            className={`fixed left-1/2 top-1/2 z-50 max-h-[85vh] max-w-[calc(100vw-1.5rem)] -translate-x-1/2 -translate-y-1/2 overflow-auto rounded-md border border-zinc-200 bg-white p-2 shadow-lg dark:border-zinc-800 dark:bg-zinc-900 ${
+              popover === "fixed"
+                ? ""
+                : "sm:absolute sm:left-0 sm:right-auto sm:top-full sm:mt-1 sm:max-h-none sm:max-w-none sm:translate-x-0 sm:translate-y-0 sm:overflow-visible"
+            }`}
+          >
             <DayPicker
               mode="single"
               selected={selected}

--- a/apps/admin/src/components/PickModal.tsx
+++ b/apps/admin/src/components/PickModal.tsx
@@ -4,6 +4,7 @@ import { Fragment, useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
+import { DatePicker } from "@/components/DatePicker";
 
 export type PickWave = {
   id: number;
@@ -72,6 +73,9 @@ export function PickModal({
   const [shipping, setShipping] = useState(false);
   const [hqLocId, setHqLocId] = useState<number | null>(null);
   const [effectiveStatus] = useState<string>(wave.status);
+  // 配送日在收件匣設定；shipped/cancelled 唯讀（RPC 也擋）
+  const [waveDate, setWaveDate] = useState(wave.wave_date);
+  const [savingDate, setSavingDate] = useState(false);
 
   const shortageCount = useMemo(() => {
     if (!items) return 0;
@@ -157,6 +161,29 @@ export function PickModal({
       next.set(itemId, val);
       return next;
     });
+  }
+
+  async function changeDate(newDate: string) {
+    if (newDate === waveDate) return;
+    setSavingDate(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes?.user?.id;
+      if (!operator) throw new Error("未登入");
+      const { error: e } = await sb.rpc("rpc_update_wave_date", {
+        p_wave_id: wave.id,
+        p_new_date: newDate,
+        p_operator: operator,
+      });
+      if (e) throw new Error(e.message);
+      setWaveDate(newDate);
+    } catch (e) {
+      setError(translateRpcError(e));
+    } finally {
+      setSavingDate(false);
+    }
   }
 
   async function saveEdits() {
@@ -262,11 +289,11 @@ export function PickModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
       <div className="flex max-h-[90vh] w-full max-w-[90vw] flex-col overflow-hidden rounded-md bg-white shadow-xl dark:bg-zinc-900">
         <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
-          <div>
+          <div className="flex flex-wrap items-center gap-2">
             <h2 className="font-semibold">
               修正數量：<span className="font-mono">{wave.wave_code}</span>{" "}
               <span className="text-xs text-zinc-500">
-                · 配送日 {wave.wave_date} · 狀態 {WAVE_STATUS_LABEL[effectiveStatus] ?? effectiveStatus}
+                · 狀態 {WAVE_STATUS_LABEL[effectiveStatus] ?? effectiveStatus}
               </span>
               {shortageCount > 0 && (
                 <span className="ml-2 inline-block rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">
@@ -274,6 +301,24 @@ export function PickModal({
                 </span>
               )}
             </h2>
+            {/* DatePicker 根節點是 div，不能塞進 h2（heading 只能含 phrasing content）→ 做成 h2 的 sibling chip */}
+            {effectiveStatus !== "shipped" && effectiveStatus !== "cancelled" ? (
+              <div
+                className="inline-flex items-center gap-1 rounded bg-blue-100 px-1.5 py-0.5 text-xs font-semibold text-blue-800 dark:bg-blue-950 dark:text-blue-300"
+                title="點日期修改配送日"
+              >
+                📅 配送日
+                <DatePicker
+                  value={waveDate}
+                  onChange={changeDate}
+                  popover="fixed"
+                  disabled={savingDate}
+                  className="rounded border border-dashed border-blue-400 px-1 font-mono text-xs font-semibold text-blue-800 hover:bg-blue-200 disabled:opacity-50 dark:border-blue-600 dark:text-blue-300 dark:hover:bg-blue-900"
+                />
+              </div>
+            ) : (
+              <span className="text-xs text-zinc-500">📅 配送日 {waveDate}</span>
+            )}
           </div>
           <div className="flex gap-2">
             {effectiveStatus !== "shipped" && edits.size > 0 && (

--- a/docs/TEST-wave-date-inbox.md
+++ b/docs/TEST-wave-date-inbox.md
@@ -1,0 +1,61 @@
+# wave-date-inbox 測試項目 — 配送日設定移到總倉收件匣撿貨單
+
+**對應 migration:** 無（沿用既有 `supabase/migrations/20260502120000_rpc_update_wave_date.sql`）
+**對應 UI 變更:** `apps/admin/src/app/(protected)/wms/picking/page.tsx`、`apps/admin/src/app/(protected)/hq/inbox/page.tsx`、`apps/admin/src/components/PickModal.tsx`、`apps/admin/src/components/DatePicker.tsx`
+
+## 1. Schema / Migration 層
+
+### 1.1 RPC 已部署（prod）
+- [ ] `rpc_update_wave_date(BIGINT, DATE, UUID)` 存在且可執行 — REST probe 帶 `p_wave_id:-1` 回 P0001 `wave -1 not found`（= 函式本體有跑）
+
+## 2. RPC 行為（SQL 直測 / REST probe）
+
+### 2.1 不存在的 wave
+**情境：** 呼叫 `rpc_update_wave_date` 帶不存在的 wave id
+**預期：** RAISE `wave % not found`
+
+### 2.2 shipped / cancelled 不可改
+**情境：** 對 status = shipped 或 cancelled 的 wave 呼叫改日期
+**預期：** RAISE `cannot change wave_date`，`wave_date` 不變
+
+### 2.3 正常改日期 + audit log
+**情境：** 對 pending 段（draft / picking / picked）wave 改成新日期
+**預期：** `picking_waves.wave_date` 更新、`updated_by` = operator；`picking_wave_audit_log` 多一筆 before/after 帶新舊日期
+
+### 2.4 同日期冪等
+**情境：** 帶入與現值相同的日期
+**預期：** 提前 return，不寫 audit log
+
+## 3. UI 行為（preview 互動）
+
+### 3.1 派貨工作台（wms/picking）
+- [ ] 控制列**不再出現**「配送日」DatePicker
+- [ ] 出現提示文案：配送日預設隔天、可到總倉收件匣撿貨單調整
+- [ ] 建立撿貨單（rpc_create_wave_from_po / rpc_create_wave_from_restock）仍帶 `p_wave_date` = 隔天（程式碼層驗證 `defaultWaveDate()` 於 submit 時計算）
+- [ ] 頁面載入無 console error
+
+### 3.2 收件匣撿貨單 row（hq/inbox → 📋 撿貨單）
+- [ ] pending 段 wave 的「📅 配送日」chip 變成可點擊按鈕，點擊開日曆（不觸發 row click 開 PickModal）
+- [ ] 日曆彈層完整可見，不被列表容器 `overflow-hidden` 裁切（含列表只有一列時）
+- [ ] 選新日期 → 呼叫 `rpc_update_wave_date` → row 上日期更新（reload 後仍是新值）
+- [ ] done（shipped）/ rejected（cancelled）段的配送日 chip 維持唯讀、不可點
+- [ ] 「📄 簽收單」連結的 `?date=` 反映更新後日期
+- [ ] RPC 失敗（如狀態已變 shipped）時錯誤訊息顯示於頁面 error 區
+
+### 3.3 PickModal 明細標頭
+- [ ] 未 shipped/cancelled 的 wave：標頭「配送日」可點開日曆改日期，改完標頭立即顯示新值
+- [ ] shipped / cancelled 的 wave：配送日維持純文字
+- [ ] 關閉 modal 後列表 reload，row 顯示新日期
+
+## 4. Regression
+
+- [ ] 派貨工作台建單流程照常：矩陣填量 → 建立撿貨單 → 導向 /hq/inbox?source=picking
+- [ ] 補貨申請（📦 無 PO 來源）建 wave 照常
+- [ ] PickModal 修正數量 / 派貨出倉照常（此改動不碰 qty 邏輯）
+- [ ] 收件匣其他來源 row（restock / transfer / aid / air / shortage）渲染與動作不受影響
+- [ ] `/picking/print-sign` 依日期列印照常（該頁自有 DatePicker 不受影響）
+- [ ] DatePicker 其他 6 個使用點（campaigns、MemberForm、CreateCampaignModal、community-candidates、finance/receivables、print-sign）行為不變
+
+## 5. 驗收門檻
+
+全部 §1-§4 勾完、**無 console error**、**build + type-check 過** 才可標 done（無新 migration，免 db push）。


### PR DESCRIPTION
## 摘要

配送日（`wave_date`）的設定點從**派貨工作台**搬到**總倉收件匣的撿貨單**上：

- **派貨工作台（/wms/picking）**：移除控制列的「配送日」DatePicker。建單時自動帶預設隔天（`rpc_create_wave_from_po` / `rpc_create_wave_from_restock` 的 `p_wave_date`），控制列改顯示提示「📅 配送日預設隔天，建單後可在總倉收件匣的撿貨單上調整」。
- **收件匣撿貨單 row（/hq/inbox?source=picking）**：「📅 配送日」chip 改為可點擊的日期選擇器，選日期即呼叫既有 `rpc_update_wave_date` 並刷新列表；`shipped` / `cancelled` 的 wave 維持唯讀 chip（RPC 端本來就擋）。點 chip 不會誤觸 row click 開明細。
- **PickModal 明細標頭**：配送日同樣可編輯，改完標頭立即更新，關閉 modal 後列表 reload。
- **DatePicker** 新增 `popover="fixed"` 選項：日曆彈層在所有斷點固定置中，避免被收件匣列表的 `overflow-hidden` 容器裁切（既有 7 個使用點行為不變）。

## 後端

**無新 migration。** 沿用 `20260502120000_rpc_update_wave_date.sql`（守衛：shipped/cancelled 不可改、寫 `picking_wave_audit_log`），已用 REST probe 確認 prod 部署且可執行。

## 驗證

- `tsc --noEmit` ✅、`next build` ✅
- Playwright + fixture（無真實登入）**14/14 PASS**：工作台無殘留選擇器／提示顯示、row chip 開日曆且不被裁切、RPC 參數正確（`p_wave_id`/`p_new_date`/`p_operator`）、reload 後顯示新值、modal 編輯即時生效、無 console error
- 測試清單：`docs/TEST-wave-date-inbox.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)