### PR TITLE
feat(inbound): 配貨支援拆行；補貨單也看得到它的補貨申請

### DIFF
--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -61,6 +61,9 @@ export default function TransfersInboxPage() {
   const [itemSummary, setItemSummary] = useState<Map<number, ItemSummary>>(new Map());
   const [locationToStore, setLocationToStore] = useState<Map<number, number>>(new Map());
   const [transferCampaigns, setTransferCampaigns] = useState<Map<number, number[]>>(new Map());
+  // 每張單的來源：campaign=開團派貨（背後有顧客訂單）/ restock=補貨 / free=自由轉貨・互助
+  // 補貨與自由轉貨本來就沒有顧客訂單，畫面要講清楚，不然點開只看到「查不到訂單」會以為壞了
+  const [sourceKinds, setSourceKinds] = useState<Map<number, string>>(new Map());
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
   const [opening, setOpening] = useState<Transfer | null>(null);
@@ -332,6 +335,17 @@ export default function TransfersInboxPage() {
           }
         }
 
+        // 來源類型（開團 / 補貨 / 自由轉貨）— 決定要不要給「看訂單」入口
+        const kindMap = new Map<number, string>();
+        if (rows.length > 0) {
+          const { data: kindData } = await sb.rpc("rpc_get_transfer_source_kinds", {
+            p_transfer_ids: rows.map((r) => r.id),
+          });
+          for (const [tid, kind] of Object.entries((kindData as Record<string, string> | null) ?? {})) {
+            kindMap.set(Number(tid), kind);
+          }
+        }
+
         // location → store mapping (for /orders link filter)
         const locStoreMap = new Map<number, number>();
         if (locIds.length > 0) {
@@ -368,6 +382,7 @@ export default function TransfersInboxPage() {
           setItemSummary(summary);
           setLocationToStore(locStoreMap);
           setTransferCampaigns(tcMap);
+          setSourceKinds(kindMap);
           setError(null);
           const auto = new Set<string>();
           for (const r of rows) {
@@ -1133,6 +1148,7 @@ export default function TransfersInboxPage() {
                         const isSelected = selected.has(t.id);
                         const wid = parseWaveId(t.transfer_no);
                         const wave = wid !== null ? waves.get(wid) : undefined;
+                        const srcKind = sourceKinds.get(t.id) ?? "campaign";
                         // 編號欄：合併同商品時看撿貨單號（哪一車來的），依撿貨單時看調撥單號
                         const code =
                           groupMode === "product" ? wave?.wave_code ?? t.transfer_no : t.transfer_no;
@@ -1180,19 +1196,23 @@ export default function TransfersInboxPage() {
                                       )}
                                       {it.name}
                                       {/* 點數量 → 這幾件分別是誰的訂單 */}
-                                      <SpinButton
-                                        onClick={() =>
-                                          setOrdersFor({
-                                            transferId: t.id,
-                                            transferNo: wave?.wave_code ?? t.transfer_no,
-                                            skuLines: [it],
-                                          })
-                                        }
-                                        className="ml-1 rounded font-semibold tabular-nums text-blue-600 underline decoration-dotted underline-offset-2 hover:text-blue-800 dark:text-blue-400"
-                                        title="看這幾件對應哪幾筆訂單"
-                                      >
-                                        × {it.qty}
-                                      </SpinButton>
+                                      {srcKind === "campaign" ? (
+                                        <SpinButton
+                                          onClick={() =>
+                                            setOrdersFor({
+                                              transferId: t.id,
+                                              transferNo: wave?.wave_code ?? t.transfer_no,
+                                              skuLines: [it],
+                                            })
+                                          }
+                                          className="ml-1 rounded font-semibold tabular-nums text-blue-600 underline decoration-dotted underline-offset-2 hover:text-blue-800 dark:text-blue-400"
+                                          title="看這幾件對應哪幾筆訂單"
+                                        >
+                                          × {it.qty}
+                                        </SpinButton>
+                                      ) : (
+                                        <span className="ml-1 font-semibold tabular-nums">× {it.qty}</span>
+                                      )}
                                       {summary.shortQty > 0 && it.skuId != null && (
                                         <SpinButton
                                           onClick={() =>
@@ -1219,6 +1239,22 @@ export default function TransfersInboxPage() {
                                   <span>{locations.get(t.dest_location) ?? `#${t.dest_location}`}</span>
                                 )}
                                 {groupMode === "wave" && wave?.wave_date && <span>📅 {wave.wave_date}</span>}
+                                {srcKind === "restock" && (
+                                  <span
+                                    className="rounded bg-violet-100 px-1.5 py-0.5 text-[10px] font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300"
+                                    title="補貨申請產生的單，背後沒有顧客訂單"
+                                  >
+                                    🔁 補貨（無顧客訂單）
+                                  </span>
+                                )}
+                                {srcKind === "free" && (
+                                  <span
+                                    className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+                                    title="沒有撿貨波次的單（自由轉貨 / 互助 / 直送），背後沒有顧客訂單"
+                                  >
+                                    ↔ 轉貨（無顧客訂單）
+                                  </span>
+                                )}
                                 {!isShipped && t.received_at && (
                                   <span className="text-emerald-700 dark:text-emerald-400">
                                     ✅ 收貨 {new Date(t.received_at).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" })}
@@ -1240,20 +1276,25 @@ export default function TransfersInboxPage() {
                               </div>
                             </td>
                             <td className="whitespace-nowrap px-3 py-2 text-right align-top">
-                              <SpinButton
-                                onClick={() =>
-                                  setOrdersFor({
-                                    transferId: t.id,
-                                    transferNo: wave?.wave_code ?? t.transfer_no,
-                                    skuLines: summary?.items ?? [],
-                                  })
-                                }
-                                disabled={!summary || summary.lines === 0}
-                                className="font-semibold tabular-nums text-blue-600 underline decoration-dotted underline-offset-2 hover:text-blue-800 disabled:text-zinc-400 disabled:no-underline dark:text-blue-400"
-                                title="看這張單對應哪幾筆訂單"
-                              >
-                                {summary?.totalQty ?? 0}
-                              </SpinButton>
+                              {srcKind === "campaign" ? (
+                                <SpinButton
+                                  onClick={() =>
+                                    setOrdersFor({
+                                      transferId: t.id,
+                                      transferNo: wave?.wave_code ?? t.transfer_no,
+                                      skuLines: summary?.items ?? [],
+                                    })
+                                  }
+                                  disabled={!summary || summary.lines === 0}
+                                  className="font-semibold tabular-nums text-blue-600 underline decoration-dotted underline-offset-2 hover:text-blue-800 disabled:text-zinc-400 disabled:no-underline dark:text-blue-400"
+                                  title="看這張單對應哪幾筆訂單"
+                                >
+                                  {summary?.totalQty ?? 0}
+                                </SpinButton>
+                              ) : (
+                                // 補貨 / 自由轉貨背後沒有顧客訂單，不給死連結
+                                <span className="font-semibold tabular-nums">{summary?.totalQty ?? 0}</span>
+                              )}
                               {summary && summary.lines > 1 && (
                                 <span className="ml-1 text-[10px] font-normal text-zinc-400">{summary.lines} 項</span>
                               )}

--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -1196,7 +1196,7 @@ export default function TransfersInboxPage() {
                                       )}
                                       {it.name}
                                       {/* 點數量 → 這幾件分別是誰的訂單 */}
-                                      {srcKind === "campaign" ? (
+                                      {srcKind !== "free" ? (
                                         <SpinButton
                                           onClick={() =>
                                             setOrdersFor({
@@ -1242,17 +1242,17 @@ export default function TransfersInboxPage() {
                                 {srcKind === "restock" && (
                                   <span
                                     className="rounded bg-violet-100 px-1.5 py-0.5 text-[10px] font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300"
-                                    title="補貨申請產生的單，背後沒有顧客訂單"
+                                    title="補貨申請（RR-xxx）產生的單，不是開團派貨；點數量可看對應的補貨申請"
                                   >
-                                    🔁 補貨（無顧客訂單）
+                                    🔁 補貨
                                   </span>
                                 )}
                                 {srcKind === "free" && (
                                   <span
                                     className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
-                                    title="沒有撿貨波次的單（自由轉貨 / 互助 / 直送），背後沒有顧客訂單"
+                                    title="沒有撿貨波次也沒掛訂單的單（自由轉貨 / 店對店），沒有可對應的單據"
                                   >
-                                    ↔ 轉貨（無顧客訂單）
+                                    ↔ 轉貨
                                   </span>
                                 )}
                                 {!isShipped && t.received_at && (
@@ -1276,7 +1276,7 @@ export default function TransfersInboxPage() {
                               </div>
                             </td>
                             <td className="whitespace-nowrap px-3 py-2 text-right align-top">
-                              {srcKind === "campaign" ? (
+                              {srcKind !== "free" ? (
                                 <SpinButton
                                   onClick={() =>
                                     setOrdersFor({
@@ -1292,7 +1292,7 @@ export default function TransfersInboxPage() {
                                   {summary?.totalQty ?? 0}
                                 </SpinButton>
                               ) : (
-                                // 補貨 / 自由轉貨背後沒有顧客訂單，不給死連結
+                                // 自由轉貨背後沒有任何單，不給死連結（補貨有 RR-xxx 可看）
                                 <span className="font-semibold tabular-nums">{summary?.totalQty ?? 0}</span>
                               )}
                               {summary && summary.lines > 1 && (

--- a/apps/admin/src/components/ShortageAllocateModal.tsx
+++ b/apps/admin/src/components/ShortageAllocateModal.tsx
@@ -40,7 +40,8 @@ export function ShortageAllocateModal({
   onSaved: () => void;
 }) {
   const [data, setData] = useState<Payload | null>(null);
-  const [allocated, setAllocated] = useState<Set<number>>(new Set());
+  // item_id → 配到的數量（可小於該行的量＝拆行：部分可取、部分待補）
+  const [alloc, setAlloc] = useState<Map<number, number>>(new Map());
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -59,8 +60,12 @@ export function ShortageAllocateModal({
       available: Number(payload.available),
       items: (payload.items ?? []).map((r) => ({ ...r, qty: Number(r.qty) })),
     });
-    // 進來時先反映現況：沒被標待補貨的就是目前配到的
-    setAllocated(new Set((payload.items ?? []).filter((r) => !r.backorder).map((r) => r.item_id)));
+    // 進來時先反映現況：沒被標待補貨的整行都算配到
+    setAlloc(
+      new Map(
+        (payload.items ?? []).map((r) => [r.item_id, r.backorder ? 0 : Number(r.qty)] as [number, number]),
+      ),
+    );
   }, [transferId, skuId]);
 
   useEffect(() => {
@@ -78,48 +83,47 @@ export function ShortageAllocateModal({
   }, [load]);
 
   const allocatedQty = useMemo(
-    () => (data?.items ?? []).filter((r) => allocated.has(r.item_id)).reduce((s, r) => s + r.qty, 0),
-    [data, allocated],
+    () => (data?.items ?? []).reduce((s, r) => s + (alloc.get(r.item_id) ?? 0), 0),
+    [data, alloc],
   );
   const backorderQty = useMemo(
-    () => (data?.items ?? []).filter((r) => !allocated.has(r.item_id)).reduce((s, r) => s + r.qty, 0),
-    [data, allocated],
+    () => (data?.items ?? []).reduce((s, r) => s + (r.qty - (alloc.get(r.item_id) ?? 0)), 0),
+    [data, alloc],
   );
   const over = data ? allocatedQty - data.available : 0;
 
   // 依訂單時間配貨：候選已由後端依 created_at, order_no 排好，
-  // 由早到晚累加，裝得下就配、裝不下就跳過（不拆行，一筆訂單要嘛全配要嘛待補）。
+  // 由早到晚配滿為止。會拆行 —— 額度只剩 1 件而該筆要 3 件時，給他 1 件、剩 2 件待補，
+  // 額度不浪費（原本整行為單位時會整筆跳過，架上的貨就白放著）。
   function autoAllocateByTime() {
     if (!data) return;
     let left = data.available;
-    const next = new Set<number>();
+    const next = new Map<number, number>();
     for (const r of data.items) {
-      if (r.qty <= left) {
-        next.add(r.item_id);
-        left -= r.qty;
-      }
+      const give = Math.max(0, Math.min(r.qty, left));
+      next.set(r.item_id, give);
+      left -= give;
     }
-    setAllocated(next);
+    setAlloc(next);
   }
 
-  function toggle(id: number) {
-    setAllocated((cur) => {
-      const n = new Set(cur);
-      if (n.has(id)) n.delete(id);
-      else n.add(id);
-      return n;
-    });
+  function setRow(id: number, v: number, max: number) {
+    const q = Number.isFinite(v) ? Math.max(0, Math.min(Math.floor(v), max)) : 0;
+    setAlloc((cur) => new Map(cur).set(id, q));
   }
 
   async function save() {
     if (!data) return;
     if (over > 0) return;
-    const backorderCount = data.items.length - allocated.size;
+    const partial = data.items.filter((r) => {
+      const a = alloc.get(r.item_id) ?? 0;
+      return a > 0 && a < r.qty;
+    }).length;
     if (
       !confirm(
-        `確認配貨？\n\n配到 ${allocated.size} 筆（${allocatedQty} 件）\n` +
-          `待補貨 ${backorderCount} 筆（${backorderQty} 件）— 這些訂單在補到貨之前不能取貨。\n\n` +
-          `不會通知客人，請店家自行聯繫。`,
+        `確認配貨？\n\n配出 ${allocatedQty} 件、待補貨 ${backorderQty} 件。\n` +
+          (partial > 0 ? `其中 ${partial} 筆訂單是部分配到（該筆會拆成可取與待補兩行）。\n` : "") +
+          `\n待補貨的部分在補到貨之前不能取貨。不會通知客人，請店家自行聯繫。`,
       )
     )
       return;
@@ -133,12 +137,15 @@ export function ShortageAllocateModal({
       const { data: res, error: e } = await sb.rpc("rpc_allocate_shortage", {
         p_transfer_id: transferId,
         p_sku_id: skuId,
-        p_allocated_item_ids: Array.from(allocated),
+        p_allocations: Object.fromEntries(alloc),
         p_operator: operator,
       });
       if (e) throw new Error(translateRpcError(e));
-      const r = (res ?? {}) as { backordered?: number; freed?: number };
-      alert(`✅ 配貨完成：待補貨 ${r.backordered ?? 0} 筆、解除 ${r.freed ?? 0} 筆`);
+      const r = (res ?? {}) as { backordered?: number; freed?: number; split?: number };
+      alert(
+        `✅ 配貨完成：待補貨 ${r.backordered ?? 0} 筆、解除 ${r.freed ?? 0} 筆` +
+          (r.split ? `、拆行 ${r.split} 筆` : ""),
+      );
       onSaved();
       onClose();
     } catch (e) {
@@ -228,7 +235,7 @@ export function ShortageAllocateModal({
 
             {over > 0 && (
               <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-900 dark:bg-rose-950 dark:text-rose-300">
-                已配 {allocatedQty} 件超過可配的 {data.available} 件，請取消勾選 {over} 件。
+                已配 {allocatedQty} 件超過可配的 {data.available} 件，請減掉 {over} 件。
               </div>
             )}
 
@@ -236,7 +243,7 @@ export function ShortageAllocateModal({
               <table className="w-full min-w-[600px] text-sm">
                 <thead>
                   <tr className="border-b border-zinc-200 bg-zinc-50 text-[11px] text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900">
-                    <th className="w-10 px-3 py-2">配貨</th>
+                    <th className="w-24 px-3 py-2">配貨數量</th>
                     <th className="px-3 py-2 text-left font-medium">訂單編號</th>
                     <th className="px-3 py-2 text-left font-medium">顧客</th>
                     <th className="px-3 py-2 text-left font-medium">下單時間</th>
@@ -246,16 +253,25 @@ export function ShortageAllocateModal({
                 </thead>
                 <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
                   {data.items.map((r) => {
-                    const on = allocated.has(r.item_id);
+                    const give = alloc.get(r.item_id) ?? 0;
+                    const short = r.qty - give;
                     return (
-                      <tr key={r.item_id} className={on ? "" : "bg-amber-50/60 dark:bg-amber-950/20"}>
-                        <td className="px-3 py-2 text-center">
-                          <input
-                            type="checkbox"
-                            checked={on}
-                            onChange={() => toggle(r.item_id)}
-                            className="cursor-pointer"
-                          />
+                      <tr
+                        key={r.item_id}
+                        className={short <= 0 ? "" : "bg-amber-50/60 dark:bg-amber-950/20"}
+                      >
+                        <td className="px-3 py-2">
+                          <div className="flex items-center gap-1">
+                            <input
+                              type="number"
+                              min={0}
+                              max={r.qty}
+                              value={give}
+                              onChange={(e) => setRow(r.item_id, Number(e.target.value), r.qty)}
+                              className="w-14 rounded-md border border-zinc-300 px-1.5 py-1 text-right text-sm tabular-nums dark:border-zinc-700 dark:bg-zinc-800"
+                            />
+                            <span className="text-[10px] text-zinc-400">/ {r.qty}</span>
+                          </div>
                         </td>
                         <td className="px-3 py-2 font-mono text-xs">{r.order_no}</td>
                         <td className="max-w-[220px] truncate px-3 py-2" title={r.customer ?? ""}>
@@ -269,8 +285,12 @@ export function ShortageAllocateModal({
                         </td>
                         <td className="px-3 py-2 text-right font-semibold tabular-nums">{r.qty}</td>
                         <td className="whitespace-nowrap px-3 py-2 text-right text-xs">
-                          {on ? (
+                          {short <= 0 ? (
                             <span className="text-zinc-500">{orderStatusLabel(r.order_status)}</span>
+                          ) : give > 0 ? (
+                            <span className="font-medium text-amber-700 dark:text-amber-400">
+                              部分待補 {short}
+                            </span>
                           ) : (
                             <span className="font-medium text-amber-700 dark:text-amber-400">待補貨</span>
                           )}
@@ -309,8 +329,9 @@ export function ShortageAllocateModal({
               </SpinButton>
             </div>
             <p className="text-[11px] text-zinc-500">
-              沒配到的訂單會標成「待補貨」，在補到貨之前取貨頁不會讓它取走。不會發通知給客人。
-              下一批到貨時再開這個視窗，把他們勾起來就會解除。
+              沒配到的量會標成「待補貨」，在補到貨之前取貨頁不會讓它取走。部分配到的訂單會拆成
+              「可取」與「待補」兩行，客人可以先領到手的部分。不會發通知給客人；下一批到貨時再開
+              這個視窗把數量補上去就會解除。
             </p>
           </>
         )}

--- a/apps/admin/src/components/TransferOrdersModal.tsx
+++ b/apps/admin/src/components/TransferOrdersModal.tsx
@@ -18,7 +18,7 @@ export type OrderLine = {
   order_status: string;
   order_qty: number;
   campaign_id: number | null;
-  match_kind: "wave" | "aid" | "store_sku";
+  match_kind: "wave" | "aid" | "restock" | "store_sku";
 };
 
 // 呼叫端已經有的品項資訊 — 免得彈窗再查一次 skus
@@ -105,13 +105,14 @@ export function TransferOrdersModal({
                   {line.name}
                 </span>
                 <span className="text-xs text-zinc-500">
-                  派出 <b className="text-zinc-800 dark:text-zinc-200">{line.qty}</b> 件 · 訂單{" "}
-                  <b className="text-zinc-800 dark:text-zinc-200">{orderQty}</b> 件 ·{" "}
-                  {orders.length} 筆
+                  派出 <b className="text-zinc-800 dark:text-zinc-200">{line.qty}</b> 件 ·{" "}
+                  {orders.some((o) => o.match_kind === "restock") ? "申請" : "訂單"}{" "}
+                  <b className="text-zinc-800 dark:text-zinc-200">{orderQty}</b> 件 · {orders.length} 筆
                 </span>
                 {extra > 0 && (
                   <span className="rounded-md bg-blue-100 px-2 py-0.5 text-[11px] font-medium text-blue-700 dark:bg-blue-950 dark:text-blue-300">
-                    🎁 總倉多給 {extra} 件（沒有訂單對應）
+                    🎁 總倉多給 {extra} 件（
+                    {orders.some((o) => o.match_kind === "restock") ? "超過申請量" : "沒有訂單對應"}）
                   </span>
                 )}
                 {extra < 0 && (
@@ -123,9 +124,9 @@ export function TransferOrdersModal({
 
               {orders.length === 0 ? (
                 <div className="px-3 py-4 text-center text-sm text-zinc-500">
-                  這個品項查不到對應的訂單 — 可能是訂單已取消／過期，或這幾件是總倉多給的。
+                  這個品項查不到對應的單 — 可能是訂單已取消／過期，或這幾件是總倉多給的。
                   <br />
-                  （補貨與自由轉貨的單本來就沒有顧客訂單，收貨頁不會給「看訂單」的入口。）
+                  （自由轉貨 / 店對店的單沒有可對應的單據，收貨頁不會給這個入口。）
                 </div>
               ) : (
                 <div className="overflow-x-auto">
@@ -141,7 +142,14 @@ export function TransferOrdersModal({
                     <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
                       {orders.map((o) => (
                         <tr key={o.order_id}>
-                          <td className="px-3 py-1.5 font-mono text-xs">{o.order_no}</td>
+                          <td className="px-3 py-1.5 font-mono text-xs">
+                            {o.order_no}
+                            {o.match_kind === "restock" && (
+                              <span className="ml-1.5 rounded bg-violet-100 px-1 py-0.5 font-sans text-[10px] font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300">
+                                補貨申請
+                              </span>
+                            )}
+                          </td>
                           <td className="max-w-[260px] truncate px-3 py-1.5" title={o.customer ?? ""}>
                             {o.customer || "—"}
                           </td>

--- a/apps/admin/src/components/TransferOrdersModal.tsx
+++ b/apps/admin/src/components/TransferOrdersModal.tsx
@@ -123,7 +123,9 @@ export function TransferOrdersModal({
 
               {orders.length === 0 ? (
                 <div className="px-3 py-4 text-center text-sm text-zinc-500">
-                  查不到對應的訂單 — 這批可能是補貨（本來就沒有顧客訂單）或自由轉貨。
+                  這個品項查不到對應的訂單 — 可能是訂單已取消／過期，或這幾件是總倉多給的。
+                  <br />
+                  （補貨與自由轉貨的單本來就沒有顧客訂單，收貨頁不會給「看訂單」的入口。）
                 </div>
               ) : (
                 <div className="overflow-x-auto">

--- a/supabase/migrations/20260805000080_rpc_transfer_source_kinds.sql
+++ b/supabase/migrations/20260805000080_rpc_transfer_source_kinds.sql
@@ -1,0 +1,42 @@
+-- ============================================================
+-- rpc_get_transfer_source_kinds：每張派貨單的來源類型
+--   → { "<transfer_id>": "campaign" | "restock" | "free" }
+--
+-- 動機：收貨頁點數量看訂單時，補貨單會回「查不到對應的訂單」，店家以為是系統
+--   壞了（2026-08-05 湖口店 WAVE-875-S49 的回報）。那張單的 5 條
+--   picking_wave_items 的 campaign_id 全是 NULL —— 它是補貨申請產生的，
+--   背後本來就沒有顧客訂單，對到的只有 order_kind='restock' 的 RR-xxx 與
+--   __INTERNAL_RESTOCK__ 內部單（rpc_get_orders_for_transfer 已正確排除）。
+--
+-- 線上 8815 張 shipped/received 裡：8433 張有開團、191 張補貨、191 張沒有波次
+--   （自由轉貨 / 互助），約 4% 會落在「查不到訂單」，值得在畫面上講清楚是哪一種。
+--
+--   campaign  有波次且至少一條帶 campaign_id → 開團派貨，背後有顧客訂單
+--   restock   有波次但 campaign_id 全 NULL   → 補貨，本來就沒有顧客訂單
+--   free      沒有任何波次行                  → 自由轉貨 / 互助 / 直送
+--
+-- 基底版本：新函式，無前版。
+-- rollback: DROP FUNCTION IF EXISTS public.rpc_get_transfer_source_kinds(BIGINT[]);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_get_transfer_source_kinds(
+  p_transfer_ids BIGINT[]
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  WITH k AS (
+    SELECT t.id AS tid,
+           CASE
+             WHEN COUNT(pwi.id) = 0                       THEN 'free'
+             WHEN COUNT(pwi.campaign_id) = 0              THEN 'restock'
+             ELSE 'campaign'
+           END AS kind
+      FROM transfers t
+      LEFT JOIN picking_wave_items pwi ON pwi.generated_transfer_id = t.id
+     WHERE t.id = ANY(p_transfer_ids)
+     GROUP BY t.id
+  )
+  SELECT COALESCE(jsonb_object_agg(k.tid::text, k.kind), '{}'::jsonb) FROM k;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_get_transfer_source_kinds(BIGINT[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_get_transfer_source_kinds(BIGINT[]) TO authenticated;

--- a/supabase/migrations/20260805000090_orders_for_transfer_include_restock.sql
+++ b/supabase/migrations/20260805000090_orders_for_transfer_include_restock.sql
@@ -1,0 +1,172 @@
+-- ============================================================
+-- rpc_get_orders_for_transfer v2：補貨單也要看得到它的補貨申請
+--
+-- 動機：湖口店 WAVE-875-S49（transfer 8624）點數量看訂單是空的，我上一版把它
+--   標成「補貨（無顧客訂單）」——講錯了。它背後有單：RR-247，一張
+--   order_kind='restock' 的 customer_orders（id 65983、湖口店、8/3 03:26 建立，
+--   波次 03:31 建立），5 個品項與這張派貨單的 5 個 SKU 一對一（申請 1/2/2/1/1、
+--   派出 1/2/2/1/2）。v1 的 (co.order_kind='normal' OR IS NULL) 把它濾掉了。
+--
+-- 補貨這條路的資料形狀跟開團不一樣，要另外處理：
+--   1. picking_wave_items.campaign_id 是 NULL（不是開團派的），wave 路線對不到。
+--   2. RR 單的品項在轉出後會被設成 cancelled，並長出
+--      __INTERNAL_RESTOCK__-TFxxxx 子單（transferred_from_order_id 指回 RR）。
+--      那是內部帳的搬運，不是「這張補貨申請不算數」——所以 restock 這條
+--      刻意不套 coi.status 的排除條件，否則畫面又會變成空的。
+--   子單本身仍被 transferred_from_order_id IS NULL 擋掉，不會跟母單重複列出。
+--
+-- 來源優先序：wave > aid > restock > store_sku。
+--
+-- 基底版本：20260805000030_rpc_get_orders_for_transfer（v1）
+-- rollback: 重跑 20260805000030。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_get_orders_for_transfer(
+  p_transfer_id BIGINT,
+  p_sku_id      BIGINT DEFAULT NULL
+) RETURNS TABLE (
+  sku_id       BIGINT,
+  order_id     BIGINT,
+  order_no     TEXT,
+  customer     TEXT,
+  order_status TEXT,
+  order_qty    NUMERIC,
+  campaign_id  BIGINT,
+  match_kind   TEXT
+)
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  WITH t AS (
+    SELECT tr.id, tr.tenant_id, tr.dest_location, tr.customer_order_id
+      FROM transfers tr
+     WHERE tr.id = p_transfer_id
+  ),
+  want AS (
+    SELECT DISTINCT ti.sku_id AS want_sku_id
+      FROM transfer_items ti
+     WHERE ti.transfer_id = p_transfer_id
+       AND (p_sku_id IS NULL OR ti.sku_id = p_sku_id)
+  ),
+  store AS (
+    SELECT s.id AS store_id
+      FROM t JOIN stores s
+        ON s.location_id = t.dest_location AND s.tenant_id = t.tenant_id
+  ),
+  from_wave AS (
+    SELECT pwi.sku_id            AS r_sku_id,
+           co.id                 AS r_order_id,
+           co.order_no           AS r_order_no,
+           COALESCE(m.name, co.nickname_snapshot) AS r_customer,
+           co.status             AS r_status,
+           SUM(coi.qty)          AS r_qty,
+           co.campaign_id        AS r_campaign_id,
+           'wave'::text          AS r_match_kind
+      FROM t
+      JOIN picking_wave_items pwi
+        ON pwi.generated_transfer_id = t.id
+       AND pwi.campaign_id IS NOT NULL
+      JOIN want w ON w.want_sku_id = pwi.sku_id
+      JOIN customer_orders co
+        ON co.tenant_id        = pwi.tenant_id
+       AND co.campaign_id      = pwi.campaign_id
+       AND co.pickup_store_id  = pwi.store_id
+       AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+       AND co.transferred_from_order_id IS NULL
+       AND (co.order_kind = 'normal' OR co.order_kind IS NULL)
+      JOIN customer_order_items coi
+        ON coi.order_id = co.id
+       AND coi.sku_id   = pwi.sku_id
+       AND coi.status NOT IN ('cancelled', 'expired')
+      LEFT JOIN members m ON m.id = co.member_id
+     GROUP BY pwi.sku_id, co.id, co.order_no, m.name, co.nickname_snapshot,
+              co.status, co.campaign_id
+  ),
+  from_aid AS (
+    SELECT coi.sku_id      AS r_sku_id,
+           co.id           AS r_order_id,
+           co.order_no     AS r_order_no,
+           COALESCE(m.name, co.nickname_snapshot) AS r_customer,
+           co.status       AS r_status,
+           SUM(coi.qty)    AS r_qty,
+           co.campaign_id  AS r_campaign_id,
+           'aid'::text     AS r_match_kind
+      FROM t
+      JOIN customer_orders co ON co.id = t.customer_order_id
+      JOIN customer_order_items coi
+        ON coi.order_id = co.id
+       AND coi.status NOT IN ('cancelled', 'expired')
+      JOIN want w ON w.want_sku_id = coi.sku_id
+      LEFT JOIN members m ON m.id = co.member_id
+     GROUP BY coi.sku_id, co.id, co.order_no, m.name, co.nickname_snapshot,
+              co.status, co.campaign_id
+  ),
+  from_restock AS (
+    -- 補貨申請（RR-xxx，order_kind='restock'）：同店 + 同品項。
+    -- 這條刻意不排除 coi.status = 'cancelled' —— 見檔頭說明。
+    SELECT coi.sku_id      AS r_sku_id,
+           co.id           AS r_order_id,
+           co.order_no     AS r_order_no,
+           COALESCE(m.name, co.nickname_snapshot, '補貨申請') AS r_customer,
+           co.status       AS r_status,
+           SUM(coi.qty)    AS r_qty,
+           co.campaign_id  AS r_campaign_id,
+           'restock'::text AS r_match_kind
+      FROM t
+      JOIN store st ON TRUE
+      JOIN customer_orders co
+        ON co.pickup_store_id = st.store_id
+       AND co.tenant_id       = t.tenant_id
+       AND co.order_kind      = 'restock'
+       AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+       AND co.transferred_from_order_id IS NULL
+      JOIN customer_order_items coi ON coi.order_id = co.id
+      JOIN want w ON w.want_sku_id = coi.sku_id
+      LEFT JOIN members m ON m.id = co.member_id
+     GROUP BY coi.sku_id, co.id, co.order_no, m.name, co.nickname_snapshot,
+              co.status, co.campaign_id
+  ),
+  from_store AS (
+    -- 一般顧客訂單的退路：沒有波次 / 波次沒帶開團時，只用「取貨店 + 品項」比對
+    SELECT coi.sku_id       AS r_sku_id,
+           co.id            AS r_order_id,
+           co.order_no      AS r_order_no,
+           COALESCE(m.name, co.nickname_snapshot) AS r_customer,
+           co.status        AS r_status,
+           SUM(coi.qty)     AS r_qty,
+           co.campaign_id   AS r_campaign_id,
+           'store_sku'::text AS r_match_kind
+      FROM t
+      JOIN store st ON TRUE
+      JOIN customer_orders co
+        ON co.pickup_store_id = st.store_id
+       AND co.tenant_id       = t.tenant_id
+       AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+       AND co.transferred_from_order_id IS NULL
+       AND (co.order_kind = 'normal' OR co.order_kind IS NULL)
+      JOIN customer_order_items coi
+        ON coi.order_id = co.id
+       AND coi.status NOT IN ('cancelled', 'expired')
+      JOIN want w ON w.want_sku_id = coi.sku_id
+      LEFT JOIN members m ON m.id = co.member_id
+     WHERE NOT EXISTS (SELECT 1 FROM from_wave fw WHERE fw.r_sku_id = coi.sku_id)
+       AND NOT EXISTS (SELECT 1 FROM from_aid  fa WHERE fa.r_sku_id = coi.sku_id)
+     GROUP BY coi.sku_id, co.id, co.order_no, m.name, co.nickname_snapshot,
+              co.status, co.campaign_id
+  ),
+  unioned AS (
+    SELECT * FROM from_wave
+    UNION ALL SELECT * FROM from_aid
+    UNION ALL SELECT * FROM from_restock
+    UNION ALL SELECT * FROM from_store
+  )
+  SELECT DISTINCT ON (u.r_sku_id, u.r_order_id)
+         u.r_sku_id, u.r_order_id, u.r_order_no, u.r_customer,
+         u.r_status, u.r_qty, u.r_campaign_id, u.r_match_kind
+    FROM unioned u
+   ORDER BY u.r_sku_id, u.r_order_id,
+            CASE u.r_match_kind
+              WHEN 'wave' THEN 1 WHEN 'aid' THEN 2 WHEN 'restock' THEN 3 ELSE 4
+            END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_get_orders_for_transfer(BIGINT, BIGINT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_get_orders_for_transfer(BIGINT, BIGINT) TO authenticated;

--- a/supabase/migrations/20260805000100_allocate_shortage_split_lines.sql
+++ b/supabase/migrations/20260805000100_allocate_shortage_split_lines.sql
@@ -1,0 +1,136 @@
+-- ============================================================
+-- 少發配貨支援拆行：一筆訂單可以「部分配到、部分待補」
+--
+-- 動機：20260805000060 的配貨是整行為單位，一筆 3 件的訂單為了補 1 件的缺口
+--   就整行被擋，回頭配貨因此標了 212 件、實際缺口只有 185 件。
+--
+-- 做法：沿用這個 codebase 既有的「拆列」慣例 —— rpc_record_pickup 部分取貨時
+--   就是把 customer_order_items 拆成 picked_up 行 + 殘行
+--   （20260801000000:755 起）。配貨照做：一筆 3 件只配到 2 件時，
+--   原行改成 2（可取），另插一行 1（backorder_at 有值）。
+--
+--   這樣取貨閘門、rpc_record_pickup、取貨頁全部不用改 —— 它們看到的永遠是
+--   「整行可取」或「整行待補」，跟改成數量比較相比少掉一整圈迴歸風險。
+--   line-level 折扣按數量比例分攤，兩行小計加總 = 原行（與拆行取貨同一套算法）。
+--
+-- p_allocations 從 BIGINT[] 換成 jsonb {"<item_id>": <配到的數量>}，
+--   所以是 DROP + CREATE（參數型別變了，CREATE OR REPLACE 只會多一個 overload）。
+--
+-- 基底版本：20260805000060_shortage_allocation 的 rpc_allocate_shortage
+-- rollback: DROP FUNCTION IF EXISTS public.rpc_allocate_shortage(bigint,bigint,jsonb,uuid);
+--           並重跑 20260805000060 的 rpc_allocate_shortage。
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.rpc_allocate_shortage(BIGINT, BIGINT, BIGINT[], UUID);
+
+CREATE OR REPLACE FUNCTION public.rpc_allocate_shortage(
+  p_transfer_id BIGINT,
+  p_sku_id      BIGINT,
+  p_allocations jsonb,     -- {"<order_item_id>": <配到的數量>}；沒列到的視為 0
+  p_operator    UUID
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_ctx        RECORD;
+  r            RECORD;
+  v_alloc      NUMERIC;
+  v_freed      INT := 0;
+  v_blocked    INT := 0;
+  v_split      INT := 0;
+  v_new_disc   NUMERIC;
+BEGIN
+  SELECT pwi.tenant_id, pwi.campaign_id, pwi.store_id, pwi.sku_id
+    INTO v_ctx
+    FROM picking_wave_items pwi
+   WHERE pwi.generated_transfer_id = p_transfer_id
+     AND pwi.sku_id = p_sku_id
+     AND pwi.campaign_id IS NOT NULL
+   LIMIT 1;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '這張派貨單的該品項查不到對應的撿貨波次（可能是補貨或自由轉貨），無法配貨';
+  END IF;
+
+  FOR r IN
+    SELECT coi.id, coi.qty, coi.tenant_id, coi.order_id, coi.campaign_item_id,
+           coi.sku_id, coi.unit_price, coi.status, coi.source, coi.notes,
+           coi.discount_amount, coi.discount_percent, coi.backorder_at
+      FROM customer_orders co
+      JOIN customer_order_items coi ON coi.order_id = co.id AND coi.sku_id = v_ctx.sku_id
+     WHERE co.tenant_id       = v_ctx.tenant_id
+       AND co.campaign_id     = v_ctx.campaign_id
+       AND co.pickup_store_id = v_ctx.store_id
+       AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+       AND co.transferred_from_order_id IS NULL
+       AND (co.order_kind = 'normal' OR co.order_kind IS NULL)
+       AND coi.status IN ('pending', 'reserved', 'ready')
+     ORDER BY coi.id
+     FOR UPDATE OF coi
+  LOOP
+    v_alloc := COALESCE((p_allocations ->> r.id::text)::numeric, 0);
+    v_alloc := GREATEST(LEAST(v_alloc, r.qty), 0);
+
+    IF v_alloc >= r.qty THEN
+      -- 全部配到：解除待補貨
+      IF r.backorder_at IS NOT NULL THEN
+        UPDATE customer_order_items
+           SET backorder_at = NULL, backorder_by = NULL,
+               updated_by = p_operator, updated_at = NOW()
+         WHERE id = r.id;
+        v_freed := v_freed + 1;
+      END IF;
+
+    ELSIF v_alloc <= 0 THEN
+      -- 完全沒配到：整行待補貨
+      IF r.backorder_at IS NULL THEN
+        UPDATE customer_order_items
+           SET backorder_at = NOW(), backorder_by = p_operator,
+               updated_by = p_operator, updated_at = NOW()
+         WHERE id = r.id;
+        v_blocked := v_blocked + 1;
+      END IF;
+
+    ELSE
+      -- 部分配到 → 拆行：原行留可取的量，另開一行掛待補貨
+      -- 折扣按數量比例分攤（與 rpc_record_pickup 拆行同一套算法）
+      v_new_disc := COALESCE(r.discount_amount, 0)
+                    - round(COALESCE(r.discount_amount, 0) * v_alloc / r.qty);
+
+      INSERT INTO customer_order_items (
+        tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+        status, source, notes, discount_amount, discount_percent,
+        backorder_at, backorder_by,
+        created_by, updated_by, created_at, updated_at
+      ) VALUES (
+        r.tenant_id, r.order_id, r.campaign_item_id, r.sku_id, r.qty - v_alloc, r.unit_price,
+        r.status, r.source, r.notes, v_new_disc, r.discount_percent,
+        NOW(), p_operator,
+        p_operator, p_operator, NOW(), NOW()
+      );
+
+      UPDATE customer_order_items
+         SET qty = v_alloc,
+             discount_amount = COALESCE(r.discount_amount, 0)
+                               - v_new_disc,
+             backorder_at = NULL,
+             backorder_by = NULL,
+             updated_by = p_operator,
+             updated_at = NOW()
+       WHERE id = r.id;
+
+      v_split := v_split + 1;
+      v_blocked := v_blocked + 1;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('freed', v_freed, 'backordered', v_blocked, 'split', v_split);
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_allocate_shortage(BIGINT, BIGINT, jsonb, UUID) IS
+  '少發配貨：p_allocations={"<order_item_id>":<配到的數量>}。'
+  '部分配到時把 customer_order_items 拆成「可取行 + 待補行」，'
+  '取貨閘門與 rpc_record_pickup 因此不必改（它們看到的永遠是整行可取或整行待補）。';
+
+REVOKE ALL ON FUNCTION public.rpc_allocate_shortage(BIGINT, BIGINT, jsonb, UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_allocate_shortage(BIGINT, BIGINT, jsonb, UUID) TO authenticated;


### PR DESCRIPTION
接續 #615。已 rebase 到最新 main，只留 #615 之後的三個 commit。

## 1. 補貨 / 自由轉貨的單標明來源（`cce6c41`）

湖口店 `WAVE-875-S49` 點數量看訂單回「查不到對應的訂單」，店家以為系統壞了。那張的 5 條 `picking_wave_items` 的 `campaign_id` 全是 NULL —— 不是開團派的。

新增 `rpc_get_transfer_source_kinds`，批次判斷每張單是：

| kind | 判定 | 畫面 |
|---|---|---|
| `campaign` | 有波次且至少一條帶 `campaign_id` | 正常，數量可點看訂單 |
| `restock` | 有波次但 `campaign_id` 全 NULL | 標「🔁 補貨」 |
| `free` | 沒有任何波次行 | 標「↔ 轉貨」，數量不給連結（點了也沒東西） |

線上 8815 張 shipped/received 裡：8433 張有開團、191 張補貨、191 張沒有波次，約 4% 會落在「查不到訂單」。

## 2. 補貨單也看得到它的補貨申請（`a86459b`）

> 上一個 commit 我把補貨標成「無顧客訂單」並拿掉入口 —— **那是錯的**，這個 commit 修正。

它背後有單：**`RR-247`**，一張 `order_kind='restock'` 的 `customer_orders`（湖口店，8/3 03:26 建立，波次 03:31 建立），5 個品項與派貨單的 5 個 SKU 一對一：

| 品項 | 申請 | 派出 |
|---|---|---|
| G00763-01 | 1 | 1 |
| G01020-03 | 2 | 2 |
| G01020-05 | 2 | 2 |
| G01279-01 | 1 | 1 |
| G01279-02 | 1 | **2** ← 多給 1 |

是 `rpc_get_orders_for_transfer` 的 `(order_kind='normal' OR IS NULL)` 把它濾掉了。

補貨這條路的資料形狀跟開團不同，另外處理：
- `picking_wave_items.campaign_id` 是 NULL，wave 路線對不到 → 改走「同店 + 同品項 + `order_kind='restock'`」。
- RR 單的品項轉出後會被設成 `cancelled`、長出 `__INTERNAL_RESTOCK__-TFxxxx` 子單（`transferred_from_order_id` 指回 RR）。那是內部帳的搬運，所以 restock 這條**刻意不套 `coi.status` 排除**，否則畫面又會是空的；子單本身仍被 `transferred_from_order_id IS NULL` 擋掉，不會與母單重複列出。
- 來源優先序 `wave > aid > restock > store_sku`。開團路徑不受影響（松山 9085 實測仍是 7 筆全走 wave）。

畫面：補貨的數量恢復可點、彈窗把該列標「補貨申請」、抬頭的「訂單 N 件」改成「申請 N 件」、多給的說法改成「超過申請量」。

## 3. 配貨支援拆行（`eb55581`）

原本配貨以整行為單位：一筆 3 件的訂單為了補 1 件的缺口就整行被擋（#615 的回頭配貨因此標了 212 件、實際缺口只有 185 件），而且額度剩 1 件時下一筆要 3 件只能整筆跳過，架上的貨白放著。

**做法是拆列，不是加數量欄位。** 這個 codebase 本來就有這個慣例 —— `rpc_record_pickup` 部分取貨時就是把 `customer_order_items` 拆成 picked_up 行 + 殘行（`20260801000000:755` 起）。配貨照做：一筆 3 件只配到 2 件時，原行改成 2（可取），另插一行 1（待補貨）。

好處是**取貨閘門、`rpc_record_pickup`、取貨頁全部不用改** —— 它們看到的永遠是「整行可取」或「整行待補」，比改成數量比較少掉一整圈迴歸風險。

- `rpc_allocate_shortage` 參數由 `BIGINT[]` 換成 `jsonb {"<item_id>": <配到的數量>}`（型別變了所以 DROP + CREATE）。折扣按數量比例分攤，兩行小計加總 = 原行。
- 配貨視窗每列改成數量輸入框（0 ~ 該行的量），「依訂單時間自動配」會把剩餘額度填給下一筆，不再整筆跳過。狀態欄多一種「部分待補 N」。

**線上實測（交易包起來後 rollback）**：qty 2 / 折扣 10 的行配 1 → 拆成 `(qty 1, 折扣 5, 可取貨=true)` + `(qty 1, 折扣 5, 待補貨, 可取貨=false)`，折扣加總不變；rollback 後確認資料無殘留。

## DB

`20260805000080` / `20260805000090` / `20260805000100`，三支都已用 Management API 部署到線上並驗證，一律 `REVOKE ALL ... FROM PUBLIC, anon`。

## 順帶回報：波次少排的根因（只查未改）

我先前說「`rpc_create_wave_from_po` 需求計算漏算」—— **講錯了，更正**。需求視圖算得完全正確：

```
v_picking_demand_by_po（松山店 / 阿猴鮮奶）
demand_qty = 11 · wave_qty = 10 · has_demand_left = true
```

真正的原因是**那 1 件從來沒有被再排一次波次**。而且不是個案：目前全系統有 **108 條線、281 件**，總倉有貨（`has_stock_left`）、需求也還在（`has_demand_left`），就是沒排進任何波次，橫跨 28 張 PO / 44 個品項 / 15 家店（最大一條是三峽店綠竹筍，需求 21 只排了 1）。

這些線本來就顯示在派貨工作台上（工作台正是用這兩個 flag 篩的），所以不是看不到，是缺「還欠多少」的總量感。要處理的話方向是給工作台一個未排完需求的統計與排序，不是改需求公式 —— 本 PR 沒有動。

## 驗證

Playwright + fixture 跑過：配貨視窗與拆行版的自動配、補貨單的訂單彈窗（RR-247 + 補貨申請標籤）、補貨標籤與連結停用、收貨頁兩種檢視、已收分頁。`tsc` 乾淨，eslint 無新增問題（2 個既有的）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTpgbPdduNrnC8V88DYxjS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTpgbPdduNrnC8V88DYxjS)_