### PR TITLE
fix(member): 未結單金額只算「已訂未領貨」，不再把取過的貨一直掛帳

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,35 @@ SELECT * FROM <your_rpc>();   -- 換成 store_staff 再跑一次，應該要被�
 
 ## 顧客訂單 (customer_orders)
 
+### `payment_status` 全站永遠是 `'unpaid'`，不可以拿來判斷「收到錢了沒」
+
+現金在門市取貨當下收，`rpc_record_pickup` **不回寫** `payment_status`；
+唯一會寫 `'paid'` 的 `rpc_wallet_pay_order` 線上 0 筆使用。所以：
+
+```sql
+SELECT payment_status, count(*) FROM customer_orders GROUP BY 1;
+--  unpaid | 65297        ← 全部，一筆 paid 都沒有
+```
+
+`WHERE payment_status = 'unpaid'` 等於**沒有 WHERE**。2026-08 的災情：會員中心
+「未結單金額」就是這樣寫的，把每位會員開站至今所有取過貨的訂單一路累加 ——
+一位團友畫面顯示 $3,072、實際沒領的只有 $1,110，全站多算 NT$482 萬。
+
+要表達「還沒收的錢」，一律用**品項有沒有被取走**：
+
+```sql
+SUM(qty * unit_price) FILTER (WHERE status NOT IN ('cancelled','expired','picked_up'))
+```
+
+view 已經備好 `v_customer_order_summary.outstanding_amount`（`20260810000000`），
+直接用它，不要自己重寫。兩個附帶條件：
+
+- 一定要**品項層級**算。訂單層級（`status <> 'completed'`）會把 `partially_completed`
+  已經取走的那半也算進去。
+- `transferred_out`（轉手給別人）的品項**留在原單且維持 `pending`**，貨已經在新單上
+  → 這個 status 必須整張歸零，否則跟新單重複計算。同理，任何「抓未取貨」的
+  查詢都要記得排除它（`20260507000001` 已經為此掃過一輪 view / RPC）。
+
 ### 取消 / 斷貨掉一個品項之後，記得重算訂單單頭
 
 訂單單頭的狀態只有取貨那一刻（`rpc_record_pickup`）會重算。品項在**取貨之後**

