### PR TITLE
feat: 互助上架與發佈後皆可改單價/商品說明；App 低於原價畫刪除線

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -37,7 +37,7 @@ type PendingOrder = {
   status: string;
   member_name: string | null;
   member_phone: string | null;
-  items: { campaign_item_id: number | null; sku_id: number | null; qty: number; sku_label: string }[];
+  items: { campaign_item_id: number | null; sku_id: number | null; qty: number; sku_label: string; unit_price: number | null; product_description: string | null }[];
 };
 
 type Reply = {
@@ -62,6 +62,24 @@ const STATUS_COLOR: Record<Post["status"], string> = {
   expired: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
   cancelled: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
 };
+
+/** TipTap HTML → 純文字（textarea 預填用）：區塊標籤轉換行、去標籤、還原常見 entity */
+function stripHtmlToText(raw: string | null | undefined): string {
+  if (!raw) return "";
+  return raw
+    .replace(/<\/(p|div|h[1-6]|li|tr|blockquote)\s*>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/(&#0*39;|&apos;)/gi, "'")
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
 
 const TYPE_LABEL: Record<PostType, string> = {
   offer: "釋出",
@@ -518,13 +536,17 @@ function OfferModal({
   const [qty, setQty] = useState("");
   const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
   const [note, setNote] = useState("");
+  // 釋出單價與商品說明：預填來源訂單原價 / 商品主檔原文，店家可改。
+  // 價低於原價時會員端會以刪除線顯示原價。
+  const [spotPrice, setSpotPrice] = useState("");
+  const [spotDesc, setSpotDesc] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) {
       setStoreId(""); setOrders(null); setOrderSearch(""); setPickedOrder(null); setPickedItemIdx(0);
-      setQty(""); setNote(""); setErr(null);
+      setQty(""); setNote(""); setSpotPrice(""); setSpotDesc(""); setErr(null);
       setExpiresAt(defaultExpiresAt());
     }
   }, [open]);
@@ -540,7 +562,7 @@ function OfferModal({
         .select(`
           id, order_no, pickup_store_id, status,
           member:members(name, phone),
-          items:customer_order_items(campaign_item_id, sku_id, qty, status, sku:skus(sku_code, product_name, variant_name))
+          items:customer_order_items(campaign_item_id, sku_id, qty, status, unit_price, sku:skus(sku_code, product_name, variant_name, product:products(description)))
         `)
         .eq("pickup_store_id", storeId)
         .eq("status", "ready")
@@ -548,8 +570,9 @@ function OfferModal({
         .limit(200);
       if (cancelled) return;
       if (e) { setErr(e.message); return; }
-      type RawSku = { sku_code: string; product_name: string; variant_name: string | null };
-      type RawItem = { campaign_item_id: number | null; sku_id: number | null; qty: number; status: string; sku: RawSku | RawSku[] | null };
+      type RawProduct = { description: string | null };
+      type RawSku = { sku_code: string; product_name: string; variant_name: string | null; product?: RawProduct | RawProduct[] | null };
+      type RawItem = { campaign_item_id: number | null; sku_id: number | null; qty: number; status: string; unit_price: number | string | null; sku: RawSku | RawSku[] | null };
       type RawMember = { name: string | null; phone: string | null };
       type RawOrder = {
         id: number; order_no: string; pickup_store_id: number; status: string;
@@ -570,6 +593,8 @@ function OfferModal({
             .filter((it) => it.status !== "cancelled" && it.status !== "expired" && it.status !== "picked_up")
             .map((it) => {
               const sku = Array.isArray(it.sku) ? it.sku[0] : it.sku;
+              const product = sku ? (Array.isArray(sku.product) ? sku.product[0] : sku.product) : null;
+              const priceN = Number(it.unit_price);
               return {
                 campaign_item_id: it.campaign_item_id,
                 sku_id: it.sku_id,
@@ -577,6 +602,8 @@ function OfferModal({
                 sku_label: sku
                   ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} (${sku.sku_code})`
                   : `品項#${it.sku_id}`,
+                unit_price: Number.isFinite(priceN) ? priceN : null,
+                product_description: product?.description ?? null,
               };
             }),
         };
@@ -586,10 +613,13 @@ function OfferModal({
     return () => { cancelled = true; };
   }, [open, storeId]);
 
-  // 選了訂單 → 自動帶第一個 item 的 qty
+  // 選了訂單 → 自動帶該 item 的數量、原價、商品說明（後兩者可改）
   useEffect(() => {
-    if (pickedOrder && pickedOrder.items[pickedItemIdx]) {
-      setQty(String(pickedOrder.items[pickedItemIdx].qty));
+    const item = pickedOrder?.items[pickedItemIdx];
+    if (item) {
+      setQty(String(item.qty));
+      setSpotPrice(item.unit_price != null ? String(item.unit_price) : "");
+      setSpotDesc(stripHtmlToText(item.product_description));
     }
   }, [pickedOrder, pickedItemIdx]);
 
@@ -617,6 +647,17 @@ function OfferModal({
     if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("數量需 > 0"); return; }
     const expDate = new Date(expiresAt);
     if (expDate <= new Date()) { setErr("到期時間需在未來"); return; }
+    const priceRaw = spotPrice.trim();
+    let priceN: number | null = null;
+    if (priceRaw !== "") {
+      priceN = Number(priceRaw);
+      if (!Number.isFinite(priceN) || priceN <= 0) { setErr("釋出單價需 > 0（留空 = 沿用原價）"); return; }
+    }
+    // 沒改的值送 null（= 沿用原價 / 商品主檔原文），改了才存進板上
+    const spotPriceParam = priceN != null && priceN !== item.unit_price ? priceN : null;
+    const descTrim = spotDesc.trim();
+    const spotDescParam =
+      descTrim !== "" && descTrim !== stripHtmlToText(item.product_description) ? descTrim : null;
 
     setSubmitting(true);
     try {
@@ -633,6 +674,8 @@ function OfferModal({
         p_operator: operator,
         p_post_type: "offer",
         p_source_customer_order_id: pickedOrder.id,
+        p_spot_price: spotPriceParam,
+        p_spot_description: spotDescParam,
       });
       if (e) { setErr(e.message); return; }
       onPosted();
@@ -728,7 +771,7 @@ function OfferModal({
           </div>
         )}
 
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-3 gap-3">
           <label>
             <span className="mb-1 block text-xs text-zinc-500">釋出數量 <span className="text-red-500">*</span></span>
             <input
@@ -737,6 +780,29 @@ function OfferModal({
               inputMode="decimal"
               className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
             />
+          </label>
+          <label>
+            <span className="mb-1 block text-xs text-zinc-500">釋出單價</span>
+            <input
+              value={spotPrice}
+              onChange={(e) => setSpotPrice(e.target.value)}
+              inputMode="decimal"
+              placeholder="留空 = 原價"
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
+            />
+            {(() => {
+              const orig = pickedOrder?.items[pickedItemIdx]?.unit_price;
+              const n = Number(spotPrice);
+              if (orig == null) return null;
+              if (spotPrice.trim() !== "" && Number.isFinite(n) && n < orig) {
+                return (
+                  <span className="mt-0.5 block text-[11px] text-emerald-600 dark:text-emerald-400">
+                    低於原價 <s>${orig.toLocaleString()}</s> — App 會用刪除線顯示原價
+                  </span>
+                );
+              }
+              return <span className="mt-0.5 block text-[11px] text-zinc-400">原價 ${orig.toLocaleString()}</span>;
+            })()}
           </label>
           <label>
             <span className="mb-1 block text-xs text-zinc-500">到期時間 <span className="text-red-500">*</span></span>
@@ -749,7 +815,17 @@ function OfferModal({
           </label>
         </div>
         <label>
-          <span className="mb-1 block text-xs text-zinc-500">備註（選填）</span>
+          <span className="mb-1 block text-xs text-zinc-500">商品說明（會顯示在會員 App 的商品詳情，可改寫）</span>
+          <textarea
+            value={spotDesc}
+            onChange={(e) => setSpotDesc(e.target.value)}
+            rows={4}
+            placeholder="選了品項會自動帶入商品主檔的說明，可直接改寫"
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+        <label>
+          <span className="mb-1 block text-xs text-zinc-500">備註（選填，店對店內部訊息，不會給會員看）</span>
           <input
             value={note}
             onChange={(e) => setNote(e.target.value)}
@@ -1191,6 +1267,8 @@ function FulfillRequestDialog({
             const sku = Array.isArray(it.sku) ? it.sku[0] : it.sku;
             return {
               campaign_item_id: null, sku_id: it.sku_id, qty: Number(it.qty),
+              // 這個 modal（回應求助）用不到單價/說明，補 null 滿足共用型別
+              unit_price: null, product_description: null,
               sku_label: sku ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} (${sku.sku_code})` : `品項#${it.sku_id}`,
             };
           }),

--- a/apps/member/src/app/spot/[id]/page.tsx
+++ b/apps/member/src/app/spot/[id]/page.tsx
@@ -163,8 +163,15 @@ export default function SpotDetailPage() {
               </h2>
 
               {item.is_my_store ? (
-                <div className="brand-gradient-text text-[32px] font-extrabold tabular-nums leading-none">
-                  {item.unit_price != null ? `$${item.unit_price.toLocaleString()}` : "—"}
+                <div className="flex items-baseline gap-2">
+                  <span className="brand-gradient-text text-[32px] font-extrabold tabular-nums leading-none">
+                    {item.unit_price != null ? `$${item.unit_price.toLocaleString()}` : "—"}
+                  </span>
+                  {item.original_price != null && (
+                    <s className="text-[17px] font-medium tabular-nums text-[var(--secondary-label)]">
+                      ${item.original_price.toLocaleString()}
+                    </s>
+                  )}
                 </div>
               ) : (
                 <div className="inline-flex items-center gap-1.5 rounded-lg bg-black/5 px-2.5 py-1.5 text-[14px] font-medium text-[var(--secondary-label)] dark:bg-white/10">

--- a/apps/member/src/components/SpotProductCard.tsx
+++ b/apps/member/src/components/SpotProductCard.tsx
@@ -22,6 +22,9 @@ export type SpotProduct = {
   expires_at: string;
   is_my_store: boolean;
   unit_price: number | null;
+  /** 原價（來源訂單單價）。只在「店家有改價且改得比原價低」時才有值，
+   *  會員端據此畫刪除線。跨店一律 null（金額隱藏）。 */
+  original_price: number | null;
 };
 
 export function spotProductTitle(p: SpotProduct): string {
@@ -102,8 +105,15 @@ export default function SpotProductCard({ item }: { item: SpotProduct }) {
 
         <div className="mt-auto pt-1">
           {item.is_my_store ? (
-            <div className="brand-gradient-text text-[24px] font-extrabold tabular-nums leading-none">
-              {item.unit_price != null ? `$${item.unit_price.toLocaleString()}` : "—"}
+            <div className="flex items-baseline gap-1.5">
+              <span className="brand-gradient-text text-[24px] font-extrabold tabular-nums leading-none">
+                {item.unit_price != null ? `$${item.unit_price.toLocaleString()}` : "—"}
+              </span>
+              {item.original_price != null && (
+                <s className="text-[14px] font-medium tabular-nums text-[var(--secondary-label)]">
+                  ${item.original_price.toLocaleString()}
+                </s>
+              )}
             </div>
           ) : (
             <div className="inline-flex items-center gap-1 rounded-md bg-black/5 px-1.5 py-1 text-[12px] font-medium text-[var(--secondary-label)] dark:bg-white/10">

--- a/docs/PLAN-現貨專區.md
+++ b/docs/PLAN-現貨專區.md
@@ -24,7 +24,8 @@
 | 上架條件 | `status='active'` ＋ `expires_at > now()` ＋ `qty_remaining > 0` |
 | 不收錄 | `post_type='request'`（我要求助，是店對店求援不是貨）；板上 `note`（店對店內部備註，不外流） |
 | 自動下架 | 被認領光（`exhausted`）／到期（既有 cron `purge-expired-aid-board` 每 10 分鐘跑）／店家取消 —— 三種都自動從 App 消失，不必另外做 |
-| 單價來源 | 該貼文 `source_customer_order_id` 的訂單中，對應 `sku_id` 的 `customer_order_items.unit_price` |
+| 單價來源 | `mutual_aid_board.spot_price`（店家上架時可改，2026-08-02 加）優先；沒改則用來源訂單 `customer_order_items.unit_price`。釋出價**低於**原價時回 `original_price`，會員端畫刪除線 |
+| 商品說明 | `mutual_aid_board.spot_description`（上架時可改寫原文）優先；沒改 fallback `products.description` |
 | 會員所在店 | `members.home_store_id`；未綁定會員退回 JWT 的 `store_id`（掃碼進站那間） |
 
 **命名分工**：對會員講「現貨專區」（現成的貨、不用等團購結單）；卡片上仍標「◯◯店 釋出」當來源。
@@ -204,8 +205,10 @@ tab active 判斷是 `pathname.startsWith(t.href)`。所以現貨專區**必須�
 | `apps/member/.env` / Vercel | 設定 | 加 `NEXT_PUBLIC_LINE_OA_ID` |
 | `docs/TEST-member-released-products.md` | 改名 | → `docs/TEST-member-spot-zone.md`，內容同步 |
 
-**沒有 migration、不動任何 RPC、不動 admin 互助交流板的既有流程。**
-店家操作完全照舊：按「我有庫存可提供」發貼文，會員端就自動看得到。
+| `supabase/migrations/20260802000000_aid_board_spot_price_description.sql` | 新增 | `mutual_aid_board` 加 `spot_price` / `spot_description`；`rpc_post_aid_board` 8 → 10 參數（DROP+CREATE，新參數有 DEFAULT 無空窗） |
+| `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` | 改 | 「我有庫存可提供」表單加「釋出單價」（預填原價，可改；低於原價有提示）與「商品說明」textarea（預填原文純文字，可改寫）；沒改的值送 NULL |
+
+店家操作照舊：按「我有庫存可提供」發貼文，會員端就自動看得到；價格與說明想改才改。
 
 ---
 

--- a/docs/TEST-member-spot-zone.md
+++ b/docs/TEST-member-spot-zone.md
@@ -8,6 +8,7 @@
 ## 涵蓋範圍
 - Edge Function `liff-api` actions：`list_spot_products`、`get_spot_product`
 - Migration `20260801000020_rpc_upsert_store_line_oa.sql`（`rpc_upsert_store` 加 `p_line_oa_basic_id`）
+- Migration `20260802000000_aid_board_spot_price_description.sql`（互助板 offer 可自訂釋出單價與商品說明）
 - 會員端：底部 tab bar 中央凸起鍵、`/spot` 列表、`/spot/[id]` 詳情（`/shop` 的現貨導流區塊已移除，見 T6）
 - 元件：`SpotProductCard.tsx`、`lib/lineInquiry.ts`
 - admin：`/stores` 的「LINE@ ID」欄位
@@ -41,6 +42,11 @@
 | # | 步驟 | 預期 |
 |---|------|------|
 | T1-1 | admin 用 A 店帳號進 `/inventory/mutual-aid` →「我有庫存可提供」→ 選 A 店訂單 + 品項 + 數量 | 貼文成立，列表出現「釋出 / 進行中 / A店」 |
+| T1-4 | 選了品項後看「釋出單價」與「商品說明」欄位 | 單價預填來源訂單原價（欄位下方顯示「原價 $X」）；說明預填商品主檔原文的**純文字**（無 HTML 標籤），皆可改 |
+| T1-5 | 把單價改低於原價 | 欄位下方出現綠色提示「低於原價 ~~$X~~ — App 會用刪除線顯示原價」 |
+| T1-6 | 單價填 0 / 負數 | 擋下「釋出單價需 > 0（留空 = 沿用原價）」 |
+| T1-7 | 單價留空 or 沒動、說明沒動 | 送出後 `mutual_aid_board.spot_price` / `spot_description` 為 `NULL`（= 沿用原值，不是存一份複本） |
+| T1-8 | SQL 直呼 `rpc_post_aid_board` 用 `p_post_type='request'` 帶 `p_spot_price` | 炸 `spot_price is only valid for offer posts` |
 | T1-2 | 同上用 B 店再發一則（挑不同 SKU 好辨識） | 貼文成立 |
 | T1-3 | `SELECT id, post_type, status, offering_store_id, sku_id, qty_remaining, expires_at FROM mutual_aid_board WHERE post_type='offer' AND status='active';` | 兩筆，`expires_at` 在未來、`qty_remaining > 0` |
 
@@ -55,7 +61,11 @@
 | T2-5 | A 店那筆 | `is_my_store=true`，`unit_price` 是數字，= 來源訂單該 SKU 的 `customer_order_items.unit_price` |
 | T2-6 | **B 店那筆（重點）** | `is_my_store=false`，**`unit_price` 為 `null`** —— 看 raw response 也拿不到金額 |
 | T2-7 | 排序 | `is_my_store=true` 的排前面 |
-| T2-8 | 每筆欄位 | `id, sku_id, sku_code, product_name, variant_name, unit, image_url, store_id, store_name, qty_remaining, expires_at, is_my_store, unit_price` |
+| T2-8 | 每筆欄位 | `id, sku_id, sku_code, product_name, variant_name, unit, image_url, store_id, store_name, qty_remaining, expires_at, is_my_store, unit_price, original_price` |
+| T2-15 | **改價後的 A 店貼文（原價 199、釋出價 149）** | `unit_price=149`、`original_price=199` |
+| T2-16 | 改價**高於**原價（例 249） | `unit_price=249`、`original_price=null`（漲價不畫刪除線） |
+| T2-17 | 沒改價 | `unit_price=原價`、`original_price=null` |
+| T2-18 | **跨店 + 有改價** | `unit_price` 與 `original_price` **都是 `null`** —— 折扣資訊也是金額，不外流 |
 | T2-9 | response 不含 `note` | 板上備註是店對店內部訊息，不外流 |
 | T2-10 | 把 A 店那筆改 `status='cancelled'` 後重打 | 只剩 1 筆（B 店） |
 | T2-11 | 把 B 店那筆 `expires_at` 改成過去後重打 | 0 筆 |
@@ -86,6 +96,7 @@
 | T4-4 | 切回「全部」 | 跨店卡回來，仍然沒有金額 |
 | T4-5 | 說明文字 | **沒有**說明段落（2026-08-01 拿掉）；分頁下面直接接卡片 |
 | T4-6 | A 店卡片 | 左上紫紅「本店釋出」；價格是品牌漸層大字 `$xxx` |
+| T4-14 | A 店卡片（釋出價低於原價） | 大字 `$149` 旁有灰色刪除線 `~~$199~~` |
 | T4-7 | **B 店卡片（重點）** | 左上深色「B店 釋出」；價格位置是灰色鎖頭膠囊「跨店 · 金額不顯示」，畫面上沒有任何金額 |
 | T4-8 | 每張卡 | 有「可提供 N〈單位〉」綠膠囊；**沒有到期倒數**（2026-08-01 從卡片拿掉，剩餘時間只在詳情頁） |
 | T4-9 | 沒有商品圖的 SKU | 暖色品牌底 + 箱子圖示，不是灰底破圖 |
@@ -150,7 +161,8 @@ LIFF 直送要三件事同時成立：`NEXT_PUBLIC_LIFF_ID` 有設（Vercel）�
 | T7-4 | `my_store_line_oa_id` | 只回會員自己店那一間；**不能出現釋出店的 LINE@** |
 | T7-5 | 商品有多張圖 | 可左右滑，底部有頁碼點 |
 | T7-6 | 商品沒有圖 | 品牌底 + 線稿箱子，不是破圖 |
-| T7-7 | 商品有 `products.description` | 顯示「商品說明」區塊；沒有就整塊不出現 |
+| T7-7 | 商品有說明 | 顯示「商品說明」區塊：上架時有改寫 → 顯示改寫版（`spot_description`）；沒改 → fallback 商品主檔原文；兩者皆無 → 整塊不出現 |
+| T7-17 | 詳情頁價格（釋出價低於原價） | 大字 `$149` 旁有刪除線 `~~$199~~`；LINE 詢問訊息帶的金額是 **149**（釋出價） |
 | T7-16 | **商品說明的排版（重點）** | 後台 TipTap 存的是 HTML。畫面上**不能出現 `<p>` `<br>` `</p>` 這種標籤字樣**，段落要正常換行（走 `cleanCampaignText`，同 `/shop/c/[id]`） |
 | T7-8 | 底部提示文字 | 本店寫「數量有限，先問先得」；跨店寫「由店家幫你調貨」 |
 | T7-9 | tab bar | 詳情頁**隱藏** tab bar（底部是詢問列，會打架）；回到 `/spot` 列表後 tab bar 回來 |

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -347,7 +347,7 @@ async function listSpotProducts(
   const { data: rows, error } = await sb
     .from("mutual_aid_board")
     .select(
-      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, images))",
+      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, spot_price, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, images))",
     )
     .eq("tenant_id", tenantId)
     .eq("post_type", "offer")
@@ -411,8 +411,17 @@ async function listSpotProducts(
     const rawImg = Array.isArray(imgs) && imgs.length > 0
       ? (typeof imgs[0] === "string" ? imgs[0] : imgs[0]?.url ?? null)
       : null;
-    const price = isMyStore && r.source_customer_order_id != null
+    // 原價 = 來源訂單單價；釋出價 = 店家上架時自訂的 spot_price（沒填就用原價）。
+    // 釋出價低於原價才回 original_price（會員端據此畫刪除線）；跨店兩者皆 null。
+    const original = isMyStore && r.source_customer_order_id != null
       ? priceMap.get(`${r.source_customer_order_id}:${r.sku_id}`) ?? null
+      : null;
+    const spot = r.spot_price != null && Number.isFinite(Number(r.spot_price))
+      ? Number(r.spot_price)
+      : null;
+    const price = isMyStore ? (spot ?? original) : null;
+    const originalPrice = isMyStore && spot != null && original != null && original > spot
+      ? original
       : null;
     return {
       id: Number(r.id),
@@ -427,7 +436,8 @@ async function listSpotProducts(
       qty_remaining: Number(r.qty_remaining ?? 0),
       expires_at: r.expires_at,
       is_my_store: isMyStore,
-      unit_price: isMyStore ? price : null,
+      unit_price: price,
+      original_price: originalPrice,
     };
   });
 
@@ -465,7 +475,7 @@ async function getSpotProduct(
   const { data: r, error } = await sb
     .from("mutual_aid_board")
     .select(
-      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, description, images))",
+      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, spot_price, spot_description, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, description, images))",
     )
     .eq("tenant_id", tenantId)
     .eq("id", boardId)
@@ -496,18 +506,29 @@ async function getSpotProduct(
     }
   }
 
+  // 原價 = 來源訂單單價；釋出價 = spot_price 優先。低於原價才回 original_price
+  // （刪除線用）。跨店連查都不查，兩者皆 null —— 同列表的金額隱藏規則。
+  let originalPrice: number | null = null;
   let unitPrice: number | null = null;
-  if (isMyStore && r.source_customer_order_id != null) {
-    const { data: it } = await sb
-      .from("customer_order_items")
-      .select("unit_price")
-      .eq("tenant_id", tenantId)
-      .eq("order_id", r.source_customer_order_id)
-      .eq("sku_id", r.sku_id)
-      .limit(1)
-      .maybeSingle();
-    const p = Number(it?.unit_price);
-    unitPrice = Number.isFinite(p) ? p : null;
+  if (isMyStore) {
+    let original: number | null = null;
+    if (r.source_customer_order_id != null) {
+      const { data: it } = await sb
+        .from("customer_order_items")
+        .select("unit_price")
+        .eq("tenant_id", tenantId)
+        .eq("order_id", r.source_customer_order_id)
+        .eq("sku_id", r.sku_id)
+        .limit(1)
+        .maybeSingle();
+      const p = Number(it?.unit_price);
+      original = Number.isFinite(p) ? p : null;
+    }
+    const spot = r.spot_price != null && Number.isFinite(Number(r.spot_price))
+      ? Number(r.spot_price)
+      : null;
+    unitPrice = spot ?? original;
+    originalPrice = spot != null && original != null && original > spot ? original : null;
   }
 
   const supabaseUrl = requireEnv("SUPABASE_URL");
@@ -528,7 +549,8 @@ async function getSpotProduct(
       sku_code: r.sku?.sku_code ?? null,
       product_name: r.sku?.product_name ?? r.sku?.product?.name ?? null,
       variant_name: r.sku?.variant_name ?? null,
-      description: r.sku?.product?.description ?? null,
+      // 上架時改寫的說明優先；沒改就 fallback 回商品主檔
+      description: r.spot_description ?? r.sku?.product?.description ?? null,
       unit: r.sku?.base_unit ?? null,
       image_url: images[0] ?? null,
       images,
@@ -537,7 +559,8 @@ async function getSpotProduct(
       qty_remaining: Number(r.qty_remaining ?? 0),
       expires_at: r.expires_at,
       is_my_store: isMyStore,
-      unit_price: isMyStore ? unitPrice : null,
+      unit_price: unitPrice,
+      original_price: originalPrice,
     },
     my_store_id: myStoreId,
     my_store_name: myStoreName,

--- a/supabase/migrations/20260802000000_aid_board_spot_price_description.sql
+++ b/supabase/migrations/20260802000000_aid_board_spot_price_description.sql
@@ -1,0 +1,142 @@
+-- ============================================================
+-- 2026-08-02: 互助板 offer 可自訂釋出單價與商品說明
+--
+-- 需求（會員端現貨專區）：
+--   1. 店家上架「我有庫存可提供」時可以改金額。App 顯示改後的價；
+--      改得比原價（來源訂單 customer_order_items.unit_price）低時，
+--      App 用刪除線顯示原價，代表比原價便宜。
+--   2. 商品說明可以改寫原文（預設帶入 products.description，可編輯）。
+--      App 詳情頁顯示改寫版，沒改就 fallback 回商品主檔的說明。
+--
+-- 變動：
+--   1. mutual_aid_board 加 spot_price / spot_description（都可 NULL =
+--      沒改，讀取端 fallback 回原價 / 原說明）
+--   2. rpc_post_aid_board 加 p_spot_price + p_spot_description
+--
+-- 基底版本：20260509000001_mutual_aid_offer_request.sql 的 8 參數版
+--   （已 grep supabase/migrations/ 確認：動過此函式的只有
+--    20260509000000（6 參數初版）與 20260509000001（現行 8 參數版），
+--    本檔基於後者擴寫，原有驗證邏輯一字未改）
+--
+-- 為何 DROP 再 CREATE：參數個數變了（8 → 10）。CREATE OR REPLACE 會多出
+--   overload，之後具名呼叫撞 "function is not unique"。
+--   新參數皆有 DEFAULT，已部署的舊前端具名呼叫 8 參數仍解得到，無空窗。
+--
+-- Rollback（回到 20260509000001 版本）：
+--   DROP FUNCTION IF EXISTS rpc_post_aid_board(
+--     BIGINT, BIGINT, NUMERIC, TIMESTAMPTZ, TEXT, UUID, TEXT, BIGINT, NUMERIC, TEXT);
+--   -- 重跑 20260509000001 的 §2 段落
+--   ALTER TABLE mutual_aid_board DROP COLUMN spot_price, DROP COLUMN spot_description;
+-- ============================================================
+
+ALTER TABLE mutual_aid_board
+  ADD COLUMN spot_price       NUMERIC(18,4) CHECK (spot_price IS NULL OR spot_price > 0),
+  ADD COLUMN spot_description TEXT;
+
+COMMENT ON COLUMN mutual_aid_board.spot_price IS
+  '釋出單價（店家上架時可改）；NULL = 沿用來源訂單原價。'
+  '低於原價時會員端會以刪除線顯示原價。';
+COMMENT ON COLUMN mutual_aid_board.spot_description IS
+  '上架時改寫的商品說明（純文字）；NULL = 會員端 fallback 回 products.description。';
+
+DROP FUNCTION IF EXISTS rpc_post_aid_board(
+  BIGINT, BIGINT, NUMERIC, TIMESTAMPTZ, TEXT, UUID, TEXT, BIGINT);
+
+CREATE OR REPLACE FUNCTION rpc_post_aid_board(
+  p_offering_store_id        BIGINT,
+  p_sku_id                   BIGINT,
+  p_qty_available            NUMERIC,
+  p_expires_at               TIMESTAMPTZ,
+  p_note                     TEXT,
+  p_operator                 UUID,
+  p_post_type                TEXT,
+  p_source_customer_order_id BIGINT,
+  p_spot_price               NUMERIC DEFAULT NULL,
+  p_spot_description         TEXT    DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant_id     UUID;
+  v_board_id      BIGINT;
+  v_order_tenant  UUID;
+  v_order_store   BIGINT;
+BEGIN
+  IF p_post_type NOT IN ('offer', 'request') THEN
+    RAISE EXCEPTION 'p_post_type must be offer or request';
+  END IF;
+  IF p_qty_available IS NULL OR p_qty_available <= 0 THEN
+    RAISE EXCEPTION 'qty_available must be > 0';
+  END IF;
+  IF p_expires_at IS NULL OR p_expires_at <= NOW() THEN
+    RAISE EXCEPTION 'expires_at must be in the future';
+  END IF;
+  -- 自訂價 / 自訂說明只對 offer 有意義（request 是求援，不是上架商品）
+  IF p_spot_price IS NOT NULL THEN
+    IF p_post_type <> 'offer' THEN
+      RAISE EXCEPTION 'spot_price is only valid for offer posts';
+    END IF;
+    IF p_spot_price <= 0 THEN
+      RAISE EXCEPTION 'spot_price must be > 0';
+    END IF;
+  END IF;
+  IF p_spot_description IS NOT NULL AND p_post_type <> 'offer' THEN
+    RAISE EXCEPTION 'spot_description is only valid for offer posts';
+  END IF;
+
+  SELECT tenant_id INTO v_tenant_id FROM stores WHERE id = p_offering_store_id;
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'store % not found', p_offering_store_id;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM skus WHERE id = p_sku_id) THEN
+    RAISE EXCEPTION 'sku % not found', p_sku_id;
+  END IF;
+
+  -- offer 必須帶 source_customer_order_id 且該 order 屬同 tenant、屬發貼店、未轉出
+  IF p_post_type = 'offer' THEN
+    IF p_source_customer_order_id IS NULL THEN
+      RAISE EXCEPTION 'offer post requires p_source_customer_order_id';
+    END IF;
+
+    SELECT tenant_id, pickup_store_id INTO v_order_tenant, v_order_store
+      FROM customer_orders WHERE id = p_source_customer_order_id;
+    IF v_order_tenant IS NULL THEN
+      RAISE EXCEPTION 'customer_order % not found', p_source_customer_order_id;
+    END IF;
+    IF v_order_tenant <> v_tenant_id THEN
+      RAISE EXCEPTION 'cross-tenant order';
+    END IF;
+    IF v_order_store <> p_offering_store_id THEN
+      RAISE EXCEPTION 'order pickup_store_id (%) does not match offering_store_id (%)',
+                       v_order_store, p_offering_store_id;
+    END IF;
+  ELSE
+    -- request：source_customer_order_id 須為 NULL
+    IF p_source_customer_order_id IS NOT NULL THEN
+      RAISE EXCEPTION 'request post must not have source_customer_order_id';
+    END IF;
+  END IF;
+
+  INSERT INTO mutual_aid_board (
+    tenant_id, offering_store_id, sku_id, qty_available, qty_remaining,
+    expires_at, note, status, post_type, source_customer_order_id,
+    spot_price, spot_description,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant_id, p_offering_store_id, p_sku_id, p_qty_available, p_qty_available,
+    p_expires_at, NULLIF(trim(p_note), ''), 'active', p_post_type, p_source_customer_order_id,
+    p_spot_price, NULLIF(trim(p_spot_description), ''),
+    p_operator, p_operator
+  )
+  RETURNING id INTO v_board_id;
+
+  RETURN v_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_post_aid_board(
+  BIGINT, BIGINT, NUMERIC, TIMESTAMPTZ, TEXT, UUID, TEXT, BIGINT, NUMERIC, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION rpc_post_aid_board IS
+  '發起互助貼文；offer 須帶 source_customer_order_id。'
+  '2026-08-02 加 p_spot_price / p_spot_description（僅 offer 可用；NULL = 沿用原價 / 原說明）。';


### PR DESCRIPTION
## 這是什麼

兩個 commit：

1. **上架時**可改「釋出單價」與「商品說明」；改得比原價低時，會員 App 用**刪除線顯示原價**（`$149` ~~$199~~）
2. **發佈後**點開貼文也能繼續改（「✏️ 修改內容」）—— 不用砍掉重發

（#576 merge 時 commit 1 才剛推上、沒被收進 —— 分支已從最新 main 重開。）

---

## 1. 上架表單（`/inventory/mutual-aid` → 我有庫存可提供）

- **釋出單價**：預填來源訂單原價，可改。改低於原價時即時提示「低於原價 ~~$X~~ — App 會用刪除線顯示原價」；填 0/負數擋下；留空 = 沿用原價
- **商品說明**：textarea 預填商品主檔原文（TipTap HTML 轉純文字），可改寫
- **沒改的值一律送 NULL** —— 板上不存複本，之後商品主檔改說明，沒改寫過的貼文自動跟上

## 2. 發佈後編輯（點開貼文 → ✏️ 修改內容）

- 編輯區帶目前值，語意與上架表單一致（空 = 沿用原價；改回原值 = 存 NULL）
- 貼文標頭顯示目前單價，低於原價附刪除線；存檔後標頭同步更新（modal 的 post prop 是父層列表舊資料，列表重抓不會回填，用本地覆蓋）
- **只有 active 的 offer** 有這顆按鈕；已結束/過期/認領光的不開放改歷史
- 會員端 liff-api 每次現查這兩欄 → **改完 App 即時生效**，不用重新部署

## DB（兩支 migration，皆已套線上）

| Migration | 內容 |
|---|---|
| `20260802000000` | `mutual_aid_board` 加 `spot_price`（CHECK > 0）/ `spot_description`；`rpc_post_aid_board` 8 → 10 參數（基於 `20260509000001` 最新版擴寫、DROP+CREATE 防 overload、新參數有 DEFAULT 無空窗；自訂價/說明僅 offer 可帶） |
| `20260802000010` | 新函式 `rpc_update_aid_board_listing`（無歷史版本）：僅 active offer 可改、NULL = 清除自訂回沿用、FOR UPDATE 鎖列避免與認領/關貼併發交錯 |

## App 顯示規則（list + detail 同一套）

| 情境 | `unit_price` | `original_price` |
|---|---|---|
| 沒改價 | 原價 | `null` |
| 改低（199 → 149） | 149 | 199（畫刪除線） |
| 改高（199 → 249） | 249 | `null`（漲價不畫刪除線） |
| **跨店** | `null` | `null`（折扣資訊也是金額，不外流） |

詳情頁說明 = `spot_description ?? products.description`。LINE 詢問訊息帶的金額是釋出價。

## 異動檔案

| 檔案 | 說明 |
|---|---|
| `supabase/migrations/20260802000000_…` / `20260802000010_…` | 新欄位 + 兩支 RPC |
| `supabase/functions/liff-api/index.ts` | spot 價優先、`original_price`、說明 fallback |
| `apps/admin/.../inventory/mutual-aid/page.tsx` | 上架欄位 + ThreadModal 編輯區與標頭單價 |
| `apps/member/src/components/SpotProductCard.tsx` | `original_price` 型別 + 卡片刪除線 |
| `apps/member/src/app/spot/[id]/page.tsx` | 詳情頁刪除線 |
| `docs/PLAN-現貨專區.md` / `docs/TEST-member-spot-zone.md` | 同步；測試加 T1-4~12、T2-15~18、T4-14、T7-17 |

## 已驗證

- 兩支 migration 已套線上；`pg_proc` 僅一支 10 參數 `rpc_post_aid_board`，無 overload
- **Rollback 交易實測**：`rpc_post_aid_board` 舊 8 參數呼叫、新參數寫入含 trim、request 帶價被擋；`rpc_update_aid_board_listing` 改值、清除（NULL 回沿用）、對 cancelled 貼文編輯正確被 RAISE 擋下。全部跑完 rollback，線上零殘留
- `liff-api` 已部署（version 54, ACTIVE）
- member / admin `tsc --noEmit` + `next build` 全過；lint 違規與 main 完全相同（6 條既有，無新增）

## 沒驗證

畫面沒實機看過。合併後照 `docs/TEST-member-spot-zone.md` 走：T1-5（上架改價提示）、**T1-9~12（發佈後編輯、清除回沿用、已結束不能改）**、T4-14 / T7-17（刪除線）、T2-18（**跨店連 `original_price` 也必須是 null**）。