### PR TITLE
feat(spot): 不公開的互助貼文，後台也只有該店看得到（含管理員）

### DIFF
--- a/docs/PLAN-現貨專區.md
+++ b/docs/PLAN-現貨專區.md
@@ -145,6 +145,28 @@ detail 漏掉的話，知道 board id 就能直接開出別店設為不公開的
 開關目前只在手動現貨的表單露出（從訂單釋出的貼文一律 `TRUE`）。要開放給訂單釋出的
 貼文只是 UI 一行的事，DB 那層本來就通用。
 
+#### 後台也一起藏（2026-08-02 加）
+
+設為不公開的貼文，**admin 互助交流板也只有該店的帳號看得到 —— 連
+`admin` / `hq_manager` / `owner` 都看不到**。後台是拿使用者 session 直接查表，
+所以這層擋在 `mutual_aid_board` 的 SELECT RLS（`can_see_aid_post()`）。
+
+⚠ 動 RLS 的兩個坑，改的時候別踩回去：
+
+1. **`aid_board_owner_write` 原本是 `FOR ALL`**。permissive policy 之間是 OR，
+   `FOR ALL` 連 SELECT 都放行 —— 只收緊 read policy 的話，
+   owner/admin/hq_manager 照樣從那條看得到。已拆成 INSERT / UPDATE / DELETE
+   三條（predicate 原封不動），不再涵蓋 SELECT。
+2. **`mutual_aid_replies` 的留言也要一起擋**，否則貼文藏了、留言還撈得到。
+
+「該店」是比對 JWT `app_metadata.stores` 裡的**店名**（本 repo 既有慣例，
+沒有 `store_id` claim）。副作用：門市改名後，該店帳號要等 `stores` 一起更新
+才看得回自己的不公開貼文。之後若補上 `store_id` claim，只要改
+`can_see_aid_post()` 內部，policy 不用動。
+
+側欄 badge（`rpc_aid_board_active_count`）是 SECURITY DEFINER、會繞過 RLS，
+所以裡面也要自己判一次，數字才會和列表一致。
+
 ---
 
 ## 5. LINE 詢問
@@ -255,6 +277,7 @@ detail 漏掉的話，知道 board id 就能直接開出別店設為不公開的
 | `supabase/migrations/20260802000030_aid_board_spot_title.sql` | 新增 | `mutual_aid_board` 加 `spot_title`；`rpc_post_aid_board` 10 → 11、`rpc_update_aid_board_listing` 5 → 6 參數。NULL = 沒改，會員端 fallback 回 SKU 組出的標題 |
 | `supabase/migrations/20260802000040_manual_spot_listing.sql` | 新增 | 手動現貨（見 §1.1）：`sku_id` 放寬 nullable、放寬 `aid_board_source_consistency`、加 `spot_images` / `spot_unit` 與兩條 CHECK、新增 `rpc_post_manual_spot`、`rpc_update_aid_board_listing` 6 → 9 參數 |
 | `supabase/migrations/20260802000050_spot_cross_store_visibility.sql` | 新增 | 跨店可見性開關（見 §4.1）：加 `spot_visible_to_other_stores`（預設 TRUE）＋ partial index；`rpc_post_manual_spot` 11 → 12、`rpc_update_aid_board_listing` 9 → 10 參數 |
+| `supabase/migrations/20260802000060_aid_board_hidden_posts_rls.sql` | 新增 | 不公開的貼文後台也只有該店看得到（見 §4.1）：`can_see_aid_post()` + 收緊 `mutual_aid_board` / `mutual_aid_replies` 的 SELECT RLS、拆掉 `FOR ALL` 的 SELECT 面、badge RPC 一起排除 |
 | `apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx` | 改 | 「我有庫存可提供」表單加「商品標題」（預填 `product_name／variant_name`）、「釋出單價」（預填原價，可改；低於原價有提示）與「商品說明」textarea（預填原文純文字，可改寫）；沒改的值送 NULL。ThreadModal 的「✏️ 修改內容」同樣四欄都能改。新增 `ManualSpotModal`（➕ 手動新增現貨）；列表與 ThreadModal 對手動貼文標「手動」badge、藏掉認領鍵 |
 | `apps/admin/src/components/ProductImagesField.tsx` | 沿用 | 手動現貨與編輯區的圖片上傳直接重用商品主檔那支（同 `products` bucket、同 `tenant_id/uuid.ext` 路徑規則） |
 