--- a/apps/member/src/app/me/page.tsx
+++ b/apps/member/src/app/me/page.tsx
@@ -326,6 +326,9 @@ export default function MePage() {
                 ${Number(overview.receivable_amount).toLocaleString()}
               </span>
             </div>
+            <div className="mt-1 text-[12px] text-[var(--tertiary-label)]">
+              已訂購但還沒領走的金額；取貨時付款，領完就不再計入
+            </div>
             <a
               href="/orders"
               className="mt-3 flex w-full items-center justify-between rounded-xl bg-[#7676801a] px-3 py-3 text-[16px] text-[var(--foreground)] active:bg-[#76768033]"

--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -11,18 +11,19 @@ import OrderCard, { orderPhase, type OrderRow } from "@/components/OrderCard";
 
 // 蝦皮式分頁。我們取貨時付現金，所以沒有「待付款」；「待收貨」＝到店「待取貨」。
 // 分桶跟卡片右上角的狀態字共用 orderPhase()，兩邊永遠一致。
-// 「不成立」（斷貨取消）跟「已轉讓」目前先整批隱藏（連「全部」也不出現），
-// 之後要開再把 HIDDEN_PHASES 拿掉、補回 void 分頁。
-type Tab = "all" | "waiting" | "pickup" | "done";
+// 「不成立」（斷貨取消）要顯示 —— 團友得知道那筆單為什麼消失（⛔ 斷貨說明）。
+// 「已轉讓」目前先隱藏（連「全部」也不出現），之後要開再把它移出 HIDDEN_PHASES。
+type Tab = "all" | "waiting" | "pickup" | "done" | "void";
 
 const TAB_LABEL: Record<Tab, string> = {
   all: "全部",
   waiting: "待到貨",
   pickup: "待取貨",
   done: "已完成",
+  void: "不成立",
 };
 
-const HIDDEN_PHASES = new Set(["void", "transferred"]);
+const HIDDEN_PHASES = new Set(["transferred"]);
 
 export default function OrdersPage() {
   const router = useRouter();
@@ -63,11 +64,11 @@ export default function OrdersPage() {
   }, [router]);
 
   const buckets = useMemo(() => {
-    const b: Record<Tab, OrderRow[]> = { all: orders, waiting: [], pickup: [], done: [] };
+    const b: Record<Tab, OrderRow[]> = { all: orders, waiting: [], pickup: [], done: [], void: [] };
     for (const o of orders) {
       const { phase } = orderPhase(o);
-      // orders 進來前已濾掉 HIDDEN_PHASES，這裡只剩三個分頁的階段
-      if (phase === "waiting" || phase === "pickup" || phase === "done") b[phase].push(o);
+      // orders 進來前已濾掉 HIDDEN_PHASES（已轉讓），剩下的都有自己的分頁
+      if (phase !== "transferred") b[phase].push(o);
     }
     return b;
   }, [orders]);

--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -11,15 +11,18 @@ import OrderCard, { orderPhase, type OrderRow } from "@/components/OrderCard";
 
 // 蝦皮式分頁。我們取貨時付現金，所以沒有「待付款」；「待收貨」＝到店「待取貨」。
 // 分桶跟卡片右上角的狀態字共用 orderPhase()，兩邊永遠一致。
-type Tab = "all" | "waiting" | "pickup" | "done" | "void";
+// 「不成立」（斷貨取消）跟「已轉讓」目前先整批隱藏（連「全部」也不出現），
+// 之後要開再把 HIDDEN_PHASES 拿掉、補回 void 分頁。
+type Tab = "all" | "waiting" | "pickup" | "done";
 
 const TAB_LABEL: Record<Tab, string> = {
   all: "全部",
   waiting: "待到貨",
   pickup: "待取貨",
   done: "已完成",
-  void: "不成立",
 };
+
+const HIDDEN_PHASES = new Set(["void", "transferred"]);
 
 export default function OrdersPage() {
   const router = useRouter();
@@ -43,11 +46,13 @@ export default function OrdersPage() {
           callLiffApi<{ orders: OrderRow[] }>(s.token, { action: "list_my_orders", tab: "active" }),
           callLiffApi<{ orders: OrderRow[] }>(s.token, { action: "list_my_orders", tab: "history" }),
         ]);
-        // 「全部」要照時間混排，不是先進行中再歷史
+        // 「全部」要照時間混排，不是先進行中再歷史；隱藏的階段在這裡就過濾掉
         setOrders(
-          [...active.orders, ...history.orders].sort(
-            (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-          ),
+          [...active.orders, ...history.orders]
+            .filter((o) => !HIDDEN_PHASES.has(orderPhase(o).phase))
+            .sort(
+              (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+            ),
         );
       } catch (e) {
         setErr(e instanceof Error ? e.message : String(e));
@@ -58,11 +63,11 @@ export default function OrdersPage() {
   }, [router]);
 
   const buckets = useMemo(() => {
-    const b: Record<Tab, OrderRow[]> = { all: orders, waiting: [], pickup: [], done: [], void: [] };
+    const b: Record<Tab, OrderRow[]> = { all: orders, waiting: [], pickup: [], done: [] };
     for (const o of orders) {
       const { phase } = orderPhase(o);
-      // transferred（已轉讓）沒有自己的分頁，只在「全部」出現（卡片有「已轉讓」標）
-      if (phase !== "transferred") b[phase].push(o);
+      // orders 進來前已濾掉 HIDDEN_PHASES，這裡只剩三個分頁的階段
+      if (phase === "waiting" || phase === "pickup" || phase === "done") b[phase].push(o);
     }
     return b;
   }, [orders]);

--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -1,21 +1,30 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession, loginPath } from "@/lib/session";
 import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
 import { LoadingScreen } from "@/components/Spinner";
 import SubTabs from "@/components/SubTabs";
-import OrderCard, { type OrderRow } from "@/components/OrderCard";
+import OrderCard, { orderPhase, type OrderRow } from "@/components/OrderCard";
 
-type Tab = "pending" | "arrived" | "history";
+// 蝦皮式分頁。我們取貨時付現金，所以沒有「待付款」；「待收貨」＝到店「待取貨」。
+// 分桶跟卡片右上角的狀態字共用 orderPhase()，兩邊永遠一致。
+type Tab = "all" | "waiting" | "pickup" | "done" | "void";
+
+const TAB_LABEL: Record<Tab, string> = {
+  all: "全部",
+  waiting: "待到貨",
+  pickup: "待取貨",
+  done: "已完成",
+  void: "不成立",
+};
 
 export default function OrdersPage() {
   const router = useRouter();
-  const [tab, setTab] = useState<Tab>("pending");
-  const [activeOrders, setActiveOrders] = useState<OrderRow[]>([]);
-  const [historyOrders, setHistoryOrders] = useState<OrderRow[]>([]);
+  const [tab, setTab] = useState<Tab>("all");
+  const [orders, setOrders] = useState<OrderRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
 
@@ -34,8 +43,12 @@ export default function OrdersPage() {
           callLiffApi<{ orders: OrderRow[] }>(s.token, { action: "list_my_orders", tab: "active" }),
           callLiffApi<{ orders: OrderRow[] }>(s.token, { action: "list_my_orders", tab: "history" }),
         ]);
-        setActiveOrders(active.orders);
-        setHistoryOrders(history.orders);
+        // 「全部」要照時間混排，不是先進行中再歷史
+        setOrders(
+          [...active.orders, ...history.orders].sort(
+            (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+          ),
+        );
       } catch (e) {
         setErr(e instanceof Error ? e.message : String(e));
       } finally {
@@ -44,21 +57,30 @@ export default function OrdersPage() {
     })();
   }, [router]);
 
