### PR TITLE
feat(admin): 互助貼文編輯區加「到期時間」

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -385,6 +385,13 @@ function SkuSearchInput({
   );
 }
 
+/** ISO timestamp → <input type="datetime-local"> 需要的本地時間字串 */
+function toLocalInput(iso: string): string {
+  const d = new Date(iso);
+  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+  return d.toISOString().slice(0, 16);
+}
+
 function defaultExpiresAt() {
   const d = new Date(Date.now() + 7 * 86400_000);
   d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
@@ -882,6 +889,9 @@ function ThreadModal({
   const [savedSpotPrice, setSavedSpotPrice] = useState<number | null>(post.spot_price);
   const [editPrice, setEditPrice] = useState(post.spot_price != null ? String(post.spot_price) : "");
   const [editDesc, setEditDesc] = useState(post.spot_description ?? "");
+  const [editExpiresAt, setEditExpiresAt] = useState(() => toLocalInput(post.expires_at));
+  // 存檔後 post prop 仍是父層舊資料，標頭到期時間用本地值蓋
+  const [savedExpiresAt, setSavedExpiresAt] = useState(post.expires_at);
   const [originalPrice, setOriginalPrice] = useState<number | null>(null);
   const [originalDesc, setOriginalDesc] = useState("");
   const [savingEdit, setSavingEdit] = useState(false);
@@ -928,6 +938,9 @@ function ThreadModal({
     const spotPriceParam = priceN != null && priceN !== originalPrice ? priceN : null;
     const descTrim = editDesc.trim();
     const spotDescParam = descTrim !== "" && descTrim !== originalDesc ? descTrim : null;
+    const expDate = new Date(editExpiresAt);
+    if (Number.isNaN(expDate.getTime())) { setErr("到期時間格式不正確"); return; }
+    if (expDate <= new Date()) { setErr("到期時間需在未來（要立刻下架請用「結束此貼」）"); return; }
     setSavingEdit(true);
     try {
       const sb = getSupabase();
@@ -939,9 +952,11 @@ function ThreadModal({
         p_operator: operator,
         p_spot_price: spotPriceParam,
         p_spot_description: spotDescParam,
+        p_expires_at: expDate.toISOString(),
       });
       if (e) { setErr(e.message); return; }
       setSavedSpotPrice(spotPriceParam);
+      setSavedExpiresAt(expDate.toISOString());
       setEditOpen(false);
       onEdited();
     } catch (e) {
@@ -1041,7 +1056,7 @@ function ThreadModal({
                 <span className="ml-1 text-[10px] text-zinc-400">/ 原 {post.qty_available}</span>
               )}
             </span>
-            <span>到期 <span className="text-zinc-700 dark:text-zinc-300">{fmtDt(post.expires_at)}</span></span>
+            <span>到期 <span className="text-zinc-700 dark:text-zinc-300">{fmtDt(savedExpiresAt)}</span></span>
             <span>發佈 {fmtDt(post.created_at)}</span>
             {post.post_type === "offer" && (
               <span>
@@ -1086,6 +1101,18 @@ function ThreadModal({
                 }
                 return <span className="ml-2 text-[11px] text-zinc-400">原價 ${originalPrice.toLocaleString()}</span>;
               })()}
+            </label>
+            <label>
+              <span className="mb-1 block text-zinc-500">到期時間</span>
+              <input
+                type="datetime-local"
+                value={editExpiresAt}
+                onChange={(e) => setEditExpiresAt(e.target.value)}
+                className="rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+              />
+              <span className="ml-2 text-[11px] text-zinc-400">
+                到期後會員端自動下架；要立刻收回請用「結束此貼」
+              </span>
             </label>
             <label>
               <span className="mb-1 block text-zinc-500">商品說明（會顯示在會員 App 的商品詳情，可改寫）</span>

--- a/docs/PLAN-現貨專區.md
+++ b/docs/PLAN-現貨專區.md
@@ -206,6 +206,7 @@ tab active 判斷是 `pathname.startsWith(t.href)`。所以現貨專區**必須�
 | `docs/TEST-member-released-products.md` | 改名 | → `docs/TEST-member-spot-zone.md`，內容同步 |
 | `supabase/migrations/20260802000000_aid_board_spot_price_description.sql` | 新增 | `mutual_aid_board` 加 `spot_price` / `spot_description`；`rpc_post_aid_board` 8 → 10 參數（DROP+CREATE，新參數有 DEFAULT 無空窗） |
 | `supabase/migrations/20260802000010_rpc_update_aid_board_listing.sql` | 新增 | 發佈後編輯：`rpc_update_aid_board_listing`（僅 active offer；NULL = 清除自訂回到沿用）。互助板點開貼文 →「✏️ 修改內容」 |
+| `supabase/migrations/20260802000020_aid_listing_edit_expires_at.sql` | 新增 | 上面那支加 `p_expires_at`（4 → 5 參數）。⚠ 它的 NULL 語意與另兩個相反：`expires_at` 是 NOT NULL 欄位，NULL = 不動；且不得設到過去（要立刻下架請用「結束此貼」） |
 | `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` | 改 | 「我有庫存可提供」表單加「釋出單價」（預填原價，可改；低於原價有提示）與「商品說明」textarea（預填原文純文字，可改寫）；沒改的值送 NULL |
 
 店家操作照舊：按「我有庫存可提供」發貼文，會員端就自動看得到；價格與說明想改才改。

--- a/docs/TEST-member-spot-zone.md
+++ b/docs/TEST-member-spot-zone.md
@@ -47,10 +47,13 @@
 | T1-6 | 單價填 0 / 負數 | 擋下「釋出單價需 > 0（留空 = 沿用原價）」 |
 | T1-7 | 單價留空 or 沒動、說明沒動 | 送出後 `mutual_aid_board.spot_price` / `spot_description` 為 `NULL`（= 沿用原值，不是存一份複本） |
 | T1-8 | SQL 直呼 `rpc_post_aid_board` 用 `p_post_type='request'` 帶 `p_spot_price` | 炸 `spot_price is only valid for offer posts` |
-| T1-9 | **發佈後編輯**：點開自己店的 offer 貼文 → 「✏️ 修改內容」 | 出現編輯區：單價（帶目前值或空 = 沿用原價，含原價提示）＋商品說明（帶改寫版或原文）；標頭顯示目前單價，低於原價時旁邊有刪除線原價 |
+| T1-9 | **發佈後編輯**：點開自己店的 offer 貼文 → 「✏️ 修改內容」 | 出現編輯區：單價（帶目前值或空 = 沿用原價，含原價提示）＋**到期時間**（帶目前值）＋商品說明（帶改寫版或原文）；標頭顯示目前單價與到期時間 |
 | T1-10 | 改單價存檔 → 會員 App 重新整理 | App 立刻顯示新價（讀取端每次現查，不用重發貼文）；標頭單價同步更新 |
 | T1-11 | 把單價清空存檔 | `spot_price` 回 `NULL` = 沿用原價；App 回到顯示原價、無刪除線 |
 | T1-12 | 對已結束（cancelled / expired / exhausted）的貼文 | 沒有「修改內容」按鈕；SQL 直呼 `rpc_update_aid_board_listing` 會炸 `only active posts can be edited` |
+| T1-13 | **改到期時間**（延長或縮短）存檔 | 標頭「到期」即時更新；會員端 `/spot` 該筆的下架時間跟著變 |
+| T1-14 | 到期時間設到**過去** | 擋下「到期時間需在未來（要立刻下架請用「結束此貼」）」；SQL 直呼也會炸 `expires_at must be in the future` |
+| T1-15 | 只改單價、不動到期 | 到期時間維持原值（前端一律帶值；SQL 層 `p_expires_at=NULL` 也是不動該欄） |
 | T1-2 | 同上用 B 店再發一則（挑不同 SKU 好辨識） | 貼文成立 |
 | T1-3 | `SELECT id, post_type, status, offering_store_id, sku_id, qty_remaining, expires_at FROM mutual_aid_board WHERE post_type='offer' AND status='active';` | 兩筆，`expires_at` 在未來、`qty_remaining > 0` |
 

--- a/supabase/migrations/20260802000020_aid_listing_edit_expires_at.sql
+++ b/supabase/migrations/20260802000020_aid_listing_edit_expires_at.sql
@@ -1,0 +1,82 @@
+-- ============================================================
+-- 2026-08-02: 互助貼文發佈後也能改到期時間
+--
+-- 需求：admin 互助板點開貼文 →「✏️ 修改內容」除了單價 / 商品說明，
+--       到期日也要能改（例如貨還在、想延長曝光；或提早收回）。
+--
+-- 變動：rpc_update_aid_board_listing 加 p_expires_at。
+--
+-- 基底版本：20260802000010_rpc_update_aid_board_listing.sql
+--   （已 grep supabase/migrations/ 確認：那是唯一動過此函式的 migration，
+--    本檔基於它擴寫，原有的 offer/active 檢查與 NULL 語意一字未改）
+--
+-- ⚠ p_expires_at 的 NULL 語意和另外兩個參數**不同**：
+--   spot_price / spot_description 的 NULL = 清除自訂值（回沿用原價 / 原文）；
+--   expires_at 是 NOT NULL 欄位、沒有「沿用」的概念 → NULL = 不動它。
+--   前端一律會帶值，這個分支只是防呆。
+--
+-- 為何 DROP 再 CREATE：參數個數變了（4 → 5），CREATE OR REPLACE 會多出
+--   overload，之後具名呼叫撞 "function is not unique"。
+--   新參數有 DEFAULT，已部署的舊前端送 4 個具名參數仍解得到，無空窗。
+--
+-- Rollback：
+--   DROP FUNCTION IF EXISTS public.rpc_update_aid_board_listing(
+--     BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ);
+--   -- 重跑 20260802000010 整支
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.rpc_update_aid_board_listing(BIGINT, UUID, NUMERIC, TEXT);
+
+CREATE OR REPLACE FUNCTION public.rpc_update_aid_board_listing(
+  p_board_id         BIGINT,
+  p_operator         UUID,
+  p_spot_price       NUMERIC     DEFAULT NULL,
+  p_spot_description TEXT        DEFAULT NULL,
+  p_expires_at       TIMESTAMPTZ DEFAULT NULL
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_post_type TEXT;
+  v_status    TEXT;
+BEGIN
+  IF p_spot_price IS NOT NULL AND p_spot_price <= 0 THEN
+    RAISE EXCEPTION 'spot_price must be > 0';
+  END IF;
+  -- 到期時間可以往後延，也可以縮短，但不能設到過去
+  -- （設到過去等於立刻下架，那是「結束此貼」該做的事，語意分開）
+  IF p_expires_at IS NOT NULL AND p_expires_at <= NOW() THEN
+    RAISE EXCEPTION 'expires_at must be in the future';
+  END IF;
+
+  SELECT post_type, status INTO v_post_type, v_status
+    FROM mutual_aid_board WHERE id = p_board_id
+    FOR UPDATE;
+  IF v_post_type IS NULL THEN
+    RAISE EXCEPTION 'board post % not found', p_board_id;
+  END IF;
+  IF v_post_type <> 'offer' THEN
+    RAISE EXCEPTION 'only offer posts have price/description';
+  END IF;
+  IF v_status <> 'active' THEN
+    RAISE EXCEPTION 'post is % — only active posts can be edited', v_status;
+  END IF;
+
+  UPDATE mutual_aid_board
+     SET spot_price       = p_spot_price,
+         spot_description = NULLIF(trim(p_spot_description), ''),
+         -- NULL = 不動（expires_at 是 NOT NULL，沒有「清除」的語意）
+         expires_at       = COALESCE(p_expires_at, expires_at),
+         updated_by       = p_operator
+   WHERE id = p_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_update_aid_board_listing(
+  BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_update_aid_board_listing IS
+  '互助板 offer 貼文發佈後編輯釋出單價 / 商品說明 / 到期時間。'
+  'spot_price、spot_description 的 NULL = 清除自訂值（回沿用原價 / 商品主檔原文）；'
+  'expires_at 的 NULL = 不動（該欄 NOT NULL），且不得設到過去。僅 active 的 offer 可改。';


### PR DESCRIPTION
## 這是什麼

#578 的「✏️ 修改內容」只能改單價和商品說明，**到期日發出去就固定了** —— 貨還在想延長曝光、或想提早收，都做不到。現在同一個編輯區可以一起改。

## 後台

貼文詳情 modal →「✏️ 修改內容」，編輯區在「釋出單價」和「商品說明」之間多一個 **到期時間**（`datetime-local`，帶目前值）。存檔後貼文標頭的「到期」即時更新。

**不能設到過去**：要立刻下架是「結束此貼」的職責，語意分開。前端擋一次、DB 再擋一次。

## DB（migration `20260802000020`）

`rpc_update_aid_board_listing` 4 → 5 參數，基於 `20260802000010` 擴寫（已 grep 確認那是唯一動過此函式的 migration）。DROP+CREATE 防 overload；新參數有 DEFAULT，已部署的舊前端送 4 個具名參數仍解得到，**無空窗**。

### ⚠ `p_expires_at` 的 NULL 語意刻意與另外兩個相反

| 參數 | NULL 的意思 |
|---|---|
| `p_spot_price` / `p_spot_description` | **清除自訂值**，回到沿用原價 / 商品主檔原文 |
| `p_expires_at` | **不動它**（`expires_at` 是 NOT NULL 欄位，沒有「沿用」的概念，用 `COALESCE` 保留原值） |

前端一律會帶值，這個分支只是防呆 + 讓舊呼叫不會誤把到期日弄掉。

## 異動檔案

| 檔案 | 說明 |
|---|---|
| `supabase/migrations/20260802000020_aid_listing_edit_expires_at.sql` | RPC 加 `p_expires_at` |
| `apps/admin/.../inventory/mutual-aid/page.tsx` | 編輯區加到期欄位、`toLocalInput` helper、標頭到期本地同步 |
| `docs/PLAN-現貨專區.md` / `docs/TEST-member-spot-zone.md` | 同步；測試加 T1-13~15 |

會員端沒動 —— 到期後自動下架是既有行為（`expires_at > now()` 過濾 + cron purge）。

## 已驗證

- Migration 已套線上；`pg_proc` 僅一支 5 參數版，無 overload
- **Rollback 交易實測**三種情境：延長到期成功、**舊 4 參數具名呼叫仍可用且不會誤動 `expires_at`**、設到過去被 RAISE 擋下（`expires_at must be in the future`）。跑完 rollback，線上零殘留
- admin `tsc --noEmit` + `next build` 過

## 順帶回報

查驗殘留時發現線上已經有一筆 `spot_price=100` + 改寫過的商品說明（板上 id 50、松山店），`updated_by` 是你的帳號 —— **前面的改價功能在正式環境已經跑起來了**，不是我的測試資料。

## 沒驗證

畫面沒實機看過。合併後照 `docs/TEST-member-spot-zone.md` 走 **T1-13~15**：改到期存檔後標頭更新、設到過去被擋、只改單價時到期不變。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DetXFF67eZbpESvKssoeXz)_