--- a/docs/TEST-member-spot-zone.md
+++ b/docs/TEST-member-spot-zone.md
@@ -12,6 +12,7 @@
 - Migration `20260802000030_aid_board_spot_title.sql`（互助板 offer 可自訂商品標題，上架時填、發佈後可改）
 - Migration `20260802000040_manual_spot_listing.sql`（手動新增現貨：免訂單、可手打商品、可傳圖）
 - Migration `20260802000050_spot_cross_store_visibility.sql`（手動現貨可設成只給本店會員看）
+- Migration `20260802000060_aid_board_hidden_posts_rls.sql`（不公開的貼文後台也只有該店看得到，含管理員）
 - 會員端：底部 tab bar 中央凸起鍵、`/spot` 列表、`/spot/[id]` 詳情（`/shop` 的現貨導流區塊已移除，見 T6）
 - 元件：`SpotProductCard.tsx`、`lib/lineInquiry.ts`
 - admin：`/stores` 的「LINE@ ID」欄位
@@ -110,6 +111,23 @@
 | T1V-12 | 再打開存檔 | badge 消失；別店會員重新整理後又看得到（金額仍鎖） |
 | T1V-13 | **訂單來源**的貼文 →「✏️ 修改內容」 | **沒有**這顆開關（只對手動現貨開放）；存檔後 `spot_visible_to_other_stores` 維持 `true` 不被動到 |
 | T1V-14 | SQL 直呼 `rpc_update_aid_board_listing` 只送 9 個具名參數（不帶 `p_visible_to_other_stores`） | 可見性**不變**（NULL = 不動，不是重設成 true） |
+
+### T1V-B — 不公開的貼文，**後台**也只有該店看得到
+
+前提：用 B 店（例：松山店）的手動現貨，把開關關掉。
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| T1V-B1 | 用 **B 店店長**帳號進 `/inventory/mutual-aid` | 看得到那則，標橘色「🔒 限本店會員」 |
+| T1V-B2 | 用 **admin（總倉）**帳號進同一頁 | **看不到那一則**（不是灰掉，是列表裡沒有） |
+| T1V-B3 | 用 **hq_manager** 帳號 | 同樣看不到；頁面正常載入不報錯（該帳號 `app_metadata.stores` 是 `null`） |
+| T1V-B4 | 用 **C 店（別的分店）**店長帳號 | 看不到 |
+| T1V-B5 | 多店店長（`stores` 含 B 店） | 看得到 |
+| T1V-B6 | admin 直接打 PostgREST `GET /mutual_aid_board?id=eq.<該筆>` | 回 `[]`（RLS 擋掉，不是靠前端過濾） |
+| T1V-B7 | admin 直接打 `GET /mutual_aid_replies?board_id=eq.<該筆>` | 回 `[]`（貼文看不到，留言也不能撈） |
+| T1V-B8 | 分店側欄「互助交流板」badge | 數字**不含**別店的不公開貼文，和列表筆數對得起來 |
+| T1V-B9 | 公開貼文（絕大多數） | 所有帳號行為完全不變 |
+| T1V-B10 | 把開關打開後重看 | admin 立刻又看得到 |
 | T1-2 | 同上用 B 店再發一則（挑不同 SKU 好辨識） | 貼文成立 |
 | T1-3 | `SELECT id, post_type, status, offering_store_id, sku_id, qty_remaining, expires_at FROM mutual_aid_board WHERE post_type='offer' AND status='active';` | 兩筆，`expires_at` 在未來、`qty_remaining > 0` |
 

