### PR TITLE
Picking workstation v4: filter by campaign/SKU/time + tablet UX

### DIFF
--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-// 批次撿貨工作站 v3 — 全清單合併視角
-// - 預設：所有 PO 合併成一個 SKU × store 矩陣，提交時依 PO 自動 FIFO 切分多張 wave
-// - 「依分店」：純檢視，每家店看到的 (PO × SKU) 待撿明細
+// 批次撿貨工作站 v4 — 從總倉庫存派出（平板優化）
+// - 上方下拉篩選：開團 / 商品 / 時間（結團時間區間），先縮小範圍再分配
+// - 矩陣：SKU × 分店，只顯示篩選範圍內有需求的分店欄；點「需 N」一鍵填入
+// - 提交時依 PO 自動 FIFO 切分多張 wave（邏輯與 v3 相同，未動）
+// - 「依分店」：純檢視，每家店看到的 (PO × SKU) 待撿明細（吃同一組篩選）
+// - 開團對應（po_item → campaign）由前端撈 purchase_request_items /
+//   purchase_request_campaigns 組出來，與 view 的 po_campaigns CTE 同構，
+//   不動 v_picking_demand_by_po（CREATE OR REPLACE VIEW 欄位順序限制多、風險高）。
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { fetchAllRows } from "@/lib/fetchAllRows";
@@ -43,6 +48,16 @@ type AllocKey = string; // `${sku_id}:${store_id}`
 type ViewMode = "matrix" | "by_store";
 // 現行成本價 / 分店價是否已設定（出貨守衛 _missing_dispatch_prices 的前端預警）
 type PriceFlags = { cost: boolean; branch: boolean };
+
+type CampaignInfo = {
+  id: number;
+  campaign_no: string;
+  name: string;
+  start_at: string | null;
+  end_at: string | null;
+  status: string;
+};
+type TimeFilter = "all" | "7" | "14" | "30" | "90";
 
 type RestockRow = {
   restock_request_id: number;
@@ -91,6 +106,18 @@ export default function PickingWorkstationPage() {
   const [priceEdit, setPriceEdit] = useState<{ skuId: number; scope: "cost" | "branch" } | null>(null);
   const [priceDraft, setPriceDraft] = useState("");
 
+  // ===== 篩選（開團 / 商品 / 時間）＋ 平板顯示選項 =====
+  // po_item_id → campaign_ids（前端組的 po_campaigns 對應）。null = 尚未載入。
+  const [poItemCampaigns, setPoItemCampaigns] = useState<Map<number, number[]> | null>(null);
+  const [campaignsById, setCampaignsById] = useState<Map<number, CampaignInfo> | null>(null);
+  // 總倉即時在庫（stock_balances.on_hand @ central_warehouse），純參考顯示。
+  const [hqOnHand, setHqOnHand] = useState<Map<number, number> | null>(null);
+  const [filterCampaign, setFilterCampaign] = useState<string>("all"); // "all" | "none" | `${campaign_id}`
+  const [filterSku, setFilterSku] = useState<string>("all"); // "all" | `${sku_id}`
+  const [filterTime, setFilterTime] = useState<TimeFilter>("all");
+  // 預設只顯示「篩選範圍內還有需求」的分店欄（17 間店的矩陣在平板上塞不下）。
+  const [showAllStores, setShowAllStores] = useState(false);
+
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
@@ -136,8 +163,13 @@ export default function PickingWorkstationPage() {
   }, [reloadKey]);
 
   // 依分店檢視分頁：lazy 撈完整 view（含缺貨待到的品項），只在切到該分頁時撈一次。
+  // in-flight 用 ref 而不是 loadingFull state 當 effect dep：
+  // 舊寫法 setLoadingFull(true) 會讓 deps 變動 → cleanup 把 cancelled 設 true →
+  // 撈回來的資料被丟掉、loadingFull 永遠卡 true，「依分店」分頁永遠顯示載入中。
+  const fullDemandInflight = useRef(false);
   useEffect(() => {
-    if (viewMode !== "by_store" || fullDemand !== null || loadingFull) return;
+    if (viewMode !== "by_store" || fullDemand !== null || fullDemandInflight.current) return;
+    fullDemandInflight.current = true;
     let cancelled = false;
     setLoadingFull(true);
     (async () => {
@@ -152,11 +184,12 @@ export default function PickingWorkstationPage() {
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err));
       } finally {
-        if (!cancelled) setLoadingFull(false);
+        fullDemandInflight.current = false;
+        setLoadingFull(false);
       }
     })();
     return () => { cancelled = true; };
-  }, [viewMode, fullDemand, loadingFull]);
+  }, [viewMode, fullDemand]);
 
   // ===== 缺價預警：抓畫面上所有 SKU 的現行成本價 / 分店價 =====
   // 與 DB 守衛 _missing_dispatch_prices 同條件（scope cost/branch、effective_to IS NULL、price>0）。
@@ -199,6 +232,106 @@ export default function PickingWorkstationPage() {
       } catch {
         // 缺價檢查失敗不影響工作台主流程，僅不顯示預警
         if (!cancelled) { setCanFixPrices(false); setPriceFlags(null); }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [demand, restockDemand]);
