### PR TITLE
feat(orders): 取貨後可補印取貨收據

### DIFF
--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -80,6 +80,27 @@ type ReturnTransfer = {
   lines: ReturnLine[];
 };
 
+// 取貨事件（order_pickup_events，append-only）。收據 /pickup/print 是以 event_id 為準，
+// 所以取貨當下沒印到 / 印壞了，事後都能靠這裡的 id 補印出「當時那張」收據。
+type PickupEventRow = {
+  id: number;
+  event_type: string;      // picked_up | partial_pickup | pickup_undone
+  created_at: string;
+  notes: string | null;
+};
+
+// 撤銷取貨不刪原事件（表禁改禁刪），而是補一筆 pickup_undone，
+// notes 固定為 `撤銷取貨事件 #<id>…`（rpc_undo_pickup）。被撤銷的那次不該再補印收據。
+function undonePickupEventIds(rows: PickupEventRow[]): Set<number> {
+  const undone = new Set<number>();
+  for (const r of rows) {
+    if (r.event_type !== "pickup_undone") continue;
+    const m = /撤銷取貨事件 #(\d+)/.exec(r.notes ?? "");
+    if (m) undone.add(Number(m[1]));
+  }
+  return undone;
+}
+
 // 品項狀態標籤（部分取貨會把一行拆成「已取」+「待取」兩行，標籤讓兩者一眼可分）
 function itemStatusBadge(status: string, stockout = false): { label: string; cls: string } | null {
   // 斷貨取消（stockout_at 有值）與一般取消區分顯示
@@ -155,6 +176,11 @@ function fmtDt(iso: string): string {
   return new Date(iso).toLocaleString("zh-TW", { hour12: false });
 }
 
+function pickupEventLabel(ev: PickupEventRow | undefined): string {
+  if (!ev) return "—";
+  return `${ev.event_type === "partial_pickup" ? "部分取貨" : "取貨"} ${fmtDt(ev.created_at)}`;
+}
+
 export function OrderDetail({
   orderId,
   onNavigate,
@@ -168,6 +194,8 @@ export function OrderDetail({
   // item.id → 是否已到貨可取（v_order_item_pickup_ready）。shipping 單部分到貨時，已到品項可先取
   const [itemReady, setItemReady] = useState<Map<number, boolean>>(new Map());
   const [returnDetailId, setReturnDetailId] = useState<number | null>(null);
+  // 該訂單的取貨事件（append-only）— 取貨後補印收據用，見 /pickup/print?event_ids=
+  const [pickupEvents, setPickupEvents] = useState<PickupEventRow[]>([]);
   const [timeline, setTimeline] = useState<TimelineStep[] | null>(null);
   const [staffNames, setStaffNames] = useState<Map<string, string>>(new Map());
   // sku_id → 現行分店價（prices scope=branch, effective_to IS NULL）
@@ -221,7 +249,7 @@ export function OrderDetail({
     let cancelled = false;
     (async () => {
       const sb = getSupabase();
-      const [hRes, iRes, rRes, arvRes] = await Promise.all([
+      const [hRes, iRes, rRes, arvRes, pevRes] = await Promise.all([
         sb.from("customer_orders")
           .select("id, order_no, status, stockout_at, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, transferred_from_order_id, is_air_transfer, discount_amount, discount_percent, wallet_paid_amount, payment_status, paid_at, notes, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .eq("id", orderId).maybeSingle(),
@@ -238,6 +266,11 @@ export function OrderDetail({
         sb.from("v_order_item_pickup_ready")
           .select("item_id, pickup_ready")
           .eq("order_id", orderId),
+        sb.from("order_pickup_events")
+          .select("id, event_type, created_at, notes")
+          .eq("order_id", orderId)
+          .in("event_type", ["picked_up", "partial_pickup", "pickup_undone"])
+          .order("id", { ascending: true }),
       ]);
       if (cancelled) return;
       if (hRes.error) { setError(hRes.error.message); return; }
@@ -252,6 +285,14 @@ export function OrderDetail({
         arrivedMap.set(r.item_id, !!r.pickup_ready);
       }
       setItemReady(arrivedMap);
+
+      const pevRows = (pevRes.data ?? []) as unknown as PickupEventRow[];
+      const undoneIds = undonePickupEventIds(pevRows);
+      setPickupEvents(
+        pevRows.filter(
+          (e) => e.event_type !== "pickup_undone" && !undoneIds.has(e.id),
+        ),
+      );
 
       // ========== 整理退貨單（return_to_hq transfer）==========
       type RetRow = {
@@ -500,8 +541,12 @@ export function OrderDetail({
   // 貨還沒到分店不能轉單：source 必須 status='ready' (跟 DB rpc_transfer_order_* 一致)
   const canTransfer = head.status === "ready";
   const canCancel = ["pending", "confirmed", "shipping"].includes(head.status);
-  // 還沒到貨（pending/confirmed/shipping）也可以列印小白單；ready 透過 PickupDialog 已有入口
-  const canPrintSlip = ["pending", "confirmed", "shipping", "ready"].includes(head.status);
+  // 還沒到貨（pending/confirmed/shipping）也可以列印小白單；ready 透過 PickupDialog 已有入口。
+  // partially_completed 也開放（對齊 /orders 列表）— 小白單只列還沒取的品項，已取走的不會重複出現。
+  const canPrintSlip = ["pending", "confirmed", "shipping", "ready", "partially_completed"].includes(head.status);
+  // 取貨收據補印：取貨當下才會自動印一次，事後只能靠 order_pickup_events 的 id 找回來。
+  // 小白單(print-list)在這裡幫不上忙 — 它只列 pending/reserved/ready 品項，取完貨會印成空單。
+  const canReprintReceipt = pickupEvents.length > 0;
   // 一般顧客訂單退回總倉（rpc_create_order_return）— 互助單不走這條（貨應退回原 source 店）
   const canReturn = !isAidOrder && ["shipping", "ready", "partially_completed", "completed", "expired"].includes(head.status);
   // 互助單已收貨未取貨（status=ready）退單：退回原 source 店（rpc_return_aid_order，#234）
@@ -679,8 +724,25 @@ export function OrderDetail({
           </SpinButton>
         </div>
       )}
-      {(canPrintSlip || canTransfer || canPickup || canUndoPickup || canCancel || canReturn || canAidReturn || isTransferredOut) && (
+      {(canPrintSlip || canReprintReceipt || canTransfer || canPickup || canUndoPickup || canCancel || canReturn || canAidReturn || isTransferredOut) && (
         <div className="flex items-center justify-end gap-2">
+          {canReprintReceipt && (
+            <SpinButton
+              onClick={() =>
+                printViaIframe(
+                  withBasePath(`/pickup/print?event_ids=${pickupEvents.map((e) => e.id).join(",")}`),
+                )
+              }
+              title={
+                pickupEvents.length > 1
+                  ? `補印取貨收據（${pickupEvents.length} 次取貨，依序各印一張）\n${pickupEvents.map((e) => pickupEventLabel(e)).join("\n")}`
+                  : `補印取貨收據（${pickupEventLabel(pickupEvents[0])}）`
+              }
+              className="rounded-md border border-zinc-300 px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              補印收據{pickupEvents.length > 1 ? `（${pickupEvents.length}）` : ""}
+            </SpinButton>
+          )}
           {canPrintSlip && (
             <SpinButton
               onClick={() =>

--- a/docs/TEST-reprint-pickup-receipt.md
+++ b/docs/TEST-reprint-pickup-receipt.md
@@ -1,0 +1,41 @@
+# 測試項目 — 取貨後補印收據（訂單明細「補印收據」鈕）
+
+**範圍:** 純前端 UI。取貨當下自動印的那張 80mm 熱感收據（`/pickup/print?event_ids=`）原本只在取貨的那一瞬間印得到，事後沒有任何入口；本次在 `OrderDetail` 加一顆「補印收據」，用 `order_pickup_events` 的 id 把當時那張收據找回來重印。無 schema / RPC 變更。
+
+**為什麼不是「補印小白單」:** `/pickup/print-list`（小白單）只列 `status ∈ {pending, reserved, ready}` 的品項，取貨後品項變 `picked_up`，硬開網址會印出空單、合計 $0。取貨後有意義的是**收據**，資料在 append-only 的 `order_pickup_events`。
+
+**對應變更:**
+- `apps/admin/src/components/OrderDetail.tsx`
+  - 主載入 `Promise.all` 加一支 `order_pickup_events` 查詢（`picked_up` / `partial_pickup` / `pickup_undone`，依 id 升冪）。
+  - `undonePickupEventIds()`：撤銷取貨不刪原事件，而是補一筆 `pickup_undone`、notes 為 `撤銷取貨事件 #<id>…`（`rpc_undo_pickup`，20260704000010）。解析出被撤銷的 id 並濾掉 — 撤銷掉的那次不給補印。
+  - `canReprintReceipt = pickupEvents.length > 0` → 動作列多一顆「補印收據」，一次帶上該訂單所有有效取貨事件（`?event_ids=a,b`，列印頁本來就支援多筆、逐張印）。多次取貨時鈕上顯示次數、title 列出每次的時間。
+  - `canPrintSlip` 加入 `partially_completed`（對齊 `/orders` 列表；先前列表印得到、進明細反而沒有鈕）。
+- 列印頁 `/pickup/print`、`/pickup/print-list` **不動**。
+
+**驗證方式:** `tsc --noEmit` + eslint（該檔 0 error，2 個既有 warning 未增加）+ Playwright fixture 驗證（`apps/admin/.claude/skills/verify`，攔 `rest/v1` 回假資料，不碰線上 DB）。
+
+---
+
+## 1. 顯示條件（已用 fixture 實測）
+
+- [x] `completed` + 2 筆取貨事件（`partial_pickup` + `picked_up`）→ 鈕顯示為「補印收據（2）」，title 列出兩次時間
+- [x] `partially_completed` + 1 筆 `partial_pickup` → 「補印收據」與「列印」（小白單）兩顆並存
+- [x] `picked_up` 事件已被 `pickup_undone` 撤銷 → 鈕**不顯示**（不會印出已作廢的收據）
+- [x] `ready`（無取貨事件）→ 只有原本的「列印」小白單鈕，無「補印收據」
+
+## 2. 列印行為（已用 fixture 實測）
+
+- [x] 點「補印收據」→ 走 `printViaIframe`（不跳新分頁），載入 `/pickup/print?event_ids=555,556`
+- [x] 單筆事件 → `?event_ids=555`
+- [ ] **使用者本機自審:** 實際印出的內容＝當時那張 80mm 收據（品項＝該事件的 `item_ids`、數量與部分取貨拆行一致）
+
+## 3. 已知限制（設計如此，非 bug）
+
+- 收據上的**折扣 / 儲值金 / 應收金額是即時從 `customer_orders` 讀的**，不是取貨當下的快照。取貨後若又改過折扣，補印出來的金額會是改後的值。要「印出當時原樣」需另存快照，本次不做。
+- 撤銷判定靠 `pickup_undone` 的 notes 格式（`撤銷取貨事件 #<id>`）。若日後改 `rpc_undo_pickup` 的 notes 文字，這裡的正則要一起改。
+
+## 4. 回歸 / 品質
+
+- [x] `tsc --noEmit` 0 error
+- [x] `OrderDetail.tsx` 無新增 eslint error/warning
+- [x] 取貨 / 撤銷取貨後 `reloadTick` 會重抓事件，鈕即時出現或消失


### PR DESCRIPTION
取貨當下自動印的 80mm 收據，事後沒有任何入口可以再印一次；小白單
(/pickup/print-list) 也幫不上忙 — 它只列 pending/reserved/ready 品項，
取完貨開網址會印成空單。

改在訂單明細動作列加一顆「補印收據」：讀 order_pickup_events（append-only）
拿該單所有取貨事件 id，走既有的 /pickup/print?event_ids= 重印當時那張。
被 rpc_undo_pickup 撤銷過的事件（補償事件 pickup_undone 的 notes 帶
「撤銷取貨事件 #<id>」）會濾掉，不給補印已作廢的收據。

順手把 canPrintSlip 加上 partially_completed，對齊 /orders 列表 —
先前同一張單在列表印得到小白單、進明細反而沒有鈕。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R8qL1C1equqhtmGzBBJSy1