### PR TITLE
Show picked-up items in shortage allocation modal

### DIFF
--- a/apps/admin/src/components/ShortageAllocateModal.tsx
+++ b/apps/admin/src/components/ShortageAllocateModal.tsx
@@ -25,7 +25,26 @@ type Candidate = {
   created_at: string;
 };
 
-type Payload = { supplied: number; picked: number; available: number; items: Candidate[] };
+// 已領走的品項行：唯讀對帳用（那 N 件是誰領走的），不參與配貨
+type PickedRow = {
+  item_id: number;
+  order_id: number;
+  order_no: string;
+  customer: string | null;
+  order_status: string;
+  item_status: string;
+  qty: number;
+  picked_at: string | null;
+  created_at: string;
+};
+
+type Payload = {
+  supplied: number;
+  picked: number;
+  available: number;
+  items: Candidate[];
+  picked_items?: PickedRow[];
+};
 
 export function ShortageAllocateModal({
   transferId,
@@ -60,6 +79,7 @@ export function ShortageAllocateModal({
       picked: Number(payload.picked),
       available: Number(payload.available),
       items: (payload.items ?? []).map((r) => ({ ...r, qty: Number(r.qty) })),
+      picked_items: (payload.picked_items ?? []).map((r) => ({ ...r, qty: Number(r.qty) })),
     });
     // 進來時先反映現況：沒被標待補貨的整行都算配到
     setAlloc(
@@ -315,6 +335,54 @@ export function ShortageAllocateModal({
                         沒有未取的訂單 — 這批不需要配貨。
                       </td>
                     </tr>
+                  )}
+                  {(data.picked_items ?? []).length > 0 && (
+                    <>
+                      <tr className="border-t border-zinc-200 bg-zinc-100/80 dark:border-zinc-800 dark:bg-zinc-900">
+                        <td colSpan={6} className="px-3 py-1.5 text-[11px] font-medium text-zinc-500">
+                          已領走 {data.picked} 件（唯讀，僅供對帳 — 這些貨已經被領走，不能重新配）
+                        </td>
+                      </tr>
+                      {(data.picked_items ?? []).map((r) => (
+                        <tr key={`picked-${r.item_id}`} className="text-zinc-400 dark:text-zinc-500">
+                          <td className="px-3 py-2 text-center">—</td>
+                          <td className="px-3 py-2 font-mono text-xs">
+                            <Link
+                              href={orderListHref(r.order_no, r.order_status)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="hover:underline"
+                              title="開新分頁查看這張訂單"
+                            >
+                              {r.order_no} ↗
+                            </Link>
+                          </td>
+                          <td className="max-w-[220px] truncate px-3 py-2" title={r.customer ?? ""}>
+                            {r.customer || "—"}
+                          </td>
+                          <td className="whitespace-nowrap px-3 py-2 text-xs">
+                            {new Date(r.created_at).toLocaleString("zh-TW", {
+                              dateStyle: "short",
+                              timeStyle: "short",
+                            })}
+                          </td>
+                          <td className="px-3 py-2 text-right tabular-nums">{r.qty}</td>
+                          <td
+                            className="whitespace-nowrap px-3 py-2 text-right text-xs"
+                            title={
+                              r.picked_at
+                                ? `領走時間 ${new Date(r.picked_at).toLocaleString("zh-TW", {
+                                    dateStyle: "short",
+                                    timeStyle: "short",
+                                  })}`
+                                : undefined
+                            }
+                          >
+                            {r.item_status === "partially_picked_up" ? "部分領走" : "已領走"}
+                          </td>
+                        </tr>
+                      ))}
+                    </>
                   )}
                 </tbody>
               </table>

--- a/supabase/migrations/20260805000160_allocation_candidates_picked_items.sql
+++ b/supabase/migrations/20260805000160_allocation_candidates_picked_items.sql
@@ -1,0 +1,114 @@
+-- ============================================================
+-- 少發配貨視窗補列「已領走」的訂單
+--
+-- 動機：店家開「少發配貨」看到 到貨 10（已領走 8）卻只列 2 張訂單，
+--   會以為漏單。其實已領走的訂單本來就不列（貨拿不回來、沒東西可配），
+--   但只給一個總數對不了帳 —— 店家想知道那 8 件是「誰」領走的，
+--   才能跟還沒拿到貨的客人解釋。
+--
+-- 做法：rpc_get_allocation_candidates 多回一個 picked_items 陣列
+--   （item_status IN ('picked_up','partially_picked_up') 的品項行），
+--   前端灰色唯讀顯示。原本的 supplied / picked / available / items
+--   完全不動，配貨邏輯零改變。
+--   領走時間取 pickup_movement（stock_movements.created_at），
+--   沒有 movement 的舊資料退用品項 updated_at。
+--
+-- 基底版本：20260805000060_shortage_allocation 的 rpc_get_allocation_candidates
+--   （唯一版本，20260805000070 / 20260805000100 皆未動這支）
+-- rollback: 重跑 20260805000060 的 rpc_get_allocation_candidates。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_get_allocation_candidates(
+  p_transfer_id BIGINT,
+  p_sku_id      BIGINT
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  WITH ctx AS (
+    SELECT pwi.tenant_id, pwi.campaign_id, pwi.store_id, pwi.sku_id
+      FROM picking_wave_items pwi
+     WHERE pwi.generated_transfer_id = p_transfer_id
+       AND pwi.sku_id = p_sku_id
+       AND pwi.campaign_id IS NOT NULL
+     LIMIT 1
+  ),
+  supplied AS (
+    -- 同一個 (團,店,品項) 可能分好幾批到，全部已收的實收量都算進可配額度
+    SELECT COALESCE(SUM(ti.qty_received), 0) AS qty
+      FROM ctx
+      JOIN picking_wave_items pwi
+        ON pwi.tenant_id = ctx.tenant_id AND pwi.campaign_id = ctx.campaign_id
+       AND pwi.store_id  = ctx.store_id  AND pwi.sku_id      = ctx.sku_id
+      JOIN transfers t      ON t.id = pwi.generated_transfer_id
+                           AND t.status IN ('received', 'closed')
+      JOIN transfer_items ti ON ti.transfer_id = t.id AND ti.sku_id = ctx.sku_id
+  ),
+  rows_all AS (
+    SELECT coi.id            AS item_id,
+           co.id             AS order_id,
+           co.order_no,
+           COALESCE(m.name, co.nickname_snapshot) AS customer,
+           co.status         AS order_status,
+           coi.status        AS item_status,
+           coi.qty,
+           coi.backorder_at,
+           co.created_at,
+           COALESCE(sm.created_at, coi.updated_at) AS picked_at
+      FROM ctx
+      JOIN customer_orders co
+        ON co.tenant_id        = ctx.tenant_id
+       AND co.campaign_id      = ctx.campaign_id
+       AND co.pickup_store_id  = ctx.store_id
+       AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+       AND co.transferred_from_order_id IS NULL
+       AND (co.order_kind = 'normal' OR co.order_kind IS NULL)
+      JOIN customer_order_items coi
+        ON coi.order_id = co.id
+       AND coi.sku_id   = ctx.sku_id
+       AND coi.status NOT IN ('cancelled', 'expired')
+      LEFT JOIN members m ON m.id = co.member_id
+      LEFT JOIN stock_movements sm ON sm.id = coi.pickup_movement_id
+  ),
+  picked AS (
+    SELECT COALESCE(SUM(r.qty), 0) AS qty FROM rows_all r
+     WHERE r.item_status IN ('picked_up', 'partially_picked_up')
+  )
+  SELECT jsonb_build_object(
+    'supplied',  (SELECT qty FROM supplied),
+    'picked',    (SELECT qty FROM picked),
+    'available', GREATEST((SELECT qty FROM supplied) - (SELECT qty FROM picked), 0),
+    'items', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+               'item_id',      r.item_id,
+               'order_id',     r.order_id,
+               'order_no',     r.order_no,
+               'customer',     r.customer,
+               'order_status', r.order_status,
+               'qty',          r.qty,
+               'backorder',    r.backorder_at IS NOT NULL,
+               'created_at',   r.created_at
+             ) ORDER BY r.created_at, r.order_no)
+        FROM rows_all r
+       WHERE r.item_status IN ('pending', 'reserved', 'ready')
+    ), '[]'::jsonb),
+    -- 已領走的行：對帳用，前端唯讀顯示，不參與配貨
+    'picked_items', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+               'item_id',      r.item_id,
+               'order_id',     r.order_id,
+               'order_no',     r.order_no,
+               'customer',     r.customer,
+               'order_status', r.order_status,
+               'item_status',  r.item_status,
+               'qty',          r.qty,
+               'picked_at',    r.picked_at,
+               'created_at',   r.created_at
+             ) ORDER BY r.picked_at, r.order_no)
+        FROM rows_all r
+       WHERE r.item_status IN ('picked_up', 'partially_picked_up')
+    ), '[]'::jsonb)
+  );
+$$;
+
+COMMENT ON FUNCTION public.rpc_get_allocation_candidates(BIGINT, BIGINT) IS
+  '少發配貨候選：supplied/picked/available + items（未取，可配）+ picked_items（已領走，唯讀對帳用）。'
+  '20260805000160 加 picked_items；配貨邏輯與 20260805000060 相同。';


