### PR TITLE
fix(member): 配對碼被 liff.login() 沖掉 — PWA 自動登入的真正卡點

### DIFF
--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -399,7 +399,25 @@ export default function LandingPage() {
       // 讓使用者知道「回來這裡就會自動完成」，否則切回來看到原本的登入頁
       // 會以為失敗，就去打驗證碼了
       setStatus("pwa_waiting");
-      window.location.href = targetUrl;
+
+      // 先試開新視窗：iOS 只有這樣才會建立返回鏈，LINE 左上角才會出現
+      // 「◀ 包子媽生鮮小舖」讓使用者一鍵回來。直接用 location.href 導航雖然
+      // 一定開得起來，卻沒有那條返回鏈 —— 使用者就回不到 PWA 了。
+      //
+      // 但 standalone PWA 的 window.open 有時會靜默失敗，所以不靠回傳值判斷
+      // （iOS 可能回一個沒真的開起來的 window），改看「頁面有沒有進背景」：
+      // 真的開起來了，這個頁面就會被切到背景。
+      window.open(targetUrl, "_blank");
+      window.setTimeout(() => {
+        if (document.visibilityState !== "visible") return;
+        logClientError(
+          "pwa_login_open_fallback",
+          "window.open 沒開起來，改直接導航",
+          { store: storeId },
+          "warn",
+        );
+        window.location.href = targetUrl;
+      }, 2000);
       return;
     }
 
