### PR TITLE
fix(member): 我的訂單「全部」分頁不再顯示應付總金額，只留待到貨/待取貨

### DIFF
--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -9,6 +9,7 @@ import { LineMessageModal } from "@/components/LineMessageModal";
 import { WalletActionModal, type WalletActionMode } from "@/components/WalletActionModal";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
+import { MemberOrdersAppView } from "@/components/MemberOrdersAppView";
 import { orderStatusLabel, orderCountsInTotals, orderItemCountsInTotals } from "@/lib/orderStatus";
 import { translateRpcError } from "@/lib/rpcError";
 import { canAdjustWallet, canUnmergeMember, isAdmin, useMyStores, useRole } from "@/lib/role";
@@ -126,6 +127,9 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
   const [orders, setOrders] = useState<MemberOrder[]>([]);
   const [orderDetail, setOrderDetail] = useState<{ id: number; no: string } | null>(null);
   const [tab, setTab] = useState<"orders" | "info" | "points" | "wallet" | "merges" | "test">("orders");
+  // 訂單分頁的兩種視圖：後台列表（全歷史 + 小計）/ 會員畫面（跟 app 一模一樣，
+  // 團友來問金額時切這個對，見 MemberOrdersAppView）
+  const [ordersView, setOrdersView] = useState<"list" | "app">("list");
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [reloadTick, setReloadTick] = useState(0);
@@ -674,7 +678,26 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
           }
           return (
             <div className="mt-3 space-y-2">
-              <div className="flex items-center justify-end">
+              <div className="flex items-center justify-between gap-2">
+                {/* 列表 = 後台口徑（全歷史、含小計）；會員畫面 = app 口徑（半年內、
+                    應付總金額）。兩邊數字本來就會不同，切換就是為了對團友的截圖。 */}
+                <div className="flex rounded-md border border-zinc-300 text-xs dark:border-zinc-700">
+                  <button
+                    type="button"
+                    onClick={() => setOrdersView("list")}
+                    className={`rounded-l-[5px] px-2.5 py-1 ${ordersView === "list" ? "bg-zinc-800 font-medium text-white dark:bg-zinc-200 dark:text-zinc-900" : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"}`}
+                  >
+                    列表
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setOrdersView("app")}
+                    title="跟會員 app「我的訂單」一模一樣的畫面 — 團友來問金額時看這個"
+                    className={`rounded-r-[5px] px-2.5 py-1 ${ordersView === "app" ? "bg-zinc-800 font-medium text-white dark:bg-zinc-200 dark:text-zinc-900" : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"}`}
+                  >
+                    📱 會員畫面
+                  </button>
+                </div>
                 <Link
                   href={`/orders?q=${encodeURIComponent(member.member_no)}`}
                   className="text-xs text-blue-600 hover:underline dark:text-blue-400"
@@ -683,6 +706,12 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
                   完整訂單頁 →
                 </Link>
               </div>
+              {ordersView === "app" ? (
+                <MemberOrdersAppView
+                  memberId={memberId}
+                  onOpenOrder={(id, no) => setOrderDetail({ id, no })}
+                />
+              ) : (
               <div className="max-h-[420px] overflow-auto rounded-md border border-zinc-200 dark:border-zinc-800">
                 <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
                   <thead className="sticky top-0 z-10 bg-zinc-50 dark:bg-zinc-900">
@@ -749,6 +778,7 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
                   )}
                 </table>
               </div>
+              )}
             </div>
           );
         })()}

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -9,7 +9,7 @@ import { LineMessageModal } from "@/components/LineMessageModal";
 import { WalletActionModal, type WalletActionMode } from "@/components/WalletActionModal";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
-import { MemberOrdersAppView } from "@/components/MemberOrdersAppView";
+import { MemberOrdersAppView, outstandingTotals, useMemberAppOrders } from "@/components/MemberOrdersAppView";
 import { orderStatusLabel, orderCountsInTotals, orderItemCountsInTotals } from "@/lib/orderStatus";
 import { translateRpcError } from "@/lib/rpcError";
 import { canAdjustWallet, canUnmergeMember, isAdmin, useMyStores, useRole } from "@/lib/role";
