### PR TITLE
互助訂單可列印出貨單（格式同內部調撥）＋儀表板提醒店家列印

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,6 +375,24 @@ RR- ride-along 單在補貨到店**之前**就存在（單頭 `pending`/`confirm
 在來源訂單頁「✈ 補出貨」），空中轉分支改成委派同一個 helper，
 並加了「已有轉移單就擋下」避免重複出貨。
 
+### 經總倉的互助：Leg-1 身上沒有訂單，別拿單段 transfer 當「這箱貨要去哪」的依據
+
+`rpc_ship_aid_order`（20260510000004）對經總倉的互助拆兩段：
+Leg-1 來源店 → 總倉（`customer_order_id = NULL`、`next_transfer_id` = Leg-2）、
+Leg-2 總倉 → 收貨店（`customer_order_id` = 轉入單）。所以**只看單一 transfer 的
+`customer_order_id` / `dest_location`，Leg-1 會回「沒有訂單、目的地是總倉」** ——
+拿它產生的單據給總倉，紙上永遠看不出這箱貨最後要轉去哪一家店（2026-08-15 店家回報
+「互助沒有列印、貨會掉」就是這個）。而且派貨之前根本還沒有 transfer，來源店裝箱時
+無單可印。
+
+- 要表達「這批互助貨的去向」一律**從 `customer_orders` 出發**（來源店 =
+  `transferred_from_order_id` 那張單的 `pickup_store_id`，收貨店 = 本單的
+  `pickup_store_id`），不要從單段 transfer 反推。互助出貨單 `/transfers/print-aid`
+  就是這樣做的。
+- 真的只有 transfer id 可用時（例：內部調撥列表的列印鈕），
+  `customer_order_id IS NULL` 就往 `next_transfer_id` 追一段再拿訂單。
+- 空中轉（`is_air_transfer`）只有一段、直送收貨店，沒有這個問題。
+
 ### 自由轉貨（rpc_create_free_transfer）已停用
 
 2026-08-14 起不再開放建單：`/wms/transfers` 的「+ 建自由轉貨」與 `/transfers/free`

--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -19,6 +19,8 @@ import { parseWaveId } from "@/components/TransferReceiveModal";
 import RestockDetailModal from "@/components/RestockDetailModal";
 import RestockToPrModal from "@/components/RestockToPrModal";
 import { ORDER_STATUS_LABEL as AID_STATUS_LABEL, type OrderStatus as AidStatus } from "@/lib/orderStatus";
+import { printViaIframe } from "@/lib/printIframe";
+import { withBasePath } from "@/lib/basePath";
 
 // standby(候補)目前只有 restock 來源會用到:pending + standby_at 有值 = 等貨源、先不佔待處理
 type Stage = "pending" | "standby" | "in_transit" | "done" | "rejected";
@@ -2592,6 +2594,7 @@ function MailRow({
     actions = (
       <>
         <AidOrderStatusActions order={{ id: a.id, status: a.status }} onChanged={onAidChanged} />
+        <AidPrintAction order={a} />
         <RowAction variant="neutral" onClick={() => onOpenAidDetail(a.id)}>查看訂單</RowAction>
       </>
     );
@@ -2610,6 +2613,7 @@ function MailRow({
     actions = (
       <>
         <AidOrderStatusActions order={{ id: a.id, status: a.status }} onChanged={onAidChanged} />
+        <AidPrintAction order={a} />
         <RowAction variant="neutral" onClick={() => onOpenAidDetail(a.id)}>查看訂單</RowAction>
       </>
     );
@@ -2695,6 +2699,22 @@ function MailRow({
         <span className="text-[11px] text-zinc-400 sm:text-right">{time}</span>
       </div>
     </div>
+  );
+}
+
+// 互助 / 空中轉的出貨單（隨貨聯 + 出貨店存根聯）。
+// 經總倉的互助拆兩段、Leg-1 身上沒有訂單也看不出最終要送到哪家店（見
+// /transfers/print-aid 檔頭），所以這裡一律用訂單 id 印整條路徑的單。
+function AidPrintAction({ order }: { order: AidRaw }) {
+  if (["cancelled", "expired"].includes(order.status)) return null;
+  return (
+    <RowAction
+      variant="neutral"
+      onClick={() => printViaIframe(withBasePath(`/transfers/print-aid?order_id=${order.id}`))}
+      title="列印互助出貨單（隨貨聯 + 出貨店存根聯）：印出來跟著箱子走，總倉／收貨店照單點收簽名"
+    >
+      🖨 出貨單
+    </RowAction>
   );
 }
 

--- a/apps/admin/src/app/(protected)/page.tsx
+++ b/apps/admin/src/app/(protected)/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import AidShipmentReminder from "@/components/AidShipmentReminder";
 import StoreHeatMap from "@/components/StoreHeatMap";
 import RegionPreferenceSummary from "@/components/RegionPreferenceSummary";
 import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
@@ -181,6 +182,9 @@ export default function Dashboard() {
             {error}
           </div>
         )}
+
+        {/* 一進系統就看得到：本店有互助的貨等著被載走 → 提醒把出貨單印給司機 */}
+        <AidShipmentReminder storeId={storeId ? Number(storeId) : null} />
 
         {pendingCandidates !== null && pendingCandidates > 0 && (
           <Link

--- a/apps/admin/src/app/(protected)/transfers/print-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/print-aid/page.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+// 互助出貨單列印 — 以「互助訂單」為主體（不是單一 transfer）。
+//
+// 為什麼不共用 /transfers/print：
+//   經總倉的互助會拆成兩段（20260510000004 rpc_ship_aid_order）：
+//     Leg-1 來源店 → 總倉（customer_order_id = NULL）
+//     Leg-2 總倉   → 收貨店（customer_order_id = 本單）
+//   Leg-1 身上沒有訂單、目的地寫的是總倉 —— 拿它去印,紙上永遠看不出「這箱貨
+//   最後要去哪一家店」,總倉沒辦法照單轉交（這正是店家反映的痛點）。
+//   而且派貨（rpc_ship_aid_order）之前根本還沒有 transfer,來源店要裝箱時無單可印。
+//   所以這張單一律從 customer_orders 出發,把整條路徑（來源店 →〔總倉〕→ 收貨店）
+//   印在同一張紙上,已建立的 AT- 段號附在下面對帳用。
+//
+// query params:
+//   order_id: 互助訂單 id（必填）
+//   copies:   逗號分隔; 預設 "driver,stub"。可傳 "driver" 只印一份。
+
+import { Fragment, Suspense, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { getSupabase } from "@/lib/supabase";
+import { getTenantName } from "@/lib/tenant";
+import { useAuth } from "@/components/AuthProvider";
+import SpinButton from "@/components/SpinButton";
+
+type SkuRef = { sku_code: string | null; product_name: string | null; variant_name: string | null };
+
+type ItemRow = {
+  id: number;
+  qty: number;
+  status: string;
+  source: string | null;
+  notes: string | null;
+  sku: SkuRef | null;
+};
+
+type OrderHead = {
+  id: number;
+  order_no: string;
+  status: string;
+  is_air_transfer: boolean | null;
+  notes: string | null;
+  created_at: string;
+  shipping_at: string | null;
+  nickname_snapshot: string | null;
+  transferred_from_order_id: number | null;
+  member: { name: string | null; member_no: string; phone: string | null } | null;
+  campaign: { campaign_no: string; name: string } | null;
+  store: { name: string } | null;
+};
+
+type Leg = {
+  id: number;
+  transfer_no: string;
+  status: string;
+  source_name: string;
+  dest_name: string;
+  shipped_at: string | null;
+  received_at: string | null;
+};
+
+type CopyKind = "driver" | "stub";
+
+const COPY_LABEL: Record<CopyKind, string> = {
+  driver: "隨貨聯 (隨箱)",
+  stub: "出貨店存根聯",
+};
+
+const LEG_STATUS_LABEL: Record<string, string> = {
+  draft: "待出貨",
+  confirmed: "已確認",
+  shipped: "已出貨",
+  received: "已收貨",
+  cancelled: "已取消",
+  closed: "已結案",
+};
+
+// 實際會被裝箱寄出的品項（對齊 rpc_ship_aid_order 只出 source='aid_transfer' 的品項）
+const ACTIVE_ITEM_STATUSES = new Set(["pending", "reserved", "ready", "picked_up"]);
+
+export default function AidTransferPrintPage() {
+  return (
+    <Suspense fallback={<div className="p-6 text-sm">載入中…</div>}>
+      <Body />
+    </Suspense>
+  );
+}
+
+function Body() {
+  const sp = useSearchParams();
+  const orderId = Number(sp.get("order_id"));
+  const copiesParam = sp.get("copies") ?? "driver,stub";
+  const copies: CopyKind[] = useMemo(() => {
+    const raw = copiesParam.split(",").map((s) => s.trim()).filter(Boolean);
+    const valid = raw.filter((k): k is CopyKind => k === "driver" || k === "stub");
+    return valid.length > 0 ? valid : ["driver"];
+  }, [copiesParam]);
+
+  const [head, setHead] = useState<OrderHead | null>(null);
+  const [items, setItems] = useState<ItemRow[] | null>(null);
+  const [sourceStore, setSourceStore] = useState<string | null>(null);
+  const [hqName, setHqName] = useState<string | null>(null);
+  const [legs, setLegs] = useState<Leg[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+
+  const paramError = !orderId ? "缺 order_id 參數" : null;
+
+  useEffect(() => {
+    if (paramError) return;
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const [hRes, iRes] = await Promise.all([
+        sb
+          .from("customer_orders")
+          .select(
+            "id, order_no, status, is_air_transfer, notes, created_at, shipping_at, nickname_snapshot, " +
+              "transferred_from_order_id, member:members(name, member_no, phone), " +
+              "campaign:group_buy_campaigns(campaign_no, name), " +
+              "store:stores!customer_orders_pickup_store_id_fkey(name)",
+          )
+          .eq("id", orderId)
+          .maybeSingle(),
+        sb
+          .from("customer_order_items")
+          .select("id, qty, status, source, notes, sku:skus(sku_code, product_name, variant_name)")
+          .eq("order_id", orderId)
+          .order("id"),
+      ]);
+      if (cancelled) return;
+      if (hRes.error || !hRes.data) { setErr(hRes.error?.message ?? "找不到此訂單"); return; }
+      const h = hRes.data as unknown as OrderHead;
+      setHead(h);
+
+      const allItems = (iRes.data ?? []) as unknown as ItemRow[];
+      const active = allItems.filter((it) => ACTIVE_ITEM_STATUSES.has(it.status));
+      // 互助品項一律是 source='aid_transfer'；混到別的來源（同一張單後來又加了團購品項）
+      // 時只印互助那些 —— 出貨店裝箱時不該把不屬於這次互助的貨也寄出去。
+      const aidItems = active.filter((it) => it.source === "aid_transfer");
+      setItems(aidItems.length > 0 ? aidItems : active);
+
+      // 來源店（貨從哪一家出去）
+      if (h.transferred_from_order_id != null) {
+        const { data: srcRow } = await sb
+          .from("customer_orders")
+          .select("store:stores!customer_orders_pickup_store_id_fkey(name)")
+          .eq("id", h.transferred_from_order_id)
+          .maybeSingle();
+        if (cancelled) return;
+        const st = (srcRow as unknown as { store: { name: string } | { name: string }[] | null } | null)?.store;
+        setSourceStore((Array.isArray(st) ? st[0]?.name : st?.name) ?? null);
+      }
+
+      // 轉移單段：Leg-2（掛本單）+ 反查 Leg-1（next_transfer_id 指向 Leg-2）
+      const cols = "id, transfer_no, status, source_location, dest_location, next_transfer_id, shipped_at, received_at";
+      const { data: tailRows } = await sb.from("transfers").select(cols).eq("customer_order_id", orderId);
+      if (cancelled) return;
+      type Raw = {
+        id: number; transfer_no: string; status: string;
+        source_location: number; dest_location: number;
+        next_transfer_id: number | null; shipped_at: string | null; received_at: string | null;
+      };
+      const tail = (tailRows ?? []) as unknown as Raw[];
+      let chain: Raw[] = tail;
+      if (tail.length > 0) {
+        const { data: prevRows } = await sb
+          .from("transfers")
+          .select(cols)
+          .in("next_transfer_id", tail.map((t) => t.id));
+        if (cancelled) return;
+        chain = [...((prevRows ?? []) as unknown as Raw[]), ...tail];
+      }
+
+      const locIds = Array.from(new Set(chain.flatMap((t) => [t.source_location, t.dest_location])));
+      const locMap = new Map<number, string>();
+      if (locIds.length > 0) {
+        const { data: locRows } = await sb.from("locations").select("id, name").in("id", locIds);
+        if (cancelled) return;
+        for (const l of (locRows ?? []) as { id: number; name: string }[]) locMap.set(l.id, l.name);
+      }
+      setLegs(
+        chain.map((t) => ({
+          id: t.id,
+          transfer_no: t.transfer_no,
+          status: t.status,
+          source_name: locMap.get(t.source_location) ?? `#${t.source_location}`,
+          dest_name: locMap.get(t.dest_location) ?? `#${t.dest_location}`,
+          shipped_at: t.shipped_at,
+          received_at: t.received_at,
+        })),
+      );
+
+      // 經總倉：還沒派貨時沒有 Leg 可以拿總倉名字，直接查一次 location
+      if (!h.is_air_transfer) {
+        const { data: hqRow } = await sb
+          .from("locations")
+          .select("name")
+          .eq("type", "central_warehouse")
+          .eq("is_active", true)
+          .order("id")
+          .limit(1)
+          .maybeSingle();
+        if (cancelled) return;
+        setHqName((hqRow as { name: string } | null)?.name ?? "總倉");
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [orderId, paramError]);
+
+  // PDF 存檔 / 列印對話框預設檔名 → 用訂單號
+  useEffect(() => {
+    if (!head) return;
+    const original = document.title;
+    document.title = head.order_no;
+    return () => { document.title = original; };
+  }, [head]);
+
+  // 資料載入完成 → 自動跳列印
+  useEffect(() => {
+    if (head && items) {
+      const t = setTimeout(() => window.print(), 400);
+      return () => clearTimeout(t);
+    }
+  }, [head, items]);
+
+  if (paramError) return <div className="p-6 text-sm text-red-700">{paramError}</div>;
+  if (err) return <div className="p-6 text-sm text-red-700">{err}</div>;
+  if (!head || !items) return <div className="p-6 text-sm text-zinc-500">載入中…</div>;
+
+  return (
+    <>
+      {/* 80mm 熱感出單機版型（對齊 /transfers/print 的轉貨單） */}
+      <style jsx global>{`
+        @media print {
+          @page { margin: 3mm; size: 80mm auto; }
+          body { background: white !important; }
+          .no-print { display: none !important; }
+          .copy-page { page-break-after: always; }
+          .copy-page:last-child { page-break-after: auto; }
+        }
+        @media screen {
+          body { background: #f0f0f0; }
+          .copy-page { margin-bottom: 24px; }
+        }
+      `}</style>
+      <div className="mx-auto my-4 max-w-[80mm] print:my-0">
+        <div className="no-print mb-3 flex justify-end gap-2">
+          <SpinButton
+            onClick={() => window.print()}
+            className="rounded bg-zinc-900 px-3 py-1 text-xs text-white hover:bg-zinc-700"
+          >
+            🖨️ 再次列印
+          </SpinButton>
+          <SpinButton
+            onClick={() => window.close()}
+            className="rounded border border-zinc-300 px-3 py-1 text-xs hover:bg-zinc-100"
+          >
+            關閉
+          </SpinButton>
+        </div>
+
+        {copies.map((kind, idx) => (
+          <Slip
+            key={`${kind}-${idx}`}
+            kind={kind}
+            head={head}
+            items={items}
+            sourceStore={sourceStore}
+            hqName={hqName}
+            legs={legs}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+function Slip({
+  kind, head, items, sourceStore, hqName, legs,
+}: {
+  kind: CopyKind;
+  head: OrderHead;
+  items: ItemRow[];
+  sourceStore: string | null;
+  hqName: string | null;
+  legs: Leg[];
+}) {
+  const { tenant } = useAuth();
+  const tenantName = tenant?.name ?? getTenantName();
+  const viaHq = !head.is_air_transfer;
+  const destStore = head.store?.name ?? "—";
+  const totalQty = items.reduce((s, it) => s + Number(it.qty ?? 0), 0);
+  const customer = head.member?.name ?? head.nickname_snapshot ?? "—";
+
+  return (
+    <div className="copy-page bg-white p-2 font-mono text-[13px] leading-tight text-black shadow print:shadow-none">
+      <div className="border-b-2 border-black pb-1 text-center">
+        <div className="text-[14px] font-bold">{tenantName}</div>
+        <div className="text-[20px] font-bold">互助出貨單</div>
+        <div className="mt-0.5 flex items-center justify-center gap-2">
+          <span className="inline-block rounded border-2 border-black px-1.5 py-0.5 text-[13px] font-bold">
+            {COPY_LABEL[kind]}
+          </span>
+          <span className="text-[13px] font-bold">{head.order_no}</span>
+        </div>
+      </div>
+
+      {/* 路徑 —— 經總倉時最終收貨店要一眼看得到，總倉才知道要往哪家轉 */}
+      <div className="border-b border-dashed border-black py-1.5">
+        <div className="text-[15px] font-bold">
+          {sourceStore ?? "—"}
+          {viaHq && (
+            <>
+              <span className="font-normal"> → </span>
+              {hqName ?? "總倉"}
+            </>
+          )}
+          <span className="font-normal"> → </span>
+          {destStore}
+        </div>
+        <div className="mt-0.5 border border-black p-1 text-center text-[15px] font-bold">
+          {viaHq ? "經總倉中轉" : "✈ 空中轉直送"} · 收貨店：{destStore}
+        </div>
+        <div className="mt-1 text-[12px]">客人 {customer}</div>
+        {head.campaign && (
+          <div className="text-[12px]">開團 {head.campaign.campaign_no}</div>
+        )}
+        <div className="text-[12px]">
+          建立 {new Date(head.created_at).toLocaleString("zh-TW", { hour12: false })}
+        </div>
+        {head.shipping_at && (
+          <div className="text-[12px]">
+            出貨 {new Date(head.shipping_at).toLocaleString("zh-TW", { hour12: false })}
+          </div>
+        )}
+      </div>
+
+      <table className="w-full border-collapse">
+        <thead>
+          <tr className="border-b border-black text-[12px]">
+            <th className="w-5 py-1 text-left">#</th>
+            <th className="py-1 text-left">品名 / 規格</th>
+            <th className="w-10 py-1 text-right">數量</th>
+            <th className="w-8 py-1 text-center">點收</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.length === 0 ? (
+            <tr><td colSpan={4} className="py-2 text-center text-zinc-500">無明細</td></tr>
+          ) : (
+            items.map((it, idx) => (
+              <Fragment key={it.id}>
+                <tr className="border-b border-dashed border-zinc-400">
+                  <td className="py-1 align-top">{idx + 1}</td>
+                  <td className="py-1 align-top">
+                    <span className="break-words font-bold">{it.sku?.product_name || "—"}</span>
+                    {it.sku?.variant_name && <span className="ml-1">/ {it.sku.variant_name}</span>}
+                    {it.sku?.sku_code && (
+                      <div className="text-[10px] text-zinc-500">{it.sku.sku_code}</div>
+                    )}
+                    {it.notes && <div className="text-[11px] italic">↳ {it.notes}</div>}
+                  </td>
+                  <td className="py-1 text-right align-top font-bold">{Number(it.qty)}</td>
+                  <td className="py-1 text-center align-top text-[15px]">☐</td>
+                </tr>
+              </Fragment>
+            ))
+          )}
+        </tbody>
+        <tfoot>
+          <tr className="border-t-2 border-black font-bold">
+            <td colSpan={2} className="py-1 text-right">合計</td>
+            <td className="py-1 text-right">{totalQty}</td>
+            <td className="py-1 text-center text-[11px]">{items.length} 項</td>
+          </tr>
+        </tfoot>
+      </table>
+
+      {head.notes && (
+        <div className="mt-1.5 border border-black p-1.5 text-[12px]">
+          <span className="font-bold">備註：</span>
+          {head.notes}
+        </div>
+      )}
+
+      {/* 已建立的轉移單段（派貨後才有）— 出了問題時對得回系統單據 */}
+      {legs.length > 0 && (
+        <div className="mt-1.5 text-[11px]">
+          {legs.map((l) => (
+            <div key={l.id}>
+              {l.transfer_no}（{l.source_name}→{l.dest_name}・{LEG_STATUS_LABEL[l.status] ?? l.status}）
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* 簽收欄：經總倉多一格給總倉點收，貨才不會在中轉站不明不白地掉 */}
+      <div className="mt-2 space-y-2 text-[12px]">
+        {viaHq && (
+          <div className="border border-black p-1.5">
+            <div className="font-bold">{hqName ?? "總倉"}點收</div>
+            <div className="mt-3 border-b border-black" />
+            <div className="mt-0.5 text-[10px] text-zinc-500">簽名 / 日期</div>
+          </div>
+        )}
+        <div className="border border-black p-1.5">
+          <div className="font-bold">{destStore} 收貨簽收</div>
+          <div className="mt-3 border-b border-black" />
+          <div className="mt-0.5 text-[10px] text-zinc-500">簽名 / 日期（收到後請在「收貨」頁點收）</div>
+        </div>
+      </div>
+
+      <div className="mt-1 text-right text-[10px] text-zinc-500">
+        列印時間 {new Date().toLocaleString("zh-TW", { hour12: false })}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(protected)/transfers/print-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/print-aid/page.tsx
@@ -61,9 +61,11 @@ type Leg = {
 
 type CopyKind = "driver" | "stub";
 
+// 版型 / 聯別一律對齊內部調撥的轉貨單（/transfers/print）—— 店家兩種單都在同一台
+// 出單機印、同一疊紙歸檔，格式不一樣就會被當成兩種單據。
 const COPY_LABEL: Record<CopyKind, string> = {
-  driver: "隨貨聯 (隨箱)",
-  stub: "出貨店存根聯",
+  driver: "司機聯 (隨貨)",
+  stub: "店家存根聯",
 };
 
 const LEG_STATUS_LABEL: Record<string, string> = {
@@ -339,14 +341,15 @@ function Slip({
         <thead>
           <tr className="border-b border-black text-[12px]">
             <th className="w-5 py-1 text-left">#</th>
-            <th className="py-1 text-left">品名 / 規格</th>
-            <th className="w-10 py-1 text-right">數量</th>
+            <th className="py-1 text-left">品名 / 描述</th>
+            <th className="w-9 py-1 text-right">應出</th>
+            <th className="w-9 py-1 text-right">實出</th>
             <th className="w-8 py-1 text-center">點收</th>
           </tr>
         </thead>
         <tbody>
           {items.length === 0 ? (
-            <tr><td colSpan={4} className="py-2 text-center text-zinc-500">無明細</td></tr>
+            <tr><td colSpan={5} className="py-2 text-center text-zinc-500">無明細</td></tr>
           ) : (
             items.map((it, idx) => (
               <Fragment key={it.id}>
@@ -360,6 +363,8 @@ function Slip({
                     )}
                     {it.notes && <div className="text-[11px] italic">↳ {it.notes}</div>}
                   </td>
+                  {/* 訂單品項只有一個數量欄；應出＝實出，跟轉貨單同欄位好對帳 */}
+                  <td className="py-1 text-right align-top">{Number(it.qty)}</td>
                   <td className="py-1 text-right align-top font-bold">{Number(it.qty)}</td>
                   <td className="py-1 text-center align-top text-[15px]">☐</td>
                 </tr>
@@ -370,6 +375,7 @@ function Slip({
         <tfoot>
           <tr className="border-t-2 border-black font-bold">
             <td colSpan={2} className="py-1 text-right">合計</td>
+            <td className="py-1 text-right">{totalQty}</td>
             <td className="py-1 text-right">{totalQty}</td>
             <td className="py-1 text-center text-[11px]">{items.length} 項</td>
           </tr>

--- a/apps/admin/src/app/(protected)/transfers/print/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/print/page.tsx
@@ -23,11 +23,23 @@ type Transfer = {
   shipping_temp: string | null;
   is_air_transfer: boolean | null;
   customer_order_id: number | null;
+  next_transfer_id: number | null;
   shipped_at: string | null;
   received_at: string | null;
   created_at: string;
   source_name: string;
   dest_name: string;
+};
+
+// 掛在這張調撥單上的顧客訂單（互助 AT- 單才有）。
+// 經總倉的互助會拆兩段（rpc_ship_aid_order）：Leg-1（來源店→總倉）身上是
+// customer_order_id = NULL，訂單掛在 next_transfer_id 指到的 Leg-2 上 ——
+// 只印本段的話，總倉手上那張紙看不出貨最後要送去哪一家店（正是店家回報的痛點），
+// 所以這裡往後追一段，把最終收貨店印出來。
+type LinkedOrder = {
+  order_no: string;
+  store_name: string | null;
+  via_next_leg: boolean;
 };
 
 type Item = {
@@ -84,6 +96,7 @@ function Body() {
 
   const [tx, setTx] = useState<Transfer | null>(null);
   const [items, setItems] = useState<Item[] | null>(null);
+  const [linkedOrder, setLinkedOrder] = useState<LinkedOrder | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
   const paramError = !transferId ? "缺 transfer_id 參數" : null;
@@ -97,7 +110,7 @@ function Body() {
         .from("transfers")
         .select(
           "id, transfer_no, source_location, dest_location, status, transfer_type, notes, " +
-            "shipping_temp, is_air_transfer, customer_order_id, shipped_at, received_at, created_at"
+            "shipping_temp, is_air_transfer, customer_order_id, next_transfer_id, shipped_at, received_at, created_at"
         )
         .eq("id", transferId)
         .maybeSingle();
@@ -169,6 +182,39 @@ function Body() {
         };
       });
 
+      // 掛著的顧客訂單：本段沒有就往 next_transfer_id 追一段（經總倉的互助 Leg-1）。
+      // 一定要在 setTx 之前解完 —— 資料到齊就會自動跳列印，晚一步紙上就少一行。
+      let orderId = t.customer_order_id;
+      let viaNextLeg = false;
+      if (orderId == null && t.next_transfer_id != null) {
+        const { data: nextRow } = await sb
+          .from("transfers")
+          .select("customer_order_id")
+          .eq("id", t.next_transfer_id)
+          .maybeSingle();
+        if (cancelled) return;
+        orderId = (nextRow as { customer_order_id: number | null } | null)?.customer_order_id ?? null;
+        viaNextLeg = orderId != null;
+      }
+      if (orderId != null) {
+        const { data: ordRow } = await sb
+          .from("customer_orders")
+          .select("order_no, store:stores!customer_orders_pickup_store_id_fkey(name)")
+          .eq("id", orderId)
+          .maybeSingle();
+        if (cancelled) return;
+        const ord = ordRow as unknown as
+          { order_no: string; store: { name: string } | { name: string }[] | null } | null;
+        if (ord) {
+          const st = ord.store;
+          setLinkedOrder({
+            order_no: ord.order_no,
+            store_name: (Array.isArray(st) ? st[0]?.name : st?.name) ?? null,
+            via_next_leg: viaNextLeg,
+          });
+        }
+      }
+
       if (!cancelled) {
         setTx({
           ...t,
@@ -234,14 +280,16 @@ function Body() {
         </div>
 
         {copies.map((kind, idx) => (
-          <Slip key={`${kind}-${idx}`} kind={kind} tx={tx} items={items} />
+          <Slip key={`${kind}-${idx}`} kind={kind} tx={tx} items={items} linkedOrder={linkedOrder} />
         ))}
       </div>
     </>
   );
 }
 
-function Slip({ kind, tx, items }: { kind: CopyKind; tx: Transfer; items: Item[] }) {
+function Slip({ kind, tx, items, linkedOrder }: {
+  kind: CopyKind; tx: Transfer; items: Item[]; linkedOrder: LinkedOrder | null;
+}) {
   const { tenant } = useAuth();
   const tenantName = tenant?.name ?? getTenantName();
   const typeLabel = TYPE_LABEL[tx.transfer_type] ?? tx.transfer_type;
@@ -277,8 +325,21 @@ function Slip({ kind, tx, items }: { kind: CopyKind; tx: Transfer; items: Item[]
             出貨 {new Date(tx.shipped_at).toLocaleString("zh-TW", { hour12: false })}
           </div>
         )}
-        {tx.customer_order_id != null && (
-          <div className="text-[12px]">關聯訂單 #{tx.customer_order_id}</div>
+        {linkedOrder ? (
+          <>
+            <div className="text-[12px]">關聯訂單 {linkedOrder.order_no}</div>
+            {/* 這一段的目的地不是最終收貨店（互助 Leg-1 只到總倉）→ 把最終收貨店框起來，
+                總倉才知道這箱貨要再轉給誰 */}
+            {linkedOrder.store_name && linkedOrder.via_next_leg && (
+              <div className="mt-0.5 border border-black p-1 text-center text-[15px] font-bold">
+                最終收貨店：{linkedOrder.store_name}
+              </div>
+            )}
+          </>
+        ) : (
+          tx.customer_order_id != null && (
+            <div className="text-[12px]">關聯訂單 #{tx.customer_order_id}</div>
+          )
         )}
       </div>
 

--- a/apps/admin/src/components/AidShipmentReminder.tsx
+++ b/apps/admin/src/components/AidShipmentReminder.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+// 儀表板提醒：本店有互助的貨要交出去，提醒店家把出貨單印出來給司機。
+//
+// 為什麼要主動提醒：互助的貨是「別人來拿」，出貨動作不像取貨那樣有客人站在櫃檯催。
+// 店家不知道自己名下有貨等著被載走，就不會去印單 —— 司機來了拿了貨、紙上什麼都沒有，
+// 中途少一箱沒人說得清（2026-08-15 店家回報）。
+//
+// 判定：轉入單（互助單）還沒被收貨店收掉（confirmed / shipping），而它的來源單是本店。
+//   - confirmed = 還沒派貨（經總倉的互助等總倉派）
+//   - shipping  = 已建 AT- 轉移單，但收貨店還沒收 → 貨可能還在店裡等司機
+//   收貨店收掉就變 ready，提醒自動消失。
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { getSupabase } from "@/lib/supabase";
+import SpinButton from "@/components/SpinButton";
+import { printViaIframe } from "@/lib/printIframe";
+import { withBasePath } from "@/lib/basePath";
+
+type PendingShip = {
+  id: number;
+  order_no: string;
+  status: string;
+  is_air_transfer: boolean;
+  dest_store: string;
+  source_store: string;
+  qty: number;
+};
+
+const PRINTED_KEY = "aid_ship_printed_v1";
+
+function loadPrinted(): Set<number> {
+  try {
+    const raw = localStorage.getItem(PRINTED_KEY);
+    const arr = raw ? (JSON.parse(raw) as unknown) : [];
+    return new Set(Array.isArray(arr) ? arr.map(Number).filter(Number.isFinite) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+export default function AidShipmentReminder({ storeId }: { storeId: number | null }) {
+  const [rows, setRows] = useState<PendingShip[] | null>(null);
+  // rows 還沒載完（含 SSR）時整個元件回 null，所以這裡讀 localStorage 不會有 hydration 落差
+  const [printed, setPrinted] = useState<Set<number>>(
+    () => (typeof window === "undefined" ? new Set<number>() : loadPrinted()),
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        // 還沒被收貨店收掉的互助轉入單（全 tenant，數量很少）
+        const { data } = await sb
+          .from("customer_orders")
+          .select(
+            "id, order_no, status, is_air_transfer, pickup_store_id, transferred_from_order_id, created_at, " +
+              "store:stores!customer_orders_pickup_store_id_fkey(name), " +
+              "items:customer_order_items!inner(qty, status, source)",
+          )
+          .eq("items.source", "aid_transfer")
+          .in("status", ["confirmed", "shipping"])
+          .not("transferred_from_order_id", "is", null)
+          .order("created_at", { ascending: true })
+          .limit(200);
+        if (cancelled) return;
+        type Raw = {
+          id: number; order_no: string; status: string; is_air_transfer: boolean | null;
+          pickup_store_id: number | null; transferred_from_order_id: number;
+          store: { name: string } | { name: string }[] | null;
+          items: { qty: number; status: string; source: string | null }[] | null;
+        };
+        const raw = (data ?? []) as unknown as Raw[];
+        if (raw.length === 0) { setRows([]); return; }
+
+        // 來源單 → 出貨店（貨從誰手上出去）
+        const srcIds = Array.from(new Set(raw.map((r) => r.transferred_from_order_id)));
+        const { data: srcData } = await sb
+          .from("customer_orders")
+          .select("id, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)")
+          .in("id", srcIds);
+        if (cancelled) return;
+        type SrcRaw = {
+          id: number; pickup_store_id: number | null;
+          store: { name: string } | { name: string }[] | null;
+        };
+        const nameOf = (s: { name: string } | { name: string }[] | null) =>
+          (Array.isArray(s) ? s[0]?.name : s?.name) ?? "—";
+        const srcMap = new Map<number, SrcRaw>(
+          ((srcData ?? []) as unknown as SrcRaw[]).map((s) => [s.id, s]),
+        );
+
+        const list = raw.flatMap((r): PendingShip[] => {
+          const src = srcMap.get(r.transferred_from_order_id);
+          if (!src) return [];
+          // 同店轉單（只是換客人）貨沒離開本店，不用出貨也不用印
+          if (src.pickup_store_id === r.pickup_store_id) return [];
+          // 儀表板選了門市（分店帳號一律鎖自己那家）→ 只提醒「要出貨的是本店」
+          if (storeId != null && src.pickup_store_id !== storeId) return [];
+          return [{
+            id: r.id,
+            order_no: r.order_no,
+            status: r.status,
+            is_air_transfer: r.is_air_transfer === true,
+            dest_store: nameOf(r.store),
+            source_store: nameOf(src.store),
+            qty: (r.items ?? [])
+              .filter((it) => !["cancelled", "expired"].includes(it.status))
+              .reduce((s, it) => s + Number(it.qty), 0),
+          }];
+        });
+        setRows(list);
+      } catch {
+        // 提醒失敗不該擋住整個儀表板
+        if (!cancelled) setRows([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [storeId]);
+
+  const markPrinted = useCallback((id: number) => {
+    setPrinted((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      try { localStorage.setItem(PRINTED_KEY, JSON.stringify([...next])); } catch { /* 隱私模式 */ }
+      return next;
+    });
+  }, []);
+
+  if (!rows || rows.length === 0) return null;
+
+  const todo = rows.filter((r) => !printed.has(r.id)).length;
+
+  return (
+    <section className="rounded-md border border-fuchsia-300 bg-fuchsia-50 p-4 dark:border-fuchsia-800 dark:bg-fuchsia-950/40">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-sm font-semibold text-fuchsia-900 dark:text-fuchsia-200">
+          🤝 有 {rows.length} 筆互助的貨要交出去
+          {todo > 0 && <span className="ml-2 font-normal">（{todo} 筆還沒列印）</span>}
+        </h2>
+        <span className="text-xs text-fuchsia-700 dark:text-fuchsia-300">
+          印出來夾在箱子上交給司機；收貨店收貨後這裡就會消失
+        </span>
+      </div>
+      <ul className="mt-3 space-y-2">
+        {rows.map((r) => (
+          <li
+            key={r.id}
+            className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded border border-fuchsia-200 bg-white px-3 py-2 text-sm dark:border-fuchsia-900 dark:bg-zinc-900"
+          >
+            <span className="font-mono text-xs">{r.order_no}</span>
+            <span className="font-medium">
+              {r.source_store} <span className="font-normal text-zinc-400">→</span>{" "}
+              {r.is_air_transfer ? "" : "總倉 → "}
+              {r.dest_store}
+            </span>
+            <span className="text-xs text-zinc-500">{r.qty} 件</span>
+            <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+              {r.is_air_transfer ? "✈ 空中轉直送" : "🏬 經總倉"}
+              {r.status === "confirmed" ? "・等派貨" : "・已出貨待收"}
+            </span>
+            {printed.has(r.id) && (
+              <span className="text-[11px] text-emerald-600 dark:text-emerald-400">✓ 已列印</span>
+            )}
+            <div className="ml-auto flex items-center gap-2">
+              <Link
+                href={`/orders?q=${encodeURIComponent(r.order_no)}`}
+                className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+              >
+                查看訂單
+              </Link>
+              <SpinButton
+                onClick={async () => {
+                  markPrinted(r.id);
+                  await printViaIframe(withBasePath(`/transfers/print-aid?order_id=${r.id}`));
+                }}
+                className="rounded-md border border-fuchsia-400 bg-white px-3 py-1 text-xs font-medium text-fuchsia-700 hover:bg-fuchsia-50 dark:border-fuchsia-700 dark:bg-zinc-900 dark:text-fuchsia-300 dark:hover:bg-fuchsia-950"
+                title="列印互助出貨單（司機聯 + 店家存根聯），格式跟內部調撥的轉貨單一樣"
+              >
+                🖨 列印出貨單
+              </SpinButton>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -97,6 +97,16 @@ type PendingAirShipment = {
   qty: number;
 };
 
+// 從本單互助 / 空中轉出去、貨還在路上的轉入單（給轉出店印出貨單隨貨走）。
+// 跟 PendingAirShipment 不同：不限空中轉、也不限 confirmed —— 經總倉的互助派貨後
+// 是 shipping，那才是最需要印單的時候（總倉要照單把貨轉給收貨店）。
+type OutgoingAidOrder = {
+  id: number;
+  order_no: string;
+  store_name: string;
+  is_air_transfer: boolean;
+};
+
 // 品項狀態標籤（部分取貨會把一行拆成「已取」+「待取」兩行，標籤讓兩者一眼可分）
 function itemStatusBadge(status: string, stockout = false): { label: string; cls: string } | null {
   // 斷貨取消（stockout_at 有值）與一般取消區分顯示
@@ -191,6 +201,8 @@ export function OrderDetail({
   const [staffNames, setStaffNames] = useState<Map<string, string>>(new Map());
   // 本單空中轉出去、還沒出貨的轉入單（舊單補推用；新單轉單時就自動出貨了）
   const [pendingAirOut, setPendingAirOut] = useState<PendingAirShipment[]>([]);
+  // 從本單轉出去、還在路上的互助單（轉出店印出貨單隨貨走）
+  const [outgoingAid, setOutgoingAid] = useState<OutgoingAidOrder[]>([]);
   // 本單自己是空中轉轉入單且還在等出貨時，轉出店店名（給接收店看「在等誰」）
   const [awaitingAirFrom, setAwaitingAirFrom] = useState<string | null>(null);
   // sku_id → 現行分店價（prices scope=branch, effective_to IS NULL）
@@ -262,13 +274,13 @@ export function OrderDetail({
           .select("item_id, pickup_ready")
           .eq("order_id", orderId),
         fetchReprintableEvents([orderId]),
-        // 從本單空中轉出去、還卡在 confirmed 的轉入單（＝自動出貨上線前的舊單）。
-        // 空中轉不經總倉，補推要由轉出店（＝正在看本單的人）按下，否則沒人有入口。
+        // 從本單互助 / 空中轉出去的轉入單。兩個用途：
+        //   1. 還卡在 confirmed 的空中轉 → 「✈ 補出貨」（自動出貨上線前的舊單，
+        //      空中轉不經總倉，補推要由轉出店＝正在看本單的人按下，否則沒人有入口）
+        //   2. 貨還沒交到客人手上的（含經總倉、含已出貨）→ 「🖨 出貨單」隨貨走
         sb.from("customer_orders")
-          .select("id, order_no, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name), items:customer_order_items(qty, status)")
-          .eq("transferred_from_order_id", orderId)
-          .eq("is_air_transfer", true)
-          .eq("status", "confirmed"),
+          .select("id, order_no, pickup_store_id, status, is_air_transfer, store:stores!customer_orders_pickup_store_id_fkey(name), items:customer_order_items(qty, status, source)")
+          .eq("transferred_from_order_id", orderId),
       ]);
       if (cancelled) return;
       if (hRes.error) { setError(hRes.error.message); return; }
@@ -286,25 +298,45 @@ export function OrderDetail({
 
       setPickupEvents(pevRes.get(orderId) ?? []);
 
-      // ========== 待出貨的空中轉（本單 → 其他店）==========
+      // ========== 從本單轉出去的互助 / 空中轉（本單 → 其他店）==========
       type AirRow = {
         id: number; order_no: string; pickup_store_id: number | null;
+        status: string; is_air_transfer: boolean | null;
         store: { name: string } | { name: string }[] | null;
-        items: { qty: number; status: string }[] | null;
+        items: { qty: number; status: string; source: string | null }[] | null;
       };
-      const airRows = ((airRes.data ?? []) as unknown as AirRow[])
-        // 同店空中轉：rpc_ship_aid_order 會以「source/dest 同 location」擋下，不給按
+      const childRows = ((airRes.data ?? []) as unknown as AirRow[])
+        // 同店轉單（換客人）不是出貨，貨沒離開本店；rpc_ship_aid_order 也會以
+        //「source/dest 同 location」擋下 —— 不算互助出貨，兩個用途都不該出現
         .filter((r) => r.pickup_store_id !== headData.pickup_store_id)
-        .map((r): PendingAirShipment => ({
-          id: r.id,
-          order_no: r.order_no,
-          pickup_store_id: r.pickup_store_id,
-          store_name: (Array.isArray(r.store) ? r.store[0]?.name : r.store?.name) ?? "—",
-          qty: (r.items ?? [])
-            .filter((it) => !["cancelled", "expired"].includes(it.status))
-            .reduce((s, it) => s + Number(it.qty), 0),
-        }));
-      setPendingAirOut(airRows);
+        // 互助品項才是真的要寄出去的貨
+        .filter((r) => (r.items ?? []).some((it) => it.source === "aid_transfer"));
+      const storeNameOf = (r: AirRow) =>
+        (Array.isArray(r.store) ? r.store[0]?.name : r.store?.name) ?? "—";
+      setPendingAirOut(
+        childRows
+          .filter((r) => r.is_air_transfer === true && r.status === "confirmed")
+          .map((r): PendingAirShipment => ({
+            id: r.id,
+            order_no: r.order_no,
+            pickup_store_id: r.pickup_store_id,
+            store_name: storeNameOf(r),
+            qty: (r.items ?? [])
+              .filter((it) => !["cancelled", "expired"].includes(it.status))
+              .reduce((s, it) => s + Number(it.qty), 0),
+          })),
+      );
+      // 出貨單入口：貨還在路上（未取貨、未取消）的才印，已完成的舊單不用洗版
+      setOutgoingAid(
+        childRows
+          .filter((r) => ["pending", "confirmed", "shipping", "ready", "partially_completed"].includes(r.status))
+          .map((r): OutgoingAidOrder => ({
+            id: r.id,
+            order_no: r.order_no,
+            store_name: storeNameOf(r),
+            is_air_transfer: r.is_air_transfer === true,
+          })),
+      );
 
       // 本單自己就是等出貨的空中轉轉入單 → 讓接收店看得到在等哪一家出貨
       if (headData.is_air_transfer && headData.status === "confirmed" && headData.transferred_from_order_id) {
@@ -792,13 +824,38 @@ export function OrderDetail({
           </SpinButton>
         </div>
       )}
-      {(canPrintSlip || canReprintReceipt || canTransfer || canPickup || canUndoPickup || canCancel || canReturn || canAidReturn || isTransferredOut || pendingAirOut.length > 0 || awaitingAirFrom) && (
+      {(canPrintSlip || canReprintReceipt || canTransfer || canPickup || canUndoPickup || canCancel || canReturn || canAidReturn || isTransferredOut || pendingAirOut.length > 0 || outgoingAid.length > 0 || awaitingAirFrom) && (
         <div className="flex flex-wrap items-center justify-end gap-2">
           {awaitingAirFrom && (
             <span className="text-xs text-amber-700 dark:text-amber-400">
               ✈ 等 {awaitingAirFrom} 補出貨（出貨後本店在「收貨」頁收貨）
             </span>
           )}
+          {/* 本單是互助轉入單 → 收貨店自己重印一份（單子丟了、要補簽收） */}
+          {isAidOrder && (
+            <SpinButton
+              onClick={() => printViaIframe(withBasePath(`/transfers/print-aid?order_id=${head.id}`))}
+              className="rounded-md border border-fuchsia-300 px-3 py-1 text-xs font-medium text-fuchsia-700 hover:bg-fuchsia-50 dark:border-fuchsia-800 dark:text-fuchsia-300 dark:hover:bg-fuchsia-950"
+              title="列印互助出貨單（隨貨聯 + 出貨店存根聯）"
+            >
+              🖨 互助出貨單
+            </SpinButton>
+          )}
+          {/* 本單把貨互助給別店 → 轉出店裝箱時印一張夾在貨上，
+              經總倉的單上面就寫著最終要送到哪一家店，總倉照單轉交、不會掉 */}
+          {outgoingAid.map((o) => (
+            <SpinButton
+              key={`aid-print-${o.id}`}
+              onClick={() => printViaIframe(withBasePath(`/transfers/print-aid?order_id=${o.id}`))}
+              className="rounded-md border border-fuchsia-300 px-3 py-1 text-xs font-medium text-fuchsia-700 hover:bg-fuchsia-50 dark:border-fuchsia-800 dark:text-fuchsia-300 dark:hover:bg-fuchsia-950"
+              title={
+                `列印互助出貨單（${o.order_no}・${o.is_air_transfer ? "空中轉直送" : "經總倉中轉"}）：` +
+                `隨貨聯夾在箱子上，${o.is_air_transfer ? "" : "總倉、"}${o.store_name}照單點收簽名`
+              }
+            >
+              🖨 出貨單 → {o.store_name}
+            </SpinButton>
+          ))}
           {pendingAirOut.map((s) => (
             <SpinButton
               key={s.id}


### PR DESCRIPTION
店家回報：互助沒有列印，貨在中轉時會掉，總倉也無從確認這箱要轉給哪一家店；內部調撥早就有「列印出貨單」，互助則完全沒有入口。後續補充：要提供貨的那家店要能直接印給司機、格式跟內部調撥一樣，而且有貨等著被拿走時，系統要在一進來就提醒去印。

（互助板「手動現貨可被認領」已拆成獨立 PR #741，本 PR 回到純列印＋提醒，**純前端、不含 migration**。）

## 1. 互助出貨單可以列印（格式同內部調撥）

經總倉的互助被 `rpc_ship_aid_order` 拆兩段 —— Leg-1（來源店 → 總倉）的 `customer_order_id` 是 **NULL**、目的地寫「總倉」，拿它去印看不出最終收貨店；而且派貨之前根本還沒有 transfer，來源店裝箱時無單可印。

新增 `/transfers/print-aid?order_id=`，以訂單為主體印 80mm 熱感單：

- 版型／聯別對齊 `/transfers/print`：「司機聯 (隨貨)」+「店家存根聯」、明細欄位 `# / 品名·描述 / 應出 / 實出 / 點收`
- 互助專屬：整條路徑（出貨店 →〔總倉〕→ 收貨店）、框起來的最終收貨店、總倉點收欄＋收貨店簽收欄
- 只印會裝箱的品項：`source='aid_transfer'` 且未取消／逾期

入口：`/hq/inbox` 互助／空中轉列上「🖨 出貨單」、互助單明細「🖨 互助出貨單」（收貨店補印）、來源訂單明細「🖨 出貨單 → ○○店」（轉出店裝箱時印；連帶把原本只撈「空中轉 + confirmed」的子單查詢放寬成撈全部子單，再各自篩出「✈ 補出貨」與列印兩組）。

順帶修 `/transfers/print`：transfer 沒掛訂單時往 `next_transfer_id` 追一段，關聯訂單改印訂單號（原本印 DB id），Leg-1 上框出「最終收貨店」。

## 2. 一進系統就提醒店家列印（`AidShipmentReminder`）

互助的貨是別人來拿、沒有客人站在櫃檯催，店家不知道自己名下有貨等著被載走就不會去印。儀表板最上方新增提醒卡：

- 判定：互助轉入單 `confirmed`（等派貨）／`shipping`（已建 AT- 單、收貨店還沒收），且來源單的取貨店是本店；收貨店一收（`ready`）自動消失
- 同店轉單（只是換客人）排除；已取消品項不計入件數
- 分店帳號鎖自己那家；總倉選「全部門市」看得到全部，可督促還沒出的店
- 按過列印記在 localStorage 標「✓ 已列印」

## 影響範圍

純前端，**沒有動 DB / migration**，沒有新增或修改任何 RPC。

## 驗證

- `tsc --noEmit`、`next build` 通過（`/transfers/print-aid` 路由已註冊）
- Playwright + fixture（不碰線上 DB）：
  - 經總倉單印出「忠順店 → 總倉 → 松山店」＋總倉點收欄；空中轉單只有收貨店一格；取消品項與非 `aid_transfer` 品項沒被印出來
  - 三個列印入口按鈕都出得來；Leg-1 調撥單印出「關聯訂單 …-TF0007」＋「最終收貨店：松山店」
  - 儀表板提醒：忠順店只看到自己那 2 筆（別店要出的被濾掉）、件數排除取消品項、按列印會標記已列印

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEYrHfptAkTChcBcmzVDPi