### PR TITLE
fix(members): 「訂單數」改名累計訂單數，未取貨金額對齊已配單口徑

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -15,7 +15,14 @@ import SearchSpinner from "@/components/SearchSpinner";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow } from "@/components/DataTable";
 import type { OrderStatus } from "@/lib/orderStatus";
 
-const PENDING_STATUSES: OrderStatus[] = ["pending", "confirmed", "shipping", "ready"];
+// 「已配單未取貨」/「未取貨金額」兩欄同口徑：貨已經在店裡、等客人來取的單。
+// 與 v_admin_member_list.unpicked_order_count（migration 20260804000010）一致 —
+// pending/confirmed/shipping 是「還沒到貨」，店裡沒東西，不算欠貨。
+const UNPICKED_STATUSES: OrderStatus[] = ["ready", "partially_completed"];
+// 未取貨金額只算「還留在店裡沒被領走」的品項行：picked_up 已被領走（partially_completed
+// 單一定有這種行）、cancelled / expired 已作廢，都要排除。與取貨頁 INACTIVE_ITEM_STATUSES 同義。
+// 註：未取退貨（退回總倉）需要 SKU 層攤提，列表頁不做，金額可能略高於取貨頁的實收。
+const INACTIVE_ITEM_STATUSES = new Set<string>(["picked_up", "cancelled", "expired"]);
 
 type Status = "active" | "inactive" | "blocked" | "merged" | "deleted";
 type SortKey =
