### PR TITLE
fix(shop): 修復 APP 下單失敗 — quick-control RPC 補漏、ambiguous 修正、grant 收斂

### DIFF
--- a/apps/member/src/app/shop/c/[id]/page.tsx
+++ b/apps/member/src/app/shop/c/[id]/page.tsx
@@ -200,9 +200,16 @@ export default function CampaignDetailPage() {
       setDoneOrderNo(r.order_no);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      const friendly = message.includes("sold out")
-        ? "已售完或數量不足，請重新整理後再選。"
-        : message;
+      const soldOut = message.includes("sold out");
+      // 售完是熱團的正常結果不記；其餘下單失敗會員只看得到 alert，一定要留 log
+      // （2026-08-14 線上 RPC 沒部署、全 APP 下單掛掉，client_error_logs 一筆都沒有）。
+      if (!soldOut) {
+        logCaught("place_member_order_failed", e, {
+          campaign_id: id,
+          items: ordered.length,
+        });
+      }
+      const friendly = soldOut ? "已售完或數量不足，請重新整理後再選。" : message;
       alert(`下單失敗：${friendly}`);
     } finally {
       setSubmitting(false);

--- a/supabase/migrations/20260814000000_quick_control_rpc_grants.sql
+++ b/supabase/migrations/20260814000000_quick_control_rpc_grants.sql
@@ -1,0 +1,23 @@
+-- ============================================================================
+-- 2026-08-14: Restrict quick-control / guarded-order RPC execute grants
+-- ----------------------------------------------------------------------------
+-- 20260813000000_quick_campaign_control / 20260813001000_quick_mobile_create_campaign
+-- 只 REVOKE FROM PUBLIC，但 Supabase 的 default privileges 會直接把 EXECUTE 發給
+-- anon / authenticated（同 20260812021000 的前例），所以線上三支函式 anon 都叫得動。
+-- rpc_place_member_order_guarded 是 SECURITY DEFINER 且 p_tenant 走參數、函式內
+-- 不驗 caller —— 必須只留 service_role（liff-api 用 service key 呼叫）。
+-- 另外兩支函式內有驗 app_metadata role，但照慣例一樣收掉 anon。
+-- ============================================================================
+
+REVOKE ALL ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) TO service_role;
+
+REVOKE ALL ON FUNCTION public.rpc_quick_update_campaign_control(BIGINT, TEXT, TIMESTAMPTZ, NUMERIC) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_quick_update_campaign_control(BIGINT, TEXT, TIMESTAMPTZ, NUMERIC) FROM anon;
+GRANT EXECUTE ON FUNCTION public.rpc_quick_update_campaign_control(BIGINT, TEXT, TIMESTAMPTZ, NUMERIC) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.rpc_quick_create_campaign_from_product(BIGINT, TEXT, TEXT, TIMESTAMPTZ, TEXT, DATE, NUMERIC, JSONB) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_quick_create_campaign_from_product(BIGINT, TEXT, TEXT, TIMESTAMPTZ, TEXT, DATE, NUMERIC, JSONB) FROM anon;
+GRANT EXECUTE ON FUNCTION public.rpc_quick_create_campaign_from_product(BIGINT, TEXT, TEXT, TIMESTAMPTZ, TEXT, DATE, NUMERIC, JSONB) TO authenticated;

