### PR TITLE
fix(admin): LINE 發送的三個實測修正 — 按鈕條件、配對選單、可取貨訂單圖

### DIFF
--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -207,8 +207,11 @@ export function LineMessageModal({
   /**
    * 把該會員的可取貨品項畫成一張圖，直接放進附圖欄。
    *
-   * 只取 item.status = 'ready'（可取貨）—— 同一張訂單裡可能混著已取貨 / 未到貨的
-   * 品項，整張塞給顧客會讓他白跑一趟或以為東西少了。
+   * 「可取貨」判斷在**單頭**（status = ready / partially_completed），不在品項 ——
+   * 這個租戶的品項狀態實際上只用 pending（未取）/ picked_up（已取）/ cancelled：
+   * 全庫 5.1 萬筆 pending、ready 只有 3 筆（2026-08-08 查證；一開始篩品項
+   * status='ready' 導致永遠回「沒有可取貨的品項」）。
+   * 所以：單頭已可取貨的訂單裡，「還沒取又沒取消」的品項就是要給顧客看的清單。
    */
   async function buildPickupImage() {
     setBuildingImage(true);
@@ -237,7 +240,9 @@ export function LineMessageModal({
           orderNo: o.order_no,
           campaign: one(o.campaign)?.name ?? null,
           lines: (o.customer_order_items ?? [])
-            .filter((it) => it.status === "ready")
+            // pending/reserved/ready 都是「尚未取貨」的細分（見 lib/orderStatus.ts）；
+            // 排除 picked_up（已拿走）與 cancelled/expired（斷貨，錢跟數量都不能算）
+            .filter((it) => ["pending", "reserved", "ready"].includes(it.status ?? ""))
             .map((it) => ({
               name: one(one(it.skus)?.products ?? null)?.name
                 ?? one(it.skus)?.sku_code

--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -159,14 +159,18 @@ export function LineMessageModal({
     // 該店還沒配對的 OA 好友：推不到時要讓店員手動挑
     (async () => {
       if (homeStoreId == null) return;
-      const { data } = await getSupabase()
+      const { data, error: fErr } = await getSupabase()
         .from("store_line_followers")
         .select("line_user_id, display_name, picture_url")
         .eq("store_id", homeStoreId)
         .is("member_id", null)
         .eq("followed", true)
         .limit(50);
-      if (!cancelled) setFollowers((data as Follower[]) ?? []);
+      if (cancelled) return;
+      // 不能吞掉錯誤：查詢失敗時清單會是空的，選單就整個不見，
+      // 畫面上卻什麼都沒說 —— 店員只會覺得「這功能壞了」而無從回報。
+      if (fErr) { setError(`讀取本店 LINE 名冊失敗：${fErr.message}`); return; }
+      setFollowers((data as Follower[]) ?? []);
     })();
     // 樣板用的會員站連結（不需要 LINE token，所以 token 沒設也拿得到）
     (async () => {
@@ -370,7 +374,8 @@ export function LineMessageModal({
         )}
 
         {/* 推不到 + 該店名冊有人 → 讓店員手動配對 */}
-        {reachable.state === "unreachable" && followers.length > 0 && (
+        {(reachable.state === "unreachable" || reachable.state === "error")
+          && followers.length > 0 && (
           <div className="rounded-md border border-sky-200 bg-sky-50 p-2 dark:border-sky-900 dark:bg-sky-950/40">
             <div className="mb-1 text-xs font-medium text-sky-900 dark:text-sky-200">
               這位會員在本店官方帳號是哪一個？

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -116,6 +116,8 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
   const [mergeOpen, setMergeOpen] = useState<false | "guest-to-real" | "real-from-guest">(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [lineMsgOpen, setLineMsgOpen] = useState(false);
+  /** 該會員在所屬分店的 OA 名冊有沒有已配對的身分（推播真正靠的是這個） */
+  const [hasStoreLineBinding, setHasStoreLineBinding] = useState(false);
   const [mergedFrom, setMergedFrom] = useState<MergedFrom[]>([]);
   const [savingFlags, setSavingFlags] = useState(false);
   const [draftAdminNote, setDraftAdminNote] = useState("");
@@ -250,6 +252,20 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
       setPLedger((pl.data as PointsEntry[]) ?? []);
       setWLedger((wl.data as WalletEntry[]) ?? []);
       setOrders((od.data as unknown as MemberOrder[]) ?? []);
+
+      // 推播用的身分在 store_line_followers（該店 OA provider 的 ID），
+      // 不是 members.line_user_id。線上 370 位松山店會員有 339 位沒有舊欄位，
+      // 只看舊欄位的話這些人綁好了按鈕也不會出現。
+      if (m.home_store_id) {
+        const { data: fol } = await sb
+          .from("store_line_followers")
+          .select("line_user_id")
+          .eq("store_id", m.home_store_id)
+          .eq("member_id", m.id)
+          .eq("followed", true)
+          .maybeSingle();
+        if (!cancelled) setHasStoreLineBinding(!!fol);
+      }
       type MergeMemberRow = { id: number; member_no: string; name: string | null; phone: string | null; avatar_url: string | null; joined_at: string };
       type MergeRow = {
         id: number;
@@ -292,7 +308,8 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
 
   const isMerged = member.status === "merged";
   const isDeleted = member.status === "deleted";
-  const hasLine = !!member.line_user_id;
+  // 「發得出訊息」的條件：該店 OA 名冊已配對（主要）或還留著舊的登入 ID（退路）
+  const hasLine = hasStoreLineBinding || !!member.line_user_id;
   // 「合併到已綁 LINE 會員」：自己未綁 LINE + status≠merged 才出現
   const canMergeOut = !hasLine && !isMerged && !isDeleted;
   // 「合併未綁 LINE 會員進來」：自己已綁 LINE + status≠merged 才出現


### PR DESCRIPTION
接續 #647。這三個 commit 是在松山店實測（Peggy 案例）時抓到的，前兩個推送時 #647 已被合併，故另開此 PR。

## 1. 發送按鈕改看該店 OA 綁定

按鈕顯示條件還停留在 `members.line_user_id`（登入用 Login channel 的 ID），但推播真正靠的是 `store_line_followers`。**松山店 370 位活躍會員有 339 位（92%）沒有舊欄位** —— 即使透過 account link 綁好了，店員也看不到按鈕。改成「該店名冊已配對 或 留有舊 ID」其一即顯示。

## 2. 配對選單不再靜默消失

兩個讓店員「以為功能壞了卻無從回報」的寫法：讀名冊的查詢錯誤被吞掉（清單空 → 選單不見、畫面無提示）；選單只在 `unreachable` 出現，但 check 本身出錯（`error`）時同樣需要手動配對。前者改為顯示錯誤，後者放寬條件。

## 3. 可取貨訂單圖：改以單頭判斷（真實資料上幾乎必現的 bug）

「這位會員目前沒有可取貨的品項」的原因：原本篩 `item.status = 'ready'`，但這個租戶「可取貨」掛在**單頭**（`ready` / `partially_completed`），品項實際只用三個值：

| 品項 status | 全庫筆數 |
|---|---|
| `pending` | 51,737 |
| `picked_up` | 26,778 |
| `cancelled` | 1,756 |
| `ready` | **3** |

篩品項 `ready` = 篩一個沒人在用的值，永遠回空。改成：單頭 `ready` / `partially_completed` 的訂單裡，取品項 `status IN (pending, reserved, ready)`，排除 `picked_up` 與 `cancelled`（斷貨的錢跟數量都不能算，對齊 CLAUDE.md「訂單金額加總一律排除 cancelled/expired」）。

以松山店真實會員驗證：修正前 0 筆 → 修正後 9 個品項、跨 7 張單。

## 附帶查證（不在 diff 內）

實測期間排除了兩個嫌疑：`line-media` bucket 與 storage RLS 均正常 —— 以合法 staff JWT 直打 storage REST 上傳回 200、跨租戶路徑正確被 RLS 擋下（403）。附圖發送鏈路本身沒有問題。

admin typecheck 與 ESLint 乾淨。

---
_Generated by [Claude Code](https://claude.ai/code/session_01B51QThXsMUzMwjyAqrHYVi)_