### PR TITLE
feat(pickup): 取貨只能按照店家 — 分店帳號鎖自己店

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -12,6 +12,8 @@ import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
 import PickupAgingPanel from "@/components/PickupAgingPanel";
 import { dropPickupRecent, getPickupRecents, recordPickupRecent, type RecentCustomer } from "@/lib/pickupRecents";
+import { useMyStores, useRole } from "@/lib/role";
+import { useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 import { publicProductUrl } from "@/lib/campaignCover";
 import { parseReturnNote } from "@/lib/returnNote";
 import { fetchReprintableEvents, pickupEventLabel, type PickupEventRow } from "@/lib/pickupReceipt";
@@ -95,6 +97,36 @@ function PickupPageContent() {
   // 最後一次真的查成功的關鍵字。常用顧客快選與 ?q= 進來時刻意不寫進搜尋框，
   // 之後的重查（取貨後 reload、切換未取/已取）就沒有關鍵字可用 → 會誤報「請至少輸入 2 字」。
   const lastSearchRef = useRef("");
+
+  // 取貨只能按照店家：分店帳號（store_manager / store_staff + app_metadata.stores
+  // 非空且不含「總倉」）只顯示、只能操作「自己店」的訂單 —— 跨店按取貨會扣到
+  // 別店的庫存帳、客人也拿不到貨。rpc_record_pickup 有同款後端守衛
+  // （20260813000000_pickup_store_guard.sql），這裡藏掉入口讓櫃台不會誤按。
+  const role = useRole();
+  const myStores = useMyStores();
+  const branchLocked =
+    (role === "store_manager" || role === "store_staff") &&
+    myStores.length > 0 &&
+    !myStores.includes("總倉");
+  // stores 清單只給貨齡面板換算 store id 用（多店帳號沿用 useUserBranchStoreId
+  // 慣例取第一個 match；訂單過濾直接比店名，不等這份清單載完）
+  const [storeList, setStoreList] = useState<{ id: number; name: string }[]>([]);
+  useEffect(() => {
+    (async () => {
+      const { data } = await getSupabase().from("stores").select("id, name").order("name");
+      setStoreList((data as { id: number; name: string }[]) ?? []);
+    })();
+  }, []);
+  const branchStoreId = useUserBranchStoreId(storeList);
+
+  function isOwnStoreOrder(o: OpenOrder): boolean {
+    return o.store?.name != null && myStores.includes(o.store.name);
+  }
+  // 分店帳號看到的該會員訂單（其他店的單以摘要提示呈現，不進這份清單）
+  function visibleOrdersOf(memberId: number): OpenOrder[] {
+    const all = orders.get(memberId) ?? [];
+    return branchLocked ? all.filter(isOwnStoreOrder) : all;
+  }
 
   // 該品項未取退貨量 / 扣掉已退後仍可取量
   function returnedOf(it: OpenOrder["items"][number]): number {
@@ -340,7 +372,7 @@ function PickupPageContent() {
   // 已取貨模式：算出「這次要印哪些」。沒勾任何東西＝該會員全部已取品項。
   // 一次只印一個會員 — 列印頁的表頭與合計都取第一張的會員，跨會員合印會印錯人。
   function pickedSelection(member: Member) {
-    const memberOrders = (orders.get(member.id) ?? []).filter((o) => pickedItemsOf(o).length > 0);
+    const memberOrders = visibleOrdersOf(member.id).filter((o) => pickedItemsOf(o).length > 0);
     const anySelected = memberOrders.some((o) => orderSelState(o) !== "none");
     const groups = memberOrders
       .map((o) => ({
@@ -388,7 +420,7 @@ function PickupPageContent() {
 
   async function bulkPickAllConfirmed(member: Member) {
     const memberId = member.id;
-    const allMemberOrders = (orders.get(memberId) ?? []).filter((o) => isPickable(o));
+    const allMemberOrders = visibleOrdersOf(memberId).filter((o) => isPickable(o));
     // 若有勾選 → 只取勾選的（且可取貨）；無勾選 → 全取
     const memberSelected = allMemberOrders.filter((o) => selected.has(o.id));
     const memberOrders = memberSelected.length > 0 ? memberSelected : allMemberOrders;
@@ -612,9 +644,14 @@ function PickupPageContent() {
             ? "輸入 姓名 / 電話末 N 碼 / 會員編號 → 找出本人未取訂單 → 確認取貨。"
             : "輸入 姓名 / 電話末 N 碼 / 會員編號 → 找出本人已取訂單 → 勾選後合併補印收據。"}
         </p>
+        {branchLocked && (
+          <p className="mt-1 text-xs font-medium text-amber-700 dark:text-amber-400">
+            🔒 分店帳號：僅顯示、僅能操作 {myStores.join("、")} 的訂單，其他分店的訂單請由該店取貨。
+          </p>
+        )}
       </header>
 
-      <PickupAgingPanel />
+      <PickupAgingPanel storeId={branchLocked ? branchStoreId : null} />
 
       {/* 未取貨 ↔ 已取貨：同一個搜尋框，切換時直接重查 */}
       <div className="flex gap-1 rounded-md border border-zinc-200 bg-zinc-50 p-1 text-sm dark:border-zinc-800 dark:bg-zinc-900 sm:w-fit">
@@ -716,7 +753,12 @@ function PickupPageContent() {
         ) : (
           <div className="space-y-3">
             {members.map((m) => {
-              const memberOrders = orders.get(m.id) ?? [];
+              const memberOrders = visibleOrdersOf(m.id);
+              // 分店帳號：其他店的單不列出、不可操作，只給一行摘要讓櫃台答得出
+              // 「客人在別店還有幾張」（取貨/補印都要由該店操作）
+              const hiddenOrders = branchLocked
+                ? (orders.get(m.id) ?? []).filter((o) => !isOwnStoreOrder(o))
+                : [];
               return (
                 <div key={m.id} className="rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
                   <div className="mb-2 flex flex-wrap items-baseline gap-2">
@@ -771,7 +813,7 @@ function PickupPageContent() {
                   </div>
                   {mode === "picked" ? (
                     memberOrders.length === 0 ? (
-                      <p className="text-xs text-zinc-500">無已取訂單。</p>
+                      <p className="text-xs text-zinc-500">{branchLocked ? "本店無已取訂單。" : "無已取訂單。"}</p>
                     ) : (
                       <ul className="space-y-2">
                         {memberOrders.map((o) => {
@@ -866,7 +908,7 @@ function PickupPageContent() {
                       </ul>
                     )
                   ) : memberOrders.length === 0 ? (
-                    <p className="text-xs text-zinc-500">無未取訂單。</p>
+                    <p className="text-xs text-zinc-500">{branchLocked ? "本店無未取訂單。" : "無未取訂單。"}</p>
                   ) : (
                     <ul className="space-y-2">
                       {memberOrders.map((o) => {
@@ -1029,6 +1071,20 @@ function PickupPageContent() {
                       })}
                     </ul>
                   )}
+                  {hiddenOrders.length > 0 && (() => {
+                    const byStore = new Map<string, number>();
+                    for (const o of hiddenOrders) {
+                      const n = o.store?.name ?? "未設定取貨店";
+                      byStore.set(n, (byStore.get(n) ?? 0) + 1);
+                    }
+                    const summary = Array.from(byStore, ([n, c]) => `${n} ×${c}`).join("、");
+                    return (
+                      <p className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
+                        🔒 另有 {hiddenOrders.length} 張{mode === "open" ? "未取" : "已取"}訂單在其他分店（{summary}）
+                        — {mode === "open" ? "請顧客至該店取貨" : "補印收據請由該店操作"}。
+                      </p>
+                    );
+                  })()}
                 </div>
               );
             })}
@@ -1156,7 +1212,7 @@ function PickupPageContent() {
         maxWidth="max-w-2xl"
       >
         {bulkConfirm && (() => {
-          const allMemberOrders = (orders.get(bulkConfirm.id) ?? []).filter((o) => isPickable(o));
+          const allMemberOrders = visibleOrdersOf(bulkConfirm.id).filter((o) => isPickable(o));
           const selectedHere = allMemberOrders.filter((o) => selected.has(o.id));
           const memberOrders = selectedHere.length > 0 ? selectedHere : allMemberOrders;
           const totalItems = memberOrders.reduce((s, o) => s + pickableItems(o).length, 0);

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -386,6 +386,12 @@ const RULES: Rule[] = [
       `無法復原：本會員目前的${m[1]}只有 ${fmt(m[2])}，少於當初併入的 ${fmt(m[3])}，扣回去會變負數。`
       + `請先確認這筆${m[1]}的去向並手動調整後再復原。`,
   },
+  // ===== 店家守衛（rpc_record_pickup / rpc_bind_store_line_follower） =====
+  {
+    // 訊息本體已是中文（如「此訂單的取貨店是「三峽店」…」），只把機器前綴拿掉
+    pattern: /^wrong_store:\s*(.+)$/i,
+    render: (m) => m[1],
+  },
   // ===== 撿貨單號碼衝突(同秒多筆提交時的 race) =====
   {
     pattern: /duplicate key value violates unique constraint "picking_waves_tenant_id_wave_code_key"/i,

--- a/docs/TEST-pickup-store-restriction.md
+++ b/docs/TEST-pickup-store-restriction.md
@@ -1,0 +1,50 @@
+# 測試項目 — 取貨只能按照店家（分店帳號鎖店）
+
+**範圍:** 取貨頁（`/pickup`）+ `rpc_record_pickup` 後端守衛。原本搜會員會列出該會員**所有分店**的未取單，A 店店員按得到 B 店訂單的「取貨」—— 庫存扣的是 B 店（stock_movement 跟著 `pickup_store_id` 的 location 走）、訂單被標成已取，但客人人在 B 店根本沒拿到貨。改成：分店帳號只顯示、只能操作自己店的訂單；後端 RPC 加同款守衛當最後防線（orders 頁批次取貨 / PickupDialog 走同一支 RPC，一併被蓋住）。
+
+**分店身分判定（前後端一致，對齊 `useUserBranchStoreId` / 20260808000020）:**
+`app_metadata.role ∈ (store_manager, store_staff)` 且 `app_metadata.stores`（店名陣列）非空、不含「總倉」→ 鎖店。HQ 層級（owner / admin / hq_manager / hq_accountant / ''）、stores 未設定的 legacy 分店帳號、含「總倉」的帳號行為不變。
+
+**對應變更:**
+- `supabase/migrations/20260813000000_pickup_store_guard.sql` — `rpc_record_pickup` 開頭加店家守衛（基底 20260801000000，rollback 重跑該段落）：訂單 `pickup_store_id` 的店名必須在呼叫者 `app_metadata.stores` 裡，否則 `RAISE EXCEPTION 'wrong_store: 此訂單的取貨店是「X」…'`。
+- `apps/admin/src/app/(protected)/pickup/page.tsx`：
+  - `branchLocked` 時，會員卡片訂單清單（未取/已取兩個模式）只列自己店的單；一次全取、合併補印、確認視窗、快速取貨都走過濾後清單。
+  - 其他店的單收成一行摘要：「🔒 另有 N 張未取訂單在其他分店（三峽店 ×2、板橋店 ×1）— 請顧客至該店取貨」（已取模式改說「補印收據請由該店操作」），讓櫃台答得出客人在別店還有幾張。
+  - 頁首加「🔒 分店帳號：僅顯示、僅能操作 X 店的訂單」提示；空清單文案改「本店無未取訂單。」。
+  - 貨齡面板 `PickupAgingPanel` 傳入 `storeId`（分店帳號只看本店統計；多店帳號沿用 `useUserBranchStoreId` 慣例取第一個 match）。
+- `apps/admin/src/lib/rpcError.ts`：`wrong_store:` 前綴剝掉、直接顯示中文訊息。
+
+**驗證方式:** `tsc --noEmit` + eslint（不新增問題）+ Playwright fixture（`apps/admin/.claude/skills/verify`，攔 `rest/v1` 假資料模擬分店/HQ 帳號，不碰線上 DB）+ 線上 DB 灌 claims 打 RPC（`p_item_ids=ARRAY[0]` 選不到任何品項，守衛通過會停在 `no items picked`，零副作用）。migration 已於 2026-08-13 套用到線上。
+
+---
+
+## 1. 分店帳號（store_staff，stores=['林口店']，Playwright fixture 已實測）
+
+- [x] 頁首顯示「🔒 分店帳號：僅顯示、僅能操作 林口店 的訂單」
+- [x] 搜跨店會員 → 只列林口店的未取單；三峽店的 2 張不出現在清單
+- [x] 卡片底部顯示「🔒 另有 2 張未取訂單在其他分店（三峽店 ×2）— 請顧客至該店取貨」
+- [x] 「📦 一次全取（N 張）」張數只算林口店的單（fixture：3 張只算 1 張）
+- [ ] 全部單都在別店 → 顯示「本店無未取訂單。」+ 其他分店摘要
+- [ ] 「✅ 已取貨（補印）」模式同樣只列本店已取單，摘要改說「補印收據請由該店操作」
+- [x] 貨齡面板只顯示本店張數（實測 rpc_pickup_aging 收到 `{"p_store_id":1}`）
+- [x] 直接打 RPC（或 orders 頁批次取貨勾別店的單）→ 後端回「此訂單的取貨店是「X」，分店帳號只能替自己店的訂單取貨，請由該店操作或先轉單」（頁面上 wrong_store 前綴已剝掉）
+
+## 2. HQ 帳號（owner / admin / hq_manager / hq_accountant / ''）
+
+- [x] 行為完全不變：所有分店的單都列出、都可取貨；無鎖店提示；貨齡面板 `p_store_id:null`（fixture 以 role='' 實測；admin 於後端實測）
+- [x] store_manager/store_staff 但 stores 含「總倉」→ 不鎖（後端已實測；前端同一個 branchLocked 條件）
+- [x] store_staff 但 stores 未設定（legacy）→ 不鎖（避免部署當天把舊帳號全鎖死；後端已實測）
+
+## 3. 後端守衛邊界（線上 DB 灌 claims 已實測，order 74848 取貨店=湖口店）
+
+```sql
+SELECT set_config('request.jwt.claims',
+  '{"tenant_id":"<uuid>","app_metadata":{"tenant_id":"<uuid>","role":"store_staff","stores":["平鎮店"]}}', true);
+SELECT rpc_record_pickup(74848, ARRAY[0]::bigint[], '<uuid>');
+-- → wrong_store: 此訂單的取貨店是「湖口店」…（換成 stores=["湖口店"] → no items picked = 守衛通過）
+```
+
+- [x] 分店帳號取自己店的單 → 通過守衛（停在 no items picked，dummy item id 零副作用）
+- [x] 分店帳號取別店的單 → wrong_store，訊息含對方店名「湖口店」
+- [ ] 訂單 pickup_store_id 為 NULL / 查無店 → 分店帳號被擋（訊息顯示「未設定」）
+- [x] HQ（role=admin）→ 通過守衛不受影響；service_role / 無 JWT（role 為空）同一條 bypass 路徑

--- a/supabase/migrations/20260813000000_pickup_store_guard.sql
+++ b/supabase/migrations/20260813000000_pickup_store_guard.sql
@@ -1,0 +1,319 @@
+-- ============================================================================
+-- 2026-08-13: 取貨加「店家守衛」— 分店帳號只能替自己店的訂單取貨
+--
+-- 需求：「取貨只能按照店家」。取貨頁搜會員會列出該會員**所有分店**的未取單，
+-- A 店店員按得到 B 店訂單的「取貨」：庫存扣的是 B 店（stock_movement 跟著
+-- pickup_store_id 的 location 走）、訂單被標成已取，但客人人在 B 店根本沒
+-- 拿到貨 —— 帳跟貨兩邊同時錯。前端同步只顯示自己店的單（pickup/page.tsx），
+-- 這裡是最後防線（orders 頁批次取貨 / PickupDialog 也走同一支 RPC）。
+--
+-- 守衛規則（對齊前端 useUserBranchStoreId 的分店判定）：
+--   JWT app_metadata.role ∈ ('store_manager','store_staff')
+--   且 app_metadata.stores（店名陣列）非空、不含「總倉」
+--   → 訂單 pickup_store_id 對應的店名必須在 stores 裡，否則 raise
+--     'wrong_store: …'。
+--   HQ 層級（owner/admin/hq_manager/hq_accountant/''）、service_role、
+--   無 stores 的 legacy 分店帳號不受影響。
+--   分店身分一律看 app_metadata.stores 店名陣列（線上 33 個 staff 帳號
+--   沒有任何一個有 store_id，見 20260808000020_slf_store_scope_by_name.sql）。
+--
+-- 基底：20260801000000_full_return_closes_order.sql 的 rpc_record_pickup
+--   （最新版本；其後的 migration 只引用、未再改寫這支）。
+-- Rollback：重跑 20260801000000 內 rpc_record_pickup 段落（即移除守衛）。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_record_pickup(
+  p_order_id  bigint,
+  p_item_ids  bigint[],
+  p_operator  uuid,
+  p_notes     text  DEFAULT NULL,
+  p_item_qtys jsonb DEFAULT NULL   -- {"<item_id>": <取貨數量>}；缺項或 >=qty 視為整行取
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_pickup_loc       BIGINT;
+  v_item             RECORD;
+  v_ret_guard        RECORD;
+  v_take             NUMERIC;
+  v_picked_disc      NUMERIC;
+  v_movement_id      BIGINT;
+  v_new_item_id      BIGINT;
+  v_picked_item_id   BIGINT;
+  v_picked_count     INT := 0;
+  v_event_item_ids   BIGINT[] := ARRAY[]::BIGINT[];
+  v_active_remaining INT;
+  v_new_status       TEXT;
+  v_event_type       TEXT;
+  v_event_id         BIGINT;
+  v_sku_label        TEXT;
+  v_now              TIMESTAMPTZ := NOW();
+  -- 店家守衛（2026-08-13）
+  v_jwt_role          TEXT  := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_my_stores         JSONB := COALESCE(auth.jwt() -> 'app_metadata' -> 'stores', '[]'::jsonb);
+  v_pickup_store_name TEXT;
+BEGIN
+  IF p_item_ids IS NULL OR array_length(p_item_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_item_ids is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_pickup:' || p_order_id::text));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION '找不到訂單 %', p_order_id;
+  END IF;
+
+  IF v_order.status IN ('completed','expired','cancelled','transferred_out') THEN
+    RAISE EXCEPTION '訂單 % 目前狀態為「%」，無法取貨', p_order_id, v_order.status;
+  END IF;
+
+  -- 店家守衛：分店角色只能替「自己店」的訂單取貨。庫存跟著 pickup_store_id
+  -- 的 location 扣，跨店按取貨會扣到別店的帳、客人也拿不到貨。
+  -- stores 為空（未設定的 legacy 帳號）或含「總倉」不鎖，對齊前端判定。
+  IF v_jwt_role IN ('store_manager','store_staff')
+     AND jsonb_typeof(v_my_stores) = 'array'
+     AND jsonb_array_length(v_my_stores) > 0
+     AND NOT (v_my_stores ? '總倉') THEN
+    SELECT s.name INTO v_pickup_store_name
+      FROM stores s
+     WHERE s.id = v_order.pickup_store_id
+       AND s.tenant_id = v_order.tenant_id;
+    IF v_pickup_store_name IS NULL OR NOT (v_my_stores ? v_pickup_store_name) THEN
+      RAISE EXCEPTION 'wrong_store: 此訂單的取貨店是「%」，分店帳號只能替自己店的訂單取貨，請由該店操作或先轉單',
+        COALESCE(v_pickup_store_name, '未設定');
+    END IF;
+  END IF;
+
+  SELECT location_id INTO v_pickup_loc
+    FROM stores
+   WHERE id = v_order.pickup_store_id;
+
+  IF v_pickup_loc IS NULL THEN
+    RAISE EXCEPTION '分店 % 未設定倉庫位置 (location_id)、無法寫 stock_movement', v_order.pickup_store_id;
+  END IF;
+
+  -- 退貨守門：同 SKU「本次取貨量」不得超過「active 品項量 − 未取退貨量」。
+  -- 未取退貨（return_to_hq、notes header 不含 |取貨後退回）的貨已離店，
+  -- 不能再被結帳；取貨後退回不計入（那批貨的錢在取貨時已收）。
+  -- 前端 PickupDialog 有同款防線，但畫面 stale 時會失效，這裡是最後防線。
+  FOR v_ret_guard IN
+    SELECT r.sku_id, r.ret_qty,
+           COALESCE(act.active_qty, 0) AS active_qty,
+           COALESCE(req.take_qty, 0)   AS take_qty
+      FROM (
+        SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+          FROM transfers t
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+         WHERE t.customer_order_id = p_order_id
+           AND t.tenant_id     = v_order.tenant_id
+           AND t.transfer_type = 'return_to_hq'
+           AND t.status IN ('shipped','received')
+           AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+               NOT LIKE '%取貨後退回%'
+         GROUP BY ti.sku_id
+      ) r
+      LEFT JOIN (
+        SELECT coi.sku_id, SUM(coi.qty) AS active_qty
+          FROM customer_order_items coi
+         WHERE coi.order_id = p_order_id
+           AND coi.status IN ('pending','reserved','ready')
+         GROUP BY coi.sku_id
+      ) act ON act.sku_id = r.sku_id
+      LEFT JOIN (
+        -- 本次各 SKU 取貨量（缺項＝整行取；clamp 到行量，超量交給主迴圈報錯）
+        SELECT coi.sku_id,
+               SUM(LEAST(COALESCE((p_item_qtys ->> coi.id::text)::numeric, coi.qty), coi.qty)) AS take_qty
+          FROM customer_order_items coi
+         WHERE coi.id = ANY(p_item_ids)
+           AND coi.order_id = p_order_id
+         GROUP BY coi.sku_id
+      ) req ON req.sku_id = r.sku_id
+     WHERE COALESCE(req.take_qty, 0) > COALESCE(act.active_qty, 0) - r.ret_qty
+  LOOP
+    SELECT COALESCE(s.variant_name, s.product_name, s.sku_code)
+      INTO v_sku_label FROM skus s WHERE s.id = v_ret_guard.sku_id;
+    RAISE EXCEPTION '品項「%」已退貨 % 件，本次最多可取 % 件（畫面資料可能過舊，請重新整理後再取）',
+      COALESCE(v_sku_label, v_ret_guard.sku_id::text),
+      v_ret_guard.ret_qty,
+      GREATEST(v_ret_guard.active_qty - v_ret_guard.ret_qty, 0);
+  END LOOP;
+
+  -- 逐品項：判斷整行取 or 拆行部分取
+  FOR v_item IN
+    SELECT id, sku_id, qty, unit_price, status, source, campaign_item_id,
+           tenant_id, notes, discount_amount, discount_percent, created_by
+      FROM customer_order_items
+     WHERE id = ANY(p_item_ids)
+       AND order_id = p_order_id
+     ORDER BY id
+     FOR UPDATE
+  LOOP
+    IF v_item.status NOT IN ('pending','reserved','ready') THEN
+      RAISE EXCEPTION '品項 % 狀態 % 不可取貨', v_item.id, v_item.status;
+    END IF;
+
+    -- 逐品項到貨擋板（取代舊的整單 is_order_pickup_ready 擋板）：
+    -- 未到貨（該 SKU 分店實收 0）的品項個別擋，已到貨的品項放行先取
+    IF NOT public.is_order_item_pickup_ready(v_item.id) THEN
+      SELECT COALESCE(s.variant_name, s.product_name, s.sku_code)
+        INTO v_sku_label FROM skus s WHERE s.id = v_item.sku_id;
+      RAISE EXCEPTION '品項「%」分店尚未實收到貨，無法取貨（請取消勾選該品項，其餘已到貨品項可先取）',
+        COALESCE(v_sku_label, v_item.sku_id::text);
+    END IF;
+
+    -- 本次取多少：p_item_qtys 指定則用之，否則整行取
+    v_take := COALESCE((p_item_qtys ->> v_item.id::text)::numeric, v_item.qty);
+    IF v_take IS NULL OR v_take <= 0 THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 不合法（須 > 0）', v_item.id, v_take;
+    END IF;
+    IF v_take > v_item.qty THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 超過待取數量 %', v_item.id, v_take, v_item.qty;
+    END IF;
+
+    IF v_take = v_item.qty THEN
+      -- ── 整行取：沿用舊邏輯，直接標 picked_up ──
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_item.id,
+        format('顧客取貨 order=%s item=%s', p_order_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      UPDATE customer_order_items
+         SET status = 'picked_up',
+             pickup_movement_id = v_movement_id,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_item.id;
+    ELSE
+      -- ── 部分取：拆行。新建 picked_up 行，原行扣量留待下次 ──
+      -- line-level 折扣金額按取貨比例分攤，確保兩行小計加總 = 原行
+      v_picked_disc := round(COALESCE(v_item.discount_amount, 0) * v_take / v_item.qty);
+
+      -- 1) 先建 picked_up 行（暫不填 movement，先拿 id）
+      INSERT INTO customer_order_items (
+        tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+        status, source, reserved_movement_id, pickup_movement_id, notes,
+        discount_amount, discount_percent, created_by, updated_by, created_at, updated_at
+      ) VALUES (
+        v_item.tenant_id, p_order_id, v_item.campaign_item_id, v_item.sku_id, v_take, v_item.unit_price,
+        'picked_up', v_item.source, NULL, NULL, v_item.notes,
+        v_picked_disc, v_item.discount_percent, v_item.created_by, p_operator, v_now, v_now
+      ) RETURNING id INTO v_new_item_id;
+
+      -- 2) sale movement 指向新行
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_new_item_id,
+        format('顧客部分取貨 order=%s item=%s (split from %s)', p_order_id, v_new_item_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      -- 3) 回填新行 movement
+      UPDATE customer_order_items
+         SET pickup_movement_id = v_movement_id
+       WHERE id = v_new_item_id;
+
+      -- 4) 原行扣量、保持 active 狀態，剩餘留待下次取
+      UPDATE customer_order_items
+         SET qty = qty - v_take,
+             discount_amount = COALESCE(discount_amount, 0) - v_picked_disc,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_new_item_id;
+    END IF;
+
+    -- event 記錄「被取走」那一行的 id（拆行時是新行）→ 收據查到正確的 qty
+    v_event_item_ids := v_event_item_ids || v_picked_item_id;
+    v_picked_count := v_picked_count + 1;
+  END LOOP;
+
+  IF v_picked_count = 0 THEN
+    RAISE EXCEPTION 'no items picked (check p_item_ids belongs to order %)', p_order_id;
+  END IF;
+
+  -- 重算 order status（剩餘 active 行 → partially_completed；全取完 → completed）。
+  -- 2026-08-01：剩餘 active 量要扣掉「未取退貨」覆蓋 — 已退回總倉的量不會再被
+  -- 取走，若某 SKU 的 active 量全被退貨蓋掉，該 SKU 的殘行不算「待取」。
+  -- 否則部分退貨後取走剩餘可取量（訂5退2取3）會讓訂單永遠卡在 partially_completed。
+  SELECT COUNT(*) INTO v_active_remaining
+    FROM customer_order_items coi
+    JOIN (
+      SELECT act.sku_id
+        FROM (
+          SELECT sku_id, SUM(qty) AS active_qty
+            FROM customer_order_items
+           WHERE order_id = p_order_id
+             AND status IN ('pending','reserved','ready')
+           GROUP BY sku_id
+        ) act
+        LEFT JOIN (
+          SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+            FROM transfers t
+            JOIN transfer_items ti ON ti.transfer_id = t.id
+           WHERE t.customer_order_id = p_order_id
+             AND t.tenant_id     = v_order.tenant_id
+             AND t.transfer_type = 'return_to_hq'
+             AND t.status IN ('shipped','received')
+             AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+                 NOT LIKE '%取貨後退回%'
+           GROUP BY ti.sku_id
+        ) r ON r.sku_id = act.sku_id
+       WHERE act.active_qty - COALESCE(r.ret_qty, 0) > 0
+    ) open_sku ON open_sku.sku_id = coi.sku_id
+   WHERE coi.order_id = p_order_id
+     AND coi.status IN ('pending','reserved','ready');
+
+  IF v_active_remaining = 0 THEN
+    v_new_status := 'completed';
+    v_event_type := 'picked_up';
+  ELSE
+    v_new_status := 'partially_completed';
+    v_event_type := 'partial_pickup';
+  END IF;
+
+  UPDATE customer_orders
+     SET status       = v_new_status,
+         completed_at = CASE WHEN v_new_status = 'completed' THEN v_now ELSE NULL END,
+         updated_by   = p_operator,
+         updated_at   = v_now
+   WHERE id = p_order_id;
+
+  INSERT INTO order_pickup_events (
+    tenant_id, order_id, pickup_store_id, event_type, item_ids, notes, created_by
+  ) VALUES (
+    v_order.tenant_id, p_order_id, v_order.pickup_store_id, v_event_type,
+    to_jsonb(v_event_item_ids), p_notes, p_operator
+  ) RETURNING id INTO v_event_id;
+
+  RETURN jsonb_build_object(
+    'event_id',        v_event_id,
+    'event_type',      v_event_type,
+    'picked_count',    v_picked_count,
+    'active_remaining', v_active_remaining,
+    'new_status',      v_new_status
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) IS
+  '取貨記帳。p_item_qtys={"<item_id>":<取貨數量>} 可指定部分取貨（拆行）。'
+  '到貨擋板為品項層級（is_order_item_pickup_ready）：未到貨品項個別擋、已到貨可先取。'
+  '退貨守門：同 SKU 取貨量不得超過 active 量 − 未取退貨量（取貨後退回不計）。'
+  'active_remaining 排除量已被未取退貨覆蓋的 SKU（退光的殘行不擋 completed）。'
+  '店家守衛：分店角色（store_manager/store_staff，app_metadata.stores 非空且不含總倉）'
+  '只能替自己店（pickup_store_id 店名 ∈ stores）的訂單取貨，否則 raise wrong_store。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) TO authenticated;


### PR DESCRIPTION
取貨頁搜會員原本列出該會員所有分店的未取單，A 店店員按得到 B 店訂單的
「取貨」：庫存扣的是 B 店（stock_movement 跟著 pickup_store_id 的 location
走）、訂單被標成已取，但客人根本沒拿到貨。

- rpc_record_pickup 加店家守衛（20260813000000，基底 20260801000000）：
  store_manager / store_staff 且 app_metadata.stores 非空、不含「總倉」時，
  訂單取貨店必須在自己的 stores 裡，否則 raise wrong_store。orders 頁批次
  取貨 / PickupDialog 走同一支 RPC，一併被蓋住；HQ 層級與 legacy 帳號不變。
- /pickup 前端：分店帳號只顯示、只能操作自己店的單（未取/已取兩模式、
  一次全取、合併補印、確認視窗）；其他店的單收成一行摘要（店名 × 張數），
  櫃台答得出「客人在別店還有幾張」；貨齡面板改帶 p_store_id 只看本店。
- rpcError: wrong_store 前綴剝掉，直接顯示中文訊息。

驗證：tsc / eslint 無新增問題；Playwright fixture 實測分店與 HQ 兩種帳號
（docs/TEST-pickup-store-restriction.md）；線上 DB 灌 claims 實測守衛
擋跨店、放行本店/HQ/總倉/legacy。migration 已套用至線上。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LpD7sKbsQKdBN5WJiKJ9G7