### PR TITLE
feat(wms): 收貨短少「拒絕短收→自動重派」；異常移除「訂單短少」分頁

### DIFF
--- a/apps/admin/src/components/ExceptionsContent.tsx
+++ b/apps/admin/src/components/ExceptionsContent.tsx
@@ -6,10 +6,14 @@
 //   2. 進貨破損 — GR qty_damaged > 0
 //   3. 過量進貨 — GR cumulative qty_received > qty_ordered
 //   4. 收貨短少 — Transfer received 但 qty_received < qty_shipped
-//   5. 訂單短少 — v_order_shortage 聚合到 order 維度
+//
+// 「訂單短少」(customer_shortage) 於 2026-08-11 移除:它是前瞻推算
+// (v_order_shortage),供應商短交後必然大量出現,實際短交已由
+// 進貨短少/收貨短少覆蓋 → v_hq_exceptions 已不再回傳此來源
+// (20260811020010),此處的分頁與批次處理 UI 一併拿掉。
 //
 // 資料與分頁:全部走 server-side。rpc_hq_exceptions(type, page, page_size)
-// 後端 union 5 來源(v_hq_exceptions)做真分頁,一次回傳 { total, counts(各 tab), rows(當前頁) }。
+// 後端 union 4 來源(v_hq_exceptions)做真分頁,一次回傳 { total, counts(各 tab), rows(當前頁) }。
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -17,7 +21,7 @@ import { getSupabase } from "@/lib/supabase";
 import SpinButton from "./SpinButton";
 import { TransferShortageResolveModal, type ShortageContext } from "./TransferShortageResolveModal";
 
