### PR TITLE
fix(stats): 轉單不再重複計數 — 一進一出總量守恆

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,45 @@ SELECT * FROM <your_rpc>();   -- 換成 store_staff 再跑一次，應該要被�
 
 ---
 
+## 顧客訂單 (customer_orders)
+
+### 取消 / 斷貨掉一個品項之後，記得重算訂單單頭
+
+訂單單頭的狀態只有取貨那一刻（`rpc_record_pickup`）會重算。品項在**取貨之後**
+才被取消（斷貨連動、待補貨取消…）時，沒有任何東西會再去看單頭一眼，訂單就
+永遠卡在 `partially_completed`（部分取貨）結不掉 —— 2026-08 一次收尾了 18 張。
+
+既有的「全品項取消 → 整單 cancelled」規則接不住這種單：它的守衛是
+`NOT EXISTS (status NOT IN ('cancelled','expired'))`，而 `picked_up` 也在
+「NOT IN」外面，所以有取過貨就不成立。
+
+新增任何會把 `customer_order_items` 改成 `cancelled` 的路徑，一律在後面接：
+
+```sql
+PERFORM public._close_orders_all_items_settled(v_order_ids, p_operator, NOW());
+```
+
+（`20260808000000`；沒有待取品項 `pending/reserved/ready` + 至少一件 `picked_up`
+→ `completed`。active 集合刻意跟 `rpc_record_pickup` 的 `v_active_remaining` 同一套，
+「先斷貨後取貨」跟「先取貨後斷貨」才會得到同一個結果。）
+
+### 訂單金額加總一律排除 `cancelled` / `expired` 品項
+
+斷貨用的是 `status='cancelled' + stockout_at`（不另開 status 值，見
+`20260702020000`），所以任何 `SUM(qty * unit_price)` 沒濾 status 就會**跟客人收
+拿不到的貨的錢**。2026-08 修掉時線上 241 張未結單合計多算 NT$24,630。
+
+四個地方要同時改，漏一個就會出現「排序看到的數字跟格子裡的不一樣」：
+
+- `v_customer_order_summary.items_total`（admin 明細 + LIFF 會員端）
+- `rpc_wallet_pay_order.v_items_total`（儲值金可扣上限）
+- `v_admin_orders_list`（`/orders` 列表的項數 / 件數 / 總金額，伺服端排序用）
+- 前端加總：`OrderDetail.tsx`、`orders/page.tsx`、member `OrderCard.tsx`
+
+`items[]` jsonb **不要**濾 —— 前端要繼續把那一列畫出來（紅標「斷貨」/ 刪除線）。
+
+---
+
 ## LINE / LIFF
 
 ### 在 LINE 內建瀏覽器裡，絕對不要把使用者導去 `access.line.me`

--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
 import { PR_TERM_ZH } from "@/lib/prStatus";