--- a/supabase/migrations/20260802000060_aid_board_hidden_posts_rls.sql
+++ b/supabase/migrations/20260802000060_aid_board_hidden_posts_rls.sql
@@ -1,0 +1,219 @@
+-- ============================================================
+-- 2026-08-02: 設為不公開的互助貼文，後台也只有該店看得到（含管理員）
+--
+-- 需求：20260802000050 的「其他分店的會員也看得到」開關關掉之後，
+--       目前只擋會員端（liff-api）。後台互助交流板每個帳號還是全看得到。
+--       要改成：**只有該店的帳號看得到，連 admin / hq_manager / owner 都不行。**
+--
+-- 做法：收緊 mutual_aid_board 的 SELECT RLS。後台是拿使用者 session 直接查表，
+--       所以 RLS 就是唯一該動的地方 —— 前端過濾擋不住直接打 PostgREST。
+--
+-- ⚠ 兩個一定要一起處理，不然等於沒做：
+--
+--   1. **`aid_board_owner_write` 是 FOR ALL**。permissive policy 之間是 OR，
+--      FOR ALL 連 SELECT 都放行 —— 只改 read policy 的話，owner/admin/hq_manager
+--      照樣從那條看得到。這裡把它拆成 INSERT / UPDATE / DELETE 三條，
+--      **predicate 一字未改**，只是不再涵蓋 SELECT。
+--      （寫入本來就都走 SECURITY DEFINER RPC，這個拆法對 app 沒有行為影響。）
+--
+--   2. **`mutual_aid_replies` 的 replies_read_all 也是 tenant 全開**。貼文藏起來
+--      但留言撈得到，等於從側門把內容漏出去。一起套同一條可見性判斷。
+--
+-- 「該店」怎麼判定：JWT 的 stores（店名陣列）裡有沒有該貼文釋出店的名字。
+--   這是本 repo 既有的慣例 —— rpc_aid_board_active_count（20260720000030）
+--   就是這樣認分店帳號的，沒有 store_id claim 可用。
+--   ⚠ 副作用：門市**改名**會讓舊帳號暫時看不到自己店的不公開貼文，
+--     直到該帳號的 app_metadata.stores 一起更新。之後若補上 store_id claim，
+--     把 can_see_aid_post() 換成用 id 比對即可，policy 本身不用動。
+--
+-- 沒有動到的：
+--   - 公開貼文（spot_visible_to_other_stores = TRUE，也就是絕大多數）行為完全不變
+--   - 會員端 liff-api 走 service_role，繞過 RLS，維持 20260802000050 的過濾
+--   - purge cron 也是 service_role，不受影響
+--
+-- Rollback：
+--   DROP POLICY IF EXISTS aid_board_read_all   ON mutual_aid_board;
+--   DROP POLICY IF EXISTS aid_board_owner_insert ON mutual_aid_board;
+--   DROP POLICY IF EXISTS aid_board_owner_update ON mutual_aid_board;
+--   DROP POLICY IF EXISTS aid_board_owner_delete ON mutual_aid_board;
+--   DROP POLICY IF EXISTS replies_read_all     ON mutual_aid_replies;
+--   CREATE POLICY aid_board_read_all ON mutual_aid_board FOR SELECT
+--     USING (tenant_id = ((auth.jwt() ->> 'tenant_id'))::uuid);
+--   CREATE POLICY aid_board_owner_write ON mutual_aid_board FOR ALL
+--     USING (tenant_id = ((auth.jwt() ->> 'tenant_id'))::uuid
+--            AND (offering_store_id = ((auth.jwt() ->> 'store_id'))::bigint
+--                 OR (auth.jwt() ->> 'role') = ANY (ARRAY['owner','admin','hq_manager'])));
+--   CREATE POLICY replies_read_all ON mutual_aid_replies FOR SELECT
+--     USING (tenant_id = ((auth.jwt() ->> 'tenant_id'))::uuid);
+--   DROP FUNCTION IF EXISTS public.can_see_aid_post(BIGINT, BOOLEAN);
+--   DROP FUNCTION IF EXISTS public.jwt_store_names();
+--   -- 並把 rpc_aid_board_active_count 重跑 20260720000030 的版本
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. helper：JWT 裡的店名陣列
+--    app_metadata 巢狀與頂層兩種擺法都收 —— 這個專案兩種都出現過
+--    （RLS 讀 auth.jwt()->>'tenant_id' 是頂層，
+--      rpc_aid_board_active_count 讀 app_metadata->'stores' 是巢狀）
+--
+--    ⚠ 一定要用 jsonb_typeof(...) = 'array' 判，不能只靠 COALESCE：
+--      線上的 hq_manager 帳號 app_metadata 是 {"stores": null}，那是 **JSON null**
+--      不是 SQL NULL，COALESCE 接不住，jsonb_array_elements_text() 會直接炸
+--      "cannot extract elements from a scalar"。20260720000030 的
+--      rpc_aid_board_active_count 就有這個潛在問題，這裡一併修掉。
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.jwt_store_names()
+RETURNS TEXT[]
+LANGUAGE sql STABLE
+SET search_path = public
+AS $$
+  SELECT ARRAY(
+    SELECT jsonb_array_elements_text(v)
+      FROM (
+        SELECT CASE
+                 WHEN jsonb_typeof(auth.jwt() -> 'app_metadata' -> 'stores') = 'array'
+                   THEN auth.jwt() -> 'app_metadata' -> 'stores'
+                 WHEN jsonb_typeof(auth.jwt() -> 'stores') = 'array'
+                   THEN auth.jwt() -> 'stores'
+                 ELSE '[]'::jsonb
+               END AS v
+      ) t
+  );
+$$;
+
+COMMENT ON FUNCTION public.jwt_store_names IS
+  '目前登入帳號在 app_metadata.stores 裡的門市名稱陣列（沒有就回空陣列）。';
+
+-- ------------------------------------------------------------
+-- 2. helper：這則貼文目前這個帳號看不看得到
+--    SECURITY DEFINER —— 判斷本身要查 stores，不該被 stores 自己的 RLS 影響
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.can_see_aid_post(
+  p_offering_store_id BIGINT,
+  p_visible_to_other_stores BOOLEAN
+) RETURNS BOOLEAN
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(p_visible_to_other_stores, TRUE)
+      OR EXISTS (
+           SELECT 1 FROM stores s
+            WHERE s.id = p_offering_store_id
+              AND s.name = ANY (public.jwt_store_names())
+         );
+$$;
+
+COMMENT ON FUNCTION public.can_see_aid_post IS
+  '互助貼文對目前帳號是否可見：公開的一律可見；設為不公開的只有釋出店的帳號'
+  '看得到（依 JWT app_metadata.stores 的店名比對）。角色不是後門 —— '
+  'admin / hq_manager / owner 一樣看不到別店的不公開貼文。';
+
+GRANT EXECUTE ON FUNCTION public.jwt_store_names() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.can_see_aid_post(BIGINT, BOOLEAN) TO authenticated;
+
+-- ------------------------------------------------------------
+-- 3. mutual_aid_board：SELECT 收緊
+-- ------------------------------------------------------------
+DROP POLICY IF EXISTS aid_board_read_all ON mutual_aid_board;
+
+CREATE POLICY aid_board_read_all ON mutual_aid_board
+  FOR SELECT
+  USING (
+    tenant_id = ((auth.jwt() ->> 'tenant_id'))::uuid
+    AND public.can_see_aid_post(offering_store_id, spot_visible_to_other_stores)
+  );
+
+-- ------------------------------------------------------------
+-- 4. mutual_aid_board：把 FOR ALL 拆成三條寫入 policy
+--    predicate 完全照抄 20260509000001 的原版，只是不再涵蓋 SELECT
+-- ------------------------------------------------------------
+DROP POLICY IF EXISTS aid_board_owner_write  ON mutual_aid_board;
+DROP POLICY IF EXISTS aid_board_owner_insert ON mutual_aid_board;
+DROP POLICY IF EXISTS aid_board_owner_update ON mutual_aid_board;
+DROP POLICY IF EXISTS aid_board_owner_delete ON mutual_aid_board;
+
+CREATE POLICY aid_board_owner_insert ON mutual_aid_board
+  FOR INSERT
+  WITH CHECK (
+    tenant_id = ((auth.jwt() ->> 'tenant_id'))::uuid
+    AND (
+      offering_store_id = ((auth.jwt() ->> 'store_id'))::bigint
+      OR (auth.jwt() ->> 'role') = ANY (ARRAY['owner', 'admin', 'hq_manager'])
+    )
+  );
+
+CREATE POLICY aid_board_owner_update ON mutual_aid_board
+  FOR UPDATE
+  USING (
+    tenant_id = ((auth.jwt() ->> 'tenant_id'))::uuid
+    AND (
+      offering_store_id = ((auth.jwt() ->> 'store_id'))::bigint
+      OR (auth.jwt() ->> 'role') = ANY (ARRAY['owner', 'admin', 'hq_manager'])
+    )
+  )
+  WITH CHECK (
+    tenant_id = ((auth.jwt() ->> 'tenant_id'))::uuid
+    AND (
+      offering_store_id = ((auth.jwt() ->> 'store_id'))::bigint
+      OR (auth.jwt() ->> 'role') = ANY (ARRAY['owner', 'admin', 'hq_manager'])
+    )
+  );
+
+CREATE POLICY aid_board_owner_delete ON mutual_aid_board
+  FOR DELETE
+  USING (
+    tenant_id = ((auth.jwt() ->> 'tenant_id'))::uuid
+    AND (
+      offering_store_id = ((auth.jwt() ->> 'store_id'))::bigint
+      OR (auth.jwt() ->> 'role') = ANY (ARRAY['owner', 'admin', 'hq_manager'])
+    )
+  );
+
+-- ------------------------------------------------------------
+-- 5. mutual_aid_replies：貼文看不到，留言也不能撈
+-- ------------------------------------------------------------
+DROP POLICY IF EXISTS replies_read_all ON mutual_aid_replies;
+
+CREATE POLICY replies_read_all ON mutual_aid_replies
+  FOR SELECT
+  USING (
+    tenant_id = ((auth.jwt() ->> 'tenant_id'))::uuid
+    AND EXISTS (
+      SELECT 1 FROM mutual_aid_board b
+       WHERE b.id = mutual_aid_replies.board_id
+         AND public.can_see_aid_post(b.offering_store_id, b.spot_visible_to_other_stores)
+    )
+  );
+
+-- ------------------------------------------------------------
+-- 6. 側欄 badge 不要把別店的不公開貼文算進去
+--    基底：20260720000030_aid_board_badge_and_expiry_purge.sql（唯一版本，
+--    已 grep 確認）。SECURITY DEFINER 會繞過 RLS，所以要自己再判一次，
+--    否則 badge 數字和列表對不起來。
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_aid_board_active_count()
+RETURNS integer
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH me AS (
+    SELECT public.jwt_store_names() AS store_names
+  )
+  SELECT CASE
+    -- 分店帳號 = stores 非空且不含「總倉」，對齊前端 isBranchUser()
+    WHEN (SELECT cardinality(store_names) > 0
+             AND NOT ('總倉' = ANY (store_names))
+            FROM me) THEN (
+      SELECT COUNT(*)::int
+        FROM mutual_aid_board b
+       WHERE b.tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND b.status = 'active'
+         AND public.can_see_aid_post(b.offering_store_id, b.spot_visible_to_other_stores)
+    )
+    ELSE 0
+  END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_aid_board_active_count IS
+  '側欄「互助交流板」badge：分店帳號看到的進行中貼文數。'
+  '2026-08-02 起排除別店設為不公開的貼文，數字才會和列表一致。';


