### PR TITLE
feat(pickup): 取貨畫面與三張列印單都顯示結單日

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -16,6 +16,7 @@ import { publicProductUrl } from "@/lib/campaignCover";
 import { parseReturnNote } from "@/lib/returnNote";
 import { fetchReprintableEvents, pickupEventLabel, type PickupEventRow } from "@/lib/pickupReceipt";
 import { itemDisplayName } from "@/lib/skuLabel";
+import { CutoffChip } from "@/components/CampaignCutoff";
 
 type Member = {
   id: number;
@@ -802,7 +803,7 @@ function PickupPageContent() {
                                 <div className="min-w-0 flex-1 text-sm">
                                   <div className="flex flex-wrap items-baseline gap-2">
                                     <span>{o.campaign?.name ?? "(未知活動)"}</span>
-                                    <CutoffChip order={o} />
+                                    <CutoffChip date={o.campaign?.cutoff_date} />
                                     {o.status === "partially_completed" && (
                                       <span className="rounded bg-teal-100 px-2 py-0.5 text-[10px] font-medium text-teal-800 dark:bg-teal-950 dark:text-teal-300">
                                         部分已取
@@ -897,7 +898,7 @@ function PickupPageContent() {
                             <div className="min-w-0 flex-1 text-sm">
                               <div className="flex flex-wrap items-baseline gap-2">
                                 <span>{o.campaign?.name ?? "(未知活動)"}</span>
-                                <CutoffChip order={o} />
+                                <CutoffChip date={o.campaign?.cutoff_date} />
                                 {o.status === "partially_completed" && (
                                   <span className="rounded bg-teal-100 px-2 py-0.5 text-[10px] font-medium text-teal-800 dark:bg-teal-950 dark:text-teal-300">
                                     部分已取
@@ -1103,7 +1104,7 @@ function PickupPageContent() {
                     <div key={g.order.id} className="text-sm">
                       <div className="mb-1 flex flex-wrap items-baseline gap-2">
                         <span>{g.order.campaign?.name ?? "(未知活動)"}</span>
-                        <CutoffChip order={g.order} />
+                        <CutoffChip date={g.order.campaign?.cutoff_date} />
                         <span className="text-[10px] text-zinc-500">取貨店：{g.order.store?.name ?? "—"}</span>
                         {evs.length > 0 && (
                           <span className="text-[10px] text-emerald-700 dark:text-emerald-400">
@@ -1185,7 +1186,7 @@ function PickupPageContent() {
                     <div key={o.id} className="text-sm">
                       <div className="mb-1 flex flex-wrap items-baseline gap-2">
                         <span>{o.campaign?.name ?? "(未知活動)"}</span>
-                        <CutoffChip order={o} />
+                        <CutoffChip date={o.campaign?.cutoff_date} />
                         <span className="text-[10px] text-zinc-500">取貨店：{o.store?.name ?? "—"}</span>
                       </div>
                       <ul className="ml-4 space-y-0.5 text-xs">
@@ -1228,20 +1229,6 @@ function PickupPageContent() {
         })()}
       </Modal>
     </div>
-  );
-}
-
-// 結單日（團的 cutoff_date）— 櫃台常要靠它分辨同一個團的不同批次 / 回答客人
-// 「我這張是哪一次訂的」。內部補貨單等沒有團的單子沒有結單日，就不畫。
-function CutoffChip({ order }: { order: OpenOrder }) {
-  if (!order.campaign?.cutoff_date) return null;
-  return (
-    <span
-      className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
-      title="此團的結單日"
-    >
-      結單日 {order.campaign.cutoff_date}
-    </span>
   );
 }
 

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -38,7 +38,7 @@ type OpenOrder = {
   transferred_from_order_id: number | null; // 互助轉入單才有；用來判斷是否走「退回原店」
   last_notify_pickup_at: string | null;
   notify_pickup_count: number;
-  campaign: { id: number; campaign_no: string; name: string } | null;
+  campaign: { id: number; campaign_no: string; name: string; cutoff_date: string | null } | null;
   store: { id: number; name: string } | null;
   items: {
     id: number;
@@ -194,7 +194,7 @@ function PickupPageContent() {
         .from("customer_orders")
         .select(
           `id, order_no, status, pickup_deadline, pickup_store_id, discount_amount, ready_at, transferred_from_order_id, last_notify_pickup_at, notify_pickup_count, member_id,
-           campaign:group_buy_campaigns(id, campaign_no, name),
+           campaign:group_buy_campaigns(id, campaign_no, name, cutoff_date),
            store:stores!customer_orders_pickup_store_id_fkey(id, name),
            items:customer_order_items(id, sku_id, qty, unit_price, status, sku:skus(variant_name, product_name, product:products(images)))`,
         )
@@ -802,6 +802,7 @@ function PickupPageContent() {
                                 <div className="min-w-0 flex-1 text-sm">
                                   <div className="flex flex-wrap items-baseline gap-2">
                                     <span>{o.campaign?.name ?? "(未知活動)"}</span>
+                                    <CutoffChip order={o} />
                                     {o.status === "partially_completed" && (
                                       <span className="rounded bg-teal-100 px-2 py-0.5 text-[10px] font-medium text-teal-800 dark:bg-teal-950 dark:text-teal-300">
                                         部分已取
@@ -894,8 +895,9 @@ function PickupPageContent() {
                             />
                             <OrderThumb order={o} />
                             <div className="min-w-0 flex-1 text-sm">
-                              <div className="flex items-baseline gap-2">
+                              <div className="flex flex-wrap items-baseline gap-2">
                                 <span>{o.campaign?.name ?? "(未知活動)"}</span>
+                                <CutoffChip order={o} />
                                 {o.status === "partially_completed" && (
                                   <span className="rounded bg-teal-100 px-2 py-0.5 text-[10px] font-medium text-teal-800 dark:bg-teal-950 dark:text-teal-300">
                                     部分已取
@@ -1099,17 +1101,18 @@ function PickupPageContent() {
                   const partial = g.items.length < pickedItemsOf(g.order).length;
                   return (
                     <div key={g.order.id} className="text-sm">
-                      <div className="mb-1">
+                      <div className="mb-1 flex flex-wrap items-baseline gap-2">
                         <span>{g.order.campaign?.name ?? "(未知活動)"}</span>
-                        <span className="ml-2 text-[10px] text-zinc-500">取貨店：{g.order.store?.name ?? "—"}</span>
+                        <CutoffChip order={g.order} />
+                        <span className="text-[10px] text-zinc-500">取貨店：{g.order.store?.name ?? "—"}</span>
                         {evs.length > 0 && (
-                          <span className="ml-2 text-[10px] text-emerald-700 dark:text-emerald-400">
+                          <span className="text-[10px] text-emerald-700 dark:text-emerald-400">
                             {pickupEventLabel(evs[evs.length - 1])}
                             {evs.length > 1 && `（共 ${evs.length} 次）`}
                           </span>
                         )}
                         {partial && (
-                          <span className="ml-2 rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                          <span className="rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">
                             只印 {g.items.length}/{pickedItemsOf(g.order).length} 項
                           </span>
                         )}
@@ -1180,9 +1183,10 @@ function PickupPageContent() {
                   const pickItems = pickableItems(o);
                   return (
                     <div key={o.id} className="text-sm">
-                      <div className="mb-1">
+                      <div className="mb-1 flex flex-wrap items-baseline gap-2">
                         <span>{o.campaign?.name ?? "(未知活動)"}</span>
-                        <span className="ml-2 text-[10px] text-zinc-500">取貨店：{o.store?.name ?? "—"}</span>
+                        <CutoffChip order={o} />
+                        <span className="text-[10px] text-zinc-500">取貨店：{o.store?.name ?? "—"}</span>
                       </div>
                       <ul className="ml-4 space-y-0.5 text-xs">
                         {pickItems.map((it) => (
@@ -1224,6 +1228,20 @@ function PickupPageContent() {
         })()}
       </Modal>
     </div>
+  );
+}
+
+// 結單日（團的 cutoff_date）— 櫃台常要靠它分辨同一個團的不同批次 / 回答客人
+// 「我這張是哪一次訂的」。內部補貨單等沒有團的單子沒有結單日，就不畫。
+function CutoffChip({ order }: { order: OpenOrder }) {
+  if (!order.campaign?.cutoff_date) return null;
+  return (
+    <span
+      className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+      title="此團的結單日"
+    >
+      結單日 {order.campaign.cutoff_date}
+    </span>
   );
 }
 

--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -7,6 +7,7 @@ import { stripTransferNotes } from "@/lib/orderNotes";
 import { parseReturnNote } from "@/lib/returnNote";
 import { itemDisplayName } from "@/lib/skuLabel";
 import SpinButton from "@/components/SpinButton";
+import { CutoffText } from "@/components/CampaignCutoff";
 
 type Order = {
   id: number;
@@ -18,7 +19,7 @@ type Order = {
   payment_status: string | null;
   notes: string | null;
   member: { id: number; member_no: string; name: string | null; phone: string | null } | null;
-  campaign: { id: number; name: string } | null;
+  campaign: { id: number; name: string; cutoff_date: string | null } | null;
   store: { id: number; name: string } | null;
   items: {
     id: number;
@@ -86,7 +87,7 @@ function Body() {
           .select(
             `id, order_no, status, discount_amount, discount_percent, wallet_paid_amount, payment_status, notes,
              member:members(id, member_no, name, phone),
-             campaign:group_buy_campaigns(id, name),
+             campaign:group_buy_campaigns(id, name, cutoff_date),
              store:stores!customer_orders_pickup_store_id_fkey(id, name),
              items:customer_order_items(id, sku_id, qty, unit_price, discount_amount, discount_percent, notes, status, sku:skus(variant_name, product_name))`,
           )
@@ -239,7 +240,10 @@ function Body() {
             const orderNotes = stripTransferNotes(o.notes);
             return (
               <div key={o.id} className="border-b border-dashed border-zinc-400 pb-1">
-                <div className="text-[13px]">{o.campaign?.name ?? "(未知活動)"}</div>
+                <div className="text-[13px]">
+                  {o.campaign?.name ?? "(未知活動)"}
+                  <CutoffText date={o.campaign?.cutoff_date} />
+                </div>
                 {orderNotes && (
                   <div className="text-[13px] italic">📝 {orderNotes}</div>
                 )}

--- a/apps/admin/src/app/(protected)/pickup/print-picked/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-picked/page.tsx
@@ -13,6 +13,7 @@ import { getSupabase } from "@/lib/supabase";
 import { stripTransferNotes } from "@/lib/orderNotes";
 import { itemDisplayName } from "@/lib/skuLabel";
 import SpinButton from "@/components/SpinButton";
+import { CutoffText } from "@/components/CampaignCutoff";
 
 type Item = {
   id: number;
@@ -33,7 +34,7 @@ type Order = {
   discount_percent: number;
   notes: string | null;
   member: { id: number; member_no: string; name: string | null; phone: string | null } | null;
-  campaign: { id: number; name: string } | null;
+  campaign: { id: number; name: string; cutoff_date: string | null } | null;
   store: { id: number; name: string } | null;
 };
 
@@ -81,7 +82,7 @@ function Body() {
       const orderIds = Array.from(new Set(items.map((it) => it.order_id)));
       const { data: ords, error: e2 } = await sb
         .from("customer_orders")
-        .select("id, order_no, discount_amount, discount_percent, notes, member:members(id, member_no, name, phone), campaign:group_buy_campaigns(id, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
+        .select("id, order_no, discount_amount, discount_percent, notes, member:members(id, member_no, name, phone), campaign:group_buy_campaigns(id, name, cutoff_date), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
         .in("id", orderIds);
       if (cancelled) return;
       if (e2) { setError(e2.message); return; }
@@ -165,7 +166,10 @@ function Body() {
             const orderNotes = stripTransferNotes(grp.order?.notes ?? null);
             return (
               <div key={gi} className="border-b border-dashed border-zinc-400 pb-1">
-                <div className="text-[13px]">{grp.order?.campaign?.name ?? "(未知活動)"}</div>
+                <div className="text-[13px]">
+                  {grp.order?.campaign?.name ?? "(未知活動)"}
+                  <CutoffText date={grp.order?.campaign?.cutoff_date} />
+                </div>
                 {orderNotes && <div className="text-[13px] italic">📝 {orderNotes}</div>}
                 {grp.items.map((it) => (
                   <div key={it.id}>

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -6,6 +6,7 @@ import { getSupabase } from "@/lib/supabase";
 import { stripTransferNotes } from "@/lib/orderNotes";
 import { itemDisplayName } from "@/lib/skuLabel";
 import SpinButton from "@/components/SpinButton";
+import { CutoffText } from "@/components/CampaignCutoff";
 
 type PickupEvent = {
   id: number;
@@ -28,7 +29,7 @@ type Order = {
   payment_status: string | null;
   notes: string | null;
   member: { id: number; member_no: string; name: string | null; phone: string | null } | null;
-  campaign: { id: number; campaign_no: string; name: string } | null;
+  campaign: { id: number; campaign_no: string; name: string; cutoff_date: string | null } | null;
   store: { id: number; name: string } | null;
 };
 
@@ -87,7 +88,7 @@ function Body() {
       const allItemIds = events.flatMap((e) => e.item_ids ?? []);
       const [{ data: ords }, { data: itms }] = await Promise.all([
         sb.from("customer_orders")
-          .select("id, order_no, status, pickup_store_id, discount_amount, discount_percent, wallet_paid_amount, payment_status, notes, member:members(id, member_no, name, phone), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
+          .select("id, order_no, status, pickup_store_id, discount_amount, discount_percent, wallet_paid_amount, payment_status, notes, member:members(id, member_no, name, phone), campaign:group_buy_campaigns(id, campaign_no, name, cutoff_date), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .in("id", orderIds),
         allItemIds.length > 0
           ? sb.from("customer_order_items").select("id, qty, unit_price, discount_amount, discount_percent, notes, status, sku:skus(sku_code, product_name, variant_name)").in("id", allItemIds)
@@ -188,7 +189,10 @@ function Body() {
             const orderNotes = stripTransferNotes(r.order?.notes);
             return (
               <div key={r.event.id} className="border-b border-dashed border-zinc-400 pb-1">
-                <div className="text-[13px]">{r.order?.campaign?.name ?? "(未知活動)"}</div>
+                <div className="text-[13px]">
+                  {r.order?.campaign?.name ?? "(未知活動)"}
+                  <CutoffText date={r.order?.campaign?.cutoff_date} />
+                </div>
                 {orderNotes && (
                   <div className="text-[13px] italic">📝 {orderNotes}</div>
                 )}

--- a/apps/admin/src/components/CampaignCutoff.tsx
+++ b/apps/admin/src/components/CampaignCutoff.tsx
@@ -1,0 +1,24 @@
+// 結單日（group_buy_campaigns.cutoff_date）的統一顯示。
+// 櫃台要靠它分辨同一個團的不同批次 / 回答客人「我這張是哪一次訂的」，
+// 而且要跟會員端「我的訂單」印的那個結單日對得起來。
+// 內部補貨等沒有團的單子沒有結單日 → 兩個元件都直接不畫（不要印「—」佔位）。
+
+// 螢幕用：團名旁邊的灰底小標（/pickup 列表與確認視窗）
+export function CutoffChip({ date }: { date?: string | null }) {
+  if (!date) return null;
+  return (
+    <span
+      className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+      title="此團的結單日"
+    >
+      結單日 {date}
+    </span>
+  );
+}
+
+// 80mm 熱感應單用：接在團名後面，不佔一整行（單子已經很長）。
+// 熱感應只有黑白，別用顏色區分 — 一律跟團名同一個灰階。
+export function CutoffText({ date }: { date?: string | null }) {
+  if (!date) return null;
+  return <span className="ml-1.5">· 結單日 {date}</span>;
+}


### PR DESCRIPTION
## 為什麼

取貨頁只看得到團名。同一個團開很多批時，櫃台分不出客人手上這張是哪一次訂的，也跟會員端「我的訂單」已經有的結單日對不起來。

## 改了什麼

把團的 `cutoff_date` 一起撈回來，畫在團名旁邊。**螢幕四處 + 紙本三張**一起補，避免只補一處造成「列表看得到、確認視窗看不到」「螢幕有、紙本沒有」：

螢幕（`/pickup`）
- 未取貨列表
- 已取貨（補印）列表
- 「一次全取」確認視窗
- 「合併補印」確認視窗

紙本（80mm 熱感）
- `/pickup/print` 取貨單（取貨完自動印 / 補印）
- `/pickup/print-list` 取貨清單（小白單）
- `/pickup/print-picked` 取貨明細（挑品項補印）

結單日的畫法收在新的 `apps/admin/src/components/CampaignCutoff.tsx`：`CutoffChip`（螢幕灰底小標）與 `CutoffText`（紙本，接在團名後面「· 結單日 YYYY-MM-DD」）。螢幕與紙本共用同一份，之後改格式不會只改到一邊。

沒有團的單（內部補貨等）`cutoff_date` 是 null，兩邊都直接不畫，也不留「—」佔位。

純顯示改動：沒有動 RPC、view、migration，也沒有動任何金額 / 可取品項的計算。

## 怎麼驗的

- `tsc --noEmit` 乾淨。
- eslint 只剩這幾支檔案本來就有的 `react-hooks/set-state-in-effect`，與 `main` 相同，非本次新增。
- 用 admin 的 verify 流程（dev server + Playwright + fixture，不碰線上 DB）實際跑過：未取貨 / 已取貨 / 一次全取視窗、以及三個列印頁都截圖確認，結單日有出現、80mm 寬度內沒把版面擠爆；同時放一張 `cutoff_date` 為 null 的訂單，確認它沒有多印東西。

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsDeyo5DcsECisFUJioczK)_