### PR TITLE
fix(pickup): 取貨閘門加數量守衛 + App 訂單依「行」分頁 — 短收沒進店的貨不再放行

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -88,6 +88,10 @@ function PickupPageContent() {
   // item.id → 該品項是否已到貨可取（v_order_item_pickup_ready）。
   // 部分到貨的 shipping 單靠這個讓「已到的品項」可先取。
   const [itemReady, setItemReady] = useState<Map<number, boolean>>(new Map());
+  // item.id → 「這組到過貨，但量不夠分到這一行」（v_order_item_pickup_ready.qty_short）。
+  // 短收時（總倉派 2、分店只收 1）多出來的那幾行就是這種。要跟「少發配貨沒配到」
+  // 分開講：這種等下一批貨到就會自己放行，不需要人工配貨。
+  const [itemQtyShort, setItemQtyShort] = useState<Map<number, boolean>>(new Map());
   // item.id → 未取退貨量（return_to_hq transfer 依 SKU 聚合後分攤到各品項行，
   // 與 PickupDialog 同構）。退回總倉的量店裡沒有、不可再取。
   const [returnedByItem, setReturnedByItem] = useState<Map<number, number>>(new Map());
@@ -162,13 +166,20 @@ function PickupPageContent() {
   function isPickable(order: OpenOrder): boolean {
     return pickableItems(order).length > 0;
   }
+  // 該品項是否為「這組到過貨但量不夠分到這一行」（短收 / 這批只到一部分）。
+  // 等下一批貨收進來就會自己放行，不需要人工配貨 —— 所以不可以標成「待補貨」。
+  function isQtyShort(it: OpenOrder["items"][number]): boolean {
+    return itemQtyShort.get(it.id) === true;
+  }
   // 該品項是否為「少發沒配到」→ 取貨頁要明講待補貨，不要只是消失。
   // 只認 ready / partially_completed：這兩種單的貨已經到店，閘門 false 就是被少發配貨
   // 標成待補貨。pending / confirmed / shipping 的 false 絕大多數只是「還沒到貨」，
   // 標成待補貨會讓店員誤以為配貨少給、跑去追不存在的補貨。
+  // 量不夠（isQtyShort）也要排除：那是「還沒到貨」，去追少發配貨一樣是白跑。
   function isBackordered(order: OpenOrder, it: OpenOrder["items"][number]): boolean {
     return (order.status === "ready" || order.status === "partially_completed")
-      && itemReady.get(it.id) === false;
+      && itemReady.get(it.id) === false
+      && !isQtyShort(it);
   }
 
   const [pickup, setPickup] = useState<{ orderId: number; orderNo: string } | null>(null);
@@ -280,16 +291,19 @@ function PickupPageContent() {
 
       // 品項到貨狀態（部分到貨的 shipping 單要逐品項判斷哪些可先取）
       const readyMap = new Map<number, boolean>();
+      const shortMap = new Map<number, boolean>();
       if (orderIds.length > 0) {
         const { data: irs } = await sb
           .from("v_order_item_pickup_ready")
-          .select("item_id, pickup_ready")
+          .select("item_id, pickup_ready, qty_short")
           .in("order_id", orderIds);
-        for (const r of (irs ?? []) as { item_id: number; pickup_ready: boolean }[]) {
+        for (const r of (irs ?? []) as { item_id: number; pickup_ready: boolean; qty_short: boolean }[]) {
           readyMap.set(r.item_id, !!r.pickup_ready);
+          shortMap.set(r.item_id, !!r.qty_short);
         }
       }
       setItemReady(readyMap);
+      setItemQtyShort(shortMap);
 
       // 未取退貨量（return_to_hq transfer）— 退掉的貨店裡沒有、不可再取。
       // 依 SKU 聚合後分攤到各 active 品項行（行序 by id，與 PickupDialog 同構）。
@@ -935,6 +949,11 @@ function PickupPageContent() {
                         const canPickup = pickableCount > 0;
                         // 部分到貨：有品項可取、但還有（未被退光的）active 品項未到
                         const partialArrival = canPickup && pickableCount < activeRemaining.length;
+                        // 「這組到過貨但量不夠分」的件數 —— 短收造成的未到貨，
+                        // 訊息要跟「分店根本還沒收貨」分開講。
+                        const shortQty = activeRemaining
+                          .filter((it) => !pickableIds.has(it.id) && isQtyShort(it))
+                          .reduce((s, it) => s + remainingQty(it), 0);
                         // 金額扣掉已退量（未取退貨不收錢，與應收 payable 扣減一致）
                         const subAmt = active.reduce((s, it) => s + remainingQty(it) * Number(it.unit_price), 0);
                         const discAmt = Number(o.discount_amount ?? 0);
@@ -977,8 +996,15 @@ function PickupPageContent() {
                                         ⏳ 待補貨
                                       </span>
                                     ) : (
-                                      partialArrival && remainingQty(it) > 0 && !pickableIds.has(it.id) && (
-                                        <span className="rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">⏳ 未到貨</span>
+                                      // 量不夠分到這一行（短收）時一定要標，不能只在「部分到貨」的單上標 ——
+                                      // 整張單只剩這一行沒到時 partialArrival 是 false，不特別處理就完全沒有提示。
+                                      (partialArrival || isQtyShort(it)) && remainingQty(it) > 0 && !pickableIds.has(it.id) && (
+                                        <span
+                                          className="rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                                          title={isQtyShort(it) ? "這批到貨量不夠，這筆還沒到；下一批收進來就會自動放行" : undefined}
+                                        >
+                                          ⏳ 未到貨
+                                        </span>
                                       )
                                     )}
                                   </li>
@@ -1013,6 +1039,15 @@ function PickupPageContent() {
                                   <span className="ml-2">{partialArrival ? `${pickableCount}/${activeRemaining.length} 項可取` : `${pickableCount} 項可取`}</span>
                                 ) : fullyReturned ? (
                                   <span className="ml-2 font-semibold text-orange-700 dark:text-orange-400">↩ 已全數退回總倉，無可取貨項目</span>
+                                ) : shortQty > 0 ? (
+                                  // 「分店尚未收貨」在這裡是錯的 —— 分店收過了，只是這批少收。
+                                  // 講清楚才不會讓店員以為系統壞了、跑去改走轉單（那會開新單變重複單）。
+                                  <span
+                                    className="ml-2 text-amber-600 dark:text-amber-400"
+                                    title="總倉派的量分店沒有全收到（收貨時已標短少）。等下一批補進來就會自動放行；要現在就發，請開庫存減抵單。"
+                                  >
+                                    ⏳ 尚有 {shortQty} 件未到貨，無法取貨
+                                  </span>
                                 ) : (
                                   <span className="ml-2 text-amber-600 dark:text-amber-400">⏳ 分店尚未收貨，無法取貨</span>
                                 )}

--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -7,7 +7,13 @@ import { callLiffApi } from "@/lib/supabase";
 import PageShell from "@/components/PageShell";
 import { LoadingScreen } from "@/components/Spinner";
 import SubTabs from "@/components/SubTabs";
-import OrderCard, { orderPhase, type OrderRow } from "@/components/OrderCard";
+import OrderCard, {
+  orderPhase,
+  splitOrderByPhase,
+  unpickedSubtotal,
+  type OrderPhase,
+  type OrderRow,
+} from "@/components/OrderCard";
 
 // 蝦皮式分頁。我們取貨時付現金，所以沒有「待付款」；「待收貨」＝到店「待取貨」。
 // 分桶跟卡片右上角的狀態字共用 orderPhase()，兩邊永遠一致。
@@ -104,12 +110,30 @@ export default function OrdersPage() {
     })();
   }, [router]);
 
+  // 依**品項行**分桶，不是整張單（2026-08-14）。短收之後一張單常常是
+  // 「一件已領走、一件根本還沒到」—— 整張塞「待取貨」等於叫客人來拿沒到的貨。
+  // 所以一張單會拆成數個分身，各自進自己的分頁（例：已取的行 → 已完成、
+  // 沒到貨的行 → 待到貨）。「全部」維持整張單不拆。
   const buckets = useMemo(() => {
     const b: Record<Tab, OrderRow[]> = { all: orders, waiting: [], pickup: [], done: [], void: [] };
     for (const o of orders) {
-      const { phase } = orderPhase(o);
-      // orders 進來前已濾掉 HIDDEN_PHASES（已轉讓），剩下的都有自己的分頁
-      if (phase !== "transferred") b[phase].push(o);
+      const parts = splitOrderByPhase(o);
+      // 應付金額要**分攤**到各分身，不能每個分身都掛整張單的 outstanding ——
+      // 一張單同時出現在「待到貨」和「待取貨」時會被算兩次
+      //（CLAUDE.md：未結金額重複計算是踩過的雷）。
+      // 依「該分身未取貨值 / 整張單未取貨值」等比分攤，兩頁相加仍等於原本的 outstanding。
+      const wholeUnpicked = unpickedSubtotal(o.items);
+      const outstanding = Number(o.outstanding_amount ?? o.payable_amount ?? 0);
+      for (const [phase, part] of parts) {
+        if (phase === "transferred") continue; // 已轉讓不出現在任何分頁
+        b[phase as Exclude<Tab, "all">].push({
+          ...part,
+          outstanding_amount:
+            wholeUnpicked > 0
+              ? (outstanding * unpickedSubtotal(part.items)) / wholeUnpicked
+              : 0,
+        });
+      }
     }
     return b;
   }, [orders]);
@@ -207,7 +231,8 @@ export default function OrdersPage() {
             className="animate-in"
             style={{ animationDelay: `${Math.min(i % PAGE_SIZE, 8) * 50}ms` }}
           >
-            <OrderCard order={o} />
+            {/* 分身卡的右上角狀態字要講「這一頁」的語意；「全部」不拆頁，維持整張單的狀態 */}
+            <OrderCard order={o} viewPhase={tab === "all" ? undefined : (tab as OrderPhase)} />
           </div>
         ))}
 

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -15,6 +15,15 @@ export type OrderItem = {
   stockout?: boolean;
   notes: string | null;
   image_url: string | null;
+  /**
+   * 這一行到店了沒（v_customer_order_summary.items[].arrived @20260814070000）。
+   * 只有 active 行（pending/reserved/ready）有值，其餘是 null —— 那些行的分桶
+   * 看 status 就決定了，不必付閘門的計算成本。
+   *
+   * ⚠️ 不可以用單頭的 arrived 代替：那一欄有快路徑，單頭一到 ready /
+   * partially_completed 就無條件 true（短收時會謊報到貨）。
+   */
+  arrived?: boolean | null;
 };
 
 export type OrderRow = {
@@ -64,6 +73,15 @@ export type OrderRow = {
  */
 export type OrderPhase = "waiting" | "pickup" | "done" | "void" | "transferred";
 
+/** 分身卡右上角的狀態字（依「行」拆頁後，整張單的狀態字會對不上該頁的內容） */
+const PHASE_LABEL: Record<OrderPhase, { label: string; className: string }> = {
+  waiting: { label: "待到貨", className: "text-[#b06c00]" },
+  pickup: { label: "待取貨", className: "text-[#b06c00]" },
+  done: { label: "已完成", className: "text-[var(--brand-strong)]" },
+  void: { label: "訂單不成立", className: "text-[#c4271d]" },
+  transferred: { label: "已轉讓", className: "text-[var(--ios-gray)]" },
+};
+
 export function orderPhase(o: Pick<OrderRow, "status" | "arrived">): {
   phase: OrderPhase;
   label: string;
@@ -91,6 +109,57 @@ export function orderPhase(o: Pick<OrderRow, "status" | "arrived">): {
   return { phase: "waiting", label: "待到貨", className: "text-[#b06c00]" };
 }
 
+/**
+ * 單一品項行屬於哪個分頁。
+ *
+ * 分頁要依**行**分，不能整張單塞同一個分頁：一張單短收之後常常是
+ * 「一件已經領走、一件根本還沒到」（GRP-20260805-006-0026 忠順），
+ * 整張歸在「待取貨」等於告訴客人剩下那件在店裡等他 —— 跑一趟撲空。
+ *
+ * 單頭層級的終局狀態（取消 / 逾期 / 轉讓）優先，其餘看行自己的狀態：
+ *   已取走            → 已完成
+ *   斷貨 / 取消 / 逾期 → 不成立
+ *   還沒取 + 到貨了    → 待取貨
+ *   還沒取 + 沒到貨    → 待到貨
+ */
+export function itemPhase(order: Pick<OrderRow, "status">, item: OrderItem): OrderPhase {
+  switch (order.status) {
+    case "cancelled":
+    case "expired":
+      return "void";
+    case "transferred_out":
+      return "transferred";
+  }
+  if (item.status === "picked_up") return "done";
+  if (["cancelled", "expired"].includes(item.status)) return "void";
+  // arrived 只有 active 行有值；缺值（舊 payload / 尚未部署 view）一律當「沒到」，
+  // 寧可少報到貨也不要叫客人白跑一趟。
+  return item.arrived === true ? "pickup" : "waiting";
+}
+
+/**
+ * 把一張單依品項分頁拆成數個「分身」，每個分身只帶屬於該分頁的品項行。
+ * 回傳的 key 就是該分身要進的分頁。一張單可能同時出現在兩個分頁
+ * （例：一件已領走 → 已完成、一件還沒到 → 待到貨），這是刻意的。
+ */
+export function splitOrderByPhase(order: OrderRow): Map<OrderPhase, OrderRow> {
+  const out = new Map<OrderPhase, OrderRow>();
+  for (const it of order.items) {
+    const ph = itemPhase(order, it);
+    const cur = out.get(ph);
+    if (cur) cur.items.push(it);
+    else out.set(ph, { ...order, items: [it] });
+  }
+  return out;
+}
+
+/** 這一組品項行還沒領走的貨值（用來把單頭的應付金額分攤到各分頁，避免重複計算） */
+export function unpickedSubtotal(items: OrderItem[]): number {
+  return items
+    .filter((i) => !["cancelled", "expired", "picked_up"].includes(i.status))
+    .reduce((s, i) => s + Number(i.subtotal ?? 0), 0);
+}
+
 function fmtAmount(n: number | string | null | undefined): string {
   return Number(n ?? 0).toLocaleString();
 }
@@ -108,7 +177,17 @@ function fmtDate(iso: string | null | undefined): string {
 // 品項的「還沒取」集合 = rpc_record_pickup 的 v_active_remaining 同一套
 const ACTIVE_ITEM_STATUSES = ["pending", "reserved", "ready"];
 
-export default function OrderCard({ order }: { order: OrderRow }) {
+export default function OrderCard({
+  order,
+  /**
+   * 這張卡是「某個分頁的分身」時傳入該分頁 —— 右上角狀態字改用分頁的語意，
+   * 而不是整張單的。不傳（「全部」分頁）就照舊顯示整張單的狀態。
+   */
+  viewPhase,
+}: {
+  order: OrderRow;
+  viewPhase?: OrderPhase;
+}) {
   // 斷貨 / 已取消的品項照樣列出來（畫成刪除線 + 「斷貨」標），但不算件數 —
   // items_total / payable_amount 從 20260808000010 起就不含這些行了，
   // 件數要跟著排除，否則「商品（5 件）$218」對不起來。
@@ -116,30 +195,47 @@ export default function OrderCard({ order }: { order: OrderRow }) {
     (s, i) => (["cancelled", "expired"].includes(i.status) ? s : s + Number(i.qty ?? 0)),
     0,
   );
+  // 分身卡（依分頁拆出來的）用得到：這張卡實際列出來的品項貨值
+  const visibleItemsTotal = order.items.reduce(
+    (s, i) => (["cancelled", "expired"].includes(i.status) ? s : s + Number(i.subtotal ?? 0)),
+    0,
+  );
   // 部分取貨的單，客人看不出哪行取了、哪行沒取（2026-08-13 中和店客訴）——
   // 取過的行和還沒取的行混在同一張卡時，逐行標「已取 / 未取」。
   // 全取完（已完成）或全沒取的單不標，右上角狀態字已經講完了，行內再標是噪音。
   // 部分數量取貨會拆行（20260630000010），所以每一行必屬其中一邊，不用管數量。
-  const showPickChips =
-    order.items.some((i) => i.status === "picked_up") &&
-    order.items.some((i) => ACTIVE_ITEM_STATUSES.includes(i.status));
-  const pickChip = (status: string) =>
-    !showPickChips ? null : status === "picked_up" ? (
-      <StatusChip tone="ok" label="已取" />
-    ) : ACTIVE_ITEM_STATUSES.includes(status) ? (
-      <StatusChip tone="warn" label="未取" />
-    ) : null;
+  // 2026-08-14：改看「行的分頁」而不是只看已取/未取 —— 短收時同一張單會有
+  // 「已領走」和「根本還沒到」兩種行，只標「未取」等於叫客人來拿沒到的貨。
+  // 行的分頁超過一種才標；單一種時右上角狀態字已經講完了，行內再標是噪音。
+  const phasesInCard = new Set(order.items.map((i) => itemPhase(order, i)));
+  const showPickChips = phasesInCard.size > 1;
+  const pickChip = (it: OrderItem) => {
+    if (!showPickChips) return null;
+    if (it.status === "picked_up") return <StatusChip tone="ok" label="已取" />;
+    if (!ACTIVE_ITEM_STATUSES.includes(it.status)) return null;
+    // 沒到貨的行講「未到貨」，不要講「未取」—— 後者會被讀成「貨在店裡等你」
+    return it.arrived === true
+      ? <StatusChip tone="warn" label="未取" />
+      : <StatusChip tone="warn" label="未到貨" />;
+  };
   // 內部 sentinel 團（店內現貨轉手單）印品項名，其餘印開團名稱 —— 見 lib/orderTitle
   const title = orderCardTitle(order);
-  const phase = orderPhase(order);
+  // 分身卡（依分頁拆出來的）右上角要講該分頁的語意，不是整張單的
+  const phase = viewPhase
+    ? { ...orderPhase(order), ...PHASE_LABEL[viewPhase] }
+    : orderPhase(order);
   // 已經領走一部分（取貨當場收現金）→ 這張單真正還要付的是 outstanding_amount。
   // 只在「領了一部分、還剩一部分」時才多畫一行：全部領完 / 取消的單 outstanding=0，
   // 那些維持原本單一「應付金額」的樣子。沒有這欄的舊 payload 也走原本的樣子。
+  // 分身卡的「應付金額」要用這張卡實際列出的品項貨值 —— 掛整張單的 payable_amount
+  // 會讓「已完成」那張分身卡寫著 $278（含還沒到貨那件的錢）。
+  // 折扣 / 運費沒有按行分攤，分身卡的這個數字是近似值（無折扣的單完全相等）。
+  const cardPayable = viewPhase ? visibleItemsTotal : Number(order.payable_amount ?? 0);
   const outstanding = Number(order.outstanding_amount ?? NaN);
   const partlyPaid =
     Number.isFinite(outstanding) &&
     outstanding > 0 &&
-    outstanding < Number(order.payable_amount ?? 0);
+    outstanding < cardPayable;
 
   return (
     <article className="card overflow-hidden">
@@ -194,15 +290,15 @@ export default function OrderCard({ order }: { order: OrderRow }) {
                       <StatusChip tone="danger" label="斷貨" />
                     </span>
                   )}
-                  {pickChip(it.status) && (
-                    <span className="ml-1.5 inline-block">{pickChip(it.status)}</span>
+                  {pickChip(it) && (
+                    <span className="ml-1.5 inline-block">{pickChip(it)}</span>
                   )}
                 </div>
               )}
-              {!it.variant_name && (it.stockout || pickChip(it.status)) && (
+              {!it.variant_name && (it.stockout || pickChip(it)) && (
                 <div className="flex items-center gap-1.5">
                   {it.stockout && <StatusChip tone="danger" label="斷貨" />}
-                  {pickChip(it.status)}
+                  {pickChip(it)}
                 </div>
               )}
               <div className="text-[14px] text-[var(--secondary-label)]">
@@ -222,7 +318,9 @@ export default function OrderCard({ order }: { order: OrderRow }) {
       <div className="space-y-1 border-t border-[var(--separator)] px-4 py-3 text-[14px]">
         <div className="flex justify-between text-[var(--secondary-label)]">
           <span>商品（{totalQty} 件）</span>
-          <span className="tabular-nums">{fmtAmount(order.items_total)}</span>
+          {/* 分身卡只列該分頁的品項行，金額要跟著只算這些行 ——
+              否則會出現「商品（1 件）278」這種件數與金額對不起來的畫面。 */}
+          <span className="tabular-nums">{fmtAmount(viewPhase ? visibleItemsTotal : order.items_total)}</span>
         </div>
         {Number(order.shipping_fee) > 0 && (
           <div className="flex justify-between text-[var(--secondary-label)]">
@@ -247,7 +345,7 @@ export default function OrderCard({ order }: { order: OrderRow }) {
                 : "text-[24px] font-semibold tabular-nums text-[var(--brand-strong)]"
             }
           >
-            ${fmtAmount(order.payable_amount)}
+            ${fmtAmount(cardPayable)}
           </span>
         </div>
         {/* 部分取貨：取走的那幾項當場付現了，卡片只留「應付金額」會跟列表上方的

--- a/supabase/migrations/20260814060000_pickup_gate_qty_aware.sql
+++ b/supabase/migrations/20260814060000_pickup_gate_qty_aware.sql
@@ -1,0 +1,407 @@
+-- ============================================================
+-- 2026-08-14 (6)：取貨閘門加數量守衛 —— 短收的那一件不可以還掛在取貨頁上
+--
+-- 災情（忠順店回報，GRP-20260805-006「夜玫瑰」紅肉李 #32 / sku 4141）：
+--   總倉派 2 件（WAVE-1278-S51 qty_shipped = 2），忠順只實收 1 件
+--   （ti.qty_received = 1，收貨頁確實標了短少）。客人 JoJo瑛550827 這張單
+--   剛好有兩行同 SKU（8/12 一行、8/14 追加一行），8/14 17:58 取走一件之後：
+--     * 訂單 → partially_completed
+--     * 剩下那一行 is_order_item_pickup_ready 仍回 true
+--     * /pickup 顯示「1 項可取」、✅ 取貨 鈕亮著
+--   但那一件貨**根本沒進店**（stock_balances.on_hand = 0）。店員照著畫面按下去
+--   就是庫存扣成 -1、客人白跑一趟。
+--
+-- 根因：閘門是 qty-blind 的。Path B 的條件是「該 (campaign,store,sku) 對齊波次
+--   且 ti.qty_received > 0」—— 只問「有沒有收到」，不問「收了幾件、夠不夠分」。
+--   同理 Path C 只問「本店該 SKU 有沒有開團後的實收」。所以一組貨只要**到過一件**，
+--   該組**所有**未取品項都會被放行。
+--
+--   這個 qty-blind 語意本來是刻意的（20260814020000 註解裡列為已知殘餘），
+--   當時的想法是「數量守衛由 _advance_arrived_confirmed_orders 負責」。
+--   但那支只管 confirmed → ready 的推進；**取貨頁對 ready /
+--   partially_completed 的單是直接吃閘門的**（pickableItems()），
+--   於是數量守衛在真正會出貨的那條路上從來沒有生效過。
+--
+--   短收的資訊全程都在（transfer_items.qty_variance = -1、收貨頁標了短少），
+--   只是沒有任何東西把它接到訂單品項上 —— 少發配貨（rpc_allocate_shortage）
+--   是唯一的接法，而它要店員手動點。沒點就等於沒守衛。
+--
+-- 影響範圍（修之前線上實測，閘門現在回 true、加了守衛會變 false 的品項）：
+--   84 個品項 / 143 件 / 82 張單。都是該 (團,店,SKU) 「實收 − 已取」已經
+--   蓋不住剩餘未取量的組，例：
+--     * GB20260518-C000154-0071：實收 10、已取 21、on_hand -11
+--     * GRP-20260609-004-0018：實收 2、已取 10、on_hand -8
+--   換句話說這 84 件現在按下去一律是負庫存 + 客人撲空。
+--
+-- 修法：閘門在既有 Path A~D' **全部逐字保留**之後，追加一道數量守衛：
+--
+--     可配量 = 該 (團,店,SKU) 開團後的 hq_to_store 實收 − 該組已取走量
+--     這一行排在同組第幾位（依 created_at, order_no, item_id 累加）
+--     累計量 ≤ 可配量 → 放行；超過 → 這一行還沒輪到，回 false
+--
+--   排序規則跟既有的「依訂單時間自動配」完全同一套
+--   （20260805000070 / ShortageAllocateModal / _advance_arrived_confirmed_orders），
+--   所以自動配、少發配貨、取貨閘門三邊看到的順序一致。
+--
+-- 刻意的設計取捨：
+--
+--   1. **只在 Path B / C 生效**。Path A（這張單自己的 transfer 被收貨）、
+--      Path D（庫存減抵單）、Path D'（offset 抵減單）都是「這一組明確被宣告覆蓋」
+--      的路徑，量的問題在那些單據上自己管，守衛跳過不動。
+--      → 也就是說 HQ 想放行一組帳面不足的貨，開一張**庫存減抵單**就是既有的正解，
+--        不必回頭改閘門。
+--
+--   2. **供給側刻意算寬（只認開團後、但不限對齊波次）**：算的是「該店該 SKU
+--      在開團之後的所有 hq_to_store 實收」，不是只算對齊波次的量。補貨路線
+--      （campaign_id IS NULL 的波次）送到店的貨也算數 —— 這一票在 Path C 本來就
+--      放行，供給側漏算會讓走補貨路線的團整批被誤擋。寧可寬一點：
+--      **false negative（貨在店裡卻不給發）比 false positive 難收拾** ——
+--      店員發不出貨只能改走轉單，那會開一張新單、原單永遠留在原狀態，
+--      就是 CLAUDE.md 記過的重複單災情。
+--
+--   3. **需求側刻意算窄**：排除 store_internal 會員的單（RR- /【內部】xx 店是
+--      現貨池容器，不是對客人的承諾，比照 _advance_arrived_confirmed_orders）、
+--      排除 offset 抵減單（負數行）、排除已經有自己 transfer 收貨的單（Path A
+--      的貨走 store_to_store，不吃 hq_to_store 這份預算）、排除掛著 backorder_at
+--      的行（它們已經被少發配貨擋掉了，再算進來會自己擋自己 ——
+--      這是 20260811000050 踩過的坑）。
+--
+--   4. **不寫任何欄位、不標 backorder_at**。守衛是純推導的：下一批貨收進來
+--      supplied 變大，這一行自己就會重新放行，不需要人工解除。
+--      （CLAUDE.md：「不要順手改成寫 backorder_at」。）
+--
+-- 基底版本（append-only，逐字保留所有 prior fix）：
+--   is_order_item_pickup_ready = 20260814020000_pickup_gate_path_c_receipts_after_campaign.sql
+--   （＝線上現行版；Path C 的「開團後實收」時間下限為該版加入）
+--   v_order_item_pickup_ready  = 20260704000000_item_level_pickup_gate.sql
+--
+-- Rollback：
+--   重跑 20260814020000 內的 CREATE OR REPLACE FUNCTION 即回舊閘門；
+--   CREATE OR REPLACE VIEW public.v_order_item_pickup_ready AS
+--     SELECT coi.id AS item_id, coi.order_id, coi.tenant_id,
+--            public.is_order_item_pickup_ready(coi.id) AS pickup_ready
+--       FROM customer_order_items coi;
+--   DROP FUNCTION IF EXISTS public._pickup_group_available(UUID,BIGINT,BIGINT,BIGINT);
+--   DROP FUNCTION IF EXISTS public._pickup_group_supplied(UUID,BIGINT,BIGINT,BIGINT);
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1a. _pickup_group_supplied — 該 (團,店,SKU) 開團後總共實收幾件
+--
+--     供給側不限對齊波次（補貨路線送到店的也算），時間下限沿用
+--     20260814020000 的判準：開團前的實收一定是上一團 / 別團的貨。
+--
+--     單獨拆一支是為了讓 view 分得出「到過貨但不夠分」與「根本沒到過」——
+--     available 已經扣掉已取量，短收又剛好取光時會是 0，兩種情形分不出來。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._pickup_group_supplied(
+  p_tenant      UUID,
+  p_campaign_id BIGINT,
+  p_store_id    BIGINT,
+  p_sku_id      BIGINT
+) RETURNS NUMERIC
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE((
+    SELECT SUM(ti.qty_received)
+      FROM stores st
+      JOIN transfers t ON t.transfer_type = 'hq_to_store'
+                      AND t.dest_location = st.location_id
+                      AND t.tenant_id     = p_tenant
+                      AND t.status IN ('received','closed')
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+                            AND ti.sku_id      = p_sku_id
+                            AND ti.qty_received > 0
+     WHERE st.id = p_store_id
+       AND t.received_at >= (
+             SELECT gc.created_at FROM group_buy_campaigns gc WHERE gc.id = p_campaign_id
+           )
+  ), 0);
+$$;
+
+COMMENT ON FUNCTION public._pickup_group_supplied(UUID,BIGINT,BIGINT,BIGINT) IS
+  '該 (團,店,SKU) 開團後該店該 SKU 的 hq_to_store 實收合計。'
+  '刻意不限對齊波次（補貨路線送到店的也算，比照取貨閘門 Path C）。';
+
+-- ----------------------------------------------------------------
+-- 1b. _pickup_group_available — 該 (團,店,SKU) 現在還能配出去幾件
+--
+--     = 開團後實收 − 該組已經被取走的量
+--     「已取走」排除 offset 單（負數行會把可配量灌大）。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._pickup_group_available(
+  p_tenant      UUID,
+  p_campaign_id BIGINT,
+  p_store_id    BIGINT,
+  p_sku_id      BIGINT
+) RETURNS NUMERIC
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT public._pickup_group_supplied(p_tenant, p_campaign_id, p_store_id, p_sku_id)
+    - COALESCE((
+      SELECT SUM(coi.qty)
+        FROM customer_orders co
+        JOIN customer_order_items coi ON coi.order_id = co.id
+       WHERE co.tenant_id       = p_tenant
+         AND co.campaign_id     = p_campaign_id
+         AND co.pickup_store_id = p_store_id
+         AND coi.sku_id         = p_sku_id
+         AND coi.status         = 'picked_up'
+         AND COALESCE(co.order_kind, 'normal') <> 'offset'
+    ), 0);
+$$;
+
+COMMENT ON FUNCTION public._pickup_group_available(UUID,BIGINT,BIGINT,BIGINT) IS
+  '該 (團,店,SKU) 還能配出去的量 = 開團後實收 − 該組已取走量。'
+  '取貨閘門 is_order_item_pickup_ready 的數量守衛用。';
+
+-- ----------------------------------------------------------------
+-- 2. is_order_item_pickup_ready — Path A~D' 逐字保留，末端追加數量守衛
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_order_item_pickup_ready(p_item_id bigint)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT EXISTS (
+    SELECT 1
+      FROM customer_order_items coi
+      JOIN customer_orders co ON co.id = coi.order_id
+     WHERE coi.id = p_item_id
+       AND co.status NOT IN ('completed','expired','cancelled','transferred_out')
+       -- 只有未取的 active item 才有「可取貨」可言
+       AND coi.status IN ('pending','reserved','ready')
+       -- 少發配貨：沒配到的品項標成待補貨，在補到之前不可取
+       --（rpc_allocate_shortage 寫入 / 清除；沒有缺貨的單這欄永遠是 NULL，行為不變）
+       AND coi.backorder_at IS NULL
+       AND CASE
+         -- aid_transfer + 跨店：只認自己的 transfer 被收貨 (Path A)
+         WHEN EXISTS (
+                SELECT 1 FROM customer_order_items x
+                 WHERE x.order_id = co.id AND x.source = 'aid_transfer'
+              )
+              AND co.transferred_from_order_id IS NOT NULL
+              AND (
+                SELECT src.pickup_store_id FROM customer_orders src
+                 WHERE src.id = co.transferred_from_order_id
+              ) IS DISTINCT FROM co.pickup_store_id
+         THEN EXISTS (
+           SELECT 1 FROM transfers t
+            WHERE t.customer_order_id = co.id
+              AND t.tenant_id = co.tenant_id
+              AND t.status IN ('received','closed')
+         )
+         ELSE (
+           -- Path A：aid 單 transfer FK 收貨
+           EXISTS (
+             SELECT 1 FROM transfers t
+              WHERE t.customer_order_id = co.id
+                AND t.tenant_id = co.tenant_id
+                AND t.status IN ('received','closed')
+           )
+           OR
+           -- Path B：campaign 對齊且該波次該 SKU 實收 qty>0
+           EXISTS (
+             SELECT 1
+               FROM picking_wave_items pwi
+               JOIN transfers t ON t.id = pwi.generated_transfer_id
+               JOIN transfer_items ti ON ti.transfer_id = t.id
+                                     AND ti.sku_id = coi.sku_id
+              WHERE pwi.tenant_id   = co.tenant_id
+                AND pwi.campaign_id = co.campaign_id
+                AND pwi.store_id    = co.pickup_store_id
+                AND pwi.sku_id      = coi.sku_id
+                AND t.status IN ('received','closed')
+                AND ti.qty_received > 0
+           )
+           OR
+           -- Path C：該 (campaign,store,sku) 完全無對齊波次（彙整 PR）才退用 store+sku 實收。
+           -- 2026-08-14：實收加時間下限 —— 只認「開團之後」收的貨。開團前的實收一定是
+           -- 上一團 / 補貨的貨，拿來開門會讓完全沒採購的新團在取貨頁放行（GRP-20260807-001 災情）。
+           (
+             NOT EXISTS (
+               SELECT 1 FROM picking_wave_items pwi
+                WHERE pwi.tenant_id   = co.tenant_id
+                  AND pwi.campaign_id = co.campaign_id
+                  AND pwi.store_id    = co.pickup_store_id
+                  AND pwi.sku_id      = coi.sku_id
+             )
+             AND EXISTS (
+               SELECT 1
+                 FROM stores st
+                 JOIN transfers t ON t.transfer_type = 'hq_to_store'
+                                 AND t.dest_location = st.location_id
+                                 AND t.tenant_id     = co.tenant_id
+                                 AND t.status IN ('received','closed')
+                 JOIN transfer_items ti ON ti.transfer_id = t.id
+                                       AND ti.sku_id = coi.sku_id
+                                       AND ti.qty_received > 0
+                WHERE st.id = co.pickup_store_id
+                  AND (
+                    co.campaign_id IS NULL   -- 無團的單沒有「開團時間」可比，維持舊行為
+                    OR t.received_at >= (
+                         SELECT gc.created_at FROM group_buy_campaigns gc
+                          WHERE gc.id = co.campaign_id
+                       )
+                  )
+             )
+           )
+           OR
+           -- Path D：庫存減抵單 — 店家用店內現貨吸收這組缺口
+           EXISTS (
+             SELECT 1 FROM inventory_deduction_notes n
+              WHERE n.tenant_id   = co.tenant_id
+                AND n.campaign_id = co.campaign_id
+                AND n.store_id    = co.pickup_store_id
+                AND n.sku_id      = coi.sku_id
+                AND n.cancelled_at IS NULL
+           )
+           OR
+           -- Path D'：抵減單（order_kind='offset' 負數訂單）— 開團時就宣告
+           -- 這組有店內現貨吸收，等同貨到（哪些行可取仍由 backorder_at 控管）
+           EXISTS (
+             SELECT 1
+               FROM customer_orders oo
+               JOIN customer_order_items oi
+                 ON oi.order_id = oo.id
+                AND oi.sku_id   = coi.sku_id
+                AND oi.qty < 0
+                AND oi.status NOT IN ('cancelled','expired')
+              WHERE oo.tenant_id       = co.tenant_id
+                AND oo.campaign_id     = co.campaign_id
+                AND oo.pickup_store_id = co.pickup_store_id
+                AND oo.order_kind      = 'offset'
+                AND oo.status NOT IN ('cancelled','expired','transferred_out')
+           )
+         )
+       END
+       -- ------------------------------------------------------------------
+       -- 2026-08-14：數量守衛（新增）。上面的 Path B / C 是 qty-blind 的
+       -- ——「該組到過貨」就整組放行 —— 短收時會讓沒進店的那幾件也亮著可取。
+       -- 這裡再問一次「這一行輪得到嗎」：同組依 (下單時間, 單號, 行 id) 累加，
+       -- 累計量超過可配量的行回 false。
+       --
+       -- 只作用在 Path B / C。Path A / D / D' 是「這一組明確被宣告覆蓋」的路徑，
+       -- 量由那些單據自己管，一律跳過守衛（HQ 要放行帳面不足的組 → 開庫存減抵單）。
+       -- ------------------------------------------------------------------
+       AND (
+         co.campaign_id IS NULL   -- 無團的單沒有「同組」可算，維持舊行為
+         -- Path A：這張單有自己的 transfer 被收貨（含 aid 跨店分支）
+         OR EXISTS (
+           SELECT 1 FROM transfers t
+            WHERE t.customer_order_id = co.id
+              AND t.tenant_id = co.tenant_id
+              AND t.status IN ('received','closed')
+         )
+         -- Path D：庫存減抵單
+         OR EXISTS (
+           SELECT 1 FROM inventory_deduction_notes n
+            WHERE n.tenant_id   = co.tenant_id
+              AND n.campaign_id = co.campaign_id
+              AND n.store_id    = co.pickup_store_id
+              AND n.sku_id      = coi.sku_id
+              AND n.cancelled_at IS NULL
+         )
+         -- Path D'：offset 抵減單
+         OR EXISTS (
+           SELECT 1
+             FROM customer_orders oo
+             JOIN customer_order_items oi
+               ON oi.order_id = oo.id
+              AND oi.sku_id   = coi.sku_id
+              AND oi.qty < 0
+              AND oi.status NOT IN ('cancelled','expired')
+            WHERE oo.tenant_id       = co.tenant_id
+              AND oo.campaign_id     = co.campaign_id
+              AND oo.pickup_store_id = co.pickup_store_id
+              AND oo.order_kind      = 'offset'
+              AND oo.status NOT IN ('cancelled','expired','transferred_out')
+         )
+         -- 數量守衛本體：這一行的累計需求 ≤ 該組可配量
+         OR (
+           SELECT COALESCE(SUM(x.qty), 0)
+             FROM customer_order_items x
+             JOIN customer_orders xo ON xo.id = x.order_id
+             LEFT JOIN members xm ON xm.id = xo.member_id
+            WHERE xo.tenant_id       = co.tenant_id
+              AND xo.campaign_id     = co.campaign_id
+              AND xo.pickup_store_id = co.pickup_store_id
+              AND x.sku_id           = coi.sku_id
+              AND x.status IN ('pending','reserved','ready')
+              -- 掛著待補貨的行已經被少發配貨擋掉了，不佔預算
+              --（算進來會自己擋自己，20260811000050 踩過）
+              AND x.backorder_at IS NULL
+              AND xo.status NOT IN ('completed','expired','cancelled','transferred_out')
+              -- 現貨池容器（RR- /【內部】xx 店）不是對客人的承諾，不佔預算
+              AND COALESCE(xm.member_type, '') <> 'store_internal'
+              -- offset 抵減單是負數行，不是需求
+              AND COALESCE(xo.order_kind, 'normal') <> 'offset'
+              -- 有自己 transfer 的單（Path A）走 store_to_store 供給，不吃這份 hq 預算
+              AND NOT EXISTS (
+                SELECT 1 FROM transfers t2
+                 WHERE t2.customer_order_id = xo.id
+                   AND t2.tenant_id = xo.tenant_id
+                   AND t2.status IN ('received','closed')
+              )
+              -- 排在自己前面（含自己）的行才計入累計
+              AND (xo.created_at, xo.order_no, x.id) <= (co.created_at, co.order_no, coi.id)
+         ) <= public._pickup_group_available(
+                co.tenant_id, co.campaign_id, co.pickup_store_id, coi.sku_id
+              )
+       )
+  );
+$function$;
+
+COMMENT ON FUNCTION public.is_order_item_pickup_ready(bigint) IS
+  '品項層級取貨閘門。Path A: aid transfer FK 收貨 / Path B: campaign 對齊波次實收 / '
+  'Path C: 無對齊波次時退用本店該 SKU「開團之後」的實收（2026-08-14 加時間下限）/ '
+  'Path D: 減抵單 / Path D'': offset 抵減單。'
+  '2026-08-14 追加數量守衛：Path B / C 不再 qty-blind —— 同組依 (下單時間, 單號, 行 id) '
+  '累加，累計量超過「開團後實收 − 已取走」的行回 false（短收時沒進店的那幾件不放行）。'
+  'Path A / D / D'' 跳過守衛，量由那些單據自己管。';
+
+-- ----------------------------------------------------------------
+-- 3. v_order_item_pickup_ready — 加 qty_short，讓前端分得出「為什麼不能取」
+--
+--    pickup_ready = false 的原因有三種，畫面上要講不一樣的話：
+--      * backorder_at 有值        → 少發配貨沒配到，「⏳ 待補貨」（要人工配貨）
+--      * qty_short = true         → 路徑到貨了但量不夠，「⏳ 未到貨」（等下一批）
+--      * 兩者皆否                 → 這批根本還沒到店
+--    欄位往後加，既有 select 不受影響。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE VIEW public.v_order_item_pickup_ready AS
+SELECT
+  coi.id AS item_id,
+  coi.order_id,
+  coi.tenant_id,
+  public.is_order_item_pickup_ready(coi.id) AS pickup_ready,
+  -- 「這組到過貨，只是不夠分到這一行」：不可取、沒掛待補貨，但該組開團後確實有實收。
+  -- 用 supplied（非 available）判斷 —— available 已扣掉已取量，短收又剛好取光時是 0，
+  -- 會跟「根本沒到過」混在一起（本次災情 GRP-20260805-006 就是 supplied 1 / picked 1）。
+  (
+    coi.status IN ('pending','reserved','ready')
+    AND coi.backorder_at IS NULL
+    AND NOT public.is_order_item_pickup_ready(coi.id)
+    AND EXISTS (
+      SELECT 1 FROM customer_orders co
+       WHERE co.id = coi.order_id
+         AND co.campaign_id IS NOT NULL
+         AND public._pickup_group_supplied(
+               co.tenant_id, co.campaign_id, co.pickup_store_id, coi.sku_id
+             ) > 0
+    )
+  ) AS qty_short
+FROM customer_order_items coi;
+
+GRANT SELECT ON public.v_order_item_pickup_ready TO authenticated;
+
+COMMENT ON VIEW public.v_order_item_pickup_ready IS
+  '品項可取貨判斷 view（item_id, order_id, pickup_ready, qty_short）。'
+  'qty_short = 該組到貨量蓋不住這一行（等下一批，不是要人工配貨），'
+  '前端用來把「⏳ 未到貨」跟「⏳ 待補貨」講清楚。';

--- a/supabase/migrations/20260814070000_member_item_level_arrived.sql
+++ b/supabase/migrations/20260814070000_member_item_level_arrived.sql
@@ -1,0 +1,128 @@
+-- ============================================================
+-- 2026-08-14 (7)：會員端 items[] 加品項層級 arrived —— App 分頁要能依「行」分桶
+--
+-- 承 20260814060000（取貨閘門加數量守衛）。那一版只修好店員端：
+--   /pickup 不再讓店員發出沒到的貨。但**會員 App 完全沒修到** ——
+--   線上實測 80 張被守衛擋下的單，v_customer_order_summary.arrived
+--   仍然 80/80 都是 true。
+--
+-- 原因是 arrived 有快路徑：
+--   co.status IN ('reserved','ready','partially_ready','partially_completed','completed')
+--   → 一律 true，閘門**只對 'shipping' 的單呼叫**。
+-- 所以單頭一旦被推到 ready / partially_completed，會員端就無條件顯示到貨。
+--
+-- 災情面（GRP-20260805-006-0026 忠順）：客人訂 2 件、店只收 1 件、取走 1 件。
+--   剩下那件根本沒到，但 App 上：
+--     * 單頭寫「部分已取」（orderPhase 的 partially_completed 分支先短路，沒問 arrived）
+--     * 行級 chip 寫「未取」（pickChip 只看品項 status，跟到貨無關）
+--     * 未結 $139
+--   合起來就是在跟客人說「還有一件在店裡等你拿」—— 客人照樣跑一趟撲空。
+--
+-- 修法：items[] jsonb 每一行加 'arrived'，讓前端能依**行**分桶
+--   （未到貨的行 → 待到貨、已取的行 → 已完成），不再整張單擠在同一個分頁。
+--
+--   成本控制：只有 active 行（pending/reserved/ready）才呼叫閘門，
+--   picked_up / cancelled / expired 一律回 NULL 不呼叫 —— 那些行的分桶
+--   看 status 就決定了，沒必要付錢。實測最重的會員（407 張單 / 684 個品項、
+--   其中 322 個 active）逐項跑閘門約 750ms，一般會員（144 單 / 204 品項）約 150ms。
+--
+--   單頭的 arrived 逐字不動（含快路徑）—— 它還有別的消費者，這一版只加不減。
+--
+-- 基底版本（append-only）：線上現行 v_customer_order_summary
+--   （= 20260811000050_order_summary_campaign_no.sql 之後的累積版，
+--     本檔以 pg_get_viewdef 實際 dump 為基底，逐字保留只加 'arrived' 一個 key）
+--
+-- Rollback：把 items 的 jsonb_build_object 裡
+--   "'arrived', CASE WHEN ... END," 這一段拿掉再 CREATE OR REPLACE 即可。
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.v_customer_order_summary AS
+ SELECT co.id,
+    co.tenant_id,
+    co.order_no,
+    co.member_id,
+    co.pickup_store_id AS store_id,
+    co.campaign_id,
+    co.channel_id,
+    co.status,
+    co.payment_status,
+    co.payment_method,
+    co.paid_at,
+    co.shipping_method,
+    co.shipping_address,
+    co.shipping_phone,
+    co.shipping_note,
+    co.remit_amount,
+    co.remit_at,
+    co.remit_note,
+    co.shipping_fee,
+    co.discount_amount,
+    co.discount_percent,
+    co.wallet_paid_amount,
+    co.pickup_deadline,
+    co.notes,
+    co.created_at,
+    co.confirmed_at,
+    co.shipping_at,
+    co.ready_at,
+    co.completed_at,
+    co.cancelled_at,
+    co.stockout_at,
+    agg.items_total,
+    agg.unpicked_total,
+    ret.returned_qty,
+    ret.returned_deduction,
+    GREATEST(0::numeric, round(GREATEST(0::numeric, agg.items_total - ret.returned_deduction) * (1::numeric - co.discount_percent / 100::numeric) + co.shipping_fee - co.discount_amount, 0)) AS payable_amount,
+    GREATEST(0::numeric, GREATEST(0::numeric, round(GREATEST(0::numeric, agg.items_total - ret.returned_deduction) * (1::numeric - co.discount_percent / 100::numeric) + co.shipping_fee - co.discount_amount, 0)) - co.wallet_paid_amount) AS balance_due,
+        CASE
+            WHEN co.status = ANY (ARRAY['cancelled'::text, 'expired'::text, 'transferred_out'::text]) THEN 0::numeric
+            WHEN agg.unpicked_total <= 0::numeric THEN 0::numeric
+            ELSE GREATEST(0::numeric, GREATEST(0::numeric, round(GREATEST(0::numeric, agg.unpicked_total - ret.returned_deduction) * (1::numeric - co.discount_percent / 100::numeric) + co.shipping_fee - co.discount_amount, 0)) - co.wallet_paid_amount)
+        END AS outstanding_amount,
+    agg.items,
+    (co.status = ANY (ARRAY['reserved'::text, 'ready'::text, 'partially_ready'::text, 'partially_completed'::text, 'completed'::text])) OR co.status = 'shipping'::text AND (EXISTS ( SELECT 1
+           FROM customer_order_items coi
+          WHERE coi.order_id = co.id AND (coi.status = ANY (ARRAY['pending'::text, 'reserved'::text, 'ready'::text])) AND is_order_item_pickup_ready(coi.id))) AS arrived,
+    co.confirmed_at IS NOT NULL OR (co.status = ANY (ARRAY['reserved'::text, 'ready'::text, 'partially_ready'::text, 'partially_completed'::text, 'shipping'::text, 'completed'::text])) AS settled,
+    co.payment_status = 'paid'::text AS paid,
+    co.status = ANY (ARRAY['shipping'::text, 'completed'::text]) AS shipped,
+    (('S-'::text || lpad(co.id::text, 8, '0'::text)) || '-'::text) || COALESCE(s.store_short_code, 'XX'::text) AS settlement_no,
+    s.name AS store_name,
+    s.code AS store_code,
+    gbc.campaign_no,
+    gbc.name AS campaign_name,
+    gbc.cover_image_url AS campaign_cover_url,
+    gbc.end_at AS campaign_end_at,
+    gbc.cutoff_date AS campaign_cutoff_date
+   FROM customer_orders co
+     LEFT JOIN stores s ON s.id = co.pickup_store_id
+     LEFT JOIN group_buy_campaigns gbc ON gbc.id = co.campaign_id
+     LEFT JOIN LATERAL ( SELECT COALESCE(sum(coi.qty * coi.unit_price) FILTER (WHERE coi.status <> ALL (ARRAY['cancelled'::text, 'expired'::text])), 0::numeric) AS items_total,
+            COALESCE(sum(coi.qty * coi.unit_price) FILTER (WHERE coi.status <> ALL (ARRAY['cancelled'::text, 'expired'::text, 'picked_up'::text])), 0::numeric) AS unpicked_total,
+            COALESCE(jsonb_agg(jsonb_build_object('id', coi.id, 'sku_id', coi.sku_id, 'sku_code', sk.sku_code, 'product_name', sk.product_name, 'variant_name', sk.variant_name, 'campaign_item_id', coi.campaign_item_id, 'qty', coi.qty, 'unit_price', coi.unit_price, 'subtotal', coi.qty * coi.unit_price, 'status', coi.status, 'stockout', coi.stockout_at IS NOT NULL, 'arrived', CASE WHEN coi.status = ANY (ARRAY['pending'::text, 'reserved'::text, 'ready'::text]) THEN is_order_item_pickup_ready(coi.id) ELSE NULL::boolean END, 'notes', coi.notes, 'image_url',
+                CASE
+                    WHEN jsonb_typeof(p.images) = 'array'::text AND jsonb_array_length(p.images) > 0 THEN COALESCE((p.images -> 0) ->> 'url'::text, p.images ->> 0)
+                    ELSE NULL::text
+                END) ORDER BY coi.id), '[]'::jsonb) AS items
+           FROM customer_order_items coi
+             LEFT JOIN skus sk ON sk.id = coi.sku_id
+             LEFT JOIN products p ON p.id = sk.product_id
+          WHERE coi.order_id = co.id) agg ON true
+     LEFT JOIN LATERAL ( SELECT COALESCE(sum(a.alloc_qty), 0::numeric) AS returned_qty,
+            COALESCE(sum(a.alloc_qty * a.unit_price), 0::numeric) AS returned_deduction
+           FROM ( SELECT i.unit_price,
+                    LEAST(i.qty, GREATEST(r.ret_qty - i.prior_qty, 0::numeric)) AS alloc_qty
+                   FROM ( SELECT ti.sku_id,
+                            sum(ti.qty_shipped) AS ret_qty
+                           FROM transfers t
+                             JOIN transfer_items ti ON ti.transfer_id = t.id
+                          WHERE t.customer_order_id = co.id AND t.tenant_id = co.tenant_id AND t.transfer_type = 'return_to_hq'::text AND (t.status = ANY (ARRAY['shipped'::text, 'received'::text])) AND COALESCE("substring"(t.notes, '^\[order return([^\]:]*)'::text), ''::text) !~~ '%取貨後退回%'::text
+                          GROUP BY ti.sku_id) r
+                     JOIN ( SELECT coi.sku_id,
+                            coi.qty,
+                            coi.unit_price,
+                            COALESCE(sum(coi.qty) OVER (PARTITION BY coi.sku_id ORDER BY coi.id ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING), 0::numeric) AS prior_qty
+                           FROM customer_order_items coi
+                          WHERE coi.order_id = co.id AND (coi.status <> ALL (ARRAY['cancelled'::text, 'expired'::text]))) i ON i.sku_id = r.sku_id) a) ret ON true;
+
+GRANT SELECT ON public.v_customer_order_summary TO authenticated;


### PR DESCRIPTION
## 災情

忠順店回報，`GRP-20260805-006`「夜玫瑰」紅肉李 #32（sku 4141）：

- 總倉派 **2** 件（`WAVE-1278-S51`，`qty_shipped=2`），忠順只實收 **1** 件（收貨頁確實標了短少）
- 客人一行訂 2 件，取走 1 件後拆行 → 訂單變 `partially_completed`
- 剩下那一行取貨頁仍顯示「1 項可取」、✅ 取貨 鈕亮著
- 但那件貨根本沒進店（`on_hand = 0`），按下去就是庫存扣成負的 + 客人白跑

關鍵那一秒：`transfer.received_at` 與訂單 `ready_at` 是**同一個時間戳**（`2026-08-14 08:13:47.663099+00`）—— 只收到 1 件，單頭在收貨當下就被推成「全部到貨」。

## 根因

取貨閘門 `is_order_item_pickup_ready` 是 qty-blind 的。Path B 的條件是：

```sql
AND ti.qty_received > 0     -- 存在性判斷，不是數量判斷
```

一組貨只要到過一件，該組**所有**未取品項都放行。

這個語意本來刻意留著、想靠 `_advance_arrived_confirmed_orders` 把關，但那支只管 `confirmed → ready` 的推進；**取貨頁對 `ready` / `partially_completed` 的單是直接吃閘門的**，所以數量守衛在真正會出貨的那條路上從來沒有生效過。

短收的資訊全程都在（`qty_variance = -1`），只是沒有任何東西把它接到訂單品項上 —— 少發配貨（`rpc_allocate_shortage`）是唯一的接法，而它要店員手動點。

## 改動

### 1. `20260814060000` — 取貨閘門加數量守衛

Path A~D' 逐字保留，末端追加：

```
可配量 = 該 (團,店,SKU) 開團後的實收 − 該組已取走量
同組依 (下單時間, 單號, 行 id) 累加，超過可配量的行回 false
```

排序跟既有「依訂單時間自動配」同一套。**只作用在 qty-blind 的 Path B / C**；Path A / D / D' 是「這組明確被宣告覆蓋」的路徑，跳過守衛 —— HQ 要放行帳面不足的組，開**庫存減抵單**仍是既有正解。

純推導、不寫任何欄位、不標 `backorder_at` —— 下一批貨收進來就自己放行，不需要人工解除。

設計取捨：供給側刻意算寬（不限對齊波次，補貨路線送到店的也算）、需求側刻意算窄（排除現貨池容器單 / offset / 有自己 transfer 的單 / 掛 `backorder_at` 的行）。false negative（貨在店裡卻不給發）會逼店員改走轉單 → 開新單 → 重複單，比 false positive 難收拾。

前端 `v_order_item_pickup_ready` 加 `qty_short`，讓畫面分得出「到過貨但量不夠」與「根本沒到」—— 前者不可以標成「待補貨」（那會叫店員去追不存在的配貨）。訂單層級改顯示「⏳ 尚有 N 件未到貨，無法取貨」。

### 2. `20260814070000` — 會員 App 依「行」分頁

第 1 版只修好店員端，會員 App 完全沒修到：線上實測 80 張被守衛擋下的單，`v_customer_order_summary.arrived` 仍然 **80/80 都是 true**。因為 `arrived` 有快路徑，單頭一到 `ready` / `partially_completed` 就無條件 true，閘門只對 `shipping` 呼叫。

- **DB**：`items[]` jsonb 每行加 `arrived`。只有 active 行才呼叫閘門，`picked_up` / `cancelled` 回 NULL 不付成本。單頭的 `arrived` 逐字不動（還有別的消費者）。
- **前端**：分頁改依行分桶 —— 已取走 → 已完成、沒到貨 → 待到貨、到貨未取 → 待取貨、斷貨 → 不成立。一張單可同時出現在兩個分頁（刻意）。「全部」維持不拆。
- **金額**：分身卡的應付金額按未取貨值**等比分攤**，不可每個分身都掛整張單的 `outstanding`（一張單同時在兩頁會被算兩次）。兩頁相加仍等於原本的 outstanding。
- 行級 chip 加「未到貨」—— 沒到貨的行只標「未取」會被讀成「貨在店裡等你」。

`listMyOrders` 走 `select("*")`，新 key 自動帶出，不需要重部署 Edge Function。

## 影響範圍（線上實測）

閘門現在回 true、加守衛後變 false 的：**84 個品項 / 143 件 / 82 張單**，其中店員真的按得下去的（`ready` / `partially_completed`）是 **82 個品項 / 141 件 / 80 張單**，分佈 10 間店（中和 20、永和 19、三峽 13、林口 8、泰山 7、忠順/古華/文山 各 4、松山 2、南平 1）。

都是該組「實收 − 已取」已經蓋不住剩餘未取量的，例如：

| 訂單 | 實收 | 已取 | on_hand |
|---|---|---|---|
| GB20260518-C000154-0071 | 10 | 21 | −11 |
| GRP-20260609-004-0018 | 2 | 10 | −8 |

## 驗證

- **部署前**在 rollback 交易裡試跑：預測的 84 個品項全數變 false，**對照組 400 個目前可取的品項全數維持可取**
- **自我修復**已實測：在 rollback 交易裡補派 1 件到忠順 → `supplied` 1→2、`available` 0→1、閘門 false→true、`qty_short` true→false，不需任何人工動作
- **admin UI**（Playwright + fixture）：未到貨徽章、「尚有 1 件未到貨，無法取貨」、取貨鈕 disabled、不誤標「待補貨」，六項全過
- **member UI**（Playwright + fixture）：待到貨出現且只列沒到那件、待取貨不出現、已完成出現已取那件，四項全過
- admin / member typecheck 乾淨；member eslint 乾淨（admin 既有的一個 error 在 HEAD 上本來就有，與本次改動無關）

兩支 migration 都已依 CLAUDE.md 的流程用 Management API 套上正式庫並驗證過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYkqTkFE6b1sKPkvWWePCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYkqTkFE6b1sKPkvWWePCN)_