### PR TITLE
訂單頁：新增「本月下單來源」折線圖 KPI，並把 App(PWA) 與商城(LIFF) 分開

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -1955,21 +1955,21 @@ function SourceTrendCard({ trend }: { trend: SourceTrendData | null }) {
       </div>
 
       {!trend ? (
-        <div className="mt-3 h-[168px] animate-pulse rounded bg-zinc-100 dark:bg-zinc-900" />
+        <div className="mt-2 h-[104px] animate-pulse rounded bg-zinc-100 dark:bg-zinc-900" />
       ) : (
         <>
-          {/* 圖例＝各通路本月累計 + 佔比（佔比分母是三條線的和，不是本月訂單數） */}
-          <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1">
+          {/* 圖例＝各通路本月累計 + 佔比（佔比分母是三條線的和，不是本月訂單數）。
+              排成一行、字級壓到跟上面 KPI 卡的副字同級 —— 這張卡是輔助視角，
+              不該比「本月營業額 / 訂單數」還搶眼。 */}
+          <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1">
             {lines.map((l) => (
-              <div key={l.label} className="min-w-0">
-                <div className="flex items-center gap-1.5 text-[11px] text-zinc-500">
-                  <span aria-hidden className="h-2 w-2 rounded-full" style={{ background: l.color }} />
-                  {l.label}
-                </div>
-                <div className="text-lg font-semibold tabular-nums leading-tight">{fmt(l.total)}</div>
-                <div className="text-[10px] text-zinc-400 tabular-nums">
+              <div key={l.label} className="flex items-center gap-1.5">
+                <span aria-hidden className="h-2 w-2 rounded-full" style={{ background: l.color }} />
+                <span className="text-[11px] text-zinc-500">{l.label}</span>
+                <span className="text-sm font-semibold tabular-nums">{fmt(l.total)}</span>
+                <span className="text-[10px] text-zinc-400 tabular-nums">
                   {grandTotal > 0 ? `${Math.round((l.total / grandTotal) * 100)}%` : "—"}
-                </div>
+                </span>
               </div>
             ))}
           </div>
@@ -1986,7 +1986,7 @@ function MultiLineChart({
   days,
   lines,
   fmt,
-  height = 168,
+  height = 104,
 }: {
   days: string[];
   lines: { label: string; color: string; values: number[] }[];
@@ -1997,10 +1997,10 @@ function MultiLineChart({
   const [hovered, setHovered] = useState<number | null>(null);
   const n = days.length;
   const w = Math.max(measured, 240);
-  const padL = 44;
+  const padL = 34;
   const padR = 10;
-  const padT = 10;
-  const padB = 18;
+  const padT = 6;
+  const padB = 14;
   const plotW = Math.max(w - padL - padR, 10);
   const plotH = height - padT - padB;
 
@@ -2030,8 +2030,9 @@ function MultiLineChart({
     >
       {measured > 0 && (
         <svg width={w} height={height} className="select-none">
-          {/* 格線 + y 軸刻度（只標 0 / 中 / 上界，三個就夠讀） */}
-          {[0, 1, 2, 3, 4].map((k) => {
+          {/* 格線 + y 軸刻度：上界照 4 格算（貼合資料），但只畫 0 / 中 / 上界
+              三條線 —— 圖只有 ~84px 高，五條格線會糊成一片。 */}
+          {[0, 2, 4].map((k) => {
             const v = step * k;
             const y = yAt(v);
             return (
@@ -2045,16 +2046,14 @@ function MultiLineChart({
                   strokeWidth="1"
                   className="text-zinc-200 dark:text-zinc-800"
                 />
-                {k % 2 === 0 && (
-                  <text
-                    x={padL - 6}
-                    y={y + 3}
-                    textAnchor="end"
-                    className="fill-zinc-400 text-[9px] tabular-nums"
-                  >
-                    {tickFmt(v)}
-                  </text>
-                )}
+                <text
+                  x={padL - 5}
+                  y={y + 3}
+                  textAnchor="end"
+                  className="fill-zinc-400 text-[9px] tabular-nums"
+                >
+                  {tickFmt(v)}
+                </text>
               </g>
             );
           })}

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
@@ -15,7 +15,7 @@ import { fetchReprintableEvents } from "@/lib/pickupReceipt";
 import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 import { useRole } from "@/lib/role";
 import { ORDER_STATUS_LABEL as STATUS_LABEL, type OrderStatus } from "@/lib/orderStatus";
-import { summarizeOrderSource } from "@/lib/orderSource";
+import { summarizeOrderSource, SOURCE_TREND_SERIES, type OrderItemSource } from "@/lib/orderSource";
 import { OrderSourceBadge } from "@/components/OrderSourceBadge";
 import SpinButton from "@/components/SpinButton";
 import SearchSpinner from "@/components/SearchSpinner";
@@ -59,6 +59,28 @@ type MonthAgg = {
 type TrendData = {
   days: DayTrend[];
   total: MonthAgg;
+};
+
+// 下單來源趨勢 — rpc_order_overview v8 的 source_days / source_total
+// （migration 20260808000030）。與 trend 同一個時間軸（當月 1 號 ~ 今天、依
+// 下單日 created_at），差別只在多按 customer_order_items.source 分組。
+// ⚠ 一張單混合來源（小幫手代 key + 會員自助）時每個來源各算一張 —— 各線
+//   加起來會比「本月訂單數」多，這是刻意的：問的是「每個通路各有幾張單在動」。
+type SourceDayAgg = { ymd: string; source: string; orders?: number; amount?: number; qty?: number };
+type SourceSeries = {
+  source: OrderItemSource;
+  label: string;
+  color: string;
+  /** 對齊 SourceTrendData.days 的每日訂單數 / 金額（沒資料補 0） */
+  daily: number[];
+  dailyAmount: number[];
+  totalOrders: number;
+  totalAmount: number;
+};
+type SourceTrendData = {
+  /** "YYYY-MM-DD" 連續序列，與 TrendData.days 同一組日期 */
+  days: string[];
+  series: SourceSeries[];
 };
 
 // 「可取貨」= status 'ready'（ORDER_STATUS_LABEL.ready），貨已到店、會員還沒來取。
@@ -350,6 +372,8 @@ function OrdersListContent() {
   // 取貨 KPI — 同一支 RPC 回的 pickup_days/pickup_total（已取貨品項的金額，
   // 依取貨當天切；「今日取貨金額」卡用最後一天＝今天）
   const [pickupTrend, setPickupTrend] = useState<TrendData | null>(null);
+  // 下單來源 KPI — 同一支 RPC 回的 source_days/source_total（App / 商城 / 小幫手）
+  const [sourceTrend, setSourceTrend] = useState<SourceTrendData | null>(null);
 
   const fromTs = useMemo(() => (dateFrom ? dayStartIso(dateFrom) : null), [dateFrom]);
   const toTs = useMemo(() => (dateTo ? dayStartIso(dateTo, 1) : null), [dateTo]);
@@ -602,6 +626,7 @@ function OrdersListContent() {
     let cancelled = false;
     setTrend(null);
     setPickupTrend(null);
+    setSourceTrend(null);
     (async () => {
       const sb = getSupabase();
       const today = new Date();
@@ -629,11 +654,17 @@ function OrdersListContent() {
         // v3 (migration 20260803000010) 起：已取貨品項金額，依取貨當天切
         pickup_days?: (AggRow & { ymd: string })[];
         pickup_total?: AggRow;
+        // v8 (migration 20260808000030) 起：依 customer_order_items.source 分組。
+        // 線上還是舊版函式時這兩個 key 不存在 → buildSourceTrend 拿空陣列，
+        // 卡片畫出三條 0 的線，其餘 KPI 不受影響。
+        source_days?: SourceDayAgg[];
+        source_total?: Omit<SourceDayAgg, "ymd">[];
       };
       if (rpcErr || !data) {
         setTabCounts(null);
         setTrend(buildTrend(startDate, today, [], null));
         setPickupTrend(buildTrend(startDate, today, [], null));
+        setSourceTrend(buildSourceTrend(startDate, today, [], []));
         return;
       }
       const ov = data as Overview;
@@ -648,6 +679,7 @@ function OrdersListContent() {
 
       setTrend(buildTrend(startDate, today, ov.trend_days ?? [], ov.trend_total));
       setPickupTrend(buildTrend(startDate, today, ov.pickup_days ?? [], ov.pickup_total));
+      setSourceTrend(buildSourceTrend(startDate, today, ov.source_days ?? [], ov.source_total ?? []));
     })();
     return () => {
       cancelled = true;
@@ -976,6 +1008,9 @@ function OrdersListContent() {
         />
         <PickupTodayCard trend={pickupTrend} />
       </div>
+
+      {/* 下單來源 KPI — App(PWA) / 商城(LIFF) / 小幫手 三條折線，看通路消長 */}
+      <SourceTrendCard trend={sourceTrend} />
 
       {/* Tab bar — 未取貨 / 可取貨 / 部分取貨 / 已完成 / 轉出 / 取消;含各 tab 數量 */}
       {/* 6 個 tab 在手機寬度放不下 → 橫向捲動,不要擠壓/換行 */}
@@ -1610,6 +1645,65 @@ function buildTrend(
   };
 }
 
+// 把 RPC 回的 (日期 × source) 聚合攤平成「每條線一組對齊日期的陣列」。
+// 只留 SOURCE_TREND_SERIES 定義的三個人工通路 —— 系統流程（遞轉/互助/匯入…）
+// 不畫線；它們不是「客人怎麼下單」的一部分，畫進去只會多兩條貼著 0 的雜訊。
+function buildSourceTrend(
+  startDate: Date,
+  today: Date,
+  rows: SourceDayAgg[],
+  totals: Omit<SourceDayAgg, "ymd">[],
+): SourceTrendData {
+  const days: string[] = [];
+  const cur = new Date(startDate);
+  while (cur <= today) {
+    days.push(fmtYmd(cur));
+    cur.setDate(cur.getDate() + 1);
+  }
+  const dayIdx = new Map(days.map((d, i) => [d, i]));
+  const totalBySource = new Map(totals.map((t) => [t.source, t]));
+
+  const series = SOURCE_TREND_SERIES.map((def) => {
+    const daily = new Array<number>(days.length).fill(0);
+    const dailyAmount = new Array<number>(days.length).fill(0);
+    for (const r of rows) {
+      if (r.source !== def.source) continue;
+      const i = dayIdx.get(r.ymd);
+      if (i === undefined) continue;
+      daily[i] = Number(r.orders ?? 0);
+      dailyAmount[i] = Number(r.amount ?? 0);
+    }
+    const t = totalBySource.get(def.source);
+    return {
+      ...def,
+      daily,
+      dailyAmount,
+      totalOrders: Number(t?.orders ?? 0),
+      totalAmount: Number(t?.amount ?? 0),
+    };
+  });
+  return { days, series };
+}
+
+// 容器實際寬度（px）—— 折線圖要滿版又要維持字級/線寬不被 viewBox 縮放，
+// 只能量出來再照 px 畫（preserveAspectRatio 會把 10px 的軸標在手機上縮成 4px）。
+function useMeasuredWidth<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null);
+  const [width, setWidth] = useState(0);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    setWidth(Math.round(el.clientWidth));
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      setWidth(Math.round(entries[0]?.contentRect.width ?? 0));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  return [ref, width] as const;
+}
+
 function Sparkline({
   values,
   labels,
@@ -1805,6 +1899,276 @@ function TrendCard({
       {hint && <div className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">{hint}</div>}
     </div>
   );
+}
+
+// 下單來源趨勢卡 — App(PWA) / 商城(LIFF) / 小幫手 三條折線疊在同一張圖上。
+// 大字放在圖例：本月各通路累計（切「金額」時同一組線改畫金額）。
+// 時間基準跟另外兩張「本月」卡一致（依下單日 created_at），所以可以直接對照。
+function SourceTrendCard({ trend }: { trend: SourceTrendData | null }) {
+  const [metric, setMetric] = useState<"orders" | "amount">("orders");
+  const fmtOrders = (v: number) => `${Math.round(v).toLocaleString("zh-TW")} 單`;
+  const fmtAmount = (v: number) => `$${Math.round(v).toLocaleString("zh-TW")}`;
+  const fmt = metric === "orders" ? fmtOrders : fmtAmount;
+
+  const lines = (trend?.series ?? []).map((s) => ({
+    label: s.label,
+    color: s.color,
+    values: metric === "orders" ? s.daily : s.dailyAmount,
+    total: metric === "orders" ? s.totalOrders : s.totalAmount,
+  }));
+  const grandTotal = lines.reduce((sum, l) => sum + l.total, 0);
+
+  return (
+    <div className="rounded-md border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <div className="text-xs text-zinc-500">本月下單來源</div>
+          <span
+            className="cursor-help text-[10px] text-zinc-400"
+            title={
+              "依訂單日 (created_at) 每日統計，套用上方的開團／店家／品項／關鍵字篩選。\n" +
+              "App = 會員在 App（PWA / 瀏覽器）自助下單；商城 = 會員在 LINE 內下單；小幫手 = 後台代客 key 單。\n" +
+              "一張單同時有多種來源時，每個來源各算一張，所以三條線加起來會多於「本月訂單數」。\n" +
+              "2026-08-08 以前的自助訂單沒有記執行環境，一律算「商城」。"
+            }
+          >
+            ⓘ
+          </span>
+        </div>
+        {/* 同一組線換指標：看單量還是看金額 */}
+        <div className="flex items-center gap-0.5 rounded-md border border-zinc-200 p-0.5 text-[11px] dark:border-zinc-800">
+          {([["orders", "訂單數"], ["amount", "金額"]] as const).map(([v, l]) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => setMetric(v)}
+              className={`rounded px-2 py-0.5 transition-colors ${
+                metric === v
+                  ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                  : "text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200"
+              }`}
+            >
+              {l}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {!trend ? (
+        <div className="mt-3 h-[168px] animate-pulse rounded bg-zinc-100 dark:bg-zinc-900" />
+      ) : (
+        <>
+          {/* 圖例＝各通路本月累計 + 佔比（佔比分母是三條線的和，不是本月訂單數） */}
+          <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1">
+            {lines.map((l) => (
+              <div key={l.label} className="min-w-0">
+                <div className="flex items-center gap-1.5 text-[11px] text-zinc-500">
+                  <span aria-hidden className="h-2 w-2 rounded-full" style={{ background: l.color }} />
+                  {l.label}
+                </div>
+                <div className="text-lg font-semibold tabular-nums leading-tight">{fmt(l.total)}</div>
+                <div className="text-[10px] text-zinc-400 tabular-nums">
+                  {grandTotal > 0 ? `${Math.round((l.total / grandTotal) * 100)}%` : "—"}
+                </div>
+              </div>
+            ))}
+          </div>
+          <MultiLineChart days={trend.days} lines={lines} fmt={fmt} />
+        </>
+      )}
+    </div>
+  );
+}
+
+// 多條折線 + 共用 y 軸的小圖表（不引第三方 chart 套件 — 這裡只需要折線）。
+// 寬度量容器實際 px 再畫，字級/線寬才不會被 viewBox 縮放（見 useMeasuredWidth）。
+function MultiLineChart({
+  days,
+  lines,
+  fmt,
+  height = 168,
+}: {
+  days: string[];
+  lines: { label: string; color: string; values: number[] }[];
+  fmt: (v: number) => string;
+  height?: number;
+}) {
+  const [ref, measured] = useMeasuredWidth<HTMLDivElement>();
+  const [hovered, setHovered] = useState<number | null>(null);
+  const n = days.length;
+  const w = Math.max(measured, 240);
+  const padL = 44;
+  const padR = 10;
+  const padT = 10;
+  const padB = 18;
+  const plotW = Math.max(w - padL - padR, 10);
+  const plotH = height - padT - padB;
+
+  // y 軸上界取「好看的整數」：step ∈ {1,2,3,5}×10^k，畫 4 格 → 格線都落在整數上
+  // 下限 1：訂單數/金額都是整數，step<1 會畫出 0.3 這種刻度
+  const maxV = Math.max(1, ...lines.flatMap((l) => l.values));
+  const step = Math.max(1, niceStep(maxV / 4));
+  const top = step * 4;
+  const tickFmt = makeTickFmt(top);
+
+  const xAt = (i: number) => (n > 1 ? padL + (plotW * i) / (n - 1) : padL + plotW / 2);
+  const yAt = (v: number) => padT + plotH - (v / top) * plotH;
+  const fmtMD = (ymd: string) => {
+    const [, m, d] = ymd.split("-");
+    return `${Number(m)}/${Number(d)}`;
+  };
+  // x 軸標籤最多 ~6 個，太密會疊在一起
+  const labelEvery = Math.max(1, Math.ceil(n / 6));
+  const hoveredX = hovered != null ? xAt(hovered) : 0;
+
+  return (
+    <div
+      ref={ref}
+      className="relative mt-2"
+      style={{ height }}
+      onMouseLeave={() => setHovered(null)}
+    >
+      {measured > 0 && (
+        <svg width={w} height={height} className="select-none">
+          {/* 格線 + y 軸刻度（只標 0 / 中 / 上界，三個就夠讀） */}
+          {[0, 1, 2, 3, 4].map((k) => {
+            const v = step * k;
+            const y = yAt(v);
+            return (
+              <g key={k}>
+                <line
+                  x1={padL}
+                  y1={y}
+                  x2={w - padR}
+                  y2={y}
+                  stroke="currentColor"
+                  strokeWidth="1"
+                  className="text-zinc-200 dark:text-zinc-800"
+                />
+                {k % 2 === 0 && (
+                  <text
+                    x={padL - 6}
+                    y={y + 3}
+                    textAnchor="end"
+                    className="fill-zinc-400 text-[9px] tabular-nums"
+                  >
+                    {tickFmt(v)}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+
+          {/* x 軸日期 */}
+          {days.map((ymd, i) =>
+            i % labelEvery === 0 || i === n - 1 ? (
+              <text
+                key={ymd}
+                x={xAt(i)}
+                y={height - 5}
+                textAnchor={i === 0 ? "start" : i === n - 1 ? "end" : "middle"}
+                className="fill-zinc-400 text-[9px] tabular-nums"
+              >
+                {fmtMD(ymd)}
+              </text>
+            ) : null,
+          )}
+
+          {/* hover 垂直線畫在折線底下，不擋線 */}
+          {hovered != null && (
+            <line
+              x1={hoveredX}
+              y1={padT}
+              x2={hoveredX}
+              y2={padT + plotH}
+              stroke="rgb(161 161 170)"
+              strokeWidth="1"
+              strokeDasharray="2 2"
+            />
+          )}
+
+          {lines.map((l) => {
+            const pts = l.values.map((v, i) => `${xAt(i).toFixed(1)},${yAt(v).toFixed(1)}`);
+            return (
+              <g key={l.label}>
+                <polyline
+                  points={pts.join(" ")}
+                  fill="none"
+                  stroke={l.color}
+                  strokeWidth="1.75"
+                  strokeLinejoin="round"
+                  strokeLinecap="round"
+                />
+                {/* 只有一天（每月 1 號）時 polyline 畫不出東西 → 補一個點 */}
+                {n === 1 && <circle cx={xAt(0)} cy={yAt(l.values[0] ?? 0)} r={2.5} fill={l.color} />}
+                {hovered != null && (
+                  <circle
+                    cx={hoveredX}
+                    cy={yAt(l.values[hovered] ?? 0)}
+                    r={3}
+                    fill={l.color}
+                    stroke="white"
+                    strokeWidth="1"
+                  />
+                )}
+              </g>
+            );
+          })}
+
+          {/* 透明感應區：一天一條，滑到哪就顯示那天的三個值 */}
+          {days.map((ymd, i) => {
+            const bandW = n > 1 ? plotW / (n - 1) : plotW;
+            return (
+              <rect
+                key={ymd}
+                x={Math.max(0, xAt(i) - bandW / 2)}
+                y={0}
+                width={bandW}
+                height={height}
+                fill="transparent"
+                onMouseEnter={() => setHovered(i)}
+                onTouchStart={() => setHovered(i)}
+              />
+            );
+          })}
+        </svg>
+      )}
+      {hovered != null && (
+        <div
+          className="pointer-events-none absolute z-20 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-900 px-2 py-1 text-[10px] leading-snug text-white shadow dark:bg-zinc-100 dark:text-zinc-900"
+          // 靠邊時夾住，tooltip 才不會被卡片裁掉
+          style={{ left: Math.min(Math.max(hoveredX, 56), w - 56), top: 0 }}
+        >
+          <div className="font-semibold">{fmtMD(days[hovered])}</div>
+          {lines.map((l) => (
+            <div key={l.label} className="flex items-center gap-1.5">
+              <span aria-hidden className="h-1.5 w-1.5 rounded-full" style={{ background: l.color }} />
+              <span className="opacity-70">{l.label}</span>
+              <span className="ml-auto tabular-nums">{fmt(l.values[hovered] ?? 0)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** ≥ v 的「好看的刻度間距」：1/2/3/5 × 10^k。 */
+function niceStep(v: number): number {
+  if (!(v > 0)) return 1;
+  const mag = Math.pow(10, Math.floor(Math.log10(v)));
+  const norm = v / mag;
+  const mult = norm <= 1 ? 1 : norm <= 2 ? 2 : norm <= 3 ? 3 : norm <= 5 ? 5 : 10;
+  return mult * mag;
+}
+
+/** y 軸刻度標的格式化器：軸很窄，上萬用 k / 上百萬用 M 省位置。
+ *  單位看「上界」決定、不逐格判斷 —— 不然會出現 0 / 6,000 / 12k 混在同一軸上。 */
+function makeTickFmt(top: number): (v: number) => string {
+  const trim = (x: number) => Number(x.toFixed(1)).toString();
+  if (top >= 1_000_000) return (v) => (v === 0 ? "0" : `${trim(v / 1_000_000)}M`);
+  if (top >= 10_000) return (v) => (v === 0 ? "0" : `${trim(v / 1_000)}k`);
+  return (v) => Math.round(v).toLocaleString("zh-TW");
 }
 
 function Th({ children, className = "" }: { children: React.ReactNode; className?: string }) {

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -1901,11 +1901,23 @@ function TrendCard({
   );
 }
 
-// 下單來源趨勢卡 — App(PWA) / 商城(LIFF) / 小幫手 三條折線疊在同一張圖上。
-// 大字放在圖例：本月各通路累計（切「金額」時同一組線改畫金額）。
-// 時間基準跟另外兩張「本月」卡一致（依下單日 created_at），所以可以直接對照。
+const SOURCE_TREND_OPEN_KEY = "orders-source-trend-open";
+
+// 下單來源卡 — App(PWA) / 商城(LIFF) / 小幫手。
+// 收起來時只有一行：三個通路的本月累計與佔比（一整列就把問題回答完了）；
+// 要看每日走勢再點開折線圖。展開與否記在 localStorage，不用每次重點。
+// 時間基準跟上面三張「本月」卡一致（依下單日 created_at），可以直接對照。
 function SourceTrendCard({ trend }: { trend: SourceTrendData | null }) {
   const [metric, setMetric] = useState<"orders" | "amount">("orders");
+  const [showChart, setShowChart] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(SOURCE_TREND_OPEN_KEY) === "1";
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(SOURCE_TREND_OPEN_KEY, showChart ? "1" : "0");
+  }, [showChart]);
+
   const fmtOrders = (v: number) => `${Math.round(v).toLocaleString("zh-TW")} 單`;
   const fmtAmount = (v: number) => `$${Math.round(v).toLocaleString("zh-TW")}`;
   const fmt = metric === "orders" ? fmtOrders : fmtAmount;
@@ -1919,24 +1931,48 @@ function SourceTrendCard({ trend }: { trend: SourceTrendData | null }) {
   const grandTotal = lines.reduce((sum, l) => sum + l.total, 0);
 
   return (
-    <div className="rounded-md border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <div className="text-xs text-zinc-500">本月下單來源</div>
-          <span
-            className="cursor-help text-[10px] text-zinc-400"
-            title={
-              "依訂單日 (created_at) 每日統計，套用上方的開團／店家／品項／關鍵字篩選。\n" +
-              "App = 會員在 App（PWA / 瀏覽器）自助下單；商城 = 會員在 LINE 內下單；小幫手 = 後台代客 key 單。\n" +
-              "一張單同時有多種來源時，每個來源各算一張，所以三條線加起來會多於「本月訂單數」。\n" +
-              "2026-08-08 以前的自助訂單沒有記執行環境，一律算「商城」。"
-            }
-          >
-            ⓘ
-          </span>
-        </div>
-        {/* 同一組線換指標：看單量還是看金額 */}
-        <div className="flex items-center gap-0.5 rounded-md border border-zinc-200 p-0.5 text-[11px] dark:border-zinc-800">
+    <div className="rounded-md border border-zinc-200 bg-white px-3 py-2 dark:border-zinc-800 dark:bg-zinc-950">
+      {/* 標題 + 圖例 + 展開鈕全部擠在同一行 —— 收起時整張卡就只有這一行 */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <button
+          type="button"
+          onClick={() => setShowChart((v) => !v)}
+          title={showChart ? "收起折線圖" : "展開每日折線圖"}
+          className="flex shrink-0 items-center gap-1 text-xs text-zinc-500 transition-colors hover:text-zinc-800 dark:hover:text-zinc-200"
+        >
+          <span aria-hidden className="inline-block w-2 text-[9px]">{showChart ? "▾" : "▸"}</span>
+          本月下單來源
+        </button>
+        <span
+          className="cursor-help text-[10px] text-zinc-400"
+          title={
+            "依訂單日 (created_at) 每日統計，套用上方的開團／店家／品項／關鍵字篩選。\n" +
+            "App = 會員在 App（PWA / 瀏覽器）自助下單；商城 = 會員在 LINE 內下單；小幫手 = 後台代客 key 單。\n" +
+            "一張單同時有多種來源時，每個來源各算一張，所以三條線加起來會多於「本月訂單數」。\n" +
+            "2026-08-08 以前的自助訂單沒有記執行環境，一律算「商城」。"
+          }
+        >
+          ⓘ
+        </span>
+
+        {!trend ? (
+          <span className="h-4 w-48 animate-pulse rounded bg-zinc-100 dark:bg-zinc-900" />
+        ) : (
+          /* 圖例＝各通路本月累計 + 佔比（佔比分母是三條線的和，不是本月訂單數） */
+          lines.map((l) => (
+            <div key={l.label} className="flex items-center gap-1.5">
+              <span aria-hidden className="h-2 w-2 rounded-full" style={{ background: l.color }} />
+              <span className="text-[11px] text-zinc-500">{l.label}</span>
+              <span className="text-sm font-semibold tabular-nums">{fmt(l.total)}</span>
+              <span className="text-[10px] text-zinc-400 tabular-nums">
+                {grandTotal > 0 ? `${Math.round((l.total / grandTotal) * 100)}%` : "—"}
+              </span>
+            </div>
+          ))
+        )}
+
+        {/* 同一組數字換指標：看單量還是看金額（收起時也能切，圖例跟著換） */}
+        <div className="ml-auto flex shrink-0 items-center gap-0.5 rounded-md border border-zinc-200 p-0.5 text-[11px] dark:border-zinc-800">
           {([["orders", "訂單數"], ["amount", "金額"]] as const).map(([v, l]) => (
             <button
               key={v}
@@ -1954,28 +1990,12 @@ function SourceTrendCard({ trend }: { trend: SourceTrendData | null }) {
         </div>
       </div>
 
-      {!trend ? (
-        <div className="mt-2 h-[104px] animate-pulse rounded bg-zinc-100 dark:bg-zinc-900" />
-      ) : (
-        <>
-          {/* 圖例＝各通路本月累計 + 佔比（佔比分母是三條線的和，不是本月訂單數）。
-              排成一行、字級壓到跟上面 KPI 卡的副字同級 —— 這張卡是輔助視角，
-              不該比「本月營業額 / 訂單數」還搶眼。 */}
-          <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1">
-            {lines.map((l) => (
-              <div key={l.label} className="flex items-center gap-1.5">
-                <span aria-hidden className="h-2 w-2 rounded-full" style={{ background: l.color }} />
-                <span className="text-[11px] text-zinc-500">{l.label}</span>
-                <span className="text-sm font-semibold tabular-nums">{fmt(l.total)}</span>
-                <span className="text-[10px] text-zinc-400 tabular-nums">
-                  {grandTotal > 0 ? `${Math.round((l.total / grandTotal) * 100)}%` : "—"}
-                </span>
-              </div>
-            ))}
-          </div>
+      {showChart &&
+        (!trend ? (
+          <div className="mt-2 h-[104px] animate-pulse rounded bg-zinc-100 dark:bg-zinc-900" />
+        ) : (
           <MultiLineChart days={trend.days} lines={lines} fmt={fmt} />
-        </>
-      )}
+        ))}
     </div>
   );
 }

--- a/apps/admin/src/lib/orderSource.ts
+++ b/apps/admin/src/lib/orderSource.ts
@@ -5,9 +5,15 @@
 // 都從這裡 import。
 //
 // source 是「品項層級」欄位（customer_order_items.source）：
-//   - 'liff'   → 顧客自己用 App（LIFF）下單     ＝ App 下單
-//   - 'manual' → 小幫手在後台代客 key 單         ＝ 小幫手
+//   - 'pwa'    → 顧客在會員 App（PWA / 外部瀏覽器）自助下單  ＝ App
+//   - 'liff'   → 顧客在 LINE 內（LIFF 商城）自助下單          ＝ 商城
+//   - 'manual' → 小幫手在後台代客 key 單                      ＝ 小幫手
 //   其餘為系統/特殊流程產生（非人工通路）。
+//
+// pwa / liff 的判斷在會員端做（apps/member/src/lib/clientChannel.ts），
+// 由 place_member_order 帶上來；liff-api 只收白名單值，沒帶就退回 'liff'。
+// ⚠ 2026-08-08 之前的自助訂單一律是 'liff'（當時沒記執行環境，不回填），
+//   所以那段期間的「App」= 0 是預期結果，不是壞掉。
 //
 // 同一張訂單因為 UNIQUE(tenant, campaign, channel, member) 會合併，
 // 顧客 App 自助 + 小幫手在 closed 緩衝期補加可能落在同一張單，
@@ -16,10 +22,12 @@
 // 新增 source 時：
 //   1. 加到 ORDER_ITEM_SOURCES tuple + ORDER_SOURCE_META
 //   2. 同步 supabase migration 的 CHECK constraint
-//      （現行：20260507000000_order_transfer_and_internal.sql）
+//      （現行：20260808000020_order_item_source_pwa.sql）
+//   3. 若屬「人工下單通路」，加進 SOURCE_TREND_SERIES（訂單頁折線圖 KPI）
 // ============================================================
 
 export const ORDER_ITEM_SOURCES = [
+  "pwa",
   "liff",
   "manual",
   "screenshot_parse",
@@ -42,7 +50,8 @@ export type SourceMeta = {
 };
 
 export const ORDER_SOURCE_META: Record<OrderItemSource, SourceMeta> = {
-  liff:             { label: "App 下單", short: "App",    icon: "📱", cls: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300" },
+  pwa:              { label: "App 下單",  short: "App",    icon: "📱", cls: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300" },
+  liff:             { label: "商城下單",  short: "商城",   icon: "🛍️", cls: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300" },
   manual:           { label: "小幫手",   short: "小幫手", icon: "🧑‍💼", cls: "bg-violet-100 text-violet-800 dark:bg-violet-950 dark:text-violet-300" },
   screenshot_parse: { label: "截圖解析", short: "截圖",   icon: "🖼️", cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300" },
   csv:              { label: "CSV 匯入", short: "CSV",    icon: "📄", cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300" },
@@ -50,6 +59,16 @@ export const ORDER_SOURCE_META: Record<OrderItemSource, SourceMeta> = {
   store_internal:   { label: "店長叫貨", short: "店叫",   icon: "🏬", cls: "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300" },
   aid_transfer:     { label: "互助轉手", short: "互助",   icon: "🤝", cls: "bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-300" },
 };
+
+// 訂單頁「下單來源」折線圖 KPI 的線 —— 只放「人是怎麼下這張單的」三個通路，
+// 系統流程（遞轉/互助/匯入…）不畫線，它們不是通路消長的一部分。
+// color 直接寫死 rgb：SVG stroke 吃不到 Tailwind class，且深/淺色模式共用同一組
+// （這三個色相在兩種底色上都夠對比）。順序＝圖例順序。
+export const SOURCE_TREND_SERIES: { source: OrderItemSource; label: string; color: string }[] = [
+  { source: "pwa",    label: "App",    color: "rgb(59 130 246)" },  // blue-500（blue-600 在深色底上太暗）
+  { source: "liff",   label: "商城",   color: "rgb(5 150 105)" },   // emerald-600
+  { source: "manual", label: "小幫手", color: "rgb(124 58 237)" },  // violet-600
+];
 
 const MIXED_META: SourceMeta = {
   label: "混合來源",

--- a/apps/member/src/app/shop/c/[id]/page.tsx
+++ b/apps/member/src/app/shop/c/[id]/page.tsx
@@ -12,6 +12,7 @@ import ViewCount from "@/components/ViewCount";
 import { cleanCampaignText } from "@/lib/text";
 import { getCampaignHint } from "@/lib/campaignHints";
 import { logCaught } from "@/lib/clientLog";
+import { detectClientChannel } from "@/lib/clientChannel";
 
 /** 把 children 渲染到 document.body（保證 fixed 相對 viewport）。 */
 function Portal({ enabled, children }: { enabled: boolean; children: React.ReactNode }) {
@@ -165,6 +166,9 @@ export default function CampaignDetailPage() {
         campaign_id: id,
         items: ordered,
         notes: notes.trim() || null,
+        // 下單通路 → customer_order_items.source（後台折線圖分 App / 商城兩條線）。
+        // 在這裡取而不是進 callLiffApi：只有「下單」這個動作要記通路。
+        client: detectClientChannel(),
       });
       setDoneOrderNo(r.order_no);
     } catch (e) {

--- a/apps/member/src/lib/clientChannel.ts
+++ b/apps/member/src/lib/clientChannel.ts
@@ -1,0 +1,30 @@
+// 會員自助下單的「通路」判斷 —— 寫進 customer_order_items.source，
+// 訂單頁的來源折線圖 KPI 就是靠這個值分 App / 商城兩條線。
+//
+//   'liff' → 在 LINE 裡面（LINE 內建瀏覽器 / LIFF）＝ 後台顯示「商城」
+//   'pwa'  → 其餘（已安裝的 PWA、外部瀏覽器開的會員站）＝ 後台顯示「App」
+//
+// 只分兩類是刻意的：會員站在「已安裝 PWA」與「外部瀏覽器」下是同一個 App
+// 體驗（同一份程式、同一組頁面），會員自己也不會覺得那是兩個東西；真正
+// 不同的是「在 LINE 裡逛」那條路。standalone 與否只影響推播能不能用
+// （見 usePushNotification），不影響下單通路的定義。
+//
+// 判斷用 UA 的 " Line/" 為主、liff.isInClient() 為輔：
+//   - UA 在 LINE webview 一定帶 " Line/"，而且 liff.init() 還沒跑完時就已經讀得到；
+//   - liff.isInClient() 只有 LIFF SDK 載好才有，補抓 UA 判不出來的邊緣情況。
+// 兩者任一為真就算在 LINE 內 —— 寧可誤判成「商城」也不要把 LINE 內的單算成 App，
+// 因為 2026-08-08 之前的歷史資料全部都是 'liff'（商城），口徑才連得起來。
+
+export type ClientChannel = "pwa" | "liff";
+
+export function detectClientChannel(): ClientChannel {
+  if (typeof window === "undefined") return "pwa";
+  const ua = window.navigator?.userAgent ?? "";
+  if (/ Line\//i.test(ua)) return "liff";
+  try {
+    if (window.liff?.isInClient?.()) return "liff";
+  } catch {
+    // SDK 沒載好 / init 前呼叫會 throw —— 當作不在 LINE 內，UA 那關已經擋過一次了
+  }
+  return "pwa";
+}

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -934,6 +934,10 @@ async function placeMemberOrder(
   const campaignId = Number(p.campaign_id);
   const items = Array.isArray(p.items) ? p.items : [];
   const notes = typeof p.notes === "string" ? p.notes.trim() : null;
+  // 下單通路（前端 detectClientChannel() 帶上來）：'pwa' = 會員 App、'liff' = LINE 商城。
+  // 只收白名單，舊版前端 / 亂帶值一律退回 'liff' —— 那是這個欄位在
+  // 2026-08-08 之前的唯一值，口徑才不會斷掉（見 migration 20260808000020）。
+  const itemSource = p.client === "pwa" ? "pwa" : "liff";
 
   if (!campaignId) return json({ error: "campaign_id required" }, 400);
   if (items.length === 0) return json({ error: "items required" }, 400);
@@ -1081,7 +1085,7 @@ async function placeMemberOrder(
         qty: qty,
         unit_price: ci.unit_price,
         status: "pending",
-        source: "liff",
+        source: itemSource,
       });
     }
   }

--- a/supabase/migrations/20260808000020_order_item_source_pwa.sql
+++ b/supabase/migrations/20260808000020_order_item_source_pwa.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- 2026-08-08: customer_order_items.source 新增 'pwa'
+--
+-- 需求：訂單頁要用折線圖分「App 下單 / 商城下單 / 小幫手」三條線，但目前
+--   會員自助下單一律寫 source='liff'（liff-api.placeMemberOrder 寫死），
+--   PWA（已安裝的會員 App）與 LINE 內建瀏覽器（LIFF 商城）分不出來。
+--
+-- 新的語意（與 apps/admin/src/lib/orderSource.ts 對齊）：
+--   'pwa'  → 會員在 App（PWA / 外部瀏覽器開的會員站）自助下單  ＝「App」
+--   'liff' → 會員在 LINE 內（LIFF 商城）自助下單                ＝「商城」
+--   'manual' → 小幫手後台代客 key 單                            ＝「小幫手」
+--
+-- 判斷在前端做（apps/member/src/lib/clientChannel.ts）：UA 含 " Line/"
+--   或 liff.isInClient() 為真 → 'liff'，其餘 → 'pwa'。liff-api 只收白名單值，
+--   沒帶／帶了非法值一律退回 'liff'（＝維持這支 migration 之前的行為）。
+--
+-- ⚠ 既有 249 筆 source='liff' 不回填 —— 當時沒有記錄執行環境，無從得知是
+--   PWA 還是 LINE 內開的。歷史資料一律算「商城」，折線圖上這段期間的
+--   「App」線會是 0，屬預期。
+--
+-- 基底版本：20260507000000_order_transfer_and_internal.sql（1.3 節，
+--   grep customer_order_items_source_check 僅該檔與 20260423120000 動過，
+--   線上 pg_get_constraintdef 與 20260507000000 一致）。
+-- Rollback：
+--   ALTER TABLE customer_order_items DROP CONSTRAINT customer_order_items_source_check;
+--   ALTER TABLE customer_order_items ADD CONSTRAINT customer_order_items_source_check
+--     CHECK (source IN ('manual','screenshot_parse','csv','rollover','liff',
+--                       'store_internal','aid_transfer'));
+--   （回滾前要先確認沒有 source='pwa' 的資料，否則加不回去。）
+-- ============================================================
+
+ALTER TABLE customer_order_items DROP CONSTRAINT IF EXISTS customer_order_items_source_check;
+ALTER TABLE customer_order_items ADD CONSTRAINT customer_order_items_source_check
+  CHECK (source IN ('manual','screenshot_parse','csv','rollover','liff','pwa',
+                    'store_internal','aid_transfer'));
+
+COMMENT ON COLUMN customer_order_items.source IS
+  '品項來源通路。pwa=會員 App 自助下單、liff=LINE 商城自助下單、manual=小幫手代客；'
+  '其餘為系統流程（screenshot_parse/csv/rollover/store_internal/aid_transfer）。'
+  '中央定義見 apps/admin/src/lib/orderSource.ts。';

--- a/supabase/migrations/20260808000030_rpc_order_overview_source_trend.sql
+++ b/supabase/migrations/20260808000030_rpc_order_overview_source_trend.sql
@@ -1,0 +1,251 @@
+-- ============================================================
+-- 2026-08-08: rpc_order_overview v8 — 新增「下單來源」每日趨勢
+--
+-- 需求：訂單頁要一張折線圖 KPI，比較「App 下單 / 商城下單 / 小幫手代客」
+--   三條線的每日走勢（並列同一張圖，看得出通路消長）。
+--
+-- 做法：沿用既有 trend_orders（本月、排除 cancelled/expired/transferred_out
+--   的訂單），往下 join 品項取 customer_order_items.source，依 (日期, source)
+--   聚合。新增兩個回傳欄位，其餘輸出一字不動：
+--     source_days  : [{ymd, source, orders, amount, qty}, ...]
+--     source_total : [{source, orders, amount, qty}, ...]
+--
+-- ⚠ orders 是 count(DISTINCT order_id)：一張單同時有小幫手代 key 與會員自助
+--   的品項（closed 緩衝期補加，見 orderSource.ts 的 summarizeOrderSource）時，
+--   兩個 source 各算一次 —— Σ source_days.orders ≥ trend_days.orders。
+--   這張圖問的是「這天每個通路各有幾張單在動」，不是把訂單切派給單一通路，
+--   混合單本來就該在兩條線上都出現。amount/qty 則是逐品項加總，不會重複。
+--
+-- 金額口徑與既有 trend 一致：排除 status IN ('cancelled','expired') 的品項
+--   （斷貨／部分轉出的來源品項留在原單上，不濾會重複計，見 20260808000000）。
+--
+-- 基底版本：20260808000000_stats_exclude_transferred_out_items.sql 第 2 節（v7，
+--   線上現行版本；grep rpc_order_overview 的最新定義）。簽章不變（7 參數），
+--   故用 CREATE OR REPLACE，不需 DROP、GRANT 也沿用。
+-- Rollback：把 20260808000000 第 2 節的函式本體再跑一次即可回到 v7。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_order_overview(p_campaign_ids bigint[], p_store_id bigint, p_keyword text, p_month_start timestamp with time zone, p_date_from timestamp with time zone DEFAULT NULL::timestamp with time zone, p_date_to timestamp with time zone DEFAULT NULL::timestamp with time zone, p_sku_ids bigint[] DEFAULT NULL::bigint[])
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH kw AS (
+    -- 與 buildKeywordOr 一致：先把 %,() 換成空白避免當成 ILIKE 萬用字元
+    SELECT NULLIF(btrim(regexp_replace(COALESCE(p_keyword, ''), '[%,()]', ' ', 'g')), '') AS q
+  ),
+  toks AS (
+    SELECT ARRAY(
+      SELECT t FROM unnest(regexp_split_to_array((SELECT q FROM kw), '[\s+]+')) AS t
+      WHERE t <> ''
+    ) AS arr
+  ),
+  qualified_members AS (
+    -- token-AND：每個 token 都要在 name/phone/member_no 至少一欄命中
+    SELECT m.id
+    FROM members m
+    WHERE (SELECT q FROM kw) IS NOT NULL
+      AND m.status <> 'deleted'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM unnest((SELECT arr FROM toks)) AS tok
+        WHERE NOT (
+          m.name      ILIKE '%' || tok || '%'
+          OR m.phone     ILIKE '%' || tok || '%'
+          OR m.member_no ILIKE '%' || tok || '%'
+        )
+      )
+  ),
+  filtered AS (
+    -- v_admin_orders = customer_orders + event_at（事件日，定義見 20260805000120）
+    SELECT o.id, o.member_id, o.created_at, o.event_at, o.status
+    FROM v_admin_orders o
+    WHERE (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      -- 品項篩選：訂單層級（至少含一列指定 SKU 的訂單），與列表的
+      -- customer_order_items!inner 內嵌過濾同義
+      AND (
+        p_sku_ids IS NULL
+        OR cardinality(p_sku_ids) = 0
+        OR EXISTS (
+          SELECT 1 FROM customer_order_items i
+          WHERE i.order_id = o.id AND i.sku_id = ANY(p_sku_ids)
+        )
+      )
+      AND (
+        (SELECT q FROM kw) IS NULL
+        OR o.order_no          ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.nickname_snapshot ILIKE '%' || (SELECT q FROM kw) || '%'
+        OR o.member_id IN (SELECT id FROM qualified_members)
+      )
+  ),
+  -- 「未取貨」tab 專用：訂單日 created_at 區間
+  ranged_order AS (
+    SELECT f.*
+    FROM filtered f
+    WHERE (p_date_from IS NULL OR f.created_at >= p_date_from)
+      AND (p_date_to   IS NULL OR f.created_at <  p_date_to)
+  ),
+  -- 其餘 tab 專用：事件日 event_at 區間
+  ranged_event AS (
+    SELECT f.*
+    FROM filtered f
+    WHERE (p_date_from IS NULL OR f.event_at >= p_date_from)
+      AND (p_date_to   IS NULL OR f.event_at <  p_date_to)
+  ),
+  tab_counts AS (
+    SELECT
+      (SELECT count(*) FROM ranged_order WHERE status IN ('pending','confirmed','shipping','ready')) AS pending,
+      -- ready 是 pending 的子集（刻意重疊）：未取貨=全部未取，可取貨=其中已到店的。
+      -- 兩者的日期語意不同（訂單日 vs 到貨可取日），故取自不同的 ranged。
+      (SELECT count(*) FROM ranged_event WHERE status = 'ready')                                     AS ready,
+      (SELECT count(*) FROM ranged_event WHERE status = 'partially_completed')                       AS partially,
+      (SELECT count(*) FROM ranged_event WHERE status = 'completed')                                 AS completed,
+      (SELECT count(*) FROM ranged_event WHERE status IN ('cancelled','expired'))                    AS cancelled,
+      (SELECT count(*) FROM ranged_event WHERE status = 'transferred_out')                           AS transferred
+  ),
+  trend_orders AS (
+    SELECT
+      f.id,
+      f.member_id,
+      to_char((f.created_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd
+    FROM filtered f
+    WHERE f.status NOT IN ('cancelled','expired','transferred_out')
+      AND f.created_at >= p_month_start
+  ),
+  order_amt AS (
+    SELECT i.order_id, SUM(i.qty * i.unit_price)::numeric AS amount
+    FROM customer_order_items i
+    JOIN trend_orders t ON t.id = i.order_id
+    -- 部分轉出會把「整項轉走」的來源品項標 cancelled 留在原單上；
+    -- 不濾掉的話同一批貨會在來源單與轉入單各算一次金額
+    WHERE i.status NOT IN ('cancelled','expired')
+    GROUP BY i.order_id
+  ),
+  day_agg AS (
+    SELECT
+      t.ymd,
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+    GROUP BY t.ymd
+  ),
+  total_agg AS (
+    SELECT
+      count(DISTINCT t.id)                 AS orders,
+      count(DISTINCT t.member_id)          AS members,
+      COALESCE(SUM(a.amount), 0)::numeric  AS amount
+    FROM trend_orders t
+    LEFT JOIN order_amt a ON a.order_id = t.id
+  ),
+  -- 來源趨勢（本月）：同一批 trend_orders 往下拆到品項，取 source。
+  -- 口徑與 order_amt 一致（排除 cancelled/expired 品項），差別只在多 GROUP BY source。
+  source_items AS (
+    SELECT
+      t.ymd,
+      i.source,
+      t.id                            AS order_id,
+      (i.qty * i.unit_price)::numeric AS amount,
+      i.qty::numeric                  AS qty
+    FROM trend_orders t
+    JOIN customer_order_items i ON i.order_id = t.id
+    WHERE i.status NOT IN ('cancelled','expired')
+  ),
+  source_day_agg AS (
+    SELECT
+      s.ymd,
+      s.source,
+      count(DISTINCT s.order_id) AS orders,
+      SUM(s.amount)::numeric     AS amount,
+      SUM(s.qty)::numeric        AS qty
+    FROM source_items s
+    GROUP BY s.ymd, s.source
+  ),
+  source_total_agg AS (
+    SELECT
+      s.source,
+      count(DISTINCT s.order_id) AS orders,
+      SUM(s.amount)::numeric     AS amount,
+      SUM(s.qty)::numeric        AS qty
+    FROM source_items s
+    GROUP BY s.source
+  ),
+  -- 取貨明細（本月）：一行 picked_up = 一次交貨，逐行加總
+  pickup_items AS (
+    SELECT
+      to_char((i.updated_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd,
+      f.id                            AS order_id,
+      (i.qty * i.unit_price)::numeric AS amount,
+      i.qty::numeric                  AS qty
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    WHERE i.status = 'picked_up'
+      AND i.updated_at >= p_month_start
+      AND f.status NOT IN ('cancelled','expired','transferred_out')
+  ),
+  pickup_day_agg AS (
+    SELECT
+      p.ymd,
+      count(DISTINCT p.order_id) AS orders,
+      SUM(p.amount)::numeric     AS amount,
+      SUM(p.qty)::numeric        AS qty
+    FROM pickup_items p
+    GROUP BY p.ymd
+  ),
+  pickup_total_agg AS (
+    SELECT
+      count(DISTINCT p.order_id)         AS orders,
+      COALESCE(SUM(p.amount), 0)::numeric AS amount,
+      COALESCE(SUM(p.qty), 0)::numeric    AS qty
+    FROM pickup_items p
+  )
+  SELECT jsonb_build_object(
+    'tab_counts', (SELECT to_jsonb(tab_counts.*) FROM tab_counts),
+    'trend_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'members', members, 'amount', amount
+                ) ORDER BY ymd)
+       FROM day_agg),
+      '[]'::jsonb
+    ),
+    'trend_total', (SELECT to_jsonb(total_agg.*) FROM total_agg),
+    'source_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'source', source, 'orders', orders, 'amount', amount, 'qty', qty
+                ) ORDER BY ymd, source)
+       FROM source_day_agg),
+      '[]'::jsonb
+    ),
+    'source_total', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'source', source, 'orders', orders, 'amount', amount, 'qty', qty
+                ) ORDER BY source)
+       FROM source_total_agg),
+      '[]'::jsonb
+    ),
+    'pickup_days', COALESCE(
+      (SELECT jsonb_agg(
+                jsonb_build_object(
+                  'ymd', ymd, 'orders', orders, 'amount', amount, 'qty', qty
+                ) ORDER BY ymd)
+       FROM pickup_day_agg),
+      '[]'::jsonb
+    ),
+    'pickup_total', (SELECT to_jsonb(pickup_total_agg.*) FROM pickup_total_agg)
+  );
+$function$;
+
+COMMENT ON FUNCTION public.rpc_order_overview(bigint[], bigint, text, timestamptz, timestamptz, timestamptz, bigint[]) IS
+  'admin /orders 頁首聚合：tab 數量（日期區間依 tab 語意走 created_at / event_at）、'
+  '本月下單趨勢 trend_days/trend_total、本月來源趨勢 source_days/source_total'
+  '（依 customer_order_items.source 分組，混合來源的單在各來源都計一張）、'
+  '本月取貨趨勢 pickup_days/pickup_total。v8，基底 20260808000000。';


### PR DESCRIPTION
會員自助下單原本一律寫 source='liff'，PWA 與 LINE 內建瀏覽器分不出來。
拆成兩個值，訂單頁再用一張三條線的折線圖比較通路消長：
  pwa    → 會員在 App（PWA / 瀏覽器）自助下單  ＝「App」
  liff   → 會員在 LINE 內（LIFF）自助下單      ＝「商城」
  manual → 小幫手後台代客 key 單                ＝「小幫手」

DB
- 20260808000020：customer_order_items.source 的 CHECK 加 'pwa'。
- 20260808000030：rpc_order_overview v8，新增 source_days / source_total
  （沿用既有 trend_orders，多按 source 分組；金額口徑與 trend 一致，
  排除 cancelled/expired 品項）。混合來源的單在各來源都計一張，
  故各線加總 ≥ 本月訂單數 —— 註解與 UI tooltip 都有標。

Edge function
- liff-api placeMemberOrder 收前端帶上來的 client，白名單只認 'pwa'，
  其餘（含舊版前端）一律退回 'liff'，維持與歷史資料同一口徑。

會員端
- 新增 lib/clientChannel.ts：UA 含 " Line/" 或 liff.isInClient() → 'liff'，
  其餘 → 'pwa'；下單時帶上。

Admin
- lib/orderSource.ts 加 'pwa' 標籤（📱App / 🛍️商城），並新增
  SOURCE_TREND_SERIES 當折線圖的中央定義。
- /orders 新增 SourceTrendCard：三條折線 + 圖例（本月累計與佔比）、
  訂單數↔金額切換、hover 顯示當日三個值；y 軸刻度取 1/2/3/5×10^k。

⚠ 2026-08-08 之前的自助訂單沒有記執行環境，不回填，一律算「商城」。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015dSj2ukpokQ3LcrEAmyeWW