### PR TITLE
feat(inbound): 收貨頁標示「補回先墊」— 這批到貨其實是補回店家墊出去的現貨

### DIFF
--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -29,6 +29,8 @@ type ItemLine = { key: string; skuId: number | null; product: string; name: stri
 // extraQty / shortQty：這張單的派出量 vs 訂單需求量差額（見下方查詢註解）
 //   extraQty = 多給、沒有訂單對應；shortQty = 不夠分，會有客人領不到
 //   coveredQty = 缺口中已用「店內現貨減抵單」吸收的件數（shortQty 已淨掉這部分）
+//   prefilledQty = 這批到貨其實是「補回店家先墊的現貨」的件數（店家已用店內現貨
+//     把客人的貨交掉，總倉的貨照樣會來 — 見 20260805000220 migration）
 type ItemSummary = {
   lines: number;
   totalQty: number;
@@ -38,6 +40,7 @@ type ItemSummary = {
   extraQty: number;
   shortQty: number;
   coveredQty: number;
+  prefilledQty: number;
 };
 
 // 列表上的一個可收合群組（product 模式＝同品相，wave 模式＝同撿貨單號）
@@ -54,6 +57,7 @@ type Group = {
   extraQty: number;        // 這組總共被總倉多給幾件
   shortQty: number;        // 這組總共少了幾件（訂單比派出多，已淨掉現貨減抵）
   coveredQty: number;      // 這組用店內現貨減抵掉幾件
+  prefilledQty: number;    // 這組有幾件是補回店家先墊的現貨
 };
 
 export default function TransfersInboxPage() {
@@ -298,7 +302,7 @@ export default function TransfersInboxPage() {
               if (code) skuCodeMap.set(s.id, code);
             }
           }
-          const emptySummary = (): ItemSummary => ({ lines: 0, totalQty: 0, names: [], codes: [], items: [], extraQty: 0, shortQty: 0, coveredQty: 0 });
+          const emptySummary = (): ItemSummary => ({ lines: 0, totalQty: 0, names: [], codes: [], items: [], extraQty: 0, shortQty: 0, coveredQty: 0, prefilledQty: 0 });
           for (const tid of transferIds) summary.set(tid, emptySummary());
           for (const it of items) {
             const cur = summary.get(it.transfer_id) ?? emptySummary();
@@ -331,13 +335,14 @@ export default function TransfersInboxPage() {
             p_transfer_ids: transferIds,
           });
           const diffs =
-            (diffData as Record<string, { over?: number; short?: number; covered?: number }> | null) ?? {};
+            (diffData as Record<string, { over?: number; short?: number; covered?: number; prefilled?: number }> | null) ?? {};
           for (const [tid, d] of Object.entries(diffs)) {
             const cur = summary.get(Number(tid));
             if (!cur) continue;
             cur.extraQty = Number(d?.over) || 0;
             cur.shortQty = Number(d?.short) || 0;
             cur.coveredQty = Number(d?.covered) || 0;
+            cur.prefilledQty = Number(d?.prefilled) || 0;
           }
         }
 
@@ -479,6 +484,7 @@ export default function TransfersInboxPage() {
             extraQty: 0,
             shortQty: 0,
             coveredQty: 0,
+            prefilledQty: 0,
           };
           map.set(key, entry);
         }
