### PR TITLE
feat(shop): 商品加上使用者瀏覽次數

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -99,6 +99,7 @@ type CampaignsCache = {
   total: number;
   itemCounts: Map<number, number>;
   listOrderCounts: Map<number, { normalQty: number; offsetQty: number }>;
+  viewCounts: Map<number, { views: number; viewers: number }>;
   queryDraft: string;
   query: string;
   status: string;
@@ -164,6 +165,8 @@ export default function CampaignsListPage() {
 
   const [itemCounts, setItemCounts] = useState<Map<number, number>>(() => campaignsCache?.itemCounts ?? new Map());
   const [listOrderCounts, setListOrderCounts] = useState<Map<number, { normalQty: number; offsetQty: number }>>(() => campaignsCache?.listOrderCounts ?? new Map());
+  // 會員 App 的商品瀏覽次數（views = 總次數、viewers = 不重複會員數）
+  const [viewCounts, setViewCounts] = useState<Map<number, { views: number; viewers: number }>>(() => campaignsCache?.viewCounts ?? new Map());
 
   // 從 cache 還原時，第一輪 render 的 reset-page / 主 fetch 都要跳過，
   // 否則會把 cache 的 page=3 重置回 1、或把畫面歸零重抓。
@@ -527,6 +530,7 @@ export default function CampaignsListPage() {
         // 為了寫回 cache，沿用 ids.length===0 時舊有狀態（與原本 setItemCounts 不動的行為一致）
         let computedItemCounts: Map<number, number> = campaignsCache?.itemCounts ?? new Map();
         let computedOrderCounts: Map<number, { normalQty: number; offsetQty: number }> = campaignsCache?.listOrderCounts ?? new Map();
+        let computedViewCounts: Map<number, { views: number; viewers: number }> = campaignsCache?.viewCounts ?? new Map();
 
         // 補商品數 + 下單總數量（normal / offset 分開、SUM(qty)）
         // chunked fetch: 跨萬筆訂單仍 work (bypass PostgREST 1000 row cap)
@@ -567,6 +571,25 @@ export default function CampaignsListPage() {
           }
           if (!cancelled) setListOrderCounts(om);
           computedOrderCounts = om;
+
+          // 商品瀏覽次數（會員 App）。走 SQL 聚合 RPC —— 瀏覽列數會超過
+          // PostgREST 1000 列上限，撈回來自己 count 會失準。
+          // RPC 還沒部署時當作沒有瀏覽資料，不能讓整頁掛掉。
+          const { data: viewRows, error: viewErr } = await getSupabase()
+            .rpc("rpc_campaign_view_counts", { p_campaign_ids: ids });
+          if (viewErr) {
+            console.warn("rpc_campaign_view_counts failed:", viewErr.message);
+          } else {
+            const vm = new Map<number, { views: number; viewers: number }>();
+            for (const v of (viewRows ?? []) as { campaign_id: number; view_count: number; viewer_count: number }[]) {
+              vm.set(Number(v.campaign_id), {
+                views: Number(v.view_count ?? 0),
+                viewers: Number(v.viewer_count ?? 0),
+              });
+            }
+            if (!cancelled) setViewCounts(vm);
+            computedViewCounts = vm;
+          }
         }
 
         // 寫回 cache 給下次返回用（保留 queryDraft / scrollY 不被洗掉）
@@ -576,6 +599,7 @@ export default function CampaignsListPage() {
             total: count ?? 0,
             itemCounts: computedItemCounts,
             listOrderCounts: computedOrderCounts,
+            viewCounts: computedViewCounts,
             queryDraft: campaignsCache?.queryDraft ?? query,
             query,
             status,
@@ -999,6 +1023,14 @@ export default function CampaignsListPage() {
                   </Link>
                 );
               })()}
+              {(() => {
+                const vc = viewCounts.get(r.id);
+                return (
+                  <span title={`會員 App 商品頁瀏覽次數${vc ? `\n不重複會員：${vc.viewers} 人` : ""}`}>
+                    瀏覽 {vc?.views ?? 0}
+                  </span>
+                );
+              })()}
               <span className="ml-auto">更新 {new Date(r.updated_at).toLocaleDateString("zh-TW")}</span>
             </div>
             <div
@@ -1029,13 +1061,13 @@ export default function CampaignsListPage() {
               className="cursor-pointer"
             />
           </Th>
-          <Th className="w-12">{""}</Th><Th className="w-20">{""}</Th><Th className="min-w-[14rem]">名稱</Th><Th className="whitespace-nowrap">狀態</Th><Th className="whitespace-nowrap">收單</Th><Th className="whitespace-nowrap">開團/收單</Th><Th className="whitespace-nowrap">取貨截止</Th><Th align="right" className="whitespace-nowrap">商品數</Th><Th align="right" className="whitespace-nowrap">下單總數</Th><Th align="right" className="whitespace-nowrap">更新</Th><Th>{""}</Th>
+          <Th className="w-12">{""}</Th><Th className="w-20">{""}</Th><Th className="min-w-[14rem]">名稱</Th><Th className="whitespace-nowrap">狀態</Th><Th className="whitespace-nowrap">收單</Th><Th className="whitespace-nowrap">開團/收單</Th><Th className="whitespace-nowrap">取貨截止</Th><Th align="right" className="whitespace-nowrap">商品數</Th><Th align="right" className="whitespace-nowrap">下單總數</Th><Th align="right" className="whitespace-nowrap">瀏覽數</Th><Th align="right" className="whitespace-nowrap">更新</Th><Th>{""}</Th>
         </THead>
         <TBody>
           {rows === null ? (
-            <LoadingRow colSpan={12} />
+            <LoadingRow colSpan={13} />
           ) : rows.length === 0 ? (
-            <EmptyRow colSpan={12}>{total === 0 && !query && !status ? "還沒有開團，按「新增開團」開始。" : "沒有符合條件的開團。"}</EmptyRow>
+            <EmptyRow colSpan={13}>{total === 0 && !query && !status ? "還沒有開團，按「新增開團」開始。" : "沒有符合條件的開團。"}</EmptyRow>
           ) : rows.map((r) => (
             <Tr key={r.id} onClick={() => openEdit(r.id)} className={selectedIds.has(r.id) ? "bg-blue-50 dark:bg-blue-950/30" : ""}>
                 <Td className="w-10">
@@ -1090,6 +1122,20 @@ export default function CampaignsListPage() {
                           </span>
                         )}
                       </Link>
+                    );
+                  })()}
+                </Td>
+                <Td align="right">
+                  {(() => {
+                    const vc = viewCounts.get(r.id);
+                    if (!vc || vc.views === 0) return <span className="font-mono text-zinc-400">0</span>;
+                    return (
+                      <span
+                        className="font-mono whitespace-nowrap"
+                        title={`會員 App 商品頁瀏覽次數：${vc.views} 次\n不重複會員：${vc.viewers} 人`}
+                      >
+                        {vc.views}
+                      </span>
                     );
                   })()}
                 </Td>

