### PR TITLE
fix(pickup): 取貨搜尋不再撈出已合併的舊帳號

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -10,7 +10,7 @@ import { withBasePath } from "@/lib/basePath";
 import { printViaIframe } from "@/lib/printIframe";
 import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
-import { getPickupRecents, recordPickupRecent, type RecentCustomer } from "@/lib/pickupRecents";
+import { dropPickupRecent, getPickupRecents, recordPickupRecent, type RecentCustomer } from "@/lib/pickupRecents";
 import { publicProductUrl } from "@/lib/campaignCover";
 import { parseReturnNote } from "@/lib/returnNote";
 import { fetchReprintableEvents, pickupEventLabel, type PickupEventRow } from "@/lib/pickupReceipt";
@@ -159,22 +159,24 @@ function PickupPageContent() {
     setSelectedItems(new Set());
     try {
       const sb = getSupabase();
-      // Google 式：以空白 / + 拆 token，每個 token 都要在 name / phone / member_no 至少一欄命中
-      const safe = q.replace(/[%,()]/g, " ");
-      const tokens = safe.split(/[\s+]+/).filter(Boolean);
-      let memberQ = sb
-        .from("members")
-        .select("id, member_no, name, phone, admin_note, no_notify_pickup, no_new_order")
-        .neq("status", "deleted")
-        .order("last_visit_at", { ascending: false, nullsFirst: false })
-        .limit(20);
-      for (const tok of tokens) {
-        memberQ = memberQ.or(`name.ilike.%${tok}%,phone.ilike.%${tok}%,member_no.ilike.%${tok}%`);
-      }
-      const { data: ms, error: e1 } = await memberQ;
+      // 與會員頁 / 開團入單 / 轉單同一支 RPC（Google 式多 token 搜尋）。
+      // 直接查 members 只擋 deleted 會把已合併 (merged) 的舊帳號也搜出來 —
+      // 訂單早已搬到新會員身上，對舊檔什麼都做不了；RPC 會把命中的舊檔
+      // 翻譯成併入的新會員並去重
+      const { data: ms, error: e1 } = await sb.rpc("rpc_search_members", { p_term: q, p_limit: 20 });
       if (e1) { setError(e1.message); return; }
       const list = (ms ?? []) as Member[];
       setMembers(list);
+
+      // 快選鈕是用 member_no 帶進來查的（q === rc.member_no）。若那個 member_no 的
+      // 本人沒出現在結果裡，代表它已被合併到別人身上（RPC 翻成新會員了）或已刪除 →
+      // 淘汰這顆幽靈鈕，免得櫃台一直看到一排點了對不上人的舊名字。
+      const ghost = recents.find((r) => r.member_no === q);
+      if (ghost && !list.some((m) => m.id === ghost.id)) {
+        dropPickupRecent(ghost.id);
+        setRecents(getPickupRecents());
+      }
+
       if (list.length === 0) return;
 
       // 搜尋有結果即記入「常用顧客」（不必等取貨）。

--- a/apps/admin/src/lib/pickupRecents.ts
+++ b/apps/admin/src/lib/pickupRecents.ts
@@ -51,6 +51,14 @@ export function getPickupRecents(): RecentCustomer[] {
     .slice(0, MAX_RETURNED);
 }
 
+// 快選鈕指到的會員已不存在（被合併到別人身上 / 已刪除）→ 從清單移除。
+// 這種鈕點下去只會查到「別人」，留著等 TTL 到期會白佔快選列的名額。
+export function dropPickupRecent(id: number): void {
+  const list = read();
+  const next = list.filter((r) => r.id !== id);
+  if (next.length !== list.length) write(next);
+}
+
 export function recordPickupRecent(m: {
   id: number;
   name: string | null;


### PR DESCRIPTION
取貨頁自己組 members 查詢，只擋 status='deleted'，沒擋 'merged' —
被合併掉的舊檔還是會搜出來。櫃台看到的是一張掛著「🚫 禁加單」、
點下去「無未取訂單」的幽靈卡片（訂單早在合併時就搬到新會員身上了），
只能困惑地跳過。

改走 rpc_search_members — 會員頁 / 開團入單 / 轉單本來就都用這支。
它除了排除 merged / deleted，還會沿著 merged_into_member_id 把命中的
舊檔翻譯成併入的新會員並去重，所以櫃台用舊名字或舊會員編號搜，
一樣找得到人，只是找到的是「現在那一隻」。

順手處理同一個 bug 留下的殘骸：「常用顧客快選」是搜尋有結果就記，
舊搜尋會回 merged 舊檔，那些舊檔因此變成 localStorage 裡的幽靈鈕，
名字還是合併前的舊名。這種鈕點下去只會查到別人、又白佔 10 顆的名額，
所以用 member_no 查而本人不在結果裡時（已被合併走 / 已刪除）就淘汰掉。

驗證（member_no 取自線上實際資料）：
- 線上跑 rpc_search_members('00783') 只回 67064「玲 000783-古華」與
  61900「#7313808：【林銘】500783-湖口」，status='merged' 的
  54170「#3320076：【玲】000783-古華」(no_new_order=true) 不在其中
- Playwright 走 UI：搜尋不再打 /rest/v1/members、禁加單卡片消失、
  點過幽靈鈕後該鈕從快選列移除，正常的鈕留著