+import { orderCountsInTotals, orderItemCountsInTotals } from "@/lib/orderStatus";
 import {
   CAMPAIGN_STATUS_LABEL,
   CAMPAIGN_STATUS_BADGE,
@@ -536,8 +537,10 @@ export default function CampaignsListPage() {
           const [itemRows, ordersList] = await Promise.all([
             fetchAll<{ campaign_id: number }>(() =>
               sb.from("campaign_items").select("campaign_id").in("campaign_id", ids).order("id", { ascending: true })),
-            fetchAll<{ id: number; campaign_id: number; order_kind: string }>(() =>
-              sb.from("customer_orders").select("id, campaign_id, order_kind").in("campaign_id", ids).order("id", { ascending: true })),
+            // 已取消/過期/轉出的單不入總數量；轉出單的品項會原樣複製到轉入單，
+            // 不濾就會一單算兩次（見 orderStatus.ts 的統計規則）
+            fetchAll<{ id: number; campaign_id: number; order_kind: string; status: string }>(() =>
+              sb.from("customer_orders").select("id, campaign_id, order_kind, status").in("campaign_id", ids).order("id", { ascending: true })),
           ]);
           const m = new Map<number, number>();
           for (const id of ids) m.set(id, 0);
@@ -547,11 +550,11 @@ export default function CampaignsListPage() {
 
           // 抓 items qty 並依 order_kind 聚合到 campaign — chunked by orderId in batches + range
           const orderIds = ordersList.map((o) => o.id);
-          const oqRows: { order_id: number; qty: number }[] = [];
+          const oqRows: { order_id: number; qty: number; status: string }[] = [];
           for (let i = 0; i < orderIds.length; i += 500) {
             const chunk = orderIds.slice(i, i + 500);
-            const rows = await fetchAll<{ order_id: number; qty: number }>(() =>
-              sb.from("customer_order_items").select("order_id, qty").in("order_id", chunk).order("id", { ascending: true }));
+            const rows = await fetchAll<{ order_id: number; qty: number; status: string }>(() =>
+              sb.from("customer_order_items").select("order_id, qty, status").in("order_id", chunk).order("id", { ascending: true }));
             oqRows.push(...rows);
           }
           const orderMeta = new Map(ordersList.map((o) => [o.id, o]));
@@ -560,6 +563,8 @@ export default function CampaignsListPage() {
           for (const it of oqRows) {
             const meta = orderMeta.get(it.order_id);
             if (!meta) continue;
+            if (!orderCountsInTotals(meta.status)) continue;
+            if (!orderItemCountsInTotals(it.status)) continue;
             const cur = om.get(meta.campaign_id) ?? { normalQty: 0, offsetQty: 0 };
             if (meta.order_kind === "offset") cur.offsetQty += Number(it.qty);
             else cur.normalQty += Number(it.qty);
@@ -652,8 +657,9 @@ export default function CampaignsListPage() {
         const [itemRows, ordersList] = await Promise.all([
           fetchAll<{ campaign_id: number }>(() =>
             sb.from("campaign_items").select("campaign_id").in("campaign_id", ids).order("id", { ascending: true })),
-          fetchAll<{ id: number; campaign_id: number; order_kind: string }>(() =>
-            sb.from("customer_orders").select("id, campaign_id, order_kind").in("campaign_id", ids).order("id", { ascending: true })),
+          // 同上：已取消/過期/轉出的單不入總數量
+          fetchAll<{ id: number; campaign_id: number; order_kind: string; status: string }>(() =>
+            sb.from("customer_orders").select("id, campaign_id, order_kind, status").in("campaign_id", ids).order("id", { ascending: true })),
         ]);
         if (cancelled) return;
         const im = new Map<number, number>();
@@ -663,11 +669,11 @@ export default function CampaignsListPage() {
         for (const it of itemRows) im.set(it.campaign_id, (im.get(it.campaign_id) ?? 0) + 1);
 
         const orderIds = ordersList.map((o) => o.id);
-        const oqRows: { order_id: number; qty: number }[] = [];
+        const oqRows: { order_id: number; qty: number; status: string }[] = [];
         for (let i = 0; i < orderIds.length; i += 500) {
           const chunk = orderIds.slice(i, i + 500);
-          const rows = await fetchAll<{ order_id: number; qty: number }>(() =>
-            sb.from("customer_order_items").select("order_id, qty").in("order_id", chunk).order("id", { ascending: true }));
+          const rows = await fetchAll<{ order_id: number; qty: number; status: string }>(() =>
+            sb.from("customer_order_items").select("order_id, qty, status").in("order_id", chunk).order("id", { ascending: true }));
           oqRows.push(...rows);
         }
         if (cancelled) return;
@@ -675,6 +681,8 @@ export default function CampaignsListPage() {
         for (const it of oqRows) {
           const meta = orderMeta.get(it.order_id);
           if (!meta) continue;
+          if (!orderCountsInTotals(meta.status)) continue;
+          if (!orderItemCountsInTotals(it.status)) continue;
           if (meta.order_kind === "offset") {
             offm.set(meta.campaign_id, (offm.get(meta.campaign_id) ?? 0) + Number(it.qty));
           } else {

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -14,7 +14,7 @@ import { printViaIframe } from "@/lib/printIframe";
 import { fetchReprintableEvents } from "@/lib/pickupReceipt";
 import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 import { useRole } from "@/lib/role";
-import { ORDER_STATUS_LABEL as STATUS_LABEL, orderItemCountsInTotals, type OrderStatus } from "@/lib/orderStatus";
+import { ORDER_STATUS_LABEL as STATUS_LABEL, type OrderStatus } from "@/lib/orderStatus";
 import { summarizeOrderSource } from "@/lib/orderSource";
 import { OrderSourceBadge } from "@/components/OrderSourceBadge";
 import SpinButton from "@/components/SpinButton";
@@ -551,10 +551,11 @@ function OrdersListContent() {
         const shippingIds = list.filter((r) => r.status === "shipping").map((r) => r.id);
         const [ic, ms, rdy] = await Promise.all([
           ids.length
-            // 撈 status：部分轉出把整項轉走的來源品項標 cancelled 留在原單，
-            // 不濾掉這一列的「數量/金額」會停在轉出前的值（見 orderStatus.ts）
-            ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price, source, status, sku:skus(product_name, variant_name)").in("order_id", ids)
-            : Promise.resolve({ data: [] as { order_id: number; qty: number; unit_price: number; source: string; status: string; sku: { product_name: string | null; variant_name: string | null } | null }[] }),
+            // 已取消 / 斷貨 / 過期的品項不算進項數 · 件數 · 金額，與伺服端
+            // v_admin_orders_list 的彙總（可排序欄位）同一套過濾，見 migration
+            // 20260808000010；不然「排序看到的數字」跟「格子裡的數字」會對不起來。
+            ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price, source, sku:skus(product_name, variant_name)").in("order_id", ids).not("status", "in", "(cancelled,expired)")
+            : Promise.resolve({ data: [] as { order_id: number; qty: number; unit_price: number; source: string; sku: { product_name: string | null; variant_name: string | null } | null }[] }),
           memIds.length
             ? getSupabase().from("members").select("id, name, phone, member_no, avatar_url").in("id", memIds)
             : Promise.resolve({ data: [] as Member[] }),
@@ -564,8 +565,7 @@ function OrdersListContent() {
         ]);
         const im = new Map<number, { lineCount: number; totalQty: number; totalAmount: number; items: { product_name: string | null; variant_name: string | null; qty: number }[]; sources: string[] }>();
         for (const id of ids) im.set(id, { lineCount: 0, totalQty: 0, totalAmount: 0, items: [], sources: [] });
-        for (const it of (ic.data as { order_id: number; qty: number; unit_price: number; source: string; status: string; sku: { product_name: string | null; variant_name: string | null } | null }[]) ?? []) {
-          if (!orderItemCountsInTotals(it.status)) continue;
+        for (const it of (ic.data as { order_id: number; qty: number; unit_price: number; source: string; sku: { product_name: string | null; variant_name: string | null } | null }[]) ?? []) {
           const cur = im.get(it.order_id) ?? { lineCount: 0, totalQty: 0, totalAmount: 0, items: [], sources: [] };
           cur.lineCount += 1;
           cur.totalQty += Number(it.qty);

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -14,7 +14,7 @@ import { printViaIframe } from "@/lib/printIframe";
 import { fetchReprintableEvents } from "@/lib/pickupReceipt";
 import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 import { useRole } from "@/lib/role";
-import { ORDER_STATUS_LABEL as STATUS_LABEL, type OrderStatus } from "@/lib/orderStatus";
+import { ORDER_STATUS_LABEL as STATUS_LABEL, orderItemCountsInTotals, type OrderStatus } from "@/lib/orderStatus";
 import { summarizeOrderSource } from "@/lib/orderSource";
 import { OrderSourceBadge } from "@/components/OrderSourceBadge";
 import SpinButton from "@/components/SpinButton";
@@ -551,8 +551,10 @@ function OrdersListContent() {
         const shippingIds = list.filter((r) => r.status === "shipping").map((r) => r.id);
         const [ic, ms, rdy] = await Promise.all([
           ids.length
-            ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price, source, sku:skus(product_name, variant_name)").in("order_id", ids)
-            : Promise.resolve({ data: [] as { order_id: number; qty: number; unit_price: number; source: string; sku: { product_name: string | null; variant_name: string | null } | null }[] }),
+            // 撈 status：部分轉出把整項轉走的來源品項標 cancelled 留在原單，
+            // 不濾掉這一列的「數量/金額」會停在轉出前的值（見 orderStatus.ts）
+            ? getSupabase().from("customer_order_items").select("order_id, qty, unit_price, source, status, sku:skus(product_name, variant_name)").in("order_id", ids)
+            : Promise.resolve({ data: [] as { order_id: number; qty: number; unit_price: number; source: string; status: string; sku: { product_name: string | null; variant_name: string | null } | null }[] }),
           memIds.length
             ? getSupabase().from("members").select("id, name, phone, member_no, avatar_url").in("id", memIds)
             : Promise.resolve({ data: [] as Member[] }),
@@ -562,7 +564,8 @@ function OrdersListContent() {
         ]);
         const im = new Map<number, { lineCount: number; totalQty: number; totalAmount: number; items: { product_name: string | null; variant_name: string | null; qty: number }[]; sources: string[] }>();
         for (const id of ids) im.set(id, { lineCount: 0, totalQty: 0, totalAmount: 0, items: [], sources: [] });
-        for (const it of (ic.data as { order_id: number; qty: number; unit_price: number; source: string; sku: { product_name: string | null; variant_name: string | null } | null }[]) ?? []) {
+        for (const it of (ic.data as { order_id: number; qty: number; unit_price: number; source: string; status: string; sku: { product_name: string | null; variant_name: string | null } | null }[]) ?? []) {
+          if (!orderItemCountsInTotals(it.status)) continue;
           const cur = im.get(it.order_id) ?? { lineCount: 0, totalQty: 0, totalAmount: 0, items: [], sources: [] };
           cur.lineCount += 1;
           cur.totalQty += Number(it.qty);

--- a/apps/admin/src/app/(protected)/picking/print-sign/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/print-sign/page.tsx
@@ -19,6 +19,7 @@ type WaveRow = {
   wave_code: string;
   wave_date: string;
   status: string;
+  created_at: string;
 };
 
 type StoreRow = { id: number; code: string | null; name: string };
@@ -36,10 +37,20 @@ type StoreSheet = {
     qty: number;
     pickedQty: number;
     waveCodes: string[];
+    unitPrice: number | null; // 分店價(prices scope='branch' 現行價)；查無 = null
+    subtotal: number | null;
   }[];
   totalPicked: number;
+  totalAmount: number; // 只加總查得到分店價的品項
+  hasMissingPrice: boolean;
   waveDates: string[]; // 涵蓋的配送日(可能多日)
+  orderDates: string[]; // 涵蓋的撿貨單建立日 = 表頭「訂單日」
 };
+
+// 表頭金額一律無小數（分店進貨單對的是整數台幣）
+function money(n: number): string {
+  return `$${Math.round(n).toLocaleString("en-US")}`;
+}
 
 export default function PrintSignPage() {
   const [date, setDate] = useState("");
@@ -48,6 +59,7 @@ export default function PrintSignPage() {
   const [items, setItems] = useState<WaveItem[]>([]);
   const [stores, setStores] = useState<StoreRow[]>([]);
   const [skus, setSkus] = useState<SkuRow[]>([]);
+  const [prices, setPrices] = useState<Map<number, number>>(new Map());
   const [error, setError] = useState<string | null>(null);
   const [tenantName, setTenantName] = useState("");
 
@@ -76,7 +88,7 @@ export default function PrintSignPage() {
         const sb = getSupabase();
         const q = sb
           .from("picking_waves")
-          .select("id, wave_code, wave_date, status")
+          .select("id, wave_code, wave_date, status, created_at")
           .neq("status", "cancelled")
           .order("wave_date", { ascending: true })
           .order("created_at", { ascending: true });
@@ -123,6 +135,25 @@ export default function PrintSignPage() {
           setSkus((sk.data as SkuRow[]) ?? []);
         }
 
+        // 單價 = 現行分店價（prices scope='branch' 且 effective_to IS NULL）。
+        // 這是派貨守衛也在檢查的那個價，跟月結拿到的價一致；查無價的品項印「—」不併入合計。
+        // .in() 有長度上限，跟派貨工作台一樣切 150 一批。
+        const priceMap = new Map<number, number>();
+        for (let i = 0; i < skuIds.length; i += 150) {
+          const chunk = skuIds.slice(i, i + 150);
+          const { data: priceRows, error: e3 } = await sb
+            .from("prices")
+            .select("sku_id, price")
+            .eq("scope", "branch")
+            .is("effective_to", null)
+            .in("sku_id", chunk);
+          if (e3) throw new Error(e3.message);
+          for (const p of (priceRows ?? []) as { sku_id: number; price: number }[]) {
+            if (!priceMap.has(p.sku_id)) priceMap.set(p.sku_id, Number(p.price));
+          }
+        }
+        if (!cancelled) setPrices(priceMap);
+
         const { data: tenantData } = await sb.from("tenants").select("name").limit(1);
         if (!cancelled) {
           const t = (tenantData as { name: string }[] | null)?.[0];
@@ -142,6 +173,10 @@ export default function PrintSignPage() {
     const skuMap = new Map(skus.map((s) => [s.id, s]));
     const waveCodeMap = new Map(waves.map((w) => [w.id, w.wave_code]));
     const waveDateMap = new Map(waves.map((w) => [w.id, w.wave_date]));
+    // 撿貨單建立日 → 表頭「訂單日」（wave_date 是配送/出貨日，兩者常差一天）
+    const orderDateMap = new Map(
+      waves.map((w) => [w.id, new Date(w.created_at).toLocaleDateString("sv-SE")])
+    );
 
     // (store_id) -> (sku_id) -> { qty, picked_qty, waveCodes Set, waveDates Set }
     const byStore = new Map<
@@ -149,10 +184,12 @@ export default function PrintSignPage() {
       {
         skus: Map<number, { qty: number; pickedQty: number; waveCodes: Set<string> }>;
         waveDates: Set<string>;
+        orderDates: Set<string>;
       }
     >();
     for (const it of items) {
-      if (!byStore.has(it.store_id)) byStore.set(it.store_id, { skus: new Map(), waveDates: new Set() });
+      if (!byStore.has(it.store_id))
+        byStore.set(it.store_id, { skus: new Map(), waveDates: new Set(), orderDates: new Set() });
       const slot = byStore.get(it.store_id)!;
       const cur = slot.skus.get(it.sku_id) ?? {
         qty: 0,
@@ -169,6 +206,8 @@ export default function PrintSignPage() {
       if (wc) cur.waveCodes.add(wc);
       const wd = waveDateMap.get(it.wave_id);
       if (wd) slot.waveDates.add(wd);
+      const od = orderDateMap.get(it.wave_id);
+      if (od) slot.orderDates.add(od);
       slot.skus.set(it.sku_id, cur);
     }
 
@@ -177,22 +216,38 @@ export default function PrintSignPage() {
       const slot = byStore.get(store.id);
       if (!slot || slot.skus.size === 0) continue;
       const rows = Array.from(slot.skus.entries())
-        .map(([skuId, v]) => ({
-          sku: skuMap.get(skuId) ?? { id: skuId, sku_code: null, product_name: null, variant_name: null },
-          qty: v.qty,
-          pickedQty: v.pickedQty,
-          waveCodes: Array.from(v.waveCodes).sort(),
-        }))
+        .map(([skuId, v]) => {
+          const unitPrice = prices.get(skuId) ?? null;
+          return {
+            sku: skuMap.get(skuId) ?? { id: skuId, sku_code: null, product_name: null, variant_name: null },
+            qty: v.qty,
+            pickedQty: v.pickedQty,
+            waveCodes: Array.from(v.waveCodes).sort(),
+            unitPrice,
+            // 小計照「實際配發量」算 — 短撿時分店只該被收到的貨算錢
+            subtotal: unitPrice == null ? null : unitPrice * v.pickedQty,
+          };
+        })
         .sort((a, b) => (a.sku.sku_code ?? "").localeCompare(b.sku.sku_code ?? ""))
         // 派貨計畫中(qty>0)的品項都要列上,即使尚未撿貨/短缺到 0
         // ─ 司機 / 收貨店家才知道「應該」收到什麼,short-pick 也看得出來
         .filter((r) => r.qty > 0 || r.pickedQty > 0);
       if (rows.length === 0) continue;
       const totalPicked = rows.reduce((s, r) => s + r.pickedQty, 0);
-      result.push({ store, rows, totalPicked, waveDates: Array.from(slot.waveDates).sort() });
+      const totalAmount = rows.reduce((s, r) => s + (r.subtotal ?? 0), 0);
+      const hasMissingPrice = rows.some((r) => r.unitPrice == null);
+      result.push({
+        store,
+        rows,
+        totalPicked,
+        totalAmount,
+        hasMissingPrice,
+        waveDates: Array.from(slot.waveDates).sort(),
+        orderDates: Array.from(slot.orderDates).sort(),
+      });
     }
     return result;
-  }, [waves, items, stores, skus]);
+  }, [waves, items, stores, skus, prices]);
 
   if (!date && !waveIds) {
     return <div className="p-6 text-sm text-zinc-500">載入中…</div>;
@@ -291,7 +346,10 @@ export default function PrintSignPage() {
                   </span>
                 </div>
                 <div className="mt-0.5 text-xs text-zinc-600">
-                  {sheets.length} 間分店 · {sheets.reduce((s, sh) => s + sh.totalPicked, 0)} 件
+                  {sheets.length} 間分店 · {sheets.reduce((s, sh) => s + sh.totalPicked, 0)} 件 ·{" "}
+                  <span className="font-mono">
+                    {money(sheets.reduce((s, sh) => s + sh.totalAmount, 0))}
+                  </span>
                 </div>
               </div>
             </div>
@@ -309,7 +367,9 @@ export default function PrintSignPage() {
                       )}
                     </div>
                     <div className="text-xs text-zinc-600">
-                      {sheet.rows.length} 樣 · {sheet.totalPicked} 件
+                      {sheet.rows.length} 樣 · {sheet.totalPicked} 件 ·{" "}
+                      <span className="font-mono">{money(sheet.totalAmount)}</span>
+                      {sheet.hasMissingPrice && <span className="ml-1 text-zinc-400">(部分未定價)</span>}
                     </div>
                   </div>
                   <ul className="ml-2 grid grid-cols-2 gap-x-6 gap-y-0.5 text-sm">
@@ -339,80 +399,78 @@ export default function PrintSignPage() {
             key={sheet.store.id}
             className="sheet mx-auto my-6 max-w-[210mm] border border-zinc-300 bg-white p-8 print:my-0 print:border-0 print:p-0"
           >
-            {/* 表頭 */}
-            <div className="mb-4 flex items-start justify-between border-b-2 border-zinc-900 pb-2">
-              <div>
-                <div className="text-xl font-bold">分店簽收單</div>
-                {tenantName && (
-                  <div className="mt-0.5 text-xs text-zinc-500">{tenantName}</div>
-                )}
-              </div>
-              <div className="text-right text-sm">
-                <div>
-                  配送日：<span className="font-mono font-semibold">{sheet.waveDates.join("、") || date}</span>
-                </div>
-                <div className="mt-0.5 text-xs text-zinc-600">
-                  撿貨單號：
-                  <span className="font-mono">
-                    {Array.from(new Set(sheet.rows.flatMap((r) => r.waveCodes))).join("、")}
-                  </span>
-                </div>
-              </div>
+            {/* 表頭 — 公司抬頭置中，底下左右兩欄的單頭欄位（單號/訂單日 ‧ 店家/出貨日）*/}
+            <div className="mb-3 text-center">
+              {tenantName && <div className="text-lg font-bold tracking-wide">{tenantName}</div>}
+              <div className="text-xs text-zinc-500">分店進貨單</div>
             </div>
 
-            {/* 分店資訊 */}
-            <div className="mb-4 flex justify-between text-sm">
-              <div>
-                <div className="text-xs text-zinc-500">收貨分店</div>
-                <div className="text-lg font-semibold">
+            <div className="mb-2 grid grid-cols-2 gap-x-8 text-sm">
+              <div className="flex">
+                <span className="w-16 shrink-0 text-zinc-500">單號</span>
+                <span className="font-mono font-semibold">
+                  {Array.from(new Set(sheet.rows.flatMap((r) => r.waveCodes))).join("、") || "—"}
+                </span>
+              </div>
+              <div className="flex">
+                <span className="w-16 shrink-0 text-zinc-500">店家</span>
+                <span className="font-semibold">
                   {sheet.store.name}
                   {sheet.store.code && (
-                    <span className="ml-2 font-mono text-sm text-zinc-500">
-                      ({sheet.store.code})
-                    </span>
+                    <span className="ml-2 font-mono text-xs text-zinc-500">({sheet.store.code})</span>
                   )}
-                </div>
+                </span>
               </div>
-              <div className="text-right">
-                <div className="text-xs text-zinc-500">合計</div>
-                <div className="text-lg font-semibold">{sheet.totalPicked} 件</div>
+              <div className="flex">
+                <span className="w-16 shrink-0 text-zinc-500">訂單日</span>
+                <span className="font-mono">{sheet.orderDates.join("、") || "—"}</span>
+              </div>
+              <div className="flex">
+                <span className="w-16 shrink-0 text-zinc-500">出貨日</span>
+                <span className="font-mono">{sheet.waveDates.join("、") || date}</span>
               </div>
             </div>
 
-            {/* 商品表 */}
+            {/* 商品表 — 編號 / 商品名稱 / 數量 / 單價 / 小計（＋點收框）*/}
             <table className="w-full border-collapse text-sm">
               <thead>
-                <tr className="border-b-2 border-zinc-900">
-                  <th className="border border-zinc-400 px-2 py-1.5 text-left text-xs">#</th>
-                  <th className="border border-zinc-400 px-2 py-1.5 text-left text-xs">商品編號</th>
-                  <th className="border border-zinc-400 px-2 py-1.5 text-left text-xs">品名</th>
-                  <th className="border border-zinc-400 px-2 py-1.5 text-right text-xs">訂購數量</th>
-                  <th className="border border-zinc-400 px-2 py-1.5 text-right text-xs">配發數量</th>
-                  <th className="border border-zinc-400 px-2 py-1.5 text-center text-xs">收貨確認</th>
+                <tr className="bg-zinc-100">
+                  <th className="border border-zinc-400 px-2 py-1.5 text-left text-xs font-semibold">編號</th>
+                  <th className="border border-zinc-400 px-2 py-1.5 text-left text-xs font-semibold">商品名稱</th>
+                  <th className="w-16 border border-zinc-400 px-2 py-1.5 text-right text-xs font-semibold">數量</th>
+                  <th className="w-20 border border-zinc-400 px-2 py-1.5 text-right text-xs font-semibold">單價</th>
+                  <th className="w-24 border border-zinc-400 px-2 py-1.5 text-right text-xs font-semibold">小計</th>
+                  <th className="w-12 whitespace-nowrap border border-zinc-400 px-2 py-1.5 text-center text-xs font-semibold">
+                    點收
+                  </th>
                 </tr>
               </thead>
               <tbody>
-                {sheet.rows.map((r, i) => (
+                {sheet.rows.map((r) => (
                   <tr key={r.sku.id}>
-                    <td className="border border-zinc-400 px-2 py-1.5 text-xs">{i + 1}</td>
-                    <td className="border border-zinc-400 px-2 py-1.5 font-mono text-xs">
+                    <td className="border border-zinc-400 px-2 py-1 font-mono text-xs">
                       {r.sku.sku_code ?? "—"}
                     </td>
-                    <td className="border border-zinc-400 px-2 py-1.5">
+                    <td className="border border-zinc-400 px-2 py-1">
                       {r.sku.product_name ?? "—"}
                       {r.sku.variant_name && (
                         <span className="ml-1 text-xs text-zinc-500">/ {r.sku.variant_name}</span>
                       )}
                     </td>
-                    <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono">
-                      {r.qty}
+                    {/* 數量 = 實際配發量；短撿時在旁邊補註訂購量，分店才對得出少了什麼 */}
+                    <td className="border border-zinc-400 px-2 py-1 text-right font-mono">
+                      <span className={r.pickedQty < r.qty ? "text-rose-600" : ""}>{r.pickedQty}</span>
+                      {r.pickedQty < r.qty && (
+                        <span className="ml-1 text-[10px] text-zinc-500">(訂 {r.qty})</span>
+                      )}
                     </td>
-                    <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono">
-                      <span className={r.pickedQty < r.qty ? "text-rose-600" : ""} title={r.pickedQty < r.qty ? `配發 ${r.pickedQty} 少於訂購 ${r.qty}` : undefined}>
-                        {r.pickedQty}
-                      </span>
+                    <td className="border border-zinc-400 px-2 py-1 text-right font-mono">
+                      {r.unitPrice == null ? "—" : money(r.unitPrice)}
                     </td>
-                    <td className="border border-zinc-400 px-2 py-1.5 text-center">
+                    <td className="border border-zinc-400 px-2 py-1 text-right font-mono">
+                      {r.subtotal == null ? "—" : money(r.subtotal)}
+                    </td>
+                    <td className="border border-zinc-400 px-2 py-1 text-center">
                       <span className="text-zinc-300">□</span>
                     </td>
                   </tr>
@@ -428,21 +486,28 @@ export default function PrintSignPage() {
                     <td className="border border-zinc-400 px-2 py-3"></td>
                   </tr>
                 ))}
-                {/* 合計列 */}
+                {/* 合計列 — 件數 + 金額，對齊紙本單 */}
                 <tr className="bg-zinc-100 font-semibold">
-                  <td colSpan={3} className="border border-zinc-400 px-2 py-1.5 text-right">
+                  <td colSpan={2} className="border border-zinc-400 px-2 py-1.5 text-right">
                     合計
                   </td>
                   <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono">
-                    {sheet.rows.reduce((s, r) => s + r.qty, 0)}
+                    {sheet.totalPicked} 件
                   </td>
+                  <td className="border border-zinc-400 px-2 py-1.5"></td>
                   <td className="border border-zinc-400 px-2 py-1.5 text-right font-mono">
-                    {sheet.totalPicked}
+                    {money(sheet.totalAmount)}
                   </td>
                   <td className="border border-zinc-400 px-2 py-1.5"></td>
                 </tr>
               </tbody>
             </table>
+
+            {sheet.hasMissingPrice && (
+              <div className="mt-1 text-[10px] text-zinc-500">
+                ※ 標「—」的品項尚未設定分店價，未計入合計金額。
+              </div>
+            )}
 
             {/* 簽名區 */}
             <div className="mt-8 grid grid-cols-2 gap-8 text-sm">

--- a/apps/admin/src/app/(protected)/stores/page.tsx
+++ b/apps/admin/src/app/(protected)/stores/page.tsx
@@ -519,7 +519,7 @@ function StoreForm({
           </span>
         </F>
 
-        <StoreLineOaField storeId={v.id} />
+        <StoreLineOaField storeId={v.id} storeCode={v.code} />
 
         <F label="備註" className="sm:col-span-4">
           <textarea

--- a/apps/admin/src/components/CampaignOrdersPanel.tsx
+++ b/apps/admin/src/components/CampaignOrdersPanel.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import { useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
-import { orderStatusLabel } from "@/lib/orderStatus";
+import { orderStatusLabel, orderCountsInTotals, orderItemCountsInTotals } from "@/lib/orderStatus";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
 
@@ -18,7 +18,7 @@ type OrderRow = {
   order_kind: string | null;
   created_at: string;
   member: { id: number; name: string | null } | null;
-  customer_order_items: { qty: number; unit_price: number }[];
+  customer_order_items: { qty: number; unit_price: number; status: string | null }[];
 };
 
 type Store = { id: number; code: string; name: string };
@@ -55,7 +55,9 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
           sb
             .from("customer_orders")
             .select(
-              "id, order_no, status, pickup_store_id, nickname_snapshot, notes, order_kind, created_at, member:members(id, name), customer_order_items(qty, unit_price)",
+              // 品項 status 一定要撈：部分轉出把來源品項標 cancelled 留在原單，
+              // 不濾掉就會跟轉入單重複計（見 orderStatus.ts 的統計規則）
+              "id, order_no, status, pickup_store_id, nickname_snapshot, notes, order_kind, created_at, member:members(id, name), customer_order_items(qty, unit_price, status)",
             )
             .eq("campaign_id", campaignId)
             .order("created_at", { ascending: false }),
@@ -96,13 +98,15 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
     let normalCount = 0;
     let offsetCount = 0;
     for (const r of filtered) {
+      const counts = orderCountsInTotals(r.status);
       const isOffset = r.order_kind === "offset";
       if (isOffset) offsetCount++;
-      else if (r.status !== "cancelled" && r.status !== "expired") normalCount++;
+      else if (counts) normalCount++;
+      if (!counts) continue;
       for (const it of r.customer_order_items ?? []) {
+        if (!orderItemCountsInTotals(it.status)) continue;
         const q = Number(it.qty);
         if (!Number.isFinite(q)) continue;
-        if (r.status === "cancelled" || r.status === "expired") continue;
         qty += q;
         amount += q * Number(it.unit_price);
       }
@@ -175,11 +179,14 @@ export function CampaignOrdersPanel({ campaignId }: { campaignId: number }) {
               <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
                 {filtered.map((r) => {
                   const store = stores.find((s) => s.id === r.pickup_store_id);
-                  const items = r.customer_order_items ?? [];
+                  // 只算「還在這張單上」的品項：部分轉出的來源品項留在原單但已 cancelled，
+                  // 一起算的話這列會顯示轉出前的數量、跟小計對不起來
+                  const items = (r.customer_order_items ?? []).filter((i) => orderItemCountsInTotals(i.status));
                   const qty = items.reduce((s, i) => s + Number(i.qty || 0), 0);
                   const amt = items.reduce((s, i) => s + Number(i.qty || 0) * Number(i.unit_price || 0), 0);
                   const isOffset = r.order_kind === "offset";
-                  const isCancelled = r.status === "cancelled" || r.status === "expired";
+                  // 已轉出的單跟已取消一樣不入小計 → 一樣淡化，避免看起來像漏加
+                  const isCancelled = !orderCountsInTotals(r.status);
                   return (
                     <tr
                       key={r.id}

--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -16,6 +16,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
+import { renderPickupImage, type PickupOrder } from "@/lib/pickupImage";
 
 const BUCKET = "line-media";
 const FN_URL = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/admin-line-push`;
@@ -97,7 +98,7 @@ async function encodeJpeg(file: File, maxDim: number, quality: number): Promise<
 }
 
 export function LineMessageModal({
-  open, onClose, member, tenantId, homeStoreId = null,
+  open, onClose, member, tenantId, homeStoreId = null, storeName = null,
 }: {
   open: boolean;
   onClose: () => void;
@@ -105,6 +106,8 @@ export function LineMessageModal({
   tenantId: string;
   /** 會員取貨店 —— 決定要看哪一家店的 OA 名冊 */
   homeStoreId?: number | null;
+  /** 取貨店名稱，印在可取貨訂單圖的抬頭 */
+  storeName?: string | null;
 }) {
   const [reachable, setReachable] = useState<Reachable>({ state: "checking" });
   const [quota, setQuota] = useState<Quota | null>(null);
@@ -112,6 +115,7 @@ export function LineMessageModal({
   const [ordersUrl, setOrdersUrl] = useState<string | null>(null);
   const [followers, setFollowers] = useState<Follower[]>([]);
   const [binding, setBinding] = useState(false);
+  const [buildingImage, setBuildingImage] = useState(false);
   const [text, setText] = useState("");
   const [image, setImage] = useState<File | null>(null);
   const [sending, setSending] = useState(false);
@@ -195,6 +199,68 @@ export function LineMessageModal({
   useEffect(() => {
     return () => { if (imagePreview) URL.revokeObjectURL(imagePreview); };
   }, [imagePreview]);
+
+  /**
+   * 把該會員的可取貨品項畫成一張圖，直接放進附圖欄。
+   *
+   * 只取 item.status = 'ready'（可取貨）—— 同一張訂單裡可能混著已取貨 / 未到貨的
+   * 品項，整張塞給顧客會讓他白跑一趟或以為東西少了。
+   */
+  async function buildPickupImage() {
+    setBuildingImage(true);
+    setError(null);
+    try {
+      const { data, error: qErr } = await getSupabase()
+        .from("customer_orders")
+        .select("order_no, status, campaign:group_buy_campaigns(name), customer_order_items(qty, unit_price, status, skus(sku_code, products(name)))")
+        .eq("member_id", member.id)
+        .in("status", ["ready", "partially_completed"])
+        .order("created_at", { ascending: false });
+      if (qErr) { setError(qErr.message); return; }
+
+      type Row = {
+        order_no: string;
+        campaign: { name: string } | { name: string }[] | null;
+        customer_order_items: {
+          qty: number; unit_price: number | null; status: string | null;
+          skus: { sku_code: string | null; products: { name: string } | { name: string }[] | null } | null;
+        }[] | null;
+      };
+      const one = <T,>(v: T | T[] | null): T | null => (Array.isArray(v) ? v[0] ?? null : v);
+
+      const orders: PickupOrder[] = ((data ?? []) as unknown as Row[])
+        .map((o) => ({
+          orderNo: o.order_no,
+          campaign: one(o.campaign)?.name ?? null,
+          lines: (o.customer_order_items ?? [])
+            .filter((it) => it.status === "ready")
+            .map((it) => ({
+              name: one(one(it.skus)?.products ?? null)?.name
+                ?? one(it.skus)?.sku_code
+                ?? "（品項）",
+              qty: Number(it.qty ?? 0),
+              unitPrice: it.unit_price == null ? null : Number(it.unit_price),
+            })),
+        }))
+        .filter((o) => o.lines.length > 0);
+
+      if (orders.length === 0) {
+        setError("這位會員目前沒有可取貨的品項");
+        return;
+      }
+
+      const blob = await renderPickupImage({
+        storeName,
+        memberName: member.name,
+        orders,
+      });
+      setImage(new File([blob], "pickup.jpg", { type: "image/jpeg" }));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBuildingImage(false);
+    }
+  }
 
   function pickImage(file: File) {
     if (!file.type.startsWith("image/")) {
@@ -419,6 +485,15 @@ export function LineMessageModal({
           <span className="mb-1 block text-xs text-zinc-500">
             截圖 / 圖片（可直接 Ctrl+V 貼上）
           </span>
+          {!imagePreview && (
+            <SpinButton
+              onClick={buildPickupImage}
+              disabled={buildingImage}
+              className="mb-2 mr-2 rounded-md border border-emerald-300 px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-950"
+            >
+              {buildingImage ? "產生中…" : "📋 帶入可取貨訂單圖"}
+            </SpinButton>
+          )}
           {imagePreview ? (
             <div className="relative inline-block">
               {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -9,7 +9,7 @@ import { LineMessageModal } from "@/components/LineMessageModal";
 import { WalletActionModal, type WalletActionMode } from "@/components/WalletActionModal";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
-import { orderStatusLabel } from "@/lib/orderStatus";
+import { orderStatusLabel, orderCountsInTotals, orderItemCountsInTotals } from "@/lib/orderStatus";
 import { translateRpcError } from "@/lib/rpcError";
 import { canAdjustWallet, isAdmin, useRole } from "@/lib/role";
 import { walletLedgerTypeLabel, walletPaymentMethodLabel } from "@/lib/walletLedger";
@@ -83,7 +83,7 @@ type MemberOrder = {
   pickup_store_id: number | null;
   created_at: string;
   campaign: { name: string } | { name: string }[] | null;
-  customer_order_items: { qty: number; unit_price: number }[];
+  customer_order_items: { qty: number; unit_price: number; status: string | null }[];
 };
 
 // 與 CampaignOrdersPanel 的 STATUS_BADGE 同款配色（+ partially_completed）
@@ -238,7 +238,7 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
           .eq("primary_member_id", memberId)
           .order("created_at", { ascending: false }),
         sb.from("customer_orders")
-          .select("id, order_no, status, order_kind, pickup_store_id, created_at, campaign:group_buy_campaigns(name), customer_order_items(qty, unit_price)")
+          .select("id, order_no, status, order_kind, pickup_store_id, created_at, campaign:group_buy_campaigns(name), customer_order_items(qty, unit_price, status)")
           .eq("member_id", memberId)
           .order("created_at", { ascending: false }),
       ]);
@@ -553,15 +553,17 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
         </div>
 
         {tab === "orders" && (() => {
-          // 統計沿用 CampaignOrdersPanel：取消/過期不入計；order_kind=offset 是抵減單，顯示負數
+          // 統計沿用 CampaignOrdersPanel：取消/過期/轉出不入計、已轉出的品項也不算；
+          // order_kind=offset 是抵減單，顯示負數（見 orderStatus.ts 的統計規則）
           let totalQty = 0, totalAmount = 0, normalCount = 0, offsetCount = 0;
           for (const o of orders) {
             const isOffset = o.order_kind === "offset";
-            const isCancelled = o.status === "cancelled" || o.status === "expired";
+            const counts = orderCountsInTotals(o.status);
             if (isOffset) offsetCount++;
-            else if (!isCancelled) normalCount++;
-            if (isCancelled) continue;
+            else if (counts) normalCount++;
+            if (!counts) continue;
             for (const it of o.customer_order_items ?? []) {
+              if (!orderItemCountsInTotals(it.status)) continue;
               totalQty += Number(it.qty || 0);
               totalAmount += Number(it.qty || 0) * Number(it.unit_price || 0);
             }
@@ -590,11 +592,12 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
                     ) : orders.map((o) => {
                       const campaign = Array.isArray(o.campaign) ? o.campaign[0] : o.campaign;
                       const store = stores.find((s) => s.id === o.pickup_store_id);
-                      const items = o.customer_order_items ?? [];
+                      // 只算「還在這張單上」的品項（部分轉出的來源品項留在原單但已 cancelled）
+                      const items = (o.customer_order_items ?? []).filter((i) => orderItemCountsInTotals(i.status));
                       const qty = items.reduce((s, i) => s + Number(i.qty || 0), 0);
                       const amt = items.reduce((s, i) => s + Number(i.qty || 0) * Number(i.unit_price || 0), 0);
                       const isOffset = o.order_kind === "offset";
-                      const isCancelled = o.status === "cancelled" || o.status === "expired";
+                      const isCancelled = !orderCountsInTotals(o.status);
                       return (
                         <tr
                           key={o.id}

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -510,6 +510,7 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
           member={{ id: member.id, name: member.name, member_no: member.member_no }}
           tenantId={tenantId}
           homeStoreId={member.home_store_id}
+          storeName={stores.find((st) => st.id === member.home_store_id)?.name ?? null}
         />
       )}
 

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -349,12 +349,22 @@ export function OrderDetail({
   const orderDiscountValue: DiscountValue = draft.discount ?? deriveDiscount(head.discount_percent, head.discount_amount);
   const orderNotesValue: string | null = Object.prototype.hasOwnProperty.call(draft, "notes") ? draft.notes! : head.notes;
 
-  const totalQty = items.reduce((s, i) => s + Number(itemEffective(i).qty), 0);
-  const grossTotal = items.reduce((s, i) => {
+  // 合計只算「還在這張單上」的品項。cancelled/expired 的行仍然要顯示
+  // （帶已取消 badge），但不能進數量與金額 —— 它們是：
+  //   1. 部分轉出：整項轉走的來源品項被標 cancelled，卻留在來源單上
+  //      （來源單 status 不變），不濾掉就等於跟轉入單重複收一次錢
+  //   2. 品項層級的取消 / 斷貨
+  // 這條線的權威是 v_customer_order_summary.items_total 與
+  // rpc_wallet_pay_order（兩者都只算 status NOT IN ('cancelled','expired')）；
+  // 這裡不濾的話畫面上的「應收」會跟資料庫實際收的金額對不起來。
+  const activeItems = items.filter((i) => !["cancelled", "expired"].includes(i.status));
+  const cancelledItemCount = items.length - activeItems.length;
+  const totalQty = activeItems.reduce((s, i) => s + Number(itemEffective(i).qty), 0);
+  const grossTotal = activeItems.reduce((s, i) => {
     const eff = itemEffective(i);
     return s + Number(eff.qty) * Number(eff.unit_price);
   }, 0);
-  const subtotal = items.reduce((s, i) => {
+  const subtotal = activeItems.reduce((s, i) => {
     const eff = itemEffective(i);
     return s + computeLineSubtotal(Number(eff.qty), eff.unit_price, eff.discount);
   }, 0);
@@ -889,7 +899,10 @@ export function OrderDetail({
       <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
         <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-xs font-medium dark:border-zinc-800 dark:bg-zinc-900">
           <span>
-            明細（{items.length} 項 · {totalQty} 件
+            明細（{activeItems.length} 項 · {totalQty} 件
+            {cancelledItemCount > 0 && (
+              <span className="ml-1 text-zinc-500">· 已取消 {cancelledItemCount} 項</span>
+            )}
             {totalReturnedQty > 0 && (
               <span className="ml-1 text-orange-700 dark:text-orange-400">· ↩ 已退 {totalReturnedQty} 件</span>
             )}

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -349,16 +349,12 @@ export function OrderDetail({
   const orderDiscountValue: DiscountValue = draft.discount ?? deriveDiscount(head.discount_percent, head.discount_amount);
   const orderNotesValue: string | null = Object.prototype.hasOwnProperty.call(draft, "notes") ? draft.notes! : head.notes;
 
-  // 合計只算「還在這張單上」的品項。cancelled/expired 的行仍然要顯示
-  // （帶已取消 badge），但不能進數量與金額 —— 它們是：
-  //   1. 部分轉出：整項轉走的來源品項被標 cancelled，卻留在來源單上
-  //      （來源單 status 不變），不濾掉就等於跟轉入單重複收一次錢
-  //   2. 品項層級的取消 / 斷貨
-  // 這條線的權威是 v_customer_order_summary.items_total 與
-  // rpc_wallet_pay_order（兩者都只算 status NOT IN ('cancelled','expired')）；
-  // 這裡不濾的話畫面上的「應收」會跟資料庫實際收的金額對不起來。
+  // 已取消 / 斷貨 / 過期的品項行照樣列在下面的表格（紅標「斷貨」「已取消」），
+  // 但不計入件數與金額 —— 客人拿不到的貨不收錢。
+  // 與 v_customer_order_summary.items_total / rpc_wallet_pay_order 同一套過濾
+  //（migration 20260808000010）。
   const activeItems = items.filter((i) => !["cancelled", "expired"].includes(i.status));
-  const cancelledItemCount = items.length - activeItems.length;
+
   const totalQty = activeItems.reduce((s, i) => s + Number(itemEffective(i).qty), 0);
   const grossTotal = activeItems.reduce((s, i) => {
     const eff = itemEffective(i);
@@ -383,8 +379,7 @@ export function OrderDetail({
   let returnedDeduction = 0;
   {
     const remaining = new Map(unpickedReturnedBySku);
-    for (const it of items) {
-      if (["cancelled", "expired"].includes(it.status)) continue;
+    for (const it of activeItems) {
       const skuId = it.sku?.id;
       const rem = skuId != null ? (remaining.get(skuId) ?? 0) : 0;
       if (skuId == null || rem <= 0) continue;
@@ -899,10 +894,8 @@ export function OrderDetail({
       <div className="rounded-md border border-zinc-200 dark:border-zinc-800">
         <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-xs font-medium dark:border-zinc-800 dark:bg-zinc-900">
           <span>
+            {/* 項數 / 件數不算已取消 / 斷貨的行（那些行仍列在表格裡，紅標標示） */}
             明細（{activeItems.length} 項 · {totalQty} 件
-            {cancelledItemCount > 0 && (
-              <span className="ml-1 text-zinc-500">· 已取消 {cancelledItemCount} 項</span>
-            )}
             {totalReturnedQty > 0 && (
               <span className="ml-1 text-orange-700 dark:text-orange-400">· ↩ 已退 {totalReturnedQty} 件</span>
             )}

--- a/apps/admin/src/components/ShortageAllocateModal.tsx
+++ b/apps/admin/src/components/ShortageAllocateModal.tsx
@@ -282,7 +282,8 @@ export function ShortageAllocateModal({
     if (
       !confirm(
         `把目前 ${ids.length} 筆「待補貨」直接取消？\n\n` +
-          `會把這些品項標成斷貨取消，若整張訂單品項都沒了且沒收過錢，訂單也會一併取消。\n` +
+          `會把這些品項標成斷貨取消，若整張訂單品項都沒了且沒收過錢，訂單也會一併取消；\n` +
+          `已取走一部分的訂單則直接結單（不會再卡在「部分取貨」）。\n` +
           `此動作不可復原。`,
       )
     )
@@ -299,8 +300,16 @@ export function ShortageAllocateModal({
         p_operator: operator,
       });
       if (e) throw new Error(translateRpcError(e));
-      const r = (res ?? {}) as { items_cancelled?: number; orders_cancelled?: number };
-      alert(`已取消 ${r.items_cancelled ?? 0} 個品項、${r.orders_cancelled ?? 0} 張訂單`);
+      const r = (res ?? {}) as {
+        items_cancelled?: number;
+        orders_cancelled?: number;
+        orders_completed?: number;
+      };
+      alert(
+        `已取消 ${r.items_cancelled ?? 0} 個品項、${r.orders_cancelled ?? 0} 張訂單` +
+          // 已取走一部分的單不會被取消，剩下的取消掉就結單（20260808000000）
+          (r.orders_completed ? `，${r.orders_completed} 張已取完的訂單結單` : ""),
+      );
       await load();
       onSaved();
     } catch (e) {

--- a/apps/admin/src/components/StoreLineOaField.tsx
+++ b/apps/admin/src/components/StoreLineOaField.tsx
@@ -17,7 +17,9 @@ import SpinButton from "@/components/SpinButton";
 
 type Status = { channel_id: string; updated_at: string } | null;
 
-export function StoreLineOaField({ storeId }: { storeId: number | null }) {
+export function StoreLineOaField({
+  storeId, storeCode,
+}: { storeId: number | null; storeCode: string }) {
   const role = useRole();
   const [status, setStatus] = useState<Status>(null);
   const [loaded, setLoaded] = useState(false);
@@ -26,6 +28,11 @@ export function StoreLineOaField({ storeId }: { storeId: number | null }) {
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  // 每家店一個 URL，結尾的 ?store= 不能省 —— line-webhook 要靠它決定用哪一把
+  // channel secret 驗簽（驗簽必須先於信任 body，所以不能改從 body 讀）。
+  const webhookUrl = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/line-webhook?store=${encodeURIComponent(storeCode)}`;
 
   useEffect(() => {
     // storeId 為 null 時走的是「請先儲存分店」那個分支，用不到 loaded
@@ -114,6 +121,36 @@ export function StoreLineOaField({ storeId }: { storeId: number | null }) {
               </div>
             )
           )}
+
+          <div className="mb-3 rounded border border-zinc-200 bg-zinc-50 p-2 dark:border-zinc-700 dark:bg-zinc-900">
+            <div className="mb-1 text-[11px] font-medium text-zinc-700 dark:text-zinc-300">
+              Webhook URL（貼到 LINE 後台 → 設定 → Messaging API）
+            </div>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 overflow-x-auto whitespace-nowrap rounded bg-white px-2 py-1 text-[11px] text-zinc-800 dark:bg-zinc-950 dark:text-zinc-200">
+                {webhookUrl}
+              </code>
+              <SpinButton
+                onClick={async () => {
+                  try {
+                    await navigator.clipboard.writeText(webhookUrl);
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 2000);
+                  } catch {
+                    // 非 https / 舊瀏覽器沒有 clipboard API，讓使用者自己選取複製
+                    setErr("此瀏覽器不允許自動複製，請手動選取上方網址");
+                  }
+                }}
+                className="shrink-0 rounded-md border border-zinc-300 px-2 py-1 text-[11px] hover:bg-zinc-100 dark:border-zinc-600 dark:hover:bg-zinc-800"
+              >
+                {copied ? "✓ 已複製" : "複製"}
+              </SpinButton>
+            </div>
+            <p className="mt-1 text-[11px] text-zinc-500">
+              貼上後按 LINE 後台的 Verify 應顯示 Success。
+              {!status && "（要先儲存下方憑證，webhook 才驗得過簽章）"}
+            </p>
+          </div>
 
           <div className="grid gap-2 sm:grid-cols-2">
             <label className="block text-xs">

--- a/apps/admin/src/lib/orderStatus.ts
+++ b/apps/admin/src/lib/orderStatus.ts
@@ -75,6 +75,44 @@ export function isTerminalStatus(s: string | null | undefined): boolean {
   return s != null && TERMINAL_STATUSES.has(s);
 }
 
+// ============================================================
+// 數量 / 金額統計的納入規則（訂單層級 + 品項層級，兩層都要套）
+//
+// 轉單不是「搬移」而是「複製 + 標記」，所以任何加總都必須兩層都濾掉，
+// 否則同一批貨會被算兩次（同店互轉最明顯：一進一出總量卻變多）：
+//
+//   1. 整單轉出 (rpc_transfer_order_to_store)
+//      來源單 status → 'transferred_out'，但**品項原封不動留著**
+//      （轉入單是 INSERT..SELECT 複製一份）。只濾 cancelled/expired
+//      不濾 transferred_out ⇒ 來源單 + 轉入單各算一次。
+//   2. 部分轉出 (rpc_transfer_order_partial)
+//      整項轉走的來源品項 → status='cancelled' 但**仍掛在來源單上**
+//      （來源單 status 不變，還是 confirmed/ready）。不濾品項 status
+//      ⇒ 來源單照算原數量 + 轉入單再算一次。
+//      實例：GRP-20260804-007 湖口店 -0058 轉 1 顆到 -TF0157，
+//      本店小計顯示 21 顆（實際 20）、$1,325（實際 $1,250）。
+//
+// 新增任何「加總 customer_order_items」的畫面時，兩個 helper 一起用。
+// ============================================================
+
+const NON_COUNTING_ORDER_STATUSES = new Set<string>([
+  "cancelled",
+  "expired",
+  "transferred_out",
+]);
+
+/** 這張訂單的數量/金額要不要計入統計（已取消/已過期/已轉出都不計）。 */
+export function orderCountsInTotals(s: string | null | undefined): boolean {
+  return !(s != null && NON_COUNTING_ORDER_STATUSES.has(s));
+}
+
+const NON_COUNTING_ITEM_STATUSES = new Set<string>(["cancelled", "expired"]);
+
+/** 這個品項的數量/金額要不要計入統計（部分轉出會把來源品項標 cancelled 留在原單）。 */
+export function orderItemCountsInTotals(s: string | null | undefined): boolean {
+  return !(s != null && NON_COUNTING_ITEM_STATUSES.has(s));
+}
+
 /**
  * 此 status 的訂單能不能用儲值金結帳。
  * 規則：非終態 + 非已付清（payment_status 由呼叫端另判）。

--- a/apps/admin/src/lib/pickupImage.ts
+++ b/apps/admin/src/lib/pickupImage.ts
@@ -1,0 +1,144 @@
+/**
+ * 把「可取貨訂單」畫成一張圖，直接當 LINE 訊息的附圖發給會員。
+ *
+ * 為什麼是圖不是文字：店員原本的做法就是自己截圖貼進 LINE，因為品項一多
+ * 純文字在手機上很難讀（會被 LINE 折行折得亂七八糟）。這裡把那張圖自動產出來，
+ * 省掉「切到訂單頁 → 截圖 → 裁切 → 貼上」四個動作，也不會截到不該給顧客看的欄位。
+ *
+ * 用 canvas 而不是後端算圖：後端要算圖得跑 headless browser，edge function 做不到；
+ * 而這張圖的資料 admin 前端本來就有，畫完直接走既有的
+ * 「上傳 line-media → admin-line-push 發送」管線，不必新增任何後端。
+ *
+ * ⚠ 一律輸出 JPEG：LINE 的 image message 只吃 JPEG/PNG，而 JPEG 沒有 alpha，
+ *   所以底色要自己鋪白（跟 LineMessageModal 的 encodeJpeg 同樣理由）。
+ */
+
+export type PickupLine = {
+  name: string;
+  qty: number;
+  unitPrice: number | null;
+};
+
+export type PickupOrder = {
+  orderNo: string;
+  campaign: string | null;
+  lines: PickupLine[];
+};
+
+export type PickupImageData = {
+  storeName: string | null;
+  memberName: string | null;
+  orders: PickupOrder[];
+};
+
+// 以 2 倍解析度繪製再縮回去，手機上看才不會糊（LINE 會放大顯示）
+const SCALE = 2;
+const W = 720;
+const PAD = 28;
+const FONT = '"Noto Sans TC", "PingFang TC", "Microsoft JhengHei", system-ui, sans-serif';
+
+/** 超出寬度的品項名截斷加省略號，避免壓到右側數量欄 */
+function ellipsize(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string {
+  if (ctx.measureText(text).width <= maxWidth) return text;
+  let t = text;
+  while (t.length > 1 && ctx.measureText(t + "…").width > maxWidth) t = t.slice(0, -1);
+  return t + "…";
+}
+
+export async function renderPickupImage(data: PickupImageData): Promise<Blob> {
+  // 先算高度：標題區 + 每張訂單（抬頭 + 品項列）+ 合計 + 頁尾
+  const lineH = 34;
+  const orderHeadH = 40;
+  let h = 96;
+  for (const o of data.orders) h += orderHeadH + o.lines.length * lineH + 12;
+  h += 76;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = W * SCALE;
+  canvas.height = h * SCALE;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("無法建立 canvas");
+  ctx.scale(SCALE, SCALE);
+
+  // JPEG 沒有透明度，底色一定要自己鋪
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, W, h);
+
+  let y = PAD;
+
+  // 標題
+  ctx.fillStyle = "#111827";
+  ctx.font = `bold 26px ${FONT}`;
+  ctx.fillText("可取貨訂單", PAD, y + 22);
+  y += 36;
+
+  ctx.font = `15px ${FONT}`;
+  ctx.fillStyle = "#6b7280";
+  const sub = [data.storeName, data.memberName].filter(Boolean).join("　·　");
+  if (sub) ctx.fillText(sub, PAD, y + 14);
+  y += 30;
+
+  ctx.strokeStyle = "#e5e7eb";
+  ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.moveTo(PAD, y); ctx.lineTo(W - PAD, y); ctx.stroke();
+  y += 12;
+
+  let totalQty = 0;
+  let totalAmount = 0;
+
+  for (const o of data.orders) {
+    ctx.fillStyle = "#111827";
+    ctx.font = `bold 16px ${FONT}`;
+    ctx.fillText(o.orderNo, PAD, y + 22);
+    // ⚠ 寬度必須在「還是 bold 16px」時量 —— 切成 14px 再量會少算，
+    //   團購名就會壓在訂單編號上面（2026-08-07 產圖預覽踩到）
+    const noW = ctx.measureText(o.orderNo).width;
+    if (o.campaign) {
+      ctx.font = `14px ${FONT}`;
+      ctx.fillStyle = "#6b7280";
+      ctx.fillText(ellipsize(ctx, o.campaign, W - PAD * 2 - noW - 20), PAD + noW + 16, y + 22);
+    }
+    y += orderHeadH;
+
+    for (const l of o.lines) {
+      totalQty += l.qty;
+      const sub2 = l.unitPrice != null ? l.unitPrice * l.qty : 0;
+      totalAmount += sub2;
+
+      ctx.font = `15px ${FONT}`;
+      ctx.fillStyle = "#374151";
+      // 右側兩欄固定寬度：數量 70、小計 110
+      ctx.fillText(ellipsize(ctx, l.name, W - PAD * 2 - 190), PAD + 8, y + 20);
+
+      ctx.textAlign = "right";
+      ctx.fillStyle = "#6b7280";
+      ctx.fillText(`×${l.qty}`, W - PAD - 120, y + 20);
+      ctx.fillStyle = "#111827";
+      ctx.fillText(l.unitPrice != null ? `$${sub2.toLocaleString()}` : "—", W - PAD, y + 20);
+      ctx.textAlign = "left";
+
+      y += lineH;
+    }
+    y += 12;
+  }
+
+  ctx.strokeStyle = "#e5e7eb";
+  ctx.beginPath(); ctx.moveTo(PAD, y); ctx.lineTo(W - PAD, y); ctx.stroke();
+  y += 12;
+
+  ctx.font = `bold 18px ${FONT}`;
+  ctx.fillStyle = "#111827";
+  ctx.fillText(`共 ${totalQty} 件`, PAD, y + 22);
+  ctx.textAlign = "right";
+  ctx.fillText(`$${totalAmount.toLocaleString()}`, W - PAD, y + 22);
+  ctx.textAlign = "left";
+  y += 38;
+
+  ctx.font = `12px ${FONT}`;
+  ctx.fillStyle = "#9ca3af";
+  ctx.fillText(`產生時間：${new Date().toLocaleString("zh-TW")}`, PAD, y + 12);
+
+  const blob = await new Promise<Blob | null>((res) => canvas.toBlob(res, "image/jpeg", 0.92));
+  if (!blob) throw new Error("圖片產生失敗");
+  return blob;
+}

--- a/apps/member/src/app/link/page.tsx
+++ b/apps/member/src/app/link/page.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+// LINE 帳號連結（account link）的落地頁。
+//
+// 為什麼需要這一頁：LINE 的 user ID 是綁 Provider 的，各店官方帳號看到的
+// 顧客 ID，跟會員站登入拿到的那組完全不同。店家要能主動推播，就得知道
+// 「這位會員在該店 OA 的 ID 是哪一個」，而 LINE 官方提供的答案就是 account link。
+//
+// 顧客體驗上這頁應該幾乎沒有存在感：他在店家 LINE 裡問訂單，收到一則
+// 「這裡可以查看您的訂單」，點進來（多半已登入）→ 自動轉一圈 → 回到 LINE。
+// 綁定是副作用，他不需要理解「綁定」兩個字。所以這頁不解釋、不要求操作，
+// 只在「還沒登入」時借用既有的登入流程。
+//
+// 登入一律走 useLineLogin，不在這裡重寫 —— 那條路上每個分支都是踩雷換來的。
+
+import { useEffect, useRef, useState } from "react";
+import { logCaught, logClientError } from "@/lib/clientLog";
+import { readParam } from "@/lib/lineAuth";
+import { getSession } from "@/lib/session";
+import { callLiffApi } from "@/lib/supabase";
+import { useLineLogin } from "@/lib/useLineLogin";
+import Spinner, { LoadingScreen } from "@/components/Spinner";
+
+type Phase = "working" | "need_login" | "error";
+
+export default function LinkPage() {
+  const { status, error: loginError, start, storeId, chooseStore, stores } = useLineLogin({
+    autoSelectSingleStore: true,
+  });
+  const [phase, setPhase] = useState<Phase>("working");
+  const [message, setMessage] = useState<string | null>(null);
+  // 轉址只能跑一次：React 嚴格模式會重跑 effect，跑兩次會把 nonce 浪費掉
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+
+    const linkToken = readParam("lt");
+    const storeCode = readParam("store");
+    if (!linkToken || !storeCode) {
+      setPhase("error");
+      setMessage("連結不完整，請回到官方帳號重新點一次。");
+      logClientError("account_link_missing_params", "缺 lt 或 store");
+      return;
+    }
+
+    // 從店家 OA 進來時 useLineLogin 還在跑（可能正在 LIFF 自動登入），
+    // 等它把 session 準備好再動作；沒登入就顯示登入按鈕。
+    const session = getSession();
+    if (!session?.memberId) {
+      if (status === "loading" || status === "liff_auth") return;
+      setPhase("need_login");
+      return;
+    }
+
+    startedRef.current = true;
+    (async () => {
+      try {
+        const { nonce } = await callLiffApi<{ nonce: string }>(session.token, {
+          action: "create_account_link_nonce",
+          store: storeCode,
+        });
+        // 交給 LINE 完成連結；成功後 LINE 會把使用者送回官方帳號對話，
+        // 並對我們的 webhook 發一則 accountLink 事件（帶著同一個 nonce）。
+        window.location.href =
+          `https://access.line.me/dialog/bot/accountLink?linkToken=${encodeURIComponent(linkToken)}` +
+          `&nonce=${encodeURIComponent(nonce)}`;
+      } catch (e) {
+        startedRef.current = false;
+        setPhase("error");
+        setMessage("連結失敗，請回到官方帳號再傳一次訊息取得新的連結。");
+        logCaught("account_link_nonce_failed", e, { store: storeCode });
+      }
+    })();
+  }, [status]);
+
+  if (phase === "working") return <LoadingScreen />;
+
+  if (phase === "need_login") {
+    return (
+      <main className="mx-auto flex min-h-dvh max-w-md flex-col justify-center gap-4 p-6 text-center">
+        <h1 className="text-lg font-semibold">查看我的訂單</h1>
+        <p className="text-sm text-zinc-500">
+          請先用 LINE 登入，登入後就會自動帶您回去。
+        </p>
+
+        {stores.length > 1 && !storeId && (
+          <select
+            value={storeId ?? ""}
+            onChange={(e) => chooseStore(e.target.value || null)}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm"
+          >
+            <option value="">— 請選擇取貨門市 —</option>
+            {stores.map((s) => (
+              <option key={s.id} value={s.code}>{s.name}</option>
+            ))}
+          </select>
+        )}
+
+        <button
+          onClick={start}
+          disabled={!storeId}
+          className="rounded-md bg-[#06C755] px-4 py-3 font-semibold text-white disabled:opacity-50"
+        >
+          {status === "loading" ? <Spinner /> : "用 LINE 登入"}
+        </button>
+
+        {loginError && <p className="text-xs text-red-600">{loginError}</p>}
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-md flex-col justify-center gap-3 p-6 text-center">
+      <p className="text-sm text-red-600">{message}</p>
+    </main>
+  );
+}

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -56,7 +56,13 @@ function fmtDate(iso: string | null | undefined): string {
 }
 
 export default function OrderCard({ order }: { order: OrderRow }) {
-  const totalQty = order.items.reduce((s, i) => s + Number(i.qty ?? 0), 0);
+  // 斷貨 / 已取消的品項照樣列出來（畫成刪除線 + 「斷貨」標），但不算件數 —
+  // items_total / payable_amount 從 20260808000010 起就不含這些行了，
+  // 件數要跟著排除，否則「商品（5 件）$218」對不起來。
+  const totalQty = order.items.reduce(
+    (s, i) => (["cancelled", "expired"].includes(i.status) ? s : s + Number(i.qty ?? 0)),
+    0,
+  );
   const title = cleanCampaignText(order.campaign_name) || "訂單";
 
   return (

--- a/docs/TEST-stockout-closes-picked-order.md
+++ b/docs/TEST-stockout-closes-picked-order.md
@@ -1,0 +1,91 @@
+# 剩餘品項斷貨 → 已取完的訂單自動結單
+
+對應 migration `20260808000000_close_order_when_remaining_items_stockout.sql`。
+
+回報案例：訂單 `GRP-20260712-004-0046`（id=49469，湖口店）4 個品項取了 3 個，
+剩下的「滷虱目魚肚」被採購斷貨連動取消，訂單卻永遠停在「部分取貨」結不掉。
+
+---
+
+## 0. 規則
+
+訂單品項被取消（斷貨 / 待補貨取消）之後，單頭重算一次：
+
+| 剩餘待取品項 | 有沒有取過貨 | 訂單 status |
+|---|---|---|
+| 有（pending/reserved/ready） | — | 不動（照舊 partially_completed / ready …） |
+| 沒有 | 有 picked_up | **completed** ← 本次新增 |
+| 沒有 | 完全沒取過 + 沒收過錢 | cancelled（既有斷貨連動規則） |
+| 沒有 | 完全沒取過 + 收過錢 | 不動（留人工退款） |
+
+「有沒有待取品項」的判定集合 = `status IN ('pending','reserved','ready')`，
+與 `rpc_record_pickup` 的 `v_active_remaining` 同一套 → 「先斷貨後取貨」和
+「先取貨後斷貨」兩種順序結果一致。
+
+實作在 `_close_orders_all_items_settled(order_ids, operator, at)`，
+由 `_stockout_po_items`（採購斷貨核心）與 `rpc_cancel_backorder_items` 呼叫。
+
+---
+
+## A. 採購斷貨（PO 品項 / 整張 PO）
+
+前置：開團訂單 X 有 A、B 兩個品項，A 已取貨（picked_up）、B 還沒到貨（pending）。
+
+- [ ] **A.1** 採購單編輯頁把 B 對應的採購品項標「⛔ 斷貨」（`rpc_stockout_po_item`）
+- [ ] **A.2** 訂單 X 的 B 品項顯示「斷貨」（紅標）、status=cancelled + stockout_at
+- [ ] **A.3** 訂單 X status → **已完成**，`completed_at` 有值
+- [ ] **A.4** /orders「部分取貨」分頁看不到 X；「已完成」分頁看得到
+- [ ] **A.5** 整張 PO 斷貨（`rpc_stockout_purchase_order`）走同一核心，結果同 A.3
+- [ ] **A.6** 回傳 jsonb 多一個 `orders_completed` 計數
+
+邊界：
+
+- [ ] **A.7** 訂單 X 還有第三個品項 C 沒取也沒斷貨 → X 維持 partially_completed
+- [ ] **A.8** 訂單 Y 一件都沒取、全品項斷貨、未付款 → 照舊整單 cancelled（不是 completed）
+- [ ] **A.9** 重跑同一支 RPC（冪等）→ `orders_completed` = 0，不重複改狀態
+
+## B. 待補貨確定補不到（少發配貨）
+
+前置：訂單 Z 有 A、B 兩品項，A 已取貨，B 在「少發配貨」被標成待補貨（backorder_at）。
+
+- [ ] **B.1** ⚖️ 少發配貨視窗按「確定補不到 → 取消待補貨」（`rpc_cancel_backorder_items`）
+- [ ] **B.2** alert 顯示「…，1 張已取完的訂單結單」
+- [ ] **B.3** 訂單 Z status → 已完成
+
+## C. 資料治理（migration 內 DO block）
+
+- [ ] **C.1** 套用 migration 後，下面這條要回 0：
+
+```sql
+SELECT count(*) FROM customer_orders co
+ WHERE co.status = 'partially_completed'
+   AND EXISTS (SELECT 1 FROM customer_order_items x
+                WHERE x.order_id = co.id AND x.status = 'picked_up')
+   AND NOT EXISTS (SELECT 1 FROM customer_order_items x
+                    WHERE x.order_id = co.id
+                      AND x.status IN ('pending','reserved','ready'));
+```
+
+- [ ] **C.2** 2026-08-08 首次套用時收尾 18 張（PO2607140844 連動 10 張、
+      2026-08-06 品項斷貨連動 8 張），全部 payment_status='unpaid'
+
+---
+
+## D. 應收不含已取消 / 斷貨品項
+
+對應 migration `20260808000010_payable_exclude_cancelled_items.sql`。
+同一張單：取走 $218、斷貨那項 $65 → 應收要是 **$218**，不是 $283。
+
+- [ ] **D.1** 訂單明細頁：原價 / 小計 / 應收都不含斷貨那列；斷貨那列**還在**表格裡（紅標「斷貨」）
+- [ ] **D.2** 明細標題「明細（3 項 · 4 件）」— 項數 / 件數也不算斷貨那列
+- [ ] **D.3** 「💳 用儲值金結帳」開出來的金額 = $218（`rpc_wallet_pay_order` 上限同步）
+- [ ] **D.4** /orders 列表：項數 3 / 總數量 4 / 總金額 $218；點欄位排序（伺服端 `v_admin_orders_list`）數字一致
+- [ ] **D.5** 會員端（LIFF）訂單卡：斷貨列維持刪除線 + 「斷貨」標，「商品（4 件）$218」、應付金額 $218
+- [ ] **D.6** 人工刪除品項（`rpc_delete_order_item` 軟刪成 cancelled）同樣不計價
+- [ ] **D.7** 未取退貨扣減（20260731000000）仍正常：退貨量只分攤到未取消的品項行，不會因為母數改變而重複扣
+
+邊界：
+
+- [ ] **D.8** 沒有任何已付款 / 用過儲值金的訂單因為應收下修變成負的 balance_due
+      （套用當下實測 `wallet_paid_amount > payable_amount` 為 0 筆）
+- [ ] **D.9** 全品項取消的訂單 → 應收 $0、列表 0 項 $0（不是負數）

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -71,6 +71,39 @@ function resolveSpotImages(
 
 // ─── actions ─────────────────────────────────────────────────────────────────
 
+/**
+ * 建立 account link 用的一次性 nonce。
+ *
+ * 流程：顧客在店家 OA 傳訊息 → webhook 回一則帶 linkToken 的連結 →
+ * 顧客點進會員站 /link 並登入（到這裡我們才知道他是哪位會員）→
+ * 呼叫這支拿 nonce → 導去 LINE 的 accountLink 頁 → LINE 回 accountLink
+ * webhook，帶著同一個 nonce → 綁定完成。
+ *
+ * nonce 是「這是哪位會員」的憑據，所以必須由**已驗證的會員 token** 產生，
+ * 不能讓前端自己指定 member_id。
+ */
+async function createAccountLinkNonce(
+  // deno-lint-ignore no-explicit-any
+  sb: any, tenantId: string, memberId: number, storeCode: string,
+) {
+  const { data: store, error: sErr } = await sb
+    .from("stores").select("id").eq("tenant_id", tenantId).eq("code", storeCode).maybeSingle();
+  if (sErr) return json({ error: sErr.message }, 500);
+  if (!store) return json({ error: "store_not_found" }, 404);
+
+  // LINE 要求 nonce 至少 128 bits、用安全亂數產生
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  const nonce = btoa(String.fromCharCode(...bytes)).replace(/[+/=]/g, (c) =>
+    ({ "+": "-", "/": "_", "=": "" }[c] ?? c));
+
+  const { error } = await sb.from("line_account_link_nonces").insert({
+    nonce, tenant_id: tenantId, store_id: store.id, member_id: memberId,
+  });
+  if (error) return json({ error: error.message }, 500);
+  return json({ nonce });
+}
+
 async function listStores(sb: any, tenantId: string) {
   // line_liff_id：每家店在自己 Provider 底下的 LIFF ID。會員必須用「所屬分店」
   // 那支 LIFF 登入，拿到的 line_user_id 才跟該店官方帳號同 provider、推得動。
@@ -1353,6 +1386,7 @@ Deno.serve(async (req) => {
       switch (action) {
         case "lookup_by_phone": return await lookupByPhone(sb, tenantId, String(body.phone ?? ""));
         case "register_and_bind": return await registerAndBind(sb, { tenantId, storeId, lineUserId, phone: String(body.phone ?? ""), name: String(body.name ?? ""), birthday: String(body.birthday ?? "") });
+        case "create_account_link_nonce": if (!memberId) return json({ error: "no member_id" }, 401); return await createAccountLinkNonce(sb, tenantId, memberId, String(body.store ?? ""));
         case "get_me": if (!memberId) return json({ error: "no member_id" }, 401); return await getMe(sb, tenantId, memberId);
         case "update_me": if (!memberId) return json({ error: "no member_id" }, 401); return await updateMe(sb, tenantId, memberId, body);
         case "get_overview": if (!memberId) return json({ error: "no member_id" }, 401); return await getOverview(sb, tenantId, storeId, memberId);

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -639,25 +639,7 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
   const { data, error } = await q
     .order("end_at", { ascending: true, nullsFirst: false });
 
-  // 算出 campaign 已下單總量 (排除取消/逾期 + 排除負數抵減單),
-  // 給前端算「剩 N 份」、「搶購一空」或顯示「已售出 N 份」
-  const orderedMap = new Map<number, number>();
   const allIds = (data ?? []).map((c: any) => c.id);
-  if (allIds.length > 0) {
-    const { data: orderRows } = await sb
-      .from("customer_orders")
-      .select("campaign_id, customer_order_items(qty)")
-      .in("campaign_id", allIds)
-      .not("status", "in", "(cancelled,expired)")
-      .or("order_kind.is.null,order_kind.eq.normal");
-    for (const o of orderRows ?? []) {
-      const sum = (o.customer_order_items ?? []).reduce(
-        (a: number, x: any) => a + Number(x.qty ?? 0),
-        0,
-      );
-      orderedMap.set(Number(o.campaign_id), (orderedMap.get(Number(o.campaign_id)) ?? 0) + sum);
-    }
-  }
 
   // 瀏覽次數（顧客端顯示「N 次瀏覽」）。RPC 未部署時整段當 0，不影響列表。
   const viewMap = new Map<number, number>();
@@ -671,17 +653,37 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
     }
   }
 
-  // 全分店訂單數 + 近 7 天訂單數（顧客端排序用：最熱銷 / 近期售出）。
-  // 走 SQL 聚合 RPC，避免訂單列數超過 PostgREST 1000 上限被截斷而計數失準。
+  // 已下單總量（前端算「剩 N 份」/「搶購一空」/「已售出 N 份」）
+  // + 訂單數 / 近 7 天訂單數（最熱銷、近期售出排序）。
+  //
+  // 三個數字一律走 rpc_member_campaign_aggregates，不要退回「撈訂單再在 JS
+  // 加總」——那條路踩過兩個坑：
+  //   1. PostgREST 有 1000 列上限且是**靜默截斷**。上架中的團底下有 1600+
+  //      筆訂單，已售出會少算；換成一團一列的 RETURNS TABLE RPC 也一樣，
+  //      團數 1500+ 照樣被截，而且截掉的是 id 最大的新團（= 正在賣的那些）。
+  //      這支 RETURNS jsonb（單列單值）不受影響，再用 p_campaign_ids 限定
+  //      只算這一頁的團。
+  //   2. 轉單是「複製 + 標記」不是「搬移」，訂單層級要排除 transferred_out、
+  //      品項層級要排除 cancelled（部分轉出的來源品項留在原單），否則已售出
+  //      虛增、吃掉 cap_qty 名額，把還有貨的團顯示成售完。過濾規則收在
+  //      RPC 內，與 admin 的 lib/orderStatus.ts 同一套。
+  const orderedMap = new Map<number, number>();
   const countMap = new Map<number, number>();
   const recentMap = new Map<number, number>();
-  const { data: cntRows } = await sb.rpc("rpc_member_campaign_order_counts", {
-    p_tenant: tenantId,
-    p_recent_days: 7,
-  });
-  for (const r of cntRows ?? []) {
-    countMap.set(Number(r.campaign_id), Number(r.order_count ?? 0));
-    recentMap.set(Number(r.campaign_id), Number(r.recent_order_count ?? 0));
+  if (allIds.length > 0) {
+    const { data: aggRows, error: aggErr } = await sb.rpc("rpc_member_campaign_aggregates", {
+      p_tenant: tenantId,
+      p_recent_days: 7,
+      p_campaign_ids: allIds,
+    });
+    // 靜默失敗會變成「全部 0 人下單、已售出 0」，看起來像沒人買 —— 留 log
+    if (aggErr) console.error("[list_active_campaigns] aggregates rpc failed", aggErr);
+    for (const r of (aggRows ?? []) as any[]) {
+      const cid = Number(r.campaign_id);
+      orderedMap.set(cid, Number(r.ordered_qty ?? 0));
+      countMap.set(cid, Number(r.order_count ?? 0));
+      recentMap.set(cid, Number(r.recent_order_count ?? 0));
+    }
   }
 
   if (error) return json({ error: error.message }, 500);
@@ -774,17 +776,32 @@ async function getCampaignDetail(sb: any, tenantId: string, campaignId: number) 
   c.view_count = Number(viewRows?.[0]?.view_count ?? 0);
   c.viewer_count = Number(viewRows?.[0]?.viewer_count ?? 0);
 
-  // 算出各品項已下單總量
+  // 算出各品項已下單總量（過濾規則同 listActiveCampaigns 的 orderedMap：
+  // 訂單層級排除 cancelled/expired/transferred_out、品項層級排除 cancelled/expired，
+  // 否則轉出的量會被算兩次、吃掉 cap_qty 名額）
+  //
+  // order_kind 的「normal 或 null」不能用 .or() 寫 —— PostgREST 的 or= 是
+  // 頂層 logic tree，塞 embedded 欄位（customer_orders.order_kind.…）會被
+  // 直接拒收：PGRST100 "failed to parse logic tree"。supabase-js 把錯誤放在
+  // 這裡沒接的 error 欄位，data 變 null ⇒ 整張表已售出通通顯示 0（這段
+  // 從寫下來就是壞的，不是這次改壞的）。改成 DB 只做得到的過濾、
+  // order_kind 拉回來在 JS 判，行為與 listActiveCampaigns 那段一致。
   const itemOrderedMap = new Map<number, number>();
-  const { data: itemOrderRows } = await sb
+  const { data: itemOrderRows, error: itemOrderErr } = await sb
     .from("customer_order_items")
     .select("campaign_item_id, qty, customer_orders!inner(status, order_kind)")
     .eq("tenant_id", tenantId)
     .eq("customer_orders.campaign_id", campaignId)
-    .not("customer_orders.status", "in", "(cancelled,expired)")
-    .or("customer_orders.order_kind.is.null,customer_orders.order_kind.eq.normal");
+    .not("status", "in", "(cancelled,expired)")
+    .not("customer_orders.status", "in", "(cancelled,expired,transferred_out)");
+  if (itemOrderErr) {
+    // 靜默失敗會變成「全部已售出 0」，看起來像沒人買 —— 留 log 才查得到
+    console.error("[get_campaign_detail] item ordered_qty query failed", itemOrderErr);
+  }
 
   for (const row of itemOrderRows ?? []) {
+    const kind = row.customer_orders?.order_kind;
+    if (kind != null && kind !== "normal") continue;
     const ciId = Number(row.campaign_item_id);
     const q = Number(row.qty ?? 0);
     itemOrderedMap.set(ciId, (itemOrderedMap.get(ciId) ?? 0) + q);

--- a/supabase/functions/line-webhook/index.ts
+++ b/supabase/functions/line-webhook/index.ts
@@ -17,6 +17,62 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.8";
 
 const LINE_PROFILE_URL = "https://api.line.me/v2/bot/profile";
+const LINE_REPLY_URL = "https://api.line.me/v2/bot/message/reply";
+const LINE_LINK_TOKEN_URL = (uid: string) => `https://api.line.me/v2/bot/user/${uid}/linkToken`;
+
+/** 同一個人多久內只邀一次綁定 —— 不擋的話每傳一句話就收到一則機器訊息 */
+const INVITE_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * 對「還不知道是誰」的顧客回一則帶 account link 的訊息。
+ *
+ * 刻意包裝成「查看我的訂單」而不是「請完成綁定」：顧客本來就是來問訂單的，
+ * 點下去就看到訂單，綁定是順帶發生的副作用，他不需要理解綁定是什麼。
+ *
+ * 用 replyToken 回覆 —— **不吃推播額度**，所以這個機制本身零成本。
+ * 失敗一律吞掉：邀請沒送出去不該影響 webhook 回 200（LINE 會重送整批事件）。
+ */
+async function inviteAccountLink(
+  accessToken: string,
+  replyToken: string,
+  lineUserId: string,
+  storeCode: string,
+  memberBase: string,
+): Promise<boolean> {
+  try {
+    const ltResp = await fetch(LINE_LINK_TOKEN_URL(lineUserId), {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${accessToken}` },
+    });
+    if (!ltResp.ok) {
+      console.error("linkToken failed:", ltResp.status, await ltResp.text());
+      return false;
+    }
+    const { linkToken } = await ltResp.json();
+    // linkToken 只有 10 分鐘效期，所以是「當下回覆」才有意義，不能事後補寄
+    const url = `${memberBase}/link?lt=${encodeURIComponent(linkToken)}&store=${encodeURIComponent(storeCode)}`;
+
+    const rResp = await fetch(LINE_REPLY_URL, {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${accessToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        replyToken,
+        messages: [{
+          type: "text",
+          text: `您好！這裡可以查看您的訂單與取貨進度 👇\n${url}`,
+        }],
+      }),
+    });
+    if (!rResp.ok) {
+      console.error("reply failed:", rResp.status, await rResp.text());
+      return false;
+    }
+    return true;
+  } catch (e) {
+    console.error("inviteAccountLink error:", String(e));
+    return false;
+  }
+}
 
 function requireEnv(name: string): string {
   const v = Deno.env.get(name);
@@ -84,6 +140,9 @@ Deno.serve(async (req) => {
       console.error("no credentials for store:", storeCode);
       return new Response("unknown store", { status: 404 });
     }
+    // PostgREST 的 to-one 關聯有時回物件、有時回陣列，兩種都要接得住
+    const credStoreCode: string | null =
+      (Array.isArray(cred.stores) ? cred.stores[0]?.code : cred.stores?.code) ?? storeCode;
 
     if (!await verifySignature(rawBody, signature, cred.channel_secret)) {
       console.error("bad signature for store:", storeCode);
@@ -146,9 +205,23 @@ Deno.serve(async (req) => {
       // follow / message / 其他有 userId 的事件 → 至少把這個人記進名冊。
       // member_id 先留 NULL：webhook 只知道「有這個 LINE 使用者」，
       // 不知道他是哪位會員，要等 account link 完成才填得上。
+      // ⚠ 不能只在 type === "follow" 才抓 profile。
+      // 實際上線後多數人是先「傳訊息」才被收進名冊（既有好友不會再觸發 follow），
+      // 只認 follow 的話名冊會一整排沒有名字，店員在配對選單只看得到
+      // "U5a54b59…" 這種字串，等於選不出來（2026-08-08 實際踩到）。
+      // 所以：只要這個人在名冊裡還沒有名字，任何事件都補抓一次。
       let displayName: string | null = null;
       let pictureUrl: string | null = null;
-      if (type === "follow" && cred.access_token) {
+
+      const { data: existing2 } = await sb
+        .from("store_line_followers")
+        .select("display_name, member_id, link_invited_at")
+        .eq("store_id", cred.store_id)
+        .eq("line_user_id", lineUserId)
+        .maybeSingle();
+      const existing = existing2;
+
+      if (!existing?.display_name && cred.access_token) {
         try {
           const p = await fetch(`${LINE_PROFILE_URL}/${lineUserId}`, {
             headers: { "Authorization": `Bearer ${cred.access_token}` },
@@ -177,6 +250,26 @@ Deno.serve(async (req) => {
         .from("store_line_followers")
         .upsert(row, { onConflict: "store_id,line_user_id", ignoreDuplicates: false });
       if (upErr) console.error("binding upsert failed:", upErr.message);
+
+      // 還不知道他是哪位會員 → 回一則帶 account link 的「查看我的訂單」。
+      // 只在有 replyToken 時做（reply 免額度，且 linkToken 只有 10 分鐘效期，
+      // 事後補寄沒有意義）。已配對的人不打擾。
+      const replyToken = ev.replyToken as string | undefined;
+      const memberBase = (Deno.env.get("MEMBER_FRONT_BASE_URL") ?? "").replace(/\/+$/, "");
+      const invitedAt = existing2?.link_invited_at ? Date.parse(existing2.link_invited_at) : 0;
+      const cooled = Date.now() - invitedAt > INVITE_COOLDOWN_MS;
+
+      if (replyToken && cred.access_token && memberBase && credStoreCode && !existing2?.member_id && cooled) {
+        const sent = await inviteAccountLink(
+          cred.access_token, replyToken, lineUserId, credStoreCode ?? "", memberBase,
+        );
+        if (sent) {
+          await sb.from("store_line_followers")
+            .update({ link_invited_at: new Date().toISOString() })
+            .eq("store_id", cred.store_id)
+            .eq("line_user_id", lineUserId);
+        }
+      }
     }
 
     return new Response("ok", { status: 200 });

--- a/supabase/migrations/20260808000000_close_order_when_remaining_items_stockout.sql
+++ b/supabase/migrations/20260808000000_close_order_when_remaining_items_stockout.sql
@@ -1,0 +1,398 @@
+-- ============================================================
+-- 2026-08-08: 剩餘品項斷貨取消後，已取完的訂單要自動結單
+--
+-- 回報案例（訂單 GRP-20260712-004-0046, id=49469, 湖口店）：
+--   4 個品項裡 3 個在 7/15 取貨完成（status='picked_up'），剩下的
+--   「滷虱目魚肚」在 7/21 因採購單 PO2607140844 整張斷貨被連動取消
+--   （coi.status='cancelled' + stockout_at）。此時訂單已經沒有任何
+--   待取品項了，卻永遠停在 'partially_completed'（部分取貨），
+--   店端在取貨頁「部分取貨」分頁一直看得到這張結不掉的單。
+--
+--   根因：斷貨連動只有「全部品項都沒了 → 整單 cancelled」這一條收尾
+--   規則（_stockout_po_items (c) / rpc_cancel_backorder_items），
+--   而該規則的 NOT EXISTS 守衛把 picked_up 品項也算成 active，
+--   所以「已取了一部分 + 剩下的斷貨」這種單兩邊都不符合：
+--     - 不符合整單取消（有 picked_up 品項，錢已收）
+--     - 也沒有任何東西再去重算單頭 → 卡在 partially_completed
+--   訂單單頭的狀態只有 rpc_record_pickup 會重算，但斷貨發生在取貨
+--   之後，不會再有下一次取貨事件來觸發重算。
+--
+--   線上受影響：18 張（PO2607140844 連動 10 張、2026-08-06 品項斷貨
+--   連動 8 張），全部 payment_status='unpaid'（本系統 completed 單
+--   20479 張也全是 unpaid，付款不走 payment_status，故自動結單不影響金流）。
+--
+-- 修法（與 20260801000000_full_return_closes_order 的「全數退貨收尾」同型）：
+--   1. 新 helper _close_orders_all_items_settled(order_ids, operator, at)：
+--      沒有任何待取品項（pending/reserved/ready）+ 至少一個 picked_up
+--      → status='completed'、completed_at 補上。判定條件與
+--      rpc_record_pickup 的 v_active_remaining 同一套（同樣的 active 集合），
+--      所以「先斷貨後取貨」與「先取貨後斷貨」兩個順序結果一致。
+--      有 picked_up 才收尾 → 與既有「整單取消」規則天然互斥
+--      （整單取消要求所有品項都 cancelled/expired，有 picked_up 就不成立）。
+--   2. _stockout_po_items：(c) 整單取消之後加 (c2) 呼叫 helper。
+--      這是採購斷貨的唯一核心（rpc_stockout_po_item /
+--      rpc_stockout_purchase_order 都走它），改一處兩個入口都涵蓋。
+--   3. rpc_cancel_backorder_items：「待補貨確定補不到 → 取消」同樣收尾。
+--   4. 資料治理（冪等）：把線上既有 18 張卡住的單收尾成 completed。
+--
+--   rpc_delete_order_item 不動：它的狀態閘只放行 status='pending' 的訂單，
+--   pending 單不可能有 picked_up 品項，helper 必然 no-op。
+--
+-- 基底版本（append-only，逐字保留所有 prior fix）：
+--   - _stockout_po_items：20260801000000_po_item_stockout.sql
+--     （逐字保留，僅加 v_close_ids / v_order_completed 宣告、(c2) 一段、
+--      回傳多一個 orders_completed 鍵）
+--   - rpc_cancel_backorder_items：20260805000060_shortage_allocation.sql
+--     （逐字保留，僅加 helper 呼叫與 orders_completed 回傳鍵）
+--
+-- Rollback：
+--   - _stockout_po_items 還原為 20260801000000 版本
+--   - rpc_cancel_backorder_items 還原為 20260805000060 版本
+--   - DROP FUNCTION public._close_orders_all_items_settled(BIGINT[], UUID, TIMESTAMPTZ);
+--   - 資料治理不自動回滾；被收尾的單可依 completed_at = 本次執行時間
+--     對照 customer_order_items.stockout_at 後手動改回 partially_completed
+--
+-- TEST: docs/TEST-stockout-closes-picked-order.md
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. helper：沒有待取品項且取過貨 → 結單
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public._close_orders_all_items_settled(
+  p_order_ids BIGINT[],
+  p_operator  UUID,
+  p_at        TIMESTAMPTZ DEFAULT NOW()
+) RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count INTEGER := 0;
+BEGIN
+  IF p_order_ids IS NULL OR array_length(p_order_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  UPDATE customer_orders co
+     SET status       = 'completed',
+         completed_at = COALESCE(co.completed_at, p_at),
+         updated_by   = p_operator,
+         updated_at   = NOW()
+   WHERE co.id = ANY(p_order_ids)
+     AND co.status IN ('pending','confirmed','ready','shipping','partially_completed')
+     -- 取過貨才叫「完成」；一件都沒取走的單交給既有的整單取消規則
+     AND EXISTS (
+           SELECT 1 FROM customer_order_items x
+            WHERE x.order_id = co.id
+              AND x.status = 'picked_up'
+         )
+     -- active 集合與 rpc_record_pickup 的 v_active_remaining 同一套
+     AND NOT EXISTS (
+           SELECT 1 FROM customer_order_items x
+            WHERE x.order_id = co.id
+              AND x.status IN ('pending','reserved','ready')
+         );
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._close_orders_all_items_settled(BIGINT[], UUID, TIMESTAMPTZ) FROM PUBLIC;
+
+COMMENT ON FUNCTION public._close_orders_all_items_settled(BIGINT[], UUID, TIMESTAMPTZ) IS
+  '訂單收尾 helper（品項被取消 / 斷貨後呼叫）：已無待取品項（pending/reserved/ready）'
+  '且至少取過一件（picked_up）→ status=completed、補 completed_at。'
+  '一件都沒取的單不動（走既有「全品項取消 → 整單 cancelled」規則）。';
+
+-- ------------------------------------------------------------
+-- 2. _stockout_po_items v2 — 斷貨連動後收尾已取完的訂單
+--    基底 20260801000000 逐字保留，僅加 (c2)
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public._stockout_po_items(
+  p_po_id    BIGINT,
+  p_item_ids BIGINT[],
+  p_operator UUID,
+  p_reason   TEXT DEFAULT NULL,
+  p_at       TIMESTAMPTZ DEFAULT NOW()
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_po            purchase_orders%ROWTYPE;
+  v_marked        BIGINT[];
+  v_stockout_skus BIGINT[];
+  v_campaign_ids  BIGINT[];
+  v_coi_ids       BIGINT[];
+  v_close_ids     BIGINT[];
+  v_ci_count      INTEGER := 0;
+  v_coi_count     INTEGER := 0;
+  v_order_count   INTEGER := 0;
+  v_order_done    INTEGER := 0;
+  v_notified      INTEGER := 0;
+  v_restock       JSONB := '{}'::jsonb;
+  v_outstanding   INTEGER;
+  v_received      NUMERIC(18,3);
+  v_new_status    TEXT;
+BEGIN
+  SELECT * INTO v_po FROM purchase_orders WHERE id = p_po_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '找不到採購單 #%', p_po_id;
+  END IF;
+
+  -- 1. 品項標記（冪等：已標記過的跳過）
+  WITH upd AS (
+    UPDATE purchase_order_items
+       SET stockout_at     = p_at,
+           stockout_by     = p_operator,
+           stockout_reason = NULLIF(BTRIM(p_reason), ''),
+           updated_by      = p_operator,
+           updated_at      = NOW()
+     WHERE po_id = p_po_id
+       AND id = ANY (COALESCE(p_item_ids, '{}'::BIGINT[]))
+       AND stockout_at IS NULL
+     RETURNING id
+  )
+  SELECT ARRAY_AGG(id) INTO v_marked FROM upd;
+
+  -- 2. 下游連動範圍（沿用 20260702020000 規則）：
+  --    完全沒到貨的品項才連動取消下游；部分到貨的品項只停止等待餘量，
+  --    已到的貨走正常撿貨 / 分貨流程。
+  SELECT ARRAY_AGG(sku_id) INTO v_stockout_skus
+    FROM purchase_order_items
+   WHERE id = ANY (COALESCE(v_marked, '{}'::BIGINT[]))
+     AND COALESCE(qty_received, 0) = 0;
+
+  -- 受影響開團：本次標記品項 → PR → purchase_request_campaigns
+  SELECT ARRAY_AGG(DISTINCT prc.campaign_id) INTO v_campaign_ids
+    FROM purchase_order_items poi
+    JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+    JOIN purchase_request_campaigns prc ON prc.pr_id = pri.pr_id
+   WHERE poi.id = ANY (COALESCE(v_marked, '{}'::BIGINT[]));
+
+  IF v_stockout_skus IS NOT NULL AND v_campaign_ids IS NOT NULL THEN
+
+    -- (a) 開團商品標記斷貨
+    UPDATE campaign_items
+       SET stockout_at = p_at,
+           updated_by  = p_operator,
+           updated_at  = NOW()
+     WHERE campaign_id = ANY(v_campaign_ids)
+       AND sku_id = ANY(v_stockout_skus)
+       AND stockout_at IS NULL;
+    GET DIAGNOSTICS v_ci_count = ROW_COUNT;
+
+    -- (b) 顧客訂單品項：pending → cancelled + 斷貨標記
+    --     （RETURNING 收集本次取消的品項，供 (d) 只通知這一批）
+    WITH upd AS (
+      UPDATE customer_order_items coi
+         SET status      = 'cancelled',
+             stockout_at = p_at,
+             updated_by  = p_operator,
+             updated_at  = NOW()
+        FROM customer_orders co
+       WHERE co.id = coi.order_id
+         AND co.campaign_id = ANY(v_campaign_ids)
+         AND coi.sku_id = ANY(v_stockout_skus)
+         AND coi.status = 'pending'
+         AND coi.stockout_at IS NULL
+       RETURNING coi.id
+    )
+    SELECT ARRAY_AGG(id) INTO v_coi_ids FROM upd;
+    v_coi_count := COALESCE(array_length(v_coi_ids, 1), 0);
+
+    -- (c) 訂單單頭：全部品項都已取消/過期 + 沒收過錢 → 整單取消（斷貨標記）
+    --     有付款 / 用過儲值金的單不自動取消，留給人工退款流程
+    UPDATE customer_orders co
+       SET status       = 'cancelled',
+           cancelled_at = p_at,
+           stockout_at  = p_at,
+           updated_by   = p_operator,
+           updated_at   = NOW()
+     WHERE co.campaign_id = ANY(v_campaign_ids)
+       AND co.status IN ('pending','confirmed')
+       AND COALESCE(co.payment_status, 'unpaid') <> 'paid'
+       AND COALESCE(co.wallet_paid_amount, 0) = 0
+       AND EXISTS (
+             SELECT 1 FROM customer_order_items x
+              WHERE x.order_id = co.id
+                AND x.stockout_at IS NOT NULL
+           )
+       AND NOT EXISTS (
+             SELECT 1 FROM customer_order_items x
+              WHERE x.order_id = co.id
+                AND x.status NOT IN ('cancelled','expired')
+           );
+    GET DIAGNOSTICS v_order_count = ROW_COUNT;
+
+    -- (c2) 20260808000000：已取走一部分、剩下的這次被斷貨取消 →
+    --      沒有待取品項了，訂單收尾成 completed（不然永遠卡「部分取貨」）。
+    --      與 (c) 互斥：(c) 要求全品項 cancelled/expired，有 picked_up 就不成立。
+    IF v_coi_ids IS NOT NULL THEN
+      SELECT ARRAY_AGG(DISTINCT order_id) INTO v_close_ids
+        FROM customer_order_items
+       WHERE id = ANY(v_coi_ids);
+
+      v_order_done := public._close_orders_all_items_settled(
+                        v_close_ids, p_operator, p_at);
+    END IF;
+
+    -- (d) 顧客通知（in-app 通知中心留底；綁定會員的訂單才發得了）
+    --     只通知本次被取消的品項 — 同 SKU 之前已斷貨/取消過的不再重發
+    IF v_coi_ids IS NOT NULL THEN
+      INSERT INTO notifications (tenant_id, member_id, category, title, body, url)
+      SELECT
+        co.tenant_id,
+        co.member_id,
+        'stockout',
+        '商品斷貨通知',
+        '您訂購的「' || string_agg(DISTINCT COALESCE(sk.product_name, sk.sku_code)
+                                    || COALESCE('-' || sk.variant_name, ''), '、')
+          || '」因供應商斷貨無法供貨，相關品項已取消，造成不便敬請見諒。',
+        '/orders'
+      FROM customer_order_items coi
+      JOIN customer_orders co ON co.id = coi.order_id
+      JOIN skus sk ON sk.id = coi.sku_id
+      WHERE coi.id = ANY(v_coi_ids)
+        AND co.member_id IS NOT NULL
+      GROUP BY co.tenant_id, co.member_id;
+      GET DIAGNOSTICS v_notified = ROW_COUNT;
+    END IF;
+
+  END IF;
+
+  -- 補貨申請連動（restock PR 不掛 campaign，走獨立鏈；helper 內自帶空集合守衛）
+  v_restock := public._stockout_propagate_restock(
+                 p_po_id, v_stockout_skus, p_operator, p_at);
+
+  -- 3. 母單收尾：不存在「未斷貨且未收滿」的品項 → 結單
+  --    （有到貨 → closed、全無 → cancelled，同整單版規則）
+  SELECT COUNT(*) FILTER (WHERE stockout_at IS NULL
+                            AND COALESCE(qty_received, 0) < qty_ordered),
+         COALESCE(SUM(qty_received), 0)
+    INTO v_outstanding, v_received
+    FROM purchase_order_items
+   WHERE po_id = p_po_id;
+
+  IF v_outstanding = 0 AND v_po.status IN ('sent','partially_received') THEN
+    v_new_status := CASE WHEN v_received > 0 THEN 'closed' ELSE 'cancelled' END;
+    UPDATE purchase_orders
+       SET status          = v_new_status,
+           stockout_at     = COALESCE(stockout_at, p_at),
+           stockout_by     = COALESCE(stockout_by, p_operator),
+           stockout_reason = COALESCE(stockout_reason, NULLIF(BTRIM(p_reason), '')),
+           updated_by      = p_operator,
+           updated_at      = NOW()
+     WHERE id = p_po_id;
+  ELSE
+    v_new_status := v_po.status;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'po_no',            v_po.po_no,
+    'po_status',        v_new_status,
+    'new_status',       v_new_status,   -- 向後相容：v3 回傳鍵名
+    'items_marked',     COALESCE(array_length(v_marked, 1), 0),
+    'stockout_skus',    COALESCE(array_length(v_stockout_skus, 1), 0),
+    'campaign_items',   v_ci_count,
+    'order_items',      v_coi_count,
+    'orders_cancelled', v_order_count,
+    'orders_completed', v_order_done,
+    'members_notified', v_notified
+  ) || COALESCE(v_restock, '{}'::jsonb);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._stockout_po_items(BIGINT, BIGINT[], UUID, TEXT, TIMESTAMPTZ) FROM PUBLIC;
+
+COMMENT ON FUNCTION public._stockout_po_items(BIGINT, BIGINT[], UUID, TEXT, TIMESTAMPTZ) IS
+  '品項斷貨核心（rpc_stockout_po_item / rpc_stockout_purchase_order 內部用）：'
+  '標記品項 stockout_at → 下游連動（開團 / 顧客訂單 / 補貨鏈 / 通知，scope 限被標記品項）'
+  '→ 全品項定案時母單自動 closed / cancelled。呼叫端需先鎖母單並驗狀態。'
+  '20260808000000：連動取消後若訂單已無待取品項且取過貨 → 收尾成 completed（orders_completed）。';
+
+-- ------------------------------------------------------------
+-- 3. rpc_cancel_backorder_items v2 — 同樣收尾已取完的訂單
+--    基底 20260805000060 逐字保留，僅加 helper 呼叫
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_cancel_backorder_items(
+  p_item_ids BIGINT[],
+  p_operator UUID
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_items     INT := 0;
+  v_orders    INT := 0;
+  v_completed INT := 0;
+  v_ids       BIGINT[] := COALESCE(p_item_ids, ARRAY[]::BIGINT[]);
+  v_order_ids BIGINT[];
+BEGIN
+  UPDATE customer_order_items coi
+     SET status = 'cancelled', stockout_at = NOW(),
+         updated_by = p_operator, updated_at = NOW()
+   WHERE coi.id = ANY(v_ids)
+     AND coi.backorder_at IS NOT NULL       -- 只准取消待補貨的，避免誤砍正常品項
+     AND coi.status IN ('pending', 'reserved', 'ready');
+  GET DIAGNOSTICS v_items = ROW_COUNT;
+
+  UPDATE customer_orders co
+     SET status = 'cancelled', cancelled_at = NOW(), stockout_at = NOW(),
+         updated_by = p_operator, updated_at = NOW()
+   WHERE co.id IN (SELECT order_id FROM customer_order_items WHERE id = ANY(v_ids))
+     AND co.status IN ('pending', 'confirmed', 'ready', 'shipping')
+     AND COALESCE(co.payment_status, 'unpaid') <> 'paid'
+     AND COALESCE(co.wallet_paid_amount, 0) = 0
+     AND NOT EXISTS (
+           SELECT 1 FROM customer_order_items x
+            WHERE x.order_id = co.id AND x.status NOT IN ('cancelled', 'expired')
+         );
+  GET DIAGNOSTICS v_orders = ROW_COUNT;
+
+  -- 20260808000000：已取走一部分、剩下的待補貨這次被取消 → 訂單收尾成 completed
+  SELECT ARRAY_AGG(DISTINCT order_id) INTO v_order_ids
+    FROM customer_order_items WHERE id = ANY(v_ids);
+  v_completed := public._close_orders_all_items_settled(v_order_ids, p_operator, NOW());
+
+  RETURN jsonb_build_object(
+    'items_cancelled',  v_items,
+    'orders_cancelled', v_orders,
+    'orders_completed', v_completed
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_cancel_backorder_items(BIGINT[], UUID) IS
+  '待補貨確定補不到 → 品項 cancelled + stockout_at（沿用斷貨語意）。'
+  '整單品項都沒了且沒收過錢 → 訂單一併取消；'
+  '已取走一部分、剩下的這次取消掉 → 訂單收尾成 completed（20260808000000）。';
+
+-- ------------------------------------------------------------
+-- 4. 資料治理：收尾線上既有卡在「部分取貨」的單（冪等）
+-- ------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_ids  BIGINT[];
+  v_done INTEGER;
+BEGIN
+  SELECT ARRAY_AGG(co.id) INTO v_ids
+    FROM customer_orders co
+   WHERE co.status = 'partially_completed'
+     AND EXISTS (
+           SELECT 1 FROM customer_order_items x
+            WHERE x.order_id = co.id AND x.status = 'picked_up'
+         )
+     AND NOT EXISTS (
+           SELECT 1 FROM customer_order_items x
+            WHERE x.order_id = co.id
+              AND x.status IN ('pending','reserved','ready')
+         );
+
+  v_done := public._close_orders_all_items_settled(v_ids, NULL, NOW());
+  RAISE NOTICE '[20260808000000] 收尾卡在部分取貨的訂單: %', v_done;
+END;
+$$;

--- a/supabase/migrations/20260808000000_stats_exclude_transferred_out_items.sql
+++ b/supabase/migrations/20260808000000_stats_exclude_transferred_out_items.sql
@@ -1,0 +1,314 @@
+-- ============================================================
+-- 2026-08-08: 統計不再重複計算「已轉走」的數量／金額
+--
+-- 回報：同店互轉（換客人）後，開團的「本店小計 / 品項數量」變多 ——
+--   一進一出總量卻不守恆。
+--
+-- 成因：轉單是「複製 + 標記」不是「搬移」，而統計只濾了訂單層級的
+--   status，沒濾品項層級：
+--     rpc_transfer_order_partial 把整項轉走的來源品項標成
+--       customer_order_items.status='cancelled'，但**留在來源單上**，
+--       來源單 status 也不變（還是 confirmed/ready）。
+--     ⇒ 來源單照算原數量 + 轉入單再算一次。
+--   實例 GRP-20260804-007 湖口店：-0058 轉 1 顆到 -TF0157，
+--   小計 21 顆 / $1,325（實際 20 顆 / $1,250）。
+--   （另一條路：rpc_transfer_order_to_store 整單轉出把來源單標
+--    transferred_out 但品項原封不動 —— 這兩支 RPC 本來就有濾
+--    transferred_out，故不受影響。）
+--
+-- 修法：
+--   1. rpc_orders_pivot — 正單 qty_sum/amount 改用「訂單被排除 OR
+--      品項被排除」單一旗標；被排除的量照舊進 neg_qty_sum/neg_amount
+--      （UI 顯示「(取消 N 個)」），drill-down 的 pos/neg_order_ids
+--      跟著同一旗標，行為與原本一致。
+--   2. rpc_order_overview — trend 的 order_amt 排除 cancelled/expired
+--      品項（pickup_items 本來就只取 i.status='picked_up'，不受影響）。
+--
+-- 前端同步（同一個 commit）：CampaignOrdersPanel / MemberDetail /
+--   campaigns 列表與月曆的加總，一律改走 lib/orderStatus.ts 的
+--   orderCountsInTotals + orderItemCountsInTotals。
+--
+-- 基底版本：兩支都以 2026-08-08 線上 pg_get_functiondef 逐字取回為基底。
+--   注意 repo drift：線上 rpc_orders_pivot 的 p_closed_only 白名單比
+--   20260622000010 多一個 'locked'（線上 hotfix），本檔一併以線上為準收錄。
+-- Rollback：CREATE OR REPLACE 回本檔內文並移除新增條件即為前一版
+--   （pivot 還原成只看 b.status；overview 移除 order_amt 的 WHERE）。
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. rpc_orders_pivot：品項層級的取消也要排除在正單數量之外
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_orders_pivot(p_view_by text, p_date_from date, p_date_to date, p_campaign_ids bigint[], p_store_id bigint, p_statuses text[], p_closed_only boolean DEFAULT NULL::boolean)
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH filtered AS (
+    SELECT o.*
+    FROM customer_orders o
+    LEFT JOIN group_buy_campaigns c ON c.id = o.campaign_id
+    WHERE o.status = ANY(p_statuses)
+      AND (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      AND (
+        p_closed_only IS NULL
+        OR (p_closed_only IS TRUE
+            AND c.status IN ('closed','locked','ordered','receiving','ready','completed'))
+        OR (p_closed_only IS FALSE
+            AND c.status NOT IN ('closed','locked','ordered','receiving','ready','completed'))
+      )
+      AND CASE p_view_by
+        WHEN 'pickup_date' THEN
+          (p_date_from IS NULL OR o.pickup_deadline >= p_date_from)
+          AND (p_date_to IS NULL OR o.pickup_deadline <  p_date_to)
+        WHEN 'order_date' THEN
+          (p_date_from IS NULL OR o.created_at >= p_date_from::timestamptz)
+          AND (p_date_to IS NULL OR o.created_at <  p_date_to::timestamptz)
+        WHEN 'campaign' THEN
+          c.end_at IS NULL
+          OR (
+            (p_date_from IS NULL OR c.end_at >= p_date_from::timestamptz)
+            AND (p_date_to IS NULL OR c.end_at <  p_date_to::timestamptz)
+          )
+        ELSE TRUE
+      END
+  ),
+  base AS (
+    SELECT
+      CASE p_view_by
+        WHEN 'campaign'    THEN 'c' || f.campaign_id::text
+        WHEN 'pickup_date' THEN 'd' || to_char(COALESCE(f.pickup_deadline, f.created_at::date), 'YYYY-MM-DD')
+        WHEN 'order_date'  THEN 'd' || to_char(f.created_at::date, 'YYYY-MM-DD')
+      END                                              AS group_key,
+      CASE WHEN p_view_by = 'campaign' THEN f.campaign_id ELSE NULL::bigint END
+                                                       AS group_id,
+      i.sku_id,
+      s.product_name                                   AS sku_product_name,
+      s.variant_name                                   AS sku_variant_name,
+      f.pickup_store_id,
+      f.id                                             AS order_id,
+      -- 排除旗標：訂單層級（取消/過期/轉出）或品項層級（部分轉出把來源品項
+      -- 標 cancelled 但留在原單）任一成立，這一列就不算進正單數量
+      (f.status IN ('cancelled','expired','transferred_out')
+       OR i.status IN ('cancelled','expired'))         AS excluded,
+      i.qty,
+      i.unit_price
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    LEFT JOIN skus s ON s.id = i.sku_id
+  ),
+  agg AS (
+    SELECT
+      b.group_key,
+      b.group_id,
+      b.sku_id,
+      b.sku_product_name,
+      b.sku_variant_name,
+      b.pickup_store_id,
+      SUM(CASE WHEN b.excluded THEN 0 ELSE b.qty END)::numeric                AS qty_sum,
+      SUM(CASE WHEN b.excluded THEN 0 ELSE b.qty * b.unit_price END)::numeric AS amount,
+      SUM(CASE WHEN b.excluded THEN b.qty ELSE 0 END)::numeric                AS neg_qty_sum,
+      SUM(CASE WHEN b.excluded THEN b.qty * b.unit_price ELSE 0 END)::numeric AS neg_amount,
+      COALESCE(
+        ARRAY_AGG(DISTINCT b.order_id) FILTER (WHERE NOT b.excluded),
+        '{}'::bigint[]
+      )                                                                       AS pos_order_ids,
+      COALESCE(
+        ARRAY_AGG(DISTINCT b.order_id) FILTER (WHERE b.excluded),
+        '{}'::bigint[]
+      )                                                                       AS neg_order_ids
+    FROM base b
+    GROUP BY
+      b.group_key,
+      b.group_id,
+      b.sku_id,
+      b.sku_product_name,
+      b.sku_variant_name,
+      b.pickup_store_id
+  )
+  SELECT COALESCE(jsonb_agg(to_jsonb(agg.*)), '[]'::jsonb)
+  FROM agg;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_orders_pivot(text, date, date, bigint[], bigint, text[], boolean) IS
+  '訂單樞紐：qty_sum/amount 只算「訂單未取消/過期/轉出」且「品項未取消/過期」的量；'
+  '被排除的量進 neg_qty_sum/neg_amount。品項層級的排除是為了部分轉出 —— '
+  '來源品項被標 cancelled 但留在原單，不濾會與轉入單重複計。基底：2026-08-08 線上版。';
+
+-- ----------------------------------------------------------------
+-- 2. rpc_order_overview：本月金額趨勢排除已取消品項
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_order_overview(p_campaign_ids bigint[], p_store_id bigint, p_keyword text, p_month_start timestamp with time zone, p_date_from timestamp with time zone DEFAULT NULL::timestamp with time zone, p_date_to timestamp with time zone DEFAULT NULL::timestamp with time zone, p_sku_ids bigint[] DEFAULT NULL::bigint[])
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH kw AS (
+    -- 與 buildKeywordOr 一致：先把 %,() 換成空白避免當成 ILIKE 萬用字元
+    SELECT NULLIF(btrim(regexp_replace(COALESCE(p_keyword, ''), '[%,()]', ' ', 'g')), '') AS q
+  ),
+  toks AS (
+    SELECT ARRAY(
+      SELECT t FROM unnest(regexp_split_to_array((SELECT q FROM kw), '[\s+]+')) AS t
+      WHERE t <> ''
+    ) AS arr
+  ),
+  qualified_members AS (
+    -- token-AND：每個 token 都要在 name/phone/member_no 至少一欄命中
+    SELECT m.id
+    FROM members m
+    WHERE (SELECT q FROM kw) IS NOT NULL
+      AND m.status <> 'deleted'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM unnest((SELECT arr FROM toks)) AS tok
+        WHERE NOT (
+          m.name      ILIKE '%' || tok || '%'
+          OR m.phone     ILIKE '%' || tok || '%'
+          OR m.member_no ILIKE '%' || tok || '%'
+        )
+      )
+  ),
+  filtered AS (
+    -- v_admin_orders = customer_orders + event_at（事件日，定義見 20260805000120）
+    SELECT o.id, o.member_id, o.created_at, o.event_at, o.status
+    FROM v_admin_orders o
+    WHERE (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      -- 品項篩選：訂單層級（至少含一列指定 SKU 的訂單），與列表的
+      -- customer_order_items!inner 內嵌過濾同義
+      AND (
+        p_sku_ids IS NULL
+        OR cardinality(p_sku_ids) = 0
+        OR EXISTS (
+          SELECT 1 FROM customer_order_items i
+          WHERE i.order_id = o.id AND i.sku_id = ANY(p_sku_ids)
+        )
+      )
+      AND (
+        (SELECT q FROM kw) IS NULL
+        OR o.order_no          ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.nickname_snapshot ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.member_id IN (SELECT id FROM qualified_members)
+      )
+  ),
+  -- 「未取貨」tab 專用：訂單日 created_at 區間
+  ranged_order AS (
+    SELECT f.*
+    FROM filtered f
+    WHERE (p_date_from IS NULL OR f.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR f.created_at <  p_date_to)
+  ),
+  -- 其餘 tab 專用：事件日 event_at 區間
+  ranged_event AS (
+    SELECT f.*
+    FROM filtered f
+    WHERE (p_date_from IS NULL OR f.event_at >= p_date_from)
+      AND (p_date_to   IS NULL OR f.event_at <  p_date_to)
+  ),
+  tab_counts AS (
+    SELECT
+      (SELECT count(*) FROM ranged_order WHERE status IN ('pending','confirmed','shipping','ready')) AS pending,
+      -- ready 是 pending 的子集（刻意重疊）：未取貨=全部未取，可取貨=其中已到店的。
+      -- 兩者的日期語意不同（訂單日 vs 到貨可取日），故取自不同的 ranged。
+      (SELECT count(*) FROM ranged_event WHERE status = 'ready')                                     AS ready,
+      (SELECT count(*) FROM ranged_event WHERE status = 'partially_completed')                       AS partially,
+      (SELECT count(*) FROM ranged_event WHERE status = 'completed')                                 AS completed,
+      (SELECT count(*) FROM ranged_event WHERE status IN ('cancelled','expired'))                    AS cancelled,
+      (SELECT count(*) FROM ranged_event WHERE status = 'transferred_out')                           AS transferred
+  ),
+  trend_orders AS (
+    SELECT
+      f.id,
+      f.member_id,
+      to_char((f.created_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd
+    FROM filtered f
+    WHERE f.status NOT IN ('cancelled','expired','transferred_out')
+      AND f.created_at >= p_month_start
+  ),
+  order_amt AS (
+    SELECT i.order_id, SUM(i.qty * i.unit_price)::numeric AS amount
+    FROM customer_order_items i
+    JOIN trend_orders t ON t.id = i.order_id
+    -- 部分轉出會把「整項轉走」的來源品項標 cancelled 留在原單上；
+    -- 不濾掉的話同一批貨會在來源單與轉入單各算一次金額
+    WHERE i.status NOT IN ('cancelled','expired')
+    GROUP BY i.order_id
+  ),
+  day_agg AS (
+    SELECT
+      t.ymd,
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+    GROUP BY t.ymd
+  ),
+  total_agg AS (
+    SELECT
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+  ),
+  -- 取貨明細（本月）：一行 picked_up = 一次交貨，逐行加總
+  pickup_items AS (
+    SELECT
+      to_char((i.updated_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd,
+      f.id                            AS order_id,
+      (i.qty * i.unit_price)::numeric AS amount,
+      i.qty::numeric                  AS qty
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    WHERE i.status = 'picked_up'
+      AND i.updated_at >= p_month_start
+      AND f.status NOT IN ('cancelled','expired','transferred_out')
+  ),
+  pickup_day_agg AS (
+    SELECT
+      p.ymd,
+      count(DISTINCT p.order_id) AS orders,
+      SUM(p.amount)::numeric     AS amount,
+      SUM(p.qty)::numeric        AS qty
+    FROM pickup_items p
+    GROUP BY p.ymd
+  ),
+  pickup_total_agg AS (
+    SELECT
+      count(DISTINCT p.order_id)         AS orders,
+      COALESCE(SUM(p.amount), 0)::numeric AS amount,
+      COALESCE(SUM(p.qty), 0)::numeric    AS qty
+    FROM pickup_items p
+  )
+  SELECT jsonb_build_object(
+    'tab_counts', (SELECT to_jsonb(tab_counts.*) FROM tab_counts),
+    'trend_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'members', members, 'amount', amount
+                ) ORDER BY ymd)
+       FROM day_agg),
+      '[]'::jsonb
+    ),
+    'trend_total', (SELECT to_jsonb(total_agg.*) FROM total_agg),
+    'pickup_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'amount', amount, 'qty', qty
+                ) ORDER BY ymd)
+       FROM pickup_day_agg),
+      '[]'::jsonb
+    ),
+    'pickup_total', (SELECT to_jsonb(pickup_total_agg.*) FROM pickup_total_agg)
+  );
+$function$;

--- a/supabase/migrations/20260808000010_account_link_invite.sql
+++ b/supabase/migrations/20260808000010_account_link_invite.sql
@@ -1,0 +1,17 @@
+-- ============================================================================
+-- 2026-08-08: account link 邀請的冷卻欄位
+--
+-- 顧客傳訊息給店家 OA 而我們還不知道他是誰時，自動回一則「查看我的訂單」，
+-- 那條連結會帶著 linkToken 走完 account link，把該店 provider 的 ID 跟會員綁起來。
+--
+-- 為什麼要冷卻：不擋的話顧客每傳一句話就收到一則機器訊息，會蓋掉正常對話。
+-- 記下上次邀請時間，同一個人一段時間內只邀一次。
+--
+-- 註：回覆訊息（replyToken）不吃推播額度，所以這個機制本身零成本。
+-- ============================================================================
+
+ALTER TABLE store_line_followers
+  ADD COLUMN IF NOT EXISTS link_invited_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN store_line_followers.link_invited_at IS
+  '上次自動發出 account link 邀請的時間；用來做冷卻，避免每則訊息都回一次';

--- a/supabase/migrations/20260808000010_member_sold_qty_exclude_transferred.sql
+++ b/supabase/migrations/20260808000010_member_sold_qty_exclude_transferred.sql
@@ -1,0 +1,219 @@
+-- ============================================================
+-- 2026-08-08: 會員端「已售出 / 剩餘 N 份」不再重複計算轉出的量
+--
+-- 延續 20260808000000（後台統計）：同一個根因也打到**顧客看得到的**
+--   數字。轉單是「複製 + 標記」不是「搬移」：
+--     整單轉出 → 來源單 status='transferred_out'，品項原封不動；
+--     部分轉出 → 來源品項 status='cancelled' 但留在來源單上。
+--   這三支 RPC 都只濾了 ('cancelled','expired')：
+--     - 訂單層級漏掉 'transferred_out'
+--     - 品項層級完全沒濾
+--   ⇒ 已售出被灌水。線上受影響：106 個團、合計虛增 518 件。
+--
+-- 為什麼比後台統計嚴重：ordered_qty 會拿去跟 cap_qty / total_cap_qty
+--   相減算「剩 N 份」「搶購一空」（apps/member/src/components/CampaignCard.tsx
+--   remaining()/soldOut()）。虛增的量會吃掉限量名額，把還有貨的團顯示成
+--   售完、把真的想買的會員擋在外面。（目前線上還沒有品項被誤判售完，
+--   是運氣，不是設計。）
+--
+-- 修法：三支一律改成
+--     co.status NOT IN ('cancelled','expired','transferred_out')
+--     coi.status NOT IN ('cancelled','expired')          -- 有 join 品項的才需要
+--   與 lib/orderStatus.ts 的 orderCountsInTotals / orderItemCountsInTotals
+--   同一套規則。
+--
+-- 同批一起改（同一個 commit）：supabase/functions/liff-api/index.ts
+--   的 listActiveCampaigns.orderedMap 與開團詳情 itemOrderedMap —— 顧客端
+--   實際顯示的數字是走那兩段 PostgREST 查詢，不是這裡的 RPC。
+--
+-- 基底版本：三支都以 2026-08-08 線上 pg_get_functiondef 逐字取回為基底。
+--   注意 drift：rpc_member_campaign_aggregates / rpc_member_campaign_detail
+--   在 supabase/migrations/ 裡**完全沒有對應檔案**（線上手動建的），
+--   本檔一併把它們收編進 migration 歷史。三支都是 anon 可呼叫。
+-- Rollback：CREATE OR REPLACE 回本檔內文，把 'transferred_out' 與
+--   coi.status 條件移除即為前一版。
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. rpc_member_campaign_order_counts：訂單筆數（最熱銷 / 近期售出排序）
+--    轉出的來源單與轉入單會各算一筆 → 排除 transferred_out
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_member_campaign_order_counts(
+  p_tenant uuid,
+  p_recent_days integer DEFAULT 7
+)
+RETURNS TABLE(campaign_id bigint, order_count bigint, recent_order_count bigint)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  SELECT
+    co.campaign_id,
+    COUNT(*) AS order_count,
+    COUNT(*) FILTER (
+      WHERE co.created_at >= now() - make_interval(days => GREATEST(p_recent_days, 0))
+    ) AS recent_order_count
+  FROM customer_orders co
+  WHERE co.tenant_id = p_tenant
+    AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+    AND COALESCE(co.order_kind, 'normal') = 'normal'
+  GROUP BY co.campaign_id;
+$function$;
+
+-- ----------------------------------------------------------------
+-- 2. rpc_member_campaign_aggregates：每團訂單數 + 已下單總量
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_member_campaign_aggregates(
+  p_tenant uuid,
+  p_recent_days integer DEFAULT 7
+)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  WITH
+  filtered_orders AS (
+    SELECT co.id, co.campaign_id, co.created_at
+    FROM customer_orders co
+    WHERE co.tenant_id = p_tenant
+      AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+      AND COALESCE(co.order_kind, 'normal') = 'normal'
+  ),
+  counts AS (
+    SELECT
+      fo.campaign_id,
+      COUNT(*)::bigint AS order_count,
+      COUNT(*) FILTER (
+        WHERE fo.created_at >= now() - make_interval(days => GREATEST(p_recent_days, 0))
+      )::bigint AS recent_order_count
+    FROM filtered_orders fo
+    GROUP BY fo.campaign_id
+  ),
+  qtys AS (
+    SELECT
+      fo.campaign_id,
+      SUM(coi.qty)::numeric AS ordered_qty
+    FROM filtered_orders fo
+    JOIN customer_order_items coi ON coi.order_id = fo.id
+    -- 部分轉出把整項轉走的來源品項標 cancelled 留在原單上
+    WHERE coi.status NOT IN ('cancelled', 'expired')
+    GROUP BY fo.campaign_id
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'campaign_id',         c.campaign_id,
+        'order_count',         c.order_count,
+        'recent_order_count',  c.recent_order_count,
+        'ordered_qty',         COALESCE(q.ordered_qty, 0)
+      )
+    ),
+    '[]'::jsonb
+  )
+  FROM counts c
+  LEFT JOIN qtys q ON q.campaign_id = c.campaign_id;
+$function$;
+
+-- ----------------------------------------------------------------
+-- 3. rpc_member_campaign_detail：開團詳情（每個 campaign_item 的已售出）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_member_campaign_detail(
+  p_tenant uuid,
+  p_campaign_id bigint
+)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  WITH
+  c AS (
+    SELECT
+      gbc.id,
+      gbc.campaign_no,
+      gbc.name,
+      gbc.description,
+      gbc.cover_image_url,
+      gbc.status,
+      gbc.end_at,
+      gbc.pickup_deadline
+    FROM group_buy_campaigns gbc
+    WHERE gbc.tenant_id = p_tenant
+      AND gbc.id = p_campaign_id
+  ),
+  items AS (
+    SELECT
+      ci.id,
+      ci.unit_price,
+      ci.cap_qty,
+      ci.sort_order,
+      sku.id           AS sku_id,
+      sku.sku_code     AS sku_code,
+      sku.product_name AS sku_product_name,
+      sku.variant_name AS sku_variant_name,
+      p.name           AS product_name,
+      p.images         AS product_images
+    FROM campaign_items ci
+    JOIN skus sku ON sku.id = ci.sku_id
+    LEFT JOIN products p ON p.id = sku.product_id
+    WHERE ci.tenant_id = p_tenant
+      AND ci.campaign_id = p_campaign_id
+  ),
+  -- 訂單筆數 (含品項一筆訂單只算一次)
+  order_count AS (
+    SELECT COUNT(*)::bigint AS n
+    FROM customer_orders co
+    WHERE co.tenant_id = p_tenant
+      AND co.campaign_id = p_campaign_id
+      AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+      AND COALESCE(co.order_kind, 'normal') = 'normal'
+  ),
+  -- 每個 campaign_item 累計已下單數量
+  -- (排除取消/逾期/轉出的單、排除非 normal 訂單、排除已取消的品項)
+  ordered_qty_per_item AS (
+    SELECT
+      coi.campaign_item_id,
+      SUM(coi.qty)::numeric AS total_qty
+    FROM customer_order_items coi
+    JOIN customer_orders co ON co.id = coi.order_id
+    WHERE coi.tenant_id = p_tenant
+      AND co.campaign_id = p_campaign_id
+      AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+      AND coi.status NOT IN ('cancelled', 'expired')
+      AND COALESCE(co.order_kind, 'normal') = 'normal'
+    GROUP BY coi.campaign_item_id
+  )
+  SELECT jsonb_build_object(
+    'campaign', (
+      SELECT to_jsonb(c) || jsonb_build_object(
+        'order_count', (SELECT n FROM order_count)
+      )
+      FROM c
+    ),
+    'items', COALESCE((
+      SELECT jsonb_agg(
+        to_jsonb(items) || jsonb_build_object(
+          'ordered_qty', COALESCE(oq.total_qty, 0)
+        )
+        ORDER BY items.sort_order ASC, items.id ASC
+      )
+      FROM items
+      LEFT JOIN ordered_qty_per_item oq ON oq.campaign_item_id = items.id
+    ), '[]'::jsonb)
+  )
+  FROM c;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_member_campaign_order_counts(uuid, integer) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_member_campaign_aggregates(uuid, integer)   TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_member_campaign_detail(uuid, bigint)        TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.rpc_member_campaign_order_counts(uuid, integer) IS
+  '會員端每團訂單筆數（最熱銷 / 近期售出排序用）。排除 cancelled/expired/transferred_out —— '
+  '轉出的來源單與轉入單否則會各算一筆。基底：2026-08-08 線上版。';
+COMMENT ON FUNCTION public.rpc_member_campaign_aggregates(uuid, integer) IS
+  '會員端每團訂單數 + 已下單總量。訂單層級排除 cancelled/expired/transferred_out、'
+  '品項層級排除 cancelled/expired（部分轉出的來源品項留在原單），否則已售出會虛增。'
+  '基底：2026-08-08 線上版（此函式原本不在 migrations 內，本檔收編）。';
+COMMENT ON FUNCTION public.rpc_member_campaign_detail(uuid, bigint) IS
+  '會員端開團詳情：每個 campaign_item 的已售出。過濾規則同 rpc_member_campaign_aggregates。'
+  'ordered_qty 會拿去跟 cap_qty 相減算「剩 N 份」，虛增會把還有貨的品項顯示成售完。'
+  '基底：2026-08-08 線上版（此函式原本不在 migrations 內，本檔收編）。';

--- a/supabase/migrations/20260808000010_payable_exclude_cancelled_items.sql
+++ b/supabase/migrations/20260808000010_payable_exclude_cancelled_items.sql
@@ -1,0 +1,403 @@
+-- ============================================================
+-- 2026-08-08: 訂單「應收」不再含已取消 / 斷貨的品項
+--
+-- 回報案例（訂單 GRP-20260712-004-0046, id=49469）：
+--   4 個品項取走 3 個（$218）、第 4 項斷貨取消（$65），訂單明細頁
+--   仍顯示「原價 $283 · 小計 $283 · 應收 $283」，「用儲值金結帳」也
+--   按 $283 開。客人拿不到的貨不該收錢。
+--
+-- 根因：items_total = SUM(qty * unit_price) 完全不濾 coi.status，
+--   斷貨取消（status='cancelled' + stockout_at，見 20260702020000）
+--   與人工刪除品項（rpc_delete_order_item 軟刪成 cancelled）都還留在
+--   加總裡。同一條算式散在四處，全都沒濾：
+--     v_customer_order_summary.items_total（admin 明細 + LIFF 會員端）
+--     rpc_wallet_pay_order.v_items_total（儲值金可扣上限）
+--     v_admin_orders_list.total_amount（/orders 列表「總金額」欄，可排序）
+--     admin OrderDetail / orders 列表 / member OrderCard 的前端加總
+--
+--   線上影響：241 張未結訂單合計多算 NT$24,630；其中
+--   payment_status='paid' 0 張、wallet_paid_amount > 0 也 0 張
+--   → 沒有任何已收款訂單會因為應收下修而出現負的 balance_due。
+--
+-- 修法：加總一律加 `status NOT IN ('cancelled','expired')`。
+--   - 這與同一支 view 的 returned_deduction 分攤子查詢（20260731000000）
+--     早就在用的過濾條件一致 —— 之前是「扣減只認 active 行、母數卻含
+--     全部行」，本次把母數對齊。
+--   - items[] jsonb **不濾**：前端要繼續顯示「⛔ 斷貨」那一列
+--     （會員端 OrderCard 會把它畫成刪除線）。
+--   - 'expired' 一併排除：與 cancelled 同屬「這行不算數」的終態，
+--     既有過濾慣例都是兩個一起寫。
+--
+-- 基底版本（append-only，逐字保留所有 prior fix）：
+--   - v_customer_order_summary：20260731000000_return_deduct_payable_and_pickup_guard.sql
+--     （逐字保留，僅 items_total 加 FILTER + COMMENT 補一句）
+--   - rpc_wallet_pay_order：20260731000000_return_deduct_payable_and_pickup_guard.sql
+--     （逐字保留，僅 v_items_total 的 SELECT 加 WHERE）
+--   - v_admin_orders_list：20260807000000_v_admin_orders_list_sortable.sql
+--     （逐字保留，僅 LATERAL 彙總加 WHERE；line_count / total_qty 一併排除，
+--      不然會出現「5 件 $218」這種列不起來的組合）
+--
+-- 對應前端（同一個 commit）：
+--   - apps/admin/src/components/OrderDetail.tsx（原價 / 小計 / 件數）
+--   - apps/admin/src/app/(protected)/orders/page.tsx（列表品項彙總）
+--   - apps/member/src/components/OrderCard.tsx（商品件數）
+--   PickupDialog 不動：它本來就只加總本次勾選的品項。
+--
+-- Rollback：
+--   - v_customer_order_summary / rpc_wallet_pay_order 還原為 20260731000000 版本
+--   - v_admin_orders_list 還原為 20260807000000 版本
+--
+-- TEST: docs/TEST-stockout-closes-picked-order.md §D
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. v_customer_order_summary v4 — items_total 排除 cancelled/expired
+-- ------------------------------------------------------------
+
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.discount_percent,
+  co.wallet_paid_amount,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  co.stockout_at,
+  agg.items_total,
+  ret.returned_qty,
+  ret.returned_deduction,
+  GREATEST(
+    0,
+    ROUND(
+      GREATEST(0, agg.items_total - ret.returned_deduction)
+        * (1 - co.discount_percent / 100)
+        + co.shipping_fee
+        - co.discount_amount,
+      0
+    )
+  )                                                                            AS payable_amount,
+  GREATEST(
+    0,
+    GREATEST(
+      0,
+      ROUND(
+        GREATEST(0, agg.items_total - ret.returned_deduction)
+          * (1 - co.discount_percent / 100)
+          + co.shipping_fee
+          - co.discount_amount,
+        0
+      )
+    ) - co.wallet_paid_amount
+  )                                                                            AS balance_due,
+  agg.items,
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','shipping','completed'))                AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))            AS settled,
+  (co.payment_status = 'paid')                                                 AS paid,
+  (co.status IN ('shipping','completed'))                                      AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                 AS settlement_no,
+  s.name                                                                        AS store_name,
+  s.code                                                                        AS store_code,
+  gbc.name                                                                      AS campaign_name,
+  gbc.cover_image_url                                                           AS campaign_cover_url,
+  gbc.end_at                                                                    AS campaign_end_at,
+  gbc.cutoff_date                                                               AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price)
+               FILTER (WHERE coi.status NOT IN ('cancelled','expired')), 0)  AS items_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'sku_code',         sk.sku_code,
+          'product_name',     sk.product_name,
+          'variant_name',     sk.variant_name,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'subtotal',         coi.qty * coi.unit_price,
+          'status',           coi.status,
+          'stockout',         (coi.stockout_at IS NOT NULL),
+          'notes',            coi.notes,
+          'image_url',        CASE
+            WHEN jsonb_typeof(p.images) = 'array' AND jsonb_array_length(p.images) > 0 THEN
+              COALESCE(p.images -> 0 ->> 'url', p.images ->> 0)
+            ELSE NULL
+          END
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                           AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus     sk ON sk.id = coi.sku_id
+  LEFT JOIN products p  ON p.id  = sk.product_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE
+LEFT JOIN LATERAL (
+  -- 未取退貨扣減：return_to_hq（shipped/received、notes header 不含
+  -- |取貨後退回）依 SKU 聚合退貨量，按品項行序 (id) 分攤到未取消品項行、
+  -- 以該行 unit_price 折算金額
+  SELECT
+    COALESCE(SUM(a.alloc_qty), 0)                AS returned_qty,
+    COALESCE(SUM(a.alloc_qty * a.unit_price), 0) AS returned_deduction
+  FROM (
+    SELECT
+      i.unit_price,
+      LEAST(i.qty, GREATEST(r.ret_qty - i.prior_qty, 0)) AS alloc_qty
+    FROM (
+      SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+        FROM transfers t
+        JOIN transfer_items ti ON ti.transfer_id = t.id
+       WHERE t.customer_order_id = co.id
+         AND t.tenant_id     = co.tenant_id
+         AND t.transfer_type = 'return_to_hq'
+         AND t.status IN ('shipped','received')
+         AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+             NOT LIKE '%取貨後退回%'
+       GROUP BY ti.sku_id
+    ) r
+    JOIN (
+      SELECT coi.sku_id, coi.qty, coi.unit_price,
+             COALESCE(SUM(coi.qty) OVER (
+               PARTITION BY coi.sku_id ORDER BY coi.id
+               ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+             ), 0) AS prior_qty
+        FROM customer_order_items coi
+       WHERE coi.order_id = co.id
+         AND coi.status NOT IN ('cancelled','expired')
+    ) i ON i.sku_id = r.sku_id
+  ) a
+) ret ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細 + percent + amount 雙折扣 + 儲值金抵扣 + balance_due'
+  '（應收已四捨五入到整數 NTD）+ 斷貨標記（stockout_at / items[].stockout）'
+  '+ 未取退貨扣減（returned_qty / returned_deduction；取貨後退回不扣、退款走 rpc_wallet_partial_refund）'
+  '。20260808000010：items_total 不含 cancelled/expired 品項（斷貨 / 人工刪除的品項不收錢）；'
+  'items[] 仍保留這些行供前端顯示「斷貨」。';
+
+-- DROP + CREATE 會清掉 grant。public schema 的 default privileges 本來就會補回
+-- anon/authenticated/service_role（20260731000000 沒寫 GRANT 也活著），這裡明寫一行
+-- 當保險，不依賴 default privileges 的設定沒被動過。
+GRANT SELECT ON v_customer_order_summary TO authenticated, anon;
+
+-- ------------------------------------------------------------
+-- 2. rpc_wallet_pay_order — v_items_total 同步排除 cancelled/expired
+--    基底 20260731000000 逐字保留，僅 v_items_total 的 SELECT 加 WHERE
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION rpc_wallet_pay_order(
+  p_order_id  BIGINT,
+  p_amount    NUMERIC,
+  p_operator  UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_order              customer_orders%ROWTYPE;
+  v_member_status      TEXT;
+  v_items_total        NUMERIC;
+  v_returned_deduction NUMERIC;
+  v_payable            NUMERIC;
+  v_new_wallet_paid    NUMERIC;
+  v_new_balance_due    NUMERIC;
+  v_ledger_id          BIGINT;
+  v_paid               BOOLEAN := FALSE;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'amount must be positive';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('aid_order:' || p_order_id));
+
+  SELECT * INTO v_order FROM customer_orders
+   WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  IF v_order.status IN ('completed','picked_up','cancelled','expired','transferred_out') THEN
+    RAISE EXCEPTION 'order % is %, cannot be paid by wallet', p_order_id, v_order.status;
+  END IF;
+  IF v_order.payment_status = 'paid' THEN
+    RAISE EXCEPTION 'order % already paid', p_order_id;
+  END IF;
+  IF v_order.member_id IS NULL THEN
+    RAISE EXCEPTION 'order % has no member', p_order_id;
+  END IF;
+
+  SELECT status INTO v_member_status FROM members
+   WHERE id = v_order.member_id AND tenant_id = v_order.tenant_id;
+  IF v_member_status IS NULL THEN
+    RAISE EXCEPTION 'member % not found', v_order.member_id;
+  END IF;
+  IF v_member_status <> 'active' THEN
+    RAISE EXCEPTION 'member status=% cannot be charged', v_member_status;
+  END IF;
+
+  -- 20260808000010：已取消 / 斷貨的品項不收錢（同 v_customer_order_summary.items_total）
+  SELECT COALESCE(SUM(qty * unit_price), 0)
+    INTO v_items_total
+    FROM customer_order_items
+   WHERE order_id = p_order_id
+     AND status NOT IN ('cancelled','expired');
+
+  -- 未取退貨扣減（同 v_customer_order_summary 的 ret LATERAL）
+  SELECT COALESCE(SUM(a.alloc_qty * a.unit_price), 0)
+    INTO v_returned_deduction
+    FROM (
+      SELECT
+        i.unit_price,
+        LEAST(i.qty, GREATEST(r.ret_qty - i.prior_qty, 0)) AS alloc_qty
+      FROM (
+        SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+          FROM transfers t
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+         WHERE t.customer_order_id = p_order_id
+           AND t.tenant_id     = v_order.tenant_id
+           AND t.transfer_type = 'return_to_hq'
+           AND t.status IN ('shipped','received')
+           AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+               NOT LIKE '%取貨後退回%'
+         GROUP BY ti.sku_id
+      ) r
+      JOIN (
+        SELECT coi.sku_id, coi.qty, coi.unit_price,
+               COALESCE(SUM(coi.qty) OVER (
+                 PARTITION BY coi.sku_id ORDER BY coi.id
+                 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+               ), 0) AS prior_qty
+          FROM customer_order_items coi
+         WHERE coi.order_id = p_order_id
+           AND coi.status NOT IN ('cancelled','expired')
+      ) i ON i.sku_id = r.sku_id
+    ) a;
+
+  -- payable 四捨五入到整數 NTD（同 v_customer_order_summary）
+  v_payable := GREATEST(
+    0,
+    ROUND(
+      GREATEST(0, v_items_total - v_returned_deduction)
+        * (1 - v_order.discount_percent / 100)
+        + v_order.shipping_fee
+        - v_order.discount_amount,
+      0
+    )
+  );
+
+  v_new_wallet_paid := v_order.wallet_paid_amount + p_amount;
+  IF v_new_wallet_paid > v_payable THEN
+    RAISE EXCEPTION 'wallet pay exceeds balance_due: paying=%, already_paid=%, payable=%',
+      p_amount, v_order.wallet_paid_amount, v_payable;
+  END IF;
+
+  v_ledger_id := rpc_wallet_spend(
+    v_order.tenant_id,
+    v_order.member_id,
+    p_amount,
+    'customer_order',
+    p_order_id,
+    p_operator
+  );
+
+  v_new_balance_due := v_payable - v_new_wallet_paid;
+  v_paid := (v_new_balance_due = 0);
+
+  UPDATE customer_orders
+     SET wallet_paid_amount = v_new_wallet_paid,
+         payment_status = CASE WHEN v_paid THEN 'paid' ELSE payment_status END,
+         paid_at        = CASE WHEN v_paid AND paid_at IS NULL THEN NOW() ELSE paid_at END,
+         updated_by     = p_operator,
+         updated_at     = NOW()
+   WHERE id = p_order_id;
+
+  RETURN jsonb_build_object(
+    'ledger_id',          v_ledger_id,
+    'wallet_paid_amount', v_new_wallet_paid,
+    'payable_amount',     v_payable,
+    'balance_due',        v_new_balance_due,
+    'payment_status',     CASE WHEN v_paid THEN 'paid' ELSE v_order.payment_status END,
+    'paid_at',            CASE WHEN v_paid THEN COALESCE(v_order.paid_at, NOW()) ELSE v_order.paid_at END
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION rpc_wallet_pay_order(BIGINT, NUMERIC, UUID) IS
+  '儲值金結帳：可扣上限 = 應收 − 已扣。應收算式與 v_customer_order_summary.payable_amount 同步 '
+  '（未取退貨扣減 @20260731000000；20260808000010 起不含 cancelled/expired 品項）。';
+
+-- ------------------------------------------------------------
+-- 3. v_admin_orders_list — /orders 列表彙總排除 cancelled/expired
+--    基底 20260807000000 逐字保留，僅 LATERAL 加 WHERE
+-- ------------------------------------------------------------
+
+DROP VIEW IF EXISTS v_admin_orders_list;
+
+CREATE VIEW v_admin_orders_list
+WITH (security_invoker = true) AS
+SELECT
+  o.*,
+  c.name AS campaign_name,
+  COALESCE(m.name, o.nickname_snapshot) AS member_name,
+  s.name AS store_name,
+  agg.line_count,
+  agg.total_qty,
+  agg.total_amount,
+  agg.source_summary
+FROM v_admin_orders o
+LEFT JOIN group_buy_campaigns c ON c.id = o.campaign_id
+LEFT JOIN members m ON m.id = o.member_id
+LEFT JOIN stores s ON s.id = o.pickup_store_id
+LEFT JOIN LATERAL (
+  SELECT
+    count(*)::int                          AS line_count,
+    COALESCE(sum(i.qty), 0)                AS total_qty,
+    COALESCE(sum(i.qty * i.unit_price), 0) AS total_amount,
+    CASE WHEN count(DISTINCT i.source) > 1 THEN 'mixed'
+         ELSE min(i.source) END            AS source_summary
+  FROM customer_order_items i
+  WHERE i.order_id = o.id
+    -- 20260808000010：已取消 / 斷貨的品項不算進項數 / 件數 / 金額
+    AND i.status NOT IN ('cancelled','expired')
+) agg ON true;
+
+COMMENT ON VIEW v_admin_orders_list IS
+  '/orders 列表查詢用：v_admin_orders + 可排序欄位（campaign_name / member_name / '
+  'store_name / line_count / total_qty / total_amount / source_summary）。'
+  '只給列表 + 選取全部用；tab 數量與趨勢的 rpc_order_overview 維持查 v_admin_orders，'
+  '避免整表聚合時多揹 per-row 品項彙總。'
+  '20260808000010：彙總排除 cancelled/expired 品項，與訂單明細的應收同一套語意。';
+
+GRANT SELECT ON v_admin_orders_list TO authenticated;

--- a/supabase/migrations/20260808000020_member_aggregates_by_campaign_ids.sql
+++ b/supabase/migrations/20260808000020_member_aggregates_by_campaign_ids.sql
@@ -1,7 +1,8 @@
 -- ============================================================
 -- 2026-08-08: 會員端「已售出 / N 人下單」改走單一聚合 RPC，修掉 1000 列截斷
 --
--- 延續 20260808000010。修完重複計數後實測顧客端列表，發現同一批數字
+-- 延續 20260808000010_member_sold_qty_exclude_transferred。修完重複計數後
+-- 實測顧客端列表，發現同一批數字
 -- 還有兩個更大的洞（都是 PostgREST 的 1000 列上限，靜默截斷、沒有錯誤）：
 --
 --   1. ordered_qty（已售出 / 剩 N 份）
@@ -26,12 +27,16 @@
 --   參數會變成新的 overload，2 參數呼叫就會 "function is not unique"），
 --   所以先 DROP 舊簽章。新簽章對舊的 2 參數具名呼叫仍相容（走 DEFAULT）。
 --
--- rpc_member_campaign_order_counts 保留不動（20260808000010 已修過過濾
+-- rpc_member_campaign_order_counts 保留不動（20260808000010_member_sold_qty_… 已修過過濾
 --   規則），但 liff-api 不再使用；COMMENT 標註它有 1000 列上限、新程式
 --   請改用本函式，避免下次有人再踩。
 --
--- 基底版本：rpc_member_campaign_aggregates = 20260808000010 版。
--- Rollback：DROP 三參數版，CREATE 回 20260808000010 的兩參數版。
+-- 基底版本：rpc_member_campaign_aggregates = 20260808000010_member_sold_qty_
+--   exclude_transferred 版。（注意 20260808000010 這個編號同時有三個檔案：
+--   另兩支 account_link_invite / payable_exclude_cancelled_items 來自 main，
+--   動到的物件與本檔不重疊，套用順序無關。）
+-- Rollback：DROP 三參數版，CREATE 回 20260808000010_member_sold_qty_exclude_
+--   transferred 的兩參數版。
 -- ============================================================
 
 DROP FUNCTION IF EXISTS public.rpc_member_campaign_aggregates(uuid, integer);
@@ -51,7 +56,7 @@ AS $function$
     FROM customer_orders co
     WHERE co.tenant_id = p_tenant
       -- 轉單是「複製 + 標記」不是「搬移」：來源單留著 transferred_out，
-      -- 不排除的話一張單會連同轉入單被算兩次（見 20260808000010）
+      -- 不排除的話一張單會連同轉入單被算兩次（見 20260808000010_member_sold_qty_exclude_transferred）
       AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
       AND COALESCE(co.order_kind, 'normal') = 'normal'
       AND (
@@ -102,7 +107,7 @@ COMMENT ON FUNCTION public.rpc_member_campaign_aggregates(uuid, integer, bigint[
   '會員端每團 order_count / recent_order_count / ordered_qty。RETURNS jsonb（單列單值），'
   '不受 PostgREST 1000 列上限影響；p_campaign_ids 限定只算這一頁要顯示的團。'
   '訂單層級排除 cancelled/expired/transferred_out、品項層級排除 cancelled/expired，'
-  '否則轉出的量會被算兩次、吃掉 cap_qty 名額。基底：20260808000010。';
+  '否則轉出的量會被算兩次、吃掉 cap_qty 名額。基底：20260808000010_member_sold_qty_exclude_transferred。';
 
 COMMENT ON FUNCTION public.rpc_member_campaign_order_counts(uuid, integer) IS
   '會員端每團訂單筆數。⚠️ RETURNS TABLE、一團一列且無 campaign 篩選 —— 團數超過 '

--- a/supabase/migrations/20260808000020_member_aggregates_by_campaign_ids.sql
+++ b/supabase/migrations/20260808000020_member_aggregates_by_campaign_ids.sql
@@ -1,0 +1,111 @@
+-- ============================================================
+-- 2026-08-08: 會員端「已售出 / N 人下單」改走單一聚合 RPC，修掉 1000 列截斷
+--
+-- 延續 20260808000010。修完重複計數後實測顧客端列表，發現同一批數字
+-- 還有兩個更大的洞（都是 PostgREST 的 1000 列上限，靜默截斷、沒有錯誤）：
+--
+--   1. ordered_qty（已售出 / 剩 N 份）
+--      liff-api listActiveCampaigns 是「撈出所有訂單再在 JS 加總」：
+--        .from("customer_orders").select("campaign_id, customer_order_items(qty)")
+--      目前 84 個上架中的團底下有 1616 筆訂單 > 1000 ⇒ 後面的整批被丟掉，
+--      已售出少算。（程式碼裡 order_count 那段的註解早就寫過這個坑，
+--      但 ordered_qty 這段沒跟著改。）
+--
+--   2. order_count / recent_order_count（已有 N 人下單、最熱銷排序）
+--      改用 rpc_member_campaign_order_counts 之後仍會踩到 —— 它
+--      RETURNS TABLE，一個團一列，全租戶有 1595 個團有訂單 > 1000，
+--      而且順序是 campaign_id ASC ⇒ **被截掉的正好是 id 最大的新團**。
+--      實測目前 open 且上架的團裡有 83 個落在截斷區，通通顯示 0 人下單。
+--
+-- 修法：rpc_member_campaign_aggregates 加上 p_campaign_ids 參數，讓
+--   liff-api 一次只問「這一頁要顯示的團」。它 RETURNS jsonb（單列單值），
+--   本身就不受 1000 列上限影響，order_count / recent_order_count /
+--   ordered_qty 三個數字也收斂到同一支、同一套過濾規則，不會再各自漂移。
+--
+-- 參數是加在既有函式上，不能用 CREATE OR REPLACE（多一個帶 DEFAULT 的
+--   參數會變成新的 overload，2 參數呼叫就會 "function is not unique"），
+--   所以先 DROP 舊簽章。新簽章對舊的 2 參數具名呼叫仍相容（走 DEFAULT）。
+--
+-- rpc_member_campaign_order_counts 保留不動（20260808000010 已修過過濾
+--   規則），但 liff-api 不再使用；COMMENT 標註它有 1000 列上限、新程式
+--   請改用本函式，避免下次有人再踩。
+--
+-- 基底版本：rpc_member_campaign_aggregates = 20260808000010 版。
+-- Rollback：DROP 三參數版，CREATE 回 20260808000010 的兩參數版。
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.rpc_member_campaign_aggregates(uuid, integer);
+
+CREATE OR REPLACE FUNCTION public.rpc_member_campaign_aggregates(
+  p_tenant       uuid,
+  p_recent_days  integer  DEFAULT 7,
+  p_campaign_ids bigint[] DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  WITH
+  filtered_orders AS (
+    SELECT co.id, co.campaign_id, co.created_at
+    FROM customer_orders co
+    WHERE co.tenant_id = p_tenant
+      -- 轉單是「複製 + 標記」不是「搬移」：來源單留著 transferred_out，
+      -- 不排除的話一張單會連同轉入單被算兩次（見 20260808000010）
+      AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+      AND COALESCE(co.order_kind, 'normal') = 'normal'
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR co.campaign_id = ANY(p_campaign_ids)
+      )
+  ),
+  counts AS (
+    SELECT
+      fo.campaign_id,
+      COUNT(*)::bigint AS order_count,
+      COUNT(*) FILTER (
+        WHERE fo.created_at >= now() - make_interval(days => GREATEST(p_recent_days, 0))
+      )::bigint AS recent_order_count
+    FROM filtered_orders fo
+    GROUP BY fo.campaign_id
+  ),
+  qtys AS (
+    SELECT
+      fo.campaign_id,
+      SUM(coi.qty)::numeric AS ordered_qty
+    FROM filtered_orders fo
+    JOIN customer_order_items coi ON coi.order_id = fo.id
+    -- 部分轉出把整項轉走的來源品項標 cancelled 留在原單上
+    WHERE coi.status NOT IN ('cancelled', 'expired')
+    GROUP BY fo.campaign_id
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'campaign_id',         c.campaign_id,
+        'order_count',         c.order_count,
+        'recent_order_count',  c.recent_order_count,
+        'ordered_qty',         COALESCE(q.ordered_qty, 0)
+      )
+    ),
+    '[]'::jsonb
+  )
+  FROM counts c
+  LEFT JOIN qtys q ON q.campaign_id = c.campaign_id;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_member_campaign_aggregates(uuid, integer, bigint[])
+  TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.rpc_member_campaign_aggregates(uuid, integer, bigint[]) IS
+  '會員端每團 order_count / recent_order_count / ordered_qty。RETURNS jsonb（單列單值），'
+  '不受 PostgREST 1000 列上限影響；p_campaign_ids 限定只算這一頁要顯示的團。'
+  '訂單層級排除 cancelled/expired/transferred_out、品項層級排除 cancelled/expired，'
+  '否則轉出的量會被算兩次、吃掉 cap_qty 名額。基底：20260808000010。';
+
+COMMENT ON FUNCTION public.rpc_member_campaign_order_counts(uuid, integer) IS
+  '會員端每團訂單筆數。⚠️ RETURNS TABLE、一團一列且無 campaign 篩選 —— 團數超過 '
+  'PostgREST 的 1000 列上限時會被靜默截斷（截掉的是 campaign_id 最大的新團）。'
+  '新程式請改用 rpc_member_campaign_aggregates(p_campaign_ids => ...)。'
+  '保留僅為相容舊呼叫端。';


### PR DESCRIPTION
回報：同店互轉（換客人）後，開團的「本店小計 / 品項數量」變多。

成因：轉單是「複製 + 標記」不是「搬移」，統計只濾了訂單層級 status，
沒濾品項層級：rpc_transfer_order_partial 把整項轉走的來源品項標成
customer_order_items.status='cancelled' 留在來源單上，來源單 status
還是 confirmed/ready ⇒ 來源單照算原數量 + 轉入單再算一次。
實例 GRP-20260804-007 湖口店：-0058 轉 1 顆到 -TF0157，
小計 21 顆 / $1,325（實際 20 顆 / $1,250）。

另一半：整單轉出把來源單標 transferred_out 但品項原封不動，
開團面板 / 會員明細 / 開團列表這幾處連 transferred_out 都沒排除
（線上 95 張這種單），也會一單算兩次。

修法：
- lib/orderStatus.ts 新增 orderCountsInTotals（訂單層級：排除
  cancelled/expired/transferred_out）與 orderItemCountsInTotals
  （品項層級：排除 cancelled/expired），把規則與踩雷原因收在一處。
- 前端加總一律改走這兩個 helper：CampaignOrdersPanel（列 + 小計）、
  MemberDetail（列 + 小計）、campaigns 列表與月曆的下單總數量、
  /orders 列表每列的數量/金額。
- migration 20260808000000：rpc_orders_pivot 的正單 qty_sum/amount
  改用「訂單被排除 OR 品項被排除」單一旗標（被排除的量照舊進
  neg_*，drill-down 行為不變）；rpc_order_overview 的 order_amt
  排除已取消品項。兩支都以線上 pg_get_functiondef 為基底，一併
  收錄線上 drift（pivot 的 p_closed_only 白名單多一個 'locked'）。

驗證：migration 已套線上；rpc_orders_pivot 對該團湖口店回 20 顆 /
$1,250（neg 1）。前端用 Playwright + 該團真實 fixture 跑過，小計
20 / $1,250、-0058 那列 1 / $75；另補整單轉出情境（來源單
transferred_out + 轉入單）小計維持 3 / $300、來源單淡化顯示。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SuopVReqNqpggYun4guCeh