### PR TITLE
feat(member): 現貨專區 — 店家釋出商品上 App，跨店金額隱藏，LINE 詢問

### DIFF
--- a/apps/member/src/app/spot/page.tsx
+++ b/apps/member/src/app/spot/page.tsx
@@ -91,14 +91,26 @@ export default function SpotPage() {
 
           {!loading && !err && visible.length === 0 && (
             <div className="flex flex-col items-center py-16 text-center">
+              {/* 用品牌色線稿箱子，不用 📦 emoji —— emoji 的咖啡色在粉色底上
+                  很跳，而且和卡片沒有圖時的 CoverFallback 是同一支圖示語言。 */}
               <div
-                className="flex h-24 w-24 items-center justify-center rounded-full text-5xl"
+                className="flex h-24 w-24 items-center justify-center rounded-full"
                 style={{
                   background:
                     "linear-gradient(135deg, var(--brand-soft) 0%, #fff4f6 100%)",
                 }}
               >
-                📦
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="var(--brand)"
+                  strokeWidth={1.3}
+                  className="h-12 w-12 opacity-80"
+                  aria-hidden
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 8.5 12 4l9 4.5v7L12 20l-9-4.5v-7Z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="m3 8.5 9 4.5 9-4.5M12 13v7" />
+                </svg>
               </div>
               <p className="mt-4 text-[17px] font-semibold text-[var(--foreground)]">
                 {tab === "mine" ? "你的店目前沒有現貨" : "目前沒有店家釋出現貨"}

--- a/apps/member/src/components/MemberTabBar.tsx
+++ b/apps/member/src/components/MemberTabBar.tsx
@@ -8,9 +8,9 @@ type Tab = {
   href: string;
   label: string;
   showBadge?: boolean;
-  /** 凸起中央鍵（現貨專區）：畫成往上浮出 bar 的品牌漸層圓鈕 */
+  /** 凸起中央鍵（現貨專區）：往上浮出 bar 的圓鈕，內容固定是包子媽 logo，不吃 icon */
   raised?: boolean;
-  icon: (active: boolean) => React.ReactNode;
+  icon?: (active: boolean) => React.ReactNode;
 };
 
 const stroke = (active: boolean) => (active ? "currentColor" : "currentColor");
@@ -43,12 +43,7 @@ const tabs: Tab[] = [
     href: "/spot",
     label: "現貨專區",
     raised: true,
-    icon: () => (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9} className="h-7 w-7">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M3 8.5 12 4l9 4.5v7L12 20l-9-4.5v-7Z" />
-        <path strokeLinecap="round" strokeLinejoin="round" d="m3 8.5 9 4.5 9-4.5M12 13v7" />
-      </svg>
-    ),
+    // icon 省略：凸起鍵畫的是包子媽 logo（見下方 raised 分支）
   },
   {
     href: "/notifications",
@@ -106,16 +101,24 @@ export default function MemberTabBar() {
                   }`}
                 >
                   {/* 外層維持和其他 tab 相同的 h-9 佔位，label 基線才會齊；
-                      圓鈕用 absolute 往上溢出，凸出 bar 上緣約 14px。 */}
+                      圓鈕用 absolute 往上溢出，凸出 bar 上緣約 14px。
+                      內容是包子媽 logo —— logo 本身不會變色，所以 active 改用
+                      外圈品牌漸層細邊 + 更深的陰影來表示。 */}
                   <span className="relative flex h-9 w-14 items-center justify-center">
                     <span
-                      className={`brand-gradient absolute -top-6 flex h-14 w-14 items-center justify-center rounded-full text-white ring-4 ring-white transition-all duration-300 ${
+                      className={`absolute -top-6 flex h-14 w-14 items-center justify-center rounded-full p-[3px] ring-4 ring-white transition-all duration-300 ${
                         active
-                          ? "scale-100 shadow-[0_10px_22px_-6px_rgba(158,47,80,0.75)]"
-                          : "scale-95 shadow-[0_6px_16px_-6px_rgba(158,47,80,0.5)]"
+                          ? "brand-gradient scale-100 shadow-[0_10px_22px_-6px_rgba(158,47,80,0.75)]"
+                          : "scale-95 bg-white shadow-[0_6px_16px_-6px_rgba(158,47,80,0.5)]"
                       }`}
                     >
-                      {t.icon(active)}
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src="/brand/logo.jpg"
+                        alt=""
+                        aria-hidden
+                        className="h-full w-full rounded-full object-cover"
+                      />
                     </span>
                   </span>
                   <span>{t.label}</span>
@@ -137,7 +140,7 @@ export default function MemberTabBar() {
                     active ? "bg-[var(--brand-soft)] scale-100" : "bg-transparent scale-90"
                   }`}
                 >
-                  {t.icon(active)}
+                  {t.icon?.(active)}
                   {showBadge && (
                     <span
                       className="absolute right-1 -top-0.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[var(--ios-red)] px-1 text-[11px] font-semibold leading-none text-white ring-2 ring-white"

--- a/apps/member/src/components/MemberTabBar.tsx
+++ b/apps/member/src/components/MemberTabBar.tsx
@@ -96,8 +96,10 @@ export default function MemberTabBar() {
               <li key={t.href} className="flex-1">
                 <Link
                   href={t.href}
-                  className={`flex flex-col items-center justify-center gap-1 px-1 pb-2.5 pt-2.5 text-[12px] font-semibold transition-colors duration-200 ${
-                    active ? "text-[var(--brand-strong)]" : "text-[var(--ios-gray)]"
+                  className={`flex flex-col items-center justify-center gap-1 px-1 pb-2.5 pt-2.5 text-[12px] transition-colors duration-200 ${
+                    active
+                      ? "font-extrabold text-[var(--brand-strong)]"
+                      : "font-semibold text-[var(--ios-gray)]"
                   }`}
                 >
                   {/* 外層維持和其他 tab 相同的 h-9 佔位，label 基線才會齊；
@@ -106,18 +108,22 @@ export default function MemberTabBar() {
                       外圈品牌漸層細邊 + 更深的陰影來表示。 */}
                   <span className="relative flex h-9 w-14 items-center justify-center">
                     <span
-                      className={`absolute -top-6 flex h-14 w-14 items-center justify-center rounded-full p-[3px] ring-4 ring-white transition-all duration-300 ${
+                      className={`absolute -top-6 flex h-14 w-14 items-center justify-center rounded-full ring-4 ring-white transition-all duration-300 ${
                         active
-                          ? "brand-gradient scale-100 shadow-[0_10px_22px_-6px_rgba(158,47,80,0.75)]"
-                          : "scale-95 bg-white shadow-[0_6px_16px_-6px_rgba(158,47,80,0.5)]"
+                          ? "brand-gradient scale-110 p-1 shadow-[0_0_0_3px_rgba(158,47,80,0.28),0_14px_26px_-6px_rgba(158,47,80,0.85)]"
+                          : "scale-90 bg-white p-[3px] shadow-[0_6px_16px_-8px_rgba(0,0,0,0.35)]"
                       }`}
                     >
+                      {/* 未選取時 logo 去彩度 + 壓透明度，對齊其他四格「灰→品牌色」的
+                          既有規則；選取時放大、上彩、外掛品牌漸層邊與光暈。 */}
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         src="/brand/logo.jpg"
                         alt=""
                         aria-hidden
-                        className="h-full w-full rounded-full object-cover"
+                        className={`h-full w-full rounded-full object-cover transition-all duration-300 ${
+                          active ? "" : "opacity-55 grayscale"
+                        }`}
                       />
                     </span>
                   </span>


### PR DESCRIPTION
## 這是什麼

店家在互助交流板按「我有庫存可提供」釋出的現貨，現在會出現在會員 App 底部**正中間的「現貨專區」**。
**只有會員所在店家釋出的商品看得到金額**，跨店的金額隱藏。點商品可以用 LINE 直接詢問店家。

規劃全文：`docs/PLAN-現貨專區.md`

## 資料定義

| 項目 | 內容 |
|---|---|
| 來源 | `mutual_aid_board` 的 `post_type='offer'` |
| 上架條件 | `status='active'` ＋ 未到期 ＋ `qty_remaining > 0` |
| 不收錄 | `post_type='request'`（店對店求援不是貨）、板上 `note`（內部備註） |
| 自動下架 | 被認領光 / 到期（既有 cron）/ 店家取消 —— 三種都自動消失，沒有額外機制 |
| 單價 | 該貼文 `source_customer_order_id` 訂單中對應 `sku_id` 的 `unit_price` |
| 會員所在店 | `members.home_store_id`，未綁定退回 JWT 的 `store_id` |

## 金額隱藏怎麼守

**在後端擋，不是 UI 藏**：

1. 後端算出 `myStoreId`
2. **只對 `offering_store_id === myStoreId` 的貼文**去查來源訂單單價 —— 跨店那幾筆連查都不查
3. Response 中跨店的 `unit_price` 恆為 `null`
4. 前端拿到 `is_my_store=false` 就畫「跨店 · 金額不顯示」鎖頭

LINE 訊息是第二道關卡：跨店那則範本不帶金額，否則等於從另一個出口漏出去。

## Tab bar：4 格 → 5 格

商品 / 訂單 / **現貨專區** / 通知 / 我，中間是包子媽 logo 的凸起圓鈕。

兩個實作上的坑：

- 路由用頂層 `/spot` 而非 `/shop/released` —— tab active 判斷是 `startsWith`，掛在 `/shop` 底下會讓「商品」跟著亮
- `PageShell` 底部留白 92px → 104px，否則凸起鈕會蓋住頁尾最後一列

選取狀態：logo 全彩 + 放大 1.1 + 品牌漸層外框與光暈；未選取去彩度縮小，對齊其他四格「灰 → 品牌色」的既有規則。

## LINE 詢問

卡片底部一顆 CTA（整張卡不可點，避免捲動誤觸彈出 App）。

- 本店：`您好，我想詢問今日現貨「〈品名〉」 金額：$149 請問店家目前還有貨嗎？`
- 跨店：`您好，我想詢問今日現貨「〈品名〉」（◯◯店釋出） 請問可以幫我調貨嗎？`

收件人一律是**會員自己的店**的 LINE@（跨店也是）：會員只跟自己的店結帳，跨店的貨本來就是自己的店走互助板去別店調。
解析順序：該店 `line_oa_basic_id` → `NEXT_PUBLIC_LINE_OA_ID` → 都沒有就不畫按鈕。

## 主要異動

| 檔案 | 說明 |
|---|---|
| `supabase/functions/liff-api/index.ts` | 新唯讀 action `list_spot_products` |
| `supabase/migrations/20260801000020_rpc_upsert_store_line_oa.sql` | `rpc_upsert_store` 加 `p_line_oa_basic_id` |
| `apps/admin/.../stores/page.tsx` | 門市表單加「LINE@ ID」欄位 |
| `apps/member/src/app/spot/page.tsx` | 現貨專區主頁 |
| `apps/member/src/components/SpotProductCard.tsx` | 現貨卡（金額 / 鎖頭 / CTA） |
| `apps/member/src/lib/lineInquiry.ts` | 訊息範本與 LINE 連結，單一真相來源 |
| `apps/member/src/components/MemberTabBar.tsx` | 5 格 + 凸起中央鍵 |
| `apps/member/src/components/PageShell.tsx` | `/spot` 列頂層路由、底部留白加高 |
| `apps/member/src/app/shop/page.tsx` | 首頁現貨導流區塊（4 張 + 「去現貨專區 ›」）|
| `docs/PLAN-現貨專區.md` / `docs/TEST-member-spot-zone.md` | 規劃與測試文件 |

互助交流板的既有 RPC / view **完全沒動**，店家操作照舊。

## 已驗證

- member / admin 兩個 app `tsc --noEmit` + `next build` 全過；新檔案無 lint 問題
- Migration 已套線上：`pg_proc` 查過只剩 9-arg 一支 `rpc_upsert_store`，沒有 overload 撞名
- `rpc_upsert_store` 用 **rollback 交易**實測四種情境：舊 8 參數具名呼叫仍可用（確認部署無空窗）、新參數寫入、前後空白 trim、空字串轉 `NULL`。跑完 rollback，線上資料原封不動
- `liff-api` 已部署（version 52, ACTIVE）：OPTIONS 200、無 auth 401、壞 token 回函式自家的錯誤
- PostgREST 實打過那串 embedded select，回傳結構正確；SQL 驗過單價能從 `source_customer_order_id` + `sku_id` 對到 `customer_order_items.unit_price`

## 還沒驗證 / 待辦

- **上線前要設 `NEXT_PUBLIC_LINE_OA_ID`**，或在 admin `/stores` 幫各店填 LINE@ ID。兩者都空的話「LINE 詢問」按鈕不會出現（其餘功能正常）。線上 23 間店這欄目前全是 `NULL`
- 實機端到端沒跑：這個環境拿不到 `PROJECT_JWT_SECRET`（Management API 回的是 hash），簽不出會員 token；線上也還沒有 active 的釋出貼文。發一則「我有庫存可提供」後照 `docs/TEST-member-spot-zone.md` 走一遍，重點是 T3-6（凸起鈕不蓋內容）、T4-7（跨店卡沒金額）、T5-5（跨店 LINE 訊息不帶金額）

---
_Generated by [Claude Code](https://claude.ai/code/session_01DetXFF67eZbpESvKssoeXz)_