### PR TITLE
feat(stores): 每分店各自的 LINE Messaging API 憑證

### DIFF
--- a/apps/admin/src/app/(protected)/stores/page.tsx
+++ b/apps/admin/src/app/(protected)/stores/page.tsx
@@ -5,6 +5,7 @@ import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import SearchSpinner from "@/components/SearchSpinner";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
+import { StoreLineOaField } from "@/components/StoreLineOaField";
 
 const PAGE_SIZE = 20;
 
@@ -515,6 +516,8 @@ function StoreForm({
             會員 App 現貨專區「LINE 詢問」會把訊息帶到這個官方帳號
           </span>
         </F>
+
+        <StoreLineOaField storeId={v.id} />
 
         <F label="備註" className="sm:col-span-4">
           <textarea

--- a/apps/admin/src/components/StoreLineOaField.tsx
+++ b/apps/admin/src/components/StoreLineOaField.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+// 分店的 LINE Messaging API 憑證（Channel ID / Channel Secret）。
+//
+// 這個租戶每家加盟店各有自己的 LINE 官方帳號，好友關係綁在單一 OA 上，
+// 所以推播憑證必須 per-store —— 拿 B 店的憑證推 A 店的好友一定失敗。
+//
+// ⚠ secret 是**只寫不讀**：後端 rpc_get_store_line_oa_status 只回 channel_id，
+//   永遠不回 secret（存 secret 的表對前端連 select 權限都沒有）。
+//   所以這裡沒有「顯示目前 secret」這種功能，只能整組重設。
+
+import { useEffect, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { isAdmin, useRole } from "@/lib/role";
+import { translateRpcError } from "@/lib/rpcError";
+import SpinButton from "@/components/SpinButton";
+
+type Status = { channel_id: string; updated_at: string } | null;
+
+export function StoreLineOaField({ storeId }: { storeId: number | null }) {
+  const role = useRole();
+  const [status, setStatus] = useState<Status>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [channelId, setChannelId] = useState("");
+  const [channelSecret, setChannelSecret] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    // storeId 為 null 時走的是「請先儲存分店」那個分支，用不到 loaded
+    if (storeId == null) return;
+    let cancelled = false;
+    (async () => {
+      const { data, error } = await getSupabase().rpc("rpc_get_store_line_oa_status");
+      if (cancelled) return;
+      if (!error && Array.isArray(data)) {
+        const row = (data as { store_id: number; channel_id: string; updated_at: string }[])
+          .find((r) => r.store_id === storeId);
+        setStatus(row ? { channel_id: row.channel_id, updated_at: row.updated_at } : null);
+      }
+      setLoaded(true);
+    })();
+    return () => { cancelled = true; };
+  }, [storeId]);
+
+  if (!isAdmin(role)) return null;
+
+  async function save(clear: boolean) {
+    if (storeId == null) return;
+    setSaving(true);
+    setErr(null);
+    setMsg(null);
+    try {
+      const { error } = await getSupabase().rpc("rpc_set_store_line_oa", {
+        p_store_id: storeId,
+        p_channel_id: clear ? "" : channelId.trim(),
+        p_channel_secret: clear ? "" : channelSecret.trim(),
+      });
+      if (error) { setErr(translateRpcError(error)); return; }
+      setChannelId("");
+      setChannelSecret("");
+      setStatus(clear ? null : { channel_id: channelId.trim(), updated_at: new Date().toISOString() });
+      setMsg(clear ? "已清除此分店的 LINE 憑證" : "已儲存（下次發送就會用這組憑證）");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="sm:col-span-4 rounded-md border border-zinc-300 bg-white/60 p-3 dark:border-zinc-700 dark:bg-zinc-900/40">
+      <div className="mb-1 text-xs font-medium text-zinc-700 dark:text-zinc-300">
+        LINE 推播憑證（Messaging API）
+      </div>
+
+      {storeId == null ? (
+        <p className="text-[11px] text-zinc-500">請先儲存這家分店，再回來設定 LINE 憑證。</p>
+      ) : (
+        <>
+          <p className="mb-2 text-[11px] text-zinc-500">
+            從「LINE 官方帳號管理後台 → 設定 → Messaging API」取得，用來對這家店的
+            會員發送 LINE 訊息。每家店各自一組，不能共用。
+          </p>
+
+          {loaded && (
+            status ? (
+              <div className="mb-2 rounded bg-emerald-50 px-2 py-1 text-[11px] text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+                ✓ 已設定　Channel ID：<span className="font-mono">{status.channel_id}</span>
+                　（{new Date(status.updated_at).toLocaleDateString("zh-TW")} 更新）
+              </div>
+            ) : (
+              <div className="mb-2 rounded bg-zinc-100 px-2 py-1 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                尚未設定 — 這家店的會員目前無法收到 LINE 推播
+              </div>
+            )
+          )}
+
+          <div className="grid gap-2 sm:grid-cols-2">
+            <label className="block text-xs">
+              <span className="mb-0.5 block text-zinc-500">Channel ID</span>
+              <input
+                value={channelId}
+                onChange={(e) => setChannelId(e.target.value)}
+                placeholder={status ? "留空 = 不變更" : "例：2001234567"}
+                autoComplete="off"
+                className="w-full rounded-md border border-zinc-300 bg-white px-2 py-1.5 font-mono text-xs dark:border-zinc-700 dark:bg-zinc-900"
+              />
+            </label>
+            <label className="block text-xs">
+              <span className="mb-0.5 block text-zinc-500">Channel Secret</span>
+              <input
+                value={channelSecret}
+                onChange={(e) => setChannelSecret(e.target.value)}
+                type="password"
+                placeholder={status ? "留空 = 不變更" : "貼上 secret"}
+                autoComplete="new-password"
+                className="w-full rounded-md border border-zinc-300 bg-white px-2 py-1.5 font-mono text-xs dark:border-zinc-700 dark:bg-zinc-900"
+              />
+            </label>
+          </div>
+
+          {(msg || err) && (
+            <div className={`mt-2 text-[11px] ${err ? "text-red-700 dark:text-red-400" : "text-emerald-700 dark:text-emerald-400"}`}>
+              {err ?? msg}
+            </div>
+          )}
+
+          <div className="mt-2 flex gap-2">
+            <SpinButton
+              onClick={() => save(false)}
+              disabled={saving || !channelId.trim() || !channelSecret.trim()}
+              className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+            >
+              {saving ? "儲存中…" : "💾 儲存憑證"}
+            </SpinButton>
+            {status && (
+              <SpinButton
+                onClick={() => {
+                  if (window.confirm("清除後這家店的會員就收不到 LINE 推播，確定？")) save(true);
+                }}
+                disabled={saving}
+                className="rounded-md border border-red-300 px-3 py-1 text-xs text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950"
+              >
+                清除
+              </SpinButton>
+            )}
+          </div>
+          <p className="mt-1 text-[11px] text-zinc-500">
+            基於安全，secret 存進去後無法再讀出來（要換只能重填整組）。
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/supabase/functions/admin-line-push/index.ts
+++ b/supabase/functions/admin-line-push/index.ts
@@ -15,9 +15,9 @@
 //   send  — push 文字和/或圖片。圖片 URL 限定自家 line-media bucket，
 //           防止拿這支函式對會員推任意外部圖。
 //
-// 需要 secret：LINE_MESSAGING_CHANNEL_ACCESS_TOKEN（OA 的 Messaging API
-// long-lived channel access token）。沒設會回 503 not_configured — 這是
-// 部署後第一個要檢查的東西，不是程式 bug。
+// 憑證來源（見 resolveOaToken）：會員所屬分店的 store_line_oa_credentials
+// → 租戶層 env LINE_MESSAGING_CHANNEL_ACCESS_TOKEN → 都沒有回 503 not_configured。
+// 這個租戶是每加盟店各有自己 OA 的架構，所以主線是分店憑證，env 只是退路。
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.8";
 import { corsHeaders } from "../_shared/cors.ts";
@@ -26,6 +26,7 @@ const LINE_PUSH_URL = "https://api.line.me/v2/bot/message/push";
 const LINE_PROFILE_URL = "https://api.line.me/v2/bot/profile";
 const LINE_QUOTA_URL = "https://api.line.me/v2/bot/message/quota";
 const LINE_BOT_INFO_URL = "https://api.line.me/v2/bot/info";
+const LINE_TOKEN_URL = "https://api.line.me/v2/oauth/accessToken";
 
 // OA 後台（LINE Official Account Manager）的 1:1 聊天室連結。
 // ⚠ 這個 URL 格式是**非官方**的 — LINE 沒有把後台網址列進 API 文件，
@@ -47,6 +48,88 @@ function json(body: unknown, status = 200) {
     status,
     headers: { ...corsHeaders, "Content-Type": "application/json" },
   });
+}
+
+type OaResolved =
+  | { token: string; source: "store" | "env" }
+  | { error: Record<string, unknown>; status: number };
+
+/**
+ * 取「該分店」的 channel access token。
+ *
+ * 順序：分店自己的憑證（store_line_oa_credentials）→ 租戶層 env token → 都沒有就報錯。
+ * env 那層是給「只有一個 OA」的租戶用的退路，以及分店還沒設定完的過渡期。
+ *
+ * 分店憑證存的是 channel_id + channel_secret（管理員在後台填的就是這兩個，
+ * 比 console 裡的 long-lived token 好找），這裡用 client_credentials 換成
+ * access token 並快取到期限前 —— 不快取的話每發一則訊息就多打一次 oauth。
+ */
+async function resolveOaToken(
+  // deno-lint-ignore no-explicit-any
+  sb: any,
+  tenantId: string,
+  storeId: number | null,
+): Promise<OaResolved> {
+  const envToken = Deno.env.get("LINE_MESSAGING_CHANNEL_ACCESS_TOKEN");
+
+  if (storeId != null) {
+    const { data: cred, error } = await sb
+      .from("store_line_oa_credentials")
+      .select("store_id, channel_id, channel_secret, access_token, access_token_expires_at")
+      .eq("tenant_id", tenantId)
+      .eq("store_id", storeId)
+      .maybeSingle();
+    if (error) return { error: { error: "internal", detail: error.message }, status: 500 };
+
+    if (cred) {
+      // 留 5 分鐘緩衝，免得剛好在發送途中過期
+      const exp = cred.access_token_expires_at ? Date.parse(cred.access_token_expires_at) : 0;
+      if (cred.access_token && exp > Date.now() + 5 * 60_000) {
+        return { token: cred.access_token, source: "store" };
+      }
+      const resp = await fetch(LINE_TOKEN_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: cred.channel_id,
+          client_secret: cred.channel_secret,
+        }),
+      });
+      if (!resp.ok) {
+        const detail = await resp.text();
+        return {
+          error: {
+            error: "bad_store_credentials",
+            message: "分店的 LINE Channel ID / Secret 無法換到 token，請確認是否填對（要用 Messaging API channel 的，不是 Login channel）",
+            detail,
+          },
+          status: 502,
+        };
+      }
+      const tok = await resp.json();
+      const expiresAt = new Date(Date.now() + (tok.expires_in ?? 0) * 1000).toISOString();
+      const { error: upErr } = await sb
+        .from("store_line_oa_credentials")
+        .update({ access_token: tok.access_token, access_token_expires_at: expiresAt })
+        .eq("store_id", storeId);
+      // 快取寫失敗不擋發送，只是下次還要再換一次
+      if (upErr) console.error("cache access_token failed:", upErr.message);
+      return { token: tok.access_token, source: "store" };
+    }
+  }
+
+  if (envToken) return { token: envToken, source: "env" };
+
+  return {
+    error: {
+      error: "not_configured",
+      message: storeId == null
+        ? "此會員沒有設定取貨店，無法決定要用哪一個官方帳號發送"
+        : "此會員所屬分店尚未設定 LINE Messaging API 憑證（請到「分店」→ 該店 →「LINE 推播憑證」填入 Channel ID / Secret）",
+    },
+    status: 503,
+  };
 }
 
 Deno.serve(async (req) => {
@@ -99,16 +182,29 @@ Deno.serve(async (req) => {
       });
     }
 
-    const oaToken = Deno.env.get("LINE_MESSAGING_CHANNEL_ACCESS_TOKEN");
-    if (!oaToken) {
-      return json({
-        error: "not_configured",
-        message: "尚未設定 LINE_MESSAGING_CHANNEL_ACCESS_TOKEN（LINE 官方帳號的 Messaging API channel access token）",
-      }, 503);
-    }
-    const oaHeaders = { "Authorization": `Bearer ${oaToken}` };
+    const memberId = body.member_id;
+    if (!memberId) return json({ error: "member_id is required" }, 400);
 
-    // ── quota：本月推播額度（不需要 member_id）─────────────────────────────
+    const { data: member, error: memErr } = await sb
+      .from("members")
+      .select("id, name, line_user_id, home_store_id")
+      .eq("tenant_id", tenantId)
+      .eq("id", memberId)
+      .maybeSingle();
+    if (memErr) return json({ error: memErr.message }, 500);
+    if (!member) return json({ error: "member not found" }, 404);
+    if (!member.line_user_id) {
+      return json({ error: "member_no_line", message: "此會員未綁定 LINE" }, 400);
+    }
+
+    // 用「會員所屬分店」的 OA 憑證。這個租戶每家加盟店各有自己的 OA，
+    // 而 LINE 好友關係是綁在單一 OA 上的 —— 拿 B 店的 token 去推 A 店的
+    // 好友一定失敗，所以絕不能共用一組 token。
+    const oa = await resolveOaToken(sb, tenantId, member.home_store_id ?? null);
+    if ("error" in oa) return json(oa.error, oa.status);
+    const oaHeaders = { "Authorization": `Bearer ${oa.token}` };
+
+    // ── quota：本月推播額度（該分店 OA 的額度）─────────────────────────────
     if (action === "quota") {
       const [qResp, cResp] = await Promise.all([
         fetch(LINE_QUOTA_URL, { headers: oaHeaders }),
@@ -124,22 +220,8 @@ Deno.serve(async (req) => {
         ok: true,
         limit: q.type === "limited" ? q.value : null,  // null = 方案無上限
         used: c.totalUsage ?? 0,
+        source: oa.source,
       });
-    }
-
-    const memberId = body.member_id;
-    if (!memberId) return json({ error: "member_id is required" }, 400);
-
-    const { data: member, error: memErr } = await sb
-      .from("members")
-      .select("id, name, line_user_id")
-      .eq("tenant_id", tenantId)
-      .eq("id", memberId)
-      .maybeSingle();
-    if (memErr) return json({ error: memErr.message }, 500);
-    if (!member) return json({ error: "member not found" }, 404);
-    if (!member.line_user_id) {
-      return json({ error: "member_no_line", message: "此會員未綁定 LINE" }, 400);
     }
 
     // ── check：能不能推得到這個人 + OA 後台 1:1 聊天室連結 ──────────────────

--- a/supabase/migrations/20260807000030_store_line_oa_credentials.sql
+++ b/supabase/migrations/20260807000030_store_line_oa_credentials.sql
@@ -1,0 +1,127 @@
+-- ============================================================================
+-- 2026-08-07: 每分店自己的 LINE Messaging API 憑證
+--
+-- 背景：這個租戶是「每加盟店各自申請 LINE OA」的架構（21 家活躍店裡已有 14 家
+-- 填了 stores.line_oa_basic_id，各自不同）。所以推播憑證天生是 per-store 的，
+-- 不可能用單一組全域 token —— 對 A 店的好友，只有 A 店的 channel 推得到。
+-- 對齊 docs/PRD-通知模組.md §6.10「LINE OA 憑證管理」。
+--
+-- ⚠ 為什麼另開一張表，而不是加欄位在 stores：
+--   channel_secret 是密鑰。RLS 是 **row-level 不是 column-level**，只要它在
+--   stores 上，任何能讀 stores 的店員都能用 PostgREST 直接 `select=*` 撈走。
+--   所以放獨立表 + 不給任何 policy（= 前端一律讀不到），只有 service_role
+--   （edge function）bypass RLS 讀得到。
+--
+-- 寫入走 rpc_set_store_line_oa（SECURITY DEFINER + owner/admin gate），
+-- 讀狀態走 rpc_get_store_line_oa_status（**只回 channel_id，永不回 secret**）。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS store_line_oa_credentials (
+  store_id                BIGINT      PRIMARY KEY REFERENCES stores(id) ON DELETE CASCADE,
+  tenant_id               UUID        NOT NULL,
+  channel_id              TEXT        NOT NULL,
+  channel_secret          TEXT        NOT NULL,
+  -- 用 channel_id + secret 跟 LINE 換來的 token（client_credentials，約 30 天）。
+  -- 快取在這裡，避免每次發訊息都多打一次 LINE 的 oauth 端點。
+  access_token            TEXT,
+  access_token_expires_at TIMESTAMPTZ,
+  updated_by              UUID,
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE  store_line_oa_credentials IS
+  '每分店的 LINE Messaging API 憑證。含密鑰，前端一律讀不到（無 RLS policy），只有 service_role 讀得到';
+COMMENT ON COLUMN store_line_oa_credentials.channel_secret IS
+  '密鑰 —— 不可經任何 RPC / view 回傳給前端';
+COMMENT ON COLUMN store_line_oa_credentials.access_token IS
+  'client_credentials 換來的 channel access token 快取；改憑證時會清空強制重換';
+
+-- ── RLS：故意「一條 policy 都不給」= authenticated / anon 讀寫都是零列 ─────
+-- service_role 走 bypass，不受影響。
+ALTER TABLE store_line_oa_credentials ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON store_line_oa_credentials FROM anon, authenticated;
+
+-- ── 寫入：owner / admin 才可以設定分店憑證 ──────────────────────────────────
+CREATE OR REPLACE FUNCTION public.rpc_set_store_line_oa(
+  p_store_id       BIGINT,
+  p_channel_id     TEXT,
+  p_channel_secret TEXT
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_role   TEXT := COALESCE(auth.jwt() ->> 'role', '');
+  v_cid    TEXT := NULLIF(btrim(COALESCE(p_channel_id, '')), '');
+  v_sec    TEXT := NULLIF(btrim(COALESCE(p_channel_secret, '')), '');
+BEGIN
+  -- '' = 沒有顯式 role 的 legacy/dev admin，對齊 apps/admin/src/lib/role.ts 的 ADMIN_ROLES
+  IF v_role NOT IN ('owner', 'admin', '') THEN
+    RAISE EXCEPTION 'insufficient_role: 只有負責人 / 管理員可以設定 LINE 憑證';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM stores WHERE id = p_store_id AND tenant_id = v_tenant
+  ) THEN
+    RAISE EXCEPTION 'store_not_found';
+  END IF;
+
+  -- 兩個都給空 = 清除設定（該店改回沒有自己的推播憑證）
+  IF v_cid IS NULL AND v_sec IS NULL THEN
+    DELETE FROM store_line_oa_credentials WHERE store_id = p_store_id;
+    RETURN;
+  END IF;
+
+  IF v_cid IS NULL OR v_sec IS NULL THEN
+    RAISE EXCEPTION 'channel_id 與 channel_secret 必須一起提供';
+  END IF;
+
+  INSERT INTO store_line_oa_credentials AS c
+    (store_id, tenant_id, channel_id, channel_secret, updated_by, updated_at)
+  VALUES (p_store_id, v_tenant, v_cid, v_sec, auth.uid(), NOW())
+  ON CONFLICT (store_id) DO UPDATE SET
+    channel_id     = EXCLUDED.channel_id,
+    channel_secret = EXCLUDED.channel_secret,
+    -- 憑證換了，舊 token 一定要作廢，否則會繼續拿舊 OA 的 token 發訊息
+    access_token            = NULL,
+    access_token_expires_at = NULL,
+    updated_by     = EXCLUDED.updated_by,
+    updated_at     = NOW();
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_set_store_line_oa(BIGINT, TEXT, TEXT) IS
+  '設定分店 LINE Messaging API 憑證（owner/admin）。兩個參數都傳空字串 = 清除';
+
+-- ── 讀狀態：只回「有沒有設定 + channel_id」，永遠不回 secret ────────────────
+-- channel_id 等同 OAuth 的 client_id，不是密鑰，回給前端可以讓管理員確認接對帳號。
+CREATE OR REPLACE FUNCTION public.rpc_get_store_line_oa_status()
+RETURNS TABLE (
+  store_id   BIGINT,
+  channel_id TEXT,
+  updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_role   TEXT := COALESCE(auth.jwt() ->> 'role', '');
+BEGIN
+  IF v_role NOT IN ('owner', 'admin', '') THEN
+    RAISE EXCEPTION 'insufficient_role';
+  END IF;
+
+  RETURN QUERY
+    SELECT c.store_id, c.channel_id, c.updated_at
+      FROM store_line_oa_credentials c
+     WHERE c.tenant_id = v_tenant;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_get_store_line_oa_status() IS
+  '列出本租戶已設定 LINE 憑證的分店（只回 channel_id，不回 secret）';
+
+REVOKE ALL ON FUNCTION public.rpc_set_store_line_oa(BIGINT, TEXT, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_get_store_line_oa_status() FROM anon;


### PR DESCRIPTION
接續 #638。#638 讓 admin 可以對會員發 LINE 訊息，但憑證來源是**單一組全域 env token**，這在本租戶的架構下不成立。

## 為什麼要 per-store

這個租戶是「每加盟店各自申請 LINE OA」的架構 —— 21 家活躍分店裡已有 14 家填了各自不同的 `stores.line_oa_basic_id`（平鎮店 `@701ktmdh`、松山店 `@200uoqkp`、中和店 `@bao666`…）。

LINE 的好友關係綁在單一官方帳號上，**拿 B 店的 token 去推 A 店的好友一定失敗**，所以推播憑證天生是 per-store 的。對齊 `docs/PRD-通知模組.md` §6.10「LINE OA 憑證管理」。

## 改了什麼

**DB**（`20260807000030_store_line_oa_credentials.sql`）
- 新表 `store_line_oa_credentials`（channel_id / channel_secret / access_token 快取）
- `rpc_set_store_line_oa`（owner/admin gate，兩個參數都給空 = 清除）
- `rpc_get_store_line_oa_status`（**只回 channel_id，永不回 secret**）

**Admin UI**
- 分店表單新增「LINE 推播憑證」區塊（`StoreLineOaField`，僅 owner/admin 可見）
- 未設定 / 已設定狀態一目瞭然；secret 欄位為 `type=password`

**Edge function `admin-line-push`**
- 依會員 `home_store_id` 取該店憑證，用 `client_credentials` 換 access token 並快取到期前 5 分鐘
- 換憑證時清掉舊 token，避免繼續用舊帳號發訊息
- 取用順序：分店憑證 → env token（退路，給單一 OA 的租戶與過渡期）→ 503 `not_configured`

## 安全性：為什麼 secret 另開一張表

**RLS 是 row-level 不是 column-level。** 只要 `channel_secret` 放在 `stores` 上，任何能讀 `stores` 的店員都能繞過畫面、直接用 PostgREST `select=*` 撈走。

所以改用獨立表 + **零 policy** + `REVOKE ALL FROM anon, authenticated`，只有 service_role（edge function）讀得到。管理員填進去之後也無法再讀出來，要換只能整組重填 —— 這是刻意的。

已用 anon key 對線上實測：

```
$ curl "$SUPABASE_URL/rest/v1/store_line_oa_credentials?select=*" -H "apikey: <anon>"
{"code":"42501","message":"permission denied for table store_line_oa_credentials"}
```

## 驗證

- migration 已套用到線上；確認 `rls_on=true` / `policies=0` / anon 與 authenticated 無任何 table grant
- 兩支 RPC 存在
- typecheck + ESLint 乾淨（`stores/page.tsx` 既有的 2 個 `set-state-in-effect` error 非本 PR 造成，改動前即存在）
- Playwright（fixture，不碰線上 DB）：憑證區塊渲染、未設定提示、空白時儲存鈕 disabled、secret 為 password type、儲存呼叫 `rpc_set_store_line_oa` 且參數正確
- 會員 LINE modal 回歸測試同樣通過

## 待辦（不在本 PR）

各分店的 Channel ID / Secret 需要管理員實際填入才會生效。填之前該店的會員仍會看到「尚未設定」。