### PR TITLE
fix(member): LINE 內建瀏覽器改走 OAuth — liff.init() 會掛死不 resolve

### DIFF
--- a/apps/member/src/app/page.tsx
+++ b/apps/member/src/app/page.tsx
@@ -43,6 +43,9 @@ const AUTO_COMPLETE_KEY = "liff_auto_complete_done";
  */
 const LOGIN_STUCK_MS = 10_000;
 
+/** liff.init() 掛住時的止血點（要比 LOGIN_STUCK_MS 短，才有機會走完後續退路） */
+const LIFF_INIT_TIMEOUT_MS = 5_000;
+
 /** sessionStorage 在無痕 / 被擋時會 throw，一律包起來 */
 function sessionFlag(key: string): boolean {
   try { return sessionStorage.getItem(key) !== null; } catch { return false; }
@@ -319,7 +322,16 @@ export default function LandingPage() {
       if (liffId) {
         try {
           const liff = await loadLiff();
-          await liff.init({ liffId });
+          // liff.init() 會掛住不 resolve —— 實測 2026-08-04：從 liff.login()
+          // 帶著 ?code= 回來時，SDK 在內部換 token 那步卡死，init 永遠不回，
+          // 整個頁面就停在 loading（liffRef 也因此一直是 null）。
+          // 沒有 timeout 的 await 等於把整條登入流程押在 SDK 身上。
+          await Promise.race([
+            liff.init({ liffId }),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error("liff.init timeout")), LIFF_INIT_TIMEOUT_MS),
+            ),
+          ]);
           liffRef.current = liff;
 
           const sFromLiff = readStore();
@@ -557,25 +569,31 @@ export default function LandingPage() {
       }
     }
 
-    // 在 LINE 內、還沒登入 LIFF → 跑 LIFF 登入。
-    // 2026-08-03 之前這條必定回 400（LIFF 的 Endpoint URL 不是本站網域，
-    // redirect_uri 沒被 channel 認可）；換上 endpoint = 本站的 LIFF 後已實測放行。
-    // 只試一次，回來還是沒登入就給外部瀏覽器指引，不要讓使用者在 LINE 裡鬼打牆。
+    // 在 LINE 內建瀏覽器、還沒登入 → 走自家 OAuth，不要用 liff.login()。
+    //
+    // 2026-08-04 實測：liff.login() 導去 LINE 授權後帶著 ?code= 回來，
+    // liff.init() 會在內部換 token 那步掛死、永遠不 resolve，頁面就停在
+    // loading（liffRef 也一直是 null），使用者只能關掉重進。
+    //
+    // OAuth 這條完全不碰 LIFF SDK，也就沒有那個掛點：
+    //   - redirect_uri 是 line-oauth-callback（channel 已註冊，不會 400 ——
+    //     先前那個 400 是 LIFF 的 redirect_uri 指到本站造成的，與這條無關）
+    //   - callback 302 回本站，session 在同一個 context 直接落地
+    // PWA 早先改走這條之後就沒再出過事，LINE 內建瀏覽器同理。
+    //
+    // 只試一次，回來還是沒登入才給外部瀏覽器指引，不要在 LINE 裡鬼打牆。
     if (isInLineApp()) {
-      if (liff && !sessionFlag(LIFF_RETRY_KEY)) {
+      if (!sessionFlag(LIFF_RETRY_KEY)) {
         setSessionFlag(LIFF_RETRY_KEY);
         logClientError(
-          "liff_login_from_line_browser",
-          "LINE 內建瀏覽器：跑 LIFF 登入",
+          "line_browser_oauth_login",
+          "LINE 內建瀏覽器：走 OAuth 登入",
           { store: storeId },
           "warn",
         );
-        try {
-          liff.login();
-          return;
-        } catch (e) {
-          logCaught("liff_login_failed", e, { store: storeId });
-        }
+        clearSession();
+        window.location.href = lineOauthStartUrl(storeId, resolvePairCode() ?? undefined);
+        return;
       }
       logClientError(
         "line_browser_login_blocked",


### PR DESCRIPTION
接續 #603。#603 部署後逾時保底有正常作動，但登入仍然完不成 —— log 指出卡點換了一個。

## 證據（05:58）

```
05:57:56  liff_login_from_line_browser           按下登入，跑 liff.login()
05:58:14  login_stuck_timeout  stuck_at="loading"    卡在 init 整整 10 秒
          page_url: ?state=...&code=...           LINE 授權其實已經回來了
05:58:19  line_browser_login_blocked  has_liff=false   liffRef 從沒被設定
```

`liff.init()` 在處理回來的 `?code=` 時，SDK 內部換 token 那步**掛死、永遠不 resolve**。所以 `liffRef` 一直是 null，逾時保底把登入頁交回去了，但登入本身仍然完不成。

---

## 修正 1：`liff.init()` 加 5 秒 timeout

沒有 timeout 的 `await` 等於把整條登入流程押在 SDK 身上。用 `Promise.race` 包起來，設得比 `LOGIN_STUCK_MS`(10s) 短，後續退路才有時間跑完。

## 修正 2：LINE 內建瀏覽器改走自家 OAuth

不再用 `liff.login()`。這條完全不碰 LIFF SDK，也就沒有那個掛點：

- `redirect_uri` 是 `line-oauth-callback`（channel 已註冊，**不會 400** —— 先前那個 400 是 LIFF 的 `redirect_uri` 指到本站造成的，與這條無關）
- callback 302 回本站，session 在同一個 context 直接落地

PWA 早先改走這條（#601）之後就沒再出過事，LINE 內建瀏覽器同理。

---

## 架構收斂

| 情境 | 登入方式 |
|---|---|
| 真正的 LIFF client（圖文選單開啟，`isInClient=true`） | LIFF `init()` 自動登入 |
| **其他全部**（LINE 內建瀏覽器、PWA、一般瀏覽器） | **OAuth** |

LIFF 只留它真正擅長的那件事。這幾天所有卡住的案例 —— 400 Bad Request、白畫面、要按兩次、卡在轉圈 —— **全都出在「非 LIFF client 卻硬用 LIFF」這個前提上**。

## 驗證

- `tsc --noEmit`、`next build --webpack` 通過
- 確認舊的 `liff.login()` 分支已完全移除、diff 不刪除任何檔案
- ⚠️ LINE 內建瀏覽器對 `access.line.me` OAuth 的實際行為只能真機驗證（curl 帶 LINE UA 測過會正常 302 到登入頁，但 webview 不保證等價）

## 合併後請測

LINE 內建瀏覽器按「用 LINE 註冊 / 登入」→ 應直接進入 LINE 授權頁 → 完成後回到商店頁。

若仍失敗，log 會有 `line_browser_oauth_login`（代表有走這條），再看後續是否出現 `oauth_callback_error`；不會再出現卡在 `liff.init()` 的情況。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dff3vnXV4RxYxDcj9sBMC)_