### PR TITLE
互助板：手動現貨也能被別店認領

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,45 @@ RR- ride-along 單在補貨到店**之前**就存在（單頭 `pending`/`confirm
 
 ---
 
+## 互助交流板 (mutual_aid_board)
+
+### 「認領」的本體是訂單轉移；載體單只能存在於那一個交易裡
+
+跨店認領＝`rpc_transfer_order_partial` 把釋出店那張單的品項轉成認領店的單，
+貨才會走既有那一套（空中轉／經總倉、收貨頁、月結一加一扣）。所以**沒有訂單就
+認領不了**：2026-08-16 線上 29 則進行中的釋出貼文有 27 則是「➕ 手動新增現貨」
+（`source_customer_order_id IS NULL`），前端直接不畫認領鈕，店家只看到
+「不開放跨店認領」——「怎麼看不到認領的按鈕」就是這個。
+
+補法（`20260816000000`）是認領當下才在釋出店建一張 `AB-<store>-<seq>` 載體單
+（restock sentinel trio、單頭 ready），**同一個交易內**立刻轉走。
+
+- **不要改成發文時就建載體單**。載體單掛在 `member_type='store_internal'` 上，
+  只要以 ready 停在庫裡就會進 `_trim_internal_pool`（20260811000030/40）的池子
+  口徑；手動現貨常常是店家自己的貨、不在 `on_hand` 裡 → 下一次自動配單就把它
+  當超額掛帳砍掉（標 `[已配給團購單]`），貼文的貨會莫名其妙消失。
+- 手動現貨開放認領之後，`rpc_update_aid_board_listing` 原本「手動現貨沒有認領
+  扣量、`qty_available`/`qty_remaining` 一起覆寫」的假設就不成立了 ——
+  改總量要保留已認領量（`remaining = 新 available − 已認領`）。
+
+### 新開 order_no 前綴之前，先查線上有沒有人用了
+
+`SP-` 已經被「現貨直配」(`rpc_create_spot_sale`) 用掉了，而**那支 RPC 在
+`supabase/migrations/` 裡找不到**（線上有、repo 沒有 —— 直接套上正式庫沒回寫
+migration 的典型後果，見本檔開頭那條）。差一點就讓互助板的載體單跟它撞號。
+
+開新前綴一律先問線上，不要只 grep repo：
+
+```sql
+SELECT p.proname FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'public' AND p.prosrc LIKE '%<你的前綴>-%';
+SELECT count(*) FROM customer_orders WHERE order_no LIKE '<你的前綴>-%';
+```
+
+順帶：`customer_orders_trio_kind_active_uniq` 的 predicate 已經排除
+`order_kind='restock'` 與 `order_no LIKE 'SP-%'`，容器單走 `restock` 就不會撞
+一店一單的唯一索引。
+
 ## 採購單 (purchase_orders)
 
 ### 斷貨會「拆單」，而且要能回復 —— 一律走 `_stockout_po_items`

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -301,6 +301,13 @@ export default function MutualAidPage() {
                       手動
                     </span>
                   )}
+                  {/* 沒選商品的手動現貨別店認領不了 —— 在列表就標出來，
+                      不用點進去才發現（20260816000000） */}
+                  {p.post_type === "offer" && p.sku_id == null && (
+                    <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800 dark:bg-amber-950 dark:text-amber-300" title="沒有選商品，別的分店無法認領；請點進貼文用「✏️ 修改內容」補選">
+                      待補商品
+                    </span>
+                  )}
                   {p.post_type === "offer" && !p.spot_visible_to_other_stores && (
                     <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800 dark:bg-amber-950 dark:text-amber-300">
                       🔒 限本店會員
@@ -677,7 +684,9 @@ function ManualSpotModal({
     setErr(null);
     if (!storeId) { setErr("請選釋出店"); return; }
     const titleTrim = title.trim();
-    if (!picked && titleTrim === "") { setErr("沒有從商品庫選品項時，商品標題必填"); return; }
+    // 商品必選：別店認領＝把這個 SKU 轉單過去，沒 SKU 就沒東西可以轉
+    // （20260816000000；主檔沒有的商品請先去「商品」頁建一筆）
+    if (!picked) { setErr("請從商品庫選商品 —— 沒選商品的話別的分店無法認領"); return; }
     const qtyN = Number(qty);
     if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("數量需 > 0"); return; }
     let priceN: number | null = null;
@@ -727,9 +736,10 @@ function ManualSpotModal({
           </div>
         )}
         <p className="rounded-md border border-emerald-200 bg-emerald-50/50 p-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300">
-          直接上架店裡現有的東西，不需要來源訂單。可以從商品庫選品項，也可以整個手打。
+          直接上架店裡現有的東西，不需要來源訂單。名稱 / 說明 / 圖片都可以自己改寫。
           <br />
-          這種貼文只給會員看，<strong>別的分店不能認領</strong>（沒有訂單可以轉移）。
+          <strong>商品要從商品庫選</strong>：別店認領＝把這個商品轉單過去，沒選就沒東西可以轉
+          （主檔還沒有的商品，請先到「商品」頁建一筆）。
         </p>
 
         <label>
@@ -746,7 +756,8 @@ function ManualSpotModal({
 
         <div>
           <span className="mb-1 block text-xs text-zinc-500">
-            從商品庫選品項（選填 —— 選了會帶出名稱與圖片，不選就純手打）
+            從商品庫選商品 <span className="text-red-500">*</span>
+            <span className="ml-1 text-zinc-400">（帶出名稱與圖片；別店要認領一定要有它）</span>
           </span>
           <SkuSearchInput value={picked} onChange={pickSku} />
           {picked && (
@@ -755,7 +766,7 @@ function ManualSpotModal({
               onClick={() => setPicked(null)}
               className="mt-1 text-[11px] text-zinc-500 underline hover:text-zinc-700 dark:hover:text-zinc-300"
             >
-              清除選擇，改成手打
+              清除選擇，重新搜尋
             </SpinButton>
           )}
         </div>
@@ -911,7 +922,10 @@ function OfferModal({
           items:customer_order_items(campaign_item_id, sku_id, qty, status, unit_price, sku:skus(sku_code, product_name, variant_name, product:products(description)))
         `)
         .eq("pickup_store_id", storeId)
