### PR TITLE
feat(members): 合併紀錄可以復原合併

### DIFF
--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -45,6 +45,10 @@ type MergedFrom = {
   merge_id: number;
   merged_at: string;
   reason: string | null;
+  /** 合併當下有沒有記下「搬走了哪些列」。false = 舊紀錄，只能靠時間戳推回（可能有漏） */
+  recorded: boolean;
+  /** 有動到點數／儲值／卡片：舊紀錄碰到這種一律擋下不給自動復原 */
+  touchedMoney: boolean;
   guest: {
     id: number;
     member_no: string;
@@ -53,6 +57,18 @@ type MergedFrom = {
     avatar_url: string | null;
     joined_at: string;
   };
+};
+
+/** rpc_unmerge_member 的回傳 */
+type UnmergeResult = {
+  reconstructed: boolean;
+  orders_restored: number;
+  orders_expected: number;
+  aliases_restored: number;
+  cards_restored: number;
+  points_restored: number;
+  wallet_restored: number;
+  target_orders_total: number | null;
 };
 
 type PointsEntry = {
@@ -119,6 +135,8 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
   /** 該會員在所屬分店的 OA 名冊有沒有已配對的身分（推播真正靠的是這個） */
   const [hasStoreLineBinding, setHasStoreLineBinding] = useState(false);
   const [mergedFrom, setMergedFrom] = useState<MergedFrom[]>([]);
+  /** 正在復原的那筆合併 id（一次只讓按一筆） */
+  const [unmerging, setUnmerging] = useState<number | null>(null);
   const [savingFlags, setSavingFlags] = useState(false);
   const [draftAdminNote, setDraftAdminNote] = useState("");
   const [draftNoNotify, setDraftNoNotify] = useState(false);
@@ -129,6 +147,55 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
   const [walletAction, setWalletAction] = useState<{ mode: WalletActionMode; reverseTarget?: WalletEntry } | null>(null);
   const role = useRole();
   const canAdjust = canAdjustWallet(role);
+
+  /**
+   * 復原一次合併：把當初搬過來的訂單／流水／餘額還給來源會員，來源會員復活。
+   *
+   * 兩種依據（見 20260809000020）：mf.recorded=true 是合併當下記下的精準清單；
+   * false 是本功能上線前的舊紀錄，後端改用 updated_at 時間戳推回 —— 不會抓錯人，
+   * 但搬過去之後又被改過狀態的訂單會漏掉，所以確認框與結果都要把話講白。
+   */
+  async function unmerge(mf: MergedFrom) {
+    const warn = mf.recorded
+      ? ""
+      : "\n\n⚠ 這筆合併在「復原」功能上線前完成，系統沒有留下當初搬走哪些資料的清單，"
+        + "只能用合併當下的時間戳推回。合併後又被改過狀態的訂單可能推不回來，"
+        + "復原後請自行核對兩邊的訂單。";
+    if (!window.confirm(
+      `確定要復原這筆合併嗎？\n\n`
+      + `「${mf.guest.name ?? mf.guest.member_no}」會重新變回獨立會員，`
+      + `當初搬過來的訂單 / 點數 / 儲值會還給他。${warn}`
+    )) return;
+
+    const reason = window.prompt("復原原因（會記進稽核紀錄）", "合併到錯的人") ?? null;
+
+    setUnmerging(mf.merge_id);
+    setError(null);
+    try {
+      const { data, error: rpcErr } = await getSupabase().rpc("rpc_unmerge_member", {
+        p_merge_id: mf.merge_id,
+        p_reason: reason,
+      });
+      if (rpcErr) { setError(translateRpcError(rpcErr)); return; }
+
+      const r = data as UnmergeResult;
+      const lines = [`已復原：${mf.guest.name ?? mf.guest.member_no} 已變回獨立會員。`];
+      lines.push(`搬回訂單 ${r.orders_restored} 張`
+        + (r.orders_expected > r.orders_restored
+          ? `（清單上有 ${r.orders_expected} 張，其餘可能已被搬去別的會員）` : ""));
+      if (Number(r.points_restored) > 0) lines.push(`點數 ${r.points_restored} 點`);
+      if (Number(r.wallet_restored) > 0) lines.push(`儲值金 $${r.wallet_restored}`);
+      if (r.cards_restored > 0) lines.push(`卡片 ${r.cards_restored} 張`);
+      if (r.reconstructed) {
+        lines.push(`\n⚠ 這是用時間戳推回的（舊紀錄），可能有漏。`
+          + `本會員名下目前還有 ${r.target_orders_total} 張訂單，請確認沒有該還沒還的。`);
+      }
+      alert(lines.join("\n"));
+      setReloadTick((n) => n + 1);
+    } finally {
+      setUnmerging(null);
+    }
+  }
 
   async function saveFlags() {
     if (!member) return;
@@ -235,9 +302,13 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
         sb.from("wallet_balances").select("balance").eq("member_id", memberId).maybeSingle<{ balance: number }>(),
         sb.from("points_ledger").select("id, change, balance_after, source_type, reason, created_at").eq("member_id", memberId).order("created_at", { ascending: false }).limit(50),
         sb.from("wallet_ledger").select("id, change, balance_after, type, payment_method, reason, reverses, created_at").eq("member_id", memberId).order("created_at", { ascending: false }).limit(50),
+        // 已復原的合併不算在清單裡（紀錄本身保留供稽核，見 20260809000020）。
+        // moved 只取「有沒有值」：有 = 合併當下記了搬走哪些列，可精準復原；
+        // NULL = 功能上線前的舊紀錄，只能靠時間戳推回，UI 要先講清楚。
         sb.from("member_merges")
-          .select("id, created_at, reason, merged_member_id, members:merged_member_id (id, member_no, name, phone, avatar_url, joined_at)")
+          .select("id, created_at, reason, merged_member_id, points_moved, wallet_moved, cards_moved, moved, members:merged_member_id (id, member_no, name, phone, avatar_url, joined_at)")
           .eq("primary_member_id", memberId)
+          .is("reverted_at", null)
           .order("created_at", { ascending: false }),
         sb.from("customer_orders")
           .select("id, order_no, status, order_kind, pickup_store_id, created_at, campaign:group_buy_campaigns(name), customer_order_items(qty, unit_price, status)")
@@ -272,6 +343,10 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
         created_at: string;
         reason: string | null;
         merged_member_id: number;
+        points_moved: number | string | null;
+        wallet_moved: number | string | null;
+        cards_moved: number | null;
+        moved: unknown;
         members: MergeMemberRow | MergeMemberRow[] | null;
       };
       const mmRows = ((mm.data ?? []) as unknown as MergeRow[])
@@ -282,6 +357,10 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
             merge_id: r.id,
             merged_at: r.created_at,
             reason: r.reason,
+            recorded: r.moved != null,
+            touchedMoney: Number(r.points_moved ?? 0) !== 0
+              || Number(r.wallet_moved ?? 0) !== 0
+              || Number(r.cards_moved ?? 0) !== 0,
             guest,
           };
         })
