### PR TITLE
針對團購建單：列出已鎖定的團、品項只帶未請購差額

### DIFF
--- a/apps/admin/src/app/(protected)/purchase/requests/page.tsx
+++ b/apps/admin/src/app/(protected)/purchase/requests/page.tsx
@@ -15,6 +15,10 @@ import {
   type PRReviewStatus,
 } from "@/lib/prStatus";
 import { PO_TERM_ZH } from "@/lib/poStatus";
+import {
+  campaignStatusLabel,
+  campaignStatusBadge,
+} from "@/lib/campaignStatus";
 
 const PAGE_SIZE = 20;
 
@@ -66,8 +70,9 @@ type ClosedCampaignRow = {
   id: number;
   name: string;
   close_date: string;
-  existing_pr_id: number | null;
-  same_close_date_has_pr: boolean;
+  status: "closed" | "locked";
+  // 已納入的未取消請購單（purchase_request_campaigns join 表）
+  linked_prs: { id: number; pr_no: string }[];
 };
 
 type StatusTab = "all" | PRStatus;
@@ -483,62 +488,53 @@ export default function PurchaseRequestsListPage() {
       const supabase = getSupabase();
       const since = new Date();
       since.setDate(since.getDate() - 60);
+      // closed（已收單）+ locked（已鎖定 = 已被請購單鎖團）都列出來 —
+      // 只列 closed 的話，團一被建單鎖定就從這裡消失，操作者無從確認
+      // 結單的商品進了哪張單、也沒辦法補單（RPC 建單只帶未請購差額，
+      // 重複選不會重複下單）。
       const { data: camps } = await supabase
         .from("group_buy_campaigns")
-        .select("id, name, end_at")
-        .eq("status", "closed")
+        .select("id, name, end_at, status")
+        .in("status", ["closed", "locked"])
         .neq("campaign_no", "__INTERNAL_RESTOCK__")
         .gte("end_at", since.toISOString())
         .order("end_at", { ascending: false });
 
-      const { data: existingCampaignPRs } = await supabase
-        .from("purchase_requests")
-        .select("id, source_campaign_id")
-        .eq("source_type", "campaign")
-        .neq("status", "cancelled");
-      const prByCamp = new Map<number, number>(
-        (
-          (existingCampaignPRs as
-            | { id: number; source_campaign_id: number | null }[]
-            | null) ?? []
-        )
-          .filter((p) => p.source_campaign_id !== null)
-          .map((p) => [p.source_campaign_id as number, p.id]),
-      );
-
-      const { data: existingCloseDatePRs } = await supabase
-        .from("purchase_requests")
-        .select("source_close_date")
-        .eq("source_type", "close_date")
-        .neq("status", "cancelled");
-      const closeDateSet = new Set(
-        (
-          (existingCloseDatePRs as
-            | { source_close_date: string | null }[]
-            | null) ?? []
-        )
-          .map((p) => p.source_close_date)
-          .filter((d): d is string => !!d),
-      );
-
-      const result: ClosedCampaignRow[] = (
+      const campRows =
         (camps as
-          | { id: number; name: string; end_at: string | null }[]
-          | null) ?? []
-      )
+          | { id: number; name: string; end_at: string | null; status: "closed" | "locked" }[]
+          | null) ?? [];
+
+      // 每團已納入的未取消請購單（join 表由所有建單路徑 + trigger 維護）
+      const prsByCamp = new Map<number, { id: number; pr_no: string }[]>();
+      if (campRows.length > 0) {
+        const { data: links } = await supabase
+          .from("purchase_request_campaigns")
+          .select("campaign_id, purchase_requests!inner(id, pr_no, status)")
+          .in("campaign_id", campRows.map((c) => c.id))
+          .neq("purchase_requests.status", "cancelled");
+        for (const l of
+          (links as
+            | {
+                campaign_id: number;
+                purchase_requests: { id: number; pr_no: string; status: string };
+              }[]
+            | null) ?? []) {
+          const list = prsByCamp.get(l.campaign_id) ?? [];
+          list.push({ id: l.purchase_requests.id, pr_no: l.purchase_requests.pr_no });
+          prsByCamp.set(l.campaign_id, list);
+        }
+      }
+
+      const result: ClosedCampaignRow[] = campRows
         .filter((c) => !!c.end_at)