+
+  // ===== 開團對應 + 總倉在庫：demand 載入後補撈（失敗只影響篩選，不影響派貨） =====
+  // po_item → campaign 與 view 的 po_campaigns CTE 同構：
+  //   pri.po_item_id → prc.campaign_id（PR 掛的開團）∪ pri.source_campaign_id
+  useEffect(() => {
+    if (!demand) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const poItemIds = Array.from(new Set(demand.map((r) => r.po_item_id).filter((v) => v != null)));
+        const skuIds = Array.from(new Set([
+          ...demand.map((r) => r.sku_id),
+          ...(restockDemand ?? []).map((r) => r.sku_id),
+        ]));
+
+        type PriRow = { po_item_id: number; pr_id: number; source_campaign_id: number | null };
+        const priRows: PriRow[] = [];
+        for (let i = 0; i < poItemIds.length; i += 200) {
+          const { data, error: e } = await sb
+            .from("purchase_request_items")
+            .select("po_item_id, pr_id, source_campaign_id")
+            .in("po_item_id", poItemIds.slice(i, i + 200));
+          if (e) throw new Error(e.message);
+          priRows.push(...(((data ?? []) as PriRow[])));
+        }
+        const prIds = Array.from(new Set(priRows.map((r) => r.pr_id)));
+        type PrcRow = { pr_id: number; campaign_id: number };
+        const prcRows: PrcRow[] = [];
+        for (let i = 0; i < prIds.length; i += 200) {
+          const { data, error: e } = await sb
+            .from("purchase_request_campaigns")
+            .select("pr_id, campaign_id")
+            .in("pr_id", prIds.slice(i, i + 200));
+          if (e) throw new Error(e.message);
+          prcRows.push(...(((data ?? []) as PrcRow[])));
+        }
+        const prToCampaigns = new Map<number, number[]>();
+        for (const r of prcRows) {
+          prToCampaigns.set(r.pr_id, [...(prToCampaigns.get(r.pr_id) ?? []), r.campaign_id]);
+        }
+        const mapping = new Map<number, Set<number>>();
+        for (const r of priRows) {
+          const set = mapping.get(r.po_item_id) ?? new Set<number>();
+          if (r.source_campaign_id != null) set.add(r.source_campaign_id);
+          for (const c of prToCampaigns.get(r.pr_id) ?? []) set.add(c);
+          mapping.set(r.po_item_id, set);
+        }
+
+        const campaignIds = Array.from(new Set(Array.from(mapping.values()).flatMap((s) => Array.from(s))));
+        const cMap = new Map<number, CampaignInfo>();
+        for (let i = 0; i < campaignIds.length; i += 200) {
+          const { data, error: e } = await sb
+            .from("group_buy_campaigns")
+            .select("id, campaign_no, name, start_at, end_at, status")
+            .in("id", campaignIds.slice(i, i + 200));
+          if (e) throw new Error(e.message);
+          for (const c of (data ?? []) as CampaignInfo[]) cMap.set(c.id, c);
+        }
+
+        // 總倉即時在庫（有些 role 讀不到 stock_balances → 留 null 不顯示，不報錯）
+        const oh = new Map<number, number>();
+        try {
+          const { data: loc } = await sb
+            .from("locations").select("id")
+            .eq("type", "central_warehouse").eq("is_active", true).limit(1);
+          const hqLocId = (((loc ?? []) as { id: number }[])[0])?.id ?? null;
+          if (hqLocId != null) {
+            for (let i = 0; i < skuIds.length; i += 200) {
+              const { data, error: e } = await sb
+                .from("stock_balances")
+                .select("sku_id, on_hand")
+                .eq("location_id", hqLocId)
+                .in("sku_id", skuIds.slice(i, i + 200));
+              if (e) throw new Error(e.message);
+              for (const r of (data ?? []) as { sku_id: number; on_hand: number }[]) {
+                oh.set(r.sku_id, Number(r.on_hand));
+              }
+            }
+          }
+        } catch {
+          oh.clear();
+        }
+
+        if (!cancelled) {
+          setPoItemCampaigns(new Map(Array.from(mapping.entries()).map(([k, v]) => [k, Array.from(v)])));
+          setCampaignsById(cMap);
+          setHqOnHand(oh.size > 0 ? oh : null);
+        }
+      } catch {
+        // 對應載入失敗 → 下拉退化成「全部」，矩陣照常可派
+        if (!cancelled) {
+          setPoItemCampaigns(new Map());
+          setCampaignsById(new Map());
+          setHqOnHand(null);
+        }
       }
     })();
     return () => { cancelled = true; };
