### PR TITLE
feat(line): account link 自動綁定、可取貨訂單圖、Webhook URL 產生器

### DIFF
--- a/apps/admin/src/app/(protected)/stores/page.tsx
+++ b/apps/admin/src/app/(protected)/stores/page.tsx
@@ -519,7 +519,7 @@ function StoreForm({
           </span>
         </F>
 
-        <StoreLineOaField storeId={v.id} />
+        <StoreLineOaField storeId={v.id} storeCode={v.code} />
 
         <F label="備註" className="sm:col-span-4">
           <textarea

--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -16,6 +16,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
+import { renderPickupImage, type PickupOrder } from "@/lib/pickupImage";
 
 const BUCKET = "line-media";
 const FN_URL = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/admin-line-push`;
@@ -97,7 +98,7 @@ async function encodeJpeg(file: File, maxDim: number, quality: number): Promise<
 }
 
 export function LineMessageModal({
-  open, onClose, member, tenantId, homeStoreId = null,
+  open, onClose, member, tenantId, homeStoreId = null, storeName = null,
 }: {
   open: boolean;
   onClose: () => void;
@@ -105,6 +106,8 @@ export function LineMessageModal({
   tenantId: string;
   /** 會員取貨店 —— 決定要看哪一家店的 OA 名冊 */
   homeStoreId?: number | null;
+  /** 取貨店名稱，印在可取貨訂單圖的抬頭 */
+  storeName?: string | null;
 }) {
   const [reachable, setReachable] = useState<Reachable>({ state: "checking" });
   const [quota, setQuota] = useState<Quota | null>(null);
@@ -112,6 +115,7 @@ export function LineMessageModal({
   const [ordersUrl, setOrdersUrl] = useState<string | null>(null);
   const [followers, setFollowers] = useState<Follower[]>([]);
   const [binding, setBinding] = useState(false);
+  const [buildingImage, setBuildingImage] = useState(false);
   const [text, setText] = useState("");
   const [image, setImage] = useState<File | null>(null);
   const [sending, setSending] = useState(false);
@@ -195,6 +199,68 @@ export function LineMessageModal({
   useEffect(() => {
     return () => { if (imagePreview) URL.revokeObjectURL(imagePreview); };
   }, [imagePreview]);
+
+  /**
+   * 把該會員的可取貨品項畫成一張圖，直接放進附圖欄。
+   *
+   * 只取 item.status = 'ready'（可取貨）—— 同一張訂單裡可能混著已取貨 / 未到貨的
+   * 品項，整張塞給顧客會讓他白跑一趟或以為東西少了。
+   */
+  async function buildPickupImage() {
+    setBuildingImage(true);
+    setError(null);
+    try {
+      const { data, error: qErr } = await getSupabase()
+        .from("customer_orders")
+        .select("order_no, status, campaign:group_buy_campaigns(name), customer_order_items(qty, unit_price, status, skus(sku_code, products(name)))")
+        .eq("member_id", member.id)
+        .in("status", ["ready", "partially_completed"])
+        .order("created_at", { ascending: false });
+      if (qErr) { setError(qErr.message); return; }
+
+      type Row = {
+        order_no: string;
+        campaign: { name: string } | { name: string }[] | null;
+        customer_order_items: {
+          qty: number; unit_price: number | null; status: string | null;
+          skus: { sku_code: string | null; products: { name: string } | { name: string }[] | null } | null;
+        }[] | null;
+      };
+      const one = <T,>(v: T | T[] | null): T | null => (Array.isArray(v) ? v[0] ?? null : v);
+
+      const orders: PickupOrder[] = ((data ?? []) as unknown as Row[])
+        .map((o) => ({
+          orderNo: o.order_no,
+          campaign: one(o.campaign)?.name ?? null,
+          lines: (o.customer_order_items ?? [])
+            .filter((it) => it.status === "ready")
+            .map((it) => ({
+              name: one(one(it.skus)?.products ?? null)?.name
+                ?? one(it.skus)?.sku_code
+                ?? "（品項）",
+              qty: Number(it.qty ?? 0),
+              unitPrice: it.unit_price == null ? null : Number(it.unit_price),
+            })),
+        }))
+        .filter((o) => o.lines.length > 0);
+
+      if (orders.length === 0) {
+        setError("這位會員目前沒有可取貨的品項");
+        return;
+      }
+
+      const blob = await renderPickupImage({
+        storeName,
+        memberName: member.name,
+        orders,
+      });
+      setImage(new File([blob], "pickup.jpg", { type: "image/jpeg" }));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBuildingImage(false);
+    }
+  }
 
   function pickImage(file: File) {
     if (!file.type.startsWith("image/")) {
@@ -419,6 +485,15 @@ export function LineMessageModal({
           <span className="mb-1 block text-xs text-zinc-500">
             截圖 / 圖片（可直接 Ctrl+V 貼上）
           </span>
+          {!imagePreview && (
+            <SpinButton
+              onClick={buildPickupImage}
+              disabled={buildingImage}
+              className="mb-2 mr-2 rounded-md border border-emerald-300 px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-950"
+            >
+              {buildingImage ? "產生中…" : "📋 帶入可取貨訂單圖"}
+            </SpinButton>
+          )}
           {imagePreview ? (
             <div className="relative inline-block">
               {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -510,6 +510,7 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
           member={{ id: member.id, name: member.name, member_no: member.member_no }}
           tenantId={tenantId}
           homeStoreId={member.home_store_id}
+          storeName={stores.find((st) => st.id === member.home_store_id)?.name ?? null}
         />
       )}
 

--- a/apps/admin/src/components/StoreLineOaField.tsx
+++ b/apps/admin/src/components/StoreLineOaField.tsx
@@ -17,7 +17,9 @@ import SpinButton from "@/components/SpinButton";
 
 type Status = { channel_id: string; updated_at: string } | null;
 
-export function StoreLineOaField({ storeId }: { storeId: number | null }) {
+export function StoreLineOaField({
+  storeId, storeCode,
+}: { storeId: number | null; storeCode: string }) {
   const role = useRole();
   const [status, setStatus] = useState<Status>(null);
   const [loaded, setLoaded] = useState(false);
@@ -26,6 +28,11 @@ export function StoreLineOaField({ storeId }: { storeId: number | null }) {
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  // 每家店一個 URL，結尾的 ?store= 不能省 —— line-webhook 要靠它決定用哪一把
+  // channel secret 驗簽（驗簽必須先於信任 body，所以不能改從 body 讀）。
+  const webhookUrl = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/line-webhook?store=${encodeURIComponent(storeCode)}`;
 
   useEffect(() => {
     // storeId 為 null 時走的是「請先儲存分店」那個分支，用不到 loaded
@@ -114,6 +121,36 @@ export function StoreLineOaField({ storeId }: { storeId: number | null }) {
               </div>
             )
           )}
+
+          <div className="mb-3 rounded border border-zinc-200 bg-zinc-50 p-2 dark:border-zinc-700 dark:bg-zinc-900">
+            <div className="mb-1 text-[11px] font-medium text-zinc-700 dark:text-zinc-300">
+              Webhook URL（貼到 LINE 後台 → 設定 → Messaging API）
+            </div>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 overflow-x-auto whitespace-nowrap rounded bg-white px-2 py-1 text-[11px] text-zinc-800 dark:bg-zinc-950 dark:text-zinc-200">
+                {webhookUrl}
+              </code>
+              <SpinButton
+                onClick={async () => {
+                  try {
+                    await navigator.clipboard.writeText(webhookUrl);
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 2000);
+                  } catch {
+                    // 非 https / 舊瀏覽器沒有 clipboard API，讓使用者自己選取複製
+                    setErr("此瀏覽器不允許自動複製，請手動選取上方網址");
+                  }
+                }}
+                className="shrink-0 rounded-md border border-zinc-300 px-2 py-1 text-[11px] hover:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-800"
+              >
+                {copied ? "✓ 已複製" : "複製"}
+              </SpinButton>
+            </div>
+            <p className="mt-1 text-[11px] text-zinc-500">
+              貼上後按 LINE 後台的 Verify 應顯示 Success。
+              {!status && "（要先儲存下方憑證，webhook 才驗得過簽章）"}
+            </p>
+          </div>
 
           <div className="grid gap-2 sm:grid-cols-2">
             <label className="block text-xs">

--- a/apps/admin/src/lib/pickupImage.ts
+++ b/apps/admin/src/lib/pickupImage.ts
@@ -1,0 +1,144 @@
+/**
+ * 把「可取貨訂單」畫成一張圖，直接當 LINE 訊息的附圖發給會員。
+ *
+ * 為什麼是圖不是文字：店員原本的做法就是自己截圖貼進 LINE，因為品項一多
+ * 純文字在手機上很難讀（會被 LINE 折行折得亂七八糟）。這裡把那張圖自動產出來，
+ * 省掉「切到訂單頁 → 截圖 → 裁切 → 貼上」四個動作，也不會截到不該給顧客看的欄位。
+ *
+ * 用 canvas 而不是後端算圖：後端要算圖得跑 headless browser，edge function 做不到；
+ * 而這張圖的資料 admin 前端本來就有，畫完直接走既有的
+ * 「上傳 line-media → admin-line-push 發送」管線，不必新增任何後端。
+ *
+ * ⚠ 一律輸出 JPEG：LINE 的 image message 只吃 JPEG/PNG，而 JPEG 沒有 alpha，
+ *   所以底色要自己鋪白（跟 LineMessageModal 的 encodeJpeg 同樣理由）。
+ */
+
+export type PickupLine = {
+  name: string;
+  qty: number;
+  unitPrice: number | null;
+};
+
+export type PickupOrder = {
+  orderNo: string;
+  campaign: string | null;
+  lines: PickupLine[];
+};
+
+export type PickupImageData = {
+  storeName: string | null;
+  memberName: string | null;
+  orders: PickupOrder[];
+};
+
+// 以 2 倍解析度繪製再縮回去，手機上看才不會糊（LINE 會放大顯示）
+const SCALE = 2;
+const W = 720;
+const PAD = 28;
+const FONT = '"Noto Sans TC", "PingFang TC", "Microsoft JhengHei", system-ui, sans-serif';
+
+/** 超出寬度的品項名截斷加省略號，避免壓到右側數量欄 */
+function ellipsize(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string {
+  if (ctx.measureText(text).width <= maxWidth) return text;
+  let t = text;
+  while (t.length > 1 && ctx.measureText(t + "…").width > maxWidth) t = t.slice(0, -1);
+  return t + "…";
+}
+
+export async function renderPickupImage(data: PickupImageData): Promise<Blob> {
+  // 先算高度：標題區 + 每張訂單（抬頭 + 品項列）+ 合計 + 頁尾
+  const lineH = 34;
+  const orderHeadH = 40;
+  let h = 96;
+  for (const o of data.orders) h += orderHeadH + o.lines.length * lineH + 12;
+  h += 76;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = W * SCALE;
+  canvas.height = h * SCALE;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("無法建立 canvas");
+  ctx.scale(SCALE, SCALE);
+
+  // JPEG 沒有透明度，底色一定要自己鋪
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, W, h);
+
+  let y = PAD;
+
+  // 標題
+  ctx.fillStyle = "#111827";
+  ctx.font = `bold 26px ${FONT}`;
+  ctx.fillText("可取貨訂單", PAD, y + 22);
+  y += 36;
+
+  ctx.font = `15px ${FONT}`;
+  ctx.fillStyle = "#6b7280";
+  const sub = [data.storeName, data.memberName].filter(Boolean).join("　·　");
+  if (sub) ctx.fillText(sub, PAD, y + 14);
+  y += 30;
+
+  ctx.strokeStyle = "#e5e7eb";
+  ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.moveTo(PAD, y); ctx.lineTo(W - PAD, y); ctx.stroke();
+  y += 12;
+
+  let totalQty = 0;
+  let totalAmount = 0;
+
+  for (const o of data.orders) {
+    ctx.fillStyle = "#111827";
+    ctx.font = `bold 16px ${FONT}`;
+    ctx.fillText(o.orderNo, PAD, y + 22);
+    // ⚠ 寬度必須在「還是 bold 16px」時量 —— 切成 14px 再量會少算，
+    //   團購名就會壓在訂單編號上面（2026-08-07 產圖預覽踩到）
+    const noW = ctx.measureText(o.orderNo).width;
+    if (o.campaign) {
+      ctx.font = `14px ${FONT}`;
+      ctx.fillStyle = "#6b7280";
+      ctx.fillText(ellipsize(ctx, o.campaign, W - PAD * 2 - noW - 20), PAD + noW + 16, y + 22);
+    }
+    y += orderHeadH;
+
+    for (const l of o.lines) {
+      totalQty += l.qty;
+      const sub2 = l.unitPrice != null ? l.unitPrice * l.qty : 0;
+      totalAmount += sub2;
+
+      ctx.font = `15px ${FONT}`;
+      ctx.fillStyle = "#374151";
+      // 右側兩欄固定寬度：數量 70、小計 110
+      ctx.fillText(ellipsize(ctx, l.name, W - PAD * 2 - 190), PAD + 8, y + 20);
+
+      ctx.textAlign = "right";
+      ctx.fillStyle = "#6b7280";
+      ctx.fillText(`×${l.qty}`, W - PAD - 120, y + 20);
+      ctx.fillStyle = "#111827";
+      ctx.fillText(l.unitPrice != null ? `$${sub2.toLocaleString()}` : "—", W - PAD, y + 20);
+      ctx.textAlign = "left";
+
+      y += lineH;
+    }
+    y += 12;
+  }
+
+  ctx.strokeStyle = "#e5e7eb";
+  ctx.beginPath(); ctx.moveTo(PAD, y); ctx.lineTo(W - PAD, y); ctx.stroke();
+  y += 12;
+
+  ctx.font = `bold 18px ${FONT}`;
+  ctx.fillStyle = "#111827";
+  ctx.fillText(`共 ${totalQty} 件`, PAD, y + 22);
+  ctx.textAlign = "right";
+  ctx.fillText(`$${totalAmount.toLocaleString()}`, W - PAD, y + 22);
+  ctx.textAlign = "left";
+  y += 38;
+
+  ctx.font = `12px ${FONT}`;
+  ctx.fillStyle = "#9ca3af";
+  ctx.fillText(`產生時間：${new Date().toLocaleString("zh-TW")}`, PAD, y + 12);
+
+  const blob = await new Promise<Blob | null>((res) => canvas.toBlob(res, "image/jpeg", 0.92));
+  if (!blob) throw new Error("圖片產生失敗");
+  return blob;
+}

--- a/apps/member/src/app/link/page.tsx
+++ b/apps/member/src/app/link/page.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+// LINE 帳號連結（account link）的落地頁。
+//
+// 為什麼需要這一頁：LINE 的 user ID 是綁 Provider 的，各店官方帳號看到的
+// 顧客 ID，跟會員站登入拿到的那組完全不同。店家要能主動推播，就得知道
+// 「這位會員在該店 OA 的 ID 是哪一個」，而 LINE 官方提供的答案就是 account link。
+//
+// 顧客體驗上這頁應該幾乎沒有存在感：他在店家 LINE 裡問訂單，收到一則
+// 「這裡可以查看您的訂單」，點進來（多半已登入）→ 自動轉一圈 → 回到 LINE。
+// 綁定是副作用，他不需要理解「綁定」兩個字。所以這頁不解釋、不要求操作，
+// 只在「還沒登入」時借用既有的登入流程。
+//
+// 登入一律走 useLineLogin，不在這裡重寫 —— 那條路上每個分支都是踩雷換來的。
+
+import { useEffect, useRef, useState } from "react";
+import { logCaught, logClientError } from "@/lib/clientLog";
+import { readParam } from "@/lib/lineAuth";
+import { getSession } from "@/lib/session";
+import { callLiffApi } from "@/lib/supabase";
+import { useLineLogin } from "@/lib/useLineLogin";
+import Spinner, { LoadingScreen } from "@/components/Spinner";
+
+type Phase = "working" | "need_login" | "error";
+
+export default function LinkPage() {
+  const { status, error: loginError, start, storeId, chooseStore, stores } = useLineLogin({
+    autoSelectSingleStore: true,
+  });
+  const [phase, setPhase] = useState<Phase>("working");
+  const [message, setMessage] = useState<string | null>(null);
+  // 轉址只能跑一次：React 嚴格模式會重跑 effect，跑兩次會把 nonce 浪費掉
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+
+    const linkToken = readParam("lt");
+    const storeCode = readParam("store");
+    if (!linkToken || !storeCode) {
+      setPhase("error");
+      setMessage("連結不完整，請回到官方帳號重新點一次。");
+      logClientError("account_link_missing_params", "缺 lt 或 store");
+      return;
+    }
+
+    // 從店家 OA 進來時 useLineLogin 還在跑（可能正在 LIFF 自動登入），
+    // 等它把 session 準備好再動作；沒登入就顯示登入按鈕。
+    const session = getSession();
+    if (!session?.memberId) {
+      if (status === "loading" || status === "liff_auth") return;
+      setPhase("need_login");
+      return;
+    }
+
+    startedRef.current = true;
+    (async () => {
+      try {
+        const { nonce } = await callLiffApi<{ nonce: string }>(session.token, {
+          action: "create_account_link_nonce",
+          store: storeCode,
+        });
+        // 交給 LINE 完成連結；成功後 LINE 會把使用者送回官方帳號對話，
+        // 並對我們的 webhook 發一則 accountLink 事件（帶著同一個 nonce）。
+        window.location.href =
+          `https://access.line.me/dialog/bot/accountLink?linkToken=${encodeURIComponent(linkToken)}` +
+          `&nonce=${encodeURIComponent(nonce)}`;
+      } catch (e) {
+        startedRef.current = false;
+        setPhase("error");
+        setMessage("連結失敗，請回到官方帳號再傳一次訊息取得新的連結。");
+        logCaught("account_link_nonce_failed", e, { store: storeCode });
+      }
+    })();
+  }, [status]);
+
+  if (phase === "working") return <LoadingScreen />;
+
+  if (phase === "need_login") {
+    return (
+      <main className="mx-auto flex min-h-dvh max-w-md flex-col justify-center gap-4 p-6 text-center">
+        <h1 className="text-lg font-semibold">查看我的訂單</h1>
+        <p className="text-sm text-zinc-500">
+          請先用 LINE 登入，登入後就會自動帶您回去。
+        </p>
+
+        {stores.length > 1 && !storeId && (
+          <select
+            value={storeId ?? ""}
+            onChange={(e) => chooseStore(e.target.value || null)}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm"
+          >
+            <option value="">— 請選擇取貨門市 —</option>
+            {stores.map((s) => (
+              <option key={s.id} value={s.code}>{s.name}</option>
+            ))}
+          </select>
+        )}
+
+        <button
+          onClick={start}
+          disabled={!storeId}
+          className="rounded-md bg-[#06C755] px-4 py-3 font-semibold text-white disabled:opacity-50"
+        >
+          {status === "loading" ? <Spinner /> : "用 LINE 登入"}
+        </button>
+
+        {loginError && <p className="text-xs text-red-600">{loginError}</p>}
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-md flex-col justify-center gap-3 p-6 text-center">
+      <p className="text-sm text-red-600">{message}</p>
+    </main>
+  );
+}

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -71,6 +71,39 @@ function resolveSpotImages(
 
 // ─── actions ─────────────────────────────────────────────────────────────────
 
+/**
+ * 建立 account link 用的一次性 nonce。
+ *
+ * 流程：顧客在店家 OA 傳訊息 → webhook 回一則帶 linkToken 的連結 →
+ * 顧客點進會員站 /link 並登入（到這裡我們才知道他是哪位會員）→
+ * 呼叫這支拿 nonce → 導去 LINE 的 accountLink 頁 → LINE 回 accountLink
+ * webhook，帶著同一個 nonce → 綁定完成。
+ *
+ * nonce 是「這是哪位會員」的憑據，所以必須由**已驗證的會員 token** 產生，
+ * 不能讓前端自己指定 member_id。
+ */
+async function createAccountLinkNonce(
+  // deno-lint-ignore no-explicit-any
+  sb: any, tenantId: string, memberId: number, storeCode: string,
+) {
+  const { data: store, error: sErr } = await sb
+    .from("stores").select("id").eq("tenant_id", tenantId).eq("code", storeCode).maybeSingle();
+  if (sErr) return json({ error: sErr.message }, 500);
+  if (!store) return json({ error: "store_not_found" }, 404);
+
+  // LINE 要求 nonce 至少 128 bits、用安全亂數產生
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  const nonce = btoa(String.fromCharCode(...bytes)).replace(/[+/=]/g, (c) =>
+    ({ "+": "-", "/": "_", "=": "" }[c] ?? c));
+
+  const { error } = await sb.from("line_account_link_nonces").insert({
+    nonce, tenant_id: tenantId, store_id: store.id, member_id: memberId,
+  });
+  if (error) return json({ error: error.message }, 500);
+  return json({ nonce });
+}
+
 async function listStores(sb: any, tenantId: string) {
   // line_liff_id：每家店在自己 Provider 底下的 LIFF ID。會員必須用「所屬分店」
   // 那支 LIFF 登入，拿到的 line_user_id 才跟該店官方帳號同 provider、推得動。
@@ -1336,6 +1369,7 @@ Deno.serve(async (req) => {
       switch (action) {
         case "lookup_by_phone": return await lookupByPhone(sb, tenantId, String(body.phone ?? ""));
         case "register_and_bind": return await registerAndBind(sb, { tenantId, storeId, lineUserId, phone: String(body.phone ?? ""), name: String(body.name ?? ""), birthday: String(body.birthday ?? "") });
+        case "create_account_link_nonce": if (!memberId) return json({ error: "no member_id" }, 401); return await createAccountLinkNonce(sb, tenantId, memberId, String(body.store ?? ""));
         case "get_me": if (!memberId) return json({ error: "no member_id" }, 401); return await getMe(sb, tenantId, memberId);
         case "update_me": if (!memberId) return json({ error: "no member_id" }, 401); return await updateMe(sb, tenantId, memberId, body);
         case "get_overview": if (!memberId) return json({ error: "no member_id" }, 401); return await getOverview(sb, tenantId, storeId, memberId);

--- a/supabase/functions/line-webhook/index.ts
+++ b/supabase/functions/line-webhook/index.ts
@@ -17,6 +17,62 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.8";
 
 const LINE_PROFILE_URL = "https://api.line.me/v2/bot/profile";
+const LINE_REPLY_URL = "https://api.line.me/v2/bot/message/reply";
+const LINE_LINK_TOKEN_URL = (uid: string) => `https://api.line.me/v2/bot/user/${uid}/linkToken`;
+
+/** 同一個人多久內只邀一次綁定 —— 不擋的話每傳一句話就收到一則機器訊息 */
+const INVITE_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * 對「還不知道是誰」的顧客回一則帶 account link 的訊息。
+ *
+ * 刻意包裝成「查看我的訂單」而不是「請完成綁定」：顧客本來就是來問訂單的，
+ * 點下去就看到訂單，綁定是順帶發生的副作用，他不需要理解綁定是什麼。
+ *
+ * 用 replyToken 回覆 —— **不吃推播額度**，所以這個機制本身零成本。
+ * 失敗一律吞掉：邀請沒送出去不該影響 webhook 回 200（LINE 會重送整批事件）。
+ */
+async function inviteAccountLink(
+  accessToken: string,
+  replyToken: string,
+  lineUserId: string,
+  storeCode: string,
+  memberBase: string,
+): Promise<boolean> {
+  try {
+    const ltResp = await fetch(LINE_LINK_TOKEN_URL(lineUserId), {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${accessToken}` },
+    });
+    if (!ltResp.ok) {
+      console.error("linkToken failed:", ltResp.status, await ltResp.text());
+      return false;
+    }
+    const { linkToken } = await ltResp.json();
+    // linkToken 只有 10 分鐘效期，所以是「當下回覆」才有意義，不能事後補寄
+    const url = `${memberBase}/link?lt=${encodeURIComponent(linkToken)}&store=${encodeURIComponent(storeCode)}`;
+
+    const rResp = await fetch(LINE_REPLY_URL, {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${accessToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        replyToken,
+        messages: [{
+          type: "text",
+          text: `您好！這裡可以查看您的訂單與取貨進度 👇\n${url}`,
+        }],
+      }),
+    });
+    if (!rResp.ok) {
+      console.error("reply failed:", rResp.status, await rResp.text());
+      return false;
+    }
+    return true;
+  } catch (e) {
+    console.error("inviteAccountLink error:", String(e));
+    return false;
+  }
+}
 
 function requireEnv(name: string): string {
   const v = Deno.env.get(name);
@@ -84,6 +140,9 @@ Deno.serve(async (req) => {
       console.error("no credentials for store:", storeCode);
       return new Response("unknown store", { status: 404 });
     }
+    // PostgREST 的 to-one 關聯有時回物件、有時回陣列，兩種都要接得住
+    const credStoreCode: string | null =
+      (Array.isArray(cred.stores) ? cred.stores[0]?.code : cred.stores?.code) ?? storeCode;
 
     if (!await verifySignature(rawBody, signature, cred.channel_secret)) {
       console.error("bad signature for store:", storeCode);
@@ -154,12 +213,13 @@ Deno.serve(async (req) => {
       let displayName: string | null = null;
       let pictureUrl: string | null = null;
 
-      const { data: existing } = await sb
+      const { data: existing2 } = await sb
         .from("store_line_followers")
-        .select("display_name")
+        .select("display_name, member_id, link_invited_at")
         .eq("store_id", cred.store_id)
         .eq("line_user_id", lineUserId)
         .maybeSingle();
+      const existing = existing2;
 
       if (!existing?.display_name && cred.access_token) {
         try {
@@ -190,6 +250,26 @@ Deno.serve(async (req) => {
         .from("store_line_followers")
         .upsert(row, { onConflict: "store_id,line_user_id", ignoreDuplicates: false });
       if (upErr) console.error("binding upsert failed:", upErr.message);
+
+      // 還不知道他是哪位會員 → 回一則帶 account link 的「查看我的訂單」。
+      // 只在有 replyToken 時做（reply 免額度，且 linkToken 只有 10 分鐘效期，
+      // 事後補寄沒有意義）。已配對的人不打擾。
+      const replyToken = ev.replyToken as string | undefined;
+      const memberBase = (Deno.env.get("MEMBER_FRONT_BASE_URL") ?? "").replace(/\/+$/, "");
+      const invitedAt = existing2?.link_invited_at ? Date.parse(existing2.link_invited_at) : 0;
+      const cooled = Date.now() - invitedAt > INVITE_COOLDOWN_MS;
+
+      if (replyToken && cred.access_token && memberBase && credStoreCode && !existing2?.member_id && cooled) {
+        const sent = await inviteAccountLink(
+          cred.access_token, replyToken, lineUserId, credStoreCode ?? "", memberBase,
+        );
+        if (sent) {
+          await sb.from("store_line_followers")
+            .update({ link_invited_at: new Date().toISOString() })
+            .eq("store_id", cred.store_id)
+            .eq("line_user_id", lineUserId);
+        }
+      }
     }
 
     return new Response("ok", { status: 200 });

--- a/supabase/functions/line-webhook/index.ts
+++ b/supabase/functions/line-webhook/index.ts
@@ -146,9 +146,22 @@ Deno.serve(async (req) => {
       // follow / message / 其他有 userId 的事件 → 至少把這個人記進名冊。
       // member_id 先留 NULL：webhook 只知道「有這個 LINE 使用者」，
       // 不知道他是哪位會員，要等 account link 完成才填得上。
+      // ⚠ 不能只在 type === "follow" 才抓 profile。
+      // 實際上線後多數人是先「傳訊息」才被收進名冊（既有好友不會再觸發 follow），
+      // 只認 follow 的話名冊會一整排沒有名字，店員在配對選單只看得到
+      // "U5a54b59…" 這種字串，等於選不出來（2026-08-08 實際踩到）。
+      // 所以：只要這個人在名冊裡還沒有名字，任何事件都補抓一次。
       let displayName: string | null = null;
       let pictureUrl: string | null = null;
-      if (type === "follow" && cred.access_token) {
+
+      const { data: existing } = await sb
+        .from("store_line_followers")
+        .select("display_name")
+        .eq("store_id", cred.store_id)
+        .eq("line_user_id", lineUserId)
+        .maybeSingle();
+
+      if (!existing?.display_name && cred.access_token) {
         try {
           const p = await fetch(`${LINE_PROFILE_URL}/${lineUserId}`, {
             headers: { "Authorization": `Bearer ${cred.access_token}` },

--- a/supabase/migrations/20260808000010_account_link_invite.sql
+++ b/supabase/migrations/20260808000010_account_link_invite.sql
@@ -1,0 +1,17 @@
+-- ============================================================================
+-- 2026-08-08: account link 邀請的冷卻欄位
+--
+-- 顧客傳訊息給店家 OA 而我們還不知道他是誰時，自動回一則「查看我的訂單」，
+-- 那條連結會帶著 linkToken 走完 account link，把該店 provider 的 ID 跟會員綁起來。
+--
+-- 為什麼要冷卻：不擋的話顧客每傳一句話就收到一則機器訊息，會蓋掉正常對話。
+-- 記下上次邀請時間，同一個人一段時間內只邀一次。
+--
+-- 註：回覆訊息（replyToken）不吃推播額度，所以這個機制本身零成本。
+-- ============================================================================
+
+ALTER TABLE store_line_followers
+  ADD COLUMN IF NOT EXISTS link_invited_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN store_line_followers.link_invited_at IS
+  '上次自動發出 account link 邀請的時間；用來做冷卻，避免每則訊息都回一次';


### PR DESCRIPTION
接續 #645 / #646。這支把 LINE 推播從「試點能動」推到「營運可用」。

## 1. account link 自動綁定（本 PR 的重點）

#646 之後，「名冊裡的人 ↔ 會員」是店員手動挑的。試點夠用，但松山店 OA 有 360 位好友，14 家店就是數千次人工比對 —— 撐不住。

**決策**：走 LINE 官方的 account link，不做「圖文選單引導」或「順其自然」。後兩者只解決「拿到 ID」，配對仍要人工；account link 一次解決兩件事，而且不會配錯人。至於「引導顧客點一下」本來就內含在 account link 裡，不需要另外做。

**刻意包裝成「查看我的訂單」，不是「請完成綁定」** —— 顧客本來就是來問訂單的，點下去看到訂單，綁定是他不會察覺的副作用：

```
顧客：「我的東西到了嗎」
 OA ：「您好！這裡可以查看您的訂單與取貨進度 👇 <連結>」
顧客：點一下 →（多半已登入，直接轉一圈）→ 回到 LINE
     ↑ 綁定完成，全程沒出現「綁定」兩個字
```

實作要點：

- 回覆用 `replyToken` —— **不吃推播額度**，360 位好友全跑一次也是零成本
- `link_invited_at` 冷卻 7 天：不擋的話顧客每傳一句話就收到一則機器訊息
- nonce 由**已驗證的會員 token** 產生（`liff-api` 的 `create_account_link_nonce`），前端不能自己指定 `member_id`
- `/link` 落地頁登入一律走 `useLineLogin`，不重寫登入邏輯；轉址用 ref 擋重入（嚴格模式重跑 effect 會白白燒掉一個 nonce）

## 2. webhook 只在 follow 抓名稱 —— 導致配對選單無法使用（bug fix）

上線後才發現：**既有好友不會再觸發 `follow`**，多數人是「傳訊息」時才被收進名冊，而原本只有 `type === 'follow'` 才去打 `/v2/bot/profile`。結果松山店名冊 5 筆有 4 筆沒有名字，店員在配對選單只看得到 `U5a54b59…`，等於選不出來 —— 功能形同無法使用。

改成：只要該筆還沒有名字，任何事件都補抓一次。線上既有 5 筆已補齊。

## 3. 一鍵帶入「可取貨訂單」圖

店員原本要切到訂單頁截圖再貼進 LINE（四個動作，還可能截到不該給顧客看的欄位）。改成一顆按鈕直接產圖，接上既有的「上傳 line-media → 發送」管線，不新增任何後端。

- 用前端 canvas 而非後端算圖：後端算圖得跑 headless browser，edge function 做不到；而這些資料 admin 本來就有
- **只取 `item.status = 'ready'`**：同一張訂單常混著已取貨 / 未到貨的品項，整張塞給顧客會害他白跑一趟或以為東西少了

產圖預覽時抓到並修掉一個版面 bug：團購名壓在訂單編號上 —— 寬度在切成 14px 之後才量，實際卻是用 bold 16px 畫的。**這種問題 typecheck 和 lint 都不會有反應，必須真的算一張圖出來看。**

## 4. Webhook URL 產生器

先前是口述 URL 給店長手貼，14 家店要手打 14 次結尾的 `?store=<code>`。貼錯的症狀特別難查：webhook 靜默收不到、畫面無任何提示。改成依該店 code 直接產生 + 一鍵複製，並註明「先存憑證再貼 URL」（憑證未設時 `line-webhook` 查不到 channel secret 會回 404，LINE 後台 Verify 會失敗）。

## 驗證

線上實測（松山店 `S002`）：

| 情境 | 結果 |
|---|---|
| `message` 事件、邀請發送失敗 | ✅ **不會**誤標 `link_invited_at`（冷卻期不被白白消耗） |
| `accountLink` 事件 | ✅ 正確建立綁定、`linked_at` 有值 |
| nonce 重放 | ✅ 已標記 `used_at`，不可重複使用 |
| webhook 回應 | ✅ 全程 200，不因邀請失敗讓 LINE 重送整批事件 |
| admin 角色讀未配對名冊（配對選單） | ✅ RLS 通過 |

Playwright（fixture，不碰線上 DB）：Webhook URL 帶正確 store code、複製鈕存在，既有項目全數通過。admin / member 兩個 app 的 typecheck 與 ESLint 乾淨。

## 已知限制

**無法批次匯入既有好友。** 用正確的 Messaging API 憑證重測 `/v2/bot/followers/ids` 仍回 **403** —— 該端點需要認證帳號，目前是輕用量方案。所以名冊只能靠互動累積，account link 就是讓這個累積過程盡量無感的手段。

手動配對選單保留，作為 account link 失敗或特殊狀況的後備。