### PR TITLE
feat(admin): 互助貼文點開後可修改釋出單價與商品說明

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -22,6 +22,8 @@ type Post = {
   note: string | null;
   status: "active" | "exhausted" | "expired" | "cancelled";
   source_customer_order_id: number | null;
+  spot_price: number | null;
+  spot_description: string | null;
   created_at: string;
   created_by: string | null;
   store_name?: string;
@@ -127,7 +129,7 @@ export default function MutualAidPage() {
         const sb = getSupabase();
         let q = sb
           .from("mutual_aid_board")
-          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, status, source_customer_order_id, created_at, created_by")
+          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, status, source_customer_order_id, spot_price, spot_description, created_at, created_by")
           .eq("status", "active")
           .order("created_at", { ascending: false })
           .limit(200);
@@ -297,6 +299,7 @@ export default function MutualAidPage() {
         <ThreadModal
           post={threadPost}
           stores={stores}
+          onEdited={() => reloadAndRefreshBadge()}
           onClose={() => setThreadPost(null)}
           onClosed={() => {
             setThreadPost(null);
@@ -853,12 +856,14 @@ function OfferModal({
 // Thread Modal
 // ============================================================
 function ThreadModal({
-  post, stores, onClose, onClosed,
+  post, stores, onClose, onClosed, onEdited,
 }: {
   post: Post;
   stores: Store[];
   onClose: () => void;
   onClosed: () => void;
+  /** 編輯單價/說明存檔後呼叫（父層重抓列表；modal 留在原地） */
+  onEdited: () => void;
 }) {
   const [replies, setReplies] = useState<Reply[] | null>(null);
   const [body, setBody] = useState("");
@@ -869,6 +874,82 @@ function ThreadModal({
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [claimOpen, setClaimOpen] = useState(false);
   const [fulfillOpen, setFulfillOpen] = useState(false);
+  // 發佈後編輯釋出單價 / 商品說明（僅 offer + active）。
+  // originalPrice / originalDesc 是「沿用值」：原價來自來源訂單、原文來自商品主檔，
+  // 編輯表單要靠它們判斷「改回原值 = 清除自訂」。
+  const [editOpen, setEditOpen] = useState(false);
+  // 存檔後 post prop 還是父層舊資料（列表重抓不會回填 modal），標頭單價用這個本地值蓋
+  const [savedSpotPrice, setSavedSpotPrice] = useState<number | null>(post.spot_price);
+  const [editPrice, setEditPrice] = useState(post.spot_price != null ? String(post.spot_price) : "");
+  const [editDesc, setEditDesc] = useState(post.spot_description ?? "");
+  const [originalPrice, setOriginalPrice] = useState<number | null>(null);
+  const [originalDesc, setOriginalDesc] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
+  const canEdit = post.post_type === "offer" && post.status === "active";
+
+  useEffect(() => {
+    if (!canEdit) return;
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const [priceRes, skuRes] = await Promise.all([
+        post.source_customer_order_id != null
+          ? sb.from("customer_order_items").select("unit_price")
+              .eq("order_id", post.source_customer_order_id).eq("sku_id", post.sku_id)
+              .limit(1).maybeSingle()
+          : Promise.resolve({ data: null }),
+        sb.from("skus").select("product:products(description)").eq("id", post.sku_id).maybeSingle(),
+      ]);
+      if (cancelled) return;
+      const priceN = Number((priceRes.data as { unit_price?: number | string } | null)?.unit_price);
+      setOriginalPrice(Number.isFinite(priceN) ? priceN : null);
+      const productRaw = (skuRes.data as { product?: { description: string | null } | { description: string | null }[] | null } | null)?.product;
+      const product = Array.isArray(productRaw) ? productRaw[0] : productRaw;
+      const desc = stripHtmlToText(product?.description);
+      setOriginalDesc(desc);
+      // 沒有自訂說明時，編輯框預填原文（跟上架表單同一套預填邏輯）
+      if (post.spot_description == null && desc) setEditDesc((cur) => (cur === "" ? desc : cur));
+    })();
+    return () => { cancelled = true; };
+    // post.id 換了整個 modal 會重掛，這裡跑一次就好
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [post.id, canEdit]);
+
+  async function saveEdit() {
+    if (savingEdit) return;
+    setErr(null);
+    const raw = editPrice.trim();
+    let priceN: number | null = null;
+    if (raw !== "") {
+      priceN = Number(raw);
+      if (!Number.isFinite(priceN) || priceN <= 0) { setErr("釋出單價需 > 0（留空 = 沿用原價）"); return; }
+    }
+    // 與原值相同就存 NULL（= 沿用），跟上架表單同語意
+    const spotPriceParam = priceN != null && priceN !== originalPrice ? priceN : null;
+    const descTrim = editDesc.trim();
+    const spotDescParam = descTrim !== "" && descTrim !== originalDesc ? descTrim : null;
+    setSavingEdit(true);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes.user?.id;
+      if (!operator) { setErr("未登入或 session 過期"); return; }
+      const { error: e } = await sb.rpc("rpc_update_aid_board_listing", {
+        p_board_id: post.id,
+        p_operator: operator,
+        p_spot_price: spotPriceParam,
+        p_spot_description: spotDescParam,
+      });
+      if (e) { setErr(e.message); return; }
+      setSavedSpotPrice(spotPriceParam);
+      setEditOpen(false);
+      onEdited();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSavingEdit(false);
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -962,9 +1043,76 @@ function ThreadModal({
             </span>
             <span>到期 <span className="text-zinc-700 dark:text-zinc-300">{fmtDt(post.expires_at)}</span></span>
             <span>發佈 {fmtDt(post.created_at)}</span>
+            {post.post_type === "offer" && (
+              <span>
+                單價{" "}
+                <span className="font-mono text-zinc-700 dark:text-zinc-300">
+                  {savedSpotPrice != null
+                    ? `$${savedSpotPrice}`
+                    : originalPrice != null
+                      ? `$${originalPrice}`
+                      : "沿用原價"}
+                </span>
+                {savedSpotPrice != null && originalPrice != null && originalPrice > savedSpotPrice && (
+                  <s className="ml-1 text-zinc-400">${originalPrice}</s>
+                )}
+              </span>
+            )}
             {post.note && <div className="basis-full pt-1 text-zinc-700 dark:text-zinc-300">「{post.note}」</div>}
           </div>
         </div>
+
+        {/* 發佈後編輯：釋出單價 / 商品說明（僅 offer + active；改完會員端即時生效） */}
+        {canEdit && editOpen && (
+          <div className="flex flex-col gap-2 rounded-md border border-blue-200 bg-blue-50/40 p-3 text-xs dark:border-blue-900 dark:bg-blue-950/20">
+            <label>
+              <span className="mb-1 block text-zinc-500">釋出單價</span>
+              <input
+                value={editPrice}
+                onChange={(e) => setEditPrice(e.target.value)}
+                inputMode="decimal"
+                placeholder="留空 = 原價"
+                className="w-40 rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
+              />
+              {(() => {
+                if (originalPrice == null) return null;
+                const n = Number(editPrice);
+                if (editPrice.trim() !== "" && Number.isFinite(n) && n < originalPrice) {
+                  return (
+                    <span className="ml-2 text-[11px] text-emerald-600 dark:text-emerald-400">
+                      低於原價 <s>${originalPrice.toLocaleString()}</s> — App 會用刪除線顯示原價
+                    </span>
+                  );
+                }
+                return <span className="ml-2 text-[11px] text-zinc-400">原價 ${originalPrice.toLocaleString()}</span>;
+              })()}
+            </label>
+            <label>
+              <span className="mb-1 block text-zinc-500">商品說明（會顯示在會員 App 的商品詳情，可改寫）</span>
+              <textarea
+                value={editDesc}
+                onChange={(e) => setEditDesc(e.target.value)}
+                rows={4}
+                className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+              />
+            </label>
+            <div className="flex justify-end gap-2">
+              <SpinButton
+                onClick={() => setEditOpen(false)}
+                className="rounded border border-zinc-300 px-3 py-1.5 dark:border-zinc-700"
+              >
+                取消
+              </SpinButton>
+              <SpinButton
+                onClick={saveEdit}
+                disabled={savingEdit}
+                className="rounded bg-blue-600 px-3 py-1.5 font-medium text-white hover:bg-blue-500 disabled:opacity-50"
+              >
+                {savingEdit ? "儲存中…" : "儲存修改"}
+              </SpinButton>
+            </div>
+          </div>
+        )}
 
         {/* Replies thread */}
         <div className="flex flex-col gap-2 max-h-80 overflow-y-auto pr-1">
@@ -1020,6 +1168,16 @@ function ThreadModal({
                     title="把釋出店的訂單轉成接收店的（走 5b-1 棄單轉出）"
                   >
                     ✋ 我要認領
+                  </SpinButton>
+                )}
+                {canEdit && !editOpen && (
+                  <SpinButton
+                    type="button"
+                    onClick={() => setEditOpen(true)}
+                    className="rounded-md border border-blue-400 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
+                    title="修改釋出單價 / 商品說明（會員端即時生效）"
+                  >
+                    ✏️ 修改內容
                   </SpinButton>
                 )}
                 {post.post_type === "request" && (

--- a/docs/PLAN-現貨專區.md
+++ b/docs/PLAN-現貨專區.md
@@ -204,8 +204,8 @@ tab active 判斷是 `pathname.startsWith(t.href)`。所以現貨專區**必須�
 | `apps/admin/src/app/(protected)/stores/page.tsx` | 改 | 表單加「LINE@ ID」欄位（寫 `line_oa_basic_id`），含 `Store` type 與存檔路徑 |
 | `apps/member/.env` / Vercel | 設定 | 加 `NEXT_PUBLIC_LINE_OA_ID` |
 | `docs/TEST-member-released-products.md` | 改名 | → `docs/TEST-member-spot-zone.md`，內容同步 |
-
 | `supabase/migrations/20260802000000_aid_board_spot_price_description.sql` | 新增 | `mutual_aid_board` 加 `spot_price` / `spot_description`；`rpc_post_aid_board` 8 → 10 參數（DROP+CREATE，新參數有 DEFAULT 無空窗） |
+| `supabase/migrations/20260802000010_rpc_update_aid_board_listing.sql` | 新增 | 發佈後編輯：`rpc_update_aid_board_listing`（僅 active offer；NULL = 清除自訂回到沿用）。互助板點開貼文 →「✏️ 修改內容」 |
 | `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` | 改 | 「我有庫存可提供」表單加「釋出單價」（預填原價，可改；低於原價有提示）與「商品說明」textarea（預填原文純文字，可改寫）；沒改的值送 NULL |
 
 店家操作照舊：按「我有庫存可提供」發貼文，會員端就自動看得到；價格與說明想改才改。

--- a/docs/TEST-member-spot-zone.md
+++ b/docs/TEST-member-spot-zone.md
@@ -47,6 +47,10 @@
 | T1-6 | 單價填 0 / 負數 | 擋下「釋出單價需 > 0（留空 = 沿用原價）」 |
 | T1-7 | 單價留空 or 沒動、說明沒動 | 送出後 `mutual_aid_board.spot_price` / `spot_description` 為 `NULL`（= 沿用原值，不是存一份複本） |
 | T1-8 | SQL 直呼 `rpc_post_aid_board` 用 `p_post_type='request'` 帶 `p_spot_price` | 炸 `spot_price is only valid for offer posts` |
+| T1-9 | **發佈後編輯**：點開自己店的 offer 貼文 → 「✏️ 修改內容」 | 出現編輯區：單價（帶目前值或空 = 沿用原價，含原價提示）＋商品說明（帶改寫版或原文）；標頭顯示目前單價，低於原價時旁邊有刪除線原價 |
+| T1-10 | 改單價存檔 → 會員 App 重新整理 | App 立刻顯示新價（讀取端每次現查，不用重發貼文）；標頭單價同步更新 |
+| T1-11 | 把單價清空存檔 | `spot_price` 回 `NULL` = 沿用原價；App 回到顯示原價、無刪除線 |
+| T1-12 | 對已結束（cancelled / expired / exhausted）的貼文 | 沒有「修改內容」按鈕；SQL 直呼 `rpc_update_aid_board_listing` 會炸 `only active posts can be edited` |
 | T1-2 | 同上用 B 店再發一則（挑不同 SKU 好辨識） | 貼文成立 |
 | T1-3 | `SELECT id, post_type, status, offering_store_id, sku_id, qty_remaining, expires_at FROM mutual_aid_board WHERE post_type='offer' AND status='active';` | 兩筆，`expires_at` 在未來、`qty_remaining > 0` |
 

--- a/supabase/migrations/20260802000010_rpc_update_aid_board_listing.sql
+++ b/supabase/migrations/20260802000010_rpc_update_aid_board_listing.sql
@@ -1,0 +1,64 @@
+-- ============================================================
+-- 2026-08-02: 互助貼文發佈後仍可改釋出單價 / 商品說明
+--
+-- 需求：admin 互助板點開貼文（ThreadModal）後要能編輯 spot_price /
+--       spot_description（欄位由 20260802000000 引入），不用砍掉重發。
+--       會員端 liff-api 讀取時本來就是每次現查這兩欄，改完即時生效。
+--
+-- rpc_update_aid_board_listing 為新函式，無歷史版本
+-- （已 grep supabase/migrations/ 確認）。
+--
+-- 語意：兩個參數都是「這次要存成什麼」——
+--   NULL = 清除自訂值，回到沿用原價 / 商品主檔原文。
+--   前端每次送出完整狀態，不做部分更新（欄位就兩個，不值得引入
+--   sentinel 區分「不動」與「清除」）。
+--
+-- 限制：只有 post_type='offer' 且 status='active' 能改。
+--   到期/認領光/取消的貼文會員端本來就看不到，不開放改歷史紀錄。
+--
+-- Rollback：DROP FUNCTION public.rpc_update_aid_board_listing(BIGINT, UUID, NUMERIC, TEXT);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_update_aid_board_listing(
+  p_board_id         BIGINT,
+  p_operator         UUID,
+  p_spot_price       NUMERIC DEFAULT NULL,
+  p_spot_description TEXT    DEFAULT NULL
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_post_type TEXT;
+  v_status    TEXT;
+BEGIN
+  IF p_spot_price IS NOT NULL AND p_spot_price <= 0 THEN
+    RAISE EXCEPTION 'spot_price must be > 0';
+  END IF;
+
+  SELECT post_type, status INTO v_post_type, v_status
+    FROM mutual_aid_board WHERE id = p_board_id
+    FOR UPDATE;
+  IF v_post_type IS NULL THEN
+    RAISE EXCEPTION 'board post % not found', p_board_id;
+  END IF;
+  IF v_post_type <> 'offer' THEN
+    RAISE EXCEPTION 'only offer posts have price/description';
+  END IF;
+  IF v_status <> 'active' THEN
+    RAISE EXCEPTION 'post is % — only active posts can be edited', v_status;
+  END IF;
+
+  UPDATE mutual_aid_board
+     SET spot_price       = p_spot_price,
+         spot_description = NULLIF(trim(p_spot_description), ''),
+         updated_by       = p_operator
+   WHERE id = p_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_update_aid_board_listing(BIGINT, UUID, NUMERIC, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_update_aid_board_listing IS
+  '互助板 offer 貼文發佈後編輯釋出單價 / 商品說明。NULL = 清除自訂值'
+  '（回到沿用原價 / 商品主檔原文）。僅 active 的 offer 可改。';


### PR DESCRIPTION
## 這是什麼

#577 只能在**上架當下**改價/改說明，貼文發出去就鎖死了。現在點開貼文（互助板 → 貼文詳情 modal）→「**✏️ 修改內容**」可以繼續改。

（#577 merge 時這個 commit 才剛推上、沒被收進 —— 分支已從最新 main 重開，本 PR 只含這一個 commit。）

## 後台操作

貼文詳情 modal 的按鈕列多一顆「✏️ 修改內容」（在「我要認領」旁），**只有 active 的 offer 才有**。展開後：

- **釋出單價**：帶目前值，空 = 沿用原價；旁邊顯示「原價 $X」，改低於原價時變綠色提示「低於原價 ~~$X~~ — App 會用刪除線顯示原價」
- **商品說明**：帶改寫版；沒改寫過就帶商品主檔原文（HTML 轉純文字）
- 語意與上架表單一致：**改回跟原值一樣就存 NULL**，板上不留複本

貼文標頭也多顯示目前單價（有折扣時附刪除線原價）。存檔後標頭用本地值同步更新 —— modal 的 `post` prop 是父層列表的舊資料，列表重抓不會回填 modal。

**改完會員端即時生效**：liff-api 每次請求現查這兩欄，不用重發貼文、不用重新部署函式。

## DB（migration `20260802000010`）

新函式 `rpc_update_aid_board_listing`（已 grep 確認無歷史版本）。限制寫在 DB 層：

- 只有 `post_type='offer'` 且 `status='active'` 能改 —— 已結束/過期/認領光的不開放改歷史紀錄
- `spot_price` 必須 > 0；兩個參數 `NULL` = 清除自訂值，回到沿用原價 / 商品主檔原文
- `FOR UPDATE` 鎖列，避免與認領、關貼併發交錯

## 異動檔案

| 檔案 | 說明 |
|---|---|
| `supabase/migrations/20260802000010_rpc_update_aid_board_listing.sql` | 新 RPC |
| `apps/admin/.../inventory/mutual-aid/page.tsx` | `Post` 型別與列表 select 帶 `spot_price` / `spot_description`；ThreadModal 加編輯區、標頭單價、`onEdited` 回呼 |
| `docs/PLAN-現貨專區.md` / `docs/TEST-member-spot-zone.md` | 同步；測試加 T1-9~12 |

會員端程式碼完全沒動（顯示邏輯 #577 已經做好）。

## 已驗證

- Migration 已套線上
- **Rollback 交易實測**三種情境：改值（含前後空白 trim）、清除（`NULL` 回沿用）、對 `cancelled` 貼文編輯正確被 RAISE 擋下（`only active posts can be edited`）。跑完 rollback，線上零殘留
- 重開分支後 admin `tsc --noEmit` + `next build` 重新驗過；lint 違規數與 main 相同（6 條既有，無新增）

## 沒驗證

畫面沒實機看過。合併後照 `docs/TEST-member-spot-zone.md` 走 **T1-9~12**：編輯區帶值正確、改價存檔後 App 重整即時反映、清空回沿用原價、已結束貼文沒有按鈕。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DetXFF67eZbpESvKssoeXz)_