### PR TITLE
撿貨單批次設定配送日（勾選多張一次改同一天）

### DIFF
--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -1381,6 +1381,15 @@ function HqInboxContent() {
       .map((r) => r.key);
   }, [paginatedRows, sourceFilter]);
 
+  // 批次配送日選擇器顯示值 = 所選撿貨單中最早的配送日（不另存 state，改完 reload 自動跟著更新）
+  const batchWaveDate = useMemo(() => {
+    const dates = paginatedRows
+      .filter((r) => selected.has(r.key) && r.source === "picking")
+      .map((r) => (r.raw as PickingRaw).wave_date)
+      .sort();
+    return dates[0] ?? "";
+  }, [paginatedRows, selected]);
+
   function selectAllVisible() {
     setSelected(new Set(batchableKeys));
   }
@@ -1563,6 +1572,53 @@ function HqInboxContent() {
         results.forEach((r) => {
           if (r.status === "rejected") errs.push(translateRpcError(r.reason));
           else if ((r.value as { error?: { message?: string } })?.error) errs.push(translateRpcError((r.value as { error: { message: string } }).error.message));
+        });
+        alert(`成功 ${okCount} / 失敗 ${failed}\n\n${errs.slice(0, 3).join("\n")}`);
+      }
+      setSelected(new Set());
+      setReloadTick((t) => t + 1);
+    } catch (e) {
+      setError(translateRpcError(e));
+    } finally {
+      setBatchBusy(false);
+    }
+  }
+
+  // 批次設定配送日 — 只對勾選的「待處理」撿貨單（shipped/cancelled 不在 batchable 內，RPC 端也擋）
+  async function batchSetWaveDate(newDate: string) {
+    const targets = paginatedRows.filter(
+      (r) => selected.has(r.key) && r.source === "picking" && r.stage === "pending" && r.raw.wave_date !== newDate,
+    );
+    if (targets.length === 0) return;
+    if (!confirm(`將選中的 ${targets.length} 張撿貨單配送日改為 ${newDate}？`)) return;
+    setBatchBusy(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) throw new Error("尚未登入");
+
+      const results = await Promise.allSettled(
+        targets.map((r) =>
+          sb.rpc("rpc_update_wave_date", {
+            p_wave_id: (r.raw as PickingRaw).id,
+            p_new_date: newDate,
+            p_operator: operator,
+          }),
+        ),
+      );
+      const okCount = results.filter((r) => r.status === "fulfilled" && !(r.value as { error?: unknown })?.error).length;
+      const failed = results.length - okCount;
+      if (failed === 0) {
+        alert(`✅ 已將 ${okCount} 張撿貨單配送日改為 ${newDate}`);
+      } else {
+        const errs: string[] = [];
+        results.forEach((r) => {
+          if (r.status === "rejected") errs.push(translateRpcError(r.reason));
+          else if ((r.value as { error?: { message?: string } })?.error) {
+            errs.push(translateRpcError((r.value as { error: { message: string } }).error.message));
+          }
         });
         alert(`成功 ${okCount} / 失敗 ${failed}\n\n${errs.slice(0, 3).join("\n")}`);
       }
@@ -2023,6 +2079,19 @@ function HqInboxContent() {
                       >
                         📄 列印簽收單 ({selected.size})
                       </Link>
+                      <div
+                        className="inline-flex items-center gap-1 rounded border border-blue-300 bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300"
+                        title="一次把所選撿貨單的配送日改成同一天"
+                      >
+                        📅 設定配送日 ({selected.size})
+                        <DatePicker
+                          value={batchWaveDate}
+                          onChange={batchSetWaveDate}
+                          popover="fixed"
+                          disabled={batchBusy}
+                          className="rounded border border-dashed border-blue-400 px-1 font-mono text-xs font-semibold text-blue-700 hover:bg-blue-100 disabled:opacity-50 dark:border-blue-600 dark:text-blue-300 dark:hover:bg-blue-900"
+                        />
+                      </div>
                       <RowAction variant="success" onClick={() => batchAction("派貨出倉")} disabled={batchBusy}>派貨出倉 ({selected.size})</RowAction>
                       <RowAction variant="danger" onClick={() => batchAction("取消")} disabled={batchBusy}>取消 ({selected.size})</RowAction>
                     </>

--- a/apps/admin/src/components/DatePicker.tsx
+++ b/apps/admin/src/components/DatePicker.tsx
@@ -84,6 +84,9 @@ export function DatePicker({
             <DayPicker
               mode="single"
               selected={selected}
+              // 沒帶 defaultMonth 時 DayPicker 一律開在「今天」那個月；
+              // 配送日可能排到數週後，開起來會在錯的月份 → 對齊目前選定日期
+              defaultMonth={selected}
               onSelect={(d) => {
                 if (d) {
                   onChange(formatLocal(d));

--- a/docs/TEST-wave-date-inbox.md
+++ b/docs/TEST-wave-date-inbox.md
@@ -42,7 +42,15 @@
 - [ ] 「📄 簽收單」連結的 `?date=` 反映更新後日期
 - [ ] RPC 失敗（如狀態已變 shipped）時錯誤訊息顯示於頁面 error 區
 
-### 3.3 PickModal 明細標頭
+### 3.3 批次設定配送日（hq/inbox 撿貨單批次工具列）
+- [ ] 勾選多張待處理撿貨單 → 批次工具列出現「📅 設定配送日 (n)」，日期鈕顯示所選中最早的配送日
+- [ ] 點日期開日曆 → 選新日期 → confirm 後對每張未達該日期的 wave 各打一次 `rpc_update_wave_date`
+- [ ] 全部成功：alert 顯示成功張數、選取清空、列表 reload 後每張都是新日期
+- [ ] 部分失敗（例如中途被別人派貨）：alert 顯示「成功 N / 失敗 M」與前 3 筆錯誤
+- [ ] 選中的 wave 配送日已全等於目標日期 → 不發 RPC、不跳 confirm
+- [ ] 已派貨（done）/ 已取消 row 不可勾選，因此不會進批次範圍
+
+### 3.4 PickModal 明細標頭
 - [ ] 未 shipped/cancelled 的 wave：標頭「配送日」可點開日曆改日期，改完標頭立即顯示新值
 - [ ] shipped / cancelled 的 wave：配送日維持純文字
 - [ ] 關閉 modal 後列表 reload，row 顯示新日期
@@ -55,6 +63,7 @@
 - [ ] 收件匣其他來源 row（restock / transfer / aid / air / shortage）渲染與動作不受影響
 - [ ] `/picking/print-sign` 依日期列印照常（該頁自有 DatePicker 不受影響）
 - [ ] DatePicker 其他 6 個使用點（campaigns、MemberForm、CreateCampaignModal、community-candidates、finance/receivables、print-sign）行為不變
+- [ ] DatePicker 加 `defaultMonth` 後：開啟時停在「目前選定日期」的月份（原本一律開在今天的月份），其他使用點不受負面影響
 
 ## 5. 驗收門檻
 


### PR DESCRIPTION
> ⚠️ **這支疊在 [#554](https://github.com/lt-foods/new_erp/pull/554) 上**（base = `claude/dispatch-delivery-date-migration-d4ecb3`），因為批次功能沿用 #554 的 `rpc_update_wave_date` 接線與 `DatePicker popover="fixed"`。**請先 merge #554**，GitHub 會自動把這支的 base 改回 `main`，再 merge 這支即可。本頁 diff 只含批次功能本身的 3 個檔案。

## 摘要

總倉收件匣的撿貨單批次工具列新增「📅 設定配送日 (n)」：勾選多張撿貨單後選一次日期，一次改成同一天。

- 對每張選中的待處理撿貨單各打一次 `rpc_update_wave_date`；**已經是該日期的自動跳過**（不發 RPC、不跳確認）
- 全部成功 → alert 成功張數；部分失敗（例如中途被別人派貨出倉）→ 顯示「成功 N / 失敗 M」與前 3 筆錯誤，成功的那幾張仍然生效
- 完成後清空選取並 reload
- 日期鈕顯示所選撿貨單中**最早的配送日**（不另存 state，改完隨列表更新）
- 已派貨 / 已取消的 wave 本來就不在可勾選範圍（`batchableKeys` 只收 pending），不會被批次波及；RPC 端也有守衛

## 順手修掉的既有問題

`DatePicker` 沒帶 `defaultMonth`，DayPicker 一律開在**今天**那個月。以前日期都在近期還不明顯，現在配送日可能排到數週後，打開來會停在錯的月份、要手動翻月。補 `defaultMonth={selected}` 後開在目前選定日期的月份，8 個使用點共同受益。

## 後端

**無新 migration** — 沿用 `20260502120000` 的 `rpc_update_wave_date`（shipped/cancelled 擋、寫 `picking_wave_audit_log`）。

## 驗證

- `tsc --noEmit` ✅、`next build` ✅
- Playwright + fixture **15/15 PASS**：shipped wave 不可勾、全選數量、日期鈕取最早日、confirm 文案、對 2 張各發一次 RPC 且參數正確、成功 alert、reload 後皆為新日期、選取清空、**部分失敗回報**、**同日期不重發**、**日曆開在正確月份**、日曆不被裁切、無 console error
- 測試清單：`docs/TEST-wave-date-inbox.md` §3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)