### PR TITLE
fix(member): Android LIFF 登入卡在轉圈 — session 不繞 URL fragment ＋ 逾時保底

### DIFF
--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { lineOauthStartUrl, callLiffApi } from "@/lib/supabase";
 import { loadLiff } from "@/lib/liff";
-import { clearSession, getSession, listenForSession } from "@/lib/session";
+import { clearSession, getSession, listenForSession, saveSession } from "@/lib/session";
 import {
   isPageUnloading,
   logCaught,
@@ -27,6 +27,8 @@ const CLAIM_RETRY_DELAY_MS = 1500;
 const PAIR_TOKEN_KEY = "pwa_pair_token";
 /** 只允許往 LIFF 彈一次的旗標（sessionStorage），避免 LIFF ↔ 網頁互推無限迴圈 */
 const LIFF_RETRY_KEY = "liff_login_retry";
+/** 「已登入但不在 LIFF client」的自動補完每次瀏覽只做一次，避免 / ↔ /shop 互推 */
+const AUTO_COMPLETE_KEY = "liff_auto_complete_done";
 
 /** sessionStorage 在無痕 / 被擋時會 throw，一律包起來 */
 function sessionFlag(key: string): boolean {
@@ -153,17 +155,18 @@ async function tryClaimPairToken(): Promise<boolean> {
       line_picture: string | null;
     }>("", { action: "claim_pwa_auth_code", code: token });
 
-    const frag = new URLSearchParams({
-      token: data.token,
-      store: data.store,
-      bound: "1",
-      member_id: String(data.member_id),
-      line_user_id: data.line_user_id,
-      line_name: data.line_name ?? "",
-      line_picture: data.line_picture ?? "",
+    // 直接寫入，不繞 URL fragment（理由同 runLiffSession：長 fragment 在
+    // Android WebView 上不保證留得住，掉了就等於白登入一場）
+    saveSession({
+      token:       data.token,
+      storeId:     data.store,
+      memberId:    data.member_id,
+      lineUserId:  data.line_user_id,
+      lineName:    data.line_name,
+      linePicture: data.line_picture,
     });
     localStorage.removeItem(PAIR_TOKEN_KEY);
-    window.location.href = `/shop#${frag.toString()}`;
+    window.location.href = "/shop";
     return true;
   } catch {
     // 沒到期或還沒寫入 → 等下次
@@ -232,7 +235,9 @@ export default function LandingPage() {
 
     const existing = getSession();
     if (existing && existing.memberId) {
+      // 真的登入成功了才把兩個一次性旗標清掉，下次登入才有完整的重試額度
       clearSessionFlag(LIFF_RETRY_KEY);
+      clearSessionFlag(AUTO_COMPLETE_KEY);
       window.location.href = landing;
       return;
     }
@@ -377,7 +382,11 @@ export default function LandingPage() {
             if (idToken) {
               // 缺門市時留給 start()：使用者選完店按一次就能補完，不必重登
               liffIdTokenRef.current = idToken;
-              if (s) {
+              // 自動補完每次瀏覽只做一次。萬一 session 寫了卻沒被 /shop 認出來
+              // （或還有別的破口），會被踢回這裡再補完一次 → 又導 /shop →
+              // 無限轉圈，而 log 因為去重只留得下第一筆，等於什麼線索都沒有。
+              if (s && !sessionFlag(AUTO_COMPLETE_KEY)) {
+                setSessionFlag(AUTO_COMPLETE_KEY);
                 setStatus("liff_auth");
                 try {
                   await runLiffSession(idToken, s, resolvePairCode());
@@ -625,16 +634,15 @@ export default function LandingPage() {
         line_picture: string | null;
       }>("", { action: "claim_pwa_auth_code", code: syncCode });
 
-      const frag = new URLSearchParams({
-        token: data.token,
-        store: data.store,
-        bound: "1",
-        member_id: String(data.member_id),
-        line_user_id: data.line_user_id,
-        line_name: data.line_name ?? "",
-        line_picture: data.line_picture ?? "",
+      saveSession({
+        token:       data.token,
+        storeId:     data.store,
+        memberId:    data.member_id,
+        lineUserId:  data.line_user_id,
+        lineName:    data.line_name,
+        linePicture: data.line_picture,
       });
-      window.location.href = `/shop#${frag.toString()}`;
+      window.location.href = "/shop";
     } catch (e) {
       logCaught("pwa_sync_code_failed", e);
       setError(e instanceof Error ? e.message : "驗證碼無效或已過期");
@@ -953,16 +961,21 @@ async function runLiffSession(
     return;
   }
 
-  const frag = new URLSearchParams({
-    token:        String(data.token),
-    store:        String(data.store),
-    bound:        "1",
-    member_id:    String(data.member_id),
-    line_user_id: String(data.line_user_id ?? ""),
+  // 直接寫進 localStorage，不繞 URL fragment。
+  // 繞 fragment 是 OAuth 那條的限制（後端 302 只能這樣帶 token），LIFF 這條
+  // 資料已經在手上，多繞一趟只是多一個失敗點：token 是 300+ 字元的 JWT，
+  // 在 Android WebView 上長 fragment 不保證留得住 —— 掉了 /shop 就讀不到
+  // session，被踢回登入頁，而登入頁又會自動補完再導一次，卡成轉圈圈迴圈。
+  saveSession({
+    token:       String(data.token),
+    storeId:     String(data.store),
+    memberId:    data.member_id != null ? Number(data.member_id) : null,
+    lineUserId:  data.line_user_id != null ? String(data.line_user_id) : null,
+    lineName:    data.line_name    != null ? String(data.line_name)    : null,
+    linePicture: data.line_picture != null ? String(data.line_picture) : null,
   });
-  if (data.line_name)    frag.set("line_name",    String(data.line_name));
-  if (data.line_picture) frag.set("line_picture", String(data.line_picture));
+
   // LIFF 自然登入(沒帶 pair) = 在 LINE webview 內。放行完整商店體驗:
   // 直接進 /shop,跟 standalone PWA 一致(不再只停在 /me)。
-  window.location.href = `/shop#${frag.toString()}`;
+  window.location.href = "/shop";
 }

--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -30,6 +30,19 @@ const LIFF_RETRY_KEY = "liff_login_retry";
 /** 「已登入但不在 LIFF client」的自動補完每次瀏覽只做一次，避免 / ↔ /shop 互推 */
 const AUTO_COMPLETE_KEY = "liff_auto_complete_done";
 
+/**
+ * 轉圈超過這個時間就直接切到登入頁。
+ *
+ * 自動登入牽涉 LIFF SDK 載入、init、liff-session、LINE 的 verify API…
+ * 任何一段掛住，使用者看到的都是同一個轉不完的圈，而且什麼都不能按 ——
+ * 只能關掉重進（實測這樣反而就登入成功了）。與其讓他自己摸索，
+ * 不如逾時就把可以操作的登入頁交回去。
+ *
+ * 10 秒是留給慢網路的餘裕：正常流程 2–5 秒會走完；真的成功了會導頁，
+ * 元件卸載、這個 timer 也就跟著清掉，不會誤觸。
+ */
+const LOGIN_STUCK_MS = 10_000;
+
 /** sessionStorage 在無痕 / 被擋時會 throw，一律包起來 */
 function sessionFlag(key: string): boolean {
   try { return sessionStorage.getItem(key) !== null; } catch { return false; }
@@ -264,6 +277,20 @@ export default function LandingPage() {
     };
     document.addEventListener("visibilitychange", onVis);
 
+    // 保底：轉圈太久就把可操作的登入頁交回去，不要讓使用者只能關掉重進
+    const stuckTimer = window.setTimeout(() => {
+      setStatus((cur) => {
+        if (cur !== "loading" && cur !== "liff_auth") return cur;
+        logClientError(
+          "login_stuck_timeout",
+          `登入流程逾時（${LOGIN_STUCK_MS / 1000}s），改顯示登入頁`,
+          { stuck_at: cur },
+          "warn",
+        );
+        return "idle";
+      });
+    }, LOGIN_STUCK_MS);
+
     (async () => {
       const errInUrl = new URLSearchParams(window.location.search).get("error");
       if (errInUrl) {
@@ -419,6 +446,7 @@ export default function LandingPage() {
 
     return () => {
       document.removeEventListener("visibilitychange", onVis);
+      window.clearTimeout(stuckTimer);
       unlisten();
     };
   }, []);

--- a/apps/member/src/lib/session.ts
+++ b/apps/member/src/lib/session.ts
@@ -20,6 +20,51 @@ export type Session = {
   linePicture: string | null;
 };
 
+/**
+ * 直接把 session 寫進儲存空間（不經過 URL fragment）。
+ *
+ * OAuth 那條是後端 302 回來，只能靠 fragment 帶 token；但 LIFF 這條是前端
+ * 自己拿到 JSON，繞一趟 fragment 只是多一個失敗點 —— token 是 300+ 字元的
+ * JWT，在 Android WebView 上長 fragment 不保證留得住，掉了就等於沒登入，
+ * 使用者會被踢回登入頁又自動重登，卡在轉圈圈（2026-08-04 實測）。
+ * 順帶好處：網址列不會留下 token。
+ */
+export function saveSession(input: {
+  token: string;
+  storeId: string;
+  memberId: number | null;
+  lineUserId?: string | null;
+  lineName?: string | null;
+  linePicture?: string | null;
+}): Session {
+  const memberId = input.memberId ?? memberIdFromJwt(input.token);
+
+  localStorage.setItem(TOKEN_KEY, input.token);
+  localStorage.setItem(STORE_KEY, input.storeId);
+  if (memberId)         localStorage.setItem(MEMBER_KEY, String(memberId));
+  if (input.lineUserId) localStorage.setItem(LINE_UID_KEY, input.lineUserId);
+  if (input.lineName)   localStorage.setItem(LINE_NAME_KEY, input.lineName);
+  if (input.linePicture) localStorage.setItem(LINE_PIC_KEY, input.linePicture);
+
+  const session: Session = {
+    token: input.token,
+    storeId: input.storeId,
+    memberId,
+    bound: memberId != null,
+    lineUserId:  input.lineUserId  ?? null,
+    lineName:    input.lineName    ?? null,
+    linePicture: input.linePicture ?? null,
+  };
+
+  // 跟 consumeFragmentToSession 一樣要廣播，其他視窗（PWA）才跟得上
+  if ("BroadcastChannel" in window) {
+    const channel = new BroadcastChannel(AUTH_CHANNEL_NAME);
+    channel.postMessage({ type: "LOGIN_SUCCESS", session });
+    channel.close();
+  }
+  return session;
+}
+
 /** 從 URL fragment 解出 session，存入儲存空間，並清理 URL。 */
 export function consumeFragmentToSession(): Session | null {
   if (typeof window === "undefined") return null;


### PR DESCRIPTION
接續 #602。Android 的 LINE 內建瀏覽器登入後卡在轉圈。

---

## 1. 根因：session 用 URL fragment 傳遞

線上 log 有個關鍵矛盾 —— **登入其實成功了**：

```
01:04:30  liff_session_ok  pair_written=null, has_pair=false
```

但畫面停在 spinner。所以卡點在成功之後：session 是用 URL fragment 傳給 `/shop` 的，而 token 是 300+ 字元的 JWT，Android WebView 對長 fragment 不保證留得住。掉了 `/shop` 就讀不到 session → 踢回登入頁 → 登入頁又自動補完再導一次 → **無限轉圈**。

log 因為 30 秒去重只留得下第一筆，所以表面看起來像「只跑了一次」，這也是先前查不出迴圈的原因。

**繞 fragment 本來只是 OAuth 那條的限制**（後端 302 只能這樣帶 token）。LIFF 與配對領取這兩條資料早就在手上，多繞一趟純粹是多一個失敗點。

- `session.ts` 新增 `saveSession()`：直接寫 localStorage 並廣播 `LOGIN_SUCCESS`（廣播不能漏，PWA 那端靠它跟上）
- 三處改用：`runLiffSession`、`tryClaimPairToken`、6 碼手動同步
- 導頁改為乾淨的 `/shop`，順帶網址列不再留下 token

另加防迴圈：自動補完每次瀏覽只做一次（`AUTO_COMPLETE_KEY`），真的登入成功時才連同 `LIFF_RETRY_KEY` 一起清掉。

## 2. 保底：轉圈超過 10 秒交回登入頁

會員回報「關掉 LIFF 重進反而就登入成功了」—— 這代表卡住時畫面上**沒有任何出路**，只剩轉不完的圈，連按都沒得按。

自動登入牽涉 LIFF SDK 載入 → `init` → `liff-session` → LINE 的 verify API，任何一段掛住都是同一個症狀。與其逐一修每種掛法（總會有沒想到的），不如讓「卡住」本身有個出口：逾時就把可操作的登入頁交回去。

- 10 秒是留給慢網路的餘裕（正常流程 2–5 秒走完）
- 真的成功會導頁、元件卸載，timer 跟著清掉，不會誤觸
- 逾時記一筆 `login_stuck_timeout` 並帶上**卡在哪個狀態**（`loading` / `liff_auth`），下次查得出是哪一段掛住

---

## 關於 LIFF 不再負責 PWA 登入

PWA 登入已於 #601 改走 OAuth，所以 LIFF 這條路上的 pair 處理（`resolvePairCode`、`liff-session` 的 `pair_written`）目前確實走不到。

**本 PR 不移除它們**，理由：
- 帶 `pair` 的 LIFF 連結仍可能存在（舊書籤、既有分享連結），保留才不會讓那些人斷掉
- 現在正在收斂登入問題，減少無關變動比較安全

等這波穩定、確認沒有流量走那條之後，再獨立一個 PR 清理，會比夾在修正裡安全。

## 驗證

- `tsc --noEmit`、`next build --webpack` 通過
- 確認 diff 不刪除任何檔案
- ⚠️ Android WebView 的 fragment 行為只能真機驗證

## 合併後請測

Android LINE 內建瀏覽器登入 → 應直接進入商店頁，不再轉圈。

若仍卡住，這次會留下 `login_stuck_timeout` 並標明卡在哪個狀態，可直接定位；而 PWA 那條的寫入結果直接查 `pwa_auth_codes` 有無 36 字元那筆即可判斷。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC)_