### PR TITLE
fix(stores): LINE 憑證 RPC 的 role 判斷改讀 app_metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,33 @@ grep -rn "<function_name>" supabase/migrations/
 把每一個動過該 function 的 migration 都讀過，基於**時間最新**那個版本擴寫，確保所有 prior fix 都保留。
 新 migration 檔頭註解務必列出「以哪個版本為基底」、「rollback 指回哪個版本」。
 
+### SQL 裡讀「應用角色」一律走 app_metadata，不要用頂層 role claim
+
+```sql
+COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')   -- ✅ 應用角色
+auth.jwt() ->> 'role'                                   -- ❌ 永遠是 'authenticated'
+```
+
+頂層 `role` 是 **Postgres 角色**，登入使用者一律是 `'authenticated'`。
+`custom_access_token_hook` 只把 `tenant_id` 拉到頂層，**role 沒有拉**。
+寫錯的症狀是「真正的 owner / admin 也被擋掉」，回 `insufficient_role` —— 看起來
+像權限設定壞了，其實是這一行。
+
+這個坑踩過至少兩次（`20260502010000_fix_purchase_rls_role_path.sql` 修 RLS、
+`20260807000040_fix_store_line_oa_role_path.sql` 修 RPC）。注意 `_current_tenant_id()`
+用頂層 `auth.jwt() ->> 'tenant_id'` 是**對的**（hook 有拉），別一起改掉。
+
+允許清單要對齊 `apps/admin/src/lib/role.ts`：管理員層級是 `('owner','admin','')`，
+`''` 是沒有顯式 role 的 legacy/dev admin，漏掉它會把舊帳號全擋在外面。
+
+驗證不用真的登入，直接灌 claims 進去打：
+
+```sql
+SELECT set_config('request.jwt.claims',
+  '{"tenant_id":"<uuid>","app_metadata":{"tenant_id":"<uuid>","role":"admin"}}', true);
+SELECT * FROM <your_rpc>();   -- 換成 store_staff 再跑一次，應該要被擋
+```
+
 ---
 
 ## LINE / LIFF