@@ -133,6 +133,9 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [reloadTick, setReloadTick] = useState(0);
+  // app 口徑的訂單抓一次、兩個視圖共用：「會員畫面」整個吃它，「列表」表尾的
+  // 應付總金額也用它 —— 這個數字必須跟團友手機上看到的一模一樣
+  const appOrders = useMemberAppOrders(memberId, reloadTick);
   const [mergeOpen, setMergeOpen] = useState<false | "guest-to-real" | "real-from-guest">(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [lineMsgOpen, setLineMsgOpen] = useState(false);
@@ -661,6 +664,10 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
         </div>
 
         {tab === "orders" && (() => {
+          // 表尾的「應付總金額」跟會員 app 完全同口徑（待到貨＋待取貨的未領貨），
+          // 團友手機上看到的就是這兩個數字 —— 跟下面的歷史小計是兩回事
+          const appWaiting = outstandingTotals(appOrders.buckets.waiting);
+          const appPickup = outstandingTotals(appOrders.buckets.pickup);
           // 統計沿用 CampaignOrdersPanel：取消/過期/轉出不入計、已轉出的品項也不算；
           // order_kind=offset 是抵減單，顯示負數（見 orderStatus.ts 的統計規則）
           let totalQty = 0, totalAmount = 0, normalCount = 0, offsetCount = 0;
@@ -708,7 +715,7 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
               </div>
               {ordersView === "app" ? (
                 <MemberOrdersAppView
-                  memberId={memberId}
+                  data={appOrders}
                   onOpenOrder={(id, no) => setOrderDetail({ id, no })}
                 />
               ) : (
@@ -773,6 +780,17 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
                         </td>
                         <td className="px-4 py-2 text-right font-mono tabular-nums font-semibold">{totalQty}</td>
                         <td className="px-4 py-2 text-right font-mono tabular-nums font-semibold">${totalAmount.toLocaleString()}</td>
+                      </tr>
+                      <tr className="border-t border-zinc-200 dark:border-zinc-800">
+                        <td colSpan={6} className="px-4 py-2 text-right text-xs text-zinc-500">
+                          應付總金額（同會員 app，未取貨才計
+                          {!appOrders.loading &&
+                            `：待到貨 $${appWaiting.amount.toLocaleString()}＋待取貨 $${appPickup.amount.toLocaleString()}`}
+                          ）
+                        </td>
+                        <td className="px-4 py-2 text-right font-mono tabular-nums font-semibold text-rose-700 dark:text-rose-400">
+                          {appOrders.loading ? "…" : `$${(appWaiting.amount + appPickup.amount).toLocaleString()}`}
+                        </td>
                       </tr>
                     </tfoot>
                   )}

--- a/apps/admin/src/components/MemberOrdersAppView.tsx
+++ b/apps/admin/src/components/MemberOrdersAppView.tsx
@@ -32,7 +32,7 @@ type AppOrderItem = {
   stockout?: boolean;
 };
 
-type AppOrderRow = {
+export type AppOrderRow = {
   id: number;
   order_no: string;
   status: string | null;
@@ -96,18 +96,15 @@ function fmtDate(iso: string | null | undefined): string {
   return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}`;
 }
 
-export function MemberOrdersAppView({
-  memberId,
-  onOpenOrder,
-}: {
-  memberId: number;
-  /** 點卡片開後台訂單明細（app 沒有；後台看細節 / 操作用） */
-  onOpenOrder: (id: number, orderNo: string) => void;
-}) {
+/**
+ * 抓「會員 app 看得到的訂單」＋分桶。抽成 hook 是因為兩個地方要用同一份數字：
+ * 「會員畫面」整個視圖、以及「列表」表尾的應付總金額（同 app 口徑）——
+ * 各抓各的遲早會分家，客服又要對不上。
+ */
+export function useMemberAppOrders(memberId: number, reloadTick = 0) {
   const [orders, setOrders] = useState<AppOrderRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
-  const [tab, setTab] = useState<Tab>("all");
 
   useEffect(() => {
     let cancelled = false;
@@ -152,7 +149,7 @@ export function MemberOrdersAppView({
     return () => {
       cancelled = true;
     };
-  }, [memberId]);
+  }, [memberId, reloadTick]);
 
   const buckets = useMemo(() => {
     const b: Record<Tab, AppOrderRow[]> = { all: orders, waiting: [], pickup: [], done: [], void: [] };
@@ -163,17 +160,45 @@ export function MemberOrdersAppView({
     return b;
   }, [orders]);
 
+  return { orders, buckets, loading, err };
+}
+
+export type MemberAppOrders = ReturnType<typeof useMemberAppOrders>;
+
+/**
+ * 一個分桶的應付加總 = 會員 app orders/page.tsx 的 sumOrders：
+ * outstanding_amount（還沒領走的貨），排除 cancelled / expired。
+ */
+export function outstandingTotals(list: AppOrderRow[]) {
+  const active = list.filter((o) => !["cancelled", "expired"].includes(String(o.status ?? "")));
+  return {
+    count: active.length,
+    amount: active.reduce(
+      (s, o) => s + Number(o.outstanding_amount ?? o.payable_amount ?? 0),
+      0,
+    ),
+    hasPicked: active.some(
+      (o) => Number(o.outstanding_amount ?? o.payable_amount ?? 0) < Number(o.payable_amount ?? 0),
+    ),
+  };
+}
+
+export function MemberOrdersAppView({
+  data,
+  onOpenOrder,
+}: {
+  /** useMemberAppOrders 的回傳 —— 由 MemberDetail 抓一次，列表表尾共用同一份 */
+  data: MemberAppOrders;
+  /** 點卡片開後台訂單明細（app 沒有；後台看細節 / 操作用） */
+  onOpenOrder: (id: number, orderNo: string) => void;
+}) {
+  const { buckets, loading, err } = data;
+  const [tab, setTab] = useState<Tab>("all");
+
   const bucket = buckets[tab];
-  // = 會員 app orders/page.tsx：應付總金額只在待到貨 / 待取貨顯示，用 outstanding_amount
+  // = 會員 app orders/page.tsx：應付總金額只在待到貨 / 待取貨顯示
   const showTotals = tab === "waiting" || tab === "pickup";
-  const active = bucket.filter((o) => !["cancelled", "expired"].includes(String(o.status ?? "")));
-  const totalAmount = active.reduce(
-    (s, o) => s + Number(o.outstanding_amount ?? o.payable_amount ?? 0),
-    0,
-  );
-  const hasPicked = active.some(
-    (o) => Number(o.outstanding_amount ?? o.payable_amount ?? 0) < Number(o.payable_amount ?? 0),
-  );
+  const { count: activeCount, amount: totalAmount, hasPicked } = outstandingTotals(bucket);
 
   if (err) {
     return (
@@ -208,12 +233,12 @@ export function MemberOrdersAppView({
 
       {loading && <div className="p-6 text-center text-sm text-zinc-500">載入中…</div>}
 
-      {!loading && showTotals && active.length > 0 && (
+      {!loading && showTotals && activeCount > 0 && (
         <div className="flex items-center justify-between gap-3 rounded-xl border border-rose-200 bg-rose-50/60 px-4 py-3 dark:border-rose-900 dark:bg-rose-950/30">
           <div>
             <div className="text-sm text-zinc-800 dark:text-zinc-200">應付總金額</div>
             <div className="text-xs text-zinc-500">
-              共 {active.length} 筆訂單
+              共 {activeCount} 筆訂單
               {hasPicked && <span className="ml-1.5">· 已取貨的不計（取貨時付現）</span>}
             </div>
           </div>

--- a/apps/admin/src/components/MemberOrdersAppView.tsx
+++ b/apps/admin/src/components/MemberOrdersAppView.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+/**
+ * 會員明細 →「會員畫面」：把會員 app「我的訂單」那一頁原樣搬進後台。
+ *
+ * 為什麼要有這個：金額客訴（例：2026-08-11 會員 109814 的「應付總金額」）
+ * 都是團友傳截圖進來、客服對著後台表格逐張猜是哪幾筆 —— 兩邊口徑不同，
+ * 對不上就得來回一整個下午。這個視圖跟 app 用同一個 view、同一套分桶與加總，
+ * 客服看到的數字 = 團友手機上的數字，一眼就能對。
+ *
+ * 「一樣」是硬需求，三個地方要跟會員端同步（改那邊記得改這邊）：
+ *   - 資料管線 = liff-api listMyOrders：v_customer_order_summary、半年內、
+ *     active / history 各最多 100 筆、一般取消不顯示但斷貨取消要顯示、已轉讓隱藏
+ *   - orderPhase 分桶 = apps/member/src/components/OrderCard.tsx
+ *   - 應付總金額只在「待到貨」「待取貨」顯示、用 outstanding_amount
+ *     = apps/member/src/app/orders/page.tsx（2026-08-11 起「全部」不顯示金額）
+ *
+ * 後台加值：點卡片可直接開訂單明細（會員 app 沒有這個）。
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { cleanCampaignText } from "@/lib/text";
+
+type AppOrderItem = {
+  id: number;
+  variant_name: string | null;
+  qty: number;
+  unit_price: number;
+  subtotal: number;
+  status: string;
+  stockout?: boolean;
+};
+
+type AppOrderRow = {
+  id: number;
+  order_no: string;
+  status: string | null;
+  stockout_at: string | null;
+  payable_amount: number;
+  outstanding_amount: number | null;
+  items_total: number;
+  shipping_fee: number;
+  discount_amount: number;
+  arrived: boolean;
+  items: AppOrderItem[];
+  created_at: string;
+  campaign_name: string | null;
+  campaign_cutoff_date: string | null;
+  store_name: string | null;
+};
+
+type Phase = "waiting" | "pickup" | "done" | "void" | "transferred";
+type Tab = "all" | "waiting" | "pickup" | "done" | "void";
+
+const TAB_LABEL: Record<Tab, string> = {
+  all: "全部",
+  waiting: "待到貨",
+  pickup: "待取貨",
+  done: "已完成",
+  void: "不成立",
+};
+
+// = apps/member/src/components/OrderCard.tsx 的 orderPhase（分桶 + 右上角狀態字）
+function orderPhase(o: Pick<AppOrderRow, "status" | "arrived">): {
+  phase: Phase;
+  label: string;
+  className: string;
+} {
+  switch (o.status) {
+    case "cancelled":
+      return { phase: "void", label: "訂單不成立", className: "text-red-700 dark:text-red-400" };
+    case "expired":
+      return { phase: "void", label: "逾期未取", className: "text-red-700 dark:text-red-400" };
+    case "transferred_out":
+      return { phase: "transferred", label: "已轉讓", className: "text-zinc-400" };
+    case "completed":
+      return { phase: "done", label: "已完成", className: "text-rose-700 dark:text-rose-400" };
+    case "partially_completed":
+      return { phase: "pickup", label: "部分已取", className: "text-amber-700 dark:text-amber-400" };
+  }
+  if (o.arrived) return { phase: "pickup", label: "待取貨", className: "text-amber-700 dark:text-amber-400" };
+  if (o.status === "shipping")
+    return { phase: "waiting", label: "運送中", className: "text-amber-700 dark:text-amber-400" };
+  return { phase: "waiting", label: "待到貨", className: "text-amber-700 dark:text-amber-400" };
+}
+
+function fmtAmount(n: number | string | null | undefined): string {
+  return Number(n ?? 0).toLocaleString();
+}
+
+function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return "-";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return String(iso);
+  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export function MemberOrdersAppView({
+  memberId,
+  onOpenOrder,
+}: {
+  memberId: number;
+  /** 點卡片開後台訂單明細（app 沒有；後台看細節 / 操作用） */
+  onOpenOrder: (id: number, orderNo: string) => void;
+}) {
+  const [orders, setOrders] = useState<AppOrderRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("all");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setErr(null);
+      const sb = getSupabase();
+      const cutoff = new Date();
+      cutoff.setMonth(cutoff.getMonth() - 6);
+      const base = () =>
+        sb
+          .from("v_customer_order_summary")
+          .select("*")
+          .eq("member_id", memberId)
+          .gte("created_at", cutoff.toISOString())
+          .order("created_at", { ascending: false })
+          .limit(100);
+      // = liff-api listMyOrders 的兩個 tab（active / history），各自 limit 100
+      const [activeQ, historyQ] = await Promise.all([
+        base().not("status", "in", "(completed,expired)"),
+        base().eq("status", "completed"),
+      ]);
+      if (cancelled) return;
+      const qErr = activeQ.error ?? historyQ.error;
+      if (qErr) {
+        setErr(qErr.message);
+        setLoading(false);
+        return;
+      }
+      // 一般取消不顯示、斷貨取消要顯示；已轉讓整個隱藏 —— 都跟 app 一致
+      const rows = [
+        ...((activeQ.data ?? []) as AppOrderRow[]).filter(
+          (o) => o.status !== "cancelled" || o.stockout_at,
+        ),
+        ...((historyQ.data ?? []) as AppOrderRow[]),
+      ]
+        .filter((o) => orderPhase(o).phase !== "transferred")
+        .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+      setOrders(rows);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [memberId]);
+
+  const buckets = useMemo(() => {
+    const b: Record<Tab, AppOrderRow[]> = { all: orders, waiting: [], pickup: [], done: [], void: [] };
+    for (const o of orders) {
+      const { phase } = orderPhase(o);
+      if (phase !== "transferred") b[phase].push(o);
+    }
+    return b;
+  }, [orders]);
+
+  const bucket = buckets[tab];
+  // = 會員 app orders/page.tsx：應付總金額只在待到貨 / 待取貨顯示，用 outstanding_amount
+  const showTotals = tab === "waiting" || tab === "pickup";
+  const active = bucket.filter((o) => !["cancelled", "expired"].includes(String(o.status ?? "")));
+  const totalAmount = active.reduce(
+    (s, o) => s + Number(o.outstanding_amount ?? o.payable_amount ?? 0),
+    0,
+  );
+  const hasPicked = active.some(
+    (o) => Number(o.outstanding_amount ?? o.payable_amount ?? 0) < Number(o.payable_amount ?? 0),
+  );
+
+  if (err) {
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+        {err}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-1.5">
+        {(Object.keys(TAB_LABEL) as Tab[]).map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setTab(t)}
+            className={
+              tab === t
+                ? "rounded-full bg-rose-600 px-3 py-1 text-xs font-semibold text-white"
+                : "rounded-full border border-zinc-300 px-3 py-1 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            }
+          >
+            {TAB_LABEL[t]}
+            {/* app 同款：全部 / 已完成不掛數字 */}
+            {t !== "all" && t !== "done" && buckets[t].length > 0 && (
+              <span className="ml-1 opacity-70">{buckets[t].length}</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {loading && <div className="p-6 text-center text-sm text-zinc-500">載入中…</div>}
+
+      {!loading && showTotals && active.length > 0 && (
+        <div className="flex items-center justify-between gap-3 rounded-xl border border-rose-200 bg-rose-50/60 px-4 py-3 dark:border-rose-900 dark:bg-rose-950/30">
+          <div>
+            <div className="text-sm text-zinc-800 dark:text-zinc-200">應付總金額</div>
+            <div className="text-xs text-zinc-500">
+              共 {active.length} 筆訂單
+              {hasPicked && <span className="ml-1.5">· 已取貨的不計（取貨時付現）</span>}
+            </div>
+          </div>
+          <span className="text-xl font-semibold tabular-nums text-rose-700 dark:text-rose-400">
+            ${fmtAmount(totalAmount)}
+          </span>
+        </div>
+      )}
+
+      {!loading && bucket.length === 0 && (
+        <div className="p-8 text-center text-sm text-zinc-500">
+          {tab === "all" ? "半年內沒有訂單" : `目前沒有「${TAB_LABEL[tab]}」的訂單`}
+        </div>
+      )}
+
+      {!loading && (
+        <div className="max-h-[560px] space-y-3 overflow-auto pr-1">
+          {bucket.map((o) => (
+            <AppOrderCard key={o.id} order={o} onClick={() => onOpenOrder(o.id, o.order_no)} />
+          ))}
+        </div>
+      )}
+
+      <p className="text-[11px] text-zinc-400">
+        與會員 app「我的訂單」同一套資料與口徑（半年內、每類最多 100 筆）；點卡片可開後台訂單明細。
+      </p>
+    </div>
+  );
+}
+
+// = apps/member/src/components/OrderCard.tsx 的卡片內容（後台配色 + 可點擊）
+function AppOrderCard({ order, onClick }: { order: AppOrderRow; onClick: () => void }) {
+  const phase = orderPhase(order);
+  const title = cleanCampaignText(order.campaign_name) || "訂單";
+  const totalQty = (order.items ?? []).reduce(
+    (s, i) => (["cancelled", "expired"].includes(i.status) ? s : s + Number(i.qty ?? 0)),
+    0,
+  );
+  const outstanding = Number(order.outstanding_amount ?? NaN);
+  const partlyPaid =
+    Number.isFinite(outstanding) && outstanding > 0 && outstanding < Number(order.payable_amount ?? 0);
+
+  return (
+    <article
+      onClick={onClick}
+      title={`點此查看訂單明細 ${order.order_no}`}
+      className="cursor-pointer overflow-hidden rounded-xl border border-zinc-200 bg-white transition-shadow hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <header className="bg-rose-50/60 px-4 pb-2.5 pt-3 dark:bg-rose-950/20">
+        <div className="flex items-center justify-between gap-2">
+          <h4 className="min-w-0 truncate text-[15px] font-bold text-zinc-900 dark:text-zinc-100">
+            {title}
+          </h4>
+          <span className={`flex-shrink-0 text-xs font-medium ${phase.className}`}>{phase.label}</span>
+        </div>
+        {order.stockout_at && (
+          <p className="mt-0.5 text-xs text-red-700 dark:text-red-400">
+            ⛔ 供應商斷貨，本筆訂單已取消，造成不便敬請見諒
+          </p>
+        )}
+        <p className="mt-0.5 text-xs text-zinc-500">
+          {fmtDate(order.created_at)}
+          {order.store_name && <span className="ml-1.5">· 取貨：{order.store_name}</span>}
+          {order.campaign_cutoff_date && <span className="ml-1.5">· 結單日 {order.campaign_cutoff_date}</span>}
+        </p>
+      </header>
+
+      <ul className="divide-y divide-zinc-100 px-4 dark:divide-zinc-800">
+        {(order.items ?? []).map((it) => (
+          <li key={it.id} className="flex items-start gap-3 py-2">
+            <div className="min-w-0 flex-1">
+              <div
+                className={`text-sm ${
+                  it.stockout
+                    ? "text-zinc-400 line-through"
+                    : "text-zinc-900 dark:text-zinc-100"
+                }`}
+              >
+                {it.variant_name ?? "—"}
+                {it.stockout && (
+                  <span className="ml-1.5 inline-block rounded bg-red-100 px-1 py-0.5 text-[10px] font-medium text-red-800 no-underline dark:bg-red-950 dark:text-red-300">
+                    斷貨
+                  </span>
+                )}
+              </div>
+              <div className="text-xs text-zinc-500">
+                {fmtAmount(it.unit_price)} × {it.qty}
+              </div>
+            </div>
+            <div
+              className={`flex-shrink-0 text-right text-sm font-medium tabular-nums ${
+                it.stockout ? "text-zinc-400 line-through" : "text-zinc-900 dark:text-zinc-100"
+              }`}
+            >
+              {fmtAmount(it.subtotal)}
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <div className="space-y-1 border-t border-zinc-100 px-4 py-2.5 text-sm dark:border-zinc-800">
+        <div className="flex justify-between text-xs text-zinc-500">
+          <span>商品（{totalQty} 件）</span>
+          <span className="tabular-nums">{fmtAmount(order.items_total)}</span>
+        </div>
+        {Number(order.shipping_fee) > 0 && (
+          <div className="flex justify-between text-xs text-zinc-500">
+            <span>運費</span>
+            <span className="tabular-nums">{fmtAmount(order.shipping_fee)}</span>
+          </div>
+        )}
+        {Number(order.discount_amount) > 0 && (
+          <div className="flex justify-between text-xs text-zinc-500">
+            <span>折扣</span>
+            <span className="tabular-nums">−{fmtAmount(order.discount_amount)}</span>
+          </div>
+        )}
+        <div className="flex items-baseline justify-between pt-1">
+          <span className="text-zinc-800 dark:text-zinc-200">
+            {partlyPaid ? "訂單金額" : "應付金額"}
+          </span>
+          <span
+            className={
+              partlyPaid
+                ? "text-sm tabular-nums text-zinc-500"
+                : "text-lg font-semibold tabular-nums text-rose-700 dark:text-rose-400"
+            }
+          >
+            ${fmtAmount(order.payable_amount)}
+          </span>
+        </div>
+        {partlyPaid && (
+          <div className="flex items-baseline justify-between">
+            <span className="text-zinc-800 dark:text-zinc-200">還需付款</span>
+            <span className="text-lg font-semibold tabular-nums text-rose-700 dark:text-rose-400">
+              ${fmtAmount(order.outstanding_amount)}
+            </span>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -34,35 +34,28 @@ function fmtAmount(n: number): string {
 }
 
 /**
- * 一個分頁的金額加總。
+ * 一個分頁的金額加總。**只有「待到貨」「待取貨」會顯示這張卡**（見 showTotals）：
+ * 「全部」混著幾十張早就取貨付清的已完成單，掛一個「應付總金額」會讓團友以為
+ * 還欠那麼多（2026-08-11 會員 109814 的回報：$13,845 裡有 $9,959 是歷史已完成單，
+ * 真正沒領的只有 $3,886）；「已完成」「不成立」則根本沒有應付。與其在「全部」
+ * 解釋口徑，不如不顯示 —— 應付金額只出現在真的還有貨要領的分頁。
  *
  * 「應付」一律用 outstanding_amount（＝還沒領走的貨），**不可以用 payable_amount**。
  * 取貨當下就收現金，已取貨的單早就付清了，payable_amount 是「這張單本身多少錢」，
- * 不是「還欠多少」。2026-08-11 團友 528204 的災情：「全部」分頁把 27 張已完成
- * ($4,137) 加上 1 張部分取貨已領走的那半 ($98) 一起算進「應付總金額」，
- * 顯示 $8,771、實際只欠 $4,536，團友焦慮到打電話進來。
- * 這跟會員中心「未結單金額」是同一個坑 —— DB 早在 20260810000000 就備好
- * outstanding_amount，那次只修了 /me，這張總金額卡漏掉。
+ * 不是「還欠多少」（2026-08-11 團友 528204 的災情，20260810000000 有完整脈絡）。
  *
- * 「已完成」分頁例外：那裡問的是「這些單總共多少錢」（歷史金額），
- * 全部都取走了 outstanding 一律是 0，所以用 payable_amount。
- *
- * 排除 cancelled / expired 的訂單：「全部」分頁刻意保留斷貨整單取消的訂單讓客人
- * 看得到（也有自己的「不成立」分頁），那種單不用付錢，算進去總金額就會跟每張卡上的
- * 應付金額加起來對不上；「不成立」分頁全是這種單，count=0 → 總金額卡整張不顯示。
- * 品項層級的斷貨排除已經在 DB 做掉了（20260808000010），這裡只要顧單頭。
+ * 排除 cancelled / expired 是保險：待到貨 / 待取貨兩個分桶本來就不含它們，
+ * 但口徑寫在這裡，之後誰把這張卡開到別的分頁也不會把不用付錢的單算進去。
  */
-function sumOrders(list: OrderRow[], tab: Tab) {
+function sumOrders(list: OrderRow[]) {
   const active = list.filter((o) => !["cancelled", "expired"].includes(String(o.status ?? "")));
-  const historical = tab === "done";
   return {
     count: active.length,
     amount: active.reduce(
-      (s, o) =>
-        s + Number((historical ? o.payable_amount : o.outstanding_amount) ?? o.payable_amount ?? 0),
+      (s, o) => s + Number(o.outstanding_amount ?? o.payable_amount ?? 0),
       0,
     ),
-    // 這個分頁裡有沒有「已經領走一部分（或全部）」的單 —— 有的話總金額不等於
+    // 這個分頁裡有沒有「已經領走一部分」的單 —— 有的話總金額不等於
     // 各卡的應付金額相加，要在副標講清楚，不然團友手動加總又會對不上。
     hasPicked: active.some(
       (o) => Number(o.outstanding_amount ?? o.payable_amount ?? 0) < Number(o.payable_amount ?? 0),
@@ -123,8 +116,9 @@ export default function OrdersPage() {
   const bucket = buckets[tab];
   const display = bucket.slice(0, visible);
   const hasMore = bucket.length > visible;
-  // 總金額卡照整個分頁算，不是只算已渲染的 10 筆
-  const totals = sumOrders(bucket, tab);
+  // 總金額卡只在「待到貨」「待取貨」出現（理由見 sumOrders 註解），照整個分頁算
+  const showTotals = tab === "waiting" || tab === "pickup";
+  const totals = sumOrders(bucket);
 
   // 捲到底自動載入下一頁（sentinel 進到視窗下方 300px 內就先載，捲起來無縫）
   const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -162,16 +156,15 @@ export default function OrdersPage() {
       <div className="space-y-3 px-4 pt-3 pb-6">
         {loading && <LoadingScreen />}
 
-        {/* 這個分頁的總金額 — 客人最常問的就是「這些加起來多少錢」 */}
-        {!loading && !err && totals.count > 0 && (
+        {/* 這個分頁的應付總金額 — 客人最常問的就是「這些加起來多少錢」。
+            只在待到貨 / 待取貨出現：其他分頁掛金額只會誤導（見 sumOrders） */}
+        {!loading && !err && showTotals && totals.count > 0 && (
           <div className="card flex items-center justify-between gap-3 px-4 py-3">
             <div className="min-w-0">
-              <div className="text-[16px] text-[var(--foreground)]">
-                {tab === "done" ? "訂單總金額" : "應付總金額"}
-              </div>
+              <div className="text-[16px] text-[var(--foreground)]">應付總金額</div>
               <div className="mt-0.5 text-[13px] text-[var(--secondary-label)]">
                 共 {totals.count} 筆訂單
-                {tab !== "done" && totals.hasPicked && (
+                {totals.hasPicked && (
                   <>
                     <span className="mx-1.5 text-[var(--tertiary-label)]">·</span>
                     已取貨的不計（取貨時付現）


### PR DESCRIPTION
「全部」混著幾十張早就取貨付清的已完成單，掛「應付總金額」會讓團友以為還欠
那麼多（會員 109814 的回報：畫面 $13,845，其中 $9,959 是歷史已完成單，真正
沒領的只有 $3,886）。應付金額只出現在真的還有貨要領的分頁；「已完成」的
訂單總金額卡一併移除。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017RsfKEgd3sRGv7PWUmjCY1