### PR TITLE
feat(admin): 會員詳情頁可經 LINE OA 直接發訊息（文字＋截圖）

### DIFF
--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -31,6 +31,11 @@ type Reachable =
 // OA 後台 1:1 聊天不吃額度，所以這裡的數字跟後台聊天量對不上是正常的。
 type Quota = { limit: number | null; used: number };
 
+// OA 後台 1:1 聊天室（chat.line.biz）。走這條發訊息不吃推播額度，
+// 但要另外登入 OA 後台、且該帳號要有這支 OA 的權限。
+// chatMode "bot" = 後台把「聊天」關掉了、只走 webhook，連過去也不能回。
+type Chat = { url: string | null; mode: string | null };
+
 async function callFn(body: Record<string, unknown>) {
   const sb = getSupabase();
   const { data: { session } } = await sb.auth.getSession();
@@ -80,6 +85,7 @@ export function LineMessageModal({
 }) {
   const [reachable, setReachable] = useState<Reachable>({ state: "checking" });
   const [quota, setQuota] = useState<Quota | null>(null);
+  const [chat, setChat] = useState<Chat | null>(null);
   const [text, setText] = useState("");
   const [image, setImage] = useState<File | null>(null);
   const [sending, setSending] = useState(false);
@@ -94,6 +100,7 @@ export function LineMessageModal({
       try {
         const { status, result } = await callFn({ action: "check", member_id: member.id });
         if (cancelled) return;
+        if (result.ok) setChat({ url: result.chat_url ?? null, mode: result.chat_mode ?? null });
         if (result.ok && result.reachable) {
           setReachable({ state: "ok", displayName: result.display_name ?? null });
         } else if (result.ok && !result.reachable) {
@@ -242,6 +249,29 @@ export function LineMessageModal({
               本月推播已用 {quota.used} / {quota.limit ?? "無上限"} 則
             </div>
           )
+        )}
+
+        {/* 免額度替代路徑：OA 後台 1:1 聊天室。額度用完時這條仍然能發。 */}
+        {chat?.url && (
+          <div className="rounded-md border border-zinc-200 bg-zinc-50 p-2 dark:border-zinc-800 dark:bg-zinc-900">
+            <a
+              href={chat.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs font-medium text-sky-700 underline hover:text-sky-900 dark:text-sky-400 dark:hover:text-sky-300"
+            >
+              💬 在官方帳號後台開啟與此會員的 1:1 聊天 ↗
+            </a>
+            <p className="mt-1 text-[11px] text-zinc-500">
+              後台聊天<strong className="font-semibold">不吃推播額度</strong>，但需另外登入 LINE 官方帳號後台。
+            </p>
+            {chat.mode === "bot" && (
+              <p className="mt-1 text-[11px] text-amber-700 dark:text-amber-400">
+                ⚠ 此官方帳號目前是「Bot 模式」，後台聊天已關閉 —
+                需先到官方帳號設定把回應方式改成「聊天模式」才能在後台回覆。
+              </p>
+            )}
+          </div>
         )}
 
         <label className="block text-sm">

--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+// 對單一會員經 LINE 官方帳號發訊息（文字 + 截圖）。
+// 後端：admin-line-push edge function（函式內驗 staff JWT）。
+//
+// 圖片流程：不管來源格式，一律 canvas 轉 JPEG 再上傳 line-media bucket —
+//   original ≤ 2048px（LINE originalContentUrl 上限 10MB，轉完遠低於此）
+//   preview  ≤  800px（LINE previewImageUrl 上限 1MB，聊天室縮圖用）
+// 順便鋪白底（截圖常有透明背景，JPEG 沒有 alpha）、去掉 EXIF。
+//
+// 開啟時先打 action:check 預檢「推不推得到」：404 = 沒加好友或
+// Login channel 跟 OA 不同 provider — 這是營運前置條件問題，不是 bug，
+// 所以要在發送前就讓店員看到，而不是發了才失敗。
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { Modal } from "@/components/Modal";
+import SpinButton from "@/components/SpinButton";
+
+const BUCKET = "line-media";
+const FN_URL = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/admin-line-push`;
+
+type Reachable =
+  | { state: "checking" }
+  | { state: "ok"; displayName: string | null }
+  | { state: "unreachable"; message: string }
+  | { state: "not_configured"; message: string }
+  | { state: "error"; message: string };
+
+async function callFn(body: Record<string, unknown>) {
+  const sb = getSupabase();
+  const { data: { session } } = await sb.auth.getSession();
+  if (!session) throw new Error("尚未登入");
+  const resp = await fetch(FN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${session.access_token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  const result = await resp.json().catch(() => ({}));
+  return { status: resp.status, result };
+}
+
+/** canvas 轉 JPEG：縮到 maxDim 內、鋪白底（透明截圖）、去 EXIF */
+async function encodeJpeg(file: File, maxDim: number, quality: number): Promise<Blob> {
+  const bmp = await createImageBitmap(file);
+  try {
+    const scale = Math.min(1, maxDim / Math.max(bmp.width, bmp.height));
+    const w = Math.max(1, Math.round(bmp.width * scale));
+    const h = Math.max(1, Math.round(bmp.height * scale));
+    const canvas = document.createElement("canvas");
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("無法建立 canvas");
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, w, h);
+    ctx.drawImage(bmp, 0, 0, w, h);
+    const blob = await new Promise<Blob | null>((res) => canvas.toBlob(res, "image/jpeg", quality));
+    if (!blob) throw new Error("圖片轉檔失敗");
+    return blob;
+  } finally {
+    bmp.close();
+  }
+}
+
+export function LineMessageModal({
+  open, onClose, member, tenantId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  member: { id: number; name: string | null; member_no: string };
+  tenantId: string;
+}) {
+  const [reachable, setReachable] = useState<Reachable>({ state: "checking" });
+  const [text, setText] = useState("");
+  const [image, setImage] = useState<File | null>(null);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 開啟時預檢可達性（modal 是條件渲染、每次開啟重新 mount，初始 state 即 checking）
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { status, result } = await callFn({ action: "check", member_id: member.id });
+        if (cancelled) return;
+        if (result.ok && result.reachable) {
+          setReachable({ state: "ok", displayName: result.display_name ?? null });
+        } else if (result.ok && !result.reachable) {
+          setReachable({ state: "unreachable", message: result.message });
+        } else if (result.error === "not_configured") {
+          setReachable({ state: "not_configured", message: result.message });
+        } else {
+          setReachable({ state: "error", message: result.message || result.error || `HTTP ${status}` });
+        }
+      } catch (e) {
+        if (!cancelled) setReachable({ state: "error", message: e instanceof Error ? e.message : String(e) });
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [open, member.id]);
+
+  // 貼上截圖（Ctrl/Cmd+V）— modal 開著時掛在 document 上，不用先點進哪個欄位
+  useEffect(() => {
+    if (!open) return;
+    function onPaste(e: ClipboardEvent) {
+      const item = Array.from(e.clipboardData?.items ?? []).find((i) => i.type.startsWith("image/"));
+      const file = item?.getAsFile();
+      if (file) {
+        e.preventDefault();
+        setError(null);
+        setImage(file);
+      }
+    }
+    document.addEventListener("paste", onPaste);
+    return () => document.removeEventListener("paste", onPaste);
+  }, [open]);
+
+  // objectURL 隨 image 換發 / 卸載時回收
+  const imagePreview = useMemo(() => (image ? URL.createObjectURL(image) : null), [image]);
+  useEffect(() => {
+    return () => { if (imagePreview) URL.revokeObjectURL(imagePreview); };
+  }, [imagePreview]);
+
+  function pickImage(file: File) {
+    if (!file.type.startsWith("image/")) {
+      setError("只能附圖片檔");
+      return;
+    }
+    setError(null);
+    setImage(file);
+  }
+
+  async function send() {
+    if (!text.trim() && !image) {
+      setError("請輸入訊息或附上截圖");
+      return;
+    }
+    setSending(true);
+    setError(null);
+    try {
+      let imageUrl: string | undefined;
+      let previewUrl: string | undefined;
+
+      if (image) {
+        const sb = getSupabase();
+        const [original, preview] = await Promise.all([
+          encodeJpeg(image, 2048, 0.9),
+          encodeJpeg(image, 800, 0.8),
+        ]);
+        const base = `${tenantId}/${crypto.randomUUID()}`;
+        for (const [path, blob] of [[`${base}.jpg`, original], [`${base}_preview.jpg`, preview]] as const) {
+          const { error: upErr } = await sb.storage
+            .from(BUCKET)
+            .upload(path, blob, { contentType: "image/jpeg", cacheControl: "3600", upsert: false });
+          if (upErr) throw new Error(`截圖上傳失敗：${upErr.message}`);
+        }
+        imageUrl = sb.storage.from(BUCKET).getPublicUrl(`${base}.jpg`).data.publicUrl;
+        previewUrl = sb.storage.from(BUCKET).getPublicUrl(`${base}_preview.jpg`).data.publicUrl;
+      }
+
+      const { status, result } = await callFn({
+        action: "send",
+        member_id: member.id,
+        text: text.trim() || undefined,
+        image_url: imageUrl,
+        preview_url: previewUrl,
+      });
+
+      if (result.ok) {
+        alert("已發送 ✓");
+        setText("");
+        setImage(null);
+        onClose();
+      } else {
+        const parts = [result.message || result.error || `HTTP ${status}`];
+        if (result.hint) parts.push(result.hint);
+        setError(parts.join("\n"));
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSending(false);
+    }
+  }
+
+  const canSend = !sending
+    && reachable.state !== "checking"
+    && reachable.state !== "not_configured"
+    && (text.trim().length > 0 || !!image);
+
+  return (
+    <Modal open={open} onClose={onClose} title={`發送 LINE 訊息 — ${member.name ?? `#${member.member_no}`}`} maxWidth="max-w-lg">
+      <div className="space-y-4">
+        {/* 可達性預檢 */}
+        {reachable.state === "checking" && (
+          <div className="rounded-md border border-zinc-200 bg-zinc-50 p-2 text-xs text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900">
+            檢查會員是否可接收 LINE 訊息…
+          </div>
+        )}
+        {reachable.state === "ok" && (
+          <div className="rounded-md border border-emerald-200 bg-emerald-50 p-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300">
+            ✓ 可發送{reachable.displayName ? `（LINE 名稱：${reachable.displayName}）` : ""}
+          </div>
+        )}
+        {reachable.state === "unreachable" && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
+            ⚠ {reachable.message}（仍可嘗試發送，但預期會失敗）
+          </div>
+        )}
+        {(reachable.state === "not_configured" || reachable.state === "error") && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {reachable.message}
+          </div>
+        )}
+
+        <label className="block text-sm">
+          <span className="mb-1 block text-xs text-zinc-500">訊息內容</span>
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={4}
+            maxLength={5000}
+            placeholder="輸入要發給會員的訊息…"
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+          />
+        </label>
+
+        <div>
+          <span className="mb-1 block text-xs text-zinc-500">
+            截圖 / 圖片（可直接 Ctrl+V 貼上）
+          </span>
+          {imagePreview ? (
+            <div className="relative inline-block">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={imagePreview} alt="附圖預覽" className="max-h-48 rounded-md border border-zinc-200 dark:border-zinc-800" />
+              <SpinButton
+                onClick={() => setImage(null)}
+                aria-label="移除圖片"
+                className="absolute -right-2 -top-2 rounded-full bg-zinc-700 px-1.5 py-0.5 text-xs text-white hover:bg-zinc-900"
+              >
+                ✕
+              </SpinButton>
+            </div>
+          ) : (
+            <SpinButton
+              onClick={() => fileInputRef.current?.click()}
+              className="rounded-md border border-dashed border-zinc-300 px-4 py-3 text-xs text-zinc-500 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              📎 選擇圖片或直接貼上截圖
+            </SpinButton>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) pickImage(f);
+              e.target.value = "";
+            }}
+          />
+        </div>
+
+        {error && (
+          <div className="whitespace-pre-wrap rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <SpinButton
+            onClick={onClose}
+            disabled={sending}
+            className="rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            取消
+          </SpinButton>
+          <SpinButton
+            onClick={send}
+            disabled={!canSend}
+            className="rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50"
+          >
+            {sending ? "發送中…" : "💬 發送"}
+          </SpinButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -36,6 +36,18 @@ type Quota = { limit: number | null; used: number };
 // chatMode "bot" = 後台把「聊天」關掉了、只走 webhook，連過去也不能回。
 type Chat = { url: string | null; mode: string | null };
 
+// 訊息樣板。連結由後端 links action 給（來自 MEMBER_FRONT_BASE_URL），
+// 不在這裡寫死網址 —— 換網域時只要改 secret，不用重新部署前端。
+//
+// ⚠ 連結一律用會員站自己的網址，不要換成 https://liff.line.me/...
+//   （LIFF endpoint 目前跨網域，會員點進去登入會爆，見 CLAUDE.md）。
+const TEMPLATES: { label: string; build: (ordersUrl: string) => string }[] = [
+  {
+    label: "📦 到貨通知",
+    build: (ordersUrl) => `您好，您有貨到了！\n查看訂單：${ordersUrl}`,
+  },
+];
+
 async function callFn(body: Record<string, unknown>) {
   const sb = getSupabase();
   const { data: { session } } = await sb.auth.getSession();
@@ -86,6 +98,7 @@ export function LineMessageModal({
   const [reachable, setReachable] = useState<Reachable>({ state: "checking" });
   const [quota, setQuota] = useState<Quota | null>(null);
   const [chat, setChat] = useState<Chat | null>(null);
+  const [ordersUrl, setOrdersUrl] = useState<string | null>(null);
   const [text, setText] = useState("");
   const [image, setImage] = useState<File | null>(null);
   const [sending, setSending] = useState(false);
@@ -120,6 +133,13 @@ export function LineMessageModal({
         const { result } = await callFn({ action: "quota" });
         if (!cancelled && result.ok) setQuota({ limit: result.limit ?? null, used: result.used ?? 0 });
       } catch { /* 額度顯示是輔助資訊，抓不到就算了 */ }
+    })();
+    // 樣板用的會員站連結（不需要 LINE token，所以 token 沒設也拿得到）
+    (async () => {
+      try {
+        const { result } = await callFn({ action: "links" });
+        if (!cancelled && result.ok) setOrdersUrl(result.orders_url ?? null);
+      } catch { /* 拿不到就不顯示樣板按鈕 */ }
     })();
     return () => { cancelled = true; };
   }, [open, member.id]);
@@ -271,6 +291,27 @@ export function LineMessageModal({
                 需先到官方帳號設定把回應方式改成「聊天模式」才能在後台回覆。
               </p>
             )}
+          </div>
+        )}
+
+        {/* 樣板：填進 textarea 後仍可自由編輯再送 */}
+        {ordersUrl && (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs text-zinc-500">套用樣板：</span>
+            {TEMPLATES.map((t) => (
+              <SpinButton
+                key={t.label}
+                onClick={() => {
+                  const next = t.build(ordersUrl);
+                  // 已經打了字才確認，避免手滑蓋掉寫好的內容
+                  if (text.trim() && !window.confirm("要用樣板取代目前已輸入的訊息嗎？")) return;
+                  setText(next);
+                }}
+                className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              >
+                {t.label}
+              </SpinButton>
+            ))}
           </div>
         )}
 

--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -27,6 +27,10 @@ type Reachable =
   | { state: "not_configured"; message: string }
   | { state: "error"; message: string };
 
+// limit=null = 方案無則數上限。額度只算「主動推播」（這個功能就是），
+// OA 後台 1:1 聊天不吃額度，所以這裡的數字跟後台聊天量對不上是正常的。
+type Quota = { limit: number | null; used: number };
+
 async function callFn(body: Record<string, unknown>) {
   const sb = getSupabase();
   const { data: { session } } = await sb.auth.getSession();
@@ -75,6 +79,7 @@ export function LineMessageModal({
   tenantId: string;
 }) {
   const [reachable, setReachable] = useState<Reachable>({ state: "checking" });
+  const [quota, setQuota] = useState<Quota | null>(null);
   const [text, setText] = useState("");
   const [image, setImage] = useState<File | null>(null);
   const [sending, setSending] = useState(false);
@@ -101,6 +106,13 @@ export function LineMessageModal({
       } catch (e) {
         if (!cancelled) setReachable({ state: "error", message: e instanceof Error ? e.message : String(e) });
       }
+    })();
+    // 額度另外抓，失敗就不顯示（不擋發送流程）
+    (async () => {
+      try {
+        const { result } = await callFn({ action: "quota" });
+        if (!cancelled && result.ok) setQuota({ limit: result.limit ?? null, used: result.used ?? 0 });
+      } catch { /* 額度顯示是輔助資訊，抓不到就算了 */ }
     })();
     return () => { cancelled = true; };
   }, [open, member.id]);
@@ -217,6 +229,19 @@ export function LineMessageModal({
           <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
             {reachable.message}
           </div>
+        )}
+
+        {/* 本月推播額度（只算主動推播；OA 後台 1:1 聊天不吃額度） */}
+        {quota && (
+          quota.limit !== null && quota.used >= quota.limit ? (
+            <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+              本月推播額度已用完（{quota.used} / {quota.limit} 則），發送會失敗。額度每月 1 號重置；OA 後台 1:1 聊天不受影響。
+            </div>
+          ) : (
+            <div className="text-xs text-zinc-500" title="只計算主動推播（此功能 / 群發）；官方帳號後台 1:1 聊天不吃額度">
+              本月推播已用 {quota.used} / {quota.limit ?? "無上限"} 則
+            </div>
+          )
         )}
 
         <label className="block text-sm">

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { MemberMergeModal } from "@/components/MemberMergeModal";
 import { MemberDeleteModal } from "@/components/MemberDeleteModal";
+import { LineMessageModal } from "@/components/LineMessageModal";
 import { WalletActionModal, type WalletActionMode } from "@/components/WalletActionModal";
 import { translateRpcError } from "@/lib/rpcError";
 import { canAdjustWallet, isAdmin, useRole } from "@/lib/role";
@@ -84,6 +85,7 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
   const [reloadTick, setReloadTick] = useState(0);
   const [mergeOpen, setMergeOpen] = useState<false | "guest-to-real" | "real-from-guest">(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [lineMsgOpen, setLineMsgOpen] = useState(false);
   const [mergedFrom, setMergedFrom] = useState<MergedFrom[]>([]);
   const [savingFlags, setSavingFlags] = useState(false);
   const [draftAdminNote, setDraftAdminNote] = useState("");
@@ -290,6 +292,15 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
           </div>
           <div className="font-mono text-xs text-zinc-500">#{member.member_no}</div>
         </div>
+        {hasLine && !isMerged && !isDeleted && (
+          <SpinButton
+            onClick={() => setLineMsgOpen(true)}
+            className="rounded-md border border-green-300 px-3 py-1 text-xs font-medium text-green-700 hover:bg-green-50 dark:border-green-800 dark:text-green-300 dark:hover:bg-green-950"
+            title="透過 LINE 官方帳號直接發訊息給此會員（可附截圖）"
+          >
+            💬 發送 LINE 訊息
+          </SpinButton>
+        )}
         {canMergeOut && (
           <SpinButton
             onClick={() => setMergeOpen("guest-to-real")}
@@ -456,6 +467,15 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
           onDeleted?.();
         }}
       />
+
+      {lineMsgOpen && tenantId && (
+        <LineMessageModal
+          open={true}
+          onClose={() => setLineMsgOpen(false)}
+          member={{ id: member.id, name: member.name, member_no: member.member_no }}
+          tenantId={tenantId}
+        />
+      )}
 
       {walletAction && tenantId && (
         <WalletActionModal

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -435,3 +435,8 @@ verify_jwt = false
 # 對齊 staff-create：gateway 驗 JWT 會擋掉 CORS preflight
 [functions.tenant-purge]
 verify_jwt = false
+
+# admin-line-push 由 admin 瀏覽器呼叫，函式內自行驗 staff JWT + tenant，
+# 對齊 staff-create：gateway 驗 JWT 會擋掉 CORS preflight
+[functions.admin-line-push]
+verify_jwt = false

--- a/supabase/functions/admin-line-push/index.ts
+++ b/supabase/functions/admin-line-push/index.ts
@@ -1,0 +1,160 @@
+// admin-line-push: admin 對單一會員經 LINE OA（Messaging API）發訊息（文字/截圖）
+//
+// 呼叫者：admin 會員詳情頁（LineMessageModal）。
+// Auth：函式內自驗 staff JWT（sb.auth.getUser）+ tenant 檢查，照 admin-notify 模式。
+//       gateway verify_jwt=false（true 會擋 CORS preflight，見 config.toml staff-create 註解）。
+//
+// actions:
+//   check — GET LINE profile，回「這個 line_user_id 對這支 OA 能不能推」
+//           （404 = 沒加好友 **或** Login channel 跟 OA 不同 provider、ID 對不上）
+//   send  — push 文字和/或圖片。圖片 URL 限定自家 line-media bucket，
+//           防止拿這支函式對會員推任意外部圖。
+//
+// 需要 secret：LINE_MESSAGING_CHANNEL_ACCESS_TOKEN（OA 的 Messaging API
+// long-lived channel access token）。沒設會回 503 not_configured — 這是
+// 部署後第一個要檢查的東西，不是程式 bug。
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.8";
+import { corsHeaders } from "../_shared/cors.ts";
+
+const LINE_PUSH_URL = "https://api.line.me/v2/bot/message/push";
+const LINE_PROFILE_URL = "https://api.line.me/v2/bot/profile";
+
+function requireEnv(name: string): string {
+  const v = Deno.env.get(name);
+  if (!v) throw new Error(`missing env ${name}`);
+  return v;
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+
+  try {
+    const auth = req.headers.get("authorization");
+    if (!auth) return json({ error: "missing authorization" }, 401);
+
+    const supabaseUrl = requireEnv("SUPABASE_URL");
+    const sb = createClient(
+      supabaseUrl,
+      requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+      { auth: { persistSession: false } }
+    );
+
+    const token = auth.replace(/^Bearer\s+/i, "");
+    const { data: { user }, error: authErr } = await sb.auth.getUser(token);
+    if (authErr || !user) {
+      return json({ error: "invalid token", detail: authErr?.message }, 401);
+    }
+
+    const tenantId = user.app_metadata?.tenant_id;
+    if (!tenantId) return json({ error: "user has no tenant_id" }, 403);
+
+    const body = await req.json();
+    const action = body.action === "check" ? "check" : "send";
+    const memberId = body.member_id;
+    if (!memberId) return json({ error: "member_id is required" }, 400);
+
+    const { data: member, error: memErr } = await sb
+      .from("members")
+      .select("id, name, line_user_id")
+      .eq("tenant_id", tenantId)
+      .eq("id", memberId)
+      .maybeSingle();
+    if (memErr) return json({ error: memErr.message }, 500);
+    if (!member) return json({ error: "member not found" }, 404);
+    if (!member.line_user_id) {
+      return json({ error: "member_no_line", message: "此會員未綁定 LINE" }, 400);
+    }
+
+    const oaToken = Deno.env.get("LINE_MESSAGING_CHANNEL_ACCESS_TOKEN");
+    if (!oaToken) {
+      return json({
+        error: "not_configured",
+        message: "尚未設定 LINE_MESSAGING_CHANNEL_ACCESS_TOKEN（LINE 官方帳號的 Messaging API channel access token）",
+      }, 503);
+    }
+    const oaHeaders = { "Authorization": `Bearer ${oaToken}` };
+
+    // ── check：能不能推得到這個人 ───────────────────────────────────────────
+    if (action === "check") {
+      const resp = await fetch(`${LINE_PROFILE_URL}/${member.line_user_id}`, { headers: oaHeaders });
+      if (resp.ok) {
+        const profile = await resp.json();
+        return json({ ok: true, reachable: true, display_name: profile.displayName ?? null });
+      }
+      const detail = await resp.text();
+      if (resp.status === 404) {
+        return json({
+          ok: true,
+          reachable: false,
+          message: "此會員尚未加入官方帳號好友（或此 LINE ID 不屬於這支官方帳號的 provider），訊息無法送達",
+        });
+      }
+      if (resp.status === 401) {
+        return json({ error: "bad_token", message: "LINE token 無效，請重新確認 LINE_MESSAGING_CHANNEL_ACCESS_TOKEN", detail }, 502);
+      }
+      return json({ error: "line_api_error", status: resp.status, detail }, 502);
+    }
+
+    // ── send ────────────────────────────────────────────────────────────────
+    const text = typeof body.text === "string" ? body.text.trim() : "";
+    const imageUrl = typeof body.image_url === "string" ? body.image_url : "";
+    const previewUrl = typeof body.preview_url === "string" && body.preview_url ? body.preview_url : imageUrl;
+
+    if (!text && !imageUrl) return json({ error: "text 或 image_url 至少要有一個" }, 400);
+    if (text.length > 5000) return json({ error: "text 超過 LINE 上限 5000 字" }, 400);
+
+    // 圖片只收自家 line-media bucket 的公開 URL
+    const mediaPrefix = `${supabaseUrl}/storage/v1/object/public/line-media/`;
+    if (imageUrl && !imageUrl.startsWith(mediaPrefix)) {
+      return json({ error: "image_url 必須是 line-media bucket 的公開 URL" }, 400);
+    }
+
+    const messages: unknown[] = [];
+    if (text) messages.push({ type: "text", text });
+    if (imageUrl) {
+      messages.push({ type: "image", originalContentUrl: imageUrl, previewImageUrl: previewUrl });
+    }
+
+    const resp = await fetch(LINE_PUSH_URL, {
+      method: "POST",
+      headers: { ...oaHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ to: member.line_user_id, messages }),
+    });
+
+    const ok = resp.ok;
+    const respText = ok ? null : await resp.text();
+
+    const { error: logErr } = await sb.from("line_push_logs").insert({
+      tenant_id: tenantId,
+      member_id: member.id,
+      line_user_id: member.line_user_id,
+      sent_by: user.id,
+      text: text || null,
+      image_url: imageUrl || null,
+      status: ok ? "sent" : "failed",
+      error: respText,
+    });
+    if (logErr) console.error("line_push_logs insert failed:", logErr.message);
+
+    if (!ok) {
+      // 400 幾乎都是「推不到這個人」：沒加好友 / 封鎖 / provider 不一致
+      const hint = resp.status === 400
+        ? "會員可能尚未加入官方帳號好友、已封鎖、或此 LINE ID 不屬於這支官方帳號"
+        : undefined;
+      return json({ error: "line_push_failed", status: resp.status, detail: respText, hint }, 502);
+    }
+    return json({ ok: true, member_name: member.name ?? null });
+  } catch (e) {
+    console.error("admin-line-push error:", e);
+    return json({ error: "internal", detail: String(e) }, 500);
+  }
+});

--- a/supabase/functions/admin-line-push/index.ts
+++ b/supabase/functions/admin-line-push/index.ts
@@ -7,6 +7,9 @@
 // actions:
 //   check — GET LINE profile，回「這個 line_user_id 對這支 OA 能不能推」
 //           （404 = 沒加好友 **或** Login channel 跟 OA 不同 provider、ID 對不上）
+//   quota — 本月推播額度（limit=null 表示方案無上限）。注意額度只算「主動
+//           推播」（push/broadcast/群發），OA 後台 1:1 聊天不吃額度 —
+//           後台數字跟這裡對不上時，先想這件事。
 //   send  — push 文字和/或圖片。圖片 URL 限定自家 line-media bucket，
 //           防止拿這支函式對會員推任意外部圖。
 //
@@ -19,6 +22,7 @@ import { corsHeaders } from "../_shared/cors.ts";
 
 const LINE_PUSH_URL = "https://api.line.me/v2/bot/message/push";
 const LINE_PROFILE_URL = "https://api.line.me/v2/bot/profile";
+const LINE_QUOTA_URL = "https://api.line.me/v2/bot/message/quota";
 
 function requireEnv(name: string): string {
   const v = Deno.env.get(name);
@@ -58,7 +62,38 @@ Deno.serve(async (req) => {
     if (!tenantId) return json({ error: "user has no tenant_id" }, 403);
 
     const body = await req.json();
-    const action = body.action === "check" ? "check" : "send";
+    const action = body.action === "check" ? "check"
+      : body.action === "quota" ? "quota"
+      : "send";
+
+    const oaToken = Deno.env.get("LINE_MESSAGING_CHANNEL_ACCESS_TOKEN");
+    if (!oaToken) {
+      return json({
+        error: "not_configured",
+        message: "尚未設定 LINE_MESSAGING_CHANNEL_ACCESS_TOKEN（LINE 官方帳號的 Messaging API channel access token）",
+      }, 503);
+    }
+    const oaHeaders = { "Authorization": `Bearer ${oaToken}` };
+
+    // ── quota：本月推播額度（不需要 member_id）─────────────────────────────
+    if (action === "quota") {
+      const [qResp, cResp] = await Promise.all([
+        fetch(LINE_QUOTA_URL, { headers: oaHeaders }),
+        fetch(`${LINE_QUOTA_URL}/consumption`, { headers: oaHeaders }),
+      ]);
+      if (!qResp.ok || !cResp.ok) {
+        const detail = `quota ${qResp.status} / consumption ${cResp.status}`;
+        return json({ error: "line_api_error", detail }, 502);
+      }
+      const q = await qResp.json();
+      const c = await cResp.json();
+      return json({
+        ok: true,
+        limit: q.type === "limited" ? q.value : null,  // null = 方案無上限
+        used: c.totalUsage ?? 0,
+      });
+    }
+
     const memberId = body.member_id;
     if (!memberId) return json({ error: "member_id is required" }, 400);
 
@@ -73,15 +108,6 @@ Deno.serve(async (req) => {
     if (!member.line_user_id) {
       return json({ error: "member_no_line", message: "此會員未綁定 LINE" }, 400);
     }
-
-    const oaToken = Deno.env.get("LINE_MESSAGING_CHANNEL_ACCESS_TOKEN");
-    if (!oaToken) {
-      return json({
-        error: "not_configured",
-        message: "尚未設定 LINE_MESSAGING_CHANNEL_ACCESS_TOKEN（LINE 官方帳號的 Messaging API channel access token）",
-      }, 503);
-    }
-    const oaHeaders = { "Authorization": `Bearer ${oaToken}` };
 
     // ── check：能不能推得到這個人 ───────────────────────────────────────────
     if (action === "check") {

--- a/supabase/functions/admin-line-push/index.ts
+++ b/supabase/functions/admin-line-push/index.ts
@@ -7,6 +7,7 @@
 // actions:
 //   check — GET LINE profile，回「這個 line_user_id 對這支 OA 能不能推」
 //           （404 = 沒加好友 **或** Login channel 跟 OA 不同 provider、ID 對不上）
+//           同時回 chat_url（OA 後台 1:1 聊天室連結）與 chat_mode。
 //   quota — 本月推播額度（limit=null 表示方案無上限）。注意額度只算「主動
 //           推播」（push/broadcast/群發），OA 後台 1:1 聊天不吃額度 —
 //           後台數字跟這裡對不上時，先想這件事。
@@ -23,6 +24,16 @@ import { corsHeaders } from "../_shared/cors.ts";
 const LINE_PUSH_URL = "https://api.line.me/v2/bot/message/push";
 const LINE_PROFILE_URL = "https://api.line.me/v2/bot/profile";
 const LINE_QUOTA_URL = "https://api.line.me/v2/bot/message/quota";
+const LINE_BOT_INFO_URL = "https://api.line.me/v2/bot/info";
+
+// OA 後台（LINE Official Account Manager）的 1:1 聊天室連結。
+// ⚠ 這個 URL 格式是**非官方**的 — LINE 沒有把後台網址列進 API 文件，
+//   哪天改版就會失效。所以：連結壞掉不要當程式 bug 追，先手動開
+//   https://chat.line.biz/ 看網址列現在長什麼樣，再回來改這一行。
+// 第一段是 OA 自己的 userId（/v2/bot/info 的 userId），不是 basicId(@xxx)。
+function chatConsoleUrl(botUserId: string, memberLineUserId: string): string {
+  return `https://chat.line.biz/${botUserId}/chat/${memberLineUserId}`;
+}
 
 function requireEnv(name: string): string {
   const v = Deno.env.get(name);
@@ -109,12 +120,31 @@ Deno.serve(async (req) => {
       return json({ error: "member_no_line", message: "此會員未綁定 LINE" }, 400);
     }
 
-    // ── check：能不能推得到這個人 ───────────────────────────────────────────
+    // ── check：能不能推得到這個人 + OA 後台 1:1 聊天室連結 ──────────────────
     if (action === "check") {
-      const resp = await fetch(`${LINE_PROFILE_URL}/${member.line_user_id}`, { headers: oaHeaders });
+      const [resp, infoResp] = await Promise.all([
+        fetch(`${LINE_PROFILE_URL}/${member.line_user_id}`, { headers: oaHeaders }),
+        fetch(LINE_BOT_INFO_URL, { headers: oaHeaders }),
+      ]);
+
+      // bot info 拿不到不擋主流程：少的只是「開聊天室」連結
+      let chatUrl: string | null = null;
+      let chatMode: string | null = null;
+      if (infoResp.ok) {
+        const info = await infoResp.json();
+        chatMode = info.chatMode ?? null;   // "chat" = 後台 1:1 聊天開著；"bot" = 只走 webhook
+        if (info.userId) chatUrl = chatConsoleUrl(info.userId, member.line_user_id);
+      } else {
+        console.error("bot info failed:", infoResp.status, await infoResp.text());
+      }
+
       if (resp.ok) {
         const profile = await resp.json();
-        return json({ ok: true, reachable: true, display_name: profile.displayName ?? null });
+        return json({
+          ok: true, reachable: true,
+          display_name: profile.displayName ?? null,
+          chat_url: chatUrl, chat_mode: chatMode,
+        });
       }
       const detail = await resp.text();
       if (resp.status === 404) {
@@ -122,6 +152,7 @@ Deno.serve(async (req) => {
           ok: true,
           reachable: false,
           message: "此會員尚未加入官方帳號好友（或此 LINE ID 不屬於這支官方帳號的 provider），訊息無法送達",
+          chat_url: chatUrl, chat_mode: chatMode,
         });
       }
       if (resp.status === 401) {

--- a/supabase/functions/admin-line-push/index.ts
+++ b/supabase/functions/admin-line-push/index.ts
@@ -11,6 +11,7 @@
 //   quota — 本月推播額度（limit=null 表示方案無上限）。注意額度只算「主動
 //           推播」（push/broadcast/群發），OA 後台 1:1 聊天不吃額度 —
 //           後台數字跟這裡對不上時，先想這件事。
+//   links — 訊息樣板要用的會員站連結（不需要 LINE token）。
 //   send  — push 文字和/或圖片。圖片 URL 限定自家 line-media bucket，
 //           防止拿這支函式對會員推任意外部圖。
 //
@@ -75,7 +76,28 @@ Deno.serve(async (req) => {
     const body = await req.json();
     const action = body.action === "check" ? "check"
       : body.action === "quota" ? "quota"
+      : body.action === "links" ? "links"
       : "send";
+
+    // ── links：訊息樣板要用的會員站連結（刻意放在 LINE token 檢查之前）──────
+    // 這幾條連結跟 LINE 無關，token 還沒設好時樣板也該能用。
+    //
+    // ⚠ 給的是會員站自己的網址，**不是** https://liff.line.me/... —
+    //   LIFF 連結會把使用者丟進 LIFF endpoint，而該 endpoint 目前指向一支
+    //   跨網域的 Cloudflare Worker，一跨網域 LIFF context 就沒了、登入必爆
+    //   （見 CLAUDE.md「LIFF app 的 Endpoint URL 必須跟會員站同網域」）。
+    //   會員站的 /orders 沒登入時會自己導去 `/` 走 useLineLogin，
+    //   那條路才是唯一維護中的登入邏輯。
+    if (action === "links") {
+      const base = (Deno.env.get("MEMBER_FRONT_BASE_URL") ?? "").replace(/\/+$/, "");
+      // localhost 是 README 給本機開發用的預設值，發到會員手機上是死連結
+      const usable = /^https:\/\//.test(base);
+      return json({
+        ok: true,
+        orders_url: usable ? `${base}/orders` : null,
+        message: usable ? undefined : "MEMBER_FRONT_BASE_URL 未設定或不是 https 網址，樣板連結無法產生",
+      });
+    }
 
     const oaToken = Deno.env.get("LINE_MESSAGING_CHANNEL_ACCESS_TOKEN");
     if (!oaToken) {

--- a/supabase/migrations/20260807000010_line_push_media_and_logs.sql
+++ b/supabase/migrations/20260807000010_line_push_media_and_logs.sql
@@ -1,0 +1,82 @@
+-- ============================================================================
+-- 2026-08-07: admin 對會員發送 LINE OA 訊息（文字 + 截圖）
+--
+-- 配套：Edge Function `admin-line-push`（staff 從 admin 會員詳情頁呼叫）。
+-- 這裡建兩樣東西：
+--   1. storage bucket `line-media` — 截圖上傳處。**必須 public**：
+--      LINE Messaging API 的 image message 只吃公開 HTTPS URL
+--      （LINE 伺服器自己去抓圖，不會帶任何 auth）。路徑帶 uuid、不可列舉。
+--      LINE 只接受 JPEG/PNG；前端一律轉 JPEG 再上傳。
+--   2. `line_push_logs` — 發送稽核紀錄（誰、何時、對誰、發了什麼、成敗）。
+--      寫入走 service role（admin-line-push 函式內），staff 只能讀自家 tenant。
+-- ============================================================================
+
+-- ── 1. storage bucket ───────────────────────────────────────────────────────
+-- 照 20260603100000_ensure_storage_buckets.sql 的做法 upsert，
+-- policy 照 20260424120002_storage_products_bucket.sql（tenant 資料夾隔離）。
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'line-media', 'line-media', TRUE, 10485760,  -- 10 MB = LINE originalContentUrl 上限
+  ARRAY['image/png','image/jpeg']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public             = EXCLUDED.public,
+  file_size_limit    = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+DROP POLICY IF EXISTS line_media_insert_tenant ON storage.objects;
+CREATE POLICY line_media_insert_tenant
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'line-media'
+    AND (storage.foldername(name))[1] = (auth.jwt() ->> 'tenant_id')
+  );
+
+DROP POLICY IF EXISTS line_media_delete_tenant ON storage.objects;
+CREATE POLICY line_media_delete_tenant
+  ON storage.objects FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'line-media'
+    AND (storage.foldername(name))[1] = (auth.jwt() ->> 'tenant_id')
+  );
+
+DROP POLICY IF EXISTS line_media_select_public ON storage.objects;
+CREATE POLICY line_media_select_public
+  ON storage.objects FOR SELECT TO public
+  USING (bucket_id = 'line-media');
+
+-- ── 2. 發送紀錄 ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS line_push_logs (
+  id           BIGSERIAL   PRIMARY KEY,
+  tenant_id    UUID        NOT NULL,
+  member_id    BIGINT      REFERENCES members(id) ON DELETE SET NULL,
+  line_user_id TEXT        NOT NULL,
+  sent_by      UUID,                 -- staff 的 auth.users.id
+  text         TEXT,
+  image_url    TEXT,
+  status       TEXT        NOT NULL CHECK (status IN ('sent', 'failed')),
+  error        TEXT,                 -- LINE API 的錯誤回應（status=failed 才有）
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_line_push_logs_tenant_recent
+  ON line_push_logs (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_line_push_logs_member_recent
+  ON line_push_logs (member_id, created_at DESC)
+  WHERE member_id IS NOT NULL;
+
+COMMENT ON TABLE  line_push_logs           IS 'admin 經 LINE OA 對會員的推播紀錄（admin-line-push 函式寫入）';
+COMMENT ON COLUMN line_push_logs.image_url IS 'line-media bucket 的公開 URL；純文字訊息為 NULL';
+COMMENT ON COLUMN line_push_logs.error     IS 'LINE API 回的錯誤內容，除錯「為什麼沒送到」用';
+
+-- 寫入只有 service role（bypass RLS）；staff 讀自家 tenant 的紀錄。
+ALTER TABLE line_push_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS line_push_logs_tenant_read ON line_push_logs;
+CREATE POLICY line_push_logs_tenant_read ON line_push_logs
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+  );


### PR DESCRIPTION
- 新 edge function admin-line-push：函式內驗 staff JWT + tenant
  （gateway verify_jwt=false，對齊 staff-create 的 CORS preflight 經驗）。
  action=check 先打 LINE profile 預檢「推不推得到」（404 = 沒加好友或
  Login channel 與 OA 不同 provider）；action=send 推文字/圖片，
  圖片 URL 限定自家 line-media bucket，防止拿函式推任意外部圖。
- 新 storage bucket line-media（public，LINE 伺服器抓圖不帶 auth）
  + line_push_logs 發送稽核表（service role 寫、staff 讀自家 tenant）。
- 會員詳情頁新增「💬 發送 LINE 訊息」按鈕（已綁 LINE 才出現）＋
  LineMessageModal：開啟即顯示可達性、支援 Ctrl+V 貼截圖、
  canvas 一律轉 JPEG（original ≤2048px / preview ≤800px，
  滿足 LINE 10MB / 1MB 上限，順便鋪白底去 EXIF）。

需要 secret LINE_MESSAGING_CHANNEL_ACCESS_TOKEN（OA 的 Messaging API
channel access token）才會通；未設時函式回 503 not_configured，
modal 會直接顯示這個訊息。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B51QThXsMUzMwjyAqrHYVi