### PR TITLE
feat(inbound): 訂單編號可點進訂單頁；狀態膠囊靠右對齊

### DIFF
--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -1073,29 +1073,17 @@ export default function TransfersInboxPage() {
                 >
                   <span className="mt-0.5 shrink-0 text-zinc-400">{open ? "▾" : "▸"}</span>
                   <span className="min-w-0">
-                    <span className="flex flex-wrap items-center gap-2">
-                      <span
-                        title={g.labelTitle || undefined}
-                        className={`break-words ${
-                          g.mono
-                            ? "font-mono text-sm font-bold text-blue-700 dark:text-blue-400"
-                            : "text-base font-bold text-zinc-900 dark:text-zinc-100"
-                        }`}
-                      >
-                        {g.label}
-                      </span>
-                      {pendingCount > 0 ? (
-                        <Pill tone="amber">待收 {pendingCount} 單</Pill>
-                      ) : (
-                        <Pill tone="emerald">✓ 已收到</Pill>
-                      )}
-                      {dueTag && <Pill tone={dueTag === "逾期" ? "rose" : "amber"}>{dueTag}</Pill>}
-                      {g.shortQty > 0 && (
-                        <Pill tone="rose">⚠ 少 {g.shortQty} 件 · 訂單比到貨多</Pill>
-                      )}
-                      {g.extraQty > 0 && (
-                        <Pill tone="blue">🎁 總倉多給 {g.extraQty} 件</Pill>
-                      )}
+                    {/* 標題只留品名/單號 — 狀態膠囊統一靠右對齊，長短不一的品名才不會
+                        把膠囊推到每列不同位置，一整頁掃下來看不出哪些有狀況 */}
+                    <span
+                      title={g.labelTitle || undefined}
+                      className={`block break-words ${
+                        g.mono
+                          ? "font-mono text-sm font-bold text-blue-700 dark:text-blue-400"
+                          : "text-base font-bold text-zinc-900 dark:text-zinc-100"
+                      }`}
+                    >
+                      {g.label}
                     </span>
                     <span className="mt-1.5 flex flex-wrap items-center gap-1.5">
                       {g.subLabel
@@ -1110,6 +1098,19 @@ export default function TransfersInboxPage() {
                     </span>
                   </span>
                 </SpinButton>
+
+                {/* 狀態膠囊：一律靠右，跟收貨按鈕同一區 */}
+                <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+                  {pendingCount > 0 ? (
+                    <Pill tone="amber">待收 {pendingCount} 單</Pill>
+                  ) : (
+                    <Pill tone="emerald">✓ 已收到</Pill>
+                  )}
+                  {dueTag && <Pill tone={dueTag === "逾期" ? "rose" : "amber"}>{dueTag}</Pill>}
+                  {g.shortQty > 0 && <Pill tone="rose">⚠ 少 {g.shortQty} 件 · 訂單比到貨多</Pill>}
+                  {g.extraQty > 0 && <Pill tone="blue">🎁 總倉多給 {g.extraQty} 件</Pill>}
+                </div>
+
                 {pendingCount > 0 && (
                   <SpinButton
                     onClick={() => receiveGroup(g)}

--- a/apps/admin/src/components/ShortageAllocateModal.tsx
+++ b/apps/admin/src/components/ShortageAllocateModal.tsx
@@ -5,7 +5,8 @@ import { Modal } from "@/components/Modal";
 import Spinner from "@/components/Spinner";
 import SpinButton from "@/components/SpinButton";
 import { getSupabase } from "@/lib/supabase";
-import { orderStatusLabel } from "@/lib/orderStatus";
+import Link from "next/link";
+import { orderStatusLabel, orderListHref } from "@/lib/orderStatus";
 import { translateRpcError } from "@/lib/rpcError";
 
 // 少發配貨：到貨量不夠分給所有訂單時，由收貨的人決定這批配給誰。
@@ -273,7 +274,17 @@ export function ShortageAllocateModal({
                             <span className="text-[10px] text-zinc-400">/ {r.qty}</span>
                           </div>
                         </td>
-                        <td className="px-3 py-2 font-mono text-xs">{r.order_no}</td>
+                        <td className="px-3 py-2 font-mono text-xs">
+                          <Link
+                            href={orderListHref(r.order_no, r.order_status)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 hover:underline dark:text-blue-400"
+                            title="開新分頁查看這張訂單（配貨中的內容不會遺失）"
+                          >
+                            {r.order_no} ↗
+                          </Link>
+                        </td>
                         <td className="max-w-[220px] truncate px-3 py-2" title={r.customer ?? ""}>
                           {r.customer || "—"}
                         </td>

--- a/apps/admin/src/components/TransferOrdersModal.tsx
+++ b/apps/admin/src/components/TransferOrdersModal.tsx
@@ -4,7 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 import { Modal } from "@/components/Modal";
 import Spinner from "@/components/Spinner";
 import { getSupabase } from "@/lib/supabase";
-import { orderStatusLabel } from "@/lib/orderStatus";
+import Link from "next/link";
+import { orderStatusLabel, orderListHref } from "@/lib/orderStatus";
 
 // 這張派貨單（可再限定單一品項）背後的顧客訂單。
 // 用途是回答店家的「這幾件是誰的？」以及「多出來的幾件為什麼沒人訂？」
@@ -143,7 +144,16 @@ export function TransferOrdersModal({
                       {orders.map((o) => (
                         <tr key={o.order_id}>
                           <td className="px-3 py-1.5 font-mono text-xs">
-                            {o.order_no}
+                            {/* 開新分頁：收貨 / 配貨做到一半不該被導走 */}
+                            <Link
+                              href={orderListHref(o.order_no, o.order_status)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-blue-600 hover:underline dark:text-blue-400"
+                              title="開新分頁查看這張訂單"
+                            >
+                              {o.order_no} ↗
+                            </Link>
                             {o.match_kind === "restock" && (
                               <span className="ml-1.5 rounded bg-violet-100 px-1 py-0.5 font-sans text-[10px] font-medium text-violet-700 dark:bg-violet-950 dark:text-violet-300">
                                 補貨申請

--- a/apps/admin/src/lib/orderStatus.ts
+++ b/apps/admin/src/lib/orderStatus.ts
@@ -95,3 +95,35 @@ export function canPayWithWallet(
 //   partially_ready       → 部分可取
 //   picked_up             → 已取貨   （只用於 customer_order_items.status）
 // ============================================================
+
+// ============================================================
+// 訂單清單頁的深連結
+//
+// /orders 沒有「全部」分頁，預設落在「未取貨」(PENDING_STATUSES)。
+// 直接用 ?q=<order_no> 連過去，已完成 / 已取消的單會找不到 —— 所以要依訂單
+// 當下的 status 一併帶上對的 tab。對應關係與 orders/page.tsx 的查詢一致：
+//   pending  → status IN (pending, confirmed, shipping, ready)
+//   ready    → status = ready            （已被 pending 涵蓋，不特別導過去）
+//   partially/completed/cancelled/transferred → 各自對應
+// ============================================================
+export function orderListTabFor(status: string | null | undefined): string {
+  switch (status) {
+    case "partially_completed":
+      return "partially";
+    case "completed":
+      return "completed";
+    case "cancelled":
+    case "expired":
+      return "cancelled";
+    case "transferred_out":
+      return "transferred";
+    default:
+      return "pending";
+  }
+}
+
+/** 訂單清單頁的深連結；帶上 status 對應的 tab，確保連過去看得到那張單 */
+export function orderListHref(orderNo: string, status?: string | null): string {
+  const qs = new URLSearchParams({ q: orderNo, tab: orderListTabFor(status) });
+  return `/orders?${qs.toString()}`;
+}


### PR DESCRIPTION
接續 #616。已 rebase 到最新 main，只留 #616 之後的兩個 commit。純前端，沒有 DB 異動。

## 1. 訂單彈窗的訂單編號可點進訂單頁（`0b1bab0`）

訂單明細、少發配貨兩個彈窗的訂單編號改成連結（`GRP-20260730-016-0008 ↗`）。

**會帶對的分頁。** `/orders` 沒有「全部」分頁，預設落在「未取貨」（`PENDING_STATUSES`）。若只用 `?q=<訂單編號>` 連過去，已完成／已取消的單會查不到 —— 又是一個「怎麼找不到」。所以新增 `orderListHref()`，依訂單當下的 status 帶對的 tab：

| 訂單狀態 | tab |
|---|---|
| pending · confirmed · shipping · ready | `pending` |
| partially_completed | `partially` |
| completed | `completed` |
| cancelled · expired | `cancelled` |
| transferred_out | `transferred` |

對應關係與 `orders/page.tsx` 的查詢逐條核對過。

**開新分頁**（`target="_blank"`）：收貨／配貨做到一半被導走的話，配貨視窗裡填到一半的數量會全部沒掉。

`/orders` 沒有濾 `order_kind`，所以補貨申請單（`RR-xxx`）連過去也查得到。實測渲染出來的 href 是 `/orders/?q=GRP-20260805-001-0007&tab=pending`（Next 會補尾斜線）。

## 2. 群組的狀態膠囊一律靠右對齊（`9e057e7`）

「✓ 已收到」「🎁 總倉多給 N 件」「⚠ 少 N 件」「逾期」「待收 N 單」原本接在品名後面。品名長短不一，膠囊就落在每列不同的位置，一整頁掃下來看不出哪幾組有狀況。改成跟收貨按鈕同一區、靠右對齊，左邊只留品名／單號。

順帶：膠囊移出了可展開的按鈕範圍，點膠囊不再誤觸展開／收合。

## 驗證

Playwright + fixture 跑過：訂單彈窗（斷言渲染出的 href 與 tab）、配貨視窗、收貨頁兩種檢視、補貨標籤、已收分頁。`tsc` 乾淨，eslint 無新增問題。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTpgbPdduNrnC8V88DYxjS

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTpgbPdduNrnC8V88DYxjS)_