### PR TITLE
fix(member): LIFF 登入不用按兩次 + /install 一鍵用瀏覽器開啟

### DIFF
--- a/apps/member/src/app/install/page.tsx
+++ b/apps/member/src/app/install/page.tsx
@@ -86,6 +86,34 @@ export default function InstallPage() {
     setTimeout(() => setCopyMsg(null), 4000);
   };
 
+  /**
+   * 直接把這一頁丟給系統的預設瀏覽器開啟。
+   *
+   * 「複製網址 → 自己去開 Safari → 貼上」對一般會員來說步驟太多，
+   * 掉在中間任何一步就裝不成。這裡改成一個按鈕：
+   *   iOS      x-safari-https://… （iOS 專用 scheme，可從 in-app browser 跳出去）
+   *   Android  intent://…#Intent;scheme=https;end（不指定 package，交給系統選預設瀏覽器）
+   *
+   * 兩者都不是保證會成功的 API（LINE 各版本行為不一），所以不能只做這條：
+   * 用「頁面有沒有進背景」判斷有沒有真的跳走，沒跳走就自動退回複製 +
+   * 顯示原本的手動步驟，使用者不會卡在一顆沒反應的按鈕上。
+   */
+  const openInBrowser = () => {
+    const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent);
+    const target = isIos
+      ? `x-safari-${pageUrl}`
+      : `intent://${pageUrl.replace(/^https?:\/\//, "")}#Intent;scheme=https;end`;
+
+    setCopyMsg("正在開啟瀏覽器…");
+    window.location.href = target;
+
+    // 沒跳走 = 這個 scheme 在此環境無效，退回複製那條路
+    window.setTimeout(() => {
+      if (document.visibilityState !== "visible") return;
+      void copyUrl();
+    }, 1500);
+  };
+
   return (
     <main className="mx-auto flex min-h-[100dvh] w-full max-w-md flex-col items-center px-5 pt-10 pb-12">
       {/* 品牌 header */}
@@ -133,22 +161,24 @@ export default function InstallPage() {
           </p>
           <div className="mt-4 space-y-3">
             <Step n={1}>
-              點下方按鈕複製網址
+              點下方按鈕，用 Safari 開啟這一頁
             </Step>
             <Step n={2}>
-              {env === "ios-line"
-                ? "點右上角 ⋯ → 「在 Safari 中開啟」(或長按貼到 Safari 網址列)"
-                : "切到 Safari → 網址列長按 → 貼上"}
-            </Step>
-            <Step n={3}>
               到 Safari 後,按下方分享按鈕 → 加入主畫面
             </Step>
           </div>
           <button
-            onClick={copyUrl}
+            onClick={openInBrowser}
             className="mt-5 w-full rounded-full bg-[#007aff] py-3 text-[16px] font-semibold text-white active:opacity-80"
           >
-            複製網址
+            用 Safari 開啟
+          </button>
+          {/* 上面那顆用的 scheme 不保證每個 LINE 版本都吃，留原本的手動路當退路 */}
+          <button
+            onClick={copyUrl}
+            className="mt-2 w-full rounded-full border border-zinc-300 py-2.5 text-[14px] font-medium text-zinc-600 active:opacity-70"
+          >
+            沒反應？改用複製網址
           </button>
           {copyMsg && (
             <p className="mt-2 text-center text-[13px] text-emerald-600">{copyMsg}</p>
@@ -189,14 +219,21 @@ export default function InstallPage() {
             LINE 內建瀏覽器無法安裝 App。請改用 Chrome:
           </p>
           <div className="mt-4 space-y-3">
-            <Step n={1}>點 LINE 視窗右上角 ⋯ → 「在其他應用程式中打開」→ 選 Chrome</Step>
+            <Step n={1}>點下方按鈕，用瀏覽器開啟這一頁</Step>
             <Step n={2}>進入 Chrome 後,看到「安裝 App」按鈕點下去</Step>
           </div>
           <button
-            onClick={copyUrl}
-            className="mt-5 w-full rounded-full bg-[#7676801f] py-3 text-[15px] font-medium text-zinc-700"
+            onClick={openInBrowser}
+            className="mt-5 w-full rounded-full bg-[#007aff] py-3 text-[16px] font-semibold text-white active:opacity-80"
           >
-            或複製網址
+            用瀏覽器開啟
+          </button>
+          {/* intent:// 不保證每個 LINE 版本都吃，留手動路當退路 */}
+          <button
+            onClick={copyUrl}
+            className="mt-2 w-full rounded-full border border-zinc-300 py-2.5 text-[14px] font-medium text-zinc-600 active:opacity-70"
+          >
+            沒反應？改用複製網址
           </button>
           {copyMsg && (
             <p className="mt-2 text-center text-[13px] text-emerald-600">{copyMsg}</p>

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -366,6 +366,34 @@ export default function LandingPage() {
             return;
           }
 
+          // 走到這裡 = 不在 LIFF client（LINE 內建瀏覽器或一般瀏覽器）。
+          //
+          // 但 liff.login() 跑完回來時就是這個狀態：isInClient 仍是 false，
+          // isLoggedIn 卻已經是 true。原本沒有這段，於是登入其實已經完成，
+          // 使用者卻被丟回登入頁、得再按一次「用 LINE 登入」才會真的進去
+          // —— 這就是「LIFF 登入要按兩次」。這裡直接把它補完。
+          if (safe(() => liff.isLoggedIn())) {
+            const idToken = safe(() => liff.getIDToken());
+            if (idToken) {
+              // 缺門市時留給 start()：使用者選完店按一次就能補完，不必重登
+              liffIdTokenRef.current = idToken;
+              if (s) {
+                setStatus("liff_auth");
+                try {
+                  await runLiffSession(idToken, s, resolvePairCode());
+                  return;
+                } catch (e) {
+                  const msg = e instanceof Error ? e.message : String(e);
+                  // store_required 不是錯誤，只是還要選門市
+                  if (!msg.includes("store_required")) {
+                    logCaught("liff_auto_complete_failed", e, { store: s });
+                  }
+                  // 落回下面的 idle，讓使用者手動重試
+                }
+              }
+            }
+          }
+
           if (!s) {
             setStatus("idle");
             return;


### PR DESCRIPTION
接續 #601。兩個獨立的體驗修正。

---

## 1. LIFF 登入要按兩次

在 LINE 內建瀏覽器裡，`isInClient()` 是 **false**（內建瀏覽器不等於 LIFF context），流程變成：

```
第 1 次按 → liff.login() → 導去 LINE 授權 → 回來
          → init 把 code 換成登入狀態，isLoggedIn 已經 true ✓
          → 但 isInClient 仍是 false
          → 不符合「自動登入」分支的條件
          → 直接落到 setStatus("idle") → 又看到登入頁
第 2 次按 → start() 才檢查 isLoggedIn → 這次才真的建 session
```

**登入其實在第一次就完成了**，只是缺少「不在 client 但已登入」這個分支，於是把使用者丟回登入頁；第二次按並不是重新登入，只是去撿已經拿到的 `id_token`。

補上該分支：直接取 `id_token` 建 session。兩個細節：
- **缺門市時**把 `id_token` 留給 `start()` —— 使用者選完店按一次就能補完，不必重新登入
- `store_required` 不記為錯誤 —— 它只代表「還要選門市」，不是失敗

---

## 2. `/install` 一鍵用瀏覽器開啟

原本要會員自己「複製網址 → 切到 Safari → 貼上」，步驟太多，掉在中間任何一步就裝不成。改成一顆按鈕直接把這頁丟給預設瀏覽器：

| 平台 | scheme |
|---|---|
| iOS | `x-safari-https://…`（可從 in-app browser 跳出去） |
| Android | `intent://…#Intent;scheme=https;end`（不指定 package，交給系統選預設瀏覽器） |

iOS 的步驟從三步縮成兩步。

**沒有只做這條。** 這兩個 scheme 都不是保證會成功的 API，LINE 各版本行為不一致；只做按鈕的話，遇到不支援的版本就是「按了完全沒反應」—— 比原本更糟，因為使用者連下一步能做什麼都不知道。

所以沿用同一套偵測：**1.5 秒後頁面若仍在前景**（代表沒真的跳走），自動退回複製網址並顯示原本的手動步驟。畫面上另留一顆「沒反應？改用複製網址」讓他能自己選。

---

## 驗證

- `tsc --noEmit`、`next build --webpack` 通過
- 確認 diff 不刪除任何檔案
- ⚠️ `x-safari-` / `intent://` 在各 LINE 版本的實際行為只能真機驗證

## 合併後請測

1. **LINE 內建瀏覽器**：按一次「用 LINE 註冊 / 登入」應該就直接進去
2. **`/install`**：按「用 Safari 開啟」應跳出 LINE 到 Safari；若變成顯示「網址已複製」，代表該版本不吃 scheme、退路正常啟動（不是壞掉）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC)_