--- a/supabase/migrations/20260814000010_fix_guarded_order_ambiguous_refs.sql
+++ b/supabase/migrations/20260814000010_fix_guarded_order_ambiguous_refs.sql
@@ -1,0 +1,428 @@
+-- ============================================================================
+-- 2026-08-14: Fix ambiguous column references in quick-control RPCs
+-- ----------------------------------------------------------------------------
+-- 基底版本：20260813000000_quick_campaign_control.sql（這兩支函式唯一的前版）。
+-- rollback：重跑該檔的對應 CREATE OR REPLACE（含 20260814000000 的 grant 收斂）。
+--
+-- RETURNS TABLE 的 OUT 參數（order_id / order_no；id / status / end_at /
+-- total_cap_qty）跟資料表欄位同名，函式內未加表別名的引用會炸
+-- 「column reference "order_no" is ambiguous」——
+-- 會員 APP 下單一進到既有單查詢就 500（8/14 上午 alice lu / 黃秀美 回報）。
+-- 修法：全部改用表別名限定，函式邏輯完全不變。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_quick_update_campaign_control(
+  p_campaign_id BIGINT,
+  p_status TEXT DEFAULT NULL,
+  p_end_at TIMESTAMPTZ DEFAULT NULL,
+  p_total_cap_qty_delta NUMERIC DEFAULT NULL
+) RETURNS TABLE (
+  id BIGINT,
+  status TEXT,
+  end_at TIMESTAMPTZ,
+  total_cap_qty NUMERIC,
+  sold_qty NUMERIC
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_user UUID := auth.uid();
+  v_role TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_campaign group_buy_campaigns%ROWTYPE;
+  v_sold_qty NUMERIC := 0;
+  v_next_status TEXT;
+  v_next_end_at TIMESTAMPTZ;
+  v_next_total_cap_qty NUMERIC;
+BEGIN
+  IF v_role NOT IN ('owner', 'admin', 'hq_manager', 'assistant', '') THEN
+    RAISE EXCEPTION 'insufficient_role';
+  END IF;
+
+  SELECT * INTO v_campaign
+    FROM group_buy_campaigns gbc
+   WHERE gbc.id = p_campaign_id
+     AND gbc.tenant_id = v_tenant
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id;
+  END IF;
+
+  IF v_campaign.status NOT IN ('draft', 'open', 'closed') THEN
+    RAISE EXCEPTION 'campaign % is %, cannot quick-control', p_campaign_id, v_campaign.status;
+  END IF;
+
+  IF NOT (
+       v_campaign.close_type IN ('food_train', 'fast', 'limited')
+    OR COALESCE(v_campaign.total_cap_qty, 0) > 0
+    OR EXISTS (
+      SELECT 1
+        FROM campaign_items ci
+       WHERE ci.tenant_id = v_tenant
+         AND ci.campaign_id = p_campaign_id
+         AND COALESCE(ci.cap_qty, 0) > 0
+    )
+  ) THEN
+    RAISE EXCEPTION 'campaign % is not a quick-control campaign', p_campaign_id;
+  END IF;
+
+  SELECT COALESCE(SUM(coi.qty), 0)
+    INTO v_sold_qty
+    FROM customer_order_items coi
+    JOIN customer_orders co ON co.id = coi.order_id
+   WHERE co.tenant_id = v_tenant
+     AND co.campaign_id = p_campaign_id
+     AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+     AND coi.status NOT IN ('cancelled', 'expired')
+     AND COALESCE(co.order_kind, 'normal') = 'normal';
+
+  v_next_status := COALESCE(p_status, v_campaign.status);
+  v_next_end_at := COALESCE(p_end_at, v_campaign.end_at);
+  v_next_total_cap_qty := v_campaign.total_cap_qty;
+
+  IF p_status IS NOT NULL THEN
+    IF p_status <> 'open' THEN
+      RAISE EXCEPTION 'invalid quick target status: %', p_status;
+    END IF;
+
+    IF p_status = 'open' THEN
+      IF v_campaign.status NOT IN ('draft', 'closed', 'open') THEN
+        RAISE EXCEPTION 'campaign % is %, cannot open', p_campaign_id, v_campaign.status;
+      END IF;
+
+      PERFORM 1 FROM campaign_items ci WHERE ci.campaign_id = p_campaign_id LIMIT 1;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'campaign % has no items', p_campaign_id;
+      END IF;
+
+      IF v_campaign.status = 'closed' AND EXISTS (
+        SELECT 1
+          FROM purchase_request_campaigns prc
+          JOIN purchase_requests pr ON pr.id = prc.pr_id
+         WHERE prc.tenant_id = v_tenant
+           AND prc.campaign_id = p_campaign_id
+           AND pr.status <> 'cancelled'
+      ) THEN
+        RAISE EXCEPTION 'campaign % already has purchase request linkage; cannot reopen', p_campaign_id;
+      END IF;
+
+      IF v_next_end_at IS NULL OR v_next_end_at <= NOW() THEN
+        RAISE EXCEPTION 'future end_at is required when opening/reopening';
+      END IF;
+    END IF;
+  END IF;
+
+  IF p_end_at IS NOT NULL THEN
+    IF p_end_at <= NOW() THEN
+      RAISE EXCEPTION 'end_at must be in the future';
+    END IF;
+    IF v_campaign.status = 'closed' AND v_next_status <> 'open' THEN
+      RAISE EXCEPTION 'closed campaigns must be reopened, not only extended';
+    END IF;
+  END IF;
+
+  IF p_total_cap_qty_delta IS NOT NULL THEN
+    IF p_total_cap_qty_delta <= 0 THEN
+      RAISE EXCEPTION 'cap delta must be > 0';
+    END IF;
+    v_next_total_cap_qty := COALESCE(v_campaign.total_cap_qty, v_sold_qty) + p_total_cap_qty_delta;
+  END IF;
+
+  UPDATE group_buy_campaigns gbc
+     SET status = v_next_status,
+         end_at = v_next_end_at,
+         total_cap_qty = v_next_total_cap_qty,
+         updated_by = v_user,
+         updated_at = NOW()
+   WHERE gbc.id = p_campaign_id
+     AND gbc.tenant_id = v_tenant;
+
+  IF p_status IS NOT NULL AND v_next_status IS DISTINCT FROM v_campaign.status THEN
+    INSERT INTO campaign_audit_log (
+      tenant_id, campaign_id, entity_type, entity_id, field,
+      before_value, after_value, edit_reason, operator_id
+    ) VALUES (
+      v_tenant, p_campaign_id, 'campaign', p_campaign_id, 'status',
+      to_jsonb(v_campaign.status), to_jsonb(v_next_status),
+      'quick_control', v_user
+    );
+  END IF;
+
+  IF p_end_at IS NOT NULL AND v_next_end_at IS DISTINCT FROM v_campaign.end_at THEN
+    INSERT INTO campaign_audit_log (
+      tenant_id, campaign_id, entity_type, entity_id, field,
+      before_value, after_value, edit_reason, operator_id
+    ) VALUES (
+      v_tenant, p_campaign_id, 'campaign', p_campaign_id, 'end_at',
+      to_jsonb(v_campaign.end_at), to_jsonb(v_next_end_at),
+      'quick_control', v_user
+    );
+  END IF;
+
+  IF p_total_cap_qty_delta IS NOT NULL AND v_next_total_cap_qty IS DISTINCT FROM v_campaign.total_cap_qty THEN
+    INSERT INTO campaign_audit_log (
+      tenant_id, campaign_id, entity_type, entity_id, field,
+      before_value, after_value, edit_reason, operator_id
+    ) VALUES (
+      v_tenant, p_campaign_id, 'campaign', p_campaign_id, 'total_cap_qty',
+      to_jsonb(v_campaign.total_cap_qty), to_jsonb(v_next_total_cap_qty),
+      'quick_control', v_user
+    );
+  END IF;
+
+  RETURN QUERY
+  SELECT p_campaign_id, v_next_status, v_next_end_at, v_next_total_cap_qty, v_sold_qty;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_quick_update_campaign_control(BIGINT, TEXT, TIMESTAMPTZ, NUMERIC) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_quick_update_campaign_control(BIGINT, TEXT, TIMESTAMPTZ, NUMERIC) FROM anon;
+GRANT EXECUTE ON FUNCTION public.rpc_quick_update_campaign_control(BIGINT, TEXT, TIMESTAMPTZ, NUMERIC) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_place_member_order_guarded(
+  p_tenant UUID,
+  p_campaign_id BIGINT,
+  p_channel_id BIGINT,
+  p_member_id BIGINT,
+  p_pickup_store_id BIGINT,
+  p_items JSONB,
+  p_notes TEXT DEFAULT NULL,
+  p_source TEXT DEFAULT 'liff'
+) RETURNS TABLE (
+  order_id BIGINT,
+  order_no TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_campaign group_buy_campaigns%ROWTYPE;
+  v_member members%ROWTYPE;
+  v_source TEXT := CASE WHEN p_source = 'pwa' THEN 'pwa' ELSE 'liff' END;
+  v_requested_count INT := 0;
+  v_requested_total NUMERIC := 0;
+  v_total_sold NUMERIC := 0;
+  v_order_id BIGINT;
+  v_order_no TEXT;
+  v_seq INT;
+  v_req RECORD;
+  v_ci RECORD;
+  v_item_sold NUMERIC;
+  v_existing_qty NUMERIC;
+BEGIN
+  IF p_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant required';
+  END IF;
+  IF p_campaign_id IS NULL THEN
+    RAISE EXCEPTION 'campaign_id required';
+  END IF;
+  IF p_channel_id IS NULL THEN
+    RAISE EXCEPTION 'channel_id required';
+  END IF;
+  IF p_member_id IS NULL THEN
+    RAISE EXCEPTION 'member_id required';
+  END IF;
+  IF p_pickup_store_id IS NULL THEN
+    RAISE EXCEPTION 'pickup_store_id required';
+  END IF;
+  IF p_items IS NULL OR jsonb_typeof(p_items) <> 'array' OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'items required';
+  END IF;
+
+  SELECT * INTO v_campaign
+    FROM group_buy_campaigns gbc
+   WHERE gbc.tenant_id = p_tenant
+     AND gbc.id = p_campaign_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'campaign not found';
+  END IF;
+  IF v_campaign.status <> 'open' THEN
+    RAISE EXCEPTION 'campaign not open';
+  END IF;
+  IF COALESCE(v_campaign.is_for_shop, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'campaign not available';
+  END IF;
+  IF v_campaign.end_at IS NOT NULL AND v_campaign.end_at <= NOW() THEN
+    RAISE EXCEPTION 'campaign already ended';
+  END IF;
+
+  SELECT * INTO v_member
+    FROM members m
+   WHERE m.tenant_id = p_tenant
+     AND m.id = p_member_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member not found';
+  END IF;
+  IF COALESCE(v_member.no_new_order, false) THEN
+    RAISE EXCEPTION 'member blocked';
+  END IF;
+
+  PERFORM 1 FROM stores s WHERE s.tenant_id = p_tenant AND s.id = p_pickup_store_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pickup_store_id required';
+  END IF;
+
+  PERFORM 1 FROM line_channels lc WHERE lc.tenant_id = p_tenant AND lc.id = p_channel_id AND lc.is_active = TRUE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'no active channel for tenant';
+  END IF;
+
+  FOR v_req IN
+    SELECT
+      (x ->> 'campaign_item_id')::BIGINT AS campaign_item_id,
+      (x ->> 'qty')::NUMERIC AS qty
+    FROM jsonb_array_elements(p_items) AS x
+  LOOP
+    IF v_req.campaign_item_id IS NULL OR v_req.qty IS NULL OR v_req.qty <= 0 THEN
+      RAISE EXCEPTION 'qty must be > 0';
+    END IF;
+  END LOOP;
+
+  SELECT COUNT(*), COALESCE(SUM(qty), 0)
+    INTO v_requested_count, v_requested_total
+    FROM (
+      SELECT (x ->> 'campaign_item_id')::BIGINT AS campaign_item_id,
+             SUM((x ->> 'qty')::NUMERIC) AS qty
+        FROM jsonb_array_elements(p_items) AS x
+       GROUP BY (x ->> 'campaign_item_id')::BIGINT
+    ) req;
+
+  IF v_requested_count = 0 OR v_requested_total <= 0 THEN
+    RAISE EXCEPTION 'items required';
+  END IF;
+
+  SELECT COALESCE(SUM(coi.qty), 0)
+    INTO v_total_sold
+    FROM customer_order_items coi
+    JOIN customer_orders co ON co.id = coi.order_id
+   WHERE co.tenant_id = p_tenant
+     AND co.campaign_id = p_campaign_id
+     AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+     AND coi.status NOT IN ('cancelled', 'expired')
+     AND COALESCE(co.order_kind, 'normal') = 'normal';
+
+  IF COALESCE(v_campaign.total_cap_qty, 0) > 0
+     AND v_total_sold + v_requested_total > v_campaign.total_cap_qty THEN
+    RAISE EXCEPTION 'sold out';
+  END IF;
+
+  FOR v_req IN
+    SELECT (x ->> 'campaign_item_id')::BIGINT AS campaign_item_id,
+           SUM((x ->> 'qty')::NUMERIC) AS qty
+      FROM jsonb_array_elements(p_items) AS x
+     GROUP BY (x ->> 'campaign_item_id')::BIGINT
+  LOOP
+    SELECT ci.id, ci.sku_id, ci.unit_price, ci.cap_qty
+      INTO v_ci
+      FROM campaign_items ci
+     WHERE ci.tenant_id = p_tenant
+       AND ci.campaign_id = p_campaign_id
+       AND ci.id = v_req.campaign_item_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'campaign item not found';
+    END IF;
+
+    SELECT COALESCE(SUM(coi.qty), 0)
+      INTO v_item_sold
+      FROM customer_order_items coi
+      JOIN customer_orders co ON co.id = coi.order_id
+     WHERE co.tenant_id = p_tenant
+       AND co.campaign_id = p_campaign_id
+       AND coi.campaign_item_id = v_req.campaign_item_id
+       AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+       AND coi.status NOT IN ('cancelled', 'expired')
+       AND COALESCE(co.order_kind, 'normal') = 'normal';
+
+    IF COALESCE(v_ci.cap_qty, 0) > 0 AND v_item_sold + v_req.qty > v_ci.cap_qty THEN
+      RAISE EXCEPTION 'item sold out';
+    END IF;
+  END LOOP;
+
+  SELECT co.id, co.order_no
+    INTO v_order_id, v_order_no
+    FROM customer_orders co
+   WHERE co.tenant_id = p_tenant
+     AND co.campaign_id = p_campaign_id
+     AND co.channel_id = p_channel_id
+     AND co.member_id = p_member_id
+     AND COALESCE(co.order_kind, 'normal') = 'normal'
+     AND co.status NOT IN ('cancelled', 'expired', 'transferred_out')
+   FOR UPDATE;
+
+  IF v_order_id IS NULL THEN
+    SELECT COUNT(*) + 1 INTO v_seq
+      FROM customer_orders co
+     WHERE co.tenant_id = p_tenant
+       AND co.campaign_id = p_campaign_id;
+    v_order_no := v_campaign.campaign_no || '-' || lpad(v_seq::TEXT, 4, '0');
+
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id,
+      nickname_snapshot, pickup_store_id, status, order_kind, notes
+    ) VALUES (
+      p_tenant, v_order_no, p_campaign_id, p_channel_id, p_member_id,
+      v_member.name, p_pickup_store_id, 'pending', 'normal', NULLIF(p_notes, '')
+    )
+    RETURNING id INTO v_order_id;
+  ELSE
+    UPDATE customer_orders co
+       SET nickname_snapshot = COALESCE(v_member.name, co.nickname_snapshot),
+           pickup_store_id = p_pickup_store_id,
+           notes = NULLIF(p_notes, ''),
+           updated_at = NOW()
+     WHERE co.id = v_order_id;
+  END IF;
+
+  FOR v_req IN
+    SELECT (x ->> 'campaign_item_id')::BIGINT AS campaign_item_id,
+           SUM((x ->> 'qty')::NUMERIC) AS qty
+      FROM jsonb_array_elements(p_items) AS x
+     GROUP BY (x ->> 'campaign_item_id')::BIGINT
+  LOOP
+    SELECT ci.sku_id, ci.unit_price
+      INTO v_ci
+      FROM campaign_items ci
+     WHERE ci.tenant_id = p_tenant
+       AND ci.campaign_id = p_campaign_id
+       AND ci.id = v_req.campaign_item_id;
+
+    SELECT coi.qty INTO v_existing_qty
+      FROM customer_order_items coi
+     WHERE coi.order_id = v_order_id
+       AND coi.campaign_item_id = v_req.campaign_item_id
+     FOR UPDATE;
+
+    IF v_existing_qty IS NULL THEN
+      INSERT INTO customer_order_items (
+        tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price, status, source
+      ) VALUES (
+        p_tenant, v_order_id, v_req.campaign_item_id, v_ci.sku_id, v_req.qty, v_ci.unit_price, 'pending', v_source
+      );
+    ELSE
+      UPDATE customer_order_items coi
+         SET qty = v_existing_qty + v_req.qty,
+             source = v_source,
+             updated_at = NOW()
+       WHERE coi.order_id = v_order_id
+         AND coi.campaign_item_id = v_req.campaign_item_id;
+    END IF;
+  END LOOP;
+
+  order_id := v_order_id;
+  order_no := v_order_no;
+  RETURN NEXT;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_place_member_order_guarded(UUID, BIGINT, BIGINT, BIGINT, BIGINT, JSONB, TEXT, TEXT) TO service_role;


### PR DESCRIPTION
## 背景

8/14 01:34 `liff-api` v75 部署後，會員 APP／商城下單全掛（紅蜻蜓農場團回報，實際影響全部團）。連環兩個問題：

1. **migration 沒上線**：liff-api 改走 `rpc_place_member_order_guarded`，但建函式的 `20260813000000_quick_campaign_control.sql` / `20260813001000_quick_mobile_create_campaign.sql`（皆已在 main）從未套上正式庫 → PostgREST 回 `Could not find the function`。
2. **函式本身的 bug**：補套上線後改炸 `column reference "order_no" is ambiguous` — `RETURNS TABLE` 的 OUT 參數（`order_id`/`order_no`；quick-control 的 `id`/`status`/`end_at`/`total_cap_qty`）跟資料表欄位同名，函式內未加表別名的引用 plpgsql 無法解析。`rpc_quick_update_campaign_control` 第一句 `WHERE id = p_campaign_id` 就會炸，等於手機快速控團一用就壞。

## 變更內容

- `20260814000000_quick_control_rpc_grants.sql`：Supabase default privileges 會把 EXECUTE 直接發給 `anon`/`authenticated`，只 `REVOKE FROM PUBLIC` 擋不掉（同 `20260812021000` 前例）。`rpc_place_member_order_guarded` 是 SECURITY DEFINER 且 `p_tenant` 走參數，收斂到只剩 `service_role`；另外兩支 quick-control RPC 收掉 `anon`。
- `20260814000010_fix_guarded_order_ambiguous_refs.sql`：兩支函式全部改用表別名限定，邏輯不變。基底＝`20260813000000_quick_campaign_control.sql`（唯一前版）。`rpc_quick_create_campaign_from_product` 的 OUT 參數只出現在 INSERT 欄位清單，不受影響。
- `apps/member` 下單 catch 分支補 `logCaught`：這次全站下單掛了約 8 小時，`client_error_logs` 一筆都沒有；補上後這類災情可直接從 log 看到範圍（售完不記，其餘都記）。

## 部署狀態

三支 migration **均已於 8/14 以 Management API 套上正式庫**（含先前漏套的兩支 20260813）。本 PR 合併即完成 repo ↔ 正式庫對齊；`apps/member` 的 log 補強需隨前端部署生效。

## 驗證

- 以真實參數（團 3895、真實會員/門市/channel）在強制 rollback 的交易內跑通三條路徑：新開單 INSERT、同人加購 UPDATE（本次炸掉的路徑）、quick-control 無參數更新；確認未留測試資料。
- PostgREST：service_role 可進函式本體；anon 呼叫回 42501 permission denied。
- ACL 驗證：`rpc_place_member_order_guarded` 僅 `postgres`+`service_role`；另兩支僅 `postgres`+`authenticated`+`service_role`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SpKXRKwq2sd72J7XWK1Xt

---
_Generated by [Claude Code](https://claude.ai/code/session_017SpKXRKwq2sd72J7XWK1Xt)_