### PR TITLE
feat(orders): 開團之下再加「品項」二層篩選

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -155,12 +155,18 @@ type OrderFilters = {
   campaignIds: string[];
   tab: Tab;
   storeId: string;
+  skuIds: string[];
   fromTs: string | null;
   toTs: string | null;
   keywordOr: string | null;
   // 日期區間看事件日（event_at）還是訂單日（created_at）— 語意跟著 tab 走，見 dateOnEvent
   dateOnEvent: boolean;
 };
+
+// 品項（SKU）篩選用的內嵌 join：applyOrderFilters 的 items.sku_id 過濾要靠 select
+// 帶這段內嵌才會生效（!inner 把父列收斂到「至少一列品項命中」的訂單）。
+// 沒篩品項時不要帶，免得多一個無謂的 join。
+const ITEM_EMBED = ", items:customer_order_items!inner(sku_id)";
 
 // 套用目前的篩選條件（開團 / tab 狀態 / 取貨店 / 日期區間 / 關鍵字）。
 // 列表分頁查詢與「選取全部符合篩選」共用同一支，確保「勾到的」＝「看到的」。
@@ -187,6 +193,9 @@ function applyOrderFilters<
   else if (f.tab === "transferred") eq("status", "transferred_out");
   else inList("status", PENDING_STATUSES);
   if (f.storeId) eq("pickup_store_id", Number(f.storeId));
+  // 品項篩選 — select 需帶 ITEM_EMBED 內嵌（見上），tab 數量端則由
+  // rpc_order_overview 的 p_sku_ids 套同一條件，兩邊數字才對得起來
+  if (f.skuIds.length > 0) inList("items.sku_id", f.skuIds.map((x) => Number(x)));
   const dateCol = f.dateOnEvent ? "event_at" : "created_at";
   if (f.fromTs) out = out.gte(dateCol, f.fromTs as never);
   if (f.toTs) out = out.lt(dateCol, f.toTs as never);
@@ -236,6 +245,7 @@ function OrdersListContent() {
     return TAB_VALUES.includes(t as Tab) ? (t as Tab) : "pending";
   })();
   const initialStoreId = searchParams.get("storeId") ?? "";
+  const initialSkuId = searchParams.get("skuId") ?? "";
   const initialKeyword = searchParams.get("q") ?? "";
   const initialDate = (key: string) => {
     const v = searchParams.get(key) ?? "";
@@ -250,6 +260,12 @@ function OrdersListContent() {
   const [campaignIds, setCampaignIds] = useState<string[]>(initialCampaignIds);
   const [tab, setTab] = useState<Tab>(initialTab);
   const [storeId, setStoreId] = useState(initialStoreId);
+  // 品項（SKU）二層篩選 — 只在選了開團後出現；"" = 全部品項
+  const [skuId, setSkuId] = useState(initialSkuId);
+  // 所選開團的品項清單（campaign_items）；label 於 render 時再組（要等 campaignMap）
+  const [skuOptionRows, setSkuOptionRows] = useState<
+    { skuId: number; campaignId: number; productName: string | null; variantName: string | null }[]
+  >([]);
   // 訂單日 (created_at) 區間；"" = 不限
   const [dateFrom, setDateFrom] = useState(initialDate("from"));
   const [dateTo, setDateTo] = useState(initialDate("to"));
@@ -305,14 +321,57 @@ function OrdersListContent() {
   // 20260805000120_v_admin_orders_event_at.sql；tab 數量同步改法見 20260805000130。
   // ⚠ 不要改用 updated_at：它會被之後任何寫入 touch 掉（線上 26% 的已完成單偏差 >1h）。
   const dateOnEvent = tab !== "pending";
-  const hasFilter = campaignIds.length > 0 || !!storeId || !!keyword || !!dateFrom || !!dateTo;
+  // 品項篩選只在有選開團時生效（下拉也只在那時渲染）。開團清空不硬清 skuId，
+  // 改由這裡歸零 — 篩選不能在 UI 看不到的情況下默默生效。
+  const activeSkuId = campaignIds.length > 0 ? skuId : "";
+  const hasFilter = campaignIds.length > 0 || !!storeId || !!activeSkuId || !!keyword || !!dateFrom || !!dateTo;
 
   useEffect(() => {
     setPage(1);
     // 篩選一變，勾選就作廢 — 不然會印到已經看不見的單
     setSelected(new Set());
     setBulkPrintErr(null);
-  }, [campaignIds, tab, storeId, keyword, fromTs, toTs]);
+  }, [campaignIds, tab, storeId, activeSkuId, keyword, fromTs, toTs]);
+
+  // 品項下拉的選項 = 所選開團的 campaign_items。沒選開團就不提供品項篩選
+  // （全庫 SKU 太多、也沒有情境）。products.name 是 source of truth
+  // （skus.product_name 是 denorm 可能過期，見 CampaignItemsTable 同註解）。
+  useEffect(() => {
+    // 沒選開團：下拉未渲染，舊選項留著無妨 — 下次選團會整批重抓
+    if (campaignIds.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      const { data } = await getSupabase()
+        .from("campaign_items")
+        .select("campaign_id, sku_id, sort_order, skus!inner(id, variant_name, products!inner(name))")
+        .in("campaign_id", campaignIds.map((x) => Number(x)))
+        .order("campaign_id")
+        .order("sort_order");
+      if (cancelled) return;
+      type ItemRow = {
+        campaign_id: number;
+        sku_id: number;
+        skus:
+          | { id: number; variant_name: string | null; products: { name: string } | { name: string }[] | null }
+          | { id: number; variant_name: string | null; products: { name: string } | { name: string }[] | null }[]
+          | null;
+      };
+      const rows = ((data ?? []) as unknown as ItemRow[]).map((r) => {
+        const sku = Array.isArray(r.skus) ? r.skus[0] : r.skus;
+        const prod = sku && (Array.isArray(sku.products) ? sku.products[0] : sku.products);
+        return {
+          skuId: r.sku_id,
+          campaignId: r.campaign_id,
+          productName: prod?.name ?? null,
+          variantName: sku?.variant_name ?? null,
+        };
+      });
+      setSkuOptionRows(rows);
+      // 換了開團組合後，原本選的品項若不在新清單裡就歸回「全部品項」
+      setSkuId((cur) => (cur && !rows.some((r) => String(r.skuId) === cur) ? "" : cur));
+    })();
+    return () => { cancelled = true; };
+  }, [campaignIds]);
 
   // 取貨店篩選不鎖分店：所有帳號都可自由選任一店 / 全部
   // （僅保留軟性預設選中自家店，使用者可自行切換到別店或「全部」）