### PR DESCRIPTION
## 這是什麼

#583 的「其他分店的會員也看得到」開關關掉之後，**目前只擋會員端**。後台互助交流板每個帳號還是全看得到。這支補上後台那一半：

**設為不公開的貼文，只有該店的帳號看得到 —— 連 `admin` / `hq_manager` / `owner` 都看不到。**

後台是拿使用者 session 直接查表，所以這層擋在 **SELECT RLS**。前端過濾攔不住直接打 PostgREST。

## ⚠ 兩個一起處理，少一個等於沒做

**1. `aid_board_owner_write` 原本是 `FOR ALL`**

permissive policy 之間是 **OR**，而 `FOR ALL` 連 SELECT 都放行 —— 只收緊 read policy 的話，`owner` / `admin` / `hq_manager` 照樣從那條看得到，這功能等於白做。

已拆成 `INSERT` / `UPDATE` / `DELETE` 三條，**predicate 一字未改**，只是不再涵蓋 SELECT。寫入本來就都走 SECURITY DEFINER RPC，對 app 沒有行為影響。

**2. `mutual_aid_replies` 的 `replies_read_all` 也是 tenant 全開**

貼文藏起來但留言撈得到，等於從側門把內容漏出去。套同一條可見性判斷。

## 「該店」怎麼判定

