### PR TITLE
月結送審可撤銷：新增 rpc_revoke_settlement_send（sent→draft，僅總倉）

### DIFF
--- a/apps/admin/src/app/(protected)/transfers/settlement/detail/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/detail/page.tsx
@@ -140,9 +140,10 @@ export default function HqSettlementDetailPage() {
   const [editReason, setEditReason] = useState("");
 
   // 頁內確認列（取代 confirm()）與爭議處理行內輸入（取代 prompt()）
-  const [pendingAction, setPendingAction] = useState<"send" | "confirm" | "settle" | null>(null);
+  const [pendingAction, setPendingAction] = useState<"send" | "confirm" | "settle" | "revoke" | null>(null);
   const [resolvingId, setResolvingId] = useState<number | null>(null);
   const [resolveNote, setResolveNote] = useState("");
+  const [revokeReason, setRevokeReason] = useState("");
 
   // 金額調整（增減金額＋原因）
   const [showAdjForm, setShowAdjForm] = useState(false);
@@ -236,6 +237,7 @@ export default function HqSettlementDetailPage() {
       setPendingAction(null);
       setResolvingId(null);
       setResolveNote("");
+      setRevokeReason("");
       setShowAdjForm(false);
       setAdjAmount("");
       setAdjReason("");
@@ -294,6 +296,11 @@ export default function HqSettlementDetailPage() {
     if (!settlementId || !pendingAction) return;
     if (pendingAction === "send") {
       void runRpc("rpc_send_settlement_to_store", { p_settlement_id: settlementId });
+    } else if (pendingAction === "revoke") {
+      void runRpc("rpc_revoke_settlement_send", {
+        p_settlement_id: settlementId,
+        p_reason: revokeReason.trim() || null,
+      });
     } else if (pendingAction === "confirm") {
       void runRpc("rpc_confirm_store_monthly_settlement", { p_settlement_id: settlementId });
     } else {
@@ -319,7 +326,8 @@ export default function HqSettlementDetailPage() {
   const canEditEst = ["draft", "sent", "disputed"].includes(header.status);
   const openDisputes = disputes.filter((d) => d.status === "open");
   const monthLabel = header.settlement_month?.slice(0, 7);
-  const showActionBar = isDraft || header.status === "disputed" || header.status === "remitted";
+  const showActionBar =
+    isDraft || header.status === "sent" || header.status === "disputed" || header.status === "remitted";
 
   return (
     <div className={`flex flex-1 flex-col gap-4 p-6 ${showActionBar ? "pb-28" : ""}`}>
@@ -358,6 +366,7 @@ export default function HqSettlementDetailPage() {
       {header.status === "sent" && (
         <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
           📨 已送店家核對（{header.sent_at ? new Date(header.sent_at).toLocaleString("zh-TW") : "—"}），等待店家同意畫押或提出爭議。
+          店家還沒回應前，總部可用下方「撤銷送審」把單子收回草稿再改。
         </div>
       )}
       {header.status === "confirmed" && (
@@ -375,6 +384,14 @@ export default function HqSettlementDetailPage() {
       {header.status === "settled" && (
         <div className="rounded-md border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
           ✅ 已結案{header.settled_at ? `（${new Date(header.settled_at).toLocaleString("zh-TW")}）` : ""}。
+        </div>
+      )}
+
+      {/* 備註／軌跡（撤銷送審等操作會 append） */}
+      {header.notes && (
+        <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+          <div className="mb-1 font-medium">備註／軌跡</div>
+          <div className="whitespace-pre-wrap">{header.notes}</div>
         </div>
       )}
 
@@ -819,6 +836,15 @@ export default function HqSettlementDetailPage() {
                     </SpinButton>
                   </>
                 )}
+                {header.status === "sent" && (
+                  <SpinButton
+                    onClick={() => setPendingAction("revoke")}
+                    disabled={busy}
+                    className="rounded-md border border-amber-400 px-4 py-2 text-sm font-medium text-amber-700 transition hover:bg-amber-50 disabled:opacity-50 dark:border-amber-700 dark:text-amber-300 dark:hover:bg-amber-950"
+                  >
+                    ↩ 撤銷送審（退回草稿）
+                  </SpinButton>
+                )}
                 {header.status === "disputed" && (
                   <SpinButton
                     onClick={() => setPendingAction("send")}
@@ -846,9 +872,18 @@ export default function HqSettlementDetailPage() {
                   {pendingAction === "send" && (header.status === "disputed"
                     ? "爭議已處理完，重新送店家核對？"
                     : "送出對帳單給店家線上核對？")}
+                  {pendingAction === "revoke" && "撤銷送審、把對帳單收回草稿？店家清單會看不到這張單，也不能再核對。"}
                   {pendingAction === "confirm" && "直接確認此月結算（跳過店家線上核對）？確認後鎖定並自動產生應付帳款單。"}
                   {pendingAction === "settle" && "確認已收到店家匯款？結案後應收單將自動入帳，不可再改。"}
                 </span>
+                {pendingAction === "revoke" && (
+                  <input
+                    value={revokeReason}
+                    onChange={(e) => setRevokeReason(e.target.value)}
+                    placeholder="撤銷原因（選填，會記進備註）"
+                    className="w-64 rounded-md border border-zinc-300 px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+                  />
+                )}
                 <SpinButton
                   onClick={onConfirmPending}
                   disabled={busy}
@@ -857,7 +892,7 @@ export default function HqSettlementDetailPage() {
                   {busy ? "送出中…" : "確定"}
                 </SpinButton>
                 <SpinButton
-                  onClick={() => setPendingAction(null)}
+                  onClick={() => { setPendingAction(null); setRevokeReason(""); }}
                   disabled={busy}
                   className="rounded-md border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700"
                 >

--- a/docs/TEST-settlement-revoke-send.md
+++ b/docs/TEST-settlement-revoke-send.md
@@ -1,0 +1,65 @@
+# TEST — 月結送審撤銷（sent → draft，總倉發起）
+
+來源：Alex（2026-08-05）：「月結送審可以撤消，由總倉發起撤銷。」
+
+情境：總部按了「送店家線上核對」之後才發現送錯月份 / 漏加人工調整 / 估價要再修。
+撤銷前唯一的回頭路是等店家提爭議（disputed），但店家一按同意就 confirmed
+鎖住並產生應收單，來不及攔。
+
+Migration：`20260805000020_rpc_revoke_settlement_send.sql`
+- 新 RPC `rpc_revoke_settlement_send(p_settlement_id, p_operator, p_reason DEFAULT NULL)`：
+  status **僅 sent** 可撤 → 回 draft；清 `sent_at` / `sent_by`；撤銷軌跡
+  （時間＋原因）append 進 `notes`。
+- 角色 gate：`_settlement_caller_is_hq()`（20260715000120，`''` = legacy admin）。
+  店家不能自己退回 draft。
+- disputed（球已在總部、估價/調整本來就能改）與 confirmed / remitted / settled
+  （已鎖定、已產生應收單）一律擋下 —— 鎖定後動金額仍走爭議 / 應收單流程。
+
+狀態機（新增一條回頭邊）：
+
+```
+draft ──送單──▶ sent ──店家全同意──▶ confirmed ──▶ remitted ──▶ settled
+  ▲              │ │店家提爭議
+  └──撤銷送審────┘ ▼
+     （總倉）    disputed ──爭議全處理+重送──▶ sent
+```
+
+UI：`/transfers/settlement/detail?id=`（HQ 明細頁）
+- status=sent → 底部固定動作列出現「↩ 撤銷送審（退回草稿）」；確認列帶
+  選填的撤銷原因輸入框（沿用既有頁內確認列，不跳瀏覽器對話框）。
+- sent 的流程狀態列補一句提示（店家未回應前總部可收回）。
+- 新增「備註／軌跡」區塊顯示 `notes`（撤銷紀錄看得到；此前 notes 有抓沒顯示）。
+
+## 測試項目
+
+### RPC（線上 DO block + RAISE 強制 rollback，2026-08-05，settlement #479）
+- [x] T1 sent → 撤銷成功：status=draft、`sent_at`/`sent_by` 清成 NULL、
+      notes append `[撤銷送審 YYYY-MM-DD HH:MI]（原因）`、回傳 `was=sent`。
+- [x] T2 draft 再撤一次 → 擋「狀態 draft 不可撤銷送審（僅 sent…）」。
+- [x] T3 confirmed → 擋（已鎖定不從這裡開後門）。
+- [x] T4 不存在的 id → `settlement % not found`。
+- [ ] T5 店家帳號（store_manager JWT）呼叫 → 應擋「僅總部帳號可撤銷送審」。
+      未單獨驗；共用 `_settlement_caller_is_hq()`，與送單／人工調整同一支 gate。
+
+### UI（Playwright + fixture，10/10 通過）
+- [x] T6 status=sent 出現「撤銷送審（退回草稿）」鈕；sent 不出現「送店家線上核對」。
+- [x] T7 點擊 → 頁內確認列文案 +「撤銷原因（選填，會記進備註）」輸入框。
+- [x] T8 送出 → `rpc_revoke_settlement_send` 帶 `p_settlement_id` /
+      `p_reason` / `p_operator`（登入者 uid）。
+- [x] T9 撤銷後畫面回 draft：狀態顯示「草稿」、送單鈕回來、撤銷送審鈕消失。
+- [x] T10 「備註／軌跡」顯示撤銷紀錄。
+- [x] T11 tsc 乾淨。
+
+### 連鎖效果（既有行為，不需另外改；本次未重跑）
+- 店家端 `StoreSettlementReview` 只列 `sent` 起 → 撤銷後該單從店家清單消失。
+- `rpc_store_review_settlement` 守門 `status='sent'` → 店家手上開著的舊分頁
+  按同意／送爭議會被擋。
+- `rpc_settlement_action_count` 店家口徑算 sent+confirmed → 側欄 badge 自動 -1。
+- 生成器 `rpc_generate_hq_to_store_settlement` 重算範圍含 draft → 撤銷後改來源
+  資料會自動重算，人工調整（錨月份+店）也會重新套用。
+
+## 待辦 / 已知限制
+- [ ] 撤銷不會通知店家（沒推播）。店家若正在核對頁，會在按下同意時才吃到
+      「狀態 draft 不可核對」錯誤，而不是當場被踢出。
+- [ ] 只能撤 sent。若店家已提爭議（disputed）想整張重來，仍需逐筆標記已處理
+      後重送，或直接改資料再重送。

--- a/supabase/migrations/20260805000020_rpc_revoke_settlement_send.sql
+++ b/supabase/migrations/20260805000020_rpc_revoke_settlement_send.sql
@@ -1,0 +1,85 @@
+-- ============================================================
+-- 2026-08-05: 月結送審撤銷 rpc_revoke_settlement_send（sent → draft，總倉發起）
+--
+-- 需求（Alex）：「月結送審可以撤消，由總倉發起撤銷。」
+--   總部按了「送店家線上核對」之後才發現送錯月份 / 漏加人工調整 /
+--   自由轉貨估價還要再修，現況沒有回頭路：只能等店家提爭議
+--   （disputed）才輪回總部，或口頭拜託店家先別按 —— 但店家一按同意
+--   就直接 confirmed 鎖住並產生應收單，來不及攔。
+--
+-- 設計：
+--   - 只收 sent（已送店家核對、店家尚未動作）→ 回 draft。
+--     disputed（球本來就在總部，估價/調整都還能改）與 confirmed 起
+--     （已鎖定、已產生應收單）都不收；鎖定後要動金額一律走爭議 /
+--     應收單流程，不從這裡開後門。
+--   - 僅總部：_settlement_caller_is_hq()（20260715000120；'' = legacy
+--     admin）。店家不能自己把單子退回 draft —— 那等於單方面把帳撤掉。
+--   - 清掉 sent_at / sent_by（回 draft 就不該再顯示送單時間），撤銷軌跡
+--     append 進 notes（時間＋原因），重新送單時 sent_at 會重新蓋上。
+--     store_agreed_at/by 不動（sent 狀態下本來就是 NULL）。
+--   - 撤銷後的連鎖效果（都是既有行為，不需另外改）：
+--     * 店家端 StoreSettlementReview 只列 sent 起 → 該單從店家清單消失。
+--     * rpc_store_review_settlement 守門 status='sent' → 店家手上開著的
+--       舊分頁按同意/送爭議會被擋（'狀態 draft 不可核對'）。
+--     * rpc_settlement_action_count 店家口徑算 sent+confirmed → badge 自動 -1。
+--     * 生成器 rpc_generate_hq_to_store_settlement 重算範圍含 draft →
+--       撤銷後改來源資料會自動重算，人工調整（錨月份+店）也會重新套用。
+--
+-- 新函式，無歷史版本（grep supabase/migrations/ 確認無同名）。
+-- 依賴：public._settlement_caller_is_hq()（20260715000120）。
+-- Rollback：DROP FUNCTION public.rpc_revoke_settlement_send(BIGINT, UUID, TEXT);
+--   （已被撤回 draft 的列不會自動回 sent，需要時重新送單即可。）
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_revoke_settlement_send(
+  p_settlement_id BIGINT,
+  p_operator      UUID,
+  p_reason        TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_s      store_monthly_settlements%ROWTYPE;
+  v_reason TEXT := NULLIF(TRIM(p_reason), '');
+BEGIN
+  IF NOT public._settlement_caller_is_hq() THEN
+    RAISE EXCEPTION '僅總部帳號可撤銷送審（role=%）',
+      COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  END IF;
+
+  SELECT * INTO v_s FROM store_monthly_settlements
+   WHERE id = p_settlement_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'settlement % not found', p_settlement_id;
+  END IF;
+
+  IF v_s.status <> 'sent' THEN
+    RAISE EXCEPTION '狀態 % 不可撤銷送審（僅 sent 已送店家核對、店家尚未回應）', v_s.status;
+  END IF;
+
+  UPDATE store_monthly_settlements
+     SET status     = 'draft',
+         sent_at    = NULL,
+         sent_by    = NULL,
+         notes      = TRIM(BOTH E'\n' FROM
+           COALESCE(notes || E'\n', '')
+           || '[撤銷送審 ' || to_char(NOW(), 'YYYY-MM-DD HH24:MI') || ']'
+           || COALESCE('（' || v_reason || '）', '')),
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_settlement_id;
+
+  RETURN jsonb_build_object(
+    'settlement_id', p_settlement_id,
+    'status',        'draft',
+    'was',           v_s.status,
+    'sent_at',       v_s.sent_at,
+    'reason',        v_reason
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_revoke_settlement_send(BIGINT, UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_revoke_settlement_send IS
+  '總部撤銷月結送審：sent→draft（清 sent_at/sent_by、撤銷軌跡寫進 notes）。'
+  '僅 sent 可撤（店家已回應的 disputed、已鎖定的 confirmed 起都不收）；僅總部可發起。';


### PR DESCRIPTION
總部送店家核對後才發現送錯月份／漏加人工調整／估價要再改時，
現況沒有回頭路：只能等店家提爭議（disputed）才輪回總部，而店家
一按同意就 confirmed 鎖住並產生應收單，來不及攔。

- 新 RPC rpc_revoke_settlement_send(id, operator, reason)：僅 sent
  可撤 → 回 draft，清 sent_at/sent_by，撤銷軌跡（時間＋原因）
  append 進 notes。角色 gate 沿用 _settlement_caller_is_hq()，
  店家不能自己把單子退回 draft。
- disputed 與 confirmed 起一律擋（鎖定後動金額仍走爭議／應收單流程）。
- HQ 明細頁 sent 狀態新增「撤銷送審（退回草稿）」＋頁內確認列與選填
  原因輸入；補上「備註／軌跡」區塊（notes 原本有抓沒顯示）。
- 撤銷後店家清單（只列 sent 起）看不到該單、核對 RPC 的 status='sent'
  守門會擋掉舊分頁、badge 自動 -1、生成器重算範圍含 draft 不受影響。

驗證：線上 DO block + 強制 rollback（T1-T4 狀態守門全過）；
Playwright fixture 10/10；tsc 乾淨。文件 docs/TEST-settlement-revoke-send.md。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MSjgaDLaCCdubnrXyFycsn