### PR TITLE
fix(member): 貨沒到不要顯示「待取貨」；應付總金額別再把取過的貨掛帳

### DIFF
--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -36,20 +36,36 @@ function fmtAmount(n: number): string {
 /**
  * 一個分頁的金額加總。
  *
+ * 「應付」一律用 outstanding_amount（＝還沒領走的貨），**不可以用 payable_amount**。
+ * 取貨當下就收現金，已取貨的單早就付清了，payable_amount 是「這張單本身多少錢」，
+ * 不是「還欠多少」。2026-08-11 團友 528204 的災情：「全部」分頁把 27 張已完成
+ * ($4,137) 加上 1 張部分取貨已領走的那半 ($98) 一起算進「應付總金額」，
+ * 顯示 $8,771、實際只欠 $4,536，團友焦慮到打電話進來。
+ * 這跟會員中心「未結單金額」是同一個坑 —— DB 早在 20260810000000 就備好
+ * outstanding_amount，那次只修了 /me，這張總金額卡漏掉。
+ *
+ * 「已完成」分頁例外：那裡問的是「這些單總共多少錢」（歷史金額），
+ * 全部都取走了 outstanding 一律是 0，所以用 payable_amount。
+ *
  * 排除 cancelled / expired 的訂單：「全部」分頁刻意保留斷貨整單取消的訂單讓客人
  * 看得到（也有自己的「不成立」分頁），那種單不用付錢，算進去總金額就會跟每張卡上的
  * 應付金額加起來對不上；「不成立」分頁全是這種單，count=0 → 總金額卡整張不顯示。
  * 品項層級的斷貨排除已經在 DB 做掉了（20260808000010），這裡只要顧單頭。
  */
-function sumOrders(list: OrderRow[]) {
+function sumOrders(list: OrderRow[], tab: Tab) {
   const active = list.filter((o) => !["cancelled", "expired"].includes(String(o.status ?? "")));
+  const historical = tab === "done";
   return {
     count: active.length,
-    payable: active.reduce((s, o) => s + Number(o.payable_amount ?? 0), 0),
-    // balance_due = 應付 − 已扣儲值金。舊版 edge function 沒回這欄時退回「沒付款就是全額」。
-    unpaid: active.reduce(
-      (s, o) => s + Number(o.balance_due ?? (o.paid ? 0 : o.payable_amount) ?? 0),
+    amount: active.reduce(
+      (s, o) =>
+        s + Number((historical ? o.payable_amount : o.outstanding_amount) ?? o.payable_amount ?? 0),
       0,
+    ),
+    // 這個分頁裡有沒有「已經領走一部分（或全部）」的單 —— 有的話總金額不等於
+    // 各卡的應付金額相加，要在副標講清楚，不然團友手動加總又會對不上。
+    hasPicked: active.some(
+      (o) => Number(o.outstanding_amount ?? o.payable_amount ?? 0) < Number(o.payable_amount ?? 0),
     ),
   };
 }
@@ -108,7 +124,7 @@ export default function OrdersPage() {
   const display = bucket.slice(0, visible);
   const hasMore = bucket.length > visible;
   // 總金額卡照整個分頁算，不是只算已渲染的 10 筆
-  const totals = sumOrders(bucket);
+  const totals = sumOrders(bucket, tab);
 
   // 捲到底自動載入下一頁（sentinel 進到視窗下方 300px 內就先載，捲起來無縫）
   const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -155,16 +171,16 @@ export default function OrdersPage() {
               </div>
               <div className="mt-0.5 text-[13px] text-[var(--secondary-label)]">
                 共 {totals.count} 筆訂單
-                {totals.unpaid > 0 && totals.unpaid !== totals.payable && (
+                {tab !== "done" && totals.hasPicked && (
                   <>
                     <span className="mx-1.5 text-[var(--tertiary-label)]">·</span>
-                    尚未付款 ${fmtAmount(totals.unpaid)}
+                    已取貨的不計（取貨時付現）
                   </>
                 )}
               </div>
             </div>
             <span className="flex-shrink-0 text-[26px] font-semibold tabular-nums text-[var(--brand-strong)]">
-              ${fmtAmount(totals.payable)}
+              ${fmtAmount(totals.amount)}
             </span>
           </div>
         )}

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -24,8 +24,14 @@ export type OrderRow = {
   stockout_at?: string | null;
   pickup_deadline: string | null;
   payable_amount: number;
-  /** 應付 − 已用儲值金扣抵；v_customer_order_summary 有給，訂單列表的「尚未付款」用它加總 */
+  /** 應付 − 已用儲值金扣抵；v_customer_order_summary 有給 */
   balance_due?: number;
+  /**
+   * 這張單真正還沒收的錢＝尚未取貨的品項（20260810000000）。取貨當下收現金，
+   * 所以「已取走」＝「已付清」。訂單列表的「應付總金額」用它加總，
+   * 不可以用 payable_amount —— 那是「這張單本身多少錢」，會把取過的貨一直掛帳。
+   */
+  outstanding_amount?: number;
   items_total: number;
   shipping_fee: number;
   discount_amount: number;
@@ -107,6 +113,14 @@ export default function OrderCard({ order }: { order: OrderRow }) {
   );
   const title = cleanCampaignText(order.campaign_name) || "訂單";
   const phase = orderPhase(order);
+  // 已經領走一部分（取貨當場收現金）→ 這張單真正還要付的是 outstanding_amount。
+  // 只在「領了一部分、還剩一部分」時才多畫一行：全部領完 / 取消的單 outstanding=0，
+  // 那些維持原本單一「應付金額」的樣子。沒有這欄的舊 payload 也走原本的樣子。
+  const outstanding = Number(order.outstanding_amount ?? NaN);
+  const partlyPaid =
+    Number.isFinite(outstanding) &&
+    outstanding > 0 &&
+    outstanding < Number(order.payable_amount ?? 0);
 
   return (
     <article className="card overflow-hidden">
@@ -198,11 +212,29 @@ export default function OrderCard({ order }: { order: OrderRow }) {
           </div>
         )}
         <div className="flex items-baseline justify-between pt-2">
-          <span className="text-[16px] text-[var(--foreground)]">應付金額</span>
-          <span className="text-[24px] font-semibold tabular-nums text-[var(--brand-strong)]">
+          <span className="text-[16px] text-[var(--foreground)]">
+            {partlyPaid ? "訂單金額" : "應付金額"}
+          </span>
+          <span
+            className={
+              partlyPaid
+                ? "text-[16px] tabular-nums text-[var(--secondary-label)]"
+                : "text-[24px] font-semibold tabular-nums text-[var(--brand-strong)]"
+            }
+          >
             ${fmtAmount(order.payable_amount)}
           </span>
         </div>
+        {/* 部分取貨：取走的那幾項當場付現了，卡片只留「應付金額」會跟列表上方的
+            總金額對不上（2026-08-11 團友 528204 手動加總差 $49 就是這張單）。 */}
+        {partlyPaid && (
+          <div className="flex items-baseline justify-between">
+            <span className="text-[16px] text-[var(--foreground)]">還需付款</span>
+            <span className="text-[24px] font-semibold tabular-nums text-[var(--brand-strong)]">
+              ${fmtAmount(order.outstanding_amount)}
+            </span>
+          </div>
+        )}
       </div>
     </article>
   );

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -48,8 +48,8 @@ export type OrderRow = {
  * 兩邊才不會出現「分在待取貨、標籤卻寫待到貨」。
  *
  * 對應（我們取貨付現，沒有「待付款」；「待收貨」＝到店「待取貨」）：
- *   waiting     待到貨（pending / confirmed / shipping，貨還沒到店）
- *   pickup      待取貨（已到店；partially_completed 剩的也還能取）
+ *   waiting     待到貨（pending / confirmed；shipping 標「運送中」，貨還沒到店）
+ *   pickup      待取貨（門市已收貨、取貨閘門放行；partially_completed 剩的也還能取）
  *   done        已完成
  *   void        不成立（斷貨取消 / 逾期）
  *   transferred 已轉讓（轉單給別人，只在「全部」出現）
@@ -72,15 +72,15 @@ export function orderPhase(o: Pick<OrderRow, "status" | "arrived">): {
       return { phase: "done", label: "已完成", className: "text-[var(--brand-strong)]" };
     case "partially_completed":
       return { phase: "pickup", label: "部分已取", className: "text-[#b06c00]" };
-    case "shipping":
-      // 派貨中 = 總倉已出貨、門市**還沒收貨**，團友這時跑來店裡會領不到東西。
-      // view 的 arrived 曾經把 shipping 當「已到店」（2026-08-11 修掉，
-      // 20260811000000）；這裡明寫一條，view 萬一被 rollback 也不會再誤報。
-      return { phase: "waiting", label: "運送中", className: "text-[#b06c00]" };
   }
-  return o.arrived
-    ? { phase: "pickup", label: "待取貨", className: "text-[#b06c00]" }
-    : { phase: "waiting", label: "待到貨", className: "text-[#b06c00]" };
+  if (o.arrived) return { phase: "pickup", label: "待取貨", className: "text-[#b06c00]" };
+  // 派貨中 = 總倉已出貨、門市**還沒收貨**，團友這時跑來店裡會領不到東西。
+  // arrived 曾經無條件把 shipping 當「已到店」（2026-08-11 修掉，20260811000010：
+  // 改問 is_order_pickup_ready）。標籤寫「運送中」比「待到貨」明確，
+  // 但仍歸在 waiting 分頁 —— 兩者對團友的意思都是「先別跑來」。
+  if (o.status === "shipping")
+    return { phase: "waiting", label: "運送中", className: "text-[#b06c00]" };
+  return { phase: "waiting", label: "待到貨", className: "text-[#b06c00]" };
 }
 
 function fmtAmount(n: number | string | null | undefined): string {

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -48,7 +48,7 @@ export type OrderRow = {
  * 兩邊才不會出現「分在待取貨、標籤卻寫待到貨」。
  *
  * 對應（我們取貨付現，沒有「待付款」；「待收貨」＝到店「待取貨」）：
- *   waiting     待到貨（pending / confirmed，貨還沒到店）
+ *   waiting     待到貨（pending / confirmed / shipping，貨還沒到店）
  *   pickup      待取貨（已到店；partially_completed 剩的也還能取）
  *   done        已完成
  *   void        不成立（斷貨取消 / 逾期）
@@ -72,6 +72,11 @@ export function orderPhase(o: Pick<OrderRow, "status" | "arrived">): {
       return { phase: "done", label: "已完成", className: "text-[var(--brand-strong)]" };
     case "partially_completed":
       return { phase: "pickup", label: "部分已取", className: "text-[#b06c00]" };
+    case "shipping":
+      // 派貨中 = 總倉已出貨、門市**還沒收貨**，團友這時跑來店裡會領不到東西。
+      // view 的 arrived 曾經把 shipping 當「已到店」（2026-08-11 修掉，
+      // 20260811000000）；這裡明寫一條，view 萬一被 rollback 也不會再誤報。
+      return { phase: "waiting", label: "運送中", className: "text-[#b06c00]" };
   }
   return o.arrived
     ? { phase: "pickup", label: "待取貨", className: "text-[#b06c00]" }

--- a/supabase/migrations/20260811000000_member_arrived_excludes_shipping.sql
+++ b/supabase/migrations/20260811000000_member_arrived_excludes_shipping.sql
@@ -1,0 +1,251 @@
+-- ============================================================
+-- 2026-08-11: 會員端「待取貨」不可以在貨還沒進店時就亮起來
+--
+-- 回報案例（古華店 / 冠顗油飯9香麻油雞肉油飯（一斤重）$155）：
+--   團友的「我的訂單」把該筆放進「待取貨 1」，卡片右上角寫「待取貨」；
+--   但同一時間 WMS /wms/receive 顯示該波次 WV26081100135 還在「未收 (16)」
+--   —— 總倉 2026-08-11 11:05 才派出，門市根本還沒收貨。
+--   團友跑一趟店裡會領不到東西。
+--
+-- 根因：v_customer_order_summary.arrived 把 'shipping' 算成「已到店」：
+--
+--     (co.status IN ('reserved','ready','partially_ready',
+--                    'partially_completed','shipping','completed')) AS arrived
+--
+--   但 customer_orders.status 的語意是（apps/admin/src/lib/orderStatus.ts）：
+--     shipping = 派貨中  ← 總倉波次已出貨，**門市尚未收貨**
+--     ready    = 可取貨  ← rpc_receive_transfer 收貨後、且
+--                          is_order_pickup_ready() 逐項確認該團該 SKU 實收
+--                          qty_received > 0 才會推上來（20260703000000）
+--   會員端 OrderCard.orderPhase() 只看 arrived 分「待到貨 / 待取貨」，
+--   於是「總倉一派出」= 團友看到「待取貨」，中間整段運送時間全是假的。
+--
+--   線上規模（修之前）：
+--     status='shipping' 共 2,260 張，其中 is_order_pickup_ready() = true 只有 6 張
+--     → 約 2,254 張訂單正對著團友顯示「待取貨」，貨其實還在路上。
+--
+--   同一支 liff-api 的「取貨提醒條」(getOverview) 用的是 status='ready'，
+--   兩邊口徑本來就對不上；這次以 'ready' 為準。
+--
+-- 修法：arrived 拿掉 'shipping'。到店與否一律以訂單狀態被推到 ready 為準
+--   （= 門市確實收到貨 + 該單每一項都實收 > 0）。
+--     shipping             → 待到貨（運送中，正確）
+--     reserved/ready       → 待取貨（已在店裡）
+--     partially_ready      → 待取貨（同上；兩者線上皆 0 筆，語意保留）
+--     partially_completed  → OrderCard 直接判「部分已取」，不看 arrived
+--     completed            → 已完成，同樣不看 arrived
+--
+--   settled（是否已結單）**不動**：'shipping' 對「這團結單了沒」而言是對的，
+--   而且線上沒有畫面在用它。shipped (status IN ('shipping','completed')) 也不動。
+--
+-- 基底版本（append-only，逐字保留所有 prior fix）：
+--   v_customer_order_summary：20260810000000_receivable_exclude_picked_up.sql
+--   （逐字複製，只改 arrived 那一個運算式）
+--
+-- Rollback：v_customer_order_summary 還原為 20260810000000 版本
+--
+-- 驗證：
+--   SELECT status, arrived, count(*) FROM v_customer_order_summary
+--    WHERE status IN ('shipping','ready') GROUP BY 1,2;
+--   -- shipping 應該全是 arrived=false，ready 全是 true
+--
+-- 對應程式（同一個 commit）：
+--   apps/member/src/components/OrderCard.tsx —— orderPhase() 明寫
+--   case 'shipping' → waiting，view 萬一被 rollback 前端也不會再誤報。
+-- ============================================================
+
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.discount_percent,
+  co.wallet_paid_amount,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  co.stockout_at,
+  agg.items_total,
+  agg.unpicked_total,
+  ret.returned_qty,
+  ret.returned_deduction,
+  GREATEST(
+    0,
+    ROUND(
+      GREATEST(0, agg.items_total - ret.returned_deduction)
+        * (1 - co.discount_percent / 100)
+        + co.shipping_fee
+        - co.discount_amount,
+      0
+    )
+  )                                                                            AS payable_amount,
+  GREATEST(
+    0,
+    GREATEST(
+      0,
+      ROUND(
+        GREATEST(0, agg.items_total - ret.returned_deduction)
+          * (1 - co.discount_percent / 100)
+          + co.shipping_fee
+          - co.discount_amount,
+        0
+      )
+    ) - co.wallet_paid_amount
+  )                                                                            AS balance_due,
+  -- 20260810000000：還沒收的錢 = 尚未取貨品項套同一條應收算式，再扣掉已付的儲值金。
+  -- 終態訂單（cancelled / expired / transferred_out）與「已全部取走」一律 0；
+  -- 全取走時直接回 0，不讓運費 / 折扣在沒有貨的情況下自己長出金額。
+  CASE
+    WHEN co.status IN ('cancelled','expired','transferred_out') THEN 0
+    WHEN agg.unpicked_total <= 0                                THEN 0
+    ELSE GREATEST(
+      0,
+      GREATEST(
+        0,
+        ROUND(
+          GREATEST(0, agg.unpicked_total - ret.returned_deduction)
+            * (1 - co.discount_percent / 100)
+            + co.shipping_fee
+            - co.discount_amount,
+          0
+        )
+      ) - co.wallet_paid_amount
+    )
+  END                                                                          AS outstanding_amount,
+  agg.items,
+  -- 20260811000000：'shipping' = 派貨中（總倉已出貨、門市未收貨），不是「到店可取」。
+  -- 到店與否只認 status 被推到 ready 之後的狀態（rpc_receive_transfer 收貨 +
+  -- is_order_pickup_ready 逐項確認實收 > 0 才會推）。
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','completed'))                           AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))            AS settled,
+  (co.payment_status = 'paid')                                                 AS paid,
+  (co.status IN ('shipping','completed'))                                      AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                 AS settlement_no,
+  s.name                                                                        AS store_name,
+  s.code                                                                        AS store_code,
+  gbc.name                                                                      AS campaign_name,
+  gbc.cover_image_url                                                           AS campaign_cover_url,
+  gbc.end_at                                                                    AS campaign_end_at,
+  gbc.cutoff_date                                                               AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price)
+               FILTER (WHERE coi.status NOT IN ('cancelled','expired')), 0)  AS items_total,
+    -- 20260810000000：尚未取貨的部分（picked_up 也排掉）。取貨當下收現金，
+    -- 所以「取走了」＝「收到錢了」，不該再算在未結裡。
+    COALESCE(SUM(coi.qty * coi.unit_price)
+               FILTER (WHERE coi.status NOT IN ('cancelled','expired','picked_up')), 0)
+                                                                              AS unpicked_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'sku_code',         sk.sku_code,
+          'product_name',     sk.product_name,
+          'variant_name',     sk.variant_name,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'subtotal',         coi.qty * coi.unit_price,
+          'status',           coi.status,
+          'stockout',         (coi.stockout_at IS NOT NULL),
+          'notes',            coi.notes,
+          'image_url',        CASE
+            WHEN jsonb_typeof(p.images) = 'array' AND jsonb_array_length(p.images) > 0 THEN
+              COALESCE(p.images -> 0 ->> 'url', p.images ->> 0)
+            ELSE NULL
+          END
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                           AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus     sk ON sk.id = coi.sku_id
+  LEFT JOIN products p  ON p.id  = sk.product_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE
+LEFT JOIN LATERAL (
+  -- 未取退貨扣減：return_to_hq（shipped/received、notes header 不含
+  -- |取貨後退回）依 SKU 聚合退貨量，按品項行序 (id) 分攤到未取消品項行、
+  -- 以該行 unit_price 折算金額
+  SELECT
+    COALESCE(SUM(a.alloc_qty), 0)                AS returned_qty,
+    COALESCE(SUM(a.alloc_qty * a.unit_price), 0) AS returned_deduction
+  FROM (
+    SELECT
+      i.unit_price,
+      LEAST(i.qty, GREATEST(r.ret_qty - i.prior_qty, 0)) AS alloc_qty
+    FROM (
+      SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+        FROM transfers t
+        JOIN transfer_items ti ON ti.transfer_id = t.id
+       WHERE t.customer_order_id = co.id
+         AND t.tenant_id     = co.tenant_id
+         AND t.transfer_type = 'return_to_hq'
+         AND t.status IN ('shipped','received')
+         AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+             NOT LIKE '%取貨後退回%'
+       GROUP BY ti.sku_id
+    ) r
+    JOIN (
+      SELECT coi.sku_id, coi.qty, coi.unit_price,
+             COALESCE(SUM(coi.qty) OVER (
+               PARTITION BY coi.sku_id ORDER BY coi.id
+               ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+             ), 0) AS prior_qty
+        FROM customer_order_items coi
+       WHERE coi.order_id = co.id
+         AND coi.status NOT IN ('cancelled','expired')
+    ) i ON i.sku_id = r.sku_id
+  ) a
+) ret ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細 + percent + amount 雙折扣 + 儲值金抵扣 + balance_due'
+  '（應收已四捨五入到整數 NTD）+ 斷貨標記（stockout_at / items[].stockout）'
+  '+ 未取退貨扣減（returned_qty / returned_deduction；取貨後退回不扣、退款走 rpc_wallet_partial_refund）'
+  '。20260808000010：items_total 不含 cancelled/expired 品項（斷貨 / 人工刪除的品項不收錢）；'
+  'items[] 仍保留這些行供前端顯示「斷貨」。'
+  '20260810000000：新增 unpicked_total / outstanding_amount —— 會員端「未結單金額」'
+  '（已訂未領貨）專用，取貨即收現金，所以 picked_up 品項不算；'
+  'cancelled/expired/transferred_out 訂單一律 0。payment_status 全站從未寫過 ''paid''，'
+  '不可以拿來當「有沒有收到錢」的依據。'
+  '20260811000000：arrived 不再含 ''shipping'' —— 派貨中＝貨還在路上，會員端只有門市收貨（status→ready）後才顯示「待取貨」。';
+
+-- DROP + CREATE 會清掉 grant。public schema 的 default privileges 本來就會補回
+-- anon/authenticated/service_role（20260731000000 沒寫 GRANT 也活著），這裡明寫一行
+-- 當保險，不依賴 default privileges 的設定沒被動過。
+GRANT SELECT ON v_customer_order_summary TO authenticated, anon;

--- a/supabase/migrations/20260811000010_member_arrived_uses_pickup_gate.sql
+++ b/supabase/migrations/20260811000010_member_arrived_uses_pickup_gate.sql
@@ -1,0 +1,247 @@
+-- ============================================================
+-- 2026-08-11 (2)：「到店了沒」改問取貨閘門，不要只看單頭 status
+--
+-- 承 20260811000000（arrived 拿掉 'shipping'）。那一版把「到店」定義成
+-- 「單頭 status 已被推到 ready 之後」，方向對，但漏了一種單：
+--
+--   文山店 campaign 3090（GRP-20260715-028）6 張單 —— 該團該店開了**抵減單**
+--   （order_kind='offset' 負數訂單，店內現貨吸收這組缺口），取貨閘門
+--   is_order_pickup_ready() 走 Path D' 判定「可以交貨」，店員也真的能發貨；
+--   但門市那張 hq_to_store transfer (10217) 還沒收，rpc_receive_transfer 沒跑過，
+--   單頭就一直卡在 'shipping'。只看 status 的話這 6 張會顯示「待到貨」，
+--   團友被擋在門外，貨其實就在店裡。
+--
+-- 修法：'shipping' 的列改問品項層級的取貨閘門 is_order_item_pickup_ready()，
+--   **只要有任何一項到貨可取就算「待取貨」**（不要求整張全到齊）——
+--   店員本來就是用同一道品項閘門逐項發貨（PickupDialog 只勾得到已到貨的行），
+--   要求全到齊會把「已經有東西可以領」的單擋在「待到貨」，反向誤導。
+--   閘門是 rpc_record_pickup 交貨時用的同一套（Path A/B/C/D、qty_received > 0、
+--   backorder_at 擋板），所以會員看到「待取貨」＝店員確實按得下去「取貨」。
+--   門市完全沒收貨的單，每一項都過不了閘門 → 一律「待到貨」，
+--   本次回報的「貨在路上卻顯示待取貨」就此消失。
+--
+-- 為什麼 ready 之後的狀態不一起重判（刻意保留快路徑，只加不減）：
+--   線上 14,454 張 status='ready' 裡有 63 張整單閘門回 false（52 張含待補貨
+--   backorder_at 品項、8 張已無 active 品項、3 張該項未到），其他行多半仍可取。
+--   ready 是收貨那一刻算過閘門才推上來的，維持「一旦可取就不會被畫面收回去」
+--   對團友比較好懂。→ 這一版只會把單子從「待到貨」救回「待取貨」，不會降級。
+--
+--   效能：函式只對 status='shipping' 的列呼叫（線上 2,260 / 65,297 ≈ 3.5%），
+--   其餘走原本的 status IN (...) 快路徑。實測單一會員 100 筆內 < 20ms；
+--   本 view 只有 liff-api 在用，且一律帶 member_id + limit 100。
+--
+-- 基底版本（append-only，逐字保留所有 prior fix）：
+--   v_customer_order_summary：20260811000000_member_arrived_excludes_shipping.sql
+--   （逐字複製，只改 arrived 那一個運算式）
+--
+-- Rollback：v_customer_order_summary 還原為 20260811000000 版本
+--
+-- 對應程式（同一個 commit）：
+--   apps/member/src/components/OrderCard.tsx —— 'shipping' 不再硬判「待到貨」，
+--   改成尊重 arrived；只有 arrived=false 時才把標籤寫成「運送中」。
+-- ============================================================
+
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.discount_percent,
+  co.wallet_paid_amount,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  co.stockout_at,
+  agg.items_total,
+  agg.unpicked_total,
+  ret.returned_qty,
+  ret.returned_deduction,
+  GREATEST(
+    0,
+    ROUND(
+      GREATEST(0, agg.items_total - ret.returned_deduction)
+        * (1 - co.discount_percent / 100)
+        + co.shipping_fee
+        - co.discount_amount,
+      0
+    )
+  )                                                                            AS payable_amount,
+  GREATEST(
+    0,
+    GREATEST(
+      0,
+      ROUND(
+        GREATEST(0, agg.items_total - ret.returned_deduction)
+          * (1 - co.discount_percent / 100)
+          + co.shipping_fee
+          - co.discount_amount,
+        0
+      )
+    ) - co.wallet_paid_amount
+  )                                                                            AS balance_due,
+  -- 20260810000000：還沒收的錢 = 尚未取貨品項套同一條應收算式，再扣掉已付的儲值金。
+  -- 終態訂單（cancelled / expired / transferred_out）與「已全部取走」一律 0；
+  -- 全取走時直接回 0，不讓運費 / 折扣在沒有貨的情況下自己長出金額。
+  CASE
+    WHEN co.status IN ('cancelled','expired','transferred_out') THEN 0
+    WHEN agg.unpicked_total <= 0                                THEN 0
+    ELSE GREATEST(
+      0,
+      GREATEST(
+        0,
+        ROUND(
+          GREATEST(0, agg.unpicked_total - ret.returned_deduction)
+            * (1 - co.discount_percent / 100)
+            + co.shipping_fee
+            - co.discount_amount,
+          0
+        )
+      ) - co.wallet_paid_amount
+    )
+  END                                                                          AS outstanding_amount,
+  agg.items,
+  -- 20260811000010：到店與否＝「現在有沒有東西可以交給客人」，直接問品項層級的
+  -- 取貨閘門（店員發貨用的同一套），不要只看單頭 status —— 單頭只有
+  -- rpc_receive_transfer 收到該店 transfer 時才會被推到 ready，靠店內現貨
+  -- 吸收缺口的單永遠等不到那一刻。有任一項可取即算，不要求整張全到齊。
+  -- 快路徑先擋掉 96%：已經是 ready 之後的狀態一律 true，函式只對 'shipping' 呼叫。
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','completed')
+   OR (co.status = 'shipping' AND EXISTS (
+         SELECT 1 FROM customer_order_items coi
+          WHERE coi.order_id = co.id
+            AND coi.status IN ('pending','reserved','ready')
+            AND public.is_order_item_pickup_ready(coi.id)
+       )))                                                                      AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))            AS settled,
+  (co.payment_status = 'paid')                                                 AS paid,
+  (co.status IN ('shipping','completed'))                                      AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                 AS settlement_no,
+  s.name                                                                        AS store_name,
+  s.code                                                                        AS store_code,
+  gbc.name                                                                      AS campaign_name,
+  gbc.cover_image_url                                                           AS campaign_cover_url,
+  gbc.end_at                                                                    AS campaign_end_at,
+  gbc.cutoff_date                                                               AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price)
+               FILTER (WHERE coi.status NOT IN ('cancelled','expired')), 0)  AS items_total,
+    -- 20260810000000：尚未取貨的部分（picked_up 也排掉）。取貨當下收現金，
+    -- 所以「取走了」＝「收到錢了」，不該再算在未結裡。
+    COALESCE(SUM(coi.qty * coi.unit_price)
+               FILTER (WHERE coi.status NOT IN ('cancelled','expired','picked_up')), 0)
+                                                                              AS unpicked_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'sku_code',         sk.sku_code,
+          'product_name',     sk.product_name,
+          'variant_name',     sk.variant_name,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'subtotal',         coi.qty * coi.unit_price,
+          'status',           coi.status,
+          'stockout',         (coi.stockout_at IS NOT NULL),
+          'notes',            coi.notes,
+          'image_url',        CASE
+            WHEN jsonb_typeof(p.images) = 'array' AND jsonb_array_length(p.images) > 0 THEN
+              COALESCE(p.images -> 0 ->> 'url', p.images ->> 0)
+            ELSE NULL
+          END
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                           AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus     sk ON sk.id = coi.sku_id
+  LEFT JOIN products p  ON p.id  = sk.product_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE
+LEFT JOIN LATERAL (
+  -- 未取退貨扣減：return_to_hq（shipped/received、notes header 不含
+  -- |取貨後退回）依 SKU 聚合退貨量，按品項行序 (id) 分攤到未取消品項行、
+  -- 以該行 unit_price 折算金額
+  SELECT
+    COALESCE(SUM(a.alloc_qty), 0)                AS returned_qty,
+    COALESCE(SUM(a.alloc_qty * a.unit_price), 0) AS returned_deduction
+  FROM (
+    SELECT
+      i.unit_price,
+      LEAST(i.qty, GREATEST(r.ret_qty - i.prior_qty, 0)) AS alloc_qty
+    FROM (
+      SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+        FROM transfers t
+        JOIN transfer_items ti ON ti.transfer_id = t.id
+       WHERE t.customer_order_id = co.id
+         AND t.tenant_id     = co.tenant_id
+         AND t.transfer_type = 'return_to_hq'
+         AND t.status IN ('shipped','received')
+         AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+             NOT LIKE '%取貨後退回%'
+       GROUP BY ti.sku_id
+    ) r
+    JOIN (
+      SELECT coi.sku_id, coi.qty, coi.unit_price,
+             COALESCE(SUM(coi.qty) OVER (
+               PARTITION BY coi.sku_id ORDER BY coi.id
+               ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+             ), 0) AS prior_qty
+        FROM customer_order_items coi
+       WHERE coi.order_id = co.id
+         AND coi.status NOT IN ('cancelled','expired')
+    ) i ON i.sku_id = r.sku_id
+  ) a
+) ret ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細 + percent + amount 雙折扣 + 儲值金抵扣 + balance_due'
+  '（應收已四捨五入到整數 NTD）+ 斷貨標記（stockout_at / items[].stockout）'
+  '+ 未取退貨扣減（returned_qty / returned_deduction；取貨後退回不扣、退款走 rpc_wallet_partial_refund）'
+  '。20260808000010：items_total 不含 cancelled/expired 品項（斷貨 / 人工刪除的品項不收錢）；'
+  'items[] 仍保留這些行供前端顯示「斷貨」。'
+  '20260810000000：新增 unpicked_total / outstanding_amount —— 會員端「未結單金額」'
+  '（已訂未領貨）專用，取貨即收現金，所以 picked_up 品項不算；'
+  'cancelled/expired/transferred_out 訂單一律 0。payment_status 全站從未寫過 ''paid''，'
+  '不可以拿來當「有沒有收到錢」的依據。'
+  '20260811000010：arrived 改問品項層級取貨閘門 is_order_item_pickup_ready() —— '
+  '派貨中（門市未收貨）一律不算到店；有任一項可取即算，不要求全到齊。';
+
+-- DROP + CREATE 會清掉 grant。public schema 的 default privileges 本來就會補回
+-- anon/authenticated/service_role（20260731000000 沒寫 GRANT 也活著），這裡明寫一行
+-- 當保險，不依賴 default privileges 的設定沒被動過。
+GRANT SELECT ON v_customer_order_summary TO authenticated, anon;


