### PR TITLE
feat(staff): 訂單樞紐「檢視所有門市」改成可個別授權

### DIFF
--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -7,6 +7,7 @@ import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
 import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
+import { useHasStaffPerm } from "@/lib/staffPerms";
 import { ORDER_STATUSES, ORDER_STATUS_LABEL, type OrderStatus } from "@/lib/orderStatus";
 import { type CampaignStatus } from "@/lib/campaignStatus";
 import SpinButton from "@/components/SpinButton";
@@ -273,14 +274,19 @@ function PivotContent() {
     }
   }, [hydrated, campaignIds, viewBy, dateFrom, dateTo, statusSet, storeId, metric, closedOnly]);
 
-  // 分店帳號鎖
-  const branchStoreId = useUserBranchStoreId(stores);
+  // 分店帳號鎖 —— 可被「訂單樞紐：檢視所有門市」功能權限個別解除。
+  // 該權限由 owner/admin 在 /staff 逐人授予（app_metadata.perms），
+  // 讓特定分店同仁看得到全部店的樞紐，又不必把他整個升成 HQ 帳號。
+  const canSeeAllStores = useHasStaffPerm("orders_pivot_all_stores");
+  const ownBranchStoreId = useUserBranchStoreId(stores);
+  const branchStoreId = canSeeAllStores ? null : ownBranchStoreId;
   useEffect(() => {
     if (branchStoreId != null && storeId !== String(branchStoreId)) {
       setStoreId(String(branchStoreId));
     }
   }, [branchStoreId, storeId]);
