### PR TITLE
Add campaign_no to order summary view & fix internal sentinel order titles

### DIFF
--- a/apps/admin/src/components/MemberOrdersAppView.tsx
+++ b/apps/admin/src/components/MemberOrdersAppView.tsx
@@ -8,22 +8,25 @@
  * 對不上就得來回一整個下午。這個視圖跟 app 用同一個 view、同一套分桶與加總，
  * 客服看到的數字 = 團友手機上的數字，一眼就能對。
  *
- * 「一樣」是硬需求，三個地方要跟會員端同步（改那邊記得改這邊）：
+ * 「一樣」是硬需求，四個地方要跟會員端同步（改那邊記得改這邊）：
  *   - 資料管線 = liff-api listMyOrders：v_customer_order_summary、半年內、
  *     active / history 各最多 100 筆、一般取消不顯示但斷貨取消要顯示、已轉讓隱藏
  *   - orderPhase 分桶 = apps/member/src/components/OrderCard.tsx
  *   - 應付總金額只在「待到貨」「待取貨」顯示、用 outstanding_amount
  *     = apps/member/src/app/orders/page.tsx（2026-08-11 起「全部」不顯示金額）
+ *   - 卡片標題 orderCardTitle（內部 sentinel 團改印品項名）
+ *     = apps/member/src/lib/orderTitle.ts 的副本 lib/orderTitle.ts
  *
  * 後台加值：點卡片可直接開訂單明細（會員 app 沒有這個）。
  */
 
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
-import { cleanCampaignText } from "@/lib/text";
+import { orderCardTitle } from "@/lib/orderTitle";
 
 type AppOrderItem = {
   id: number;
+  product_name: string | null;
   variant_name: string | null;
   qty: number;
   unit_price: number;
@@ -45,6 +48,8 @@ export type AppOrderRow = {
   arrived: boolean;
   items: AppOrderItem[];
   created_at: string;
+  /** 內部 sentinel 團判斷用（'__' 開頭）；v_customer_order_summary @20260811000050 */
+  campaign_no: string | null;
   campaign_name: string | null;
   campaign_cutoff_date: string | null;
   store_name: string | null;
@@ -272,7 +277,8 @@ export function MemberOrdersAppView({
 // = apps/member/src/components/OrderCard.tsx 的卡片內容（後台配色 + 可點擊）
 function AppOrderCard({ order, onClick }: { order: AppOrderRow; onClick: () => void }) {
   const phase = orderPhase(order);
-  const title = cleanCampaignText(order.campaign_name) || "訂單";
+  // 內部 sentinel 團（店內現貨轉手單）印品項名，其餘印開團名稱 —— 見 lib/orderTitle
+  const title = orderCardTitle(order);
   const totalQty = (order.items ?? []).reduce(
     (s, i) => (["cancelled", "expired"].includes(i.status) ? s : s + Number(i.qty ?? 0)),
     0,

--- a/apps/admin/src/lib/orderTitle.ts
+++ b/apps/admin/src/lib/orderTitle.ts
@@ -1,0 +1,67 @@
+// 訂單卡標題：一般團購單印開團名稱，內部 sentinel 團改印品項名。
+//
+// 為什麼要有例外：店內現貨轉手給客人的單（__INTERNAL_RESTOCK__-TFxxxx）
+// 全部掛在共用 sentinel 團「【內部】補貨申請」底下 —— 那個名字是內部帳本用語，
+// 一個商品字都沒有。直接印出來，客人看到的就是一張標題「【內部】補貨申請」、
+// 品項只有規格「一尾 139 × 2」的卡片，完全認不出自己買了什麼
+// （2026-08-11 回報；線上 94 張、84 位真會員中獎）。
+//
+// 一般團購單維持印開團名稱 —— 客人是照開團名下單的，改成商品名反而對不上。
+//
+// ⚠️ 這是會員 app 那份的副本（後台「會員畫面」＝團友手機上的畫面，客服對帳時
+//    兩邊要一模一樣）：apps/member/src/lib/orderTitle.ts。改這邊記得改那邊。
+
+import { cleanCampaignText } from "@/lib/text";
+
+export type TitleItemLike = {
+  product_name?: string | null;
+  variant_name?: string | null;
+  status?: string | null;
+};
+
+export type TitleOrderLike = {
+  /** v_customer_order_summary.campaign_no（20260811000050 起才有） */
+  campaign_no?: string | null;
+  campaign_name?: string | null;
+  items?: TitleItemLike[] | null;
+};
+
+/**
+ * 內部 sentinel 團：campaign_no 以 '__' 開頭（= /shop 擋掉內部團用的同一條判斷）。
+ * campaign_name 的「【內部】」前綴是備援 —— 舊 payload（view 還沒補 campaign_no
+ * 之前的快取回應）也要能認出來，否則就會漏印成內部用語。
+ */
+export function isInternalCampaign(order: TitleOrderLike): boolean {
+  const no = (order.campaign_no ?? "").trim();
+  if (no) return no.startsWith("__");
+  return (order.campaign_name ?? "").trim().startsWith("【內部】");
+}
+
+/** 一列品項要用哪個名字：商品名優先，沒有才退規格名 */
+function itemName(it: TitleItemLike): string {
+  return cleanCampaignText(it.product_name) || cleanCampaignText(it.variant_name) || "";
+}
+
+function distinctItemNames(items: TitleItemLike[]): string[] {
+  const out: string[] = [];
+  for (const it of items) {
+    const n = itemName(it);
+    if (n && !out.includes(n)) out.push(n);
+  }
+  return out;
+}
+
+export function orderCardTitle(order: TitleOrderLike): string {
+  const campaign = cleanCampaignText(order.campaign_name);
+  if (!isInternalCampaign(order)) return campaign || "訂單";
+
+  const items = order.items ?? [];
+  // 斷貨 / 取消的品項不拿來當標題（那些行卡片上已經畫成刪除線）；
+  // 整張都被取消時退回用全部品項，才不會變成沒有標題的空卡片。
+  const active = items.filter((it) => !["cancelled", "expired"].includes(String(it.status ?? "")));
+  const names = distinctItemNames(active.length > 0 ? active : items);
+
+  if (names.length === 0) return campaign || "訂單";
+  if (names.length <= 2) return names.join("、");
+  return `${names[0]} 等 ${names.length} 項`;
+}

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -1,4 +1,4 @@
-import { cleanCampaignText } from "@/lib/text";
+import { orderCardTitle } from "@/lib/orderTitle";
 import StatusChip from "@/components/StatusChip";
 
 export type OrderItem = {
@@ -42,6 +42,8 @@ export type OrderRow = {
   items: OrderItem[];
   notes: string | null;
   created_at: string;
+  /** 內部 sentinel 團判斷用（'__' 開頭）；v_customer_order_summary @20260811000050 */
+  campaign_no?: string | null;
   campaign_name: string | null;
   campaign_cover_url: string | null;
   campaign_cutoff_date: string | null;
@@ -111,7 +113,8 @@ export default function OrderCard({ order }: { order: OrderRow }) {
     (s, i) => (["cancelled", "expired"].includes(i.status) ? s : s + Number(i.qty ?? 0)),
     0,
   );
-  const title = cleanCampaignText(order.campaign_name) || "訂單";
+  // 內部 sentinel 團（店內現貨轉手單）印品項名，其餘印開團名稱 —— 見 lib/orderTitle
+  const title = orderCardTitle(order);
   const phase = orderPhase(order);
   // 已經領走一部分（取貨當場收現金）→ 這張單真正還要付的是 outstanding_amount。
   // 只在「領了一部分、還剩一部分」時才多畫一行：全部領完 / 取消的單 outstanding=0，

--- a/apps/member/src/lib/orderTitle.ts
+++ b/apps/member/src/lib/orderTitle.ts
@@ -1,0 +1,67 @@
+// 訂單卡標題：一般團購單印開團名稱，內部 sentinel 團改印品項名。
+//
+// 為什麼要有例外：店內現貨轉手給客人的單（__INTERNAL_RESTOCK__-TFxxxx）
+// 全部掛在共用 sentinel 團「【內部】補貨申請」底下 —— 那個名字是內部帳本用語，
+// 一個商品字都沒有。直接印出來，客人看到的就是一張標題「【內部】補貨申請」、
+// 品項只有規格「一尾 139 × 2」的卡片，完全認不出自己買了什麼
+// （2026-08-11 回報；線上 94 張、84 位真會員中獎）。
+//
+// 一般團購單維持印開團名稱 —— 客人是照開團名下單的，改成商品名反而對不上。
+//
+// ⚠️ 這份邏輯在後台「會員畫面」有一份一模一樣的副本（會員來問時客服要看到
+//    跟團友手機上完全相同的畫面）：apps/admin/src/lib/orderTitle.ts。改這邊記得改那邊。
+
+import { cleanCampaignText } from "@/lib/text";
+
+export type TitleItemLike = {
+  product_name?: string | null;
+  variant_name?: string | null;
+  status?: string | null;
+};
+
+export type TitleOrderLike = {
+  /** v_customer_order_summary.campaign_no（20260811000050 起才有） */
+  campaign_no?: string | null;
+  campaign_name?: string | null;
+  items?: TitleItemLike[] | null;
+};
+
+/**
+ * 內部 sentinel 團：campaign_no 以 '__' 開頭（= /shop 擋掉內部團用的同一條判斷）。
+ * campaign_name 的「【內部】」前綴是備援 —— 舊 payload（view 還沒補 campaign_no
+ * 之前的快取回應）也要能認出來，否則就會漏印成內部用語。
+ */
+export function isInternalCampaign(order: TitleOrderLike): boolean {
+  const no = (order.campaign_no ?? "").trim();
+  if (no) return no.startsWith("__");
+  return (order.campaign_name ?? "").trim().startsWith("【內部】");
+}
+
+/** 一列品項要用哪個名字：商品名優先，沒有才退規格名 */
+function itemName(it: TitleItemLike): string {
+  return cleanCampaignText(it.product_name) || cleanCampaignText(it.variant_name) || "";
+}
+
+function distinctItemNames(items: TitleItemLike[]): string[] {
+  const out: string[] = [];
+  for (const it of items) {
+    const n = itemName(it);
+    if (n && !out.includes(n)) out.push(n);
+  }
+  return out;
+}
+
+export function orderCardTitle(order: TitleOrderLike): string {
+  const campaign = cleanCampaignText(order.campaign_name);
+  if (!isInternalCampaign(order)) return campaign || "訂單";
+
+  const items = order.items ?? [];
+  // 斷貨 / 取消的品項不拿來當標題（那些行卡片上已經畫成刪除線）；
+  // 整張都被取消時退回用全部品項，才不會變成沒有標題的空卡片。
+  const active = items.filter((it) => !["cancelled", "expired"].includes(String(it.status ?? "")));
+  const names = distinctItemNames(active.length > 0 ? active : items);
+
+  if (names.length === 0) return campaign || "訂單";
+  if (names.length <= 2) return names.join("、");
+  return `${names[0]} 等 ${names.length} 項`;
+}

--- a/supabase/migrations/20260811000050_order_summary_campaign_no.sql
+++ b/supabase/migrations/20260811000050_order_summary_campaign_no.sql
@@ -1,0 +1,234 @@
+-- ============================================================
+-- 2026-08-11 (5)：v_customer_order_summary 補上 campaign_no
+--
+-- 為什麼：內部 sentinel 團（campaign_no = '__INTERNAL_RESTOCK__'、名稱
+--   「【內部】補貨申請」）底下會長出**真會員**的訂單 —— 店內現貨轉手給客人
+--   （__INTERNAL_RESTOCK__-TFxxxx）就是掛在這個團。線上 94 張、84 位真會員。
+--   會員 app / 後台「會員畫面」的訂單卡標題直接印 campaign_name，結果客人看到的
+--   是「【內部】補貨申請」—— 內部帳本用語，而且一個商品字都沒有，客人根本
+--   認不出自己買了什麼（2026-08-11 回報：會員 M043330 #72917）。
+--
+--   前端要能認出「這是 sentinel 團 → 標題改印品項」，但 view 只給了
+--   campaign_name，只能用中文字串比對（脆）。這一版把 campaign_no 一起吐出來，
+--   前端沿用 /shop 既有的判斷方式：campaign_no 以 '__' 開頭 = 內部 sentinel。
+--
+-- 基底版本（append-only，逐字保留所有 prior fix）：
+--   v_customer_order_summary：20260811000010_member_arrived_uses_pickup_gate.sql
+--   （逐字複製，只多一個 gbc.campaign_no 輸出欄）
+--
+-- Rollback：v_customer_order_summary 還原為 20260811000010 版本
+--
+-- 對應程式（同一個 commit）：
+--   apps/member/src/components/OrderCard.tsx
+--   apps/admin/src/components/MemberOrdersAppView.tsx
+--   兩邊共用同一條規則（orderCardTitle）：sentinel 團的卡片標題改印品項名。
+-- ============================================================
+
+DROP VIEW IF EXISTS v_customer_order_summary;
+
+CREATE VIEW v_customer_order_summary AS
+SELECT
+  co.id,
+  co.tenant_id,
+  co.order_no,
+  co.member_id,
+  co.pickup_store_id          AS store_id,
+  co.campaign_id,
+  co.channel_id,
+  co.status,
+  co.payment_status,
+  co.payment_method,
+  co.paid_at,
+  co.shipping_method,
+  co.shipping_address,
+  co.shipping_phone,
+  co.shipping_note,
+  co.remit_amount,
+  co.remit_at,
+  co.remit_note,
+  co.shipping_fee,
+  co.discount_amount,
+  co.discount_percent,
+  co.wallet_paid_amount,
+  co.pickup_deadline,
+  co.notes,
+  co.created_at,
+  co.confirmed_at,
+  co.shipping_at,
+  co.ready_at,
+  co.completed_at,
+  co.cancelled_at,
+  co.stockout_at,
+  agg.items_total,
+  agg.unpicked_total,
+  ret.returned_qty,
+  ret.returned_deduction,
+  GREATEST(
+    0,
+    ROUND(
+      GREATEST(0, agg.items_total - ret.returned_deduction)
+        * (1 - co.discount_percent / 100)
+        + co.shipping_fee
+        - co.discount_amount,
+      0
+    )
+  )                                                                            AS payable_amount,
+  GREATEST(
+    0,
+    GREATEST(
+      0,
+      ROUND(
+        GREATEST(0, agg.items_total - ret.returned_deduction)
+          * (1 - co.discount_percent / 100)
+          + co.shipping_fee
+          - co.discount_amount,
+        0
+      )
+    ) - co.wallet_paid_amount
+  )                                                                            AS balance_due,
+  -- 20260810000000：還沒收的錢 = 尚未取貨品項套同一條應收算式，再扣掉已付的儲值金。
+  -- 終態訂單（cancelled / expired / transferred_out）與「已全部取走」一律 0；
+  -- 全取走時直接回 0，不讓運費 / 折扣在沒有貨的情況下自己長出金額。
+  CASE
+    WHEN co.status IN ('cancelled','expired','transferred_out') THEN 0
+    WHEN agg.unpicked_total <= 0                                THEN 0
+    ELSE GREATEST(
+      0,
+      GREATEST(
+        0,
+        ROUND(
+          GREATEST(0, agg.unpicked_total - ret.returned_deduction)
+            * (1 - co.discount_percent / 100)
+            + co.shipping_fee
+            - co.discount_amount,
+          0
+        )
+      ) - co.wallet_paid_amount
+    )
+  END                                                                          AS outstanding_amount,
+  agg.items,
+  -- 20260811000010：到店與否＝「現在有沒有東西可以交給客人」，直接問品項層級的
+  -- 取貨閘門（店員發貨用的同一套），不要只看單頭 status —— 單頭只有
+  -- rpc_receive_transfer 收到該店 transfer 時才會被推到 ready，靠店內現貨
+  -- 吸收缺口的單永遠等不到那一刻。有任一項可取即算，不要求整張全到齊。
+  -- 快路徑先擋掉 96%：已經是 ready 之後的狀態一律 true，函式只對 'shipping' 呼叫。
+  (co.status IN ('reserved','ready','partially_ready',
+                 'partially_completed','completed')
+   OR (co.status = 'shipping' AND EXISTS (
+         SELECT 1 FROM customer_order_items coi
+          WHERE coi.order_id = co.id
+            AND coi.status IN ('pending','reserved','ready')
+            AND public.is_order_item_pickup_ready(coi.id)
+       )))                                                                      AS arrived,
+  (co.confirmed_at IS NOT NULL
+    OR co.status IN ('reserved','ready','partially_ready',
+                     'partially_completed','shipping','completed'))            AS settled,
+  (co.payment_status = 'paid')                                                 AS paid,
+  (co.status IN ('shipping','completed'))                                      AS shipped,
+  ('S-' || lpad(co.id::text, 8, '0')
+        || '-'
+        || COALESCE(s.store_short_code, 'XX'))                                 AS settlement_no,
+  s.name                                                                        AS store_name,
+  s.code                                                                        AS store_code,
+  gbc.campaign_no                                                               AS campaign_no,
+  gbc.name                                                                      AS campaign_name,
+  gbc.cover_image_url                                                           AS campaign_cover_url,
+  gbc.end_at                                                                    AS campaign_end_at,
+  gbc.cutoff_date                                                               AS campaign_cutoff_date
+FROM customer_orders co
+LEFT JOIN stores               s   ON s.id = co.pickup_store_id
+LEFT JOIN group_buy_campaigns  gbc ON gbc.id = co.campaign_id
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price)
+               FILTER (WHERE coi.status NOT IN ('cancelled','expired')), 0)  AS items_total,
+    -- 20260810000000：尚未取貨的部分（picked_up 也排掉）。取貨當下收現金，
+    -- 所以「取走了」＝「收到錢了」，不該再算在未結裡。
+    COALESCE(SUM(coi.qty * coi.unit_price)
+               FILTER (WHERE coi.status NOT IN ('cancelled','expired','picked_up')), 0)
+                                                                              AS unpicked_total,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',               coi.id,
+          'sku_id',           coi.sku_id,
+          'sku_code',         sk.sku_code,
+          'product_name',     sk.product_name,
+          'variant_name',     sk.variant_name,
+          'campaign_item_id', coi.campaign_item_id,
+          'qty',              coi.qty,
+          'unit_price',       coi.unit_price,
+          'subtotal',         coi.qty * coi.unit_price,
+          'status',           coi.status,
+          'stockout',         (coi.stockout_at IS NOT NULL),
+          'notes',            coi.notes,
+          'image_url',        CASE
+            WHEN jsonb_typeof(p.images) = 'array' AND jsonb_array_length(p.images) > 0 THEN
+              COALESCE(p.images -> 0 ->> 'url', p.images ->> 0)
+            ELSE NULL
+          END
+        ) ORDER BY coi.id
+      ),
+      '[]'::jsonb
+    )                                                                           AS items
+  FROM customer_order_items coi
+  LEFT JOIN skus     sk ON sk.id = coi.sku_id
+  LEFT JOIN products p  ON p.id  = sk.product_id
+  WHERE coi.order_id = co.id
+) agg ON TRUE
+LEFT JOIN LATERAL (
+  -- 未取退貨扣減：return_to_hq（shipped/received、notes header 不含
+  -- |取貨後退回）依 SKU 聚合退貨量，按品項行序 (id) 分攤到未取消品項行、
+  -- 以該行 unit_price 折算金額
+  SELECT
+    COALESCE(SUM(a.alloc_qty), 0)                AS returned_qty,
+    COALESCE(SUM(a.alloc_qty * a.unit_price), 0) AS returned_deduction
+  FROM (
+    SELECT
+      i.unit_price,
+      LEAST(i.qty, GREATEST(r.ret_qty - i.prior_qty, 0)) AS alloc_qty
+    FROM (
+      SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+        FROM transfers t
+        JOIN transfer_items ti ON ti.transfer_id = t.id
+       WHERE t.customer_order_id = co.id
+         AND t.tenant_id     = co.tenant_id
+         AND t.transfer_type = 'return_to_hq'
+         AND t.status IN ('shipped','received')
+         AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+             NOT LIKE '%取貨後退回%'
+       GROUP BY ti.sku_id
+    ) r
+    JOIN (
+      SELECT coi.sku_id, coi.qty, coi.unit_price,
+             COALESCE(SUM(coi.qty) OVER (
+               PARTITION BY coi.sku_id ORDER BY coi.id
+               ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+             ), 0) AS prior_qty
+        FROM customer_order_items coi
+       WHERE coi.order_id = co.id
+         AND coi.status NOT IN ('cancelled','expired')
+    ) i ON i.sku_id = r.sku_id
+  ) a
+) ret ON TRUE;
+
+COMMENT ON VIEW v_customer_order_summary IS
+  'LIFF 顧客端共用：訂單聚合 + 品項詳細 + percent + amount 雙折扣 + 儲值金抵扣 + balance_due'
+  '（應收已四捨五入到整數 NTD）+ 斷貨標記（stockout_at / items[].stockout）'
+  '+ 未取退貨扣減（returned_qty / returned_deduction；取貨後退回不扣、退款走 rpc_wallet_partial_refund）'
+  '。20260808000010：items_total 不含 cancelled/expired 品項（斷貨 / 人工刪除的品項不收錢）；'
+  'items[] 仍保留這些行供前端顯示「斷貨」。'
+  '20260810000000：新增 unpicked_total / outstanding_amount —— 會員端「未結單金額」'
+  '（已訂未領貨）專用，取貨即收現金，所以 picked_up 品項不算；'
+  'cancelled/expired/transferred_out 訂單一律 0。payment_status 全站從未寫過 ''paid''，'
+  '不可以拿來當「有沒有收到錢」的依據。'
+  '20260811000010：arrived 改問品項層級取貨閘門 is_order_item_pickup_ready() —— '
+  '派貨中（門市未收貨）一律不算到店；有任一項可取即算，不要求全到齊。'
+  '20260811000050：新增 campaign_no —— 前端用 ''__'' 前綴認出內部 sentinel 團'
+  '（__INTERNAL_RESTOCK__），訂單卡標題改印品項名，不要把「【內部】補貨申請」'
+  '這種內部用語印給客人看。';
+
+-- DROP + CREATE 會清掉 grant。public schema 的 default privileges 本來就會補回
+-- anon/authenticated/service_role（20260731000000 沒寫 GRANT 也活著），這裡明寫一行
+-- 當保險，不依賴 default privileges 的設定沒被動過。
+GRANT SELECT ON v_customer_order_summary TO authenticated, anon;


### PR DESCRIPTION
## Summary

Fixes customer-facing order card titles for internal sentinel orders (store inventory transfers). These orders were incorrectly displaying "【內部】補貨申請" (internal restock request) instead of product names, making it impossible for customers to recognize what they purchased.

## Changes

**Database Migration** (`20260811000050_order_summary_campaign_no.sql`)
- Adds `campaign_no` column to `v_customer_order_summary` view
- Enables frontend to identify internal sentinel campaigns (those with `campaign_no` starting with `__`) without relying on fragile Chinese text matching
- Preserves all prior fixes from `20260811000010` version (append-only migration pattern)

**Shared Order Title Logic** (new files)
- `apps/admin/src/lib/orderTitle.ts` - Backend admin panel order title logic
- `apps/member/src/lib/orderTitle.ts` - Member app order title logic (identical copy)

Both implement `orderCardTitle()` function that:
- Displays campaign name for regular group buy orders
- Displays product names for internal sentinel orders (identified by `campaign_no` starting with `__` or fallback to `【內部】` prefix)
- Filters out cancelled/expired items from title generation
- Handles edge cases (no items, multiple items with "等 N 項" format)

**Component Updates**
- `apps/admin/src/components/MemberOrdersAppView.tsx` - Uses new `orderCardTitle()` instead of direct `campaign_name` display; adds `campaign_no` to `AppOrderRow` type
- `apps/member/src/components/OrderCard.tsx` - Uses new `orderCardTitle()` instead of direct `campaign_name` display; adds `campaign_no` to `OrderRow` type

## Implementation Details

- The `campaign_no` field provides a reliable, non-text-dependent way to identify internal sentinel campaigns (matching the same `__` prefix check used in `/shop` endpoint)
- Fallback to `【內部】` prefix check ensures backward compatibility with cached responses before view was updated
- Both frontend implementations are intentionally identical copies to ensure customer-facing display matches backend admin view (critical for customer service alignment)
- Active items (non-cancelled/expired) are prioritized for title generation; if all items are cancelled, falls back to full item list to avoid empty titles

https://claude.ai/code/session_016VZmCYirmpyFNTPLxLWHjM