### PR TITLE
feat(orders): 已完成／部分取貨分頁的日期區間改看取貨日

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -234,6 +234,11 @@ function OrdersListContent() {
 
   const fromTs = useMemo(() => (dateFrom ? dayStartIso(dateFrom) : null), [dateFrom]);
   const toTs = useMemo(() => (dateTo ? dayStartIso(dateTo, 1) : null), [dateTo]);
+  // 日期區間的語意跟著 tab 走（不另做切換 UI）：已完成 / 部分取貨 = 取貨日，其餘 = 訂單日。
+  // 團購下單到取貨隔好幾天甚至幾週，在「已完成」用訂單日篩最近幾天永遠是 0 筆；
+  // 這兩個 tab 使用者真正要問的是「這幾天交出去哪些貨」。DB 端 tab 數量同步改法見
+  // migration 20260805000110_rpc_order_overview_pickup_date_tabs.sql。
+  const dateOnPickup = tab === "completed" || tab === "partially";
   const hasFilter = campaignIds.length > 0 || !!storeId || !!keyword || !!dateFrom || !!dateTo;
 
   useEffect(() => { setPage(1); }, [campaignIds, tab, storeId, keyword, fromTs, toTs]);
@@ -323,9 +328,17 @@ function OrdersListContent() {
     setLoading(true);
     (async () => {
       try {
+        const cols = "id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, transferred_from_order_id, created_at, updated_at";
+        // 取貨日模式（已完成 / 部分取貨 + 有設日期）：改用 PostgREST 內嵌 !inner 過濾
+        // 「該區間內有 picked_up 明細」的訂單。內嵌是 lateral，父列不會因多筆明細重複，
+        // count:exact 仍等於訂單數（線上對照 EXISTS 版 SQL：同為 213 筆）。
+        const pickupRange = dateOnPickup && !!(fromTs || toTs);
+        // select 字串是動態的（兩種 shape），supabase-js 的型別解析器吃不了 union，
+        // 故標成 string 讓它退回 any；回傳值下面照舊 cast 成 Row[]。
+        const sel: string = pickupRange ? `${cols}, customer_order_items!inner(order_id)` : cols;
         let q = getSupabase()
           .from("customer_orders")
-          .select("id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, transferred_from_order_id, created_at, updated_at", { count: "exact" })
+          .select(sel, { count: "exact" })
           .order("updated_at", { ascending: false })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 
@@ -339,8 +352,15 @@ function OrdersListContent() {
         else if (tab === "transferred") q = q.eq("status", "transferred_out");
         else q = q.in("status", PENDING_STATUSES);
         if (storeId) q = q.eq("pickup_store_id", Number(storeId));
-        if (fromTs) q = q.gte("created_at", fromTs);
-        if (toTs) q = q.lt("created_at", toTs);
+        if (pickupRange) {
+          // 取貨日 = picked_up 明細的 updated_at（與 KPI「今日取貨金額」同一定義）
+          q = q.eq("customer_order_items.status", "picked_up");
+          if (fromTs) q = q.gte("customer_order_items.updated_at", fromTs);
+          if (toTs) q = q.lt("customer_order_items.updated_at", toTs);
+        } else {
+          if (fromTs) q = q.gte("created_at", fromTs);
+          if (toTs) q = q.lt("created_at", toTs);
+        }
         const kwOr = await buildKeywordOr(keyword);
         if (cancelled) return;
         if (kwOr) q = q.or(kwOr);
@@ -349,13 +369,14 @@ function OrdersListContent() {
         if (cancelled) return;
         if (error) { setError(error.message); return; }
         setError(null);
-        setRows((data ?? []) as Row[]);
+        const list = (data ?? []) as unknown as Row[];
+        setRows(list);
         setTotal(count ?? 0);
 
-        const ids = (data ?? []).map((r) => r.id);
-        const memIds = Array.from(new Set((data ?? []).map((r) => r.member_id).filter((x): x is number => x != null)));
+        const ids = list.map((r) => r.id);
+        const memIds = Array.from(new Set(list.map((r) => r.member_id).filter((x): x is number => x != null)));
         // shipping 單查品項到貨狀態（pickup_ready=true 隱含該品項 active 且已到貨）
-        const shippingIds = (data ?? []).filter((r) => r.status === "shipping").map((r) => r.id);
+        const shippingIds = list.filter((r) => r.status === "shipping").map((r) => r.id);
         const [ic, ms, rdy] = await Promise.all([
           ids.length
             ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price, source, sku:skus(product_name, variant_name)").in("order_id", ids)
@@ -396,7 +417,7 @@ function OrdersListContent() {
       }
     })();
     return () => { cancelled = true; };
-  }, [campaignIds, tab, storeId, page, reloadOrders, keyword, fromTs, toTs]);
+  }, [campaignIds, tab, dateOnPickup, storeId, page, reloadOrders, keyword, fromTs, toTs]);
 
   // 頁首聚合（tab 數量 + 月趨勢）— 單一伺服端 RPC rpc_order_overview
   // 取代之前 client 端「5 個 count:exact 全表掃描」+「搬整月訂單+全部明細
@@ -834,14 +855,19 @@ function OrdersListContent() {
         </form>
       </div>
 
-      {/* 訂單日 (created_at) 區間 — 含起訖當日；留空 = 不限。
+      {/* 日期區間 — 含起訖當日；留空 = 不限。語意跟著 tab 走（見 dateOnPickup）：
+          已完成 / 部分取貨 = 取貨日，其餘 = 訂單日 (created_at)。
           自成一列：兩個 date input + 快捷鈕塞進上面的 3 欄 grid 會被壓到看不到年份。 */}
       <div className="flex flex-wrap items-center gap-2 text-sm">
         <div
           className="flex items-center gap-1 rounded-md border border-zinc-300 bg-white px-2 py-1 dark:border-zinc-700 dark:bg-zinc-800"
-          title="依訂單日 (created_at) 篩選，含起訖當日；留空 = 不限"
+          title={dateOnPickup
+            ? "此分頁依取貨日篩選（已取貨品項的取貨時間），含起訖當日；留空 = 不限"
+            : "依訂單日 (created_at) 篩選，含起訖當日；留空 = 不限"}
         >
-          <span className="shrink-0 pl-1 text-xs text-zinc-500">訂單日</span>
+          <span className={`shrink-0 pl-1 text-xs ${dateOnPickup ? "font-medium text-emerald-700 dark:text-emerald-400" : "text-zinc-500"}`}>
+            {dateOnPickup ? "取貨日" : "訂單日"}
+          </span>
           <input
             type="date"
             value={dateFrom}

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -73,6 +73,16 @@ const TABS: { value: Tab; label: string }[] = [
   { value: "cancelled", label: "取消" },
 ];
 const TAB_VALUES = TABS.map((t) => t.value);
+// 日期區間欄位在各 tab 的名稱與說明 —— 對應 v_admin_orders.event_at 的來源
+// （只有「未取貨」看訂單日 created_at，其餘看該狀態自己的事件時間）。
+const DATE_FIELD_LABEL: Record<Tab, { label: string; hint: string }> = {
+  pending:     { label: "訂單日", hint: "依訂單日 (created_at) 篩選" },
+  ready:       { label: "可取日", hint: "依「到貨變成可取貨」的日期篩選" },
+  partially:   { label: "取貨日", hint: "依最後一次取貨的日期篩選" },
+  completed:   { label: "取貨日", hint: "依取貨完成的日期篩選" },
+  cancelled:   { label: "取消日", hint: "依取消／過期的日期篩選" },
+  transferred: { label: "轉出日", hint: "依轉出（開出接手單）的日期篩選" },
+};
 const PENDING_STATUSES: OrderStatus[] = ["pending", "confirmed", "shipping", "ready"];
 const CANCELLED_STATUSES: OrderStatus[] = ["cancelled", "expired"];
 
@@ -234,11 +244,14 @@ function OrdersListContent() {
 
   const fromTs = useMemo(() => (dateFrom ? dayStartIso(dateFrom) : null), [dateFrom]);
   const toTs = useMemo(() => (dateTo ? dayStartIso(dateTo, 1) : null), [dateTo]);
-  // 日期區間的語意跟著 tab 走（不另做切換 UI）：已完成 / 部分取貨 = 取貨日，其餘 = 訂單日。
-  // 團購下單到取貨隔好幾天甚至幾週，在「已完成」用訂單日篩最近幾天永遠是 0 筆；
-  // 這兩個 tab 使用者真正要問的是「這幾天交出去哪些貨」。DB 端 tab 數量同步改法見
-  // migration 20260805000110_rpc_order_overview_pickup_date_tabs.sql。
-  const dateOnPickup = tab === "completed" || tab === "partially";
+  // 日期區間的語意跟著 tab 走（不另做切換 UI）：只有「未取貨」看訂單日，其餘每個 tab
+  // 都看該狀態自己的事件日 v_admin_orders.event_at（可取=ready_at、取貨=completed_at /
+  // 最後一次取貨、取消=cancelled_at、轉出=接手單 created_at）。
+  // 團購下單到取貨隔好幾天甚至幾週，終態 tab 用訂單日篩最近幾天永遠是 0 筆 ——
+  // 使用者要問的是「這幾天*發生*了什麼」。定義與覆蓋率見 migration
+  // 20260805000120_v_admin_orders_event_at.sql；tab 數量同步改法見 20260805000130。
+  // ⚠ 不要改用 updated_at：它會被之後任何寫入 touch 掉（線上 26% 的已完成單偏差 >1h）。
+  const dateOnEvent = tab !== "pending";
   const hasFilter = campaignIds.length > 0 || !!storeId || !!keyword || !!dateFrom || !!dateTo;
 
   useEffect(() => { setPage(1); }, [campaignIds, tab, storeId, keyword, fromTs, toTs]);
@@ -328,18 +341,13 @@ function OrdersListContent() {
     setLoading(true);
     (async () => {
       try {
-        const cols = "id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, transferred_from_order_id, created_at, updated_at";
-        // 取貨日模式（已完成 / 部分取貨 + 有設日期）：改用 PostgREST 內嵌 !inner 過濾
-        // 「該區間內有 picked_up 明細」的訂單。內嵌是 lateral，父列不會因多筆明細重複，
-        // count:exact 仍等於訂單數（線上對照 EXISTS 版 SQL：同為 213 筆）。
-        const pickupRange = dateOnPickup && !!(fromTs || toTs);
-        // select 字串是動態的（兩種 shape），supabase-js 的型別解析器吃不了 union，
-        // 故標成 string 讓它退回 any；回傳值下面照舊 cast 成 Row[]。
-        const sel: string = pickupRange ? `${cols}, customer_order_items!inner(order_id)` : cols;
+        // 查 v_admin_orders（= customer_orders + 事件日 event_at），日期區間才有單一
+        // 欄位可篩；事件日 tab 也照事件日排序（照 updated_at 排會讓被批次寫入 touch
+        // 過的舊單浮到最前面）。
         let q = getSupabase()
-          .from("customer_orders")
-          .select(sel, { count: "exact" })
-          .order("updated_at", { ascending: false })
+          .from("v_admin_orders")
+          .select("id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, transferred_from_order_id, created_at, updated_at", { count: "exact" })
+          .order(dateOnEvent ? "event_at" : "updated_at", { ascending: false })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 
         if (campaignIds.length === 1) q = q.eq("campaign_id", Number(campaignIds[0]));
@@ -352,15 +360,9 @@ function OrdersListContent() {
         else if (tab === "transferred") q = q.eq("status", "transferred_out");
         else q = q.in("status", PENDING_STATUSES);
         if (storeId) q = q.eq("pickup_store_id", Number(storeId));
-        if (pickupRange) {
-          // 取貨日 = picked_up 明細的 updated_at（與 KPI「今日取貨金額」同一定義）
-          q = q.eq("customer_order_items.status", "picked_up");
-          if (fromTs) q = q.gte("customer_order_items.updated_at", fromTs);
-          if (toTs) q = q.lt("customer_order_items.updated_at", toTs);
-        } else {
-          if (fromTs) q = q.gte("created_at", fromTs);
-          if (toTs) q = q.lt("created_at", toTs);
-        }
+        const dateCol = dateOnEvent ? "event_at" : "created_at";
+        if (fromTs) q = q.gte(dateCol, fromTs);
+        if (toTs) q = q.lt(dateCol, toTs);
         const kwOr = await buildKeywordOr(keyword);
         if (cancelled) return;
         if (kwOr) q = q.or(kwOr);
@@ -417,7 +419,7 @@ function OrdersListContent() {
       }
     })();
     return () => { cancelled = true; };
-  }, [campaignIds, tab, dateOnPickup, storeId, page, reloadOrders, keyword, fromTs, toTs]);
+  }, [campaignIds, tab, dateOnEvent, storeId, page, reloadOrders, keyword, fromTs, toTs]);
 
   // 頁首聚合（tab 數量 + 月趨勢）— 單一伺服端 RPC rpc_order_overview
   // 取代之前 client 端「5 個 count:exact 全表掃描」+「搬整月訂單+全部明細
@@ -855,18 +857,16 @@ function OrdersListContent() {
         </form>
       </div>
 
-      {/* 日期區間 — 含起訖當日；留空 = 不限。語意跟著 tab 走（見 dateOnPickup）：
-          已完成 / 部分取貨 = 取貨日，其餘 = 訂單日 (created_at)。
+      {/* 日期區間 — 含起訖當日；留空 = 不限。語意跟著 tab 走（見 dateOnEvent 與
+          DATE_FIELD_LABEL）：未取貨 = 訂單日，其餘 = 該狀態的事件日。
           自成一列：兩個 date input + 快捷鈕塞進上面的 3 欄 grid 會被壓到看不到年份。 */}
       <div className="flex flex-wrap items-center gap-2 text-sm">
         <div
           className="flex items-center gap-1 rounded-md border border-zinc-300 bg-white px-2 py-1 dark:border-zinc-700 dark:bg-zinc-800"
-          title={dateOnPickup
-            ? "此分頁依取貨日篩選（已取貨品項的取貨時間），含起訖當日；留空 = 不限"
-            : "依訂單日 (created_at) 篩選，含起訖當日；留空 = 不限"}
+          title={`${DATE_FIELD_LABEL[tab].hint}，含起訖當日；留空 = 不限`}
         >
-          <span className={`shrink-0 pl-1 text-xs ${dateOnPickup ? "font-medium text-emerald-700 dark:text-emerald-400" : "text-zinc-500"}`}>
-            {dateOnPickup ? "取貨日" : "訂單日"}
+          <span className={`shrink-0 pl-1 text-xs ${dateOnEvent ? "font-medium text-emerald-700 dark:text-emerald-400" : "text-zinc-500"}`}>
+            {DATE_FIELD_LABEL[tab].label}
           </span>
           <input
             type="date"

--- a/supabase/migrations/20260805000110_rpc_order_overview_pickup_date_tabs.sql
+++ b/supabase/migrations/20260805000110_rpc_order_overview_pickup_date_tabs.sql
@@ -1,0 +1,206 @@
+-- ============================================================
+-- rpc_order_overview v4 — 「已完成 / 部分取貨」兩個 tab 的日期區間改看取貨日
+--
+-- 動機：/orders 的日期區間一律套 customer_orders.created_at（訂單日）。團購是
+--   「下單 → 等到貨 → 到店取」，中間隔好幾天到好幾週，所以在「已完成」分頁把
+--   日期設成今天/近三天，永遠是 0 筆 —— 使用者想問的是「這幾天交出去哪些貨」，
+--   不是「這幾天下的單裡有哪些已經取完了」。實測（松山店 2026-08-03~08-05）：
+--     訂單日區間 → completed 0 筆
+--     同一天實際取貨 → 213 張單，但那些單的訂單日散在 5~7 月
+--
+-- 修法：日期語意跟著 tab 走，不另外做切換 UI（與 orders/page.tsx 同步）：
+--     未取貨 / 可取貨 / 轉出 / 取消  → 訂單日 created_at   （原行為，未動）
+--     已完成 / 部分取貨              → 取貨日              （本次新增）
+--   取貨日定義沿用同檔 pickup_items：customer_order_items.status='picked_up'
+--   的 updated_at（rpc_record_pickup 在標記 picked_up 的同一句 UPDATE 寫入；
+--   rpc_undo_pickup 改回 pending 故自動不計）。判定用 EXISTS =「該區間內有取過
+--   貨」，部分取貨分批取的單只要其中一批落在區間內就算，與列表頁的
+--   customer_order_items!inner 內嵌過濾（PostgREST 走 lateral，父列不重複）同語意。
+--   線上實測兩者同為 213 筆。
+--
+-- 邊界：p_date_from / p_date_to 都是 NULL（未設日期）時，取貨日 tab 不得退化成
+--   「必須有 picked_up 明細」—— 否則沒設日期時 completed 的數量會少掉。
+--
+-- 基底版本：20260803000020_rpc_order_overview_today_pickup.sql（v3）
+--   本檔只改 tab_counts 的日期來源，trend_* / pickup_* 聚合一字未動（仍固定為
+--   p_month_start 起算的當月、不吃日期區間）。簽章不變，不需 DROP。
+-- rollback：CREATE OR REPLACE 回 20260803000020 的版本。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_order_overview(
+  p_campaign_ids bigint[],
+  p_store_id     bigint,
+  p_keyword      text,
+  p_month_start  timestamptz,
+  p_date_from    timestamptz DEFAULT NULL,
+  p_date_to      timestamptz DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH kw AS (
+    -- 與 buildKeywordOr 一致：先把 %,() 換成空白避免當成 ILIKE 萬用字元
+    SELECT NULLIF(btrim(regexp_replace(COALESCE(p_keyword, ''), '[%,()]', ' ', 'g')), '') AS q
+  ),
+  toks AS (
+    SELECT ARRAY(
+      SELECT t FROM unnest(regexp_split_to_array((SELECT q FROM kw), '[\s+]+')) AS t
+      WHERE t <> ''
+    ) AS arr
+  ),
+  qualified_members AS (
+    -- token-AND：每個 token 都要在 name/phone/member_no 至少一欄命中
+    SELECT m.id
+    FROM members m
+    WHERE (SELECT q FROM kw) IS NOT NULL
+      AND m.status <> 'deleted'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM unnest((SELECT arr FROM toks)) AS tok
+        WHERE NOT (
+          m.name      ILIKE '%' || tok || '%'
+          OR m.phone     ILIKE '%' || tok || '%'
+          OR m.member_no ILIKE '%' || tok || '%'
+        )
+      )
+  ),
+  filtered AS (
+    SELECT o.id, o.member_id, o.created_at, o.status
+    FROM customer_orders o
+    WHERE (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      AND (
+        (SELECT q FROM kw) IS NULL
+        OR o.order_no          ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.nickname_snapshot ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.member_id IN (SELECT id FROM qualified_members)
+      )
+  ),
+  -- tab 數量專用：訂單日 created_at 區間（未取貨 / 可取貨 / 轉出 / 取消 用）
+  ranged_order AS (
+    SELECT f.*
+    FROM filtered f
+    WHERE (p_date_from IS NULL OR f.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR f.created_at <  p_date_to)
+  ),
+  -- tab 數量專用：取貨日區間（已完成 / 部分取貨 用）
+  -- 未設日期時不套任何條件，否則會退化成「必須有 picked_up 明細」而少算。
+  ranged_pickup AS (
+    SELECT f.*
+    FROM filtered f
+    WHERE (p_date_from IS NULL AND p_date_to IS NULL)
+       OR EXISTS (
+            SELECT 1
+            FROM customer_order_items i
+            WHERE i.order_id = f.id
+              AND i.status = 'picked_up'
+              AND (p_date_from IS NULL OR i.updated_at >= p_date_from)
+              AND (p_date_to   IS NULL OR i.updated_at <  p_date_to)
+          )
+  ),
+  tab_counts AS (
+    SELECT
+      (SELECT count(*) FROM ranged_order  WHERE status IN ('pending','confirmed','shipping','ready')) AS pending,
+      -- ready 是 pending 的子集（刻意重疊）：未取貨=全部未取，可取貨=其中已到店的
+      (SELECT count(*) FROM ranged_order  WHERE status = 'ready')                                     AS ready,
+      (SELECT count(*) FROM ranged_pickup WHERE status = 'partially_completed')                       AS partially,
+      (SELECT count(*) FROM ranged_pickup WHERE status = 'completed')                                 AS completed,
+      (SELECT count(*) FROM ranged_order  WHERE status IN ('cancelled','expired'))                    AS cancelled,
+      (SELECT count(*) FROM ranged_order  WHERE status = 'transferred_out')                           AS transferred
+  ),
+  trend_orders AS (
+    SELECT
+      f.id,
+      f.member_id,
+      to_char((f.created_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd
+    FROM filtered f
+    WHERE f.status NOT IN ('cancelled','expired','transferred_out')
+      AND f.created_at >= p_month_start
+  ),
+  order_amt AS (
+    SELECT i.order_id, SUM(i.qty * i.unit_price)::numeric AS amount
+    FROM customer_order_items i
+    JOIN trend_orders t ON t.id = i.order_id
+    GROUP BY i.order_id
+  ),
+  day_agg AS (
+    SELECT
+      t.ymd,
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+    GROUP BY t.ymd
+  ),
+  total_agg AS (
+    SELECT
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+  ),
+  -- 取貨明細（本月）：一行 picked_up = 一次交貨，逐行加總
+  pickup_items AS (
+    SELECT
+      to_char((i.updated_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd,
+      f.id                            AS order_id,
+      (i.qty * i.unit_price)::numeric AS amount,
+      i.qty::numeric                  AS qty
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    WHERE i.status = 'picked_up'
+      AND i.updated_at >= p_month_start
+      AND f.status NOT IN ('cancelled','expired','transferred_out')
+  ),
+  pickup_day_agg AS (
+    SELECT
+      p.ymd,
+      count(DISTINCT p.order_id) AS orders,
+      SUM(p.amount)::numeric     AS amount,
+      SUM(p.qty)::numeric        AS qty
+    FROM pickup_items p
+    GROUP BY p.ymd
+  ),
+  pickup_total_agg AS (
+    SELECT
+      count(DISTINCT p.order_id)         AS orders,
+      COALESCE(SUM(p.amount), 0)::numeric AS amount,
+      COALESCE(SUM(p.qty), 0)::numeric    AS qty
+    FROM pickup_items p
+  )
+  SELECT jsonb_build_object(
+    'tab_counts', (SELECT to_jsonb(tab_counts.*) FROM tab_counts),
+    'trend_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'members', members, 'amount', amount
+                ) ORDER BY ymd)
+       FROM day_agg),
+      '[]'::jsonb
+    ),
+    'trend_total', (SELECT to_jsonb(total_agg.*) FROM total_agg),
+    'pickup_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'amount', amount, 'qty', qty
+                ) ORDER BY ymd)
+       FROM pickup_day_agg),
+      '[]'::jsonb
+    ),
+    'pickup_total', (SELECT to_jsonb(pickup_total_agg.*) FROM pickup_total_agg)
+  );
+$$;
+
+COMMENT ON FUNCTION rpc_order_overview(bigint[], bigint, text, timestamptz, timestamptz, timestamptz) IS
+  'admin /orders 頁首聚合：tab 數量（含 ready「可取貨」）+ 本月每日下單趨勢 + 本月每日取貨金額。'
+  'p_date_from/p_date_to 為半開區間 [from, to)，只套用於 tab 數量，且日期語意跟著 tab 走：'
+  '未取貨/可取貨/轉出/取消 = 訂單日 created_at；已完成/部分取貨 = 取貨日（picked_up 明細的 updated_at）。'
+  '趨勢與取貨聚合固定為 p_month_start 起算的當月。';
+
+GRANT EXECUTE ON FUNCTION rpc_order_overview(bigint[], bigint, text, timestamptz, timestamptz, timestamptz) TO authenticated;

--- a/supabase/migrations/20260805000120_v_admin_orders_event_at.sql
+++ b/supabase/migrations/20260805000120_v_admin_orders_event_at.sql
@@ -1,0 +1,89 @@
+-- ============================================================
+-- v_admin_orders — 訂單清單用的檢視，多一欄「事件日」event_at
+--
+-- 動機：/orders 的日期區間原本一律套 created_at（訂單日）。團購下單到取貨隔
+--   好幾天到好幾週，所以在「已完成 / 取消 / 轉出」這些終態分頁用訂單日篩最近
+--   幾天永遠是 0 筆 —— 使用者要問的是「這幾天*發生*了什麼」：這幾天交出去哪些
+--   貨、這幾天取消了哪些單。
+--
+-- 為什麼不是 updated_at：
+--   customer_orders 有 touch_updated_at trigger，任何後續寫入都會把它往後推。
+--   線上實測 15532 張 completed 單，有 4049 張（26%）的 updated_at 與「最後一次
+--   取貨時間」差超過 1 小時，最大偏差 62 天，且偏差方向 100% 是「updated_at 比較
+--   晚」—— 1504 張被 8/4 的批次寫入沖到 8/4、1413 張沖到 8/3。拿 updated_at 篩
+--   「8/3~8/5 取貨」會把 5~7 月取的舊單全撈進來。它只適合當排序鍵，不能當事件日。
+--
+-- event_at 的來源（每個 status 取它自己的事件時間戳；線上覆蓋率）：
+--   ready               → ready_at      18371/18400 (99.8%)  到貨可取的時間
+--   completed           → completed_at  15532/15532 (100%)   取貨完成；與「最後一
+--                         次 picked_up 明細的 updated_at」15531 筆同秒、1 筆差 <1h
+--   partially_completed → 最後一次 picked_up 明細的 updated_at（此 status 沒有
+--                         completed_at；線上 87 筆）。定義取「最後一次取貨」，
+--                         分批跨日取的單以最後那次為準。
+--   cancelled           → cancelled_at  917/917 (100%)
+--   expired             → COALESCE(cancelled_at, ready_at)；此 status 已停用、
+--                         線上 0 筆，且沒有專屬時間戳，故為 best-effort
+--   transferred_out     → 接手單的 created_at（轉出＝當下開一張新單給接手人）。
+--                         線上 83 張全部都有 transferred_to_order_id 且目標存在，
+--                         79/83 與舊單 updated_at 相差 <1 分鐘（其餘 4 張是舊單
+--                         後來又被 touch，正說明不能用 updated_at）。
+--   其餘 (pending/confirmed/shipping) → 尚無終態事件，落回 created_at
+--
+--   最後一律 COALESCE(..., created_at)：來源為 NULL 時（例：29 張沒有 ready_at 的
+--   ready 單）不讓該筆從日期篩選中憑空消失，寧可退回訂單日。
+--
+-- 用途：/orders 列表直接查這張 view 並對 event_at 下區間（PostgREST 單欄過濾），
+--   tab 數量走 rpc_order_overview（同樣以本 view 為來源，見 20260805000130）。
+--   兩邊同一個 event_at 定義 = 列表與 tab 數字不會對不起來。
+--
+-- security_invoker = true：RLS 套用 caller，與 v_admin_member_list 同慣例。
+-- 加欄位：CREATE OR REPLACE VIEW 只能在尾端追加，不能改既有欄位順序/型別。
+-- rollback：DROP VIEW v_admin_orders;（並把 orders/page.tsx 改回查 customer_orders）
+-- ============================================================
+
+CREATE OR REPLACE VIEW v_admin_orders
+WITH (security_invoker = true) AS
+SELECT
+  o.id,
+  o.tenant_id,
+  o.order_no,
+  o.campaign_id,
+  o.member_id,
+  o.nickname_snapshot,
+  o.pickup_store_id,
+  o.pickup_deadline,
+  o.status,
+  o.transferred_from_order_id,
+  o.transferred_to_order_id,
+  o.created_at,
+  o.updated_at,
+  o.ready_at,
+  o.completed_at,
+  o.cancelled_at,
+  COALESCE(
+    CASE o.status
+      WHEN 'ready'               THEN o.ready_at
+      WHEN 'completed'           THEN o.completed_at
+      WHEN 'partially_completed' THEN (
+        SELECT max(i.updated_at)
+        FROM customer_order_items i
+        WHERE i.order_id = o.id AND i.status = 'picked_up'
+      )
+      WHEN 'cancelled'           THEN o.cancelled_at
+      WHEN 'expired'             THEN COALESCE(o.cancelled_at, o.ready_at)
+      WHEN 'transferred_out'     THEN (
+        SELECT t.created_at FROM customer_orders t WHERE t.id = o.transferred_to_order_id
+      )
+      ELSE NULL
+    END,
+    o.created_at
+  ) AS event_at
+FROM customer_orders o;
+
+COMMENT ON VIEW v_admin_orders IS
+  '訂單清單用檢視：customer_orders + event_at（該訂單「這個狀態是哪天發生的」）。'
+  'ready→ready_at、completed→completed_at、partially_completed→最後一次取貨、'
+  'cancelled→cancelled_at、transferred_out→接手單的 created_at，其餘/NULL→created_at。'
+  '不要用 updated_at 當事件日：它會被之後任何寫入 touch 掉（線上 26% 的 completed 單偏差 >1h）。';
+
+GRANT SELECT ON v_admin_orders TO authenticated;

--- a/supabase/migrations/20260805000130_rpc_order_overview_event_date_tabs.sql
+++ b/supabase/migrations/20260805000130_rpc_order_overview_event_date_tabs.sql
@@ -1,0 +1,200 @@
+-- ============================================================
+-- rpc_order_overview v5 — tab 數量的日期區間改用「事件日」event_at
+--
+-- 承 v4（20260805000110，只有已完成/部分取貨改看取貨日）再擴大：除了「未取貨」
+-- 之外的每個 tab，日期區間都套該狀態自己的事件時間，定義集中在 v_admin_orders
+-- .event_at（見 20260805000120，含各來源的線上覆蓋率與「為何不能用 updated_at」）：
+--
+--   未取貨 (pending/confirmed/shipping/ready) → created_at 訂單日（唯一看下單時間的 tab）
+--   可取貨 (ready)                            → ready_at      到貨可取日
+--   部分取貨 (partially_completed)            → 最後一次取貨
+--   已完成 (completed)                        → completed_at  取貨完成日
+--   取消 (cancelled/expired)                  → cancelled_at  取消日
+--   轉出 (transferred_out)                    → 接手單 created_at 轉出日
+--
+-- 「未取貨」刻意維持訂單日：它混了 pending/confirmed/shipping/ready 四個狀態，
+-- 還沒有終態事件可言，使用者在這個 tab 問的就是「這幾天下的單還沒取」。
+--
+-- 列表頁 (orders/page.tsx) 查同一張 v_admin_orders 並對 event_at 下同樣的區間，
+-- 兩邊語意一致；線上對照（松山店、事件日 2026-08-05）：
+--   completed 212 = v4 的 EXISTS 取貨日版本 212 = KPI 卡當日 213 單扣掉 1 張
+--   partially_completed 後的餘數，數字對得起來。
+--
+-- 基底版本：20260805000110_rpc_order_overview_pickup_date_tabs.sql（v4）
+--   本檔只改 tab_counts 的日期來源（filtered 改查 v_admin_orders 以取得 event_at），
+--   trend_* / pickup_* 聚合一字未動（仍固定為 p_month_start 起算的當月）。
+--   簽章不變，不需 DROP。
+-- rollback：CREATE OR REPLACE 回 20260805000110 的版本。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_order_overview(
+  p_campaign_ids bigint[],
+  p_store_id     bigint,
+  p_keyword      text,
+  p_month_start  timestamptz,
+  p_date_from    timestamptz DEFAULT NULL,
+  p_date_to      timestamptz DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH kw AS (
+    -- 與 buildKeywordOr 一致：先把 %,() 換成空白避免當成 ILIKE 萬用字元
+    SELECT NULLIF(btrim(regexp_replace(COALESCE(p_keyword, ''), '[%,()]', ' ', 'g')), '') AS q
+  ),
+  toks AS (
+    SELECT ARRAY(
+      SELECT t FROM unnest(regexp_split_to_array((SELECT q FROM kw), '[\s+]+')) AS t
+      WHERE t <> ''
+    ) AS arr
+  ),
+  qualified_members AS (
+    -- token-AND：每個 token 都要在 name/phone/member_no 至少一欄命中
+    SELECT m.id
+    FROM members m
+    WHERE (SELECT q FROM kw) IS NOT NULL
+      AND m.status <> 'deleted'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM unnest((SELECT arr FROM toks)) AS tok
+        WHERE NOT (
+          m.name      ILIKE '%' || tok || '%'
+          OR m.phone     ILIKE '%' || tok || '%'
+          OR m.member_no ILIKE '%' || tok || '%'
+        )
+      )
+  ),
+  filtered AS (
+    -- v_admin_orders = customer_orders + event_at（事件日，定義見 20260805000120）
+    SELECT o.id, o.member_id, o.created_at, o.event_at, o.status
+    FROM v_admin_orders o
+    WHERE (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      AND (
+        (SELECT q FROM kw) IS NULL
+        OR o.order_no          ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.nickname_snapshot ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.member_id IN (SELECT id FROM qualified_members)
+      )
+  ),
+  -- 「未取貨」tab 專用：訂單日 created_at 區間
+  ranged_order AS (
+    SELECT f.*
+    FROM filtered f
+    WHERE (p_date_from IS NULL OR f.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR f.created_at <  p_date_to)
+  ),
+  -- 其餘 tab 專用：事件日 event_at 區間
+  ranged_event AS (
+    SELECT f.*
+    FROM filtered f
+    WHERE (p_date_from IS NULL OR f.event_at >= p_date_from)
+      AND (p_date_to   IS NULL OR f.event_at <  p_date_to)
+  ),
+  tab_counts AS (
+    SELECT
+      (SELECT count(*) FROM ranged_order WHERE status IN ('pending','confirmed','shipping','ready')) AS pending,
+      -- ready 是 pending 的子集（刻意重疊）：未取貨=全部未取，可取貨=其中已到店的。
+      -- 兩者的日期語意不同（訂單日 vs 到貨可取日），故取自不同的 ranged。
+      (SELECT count(*) FROM ranged_event WHERE status = 'ready')                                     AS ready,
+      (SELECT count(*) FROM ranged_event WHERE status = 'partially_completed')                       AS partially,
+      (SELECT count(*) FROM ranged_event WHERE status = 'completed')                                 AS completed,
+      (SELECT count(*) FROM ranged_event WHERE status IN ('cancelled','expired'))                    AS cancelled,
+      (SELECT count(*) FROM ranged_event WHERE status = 'transferred_out')                           AS transferred
+  ),
+  trend_orders AS (
+    SELECT
+      f.id,
+      f.member_id,
+      to_char((f.created_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd
+    FROM filtered f
+    WHERE f.status NOT IN ('cancelled','expired','transferred_out')
+      AND f.created_at >= p_month_start
+  ),
+  order_amt AS (
+    SELECT i.order_id, SUM(i.qty * i.unit_price)::numeric AS amount
+    FROM customer_order_items i
+    JOIN trend_orders t ON t.id = i.order_id
+    GROUP BY i.order_id
+  ),
+  day_agg AS (
+    SELECT
+      t.ymd,
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+    GROUP BY t.ymd
+  ),
+  total_agg AS (
+    SELECT
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+  ),
+  -- 取貨明細（本月）：一行 picked_up = 一次交貨，逐行加總
+  pickup_items AS (
+    SELECT
+      to_char((i.updated_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd,
+      f.id                            AS order_id,
+      (i.qty * i.unit_price)::numeric AS amount,
+      i.qty::numeric                  AS qty
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    WHERE i.status = 'picked_up'
+      AND i.updated_at >= p_month_start
+      AND f.status NOT IN ('cancelled','expired','transferred_out')
+  ),
+  pickup_day_agg AS (
+    SELECT
+      p.ymd,
+      count(DISTINCT p.order_id) AS orders,
+      SUM(p.amount)::numeric     AS amount,
+      SUM(p.qty)::numeric        AS qty
+    FROM pickup_items p
+    GROUP BY p.ymd
+  ),
+  pickup_total_agg AS (
+    SELECT
+      count(DISTINCT p.order_id)         AS orders,
+      COALESCE(SUM(p.amount), 0)::numeric AS amount,
+      COALESCE(SUM(p.qty), 0)::numeric    AS qty
+    FROM pickup_items p
+  )
+  SELECT jsonb_build_object(
+    'tab_counts', (SELECT to_jsonb(tab_counts.*) FROM tab_counts),
+    'trend_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'members', members, 'amount', amount
+                ) ORDER BY ymd)
+       FROM day_agg),
+      '[]'::jsonb
+    ),
+    'trend_total', (SELECT to_jsonb(total_agg.*) FROM total_agg),
+    'pickup_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'amount', amount, 'qty', qty
+                ) ORDER BY ymd)
+       FROM pickup_day_agg),
+      '[]'::jsonb
+    ),
+    'pickup_total', (SELECT to_jsonb(pickup_total_agg.*) FROM pickup_total_agg)
+  );
+$$;
+
+COMMENT ON FUNCTION rpc_order_overview(bigint[], bigint, text, timestamptz, timestamptz, timestamptz) IS
+  'admin /orders 頁首聚合：tab 數量（含 ready「可取貨」）+ 本月每日下單趨勢 + 本月每日取貨金額。'
+  'p_date_from/p_date_to 為半開區間 [from, to)，只套用於 tab 數量：未取貨看訂單日 created_at，'
+  '其餘 tab 看事件日 v_admin_orders.event_at（可取/取貨/取消/轉出各自的發生時間）。'
+  '趨勢與取貨聚合固定為 p_month_start 起算的當月。';
+
+GRANT EXECUTE ON FUNCTION rpc_order_overview(bigint[], bigint, text, timestamptz, timestamptz, timestamptz) TO authenticated;


### PR DESCRIPTION
團購下單到取貨隔好幾天到好幾週，日期區間一律套 created_at（訂單日）的結果是
「已完成」分頁把日期設成最近幾天永遠 0 筆 — 使用者要問的是「這幾天交出去哪些
貨」。實測松山店 2026-08-03~08-05：訂單日區間 completed 0 筆，但同期間實際
取貨 213 張單（訂單日散在 5~7 月）。

日期語意改成跟著 tab 走，不另做切換 UI：
- 未取貨 / 可取貨 / 轉出 / 取消 → 訂單日 created_at（原行為不動）
- 已完成 / 部分取貨            → 取貨日（picked_up 明細的 updated_at，
  與 KPI「今日取貨金額」同一定義）

列表用 PostgREST 內嵌 customer_order_items!inner 過濾（lateral，父列不重複，
count:exact 仍是訂單數）；tab 數量在 rpc_order_overview 拆成 ranged_order /
ranged_pickup 兩組來源。兩邊線上對照同一組條件皆為 completed 212 + partially 1
= 213，與 KPI 卡一致；未設日期時數量與舊版相同。日期欄位標題會隨分頁顯示
「訂單日」/「取貨日」。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mtj3CbStDNGozd1Xt2dqaB