### PR TITLE
fix(member): PWA 單純用 LINE 登入（免驗證碼）+ 新增 /logout 重置

### DIFF
--- a/apps/member/src/app/logout/page.tsx
+++ b/apps/member/src/app/logout/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { hardLogout, type LogoutStep } from "@/lib/logout";
+import Spinner from "@/components/Spinner";
+
+/**
+ * 登出 / 重置這台裝置。
+ *
+ * 做成獨立路徑（直接開 /logout 就能到）是為了測試：要驗證登入流程時，
+ * 需要一個可靠的方法回到「從沒登入過」的狀態，而不是靠手動清瀏覽器資料。
+ *
+ * 不在載入時就自動清 —— 誤觸或被分享到這個網址會直接把人登出。
+ * 先列出會清什麼，按下才執行。
+ */
+export default function LogoutPage() {
+  const [state, setState] = useState<"idle" | "running" | "done">("idle");
+  const [steps, setSteps] = useState<LogoutStep[]>([]);
+
+  const run = async () => {
+    setState("running");
+    setSteps(await hardLogout());
+    setState("done");
+  };
+
+  return (
+    <main className="mx-auto flex min-h-[100dvh] w-full max-w-md flex-col px-6 py-10">
+      <h1 className="text-[22px] font-bold text-[var(--foreground)]">登出並重置</h1>
+      <p className="mt-2 text-[14px] leading-relaxed text-[var(--secondary-label)]">
+        把這台裝置恢復成「從沒登入過」的狀態。下次進入時會重新選門市、重新用 LINE 登入。
+      </p>
+
+      {state === "idle" && (
+        <>
+          <ul className="card mt-5 space-y-2 p-5 text-[14px] text-[var(--secondary-label)]">
+            <li>· LINE LIFF 的登入狀態</li>
+            <li>· 推播訂閱</li>
+            <li>· 會員登入資料、記住的門市</li>
+            <li>· PWA 快取與 Service Worker</li>
+            <li>· App 圖示上的未讀數</li>
+          </ul>
+          <button
+            onClick={run}
+            className="mt-5 w-full rounded-xl bg-[var(--ios-red)] px-4 py-3.5 text-[16px] font-semibold text-white transition active:scale-[0.98]"
+          >
+            確定登出並清除
+          </button>
+          <a
+            href="/"
+            className="mx-auto mt-4 block text-[14px] font-medium text-[var(--secondary-label)] underline underline-offset-4"
+          >
+            取消，回首頁
+          </a>
+        </>
+      )}
+
+      {state === "running" && (
+        <div className="card mt-5 flex flex-col items-center gap-3 p-8">
+          <Spinner size={28} />
+          <p className="text-[15px] text-[var(--secondary-label)]">清除中…</p>
+        </div>
+      )}
+
+      {state === "done" && (
+        <>
+          <ul className="card mt-5 space-y-2.5 p-5">
+            {steps.map((s, i) => (
+              <li key={i} className="flex gap-2 text-[14px]">
+                <span className={s.ok ? "text-[var(--ios-green,#34c759)]" : "text-[#c4271d]"}>
+                  {s.ok ? "✓" : "✕"}
+                </span>
+                <span className="flex-1">
+                  <span className="text-[var(--foreground)]">{s.label}</span>
+                  {s.detail && (
+                    <span className="block text-[12px] text-[var(--tertiary-label)]">
+                      {s.detail}
+                    </span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <p className="mt-4 text-[13px] leading-relaxed text-[var(--tertiary-label)]">
+            如果這是安裝在桌面的 App，建議把它從多工列滑掉再重開，確保舊的
+            Service Worker 完全結束。
+          </p>
+
+          {/* 用 a 而非 router：要的是完整重新載入，讓剛註銷的 SW 不再接管這一頁 */}
+          <a
+            href="/"
+            className="mt-5 block w-full rounded-xl brand-gradient px-4 py-3.5 text-center text-[16px] font-semibold text-white transition active:scale-[0.98]"
+          >
+            回到首頁重新登入
+          </a>
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -510,6 +510,15 @@ export default function MePage() {
         <p className="px-4 pt-2 text-[12px] text-[var(--tertiary-label)]">
           會員卡 QR、點數等更多功能持續開發中。
         </p>
+
+        {/* 登出放最下面、樣式低調 —— 這是少數人偶爾才需要的動作（換帳號、
+            把裝置交給別人），擺太醒目只會提高誤觸機率 */}
+        <a
+          href="/logout"
+          className="mx-auto block pt-4 text-[14px] font-medium text-[var(--ios-red)] underline underline-offset-4"
+        >
+          登出
+        </a>
       </div>
     </PageShell>
   );

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -12,7 +12,17 @@ import {
 } from "@/lib/clientLog";
 import Spinner, { LoadingScreen } from "@/components/Spinner";
 
-type Status = "loading" | "idle" | "liff_auth" | "pair_done" | "error";
+type Status = "loading" | "idle" | "liff_auth" | "pair_done" | "pwa_waiting" | "error";
+
+/**
+ * 切回 PWA 時「輪詢」領取配對 token，而不是只試一次。
+ *
+ * 使用者關掉 LINE 回到 PWA 的那一瞬間，LIFF 端可能還在寫 pwa_auth_codes。
+ * 只試一次很容易剛好落在寫入完成之前 —— 一旦錯過，在使用者再次切出去切回來
+ * 之前都不會重試，體感就是「自動登入沒用」，只好去打驗證碼。
+ */
+const CLAIM_RETRY_ATTEMPTS = 8;
+const CLAIM_RETRY_DELAY_MS = 1500;
 
 const PAIR_TOKEN_KEY = "pwa_pair_token";
 /** 只允許往 LIFF 彈一次的旗標（sessionStorage），避免 LIFF ↔ 網頁互推無限迴圈 */
@@ -133,6 +143,28 @@ async function tryClaimPairToken(): Promise<boolean> {
   }
 }
 
+/** 同時間只跑一輪輪詢（多次 visibilitychange 不該疊出好幾輪） */
+let claimPolling = false;
+
+async function claimPairTokenWithRetry(): Promise<void> {
+  if (typeof window === "undefined" || claimPolling) return;
+  if (!localStorage.getItem(PAIR_TOKEN_KEY)) return;
+
+  claimPolling = true;
+  try {
+    for (let i = 0; i < CLAIM_RETRY_ATTEMPTS; i++) {
+      // 成功會直接 navigate 到 /shop，不會回到這裡
+      if (await tryClaimPairToken()) return;
+      // 被別的分頁 / 這輪之外的呼叫領走了，或使用者切走了 → 收工
+      if (!localStorage.getItem(PAIR_TOKEN_KEY)) return;
+      if (document.visibilityState !== "visible") return;
+      await new Promise((r) => setTimeout(r, CLAIM_RETRY_DELAY_MS));
+    }
+  } finally {
+    claimPolling = false;
+  }
+}
+
 type StoreOption = { id: number; code: string; name: string };
 
 export default function LandingPage() {
@@ -145,6 +177,8 @@ export default function LandingPage() {
   /** 在 LINE 內建瀏覽器又沒有 LIFF context = 無路可走，改給外部瀏覽器指引 */
   const [lineStuck, setLineStuck] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
+  /** 驗證碼是退路，預設收起來，不跟「用 LINE 登入」並列 */
+  const [showSyncCode, setShowSyncCode] = useState(false);
   const [reportState, setReportState] = useState<"idle" | "sending" | "sent" | "failed">("idle");
   /** LIFF 已登入但缺門市時留下的 id_token，選完門市直接拿它補完登入 */
   const liffIdTokenRef = useRef<string | null>(null);
@@ -189,9 +223,9 @@ export default function LandingPage() {
       });
 
     // 3. 從 LIFF 配對流程切回 PWA 時，自動 claim
-    void tryClaimPairToken();
+    void claimPairTokenWithRetry();
     const onVis = () => {
-      if (document.visibilityState === "visible") void tryClaimPairToken();
+      if (document.visibilityState === "visible") void claimPairTokenWithRetry();
     };
     document.addEventListener("visibilitychange", onVis);
 
@@ -348,6 +382,9 @@ export default function LandingPage() {
       document.body.appendChild(a);
       a.click();
       a.remove();
+      // 讓使用者知道「回來這裡就會自動完成」，否則切回來看到原本的登入頁
+      // 會以為失敗，就去打驗證碼了
+      setStatus("pwa_waiting");
       return;
     }
 
@@ -411,7 +448,11 @@ export default function LandingPage() {
     }
 
     clearSession();
-    window.location.href = lineOauthStartUrl(storeId);
+    // 帶上 URL 裡的 pair：PWA 把使用者導到瀏覽器登入時（例如 iOS 沒把
+    // liff.line.me 交給 LINE app，而是開在 Safari），pair 會跟著 liff.state 過來。
+    // 不轉交給 OAuth 的話，登入成功後不會寫 pwa_auth_codes，PWA 那端永遠領不到，
+    // 使用者就只剩手動輸入驗證碼一條路 —— 這正是要消滅的情境。
+    window.location.href = lineOauthStartUrl(storeId, readPairFromUrl() ?? undefined);
   };
 
   /**
@@ -516,6 +557,26 @@ export default function LandingPage() {
         {status === "loading" && <LoadingScreen className="py-14" />}
 
         {status === "liff_auth" && <LoadingScreen className="py-14" />}
+
+        {status === "pwa_waiting" && (
+          <div className="card space-y-4 p-6 text-center">
+            <Spinner size={28} />
+            <p className="text-[17px] font-bold text-[var(--foreground)]">
+              請在 LINE 完成登入
+            </p>
+            <p className="text-[14px] leading-relaxed text-[var(--secondary-label)]">
+              完成後關閉 LINE、回到這個 App，我們會自動帶您進入。
+              <br />
+              不需要輸入任何驗證碼。
+            </p>
+            <button
+              onClick={() => setStatus("idle")}
+              className="text-[14px] font-medium text-[var(--secondary-label)] underline underline-offset-4"
+            >
+              返回
+            </button>
+          </div>
+        )}
 
         {status === "pair_done" && (
           <div className="card p-6 text-center">
@@ -645,22 +706,25 @@ export default function LandingPage() {
                   )}
                 </div>
 
-                {standalone && (
-                  <>
-                    <div className="relative">
-                      <div className="absolute inset-0 flex items-center">
-                        <span className="w-full border-t border-[var(--separator)]" />
-                      </div>
-                      <div className="relative flex justify-center">
-                        <span className="bg-[var(--background)] px-3 text-[12px] font-medium text-[var(--tertiary-label)]">
-                          或者
-                        </span>
-                      </div>
-                    </div>
+                {/* 驗證碼是「自動配對失敗」時的救命繩，不是並列的登入選項。
+                    平鋪出來會讓會員以為登入本來就要打一組碼 —— 而那段流程
+                    （自己先去瀏覽器登入、記下 6 碼、切回來輸入）對一般人根本走不完。
+                    預設收起來，只有真的卡住的人才會展開。 */}
+                {standalone && !showSyncCode && (
+                  <button
+                    onClick={() => setShowSyncCode(true)}
+                    className="mx-auto block text-[13px] text-[var(--tertiary-label)] underline underline-offset-4"
+                  >
+                    登入遇到問題？用驗證碼手動同步
+                  </button>
+                )}
 
+                {standalone && showSyncCode && (
+                  <>
                     <div className="card space-y-3 p-5">
                       <p className="text-[14px] text-[var(--secondary-label)]">
-                        如果您已在瀏覽器登入，請輸入驗證碼：
+                        僅在自動登入失敗時需要：請先用手機瀏覽器開啟本站登入，
+                        再把該畫面顯示的 6 位數驗證碼輸入這裡。
                       </p>
                       <form onSubmit={handleSyncSubmit} className="flex gap-2">
                         <input

--- a/apps/member/src/lib/logout.ts
+++ b/apps/member/src/lib/logout.ts
@@ -1,0 +1,93 @@
+// 完整登出 —— 把這台裝置恢復成「從沒登入過」的狀態。
+//
+// 為什麼不能只 clearSession()：會員端的狀態散在五個地方，漏掉任何一個，
+// 下次登入就會撈到上一輪的殘留（最典型的是 LIFF 自己記著已登入，
+// 於是「登出」後一進 LINE 又用舊帳號自動登入，看起來像登出失敗）。
+//
+// 主要用途是測試與換帳號，所以寧可清過頭：這裡清掉的東西全都能重新取得。
+
+import { clearSession } from "./session";
+import { initLiff } from "./liff";
+import { setAppBadgeCount } from "./appBadge";
+import { clearLocalLogs } from "./clientLog";
+
+/** 一步一步回報進度，讓 /logout 頁面能顯示到底清了什麼 */
+export type LogoutStep = { label: string; ok: boolean; detail?: string };
+
+/** clearSession() 管不到、但會影響下次登入的 localStorage key */
+const EXTRA_LOCAL_KEYS = [
+  "last_store_id",     // 記住的門市 —— 不清的話下次直接跳過選店
+  "pwa_pair_token",    // 上一輪沒領完的 PWA 配對 token
+  "sw_register_error", // service worker 註冊失敗的紀錄
+];
+
+/** 往 LIFF 彈過一次的旗標（sessionStorage） */
+const SESSION_KEYS = ["liff_login_retry"];
+
+export async function hardLogout(): Promise<LogoutStep[]> {
+  const steps: LogoutStep[] = [];
+  const run = async (label: string, fn: () => Promise<string | void> | string | void) => {
+    try {
+      const detail = await fn();
+      steps.push({ label, ok: true, detail: detail || undefined });
+    } catch (e) {
+      steps.push({ label, ok: false, detail: e instanceof Error ? e.message : String(e) });
+    }
+  };
+
+  // 1) LIFF 的登入狀態 —— 最容易漏掉的一個。
+  //    不呼叫 liff.logout()，下次在 LINE 裡開就會直接用舊帳號自動登入，
+  //    使用者會覺得「明明登出了卻還是原本的人」。
+  await run("清除 LINE LIFF 登入狀態", async () => {
+    const liff = await initLiff();
+    if (!liff) return "未設定 LIFF 或不在 LIFF 環境，略過";
+    if (!liff.isLoggedIn()) return "本來就未登入";
+    liff.logout();
+    return "已呼叫 liff.logout()";
+  });
+
+  // 2) 推播訂閱 —— 不退訂的話，換帳號後這台裝置還會收到前一個帳號的通知
+  await run("取消推播訂閱", async () => {
+    if (!("serviceWorker" in navigator)) return "此瀏覽器不支援，略過";
+    const reg = await navigator.serviceWorker.getRegistration();
+    const sub = await reg?.pushManager?.getSubscription();
+    if (!sub) return "沒有訂閱";
+    await sub.unsubscribe();
+    return "已退訂";
+  });
+
+  // 3) 會員 session 與其他 localStorage 殘留
+  await run("清除登入資料", () => {
+    clearSession();
+    EXTRA_LOCAL_KEYS.forEach((k) => localStorage.removeItem(k));
+    clearLocalLogs();
+    return `含門市、配對 token、錯誤紀錄`;
+  });
+
+  await run("清除暫存旗標", () => {
+    SESSION_KEYS.forEach((k) => sessionStorage.removeItem(k));
+  });
+
+  // 4) 桌面圖示上的未讀數
+  await run("清除 App 圖示未讀數", async () => {
+    await setAppBadgeCount(0);
+  });
+
+  // 5) PWA 快取與 service worker。
+  //    放最後：unregister 之後這一頁就沒有 SW 了，前面幾步若還需要它會失敗。
+  await run("清除 PWA 快取", async () => {
+    if (typeof caches === "undefined") return "此瀏覽器不支援，略過";
+    const keys = await caches.keys();
+    await Promise.all(keys.map((k) => caches.delete(k)));
+    return keys.length ? `${keys.length} 組快取` : "沒有快取";
+  });
+
+  await run("註銷 Service Worker", async () => {
+    if (!("serviceWorker" in navigator)) return "此瀏覽器不支援，略過";
+    const regs = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(regs.map((r) => r.unregister()));
+    return regs.length ? `${regs.length} 個` : "沒有註冊";
+  });
+
+  return steps;
+}


### PR DESCRIPTION
接續 #596。兩件事：讓 PWA 登入真的不需要驗證碼，以及補上一直缺席的登出功能。

---

## 1. PWA 單純用 LINE 登入，免驗證碼

驗證碼本來只是自動配對失敗時的救命繩。但 `pwa_auth_codes` 從 2026-05-18 至今 **502 筆全是 6 碼、一筆自動配對 token 都沒有** —— 等於自動配對從沒成功過，會員被迫走「自己先去瀏覽器登入、記下 6 碼、切回來輸入」這條一般人根本走不完的流程。

主因（LIFF endpoint 跨網域導致 pair 在 `/orders` 的 `router.replace("/")` 遺失）已於 #593 / #594 修掉。本 PR 補剩下三個仍會讓人掉回驗證碼的破口：

**① 切回 PWA 只 claim 一次 → 改輪詢（8 次 × 1.5s）**
使用者關掉 LINE 回來的瞬間，LIFF 端可能還在寫 `pwa_auth_codes`。單次嘗試很容易落在寫入完成之前，一旦錯過，在使用者再次切出去切回來之前都不會重試 —— 體感就是「自動登入沒用」。同時只跑一輪，頁面切走就收工。

**② 掉到瀏覽器時 OAuth 沒帶 pair → 補上**
iOS 若沒把 `liff.line.me` 交給 LINE app 而是開在 Safari，pair 會跟著 `liff.state` 過來，但原本的 OAuth 分支沒轉交，登入成功也不會寫 `pwa_auth_codes`，PWA 那端永遠領不到。

**③ 按下登入後畫面沒反應 → 加等待狀態**
原本按了之後畫面完全不變（只是背景開了 LINE）。切回來看到同一個登入頁自然以為失敗，就去找驗證碼了。改為明確顯示「完成後回到這個 App 會自動帶您進入，不需要輸入任何驗證碼」。

**另**：驗證碼區塊從與登入按鈕並列改為預設收合的小字連結，文案點明「僅在自動登入失敗時需要」。預設畫面只剩一顆「用 LINE 登入」。

---

## 2. `/logout` — 一鍵回到「從沒登入過」的狀態

原本完全沒有登出功能。測試登入流程只能手動清瀏覽器資料，而且很容易漏掉 LIFF 那份 —— 於是「清乾淨」後一進 LINE 又用舊帳號自動登入，看起來像登入流程有問題，其實是殘留。

會員端狀態散在五個地方，漏一個下次登入就會撈到上一輪的殘留：

| 項目 | 不清的後果 |
|---|---|
| **LINE LIFF 登入狀態**（`liff.logout()`） | LINE 內直接用舊帳號自動登入 ← 最容易漏 |
| **推播訂閱** | 換帳號後仍收到前一個帳號的通知 |
| localStorage | session 六個 key + `last_store_id` / `pwa_pair_token` / `sw_register_error` / `client_error_log` |
| sessionStorage | `liff_login_retry` |
| PWA 快取 / Service Worker / App 圖示未讀數 | 載到舊版程式、桌面殘留舊帳號數字 |

**設計**
- 逐步執行並回報每一步結果，卡在哪一步一眼看得出來
- SW 註銷放最後 —— 之後這一頁就沒有 SW 了，前面幾步若還需要它會失敗
- 做成獨立路徑（直接開 `/logout`）讓測試可重複；但**不在載入時自動清** —— 誤觸或網址被轉傳會直接把人登出，改為先列出會清什麼、按下才執行
- `/me` 底部加低調入口（少數人偶爾才需要，擺醒目只會提高誤觸）

已交叉比對 `session.ts` / `clientLog` / `appBadge` 及各處直接呼叫的所有 storage key，確認無遺漏。

---

## 驗證

- `tsc --noEmit`、`next build --webpack` 通過，`/logout` 路由正常產出
- claim 端實測：36 字元配對 token 可正常領取、回傳完整 session、領完即刪
- ⚠️ **寫入端只能真機驗證** —— 需要真實 LINE id_token，無法在此環境模擬

## 合併後請實測

PWA 按綠色「用 LINE 登入」→ 在 LINE 完成 → 關掉 LINE 回 PWA → **預期自動進入商店頁，全程不需輸入驗證碼**。

沒成功的話查 `pwa_auth_codes` 有無 36 字元那筆：有 = 領取端問題，沒有 = LIFF 寫入端問題，可直接定位。

## 已知遺留

登出不會刪 DB 裡的 `push_subscriptions`（endpoint 已失效，推播送過去會失敗）—— 登出後就沒有 token 可呼叫後端，要做得在登出前先打一支 API，判斷不值得為此多一個失敗點。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC)_