### PR TITLE
feat(member): 部分取貨的訂單卡逐行標「已取貨 / 未取貨」

### DIFF
--- a/apps/admin/src/components/MemberOrdersAppView.tsx
+++ b/apps/admin/src/components/MemberOrdersAppView.tsx
@@ -274,6 +274,9 @@ export function MemberOrdersAppView({
   );
 }
 
+// 品項的「還沒取」集合 = rpc_record_pickup 的 v_active_remaining 同一套
+const ACTIVE_ITEM_STATUSES = ["pending", "reserved", "ready"];
+
 // = apps/member/src/components/OrderCard.tsx 的卡片內容（後台配色 + 可點擊）
 function AppOrderCard({ order, onClick }: { order: AppOrderRow; onClick: () => void }) {
   const phase = orderPhase(order);
@@ -283,6 +286,21 @@ function AppOrderCard({ order, onClick }: { order: AppOrderRow; onClick: () => v
     (s, i) => (["cancelled", "expired"].includes(i.status) ? s : s + Number(i.qty ?? 0)),
     0,
   );
+  // = 會員端 OrderCard：部分取貨時逐行標「已取貨 / 未取貨」，客服看到的跟
+  // 團友手機上的一致（2026-08-13 中和店客訴：分不出哪行取了）
+  const showPickChips =
+    (order.items ?? []).some((i) => i.status === "picked_up") &&
+    (order.items ?? []).some((i) => ACTIVE_ITEM_STATUSES.includes(i.status));
+  const pickChip = (status: string) =>
+    !showPickChips ? null : status === "picked_up" ? (
+      <span className="ml-1.5 inline-block rounded bg-green-100 px-1 py-0.5 text-[10px] font-medium text-green-800 dark:bg-green-950 dark:text-green-300">
+        已取貨
+      </span>
+    ) : ACTIVE_ITEM_STATUSES.includes(status) ? (
+      <span className="ml-1.5 inline-block rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+        未取貨
+      </span>
+    ) : null;
   const outstanding = Number(order.outstanding_amount ?? NaN);
   const partlyPaid =
     Number.isFinite(outstanding) && outstanding > 0 && outstanding < Number(order.payable_amount ?? 0);
@@ -329,6 +347,7 @@ function AppOrderCard({ order, onClick }: { order: AppOrderRow; onClick: () => v
                     斷貨
                   </span>
                 )}
+                {pickChip(it.status)}
               </div>
               <div className="text-xs text-zinc-500">
                 {fmtAmount(it.unit_price)} × {it.qty}

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -105,6 +105,9 @@ function fmtDate(iso: string | null | undefined): string {
   return `${y}/${m}/${day}`;
 }
 
+// 品項的「還沒取」集合 = rpc_record_pickup 的 v_active_remaining 同一套
+const ACTIVE_ITEM_STATUSES = ["pending", "reserved", "ready"];
+
 export default function OrderCard({ order }: { order: OrderRow }) {
   // 斷貨 / 已取消的品項照樣列出來（畫成刪除線 + 「斷貨」標），但不算件數 —
   // items_total / payable_amount 從 20260808000010 起就不含這些行了，
@@ -113,6 +116,19 @@ export default function OrderCard({ order }: { order: OrderRow }) {
     (s, i) => (["cancelled", "expired"].includes(i.status) ? s : s + Number(i.qty ?? 0)),
     0,
   );
+  // 部分取貨的單，客人看不出哪行取了、哪行沒取（2026-08-13 中和店客訴）——
+  // 取過的行和還沒取的行混在同一張卡時，逐行標「已取貨 / 未取貨」。
+  // 全取完（已完成）或全沒取的單不標，右上角狀態字已經講完了，行內再標是噪音。
+  // 部分數量取貨會拆行（20260630000010），所以每一行必屬其中一邊，不用管數量。
+  const showPickChips =
+    order.items.some((i) => i.status === "picked_up") &&
+    order.items.some((i) => ACTIVE_ITEM_STATUSES.includes(i.status));
+  const pickChip = (status: string) =>
+    !showPickChips ? null : status === "picked_up" ? (
+      <StatusChip tone="ok" label="已取貨" />
+    ) : ACTIVE_ITEM_STATUSES.includes(status) ? (
+      <StatusChip tone="warn" label="未取貨" />
+    ) : null;
   // 內部 sentinel 團（店內現貨轉手單）印品項名，其餘印開團名稱 —— 見 lib/orderTitle
   const title = orderCardTitle(order);
   const phase = orderPhase(order);
@@ -178,10 +194,16 @@ export default function OrderCard({ order }: { order: OrderRow }) {
                       <StatusChip tone="danger" label="斷貨" />
                     </span>
                   )}
+                  {pickChip(it.status) && (
+                    <span className="ml-1.5 inline-block">{pickChip(it.status)}</span>
+                  )}
                 </div>
               )}
-              {!it.variant_name && it.stockout && (
-                <div><StatusChip tone="danger" label="斷貨" /></div>
+              {!it.variant_name && (it.stockout || pickChip(it.status)) && (
+                <div className="flex items-center gap-1.5">
+                  {it.stockout && <StatusChip tone="danger" label="斷貨" />}
+                  {pickChip(it.status)}
+                </div>
               )}
               <div className="text-[14px] text-[var(--secondary-label)]">
                 {fmtAmount(it.unit_price)} × {it.qty}


### PR DESCRIPTION
中和店 2026-08-13 客訴：訂單卡標了「部分已取」，但每一行品項長得一模一樣，
客人看不出哪個取了、哪個還沒取（兩行 39 元的義大利麵只能用金額反推）。

items[] 本來就帶品項層級 status（部分數量取貨會拆行，20260630000010，
所以每行必為整取或整未取），純前端補顯示：

- 會員端 OrderCard：卡片上同時有取過的行（picked_up）和還沒取的行
  （pending/reserved/ready）時，前者掛綠色「已取貨」、後者掛橘色「未取貨」。
  全取完 / 全沒取 / 斷貨收尾的單不掛，右上角狀態字已經講完了。
- 後台 MemberOrdersAppView 同步同一套規則（客服對截圖用，口徑須一致）。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SADz8oChBDpL3PYJPvCSAF