### PR TITLE
取貨清單不印內部備註／sentinel 團名，＋現貨直配單可以取消

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -3,7 +3,8 @@
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
-import { stripTransferNotes } from "@/lib/orderNotes";
+import { stripTransferNotes, stripItemNotes } from "@/lib/orderNotes";
+import { internalOrderSource } from "@/lib/orderTitle";
 import { parseReturnNote } from "@/lib/returnNote";
 import { itemDisplayName } from "@/lib/skuLabel";
 import SpinButton from "@/components/SpinButton";
@@ -19,7 +20,7 @@ type Order = {
   payment_status: string | null;
   notes: string | null;
   member: { id: number; member_no: string; name: string | null; phone: string | null } | null;
-  campaign: { id: number; name: string; cutoff_date: string | null } | null;
+  campaign: { id: number; campaign_no: string; name: string; cutoff_date: string | null } | null;
   store: { id: number; name: string } | null;
   items: {
     id: number;
@@ -87,7 +88,7 @@ function Body() {
           .select(
             `id, order_no, status, discount_amount, discount_percent, wallet_paid_amount, payment_status, notes,
              member:members(id, member_no, name, phone),
-             campaign:group_buy_campaigns(id, name, cutoff_date),
+             campaign:group_buy_campaigns(id, campaign_no, name, cutoff_date),
              store:stores!customer_orders_pickup_store_id_fkey(id, name),
              items:customer_order_items(id, sku_id, qty, unit_price, discount_amount, discount_percent, notes, status, sku:skus(variant_name, product_name))`,
           )
@@ -241,7 +242,9 @@ function Body() {
             return (
               <div key={o.id} className="border-b border-dashed border-zinc-400 pb-1">
                 <div className="text-[13px]">
-                  {o.campaign?.name ?? "(未知活動)"}
+                  {o.campaign?.campaign_no?.startsWith("__")
+                    ? internalOrderSource(o.order_no)?.label ?? "店內現貨"
+                    : o.campaign?.name ?? "(未知活動)"}
                   <CutoffText date={o.campaign?.cutoff_date} />
                 </div>
                 {orderNotes && (
@@ -281,8 +284,8 @@ function Body() {
                             : `-$${it.discount_amount}`}
                         </div>
                       )}
-                      {it.notes && (
-                        <div className="pl-2 text-[13px] italic">↳ 備註：{it.notes}</div>
+                      {stripItemNotes(it.notes) && (
+                        <div className="pl-2 text-[13px] italic">↳ 備註：{stripItemNotes(it.notes)}</div>
                       )}
                     </div>
                   );

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -3,7 +3,8 @@
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
-import { stripTransferNotes } from "@/lib/orderNotes";
+import { stripTransferNotes, stripItemNotes } from "@/lib/orderNotes";
+import { internalOrderSource } from "@/lib/orderTitle";
 import { itemDisplayName } from "@/lib/skuLabel";
 import SpinButton from "@/components/SpinButton";
 import { CutoffText } from "@/components/CampaignCutoff";
@@ -190,7 +191,9 @@ function Body() {
             return (
               <div key={r.event.id} className="border-b border-dashed border-zinc-400 pb-1">
                 <div className="text-[13px]">
-                  {r.order?.campaign?.name ?? "(未知活動)"}
+                  {r.order?.campaign?.campaign_no?.startsWith("__")
+                    ? internalOrderSource(r.order?.order_no)?.label ?? "店內現貨"
+                    : r.order?.campaign?.name ?? "(未知活動)"}
                   <CutoffText date={r.order?.campaign?.cutoff_date} />
                 </div>
                 {orderNotes && (
@@ -225,8 +228,8 @@ function Body() {
                             : `-$${it.discount_amount}`}
                         </div>
                       )}
-                      {it.notes && (
-                        <div className="pl-2 text-[13px] italic">↳ 備註：{it.notes}</div>
+                      {stripItemNotes(it.notes) && (
+                        <div className="pl-2 text-[13px] italic">↳ 備註：{stripItemNotes(it.notes)}</div>
                       )}
                     </div>
                   );

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -628,7 +628,13 @@ export function OrderDetail({
     head.status === "partially_completed" &&
     items.some((it) => ["pending", "reserved", "ready"].includes(it.status));
   const canTransfer = head.status === "ready" || transferBeforeArrival || transferAfterPartialPickup;
-  const canCancel = ["pending", "confirmed", "shipping"].includes(head.status);
+  // 現貨直配（SP-）單一建立就是 'ready'，但還沒扣庫存 → 取消是安全的，
+  // 只是把可分配量放回去（20260816000070 放寬了伺服端守衛）。
+  // 不放寬一般 ready 單：那代表貨已配到客人頭上，取消的連動完全不同。
+  const isSpotSale = head.order_no?.startsWith("SP-") ?? false;
+  const canCancel =
+    ["pending", "confirmed", "shipping"].includes(head.status) ||
+    (isSpotSale && head.status === "ready");
   // 還沒到貨（pending/confirmed/shipping）也可以列印小白單；ready 透過 PickupDialog 已有入口。
   // partially_completed 也開放（對齊 /orders 列表）— 小白單只列還沒取的品項，已取走的不會重複出現。
   const canPrintSlip = ["pending", "confirmed", "shipping", "ready", "partially_completed"].includes(head.status);
@@ -650,7 +656,9 @@ export function OrderDetail({
     const reason = prompt(
       (head.status === "shipping"
         ? `撤回派貨：${head.order_no}\n${isAidOrder ? "會撤回派貨單並反向回收已出庫存" : "波次出貨的訂單不動庫存，貨留在店端"}，請輸入原因：`
-        : `取消訂單：${head.order_no}\n請輸入取消原因：`) + walletNote
+        : isSpotSale
+          ? `取消現貨直配單：${head.order_no}\n這張單還沒扣庫存，取消後那些貨會變回「可分配」。\n請輸入取消原因：`
+          : `取消訂單：${head.order_no}\n請輸入取消原因：`) + walletNote
     );
     if (reason === null) return;
     const sb = getSupabase();

--- a/apps/admin/src/lib/orderNotes.ts
+++ b/apps/admin/src/lib/orderNotes.ts
@@ -6,12 +6,32 @@
 // 這些是內部轉單流程訊息，客人拿到的取貨單不該出現 —— 列印前整行剔除。
 const TRANSFER_MARKER_LINE = /^\s*\[(?:追加轉入|轉入|全部轉出|部分轉出|部分追加|轉出)[^\]]*\]/;
 
+// 現貨直配（20260816000010 起）同樣往 notes 寫內部標記，而且**單頭與品項都會寫**：
+//   單頭：【現貨直配】店內現貨直接配給客人（待取，取貨時才扣庫存收款）
+//         [拆單] 自 SP-2-0001 拆出（…）
+//   品項：[現貨直配] 2026-08-16 08:49
+// 2026-08-16 回報：這些整段被印在客人的取貨清單上。與轉單標記同一類 ——
+// 是給後台看的流程訊息，不是客人交代的事情，列印前一律剔除。
+// 用全形【】與半形[] 兩種括號都要認：單頭那行是全形、品項那行是半形。
+const SPOT_MARKER_LINE = /^\s*(?:【現貨直配】|\[(?:現貨直配|拆單)[^\]]*\])/;
+
+function isInternalMarker(line: string): boolean {
+  return TRANSFER_MARKER_LINE.test(line) || SPOT_MARKER_LINE.test(line);
+}
+
+/**
+ * 列印用：剔除內部流程標記，只留真正由店員手打、客人該看到的備註。
+ * 整段都是內部標記時回 null（呼叫端就不會畫出空的「📝」）。
+ */
 export function stripTransferNotes(notes: string | null | undefined): string | null {
   if (!notes) return null;
   const kept = notes
     .split("\n")
-    .filter((line) => !TRANSFER_MARKER_LINE.test(line))
+    .filter((line) => !isInternalMarker(line))
     .join("\n")
     .trim();
   return kept || null;
 }
+
+/** 品項備註同一套規則（`customer_order_items.notes`）。 */
+export const stripItemNotes = stripTransferNotes;

--- a/supabase/migrations/20260816000070_allow_cancel_spot_sale_ready.sql
+++ b/supabase/migrations/20260816000070_allow_cancel_spot_sale_ready.sql
@@ -1,0 +1,229 @@
+-- ============================================================
+-- 現貨直配單可以取消（狀態守衛放寬）＋ 取消時作廢它的 DN 減抵單
+--
+-- 回報（Alex 2026-08-16）：「可以取消這個單再回庫存嗎？」
+--
+-- 現況：做不到。rpc_cancel_aid_order 的守衛是
+--   status IN ('pending','confirmed','shipping')，
+-- 而現貨直配單**一建立就是 'ready'**（貨就在店裡、等客人來拿）→ 直接被擋；
+-- 前端 canCancel 用同一組狀態，所以連「取消」按鈕都不會出現。
+-- 刪單一品項的 rpc_delete_order_item 也要 status='pending'（canEditQty）。
+-- 結果是：做得出這種單，卻沒有任何路徑可以取消它 ——
+-- CLAUDE.md「新增路徑要確認下游有人推得動」的反面案例，而且是自己種的。
+--
+-- 為什麼放寬是安全的：
+--   現貨直配＝配單，**當下不扣庫存**（rpc_record_pickup 取貨時才扣）。
+--   所以「取消再回庫存」實際上不需要回沖任何庫存異動 ——
+--   單頭一變 cancelled，_sku_commitment 的 promised 就不再算它
+--   （promised 看的是單頭 status IN ('ready','partially_completed','shipping')），
+--   可分配量自動回來。這也是為什麼不需要動 stock_movements。
+--   SP- 單也沒有 transfer chain、沒有儲值金付款，原函式那兩段分支都不會跑到。
+--
+-- 只對 SP- 放寬，其餘單型維持原規則：一般團購單在 ready 代表貨已配到客人頭上，
+-- 取消的語意與連動（池子、波次、到貨通知）完全不同，不在本次範圍。
+--
+-- 併帶：取消時作廢該單開的 DN 減抵單。留著不會讓庫存算錯（自由量不看 DN），
+--   但 is_order_item_pickup_ready 的 Path D 是以 (tenant, campaign, store, sku)
+--   整組查有效減抵，而現貨直配全掛在共用 sentinel 團底下 —— 一張孤兒 DN 會讓
+--   同團同店同 SKU 的其他單（RR- / OV- 容器單也在這個團）憑空通過到貨閘門。
+--
+-- 基底：rpc_cancel_aid_order = 20260804000000（最新；本檔函式本體從該檔逐字
+--   抽出後只改守衛＋插入作廢段，非手抄）
+-- rollback: 重跑 20260804000000 的 rpc_cancel_aid_order。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_cancel_aid_order(
+  p_order_id BIGINT,
+  p_reason   TEXT,
+  p_operator UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_terminal_id      BIGINT;
+  v_xfer             transfers%ROWTYPE;
+  v_ti               RECORD;
+  v_cancelled_ids    BIGINT[] := ARRAY[]::BIGINT[];
+  v_reason_note      TEXT;
+  v_refund_ledger_id BIGINT;
+  v_refunded_amount  NUMERIC := 0;
+  v_src_id           BIGINT;
+  v_src_pickable     BOOLEAN := FALSE;
+  v_is_aid           BOOLEAN := FALSE;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('aid_order:' || p_order_id));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  -- 現貨直配（SP-）單一建立就是 'ready'（貨就在店裡、等客人來拿），
+  -- 但它**還沒扣庫存**（配單＝待取，rpc_record_pickup 才扣）→ 取消是安全的，
+  -- 只是把可分配量放回去。原本的守衛把它擋在外面，等於做得出單卻取消不掉
+  -- （2026-08-16 回報）。其餘單型維持原規則不動。
+  IF v_order.status NOT IN ('pending', 'confirmed', 'shipping')
+     AND NOT (v_order.status = 'ready' AND v_order.order_no LIKE 'SP-%') THEN
+    RAISE EXCEPTION 'order % is %, only pending/confirmed/shipping can be cancelled', p_order_id, v_order.status;
+  END IF;
+
+  v_reason_note := '[cancelled by source: ' || COALESCE(p_reason, '') || ']';
+
+  -- 場景 B：已派貨，要回收 transfer chain
+  IF v_order.status = 'shipping' THEN
+    SELECT id INTO v_terminal_id
+      FROM transfers
+     WHERE customer_order_id = p_order_id
+       AND tenant_id = v_order.tenant_id
+     LIMIT 1;
+
+    -- 沒有掛在此單上的 transfer：
+    --   互助單 → 真的資料不一致，擋下來；
+    --   一般（波次出貨）訂單 → 本來就沒有 per-order transfer，直接往下取消。
+    IF v_terminal_id IS NULL THEN
+      v_is_aid := v_order.transferred_from_order_id IS NOT NULL
+                  OR EXISTS (
+                       SELECT 1 FROM customer_order_items coi
+                        WHERE coi.order_id = p_order_id
+                          AND coi.source = 'aid_transfer'
+                          AND coi.status <> 'cancelled'
+                     );
+      IF v_is_aid THEN
+        RAISE EXCEPTION 'order % is shipping but has no terminal transfer', p_order_id;
+      END IF;
+    END IF;
+
+    IF v_terminal_id IS NOT NULL THEN
+      FOR v_xfer IN
+        WITH RECURSIVE chain_back AS (
+          SELECT * FROM transfers WHERE id = v_terminal_id
+          UNION ALL
+          SELECT t.* FROM transfers t
+            JOIN chain_back c ON c.id = ANY(
+              SELECT id FROM transfers WHERE next_transfer_id = c.id
+            )
+        ),
+        head AS (
+          SELECT id FROM chain_back
+           WHERE id NOT IN (SELECT next_transfer_id FROM transfers WHERE next_transfer_id IS NOT NULL)
+           LIMIT 1
+        ),
+        chain_forward AS (
+          SELECT * FROM transfers WHERE id = (SELECT id FROM head)
+          UNION ALL
+          SELECT t.* FROM transfers t
+            JOIN chain_forward c ON t.id = c.next_transfer_id
+        )
+        SELECT * FROM chain_forward ORDER BY id
+      LOOP
+        IF v_xfer.status = 'received' THEN
+          RAISE EXCEPTION 'transfer % already received, cannot cancel chain', v_xfer.id;
+        END IF;
+
+        IF v_xfer.status = 'shipped' THEN
+          FOR v_ti IN
+            SELECT id, sku_id, qty_shipped FROM transfer_items
+             WHERE transfer_id = v_xfer.id AND qty_shipped > 0
+          LOOP
+            PERFORM rpc_inbound(
+              p_tenant_id       => v_xfer.tenant_id,
+              p_location_id     => v_xfer.source_location,
+              p_sku_id          => v_ti.sku_id,
+              p_quantity        => v_ti.qty_shipped,
+              p_unit_cost       => 0,
+              p_movement_type   => 'transfer_cancel',
+              p_source_doc_type => 'transfer',
+              p_source_doc_id   => v_xfer.id,
+              p_operator        => p_operator
+            );
+          END LOOP;
+        END IF;
+
+        UPDATE transfers
+           SET status = 'cancelled',
+               notes = CASE
+                         WHEN notes IS NULL OR notes = '' THEN v_reason_note
+                         ELSE notes || E'\n' || v_reason_note
+                       END,
+               updated_by = p_operator
+         WHERE id = v_xfer.id;
+        v_cancelled_ids := v_cancelled_ids || v_xfer.id;
+      END LOOP;
+    END IF;
+  END IF;
+
+  -- 若有用儲值金結帳，自動 refund 回會員餘額
+  IF v_order.wallet_paid_amount > 0 AND v_order.member_id IS NOT NULL THEN
+    v_refund_ledger_id := rpc_wallet_refund(
+      v_order.tenant_id,
+      v_order.member_id,
+      v_order.wallet_paid_amount,
+      'customer_order',
+      p_order_id,
+      'order_cancelled: ' || COALESCE(p_reason, '(no reason)'),
+      p_operator
+    );
+    v_refunded_amount := v_order.wallet_paid_amount;
+    -- wallet_paid_amount 保留歷史值，不清零
+  END IF;
+
+  -- 標記訂單 cancelled
+  -- 現貨直配單取消 → 把它開的 DN 減抵單一併作廢。
+  -- 留著不會讓庫存算錯（自由量不看 DN），但 is_order_item_pickup_ready 的
+  -- Path D 是以 (tenant, campaign, store, sku) 整組查有效減抵，而現貨直配全部
+  -- 掛在共用 sentinel 團底下 —— 一張孤兒 DN 會讓**同團同店同 SKU 的其他單**
+  -- （RR- / OV- 容器單也在這個團）憑空通過到貨閘門。
+  IF v_order.order_no LIKE 'SP-%' THEN
+    UPDATE inventory_deduction_notes n
+       SET cancelled_at = NOW(), cancelled_by = p_operator
+     WHERE n.cancelled_at IS NULL
+       AND EXISTS (SELECT 1 FROM inventory_deduction_note_items li
+                    WHERE li.note_id = n.id AND li.order_id = p_order_id);
+  END IF;
+
+  UPDATE customer_orders
+     SET status       = 'cancelled',
+         cancelled_at = NOW(),
+         updated_by   = p_operator,
+         updated_at   = NOW()
+   WHERE id = p_order_id;
+
+  -- ── source order 退回 ──（2026-07-13）
+  -- 先解除轉出鎖定回到 confirmed；若原店的貨其實已到（波次已收 → is_order_pickup_ready），
+  -- 直接推到 ready 讓它立刻可取貨，避免波次早跑完、confirmed 再也不會被 mark_shipping 推進而永遠卡住。
+  v_src_id := v_order.transferred_from_order_id;
+  IF v_src_id IS NOT NULL THEN
+    UPDATE customer_orders
+       SET status                   = 'confirmed',
+           transferred_to_order_id  = NULL,
+           updated_by               = p_operator,
+           updated_at               = NOW()
+     WHERE id = v_src_id
+       AND status = 'transferred_out';
+
+    v_src_pickable := public.is_order_pickup_ready(v_src_id);
+    IF v_src_pickable THEN
+      UPDATE customer_orders
+         SET status     = 'ready',
+             ready_at   = COALESCE(ready_at, NOW()),
+             updated_by = p_operator,
+             updated_at = NOW()
+       WHERE id = v_src_id
+         AND status = 'confirmed';
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'order_id', p_order_id,
+    'cancelled_transfer_ids', to_jsonb(v_cancelled_ids),
+    'source_order_reverted', v_src_id IS NOT NULL,
+    'source_order_pickable', v_src_pickable,
+    'wallet_refunded',       v_refunded_amount,
+    'wallet_refund_ledger_id', v_refund_ledger_id
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_cancel_aid_order(BIGINT, TEXT, UUID) IS
+  '取消訂單（互助/一般/派貨中皆走這支）：回收 transfer chain、退儲值金、寫 audit。'
+  '20260816000070：現貨直配（SP-）單在 ready 也可取消（它還沒扣庫存，'
+  '取消＝把可分配量放回去），並一併作廢該單開的 DN 減抵單。';


### PR DESCRIPTION
承接 #739（已合併）。`20260816000070` **已套上正式庫**，本 PR 把 repo 補回一致。

---

## 1. 取貨清單不再印出內部技術文字

回報（附收據照片）：客人的取貨清單上印出整段內部流程訊息 ——

```
[內部] 補貨申請
📝 【現貨直配】店內現貨直接配給客人（待取，取貨時才扣庫存收款）
   [拆單] 自 SP-2-0001 拆出（上線首日兩次配貨被併成一張，2026-08-16 09:27:32）
↳ 備註：[現貨直配] 2026-08-16 08:49
```

**沿用既有機制而不是整欄拿掉**：`orderNotes.ts` 的 `stripTransferNotes` 本來就是為了「內部流程訊息不該出現在客人的取貨單」而存在（轉單標記）。現貨直配的標記是同一類，把 regex 擴充涵蓋 `【現貨直配】` / `[現貨直配]` / `[拆單]`（全形半形都認）。

這樣**店員手打的真備註會保留**，只剔除系統標記 —— 整欄拿掉會把「客人說星期六下午來拿」一起弄丟。

三處一起處理：

| | 原本 | 現在 |
|---|---|---|
| 單頭備註 | 印出全部 | 剔除內部標記後才印 |
| 品項備註 | 直接印 `it.notes` | 套同一套 strip |
| 活動名 | `【內部】補貨申請` | `internalOrderSource` 的來源標籤 |

`print-list` 原本沒撈 `campaign_no`（判不出 sentinel），一併補上。兩支列印模板（`/pickup/print-list` 與 `/pickup/print`）互為鏡像，同步改。

## 2. 現貨直配單可以取消

回報：「可以取消這個單再回庫存嗎？」—— **原本做不到**。

`rpc_cancel_aid_order` 的守衛是 `status IN ('pending','confirmed','shipping')`，而現貨直配單**一建立就是 `ready`** → 直接被擋；前端 `canCancel` 用同一組狀態，連按鈕都不會出現；刪單一品項的 `rpc_delete_order_item` 又要求 `status='pending'`。等於做得出這種單、卻沒有任何路徑取消它 —— CLAUDE.md「新增路徑要確認下游有人推得動」的反面案例，而且是 #736 自己種的。

**放寬是安全的**：現貨直配＝配單，當下不扣庫存（`rpc_record_pickup` 取貨時才扣）。所以「取消再回庫存」不需要回沖任何庫存異動 —— 單頭一變 `cancelled`，`_sku_commitment` 的 `promised` 就不再算它（promised 看的正是單頭 status），可分配量自動回來。SP- 單也沒有 transfer chain、沒有儲值金付款，原函式那兩段分支不會跑到。

**只對 `SP-` 放寬**，一般 `ready` 單維持原規則 —— 那代表貨已配到客人頭上，取消的連動（池子、波次、到貨通知）完全不同，不在本次範圍。

**併帶：取消時作廢該單開的 DN 減抵單。** 留著不會讓庫存算錯（自由量不看 DN），但 `is_order_item_pickup_ready` 的 Path D 是以 `(tenant, campaign, store, sku)` **整組**查有效減抵，而現貨直配全掛在共用 sentinel 團底下 —— 一張孤兒 DN 會讓同團同店同 SKU 的其他單（`RR-` / `OV-` 容器單也在這個團）憑空通過到貨閘門。

---

## 驗證

**列印**：拿線上 SP-2-0001 / SP-2-0002 的**實際 notes** 跑 strip：

```
✅ 整段不印   SP-2-0001 單頭（3 行內部標記）
✅ 整段不印   SP-2-0002 單頭
✅ 整段不印   品項備註 [現貨直配] 2026-08-16 08:49
📝 印出       「客人說星期六下午來拿，請先留著」    ← 手打的保留
📝 印出       「客人指定要灰色那款」                ← 混合時只留手打那行
✅ 整段不印   既有的轉單標記（行為沒壞）
```

**取消**：線上在交易內實跑取消再 rollback ——

```
單頭      ready → cancelled
可分配    0 → 1（+1）
DN 減抵單 DN2608160033 已作廢
```

事後確認兩張 SP- 單仍是 `ready`、無新增作廢 DN（既有 6 筆都是 8/13 `PROD-fix-void-phantom-deduction-notes` 留下的）。

**其他**：`check-sql-syntax.cjs` 通過（含 `parsePlpgsql`）；`tsc --noEmit` 乾淨；四個檔案 lint 皆與 rebase 後 baseline 相同（1/1/2/0），零新增。

## 備註

`rpc_cancel_aid_order` 的函式本體是從 `20260804000000` 逐字抽出後只改守衛＋插入作廢段，非手抄；已 diff 驗證變更範圍。分支從最新 `main` 重開（#739 是 squash merge）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPzkxUng2Qg4GRHB1QAC3r)_