### PR TITLE
fix(member): 修掉 LINE 內建瀏覽器登入回 400 Bad Request

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,28 @@ LIFF ↔ 網頁互推的迴圈，第二次還沒登入就給文字指引（請�
 
 debug 提醒：`line-oauth-start` 用 curl 打回 302 → LINE login page **不代表沒問題** —
 這條路在一般瀏覽器本來就會過，400 只在真的 LINE webview 裡才會出現。
+
+---
+
+## 會員前端（apps/member）
+
+### 使用者會卡住的分支，一律留 log
+
+會員端的錯誤只發生在對方手機上，我們看不到 console；靠截圖來回問要花掉整個下午。
+所以前端只要走到「使用者會卡住 / 功能默默降級」的分支，一律呼叫
+`logClientError()` 或 `logCaught()`（`apps/member/src/lib/clientLog.ts`）。
+
+- 寫兩份：DB `client_error_logs`（`liff-api` 的 `log_client_error` action，**免 token**，
+  因為最需要記的就是「還沒登入就壞掉」）+ 本機 ring buffer（會員開 `/debug` 可當場給客服）。
+- 已在 layout 掛 `ErrorLogger` 攔 `window.onerror` / `unhandledrejection`，
+  但**未捕捉的例外不等於有記到**：被 `try/catch` 吞掉的分支要自己補呼叫。
+- 不要在 catch 裡只寫 `console.warn` 就算了 — 那等於沒記。
+
+查最近的錯誤：
+
+```sql
+SELECT created_at, source, message, detail, env
+  FROM client_error_logs ORDER BY id DESC LIMIT 50;
+```
+
+保留期自己顧：`SELECT purge_client_error_logs(30);`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,23 @@ grep -rn "<function_name>" supabase/migrations/
 
 把每一個動過該 function 的 migration 都讀過，基於**時間最新**那個版本擴寫，確保所有 prior fix 都保留。
 新 migration 檔頭註解務必列出「以哪個版本為基底」、「rollback 指回哪個版本」。
+
+---
+
+## LINE / LIFF
+
+### 在 LINE 內建瀏覽器裡，絕對不要把使用者導去 `access.line.me`
+
+LINE 官方明講「LIFF browser 內的 LINE Login 授權請求行為不保證」，實際結果是
+`access.line.me/oauth2/v2.1/authorize` 直接回一頁 **400 Bad Request**，使用者卡死。
+兩個都會踩到：
+
+- `liff.login()`（LIFF browser 內登入是 `liff.init()` 自動跑的，**不可以**自己再呼叫一次）
+- 自家的 `line-oauth-start` → 302 到 authorize（給外部瀏覽器 / PWA 用的，不能在 LINE 內用）
+
+在 LINE 內（UA 含 `" Line/"`）要登入 → 一律導去 `https://liff.line.me/{LIFF_ID}?store=...`
+讓 LINE 重開 LIFF、走 init 的 auto login。往 LIFF 彈要有 sessionStorage 一次性旗標擋住
+LIFF ↔ 網頁互推的迴圈，第二次還沒登入就給文字指引（請用外部瀏覽器開）。
+
+debug 提醒：`line-oauth-start` 用 curl 打回 302 → LINE login page **不代表沒問題** —
+這條路在一般瀏覽器本來就會過，400 只在真的 LINE webview 裡才會出現。

