### PR TITLE
feat(spot): 手動現貨可設成只給本店會員看

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -29,6 +29,8 @@ type Post = {
   spot_title: string | null;
   spot_unit: string | null;
   spot_images: string[] | null;
+  /** false = 只有 offering_store_id 那間店的會員看得到（liff-api 直接濾掉） */
+  spot_visible_to_other_stores: boolean;
   created_at: string;
   created_by: string | null;
   store_name?: string;
@@ -145,7 +147,7 @@ export default function MutualAidPage() {
         const sb = getSupabase();
         let q = sb
           .from("mutual_aid_board")
-          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, status, source_customer_order_id, spot_price, spot_description, spot_title, spot_unit, spot_images, created_at, created_by")
+          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, status, source_customer_order_id, spot_price, spot_description, spot_title, spot_unit, spot_images, spot_visible_to_other_stores, created_at, created_by")
           .eq("status", "active")
           .order("created_at", { ascending: false })
           .limit(200);
@@ -287,6 +289,11 @@ export default function MutualAidPage() {
                   {p.post_type === "offer" && p.source_customer_order_id == null && (
                     <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
                       手動
+                    </span>
+                  )}
+                  {p.post_type === "offer" && !p.spot_visible_to_other_stores && (
+                    <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                      🔒 限本店會員
                     </span>
                   )}
                   <span className="ml-auto text-xs text-zinc-500">💬 {p.replies_count} 留言</span>
@@ -573,6 +580,39 @@ function RequestModal({
   );
 }
 
+/**
+ * 「其他分店的會員也看得到」開關。上架表單與 ThreadModal 編輯區共用。
+ *
+ * 開（預設）= 維持既有行為：別店會員在現貨專區看得到這張卡，但金額隱藏。
+ * 關         = 別店會員的列表與詳情都查不到（過濾在 liff-api，不是前端藏）。
+ */
+function VisibilityToggle({
+  checked, onChange, storeName,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  storeName: string | null;
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-2 rounded-md border border-zinc-200 p-2 dark:border-zinc-800">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 h-4 w-4 shrink-0 accent-emerald-600"
+      />
+      <span className="text-xs">
+        <span className="font-medium text-zinc-700 dark:text-zinc-300">其他分店的會員也看得到</span>
+        <span className="mt-0.5 block text-zinc-500">
+          {checked
+            ? "所有會員都看得到這項商品；跨店的金額照舊隱藏（顯示鎖頭）。"
+            : `只有${storeName ? `「${storeName}」` : "釋出店"}的會員看得到，其他分店的會員完全查不到這一筆。`}
+        </span>
+      </span>
+    </label>
+  );
+}
+
 // ============================================================
 // Manual Spot Modal — 手動新增現貨（不需要來源訂單）
 //
@@ -599,6 +639,8 @@ function ManualSpotModal({
   const [desc, setDesc] = useState("");
   const [images, setImages] = useState<string[]>([]);
   const [note, setNote] = useState("");
+  // 預設「其他分店的會員也看得到」（維持既有行為：跨店看得到卡片、金額隱藏）
+  const [visibleToOthers, setVisibleToOthers] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -606,6 +648,7 @@ function ManualSpotModal({
     if (open) {
       setStoreId(""); setPicked(null); setTitle(""); setQty(""); setUnit("");
       setPrice(""); setDesc(""); setImages([]); setNote(""); setErr(null);
+      setVisibleToOthers(true);
       setExpiresAt(defaultExpiresAt());
     }
   }, [open]);
@@ -654,6 +697,7 @@ function ManualSpotModal({
         p_spot_images: images.length > 0 ? images : null,
         p_note: note.trim() || null,
         p_operator: operator,
+        p_visible_to_other_stores: visibleToOthers,
       });
       if (e) { setErr(e.message); return; }
       onPosted();
@@ -776,6 +820,12 @@ function ManualSpotModal({
           </span>
           <ProductImagesField value={images} onChange={setImages} />
         </div>
+
+        <VisibilityToggle
+          checked={visibleToOthers}
+          onChange={setVisibleToOthers}
+          storeName={stores.find((s) => s.id === storeId)?.name ?? null}
+        />
 
         <label>
           <span className="mb-1 block text-xs text-zinc-500">備註（選填，店對店內部訊息，不會給會員看）</span>
@@ -1187,6 +1237,9 @@ function ThreadModal({
   const [editUnit, setEditUnit] = useState(post.spot_unit ?? "");
   const [editImages, setEditImages] = useState<string[]>(post.spot_images ?? []);
   const [editQty, setEditQty] = useState(String(post.qty_available));
+  const [editVisible, setEditVisible] = useState(post.spot_visible_to_other_stores);
+  // 存檔後 post prop 仍是父層舊資料，標頭的「限本店」標記用本地值蓋
+  const [savedVisible, setSavedVisible] = useState(post.spot_visible_to_other_stores);
   const [editExpiresAt, setEditExpiresAt] = useState(() => toLocalInput(post.expires_at));
   // 存檔後 post prop 仍是父層舊資料，標頭到期時間 / 數量用本地值蓋
   const [savedExpiresAt, setSavedExpiresAt] = useState(post.expires_at);
@@ -1292,12 +1345,15 @@ function ThreadModal({
         p_spot_images: editImages.length > 0 ? editImages : null,
         p_spot_unit: editUnit.trim() || null,
         p_qty_available: qtyParam,
+        // 只有手動現貨開放這個開關，訂單來源的送 null（= 不動，維持看得到）
+        p_visible_to_other_stores: isManual ? editVisible : null,
       });
       if (e) { setErr(e.message); return; }
       setSavedSpotPrice(spotPriceParam);
       setSavedSpotTitle(spotTitleParam);
       setSavedExpiresAt(expDate.toISOString());
       if (qtyParam != null) setSavedQty({ available: qtyParam, remaining: qtyParam });
+      if (isManual) setSavedVisible(editVisible);
       setEditOpen(false);
       onEdited();
     } catch (e) {
@@ -1391,6 +1447,11 @@ function ThreadModal({
             {isManual && (
               <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
                 手動{post.sku_id == null ? "・手打商品" : ""}
+              </span>
+            )}
+            {!savedVisible && (
+              <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                🔒 限本店會員
               </span>
             )}
             {savedSpotTitle && (
@@ -1517,6 +1578,13 @@ function ThreadModal({
               </span>
               <ProductImagesField value={editImages} onChange={setEditImages} />
             </div>
+            {isManual && (
+              <VisibilityToggle
+                checked={editVisible}
+                onChange={setEditVisible}
+                storeName={post.store_name ?? null}
+              />
+            )}
             <div className="flex justify-end gap-2">
               <SpinButton
                 onClick={() => setEditOpen(false)}

--- a/docs/PLAN-現貨專區.md
+++ b/docs/PLAN-現貨專區.md
@@ -29,6 +29,7 @@
 | 商品標題 | `mutual_aid_board.spot_title`（上架時可改寫，2026-08-02 加）優先；沒改則由會員端組 `product_name／variant_name` |
 | 商品圖片 | `mutual_aid_board.spot_images`（JSONB 路徑陣列，2026-08-02 加）優先；沒設 fallback `products.images` |
 | 數量單位 | `mutual_aid_board.spot_unit`（2026-08-02 加）優先；沒設 fallback `skus.base_unit` |
+| 跨店可見性 | `mutual_aid_board.spot_visible_to_other_stores`（2026-08-02 加，預設 `TRUE`）。`FALSE` = 只有釋出店的會員查得到，別店會員連 detail 都是 404。見 §4.1 |
 | 會員所在店 | `members.home_store_id`；未綁定會員退回 JWT 的 `store_id`（掃碼進站那間） |
 
 **命名分工**：對會員講「現貨專區」（現成的貨、不用等團購結單）；卡片上仍標「◯◯店 釋出」當來源。
@@ -124,6 +125,25 @@ tab active 判斷是 `pathname.startsWith(t.href)`。所以現貨專區**必須�
 
 驗收：直接看 raw response，跨店那筆 `unit_price` 必須是 `null`（測試文件 T2-5）。
 **改動時別把它退化成前端過濾。**
+
+### 4.1 跨店可見性開關（2026-08-02 加）
+
+金額隱藏之外，手動現貨還有一個**要不要讓別店會員看到這項商品**的開關
+（`spot_visible_to_other_stores`，預設 `TRUE`）。兩者疊起來是三段式：
+
+| 狀態 | 別店會員的體感 |
+|---|---|
+| 開關 ON（預設） | 看得到卡片，但金額是鎖頭（既有行為，沒變） |
+| 開關 OFF | 列表查不到、詳情 404 —— 對別店會員來說這筆不存在 |
+| 本店會員 | 不受開關影響，永遠看得到而且有金額 |
+
+實作：`liff-api` 的 list 與 detail **都要**加同一條
+`.or("spot_visible_to_other_stores.eq.true,offering_store_id.eq.<myStoreId>")`。
+detail 漏掉的話，知道 board id 就能直接開出別店設為不公開的商品 —— 和 §4 同一個原則：
+**後端擋，不能只藏 UI**。
+
+開關目前只在手動現貨的表單露出（從訂單釋出的貼文一律 `TRUE`）。要開放給訂單釋出的
+貼文只是 UI 一行的事，DB 那層本來就通用。
 
 ---
 
@@ -234,6 +254,7 @@ tab active 判斷是 `pathname.startsWith(t.href)`。所以現貨專區**必須�
 | `supabase/migrations/20260802000020_aid_listing_edit_expires_at.sql` | 新增 | 上面那支加 `p_expires_at`（4 → 5 參數）。⚠ 它的 NULL 語意與另兩個相反：`expires_at` 是 NOT NULL 欄位，NULL = 不動；且不得設到過去（要立刻下架請用「結束此貼」） |
 | `supabase/migrations/20260802000030_aid_board_spot_title.sql` | 新增 | `mutual_aid_board` 加 `spot_title`；`rpc_post_aid_board` 10 → 11、`rpc_update_aid_board_listing` 5 → 6 參數。NULL = 沒改，會員端 fallback 回 SKU 組出的標題 |
 | `supabase/migrations/20260802000040_manual_spot_listing.sql` | 新增 | 手動現貨（見 §1.1）：`sku_id` 放寬 nullable、放寬 `aid_board_source_consistency`、加 `spot_images` / `spot_unit` 與兩條 CHECK、新增 `rpc_post_manual_spot`、`rpc_update_aid_board_listing` 6 → 9 參數 |
+| `supabase/migrations/20260802000050_spot_cross_store_visibility.sql` | 新增 | 跨店可見性開關（見 §4.1）：加 `spot_visible_to_other_stores`（預設 TRUE）＋ partial index；`rpc_post_manual_spot` 11 → 12、`rpc_update_aid_board_listing` 9 → 10 參數 |
 | `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` | 改 | 「我有庫存可提供」表單加「商品標題」（預填 `product_name／variant_name`）、「釋出單價」（預填原價，可改；低於原價有提示）與「商品說明」textarea（預填原文純文字，可改寫）；沒改的值送 NULL。ThreadModal 的「✏️ 修改內容」同樣四欄都能改。新增 `ManualSpotModal`（➕ 手動新增現貨）；列表與 ThreadModal 對手動貼文標「手動」badge、藏掉認領鍵 |
 | `apps/admin/src/components/ProductImagesField.tsx` | 沿用 | 手動現貨與編輯區的圖片上傳直接重用商品主檔那支（同 `products` bucket、同 `tenant_id/uuid.ext` 路徑規則） |
 

--- a/docs/TEST-member-spot-zone.md
+++ b/docs/TEST-member-spot-zone.md
@@ -11,6 +11,7 @@
 - Migration `20260802000000_aid_board_spot_price_description.sql`（互助板 offer 可自訂釋出單價與商品說明）
 - Migration `20260802000030_aid_board_spot_title.sql`（互助板 offer 可自訂商品標題，上架時填、發佈後可改）
 - Migration `20260802000040_manual_spot_listing.sql`（手動新增現貨：免訂單、可手打商品、可傳圖）
+- Migration `20260802000050_spot_cross_store_visibility.sql`（手動現貨可設成只給本店會員看）
 - 會員端：底部 tab bar 中央凸起鍵、`/spot` 列表、`/spot/[id]` 詳情（`/shop` 的現貨導流區塊已移除，見 T6）
 - 元件：`SpotProductCard.tsx`、`lib/lineInquiry.ts`
 - admin：`/stores` 的「LINE@ ID」欄位
@@ -88,6 +89,27 @@
 | T1M-19 | SQL 直呼 `rpc_post_manual_spot` 帶 `p_spot_images => '{"a":1}'::jsonb` | 炸 `spot_images must be a JSON array of storage paths` |
 | T1M-20 | SQL 直接 INSERT 一列 `post_type='request'` 且 `sku_id IS NULL` | 撞 CHECK `chk_aid_board_request_needs_sku`（求助一定要有 SKU 才轉得了單） |
 | T1M-21 | SQL 直呼 `rpc_post_aid_board` 用 `p_post_type='offer'` 但 `p_source_customer_order_id => NULL` | 仍炸 `offer post requires p_source_customer_order_id`（放寬 CHECK 沒有替訂單釋出路徑開洞） |
+
+## T1V — 跨店可見性開關（手動現貨）
+
+前提：A 店（測試會員 M 的所在店）與 B 店各有一則手動現貨。
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T1V-1 | 開「➕ 手動新增現貨」看開關 | 「其他分店的會員也看得到」**預設打勾**；說明文字是「所有會員都看得到這項商品；跨店的金額照舊隱藏（顯示鎖頭）」 |
+| T1V-2 | 把勾取消 | 說明文字改成「只有「〈選定的店〉」的會員看得到，其他分店的會員完全查不到這一筆」 |
+| T1V-3 | 取消勾選後上架 | `mutual_aid_board.spot_visible_to_other_stores = false` |
+| T1V-4 | 不動開關上架 | 該欄為 `true`（維持既有行為） |
+| T1V-5 | **B 店關掉開關** → 會員 M（A 店）看 `/spot` | **完全看不到那一筆**（不是有卡片但鎖金額 —— 是整筆消失） |
+| T1V-6 | 會員 M 直接打 `/spot/<那筆 id>` | **404「已經不在架上」**；`curl {"action":"get_spot_product","id":<該筆>}` 回 404，不是回商品內容 |
+| T1V-7 | B 店自己的會員看 | 照常看得到，而且有金額 |
+| T1V-8 | **A 店關掉開關**（自己店的商品）→ 會員 M 看 | 照常看得到、照常有金額（開關只擋別店會員） |
+| T1V-9 | 列表與 ThreadModal 標頭 | 關掉的貼文有橘色「🔒 限本店會員」badge |
+| T1V-10 | ThreadModal →「✏️ 修改內容」 | 手動現貨的編輯區最下面有同一顆開關，帶目前狀態 |
+| T1V-11 | 發佈後把開關關掉存檔 | 標頭立刻出現「🔒 限本店會員」；別店會員重新整理後該筆消失 |
+| T1V-12 | 再打開存檔 | badge 消失；別店會員重新整理後又看得到（金額仍鎖） |
+| T1V-13 | **訂單來源**的貼文 →「✏️ 修改內容」 | **沒有**這顆開關（只對手動現貨開放）；存檔後 `spot_visible_to_other_stores` 維持 `true` 不被動到 |
+| T1V-14 | SQL 直呼 `rpc_update_aid_board_listing` 只送 9 個具名參數（不帶 `p_visible_to_other_stores`） | 可見性**不變**（NULL = 不動，不是重設成 true） |
 | T1-2 | 同上用 B 店再發一則（挑不同 SKU 好辨識） | 貼文成立 |
 | T1-3 | `SELECT id, post_type, status, offering_store_id, sku_id, qty_remaining, expires_at FROM mutual_aid_board WHERE post_type='offer' AND status='active';` | 兩筆，`expires_at` 在未來、`qty_remaining > 0` |
 

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -376,6 +376,9 @@ async function listSpotProducts(
     .eq("status", "active")
     .gt("qty_remaining", 0)
     .gt("expires_at", new Date().toISOString())
+    // 店家把「其他分店的會員也看得到」關掉的，只有釋出店自己的會員查得到。
+    // 一定要在這裡濾 —— 前端藏卡片沒用，raw response 還是會外流。
+    .or(`spot_visible_to_other_stores.eq.true,offering_store_id.eq.${myStoreId}`)
     .order("created_at", { ascending: false });
   if (error) return json({ error: error.message }, 500);
 
@@ -477,9 +480,9 @@ async function listSpotProducts(
 /**
  * 現貨專區單一商品詳情。
  *
- * 上架條件和列表完全一致（offer / active / 未到期 / 還有量）—— 條件不符就回
- * 404，不能因為「知道 id」就繞過列表看得到的範圍（例如已被認領光、已取消、
- * 已過期的貼文，或別租戶的 id）。
+ * 上架條件和列表完全一致（offer / active / 未到期 / 還有量 / 跨店可見性）——
+ * 條件不符就回 404，不能因為「知道 id」就繞過列表看得到的範圍（例如已被認領光、
+ * 已取消、已過期的貼文，別租戶的 id，或別店設成「只給本店會員看」的現貨）。
  *
  * 金額規則同列表：跨店連查都不查，`unit_price` 恆為 null。
  * 板上的 note 一樣不外露；LINE@ 只回會員自己店那一間的。
@@ -505,6 +508,8 @@ async function getSpotProduct(
     .eq("status", "active")
     .gt("qty_remaining", 0)
     .gt("expires_at", new Date().toISOString())
+    // 同列表：只給本店看的，別店會員連知道 id 也開不出來（落到下面的 404）
+    .or(`spot_visible_to_other_stores.eq.true,offering_store_id.eq.${myStoreId}`)
     .maybeSingle();
   if (error) return json({ error: error.message }, 500);
   if (!r) return json({ error: "spot product not found" }, 404);

--- a/supabase/migrations/20260802000050_spot_cross_store_visibility.sql
+++ b/supabase/migrations/20260802000050_spot_cross_store_visibility.sql
@@ -1,0 +1,254 @@
+-- ============================================================
+-- 2026-08-02: 手動現貨可以只給本店會員看
+--
+-- 需求：手動上架的現貨要有一個開關控制「其他分店的會員看不看得到」。
+--       預設看得到（維持現況）；關掉之後只有釋出店自己的會員看得到。
+--
+-- 和既有的「跨店金額隱藏」是兩件事，疊在一起是三段式：
+--   開關 ON （預設）→ 別店會員看得到這張卡，但金額仍然隱藏（既有行為）
+--   開關 OFF        → 別店會員的列表與詳情都查不到這筆，等於不存在
+--
+-- 變動：
+--   1. mutual_aid_board 加 spot_visible_to_other_stores BOOLEAN NOT NULL DEFAULT TRUE
+--   2. rpc_post_manual_spot            11 → 12 參數
+--   3. rpc_update_aid_board_listing     9 → 10 參數
+--
+-- 基底版本（已 grep supabase/migrations/ 確認是最新版）：
+--   - rpc_post_manual_spot         → 20260802000040_manual_spot_listing.sql（唯一版本）
+--   - rpc_update_aid_board_listing → 20260802000040_manual_spot_listing.sql
+--     （歷史：…000010 4 → …000020 5 → …000030 6 → …000040 9 參數）
+--   兩支的原有驗證邏輯一字未改，只多接一個參數。
+--   rpc_post_aid_board 不動：從訂單釋出的貼文一律走預設值 TRUE。
+--
+-- ⚠ update 的 p_visible_to_other_stores NULL 語意 = **不動**（同 p_expires_at /
+--   p_qty_available），不是「關掉」。欄位是 NOT NULL，沒有「清除」的概念；
+--   而且舊前端送 9 個具名參數時不該把可見性悄悄改掉。
+--
+-- ⚠ 過濾要在**後端**做（liff-api 的 list / detail 都要），不能只藏 UI。
+--   detail 沒擋的話，知道 board id 就能直接開出別店設為不公開的商品。
+--
+-- 為何 DROP 再 CREATE：參數個數變了，CREATE OR REPLACE 會多出 overload，
+--   之後具名呼叫撞 "function is not unique"。新參數有 DEFAULT，
+--   已部署的舊前端具名呼叫仍解得到，無空窗。
+--
+-- Rollback：
+--   DROP FUNCTION IF EXISTS public.rpc_post_manual_spot(
+--     BIGINT, BIGINT, TEXT, NUMERIC, TIMESTAMPTZ, NUMERIC, TEXT, TEXT, JSONB, TEXT, UUID, BOOLEAN);
+--   DROP FUNCTION IF EXISTS public.rpc_update_aid_board_listing(
+--     BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ, TEXT, JSONB, TEXT, NUMERIC, BOOLEAN);
+--   -- 重跑 20260802000040 的 §2、§3 段落
+--   ALTER TABLE mutual_aid_board DROP COLUMN spot_visible_to_other_stores;
+-- ============================================================
+
+ALTER TABLE mutual_aid_board
+  ADD COLUMN spot_visible_to_other_stores BOOLEAN NOT NULL DEFAULT TRUE;
+
+COMMENT ON COLUMN mutual_aid_board.spot_visible_to_other_stores IS
+  'FALSE = 這筆現貨只有 offering_store_id 那間店的會員看得到（liff-api 的 '
+  'list / detail 都會濾掉）。TRUE（預設）= 所有會員都看得到，但跨店的金額'
+  '照舊隱藏。只對 offer 有意義。';
+
+-- 只給本店看的那些，查詢一定會帶 offering_store_id，走這個 partial index
+CREATE INDEX idx_aid_board_own_store_only
+  ON mutual_aid_board (offering_store_id)
+  WHERE spot_visible_to_other_stores = FALSE;
+
+-- ------------------------------------------------------------
+-- 1. rpc_post_manual_spot：11 → 12 參數
+-- ------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.rpc_post_manual_spot(
+  BIGINT, BIGINT, TEXT, NUMERIC, TIMESTAMPTZ, NUMERIC, TEXT, TEXT, JSONB, TEXT, UUID);
+
+CREATE OR REPLACE FUNCTION public.rpc_post_manual_spot(
+  p_offering_store_id BIGINT,
+  p_sku_id            BIGINT,
+  p_spot_title        TEXT,
+  p_qty_available     NUMERIC,
+  p_expires_at        TIMESTAMPTZ,
+  p_spot_price        NUMERIC     DEFAULT NULL,
+  p_spot_description  TEXT        DEFAULT NULL,
+  p_spot_unit         TEXT        DEFAULT NULL,
+  p_spot_images       JSONB       DEFAULT NULL,
+  p_note              TEXT        DEFAULT NULL,
+  p_operator          UUID        DEFAULT NULL,
+  p_visible_to_other_stores BOOLEAN DEFAULT TRUE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant_id UUID;
+  v_title     TEXT := NULLIF(trim(p_spot_title), '');
+  v_images    JSONB;
+  v_board_id  BIGINT;
+BEGIN
+  IF p_qty_available IS NULL OR p_qty_available <= 0 THEN
+    RAISE EXCEPTION 'qty_available must be > 0';
+  END IF;
+  IF p_expires_at IS NULL OR p_expires_at <= NOW() THEN
+    RAISE EXCEPTION 'expires_at must be in the future';
+  END IF;
+  IF p_spot_price IS NOT NULL AND p_spot_price <= 0 THEN
+    RAISE EXCEPTION 'spot_price must be > 0';
+  END IF;
+  -- 沒選 SKU 就一定要有標題，否則會員端沒東西可顯示（也會撞 CHECK）
+  IF p_sku_id IS NULL AND v_title IS NULL THEN
+    RAISE EXCEPTION 'manual spot without sku_id requires spot_title';
+  END IF;
+
+  SELECT tenant_id INTO v_tenant_id FROM stores WHERE id = p_offering_store_id;
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'store % not found', p_offering_store_id;
+  END IF;
+
+  IF p_sku_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM skus WHERE id = p_sku_id) THEN
+    RAISE EXCEPTION 'sku % not found', p_sku_id;
+  END IF;
+
+  -- 圖片必須是字串陣列（storage 相對路徑）；空陣列存 NULL = 沿用主檔圖
+  IF p_spot_images IS NOT NULL THEN
+    IF jsonb_typeof(p_spot_images) <> 'array' THEN
+      RAISE EXCEPTION 'spot_images must be a JSON array of storage paths';
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM jsonb_array_elements(p_spot_images) e
+       WHERE jsonb_typeof(e) <> 'string'
+    ) THEN
+      RAISE EXCEPTION 'spot_images must contain only strings';
+    END IF;
+    v_images := NULLIF(p_spot_images, '[]'::jsonb);
+  END IF;
+
+  INSERT INTO mutual_aid_board (
+    tenant_id, offering_store_id, sku_id, qty_available, qty_remaining,
+    expires_at, note, status, post_type, source_customer_order_id,
+    spot_price, spot_description, spot_title, spot_unit, spot_images,
+    spot_visible_to_other_stores,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant_id, p_offering_store_id, p_sku_id, p_qty_available, p_qty_available,
+    p_expires_at, NULLIF(trim(p_note), ''), 'active', 'offer', NULL,
+    p_spot_price, NULLIF(trim(p_spot_description), ''), v_title,
+    NULLIF(trim(p_spot_unit), ''), v_images,
+    COALESCE(p_visible_to_other_stores, TRUE),
+    p_operator, p_operator
+  )
+  RETURNING id INTO v_board_id;
+
+  RETURN v_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_post_manual_spot(
+  BIGINT, BIGINT, TEXT, NUMERIC, TIMESTAMPTZ, NUMERIC, TEXT, TEXT, JSONB, TEXT, UUID, BOOLEAN) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_post_manual_spot IS
+  '手動上架現貨：post_type=offer 但沒有來源訂單。p_sku_id 可為 NULL（純手打，'
+  '此時 p_spot_title 必填）。這種貼文不能被別店認領（沒有訂單可轉移）。'
+  'p_visible_to_other_stores=FALSE 則只有釋出店的會員看得到。';
+
+-- ------------------------------------------------------------
+-- 2. rpc_update_aid_board_listing：9 → 10 參數
+-- ------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.rpc_update_aid_board_listing(
+  BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ, TEXT, JSONB, TEXT, NUMERIC);
+
+CREATE OR REPLACE FUNCTION public.rpc_update_aid_board_listing(
+  p_board_id         BIGINT,
+  p_operator         UUID,
+  p_spot_price       NUMERIC     DEFAULT NULL,
+  p_spot_description TEXT        DEFAULT NULL,
+  p_expires_at       TIMESTAMPTZ DEFAULT NULL,
+  p_spot_title       TEXT        DEFAULT NULL,
+  p_spot_images      JSONB       DEFAULT NULL,
+  p_spot_unit        TEXT        DEFAULT NULL,
+  p_qty_available    NUMERIC     DEFAULT NULL,
+  p_visible_to_other_stores BOOLEAN DEFAULT NULL
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_post_type TEXT;
+  v_status    TEXT;
+  v_sku_id    BIGINT;
+  v_order_id  BIGINT;
+  v_title     TEXT := NULLIF(trim(p_spot_title), '');
+  v_images    JSONB;
+BEGIN
+  IF p_spot_price IS NOT NULL AND p_spot_price <= 0 THEN
+    RAISE EXCEPTION 'spot_price must be > 0';
+  END IF;
+  -- 到期時間可以往後延，也可以縮短，但不能設到過去
+  -- （設到過去等於立刻下架，那是「結束此貼」該做的事，語意分開）
+  IF p_expires_at IS NOT NULL AND p_expires_at <= NOW() THEN
+    RAISE EXCEPTION 'expires_at must be in the future';
+  END IF;
+  IF p_qty_available IS NOT NULL AND p_qty_available <= 0 THEN
+    RAISE EXCEPTION 'qty_available must be > 0';
+  END IF;
+  IF p_spot_images IS NOT NULL THEN
+    IF jsonb_typeof(p_spot_images) <> 'array' THEN
+      RAISE EXCEPTION 'spot_images must be a JSON array of storage paths';
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM jsonb_array_elements(p_spot_images) e
+       WHERE jsonb_typeof(e) <> 'string'
+    ) THEN
+      RAISE EXCEPTION 'spot_images must contain only strings';
+    END IF;
+    v_images := NULLIF(p_spot_images, '[]'::jsonb);
+  END IF;
+
+  SELECT post_type, status, sku_id, source_customer_order_id
+    INTO v_post_type, v_status, v_sku_id, v_order_id
+    FROM mutual_aid_board WHERE id = p_board_id
+    FOR UPDATE;
+  IF v_post_type IS NULL THEN
+    RAISE EXCEPTION 'board post % not found', p_board_id;
+  END IF;
+  IF v_post_type <> 'offer' THEN
+    RAISE EXCEPTION 'only offer posts have price/description';
+  END IF;
+  IF v_status <> 'active' THEN
+    RAISE EXCEPTION 'post is % — only active posts can be edited', v_status;
+  END IF;
+  -- 手打商品沒有 SKU 可以 fallback，標題不能清空（先擋，別讓它撞 CHECK）
+  IF v_sku_id IS NULL AND v_title IS NULL THEN
+    RAISE EXCEPTION 'this listing has no sku — spot_title cannot be cleared';
+  END IF;
+  -- 數量只有手動現貨能改：從訂單釋出的貼文，qty 和認領扣量的帳綁在一起，
+  -- 直接覆寫會讓已認領的量對不上（要調整請結束此貼重發）
+  IF p_qty_available IS NOT NULL AND v_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'qty of an order-sourced listing cannot be edited';
+  END IF;
+
+  UPDATE mutual_aid_board
+     SET spot_price       = p_spot_price,
+         spot_description = NULLIF(trim(p_spot_description), ''),
+         spot_title       = v_title,
+         spot_unit        = NULLIF(trim(p_spot_unit), ''),
+         spot_images      = v_images,
+         -- NULL = 不動（expires_at 是 NOT NULL，沒有「清除」的語意）
+         expires_at       = COALESCE(p_expires_at, expires_at),
+         -- 手動現貨沒有認領扣量，qty_available / qty_remaining 一起覆寫
+         qty_available    = COALESCE(p_qty_available, qty_available),
+         qty_remaining    = COALESCE(p_qty_available, qty_remaining),
+         -- NULL = 不動（欄位 NOT NULL；舊前端沒送就別動人家的可見性）
+         spot_visible_to_other_stores =
+           COALESCE(p_visible_to_other_stores, spot_visible_to_other_stores),
+         updated_by       = p_operator
+   WHERE id = p_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_update_aid_board_listing(
+  BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ, TEXT, JSONB, TEXT, NUMERIC, BOOLEAN) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_update_aid_board_listing IS
+  '互助板 offer 貼文發佈後編輯釋出單價 / 商品說明 / 商品標題 / 單位 / 圖片 / '
+  '到期時間 / 數量 / 跨店可見性。spot_price、spot_description、spot_title、'
+  'spot_unit、spot_images 的 NULL = 清除自訂值（回沿用原價 / 主檔原文 / '
+  'SKU 標題 / base_unit / 主檔圖）；expires_at、qty_available、'
+  'visible_to_other_stores 的 NULL = 不動。qty_available 只有手動現貨'
+  '（無來源訂單）能改。僅 active 的 offer 可改。';


### PR DESCRIPTION
## 這是什麼

手動上架現貨時多一個開關 **「其他分店的會員也看得到」**，**預設打勾**（維持既有行為）。關掉之後，別店會員在現貨專區完全查不到這一筆。

發佈後也能在「✏️ 修改內容」裡隨時切換。

## 和既有的「跨店金額隱藏」是兩件事

疊起來是三段式：

| 狀態 | 別店會員的體感 | 本店會員 |
|---|---|---|
| **開關 ON（預設）** | 看得到卡片，金額是鎖頭 —— **既有行為，沒變** | 看得到 + 有金額 |
| **開關 OFF** | 列表查不到、詳情 404，等於這筆不存在 | 看得到 + 有金額 |

也就是說：開關**只擋別店會員**，釋出店自己的會員不受影響。

## DB（migration `20260802000050`）

- 加 `spot_visible_to_other_stores BOOLEAN NOT NULL DEFAULT TRUE`
  → 線上既有 35 列全部落在預設值，**行為零變化**
- 加 partial index（`WHERE spot_visible_to_other_stores = FALSE`）—— 只給本店看的那些查詢一定會帶 `offering_store_id`
- `rpc_post_manual_spot` 11 → 12 參數
- `rpc_update_aid_board_listing` 9 → 10 參數，基底 `20260802000040`，原有驗證邏輯一字未改

### `p_visible_to_other_stores` 的 NULL = 不動

跟 `p_expires_at` / `p_qty_available` 同一組語意，**不是**「關掉」。欄位是 `NOT NULL` 沒有「清除」的概念；更重要的是舊前端送 9 個具名參數時不該把人家的可見性悄悄改掉。（有實測，見下。）

`rpc_post_aid_board` 完全沒動 —— 從訂單釋出的貼文一律走預設值 `TRUE`。

## ⚠ 過濾在後端，list 和 detail 都要

`liff-api` 兩支查詢都加同一條：

```ts
.or(`spot_visible_to_other_stores.eq.true,offering_store_id.eq.${myStoreId}`)
```

**detail 漏掉就等於沒做** —— 知道 board id 就能直接開出別店設為不公開的商品。這和金額隱藏是同一個原則：後端擋，不能只藏 UI。

## admin 互助板

- 抽出 `VisibilityToggle`，**上架表單與 ThreadModal 編輯區共用**。勾與不勾各自把「會員端會怎樣」寫出來（不勾時會帶入實際店名：「只有『松山店』的會員看得到…」）
- 列表與貼文標頭對關掉的貼文標橘色 **「🔒 限本店會員」**
- 開關**只對手動現貨露出**；訂單釋出的貼文送 `null`（不動，維持看得到）。要開放給訂單釋出的貼文只是 UI 一行的事，DB 那層本來就通用

## 會員端

**一行都沒改。** 過濾在後端，前端拿到的就已經是該看的那些。

## 異動檔案

| 檔案 | 說明 |
|---|---|
| `supabase/migrations/20260802000050_spot_cross_store_visibility.sql` | 欄位 + index + 兩支 RPC |
| `supabase/functions/liff-api/index.ts` | list / detail 各加一條 `.or()` 過濾 |
| `apps/admin/.../inventory/mutual-aid/page.tsx` | `VisibilityToggle`、兩處接上、兩處 badge、`Post` 型別與 select |
| `docs/PLAN-現貨專區.md` / `docs/TEST-member-spot-zone.md` | 加 §4.1 三段式對照表；測試加 T1V-1~14 |

## 已驗證

Migration 已套線上，`pg_proc` 確認每支 RPC **只有一個簽章**（`rpc_post_manual_spot` 12、`rpc_update_aid_board_listing` 10、`rpc_post_aid_board` 維持 11），無 overload。既有 35 列 `spot_visible_to_other_stores` 全是 `true`。

**Rollback 交易實測 5 種情境**，跑完 rollback、線上零殘留（`hidden_rows = 0`）：

| 情境 | 結果 |
|---|---|
| 上架時關掉開關 | ✅ 存 `false` |
| 上架時不帶該參數 | ✅ 存 `true`（預設看得到） |
| 發佈後關掉 | ✅ `false` |
| 關掉後再打開 | ✅ `true` |
| **舊前端 9 個具名參數呼叫 update RPC** | ✅ 可見性**不變**（原本 `false` 就留 `false`），同時 `qty_available` 照常更新 |

**`.or()` 過濾用線上真實資料實打驗過**（探針用的是已經 `cancelled` 的 id 65，會員本來就看不到，驗完立刻改回 `true`）：

| 以哪個 store 當 myStoreId | 查得到 |
|---|---|
| 店 2（= 65 的釋出店，65 設為不公開） | id 65 ✅ + id 67 |
| 店 1（別店） | 只有 id 67 —— **65 被濾掉** |
| 店 48（別店） | 只有 id 67 —— **65 被濾掉** |

其他：
- `liff-api` 已部署（**v57 ACTIVE**）；`OPTIONS` 回 200、無 auth `POST` 回函式自家的 401
- admin `tsc --noEmit` + `next build` 過；member `tsc` 過（沒動到）
- lint 錯誤數與 `main` 相同（7 個既有的 `react-hooks/set-state-in-effect`），本次沒新增

## 沒驗證

- **畫面沒實機看過。** 合併 + 部署後照 `docs/TEST-member-spot-zone.md` 走 **T1V-1~14**，重點是 **T1V-5/6**（別店會員列表看不到、直接打 id 也是 404）與 **T1V-8**（本店會員不受影響）
- 沒有用真的會員 JWT 端到端跑過（`PROJECT_JWT_SECRET` 從 Management API 拿回來是雜湊值、簽不出來）。驗到的是同一條 PostgREST 過濾條件

---
_Generated by [Claude Code](https://claude.ai/code/session_01DetXFF67eZbpESvKssoeXz)_