@@ -404,13 +463,17 @@ function OrdersListContent() {
         // 過的舊單浮到最前面）。
         const base = getSupabase()
           .from("v_admin_orders")
-          .select("id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, transferred_from_order_id, created_at, updated_at", { count: "exact" })
+          .select(
+            "id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, transferred_from_order_id, created_at, updated_at"
+              + (activeSkuId ? ITEM_EMBED : ""),
+            { count: "exact" },
+          )
           .order(dateOnEvent ? "event_at" : "updated_at", { ascending: false })
           .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1);
 
         const kwOr = await buildKeywordOr(keyword);
         if (cancelled) return;
-        const q = applyOrderFilters(base, { campaignIds, tab, storeId, fromTs, toTs, keywordOr: kwOr, dateOnEvent });
+        const q = applyOrderFilters(base, { campaignIds, tab, storeId, skuIds: activeSkuId ? [activeSkuId] : [], fromTs, toTs, keywordOr: kwOr, dateOnEvent });
 
         const { data, count, error } = await q;
         if (cancelled) return;
@@ -464,7 +527,7 @@ function OrdersListContent() {
       }
     })();
     return () => { cancelled = true; };
-  }, [campaignIds, tab, dateOnEvent, storeId, page, reloadOrders, keyword, fromTs, toTs]);
+  }, [campaignIds, tab, dateOnEvent, storeId, activeSkuId, page, reloadOrders, keyword, fromTs, toTs]);
 
   // 頁首聚合（tab 數量 + 月趨勢）— 單一伺服端 RPC rpc_order_overview
   // 取代之前 client 端「5 個 count:exact 全表掃描」+「搬整月訂單+全部明細
@@ -487,6 +550,9 @@ function OrdersListContent() {
         p_month_start: startDate.toISOString(),
         p_date_from: fromTs,
         p_date_to: toTs,
+        // p_sku_ids 是 v6（20260806000020）才有的參數：沒篩品項就不帶這個 key，
+        // 萬一線上還是舊版函式，其餘功能不受影響
+        ...(activeSkuId ? { p_sku_ids: [Number(activeSkuId)] } : {}),
       });
       if (cancelled) return;
 