### PR DESCRIPTION
## Summary

Adds a read-only "picked items" section to the shortage allocation modal to help store staff reconcile inventory when some items have already been picked up by customers.

## Motivation

When a store opens the shortage allocation view and sees "Arrived: 10 (Picked up: 8)" but only 2 orders listed, they assume orders are missing. In reality, picked-up items aren't shown because the goods can't be reclaimed. However, showing only the total count makes reconciliation impossible — staff need to know *who* picked up those 8 items to explain to customers still waiting for their orders.

## Changes

### Database Migration (`20260805000160_allocation_candidates_picked_items.sql`)
- Extended `rpc_get_allocation_candidates()` to return a new `picked_items` array alongside existing `supplied`, `picked`, `available`, and `items` fields
- `picked_items` contains order line items with status `'picked_up'` or `'partially_picked_up'`
- Pickup timestamp sourced from `stock_movements.created_at` (via `pickup_movement_id`), falling back to `customer_order_items.updated_at` for legacy data
- Allocation logic unchanged — picked items are for reconciliation only, not involved in reallocation

### Frontend (`ShortageAllocateModal.tsx`)
- Added `PickedRow` type to represent picked-up items with fields: `item_id`, `order_id`, `order_no`, `customer`, `order_status`, `item_status`, `qty`, `picked_at`, `created_at`
- Updated `Payload` type to include optional `picked_items` array
- Parse `picked_items` from RPC response and convert quantities to numbers
- Render picked items in a separate gray, read-only section below available items
- Display section header showing total picked quantity with explanation that these items cannot be reallocated
- Each picked item row shows order number (linked), customer name, order creation time, quantity, and pickup status (full or partial)
- Picked items sorted by pickup time, then order number

## Implementation Notes

- Picked items section only renders if `picked_items` array is non-empty
- All picked item rows are visually grayed out (`text-zinc-400`) to indicate read-only status
- Pickup timestamp shown in tooltip on the status column
- Order links open in new tab for easy reference
- No changes to allocation logic or existing `items` array behavior

https://claude.ai/code/session_0197k5vzKdueVzJ88kRDh5s3