@@ -253,7 +260,7 @@ function MembersListBody() {
             if (!VOID_STATUSES.has(o.status)) {
               countByMember.set(o.member_id, (countByMember.get(o.member_id) ?? 0) + 1);
             }
-            if ((PENDING_STATUSES as string[]).includes(o.status)) {
+            if ((UNPICKED_STATUSES as string[]).includes(o.status)) {
               orderToMember.set(o.id, o.member_id);
             }
           }
@@ -263,9 +270,10 @@ function MembersListBody() {
           if (orderIds.length) {
             const items = await getSupabase()
               .from("customer_order_items")
-              .select("order_id, qty, unit_price")
+              .select("order_id, qty, unit_price, status")
               .in("order_id", orderIds);
-            for (const it of (items.data ?? []) as { order_id: number; qty: number; unit_price: number }[]) {
+            for (const it of (items.data ?? []) as { order_id: number; qty: number; unit_price: number; status: string }[]) {
+              if (INACTIVE_ITEM_STATUSES.has(it.status)) continue;
               const mid = orderToMember.get(it.order_id);
               if (mid == null) continue;
               const cur = m.get(mid);
@@ -438,9 +446,9 @@ function MembersListBody() {
           <ThSort label="姓名" col="name" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
           <ThSort label="取貨店" col="home_store_id" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} />
           <Th>手機</Th>
-          <Th align="right">訂單數</Th>
-          <ThSort label="已配單未取貨" col="unpicked_order_count" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} align="right" />
-          <Th align="right">未取貨金額</Th>
+          <Th align="right" title="歷史累計有效訂單數（不含取消/過期/轉出）；已取貨的單仍會計入，不代表還欠貨">累計訂單數</Th>
+          <ThSort label="已配單未取貨" col="unpicked_order_count" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} align="right" title="貨已到店、還沒被領走的訂單數（可取貨／部分取貨）" />
+          <Th align="right" title="上一欄那些單還留在店裡的品項金額（不含未到貨的單）">未取貨金額</Th>
           <Th align="right">儲值</Th>
           <ThSort label="加入時間" col="joined_at" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} align="right" />
           <ThSort label="最後登入" col="last_visit_at" sortBy={sortBy} sortDir={sortDir} onToggle={toggleSort} align="right" />
@@ -651,15 +659,16 @@ function MembersListBody() {
 }
 
 function ThSort({
-  label, col, sortBy, sortDir, onToggle, align = "left",
+  label, col, sortBy, sortDir, onToggle, align = "left", title,
 }: {
   label: string; col: SortKey; sortBy: SortKey; sortDir: SortDir;
-  onToggle: (c: SortKey) => void; align?: "left" | "right";
+  onToggle: (c: SortKey) => void; align?: "left" | "right"; title?: string;
 }) {
   const active = sortBy === col;
   const arrow = active ? (sortDir === "asc" ? "↑" : "↓") : "";
   return (
     <th
+      title={title}
       onClick={() => onToggle(col)}
       className={`cursor-pointer px-4 py-2 text-xs font-medium uppercase tracking-wide text-zinc-500 select-none hover:text-zinc-900 dark:hover:text-zinc-100 ${align === "right" ? "text-right" : "text-left"}`}
     >

--- a/apps/admin/src/components/DataTable.tsx
+++ b/apps/admin/src/components/DataTable.tsx
@@ -62,16 +62,19 @@ export function Th({
   align,
   onClick,
   scope = "col",
+  title,
 }: {
   children?: ReactNode;
   className?: string;
   align?: Align;
   onClick?: () => void;
   scope?: "col" | "row";
+  title?: string;
 }) {
   return (
     <th
       scope={scope}
+      title={title}
       onClick={onClick}
       className={`px-4 py-2 ${alignCls(align)} text-xs font-medium uppercase tracking-wide text-zinc-500 ${onClick ? "cursor-pointer select-none hover:text-zinc-900 dark:hover:text-zinc-100" : ""} ${className}`}
     >

--- a/docs/TEST-member-unpicked-count.md
+++ b/docs/TEST-member-unpicked-count.md
@@ -2,7 +2,16 @@
 
 **對應 UI 變更:** `apps/admin/src/app/(protected)/members/page.tsx`
 **對應後端:** 新 view `public.v_admin_member_list`（members + 聚合 unpicked_order_count）
-**對應 migration:** `supabase/migrations/20260531120000_v_admin_member_list.sql`
+**對應 migration:** `supabase/migrations/20260701020000_v_admin_member_list.sql`
+　　　　　　　　→ 口徑修正：`supabase/migrations/20260804000010_v_admin_member_list_ready_only.sql`
+
+> **2026-08-04 口徑更新**：`unpicked_order_count` 與「未取貨金額」一律只算
+> `ready` / `partially_completed`（＝貨已到店、還沒被領走）。
+> `pending` / `confirmed` / `shipping` 是還沒到貨，不算欠貨。
+> 金額另外排除 `picked_up` / `cancelled` / `expired` 的品項行
+> （`partially_completed` 單一定有已領走的行，不排除會灌水）。
+> 同一列的「累計訂單數」是歷史累計（只扣 cancelled/expired/transferred_out），
+> **已取貨的單仍會計入**，不是欠貨指標 — 不要拿它跟這兩欄對帳。
 
 ## 1. Schema / Migration 層
 
@@ -14,18 +23,20 @@
 ## 2. SQL 層直測
 
 - [ ] `SELECT id, member_no, unpicked_order_count FROM v_admin_member_list ORDER BY unpicked_order_count DESC LIMIT 10` 返回排序正確
-- [ ] 對某個有未取貨訂單的會員（已知 id），view 回傳的 `unpicked_order_count` = `SELECT COUNT(*) FROM customer_orders WHERE member_id=X AND status IN ('pending','confirmed','shipping','ready')`
+- [ ] 對某個有未取貨訂單的會員（已知 id），view 回傳的 `unpicked_order_count` = `SELECT COUNT(*) FROM customer_orders WHERE member_id=X AND status IN ('ready','partially_completed')`
 - [ ] 對無訂單的會員 `unpicked_order_count = 0`（不是 NULL）
 - [ ] 對只有 completed/cancelled/expired/transferred_out 訂單的會員 `unpicked_order_count = 0`
+- [ ] 對只有 pending/confirmed/shipping（未到貨）訂單的會員 `unpicked_order_count = 0`，且「未取貨金額」也是 `—`（兩欄同進同退）
 - [ ] `EXPLAIN ANALYZE` 對 sort by unpicked_order_count 走得到 `idx_corders_member`（status 為 leftmost prefix 第二欄，可 backward index scan）
 
 ## 3. UI 行為
 
 ### 3.1 欄位顯示
 - [ ] 會員列表頁載入無 console error
-- [ ] 表頭出現新欄「已配單未取貨」（在「訂單數」與「未取貨金額」之間，置中右對齊）
+- [ ] 表頭出現新欄「已配單未取貨」（在「累計訂單數」與「未取貨金額」之間，置中右對齊）
 - [ ] 列出的每位會員都顯示一個整數（無未取貨單 = 顯示 `0` 或 `—`）
-- [ ] 與「未取貨金額」口徑一致：有金額者通常 unpicked_order_count > 0；零者皆 0
+- [ ] 與「未取貨金額」口徑一致：`unpicked_order_count = 0` 的會員金額必為 `—`（反之亦然，除非該單品項已全部退貨）
+- [ ] 三個表頭 hover 有 tooltip 說明口徑（累計訂單數 / 已配單未取貨 / 未取貨金額）
 
 ### 3.2 排序
 - [ ] 點欄位 header 一次：依此欄 asc 排序

--- a/supabase/migrations/20260804000010_v_admin_member_list_ready_only.sql
+++ b/supabase/migrations/20260804000010_v_admin_member_list_ready_only.sql
@@ -1,0 +1,35 @@
+-- v_admin_member_list.unpicked_order_count 口徑：只算「已配單未取貨」＝ ready / partially_completed。
+--
+-- 背景：線上 view 早就被手動改成 ready/partially_completed，但 repo 的
+-- 20260701020000_v_admin_member_list.sql 仍寫著 pending/confirmed/shipping/ready
+-- （4 個狀態），repo 與 prod 不同步。任何人照 repo 重跑 migration 都會把線上
+-- 口徑改回去，造成「已配單未取貨」把還沒到貨的單也算進來。
+-- 這支把線上的真實定義寫回 repo，並與 admin 會員列表「未取貨金額」欄同口徑
+-- （apps/admin/src/app/(protected)/members/page.tsx 的 UNPICKED_STATUSES）。
+--
+-- 口徑說明：
+--   ready               = 貨到店、等客人來取           → 算
+--   partially_completed = 取了一部分、店裡還有剩       → 算
+--   pending / confirmed = 還沒到貨，店裡沒有東西       → 不算
+--   shipping            = 派貨中，尚未確認到店         → 不算
+--
+-- 基底：線上實際 view 定義（= 20260701020000 的 4 狀態版本被手改後的樣子）。
+-- Rollback：把 WHERE 的狀態陣列改回
+--   ARRAY['pending','confirmed','shipping','ready']（即 20260701020000 的版本）。
+
+DROP VIEW IF EXISTS public.v_admin_member_list;
+
+CREATE VIEW public.v_admin_member_list
+WITH (security_invoker = true) AS
+SELECT
+  m.*,
+  COALESCE(uo.unpicked_order_count, 0)::int AS unpicked_order_count
+FROM public.members m
+LEFT JOIN (
+  SELECT member_id, COUNT(*) AS unpicked_order_count
+  FROM public.customer_orders
+  WHERE status IN ('ready','partially_completed')
+  GROUP BY member_id
+) uo ON uo.member_id = m.id;
+
+GRANT SELECT ON public.v_admin_member_list TO authenticated, anon;


### PR DESCRIPTION
會員取完貨後列表仍顯示「訂單數 1」，店員以為卡單、反覆整理。實際上該欄
是歷史累計（只扣 cancelled/expired/transferred_out），completed 也算，
永遠不會歸零。

1. 表頭改為「累計訂單數」並加 tooltip 說明；已配單未取貨 / 未取貨金額
   兩欄也補上口徑 tooltip（Th / ThSort 新增 title prop）。
2. 「未取貨金額」從 pending/confirmed/shipping/ready 改成
   ready/partially_completed，與 v_admin_member_list.unpicked_order_count
   同口徑，兩欄不再一個 — 一個有金額；金額另排除 picked_up / cancelled /
   expired 的品項行，partially_completed 單不再把已領走的貨算進欠貨。
3. 補 migration 20260804000010：線上 view 早已手改成 ready/
   partially_completed，但 repo 還留著 4 狀態版本，照 repo 重跑會把口徑
   改壞 — 把線上真實定義寫回 repo。

驗證：Playwright + fixture 三種情境（已取完 / 未到貨 / 到貨未取含部分取貨）
表格數值與 tooltip 全對；tsc + next build 通過；migration 已套線上並確認
view 定義、security_invoker、grant 不變。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QEdhAwXqZVxsZhjed2G4eN