--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -99,7 +99,6 @@ type CampaignsCache = {
   total: number;
   itemCounts: Map<number, number>;
   listOrderCounts: Map<number, { normalQty: number; offsetQty: number }>;
-  viewCounts: Map<number, { views: number; viewers: number }>;
   queryDraft: string;
   query: string;
   status: string;
@@ -165,8 +164,6 @@ export default function CampaignsListPage() {
 
   const [itemCounts, setItemCounts] = useState<Map<number, number>>(() => campaignsCache?.itemCounts ?? new Map());
   const [listOrderCounts, setListOrderCounts] = useState<Map<number, { normalQty: number; offsetQty: number }>>(() => campaignsCache?.listOrderCounts ?? new Map());
-  // 會員 App 的商品瀏覽次數（views = 總次數、viewers = 不重複會員數）
-  const [viewCounts, setViewCounts] = useState<Map<number, { views: number; viewers: number }>>(() => campaignsCache?.viewCounts ?? new Map());
 
   // 從 cache 還原時，第一輪 render 的 reset-page / 主 fetch 都要跳過，
   // 否則會把 cache 的 page=3 重置回 1、或把畫面歸零重抓。
@@ -530,7 +527,6 @@ export default function CampaignsListPage() {
         // 為了寫回 cache，沿用 ids.length===0 時舊有狀態（與原本 setItemCounts 不動的行為一致）
         let computedItemCounts: Map<number, number> = campaignsCache?.itemCounts ?? new Map();
         let computedOrderCounts: Map<number, { normalQty: number; offsetQty: number }> = campaignsCache?.listOrderCounts ?? new Map();
-        let computedViewCounts: Map<number, { views: number; viewers: number }> = campaignsCache?.viewCounts ?? new Map();
 
         // 補商品數 + 下單總數量（normal / offset 分開、SUM(qty)）
         // chunked fetch: 跨萬筆訂單仍 work (bypass PostgREST 1000 row cap)
@@ -571,25 +567,6 @@ export default function CampaignsListPage() {
           }
           if (!cancelled) setListOrderCounts(om);
           computedOrderCounts = om;
-
-          // 商品瀏覽次數（會員 App）。走 SQL 聚合 RPC —— 瀏覽列數會超過
-          // PostgREST 1000 列上限，撈回來自己 count 會失準。
-          // RPC 還沒部署時當作沒有瀏覽資料，不能讓整頁掛掉。
-          const { data: viewRows, error: viewErr } = await getSupabase()
-            .rpc("rpc_campaign_view_counts", { p_campaign_ids: ids });
-          if (viewErr) {
-            console.warn("rpc_campaign_view_counts failed:", viewErr.message);
-          } else {
-            const vm = new Map<number, { views: number; viewers: number }>();
-            for (const v of (viewRows ?? []) as { campaign_id: number; view_count: number; viewer_count: number }[]) {
-              vm.set(Number(v.campaign_id), {
-                views: Number(v.view_count ?? 0),
-                viewers: Number(v.viewer_count ?? 0),
-              });
-            }
-            if (!cancelled) setViewCounts(vm);
-            computedViewCounts = vm;
-          }
         }
 
         // 寫回 cache 給下次返回用（保留 queryDraft / scrollY 不被洗掉）
@@ -599,7 +576,6 @@ export default function CampaignsListPage() {
             total: count ?? 0,
             itemCounts: computedItemCounts,
             listOrderCounts: computedOrderCounts,
-            viewCounts: computedViewCounts,
             queryDraft: campaignsCache?.queryDraft ?? query,
             query,
             status,
@@ -1023,14 +999,6 @@ export default function CampaignsListPage() {
                   </Link>
                 );
               })()}
-              {(() => {
-                const vc = viewCounts.get(r.id);
-                return (
-                  <span title={`會員 App 商品頁瀏覽次數${vc ? `\n不重複會員：${vc.viewers} 人` : ""}`}>
-                    瀏覽 {vc?.views ?? 0}
-                  </span>
-                );
-              })()}
               <span className="ml-auto">更新 {new Date(r.updated_at).toLocaleDateString("zh-TW")}</span>
             </div>
             <div
@@ -1061,13 +1029,13 @@ export default function CampaignsListPage() {
               className="cursor-pointer"
             />
           </Th>
-          <Th className="w-12">{""}</Th><Th className="w-20">{""}</Th><Th className="min-w-[14rem]">名稱</Th><Th className="whitespace-nowrap">狀態</Th><Th className="whitespace-nowrap">收單</Th><Th className="whitespace-nowrap">開團/收單</Th><Th className="whitespace-nowrap">取貨截止</Th><Th align="right" className="whitespace-nowrap">商品數</Th><Th align="right" className="whitespace-nowrap">下單總數</Th><Th align="right" className="whitespace-nowrap">瀏覽數</Th><Th align="right" className="whitespace-nowrap">更新</Th><Th>{""}</Th>
+          <Th className="w-12">{""}</Th><Th className="w-20">{""}</Th><Th className="min-w-[14rem]">名稱</Th><Th className="whitespace-nowrap">狀態</Th><Th className="whitespace-nowrap">收單</Th><Th className="whitespace-nowrap">開團/收單</Th><Th className="whitespace-nowrap">取貨截止</Th><Th align="right" className="whitespace-nowrap">商品數</Th><Th align="right" className="whitespace-nowrap">下單總數</Th><Th align="right" className="whitespace-nowrap">更新</Th><Th>{""}</Th>
         </THead>
         <TBody>
           {rows === null ? (
-            <LoadingRow colSpan={13} />
+            <LoadingRow colSpan={12} />
           ) : rows.length === 0 ? (
-            <EmptyRow colSpan={13}>{total === 0 && !query && !status ? "還沒有開團，按「新增開團」開始。" : "沒有符合條件的開團。"}</EmptyRow>
+            <EmptyRow colSpan={12}>{total === 0 && !query && !status ? "還沒有開團，按「新增開團」開始。" : "沒有符合條件的開團。"}</EmptyRow>
           ) : rows.map((r) => (
             <Tr key={r.id} onClick={() => openEdit(r.id)} className={selectedIds.has(r.id) ? "bg-blue-50 dark:bg-blue-950/30" : ""}>
                 <Td className="w-10">
@@ -1122,20 +1090,6 @@ export default function CampaignsListPage() {
                           </span>
                         )}
                       </Link>
-                    );
-                  })()}
-                </Td>
-                <Td align="right">
-                  {(() => {
-                    const vc = viewCounts.get(r.id);
-                    if (!vc || vc.views === 0) return <span className="font-mono text-zinc-400">0</span>;
-                    return (
-                      <span
-                        className="font-mono whitespace-nowrap"
-                        title={`會員 App 商品頁瀏覽次數：${vc.views} 次\n不重複會員：${vc.viewers} 人`}
-                      >
-                        {vc.views}
-                      </span>
                     );
                   })()}
                 </Td>

