### PR TITLE
feat(line): 登入用 LIFF ID 改為每分店可設定，並補上憑證存檔即驗證

### DIFF
--- a/apps/admin/src/app/(protected)/stores/page.tsx
+++ b/apps/admin/src/app/(protected)/stores/page.tsx
@@ -29,6 +29,7 @@ type Store = {
   is_active: boolean;
   notes: string | null;
   line_oa_basic_id: string | null;
+  line_liff_id: string | null;
   updated_at: string;
   deleted_at: string | null;
 };
@@ -46,6 +47,7 @@ const EMPTY: Omit<Store, "id" | "updated_at" | "deleted_at"> = {
   is_active: true,
   notes: null,
   line_oa_basic_id: null,
+  line_liff_id: null,
 };
 
 type ActiveFilter = "active" | "all" | "deleted";
@@ -90,7 +92,7 @@ export default function StoresPage() {
   async function reload() {
     let q = getSupabase()
       .from("stores")
-      .select("id, code, name, location_id, pickup_window_days, allowed_payment_methods, is_active, notes, line_oa_basic_id, updated_at, deleted_at")
+      .select("id, code, name, location_id, pickup_window_days, allowed_payment_methods, is_active, notes, line_oa_basic_id, line_liff_id, updated_at, deleted_at")
       .order("updated_at", { ascending: false })
       .limit(500);
     if (query.trim()) {
@@ -517,7 +519,7 @@ function StoreForm({
           </span>
         </F>
 
-        <StoreLineOaField storeId={v.id} />
+        <StoreLineOaField storeId={v.id} liffId={v.line_liff_id} />
 
         <F label="備註" className="sm:col-span-4">
           <textarea

--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -121,7 +121,12 @@ export function LineMessageModal({
         } else if (result.error === "not_configured") {
           setReachable({ state: "not_configured", message: result.message });
         } else {
-          setReachable({ state: "error", message: result.message || result.error || `HTTP ${status}` });
+          // detail 一定要帶上：只顯示 error code（line_api_error）等於沒說，
+          // 之前就是因為這樣得回資料庫撈 line_push_logs 才知道真正原因
+          setReachable({
+            state: "error",
+            message: result.message || result.detail || result.error || `HTTP ${status}`,
+          });
         }
       } catch (e) {
         if (!cancelled) setReachable({ state: "error", message: e instanceof Error ? e.message : String(e) });
@@ -219,6 +224,8 @@ export function LineMessageModal({
       } else {
         const parts = [result.message || result.error || `HTTP ${status}`];
         if (result.hint) parts.push(result.hint);
+        // 後端沒能翻譯的錯誤，至少要把 LINE 的原文露出來
+        if (result.detail && !result.message) parts.push(String(result.detail));
         setError(parts.join("\n"));
       }
     } catch (e) {

--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -292,6 +292,14 @@ export function LineMessageModal({
             <p className="mt-1 text-[11px] text-zinc-500">
               後台聊天<strong className="font-semibold">不吃推播額度</strong>，但需另外登入 LINE 官方帳號後台。
             </p>
+            {/* 聊天室網址也是用同一組 line_user_id 組的：profile 查不到（provider
+                不一致）時，這條連結一樣會開到不存在的對話，不能讓它看起來可用 */}
+            {reachable.state === "unreachable" && (
+              <p className="mt-1 text-[11px] text-amber-700 dark:text-amber-400">
+                ⚠ 此會員的 LINE ID 在這支官方帳號查不到，這條連結可能開不到正確的對話 —
+                請改用官方帳號後台自行搜尋該顧客。
+              </p>
+            )}
             {chat.mode === "bot" && (
               <p className="mt-1 text-[11px] text-amber-700 dark:text-amber-400">
                 ⚠ 此官方帳號目前是「Bot 模式」，後台聊天已關閉 —

--- a/apps/admin/src/components/StoreLineOaField.tsx
+++ b/apps/admin/src/components/StoreLineOaField.tsx
@@ -61,7 +61,27 @@ export function StoreLineOaField({ storeId }: { storeId: number | null }) {
       setChannelId("");
       setChannelSecret("");
       setStatus(clear ? null : { channel_id: channelId.trim(), updated_at: new Date().toISOString() });
-      setMsg(clear ? "已清除此分店的 LINE 憑證" : "已儲存（下次發送就會用這組憑證）");
+      if (clear) {
+        setMsg("已清除此分店的 LINE 憑證");
+        return;
+      }
+
+      // 存起來不代表能用：Login channel 的憑證一樣換得到 token，
+      // 要打一支 Messaging API 端點才知道。現在就驗，不要等到發訊息才炸。
+      setMsg("已儲存，驗證中…");
+      const { data: { session } } = await getSupabase().auth.getSession();
+      const resp = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/admin-line-push`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Authorization": `Bearer ${session?.access_token}` },
+        body: JSON.stringify({ action: "verify_store", store_id: storeId }),
+      });
+      const result = await resp.json().catch(() => ({}));
+      if (result.ok) {
+        setMsg(`✓ 驗證通過 — 已接上官方帳號「${result.display_name ?? "?"}」${result.basic_id ?? ""}`);
+      } else {
+        setMsg(null);
+        setErr(result.message || result.detail || result.error || `驗證失敗（HTTP ${resp.status}）`);
+      }
     } finally {
       setSaving(false);
     }

--- a/apps/admin/src/components/StoreLineOaField.tsx
+++ b/apps/admin/src/components/StoreLineOaField.tsx
@@ -17,7 +17,9 @@ import SpinButton from "@/components/SpinButton";
 
 type Status = { channel_id: string; updated_at: string } | null;
 
-export function StoreLineOaField({ storeId }: { storeId: number | null }) {
+export function StoreLineOaField({
+  storeId, liffId = null,
+}: { storeId: number | null; liffId?: string | null }) {
   const role = useRole();
   const [status, setStatus] = useState<Status>(null);
   const [loaded, setLoaded] = useState(false);
@@ -168,7 +170,78 @@ export function StoreLineOaField({ storeId }: { storeId: number | null }) {
           <p className="mt-1 text-[11px] text-zinc-500">
             基於安全，secret 存進去後無法再讀出來（要換只能重填整組）。
           </p>
+
+          <StoreLiffField storeId={storeId} initial={liffId} />
         </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * 該店登入用的 LIFF ID。
+ *
+ * 為什麼要分店設定：LINE 的 user ID 綁 Provider。各店 OA 在自己的 Provider 底下，
+ * 會員必須用「所屬分店那支 Login channel 的 LIFF」登入，取得的 line_user_id
+ * 才跟該店 OA 通用 —— 否則存進資料庫也推不動（2026-08-07 實測：取樣 12 位
+ * 松山店會員，用舊 ID 查該店 OA 的 profile 全部 404）。
+ *
+ * 留空 = 退回會員站的 NEXT_PUBLIC_LIFF_ID（租戶預設）。
+ */
+function StoreLiffField({ storeId, initial }: { storeId: number; initial: string | null }) {
+  const [value, setValue] = useState(initial ?? "");
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const dirty = value.trim() !== (initial ?? "");
+
+  async function save() {
+    setSaving(true);
+    setErr(null);
+    setMsg(null);
+    try {
+      const { error } = await getSupabase().rpc("rpc_set_store_line_liff", {
+        p_store_id: storeId,
+        p_liff_id: value.trim(),
+      });
+      if (error) { setErr(translateRpcError(error)); return; }
+      setMsg(value.trim() ? "已儲存（該店會員下次登入就會用這支 LIFF）" : "已清除，改用租戶預設 LIFF");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mt-3 border-t border-zinc-200 pt-3 dark:border-zinc-700">
+      <div className="mb-1 text-xs font-medium text-zinc-700 dark:text-zinc-300">
+        登入用 LIFF ID
+      </div>
+      <p className="mb-2 text-[11px] text-zinc-500">
+        這家店 Provider 底下的 LINE Login channel 所建的 LIFF app ID。會員要用這支登入，
+        取得的身分才跟本店官方帳號相通、收得到推播。留空 = 用預設。
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="2001234567-AbCdEfGh"
+          autoComplete="off"
+          className="min-w-[220px] flex-1 rounded-md border border-zinc-300 bg-white px-2 py-1.5 font-mono text-xs dark:border-zinc-700 dark:bg-zinc-900"
+        />
+        {dirty && (
+          <SpinButton
+            onClick={save}
+            disabled={saving}
+            className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {saving ? "儲存中…" : "💾 儲存"}
+          </SpinButton>
+        )}
+      </div>
+      {(msg || err) && (
+        <div className={`mt-1 text-[11px] ${err ? "text-red-700 dark:text-red-400" : "text-emerald-700 dark:text-emerald-400"}`}>
+          {err ?? msg}
+        </div>
       )}
     </div>
   );

--- a/apps/member/src/lib/storeLiff.ts
+++ b/apps/member/src/lib/storeLiff.ts
@@ -1,0 +1,88 @@
+/**
+ * 「這家店該用哪支 LIFF 登入」的查表。
+ *
+ * 為什麼要分店查表：LINE 的 user ID 是**綁 Provider** 的。本租戶 14 家店的
+ * 官方帳號各自在自己的 Provider 底下，會員必須用「所屬分店那支 Login channel
+ * 的 LIFF」登入，拿到的 line_user_id 才跟該店 OA 通用 —— 用錯的 LIFF 登入，
+ * ID 存進資料庫也推不動訊息（2026-08-07 實測：取樣 12 位松山店會員，
+ * 用舊 ID 查該店 OA 的 profile 全數 404）。
+ *
+ * 沒設定該店 LIFF ID 時退回 `NEXT_PUBLIC_LIFF_ID`（租戶層預設），
+ * 也就是維持這個欄位出現之前的行為，不會讓既有的店突然登不進去。
+ *
+ * ⚠ 快取存在 localStorage 是**必要的**，不是效能優化：
+ *   在 LINE 內冷啟動時，`liff.init()` 必須用「當初開啟這個 app 的那支 LIFF ID」，
+ *   而那時門市清單還沒抓回來。有快取才不會退回錯的預設值。
+ */
+
+import { callLiffApi } from "./supabase";
+
+const CACHE_KEY = "store_liff_ids";
+
+export type StoreLiffMap = Record<string, string>;  // store code → liff id
+
+function envLiffId(): string | undefined {
+  return process.env.NEXT_PUBLIC_LIFF_ID || undefined;
+}
+
+function readCache(): StoreLiffMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    return raw ? (JSON.parse(raw) as StoreLiffMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** 門市清單載回來時呼叫，把 code → liff id 的對照存起來 */
+export function cacheStoreLiffIds(
+  stores: { code: string; line_liff_id?: string | null }[],
+): void {
+  if (typeof window === "undefined") return;
+  const map: StoreLiffMap = {};
+  for (const s of stores) {
+    if (s.code && s.line_liff_id) map[s.code] = s.line_liff_id;
+  }
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(map));
+  } catch { /* 隱私模式寫不進去就算了，退回預設值仍可運作 */ }
+}
+
+/** 只讀快取，不發網路請求。給 render / callback 這種不能 await 的地方用。 */
+export function resolveLiffIdSync(storeCode: string | null): string | undefined {
+  if (!storeCode) return envLiffId();
+  return readCache()[storeCode] ?? envLiffId();
+}
+
+/**
+ * 解析該店的 LIFF ID；快取沒有就抓一次門市清單。
+ *
+ * 抓清單有 timeout —— 這條路擋在 `liff.init()` 前面，網路慢的話不能把整個
+ * 登入流程押在它身上（對齊 useLineLogin 裡 liff.init 也包 timeout 的做法）。
+ */
+export async function resolveLiffId(
+  storeCode: string | null,
+  timeoutMs = 3000,
+): Promise<string | undefined> {
+  if (!storeCode) return envLiffId();
+
+  const cached = readCache()[storeCode];
+  if (cached) return cached;
+
+  try {
+    const r = await Promise.race([
+      callLiffApi<{ stores: { code: string; line_liff_id?: string | null }[] }>(
+        "", { action: "list_stores" },
+      ),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("list_stores timeout")), timeoutMs),
+      ),
+    ]);
+    cacheStoreLiffIds(r.stores ?? []);
+    return readCache()[storeCode] ?? envLiffId();
+  } catch {
+    // 抓不到就用預設值 —— 跟這個功能出現之前的行為一致
+    return envLiffId();
+  }
+}

--- a/apps/member/src/lib/useLineLogin.ts
+++ b/apps/member/src/lib/useLineLogin.ts
@@ -11,6 +11,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { loadLiff } from "@/lib/liff";
+import { cacheStoreLiffIds, resolveLiffId, resolveLiffIdSync } from "@/lib/storeLiff";
 import { callLiffApi, lineOauthStartUrl } from "@/lib/supabase";
 import { clearSession, getSession, listenForSession } from "@/lib/session";
 import {
@@ -47,7 +48,13 @@ export type LoginStatus =
   | "pair_done"
   | "pwa_waiting";
 
-export type StoreOption = { id: number; code: string; name: string };
+export type StoreOption = {
+  id: number;
+  code: string;
+  name: string;
+  /** 該店 Provider 底下的 LIFF ID；沒設就退回 NEXT_PUBLIC_LIFF_ID */
+  line_liff_id?: string | null;
+};
 
 export type UseLineLoginOptions = {
   /**
@@ -139,7 +146,11 @@ export function useLineLogin(options: UseLineLoginOptions = {}): UseLineLogin {
 
     // 抓門市清單給下拉選用(免 token,公開資訊)
     callLiffApi<{ stores: StoreOption[] }>("", { action: "list_stores" })
-      .then((r) => setStores(r.stores ?? []))
+      .then((r) => {
+        setStores(r.stores ?? []);
+        // 存起來給下次冷啟動用：LINE 內 liff.init() 跑在清單抓回來之前
+        cacheStoreLiffIds(r.stores ?? []);
+      })
       .catch((e) => {
         // 跳頁把這個 fetch 取消掉不算故障（Safari 回 "Load failed"），記了只是雜訊
         if (isPageUnloading()) return;
@@ -176,8 +187,6 @@ export function useLineLogin(options: UseLineLoginOptions = {}): UseLineLogin {
         setError(errInUrl);
       }
 
-      const liffId = process.env.NEXT_PUBLIC_LIFF_ID;
-
       // 一進頁面就把配對碼備份起來 —— 必須趕在 liff.login() 把 URL 上的
       // liff.state 換成 ?code=... 之前，否則這趟 PWA 配對就再也接不回去了
       resolvePairCode();
@@ -196,6 +205,14 @@ export function useLineLogin(options: UseLineLoginOptions = {}): UseLineLogin {
         setPickedStore(s);
         localStorage.setItem("last_store_id", s);
       }
+
+      // 用「這家店」的 LIFF 登入，不是租戶預設的那支。
+      //
+      // LINE 的 user ID 綁 Provider：14 家店的官方帳號各在自己的 Provider，
+      // 用錯的 LIFF 登入，拿到的 line_user_id 對該店 OA 是查不到的（推播必失敗）。
+      // 這行必須排在讀門市之後、liff.init() 之前 —— 順序不能動。
+      // 該店沒設就退回 NEXT_PUBLIC_LIFF_ID，等於維持這個欄位出現前的行為。
+      const liffId = await resolveLiffId(s);
 
       // LIFF 初始化
       if (liffId) {
@@ -359,7 +376,9 @@ export function useLineLogin(options: UseLineLoginOptions = {}): UseLineLogin {
   const start = useCallback(() => {
     if (!storeId) return;
 
-    const liffId = process.env.NEXT_PUBLIC_LIFF_ID;
+    // 同上：用該店的 LIFF。走到這裡門市清單早就載完、快取是熱的，
+    // 所以讀快取版本就夠（這是 callback，不能 await）。
+    const liffId = resolveLiffIdSync(storeId);
 
     if (standalone) {
       // 點下登入 = 明確要重新登,清掉所有舊 session 避免「看到舊 token 就跳 /me」

--- a/supabase/functions/admin-line-push/index.ts
+++ b/supabase/functions/admin-line-push/index.ts
@@ -12,6 +12,8 @@
 //           推播」（push/broadcast/群發），OA 後台 1:1 聊天不吃額度 —
 //           後台數字跟這裡對不上時，先想這件事。
 //   links — 訊息樣板要用的會員站連結（不需要 LINE token）。
+//   verify_store — 存完分店憑證後立刻驗一次（打 /v2/bot/info）。換 token 成功
+//           不代表能用（Login channel 也換得到），這支才是真正的分水嶺。
 //   send  — push 文字和/或圖片。圖片 URL 限定自家 line-media bucket，
 //           防止拿這支函式對會員推任意外部圖。
 //
@@ -48,6 +50,30 @@ function json(body: unknown, status = 200) {
     status,
     headers: { ...corsHeaders, "Content-Type": "application/json" },
   });
+}
+
+/**
+ * 把 LINE 的錯誤翻成「店員看得懂、而且知道下一步」的話。
+ *
+ * 最容易踩的是拿 **LINE Login channel** 的 Channel ID / Secret 來設定 ——
+ * 那組 client_credentials **換得到 token**（所以設定當下不會報錯），但拿去打
+ * Messaging API 一律回 "Access to this API is not available for your account"。
+ * 辨識法：Login channel 底下才掛得了 LIFF app，所以「Channel ID 跟 LIFF ID
+ * 前綴同號」= 那是 Login channel，不是 Messaging API channel。
+ */
+function explainLineError(status: number, detail: string): string | undefined {
+  if (/not available for your account/i.test(detail)) {
+    return "這組憑證不能用 Messaging API —— 多半是填成了「LINE Login channel」的 Channel ID / Secret。"
+      + "請改用該官方帳號的「Messaging API channel」憑證"
+      + "（官方帳號管理後台 → 設定 → Messaging API；若沒看到就是還沒啟用）。";
+  }
+  if (status === 401) {
+    return "LINE 拒絕這組憑證（401）。Channel ID / Secret 可能填錯或已重新產生，請重新確認後再存一次。";
+  }
+  if (status === 429) {
+    return "已達 LINE 的發送上限（429）。額度每月 1 號重置；官方帳號後台的 1:1 聊天不吃額度，可先走那條。";
+  }
+  return undefined;
 }
 
 type OaResolved =
@@ -160,6 +186,7 @@ Deno.serve(async (req) => {
     const action = body.action === "check" ? "check"
       : body.action === "quota" ? "quota"
       : body.action === "links" ? "links"
+      : body.action === "verify_store" ? "verify_store"
       : "send";
 
     // ── links：訊息樣板要用的會員站連結（刻意放在 LINE token 檢查之前）──────
@@ -179,6 +206,45 @@ Deno.serve(async (req) => {
         ok: true,
         orders_url: usable ? `${base}/orders` : null,
         message: usable ? undefined : "MEMBER_FRONT_BASE_URL 未設定或不是 https 網址，樣板連結無法產生",
+      });
+    }
+
+    // ── verify_store：分店憑證存檔後立刻驗一次 ──────────────────────────────
+    // 為什麼需要：client_credentials 換 token 這一步，**拿 LINE Login channel
+    // 的憑證也會成功**，所以「存檔沒報錯」完全不代表能用。真正的分水嶺是打
+    // 一支 Messaging API 端點（/v2/bot/info）看回不回 403。不在這裡驗的話，
+    // 錯誤要等到店員實際要發訊息給客人時才爆出來。
+    if (action === "verify_store") {
+      const role = user.app_metadata?.role ?? "";
+      if (!["owner", "admin", ""].includes(role)) {
+        return json({ error: "insufficient_role" }, 403);
+      }
+      const storeId = Number(body.store_id);
+      if (!storeId) return json({ error: "store_id is required" }, 400);
+
+      const res = await resolveOaToken(sb, tenantId, storeId);
+      if ("error" in res) return json(res.error, res.status);
+      if (res.source !== "store") {
+        return json({ error: "no_store_credentials", message: "這家店還沒有自己的憑證" }, 400);
+      }
+
+      const infoResp = await fetch(LINE_BOT_INFO_URL, {
+        headers: { "Authorization": `Bearer ${res.token}` },
+      });
+      if (!infoResp.ok) {
+        const detail = await infoResp.text();
+        return json({
+          error: "line_api_error",
+          message: explainLineError(infoResp.status, detail) ?? `LINE 回應 ${infoResp.status}：${detail}`,
+          detail,
+        }, 502);
+      }
+      const info = await infoResp.json();
+      return json({
+        ok: true,
+        display_name: info.displayName ?? null,
+        basic_id: info.basicId ?? null,
+        chat_mode: info.chatMode ?? null,
       });
     }
 
@@ -211,8 +277,13 @@ Deno.serve(async (req) => {
         fetch(`${LINE_QUOTA_URL}/consumption`, { headers: oaHeaders }),
       ]);
       if (!qResp.ok || !cResp.ok) {
-        const detail = `quota ${qResp.status} / consumption ${cResp.status}`;
-        return json({ error: "line_api_error", detail }, 502);
+        const bad = !qResp.ok ? qResp : cResp;
+        const detail = await bad.text();
+        return json({
+          error: "line_api_error",
+          message: explainLineError(bad.status, detail) ?? `LINE 回應 ${bad.status}：${detail}`,
+          detail,
+        }, 502);
       }
       const q = await qResp.json();
       const c = await cResp.json();
@@ -259,10 +330,12 @@ Deno.serve(async (req) => {
           chat_url: chatUrl, chat_mode: chatMode,
         });
       }
-      if (resp.status === 401) {
-        return json({ error: "bad_token", message: "LINE token 無效，請重新確認 LINE_MESSAGING_CHANNEL_ACCESS_TOKEN", detail }, 502);
-      }
-      return json({ error: "line_api_error", status: resp.status, detail }, 502);
+      return json({
+        error: "line_api_error",
+        status: resp.status,
+        message: explainLineError(resp.status, detail) ?? `LINE 回應 ${resp.status}：${detail}`,
+        detail,
+      }, 502);
     }
 
     // ── send ────────────────────────────────────────────────────────────────
@@ -307,11 +380,13 @@ Deno.serve(async (req) => {
     if (logErr) console.error("line_push_logs insert failed:", logErr.message);
 
     if (!ok) {
+      const explained = explainLineError(resp.status, respText ?? "");
       // 400 幾乎都是「推不到這個人」：沒加好友 / 封鎖 / provider 不一致
-      const hint = resp.status === 400
-        ? "會員可能尚未加入官方帳號好友、已封鎖、或此 LINE ID 不屬於這支官方帳號"
-        : undefined;
-      return json({ error: "line_push_failed", status: resp.status, detail: respText, hint }, 502);
+      const message = explained
+        ?? (resp.status === 400
+          ? "發送失敗：會員可能尚未加入官方帳號好友、已封鎖、或此 LINE ID 不屬於這支官方帳號"
+          : `LINE 回應 ${resp.status}：${respText}`);
+      return json({ error: "line_push_failed", status: resp.status, message, detail: respText }, 502);
     }
     return json({ ok: true, member_name: member.name ?? null });
   } catch (e) {

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -72,9 +72,12 @@ function resolveSpotImages(
 // ─── actions ─────────────────────────────────────────────────────────────────
 
 async function listStores(sb: any, tenantId: string) {
+  // line_liff_id：每家店在自己 Provider 底下的 LIFF ID。會員必須用「所屬分店」
+  // 那支 LIFF 登入，拿到的 line_user_id 才跟該店官方帳號同 provider、推得動。
+  // 不是密鑰（本來就明碼在會員端 bundle），可以隨門市清單一起公開。
   const { data, error } = await sb
     .from("stores")
-    .select("id, code, name")
+    .select("id, code, name, line_liff_id")
     .eq("tenant_id", tenantId)
     .eq("is_active", true)
     .order("code", { ascending: true });

--- a/supabase/migrations/20260807000050_store_line_liff_id.sql
+++ b/supabase/migrations/20260807000050_store_line_liff_id.sql
@@ -1,0 +1,76 @@
+-- ============================================================================
+-- 2026-08-07: 每分店自己的 LIFF ID（登入用）
+--
+-- 為什麼需要：LINE 的 user ID 是**綁 Provider** 的。這個租戶 14 家店的官方帳號
+-- 各自在自己的 Provider 底下，而會員登入走的是單一支 Login channel（另一個
+-- Provider），所以 members.line_user_id 對任何一家店的 OA 都查不到。
+--
+-- 2026-08-07 實測（松山店 OA，channel 2008395869）：
+--   取樣 12 位松山店已綁 LINE 的活躍會員 → /v2/bot/profile 全部 404，0 筆成功。
+--   同一組憑證打 /v2/bot/info 回 200（帳號正確），可見不是憑證問題。
+--
+-- 解法：每家店在**自己的 Provider** 底下開一支 LINE Login channel + LIFF app，
+-- 會員依所屬分店用對應的 LIFF 登入，拿到的 ID 才跟該店 OA 通用。
+-- 這裡存那支 LIFF ID。
+--
+-- ⚠ LIFF ID **不是密鑰**（現在就明碼在會員端 bundle 的 NEXT_PUBLIC_LIFF_ID
+--   裡），所以放 stores、跟 line_oa_basic_id 並列即可，不需要像
+--   channel_secret 那樣鎖進 store_line_oa_credentials。
+--
+-- 為什麼另開 RPC 而不是擴 rpc_upsert_store：
+--   已 grep supabase/migrations/ —— rpc_upsert_store 被 20260425120000 /
+--   20260801000020 / 20260805000010 三支動過，且參數個數已經改過一次
+--   （8→9，當時必須 DROP+CREATE 才避開 overload 撞名，見 20260801000020）。
+--   為了一個獨立欄位再冒一次那個風險不划算，改用單一用途的小 RPC。
+--
+-- Rollback：
+--   DROP FUNCTION IF EXISTS public.rpc_set_store_line_liff(BIGINT, TEXT);
+--   ALTER TABLE stores DROP COLUMN IF EXISTS line_liff_id;
+-- ============================================================================
+
+ALTER TABLE stores ADD COLUMN IF NOT EXISTS line_liff_id TEXT;
+
+COMMENT ON COLUMN stores.line_liff_id IS
+  '這家店的 LINE Login channel 對應的 LIFF ID（例 2001234567-AbCdEfGh）。'
+  '會員依所屬分店用這支 LIFF 登入，取得的 line_user_id 才跟該店 OA 同 provider。'
+  '留空 = 退回 NEXT_PUBLIC_LIFF_ID（租戶層預設）';
+
+CREATE OR REPLACE FUNCTION public.rpc_set_store_line_liff(
+  p_store_id BIGINT,
+  p_liff_id  TEXT
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  -- ⚠ 應用角色一定要走 app_metadata；頂層 'role' 是 Postgres 角色
+  --   （見 CLAUDE.md、20260807000040）
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_liff   TEXT := NULLIF(btrim(COALESCE(p_liff_id, '')), '');
+BEGIN
+  IF v_role NOT IN ('owner', 'admin', '') THEN
+    RAISE EXCEPTION 'insufficient_role: 只有負責人 / 管理員可以設定 LIFF ID';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM stores WHERE id = p_store_id AND tenant_id = v_tenant
+  ) THEN
+    RAISE EXCEPTION 'store_not_found';
+  END IF;
+
+  -- 格式擋一下：LIFF ID 長得像 {channelId}-{8碼}，貼錯成 channel id 或 @basicId
+  -- 會在會員手機上才爆，那裡我們看不到，所以在寫入這關就擋掉。
+  IF v_liff IS NOT NULL AND v_liff !~ '^[0-9]{10}-[0-9a-zA-Z]{8}$' THEN
+    RAISE EXCEPTION 'invalid_liff_id: LIFF ID 格式應為 2001234567-AbCdEfGh';
+  END IF;
+
+  UPDATE stores SET line_liff_id = v_liff, updated_by = auth.uid(), updated_at = NOW()
+   WHERE id = p_store_id AND tenant_id = v_tenant;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_set_store_line_liff(BIGINT, TEXT) IS
+  '設定分店登入用的 LIFF ID（owner/admin）。傳空字串 = 清除，退回租戶預設';
+
+REVOKE ALL ON FUNCTION public.rpc_set_store_line_liff(BIGINT, TEXT) FROM anon;


### PR DESCRIPTION
接續 #641 / #642。憑證接上去之後，實際發訊息仍然失敗 —— 這支 PR 修的是那個根因，外加兩個排查過程中暴露的體驗缺陷。

## 根因：LINE user ID 綁 Provider

`members.line_user_id` 全部來自單一支 LINE Login channel（Provider A），但 14 家店的官方帳號各自在**自己的 Provider** 底下。LINE 的 user ID 是 per-provider 的，所以那些 ID 對任何一家店的 OA 都查不到。

2026-08-07 對松山店 OA（channel `2008395869`）實測：

| 檢查 | 結果 |
|---|---|
| `/v2/bot/info` | ✅ 200 — 包子媽生鮮小舖『松山店』`@200uoqkp`，chatMode `chat` |
| 取樣 12 位該店已綁 LINE 的活躍會員 → `/v2/bot/profile` | ❌ **12 筆全部 404，0 筆成功** |
| 本人確認已加該 OA 好友，再查一次 | ❌ 仍 404 |

憑證正確、好友關係也在，卻全數 404 → 確認是 provider 不一致，不是設定錯誤、也不是好友問題。

## 解法：每店一支 Login channel + LIFF

各店在自己的 Provider 底下開 LINE Login channel 與 LIFF app，會員依所屬分店用對應的 LIFF 登入，取得的 `line_user_id` 才跟該店 OA 通用。

- `stores.line_liff_id` + `rpc_set_store_line_liff`（owner/admin）
  - RPC 擋格式（`^\d{10}-\w{8}$`）：貼成 channel id 或 `@basicId` 只會在**會員手機上**爆，那裡我們看不到，所以在寫入這關就擋掉
  - 另開 RPC 而非擴 `rpc_upsert_store`：已 grep，該函式被三支 migration 動過且參數個數改過一次（當時必須 DROP+CREATE 才避開 overload 撞名，見 `20260801000020`）。為一個獨立欄位再冒一次那個風險不划算
- `liff-api` 的 `list_stores` 回 `line_liff_id`（**非密鑰** —— 本來就明碼在會員端 bundle 的 `NEXT_PUBLIC_LIFF_ID`）
- 會員端 `lib/storeLiff.ts` 查表 + localStorage 快取
  - 快取是**必要的，不是效能優化**：在 LINE 內冷啟動時 `liff.init()` 跑在門市清單抓回來之前，沒快取就會退回錯的預設 LIFF
  - 抓清單有 timeout，不把登入流程押在它身上（對齊 `liff.init` 本身也包 timeout 的既有寫法）
- `useLineLogin` **只換「liffId 從哪來」**，登入分支邏輯（LIFF browser 不可自行 `liff.login()`、PWA 走 OAuth 等）一行未動
- admin 分店設定新增「登入用 LIFF ID」欄位

該店留空 = 退回 `NEXT_PUBLIC_LIFF_ID`，與這個欄位出現前完全一致，**其他 13 家店不受影響**，可單店試點。

## 另外兩個修正

**憑證存檔即驗證**（`action=verify_store`）— 拿 LINE **Login** channel 的憑證去設定，`client_credentials` 換 token **會成功**，所以存檔當下毫無異狀，但打任何 Messaging API 端點都回 403。錯誤要等到店員實際要發訊息給客人時才爆。現在存檔後立刻打 `/v2/bot/info`，通過會顯示接上的官方帳號名稱。

**錯誤訊息說人話** — 先前畫面只顯示 `line_api_error` / `line_push_failed` 兩個代號，真正原因得回 DB 撈 `line_push_logs` 才看得到。新增 `explainLineError()`，最常見的 `not available for your account` 直接點名「多半填成 Login channel 了」；後端翻譯不了的至少露出 LINE 原文。順帶修正 1:1 聊天連結 —— 它跟 profile 查詢用同一組 ID，profile 404 時那條連結一樣會開到不存在的對話，先前卻仍以正常樣式顯示。

辨識法備忘：LIFF app 只掛得上 Login channel，所以「Channel ID 與 LIFF ID 前綴同號」＝ 那是 Login channel，不是 Messaging API channel。

## 驗證

- migration 已套用到線上
- `rpc_set_store_line_liff` 灌 claims 實測：格式錯（`2008395869`）→ 擋下 `invalid_liff_id`；正確格式 → 寫入成功；傳空字串 → 清為 NULL
- `list_stores` 線上實測：21 家門市、回傳含 `line_liff_id` 欄位
- Playwright（fixture，不碰線上 DB）：憑證區塊、未設定提示、空白時 disabled、secret 為 password type、存檔後自動驗證顯示官方帳號、LIFF ID 欄位存在且儲存帶對參數
- 會員 LINE modal 回歸測試通過
- admin / member 兩個 app 的 typecheck 與 ESLint 乾淨

## 已知限制（不是這支 PR 能解的）

LIFF ID 設定後，**只有之後重新登入過的會員**才會拿到可用的 ID。既有的舊 ID 屬於另一個 Provider，無法轉換。推播覆蓋率會隨會員陸續登入而成長，不是一設定就 100%。若要加速，後續可在會員站或官方帳號圖文選單加引導 —— 建議等單店試點驗證成功再談。

---
_Generated by [Claude Code](https://claude.ai/code/session_01B51QThXsMUzMwjyAqrHYVi)_