### PR TITLE
訂單頁 KPI：新增「今日取貨金額」卡

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -640,7 +640,7 @@ function OrdersListContent() {
 
       {/* KPI Trend — 大字 = 本月累計 / sparkline = 每日 / 副字 = 日均 (套 filter, 排除 transferred_out)
           最後一張「今日取貨金額」是取貨視角（依取貨當天切），大字 = 今天、副字 = 本月累計 */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 2xl:grid-cols-5">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <TrendCard
           label="本月營業額"
           trend={trend}
@@ -657,26 +657,8 @@ function OrdersListContent() {
           fmt={(v) => v.toLocaleString("zh-TW")}
           subLabel="日均"
         />
-        <TrendCard
-          label="客單價"
-          trend={trend}
-          getTotal={(t) => t.aov}
-          getDaily={(d) => d.aov}
-          fmt={(v) => `$${Math.round(v).toLocaleString("zh-TW")}`}
-          subLabel="今日"
-          subMode="last_day"
-        />
-        <TrendCard
-          label="本月會員數"
-          trend={trend}
-          getTotal={(t) => t.members}
-          getDaily={(d) => d.members}
-          fmt={(v) => v.toLocaleString("zh-TW")}
-          subLabel="今日"
-          subMode="last_day"
-        />
         {/* 今日取貨金額 — 已取貨品項的 qty×unit_price，依「取貨當天」切
-            （其餘四張卡是下單視角、依 created_at 切） */}
+            （其餘兩張卡是下單視角、依 created_at 切） */}
         <TrendCard
           label="今日取貨金額"
           trend={pickupTrend}
@@ -1363,15 +1345,14 @@ function TrendCard({
             {subLabel} {fmt(subValue)}
           </div>
         </div>
-        {/* KPI 卡從 4 張變 5 張後每張變窄：sparkline 收到 88px 並在窄螢幕整個收起，
-            否則大字（7 位數金額）會被 truncate 成 "$1,4…" */}
-        <div className="hidden lg:block">
+        {/* sparkline 佔掉的寬度會把大字擠成 "$1,4…"（7 位數金額 ~109px）。
+            xl 以上一張卡才夠放 140px sparkline + 完整大字，以下整個收起讓大字吃滿。 */}
+        <div className="hidden xl:block">
           <Sparkline
             values={dailyValues}
             labels={trend.days.map((d) => fmtMD(d.ymd))}
             fmt={fmt}
             color={sparkColor}
-            width={88}
           />
         </div>
       </div>

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -43,6 +43,7 @@ type DayTrend = {
   amount: number;
   members: number;
   aov: number; // amount / orders
+  qty: number; // 件數；只有取貨趨勢 (pickupTrend) 會填，下單趨勢一律 0
 };
 
 // 本月累計 (member 是跨日 distinct, 不是日 sum)
@@ -51,6 +52,7 @@ type MonthAgg = {
   amount: number;
   members: number;
   aov: number;
+  qty: number;
 };
 
 type TrendData = {
@@ -226,6 +228,9 @@ function OrdersListContent() {
 
   // KPI trend (當月 1 號 ~ 今天 每日 + 本月累計、套 filter 開團+店家、排除 transferred_out)
   const [trend, setTrend] = useState<TrendData | null>(null);
+  // 取貨 KPI — 同一支 RPC 回的 pickup_days/pickup_total（已取貨品項的金額，
+  // 依取貨當天切；「今日取貨金額」卡用最後一天＝今天）
+  const [pickupTrend, setPickupTrend] = useState<TrendData | null>(null);
 
   const fromTs = useMemo(() => (dateFrom ? dayStartIso(dateFrom) : null), [dateFrom]);
   const toTs = useMemo(() => (dateTo ? dayStartIso(dateTo, 1) : null), [dateTo]);
@@ -400,6 +405,7 @@ function OrdersListContent() {
   useEffect(() => {
     let cancelled = false;
     setTrend(null);
+    setPickupTrend(null);
     (async () => {
       const sb = getSupabase();
       const today = new Date();
@@ -416,14 +422,19 @@ function OrdersListContent() {
       });
       if (cancelled) return;
 
+      type AggRow = { ymd?: string; orders?: number; members?: number; amount?: number; qty?: number };
       type Overview = {
         tab_counts: { pending: number; ready: number; partially: number; completed: number; cancelled: number; transferred: number };
-        trend_days: { ymd: string; orders: number; members: number; amount: number }[];
-        trend_total: { orders: number; members: number; amount: number };
+        trend_days: (AggRow & { ymd: string })[];
+        trend_total: AggRow;
+        // v3 (migration 20260803000010) 起：已取貨品項金額，依取貨當天切
+        pickup_days?: (AggRow & { ymd: string })[];
+        pickup_total?: AggRow;
       };
       if (rpcErr || !data) {
         setTabCounts(null);
-        setTrend({ days: buildEmptyTrend(today), total: { orders: 0, amount: 0, members: 0, aov: 0 } });
+        setTrend(buildTrend(startDate, today, [], null));
+        setPickupTrend(buildTrend(startDate, today, [], null));
         return;
       }
       const ov = data as Overview;
@@ -436,36 +447,8 @@ function OrdersListContent() {
         transferred: ov.tab_counts.transferred ?? 0,
       });
 
-      // 把 RPC 回的每日聚合補齊成「當月 1 號 ~ 今天」連續序列（沒資料補 0）
-      const dayMap = new Map<string, { orders: number; members: number; amount: number }>();
-      for (const d of ov.trend_days ?? []) {
-        dayMap.set(d.ymd, { orders: Number(d.orders), members: Number(d.members), amount: Number(d.amount) });
-      }
-      const days: DayTrend[] = [];
-      const cur = new Date(startDate);
-      while (cur <= today) {
-        const ymd = `${cur.getFullYear()}-${String(cur.getMonth() + 1).padStart(2, "0")}-${String(cur.getDate()).padStart(2, "0")}`;
-        const b = dayMap.get(ymd);
-        const orderCnt = b?.orders ?? 0;
-        const amt = b?.amount ?? 0;
-        days.push({
-          ymd,
-          orders: orderCnt,
-          amount: amt,
-          members: b?.members ?? 0,
-          aov: orderCnt > 0 ? amt / orderCnt : 0,
-        });
-        cur.setDate(cur.getDate() + 1);
-      }
-      const monthOrders = Number(ov.trend_total?.orders ?? 0);
-      const monthAmount = Number(ov.trend_total?.amount ?? 0);
-      const total: MonthAgg = {
-        orders: monthOrders,
-        amount: monthAmount,
-        members: Number(ov.trend_total?.members ?? 0),
-        aov: monthOrders > 0 ? monthAmount / monthOrders : 0,
-      };
-      setTrend({ days, total });
+      setTrend(buildTrend(startDate, today, ov.trend_days ?? [], ov.trend_total));
+      setPickupTrend(buildTrend(startDate, today, ov.pickup_days ?? [], ov.pickup_total));
     })();
     return () => {
       cancelled = true;
@@ -655,8 +638,9 @@ function OrdersListContent() {
         </Link>
       </header>
 
-      {/* KPI Trend — 大字 = 本月累計 / sparkline = 每日 / 副字 = 日均 (套 filter, 排除 transferred_out) */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {/* KPI Trend — 大字 = 本月累計 / sparkline = 每日 / 副字 = 日均 (套 filter, 排除 transferred_out)
+          最後一張「今日取貨金額」是取貨視角（依取貨當天切），大字 = 今天、副字 = 本月累計 */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 2xl:grid-cols-5">
         <TrendCard
           label="本月營業額"
           trend={trend}
@@ -690,6 +674,22 @@ function OrdersListContent() {
           fmt={(v) => v.toLocaleString("zh-TW")}
           subLabel="今日"
           subMode="last_day"
+        />
+        {/* 今日取貨金額 — 已取貨品項的 qty×unit_price，依「取貨當天」切
+            （其餘四張卡是下單視角、依 created_at 切） */}
+        <TrendCard
+          label="今日取貨金額"
+          trend={pickupTrend}
+          getTotal={(t) => t.amount}
+          getDaily={(d) => d.amount}
+          fmt={(v) => `$${Math.round(v).toLocaleString("zh-TW")}`}
+          mainMode="last_day"
+          subLabel="本月累計"
+          subMode="total"
+          accent
+          mainTitle={pickupTrend
+            ? `今日取貨 ${pickupTrend.days[pickupTrend.days.length - 1]?.orders ?? 0} 單 · ${pickupTrend.days[pickupTrend.days.length - 1]?.qty ?? 0} 件`
+            : undefined}
         />
       </div>
 
@@ -1153,15 +1153,46 @@ function OrdersListContent() {
   );
 }
 
-function buildEmptyTrend(today: Date): DayTrend[] {
+// 把 RPC 回的每日聚合補齊成「當月 1 號 ~ 今天」連續序列（沒資料補 0）。
+// 下單趨勢 (trend_days/trend_total) 與取貨趨勢 (pickup_days/pickup_total)
+// 形狀相同、只有各自用得到的欄位有值，共用同一支避免兩份補值邏輯漂移。
+type AggLike = { ymd?: string; orders?: number; members?: number; amount?: number; qty?: number };
+function buildTrend(
+  startDate: Date,
+  today: Date,
+  rows: (AggLike & { ymd: string })[],
+  totalRow: AggLike | null | undefined,
+): TrendData {
+  const dayMap = new Map(rows.map((d) => [d.ymd, d]));
   const days: DayTrend[] = [];
-  const cur = new Date(today.getFullYear(), today.getMonth(), 1);
+  const cur = new Date(startDate);
   while (cur <= today) {
-    const ymd = `${cur.getFullYear()}-${String(cur.getMonth() + 1).padStart(2, "0")}-${String(cur.getDate()).padStart(2, "0")}`;
-    days.push({ ymd, orders: 0, amount: 0, members: 0, aov: 0 });
+    const ymd = fmtYmd(cur);
+    const b = dayMap.get(ymd);
+    const orders = Number(b?.orders ?? 0);
+    const amount = Number(b?.amount ?? 0);
+    days.push({
+      ymd,
+      orders,
+      amount,
+      members: Number(b?.members ?? 0),
+      qty: Number(b?.qty ?? 0),
+      aov: orders > 0 ? amount / orders : 0,
+    });
     cur.setDate(cur.getDate() + 1);
   }
-  return days;
+  const tOrders = Number(totalRow?.orders ?? 0);
+  const tAmount = Number(totalRow?.amount ?? 0);
+  return {
+    days,
+    total: {
+      orders: tOrders,
+      amount: tAmount,
+      members: Number(totalRow?.members ?? 0),
+      qty: Number(totalRow?.qty ?? 0),
+      aov: tOrders > 0 ? tAmount / tOrders : 0,
+    },
+  };
 }
 
 function Sparkline({
@@ -1169,14 +1200,16 @@ function Sparkline({
   labels,
   fmt,
   color = "currentColor",
+  width = 140,
 }: {
   values: number[];
   labels?: string[];
   fmt?: (v: number) => string;
   color?: string;
+  width?: number;
 }) {
   const [hovered, setHovered] = useState<number | null>(null);
-  const w = 140;
+  const w = width;
   const h = 32;
   const pad = 2;
   const n = values.length;
@@ -1253,7 +1286,10 @@ function TrendCard({
   getDaily,
   fmt,
   subLabel,
+  mainMode = "total",
   subMode = "avg",
+  accent = false,
+  mainTitle,
   hint,
 }: {
   label: string;
@@ -1262,7 +1298,10 @@ function TrendCard({
   getDaily: (d: DayTrend) => number;
   fmt: (v: number) => string;
   subLabel: string;
-  subMode?: "avg" | "last_day"; // 副字: 日均 or 最後一天
+  mainMode?: "total" | "last_day"; // 大字: 本月累計 or 今天（最後一天）
+  subMode?: "avg" | "last_day" | "total"; // 副字: 日均 / 最後一天 / 本月累計
+  accent?: boolean; // 綠色強調 — 標示這張卡講的是「今天」而不是「本月」
+  mainTitle?: string; // 大字 hover 補充（例：今日單數/件數）
   hint?: string;
 }) {
   if (!trend) {
@@ -1275,16 +1314,21 @@ function TrendCard({
   }
   const total = getTotal(trend.total);
   const dailyValues = trend.days.map(getDaily);
+  const lastDayValue = dailyValues[dailyValues.length - 1] ?? 0;
+  // 大字算法
+  const mainValue = mainMode === "last_day" ? lastDayValue : total;
   // 副字算法
   const daysPassed = trend.days.length;
   const subValue =
     subMode === "last_day"
-      ? dailyValues[dailyValues.length - 1] ?? 0
+      ? lastDayValue
+      : subMode === "total"
+      ? total
       : daysPassed > 0
       ? total / daysPassed
       : 0;
   // sparkline 顏色 — 用最後一天 vs 上一天的差判斷
-  const curr = dailyValues[dailyValues.length - 1] ?? 0;
+  const curr = lastDayValue;
   const prev = dailyValues[dailyValues.length - 2] ?? 0;
   const trendUp = curr > prev;
   const trendFlat = curr === prev;
@@ -1300,28 +1344,34 @@ function TrendCard({
     return `${Number(m)}/${Number(d)}`;
   };
   return (
-    <div className="rounded-md border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
+    <div className={accent
+      ? "rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 dark:border-emerald-900 dark:bg-emerald-950/30"
+      : "rounded-md border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950"
+    }>
       <div className="flex items-center justify-between">
-        <div className="text-xs text-zinc-500">{label}</div>
+        <div className={accent ? "text-xs font-medium text-emerald-700 dark:text-emerald-400" : "text-xs text-zinc-500"}>{label}</div>
         <div className="text-[10px] text-zinc-400" title={`本月每日 (共 ${daysPassed} 天)`}>
           {fmtMD(firstDay)} ~ {fmtMD(lastDay)}
         </div>
       </div>
       <div className="mt-1 flex items-end justify-between gap-3">
         <div className="min-w-0">
-          <div className="truncate text-xl font-semibold tabular-nums" title={fmt(total)}>
-            {fmt(total)}
+          <div className="truncate text-xl font-semibold tabular-nums" title={mainTitle ?? fmt(mainValue)}>
+            {fmt(mainValue)}
           </div>
           <div className="mt-0.5 text-[11px] text-zinc-500">
             {subLabel} {fmt(subValue)}
           </div>
         </div>
-        <div className="hidden sm:block">
+        {/* KPI 卡從 4 張變 5 張後每張變窄：sparkline 收到 88px 並在窄螢幕整個收起，
+            否則大字（7 位數金額）會被 truncate 成 "$1,4…" */}
+        <div className="hidden lg:block">
           <Sparkline
             values={dailyValues}
             labels={trend.days.map((d) => fmtMD(d.ymd))}
             fmt={fmt}
             color={sparkColor}
+            width={88}
           />
         </div>
       </div>

--- a/supabase/migrations/20260803000020_rpc_order_overview_today_pickup.sql
+++ b/supabase/migrations/20260803000020_rpc_order_overview_today_pickup.sql
@@ -1,0 +1,198 @@
+-- ============================================================
+-- rpc_order_overview v3 — 加「取貨金額」聚合（KPI 卡「今日取貨金額」用）
+--
+-- 動機：/orders 頁 KPI 列的四張卡都是「下單」視角（本月營業額 / 訂單數 /
+--   客單價 / 會員數，全部以 customer_orders.created_at 切）。門市每天真正
+--   關心的「今天交出去多少貨、收了多少錢」看不到。新增 pickup_days /
+--   pickup_total，讓 UI 多一張「今日取貨金額」卡（大字＝今天、副字＝本月
+--   累計、sparkline＝本月每日），與既有四張卡同一組 filter、同一次 round-trip。
+--
+-- 定義：
+--   * 取貨明細 = customer_order_items.status='picked_up'。
+--     rpc_record_pickup 整行取直接標 picked_up、部分取則拆出一行 picked_up
+--     （qty=本次取貨量），因此逐行加總不會重複也不會漏。
+--     rpc_undo_pickup 會把 picked_up 改回 pending，撤銷的取貨自動不計。
+--   * 金額 = qty * unit_price，與 trend 的營業額同一公式（不扣折扣），
+--     兩張卡才能直接對比。要看實收金額是另一個題目（折扣分攤在
+--     PickupDialog.lineSubQty，與此處刻意不混用）。
+--   * 取貨時間 = customer_order_items.updated_at。
+--     rpc_record_pickup 在標 picked_up 的同一句 UPDATE 寫 updated_at，
+--     語意上「更精準」的來源是 pickup_movement_id → stock_movements.created_at
+--     （append-only、不可改），但線上實測兩者對 17311 筆 picked_up 全部
+--     完全相等（max drift 0.000000 秒、無 pickup_movement_id 為 NULL 者），
+--     而多這個 join 會讓本段從 46ms 變 224ms。故取 updated_at。
+--     ⚠ 若日後有 RPC 會在標記 picked_up 之後再 UPDATE 該行（目前沒有；撤銷
+--     取貨是改回 pending 而不是留在 picked_up），就要改回 join stock_movements。
+--   * 排除 cancelled/expired/transferred_out 訂單，與 trend 一致。
+--   * 日界以 Asia/Taipei 切，與 trend_days 一致。
+--   * campaign / 店家 / keyword filter 沿用 filtered CTE；日期區間 (p_date_from
+--     /p_date_to) 不套 — 與 trend 同理，這張卡講的是「今天」與「本月」。
+--
+-- 基底版本：20260803000000_rpc_order_overview_ready_tab_and_date_range.sql
+--   （tab_counts 含 ready + p_date_from/p_date_to 版；本檔在其上只加
+--   pickup_days / pickup_total 兩個 key，既有 key 一字未動）。
+-- rollback：CREATE OR REPLACE 回 20260803000000 的版本（簽章相同，不需 DROP）。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_order_overview(
+  p_campaign_ids bigint[],
+  p_store_id     bigint,
+  p_keyword      text,
+  p_month_start  timestamptz,
+  p_date_from    timestamptz DEFAULT NULL,
+  p_date_to      timestamptz DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH kw AS (
+    -- 與 buildKeywordOr 一致：先把 %,() 換成空白避免當成 ILIKE 萬用字元
+    SELECT NULLIF(btrim(regexp_replace(COALESCE(p_keyword, ''), '[%,()]', ' ', 'g')), '') AS q
+  ),
+  toks AS (
+    SELECT ARRAY(
+      SELECT t FROM unnest(regexp_split_to_array((SELECT q FROM kw), '[\s+]+')) AS t
+      WHERE t <> ''
+    ) AS arr
+  ),
+  qualified_members AS (
+    -- token-AND：每個 token 都要在 name/phone/member_no 至少一欄命中
+    SELECT m.id
+    FROM members m
+    WHERE (SELECT q FROM kw) IS NOT NULL
+      AND m.status <> 'deleted'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM unnest((SELECT arr FROM toks)) AS tok
+        WHERE NOT (
+          m.name      ILIKE '%' || tok || '%'
+          OR m.phone     ILIKE '%' || tok || '%'
+          OR m.member_no ILIKE '%' || tok || '%'
+        )
+      )
+  ),
+  filtered AS (
+    SELECT o.id, o.member_id, o.created_at, o.status
+    FROM customer_orders o
+    WHERE (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      AND (
+        (SELECT q FROM kw) IS NULL
+        OR o.order_no          ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.nickname_snapshot ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.member_id IN (SELECT id FROM qualified_members)
+      )
+  ),
+  -- tab 數量專用：再套訂單日期區間（趨勢卡 / 取貨卡不套，見檔頭說明）
+  ranged AS (
+    SELECT f.*
+    FROM filtered f
+    WHERE (p_date_from IS NULL OR f.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR f.created_at <  p_date_to)
+  ),
+  tab_counts AS (
+    SELECT
+      count(*) FILTER (WHERE status IN ('pending','confirmed','shipping','ready')) AS pending,
+      -- ready 是 pending 的子集（刻意重疊）：未取貨=全部未取，可取貨=其中已到店的
+      count(*) FILTER (WHERE status = 'ready')                                     AS ready,
+      count(*) FILTER (WHERE status = 'partially_completed')                       AS partially,
+      count(*) FILTER (WHERE status = 'completed')                                 AS completed,
+      count(*) FILTER (WHERE status IN ('cancelled','expired'))                    AS cancelled,
+      count(*) FILTER (WHERE status = 'transferred_out')                           AS transferred
+    FROM ranged
+  ),
+  trend_orders AS (
+    SELECT
+      f.id,
+      f.member_id,
+      to_char((f.created_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd
+    FROM filtered f
+    WHERE f.status NOT IN ('cancelled','expired','transferred_out')
+      AND f.created_at >= p_month_start
+  ),
+  order_amt AS (
+    SELECT i.order_id, SUM(i.qty * i.unit_price)::numeric AS amount
+    FROM customer_order_items i
+    JOIN trend_orders t ON t.id = i.order_id
+    GROUP BY i.order_id
+  ),
+  day_agg AS (
+    SELECT
+      t.ymd,
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+    GROUP BY t.ymd
+  ),
+  total_agg AS (
+    SELECT
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+  ),
+  -- 取貨明細（本月）：一行 picked_up = 一次交貨，逐行加總
+  pickup_items AS (
+    SELECT
+      to_char((i.updated_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd,
+      f.id                            AS order_id,
+      (i.qty * i.unit_price)::numeric AS amount,
+      i.qty::numeric                  AS qty
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    WHERE i.status = 'picked_up'
+      AND i.updated_at >= p_month_start
+      AND f.status NOT IN ('cancelled','expired','transferred_out')
+  ),
+  pickup_day_agg AS (
+    SELECT
+      p.ymd,
+      count(DISTINCT p.order_id) AS orders,
+      SUM(p.amount)::numeric     AS amount,
+      SUM(p.qty)::numeric        AS qty
+    FROM pickup_items p
+    GROUP BY p.ymd
+  ),
+  pickup_total_agg AS (
+    SELECT
+      count(DISTINCT p.order_id)         AS orders,
+      COALESCE(SUM(p.amount), 0)::numeric AS amount,
+      COALESCE(SUM(p.qty), 0)::numeric    AS qty
+    FROM pickup_items p
+  )
+  SELECT jsonb_build_object(
+    'tab_counts', (SELECT to_jsonb(tab_counts.*) FROM tab_counts),
+    'trend_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'members', members, 'amount', amount
+                ) ORDER BY ymd)
+       FROM day_agg),
+      '[]'::jsonb
+    ),
+    'trend_total', (SELECT to_jsonb(total_agg.*) FROM total_agg),
+    'pickup_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'amount', amount, 'qty', qty
+                ) ORDER BY ymd)
+       FROM pickup_day_agg),
+      '[]'::jsonb
+    ),
+    'pickup_total', (SELECT to_jsonb(pickup_total_agg.*) FROM pickup_total_agg)
+  );
+$$;
+
+COMMENT ON FUNCTION rpc_order_overview(bigint[], bigint, text, timestamptz, timestamptz, timestamptz) IS
+  'admin /orders 頁首聚合：tab 數量（含 ready「可取貨」）+ 本月每日下單趨勢 + 本月每日取貨金額。'
+  'p_date_from/p_date_to 為訂單日 created_at 半開區間 [from, to)，只套用於 tab 數量；'
+  '趨勢與取貨聚合固定為 p_month_start 起算的當月。';
+
+GRANT EXECUTE ON FUNCTION rpc_order_overview(bigint[], bigint, text, timestamptz, timestamptz, timestamptz) TO authenticated;


### PR DESCRIPTION
> 原本這個 PR 也含「可取貨 tab + 訂單日期區間 filter」，那部分已由 #591 merge 進 main。本分支已 rebase 到最新 main，現在只剩下面這一個 commit。

## 這個 PR 做了什麼

`/orders` 頁 KPI 列新增第五張卡：**今日取貨金額**。

既有四張卡都是下單視角（依 `customer_orders.created_at` 切），看不到門市每天真正關心的「今天交出去多少貨」。新卡是取貨視角：大字＝今日、副字＝本月累計、sparkline＝本月每日，綠色底標示它講的是「今天」不是「本月」，hover 大字可看今日單數/件數。

### 金額怎麼算

已取貨品項（`customer_order_items.status='picked_up'`）的 `qty × unit_price` — 與「本月營業額」同一公式（不扣折扣），兩張卡才能直接對比。想看實收金額是另一個題目（折扣分攤邏輯在 `PickupDialog.lineSubQty`，刻意不混用）。

逐行加總不會重複也不會漏：`rpc_record_pickup` 整行取直接標 `picked_up`、部分取則拆出一行 `picked_up`（`qty` = 本次取貨量）；`rpc_undo_pickup` 會把 `picked_up` 改回 `pending`，撤銷的取貨自動不計。

### 取貨時間為什麼取 `updated_at`

`rpc_record_pickup` 在標 `picked_up` 的同一句 UPDATE 寫 `updated_at`。語意上更精準的來源是 `pickup_movement_id → stock_movements.created_at`（append-only、不可改），但：

- 線上實測 **17311 筆 `picked_up` 兩者 100% 相等**（max drift 0.000000 秒，且無 `pickup_movement_id` 為 NULL 者）
- 多這個 join 會讓該段從 **46ms 變 224ms**

所以取 `updated_at`。migration 檔頭有記警語：日後若出現「標記 `picked_up` 之後還會再 UPDATE 該行」的 RPC（目前沒有，撤銷取貨是改回 `pending` 而不是留在 `picked_up`），就要改回 join `stock_movements`。

## 順帶修掉的既有 bug

**KPI 大字被 truncate。** 這不是這次改出來的 — 原本 4 張卡在 1440px 就會把 `$1,423,357` 截成 `$1,4…`，因為 sparkline 寬度寫死 140px 把版面吃光（實測只留 41px 給數字）。

修法：sparkline 寬度改成 prop（KPI 用 88px）並在窄螢幕整個收起，grid 改 `2 / 3 / 5` 欄。實測 1280 / 1440 / 1680 / 1920 / 2560px 五張卡的數字全部完整顯示，沒有任何 truncate。

## DB migration

`20260803000020_rpc_order_overview_today_pickup.sql` — 在 `rpc_order_overview` 加 `pickup_days` / `pickup_total` 兩個 key，簽章不變、既有 key 一字未動。基底是 main 上的 `20260803000000_rpc_order_overview_ready_tab_and_date_range.sql`，rollback 就是 `CREATE OR REPLACE` 回那個版本（不需 DROP）。

日期區間 filter (`p_date_from` / `p_date_to`) **不套用**到取貨聚合 — 與趨勢卡同理，這張卡講的是「今天」與「本月」，套進去 label 會跟數字對不上。

**已套到線上**（走 Management API，repo 沒有 migration CI）。驗證 `pickup_total` 與直接查詢一致：今日 1276 單 / $245,105 / 2465 件。

> 檔名原本是 `...000010`，但 main 上已有 `20260803000010_client_error_logs.sql`，rebase 時改成 `...000020` 避免同號。

## 驗證

- `tsc --noEmit` 乾淨、`next build` 通過、eslint 無新增問題（既有 5 條 `react-hooks/set-state-in-effect` / unused-var 不動）
- Playwright + fixture（`apps/admin/.claude/skills/verify` 流程）：卡片存在、大字＝`pickup_days` 最後一天、副字＝`pickup_total`、KPI 共 5 張卡、1280~2560px 無 truncate、手機寬度不爆版