@@ -487,6 +493,7 @@ export default function TransfersInboxPage() {
         entry.extraQty += itemSummary.get(t.id)?.extraQty ?? 0;
         entry.shortQty += itemSummary.get(t.id)?.shortQty ?? 0;
         entry.coveredQty += itemSummary.get(t.id)?.coveredQty ?? 0;
+        entry.prefilledQty += itemSummary.get(t.id)?.prefilledQty ?? 0;
       }
       return Array.from(map.values()).sort((a, b) => {
         // 「其他調撥」永遠墊底，其餘依撿貨單號遞減
@@ -528,6 +535,7 @@ export default function TransfersInboxPage() {
           extraQty: 0,
           shortQty: 0,
           coveredQty: 0,
+          prefilledQty: 0,
         };
         map.set(key, entry);
       }
@@ -536,6 +544,7 @@ export default function TransfersInboxPage() {
       entry.extraQty += s?.extraQty ?? 0;
       entry.shortQty += s?.shortQty ?? 0;
       entry.coveredQty += s?.coveredQty ?? 0;
+      entry.prefilledQty += s?.prefilledQty ?? 0;
     }
     const asc = tab === "unreceived";
     return Array.from(map.values()).sort((a, b) =>
@@ -1119,6 +1128,9 @@ export default function TransfersInboxPage() {
                   {dueTag && <Pill tone={dueTag === "逾期" ? "rose" : "amber"}>{dueTag}</Pill>}
                   {g.shortQty > 0 && <Pill tone="rose">⚠ 少 {g.shortQty} 件 · 訂單比到貨多</Pill>}
                   {g.coveredQty > 0 && <Pill tone="violet">🏬 現貨減抵 {g.coveredQty} 件</Pill>}
+                  {g.prefilledQty > 0 && (
+                    <Pill tone="violet">🔄 補回先墊 {g.prefilledQty} 件</Pill>
+                  )}
                   {g.extraQty > 0 && <Pill tone="blue">🎁 總倉多給 {g.extraQty} 件</Pill>}
                 </div>
 
@@ -1317,6 +1329,14 @@ export default function TransfersInboxPage() {
                                   title="訂單比這批到貨量多，這幾件會有客人領不到 — 點數量看是哪幾筆訂單"
                                 >
                                   ⚠ 少 {summary.shortQty}
+                                </div>
+                              )}
+                              {summary && summary.prefilledQty > 0 && (
+                                <div
+                                  className="text-[10px] font-medium text-violet-600 dark:text-violet-400"
+                                  title="這幾件的客人早就用店內現貨交過了（減抵單 / 現貨直售），這批到貨是把店家先墊的貨補回架上 — 收貨後放回庫存即可，不會有人來領"
+                                >
+                                  🔄 補回先墊 {summary.prefilledQty}
                                 </div>
                               )}
                               {summary && summary.coveredQty > 0 && (

--- a/supabase/migrations/20260805000220_ship_vs_demand_prefilled.sql
+++ b/supabase/migrations/20260805000220_ship_vs_demand_prefilled.sql
@@ -1,0 +1,123 @@
+-- ============================================================
+-- 收貨頁標示「這批有幾件是補回店家先墊的現貨」
+--
+-- 動機：店家用店內現貨先把客人的貨交掉（庫存減抵單 / 加單頁現貨直售）之後，
+--   總倉那批貨還是會來 —— 因為派貨分貨的需求量把「已取貨」的品項也算進去
+--   （只排除 cancelled/expired，見 v_picking_demand / arrive_auto_allocations）。
+--   那批到貨實質上是「把店家先墊的貨補回架上」，但收貨頁看起來就是一張普通的單：
+--   缺口已經是 0（demand = shipped），covered 被 GREATEST(demand−shipped,0) 夾成 0，
+--   標籤不會亮。店家會困惑「這件我明明已經賣掉了，怎麼又來？」
+--
+-- 做法：多回一個 prefilled —— 該組減抵單裡「沒有在補缺口、而是由本批到貨補回」的量。
+--   prefilled = LEAST(減抵總量 − 本線已算進 covered 的量, 本線派出量)
+--   covered / short / over 的算法完全不動 → 既有標籤行為零改變。
+--
+-- 例：訂單 1、店家現貨先交 1（減抵單 1）、總倉照樣派 1
+--     demand=1, shipped=1 → short=0, over=0, covered=0, prefilled=1
+-- 例（20260805000060 的少發情境）：訂單 8、到貨 6、減抵 2
+--     covered=2（在補缺口）, prefilled=LEAST(2−2, 6)=0 → 不會重複標
+--
+-- 基底版本：20260805000180_offset_orders_count_as_coverage 的
+--   rpc_get_ship_vs_demand_for_transfers（唯一版本；20260805000190 只動 candidates）
+-- rollback: 重跑 20260805000180 的 rpc_get_ship_vs_demand_for_transfers。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_get_ship_vs_demand_for_transfers(
+  p_transfer_ids BIGINT[]
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  WITH pw AS (
+    SELECT pwi.generated_transfer_id      AS tid,
+           pwi.tenant_id,
+           pwi.campaign_id,
+           pwi.store_id,
+           pwi.sku_id,
+           COALESCE(pwi.picked_qty, pwi.qty) AS shipped
+      FROM picking_wave_items pwi
+     WHERE pwi.generated_transfer_id = ANY(p_transfer_ids)
+       AND pwi.campaign_id IS NOT NULL
+  ),
+  dem AS (
+    SELECT pw.tid, pw.shipped, d.demand, cov.covered
+      FROM pw
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(SUM(coi.qty), 0) AS demand
+          FROM customer_orders co
+          JOIN customer_order_items coi
+            ON coi.order_id = co.id
+           AND coi.sku_id   = pw.sku_id
+           AND coi.status NOT IN ('cancelled', 'expired')
+         WHERE co.tenant_id       = pw.tenant_id
+           AND co.campaign_id     = pw.campaign_id
+           AND co.pickup_store_id = pw.store_id
+           AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+           AND co.transferred_from_order_id IS NULL
+           AND (co.order_kind = 'normal' OR co.order_kind IS NULL)
+      ) d
+      CROSS JOIN LATERAL (
+        -- coverage = 庫存減抵單（已用店內現貨交貨）+ 抵減單（開團時宣告用店內現貨）
+        SELECT COALESCE((
+                 SELECT SUM(n.qty) FROM inventory_deduction_notes n
+                  WHERE n.tenant_id   = pw.tenant_id
+                    AND n.campaign_id = pw.campaign_id
+                    AND n.store_id    = pw.store_id
+                    AND n.sku_id      = pw.sku_id
+                    AND n.cancelled_at IS NULL
+               ), 0)
+             + COALESCE((
+                 SELECT SUM(-oi.qty)
+                   FROM customer_orders oo
+                   JOIN customer_order_items oi
+                     ON oi.order_id = oo.id
+                    AND oi.sku_id   = pw.sku_id
+                    AND oi.qty < 0
+                    AND oi.status NOT IN ('cancelled', 'expired')
+                  WHERE oo.tenant_id       = pw.tenant_id
+                    AND oo.campaign_id     = pw.campaign_id
+                    AND oo.pickup_store_id = pw.store_id
+                    AND oo.order_kind      = 'offset'
+                    AND oo.status NOT IN ('cancelled', 'expired', 'transferred_out')
+               ), 0) AS covered
+      ) cov
+  ),
+  per_line AS (
+    SELECT dem.tid,
+           GREATEST(dem.shipped - dem.demand, 0)               AS over_qty,
+           GREATEST(dem.demand - dem.shipped - dem.covered, 0) AS short_qty,
+           LEAST(dem.covered, GREATEST(dem.demand - dem.shipped, 0)) AS covered_qty,
+           -- 沒在補缺口的減抵量 = 這批到貨其實是補回店家先墊的貨
+           LEAST(
+             GREATEST(dem.covered - LEAST(dem.covered, GREATEST(dem.demand - dem.shipped, 0)), 0),
+             dem.shipped
+           ) AS prefilled_qty
+      FROM dem
+  ),
+  per_transfer AS (
+    SELECT per_line.tid,
+           SUM(per_line.over_qty)      AS over_qty,
+           SUM(per_line.short_qty)     AS short_qty,
+           SUM(per_line.covered_qty)   AS covered_qty,
+           SUM(per_line.prefilled_qty) AS prefilled_qty
+      FROM per_line
+     GROUP BY per_line.tid
+    HAVING SUM(per_line.over_qty) > 0
+        OR SUM(per_line.short_qty) > 0
+        OR SUM(per_line.covered_qty) > 0
+        OR SUM(per_line.prefilled_qty) > 0
+  )
+  SELECT COALESCE(
+           jsonb_object_agg(
+             per_transfer.tid::text,
+             jsonb_build_object('over', per_transfer.over_qty,
+                                'short', per_transfer.short_qty,
+                                'covered', per_transfer.covered_qty,
+                                'prefilled', per_transfer.prefilled_qty)
+           ),
+           '{}'::jsonb)
+    FROM per_transfer;
+$$;
+
+COMMENT ON FUNCTION public.rpc_get_ship_vs_demand_for_transfers(BIGINT[]) IS
+  '每張派貨單的派出量 vs 訂單需求量：over（多給）/ short（不夠分，已淨掉 coverage）/ '
+  'covered（缺口由店內現貨吸收）/ prefilled（本批是補回店家先墊的現貨）。'
+  'coverage = 庫存減抵單 + 抵減單（負數訂單）。';


### PR DESCRIPTION
## 背景

店家用店內現貨先把客人的貨交掉（庫存減抵單 / 加單頁現貨直售）之後，**總倉那批貨還是會來** —— 因為派貨分貨的需求量把「已取貨」的品項也算進去（`v_picking_demand`、`arrive_auto_allocations` 只排除 `cancelled` / `expired`）。

那批到貨實質上是「把店家先墊的貨補回架上」，但收貨頁看起來就是一張普通的單：缺口已經是 0（demand = shipped），`covered` 被 `GREATEST(demand − shipped, 0)` 夾成 0，什麼標籤都不會亮。店家會困惑「這件我明明已經賣掉了，怎麼又來？」

## 改了什麼

- `rpc_get_ship_vs_demand_for_transfers` 多回一個 **`prefilled`**：該組減抵量裡「沒有在補缺口、而是由本批到貨補回」的件數。
  ```
  prefilled = LEAST(減抵總量 − 本線已算進 covered 的量, 本線派出量)
  ```
  `covered` / `short` / `over` 的算法完全不動 → 既有標籤行為零改變。
- 收貨頁的群組膠囊與明細列加上「🔄 補回先墊 N 件」，tooltip 說明：這幾件的客人早就交過了，收貨後放回庫存即可，不會有人來領。

只有 `prefilled` 的情況不會出現「⚖️ 配貨」入口（沒有東西要配），符合預期。

## 驗證

**線上真實資料**（交易內執行後 ROLLBACK）：

| 情境 | over | short | covered | prefilled |
|---|---|---|---|---|
| 現貨直售 1 件後，總倉照樣派 1 件 | 0 | 0 | 0 | **1** ✅ |
| 既有少發情境（松山洗碗精，訂 8 到 6 減抵 2） | 0 | 0 | **2** | 0 ✅ |

第二列確認既有的「現貨減抵」標籤不會被新欄位誤標。

UI 以 Playwright + fixture 驗證膠囊、明細列與「不出現配貨鈕」，4/4 通過。`tsc --noEmit` 乾淨。migration 已套用線上。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoQigeNcKsHhGgMYV1KpxL)_