### PR TITLE
feat: add manual settlement adjustment (amount + reason)

### DIFF
--- a/apps/admin/src/app/(protected)/finance/receivables/print/page.tsx
+++ b/apps/admin/src/app/(protected)/finance/receivables/print/page.tsx
@@ -32,6 +32,13 @@ type SettlementItem = {
   description: string | null;
 };
 
+type Adjustment = {
+  id: number;
+  amount: number;
+  reason: string;
+  created_at: string;
+};
+
 type Store = { id: number; code: string; name: string };
 type Sku = { id: number; sku_code: string | null; product_name: string | null; variant_name: string | null };
 type Transfer = { id: number; transfer_no: string };
@@ -59,6 +66,7 @@ export default function PrintSettlementPage() {
   const [settlement, setSettlement] = useState<Settlement | null>(null);
   const [store, setStore] = useState<Store | null>(null);
   const [items, setItems] = useState<SettlementItem[]>([]);
+  const [adjustments, setAdjustments] = useState<Adjustment[]>([]);
   const [transfers, setTransfers] = useState<Map<number, Transfer>>(new Map());
   const [skus, setSkus] = useState<Map<number, Sku>>(new Map());
   const [tenantName, setTenantName] = useState("");
@@ -91,7 +99,7 @@ export default function PrintSettlementPage() {
         const sd = s as Settlement;
         setSettlement(sd);
 
-        const [{ data: storeData }, { data: itemRows }, { data: tenantData }] = await Promise.all([
+        const [{ data: storeData }, { data: itemRows }, { data: tenantData }, { data: adjData }] = await Promise.all([
           sb.from("stores").select("id, code, name").eq("id", sd.store_id).maybeSingle(),
           sb.from("store_monthly_settlement_items")
             .select("id, transfer_id, sku_id, qty_received, unit_cost, line_amount, unit_branch_price, branch_amount, received_at, entry_type, description")
@@ -99,9 +107,16 @@ export default function PrintSettlementPage() {
             .order("entry_type")
             .order("received_at"),
           sb.from("tenants").select("name").limit(1),
+          sb.from("store_settlement_adjustments")
+            .select("id, amount, reason, created_at")
+            .eq("store_id", sd.store_id)
+            .eq("settlement_month", sd.settlement_month)
+            .eq("status", "active")
+            .order("created_at"),
         ]);
         if (cancelled) return;
         if (storeData) setStore(storeData as Store);
+        setAdjustments((adjData ?? []) as Adjustment[]);
         const itList = (itemRows ?? []) as SettlementItem[];
         setItems(itList);
         const t = (tenantData as { name: string }[] | null)?.[0];
@@ -155,6 +170,7 @@ export default function PrintSettlementPage() {
   const monthLabel = settlement.settlement_month?.slice(0, 7);
   const totalCost = items.reduce((s, it) => s + Number(it.line_amount), 0);
   const totalBranch = items.reduce((s, it) => s + Number(it.branch_amount ?? 0), 0);
+  const adjTotal = adjustments.reduce((s, a) => s + Number(a.amount), 0);
   const today = new Date().toLocaleDateString("zh-TW");
   const internal = view === "internal" && costAllowed;
 
@@ -334,10 +350,52 @@ export default function PrintSettlementPage() {
             </tbody>
           </table>
 
+          {/* 金額調整（明細以外的加減項＋原因） */}
+          {adjustments.length > 0 && (
+            <>
+              <div className="mt-4 mb-1 text-xs font-semibold">金額調整</div>
+              <table className="stmt-table w-full border-collapse text-xs">
+                <thead>
+                  <tr className="border-b-2 border-zinc-900">
+                    <th className="border border-zinc-400 px-2 py-1.5 text-left">#</th>
+                    <th className="border border-zinc-400 px-2 py-1.5 text-left">日期</th>
+                    <th className="border border-zinc-400 px-2 py-1.5 text-left">原因</th>
+                    <th className="border border-zinc-400 px-2 py-1.5 text-right">金額</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {adjustments.map((a, i) => (
+                    <tr key={a.id}>
+                      <td className="border border-zinc-400 px-2 py-1">{i + 1}</td>
+                      <td className="border border-zinc-400 px-2 py-1 whitespace-nowrap">{new Date(a.created_at).toLocaleDateString("zh-TW")}</td>
+                      <td className="border border-zinc-400 px-2 py-1">{a.reason}</td>
+                      <td className={`border border-zinc-400 px-2 py-1 text-right font-mono whitespace-nowrap ${Number(a.amount) < 0 ? "text-emerald-700" : ""}`}>
+                        {Number(a.amount) < 0 ? "−" : "+"}${Math.abs(Number(a.amount)).toLocaleString("zh-TW")}
+                      </td>
+                    </tr>
+                  ))}
+                  <tr className="bg-zinc-100 font-semibold">
+                    <td colSpan={3} className="border border-zinc-400 px-2 py-1.5 text-right">調整合計</td>
+                    <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono whitespace-nowrap">
+                      {adjTotal < 0 ? "−" : "+"}${Math.abs(adjTotal).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div className="mt-2 text-right text-sm font-semibold">
+                商品合計 ${totalBranch.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                <span className="mx-1">＋</span>調整 {adjTotal < 0 ? "−" : "+"}${Math.abs(adjTotal).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                <span className="mx-1">＝</span>應付金額{" "}
+                <span className="text-rose-600">${Number(settlement.payable_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}</span>
+              </div>
+            </>
+          )}
+
           {/* 說明 */}
           <div className="mt-3 text-[10px] text-zinc-500">
             ※ 類型說明：HQ 進貨 = 總倉直接出貨給本店；空中轉入 = 別店空中轉來（加應付）；空中轉出 = 空中轉去別店（減應付）；
             自由轉入／轉出 = 店間自由轉貨（轉貨時申報金額入帳）；退貨沖回 = 退貨回總倉（減應付）。
+            {adjustments.length > 0 && "金額調整 = 總部人工加減項（正=加收、負=減收），原因如上表。"}
             {internal && (
               <>
                 <br />

--- a/apps/admin/src/app/(protected)/transfers/settlement/detail/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/detail/page.tsx
@@ -19,6 +19,7 @@ type Settlement = {
   payable_amount: number;
   cost_amount: number;
   branch_amount: number;
+  adjustment_amount: number;
   transfer_count: number;
   item_count: number;
   status: SettlementStatus;
@@ -67,12 +68,22 @@ type Dispute = {
   resolution_note: string | null;
 };
 
+type Adjustment = {
+  id: number;
+  amount: number;
+  reason: string;
+  status: "active" | "voided";
+  created_at: string;
+  voided_at: string | null;
+  void_reason: string | null;
+};
+
 type Store = { id: number; code: string; name: string };
 type Transfer = { id: number; transfer_no: string; status: string; shipped_at: string | null };
 type Sku = { id: number; sku_code: string | null; product_name: string | null; variant_name: string | null };
 
 const SETTLEMENT_SELECT =
-  "id, settlement_month, store_id, payable_amount, cost_amount, branch_amount, transfer_count, item_count, status, confirmed_at, settled_at, generated_receivable_id, notes, updated_at, sent_at, store_agreed_at, remitted_at, remit_note";
+  "id, settlement_month, store_id, payable_amount, cost_amount, branch_amount, adjustment_amount, transfer_count, item_count, status, confirmed_at, settled_at, generated_receivable_id, notes, updated_at, sent_at, store_agreed_at, remitted_at, remit_note";
 
 const ENTRY_TYPE_LABEL: Record<Item["entry_type"], string> = {
   hq_inbound: "HQ 進貨",
@@ -116,6 +127,7 @@ export default function HqSettlementDetailPage() {
   const [store, setStore] = useState<Store | null>(null);
   const [items, setItems] = useState<Item[] | null>(null);
   const [disputes, setDisputes] = useState<Dispute[]>([]);
+  const [adjustments, setAdjustments] = useState<Adjustment[]>([]);
   const [transfers, setTransfers] = useState<Map<number, Transfer>>(new Map());
   const [skus, setSkus] = useState<Map<number, Sku>>(new Map());
   const [err, setErr] = useState<string | null>(null);
@@ -131,6 +143,14 @@ export default function HqSettlementDetailPage() {
   const [pendingAction, setPendingAction] = useState<"send" | "confirm" | "settle" | null>(null);
   const [resolvingId, setResolvingId] = useState<number | null>(null);
   const [resolveNote, setResolveNote] = useState("");
+
+  // 金額調整（增減金額＋原因）
+  const [showAdjForm, setShowAdjForm] = useState(false);
+  const [adjSign, setAdjSign] = useState<"add" | "minus">("add");
+  const [adjAmount, setAdjAmount] = useState("");
+  const [adjReason, setAdjReason] = useState("");
+  const [voidingAdjId, setVoidingAdjId] = useState<number | null>(null);
+  const [voidReason, setVoidReason] = useState("");
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -170,7 +190,7 @@ export default function HqSettlementDetailPage() {
       const list = (data ?? []) as Item[];
       setItems(list);
 
-      const [{ data: storeData }, { data: tx }, { data: sk }] = await Promise.all([
+      const [{ data: storeData }, { data: tx }, { data: sk }, { data: adjData }] = await Promise.all([
         sb.from("stores").select("id, code, name").eq("id", hd.store_id).maybeSingle(),
         list.length
           ? sb.from("transfers").select("id, transfer_no, status, shipped_at").in("id", Array.from(new Set(list.map((it) => it.transfer_id))))
@@ -178,9 +198,16 @@ export default function HqSettlementDetailPage() {
         list.length
           ? sb.from("skus").select("id, sku_code, product_name, variant_name").in("id", Array.from(new Set(list.map((it) => it.sku_id))))
           : Promise.resolve({ data: [] as Sku[] }),
+        sb
+          .from("store_settlement_adjustments")
+          .select("id, amount, reason, status, created_at, voided_at, void_reason")
+          .eq("store_id", hd.store_id)
+          .eq("settlement_month", hd.settlement_month)
+          .order("created_at", { ascending: true }),
       ]);
       if (cancelled) return;
       if (storeData) setStore(storeData as Store);
+      setAdjustments((adjData ?? []) as Adjustment[]);
       const tm = new Map<number, Transfer>();
       for (const t of (tx ?? []) as Transfer[]) tm.set(t.id, t);
       setTransfers(tm);
@@ -209,6 +236,11 @@ export default function HqSettlementDetailPage() {
       setPendingAction(null);
       setResolvingId(null);
       setResolveNote("");
+      setShowAdjForm(false);
+      setAdjAmount("");
+      setAdjReason("");
+      setVoidingAdjId(null);
+      setVoidReason("");
       refresh();
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
@@ -244,6 +276,18 @@ export default function HqSettlementDetailPage() {
     } finally {
       setBusy(false);
     }
+  }
+
+  function onAddAdjustment() {
+    if (!settlementId) return;
+    const amt = Number(adjAmount);
+    if (!Number.isFinite(amt) || amt <= 0) { setErr("調整金額需為 > 0 的數字"); return; }
+    if (!adjReason.trim()) { setErr("調整金額必須填原因"); return; }
+    void runRpc("rpc_add_settlement_adjustment", {
+      p_settlement_id: settlementId,
+      p_amount: adjSign === "minus" ? -amt : amt,
+      p_reason: adjReason.trim(),
+    });
   }
 
   function onConfirmPending() {
@@ -295,9 +339,16 @@ export default function HqSettlementDetailPage() {
       </header>
 
       <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3 lg:grid-cols-6">
-        <Stat label="應付金額（分店價口徑）" value={`$${Number(header.payable_amount).toLocaleString("zh-TW")}`} accent="negative" />
+        <Stat label="應付金額（含調整）" value={`$${Number(header.payable_amount).toLocaleString("zh-TW")}`} accent="negative" />
         <Stat label="成本口徑金額（參考）" value={`$${Number(header.cost_amount ?? 0).toLocaleString("zh-TW")}`} />
         <Stat label="口徑差額（總部毛利）" value={`$${(Number(header.branch_amount ?? 0) - Number(header.cost_amount ?? 0)).toLocaleString("zh-TW")}`} accent="info" />
+        {Number(header.adjustment_amount ?? 0) !== 0 && (
+          <Stat
+            label="人工調整合計"
+            value={`${Number(header.adjustment_amount) > 0 ? "+" : "−"}$${Math.abs(Number(header.adjustment_amount)).toLocaleString("zh-TW")}`}
+            accent="info"
+          />
+        )}
         <Stat label="調撥單數" value={String(header.transfer_count)} />
         <Stat label="商品行數" value={String(header.item_count)} />
         <Stat label="月份" value={monthLabel} />
@@ -413,6 +464,168 @@ export default function HqSettlementDetailPage() {
           📄 列印對帳單
         </a>
       </div>
+
+      {/* 金額調整（增減金額＋原因） */}
+      {(adjustments.length > 0 || canEditEst) && (
+        <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-zinc-200 bg-zinc-50 px-3 py-2 dark:border-zinc-800 dark:bg-zinc-900">
+            <span className="text-sm font-medium">金額調整（加收 / 減收，需填原因）</span>
+            {canEditEst && !showAdjForm && (
+              <SpinButton
+                onClick={() => { setShowAdjForm(true); setAdjSign("add"); setAdjAmount(""); setAdjReason(""); setVoidingAdjId(null); setErr(null); }}
+                disabled={busy}
+                className="rounded-md border border-blue-300 px-2 py-1 text-xs text-blue-700 hover:bg-blue-50 dark:border-blue-800 dark:text-blue-300 dark:hover:bg-blue-950"
+              >
+                ＋ 新增調整
+              </SpinButton>
+            )}
+          </div>
+
+          {showAdjForm && (
+            <div className="border-b border-zinc-200 p-3 dark:border-zinc-800">
+              <div className="flex flex-wrap items-end gap-2">
+                <label className="text-xs">
+                  <span className="mb-1 block text-zinc-500">方向</span>
+                  <select
+                    value={adjSign}
+                    onChange={(e) => setAdjSign(e.target.value as "add" | "minus")}
+                    className="rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                  >
+                    <option value="add">增加金額（加收 +）</option>
+                    <option value="minus">減少金額（減收 −）</option>
+                  </select>
+                </label>
+                <label className="text-xs">
+                  <span className="mb-1 block text-zinc-500">金額</span>
+                  <input
+                    type="number"
+                    min="1"
+                    step="1"
+                    value={adjAmount}
+                    onChange={(e) => setAdjAmount(e.target.value)}
+                    className="w-32 rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                  />
+                </label>
+                <label className="min-w-48 flex-1 text-xs">
+                  <span className="mb-1 block text-zinc-500">原因（必填）</span>
+                  <input
+                    value={adjReason}
+                    onChange={(e) => setAdjReason(e.target.value)}
+                    placeholder="例：11 月運費分攤／破損折讓"
+                    className="w-full rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                  />
+                </label>
+                <SpinButton
+                  onClick={onAddAdjustment}
+                  disabled={busy}
+                  className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {busy ? "儲存中…" : "儲存調整"}
+                </SpinButton>
+                <SpinButton
+                  onClick={() => { setShowAdjForm(false); setErr(null); }}
+                  disabled={busy}
+                  className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700"
+                >
+                  取消
+                </SpinButton>
+              </div>
+            </div>
+          )}
+
+          {adjustments.length === 0 ? (
+            <div className="p-3 text-sm text-zinc-500">
+              尚無調整。明細以外的加減項（運費、折讓、補貼、尾差沖抵…）可在此直接增減應付金額。
+            </div>
+          ) : (
+            <>
+              <ul className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                {adjustments.map((a) => {
+                  const voided = a.status === "voided";
+                  const positive = Number(a.amount) > 0;
+                  return (
+                    <li key={a.id} className="flex flex-wrap items-start gap-3 px-3 py-2 text-sm">
+                      <span
+                        className={`mt-0.5 inline-block rounded px-2 py-0.5 text-xs ${
+                          voided
+                            ? "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400"
+                            : positive
+                              ? "bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-300"
+                              : "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
+                        }`}
+                      >
+                        {voided ? "已作廢" : positive ? "加收" : "減收"}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className={voided ? "text-zinc-400 line-through" : ""}>
+                          <span className="font-mono font-medium">
+                            {positive ? "+" : "−"}${Math.abs(Number(a.amount)).toLocaleString("zh-TW")}
+                          </span>
+                          <span className="ml-2 break-words">{a.reason}</span>
+                        </div>
+                        <div className="text-xs text-zinc-500">
+                          {new Date(a.created_at).toLocaleString("zh-TW")}
+                          {voided && a.voided_at && (
+                            <span className="ml-2">
+                              作廢於 {new Date(a.voided_at).toLocaleString("zh-TW")}
+                              {a.void_reason && `（${a.void_reason}）`}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      {!voided && canEditEst && voidingAdjId !== a.id && (
+                        <SpinButton
+                          onClick={() => { setVoidingAdjId(a.id); setVoidReason(""); setShowAdjForm(false); setErr(null); }}
+                          disabled={busy}
+                          className="shrink-0 rounded-md border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        >
+                          作廢
+                        </SpinButton>
+                      )}
+                      {voidingAdjId === a.id && (
+                        <div className="flex w-full flex-wrap items-end gap-2 rounded-md border border-amber-300 bg-amber-50 p-2 dark:border-amber-800 dark:bg-amber-950">
+                          <label className="flex-1 text-xs">
+                            <span className="mb-1 block text-zinc-500">作廢原因（選填）</span>
+                            <input
+                              value={voidReason}
+                              onChange={(e) => setVoidReason(e.target.value)}
+                              placeholder="例：金額打錯，另開一筆"
+                              className="w-full rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                            />
+                          </label>
+                          <SpinButton
+                            onClick={() => void runRpc("rpc_void_settlement_adjustment", { p_adjustment_id: a.id, p_reason: voidReason.trim() || null })}
+                            disabled={busy}
+                            className="rounded-md bg-amber-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-700 disabled:opacity-50"
+                          >
+                            {busy ? "作廢中…" : "確定作廢"}
+                          </SpinButton>
+                          <SpinButton
+                            onClick={() => setVoidingAdjId(null)}
+                            disabled={busy}
+                            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700"
+                          >
+                            取消
+                          </SpinButton>
+                        </div>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+              <div className="border-t border-zinc-200 bg-zinc-50 px-3 py-2 text-right text-sm dark:border-zinc-800 dark:bg-zinc-900">
+                貨款合計（分店價）<span className="font-mono">${Number(header.branch_amount ?? 0).toLocaleString("zh-TW")}</span>
+                <span className="mx-1">＋</span>調整合計{" "}
+                <span className="font-mono">
+                  {Number(header.adjustment_amount ?? 0) < 0 ? "−" : "+"}${Math.abs(Number(header.adjustment_amount ?? 0)).toLocaleString("zh-TW")}
+                </span>
+                <span className="mx-1">＝</span>應付金額{" "}
+                <span className="font-mono font-semibold text-rose-600">${Number(header.payable_amount).toLocaleString("zh-TW")}</span>
+              </div>
+            </>
+          )}
+        </div>
+      )}
 
       <div>
         <div className="mb-2 text-sm font-medium">出貨明細（{items?.length ?? 0} 筆）</div>

--- a/apps/admin/src/app/(protected)/transfers/settlement/review/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/review/page.tsx
@@ -20,6 +20,7 @@ type Settlement = {
   settlement_month: string;
   store_id: number;
   payable_amount: number;
+  adjustment_amount: number;
   item_count: number;
   status: "sent" | "disputed" | "confirmed" | "remitted" | "settled" | "draft" | "cancelled";
   sent_at: string | null;
@@ -48,6 +49,13 @@ type Dispute = {
   reason: string;
   status: "open" | "resolved";
   resolution_note: string | null;
+};
+
+type Adjustment = {
+  id: number;
+  amount: number;
+  reason: string;
+  created_at: string;
 };
 
 type Transfer = { id: number; transfer_no: string };
@@ -102,6 +110,7 @@ export default function SettlementReviewPage() {
   const [store, setStore] = useState<StoreRow | null>(null);
   const [items, setItems] = useState<Item[] | null>(null);
   const [disputes, setDisputes] = useState<Dispute[]>([]);
+  const [adjustments, setAdjustments] = useState<Adjustment[]>([]);
   const [transfers, setTransfers] = useState<Map<number, Transfer>>(new Map());
   const [skus, setSkus] = useState<Map<number, Sku>>(new Map());
   const [err, setErr] = useState<string | null>(null);
@@ -137,7 +146,7 @@ export default function SettlementReviewPage() {
       const [{ data: s, error: e0 }, { data: itemRows, error: e1 }, { data: dData }] = await Promise.all([
         sb
           .from("store_monthly_settlements")
-          .select("id, settlement_month, store_id, payable_amount, item_count, status, sent_at, store_agreed_at, remitted_at, remit_note, settled_at")
+          .select("id, settlement_month, store_id, payable_amount, adjustment_amount, item_count, status, sent_at, store_agreed_at, remitted_at, remit_note, settled_at")
           .eq("id", settlementId)
           .maybeSingle(),
         sb
@@ -162,7 +171,7 @@ export default function SettlementReviewPage() {
       const list = (itemRows ?? []) as Item[];
       setItems(list);
 
-      const [{ data: storeData }, { data: tx }, { data: sk }] = await Promise.all([
+      const [{ data: storeData }, { data: tx }, { data: sk }, { data: adjData }] = await Promise.all([
         sb.from("stores").select("id, name").eq("id", sd.store_id).maybeSingle(),
         list.length
           ? sb.from("transfers").select("id, transfer_no").in("id", Array.from(new Set(list.map((it) => it.transfer_id))))
@@ -170,9 +179,17 @@ export default function SettlementReviewPage() {
         list.length
           ? sb.from("skus").select("id, sku_code, product_name, variant_name").in("id", Array.from(new Set(list.map((it) => it.sku_id))))
           : Promise.resolve({ data: [] as Sku[] }),
+        sb
+          .from("store_settlement_adjustments")
+          .select("id, amount, reason, created_at")
+          .eq("store_id", sd.store_id)
+          .eq("settlement_month", sd.settlement_month)
+          .eq("status", "active")
+          .order("created_at", { ascending: true }),
       ]);
       if (cancelled) return;
       if (storeData) setStore(storeData as StoreRow);
+      setAdjustments((adjData ?? []) as Adjustment[]);
       const tm = new Map<number, Transfer>();
       for (const t of (tx ?? []) as Transfer[]) tm.set(t.id, t);
       setTransfers(tm);
@@ -504,6 +521,40 @@ export default function SettlementReviewPage() {
           )}
         </table>
       </div>
+
+      {/* 總部金額調整（明細以外的加減項，含原因） */}
+      {adjustments.length > 0 && (
+        <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
+          <div className="border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-sm font-medium dark:border-zinc-800 dark:bg-zinc-900">
+            總部金額調整（{adjustments.length} 筆）
+          </div>
+          <ul className="divide-y divide-zinc-200 dark:divide-zinc-800">
+            {adjustments.map((a) => {
+              const positive = Number(a.amount) > 0;
+              return (
+                <li key={a.id} className="flex items-start justify-between gap-3 px-3 py-2 text-sm">
+                  <div className="min-w-0 flex-1">
+                    <span className="break-words">{a.reason}</span>
+                    <span className="ml-2 text-xs text-zinc-500">{new Date(a.created_at).toLocaleDateString("zh-TW")}</span>
+                  </div>
+                  <span className={`shrink-0 font-mono ${positive ? "text-rose-600" : "text-emerald-600"}`}>
+                    {positive ? "+" : "−"}${Math.abs(Number(a.amount)).toLocaleString("zh-TW")}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+          <div className="border-t border-zinc-200 bg-zinc-50 px-3 py-2 text-right text-sm dark:border-zinc-800 dark:bg-zinc-900">
+            商品合計 <span className="font-mono">${total.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}</span>
+            <span className="mx-1">＋</span>調整{" "}
+            <span className="font-mono">
+              {Number(settlement.adjustment_amount ?? 0) < 0 ? "−" : "+"}${Math.abs(Number(settlement.adjustment_amount ?? 0)).toLocaleString("zh-TW")}
+            </span>
+            <span className="mx-1">＝</span>應付總部{" "}
+            <span className="font-mono font-semibold text-rose-600">${Number(settlement.payable_amount).toLocaleString("zh-TW")}</span>
+          </div>
+        </div>
+      )}
 
       {err && (
         <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">

--- a/docs/TEST-settlement-manual-adjustment.md
+++ b/docs/TEST-settlement-manual-adjustment.md
@@ -1,0 +1,56 @@
+# TEST — 月結人工調整（增減金額＋必填原因）
+
+需求（2026-08-01）：月結功能要可以增加/減少金額並寫原因 —— 明細行以外的
+加減項（運費分攤、破損折讓、活動補貼、上月尾差沖抵…）總部要能直接調整
+單一分店單一月份的應付金額，店家核對與列印對帳單都看得到金額與原因。
+
+Migration：`20260801000000_settlement_manual_adjustment.sql`
+- 新表 `store_settlement_adjustments`：帶正負號金額（正=加收、負=減收）＋
+  必填原因；**錨定 (tenant, 月份, store)** 而非 settlement_id —— 生成器重算
+  DELETE/重建 draft 後調整自動重新套用、不失聯。只能作廢（voided）不能改，
+  留完整軌跡。RLS 只開同 tenant SELECT（比照 auth_read_sms），寫入全走
+  SECURITY DEFINER RPC。
+- `store_monthly_settlements.adjustment_amount`（active 調整合計）；
+  **payable_amount = branch_amount + adjustment_amount**。branch/cost 維持
+  純貨款口徑，毛利顯示（branch − cost）不受調整影響。
+- 新 RPC：`rpc_add_settlement_adjustment(settlement_id, amount, operator, reason)`、
+  `rpc_void_settlement_adjustment(adjustment_id, operator, reason?)`；
+  角色 gate `_settlement_caller_is_hq()`；僅鎖定前（draft/sent/disputed）可加/廢，
+  confirmed 起擋下（對齊估價修正 v2 的鎖定判斷）。
+- 生成器 v4（基底 `20260715000120` 逐字保留）：加 G) 調整段，重算時把
+  active 調整合計加回 payable；「該月無調撥活動但有 active 調整」不再砍
+  draft（純收費月份成立）；回傳加 `total_adjustment`。
+
+前端（apps/admin）：
+- 總部明細頁 `/transfers/settlement/detail`：「金額調整」區塊 —— 新增
+  （方向加收/減收＋金額＋必填原因）、作廢（帶作廢原因）、清單含已作廢
+  軌跡；合計列「貨款＋調整＝應付」；header 應付改標「含調整」、加
+  「人工調整合計」卡（非 0 才顯示）。
+- 店家核對頁 `/transfers/settlement/review`：「總部金額調整」唯讀清單
+  （原因＋金額，只列 active）＋「商品合計＋調整＝應付總部」組成列。
+- 列印對帳單 `/finance/receivables/print`：金額調整表（日期/原因/金額/
+  調整合計）＋「商品合計＋調整＝應付金額」總結列（分店版/內部版都有）。
+
+## 測試項目
+
+### 線上 DB（Management API DO block + RAISE 強制 rollback，2026-08-01）
+- [x] T1 部署後物件齊備：2 支新 RPC、調整表、adjustment_amount 欄位、
+      RLS policy、生成器 v4（含 total_adjustment）。
+- [x] T2 對未鎖定 settlement（#114）加 −150 減收 → adjustment_amount −150、
+      payable_amount = branch_amount + adjustment_amount 同步。
+- [x] T3 作廢該筆 → adjustment_amount / payable_amount 還原原值。
+- [x] T4 全程 rollback，無殘留（adj_rows=0）。
+
+### 待驗（上線後首次實際使用時勾）
+- [ ] T5 金額 0 / 原因空白 → RPC 擋（「調整金額不可為 0」「必須填原因」）。
+- [ ] T6 confirmed/remitted/settled 狀態加調整或作廢 → 擋「已鎖定」。
+- [ ] T7 店家帳號（store_manager JWT）呼叫 add/void → 擋「僅總部帳號」。
+- [ ] T8 加調整後重跑生成器 → 調整保留、payable 重算仍含調整；
+      sent/disputed 列重算後調整不掉。
+- [ ] T9 店家核對頁看得到調整原因與金額、應付組成列一致；
+      畫押後應收單金額 = 含調整之 payable。
+- [ ] T10 列印對帳單（分店版）含金額調整表與總結列。
+
+### UI（Playwright fixture）
+- 見 `apps/admin` verify 流程；本次驗證：明細頁調整區塊（新增表單、
+  作廢流、合計列）、核對頁唯讀調整清單、列印頁調整表。

--- a/supabase/migrations/20260801000000_settlement_manual_adjustment.sql
+++ b/supabase/migrations/20260801000000_settlement_manual_adjustment.sql
@@ -1,0 +1,637 @@
+-- ============================================================
+-- 2026-08-01: 月結人工調整（增減金額＋必填原因）
+--
+-- 需求：月結對帳時常有明細行以外的加減項（例：運費分攤、破損折讓、
+--   活動補貼、上月尾差沖抵），總部要能對單一分店的月結單直接
+--   「增加或減少金額」並記錄原因，店家核對與列印對帳單都要看得到。
+--
+-- 設計：
+--   - 新表 store_settlement_adjustments：一筆調整 = 一個帶正負號的
+--     金額（正=加收、負=減收）＋必填原因。錨定 (tenant, 月份, store)
+--     而非 settlement_id —— 生成器重算會 DELETE/重建 draft 列，
+--     錨月份+店讓調整在重算後自動保留、重新套用。
+--   - 只能作廢（voided）不能改：留完整軌跡，改金額 = 作廢舊的再開新的。
+--   - store_monthly_settlements 加 adjustment_amount 欄位（active 調整
+--     合計）；payable_amount = branch_amount + adjustment_amount。
+--     branch_amount / cost_amount 維持「純貨款」口徑，毛利顯示
+--     （branch - cost）不受調整影響。
+--   - 調整/作廢僅限鎖定前（draft/sent/disputed），confirmed 起擋下
+--     —— 對齊 rpc_update_free_transfer_amount v2 的鎖定判斷。
+--   - 角色 gate：僅總部（_settlement_caller_is_hq()，20260715000120）。
+--     寫入全走 SECURITY DEFINER RPC；RLS 只開同 tenant SELECT
+--     （比照 auth_read_sms pattern，店家核對頁要能讀）。
+--   - 生成器 v4：重算時把 active 調整合計加回 payable；「該月無任何
+--     調撥活動」但有 active 調整時不再砍 draft（例：純收費月份）。
+--
+-- 基底版本：
+--   rpc_generate_hq_to_store_settlement ← 20260715000120（v3, estatement flow）
+--   rpc_confirm_store_monthly_settlement / 其餘流程 RPC 不動
+--     （confirm 讀 payable_amount，已含調整）。
+-- Rollback：
+--   CREATE OR REPLACE rpc_generate_hq_to_store_settlement 回 20260715000120 版；
+--   DROP FUNCTION public.rpc_add_settlement_adjustment(BIGINT, NUMERIC, UUID, TEXT);
+--   DROP FUNCTION public.rpc_void_settlement_adjustment(BIGINT, UUID, TEXT);
+--   DROP TABLE public.store_settlement_adjustments;
+--   ALTER TABLE store_monthly_settlements DROP COLUMN adjustment_amount;
+--   （已含調整的 draft/sent/disputed 列重跑一次生成器歸回純貨款金額）
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. 主檔加 adjustment_amount（active 調整合計，生成器/RPC 維護）
+-- ------------------------------------------------------------
+ALTER TABLE public.store_monthly_settlements
+  ADD COLUMN IF NOT EXISTS adjustment_amount NUMERIC(18,4) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN store_monthly_settlements.adjustment_amount IS
+  '人工調整合計（store_settlement_adjustments active 加總；正=加收、負=減收）。'
+  'payable_amount = branch_amount + adjustment_amount。';
+
+-- ------------------------------------------------------------
+-- 2. 調整表（錨定 tenant+月份+store，生成器重算不失聯）
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.store_settlement_adjustments (
+  id               BIGSERIAL PRIMARY KEY,
+  tenant_id        UUID NOT NULL,
+  settlement_month DATE NOT NULL,             -- 該月第一天（同 store_monthly_settlements）
+  store_id         BIGINT NOT NULL REFERENCES public.stores(id),
+  amount           NUMERIC(18,4) NOT NULL CHECK (amount <> 0),  -- 正=加收、負=減收
+  reason           TEXT NOT NULL,
+  status           TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','voided')),
+  created_by       UUID NOT NULL,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  voided_by        UUID,
+  voided_at        TIMESTAMPTZ,
+  void_reason      TEXT,
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ssa_month_store
+  ON public.store_settlement_adjustments (tenant_id, settlement_month, store_id, status);
+
+COMMENT ON TABLE store_settlement_adjustments IS
+  '月結人工調整：總部對單一分店單一月份的加減金額（正=加收、負=減收）＋必填原因。'
+  '只能作廢不能改；錨定月份+店，月結 draft 重算後自動重新套用。';
+
+ALTER TABLE public.store_settlement_adjustments ENABLE ROW LEVEL SECURITY;
+
+-- 同 tenant 皆可讀（比照 auth_read_sms/smsi；店家核對頁要顯示調整行）。
+-- 寫入不開 policy —— 全部走下方 SECURITY DEFINER RPC。
+DROP POLICY IF EXISTS auth_read_ssa ON public.store_settlement_adjustments;
+CREATE POLICY auth_read_ssa ON public.store_settlement_adjustments
+  FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid);
+
+-- ------------------------------------------------------------
+-- 3. RPC: 新增調整（增減金額＋必填原因）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_add_settlement_adjustment(
+  p_settlement_id BIGINT,
+  p_amount        NUMERIC,
+  p_operator      UUID,
+  p_reason        TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_s      store_monthly_settlements%ROWTYPE;
+  v_reason TEXT;
+  v_adj_id BIGINT;
+  v_total  NUMERIC(18,4);
+BEGIN
+  IF NOT public._settlement_caller_is_hq() THEN
+    RAISE EXCEPTION '僅總部帳號可調整月結金額（role=%）',
+      COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  END IF;
+
+  IF p_amount IS NULL OR p_amount = 0 THEN
+    RAISE EXCEPTION '調整金額不可為 0（正=加收、負=減收）';
+  END IF;
+  v_reason := NULLIF(TRIM(p_reason), '');
+  IF v_reason IS NULL THEN
+    RAISE EXCEPTION '調整金額必須填原因';
+  END IF;
+
+  SELECT * INTO v_s FROM store_monthly_settlements
+   WHERE id = p_settlement_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'settlement % not found', p_settlement_id;
+  END IF;
+  IF v_s.status NOT IN ('draft', 'sent', 'disputed') THEN
+    RAISE EXCEPTION '狀態 % 不可調整金額（confirmed 起鎖定，請走爭議/沖帳流程）', v_s.status;
+  END IF;
+
+  INSERT INTO store_settlement_adjustments (
+    tenant_id, settlement_month, store_id, amount, reason, created_by
+  ) VALUES (
+    v_s.tenant_id, v_s.settlement_month, v_s.store_id, p_amount, v_reason, p_operator
+  ) RETURNING id INTO v_adj_id;
+
+  SELECT COALESCE(SUM(amount), 0) INTO v_total
+    FROM store_settlement_adjustments
+   WHERE tenant_id = v_s.tenant_id
+     AND settlement_month = v_s.settlement_month
+     AND store_id = v_s.store_id
+     AND status = 'active';
+
+  UPDATE store_monthly_settlements
+     SET adjustment_amount = v_total,
+         payable_amount    = branch_amount + v_total,
+         updated_by        = p_operator,
+         updated_at        = NOW()
+   WHERE id = p_settlement_id;
+
+  RETURN jsonb_build_object(
+    'adjustment_id',    v_adj_id,
+    'settlement_id',    p_settlement_id,
+    'amount',           p_amount,
+    'adjustment_total', v_total,
+    'payable_amount',   v_s.branch_amount + v_total
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_add_settlement_adjustment(BIGINT, NUMERIC, UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_add_settlement_adjustment IS
+  '總部對月結單加一筆人工調整（正=加收、負=減收，原因必填）：僅鎖定前'
+  '（draft/sent/disputed）可加；payable_amount 同步 = branch_amount + active 調整合計。';
+
+-- ------------------------------------------------------------
+-- 4. RPC: 作廢調整（不能改、只能廢；重開一筆取代）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_void_settlement_adjustment(
+  p_adjustment_id BIGINT,
+  p_operator      UUID,
+  p_reason        TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_a     store_settlement_adjustments%ROWTYPE;
+  v_s     store_monthly_settlements%ROWTYPE;
+  v_total NUMERIC(18,4);
+BEGIN
+  IF NOT public._settlement_caller_is_hq() THEN
+    RAISE EXCEPTION '僅總部帳號可作廢月結調整（role=%）',
+      COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  END IF;
+
+  SELECT * INTO v_a FROM store_settlement_adjustments
+   WHERE id = p_adjustment_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'adjustment % not found', p_adjustment_id;
+  END IF;
+  IF v_a.status <> 'active' THEN
+    RAISE EXCEPTION 'adjustment % 已作廢', p_adjustment_id;
+  END IF;
+
+  SELECT * INTO v_s FROM store_monthly_settlements
+   WHERE tenant_id = v_a.tenant_id
+     AND settlement_month = v_a.settlement_month
+     AND store_id = v_a.store_id
+   FOR UPDATE;
+  IF FOUND AND v_s.status NOT IN ('draft', 'sent', 'disputed') THEN
+    RAISE EXCEPTION '該月結算已鎖定（%），調整不可作廢', v_s.status;
+  END IF;
+
+  UPDATE store_settlement_adjustments
+     SET status      = 'voided',
+         voided_by   = p_operator,
+         voided_at   = NOW(),
+         void_reason = NULLIF(TRIM(p_reason), ''),
+         updated_at  = NOW()
+   WHERE id = p_adjustment_id;
+
+  IF v_s.id IS NOT NULL THEN
+    SELECT COALESCE(SUM(amount), 0) INTO v_total
+      FROM store_settlement_adjustments
+     WHERE tenant_id = v_a.tenant_id
+       AND settlement_month = v_a.settlement_month
+       AND store_id = v_a.store_id
+       AND status = 'active';
+
+    UPDATE store_monthly_settlements
+       SET adjustment_amount = v_total,
+           payable_amount    = branch_amount + v_total,
+           updated_by        = p_operator,
+           updated_at        = NOW()
+     WHERE id = v_s.id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'adjustment_id',    p_adjustment_id,
+    'settlement_id',    v_s.id,
+    'adjustment_total', COALESCE(v_total, 0)
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_void_settlement_adjustment(BIGINT, UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_void_settlement_adjustment IS
+  '作廢一筆月結人工調整（僅鎖定前）；payable_amount 同步回算。'
+  '調整不能改金額，改 = 作廢舊的再加新的。';
+
+-- ------------------------------------------------------------
+-- 5. 生成器 v4：重算時套用 active 調整
+--    （基底 20260715000120 v3 逐字保留，僅加 G) 調整段、skip 條件、
+--      upsert 欄位與回傳 total_adjustment）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_generate_hq_to_store_settlement(p_month date, p_operator uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_tenant         UUID;
+  v_month_start    DATE := DATE_TRUNC('month', p_month)::DATE;
+  v_month_end      DATE := (DATE_TRUNC('month', p_month) + INTERVAL '1 month')::DATE;
+  v_store          RECORD;
+  v_settlement_id  BIGINT;
+  v_hq_inbound     NUMERIC(18,4);
+  v_air_in         NUMERIC(18,4);
+  v_air_out        NUMERIC(18,4);
+  v_free_in        NUMERIC(18,4);
+  v_free_out       NUMERIC(18,4);
+  v_return_out     NUMERIC(18,4);
+  v_hq_inbound_b   NUMERIC(18,4);  -- 分店價口徑
+  v_air_in_b       NUMERIC(18,4);
+  v_air_out_b      NUMERIC(18,4);
+  v_return_out_b   NUMERIC(18,4);
+  v_adjust         NUMERIC(18,4);  -- 人工調整（active 合計）
+  v_cost_total     NUMERIC(18,4);
+  v_branch_total   NUMERIC(18,4);
+  v_payable        NUMERIC(18,4);
+  v_xfer_count     INTEGER;
+  v_item_count     INTEGER;
+  v_total_stores   INTEGER := 0;
+  v_total_amount   NUMERIC(18,4) := 0;
+  v_total_cost     NUMERIC(18,4) := 0;
+  v_total_branch   NUMERIC(18,4) := 0;
+  v_total_adjust   NUMERIC(18,4) := 0;
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM stores LIMIT 1;
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'no stores found, cannot infer tenant_id';
+  END IF;
+
+  FOR v_store IN
+    SELECT s.id, s.code, s.name, s.location_id
+      FROM stores s
+     WHERE s.tenant_id = v_tenant
+       AND s.location_id IS NOT NULL
+  LOOP
+    -- 跳過已鎖定/結案/作廢（confirmed 起不再重算；cancelled 舊版會 NULL crash，一併跳過）
+    IF EXISTS (
+      SELECT 1 FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status IN ('confirmed','settled','remitted','cancelled')
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    -- A) hq_inbound: 從 HQ 收貨（成本口徑 + 分店價口徑）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_hq_inbound, v_hq_inbound_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- B) air_in: 空中轉收進來（該店是 dest）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_air_in, v_air_in_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- C) air_out: 空中轉送出去（該店是 source）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_air_out, v_air_out_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- D) free_in: 自由轉貨收進來（估價入帳、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_in
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out: 自由轉貨送出去（估價入帳、貸記、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_out
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out: 退貨回總倉（成本沖回 + 分店價沖回）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_return_out, v_return_out_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- G) 人工調整（active 合計；只進 payable，不動貨款兩口徑）
+    SELECT COALESCE(SUM(a.amount), 0)
+      INTO v_adjust
+      FROM store_settlement_adjustments a
+     WHERE a.tenant_id = v_tenant
+       AND a.settlement_month = v_month_start
+       AND a.store_id = v_store.id
+       AND a.status = 'active';
+
+    v_cost_total   := v_hq_inbound   + v_air_in   - v_air_out   + v_free_in - v_free_out - v_return_out;
+    v_branch_total := v_hq_inbound_b + v_air_in_b - v_air_out_b + v_free_in - v_free_out - v_return_out_b;
+    -- 賣斷制：總倉出給分店、跟分店收「分店價」；成本口徑僅供總倉毛利參考
+    v_payable      := v_branch_total + v_adjust;
+
+    -- 沒任何活動就 skip + 砍 draft（兩口徑皆 0 且無 active 調整才算無活動；
+    -- 只砍 draft，sent/disputed 已進流程不自動刪）
+    IF v_hq_inbound = 0 AND v_air_in = 0 AND v_air_out = 0
+       AND v_free_in = 0 AND v_free_out = 0 AND v_return_out = 0
+       AND v_hq_inbound_b = 0 AND v_air_in_b = 0 AND v_air_out_b = 0
+       AND v_return_out_b = 0 AND v_adjust = 0 THEN
+      DELETE FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status = 'draft';
+      CONTINUE;
+    END IF;
+
+    -- 計 transfer_count + item_count
+    SELECT
+      COUNT(DISTINCT t.id), COUNT(ti.id)
+      INTO v_xfer_count, v_item_count
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.status IN ('received','closed')
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0
+       AND (
+         (t.transfer_type = 'hq_to_store' AND t.dest_location = v_store.location_id)
+         OR
+         (t.transfer_type = 'store_to_store'
+          AND (t.dest_location = v_store.location_id OR t.source_location = v_store.location_id))
+         OR
+         (t.transfer_type = 'return_to_hq' AND t.source_location = v_store.location_id)
+       );
+
+    -- upsert（鎖定前狀態 draft/sent/disputed 都重算；status 本身不動）
+    INSERT INTO store_monthly_settlements (
+      tenant_id, settlement_month, store_id,
+      payable_amount, cost_amount, branch_amount, adjustment_amount,
+      transfer_count, item_count,
+      status, created_by, updated_by
+    ) VALUES (
+      v_tenant, v_month_start, v_store.id,
+      v_payable, v_cost_total, v_branch_total, v_adjust,
+      v_xfer_count, v_item_count,
+      'draft', p_operator, p_operator
+    )
+    ON CONFLICT (tenant_id, settlement_month, store_id)
+    DO UPDATE SET
+      payable_amount    = EXCLUDED.payable_amount,
+      cost_amount       = EXCLUDED.cost_amount,
+      branch_amount     = EXCLUDED.branch_amount,
+      adjustment_amount = EXCLUDED.adjustment_amount,
+      transfer_count    = EXCLUDED.transfer_count,
+      item_count        = EXCLUDED.item_count,
+      updated_by        = p_operator,
+      updated_at        = NOW()
+    WHERE store_monthly_settlements.status IN ('draft','sent','disputed')
+    RETURNING id INTO v_settlement_id;
+
+    -- 重建 items
+    DELETE FROM store_monthly_settlement_items WHERE settlement_id = v_settlement_id;
+
+    -- A) hq_inbound items（雙口徑）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      ti.qty_received * COALESCE(sm.unit_cost, 0),
+      t.received_at, 'hq_inbound',
+      bp.p, ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- B) air_in items（雙口徑）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      ti.qty_received * COALESCE(sm.unit_cost, 0),
+      t.received_at, 'air_in',
+      bp.p, ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- C) air_out items（兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      -1 * ti.qty_received * COALESCE(sm.unit_cost, 0),  -- 負值
+      t.received_at, 'air_out',
+      bp.p, -1 * ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NOT NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- D) free_in items（估價入帳、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      COALESCE(ti.estimated_amount, 0),
+      t.received_at, 'free_in', ti.description,
+      0, COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out items（估價入帳、負值、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      -1 * COALESCE(ti.estimated_amount, 0),  -- 負值
+      t.received_at, 'free_out', ti.description,
+      0, -1 * COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out items（沖回、兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      -1 * ti.qty_received * COALESCE(sm.unit_cost, 0),  -- 負值
+      t.received_at, 'return_out',
+      bp.p, -1 * ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_month_start
+       AND t.received_at < v_month_end
+       AND ti.qty_received > 0;
+
+    v_total_stores := v_total_stores + 1;
+    v_total_amount := v_total_amount + v_payable;
+    v_total_cost   := v_total_cost + v_cost_total;
+    v_total_branch := v_total_branch + v_branch_total;
+    v_total_adjust := v_total_adjust + v_adjust;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'month',                to_char(v_month_start, 'YYYY-MM'),
+    'stores_count',         v_total_stores,
+    'total_amount',         v_total_amount,
+    'total_cost_amount',    v_total_cost,
+    'total_branch_amount',  v_total_branch,
+    'total_adjustment',     v_total_adjust
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_generate_hq_to_store_settlement IS
+  'HQ→店月結算（總倉當清算中心）：每筆分錄雙口徑 cost_amount / branch_amount。'
+  'payable = 分店價口徑 + 人工調整（store_settlement_adjustments active 合計）。'
+  'draft/sent/disputed 重建、confirmed/settled/remitted/cancelled 跳過（confirmed 起鎖定）。';


### PR DESCRIPTION
## Summary

Implement manual settlement adjustment feature allowing HQ to add/deduct amounts with required reasons for individual store monthly settlements. Adjustments are anchored to (tenant, month, store) to survive settlement regeneration, and can only be voided (not edited) to maintain full audit trail.

## Key Changes

### Database (Migration 20260801000000)
- **New table `store_settlement_adjustments`**: Stores manual adjustments with signed amount (positive=add, negative=deduct), required reason, and status (active/voided). Indexed on (tenant_id, settlement_month, store_id, status) to enable regeneration-safe reapplication.
- **Column `store_monthly_settlements.adjustment_amount`**: Tracks sum of active adjustments; `payable_amount = branch_amount + adjustment_amount`.
- **RLS policy**: Read-only for same-tenant users (shop review pages); writes restricted to SECURITY DEFINER RPCs.
- **Two new RPCs**:
  - `rpc_add_settlement_adjustment(settlement_id, amount, operator, reason)`: Add adjustment (positive/negative) with mandatory reason; only allowed in draft/sent/disputed status.
  - `rpc_void_settlement_adjustment(adjustment_id, operator, reason?)`: Void adjustment (immutable design); recalculates payable_amount.
- **Generator v4** (`rpc_generate_hq_to_store_settlement`): 
  - Adds section G to sum active adjustments and include in payable.
  - Preserves draft rows if month has active adjustments but no transfers (pure fee months).
  - Returns `total_adjustment` in response.
  - Maintains cost_amount/branch_amount as pure cargo amounts (adjustment does not affect margin display).

### Frontend (apps/admin)

**Settlement Detail Page** (`/transfers/settlement/detail`):
- New "金額調整" section with form to add adjustments (direction: add/deduct, amount, required reason).
- Void action with optional void reason; displays full audit trail including voided entries.
- Header stat card shows "人工調整合計" (non-zero only); "應付金額" label changed to "含調整".
- Summary row displays: cargo amount + adjustment = payable.

**Settlement Review Page** (`/transfers/settlement/review`):
- Read-only adjustment list (active only) showing reason and amount.
- Composition row: cargo + adjustment = payable to HQ.

**Print Settlement Page** (`/finance/receivables/print`):
- Adjustment table (date, reason, amount, subtotal) in both store and internal views.
- Summary row: cargo + adjustment = payable amount.

## Implementation Details

- **Role gate**: Only HQ accounts (via `_settlement_caller_is_hq()`) can add/void adjustments.
- **Lock enforcement**: Adjustments blocked once settlement reaches confirmed status (aligns with prior estimate correction v2 locking).
- **Regeneration safety**: Anchoring to (tenant, month, store) instead of settlement_id ensures adjustments persist across draft regeneration and DELETE/rebuild cycles.
- **Immutable audit trail**: Adjustments can only be voided, not edited; corrections require voiding old + adding new.
- **Margin preservation**: branch_amount and cost_amount remain pure cargo figures; adjustment only affects payable, not margin calculation.

## Testing

See `docs/TEST-settlement-manual-adjustment.md` for test matrix (DB validation, RPC guards, UI flows, print output).

https://claude.ai/code/session_01WjqKBbkQRUrgS9LrXD8AjY