### PR TITLE
收貨待辦「收貨後通知會員」開關：三條收貨路徑可整批推播/關閉到貨通知

### DIFF
--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -15,6 +15,7 @@ import SpinButton from "@/components/SpinButton";
 import { translateRpcError } from "@/lib/rpcError";
 import { useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 import { fetchAllRows } from "@/lib/fetchAllRows";
+import { fanoutPickupNotifications } from "@/lib/pickupNotify";
 
 type Location = { id: number; name: string };
 type StoreLite = { id: number; location_id: number | null };
@@ -41,6 +42,16 @@ export default function TransfersInboxPage() {
   const [groupLimit, setGroupLimit] = useState(20);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [batchBusy, setBatchBusy] = useState(false);
+  // 收貨後是否整批推播「到貨」給受影響會員；店家可自行開關，記在 localStorage（預設開）
+  const [notifyMembers, setNotifyMembers] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    return window.localStorage.getItem("inbound-notify-members") !== "0";
+  });
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("inbound-notify-members", notifyMembers ? "1" : "0");
+    }
+  }, [notifyMembers]);
   // 待收子篩選（僅在「未收」分頁內作用）
   type DateFilter = "tomorrow" | "today_or_earlier" | "all_pending" | null;
   const [dateFilter, setDateFilter] = useState<DateFilter>(null);
@@ -446,10 +457,16 @@ export default function TransfersInboxPage() {
     window.dispatchEvent(new Event("inbound-badge-refresh"));
   }
 
+  // confirm 對話框裡的「是否通知會員」提示行（依開關狀態）
+  const notifyHint = () =>
+    notifyMembers
+      ? "📩 收貨後會推播「到貨」通知給相關會員。"
+      : "🔕 已關閉會員通知,本次收貨不推播。";
+
   // 單筆全收 — 直接 confirm + RPC,跟批次邏輯一樣(p_lines=null)
   async function quickReceive(t: Transfer) {
     const dest = locations.get(t.dest_location) ?? `#${t.dest_location}`;
-    if (!confirm(`確認收貨 ${t.transfer_no}(送到 ${dest})?\n\n以「全收」(實收 = 派出量,無破損)處理。需要調整數量請點「調整」。`)) return;
+    if (!confirm(`確認收貨 ${t.transfer_no}(送到 ${dest})?\n\n以「全收」(實收 = 派出量,無破損)處理。需要調整數量請點「調整」。\n${notifyHint()}`)) return;
     setBatchBusy(true);
     try {
       const sb = getSupabase();
@@ -463,6 +480,14 @@ export default function TransfersInboxPage() {
         p_notes: null,
       });
       if (e) throw new Error(translateRpcError(e));
+      // 依「收貨後通知會員」設定推播到貨通知；失敗不影響收貨流程
+      if (notifyMembers) {
+        const pushed = await fanoutPickupNotifications([t.id]).catch((err) => {
+          console.warn("push fanout error:", err);
+          return 0;
+        });
+        if (pushed > 0) alert(`📩 已推播 ${pushed} 位顧客`);
+      }
       reloadAndRefreshBadge();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -504,7 +529,7 @@ export default function TransfersInboxPage() {
 
   async function batchReceive() {
     if (selected.size === 0) return;
-    if (!confirm(`確認批次收貨 ${selected.size} 筆?\n\n所有品項都將以「全收」(實收 = 派出量,無破損)處理。需要編輯數量請點個別「收貨」按鈕。`)) return;
+    if (!confirm(`確認批次收貨 ${selected.size} 筆?\n\n所有品項都將以「全收」(實收 = 派出量,無破損)處理。需要編輯數量請點個別「收貨」按鈕。\n${notifyHint()}`)) return;
     setBatchBusy(true);
     try {
       const sb = getSupabase();
@@ -533,13 +558,26 @@ export default function TransfersInboxPage() {
         error: translateRpcError(f.error),
       }));
 
+      // 依「收貨後通知會員」設定，對成功收貨的單整批推播（跨單去重同會員只推一次）
+      let pushNote = "";
+      if (notifyMembers && okCount > 0) {
+        const failedIds = new Set((res.failed ?? []).map((f) => f.id));
+        const okIds = ids.filter((id) => !failedIds.has(id));
+        const pushed = await fanoutPickupNotifications(okIds).catch((err) => {
+          console.warn("push fanout error:", err);
+          return 0;
+        });
+        if (pushed > 0) pushNote = `\n📩 已推播 ${pushed} 位顧客`;
+      }
+
       if (failures.length === 0) {
-        alert(`✅ 批次收貨完成:${okCount} 筆`);
+        alert(`✅ 批次收貨完成:${okCount} 筆${pushNote}`);
       } else {
         const failBrief = failures.slice(0, 5).map((f) => `  #${f.id}: ${f.error}`).join("\n");
         alert(
           `⚠ 部分成功:\n` +
-          `成功 ${okCount} 筆 / 失敗 ${failures.length} 筆\n\n` +
+          `成功 ${okCount} 筆 / 失敗 ${failures.length} 筆` +
+          pushNote + `\n\n` +
           `失敗(前 5):\n${failBrief}` +
           (failures.length > 5 ? `\n…(還有 ${failures.length - 5} 筆)` : ""),
         );
@@ -703,6 +741,19 @@ export default function TransfersInboxPage() {
               清空
             </SpinButton>
           )}
+          {/* 收貨後是否整批推播「到貨」給會員 — 適用單筆收貨 / 批次收貨 / 調整 modal，設定會記住 */}
+          <label
+            className="flex cursor-pointer items-center gap-1.5 text-xs text-zinc-600 dark:text-zinc-300"
+            title="開啟:收貨完成後整批推播「您的商品到貨」給該店受影響的會員(不通知名單會自動排除)。關閉:收貨不推播。"
+          >
+            <input
+              type="checkbox"
+              checked={notifyMembers}
+              onChange={(e) => setNotifyMembers(e.target.checked)}
+              className="cursor-pointer"
+            />
+            {notifyMembers ? "📩 收貨後通知會員" : "🔕 收貨後不通知會員"}
+          </label>
           <SpinButton
             type="button"
             onClick={batchReceive}
@@ -926,6 +977,7 @@ export default function TransfersInboxPage() {
             const wid = parseWaveId(opening.transfer_no);
             return wid !== null ? waves.get(wid) ?? null : null;
           })()}