@@ -322,6 +455,7 @@ export default function PickingWorkstationPage() {
     totalShortage: number;                // 總短少(永遠不會到)
     totalAlreadyWave: number;             // 總已撿
     totalAvailable: number;               // 可分配 = totalGr - totalAlreadyWave
+    campaignIds: Set<number>;             // 此 SKU 對應的開團（跨 po_item 聯集），篩選用
   };
 
   const skuRows: SkuRow[] = useMemo(() => {
@@ -347,9 +481,11 @@ export default function PickingWorkstationPage() {
           totalShortage: 0,
           totalAlreadyWave: 0,
           totalAvailable: 0,
+          campaignIds: new Set<number>(),
         };
         grouped.set(r.sku_id, s);
       }
+      for (const cid of poItemCampaigns?.get(r.po_item_id) ?? []) s.campaignIds.add(cid);
       const poSkuKey = `${r.po_id}:${r.sku_id}`;
       if (!poSkuSeen.has(poSkuKey)) {
         poSkuSeen.add(poSkuKey);
@@ -389,7 +525,7 @@ export default function PickingWorkstationPage() {
       // 派貨工作台是「我現在可以分配什麼」,在途的等 PO 收貨後自然會回來。
       .filter((s) => s.totalAvailable > 0)
       .sort((a, b) => (a.sku_code ?? "").localeCompare(b.sku_code ?? ""));
-  }, [demand]);
+  }, [demand, poItemCampaigns]);
 
   const allStores: StoreInfo[] = useMemo(() => {
     if (!demand) return [];
@@ -406,6 +542,97 @@ export default function PickingWorkstationPage() {
     return Array.from(m.values()).sort((a, b) => (a.store_code ?? "").localeCompare(b.store_code ?? ""));
   }, [demand]);
 
+  // ===== 篩選：開團 / 商品 / 時間 =====
+  // 時間 = 開團結團時間（end_at，沒有就退 start_at）在最近 N 天內（含還沒結的）。
+  const timeCutoff = useMemo(() => {
+    if (filterTime === "all") return null;
+    const d = new Date();
+    d.setDate(d.getDate() - Number(filterTime));
+    return d.getTime();
+  }, [filterTime]);
+  const campaignInTime = (cid: number): boolean => {
+    if (timeCutoff === null) return true;
+    const c = campaignsById?.get(cid);
+    const ref = c?.end_at ?? c?.start_at;
+    if (!ref) return false;
+    return new Date(ref).getTime() >= timeCutoff;
+  };
+  // 開團下拉選項：目前矩陣有出現、且通過時間篩選的開團，依結團時間新→舊排。
+  const campaignOptions: CampaignInfo[] = useMemo(() => {
+    if (!campaignsById) return [];
+    const ids = new Set<number>();
+    for (const sk of skuRows) for (const cid of sk.campaignIds) ids.add(cid);
+    return Array.from(ids)
+      .filter((cid) => campaignInTime(cid))
+      .map((cid) => campaignsById.get(cid))
+      .filter((c): c is CampaignInfo => !!c)
+      .sort((a, b) => (b.end_at ?? b.start_at ?? "").localeCompare(a.end_at ?? a.start_at ?? ""));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [skuRows, campaignsById, timeCutoff]);
+  const hasNoCampaignRows = useMemo(
+    () => skuRows.some((sk) => sk.campaignIds.size === 0),
+    [skuRows],
+  );
+
+  // 選中的開團從清單消失（時間改了、需求派完了、對應還沒載入）→ 視同「全部」。
+  // 用衍生值而不是 effect 改 state，避免 cascading render。
+  const effFilterCampaign =
+    filterCampaign === "all" || filterCampaign === "none"
+      ? filterCampaign
+      : campaignOptions.some((c) => String(c.id) === filterCampaign)
+        ? filterCampaign
+        : "all";
+
+  // 商品下拉選項：通過 開團＋時間 篩選的品項（商品自身的篩選不影響選項清單）。
+  const skuOptions = useMemo(
+    () =>
+      skuRows.filter((sk) => {
+        const cids = Array.from(sk.campaignIds);
+        if (filterTime !== "all" && !cids.some(campaignInTime)) return false;
+        if (effFilterCampaign === "none" && cids.length > 0) return false;
+        if (effFilterCampaign !== "all" && effFilterCampaign !== "none" && !cids.includes(Number(effFilterCampaign))) return false;
+        return true;
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [skuRows, effFilterCampaign, filterTime, timeCutoff, campaignsById],
+  );
+  const effFilterSku =
+    filterSku !== "all" && skuOptions.some((sk) => String(sk.sku_id) === filterSku)
+      ? filterSku
+      : "all";
+
+  const rowPassesFilters = (campaignIds: Iterable<number>, skuId: number): boolean => {
+    const cids = Array.from(campaignIds);
+    if (filterTime !== "all" && !cids.some(campaignInTime)) return false;
+    if (effFilterCampaign === "none" && cids.length > 0) return false;
+    if (effFilterCampaign !== "all" && effFilterCampaign !== "none" && !cids.includes(Number(effFilterCampaign))) return false;
+    if (effFilterSku !== "all" && skuId !== Number(effFilterSku)) return false;
+    return true;
+  };
+  const hasActiveFilter = effFilterCampaign !== "all" || effFilterSku !== "all" || filterTime !== "all";
+
+  // 通過全部篩選的矩陣列
+  const filteredSkuRows = useMemo(
+    () => skuRows.filter((sk) => rowPassesFilters(sk.campaignIds, sk.sku_id)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [skuRows, effFilterCampaign, effFilterSku, filterTime, timeCutoff, campaignsById],
+  );
+
+  // 平板塞不下 17 欄 → 預設只顯示「篩選範圍內還有未派需求、或已填擬分量」的分店欄。
+  // 注意：分配上限（getSkuAllocTotal）永遠算全部分店，隱藏欄的擬分量照樣計入。
+  const visibleStores: StoreInfo[] = useMemo(() => {
+    if (showAllStores) return allStores;
+    const kept = allStores.filter((st) =>
+      filteredSkuRows.some(
+        (sk) => storeDemandLeft(sk, st.store_id) > 0 || getAlloc(sk.sku_id, st.store_id) > 0,
+      ),
+    );
+    // 全部被濾光（例如需求都派完了）就退回顯示全部，避免空矩陣看不懂
+    return kept.length > 0 ? kept : allStores;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allStores, filteredSkuRows, showAllStores, allocs]);
+  const hiddenStoreCount = allStores.length - visibleStores.length;
+
   // 依分店視角（純檢視）
   type StoreSection = {
     storeId: number;
@@ -415,10 +642,12 @@ export default function PickingWorkstationPage() {
   };
   const storeSections: StoreSection[] = useMemo(() => {
     // 依分店檢視用完整清單（含缺貨待到）；矩陣的 demand 只有可分配列，不夠。
+    // 吃同一組 開團/商品/時間 篩選（逐列用 po_item → campaign 對應判斷）。
     if (!fullDemand) return [];
     const grouped = new Map<number, StoreSection>();
     for (const r of fullDemand) {
       if (r.store_id === null) continue;
+      if (!rowPassesFilters(poItemCampaigns?.get(r.po_item_id) ?? [], r.sku_id)) continue;
       if (!grouped.has(r.store_id)) {
         grouped.set(r.store_id, {
           storeId: r.store_id,
@@ -430,7 +659,8 @@ export default function PickingWorkstationPage() {
       grouped.get(r.store_id)!.rows.push(r);
     }
     return Array.from(grouped.values()).sort((a, b) => (a.storeCode ?? "").localeCompare(b.storeCode ?? ""));
-  }, [fullDemand]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fullDemand, poItemCampaigns, effFilterCampaign, effFilterSku, filterTime, timeCutoff, campaignsById]);
 
   // 補貨申請預設分配 = min(申請量 - 已撿, HQ 庫存) per (rr, sku)
   useEffect(() => {
@@ -693,11 +923,11 @@ export default function PickingWorkstationPage() {
   // 一律以「與目前清單的交集」為準：selectedSkus 可能殘留已消失的 sku_id，
   // 交集會自動忽略它們（免用 effect 清理、計數也不會超算）。
   const selectedRows = useMemo(
-    () => skuRows.filter((s) => selectedSkus.has(s.sku_id)),
-    [skuRows, selectedSkus],
+    () => filteredSkuRows.filter((s) => selectedSkus.has(s.sku_id)),
+    [filteredSkuRows, selectedSkus],
   );
   const hasSelection = selectedRows.length > 0;
-  const allVisibleSelected = skuRows.length > 0 && selectedRows.length === skuRows.length;
+  const allVisibleSelected = filteredSkuRows.length > 0 && selectedRows.length === filteredSkuRows.length;
   function toggleSku(skuId: number) {
     setSelectedSkus((prev) => {
       const next = new Set(prev);
@@ -708,14 +938,14 @@ export default function PickingWorkstationPage() {
   }
   function toggleAllSkus() {
     setSelectedSkus((prev) =>
-      skuRows.length > 0 && skuRows.every((s) => prev.has(s.sku_id))
+      filteredSkuRows.length > 0 && filteredSkuRows.every((s) => prev.has(s.sku_id))
         ? new Set()
-        : new Set(skuRows.map((s) => s.sku_id)),
+        : new Set(filteredSkuRows.map((s) => s.sku_id)),
     );
   }
 
-  // 本次建單納入的品項：有勾選 → 只取選取的；未勾選 → 全部
-  const effectiveSkuRows = hasSelection ? selectedRows : skuRows;
+  // 本次建單納入的品項：有勾選 → 只取選取的；未勾選 → 篩選範圍內全部
+  const effectiveSkuRows = hasSelection ? selectedRows : filteredSkuRows;
 
   // 本次擬分總量（限納入的品項）
   const totalAllocSum = useMemo(() => {
@@ -767,12 +997,12 @@ export default function PickingWorkstationPage() {
   const missingPriceCount = useMemo(() => {
     if (!canFixPrices || !priceFlags) return 0;
     let n = 0;
-    for (const sk of skuRows) {
+    for (const sk of filteredSkuRows) {
       const f = priceFlags.get(sk.sku_id);
       if (f && (!f.cost || !f.branch)) n += 1;
     }
     return n;
-  }, [skuRows, priceFlags, canFixPrices]);
+  }, [filteredSkuRows, priceFlags, canFixPrices]);
 
   // ===== 補貨申請(無 PO 來源)分組 =====
   type RestockGroup = {
@@ -803,6 +1033,14 @@ export default function PickingWorkstationPage() {
     }
     return Array.from(map.values()).sort((a, b) => a.rrId - b.rrId);
   }, [restockDemand]);
+
+  // 補貨申請不屬於任何開團：選了特定開團就整段隱藏；商品篩選則濾到含該品項的申請。
+  const visibleRestockGroups = useMemo(() => {
+    if (effFilterCampaign !== "all" && effFilterCampaign !== "none") return [];
+    if (effFilterSku === "all") return restockGroups;
+    const skuId = Number(effFilterSku);
+    return restockGroups.filter((g) => g.lines.some((ln) => ln.sku_id === skuId));
+  }, [restockGroups, effFilterCampaign, effFilterSku]);
 
   function getRestockAlloc(rrId: number, skuId: number): number {
     return restockAllocs.get(`${rrId}:${skuId}`) ?? 0;
@@ -855,14 +1093,14 @@ export default function PickingWorkstationPage() {
   const kpis = useMemo(() => {
     let totalAvailable = 0, totalInTransit = 0, totalShortage = 0;
     let skuShortageCount = 0;
-    for (const sk of skuRows) {
+    for (const sk of filteredSkuRows) {
       totalAvailable += sk.totalAvailable;
       totalInTransit += sk.totalInTransit;
       totalShortage += sk.totalShortage;
       if (sk.totalShortage > 0) skuShortageCount += 1;
     }
     return { totalAvailable, totalInTransit, totalShortage, skuShortageCount };
-  }, [skuRows]);
+  }, [filteredSkuRows]);
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
@@ -870,19 +1108,79 @@ export default function PickingWorkstationPage() {
         <div>
           <h1 className="text-xl font-semibold">🚦 派貨工作台</h1>
           <p className="text-sm text-zinc-500">
-            合併所有還有分店需求未派的 PO 為一張矩陣 — 直接針對 品項 × 分店分配,提交時依 PO 自動切分。包含客戶訂單派貨與補貨申請(📦);需求派完的品項會自動下架。
+            從總倉已到貨庫存派給各分店 — 先用下拉選「開團 / 商品 / 時間」縮小範圍,再對 品項 × 分店 填配送量;建單時依 PO 自動切分。需求派完的品項會自動下架。
           </p>
         </div>
         <Link
           href="/hq/inbox?source=picking"
-          className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          className="rounded-md border border-zinc-300 px-3 py-2 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
         >
           撿貨單列表 →
         </Link>
       </header>
 
-      {/* KPI bar */}
+      {/* 篩選列：開團 / 商品 / 時間（平板友善的大下拉） */}
       {skuRows.length > 0 && (
+        <div className="flex flex-wrap items-end gap-3 rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
+          <label className="flex min-w-[220px] flex-1 flex-col gap-1 sm:max-w-xs">
+            <span className="text-xs font-medium text-zinc-500">開團</span>
+            <select
+              value={effFilterCampaign}
+              onChange={(e) => setFilterCampaign(e.target.value)}
+              className="h-11 w-full rounded-md border border-zinc-300 bg-white px-3 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+            >
+              <option value="all">全部開團</option>
+              {hasNoCampaignRows && <option value="none">無開團來源（補貨等）</option>}
+              {campaignOptions.map((c) => (
+                <option key={c.id} value={String(c.id)}>
+                  {c.campaign_no} · {c.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex min-w-[220px] flex-1 flex-col gap-1 sm:max-w-xs">
+            <span className="text-xs font-medium text-zinc-500">商品</span>
+            <select
+              value={effFilterSku}
+              onChange={(e) => setFilterSku(e.target.value)}
+              className="h-11 w-full rounded-md border border-zinc-300 bg-white px-3 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+            >
+              <option value="all">全部商品（{skuOptions.length}）</option>
+              {skuOptions.map((sk) => (
+                <option key={sk.sku_id} value={String(sk.sku_id)}>
+                  {sk.sku_code ? `${sk.sku_code} · ` : ""}{sk.sku_label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex w-40 flex-col gap-1">
+            <span className="text-xs font-medium text-zinc-500" title="以開團的結團時間算（沒結團時間就看開團時間），含還沒結團的">時間</span>
+            <select
+              value={filterTime}
+              onChange={(e) => setFilterTime(e.target.value as TimeFilter)}
+              className="h-11 w-full rounded-md border border-zinc-300 bg-white px-3 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+            >
+              <option value="all">全部時間</option>
+              <option value="7">近 7 天結團</option>
+              <option value="14">近 14 天結團</option>
+              <option value="30">近 30 天結團</option>
+              <option value="90">近 90 天結團</option>
+            </select>
+          </label>
+          {hasActiveFilter && (
+            <button
+              type="button"
+              onClick={() => { setFilterCampaign("all"); setFilterSku("all"); setFilterTime("all"); }}
+              className="h-11 rounded-md border border-zinc-300 px-4 text-sm text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              ✕ 清除篩選
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* KPI bar */}
+      {filteredSkuRows.length > 0 && (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           <KpiCard label="可分配庫存" value={kpis.totalAvailable} accent="text-emerald-700 dark:text-emerald-400" hint="HQ 已到貨可派" />
           <KpiCard label="本次擬分" value={totalAllocSum} accent="text-blue-700 dark:text-blue-400" hint={involvedPos > 0 ? `預計切 ${involvedPos} 張 wave` : "尚未填入分配量"} />
@@ -917,20 +1215,41 @@ export default function PickingWorkstationPage() {
           {loading
             ? "載入中…"
             : viewMode === "matrix"
-              ? `${skuRows.length} 個品項 · ${allStores.length} 間分店${
+              ? `${filteredSkuRows.length}${hasActiveFilter ? ` / ${skuRows.length}` : ""} 個品項 · ${visibleStores.length}${
+                  hiddenStoreCount > 0 ? ` / ${allStores.length}` : ""
+                } 間分店${
                   hasSelection ? ` · 已選 ${selectedRows.length} 品項` : ""
                 } · 擬分 ${totalAllocSum}${involvedPos > 0 ? ` · 預計切 ${involvedPos} 張撿貨單` : ""}`
               : loadingFull || fullDemand === null
                 ? "載入完整清單中…"
                 : `${storeSections.length} 間分店有待撿貨`}
         </span>
+        {viewMode === "matrix" && hiddenStoreCount > 0 && !showAllStores && (
+          <button
+            type="button"
+            onClick={() => setShowAllStores(true)}
+            className="text-xs text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
+            title="預設只顯示篩選範圍內還有需求的分店欄"
+          >
+            另有 {hiddenStoreCount} 間分店無需求 — 顯示全部
+          </button>
+        )}
+        {viewMode === "matrix" && showAllStores && allStores.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowAllStores(false)}
+            className="text-xs text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
+          >
+            只顯示有需求的分店
+          </button>
+        )}
         {viewMode === "matrix" && missingPriceCount > 0 && (
           <span className="text-xs font-medium text-rose-700 dark:text-rose-400">
             缺價 {missingPriceCount} 品項 — 補價前派貨會被擋
           </span>
         )}
 
-        {viewMode === "matrix" && skuRows.length > 0 && (
+        {viewMode === "matrix" && filteredSkuRows.length > 0 && (
           <div className="ml-auto flex flex-wrap gap-2">
             {hasSelection && (
               <button
@@ -972,9 +1291,11 @@ export default function PickingWorkstationPage() {
       {demand === null ? (
         <div className="text-center text-sm text-zinc-500">載入中…</div>
       ) : viewMode === "matrix" ? (
-        skuRows.length === 0 ? (
+        filteredSkuRows.length === 0 ? (
           <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
-            目前沒有待派的品項(該派的都派完了;在途的等收貨後、新需求進來後會自動回來)。
+            {skuRows.length === 0
+              ? "目前沒有待派的品項(該派的都派完了;在途的等收貨後、新需求進來後會自動回來)。"
+              : "目前的篩選條件下沒有待派品項 — 換個開團 / 商品 / 時間,或清除篩選。"}
           </div>
         ) : (
           // 只保留水平(左右)捲軸:拿掉高度上限,表格整高展開、跟著整頁一起垂直捲動,
@@ -982,29 +1303,25 @@ export default function PickingWorkstationPage() {
           // sticky 左欄在橫向捲動時固定品項欄。
           <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
             {/* table-fixed + 明確總寬：auto layout 把 <col> 寬度當建議值,店一多就把店別欄
-                壓到比 80px 窄、數量輸入框跟著縮,兩位數以上直接被裁掉(線上 17 間店整排看不到數字),
-                品項欄反而膨脹(truncate 失效)。fixed layout 嚴格吃 <col> 寬度,
+                壓窄、數量輸入框跟著縮,兩位數以上直接被裁掉。fixed layout 嚴格吃 <col> 寬度,
                 超出容器交給外層 overflow-x-auto 出捲軸;容器比較寬時 min-w-full 照舊撐滿。
-                總寬 = 品項 240 + 數字欄 5×56(w-14) + 可分配/合計 2×64(w-16) + 店別 n×80(w-20),
+                平板優化:訂購/已到/在途/短少/已派 收斂進品項欄的統計列,只留
+                可分配 + 擬分合計 兩個數字欄;店別欄放大到 96px 裝大號觸控輸入框。
+                總寬 = 品項 230 + 可分配 80(w-20) + 擬分 64(w-16) + 店別 n×96(w-24),
                 改 colgroup 時要一起改這條。 */}
             <table
               className="min-w-full table-fixed divide-y divide-zinc-200 text-sm dark:divide-zinc-800"
-              style={{ width: 240 + 5 * 56 + 2 * 64 + allStores.length * 80 }}
+              style={{ width: 230 + 80 + 64 + visibleStores.length * 96 }}
             >
               <colgroup>
-                <col className="w-[240px]" />
-                <col className="w-14" />
-                <col className="w-14" />
-                <col className="w-14" />
-                <col className="w-14" />
-                <col className="w-14" />
+                <col className="w-[230px]" />
+                <col className="w-20" />
                 <col className="w-16" />
-                <col className="w-16" />
-                {allStores.map((st) => <col key={st.store_id} className="w-20" />)}
+                {visibleStores.map((st) => <col key={st.store_id} className="w-24" />)}
               </colgroup>
               <thead className="sticky top-0 z-10 bg-zinc-50 dark:bg-zinc-900">
                 <tr>
-                  <Th className="sticky left-0 z-20 bg-zinc-50 dark:bg-zinc-900">
+                  <Th className="sticky left-0 z-20 bg-zinc-50 py-2 dark:bg-zinc-900">
                     <div className="flex items-center gap-2">
                       <input
                         type="checkbox"
@@ -1012,48 +1329,44 @@ export default function PickingWorkstationPage() {
                         checked={allVisibleSelected}
                         ref={(el) => { if (el) el.indeterminate = hasSelection && !allVisibleSelected; }}
                         onChange={toggleAllSkus}
-                        className="shrink-0 cursor-pointer"
+                        className="h-4 w-4 shrink-0 cursor-pointer"
                       />
-                      品項 / 來源 PO
+                      品項 / 來源
                     </div>
                   </Th>
-                  <Th className="text-center">訂購</Th>
-                  <Th className="text-center">已到</Th>
-                  <Th className="text-center" title="PO 還沒結、還會繼續到的數量">在途</Th>
-                  <Th className="text-center" title="PO 結了但供應商少給的數量(永遠不會到)">短少</Th>
-                  <Th className="text-center" title="已派出的數量(含撿貨單與補貨直派)">已派</Th>
-                  <Th className="text-center">可分配</Th>
-                  <Th className="text-center">合計</Th>
-                  {allStores.map((st) => (
-                    <Th key={st.store_id} className="text-center">
-                      <div className="text-[11px] font-medium">{st.store_name}</div>
-                      <div className="font-mono text-[9px] text-zinc-400">{st.store_code}</div>
+                  <Th className="py-2 text-center" title="可分配剩餘 = 總倉已到貨 − 已派 − 本次擬分">可分配</Th>
+                  <Th className="py-2 text-center" title="本次擬分合計(含被隱藏的分店欄)">擬分</Th>
+                  {visibleStores.map((st) => (
+                    <Th key={st.store_id} className="py-2 text-center">
+                      <div className="text-xs font-semibold normal-case text-zinc-700 dark:text-zinc-200">{st.store_name}</div>
+                      <div className="font-mono text-[10px] font-normal text-zinc-400">{st.store_code}</div>
                     </Th>
                   ))}
                 </tr>
               </thead>
               <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                {skuRows.map((sk) => {
+                {filteredSkuRows.map((sk) => {
                   const allocSum = getSkuAllocTotal(sk);
                   const overAlloc = allocSum > sk.totalAvailable;
                   const remaining = sk.totalAvailable - allocSum; // 可分配剩餘
                   const isSel = selectedSkus.has(sk.sku_id);
+                  const onHand = hqOnHand?.get(sk.sku_id);
                   return (
                     <tr key={sk.sku_id} className={overAlloc ? "bg-red-50 dark:bg-red-950/30" : isSel ? "bg-blue-50/60 dark:bg-blue-950/20" : ""}>
-                      <Td className={`sticky left-0 px-3 py-2 text-xs ${isSel ? "bg-blue-50 dark:bg-blue-950/30" : "bg-white dark:bg-zinc-900"}`}>
+                      <Td className={`sticky left-0 px-3 py-2.5 text-xs ${isSel ? "bg-blue-50 dark:bg-blue-950/30" : "bg-white dark:bg-zinc-900"}`}>
                         <div className="flex items-start gap-2">
                           <input
                             type="checkbox"
                             aria-label={`選取 ${sk.sku_code ?? sk.sku_label}`}
                             checked={isSel}
                             onChange={() => toggleSku(sk.sku_id)}
-                            className="mt-0.5 shrink-0 cursor-pointer"
+                            className="mt-1 h-4 w-4 shrink-0 cursor-pointer"
                           />
                           <div className="flex min-w-0 flex-1 items-start justify-between gap-2">
                           <div className="min-w-0 flex-1">
                             <div className="font-mono text-[11px] text-zinc-500">{sk.sku_code ?? "—"}</div>
                             {/* 品項欄是固定寬(table-fixed),截斷改用兩行,單行 truncate 只剩 ~10 個字 */}
-                            <div className="line-clamp-2" title={sk.sku_label}>{sk.sku_label}</div>
+                            <div className="line-clamp-2 text-[13px] font-medium" title={sk.sku_label}>{sk.sku_label}</div>
                             <div className="mt-1 flex flex-wrap items-center gap-1 text-[10px] text-zinc-400">
                               {sk.poList.length === 1
                                 ? <span className="font-mono" title={`${sk.poList[0].po_status ?? ""} · 訂 ${sk.poList[0].qty_ordered}/已到 ${sk.poList[0].gr_qty}/在途 ${sk.poList[0].qty_in_transit}/短少 ${sk.poList[0].qty_shortage}`}>{sk.poList[0].po_no}</span>
@@ -1068,69 +1381,90 @@ export default function PickingWorkstationPage() {
                               )}
                               {renderPriceTags(sk.sku_id)}
                             </div>
+                            {/* 訂/到/途/短/派 收斂成統計列(原本各佔一欄,平板上擠掉店別欄) */}
+                            <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5 font-mono text-[10px] tabular-nums text-zinc-400">
+                              <span title="向供應商訂購的總量">訂 {sk.totalOrdered}</span>
+                              <span title="總倉已到貨" className="text-zinc-500 dark:text-zinc-300">到 {sk.totalGr}</span>
+                              {sk.totalInTransit > 0 && (
+                                <span title="PO 還沒結、還會繼續到的數量" className="text-amber-600 dark:text-amber-400">途 {sk.totalInTransit}</span>
+                              )}
+                              {sk.totalShortage > 0 && (
+                                <span title="PO 結了但供應商少給的數量(永遠不會到)" className="text-rose-600 dark:text-rose-400">短 {sk.totalShortage}</span>
+                              )}
+                              <span title="已派出的數量(含撿貨單與補貨直派)">派 {sk.totalAlreadyWave}</span>
+                              {onHand !== undefined && (
+                                <span title="總倉即時在庫(stock_balances,純參考;派貨上限仍以 已到貨−已派 計)">倉 {onHand}</span>
+                              )}
+                            </div>
                           </div>
                           <SpinButton
                             type="button"
                             onClick={() => autoDistribute(sk)}
                             disabled={sk.totalAvailable === 0}
                             title={`依可分配 ${sk.totalAvailable} 平均分到各店(cap 在各店未派需求量)`}
-                            className="shrink-0 self-center rounded border border-blue-300 bg-blue-50 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 hover:bg-blue-100 disabled:opacity-40 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
+                            className="shrink-0 self-center rounded-md border border-blue-300 bg-blue-50 px-2 py-1.5 text-[11px] font-medium text-blue-700 hover:bg-blue-100 disabled:opacity-40 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
                           >
                             ⚖ 平均
                           </SpinButton>
                           </div>
                         </div>
                       </Td>
-                      <NumCell value={sk.totalOrdered} muted />
-                      <NumCell value={sk.totalGr} bold />
-                      <NumCell value={sk.totalInTransit} accent={sk.totalInTransit > 0 ? "transit" : undefined} />
-                      <NumCell value={sk.totalShortage} accent={sk.totalShortage > 0 ? "danger" : undefined} />
-                      <NumCell value={sk.totalAlreadyWave} muted />
                       {/* 可分配 = 剩餘 (totalAvailable - allocSum) */}
                       <td className="px-2 py-2 text-center align-middle">
-                        <span
+                        <div
                           title={`可分配上限 ${sk.totalAvailable} / 已分配 ${allocSum}${overAlloc ? ` / 超出 ${allocSum - sk.totalAvailable}` : ""}`}
-                          className={`font-mono text-lg font-bold tabular-nums ${
+                          className={`font-mono text-xl font-bold tabular-nums ${
                             overAlloc
                               ? "text-red-700 dark:text-red-400"
                               : remaining === 0
                                 ? "text-zinc-300 dark:text-zinc-600"
-                                : "text-rose-700 dark:text-rose-300"
+                                : "text-emerald-700 dark:text-emerald-300"
                           }`}
                         >
                           {remaining}
-                        </span>
+                        </div>
+                        <div className="font-mono text-[10px] tabular-nums text-zinc-400">/ {sk.totalAvailable}</div>
                       </td>
                       <NumCell value={allocSum} accent={overAlloc ? "danger" : "primary"} />
-                      {allStores.map((st) => {
+                      {visibleStores.map((st) => {
                         const value = getAlloc(sk.sku_id, st.store_id);
                         const demandQty = sk.storeDemand.get(st.store_id) ?? 0;
                         const demandLeft = storeDemandLeft(sk, st.store_id);
                         const maxForCell = value + Math.max(0, sk.totalAvailable - allocSum);
                         return (
-                          <td key={st.store_id} className="px-2 py-1.5 text-center align-top">
+                          <td key={st.store_id} className="px-1.5 py-2 text-center align-top">
                             <input
                               type="number"
+                              inputMode="numeric"
                               value={value}
                               onChange={(e) => setAllocCapped(sk.sku_id, st.store_id, Number(e.target.value), sk.totalAvailable)}
+                              onFocus={(e) => e.currentTarget.select()}
                               min={0}
                               max={maxForCell}
                               step={1}
                               title={`未派需求 ${demandLeft}（原始需求 ${demandQty}）· 此格最多可填 ${maxForCell}`}
-                              className={`w-full max-w-[68px] rounded border px-1 py-0.5 text-center font-mono text-sm font-medium tabular-nums dark:bg-zinc-800 ${
+                              className={`h-10 w-full rounded-md border px-1 text-center font-mono text-base font-semibold tabular-nums dark:bg-zinc-800 ${
                                 value === 0
                                   ? "border-zinc-200 text-zinc-300 dark:border-zinc-700"
-                                  : "border-blue-300 text-blue-700 dark:border-blue-700 dark:text-blue-300"
+                                  : "border-blue-400 text-blue-700 dark:border-blue-600 dark:text-blue-300"
                               }`}
                             />
-                            {/* 需 = 尚未派的需求（demand − 已派，含補貨直派）；派完顯示 ✓，別再邀請使用者重複派 */}
-                            <div className="mt-0.5 text-[10px] text-zinc-400">
-                              {demandLeft > 0
-                                ? `需 ${demandLeft}`
-                                : demandQty > 0
-                                  ? <span className="text-emerald-600 dark:text-emerald-500">✓ 已派</span>
-                                  : "需 0"}
-                            </div>
+                            {/* 需 = 尚未派的需求（demand − 已派，含補貨直派）；點一下直接填入(受可分配量 cap)。
+                                派完顯示 ✓，別再邀請使用者重複派 */}
+                            {demandLeft > 0 ? (
+                              <button
+                                type="button"
+                                onClick={() => setAllocCapped(sk.sku_id, st.store_id, demandLeft, sk.totalAvailable)}
+                                title={`點一下填入未派需求 ${demandLeft}(原始需求 ${demandQty};超過可分配量會自動夾住)`}
+                                className="mt-1 w-full rounded bg-zinc-100 px-1 py-1 text-[11px] font-medium tabular-nums text-zinc-600 hover:bg-blue-100 hover:text-blue-700 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-blue-950 dark:hover:text-blue-300"
+                              >
+                                需 {demandLeft}
+                              </button>
+                            ) : demandQty > 0 ? (
+                              <div className="mt-1 py-1 text-[11px] text-emerald-600 dark:text-emerald-500">✓ 已派</div>
+                            ) : (
+                              <div className="mt-1 py-1 text-[11px] text-zinc-300 dark:text-zinc-600">—</div>
+                            )}
                           </td>
                         );
                       })}
@@ -1149,7 +1483,7 @@ export default function PickingWorkstationPage() {
           </div>
         ) : storeSections.length === 0 ? (
           <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
-            沒有任何分店有待撿貨。
+            {hasActiveFilter ? "目前的篩選條件下沒有分店有待撿貨 — 換個條件或清除篩選。" : "沒有任何分店有待撿貨。"}
           </div>
         ) : storeSections.map((section) => {
           let totalDemand = 0, totalWave = 0, totalShipped = 0, totalAlloc = 0;
@@ -1220,18 +1554,18 @@ export default function PickingWorkstationPage() {
       )}
 
       {/* === 補貨申請(無 PO 來源) section === */}
-      {restockDemand !== null && restockGroups.length > 0 && (
+      {restockDemand !== null && visibleRestockGroups.length > 0 && (
         <section className="mt-2 rounded-md border border-amber-200 bg-amber-50/40 dark:border-amber-900 dark:bg-amber-950/20">
           <header className="border-b border-amber-200 px-4 py-2 dark:border-amber-900">
             <h2 className="text-sm font-semibold text-amber-900 dark:text-amber-200">
               📦 補貨申請(無 PO 來源)
               <span className="ml-2 text-xs font-normal text-amber-700/80 dark:text-amber-300/70">
-                {restockGroups.length} 張申請 · 供給來自 HQ 即時庫存
+                {visibleRestockGroups.length} 張申請 · 供給來自 HQ 即時庫存
               </span>
             </h2>
           </header>
           <div className="flex flex-col gap-3 p-3">
-            {restockGroups.map((g) => {
+            {visibleRestockGroups.map((g) => {
               const allocSum = g.lines.reduce(
                 (s, ln) => s + getRestockAlloc(g.rrId, ln.sku_id),
                 0,
@@ -1309,6 +1643,7 @@ export default function PickingWorkstationPage() {
                             <td className="px-2 py-1.5 text-center">
                               <input
                                 type="number"
+                                inputMode="numeric"
                                 value={value}
                                 min={0}
                                 max={maxForLine}
@@ -1321,11 +1656,12 @@ export default function PickingWorkstationPage() {
                                     maxForLine,
                                   )
                                 }
+                                onFocus={(e) => e.currentTarget.select()}
                                 title={`最多可撿 ${maxForLine}(申請 ${ln.demand_qty}、庫存 ${ln.gr_qty}、已撿 ${ln.wave_qty})`}
-                                className={`w-full max-w-[80px] rounded border px-1 py-0.5 text-center font-mono text-sm font-medium tabular-nums dark:bg-zinc-800 ${
+                                className={`h-10 w-full max-w-[96px] rounded-md border px-1 text-center font-mono text-base font-semibold tabular-nums dark:bg-zinc-800 ${
                                   value === 0
                                     ? "border-zinc-200 text-zinc-300 dark:border-zinc-700"
-                                    : "border-amber-300 text-amber-700 dark:border-amber-700 dark:text-amber-300"
+                                    : "border-amber-400 text-amber-700 dark:border-amber-600 dark:text-amber-300"
                                 }`}
                               />
                               <div className="mt-0.5 text-[10px] text-zinc-400">


### PR DESCRIPTION
## Summary

Upgrade picking workstation from v3 (merged PO matrix) to v4 with dropdown filters and tablet-optimized layout. Users can now filter by campaign/product/time window before allocating stock, and the matrix displays only stores with demand in the filtered range.

## Key Changes

- **Campaign/SKU/time filters**: Added dropdown selectors to narrow scope before allocation. Time filter uses campaign end_at (or start_at) within N days. Filters apply to both matrix and by-store views.
- **Frontend campaign mapping**: Load `purchase_request_items` + `purchase_request_campaigns` to build po_item → campaign mapping (same logic as view's po_campaigns CTE). Failures degrade gracefully without blocking dispatch.
- **HQ on-hand reference**: Fetch `stock_balances` for central warehouse location; display as reference info (dispatch limits still use GR − already_waved).
- **Tablet layout optimization**:
  - Collapse 5 numeric columns (ordered/arrived/in-transit/shortage/shipped) into single stats row under SKU name
  - Reduce store columns from 80px to 96px for larger touch inputs
  - Hide stores with no demand by default; toggle "show all" button if hidden
  - Increase input field sizes (h-10, text-base font)
- **One-click demand fill**: "需 N" button in each store cell now fills that demand amount (capped by available stock) instead of just displaying it.
- **Fix by-store view loading**: Use `useRef` for in-flight flag instead of state to prevent cleanup from discarding fetched data and leaving loading state stuck.
- **Restock filtering**: Hide restock groups when specific campaign selected (they have no campaign); filter by SKU if selected.
- **Selection & submission**: "Select all" / "Submit" now operate on filtered rows only; unfiltered rows still count toward allocation caps.

## Implementation Details

- Campaign data loaded in separate effect after demand; failures set empty maps (filters degrade to "all").
- `rowPassesFilters()` helper checks campaign/SKU/time for both matrix and by-store rows.
- `visibleStores` computed from filtered SKU rows + current allocations; falls back to all stores if filtering hides everything.
- Time cutoff calculated once per filter change; `campaignInTime()` checks each campaign's end_at/start_at.
- Batch queries (200 items per request) for purchase_request_items, purchase_request_campaigns, group_buy_campaigns, stock_balances.
- Checkbox styling updated to explicit h-4 w-4 for better touch targets.

https://claude.ai/code/session_01Jn6T4VGUsarmqHp2HWVsZq