### PR TITLE
開團頁新增「匯出樂樂上架檔」

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -24,7 +24,8 @@
     "papaparse": "^5.5.3",
     "react": "19.2.4",
     "react-day-picker": "^9.14.0",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "xlsx": "0.18.5"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -21,6 +21,7 @@ import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/compone
 import Spinner, { LoadingBlock } from "@/components/Spinner";
 import { CampaignThumb } from "@/components/CampaignThumb";
 import { campaignCoverUrl, type CampaignCoverItem } from "@/lib/campaignCover";
+import { exportLeleXls, type LeleCampaign, type LeleTruncation, type LeleSkip } from "@/lib/exportLeleXls";
 import FbPublishModal from "@/components/FbPublishModal";
 import FbBulkPublishModal from "@/components/FbBulkPublishModal";
 import { useRole, isAdmin } from "@/lib/role";
@@ -182,6 +183,17 @@ export default function CampaignsListPage() {
   const [bulkEndAt, setBulkEndAt] = useState("");
   const [endAtErr, setEndAtErr] = useState<string | null>(null);
 
+  // 匯出樂樂上架檔（依「開團時間」start_at 區間；預設近 7 天）
+  const [leleOpen, setLeleOpen] = useState(false);
+  const [leleFrom, setLeleFrom] = useState(() => localDateKey(addDays(startOfDay(new Date()), -7)));
+  const [leleTo, setLeleTo] = useState(() => localDateKey(startOfDay(new Date())));
+  const [leleErr, setLeleErr] = useState<string | null>(null);
+  // 匯出中：擋住重複觸發（含關閉 modal 再開一次），也擋住關閉以免截斷提示看不到
+  const [leleBusy, setLeleBusy] = useState(false);
+  const [leleWarn, setLeleWarn] = useState<LeleTruncation[] | null>(null);
+  // 款式太多、匯出會造成價格錯位而整團沒匯出的團（嚴重度高於 leleWarn）
+  const [leleSkip, setLeleSkip] = useState<LeleSkip[] | null>(null);
+
   const [view, setView] = useState<View>(() => {
     if (typeof window === "undefined") return "list";
     const saved = window.localStorage.getItem("campaigns:view");
@@ -250,6 +262,92 @@ export default function CampaignsListPage() {
       }
     } catch (e) {
       setEndAtErr(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  // 匯出樂樂上架檔：撈區間內的團 + 明細 → 交給 lib 產 BIFF8 .xls 下載
+  async function runExportLele() {
+    if (leleBusy) return; // 併發保險：即使關掉 modal 再開一次也不會跑第二份
+    setLeleErr(null);
+    setLeleWarn(null);
+    setLeleSkip(null);
+    if (!leleFrom || !leleTo) { setLeleErr("請選擇開團時間的起日與迄日"); return; }
+    if (leleFrom > leleTo) { setLeleErr("起日不能晚於迄日"); return; }
+    type CampRow = { id: number; campaign_no: string; name: string; description: string | null; end_at: string | null };
+    type ItemRow = {
+      campaign_id: number; id: number; sort_order: number; unit_price: number;
+      skus: { sku_code: string; variant_name: string | null };
+    };
+    setLeleBusy(true);
+    try {
+      const sb = getSupabase();
+      const from = new Date(`${leleFrom}T00:00:00`).toISOString();
+      const to = new Date(`${leleTo}T23:59:59.999`).toISOString();
+      // 已取消的團不匯；__INTERNAL_RESTOCK__ 不是真的團（與本頁其他查詢一致）
+      const camps = await fetchAll<CampRow>(() =>
+        sb.from("group_buy_campaigns")
+          .select("id, campaign_no, name, description, end_at")
+          .neq("campaign_no", "__INTERNAL_RESTOCK__")
+          .neq("status", "cancelled")
+          .gte("start_at", from)
+          .lte("start_at", to)
+          .order("start_at", { ascending: true })
+          .order("id", { ascending: true }));
+
+      // 明細分批撈（沿用本頁 chunk 慣例，避免 .in() 把 URL 塞爆）
+      const ids = camps.map((c) => c.id);
+      const itemRows: ItemRow[] = [];
+      for (let i = 0; i < ids.length; i += 500) {
+        const chunk = ids.slice(i, i + 500);
+        const part = await fetchAll<ItemRow>(() =>
+          sb.from("campaign_items")
+            .select("campaign_id, id, sort_order, unit_price, skus!inner(sku_code, variant_name)")
+            .in("campaign_id", chunk)
+            .order("id", { ascending: true }));
+        itemRows.push(...part);
+      }
+
+      const byCampaign = new Map<number, LeleCampaign["items"]>();
+      for (const it of itemRows) {
+        const arr = byCampaign.get(it.campaign_id) ?? [];
+        arr.push({
+          id: it.id,
+          sort_order: it.sort_order,
+          unit_price: it.unit_price,
+          variant_name: it.skus?.variant_name ?? null,
+          sku_code: it.skus?.sku_code ?? "",
+        });
+        byCampaign.set(it.campaign_id, arr);
+      }
+
+      const payload: LeleCampaign[] = camps.map((c) => ({
+        campaign_no: c.campaign_no,
+        name: c.name,
+        description: c.description,
+        end_at: c.end_at,
+        items: byCampaign.get(c.id) ?? [],
+      }));
+
+      const fname = `樂樂上架_${leleFrom.replace(/-/g, "")}-${leleTo.replace(/-/g, "")}.xls`;
+      const { exported, truncated, skipped } = await exportLeleXls(payload, fname);
+      if (skipped.length > 0) setLeleSkip(skipped);
+      if (truncated.length > 0) setLeleWarn(truncated);
+      if (exported === 0) {
+        // 全部被跳過 vs 本來就沒東西可匯，要講不一樣的話（前者沒有產生檔案）
+        setLeleErr(
+          skipped.length > 0
+            ? `這個區間的 ${skipped.length} 個團全部因為款式太多無法匯出，沒有產生檔案。`
+            : `${leleFrom} ~ ${leleTo} 這個區間沒有可匯出的開團（已排除「已取消」與沒有商品明細的團）。`,
+        );
+        return;
+      }
+      // 有團被跳過或描述被截斷 → 檔案照常下載，但 modal 留著把發生什麼事講清楚
+      if (skipped.length > 0 || truncated.length > 0) return;
+      setLeleOpen(false);
+    } catch (e) {
+      setLeleErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLeleBusy(false);
     }
   }
 
@@ -681,6 +779,13 @@ export default function CampaignsListPage() {
             >
               🔁 批次建立
             </SpinButton>
+            <SpinButton
+              onClick={() => { setLeleErr(null); setLeleWarn(null); setLeleSkip(null); setLeleOpen(true); }}
+              disabled={leleBusy}
+              className="rounded-md border border-zinc-300 px-3 py-2 text-sm font-medium hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              匯出樂樂
+            </SpinButton>
             <Link href="/products?mode=campaign" className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200">
               + 從商品開團
             </Link>
@@ -1051,6 +1156,79 @@ export default function CampaignsListPage() {
                 className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900"
               >
                 確定套用
+              </SpinButton>
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      <Modal
+        open={leleOpen}
+        onClose={() => { if (!leleBusy) setLeleOpen(false); }}
+        title="匯出樂樂上架檔"
+        maxWidth="max-w-md"
+      >
+        {leleOpen && (
+          <div className="space-y-4">
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+              依「開團時間」區間匯出，產生樂樂團購可直接上傳的 Excel 97-2003（.xls）。
+              已取消的開團、以及還沒加商品的開團不會匯出。
+            </p>
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <span className="text-zinc-600 dark:text-zinc-400">開團時間</span>
+              {/* 不互相 min/max 綁死：要把區間整段往後移時會被鎖住選不動，改由下方驗證擋 */}
+              <DatePicker value={leleFrom} onChange={setLeleFrom} popover="fixed" />
+              <span className="text-zinc-400">～</span>
+              <DatePicker value={leleTo} onChange={setLeleTo} popover="fixed" />
+            </div>
+            {leleErr && <p className="text-xs text-rose-600">{leleErr}</p>}
+            {leleSkip && leleSkip.length > 0 && (
+              <div className="rounded-md border border-red-300 bg-red-50 p-3 text-xs text-red-900 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
+                <p className="font-medium">
+                  ⚠️ 以下 {leleSkip.length} 個團「沒有匯出」，因為款式太多超過樂樂單欄上限。
+                  硬匯出會造成款式與價格錯位、上架成錯誤價格，所以直接排除。
+                  請先把商品拆成多個團再匯出：
+                </p>
+                <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                  {leleSkip.map((s) => (
+                    <li key={s.campaign_no}>
+                      {s.campaign_no}｜{s.name}｜{s.itemCount} 款（{s.reason}）
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {leleWarn && leleWarn.length > 0 && (
+              <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+                <p className="font-medium">
+                  檔案已下載。但下列 {leleWarn.length} 團的「商品描述」超過樂樂單格上限 255 字元，已自動截斷：
+                </p>
+                <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                  {leleWarn.map((t) => (
+                    <li key={t.campaign_no}>
+                      {t.campaign_no}｜{t.name}（原本 {t.originalLength} 字元，只保留前 255）
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-1.5">
+                  文案若不能被砍，請先把這幾團的商品描述縮到 255 字元內再重新匯出。
+                </p>
+              </div>
+            )}
+            <div className="flex justify-end gap-2 pt-2">
+              <SpinButton
+                onClick={() => setLeleOpen(false)}
+                disabled={leleBusy}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              >
+                {leleWarn || leleSkip ? "關閉" : "取消"}
+              </SpinButton>
+              <SpinButton
+                onClick={runExportLele}
+                disabled={leleBusy}
+                className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900"
+              >
+                匯出
               </SpinButton>
             </div>
           </div>

--- a/apps/admin/src/lib/exportLeleXls.ts
+++ b/apps/admin/src/lib/exportLeleXls.ts
@@ -1,0 +1,260 @@
+"use client";
+
+// 匯出「樂樂團購」商品上架檔。
+// 格式是拿老闆實際上架成功的檔反推的：Excel 97-2003 (BIFF8 .xls)、工作表名「商品匯入」、
+// 24 欄固定順序。⚠ 樂樂不吃 xlsx，bookType 一定要 biff8。
+//
+// 一團一列。單款把售價寫進品名（💰85）、多款不寫（價格不同），
+// 改用「(A)款名,(B)款名」對上「售價」欄的逗號序列 — 兩邊順序必須完全對齊。
+
+export type LeleItem = {
+  id: number;
+  sort_order: number;
+  unit_price: number | string;
+  variant_name: string | null;
+  sku_code: string;
+};
+
+export type LeleCampaign = {
+  campaign_no: string;
+  name: string;
+  description: string | null;
+  end_at: string | null;
+  items: LeleItem[];
+};
+
+/** 樂樂匯入檔固定 24 欄 */
+export const LELE_COLUMN_COUNT = 24;
+
+/** 表頭（含欄內換行，順序與字面都不可動 — 樂樂靠這個認欄位）*/
+export const LELE_HEADERS = [
+  "保留欄位",
+  "自定義編號",
+  "商品名稱",
+  "主要分類\n(款式名稱，以半形逗號分隔)",
+  "細項一\n(款式二名稱，以半形逗號分隔)",
+  "細項二\n(款式三名稱，以半形逗號分隔)",
+  "售價\n(以半形逗號分隔)",
+  "VIP價\n(以半形逗號分隔)",
+  "成本\n(以半形逗號分隔)",
+  "庫存\n(以半形逗號分隔)",
+  "僅限VIP\n(1=是, 空白=否)",
+  "上架個人賣場\n(1=是, 空白=否)",
+  "商品分類\n(以半形逗號分隔)",
+  "僅供現貨\n(1=是, 空白=否)",
+  "禁止結單\n(1=是, 空白=否)",
+  "成團人數",
+  "收單時間\n(yyyy/M/d  hh:mm:ss AM/PM)",
+  "自定義標籤\n(以半形逗號分隔)",
+  "倉儲位置",
+  "預設供貨商",
+  "商品描述",
+  "商品備註",
+  "公開備註",
+  "檔案版本",
+];
+
+const SHEET_NAME = "商品匯入";
+
+/** 售價：整數不要拖小數點（實檔是 85，不是 85.0000）*/
+function fmtPrice(v: number | string): string {
+  const n = Number(v);
+  return Number.isFinite(n) ? String(n) : "";
+}
+
+function toDate(iso: string | null): Date | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** 品名裡的收單日 M/D，不補零（4/5 不是 04/05）*/
+function fmtMonthDay(d: Date): string {
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+/** 收單時間欄：yyyy/M/d ＋ 兩個半形空格 ＋ hh:mm:ss ＋ " PM"（照老闆實檔原樣，PM 是固定字面）*/
+function fmtCloseAt(d: Date | null): string {
+  if (!d) return "";
+  const p2 = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}  ${p2(d.getHours())}:${p2(d.getMinutes())}:${p2(d.getSeconds())} PM`;
+}
+
+/**
+ * BIFF8 單一儲存格的字串上限＝255 個 UTF-16 code unit（不是 code point）。
+ * SheetJS 0.18.5 寫超過就「靜默」截到 255，不報錯也不警告 — 實測 256→255、3000→255。
+ * （bookSST:true 那條路在 ~4000 字會 OOM 讓整個 process 掛掉，比截斷更糟，不能走。）
+ */
+const BIFF8_MAX_CHARS = 255;
+
+/**
+ * 安全截斷：切完若尾巴是孤兒 high surrogate（emoji 被切一半）就再退一格。
+ * 老闆文案大量用 emoji（🌿⏰💰🇯🇵），emoji 佔 2 個 code unit，
+ * 天真的 slice(0,255) 實測會留下 \ud83c 這種半個字元，寫進檔案就是亂碼。
+ */
+function cutForBiff8(text: string): string {
+  if (text.length <= BIFF8_MAX_CHARS) return text;
+  const cut = text.slice(0, BIFF8_MAX_CHARS);
+  const last = cut.charCodeAt(cut.length - 1);
+  return last >= 0xd800 && last <= 0xdbff ? cut.slice(0, -1) : cut;
+}
+
+/** 款式序號 A、B、C…（超過 26 款接 AA、AB…，避免掉出字母範圍變亂碼）*/
+function letterLabel(i: number): string {
+  let s = "";
+  for (let n = i; n >= 0; n = Math.floor(n / 26) - 1) {
+    s = String.fromCharCode(65 + (n % 26)) + s;
+  }
+  return s;
+}
+
+/** 商品描述被 255 字上限截掉的團，匯出後要回報給使用者（不擋匯出）*/
+export type LeleTruncation = {
+  campaign_no: string;
+  name: string;
+  /** 截斷前的長度，單位是 UTF-16 code unit（emoji 算 2）*/
+  originalLength: number;
+};
+
+/** 因為欄 3/欄 6 會破 255 而「整團不匯出」的團 — 嚴重度高於描述截斷 */
+export type LeleSkip = {
+  campaign_no: string;
+  name: string;
+  itemCount: number;
+  /** 哪一欄過長、長到多少，讓老闆知道要拆多少 */
+  reason: string;
+};
+
+/**
+ * 組出整份工作表的列（第 0 列是表頭）。純函式、無 DOM，方便單獨驗。
+ * 沒有 campaign_items 的團會跳過（無款式無售價，樂樂吃不了）。
+ * 商品描述超過 255 字會被截斷並記進 truncated（老闆現行流程本來就在截，
+ * 不可接受的是「靜默」截 → 照常匯出，但要講出來截了哪幾團）。
+ */
+export function buildLeleRows(campaigns: LeleCampaign[]): {
+  rows: string[][];
+  truncated: LeleTruncation[];
+  skipped: LeleSkip[];
+} {
+  if (LELE_HEADERS.length !== LELE_COLUMN_COUNT) {
+    throw new Error(`匯出樂樂：表頭欄數 ${LELE_HEADERS.length} ≠ ${LELE_COLUMN_COUNT}`);
+  }
+
+  const rows: string[][] = [LELE_HEADERS.slice()];
+  const truncated: LeleTruncation[] = [];
+  const skipped: LeleSkip[] = [];
+
+  for (const c of campaigns) {
+    const items = [...c.items].sort((a, b) => a.sort_order - b.sort_order || a.id - b.id);
+    if (items.length === 0) continue;
+    const multi = items.length > 1;
+
+    const endAt = toDate(c.end_at);
+    // end_at 是 null 就整段 ⏰…結單 省略
+    const closeTag = endAt ? `⏰${fmtMonthDay(endAt)}結單` : "";
+    // 多款價格不同，品名不放 💰
+    const priceTag = multi ? "" : `💰${fmtPrice(items[0].unit_price)}`;
+    const title = `⬜${c.name}${priceTag}${closeTag}`;
+
+    // 單款：主要分類 = 商品名稱整串；多款：(A)款名,(B)款名…（順序與售價欄一致）
+    const category = multi
+      ? items.map((it, i) => `(${letterLabel(i)})${it.variant_name?.trim() || it.sku_code}`).join(",")
+      : title;
+    const prices = items.map((it) => fmtPrice(it.unit_price)).join(",");
+
+    // 欄 3 主要分類 / 欄 6 售價是「半形逗號分隔」欄位。這兩欄一旦破 255 被 BIFF8 截掉，
+    // 款式會少幾個、售價卻一個沒少 → 樂樂自動補價 → 上架出價格錯誤的商品（會賠錢）。
+    // 描述截斷只是文案變短可以接受，這個不行 → 整團不寫進檔案，交回去請人拆團。
+    // 實測門檻：約 22 款以內安全，26 款 x 8 字款名就會錯位。
+    const overLong: string[] = [];
+    if (category.length > BIFF8_MAX_CHARS) overLong.push(`主要分類 ${category.length} 字元`);
+    if (prices.length > BIFF8_MAX_CHARS) overLong.push(`售價 ${prices.length} 字元`);
+    if (overLong.length > 0) {
+      skipped.push({
+        campaign_no: c.campaign_no,
+        name: c.name,
+        itemCount: items.length,
+        reason: `${overLong.join("、")}，超過單欄上限 ${BIFF8_MAX_CHARS}`,
+      });
+      continue;
+    }
+
+    // 欄 20 商品描述是唯一「可以」截斷的長欄位（開團文案沒有長度限制）
+    const description = c.description ?? "";
+    const descriptionCut = cutForBiff8(description);
+    if (descriptionCut !== description) {
+      truncated.push({ campaign_no: c.campaign_no, name: c.name, originalLength: description.length });
+    }
+
+    const row = [
+      "",              // 0  保留欄位
+      c.campaign_no,   // 1  自定義編號
+      title,           // 2  商品名稱
+      category,        // 3  主要分類
+      "",              // 4  細項一
+      "",              // 5  細項二
+      prices,          // 6  售價
+      "",              // 7  VIP價
+      "",              // 8  成本
+      "",              // 9  庫存
+      "",              // 10 僅限VIP
+      "1",             // 11 上架個人賣場
+      "團購商品💕",     // 12 商品分類
+      "",              // 13 僅供現貨
+      "1",             // 14 禁止結單
+      "",              // 15 成團人數
+      fmtCloseAt(endAt), // 16 收單時間
+      "",              // 17 自定義標籤
+      "",              // 18 倉儲位置
+      "",              // 19 預設供貨商
+      descriptionCut,  // 20 商品描述（保留原本換行；超過 255 已安全截斷）
+      "",              // 21 商品備註
+      "",              // 22 公開備註
+      "1",             // 23 檔案版本
+    ];
+
+    if (row.length !== LELE_COLUMN_COUNT) {
+      throw new Error(`匯出樂樂：團 ${c.campaign_no} 欄數 ${row.length} ≠ ${LELE_COLUMN_COUNT}`);
+    }
+    // 欄 3（主要分類）與欄 6（售價）都是「半形逗號分隔」欄位，兩邊筆數必須一致。
+    // 對不齊時樂樂不會擋下來，而是自動補足最後一筆數字 → 默默上架成錯的商品（比直接失敗更糟），
+    // 所以這裡寧可整份匯出失敗、把團號團名報出來讓人去改，也不自動替換逗號
+    // （自動替換會讓商品名稱與主要分類兩欄長得不一樣，更難查）。
+    // 單款時 category = title，團名裡的半形逗號會被同一個檢查抓到（nPrice 恆為 1）。
+    const nVariant = category.split(",").length;
+    const nPrice = prices.split(",").length;
+    if (nVariant !== nPrice) {
+      const culprit = multi ? "款式名稱" : "團名";
+      throw new Error(
+        `匯出樂樂：團 ${c.campaign_no}「${c.name}」款式數 ${nVariant} ≠ 售價數 ${nPrice}（${culprit}可能含半形逗號，請先改掉再匯出）`,
+      );
+    }
+    rows.push(row);
+  }
+
+  return { rows, truncated, skipped };
+}
+
+/**
+ * 產生並下載樂樂上架檔。
+ * exported  = 實際匯出的團數（0 表示沒東西可匯，不會產生檔案）
+ * truncated = 商品描述被截到 255 字的團（有匯出，但文案被砍）
+ * skipped   = 欄 3/欄 6 會破 255 而整團沒匯出的團（嚴重度較高，呼叫端要另外醒目顯示）
+ */
+export async function exportLeleXls(
+  campaigns: LeleCampaign[],
+  filename: string,
+): Promise<{ exported: number; truncated: LeleTruncation[]; skipped: LeleSkip[] }> {
+  const { rows, truncated, skipped } = buildLeleRows(campaigns);
+  const exported = rows.length - 1; // 扣掉表頭
+  // 全被跳過（或本來就沒東西）→ 不產生空檔
+  if (exported === 0) return { exported: 0, truncated, skipped };
+
+  // 動態載入：xlsx 近 1MB，不讓它進開團頁的主 bundle
+  const XLSX = await import("xlsx");
+  const ws = XLSX.utils.aoa_to_sheet(rows);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, SHEET_NAME);
+  XLSX.writeFile(wb, filename, { bookType: "biff8" });
+  return { exported, truncated, skipped };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "papaparse": "^5.5.3",
         "react": "19.2.4",
         "react-day-picker": "^9.14.0",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "xlsx": "0.18.5"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -3233,6 +3234,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/admin": {
       "resolved": "apps/admin",
       "link": true
@@ -3698,6 +3708,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3720,6 +3743,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3763,6 +3795,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4802,6 +4846,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/function-bind": {
@@ -7768,6 +7821,18 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -8597,6 +8662,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8626,6 +8709,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {


### PR DESCRIPTION
開團列表頁新增「匯出樂樂」，選開團時間（`start_at`）區間，匯出樂樂團購系統可上傳的 **24 欄 BIFF8 `.xls`**。

格式依老闆實際上架成功的檔反推，與參考檔**逐格比對 0 差異**。

## 做了什麼

- 一團一列。單款品名帶 `💰售價`；多款改用 `(A)款名,(B)款名` 對齊售價欄
- 排除 `cancelled` 與 `__INTERNAL_RESTOCK__`；無明細團跳過；走既有 `fetchAll` 分頁
- 工作表名 `商品匯入`、`bookType: "biff8"`（樂樂不吃 xlsx）

## 兩個資料安全處理

BIFF8 單一儲存格上限 255 字元，超過會**靜默截斷**（實測 3000 字寫入只剩 255，不報錯）：

- **欄20 商品描述** → 安全截斷（切完退一格，避免切斷 emoji 產生孤兒代理對），照常匯出並回報被截斷清單
- **欄3 主要分類／欄6 售價** → **整團跳過不匯出**。截斷會讓款式數少、售價數不變，樂樂會自動補價 → 上架成錯誤價格。寧可不出也不能出錯價，紅字提示請先拆團

## 其他

- 匯出中鎖定按鈕與關閉鍵，避免併發重複下載、避免警示被 unmount
- `xlsx@0.18.5` 補進 `package.json` 與 lockfile（原本只在 node_modules）
- `page.tsx` 純新增 178 行、**0 刪除**；零資料庫改動

## 驗證

- 自動化測試 67 項全過（emoji 邊界、價格錯位、跳過邏輯、255 邊界逐字比對）
- Codex 五輪審查，P0/P1 清零
- `tsc` / `next build` 皆通過

## 已知待驗

尚未實際上傳樂樂後台驗證。特別是收單時間尾綴 ` PM`（照實檔寫死）與「自定義編號」填團號，需上線後用真實資料匯出試傳確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)