比對 JWT `app_metadata.stores` 裡的**店名**。這是本 repo 既有慣例 —— `rpc_aid_board_active_count`（`20260720000030`）就是這樣認分店帳號的，沒有 `store_id` claim 可用。

⚠ 副作用（已寫進 migration 檔頭）：門市**改名**會讓該店帳號暫時看不到自己的不公開貼文，直到 `app_metadata.stores` 一起更新。之後若補上 `store_id` claim，只要改 `can_see_aid_post()` 內部，policy 不用動。

## 順手修一個既有 bug

線上 `hq_manager` 帳號的 `app_metadata` 是 `{"stores": null}` —— 那是 **JSON null**，不是 SQL NULL，`COALESCE(... , '[]'::jsonb)` 接不住，`jsonb_array_elements_text()` 會直接炸：

```
ERROR: 22023: cannot extract elements from a scalar
```

`20260720000030` 的 badge RPC 本來就有這顆地雷（只是 badge 對 HQ 帳號回 0、走不到那段所以沒爆）。新的 helper 改用 `jsonb_typeof(...) = 'array'` 判掉，badge RPC 一起吃到修正。**這是實測時撞出來的，不是理論推測。**

## badge 也要一起改

`rpc_aid_board_active_count` 是 `SECURITY DEFINER`、**會繞過 RLS**，所以裡面要自己再判一次，否則側欄數字會比列表多，看起來像少了幾筆。

