### PR TITLE
fix(admin): 配對前確認兩邊名字，配錯可在畫面上解除綁定

### DIFF
--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -350,8 +350,31 @@ export function LineMessageModal({
           </div>
         )}
         {reachable.state === "ok" && (
-          <div className="rounded-md border border-emerald-200 bg-emerald-50 p-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300">
-            ✓ 可發送{reachable.displayName ? `（LINE 名稱：${reachable.displayName}）` : ""}
+          <div className="flex items-center justify-between gap-2 rounded-md border border-emerald-200 bg-emerald-50 p-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300">
+            <span>✓ 可發送{reachable.displayName ? `（LINE 名稱：${reachable.displayName}）` : ""}</span>
+            <SpinButton
+              onClick={async () => {
+                if (!window.confirm(`解除「${reachable.displayName ?? "此 LINE 身分"}」與這位會員的綁定？（配對錯人時用）`)) return;
+                const { error: uErr } = await getSupabase().rpc("rpc_unbind_store_line_follower", { p_member_id: member.id });
+                if (uErr) { setError(uErr.message); return; }
+                // 解除後重新預檢，畫面翻回「推不到 + 配對選單」
+                setReachable({ state: "checking" });
+                const { result } = await callFn({ action: "check", member_id: member.id });
+                if (result.ok && result.reachable) setReachable({ state: "ok", displayName: result.display_name ?? null });
+                else setReachable({ state: "unreachable", message: result.message ?? "尚未綁定" });
+                if (homeStoreId != null) {
+                  const { data } = await getSupabase()
+                    .from("store_line_followers")
+                    .select("line_user_id, display_name, picture_url")
+                    .eq("store_id", homeStoreId).is("member_id", null).eq("followed", true).limit(50);
+                  setFollowers((data as Follower[]) ?? []);
+                }
+              }}
+              title="配對錯人時，解除後可重新從名冊挑選"
+              className="shrink-0 rounded border border-emerald-300 px-2 py-0.5 text-[11px] text-emerald-700 hover:bg-emerald-100 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-900"
+            >
+              解除綁定
+            </SpinButton>
           </div>
         )}
         {reachable.state === "unreachable" && (
@@ -394,6 +417,8 @@ export function LineMessageModal({
                   key={f.line_user_id}
                   disabled={binding}
                   onClick={async () => {
+                    // 人工配對點錯過（2026-08-10 平鎮兩筆）— 綁定前把兩個名字並列確認
+                    if (!window.confirm(`把 LINE「${f.display_name ?? f.line_user_id.slice(0, 8)}」綁定為會員「${member.name ?? member.member_no}」？`)) return;
                     setBinding(true);
                     try {
                       const { error } = await getSupabase().rpc("rpc_bind_store_line_follower", {

--- a/supabase/migrations/20260810000010_rpc_unbind_store_line_follower.sql
+++ b/supabase/migrations/20260810000010_rpc_unbind_store_line_follower.sql
@@ -1,0 +1,55 @@
+-- ============================================================================
+-- 2026-08-10: 解除會員的 LINE 名冊綁定
+--
+-- 背景：配對是人工從名冊挑的，會點錯（2026-08-10 平鎮店實際發生兩筆，
+-- 相隔一分鐘 —— 錯的綁定 = 訊息發給錯的顧客）。錯了之後畫面上原本沒有
+-- 任何解法，只能進資料庫改。這支讓店員自己解。
+--
+-- 角色與範圍完全對齊 rpc_bind_store_line_follower（20260808000020 版）：
+-- 分店角色只能動自己店的會員。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_unbind_store_line_follower(
+  p_member_id BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_store  BIGINT;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq','hq_manager','store_manager','store_staff','') THEN
+    RAISE EXCEPTION 'insufficient_role';
+  END IF;
+
+  SELECT home_store_id INTO v_store
+    FROM members WHERE id = p_member_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'member_not_found'; END IF;
+  IF v_store IS NULL THEN RAISE EXCEPTION 'member_has_no_store'; END IF;
+
+  IF v_role IN ('store_manager','store_staff') AND NOT EXISTS (
+    SELECT 1 FROM stores s
+    WHERE s.id = v_store AND s.tenant_id = v_tenant
+      AND s.name IN (SELECT jsonb_array_elements_text(auth.jwt() -> 'app_metadata' -> 'stores'))
+  ) THEN
+    RAISE EXCEPTION 'wrong_store: 只能解除自己店的會員';
+  END IF;
+
+  UPDATE store_line_followers
+     SET member_id = NULL, linked_at = NULL
+   WHERE tenant_id = v_tenant AND store_id = v_store AND member_id = p_member_id;
+
+  IF NOT FOUND THEN
+    -- 沒有名冊綁定 → 「可發送」是來自舊登入資料（members.line_user_id），
+    -- 那不是這支能解的，讓前端把話說清楚
+    RAISE EXCEPTION 'no_binding: 此會員沒有名冊綁定，顯示的 LINE 身分來自舊登入資料';
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_unbind_store_line_follower(BIGINT) IS
+  '解除會員在其所屬分店的 LINE 名冊綁定（配對錯了用；分店角色限自己店）';
+
+REVOKE ALL ON FUNCTION public.rpc_unbind_store_line_follower(BIGINT) FROM anon;


### PR DESCRIPTION
接續 #654（此 commit 推送時 #654 已合併，故另開）。

## 背景

2026-08-10 平鎮店實際發生兩筆配對錯人（相隔一分鐘，人工從名冊點錯）——「二寶媽001498-平鎮2」被綁成 LINE「珊瑪」、「美娥姐521135-平鎮」被綁成「洪逸榛」。錯的綁定 = 訊息發給錯的顧客，而畫面上原本**沒有任何解法**，只能進資料庫改。兩筆已當場解除。

## 修正

- **綁定前確認**：點名冊人名先跳 confirm，兩邊名字並列 —「把 LINE『珊瑪』綁定為會員『二寶媽001498-平鎮2』？」
- **畫面上可解綁**：「✓ 可發送」列新增「解除綁定」，解除後自動重新預檢並帶回配對選單重挑
- 新 RPC `rpc_unbind_store_line_follower`：角色與範圍完全對齊 bind（分店角色限自己店）。沒有名冊綁定時回 `no_binding` 並說明「顯示的身分來自舊登入資料」— 那不是這支能解的

migration 已套用到線上。

## 驗證（灌 claims 模擬）

| 動作 | 結果 |
|---|---|
| 店長解除自己店會員的綁定 | ✅ 成功 |
| 解除沒有綁定的會員 | ✅ 回 `no_binding` 並說明來源 |
| 平鎮兩筆錯誤綁定 | ✅ 已解除，退回未配對名單 |
| 松山 Alex Chen 解除後重綁 | ✅ 回復正確配對 |

admin typecheck 與 ESLint 乾淨。

---
_Generated by [Claude Code](https://claude.ai/code/session_01B51QThXsMUzMwjyAqrHYVi)_