-  const pending = activeOrders.filter((o) => !o.arrived);
-  const arrived = activeOrders.filter((o) => o.arrived);
-  const display = tab === "pending" ? pending : tab === "arrived" ? arrived : historyOrders;
-  const emptyLabel = tab === "pending" ? "未到貨" : tab === "arrived" ? "已到貨" : "已完成";
+  const buckets = useMemo(() => {
+    const b: Record<Tab, OrderRow[]> = { all: orders, waiting: [], pickup: [], done: [], void: [] };
+    for (const o of orders) {
+      const { phase } = orderPhase(o);
+      // transferred（已轉讓）沒有自己的分頁，只在「全部」出現（卡片有「已轉讓」標）
+      if (phase !== "transferred") b[phase].push(o);
+    }
+    return b;
+  }, [orders]);
+
+  const display = buckets[tab];
 
   return (
     <PageShell title="我的訂單">
       <SubTabs
+        variant="scroll"
         value={tab}
         onChange={(v) => setTab(v as Tab)}
-        options={[
-          { value: "pending", label: "未到貨", count: pending.length },
-          { value: "arrived", label: "已到貨", count: arrived.length },
-          { value: "history", label: "訂單紀錄", count: historyOrders.length },
-        ]}
+        options={(Object.keys(TAB_LABEL) as Tab[]).map((t) => ({
+          value: t,
+          label: TAB_LABEL[t],
+          // 「全部」不掛數字；待到貨/待取貨掛數字提醒還有幾筆
+          count: t === "all" || t === "done" ? undefined : buckets[t].length,
+        }))}
       />
 
       <div className="space-y-3 px-4 pt-3 pb-6">
@@ -79,7 +101,7 @@ export default function OrdersPage() {
               📦
             </div>
             <p className="mt-4 text-[16px] font-semibold text-[var(--foreground)]">
-              目前沒有{emptyLabel}訂單
+              {tab === "all" ? "目前沒有訂單" : `目前沒有「${TAB_LABEL[tab]}」的訂單`}
             </p>
           </div>
         )}

