### PR TITLE
fix(member): 訂單分頁「全部」移到最後，預設落在待到貨；取貨標示改「已取/未取」

### DIFF
--- a/apps/admin/src/components/MemberOrdersAppView.tsx
+++ b/apps/admin/src/components/MemberOrdersAppView.tsx
@@ -58,12 +58,14 @@ export type AppOrderRow = {
 type Phase = "waiting" | "pickup" | "done" | "void" | "transferred";
 type Tab = "all" | "waiting" | "pickup" | "done" | "void";
 
+// 「全部」放最後、預設落在「待到貨」＝會員 app（2026-08-13：預設「全部」會讓
+// 待取貨跟未到貨混排，客人以為全到貨跑來撲空）
 const TAB_LABEL: Record<Tab, string> = {
-  all: "全部",
   waiting: "待到貨",
   pickup: "待取貨",
   done: "已完成",
   void: "不成立",
+  all: "全部",
 };
 
 // = apps/member/src/components/OrderCard.tsx 的 orderPhase（分桶 + 右上角狀態字）
@@ -198,7 +200,7 @@ export function MemberOrdersAppView({
   onOpenOrder: (id: number, orderNo: string) => void;
 }) {
   const { buckets, loading, err } = data;
-  const [tab, setTab] = useState<Tab>("all");
+  const [tab, setTab] = useState<Tab>("waiting");
 
   const bucket = buckets[tab];
   // = 會員 app orders/page.tsx：應付總金額只在待到貨 / 待取貨顯示
@@ -286,7 +288,7 @@ function AppOrderCard({ order, onClick }: { order: AppOrderRow; onClick: () => v
     (s, i) => (["cancelled", "expired"].includes(i.status) ? s : s + Number(i.qty ?? 0)),
     0,
   );
-  // = 會員端 OrderCard：部分取貨時逐行標「已取貨 / 未取貨」，客服看到的跟
+  // = 會員端 OrderCard：部分取貨時逐行標「已取 / 未取」，客服看到的跟
   // 團友手機上的一致（2026-08-13 中和店客訴：分不出哪行取了）
   const showPickChips =
     (order.items ?? []).some((i) => i.status === "picked_up") &&
@@ -294,11 +296,11 @@ function AppOrderCard({ order, onClick }: { order: AppOrderRow; onClick: () => v
   const pickChip = (status: string) =>
     !showPickChips ? null : status === "picked_up" ? (
       <span className="ml-1.5 inline-block rounded bg-green-100 px-1 py-0.5 text-[10px] font-medium text-green-800 dark:bg-green-950 dark:text-green-300">
-        已取貨
+        已取
       </span>
     ) : ACTIVE_ITEM_STATUSES.includes(status) ? (
       <span className="ml-1.5 inline-block rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">
-        未取貨
+        未取
       </span>
     ) : null;
   const outstanding = Number(order.outstanding_amount ?? NaN);

--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -13,14 +13,17 @@ import OrderCard, { orderPhase, type OrderRow } from "@/components/OrderCard";
 // 分桶跟卡片右上角的狀態字共用 orderPhase()，兩邊永遠一致。
 // 「不成立」（斷貨取消）要顯示 —— 團友得知道那筆單為什麼消失（⛔ 斷貨說明）。
 // 「已轉讓」目前先隱藏（連「全部」也不出現），之後要開再把它移出 HIDDEN_PHASES。
+//
+// 「全部」放最後、預設落在「待到貨」（2026-08-13 門市回報）：預設開在「全部」時
+// 待取貨跟還沒到貨的單混排，客人以為全部到貨就跑來，結果要的那件還在路上。
 type Tab = "all" | "waiting" | "pickup" | "done" | "void";
 
 const TAB_LABEL: Record<Tab, string> = {
-  all: "全部",
   waiting: "待到貨",
   pickup: "待取貨",
   done: "已完成",
   void: "不成立",
+  all: "全部",
 };
 
 const HIDDEN_PHASES = new Set(["transferred"]);
@@ -65,7 +68,7 @@ function sumOrders(list: OrderRow[]) {
 
 export default function OrdersPage() {
   const router = useRouter();
-  const [tab, setTab] = useState<Tab>("all");
+  const [tab, setTab] = useState<Tab>("waiting");
   const [orders, setOrders] = useState<OrderRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -117,7 +117,7 @@ export default function OrderCard({ order }: { order: OrderRow }) {
     0,
   );
   // 部分取貨的單，客人看不出哪行取了、哪行沒取（2026-08-13 中和店客訴）——
-  // 取過的行和還沒取的行混在同一張卡時，逐行標「已取貨 / 未取貨」。
+  // 取過的行和還沒取的行混在同一張卡時，逐行標「已取 / 未取」。
   // 全取完（已完成）或全沒取的單不標，右上角狀態字已經講完了，行內再標是噪音。
   // 部分數量取貨會拆行（20260630000010），所以每一行必屬其中一邊，不用管數量。
   const showPickChips =
@@ -125,9 +125,9 @@ export default function OrderCard({ order }: { order: OrderRow }) {
     order.items.some((i) => ACTIVE_ITEM_STATUSES.includes(i.status));
   const pickChip = (status: string) =>
     !showPickChips ? null : status === "picked_up" ? (
-      <StatusChip tone="ok" label="已取貨" />
+      <StatusChip tone="ok" label="已取" />
     ) : ACTIVE_ITEM_STATUSES.includes(status) ? (
-      <StatusChip tone="warn" label="未取貨" />
+      <StatusChip tone="warn" label="未取" />
     ) : null;
   // 內部 sentinel 團（店內現貨轉手單）印品項名，其餘印開團名稱 —— 見 lib/orderTitle
   const title = orderCardTitle(order);


### PR DESCRIPTION
門市回報（2026-08-13）：訂單頁預設開在「全部」，待取貨跟還沒到貨的單混排，
客人以為全部到貨就跑來取，結果要的那件還在路上。

- 「全部」分頁移到最後，預設分頁改「待到貨」；分桶邏輯不動，
  只調 TAB_LABEL 順序（分頁列照 key 順序渲染）與初始 tab。
- 部分取貨的逐行標示由「已取貨 / 未取貨」縮成「已取 / 未取」。
- 後台「會員畫面」（MemberOrdersAppView）同步同一套：分頁順序、預設分頁、
  標示文字，客服對截圖口徑一致。

驗證：apps/member、apps/admin 各自 tsc --noEmit 與 eslint 無新增問題。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KwfQfE7j4eC1VtMWiKgmp6