+          notifyMembers={notifyMembers}
           onClose={() => setOpening(null)}
           onSubmitted={() => {
             setOpening(null);

--- a/apps/admin/src/components/TransferReceiveModal.tsx
+++ b/apps/admin/src/components/TransferReceiveModal.tsx
@@ -3,73 +3,8 @@
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
+import { fanoutPickupNotifications } from "@/lib/pickupNotify";
 import SpinButton from "@/components/SpinButton";
-
-async function fanoutPushNotifications(transferId: number): Promise<number> {
-  const sb = getSupabase();
-  const { data: rows, error } = await sb.rpc("rpc_get_members_to_notify_for_transfer", {
-    p_transfer_id: transferId,
-  });
-  if (error) {
-    console.warn("get members for push failed:", error.message);
-    return 0;
-  }
-  const list = (rows as { member_id: number; order_id: number; order_no: string; last_notify_pickup_at: string | null }[] | null) ?? [];
-  if (list.length === 0) return 0;  // RPC 已過濾黑名單會員
-
-  // 去重：同一會員多張訂單只推一次（取第一張當代表）
-  const seenMembers = new Set<number>();
-  const uniqueByMember = list.filter((r) => {
-    if (seenMembers.has(r.member_id)) return false;
-    seenMembers.add(r.member_id);
-    return true;
-  });
-
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  if (!supabaseUrl) return 0;
-  const { data: sess } = await sb.auth.getSession();
-  const token = sess.session?.access_token;
-  const operator = sess.session?.user?.id;
-  if (!token) return 0;
-
-  let success = 0;
-  await Promise.allSettled(
-    uniqueByMember.map(async (r) => {
-      try {
-        const resp = await fetch(`${supabaseUrl}/functions/v1/admin-notify`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            member_id: r.member_id,
-            title: "您的商品到貨",
-            message: "點此開啟訂單頁查看",
-            url: "/orders",
-            category: "order_arrived",
-          }),
-        });
-        if (resp.ok) success += 1;
-      } catch (e) {
-        console.warn(`push to member ${r.member_id} failed:`, e);
-      }
-    }),
-  );
-
-  // 不論推播成功與否，都把所有受影響訂單 (含同會員多張) 標 last_notify_pickup_at
-  // 讓 /pickup 顯示「📨 上次通知 X」避免再手動重複推
-  await Promise.allSettled(
-    list.map((r) =>
-      sb.rpc("rpc_mark_pickup_notified", {
-        p_order_id: r.order_id,
-        p_operator: operator ?? null,
-      }),
-    ),
-  );
-
-  return success;
-}
 
 export type Transfer = {
   id: number;
@@ -124,6 +59,7 @@ export function TransferReceiveModal({
   srcName,
   dstName,
   wave,
+  notifyMembers = true,
   onClose,
   onSubmitted,
 }: {
@@ -131,6 +67,8 @@ export function TransferReceiveModal({
   srcName: string;
   dstName: string;
   wave: Wave | null;
+  // 收貨完成後是否整批推播「到貨」給受影響會員（收貨待辦頁的開關）
+  notifyMembers?: boolean;
   onClose: () => void;
   onSubmitted: () => void;
 }) {
@@ -250,12 +188,14 @@ export function TransferReceiveModal({
           ? `\n⚠ 短收 ${Math.abs(Number(r.total_variance))}`
           : "";
 
-      // Fire-and-forget：通知該店所有受影響的顧客「貨已到店」
+      // Fire-and-forget：通知該店所有受影響的顧客「貨已到店」，依「收貨後通知會員」設定可整批關掉
       // 失敗不影響收貨流程（push 失敗只是該會員拿不到推播）
-      const pushed = await fanoutPushNotifications(transfer.id).catch((err) => {
-        console.warn("push fanout error:", err);
-        return 0;
-      });
+      const pushed = notifyMembers
+        ? await fanoutPickupNotifications([transfer.id]).catch((err) => {
+            console.warn("push fanout error:", err);
+            return 0;
+          })
+        : 0;
       const pushNote = pushed > 0 ? `\n📩 已推播 ${pushed} 位顧客` : "";
       alert(
         `收貨完成：${r?.items_received ?? 0} 行，實收合計 ${r?.total_qty_received ?? 0}${varNote}${pushNote}`,

--- a/apps/admin/src/lib/pickupNotify.ts
+++ b/apps/admin/src/lib/pickupNotify.ts
@@ -1,0 +1,95 @@
+import { getSupabase } from "@/lib/supabase";
+
+type NotifyTarget = {
+  member_id: number;
+  order_id: number;
+  order_no: string;
+  last_notify_pickup_at: string | null;
+};
+
+// 收貨後推播「您的商品到貨」給受影響會員。可一次傳多張調撥單（批次收貨），
+// 會先合併名單再去重：同會員只推一次、同訂單只標記一次 last_notify_pickup_at。
+// 名單由 rpc_get_members_to_notify_for_transfer 提供（已過濾 no_notify_pickup 黑名單）。
+// 回傳推播成功的會員數；任何失敗只 console.warn，不影響收貨流程。
+export async function fanoutPickupNotifications(transferIds: number[]): Promise<number> {
+  if (transferIds.length === 0) return 0;
+  const sb = getSupabase();
+
+  const results = await Promise.allSettled(
+    transferIds.map((id) =>
+      sb.rpc("rpc_get_members_to_notify_for_transfer", { p_transfer_id: id }),
+    ),
+  );
+  const list: NotifyTarget[] = [];
+  for (const r of results) {
+    if (r.status !== "fulfilled") {
+      console.warn("get members for push failed:", r.reason);
+      continue;
+    }
+    if (r.value.error) {
+      console.warn("get members for push failed:", r.value.error.message);
+      continue;
+    }
+    list.push(...((r.value.data as NotifyTarget[] | null) ?? []));
+  }
+  if (list.length === 0) return 0;
+
+  // 去重：同一會員（可能跨多張調撥單 / 多張訂單）只推一次（取第一張當代表）
+  const seenMembers = new Set<number>();
+  const uniqueByMember = list.filter((r) => {
+    if (seenMembers.has(r.member_id)) return false;
+    seenMembers.add(r.member_id);
+    return true;
+  });
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!supabaseUrl) return 0;
+  const { data: sess } = await sb.auth.getSession();
+  const token = sess.session?.access_token;
+  const operator = sess.session?.user?.id;
+  if (!token) return 0;
+
+  let success = 0;
+  await Promise.allSettled(
+    uniqueByMember.map(async (r) => {
+      try {
+        const resp = await fetch(`${supabaseUrl}/functions/v1/admin-notify`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            member_id: r.member_id,
+            title: "您的商品到貨",
+            message: "點此開啟訂單頁查看",
+            url: "/orders",
+            category: "order_arrived",
+          }),
+        });
+        if (resp.ok) success += 1;
+      } catch (e) {
+        console.warn(`push to member ${r.member_id} failed:`, e);
+      }
+    }),
+  );
+
+  // 不論推播成功與否，都把所有受影響訂單（含同會員多張，跨單去重）標 last_notify_pickup_at
+  // 讓 /pickup 顯示「📨 上次通知 X」避免再手動重複推
+  const seenOrders = new Set<number>();
+  const uniqueOrders = list.filter((r) => {
+    if (seenOrders.has(r.order_id)) return false;
+    seenOrders.add(r.order_id);
+    return true;
+  });
+  await Promise.allSettled(
+    uniqueOrders.map((r) =>
+      sb.rpc("rpc_mark_pickup_notified", {
+        p_order_id: r.order_id,
+        p_operator: operator ?? null,
+      }),
+    ),
+  );
+
+  return success;
+}

--- a/docs/TEST-inbound-notify-members-toggle.md
+++ b/docs/TEST-inbound-notify-members-toggle.md
@@ -1,0 +1,75 @@
+---
+title: TEST — 收貨待辦「收貨後通知會員」開關
+module: WMS / Inbound
+status: draft
+owner: alex.chen
+created: 2026-07-31
+---
+
+# 測試清單 — 收貨待辦「收貨後通知會員」開關
+
+店家在 `/wms/inbound` 收貨時，可用開關決定要不要**整批**推播「您的商品到貨」給受影響會員。
+開關套用到全部三條收貨路徑：單筆「收貨」、「✓ 批次收貨」、「✎ 調整」modal。
+
+## Scope
+
+- 前端：
+  - `apps/admin/src/app/(protected)/wms/inbound/page.tsx` — 開關 UI（批次工具列）、`quickReceive` / `batchReceive` 接推播
+  - `apps/admin/src/components/TransferReceiveModal.tsx` — 移除本地 fanout，改吃 `notifyMembers` prop
+  - `apps/admin/src/lib/pickupNotify.ts`（新）— 共用 `fanoutPickupNotifications(transferIds: number[])`
+- 後端：**無 schema / RPC 變更**。沿用既有 `rpc_get_members_to_notify_for_transfer`（已過濾
+  `no_notify_pickup` 黑名單）、`rpc_mark_pickup_notified`、edge function `admin-notify`。
+- 偏好儲存：`localStorage["inbound-notify-members"]`（`"1"` 開 / `"0"` 關，預設開）。
+
+## 行為定義
+
+| 路徑 | 開關 ON（預設） | 開關 OFF |
+|---|---|---|
+| 單筆「收貨」 | 收貨成功後推播該張 transfer 的受影響會員；推 >0 時 alert 顯示人數 | 只收貨，不推播 |
+| 「✓ 批次收貨」 | 只對**成功**收貨的單 fan-out；跨單合併名單、**同會員只推一次**；alert 附「📩 已推播 N 位顧客」 | 只收貨，不推播 |
+| 「✎ 調整」modal | 同舊行為：收貨完成後推播（原本是無條件推） | 不推播 |
+| confirm 對話框 | 附註「📩 收貨後會推播…」 | 附註「🔕 已關閉會員通知…」 |
+
+不受開關影響的既有行為：
+- `rpc_get_members_to_notify_for_transfer` 內建的黑名單過濾（`members.no_notify_pickup`）。
+- 推播與否不影響收貨本身；fan-out 任何失敗只 `console.warn`。
+- 有推播時，所有受影響訂單（跨單去重）照舊標 `last_notify_pickup_at`（`rpc_mark_pickup_notified`）。
+- 「↩ 退回收貨」不撤銷已發通知（`last_notify_pickup_at` 是 audit，維持不清除）。
+
+## 測試項目
+
+### A. 開關本身
+
+- [ ] 未收分頁、有待收單時，批次工具列出現「📩 收貨後通知會員」checkbox，預設勾選
+- [ ] 取消勾選 → 文案變「🔕 收貨後不通知會員」；重新整理頁面後仍是關閉（localStorage 記住）
+- [ ] 分店帳號（非 HQ）也看得到、可操作此開關
+
+### B. 單筆「收貨」
+
+- [ ] ON：confirm 內含「📩 收貨後會推播…」；確認後該店受影響會員收到推播＋`notifications` 各新增一筆 `order_arrived`；訂單 `last_notify_pickup_at` 更新
+- [ ] ON 且推播人數 > 0：alert「📩 已推播 N 位顧客」
+- [ ] ON 但該 transfer 無對應會員訂單（如 return_to_hq / 純補貨）：不推播、無 alert、收貨正常
+- [ ] OFF：confirm 內含「🔕 …」；收貨成功、完全無推播、`last_notify_pickup_at` 不變
+
+### C. 「✓ 批次收貨」
+
+- [ ] ON：勾 N 筆批次收貨 → alert「✅ 批次收貨完成:N 筆 📩 已推播 M 位顧客」
+- [ ] 同一會員的訂單分散在多張選中的 transfer → 只收到 **1** 則推播；其所有受影響訂單都有標 `last_notify_pickup_at`
+- [ ] 部分失敗：只對成功的單 fan-out（失敗單的會員不收到推播）；alert 的「部分成功」訊息含推播數
+- [ ] OFF：批次收貨成功、無任何推播
+
+### D. 「✎ 調整」modal
+
+- [ ] ON：調整數量後確認收貨 → 推播照舊、alert 含「📩 已推播 N 位顧客」（與改版前行為一致）
+- [ ] OFF：確認收貨 → 不推播、alert 無推播行
+- [ ] 已收單開「看明細」（readOnly）→ 無收貨動作、無推播（不受開關影響）
+
+### E. 黑名單與去重（回歸）
+
+- [ ] `members.no_notify_pickup = true` 的會員：開關 ON 也不會收到推播（RPC 端過濾，非前端）
+- [ ] 同會員多張訂單在同一張 transfer：仍只推 1 次（原有去重不變）
+
+### F. 失敗容錯（回歸）
+
+- [ ] `admin-notify` 回非 2xx / 網路失敗：收貨結果不受影響，只少了該會員的推播
+- [ ] `rpc_get_members_to_notify_for_transfer` 失敗：收貨照常完成、alert 無推播行


### PR DESCRIPTION
店家在 /wms/inbound 收貨時可自行決定要不要整批通知會員：

- 批次工具列新增「📩 收貨後通知會員」checkbox（localStorage 記住，預設開）
- 單筆「收貨」與「✓ 批次收貨」原本完全不推播 → 開關 ON 時收貨成功後
  推播「您的商品到貨」；批次只對成功收貨的單發、跨單去重同會員只推一次
- 「✎ 調整」modal 原本無條件推播 → 改吃 notifyMembers prop，可關閉
- fanout 抽成共用 lib/pickupNotify.ts（吃 transferIds[]，會員/訂單皆去重，
  沿用 rpc_get_members_to_notify_for_transfer 黑名單過濾 + rpc_mark_pickup_notified）
- confirm 對話框附註本次收貨會不會推播，alert 顯示實際推播人數
- 無 schema / RPC 變更；測試清單見 docs/TEST-inbound-notify-members-toggle.md

Playwright fixture 驗證（apps/admin:verify）10 項全過。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lw3FA7or3TBNx3jwpGLihW