### PR DESCRIPTION
兩個團友回報的會員端顯示問題，都是同一類：畫面上的數字/狀態用了錯的欄位。

---

## 1. 貨還在路上，卻顯示「待取貨」

**回報**（古華店，冠顗油飯9香麻油雞肉油飯 $155）：團友的「我的訂單」把該筆放進「待取貨 1」，但同一時間 WMS `/wms/receive` 顯示波次 `WV26081100135` 還在「未收 (16)」—— 總倉 2026-08-11 11:05 才派出，門市根本還沒收貨。跑一趟店裡會領不到東西。

**根因**：`v_customer_order_summary.arrived` 把 `status='shipping'` 算成「已到店」：

```sql
(co.status IN ('reserved','ready','partially_ready',
               'partially_completed','shipping','completed')) AS arrived
```

但 `shipping` 的語意是**派貨中**（總倉已出貨、門市未收貨），真正的到店是 `rpc_receive_transfer` 收貨後才會推上去的 `ready`。會員端 `OrderCard.orderPhase()` 只看 `arrived` 分「待到貨 / 待取貨」，於是總倉一派出，團友就看到「待取貨」。

修之前線上 `status='shipping'` 共 2,260 張，其中真的可取貨的只有 6 張。

**修法**（`20260811000000` → `20260811000010`）：`shipping` 的列改問**品項層級的取貨閘門** `is_order_item_pickup_ready()` —— 那正是店員 PickupDialog 發貨時用的同一套（Path A/B/C/D、`qty_received > 0`、`backorder_at` 擋板）。**有任一項到貨即算「待取貨」，不要求整張全到齊**，因為店員本來就逐項發貨。