--- a/apps/member/src/app/debug/page.tsx
+++ b/apps/member/src/app/debug/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { clearLocalLogs, getLocalLogs, type ClientLogEntry } from "@/lib/clientLog";
+
+/**
+ * 客服用的錯誤紀錄頁：會員回報「壞掉」時，請他開 /debug 截圖或按「複製」貼給我們。
+ *
+ * 這頁只讀本機 ring buffer，不打 API — 因為最常見的情境就是網路 / 登入本身壞掉，
+ * 這時候還能打的 API 也不多。完整紀錄在 DB 的 client_error_logs。
+ */
+export default function DebugPage() {
+  const [logs, setLogs] = useState<ClientLogEntry[]>([]);
+  const [copied, setCopied] = useState(false);
+  const [env, setEnv] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    setLogs(getLocalLogs().slice().reverse());
+    const nav = navigator as Navigator & { standalone?: boolean };
+    setEnv({
+      "在 LINE 內": / Line\//i.test(nav.userAgent) ? "是" : "否",
+      "PWA (standalone)":
+        nav.standalone === true ||
+        window.matchMedia("(display-mode: standalone)").matches
+          ? "是"
+          : "否",
+      "門市": localStorage.getItem("member_store_id") ?? "（無）",
+      "已登入": localStorage.getItem("member_jwt") ? "是" : "否",
+      "UA": nav.userAgent,
+    });
+  }, []);
+
+  const copy = async () => {
+    const text = JSON.stringify({ env, logs }, null, 2);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // 剪貼簿被擋（LINE webview 常見）→ 請使用者截圖
+      setCopied(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-md px-4 py-6">
+      <h1 className="text-[20px] font-bold text-[var(--foreground)]">錯誤紀錄</h1>
+      <p className="mt-1 text-[13px] text-[var(--secondary-label)]">
+        回報問題時，請把這頁截圖或按「複製」貼給客服。
+      </p>
+
+      <div className="card mt-4 space-y-1.5 p-4">
+        {Object.entries(env).map(([k, v]) => (
+          <div key={k} className="flex gap-2 text-[13px]">
+            <span className="shrink-0 text-[var(--secondary-label)]">{k}</span>
+            <span className="break-all font-medium text-[var(--foreground)]">{v}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 flex gap-2">
+        <button
+          onClick={copy}
+          className="flex-1 rounded-xl brand-gradient px-4 py-2.5 text-[15px] font-semibold text-white active:scale-[0.98]"
+        >
+          {copied ? "已複製" : "複製全部"}
+        </button>
+        <button
+          onClick={() => { clearLocalLogs(); setLogs([]); }}
+          className="rounded-xl border border-[var(--separator)] px-4 py-2.5 text-[15px] font-medium text-[var(--secondary-label)] active:scale-[0.98]"
+        >
+          清除
+        </button>
+      </div>
+
+      {logs.length === 0 ? (
+        <p className="mt-6 text-center text-[14px] text-[var(--tertiary-label)]">
+          目前沒有錯誤紀錄
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {logs.map((l, i) => (
+            <li key={i} className="card p-3">
+              <div className="flex items-baseline justify-between gap-2">
+                <span
+                  className={
+                    "text-[13px] font-bold " +
+                    (l.level === "error"
+                      ? "text-[#c4271d]"
+                      : "text-[var(--secondary-label)]")
+                  }
+                >
+                  {l.source}
+                </span>
+                <span className="shrink-0 text-[11px] text-[var(--tertiary-label)]">
+                  {l.at.replace("T", " ").slice(0, 19)}
+                </span>
+              </div>
+              <p className="mt-1 break-all text-[13px] text-[var(--foreground)]">
+                {l.message}
+              </p>
+              {l.detail != null && (
+                <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-all text-[11px] text-[var(--tertiary-label)]">
+                  {JSON.stringify(l.detail)}
+                </pre>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/apps/member/src/app/layout.tsx
+++ b/apps/member/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import ServiceWorkerRegister from "@/components/ServiceWorkerRegister";
+import ErrorLogger from "@/components/ErrorLogger";
 
 export const metadata: Metadata = {
   title: "包子媽生鮮小舖",
@@ -41,6 +42,7 @@ export default function RootLayout({
   return (
     <html lang="zh-Hant" className="h-full antialiased">
       <body className="min-h-full flex flex-col">
+        <ErrorLogger />
         <ServiceWorkerRegister />
         {children}
       </body>

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -9,6 +9,41 @@ import Spinner, { LoadingScreen } from "@/components/Spinner";
 type Status = "loading" | "idle" | "liff_auth" | "pair_done" | "error";
 
 const PAIR_TOKEN_KEY = "pwa_pair_token";
+/** 只允許往 LIFF 彈一次的旗標（sessionStorage），避免 LIFF ↔ 網頁互推無限迴圈 */
+const LIFF_RETRY_KEY = "liff_login_retry";
+
+/** sessionStorage 在無痕 / 被擋時會 throw，一律包起來 */
+function sessionFlag(key: string): boolean {
+  try { return sessionStorage.getItem(key) !== null; } catch { return false; }
+}
+function setSessionFlag(key: string) {
+  try { sessionStorage.setItem(key, "1"); } catch { /* noop */ }
+}
+function clearSessionFlag(key: string) {
+  try { sessionStorage.removeItem(key); } catch { /* noop */ }
+}
+
+/** 是否在 LINE 的內建瀏覽器裡（含 LIFF browser）。UA 帶 " Line/"。 */
+function isInLineApp(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return / Line\//i.test(navigator.userAgent);
+}
+
+/** 組 LIFF 入口 URL（LINE 會用 LIFF 重開這個 app，init 時自動登入） */
+function liffAppUrl(
+  liffId: string,
+  storeId?: string | null,
+  pairCode?: string | null,
+): string {
+  const q = new URLSearchParams();
+  if (storeId) q.set("store", storeId);
+  if (pairCode) q.set("pair", pairCode);
+  const qs = q.toString();
+  return `https://liff.line.me/${encodeURIComponent(liffId)}${qs ? `?${qs}` : ""}`;
+}
+
+const LINE_BROWSER_HINT =
+  "LINE 內建瀏覽器無法完成 LINE 登入。請點右上角「⋮」選「用其他瀏覽器開啟」後再登入，或從 LINE 官方帳號的選單重新進入。";
 
 function isStandalone(): boolean {
   if (typeof window === "undefined") return false;
@@ -113,6 +148,7 @@ export default function LandingPage() {
 
     const existing = getSession();
     if (existing && existing.memberId) {
+      clearSessionFlag(LIFF_RETRY_KEY);
       window.location.href = landing;
       return;
     }
@@ -169,9 +205,25 @@ export default function LandingPage() {
           if (liff.isInClient()) {
             setStatus("liff_auth");
             if (!liff.isLoggedIn()) {
-              liff.login();
+              // ⚠️ 這裡**不能**呼叫 liff.login()。
+              // LIFF browser 內的登入是 liff.init() 自動跑的；官方明講
+              // 「LIFF browser 內的 LINE Login 授權請求行為不保證」，
+              // 實際呼叫會被導到 access.line.me 然後回一頁 400 Bad Request，
+              // 使用者就卡死在那頁（2026-08 會員回報）。
+              // 正解：重新開一次 LIFF app，讓 init 的 auto login 再跑一次；
+              // 只重試一次，第二次還不行就給明確指引，不要無限彈。
+              if (!sessionFlag(LIFF_RETRY_KEY)) {
+                setSessionFlag(LIFF_RETRY_KEY);
+                window.location.href = liffAppUrl(liffId, s, readPairFromUrl());
+                return;
+              }
+              setError(
+                "LINE 自動登入沒有完成。請關掉這個視窗，從 LINE 官方帳號的選單重新開啟一次；若還是不行，請改用手機瀏覽器開啟本站登入。",
+              );
+              setStatus("idle");
               return;
             }
+            clearSessionFlag(LIFF_RETRY_KEY);
             // LIFF 走自動登入,先把 webview 內任何殘留的舊 session 清掉,
             // 避免 fragment 寫入後跟舊 key 撞
             clearSession();
@@ -239,9 +291,7 @@ export default function LandingPage() {
       localStorage.setItem(PAIR_TOKEN_KEY, token);
 
       const targetUrl = liffId
-        ? `https://liff.line.me/${encodeURIComponent(liffId)}` +
-          `?store=${encodeURIComponent(storeId)}` +
-          `&pair=${encodeURIComponent(token)}`
+        ? liffAppUrl(liffId, storeId, token)
         : lineOauthStartUrl(storeId, token);
 
       const a = document.createElement("a");
@@ -251,6 +301,20 @@ export default function LandingPage() {
       document.body.appendChild(a);
       a.click();
       a.remove();
+      return;
+    }
+
+    // 在 LINE 內建瀏覽器開本站（例：從聊天室 / 貼文點連結進來，不是 LIFF context）：
+    // 一樣不能把人丟去 access.line.me 跑 OAuth，會回 400 Bad Request。
+    // 改用 LIFF URL 讓 LINE 以 LIFF 重開這個 app（LIFF 內是自動登入）。
+    if (isInLineApp()) {
+      if (liffId && !sessionFlag(LIFF_RETRY_KEY)) {
+        setSessionFlag(LIFF_RETRY_KEY);
+        clearSession();
+        window.location.href = liffAppUrl(liffId, storeId);
+        return;
+      }
+      setError(LINE_BROWSER_HINT);
       return;
     }
 

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { lineOauthStartUrl, callLiffApi } from "@/lib/supabase";
 import { loadLiff } from "@/lib/liff";
 import { clearSession, getSession, listenForSession } from "@/lib/session";
+import { logCaught, logClientError } from "@/lib/clientLog";
 import Spinner, { LoadingScreen } from "@/components/Spinner";
 
 type Status = "loading" | "idle" | "liff_auth" | "pair_done" | "error";
@@ -162,8 +163,8 @@ export default function LandingPage() {
     callLiffApi<{ stores: StoreOption[] }>("", { action: "list_stores" })
       .then((r) => setStores(r.stores ?? []))
       .catch((e) => {
-        // 抓不到就退回手動輸入；但要 warn 以免靜默失敗（例：.env.local 缺 NEXT_PUBLIC_SUPABASE_URL → callLiffApi throw）
-        console.warn("[liff] list_stores failed, falling back to text input:", e);
+        // 抓不到就退回手動輸入；但要留痕以免靜默失敗（例：.env.local 缺 NEXT_PUBLIC_SUPABASE_URL → callLiffApi throw）
+        logCaught("list_stores_failed", e, { fallback: "manual_store_input" });
       });
 
     // 3. 從 LIFF 配對流程切回 PWA 時，自動 claim
@@ -175,7 +176,11 @@ export default function LandingPage() {
 
     (async () => {
       const errInUrl = new URLSearchParams(window.location.search).get("error");
-      if (errInUrl) setError(errInUrl);
+      if (errInUrl) {
+        // OAuth callback 失敗會把原因塞回 ?error=，這是登入壞掉最直接的證據
+        logClientError("oauth_callback_error", errInUrl);
+        setError(errInUrl);
+      }
 
       const liffId = process.env.NEXT_PUBLIC_LIFF_ID;
 
@@ -213,10 +218,21 @@ export default function LandingPage() {
               // 正解：重新開一次 LIFF app，讓 init 的 auto login 再跑一次；
               // 只重試一次，第二次還不行就給明確指引，不要無限彈。
               if (!sessionFlag(LIFF_RETRY_KEY)) {
+                logClientError(
+                  "liff_auto_login_failed",
+                  "LIFF isInClient 但 isLoggedIn=false，重開 LIFF 重試一次",
+                  { store: s, has_pair: Boolean(readPairFromUrl()) },
+                  "warn",
+                );
                 setSessionFlag(LIFF_RETRY_KEY);
                 window.location.href = liffAppUrl(liffId, s, readPairFromUrl());
                 return;
               }
+              logClientError(
+                "liff_auto_login_failed_final",
+                "重開 LIFF 後仍未登入，改顯示指引",
+                { store: s },
+              );
               setError(
                 "LINE 自動登入沒有完成。請關掉這個視窗，從 LINE 官方帳號的選單重新開啟一次；若還是不行，請改用手機瀏覽器開啟本站登入。",
               );
@@ -228,7 +244,10 @@ export default function LandingPage() {
             // 避免 fragment 寫入後跟舊 key 撞
             clearSession();
             const idToken = liff.getIDToken();
-            if (!idToken) throw new Error("LIFF getIDToken returned null");
+            if (!idToken) {
+              logClientError("liff_id_token_null", "LIFF getIDToken 回 null", { store: s });
+              throw new Error("LIFF getIDToken returned null");
+            }
 
             const pairCode = readPairFromUrl();
             try {
@@ -241,6 +260,7 @@ export default function LandingPage() {
                 setStatus("idle");
                 return;
               }
+              logCaught("liff_session_failed", e, { store: s, has_pair: Boolean(pairCode) });
               throw e;
             }
 
@@ -258,7 +278,9 @@ export default function LandingPage() {
             return;
           }
         } catch (e) {
-          console.warn("liff init failed, falling back:", e);
+          // 走到這裡 = LIFF 這條路整條掛掉，使用者會退回選門市 + OAuth。
+          // 不是致命，但要留痕：多數 LIFF 問題都只在會員手機上重現得出來。
+          logCaught("liff_init_failed", e, { store: s, liff_id: liffId });
         }
       }
 
@@ -309,11 +331,22 @@ export default function LandingPage() {
     // 改用 LIFF URL 讓 LINE 以 LIFF 重開這個 app（LIFF 內是自動登入）。
     if (isInLineApp()) {
       if (liffId && !sessionFlag(LIFF_RETRY_KEY)) {
+        logClientError(
+          "line_browser_oauth_blocked",
+          "LINE 內建瀏覽器按登入，改導 LIFF URL",
+          { store: storeId },
+          "warn",
+        );
         setSessionFlag(LIFF_RETRY_KEY);
         clearSession();
         window.location.href = liffAppUrl(liffId, storeId);
         return;
       }
+      logClientError(
+        "line_browser_login_dead_end",
+        "LINE 內建瀏覽器無法登入且沒有 LIFF 退路",
+        { store: storeId, has_liff_id: Boolean(liffId) },
+      );
       setError(LINE_BROWSER_HINT);
       return;
     }
@@ -357,6 +390,7 @@ export default function LandingPage() {
       });
       window.location.href = `/shop#${frag.toString()}`;
     } catch (e) {
+      logCaught("pwa_sync_code_failed", e);
       setError(e instanceof Error ? e.message : "驗證碼無效或已過期");
     } finally {
       setSyncing(false);

--- a/apps/member/src/components/ErrorLogger.tsx
+++ b/apps/member/src/components/ErrorLogger.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { installGlobalErrorLogging } from "@/lib/clientLog";
+
+/**
+ * 掛全域錯誤攔截（未 catch 的例外 / promise rejection → client_error_logs）。
+ * 只負責掛 listener，不 render 任何東西。放在 layout 最上層。
+ */
+export default function ErrorLogger() {
+  useEffect(() => {
+    installGlobalErrorLogging();
+  }, []);
+
+  return null;
+}

--- a/apps/member/src/lib/clientLog.ts
+++ b/apps/member/src/lib/clientLog.ts
@@ -1,0 +1,193 @@
+// 前端錯誤 log —— 會員手機上的 console 我們看不到，所以「使用者會卡住」的分支
+// 一律呼叫 logClientError()，一份寫進 DB（liff-api → client_error_logs），
+// 一份留在本機 ring buffer（/debug 可以當場看，網路不通時也還在）。
+//
+// 三個硬規則：
+//   1. 永遠不 throw、不 await 卡住呼叫端 —— log 失敗不能變成新的錯誤。
+//   2. 有節流 —— 進到 render loop 時不能把自己的 DB 灌爆。
+//   3. 不記 token、不記完整個資 —— detail 裡只放除錯需要的東西。
+
+const LOCAL_KEY = "client_error_log";
+const LOCAL_MAX = 50;
+/** 同一則訊息的最短重送間隔 */
+const DEDUPE_MS = 30_000;
+/** 單次瀏覽最多送幾筆到後端 */
+const SESSION_MAX = 30;
+
+export type ClientLogLevel = "error" | "warn" | "info";
+
+export type ClientLogEntry = {
+  at: string;
+  level: ClientLogLevel;
+  source: string;
+  message: string;
+  detail?: unknown;
+};
+
+const sentAt = new Map<string, number>();
+let sentCount = 0;
+
+/** Error / 任意 throw 值 → 可讀訊息 */
+export function errMessage(e: unknown): string {
+  if (e instanceof Error) return e.message || e.name;
+  if (typeof e === "string") return e;
+  try { return JSON.stringify(e); } catch { return String(e); }
+}
+
+function errDetail(e: unknown): Record<string, unknown> | undefined {
+  if (e instanceof Error) {
+    return { name: e.name, stack: e.stack?.slice(0, 2000) };
+  }
+  return undefined;
+}
+
+/** 當下的執行環境 —— 判斷 LIFF / PWA 相關問題幾乎都要看這幾個值 */
+function env(): Record<string, unknown> {
+  if (typeof window === "undefined") return {};
+  const nav = window.navigator as Navigator & { standalone?: boolean };
+  return {
+    in_line: / Line\//i.test(nav.userAgent),
+    in_liff: typeof window.liff?.isInClient === "function"
+      ? safeBool(() => window.liff!.isInClient())
+      : null,
+    standalone:
+      nav.standalone === true ||
+      window.matchMedia("(display-mode: standalone)").matches,
+    has_liff_id: Boolean(process.env.NEXT_PUBLIC_LIFF_ID),
+    lang: nav.language,
+    screen: `${window.screen?.width ?? 0}x${window.screen?.height ?? 0}`,
+  };
+}
+
+function safeBool(fn: () => boolean): boolean | null {
+  try { return fn(); } catch { return null; }
+}
+
+/** 本機 ring buffer —— /debug 讀這個 */
+function pushLocal(entry: ClientLogEntry) {
+  try {
+    const raw = localStorage.getItem(LOCAL_KEY);
+    const list: ClientLogEntry[] = raw ? JSON.parse(raw) : [];
+    list.push(entry);
+    localStorage.setItem(
+      LOCAL_KEY,
+      JSON.stringify(list.slice(-LOCAL_MAX)),
+    );
+  } catch { /* 存不進去就算了，不能因為 log 再壞一次 */ }
+}
+
+export function getLocalLogs(): ClientLogEntry[] {
+  try {
+    const raw = localStorage.getItem(LOCAL_KEY);
+    return raw ? JSON.parse(raw) as ClientLogEntry[] : [];
+  } catch { return []; }
+}
+
+export function clearLocalLogs() {
+  try { localStorage.removeItem(LOCAL_KEY); } catch { /* noop */ }
+}
+
+/**
+ * 記一筆前端錯誤。fire-and-forget，呼叫端不需要 await。
+ *
+ * @param source 發生位置代號（例：`liff_auto_login_failed`），查 log 時用這個分群
+ */
+export function logClientError(
+  source: string,
+  message: string,
+  detail?: unknown,
+  level: ClientLogLevel = "error",
+): void {
+  const entry: ClientLogEntry = {
+    at: new Date().toISOString(),
+    level,
+    source,
+    message,
+    detail,
+  };
+
+  if (level === "error") console.error(`[${source}]`, message, detail ?? "");
+  else console.warn(`[${source}]`, message, detail ?? "");
+
+  pushLocal(entry);
+  void sendRemote(entry);
+}
+
+/** 直接吃 catch 到的東西，自動抽 message / stack */
+export function logCaught(source: string, e: unknown, extra?: Record<string, unknown>): void {
+  logClientError(source, errMessage(e), { ...errDetail(e), ...extra });
+}
+
+async function sendRemote(entry: ClientLogEntry): Promise<void> {
+  try {
+    if (typeof window === "undefined") return;
+    const base = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    if (!base) return;
+
+    // 節流：同訊息 30 秒內只送一次、單次瀏覽最多 30 筆
+    const key = `${entry.source}|${entry.message}`;
+    const now = Date.now();
+    const last = sentAt.get(key);
+    if (last && now - last < DEDUPE_MS) return;
+    if (sentCount >= SESSION_MAX) return;
+    sentAt.set(key, now);
+    sentCount += 1;
+
+    const token = localStorage.getItem("member_jwt");
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    await fetch(`${base}/functions/v1/liff-api`, {
+      method: "POST",
+      headers,
+      // keepalive：使用者當下常常正要跳頁（登入失敗、導去 LIFF），
+      // 沒有 keepalive 這筆 log 會跟著 navigation 一起被取消。
+      keepalive: true,
+      body: JSON.stringify({
+        action: "log_client_error",
+        level: entry.level,
+        source: entry.source,
+        message: entry.message,
+        detail: entry.detail ?? null,
+        store_code: localStorage.getItem("member_store_id"),
+        line_user_id: localStorage.getItem("line_user_id"),
+        page_url: window.location.href.slice(0, 500),
+        user_agent: navigator.userAgent,
+        env: env(),
+      }),
+    });
+  } catch {
+    // 送不出去就只留本機那份 —— 這裡絕對不能再拋
+  }
+}
+
+let handlersInstalled = false;
+
+/**
+ * 掛全域攔截器（未被 catch 的錯誤 / promise rejection）。
+ * 在 layout 掛一次就好，重複呼叫是 no-op。
+ */
+export function installGlobalErrorLogging(): void {
+  if (typeof window === "undefined" || handlersInstalled) return;
+  handlersInstalled = true;
+
+  window.addEventListener("error", (ev) => {
+    // 圖片 / script 載入失敗也會走 error event，但沒有 ev.error
+    const where = ev.filename
+      ? `${ev.filename}:${ev.lineno}:${ev.colno}`
+      : undefined;
+    logClientError(
+      "window_error",
+      ev.message || errMessage(ev.error),
+      { where, ...errDetail(ev.error) },
+    );
+  });
+
+  window.addEventListener("unhandledrejection", (ev) => {
+    logClientError(
+      "unhandled_rejection",
+      errMessage(ev.reason),
+      errDetail(ev.reason),
+    );
+  });
+}

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -1036,6 +1036,68 @@ async function upsertPushSubscription(sb: any, tenantId: string, memberId: numbe
   return json({ ok: true, id: insertedId, debug: rpcParams });
 }
 
+/**
+ * 收前端的錯誤 log。**不需要 token** — 最需要記錄的正是「還沒登入就壞掉」。
+ *
+ * 因為是開放端點，所有欄位一律截長度、且每分鐘全域上限 300 筆；
+ * 超過就靜默丟掉（回 ok，不讓前端因為 log 失敗再噴一次錯）。
+ * 有帶合法 token 時才補 member_id / store_id / line_user_id。
+ */
+async function logClientError(
+  sb: any,
+  tenantId: string,
+  body: Record<string, unknown>,
+  claims: Record<string, unknown> | null,
+) {
+  const cut = (v: unknown, n: number): string | null => {
+    if (v === null || v === undefined) return null;
+    const s = typeof v === "string" ? v : String(v);
+    return s.length > n ? s.slice(0, n) : s;
+  };
+  const cutJson = (v: unknown, n: number): unknown => {
+    if (v === null || v === undefined) return null;
+    const s = JSON.stringify(v);
+    if (s === undefined) return null;
+    return s.length > n ? { truncated: true, raw: s.slice(0, n) } : v;
+  };
+
+  const message = cut(body.message, 500);
+  if (!message) return json({ ok: false, error: "message required" }, 400);
+
+  // 洩洪閥：前端進到 render loop 時不要把 DB 灌爆
+  const since = new Date(Date.now() - 60_000).toISOString();
+  const { count } = await sb
+    .from("client_error_logs")
+    .select("id", { count: "exact", head: true })
+    .gte("created_at", since);
+  if (typeof count === "number" && count >= 300) {
+    return json({ ok: true, dropped: "rate_limited" });
+  }
+
+  const level = ["error", "warn", "info"].includes(String(body.level))
+    ? String(body.level)
+    : "error";
+
+  const { error } = await sb.from("client_error_logs").insert({
+    tenant_id:    tenantId,
+    member_id:    claims?.member_id ? Number(claims.member_id) : null,
+    line_user_id: claims?.line_user_id ? cut(claims.line_user_id, 64) : cut(body.line_user_id, 64),
+    store_code:   cut(body.store_code, 32),
+    level,
+    source:       cut(body.source, 64) ?? "unknown",
+    message,
+    detail:       cutJson(body.detail, 4000),
+    page_url:     cut(body.page_url, 500),
+    user_agent:   cut(body.user_agent, 300),
+    env:          cutJson(body.env, 1000),
+  });
+  if (error) {
+    console.error("log_client_error insert failed:", error);
+    return json({ ok: false, error: error.message }, 500);
+  }
+  return json({ ok: true });
+}
+
 // ─── main ────────────────────────────────────────────────────────────────────
 
 Deno.serve(async (req) => {
@@ -1050,6 +1112,23 @@ Deno.serve(async (req) => {
     // ── 不需要 Token 的 actions ──
     if (action === "claim_pwa_auth_code") return await claimPwaAuthCode(sb, String(body.code ?? ""));
     if (action === "list_stores") return await listStores(sb, requireEnv("DEFAULT_TENANT_ID"));
+    if (action === "log_client_error") {
+      // 有帶 token 就順便解出來補會員資訊；解不開不算錯（登入前的錯誤本來就沒 token）
+      let logClaims: Record<string, unknown> | null = null;
+      const logAuth = req.headers.get("authorization");
+      if (logAuth) {
+        try {
+          logClaims = await verifyJwtHs256(
+            logAuth.replace(/^Bearer\s+/i, ""),
+            requireEnv("PROJECT_JWT_SECRET"),
+          ) as Record<string, unknown>;
+        } catch { /* 匿名記錄 */ }
+      }
+      const logTenant = logClaims?.tenant_id
+        ? String(logClaims.tenant_id)
+        : requireEnv("DEFAULT_TENANT_ID");
+      return await logClientError(sb, logTenant, body, logClaims);
+    }
 
     const auth = req.headers.get("authorization");
     if (!auth) return json({ error: "missing authorization" }, 401);

--- a/supabase/migrations/20260803000010_client_error_logs.sql
+++ b/supabase/migrations/20260803000010_client_error_logs.sql
@@ -1,0 +1,79 @@
+-- ============================================================================
+-- 會員 App（前端）錯誤 log 落地
+--
+-- 動機：會員端的錯誤只發生在對方手機上，console 我們看不到。2026-08 的
+-- 「LINE 登入回 400 Bad Request」就是靠使用者截圖才發現，中間白花了很多來回。
+-- 之後前端只要走到「使用者會卡住」的分支，一律寫一筆進這裡。
+--
+-- 寫入路徑：liff-api 的 `log_client_error` action（service role 寫入）。
+-- 這個 action **不需要 token** — 因為最需要記錄的就是「還沒登入就壞掉」。
+-- 有帶合法 token 時才會補上 member_id / store_id。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS client_error_logs (
+  id           BIGSERIAL   PRIMARY KEY,
+  tenant_id    UUID        NOT NULL,
+  member_id    BIGINT      REFERENCES members(id) ON DELETE SET NULL,
+  line_user_id TEXT,
+  store_code   TEXT,
+  level        TEXT        NOT NULL DEFAULT 'error'
+                           CHECK (level IN ('error', 'warn', 'info')),
+  source       TEXT        NOT NULL,
+  message      TEXT        NOT NULL,
+  detail       JSONB,
+  page_url     TEXT,
+  user_agent   TEXT,
+  env          JSONB,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 查 log 幾乎只有兩種問法：「最近發生什麼」、「這個 source 最近發生什麼」
+CREATE INDEX IF NOT EXISTS idx_client_error_logs_recent
+  ON client_error_logs (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_client_error_logs_source_recent
+  ON client_error_logs (source, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_client_error_logs_member_recent
+  ON client_error_logs (member_id, created_at DESC)
+  WHERE member_id IS NOT NULL;
+
+COMMENT ON TABLE  client_error_logs            IS '會員前端 App 的錯誤紀錄（liff-api log_client_error 寫入）';
+COMMENT ON COLUMN client_error_logs.source     IS '發生位置代號，例：liff_auto_login_failed / line_browser_oauth_blocked / window_error / unhandled_rejection';
+COMMENT ON COLUMN client_error_logs.level      IS 'error = 使用者被卡住；warn = 有退路但不如預期；info = 只是留痕';
+COMMENT ON COLUMN client_error_logs.detail     IS '自由欄位：stack、上游回應、當下狀態等';
+COMMENT ON COLUMN client_error_logs.env        IS '執行環境：{ in_line, in_liff, standalone, has_liff_id, lang, screen }';
+COMMENT ON COLUMN client_error_logs.member_id  IS '只有請求帶了合法 member token 才會有值；登入前的錯誤是 NULL';
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+-- liff-api 走 SERVICE_ROLE_KEY 寫入（bypass RLS）。這裡只開總部讀，
+-- 會員自己不該讀得到別人的錯誤內容（detail 可能含 URL / UA 等資訊）。
+ALTER TABLE client_error_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS client_error_logs_hq_all ON client_error_logs;
+CREATE POLICY client_error_logs_hq_all ON client_error_logs
+  FOR ALL USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+    AND (auth.jwt() ->> 'role') = 'hq'
+  );
+
+-- ── 保留期 ───────────────────────────────────────────────────────────────────
+-- 這張表只有除錯價值，不留長期資料。手動或排程呼叫：
+--   SELECT purge_client_error_logs(30);
+CREATE OR REPLACE FUNCTION purge_client_error_logs(p_days INT DEFAULT 30)
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_deleted BIGINT;
+BEGIN
+  DELETE FROM client_error_logs
+   WHERE created_at < NOW() - (p_days || ' days')::INTERVAL;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;
+
+COMMENT ON FUNCTION purge_client_error_logs(INT) IS '刪掉 N 天前的前端錯誤 log，回傳刪除筆數';


### PR DESCRIPTION
會員在 LINE 裡點登入會停在 access.line.me 的「400 Bad Request」白頁。
原因是在 LINE 的 in-app / LIFF browser 內發了 LINE Login 授權請求 —
官方明講這個行為不保證，實測直接被擋成 400。

兩條路都會踩到：
- `liff.isInClient()` 為真但 `isLoggedIn()` 為假時呼叫 `liff.login()`
  （LIFF 內的登入本來就是 `liff.init()` 自動跑的，不該再呼叫一次）
- 從聊天室連結進站、以 in-app browser 開時，登入鈕直接送去
  `line-oauth-start` → 302 到 authorize

改法：在 LINE 內一律改導 `https://liff.line.me/{LIFF_ID}?store=...`，
讓 LINE 重開 LIFF 走 init 的 auto login；用 sessionStorage 旗標限制只彈一次，
避免 LIFF ↔ 網頁互推，第二次仍未登入就顯示可操作的指引文字而不是白頁。

順手把 PWA 那條的 LIFF URL 組字串抽成共用的 `liffAppUrl()`。
CLAUDE.md 補上這條 standing rule。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC