### PR TITLE
feat(orders/pickup): 標出 $0 品項的訂單，並在取貨時擋下

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -32,6 +32,11 @@ type Row = {
   transferred_from_order_id: number | null;
   created_at: string;
   updated_at: string;
+  // 單價 $0 的品項行數（v_admin_orders_list @20260815000000）。>0 = 開團／代 key
+  // 漏填金額 —— 取貨時 rpc_record_pickup 的零元守衛會擋下整張單。
+  // 【內部】xx 店 / RR- / OV- 容器單（member_type='store_internal'）恆為 0：
+  // 池子單價本來就可能是 0，不是漏填。
+  zero_price_lines: number | null;
 };
 
 type Campaign = { id: number; campaign_no: string; name: string; cover_image_url: string | null; start_at: string | null };
@@ -221,6 +226,9 @@ type OrderFilters = {
   keywordOr: string | null;
   // 日期區間看事件日（event_at）還是訂單日（created_at）— 語意跟著 tab 走，見 dateOnEvent
   dateOnEvent: boolean;
+  // 只看「含 $0 品項」的訂單（漏填金額）。伺服端篩 v_admin_orders_list.zero_price_lines，
+  // 跨分頁有效 —— client 端只濾得到當頁 50 筆，數字會跟提示條對不起來
+  zeroOnly: boolean;
 };
 
 // 品項（SKU）篩選用的內嵌 join：applyOrderFilters 的 items.sku_id 過濾要靠 select
@@ -234,6 +242,7 @@ function applyOrderFilters<
   Q extends {
     eq(column: string, value: never): Q;
     in(column: string, values: never[]): Q;
+    gt(column: string, value: never): Q;
     gte(column: string, value: never): Q;
     lt(column: string, value: never): Q;
     or(filters: string): Q;
@@ -260,6 +269,7 @@ function applyOrderFilters<
   if (f.fromTs) out = out.gte(dateCol, f.fromTs as never);
   if (f.toTs) out = out.lt(dateCol, f.toTs as never);
   if (f.keywordOr) out = out.or(f.keywordOr);
+  if (f.zeroOnly) out = out.gt("zero_price_lines", 0 as never);
   return out;
 }
 
@@ -281,6 +291,20 @@ function cardTint(status: OrderStatus): string {
   if (status === "expired") return "border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/30";
   if (status === "transferred_out") return "border-zinc-200 bg-zinc-100 text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900";
   return "border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950";
+}
+
+// 「這張單有 $0 品項」紅標 — 數字來自 v_admin_orders_list.zero_price_lines
+// （伺服端算的，與提示條的數量、「只看 $0」篩選同一個來源，不會各說各話）
+function ZeroPriceBadge({ lines }: { lines: number | null }) {
+  if (!lines || lines <= 0) return null;
+  return (
+    <span
+      title="這張單有品項的單價是 $0，可能是開團時漏填金額。取貨會被擋下，請先補上金額。"
+      className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-semibold text-red-700 dark:bg-red-950 dark:text-red-300"
+    >
+      ⚠️ $0 品項 ×{lines}
+    </span>
+  );
 }
 
 export default function OrdersListPage() {
@@ -305,6 +329,8 @@ function OrdersListContent() {
     return TAB_VALUES.includes(t as Tab) ? (t as Tab) : "pending";
   })();
   const initialStoreId = searchParams.get("storeId") ?? "";
+  // ?zero=1 —— 讓「$0 提示條」可以被貼成連結丟給同事
+  const initialZeroOnly = searchParams.get("zero") === "1";
   const initialSkuId = searchParams.get("skuId") ?? "";
   const initialKeyword = searchParams.get("q") ?? "";
   const initialDate = (key: string) => {
@@ -326,6 +352,10 @@ function OrdersListContent() {
   const [skuOptionRows, setSkuOptionRows] = useState<
     { skuId: number; campaignId: number; productName: string | null; variantName: string | null }[]
   >([]);
+  // 只看含 $0 品項的訂單（提示條的「只看這些」）
+  const [zeroOnly, setZeroOnly] = useState(initialZeroOnly);
+  // 目前 tab + 篩選底下有幾張含 $0 品項的訂單（提示條的數字；zeroOnly 關掉時也要算）
+  const [zeroCount, setZeroCount] = useState<number | null>(null);
   // 訂單日 (created_at) 區間；"" = 不限
   const [dateFrom, setDateFrom] = useState(initialDate("from"));
   const [dateTo, setDateTo] = useState(initialDate("to"));
@@ -410,14 +440,14 @@ function OrdersListContent() {
   // 品項篩選只在有選開團時生效（下拉也只在那時渲染）。開團清空不硬清 skuId，
   // 改由這裡歸零 — 篩選不能在 UI 看不到的情況下默默生效。
   const activeSkuId = campaignIds.length > 0 ? skuId : "";
-  const hasFilter = campaignIds.length > 0 || !!storeId || !!activeSkuId || !!keyword || !!dateFrom || !!dateTo;
+  const hasFilter = campaignIds.length > 0 || !!storeId || !!activeSkuId || !!keyword || !!dateFrom || !!dateTo || zeroOnly;
 
   useEffect(() => {
     setPage(1);
     // 篩選一變，勾選就作廢 — 不然會印到已經看不見的單
     setSelected(new Set());
     setBulkPrintErr(null);
-  }, [campaignIds, tab, storeId, activeSkuId, keyword, fromTs, toTs]);
+  }, [campaignIds, tab, storeId, activeSkuId, keyword, fromTs, toTs, zeroOnly]);
 
   // 品項下拉的選項 = 所選開團的 campaign_items。沒選開團就不提供品項篩選
   // （全庫 SKU 太多、也沒有情境）。products.name 是 source of truth
@@ -550,7 +580,7 @@ function OrdersListContent() {
         const base = getSupabase()
           .from("v_admin_orders_list")
           .select(
-            "id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, transferred_from_order_id, created_at, updated_at"
+            "id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, transferred_from_order_id, created_at, updated_at, zero_price_lines"
               + (activeSkuId ? ITEM_EMBED : ""),
             { count: "exact" },
           )
@@ -560,7 +590,7 @@ function OrdersListContent() {
 
         const kwOr = await buildKeywordOr(keyword);
         if (cancelled) return;
-        const q = applyOrderFilters(base, { campaignIds, tab, storeId, skuIds: activeSkuId ? [activeSkuId] : [], fromTs, toTs, keywordOr: kwOr, dateOnEvent });
+        const q = applyOrderFilters(base, { campaignIds, tab, storeId, skuIds: activeSkuId ? [activeSkuId] : [], fromTs, toTs, keywordOr: kwOr, dateOnEvent, zeroOnly });
 
         const { data, count, error } = await q;
         if (cancelled) return;
@@ -617,7 +647,31 @@ function OrdersListContent() {
       }
     })();
     return () => { cancelled = true; };
-  }, [campaignIds, tab, dateOnEvent, storeId, activeSkuId, page, reloadOrders, keyword, fromTs, toTs, sortSpec]);
+  }, [campaignIds, tab, dateOnEvent, storeId, activeSkuId, page, reloadOrders, keyword, fromTs, toTs, sortSpec, zeroOnly]);
+
+  // 「$0 品項」提示條的數字 — 與列表同一組篩選（含 tab），只多一條
+  // zero_price_lines > 0。刻意獨立一支查詢而不是數當頁 rows：跨分頁才算得準，
+  // 而且 zeroOnly 關著的時候也要能顯示「有 N 張要處理」。
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setZeroCount(null);
+      const kwOr = await buildKeywordOr(keyword);
+      if (cancelled) return;
+      const base = getSupabase()
+        .from("v_admin_orders_list")
+        .select("id" + (activeSkuId ? ITEM_EMBED : ""), { count: "exact", head: true });
+      const { count, error } = await applyOrderFilters(base, {
+        campaignIds, tab, storeId, skuIds: activeSkuId ? [activeSkuId] : [],
+        fromTs, toTs, keywordOr: kwOr, dateOnEvent, zeroOnly: true,
+      });
+      if (cancelled) return;
+      // 查不到就當 0（例如線上還沒套 migration、view 沒有這一欄）——
+      // 提示條消失即可，不要讓訂單頁整頁報錯
+      setZeroCount(error ? 0 : count ?? 0);
+    })();
+    return () => { cancelled = true; };
+  }, [campaignIds, tab, dateOnEvent, storeId, activeSkuId, reloadOrders, keyword, fromTs, toTs]);
 
   // 頁首聚合（tab 數量 + 月趨勢）— 單一伺服端 RPC rpc_order_overview
   // 取代之前 client 端「5 個 count:exact 全表掃描」+「搬整月訂單+全部明細
