### PR TITLE
fix(orders): 空中轉補上出貨入口 — 之前全站沒有任何人按得到

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,35 @@ RR- ride-along 單在補貨到店**之前**就存在（單頭 `pending`/`confirm
 所以 RPC 另外回一個 `backorder`（這組還掛著幾件待補貨），讓還有人在等的組別一定
 看得到入口。改這支的顯示條件時記得三個一起看。
 
+### 把某個角色的動作按鈕拿掉之前，先確認狀態機還有別人推得動
+
+「這一頁不該由總倉操作」是對的判斷，但把按鈕拿掉**不等於**別人就長出入口。
+狀態機卡在中間沒有任何 UI 的話，畫面上不會報錯，只會安靜地不動。
+
+前例（空中轉，2026-08）：`rpc_ship_aid_order`（confirmed → shipping，建 AT- 轉移單
+＋轉出店出庫）全站唯一入口是 `AidOrderStatusActions`，只掛在 `/hq/inbox`；
+而 `/hq/inbox` 在 `BRANCH_HIDDEN_HREFS` 裡、分店根本看不到。後來 air 被拆成獨立
+分頁並做成「唯讀、不出任何動作按鈕」（理由沒錯：空中轉不經總倉）→ **全站沒有任何人
+能派貨**。線上 5 張單卡在 `confirmed`、`transfers` 一張沒建，最久的卡了 12 天；
+進度條還照實寫著「（空中轉、暫無系統紀錄）」沒人當回事。
+
+所以動 UI 權限時：
+
+- 先 `grep -rn "<rpc_name>" apps/` 數一數入口有幾個。**只有一個**就不能只是拿掉，
+  要先把它搬到新的正主看得到的地方。
+- 正主＝**實際做那件事的人**。空中轉出貨是轉出店（貨從他們手上出去），
+  所以按鈕放在轉出店自己那張來源訂單上（`OrderDetail` 反查
+  `transferred_from_order_id = 本單 AND is_air_transfer AND status='confirmed'`）。
+  **反查、不要用 `transferred_to_order_id`** —— 部分轉出不寫那一欄。
+- 對面那一側（接收店）要看得到「在等誰」，不然他們只看到「已確認」三個字，
+  只能改走轉單，就變重複單。
+- 拿掉入口的同時留一份後備給 HQ；卡住時才有人救得了。
+
+驗這種洞不用等使用者回報，直接問 DB：
+「某狀態的單有多少張、對應的下游單據建了沒」——
+`SELECT status, count(*), sum((SELECT count(*) FROM transfers t WHERE t.customer_order_id = co.id)) ...`
+數字是 0 就是沒人按得到。
+
 ---
 
 ## 採購單 (purchase_orders)

--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -2573,7 +2573,9 @@ function MailRow({
       );
     }
   } else if (row.source === "air") {
-    // 空中轉:唯讀,只顯示資訊(訂單號 / 店 / 開團 / 品項 / 狀態),不出任何動作按鈕
+    // 空中轉:貨走店對店、總倉不碰,所以出貨的正主是轉出店(在來源訂單上按「✈ 出貨」)。
+    // 這裡仍留一份動作按鈕當後備 —— 之前做成純唯讀,而分店帳號看不到 /hq/inbox,
+    // 結果全站沒有任何人有派貨入口,空中轉單就永遠停在「已確認」(線上卡了 5 張)。
     const a = row.raw;
     idText = a.order_no;
     title = <>{a.campaign_no ?? "—"} <span className="text-zinc-400 mx-1">→</span> {a.store_name ?? "—"}</>;
@@ -2586,7 +2588,10 @@ function MailRow({
     );
     timeIso = a.updated_at;
     actions = (
-      <RowAction variant="neutral" onClick={() => onOpenAidDetail(a.id)}>查看訂單</RowAction>
+      <>
+        <AidOrderStatusActions order={{ id: a.id, status: a.status }} onChanged={onAidChanged} />
+        <RowAction variant="neutral" onClick={() => onOpenAidDetail(a.id)}>查看訂單</RowAction>
+      </>
     );
   } else {
     const a = row.raw;

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -85,6 +85,16 @@ type ReturnTransfer = {
   lines: ReturnLine[];
 };
 
+// 從本單空中轉出去、還等著轉出店出貨的轉入單（confirmed、還沒建 AT- 轉移單）。
+// 空中轉不經總倉，所以出貨這一步的操作者是轉出店 —— 也就是看著本單的人。
+type PendingAirShipment = {
+  id: number;
+  order_no: string;
+  pickup_store_id: number | null;
+  store_name: string;
+  qty: number;
+};
+
 // 品項狀態標籤（部分取貨會把一行拆成「已取」+「待取」兩行，標籤讓兩者一眼可分）
 function itemStatusBadge(status: string, stockout = false): { label: string; cls: string } | null {
   // 斷貨取消（stockout_at 有值）與一般取消區分顯示
@@ -177,6 +187,10 @@ export function OrderDetail({
   const [pickupEvents, setPickupEvents] = useState<PickupEventRow[]>([]);
   const [timeline, setTimeline] = useState<TimelineStep[] | null>(null);
   const [staffNames, setStaffNames] = useState<Map<string, string>>(new Map());
+  // 本單空中轉出去、還沒出貨的轉入單（給轉出店按「✈ 出貨」用）
+  const [pendingAirOut, setPendingAirOut] = useState<PendingAirShipment[]>([]);
+  // 本單自己是空中轉轉入單且還在等出貨時，轉出店店名（給接收店看「在等誰」）
+  const [awaitingAirFrom, setAwaitingAirFrom] = useState<string | null>(null);
   // sku_id → 現行分店價（prices scope=branch, effective_to IS NULL）
   const [branchPrices, setBranchPrices] = useState<Map<number, number>>(new Map());
   const [error, setError] = useState<string | null>(null);
@@ -228,7 +242,7 @@ export function OrderDetail({
     let cancelled = false;
     (async () => {
       const sb = getSupabase();
-      const [hRes, iRes, rRes, arvRes, pevRes] = await Promise.all([
+      const [hRes, iRes, rRes, arvRes, pevRes, airRes] = await Promise.all([
         sb.from("customer_orders")
           .select("id, order_no, status, stockout_at, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, transferred_from_order_id, is_air_transfer, discount_amount, discount_percent, wallet_paid_amount, payment_status, paid_at, notes, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .eq("id", orderId).maybeSingle(),
@@ -246,6 +260,13 @@ export function OrderDetail({
           .select("item_id, pickup_ready")
           .eq("order_id", orderId),
         fetchReprintableEvents([orderId]),
+        // 從本單空中轉出去、還卡在 confirmed 的轉入單。空中轉不經總倉，
+        // 出貨要由轉出店（＝正在看本單的人）按下，否則沒有任何人有入口。
+        sb.from("customer_orders")
+          .select("id, order_no, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name), items:customer_order_items(qty, status)")
+          .eq("transferred_from_order_id", orderId)
+          .eq("is_air_transfer", true)
+          .eq("status", "confirmed"),
       ]);
       if (cancelled) return;
       if (hRes.error) { setError(hRes.error.message); return; }
@@ -262,6 +283,45 @@ export function OrderDetail({
       setItemReady(arrivedMap);
 
       setPickupEvents(pevRes.get(orderId) ?? []);
+
+      // ========== 待出貨的空中轉（本單 → 其他店）==========
+      type AirRow = {
+        id: number; order_no: string; pickup_store_id: number | null;
+        store: { name: string } | { name: string }[] | null;
+        items: { qty: number; status: string }[] | null;
+      };
+      const airRows = ((airRes.data ?? []) as unknown as AirRow[])
+        // 同店空中轉：rpc_ship_aid_order 會以「source/dest 同 location」擋下，不給按
+        .filter((r) => r.pickup_store_id !== headData.pickup_store_id)
+        .map((r): PendingAirShipment => ({
+          id: r.id,
+          order_no: r.order_no,
+          pickup_store_id: r.pickup_store_id,
+          store_name: (Array.isArray(r.store) ? r.store[0]?.name : r.store?.name) ?? "—",
+          qty: (r.items ?? [])
+            .filter((it) => !["cancelled", "expired"].includes(it.status))
+            .reduce((s, it) => s + Number(it.qty), 0),
+        }));
+      setPendingAirOut(airRows);
+
+      // 本單自己就是等出貨的空中轉轉入單 → 讓接收店看得到在等哪一家出貨
+      if (headData.is_air_transfer && headData.status === "confirmed" && headData.transferred_from_order_id) {
+        const { data: srcRow } = await sb
+          .from("customer_orders")
+          .select("pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)")
+          .eq("id", headData.transferred_from_order_id)
+          .maybeSingle();
+        const src = srcRow as unknown as
+          { pickup_store_id: number | null; store: { name: string } | { name: string }[] | null } | null;
+        const st = src?.store;
+        // 同店不需要出貨（rpc_ship_aid_order 也會擋），不掛「等出貨」
+        const sameStore = src?.pickup_store_id === headData.pickup_store_id;
+        if (!cancelled) {
+          setAwaitingAirFrom(sameStore ? null : (Array.isArray(st) ? st[0]?.name : st?.name) ?? "轉出店");
+        }
+      } else if (!cancelled) {
+        setAwaitingAirFrom(null);
+      }
 
       // ========== 整理退貨單（return_to_hq transfer）==========
       type RetRow = {
@@ -588,6 +648,28 @@ export function OrderDetail({
     setReloadTick((n) => n + 1);
   }
 
+  // 空中轉出貨：建 AT- 轉移單（store_to_store, shipped）＋本店即時出庫，
+  // 轉入單 confirmed → shipping。接收店隨後在「收貨」頁收掉就變成可取貨。
+  async function shipAir(s: PendingAirShipment) {
+    if (!head) return;
+    if (!confirm(
+      `✈ 空中轉出貨：${s.order_no}（${s.store_name}）\n\n` +
+      `會從本店庫存扣掉 ${s.qty} 件並建立轉移單，${s.store_name}在「收貨」頁收貨後即可交給顧客。\n` +
+      `確定貨已經寄出／交給司機了嗎？`,
+    )) return;
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id ?? null;
+    if (!operator) { alert("尚未登入"); return; }
+    const { error: rpcErr } = await sb.rpc("rpc_ship_aid_order", {
+      p_order_id: s.id,
+      p_operator: operator,
+    });
+    if (rpcErr) { alert(`出貨失敗：${translateRpcError(rpcErr)}`); return; }
+    alert(`已出貨，等 ${s.store_name} 在「收貨」頁收貨`);
+    setReloadTick((n) => n + 1);
+  }
+
   async function aidReturn() {
     if (!head) return;
     const walletPaid = Number(head.wallet_paid_amount ?? 0);
@@ -700,8 +782,23 @@ export function OrderDetail({
           </SpinButton>
         </div>
       )}
-      {(canPrintSlip || canReprintReceipt || canTransfer || canPickup || canUndoPickup || canCancel || canReturn || canAidReturn || isTransferredOut) && (
-        <div className="flex items-center justify-end gap-2">
+      {(canPrintSlip || canReprintReceipt || canTransfer || canPickup || canUndoPickup || canCancel || canReturn || canAidReturn || isTransferredOut || pendingAirOut.length > 0 || awaitingAirFrom) && (
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {awaitingAirFrom && (
+            <span className="text-xs text-amber-700 dark:text-amber-400">
+              ✈ 等 {awaitingAirFrom} 出貨（出貨後本店在「收貨」頁收貨）
+            </span>
+          )}
+          {pendingAirOut.map((s) => (
+            <SpinButton
+              key={s.id}
+              onClick={() => shipAir(s)}
+              className="rounded-md border border-sky-300 px-3 py-1 text-xs font-medium text-sky-700 hover:bg-sky-50 dark:border-sky-800 dark:text-sky-300 dark:hover:bg-sky-950"
+              title={`空中轉：從本店出庫 ${s.qty} 件並建立轉移單，交給 ${s.store_name} 收貨（${s.order_no}）`}
+            >
+              ✈ 出貨到 {s.store_name}
+            </SpinButton>
+          ))}
           {canReprintReceipt && (
             <SpinButton
               onClick={() =>
@@ -1327,14 +1424,22 @@ async function buildTimeline(
     };
 
     if (head.is_air_transfer) {
-      // 空中轉：店對店直送
+      // 空中轉：店對店直送，全程不經總倉 —— 出貨由轉出店自己在來源訂單上按
       return [
         sourceStep,
+        {
+          label: "轉出店出貨",
+          ts: null,
+          done: rank >= 3,
+          detail: rank >= 3
+            ? "（已出庫、轉移單已建立）"
+            : `（等 ${srcStoreName} 在來源訂單按「✈ 出貨」）`,
+        },
         {
           label: "分店收貨",
           ts: null,
           done: rank >= 4,
-          detail: rank >= 4 ? "（分店已可取貨）" : "（空中轉、暫無系統紀錄）",
+          detail: rank >= 4 ? "（分店已可取貨）" : "（在「收貨」頁收 AT- 轉移單）",
         },
         customerStep,
       ];

--- a/docs/TEST-air-transfer-ship-entry.md
+++ b/docs/TEST-air-transfer-ship-entry.md
@@ -1,0 +1,88 @@
+# TEST — 空中轉的「出貨 / 收貨」入口
+
+## 背景（線上災情）
+
+空中轉（店對店直送、不經總倉）的完整流程是：
+
+```
+轉出店 ↗轉出此訂單(勾空中轉)  →  轉入單 confirmed
+      →  rpc_ship_aid_order(派貨)  →  建 AT- 轉移單(store_to_store, shipped) + 轉出店出庫
+      →  轉入單 shipping
+      →  接收店在 /wms/inbound 收貨 (rpc_receive_transfer)
+      →  轉入單 ready  →  顧客取貨
+```
+
+第 2 步（派貨）全站唯一入口是 `AidOrderStatusActions`，而它只掛在 `/hq/inbox`：
+
+- `/hq/inbox` 在 `BRANCH_HIDDEN_HREFS` 裡 → 分店帳號完全看不到這一頁。
+- `/hq/inbox` 的 `source=air` 分頁被做成「唯讀，不出任何動作按鈕」（空中轉不經總倉，
+  所以不讓總倉動）。
+
+兩件事加起來 = **全站沒有任何人有派貨入口**。線上 5 張空中轉單卡在 `confirmed`、
+`transfers` 一張都沒建（最早 2026-08-01）；唯一走完的一張（#42045, 2026-07-01）
+是在 air 還併在 aid 分頁、還有按鈕的時候派掉的。
+
+`OrderDetail` 的進度條當時也直說「（空中轉、暫無系統紀錄）」。
+
+## 修法
+
+出貨的正主是**轉出店**（貨從他們手上出去），所以把入口放到轉出店看得到的地方
+—— 他們自己那張來源訂單：
+
+- `OrderDetail` 反查 `customer_orders WHERE transferred_from_order_id = 本單
+  AND is_air_transfer AND status='confirmed'`，每張秀一顆「✈ 出貨到 XX店」。
+  （反查而不是用 `transferred_to_order_id`：部分轉出不會寫那一欄。）
+- 接收店那一側改秀「✈ 等 XX店 出貨」，並在進度條補一格「轉出店出貨」。
+- `/hq/inbox` 的 air 分頁把動作按鈕加回去當後備。
+
+---
+
+## 轉出店側（來源訂單）
+
+- [ ] **A1** 來源單有一張空中轉轉入單卡在 `confirmed` → 明細出現「✈ 出貨到 XX店」。
+- [ ] **A2** 按下去 → `rpc_ship_aid_order` 成功：建 1 張 `AT-O<id>-<epoch>`
+      （`transfer_type='store_to_store'`, `status='shipped'`, `customer_order_id=轉入單`,
+      `next_transfer_id=NULL`），轉出店 `stock_movements` 出現 `transfer_out`，
+      轉入單 → `shipping`。**不建 HQ leg**。
+- [ ] **A3** 整單轉出（來源單 `transferred_out`）與部分轉出（來源單仍 `ready`）
+      兩種都看得到按鈕。
+- [ ] **A4** 同店空中轉不出按鈕（`rpc_ship_aid_order` 會以 source/dest 同 location 擋下）。
+- [ ] **A5** 轉入單已 `shipping` / `ready` / `cancelled` → 按鈕消失（只撈 `confirmed`）。
+- [ ] **A6** 一張來源單分別空中轉給兩家店 → 兩顆按鈕，各自獨立出貨。
+- [ ] **A7** 轉出店庫存不足 → RPC raise `Insufficient stock`，前端跳「出貨失敗：…」，
+      訂單狀態不動（整個 transaction rollback）。
+
+## 接收店側（轉入單）
+
+- [ ] **B1** 空中轉轉入單 `confirmed` → 明細出現「✈ 等 XX店 出貨（出貨後本店在「收貨」頁收貨）」，
+      **不出**出貨按鈕（避免接收店去扣別人家的庫存）。
+- [ ] **B2** 進度條四格：轉出店 ✓ → 轉出店出貨（等 XX店 …）→ 分店收貨（在「收貨」頁收 AT- 轉移單）
+      → 顧客取貨；不再出現「暫無系統紀錄」。
+- [ ] **B3** 轉出店出貨後重整 → 進度條第 2 格變 done、hint 消失。
+- [ ] **B4** `/wms/inbound`（分店帳號）看得到那張 AT- 轉移單（`dest_location` = 本店），
+      收貨後轉入單 → `ready`，`/pickup` 可勾品項交貨。
+- [ ] **B5** 經總倉（`is_air_transfer=false`）的轉入單完全不受影響：沒有 hint、
+      進度條仍是 總倉收到 / 運送中 / 分店收貨 三格。
+
+## HQ 後備
+
+- [ ] **C1** `/hq/inbox?source=air` 每列回到「派貨 / 取消 / 查看訂單」，
+      派貨行為與 `source=aid` 一致。
+- [ ] **C2** `source=aid` 分頁不含空中轉（維持既有 `is_air_transfer` 分流），計數不重複。
+
+## Regression
+
+- [ ] **R1** `tsc --noEmit`（apps/admin）通過。
+- [ ] **R2** eslint 對兩支改動檔沒有新增 error（既有 3 個 `set-state-in-effect`
+      是 hq/inbox 原本就有的）。
+- [ ] **R3** 一般顧客訂單（非互助）明細完全不變 —— 反查查不到東西時不多打任何 UI。
+
+---
+
+### 驗證狀態（本輪）
+
+- ✅ `tsc --noEmit` 通過
+- ✅ eslint 無新增 error（與改動前同樣 3 個既有 error）
+- ✅ A1 / B1 / B2：Playwright + fixture（線上真實兩張單 #70214 松山店 →
+  #74738 三峽店 的資料）跑過，兩側畫面都如預期
+- ⏳ A2 / A7 / B3 / B4 需在真資料上點一次才算數（會動庫存，留給店家操作）


### PR DESCRIPTION
空中轉（店對店直送、不經總倉）的狀態機是
  轉出 → confirmed →（rpc_ship_aid_order 派貨，建 AT- 轉移單＋轉出店出庫）
  → shipping → 接收店在 /wms/inbound 收貨 → ready → 顧客取貨。

中間那一步「派貨」全站唯一入口是 AidOrderStatusActions，而它只掛在
/hq/inbox；/hq/inbox 又在 BRANCH_HIDDEN_HREFS 裡，分店根本看不到這一頁。
後來 air 被拆成獨立分頁並做成「唯讀、不出任何動作按鈕」（理由沒錯：空中轉
不經總倉）→ 於是沒有任何角色能把單子往前推。

線上實況：5 張空中轉單卡在 confirmed、transfers 一張都沒建，最早卡自
2026-08-01；唯一走完的一張（#42045）是在 air 還併在 aid 分頁、還有按鈕的
時候派掉的。訂單明細的進度條也照實寫著「（空中轉、暫無系統紀錄）」。

出貨的正主是轉出店（貨從他們手上出去），所以入口放到轉出店看得到的地方：

- OrderDetail 反查「從本單空中轉出去、還卡在 confirmed」的轉入單，
  每張秀一顆「✈ 出貨到 XX店」，按下走 rpc_ship_aid_order。
  用反查而不是 transferred_to_order_id —— 部分轉出不寫那一欄。
  同店的不出按鈕（RPC 會以 source/dest 同 location 擋下）。
- 接收店那一側改秀「✈ 等 XX店 出貨」，並在進度條補一格「轉出店出貨」，
  取代原本的「暫無系統紀錄」。不給接收店出貨鈕，免得去扣別人家的庫存。
- /hq/inbox 的 air 分頁把動作按鈕加回去當後備，卡住時 HQ 救得了。

收貨端本來就是通的（rpc_receive_transfer 看 customer_order_id 推 ready，
AT- 轉移單在 /wms/inbound 歸在「其他」群組），這次沒動。

驗證：tsc --noEmit 通過；eslint 無新增 error；Playwright + fixture
（線上真實的 #70214 松山店 → #74738 三峽店）確認兩側畫面如預期。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F4KdBkwWBKU9y9nL7FS7yU