## 異動檔案

| 檔案 | 說明 |
|---|---|
| `supabase/migrations/20260802000060_aid_board_hidden_posts_rls.sql` | `jwt_store_names()` / `can_see_aid_post()`；收緊 board 與 replies 的 SELECT RLS；拆掉 `FOR ALL`；badge RPC |
| `docs/PLAN-現貨專區.md` / `docs/TEST-member-spot-zone.md` | §4.1 加「後台也一起藏」與兩個坑；測試加 T1V-B1~B10 |

**只有一支 migration，沒有前端改動。** 會員端與 `liff-api` 也沒動 —— 它走 service_role，繞過 RLS，維持 #583 的過濾。

## 已驗證

Migration 已套線上。policy 現況：`mutual_aid_board` 四條（SELECT / INSERT / UPDATE / DELETE），`mutual_aid_replies` 兩條。

**用 `SET LOCAL ROLE authenticated` + 塞 `request.jwt.claims` 模擬各種帳號實測**（探針貼文在交易裡建、跑完 rollback，線上零殘留）：

| 帳號 | 看得到的貼文 | 看得到的留言 |
|---|---|---|
| `admin`（stores `["總倉"]`） | 只有 PUBLIC —— **HIDDEN 看不到** ✅ | 只有 PUBLIC ✅ |
| `hq_manager`（stores `null`） | 只有 PUBLIC ✅ **且不再炸** | 只有 PUBLIC ✅ |
| 松山店 店長 | PUBLIC + **HIDDEN** ✅ | 兩則都看得到 ✅ |
| 三峽店 店長 | 只有 PUBLIC ✅ | 只有 PUBLIC ✅ |
| 多店店長（`["忠順店","松山店"]`） | PUBLIC + **HIDDEN** ✅ | 兩則都看得到 ✅ |

badge：

| 情境 | 數字 |
|---|---|
| 松山店（沒有探針時的基準） | 20 |
| 加一筆松山店的不公開貼文後，**松山店** | 21 ✅ 自己的算進去 |
| 同上，**三峽店** | 20 ✅ 別店的不算 |
| admin（總倉） | 0（HQ 帳號本來就不顯示 badge） |

其他：
- `liff-api` 打起來仍回自家 401（service_role 不受 RLS 影響）
- admin `tsc --noEmit` 過
- migration 寫成可重跑（新 policy 也有 `DROP ... IF EXISTS`）—— 第一次跑漏了這個，重跑會撞 `already exists`，已修

## 沒驗證

- **沒有用真的 admin / 店長帳號登入後台點過畫面。** 驗到的是 RLS 這一層（用模擬 JWT 直接對資料庫測），那也是唯一擋得住的地方。合併後照 `docs/TEST-member-spot-zone.md` 走 **T1V-B1~B10**，重點是 B2（admin 看不到）、B3（hq_manager 頁面不報錯）、B6/B7（直接打 PostgREST 回 `[]`）
- 沒有測「門市改名之後該店帳號暫時看不到」這條已知副作用

---
_Generated by [Claude Code](https://claude.ai/code/session_01DetXFF67eZbpESvKssoeXz)_