--- a/apps/member/src/app/shop/c/[id]/page.tsx
+++ b/apps/member/src/app/shop/c/[id]/page.tsx
@@ -8,6 +8,7 @@ import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
 import Spinner from "@/components/Spinner";
 import Countdown from "@/components/Countdown";
+import ViewCount from "@/components/ViewCount";
 import { cleanCampaignText } from "@/lib/text";
 import { getCampaignHint } from "@/lib/campaignHints";
 import { logCaught } from "@/lib/clientLog";
@@ -234,12 +235,9 @@ export default function CampaignDetailPage() {
                   </div>
                 )}
               </div>
-              {viewCount > 0 && (
-                <div className="flex items-center gap-1.5 text-[13px] text-[var(--tertiary-label)]">
-                  <EyeIcon />
-                  <span className="tabular-nums">{viewCount.toLocaleString()} 次瀏覽</span>
-                </div>
-              )}
+              <ViewCount count={viewCount} size="md" />
+
+
               {displayDescription && (() => {
                 const desc = cleanCampaignText(displayDescription);
                 if (!desc) return null;
@@ -382,16 +380,6 @@ export default function CampaignDetailPage() {
         </div>
       </Portal>
     </PageShell>
-  );
-}
-
-/** 瀏覽次數用的眼睛 icon */
-function EyeIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} className="h-4 w-4 shrink-0">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M2.5 12S6 5.5 12 5.5 21.5 12 21.5 12 18 18.5 12 18.5 2.5 12 2.5 12Z" />
-      <circle cx="12" cy="12" r="3" />
-    </svg>
   );
 }
 

--- a/apps/member/src/app/shop/c/[id]/page.tsx
+++ b/apps/member/src/app/shop/c/[id]/page.tsx
@@ -10,6 +10,7 @@ import Spinner from "@/components/Spinner";
 import Countdown from "@/components/Countdown";
 import { cleanCampaignText } from "@/lib/text";
 import { getCampaignHint } from "@/lib/campaignHints";
+import { logCaught } from "@/lib/clientLog";
 
 /** 把 children 渲染到 document.body（保證 fixed 相對 viewport）。 */
 function Portal({ enabled, children }: { enabled: boolean; children: React.ReactNode }) {
@@ -26,6 +27,8 @@ type CampaignDetail = {
   status: string;
   end_at: string | null;
   pickup_deadline: string | null;
+  /** 總瀏覽次數。後端未部署 track_campaign_view 前可能沒有這個欄位。 */
+  view_count?: number;
 };
 
 type Item = {
@@ -56,6 +59,8 @@ export default function CampaignDetailPage() {
   const [qtyMap, setQtyMap] = useState<Record<number, number>>({});
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
+  // 瀏覽次數：先用列表 hint 的值墊著，detail / track 回來再蓋掉（含本次瀏覽）
+  const [viewCount, setViewCount] = useState<number>(() => hint?.view_count ?? 0);
 
   // confirm sheet
   const [sheetOpen, setSheetOpen] = useState(false);
@@ -88,6 +93,9 @@ export default function CampaignDetailPage() {
         setCampaign(d.campaign);
         setItems(d.items);
         setHeroImages(d.hero_images ?? []);
+        if (typeof d.campaign.view_count === "number") {
+          setViewCount(d.campaign.view_count);
+        }
       } catch (e) {
         setErr(e instanceof Error ? e.message : String(e));
       } finally {
@@ -95,6 +103,29 @@ export default function CampaignDetailPage() {
       }
     })();
   }, [id, router]);
+
+  // 記一次瀏覽，並拿回含本次的最新計數。
+  // 同會員同商品 30 分鐘內在後端去重，所以「返回列表再點進來」不會灌水。
+  const trackedRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!id || trackedRef.current === id) return;
+    const s = getSession();
+    if (!s || !s.memberId) return;
+    trackedRef.current = id;
+    (async () => {
+      try {
+        const r = await callLiffApi<{ view_count: number }>(s.token, {
+          action: "track_campaign_view",
+          campaign_id: id,
+        });
+        if (typeof r.view_count === "number") setViewCount(r.view_count);
+      } catch (e) {
+        // 瀏覽數是附加資訊，記不到不能影響購物；但要留痕，
+        // 否則「數字一直是 0」只會在會員手機上重現得出來。
+        logCaught("track_campaign_view_failed", e, { campaign_id: id });
+      }
+    })();
+  }, [id]);
 
   const totalQty = useMemo(
     () => Object.values(qtyMap).reduce((s, n) => s + (n || 0), 0),
@@ -203,6 +234,12 @@ export default function CampaignDetailPage() {
                   </div>
                 )}
               </div>
+              {viewCount > 0 && (
+                <div className="flex items-center gap-1.5 text-[13px] text-[var(--tertiary-label)]">
+                  <EyeIcon />
+                  <span className="tabular-nums">{viewCount.toLocaleString()} 次瀏覽</span>
+                </div>
+              )}
               {displayDescription && (() => {
                 const desc = cleanCampaignText(displayDescription);
                 if (!desc) return null;
@@ -345,6 +382,16 @@ export default function CampaignDetailPage() {
         </div>
       </Portal>
     </PageShell>
+  );
+}
+
+/** 瀏覽次數用的眼睛 icon */
+function EyeIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} className="h-4 w-4 shrink-0">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M2.5 12S6 5.5 12 5.5 21.5 12 21.5 12 18 18.5 12 18.5 2.5 12 2.5 12Z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
   );
 }
 

--- a/apps/member/src/app/shop/flash/page.tsx
+++ b/apps/member/src/app/shop/flash/page.tsx
@@ -13,6 +13,7 @@ import CampaignCard, {
   type CampaignSummary,
 } from "@/components/CampaignCard";
 import Countdown from "@/components/Countdown";
+import ViewCount from "@/components/ViewCount";
 import { cleanCampaignText } from "@/lib/text";
 import { setCampaignHints } from "@/lib/campaignHints";
 