-  useDefaultStoreFromUser(stores, storeId, setStoreId);
+  // 有授權者預設停在「全部取貨店」，不要被帶回自己店
+  useDefaultStoreFromUser(stores, storeId, setStoreId, !canSeeAllStores);
 
   // Load stores 一次
   useEffect(() => {
@@ -803,6 +809,11 @@ function PivotContent() {
           <select
             value={storeId}
             onChange={(e) => setStoreId(e.target.value)}
+            title={
+              canSeeAllStores && ownBranchStoreId != null
+                ? "已個別授權「訂單樞紐：檢視所有門市」"
+                : undefined
+            }
             className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
           >
             <option value="">全部取貨店</option>

--- a/apps/admin/src/app/(protected)/staff/page.tsx
+++ b/apps/admin/src/app/(protected)/staff/page.tsx
@@ -9,6 +9,7 @@ import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow } from "@/components/DataTable";
 import { RoleChip, ALL_ROLES, roleLabel, type StaffRole } from "@/components/RoleChip";
+import { ALL_STAFF_PERMS, permLabel } from "@/lib/staffPerms";
 
 type StaffRow = {
   user_id: string;
@@ -16,6 +17,8 @@ type StaffRow = {
   display_name: string | null;
   role: string;
   stores: string[];
+  // 功能權限（app_metadata.perms）— role 之外個別授予的細粒度開關
+  perms: string[];
   disabled: boolean;
   created_at: string;
   last_sign_in_at: string | null;
@@ -27,6 +30,7 @@ type Modal =
   | { mode: "create" }
   | { mode: "role"; row: StaffRow }
   | { mode: "stores"; row: StaffRow }
+  | { mode: "perms"; row: StaffRow }
   | { mode: "disable"; row: StaffRow }
   | null;
 
@@ -62,7 +66,13 @@ export default function StaffPage() {
       if (s.error) { setError(s.error.message); return; }
       if (l.error) { setError(l.error.message); return; }
       setStores((s.data ?? []) as Store[]);
-      setRows((l.data ?? []) as StaffRow[]);
+      // perms 是後加的欄位；線上 RPC 還沒套 migration 時會是 undefined → 補成空陣列
+      setRows(
+        ((l.data ?? []) as StaffRow[]).map((r) => ({
+          ...r,
+          perms: Array.isArray(r.perms) ? r.perms : [],
+        })),
+      );
     })();
     return () => { cancelled = true; };
   }, [canManage, reloadTick]);
@@ -110,15 +120,16 @@ export default function StaffPage() {
           <Th>顯示名</Th>
           <Th>角色</Th>
           <Th>綁定店</Th>
+          <Th>功能權限</Th>
           <Th align="right">建立</Th>
           <Th align="right">最後登入</Th>
           <Th>{""}</Th>
         </THead>
         <TBody>
           {rows === null ? (
-            <EmptyRow colSpan={7}>載入中…</EmptyRow>
+            <EmptyRow colSpan={8}>載入中…</EmptyRow>
           ) : rows.length === 0 ? (
-            <EmptyRow colSpan={7}>沒有員工</EmptyRow>
+            <EmptyRow colSpan={8}>沒有員工</EmptyRow>
           ) : (
             rows.map((r) => {
               const isSelf = r.user_id === user?.id;
@@ -138,6 +149,22 @@ export default function StaffPage() {
                       <div className="flex flex-wrap gap-1">
                         {r.stores.map((s) => (
                           <span key={s} className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">{s}</span>
+                        ))}
+                      </div>
+                    )}
+                  </Td>
+                  <Td>
+                    {r.perms.length === 0 ? (
+                      <span className="text-xs text-zinc-400">—</span>
+                    ) : (
+                      <div className="flex flex-wrap gap-1">
+                        {r.perms.map((p) => (
+                          <span
+                            key={p}
+                            className="rounded bg-sky-100 px-1.5 py-0.5 text-[10px] text-sky-700 dark:bg-sky-950 dark:text-sky-300"
+                          >
+                            {permLabel(p)}
+                          </span>
                         ))}
                       </div>
                     )}
@@ -167,6 +194,13 @@ export default function StaffPage() {
                         className="text-xs text-blue-600 hover:underline dark:text-blue-400"
                       >
                         綁店
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setModal({ mode: "perms", row: r })}
+                        className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                      >
+                        功能權限
                       </button>
                       {disabled ? (
                         <button
@@ -216,6 +250,13 @@ export default function StaffPage() {
         <StoresModal
           row={modal.row}
           stores={stores}
+          onClose={() => setModal(null)}
+          onSaved={() => { setModal(null); reload(); }}
+        />
+      )}
+      {modal?.mode === "perms" && (
+        <PermsModal
+          row={modal.row}
           onClose={() => setModal(null)}
           onSaved={() => { setModal(null); reload(); }}
         />
@@ -335,6 +376,64 @@ function StoresModal({
               />
               <span>{s.name}</span>
               <span className="ml-auto text-[10px] text-zinc-400">{s.code}</span>
+            </label>
+          ))}
+        </div>
+        <p className="text-[11px] text-zinc-500">改完員工需重新登入才會生效。</p>
+        {err && <p className="text-xs text-rose-600">{err}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <SpinButton onClick={onClose} className="rounded-md border border-zinc-300 px-3 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800">取消</SpinButton>
+          <SpinButton onClick={save} className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900">儲存</SpinButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function PermsModal({
+  row, onClose, onSaved,
+}: { row: StaffRow; onClose: () => void; onSaved: () => void }) {
+  const [sel, setSel] = useState<Set<string>>(new Set(row.perms));
+  const [err, setErr] = useState<string | null>(null);
+
+  function toggle(key: string) {
+    setSel((s) => {
+      const n = new Set(s);
+      if (n.has(key)) n.delete(key); else n.add(key);
+      return n;
+    });
+  }
+
+  async function save() {
+    const { error } = await getSupabase().rpc("rpc_update_staff_perms", {
+      p_user_id: row.user_id, p_perms: Array.from(sel),
+    });
+    if (error) { setErr(error.message); return; }
+    onSaved();
+  }
+
+  return (
+    <Modal open onClose={onClose} title={`功能權限 — ${row.email}`} maxWidth="max-w-md">
+      <div className="space-y-3 p-5">
+        <p className="text-xs text-zinc-500">
+          角色之外「個別加開」的功能。不勾＝依角色/綁店的預設權限。
+        </p>
+        <div className="space-y-2">
+          {ALL_STAFF_PERMS.map((p) => (
+            <label
+              key={p.key}
+              className="flex cursor-pointer items-start gap-2 rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-700"
+            >
+              <input
+                type="checkbox"
+                checked={sel.has(p.key)}
+                onChange={() => toggle(p.key)}
+                className="mt-0.5 h-4 w-4"
+              />
+              <span>
+                <span className="font-medium">{p.label}</span>
+                <span className="mt-0.5 block text-[11px] text-zinc-500">{p.desc}</span>
+              </span>
             </label>
           ))}
         </div>

--- a/apps/admin/src/lib/staffPerms.ts
+++ b/apps/admin/src/lib/staffPerms.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMemo } from "react";
+import { useAuth } from "@/components/AuthProvider";
+
+/**
+ * 員工「功能權限」— role 之外再掛一層、可個別授予特定人的細粒度開關。
+ *
+ * 存在 JWT 的 app_metadata.perms（字串陣列），由 owner/admin 經
+ * rpc_update_staff_perms 設定（見 supabase/migrations/20260803000000_staff_feature_perms.sql）。
+ * 使用者自己改不到，但**改完要重新登入 / token refresh 才會進 JWT**。
+ *
+ * 新增權限時：這裡加一筆 + migration 的 _is_valid_staff_perm 白名單加同一個 key。
+ */
+export const ALL_STAFF_PERMS = [
+  {
+    key: "orders_pivot_all_stores",
+    label: "訂單樞紐：檢視所有門市",
+    desc: "分店帳號在「訂單 — 樞紐表」不再被鎖在自己那間店，可切換／同時檢視每一間店。",
+  },
+] as const;
+
+export type StaffPerm = (typeof ALL_STAFF_PERMS)[number]["key"];
+
+const PERM_LABEL: Record<string, string> = Object.fromEntries(
+  ALL_STAFF_PERMS.map((p) => [p.key, p.label]),
+);
+
+export function permLabel(key: string): string {
+  return PERM_LABEL[key] ?? key;
+}
+
+/** 把 app_metadata.perms（unknown）正規化成字串 Set；非陣列一律視為沒有權限 */
+export function parsePerms(raw: unknown): Set<string> {
+  if (!Array.isArray(raw)) return new Set();
+  return new Set(raw.filter((x): x is string => typeof x === "string"));
+}
+
+/** 目前登入者被授予的功能權限 */
+export function useStaffPerms(): Set<string> {
+  const { user } = useAuth();
+  return useMemo(() => parsePerms(user?.app_metadata?.perms), [user]);
+}
+
+/** 目前登入者是否有某項功能權限 */
+export function useHasStaffPerm(perm: StaffPerm): boolean {
+  return useStaffPerms().has(perm);
+}

--- a/apps/admin/src/lib/useDefaultStoreFromUser.ts
+++ b/apps/admin/src/lib/useDefaultStoreFromUser.ts
@@ -27,6 +27,8 @@ export function useUserBranchStoreId(
  *   設成 storeId state (如果現在還是空的)
  * - HQ 帳號 (沒 stores 或包含「總倉」) → 不動
  * - 一旦套過就不再 reapply,使用者手動切回「全部」也尊重
+ * - enabled=false → 完全不套（給「被個別授權可看全部店」的分店帳號用,
+ *   讓它預設停在「全部門市」而不是被帶回自己店）
  *
  * 用法:
  *   useDefaultStoreFromUser(stores, storeId, setStoreId);
@@ -35,11 +37,13 @@ export function useDefaultStoreFromUser(
   stores: ReadonlyArray<{ id: number | string; name: string }>,
   currentStoreId: string,
   setStoreId: (v: string) => void,
+  enabled = true,
 ) {
   const { user } = useAuth();
   const appliedRef = useRef(false);
 
   useEffect(() => {
+    if (!enabled) return;
     if (appliedRef.current) return;
     if (currentStoreId) {
       // URL 或使用者已預先設過 → 不覆蓋
@@ -55,5 +59,5 @@ export function useDefaultStoreFromUser(
       setStoreId(String(match.id));
       appliedRef.current = true;
     }
-  }, [stores, user, currentStoreId, setStoreId]);
+  }, [stores, user, currentStoreId, setStoreId, enabled]);
 }

--- a/docs/TEST-staff-feature-perms.md
+++ b/docs/TEST-staff-feature-perms.md
@@ -1,0 +1,85 @@
+# 員工功能權限 v1 — 訂單樞紐「檢視所有門市」個別授權
+
+**對應 migration：** `supabase/migrations/20260803000000_staff_feature_perms.sql`
+**對應 UI：**
+- `apps/admin/src/lib/staffPerms.ts`（新檔：perm 清單 + JWT 讀取 hook）
+- `apps/admin/src/app/(protected)/staff/page.tsx`（員工列表加「功能權限」欄 + modal）
+- `apps/admin/src/app/(protected)/orders/pivot/page.tsx`（分店鎖可被權限解除）
+- `apps/admin/src/lib/useDefaultStoreFromUser.ts`（加 `enabled` 參數）
+
+**背景：** 樞紐表原本只有 HQ 帳號看得到全部門市欄位，分店帳號一律鎖自己店。
+需要讓「特定分店同仁」也看得到全部店，但不想把他升成 HQ 帳號（會連帶開放
+商品 / 採購 / 總倉收件匣等頁面）。→ role 之外加一層可個別授予的功能權限。
+
+---
+
+## 設計
+
+- 權限存在 `auth.users.raw_app_meta_data.perms`（JSON 字串陣列），與既有 `role` / `stores` 同一個地方。
+- v1 只有一個 key：`orders_pivot_all_stores`。
+- 授予者：owner / admin，在 `/staff` → 該員工列的「功能權限」。
+- **改完該員工要重新登入（或 token refresh）才會進 JWT 生效** — 與改 role / 綁店一致。
+
+---
+
+## 1. RPC 層
+
+### 1.1 `_is_valid_staff_perm`
+- [x] `_is_valid_staff_perm('orders_pivot_all_stores')` → true
+- [x] `_is_valid_staff_perm('nope')` → false
+
+### 1.2 `rpc_update_staff_perms(p_user_id, p_perms)`
+- [ ] owner 對分店員工設 `['orders_pivot_all_stores']` → `raw_app_meta_data.perms` 更新、回 true
+- [ ] 傳 `[]` → 收回全部功能權限（key 仍在，值為 `[]`）
+- [ ] 傳重複值 / 空字串 → 自動去重去空白後寫入
+- [ ] 傳白名單外的 key → `RAISE EXCEPTION 'invalid perm: %'`
+- [ ] 非 owner/admin caller → `permission denied: requires owner/admin role`
+- [ ] 跨 tenant 的 user_id → `user % not in tenant`
+- [ ] admin 改 owner → `admin cannot modify owner`
+
+### 1.3 `rpc_list_staff`
+- [x] 回傳多一個 `perms JSONB` 欄位（`TABLE(user_id, email, display_name, role, stores, perms, disabled, created_at, last_sign_in_at)`）
+- [ ] 沒設過 perms 的舊帳號 → 回 `[]` 而非 null
+- [ ] 其餘欄位 / 排序 / owner-admin gate 與改版前一致（regression）
+
+### 1.4 `_jwt_has_perm`
+- [ ] 給日後在 RPC / RLS 加 server-side gate 用；v1 前端自行讀 JWT，沒有呼叫點
+- [ ] `perms` 不是陣列（舊帳號 / 髒資料）→ 回 false 不報錯
+
+---
+
+## 2. UI — `/staff`
+
+- [x] 列表多一欄「功能權限」，有授權者顯示藍色 chip「訂單樞紐：檢視所有門市」，無則「—」
+- [x] 每列多一顆「功能權限」按鈕 → 開 modal，標題 `功能權限 — <email>`
+- [x] modal checkbox 依該員現況預設勾選
+- [x] 取消勾選後儲存 → 送出 `rpc_update_staff_perms { p_user_id, p_perms: [] }`
+- [ ] 非 owner/admin 進不了 `/staff`（既有行為，未改）
+
+## 3. UI — `/orders/pivot`
+
+| 帳號 | 預期 |
+|---|---|
+| HQ（stores 含「總倉」或未綁店） | 全部門市下拉（未改變） |
+| 分店帳號 · 未授權 | 顯示 `🏬 <店名> (僅本店)` 鎖定 chip、無下拉 |
+| 分店帳號 · 已授權 | 顯示門市下拉、預設「全部取貨店」、可自由切換 |
+
+- [x] 未授權：鎖定 chip 出現、下拉不存在（Playwright fixture 驗證）
+- [x] 已授權：下拉出現且選項為「全部取貨店 / 各分店」，預設值為空（＝全部）
+- [x] 兩種情況都無 console error
+- [ ] 授權者切到單店後，篩選結果只剩該店（localStorage 會記住上次選擇）
+
+## 4. Regression
+
+- [x] `useDefaultStoreFromUser` 新增的 `enabled` 參數有預設值 `true` → 其餘 8 個呼叫點行為不變
+- [x] `useUserBranchStoreId` 本身沒改 → 訂單列表 / 庫存 / 盤點 / 收貨等頁面的分店鎖不受影響
+- [x] `apps/admin` typecheck + `next build` 通過；eslint 無新增問題
+- [ ] 沒有功能權限的分店帳號，其他頁面權限完全不變
+
+---
+
+## 5. 之後要加新的細粒度權限時
+
+1. migration 在 `_is_valid_staff_perm` 白名單加 key
+2. `apps/admin/src/lib/staffPerms.ts` 的 `ALL_STAFF_PERMS` 加一筆（key / label / desc）
+3. 要 server-side 擋的話，在對應 RPC / RLS 用 `_jwt_has_perm('<key>')`

--- a/supabase/migrations/20260803000000_staff_feature_perms.sql
+++ b/supabase/migrations/20260803000000_staff_feature_perms.sql
@@ -1,0 +1,187 @@
+-- ============================================================
+-- 員工「功能權限」(per-feature toggle) v1
+--
+-- 需求：訂單樞紐表 (/orders/pivot) 原本只有 HQ 帳號（app_metadata.stores
+--   含「總倉」或未綁店）看得到全部門市欄位；分店帳號一律被鎖在自己那間店。
+--   實務上會有「某位分店同仁需要看全部店的樞紐」的例外，但又不想把他升成
+--   HQ 帳號（那會連帶開放商品/採購/總倉收件匣等一堆頁面）。
+--   → 改成 role 之外再掛一層「個別授予」的功能權限旗標。
+--
+-- 做法：沿用既有 auth.users.raw_app_meta_data 設計（同 role / stores），
+--   新增 key `perms`（TEXT[] → jsonb array of perm key）。v1 只有一個 key：
+--     - orders_pivot_all_stores：訂單樞紐表可檢視所有門市
+--   之後要加新的細粒度權限，只要在 _is_valid_staff_perm 補 key + 前端
+--   ALL_STAFF_PERMS 補一筆即可，不用再動 schema。
+--
+-- 基底版本：
+--   - rpc_list_staff 以 20260613000150_staff_permissions.sql 的版本擴寫
+--     （20260613000160_staff_permissions_fix.sql 只改了 rpc_update_staff_role
+--       / rpc_update_staff_stores，沒有動 rpc_list_staff）。
+--     這裡只多回傳一個 perms 欄位，其餘 SELECT / 排序 / tenant gate 原樣保留。
+--     回傳 shape 改變 → 必須先 DROP 再 CREATE。
+--
+-- Rollback：
+--   DROP FUNCTION public.rpc_update_staff_perms(UUID, TEXT[]);
+--   DROP FUNCTION public._is_valid_staff_perm(TEXT);
+--   DROP FUNCTION public._jwt_has_perm(TEXT);
+--   DROP FUNCTION public.rpc_list_staff();
+--   再把 rpc_list_staff 重建回 20260613000150_staff_permissions.sql 的版本。
+--   （app_metadata.perms 留著不影響任何既有邏輯）
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. 合法 perm key 白名單
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._is_valid_staff_perm(p_perm TEXT)
+RETURNS BOOLEAN LANGUAGE sql IMMUTABLE AS $$
+  SELECT p_perm IN (
+    'orders_pivot_all_stores'   -- 訂單樞紐表：檢視所有門市欄位
+  );
+$$;
+
+COMMENT ON FUNCTION public._is_valid_staff_perm(TEXT) IS
+  '功能權限 key 白名單。新增細粒度權限時在這裡加 key（同時更新前端 ALL_STAFF_PERMS）。';
+
+-- ------------------------------------------------------------
+-- 2. 目前登入者是否被授予某個功能權限
+--    （v1 前端自己讀 JWT 判斷即可；這支留給之後要在 RPC / RLS 加 gate 時共用）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._jwt_has_perm(p_perm TEXT)
+RETURNS BOOLEAN LANGUAGE sql STABLE AS $$
+  SELECT COALESCE(
+    jsonb_typeof(auth.jwt() -> 'app_metadata' -> 'perms') = 'array'
+      AND (auth.jwt() -> 'app_metadata' -> 'perms') ? p_perm,
+    FALSE
+  );
+$$;
+
+COMMENT ON FUNCTION public._jwt_has_perm(TEXT) IS
+  '當前 JWT 的 app_metadata.perms 是否包含指定功能權限 key。perms 由 owner/admin 經 rpc_update_staff_perms 設定，使用者不可自改。';
+
+GRANT EXECUTE ON FUNCTION public._is_valid_staff_perm(TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public._jwt_has_perm(TEXT) TO authenticated;
+
+-- ------------------------------------------------------------
+-- 3. rpc_update_staff_perms — owner/admin 個別授予功能權限
+--    gate 與 tenant 檢查對齊 rpc_update_staff_stores
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_update_staff_perms(
+  p_user_id UUID,
+  p_perms   TEXT[]
+) RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant        UUID := public._current_tenant_id();
+  v_target_tenant UUID;
+  v_target_role   TEXT;
+  v_invalid_perm  TEXT;
+  v_clean         TEXT[];
+BEGIN
+  IF NOT public._caller_can_manage_staff() THEN
+    RAISE EXCEPTION 'permission denied: requires owner/admin role';
+  END IF;
+
+  SELECT (raw_app_meta_data ->> 'tenant_id')::uuid,
+         COALESCE(raw_app_meta_data ->> 'role', '')
+    INTO v_target_tenant, v_target_role
+    FROM auth.users
+   WHERE id = p_user_id;
+
+  IF NOT FOUND OR v_target_tenant IS DISTINCT FROM v_tenant THEN
+    RAISE EXCEPTION 'user % not in tenant', p_user_id;
+  END IF;
+
+  -- admin 不能動 owner（對齊 rpc_update_staff_role）
+  IF NOT public._caller_is_owner() AND v_target_role = 'owner' THEN
+    RAISE EXCEPTION 'admin cannot modify owner';
+  END IF;
+
+  -- 去重 + 去空白，並驗證每個 key 都在白名單
+  SELECT COALESCE(array_agg(DISTINCT p ORDER BY p), '{}')
+    INTO v_clean
+    FROM unnest(COALESCE(p_perms, '{}')) AS p
+   WHERE COALESCE(btrim(p), '') <> '';
+
+  SELECT p INTO v_invalid_perm
+    FROM unnest(v_clean) AS p
+   WHERE NOT public._is_valid_staff_perm(p)
+   LIMIT 1;
+  IF v_invalid_perm IS NOT NULL THEN
+    RAISE EXCEPTION 'invalid perm: %', v_invalid_perm;
+  END IF;
+
+  UPDATE auth.users
+     SET raw_app_meta_data = COALESCE(raw_app_meta_data, '{}'::jsonb)
+       || jsonb_build_object('perms', to_jsonb(v_clean))
+   WHERE id = p_user_id;
+
+  RETURN TRUE;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_update_staff_perms(UUID, TEXT[]) IS
+  '設定某員工的功能權限清單（app_metadata.perms）。owner/admin 限定、tenant 綁定、admin 不能改 owner。傳空陣列＝收回全部功能權限。改完該員工需重新登入 / token refresh 才生效。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_update_staff_perms(UUID, TEXT[]) TO authenticated;
+
+-- ------------------------------------------------------------
+-- 4. rpc_list_staff — 多回一個 perms 欄位
+--    （其餘與 20260613000150 版本相同）
+-- ------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.rpc_list_staff();
+
+CREATE OR REPLACE FUNCTION public.rpc_list_staff()
+RETURNS TABLE (
+  user_id         UUID,
+  email           TEXT,
+  display_name    TEXT,
+  role            TEXT,
+  stores          JSONB,
+  perms           JSONB,
+  disabled        BOOLEAN,
+  created_at      TIMESTAMPTZ,
+  last_sign_in_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+BEGIN
+  IF NOT public._caller_can_manage_staff() THEN
+    RAISE EXCEPTION 'permission denied: requires owner/admin role';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    u.id,
+    u.email::TEXT,
+    COALESCE(u.raw_user_meta_data ->> 'display_name', u.raw_user_meta_data ->> 'name')::TEXT,
+    COALESCE(u.raw_app_meta_data ->> 'role', '')::TEXT,
+    COALESCE(u.raw_app_meta_data -> 'stores', '[]'::jsonb),
+    CASE
+      WHEN jsonb_typeof(u.raw_app_meta_data -> 'perms') = 'array'
+        THEN u.raw_app_meta_data -> 'perms'
+      ELSE '[]'::jsonb
+    END,
+    (COALESCE(u.raw_app_meta_data ->> 'role', '') = 'disabled')::BOOLEAN,
+    u.created_at,
+    u.last_sign_in_at
+  FROM auth.users u
+  WHERE (u.raw_app_meta_data ->> 'tenant_id')::uuid = v_tenant
+  ORDER BY
+    CASE COALESCE(u.raw_app_meta_data ->> 'role', '')
+      WHEN 'owner' THEN 1
+      WHEN 'admin' THEN 2
+      WHEN 'hq_manager' THEN 3
+      WHEN 'hq_accountant' THEN 4
+      WHEN 'purchaser' THEN 5
+      WHEN 'assistant' THEN 6
+      WHEN 'store_manager' THEN 7
+      WHEN 'store_staff' THEN 8
+      WHEN 'disabled' THEN 99
+      ELSE 50
+    END,
+    u.email;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_list_staff() TO authenticated;


### PR DESCRIPTION
樞紐表原本只有 HQ 帳號（app_metadata.stores 含「總倉」或未綁店）看得到
全部門市欄位，分店帳號一律被鎖在自己那間店。實務上會有個別分店同仁需要
看全部店的樞紐，但升成 HQ 帳號會連帶開放商品/採購/總倉收件匣等頁面。

改成 role 之外再掛一層可逐人授予的功能權限（app_metadata.perms）：

- migration 20260803000000_staff_feature_perms.sql
  - _is_valid_staff_perm 白名單（v1 只有 orders_pivot_all_stores）
  - _jwt_has_perm：留給日後在 RPC / RLS 加 server-side gate
  - rpc_update_staff_perms：owner/admin 限定、tenant 綁定、admin 不能改 owner、
    去重去空白 + 白名單驗證
  - rpc_list_staff 多回 perms 欄位（以 20260613000150 版本為基底擴寫，
    rollback 指回該版本）
- lib/staffPerms.ts：perm 清單 + 從 JWT 讀權限的 hook
- /staff：列表多「功能權限」欄與 chip，每列可開 modal 逐人勾選
- /orders/pivot：有 orders_pivot_all_stores 者不再套分店鎖，門市下拉可見
  且預設停在「全部取貨店」
- useDefaultStoreFromUser 加 enabled 參數（預設 true，其餘呼叫點行為不變）

驗證：typecheck + next build 通過、eslint 無新增問題；Playwright fixture 確認
未授權分店帳號仍顯示「(僅本店)」鎖定、已授權則出現全部門市下拉且無 console error。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GXjxHf7s2HckTrBudqsjPN