### PR TITLE
style(member): 現貨專區圖示調整 — 中央鍵換包子媽 logo、選取狀態加強、空狀態換線稿箱子

### DIFF
--- a/apps/member/src/app/spot/page.tsx
+++ b/apps/member/src/app/spot/page.tsx
@@ -91,14 +91,26 @@ export default function SpotPage() {
 
           {!loading && !err && visible.length === 0 && (
             <div className="flex flex-col items-center py-16 text-center">
+              {/* 用品牌色線稿箱子，不用 📦 emoji —— emoji 的咖啡色在粉色底上
+                  很跳，而且和卡片沒有圖時的 CoverFallback 是同一支圖示語言。 */}
               <div
-                className="flex h-24 w-24 items-center justify-center rounded-full text-5xl"
+                className="flex h-24 w-24 items-center justify-center rounded-full"
                 style={{
                   background:
                     "linear-gradient(135deg, var(--brand-soft) 0%, #fff4f6 100%)",
                 }}
               >
-                📦
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="var(--brand)"
+                  strokeWidth={1.3}
+                  className="h-12 w-12 opacity-80"
+                  aria-hidden
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 8.5 12 4l9 4.5v7L12 20l-9-4.5v-7Z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="m3 8.5 9 4.5 9-4.5M12 13v7" />
+                </svg>
               </div>
               <p className="mt-4 text-[17px] font-semibold text-[var(--foreground)]">
                 {tab === "mine" ? "你的店目前沒有現貨" : "目前沒有店家釋出現貨"}

--- a/apps/member/src/components/MemberTabBar.tsx
+++ b/apps/member/src/components/MemberTabBar.tsx
@@ -8,9 +8,9 @@ type Tab = {
   href: string;
   label: string;
   showBadge?: boolean;
-  /** 凸起中央鍵（現貨專區）：畫成往上浮出 bar 的品牌漸層圓鈕 */
+  /** 凸起中央鍵（現貨專區）：往上浮出 bar 的圓鈕，內容固定是包子媽 logo，不吃 icon */
   raised?: boolean;
-  icon: (active: boolean) => React.ReactNode;
+  icon?: (active: boolean) => React.ReactNode;
 };
 
 const stroke = (active: boolean) => (active ? "currentColor" : "currentColor");
@@ -43,12 +43,7 @@ const tabs: Tab[] = [
     href: "/spot",
     label: "現貨專區",
     raised: true,
-    icon: () => (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9} className="h-7 w-7">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M3 8.5 12 4l9 4.5v7L12 20l-9-4.5v-7Z" />
-        <path strokeLinecap="round" strokeLinejoin="round" d="m3 8.5 9 4.5 9-4.5M12 13v7" />
-      </svg>
-    ),
+    // icon 省略：凸起鍵畫的是包子媽 logo（見下方 raised 分支）
   },
   {
     href: "/notifications",
@@ -106,16 +101,24 @@ export default function MemberTabBar() {
                   }`}
                 >
                   {/* 外層維持和其他 tab 相同的 h-9 佔位，label 基線才會齊；
-                      圓鈕用 absolute 往上溢出，凸出 bar 上緣約 14px。 */}
+                      圓鈕用 absolute 往上溢出，凸出 bar 上緣約 14px。
+                      內容是包子媽 logo —— logo 本身不會變色，所以 active 改用
+                      外圈品牌漸層細邊 + 更深的陰影來表示。 */}
                   <span className="relative flex h-9 w-14 items-center justify-center">
                     <span
-                      className={`brand-gradient absolute -top-6 flex h-14 w-14 items-center justify-center rounded-full text-white ring-4 ring-white transition-all duration-300 ${
+                      className={`absolute -top-6 flex h-14 w-14 items-center justify-center rounded-full p-[3px] ring-4 ring-white transition-all duration-300 ${
                         active
-                          ? "scale-100 shadow-[0_10px_22px_-6px_rgba(158,47,80,0.75)]"
-                          : "scale-95 shadow-[0_6px_16px_-6px_rgba(158,47,80,0.5)]"
+                          ? "brand-gradient scale-100 shadow-[0_10px_22px_-6px_rgba(158,47,80,0.75)]"
+                          : "scale-95 bg-white shadow-[0_6px_16px_-6px_rgba(158,47,80,0.5)]"
                       }`}
                     >
-                      {t.icon(active)}
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src="/brand/logo.jpg"
+                        alt=""
+                        aria-hidden
+                        className="h-full w-full rounded-full object-cover"
+                      />
                     </span>
                   </span>
                   <span>{t.label}</span>
@@ -137,7 +140,7 @@ export default function MemberTabBar() {
                     active ? "bg-[var(--brand-soft)] scale-100" : "bg-transparent scale-90"
                   }`}
                 >
-                  {t.icon(active)}
+                  {t.icon?.(active)}
                   {showBadge && (
                     <span
                       className="absolute right-1 -top-0.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[var(--ios-red)] px-1 text-[11px] font-semibold leading-none text-white ring-2 ring-white"

--- a/apps/member/src/components/MemberTabBar.tsx
+++ b/apps/member/src/components/MemberTabBar.tsx
@@ -96,8 +96,10 @@ export default function MemberTabBar() {
               <li key={t.href} className="flex-1">
                 <Link
                   href={t.href}
-                  className={`flex flex-col items-center justify-center gap-1 px-1 pb-2.5 pt-2.5 text-[12px] font-semibold transition-colors duration-200 ${
-                    active ? "text-[var(--brand-strong)]" : "text-[var(--ios-gray)]"
+                  className={`flex flex-col items-center justify-center gap-1 px-1 pb-2.5 pt-2.5 text-[12px] transition-colors duration-200 ${
+                    active
+                      ? "font-extrabold text-[var(--brand-strong)]"
+                      : "font-semibold text-[var(--ios-gray)]"
                   }`}
                 >
                   {/* 外層維持和其他 tab 相同的 h-9 佔位，label 基線才會齊；
@@ -106,18 +108,22 @@ export default function MemberTabBar() {
                       外圈品牌漸層細邊 + 更深的陰影來表示。 */}
                   <span className="relative flex h-9 w-14 items-center justify-center">
                     <span
-                      className={`absolute -top-6 flex h-14 w-14 items-center justify-center rounded-full p-[3px] ring-4 ring-white transition-all duration-300 ${
+                      className={`absolute -top-6 flex h-14 w-14 items-center justify-center rounded-full ring-4 ring-white transition-all duration-300 ${
                         active
-                          ? "brand-gradient scale-100 shadow-[0_10px_22px_-6px_rgba(158,47,80,0.75)]"
-                          : "scale-95 bg-white shadow-[0_6px_16px_-6px_rgba(158,47,80,0.5)]"
+                          ? "brand-gradient scale-110 p-1 shadow-[0_0_0_3px_rgba(158,47,80,0.28),0_14px_26px_-6px_rgba(158,47,80,0.85)]"
+                          : "scale-90 bg-white p-[3px] shadow-[0_6px_16px_-8px_rgba(0,0,0,0.35)]"
                       }`}
                     >
+                      {/* 未選取時 logo 去彩度 + 壓透明度，對齊其他四格「灰→品牌色」的
+                          既有規則；選取時放大、上彩、外掛品牌漸層邊與光暈。 */}
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         src="/brand/logo.jpg"
                         alt=""
                         aria-hidden
-                        className="h-full w-full rounded-full object-cover"
+                        className={`h-full w-full rounded-full object-cover transition-all duration-300 ${
+                          active ? "" : "opacity-55 grayscale"
+                        }`}
                       />
                     </span>
                   </span>


### PR DESCRIPTION
## 這是什麼

#570 之後的視覺調整，純前端、只動兩個檔案。承接 #570 的現貨專區。

（#571 已關閉：那個 PR 的分支還帶著 #570 已合併的 commit，顯示 conflict。分支已從最新 main 重開，只留下面這三個 commit。）

## 1. tab bar 中央凸起鍵換成包子媽 logo

原本是白色箱子 SVG，改用 `/brand/logo.jpg`（和標題列頭像同一張）。

## 2. 選取狀態做明顯一點

原本只差一圈細邊和陰影，滑過去幾乎看不出來。logo 本身不會變色，所以拉開四個維度：

| | 未選取 | 選取中 |
|---|---|---|
| logo | 去彩度、透明度 55% | 全彩 |
| 大小 | 縮到 0.9 | 放大到 1.1 |
| 外框 | 白色（融進 bar） | 4px 品牌漸層 + 品牌色光暈 |
| 文字 | 灰、semibold | 品牌紅、extrabold |

「灰 → 品牌色」對齊旁邊四格 tab 的既有規則，所以不會突兀。

## 3. 空狀態換掉 📦 emoji

emoji 的咖啡色在粉色圓底上很跳。改成品牌色線稿箱子，和卡片沒有圖時的 `CoverFallback` 是同一支圖示語言。

## 異動檔案

| 檔案 | 說明 |
|---|---|
| `apps/member/src/components/MemberTabBar.tsx` | 中央鍵改 logo、選取狀態強化；`Tab.icon` 改 optional（凸起鍵不吃 icon） |
| `apps/member/src/app/spot/page.tsx` | 空狀態圖示 |

沒有 migration、沒有後端異動、沒動任何 RPC。

## 已驗證

- `tsc --noEmit` + `next build` 全過，無新增 lint 問題
- 重開分支後的 tree 與重開前逐位元組相同（`git diff` 對照舊 head 為空）

## 沒驗證

實機畫面沒看過 —— 這個環境跑不了會員端登入。合併後在手機上確認一下選取／未選取的對比夠不夠，以及凸起鈕沒有蓋到頁尾內容（`docs/TEST-member-spot-zone.md` T3-2、T3-6）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DetXFF67eZbpESvKssoeXz)_