@@ -744,7 +823,34 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
                     {mf.reason && (
                       <div className="text-xs text-zinc-500">原因：{mf.reason}</div>
                     )}
+                    {/* 舊紀錄先說清楚復原是「推回來的」，不要等按下去才發現有漏 */}
+                    {!mf.recorded && !mf.touchedMoney && (
+                      <div className="mt-0.5 text-[11px] text-amber-700 dark:text-amber-400">
+                        ⚠ 此筆早於「復原」功能，沒有搬移清單；復原會用合併當下的時間戳推回，可能有漏
+                      </div>
+                    )}
+                    {!mf.recorded && mf.touchedMoney && (
+                      <div className="mt-0.5 text-[11px] text-amber-700 dark:text-amber-400">
+                        ⚠ 此筆早於「復原」功能且動到點數／儲值／卡片，無法自動復原，請聯絡工程師
+                      </div>
+                    )}
                   </div>
+                  {/* 併錯人的退路。合併會讓來源會員整個消失、訂單掛到別人名下，
+                      靠人工改 DB 才救得回來 —— 所以這顆按鈕要留在管理員手上。 */}
+                  {isAdmin(role) && !isMerged && !isDeleted && (
+                    <SpinButton
+                      onClick={() => unmerge(mf)}
+                      disabled={unmerging !== null || (!mf.recorded && mf.touchedMoney)}
+                      title={
+                        !mf.recorded && mf.touchedMoney
+                          ? "此筆合併動到了點數／儲值／卡片且沒有搬移清單，無法自動復原"
+                          : "把這位會員從本會員拆回去，訂單 / 點數 / 儲值一起還回去"
+                      }
+                      className="rounded-md border border-amber-300 px-2 py-1 text-xs font-medium text-amber-700 hover:bg-amber-50 disabled:opacity-40 dark:border-amber-800 dark:text-amber-300 dark:hover:bg-amber-950"
+                    >
+                      ↩ 復原合併
+                    </SpinButton>
+                  )}
                 </li>
               ))}
             </ul>

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -356,6 +356,36 @@ const RULES: Rule[] = [
     pattern: /transfer (\d+) not found/i,
     render: () => "找不到此調撥單（可能已被刪除）。",
   },