--- a/supabase/migrations/20260807000040_fix_store_line_oa_role_path.sql
+++ b/supabase/migrations/20260807000040_fix_store_line_oa_role_path.sql
@@ -1,0 +1,92 @@
+-- ============================================================================
+-- 2026-08-07: 修正 store_line_oa RPC 的 role 讀取路徑
+--
+-- Bug：20260807000030 用 `auth.jwt() ->> 'role'` 判斷角色。那個 claim 是
+-- **Postgres 角色**（永遠是 'authenticated'），不是應用角色 —— 結果真正的
+-- owner / admin 也被擋，畫面上出現：
+--   insufficient_role: 只有負責人 / 管理員可以設定 LINE 憑證
+--
+-- 應用角色在 `auth.jwt() -> 'app_metadata' ->> 'role'`
+-- （custom_access_token_hook 只把 tenant_id 拉到頂層，role 沒有拉）。
+-- 這個坑本 repo 已經踩過一次，見 20260502010000_fix_purchase_rls_role_path.sql。
+--
+-- 基底版本：20260807000030_store_line_oa_credentials.sql
+--           （已 grep supabase/migrations/ 確認：那是唯一動過這兩支函式的
+--             migration，本檔只改 role 判斷，其餘邏輯一字未改）
+--
+-- Rollback：重跑 20260807000030 的兩支 CREATE OR REPLACE FUNCTION。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_set_store_line_oa(
+  p_store_id       BIGINT,
+  p_channel_id     TEXT,
+  p_channel_secret TEXT
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  -- ⚠ 一定要走 app_metadata；頂層 'role' 是 Postgres 角色，不是應用角色
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_cid    TEXT := NULLIF(btrim(COALESCE(p_channel_id, '')), '');
+  v_sec    TEXT := NULLIF(btrim(COALESCE(p_channel_secret, '')), '');
+BEGIN
+  -- '' = 沒有顯式 role 的 legacy/dev admin，對齊 apps/admin/src/lib/role.ts 的 ADMIN_ROLES
+  IF v_role NOT IN ('owner', 'admin', '') THEN
+    RAISE EXCEPTION 'insufficient_role: 只有負責人 / 管理員可以設定 LINE 憑證';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM stores WHERE id = p_store_id AND tenant_id = v_tenant
+  ) THEN
+    RAISE EXCEPTION 'store_not_found';
+  END IF;
+
+  -- 兩個都給空 = 清除設定（該店改回沒有自己的推播憑證）
+  IF v_cid IS NULL AND v_sec IS NULL THEN
+    DELETE FROM store_line_oa_credentials WHERE store_id = p_store_id;
+    RETURN;
+  END IF;
+
+  IF v_cid IS NULL OR v_sec IS NULL THEN
+    RAISE EXCEPTION 'channel_id 與 channel_secret 必須一起提供';
+  END IF;
+
+  INSERT INTO store_line_oa_credentials AS c
+    (store_id, tenant_id, channel_id, channel_secret, updated_by, updated_at)
+  VALUES (p_store_id, v_tenant, v_cid, v_sec, auth.uid(), NOW())
+  ON CONFLICT (store_id) DO UPDATE SET
+    channel_id     = EXCLUDED.channel_id,
+    channel_secret = EXCLUDED.channel_secret,
+    -- 憑證換了，舊 token 一定要作廢，否則會繼續拿舊 OA 的 token 發訊息
+    access_token            = NULL,
+    access_token_expires_at = NULL,
+    updated_by     = EXCLUDED.updated_by,
+    updated_at     = NOW();
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.rpc_get_store_line_oa_status()
+RETURNS TABLE (
+  store_id   BIGINT,
+  channel_id TEXT,
+  updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+BEGIN
+  IF v_role NOT IN ('owner', 'admin', '') THEN
+    RAISE EXCEPTION 'insufficient_role';
+  END IF;
+
+  RETURN QUERY
+    SELECT c.store_id, c.channel_id, c.updated_at
+      FROM store_line_oa_credentials c
+     WHERE c.tenant_id = v_tenant;
+END;
+$$;


### PR DESCRIPTION
修 #641 引入的 bug：真正的 owner / admin 也被擋在外面，無法設定分店 LINE 憑證。

## 症狀

在分店設定頁填好 Channel ID / Secret 按儲存，即使登入帳號是 admin 也會出現：

```
insufficient_role: 只有負責人 / 管理員可以設定 LINE 憑證
```

## 原因

`20260807000030` 用 `auth.jwt() ->> 'role'` 判斷角色。**那個 claim 是 Postgres 角色**，任何登入使用者一律是 `'authenticated'`，永遠不會等於 `owner` / `admin`，所以閘門對誰都關著。

應用角色其實在 `auth.jwt() -> 'app_metadata' ->> 'role'` —— `custom_access_token_hook` 只把 `tenant_id` 拉到頂層，**role 沒有拉**。

```sql
COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')   -- ✅ 應用角色
auth.jwt() ->> 'role'                                   -- ❌ 永遠是 'authenticated'
```

## 改了什麼

- `20260807000040_fix_store_line_oa_role_path.sql`：`rpc_set_store_line_oa` 與 `rpc_get_store_line_oa_status` 兩支的 role 判斷改走 `app_metadata`。以 `20260807000030` 為基底，**只改這一行判斷，其餘邏輯一字未動**。
- `CLAUDE.md` 新增一條規則（見下）。

注意 `_current_tenant_id()` 用頂層 `auth.jwt() ->> 'tenant_id'` 是**對的**（hook 有拉），沒有一起改。

## 驗證

不用真的登入，直接灌 `request.jwt.claims` 模擬各種角色打 RPC：

| 模擬角色 | 預期 | 實測 |
|---|---|---|
| `admin` | 通過 | 讀狀態成功、寫入憑證成功 |
| `store_staff` | 擋下 | `ERROR: P0001: insufficient_role` |

寫入測試用假憑證（`TESTID`），跑完已刪除，`store_line_oa_credentials` 目前 0 筆。

migration 已套用到線上。

## 為什麼順手改 CLAUDE.md

這個坑本 repo **已經踩過一次** —— `20260502010000_fix_purchase_rls_role_path.sql`，標題就叫「修正 RLS：role 應從 app_metadata 讀」。我沒先查就重犯了同一個錯，所以把規則寫進 CLAUDE.md（含「怎麼灌 claims 驗證」的指令），避免第三次。

---
_Generated by [Claude Code](https://claude.ai/code/session_01B51QThXsMUzMwjyAqrHYVi)_