### PR TITLE
feat(line): 各店 OA 的 webhook 端點，收該店 provider 的 line_user_id

### DIFF
--- a/apps/admin/src/components/StoreLineOaField.tsx
+++ b/apps/admin/src/components/StoreLineOaField.tsx
@@ -205,7 +205,24 @@ function StoreLiffField({ storeId, initial }: { storeId: number; initial: string
         p_liff_id: value.trim(),
       });
       if (error) { setErr(translateRpcError(error)); return; }
-      setMsg(value.trim() ? "已儲存（該店會員下次登入就會用這支 LIFF）" : "已清除，改用租戶預設 LIFF");
+      if (!value.trim()) { setMsg("已清除，改用租戶預設 LIFF"); return; }
+
+      // 存起來不代表能用：endpoint 若不在會員站網域底下，LIFF context 會消失、
+      // 登入直接 400（CLAUDE.md 記過的坑）。純前端抓不到 liff.line.me，走後端驗。
+      setMsg("已儲存，驗證 endpoint 中…");
+      const { data: { session } } = await getSupabase().auth.getSession();
+      const resp = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/admin-line-push`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Authorization": `Bearer ${session?.access_token}` },
+        body: JSON.stringify({ action: "verify_liff", liff_id: value.trim() }),
+      });
+      const result = await resp.json().catch(() => ({}));
+      if (result.ok) {
+        setMsg(result.message ?? "✓ 已儲存");
+      } else {
+        setMsg(null);
+        setErr(result.message || result.error || `驗證失敗（HTTP ${resp.status}）`);
+      }
     } finally {
       setSaving(false);
     }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -440,3 +440,8 @@ verify_jwt = false
 # 對齊 staff-create：gateway 驗 JWT 會擋掉 CORS preflight
 [functions.admin-line-push]
 verify_jwt = false
+
+# line-webhook 由 LINE 平台直接打，不可能帶我們的 JWT。
+# 安全性靠 X-Line-Signature 驗簽（HMAC-SHA256 + 該店 channel secret）。
+[functions.line-webhook]
+verify_jwt = false

--- a/supabase/functions/admin-line-push/index.ts
+++ b/supabase/functions/admin-line-push/index.ts
@@ -187,6 +187,7 @@ Deno.serve(async (req) => {
       : body.action === "quota" ? "quota"
       : body.action === "links" ? "links"
       : body.action === "verify_store" ? "verify_store"
+      : body.action === "verify_liff" ? "verify_liff"
       : "send";
 
     // ── links：訊息樣板要用的會員站連結（刻意放在 LINE token 檢查之前）──────
@@ -245,6 +246,47 @@ Deno.serve(async (req) => {
         display_name: info.displayName ?? null,
         basic_id: info.basicId ?? null,
         chat_mode: info.chatMode ?? null,
+      });
+    }
+
+    // ── verify_liff：檢查這支 LIFF 的 endpoint 有沒有指回會員站 ─────────────
+    // 為什麼要驗：LIFF 登入會把「當下網址」當 redirect_uri 送出去，只要 endpoint
+    // 不在會員站網域底下，LINE 直接回 400，而且一跨網域 LIFF context 就沒了
+    // （isInClient() 變 false、沒有 auto login）。這個坑 CLAUDE.md 記過一次
+    // ——endpoint 被指到一支 Cloudflare Worker，再 302 回會員站，登入全掛。
+    // 純前端擋不了（要抓 liff.line.me 的頁面），所以放後端。
+    if (action === "verify_liff") {
+      const role = user.app_metadata?.role ?? "";
+      if (!["owner", "admin", ""].includes(role)) {
+        return json({ error: "insufficient_role" }, 403);
+      }
+      const liffId = String(body.liff_id ?? "").trim();
+      if (!liffId) return json({ error: "liff_id is required" }, 400);
+
+      const resp = await fetch(`https://liff.line.me/${encodeURIComponent(liffId)}`);
+      if (!resp.ok) {
+        return json({ error: "liff_not_found", message: `查不到這支 LIFF（HTTP ${resp.status}），請確認 ID 是否正確` }, 502);
+      }
+      const html = await resp.text();
+      const endpoint = html.match(/liffEndpointUrl\s*=\s*"([^"]+)"/)?.[1] ?? null;
+      if (!endpoint) {
+        return json({ ok: true, endpoint: null, message: "讀不到 endpoint，無法自動驗證，請自行確認" });
+      }
+
+      const memberBase = (Deno.env.get("MEMBER_FRONT_BASE_URL") ?? "").replace(/\/+$/, "");
+      let sameHost = false;
+      try {
+        sameHost = new URL(endpoint).host === new URL(memberBase).host;
+      } catch { /* 網址解不開就當不相符 */ }
+
+      return json({
+        ok: sameHost,
+        endpoint,
+        message: sameHost
+          ? `✓ endpoint 正確指向會員站（${endpoint}）`
+          : `endpoint 指向 ${endpoint}，不是會員站（${memberBase}）。`
+            + "跨網域會讓 LIFF context 消失、登入回 400，這支 LIFF 不能用於登入 —— "
+            + "請把該 LIFF app 的 Endpoint URL 改成會員站網址，或改用正確的那支。",
       });
     }
 