+  // ===== rpc_unmerge_member（復原合併） =====
+  {
+    pattern: /^merge_not_found(?::|$)/i,
+    render: () => "找不到這筆合併紀錄（可能已被其他人復原）。請關掉視窗重開一次。",
+  },
+  {
+    pattern: /^merge_already_reverted(?::|$)/i,
+    render: () => "這筆合併已經復原過了。請關掉視窗重開一次看最新狀態。",
+  },
+  {
+    pattern: /^merge_state_changed(?::|$)/i,
+    render: () =>
+      "來源會員目前的狀態已經不是「被併入此會員」（可能已被刪除，或又被合併到別人身上），無法自動復原。請聯絡工程師處理。",
+  },
+  {
+    pattern: /^unmerge_needs_manual(?::|$)/i,
+    render: () =>
+      "這筆合併在「復原」功能上線前完成，且動到了點數／儲值／卡片，沒有足夠資料可以安全還原，請聯絡工程師處理。",
+  },
+  {
+    pattern: /^unmerge_would_collide(?::|$)/i,
+    render: () =>
+      "來源會員身上已經有同一團、同通路的有效訂單，訂單搬回去會撞單。請先處理掉其中一筆再復原。",
+  },
+  {
+    pattern: /^unmerge_balance_insufficient:\s*目標會員目前(點數|儲值金)\s*([\d.]+)\s*少於當初併入的\s*([\d.]+)/,
+    render: (m) =>
+      `無法復原：本會員目前的${m[1]}只有 ${fmt(m[2])}，少於當初併入的 ${fmt(m[3])}，扣回去會變負數。`
+      + `請先確認這筆${m[1]}的去向並手動調整後再復原。`,
+  },
   // ===== 撿貨單號碼衝突(同秒多筆提交時的 race) =====
   {
     pattern: /duplicate key value violates unique constraint "picking_waves_tenant_id_wave_code_key"/i,

--- a/supabase/migrations/20260809000000_member_merges_record_moved.sql
+++ b/supabase/migrations/20260809000000_member_merges_record_moved.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- 2026-08-09: member_merges 記錄「這次合併搬走了哪些列」+ 復原狀態欄位
+--
+-- 為什麼需要：rpc_merge_member 是用 `UPDATE ... SET member_id = 目標` 搬資料的，
+-- 搬完之後那些列跟目標自己原本的列**長得一模一樣**，沒有任何欄位指回來源。
+-- member_merges 只存了加總（points_moved / wallet_moved / cards_moved），
+-- 存不下「是哪 39 張訂單」。所以合併一旦做錯，就沒有東西能拿來精準還原。
+--
+-- 這支補上缺的那塊：合併當下把每張表被搬走的 id 陣列寫進 moved。
+-- 有了它，rpc_unmerge_member 才能「原封不動搬回去」，而不是靠猜。
+--
+-- moved 的形狀（v=1）：
+--   {
+--     "v": 1,
+--     "source": "recorded",          -- recorded = 合併當下記的；reconstructed = 事後推回來的
+--     "src_status_before": "active", -- 來源會員被標成 merged 之前的 status，復原要還原成它
+--     "order_ids": [...], "alias_ids": [...], "tag_ids": [...], "card_ids": [...],
+--     "points_ledger_ids": [...], "wallet_ledger_ids": [...]
+--   }
+--
+-- 舊資料（本次上線前的 816 筆）moved 一律是 NULL —— 那是事實，不要填假的進去。
+-- rpc_unmerge_member 對 NULL 的處理見該支自己的註解（用 updated_at 時間戳推回，
+-- 且只在沒動到錢/卡片時才允許）。
+--
+-- Rollback：
+--   ALTER TABLE member_merges DROP COLUMN moved, DROP COLUMN reverted_at,
+--     DROP COLUMN reverted_by, DROP COLUMN reverted_reason;
+-- ============================================================================
+
+ALTER TABLE member_merges
+  ADD COLUMN IF NOT EXISTS moved           JSONB,
+  ADD COLUMN IF NOT EXISTS reverted_at     TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS reverted_by     UUID,
+  ADD COLUMN IF NOT EXISTS reverted_reason TEXT;
+
+COMMENT ON COLUMN member_merges.moved IS
+  '合併當下被搬走的列 id（v=1；order_ids / alias_ids / tag_ids / card_ids / points_ledger_ids / wallet_ledger_ids 與 src_status_before）。NULL = 本欄上線前的舊紀錄，沒有精準還原依據';
+COMMENT ON COLUMN member_merges.reverted_at IS
+  '這筆合併被復原的時間；非 NULL 表示已復原（紀錄保留供稽核，但不再算在「合併紀錄」清單裡）';
+COMMENT ON COLUMN member_merges.reverted_by IS '執行復原的操作者';
+COMMENT ON COLUMN member_merges.reverted_reason IS '復原原因（店員填的，例如「合併到錯的人」）';
+
+-- 「還沒被復原的合併」是 UI 清單與各處統計的主要查詢條件
+CREATE INDEX IF NOT EXISTS idx_member_merges_active
+  ON member_merges (primary_member_id) WHERE reverted_at IS NULL;

--- a/supabase/migrations/20260809000010_rpc_merge_member_record_moved.sql
+++ b/supabase/migrations/20260809000010_rpc_merge_member_record_moved.sql
@@ -1,0 +1,188 @@
+-- ============================================================================
+-- 2026-08-09: rpc_merge_member — 合併時把「搬走了哪些列」記進 member_merges.moved
+-- ----------------------------------------------------------------------------
+-- 以哪個版本為基底：20260714000070_rpc_merge_member_target_orders_collision_only.sql
+--                  （grep 過 supabase/migrations/ 全部 8 支動過本函式的檔，那支是最新的）
+-- rollback 指回　 ：20260714000070_rpc_merge_member_target_orders_collision_only.sql
+--
+-- 變更（相對 20260714000070）：**只有記錄，沒有任何行為改變**。
+--   1. 原本 `UPDATE ... SET member_id = p_real_id` 的六張表，改成 CTE + RETURNING id，
+--      把被搬走的 id 收進陣列。WHERE 條件逐字不動。
+--   2. 來源會員被標成 merged 之前的 status 記進 src_status_before（復原要還原成它，
+--      不能一律假設 active —— 來源可能本來是 inactive / blocked）。
+--   3. INSERT INTO member_merges 多帶一個 moved 欄位。
+--   其餘（來源已綁 LINE / 已合併 / 自己併自己 的守門、撞唯一索引的精準守門、
+--   點數與儲值的加總與搬移、卡片計數、稽核欄位）全部逐字保留。
+--
+-- 為什麼要記：搬完之後那些列跟目標自己的列無法區分，沒有這份清單就無法精準復原。
+-- 見 20260809000000 與 rpc_unmerge_member。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION rpc_merge_member(
+  p_guest_id BIGINT,
+  p_real_id  BIGINT,
+  p_operator UUID DEFAULT NULL,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_tenant      UUID;
+  v_operator    UUID;
+  v_points      NUMERIC(18,2) := 0;
+  v_wallet      NUMERIC(18,2) := 0;
+  v_cards       INTEGER       := 0;
+  v_src_line    TEXT;
+  v_src_status  TEXT;
+  -- 被搬走的列 id（供 rpc_unmerge_member 精準搬回）
+  v_order_ids   BIGINT[] := '{}';
+  v_alias_ids   BIGINT[] := '{}';
+  v_tag_ids     BIGINT[] := '{}';
+  v_card_ids    BIGINT[] := '{}';
+  v_pl_ids      BIGINT[] := '{}';
+  v_wl_ids      BIGINT[] := '{}';
+BEGIN
+  v_operator := COALESCE(p_operator, auth.uid(), '00000000-0000-0000-0000-000000000000'::uuid);
+
+  SELECT tenant_id, line_user_id, status
+    INTO v_tenant, v_src_line, v_src_status
+    FROM members WHERE id = p_guest_id;
+
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'source member % not found', p_guest_id;
+  END IF;
+
+  IF v_src_line IS NOT NULL THEN
+    RAISE EXCEPTION 'source member % is already bound to LINE — pick the unbound one as source', p_guest_id;
+  END IF;
+
+  IF v_src_status = 'merged' THEN
+    RAISE EXCEPTION 'source member % is already merged', p_guest_id;
+  END IF;
+
+  IF p_guest_id = p_real_id THEN
+    RAISE EXCEPTION 'source and target must differ';
+  END IF;
+
+  -- 精準守門：目標(已綁 LINE)可以有訂單；只有當「來源 active 訂單」與「目標 active
+  -- 訂單」落在同一個 (tenant, campaign, channel, order_kind) 時，把來源訂單搬過去
+  -- 才會撞 customer_orders_trio_kind_active_uniq。這種情形才擋（需先人工處理其一）。
+  PERFORM 1
+    FROM customer_orders s
+    JOIN customer_orders t
+      ON t.tenant_id   = s.tenant_id
+     AND t.campaign_id = s.campaign_id
+     AND t.channel_id  = s.channel_id
+     AND t.order_kind  = s.order_kind
+   WHERE s.member_id = p_guest_id
+     AND t.member_id = p_real_id
+     AND s.tenant_id = v_tenant
+     AND s.status NOT IN ('transferred_out', 'expired', 'cancelled')
+     AND t.status NOT IN ('transferred_out', 'expired', 'cancelled')
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'merge would collide: source % and target % both have an active order in the same campaign/channel, cannot merge', p_guest_id, p_real_id;
+  END IF;
+
+  -- 把來源（虛擬會員）的訂單搬到目標（LINE 會員）：已確認無同 trio+kind 的 active 撞單
+  WITH upd AS (
+    UPDATE customer_orders SET member_id = p_real_id
+     WHERE member_id = p_guest_id AND tenant_id = v_tenant
+    RETURNING id
+  ) SELECT COALESCE(array_agg(id), '{}') INTO v_order_ids FROM upd;
+
+  WITH upd AS (
+    UPDATE customer_line_aliases SET member_id = p_real_id
+     WHERE member_id = p_guest_id
+    RETURNING id
+  ) SELECT COALESCE(array_agg(id), '{}') INTO v_alias_ids FROM upd;
+
+  WITH upd AS (
+    UPDATE member_tags SET member_id = p_real_id
+     WHERE member_id = p_guest_id
+    RETURNING id
+  ) SELECT COALESCE(array_agg(id), '{}') INTO v_tag_ids FROM upd;
+
+  SELECT COUNT(*) INTO v_cards FROM member_cards WHERE member_id = p_guest_id;
+  v_cards := COALESCE(v_cards, 0);
+  WITH upd AS (
+    UPDATE member_cards SET member_id = p_real_id
+     WHERE member_id = p_guest_id
+    RETURNING id
+  ) SELECT COALESCE(array_agg(id), '{}') INTO v_card_ids FROM upd;
+
+  SELECT COALESCE(balance, 0) INTO v_points
+    FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  v_points := COALESCE(v_points, 0);
+
+  SELECT COALESCE(balance, 0) INTO v_wallet
+    FROM wallet_balances       WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  v_wallet := COALESCE(v_wallet, 0);
+
+  WITH upd AS (
+    UPDATE points_ledger SET member_id = p_real_id
+     WHERE member_id = p_guest_id
+    RETURNING id
+  ) SELECT COALESCE(array_agg(id), '{}') INTO v_pl_ids FROM upd;
+
+  WITH upd AS (
+    UPDATE wallet_ledger SET member_id = p_real_id
+     WHERE member_id = p_guest_id
+    RETURNING id
+  ) SELECT COALESCE(array_agg(id), '{}') INTO v_wl_ids FROM upd;
+
+  IF v_points > 0 THEN
+    INSERT INTO member_points_balance (tenant_id, member_id, balance, version, updated_at)
+    VALUES (v_tenant, p_real_id, v_points, 1, NOW())
+    ON CONFLICT (tenant_id, member_id) DO UPDATE
+      SET balance          = member_points_balance.balance + EXCLUDED.balance,
+          version          = member_points_balance.version + 1,
+          last_movement_at = NOW(),
+          updated_at       = NOW();
+  END IF;
+
+  IF v_wallet > 0 THEN
+    INSERT INTO wallet_balances (tenant_id, member_id, balance, version, updated_at)
+    VALUES (v_tenant, p_real_id, v_wallet, 1, NOW())
+    ON CONFLICT (tenant_id, member_id) DO UPDATE
+      SET balance          = wallet_balances.balance + EXCLUDED.balance,
+          version          = wallet_balances.version + 1,
+          last_movement_at = NOW(),
+          updated_at       = NOW();
+  END IF;
+
+  DELETE FROM member_points_balance WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+  DELETE FROM wallet_balances        WHERE tenant_id = v_tenant AND member_id = p_guest_id;
+
+  UPDATE members
+     SET status                = 'merged',
+         merged_into_member_id = p_real_id,
+         updated_at            = NOW(),
+         updated_by            = v_operator
+   WHERE id = p_guest_id;
+
+  INSERT INTO member_merges (
+    tenant_id, primary_member_id, merged_member_id,
+    points_moved, wallet_moved, cards_moved, reason, operator_id, moved
+  ) VALUES (
+    v_tenant, p_real_id, p_guest_id,
+    v_points, v_wallet, v_cards, p_reason, v_operator,
+    jsonb_build_object(
+      'v', 1,
+      'source', 'recorded',
+      'src_status_before', v_src_status,
+      'order_ids',         to_jsonb(v_order_ids),
+      'alias_ids',         to_jsonb(v_alias_ids),
+      'tag_ids',           to_jsonb(v_tag_ids),
+      'card_ids',          to_jsonb(v_card_ids),
+      'points_ledger_ids', to_jsonb(v_pl_ids),
+      'wallet_ledger_ids', to_jsonb(v_wl_ids)
+    )
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION rpc_merge_member(BIGINT, BIGINT, UUID, TEXT) IS
+  '會員合併：把未綁 LINE 的來源併入已綁 LINE 的目標，訂單一起搬。目標可有訂單；'
+  '僅當來源與目標各有一筆 active 訂單且落在同一 (tenant,campaign,channel,order_kind) '
+  '時才擋（會撞 customer_orders_trio_kind_active_uniq）。卡片/點數/儲值/標籤/暱稱/流水照搬，'
+  '並把被搬走的列 id 記進 member_merges.moved 供 rpc_unmerge_member 精準復原。';

--- a/supabase/migrations/20260809000020_rpc_unmerge_member.sql
+++ b/supabase/migrations/20260809000020_rpc_unmerge_member.sql
@@ -1,0 +1,265 @@
+-- ============================================================================
+-- 2026-08-09: rpc_unmerge_member —— 合併綁錯人可以復原
+--
+-- 合併是店員在「疑似同一人」的兩筆會員之間用眼睛判斷的，併錯的代價很重：來源會員
+-- 整個消失（status='merged'）、他的訂單全部掛到別人名下。以前唯一的救法是找工程師
+-- 手動改 DB，所以這條路一定要留在後台。
+--
+-- ── 兩種復原依據 ──────────────────────────────────────────────────────────
+--
+-- A. moved 有值（20260809000010 之後做的合併）：精準復原。
+--    合併當下記下了每張表被搬走的 id，原封不動搬回去，不多不少。
+--
+-- B. moved 是 NULL（本功能上線前的 816 筆舊紀錄）：靠時間戳推回，且**條件收緊**。
+--    customer_orders 有 BEFORE UPDATE 的 touch_updated_at trigger，而 NOW() 在同一
+--    交易內是固定值 —— 所以被那次合併搬走的訂單，updated_at 會**精確等於**
+--    member_merges.created_at（微秒級）。別的交易不可能剛好落在同一個微秒，
+--    所以不會誤抓目標自己的訂單（無偽陽性）。
+--    但反過來會漏：搬過去之後又被改過狀態（取貨、取消…）的訂單，updated_at 已被
+--    覆蓋，推不回來（偽陰性）。所以 B 路徑：
+--      - 只在 points_moved / wallet_moved / cards_moved 全為 0 時允許
+--        （線上 816 筆裡 815 筆符合；ledger 沒有 updated_at，動到錢的那筆推不了，
+--         寧可擋下讓人工處理，也不要把錢還錯位置）
+--      - 回傳 reconstructed=true 與 orders_left_behind，讓 UI 明講「可能有漏，
+--        請自己核對」，而不是假裝復原得很乾淨
+--
+-- ── 不做的事 ──────────────────────────────────────────────────────────────
+-- 不刪 member_merges 那一列：改標 reverted_at/by/reason，稽核要看得到「併過又復原」。
+-- 前端清單要自己加 `reverted_at IS NULL`。
+--
+-- 依賴：20260809000000（moved / reverted_* 欄位）、20260809000010（寫 moved 的合併）
+-- Rollback：DROP FUNCTION public.rpc_unmerge_member(BIGINT, UUID, TEXT);
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_unmerge_member(
+  p_merge_id BIGINT,
+  p_operator UUID DEFAULT NULL,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant     UUID := public._current_tenant_id();
+  -- ⚠ 應用角色走 app_metadata（見 CLAUDE.md / 20260807000040）
+  v_role       TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_operator   UUID;
+  v_mm         member_merges%ROWTYPE;
+  v_guest      BIGINT;
+  v_real       BIGINT;
+  v_moved      JSONB;
+  v_recon      BOOLEAN := FALSE;
+  v_status_to  TEXT;
+  v_order_ids  BIGINT[] := '{}';
+  v_alias_ids  BIGINT[] := '{}';
+  v_tag_ids    BIGINT[] := '{}';
+  v_card_ids   BIGINT[] := '{}';
+  v_pl_ids     BIGINT[] := '{}';
+  v_wl_ids     BIGINT[] := '{}';
+  v_n_orders   INT := 0;
+  v_n_alias    INT := 0;
+  v_n_tags     INT := 0;
+  v_n_cards    INT := 0;
+  v_n_pl       INT := 0;
+  v_n_wl       INT := 0;
+  v_left       INT := 0;
+  v_src_status TEXT;
+  v_src_merged BIGINT;
+  v_bal        NUMERIC(18,2);
+BEGIN
+  -- 復原比合併危險（會把錢與訂單搬回去），限管理員層級。
+  -- '' = 沒有顯式 role 的 legacy/dev admin，對齊 apps/admin/src/lib/role.ts 的 isAdmin。
+  IF v_role NOT IN ('owner','admin','') THEN
+    RAISE EXCEPTION 'insufficient_role';
+  END IF;
+
+  v_operator := COALESCE(p_operator, auth.uid(), '00000000-0000-0000-0000-000000000000'::uuid);
+
+  SELECT * INTO v_mm FROM member_merges
+   WHERE id = p_merge_id AND tenant_id = v_tenant
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'merge_not_found: 找不到這筆合併紀錄';
+  END IF;
+  IF v_mm.reverted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'merge_already_reverted: 這筆合併已經復原過了';
+  END IF;
+
+  v_guest := v_mm.merged_member_id;
+  v_real  := v_mm.primary_member_id;
+
+  -- 來源會員必須還停在「被這次合併併掉」的狀態。之後被 GDPR 刪除、或被再併去
+  -- 別人身上的話，硬搬回來只會製造更難救的狀態 —— 擋下來讓人工處理。
+  SELECT status, merged_into_member_id INTO v_src_status, v_src_merged
+    FROM members WHERE id = v_guest AND tenant_id = v_tenant
+    FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'merge_state_changed: 來源會員已不存在，無法復原';
+  END IF;
+  IF v_src_status <> 'merged' OR v_src_merged IS DISTINCT FROM v_real THEN
+    RAISE EXCEPTION 'merge_state_changed: 來源會員目前的狀態不是「被併入此會員」（可能已被刪除或再次合併），無法自動復原';
+  END IF;
+
+  v_moved := v_mm.moved;
+
+  IF v_moved ? 'order_ids' THEN
+    -- A：合併當下記下來的精準清單
+    v_status_to := COALESCE(v_moved ->> 'src_status_before', 'active');
+    SELECT COALESCE(array_agg(x::BIGINT), '{}') INTO v_order_ids FROM jsonb_array_elements_text(v_moved -> 'order_ids') x;
+    SELECT COALESCE(array_agg(x::BIGINT), '{}') INTO v_alias_ids FROM jsonb_array_elements_text(COALESCE(v_moved -> 'alias_ids', '[]'::jsonb)) x;
+    SELECT COALESCE(array_agg(x::BIGINT), '{}') INTO v_tag_ids   FROM jsonb_array_elements_text(COALESCE(v_moved -> 'tag_ids', '[]'::jsonb)) x;
+    SELECT COALESCE(array_agg(x::BIGINT), '{}') INTO v_card_ids  FROM jsonb_array_elements_text(COALESCE(v_moved -> 'card_ids', '[]'::jsonb)) x;
+    SELECT COALESCE(array_agg(x::BIGINT), '{}') INTO v_pl_ids    FROM jsonb_array_elements_text(COALESCE(v_moved -> 'points_ledger_ids', '[]'::jsonb)) x;
+    SELECT COALESCE(array_agg(x::BIGINT), '{}') INTO v_wl_ids    FROM jsonb_array_elements_text(COALESCE(v_moved -> 'wallet_ledger_ids', '[]'::jsonb)) x;
+  ELSE
+    -- B：舊紀錄，靠 updated_at 時間戳推回（理由見檔頭）
+    IF v_mm.points_moved <> 0 OR v_mm.wallet_moved <> 0 OR v_mm.cards_moved <> 0 THEN
+      RAISE EXCEPTION 'unmerge_needs_manual: 這筆合併在記錄功能上線前完成，且動到了點數／儲值／卡片，無法安全地自動復原，請聯絡工程師處理';
+    END IF;
+    v_recon     := TRUE;
+    v_status_to := 'active';
+    SELECT COALESCE(array_agg(id), '{}') INTO v_order_ids
+      FROM customer_orders
+     WHERE tenant_id = v_tenant AND member_id = v_real AND updated_at = v_mm.created_at;
+    SELECT COALESCE(array_agg(id), '{}') INTO v_alias_ids
+      FROM customer_line_aliases
+     WHERE member_id = v_real AND updated_at = v_mm.created_at;
+  END IF;
+
+  -- 搬回去之前先確認不會撞唯一索引：來源會員身上若已經有同 (campaign, channel, kind)
+  -- 的 active 訂單（合併後又補單之類），硬搬會炸在 customer_orders_trio_kind_active_uniq。
+  --
+  -- ⚠ campaign_id / channel_id 用 `=` 而不是 IS NOT DISTINCT FROM：btree unique 視
+  --   NULL 彼此為相異、本來就不強制唯一，用 IS NOT DISTINCT FROM 會把兩筆 NULL 當成
+  --   撞到而擋掉根本不會撞的復原。這跟 rpc_merge_member 的守門是同一套語意。
+  PERFORM 1
+    FROM customer_orders s
+    JOIN customer_orders t
+      ON t.tenant_id   = s.tenant_id
+     AND t.campaign_id = s.campaign_id
+     AND t.channel_id  = s.channel_id
+     AND t.order_kind  = s.order_kind
+   WHERE s.id = ANY(v_order_ids)
+     AND t.member_id = v_guest
+     AND t.tenant_id = v_tenant
+     AND s.status NOT IN ('transferred_out', 'expired', 'cancelled')
+     AND t.status NOT IN ('transferred_out', 'expired', 'cancelled')
+     AND s.order_kind <> 'restock'
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'unmerge_would_collide: 來源會員身上已有同一團同通路的有效訂單，搬回去會撞單，請先人工處理';
+  END IF;
+
+  -- ── 搬回來源 ─────────────────────────────────────────────────────────────
+  UPDATE customer_orders       SET member_id = v_guest WHERE id = ANY(v_order_ids) AND tenant_id = v_tenant AND member_id = v_real;
+  GET DIAGNOSTICS v_n_orders = ROW_COUNT;
+  UPDATE customer_line_aliases SET member_id = v_guest WHERE id = ANY(v_alias_ids) AND member_id = v_real;
+  GET DIAGNOSTICS v_n_alias = ROW_COUNT;
+  UPDATE member_tags           SET member_id = v_guest WHERE id = ANY(v_tag_ids)   AND member_id = v_real;
+  GET DIAGNOSTICS v_n_tags = ROW_COUNT;
+  UPDATE member_cards          SET member_id = v_guest WHERE id = ANY(v_card_ids)  AND member_id = v_real;
+  GET DIAGNOSTICS v_n_cards = ROW_COUNT;
+  UPDATE points_ledger         SET member_id = v_guest WHERE id = ANY(v_pl_ids)    AND member_id = v_real;
+  GET DIAGNOSTICS v_n_pl = ROW_COUNT;
+  UPDATE wallet_ledger         SET member_id = v_guest WHERE id = ANY(v_wl_ids)    AND member_id = v_real;
+  GET DIAGNOSTICS v_n_wl = ROW_COUNT;
+
+  -- ── 餘額搬回來源 ─────────────────────────────────────────────────────────
+  -- 合併是「加進目標」，復原就「從目標扣掉同一筆金額、還給來源」。目標的餘額在合併
+  -- 之後可能又被動過，扣下去會變負數的話擋掉 —— 餘額是錢，寧可要求人工處理。
+  IF v_mm.points_moved > 0 THEN
+    SELECT COALESCE(balance, 0) INTO v_bal FROM member_points_balance
+     WHERE tenant_id = v_tenant AND member_id = v_real FOR UPDATE;
+    IF COALESCE(v_bal, 0) < v_mm.points_moved THEN
+      RAISE EXCEPTION 'unmerge_balance_insufficient: 目標會員目前點數 % 少於當初併入的 %，扣回去會變負數，請先人工調整',
+        COALESCE(v_bal, 0), v_mm.points_moved;
+    END IF;
+    UPDATE member_points_balance
+       SET balance = balance - v_mm.points_moved, version = version + 1, updated_at = NOW()
+     WHERE tenant_id = v_tenant AND member_id = v_real;
+    INSERT INTO member_points_balance (tenant_id, member_id, balance, version, updated_at)
+    VALUES (v_tenant, v_guest, v_mm.points_moved, 1, NOW())
+    ON CONFLICT (tenant_id, member_id) DO UPDATE
+      SET balance    = member_points_balance.balance + EXCLUDED.balance,
+          version    = member_points_balance.version + 1,
+          updated_at = NOW();
+  END IF;
+
+  IF v_mm.wallet_moved > 0 THEN
+    SELECT COALESCE(balance, 0) INTO v_bal FROM wallet_balances
+     WHERE tenant_id = v_tenant AND member_id = v_real FOR UPDATE;
+    IF COALESCE(v_bal, 0) < v_mm.wallet_moved THEN
+      RAISE EXCEPTION 'unmerge_balance_insufficient: 目標會員目前儲值金 % 少於當初併入的 %，扣回去會變負數，請先人工調整',
+        COALESCE(v_bal, 0), v_mm.wallet_moved;
+    END IF;
+    UPDATE wallet_balances
+       SET balance = balance - v_mm.wallet_moved, version = version + 1, updated_at = NOW()
+     WHERE tenant_id = v_tenant AND member_id = v_real;
+    INSERT INTO wallet_balances (tenant_id, member_id, balance, version, updated_at)
+    VALUES (v_tenant, v_guest, v_mm.wallet_moved, 1, NOW())
+    ON CONFLICT (tenant_id, member_id) DO UPDATE
+      SET balance    = wallet_balances.balance + EXCLUDED.balance,
+          version    = wallet_balances.version + 1,
+          updated_at = NOW();
+  END IF;
+
+  -- ── 來源會員復活 ─────────────────────────────────────────────────────────
+  UPDATE members
+     SET status                = v_status_to,
+         merged_into_member_id = NULL,
+         updated_at            = NOW(),
+         updated_by            = v_operator
+   WHERE id = v_guest AND tenant_id = v_tenant;
+
+  -- B 路徑漏掉的：合併時搬過去、但之後 updated_at 被覆蓋而推不回來的訂單。
+  -- 沒辦法精算，至少把「目標身上還有多少張單」給出去讓人核對。
+  IF v_recon THEN
+    SELECT count(*) INTO v_left FROM customer_orders
+     WHERE tenant_id = v_tenant AND member_id = v_real;
+  END IF;
+
+  UPDATE member_merges
+     SET reverted_at = NOW(), reverted_by = v_operator, reverted_reason = p_reason
+   WHERE id = p_merge_id;
+
+  INSERT INTO member_audit_log (
+    tenant_id, entity_type, entity_id, action, before_value, after_value, reason, operator_id
+  ) VALUES (
+    v_tenant, 'merge', p_merge_id, 'unmerge',
+    jsonb_build_object('primary_member_id', v_real, 'merged_member_id', v_guest,
+                       'points_moved', v_mm.points_moved, 'wallet_moved', v_mm.wallet_moved,
+                       'cards_moved', v_mm.cards_moved, 'merged_at', v_mm.created_at),
+    jsonb_build_object('reconstructed', v_recon, 'orders', v_n_orders, 'aliases', v_n_alias,
+                       'tags', v_n_tags, 'cards', v_n_cards,
+                       'points_ledger', v_n_pl, 'wallet_ledger', v_n_wl,
+                       'restored_status', v_status_to),
+    p_reason, v_operator
+  );
+
+  RETURN jsonb_build_object(
+    'merge_id',            p_merge_id,
+    'source_member_id',    v_guest,
+    'target_member_id',    v_real,
+    'reconstructed',       v_recon,
+    'orders_restored',     v_n_orders,
+    -- 清單裡有、但實際沒搬回來的（合併後又被搬去第三個人身上）。
+    -- 兩個數字不一樣時 UI 要講出來，不能只報成功。
+    'orders_expected',     COALESCE(array_length(v_order_ids, 1), 0),
+    'aliases_restored',    v_n_alias,
+    'tags_restored',       v_n_tags,
+    'cards_restored',      v_n_cards,
+    'points_restored',     v_mm.points_moved,
+    'wallet_restored',     v_mm.wallet_moved,
+    'restored_status',     v_status_to,
+    -- 只有 B 路徑給：目標名下剩餘的訂單總數，供人工核對有沒有漏搬
+    'target_orders_total', CASE WHEN v_recon THEN v_left ELSE NULL END
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_unmerge_member(BIGINT, UUID, TEXT) IS
+  '復原一次會員合併：把當初搬走的訂單／暱稱／標籤／卡片／流水與餘額還給來源會員並讓它復活。'
+  'moved 有值時精準復原；舊紀錄（moved 為 NULL）改用 updated_at 時間戳推回，且僅限沒動到點數／儲值／卡片者，'
+  '回傳 reconstructed=true 提醒可能有漏。紀錄本身不刪，只標 reverted_at。';
+
+REVOKE ALL ON FUNCTION public.rpc_unmerge_member(BIGINT, UUID, TEXT) FROM anon;


### PR DESCRIPTION
合併紀錄那一區以前只能看。併錯人的話來源會員整個消失（`status='merged'`）、訂單全部掛到別人名下，唯一的解法是找工程師改 DB。這支把退路交回後台。

## 為什麼不是一支 RPC 就好

`rpc_merge_member` 是用 `UPDATE ... SET member_id = 目標` 搬資料的 — 搬完之後那些列跟目標自己原本的列**完全無法區分**，`member_merges` 又只存了加總（`points_moved` / `wallet_moved` / `cards_moved`），存不下「是哪 39 張訂單」。所以要先把缺的那塊補起來，復原才有依據。

## 改了什麼

| Migration | 內容 |
| --- | --- |
| `20260809000000` | `member_merges` 補 `moved` / `reverted_at` / `reverted_by` / `reverted_reason` |
| `20260809000010` | `rpc_merge_member` 改用 CTE + `RETURNING` 把六張表被搬走的 id 記進 `moved`，並記下來源原本的 status |
| `20260809000020` | 新增 `rpc_unmerge_member(merge_id, operator, reason)` |

`rpc_merge_member` 以 `20260714000070` 為基底（grep 過全部 8 支動過本函式的 migration，那支最新）。守門、金額搬移、稽核欄位**逐字保留，行為零改變** — 這次只加記錄。

`rpc_unmerge_member` 限管理員（`owner` / `admin` / `''`，對齊 `role.ts` 的 `isAdmin`），把訂單／暱稱／標籤／卡片／流水與餘額還給來源會員並讓它復活。合併紀錄本身不刪，只標 `reverted_at`，稽核要看得到「併過又復原」；同時寫一筆 `member_audit_log`（`entity_type='merge'`, `action='unmerge'`）。

## 舊紀錄怎麼辦（816 筆沒有 moved）

改用時間戳推回：`customer_orders` 有 `touch_updated_at` trigger，而 `NOW()` 在同一交易內是固定值 —— 被那次合併搬走的訂單，`updated_at` 會**精確等於** `member_merges.created_at`。微秒級不可能落在別的交易，所以**不會抓錯目標自己的訂單**（無偽陽性）；但搬過去之後又被改過狀態（取貨、取消…）的訂單推不回來（偽陰性）。

因此這條路收緊成：

- 只在 `points_moved` / `wallet_moved` / `cards_moved` **全為 0** 時開放（線上 815/816 筆符合；ledger 沒有 `updated_at`，動到錢的那筆寧可擋下讓人工處理，也不要把錢還錯位置）
- 回傳 `reconstructed=true` 與目標剩餘訂單數，UI 明講「可能有漏，請自行核對」，不假裝復原得很乾淨

## UI

合併紀錄每列加「↩ 復原合併」：舊紀錄先標黃字警告、動到錢的直接 disabled 並說明原因。確認框會依紀錄種類換掉措辭，復原後用結果摘要回報實際搬回幾張（清單上有 N 張但只搬回 M 張時會講出來）。清單查詢改讀 `reverted_at IS NULL`。錯誤一律走 `translateRpcError`，六個新錯誤碼補上中文。

## 驗證

**後端**（Management API 灌 claims 實測，**全部包在交易內 ROLLBACK，線上資料未變動**）：

| 情境 | 結果 |
| --- | --- |
| 合併 → 復原來回 | 訂單與會員狀態 **0 筆**沒還原；`orders_restored=2/2`；紀錄標記與稽核各 1 筆 |
| 舊紀錄 822（39 張單） | 推回 **39/39**、來源復活、`reconstructed=true` |
| 舊紀錄且動到錢 | `unmerge_needs_manual` |
| `store_manager` | `insufficient_role` |
| 不存在的 merge id | `merge_not_found` |
| 連按兩次 | `merge_already_reverted` |
| 來源被再併走 | `merge_state_changed` |

複查線上：`reverted_rows=0`、`unmerge_audit_rows=0`、測試對象 status 仍為 `merged` — 測試沒有外洩。

**前端**：Playwright + fixture 走完三種紀錄的畫面與兩種復原流程，12 項斷言全過；`tsc` / `eslint` / `next build` 皆綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrzUqgvC2L3oHpoXm2gYmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrzUqgvC2L3oHpoXm2gYmJ)_