為什麼不能只看單頭 status：文山店 campaign 3090 有 6 張單開了**抵減單**（店內現貨吸收缺口），閘門判定可交貨、店員也發得出去，但門市那張 transfer 沒收，單頭永遠卡在 `shipping` —— 只看 status 會把團友擋在門外。

`ready` 之後的狀態維持快路徑不重判（只加不減，不會把任何已可取的單降級）。

線上結果：

| status | arrived | 張數 |
|---|---|---|
| shipping | false（貨在路上） | 2,212 |
| shipping | true（有東西可領） | 47 |
| ready | true | 14,454 |
| pending / confirmed | false | 20,818 |

回報的 4 張古華店油飯單 → `arrived=false`。效能：函式只對 `shipping` 那 3.5% 的列呼叫，實測會員訂單列表 11ms。

前端 `OrderCard`：`shipping` 未到貨時標籤寫「運送中」（比「待到貨」明確），仍歸在 waiting 分頁。

---

## 2. 「應付總金額」把已取貨的單一直掛帳

**回報**（團友 528204，南平店）：「全部」分頁顯示應付總金額 **$8,771 / 共 52 筆**，店長手動加總只有 $4,487。

**根因**：`sumOrders()` 用 `payable_amount` 加總，只濾掉 `cancelled`/`expired`。`payable_amount` 是「這張單本身多少錢」，不是「還欠多少」—— 取貨當下就收現金，已取貨的單早就付清了。她的 52 筆：

