### PR TITLE
v_order_shortage v5: campaign×sku gate + forward-looking model

### DIFF
--- a/apps/admin/src/components/ExceptionsContent.tsx
+++ b/apps/admin/src/components/ExceptionsContent.tsx
@@ -55,6 +55,8 @@ type ExceptionRow = {
   diff: number;
   reason: string | null;
   extra: string;
+  // 該筆異常的地點:PO/GR 收貨倉、收貨分店、取貨店(v_hq_exceptions.warehouse_name)
+  warehouse_name: string | null;
   shortage_ctx?: ShortageContext;
   // customer_shortage 用
   customer_order_id?: number;
@@ -86,6 +88,7 @@ type ViewRow = {
   dest_store_name: string | null;
   customer_order_id: number | null;
   shortage_resolution: string | null;
+  warehouse_name: string | null;
 };
 
 type ExceptionCounts = Record<Tab, number>;
@@ -224,6 +227,7 @@ export default function ExceptionsContent({
           diff: Number(r.diff),
           reason: r.reason,
           extra: r.extra,
+          warehouse_name: r.warehouse_name,
           shortage_ctx:
             r.type === "transfer_short" && r.transfer_item_id != null
               ? {
@@ -423,6 +427,7 @@ export default function ExceptionsContent({
               </th>
               <th className="px-3 py-2">類型</th>
               <th className="px-3 py-2">單號</th>
+              <th className="px-3 py-2">地點</th>
               <th className="px-3 py-2">品項</th>
               <th className="px-3 py-2 text-right">預期</th>
               <th className="px-3 py-2 text-right">實際</th>
@@ -433,9 +438,9 @@ export default function ExceptionsContent({
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={9} className="p-6 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={10} className="p-6 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={9} className="p-6 text-center text-zinc-500">沒有異常,系統運作正常 ✓</td></tr>
+              <tr><td colSpan={10} className="p-6 text-center text-zinc-500">沒有異常,系統運作正常 ✓</td></tr>
             ) : rows.map((r) => (
               <tr key={r.key} className="hover:bg-zinc-50 dark:hover:bg-zinc-950">
                 <td className="px-3 py-2">
@@ -460,6 +465,7 @@ export default function ExceptionsContent({
                   }`}>{TAB_LABEL[r.type]}</span>
                 </td>
                 <td className="px-3 py-2 font-mono text-xs whitespace-nowrap">{r.doc_no}</td>
+                <td className="px-3 py-2 text-xs whitespace-nowrap font-medium">{r.warehouse_name ?? "—"}</td>
                 <td className="px-3 py-2 text-xs min-w-[220px]">
                   {r.sku_code && <div className="font-mono text-[10px] text-zinc-500">{r.sku_code}</div>}
                   <div>{r.sku_label}</div>

--- a/supabase/migrations/20260811010000_v_order_shortage_v5_campaign_gate.sql
+++ b/supabase/migrations/20260811010000_v_order_shortage_v5_campaign_gate.sql
@@ -1,0 +1,276 @@
+-- ============================================================
+-- v_order_shortage v5：前瞻模型（v4）＋「這一輪團的採購已定案」閘門
+--
+-- 事故案例（本次修法動機）：
+--   2026-08-11 /wms/exceptions「訂單短少」266 列，抽查後 260 列是誤報：
+--
+--   A. 還在收單的團就先爆警報（177 列 / 172 單 / 307 件，最大宗）
+--      GRP-20260806-009 厚實鮭魚菲力、GRP-20260807-001 土雞蛋、
+--      GRP-20260807-002 小卷炊粉、GRP-20260806-005 海鮮煎餅、
+--      GRP-20260806-008 牛三寶 —— 全部 status='open'、end_at=2026-08-11
+--      （當天才結單），這幾支 SKU 八月的 PO 一張都沒有（本來就還沒到
+--      下採購單的時候）。但線上 v3 的「採購已定案」閘門是**SKU 層級**的
+--      （該 SKU 存在 sent/partial/fully/closed 的 PO 就判），這幾支 SKU
+--      六月/七月的舊團各有一張 fully_received 的舊 PO → 閘門成立，
+--      供給欄只認得到舊團的累計收貨（G00075-02 只有 27 件、
+--      G00199-01 125 件…），新團一開賣就整團掛短缺。
+--      ＝「同一支 SKU 只要開過一次團，之後每一輪都會在結單前先被判短缺」。
+--
+--   B. 貨已經到店的單還算在需求裡（41 列 / 34 單 / 208 件）
+--      RR-373/376/377/381/392、__INTERNAL_RESTOCK__-TF0381/TF0393 這些
+--      補貨/現貨池單 status 已是 ready（貨真的在店裡），v3 的需求集合是
+--      「非終態訂單」，ready 也算 → G01203-01 智利鮭魚頭需求 253 件裡
+--      241 件是 ready，累計收貨 223 → 假短缺 30。
+--      （＝ 20260801000000_v_order_shortage_v4 檔頭寫的「破洞 2」。）
+--
+-- 修法：v4 前瞻模型補回線上，並把閘門從 SKU 層級改成 campaign×sku 層級。
+--
+--   需求 = 還沒拿到貨的品項：
+--     coi.status='pending' AND co.status IN ('pending','confirmed','shipping')
+--     （ready/completed = 貨已到店，離開需求池 → B 消失）
+--     抵減單（order_kind='offset'，負數量）不論 pending/confirmed/ready
+--     都保留在需求裡（會計性抵減、不是待送達的貨；線上 13 列 -26 件掛在
+--     ready 單上，若隨 ready 一起被排除會虛增需求）。
+--   供給 = 經總倉現貨 on_hand（含盤點/調帳來的貨，不限 PO/GR 管道）
+--        + PO 在途（sent/partially_received 未收餘量，且 stockout_at IS NULL）
+--        + 調撥在途（transfers.status='shipped' 的 qty_shipped）。
+--     累計 GR 不再進判定（total_gr 保留為純資訊欄）。
+--   閘門 = **這張訂單所屬的 campaign×sku 有一張定案 PO** 才判短缺。
+--     po_item ↔ campaign 的對應沿用 v_picking_demand_by_po 的 po_campaigns
+--     寫法（purchase_request_campaigns UNION purchase_request_items
+--     .source_campaign_id），不要另外自己定義。→ A 消失。
+--   短缺 = GREATEST(0, 需求 − 供給)，用線上現行的 LIFO 拆行分攤
+--     （見下方「線上 drift」）。
+--
+-- 模型自癒：採購開單 → 閘門成立、在途進供給；盤點加貨 → on_hand 上升；
+--   波次出貨 → 轉調撥在途；店端收貨 → 訂單 ready 離開需求。
+--
+-- 線上 drift（本檔一併收編，別再被沖掉）：
+--   1. repo 的 20260801000000_v_order_shortage_v4_forward_looking.sql
+--      從來沒部署過；20260807000000_same_store_transfer_before_arrival.sql
+--      以「線上現行定義」為基底重寫時收錄的是 po_item_stockout 的 v3 分支，
+--      等於把 v4 蓋掉。本檔＝v4 的模型 + 20260807000000 的同店衍生單規則。
+--   2. 線上現行版本另有一段 **repo 從來沒有的 LIFO 拆行 hotfix**：
+--        newer_qty = 同 SKU 內比自己新的單的數量累計（created_at DESC, coi.id DESC）
+--        demand_unfulfillable = LEAST(order_qty, CEIL(shortage) − newer_qty)
+--      ＝ 短缺一律扣在**最新**下單的人身上（先到先得），不是 v4 的比例分攤。
+--      這是業務規則，本檔原樣保留。
+--
+-- 2026-08-11 線上 dry-run（現行 266 列 → 本檔 366 列）：
+--   保留 6 列（GRP-20260709-013 迷你桌面吸塵器，7/9 卡 confirmed、GR 0 → 真短缺）
+--   消失 260 列（上述 A + B 全部）
+--   新增 360 列 / 152 SKU：全部是 5/25–7/28 建立、卡在 shipping/confirmed
+--     的存量殭屍單，其中 326 列的取貨店現貨為 0、總倉現貨 0、無在途
+--     —— 沒有任何東西會再把貨送過去，正是 v3 用累計 GR 掩蓋掉的真異常
+--     （v4 檔頭的「破洞 3」）。另 40 列貨其實在店裡、只是單頭狀態沒推進，
+--     屬 20260811000020 修的那一類，下批到貨會自然收斂。
+--   ⚠️ 這 360 列都是 shortage_resolution IS NULL 的未處理單，套用後
+--      收件匣「訂單短少」會從 266 跳到 366，需要 HQ 實際去收。
+--
+-- 欄位：與線上完全同名同序同型別，下游 v_hq_exceptions、v_hq_inbox、
+--   rpc_hq_shortage_orders、rpc_hq_inbox_search、前端
+--   hq/inbox/page.tsx 的 .from("v_order_shortage") 全部免改。
+--
+-- 已知邊界（有意取捨）：
+--   - 全域 pooling 沿用 v2~v4：店 A 的在途/現貨帳面可蓋店 B 的需求。
+--   - 分店貨架庫存不算供給（那是 ready 單與零售的貨，算入會雙重計）。
+--   - draft PO 不算供給、也不算定案：採購擬單期間不判短缺。
+--   - 補貨單（RR- /【內部】xx 店，campaign 806 __INTERNAL_RESTOCK__）
+--     永遠對不到 po_campaigns（補貨 PR 不帶 source_campaign_id、也不進
+--     purchase_request_campaigns）→ 一律不判短缺。它們的供給來源是總倉
+--     現貨/調撥而不是採購批次，缺口在 /wms/restock 與「收貨短少」已有
+--     專屬流程，放進這裡只會製造重複帳（B 就是這樣來的）。
+--   - 跨店衍生單維持排除、同店衍生單保留（20260807000000 的規則）。
+--
+-- 基於：線上 pg_get_viewdef 逐字取回的現行定義（v3 + stockout 閘 +
+--   同店衍生單 + LIFO 拆行 hotfix），模型部分換成
+--   20260801000000_v_order_shortage_v4_forward_looking.sql 的前瞻算法。
+-- Rollback：CREATE OR REPLACE VIEW 回
+--   20260807000000_same_store_transfer_before_arrival.sql 的第 5 節，
+--   再手動補回上述 LIFO 拆行 hotfix（該檔內文是比例分攤版，直接回退會
+--   連 LIFO 一起掉）。
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.v_order_shortage AS
+WITH
+-- 1. po_item ↔ campaign 對應（與 v_picking_demand_by_po.po_campaigns 同一套）
+po_campaigns AS (
+  SELECT DISTINCT u.po_item_id, u.campaign_id
+  FROM (
+    SELECT poi.id AS po_item_id, prc.campaign_id
+      FROM purchase_order_items poi
+      JOIN purchase_request_items pri      ON pri.po_item_id = poi.id
+      JOIN purchase_requests pr            ON pr.id = pri.pr_id
+      JOIN purchase_request_campaigns prc  ON prc.pr_id = pr.id
+    UNION
+    SELECT poi.id AS po_item_id, pri.source_campaign_id AS campaign_id
+      FROM purchase_order_items poi
+      JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+     WHERE pri.source_campaign_id IS NOT NULL
+  ) u
+),
+-- 2. 閘門：這一輪團的這支 SKU 採購已定案（沒有列 = 不判短缺，等採購開單）
+settled_campaign_sku AS (
+  SELECT DISTINCT pc.campaign_id, poi.sku_id
+    FROM po_campaigns pc
+    JOIN purchase_order_items poi ON poi.id = pc.po_item_id
+    JOIN purchase_orders po       ON po.id = poi.po_id
+   WHERE po.status IN ('sent', 'partially_received', 'fully_received', 'closed')
+),
+-- 3. PO 供給：sent/partial 未收餘量（斷貨品項不算，20260801000000）；
+--    total_gr 為歷史累計，純資訊欄，不進判定
+settled_po_supply AS (
+  SELECT poi.sku_id,
+         SUM(COALESCE(g.gr_qty, 0)) AS total_gr,
+         SUM(CASE WHEN po.status IN ('sent', 'partially_received')
+                   AND poi.stockout_at IS NULL
+                  THEN GREATEST(0, poi.qty_ordered - COALESCE(g.gr_qty, 0))
+                  ELSE 0
+             END) AS po_in_transit
+    FROM purchase_orders po
+    JOIN purchase_order_items poi ON poi.po_id = po.id
+    LEFT JOIN (
+      SELECT gri.po_item_id, SUM(gri.qty_received) AS gr_qty
+        FROM goods_receipt_items gri
+        JOIN goods_receipts gr ON gr.id = gri.gr_id
+       WHERE gr.status = 'confirmed'
+       GROUP BY gri.po_item_id
+    ) g ON g.po_item_id = poi.id
+   WHERE po.status IN ('sent', 'partially_received', 'fully_received', 'closed')
+   GROUP BY poi.sku_id
+),
+-- 4. 經總倉現貨：含盤點調整/手動調帳進來的貨（不限 PO/GR 管道）
+hq_on_hand AS (
+  SELECT sb.sku_id, SUM(sb.on_hand) AS hq_on_hand
+    FROM stock_balances sb
+    JOIN locations l ON l.id = sb.location_id
+   WHERE l.type = 'central_warehouse' AND l.is_active = TRUE
+   GROUP BY sb.sku_id
+),
+-- 5. 調撥在途：已出貨未收貨（shipping 單的貨在車上）
+xfer_in_transit AS (
+  SELECT ti.sku_id, SUM(ti.qty_shipped) AS xfer_in_transit
+    FROM transfer_items ti
+    JOIN transfers t ON t.id = ti.transfer_id
+   WHERE t.status = 'shipped'
+   GROUP BY ti.sku_id
+),
+-- 6. 已撿+已派（純資訊欄位，不影響短缺判定）
+allocated_per_sku_store AS (
+  SELECT sku_id, store_id,
+         SUM(wave_qty)    AS total_wave,
+         SUM(shipped_qty) AS total_shipped
+    FROM v_picking_demand_by_po
+   WHERE store_id IS NOT NULL
+   GROUP BY sku_id, store_id
+),
+allocated_per_sku AS (
+  SELECT sku_id, SUM(total_wave) AS total_wave, SUM(total_shipped) AS total_shipped
+    FROM allocated_per_sku_store
+   GROUP BY sku_id
+),
+-- 7. 未到貨需求（過閘門）：pending 品項 × pending/confirmed/shipping 訂單；
+--    抵減單（負數量）非終態全算；同店衍生單保留、跨店衍生單排除
+demand_rows AS (
+  SELECT co.id  AS order_id,
+         coi.id AS order_item_id,
+         coi.sku_id,
+         coi.qty,
+         co.created_at AS order_created_at
+    FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+    JOIN settled_campaign_sku scs
+      ON scs.campaign_id = co.campaign_id AND scs.sku_id = coi.sku_id
+   WHERE co.pickup_store_id IS NOT NULL
+     AND coi.status NOT IN ('cancelled', 'expired')
+     AND (co.transferred_from_order_id IS NULL
+          OR EXISTS (SELECT 1 FROM customer_orders src
+                      WHERE src.id = co.transferred_from_order_id
+                        AND src.pickup_store_id = co.pickup_store_id))
+     AND (
+       (COALESCE(co.order_kind, 'normal') <> 'offset'
+         AND co.status IN ('pending', 'confirmed', 'shipping')
+         AND coi.status = 'pending')
+       OR
+       (co.order_kind = 'offset'
+         AND co.status NOT IN ('cancelled', 'expired', 'transferred_out'))
+     )
+),
+demand_per_sku AS (
+  SELECT sku_id, SUM(qty) AS total_demand FROM demand_rows GROUP BY sku_id
+),
+-- 8. SKU 層級短缺判定
+sku_shortage AS (
+  SELECT d.sku_id,
+         d.total_demand,
+         COALESCE(s.total_gr, 0) AS total_gr,
+         COALESCE(s.po_in_transit, 0) + COALESCE(x.xfer_in_transit, 0) AS total_in_transit,
+         COALESCE(a.total_wave, 0)    AS total_wave,
+         COALESCE(a.total_shipped, 0) AS total_shipped,
+         GREATEST(0, d.total_demand
+                     - COALESCE(h.hq_on_hand, 0)
+                     - COALESCE(s.po_in_transit, 0)
+                     - COALESCE(x.xfer_in_transit, 0)) AS sku_shortage_qty
+    FROM demand_per_sku d
+    LEFT JOIN settled_po_supply s ON s.sku_id = d.sku_id
+    LEFT JOIN hq_on_hand h        ON h.sku_id = d.sku_id
+    LEFT JOIN xfer_in_transit x   ON x.sku_id = d.sku_id
+    LEFT JOIN allocated_per_sku a ON a.sku_id = d.sku_id
+   WHERE d.total_demand > COALESCE(h.hq_on_hand, 0)
+                        + COALESCE(s.po_in_transit, 0)
+                        + COALESCE(x.xfer_in_transit, 0)
+),
+-- 9. 展開到 order_item：LIFO — 短缺扣在最新下單的人身上（線上 hotfix，保留）
+expanded AS (
+  SELECT dr.order_id, dr.order_item_id, dr.sku_id,
+         dr.qty AS order_qty, dr.order_created_at,
+         ss.total_demand, ss.total_gr, ss.total_in_transit,
+         ss.total_wave, ss.total_shipped, ss.sku_shortage_qty,
+         SUM(dr.qty) OVER (PARTITION BY dr.sku_id
+                           ORDER BY dr.order_created_at DESC, dr.order_item_id DESC
+                           ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) - dr.qty AS newer_qty
+    FROM demand_rows dr
+    JOIN sku_shortage ss ON ss.sku_id = dr.sku_id
+   WHERE dr.qty > 0
+     AND ss.sku_shortage_qty > 0
+)
+SELECT co.tenant_id,
+       e.order_id,
+       co.order_no,
+       co.member_id,
+       co.pickup_store_id AS store_id,
+       st.name            AS store_name,
+       co.status          AS order_status,
+       co.shortage_notified_at,
+       co.shortage_resolution,
+       co.shortage_resolution_at,
+       e.order_item_id,
+       e.sku_id,
+       s.sku_code,
+       s.product_name,
+       s.variant_name,
+       e.order_qty,
+       e.total_demand,
+       e.total_gr,
+       e.total_in_transit,
+       e.total_wave,
+       e.total_shipped,
+       e.sku_shortage_qty AS total_supplier_shortage,
+       LEAST(e.order_qty::NUMERIC, CEIL(e.sku_shortage_qty) - e.newer_qty) AS demand_unfulfillable,
+       e.order_created_at,
+       co.updated_at      AS order_updated_at
+  FROM expanded e
+  JOIN customer_orders co ON co.id = e.order_id
+  LEFT JOIN skus s    ON s.id = e.sku_id
+  LEFT JOIN stores st ON st.id = co.pickup_store_id
+ WHERE (CEIL(e.sku_shortage_qty) - e.newer_qty) > 0;
+
+GRANT SELECT ON public.v_order_shortage TO authenticated;
+
+COMMENT ON VIEW public.v_order_shortage IS
+  '短缺訂單看板 v5：未到貨需求（pending 品項 × pending/confirmed/shipping 訂單）'
+  ' vs 現在拿得出的貨（經總倉現貨 + PO 在途 + 調撥在途）。'
+  '閘門改為 campaign×sku 層級（這一輪團有定案 PO 才判；SKU 層級會讓還在收單的新團一開賣就爆警報）。'
+  'ready/completed 單＝貨已到店、離開需求池；抵減單（offset，負量）非終態全算需求。'
+  '累計 GR 不再進判定（total_gr 為純資訊欄）。分攤為 LIFO：短缺扣在最新下單者身上。'
+  '補貨單（__INTERNAL_RESTOCK__）對不到 campaign PO，一律不判短缺 — 走 /wms/restock 與收貨短少。';

--- a/supabase/migrations/20260811010010_hq_exceptions_capture_drift.sql
+++ b/supabase/migrations/20260811010010_hq_exceptions_capture_drift.sql
@@ -1,0 +1,233 @@
+-- ============================================================
+-- v_hq_exceptions：收編線上 drift + 「地點」改由 warehouse_name 統一供應
+--
+-- 動機：
+--   /wms/exceptions 的「收貨短少」「過量進貨」看不出是哪一間店 / 哪個倉收的，
+--   只有「訂單短少」把店名塞在 extra 開頭（`四號店 · 會員 #68599 · …`）。
+--   線上其實**每一種異常都已經有 warehouse_name 欄位**（見下方 drift），
+--   只是前端沒有畫出來。這一檔把 extra 裡重複的店名拿掉，改由前端統一用
+--   warehouse_name 畫成獨立的「地點」欄，五種異常一致。
+--     po_shortage / po_damage / po_over → PO / GR 的收貨地點（多為「經總倉」）
+--     transfer_short                    → 收貨分店（永和店 / 忠順店 …）
+--     customer_shortage                 → 取貨店
+--
+-- 線上 drift（repo 從 20260704000020 之後就沒再記錄過，本檔一併收編，
+--   下次誰要改這支 view 請以本檔為基底，不要回去抄 20260704000020）：
+--   1. 多了 doc_id、warehouse_name 兩欄。
+--   2. po_shortage / po_over 合併成同一個 UNION 分支（同一個 DISTINCT
+--      子查詢用 qty_shortage > 0 決定 type），不再掃 v_picking_demand_by_po 兩次。
+--   3. transfer_short 的 reason 改成帶出店家收貨備註
+--      （`店家收貨備註：<t.notes>`）。
+--   4. transfer_short 的 WHERE 放寬：shortage_resolution='replenish'
+--      （已標補出貨）的列**繼續列出**，直到之後同店同 SKU 的收貨量補滿
+--      缺口為止；extra 會加註「· 已標補出貨,尚未補到」。
+--
+-- 本檔唯一的行為變更：customer_shortage 的 extra 去掉開頭的
+--   `<店名> · `，只留 `會員 #<id> · <N> 樣品項短少`（店名改走 warehouse_name）。
+--   其餘一律與線上現行定義逐字相同。
+--
+-- 基於：2026-08-11 線上 pg_get_viewdef('public.v_hq_exceptions') 逐字取回。
+-- Rollback：CREATE OR REPLACE VIEW 回本檔內文，把 customer_shortage 的
+--   extra 還原成 `COALESCE(agg.store_name,'—') || ' · 會員 #' || …`。
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.v_hq_exceptions AS
+-- 1+3. 進貨短少 / 過量進貨（同一次掃描，用 qty_shortage 決定 type）
+SELECT
+  CASE WHEN pd.qty_shortage > 0 THEN 'po_shortage' ELSE 'po_over' END::text AS type,
+  (CASE WHEN pd.qty_shortage > 0 THEN 'po-short-' ELSE 'po-over-' END
+    || pd.po_id::text || ':' || pd.sku_id::text)                            AS row_key,
+  po.created_at                                                             AS ts,
+  pd.po_no                                                                  AS doc_no,
+  pd.sku_code,
+  pd.sku_label,
+  pd.qty_ordered::numeric                                                   AS expected,
+  pd.gr_qty                                                                 AS actual,
+  CASE WHEN pd.qty_shortage > 0 THEN pd.qty_shortage
+       ELSE pd.gr_qty - pd.qty_ordered END                                  AS diff,
+  NULL::text                                                                AS reason,
+  CASE WHEN pd.qty_shortage > 0 THEN 'PO 已關單,差額不會到'
+       ELSE '供應商多送或重複入庫' END::text                                 AS extra,
+  NULL::bigint                                                              AS transfer_item_id,
+  NULL::bigint                                                              AS transfer_id,
+  NULL::text                                                                AS transfer_no,
+  pd.sku_id,
+  NULL::numeric                                                             AS qty_shipped,
+  NULL::numeric                                                             AS qty_received,
+  NULL::numeric                                                             AS shortage_qty,
+  NULL::bigint                                                              AS dest_location,
+  NULL::bigint                                                              AS dest_store_id,
+  NULL::text                                                                AS dest_store_name,
+  NULL::bigint                                                              AS customer_order_id,
+  NULL::text                                                                AS shortage_resolution,
+  pd.po_id                                                                  AS doc_id,
+  (SELECT l.name FROM locations l WHERE l.id = po.dest_location_id)         AS warehouse_name
+FROM (
+  SELECT DISTINCT po_id, sku_id, po_no, sku_code, sku_label, qty_ordered, gr_qty, qty_shortage
+  FROM public.v_picking_demand_by_po
+  WHERE qty_shortage > 0 OR gr_qty > qty_ordered
+) pd
+LEFT JOIN public.purchase_orders po ON po.id = pd.po_id
+
+UNION ALL
+
+-- 2. 進貨破損
+SELECT
+  'po_damage'::text,
+  'po-dmg-' || gri.id::text,
+  gr.created_at,
+  gr.gr_no,
+  s.sku_code,
+  COALESCE(NULLIF(TRIM(COALESCE(s.product_name,'') || COALESCE(' / ' || NULLIF(s.variant_name,''), '')), ''), '品項#' || gri.sku_id::text),
+  gri.qty_received::numeric,
+  gri.qty_received - gri.qty_damaged,
+  gri.qty_damaged::numeric,
+  gri.variance_reason,
+  '已收 ' || gri.qty_received::text || ' 含瑕疵 ' || gri.qty_damaged::text,
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  gri.sku_id,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  NULL::bigint,
+  NULL::text,
+  gr.po_id,
+  (SELECT l.name FROM locations l WHERE l.id = gr.dest_location_id)
+FROM public.goods_receipt_items gri
+JOIN public.goods_receipts gr ON gr.id = gri.gr_id
+LEFT JOIN public.skus s ON s.id = gri.sku_id
+WHERE gri.qty_damaged > 0
+  AND gr.status = 'confirmed'
+
+UNION ALL
+
+-- 4. 收貨短少（轉貨 received 但實收 < 出貨；已標補出貨但還沒補到的也繼續列）
+SELECT
+  'transfer_short'::text,
+  'tshort-' || ti.id::text,
+  COALESCE(t.received_at, t.created_at),
+  t.transfer_no,
+  s.sku_code,
+  COALESCE(NULLIF(TRIM(COALESCE(s.product_name,'') || COALESCE(' / ' || NULLIF(s.variant_name,''), '')), ''), '品項#' || ti.sku_id::text),
+  ti.qty_shipped::numeric,
+  ti.qty_received::numeric,
+  ti.qty_shipped - ti.qty_received,
+  CASE WHEN NULLIF(TRIM(COALESCE(t.notes,'')), '') IS NOT NULL
+       THEN '店家收貨備註：' || TRIM(t.notes) ELSE NULL END,
+  (CASE WHEN COALESCE(ti.damage_qty, 0) > 0 THEN '含破損 ' || ti.damage_qty::text
+        ELSE '分店少收或運送中遺失' END)
+  || (CASE WHEN ti.shortage_resolution = 'replenish' THEN ' · 已標補出貨,尚未補到' ELSE '' END),
+  ti.id,
+  ti.transfer_id,
+  t.transfer_no,
+  ti.sku_id,
+  ti.qty_shipped::numeric,
+  ti.qty_received::numeric,
+  ti.qty_shipped - ti.qty_received,
+  t.dest_location,
+  (SELECT ds.id FROM public.stores ds WHERE ds.location_id = t.dest_location ORDER BY ds.id LIMIT 1),
+  COALESCE(
+    (SELECT ds.name FROM public.stores ds WHERE ds.location_id = t.dest_location ORDER BY ds.id LIMIT 1),
+    (SELECT l.name FROM public.locations l WHERE l.id = t.dest_location),
+    '位置 #' || COALESCE(t.dest_location::text, '?')
+  ),
+  NULL::bigint,
+  NULL::text,
+  ti.transfer_id,
+  COALESCE(
+    (SELECT ds.name FROM public.stores ds WHERE ds.location_id = t.dest_location ORDER BY ds.id LIMIT 1),
+    (SELECT l.name FROM public.locations l WHERE l.id = t.dest_location),
+    '位置 #' || COALESCE(t.dest_location::text, '?')
+  )
+FROM public.transfer_items ti
+JOIN public.transfers t ON t.id = ti.transfer_id
+LEFT JOIN public.skus s ON s.id = ti.sku_id
+WHERE t.status = 'received'
+  AND ti.qty_received < ti.qty_shipped
+  AND (
+    ti.shortage_resolution IS NULL
+    OR (
+      ti.shortage_resolution = 'replenish'
+      AND COALESCE((
+        SELECT SUM(ti2.qty_received)
+        FROM public.transfers t2
+        JOIN public.transfer_items ti2 ON ti2.transfer_id = t2.id
+        WHERE t2.dest_location = t.dest_location
+          AND t2.tenant_id = t.tenant_id
+          AND ti2.sku_id = ti.sku_id
+          AND t2.status IN ('received', 'closed')
+          AND COALESCE(t2.received_at, t2.updated_at) > ti.shortage_resolution_at
+      ), 0) < (ti.qty_shipped - ti.qty_received)
+    )
+  )
+
+UNION ALL
+
+-- 5. 訂單短少（v_order_shortage order×sku → 聚合到 order）
+--    extra 不再帶店名 —— 店名走 warehouse_name，前端畫成獨立的「地點」欄
+SELECT
+  'customer_shortage'::text,
+  'custshort-' || agg.order_id::text,
+  agg.ts,
+  agg.order_no,
+  NULL::text,
+  agg.sku_label,
+  agg.expected,
+  GREATEST(0, agg.expected - agg.total_unfulfillable),
+  agg.total_unfulfillable,
+  CASE agg.shortage_resolution
+    WHEN 'notified'        THEN '✓ 已通知客戶'
+    WHEN 'cancelled'       THEN '✓ 已取消退款'
+    WHEN 'reallocated'     THEN '✓ 已改派'
+    WHEN 'waiting_next_po' THEN '⏳ 等下批 PO'
+    ELSE NULL
+  END,
+  '會員 #' || COALESCE(agg.member_id::text, '—') || ' · ' || agg.short_item_count::text || ' 樣品項短少',
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  NULL::bigint,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  agg.order_id,
+  agg.shortage_resolution,
+  agg.order_id,
+  agg.store_name
+FROM (
+  SELECT
+    vos.order_id,
+    MAX(vos.order_no)             AS order_no,
+    MAX(vos.member_id)            AS member_id,
+    MAX(vos.store_name)           AS store_name,
+    MAX(vos.shortage_resolution)  AS shortage_resolution,
+    MAX(vos.order_updated_at)     AS ts,
+    SUM(vos.order_qty)            AS expected,
+    SUM(vos.demand_unfulfillable) AS total_unfulfillable,
+    COUNT(*)                      AS short_item_count,
+    string_agg(
+      CASE
+        WHEN vos.sku_code IS NOT NULL AND vos.sku_code <> ''
+          THEN vos.sku_code || ' ' || COALESCE(NULLIF(TRIM(COALESCE(vos.product_name,'') || COALESCE(' / ' || NULLIF(vos.variant_name,''), '')), ''), '品項#' || vos.sku_id::text)
+        ELSE COALESCE(NULLIF(TRIM(COALESCE(vos.product_name,'') || COALESCE(' / ' || NULLIF(vos.variant_name,''), '')), ''), '品項#' || vos.sku_id::text)
+      END,
+      '、' ORDER BY vos.sku_id
+    )                             AS sku_label
+  FROM public.v_order_shortage vos
+  GROUP BY vos.order_id
+) agg;
+
+GRANT SELECT ON public.v_hq_exceptions TO authenticated;
+
+COMMENT ON VIEW public.v_hq_exceptions IS
+  '總倉收件匣異常統一 view:union 進貨短少/破損/過量/收貨短少/訂單短少 5 來源為扁平列,'
+  '供 rpc_hq_exceptions 做 server-side 分頁與計數。'
+  'warehouse_name = 該筆異常的地點（PO/GR 收貨倉、收貨分店、取貨店），前端畫成「地點」欄。';


### PR DESCRIPTION
## Summary

Replaces the SKU-level shortage gate with a campaign×sku-level gate and adopts the forward-looking demand/supply model from v4, fixing false positives where new campaigns would trigger shortage alerts before purchase orders are placed.

## Key Changes

**Database Migrations:**

- `20260811010000_v_order_shortage_v5_campaign_gate.sql`: Rewrites `v_order_shortage` view
  - Gate moved from SKU level → campaign×sku level (via `po_campaigns` CTE matching `v_picking_demand_by_po` logic)
  - Demand: pending items in pending/confirmed/shipping orders only (ready/completed orders excluded; offset orders kept)
  - Supply: HQ on-hand + PO in-transit (sent/partially_received, non-stockout) + transfers in-transit (shipped status)
  - Cumulative GR removed from shortage calculation (kept as info column only)
  - LIFO allocation: shortage charged to newest order first (line-by-line via `newer_qty` window function)
  - Excludes restock campaigns (`__INTERNAL_RESTOCK__`) and cross-store transfers per existing rules

- `20260811010010_hq_exceptions_capture_drift.sql`: Updates `v_hq_exceptions` view
  - Adds `doc_id` and `warehouse_name` columns (location of shortage: warehouse for PO/GR, receiving store for transfers, pickup store for orders)
  - Consolidates po_shortage/po_over into single UNION branch (uses `qty_shortage > 0` to determine type)
  - Removes store name from customer_shortage `extra` field (now supplied via `warehouse_name` for unified UI)
  - Preserves transfer_short with replenish status and shop notes

**Frontend:**

- `ExceptionsContent.tsx`: Adds `warehouse_name` field to exception row type and view row type, enabling unified location display across all exception types

## Implementation Notes

- Follows `v_picking_demand_by_po.po_campaigns` pattern for campaign-PO mapping (union of `purchase_request_campaigns` and `purchase_request_items.source_campaign_id`)
- Incorporates line-online LIFO hotfix (short缺 扣在最新下單者) that was never in repo but present in production
- Maintains global pooling model (store A inventory can cover store B demand) and excludes draft POs, shelf inventory, and restock orders per existing design
- Rollback: revert to `20260807000000_same_store_transfer_before_arrival.sql` view definition + manual restoration of LIFO hotfix

## Dry-run Results (2026-08-11)

- Current: 266 shortage rows → Expected: 366 rows
- Preserves 6 true shortages (GRP-20260709-013 confirmed, 0 GR)
- Eliminates 260 false positives (177 rows from open campaigns + 41 rows from ready orders)
- Surfaces 360 zombie orders (5/25–7/28 created, stuck in shipping/confirmed, no on-hand/in-transit supply)

https://claude.ai/code/session_01U88Hw7B91GwwHis8nwcqdn