@@ -893,7 +947,7 @@ function OrdersListContent() {
       .order("id", { ascending: false })
       .limit(SELECT_ALL_MAX);
     const { data, error } = await applyOrderFilters(base, {
-      campaignIds, tab, storeId, skuIds: activeSkuId ? [activeSkuId] : [], fromTs, toTs, keywordOr: kwOr, dateOnEvent,
+      campaignIds, tab, storeId, skuIds: activeSkuId ? [activeSkuId] : [], fromTs, toTs, keywordOr: kwOr, dateOnEvent, zeroOnly,
     });
     if (error) { setBulkPrintErr(error.message); return; }
     const ids = ((data ?? []) as unknown as { id: number }[]).map((r) => r.id);
@@ -1044,6 +1098,31 @@ function OrdersListContent() {
           );
         })}
       </div>
+
+      {/* ⚠ 漏填金額提示 — 目前 tab + 篩選底下有幾張訂單含 $0 品項。
+          $0 幾乎都是開團 / 代 key 時漏填單價（線上抽查 notes 全為 NULL，沒有一筆是
+          刻意的贈品），取貨那一刻就是收錢的時候 → 不補金額等於把貨白送。
+          取貨頁與 rpc_record_pickup 會擋下這種單，所以這裡要讓人一眼看到、點得進去。*/}
+      {(zeroOnly || (zeroCount ?? 0) > 0) && (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          <span className="font-semibold">
+            ⚠️ 有 {zeroCount ?? "…"} 張訂單含 $0 品項
+          </span>
+          <span className="text-xs">
+            可能是開團時漏填金額。這些單在取貨頁會被擋下，請先補上金額（點訂單開明細改單價，或在取貨頁該品項旁直接補填）。
+          </span>
+          <SpinButton
+            type="button"
+            onClick={() => setZeroOnly((v) => !v)}
+            className={zeroOnly
+              ? "ml-auto shrink-0 rounded-md bg-red-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-red-700"
+              : "ml-auto shrink-0 rounded-md border border-red-400 px-2.5 py-1 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-950"
+            }
+          >
+            {zeroOnly ? "✕ 取消只看 $0" : "只看這些"}
+          </SpinButton>
+        </div>
+      )}
 
       <div className="grid gap-3 sm:grid-cols-3">
         <div className="relative">
@@ -1421,6 +1500,7 @@ function OrdersListContent() {
                 <span>{sum?.lineCount ?? 0} 項</span>
                 <span>共 {sum?.totalQty ?? 0} 件</span>
                 <span className="font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-100">${sum?.totalAmount ?? 0}</span>
+                <ZeroPriceBadge lines={r.zero_price_lines} />
                 <span
                   className="ml-auto"
                   title={`訂單日：${new Date(r.created_at).toLocaleString("zh-TW", { hour12: false })}\n更新日：${new Date(r.updated_at).toLocaleString("zh-TW", { hour12: false })}`}
@@ -1548,7 +1628,14 @@ function OrdersListContent() {
                   <Td className="whitespace-nowrap text-xs">{s?.name ?? "—"}</Td>
                   <Td className="whitespace-nowrap text-right font-mono">{itemSummary.get(r.id)?.lineCount ?? 0}</Td>
                   <Td className="whitespace-nowrap text-right font-mono">{itemSummary.get(r.id)?.totalQty ?? 0}</Td>
-                  <Td className="whitespace-nowrap text-right font-mono">${itemSummary.get(r.id)?.totalAmount ?? 0}</Td>
+                  <Td className="whitespace-nowrap text-right font-mono">
+                    ${itemSummary.get(r.id)?.totalAmount ?? 0}
+                    {(r.zero_price_lines ?? 0) > 0 && (
+                      <div className="mt-0.5">
+                        <ZeroPriceBadge lines={r.zero_price_lines} />
+                      </div>
+                    )}
+                  </Td>
                   <Td
                     className="whitespace-nowrap text-right text-xs text-zinc-500"
                     title={`訂單日：${new Date(r.created_at).toLocaleString("zh-TW", { hour12: false })}\n更新日：${new Date(r.updated_at).toLocaleString("zh-TW", { hour12: false })}`}

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -95,6 +95,13 @@ function PickupPageContent() {
   // item.id → 未取退貨量（return_to_hq transfer 依 SKU 聚合後分攤到各品項行，
   // 與 PickupDialog 同構）。退回總倉的量店裡沒有、不可再取。
   const [returnedByItem, setReturnedByItem] = useState<Map<number, number>>(new Map());
+  // member_type='store_internal' 的會員 id（【內部】xx 店 / RR- / OV- 現貨池容器）。
+  // 這些單的 unit_price 本來就可能是 0（掛帳用，轉單給客人時才鎖現售價），
+  // 不算漏填 —— 零元守衛前後端都放行，見 migration 20260815000000。
+  const [internalMemberIds, setInternalMemberIds] = useState<Set<number>>(new Set());
+  // item.id → 櫃台補填金額的輸入值 / 正在送出的那一筆
+  const [zeroFillDraft, setZeroFillDraft] = useState<Map<number, string>>(new Map());
+  const [zeroFilling, setZeroFilling] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
   const autoSearchedRef = useRef(false);
@@ -163,8 +170,20 @@ function PickupPageContent() {
     }
     return [];
   }
+  // 本次要取的品項裡，單價是 $0 的那些 —— 開團 / 代 key 漏填金額。
+  // 取貨就是收錢的那一刻，放行等於把貨白送（線上已經這樣送掉 111 列），
+  // 所以整張擋下、要求先補金額。rpc_record_pickup 有同款守衛（zero_price:），
+  // 這裡是為了讓店員在按下去之前就看到、而且當場補得了。
+  // 【內部】xx 店 / RR- / OV- 現貨池容器單的 0 是掛帳用的，不擋。
+  function zeroPriceItems(order: OpenOrder & { member_id?: number }) {
+    if (order.member_id != null && internalMemberIds.has(order.member_id)) return [];
+    return pickableItems(order).filter((it) => Number(it.unit_price) === 0);
+  }
+  function hasZeroPrice(order: OpenOrder): boolean {
+    return zeroPriceItems(order).length > 0;
+  }
   function isPickable(order: OpenOrder): boolean {
-    return pickableItems(order).length > 0;
+    return pickableItems(order).length > 0 && !hasZeroPrice(order);
   }
   // 該品項是否為「這組到過貨但量不夠分到這一行」（短收 / 這批只到一部分）。
   // 等下一批貨收進來就會自己放行，不需要人工配貨 —— 所以不可以標成「待補貨」。
@@ -237,6 +256,17 @@ function PickupPageContent() {
       }
 
       if (list.length === 0) return;
+
+      // 現貨池容器會員（member_type='store_internal'）—— 零元守衛對它們不生效。
+      // rpc_search_members 不回 member_type，所以另外撈一次（結果最多 20 筆）。
+      {
+        const { data: its } = await sb
+          .from("members")
+          .select("id")
+          .in("id", list.map((mem) => mem.id))
+          .eq("member_type", "store_internal");
+        setInternalMemberIds(new Set(((its ?? []) as { id: number }[]).map((x) => x.id)));
+      }
 
       // 搜尋有結果即記入「常用顧客」（不必等取貨）。
       // ≤5 筆視為「找到特定顧客」才記；>5 視為廣搜（如只打姓氏），不記以免洗版。
@@ -535,6 +565,39 @@ function PickupPageContent() {
       }
     }
     setReloadTick((n) => n + 1);
+  }
+
+  // 櫃台補填漏填的金額（$0 → 正數）。走窄口徑的 rpc_fill_zero_order_item_price：
+  // 改單價的 rpc_update_order_item_price 認 app_metadata.store_id，分店帳號一個都沒有
+  // （店歸屬存的是 stores 店名陣列）→ 店員按不動。沒有這個入口的話，零元守衛會變成
+  // 「客人在櫃台、按鈕按不下去、自己又改不了」，只能打電話找總部或改走轉單（重複單）。
+  async function fillZeroPrice(order: OpenOrder, itemId: number) {
+    const raw = (zeroFillDraft.get(itemId) ?? "").trim();
+    const price = Number(raw);
+    if (!raw || !Number.isFinite(price) || price <= 0) {
+      setError("請先輸入大於 0 的金額再補填");
+      return;
+    }
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id;
+    if (!operator) { setError("尚未登入"); return; }
+    setZeroFilling(itemId);
+    setError(null);
+    try {
+      const { error: e } = await sb.rpc("rpc_fill_zero_order_item_price", {
+        p_order_id: order.id,
+        p_item_id: itemId,
+        p_new_unit_price: price,
+        p_operator: operator,
+        p_reason: null,
+      });
+      if (e) { setError(`${order.order_no} 補填金額失敗：${translateRpcError(e)}`); return; }
+      setZeroFillDraft((m2) => { const next = new Map(m2); next.delete(itemId); return next; });
+      setReloadTick((n) => n + 1);
+    } finally {
+      setZeroFilling(null);
+    }
   }
 
   // 取消訂單 — 沿用訂單頁完全相同的 rpc_cancel_aid_order 流程：
