### PR TITLE
feat(spot): 手動新增現貨 — 免訂單、可手打商品、金額與圖片自訂

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -5,6 +5,7 @@ import { Modal } from "@/components/Modal";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import SearchSpinner from "@/components/SearchSpinner";
+import { ProductImagesField } from "@/components/ProductImagesField";
 
 type Store = { id: number; code: string; name: string };
 type SkuOption = { id: number; sku_code: string; product_name: string; variant_name: string | null };
@@ -15,7 +16,8 @@ type Post = {
   id: number;
   post_type: PostType;
   offering_store_id: number;
-  sku_id: number;
+  /** 手動現貨可能沒有 SKU（店家直接手打的商品） */
+  sku_id: number | null;
   qty_available: number;
   qty_remaining: number;
   expires_at: string;
@@ -25,6 +27,8 @@ type Post = {
   spot_price: number | null;
   spot_description: string | null;
   spot_title: string | null;
+  spot_unit: string | null;
+  spot_images: string[] | null;
   created_at: string;
   created_by: string | null;
   store_name?: string;
@@ -112,6 +116,7 @@ export default function MutualAidPage() {
   const [reloadTick, setReloadTick] = useState(0);
   const [requestModalOpen, setRequestModalOpen] = useState(false);
   const [offerModalOpen, setOfferModalOpen] = useState(false);
+  const [manualModalOpen, setManualModalOpen] = useState(false);
   const [threadPost, setThreadPost] = useState<Post | null>(null);
 
   // 貼文數變動（發文/關貼/認領）後重載列表，並通知側欄「互助交流板」badge 重抓
@@ -140,7 +145,7 @@ export default function MutualAidPage() {
         const sb = getSupabase();
         let q = sb
           .from("mutual_aid_board")
-          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, status, source_customer_order_id, spot_price, spot_description, spot_title, created_at, created_by")
+          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, status, source_customer_order_id, spot_price, spot_description, spot_title, spot_unit, spot_images, created_at, created_by")
           .eq("status", "active")
           .order("created_at", { ascending: false })
           .limit(200);
@@ -152,13 +157,16 @@ export default function MutualAidPage() {
           if (!cancelled) setPosts([]);
           return;
         }
-        const skuIds = Array.from(new Set(rows.map((r) => r.sku_id)));
+        // 手打的手動現貨沒有 sku_id，別把 null 塞進 .in() 查詢
+        const skuIds = Array.from(new Set(rows.map((r) => r.sku_id).filter((x): x is number => x != null)));
         const storeIds = Array.from(new Set(rows.map((r) => r.offering_store_id)));
         const boardIds = rows.map((r) => r.id);
         const orderIds = Array.from(new Set(rows.map((r) => r.source_customer_order_id).filter((x): x is number => x != null)));
 
         const [skuRes, storeRes, replyRes, orderRes] = await Promise.all([
-          sb.from("skus").select("id, sku_code, product_name, variant_name").in("id", skuIds),
+          skuIds.length > 0
+            ? sb.from("skus").select("id, sku_code, product_name, variant_name").in("id", skuIds)
+            : Promise.resolve({ data: [], error: null }),
           sb.from("stores").select("id, name").in("id", storeIds),
           sb.from("mutual_aid_replies").select("board_id").in("board_id", boardIds),
           orderIds.length > 0
@@ -173,11 +181,16 @@ export default function MutualAidPage() {
           replyCount.set(r.board_id, (replyCount.get(r.board_id) ?? 0) + 1);
         }
         const enriched = rows.map((r) => {
-          const sku = skuMap.get(r.sku_id);
+          const sku = r.sku_id != null ? skuMap.get(r.sku_id) : undefined;
           return {
             ...r,
             store_name: storeMap.get(r.offering_store_id) ?? `#${r.offering_store_id}`,
-            sku_label: sku ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} (${sku.sku_code})` : `品項#${r.sku_id}`,
+            // 沒 SKU 的手打商品只有 spot_title 可以顯示
+            sku_label: sku
+              ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} (${sku.sku_code})`
+              : r.sku_id != null
+                ? `品項#${r.sku_id}`
+                : r.spot_title ?? "（未命名）",
             source_order_no: r.source_customer_order_id ? orderMap.get(r.source_customer_order_id) ?? null : null,
             replies_count: replyCount.get(r.id) ?? 0,
           };
@@ -213,6 +226,13 @@ export default function MutualAidPage() {
             className="rounded-md bg-pink-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-pink-700"
           >
             📦 我有庫存可提供
+          </SpinButton>
+          <SpinButton
+            type="button"
+            onClick={() => setManualModalOpen(true)}
+            className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700"
+          >
+            ➕ 手動新增現貨
           </SpinButton>
         </div>
       </header>
@@ -264,6 +284,11 @@ export default function MutualAidPage() {
                   </span>
                   <span className="text-sm font-medium">{p.store_name}</span>
                   <span className="text-sm">{p.sku_label}</span>
+                  {p.post_type === "offer" && p.source_customer_order_id == null && (
+                    <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+                      手動
+                    </span>
+                  )}
                   <span className="ml-auto text-xs text-zinc-500">💬 {p.replies_count} 留言</span>
                 </div>
                 <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">
@@ -302,6 +327,16 @@ export default function MutualAidPage() {
         stores={stores}
         onPosted={() => {
           setOfferModalOpen(false);
+          reloadAndRefreshBadge();
+        }}
+      />
+
+      <ManualSpotModal
+        open={manualModalOpen}
+        onClose={() => setManualModalOpen(false)}
+        stores={stores}
+        onPosted={() => {
+          setManualModalOpen(false);
           reloadAndRefreshBadge();
         }}
       />
@@ -531,6 +566,235 @@ function RequestModal({
             className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
           >
             {submitting ? "送出中…" : "發佈求助"}
+          </SpinButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ============================================================
+// Manual Spot Modal — 手動新增現貨（不需要來源訂單）
+//
+// 和 OfferModal 的差別：那支是「把客人棄單的訂單釋出去」，一切資料都從訂單帶；
+// 這支是店家直接把店裡有的東西上架 —— 可以從商品庫挑 SKU 帶出名字，
+// 也可以整個手打（店裡自製、臨時進的貨，主檔根本沒有）。
+// 這種貼文**不會出現認領按鈕**：沒有訂單可以轉移給別店。
+// ============================================================
+function ManualSpotModal({
+  open, onClose, stores, onPosted,
+}: {
+  open: boolean;
+  onClose: () => void;
+  stores: Store[];
+  onPosted: () => void;
+}) {
+  const [storeId, setStoreId] = useState<number | "">("");
+  const [picked, setPicked] = useState<SkuOption | null>(null);
+  const [title, setTitle] = useState("");
+  const [qty, setQty] = useState("");
+  const [unit, setUnit] = useState("");
+  const [price, setPrice] = useState("");
+  const [expiresAt, setExpiresAt] = useState(defaultExpiresAt);
+  const [desc, setDesc] = useState("");
+  const [images, setImages] = useState<string[]>([]);
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setStoreId(""); setPicked(null); setTitle(""); setQty(""); setUnit("");
+      setPrice(""); setDesc(""); setImages([]); setNote(""); setErr(null);
+      setExpiresAt(defaultExpiresAt());
+    }
+  }, [open]);
+
+  // 挑了 SKU → 帶出標題當起點（和會員端 spotProductTitle() 同一套組法）；
+  // 已經手打過的標題不覆蓋，清掉選擇也不清標題（打過的字不該憑空消失）。
+  function pickSku(s: SkuOption | null) {
+    setPicked(s);
+    if (!s) return;
+    const def = `${s.product_name}${s.variant_name ? `／${s.variant_name}` : ""}`;
+    setTitle((cur) => (cur.trim() === "" ? def : cur));
+  }
+
+  async function submit() {
+    if (submitting) return;
+    setErr(null);
+    if (!storeId) { setErr("請選釋出店"); return; }
+    const titleTrim = title.trim();
+    if (!picked && titleTrim === "") { setErr("沒有從商品庫選品項時，商品標題必填"); return; }
+    const qtyN = Number(qty);
+    if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("數量需 > 0"); return; }
+    let priceN: number | null = null;
+    if (price.trim() !== "") {
+      priceN = Number(price);
+      if (!Number.isFinite(priceN) || priceN <= 0) { setErr("金額需 > 0（留空 = 不顯示金額）"); return; }
+    }
+    const expDate = new Date(expiresAt);
+    if (Number.isNaN(expDate.getTime())) { setErr("到期時間格式不正確"); return; }
+    if (expDate <= new Date()) { setErr("到期時間需在未來"); return; }
+
+    setSubmitting(true);
+    try {
+      const sb = getSupabase();
+      const { data: userRes } = await sb.auth.getUser();
+      const operator = userRes.user?.id;
+      if (!operator) { setErr("未登入或 session 過期"); return; }
+      const { error: e } = await sb.rpc("rpc_post_manual_spot", {
+        p_offering_store_id: storeId,
+        p_sku_id: picked?.id ?? null,
+        p_spot_title: titleTrim || null,
+        p_qty_available: qtyN,
+        p_expires_at: expDate.toISOString(),
+        p_spot_price: priceN,
+        p_spot_description: desc.trim() || null,
+        p_spot_unit: unit.trim() || null,
+        p_spot_images: images.length > 0 ? images : null,
+        p_note: note.trim() || null,
+        p_operator: operator,
+      });
+      if (e) { setErr(e.message); return; }
+      onPosted();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title="➕ 手動新增現貨" maxWidth="max-w-2xl">
+      <div className="flex flex-col gap-3 text-sm">
+        {err && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {err}
+          </div>
+        )}
+        <p className="rounded-md border border-emerald-200 bg-emerald-50/50 p-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300">
+          直接上架店裡現有的東西，不需要來源訂單。可以從商品庫選品項，也可以整個手打。
+          <br />
+          這種貼文只給會員看，<strong>別的分店不能認領</strong>（沒有訂單可以轉移）。
+        </p>
+
+        <label>
+          <span className="mb-1 block text-xs text-zinc-500">釋出店 <span className="text-red-500">*</span></span>
+          <select
+            value={storeId}
+            onChange={(e) => setStoreId(e.target.value ? Number(e.target.value) : "")}
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="">— 選店 —</option>
+            {stores.map((s) => (<option key={s.id} value={s.id}>{s.name} ({s.code})</option>))}
+          </select>
+        </label>
+
+        <div>
+          <span className="mb-1 block text-xs text-zinc-500">
+            從商品庫選品項（選填 —— 選了會帶出名稱與圖片，不選就純手打）
+          </span>
+          <SkuSearchInput value={picked} onChange={pickSku} />
+          {picked && (
+            <SpinButton
+              type="button"
+              onClick={() => setPicked(null)}
+              className="mt-1 text-[11px] text-zinc-500 underline hover:text-zinc-700 dark:hover:text-zinc-300"
+            >
+              清除選擇，改成手打
+            </SpinButton>
+          )}
+        </div>
+
+        <label>
+          <span className="mb-1 block text-xs text-zinc-500">
+            商品標題{!picked && <span className="text-red-500"> *</span>}
+            <span className="ml-1 text-zinc-400">（會員 App 現貨專區顯示的名稱）</span>
+          </span>
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder={picked ? "留空 = 沿用商品名稱" : "例：今日現滷拼盤"}
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+
+        <div className="grid grid-cols-4 gap-3">
+          <label>
+            <span className="mb-1 block text-xs text-zinc-500">數量 <span className="text-red-500">*</span></span>
+            <input
+              value={qty}
+              onChange={(e) => setQty(e.target.value)}
+              inputMode="decimal"
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </label>
+          <label>
+            <span className="mb-1 block text-xs text-zinc-500">單位</span>
+            <input
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+              placeholder={picked ? "留空 = 商品單位" : "包 / 份"}
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </label>
+          <label>
+            <span className="mb-1 block text-xs text-zinc-500">金額</span>
+            <input
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+              inputMode="decimal"
+              placeholder="留空 = 不顯示"
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </label>
+          <label>
+            <span className="mb-1 block text-xs text-zinc-500">到期時間 <span className="text-red-500">*</span></span>
+            <input
+              type="datetime-local"
+              value={expiresAt}
+              onChange={(e) => setExpiresAt(e.target.value)}
+              className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+            />
+          </label>
+        </div>
+
+        <label>
+          <span className="mb-1 block text-xs text-zinc-500">商品說明（會顯示在會員 App 的商品詳情）</span>
+          <textarea
+            value={desc}
+            onChange={(e) => setDesc(e.target.value)}
+            rows={4}
+            placeholder="這批貨的狀況、口味、注意事項…"
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+
+        <div>
+          <span className="mb-1 block text-xs text-zinc-500">
+            商品圖片{picked && <span className="ml-1 text-zinc-400">（留空 = 沿用商品主檔的圖）</span>}
+          </span>
+          <ProductImagesField value={images} onChange={setImages} />
+        </div>
+
+        <label>
+          <span className="mb-1 block text-xs text-zinc-500">備註（選填，店對店內部訊息，不會給會員看）</span>
+          <input
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+
+        <div className="mt-2 flex justify-end gap-2">
+          <SpinButton type="button" onClick={onClose} className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700">取消</SpinButton>
+          <SpinButton
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {submitting ? "上架中…" : "上架"}
           </SpinButton>
         </div>
       </div>
@@ -920,14 +1184,23 @@ function ThreadModal({
   const [editPrice, setEditPrice] = useState(post.spot_price != null ? String(post.spot_price) : "");
   const [editDesc, setEditDesc] = useState(post.spot_description ?? "");
   const [editTitle, setEditTitle] = useState(post.spot_title ?? "");
+  const [editUnit, setEditUnit] = useState(post.spot_unit ?? "");
+  const [editImages, setEditImages] = useState<string[]>(post.spot_images ?? []);
+  const [editQty, setEditQty] = useState(String(post.qty_available));
   const [editExpiresAt, setEditExpiresAt] = useState(() => toLocalInput(post.expires_at));
-  // 存檔後 post prop 仍是父層舊資料，標頭到期時間用本地值蓋
+  // 存檔後 post prop 仍是父層舊資料，標頭到期時間 / 數量用本地值蓋
   const [savedExpiresAt, setSavedExpiresAt] = useState(post.expires_at);
+  const [savedQty, setSavedQty] = useState<{ available: number; remaining: number }>({
+    available: post.qty_available,
+    remaining: post.qty_remaining,
+  });
   const [originalPrice, setOriginalPrice] = useState<number | null>(null);
   const [originalDesc, setOriginalDesc] = useState("");
   const [originalTitle, setOriginalTitle] = useState("");
   const [savingEdit, setSavingEdit] = useState(false);
   const canEdit = post.post_type === "offer" && post.status === "active";
+  /** 手動現貨：沒有來源訂單 → 不能被認領，但數量可以直接改 */
+  const isManual = post.post_type === "offer" && post.source_customer_order_id == null;
 
   useEffect(() => {
     if (!canEdit) return;
@@ -940,7 +1213,11 @@ function ThreadModal({
               .eq("order_id", post.source_customer_order_id).eq("sku_id", post.sku_id)
               .limit(1).maybeSingle()
           : Promise.resolve({ data: null }),
-        sb.from("skus").select("product_name, variant_name, product:products(description)").eq("id", post.sku_id).maybeSingle(),
+        // 手打的手動現貨沒有 SKU，沒有主檔可以查（標題/說明也就沒有「沿用值」）
+        post.sku_id != null
+          ? sb.from("skus").select("product_name, variant_name, product:products(description)")
+              .eq("id", post.sku_id).maybeSingle()
+          : Promise.resolve({ data: null }),
       ]);
       if (cancelled) return;
       const priceN = Number((priceRes.data as { unit_price?: number | string } | null)?.unit_price);
@@ -983,9 +1260,21 @@ function ThreadModal({
     const spotDescParam = descTrim !== "" && descTrim !== originalDesc ? descTrim : null;
     const titleTrim = editTitle.trim();
     const spotTitleParam = titleTrim !== "" && titleTrim !== originalTitle ? titleTrim : null;
+    // 沒 SKU 的手打商品沒有 fallback，標題不能清空（DB 也會擋，這裡先講人話）
+    if (post.sku_id == null && spotTitleParam == null) {
+      setErr("這則是手打的商品、沒有商品主檔可沿用，標題不能留空");
+      return;
+    }
     const expDate = new Date(editExpiresAt);
     if (Number.isNaN(expDate.getTime())) { setErr("到期時間格式不正確"); return; }
     if (expDate <= new Date()) { setErr("到期時間需在未來（要立刻下架請用「結束此貼」）"); return; }
+    // 數量只有手動現貨能改；從訂單釋出的貼文 qty 和認領扣量綁在一起，不送這個參數
+    let qtyParam: number | null = null;
+    if (isManual) {
+      const qtyN = Number(editQty);
+      if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("數量需 > 0"); return; }
+      qtyParam = qtyN;
+    }
     setSavingEdit(true);
     try {
       const sb = getSupabase();
@@ -999,11 +1288,16 @@ function ThreadModal({
         p_spot_description: spotDescParam,
         p_expires_at: expDate.toISOString(),
         p_spot_title: spotTitleParam,
+        // 圖片留空 = 清除自訂、回沿用商品主檔的圖
+        p_spot_images: editImages.length > 0 ? editImages : null,
+        p_spot_unit: editUnit.trim() || null,
+        p_qty_available: qtyParam,
       });
       if (e) { setErr(e.message); return; }
       setSavedSpotPrice(spotPriceParam);
       setSavedSpotTitle(spotTitleParam);
       setSavedExpiresAt(expDate.toISOString());
+      if (qtyParam != null) setSavedQty({ available: qtyParam, remaining: qtyParam });
       setEditOpen(false);
       onEdited();
     } catch (e) {
@@ -1094,6 +1388,11 @@ function ThreadModal({
             <span className="font-medium text-zinc-700 dark:text-zinc-300">{post.store_name}</span>
             <span className="text-zinc-500">釋出</span>
             <span>{post.sku_label}</span>
+            {isManual && (
+              <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+                手動{post.sku_id == null ? "・手打商品" : ""}
+              </span>
+            )}
             {savedSpotTitle && (
               <span className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-800 dark:bg-blue-950 dark:text-blue-300">
                 App 標題：{savedSpotTitle}
@@ -1103,9 +1402,9 @@ function ThreadModal({
           <div className="flex flex-wrap gap-x-4 gap-y-1 text-zinc-500">
             <span>
               {post.post_type === "request" ? "尚需" : "可釋"}{" "}
-              <span className="font-mono text-zinc-700 dark:text-zinc-300">{post.qty_remaining}</span>
-              {post.qty_remaining !== post.qty_available && (
-                <span className="ml-1 text-[10px] text-zinc-400">/ 原 {post.qty_available}</span>
+              <span className="font-mono text-zinc-700 dark:text-zinc-300">{savedQty.remaining}</span>
+              {savedQty.remaining !== savedQty.available && (
+                <span className="ml-1 text-[10px] text-zinc-400">/ 原 {savedQty.available}</span>
               )}
             </span>
             <span>到期 <span className="text-zinc-700 dark:text-zinc-300">{fmtDt(savedExpiresAt)}</span></span>
@@ -1129,8 +1428,8 @@ function ThreadModal({
           </div>
         </div>
 
-        {/* 發佈後編輯：商品標題 / 釋出單價 / 到期時間 / 商品說明
-            （僅 offer + active；改完會員端即時生效） */}
+        {/* 發佈後編輯：商品標題 / 釋出單價 / 單位 / 數量 / 到期時間 / 商品說明 / 圖片
+            （僅 offer + active；改完會員端即時生效。數量只有手動現貨能改） */}
         {canEdit && editOpen && (
           <div className="flex flex-col gap-2 rounded-md border border-blue-200 bg-blue-50/40 p-3 text-xs dark:border-blue-900 dark:bg-blue-950/20">
             <label>
@@ -1138,21 +1437,47 @@ function ThreadModal({
               <input
                 value={editTitle}
                 onChange={(e) => setEditTitle(e.target.value)}
-                placeholder={originalTitle || "留空 = 沿用商品名稱"}
+                placeholder={originalTitle || (post.sku_id == null ? "手打商品，標題必填" : "留空 = 沿用商品名稱")}
                 className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
               />
             </label>
+            {isManual && (
+              <div className="grid grid-cols-2 gap-2">
+                <label>
+                  <span className="mb-1 block text-zinc-500">數量</span>
+                  <input
+                    value={editQty}
+                    onChange={(e) => setEditQty(e.target.value)}
+                    inputMode="decimal"
+                    className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
+                  />
+                  <span className="mt-0.5 block text-[11px] text-zinc-400">手動現貨沒有認領扣量，改了就直接覆蓋剩餘量</span>
+                </label>
+                <label>
+                  <span className="mb-1 block text-zinc-500">單位</span>
+                  <input
+                    value={editUnit}
+                    onChange={(e) => setEditUnit(e.target.value)}
+                    placeholder={post.sku_id != null ? "留空 = 商品單位" : "包 / 份"}
+                    className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+                  />
+                </label>
+              </div>
+            )}
             <label>
               <span className="mb-1 block text-zinc-500">釋出單價</span>
               <input
                 value={editPrice}
                 onChange={(e) => setEditPrice(e.target.value)}
                 inputMode="decimal"
-                placeholder="留空 = 原價"
+                placeholder={originalPrice != null ? "留空 = 原價" : "留空 = 不顯示"}
                 className="w-40 rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
               />
               {(() => {
-                if (originalPrice == null) return null;
+                // 手動現貨沒有來源訂單 → 沒有「原價」可比，也就沒有刪除線那套
+                if (originalPrice == null) {
+                  return <span className="ml-2 text-[11px] text-zinc-400">沒有來源訂單，留空的話 App 不顯示金額</span>;
+                }
                 const n = Number(editPrice);
                 if (editPrice.trim() !== "" && Number.isFinite(n) && n < originalPrice) {
                   return (
@@ -1185,6 +1510,13 @@ function ThreadModal({
                 className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
               />
             </label>
+            <div>
+              <span className="mb-1 block text-zinc-500">
+                商品圖片
+                {post.sku_id != null && <span className="ml-1 text-zinc-400">（留空 = 沿用商品主檔的圖）</span>}
+              </span>
+              <ProductImagesField value={editImages} onChange={setEditImages} />
+            </div>
             <div className="flex justify-end gap-2">
               <SpinButton
                 onClick={() => setEditOpen(false)}
@@ -1249,7 +1581,8 @@ function ThreadModal({
             />
             <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
               <div className="flex flex-wrap gap-2">
-                {post.post_type === "offer" && (
+                {/* 手動現貨沒有來源訂單 → 沒東西可轉移，認領按鈕不該出現 */}
+                {post.post_type === "offer" && !isManual && (
                   <SpinButton
                     type="button"
                     onClick={() => setClaimOpen(true)}
@@ -1259,12 +1592,17 @@ function ThreadModal({
                     ✋ 我要認領
                   </SpinButton>
                 )}
+                {post.post_type === "offer" && isManual && (
+                  <span className="self-center text-[11px] text-zinc-400">
+                    手動現貨・只給會員看，不開放跨店認領
+                  </span>
+                )}
                 {canEdit && !editOpen && (
                   <SpinButton
                     type="button"
                     onClick={() => setEditOpen(true)}
                     className="rounded-md border border-blue-400 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-                    title="修改釋出單價 / 商品說明（會員端即時生效）"
+                    title="修改標題 / 單價 / 到期 / 說明 / 圖片（會員端即時生效）"
                   >
                     ✏️ 修改內容
                   </SpinButton>

--- a/apps/member/src/components/SpotProductCard.tsx
+++ b/apps/member/src/components/SpotProductCard.tsx
@@ -10,7 +10,8 @@ import Link from "next/link";
  */
 export type SpotProduct = {
   id: number;
-  sku_id: number;
+  /** 手動上架的現貨可能沒有 SKU（店家直接手打的商品，商品主檔沒有） */
+  sku_id: number | null;
   sku_code: string | null;
   product_name: string | null;
   variant_name: string | null;

--- a/docs/PLAN-現貨專區.md
+++ b/docs/PLAN-現貨專區.md
@@ -20,17 +20,41 @@
 
 | 項目 | 內容 |
 |---|---|
-| 資料來源 | `mutual_aid_board` 的 `post_type='offer'`（互助交流板「我有庫存可提供」） |
+| 資料來源 | `mutual_aid_board` 的 `post_type='offer'`。兩條進貨路徑：①「我有庫存可提供」從既有訂單釋出（有 `source_customer_order_id`）②「手動新增現貨」店家直接上架（`source_customer_order_id IS NULL`，見 §1.1） |
 | 上架條件 | `status='active'` ＋ `expires_at > now()` ＋ `qty_remaining > 0` |
 | 不收錄 | `post_type='request'`（我要求助，是店對店求援不是貨）；板上 `note`（店對店內部備註，不外流） |
 | 自動下架 | 被認領光（`exhausted`）／到期（既有 cron `purge-expired-aid-board` 每 10 分鐘跑）／店家取消 —— 三種都自動從 App 消失，不必另外做 |
 | 單價來源 | `mutual_aid_board.spot_price`（店家上架時可改，2026-08-02 加）優先；沒改則用來源訂單 `customer_order_items.unit_price`。釋出價**低於**原價時回 `original_price`，會員端畫刪除線 |
 | 商品說明 | `mutual_aid_board.spot_description`（上架時可改寫原文）優先；沒改 fallback `products.description` |
 | 商品標題 | `mutual_aid_board.spot_title`（上架時可改寫，2026-08-02 加）優先；沒改則由會員端組 `product_name／variant_name` |
+| 商品圖片 | `mutual_aid_board.spot_images`（JSONB 路徑陣列，2026-08-02 加）優先；沒設 fallback `products.images` |
+| 數量單位 | `mutual_aid_board.spot_unit`（2026-08-02 加）優先；沒設 fallback `skus.base_unit` |
 | 會員所在店 | `members.home_store_id`；未綁定會員退回 JWT 的 `store_id`（掃碼進站那間） |
 
 **命名分工**：對會員講「現貨專區」（現成的貨、不用等團購結單）；卡片上仍標「◯◯店 釋出」當來源。
 對店家端（admin 互助交流板）用語完全不動。
+
+### 1.1 手動現貨（2026-08-02 加）
+
+店裡自製、臨時進的貨不會有客人棄單的訂單可以釋出，所以另開一條路：admin 互助板
+「➕ 手動新增現貨」。可以從商品庫挑 SKU 帶出名稱與主檔圖，也可以**整個手打**
+（`sku_id` 留 NULL）。金額、單位、圖片、說明、到期都自己填。
+
+| | 從訂單釋出（📦 我有庫存可提供） | 手動新增（➕ 手動新增現貨） |
+|---|---|---|
+| 入口 RPC | `rpc_post_aid_board` | `rpc_post_manual_spot` |
+| `source_customer_order_id` | 必填 | 恆為 NULL |
+| `sku_id` | 必填（來自訂單品項） | 選填 |
+| 金額 | 預填訂單原價，可改；低於原價畫刪除線 | 純自填，沒有「原價」可比 → 不會有刪除線 |
+| 別店可否認領 | ✅ 走 `rpc_transfer_order_partial` 轉訂單 | ❌ 沒有訂單可轉，admin 藏掉認領鍵 |
+| 數量可否事後改 | ❌ 和認領扣量的帳綁在一起 | ✅ 沒有扣量帳，直接覆寫 |
+
+**「手動」的判準就是 `source_customer_order_id IS NULL`**，不另立 `is_manual` 旗標
+—— 少一個會不同步的欄位。
+
+⚠ 為此放寬了 `20260509000001` 訂的 `aid_board_source_consistency`（原本要求
+offer 一定有 source_order）。offer 那半邊的把關改由 `rpc_post_aid_board` 自己
+`RAISE` 負責（那支一行沒動），走訂單釋出路徑一樣進不來沒有訂單的列。
 
 ---
 
@@ -209,7 +233,9 @@ tab active 判斷是 `pathname.startsWith(t.href)`。所以現貨專區**必須�
 | `supabase/migrations/20260802000010_rpc_update_aid_board_listing.sql` | 新增 | 發佈後編輯：`rpc_update_aid_board_listing`（僅 active offer；NULL = 清除自訂回到沿用）。互助板點開貼文 →「✏️ 修改內容」 |
 | `supabase/migrations/20260802000020_aid_listing_edit_expires_at.sql` | 新增 | 上面那支加 `p_expires_at`（4 → 5 參數）。⚠ 它的 NULL 語意與另兩個相反：`expires_at` 是 NOT NULL 欄位，NULL = 不動；且不得設到過去（要立刻下架請用「結束此貼」） |
 | `supabase/migrations/20260802000030_aid_board_spot_title.sql` | 新增 | `mutual_aid_board` 加 `spot_title`；`rpc_post_aid_board` 10 → 11、`rpc_update_aid_board_listing` 5 → 6 參數。NULL = 沒改，會員端 fallback 回 SKU 組出的標題 |
-| `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` | 改 | 「我有庫存可提供」表單加「商品標題」（預填 `product_name／variant_name`）、「釋出單價」（預填原價，可改；低於原價有提示）與「商品說明」textarea（預填原文純文字，可改寫）；沒改的值送 NULL。ThreadModal 的「✏️ 修改內容」同樣四欄都能改 |
+| `supabase/migrations/20260802000040_manual_spot_listing.sql` | 新增 | 手動現貨（見 §1.1）：`sku_id` 放寬 nullable、放寬 `aid_board_source_consistency`、加 `spot_images` / `spot_unit` 與兩條 CHECK、新增 `rpc_post_manual_spot`、`rpc_update_aid_board_listing` 6 → 9 參數 |
+| `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` | 改 | 「我有庫存可提供」表單加「商品標題」（預填 `product_name／variant_name`）、「釋出單價」（預填原價，可改；低於原價有提示）與「商品說明」textarea（預填原文純文字，可改寫）；沒改的值送 NULL。ThreadModal 的「✏️ 修改內容」同樣四欄都能改。新增 `ManualSpotModal`（➕ 手動新增現貨）；列表與 ThreadModal 對手動貼文標「手動」badge、藏掉認領鍵 |
+| `apps/admin/src/components/ProductImagesField.tsx` | 沿用 | 手動現貨與編輯區的圖片上傳直接重用商品主檔那支（同 `products` bucket、同 `tenant_id/uuid.ext` 路徑規則） |
 
 店家操作照舊：按「我有庫存可提供」發貼文，會員端就自動看得到；標題、價格與說明想改才改。
 

--- a/docs/TEST-member-spot-zone.md
+++ b/docs/TEST-member-spot-zone.md
@@ -10,6 +10,7 @@
 - Migration `20260801000020_rpc_upsert_store_line_oa.sql`（`rpc_upsert_store` 加 `p_line_oa_basic_id`）
 - Migration `20260802000000_aid_board_spot_price_description.sql`（互助板 offer 可自訂釋出單價與商品說明）
 - Migration `20260802000030_aid_board_spot_title.sql`（互助板 offer 可自訂商品標題，上架時填、發佈後可改）
+- Migration `20260802000040_manual_spot_listing.sql`（手動新增現貨：免訂單、可手打商品、可傳圖）
 - 會員端：底部 tab bar 中央凸起鍵、`/spot` 列表、`/spot/[id]` 詳情（`/shop` 的現貨導流區塊已移除，見 T6）
 - 元件：`SpotProductCard.tsx`、`lib/lineInquiry.ts`
 - admin：`/stores` 的「LINE@ ID」欄位
@@ -61,6 +62,32 @@
 | T1-19 | **發佈後改標題**：ThreadModal →「✏️ 修改內容」→ 改「商品標題」存檔 | 標頭出現藍色「App 標題：◯◯」標記；App 重新整理即時生效 |
 | T1-20 | 把標題清空（或改回預填值）存檔 | `spot_title` 回 `NULL`，App 回到 SKU 組出的標題 |
 | T1-21 | SQL 直呼 `rpc_post_aid_board` 用 `p_post_type='request'` 帶 `p_spot_title` | 炸 `spot_title is only valid for offer posts` |
+
+## T1M — 手動新增現貨（免訂單）
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T1M-1 | admin `/inventory/mutual-aid` →「➕ 手動新增現貨」 | 開出 modal，最上面有綠色提示說明「不需要來源訂單、別的分店不能認領」 |
+| T1M-2 | **不選 SKU**、標題留空就送出 | 擋下「沒有從商品庫選品項時，商品標題必填」 |
+| T1M-3 | **不選 SKU**、標題打「今日現滷拼盤」＋數量 8＋單位「份」＋金額 180＋上傳 2 張圖 | 上架成功；`mutual_aid_board` 該列 `sku_id IS NULL`、`source_customer_order_id IS NULL`、`spot_images` 是 2 個路徑的陣列 |
+| T1M-4 | 從商品庫選 SKU | 「商品標題」自動帶入 `商品名稱／規格`；已經手打過的標題**不會**被覆蓋 |
+| T1M-5 | 選了 SKU 後按「清除選擇，改成手打」 | SKU 清掉，但已經打好的標題保留（打過的字不憑空消失） |
+| T1M-6 | 選了 SKU、圖片留空 | 會員端 fallback 顯示商品主檔的圖 |
+| T1M-7 | 金額留空 | 上架成功，`spot_price IS NULL`；會員端本店看到的價格位置是「—」 |
+| T1M-8 | 金額填 0 / 負數 | 擋下「金額需 > 0（留空 = 不顯示金額）」 |
+| T1M-9 | 到期時間設到過去 | 擋下「到期時間需在未來」 |
+| T1M-10 | 手動貼文在列表 | 品名旁有綠色「手動」badge |
+| T1M-11 | 點開手動貼文 | **沒有「✋ 我要認領」按鈕**，改顯示「手動現貨・只給會員看，不開放跨店認領」 |
+| T1M-12 | 手動貼文 →「✏️ 修改內容」 | 編輯區比訂單來源的多出 **數量** 與 **單位** 兩欄，最下面有 **商品圖片** 上傳區 |
+| T1M-13 | 改數量存檔 | 標頭「可釋」即時更新；`qty_available` 與 `qty_remaining` 一起被覆寫 |
+| T1M-14 | **訂單來源**的貼文 →「✏️ 修改內容」 | **沒有**數量欄（qty 和認領扣量的帳綁在一起）；SQL 直呼帶 `p_qty_available` 會炸 `qty of an order-sourced listing cannot be edited` |
+| T1M-15 | 手打（無 SKU）貼文把標題清空存檔 | 擋下「這則是手打的商品、沒有商品主檔可沿用，標題不能留空」；SQL 直呼也會炸 `this listing has no sku — spot_title cannot be cleared` |
+| T1M-16 | 編輯區把圖片全刪掉存檔 | `spot_images` 回 `NULL`；有 SKU 的話 App 回到顯示主檔圖，手打的話變成品牌底placeholder |
+| T1M-17 | 會員 App `/spot` | 手動現貨和訂單現貨混在同一個列表，本店的一樣排前面、一樣看得到金額；跨店一樣鎖頭 |
+| T1M-18 | 手打商品的 `/spot/[id]` | 標題是 `spot_title`、圖是 `spot_images`、**沒有「商品編號」那一列**（沒有 SKU） |
+| T1M-19 | SQL 直呼 `rpc_post_manual_spot` 帶 `p_spot_images => '{"a":1}'::jsonb` | 炸 `spot_images must be a JSON array of storage paths` |
+| T1M-20 | SQL 直接 INSERT 一列 `post_type='request'` 且 `sku_id IS NULL` | 撞 CHECK `chk_aid_board_request_needs_sku`（求助一定要有 SKU 才轉得了單） |
+| T1M-21 | SQL 直呼 `rpc_post_aid_board` 用 `p_post_type='offer'` 但 `p_source_customer_order_id => NULL` | 仍炸 `offer post requires p_source_customer_order_id`（放寬 CHECK 沒有替訂單釋出路徑開洞） |
 | T1-2 | 同上用 B 店再發一則（挑不同 SKU 好辨識） | 貼文成立 |
 | T1-3 | `SELECT id, post_type, status, offering_store_id, sku_id, qty_remaining, expires_at FROM mutual_aid_board WHERE post_type='offer' AND status='active';` | 兩筆，`expires_at` 在未來、`qty_remaining > 0` |
 

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -46,6 +46,28 @@ function toPublicUrl(
   return `${supabaseUrl}/storage/v1/object/public/${bucket}/${pathOrUrl}`;
 }
 
+/**
+ * 現貨貼文的圖片：貼文自帶的 spot_images 優先，沒有才 fallback 回商品主檔。
+ *
+ * 兩邊都是 products bucket 的相對路徑陣列，但主檔那份歷史上允許
+ * `{ url }` 物件，所以這裡兩種形狀都收。手打的商品沒有 SKU、只有 spot_images。
+ */
+function resolveSpotImages(
+  supabaseUrl: string,
+  spotImages: unknown,
+  productImages: unknown,
+): string[] {
+  const src = Array.isArray(spotImages) && spotImages.length > 0 ? spotImages : productImages;
+  if (!Array.isArray(src)) return [];
+  const out: string[] = [];
+  for (const img of src) {
+    const path = typeof img === "string" ? img : (img as any)?.url ?? null;
+    const url = toPublicUrl(supabaseUrl, "products", path);
+    if (url && !out.includes(url)) out.push(url);
+  }
+  return out;
+}
+
 // ─── actions ─────────────────────────────────────────────────────────────────
 
 async function listStores(sb: any, tenantId: string) {
@@ -347,7 +369,7 @@ async function listSpotProducts(
   const { data: rows, error } = await sb
     .from("mutual_aid_board")
     .select(
-      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, spot_price, spot_title, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, images))",
+      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, spot_price, spot_title, spot_unit, spot_images, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, images))",
     )
     .eq("tenant_id", tenantId)
     .eq("post_type", "offer")
@@ -407,10 +429,7 @@ async function listSpotProducts(
   const supabaseUrl = requireEnv("SUPABASE_URL");
   const items = (rows ?? []).map((r: any) => {
     const isMyStore = Number(r.offering_store_id) === myStoreId;
-    const imgs = r.sku?.product?.images;
-    const rawImg = Array.isArray(imgs) && imgs.length > 0
-      ? (typeof imgs[0] === "string" ? imgs[0] : imgs[0]?.url ?? null)
-      : null;
+    const images = resolveSpotImages(supabaseUrl, r.spot_images, r.sku?.product?.images);
     // 原價 = 來源訂單單價；釋出價 = 店家上架時自訂的 spot_price（沒填就用原價）。
     // 釋出價低於原價才回 original_price（會員端據此畫刪除線）；跨店兩者皆 null。
     const original = isMyStore && r.source_customer_order_id != null
@@ -425,14 +444,15 @@ async function listSpotProducts(
       : null;
     return {
       id: Number(r.id),
-      sku_id: Number(r.sku_id),
+      // 手動上架的現貨可能完全沒有 SKU（店家直接手打的商品）
+      sku_id: r.sku_id != null ? Number(r.sku_id) : null,
       sku_code: r.sku?.sku_code ?? null,
       product_name: r.sku?.product_name ?? r.sku?.product?.name ?? null,
       variant_name: r.sku?.variant_name ?? null,
       // 上架時改寫的標題優先；沒改就由前端組 product_name／variant_name
       spot_title: r.spot_title ?? null,
-      unit: r.sku?.base_unit ?? null,
-      image_url: toPublicUrl(supabaseUrl, "products", rawImg),
+      unit: r.spot_unit ?? r.sku?.base_unit ?? null,
+      image_url: images[0] ?? null,
       store_id: Number(r.offering_store_id),
       store_name: storeNameMap.get(Number(r.offering_store_id)) ?? null,
       qty_remaining: Number(r.qty_remaining ?? 0),
@@ -477,7 +497,7 @@ async function getSpotProduct(
   const { data: r, error } = await sb
     .from("mutual_aid_board")
     .select(
-      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, spot_price, spot_description, spot_title, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, description, images))",
+      "id, offering_store_id, sku_id, qty_remaining, expires_at, created_at, source_customer_order_id, spot_price, spot_description, spot_title, spot_unit, spot_images, sku:skus(sku_code, product_name, variant_name, base_unit, product:products(name, description, images))",
     )
     .eq("tenant_id", tenantId)
     .eq("id", boardId)
@@ -534,20 +554,13 @@ async function getSpotProduct(
   }
 
   const supabaseUrl = requireEnv("SUPABASE_URL");
-  const rawImgs = r.sku?.product?.images;
-  const images: string[] = [];
-  if (Array.isArray(rawImgs)) {
-    for (const img of rawImgs) {
-      const path = typeof img === "string" ? img : img?.url ?? null;
-      const url = toPublicUrl(supabaseUrl, "products", path);
-      if (url && !images.includes(url)) images.push(url);
-    }
-  }
+  const images = resolveSpotImages(supabaseUrl, r.spot_images, r.sku?.product?.images);
 
   return json({
     item: {
       id: Number(r.id),
-      sku_id: Number(r.sku_id),
+      // 手動上架的現貨可能完全沒有 SKU（店家直接手打的商品）
+      sku_id: r.sku_id != null ? Number(r.sku_id) : null,
       sku_code: r.sku?.sku_code ?? null,
       product_name: r.sku?.product_name ?? r.sku?.product?.name ?? null,
       variant_name: r.sku?.variant_name ?? null,
@@ -555,7 +568,7 @@ async function getSpotProduct(
       spot_title: r.spot_title ?? null,
       // 上架時改寫的說明優先；沒改就 fallback 回商品主檔
       description: r.spot_description ?? r.sku?.product?.description ?? null,
-      unit: r.sku?.base_unit ?? null,
+      unit: r.spot_unit ?? r.sku?.base_unit ?? null,
       image_url: images[0] ?? null,
       images,
       store_id: Number(r.offering_store_id),

--- a/supabase/migrations/20260802000040_manual_spot_listing.sql
+++ b/supabase/migrations/20260802000040_manual_spot_listing.sql
@@ -1,0 +1,284 @@
+-- ============================================================
+-- 2026-08-02: 手動新增現貨（不需要來源訂單）
+--
+-- 需求：現貨專區目前只能從「客人棄單的 ready 訂單」釋出。店家想直接把
+--       店裡現有的東西丟上架 —— 可以從商品庫選 SKU，也可以完全手打
+--       （店裡自製、臨時進的貨，主檔根本沒有）。金額自己填、圖片自己傳。
+--
+-- 資料模型：手動現貨就是 post_type='offer' 且 source_customer_order_id IS NULL
+--   的 mutual_aid_board 列。不另立 is_manual 旗標 —— 「沒有來源訂單」本身
+--   就是唯一且不會不同步的判準。
+--
+-- ⚠ 手動現貨**不能被別店認領**：認領走 rpc_transfer_order_partial，需要一張
+--   真的訂單。admin 端會對 source_customer_order_id IS NULL 的貼文藏掉
+--   「我要認領」。它是純粹的會員端商品，不是店對店互助標的。
+--
+-- 變動：
+--   1. sku_id 放寬為 nullable（手打商品沒有 SKU）
+--   2. 放寬 aid_board_source_consistency：offer 不再強制要有 source_order
+--   3. 加 spot_images（JSONB，同 products.images 格式）、spot_unit
+--   4. 三條 CHECK 守住放寬後的空間
+--   5. 新增 rpc_post_manual_spot
+--   6. rpc_update_aid_board_listing 6 → 9 參數（圖片 / 單位 / 數量也能改）
+--
+-- 基底版本（已 grep supabase/migrations/ 確認是最新版）：
+--   - rpc_update_aid_board_listing → 20260802000030_aid_board_spot_title.sql
+--     （歷史：20260802000010 4 → 20260802000020 5 → 20260802000030 6 參數）
+--     原有的 offer/active 檢查與各參數 NULL 語意一字未改，只多接三個。
+--   - rpc_post_aid_board **完全不動**：它的核心保證是「offer 必須來自訂單」，
+--     那是認領/轉移流程安全的前提，不在這裡開洞。手動現貨走新的入口。
+--
+-- Rollback：
+--   DROP FUNCTION IF EXISTS public.rpc_post_manual_spot(
+--     BIGINT, BIGINT, TEXT, NUMERIC, TIMESTAMPTZ, NUMERIC, TEXT, TEXT, JSONB, TEXT, UUID);
+--   DROP FUNCTION IF EXISTS public.rpc_update_aid_board_listing(
+--     BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ, TEXT, JSONB, TEXT, NUMERIC);
+--   -- 重跑 20260802000030 的 §2 段落
+--   ALTER TABLE mutual_aid_board
+--     DROP CONSTRAINT chk_aid_board_request_needs_sku,
+--     DROP CONSTRAINT chk_aid_board_displayable,
+--     DROP CONSTRAINT aid_board_source_consistency,
+--     DROP COLUMN spot_images,
+--     DROP COLUMN spot_unit;
+--   -- 復原 20260509000001 的原版（offer 必須有 source_order）：
+--   DELETE FROM mutual_aid_board
+--    WHERE post_type = 'offer' AND source_customer_order_id IS NULL;
+--   ALTER TABLE mutual_aid_board ADD CONSTRAINT aid_board_source_consistency CHECK (
+--     (post_type = 'offer' AND source_customer_order_id IS NOT NULL)
+--     OR (post_type = 'request' AND source_customer_order_id IS NULL));
+--   -- ⚠ 復原 sku_id NOT NULL 前要先清掉手打的列，否則 ALTER 會失敗：
+--   --   DELETE FROM mutual_aid_board WHERE sku_id IS NULL;
+--   ALTER TABLE mutual_aid_board ALTER COLUMN sku_id SET NOT NULL;
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. 欄位
+-- ------------------------------------------------------------
+ALTER TABLE mutual_aid_board
+  ALTER COLUMN sku_id DROP NOT NULL;
+
+ALTER TABLE mutual_aid_board
+  ADD COLUMN spot_images JSONB,
+  ADD COLUMN spot_unit   TEXT;
+
+COMMENT ON COLUMN mutual_aid_board.sku_id IS
+  '對應商品 SKU。手動現貨可為 NULL（店家直接手打的商品，主檔沒有）；'
+  'request 貼文一定要有（認領要靠它轉移訂單）。';
+
+COMMENT ON COLUMN mutual_aid_board.spot_images IS
+  '這則貼文專用的圖片（JSONB 字串陣列，storage products bucket 的相對路徑，'
+  '格式同 products.images）；NULL = 會員端 fallback 回商品主檔的圖。';
+
+COMMENT ON COLUMN mutual_aid_board.spot_unit IS
+  '數量單位（例「包」「份」）；NULL = 會員端 fallback 回 skus.base_unit。';
+
+-- 20260509000001 訂的 aid_board_source_consistency 是
+--   「offer 一定有 source_order、request 一定沒有」。
+-- 手動現貨正是「offer 但沒有 source_order」，所以要放寬成只管 request 那半邊。
+-- offer 的 source_order 改由 rpc_post_aid_board 自己 RAISE 把關（那支沒動），
+-- 走它的訂單釋出路徑一樣進不來沒有訂單的列。
+ALTER TABLE mutual_aid_board
+  DROP CONSTRAINT aid_board_source_consistency;
+
+ALTER TABLE mutual_aid_board
+  ADD CONSTRAINT aid_board_source_consistency
+  CHECK (post_type <> 'request' OR source_customer_order_id IS NULL);
+
+-- request 一定要有 SKU：它會被別店「回應求助」轉單，沒 SKU 沒得轉
+ALTER TABLE mutual_aid_board
+  ADD CONSTRAINT chk_aid_board_request_needs_sku
+  CHECK (post_type <> 'request' OR sku_id IS NOT NULL);
+
+-- 會員端一定要有東西可顯示：不是有 SKU（組得出標題）就是有自訂標題
+ALTER TABLE mutual_aid_board
+  ADD CONSTRAINT chk_aid_board_displayable
+  CHECK (sku_id IS NOT NULL OR spot_title IS NOT NULL);
+
+-- ------------------------------------------------------------
+-- 2. rpc_post_manual_spot — 手動上架（新函式，無歷史版本）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_post_manual_spot(
+  p_offering_store_id BIGINT,
+  p_sku_id            BIGINT,
+  p_spot_title        TEXT,
+  p_qty_available     NUMERIC,
+  p_expires_at        TIMESTAMPTZ,
+  p_spot_price        NUMERIC     DEFAULT NULL,
+  p_spot_description  TEXT        DEFAULT NULL,
+  p_spot_unit         TEXT        DEFAULT NULL,
+  p_spot_images       JSONB       DEFAULT NULL,
+  p_note              TEXT        DEFAULT NULL,
+  p_operator          UUID        DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant_id UUID;
+  v_title     TEXT := NULLIF(trim(p_spot_title), '');
+  v_images    JSONB;
+  v_board_id  BIGINT;
+BEGIN
+  IF p_qty_available IS NULL OR p_qty_available <= 0 THEN
+    RAISE EXCEPTION 'qty_available must be > 0';
+  END IF;
+  IF p_expires_at IS NULL OR p_expires_at <= NOW() THEN
+    RAISE EXCEPTION 'expires_at must be in the future';
+  END IF;
+  IF p_spot_price IS NOT NULL AND p_spot_price <= 0 THEN
+    RAISE EXCEPTION 'spot_price must be > 0';
+  END IF;
+  -- 沒選 SKU 就一定要有標題，否則會員端沒東西可顯示（也會撞 CHECK）
+  IF p_sku_id IS NULL AND v_title IS NULL THEN
+    RAISE EXCEPTION 'manual spot without sku_id requires spot_title';
+  END IF;
+
+  SELECT tenant_id INTO v_tenant_id FROM stores WHERE id = p_offering_store_id;
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'store % not found', p_offering_store_id;
+  END IF;
+
+  IF p_sku_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM skus WHERE id = p_sku_id) THEN
+    RAISE EXCEPTION 'sku % not found', p_sku_id;
+  END IF;
+
+  -- 圖片必須是字串陣列（storage 相對路徑）；空陣列存 NULL = 沿用主檔圖
+  IF p_spot_images IS NOT NULL THEN
+    IF jsonb_typeof(p_spot_images) <> 'array' THEN
+      RAISE EXCEPTION 'spot_images must be a JSON array of storage paths';
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM jsonb_array_elements(p_spot_images) e
+       WHERE jsonb_typeof(e) <> 'string'
+    ) THEN
+      RAISE EXCEPTION 'spot_images must contain only strings';
+    END IF;
+    v_images := NULLIF(p_spot_images, '[]'::jsonb);
+  END IF;
+
+  INSERT INTO mutual_aid_board (
+    tenant_id, offering_store_id, sku_id, qty_available, qty_remaining,
+    expires_at, note, status, post_type, source_customer_order_id,
+    spot_price, spot_description, spot_title, spot_unit, spot_images,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant_id, p_offering_store_id, p_sku_id, p_qty_available, p_qty_available,
+    p_expires_at, NULLIF(trim(p_note), ''), 'active', 'offer', NULL,
+    p_spot_price, NULLIF(trim(p_spot_description), ''), v_title,
+    NULLIF(trim(p_spot_unit), ''), v_images,
+    p_operator, p_operator
+  )
+  RETURNING id INTO v_board_id;
+
+  RETURN v_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_post_manual_spot(
+  BIGINT, BIGINT, TEXT, NUMERIC, TIMESTAMPTZ, NUMERIC, TEXT, TEXT, JSONB, TEXT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_post_manual_spot IS
+  '手動上架現貨：post_type=offer 但沒有來源訂單。p_sku_id 可為 NULL（純手打，'
+  '此時 p_spot_title 必填）。這種貼文不能被別店認領（沒有訂單可轉移）。';
+
+-- ------------------------------------------------------------
+-- 3. rpc_update_aid_board_listing：6 → 9 參數
+--    加 p_spot_images / p_spot_unit / p_qty_available
+-- ------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.rpc_update_aid_board_listing(
+  BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ, TEXT);
+
+CREATE OR REPLACE FUNCTION public.rpc_update_aid_board_listing(
+  p_board_id         BIGINT,
+  p_operator         UUID,
+  p_spot_price       NUMERIC     DEFAULT NULL,
+  p_spot_description TEXT        DEFAULT NULL,
+  p_expires_at       TIMESTAMPTZ DEFAULT NULL,
+  p_spot_title       TEXT        DEFAULT NULL,
+  p_spot_images      JSONB       DEFAULT NULL,
+  p_spot_unit        TEXT        DEFAULT NULL,
+  p_qty_available    NUMERIC     DEFAULT NULL
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_post_type TEXT;
+  v_status    TEXT;
+  v_sku_id    BIGINT;
+  v_order_id  BIGINT;
+  v_title     TEXT := NULLIF(trim(p_spot_title), '');
+  v_images    JSONB;
+BEGIN
+  IF p_spot_price IS NOT NULL AND p_spot_price <= 0 THEN
+    RAISE EXCEPTION 'spot_price must be > 0';
+  END IF;
+  -- 到期時間可以往後延，也可以縮短，但不能設到過去
+  -- （設到過去等於立刻下架，那是「結束此貼」該做的事，語意分開）
+  IF p_expires_at IS NOT NULL AND p_expires_at <= NOW() THEN
+    RAISE EXCEPTION 'expires_at must be in the future';
+  END IF;
+  IF p_qty_available IS NOT NULL AND p_qty_available <= 0 THEN
+    RAISE EXCEPTION 'qty_available must be > 0';
+  END IF;
+  IF p_spot_images IS NOT NULL THEN
+    IF jsonb_typeof(p_spot_images) <> 'array' THEN
+      RAISE EXCEPTION 'spot_images must be a JSON array of storage paths';
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM jsonb_array_elements(p_spot_images) e
+       WHERE jsonb_typeof(e) <> 'string'
+    ) THEN
+      RAISE EXCEPTION 'spot_images must contain only strings';
+    END IF;
+    v_images := NULLIF(p_spot_images, '[]'::jsonb);
+  END IF;
+
+  SELECT post_type, status, sku_id, source_customer_order_id
+    INTO v_post_type, v_status, v_sku_id, v_order_id
+    FROM mutual_aid_board WHERE id = p_board_id
+    FOR UPDATE;
+  IF v_post_type IS NULL THEN
+    RAISE EXCEPTION 'board post % not found', p_board_id;
+  END IF;
+  IF v_post_type <> 'offer' THEN
+    RAISE EXCEPTION 'only offer posts have price/description';
+  END IF;
+  IF v_status <> 'active' THEN
+    RAISE EXCEPTION 'post is % — only active posts can be edited', v_status;
+  END IF;
+  -- 手打商品沒有 SKU 可以 fallback，標題不能清空（先擋，別讓它撞 CHECK）
+  IF v_sku_id IS NULL AND v_title IS NULL THEN
+    RAISE EXCEPTION 'this listing has no sku — spot_title cannot be cleared';
+  END IF;
+  -- 數量只有手動現貨能改：從訂單釋出的貼文，qty 和認領扣量的帳綁在一起，
+  -- 直接覆寫會讓已認領的量對不上（要調整請結束此貼重發）
+  IF p_qty_available IS NOT NULL AND v_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'qty of an order-sourced listing cannot be edited';
+  END IF;
+
+  UPDATE mutual_aid_board
+     SET spot_price       = p_spot_price,
+         spot_description = NULLIF(trim(p_spot_description), ''),
+         spot_title       = v_title,
+         spot_unit        = NULLIF(trim(p_spot_unit), ''),
+         spot_images      = v_images,
+         -- NULL = 不動（expires_at 是 NOT NULL，沒有「清除」的語意）
+         expires_at       = COALESCE(p_expires_at, expires_at),
+         -- 手動現貨沒有認領扣量，qty_available / qty_remaining 一起覆寫
+         qty_available    = COALESCE(p_qty_available, qty_available),
+         qty_remaining    = COALESCE(p_qty_available, qty_remaining),
+         updated_by       = p_operator
+   WHERE id = p_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_update_aid_board_listing(
+  BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ, TEXT, JSONB, TEXT, NUMERIC) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_update_aid_board_listing IS
+  '互助板 offer 貼文發佈後編輯釋出單價 / 商品說明 / 商品標題 / 單位 / 圖片 / '
+  '到期時間 / 數量。spot_price、spot_description、spot_title、spot_unit、'
+  'spot_images 的 NULL = 清除自訂值（回沿用原價 / 主檔原文 / SKU 標題 / '
+  'base_unit / 主檔圖）；expires_at 與 qty_available 的 NULL = 不動。'
+  'qty_available 只有手動現貨（無來源訂單）能改。僅 active 的 offer 可改。';


### PR DESCRIPTION
> ⚠ **這支疊在 #580 上面**（base 是 `claude/merchant-products-cross-store-hide-5c9v47`，不是 `main`），這樣 diff 才只有本次的內容。**請先合 #580**，這支會自動轉指向 `main`。

## 這是什麼

現貨專區原本只能從「客人棄單的 ready 訂單」釋出。店裡自製、臨時進的貨沒有那張訂單，等於上不了架。

新開一條路：互助板 **「➕ 手動新增現貨」**。可以從商品庫挑 SKU 帶出名稱與主檔圖，也可以**整個手打**（`sku_id` 留 NULL，商品主檔根本沒這東西也沒關係）。金額、單位、圖片、說明、到期都自己填。

## 資料模型

**手動現貨 = `post_type='offer'` 且 `source_customer_order_id IS NULL`**。不另立 `is_manual` 旗標 —— 「沒有來源訂單」本身就是唯一且不會不同步的判準。

| | 從訂單釋出（📦 我有庫存可提供） | 手動新增（➕ 手動新增現貨） |
|---|---|---|
| 入口 RPC | `rpc_post_aid_board` | `rpc_post_manual_spot` |
| `source_customer_order_id` | 必填 | 恆為 NULL |
| `sku_id` | 必填（來自訂單品項） | 選填 |
| 金額 | 預填訂單原價，可改；低於原價畫刪除線 | 純自填，沒有「原價」可比 → 不會有刪除線 |
| 別店可否認領 | ✅ 走 `rpc_transfer_order_partial` 轉訂單 | ❌ 沒有訂單可轉，admin 藏掉認領鍵 |
| 數量可否事後改 | ❌ 和認領扣量的帳綁在一起 | ✅ 沒有扣量帳，直接覆寫 |

### ⚠ 放寬了一條既有 CHECK

`20260509000001` 訂的 `aid_board_source_consistency` 原本是「offer 一定有 source_order、request 一定沒有」。手動現貨正是「offer 但沒有 source_order」，所以放寬成只管 request 那半邊：

```sql
CHECK (post_type <> 'request' OR source_customer_order_id IS NULL)
```

**offer 那半邊的把關改由 `rpc_post_aid_board` 自己 `RAISE` 負責 —— 那支一行沒動**，走訂單釋出路徑一樣進不來沒有訂單的列（下面有實測）。

補回兩條新 CHECK 守住放寬後的空間：

| CHECK | 守什麼 |
|---|---|
| `chk_aid_board_request_needs_sku` | request 一定要有 SKU（沒 SKU 就轉不了單） |
| `chk_aid_board_displayable` | 每列至少要有 `sku_id` 或 `spot_title`，會員端才有東西可顯示 |

## DB（migration `20260802000040`）

- `sku_id` 放寬 nullable
- 加 `spot_images`（JSONB 字串陣列，storage `products` bucket 相對路徑，格式同 `products.images`）與 `spot_unit`；各自 NULL = fallback 主檔圖 / `skus.base_unit`
- 新增 `rpc_post_manual_spot`（11 參數）
- `rpc_update_aid_board_listing` 6 → 9（`p_spot_images` / `p_spot_unit` / `p_qty_available`），基底是 `20260802000030`，原有的 offer/active 檢查與各參數 NULL 語意一字未改

兩個刻意的擋法：

- **`p_qty_available` 只有手動現貨能用**。訂單來源的 qty 和認領扣量的帳綁在一起，直接覆寫會讓已認領的量對不上 → RPC RAISE 擋掉（要調整請結束此貼重發）。
- **手打（無 SKU）的貼文不能把標題清空**。沒有主檔可以 fallback，先用人話 RAISE，不要讓它去撞 CHECK。

## 前後台

**admin 互助板**
- 新增 `ManualSpotModal`：釋出店 / SKU（選填，可「清除選擇，改成手打」）/ 商品標題 / 數量 / 單位 / 金額 / 到期 / 說明 / 圖片 / 備註
- 挑了 SKU 自動帶出標題，但**已經手打過的標題不覆蓋**、清掉選擇也不清標題
- 列表與 ThreadModal 對手動貼文標綠色「手動」badge（純手打再加「・手打商品」）
- 認領鍵換成「手動現貨・只給會員看，不開放跨店認領」
- 「✏️ 修改內容」加圖片上傳，手動貼文多出數量 / 單位兩欄
- 圖片直接重用商品主檔那支 `ProductImagesField`（同 bucket、同 `tenant_id/uuid.ext` 路徑規則），沒有另寫一份上傳邏輯

**liff-api**
- 回 `spot_unit` / `spot_images`；`sku_id` 可為 `null`
- 抽出 `resolveSpotImages()`：貼文自帶圖優先，沒有才 fallback 商品主檔（主檔那份歷史上允許 `{url}` 物件，兩種形狀都收）

**member**
- `SpotProduct.sku_id` 改 `number | null`。詳情頁的「商品編號」本來就有 `item.sku_code &&` 守著，手打商品那一列自動不出現

## 異動檔案

| 檔案 | 說明 |
|---|---|
| `supabase/migrations/20260802000040_manual_spot_listing.sql` | nullable `sku_id`、放寬/新增 CHECK、`spot_images` / `spot_unit`、`rpc_post_manual_spot`、update RPC 6 → 9 |
| `supabase/functions/liff-api/index.ts` | 兩個 action 回新欄位；`resolveSpotImages()` |
| `apps/member/src/components/SpotProductCard.tsx` | `sku_id` 改 nullable |
| `apps/admin/.../inventory/mutual-aid/page.tsx` | `ManualSpotModal`、編輯區圖片/單位/數量、手動 badge、認領鍵處理 |
| `docs/PLAN-現貨專區.md` / `docs/TEST-member-spot-zone.md` | 加 §1.1 手動現貨對照表；測試加 T1M-1~21 |

## 已驗證

Migration 已套線上，`pg_proc` 確認每支 RPC **只有一個簽章**（`rpc_post_aid_board` 11、`rpc_post_manual_spot` 11、`rpc_update_aid_board_listing` 9），無 overload。

**Rollback 交易實測 12 種情境**，跑完 rollback、線上零殘留（`sku_id IS NULL` / `spot_images` / `spot_unit` 的列數都是 0）：

| 情境 | 結果 |
|---|---|
| 純手打（無 SKU）上架，含 trim | ✅ 標題/說明/單位都被 trim，圖片陣列正確寫入 |
| 選了 SKU、不填標題 | ✅ `spot_title` 存 NULL（fallback 主檔） |
| 無 SKU 又無標題 | ⛔ `manual spot without sku_id requires spot_title` |
| 圖片不是陣列 | ⛔ `spot_images must be a JSON array of storage paths` |
| 圖片陣列含非字串 | ⛔ `spot_images must contain only strings` |
| 空圖片陣列 | ✅ 存 NULL（= 沿用主檔圖） |
| 手動貼文改圖 / 單位 / 數量 | ✅ `qty_available` 與 `qty_remaining` 一起覆寫 |
| 手打貼文把標題清空 | ⛔ `this listing has no sku — spot_title cannot be cleared` |
| **訂單來源**貼文改 qty | ⛔ `qty of an order-sourced listing cannot be edited` |
| **舊前端 6 個具名參數呼叫 update RPC** | ✅ 仍解得到（新參數有 DEFAULT，無空窗） |
| `request` 無 SKU 直接 INSERT | ⛔ 撞 `chk_aid_board_request_needs_sku` |
| **`rpc_post_aid_board` 的 offer 帶 NULL 訂單** | ⛔ 仍炸 `offer post requires p_source_customer_order_id` —— 確認放寬 CHECK 沒有替訂單釋出路徑開洞 |

其他：
- `liff-api` 已部署（**v56 ACTIVE**）；`OPTIONS` 回 200、無 auth `POST` 回函式自家的 401（不是 gateway 404）
- 新的 PostgREST select 用 service-role 實打驗過，**含 `sku_id IS NULL` 的情況**：embedded select 回 `sku: null`，`spot_title` / `spot_unit` / `spot_images` 都照 mapper 的預期解出來。驗證用的探針列建成 `status='cancelled'`（函式只吃 `active`，會員看不到），驗完即刪
- 兩個 app 的 `tsc --noEmit` + `next build` 都過

## 沒驗證

- **畫面沒實機看過。** 合併後照 `docs/TEST-member-spot-zone.md` 走 **T1M-1~21**（圖片上傳、認領鍵消失、數量只有手動能改、手打清標題被擋…）
- 手打商品**沒有**透過部署後的 liff-api 端到端跑過（要會員 JWT，`PROJECT_JWT_SECRET` 從 Management API 拿回來是雜湊值、簽不出來）。驗到的是同一組 PostgREST 查詢 + mapper 邏輯
- lint：`mutual-aid/page.tsx` 從 6 個既有的 `react-hooks/set-state-in-effect` 變成 7 個。多的那個是 `ManualSpotModal` 的「開啟時重設表單」effect，和同檔 `RequestModal` / `OfferModal` 是一模一樣的寫法。SKU → 標題預填原本也會多一個，已改成寫在 `onChange` 裡避掉

---
_Generated by [Claude Code](https://claude.ai/code/session_01DetXFF67eZbpESvKssoeXz)_