--- a/apps/member/src/app/overview/page.tsx
+++ b/apps/member/src/app/overview/page.tsx
@@ -108,6 +108,9 @@ export default function OverviewPage() {
                   ${Number(data.receivable_amount).toLocaleString()}
                 </span>
               </div>
+              <div className="mt-1 text-[12px] text-[var(--tertiary-label)]">
+                已訂購但還沒領走的金額；取貨時付款，領完就不再計入
+              </div>
               {data.active_orders_count > 0 && (
                 <button
                   onClick={() => router.push("/orders")}

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -41,6 +41,41 @@ export type OrderRow = {
   settlement_no: string;
 };
 
+/**
+ * 蝦皮式訂單階段：分頁分桶 + 卡片右上角狀態字共用同一份判定，
+ * 兩邊才不會出現「分在待取貨、標籤卻寫待到貨」。
+ *
+ * 對應（我們取貨付現，沒有「待付款」；「待收貨」＝到店「待取貨」）：
+ *   waiting     待到貨（pending / confirmed，貨還沒到店）
+ *   pickup      待取貨（已到店；partially_completed 剩的也還能取）
+ *   done        已完成
+ *   void        不成立（斷貨取消 / 逾期）
+ *   transferred 已轉讓（轉單給別人，只在「全部」出現）
+ */
+export type OrderPhase = "waiting" | "pickup" | "done" | "void" | "transferred";
+
+export function orderPhase(o: Pick<OrderRow, "status" | "arrived">): {
+  phase: OrderPhase;
+  label: string;
+  className: string;
+} {
+  switch (o.status) {
+    case "cancelled":
+      return { phase: "void", label: "訂單不成立", className: "text-[#c4271d]" };
+    case "expired":
+      return { phase: "void", label: "逾期未取", className: "text-[#c4271d]" };
+    case "transferred_out":
+      return { phase: "transferred", label: "已轉讓", className: "text-[var(--ios-gray)]" };
+    case "completed":
+      return { phase: "done", label: "已完成", className: "text-[var(--brand-strong)]" };
+    case "partially_completed":
+      return { phase: "pickup", label: "部分已取", className: "text-[#b06c00]" };
+  }
+  return o.arrived
+    ? { phase: "pickup", label: "待取貨", className: "text-[#b06c00]" }
+    : { phase: "waiting", label: "待到貨", className: "text-[#b06c00]" };
+}
+
 function fmtAmount(n: number | string | null | undefined): string {
   return Number(n ?? 0).toLocaleString();
 }
@@ -64,15 +99,22 @@ export default function OrderCard({ order }: { order: OrderRow }) {
     0,
   );
   const title = cleanCampaignText(order.campaign_name) || "訂單";
+  const phase = orderPhase(order);
 
   return (
     <article className="card overflow-hidden">
       <header className="bg-[var(--brand-soft)]/35 px-4 pt-4 pb-3">
-        <div className="flex items-center gap-2">
-          <h3 className="min-w-0 truncate text-[18px] font-bold text-[var(--foreground)]">{title}</h3>
-          {order.stockout_at && (
-            <StatusChip tone="danger" label="斷貨" />
-          )}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <h3 className="min-w-0 truncate text-[18px] font-bold text-[var(--foreground)]">{title}</h3>
+            {order.stockout_at && (
+              <StatusChip tone="danger" label="斷貨" />
+            )}
+          </div>
+          {/* 蝦皮式右上角狀態字 */}
+          <span className={`flex-shrink-0 text-[14px] font-medium ${phase.className}`}>
+            {phase.label}
+          </span>
         </div>
         {order.stockout_at && (
           <p className="mt-1 text-[13px] text-[#c4271d]">

--- a/apps/member/src/components/SettlementCard.tsx
+++ b/apps/member/src/components/SettlementCard.tsx
@@ -18,6 +18,8 @@ export type SettlementRow = {
   shipping_fee: number;
   discount_amount: number;
   payable_amount: number;
+  /** 還沒領走的金額（@20260810000000）；0 = 貨都領完了 = 現金都收了 */
+  outstanding_amount?: number;
 };
 
 function fmtAmount(n: number): string {
@@ -40,7 +42,11 @@ function Row({
 }
 
 export default function SettlementCard({ settlement: s }: { settlement: SettlementRow }) {
-  const paid = s.payment_status === "paid";
+  // payment_status 全站從來沒被寫成 'paid'（取貨當下收現金，不回寫欄位），
+  // 只看它會讓每一張已取貨的單都掛「未付款」。以「還有沒有貨沒領」為準。
+  const paid =
+    s.payment_status === "paid" ||
+    (s.outstanding_amount != null && Number(s.outstanding_amount) <= 0);
   const shipped = ["shipping", "completed"].includes(s.status);
 
   return (

--- a/apps/member/src/components/SubTabs.tsx
+++ b/apps/member/src/components/SubTabs.tsx
@@ -5,16 +5,54 @@ type Option = { value: string; label: string; count?: number };
 /**
  * iOS-style segmented control。
  * 整體放在 #767680 ~12% alpha 的灰色 track 上，選中項是白色帶 shadow。
+ *
+ * variant="scroll"：蝦皮式底線分頁（可橫向捲動），給 4 個以上分頁用 ——
+ * segmented control 塞 5 個在小螢幕會擠爆。
  */
 export default function SubTabs({
   value,
   onChange,
   options,
+  variant = "segment",
 }: {
   value: string;
   onChange: (v: string) => void;
   options: Option[];
+  variant?: "segment" | "scroll";
 }) {
+  if (variant === "scroll") {
+    return (
+      <div className="overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div className="flex min-w-max gap-1 border-b border-[var(--separator)] px-2">
+          {options.map((o) => {
+            const active = value === o.value;
+            return (
+              <button
+                key={o.value}
+                onClick={() => onChange(o.value)}
+                className={`relative whitespace-nowrap px-3 py-2.5 text-[15px] transition-colors duration-150 ${
+                  active
+                    ? "font-bold text-[var(--brand-strong)]"
+                    : "font-medium text-[var(--ios-gray)]"
+                }`}
+              >
+                {o.label}
+                {o.count !== undefined && o.count > 0 && (
+                  <span className={`ml-0.5 text-[13px] ${active ? "text-[var(--brand-strong)]/70" : "text-[var(--ios-gray)]/70"}`}>
+                    {o.count}
+                  </span>
+                )}
+                {active && (
+                  <span className="absolute inset-x-3 bottom-0 h-[2.5px] rounded-full bg-[var(--brand-strong)]" />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="px-4 pt-3">
       <div className="flex rounded-[10px] bg-[#7676801f] p-[2px]">

--- a/docs/TEST-LIFF-overview-orders-settlements.md
+++ b/docs/TEST-LIFF-overview-orders-settlements.md
@@ -41,8 +41,8 @@
 | T3-1 | `curl POST /functions/v1/liff-api { action: "get_overview" }` 用會員 A、A 店 token | 200，回 `{store: {...}, receivable_amount, active_orders_count}` |
 | T3-2 | T3-1 回應的 store.id | = JWT 中的 store_id |
 | T3-3 | T3-1 回應的 store 必含欄位 | id, code, name, banner_url, description, payment_methods_text, shipping_methods_text |
-| T3-4 | T3-1 回應的 receivable_amount | = SUM(payable_amount) WHERE payment_status='unpaid' AND status NOT IN ('cancelled','expired') for that member+store |
-| T3-5 | active_orders_count | = COUNT(*) WHERE status NOT IN ('completed','cancelled','expired') |
+| T3-4 | T3-1 回應的 receivable_amount | = SUM(outstanding_amount) WHERE outstanding_amount > 0 for that member（跨店，@20260810000000。**不可以**用 payment_status='unpaid'，見 `TEST-member-receivable-unpicked.md`） |
+| T3-5 | active_orders_count | = COUNT(*) WHERE status NOT IN ('completed','cancelled','expired','transferred_out') |
 | T3-6 | 不帶 Authorization | 401 missing authorization |
 | T3-7 | 帶過期 / 偽造 JWT | 401 invalid token |
 

--- a/docs/TEST-member-receivable-unpicked.md
+++ b/docs/TEST-member-receivable-unpicked.md
@@ -1,0 +1,87 @@
+# TEST — 會員端「未結單金額」只算已訂未領貨
+
+對應 migration：`20260810000000_receivable_exclude_picked_up.sql`
+對應程式：`supabase/functions/liff-api/index.ts`（`get_overview` / `list_my_settlements`）、
+`apps/member/src/components/SettlementCard.tsx`、`apps/member/src/app/me|overview/page.tsx`
+
+## 背景（回報案例）
+
+團友回報「未到貨總金額跟實際內容出入很大」，4 位會員：
+
+| 會員 | 畫面顯示（舊） | 逐張加總（實際未領） |
+|------|---------------|--------------------|
+| 528590 | $3,072 | $1,110 |
+| 581086 | $6,336 | $1,421 |
+| 160806 | $5,280 | $1,808 |
+| 091207 | $9,700 | $4,171 |
+
+根因：`get_overview` 用 `payment_status='unpaid'` 當「還沒收錢」的條件，
+但這個欄位全站**從來沒有被寫成 `'paid'` 過**（取貨當下收現金，`rpc_record_pickup`
+不回寫），等於沒過濾 → 把所有取過貨的舊訂單一路累加。
+
+---
+
+## A — 資料前提（跑之前先確認，這是整個 bug 的根）
+
+| # | SQL | 預期 |
+|---|-----|------|
+| A-1 | `SELECT payment_status, count(*) FROM customer_orders GROUP BY 1;` | 只有 `unpaid` 一列。**只要這裡沒有 `paid`，任何拿 payment_status 判斷收款的程式都是錯的** |
+| A-2 | `SELECT status, count(*) FROM customer_order_items GROUP BY 1;` | 有 `pending` / `picked_up` / `cancelled`（/`ready`）；`picked_up` = 已收現金 |
+
+## B — view 欄位
+
+| # | SQL | 預期 |
+|---|-----|------|
+| B-1 | `SELECT id, items_total, unpicked_total, payable_amount, outstanding_amount FROM v_customer_order_summary LIMIT 1;` | 4 欄都在，不報錯 |
+| B-2 | 挑一張 `status='completed'`（品項全 `picked_up`） | `unpicked_total=0`、`outstanding_amount=0`、`payable_amount` 不變（仍是原訂單金額） |
+| B-3 | 挑一張 `status='confirmed'`（品項全 `pending`） | `outstanding_amount = payable_amount` |
+| B-4 | 挑一張 `status='partially_completed'` | `0 < outstanding_amount < payable_amount`，且 `unpicked_total` = 未取品項小計 |
+| B-5 | `SELECT count(*) FROM v_customer_order_summary WHERE status IN ('cancelled','expired','transferred_out') AND outstanding_amount <> 0;` | `0`（終態一律 0；`transferred_out` 的品項還留在原單且是 `pending`，不歸零會跟新單重複計算） |
+| B-6 | `SELECT count(*) FROM v_customer_order_summary WHERE outstanding_amount > payable_amount;` | `0` |
+| B-7 | 挑一張「剩下沒取的都退回總倉」的單（`returned_deduction >= unpicked_total`） | `outstanding_amount=0`（貨退了就不該收錢） |
+
+## C — 回歸：4 位回報會員
+
+```sql
+SELECT m.id, m.name,
+       SUM(v.outstanding_amount) AS new_amt,
+       SUM(v.payable_amount) FILTER (
+         WHERE v.payment_status='unpaid' AND v.status NOT IN ('cancelled','expired')
+       ) AS old_amt
+  FROM members m
+  JOIN v_customer_order_summary v ON v.member_id = m.id
+ WHERE m.id IN (67982, 68270, 67958, 69032)
+ GROUP BY 1,2;
+```
+
+預期 `new_amt` 分別為 1110 / 1421 / 1808 / 4171（= 上表右欄），
+`old_amt` 為 3072 / 6336 / 5280 / 9700（= 團友截圖那些數字）。
+
+## D — Edge Function
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| D-1 | `POST /functions/v1/liff-api {"action":"get_overview"}`（會員 528590 的 token） | `receivable_amount = 1110` |
+| D-2 | 同上 | `active_orders_count = 7` |
+| D-3 | `{"action":"list_my_orders","tab":"active"}` 逐張 `payable_amount` 加總 | = D-1 的 `receivable_amount`（**這就是團友做的驗算，兩邊必須一致**） |
+| D-4 | `{"action":"list_my_settlements","tab":"unpaid"}` | 只回還有沒領走的貨的單；已全部取貨的舊單不出現 |
+| D-5 | 不帶 Authorization | 401 missing authorization（確認函式真的有部署，不是 gateway 404） |
+
+## E — 會員端畫面
+
+| # | 步驟 | 預期 |
+|---|------|------|
+| E-1 | 會員中心 `/me` | 「未結單金額」= D-1 的數字，下方有一行「已訂購但還沒領走的金額；取貨時付款，領完就不再計入」 |
+| E-2 | 點「進行中訂單 N 筆」進 `/orders` | 逐張「應付金額」加總 = E-1 的數字 |
+| E-3 | 取貨一張單之後重新整理 `/me` | 未結單金額**下降**該單金額；筆數 −1 |
+| E-4 | 部分取貨（partially_completed）後 | 未結單金額只扣掉已取走的那部分 |
+| E-5 | `/settlements` 的「待付款」分頁 | 已取貨的單不再出現；卡片上的「已付款 / 未付款」標依「還有沒有貨沒領」判定 |
+
+## 已知限制（不在本次修復範圍）
+
+- `payment_status` 仍然是全站 `unpaid`，本次只是**不再拿它當收款依據**。
+  若之後要做「取貨時記錄實收現金」，應在 `rpc_record_pickup` 回寫
+  `payment_status` / `paid_at`，屆時 `outstanding_amount` 需再把「已付款但還沒領」
+  的情況納入。
+- 匯款 / 宅配（`remit_amount`、`shipping_method`）目前線上都是 0 筆使用，
+  未取貨即付款的情境沒有實測資料。

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -316,9 +316,14 @@ async function getOverview(sb: any, tenantId: string, storeId: number, memberId:
   // 未結金額 / 進行中筆數依 member_id 會員級加總，不依 store_id 過濾：
   // member_id 是 tenant 級、訂單 pickup 店可不同於登入店，需與 listMyOrders（跨店）一致，
   // 否則訂單列表看得到、overview 金額卻 0。
-  const { data: unpaidRows } = await sb.from("v_customer_order_summary").select("payable_amount").eq("tenant_id", tenantId).eq("member_id", memberId).eq("payment_status", "unpaid").not("status", "in", "(cancelled,expired)");
-  const receivable = (unpaidRows ?? []).reduce((s: number, r: any) => s + Number(r.payable_amount ?? 0), 0);
-  const { count: activeCount } = await sb.from("v_customer_order_summary").select("*", { count: "exact", head: true }).eq("tenant_id", tenantId).eq("member_id", memberId).not("status", "in", "(completed,cancelled,expired)");
+  // 「未結單金額」＝ 已訂未領貨 = SUM(outstanding_amount)（@20260810000000）。
+  // 不可以用 payment_status='unpaid' 當條件 —— 那個欄位全站從來沒被寫成 'paid'
+  // （取貨收現金，rpc_record_pickup 不碰它），等於沒過濾，會把早就取走的訂單
+  // 一路累加上去（回報案例：顯示 $3,072、實際未領只有 $1,110）。
+  const { data: unpaidRows } = await sb.from("v_customer_order_summary").select("outstanding_amount").eq("tenant_id", tenantId).eq("member_id", memberId).gt("outstanding_amount", 0);
+  const receivable = (unpaidRows ?? []).reduce((s: number, r: any) => s + Number(r.outstanding_amount ?? 0), 0);
+  // transferred_out（轉手給別人）的品項仍留在原單且維持 pending，貨已經在新單上 → 不算進行中。
+  const { count: activeCount } = await sb.from("v_customer_order_summary").select("*", { count: "exact", head: true }).eq("tenant_id", tenantId).eq("member_id", memberId).not("status", "in", "(completed,cancelled,expired,transferred_out)");
   return json({ store: storeRow, receivable_amount: receivable, active_orders_count: activeCount ?? 0 });
 }
 
@@ -354,7 +359,9 @@ async function listMySettlements(sb: any, tenantId: string, _storeId: number, me
   const cutoff = new Date(); cutoff.setMonth(cutoff.getMonth() - 6);
   // 同 listMyOrders：跨店訂單都納入（OrderCard 顯示 store_name）。
   let q = sb.from("v_customer_order_summary").select("*").eq("tenant_id", tenantId).eq("member_id", memberId).gte("created_at", cutoff.toISOString()).order("created_at", { ascending: false }).limit(100);
-  if (tab === "unpaid") q = q.eq("payment_status", "unpaid").not("status", "in", "(cancelled,expired)");
+  // 「待付款」＝ 還有沒領走的貨（同 getOverview 的口徑，@20260810000000）。
+  // 同樣不能用 payment_status='unpaid'：那會把所有已取貨的舊單一起列出來。
+  if (tab === "unpaid") q = q.gt("outstanding_amount", 0);
   else q = q.in("status", ["shipping", "completed"]);
   const { data, error } = await q;
   if (error) return json({ error: error.message }, 500);

--- a/supabase/migrations/20260810000000_receivable_exclude_picked_up.sql
+++ b/supabase/migrations/20260810000000_receivable_exclude_picked_up.sql
@@ -1,0 +1,252 @@
+-- ============================================================
+-- 2026-08-10: 會員端「未結單金額」只算「已訂未領貨」，不再把取過的貨一直掛帳
+--
+-- 回報案例（多位團友，會員 528590 / 581086 / 160806 / 091207）：
+--   528590 的會員中心顯示「未結單金額 $3,072」，但同一頁點進「進行中訂單
+--   7 筆」逐張加總只有 $1,110。581086 顯示 6,336 / 實際 1,421，
+--   160806 顯示 5,280 / 實際 1,808，091207 顯示 9,700 / 實際 4,171。
+--
+-- 根因：liff-api getOverview 的「未結」定義是
+--     payment_status = 'unpaid' AND status NOT IN ('cancelled','expired')
+--   但 payment_status 這個欄位在這套系統裡**從來沒有被寫成 'paid' 過**
+--   （現金在門市取貨當下收，rpc_record_pickup 不碰 payment_status；
+--    唯一會寫 'paid' 的 rpc_wallet_pay_order 目前線上 0 筆使用）：
+--
+--     SELECT payment_status, count(*) FROM customer_orders GROUP BY 1;
+--       unpaid | 65297      ← 全部，一筆 'paid' 都沒有
+--
+--   所以那個條件等於沒有條件，「未結單金額」實際上是
+--   **這位會員從開站到現在所有沒被取消的訂單總和** —— 早就取貨付現的
+--   23,731 張 completed 訂單全都還掛在上面，而且只會愈積愈多。
+--   全站被多算的金額 = NT$4,822,464（1,745 位會員）。
+--
+-- 修法：不要再用 payment_status 當「有沒有收到錢」的依據，改用**品項有沒有
+--   被取走**。取貨 = 付款（現金當場收），所以
+--     未結 = 尚未取貨的品項金額
+--   品項層級才算得準：partially_completed（取一半）那 69 張，用訂單層級
+--   算會把已取走的那半也算進去。
+--
+--   新增兩個欄位到 v_customer_order_summary：
+--     unpicked_total      尚未取貨的品項小計（排除 picked_up / cancelled / expired）
+--     outstanding_amount  這張單真正還沒收的錢（unpicked_total 套用退貨扣減 /
+--                         折扣 / 運費 / 已扣儲值金；終態訂單一律 0）
+--
+--   終態訂單（cancelled / expired / transferred_out）一律回 0：
+--   transferred_out 的品項在轉手後**仍留在原單且維持 pending**
+--   （見 20260507000000），貨已經在新單上，不歸零會整批重複計算
+--   （線上 115 張、$29,560）。
+--
+--   items_total / payable_amount **語意不變** —— 那是「這張單本身多少錢」，
+--   訂單明細、結單、admin 都在用；本次只是另外給「還沒收的部分」一個欄位。
+--
+-- 驗證（member 67982 = 528590）：
+--   SUM(outstanding_amount) = 1110  ← 與「進行中訂單 7 筆」逐張加總一致
+--   舊算法                  = 3072  ← 團友截圖那個數字
+--
+-- 基底版本（append-only，逐字保留所有 prior fix）：
+--   v_customer_order_summary：20260808000010_payable_exclude_cancelled_items.sql
+--   （逐字保留，僅 agg LATERAL 加 unpicked_total、SELECT 清單加兩欄）
+--
+-- Rollback：v_customer_order_summary 還原為 20260808000010 版本
+--   （前端 / liff-api 需一併回退，它們會 select outstanding_amount）
+--
+-- 對應程式（同一個 commit）：
+--   supabase/functions/liff-api/index.ts
+--     - getOverview：receivable 改加總 outstanding_amount，
+--       active_orders_count 一併排除 transferred_out
+--     - listMySettlements（tab=unpaid）：改用 outstanding_amount > 0
+--   apps/member/src/components/SettlementCard.tsx（已付款判定）
+--   apps/member/src/app/me/page.tsx、overview/page.tsx（加一行文案說明口徑）
+-- ============================================================
+
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.discount_percent,
+  co.wallet_paid_amount,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  co.stockout_at,
+  agg.items_total,
+  agg.unpicked_total,
+  ret.returned_qty,
+  ret.returned_deduction,
+  GREATEST(
+    0,
+    ROUND(
+      GREATEST(0, agg.items_total - ret.returned_deduction)
+        * (1 - co.discount_percent / 100)
+        + co.shipping_fee
+        - co.discount_amount,
+      0
+    )
+  )                                                                            AS payable_amount,
+  GREATEST(
+    0,
+    GREATEST(
+      0,
+      ROUND(
+        GREATEST(0, agg.items_total - ret.returned_deduction)
+          * (1 - co.discount_percent / 100)
+          + co.shipping_fee
+          - co.discount_amount,
+        0
+      )
+    ) - co.wallet_paid_amount
+  )                                                                            AS balance_due,
+  -- 20260810000000：還沒收的錢 = 尚未取貨品項套同一條應收算式，再扣掉已付的儲值金。
+  -- 終態訂單（cancelled / expired / transferred_out）與「已全部取走」一律 0；
+  -- 全取走時直接回 0，不讓運費 / 折扣在沒有貨的情況下自己長出金額。
+  CASE
+    WHEN co.status IN ('cancelled','expired','transferred_out') THEN 0
+    WHEN agg.unpicked_total <= 0                                THEN 0
+    ELSE GREATEST(
+      0,
+      GREATEST(
+        0,
+        ROUND(
+          GREATEST(0, agg.unpicked_total - ret.returned_deduction)
+            * (1 - co.discount_percent / 100)
+            + co.shipping_fee
+            - co.discount_amount,
+          0
+        )
+      ) - co.wallet_paid_amount
+    )
+  END                                                                          AS outstanding_amount,
+  agg.items,
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','shipping','completed'))                AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))            AS settled,
+  (co.payment_status = 'paid')                                                 AS paid,
+  (co.status IN ('shipping','completed'))                                      AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                 AS settlement_no,
+  s.name                                                                        AS store_name,
+  s.code                                                                        AS store_code,
+  gbc.name                                                                      AS campaign_name,
+  gbc.cover_image_url                                                           AS campaign_cover_url,
+  gbc.end_at                                                                    AS campaign_end_at,
+  gbc.cutoff_date                                                               AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price)
+               FILTER (WHERE coi.status NOT IN ('cancelled','expired')), 0)  AS items_total,
+    -- 20260810000000：尚未取貨的部分（picked_up 也排掉）。取貨當下收現金，
+    -- 所以「取走了」＝「收到錢了」，不該再算在未結裡。
+    COALESCE(SUM(coi.qty * coi.unit_price)
+               FILTER (WHERE coi.status NOT IN ('cancelled','expired','picked_up')), 0)
+                                                                              AS unpicked_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'sku_code',         sk.sku_code,
+          'product_name',     sk.product_name,
+          'variant_name',     sk.variant_name,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'subtotal',         coi.qty * coi.unit_price,
+          'status',           coi.status,
+          'stockout',         (coi.stockout_at IS NOT NULL),
+          'notes',            coi.notes,
+          'image_url',        CASE
+            WHEN jsonb_typeof(p.images) = 'array' AND jsonb_array_length(p.images) > 0 THEN
+              COALESCE(p.images -> 0 ->> 'url', p.images ->> 0)
+            ELSE NULL
+          END
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                           AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus     sk ON sk.id = coi.sku_id
+  LEFT JOIN products p  ON p.id  = sk.product_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE
+LEFT JOIN LATERAL (
+  -- 未取退貨扣減：return_to_hq（shipped/received、notes header 不含
+  -- |取貨後退回）依 SKU 聚合退貨量，按品項行序 (id) 分攤到未取消品項行、
+  -- 以該行 unit_price 折算金額
+  SELECT
+    COALESCE(SUM(a.alloc_qty), 0)                AS returned_qty,
+    COALESCE(SUM(a.alloc_qty * a.unit_price), 0) AS returned_deduction
+  FROM (
+    SELECT
+      i.unit_price,
+      LEAST(i.qty, GREATEST(r.ret_qty - i.prior_qty, 0)) AS alloc_qty
+    FROM (
+      SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+        FROM transfers t
+        JOIN transfer_items ti ON ti.transfer_id = t.id
+       WHERE t.customer_order_id = co.id
+         AND t.tenant_id     = co.tenant_id
+         AND t.transfer_type = 'return_to_hq'
+         AND t.status IN ('shipped','received')
+         AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+             NOT LIKE '%取貨後退回%'
+       GROUP BY ti.sku_id
+    ) r
+    JOIN (
+      SELECT coi.sku_id, coi.qty, coi.unit_price,
+             COALESCE(SUM(coi.qty) OVER (
+               PARTITION BY coi.sku_id ORDER BY coi.id
+               ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+             ), 0) AS prior_qty
+        FROM customer_order_items coi
+       WHERE coi.order_id = co.id
+         AND coi.status NOT IN ('cancelled','expired')
+    ) i ON i.sku_id = r.sku_id
+  ) a
+) ret ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細 + percent + amount 雙折扣 + 儲值金抵扣 + balance_due'
+  '（應收已四捨五入到整數 NTD）+ 斷貨標記（stockout_at / items[].stockout）'
+  '+ 未取退貨扣減（returned_qty / returned_deduction；取貨後退回不扣、退款走 rpc_wallet_partial_refund）'
+  '。20260808000010：items_total 不含 cancelled/expired 品項（斷貨 / 人工刪除的品項不收錢）；'
+  'items[] 仍保留這些行供前端顯示「斷貨」。'
+  '20260810000000：新增 unpicked_total / outstanding_amount —— 會員端「未結單金額」'
+  '（已訂未領貨）專用，取貨即收現金，所以 picked_up 品項不算；'
+  'cancelled/expired/transferred_out 訂單一律 0。payment_status 全站從未寫過 ''paid''，'
+  '不可以拿來當「有沒有收到錢」的依據。';
+
+-- DROP + CREATE 會清掉 grant。public schema 的 default privileges 本來就會補回
+-- anon/authenticated/service_role（20260731000000 沒寫 GRANT 也活著），這裡明寫一行
+-- 當保險，不依賴 default privileges 的設定沒被動過。
+GRANT SELECT ON v_customer_order_summary TO authenticated, anon;


### PR DESCRIPTION
團友回報會員中心的「未結單金額」跟逐張加總差很多（528590 顯示 $3,072、
實際只有 $1,110；581086 6,336/1,421、160806 5,280/1,808、091207 9,700/4,171）。

根因：get_overview 用 payment_status='unpaid' 當「還沒收錢」的條件，但這個
欄位全站從來沒被寫成 'paid'（現金在取貨當下收，rpc_record_pickup 不回寫，
唯一會寫的 rpc_wallet_pay_order 線上 0 筆使用）——
SELECT payment_status, count(*) FROM customer_orders GROUP BY 1 只有 unpaid 一列。
那個條件等於沒有條件，所以顯示的是「這位會員開站至今所有沒被取消的訂單總和」，
早就取貨付現的 23,731 張還全掛在上面，全站多算 NT$4,822,464。

改用品項有沒有被取走來算：

- v_customer_order_summary 新增 unpicked_total / outstanding_amount
  （排除 picked_up/cancelled/expired 品項；cancelled/expired/transferred_out
  訂單一律 0 —— transferred_out 的品項留在原單且維持 pending，貨已在新單上）。
  items_total / payable_amount 語意不變。
- liff-api get_overview 改加總 outstanding_amount；active_orders_count
  一併排除 transferred_out。list_my_settlements 的「待付款」同口徑。
- SettlementCard 的已付款判定改看還有沒有貨沒領。
- /me 與 /overview 的金額下方補一行口徑說明，避免同樣的誤會再發生。

驗證：4 位回報會員的新數字與各自「進行中訂單」逐張加總完全一致。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CnVpvNB1AUnLBcRVo3mVKX