@@ -158,6 +159,7 @@ function FlashRow({ campaign }: { campaign: CampaignSummary }) {
               {campaign.order_count} 筆訂單
             </div>
           )}
+          <ViewCount count={campaign.view_count} />
         </div>
         {campaign.ordered_qty > 0 && (
           <div className="text-[12px] font-medium text-[var(--tertiary-label)]">

--- a/apps/member/src/app/spot/[id]/page.tsx
+++ b/apps/member/src/app/spot/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useParams, useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession, loginPath } from "@/lib/session";
@@ -8,7 +8,9 @@ import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
 import { LoadingScreen } from "@/components/Spinner";
 import Countdown from "@/components/Countdown";
+import ViewCount from "@/components/ViewCount";
 import { cleanCampaignText } from "@/lib/text";
+import { logCaught } from "@/lib/clientLog";
 import { isInLiffClient, sendLineInquiry } from "@/lib/lineInquiry";
 import { type SpotProduct, spotProductTitle } from "@/components/SpotProductCard";
 
@@ -62,6 +64,8 @@ export default function SpotDetailPage() {
   // LINE、畫面沒變化，必須有個明確回饋說「已經發出去了」）
   const [sentPopup, setSentPopup] = useState(false);
   const [sendErr, setSendErr] = useState<string | null>(null);
+  // 瀏覽次數：detail 先給一個值，track 回來再蓋掉（含本次瀏覽）
+  const [viewCount, setViewCount] = useState(0);
 
   // portal 要等 client mount（同 /shop/c/[id] 的做法，避免 hydration 對不上）
   useEffect(() => setMounted(true), []);
@@ -83,6 +87,7 @@ export default function SpotDetailPage() {
         const d = await callLiffApi<Resp>(s.token, { action: "get_spot_product", id });
         setItem(d.item);
         setLineOaId(d.my_store_line_oa_id ?? null);
+        if (typeof d.item.view_count === "number") setViewCount(d.item.view_count);
       } catch (e) {
         setErr(e instanceof Error ? e.message : String(e));
       } finally {
@@ -90,6 +95,27 @@ export default function SpotDetailPage() {
       }
     })();
   }, [router, id, validId]);
+
+  // 記一次瀏覽，並拿回含本次的最新計數（去重在後端做，同 /shop/c/[id]）
+  const trackedRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!validId || trackedRef.current === id) return;
+    const s = getSession();
+    if (!s || !s.memberId) return;
+    trackedRef.current = id;
+    (async () => {
+      try {
+        const r = await callLiffApi<{ view_count: number }>(s.token, {
+          action: "track_spot_view",
+          id,
+        });
+        if (typeof r.view_count === "number") setViewCount(r.view_count);
+      } catch (e) {
+        // 記不到不能影響詢問流程，但要留痕（只在會員手機上重現得出來）
+        logCaught("track_spot_view_failed", e, { board_id: id });
+      }
+    })();
+  }, [id, validId]);
 
   const title = item ? spotProductTitle(item) : "";
   const subject = item
