### PR TITLE
訂單頁 KPI：「今日取貨金額」卡只留今天

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -657,22 +657,7 @@ function OrdersListContent() {
           fmt={(v) => v.toLocaleString("zh-TW")}
           subLabel="日均"
         />
-        {/* 今日取貨金額 — 已取貨品項的 qty×unit_price，依「取貨當天」切
-            （其餘兩張卡是下單視角、依 created_at 切） */}
-        <TrendCard
-          label="今日取貨金額"
-          trend={pickupTrend}
-          getTotal={(t) => t.amount}
-          getDaily={(d) => d.amount}
-          fmt={(v) => `$${Math.round(v).toLocaleString("zh-TW")}`}
-          mainMode="last_day"
-          subLabel="本月累計"
-          subMode="total"
-          accent
-          mainTitle={pickupTrend
-            ? `今日取貨 ${pickupTrend.days[pickupTrend.days.length - 1]?.orders ?? 0} 單 · ${pickupTrend.days[pickupTrend.days.length - 1]?.qty ?? 0} 件`
-            : undefined}
-        />
+        <PickupTodayCard trend={pickupTrend} />
       </div>
 
       {/* Tab bar — 未取貨 / 可取貨 / 部分取貨 / 已完成 / 轉出 / 取消;含各 tab 數量 */}
@@ -1182,16 +1167,14 @@ function Sparkline({
   labels,
   fmt,
   color = "currentColor",
-  width = 140,
 }: {
   values: number[];
   labels?: string[];
   fmt?: (v: number) => string;
   color?: string;
-  width?: number;
 }) {
   const [hovered, setHovered] = useState<number | null>(null);
-  const w = width;
+  const w = 140;
   const h = 32;
   const pad = 2;
   const n = values.length;
@@ -1261,6 +1244,38 @@ function Sparkline({
   );
 }
 
+// 今日取貨金額 — 只看今天：已取貨品項 (status='picked_up') 的 qty×unit_price，
+// 依「取貨當天」切。與另外兩張「本月」卡時間基準不同（那兩張依下單日 created_at），
+// 所以綠底標示、也不放 sparkline / 本月累計 — 這張卡就只回答「今天交出去多少」。
+function PickupTodayCard({ trend }: { trend: TrendData | null }) {
+  const today = trend ? trend.days[trend.days.length - 1] : null;
+  const num = (v: number) => v.toLocaleString("zh-TW");
+  return (
+    <div className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 dark:border-emerald-900 dark:bg-emerald-950/30">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-medium text-emerald-700 dark:text-emerald-400">今日取貨金額</div>
+        {today && (
+          <div className="text-[10px] text-zinc-400">
+            {Number(today.ymd.split("-")[1])}/{Number(today.ymd.split("-")[2])}
+          </div>
+        )}
+      </div>
+      {!trend ? (
+        <div className="mt-1 text-xl font-semibold tabular-nums text-zinc-400">—</div>
+      ) : (
+        <>
+          <div className="mt-1 truncate text-xl font-semibold tabular-nums">
+            ${num(Math.round(today?.amount ?? 0))}
+          </div>
+          <div className="mt-0.5 text-[11px] text-zinc-500">
+            {num(today?.orders ?? 0)} 單 · {num(today?.qty ?? 0)} 件
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 function TrendCard({
   label,
   trend,
@@ -1268,10 +1283,7 @@ function TrendCard({
   getDaily,
   fmt,
   subLabel,
-  mainMode = "total",
   subMode = "avg",
-  accent = false,
-  mainTitle,
   hint,
 }: {
   label: string;
@@ -1280,10 +1292,7 @@ function TrendCard({
   getDaily: (d: DayTrend) => number;
   fmt: (v: number) => string;
   subLabel: string;
-  mainMode?: "total" | "last_day"; // 大字: 本月累計 or 今天（最後一天）
-  subMode?: "avg" | "last_day" | "total"; // 副字: 日均 / 最後一天 / 本月累計
-  accent?: boolean; // 綠色強調 — 標示這張卡講的是「今天」而不是「本月」
-  mainTitle?: string; // 大字 hover 補充（例：今日單數/件數）
+  subMode?: "avg" | "last_day"; // 副字: 日均 or 最後一天
   hint?: string;
 }) {
   if (!trend) {
@@ -1297,18 +1306,10 @@ function TrendCard({
   const total = getTotal(trend.total);
   const dailyValues = trend.days.map(getDaily);
   const lastDayValue = dailyValues[dailyValues.length - 1] ?? 0;
-  // 大字算法
-  const mainValue = mainMode === "last_day" ? lastDayValue : total;
   // 副字算法
   const daysPassed = trend.days.length;
   const subValue =
-    subMode === "last_day"
-      ? lastDayValue
-      : subMode === "total"
-      ? total
-      : daysPassed > 0
-      ? total / daysPassed
-      : 0;
+    subMode === "last_day" ? lastDayValue : daysPassed > 0 ? total / daysPassed : 0;
   // sparkline 顏色 — 用最後一天 vs 上一天的差判斷
   const curr = lastDayValue;
   const prev = dailyValues[dailyValues.length - 2] ?? 0;
@@ -1326,20 +1327,17 @@ function TrendCard({
     return `${Number(m)}/${Number(d)}`;
   };
   return (
-    <div className={accent
-      ? "rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 dark:border-emerald-900 dark:bg-emerald-950/30"
-      : "rounded-md border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950"
-    }>
+    <div className="rounded-md border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
       <div className="flex items-center justify-between">
-        <div className={accent ? "text-xs font-medium text-emerald-700 dark:text-emerald-400" : "text-xs text-zinc-500"}>{label}</div>
+        <div className="text-xs text-zinc-500">{label}</div>
         <div className="text-[10px] text-zinc-400" title={`本月每日 (共 ${daysPassed} 天)`}>
           {fmtMD(firstDay)} ~ {fmtMD(lastDay)}
         </div>
       </div>
       <div className="mt-1 flex items-end justify-between gap-3">
         <div className="min-w-0">
-          <div className="truncate text-xl font-semibold tabular-nums" title={mainTitle ?? fmt(mainValue)}>
-            {fmt(mainValue)}
+          <div className="truncate text-xl font-semibold tabular-nums" title={fmt(total)}>
+            {fmt(total)}
           </div>
           <div className="mt-0.5 text-[11px] text-zinc-500">
             {subLabel} {fmt(subValue)}


### PR DESCRIPTION
接續 #595（已 merge）。分支已 rebase 到最新 main，只剩這一個 commit。

## 改了什麼

「今日取貨金額」卡原本是套 `TrendCard` 做的，跟著帶了 sparkline、「本月累計」副字、右上角「8/1 ~ 8/3」月份區間。但這張卡要回答的只有一件事：**今天交出去多少**。

改成獨立的 `PickupTodayCard`：

```
今日取貨金額                8/3
$245,105
1,276 單 · 2,465 件
```

- 拿掉 sparkline、本月累計、月份區間
- 副字換成今天的單數/件數 — 直接回答「今天多少人來取」
- 右上角改標今天日期

## 計算基準沒有變

一直都只算**實際有取貨的品項**（`customer_order_items.status='picked_up'` 的 `qty × unit_price`），沒取貨的訂單不會進來。

線上今天的資料逐項查過：**1281 單 / $246,505**，且沒有內部補貨單（`【內部】` 會員名下的現貨單）混進去，全部是真的有人來取的。

## 順手清掉的東西

`TrendCard` 還原成原本的樣子 — 上一個 PR 為了這張卡加的 `mainMode` / `subMode:"total"` / `accent` / `mainTitle`，以及 `Sparkline` 的 `width` prop，改用獨立元件後就沒有 caller 了，一併移除。

sparkline 的 `hidden xl:block` 保留 —— 那是 truncate 的修法，跟這張卡無關（xl 以下一張卡放不下 140px sparkline + 7 位數金額）。

## 沒有 migration

`rpc_order_overview` 一個字都沒動，仍回傳整個月的 `pickup_days` / `pickup_total`，只是前端不再顯示。

**刻意不縮 RPC 契約**：這版已經部署到線上了，如果 migration 把那些欄位拿掉，從套 migration 到前端重新部署之間會有空窗期，線上卡片會顯示錯的數字。留著也不影響效能（那段聚合實測 46ms）。

## 驗證

- `tsc --noEmit` 乾淨、`next build` 通過、eslint 無新增問題
- Playwright + fixture（`apps/admin/.claude/skills/verify` 流程）21 項全過，新增三項：「不再顯示本月累計」「副字＝今日單數/件數」「卡內無 sparkline」

---
_Generated by [Claude Code](https://claude.ai/code/session_013FYTYHft5wRGzRx9DVs1pZ)_