### PR TITLE
fix(line): 配對選單改「最近有動靜優先」排序＋搜尋，修名冊>50人時找不到新好友

### DIFF
--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -46,6 +46,29 @@ type Chat = { url: string | null; mode: string | null };
  */
 type Follower = { line_user_id: string; display_name: string | null; picture_url: string | null };
 
+/**
+ * 抓該店「還沒配對到會員」的好友名冊，**最近有動靜的排最前面**。
+ *
+ * 排序不能省：之前沒排序就 `limit(50)`，PostgREST 回的是最舊的 50 筆 ——
+ * 名冊一超過 50 人，「剛加好友的顧客」（正是店員此刻要配對的人）反而
+ * 永遠不在選單裡。2026-08-13 三峽店實際踩到：名冊 104 人，會員當天加好友
+ * 加入會員，選單裡卻找不到她，變成「綁定了但不能發 LINE」的死路。
+ */
+async function fetchUnpairedFollowers(storeId: number) {
+  return await getSupabase()
+    .from("store_line_followers")
+    .select("line_user_id, display_name, picture_url")
+    .eq("store_id", storeId)
+    .is("member_id", null)
+    .eq("followed", true)
+    .order("last_event_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false })
+    .limit(200);
+}
+
+/** 選單一次最多畫幾顆（超過的用搜尋縮小範圍，不然是一面牆的頭像） */
+const FOLLOWER_RENDER_MAX = 50;
+
 // 訊息樣板。連結由後端 links action 給（來自 MEMBER_FRONT_BASE_URL），
 // 不在這裡寫死網址 —— 換網域時只要改 secret，不用重新部署前端。
 //
@@ -119,6 +142,7 @@ export function LineMessageModal({
   const [chat, setChat] = useState<Chat | null>(null);
   const [ordersUrl, setOrdersUrl] = useState<string | null>(null);
   const [followers, setFollowers] = useState<Follower[]>([]);
+  const [followerFilter, setFollowerFilter] = useState("");
   const [binding, setBinding] = useState(false);
   const [buildingImage, setBuildingImage] = useState(false);
   const [text, setText] = useState("");
@@ -164,13 +188,7 @@ export function LineMessageModal({
     // 該店還沒配對的 OA 好友：推不到時要讓店員手動挑
     (async () => {
       if (homeStoreId == null) return;
-      const { data, error: fErr } = await getSupabase()
-        .from("store_line_followers")
-        .select("line_user_id, display_name, picture_url")
-        .eq("store_id", homeStoreId)
-        .is("member_id", null)
-        .eq("followed", true)
-        .limit(50);
+      const { data, error: fErr } = await fetchUnpairedFollowers(homeStoreId);
       if (cancelled) return;
       // 不能吞掉錯誤：查詢失敗時清單會是空的，選單就整個不見，
       // 畫面上卻什麼都沒說 —— 店員只會覺得「這功能壞了」而無從回報。
@@ -208,6 +226,23 @@ export function LineMessageModal({
   useEffect(() => {
     return () => { if (imagePreview) URL.revokeObjectURL(imagePreview); };
   }, [imagePreview]);
+
+  // 配對選單的顯示清單：關鍵字過濾 + 「LINE 名稱出現在會員姓名裡」的排最前。
+  // 這個租戶的會員名慣例是「LINE名稱＋電話末碼-店」（例：珍珠貝（Fang Cheng)922278-三峽），
+  // 所以名稱包含是很強的「疑似本人」訊號 —— 但只拿來排序加星，綁定仍要店員確認，
+  // 自動綁過會綁錯人（2026-08-10 平鎮兩筆）。
+  const visibleFollowers = useMemo(() => {
+    const kw = followerFilter.trim().toLowerCase();
+    const memberName = (member.name ?? "").toLowerCase();
+    return followers
+      .filter((f) => !kw || (f.display_name ?? "").toLowerCase().includes(kw))
+      .map((f) => {
+        const n = (f.display_name ?? "").trim().toLowerCase();
+        return { ...f, suggested: n.length >= 2 && memberName.includes(n) };
+      })
+      // sort 是穩定排序：同組之間維持後端給的「最近有動靜優先」順序
+      .sort((a, b) => Number(b.suggested) - Number(a.suggested));
+  }, [followers, followerFilter, member.name]);
 
   /**
    * 把該會員的可取貨品項畫成一張圖，直接放進附圖欄。
@@ -368,10 +403,7 @@ export function LineMessageModal({
                 if (result.ok && result.reachable) setReachable({ state: "ok", displayName: result.display_name ?? null });
                 else setReachable({ state: "unreachable", message: result.message ?? "尚未綁定" });
                 if (homeStoreId != null) {
-                  const { data } = await getSupabase()
-                    .from("store_line_followers")
-                    .select("line_user_id, display_name, picture_url")
-                    .eq("store_id", homeStoreId).is("member_id", null).eq("followed", true).limit(50);
+                  const { data } = await fetchUnpairedFollowers(homeStoreId);
                   setFollowers((data as Follower[]) ?? []);
                 }
               }}
@@ -414,10 +446,18 @@ export function LineMessageModal({
               這位會員在本店官方帳號是哪一個？
             </div>
             <p className="mb-2 text-[11px] text-sky-800/80 dark:text-sky-300/80">
-              以下是已加入本店官方帳號、但還沒對應到會員的人。選對之後就能發送。
+              以下是已加入本店官方帳號、但還沒對應到會員的人（最近有動靜的排前面，⭐ = LINE 名稱與會員姓名相符）。選對之後就能發送。
             </p>
+            {followers.length > 10 && (
+              <input
+                value={followerFilter}
+                onChange={(e) => setFollowerFilter(e.target.value)}
+                placeholder={`搜尋 LINE 名稱（共 ${followers.length} 人）…`}
+                className="mb-2 w-full rounded-md border border-sky-300 bg-white px-2 py-1 text-xs dark:border-sky-800 dark:bg-zinc-900"
+              />
+            )}
             <div className="flex flex-wrap gap-2">
-              {followers.map((f) => (
+              {visibleFollowers.slice(0, FOLLOWER_RENDER_MAX).map((f) => (
                 <SpinButton
                   key={f.line_user_id}
                   disabled={binding}
@@ -450,10 +490,21 @@ export function LineMessageModal({
                     // eslint-disable-next-line @next/next/no-img-element
                     <img src={f.picture_url} alt="" className="h-5 w-5 rounded-full object-cover" />
                   )}
+                  {f.suggested && <span title="LINE 名稱與會員姓名相符，疑似本人">⭐</span>}
                   {f.display_name ?? f.line_user_id.slice(0, 8) + "…"}
                 </SpinButton>
               ))}
             </div>
+            {visibleFollowers.length === 0 && (
+              <p className="text-[11px] text-sky-800/80 dark:text-sky-300/80">
+                沒有符合「{followerFilter.trim()}」的人 —— 顧客的 LINE 名稱可能跟會員姓名不同，清空搜尋看看全部。
+              </p>
+            )}
+            {visibleFollowers.length > FOLLOWER_RENDER_MAX && (
+              <p className="mt-2 text-[11px] text-sky-800/80 dark:text-sky-300/80">
+                還有 {visibleFollowers.length - FOLLOWER_RENDER_MAX} 人未顯示，請輸入名稱縮小範圍。
+              </p>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
發送 LINE 的手動配對選單原本對 store_line_followers 無排序直接
limit(50)——PostgREST 回的是最舊的 50 筆。名冊一超過 50 人（目前
8 家店如此，最多 245 人），剛加好友的顧客反而永遠不在選單裡：
2026-08-13 三峽店會員當天加好友＋註冊，店員配對不到，變成
「綁定了但發送失敗（LINE 400）」的死路。

- 抓名冊改 last_event_at DESC（最近互動優先）、上限 200，
  兩處重複查詢收成 fetchUnpairedFollowers()
- 名冊 >10 人時給關鍵字搜尋；一次最多畫 50 顆，超過提示縮小範圍
- LINE 名稱出現在會員姓名裡的排最前＋標 ⭐（本租戶會員名慣例
  「LINE名稱＋電話末碼-店」，訊號很準）；仍需店員確認才綁定，
  不自動配對（同名對到多個會員的情況真實存在）

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013YHZMm6mic9YroVG6PSoZ8