@@ -161,6 +187,8 @@ export default function SpotDetailPage() {
               <h2 className="text-[24px] font-bold leading-tight text-[var(--foreground)]">
                 {title}
               </h2>
+
+              <ViewCount count={viewCount} size="md" />
 
               {item.is_my_store ? (
                 <div className="flex items-baseline gap-2">

--- a/apps/member/src/components/CampaignCard.tsx
+++ b/apps/member/src/components/CampaignCard.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import Countdown from "./Countdown";
+import ViewCount from "./ViewCount";
 import { cleanCampaignText } from "@/lib/text";
 
 export type CampaignSummary = {
@@ -17,7 +18,7 @@ export type CampaignSummary = {
   order_count: number;
   /** 近 7 天訂單數（近期售出排序用）。 */
   recent_order_count: number;
-  /** 總瀏覽次數。後端未部署前可能沒有這個欄位，詳情頁只拿來當預填值。 */
+  /** 總瀏覽次數。後端未部署前可能沒有這個欄位（當 0 處理、不顯示）。 */
   view_count?: number;
   end_at: string | null;
   pickup_deadline: string | null;
@@ -160,9 +161,14 @@ export default function CampaignCard({
               共 {campaign.item_count} 項
             </span>
           </div>
-          {campaign.ordered_qty > 0 && (
-            <div className="text-right text-[14px] font-medium text-[var(--secondary-label)]">
-              已訂購 {campaign.ordered_qty.toLocaleString()} 件
+          {(campaign.ordered_qty > 0 || (campaign.view_count ?? 0) > 0) && (
+            <div className="flex items-center justify-between gap-2 text-[14px] font-medium text-[var(--secondary-label)]">
+              <ViewCount count={campaign.view_count} />
+              {campaign.ordered_qty > 0 && (
+                <span className="ml-auto">
+                  已訂購 {campaign.ordered_qty.toLocaleString()} 件
+                </span>
+              )}
             </div>
           )}
         </div>
@@ -229,11 +235,14 @@ export default function CampaignCard({
           <div className="brand-gradient-text text-[24px] font-extrabold tabular-nums leading-none">
             {priceText}
           </div>
-          {campaign.ordered_qty > 0 && (
-            <div className="text-[12px] font-medium text-[var(--secondary-label)]">
-              已訂購 {campaign.ordered_qty.toLocaleString()} 件
-            </div>
-          )}
+          {/* 已訂購 / 瀏覽數直向堆疊在價格右邊 —— 卡片是兩欄格線，
+              跟倒數同一列會擠爆（倒數字串長達「14 天 23:19:10」）。 */}
+          <div className="flex shrink-0 flex-col items-end gap-0.5 text-[12px] font-medium text-[var(--secondary-label)]">
+            {campaign.ordered_qty > 0 && (
+              <span>已訂購 {campaign.ordered_qty.toLocaleString()} 件</span>
+            )}
+            <ViewCount count={campaign.view_count} />
+          </div>
         </div>
         {campaign.end_at && (
           <div className="inline-flex items-center gap-1 rounded-md bg-[var(--brand-soft)] px-1.5 py-0.5 text-[12px] font-semibold tabular-nums text-[var(--brand-strong)]">

--- a/apps/member/src/components/CampaignCard.tsx
+++ b/apps/member/src/components/CampaignCard.tsx
@@ -17,6 +17,8 @@ export type CampaignSummary = {
   order_count: number;
   /** 近 7 天訂單數（近期售出排序用）。 */
   recent_order_count: number;
+  /** 總瀏覽次數。後端未部署前可能沒有這個欄位，詳情頁只拿來當預填值。 */
+  view_count?: number;
   end_at: string | null;
   pickup_deadline: string | null;
   item_count: number;

--- a/apps/member/src/components/SpotProductCard.tsx
+++ b/apps/member/src/components/SpotProductCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import ViewCount from "./ViewCount";
 
 /**
  * 現貨專區商品（互助交流板「我有庫存可提供」）在會員端的資料形狀。
@@ -28,6 +29,8 @@ export type SpotProduct = {
   /** 原價（來源訂單單價）。只在「店家有改價且改得比原價低」時才有值，
    *  會員端據此畫刪除線。跨店一律 null（金額隱藏）。 */
   original_price: number | null;
+  /** 總瀏覽次數。後端未部署前可能沒有這個欄位（當 0 處理、不顯示）。 */
+  view_count?: number;
 };
 
 export function spotProductTitle(p: SpotProduct): string {
@@ -104,8 +107,13 @@ export default function SpotProductCard({ item }: { item: SpotProduct }) {
           {title}
         </h3>
 
-        <div className="inline-flex w-fit items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[12px] font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
-          可提供 {qtyText}
+        {/* 瀏覽數放在「可提供」這排，不跟價格 / 跨店徽章同排 ——
+            「跨店 · 金額不顯示」本身就快佔滿兩欄卡的寬度，擠不下第二個元素。 */}
+        <div className="flex items-center justify-between gap-1.5">
+          <div className="inline-flex w-fit items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[12px] font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+            可提供 {qtyText}
+          </div>
+          <ViewCount count={item.view_count} />
         </div>
 
         <div className="mt-auto pt-1">

--- a/apps/member/src/components/ViewCount.tsx
+++ b/apps/member/src/components/ViewCount.tsx
@@ -1,0 +1,52 @@
+/**
+ * 商品瀏覽次數：眼睛 icon + 數字。
+ *
+ * 商城列表卡片與商品詳情頁共用同一個樣式 —— 兩邊各畫一份的話，之後調字級 /
+ * 顏色只會改到其中一邊。
+ */
+export default function ViewCount({
+  count,
+  size = "sm",
+  className = "",
+}: {
+  count: number | null | undefined;
+  /** sm = 列表卡片、md = 商品詳情頁 */
+  size?: "sm" | "md";
+  className?: string;
+}) {
+  const n = Number(count ?? 0);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const isMd = size === "md";
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-[var(--tertiary-label)] ${
+        isMd ? "text-[13px]" : "text-[12px]"
+      } ${className}`}
+      title={`${n.toLocaleString()} 次瀏覽`}
+    >
+      <EyeIcon className={isMd ? "h-4 w-4" : "h-3.5 w-3.5"} />
+      <span className="tabular-nums">{n.toLocaleString()}</span>
+      {isMd && <span>次瀏覽</span>}
+    </span>
+  );
+}
+
+export function EyeIcon({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      aria-hidden
+      className={`shrink-0 ${className}`}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.5 12S6 5.5 12 5.5 21.5 12 21.5 12 18 18.5 12 18.5 2.5 12 2.5 12Z"
+      />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -634,6 +634,18 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
     }
   }
 
+  // 瀏覽次數（顧客端顯示「N 次瀏覽」）。RPC 未部署時整段當 0，不影響列表。
+  const viewMap = new Map<number, number>();
+  if (allIds.length > 0) {
+    const { data: viewRows } = await sb.rpc("rpc_campaign_view_counts", {
+      p_tenant: tenantId,
+      p_campaign_ids: allIds,
+    });
+    for (const r of viewRows ?? []) {
+      viewMap.set(Number(r.campaign_id), Number(r.view_count ?? 0));
+    }
+  }
+
   // 全分店訂單數 + 近 7 天訂單數（顧客端排序用：最熱銷 / 近期售出）。
   // 走 SQL 聚合 RPC，避免訂單列數超過 PostgREST 1000 上限被截斷而計數失準。
   const countMap = new Map<number, number>();
@@ -678,6 +690,7 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
       ordered_qty: orderedMap.get(Number(c.id)) ?? 0,
       order_count: countMap.get(Number(c.id)) ?? 0,
       recent_order_count: recentMap.get(Number(c.id)) ?? 0,
+      view_count: viewMap.get(Number(c.id)) ?? 0,
       end_at: c.end_at,
       pickup_deadline: c.pickup_deadline,
       item_count: prices.length,
@@ -727,6 +740,14 @@ async function getCampaignDetail(sb: any, tenantId: string, campaignId: number) 
     .not("status", "in", "(cancelled,expired)")
     .or("order_kind.is.null,order_kind.eq.normal");
   c.order_count = orderCount ?? 0;
+
+  // 瀏覽次數（這次的瀏覽由前端另外打 track_campaign_view 記，並拿回最新計數）
+  const { data: viewRows } = await sb.rpc("rpc_campaign_view_counts", {
+    p_tenant: tenantId,
+    p_campaign_ids: [campaignId],
+  });
+  c.view_count = Number(viewRows?.[0]?.view_count ?? 0);
+  c.viewer_count = Number(viewRows?.[0]?.viewer_count ?? 0);
 
   // 算出各品項已下單總量
   const itemOrderedMap = new Map<number, number>();
@@ -780,6 +801,32 @@ async function getCampaignDetail(sb: any, tenantId: string, campaignId: number) 
     };
   });
   return json({ campaign: c, items: flat, hero_images: heroPaths });
+}
+
+/**
+ * 記一次商品瀏覽，回傳更新後的計數。
+ *
+ * 去重（同會員同商品 30 分鐘內只算一次）在 SQL 裡做 —— 前端的 useEffect
+ * 會因為返回 / 重整重跑，只靠前端擋不住，數字會失真。
+ */
+async function trackCampaignView(
+  sb: any,
+  tenantId: string,
+  memberId: number,
+  campaignId: number,
+) {
+  if (!campaignId) return json({ error: "campaign_id required" }, 400);
+  const { data, error } = await sb.rpc("rpc_track_campaign_view", {
+    p_tenant: tenantId,
+    p_campaign_id: campaignId,
+    p_member_id: memberId,
+  });
+  if (error) return json({ error: error.message }, 500);
+  const row = Array.isArray(data) ? data[0] : data;
+  return json({
+    view_count: Number(row?.view_count ?? 0),
+    viewer_count: Number(row?.viewer_count ?? 0),
+  });
 }
 
 async function placeMemberOrder(
@@ -1257,6 +1304,7 @@ Deno.serve(async (req) => {
         case "generate_pwa_auth_code": if (!memberId) return json({ error: "no member_id" }, 401); return await generatePwaAuthCode(sb, tenantId, memberId, claims, token, body);
         case "list_active_campaigns": return await listActiveCampaigns(sb, tenantId, typeof body.close_type === "string" ? body.close_type : null, memberId);
         case "get_campaign_detail": return await getCampaignDetail(sb, tenantId, Number(body.campaign_id ?? 0));
+        case "track_campaign_view": if (!memberId) return json({ error: "no member_id" }, 401); return await trackCampaignView(sb, tenantId, memberId, Number(body.campaign_id ?? 0));
         case "list_spot_products": return await listSpotProducts(sb, tenantId, storeId, memberId);
         case "get_spot_product": return await getSpotProduct(sb, tenantId, storeId, memberId, Number(body.id ?? 0));
         case "place_member_order": if (!memberId) return json({ error: "no member_id" }, 401); return await placeMemberOrder(sb, tenantId, memberId, body);

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -434,6 +434,19 @@ async function listSpotProducts(
     }
   }
 
+  // 瀏覽次數（顧客端卡片顯示「👁 N」）。RPC 未部署時整段當 0，不影響列表。
+  const viewMap = new Map<number, number>();
+  const boardIds = (rows ?? []).map((r: any) => Number(r.id));
+  if (boardIds.length > 0) {
+    const { data: viewRows } = await sb.rpc("rpc_spot_view_counts", {
+      p_tenant: tenantId,
+      p_board_ids: boardIds,
+    });
+    for (const v of viewRows ?? []) {
+      viewMap.set(Number(v.board_id), Number(v.view_count ?? 0));
+    }
+  }
+
   const supabaseUrl = requireEnv("SUPABASE_URL");
   const items = (rows ?? []).map((r: any) => {
     const isMyStore = Number(r.offering_store_id) === myStoreId;
@@ -468,6 +481,7 @@ async function listSpotProducts(
       is_my_store: isMyStore,
       unit_price: price,
       original_price: originalPrice,
+      view_count: viewMap.get(Number(r.id)) ?? 0,
     };
   });
 
@@ -566,6 +580,12 @@ async function getSpotProduct(
   const supabaseUrl = requireEnv("SUPABASE_URL");
   const images = resolveSpotImages(supabaseUrl, r.spot_images, r.sku?.product?.images);
 
+  // 瀏覽次數（本次瀏覽由前端另外打 track_spot_view 記，並拿回最新計數）
+  const { data: viewRows } = await sb.rpc("rpc_spot_view_counts", {
+    p_tenant: tenantId,
+    p_board_ids: [Number(r.id)],
+  });
+
   return json({
     item: {
       id: Number(r.id),
@@ -588,6 +608,8 @@ async function getSpotProduct(
       is_my_store: isMyStore,
       unit_price: unitPrice,
       original_price: originalPrice,
+      view_count: Number(viewRows?.[0]?.view_count ?? 0),
+      viewer_count: Number(viewRows?.[0]?.viewer_count ?? 0),
     },
     my_store_id: myStoreId,
     my_store_name: myStoreName,
@@ -819,6 +841,27 @@ async function trackCampaignView(
   const { data, error } = await sb.rpc("rpc_track_campaign_view", {
     p_tenant: tenantId,
     p_campaign_id: campaignId,
+    p_member_id: memberId,
+  });
+  if (error) return json({ error: error.message }, 500);
+  const row = Array.isArray(data) ? data[0] : data;
+  return json({
+    view_count: Number(row?.view_count ?? 0),
+    viewer_count: Number(row?.viewer_count ?? 0),
+  });
+}
+
+/** 記一次現貨商品瀏覽（規則同 trackCampaignView，只是換一張表） */
+async function trackSpotView(
+  sb: any,
+  tenantId: string,
+  memberId: number,
+  boardId: number,
+) {
+  if (!boardId) return json({ error: "id required" }, 400);
+  const { data, error } = await sb.rpc("rpc_track_spot_view", {
+    p_tenant: tenantId,
+    p_board_id: boardId,
     p_member_id: memberId,
   });
   if (error) return json({ error: error.message }, 500);
@@ -1307,6 +1350,7 @@ Deno.serve(async (req) => {
         case "track_campaign_view": if (!memberId) return json({ error: "no member_id" }, 401); return await trackCampaignView(sb, tenantId, memberId, Number(body.campaign_id ?? 0));
         case "list_spot_products": return await listSpotProducts(sb, tenantId, storeId, memberId);
         case "get_spot_product": return await getSpotProduct(sb, tenantId, storeId, memberId, Number(body.id ?? 0));
+        case "track_spot_view": if (!memberId) return json({ error: "no member_id" }, 401); return await trackSpotView(sb, tenantId, memberId, Number(body.id ?? 0));
         case "place_member_order": if (!memberId) return json({ error: "no member_id" }, 401); return await placeMemberOrder(sb, tenantId, memberId, body);
         default: return json({ error: `unknown action: ${action}` }, 400);
       }

--- a/supabase/migrations/20260805000000_campaign_views.sql
+++ b/supabase/migrations/20260805000000_campaign_views.sql
@@ -1,0 +1,144 @@
+-- ============================================================================
+-- 商品（團購活動）瀏覽次數
+--
+-- 動機：店家想知道「這個商品有多少人看過」——沒下單的流量目前完全看不到，
+-- 只能從訂單數反推，等於把「沒人看到」跟「看到但沒買」混成同一件事。
+--
+-- 資料形狀：每個 (campaign, member) 一列，累加 view_count。
+--   → 總瀏覽次數 = SUM(view_count)、不重複瀏覽人數 = COUNT(*)，兩個都拿得到，
+--     而且列數上限是 會員數 × 團數（不會像逐筆 event log 那樣無限長）。
+--
+-- 刻意 **不** 在 group_buy_campaigns 上放 view_count 計數欄：那張表有
+-- trg_touch_gbc（BEFORE UPDATE 更新 updated_at），每次瀏覽都會把「更新時間」
+-- 洗掉，管理頁的「更新」欄會變成無意義的瀏覽時間，開團列也會被瀏覽流量狂寫。
+--
+-- 寫入路徑：liff-api 的 `track_campaign_view` action（service role）→
+--   rpc_track_campaign_view。會員端沒有 supabase auth JWT，一律走 edge function。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS campaign_views (
+  id              BIGSERIAL   PRIMARY KEY,
+  tenant_id       UUID        NOT NULL,
+  campaign_id     BIGINT      NOT NULL REFERENCES group_buy_campaigns(id) ON DELETE CASCADE,
+  member_id       BIGINT      NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+  view_count      INT         NOT NULL DEFAULT 1,
+  first_viewed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_viewed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, campaign_id, member_id)
+);
+
+-- 「這個團被誰看過幾次」：UNIQUE 的 (tenant_id, campaign_id, ...) 前綴就夠用。
+-- 另外補一條給「這個會員最近看過什麼」（之後做瀏覽紀錄 / 推薦時會用到）。
+CREATE INDEX IF NOT EXISTS idx_campaign_views_member_recent
+  ON campaign_views (tenant_id, member_id, last_viewed_at DESC);
+
+COMMENT ON TABLE  campaign_views                 IS '商品（團購活動）瀏覽次數，每個 (活動, 會員) 一列';
+COMMENT ON COLUMN campaign_views.view_count      IS '該會員看這個團的次數（同一會員 N 分鐘內重複開只算一次，見 rpc_track_campaign_view）';
+COMMENT ON COLUMN campaign_views.last_viewed_at  IS '最後一次瀏覽時間，也是去重視窗的判斷依據';
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+-- 寫入只走 service role（liff-api）與 SECURITY DEFINER RPC，故不開 write policy。
+-- 讀取比照 auth_read_group_buy_campaigns：同租戶的後台使用者都看得到。
+ALTER TABLE campaign_views ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS auth_read_campaign_views ON campaign_views;
+CREATE POLICY auth_read_campaign_views ON campaign_views
+  FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::UUID);
+
+-- ── 記一次瀏覽 ───────────────────────────────────────────────────────────────
+-- 去重視窗：同一會員在 p_dedupe_minutes 內重複打開同一個商品只算一次
+-- （下拉重整 / 返回列表再點進來會重跑 useEffect，不去重的話數字會膨脹到沒有
+--  參考價值）。回傳更新後的總計，前端可以直接顯示、不用再查一次。
+CREATE OR REPLACE FUNCTION public.rpc_track_campaign_view(
+  p_tenant          UUID,
+  p_campaign_id     BIGINT,
+  p_member_id       BIGINT,
+  p_dedupe_minutes  INT DEFAULT 30
+)
+RETURNS TABLE (view_count BIGINT, viewer_count BIGINT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_jwt_tenant TEXT := auth.jwt() ->> 'tenant_id';
+BEGIN
+  -- service role（liff-api）沒有 tenant_id claim → 跳過；後台使用者只能動自己的租戶
+  IF v_jwt_tenant IS NOT NULL AND v_jwt_tenant::UUID <> p_tenant THEN
+    RAISE EXCEPTION 'tenant mismatch';
+  END IF;
+  IF p_campaign_id IS NULL OR p_member_id IS NULL THEN
+    RAISE EXCEPTION 'campaign_id and member_id are required';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM group_buy_campaigns c
+     WHERE c.id = p_campaign_id AND c.tenant_id = p_tenant
+  ) THEN
+    RAISE EXCEPTION 'campaign not found';
+  END IF;
+
+  INSERT INTO campaign_views AS cv (tenant_id, campaign_id, member_id)
+  VALUES (p_tenant, p_campaign_id, p_member_id)
+  ON CONFLICT (tenant_id, campaign_id, member_id) DO UPDATE
+     SET view_count = cv.view_count + CASE
+           WHEN cv.last_viewed_at
+                < NOW() - make_interval(mins => GREATEST(COALESCE(p_dedupe_minutes, 30), 0))
+           THEN 1 ELSE 0 END,
+         last_viewed_at = NOW();
+
+  RETURN QUERY
+  SELECT COALESCE(SUM(cv.view_count), 0)::BIGINT,
+         COUNT(*)::BIGINT
+    FROM campaign_views cv
+   WHERE cv.tenant_id = p_tenant
+     AND cv.campaign_id = p_campaign_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_track_campaign_view(UUID, BIGINT, BIGINT, INT)
+  IS '記一次商品瀏覽（同會員同商品 N 分鐘內去重），回傳該商品的總瀏覽次數與不重複人數';
+
+-- ── 讀計數 ───────────────────────────────────────────────────────────────────
+-- 用 SQL 聚合而不是把列撈回前端 count：PostgREST 單次最多 1000 列，
+-- 瀏覽列數會超過（本專案已為此踩過雷，見 rpc_member_campaign_order_counts）。
+-- p_tenant 省略時取 JWT 的 tenant_id（後台呼叫）；liff-api 走 service role
+-- 沒有 claim，一定要帶。
+CREATE OR REPLACE FUNCTION public.rpc_campaign_view_counts(
+  p_campaign_ids BIGINT[] DEFAULT NULL,
+  p_tenant       UUID DEFAULT NULL
+)
+RETURNS TABLE (campaign_id BIGINT, view_count BIGINT, viewer_count BIGINT)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_jwt_tenant TEXT := auth.jwt() ->> 'tenant_id';
+  v_tenant     UUID := COALESCE(p_tenant, NULLIF(v_jwt_tenant, '')::UUID);
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant is required';
+  END IF;
+  IF v_jwt_tenant IS NOT NULL AND v_jwt_tenant::UUID <> v_tenant THEN
+    RAISE EXCEPTION 'tenant mismatch';
+  END IF;
+
+  RETURN QUERY
+  SELECT cv.campaign_id,
+         SUM(cv.view_count)::BIGINT AS view_count,
+         COUNT(*)::BIGINT           AS viewer_count
+    FROM campaign_views cv
+   WHERE cv.tenant_id = v_tenant
+     AND (p_campaign_ids IS NULL OR cv.campaign_id = ANY (p_campaign_ids))
+   GROUP BY cv.campaign_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_campaign_view_counts(BIGINT[], UUID)
+  IS '每個商品（團購活動）的總瀏覽次數與不重複瀏覽人數；p_campaign_ids 省略 = 全租戶';
+
+GRANT EXECUTE ON FUNCTION public.rpc_track_campaign_view(UUID, BIGINT, BIGINT, INT)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_campaign_view_counts(BIGINT[], UUID)
+  TO authenticated, service_role;

--- a/supabase/migrations/20260805000010_spot_views.sql
+++ b/supabase/migrations/20260805000010_spot_views.sql
@@ -1,0 +1,131 @@
+-- ============================================================================
+-- 現貨專區（mutual_aid_board 的 offer 貼文）瀏覽次數
+--
+-- 跟 20260805000000_campaign_views 同一套做法，只是掛在另一種商品上：
+-- 商城的團購商品 → campaign_views；現貨專區的商品 → spot_views。
+-- 兩邊資料表不同（group_buy_campaigns / mutual_aid_board），FK 各自掛好才有
+-- ON DELETE CASCADE，所以不合併成一張 (entity_type, entity_id) 的泛用表。
+--
+-- 寫入路徑：liff-api 的 `track_spot_view` action（service role）→
+--   rpc_track_spot_view。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS spot_views (
+  id              BIGSERIAL   PRIMARY KEY,
+  tenant_id       UUID        NOT NULL,
+  board_id        BIGINT      NOT NULL REFERENCES mutual_aid_board(id) ON DELETE CASCADE,
+  member_id       BIGINT      NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+  view_count      INT         NOT NULL DEFAULT 1,
+  first_viewed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_viewed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, board_id, member_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_spot_views_member_recent
+  ON spot_views (tenant_id, member_id, last_viewed_at DESC);
+
+COMMENT ON TABLE  spot_views                IS '現貨專區商品瀏覽次數，每個 (貼文, 會員) 一列';
+COMMENT ON COLUMN spot_views.board_id       IS 'mutual_aid_board.id（post_type=offer 的現貨貼文）';
+COMMENT ON COLUMN spot_views.view_count     IS '該會員看這個現貨的次數（同一會員 N 分鐘內重複開只算一次）';
+COMMENT ON COLUMN spot_views.last_viewed_at IS '最後一次瀏覽時間，也是去重視窗的判斷依據';
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+-- 寫入只走 service role（liff-api）與 SECURITY DEFINER RPC，故不開 write policy。
+ALTER TABLE spot_views ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS auth_read_spot_views ON spot_views;
+CREATE POLICY auth_read_spot_views ON spot_views
+  FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::UUID);
+
+-- ── 記一次瀏覽 ───────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.rpc_track_spot_view(
+  p_tenant          UUID,
+  p_board_id        BIGINT,
+  p_member_id       BIGINT,
+  p_dedupe_minutes  INT DEFAULT 30
+)
+RETURNS TABLE (view_count BIGINT, viewer_count BIGINT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_jwt_tenant TEXT := auth.jwt() ->> 'tenant_id';
+BEGIN
+  IF v_jwt_tenant IS NOT NULL AND v_jwt_tenant::UUID <> p_tenant THEN
+    RAISE EXCEPTION 'tenant mismatch';
+  END IF;
+  IF p_board_id IS NULL OR p_member_id IS NULL THEN
+    RAISE EXCEPTION 'board_id and member_id are required';
+  END IF;
+  -- 只認現貨貼文（offer）；認領貼文 / 別租戶的 id 一律擋掉
+  IF NOT EXISTS (
+    SELECT 1 FROM mutual_aid_board b
+     WHERE b.id = p_board_id
+       AND b.tenant_id = p_tenant
+       AND b.post_type = 'offer'
+  ) THEN
+    RAISE EXCEPTION 'spot product not found';
+  END IF;
+
+  INSERT INTO spot_views AS sv (tenant_id, board_id, member_id)
+  VALUES (p_tenant, p_board_id, p_member_id)
+  ON CONFLICT (tenant_id, board_id, member_id) DO UPDATE
+     SET view_count = sv.view_count + CASE
+           WHEN sv.last_viewed_at
+                < NOW() - make_interval(mins => GREATEST(COALESCE(p_dedupe_minutes, 30), 0))
+           THEN 1 ELSE 0 END,
+         last_viewed_at = NOW();
+
+  RETURN QUERY
+  SELECT COALESCE(SUM(sv.view_count), 0)::BIGINT,
+         COUNT(*)::BIGINT
+    FROM spot_views sv
+   WHERE sv.tenant_id = p_tenant
+     AND sv.board_id = p_board_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_track_spot_view(UUID, BIGINT, BIGINT, INT)
+  IS '記一次現貨商品瀏覽（同會員同商品 N 分鐘內去重），回傳總瀏覽次數與不重複人數';
+
+-- ── 讀計數 ───────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.rpc_spot_view_counts(
+  p_board_ids BIGINT[] DEFAULT NULL,
+  p_tenant    UUID DEFAULT NULL
+)
+RETURNS TABLE (board_id BIGINT, view_count BIGINT, viewer_count BIGINT)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_jwt_tenant TEXT := auth.jwt() ->> 'tenant_id';
+  v_tenant     UUID := COALESCE(p_tenant, NULLIF(v_jwt_tenant, '')::UUID);
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant is required';
+  END IF;
+  IF v_jwt_tenant IS NOT NULL AND v_jwt_tenant::UUID <> v_tenant THEN
+    RAISE EXCEPTION 'tenant mismatch';
+  END IF;
+
+  RETURN QUERY
+  SELECT sv.board_id,
+         SUM(sv.view_count)::BIGINT AS view_count,
+         COUNT(*)::BIGINT           AS viewer_count
+    FROM spot_views sv
+   WHERE sv.tenant_id = v_tenant
+     AND (p_board_ids IS NULL OR sv.board_id = ANY (p_board_ids))
+   GROUP BY sv.board_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_spot_view_counts(BIGINT[], UUID)
+  IS '每個現貨商品的總瀏覽次數與不重複瀏覽人數；p_board_ids 省略 = 全租戶';
+
+GRANT EXECUTE ON FUNCTION public.rpc_track_spot_view(UUID, BIGINT, BIGINT, INT)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_spot_view_counts(BIGINT[], UUID)
+  TO authenticated, service_role;


### PR DESCRIPTION
會員 App 的商品（團購）頁現在會記錄瀏覽並顯示「N 次瀏覽」，後台開團列表
新增「瀏覽數」欄（tooltip 帶不重複會員數）—— 以前沒下單的流量完全看不到，
「沒人看到」跟「看到但沒買」被混成同一件事。

- 新表 campaign_views：每個 (商品, 會員) 一列累加，總次數 = SUM(view_count)、
  不重複人數 = COUNT(*)，列數上限是 會員數 × 團數。
- 刻意不在 group_buy_campaigns 放計數欄：那張表有 trg_touch_gbc，每次瀏覽
  都會把 updated_at 洗成瀏覽時間，管理頁的「更新」欄會變得沒有意義。
- rpc_track_campaign_view：同會員同商品 30 分鐘內去重（前端 useEffect 會因
  返回 / 重整重跑，只靠前端擋不住），回傳含本次的最新計數給前端直接顯示。
- rpc_campaign_view_counts：SQL 聚合，避開 PostgREST 1000 列上限。
  兩支都擋跨租戶（JWT tenant_id 與 p_tenant 不符即 raise）。
- liff-api 新增 track_campaign_view action，list_active_campaigns /
  get_campaign_detail 一併回 view_count；記不到只留 log，不影響購物流程。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Di83EUGPJ6f7EWqnBqPo1q