--- a/supabase/functions/admin-line-push/index.ts
+++ b/supabase/functions/admin-line-push/index.ts
@@ -241,6 +241,16 @@ Deno.serve(async (req) => {
         }, 502);
       }
       const info = await infoResp.json();
+      // 順手記下 OA 自己的 userId：line-webhook 在 URL 沒帶 ?store= 時，
+      // 要靠 body 的 destination 反查是哪一家店（這支本來就在打 /v2/bot/info，
+      // 不必為此多一次請求）
+      if (info.userId) {
+        const { error: upErr } = await sb
+          .from("store_line_oa_credentials")
+          .update({ bot_user_id: info.userId })
+          .eq("store_id", storeId);
+        if (upErr) console.error("cache bot_user_id failed:", upErr.message);
+      }
       return json({
         ok: true,
         display_name: info.displayName ?? null,

--- a/supabase/functions/line-webhook/index.ts
+++ b/supabase/functions/line-webhook/index.ts
@@ -1,0 +1,188 @@
+// line-webhook: 收各分店 LINE 官方帳號的 Messaging API webhook 事件
+//
+// 這支存在的理由：LINE 的 user ID 綁 Provider。14 家店的 OA 各在自己的
+// Provider，members.line_user_id（來自單一支 Login channel）對任何一家店的 OA
+// 都查不到（2026-08-07 實測：松山店 12 位活躍會員全數 404）。要推播就必須拿到
+// 「該店 provider 的 ID」，而唯一的來源就是該店 OA 自己的 webhook。
+//
+// 設定方式：每家店的 Webhook URL 各自帶自己的 store code，例：
+//   https://<project>.supabase.co/functions/v1/line-webhook?store=S002
+// 用 query 而不是靠 body 的 destination 判斷，是因為**驗簽需要先知道用哪把
+// channel secret**；URL 帶著就不必先信任未驗證的 body。
+// （沒帶 store 時才退而求其次用 destination 比對 bot_user_id。）
+//
+// ⚠ verify_jwt 必須是 false：LINE 不會帶我們的 JWT。安全性靠 X-Line-Signature
+//   驗簽（HMAC-SHA256 + channel secret），驗不過一律 403。
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.8";
+
+const LINE_PROFILE_URL = "https://api.line.me/v2/bot/profile";
+
+function requireEnv(name: string): string {
+  const v = Deno.env.get(name);
+  if (!v) throw new Error(`missing env ${name}`);
+  return v;
+}
+
+/** X-Line-Signature = Base64(HMAC-SHA256(channel_secret, raw_body)) */
+async function verifySignature(
+  rawBody: string,
+  signature: string,
+  channelSecret: string,
+): Promise<boolean> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(channelSecret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(rawBody));
+  const expected = btoa(String.fromCharCode(...new Uint8Array(mac)));
+  // 長度不同直接不等；長度相同才逐字元比，避免早退洩漏資訊
+  if (expected.length !== signature.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) diff |= expected.charCodeAt(i) ^ signature.charCodeAt(i);
+  return diff === 0;
+}
+
+Deno.serve(async (req) => {
+  // LINE 只會 POST。回 200 要快 —— 逾時 LINE 會判定 webhook 失敗並停用。
+  if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+
+  try {
+    const url = new URL(req.url);
+    const storeCode = url.searchParams.get("store");
+    const rawBody = await req.text();
+    const signature = req.headers.get("x-line-signature") ?? "";
+
+    const sb = createClient(
+      requireEnv("SUPABASE_URL"),
+      requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+      { auth: { persistSession: false } },
+    );
+
+    // 找出這通 webhook 屬於哪一家店（要拿它的 channel secret 驗簽）
+    let credQuery = sb
+      .from("store_line_oa_credentials")
+      .select("store_id, tenant_id, channel_secret, access_token, stores!inner(code)");
+    if (storeCode) {
+      credQuery = credQuery.eq("stores.code", storeCode);
+    } else {
+      // 沒帶 store：用 body 的 destination（= OA 自己的 userId）比對。
+      // 這裡讀的是**還沒驗簽**的 body，只當查表 key 用，不做任何信任決策。
+      const dest = (() => { try { return JSON.parse(rawBody)?.destination ?? null; } catch { return null; } })();
+      if (!dest) return new Response("store not specified", { status: 400 });
+      credQuery = credQuery.eq("bot_user_id", dest);
+    }
+    const { data: cred, error: credErr } = await credQuery.maybeSingle();
+    if (credErr) {
+      console.error("cred lookup failed:", credErr.message);
+      return new Response("internal", { status: 500 });
+    }
+    if (!cred) {
+      console.error("no credentials for store:", storeCode);
+      return new Response("unknown store", { status: 404 });
+    }
+
+    if (!await verifySignature(rawBody, signature, cred.channel_secret)) {
+      console.error("bad signature for store:", storeCode);
+      return new Response("bad signature", { status: 403 });
+    }
+
+    const body = JSON.parse(rawBody);
+    const events: Record<string, unknown>[] = body.events ?? [];
+
+    // LINE 後台按「Verify」時送的是空 events —— 必須回 200 才算驗證成功
+    if (events.length === 0) return new Response("ok", { status: 200 });
+
+    for (const ev of events) {
+      const type = ev.type as string;
+      const source = ev.source as Record<string, unknown> | undefined;
+      const lineUserId = source?.userId as string | undefined;
+      if (!lineUserId) continue;   // 群組 / 聊天室事件沒有 userId，略過
+
+      const at = ev.timestamp ? new Date(Number(ev.timestamp)).toISOString() : new Date().toISOString();
+
+      if (type === "unfollow") {
+        await sb.from("store_line_followers")
+          .update({ followed: false, last_event_at: at })
+          .eq("store_id", cred.store_id)
+          .eq("line_user_id", lineUserId);
+        continue;
+      }
+
+      if (type === "accountLink") {
+        const link = ev.link as { result?: string; nonce?: string } | undefined;
+        if (link?.result !== "ok" || !link.nonce) {
+          console.error("accountLink failed or missing nonce");
+          continue;
+        }
+        // nonce 是我們在發 linkToken 前自己種下的，帶著「這是哪位會員」
+        const { data: n } = await sb
+          .from("line_account_link_nonces")
+          .select("nonce, member_id, store_id, tenant_id, used_at")
+          .eq("nonce", link.nonce)
+          .maybeSingle();
+        if (!n || n.used_at || n.store_id !== cred.store_id) {
+          console.error("nonce invalid / already used / store mismatch");
+          continue;
+        }
+        await sb.from("store_line_followers").upsert({
+          tenant_id: n.tenant_id,
+          store_id: n.store_id,
+          line_user_id: lineUserId,
+          member_id: n.member_id,
+          followed: true,
+          linked_at: at,
+          last_event_at: at,
+        }, { onConflict: "store_id,line_user_id" });
+        await sb.from("line_account_link_nonces")
+          .update({ used_at: new Date().toISOString() })
+          .eq("nonce", link.nonce);
+        continue;
+      }
+
+      // follow / message / 其他有 userId 的事件 → 至少把這個人記進名冊。
+      // member_id 先留 NULL：webhook 只知道「有這個 LINE 使用者」，
+      // 不知道他是哪位會員，要等 account link 完成才填得上。
+      let displayName: string | null = null;
+      let pictureUrl: string | null = null;
+      if (type === "follow" && cred.access_token) {
+        try {
+          const p = await fetch(`${LINE_PROFILE_URL}/${lineUserId}`, {
+            headers: { "Authorization": `Bearer ${cred.access_token}` },
+          });
+          if (p.ok) {
+            const prof = await p.json();
+            displayName = prof.displayName ?? null;
+            pictureUrl = prof.pictureUrl ?? null;
+          }
+        } catch (e) {
+          console.error("profile fetch failed:", String(e));
+        }
+      }
+
+      const row: Record<string, unknown> = {
+        tenant_id: cred.tenant_id,
+        store_id: cred.store_id,
+        line_user_id: lineUserId,
+        followed: true,
+        last_event_at: at,
+      };
+      if (displayName) row.display_name = displayName;
+      if (pictureUrl) row.picture_url = pictureUrl;
+
+      const { error: upErr } = await sb
+        .from("store_line_followers")
+        .upsert(row, { onConflict: "store_id,line_user_id", ignoreDuplicates: false });
+      if (upErr) console.error("binding upsert failed:", upErr.message);
+    }
+
+    return new Response("ok", { status: 200 });
+  } catch (e) {
+    // 回 500 會讓 LINE 重送；但解析失敗重送也不會變好，記下來回 200 比較安全。
+    console.error("line-webhook error:", e);
+    return new Response("ok", { status: 200 });
+  }
+});

--- a/supabase/migrations/20260807000060_member_line_bindings.sql
+++ b/supabase/migrations/20260807000060_member_line_bindings.sql
@@ -1,0 +1,84 @@
+-- ============================================================================
+-- 2026-08-07: 每分店的 LINE 綁定（webhook 收 ID）
+--
+-- 背景：LINE 的 user ID 綁 Provider。14 家店的 OA 各在自己的 Provider，
+-- members.line_user_id（來自單一支 Login channel）對任何一家店的 OA 都查不到
+-- —— 2026-08-07 實測：松山店 12 位活躍會員的 ID，查該店 OA profile 全數 404。
+--
+-- 改走 Messaging API 的 account link（官方機制，**不需要 LINE Login channel**）：
+--   1. 顧客加該店 OA 好友 / 傳訊息 → webhook 收到該店 provider 的 line_user_id
+--   2. 要配對時發 linkToken 連結，顧客登入後 LINE 回 accountLink 事件
+--   3. 用 nonce 把 member_id 跟該店 line_user_id 綁起來
+--
+-- 對齊 docs/PRD-通知模組.md §6.8「同一會員在不同店有不同 line_user_id」。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS member_line_bindings (
+  id           BIGSERIAL   PRIMARY KEY,
+  tenant_id    UUID        NOT NULL,
+  store_id     BIGINT      NOT NULL REFERENCES stores(id) ON DELETE CASCADE,
+  -- 該店 Provider 底下的 ID。**不要**跟 members.line_user_id 混用，那是另一個
+  -- provider 的東西，兩者對同一個人是不同字串。
+  line_user_id TEXT        NOT NULL,
+  -- 還沒配對到會員時是 NULL：webhook 只知道「有這個 LINE 使用者」，
+  -- 不知道他是誰，要等 account link 完成才填得上。
+  member_id    BIGINT      REFERENCES members(id) ON DELETE SET NULL,
+  display_name TEXT,
+  picture_url  TEXT,
+  followed     BOOLEAN     NOT NULL DEFAULT TRUE,
+  linked_at    TIMESTAMPTZ,
+  last_event_at TIMESTAMPTZ,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (store_id, line_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mlb_member ON member_line_bindings (member_id)
+  WHERE member_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mlb_store_unlinked ON member_line_bindings (store_id)
+  WHERE member_id IS NULL;
+
+COMMENT ON TABLE  member_line_bindings IS
+  '每分店 OA 的 LINE 使用者名冊 + 與會員的對應。line_user_id 是「該店 provider」的 ID，與 members.line_user_id 不同源、不可互換';
+COMMENT ON COLUMN member_line_bindings.member_id IS
+  'NULL = webhook 收到這個 LINE 使用者但還沒配對到會員';
+
+ALTER TABLE member_line_bindings ENABLE ROW LEVEL SECURITY;
+
+-- 讀：自家 tenant 的 staff 可看（用來在 admin 顯示「這位會員在這家店綁了沒」）
+DROP POLICY IF EXISTS mlb_tenant_read ON member_line_bindings;
+CREATE POLICY mlb_tenant_read ON member_line_bindings
+  FOR SELECT USING (tenant_id = (auth.jwt() ->> 'tenant_id')::UUID);
+-- 寫：只有 service_role（webhook），不開給前端
+
+-- ── account link 用的一次性 nonce ───────────────────────────────────────────
+-- 流程：發 linkToken 前先建一筆（記住這是哪位會員、哪家店），
+-- LINE 回 accountLink 事件時帶著同一個 nonce，才知道要綁給誰。
+CREATE TABLE IF NOT EXISTS line_account_link_nonces (
+  nonce      TEXT        PRIMARY KEY,
+  tenant_id  UUID        NOT NULL,
+  store_id   BIGINT      NOT NULL REFERENCES stores(id) ON DELETE CASCADE,
+  member_id  BIGINT      NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  used_at    TIMESTAMPTZ
+);
+
+COMMENT ON TABLE line_account_link_nonces IS
+  'account link 的一次性 nonce。LINE 的 linkToken 只有 10 分鐘效期，這裡的紀錄同樣是短命的';
+
+ALTER TABLE line_account_link_nonces ENABLE ROW LEVEL SECURITY;
+-- 前端完全不需要讀寫；service_role bypass
+REVOKE ALL ON line_account_link_nonces FROM anon, authenticated;
+
+-- 過期清理（nonce 只有 10 分鐘有效，留 1 天足夠除錯）
+CREATE OR REPLACE FUNCTION purge_line_account_link_nonces(p_days INT DEFAULT 1)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE v_deleted BIGINT;
+BEGIN
+  DELETE FROM line_account_link_nonces
+   WHERE created_at < NOW() - (p_days || ' days')::INTERVAL;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;

--- a/supabase/migrations/20260807000070_store_line_oa_bot_user_id.sql
+++ b/supabase/migrations/20260807000070_store_line_oa_bot_user_id.sql
@@ -1,0 +1,18 @@
+-- ============================================================================
+-- 2026-08-07: store_line_oa_credentials 記下 OA 自己的 userId
+--
+-- 用途：line-webhook 在「Webhook URL 沒帶 ?store=」時，要靠 body 的
+-- `destination`（= 該 OA 的 userId）反查是哪一家店。主要路徑仍是 ?store=，
+-- 這是備援 —— 14 家店手動貼 URL，難免有人漏了 query。
+--
+-- 值從 /v2/bot/info 的 userId 來，admin-line-push 的 verify_store 會順手寫入
+-- （那支本來就在打 /v2/bot/info）。
+-- ============================================================================
+
+ALTER TABLE store_line_oa_credentials ADD COLUMN IF NOT EXISTS bot_user_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_store_line_oa_bot_user
+  ON store_line_oa_credentials (bot_user_id) WHERE bot_user_id IS NOT NULL;
+
+COMMENT ON COLUMN store_line_oa_credentials.bot_user_id IS
+  '該 OA 自己的 LINE userId（/v2/bot/info 的 userId）。webhook 沒帶 ?store= 時用 destination 反查用';

--- a/supabase/migrations/20260807000080_revert_mlb_tenant_read.sql
+++ b/supabase/migrations/20260807000080_revert_mlb_tenant_read.sql
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- 2026-08-07: 撤掉誤加到 member_line_bindings 的 mlb_tenant_read policy
+--
+-- 事故經過：20260807000060 想建一張「webhook 收 LINE ID」的新表，取名
+-- member_line_bindings —— 但**這張表早就存在**（20260425130000_line_bindings.sql，
+-- 線上 948 筆真資料、18 家店）。`CREATE TABLE IF NOT EXISTS` 靜默跳過，
+-- 後面的 ALTER / CREATE POLICY 卻照樣套到了既有表上。
+--
+-- 後果：多出一條 mlb_tenant_read（同租戶任何登入者可讀**全部**門市的綁定），
+-- 比原設計寬。原設計是刻意三層收窄的：
+--   mlb_self_read  顧客只讀自己
+--   mlb_store_read 店員只讀自己那家店
+--   mlb_hq_all     只有 hq 能全看
+-- 這裡把多出來的那條移除，回到原本的三條。
+--
+-- 順便移除同批加的兩個無用索引：該表 member_id 是 NOT NULL，
+-- `WHERE member_id IS NOT NULL` 等於全表、`WHERE member_id IS NULL` 恆空。
+--
+-- 教訓：建新表前先確認名字沒被用過 ——
+--   SELECT to_regclass('public.<table>');
+-- ============================================================================
+
+DROP POLICY IF EXISTS mlb_tenant_read ON member_line_bindings;
+
+DROP INDEX IF EXISTS idx_mlb_member;
+DROP INDEX IF EXISTS idx_mlb_store_unlinked;
+
+-- 把被覆蓋掉的註解改回描述這張表真正的用途
+COMMENT ON TABLE member_line_bindings IS
+  '會員 × 門市 的 LINE 綁定（見 20260425130000）。注意：這裡的 line_user_id 來自'
+  '會員登入用的 Login channel provider，**不等於**各店 OA 看到的 ID；'
+  '要推播用的 per-store ID 在 store_line_followers';
+COMMENT ON COLUMN member_line_bindings.member_id IS '所屬會員（NOT NULL）';

--- a/supabase/migrations/20260807000090_store_line_followers.sql
+++ b/supabase/migrations/20260807000090_store_line_followers.sql
@@ -1,0 +1,61 @@
+-- ============================================================================
+-- 2026-08-07: store_line_followers —— 各店 OA 的 LINE 好友名冊（webhook 寫入）
+--
+-- 為什麼不塞進既有的 member_line_bindings：
+--   那張表裡的 line_user_id 來自**會員登入用的 Login channel provider**
+--   （線上 948 筆中有 944 筆與 members.line_user_id 完全相同），
+--   而這裡要存的是**各店 OA provider** 的 ID。兩者對同一個人是不同字串、
+--   不可互換。混在同一張表 = 之後沒人分得出哪一筆推得動、哪一筆推不動，
+--   而「分不出來」正是今天繞一整圈的根源。所以刻意分開存。
+--
+-- 另外 member_line_bindings.member_id 是 NOT NULL，裝不下「webhook 收到某個
+-- LINE 使用者但還不知道他是誰」這個中間狀態 —— 那正是本表的主要用途。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS store_line_followers (
+  id            BIGSERIAL   PRIMARY KEY,
+  tenant_id     UUID        NOT NULL,
+  store_id      BIGINT      NOT NULL REFERENCES stores(id) ON DELETE CASCADE,
+  -- 該店 OA provider 的 ID。**不要**跟 members.line_user_id 或
+  -- member_line_bindings.line_user_id 混用或比對，那是另一個 provider 的東西。
+  line_user_id  TEXT        NOT NULL,
+  -- NULL = 收到這個 LINE 使用者，但還沒配對到會員（等 account link 完成）
+  member_id     BIGINT      REFERENCES members(id) ON DELETE SET NULL,
+  display_name  TEXT,
+  picture_url   TEXT,
+  followed      BOOLEAN     NOT NULL DEFAULT TRUE,
+  linked_at     TIMESTAMPTZ,
+  last_event_at TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (store_id, line_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_slf_member
+  ON store_line_followers (member_id) WHERE member_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_slf_unlinked
+  ON store_line_followers (store_id) WHERE member_id IS NULL;
+
+COMMENT ON TABLE store_line_followers IS
+  '各分店 OA 的 LINE 好友名冊（line-webhook 寫入）。line_user_id 是該店 OA provider 的 ID，可直接用於 push';
+COMMENT ON COLUMN store_line_followers.member_id IS
+  'NULL = 還沒配對到會員；配對走 Messaging API 的 account link（linkToken + nonce）';
+
+ALTER TABLE store_line_followers ENABLE ROW LEVEL SECURITY;
+
+-- 讀取權限對齊既有 member_line_bindings 的三層設計，不要放寬：
+--   hq 全看、店員只看自己那家店。顧客端不需要讀這張表。
+DROP POLICY IF EXISTS slf_hq_all ON store_line_followers;
+CREATE POLICY slf_hq_all ON store_line_followers
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+    AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '') IN ('owner','admin','hq','hq_manager','')
+  );
+
+DROP POLICY IF EXISTS slf_store_read ON store_line_followers;
+CREATE POLICY slf_store_read ON store_line_followers
+  FOR SELECT USING (
+    tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+    AND store_id = NULLIF(auth.jwt() -> 'app_metadata' ->> 'store_id', '')::BIGINT
+    AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '') IN ('store_manager','store_staff')
+  );
+-- 寫入只有 service_role（line-webhook），不開給前端


### PR DESCRIPTION
接續 #643。#643 走的是「每店開一支 Login channel + LIFF」，實際操作時發現要在 14 個 Provider 各建一支太重；改走 Messaging API 的 **account link**（官方機制，[文件明載不需要 LINE Login channel](https://developers.line.biz/en/docs/messaging-api/linking-accounts/)）。

## 為什麼非得有 webhook

各店 OA 看到的顧客 ID 跟我們手上那組是完全不同的字串（#643 已驗證：松山店 12 位會員全數 404）。而 LINE **不提供任何反查方式**：

- 不能用手機號 / 姓名查 user ID
- 不能列舉好友清單 —— 實測 `/v2/bot/followers/ids` 回 **403**（需認證帳號）
- 不能從別的 provider 換算，那是設計上刻意隔離的

LINE 只在顧客主動與該 OA 互動時（加好友、傳訊息）交出他的 ID，傳遞方式就是打 webhook。**沒有 webhook，那個 ID 永遠拿不到。** 而且 account link 成功與否也是透過 webhook 回報，兩條路都繞不開。

## 改了什麼

**`line-webhook` edge function**
- 驗 `X-Line-Signature`（HMAC-SHA256 + 該店 channel secret），常數時間比對
- 處理 `follow` / `message` / `unfollow` / `accountLink`
- `verify_jwt = false` —— LINE 不會帶我們的 JWT，安全性**全部**倚賴驗簽
- 空 `events` 回 200，讓後台的 Verify 按鈕能過
- 每店 URL 各自帶 `?store=<code>`：驗簽必須**先**知道用哪把 secret，URL 帶著就不必先信任未驗證的 body。沒帶時才用 `destination` 反查 `bot_user_id`（備援）

**資料表**
- `store_line_followers` —— 該店 provider 的 ID 名冊，`member_id` 可為 NULL（webhook 只知道「有這個 LINE 使用者」，不知道他是誰）
- `line_account_link_nonces` —— account link 的一次性 nonce
- `store_line_oa_credentials.bot_user_id` —— `verify_store` 順手記下（本來就在打 `/v2/bot/info`，不多一次請求）

## ⚠️ 我造成又修掉的一個問題

新表原本取名 `member_line_bindings` —— 但**那張表早就存在**（`20260425130000`，線上 948 筆真資料、18 家店）。`CREATE TABLE IF NOT EXISTS` 靜默跳過，後面的 `CREATE POLICY` 卻照樣套到了既有表上，多出一條 `mlb_tenant_read`（同租戶任何登入者可讀**全部門市**的綁定），比原本刻意收窄的三層設計寬：

| policy | 原設計範圍 |
|---|---|
| `mlb_self_read` | 顧客只讀自己 |
| `mlb_store_read` | 店員只讀自己那家店 |
| `mlb_hq_all` | 只有 hq 全看 |

`20260807000080` 已撤除該 policy、移除同批加的兩個無用索引（該表 `member_id` 是 NOT NULL，`WHERE member_id IS NOT NULL` 等於全表、`IS NULL` 恆空）、並還原被覆蓋的註解。已確認線上回到原本三條 policy、948 筆資料未被更動。

Migration 是 append-only 且 `060` 已套用到線上，所以保留該檔 + 用 `080` 修正，而不是改寫歷史。

## 為什麼兩張表不合併

`member_line_bindings` 存的是**登入用 Login channel provider** 的 ID（948 筆中 944 筆與 `members.line_user_id` 完全相同）；`store_line_followers` 存的是**各店 OA provider** 的 ID。同一個人在兩邊是不同字串。混在一起就分不出哪一筆推得動 —— 而「分不出來」正是這整串問題的根源，所以刻意分開。

## 驗證

線上實測（松山店 `S002`）：

| 情境 | 預期 | 實測 |
|---|---|---|
| 正確簽章 + 空 events（後台 Verify） | 200 | ✅ 200 |
| 錯誤簽章 | 403 | ✅ 403 `bad signature` |
| 無簽章 | 403 | ✅ 403 |
| 未知門市 | 404 | ✅ 404 `unknown store` |
| 模擬 `follow` 事件 | 寫入名冊、`member_id` 為 NULL | ✅ 正確 |

測試資料已清除；`member_line_bindings` 仍為 948 筆未受影響。admin typecheck / ESLint 乾淨。

同批還有一個 #643 的後續修正：LIFF ID 存檔時驗證 endpoint 是否指回會員站 —— 實際設定時把舊的 `2009883687-NZX6xXEW` 填了進去，格式檢查過關，但那支的 endpoint 是 `line-richmenu-branches.www161616.workers.dev`（跨網域，CLAUDE.md 記過的坑，會讓 LIFF context 消失、登入回 400）。新增 `verify_liff` 抓 `liff.line.me/{id}` 解出 `liffEndpointUrl` 與 `MEMBER_FRONT_BASE_URL` 比對 host。

## 尚未完成（下一步）

「把名冊裡的 LINE 使用者配對到會員」那段還沒做 —— 需要發 linkToken、做綁定落地頁。本 PR 先讓 ID 收得到；配對流程會碰到顧客端體驗，建議先讓松山店實際跑一輪收到 ID 再設計。

---
_Generated by [Claude Code](https://claude.ai/code/session_01B51QThXsMUzMwjyAqrHYVi)_