### PR TITLE
feat(member): 訂單卡的品項顯示商品縮圖

### DIFF
--- a/apps/member/src/app/shop/c/[id]/CampaignDetailClient.tsx
+++ b/apps/member/src/app/shop/c/[id]/CampaignDetailClient.tsx
@@ -37,6 +37,12 @@ type CampaignDetail = {
   total_cap_qty: number | null;
   /** 總瀏覽次數。後端未部署 track_campaign_view 前可能沒有這個欄位。 */
   view_count?: number;
+  /**
+   * 還能不能下單。false = 已結單 / 已下架，只放行「自己買過這團」的會員回頭看
+   * （從訂單卡點進來的路徑），畫面要收掉所有下單入口。
+   * 舊版後端沒有這個欄位 → undefined，一律當可下單（那時候不可下單的團根本 404）。
+   */
+  available?: boolean;
 };
 
 type Item = {
@@ -127,9 +133,13 @@ export default function CampaignDetailClient() {
 
   // 記一次瀏覽，並拿回含本次的最新計數。
   // 同會員同商品 30 分鐘內在後端去重，所以「返回列表再點進來」不會灌水。
+  //
+  // 已結單的團不記：那些瀏覽是團友回頭看自己的訂單，不是還在考慮要不要買的人，
+  // 記下去會讓「熱門度」被結單後的回訪灌水。
   const trackedRef = useRef<number | null>(null);
   useEffect(() => {
     if (!id || trackedRef.current === id) return;
+    if (!campaign || campaign.available === false) return;
     const s = getSession();
     if (!s || !s.memberId) return;
     trackedRef.current = id;
@@ -146,7 +156,7 @@ export default function CampaignDetailClient() {
         logCaught("track_campaign_view_failed", e, { campaign_id: id });
       }
     })();
-  }, [id]);
+  }, [id, campaign]);
 
   const totalQty = useMemo(
     () => Object.values(qtyMap).reduce((s, n) => s + (n || 0), 0),
@@ -162,6 +172,8 @@ export default function CampaignDetailClient() {
     return sum;
   }, [items, qtyMap]);
 