@@ -521,10 +587,28 @@ function OrdersListContent() {
     return () => {
       cancelled = true;
     };
-  }, [campaignIds, storeId, reloadOrders, keyword, fromTs, toTs]);
+  }, [campaignIds, storeId, activeSkuId, reloadOrders, keyword, fromTs, toTs]);
 
   const campaignMap = useMemo(() => new Map(campaigns.map((c) => [c.id, c])), [campaigns]);
   const storeMap = useMemo(() => new Map(stores.map((s) => [s.id, s])), [stores]);
+  // 品項下拉顯示用：跨團 dedupe by sku_id；label 沿用 itemLabel 慣例
+  // （一團一品時商品名＝開團名 → 只顯示規格，否則顯示「商品 / 規格」）
+  const skuFilterOptions = useMemo(() => {
+    const seen = new Set<number>();
+    const out: { id: number; label: string }[] = [];
+    for (const r of skuOptionRows) {
+      if (seen.has(r.skuId)) continue;
+      seen.add(r.skuId);
+      out.push({
+        id: r.skuId,
+        label: itemLabel(
+          { product_name: r.productName, variant_name: r.variantName },
+          campaignMap.get(r.campaignId)?.name ?? "",
+        ),
+      });
+    }
+    return out;
+  }, [skuOptionRows, campaignMap]);
 
   // 批次取貨 — 抓所有勾選訂單的 pickable items, 連續呼 rpc_record_pickup,
   async function cancelOrder(orderId: number, orderNo: string, status: string) {
@@ -704,14 +788,14 @@ function OrdersListContent() {
     const kwOr = await buildKeywordOr(keyword);
     const base = getSupabase()
       .from("v_admin_orders")
-      .select("id")
+      .select("id" + (activeSkuId ? ITEM_EMBED : ""))
       .order(dateOnEvent ? "event_at" : "updated_at", { ascending: false })
       .limit(SELECT_ALL_MAX);
     const { data, error } = await applyOrderFilters(base, {
-      campaignIds, tab, storeId, fromTs, toTs, keywordOr: kwOr, dateOnEvent,
+      campaignIds, tab, storeId, skuIds: activeSkuId ? [activeSkuId] : [], fromTs, toTs, keywordOr: kwOr, dateOnEvent,
     });
     if (error) { setBulkPrintErr(error.message); return; }
-    const ids = ((data ?? []) as { id: number }[]).map((r) => r.id);
+    const ids = ((data ?? []) as unknown as { id: number }[]).map((r) => r.id);
     setSelected(new Set(ids));
     if (total > ids.length) {
       setBulkPrintErr(`符合條件共 ${total} 筆，一次最多選 ${SELECT_ALL_MAX} 筆（已選最新的 ${ids.length} 筆）`);
@@ -952,6 +1036,20 @@ function OrdersListContent() {
             </div>
           )}
         </div>
+        {/* 品項二層篩選 — 選了開團才出現（選項 = 所選開團的品項），只看含此品項的訂單 */}
+        {campaignIds.length > 0 && (
+          <select
+            value={skuId}
+            onChange={(e) => setSkuId(e.target.value)}
+            title="再依品項（規格）篩選：只看含此品項的訂單"
+            className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="">全部品項</option>
+            {skuFilterOptions.map((o) => (
+              <option key={o.id} value={o.id}>{o.label}</option>
+            ))}
+          </select>
+        )}
         <select value={storeId} onChange={(e) => setStoreId(e.target.value)}
           className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
           <option value="">全部取貨店</option>

--- a/supabase/migrations/20260806000020_rpc_order_overview_sku_filter.sql
+++ b/supabase/migrations/20260806000020_rpc_order_overview_sku_filter.sql
@@ -1,0 +1,205 @@
+-- ============================================================
+-- rpc_order_overview v6 — 新增品項（SKU）篩選 p_sku_ids
+--
+-- 動機：/orders 選了開團之後，還要能再針對「品項」（同團的不同規格，例：
+--   D·灰 / C·綠）篩選訂單。列表走 PostgREST 內嵌 !inner 過濾
+--   （customer_order_items.sku_id），tab 數量與 KPI 卡走本 RPC —— 兩邊要吃
+--   同一個條件，數字才對得起來（沿用 campaign / store / keyword 的既有慣例）。
+--
+-- 語意：訂單層級過濾 —— 「至少含一列指定品項」的訂單整張算進來，金額/件數
+--   仍是整張單（與列表一致：列表顯示的是整張訂單，總金額也是整單）。
+--   不是品項行級的金額拆分。
+--
+-- 基底版本：20260805000130_rpc_order_overview_event_date_tabs.sql（v5）
+--   本檔只在 filtered CTE 加一個 EXISTS 條件；kw/toks/qualified_members、
+--   ranged_order/ranged_event、tab_counts、trend_* / pickup_* 一字未動。
+--   簽章有變（多一個參數）→ 必須先 DROP 舊簽章，否則 PostgREST 會因為
+--   overload 找不到唯一候選（新參數有 DEFAULT，6 參數呼叫兩個都能匹配）。
+-- rollback：DROP 本簽章後 CREATE 回 20260805000130 的版本。
+-- ============================================================
+
+DROP FUNCTION IF EXISTS rpc_order_overview(bigint[], bigint, text, timestamptz, timestamptz, timestamptz);
+
+CREATE FUNCTION rpc_order_overview(
+  p_campaign_ids bigint[],
+  p_store_id     bigint,
+  p_keyword      text,
+  p_month_start  timestamptz,
+  p_date_from    timestamptz DEFAULT NULL,
+  p_date_to      timestamptz DEFAULT NULL,
+  p_sku_ids      bigint[]    DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH kw AS (
+    -- 與 buildKeywordOr 一致：先把 %,() 換成空白避免當成 ILIKE 萬用字元
+    SELECT NULLIF(btrim(regexp_replace(COALESCE(p_keyword, ''), '[%,()]', ' ', 'g')), '') AS q
+  ),
+  toks AS (
+    SELECT ARRAY(
+      SELECT t FROM unnest(regexp_split_to_array((SELECT q FROM kw), '[\s+]+')) AS t
+      WHERE t <> ''
+    ) AS arr
+  ),
+  qualified_members AS (
+    -- token-AND：每個 token 都要在 name/phone/member_no 至少一欄命中
+    SELECT m.id
+    FROM members m
+    WHERE (SELECT q FROM kw) IS NOT NULL
+      AND m.status <> 'deleted'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM unnest((SELECT arr FROM toks)) AS tok
+        WHERE NOT (
+          m.name      ILIKE '%' || tok || '%'
+          OR m.phone     ILIKE '%' || tok || '%'
+          OR m.member_no ILIKE '%' || tok || '%'
+        )
+      )
+  ),
+  filtered AS (
+    -- v_admin_orders = customer_orders + event_at（事件日，定義見 20260805000120）
+    SELECT o.id, o.member_id, o.created_at, o.event_at, o.status
+    FROM v_admin_orders o
+    WHERE (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      -- 品項篩選：訂單層級（至少含一列指定 SKU 的訂單），與列表的
+      -- customer_order_items!inner 內嵌過濾同義
+      AND (
+        p_sku_ids IS NULL
+        OR cardinality(p_sku_ids) = 0
+        OR EXISTS (
+          SELECT 1 FROM customer_order_items i
+          WHERE i.order_id = o.id AND i.sku_id = ANY(p_sku_ids)
+        )
+      )
+      AND (
+        (SELECT q FROM kw) IS NULL
+        OR o.order_no          ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.nickname_snapshot ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.member_id IN (SELECT id FROM qualified_members)
+      )
+  ),
+  -- 「未取貨」tab 專用：訂單日 created_at 區間
+  ranged_order AS (
+    SELECT f.*
+    FROM filtered f
+    WHERE (p_date_from IS NULL OR f.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR f.created_at <  p_date_to)
+  ),
+  -- 其餘 tab 專用：事件日 event_at 區間
+  ranged_event AS (
+    SELECT f.*
+    FROM filtered f
+    WHERE (p_date_from IS NULL OR f.event_at >= p_date_from)
+      AND (p_date_to   IS NULL OR f.event_at <  p_date_to)
+  ),
+  tab_counts AS (
+    SELECT
+      (SELECT count(*) FROM ranged_order WHERE status IN ('pending','confirmed','shipping','ready')) AS pending,
+      -- ready 是 pending 的子集（刻意重疊）：未取貨=全部未取，可取貨=其中已到店的。
+      -- 兩者的日期語意不同（訂單日 vs 到貨可取日），故取自不同的 ranged。
+      (SELECT count(*) FROM ranged_event WHERE status = 'ready')                                     AS ready,
+      (SELECT count(*) FROM ranged_event WHERE status = 'partially_completed')                       AS partially,
+      (SELECT count(*) FROM ranged_event WHERE status = 'completed')                                 AS completed,
+      (SELECT count(*) FROM ranged_event WHERE status IN ('cancelled','expired'))                    AS cancelled,
+      (SELECT count(*) FROM ranged_event WHERE status = 'transferred_out')                           AS transferred
+  ),
+  trend_orders AS (
+    SELECT
+      f.id,
+      f.member_id,
+      to_char((f.created_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd
+    FROM filtered f
+    WHERE f.status NOT IN ('cancelled','expired','transferred_out')
+      AND f.created_at >= p_month_start
+  ),
+  order_amt AS (
+    SELECT i.order_id, SUM(i.qty * i.unit_price)::numeric AS amount
+    FROM customer_order_items i
+    JOIN trend_orders t ON t.id = i.order_id
+    GROUP BY i.order_id
+  ),
+  day_agg AS (
+    SELECT
+      t.ymd,
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+    GROUP BY t.ymd
+  ),
+  total_agg AS (
+    SELECT
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+  ),
+  -- 取貨明細（本月）：一行 picked_up = 一次交貨，逐行加總
+  pickup_items AS (
+    SELECT
+      to_char((i.updated_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd,
+      f.id                            AS order_id,
+      (i.qty * i.unit_price)::numeric AS amount,
+      i.qty::numeric                  AS qty
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    WHERE i.status = 'picked_up'
+      AND i.updated_at >= p_month_start
+      AND f.status NOT IN ('cancelled','expired','transferred_out')
+  ),
+  pickup_day_agg AS (
+    SELECT
+      p.ymd,
+      count(DISTINCT p.order_id) AS orders,
+      SUM(p.amount)::numeric     AS amount,
+      SUM(p.qty)::numeric        AS qty
+    FROM pickup_items p
+    GROUP BY p.ymd
+  ),
+  pickup_total_agg AS (
+    SELECT
+      count(DISTINCT p.order_id)         AS orders,
+      COALESCE(SUM(p.amount), 0)::numeric AS amount,
+      COALESCE(SUM(p.qty), 0)::numeric    AS qty
+    FROM pickup_items p
+  )
+  SELECT jsonb_build_object(
+    'tab_counts', (SELECT to_jsonb(tab_counts.*) FROM tab_counts),
+    'trend_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'members', members, 'amount', amount
+                ) ORDER BY ymd)
+       FROM day_agg),
+      '[]'::jsonb
+    ),
+    'trend_total', (SELECT to_jsonb(total_agg.*) FROM total_agg),
+    'pickup_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'amount', amount, 'qty', qty
+                ) ORDER BY ymd)
+       FROM pickup_day_agg),
+      '[]'::jsonb
+    ),
+    'pickup_total', (SELECT to_jsonb(pickup_total_agg.*) FROM pickup_total_agg)
+  );
+$$;
+
+COMMENT ON FUNCTION rpc_order_overview(bigint[], bigint, text, timestamptz, timestamptz, timestamptz, bigint[]) IS
+  'admin /orders 頁首聚合：tab 數量（含 ready「可取貨」）+ 本月每日下單趨勢 + 本月每日取貨金額。'
+  'p_date_from/p_date_to 為半開區間 [from, to)，只套用於 tab 數量：未取貨看訂單日 created_at，'
+  '其餘 tab 看事件日 v_admin_orders.event_at（可取/取貨/取消/轉出各自的發生時間）。'
+  'p_sku_ids 品項篩選為訂單層級（至少含一列指定 SKU 的訂單整張算入），套用於所有聚合。'
+  '趨勢與取貨聚合固定為 p_month_start 起算的當月。';
+
+GRANT EXECUTE ON FUNCTION rpc_order_overview(bigint[], bigint, text, timestamptz, timestamptz, timestamptz, bigint[]) TO authenticated;


### PR DESCRIPTION
選了開團後出現品項下拉（選項＝所選開團的 campaign_items），選定後：
- 列表 / 選全部：v_admin_orders 帶 customer_order_items!inner 內嵌，
  items.sku_id=in.(…) 收斂到「至少含一列該品項」的訂單
- tab 數量 / KPI 卡：rpc_order_overview v6 新增 p_sku_ids（訂單層級
  EXISTS，同一條件），兩邊數字才對得起來
- 開團清空時篩選由 activeSkuId 歸零，不會在 UI 看不到時默默生效
- 未篩品項時不帶 p_sku_ids key，相容尚未套 migration 的舊版函式

migration 已套線上並驗證：overload 唯一、p_sku_ids 篩選數與直接
SQL count 一致；anon 打 view 內嵌過濾回 200（關聯解析 OK）。
Playwright fixture 驗證：下拉出現/選項/列表過濾/RPC 參數/清除還原。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KK31XLuaMAbTVxBx5xsBac