@@ -946,9 +1009,14 @@ function PickupPageContent() {
                         const pickable = pickableItems(o);
                         const pickableIds = new Set(pickable.map((it) => it.id));
                         const pickableCount = pickable.length;
-                        const canPickup = pickableCount > 0;
-                        // 部分到貨：有品項可取、但還有（未被退光的）active 品項未到
-                        const partialArrival = canPickup && pickableCount < activeRemaining.length;
+                        // 漏填金額（$0）→ 整張擋下，補完才放行（後端 rpc_record_pickup 同款守衛）
+                        const zeroItems = zeroPriceItems(o);
+                        const zeroIds = new Set(zeroItems.map((it) => it.id));
+                        const canPickup = pickableCount > 0 && zeroItems.length === 0;
+                        // 部分到貨：有品項可取、但還有（未被退光的）active 品項未到。
+                        // 一律看「到貨」本身（pickableCount），不要跟 canPickup 綁 ——
+                        // 被漏填金額擋住的單，貨其實在店裡，講成「未到貨」會讓店員跑去追補貨。
+                        const partialArrival = pickableCount > 0 && pickableCount < activeRemaining.length;
                         // 「這組到過貨但量不夠分」的件數 —— 短收造成的未到貨，
                         // 訊息要跟「分店根本還沒收貨」分開講。
                         const shortQty = activeRemaining
@@ -981,9 +1049,46 @@ function PickupPageContent() {
                               </div>
                               <ul className="mt-0.5 space-y-0.5 text-xs text-zinc-700 dark:text-zinc-300">
                                 {active.map((it) => (
-                                  <li key={it.id} className="flex items-baseline gap-1.5">
+                                  <li key={it.id} className="flex flex-wrap items-baseline gap-1.5">
                                     <span className="font-bold">{itemDisplayName(it.sku, o.campaign?.name)}</span>
                                     <span className="font-mono text-zinc-500">× {Number(it.qty)}</span>
+                                    {/* 漏填金額：當場補（$0 → 正數）。不給補的話櫃台只能打電話找總部，
+                                        或改走轉單開新單 → 變重複單。 */}
+                                    {zeroIds.has(it.id) && (
+                                      <span className="flex items-center gap-1">
+                                        <span
+                                          className="rounded bg-red-100 px-1 py-0.5 text-[10px] font-semibold text-red-700 dark:bg-red-950 dark:text-red-300"
+                                          title="這個品項的單價是 $0，可能是開團時漏填金額。補上金額才能取貨。"
+                                        >
+                                          ⚠️ 未填金額
+                                        </span>
+                                        <span className="text-[10px] text-zinc-500">$</span>
+                                        <input
+                                          type="number"
+                                          min={1}
+                                          step="1"
+                                          inputMode="numeric"
+                                          value={zeroFillDraft.get(it.id) ?? ""}
+                                          onChange={(e) =>
+                                            setZeroFillDraft((m2) => {
+                                              const next = new Map(m2);
+                                              next.set(it.id, e.target.value);
+                                              return next;
+                                            })
+                                          }
+                                          placeholder="單價"
+                                          className="w-16 rounded border border-red-300 px-1 py-0.5 text-right font-mono text-xs dark:border-red-800 dark:bg-zinc-900"
+                                        />
+                                        <SpinButton
+                                          onClick={() => fillZeroPrice(o, it.id)}
+                                          disabled={zeroFilling === it.id}
+                                          title="把這個品項的單價補上（只能從 $0 補成正數，會寫入異動紀錄）"
+                                          className="rounded bg-red-600 px-1.5 py-0.5 text-[10px] font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                                        >
+                                          {zeroFilling === it.id ? "…" : "補填"}
+                                        </SpinButton>
+                                      </span>
+                                    )}
                                     {returnedOf(it) > 0 && (
                                       <span className="rounded bg-orange-100 px-1 py-0.5 text-[10px] font-medium text-orange-800 dark:bg-orange-950 dark:text-orange-300">↩ 已退 {returnedOf(it)}</span>
                                     )}
@@ -1020,7 +1125,7 @@ function PickupPageContent() {
                                   <span className="ml-2 font-semibold text-emerald-700 dark:text-emerald-400">
                                     到貨：{new Date(o.ready_at).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" })}
                                   </span>
-                                ) : canPickup ? (
+                                ) : pickableCount > 0 ? (
                                   <span className="ml-2 font-semibold text-emerald-700 dark:text-emerald-400">
                                     ✅ 已到貨
                                   </span>
@@ -1035,7 +1140,11 @@ function PickupPageContent() {
                                     (含 ${discAmt} 折扣)
                                   </span>
                                 )}
-                                {canPickup ? (
+                                {zeroItems.length > 0 ? (
+                                  <span className="ml-2 font-semibold text-red-700 dark:text-red-400">
+                                    ⚠️ 有 {zeroItems.length} 項未填金額，無法取貨
+                                  </span>
+                                ) : canPickup ? (
                                   <span className="ml-2">{partialArrival ? `${pickableCount}/${activeRemaining.length} 項可取` : `${pickableCount} 項可取`}</span>
                                 ) : fullyReturned ? (
                                   <span className="ml-2 font-semibold text-orange-700 dark:text-orange-400">↩ 已全數退回總倉，無可取貨項目</span>
@@ -1071,14 +1180,18 @@ function PickupPageContent() {
                             <SpinButton
                               onClick={() => quickPickup(o)}
                               disabled={!canPickup}
-                              title="一鍵取走已到貨品項並列印（不開明細視窗）"
+                              title={zeroItems.length > 0
+                                ? "有品項的單價是 $0（可能漏填金額），補上金額才能取貨"
+                                : "一鍵取走已到貨品項並列印（不開明細視窗）"}
                               className="rounded-md bg-emerald-600 px-3 py-2 text-xs font-medium text-white transition hover:bg-emerald-700 disabled:opacity-50"
                             >
                               ✅ 取貨
                             </SpinButton>
+                            {/* ✏️ 不跟著零元守衛一起關掉：一張單只有其中一項漏填時，
+                                進階視窗可以只取有價格的那幾項（$0 那列在視窗裡是鎖住的）。*/}
                             <SpinButton
                               onClick={() => setPickup({ orderId: o.id, orderNo: o.order_no })}
-                              disabled={!canPickup}
+                              disabled={pickableCount === 0}
                               title="進階：折扣 / 只取部分品項 / 扣儲值金"
                               className="rounded-md border border-emerald-300 px-2 py-2 text-xs font-medium text-emerald-700 transition hover:bg-emerald-50 disabled:opacity-50 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-950"
                             >

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -30,6 +30,9 @@ type OrderHead = {
   payment_status: string | null;
   // 只拿來決定品項要不要補印商品名（見 lib/skuLabel）
   campaign: { name: string } | { name: string }[] | null;
+  // store_internal = 【內部】xx 店 / RR- / OV- 現貨池容器單：單價 0 是掛帳用的，
+  // 不算漏填，零元守衛（migration 20260815000000）前後端都放行
+  member: { member_type: string | null } | { member_type: string | null }[] | null;
 };
 
 // 以指定數量計算小計（line-level 折扣金額按比例分攤，對齊後端拆行邏輯）
@@ -61,6 +64,9 @@ export function PickupDialog({
   // item.id → 是否已到貨（v_order_item_pickup_ready）。未到貨品項鎖住不可勾，
   // 後端 rpc_record_pickup 也會逐品項擋，這裡是前端提示。查無資料時當已到貨（交給後端把關）。
   const [readyByItem, setReadyByItem] = useState<Map<number, boolean>>(new Map());
+  // 這張單是不是現貨池容器單（member_type='store_internal'）。是的話 $0 不算漏填，
+  // 零元守衛放行 —— 與 rpc_record_pickup 同一條例外。
+  const [isInternalPool, setIsInternalPool] = useState(false);
   const [discountValue, setDiscountValue] = useState<DiscountValue>({ kind: "amount", value: 0 });
   const [originalDiscount, setOriginalDiscount] = useState<{ amount: number; percent: number }>({ amount: 0, percent: 0 });
   const [memberId, setMemberId] = useState<number | null>(null);
@@ -88,7 +94,7 @@ export function PickupDialog({
           .in("status", ["pending", "reserved", "ready"])
           .order("id"),
         sb.from("customer_orders")
-          .select("discount_amount, discount_percent, member_id, wallet_paid_amount, payment_status, campaign:group_buy_campaigns(name)")
+          .select("discount_amount, discount_percent, member_id, wallet_paid_amount, payment_status, campaign:group_buy_campaigns(name), member:members(member_type)")
           .eq("id", orderId)
           .maybeSingle<OrderHead>(),
         // 已退回總倉量（return_to_hq transfer）— 退掉的貨店裡沒有、不可再取。
@@ -106,6 +112,12 @@ export function PickupDialog({
       if (cancelled) return;
       if (iRes.error) { setErr(iRes.error.message); return; }
       const list = (iRes.data ?? []) as unknown as PickableItem[];
+
+      // 零元守衛的例外判定要在「預設勾選」之前算出來（$0 品項預設不勾）
+      const headMember = Array.isArray(hRes.data?.member) ? hRes.data?.member[0] : hRes.data?.member;
+      const internalPool = headMember?.member_type === "store_internal";
+      setIsInternalPool(internalPool);
+      const zeroPriced = (it: PickableItem) => !internalPool && Number(it.unit_price) === 0;
 
       // ----- 退貨量依 SKU 聚合，再分攤到各 pending 品項行（list 已 order by id，分攤穩定）-----
       // 只算「未取退貨」：取貨後退回（|取貨後退回）的是客戶已取走的貨，不扣未取品項的可取量
@@ -137,9 +149,11 @@ export function PickupDialog({
       const arrived = (it: PickableItem) => arrivedMap.get(it.id) !== false;
 
       setItems(list);
-      // 預設勾選 + 全取：只含「已到貨、且扣掉已退後仍有可取量」的品項
+      // 預設勾選 + 全取：只含「已到貨、且扣掉已退後仍有可取量」的品項。
+      // 單價 $0（漏填金額）的品項也排除 —— 勾了整批都會被後端零元守衛擋掉，
+      // 預設不勾才能讓店員把有價格的那幾項先取走。
       const pickableQty = (it: PickableItem) => Math.max(0, Number(it.qty) - (allocMap.get(it.id) ?? 0));
-      setPicked(new Set(list.filter((it) => pickableQty(it) > 0 && arrived(it)).map((it) => it.id)));
+      setPicked(new Set(list.filter((it) => pickableQty(it) > 0 && arrived(it) && !zeroPriced(it)).map((it) => it.id)));
       setPickQty(new Map(list.map((it) => [it.id, String(pickableQty(it))])));
       const head = hRes.data;
       const headAmt = Number(head?.discount_amount ?? 0);
@@ -196,6 +210,12 @@ export function PickupDialog({
   // 該品項是否未到貨（分店實收 0）— 未到貨不可勾選取貨
   function notArrived(it: PickableItem): boolean {
     return readyByItem.get(it.id) === false;
+  }
+  // 該品項是否漏填金額（單價 $0）。取貨＝收錢，$0 收不到錢 → 鎖住不可勾，
+  // 後端 rpc_record_pickup 的零元守衛也會擋（migration 20260815000000）。
+  // 現貨池容器單（store_internal）的 0 是掛帳用的，不算。
+  function zeroPrice(it: PickableItem): boolean {
+    return !isInternalPool && Number(it.unit_price) === 0;
   }
   function pickableOf(it: PickableItem): number {
     return Math.max(0, Number(it.qty) - returnedOf(it));
@@ -360,6 +380,13 @@ export function PickupDialog({
               ↩ 本訂單商品已全數退回總倉，無可取貨項目。
             </div>
           )}
+          {items.some((it) => zeroPrice(it)) && (
+            <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+              ⚠️ 有 {items.filter((it) => zeroPrice(it)).length} 個品項的單價是 $0（可能是開團時漏填金額），
+              已鎖住不能取貨。請到取貨頁該品項旁「補填」金額，或到訂單明細改單價；
+              其餘有價格的品項可以先取。
+            </div>
+          )}
           <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
             <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
               <thead className="bg-zinc-50 dark:bg-zinc-900">
@@ -377,7 +404,7 @@ export function PickupDialog({
                   const returned = returnedOf(it);
                   const pickable = pickableOf(it);
                   const fullyReturned = pickable <= 0;
-                  const blocked = fullyReturned || notArrived(it);
+                  const blocked = fullyReturned || notArrived(it) || zeroPrice(it);
                   const take = effQty(it);
                   const sub = lineSubQty(it, take);
                   const partial = take < pickable;
@@ -435,7 +462,9 @@ export function PickupDialog({
                           ? <span className="rounded bg-orange-100 px-1.5 py-0.5 font-medium text-orange-800 dark:bg-orange-950 dark:text-orange-300">已退貨・不能取貨</span>
                           : notArrived(it)
                             ? <span className="rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">⏳ 未到貨・不能取貨</span>
-                            : orderItemStatusLabel(it.status)}
+                            : zeroPrice(it)
+                              ? <span className="rounded bg-red-100 px-1.5 py-0.5 font-medium text-red-700 dark:bg-red-950 dark:text-red-300">⚠️ 未填金額・不能取貨</span>
+                              : orderItemStatusLabel(it.status)}
                       </td>
                     </tr>
                   );

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -386,6 +386,20 @@ const RULES: Rule[] = [
       `無法復原：本會員目前的${m[1]}只有 ${fmt(m[2])}，少於當初併入的 ${fmt(m[3])}，扣回去會變負數。`
       + `請先確認這筆${m[1]}的去向並手動調整後再復原。`,
   },
+  // ===== 零元守衛（rpc_record_pickup / rpc_fill_zero_order_item_price） =====
+  {
+    // 訊息本體已是中文（「品項「X」的單價是 $0…」），只把機器前綴拿掉
+    pattern: /^zero_price(?:_fill)?:\s*([\s\S]+)$/i,
+    render: (m) => m[1],
+  },
+  {
+    // _check_order_edit_notes_perm 的拒絕訊息（補填金額沿用它做權限判斷，
+    // 所以字面上會寫「edit notes」）— 對店員講清楚是「不是你們店的單」
+    pattern: /permission denied: role=(\S+) stores=\{([^}]*)\} cannot edit notes of order/i,
+    render: (m) =>
+      `這張訂單不屬於你的店（你的帳號是 ${m[1]}，可操作：${m[2] || "未設定"}），無法修改。`
+      + `請由該店的帳號操作，或請總部處理。`,
+  },
   // ===== 店家守衛（rpc_record_pickup / rpc_bind_store_line_follower） =====
   {
     // 訊息本體已是中文（如「此訂單的取貨店是「三峽店」…」），只把機器前綴拿掉

--- a/supabase/migrations/20260815000000_zero_price_order_guard.sql
+++ b/supabase/migrations/20260815000000_zero_price_order_guard.sql
@@ -1,0 +1,517 @@
+-- ============================================================================
+-- 2026-08-15: $0 品項（漏填金額）— 訂單頁標示 + 取貨擋下 + 分店可補填
+--
+-- 需求：「訂單頁上面顯示現在有哪些訂單是 0 元，提醒店家漏填金額了，並在要取貨
+--        的時候擋下裡面有零元品項的訂單」。
+--
+-- 現況（線上實測 2026-08-15）：
+--   customer_order_items.unit_price = 0 且 status 未取消 → 233 列 / 194 張單。
+--   其中 111 列已經 picked_up（貨白送了），96 列還在 confirmed/ready/shipping
+--   等著被取走。來源 228 列是 source='manual'（小幫手代 key），notes 全為 NULL
+--   —— 沒有任何一列是「刻意的贈品」，全部是開團時 campaign_items.unit_price
+--   漏填（線上 45 個 campaign_item 單價是 0，含 8/17 才結單的進行中團）。
+--
+--   例外只有一種：members.member_type = 'store_internal' 的 RR- /【內部】xx 店
+--   /OV- 容器單。那是店端現貨池的掛帳帳本，`_grow_internal_pool` 找不到
+--   branch/retail 價時本來就會寫 0（見 20260814010000），轉單給真會員時
+--   `rpc_transfer_order_partial` 會改鎖當下現售價 → 池子的 0 不會流到客人身上。
+--   本次三段程式一律排除它，否則現貨池會整批被標紅 + 擋住。
+--
+-- 本次三段：
+--   1. v_admin_orders_list + zero_price_lines（/orders 列表的紅標與「只看 $0」
+--      伺服端篩選都靠它；PostgREST 直接 .gt("zero_price_lines", 0)）
+--   2. rpc_record_pickup 加零元守衛 —— 取貨＝收錢，$0 收不到錢，擋在扣庫存之前
+--   3. rpc_fill_zero_order_item_price —— 分店把 0 補成正數的唯一入口
+--
+-- ⚠ 為什麼一定要有第 3 段（CLAUDE.md「拿掉入口前先確認有人推得動」）：
+--   改單價的 rpc_update_order_item_price 走 _check_order_edit_perm，它認的是
+--   app_metadata.store_id，而線上 33 個分店帳號一個都沒有 store_id（店歸屬存在
+--   app_metadata.stores 店名陣列，見 20260808000020）→ 店長/店員改單價一律
+--   permission denied，前端 OrderDetail 的 canEdit 也只放 HQ / 總倉。
+--   只加第 2 段的話，櫃台會變成「客人站在面前、按鈕按不下去、自己又改不了價」，
+--   只能打電話找總部 —— 或更糟，改走轉單開一張新單（重複單）。
+--   所以另開一支窄口徑 RPC：只能 0 → 正數、只能動未取品項，權限沿用備註那套
+--   （_check_order_edit_notes_perm：HQ / 總倉 / 自店），不等於開放改價。
+--
+-- 基底版本（append-only，逐字保留所有 prior fix）：
+--   - v_admin_orders_list：20260808000010_payable_exclude_cancelled_items.sql
+--     （逐字保留，只在 LATERAL 加一個 count FILTER + 外層加一個 CASE 欄）
+--   - rpc_record_pickup：20260813000000_pickup_store_guard.sql
+--     （逐字保留，只在店家守衛後面插入零元守衛）
+--
+-- Rollback：
+--   - 重跑 20260808000010 的 v_admin_orders_list 段落（少一欄，前端 .gt 會 400，
+--     要連同前端一起回退）
+--   - 重跑 20260813000000 的 rpc_record_pickup 段落（移除零元守衛）
+--   - DROP FUNCTION public.rpc_fill_zero_order_item_price(BIGINT,BIGINT,NUMERIC,UUID,TEXT)
+--
+-- 對應前端（同一個 commit）：
+--   - apps/admin/src/app/(protected)/orders/page.tsx（$0 提示條 + 只看 $0 篩選 + 列上紅標）
+--   - apps/admin/src/app/(protected)/pickup/page.tsx（擋下取貨 + 櫃台補填金額）
+--   - apps/admin/src/components/PickupDialog.tsx（$0 品項不可勾）
+--   - apps/admin/src/lib/rpcError.ts（zero_price: 前綴中文化）
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. v_admin_orders_list v3 — 加 zero_price_lines（$0 品項行數）
+--    基底 20260808000010 逐字保留，只多一個彙總欄
+-- ----------------------------------------------------------------------------
+
+DROP VIEW IF EXISTS v_admin_orders_list;
+
+CREATE VIEW v_admin_orders_list
+WITH (security_invoker = true) AS
+SELECT
+  o.*,
+  c.name AS campaign_name,
+  COALESCE(m.name, o.nickname_snapshot) AS member_name,
+  s.name AS store_name,
+  agg.line_count,
+  agg.total_qty,
+  agg.total_amount,
+  agg.source_summary,
+  -- 20260815000000：$0 品項行數（可能漏填金額）。store_internal 的容器單一律 0
+  -- —— 池子單價本來就可能是 0，標紅只會製造雜訊（見檔頭）。
+  CASE WHEN COALESCE(m.member_type, '') = 'store_internal' THEN 0
+       ELSE agg.zero_price_lines END       AS zero_price_lines
+FROM v_admin_orders o
+LEFT JOIN group_buy_campaigns c ON c.id = o.campaign_id
+LEFT JOIN members m ON m.id = o.member_id
+LEFT JOIN stores s ON s.id = o.pickup_store_id
+LEFT JOIN LATERAL (
+  SELECT
+    count(*)::int                          AS line_count,
+    COALESCE(sum(i.qty), 0)                AS total_qty,
+    COALESCE(sum(i.qty * i.unit_price), 0) AS total_amount,
+    CASE WHEN count(DISTINCT i.source) > 1 THEN 'mixed'
+         ELSE min(i.source) END            AS source_summary,
+    count(*) FILTER (WHERE COALESCE(i.unit_price, 0) = 0)::int AS zero_price_lines
+  FROM customer_order_items i
+  WHERE i.order_id = o.id
+    -- 20260808000010：已取消 / 斷貨的品項不算進項數 / 件數 / 金額
+    AND i.status NOT IN ('cancelled','expired')
+) agg ON true;
+
+COMMENT ON VIEW v_admin_orders_list IS
+  '/orders 列表查詢用：v_admin_orders + 可排序欄位（campaign_name / member_name / '
+  'store_name / line_count / total_qty / total_amount / source_summary）。'
+  '只給列表 + 選取全部用；tab 數量與趨勢的 rpc_order_overview 維持查 v_admin_orders，'
+  '避免整表聚合時多揹 per-row 品項彙總。'
+  '20260808000010：彙總排除 cancelled/expired 品項，與訂單明細的應收同一套語意。'
+  '20260815000000：zero_price_lines = 單價 $0 的品項行數（漏填金額提示 / 「只看 $0」'
+  '伺服端篩選）；store_internal 容器單恆為 0。';
+
+GRANT SELECT ON v_admin_orders_list TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 2. rpc_record_pickup — 加零元守衛
+--    基底 20260813000000 逐字保留，只在店家守衛之後插入零元守衛
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_record_pickup(
+  p_order_id  bigint,
+  p_item_ids  bigint[],
+  p_operator  uuid,
+  p_notes     text  DEFAULT NULL,
+  p_item_qtys jsonb DEFAULT NULL   -- {"<item_id>": <取貨數量>}；缺項或 >=qty 視為整行取
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_pickup_loc       BIGINT;
+  v_item             RECORD;
+  v_ret_guard        RECORD;
+  v_take             NUMERIC;
+  v_picked_disc      NUMERIC;
+  v_movement_id      BIGINT;
+  v_new_item_id      BIGINT;
+  v_picked_item_id   BIGINT;
+  v_picked_count     INT := 0;
+  v_event_item_ids   BIGINT[] := ARRAY[]::BIGINT[];
+  v_active_remaining INT;
+  v_new_status       TEXT;
+  v_event_type       TEXT;
+  v_event_id         BIGINT;
+  v_sku_label        TEXT;
+  v_now              TIMESTAMPTZ := NOW();
+  -- 店家守衛（2026-08-13）
+  v_jwt_role          TEXT  := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_my_stores         JSONB := COALESCE(auth.jwt() -> 'app_metadata' -> 'stores', '[]'::jsonb);
+  v_pickup_store_name TEXT;
+  -- 零元守衛（2026-08-15）
+  v_is_internal_pool  BOOLEAN;
+  v_zero_labels       TEXT[] := ARRAY[]::TEXT[];
+BEGIN
+  IF p_item_ids IS NULL OR array_length(p_item_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_item_ids is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_pickup:' || p_order_id::text));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION '找不到訂單 %', p_order_id;
+  END IF;
+
+  IF v_order.status IN ('completed','expired','cancelled','transferred_out') THEN
+    RAISE EXCEPTION '訂單 % 目前狀態為「%」，無法取貨', p_order_id, v_order.status;
+  END IF;
+
+  -- 店家守衛：分店角色只能替「自己店」的訂單取貨。庫存跟著 pickup_store_id
+  -- 的 location 扣，跨店按取貨會扣到別店的帳、客人也拿不到貨。
+  -- stores 為空（未設定的 legacy 帳號）或含「總倉」不鎖，對齊前端判定。
+  IF v_jwt_role IN ('store_manager','store_staff')
+     AND jsonb_typeof(v_my_stores) = 'array'
+     AND jsonb_array_length(v_my_stores) > 0
+     AND NOT (v_my_stores ? '總倉') THEN
+    SELECT s.name INTO v_pickup_store_name
+      FROM stores s
+     WHERE s.id = v_order.pickup_store_id
+       AND s.tenant_id = v_order.tenant_id;
+    IF v_pickup_store_name IS NULL OR NOT (v_my_stores ? v_pickup_store_name) THEN
+      RAISE EXCEPTION 'wrong_store: 此訂單的取貨店是「%」，分店帳號只能替自己店的訂單取貨，請由該店操作或先轉單',
+        COALESCE(v_pickup_store_name, '未設定');
+    END IF;
+  END IF;
+
+  -- 零元守衛（2026-08-15）：本次要取的品項若單價是 $0，代表開團 / 代 key 時
+  -- 漏填金額 —— 取貨就是收錢的那一刻，放行等於把貨白送出去（線上已經這樣送掉
+  -- 111 列）。擋在扣庫存之前，補填金額後即可重取。
+  -- 例外：【內部】xx 店 / RR- / OV- 容器單（member_type='store_internal'）的
+  -- 池子單價本來就可能是 0，不是漏填。
+  SELECT EXISTS (
+    SELECT 1 FROM members mb
+     WHERE mb.id = v_order.member_id
+       AND mb.tenant_id = v_order.tenant_id
+       AND mb.member_type = 'store_internal'
+  ) INTO v_is_internal_pool;
+
+  IF NOT v_is_internal_pool THEN
+    SELECT array_agg(COALESCE(sk.variant_name, sk.product_name, sk.sku_code, coi.id::text)
+                     ORDER BY coi.id)
+      INTO v_zero_labels
+      FROM customer_order_items coi
+      LEFT JOIN skus sk ON sk.id = coi.sku_id
+     WHERE coi.id = ANY(p_item_ids)
+       AND coi.order_id = p_order_id
+       AND coi.status IN ('pending','reserved','ready')
+       AND COALESCE(coi.unit_price, 0) = 0;
+
+    IF v_zero_labels IS NOT NULL AND array_length(v_zero_labels, 1) > 0 THEN
+      RAISE EXCEPTION 'zero_price: 品項「%」的單價是 $0，看起來是開團時漏填金額。請先補上金額再取貨（取貨頁該品項旁可直接補填，或到訂單明細改單價）',
+        array_to_string(v_zero_labels, '」、「');
+    END IF;
+  END IF;
+
+  SELECT location_id INTO v_pickup_loc
+    FROM stores
+   WHERE id = v_order.pickup_store_id;
+
+  IF v_pickup_loc IS NULL THEN
+    RAISE EXCEPTION '分店 % 未設定倉庫位置 (location_id)、無法寫 stock_movement', v_order.pickup_store_id;
+  END IF;
+
+  -- 退貨守門：同 SKU「本次取貨量」不得超過「active 品項量 − 未取退貨量」。
+  -- 未取退貨（return_to_hq、notes header 不含 |取貨後退回）的貨已離店，
+  -- 不能再被結帳；取貨後退回不計入（那批貨的錢在取貨時已收）。
+  -- 前端 PickupDialog 有同款防線，但畫面 stale 時會失效，這裡是最後防線。
+  FOR v_ret_guard IN
+    SELECT r.sku_id, r.ret_qty,
+           COALESCE(act.active_qty, 0) AS active_qty,
+           COALESCE(req.take_qty, 0)   AS take_qty
+      FROM (
+        SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+          FROM transfers t
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+         WHERE t.customer_order_id = p_order_id
+           AND t.tenant_id     = v_order.tenant_id
+           AND t.transfer_type = 'return_to_hq'
+           AND t.status IN ('shipped','received')
+           AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+               NOT LIKE '%取貨後退回%'
+         GROUP BY ti.sku_id
+      ) r
+      LEFT JOIN (
+        SELECT coi.sku_id, SUM(coi.qty) AS active_qty
+          FROM customer_order_items coi
+         WHERE coi.order_id = p_order_id
+           AND coi.status IN ('pending','reserved','ready')
+         GROUP BY coi.sku_id
+      ) act ON act.sku_id = r.sku_id
+      LEFT JOIN (
+        -- 本次各 SKU 取貨量（缺項＝整行取；clamp 到行量，超量交給主迴圈報錯）
+        SELECT coi.sku_id,
+               SUM(LEAST(COALESCE((p_item_qtys ->> coi.id::text)::numeric, coi.qty), coi.qty)) AS take_qty
+          FROM customer_order_items coi
+         WHERE coi.id = ANY(p_item_ids)
+           AND coi.order_id = p_order_id
+         GROUP BY coi.sku_id
+      ) req ON req.sku_id = r.sku_id
+     WHERE COALESCE(req.take_qty, 0) > COALESCE(act.active_qty, 0) - r.ret_qty
+  LOOP
+    SELECT COALESCE(s.variant_name, s.product_name, s.sku_code)
+      INTO v_sku_label FROM skus s WHERE s.id = v_ret_guard.sku_id;
+    RAISE EXCEPTION '品項「%」已退貨 % 件，本次最多可取 % 件（畫面資料可能過舊，請重新整理後再取）',
+      COALESCE(v_sku_label, v_ret_guard.sku_id::text),
+      v_ret_guard.ret_qty,
+      GREATEST(v_ret_guard.active_qty - v_ret_guard.ret_qty, 0);
+  END LOOP;
+
+  -- 逐品項：判斷整行取 or 拆行部分取
+  FOR v_item IN
+    SELECT id, sku_id, qty, unit_price, status, source, campaign_item_id,
+           tenant_id, notes, discount_amount, discount_percent, created_by
+      FROM customer_order_items
+     WHERE id = ANY(p_item_ids)
+       AND order_id = p_order_id
+     ORDER BY id
+     FOR UPDATE
+  LOOP
+    IF v_item.status NOT IN ('pending','reserved','ready') THEN
+      RAISE EXCEPTION '品項 % 狀態 % 不可取貨', v_item.id, v_item.status;
+    END IF;
+
+    -- 逐品項到貨擋板（取代舊的整單 is_order_pickup_ready 擋板）：
+    -- 未到貨（該 SKU 分店實收 0）的品項個別擋，已到貨的品項放行先取
+    IF NOT public.is_order_item_pickup_ready(v_item.id) THEN
+      SELECT COALESCE(s.variant_name, s.product_name, s.sku_code)
+        INTO v_sku_label FROM skus s WHERE s.id = v_item.sku_id;
+      RAISE EXCEPTION '品項「%」分店尚未實收到貨，無法取貨（請取消勾選該品項，其餘已到貨品項可先取）',
+        COALESCE(v_sku_label, v_item.sku_id::text);
+    END IF;
+
+    -- 本次取多少：p_item_qtys 指定則用之，否則整行取
+    v_take := COALESCE((p_item_qtys ->> v_item.id::text)::numeric, v_item.qty);
+    IF v_take IS NULL OR v_take <= 0 THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 不合法（須 > 0）', v_item.id, v_take;
+    END IF;
+    IF v_take > v_item.qty THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 超過待取數量 %', v_item.id, v_take, v_item.qty;
+    END IF;
+
+    IF v_take = v_item.qty THEN
+      -- ── 整行取：沿用舊邏輯，直接標 picked_up ──
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_item.id,
+        format('顧客取貨 order=%s item=%s', p_order_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      UPDATE customer_order_items
+         SET status = 'picked_up',
+             pickup_movement_id = v_movement_id,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_item.id;
+    ELSE
+      -- ── 部分取：拆行。新建 picked_up 行，原行扣量留待下次 ──
+      -- line-level 折扣金額按取貨比例分攤，確保兩行小計加總 = 原行
+      v_picked_disc := round(COALESCE(v_item.discount_amount, 0) * v_take / v_item.qty);
+
+      -- 1) 先建 picked_up 行（暫不填 movement，先拿 id）
+      INSERT INTO customer_order_items (
+        tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+        status, source, reserved_movement_id, pickup_movement_id, notes,
+        discount_amount, discount_percent, created_by, updated_by, created_at, updated_at
+      ) VALUES (
+        v_item.tenant_id, p_order_id, v_item.campaign_item_id, v_item.sku_id, v_take, v_item.unit_price,
+        'picked_up', v_item.source, NULL, NULL, v_item.notes,
+        v_picked_disc, v_item.discount_percent, v_item.created_by, p_operator, v_now, v_now
+      ) RETURNING id INTO v_new_item_id;
+
+      -- 2) sale movement 指向新行
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_new_item_id,
+        format('顧客部分取貨 order=%s item=%s (split from %s)', p_order_id, v_new_item_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      -- 3) 回填新行 movement
+      UPDATE customer_order_items
+         SET pickup_movement_id = v_movement_id
+       WHERE id = v_new_item_id;
+
+      -- 4) 原行扣量、保持 active 狀態，剩餘留待下次取
+      UPDATE customer_order_items
+         SET qty = qty - v_take,
+             discount_amount = COALESCE(discount_amount, 0) - v_picked_disc,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_new_item_id;
+    END IF;
+
+    -- event 記錄「被取走」那一行的 id（拆行時是新行）→ 收據查到正確的 qty
+    v_event_item_ids := v_event_item_ids || v_picked_item_id;
+    v_picked_count := v_picked_count + 1;
+  END LOOP;
+
+  IF v_picked_count = 0 THEN
+    RAISE EXCEPTION 'no items picked (check p_item_ids belongs to order %)', p_order_id;
+  END IF;
+
+  -- 重算 order status（剩餘 active 行 → partially_completed；全取完 → completed）。
+  -- 2026-08-01：剩餘 active 量要扣掉「未取退貨」覆蓋 — 已退回總倉的量不會再被
+  -- 取走，若某 SKU 的 active 量全被退貨蓋掉，該 SKU 的殘行不算「待取」。
+  -- 否則部分退貨後取走剩餘可取量（訂5退2取3）會讓訂單永遠卡在 partially_completed。
+  SELECT COUNT(*) INTO v_active_remaining
+    FROM customer_order_items coi
+    JOIN (
+      SELECT act.sku_id
+        FROM (
+          SELECT sku_id, SUM(qty) AS active_qty
+            FROM customer_order_items
+           WHERE order_id = p_order_id
+             AND status IN ('pending','reserved','ready')
+           GROUP BY sku_id
+        ) act
+        LEFT JOIN (
+          SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+            FROM transfers t
+            JOIN transfer_items ti ON ti.transfer_id = t.id
+           WHERE t.customer_order_id = p_order_id
+             AND t.tenant_id     = v_order.tenant_id
+             AND t.transfer_type = 'return_to_hq'
+             AND t.status IN ('shipped','received')
+             AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+                 NOT LIKE '%取貨後退回%'
+           GROUP BY ti.sku_id
+        ) r ON r.sku_id = act.sku_id
+       WHERE act.active_qty - COALESCE(r.ret_qty, 0) > 0
+    ) open_sku ON open_sku.sku_id = coi.sku_id
+   WHERE coi.order_id = p_order_id
+     AND coi.status IN ('pending','reserved','ready');
+
+  IF v_active_remaining = 0 THEN
+    v_new_status := 'completed';
+    v_event_type := 'picked_up';
+  ELSE
+    v_new_status := 'partially_completed';
+    v_event_type := 'partial_pickup';
+  END IF;
+
+  UPDATE customer_orders
+     SET status       = v_new_status,
+         completed_at = CASE WHEN v_new_status = 'completed' THEN v_now ELSE NULL END,
+         updated_by   = p_operator,
+         updated_at   = v_now
+   WHERE id = p_order_id;
+
+  INSERT INTO order_pickup_events (
+    tenant_id, order_id, pickup_store_id, event_type, item_ids, notes, created_by
+  ) VALUES (
+    v_order.tenant_id, p_order_id, v_order.pickup_store_id, v_event_type,
+    to_jsonb(v_event_item_ids), p_notes, p_operator
+  ) RETURNING id INTO v_event_id;
+
+  RETURN jsonb_build_object(
+    'event_id',        v_event_id,
+    'event_type',      v_event_type,
+    'picked_count',    v_picked_count,
+    'active_remaining', v_active_remaining,
+    'new_status',      v_new_status
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) IS
+  '取貨記帳。p_item_qtys={"<item_id>":<取貨數量>} 可指定部分取貨（拆行）。'
+  '到貨擋板為品項層級（is_order_item_pickup_ready）：未到貨品項個別擋、已到貨可先取。'
+  '退貨守門：同 SKU 取貨量不得超過 active 量 − 未取退貨量（取貨後退回不計）。'
+  'active_remaining 排除量已被未取退貨覆蓋的 SKU（退光的殘行不擋 completed）。'
+  '店家守衛：分店角色（store_manager/store_staff，app_metadata.stores 非空且不含總倉）'
+  '只能替自己店（pickup_store_id 店名 ∈ stores）的訂單取貨，否則 raise wrong_store。'
+  '零元守衛（20260815000000）：本次要取的品項單價為 $0 一律 raise zero_price'
+  '（漏填金額 → 取貨等於白送）；member_type=store_internal 的容器單不受限。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 3. rpc_fill_zero_order_item_price — 補填漏填的金額（櫃台可用）
+--    刻意不是「改價」：只允許 0 → 正數、只允許未取品項，
+--    所以權限可以放到自店（沿用備註那套 _check_order_edit_notes_perm）。
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_fill_zero_order_item_price(
+  p_order_id       BIGINT,
+  p_item_id        BIGINT,
+  p_new_unit_price NUMERIC,
+  p_operator       UUID,
+  p_reason         TEXT DEFAULT NULL
+) RETURNS customer_order_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order  customer_orders%ROWTYPE;
+  v_old    NUMERIC;
+  v_status TEXT;
+  v_row    customer_order_items;
+BEGIN
+  -- HQ / 總倉 / 該訂單取貨店（app_metadata.stores 店名比對）
+  v_order := public._check_order_edit_notes_perm(p_order_id);
+
+  IF p_new_unit_price IS NULL OR p_new_unit_price <= 0 THEN
+    RAISE EXCEPTION 'zero_price_fill: 補填金額必須大於 0';
+  END IF;
+
+  SELECT unit_price, status INTO v_old, v_status
+    FROM customer_order_items
+   WHERE id = p_item_id AND order_id = p_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'zero_price_fill: 品項 % 不屬於訂單 %', p_item_id, p_order_id;
+  END IF;
+
+  -- 只補填、不改價：非 0 的單價要改一律走 rpc_update_order_item_price（HQ 權限）
+  IF COALESCE(v_old, 0) <> 0 THEN
+    RAISE EXCEPTION 'zero_price_fill: 此品項單價已是 $%，補填功能只處理 $0 的品項；要改價請洽總部',
+      v_old;
+  END IF;
+
+  -- 已取貨 / 已取消的行不補（那是事後改帳，金額已進收據 / 已結案）
+  IF v_status NOT IN ('pending','reserved','ready') THEN
+    RAISE EXCEPTION 'zero_price_fill: 品項狀態為「%」，只有未取貨的品項可以補填金額', v_status;
+  END IF;
+
+  UPDATE customer_order_items
+     SET unit_price = p_new_unit_price,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE id = p_item_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'item', p_item_id, 'unit_price',
+     to_jsonb(v_old), to_jsonb(p_new_unit_price),
+     COALESCE(NULLIF(p_reason, ''), '補填漏填金額（取貨零元守衛）'), p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_fill_zero_order_item_price(BIGINT, BIGINT, NUMERIC, UUID, TEXT) IS
+  '補填漏填的品項金額：只允許 unit_price 0 → 正數、只允許未取貨品項。'
+  '權限沿用 _check_order_edit_notes_perm（HQ / 總倉 / 自店），讓櫃台被零元守衛擋下時'
+  '自己就能解，不必回頭找總部（分店帳號沒有 app_metadata.store_id，走不了'
+  'rpc_update_order_item_price 的 _check_order_edit_perm）。每次寫一筆 audit log。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_fill_zero_order_item_price(BIGINT, BIGINT, NUMERIC, UUID, TEXT)
+  TO authenticated;


### PR DESCRIPTION
漏填金額的訂單（customer_order_items.unit_price = 0）之前完全沒有提示，
取貨照樣放行 —— 線上已經有 111 列 $0 品項被取走（貨白送），另有 96 列還在
等著被取。抽查 233 列的 notes 全為 NULL，沒有一筆是刻意的贈品，全部是開團時
campaign_items 漏填單價（線上 45 個 campaign_item 單價是 0，含進行中的團）。

/orders：
- v_admin_orders_list 加 zero_price_lines（$0 品項行數），tab 上方出現紅色
  提示條「有 N 張訂單含 $0 品項」，可一鍵「只看這些」（伺服端篩選，跨分頁有效）
- 每一列的總金額下方掛 ⚠️ $0 品項 ×N 紅標

/pickup：
- rpc_record_pickup 加零元守衛：本次要取的品項單價是 $0 就 raise zero_price，
  擋在扣庫存之前
- 取貨頁同步擋下（✅ 取貨 / 一次全取 / 勾選都拿掉該張單），並在品項旁直接
  提供「補填」輸入框；PickupDialog 把 $0 那列鎖住、預設不勾，其餘品項可先取

補填走新的 rpc_fill_zero_order_item_price（只能 0 → 正數、只能動未取品項，
權限沿用 _check_order_edit_notes_perm＝HQ/總倉/自店）。改單價的
rpc_update_order_item_price 認 app_metadata.store_id，而分店帳號一個都沒有
→ 店員改不了價。少了這支，零元守衛會變成「客人在櫃台、按鈕按不下去、自己又
解不了」，只能打電話找總部或改走轉單開新單（重複單）。

例外：member_type='store_internal' 的【內部】xx 店 / RR- / OV- 現貨池容器單，
單價 0 是掛帳用的（_grow_internal_pool 找不到價就寫 0），轉單給客人時才鎖現售價
—— 三段程式一律放行。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012t4dfyX6XVhGT6gjSDgaFb