| status | 張數 | 被加總的 payable | 真正還沒收 |
|---|---|---|---|
| completed | 27 | $4,137 | $0 |
| confirmed | 17 | 3,945 | 3,945 |
| pending | 5 | 372 | 372 |
| shipping | 2 | 170 | 170 |
| partially_completed | 1 | 147 | 49（已領走 $98） |

`8,771 − 4,536 = 4,235 = 4,137 + 98`。店長手算的 4,487 其實是「待到貨」那一頁，少的 $49 正是那張部分取貨的殘額 —— **正確答案是 $4,536**。

這跟 2026-08 會員中心「未結單金額」是同一個坑：DB 早在 `20260810000000` 就備好 `outstanding_amount`，那次只修了 `/me`，訂單列表這張總金額卡漏掉。

**修法**（純前端，無 DB 異動）：

- `orders/page.tsx`：非「已完成」分頁一律加總 `outstanding_amount`；「已完成」問的是歷史總額，維持 `payable_amount`。副標拿掉沒意義的「尚未付款」，改成在有已取貨訂單時註明「已取貨的不計（取貨時付現）」。
- `OrderCard`：部分取貨的卡片多一行「還需付款」= `outstanding_amount`，原本的應付金額降級成灰字「訂單金額」。不然團友照卡片手動加總還是會差那 $49。

驗證（member 68906，同一組資料）：

| 分頁 | 修好後 |
|---|---|
| 全部 | **$4,536**（原本 8,771） |
| 待到貨 | 4,487 ← 店長手算的數字 |
| 待取貨 | 49 |
| 已完成 | 4,137（標「訂單總金額」） |

---

## 部署狀態

- 兩支 migration **已經用 Management API 套到線上**，`arrived` 那半已生效。
- 第 2 項是純前端，**要等 member app 部署**才會看到正確金額。

## 變更檔案

- `supabase/migrations/20260811000000_member_arrived_excludes_shipping.sql`（新）
- `supabase/migrations/20260811000010_member_arrived_uses_pickup_gate.sql`（新）
- `apps/member/src/components/OrderCard.tsx`
- `apps/member/src/app/orders/page.tsx`

Rollback：兩支 migration 各自的檔頭都寫了指回哪個版本（`20260810000000` / `20260811000000`）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdoiFsURezW2iDgH6jKQB3)_