-        .map((c) => {
-          const closeDate = new Date(c.end_at as string).toLocaleDateString(
-            "sv-SE",
-          );
-          return {
-            id: c.id,
-            name: c.name,
-            close_date: closeDate,
-            existing_pr_id: prByCamp.get(c.id) ?? null,
-            same_close_date_has_pr: closeDateSet.has(closeDate),
-          };
-        });
+        .map((c) => ({
+          id: c.id,
+          name: c.name,
+          close_date: new Date(c.end_at as string).toLocaleDateString("sv-SE"),
+          status: c.status,
+          linked_prs: (prsByCamp.get(c.id) ?? []).sort((a, b) => b.id - a.id),
+        }));
 
       setClosedCampaigns(result);
     } catch (e) {
@@ -1182,7 +1178,7 @@ export default function PurchaseRequestsListPage() {
               <div>
                 <h3 className="text-base font-semibold">針對團購建{PR_TERM_ZH}</h3>
                 <p className="mt-0.5 text-xs text-zinc-500">
-                  可多選、同團購可重複開單（補單）
+                  可多選、含已鎖定的團；重複開單只帶尚未請購的差額（補單）
                 </p>
               </div>
               <SpinButton
@@ -1248,19 +1244,35 @@ export default function PurchaseRequestsListPage() {
                             className="h-4 w-4 rounded border-zinc-300 text-blue-600 focus:ring-blue-500"
                           />
                           <div className="min-w-0 flex-1">
-                            <div className="truncate text-sm font-medium">
-                              {c.name}
+                            <div className="flex items-center gap-2">
+                              <span className="truncate text-sm font-medium">
+                                {c.name}
+                              </span>
+                              <span
+                                className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] ${campaignStatusBadge(c.status)}`}
+                              >
+                                {campaignStatusLabel(c.status)}
+                              </span>
                             </div>
                             <div className="mt-0.5 text-xs text-zinc-500">
                               結單日 {c.close_date}
-                              {c.existing_pr_id !== null && (
-                                <Link
-                                  href={`/purchase/requests/edit?id=${c.existing_pr_id}`}
-                                  onClick={(e) => e.stopPropagation()}
-                                  className="ml-2 text-amber-600 hover:underline dark:text-amber-400"
-                                >
-                                  · 已有{PR_TERM_ZH} #{c.existing_pr_id}（補單會新建）
-                                </Link>
+                              {c.linked_prs.length > 0 && (
+                                <span className="ml-2 text-amber-600 dark:text-amber-400">
+                                  · 已納入
+                                  {c.linked_prs.slice(0, 3).map((p) => (
+                                    <Link
+                                      key={p.id}
+                                      href={`/purchase/requests/edit?id=${p.id}`}
+                                      onClick={(e) => e.stopPropagation()}
+                                      className="ml-1 hover:underline"
+                                    >
+                                      {p.pr_no}
+                                    </Link>
+                                  ))}
+                                  {c.linked_prs.length > 3 &&
+                                    ` 等 ${c.linked_prs.length} 張`}
+                                  （補單只帶未請購差額）
+                                </span>
                               )}
                             </div>
                           </div>

--- a/supabase/migrations/20260812010000_pr_from_campaigns_locked_delta.sql
+++ b/supabase/migrations/20260812010000_pr_from_campaigns_locked_delta.sql
@@ -1,0 +1,198 @@
+-- ============================================================================
+-- 2026-08-12: 針對團購建單 — 接受已鎖定 (locked) 的團 + 品項只帶未請購差額
+-- ----------------------------------------------------------------------------
+-- 實案（2026-08-12 使用者回報）：8/11 結單的「一次性隔髒墊」在
+-- 「針對團購建單」modal 搜不到。原因鏈：
+--   1. 結單日 8/11 的團分批結單，白天建的 close_date PR（含補單）當下
+--      只吃 status='closed' 的團；晚上 23:59 才自動結單的團不在裡面。
+--   2. 隔天早上建結單日補單（rpc_create_supplementary_pr_from_close_date）
+--      時這些團被納入並整批推成 'locked'（20260714000060 鎖團尾巴）。
+--   3. modal 前端只列 status='closed'，rpc_create_pr_from_campaigns 守衛的
+--      允許清單 ('closed','ordered','receiving','ready','completed') 也獨漏
+--      'locked'（本函式寫於 20260513，早於 20260625000000 引入鎖團）——
+--      團一被鎖就從 modal 消失，也無法從這條路補單，操作者無從確認
+--      「結單的商品到底進了哪張請購單」。
+--
+-- 本 migration：CREATE OR REPLACE rpc_create_pr_from_campaigns v2
+--   基底：20260513000001（唯一前版；已比對線上版本一致）。
+--   1. 守衛允許清單加入 'locked'。
+--   2. 品項數量改為「補單差額」：
+--        delta(sku) = 所選團目前訂單需求(sku)
+--                   − 該團結單日所有『未取消 close_date PR』已請購量(sku)
+--      算法對齊 rpc_create_supplementary_pr_from_close_date /
+--      rpc_list_supplementable_close_dates（單一真相），差在範圍縮到所選團的
+--      SKU。已被結單日 PR 涵蓋的量自動歸零剔除 → 重複選團不會重複下單
+--      （modal 本來就標榜「同團購可重複開單（補單）」，v1 會整份需求重抓）。
+--      註：同一結單日內沒有 SKU 橫跨多個團（線上 2,514 組 (sku,結單日) 全數
+--      單一團），SKU 層級沖銷不會把別團的請購量錯算到所選團頭上。
+--      跨結單日各自沖銷自己那天的 close_date PR；同 SKU 跨日合併成一列
+--      （避免同 PR 重複 SKU 列干擾下游依 SKU 的彙總）。
+--   3. 差額全為 0 → RAISE（不留空 PR、不浪費 pr_no），訊息直接顯示在前端。
+--   4. purchase_request_campaigns 一律寫入全部所選團（含差額 0 者），
+--      比照 20260714000060「顯式補全」的先例，取貨聚合閘門才看得到連結。
+--
+-- 故意不動：
+--   - 不鎖團、不 auto-confirm 訂單（沿用 v1；差額制下重複建單不會重複算量，
+--     closed 的團維持可加單/改 qty 的語意）。
+--   - rpc_create_pr_from_close_date / rpc_append_campaign_to_pr / 補單雙函式。
+--   - 供應商帶入維持函式內 LATERAL + trg_pri_fill_default_supplier fallback
+--     （20260709000030）雙保險。
+--
+-- Rollback：重跑 20260513000001 的 rpc_create_pr_from_campaigns 定義。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_create_pr_from_campaigns(
+  p_campaign_ids BIGINT[],
+  p_operator     UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant         UUID := public._current_tenant_id();
+  v_pr_id          BIGINT;
+  v_pr_no          TEXT;
+  v_dest_loc       BIGINT;
+  v_delta_count    INTEGER;
+  v_min_close_date DATE;
+BEGIN
+  IF p_campaign_ids IS NULL OR array_length(p_campaign_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_campaign_ids is empty';
+  END IF;
+
+  -- 守衛：所有 campaigns 都必須屬同 tenant 且已結單（v2：補上 'locked'）
+  IF EXISTS (
+    SELECT 1 FROM group_buy_campaigns
+     WHERE id = ANY(p_campaign_ids)
+       AND (tenant_id <> v_tenant
+            OR status NOT IN ('closed','locked','ordered','receiving','ready','completed'))
+  ) THEN
+    RAISE EXCEPTION 'some campaigns not in tenant or not closed yet';
+  END IF;
+
+  -- 取最小 close_date 作 source_close_date（向下相容用、實際資料看 join 表）
+  SELECT MIN(DATE(end_at AT TIME ZONE 'Asia/Taipei')) INTO v_min_close_date
+    FROM group_buy_campaigns
+   WHERE id = ANY(p_campaign_ids);
+
+  -- dest location
+  SELECT id INTO v_dest_loc FROM locations WHERE tenant_id = v_tenant ORDER BY id LIMIT 1;
+  IF v_dest_loc IS NULL THEN
+    RAISE EXCEPTION 'no locations defined';
+  END IF;
+
+  -- v2：先算差額（目前需求 − 該團結單日所有未取消 close_date PR 已請購量），
+  -- 空的話直接 RAISE，不浪費 pr_no、不留殘 header（比照 20260714000060 補單）。
+  CREATE TEMP TABLE _camp_pr_delta ON COMMIT DROP AS
+  WITH sel AS (
+    SELECT id, DATE(end_at AT TIME ZONE 'Asia/Taipei') AS close_date
+      FROM group_buy_campaigns
+     WHERE id = ANY(p_campaign_ids)
+  ),
+  demand AS (
+    SELECT
+      coi.sku_id,
+      s.close_date,
+      MIN(co.campaign_id) AS first_campaign_id,
+      SUM(coi.qty)        AS qty
+      FROM sel s
+      JOIN customer_orders co        ON co.campaign_id = s.id
+      JOIN customer_order_items coi  ON coi.order_id = co.id
+     WHERE co.tenant_id = v_tenant
+       AND co.status  NOT IN ('cancelled','expired','transferred_out')
+       AND coi.status NOT IN ('cancelled','expired')
+     GROUP BY coi.sku_id, s.close_date
+  ),
+  already AS (
+    SELECT pri.sku_id, pr.source_close_date AS close_date, SUM(pri.qty_requested) AS qty
+      FROM purchase_requests pr
+      JOIN purchase_request_items pri ON pri.pr_id = pr.id
+     WHERE pr.tenant_id = v_tenant
+       AND pr.source_type = 'close_date'
+       AND pr.source_close_date IN (SELECT DISTINCT close_date FROM sel)
+       AND pr.status <> 'cancelled'
+     GROUP BY 1, 2
+  )
+  -- 同 SKU 跨結單日合併成一列（差額各自沖銷完再相加）
+  SELECT
+    d.sku_id,
+    MIN(d.first_campaign_id) AS first_campaign_id,
+    SUM(GREATEST(d.qty - COALESCE(a.qty, 0), 0)) AS delta_qty
+    FROM demand d
+    LEFT JOIN already a
+           ON a.sku_id = d.sku_id AND a.close_date = d.close_date
+   GROUP BY d.sku_id
+  HAVING SUM(GREATEST(d.qty - COALESCE(a.qty, 0), 0)) > 0;
+
+  SELECT COUNT(*) INTO v_delta_count FROM _camp_pr_delta;
+
+  IF v_delta_count = 0 THEN
+    RAISE EXCEPTION '所選團購的需求已全數納入既有請購單（結單日 close_date PR），沒有可補的請購量';
+  END IF;
+
+  -- PR header（source_type 沿用 close_date、close_date 取最小值 — v1 相容）
+  v_pr_no := public.rpc_next_pr_no();
+
+  INSERT INTO purchase_requests (
+    tenant_id, pr_no, source_type, source_close_date,
+    source_location_id, status, total_amount, notes,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_pr_no, 'close_date', v_min_close_date,
+    v_dest_loc, 'draft', 0,
+    '針對團購建單（僅帶尚未請購的差額）',
+    p_operator, p_operator
+  ) RETURNING id INTO v_pr_id;
+
+  -- 寫入 join 表：全部所選團（含差額 0 者；trigger 只會補有品項的那幾團）
+  INSERT INTO purchase_request_campaigns (pr_id, campaign_id, tenant_id)
+  SELECT v_pr_id, unnest(p_campaign_ids), v_tenant
+  ON CONFLICT (pr_id, campaign_id) DO NOTHING;
+
+  -- 差額 → PR items（含售價 snapshot，沿用 v1）
+  INSERT INTO purchase_request_items (
+    pr_id, sku_id, qty_requested,
+    suggested_supplier_id, unit_cost,
+    retail_price, franchise_price,
+    source_campaign_id,
+    created_by, updated_by
+  )
+  SELECT
+    v_pr_id, dq.sku_id, dq.delta_qty,
+    ss.supplier_id, COALESCE(ss.default_unit_cost, 0),
+    pr_retail.price, pr_franchise.price,
+    dq.first_campaign_id, p_operator, p_operator
+  FROM _camp_pr_delta dq
+  LEFT JOIN LATERAL (
+    SELECT supplier_id, default_unit_cost
+      FROM supplier_skus
+     WHERE tenant_id = v_tenant AND sku_id = dq.sku_id AND is_preferred = TRUE
+     LIMIT 1
+  ) ss ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT price FROM prices WHERE sku_id = dq.sku_id AND scope = 'retail'
+     ORDER BY effective_from DESC NULLS LAST LIMIT 1
+  ) pr_retail ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT price FROM prices WHERE sku_id = dq.sku_id AND scope = 'franchise'
+     ORDER BY effective_from DESC NULLS LAST LIMIT 1
+  ) pr_franchise ON TRUE;
+
+  -- total snapshot
+  UPDATE purchase_requests pr
+     SET total_amount = COALESCE((
+           SELECT SUM(line_subtotal) FROM purchase_request_items WHERE pr_id = v_pr_id
+         ), 0),
+         updated_at = NOW()
+   WHERE pr.id = v_pr_id;
+
+  RETURN v_pr_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_pr_from_campaigns(BIGINT[], UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_pr_from_campaigns IS
+  '從多選 campaigns 建 PR（v2, 20260812010000）：接受 closed/locked/ordered/receiving/ready/completed；'
+  '品項只帶「目前需求 − 該團結單日未取消 close_date PR 已請購量」的差額（對齊結單日補單算法），'
+  '差額全 0 → RAISE、不留空單。不鎖團、不 auto-confirm（重複建單不重複算量）。';


### PR DESCRIPTION
使用者回報：8/11 結單的「一次性隔髒墊」在「針對團購建單」modal 搜不到。
原因是該日團購分批結單，白天建的 close_date PR 只吃當下已 closed 的團；
23:59 才自動結單的團到隔天早上被結單日補單納入並整批推成 locked，
而 modal 前端只列 status='closed'、rpc_create_pr_from_campaigns 守衛的
允許清單也獨漏 'locked'（該函式寫於 20260513，早於 20260625 引入鎖團），
團一被鎖就從 modal 消失，操作者無從確認商品進了哪張請購單。

- rpc_create_pr_from_campaigns v2（20260812010000）：
  - 守衛允許清單補上 'locked'
  - 品項改帶「目前需求 − 該團結單日未取消 close_date PR 已請購量」差額，
    算法對齊結單日補單（單一真相）；重複選團不再重複下單
  - 差額全 0 → RAISE，不留空單、不浪費 pr_no
  - join 表一律寫入全部所選團（比照 20260714000060 顯式補全先例）
- modal 前端：closed+locked 都列出、加狀態 badge；
  「已有請購單」改查 purchase_request_campaigns join 表
  （原本查 source_type='campaign' 的 PR，但所有建單路徑都寫
  close_date/manual，全庫 0 筆 campaign 型，提示永遠不會出現）

已套用線上並以 claims 注入驗證：已涵蓋的鎖定團拒建、混選只帶差額、
open 團仍被擋；modal 以 Playwright fixture 驗證通過。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E8WcDZF4UMK5Jom5Ns93ko