### PR TITLE
現貨直配單的按鈕改叫「退回庫存」

### DIFF
--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -657,7 +657,7 @@ export function OrderDetail({
       (head.status === "shipping"
         ? `撤回派貨：${head.order_no}\n${isAidOrder ? "會撤回派貨單並反向回收已出庫存" : "波次出貨的訂單不動庫存，貨留在店端"}，請輸入原因：`
         : isSpotSale
-          ? `取消現貨直配單：${head.order_no}\n這張單還沒扣庫存，取消後那些貨會變回「可分配」。\n請輸入取消原因：`
+          ? `退回庫存：${head.order_no}\n這張單的貨還沒扣庫存，退回後會變回「可分配」，可以再配給別人。\n請輸入原因：`
           : `取消訂單：${head.order_no}\n請輸入取消原因：`) + walletNote
     );
     if (reason === null) return;
@@ -674,7 +674,9 @@ export function OrderDetail({
     const refunded = Number((data as { wallet_refunded?: number } | null)?.wallet_refunded ?? 0);
     alert(refunded > 0
       ? `已取消，已退回 $${refunded} 儲值金到會員餘額`
-      : "已取消");
+      : isSpotSale
+        ? "✅ 已退回庫存，這些貨變回「可分配」了"
+        : "已取消");
     setReloadTick((n) => n + 1);
   }
 
@@ -962,10 +964,22 @@ export function OrderDetail({
           {canCancel && (
             <SpinButton
               onClick={cancelOrder}
-              className="rounded-md border border-red-300 px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950"
-              title={head.status === "shipping" ? "撤回派貨並反向回收已出庫存" : "取消訂單"}
+              className={`rounded-md border px-3 py-1 text-xs font-medium ${
+                isSpotSale
+                  ? "border-amber-300 text-amber-700 hover:bg-amber-50 dark:border-amber-800 dark:text-amber-300 dark:hover:bg-amber-950"
+                  : "border-red-300 text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950"
+              }`}
+              title={
+                head.status === "shipping"
+                  ? "撤回派貨並反向回收已出庫存"
+                  : isSpotSale
+                    ? "這張單的貨還沒扣庫存，退回後會變回「可分配」，可以再配給別人"
+                    : "取消訂單"
+              }
             >
-              取消
+              {/* 現貨直配的貨是從庫存配出去的，退掉＝貨回到可分配，
+                  講「取消」像是作廢一筆買賣，跟店員腦中的動作對不起來（2026-08-16 回報）*/}
+              {isSpotSale ? "↩ 退回庫存" : "取消"}
               {Number(head.wallet_paid_amount ?? 0) > 0 && (
                 <span className="ml-1 text-[10px] font-normal text-zinc-500">(將退 ${Number(head.wallet_paid_amount)})</span>
               )}


### PR DESCRIPTION
承接 #740（已合併）。純前端文案／樣式，沒有 migration。

---

回報：「從庫存來的訂單，應該按鈕是退回庫存」。

那些貨是從庫存配出去的，退掉＝貨回到「可分配」、可以再配給別人。講「取消」像是作廢一筆買賣，跟店員腦中的動作對不起來。

| | 現貨直配（`SP-`） | 其餘訂單 |
|---|---|---|
| 按鈕 | ↩ 退回庫存（琥珀色） | 取消（紅色） |
| 確認框 | 「這張單的貨還沒扣庫存，退回後會變回可分配，可以再配給別人。」 | 「請輸入取消原因」 |
| 完成訊息 | 「✅ 已退回庫存，這些貨變回「可分配」了」 | 「已取消」 |

伺服端行為完全不變 —— #740 的 `20260816000070` 已經放行 `SP-` 單在 `ready` 取消並作廢其 DN 減抵單，這支只換文字與顏色。

## 驗證

`tsc --noEmit` 乾淨；`OrderDetail.tsx` lint 維持 baseline 2（零新增）。

⚠️ **這一項沒有實機截圖**：Playwright harness 這次沒能把訂單明細彈窗開起來（fixture 湊不齊列表資料所需的欄位），所以只有型別與靜態檢查。條件是單純的 `head.order_no?.startsWith("SP-") ?? false`，falsy 時原樣回退到既有的「取消」分支，風險侷限在文案本身。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPzkxUng2Qg4GRHB1QAC3r)_