### PR TITLE
feat: 自由轉貨草稿可刪除（店家自刪自己店的單）

### DIFF
--- a/apps/admin/src/app/(protected)/wms/transfers/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/transfers/page.tsx
@@ -12,6 +12,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { LoadingBlock } from "@/components/Spinner";
 import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
 import FreeTransferCreateModal from "@/components/FreeTransferCreateModal";
 import FreeTransferExplainerModal, { FT_EXPLAINER_HIDE_KEY } from "@/components/FreeTransferExplainerModal";
@@ -30,6 +31,7 @@ type TransferRow = {
   dest_location: number;
   status: string;
   transfer_type: string;
+  customer_order_id: number | null;
   notes: string | null;
   created_at: string;
   shipped_at: string | null;
@@ -84,7 +86,7 @@ export default function InternalTransfersPage() {
         const sb = getSupabase();
         const { data, error: e } = await sb
           .from("transfers")
-          .select("id, transfer_no, source_location, dest_location, status, transfer_type, notes, created_at, shipped_at, received_at")
+          .select("id, transfer_no, source_location, dest_location, status, transfer_type, customer_order_id, notes, created_at, shipped_at, received_at")
           .in("transfer_type", ["store_to_store", "return_to_hq"])
           .order("id", { ascending: false })
           .limit(200);
@@ -177,6 +179,30 @@ export default function InternalTransfersPage() {
   // 退訂單(由 rpc_create_order_return 產生,note 以「[order return」開頭)
   function isOrderReturn(notes: string | null): boolean {
     return !!notes && notes.startsWith("[order return");
+  }
+
+  // 可刪除 = 自由轉貨(店↔店、無綁訂單)且還在草稿(總倉配送前);互助接力單/退訂單不可刪
+  function canDelete(t: TransferRow): boolean {
+    return t.status === "draft" && t.transfer_type === "store_to_store" && t.customer_order_id == null;
+  }
+
+  async function handleDelete(t: TransferRow) {
+    const src = locs.get(t.source_location)?.name ?? `#${t.source_location}`;
+    const dst = locs.get(t.dest_location)?.name ?? `#${t.dest_location}`;
+    const ok = window.confirm(
+      `確定刪除自由轉貨 ${t.transfer_no}(${src} → ${dst})?\n\n` +
+      `${t.items_summary || "(無品項)"}\n` +
+      `刪除後無法復原;只有「草稿」(總倉配送前)的自由轉貨可以刪除。`,
+    );
+    if (!ok) return;
+    try {
+      const { error: err } = await getSupabase().rpc("rpc_delete_free_transfer", { p_transfer_id: t.id });
+      if (err) throw err;
+      setError(null);
+      setTransfers((prev) => (prev ?? []).filter((x) => x.id !== t.id));
+    } catch (e) {
+      setError(translateRpcError(e));
+    }
   }
 
   // 翻譯系統產生的 note tag,例如:
@@ -346,15 +372,26 @@ export default function InternalTransfersPage() {
                   <td className="px-3 py-2"><span className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${STATUS_COLOR[t.status] ?? STATUS_COLOR.draft}`}>{STATUS_LABEL[t.status] ?? t.status}</span></td>
                   <td className="px-3 py-2 text-xs text-zinc-500" title={t.notes ?? undefined}>{formatNote(t.notes)}</td>
                   <td className="px-3 py-2 text-right" onClick={(e) => e.stopPropagation()}>
-                    <SpinButton
-                      onClick={() =>
-                        printViaIframe(withBasePath(`/transfers/print?transfer_id=${t.id}&copies=driver,stub`))
-                      }
-                      title="列印出貨單（司機聯 + 店家存根聯）"
-                      className="rounded-md border border-zinc-300 px-2 py-1 text-[11px] font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                    >
-                      列印出貨單
-                    </SpinButton>
+                    <div className="flex justify-end gap-1.5">
+                      <SpinButton
+                        onClick={() =>
+                          printViaIframe(withBasePath(`/transfers/print?transfer_id=${t.id}&copies=driver,stub`))
+                        }
+                        title="列印出貨單（司機聯 + 店家存根聯）"
+                        className="rounded-md border border-zinc-300 px-2 py-1 text-[11px] font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                      >
+                        列印出貨單
+                      </SpinButton>
+                      {canDelete(t) && (
+                        <SpinButton
+                          onClick={() => handleDelete(t)}
+                          title="刪除自由轉貨（僅草稿可刪）"
+                          className="rounded-md border border-red-300 px-2 py-1 text-[11px] font-medium text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
+                        >
+                          刪除
+                        </SpinButton>
+                      )}
+                    </div>
                   </td>
                 </tr>
               );

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -327,6 +327,35 @@ const RULES: Rule[] = [
     pattern: /product \d+ not found/i,
     render: () => "找不到此商品（可能已被刪除）。",
   },
+  // ===== rpc_delete_free_transfer（自由轉貨刪除守門） =====
+  {
+    pattern: /permission denied: role (\w+) cannot delete free transfer/i,
+    render: (m) => `權限不足：角色「${m[1]}」無法刪除自由轉貨。`,
+  },
+  {
+    pattern: /transfer \d+ is not a free transfer \((?:type=)?(\w+)\), cannot delete/i,
+    render: () => "此調撥單不是自由轉貨（例如互助接力單、總倉派貨），無法在此刪除。",
+  },
+  {
+    pattern: /store role can only delete free transfer involving own store/i,
+    render: () => "門市角色只能刪除自己店參與的自由轉貨。",
+  },
+  {
+    pattern: /transfer \d+ is (\w+), only draft can be deleted/i,
+    render: (m) => `此自由轉貨狀態為「${tStatus(m[1])}」，只有「草稿」（總倉配送前）可以刪除。`,
+  },
+  {
+    pattern: /transfer \d+ already referenced by picking waves, cannot delete/i,
+    render: () => "此調撥單已被撿貨單引用，無法刪除。",
+  },
+  {
+    pattern: /transfer \d+ still referenced by other records, cannot delete/i,
+    render: () => "此調撥單仍被其他資料參照，無法刪除。請先解除關聯後再試。",
+  },
+  {
+    pattern: /transfer (\d+) not found/i,
+    render: () => "找不到此調撥單（可能已被刪除）。",
+  },
   // ===== 撿貨單號碼衝突(同秒多筆提交時的 race) =====
   {
     pattern: /duplicate key value violates unique constraint "picking_waves_tenant_id_wave_code_key"/i,

--- a/docs/TEST-store-self-service.md
+++ b/docs/TEST-store-self-service.md
@@ -168,6 +168,19 @@ SELECT proname, pg_get_function_arguments(oid) FROM pg_proc
   status='approved_pr'、approved_by/at 寫入
 - 「刪除全部剩餘品相」也會直接結案（至少一個品相已開單 → approved_pr）
 
+### 2.16 rpc_delete_free_transfer — 自由轉貨刪除（20260801000010）
+**情境：** 分店建錯自由轉貨（draft、store_to_store、無訂單 FK），店家自行刪除
+
+**預期：**
+- HQ 職能（owner/admin/hq_manager/''）：任何 draft 自由轉貨可刪
+- 門市職能（store_manager/store_staff）：source 或 dest 在自己店
+  （_jwt_store_location_ids()）→ 可刪；不相干店 → RAISE 'own store'
+- 非 store_to_store、customer_order_id 有值（互助接力單）、
+  next_transfer_id 有值 → RAISE 'not a free transfer'
+- 非 draft（總倉已配送）→ RAISE 'only draft can be deleted'
+- 硬刪 transfers、transfer_items 由 ON DELETE CASCADE 連帶刪
+- 跨 tenant id → 'not found'
+
 ---
 
 ## 3. UI 行為（preview 互動）
@@ -198,6 +211,12 @@ SELECT proname, pg_get_function_arguments(oid) FROM pg_proc
 - [ ] 「派貨」彈確認 → 呼叫 approve_to_transfer → row 移除 pending tab、出現在 history tab
 - [ ] 「進貨」同上
 - [ ] 「拒絕」彈出原因輸入 modal → 提交
+
+### 3.4b /wms/transfers — 自由轉貨刪除按鈕
+- [x] draft + store_to_store + 無 customer_order_id 的 row 顯示「刪除」
+- [x] shipped / 互助接力單（customer_order_id 有值）/ 退訂單（return_to_hq）不顯示
+- [x] 按刪除 → confirm → 呼叫 rpc_delete_free_transfer → row 移除、無 console error
+      （Playwright + fixture 驗證，store_manager 角色）
 
 ### 3.5 撿貨頁 description fallback
 - [ ] 撿貨工作站 wave row 顯示：`{transfer_items.description ?? sku.product_name}`

--- a/supabase/migrations/20260801000010_rpc_delete_free_transfer.sql
+++ b/supabase/migrations/20260801000010_rpc_delete_free_transfer.sql
@@ -1,0 +1,102 @@
+-- ============================================================================
+-- 2026-08-01: rpc_delete_free_transfer — 自由轉貨刪除（限 draft、實體硬刪、門市可自刪）
+-- ----------------------------------------------------------------------------
+-- 需求：店家建錯自由轉貨（store_to_store、MISC 虛擬 SKU + description + 估價）
+--   要能自己刪掉。現況唯一的刪法是總倉收件匣的 rpc_transfer_batch_delete
+--   （20260508000000），但該支完全沒有 role / tenant / 店別守門，
+--   不適合開放給分店前台呼叫；分店頁（/wms/transfers）也沒有刪除入口。
+--
+-- 設計（守門順序，對齊 rpc_delete_restock_request 20260714000030 的門市放行做法）：
+--   role 守門（HQ 職能 + 門市職能；空字串放行，對齊既有 restock RPC）→
+--   not found / 跨 tenant → 非自由轉貨擋（type 非 store_to_store、綁訂單的
+--   aid 接力單、有 next_transfer_id 鏈的一律不收）→ 門市角色限自己店
+--   （source 或 dest 在 _jwt_store_location_ids() 內，見 20260707000070）→
+--   非 draft 擋（HQ 配送後貨已在途，走拒收 / 收貨流程）→
+--   撿貨波引用擋（draft 自由轉貨理論上不會有，防資料不一致的雙重保險）→
+--   實體刪 transfers（transfer_items 為 ON DELETE CASCADE）。
+--
+-- 為何限 draft：自由轉貨由分店建立即為 draft，總倉收件匣配送
+--   （rpc_transfer_distribute_batch）後轉 shipped 才有在途貨；draft 無任何
+--   stock movement / 下游單據，硬刪安全。月結（20260715000120）只計
+--   received/closed，draft 不入帳。
+--
+-- 本 function 為新建（無歷史版本；grep migrations 確認無同名）。
+-- 基底慣例：rpc_delete_restock_request（20260714000030 門市守門）＋
+--           rpc_transfer_batch_delete（20260508000000 僅 draft 可刪）。
+-- 依賴：transfer_items.transfer_id ON DELETE CASCADE（20260422120003）；
+--       picking_wave_items.generated_transfer_id 無 CASCADE（20260423120002）；
+--       _jwt_store_location_ids()（20260707000070）。
+-- Rollback：DROP FUNCTION public.rpc_delete_free_transfer(BIGINT);
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_delete_free_transfer(
+  p_transfer_id BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_xfer   RECORD;
+  v_waves  INTEGER;
+BEGIN
+  -- role 守門：HQ 職能 + 門市職能（空字串放行 — 對齊既有 restock RPC）
+  IF v_role NOT IN ('owner','admin','hq_manager','store_manager','store_staff','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot delete free transfer', v_role;
+  END IF;
+
+  SELECT * INTO v_xfer FROM transfers
+   WHERE id = p_transfer_id AND tenant_id = v_tenant
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transfer % not found', p_transfer_id;
+  END IF;
+
+  -- 只收自由轉貨：店↔店、無訂單 FK（綁訂單的是互助接力單）、無接力鏈
+  IF v_xfer.transfer_type <> 'store_to_store'
+     OR v_xfer.customer_order_id IS NOT NULL
+     OR v_xfer.next_transfer_id IS NOT NULL THEN
+    RAISE EXCEPTION 'transfer % is not a free transfer (type=%), cannot delete',
+      p_transfer_id, v_xfer.transfer_type;
+  END IF;
+
+  -- 門市角色只能刪自己店參與的單（店名 claim → location，見 20260707000070）
+  IF v_role IN ('store_manager','store_staff')
+     AND NOT (v_xfer.source_location = ANY (public._jwt_store_location_ids())
+              OR v_xfer.dest_location = ANY (public._jwt_store_location_ids())) THEN
+    RAISE EXCEPTION 'store role can only delete free transfer involving own store';
+  END IF;
+
+  -- 守門 1：只有 draft 可刪 — 配送後貨已在途，走拒收 / 收貨流程
+  IF v_xfer.status <> 'draft' THEN
+    RAISE EXCEPTION 'transfer % is %, only draft can be deleted',
+      p_transfer_id, v_xfer.status;
+  END IF;
+
+  -- 守門 2：雙重保險 — 已有撿貨波引用（自由轉貨不走 wave；防資料不一致）
+  SELECT COUNT(*) INTO v_waves
+    FROM picking_wave_items
+   WHERE generated_transfer_id = p_transfer_id;
+  IF v_waves > 0 THEN
+    RAISE EXCEPTION 'transfer % already referenced by picking waves, cannot delete', p_transfer_id;
+  END IF;
+
+  -- 實體硬刪：transfer_items 為 ON DELETE CASCADE
+  BEGIN
+    DELETE FROM transfers
+     WHERE id = p_transfer_id AND tenant_id = v_tenant;
+  EXCEPTION WHEN foreign_key_violation THEN
+    RAISE EXCEPTION 'transfer % still referenced by other records, cannot delete', p_transfer_id;
+  END;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_delete_free_transfer(BIGINT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_delete_free_transfer(BIGINT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_delete_free_transfer(BIGINT) IS
+  '自由轉貨刪除（硬刪）：限 store_to_store 且無訂單 FK / 接力鏈的 draft；'
+  'transfer_items 由 ON DELETE CASCADE 連帶刪；同 tenant；'
+  'HQ 職能全刪、門市職能限自己店參與的單（_jwt_store_location_ids）。';


### PR DESCRIPTION
新增 rpc_delete_free_transfer：限 store_to_store、無訂單 FK / 接力鏈的
draft 自由轉貨；HQ 職能全刪、門市職能限自己店參與的單
（_jwt_store_location_ids）。既有 rpc_transfer_batch_delete 無 role/tenant
守門，僅供總倉收件匣，不開放分店。

/wms/transfers 列表對符合條件的 row 顯示「刪除」按鈕（confirm 後呼叫
RPC、移除 row），互助接力單 / 退訂單 / 已配送單不顯示。rpcError 補中譯。

補貨申請刪除（rpc_delete_restock_request）既有版本已放行門市角色且
線上已部署，本次不需改動。

TEST: docs/TEST-store-self-service.md §2.16 / §3.4b
（守門四路徑 + happy path 已於線上 DB 直測；UI 以 Playwright + fixture
以 store_manager 角色驗證）

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012NWdTUdZ5zLbjG3bT3NKuH