### PR TITLE
修正總倉收件匣「異常」爆量:訂單短少只判採購已定案的 SKU、closed PO 供給不歸零

### DIFF
--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -562,83 +562,38 @@ async function fetchShortageRows(
   dateFrom: string,
   dateTo: string,
 ): Promise<{ rows: Row[]; total: number }> {
-  // v_order_shortage 是 (order × sku) 維度,需多撈再聚合。
-  // 先做簡化版:抓所有相關 row,client-side 聚合 + 切頁。
-  let q = sb
-    .from("v_order_shortage")
-    .select(
-      "order_id, order_no, member_id, store_name, order_status, shortage_resolution, shortage_notified_at, sku_id, product_name, variant_name, sku_code, order_qty, demand_unfulfillable, order_updated_at",
-    )
-    .order("order_updated_at", { ascending: false });
-  if (stage) {
-    const resolutions = SHORTAGE_RESOLUTION_BY_STAGE[stage];
-    if (resolutions === null) q = q.is("shortage_resolution", null);
-    else if (resolutions.length === 0) return { rows: [], total: 0 };
-    else q = q.in("shortage_resolution", resolutions);
+  // server-side 分頁:rpc_hq_shortage_orders 在 DB 端把 v_order_shortage
+  // (order × sku) 聚合到 order 維度、套 stage / 日期篩選後分頁,
+  // 一次回傳 { total, rows(ShortageRaw 形狀) },前端只收當頁 20 筆。
+  if (stage && (SHORTAGE_RESOLUTION_BY_STAGE[stage]?.length ?? 1) === 0) {
+    return { rows: [], total: 0 }; // standby / rejected:訂單短少沒有這兩個 stage
   }
-  if (dateFrom) q = q.gte("order_updated_at", `${dateFrom}T00:00:00`);
-  if (dateTo) q = q.lte("order_updated_at", `${dateTo}T23:59:59.999`);
-  // v_order_shortage 是 (order × sku) 維度,撈夠多 row 才能聚合出正確 distinct 訂單數
-  q = q.limit(20000);
-  const { data, error } = await q;
+  const { data, error } = await sb.rpc("rpc_hq_shortage_orders", {
+    p_stage: stage,
+    p_page: page,
+    p_page_size: PAGE_SIZE,
+    p_date_from: dateFrom ? `${dateFrom}T00:00:00` : null,
+    p_date_to: dateTo ? `${dateTo}T23:59:59.999` : null,
+  });
   if (error) throw new Error("shortage: " + error.message);
 
-  type ShortageRowRaw = {
-    order_id: number;
-    order_no: string;
-    member_id: number | null;
-    store_name: string | null;
-    order_status: string;
-    shortage_resolution: string | null;
-    shortage_notified_at: string | null;
-    sku_id: number;
-    product_name: string | null;
-    variant_name: string | null;
-    sku_code: string | null;
-    order_qty: number;
-    demand_unfulfillable: number;
-    order_updated_at: string;
-  };
-  const shortageRaw = (data ?? []) as ShortageRowRaw[];
-  const shortageByOrder = new Map<number, ShortageRaw>();
-  for (const r of shortageRaw) {
-    let s = shortageByOrder.get(r.order_id);
-    if (!s) {
-      s = {
-        order_id: r.order_id,
-        order_no: r.order_no,
-        member_id: r.member_id,
-        store_name: r.store_name,
-        order_status: r.order_status,
-        shortage_resolution: r.shortage_resolution,
-        shortage_notified_at: r.shortage_notified_at,
-        short_items: [],
-        total_unfulfillable: 0,
-        order_updated_at: r.order_updated_at,
-      };
-      shortageByOrder.set(r.order_id, s);
-    }
-    const skuLabel = `${r.product_name ?? ""}${r.variant_name ? ` / ${r.variant_name}` : ""}`.trim() || `品項#${r.sku_id}`;
-    s.short_items.push({
-      sku_id: r.sku_id,
-      sku_label: r.sku_code ? `${r.sku_code} ${skuLabel}` : skuLabel,
-      order_qty: Number(r.order_qty),
-      demand_unfulfillable: Number(r.demand_unfulfillable),
-    });
-    s.total_unfulfillable += Number(r.demand_unfulfillable);
-  }
-  const allOrderRows = Array.from(shortageByOrder.values());
-  const total = allOrderRows.length;
-  const start = (page - 1) * PAGE_SIZE;
-  const pageRows = allOrderRows.slice(start, start + PAGE_SIZE);
-  const rows: Row[] = pageRows.map((s) => ({
+  const resp = (data ?? { total: 0, rows: [] }) as { total: number; rows: ShortageRaw[] };
+  const rows: Row[] = (resp.rows ?? []).map((s) => ({
     key: `shortage-${s.order_id}`,
     source: "shortage" as const,
     ts: new Date(s.order_updated_at).getTime(),
     stage: classifyShortage(s.shortage_resolution),
-    raw: s,
+    raw: {
+      ...s,
+      total_unfulfillable: Number(s.total_unfulfillable),
+      short_items: (s.short_items ?? []).map((it) => ({
+        ...it,
+        order_qty: Number(it.order_qty),
+        demand_unfulfillable: Number(it.demand_unfulfillable),
+      })),
+    },
   }));
-  return { rows, total };
+  return { rows, total: resp.total ?? 0 };
 }
 
 async function fetchPickingRows(
@@ -1237,6 +1192,33 @@ function HqInboxContent() {
   // server-side 已分頁,paginatedRows 直接 = filtered(當前頁的 rows 經過 search 過濾)
   const paginatedRows = filtered;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  // 分頁控制列 — 列表上、下各放一份(手機不用滑到底才能換頁)
+  const paginationBar = total > PAGE_SIZE ? (
+    <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
+      <span className="text-xs text-zinc-500">
+        共 {total} 筆 ·
+        顯示 {(page - 1) * PAGE_SIZE + 1} - {Math.min(page * PAGE_SIZE, total)}
+      </span>
+      <SpinButton onClick={() => setPage(1)} disabled={page === 1}
+        className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
+        « 第一頁
+      </SpinButton>
+      <SpinButton onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}
+        className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
+        ‹ 上頁
+      </SpinButton>
+      <span className="text-xs text-zinc-500">{page} / {totalPages}</span>
+      <SpinButton onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages}
+        className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
+        下頁 ›
+      </SpinButton>
+      <SpinButton onClick={() => setPage(totalPages)} disabled={page === totalPages}
+        className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
+        最末頁 »
+      </SpinButton>
+    </div>
+  ) : null;
 
   // 任何 server 端篩選變動 → 回到第 1 頁(避免 page 超出範圍)
   useEffect(() => {
@@ -2139,6 +2121,9 @@ function HqInboxContent() {
             </div>
           )}
 
+          {/* 分頁 — 列表上方(手機優先看得到) */}
+          {paginationBar}
+
           {/* === Row list (郵件列) === */}
           <div className="overflow-hidden rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
             {rows === null ? (
@@ -2180,32 +2165,8 @@ function HqInboxContent() {
             )}
           </div>
 
-          {/* 分頁 — server-side,所有來源(含「全部」)都可用 */}
-          {total > PAGE_SIZE && (
-            <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
-              <span className="text-xs text-zinc-500">
-                共 {total} 筆 ·
-                顯示 {(page - 1) * PAGE_SIZE + 1} - {Math.min(page * PAGE_SIZE, total)}
-              </span>
-              <SpinButton onClick={() => setPage(1)} disabled={page === 1}
-                className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
-                « 第一頁
-              </SpinButton>
-              <SpinButton onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}
-                className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
-                ‹ 上頁
-              </SpinButton>
-              <span className="text-xs text-zinc-500">{page} / {totalPages}</span>
-              <SpinButton onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages}
-                className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
-                下頁 ›
-              </SpinButton>
-              <SpinButton onClick={() => setPage(totalPages)} disabled={page === totalPages}
-                className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
-                最末頁 »
-              </SpinButton>
-            </div>
-          )}
+          {/* 分頁 — server-side,所有來源(含「全部」)都可用;列表下方再放一份 */}
+          {paginationBar}
           </>
         )}
       </div>

--- a/apps/admin/src/components/ExceptionsContent.tsx
+++ b/apps/admin/src/components/ExceptionsContent.tsx
@@ -232,6 +232,33 @@ export default function ExceptionsContent({
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const currentPage = Math.min(page, totalPages);
 
+  // 分頁控制列 — server-side(rpc_hq_exceptions),表格上、下各放一份
+  // (手機不用滑過整頁 20 列才能換頁),樣式對齊 /hq/inbox 其他來源
+  const paginationBar = rows !== null && total > PAGE_SIZE ? (
+    <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
+      <span className="text-xs text-zinc-500">
+        共 {total} 筆 · 顯示 {(currentPage - 1) * PAGE_SIZE + 1} - {Math.min(currentPage * PAGE_SIZE, total)}
+      </span>
+      <SpinButton onClick={() => setPage(1)} disabled={currentPage === 1}
+        className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
+        « 第一頁
+      </SpinButton>
+      <SpinButton onClick={() => setPage(currentPage - 1)} disabled={currentPage === 1}
+        className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
+        ‹ 上頁
+      </SpinButton>
+      <span className="text-xs text-zinc-500">{currentPage} / {totalPages}</span>
+      <SpinButton onClick={() => setPage(currentPage + 1)} disabled={currentPage === totalPages}
+        className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
+        下頁 ›
+      </SpinButton>
+      <SpinButton onClick={() => setPage(totalPages)} disabled={currentPage === totalPages}
+        className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
+        最末頁 »
+      </SpinButton>
+    </div>
+  ) : null;
+
   return (
     <div className="flex flex-1 flex-col gap-4">
       {showHeader && (
@@ -267,6 +294,9 @@ export default function ExceptionsContent({
           );
         })}
       </div>
+
+      {/* 分頁 — 表格上方(手機優先看得到) */}
+      {paginationBar}
 
       <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
@@ -363,31 +393,8 @@ export default function ExceptionsContent({
         </table>
       </div>
 
-      {/* 分頁 — server-side(rpc_hq_exceptions),樣式對齊 /hq/inbox 其他來源 */}
-      {rows !== null && total > PAGE_SIZE && (
-        <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
-          <span className="text-xs text-zinc-500">
-            共 {total} 筆 · 顯示 {(currentPage - 1) * PAGE_SIZE + 1} - {Math.min(currentPage * PAGE_SIZE, total)}
-          </span>
-          <SpinButton onClick={() => setPage(1)} disabled={currentPage === 1}
-            className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
-            « 第一頁
-          </SpinButton>
-          <SpinButton onClick={() => setPage(currentPage - 1)} disabled={currentPage === 1}
-            className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
-            ‹ 上頁
-          </SpinButton>
-          <span className="text-xs text-zinc-500">{currentPage} / {totalPages}</span>
-          <SpinButton onClick={() => setPage(currentPage + 1)} disabled={currentPage === totalPages}
-            className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
-            下頁 ›
-          </SpinButton>
-          <SpinButton onClick={() => setPage(totalPages)} disabled={currentPage === totalPages}
-            className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800">
-            最末頁 »
-          </SpinButton>
-        </div>
-      )}
+      {/* 分頁 — 表格下方再放一份 */}
+      {paginationBar}
 
       {resolveCtx && (
         <TransferShortageResolveModal

--- a/supabase/migrations/20260731000010_v_order_shortage_settled_po_gate.sql
+++ b/supabase/migrations/20260731000010_v_order_shortage_settled_po_gate.sql
@@ -1,0 +1,168 @@
+-- ============================================================
+-- v_order_shortage v3:只判「採購已定案」的 SKU + closed PO 供給不歸零
+--
+-- 問題(總倉收件匣「異常」爆量 8,823 筆、其中訂單短少 8,733):
+--   v2 的供給來自 v_picking_demand_by_po,該 view 只含
+--   status IN ('sent','partially_received','fully_received') 的 PO。
+--   線上實測 8,733 筆的組成:
+--     1. ~7,300 筆:新檔期(7/20-7/28 團購)收單了但 PO 還沒開
+--        → 517 個 SKU 完全沒有 PO → 供給 = 0 → 檔期每一張訂單都被
+--        標成「訂單短少」。這不是短少,是採購流程還沒跑到。
+--     2. ~1,087 筆:斷貨後遺症。rpc_stockout_purchase_order 會把
+--        部分到貨的 PO 轉 'closed'(20260702020000),而「部分到貨的
+--        SKU 不視為斷貨」→ 其訂單品項不會被連動取消;但 PO 一轉
+--        closed,已收的量就從 v2 供給裡消失 → 需求還在、供給歸零
+--        → 82 個 SKU 的殘留訂單全變假異常。
+--     3. ~340 筆:有活躍 PO 但供給真的不足 — 唯一的真異常。
+--
+-- 修法(兩刀):
+--   A. 供給改為直接從 purchase_orders / goods_receipts 計算,
+--      納入 'closed' PO 的已收量(關單 ≠ 貨消失;closed 的在途 = 0,
+--      差額不會再到)。不再依賴 v_picking_demand_by_po 的供給欄位,
+--      避免動到撿貨工作站 view。
+--   B. 只對「採購已定案」的 SKU 判定短缺:SKU 必須存在至少一張
+--      status IN ('sent','partially_received','fully_received','closed')
+--      的 PO(以 INNER JOIN settled 供給實現)。完全沒 PO 的 SKU
+--      = 還在等採購開單,不判短缺;只剩 cancelled PO 的 SKU
+--      = 斷貨且零到貨,由斷貨連動(取消品項+通知)處理,不重複列。
+--
+-- 已知邊界:SKU 跨檔期重用時,舊 PO 會讓新檔期提早進入判定
+--   (供給算舊 PO 的量)。此 view 本來就是 SKU 維度全域 pooling,
+--   維持一致;誤差遠小於修掉的 8,400 筆假警報。
+--
+-- 欄位:與 v2 完全同名同序同型別(僅來源改寫),下游
+--   v_hq_exceptions / v_hq_inbox / hq/inbox 頁免改。
+-- total_wave / total_shipped 仍取自 v_picking_demand_by_po(僅活躍 PO
+--   的已撿/已派,資訊欄位,不影響短缺判定),與 v2 行為一致。
+--
+-- 基於:20260607000020_v_order_shortage_fix.sql(v2,最新版)。
+-- Rollback:CREATE OR REPLACE VIEW 回 20260607000020 版本。
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.v_order_shortage AS
+WITH
+-- 1. SKU 維度供給:sent/partial/fully 算「已收 + 在途(未收餘量)」,
+--    closed 只算已收(差額不會再到)。cancelled / draft 不入列。
+--    這個 CTE 同時是「採購已定案」閘門:沒有列 = 該 SKU 不判短缺。
+settled_po_supply AS (
+  SELECT
+    poi.sku_id,
+    SUM(COALESCE(g.gr_qty, 0)) AS total_gr,
+    SUM(
+      CASE WHEN po.status IN ('sent', 'partially_received')
+           THEN GREATEST(0, poi.qty_ordered - COALESCE(g.gr_qty, 0))
+           ELSE 0
+      END
+    ) AS total_in_transit
+  FROM purchase_orders po
+  JOIN purchase_order_items poi ON poi.po_id = po.id
+  LEFT JOIN (
+    SELECT gri.po_item_id, SUM(gri.qty_received) AS gr_qty
+    FROM goods_receipt_items gri
+    JOIN goods_receipts gr ON gr.id = gri.gr_id
+    WHERE gr.status = 'confirmed'
+    GROUP BY gri.po_item_id
+  ) g ON g.po_item_id = poi.id
+  WHERE po.status IN ('sent', 'partially_received', 'fully_received', 'closed')
+  GROUP BY poi.sku_id
+),
+-- 已撿+已派(沿用 v2:每 (sku, store) 算一次,不重複)
+allocated_per_sku_store AS (
+  SELECT
+    sku_id, store_id,
+    SUM(wave_qty)    AS total_wave,
+    SUM(shipped_qty) AS total_shipped
+  FROM v_picking_demand_by_po
+  WHERE store_id IS NOT NULL
+  GROUP BY sku_id, store_id
+),
+allocated_per_sku AS (
+  SELECT sku_id,
+    SUM(total_wave)    AS total_wave,
+    SUM(total_shipped) AS total_shipped
+  FROM allocated_per_sku_store
+  GROUP BY sku_id
+),
+-- 2. SKU 維度 demand(沿用 v2)
+demand_per_sku_store AS (
+  SELECT
+    coi.sku_id,
+    co.pickup_store_id AS store_id,
+    SUM(coi.qty) AS demand_qty
+  FROM customer_orders co
+  JOIN customer_order_items coi ON coi.order_id = co.id
+  WHERE co.status NOT IN ('cancelled','expired','transferred_out','completed','partially_completed')
+    AND coi.status NOT IN ('cancelled','expired')
+    AND co.transferred_from_order_id IS NULL
+    AND co.pickup_store_id IS NOT NULL
+  GROUP BY coi.sku_id, co.pickup_store_id
+),
+demand_per_sku AS (
+  SELECT sku_id, SUM(demand_qty) AS total_demand
+  FROM demand_per_sku_store
+  GROUP BY sku_id
+),
+-- 3. SKU 層級短缺判定:INNER JOIN settled_po_supply = 採購定案閘門
+sku_shortage AS (
+  SELECT
+    d.sku_id,
+    d.total_demand,
+    COALESCE(s.total_gr, 0)         AS total_gr,
+    COALESCE(s.total_in_transit, 0) AS total_in_transit,
+    COALESCE(a.total_wave, 0)       AS total_wave,
+    COALESCE(a.total_shipped, 0)    AS total_shipped,
+    GREATEST(0,
+      d.total_demand - COALESCE(s.total_gr, 0) - COALESCE(s.total_in_transit, 0)
+    ) AS sku_shortage_qty
+  FROM demand_per_sku d
+  JOIN settled_po_supply s ON s.sku_id = d.sku_id
+  LEFT JOIN allocated_per_sku a ON a.sku_id = d.sku_id
+  WHERE
+    -- 只列總供給 < 總需求 的 SKU
+    d.total_demand > COALESCE(s.total_gr, 0) + COALESCE(s.total_in_transit, 0)
+)
+-- 4. 展開到 order_item:該訂單按 (sku, store) demand 比例承擔短缺(沿用 v2)
+SELECT
+  co.tenant_id,
+  co.id              AS order_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id AS store_id,
+  st.name            AS store_name,
+  co.status          AS order_status,
+  co.shortage_notified_at,
+  co.shortage_resolution,
+  co.shortage_resolution_at,
+  coi.id             AS order_item_id,
+  coi.sku_id,
+  s.sku_code,
+  s.product_name,
+  s.variant_name,
+  coi.qty            AS order_qty,
+  ss.total_demand,
+  ss.total_gr,
+  ss.total_in_transit,
+  ss.total_wave,
+  ss.total_shipped,
+  ss.sku_shortage_qty AS total_supplier_shortage,
+  -- 每張 order_item 的短缺量 = 比例分配
+  ROUND(coi.qty::NUMERIC * ss.sku_shortage_qty / NULLIF(ss.total_demand, 0), 2) AS demand_unfulfillable,
+  co.created_at      AS order_created_at,
+  co.updated_at      AS order_updated_at
+FROM customer_orders co
+JOIN customer_order_items coi ON coi.order_id = co.id
+JOIN sku_shortage ss ON ss.sku_id = coi.sku_id
+LEFT JOIN skus s ON s.id = coi.sku_id
+LEFT JOIN stores st ON st.id = co.pickup_store_id
+WHERE co.status NOT IN ('cancelled','expired','transferred_out','completed','partially_completed')
+  AND coi.status NOT IN ('cancelled','expired')
+  AND co.transferred_from_order_id IS NULL
+  AND ss.sku_shortage_qty > 0;
+
+GRANT SELECT ON public.v_order_shortage TO authenticated;
+
+COMMENT ON VIEW public.v_order_shortage IS
+  '短缺訂單看板 v3:只對「採購已定案」(存在 sent/partial/fully/closed PO)的 SKU 判定短缺;'
+  '供給直接從 PO/GR 計算,closed PO 的已收量不歸零(關單≠貨消失)。'
+  '完全沒 PO 的 SKU = 等採購開單,不列;只剩 cancelled PO 的 SKU 由斷貨連動處理,不列。'
+  '展開到 order_item 按比例分攤短缺量,欄位與 v2 相容。';

--- a/supabase/migrations/20260731000020_rpc_hq_shortage_orders.sql
+++ b/supabase/migrations/20260731000020_rpc_hq_shortage_orders.sql
@@ -1,0 +1,106 @@
+-- ============================================================
+-- rpc_hq_shortage_orders — 總倉收件匣「訂單短少」來源 server-side 分頁
+--
+-- 背景:
+--   /hq/inbox 的 shortage 來源(fetchShortageRows)原本前端
+--   `.from("v_order_shortage").limit(20000)` 把 (order × sku) 全撈,
+--   client 聚合到 order 維度再切頁 — 是「假分頁」:換頁/換 stage 都
+--   重新下載整包。訂單短少爆量時(修正前 8,733 張單)行動網路上
+--   要載幾十秒,體感就是「這頁沒分頁」。
+--
+-- 解法:聚合 + stage/日期篩選 + 分頁全部搬進 DB,一次回傳
+--   { total, rows(當前頁, ShortageRaw 形狀) },前端只收 20 筆。
+--
+-- 對齊前端(hq/inbox/page.tsx):
+--   - rows 欄位 = ShortageRaw:order_id / order_no / member_id /
+--     store_name / order_status / shortage_resolution /
+--     shortage_notified_at / short_items[] / total_unfulfillable /
+--     order_updated_at
+--   - p_stage 篩選 = SHORTAGE_RESOLUTION_BY_STAGE:
+--       pending    → shortage_resolution IS NULL
+--       in_transit → IN ('notified','waiting_next_po')
+--       done       → IN ('cancelled','reallocated')
+--       其他值     → 空(standby / rejected 前端本來就直接回空)
+--   - 排序 = order_updated_at DESC(同原查詢)
+--   - sku_label 組法與 v_hq_exceptions customer_shortage 分支一致
+--
+-- 慣例對齊:SECURITY DEFINER + GRANT EXECUTE TO authenticated
+--   (同 rpc_hq_exceptions,20260704000020)。
+--
+-- 基於:v_order_shortage v3(20260731000010)。本 RPC 為新建,無前身。
+-- Rollback:DROP FUNCTION public.rpc_hq_shortage_orders(text,int,int,timestamptz,timestamptz);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_hq_shortage_orders(
+  p_stage     text        DEFAULT NULL,
+  p_page      int         DEFAULT 1,
+  p_page_size int         DEFAULT 20,
+  p_date_from timestamptz DEFAULT NULL,
+  p_date_to   timestamptz DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH agg AS MATERIALIZED (
+    SELECT
+      vos.order_id,
+      MAX(vos.order_no)             AS order_no,
+      MAX(vos.member_id)            AS member_id,
+      MAX(vos.store_name)           AS store_name,
+      MAX(vos.order_status)         AS order_status,
+      MAX(vos.shortage_resolution)  AS shortage_resolution,
+      MAX(vos.shortage_notified_at) AS shortage_notified_at,
+      MAX(vos.order_updated_at)     AS order_updated_at,
+      SUM(vos.demand_unfulfillable) AS total_unfulfillable,
+      jsonb_agg(
+        jsonb_build_object(
+          'sku_id', vos.sku_id,
+          'sku_label',
+            CASE
+              WHEN vos.sku_code IS NOT NULL AND vos.sku_code <> ''
+                THEN vos.sku_code || ' ' || COALESCE(NULLIF(TRIM(COALESCE(vos.product_name,'') || COALESCE(' / ' || NULLIF(vos.variant_name,''), '')), ''), '品項#' || vos.sku_id::text)
+              ELSE COALESCE(NULLIF(TRIM(COALESCE(vos.product_name,'') || COALESCE(' / ' || NULLIF(vos.variant_name,''), '')), ''), '品項#' || vos.sku_id::text)
+            END,
+          'order_qty', vos.order_qty,
+          'demand_unfulfillable', vos.demand_unfulfillable
+        )
+        ORDER BY vos.sku_id
+      )                             AS short_items
+    FROM public.v_order_shortage vos
+    GROUP BY vos.order_id
+  ),
+  filtered AS (
+    SELECT * FROM agg
+    WHERE CASE
+            WHEN p_stage IS NULL            THEN TRUE
+            WHEN p_stage = 'pending'        THEN shortage_resolution IS NULL
+            WHEN p_stage = 'in_transit'     THEN shortage_resolution IN ('notified','waiting_next_po')
+            WHEN p_stage = 'done'           THEN shortage_resolution IN ('cancelled','reallocated')
+            ELSE FALSE
+          END
+      AND (p_date_from IS NULL OR order_updated_at >= p_date_from)
+      AND (p_date_to   IS NULL OR order_updated_at <= p_date_to)
+  ),
+  page AS (
+    SELECT * FROM filtered
+    ORDER BY order_updated_at DESC NULLS LAST, order_id
+    LIMIT  GREATEST(1, p_page_size)
+    OFFSET GREATEST(0, (p_page - 1) * p_page_size)
+  )
+  SELECT jsonb_build_object(
+    'total', (SELECT COUNT(*) FROM filtered),
+    'rows', (
+      SELECT COALESCE(jsonb_agg(to_jsonb(page) ORDER BY order_updated_at DESC NULLS LAST, order_id), '[]'::jsonb)
+      FROM page
+    )
+  );
+$$;
+
+COMMENT ON FUNCTION public.rpc_hq_shortage_orders(text, int, int, timestamptz, timestamptz) IS
+  '總倉收件匣「訂單短少」server-side 分頁:v_order_shortage 聚合到 order 維度,'
+  '依 stage(shortage_resolution)/ 日期篩選後分頁,回傳 { total, rows }。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_hq_shortage_orders(text, int, int, timestamptz, timestamptz) TO authenticated;


### PR DESCRIPTION
線上異常 8,823 筆中 8,733 筆是 v_order_shortage 的假警報:
- ~7,300 筆:新檔期收單但 PO 還沒開(517 個 SKU 無任何 PO,供給=0
  → 檔期每張訂單都被標短少)
- ~1,087 筆:斷貨把部分到貨 PO 轉 closed 後,已收量從供給消失
  (v2 供給只算 sent/partial/fully 的 PO),殘留訂單全變假異常
- ~340 筆:真短少

v3 改法:
- 供給直接從 PO/GR 計算,納入 closed PO 已收量(關單≠貨消失)
- INNER JOIN 供給 = 「採購已定案」閘門:無 PO 的 SKU 不判短缺,
  只剩 cancelled PO 的 SKU 交給斷貨連動處理
- 欄位與 v2 完全相容,下游 v_hq_exceptions / v_hq_inbox 免改

已部署線上並驗證:異常 8,823 → 400(訂單短少 8,733 → 310,
全部都有實際 PO 且到貨+在途 < 需求)。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01454sxHuVFmKsNKkmxB1t7E