### PR TITLE
feat(spot): 互助 offer 可自訂商品標題（上架時填、發佈後可改）

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -24,6 +24,7 @@ type Post = {
   source_customer_order_id: number | null;
   spot_price: number | null;
   spot_description: string | null;
+  spot_title: string | null;
   created_at: string;
   created_by: string | null;
   store_name?: string;
@@ -39,7 +40,17 @@ type PendingOrder = {
   status: string;
   member_name: string | null;
   member_phone: string | null;
-  items: { campaign_item_id: number | null; sku_id: number | null; qty: number; sku_label: string; unit_price: number | null; product_description: string | null }[];
+  items: {
+    campaign_item_id: number | null;
+    sku_id: number | null;
+    qty: number;
+    sku_label: string;
+    /** 會員 App 沒有自訂標題時會組出的字串（product_name／variant_name）。
+     *  上架表單拿它當「商品標題」的預設值，店家沒動就不寫進 spot_title。 */
+    default_title: string;
+    unit_price: number | null;
+    product_description: string | null;
+  }[];
 };
 
 type Reply = {
@@ -129,7 +140,7 @@ export default function MutualAidPage() {
         const sb = getSupabase();
         let q = sb
           .from("mutual_aid_board")
-          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, status, source_customer_order_id, spot_price, spot_description, created_at, created_by")
+          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, status, source_customer_order_id, spot_price, spot_description, spot_title, created_at, created_by")
           .eq("status", "active")
           .order("created_at", { ascending: false })
           .limit(200);
@@ -546,8 +557,9 @@ function OfferModal({
   const [qty, setQty] = useState("");
   const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
   const [note, setNote] = useState("");
-  // 釋出單價與商品說明：預填來源訂單原價 / 商品主檔原文，店家可改。
-  // 價低於原價時會員端會以刪除線顯示原價。
+  // 商品標題 / 釋出單價 / 商品說明：預填 SKU 組出的標題、來源訂單原價、
+  // 商品主檔原文，店家可改。價低於原價時會員端會以刪除線顯示原價。
+  const [spotTitle, setSpotTitle] = useState("");
   const [spotPrice, setSpotPrice] = useState("");
   const [spotDesc, setSpotDesc] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -556,7 +568,7 @@ function OfferModal({
   useEffect(() => {
     if (open) {
       setStoreId(""); setOrders(null); setOrderSearch(""); setPickedOrder(null); setPickedItemIdx(0);
-      setQty(""); setNote(""); setSpotPrice(""); setSpotDesc(""); setErr(null);
+      setQty(""); setNote(""); setSpotTitle(""); setSpotPrice(""); setSpotDesc(""); setErr(null);
       setExpiresAt(defaultExpiresAt());
     }
   }, [open]);
@@ -612,6 +624,10 @@ function OfferModal({
                 sku_label: sku
                   ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} (${sku.sku_code})`
                   : `品項#${it.sku_id}`,
+                // 和會員端 spotProductTitle() 的組法一字不差（全形／、不含 sku_code）
+                default_title: sku
+                  ? `${sku.product_name}${sku.variant_name ? `／${sku.variant_name}` : ""}`
+                  : `品項#${it.sku_id}`,
                 unit_price: Number.isFinite(priceN) ? priceN : null,
                 product_description: product?.description ?? null,
               };
@@ -623,11 +639,12 @@ function OfferModal({
     return () => { cancelled = true; };
   }, [open, storeId]);
 
-  // 選了訂單 → 自動帶該 item 的數量、原價、商品說明（後兩者可改）
+  // 選了訂單 → 自動帶該 item 的數量、標題、原價、商品說明（後三者可改）
   useEffect(() => {
     const item = pickedOrder?.items[pickedItemIdx];
     if (item) {
       setQty(String(item.qty));
+      setSpotTitle(item.default_title);
       setSpotPrice(item.unit_price != null ? String(item.unit_price) : "");
       setSpotDesc(stripHtmlToText(item.product_description));
     }
@@ -663,11 +680,13 @@ function OfferModal({
       priceN = Number(priceRaw);
       if (!Number.isFinite(priceN) || priceN <= 0) { setErr("釋出單價需 > 0（留空 = 沿用原價）"); return; }
     }
-    // 沒改的值送 null（= 沿用原價 / 商品主檔原文），改了才存進板上
+    // 沒改的值送 null（= 沿用原價 / 商品主檔原文 / SKU 組出的標題），改了才存進板上
     const spotPriceParam = priceN != null && priceN !== item.unit_price ? priceN : null;
     const descTrim = spotDesc.trim();
     const spotDescParam =
       descTrim !== "" && descTrim !== stripHtmlToText(item.product_description) ? descTrim : null;
+    const titleTrim = spotTitle.trim();
+    const spotTitleParam = titleTrim !== "" && titleTrim !== item.default_title ? titleTrim : null;
 
     setSubmitting(true);
     try {
@@ -686,6 +705,7 @@ function OfferModal({
         p_source_customer_order_id: pickedOrder.id,
         p_spot_price: spotPriceParam,
         p_spot_description: spotDescParam,
+        p_spot_title: spotTitleParam,
       });
       if (e) { setErr(e.message); return; }
       onPosted();
@@ -781,6 +801,15 @@ function OfferModal({
           </div>
         )}
 
+        <label>
+          <span className="mb-1 block text-xs text-zinc-500">商品標題（會員 App 現貨專區顯示的名稱，可改寫）</span>
+          <input
+            value={spotTitle}
+            onChange={(e) => setSpotTitle(e.target.value)}
+            placeholder="選了品項會自動帶入商品名稱，可直接改寫"
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
         <div className="grid grid-cols-3 gap-3">
           <label>
             <span className="mb-1 block text-xs text-zinc-500">釋出數量 <span className="text-red-500">*</span></span>
@@ -869,7 +898,7 @@ function ThreadModal({
   stores: Store[];
   onClose: () => void;
   onClosed: () => void;
-  /** 編輯單價/說明存檔後呼叫（父層重抓列表；modal 留在原地） */
+  /** 編輯標題/單價/到期/說明存檔後呼叫（父層重抓列表；modal 留在原地） */
   onEdited: () => void;
 }) {
   const [replies, setReplies] = useState<Reply[] | null>(null);
@@ -881,19 +910,22 @@ function ThreadModal({
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [claimOpen, setClaimOpen] = useState(false);
   const [fulfillOpen, setFulfillOpen] = useState(false);
-  // 發佈後編輯釋出單價 / 商品說明（僅 offer + active）。
-  // originalPrice / originalDesc 是「沿用值」：原價來自來源訂單、原文來自商品主檔，
-  // 編輯表單要靠它們判斷「改回原值 = 清除自訂」。
+  // 發佈後編輯商品標題 / 釋出單價 / 到期時間 / 商品說明（僅 offer + active）。
+  // originalPrice / originalDesc / originalTitle 是「沿用值」：原價來自來源訂單、
+  // 原文與標題來自商品主檔 / SKU，編輯表單要靠它們判斷「改回原值 = 清除自訂」。
   const [editOpen, setEditOpen] = useState(false);
   // 存檔後 post prop 還是父層舊資料（列表重抓不會回填 modal），標頭單價用這個本地值蓋
   const [savedSpotPrice, setSavedSpotPrice] = useState<number | null>(post.spot_price);
+  const [savedSpotTitle, setSavedSpotTitle] = useState<string | null>(post.spot_title);
   const [editPrice, setEditPrice] = useState(post.spot_price != null ? String(post.spot_price) : "");
   const [editDesc, setEditDesc] = useState(post.spot_description ?? "");
+  const [editTitle, setEditTitle] = useState(post.spot_title ?? "");
   const [editExpiresAt, setEditExpiresAt] = useState(() => toLocalInput(post.expires_at));
   // 存檔後 post prop 仍是父層舊資料，標頭到期時間用本地值蓋
   const [savedExpiresAt, setSavedExpiresAt] = useState(post.expires_at);
   const [originalPrice, setOriginalPrice] = useState<number | null>(null);
   const [originalDesc, setOriginalDesc] = useState("");
+  const [originalTitle, setOriginalTitle] = useState("");
   const [savingEdit, setSavingEdit] = useState(false);
   const canEdit = post.post_type === "offer" && post.status === "active";
 
@@ -908,17 +940,28 @@ function ThreadModal({
               .eq("order_id", post.source_customer_order_id).eq("sku_id", post.sku_id)
               .limit(1).maybeSingle()
           : Promise.resolve({ data: null }),
-        sb.from("skus").select("product:products(description)").eq("id", post.sku_id).maybeSingle(),
+        sb.from("skus").select("product_name, variant_name, product:products(description)").eq("id", post.sku_id).maybeSingle(),
       ]);
       if (cancelled) return;
       const priceN = Number((priceRes.data as { unit_price?: number | string } | null)?.unit_price);
       setOriginalPrice(Number.isFinite(priceN) ? priceN : null);
-      const productRaw = (skuRes.data as { product?: { description: string | null } | { description: string | null }[] | null } | null)?.product;
+      const skuRow = skuRes.data as {
+        product_name?: string | null;
+        variant_name?: string | null;
+        product?: { description: string | null } | { description: string | null }[] | null;
+      } | null;
+      const productRaw = skuRow?.product;
       const product = Array.isArray(productRaw) ? productRaw[0] : productRaw;
       const desc = stripHtmlToText(product?.description);
       setOriginalDesc(desc);
-      // 沒有自訂說明時，編輯框預填原文（跟上架表單同一套預填邏輯）
+      // 和會員端 spotProductTitle() 的組法一字不差（全形／）
+      const title = skuRow?.product_name
+        ? `${skuRow.product_name}${skuRow.variant_name ? `／${skuRow.variant_name}` : ""}`
+        : "";
+      setOriginalTitle(title);
+      // 沒有自訂說明/標題時，編輯框預填原值（跟上架表單同一套預填邏輯）
       if (post.spot_description == null && desc) setEditDesc((cur) => (cur === "" ? desc : cur));
+      if (post.spot_title == null && title) setEditTitle((cur) => (cur === "" ? title : cur));
     })();
     return () => { cancelled = true; };
     // post.id 換了整個 modal 會重掛，這裡跑一次就好
@@ -938,6 +981,8 @@ function ThreadModal({
     const spotPriceParam = priceN != null && priceN !== originalPrice ? priceN : null;
     const descTrim = editDesc.trim();
     const spotDescParam = descTrim !== "" && descTrim !== originalDesc ? descTrim : null;
+    const titleTrim = editTitle.trim();
+    const spotTitleParam = titleTrim !== "" && titleTrim !== originalTitle ? titleTrim : null;
     const expDate = new Date(editExpiresAt);
     if (Number.isNaN(expDate.getTime())) { setErr("到期時間格式不正確"); return; }
     if (expDate <= new Date()) { setErr("到期時間需在未來（要立刻下架請用「結束此貼」）"); return; }
@@ -953,9 +998,11 @@ function ThreadModal({
         p_spot_price: spotPriceParam,
         p_spot_description: spotDescParam,
         p_expires_at: expDate.toISOString(),
+        p_spot_title: spotTitleParam,
       });
       if (e) { setErr(e.message); return; }
       setSavedSpotPrice(spotPriceParam);
+      setSavedSpotTitle(spotTitleParam);
       setSavedExpiresAt(expDate.toISOString());
       setEditOpen(false);
       onEdited();
@@ -1047,6 +1094,11 @@ function ThreadModal({
             <span className="font-medium text-zinc-700 dark:text-zinc-300">{post.store_name}</span>
             <span className="text-zinc-500">釋出</span>
             <span>{post.sku_label}</span>
+            {savedSpotTitle && (
+              <span className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-800 dark:bg-blue-950 dark:text-blue-300">
+                App 標題：{savedSpotTitle}
+              </span>
+            )}
           </div>
           <div className="flex flex-wrap gap-x-4 gap-y-1 text-zinc-500">
             <span>
@@ -1077,9 +1129,19 @@ function ThreadModal({
           </div>
         </div>
 
-        {/* 發佈後編輯：釋出單價 / 商品說明（僅 offer + active；改完會員端即時生效） */}
+        {/* 發佈後編輯：商品標題 / 釋出單價 / 到期時間 / 商品說明
+            （僅 offer + active；改完會員端即時生效） */}
         {canEdit && editOpen && (
           <div className="flex flex-col gap-2 rounded-md border border-blue-200 bg-blue-50/40 p-3 text-xs dark:border-blue-900 dark:bg-blue-950/20">
+            <label>
+              <span className="mb-1 block text-zinc-500">商品標題（會員 App 現貨專區顯示的名稱，可改寫）</span>
+              <input
+                value={editTitle}
+                onChange={(e) => setEditTitle(e.target.value)}
+                placeholder={originalTitle || "留空 = 沿用商品名稱"}
+                className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+              />
+            </label>
             <label>
               <span className="mb-1 block text-zinc-500">釋出單價</span>
               <input
@@ -1452,9 +1514,10 @@ function FulfillRequestDialog({
             const sku = Array.isArray(it.sku) ? it.sku[0] : it.sku;
             return {
               campaign_item_id: null, sku_id: it.sku_id, qty: Number(it.qty),
-              // 這個 modal（回應求助）用不到單價/說明，補 null 滿足共用型別
+              // 這個 modal（回應求助）用不到單價/說明/自訂標題，補 null 滿足共用型別
               unit_price: null, product_description: null,
               sku_label: sku ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} (${sku.sku_code})` : `品項#${it.sku_id}`,
+              default_title: sku ? `${sku.product_name}${sku.variant_name ? `／${sku.variant_name}` : ""}` : `品項#${it.sku_id}`,
             };
           }),
         };

--- a/apps/member/src/components/SpotProductCard.tsx
+++ b/apps/member/src/components/SpotProductCard.tsx
@@ -14,6 +14,8 @@ export type SpotProduct = {
   sku_code: string | null;
   product_name: string | null;
   variant_name: string | null;
+  /** 店家上架時自訂的標題。null = 沒改，走 product_name／variant_name。 */
+  spot_title: string | null;
   unit: string | null;
   image_url: string | null;
   store_id: number;
@@ -28,6 +30,8 @@ export type SpotProduct = {
 };
 
 export function spotProductTitle(p: SpotProduct): string {
+  // 店家自訂標題優先（後台互助板可在上架時填、發佈後改）
+  if (p.spot_title) return p.spot_title;
   const base = p.product_name ?? p.sku_code ?? "商品";
   return p.variant_name ? `${base}／${p.variant_name}` : base;
 }

--- a/docs/PLAN-現貨專區.md
+++ b/docs/PLAN-現貨專區.md
@@ -26,6 +26,7 @@
 | 自動下架 | 被認領光（`exhausted`）／到期（既有 cron `purge-expired-aid-board` 每 10 分鐘跑）／店家取消 —— 三種都自動從 App 消失，不必另外做 |
 | 單價來源 | `mutual_aid_board.spot_price`（店家上架時可改，2026-08-02 加）優先；沒改則用來源訂單 `customer_order_items.unit_price`。釋出價**低於**原價時回 `original_price`，會員端畫刪除線 |
 | 商品說明 | `mutual_aid_board.spot_description`（上架時可改寫原文）優先；沒改 fallback `products.description` |
+| 商品標題 | `mutual_aid_board.spot_title`（上架時可改寫，2026-08-02 加）優先；沒改則由會員端組 `product_name／variant_name` |
 | 會員所在店 | `members.home_store_id`；未綁定會員退回 JWT 的 `store_id`（掃碼進站那間） |
 
 **命名分工**：對會員講「現貨專區」（現成的貨、不用等團購結單）；卡片上仍標「◯◯店 釋出」當來源。
@@ -207,9 +208,10 @@ tab active 判斷是 `pathname.startsWith(t.href)`。所以現貨專區**必須�
 | `supabase/migrations/20260802000000_aid_board_spot_price_description.sql` | 新增 | `mutual_aid_board` 加 `spot_price` / `spot_description`；`rpc_post_aid_board` 8 → 10 參數（DROP+CREATE，新參數有 DEFAULT 無空窗） |
 | `supabase/migrations/20260802000010_rpc_update_aid_board_listing.sql` | 新增 | 發佈後編輯：`rpc_update_aid_board_listing`（僅 active offer；NULL = 清除自訂回到沿用）。互助板點開貼文 →「✏️ 修改內容」 |
 | `supabase/migrations/20260802000020_aid_listing_edit_expires_at.sql` | 新增 | 上面那支加 `p_expires_at`（4 → 5 參數）。⚠ 它的 NULL 語意與另兩個相反：`expires_at` 是 NOT NULL 欄位，NULL = 不動；且不得設到過去（要立刻下架請用「結束此貼」） |
-| `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` | 改 | 「我有庫存可提供」表單加「釋出單價」（預填原價，可改；低於原價有提示）與「商品說明」textarea（預填原文純文字，可改寫）；沒改的值送 NULL |
+| `supabase/migrations/20260802000030_aid_board_spot_title.sql` | 新增 | `mutual_aid_board` 加 `spot_title`；`rpc_post_aid_board` 10 → 11、`rpc_update_aid_board_listing` 5 → 6 參數。NULL = 沒改，會員端 fallback 回 SKU 組出的標題 |
+| `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` | 改 | 「我有庫存可提供」表單加「商品標題」（預填 `product_name／variant_name`）、「釋出單價」（預填原價，可改；低於原價有提示）與「商品說明」textarea（預填原文純文字，可改寫）；沒改的值送 NULL。ThreadModal 的「✏️ 修改內容」同樣四欄都能改 |
 
-店家操作照舊：按「我有庫存可提供」發貼文，會員端就自動看得到；價格與說明想改才改。
+店家操作照舊：按「我有庫存可提供」發貼文，會員端就自動看得到；標題、價格與說明想改才改。
 
 ---
 

--- a/docs/TEST-member-spot-zone.md
+++ b/docs/TEST-member-spot-zone.md
@@ -9,6 +9,7 @@
 - Edge Function `liff-api` actions：`list_spot_products`、`get_spot_product`
 - Migration `20260801000020_rpc_upsert_store_line_oa.sql`（`rpc_upsert_store` 加 `p_line_oa_basic_id`）
 - Migration `20260802000000_aid_board_spot_price_description.sql`（互助板 offer 可自訂釋出單價與商品說明）
+- Migration `20260802000030_aid_board_spot_title.sql`（互助板 offer 可自訂商品標題，上架時填、發佈後可改）
 - 會員端：底部 tab bar 中央凸起鍵、`/spot` 列表、`/spot/[id]` 詳情（`/shop` 的現貨導流區塊已移除，見 T6）
 - 元件：`SpotProductCard.tsx`、`lib/lineInquiry.ts`
 - admin：`/stores` 的「LINE@ ID」欄位
@@ -47,13 +48,19 @@
 | T1-6 | 單價填 0 / 負數 | 擋下「釋出單價需 > 0（留空 = 沿用原價）」 |
 | T1-7 | 單價留空 or 沒動、說明沒動 | 送出後 `mutual_aid_board.spot_price` / `spot_description` 為 `NULL`（= 沿用原值，不是存一份複本） |
 | T1-8 | SQL 直呼 `rpc_post_aid_board` 用 `p_post_type='request'` 帶 `p_spot_price` | 炸 `spot_price is only valid for offer posts` |
-| T1-9 | **發佈後編輯**：點開自己店的 offer 貼文 → 「✏️ 修改內容」 | 出現編輯區：單價（帶目前值或空 = 沿用原價，含原價提示）＋**到期時間**（帶目前值）＋商品說明（帶改寫版或原文）；標頭顯示目前單價與到期時間 |
+| T1-9 | **發佈後編輯**：點開自己店的 offer 貼文 → 「✏️ 修改內容」 | 出現編輯區：**商品標題**（帶改寫版或 SKU 組出的預設）＋單價（帶目前值或空 = 沿用原價，含原價提示）＋**到期時間**（帶目前值）＋商品說明（帶改寫版或原文）；標頭顯示目前單價與到期時間 |
 | T1-10 | 改單價存檔 → 會員 App 重新整理 | App 立刻顯示新價（讀取端每次現查，不用重發貼文）；標頭單價同步更新 |
 | T1-11 | 把單價清空存檔 | `spot_price` 回 `NULL` = 沿用原價；App 回到顯示原價、無刪除線 |
 | T1-12 | 對已結束（cancelled / expired / exhausted）的貼文 | 沒有「修改內容」按鈕；SQL 直呼 `rpc_update_aid_board_listing` 會炸 `only active posts can be edited` |
 | T1-13 | **改到期時間**（延長或縮短）存檔 | 標頭「到期」即時更新；會員端 `/spot` 該筆的下架時間跟著變 |
 | T1-14 | 到期時間設到**過去** | 擋下「到期時間需在未來（要立刻下架請用「結束此貼」）」；SQL 直呼也會炸 `expires_at must be in the future` |
 | T1-15 | 只改單價、不動到期 | 到期時間維持原值（前端一律帶值；SQL 層 `p_expires_at=NULL` 也是不動該欄） |
+| T1-16 | 選了品項後看「商品標題」欄位 | 預填 `商品名稱／規格`（全形／，不含 SKU code），和 App 沒改時顯示的字串一模一樣 |
+| T1-17 | 標題沒動就送出 | `mutual_aid_board.spot_title` 為 `NULL`（= 沿用 SKU 組出的標題；商品主檔之後改名會自動跟上） |
+| T1-18 | 標題改成別的字（例「今日現貨・梅花豬」）送出 | `spot_title` 存改寫值；會員 App 的 `/spot` 卡片、`/spot/[id]` 詳情、LINE 詢問文字三處都用新標題 |
+| T1-19 | **發佈後改標題**：ThreadModal →「✏️ 修改內容」→ 改「商品標題」存檔 | 標頭出現藍色「App 標題：◯◯」標記；App 重新整理即時生效 |
+| T1-20 | 把標題清空（或改回預填值）存檔 | `spot_title` 回 `NULL`，App 回到 SKU 組出的標題 |
+| T1-21 | SQL 直呼 `rpc_post_aid_board` 用 `p_post_type='request'` 帶 `p_spot_title` | 炸 `spot_title is only valid for offer posts` |
 | T1-2 | 同上用 B 店再發一則（挑不同 SKU 好辨識） | 貼文成立 |
 | T1-3 | `SELECT id, post_type, status, offering_store_id, sku_id, qty_remaining, expires_at FROM mutual_aid_board WHERE post_type='offer' AND status='active';` | 兩筆，`expires_at` 在未來、`qty_remaining > 0` |
 
@@ -170,6 +177,7 @@ LIFF 直送要三件事同時成立：`NEXT_PUBLIC_LIFF_ID` 有設（Vercel）�
 | T7-6 | 商品沒有圖 | 品牌底 + 線稿箱子，不是破圖 |
 | T7-7 | 商品有說明 | 顯示「商品說明」區塊：上架時有改寫 → 顯示改寫版（`spot_description`）；沒改 → fallback 商品主檔原文；兩者皆無 → 整塊不出現 |
 | T7-17 | 詳情頁價格（釋出價低於原價） | 大字 `$149` 旁有刪除線 `~~$199~~`；LINE 詢問訊息帶的金額是 **149**（釋出價） |
+| T7-18 | 上架時改過商品標題的品項 | 詳情頁標題、列表卡片、LINE 詢問訊息的「今日現貨『◯◯』」三處都是改寫後的標題（`spot_title`）；沒改則是 `商品名稱／規格` |
 | T7-16 | **商品說明的排版（重點）** | 後台 TipTap 存的是 HTML。畫面上**不能出現 `<p>` `<br>` `</p>` 這種標籤字樣**，段落要正常換行（走 `cleanCampaignText`，同 `/shop/c/[id]`） |
 | T7-8 | 底部提示文字 | 本店寫「數量有限，先問先得」；跨店寫「由店家幫你調貨」 |
 | T7-9 | tab bar | 詳情頁**隱藏** tab bar（底部是詢問列，會打架）；回到 `/spot` 列表後 tab bar 回來 |

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -347,7 +347,7 @@ async function listSpotProducts(
   const { data: rows, error } = await sb
     .from("mutual_aid_board")
     .select(
-      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, spot_price, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, images))",
+      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, spot_price, spot_title, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, images))",
     )
     .eq("tenant_id", tenantId)
     .eq("post_type", "offer")
@@ -429,6 +429,8 @@ async function listSpotProducts(
       sku_code: r.sku?.sku_code ?? null,
       product_name: r.sku?.product_name ?? r.sku?.product?.name ?? null,
       variant_name: r.sku?.variant_name ?? null,
+      // 上架時改寫的標題優先；沒改就由前端組 product_name／variant_name
+      spot_title: r.spot_title ?? null,
       unit: r.sku?.base_unit ?? null,
       image_url: toPublicUrl(supabaseUrl, "products", rawImg),
       store_id: Number(r.offering_store_id),
@@ -475,7 +477,7 @@ async function getSpotProduct(
   const { data: r, error } = await sb
     .from("mutual_aid_board")
     .select(
-      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, spot_price, spot_description, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, description, images))",
+      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, spot_price, spot_description, spot_title, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, description, images))",
     )
     .eq("tenant_id", tenantId)
     .eq("id", boardId)
@@ -549,6 +551,8 @@ async function getSpotProduct(
       sku_code: r.sku?.sku_code ?? null,
       product_name: r.sku?.product_name ?? r.sku?.product?.name ?? null,
       variant_name: r.sku?.variant_name ?? null,
+      // 上架時改寫的標題優先；沒改就由前端組 product_name／variant_name
+      spot_title: r.spot_title ?? null,
       // 上架時改寫的說明優先；沒改就 fallback 回商品主檔
       description: r.spot_description ?? r.sku?.product?.description ?? null,
       unit: r.sku?.base_unit ?? null,

--- a/supabase/migrations/20260802000030_aid_board_spot_title.sql
+++ b/supabase/migrations/20260802000030_aid_board_spot_title.sql
@@ -1,0 +1,215 @@
+-- ============================================================
+-- 2026-08-02: 互助板 offer 可自訂商品標題
+--
+-- 需求：會員 App 現貨專區的商品標題目前一律組自 SKU
+--       （`product_name／variant_name`，例「火鍋肉片500g/包／(C)台灣梅花豬」），
+--       店家希望能改成給顧客看的說法。上架時可填、發佈後也能改。
+--
+-- 沿用 spot_price / spot_description 的同一套語意：
+--   NULL = 沒改，讀取端 fallback 回 SKU 組出來的標題。
+--   商品主檔之後改名，沒改寫過的貼文會自動跟上。
+--
+-- 變動：
+--   1. mutual_aid_board 加 spot_title
+--   2. rpc_post_aid_board            10 → 11 參數（上架時填）
+--   3. rpc_update_aid_board_listing   5 →  6 參數（發佈後改）
+--
+-- 基底版本（已 grep supabase/migrations/ 確認各自的最新版）：
+--   - rpc_post_aid_board          → 20260802000000_aid_board_spot_price_description.sql
+--     （歷史：20260509000000 6 參數 → 20260509000001 8 參數 → 20260802000000 10 參數）
+--   - rpc_update_aid_board_listing → 20260802000020_aid_listing_edit_expires_at.sql
+--     （歷史：20260802000010 4 參數 → 20260802000020 5 參數）
+--   兩支的原有驗證邏輯一字未改，只多接一個參數。
+--
+-- 為何 DROP 再 CREATE：參數個數變了，CREATE OR REPLACE 會多出 overload，
+--   之後具名呼叫撞 "function is not unique"。新參數有 DEFAULT，
+--   已部署的舊前端具名呼叫仍解得到，無空窗。
+--
+-- Rollback：
+--   DROP FUNCTION IF EXISTS rpc_post_aid_board(
+--     BIGINT, BIGINT, NUMERIC, TIMESTAMPTZ, TEXT, UUID, TEXT, BIGINT, NUMERIC, TEXT, TEXT);
+--   DROP FUNCTION IF EXISTS public.rpc_update_aid_board_listing(
+--     BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ, TEXT);
+--   -- 重跑 20260802000000 的 §rpc 段落 與 20260802000020 整支
+--   ALTER TABLE mutual_aid_board DROP COLUMN spot_title;
+-- ============================================================
+
+ALTER TABLE mutual_aid_board
+  ADD COLUMN spot_title TEXT;
+
+COMMENT ON COLUMN mutual_aid_board.spot_title IS
+  '上架時自訂的商品標題（純文字）；NULL = 會員端 fallback 回 SKU 組出的 '
+  'product_name／variant_name。';
+
+-- ------------------------------------------------------------
+-- 1. rpc_post_aid_board：10 → 11 參數
+-- ------------------------------------------------------------
+DROP FUNCTION IF EXISTS rpc_post_aid_board(
+  BIGINT, BIGINT, NUMERIC, TIMESTAMPTZ, TEXT, UUID, TEXT, BIGINT, NUMERIC, TEXT);
+
+CREATE OR REPLACE FUNCTION rpc_post_aid_board(
+  p_offering_store_id        BIGINT,
+  p_sku_id                   BIGINT,
+  p_qty_available            NUMERIC,
+  p_expires_at               TIMESTAMPTZ,
+  p_note                     TEXT,
+  p_operator                 UUID,
+  p_post_type                TEXT,
+  p_source_customer_order_id BIGINT,
+  p_spot_price               NUMERIC DEFAULT NULL,
+  p_spot_description         TEXT    DEFAULT NULL,
+  p_spot_title               TEXT    DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant_id     UUID;
+  v_board_id      BIGINT;
+  v_order_tenant  UUID;
+  v_order_store   BIGINT;
+BEGIN
+  IF p_post_type NOT IN ('offer', 'request') THEN
+    RAISE EXCEPTION 'p_post_type must be offer or request';
+  END IF;
+  IF p_qty_available IS NULL OR p_qty_available <= 0 THEN
+    RAISE EXCEPTION 'qty_available must be > 0';
+  END IF;
+  IF p_expires_at IS NULL OR p_expires_at <= NOW() THEN
+    RAISE EXCEPTION 'expires_at must be in the future';
+  END IF;
+  -- 自訂價 / 說明 / 標題只對 offer 有意義（request 是求援，不是上架商品）
+  IF p_spot_price IS NOT NULL THEN
+    IF p_post_type <> 'offer' THEN
+      RAISE EXCEPTION 'spot_price is only valid for offer posts';
+    END IF;
+    IF p_spot_price <= 0 THEN
+      RAISE EXCEPTION 'spot_price must be > 0';
+    END IF;
+  END IF;
+  IF p_spot_description IS NOT NULL AND p_post_type <> 'offer' THEN
+    RAISE EXCEPTION 'spot_description is only valid for offer posts';
+  END IF;
+  IF p_spot_title IS NOT NULL AND p_post_type <> 'offer' THEN
+    RAISE EXCEPTION 'spot_title is only valid for offer posts';
+  END IF;
+
+  SELECT tenant_id INTO v_tenant_id FROM stores WHERE id = p_offering_store_id;
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'store % not found', p_offering_store_id;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM skus WHERE id = p_sku_id) THEN
+    RAISE EXCEPTION 'sku % not found', p_sku_id;
+  END IF;
+
+  -- offer 必須帶 source_customer_order_id 且該 order 屬同 tenant、屬發貼店、未轉出
+  IF p_post_type = 'offer' THEN
+    IF p_source_customer_order_id IS NULL THEN
+      RAISE EXCEPTION 'offer post requires p_source_customer_order_id';
+    END IF;
+
+    SELECT tenant_id, pickup_store_id INTO v_order_tenant, v_order_store
+      FROM customer_orders WHERE id = p_source_customer_order_id;
+    IF v_order_tenant IS NULL THEN
+      RAISE EXCEPTION 'customer_order % not found', p_source_customer_order_id;
+    END IF;
+    IF v_order_tenant <> v_tenant_id THEN
+      RAISE EXCEPTION 'cross-tenant order';
+    END IF;
+    IF v_order_store <> p_offering_store_id THEN
+      RAISE EXCEPTION 'order pickup_store_id (%) does not match offering_store_id (%)',
+                       v_order_store, p_offering_store_id;
+    END IF;
+  ELSE
+    -- request：source_customer_order_id 須為 NULL
+    IF p_source_customer_order_id IS NOT NULL THEN
+      RAISE EXCEPTION 'request post must not have source_customer_order_id';
+    END IF;
+  END IF;
+
+  INSERT INTO mutual_aid_board (
+    tenant_id, offering_store_id, sku_id, qty_available, qty_remaining,
+    expires_at, note, status, post_type, source_customer_order_id,
+    spot_price, spot_description, spot_title,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant_id, p_offering_store_id, p_sku_id, p_qty_available, p_qty_available,
+    p_expires_at, NULLIF(trim(p_note), ''), 'active', p_post_type, p_source_customer_order_id,
+    p_spot_price, NULLIF(trim(p_spot_description), ''), NULLIF(trim(p_spot_title), ''),
+    p_operator, p_operator
+  )
+  RETURNING id INTO v_board_id;
+
+  RETURN v_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_post_aid_board(
+  BIGINT, BIGINT, NUMERIC, TIMESTAMPTZ, TEXT, UUID, TEXT, BIGINT, NUMERIC, TEXT, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION rpc_post_aid_board IS
+  '發起互助貼文；offer 須帶 source_customer_order_id。'
+  '2026-08-02 加 p_spot_price / p_spot_description / p_spot_title'
+  '（僅 offer 可用；NULL = 沿用原價 / 商品主檔說明 / SKU 組出的標題）。';
+
+-- ------------------------------------------------------------
+-- 2. rpc_update_aid_board_listing：5 → 6 參數
+-- ------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.rpc_update_aid_board_listing(
+  BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ);
+
+CREATE OR REPLACE FUNCTION public.rpc_update_aid_board_listing(
+  p_board_id         BIGINT,
+  p_operator         UUID,
+  p_spot_price       NUMERIC     DEFAULT NULL,
+  p_spot_description TEXT        DEFAULT NULL,
+  p_expires_at       TIMESTAMPTZ DEFAULT NULL,
+  p_spot_title       TEXT        DEFAULT NULL
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_post_type TEXT;
+  v_status    TEXT;
+BEGIN
+  IF p_spot_price IS NOT NULL AND p_spot_price <= 0 THEN
+    RAISE EXCEPTION 'spot_price must be > 0';
+  END IF;
+  -- 到期時間可以往後延，也可以縮短，但不能設到過去
+  -- （設到過去等於立刻下架，那是「結束此貼」該做的事，語意分開）
+  IF p_expires_at IS NOT NULL AND p_expires_at <= NOW() THEN
+    RAISE EXCEPTION 'expires_at must be in the future';
+  END IF;
+
+  SELECT post_type, status INTO v_post_type, v_status
+    FROM mutual_aid_board WHERE id = p_board_id
+    FOR UPDATE;
+  IF v_post_type IS NULL THEN
+    RAISE EXCEPTION 'board post % not found', p_board_id;
+  END IF;
+  IF v_post_type <> 'offer' THEN
+    RAISE EXCEPTION 'only offer posts have price/description';
+  END IF;
+  IF v_status <> 'active' THEN
+    RAISE EXCEPTION 'post is % — only active posts can be edited', v_status;
+  END IF;
+
+  UPDATE mutual_aid_board
+     SET spot_price       = p_spot_price,
+         spot_description = NULLIF(trim(p_spot_description), ''),
+         spot_title       = NULLIF(trim(p_spot_title), ''),
+         -- NULL = 不動（expires_at 是 NOT NULL，沒有「清除」的語意）
+         expires_at       = COALESCE(p_expires_at, expires_at),
+         updated_by       = p_operator
+   WHERE id = p_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_update_aid_board_listing(
+  BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_update_aid_board_listing IS
+  '互助板 offer 貼文發佈後編輯釋出單價 / 商品說明 / 商品標題 / 到期時間。'
+  'spot_price、spot_description、spot_title 的 NULL = 清除自訂值'
+  '（回沿用原價 / 商品主檔原文 / SKU 組出的標題）；'
+  'expires_at 的 NULL = 不動（該欄 NOT NULL），且不得設到過去。僅 active 的 offer 可改。';


### PR DESCRIPTION
## 這是什麼

會員 App 現貨專區的標題原本一律組自 SKU（`商品名稱／規格`，例「火鍋肉片500g/包／(C)台灣梅花豬」），店家沒辦法改成給顧客看的說法。現在**上架時可填、發佈後也能改**。

沿用 `spot_price` / `spot_description` 已經在用的同一套語意：**NULL = 沒改**，讀取端 fallback 回 SKU 組出的標題。好處是商品主檔之後改名，沒改寫過的貼文會自動跟上，不用回頭清資料。

> 後續的「手動新增現貨」疊在這支上面：**#581**（base 就是這條分支）。這支合併後 #581 會自動轉指向 `main`。請先合這支。

## 後台（互助交流板）

| 位置 | 變動 |
|---|---|
| 「我有庫存可提供」上架表單 | 最上面多一個 **商品標題**，選了品項自動預填 `商品名稱／規格`，可直接改寫 |
| 貼文詳情 modal →「✏️ 修改內容」 | 編輯區最上面多一個 **商品標題**，帶目前值（沒自訂就帶預設） |
| 貼文標頭 | 有自訂標題時顯示藍色標記「App 標題：◯◯」，存檔後即時更新 |

預填字串和會員端 `spotProductTitle()` 的組法**一字不差**（全形／、不含 SKU code），所以「沒動 = 送 NULL」判斷得準，不會因為格式差一個斜線就誤存一份複本。

## 會員端

`SpotProduct` 加 `spot_title`，`spotProductTitle()` 優先用它 —— 因為列表卡片、詳情頁、LINE 詢問訊息**三處都走這一支**，改一個地方三處一起吃到。

## DB（migration `20260802000030`）

`mutual_aid_board` 加 `spot_title TEXT`，兩支 RPC 各多接一個參數：

| RPC | 參數 | 基底版本 |
|---|---|---|
| `rpc_post_aid_board` | 10 → 11 | `20260802000000`（歷史：`20260509000000` 6 → `20260509000001` 8 → 10） |
| `rpc_update_aid_board_listing` | 5 → 6 | `20260802000020`（歷史：`20260802000010` 4 → 5） |

已 grep `supabase/migrations/` 確認基底是各自**時間最新**的版本，原有驗證邏輯一字未改。兩支都 DROP+CREATE（參數個數變了，`CREATE OR REPLACE` 會多出 overload，之後具名呼叫撞 `function is not unique`）；新參數有 DEFAULT，已部署的舊前端具名呼叫仍解得到，**無空窗**。

`spot_title` 和 `spot_price` / `spot_description` 一樣只對 `offer` 有意義，`request` 帶了會 RAISE。

## 異動檔案

| 檔案 | 說明 |
|---|---|
| `supabase/migrations/20260802000030_aid_board_spot_title.sql` | 加欄位 + 兩支 RPC |
| `supabase/functions/liff-api/index.ts` | `list_spot_products` / `get_spot_product` 回 `spot_title` |
| `apps/member/src/components/SpotProductCard.tsx` | 型別加 `spot_title`；`spotProductTitle()` 優先用它 |
| `apps/admin/.../inventory/mutual-aid/page.tsx` | 上架表單 + ThreadModal 編輯區各加「商品標題」；`PendingOrder.items` 加 `default_title` |
| `docs/PLAN-現貨專區.md` / `docs/TEST-member-spot-zone.md` | 同步；測試加 T1-16~21、T7-18 |

## 已驗證

- Migration 已套線上；`pg_proc` 確認兩支各**只有一個簽章**（11 / 6 參數），無 overload
- **Rollback 交易實測** 6 種情境，跑完 rollback、線上零殘留（`max(id)` 與板上 id 50 內容都沒變）：
  - 存標題含前後空白 → 被 `trim`
  - 標題給空白字串 → 存成 `NULL`
  - **舊前端 5 個具名參數呼叫 `rpc_update_aid_board_listing` 仍可用**
  - **舊前端 10 個具名參數呼叫 `rpc_post_aid_board` 仍可用**
  - offer 上架帶標題 → 正確寫入
  - `request` 帶 `p_spot_title` → 被擋（`spot_title is only valid for offer posts`）
- `liff-api` 已部署；`OPTIONS` 回 200、無 auth `POST` 回函式自家的 401（不是 gateway 404）
- 新的 PostgREST select 字串實打驗過，embedded select 解得開
- 兩個 app 的 `tsc --noEmit` + `next build` 都過；lint 錯誤數與 `main` 相同（6 個既有的 `react-hooks/set-state-in-effect`，非本次新增）

## 沒驗證

畫面沒實機看過。合併後照 `docs/TEST-member-spot-zone.md` 走 **T1-16~21**（預填格式、沒動送 NULL、發佈後改、清空回 fallback）與 **T7-18**（卡片／詳情／LINE 訊息三處同步）。