@@ -580,10 +598,16 @@ export default function LandingPage() {
               請在 LINE 完成登入
             </p>
             <p className="text-[14px] leading-relaxed text-[var(--secondary-label)]">
-              完成後關閉 LINE、回到這個 App，我們會自動帶您進入。
-              <br />
-              不需要輸入任何驗證碼。
+              完成後請回到本 App，我們會自動帶您進入，不需要輸入任何驗證碼。
             </p>
+            {/* iOS 從 LINE 回來的路不只一條，而使用者不見得找得到 —— 明講兩種 */}
+            <div className="w-full rounded-xl bg-[var(--fill-quaternary,rgba(120,120,128,0.08))] p-3 text-left text-[13px] leading-relaxed text-[var(--secondary-label)]">
+              回來的方式：
+              <br />
+              1. 點 LINE 畫面左上角的「◀ 包子媽生鮮小舖」
+              <br />
+              2. 或關閉 LINE，從手機桌面重新點開本 App
+            </div>
             {/* LINE 沒被開起來時的自救 —— 沒有這顆就只能乾等，
                 而使用者無從判斷是「還沒好」還是「根本沒開」 */}
             {pwaLoginUrl && (
@@ -609,8 +633,13 @@ export default function LandingPage() {
               ✓
             </div>
             <p className="mt-3 text-[17px] font-bold text-[var(--foreground)]">登入完成</p>
-            <p className="mt-1 text-[14px] text-[var(--secondary-label)]">
-              請關閉 LINE 視窗，回到桌面點擊 PWA 圖示。
+            {/* 「PWA 圖示」是黑話，會員看不懂；而且回去的路有兩條，都要講 */}
+            <p className="mt-2 text-left text-[14px] leading-relaxed text-[var(--secondary-label)]">
+              請回到「包子媽生鮮小舖」App：
+              <br />
+              1. 點左上角的「◀ 包子媽生鮮小舖」
+              <br />
+              2. 或關閉 LINE，從手機桌面重新點開本 App
             </p>
           </div>
         )}

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -892,6 +892,20 @@ async function runLiffSession(
     );
   }
 
+  // 記錄配對鑰匙有沒有真的寄存到遠端 —— PWA 那端輪詢領不到時，
+  // 靠這筆才分得出是「根本沒寫進去」還是「寫了但沒領到」
+  logClientError(
+    "liff_session_ok",
+    `liff-session 完成（pair_written=${String((data as { pair_written?: unknown }).pair_written)}）`,
+    {
+      has_pair: Boolean(pairCode),
+      pair_written: (data as { pair_written?: unknown }).pair_written ?? null,
+      pair_error: (data as { pair_error?: unknown }).pair_error ?? null,
+      store: storeId,
+    },
+    "info",
+  );
+
   // 若是 PWA pairing 流程,session 已經寫進 pwa_auth_codes,
   // 這裡 LIFF 端不需要也不應該跳到 /me（user 應該回 PWA）。
   if (pairCode) {

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -94,6 +94,34 @@ function liffStateParams(raw: string): URLSearchParams {
   return new URLSearchParams(q >= 0 ? raw.slice(q + 1) : raw);
 }
 
+/** 本次瀏覽暫存的配對碼（URL 被沖掉後還讀得到） */
+const PAIR_PENDING_KEY = "pending_pair_code";
+
+/**
+ * 取配對碼：URL 優先，其次是本 context 稍早存下的那份。
+ *
+ * 為什麼一定要備份：liff.login() 導去 LINE 再回來時，URL 上的 liff.state
+ * （裡面才有 pair）會被 LIFF 換成 `?code=...&liffClientId=...`，pair 就此消失。
+ * 於是登入是成功了，卻不會寫 pwa_auth_codes，PWA 那端永遠領不到 ——
+ * 2026-08-03 實測「手動回到 PWA 還是停在等待畫面」的卡點就在這裡。
+ *
+ * 用 sessionStorage 而非 localStorage：配對碼只在這一趟登入有意義，
+ * 留到下次瀏覽只會拿舊碼去領一個早就過期的 session。
+ */
+function resolvePairCode(): string | null {
+  if (typeof window === "undefined") return null;
+  const fromUrl = readPairFromUrl();
+  if (fromUrl) {
+    try { sessionStorage.setItem(PAIR_PENDING_KEY, fromUrl); } catch { /* noop */ }
+    return fromUrl;
+  }
+  try { return sessionStorage.getItem(PAIR_PENDING_KEY); } catch { return null; }
+}
+
+function clearPendingPairCode() {
+  try { sessionStorage.removeItem(PAIR_PENDING_KEY); } catch { /* noop */ }
+}
+
 function readPairFromUrl(): string | null {
   if (typeof window === "undefined") return null;
   const sp = new URLSearchParams(window.location.search);
@@ -241,6 +269,10 @@ export default function LandingPage() {
 
       const liffId = process.env.NEXT_PUBLIC_LIFF_ID;
 
+      // 一進頁面就把配對碼備份起來 —— 必須趕在 liff.login() 把 URL 上的
+      // liff.state 換成 ?code=... 之前，否則這趟 PWA 配對就再也接不回去了
+      resolvePairCode();
+
       // 讀門市
       let s = readStore();
       if (!s && typeof window !== "undefined") {
@@ -279,11 +311,11 @@ export default function LandingPage() {
                 logClientError(
                   "liff_auto_login_failed",
                   "LIFF isInClient 但 isLoggedIn=false，重開 LIFF 重試一次",
-                  { store: s, has_pair: Boolean(readPairFromUrl()) },
+                  { store: s, has_pair: Boolean(resolvePairCode()) },
                   "warn",
                 );
                 setSessionFlag(LIFF_RETRY_KEY);
-                window.location.href = liffAppUrl(liffId, s, readPairFromUrl());
+                window.location.href = liffAppUrl(liffId, s, resolvePairCode());
                 return;
               }
               logClientError(
@@ -307,7 +339,7 @@ export default function LandingPage() {
               throw new Error("LIFF getIDToken returned null");
             }
 
-            const pairCode = readPairFromUrl();
+            const pairCode = resolvePairCode();
             try {
               // 沒帶 store 也試 — 後端會用 line_user_id 找既有 binding
               await runLiffSession(idToken, s, pairCode);
@@ -426,7 +458,7 @@ export default function LandingPage() {
     const pendingIdToken = liffIdTokenRef.current;
     if (pendingIdToken) {
       setStatus("liff_auth");
-      runLiffSession(pendingIdToken, storeId, readPairFromUrl()).catch((e) => {
+      runLiffSession(pendingIdToken, storeId, resolvePairCode()).catch((e) => {
         logCaught("liff_session_retry_failed", e, { store: storeId });
         setError(e instanceof Error ? e.message : String(e));
         setStatus("idle");
@@ -442,7 +474,7 @@ export default function LandingPage() {
       const idToken = safe(() => liff.getIDToken());
       if (idToken) {
         setStatus("liff_auth");
-        runLiffSession(idToken, storeId, readPairFromUrl()).catch((e) => {
+        runLiffSession(idToken, storeId, resolvePairCode()).catch((e) => {
           logCaught("liff_session_retry_failed", e, { store: storeId });
           setError(e instanceof Error ? e.message : String(e));
           setStatus("idle");
@@ -485,7 +517,7 @@ export default function LandingPage() {
     // liff.line.me 交給 LINE app，而是開在 Safari），pair 會跟著 liff.state 過來。
     // 不轉交給 OAuth 的話，登入成功後不會寫 pwa_auth_codes，PWA 那端永遠領不到，
     // 使用者就只剩手動輸入驗證碼一條路 —— 這正是要消滅的情境。
-    window.location.href = lineOauthStartUrl(storeId, readPairFromUrl() ?? undefined);
+    window.location.href = lineOauthStartUrl(storeId, resolvePairCode() ?? undefined);
   };
 
   /**
@@ -862,7 +894,12 @@ async function runLiffSession(
 
   // 若是 PWA pairing 流程,session 已經寫進 pwa_auth_codes,
   // 這裡 LIFF 端不需要也不應該跳到 /me（user 應該回 PWA）。
-  if (pairCode) return;
+  if (pairCode) {
+    // 已經交棒給 PWA 了，備份就該清掉 —— 留著只會讓這個 context 之後
+    // 又拿同一組碼去寫一次，覆蓋掉 PWA 可能已經領走的那筆
+    clearPendingPairCode();
+    return;
+  }
 
   const frag = new URLSearchParams({
     token:        String(data.token),

--- a/supabase/functions/liff-session/index.ts
+++ b/supabase/functions/liff-session/index.ts
@@ -125,6 +125,15 @@ Deno.serve(async (req) => {
 
     // 若帶了 pair_code（PWA 主動觸發 LIFF 登入流程），把 session 寫進 pwa_auth_codes
     // 讓 PWA 切回桌面後可以用該 code claim 拿回 session。
+    // pair_written 回給前端是為了可觀測性：
+    //   null  = 這趟根本沒帶 pair 進來（PWA 配對的鑰匙在路上就掉了）
+    //   false = 有帶但寫入失敗
+    //   true  = 已寫入，PWA 那端輪詢就領得到
+    // 少了這個欄位，「沒被呼叫」與「呼叫了但失敗」在外面看起來一模一樣，
+    // 只能靠猜 —— 2026-08-03 查這個問題就卡在這裡。
+    let pairWritten: boolean | null = null;
+    let pairError: string | null = null;
+
     if (pairCode && pairCode.length >= 8 && pairCode.length <= 64) {
       const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
       const insertResp = await fetch(`${supabaseUrl}/rest/v1/pwa_auth_codes`, {
@@ -142,13 +151,17 @@ Deno.serve(async (req) => {
           expires_at: expiresAt,
         }),
       });
+      pairWritten = insertResp.ok;
       if (!insertResp.ok) {
-        console.error("pwa_auth_codes insert failed", insertResp.status, await insertResp.text());
+        pairError = `${insertResp.status}: ${(await insertResp.text()).slice(0, 200)}`;
+        console.error("pwa_auth_codes insert failed", pairError);
         // 不擋使用者，繼續回 session 給 LIFF 端
       }
     }
 
-    return json(sessionPayload);
+    // 注意：pair_written / pair_error 只回給前端，不能混進 sessionPayload ——
+    // 那份會原封不動存進 pwa_auth_codes 再交給 PWA 當 session 用
+    return json({ ...sessionPayload, pair_written: pairWritten, pair_error: pairError });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     console.error("liff-session error:", msg);


### PR DESCRIPTION
接續 #599。這次靠 log 定位到 PWA 自動配對**從 2026-05-18 上線起就沒成功過**的真正原因。

---

## 根因：鑰匙在半路掉了

`client_error_logs` 的證據鏈：

| 紀錄 | 值 | 說明 |
|---|---|---|
| `pwa_login_started` × 3 | `standalone: true` | PWA 有按下登入，LINE 也開起來了 |
| `liff_login_from_line_browser` | `standalone: false`、**`in_liff: false`** | LINE 是用**內建瀏覽器**載入本站，需要跑一次 `liff.login()` |
| `pwa_auth_codes` | **全空** | 從沒寫入 |

問題就在那一次 `liff.login()`：導去 LINE 再回來時，URL 上的 `liff.state`（**裡面才有 pair**）被 LIFF 換成 `?code=...&liffClientId=...`，pair 就此消失。

而程式裡六個讀 pair 的地方全是 `readPairFromUrl()` —— 回來後一律拿到 `null`。於是**登入確實成功了，卻不會寫 `pwa_auth_codes`**，PWA 那端永遠領不到，使用者手動回到 PWA 也只會看到同一個等待畫面。

這也解釋了為什麼 `pwa_auth_codes` 至今 500+ 筆全是人工 6 碼、一筆自動配對 token 都沒有。

## 修法

`resolvePairCode()`：URL 優先，沒有就讀本 context 稍早存下的備份。

- **頁面一 mount 就先備份**，趕在 `liff.login()` 沖掉 URL 之前
- 六個讀取點全部改用它
- 存 `sessionStorage` 而非 `localStorage` —— 配對碼只在這趟登入有意義，留到下次瀏覽只會拿舊碼去領一個早就過期的 session
- 交棒給 PWA 後清掉備份，避免同一組碼被重複寫入、覆蓋掉 PWA 可能已經領走的那筆

---

## 一併帶進來的兩項

### 1. 恢復開新視窗以保住 iOS 返回鏈

#599 把 `target=_blank` 改成 `location.href` 解決了「LINE 沒開起來」，卻弄丟了返回鏈 —— iOS 只有透過開新視窗才會在 LINE 左上角放「◀ 包子媽生鮮小舖」，直接導航則沒有，使用者到了 LINE 就回不去。

改成兩者兼顧：先 `window.open` 保住返回鏈，沒開起來才退回直接導航。判斷依據不用 `window.open` 的回傳值（iOS 可能回一個沒真的開起來的 window），改看 2 秒後「頁面有沒有進背景」。退回導航時記一筆 `pwa_login_open_fallback`。

文案一併修：「PWA 圖示」是黑話會員看不懂，改成「從手機桌面重新點開本 App」；回去的路有兩條（左上角返回鏈／桌面圖示），兩條都明講。

### 2. `liff-session` 回報配對鑰匙是否真的寄存成功

查這個問題時卡住的原因是：寫入失敗只有 `console.error`（我們看不到），**成功時毫無紀錄** —— 「沒被呼叫」與「呼叫了但失敗」從外面看起來一模一樣，只能猜。

回應加 `pair_written` / `pair_error`：

| 值 | 意義 |
|---|---|
| `null` | 這趟根本沒帶 pair 進來（鑰匙在路上就掉了） |
| `false` | 有帶但寫入失敗，`pair_error` 有原因 |
| `true` | 已寫入，PWA 那端輪詢就領得到 |

前端收到後記一筆 `liff_session_ok`。這兩個欄位刻意不混進 `sessionPayload` —— 那份會原封不動存進 `pwa_auth_codes` 再交給 PWA 當 session 用。

**已部署 liff-session v18 ACTIVE**（後端這半邊不必等 merge）。

---

## 驗證

- `tsc --noEmit`、`next build --webpack` 通過
- 確認 diff 不刪除任何檔案
- claim 端先前已實測：36 字元配對 token 可正常領取、領完即刪
- ⚠️ 寫入端仍需真機驗證（需要真實 LINE id_token）

## 合併後這樣測

PWA 按「用 LINE 登入」→ 在 LINE 完成 → 回 PWA。預期自動進入商店頁。

若仍卡住，這次可直接定位而不必推測：

| `client_error_logs` 狀況 | 結論 |
|---|---|
| 沒有 `liff_session_ok` | LIFF 端沒跑完登入 |
| `pair_written: null` | 鑰匙仍掉了，往前查 |
| `pair_written: false` | 寫入被拒，看 `pair_error` |
| `pair_written: true` 但沒進去 | 這才輪到領取端 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC)_