### PR TITLE
feat(settlement): 分店端「每日進貨對帳」— 不用等月結就看得到金額

### DIFF
--- a/apps/admin/src/app/(protected)/transfers/settlement/daily/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/daily/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+// 分店端「每日進貨對帳」— 不用等月結送單就看得到金額。
+// 店家當天被問「今日進貨總共多少錢？」時，直接開這頁報數字。
+//
+// 金額口徑與月結對帳單完全相同（分店價；空中轉出/退貨沖回為負值），
+// 每日金額加總 = 該月月結的貨款金額（不含總部人工調整）。
+// 資料走 rpc_store_inbound_daily_summary / rpc_store_inbound_day_items
+// （20260803000000），分店帳號只查得到自己店。
+
+import Link from "next/link";
+import { Fragment, useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { useAuth } from "@/components/AuthProvider";
+import Spinner, { LoadingBlock } from "@/components/Spinner";
+
+type StoreRow = { id: number; name: string; location_id: number | null };
+
+type DaySummary = { date: string; line_count: number; amount: number };
+type Summary = {
+  store_id: number;
+  store_name: string;
+  month: string;
+  days: DaySummary[];
+  month_amount: number;
+  month_lines: number;
+};
+
+type DayItem = {
+  transfer_id: number;
+  transfer_no: string | null;
+  transfer_item_id: number;
+  sku_id: number;
+  sku_code: string | null;
+  product_name: string | null;
+  variant_name: string | null;
+  qty: number;
+  unit_branch_price: number;
+  amount: number;
+  entry_type: "hq_inbound" | "air_in" | "air_out" | "free_in" | "free_out" | "return_out";
+  description: string | null;
+  missing_price: boolean;
+  received_at: string;
+};
+type DayDetail = { store_id: number; store_name: string; date: string; items: DayItem[]; total: number };
+
+const ENTRY_TYPE_LABEL: Record<DayItem["entry_type"], string> = {
+  hq_inbound: "總倉進貨",
+  air_in: "空中轉入",
+  air_out: "空中轉出",
+  free_in: "自由轉入",
+  free_out: "自由轉出",
+  return_out: "退貨沖回",
+};
+
+// 負數寫成 -$130（不是 $-130）：退貨沖回那行店家一眼看得懂是扣款
+const money = (n: number) =>
+  `${Number(n) < 0 ? "-" : ""}$${Math.abs(Number(n)).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}`;
+const qtyText = (n: number) => Number(n).toLocaleString("zh-TW", { maximumFractionDigits: 3 });
+
+// 台北時區的今天 / 本月（伺服器與瀏覽器時區都可能不是 +08，統一換算）
+function taipeiParts(d = new Date()) {
+  const s = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Taipei",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d); // YYYY-MM-DD
+  return { date: s, month: s.slice(0, 7) };
+}
+
+function weekday(dateStr: string) {
+  const wd = ["日", "一", "二", "三", "四", "五", "六"];
+  // 用 UTC 解析純日期字串，避免本機時區把日期推前一天
+  return wd[new Date(`${dateStr}T00:00:00Z`).getUTCDay()];
+}
+
+export default function StoreDailyInboundPage() {
+  const { user } = useAuth();
+  const today = useMemo(() => taipeiParts(), []);
+  const [stores, setStores] = useState<StoreRow[]>([]);
+  const [pickedStoreId, setPickedStoreId] = useState<number | null>(null);
+  const [month, setMonth] = useState(today.month);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [loading, setLoading] = useState(false);
+  // undefined = 還沒手動點過（沿用「今天預設展開」）；null = 使用者自己收合了
+  const [openDateOverride, setOpenDateOverride] = useState<string | null | undefined>(undefined);
+  const [detail, setDetail] = useState<DayDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data } = await getSupabase()
+        .from("stores")
+        .select("id, name, location_id")
+        .not("location_id", "is", null)
+        .order("name");
+      if (!cancelled) setStores((data ?? []) as StoreRow[]);
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // 分店帳號：只列自己綁定的店；HQ / 總倉：全部店可選
+  const selectableStores = useMemo(() => {
+    const userStores = user?.app_metadata?.stores as unknown;
+    if (!Array.isArray(userStores) || userStores.length === 0) return stores;
+    if (userStores.includes("總倉")) return stores;
+    return stores.filter((s) => userStores.includes(s.name));
+  }, [user, stores]);
+  const storeId = pickedStoreId ?? selectableStores[0]?.id ?? null;
+
+  useEffect(() => {
+    if (storeId === null) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      const { data, error: e } = await getSupabase().rpc("rpc_store_inbound_daily_summary", {
+        p_store_id: storeId,
+        p_month: `${month}-01`,
+      });
+      if (cancelled) return;
+      setLoading(false);
+      if (e) { setError(e.message); setSummary(null); return; }
+      setError(null);
+      setSummary(data as unknown as Summary);
+    })();
+    return () => { cancelled = true; };
+  }, [storeId, month]);
+
+  // 當月列表裡今天那列（今天不在本月時為 undefined）
+  const todayRow = useMemo(
+    () => summary?.days.find((d) => d.date === today.date),
+    [summary, today.date],
+  );
+  const isCurrentMonth = month === today.month;
+
+  // 沒手動點過時，今天有貨就預設展開 → 店家一進來就看得到今日明細
+  const openDate = openDateOverride === undefined
+    ? (isCurrentMonth && todayRow ? today.date : null)
+    : openDateOverride;
+
+  useEffect(() => {
+    if (openDate === null || storeId === null) return;
+    let cancelled = false;
+    (async () => {
+      setDetailLoading(true);
+      setDetail(null);
+      const { data, error: e } = await getSupabase().rpc("rpc_store_inbound_day_items", {
+        p_store_id: storeId,
+        p_date: openDate,
+      });
+      if (cancelled) return;
+      setDetailLoading(false);
+      if (e) { setError(e.message); setDetail(null); return; }
+      setError(null);
+      setDetail(data as unknown as DayDetail);
+    })();
+    return () => { cancelled = true; };
+  }, [openDate, storeId]);
+
+  function toggleDay(date: string) {
+    setOpenDateOverride(openDate === date ? null : date);
+  }
+
+  if (selectableStores.length === 0 && stores.length > 0) {
+    return (
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <p className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
+          此帳號未綁定分店，請聯絡總部設定。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">每日進貨對帳</h1>
+          <p className="text-sm text-zinc-500">
+            當日收到的所有品項、分店價與當日總金額，收完貨馬上看得到，不用等月結送單。
+            金額口徑與月結對帳單相同（空中轉出／退貨沖回為負值），每日加總 = 該月月結貨款。
+          </p>
+        </div>
+        <Link
+          href="/transfers/settlement"
+          className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          回月結對帳
+        </Link>
+      </header>
+
+      <div className="flex flex-wrap items-end gap-3">
+        {selectableStores.length > 1 && (
+          <label className="text-sm">
+            <span className="mb-1 block text-xs text-zinc-500">分店</span>
+            <select
+              value={storeId ?? ""}
+              onChange={(e) => { setPickedStoreId(Number(e.target.value) || null); setOpenDateOverride(undefined); }}
+              className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+            >
+              {selectableStores.map((s) => (
+                <option key={s.id} value={s.id}>{s.name}</option>
+              ))}
+            </select>
+          </label>
+        )}
+        <label className="text-sm">
+          <span className="mb-1 block text-xs text-zinc-500">月份</span>
+          <input
+            type="month"
+            value={month}
+            max={today.month}
+            onChange={(e) => { setMonth(e.target.value || today.month); setOpenDateOverride(undefined); }}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+        {!isCurrentMonth && (
+          <button
+            type="button"
+            onClick={() => { setMonth(today.month); setOpenDateOverride(undefined); }}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            回到本月
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          <p className="font-mono text-xs">{error}</p>
+        </div>
+      )}
+
+      {/* 今日 / 本月兩張數字卡：店家最常被問的兩個數 */}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="rounded-md border border-zinc-200 p-4 dark:border-zinc-800">
+          <p className="text-xs text-zinc-500">今日進貨金額（{today.date}）</p>
+          <p className="mt-1 font-mono text-2xl">
+            {loading ? <Spinner /> : isCurrentMonth ? money(todayRow?.amount ?? 0) : "—"}
+          </p>
+          <p className="mt-1 text-xs text-zinc-500">
+            {isCurrentMonth ? `${todayRow?.line_count ?? 0} 個品項` : "切到本月才顯示"}
+          </p>
+        </div>
+        <div className="rounded-md border border-zinc-200 p-4 dark:border-zinc-800">
+          <p className="text-xs text-zinc-500">{summary?.month ?? month} 累計貨款</p>
+          <p className="mt-1 font-mono text-2xl">
+            {loading ? <Spinner /> : money(summary?.month_amount ?? 0)}
+          </p>
+          <p className="mt-1 text-xs text-zinc-500">
+            {summary?.month_lines ?? 0} 個品項{isCurrentMonth ? "（本月未結，會隨收貨變動）" : ""}
+          </p>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+        <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+          <thead className="bg-zinc-50 dark:bg-zinc-900">
+            <tr>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">日期</th>
+              <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">品項數</th>
+              <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">當日金額</th>
+              <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">明細</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+            {loading ? (
+              <tr><td colSpan={4} className="p-6"><LoadingBlock /></td></tr>
+            ) : !summary || summary.days.length === 0 ? (
+              <tr><td colSpan={4} className="p-6 text-center text-zinc-500">這個月還沒有收貨紀錄。</td></tr>
+            ) : summary.days.map((d) => (
+              <Fragment key={d.date}>
+              <tr className={openDate === d.date ? "bg-zinc-50 dark:bg-zinc-900" : undefined}>
+                <td className="px-3 py-2 font-mono text-xs">
+                  {d.date}（{weekday(d.date)}）
+                  {d.date === today.date && (
+                    <span className="ml-2 rounded bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-800 dark:bg-blue-950 dark:text-blue-300">今天</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-zinc-500">{d.line_count}</td>
+                <td className={`px-3 py-2 text-right font-mono ${d.amount < 0 ? "text-emerald-600" : ""}`}>{money(d.amount)}</td>
+                <td className="px-3 py-2 text-right">
+                  <button
+                    type="button"
+                    onClick={() => toggleDay(d.date)}
+                    className="rounded-md border border-zinc-300 px-3 py-1 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                  >
+                    {openDate === d.date ? "收合" : "看明細"}
+                  </button>
+                </td>
+              </tr>
+              {openDate === d.date && (
+                <tr>
+                  <td colSpan={4} className="px-3 pb-3">
+                    <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
+                      {detailLoading || !detail ? (
+                        <div className="p-4"><LoadingBlock /></div>
+                      ) : detail.items.length === 0 ? (
+                        <p className="p-4 text-center text-xs text-zinc-500">當日無明細。</p>
+                      ) : (
+                        <table className="min-w-full divide-y divide-zinc-200 text-xs dark:divide-zinc-800">
+                          <thead className="bg-zinc-50 dark:bg-zinc-900">
+                            <tr>
+                              <th className="px-2 py-1.5 text-left font-medium text-zinc-500">品項</th>
+                              <th className="px-2 py-1.5 text-left font-medium text-zinc-500">類別</th>
+                              <th className="px-2 py-1.5 text-right font-medium text-zinc-500">數量</th>
+                              <th className="px-2 py-1.5 text-right font-medium text-zinc-500">分店價</th>
+                              <th className="px-2 py-1.5 text-right font-medium text-zinc-500">小計</th>
+                              <th className="px-2 py-1.5 text-left font-medium text-zinc-500">單號</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                            {detail.items.map((it) => (
+                              <tr key={`${it.entry_type}-${it.transfer_item_id}`}>
+                                <td className="px-2 py-1.5">
+                                  <span className="font-medium">{it.product_name ?? `SKU #${it.sku_id}`}</span>
+                                  {it.variant_name && <span className="text-zinc-500"> {it.variant_name}</span>}
+                                  {it.sku_code && <span className="ml-1 font-mono text-[10px] text-zinc-400">{it.sku_code}</span>}
+                                  {it.missing_price && (
+                                    <span className="ml-1 rounded bg-red-100 px-1 py-0.5 text-[10px] text-red-800 dark:bg-red-950 dark:text-red-300">
+                                      未設分店價
+                                    </span>
+                                  )}
+                                </td>
+                                <td className="px-2 py-1.5 text-zinc-500">{ENTRY_TYPE_LABEL[it.entry_type]}</td>
+                                <td className="px-2 py-1.5 text-right font-mono">{qtyText(it.qty)}</td>
+                                <td className="px-2 py-1.5 text-right font-mono">
+                                  {it.entry_type === "free_in" || it.entry_type === "free_out" ? "估價" : money(it.unit_branch_price)}
+                                </td>
+                                <td className={`px-2 py-1.5 text-right font-mono ${it.amount < 0 ? "text-emerald-600" : ""}`}>
+                                  {money(it.amount)}
+                                </td>
+                                <td className="px-2 py-1.5 font-mono text-[10px] text-zinc-500">{it.transfer_no ?? `#${it.transfer_id}`}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                          <tfoot className="bg-zinc-50 dark:bg-zinc-900">
+                            <tr>
+                              <td className="px-2 py-1.5 font-medium" colSpan={4}>當日合計</td>
+                              <td className="px-2 py-1.5 text-right font-mono font-semibold">{money(detail.total)}</td>
+                              <td />
+                            </tr>
+                          </tfoot>
+                        </table>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              )}
+              </Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-xs text-zinc-500">
+        註：金額為分店價（總倉賣斷給分店的價格），不含總部月結時的人工調整（運費分攤、折讓等）。
+        正式應付金額以每月的月結對帳單為準。
+      </p>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
@@ -106,12 +106,21 @@ export default function SettlementPage() {
   if (role !== null && !isHqRole(role)) {
     return (
       <div className="flex flex-1 flex-col gap-4 p-6">
-        <header>
-          <h1 className="text-xl font-semibold">月結對帳</h1>
-          <p className="text-sm text-zinc-500">
-            總部送來的月結對帳單：逐筆核對，有問題的行按「有問題」附備註送出爭議；
-            全部無誤按「同意畫押」鎖定，匯款後回來按「我已匯款」。
-          </p>
+        <header className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-xl font-semibold">月結對帳</h1>
+            <p className="text-sm text-zinc-500">
+              總部送來的月結對帳單：逐筆核對，有問題的行按「有問題」附備註送出爭議；
+              全部無誤按「同意畫押」鎖定，匯款後回來按「我已匯款」。
+            </p>
+          </div>
+          {/* 店家當天就想知道「今天進了多少錢」— 不用等月結送單 */}
+          <Link
+            href="/transfers/settlement/daily"
+            className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+          >
+            查每日進貨金額
+          </Link>
         </header>
         <StoreSettlementReview />
       </div>
@@ -120,13 +129,22 @@ export default function SettlementPage() {
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
-      <header>
-        <h1 className="text-xl font-semibold">月結算</h1>
-        <p className="text-sm text-zinc-500">
-          總倉對各分店：賣斷制、依 hq_to_store 已收貨 transfers 計算貨款（含空中轉調整）。
-          應付金額以分店價口徑計；成本口徑另計、供總倉毛利參考。
-          流程：產生 → 送店家核對 → （爭議處理）→ 雙方同意鎖定 → 店家匯款 → 收款結案。
-        </p>
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">月結算</h1>
+          <p className="text-sm text-zinc-500">
+            總倉對各分店：賣斷制、依 hq_to_store 已收貨 transfers 計算貨款（含空中轉調整）。
+            應付金額以分店價口徑計；成本口徑另計、供總倉毛利參考。
+            流程：產生 → 送店家核對 → （爭議處理）→ 雙方同意鎖定 → 店家匯款 → 收款結案。
+          </p>
+        </div>
+        {/* 店家臨時問「今天進了多少」時，總部也能直接查任一店的每日金額 */}
+        <Link
+          href="/transfers/settlement/daily"
+          className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+        >
+          查分店每日進貨金額
+        </Link>
       </header>
 
       <HqToStoreTab />

--- a/apps/admin/src/components/StoreSettlementReview.tsx
+++ b/apps/admin/src/components/StoreSettlementReview.tsx
@@ -130,8 +130,23 @@ export default function StoreSettlementReview() {
             ) : rows.map((r) => (
               <tr key={r.id} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
                 <td className="px-3 py-2 font-mono text-xs">{r.settlement_month?.slice(0, 7)}</td>
-                <td className="px-3 py-2 text-right font-mono text-rose-600">
-                  ${Number(r.payable_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                <td className="px-3 py-2 text-right font-mono">
+                  {/* 有明細卻 0 元 = 該月進退相抵；負數 = 退貨多於進貨，總倉要退款給店家。
+                      兩種情況都用紅字寫「$0 / $-x」店家會看不懂，分開標示。 */}
+                  {Number(r.payable_amount) < 0 ? (
+                    <span className="text-emerald-600">
+                      總倉應退 ${Math.abs(Number(r.payable_amount)).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                    </span>
+                  ) : (
+                    <>
+                      <span className={Number(r.payable_amount) > 0 ? "text-rose-600" : "text-zinc-500"}>
+                        ${Number(r.payable_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                      </span>
+                      {Number(r.payable_amount) === 0 && r.item_count > 0 && (
+                        <span className="block text-[10px] text-zinc-500">進貨與退貨相抵</span>
+                      )}
+                    </>
+                  )}
                 </td>
                 <td className="px-3 py-2 text-right font-mono">{r.item_count}</td>
                 <td className="px-3 py-2">

--- a/docs/TEST-store-daily-inbound.md
+++ b/docs/TEST-store-daily-inbound.md
@@ -1,0 +1,59 @@
+# TEST — 分店端「每日進貨對帳」
+
+需求（2026-08-03，楊小胖 / 1688 群組）：店家當天問「今日進貨的總金額多少？」，
+紙本出貨單只有品名數量沒有金額，系統裡也只有月結對帳單送出後才看得到分店價。
+要讓分店隨時查「當日所有品項的分店價 + 當日總金額」，不用等月結。
+
+Migration：`20260803000000_store_daily_inbound.sql`（全新函式，不覆寫既有物件）
+- helper `_store_inbound_lines(store_id, from, to)`：某店期間內的分店價分錄逐行。
+  六種 entry_type 與 `rpc_generate_hq_to_store_settlement` v4（`20260801000000`）
+  **逐項對齊**：hq_inbound / air_in（+，`_branch_price_at`）、air_out / return_out
+  （−，`_branch_price_at`）、free_in（+`estimated_amount`）/ free_out（−）。
+  不對外開放（`REVOKE ALL … FROM PUBLIC`），只給下面兩支 RPC 內部用。
+- `rpc_store_inbound_daily_summary(store_id, month)` → `{days:[{date,line_count,amount}],
+  month_amount, month_lines}`（日期倒序）。
+- `rpc_store_inbound_day_items(store_id, date)` → 當日逐行（品項/類別/數量/分店價/
+  小計/單號）＋ `total`；`missing_price` 標出貨款行卻抓不到分店價的品項。
+- 權限：SECURITY DEFINER + in-RPC gate `_settlement_caller_is_hq() OR
+  _settlement_caller_in_store(store_id)`（沿用 `20260715000120`）——
+  分店只查得到自己店、HQ 可查任一店。
+- **日界用 Asia/Taipei**（店家認知的「今天」，對齊 repo 既有
+  `DATE(x AT TIME ZONE 'Asia/Taipei')` 慣例）。月結生成器的月界是 DB session tz
+  （UTC）—— 跨月當天 00:00–08:00（台北）收的貨，日曆歸屬會與月結差一天。
+  現網全量 7439 筆 transfers 只有 2 筆落在此窗，本次不動月結生成器。
+
+前端（apps/admin）：
+- 新頁 `/transfers/settlement/daily`：今日金額 / 本月累計兩張數字卡、每日金額列表
+  （點「看明細」展開當日逐品項；今天有貨預設展開）、月份切換、HQ 可切分店。
+  負數（空中轉出／退貨沖回）寫成 `-$130` 並用綠字。
+- 入口：分店版「月結對帳」與總部版「月結算」頁 header 各加一顆按鈕。
+- `StoreSettlementReview` 金額欄：`$0` 且有明細 → 加註「進貨與退貨相抵」；
+  負數 → 綠字「總倉應退 $x」（原本一律紅字 `$-11,720`，店家看不懂）。
+
+## 測試項目
+
+### 線上 DB（Management API，2026-08-03）
+- [x] T1 部署成功、3 個函式建立完成。
+- [x] T2 **口徑對帳**：2026-07 全 15 家有帳的店，
+      `rpc_store_inbound_daily_summary(...)->>'month_amount'`
+      與 `store_monthly_settlements.branch_amount` 逐店 diff 皆為 `0.0000`。
+- [x] T3 龍潭店 2026-06（截圖那張 $0 的單）：每日彙總得 `2026-06-24` 一天、
+      2 行、金額 0 —— 同日 `hq_inbound +130` 與 `return_out −130` 相抵，
+      與 `store_monthly_settlement_items` 完全一致（$0 是正確結果，非計價 bug）。
+- [x] T4 `rpc_store_inbound_day_items(龍潭, 2026-06-24)` 回 2 行、
+      帶 sku_code / 品名 / 規格 / 單號（WAVE-16-S47、TR2606240104）、total 0。
+- [x] T5 近期（2026-07-01 ~ 2026-08-03）全店貨款行 `missing_price` 掃描 = 0 筆。
+
+### UI（Playwright + fixture，`store_manager` / 綁定「龍潭店」）
+- [x] T6 `/transfers/settlement/daily`：兩張數字卡、每日列表、今天列自動展開明細、
+      「未設分店價」紅標、當日合計列；無 console error。
+- [x] T7 收合今天 → 展開其他日期，明細正確重抓。
+- [x] T8 只綁一家店的帳號看不到分店下拉（鎖定自己店）。
+- [x] T9 `/transfers/settlement`：新按鈕「查每日進貨金額」出現；
+      `$0` 列顯示「進貨與退貨相抵」、負數列顯示綠字「總倉應退 $11,720」。
+
+### 待辦 / 已知限制
+- [ ] 跨月當天凌晨（台北 00:00–08:00）收貨的月份歸屬，日曆與月結會差一天；
+      要對齊須另開 migration 把生成器月界改成 Asia/Taipei（會動到既有 draft 金額）。
+- [ ] 分店價缺漏（`prices` scope=branch 沒設）的品項會以 $0 入帳，
+      目前只在每日明細標紅提醒；總部端沒有主動告警。

--- a/supabase/migrations/20260803000000_store_daily_inbound.sql
+++ b/supabase/migrations/20260803000000_store_daily_inbound.sql
@@ -1,0 +1,317 @@
+-- ============================================================
+-- 2026-08-03: 分店端「每日進貨對帳」（不用等月結才看得到金額）
+--
+-- 需求（楊小胖 / 1688 群組）：
+--   店家當天問「今日進貨總金額多少？」——紙本出貨單只有品名數量沒有金額，
+--   系統裡也只有月結對帳單送出後才看得到分店價。要讓分店隨時查
+--   「當日所有品項的分店價 + 當日總金額」。
+--
+-- 設計：
+--   - 不新增表、不改月結生成器。金額口徑跟 rpc_generate_hq_to_store_settlement
+--     v4（20260801000000）逐項對齊：hq_inbound / air_in（+）、air_out /
+--     return_out（−）走 _branch_price_at 分店價；free_in（+）/ free_out（−）
+--     走 estimated_amount。所以每日金額加總 = 該月月結的 branch_amount
+--     （不含人工調整 adjustment_amount）。
+--   - 日界用 Asia/Taipei（店家認知的「今天」；對齊 repo 既有
+--     DATE(x AT TIME ZONE 'Asia/Taipei') 慣例）。月結生成器的月界是 DB
+--     session tz（UTC），所以跨月那天凌晨 00:00–08:00(台北) 收的貨，
+--     日曆歸屬會跟月結差一天 —— 現網全量 7439 筆只有 2 筆落在此窗，
+--     暫不動月結生成器（要動是另一支 migration 的事）。
+--   - 權限：SECURITY DEFINER + in-RPC gate，沿用 20260715000120 的
+--     _settlement_caller_is_hq() / _settlement_caller_in_store()
+--     —— 分店只能查自己店，HQ 可查任一店。
+--   - helper _store_inbound_lines 不對外開放（REVOKE PUBLIC），
+--     只給兩支 RPC 內部用。
+--
+-- 基底版本：無（全新函式，不覆寫任何既有物件）
+-- Rollback：
+--   DROP FUNCTION public.rpc_store_inbound_day_items(BIGINT, DATE);
+--   DROP FUNCTION public.rpc_store_inbound_daily_summary(BIGINT, DATE);
+--   DROP FUNCTION public._store_inbound_lines(BIGINT, TIMESTAMPTZ, TIMESTAMPTZ);
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. helper：某店在 [p_from, p_to) 之間的分店價分錄（逐行）
+--    正負號與 store_monthly_settlement_items.branch_amount 一致。
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._store_inbound_lines(
+  p_store_id BIGINT,
+  p_from     TIMESTAMPTZ,
+  p_to       TIMESTAMPTZ
+) RETURNS TABLE (
+  transfer_id       BIGINT,
+  transfer_item_id  BIGINT,
+  sku_id            BIGINT,
+  qty               NUMERIC,
+  unit_branch_price NUMERIC,
+  amount            NUMERIC,
+  entry_type        TEXT,
+  description       TEXT,
+  received_at       TIMESTAMPTZ,
+  biz_date          DATE
+)
+LANGUAGE sql STABLE
+AS $$
+  WITH st AS (
+    SELECT s.id, s.tenant_id, s.location_id
+      FROM public.stores s
+     WHERE s.id = p_store_id
+       AND s.location_id IS NOT NULL
+  )
+  -- A) hq_inbound：總倉進貨（+）
+  SELECT t.id, ti.id, ti.sku_id, ti.qty_received,
+         bp.p, ti.qty_received * bp.p,
+         'hq_inbound'::TEXT, ti.description, t.received_at,
+         (t.received_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.transfers t ON t.tenant_id = st.tenant_id
+    JOIN public.transfer_items ti ON ti.transfer_id = t.id
+    CROSS JOIN LATERAL (
+      SELECT COALESCE(public._branch_price_at(st.tenant_id, ti.sku_id, t.received_at), 0) AS p
+    ) bp
+   WHERE t.transfer_type = 'hq_to_store'
+     AND t.status IN ('received','closed')
+     AND t.dest_location = st.location_id
+     AND t.received_at >= p_from
+     AND t.received_at <  p_to
+     AND ti.qty_received > 0
+
+  UNION ALL
+  -- B) air_in：空中轉入（+）
+  SELECT t.id, ti.id, ti.sku_id, ti.qty_received,
+         bp.p, ti.qty_received * bp.p,
+         'air_in'::TEXT, ti.description, t.received_at,
+         (t.received_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.transfers t ON t.tenant_id = st.tenant_id
+    JOIN public.transfer_items ti ON ti.transfer_id = t.id
+    CROSS JOIN LATERAL (
+      SELECT COALESCE(public._branch_price_at(st.tenant_id, ti.sku_id, t.received_at), 0) AS p
+    ) bp
+   WHERE t.transfer_type = 'store_to_store'
+     AND t.customer_order_id IS NOT NULL
+     AND t.status IN ('received','closed')
+     AND t.dest_location = st.location_id
+     AND t.received_at >= p_from
+     AND t.received_at <  p_to
+     AND ti.qty_received > 0
+
+  UNION ALL
+  -- C) air_out：空中轉出（−）
+  SELECT t.id, ti.id, ti.sku_id, ti.qty_received,
+         bp.p, -1 * ti.qty_received * bp.p,
+         'air_out'::TEXT, ti.description, t.received_at,
+         (t.received_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.transfers t ON t.tenant_id = st.tenant_id
+    JOIN public.transfer_items ti ON ti.transfer_id = t.id
+    CROSS JOIN LATERAL (
+      SELECT COALESCE(public._branch_price_at(st.tenant_id, ti.sku_id, t.received_at), 0) AS p
+    ) bp
+   WHERE t.transfer_type = 'store_to_store'
+     AND t.customer_order_id IS NOT NULL
+     AND t.status IN ('received','closed')
+     AND t.source_location = st.location_id
+     AND t.received_at >= p_from
+     AND t.received_at <  p_to
+     AND ti.qty_received > 0
+
+  UNION ALL
+  -- D) free_in：自由轉入（+，估價）
+  SELECT t.id, ti.id, ti.sku_id, ti.qty_received,
+         0, COALESCE(ti.estimated_amount, 0),
+         'free_in'::TEXT, ti.description, t.received_at,
+         (t.received_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.transfers t ON t.tenant_id = st.tenant_id
+    JOIN public.transfer_items ti ON ti.transfer_id = t.id
+   WHERE t.transfer_type = 'store_to_store'
+     AND t.customer_order_id IS NULL
+     AND t.status IN ('received','closed')
+     AND t.dest_location = st.location_id
+     AND t.received_at >= p_from
+     AND t.received_at <  p_to
+     AND ti.qty_received > 0
+
+  UNION ALL
+  -- E) free_out：自由轉出（−，估價）
+  SELECT t.id, ti.id, ti.sku_id, ti.qty_received,
+         0, -1 * COALESCE(ti.estimated_amount, 0),
+         'free_out'::TEXT, ti.description, t.received_at,
+         (t.received_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.transfers t ON t.tenant_id = st.tenant_id
+    JOIN public.transfer_items ti ON ti.transfer_id = t.id
+   WHERE t.transfer_type = 'store_to_store'
+     AND t.customer_order_id IS NULL
+     AND t.status IN ('received','closed')
+     AND t.source_location = st.location_id
+     AND t.received_at >= p_from
+     AND t.received_at <  p_to
+     AND ti.qty_received > 0
+
+  UNION ALL
+  -- F) return_out：退貨回總倉（−）
+  SELECT t.id, ti.id, ti.sku_id, ti.qty_received,
+         bp.p, -1 * ti.qty_received * bp.p,
+         'return_out'::TEXT, ti.description, t.received_at,
+         (t.received_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.transfers t ON t.tenant_id = st.tenant_id
+    JOIN public.transfer_items ti ON ti.transfer_id = t.id
+    CROSS JOIN LATERAL (
+      SELECT COALESCE(public._branch_price_at(st.tenant_id, ti.sku_id, t.received_at), 0) AS p
+    ) bp
+   WHERE t.transfer_type = 'return_to_hq'
+     AND t.status IN ('received','closed')
+     AND t.source_location = st.location_id
+     AND t.received_at >= p_from
+     AND t.received_at <  p_to
+     AND ti.qty_received > 0
+$$;
+
+COMMENT ON FUNCTION public._store_inbound_lines(BIGINT, TIMESTAMPTZ, TIMESTAMPTZ) IS
+  '某分店在指定期間的分店價分錄逐行（口徑同月結 branch_amount，正負號一致）。'
+  '內部 helper：不開放直接呼叫，只給 rpc_store_inbound_* 用。';
+
+REVOKE ALL ON FUNCTION public._store_inbound_lines(BIGINT, TIMESTAMPTZ, TIMESTAMPTZ) FROM PUBLIC;
+
+-- ------------------------------------------------------------
+-- 2. RPC：某店某月的「每日金額」彙總（日曆列表用）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_store_inbound_daily_summary(
+  p_store_id BIGINT,
+  p_month    DATE
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_store       public.stores%ROWTYPE;
+  v_month_start DATE := DATE_TRUNC('month', p_month)::DATE;
+  v_from        TIMESTAMPTZ;
+  v_to          TIMESTAMPTZ;
+  v_days        JSONB;
+  v_amount      NUMERIC(18,4);
+  v_lines       INTEGER;
+BEGIN
+  SELECT * INTO v_store FROM public.stores WHERE id = p_store_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'store % not found', p_store_id;
+  END IF;
+  IF NOT (public._settlement_caller_is_hq() OR public._settlement_caller_in_store(p_store_id)) THEN
+    RAISE EXCEPTION '無權查看此分店的進貨明細（store_id=%）', p_store_id;
+  END IF;
+  IF v_store.location_id IS NULL THEN
+    RAISE EXCEPTION '分店 % 未設定倉別（location_id），無法計算進貨金額', v_store.name;
+  END IF;
+
+  -- 台北時區的月首/次月首（helper 依 received_at timestamptz 比對）
+  v_from := (v_month_start)::TIMESTAMP AT TIME ZONE 'Asia/Taipei';
+  v_to   := (v_month_start + INTERVAL '1 month')::TIMESTAMP AT TIME ZONE 'Asia/Taipei';
+
+  WITH d AS (
+    SELECT l.biz_date,
+           COUNT(*)::INT       AS line_count,
+           SUM(l.amount)       AS amount
+      FROM public._store_inbound_lines(p_store_id, v_from, v_to) l
+     GROUP BY l.biz_date
+  )
+  SELECT
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'date',       d.biz_date,
+      'line_count', d.line_count,
+      'amount',     d.amount
+    ) ORDER BY d.biz_date DESC), '[]'::jsonb),
+    COALESCE(SUM(d.amount), 0),
+    COALESCE(SUM(d.line_count), 0)
+    INTO v_days, v_amount, v_lines
+    FROM d;
+
+  RETURN jsonb_build_object(
+    'store_id',     p_store_id,
+    'store_name',   v_store.name,
+    'month',        to_char(v_month_start, 'YYYY-MM'),
+    'days',         v_days,
+    'month_amount', v_amount,
+    'month_lines',  v_lines
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_store_inbound_daily_summary(BIGINT, DATE) IS
+  '分店某月「每日進貨金額」彙總（分店價口徑，日界 Asia/Taipei）。'
+  '月合計 = 該月月結 branch_amount（不含人工調整）。分店只能查自己店、HQ 可查全部。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_store_inbound_daily_summary(BIGINT, DATE) TO authenticated;
+
+-- ------------------------------------------------------------
+-- 3. RPC：某店某日的進貨明細（品項 + 分店價 + 小計 + 當日總額）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_store_inbound_day_items(
+  p_store_id BIGINT,
+  p_date     DATE
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_store  public.stores%ROWTYPE;
+  v_from   TIMESTAMPTZ;
+  v_to     TIMESTAMPTZ;
+  v_items  JSONB;
+  v_total  NUMERIC(18,4);
+BEGIN
+  SELECT * INTO v_store FROM public.stores WHERE id = p_store_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'store % not found', p_store_id;
+  END IF;
+  IF NOT (public._settlement_caller_is_hq() OR public._settlement_caller_in_store(p_store_id)) THEN
+    RAISE EXCEPTION '無權查看此分店的進貨明細（store_id=%）', p_store_id;
+  END IF;
+  IF v_store.location_id IS NULL THEN
+    RAISE EXCEPTION '分店 % 未設定倉別（location_id），無法計算進貨金額', v_store.name;
+  END IF;
+
+  v_from := (p_date)::TIMESTAMP AT TIME ZONE 'Asia/Taipei';
+  v_to   := (p_date + 1)::TIMESTAMP AT TIME ZONE 'Asia/Taipei';
+
+  WITH l AS (
+    SELECT * FROM public._store_inbound_lines(p_store_id, v_from, v_to)
+  )
+  SELECT
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'transfer_id',       l.transfer_id,
+      'transfer_no',       t.transfer_no,
+      'transfer_item_id',  l.transfer_item_id,
+      'sku_id',            l.sku_id,
+      'sku_code',          sk.sku_code,
+      'product_name',      COALESCE(sk.product_name, l.description),
+      'variant_name',      sk.variant_name,
+      'qty',               l.qty,
+      'unit_branch_price', l.unit_branch_price,
+      'amount',            l.amount,
+      'entry_type',        l.entry_type,
+      'description',       l.description,
+      -- 分店價沒設到（貨款行卻 0 元）→ 前端標示，提醒回報總部補價
+      'missing_price',     (l.entry_type IN ('hq_inbound','air_in','air_out','return_out')
+                            AND l.unit_branch_price = 0),
+      'received_at',       l.received_at
+    ) ORDER BY l.entry_type, l.received_at, l.transfer_item_id), '[]'::jsonb),
+    COALESCE(SUM(l.amount), 0)
+    INTO v_items, v_total
+    FROM l
+    LEFT JOIN public.transfers t ON t.id = l.transfer_id
+    LEFT JOIN public.skus sk     ON sk.id = l.sku_id;
+
+  RETURN jsonb_build_object(
+    'store_id',   p_store_id,
+    'store_name', v_store.name,
+    'date',       to_char(p_date, 'YYYY-MM-DD'),
+    'items',      v_items,
+    'total',      v_total
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_store_inbound_day_items(BIGINT, DATE) IS
+  '分店某日進貨明細（品項/數量/分店價/小計）＋當日總金額，日界 Asia/Taipei。'
+  '口徑同月結對帳單（分店價），分店只能查自己店、HQ 可查全部。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_store_inbound_day_items(BIGINT, DATE) TO authenticated;


### PR DESCRIPTION
店家當天問「今日進貨總金額多少」，紙本出貨單沒金額、系統也只有月結
對帳單送出後才看得到分店價。新增每日視角：

- migration 20260803000000：helper `_store_inbound_lines` + 兩支
  SECURITY DEFINER RPC（daily_summary / day_items）。六種 entry_type
  與月結生成器 v4 逐項對齊 → 每日金額加總 = 該月 branch_amount
  （線上 2026-07 全 15 店逐店 diff 為 0 驗證過）。日界用 Asia/Taipei。
  gate 沿用 _settlement_caller_is_hq / _in_store：分店只查自己店。
- 新頁 /transfers/settlement/daily：今日 / 本月累計數字卡、每日金額列表、
  展開當日逐品項（分店價 / 小計 / 單號），今天有貨預設展開；
  分店版與總部版月結頁 header 各加入口。
- StoreSettlementReview 金額欄：$0 有明細時標「進貨與退貨相抵」、
  負數改綠字「總倉應退 $x」（原本一律紅字，店家看不懂）。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XnXtiGBZY44kcSNdTKCKSF