-type Tab = "all" | "po_shortage" | "po_damage" | "po_over" | "transfer_short" | "customer_shortage";
+type Tab = "all" | "po_shortage" | "po_damage" | "po_over" | "transfer_short";
 
 const TAB_LABEL: Record<Tab, string> = {
   all: "全部",
@@ -25,22 +29,12 @@ const TAB_LABEL: Record<Tab, string> = {
   po_damage: "進貨破損",
   po_over: "過量進貨",
   transfer_short: "收貨短少",
-  customer_shortage: "訂單短少",
 };
 
 // 與 /hq/inbox 其他來源一致的每頁筆數
 const PAGE_SIZE = 20;
 
-type ShortageAction = "notified" | "cancelled" | "waiting_next_po" | "reallocated";
-
-const BULK_ACTION_LABEL: Record<ShortageAction, string> = {
-  notified: "通知客戶(標記已通知)",
-  cancelled: "取消(請去訂單頁正式取消退款)",
-  waiting_next_po: "等下批 PO 補貨",
-  reallocated: "改派(從其他店調貨)",
-};
-
-type ExceptionType = "po_shortage" | "po_damage" | "po_over" | "transfer_short" | "customer_shortage";
+type ExceptionType = "po_shortage" | "po_damage" | "po_over" | "transfer_short";
 
 type ExceptionRow = {
   key: string;
@@ -58,14 +52,13 @@ type ExceptionRow = {
   // 該筆異常的地點:PO/GR 收貨倉、收貨分店、取貨店(v_hq_exceptions.warehouse_name)
   warehouse_name: string | null;
   shortage_ctx?: ShortageContext;
-  // customer_shortage 用
-  customer_order_id?: number;
-  shortage_resolution?: string | null;
 };
 
 // rpc_hq_exceptions 回傳的單列(= v_hq_exceptions 扁平欄位)
+// type 保留 string:DB view 若尚未套 20260811020010,可能還會回 customer_shortage,
+// 前端一律濾掉(見下方 filter)。
 type ViewRow = {
-  type: ExceptionType;
+  type: ExceptionType | string;
   row_key: string;
   ts: string | null;
   doc_no: string;
@@ -94,11 +87,10 @@ type ViewRow = {
 type ExceptionCounts = Record<Tab, number>;
 
 const EMPTY_COUNTS: ExceptionCounts = {
-  all: 0, po_shortage: 0, po_damage: 0, po_over: 0, transfer_short: 0, customer_shortage: 0,
+  all: 0, po_shortage: 0, po_damage: 0, po_over: 0, transfer_short: 0,
 };
 
 function docLinkFor(r: ViewRow): string {
-  if (r.type === "customer_shortage") return `/orders?id=${r.customer_order_id}`;
   if (r.type === "transfer_short") return `/wms/inbound`;
   return `/wms/receiving`;
 }
@@ -117,81 +109,13 @@ export default function ExceptionsContent({
   const [tab, setTab] = useState<Tab>("all");
   const [resolveCtx, setResolveCtx] = useState<ShortageContext | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
-  const [busy, setBusy] = useState<number | null>(null);
   const [page, setPage] = useState(1);
   const [prevTab, setPrevTab] = useState<Tab>(tab);
-  // 多選批次處理:只針對「訂單短少」且尚未處理的列(其他類型需逐筆開 modal / 前往單據)
-  const [selected, setSelected] = useState<number[]>([]);
-  const [bulkBusy, setBulkBusy] = useState(false);
-  const [bulkProgress, setBulkProgress] = useState<{ done: number; total: number } | null>(null);
-
-  async function handleCustomerShortageAction(
-    orderId: number,
-    action: ShortageAction,
-  ) {
-    if (!confirm(`確定:${BULK_ACTION_LABEL[action]}?`)) return;
-    setBusy(orderId);
-    try {
-      const sb = getSupabase();
-      const { data: sess } = await sb.auth.getSession();
-      const operator = sess.session?.user?.id;
-      if (!operator) throw new Error("尚未登入");
-      const { error: err } = await sb.rpc("rpc_handle_shortage_order", {
-        p_order_id: orderId,
-        p_action: action,
-        p_operator: operator,
-      });
-      if (err) throw err;
-      setReloadTick((t) => t + 1);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(null);
-    }
-  }
-
-  // 批次:對所有已選訂單依序跑 rpc_handle_shortage_order(逐筆送,單筆失敗不中斷其他筆)
-  async function handleBulkAction(action: ShortageAction) {
-    const ids = selected;
-    if (ids.length === 0) return;
-    if (!confirm(`確定對已選的 ${ids.length} 筆訂單執行:${BULK_ACTION_LABEL[action]}?`)) return;
-    setBulkBusy(true);
-    setBulkProgress({ done: 0, total: ids.length });
-    const failed: string[] = [];
-    try {
-      const sb = getSupabase();
-      const { data: sess } = await sb.auth.getSession();
-      const operator = sess.session?.user?.id;
-      if (!operator) throw new Error("尚未登入");
-      for (const orderId of ids) {
-        try {
-          const { error: err } = await sb.rpc("rpc_handle_shortage_order", {
-            p_order_id: orderId,
-            p_action: action,
-            p_operator: operator,
-          });
-          if (err) throw err;
-        } catch (e) {
-          failed.push(`#${orderId}:${e instanceof Error ? e.message : String(e)}`);
-        }
-        setBulkProgress((p) => (p ? { ...p, done: p.done + 1 } : p));
-      }
-      setError(failed.length ? `${ids.length - failed.length}/${ids.length} 筆成功,失敗:${failed.join(" / ")}` : null);
-      setSelected([]);
-      setReloadTick((t) => t + 1);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBulkBusy(false);
-      setBulkProgress(null);
-    }
-  }
 
   // 切換分頁籤 → 回第 1 頁(render 階段調整 state,非 effect → 不觸發 set-state-in-effect,也不會 flash 舊頁)
   if (prevTab !== tab) {
     setPrevTab(tab);
     setPage(1);
-    setSelected([]);
   }
 
   // server-side 抓當前 tab + page(rpc_hq_exceptions 一次回 total / 各 tab counts / 當頁 rows)
@@ -214,7 +138,10 @@ export default function ExceptionsContent({
           rows: ViewRow[];
         };
 
-        const mapped: ExceptionRow[] = (resp.rows ?? []).map((r) => ({
+        const mapped: ExceptionRow[] = (resp.rows ?? [])
+          // DB view 未套 20260811020010 前的防禦:customer_shortage 一律不顯示
+          .filter((r): r is ViewRow & { type: ExceptionType } => r.type in TAB_LABEL && r.type !== "all")
+          .map((r) => ({
           key: r.row_key,
           type: r.type,
           ts: r.ts ?? "—",
@@ -245,8 +172,6 @@ export default function ExceptionsContent({
                   dest_store_name: r.dest_store_name ?? `位置 #${r.dest_location ?? "?"}`,
                 }
               : undefined,
-          customer_order_id: r.customer_order_id ?? undefined,
-          shortage_resolution: r.shortage_resolution,
         }));
 
         const cnts: ExceptionCounts = {
@@ -255,17 +180,9 @@ export default function ExceptionsContent({
           po_damage: resp.counts?.po_damage ?? 0,
           po_over: resp.counts?.po_over ?? 0,
           transfer_short: resp.counts?.transfer_short ?? 0,
-          customer_shortage: resp.counts?.customer_shortage ?? 0,
         };
 
         setRows(mapped);
-        // 只保留仍在當頁、且仍待處理的選取(換頁 / 處理完後自動清掉失效的選取)
-        const stillSelectable = new Set(
-          mapped
-            .filter((m) => m.type === "customer_shortage" && m.customer_order_id && !m.shortage_resolution)
-            .map((m) => m.customer_order_id as number),
-        );
-        setSelected((prev) => prev.filter((id) => stillSelectable.has(id)));
         setTotal(resp.total ?? 0);
         setCounts(cnts);
         setError(null);
@@ -285,18 +202,6 @@ export default function ExceptionsContent({
   }, [tab, page, reloadTick, onCountChange]);
 
   const c = counts ?? EMPTY_COUNTS;
-  // 可多選的列 = 當頁「訂單短少」且尚未處理者
-  const selectableIds = (rows ?? [])
-    .filter((r) => r.type === "customer_shortage" && r.customer_order_id && !r.shortage_resolution)
-    .map((r) => r.customer_order_id as number);
-  const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selected.includes(id));
-
-  function toggleRow(id: number) {
-    setSelected((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
-  }
-  function toggleAll() {
-    setSelected(allSelected ? [] : selectableIds);
-  }
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const currentPage = Math.min(page, totalPages);
 
@@ -333,7 +238,7 @@ export default function ExceptionsContent({
         <header>
           <h1 className="text-xl font-semibold">⚠️ 異常處理</h1>
           <p className="text-sm text-zinc-500">
-            {counts === null ? "載入中…" : `共 ${c.all} 筆異常 · 進貨短少 ${c.po_shortage} / 進貨破損 ${c.po_damage} / 過量 ${c.po_over} / 收貨短少 ${c.transfer_short} / 訂單短少 ${c.customer_shortage}`}
+            {counts === null ? "載入中…" : `共 ${c.all} 筆異常 · 進貨短少 ${c.po_shortage} / 進貨破損 ${c.po_damage} / 過量 ${c.po_over} / 收貨短少 ${c.transfer_short}`}
           </p>
         </header>
       )}
@@ -345,7 +250,7 @@ export default function ExceptionsContent({
       )}
 
       <div className="flex flex-wrap gap-1 border-b border-zinc-200 dark:border-zinc-800">
-        {(["all", "po_shortage", "po_damage", "po_over", "transfer_short", "customer_shortage"] as const).map((t) => {
+        {(["all", "po_shortage", "po_damage", "po_over", "transfer_short"] as const).map((t) => {
           const active = tab === t;
           return (
             <SpinButton
@@ -366,65 +271,10 @@ export default function ExceptionsContent({
       {/* 分頁 — 表格上方(手機優先看得到) */}
       {paginationBar}
 
-      {/* 批次操作列 — 只在有選取「訂單短少」列時出現 */}
-      {selected.length > 0 && (
-        <div className="sticky top-0 z-10 flex flex-wrap items-center gap-2 rounded-md border border-fuchsia-200 bg-fuchsia-50 p-2 text-sm dark:border-fuchsia-900 dark:bg-fuchsia-950">
-          <span className="font-semibold text-fuchsia-800 dark:text-fuchsia-300">
-            已選 {selected.length} 筆訂單短少
-            {bulkProgress && `(處理中 ${bulkProgress.done}/${bulkProgress.total}…)`}
-          </span>
-          <SpinButton
-            onClick={() => handleBulkAction("notified")}
-            disabled={bulkBusy}
-            className="rounded border border-blue-300 bg-blue-50 px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 disabled:opacity-50 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300"
-          >
-            通知客戶
-          </SpinButton>
-          <SpinButton
-            onClick={() => handleBulkAction("waiting_next_po")}
-            disabled={bulkBusy}
-            className="rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-700 hover:bg-amber-100 disabled:opacity-50 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-300"
-          >
-            等下批
-          </SpinButton>
-          <SpinButton
-            onClick={() => handleBulkAction("reallocated")}
-            disabled={bulkBusy}
-            className="rounded border border-emerald-300 bg-emerald-50 px-2 py-1 text-xs text-emerald-700 hover:bg-emerald-100 disabled:opacity-50 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
-          >
-            改派
-          </SpinButton>
-          <SpinButton
-            onClick={() => handleBulkAction("cancelled")}
-            disabled={bulkBusy}
-            className="rounded border border-rose-300 bg-rose-50 px-2 py-1 text-xs text-rose-700 hover:bg-rose-100 disabled:opacity-50 dark:border-rose-700 dark:bg-rose-950 dark:text-rose-300"
-          >
-            取消退款
-          </SpinButton>
-          <SpinButton
-            onClick={() => setSelected([])}
-            disabled={bulkBusy}
-            className="ml-auto rounded border border-zinc-300 px-2 py-1 text-xs text-zinc-600 hover:bg-white disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-900"
-          >
-            清除選取
-          </SpinButton>
-        </div>
-      )}
-
       <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr className="text-left text-xs uppercase tracking-wide text-zinc-500">
-              <th className="px-3 py-2 w-8">
-                <input
-                  type="checkbox"
-                  aria-label="全選本頁訂單短少"
-                  className="h-4 w-4 cursor-pointer align-middle disabled:cursor-not-allowed disabled:opacity-40"
-                  checked={allSelected}
-                  disabled={selectableIds.length === 0 || bulkBusy}
-                  onChange={toggleAll}
-                />
-              </th>
               <th className="px-3 py-2">類型</th>
               <th className="px-3 py-2">單號</th>
               <th className="px-3 py-2">地點</th>
@@ -438,30 +288,17 @@ export default function ExceptionsContent({
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={10} className="p-6 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={9} className="p-6 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={10} className="p-6 text-center text-zinc-500">沒有異常,系統運作正常 ✓</td></tr>
+              <tr><td colSpan={9} className="p-6 text-center text-zinc-500">沒有異常,系統運作正常 ✓</td></tr>
             ) : rows.map((r) => (
               <tr key={r.key} className="hover:bg-zinc-50 dark:hover:bg-zinc-950">
-                <td className="px-3 py-2">
-                  {r.type === "customer_shortage" && r.customer_order_id && !r.shortage_resolution && (
-                    <input
-                      type="checkbox"
-                      aria-label={`選取訂單 ${r.doc_no}`}
-                      className="h-4 w-4 cursor-pointer align-middle"
-                      checked={selected.includes(r.customer_order_id)}
-                      disabled={bulkBusy}
-                      onChange={() => toggleRow(r.customer_order_id!)}
-                    />
-                  )}
-                </td>
                 <td className="px-3 py-2 whitespace-nowrap">
                   <span className={`inline-flex whitespace-nowrap rounded px-2 py-0.5 text-xs font-medium ${
                     r.type === "po_shortage" ? "bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-300" :
                     r.type === "po_damage" ? "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300" :
                     r.type === "po_over" ? "bg-purple-100 text-purple-800 dark:bg-purple-950 dark:text-purple-300" :
-                    r.type === "transfer_short" ? "bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-300" :
-                    "bg-fuchsia-100 text-fuchsia-800 dark:bg-fuchsia-950 dark:text-fuchsia-300"
+                    "bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-300"
                   }`}>{TAB_LABEL[r.type]}</span>
                 </td>
                 <td className="px-3 py-2 font-mono text-xs whitespace-nowrap">{r.doc_no}</td>
@@ -485,41 +322,6 @@ export default function ExceptionsContent({
                     >
                       處理
                     </SpinButton>
-                  ) : r.type === "customer_shortage" && r.customer_order_id ? (
-                    r.shortage_resolution ? (
-                      <Link href={r.doc_link} className="text-blue-600 hover:underline dark:text-blue-400">看訂單 →</Link>
-                    ) : (
-                      <div className="flex flex-nowrap justify-end gap-1">
-                        <SpinButton
-                          onClick={() => handleCustomerShortageAction(r.customer_order_id!, "notified")}
-                          disabled={busy === r.customer_order_id}
-                          className="rounded border border-blue-300 bg-blue-50 px-2 py-0.5 text-[11px] text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300"
-                        >
-                          通知客戶
-                        </SpinButton>
-                        <SpinButton
-                          onClick={() => handleCustomerShortageAction(r.customer_order_id!, "waiting_next_po")}
-                          disabled={busy === r.customer_order_id}
-                          className="rounded border border-amber-300 bg-amber-50 px-2 py-0.5 text-[11px] text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-300"
-                        >
-                          等下批
-                        </SpinButton>
-                        <SpinButton
-                          onClick={() => handleCustomerShortageAction(r.customer_order_id!, "reallocated")}
-                          disabled={busy === r.customer_order_id}
-                          className="rounded border border-emerald-300 bg-emerald-50 px-2 py-0.5 text-[11px] text-emerald-700 hover:bg-emerald-100 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
-                        >
-                          改派
-                        </SpinButton>
-                        <SpinButton
-                          onClick={() => handleCustomerShortageAction(r.customer_order_id!, "cancelled")}
-                          disabled={busy === r.customer_order_id}
-                          className="rounded border border-rose-300 bg-rose-50 px-2 py-0.5 text-[11px] text-rose-700 hover:bg-rose-100 dark:border-rose-700 dark:bg-rose-950 dark:text-rose-300"
-                        >
-                          取消退款
-                        </SpinButton>
-                      </div>
-                    )
                   ) : (
                     <Link href={r.doc_link} className="text-blue-600 hover:underline dark:text-blue-400">前往 →</Link>
                   )}

--- a/apps/admin/src/components/TransferShortageResolveModal.tsx
+++ b/apps/admin/src/components/TransferShortageResolveModal.tsx
@@ -29,7 +29,7 @@ export type ShortageContext = {
   dest_store_name: string;
 };
 
-type Resolution = "restock_hq" | "replenish" | "cancel_orders" | "vendor_claim" | "accept";
+type Resolution = "redispatch" | "restock_hq" | "replenish" | "cancel_orders" | "vendor_claim" | "accept";
 
 const RESOLUTION_OPTIONS: Array<{
   value: Resolution;
@@ -39,10 +39,16 @@ const RESOLUTION_OPTIONS: Array<{
   cta?: { label: string; href: string; hint: string };
 }> = [
   {
+    value: "redispatch",
+    icon: "🔁",
+    title: "拒絕短收 — 沖回總倉並自動重派",
+    desc: "貨仍在總倉(漏裝/揀貨少拿):短少數量沖回總倉庫存,並自動開一張撿貨單重派回原店、接回原訂單(出貨/收貨後訂單自動推進)。重派撿貨單會出現在總倉收件匣的撿貨單匣。真的遺失請勿選(帳會多)。",
+  },
+  {
     value: "restock_hq",
     icon: "🏭",
-    title: "貨仍在總倉（沖回總倉庫存）",
-    desc: "漏裝/揀貨少拿,貨沒上車:把短少數量以原出庫成本記回總倉庫存,之後可再派。真的遺失請勿選(帳會多)。",
+    title: "貨仍在總倉（只沖回庫存,不重派）",
+    desc: "把短少數量以原出庫成本記回總倉庫存,之後再自行決定怎麼派。要自動重派回原店請選上面的「拒絕短收」。真的遺失請勿選(帳會多)。",
   },
   {
     value: "replenish",
@@ -61,9 +67,10 @@ const RESOLUTION_OPTIONS: Array<{
     title: "取消客戶訂單",
     desc: "通知顧客貨拿不到,在客戶端取消訂單 / 退款。",
     cta: {
-      label: "前往總倉收件匣 → 短少訂單",
-      href: "/hq/inbox",
-      hint: "在短少訂單來源中處理該店該品項顧客",
+      // 收件匣「異常 → 訂單短少」分頁已於 2026-08-11 移除,改導去訂單管理頁處理
+      label: "前往訂單管理",
+      href: "/orders",
+      hint: "取消該店該品項的顧客訂單後,回來標記為「已處理」",
     },
   },
   {

--- a/supabase/migrations/20260811020000_transfer_shortage_redispatch.sql
+++ b/supabase/migrations/20260811020000_transfer_shortage_redispatch.sql
@@ -1,0 +1,281 @@
+-- ============================================================
+-- 2026-08-11: 收貨短少新增「拒絕短收（沖回＋自動重派撿貨單）」(redispatch)
+--
+-- 需求（使用者 2026-08-11）：收貨短少要能「拒絕」— 短收量沖回總倉之後，
+-- 自動再開一張撿貨單回原店家、接回原訂單，不必人工去自由轉貨建單。
+--
+-- 現況痛點：restock_hq 只把短收量沖回總倉庫存，貨帳回來了但沒人重派 —
+--   工作台的需求模型認為該 (po, sku, store) 已派過（wave_qty 含原出貨），
+--   不會再邀請派貨；replenish 選項只是連去自由轉貨頁手動建單，而自由轉貨
+--   不掛 campaign → 原團購單收貨後接不回（單頭卡 shipping/confirmed）。
+--
+-- 修法：
+--   1. transfer_items.shortage_resolution 允許值加 'redispatch'，
+--      新欄 shortage_redispatch_wave_id 記重派 wave（防重複重派）。
+--   2. rpc_resolve_transfer_item_shortage v3：p_resolution='redispatch' 時
+--      a) 短收量沖回總倉（與 restock_hq 完全同語意：原出庫成本、
+--         movement_type='transfer_cancel'；若該明細先前已沖回過則跳過）。
+--      b) 自動開一張 draft 撿貨單（單一品項 × 原店 × 短收量），
+--         wave_date 預設隔天（同派貨工作台慣例，可在收件匣撿貨單上調整）。
+--         campaign_id / source_po_id 皆繼承原出貨 wave 的 wave item —
+--         campaign 對得上，出貨時 rpc_mark_orders_shipping_for_wave 才推得動
+--         原訂單（confirmed→shipping），店端收貨走 rpc_receive_transfer
+--         邏輯 C 推 ready；source_po_id 對得上，工作台的 already_wave
+--         帳才會把沖回的貨視為「已被重派佔用」，不會被派給別人。
+--      守衛：短收量>0 / 未重派過 / 調撥已收貨(received|closed) /
+--         出貨端必須是總倉（店對店短收沒有「從總倉再撿一次」的語意，
+--         請走自由轉貨）/ 收貨端要對得到分店。
+--
+-- 真的遺失（物流丟件、供應商短裝）仍走 vendor_claim / accept；
+-- 只想補帳不重派仍可用 restock_hq。
+--
+-- 基底版本：rpc_resolve_transfer_item_shortage ←
+--   20260810000010_shortage_restock_back_to_source.sql（v2，最新版；
+--   逐字保留 role gate、restock_hq 分支與原 4 個 resolution 的行為）。
+--   曾動過此 function 的 migration：20260607000040（v1）、20260810000010（v2）。
+--
+-- Rollback:
+--   - CREATE OR REPLACE 回 20260810000010 版本
+--   - constraint 還原（先確認沒有 redispatch 資料）：
+--       ALTER TABLE transfer_items DROP CONSTRAINT transfer_items_shortage_resolution_check;
+--       ALTER TABLE transfer_items ADD CONSTRAINT transfer_items_shortage_resolution_check
+--         CHECK (shortage_resolution IS NULL OR shortage_resolution IN
+--           ('replenish','cancel_orders','vendor_claim','accept','restock_hq'));
+--   - ALTER TABLE transfer_items DROP COLUMN IF EXISTS shortage_redispatch_wave_id;
+--     （已建立的重派 wave / 已沖回的 movement 需人工處理，不自動回滾）
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. schema：允許值 + 重派 wave 記錄欄
+-- ----------------------------------------------------------------
+DO $$
+DECLARE
+  v_conname TEXT;
+BEGIN
+  -- 依定義內容找出現行 CHECK（20260810000010 已改為具名，但保守處理）
+  SELECT conname INTO v_conname
+    FROM pg_constraint
+   WHERE conrelid = 'transfer_items'::regclass
+     AND contype = 'c'
+     AND pg_get_constraintdef(oid) LIKE '%shortage_resolution%';
+  IF v_conname IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE transfer_items DROP CONSTRAINT %I', v_conname);
+  END IF;
+END $$;
+
+ALTER TABLE transfer_items
+  ADD CONSTRAINT transfer_items_shortage_resolution_check
+    CHECK (shortage_resolution IS NULL OR shortage_resolution IN
+      ('replenish','cancel_orders','vendor_claim','accept','restock_hq','redispatch'));
+
+ALTER TABLE transfer_items
+  ADD COLUMN IF NOT EXISTS shortage_redispatch_wave_id BIGINT REFERENCES picking_waves(id);
+
+COMMENT ON COLUMN transfer_items.shortage_resolution IS
+  '短收處理方式:replenish=補出貨/cancel_orders=取消客戶訂單/vendor_claim=供應商求償/'
+  'accept=接受認賠/restock_hq=貨仍在總倉,短收量沖回出貨端庫存/'
+  'redispatch=拒絕短收:沖回總倉並自動開撿貨單重派回原店';
+COMMENT ON COLUMN transfer_items.shortage_redispatch_wave_id IS
+  'redispatch 自動建立的重派撿貨單 wave id（有值=已重派過，不可重複重派）';
+
+-- ----------------------------------------------------------------
+-- 2. rpc_resolve_transfer_item_shortage v3 — 支援 redispatch
+--    基底：20260810000010 逐字保留，加 redispatch 分支。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_resolve_transfer_item_shortage(
+  p_transfer_item_id BIGINT,
+  p_resolution       TEXT,
+  p_notes            TEXT,
+  p_operator         UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role        TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_item        transfer_items%ROWTYPE;
+  v_transfer    transfers%ROWTYPE;
+  v_shortage    NUMERIC;
+  v_unit_cost   NUMERIC;
+  v_mov_id      BIGINT;
+  -- redispatch 用
+  v_src_type    TEXT;
+  v_store_id    BIGINT;
+  v_campaign_id BIGINT;
+  v_src_po_id   BIGINT;
+  v_wave_id     BIGINT;
+  v_wave_code   TEXT;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot resolve shortage', v_role;
+  END IF;
+  IF p_resolution NOT IN ('replenish','cancel_orders','vendor_claim','accept','restock_hq','redispatch') THEN
+    RAISE EXCEPTION 'invalid resolution: %', p_resolution;
+  END IF;
+
+  SELECT * INTO v_item FROM transfer_items
+   WHERE id = p_transfer_item_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transfer_item % not found', p_transfer_item_id;
+  END IF;
+
+  -- restock_hq / redispatch 共同前置：算短收量、鎖調撥單、驗狀態
+  IF p_resolution IN ('restock_hq','redispatch') THEN
+    v_shortage := COALESCE(v_item.qty_shipped, 0) - COALESCE(v_item.qty_received, 0);
+    IF v_shortage <= 0 THEN
+      RAISE EXCEPTION '此明細沒有短收數量（出 % / 收 %），不需處理',
+        v_item.qty_shipped, v_item.qty_received;
+    END IF;
+
+    SELECT * INTO v_transfer FROM transfers
+     WHERE id = v_item.transfer_id
+     FOR UPDATE;
+    IF v_transfer.status NOT IN ('received','closed') THEN
+      RAISE EXCEPTION '調撥單 % 狀態為「%」，僅已收貨(received/closed)可處理短收',
+        v_item.transfer_id, v_transfer.status;
+    END IF;
+  END IF;
+
+  -- restock_hq：短收量以原出庫成本記回出貨端庫存（20260810000010 原行為）
+  IF p_resolution = 'restock_hq' THEN
+    IF v_item.shortage_restock_movement_id IS NOT NULL THEN
+      RAISE EXCEPTION '此明細已沖回過出貨端庫存（movement %），不可重複沖回',
+        v_item.shortage_restock_movement_id;
+    END IF;
+
+    SELECT COALESCE(ABS(unit_cost), 0) INTO v_unit_cost
+      FROM stock_movements
+     WHERE id = v_item.out_movement_id;
+
+    -- 語意同 transfer_cancel（20260713000000）：對方沒收到的貨記回出貨端
+    v_mov_id := rpc_inbound(
+      p_tenant_id       => v_transfer.tenant_id,
+      p_location_id     => v_transfer.source_location,
+      p_sku_id          => v_item.sku_id,
+      p_quantity        => v_shortage,
+      p_unit_cost       => COALESCE(v_unit_cost, 0),
+      p_movement_type   => 'transfer_cancel',
+      p_source_doc_type => 'transfer',
+      p_source_doc_id   => v_item.transfer_id,
+      p_operator        => p_operator
+    );
+  END IF;
+
+  -- redispatch：拒絕短收 — 沖回總倉 + 自動開撿貨單重派回原店
+  IF p_resolution = 'redispatch' THEN
+    IF v_item.shortage_redispatch_wave_id IS NOT NULL THEN
+      RAISE EXCEPTION '此明細已重派過（撿貨單 wave %），不可重複重派',
+        v_item.shortage_redispatch_wave_id;
+    END IF;
+
+    -- 重派 = 從總倉再撿一次；店對店短收沒有這個語意 → 擋下，請走自由轉貨
+    SELECT l.type INTO v_src_type FROM locations l WHERE l.id = v_transfer.source_location;
+    IF COALESCE(v_src_type, '') <> 'central_warehouse' THEN
+      RAISE EXCEPTION '調撥單 % 的出貨端不是總倉，無法自動重派；店對店短收請改用「補出貨」走自由轉貨',
+        v_transfer.transfer_no;
+    END IF;
+
+    SELECT ds.id INTO v_store_id
+      FROM stores ds
+     WHERE ds.location_id = v_transfer.dest_location
+     ORDER BY ds.id
+     LIMIT 1;
+    IF v_store_id IS NULL THEN
+      RAISE EXCEPTION '調撥單 % 的收貨端對不到分店，無法自動重派', v_transfer.transfer_no;
+    END IF;
+
+    -- a) 沖回總倉（同 restock_hq；先前已用 restock_hq 沖回過就不重複沖）
+    IF v_item.shortage_restock_movement_id IS NULL THEN
+      SELECT COALESCE(ABS(unit_cost), 0) INTO v_unit_cost
+        FROM stock_movements
+       WHERE id = v_item.out_movement_id;
+
+      v_mov_id := rpc_inbound(
+        p_tenant_id       => v_transfer.tenant_id,
+        p_location_id     => v_transfer.source_location,
+        p_sku_id          => v_item.sku_id,
+        p_quantity        => v_shortage,
+        p_unit_cost       => COALESCE(v_unit_cost, 0),
+        p_movement_type   => 'transfer_cancel',
+        p_source_doc_type => 'transfer',
+        p_source_doc_id   => v_item.transfer_id,
+        p_operator        => p_operator
+      );
+    END IF;
+
+    -- b) 繼承原出貨 wave 的 campaign / source_po：
+    --    campaign 對上 → 出貨時 rpc_mark_orders_shipping_for_wave 推得動原訂單；
+    --    source_po 對上 → rpc_create_wave_from_po 的 already_wave 帳把沖回的貨
+    --    視為已被本次重派佔用，工作台不會再派給別人。
+    --    補貨直派 transfer 沒有 wave item → 兩者為 NULL，收貨端仍有
+    --    _advance_arrived_confirmed_orders（20260811000020）接手推單。
+    SELECT pwi.campaign_id, pw.source_po_id
+      INTO v_campaign_id, v_src_po_id
+      FROM picking_wave_items pwi
+      JOIN picking_waves pw ON pw.id = pwi.wave_id
+     WHERE pwi.generated_transfer_id = v_item.transfer_id
+       AND pwi.sku_id = v_item.sku_id
+     LIMIT 1;
+
+    -- c) 開 draft 撿貨單（wave_code 用 sequence，同 20260609000001）
+    v_wave_code := 'WV'
+                || to_char(NOW() AT TIME ZONE 'Asia/Taipei', 'YYMMDD')
+                || LPAD(nextval('public.picking_wave_code_seq')::TEXT, 6, '0');
+
+    INSERT INTO picking_waves (
+      tenant_id, wave_code, wave_date, status, source_po_id,
+      store_count, item_count, total_qty, note, created_by, updated_by
+    ) VALUES (
+      v_transfer.tenant_id, v_wave_code, CURRENT_DATE + 1, 'draft', v_src_po_id,
+      1, 1, v_shortage,
+      '短收重派 ← ' || v_transfer.transfer_no || '（短收 ' || v_shortage || ' 件）',
+      p_operator, p_operator
+    ) RETURNING id INTO v_wave_id;
+
+    INSERT INTO picking_wave_items (
+      tenant_id, wave_id, sku_id, store_id, qty, campaign_id, note,
+      created_by, updated_by
+    ) VALUES (
+      v_transfer.tenant_id, v_wave_id, v_item.sku_id, v_store_id, v_shortage,
+      v_campaign_id, '短收重派 ← ' || v_transfer.transfer_no,
+      p_operator, p_operator
+    );
+
+    INSERT INTO picking_wave_audit_log (
+      tenant_id, wave_id, action, after_value, note, created_by
+    ) VALUES (
+      v_transfer.tenant_id, v_wave_id, 'wave_created',
+      jsonb_build_object(
+        'redispatch_from_transfer_id', v_item.transfer_id,
+        'transfer_item_id', v_item.id,
+        'sku_id', v_item.sku_id,
+        'store_id', v_store_id,
+        'qty', v_shortage,
+        'campaign_id', v_campaign_id,
+        'source_po_id', v_src_po_id
+      ),
+      '收貨短少拒絕短收自動重派', p_operator
+    );
+  END IF;
+
+  UPDATE transfer_items
+     SET shortage_resolution          = p_resolution,
+         shortage_resolution_at       = NOW(),
+         shortage_resolution_by       = p_operator,
+         shortage_resolution_notes    = NULLIF(TRIM(p_notes), ''),
+         shortage_restock_movement_id = COALESCE(v_mov_id, shortage_restock_movement_id),
+         shortage_redispatch_wave_id  = COALESCE(v_wave_id, shortage_redispatch_wave_id),
+         updated_by                   = p_operator
+   WHERE id = p_transfer_item_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_resolve_transfer_item_shortage(BIGINT, TEXT, TEXT, UUID)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_resolve_transfer_item_shortage(BIGINT, TEXT, TEXT, UUID) IS
+  'HQ 處理收貨短少:標記 resolution(replenish/cancel_orders/vendor_claim/accept/restock_hq/redispatch)+ 備註。'
+  'restock_hq 把短收量以原出庫成本沖回出貨端庫存(transfer_cancel movement,防重複);'
+  'redispatch=拒絕短收:沖回總倉＋自動開 draft 撿貨單重派回原店(繼承原 wave 的 campaign/source_po,'
+  '出貨收貨後原訂單自動推進);其餘 resolution 僅打標記。';

--- a/supabase/migrations/20260811020010_hq_exceptions_drop_customer_shortage.sql
+++ b/supabase/migrations/20260811020010_hq_exceptions_drop_customer_shortage.sql
@@ -1,0 +1,170 @@
+-- ============================================================
+-- 2026-08-11: 總倉收件匣「異常」移除「訂單短少」(customer_shortage) 來源
+--
+-- 決策（使用者 2026-08-11）：訂單短少是前瞻推算（v_order_shortage：
+-- 未到貨需求 vs 現在拿得出的貨），供應商短交後必然大量出現；總倉已經從
+-- 「進貨短少」「收貨短少」兩個實績分頁知道哪些貨少了，這個分頁 290 筆
+-- 只是噪音 → 收件匣不再顯示。
+--
+-- 修法：v_hq_exceptions 拿掉第 5 來源（customer_shortage），
+--   其餘來源逐字保留。欄位形狀不變（25 欄同名同序同型別，
+--   customer_order_id / shortage_resolution 對其餘來源本來就是 NULL）→
+--   rpc_hq_exceptions 免改（counts.customer_shortage 自然歸 0），
+--   收件匣「⚠️ 異常」徽章（= counts.all）同步少掉這批。
+--   線上實測：531 → 242（290 筆訂單短少歸零）。
+--
+-- 保留不動：
+--   - v_order_shortage 本身（收件匣 URL 直達的「短少訂單」legacy 來源、
+--     rpc_hq_shortage_orders、rpc_handle_shortage_order 仍在用）。
+--   - 前端 ExceptionsContent 的訂單短少分頁與批次處理 UI 同步移除（同 PR）。
+--
+-- 基於：20260811010010_hq_exceptions_capture_drift.sql（最新版；
+--   該檔已收編線上 drift：po_shortage/po_over 合併掃描、doc_id /
+--   warehouse_name 欄、replenish 未補到重新浮上來、店家收貨備註進 reason）。
+-- Rollback：CREATE OR REPLACE VIEW 回 20260811010010 版本
+--   （補回 customer_shortage 分支）。
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.v_hq_exceptions AS
+-- 1+3. 進貨短少 / 過量進貨（同一次掃描，用 qty_shortage 決定 type）
+SELECT
+  CASE WHEN pd.qty_shortage > 0 THEN 'po_shortage' ELSE 'po_over' END::text AS type,
+  (CASE WHEN pd.qty_shortage > 0 THEN 'po-short-' ELSE 'po-over-' END
+    || pd.po_id::text || ':' || pd.sku_id::text)                            AS row_key,
+  po.created_at                                                             AS ts,
+  pd.po_no                                                                  AS doc_no,
+  pd.sku_code,
+  pd.sku_label,
+  pd.qty_ordered::numeric                                                   AS expected,
+  pd.gr_qty                                                                 AS actual,
+  CASE WHEN pd.qty_shortage > 0 THEN pd.qty_shortage
+       ELSE pd.gr_qty - pd.qty_ordered END                                  AS diff,
+  NULL::text                                                                AS reason,
+  CASE WHEN pd.qty_shortage > 0 THEN 'PO 已關單,差額不會到'
+       ELSE '供應商多送或重複入庫' END::text                                 AS extra,
+  NULL::bigint                                                              AS transfer_item_id,
+  NULL::bigint                                                              AS transfer_id,
+  NULL::text                                                                AS transfer_no,
+  pd.sku_id,
+  NULL::numeric                                                             AS qty_shipped,
+  NULL::numeric                                                             AS qty_received,
+  NULL::numeric                                                             AS shortage_qty,
+  NULL::bigint                                                              AS dest_location,
+  NULL::bigint                                                              AS dest_store_id,
+  NULL::text                                                                AS dest_store_name,
+  NULL::bigint                                                              AS customer_order_id,
+  NULL::text                                                                AS shortage_resolution,
+  pd.po_id                                                                  AS doc_id,
+  (SELECT l.name FROM locations l WHERE l.id = po.dest_location_id)         AS warehouse_name
+FROM (
+  SELECT DISTINCT po_id, sku_id, po_no, sku_code, sku_label, qty_ordered, gr_qty, qty_shortage
+  FROM public.v_picking_demand_by_po
+  WHERE qty_shortage > 0 OR gr_qty > qty_ordered
+) pd
+LEFT JOIN public.purchase_orders po ON po.id = pd.po_id
+
+UNION ALL
+
+-- 2. 進貨破損
+SELECT
+  'po_damage'::text,
+  'po-dmg-' || gri.id::text,
+  gr.created_at,
+  gr.gr_no,
+  s.sku_code,
+  COALESCE(NULLIF(TRIM(COALESCE(s.product_name,'') || COALESCE(' / ' || NULLIF(s.variant_name,''), '')), ''), '品項#' || gri.sku_id::text),
+  gri.qty_received::numeric,
+  gri.qty_received - gri.qty_damaged,
+  gri.qty_damaged::numeric,
+  gri.variance_reason,
+  '已收 ' || gri.qty_received::text || ' 含瑕疵 ' || gri.qty_damaged::text,
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  gri.sku_id,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::numeric,
+  NULL::bigint,
+  NULL::bigint,
+  NULL::text,
+  NULL::bigint,
+  NULL::text,
+  gr.po_id,
+  (SELECT l.name FROM locations l WHERE l.id = gr.dest_location_id)
+FROM public.goods_receipt_items gri
+JOIN public.goods_receipts gr ON gr.id = gri.gr_id
+LEFT JOIN public.skus s ON s.id = gri.sku_id
+WHERE gri.qty_damaged > 0
+  AND gr.status = 'confirmed'
+
+UNION ALL
+
+-- 4. 收貨短少（轉貨 received 但實收 < 出貨；已標補出貨但還沒補到的也繼續列）
+SELECT
+  'transfer_short'::text,
+  'tshort-' || ti.id::text,
+  COALESCE(t.received_at, t.created_at),
+  t.transfer_no,
+  s.sku_code,
+  COALESCE(NULLIF(TRIM(COALESCE(s.product_name,'') || COALESCE(' / ' || NULLIF(s.variant_name,''), '')), ''), '品項#' || ti.sku_id::text),
+  ti.qty_shipped::numeric,
+  ti.qty_received::numeric,
+  ti.qty_shipped - ti.qty_received,
+  CASE WHEN NULLIF(TRIM(COALESCE(t.notes,'')), '') IS NOT NULL
+       THEN '店家收貨備註：' || TRIM(t.notes) ELSE NULL END,
+  (CASE WHEN COALESCE(ti.damage_qty, 0) > 0 THEN '含破損 ' || ti.damage_qty::text
+        ELSE '分店少收或運送中遺失' END)
+  || (CASE WHEN ti.shortage_resolution = 'replenish' THEN ' · 已標補出貨,尚未補到' ELSE '' END),
+  ti.id,
+  ti.transfer_id,
+  t.transfer_no,
+  ti.sku_id,
+  ti.qty_shipped::numeric,
+  ti.qty_received::numeric,
+  ti.qty_shipped - ti.qty_received,
+  t.dest_location,
+  (SELECT ds.id FROM public.stores ds WHERE ds.location_id = t.dest_location ORDER BY ds.id LIMIT 1),
+  COALESCE(
+    (SELECT ds.name FROM public.stores ds WHERE ds.location_id = t.dest_location ORDER BY ds.id LIMIT 1),
+    (SELECT l.name FROM public.locations l WHERE l.id = t.dest_location),
+    '位置 #' || COALESCE(t.dest_location::text, '?')
+  ),
+  NULL::bigint,
+  NULL::text,
+  ti.transfer_id,
+  COALESCE(
+    (SELECT ds.name FROM public.stores ds WHERE ds.location_id = t.dest_location ORDER BY ds.id LIMIT 1),
+    (SELECT l.name FROM public.locations l WHERE l.id = t.dest_location),
+    '位置 #' || COALESCE(t.dest_location::text, '?')
+  )
+FROM public.transfer_items ti
+JOIN public.transfers t ON t.id = ti.transfer_id
+LEFT JOIN public.skus s ON s.id = ti.sku_id
+WHERE t.status = 'received'
+  AND ti.qty_received < ti.qty_shipped
+  AND (
+    ti.shortage_resolution IS NULL
+    OR (
+      ti.shortage_resolution = 'replenish'
+      AND COALESCE((
+        SELECT SUM(ti2.qty_received)
+        FROM public.transfers t2
+        JOIN public.transfer_items ti2 ON ti2.transfer_id = t2.id
+        WHERE t2.dest_location = t.dest_location
+          AND t2.tenant_id = t.tenant_id
+          AND ti2.sku_id = ti.sku_id
+          AND t2.status IN ('received', 'closed')
+          AND COALESCE(t2.received_at, t2.updated_at) > ti.shortage_resolution_at
+      ), 0) < (ti.qty_shipped - ti.qty_received)
+    )
+  );
+
+GRANT SELECT ON public.v_hq_exceptions TO authenticated;
+
+COMMENT ON VIEW public.v_hq_exceptions IS
+  '總倉收件匣異常統一 view:union 進貨短少/破損/過量/收貨短少 4 來源為扁平列,'
+  '供 rpc_hq_exceptions 做 server-side 分頁與計數。'
+  'warehouse_name = 該筆異常的地點（PO/GR 收貨倉、收貨分店），前端畫成「地點」欄。'
+  '訂單短少(customer_shortage)於 2026-08-11 移除 — 前瞻推算噪音大,'
+  '實際短交已由進貨短少/收貨短少覆蓋;v_order_shortage 本身保留。';


### PR DESCRIPTION
## 一、收貨短少新增「拒絕短收 — 沖回總倉並自動重派」(`redispatch`)

**需求**：收貨短少要能「拒絕」— 短收量沖回總倉之後，自動再開一張撿貨單回原店家、接回原訂單，不必人工去自由轉貨建單。

**現況痛點**：`restock_hq` 只沖回庫存，貨帳回來了但沒人重派（工作台的需求模型認為該 (po, sku, store) 已派過，不會再邀請派貨）；`replenish` 只是連去自由轉貨手動建單，而自由轉貨不掛 campaign → 原團購單收貨後接不回。

**修法**（`20260811020000_transfer_shortage_redispatch.sql`）：
- `rpc_resolve_transfer_item_shortage` v3 新增 `redispatch`：
  1. 短收量以原出庫成本沖回總倉（同 restock_hq 的 `transfer_cancel` movement，先前沖回過就不重複）
  2. 自動開一張 **draft 撿貨單**（短收量 × 原店、配送日隔天），出現在總倉收件匣撿貨單匣走正常揀貨出貨流程
- 重派 wave item **繼承原出貨 wave 的 `campaign_id` / `source_po_id`**：出貨時 `rpc_mark_orders_shipping_for_wave` 推得動原訂單、收貨走 `rpc_receive_transfer` 邏輯 C 推 ready；工作台 `already_wave` 帳把沖回的貨視為已被重派佔用，不會誤派給別人
- 守衛：無短收量／已重派過（新欄 `shortage_redispatch_wave_id`）／調撥未收貨／**出貨端不是總倉**（店對店短收擋下，提示走自由轉貨）
- Modal 新增第一個選項「🔁 拒絕短收 — 沖回總倉並自動重派」，原 restock_hq 改名「只沖回庫存，不重派」以區隔

## 二、異常移除「訂單短少」分頁

**決策**：訂單短少是前瞻推算（`v_order_shortage`），供應商短交後必然大量出現；總倉已從「進貨短少」「收貨短少」兩個實績分頁知道哪些貨少了，這個分頁 290 筆只是噪音。

**修法**（`20260811020010_hq_exceptions_drop_customer_shortage.sql`）：
- `v_hq_exceptions` 拿掉 `customer_shortage` 分支（**以 #678 的 `20260811010010_hq_exceptions_capture_drift.sql` 為基底**，其餘來源含「地點」欄逐字保留），欄位形狀不變 → `rpc_hq_exceptions` 免改，counts／收件匣「⚠️ 異常」徽章同步歸零
- 前端 `ExceptionsContent` 的訂單短少分頁與整套批次處理（通知客戶／等下批／改派／取消退款）UI 移除，保留 #678 新增的「地點」欄
- `v_order_shortage`／`rpc_handle_shortage_order` 保留（URL 直達的 legacy「短少訂單」來源仍在用）

## 驗證

- **兩支 migration 已套用線上**：異常徽章 531 → 242（customer_shortage 290 → 0，其餘 3/2/40/197 不變）
- redispatch 在線上 rollback 交易乾跑：對真實短收明細（WAVE-1227-S63、出 19 收 0）正確產生 `transfer_cancel` 沖回 movement（qty 19、原成本 52、回總倉）＋ draft 重派 wave（19 件 × 原店、繼承 campaign/source_po），驗畢回滾不留痕跡
- Playwright fixture 驗證：異常分頁列只剩 4 類、Modal 六選項含新「拒絕短收」
- `tsc` 乾淨；eslint 僅剩既有警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQsjw8P595JDpQCo3WN4BQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQsjw8P595JDpQCo3WN4BQ)_