### PR TITLE
fix(pickup): 轉貨補單的取貨單印得出品項 — 活動名稱沒帶到商品名就補上

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -15,6 +15,7 @@ import { dropPickupRecent, getPickupRecents, recordPickupRecent, type RecentCust
 import { publicProductUrl } from "@/lib/campaignCover";
 import { parseReturnNote } from "@/lib/returnNote";
 import { fetchReprintableEvents, pickupEventLabel, type PickupEventRow } from "@/lib/pickupReceipt";
+import { itemDisplayName } from "@/lib/skuLabel";
 
 type Member = {
   id: number;
@@ -818,7 +819,7 @@ function PickupPageContent() {
                                             onChange={() => toggleItem(it.id)}
                                             className="h-3.5 w-3.5 shrink-0 translate-y-0.5"
                                           />
-                                          <span className="font-bold">{it.sku?.variant_name || it.sku?.product_name || "—"}</span>
+                                          <span className="font-bold">{itemDisplayName(it.sku, o.campaign?.name)}</span>
                                           <span className="font-mono text-zinc-500">× {Number(it.qty)}</span>
                                           <span className="font-mono text-zinc-400">${Number(it.qty) * Number(it.unit_price)}</span>
                                         </label>
@@ -904,7 +905,7 @@ function PickupPageContent() {
                               <ul className="mt-0.5 space-y-0.5 text-xs text-zinc-700 dark:text-zinc-300">
                                 {active.map((it) => (
                                   <li key={it.id} className="flex items-baseline gap-1.5">
-                                    <span className="font-bold">{it.sku?.variant_name || it.sku?.product_name || "—"}</span>
+                                    <span className="font-bold">{itemDisplayName(it.sku, o.campaign?.name)}</span>
                                     <span className="font-mono text-zinc-500">× {Number(it.qty)}</span>
                                     {returnedOf(it) > 0 && (
                                       <span className="rounded bg-orange-100 px-1 py-0.5 text-[10px] font-medium text-orange-800 dark:bg-orange-950 dark:text-orange-300">↩ 已退 {returnedOf(it)}</span>
@@ -1116,7 +1117,7 @@ function PickupPageContent() {
                       <ul className="ml-4 space-y-0.5 text-xs">
                         {g.items.map((it) => (
                           <li key={it.id} className="flex items-baseline gap-2">
-                            <span className="font-bold">{it.sku?.variant_name || it.sku?.product_name || "—"}</span>
+                            <span className="font-bold">{itemDisplayName(it.sku, g.order.campaign?.name)}</span>
                             <span className="font-mono">×{Number(it.qty)}</span>
                           </li>
                         ))}
@@ -1186,7 +1187,7 @@ function PickupPageContent() {
                       <ul className="ml-4 space-y-0.5 text-xs">
                         {pickItems.map((it) => (
                           <li key={it.id} className="flex items-baseline gap-2">
-                            <span className="font-bold">{it.sku?.variant_name || it.sku?.product_name || "—"}</span>
+                            <span className="font-bold">{itemDisplayName(it.sku, o.campaign?.name)}</span>
                             <span className="font-mono">×{Number(it.qty)}</span>
                           </li>
                         ))}

--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { stripTransferNotes } from "@/lib/orderNotes";
 import { parseReturnNote } from "@/lib/returnNote";
+import { itemDisplayName } from "@/lib/skuLabel";
 import SpinButton from "@/components/SpinButton";
 
 type Order = {
@@ -252,7 +253,7 @@ function Body() {
                     <div key={it.id}>
                       <div className="flex items-baseline justify-between gap-2">
                         <span className="min-w-0 flex-1 break-words text-[16px] font-bold">
-                          {it.sku?.variant_name || it.sku?.product_name || "—"}
+                          {itemDisplayName(it.sku, o.campaign?.name)}
                         </span>
                         <span className="whitespace-nowrap text-[15px]">
                           × {qty}

--- a/apps/admin/src/app/(protected)/pickup/print-picked/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-picked/page.tsx
@@ -11,6 +11,7 @@ import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { stripTransferNotes } from "@/lib/orderNotes";
+import { itemDisplayName } from "@/lib/skuLabel";
 import SpinButton from "@/components/SpinButton";
 
 type Item = {
@@ -170,7 +171,7 @@ function Body() {
                   <div key={it.id}>
                     <div className="flex items-baseline justify-between gap-2">
                       <span className="min-w-0 flex-1 break-words text-[16px] font-bold">
-                        {it.sku?.variant_name || it.sku?.product_name || "—"}
+                        {itemDisplayName(it.sku, grp.order?.campaign?.name)}
                       </span>
                       <span className="whitespace-nowrap text-[15px]">
                         × {Number(it.qty)}

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { stripTransferNotes } from "@/lib/orderNotes";
+import { itemDisplayName } from "@/lib/skuLabel";
 import SpinButton from "@/components/SpinButton";
 
 type PickupEvent = {
@@ -199,7 +200,7 @@ function Body() {
                     <div key={it.id}>
                       <div className="flex items-baseline justify-between gap-2">
                         <span className="min-w-0 flex-1 break-words text-[16px] font-bold">
-                          {it.sku?.variant_name || it.sku?.product_name || "—"}
+                          {itemDisplayName(it.sku, r.order?.campaign?.name)}
                         </span>
                         <span className="whitespace-nowrap text-[15px]">
                           × {Number(it.qty)}

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -10,6 +10,7 @@ import SpinButton from "@/components/SpinButton";
 import { EditableDiscount, deriveDiscount, type DiscountValue } from "@/components/EditableDiscount";
 import { orderItemStatusLabel } from "@/lib/orderStatus";
 import { parseReturnNote } from "@/lib/returnNote";
+import { itemDisplayName } from "@/lib/skuLabel";
 
 type PickableItem = {
   id: number;
@@ -27,6 +28,8 @@ type OrderHead = {
   member_id: number | null;
   wallet_paid_amount: number;
   payment_status: string | null;
+  // 只拿來決定品項要不要補印商品名（見 lib/skuLabel）
+  campaign: { name: string } | { name: string }[] | null;
 };
 
 // 以指定數量計算小計（line-level 折扣金額按比例分攤，對齊後端拆行邏輯）
@@ -61,6 +64,7 @@ export function PickupDialog({
   const [discountValue, setDiscountValue] = useState<DiscountValue>({ kind: "amount", value: 0 });
   const [originalDiscount, setOriginalDiscount] = useState<{ amount: number; percent: number }>({ amount: 0, percent: 0 });
   const [memberId, setMemberId] = useState<number | null>(null);
+  const [campaignName, setCampaignName] = useState<string | null>(null);
   const [walletPaidSoFar, setWalletPaidSoFar] = useState(0);
   const [paymentStatus, setPaymentStatus] = useState<string | null>(null);
   const [walletBalance, setWalletBalance] = useState<number | null>(null);
@@ -84,7 +88,7 @@ export function PickupDialog({
           .in("status", ["pending", "reserved", "ready"])
           .order("id"),
         sb.from("customer_orders")
-          .select("discount_amount, discount_percent, member_id, wallet_paid_amount, payment_status")
+          .select("discount_amount, discount_percent, member_id, wallet_paid_amount, payment_status, campaign:group_buy_campaigns(name)")
           .eq("id", orderId)
           .maybeSingle<OrderHead>(),
         // 已退回總倉量（return_to_hq transfer）— 退掉的貨店裡沒有、不可再取。
@@ -143,6 +147,8 @@ export function PickupDialog({
       setOriginalDiscount({ amount: headAmt, percent: headPct });
       setDiscountValue(deriveDiscount(headPct, headAmt));
       setMemberId(head?.member_id ?? null);
+      const camp = Array.isArray(head?.campaign) ? head?.campaign[0] : head?.campaign;
+      setCampaignName(camp?.name ?? null);
       const alreadyPaid = Number(head?.wallet_paid_amount ?? 0);
       const isPaid = head?.payment_status === "paid";
       setWalletPaidSoFar(alreadyPaid);
@@ -389,7 +395,7 @@ export function PickupDialog({
                         />
                       </td>
                       <td className="px-3 py-2">
-                        <span className="font-medium">{it.sku?.variant_name ?? it.sku?.product_name ?? "—"}</span>
+                        <span className="font-medium">{itemDisplayName(it.sku, campaignName)}</span>
                         {it.sku?.sku_code && (
                           <span className="ml-2 font-mono text-[10px] text-zinc-400">{it.sku.sku_code}</span>
                         )}

--- a/apps/admin/src/lib/skuLabel.ts
+++ b/apps/admin/src/lib/skuLabel.ts
@@ -1,0 +1,33 @@
+// 取貨畫面 / 小白單的品項顯示名
+//
+// 一般團購單的活動名稱 ≈ 商品名（線上 83,351 筆品項有 82,176 筆的 campaign.name
+// 就含著 skus.product_name），所以品項只印規格（「一包」「(A)高麗菜」）剛剛好，
+// 80mm 單也塞得下。
+//
+// 但轉貨補單 / 補貨申請的單全部掛在共用活動「【內部】補貨申請」
+// (campaign_no = __INTERNAL_RESTOCK__) 底下，活動名稱一個商品字都沒有 ——
+// 只印規格的話整張取貨單就變成「【內部】補貨申請 / 一包 × 2」，
+// 店員看不出要拿什麼貨（2026-08-11 回報：RR / TF 補單列印看不到品項）。
+//
+// 規則：活動名稱已經帶到商品名 → 維持只顯示規格；沒帶到 → 補上商品名。
+
+export type SkuNameLike = {
+  product_name?: string | null;
+  variant_name?: string | null;
+} | null | undefined;
+
+// 比對用正規化：去掉半形/全形空白再比，避免 " Chuli 初梨…" 這種前後空白的資料
+// 被當成跟活動名稱不同（線上真的有）。
+function norm(s: string): string {
+  return s.replace(/[\s　]+/g, "").toLowerCase();
+}
+
+export function itemDisplayName(sku: SkuNameLike, campaignName?: string | null): string {
+  const product = (sku?.product_name ?? "").trim();
+  const variant = (sku?.variant_name ?? "").trim();
+  if (!product) return variant || "—";
+  if (!variant || norm(variant) === norm(product)) return product;
+  const campaign = (campaignName ?? "").trim();
+  if (campaign && norm(campaign).includes(norm(product))) return variant;
+  return `${product} / ${variant}`;
+}


### PR DESCRIPTION
RR / TF 補單全部掛在共用活動「【內部】補貨申請」(__INTERNAL_RESTOCK__) 底下，
但取貨畫面與三張小白單的品項一律只顯示 skus.variant_name，整張單就變成
「【內部】補貨申請 / 一包 × 2」，店員看不出要拿什麼貨。

一般團購單之所以看得懂，是因為活動名稱本來就等於商品名（線上 83,351 筆品項
有 82,176 筆的 campaign.name 含著 skus.product_name），規格單獨列剛好夠用、
80mm 也塞得下。所以新增 lib/skuLabel.ts 的 itemDisplayName()：活動名稱已帶到
商品名 → 維持只印規格；沒帶到（補貨申請、活動名與商品名不一致的單）→ 補成
「商品名 / 規格」。比對前把半形/全形空白正規化，避免商品名前後有空白的資料
被誤判成不同。

套用範圍（同一組店員在看的同一批畫面，label 要一致）：
- /pickup/print（取貨收據）、/pickup/print-list（取貨清單）、/pickup/print-picked
- /pickup 列表的四處品項清單
- PickupDialog（改抓 campaign name 供判斷）

以 fixture + Playwright 驗過 /pickup/print 與 /pickup/print-list：補貨申請單印出
「智利鮭魚頭剖半 （450克±10 %） / 一包」，一般團購單維持「一包」，80mm 版型正常換行。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DtTX2PnQTTkHNFtcVGn62f