### PR TITLE
fix(member): PWA 按登入後 LINE 沒開起來 — 改直接導航，不用 target=_blank

### DIFF
--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -511,11 +511,13 @@ export default function MePage() {
           會員卡 QR、點數等更多功能持續開發中。
         </p>
 
-        {/* 登出放最下面、樣式低調 —— 這是少數人偶爾才需要的動作（換帳號、
-            把裝置交給別人），擺太醒目只會提高誤觸機率 */}
+        {/* 登出仍放最下面（少數人偶爾才需要），但要點得到：
+            原本的 mx-auto 對全寬 block 不生效，變成靠左的一行小字，
+            又緊貼底部 tab bar，實際上很難按。改成明確的按鈕。
+            用外框而非實心紅 —— 要好按，但不該比頁面主要動作更搶眼。 */}
         <a
           href="/logout"
-          className="mx-auto block pt-4 text-[14px] font-medium text-[var(--ios-red)] underline underline-offset-4"
+          className="mt-2 block w-full rounded-xl border border-[var(--ios-red)]/35 bg-[var(--ios-red)]/[0.06] px-4 py-3.5 text-center text-[16px] font-semibold text-[var(--ios-red)] transition active:scale-[0.98]"
         >
           登出
         </a>

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -179,6 +179,8 @@ export default function LandingPage() {
   const [linkCopied, setLinkCopied] = useState(false);
   /** 驗證碼是退路，預設收起來，不跟「用 LINE 登入」並列 */
   const [showSyncCode, setShowSyncCode] = useState(false);
+  /** PWA 等待畫面用：LINE 沒自動開起來時讓使用者手動再開一次 */
+  const [pwaLoginUrl, setPwaLoginUrl] = useState<string | null>(null);
   const [reportState, setReportState] = useState<"idle" | "sending" | "sent" | "failed">("idle");
   /** LIFF 已登入但缺門市時留下的 id_token，選完門市直接拿它補完登入 */
   const liffIdTokenRef = useRef<string | null>(null);
@@ -375,16 +377,29 @@ export default function LandingPage() {
         ? liffAppUrl(liffId, storeId, token)
         : lineOauthStartUrl(storeId, token);
 
-      const a = document.createElement("a");
-      a.href = targetUrl;
-      a.target = "_blank";
-      a.rel = "noopener noreferrer";
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
+      // ⚠️ 這裡**不要**用 a.target="_blank"。
+      // iOS 的 standalone PWA 對程式化開新視窗不可靠：可能靜默失敗（畫面
+      // 停在等待、LINE 根本沒開），也可能開到 Safari —— 那更糟，登入完成後
+      // session 進的是 Safari，PWA 這端永遠領不到。
+      // 2026-08-03 實測就是卡在這：等待畫面出現，但 pwa_auth_codes 與
+      // client_error_logs 全無紀錄，代表 LINE 那端根本沒被開起來。
+      //
+      // 直接導航兩種結果都走得通：
+      //   1. iOS 攔截 universal link → 開 LINE，PWA 留在背景、頁面沒變，
+      //      切回來時 visibilitychange 觸發領取
+      //   2. 沒被攔截 → 在 PWA 內走到本站（liff.state 帶著 store 與 pair），
+      //      整段登入就在 PWA 內完成，session 直接落地，連配對都不需要
+      setPwaLoginUrl(targetUrl);
+      logClientError(
+        "pwa_login_started",
+        "PWA 觸發 LINE 登入",
+        { store: storeId, via: liffId ? "liff" : "oauth" },
+        "info",
+      );
       // 讓使用者知道「回來這裡就會自動完成」，否則切回來看到原本的登入頁
       // 會以為失敗，就去打驗證碼了
       setStatus("pwa_waiting");
+      window.location.href = targetUrl;
       return;
     }
 
@@ -569,6 +584,16 @@ export default function LandingPage() {
               <br />
               不需要輸入任何驗證碼。
             </p>
+            {/* LINE 沒被開起來時的自救 —— 沒有這顆就只能乾等，
+                而使用者無從判斷是「還沒好」還是「根本沒開」 */}
+            {pwaLoginUrl && (
+              <a
+                href={pwaLoginUrl}
+                className="block w-full rounded-xl bg-[#06C755] px-4 py-3 text-[15px] font-semibold text-white transition active:scale-[0.98]"
+              >
+                LINE 沒有開啟？點這裡再試一次
+              </a>
+            )}
             <button
               onClick={() => setStatus("idle")}
               className="text-[14px] font-medium text-[var(--secondary-label)] underline underline-offset-4"


### PR DESCRIPTION
接續 #598。#598 讓等待畫面出現了，但實測發現 LINE 那端**根本沒被開起來**。

## 現象與證據

PWA 顯示「請在 LINE 完成登入」等待畫面後就卡住。查該時段：

- `pwa_auth_codes` — 沒有任何配對 token（36 字元）
- `client_error_logs` — 一片空白

寫入端或領取端若失敗，至少會留下痕跡。**兩邊都毫無紀錄，代表 LINE 根本沒被開起來** —— 使用者是在等一個不存在的東西。

## 原因

`a.target="_blank"` 在 iOS 的 standalone PWA 不可靠：

- 可能靜默失敗（畫面停在等待、什麼都沒發生）← 本次實測的情況
- 也可能開到 Safari —— 那更糟，登入完成後 session 進的是 Safari，PWA 這端永遠領不到，使用者又被逼回驗證碼

## 修法

改用 `window.location.href` 直接導航。**兩種結果都走得通**，最差情況（開到 Safari）被消除：

1. iOS 攔截 universal link → 開 LINE，PWA 留在背景、頁面沒變，切回來時 `visibilitychange` 觸發領取
2. 沒被攔截 → 在 PWA 內走到本站（`liff.state` 帶著 store 與 pair），整段登入在 PWA 內完成，session 直接落地，**連配對機制都不需要**

## 另加兩項

**等待畫面加「LINE 沒有開啟？點這裡再試一次」** —— 沒有這顆就只能乾等，而使用者無從判斷是「還沒好」還是「根本沒開」。

**記一筆 `pwa_login_started`** —— 這次查不出原因正是因為這段完全沒有痕跡。有了它，之後才分得出「使用者沒按到」與「按了但沒開起來」。

## 驗證

- 確認已無 `target = "_blank"`
- `tsc --noEmit`、`next build --webpack` 通過
- ⚠️ iOS PWA 的 universal link 攔截行為只能真機驗證，無法在此環境模擬

## 合併後請測

PWA 按「用 LINE 登入」→ 觀察 LINE 是否被開起來 → 完成登入 → 關掉 LINE 回 PWA → 預期自動進入商店頁。

若仍卡住，這次會留下 `pwa_login_started`，可據此判斷卡在哪一段。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC)_