-        .eq("status", "ready")
+        // partially_completed 也要列：內部現貨池的單臨櫃賣掉一件就變這個狀態，
+        // 只列 ready 的話「店裡明明還有貨」卻挑不到單，店家只好改發手動現貨
+        // （轉單 RPC 本來就接受這兩個狀態，20260814000020）
+        .in("status", ["ready", "partially_completed"])
         .order("id", { ascending: false })
         .limit(200);
       if (cancelled) return;
@@ -1262,8 +1276,14 @@ function ThreadModal({
   const [originalTitle, setOriginalTitle] = useState("");
   const [savingEdit, setSavingEdit] = useState(false);
   const canEdit = post.post_type === "offer" && post.status === "active";
-  /** 手動現貨：沒有來源訂單 → 不能被認領，但數量可以直接改 */
+  /** 手動現貨：沒有來源訂單（數量可以直接改；認領走 rpc_claim_manual_spot） */
   const isManual = post.post_type === "offer" && post.source_customer_order_id == null;
+  /** 補選商品後 post prop 還是父層舊資料，認領鈕的判斷用這個本地值蓋 */
+  const [savedSkuId, setSavedSkuId] = useState<number | null>(post.sku_id);
+  const [editSku, setEditSku] = useState<SkuOption | null>(null);
+  /** 可認領＝有來源訂單（原本那條），或手動現貨但已經選好商品 */
+  const canClaim = post.post_type === "offer" && post.status === "active" &&
+    (!isManual || savedSkuId != null);
 
   useEffect(() => {
     if (!canEdit) return;
@@ -1357,12 +1377,21 @@ function ThreadModal({
         p_qty_available: qtyParam,
         // 只有手動現貨開放這個開關，訂單來源的送 null（= 不動，維持看得到）
         p_visible_to_other_stores: isManual ? editVisible : null,
+        // 補選商品：沒挑就送 null（= 不動）；訂單來源的貼文 SKU 綁著來源品項不可改
+        p_sku_id: isManual && editSku ? editSku.id : null,
       });
       if (e) { setErr(e.message); return; }
       setSavedSpotPrice(spotPriceParam);
       setSavedSpotTitle(spotTitleParam);
       setSavedExpiresAt(expDate.toISOString());
-      if (qtyParam != null) setSavedQty({ available: qtyParam, remaining: qtyParam });
+      if (editSku) setSavedSkuId(editSku.id);
+      // 已認領的量要留著（伺服端同一套算法），不能直接把 remaining 蓋成新總量
+      if (qtyParam != null) {
+        setSavedQty((prev) => ({
+          available: qtyParam,
+          remaining: Math.max(0, qtyParam - Math.max(0, prev.available - prev.remaining)),
+        }));
+      }
       if (isManual) setSavedVisible(editVisible);
       setEditOpen(false);
       onEdited();
@@ -1512,6 +1541,27 @@ function ThreadModal({
                 className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
               />
             </label>
+            {/* 補選商品：沒選 SKU 的手動現貨別店認領不了（沒東西可以轉單）。
+                選了就不能改回「沒有」—— 送 NULL 是「不動」，不是清除。 */}
+            {isManual && (
+              <div>
+                <span className="mb-1 block text-zinc-500">
+                  商品（SKU）
+                  {savedSkuId == null && (
+                    <span className="ml-1 text-amber-600 dark:text-amber-400">— 沒選商品的話，別的分店無法認領</span>
+                  )}
+                </span>
+                {savedSkuId != null && !editSku ? (
+                  <div className="flex items-center gap-2">
+                    <span className="rounded bg-white px-2 py-1 dark:bg-zinc-800">{post.sku_label ?? `#${savedSkuId}`}</span>
+                    <span className="text-[11px] text-zinc-400">已可被認領；要換商品請在下方重新搜尋</span>
+                  </div>
+                ) : null}
+                <div className="mt-1">
+                  <SkuSearchInput value={editSku} onChange={setEditSku} />
+                </div>
+              </div>
+            )}
             {isManual && (
               <div className="grid grid-cols-2 gap-2">
                 <label>
@@ -1522,7 +1572,7 @@ function ThreadModal({
                     inputMode="decimal"
                     className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-right dark:border-zinc-700 dark:bg-zinc-800"
                   />
-                  <span className="mt-0.5 block text-[11px] text-zinc-400">手動現貨沒有認領扣量，改了就直接覆蓋剩餘量</span>
+                  <span className="mt-0.5 block text-[11px] text-zinc-400">改總量會保留已被認領的部分（剩餘量 = 新總量 − 已認領）</span>
                 </label>
                 <label>
                   <span className="mb-1 block text-zinc-500">單位</span>
@@ -1659,20 +1709,24 @@ function ThreadModal({
             />
             <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
               <div className="flex flex-wrap gap-2">
-                {/* 手動現貨沒有來源訂單 → 沒東西可轉移，認領按鈕不該出現 */}
-                {post.post_type === "offer" && !isManual && (
+                {/* 手動現貨也能認領（20260816000000）：認領當下才在釋出店建一張
+                    載體單再轉給認領店。但沒選商品（SKU）就沒東西可以轉 —— 那種
+                    貼文要先按「✏️ 修改內容」補選商品。 */}
+                {post.post_type === "offer" && canClaim && (
                   <SpinButton
                     type="button"
                     onClick={() => setClaimOpen(true)}
                     className="rounded-md border border-pink-400 bg-pink-50 px-3 py-1.5 text-xs font-medium text-pink-700 hover:bg-pink-100 dark:border-pink-700 dark:bg-pink-950 dark:text-pink-300 dark:hover:bg-pink-900"
-                    title="把釋出店的訂單轉成接收店的（走 5b-1 棄單轉出）"
+                    title={isManual
+                      ? "把這批現貨轉給接收店（系統會在釋出店開一張內部載體單再轉單）"
+                      : "把釋出店的訂單轉成接收店的（走 5b-1 棄單轉出）"}
                   >
                     ✋ 我要認領
                   </SpinButton>
                 )}
-                {post.post_type === "offer" && isManual && (
-                  <span className="self-center text-[11px] text-zinc-400">
-                    手動現貨・只給會員看，不開放跨店認領
+                {post.post_type === "offer" && !canClaim && (
+                  <span className="self-center text-[11px] text-amber-600 dark:text-amber-400">
+                    這則還沒選商品 → 別店認領不了，請按「✏️ 修改內容」補選商品
                   </span>
                 )}
                 {canEdit && !editOpen && (
@@ -1726,6 +1780,7 @@ function ThreadModal({
       {claimOpen && (
         <ClaimOfferDialog
           post={post}
+          skuId={savedSkuId}
           stores={stores}
           onCancel={() => setClaimOpen(false)}
           onDone={() => {
@@ -1753,9 +1808,11 @@ function ThreadModal({
 // Claim Offer Dialog — 認領釋出（receiving store 從釋出方拿訂單）
 // ============================================================
 function ClaimOfferDialog({
-  post, stores, onCancel, onDone,
+  post, skuId, stores, onCancel, onDone,
 }: {
   post: Post;
+  /** 補選商品後父層 post 還是舊資料，SKU 一律吃 thread modal 的本地值 */
+  skuId: number | null;
   stores: Store[];
   onCancel: () => void;
   onDone: () => void;
@@ -1767,11 +1824,14 @@ function ClaimOfferDialog({
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
+  const isManual = post.source_customer_order_id == null;
+
   async function submit() {
     if (busy) return;
     setErr(null);
     if (!toStore) { setErr("請選接收店"); return; }
-    if (!post.source_customer_order_id) { setErr("此 offer 缺 source_customer_order_id（資料異常）"); return; }
+    if (!isManual && !post.source_customer_order_id) { setErr("此 offer 缺 source_customer_order_id（資料異常）"); return; }
+    if (isManual && !skuId) { setErr("這則貼文還沒選商品，請先用「✏️ 修改內容」補選"); return; }
     const qtyN = Number(qty);
     if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("認領數量需 > 0"); return; }
     if (qtyN > post.qty_remaining) { setErr(`認領數量超過剩餘量 ${post.qty_remaining}`); return; }
@@ -1780,6 +1840,21 @@ function ClaimOfferDialog({
       const sb = getSupabase();
       const { data: { user } } = await sb.auth.getUser();
       if (!user?.id) { setErr("未登入"); return; }
+      // 手動現貨沒有來源訂單 → 走 rpc_claim_manual_spot：它會在釋出店建一張
+      // 載體單、當場轉給接收店、扣貼文量，全部在同一個交易裡（20260816000000）
+      if (isManual) {
+        const { error: eM } = await sb.rpc("rpc_claim_manual_spot", {
+          p_board_id: post.id,
+          p_to_store_id: toStore,
+          p_qty: qtyN,
+          p_operator: user.id,
+          p_reason: reason || null,
+          p_is_air_transfer: isAir,
+        });
+        if (eM) { setErr(eM.message); return; }
+        onDone();
+        return;
+      }
       const { error: e1 } = await sb.rpc("rpc_transfer_order_partial", {
         p_order_id: post.source_customer_order_id,
         p_to_pickup_store_id: toStore,
@@ -1814,7 +1889,16 @@ function ClaimOfferDialog({
           <div className="mb-2 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">{err}</div>
         )}
         <div className="mb-3 rounded bg-zinc-50 p-2 text-xs dark:bg-zinc-950">
-          從「{post.store_name}」的訂單 <span className="font-mono">{post.source_order_no ?? `#${post.source_customer_order_id}`}</span> 取出指定數量、開新單給接收店（走 5b-1 partial transfer）。
+          {isManual ? (
+            <>
+              把「{post.store_name}」的現貨 <span className="font-medium">{post.spot_title ?? post.sku_label}</span> 轉給接收店：
+              系統會在釋出店開一張內部載體單再轉單，接收店在「收貨」頁收貨後就能出給客人。
+            </>
+          ) : (
+            <>
+              從「{post.store_name}」的訂單 <span className="font-mono">{post.source_order_no ?? `#${post.source_customer_order_id}`}</span> 取出指定數量、開新單給接收店（走 5b-1 partial transfer）。
+            </>
+          )}
         </div>
         <div className="mb-3 grid grid-cols-2 gap-3 text-sm">
           <label>

--- a/supabase/migrations/20260816000000_manual_spot_claimable.sql
+++ b/supabase/migrations/20260816000000_manual_spot_claimable.sql
@@ -1,0 +1,357 @@
+-- ============================================================================
+-- 2026-08-16：手動現貨也能被別店認領（互助交流板）
+--
+-- 需求（店家回報）：「互助交流上面針對有人釋出，分店上來要可以認領，
+--   現在怎麼看不到認領的按鈕」。
+--
+-- 現況（線上實測 2026-08-16）：進行中的釋出貼文 29 則，其中
+--   **27 則是「➕ 手動新增現貨」發的**（source_customer_order_id IS NULL）——
+--   前端刻意不畫認領鈕（「沒有訂單可以轉移給別店」），只有 2 則從訂單釋出的
+--   才有鈕。而 27 則裡有 20 則連 sku_id 都是 NULL（純手打標題）。
+--
+-- 認領的本體是「訂單轉移」：rpc_transfer_order_partial 把釋出店那張來源訂單的
+-- 品項轉成認領店的單，貨才會走既有那一套（空中轉當下建 AT- 單並出庫 / 經總倉
+-- 兩段派貨、收貨頁收貨、月結一加一扣）。手動現貨沒有來源訂單，所以要補一張。
+--
+-- 做法：
+--   1. rpc_claim_manual_spot(board, to_store, qty, operator, reason, is_air)
+--      認領當下才在釋出店建一張**載體單** AB-<store>-<seq>
+--      （restock sentinel trio ＋【內部】xx 店 member、order_kind='restock'、
+--       單頭 ready 以便轉單），寫一列 qty = 認領量的品項，接著在**同一個交易**
+--      裡呼叫 rpc_transfer_order_partial 轉給認領店，最後 rpc_consume_aid_board 扣量。
+--
+--      ⚠ 為什麼是「認領當下才建、當下就轉走」，不是發文時就建：
+--        載體單掛在 member_type='store_internal' 上，只要它以 ready 停留在庫裡，
+--        就會進 _trim_internal_pool（20260811000030 / 20260811000040）的池子口徑 ——
+--        手動現貨常常是店家自己的貨、根本不在 stock_balances.on_hand 裡，
+--        下一次自動配單就會把它當「超額掛帳」砍掉（標 [已配給團購單]），
+--        貼文的貨會莫名其妙消失。建完就轉走則品項立刻變 cancelled / 換到別店，
+--        不在 ('pending','reserved','ready') 口徑內，池子收斂看不到它。
+--
+--      單價：spot_price 優先 → 分店價 → 零售價 → 0（同 _grow_internal_pool 的
+--      fallback 順序）。0 元守衛（20260815000000）本來就排除 store_internal 容器單，
+--      且 rpc_transfer_order_partial 轉給真會員時會改鎖現售價，不會流到客人身上。
+--
+--      庫存：轉出是既有那一套（空中轉走 _air_ship_order_items，p_allow_negative
+--      => TRUE，20260814030000）。手動現貨的貨本來就可能沒入帳，出庫記成負的
+--      比拒絕記錄準確，交給盤點。
+--
+--   2. rpc_update_aid_board_listing 10 → 11 參數（加 p_sku_id）：
+--      既有 20 則沒 SKU 的貼文要能「補選商品」才認領得了。只有手動現貨
+--      （source_customer_order_id IS NULL）能改 SKU —— 從訂單釋出的貼文
+--      SKU 綁著來源訂單品項，改了就對不到帳。
+--      NULL = 不動（不是清除）：清掉 SKU 只會讓貼文退回不可認領，沒有意義。
+--
+--      連帶修 qty_available 覆寫：原版「手動現貨沒有認領扣量」所以
+--      qty_available / qty_remaining 一起覆寫；手動現貨開放認領之後這個假設
+--      不成立了，改成保留已認領量（remaining = 新 available − 已認領），
+--      並擋下「改到比已認領量還小」。
+--
+-- 基底版本（append-only，逐字保留所有 prior fix；已與線上 pg_get_functiondef
+--   逐字 diff 確認一致）：
+--   rpc_update_aid_board_listing = 20260802000050_spot_cross_store_visibility.sql
+--
+-- Rollback：
+--   DROP FUNCTION public.rpc_claim_manual_spot(BIGINT,BIGINT,NUMERIC,UUID,TEXT,BOOLEAN);
+--   DROP FUNCTION public.rpc_update_aid_board_listing(
+--     BIGINT,UUID,NUMERIC,TEXT,TIMESTAMPTZ,TEXT,JSONB,TEXT,NUMERIC,BOOLEAN,BIGINT);
+--   重跑 20260802000050 的 rpc_update_aid_board_listing 段落（前端要一起回退，
+--   不然編輯表單送 11 個參數會 404）。
+--   已認領出去的貨要退回請走既有的「↩ 退單（已收貨）」/ 撤回派貨，
+--   載體單 AB-<store>-<seq> 留著當軌跡，不要直接刪。
+--
+-- 對應前端（同一個 commit）：
+--   apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+--     - 手動現貨 + 有 SKU → 出「✋ 我要認領」（走 rpc_claim_manual_spot）
+--     - 手動現貨 + 沒 SKU → 提示先補選商品，編輯表單多一個商品選擇
+--     - ➕ 手動新增現貨：商品改必填（不選就沒人能認領）
+--     - 📦 我有庫存可提供：可釋出訂單放寬到 ready + partially_completed
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. rpc_claim_manual_spot — 手動現貨的認領（建載體單 → 轉單 → 扣貼文量）
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_claim_manual_spot(
+  p_board_id        BIGINT,
+  p_to_store_id     BIGINT,
+  p_qty             NUMERIC,
+  p_operator        UUID,
+  p_reason          TEXT    DEFAULT NULL,
+  p_is_air_transfer BOOLEAN DEFAULT FALSE
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_board        mutual_aid_board%ROWTYPE;
+  v_tenant       UUID;
+  v_store_name   TEXT;
+  v_member       BIGINT;
+  v_campaign     BIGINT;
+  v_channel      BIGINT;
+  v_ci           BIGINT;
+  v_price        NUMERIC;
+  v_seq          INT;
+  v_order_no     TEXT;
+  v_order_id     BIGINT;
+  v_dest_order   BIGINT;
+  v_board_status TEXT;
+  v_now          TIMESTAMPTZ := NOW();
+BEGIN
+  IF p_qty IS NULL OR p_qty <= 0 THEN
+    RAISE EXCEPTION '認領數量需 > 0';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('aid_board_claim:' || p_board_id::TEXT));
+
+  SELECT * INTO v_board FROM mutual_aid_board WHERE id = p_board_id FOR UPDATE;
+  IF v_board.id IS NULL THEN
+    RAISE EXCEPTION '找不到互助貼文 #%', p_board_id;
+  END IF;
+  IF v_board.post_type <> 'offer' THEN
+    RAISE EXCEPTION '只有「釋出」貼文可以認領';
+  END IF;
+  IF v_board.status <> 'active' THEN
+    RAISE EXCEPTION '此貼文已結束（%），不能認領', v_board.status;
+  END IF;
+  -- 有來源訂單的貼文走原本那條（前端直接呼叫 rpc_transfer_order_partial），
+  -- 不要在這裡另外生一張載體單、憑空多出一份貨
+  IF v_board.source_customer_order_id IS NOT NULL THEN
+    RAISE EXCEPTION '此貼文有來源訂單，請走原本的認領流程';
+  END IF;
+  IF v_board.sku_id IS NULL THEN
+    RAISE EXCEPTION '此貼文還沒選商品，釋出店要先用「✏️ 修改內容」補選商品才能被認領';
+  END IF;
+  IF v_board.qty_remaining < p_qty THEN
+    RAISE EXCEPTION '認領數量超過剩餘量（剩 %）', v_board.qty_remaining;
+  END IF;
+  IF p_to_store_id = v_board.offering_store_id THEN
+    RAISE EXCEPTION '接收店不能是釋出店本身';
+  END IF;
+
+  SELECT tenant_id, name INTO v_tenant, v_store_name
+    FROM stores WHERE id = v_board.offering_store_id;
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION '釋出店（ID %）不存在', v_board.offering_store_id;
+  END IF;
+
+  v_member   := rpc_get_or_create_store_member(v_board.offering_store_id, p_operator);
+  v_campaign := _restock_sentinel_campaign(v_tenant);
+  v_channel  := _restock_sentinel_channel(v_tenant, v_board.offering_store_id);
+
+  -- 單價：貼文自訂價 → 分店價 → 零售價 → 0（同 _grow_internal_pool）
+  v_price := v_board.spot_price;
+  IF v_price IS NULL THEN
+    SELECT price INTO v_price
+      FROM prices
+     WHERE tenant_id = v_tenant AND sku_id = v_board.sku_id AND scope = 'branch'
+       AND effective_from <= v_now AND (effective_to IS NULL OR effective_to > v_now)
+     ORDER BY effective_from DESC
+     LIMIT 1;
+  END IF;
+  IF v_price IS NULL THEN
+    SELECT price INTO v_price
+      FROM prices
+     WHERE tenant_id = v_tenant AND sku_id = v_board.sku_id AND scope = 'retail'
+       AND effective_from <= v_now AND (effective_to IS NULL OR effective_to > v_now)
+     ORDER BY effective_from DESC
+     LIMIT 1;
+  END IF;
+  v_price := COALESCE(v_price, 0);
+
+  SELECT COUNT(*) + 1 INTO v_seq
+    FROM customer_orders
+   WHERE tenant_id = v_tenant
+     AND order_no LIKE 'AB-' || v_board.offering_store_id::TEXT || '-%';
+  v_order_no := 'AB-' || v_board.offering_store_id::TEXT || '-' || LPAD(v_seq::TEXT, 4, '0');
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id, pickup_store_id,
+    status, ready_at, order_kind, order_type, notes,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_tenant, v_order_no, v_campaign, v_channel, v_member, v_board.offering_store_id,
+    'ready', v_now, 'restock', 'regular',
+    '【內部】互助板現貨載體 #' || p_board_id ||
+      COALESCE('（' || NULLIF(trim(v_board.spot_title), '') || '）', ''),
+    p_operator, p_operator, v_now, v_now
+  ) RETURNING id INTO v_order_id;
+
+  v_ci := _restock_sentinel_campaign_item(v_tenant, v_campaign, v_board.sku_id, v_price);
+
+  INSERT INTO customer_order_items (
+    tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+    status, source, notes, created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_tenant, v_order_id, v_ci, v_board.sku_id, p_qty, v_price,
+    'pending', 'store_internal', '[互助板認領 #' || p_board_id || ']',
+    p_operator, p_operator, v_now, v_now
+  );
+
+  -- 轉給認領店：空中轉當下就建 AT- 單並從釋出店出庫（20260814030000），
+  -- 沒勾則走經總倉兩段（總倉收件匣派貨）
+  v_dest_order := rpc_transfer_order_partial(
+    p_order_id           => v_order_id,
+    p_to_pickup_store_id => p_to_store_id,
+    p_to_member_id       => NULL,
+    p_to_channel_id      => NULL,
+    p_operator           => p_operator,
+    p_reason             => COALESCE(NULLIF(trim(p_reason), ''), '互助板認領 #' || p_board_id),
+    p_items              => jsonb_build_array(
+                              jsonb_build_object('sku_id', v_board.sku_id, 'qty', p_qty)
+                            ),
+    p_is_air_transfer    => COALESCE(p_is_air_transfer, FALSE)
+  );
+
+  v_board_status := rpc_consume_aid_board(p_board_id, p_qty, p_operator);
+
+  RETURN jsonb_build_object(
+    'board_id',         p_board_id,
+    'board_status',     v_board_status,
+    'carrier_order_id', v_order_id,
+    'carrier_order_no', v_order_no,
+    'dest_order_id',    v_dest_order,
+    'qty',              p_qty
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_claim_manual_spot(BIGINT, BIGINT, NUMERIC, UUID, TEXT, BOOLEAN) IS
+  '互助板「手動現貨」（無來源訂單）的跨店認領：在釋出店建 AB- 載體單（restock '
+  'sentinel trio、單頭 ready）→ 同交易內 rpc_transfer_order_partial 轉給認領店 → '
+  'rpc_consume_aid_board 扣量。載體單建完就轉走，不會停留在現貨池被 _trim_internal_pool 砍。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_claim_manual_spot(BIGINT, BIGINT, NUMERIC, UUID, TEXT, BOOLEAN)
+  TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 2. rpc_update_aid_board_listing：10 → 11 參數（加 p_sku_id 補選商品）
+--    基底 20260802000050 逐字保留，只加 SKU 補選與 qty_remaining 保留已認領量
+-- ----------------------------------------------------------------------------
+
+DROP FUNCTION IF EXISTS public.rpc_update_aid_board_listing(
+  BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ, TEXT, JSONB, TEXT, NUMERIC, BOOLEAN);
+
+CREATE OR REPLACE FUNCTION public.rpc_update_aid_board_listing(
+  p_board_id         BIGINT,
+  p_operator         UUID,
+  p_spot_price       NUMERIC     DEFAULT NULL,
+  p_spot_description TEXT        DEFAULT NULL,
+  p_expires_at       TIMESTAMPTZ DEFAULT NULL,
+  p_spot_title       TEXT        DEFAULT NULL,
+  p_spot_images      JSONB       DEFAULT NULL,
+  p_spot_unit        TEXT        DEFAULT NULL,
+  p_qty_available    NUMERIC     DEFAULT NULL,
+  p_visible_to_other_stores BOOLEAN DEFAULT NULL,
+  p_sku_id           BIGINT      DEFAULT NULL
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_post_type TEXT;
+  v_status    TEXT;
+  v_sku_id    BIGINT;
+  v_order_id  BIGINT;
+  v_title     TEXT := NULLIF(trim(p_spot_title), '');
+  v_images    JSONB;
+  v_available NUMERIC;
+  v_remaining NUMERIC;
+  v_claimed   NUMERIC;
+BEGIN
+  IF p_spot_price IS NOT NULL AND p_spot_price <= 0 THEN
+    RAISE EXCEPTION 'spot_price must be > 0';
+  END IF;
+  -- 到期時間可以往後延，也可以縮短，但不能設到過去
+  -- （設到過去等於立刻下架，那是「結束此貼」該做的事，語意分開）
+  IF p_expires_at IS NOT NULL AND p_expires_at <= NOW() THEN
+    RAISE EXCEPTION 'expires_at must be in the future';
+  END IF;
+  IF p_qty_available IS NOT NULL AND p_qty_available <= 0 THEN
+    RAISE EXCEPTION 'qty_available must be > 0';
+  END IF;
+  IF p_spot_images IS NOT NULL THEN
+    IF jsonb_typeof(p_spot_images) <> 'array' THEN
+      RAISE EXCEPTION 'spot_images must be a JSON array of storage paths';
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM jsonb_array_elements(p_spot_images) e
+       WHERE jsonb_typeof(e) <> 'string'
+    ) THEN
+      RAISE EXCEPTION 'spot_images must contain only strings';
+    END IF;
+    v_images := NULLIF(p_spot_images, '[]'::jsonb);
+  END IF;
+
+  SELECT post_type, status, sku_id, source_customer_order_id, qty_available, qty_remaining
+    INTO v_post_type, v_status, v_sku_id, v_order_id, v_available, v_remaining
+    FROM mutual_aid_board WHERE id = p_board_id
+    FOR UPDATE;
+  IF v_post_type IS NULL THEN
+    RAISE EXCEPTION 'board post % not found', p_board_id;
+  END IF;
+  IF v_post_type <> 'offer' THEN
+    RAISE EXCEPTION 'only offer posts have price/description';
+  END IF;
+  IF v_status <> 'active' THEN
+    RAISE EXCEPTION 'post is % — only active posts can be edited', v_status;
+  END IF;
+  -- 手打商品沒有 SKU 可以 fallback，標題不能清空（先擋，別讓它撞 CHECK）
+  IF v_sku_id IS NULL AND p_sku_id IS NULL AND v_title IS NULL THEN
+    RAISE EXCEPTION 'this listing has no sku — spot_title cannot be cleared';
+  END IF;
+  -- SKU 補選只給手動現貨：從訂單釋出的貼文 SKU 綁著來源訂單品項，改了對不到帳
+  IF p_sku_id IS NOT NULL AND v_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'sku of an order-sourced listing cannot be changed';
+  END IF;
+  IF p_sku_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM skus WHERE id = p_sku_id) THEN
+    RAISE EXCEPTION 'sku % not found', p_sku_id;
+  END IF;
+  -- 數量只有手動現貨能改：從訂單釋出的貼文，qty 和認領扣量的帳綁在一起，
+  -- 直接覆寫會讓已認領的量對不上（要調整請結束此貼重發）
+  IF p_qty_available IS NOT NULL AND v_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'qty of an order-sourced listing cannot be edited';
+  END IF;
+  -- 手動現貨自 20260816000000 起也會被認領扣量 → 改總量時要保留已認領的部分
+  v_claimed := GREATEST(COALESCE(v_available, 0) - COALESCE(v_remaining, 0), 0);
+  IF p_qty_available IS NOT NULL AND p_qty_available < v_claimed THEN
+    RAISE EXCEPTION '已被認領 % 件，數量不能改到比它還小', v_claimed;
+  END IF;
+
+  UPDATE mutual_aid_board
+     SET spot_price       = p_spot_price,
+         spot_description = NULLIF(trim(p_spot_description), ''),
+         spot_title       = v_title,
+         spot_unit        = NULLIF(trim(p_spot_unit), ''),
+         spot_images      = v_images,
+         -- NULL = 不動（清掉 SKU 只會讓貼文退回不可認領，沒有意義）
+         sku_id           = COALESCE(p_sku_id, sku_id),
+         -- NULL = 不動（expires_at 是 NOT NULL，沒有「清除」的語意）
+         expires_at       = COALESCE(p_expires_at, expires_at),
+         -- 手動現貨改總量：剩餘量 = 新總量 − 已認領量（原版直接覆寫，
+         -- 那是「手動現貨不會被認領」年代的假設）
+         qty_available    = COALESCE(p_qty_available, qty_available),
+         qty_remaining    = CASE
+                              WHEN p_qty_available IS NULL THEN qty_remaining
+                              ELSE p_qty_available - v_claimed
+                            END,
+         -- NULL = 不動（欄位 NOT NULL；舊前端沒送就別動人家的可見性）
+         spot_visible_to_other_stores =
+           COALESCE(p_visible_to_other_stores, spot_visible_to_other_stores),
+         updated_by       = p_operator
+   WHERE id = p_board_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_update_aid_board_listing(
+  BIGINT, UUID, NUMERIC, TEXT, TIMESTAMPTZ, TEXT, JSONB, TEXT, NUMERIC, BOOLEAN, BIGINT)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_update_aid_board_listing IS
+  '互助板 offer 貼文發佈後編輯釋出單價 / 商品說明 / 商品標題 / 單位 / 圖片 / '
+  '到期時間 / 數量 / 跨店可見性 / 補選商品(SKU)。spot_price、spot_description、'
+  'spot_title、spot_unit、spot_images 送 NULL = 清除自訂值；expires_at、'
+  'qty_available、visible_to_other_stores、sku_id 送 NULL = 不動。'
+  'sku_id 與 qty 只有手動現貨（無來源訂單）能改；改總量時剩餘量會保留已認領的部分。';


### PR DESCRIPTION
店家回報：「互助交流上面針對有人釋出，分店上來要可以認領，現在怎麼看不到認領的按鈕」。

> ⚠️ **本 PR 的 migration（`20260816000000_manual_spot_claimable.sql`）已於 2026-08-16 走 Management API 套上正式庫**。依 CLAUDE.md 規則，這支要**當天合併進 main**，否則 repo 與正式庫脫鉤。舊前端不會壞：`rpc_update_aid_board_listing` 新參數有 DEFAULT，送 10 個參數仍然通。

## 為什麼看不到認領鈕

線上實測（2026-08-16）：進行中的釋出貼文 29 則，**27 則是「➕ 手動新增現貨」發的**（`source_customer_order_id IS NULL`），前端刻意不畫認領鈕（「沒有訂單可以轉移給別店」）；其中 20 則連 `sku_id` 都是 NULL（純手打標題）。只有 2 則從訂單釋出的才有鈕。

認領的本體是**訂單轉移**（`rpc_transfer_order_partial`）——貨要走既有那一套（空中轉當下建 AT- 單並出庫／經總倉兩段派貨、收貨頁收貨、月結一加一扣），沒有來源訂單就沒東西可轉。

## 改了什麼

**DB（已套上線）**

- 新增 `rpc_claim_manual_spot(board, to_store, qty, operator, reason, is_air)`：認領當下才在釋出店建一張 `AB-<store>-<seq>` 載體單（restock sentinel trio、單頭 ready），**同一個交易內** `rpc_transfer_order_partial` 轉給認領店 → `rpc_consume_aid_board` 扣貼文量。
  - 載體單刻意「建完就轉走」，不是發文時就建：掛在 `store_internal` 上以 ready 停在庫裡會進 `_trim_internal_pool`（20260811000030/40）的池子口徑，手動現貨常常不在 `on_hand` 裡 → 下一次自動配單會把它當超額掛帳砍掉，貼文的貨會莫名其妙消失。
  - 單價 `spot_price` → 分店價 → 零售價 → 0（同 `_grow_internal_pool`）；0 元守衛（20260815000000）本來就排除 `store_internal` 容器單，轉給真會員時會改鎖現售價。
  - 前綴用 `AB-` 不是 `SP-`：`SP-` 已被線上的「現貨直配」`rpc_create_spot_sale` 佔用（⚠️ 該 RPC 線上有、`supabase/migrations/` 沒有 —— 既有的 repo／正式庫脫鉤，不在本 PR 範圍，另行補）。
- `rpc_update_aid_board_listing` 10 → 11 參數（加 `p_sku_id`，基底 20260802000050 逐字保留）：既有 20 則沒商品的貼文能「補選商品」才認領得了；只有手動現貨可改 SKU（訂單來源的綁著來源品項）。連帶修改總量行為：保留已認領量（`remaining = 新 available − 已認領`），並擋「改到比已認領量小」——原本 available/remaining 一起覆寫是「手動現貨不會被認領」年代的假設。

**前端（互助交流板）**

- 手動現貨＋有商品 → 出「✋ 我要認領」（走 `rpc_claim_manual_spot`）；沒商品 → 不出鈕、提示「請按『✏️ 修改內容』補選商品」，列表上標「待補商品」
- 貼文編輯表單多一個商品（SKU）選擇（補選後即可被認領；送 NULL = 不動）
- 「➕ 手動新增現貨」商品改必填（不選就沒人能認領；主檔沒有的先去「商品」頁建）
- 「📦 我有庫存可提供」可挑的訂單從只列 `ready` 放寬到 `ready` + `partially_completed` —— 內部現貨池的單臨櫃賣掉一件就變 `partially_completed`，原本挑不到單，店家只好改發手動現貨（正是這次 27:2 比例的成因之一；轉單 RPC 本來就接受這兩個狀態，20260814000020）

## 驗證

- `next build` 通過；lint 無新增錯誤（該頁既有 7 個 `set-state-in-effect` 為 baseline）
- Playwright + fixture（不碰線上 DB）：有商品的手動現貨出認領鈕、送出打 `rpc_claim_manual_spot` 且 payload 正確；沒商品的不出鈕、顯示補選提示、列表標「待補商品」
- 正式庫（transaction 內實測後 rollback，未留資料）：
  - `rpc_claim_manual_spot(131, 松山店, 2, …, is_air=TRUE)` → 建 `AB-41-0001`、轉入單、`AT-O…` 古華店倉 → 松山店倉 `shipped` ×2
  - 補選 SKU 寫得進去；已認領 2 件的貼文把總量改成 4 → 剩餘量正確變 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEYrHfptAkTChcBcmzVDPi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEYrHfptAkTChcBcmzVDPi)_