### PR TITLE
feat(member): 我的訂單卡片不再顯示內部備註

### DIFF
--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -114,9 +114,7 @@ export default function OrderCard({ order }: { order: OrderRow }) {
               <div className="text-[14px] text-[var(--secondary-label)]">
                 {fmtAmount(it.unit_price)} × {it.qty}
               </div>
-              {it.notes && (
-                <div className="mt-0.5 text-[14px] text-[var(--secondary-label)]">📝 {it.notes}</div>
-              )}
+              {/* it.notes 是內部備註（補貨申請 / 轉單軌跡等），顧客端不顯示 */}
             </div>
             <div className={`flex-shrink-0 text-right text-[16px] font-medium tabular-nums ${it.stockout ? "text-[var(--secondary-label)] line-through" : "text-[var(--foreground)]"}`}>
               {fmtAmount(it.subtotal)}
@@ -125,11 +123,7 @@ export default function OrderCard({ order }: { order: OrderRow }) {
         ))}
       </ul>
 
-      {order.notes && (
-        <div className="mx-4 mb-3 rounded-xl bg-[#7676801a] p-3 text-[14px] text-[var(--secondary-label)]">
-          📝 {order.notes}
-        </div>
-      )}
+      {/* order.notes 同為內部備註，顧客端不顯示 */}
 
       <div className="space-y-1 border-t border-[var(--separator)] px-4 py-3 text-[14px]">
         <div className="flex justify-between text-[var(--secondary-label)]">


### PR DESCRIPTION
order.notes / item.notes 存的是 ERP 內部資訊（補貨申請單號、
「[轉入 (部分, 經總倉) ← 訂單 #xxxxx]」轉單軌跡等），直接渲染在
顧客端「我的訂單」會把內部單號與流程細節曝光給客人。移除兩處
📝 備註區塊的渲染，型別欄位保留（API 仍回傳，僅前端不顯示）。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MGQFLAmLbospbuJDmdqkz8