+  // 已結單 / 已下架的團（只有買過的會員從訂單卡點得進來）：整頁收成唯讀。
+  const readOnly = campaign?.available === false;
   const orderedQtyTotal = items.reduce((s, it) => s + Number(it.ordered_qty ?? 0), 0);
   const campaignRemaining = useMemo(() => {
     const cap = Number(campaign?.total_cap_qty ?? 0);
@@ -259,7 +271,8 @@ export default function CampaignDetailClient() {
 
   return (
     <PageShell title={cleanCampaignText(displayName) || "商品"}>
-      <div className="space-y-4 px-0 pb-[160px]">
+      {/* 唯讀模式沒有常駐下單列，底部不用留它的位置 */}
+      <div className={`space-y-4 px-0 ${readOnly ? "pb-10" : "pb-[160px]"}`}>
         {err && (
           <div className="mx-4 rounded-2xl bg-[#ff3b30]/10 p-3 text-[15px] text-[#c4271d]">
             {err}
@@ -277,7 +290,13 @@ export default function CampaignDetailClient() {
             {/* 封面 carousel — 有 hint 時先顯示列表封面, detail 回來再換成完整圖集 */}
             <div className="relative">
               <HeroCarousel images={heroImageList} />
-              {displayEndAt && (
+              {/* 已結單的團不畫倒數（Countdown 過期會回「已結束」，包在「剩 …」裡
+                  變成「剩 已結束」）；改標一顆狀態膠囊。 */}
+              {readOnly ? (
+                <div className="absolute right-3 top-3 rounded-full bg-black/70 px-3 py-1 text-[14px] font-medium text-white backdrop-blur">
+                  已結單
+                </div>
+              ) : displayEndAt && (
                 <div className="absolute right-3 top-3 rounded-full bg-black/70 px-3 py-1 text-[14px] font-medium text-white backdrop-blur">
                   剩 <Countdown target={displayEndAt} compact className="text-white" />
                 </div>
@@ -301,7 +320,15 @@ export default function CampaignDetailClient() {
                 <ShareButtons url={shareUrl} title={shareTitle} text={shareText} />
               </div>
 
-              {campaignRemaining !== null && (
+              {readOnly && (
+                <div className="rounded-2xl bg-zinc-100 px-4 py-3 text-[15px] text-[var(--secondary-label)]">
+                  本團已結單，這裡只能查看商品內容。
+                  <br />
+                  你的訂單狀態請看「訂單」分頁。
+                </div>
+              )}
+
+              {!readOnly && campaignRemaining !== null && (
                 <div className={`inline-flex rounded-full px-3 py-1 text-[14px] font-semibold ${
                   campaignRemaining > 0
                     ? "bg-[var(--brand-soft)] text-[var(--brand-strong)]"
@@ -346,7 +373,9 @@ export default function CampaignDetailClient() {
                   items.map((it, idx) => {
                     const q = qtyMap[it.campaign_item_id] ?? 0;
                     const remaining = itemRemaining(it);
-                    const soldOut = itemOrderMax(it, campaignRemaining, q) <= 0 && q === 0;
+                    // 唯讀模式（已結單）不談售完 / 剩餘 —— 那是「還能不能買」的語言，
+                    // 團都結了再標「售完」只會讓回頭看訂單的客人以為是自己沒買到。
+                    const soldOut = !readOnly && itemOrderMax(it, campaignRemaining, q) <= 0 && q === 0;
                     return (
                       <div
                         key={it.campaign_item_id}
@@ -373,7 +402,7 @@ export default function CampaignDetailClient() {
                               </div>
                             )}
                           </div>
-                          {remaining !== null && (
+                          {!readOnly && remaining !== null && (
                             <div className={`mt-1 text-[12px] font-semibold ${remaining > 0 ? "text-[#c4271d]" : "text-zinc-500"}`}>
                               {remaining > 0 ? `剩 ${remaining} 份` : "此規格已售完"}
                             </div>
@@ -399,7 +428,7 @@ export default function CampaignDetailClient() {
       </div>
 
       {/* 常駐底部購買列 — portal 到 body，永遠釘在 viewport（蝦皮式，免滑到底）*/}
-      <Portal enabled={mounted && !!campaign && items.length > 0}>
+      <Portal enabled={mounted && !!campaign && items.length > 0 && !readOnly}>
         <div
           className="fixed inset-x-0 bottom-0 z-40 border-t border-[var(--separator)] bg-white/95 backdrop-blur-xl"
           style={{ paddingBottom: "max(env(safe-area-inset-bottom), 10px)" }}

--- a/apps/member/src/app/shop/c/[id]/CampaignDetailClient.tsx
+++ b/apps/member/src/app/shop/c/[id]/CampaignDetailClient.tsx
@@ -11,6 +11,7 @@ import Countdown from "@/components/Countdown";
 import OrderedCount from "@/components/OrderedCount";
 import ViewCount from "@/components/ViewCount";
 import ShareButtons from "@/components/ShareButtons";
+import SkuThumb from "@/components/SkuThumb";
 import { campaignShareUrl } from "@/lib/shareLink";
 import { cleanCampaignText } from "@/lib/text";
 import { getCampaignHint } from "@/lib/campaignHints";
@@ -631,21 +632,6 @@ function ItemSkeleton({ priceText }: { priceText: string | null }) {
         </div>
       ))}
     </>
-  );
-}
-
-function SkuThumb({ url }: { url: string | null }) {
-  if (url) {
-    // eslint-disable-next-line @next/next/no-img-element
-    return <img src={url} alt="" className="h-14 w-14 shrink-0 rounded-xl object-cover" />;
-  }
-  return (
-    <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-[var(--brand-soft)] text-[var(--brand)]">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.4} className="h-6 w-6">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M5 8h14l-1 11a2 2 0 0 1-2 1.8H8A2 2 0 0 1 6 19L5 8Z" />
-        <path strokeLinecap="round" strokeLinejoin="round" d="M9 8V6.5a3 3 0 0 1 6 0V8" />
-      </svg>
-    </div>
   );
 }
 

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -1,4 +1,5 @@
-import { orderCardTitle } from "@/lib/orderTitle";
+import Link from "next/link";
+import { orderCardTitle, isInternalCampaign } from "@/lib/orderTitle";
 import StatusChip from "@/components/StatusChip";
 import SkuThumb from "@/components/SkuThumb";
 
@@ -54,6 +55,8 @@ export type OrderRow = {
   created_at: string;
   /** 內部 sentinel 團判斷用（'__' 開頭）；v_customer_order_summary @20260811000050 */
   campaign_no?: string | null;
+  /** 點品項連到 /shop/c/[id] 用 */
+  campaign_id?: number | null;
   campaign_name: string | null;
   campaign_cover_url: string | null;
   campaign_cutoff_date: string | null;
@@ -221,6 +224,13 @@ export default function OrderCard({
   };
   // 內部 sentinel 團（店內現貨轉手單）印品項名，其餘印開團名稱 —— 見 lib/orderTitle
   const title = orderCardTitle(order);
+  // 點品項 → 開團商品頁。已結單的團也連得過去（liff-api 對「自己買過這團」的會員
+  // 回唯讀版，2026-08-15）—— 線上 97% 的訂單都是已結單的團，不放行等於全是死連結。
+  //
+  // 內部 sentinel 團（【內部】補貨申請、現貨轉手單）不連：那一頁列的是整本內部
+  // 補貨帳，不是客人買的東西。
+  const campaignHref =
+    order.campaign_id && !isInternalCampaign(order) ? `/shop/c/${order.campaign_id}` : null;
   // 分身卡（依分頁拆出來的）右上角要講該分頁的語意，不是整張單的
   const phase = viewPhase
     ? { ...orderPhase(order), ...PHASE_LABEL[viewPhase] }
@@ -275,49 +285,70 @@ export default function OrderCard({
       </header>
 
       <ul className="border-t border-[var(--separator)] px-4">
-        {order.items.map((it, idx) => (
-          <li
-            key={it.id}
-            className={`flex items-start gap-3 py-3 ${
-              idx > 0 ? "border-t border-[var(--separator)]" : ""
-            }`}
-          >
-            {/* 商品沒自己的圖時退到開團封面 —— 團購品項多半只有封面，
-                不退一層的話整張單會是一排購物袋 placeholder。 */}
-            <SkuThumb
-              url={it.image_url ?? order.campaign_cover_url}
-              muted={["cancelled", "expired"].includes(it.status)}
-            />
-            <div className="min-w-0 flex-1">
-              {it.variant_name && (
-                <div className={`text-[16px] ${it.stockout ? "text-[var(--secondary-label)] line-through" : "text-[var(--foreground)]"}`}>
-                  {it.variant_name}
-                  {it.stockout && (
-                    <span className="ml-1.5 inline-block no-underline">
-                      <StatusChip tone="danger" label="斷貨" />
-                    </span>
-                  )}
-                  {pickChip(it) && (
-                    <span className="ml-1.5 inline-block">{pickChip(it)}</span>
-                  )}
+        {order.items.map((it, idx) => {
+          const row = (
+            <>
+              {/* 商品沒自己的圖時退到開團封面 —— 團購品項多半只有封面，
+                  不退一層的話整張單會是一排購物袋 placeholder。 */}
+              <SkuThumb
+                url={it.image_url ?? order.campaign_cover_url}
+                muted={["cancelled", "expired"].includes(it.status)}
+              />
+              <div className="min-w-0 flex-1">
+                {it.variant_name && (
+                  <div className={`text-[16px] ${it.stockout ? "text-[var(--secondary-label)] line-through" : "text-[var(--foreground)]"}`}>
+                    {it.variant_name}
+                    {it.stockout && (
+                      <span className="ml-1.5 inline-block no-underline">
+                        <StatusChip tone="danger" label="斷貨" />
+                      </span>
+                    )}
+                    {pickChip(it) && (
+                      <span className="ml-1.5 inline-block">{pickChip(it)}</span>
+                    )}
+                  </div>
+                )}
+                {!it.variant_name && (it.stockout || pickChip(it)) && (
+                  <div className="flex items-center gap-1.5">
+                    {it.stockout && <StatusChip tone="danger" label="斷貨" />}
+                    {pickChip(it)}
+                  </div>
+                )}
+                <div className="text-[14px] text-[var(--secondary-label)]">
+                  {fmtAmount(it.unit_price)} × {it.qty}
                 </div>
-              )}
-              {!it.variant_name && (it.stockout || pickChip(it)) && (
-                <div className="flex items-center gap-1.5">
-                  {it.stockout && <StatusChip tone="danger" label="斷貨" />}
-                  {pickChip(it)}
-                </div>
-              )}
-              <div className="text-[14px] text-[var(--secondary-label)]">
-                {fmtAmount(it.unit_price)} × {it.qty}
+                {/* it.notes 是內部備註（補貨申請 / 轉單軌跡等），顧客端不顯示 */}
               </div>
-              {/* it.notes 是內部備註（補貨申請 / 轉單軌跡等），顧客端不顯示 */}
-            </div>
-            <div className={`flex-shrink-0 text-right text-[16px] font-medium tabular-nums ${it.stockout ? "text-[var(--secondary-label)] line-through" : "text-[var(--foreground)]"}`}>
-              {fmtAmount(it.subtotal)}
-            </div>
-          </li>
-        ))}
+              <div className={`flex-shrink-0 text-right text-[16px] font-medium tabular-nums ${it.stockout ? "text-[var(--secondary-label)] line-through" : "text-[var(--foreground)]"}`}>
+                {fmtAmount(it.subtotal)}
+              </div>
+              {campaignHref && (
+                <span
+                  aria-hidden
+                  className="mt-0.5 flex-shrink-0 text-[18px] leading-none text-[var(--tertiary-label)]"
+                >
+                  ›
+                </span>
+              )}
+            </>
+          );
+          const cls = `flex items-start gap-3 py-3 ${
+            idx > 0 ? "border-t border-[var(--separator)]" : ""
+          }`;
+          return (
+            <li key={it.id}>
+              {campaignHref ? (
+                // prefetch 關掉：一次畫幾十張卡 = 幾十個 /shop/c/[id] 預抓，
+                // 而那是 dynamic route，每一個都會真的打到伺服器。
+                <Link href={campaignHref} prefetch={false} className={`${cls} active:opacity-60`}>
+                  {row}
+                </Link>
+              ) : (
+                <div className={cls}>{row}</div>
+              )}
+            </li>
+          );
+        })}
       </ul>
 
       {/* order.notes 同為內部備註，顧客端不顯示 */}

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -1,5 +1,6 @@
 import { orderCardTitle } from "@/lib/orderTitle";
 import StatusChip from "@/components/StatusChip";
+import SkuThumb from "@/components/SkuThumb";
 
 export type OrderItem = {
   id: number;
@@ -281,6 +282,12 @@ export default function OrderCard({
               idx > 0 ? "border-t border-[var(--separator)]" : ""
             }`}
           >
+            {/* 商品沒自己的圖時退到開團封面 —— 團購品項多半只有封面，
+                不退一層的話整張單會是一排購物袋 placeholder。 */}
+            <SkuThumb
+              url={it.image_url ?? order.campaign_cover_url}
+              muted={["cancelled", "expired"].includes(it.status)}
+            />
             <div className="min-w-0 flex-1">
               {it.variant_name && (
                 <div className={`text-[16px] ${it.stockout ? "text-[var(--secondary-label)] line-through" : "text-[var(--foreground)]"}`}>

--- a/apps/member/src/components/SkuThumb.tsx
+++ b/apps/member/src/components/SkuThumb.tsx
@@ -1,0 +1,43 @@
+/**
+ * 品項縮圖（商品主圖，沒有就畫購物袋 placeholder）。
+ *
+ * 團購商品常常沒上傳自己的圖，只有開團封面 —— 呼叫端可以用
+ * `url={it.image_url ?? campaign_cover_url}` 退一層，兩張都沒有才會看到 placeholder。
+ * 商品頁與訂單卡共用同一支，placeholder 的樣子才不會各長各的。
+ */
+export default function SkuThumb({
+  url,
+  /** 斷貨 / 已取消的行：跟旁邊的刪除線一起淡掉 */
+  muted = false,
+  className = "h-14 w-14",
+}: {
+  url: string | null;
+  muted?: boolean;
+  className?: string;
+}) {
+  if (url) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={url}
+        alt=""
+        loading="lazy"
+        className={`${className} shrink-0 rounded-xl bg-[var(--brand-soft)]/40 object-cover ${
+          muted ? "opacity-45 grayscale" : ""
+        }`}
+      />
+    );
+  }
+  return (
+    <div
+      className={`${className} flex shrink-0 items-center justify-center rounded-xl bg-[var(--brand-soft)] text-[var(--brand)] ${
+        muted ? "opacity-45 grayscale" : ""
+      }`}
+    >
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.4} className="h-6 w-6">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 8h14l-1 11a2 2 0 0 1-2 1.8H8A2 2 0 0 1 6 19L5 8Z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 8V6.5a3 3 0 0 1 6 0V8" />
+      </svg>
+    </div>
+  );
+}

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -794,7 +794,22 @@ async function listActiveCampaigns(sb: any, tenantId: string, closeType?: string
   return json({ campaigns, pending_pickup_count: pendingPickupCount });
 }
 
-async function getCampaignDetail(sb: any, tenantId: string, campaignId: number) {
+/**
+ * 開團詳細。`available=false` 代表「只能看、不能下單」。
+ *
+ * 為什麼要有唯讀模式：訂單卡的品項點得進商品頁（2026-08-15），而會員的訂單
+ * 絕大多數是**已結單**的團 —— 線上 6 個月內 69,540 張單裡，通過原本那道
+ * 「open + is_for_shop + 還沒到 end_at」閘門的只有 2,114 張（3%）。
+ * 沿用原本無條件 404 的話，等於每 30 張訂單卡有 29 張點下去是死路。
+ *
+ * 放寬的範圍卡在「這位會員自己買過這一團」：沒買過的人（含猜 id 的）
+ * 一律維持 404，未上架 / 內部團不會因此外流。
+ *
+ * 不必擔心唯讀模式被繞過下單：`rpc_place_member_order_guarded`
+ * 自己也擋 status / is_for_shop / end_at（20260813000000），
+ * 寫入端的閘門跟這裡的讀取端閘門是同一套條件。
+ */
+async function getCampaignDetail(sb: any, tenantId: string, campaignId: number, memberId: number | null) {
   const { data: c, error: cErr } = await sb
     .from("group_buy_campaigns")
     .select("id, campaign_no, name, description, cover_image_url, status, close_type, end_at, pickup_deadline, total_cap_qty, is_for_shop")
@@ -802,9 +817,22 @@ async function getCampaignDetail(sb: any, tenantId: string, campaignId: number) 
     .eq("id", campaignId)
     .single();
   if (cErr || !c) return json({ error: "campaign not found" }, 404);
-  if (c.status !== "open" || !c.is_for_shop || (c.end_at && new Date(c.end_at).getTime() <= Date.now())) {
-    return json({ error: "campaign not available" }, 404);
+  const available = c.status === "open"
+    && !!c.is_for_shop
+    && !(c.end_at && new Date(c.end_at).getTime() <= Date.now());
+  if (!available) {
+    if (!memberId) return json({ error: "campaign not available" }, 404);
+    // 自己的訂單（含取消 / 逾期的）才放行 —— 客人要回頭看「我買的是什麼」，
+    // 而訂單被取消時最需要看的就是那一頁。
+    const { count, error: oErr } = await sb
+      .from("customer_orders")
+      .select("id", { count: "exact", head: true })
+      .eq("tenant_id", tenantId)
+      .eq("member_id", memberId)
+      .eq("campaign_id", campaignId);
+    if (oErr || !count) return json({ error: "campaign not available" }, 404);
   }
+  c.available = available;
 
   const { data: items, error: iErr } = await sb
     .from("campaign_items")
@@ -1424,7 +1452,7 @@ Deno.serve(async (req) => {
         case "mark_notification_read": if (!memberId) return json({ error: "no member_id" }, 401); return await markNotificationRead(sb, tenantId, memberId, body);
         case "generate_pwa_auth_code": if (!memberId) return json({ error: "no member_id" }, 401); return await generatePwaAuthCode(sb, tenantId, memberId, claims, token, body);
         case "list_active_campaigns": return await listActiveCampaigns(sb, tenantId, typeof body.close_type === "string" ? body.close_type : null, memberId);
-        case "get_campaign_detail": return await getCampaignDetail(sb, tenantId, Number(body.campaign_id ?? 0));
+        case "get_campaign_detail": return await getCampaignDetail(sb, tenantId, Number(body.campaign_id ?? 0), memberId);
         case "track_campaign_view": if (!memberId) return json({ error: "no member_id" }, 401); return await trackCampaignView(sb, tenantId, memberId, Number(body.campaign_id ?? 0));
         case "list_spot_products": return await listSpotProducts(sb, tenantId, storeId, memberId);
         case "get_spot_product": return await getSpotProduct(sb, tenantId, storeId, memberId, Number(body.id ?? 0));


### PR DESCRIPTION
「我的訂單」每一行只有品名與金額，客人要對「這是哪個商品」只能靠文字。
資料其實早就備齊：v_customer_order_summary 的 items[].image_url（20260516000008）
＋ liff-api listMyOrders 已經把它轉成 storage public URL，只差前端沒畫。

- 品項行左側加 56px 縮圖；商品沒自己的圖時退到開團封面 —— 團購品項多半
  只有封面，不退一層整張單會是一排 placeholder。
- 斷貨 / 已取消的行縮圖淡化 + 去色，跟旁邊既有的刪除線一致。
- placeholder 與商品頁共用一支 components/SkuThumb（原本是 CampaignDetailClient
  的區域元件），兩邊的樣子不會各長各的。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013x44HNLUxR2kjkv5Pjofox