### PR TITLE
fix(shop): 補上 quick-control RPC 的 grant 收斂 + APP 下單失敗留 log

### DIFF
--- a/apps/member/src/app/shop/c/[id]/page.tsx
+++ b/apps/member/src/app/shop/c/[id]/page.tsx
@@ -200,9 +200,16 @@ export default function CampaignDetailPage() {
       setDoneOrderNo(r.order_no);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      const friendly = message.includes("sold out")
-        ? "已售完或數量不足，請重新整理後再選。"
-        : message;
+      const soldOut = message.includes("sold out");
+      // 售完是熱團的正常結果不記；其餘下單失敗會員只看得到 alert，一定要留 log
+      // （2026-08-14 線上 RPC 沒部署、全 APP 下單掛掉，client_error_logs 一筆都沒有）。
+      if (!soldOut) {
+        logCaught("place_member_order_failed", e, {
+          campaign_id: id,
+          items: ordered.length,
+        });
+      }
+      const friendly = soldOut ? "已售完或數量不足，請重新整理後再選。" : message;
       alert(`下單失敗：${friendly}`);
     } finally {
       setSubmitting(false);

--- a/supabase/migrations/20260814000000_quick_control_rpc_grants.sql
+++ b/supabase/migrations/20260814000000_quick_control_rpc_grants.sql
@@ -1,0 +1,23 @@
+-- ============================================================================
+-- 2026-08-14: Restrict quick-control / guarded-order RPC execute grants
+-- ----------------------------------------------------------------------------
+-- 20260813000000_quick_campaign_control / 20260813001000_quick_mobile_create_campaign
+-- 只 REVOKE FROM PUBLIC，但 Supabase 的 default privileges 會直接把 EXECUTE 發給
+-- anon / authenticated（同 20260812021000 的前例），所以線上三支函式 anon 都叫得動。
+-- rpc_place_member_order_guarded 是 SECURITY DEFINER 且 p_tenant 走參數、函式內
+-- 不驗 caller —— 必須只留 service_role（liff-api 用 service key 呼叫）。
+-- 另外兩支函式內有驗 app_metadata role，但照慣例一樣收掉 anon。
+-- ============================================================================
+
+REVOKE ALL ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) TO service_role;
+
+REVOKE ALL ON FUNCTION public.rpc_quick_update_campaign_control(BIGINT, TEXT, TIMESTAMPTZ, NUMERIC) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_quick_update_campaign_control(BIGINT, TEXT, TIMESTAMPTZ, NUMERIC) FROM anon;
+GRANT EXECUTE ON FUNCTION public.rpc_quick_update_campaign_control(BIGINT, TEXT, TIMESTAMPTZ, NUMERIC) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.rpc_quick_create_campaign_from_product(BIGINT, TEXT, TEXT, TIMESTAMPTZ, TEXT, DATE, NUMERIC, JSONB) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_quick_create_campaign_from_product(BIGINT, TEXT, TEXT, TIMESTAMPTZ, TEXT, DATE, NUMERIC, JSONB) FROM anon;
+GRANT EXECUTE ON FUNCTION public.rpc_quick_create_campaign_from_product(BIGINT, TEXT, TEXT, TIMESTAMPTZ, TEXT, DATE, NUMERIC, JSONB) TO authenticated;


### PR DESCRIPTION
8/14 01:34 liff-api v75 部署後全 APP 下單掛掉：place_member_order 改走
rpc_place_member_order_guarded，但 20260813000000_quick_campaign_control /
20260813001000_quick_mobile_create_campaign 兩支 migration 沒套上正式庫
（PostgREST 回 Could not find the function）。兩支已於今日以 Management API
補套上線。

本 commit 補兩件事：
- 20260814000000_quick_control_rpc_grants.sql：Supabase default privileges
  會把 EXECUTE 直接發給 anon/authenticated，只 REVOKE PUBLIC 擋不掉（同
  20260812021000 前例）。rpc_place_member_order_guarded 是 SECURITY DEFINER
  且 p_tenant 走參數，收斂到只剩 service_role；另外兩支 quick-control RPC
  收掉 anon。已套上正式庫並驗證 ACL。
- 會員端下單 catch 分支補 logCaught：這次全站下單掛了 8 小時，
  client_error_logs 一筆都沒有，違反「使用者會卡住的分支一律留 log」。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017SpKXRKwq2sd72J7XWK1Xt