### PR TITLE
feat(inbound): 少發配貨 — 收貨當下決定配給誰，沒配到的擋住不給取

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -97,13 +97,20 @@ function PickupPageContent() {
   // 一律排除「量已被未取退貨蓋掉」的品項行（退回總倉的貨不可再取）。
   function pickableItems(order: OpenOrder) {
     const act = activeItems(order).filter((it) => remainingQty(it) > 0);
-    if (order.status === "ready") return act;
+    // ready 單原本整單放行，但「少發配貨」會把沒配到的品項標成待補貨
+    // （customer_order_items.backorder_at → is_order_item_pickup_ready 回 false）。
+    // 不濾掉的話店員會勾得到、按下去才被 rpc_record_pickup 擋，訊息還會誤導成「尚未到貨」。
+    if (order.status === "ready") return act.filter((it) => itemReady.get(it.id) !== false);
     if (order.status === "partially_completed") return act.filter((it) => itemReady.get(it.id) !== false);
     if (order.status === "shipping") return act.filter((it) => itemReady.get(it.id) === true);
     return [];
   }
   function isPickable(order: OpenOrder): boolean {
     return pickableItems(order).length > 0;
+  }
+  // 該品項是否為「少發沒配到」→ 取貨頁要明講待補貨，不要只是消失
+  function isBackordered(order: OpenOrder, it: OpenOrder["items"][number]): boolean {
+    return order.status !== "shipping" && itemReady.get(it.id) === false;
   }
 
   const [pickup, setPickup] = useState<{ orderId: number; orderNo: string } | null>(null);
@@ -632,8 +639,18 @@ function PickupPageContent() {
                                     {returnedOf(it) > 0 && (
                                       <span className="rounded bg-orange-100 px-1 py-0.5 text-[10px] font-medium text-orange-800 dark:bg-orange-950 dark:text-orange-300">↩ 已退 {returnedOf(it)}</span>
                                     )}
-                                    {partialArrival && remainingQty(it) > 0 && !pickableIds.has(it.id) && (
-                                      <span className="rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">⏳ 未到貨</span>
+                                    {/* 少發配貨沒配到 → 明講「待補貨」，別讓品項無聲消失讓店員以為是系統壞了 */}
+                                    {remainingQty(it) > 0 && isBackordered(o, it) ? (
+                                      <span
+                                        className="rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                                        title="這批到貨量不夠分，這筆沒配到，要等下一批補貨"
+                                      >
+                                        ⏳ 待補貨
+                                      </span>
+                                    ) : (
+                                      partialArrival && remainingQty(it) > 0 && !pickableIds.has(it.id) && (
+                                        <span className="rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">⏳ 未到貨</span>
+                                      )
                                     )}
                                   </li>
                                 ))}

--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -25,7 +25,8 @@ type StoreRow = { id: number; name: string; location_id: number | null };
 // items：拆開的品項行（key = 合併同品相用的識別；自由轉貨掛虛擬 SKU，要用 description 當 key）
 // product = 只有商品名（不含規格），給群組標題用；name = 商品名 / 規格，明細表用
 type ItemLine = { key: string; skuId: number | null; product: string; name: string; skuCode: string | null; qty: number };
-// extraQty：這張單裡「沒有訂單對應」的件數（派出量 − 訂單需求量），見下方查詢註解
+// extraQty / shortQty：這張單的派出量 vs 訂單需求量差額（見下方查詢註解）
+//   extraQty = 多給、沒有訂單對應；shortQty = 不夠分，會有客人領不到
 type ItemSummary = {
   lines: number;
   totalQty: number;
@@ -33,6 +34,7 @@ type ItemSummary = {
   codes: string[];
   items: ItemLine[];
   extraQty: number;
+  shortQty: number;
 };
 
 // 列表上的一個可收合群組（product 模式＝同品相，wave 模式＝同撿貨單號）
@@ -47,6 +49,7 @@ type Group = {
   sortCode: string;
   waveDate: string | null; // 配送日，用來標「逾期 / 今天」
   extraQty: number;        // 這組總共被總倉多給幾件
+  shortQty: number;        // 這組總共少了幾件（訂單比派出多）
 };
 
 export default function TransfersInboxPage() {
@@ -284,7 +287,7 @@ export default function TransfersInboxPage() {
               if (code) skuCodeMap.set(s.id, code);
             }
           }
-          const emptySummary = (): ItemSummary => ({ lines: 0, totalQty: 0, names: [], codes: [], items: [], extraQty: 0 });
+          const emptySummary = (): ItemSummary => ({ lines: 0, totalQty: 0, names: [], codes: [], items: [], extraQty: 0, shortQty: 0 });
           for (const tid of transferIds) summary.set(tid, emptySummary());
           for (const it of items) {
             const cur = summary.get(it.transfer_id) ?? emptySummary();
@@ -308,16 +311,19 @@ export default function TransfersInboxPage() {
             summary.set(it.transfer_id, cur);
           }
 
-          // 「總倉多給」= 派出量 > 該店該團的訂單需求量（沒有訂單對應的那幾件）。
-          // 不是比 picking_wave_items 的 picked_qty vs qty — 線上 17429 列裡
-          // over_pick 是 0，用那個定義標籤永遠不會亮（見 20260805000040 migration）。
-          // 每張單的件數與彈窗裡「派出 − 訂單合計」同一套 join，兩邊數字保證一致。
-          const { data: overData } = await sb.rpc("rpc_get_over_ship_for_transfers", {
+          // 派出量 vs 該店該團的訂單需求量：多給（沒訂單對應）與不夠分（會有人領不到）。
+          // 不是比 picking_wave_items 的 picked_qty vs qty — 線上 17429 列裡 over_pick
+          // 是 0，用那個定義標籤永遠不會亮（見 20260805000050 migration）。
+          // 件數與彈窗裡「派出 − 訂單合計」同一套 join，兩邊數字保證一致。
+          const { data: diffData } = await sb.rpc("rpc_get_ship_vs_demand_for_transfers", {
             p_transfer_ids: transferIds,
           });
-          for (const [tid, extra] of Object.entries((overData as Record<string, unknown> | null) ?? {})) {
+          const diffs = (diffData as Record<string, { over?: number; short?: number }> | null) ?? {};
+          for (const [tid, d] of Object.entries(diffs)) {
             const cur = summary.get(Number(tid));
-            if (cur) cur.extraQty = Number(extra) || 0;
+            if (!cur) continue;
+            cur.extraQty = Number(d?.over) || 0;
+            cur.shortQty = Number(d?.short) || 0;
           }
         }
 
@@ -445,12 +451,14 @@ export default function TransfersInboxPage() {
             sortCode: w?.wave_code ?? (wid !== null ? `WAVE-${wid}` : ""),
             waveDate: w?.wave_date ?? null,
             extraQty: 0,
+            shortQty: 0,
           };
           map.set(key, entry);
         }
         entry.transfers.push(t);
         entry.totalQty += itemSummary.get(t.id)?.totalQty ?? 0;
         entry.extraQty += itemSummary.get(t.id)?.extraQty ?? 0;
+        entry.shortQty += itemSummary.get(t.id)?.shortQty ?? 0;
       }
       return Array.from(map.values()).sort((a, b) => {
         // 「其他調撥」永遠墊底，其餘依撿貨單號遞減
@@ -490,12 +498,14 @@ export default function TransfersInboxPage() {
           sortCode: `${date || "9999-99-99"}|${products.join("、")}|${dest}`,
           waveDate: date || null,
           extraQty: 0,
+          shortQty: 0,
         };
         map.set(key, entry);
       }
       entry.transfers.push(t);
       entry.totalQty += s?.totalQty ?? 0;
       entry.extraQty += s?.extraQty ?? 0;
+      entry.shortQty += s?.shortQty ?? 0;
     }
     const asc = tab === "unreceived";
     return Array.from(map.values()).sort((a, b) =>
@@ -1060,6 +1070,9 @@ export default function TransfersInboxPage() {
                         <Pill tone="emerald">✓ 已收到</Pill>
                       )}
                       {dueTag && <Pill tone={dueTag === "逾期" ? "rose" : "amber"}>{dueTag}</Pill>}
+                      {g.shortQty > 0 && (
+                        <Pill tone="rose">⚠ 少 {g.shortQty} 件 · 訂單比到貨多</Pill>
+                      )}
                       {g.extraQty > 0 && (
                         <Pill tone="blue">🎁 總倉多給 {g.extraQty} 件</Pill>
                       )}
@@ -1223,6 +1236,14 @@ export default function TransfersInboxPage() {
                               </SpinButton>
                               {summary && summary.lines > 1 && (
                                 <span className="ml-1 text-[10px] font-normal text-zinc-400">{summary.lines} 項</span>
+                              )}
+                              {summary && summary.shortQty > 0 && (
+                                <div
+                                  className="text-[10px] font-medium text-rose-600 dark:text-rose-400"
+                                  title="訂單比這批到貨量多，這幾件會有客人領不到 — 點數量看是哪幾筆訂單"
+                                >
+                                  ⚠ 少 {summary.shortQty}
+                                </div>
                               )}
                               {summary && summary.extraQty > 0 && (
                                 <div

--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -17,6 +17,7 @@ import { useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 import { fetchAllRows } from "@/lib/fetchAllRows";
 import { fanoutPickupNotifications } from "@/lib/pickupNotify";
 import { TransferOrdersModal, type ModalSkuLine } from "@/components/TransferOrdersModal";
+import { ShortageAllocateModal } from "@/components/ShortageAllocateModal";
 
 type Location = { id: number; name: string };
 type StoreLite = { id: number; location_id: number | null };
@@ -66,6 +67,10 @@ export default function TransfersInboxPage() {
   // 點數量開的「訂單明細」彈窗：看這幾件分別是誰的訂單、多給的幾件沒人訂
   const [ordersFor, setOrdersFor] = useState<
     { transferId: number; transferNo: string; skuLines: ModalSkuLine[] } | null
+  >(null);
+  // 少發配貨對話框：這批不夠分時決定配給誰
+  const [allocFor, setAllocFor] = useState<
+    { transferId: number; skuId: number; skuName: string } | null
   >(null);
   const [locationFilter, setLocationFilter] = useState<number | "all">("all");
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -1188,6 +1193,21 @@ export default function TransfersInboxPage() {
                                       >
                                         × {it.qty}
                                       </SpinButton>
+                                      {summary.shortQty > 0 && it.skuId != null && (
+                                        <SpinButton
+                                          onClick={() =>
+                                            setAllocFor({
+                                              transferId: t.id,
+                                              skuId: it.skuId as number,
+                                              skuName: it.name,
+                                            })
+                                          }
+                                          className="ml-1.5 rounded border border-rose-300 px-1.5 py-0.5 text-[10px] font-medium text-rose-700 hover:bg-rose-50 dark:border-rose-800 dark:text-rose-400 dark:hover:bg-rose-950"
+                                          title="這批不夠分 — 決定配給哪幾筆訂單"
+                                        >
+                                          ⚖️ 配貨
+                                        </SpinButton>
+                                      )}
                                     </li>
                                   ))}
                                 </ul>
@@ -1328,6 +1348,16 @@ export default function TransfersInboxPage() {
             載入全部
           </SpinButton>
         </div>
+      )}
+
+      {allocFor && (
+        <ShortageAllocateModal
+          transferId={allocFor.transferId}
+          skuId={allocFor.skuId}
+          skuName={allocFor.skuName}
+          onClose={() => setAllocFor(null)}
+          onSaved={() => reloadAndRefreshBadge()}
+        />
       )}
 
       {ordersFor && (

--- a/apps/admin/src/components/ShortageAllocateModal.tsx
+++ b/apps/admin/src/components/ShortageAllocateModal.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Modal } from "@/components/Modal";
+import Spinner from "@/components/Spinner";
+import SpinButton from "@/components/SpinButton";
+import { getSupabase } from "@/lib/supabase";
+import { orderStatusLabel } from "@/lib/orderStatus";
+import { translateRpcError } from "@/lib/rpcError";
+
+// 少發配貨：到貨量不夠分給所有訂單時，由收貨的人決定這批配給誰。
+// 沒配到的標成「待補貨」（customer_order_items.backorder_at），在補到之前不可取貨
+// —— 取貨閘門 is_order_item_pickup_ready 會擋，rpc_record_pickup 也擋得住。
+// 見 20260805000060_shortage_allocation.sql。
+
+type Candidate = {
+  item_id: number;
+  order_id: number;
+  order_no: string;
+  customer: string | null;
+  order_status: string;
+  qty: number;
+  backorder: boolean;
+  created_at: string;
+};
+
+type Payload = { supplied: number; picked: number; available: number; items: Candidate[] };
+
+export function ShortageAllocateModal({
+  transferId,
+  skuId,
+  skuName,
+  onClose,
+  onSaved,
+}: {
+  transferId: number;
+  skuId: number;
+  skuName: string;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [data, setData] = useState<Payload | null>(null);
+  const [allocated, setAllocated] = useState<Set<number>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    const sb = getSupabase();
+    const { data: d, error: e } = await sb.rpc("rpc_get_allocation_candidates", {
+      p_transfer_id: transferId,
+      p_sku_id: skuId,
+    });
+    if (e) throw new Error(e.message);
+    const payload = d as Payload;
+    setData({
+      ...payload,
+      supplied: Number(payload.supplied),
+      picked: Number(payload.picked),
+      available: Number(payload.available),
+      items: (payload.items ?? []).map((r) => ({ ...r, qty: Number(r.qty) })),
+    });
+    // 進來時先反映現況：沒被標待補貨的就是目前配到的
+    setAllocated(new Set((payload.items ?? []).filter((r) => !r.backorder).map((r) => r.item_id)));
+  }, [transferId, skuId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await load();
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  const allocatedQty = useMemo(
+    () => (data?.items ?? []).filter((r) => allocated.has(r.item_id)).reduce((s, r) => s + r.qty, 0),
+    [data, allocated],
+  );
+  const backorderQty = useMemo(
+    () => (data?.items ?? []).filter((r) => !allocated.has(r.item_id)).reduce((s, r) => s + r.qty, 0),
+    [data, allocated],
+  );
+  const over = data ? allocatedQty - data.available : 0;
+
+  // 依訂單時間配貨：候選已由後端依 created_at, order_no 排好，
+  // 由早到晚累加，裝得下就配、裝不下就跳過（不拆行，一筆訂單要嘛全配要嘛待補）。
+  function autoAllocateByTime() {
+    if (!data) return;
+    let left = data.available;
+    const next = new Set<number>();
+    for (const r of data.items) {
+      if (r.qty <= left) {
+        next.add(r.item_id);
+        left -= r.qty;
+      }
+    }
+    setAllocated(next);
+  }
+
+  function toggle(id: number) {
+    setAllocated((cur) => {
+      const n = new Set(cur);
+      if (n.has(id)) n.delete(id);
+      else n.add(id);
+      return n;
+    });
+  }
+
+  async function save() {
+    if (!data) return;
+    if (over > 0) return;
+    const backorderCount = data.items.length - allocated.size;
+    if (
+      !confirm(
+        `確認配貨？\n\n配到 ${allocated.size} 筆（${allocatedQty} 件）\n` +
+          `待補貨 ${backorderCount} 筆（${backorderQty} 件）— 這些訂單在補到貨之前不能取貨。\n\n` +
+          `不會通知客人，請店家自行聯繫。`,
+      )
+    )
+      return;
+    setBusy(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) throw new Error("尚未登入");
+      const { data: res, error: e } = await sb.rpc("rpc_allocate_shortage", {
+        p_transfer_id: transferId,
+        p_sku_id: skuId,
+        p_allocated_item_ids: Array.from(allocated),
+        p_operator: operator,
+      });
+      if (e) throw new Error(translateRpcError(e));
+      const r = (res ?? {}) as { backordered?: number; freed?: number };
+      alert(`✅ 配貨完成：待補貨 ${r.backordered ?? 0} 筆、解除 ${r.freed ?? 0} 筆`);
+      onSaved();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // 確定補不到 → 沿用斷貨語意取消（品項 cancelled + stockout_at）
+  async function cancelBackorders() {
+    if (!data) return;
+    const ids = data.items.filter((r) => r.backorder).map((r) => r.item_id);
+    if (ids.length === 0) return;
+    if (
+      !confirm(
+        `把目前 ${ids.length} 筆「待補貨」直接取消？\n\n` +
+          `會把這些品項標成斷貨取消，若整張訂單品項都沒了且沒收過錢，訂單也會一併取消。\n` +
+          `此動作不可復原。`,
+      )
+    )
+      return;
+    setBusy(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) throw new Error("尚未登入");
+      const { data: res, error: e } = await sb.rpc("rpc_cancel_backorder_items", {
+        p_item_ids: ids,
+        p_operator: operator,
+      });
+      if (e) throw new Error(translateRpcError(e));
+      const r = (res ?? {}) as { items_cancelled?: number; orders_cancelled?: number };
+      alert(`已取消 ${r.items_cancelled ?? 0} 個品項、${r.orders_cancelled ?? 0} 張訂單`);
+      await load();
+      onSaved();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const hasBackordered = (data?.items ?? []).some((r) => r.backorder);
+
+  return (
+    <Modal open onClose={onClose} title={`⚖️ 少發配貨 — ${skuName}`} maxWidth="max-w-4xl">
+      <div className="space-y-3">
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        {data === null && !error && (
+          <div className="flex items-center justify-center gap-2 py-8 text-sm text-zinc-500">
+            <Spinner size={16} /> 載入訂單…
+          </div>
+        )}
+
+        {data && (
+          <>
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm dark:border-zinc-800 dark:bg-zinc-900/60">
+              <span>
+                到貨 <b>{data.supplied}</b> 件
+                {data.picked > 0 && <span className="text-zinc-500">（已領走 {data.picked}）</span>}
+              </span>
+              <span>
+                可配 <b className="text-emerald-700 dark:text-emerald-400">{data.available}</b> 件
+              </span>
+              <span>
+                已配 <b className={over > 0 ? "text-rose-600" : ""}>{allocatedQty}</b> 件
+              </span>
+              <span>
+                待補貨 <b className="text-amber-700 dark:text-amber-400">{backorderQty}</b> 件
+              </span>
+              <SpinButton
+                onClick={autoAllocateByTime}
+                className="ml-auto rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900"
+                title="依下單時間由早到晚配，配滿為止（同時間以訂單編號先後為準）"
+              >
+                ⏱ 依訂單時間自動配
+              </SpinButton>
+            </div>
+
+            {over > 0 && (
+              <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-900 dark:bg-rose-950 dark:text-rose-300">
+                已配 {allocatedQty} 件超過可配的 {data.available} 件，請取消勾選 {over} 件。
+              </div>
+            )}
+
+            <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+              <table className="w-full min-w-[600px] text-sm">
+                <thead>
+                  <tr className="border-b border-zinc-200 bg-zinc-50 text-[11px] text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900">
+                    <th className="w-10 px-3 py-2">配貨</th>
+                    <th className="px-3 py-2 text-left font-medium">訂單編號</th>
+                    <th className="px-3 py-2 text-left font-medium">顧客</th>
+                    <th className="px-3 py-2 text-left font-medium">下單時間</th>
+                    <th className="px-3 py-2 text-right font-medium">數量</th>
+                    <th className="px-3 py-2 text-right font-medium">狀態</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                  {data.items.map((r) => {
+                    const on = allocated.has(r.item_id);
+                    return (
+                      <tr key={r.item_id} className={on ? "" : "bg-amber-50/60 dark:bg-amber-950/20"}>
+                        <td className="px-3 py-2 text-center">
+                          <input
+                            type="checkbox"
+                            checked={on}
+                            onChange={() => toggle(r.item_id)}
+                            className="cursor-pointer"
+                          />
+                        </td>
+                        <td className="px-3 py-2 font-mono text-xs">{r.order_no}</td>
+                        <td className="max-w-[220px] truncate px-3 py-2" title={r.customer ?? ""}>
+                          {r.customer || "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-xs text-zinc-500">
+                          {new Date(r.created_at).toLocaleString("zh-TW", {
+                            dateStyle: "short",
+                            timeStyle: "short",
+                          })}
+                        </td>
+                        <td className="px-3 py-2 text-right font-semibold tabular-nums">{r.qty}</td>
+                        <td className="whitespace-nowrap px-3 py-2 text-right text-xs">
+                          {on ? (
+                            <span className="text-zinc-500">{orderStatusLabel(r.order_status)}</span>
+                          ) : (
+                            <span className="font-medium text-amber-700 dark:text-amber-400">待補貨</span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {data.items.length === 0 && (
+                    <tr>
+                      <td colSpan={6} className="px-3 py-6 text-center text-zinc-500">
+                        沒有未取的訂單 — 這批不需要配貨。
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              {hasBackordered && (
+                <SpinButton
+                  onClick={cancelBackorders}
+                  disabled={busy}
+                  className="rounded-md border border-rose-300 px-3 py-1.5 text-xs text-rose-700 hover:bg-rose-50 disabled:opacity-50 dark:border-rose-800 dark:text-rose-400 dark:hover:bg-rose-950"
+                  title="確定補不到貨時，把待補貨的品項直接標成斷貨取消"
+                >
+                  ✕ 補不到了，把待補貨轉取消
+                </SpinButton>
+              )}
+              <SpinButton
+                onClick={save}
+                disabled={busy || over > 0 || data.items.length === 0}
+                className="ml-auto rounded-md bg-emerald-600 px-5 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
+              >
+                {busy ? "處理中…" : "儲存配貨"}
+              </SpinButton>
+            </div>
+            <p className="text-[11px] text-zinc-500">
+              沒配到的訂單會標成「待補貨」，在補到貨之前取貨頁不會讓它取走。不會發通知給客人。
+              下一批到貨時再開這個視窗，把他們勾起來就會解除。
+            </p>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+export default ShortageAllocateModal;

--- a/supabase/migrations/20260805000050_rpc_ship_vs_demand_for_transfers.sql
+++ b/supabase/migrations/20260805000050_rpc_ship_vs_demand_for_transfers.sql
@@ -1,0 +1,84 @@
+-- ============================================================
+-- rpc_get_ship_vs_demand_for_transfers：每張派貨單的「派出量 vs 訂單需求量」差額
+--   → { "<transfer_id>": { "over": <多給件數>, "short": <不夠分的件數> } }
+--   兩邊都是 0 的單不回傳。
+--
+-- 取代 20260805000040 的 rpc_get_over_ship_for_transfers（只算多給的那一半）。
+--
+-- 為什麼要補 short：2026-08-05 松山店 / 永和店的阿猴鮮奶（G01476-01）各派 10 瓶、
+--   訂單 11 瓶。店端收貨沒有短收（派 10 收 10），缺口是排波次時就少排了
+--   （全團訂單 107、波次只排 105，而採購實收 120，總倉根本有貨）。
+--   店家在收貨當下完全看不出這批不夠分，等到最後一位客人上門才發現沒貨。
+--   這個差額是文件層的事實（訂單 vs 派出），不依賴會漂移的店內庫存餘額。
+--
+-- 為什麼不用「店內庫存 < 未取訂單量」當警示：線上實測光松山＋永和兩家店就有
+--   15 個以上品項符合，還有 on_hand 是負數的（-4）。店內餘額不可靠，拿來當
+--   警示只會變成天天在叫的狼來了。
+--
+-- 需求量的 join 與 rpc_get_orders_for_transfer 的 wave 路線一致，
+--   標籤上的件數 = 彈窗裡「派出 − 訂單合計」。
+-- campaign_id IS NULL 的線（補貨直送）沒有顧客訂單，兩邊都不算。
+--
+-- 基底版本：20260805000040_rpc_get_over_ship_for_transfers（本檔一併 DROP 舊函式）
+-- rollback: DROP FUNCTION IF EXISTS public.rpc_get_ship_vs_demand_for_transfers(BIGINT[]);
+--           並重跑 20260805000040。
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.rpc_get_over_ship_for_transfers(BIGINT[]);
+
+CREATE OR REPLACE FUNCTION public.rpc_get_ship_vs_demand_for_transfers(
+  p_transfer_ids BIGINT[]
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  WITH pw AS (
+    SELECT pwi.generated_transfer_id      AS tid,
+           pwi.tenant_id,
+           pwi.campaign_id,
+           pwi.store_id,
+           pwi.sku_id,
+           COALESCE(pwi.picked_qty, pwi.qty) AS shipped
+      FROM picking_wave_items pwi
+     WHERE pwi.generated_transfer_id = ANY(p_transfer_ids)
+       AND pwi.campaign_id IS NOT NULL
+  ),
+  dem AS (
+    SELECT pw.tid, pw.shipped, d.demand
+      FROM pw
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(SUM(coi.qty), 0) AS demand
+          FROM customer_orders co
+          JOIN customer_order_items coi
+            ON coi.order_id = co.id
+           AND coi.sku_id   = pw.sku_id
+           AND coi.status NOT IN ('cancelled', 'expired')
+         WHERE co.tenant_id       = pw.tenant_id
+           AND co.campaign_id     = pw.campaign_id
+           AND co.pickup_store_id = pw.store_id
+           AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+           AND co.transferred_from_order_id IS NULL
+           AND (co.order_kind = 'normal' OR co.order_kind IS NULL)
+      ) d
+  ),
+  per_transfer AS (
+    SELECT dem.tid,
+           SUM(GREATEST(dem.shipped - dem.demand, 0)) AS over_qty,
+           SUM(GREATEST(dem.demand - dem.shipped, 0)) AS short_qty
+      FROM dem
+     GROUP BY dem.tid
+    HAVING SUM(GREATEST(dem.shipped - dem.demand, 0)) > 0
+        OR SUM(GREATEST(dem.demand - dem.shipped, 0)) > 0
+  )
+  SELECT COALESCE(
+           jsonb_object_agg(
+             per_transfer.tid::text,
+             jsonb_build_object('over', per_transfer.over_qty,
+                                'short', per_transfer.short_qty)
+           ),
+           '{}'::jsonb)
+    FROM per_transfer;
+$$;
+
+-- Postgres 預設把新函式的 EXECUTE 給 PUBLIC；這支是 SECURITY DEFINER，
+-- 雖然只吐數字，仍不該讓 anon 拿來探測各店各團的出貨與訂單量。
+REVOKE ALL ON FUNCTION public.rpc_get_ship_vs_demand_for_transfers(BIGINT[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_get_ship_vs_demand_for_transfers(BIGINT[]) TO authenticated;

--- a/supabase/migrations/20260805000060_shortage_allocation.sql
+++ b/supabase/migrations/20260805000060_shortage_allocation.sql
@@ -1,0 +1,330 @@
+-- ============================================================
+-- 少發配貨（待補貨）
+--
+-- 動機：2026-08-05 松山店 / 永和店的阿猴鮮奶各派 10 瓶、訂單 11 瓶，7 筆訂單
+--   卻全部顯示「可取貨」——因為 is_order_item_pickup_ready 的 Path B 是布林
+--   EXISTS（該店該團該品項有收到貨 > 0 就全部放行），從不比較「到的量夠不夠分」。
+--   先到的人領走，最後一位上門才發現沒貨。線上已收貨的單裡有 70 組（店 × 團 ×
+--   品項）訂單量 > 到貨量，共缺 190 件、牽涉 267 筆未取訂單。
+--
+-- 做法：不新增分配表，只標記「沒配到的那些」。
+--   customer_order_items.backorder_at 有值 = 待補貨，取貨閘門就擋下來。
+--   沒有缺貨的單這欄永遠是 NULL → 現有行為完全不變，風險只落在真的缺貨的組合。
+--   閘門一改，rpc_record_pickup 的品項擋板（呼叫同一支函式，見 20260801000000:745）
+--   也跟著生效，伺服端擋得住，不只是畫面上不給點。
+--
+-- 排序基準：co.created_at, co.order_no。ordered_at 全庫都是 NULL（22522/22522），
+--   created_at 又大量重複（近 30 天 22522 筆只有 8612 個相異值，開團是整批匯入的），
+--   單靠時間排不出先後；order_no 末碼是團內流水號，拿來當同分決勝可還原批次內順序。
+--
+-- 基底版本：
+--   is_order_item_pickup_ready = 20260704000000（唯一版本，已與線上 pg_get_functiondef 比對一致）
+-- rollback:
+--   重跑 20260704000000 的 CREATE OR REPLACE；
+--   DROP FUNCTION IF EXISTS public.rpc_allocate_shortage(bigint,bigint,bigint[],uuid);
+--   DROP FUNCTION IF EXISTS public.rpc_get_allocation_candidates(bigint,bigint);
+--   DROP FUNCTION IF EXISTS public.rpc_cancel_backorder_items(bigint[],uuid,text);
+--   ALTER TABLE customer_order_items DROP COLUMN IF EXISTS backorder_at, DROP COLUMN IF EXISTS backorder_by;
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. 待補貨標記
+-- ------------------------------------------------------------
+ALTER TABLE customer_order_items
+  ADD COLUMN IF NOT EXISTS backorder_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS backorder_by UUID;
+
+COMMENT ON COLUMN customer_order_items.backorder_at IS
+  '待補貨（少發配貨時沒配到）時間；NULL = 正常。由 rpc_allocate_shortage 寫入 / 清除。'
+  '有值時 is_order_item_pickup_ready 回 false，取貨會被擋。';
+
+-- 待補貨是少數，用部分索引讓「查某店還有哪些待補」不必全表掃
+CREATE INDEX IF NOT EXISTS idx_coi_backorder
+  ON customer_order_items (sku_id, order_id)
+  WHERE backorder_at IS NOT NULL;
+
+-- ------------------------------------------------------------
+-- 2. 取貨閘門：加一個 backorder_at IS NULL（其餘與 20260704000000 逐字相同）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_order_item_pickup_ready(p_item_id bigint)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT EXISTS (
+    SELECT 1
+      FROM customer_order_items coi
+      JOIN customer_orders co ON co.id = coi.order_id
+     WHERE coi.id = p_item_id
+       AND co.status NOT IN ('completed','expired','cancelled','transferred_out')
+       -- 只有未取的 active item 才有「可取貨」可言
+       AND coi.status IN ('pending','reserved','ready')
+       -- 少發配貨：沒配到的品項標成待補貨，在補到之前不可取
+       --（rpc_allocate_shortage 寫入 / 清除；沒有缺貨的單這欄永遠是 NULL，行為不變）
+       AND coi.backorder_at IS NULL
+       AND CASE
+         -- aid_transfer + 跨店：只認自己的 transfer 被收貨 (Path A)
+         WHEN EXISTS (
+                SELECT 1 FROM customer_order_items x
+                 WHERE x.order_id = co.id AND x.source = 'aid_transfer'
+              )
+              AND co.transferred_from_order_id IS NOT NULL
+              AND (
+                SELECT src.pickup_store_id FROM customer_orders src
+                 WHERE src.id = co.transferred_from_order_id
+              ) IS DISTINCT FROM co.pickup_store_id
+         THEN EXISTS (
+           SELECT 1 FROM transfers t
+            WHERE t.customer_order_id = co.id
+              AND t.tenant_id = co.tenant_id
+              AND t.status IN ('received','closed')
+         )
+         ELSE (
+           -- Path A：aid 單 transfer FK 收貨
+           EXISTS (
+             SELECT 1 FROM transfers t
+              WHERE t.customer_order_id = co.id
+                AND t.tenant_id = co.tenant_id
+                AND t.status IN ('received','closed')
+           )
+           OR
+           -- Path B：campaign 對齊且該波次該 SKU 實收 qty>0
+           EXISTS (
+             SELECT 1
+               FROM picking_wave_items pwi
+               JOIN transfers t ON t.id = pwi.generated_transfer_id
+               JOIN transfer_items ti ON ti.transfer_id = t.id
+                                     AND ti.sku_id = coi.sku_id
+              WHERE pwi.tenant_id   = co.tenant_id
+                AND pwi.campaign_id = co.campaign_id
+                AND pwi.store_id    = co.pickup_store_id
+                AND pwi.sku_id      = coi.sku_id
+                AND t.status IN ('received','closed')
+                AND ti.qty_received > 0
+           )
+           OR
+           -- Path C：該 (campaign,store,sku) 完全無對齊波次（彙整 PR）才退用 store+sku 實收
+           (
+             NOT EXISTS (
+               SELECT 1 FROM picking_wave_items pwi
+                WHERE pwi.tenant_id   = co.tenant_id
+                  AND pwi.campaign_id = co.campaign_id
+                  AND pwi.store_id    = co.pickup_store_id
+                  AND pwi.sku_id      = coi.sku_id
+             )
+             AND EXISTS (
+               SELECT 1
+                 FROM stores st
+                 JOIN transfers t ON t.transfer_type = 'hq_to_store'
+                                 AND t.dest_location = st.location_id
+                                 AND t.tenant_id     = co.tenant_id
+                                 AND t.status IN ('received','closed')
+                 JOIN transfer_items ti ON ti.transfer_id = t.id
+                                       AND ti.sku_id = coi.sku_id
+                                       AND ti.qty_received > 0
+                WHERE st.id = co.pickup_store_id
+             )
+           )
+         )
+       END
+  );
+$function$;
+
+COMMENT ON FUNCTION public.is_order_item_pickup_ready(bigint) IS
+  '單一品項是否已到貨可取（Path A/B/C，shortage-aware）。'
+  '20260703000000 的整單判定搬到品項粒度：未到貨品項個別擋、已到貨可先取。'
+  '20260805000060 加上待補貨（backorder_at）擋板：少發配貨時沒配到的品項不可取。';
+
+-- ------------------------------------------------------------
+-- 3. rpc_get_allocation_candidates — 某張派貨單某個品項的可配額度與候選訂單
+--    回 { supplied, picked, available, allocated, items:[...] }
+--    supplied  該店該團該品項「已實收」的總量（跨多批到貨累加）
+--    picked    已經被領走的量（不能再配給別人）
+--    available supplied − picked，這就是還能配出去的量
+--    items     未取的品項行，依 created_at, order_no 排序（＝「依訂單時間」）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_get_allocation_candidates(
+  p_transfer_id BIGINT,
+  p_sku_id      BIGINT
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  WITH ctx AS (
+    SELECT pwi.tenant_id, pwi.campaign_id, pwi.store_id, pwi.sku_id
+      FROM picking_wave_items pwi
+     WHERE pwi.generated_transfer_id = p_transfer_id
+       AND pwi.sku_id = p_sku_id
+       AND pwi.campaign_id IS NOT NULL
+     LIMIT 1
+  ),
+  supplied AS (
+    -- 同一個 (團,店,品項) 可能分好幾批到，全部已收的實收量都算進可配額度
+    SELECT COALESCE(SUM(ti.qty_received), 0) AS qty
+      FROM ctx
+      JOIN picking_wave_items pwi
+        ON pwi.tenant_id = ctx.tenant_id AND pwi.campaign_id = ctx.campaign_id
+       AND pwi.store_id  = ctx.store_id  AND pwi.sku_id      = ctx.sku_id
+      JOIN transfers t      ON t.id = pwi.generated_transfer_id
+                           AND t.status IN ('received', 'closed')
+      JOIN transfer_items ti ON ti.transfer_id = t.id AND ti.sku_id = ctx.sku_id
+  ),
+  rows_all AS (
+    SELECT coi.id            AS item_id,
+           co.id             AS order_id,
+           co.order_no,
+           COALESCE(m.name, co.nickname_snapshot) AS customer,
+           co.status         AS order_status,
+           coi.status        AS item_status,
+           coi.qty,
+           coi.backorder_at,
+           co.created_at
+      FROM ctx
+      JOIN customer_orders co
+        ON co.tenant_id        = ctx.tenant_id
+       AND co.campaign_id      = ctx.campaign_id
+       AND co.pickup_store_id  = ctx.store_id
+       AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+       AND co.transferred_from_order_id IS NULL
+       AND (co.order_kind = 'normal' OR co.order_kind IS NULL)
+      JOIN customer_order_items coi
+        ON coi.order_id = co.id
+       AND coi.sku_id   = ctx.sku_id
+       AND coi.status NOT IN ('cancelled', 'expired')
+      LEFT JOIN members m ON m.id = co.member_id
+  ),
+  picked AS (
+    SELECT COALESCE(SUM(r.qty), 0) AS qty FROM rows_all r
+     WHERE r.item_status IN ('picked_up', 'partially_picked_up')
+  )
+  SELECT jsonb_build_object(
+    'supplied',  (SELECT qty FROM supplied),
+    'picked',    (SELECT qty FROM picked),
+    'available', GREATEST((SELECT qty FROM supplied) - (SELECT qty FROM picked), 0),
+    'items', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+               'item_id',      r.item_id,
+               'order_id',     r.order_id,
+               'order_no',     r.order_no,
+               'customer',     r.customer,
+               'order_status', r.order_status,
+               'qty',          r.qty,
+               'backorder',    r.backorder_at IS NOT NULL,
+               'created_at',   r.created_at
+             ) ORDER BY r.created_at, r.order_no)
+        FROM rows_all r
+       WHERE r.item_status IN ('pending', 'reserved', 'ready')
+    ), '[]'::jsonb)
+  );
+$$;
+
+-- ------------------------------------------------------------
+-- 4. rpc_allocate_shortage — 配貨：指定「配到的」品項，其餘同組未取品項全部標待補貨
+--    p_allocated_item_ids 以外的候選一律 backorder；名單內的一律清除 backorder，
+--    所以下一批到貨時再呼叫一次就能把先前沒配到的補回來。
+--    只動 (該派貨單所屬的 團,店,品項) 這一組，不會波及別團別店。
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_allocate_shortage(
+  p_transfer_id        BIGINT,
+  p_sku_id             BIGINT,
+  p_allocated_item_ids BIGINT[],
+  p_operator           UUID
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_ctx      RECORD;
+  v_alloc    BIGINT[] := COALESCE(p_allocated_item_ids, ARRAY[]::BIGINT[]);
+  v_freed    INT := 0;
+  v_blocked  INT := 0;
+BEGIN
+  SELECT pwi.tenant_id, pwi.campaign_id, pwi.store_id, pwi.sku_id
+    INTO v_ctx
+    FROM picking_wave_items pwi
+   WHERE pwi.generated_transfer_id = p_transfer_id
+     AND pwi.sku_id = p_sku_id
+     AND pwi.campaign_id IS NOT NULL
+   LIMIT 1;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '這張派貨單的該品項查不到對應的撿貨波次（可能是補貨或自由轉貨），無法配貨';
+  END IF;
+
+  -- 配到的：解除待補貨
+  UPDATE customer_order_items coi
+     SET backorder_at = NULL, backorder_by = NULL, updated_by = p_operator, updated_at = NOW()
+    FROM customer_orders co
+   WHERE co.id = coi.order_id
+     AND coi.id = ANY(v_alloc)
+     AND coi.sku_id = v_ctx.sku_id
+     AND co.tenant_id = v_ctx.tenant_id
+     AND co.campaign_id = v_ctx.campaign_id
+     AND co.pickup_store_id = v_ctx.store_id
+     AND coi.backorder_at IS NOT NULL;
+  GET DIAGNOSTICS v_freed = ROW_COUNT;
+
+  -- 沒配到的：標待補貨（已領走的不動）
+  UPDATE customer_order_items coi
+     SET backorder_at = NOW(), backorder_by = p_operator, updated_by = p_operator, updated_at = NOW()
+    FROM customer_orders co
+   WHERE co.id = coi.order_id
+     AND NOT (coi.id = ANY(v_alloc))
+     AND coi.sku_id = v_ctx.sku_id
+     AND co.tenant_id = v_ctx.tenant_id
+     AND co.campaign_id = v_ctx.campaign_id
+     AND co.pickup_store_id = v_ctx.store_id
+     AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+     AND co.transferred_from_order_id IS NULL
+     AND (co.order_kind = 'normal' OR co.order_kind IS NULL)
+     AND coi.status IN ('pending', 'reserved', 'ready')
+     AND coi.backorder_at IS NULL;
+  GET DIAGNOSTICS v_blocked = ROW_COUNT;
+
+  RETURN jsonb_build_object('allocated', COALESCE(array_length(v_alloc, 1), 0),
+                            'freed', v_freed, 'backordered', v_blocked);
+END;
+$$;
+
+-- ------------------------------------------------------------
+-- 5. rpc_cancel_backorder_items — 待補貨轉取消（確定補不到時的一鍵處理）
+--    沿用既有斷貨語意（20260702020000）：品項 cancelled + stockout_at，
+--    整單品項都沒了且沒收過錢 → 訂單也一併取消。不在這裡發通知（店家自己跟客人講）。
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_cancel_backorder_items(
+  p_item_ids BIGINT[],
+  p_operator UUID
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_items   INT := 0;
+  v_orders  INT := 0;
+  v_ids     BIGINT[] := COALESCE(p_item_ids, ARRAY[]::BIGINT[]);
+BEGIN
+  UPDATE customer_order_items coi
+     SET status = 'cancelled', stockout_at = NOW(),
+         updated_by = p_operator, updated_at = NOW()
+   WHERE coi.id = ANY(v_ids)
+     AND coi.backorder_at IS NOT NULL       -- 只准取消待補貨的，避免誤砍正常品項
+     AND coi.status IN ('pending', 'reserved', 'ready');
+  GET DIAGNOSTICS v_items = ROW_COUNT;
+
+  UPDATE customer_orders co
+     SET status = 'cancelled', cancelled_at = NOW(), stockout_at = NOW(),
+         updated_by = p_operator, updated_at = NOW()
+   WHERE co.id IN (SELECT order_id FROM customer_order_items WHERE id = ANY(v_ids))
+     AND co.status IN ('pending', 'confirmed', 'ready', 'shipping')
+     AND COALESCE(co.payment_status, 'unpaid') <> 'paid'
+     AND COALESCE(co.wallet_paid_amount, 0) = 0
+     AND NOT EXISTS (
+           SELECT 1 FROM customer_order_items x
+            WHERE x.order_id = co.id AND x.status NOT IN ('cancelled', 'expired')
+         );
+  GET DIAGNOSTICS v_orders = ROW_COUNT;
+
+  RETURN jsonb_build_object('items_cancelled', v_items, 'orders_cancelled', v_orders);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_get_allocation_candidates(BIGINT, BIGINT) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.rpc_allocate_shortage(BIGINT, BIGINT, BIGINT[], UUID) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.rpc_cancel_backorder_items(BIGINT[], UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_get_allocation_candidates(BIGINT, BIGINT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_allocate_shortage(BIGINT, BIGINT, BIGINT[], UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_cancel_backorder_items(BIGINT[], UUID) TO authenticated;

--- a/supabase/migrations/20260805000070_backfill_shortage_allocation.sql
+++ b/supabase/migrations/20260805000070_backfill_shortage_allocation.sql
@@ -1,0 +1,95 @@
+-- ============================================================
+-- 一次性資料治理：既有已收貨的缺口，依訂單時間回頭配貨
+--
+-- 20260805000060 讓「少發配貨」從今以後在收貨當下就做，但線上已經累積了一批
+-- 到貨量 < 未取訂單量、卻全部顯示「可取貨」的組合。這支把它們依訂單時間
+-- （created_at, order_no）補配一次，配不到的標成待補貨。
+--
+-- 只跑「帳目自洽」的組合 —— supplied > 0 且 picked <= supplied。實測 130 個
+-- 缺口組合裡：
+--   31 個 supplied = 0（收貨時該品項實收 0）→ 本來就被 Path B 的 qty_received > 0
+--      擋著，標了反而多一道要手動解除的關卡，不碰。
+--   11 個 picked > supplied（領走的比這團到貨的還多）→ 店裡的貨是跨團／跨批
+--      流用的，用單一團的帳去推誰該待補會冤枉人，不碰，留給店家用配貨視窗處理。
+--   88 個自洽 → 本檔處理，共 185 件。這 88 個另外用實體庫存交叉驗證過
+--      （stock_balances.on_hand < 未取需求）88/88 成立，兩套獨立算法一致。
+--
+-- 配法與彈窗的「依訂單時間自動配」同規則：由早到晚，裝得下就配、裝不下就跳過
+-- 繼續試後面的（不拆行）。剩下的標 backorder_at。
+--
+-- 冪等：重跑會依當下資料重算，已被店家手動調過的配貨結果會被覆蓋回自動配的
+-- 結果，所以這支只該跑一次（migration 本來就只跑一次）。
+--
+-- rollback: UPDATE customer_order_items SET backorder_at = NULL, backorder_by = NULL
+--             WHERE backorder_by = '00000000-0000-0000-0000-000000000000';
+-- ============================================================
+
+DO $$
+DECLARE
+  c RECORD;
+  r RECORD;
+  v_left    NUMERIC;
+  v_blocked INT := 0;
+  v_combos  INT := 0;
+BEGIN
+  FOR c IN
+    WITH pw AS (
+      SELECT pwi.tenant_id, pwi.campaign_id, pwi.store_id, pwi.sku_id,
+             SUM(ti.qty_received) AS supplied
+        FROM picking_wave_items pwi
+        JOIN transfers t       ON t.id = pwi.generated_transfer_id
+                              AND t.status IN ('received', 'closed')
+        JOIN transfer_items ti ON ti.transfer_id = t.id AND ti.sku_id = pwi.sku_id
+       WHERE pwi.campaign_id IS NOT NULL
+       GROUP BY 1, 2, 3, 4
+    )
+    SELECT pw.*, d.demand, d.picked
+      FROM pw
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(SUM(coi.qty) FILTER (WHERE coi.status IN ('pending','reserved','ready')), 0) AS demand,
+               COALESCE(SUM(coi.qty) FILTER (WHERE coi.status IN ('picked_up','partially_picked_up')), 0) AS picked
+          FROM customer_orders co
+          JOIN customer_order_items coi ON coi.order_id = co.id AND coi.sku_id = pw.sku_id
+         WHERE co.tenant_id       = pw.tenant_id
+           AND co.campaign_id     = pw.campaign_id
+           AND co.pickup_store_id = pw.store_id
+           AND co.status NOT IN ('cancelled','expired','transferred_out')
+           AND co.transferred_from_order_id IS NULL
+           AND (co.order_kind = 'normal' OR co.order_kind IS NULL)
+           AND coi.status NOT IN ('cancelled','expired')
+      ) d
+     WHERE d.demand > GREATEST(pw.supplied - d.picked, 0)
+       AND pw.supplied > 0            -- 排除「實收 0」：本來就被 Path B 擋著
+       AND d.picked <= pw.supplied    -- 排除「領走的比到貨多」：跨團流用，帳推不準
+  LOOP
+    v_combos := v_combos + 1;
+    v_left := GREATEST(c.supplied - c.picked, 0);
+    FOR r IN
+      SELECT coi.id AS item_id, coi.qty
+        FROM customer_orders co
+        JOIN customer_order_items coi ON coi.order_id = co.id AND coi.sku_id = c.sku_id
+       WHERE co.tenant_id       = c.tenant_id
+         AND co.campaign_id     = c.campaign_id
+         AND co.pickup_store_id = c.store_id
+         AND co.status NOT IN ('cancelled','expired','transferred_out')
+         AND co.transferred_from_order_id IS NULL
+         AND (co.order_kind = 'normal' OR co.order_kind IS NULL)
+         AND coi.status IN ('pending','reserved','ready')
+       ORDER BY co.created_at, co.order_no     -- ＝「依訂單時間」，同時間用單號決勝
+    LOOP
+      IF r.qty <= v_left THEN
+        v_left := v_left - r.qty;
+      ELSE
+        UPDATE customer_order_items
+           SET backorder_at = NOW(),
+               -- 全 0 的 uuid = 系統回頭配貨，好跟店家手動配的區分／回滾
+               backorder_by = '00000000-0000-0000-0000-000000000000'::uuid,
+               updated_at   = NOW()
+         WHERE id = r.item_id AND backorder_at IS NULL;
+        v_blocked := v_blocked + 1;
+      END IF;
+    END LOOP;
+  END LOOP;
+
+  RAISE NOTICE '回頭配貨：% 個組合、% 個品項行標為待補貨', v_combos, v_blocked;
+END $$;


### PR DESCRIPTION
接續 #614。那支只做到「看得見」（多給 / 少了幾件、點數量看背後訂單），這支做「擋得住」。

## 問題

取貨閘門 `is_order_item_pickup_ready` 的 Path B 是**布林 EXISTS**：該店該團該品項只要有收到貨（`qty_received > 0`），這組條件下的**所有**未取訂單一律翻成「可取貨」。系統從來沒有比較過「到的量夠不夠分」。

2026-08-05 松山店阿猴鮮奶到 **10 瓶**、訂單 **11 瓶**，7 筆訂單全部亮綠燈。先到的人領走，最後一位上門才發現沒貨。永和店同品項同樣狀況。缺口不在店端（派 10 收 10，沒有短收），是排波次時就少排了。

## 改了什麼

**1. 待補貨標記 + 閘門**

`customer_order_items.backorder_at` 有值＝待補貨。閘門只多一個 `AND coi.backorder_at IS NULL`，其餘**逐字沿用 20260704000000**（已與線上 `pg_get_functiondef` 比對，確認沒有其他 hotfix）。沒缺貨的單這欄永遠是 NULL → **現有行為完全不變**，風險只落在真的缺貨的組合。

閘門一改，`rpc_record_pickup` 的品項擋板（呼叫同一支函式，見 20260801000000:745）也跟著生效 — **伺服端擋得住，不只是畫面上不給點**。

**2. 配貨視窗（ShortageAllocateModal）**

收貨頁少發的品項旁多一顆「⚖️ 配貨」。視窗上方是到貨 / 可配 / 已配 / 待補貨四個數字，下面是依訂單時間排好的訂單清單，可勾選，超額不給存。附 **「⏱ 依訂單時間自動配」** 一鍵由早到晚配滿為止。

沒配到的標待補貨；下一批到貨再開同一個視窗勾起來就解除。確定補不到的話有「補不到了，轉取消」（沿用既有斷貨語意：品項 cancelled + `stockout_at`，整單品項都沒了且沒收過錢就一併取消）。依先前確認：**不發通知給客人**，由店家自行聯繫。

**3. 排序基準：`created_at` + `order_no`**

`ordered_at` 全庫 22522 筆**都是 NULL**；`created_at` 大量重複（22522 筆只有 8612 個相異值，開團是整批匯入的），單靠時間排不出先後。`order_no` 末碼是團內流水號，拿來當同分決勝可還原批次內順序。

**4. 取貨頁**

`ready` 單原本整單放行、完全不看 `itemReady`，會讓店員勾得到、按下去才被 RPC 擋，訊息還誤導成「尚未實收到貨」。改成一併過濾；待補貨的品項明確標「⏳ 待補貨」而不是默默消失。

## DB

| migration | 內容 |
|---|---|
| `20260805000050_rpc_ship_vs_demand_for_transfers` | 取代 `rpc_get_over_ship_for_transfers`，一次回 `{ over, short }`。845 張待收單 93ms。 |
| `20260805000060_shortage_allocation` | `backorder_at` 欄位 + 部分索引、閘門加擋板、`rpc_get_allocation_candidates` / `rpc_allocate_shortage` / `rpc_cancel_backorder_items`。 |
| `20260805000070_backfill_shortage_allocation` | 一次性治理，見下。 |

三支都已用 Management API 部署到線上並驗證。新 RPC 一律 `REVOKE ALL ... FROM PUBLIC, anon`（Postgres 預設把 EXECUTE 給 PUBLIC），部署後實測 anon 回 401。

## 一次性治理：既有缺口回頭配貨

**沒有無差別跑。** 乾跑後 130 個缺口組合分成三類：

| | 件數 | 處理 |
|---|---|---|
| 帳目自洽（`supplied > 0` 且 `picked <= supplied`）88 個 | 標了 131 行 / 212 件 / 129 張訂單 | ✅ 已跑 |
| `到貨 = 0` 的 31 個 | — | ❌ 跳過：本來就被 Path B 的 `qty_received > 0` 擋著，標了反而多一道要手動解除的關卡 |
| `已領 > 到貨` 的 11 個 | — | ❌ 跳過：例如三峽店某品項到貨 1 卻領走 10，店裡的貨是跨團／跨批流用的，用單一團的帳推誰該待補會冤枉人 |

那 88 個另外用實體庫存交叉驗證（`stock_balances.on_hand < 未取需求`）**88/88 成立**，兩套獨立算法一致才動手。

**松山阿猴鮮奶驗證**：0008 / 0011 / 0046 三筆（共 6 件，剛好等於架上的 6 瓶）維持可取貨；0058（1 件）轉待補貨、`is_order_item_pickup_ready` 回 false。

已知限制：標到 212 件而非缺口的 185 件，因為**不拆行** — 為補 1 件的缺口而擋掉一筆 3 件的訂單就會多擋 2 件。拆行（一筆訂單部分可取）要另外設計。

## 驗證

Playwright + fixture 跑過配貨視窗與「依訂單時間自動配」（可配 6 → 前 3 筆各 2 件配滿、最後 1 件轉待補貨，與線上真實案例逐格吻合），另含收貨頁兩種檢視、訂單彈窗、已收分頁。`tsc` 乾淨，eslint 無新增問題（inbound 2 個、pickup 2 個都是既有的）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTpgbPdduNrnC8V88DYxjS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTpgbPdduNrnC8V88DYxjS)_