### PR TITLE
feat(picking): 派貨工作台改成兩步驟 — 先挑商品，再確認數量建單

### DIFF
--- a/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
@@ -2,10 +2,13 @@
 
 // 撿貨清單列印 — SKU × 店家 矩陣，給現場撿貨用
 // 列 = SKU；前幾欄 = 訂購/已到/已撿/可分配；之後是各店家需求數量。
-// 開啟方式：從 /wms/picking 點「📄 列印撿貨清單」開新分頁。
-// data source: 與派貨工作台同 v_picking_demand_by_po。
+// 開啟方式：從 /wms/picking 點「📄 列印…」開新分頁。
+// data source: 與派貨工作台同 v_picking_demand_by_po（本頁自己撈，與工作台零耦合）。
+// ?skus=1,2,3 → 只印這幾個 sku（派貨工作台步驟 1 挑好的品項）。
+//   沒帶這個參數時一切照舊，印全部待撿清單。
 
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { fetchAllRows } from "@/lib/fetchAllRows";
 import SpinButton from "@/components/SpinButton";
@@ -46,11 +49,31 @@ type SkuRow = {
 };
 
 export default function PrintPickListPage() {
+  return (
+    <Suspense fallback={<div className="p-4 text-sm text-zinc-500">載入中…</div>}>
+      <Body />
+    </Suspense>
+  );
+}
+
+function Body() {
   const { tenant } = useAuth();
+  const sp = useSearchParams();
   const [demand, setDemand] = useState<DemandRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const tenantName = tenant?.name ?? getTenantName();
   const [printedAt] = useState(() => new Date());
+
+  // 由派貨工作台「📄 列印已挑 N 樣」帶入。null = 沒帶參數 = 印全部（原行為，一個字不變）。
+  // 參數存在但解析不出東西時回空集合（不是 null）—— 寧可印 0 列並明說，
+  // 也不要「以為只印挑好的、實際印出 180 樣全表」。
+  const skusParam = sp.get("skus");
+  const pickedSkuIds = useMemo(() => {
+    if (skusParam === null) return null;
+    return new Set(
+      skusParam.split(",").map(Number).filter((n) => Number.isInteger(n) && n > 0),
+    );
+  }, [skusParam]);
 
   useEffect(() => {
     let cancelled = false;
@@ -130,9 +153,12 @@ export default function PrintPickListPage() {
       // 隱藏「已到貨且全部派完」與「需求已全數派完（含補貨直派）」的 SKU —
       // 與派貨工作台矩陣的 has_stock_left + has_demand_left 過濾同語意
       .filter((s) => !(s.totalGr > 0 && s.totalAvailable === 0) && s.demandLeft > 0)
+      // ?skus= 帶進來的已挑清單（null = 沒帶 = 不過濾，行為與舊版完全相同）。
+      // 只縮列，不動 stores：店別欄位維持原本的算法，欄位位置在每次列印間保持一致。
+      .filter((s) => pickedSkuIds === null || pickedSkuIds.has(s.sku_id))
       .sort((a, b) => (a.sku_code ?? "").localeCompare(b.sku_code ?? ""));
     return { skuRows, stores };
-  }, [demand]);
+  }, [demand, pickedSkuIds]);
 
   return (
     <>
@@ -175,13 +201,20 @@ export default function PrintPickListPage() {
       <div className="bg-white text-zinc-900 print:bg-white">
         {/* 控制列（列印時隱藏）*/}
         <div className="no-print sticky top-0 z-20 flex flex-wrap items-center gap-3 border-b border-zinc-200 bg-zinc-50 p-3 print:hidden">
-          <h1 className="text-base font-semibold">📄 撿貨清單列印</h1>
+          <h1 className="text-base font-semibold">
+            📄 撿貨清單列印{pickedSkuIds !== null && "（本次已挑）"}
+          </h1>
           <span className="text-sm text-zinc-500">
             {demand === null
               ? "載入中…"
               : skuRows.length === 0
                 ? "（無資料）"
                 : `${skuRows.length} 個 SKU × ${stores.length} 間分店`}
+            {pickedSkuIds !== null && demand !== null && skuRows.length < pickedSkuIds.size && (
+              <span className="ml-2 text-amber-700">
+                （挑了 {pickedSkuIds.size} 樣，其中 {pickedSkuIds.size - skuRows.length} 樣已無待撿需求，未列出）
+              </span>
+            )}
           </span>
           <SpinButton
             onClick={() => window.print()}
@@ -200,7 +233,9 @@ export default function PrintPickListPage() {
 
         {skuRows.length === 0 && demand !== null && (
           <div className="no-print p-6 text-center text-sm text-zinc-500">
-            目前沒有待撿項目。
+            {pickedSkuIds === null
+              ? "目前沒有待撿項目。"
+              : "已挑的品項目前都沒有待撿需求（可能剛建過撿貨單，或需求已派完）。"}
           </div>
         )}
 
@@ -208,7 +243,9 @@ export default function PrintPickListPage() {
           <div className="mx-auto p-4 print:p-0">
             <div className="mb-3 flex items-end justify-between border-b-2 border-zinc-900 pb-2">
               <div>
-                <div className="text-xl font-bold">撿貨清單</div>
+                <div className="text-xl font-bold">
+                  撿貨清單{pickedSkuIds !== null && <span className="ml-2 text-sm font-normal">（本次挑選）</span>}
+                </div>
                 {tenantName && <div className="mt-0.5 text-xs text-zinc-500">{tenantName}</div>}
               </div>
               <div className="text-right text-xs text-zinc-600">

--- a/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
+++ b/apps/admin/src/app/(protected)/picking/print-pick-list/page.tsx
@@ -74,6 +74,9 @@ function Body() {
       skusParam.split(",").map(Number).filter((n) => Number.isInteger(n) && n > 0),
     );
   }, [skusParam]);
+  // 帶了 ?skus= 但一個有效商品編號都解析不出來（?skus= 空的、?skus=abc）。
+  // 這跟「挑的商品都沒貨」是完全不同的兩件事，文案不可以混在一起講。
+  const skusParamInvalid = pickedSkuIds !== null && pickedSkuIds.size === 0;
 
   useEffect(() => {
     let cancelled = false;
@@ -202,7 +205,8 @@ function Body() {
         {/* 控制列（列印時隱藏）*/}
         <div className="no-print sticky top-0 z-20 flex flex-wrap items-center gap-3 border-b border-zinc-200 bg-zinc-50 p-3 print:hidden">
           <h1 className="text-base font-semibold">
-            📄 撿貨清單列印{pickedSkuIds !== null && "（本次已挑）"}
+            📄 撿貨清單列印
+            {skusParamInvalid ? "（網址參數無效）" : pickedSkuIds !== null && "（本次已挑）"}
           </h1>
           <span className="text-sm text-zinc-500">
             {demand === null
@@ -235,7 +239,9 @@ function Body() {
           <div className="no-print p-6 text-center text-sm text-zinc-500">
             {pickedSkuIds === null
               ? "目前沒有待撿項目。"
-              : "已挑的品項目前都沒有待撿需求（可能剛建過撿貨單，或需求已派完）。"}
+              : skusParamInvalid
+                ? "網址參數（?skus=）沒有有效的商品編號，未列印任何列 — 請回派貨工作台重新點「📄 列印已挑 N 樣」。"
+                : "已挑的品項目前都沒有待撿需求（可能剛建過撿貨單，或需求已派完）。"}
           </div>
         )}
 

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -102,6 +102,14 @@ let pickedOwnerKey: string | null = null; // 目前可以寫進哪一把 key；n
 //   (b) 曾經有身分、後來沒了（登出／session 失效）→ 記憶體裡的是「上一個人的」，
 //       絕對不可以在下一把 key 綁定時寫進去。
 let pickedEverBound = false;
+// 「身分世代」：已挑清單的歸屬每換一次（換人、換 scope／換綁 key）就 +1。
+// ⛔ 這是跨使用者資料污染的根本防線。React 的 passive effects 是同一輪一起跑的，
+//    前面的 effect 換掉了 store 的內容與歸屬，**不會**讓後面 effect 的 closure 跟著更新
+//    （阿審第三輪抓到的 P0 就是這個：prune effect 拿 A 的舊 pickedIds 寫進 B 的 key）。
+//    所以寫入端必須帶上「它讀到資料時的世代」，對不上就整批拒絕 —— 不只修掉現在這一個洞，
+//    以後任何人（含平行 session）新增寫入點也一樣擋得住。
+// ⚠️ 每次 +1 之後一定要 emitPicked()，否則畫面上的世代會過期、之後的挑選會被自己擋掉。
+let pickedEpoch = 0;
 const pickedListeners = new Set<() => void>();
 function emitPicked() { for (const l of pickedListeners) l(); }
 function subscribePicked(cb: () => void) {
@@ -109,6 +117,7 @@ function subscribePicked(cb: () => void) {
   return () => { pickedListeners.delete(cb); };
 }
 function getPickedSkuIds() { return pickedSkuIds; }
+function getPickedEpoch() { return pickedEpoch; }
 function readStoredPicked(key: string): number[] {
   try {
     const raw = localStorage.getItem(key);
@@ -125,10 +134,14 @@ function writeStoredPicked(key: string, ids: number[]) {
   } catch { /* 隱私模式：存不了就算了，畫面照常運作 */ }
 }
 // 一律寫進 store 目前綁定的 key（pickedOwnerKey）。還沒綁定（拿不到 tenant/user）就只留在記憶體。
-function setPickedSkuIds(ids: number[]) {
+// expectedEpoch = 呼叫端「讀到這批資料時」的世代，對不上就整批拒絕（連記憶體都不動）。
+// 回傳有沒有寫進去，方便測試與除錯。
+function setPickedSkuIds(ids: number[], expectedEpoch: number): boolean {
+  if (expectedEpoch !== pickedEpoch) return false; // 換人／換 scope 了 —— 這批是上一個人的，丟掉
   pickedSkuIds = ids;
   if (pickedOwnerKey) writeStoredPicked(pickedOwnerKey, ids);
   emitPicked();
+  return true;
 }
 // storage key 一成立（或換帳號 / 換租戶）就對齊一次。
 // 「還沒綁定過」且本機已經挑了東西 → 把它寫下去（tenant 晚到不該讓剛挑的掉）；
@@ -139,13 +152,13 @@ function bindPickedStorage(key: string) {
   //    登出後 pickedOwnerKey 也會是 null，若用它判斷會把上一個人的清單寫進下一個人的 key。
   const draftBeforeAnyIdentity = !pickedEverBound;
   if (draftBeforeAnyIdentity && pickedSkuIds.length > 0) {
+    // 同一個人的草稿落地，歸屬沒變 → 不動世代
     writeStoredPicked(key, pickedSkuIds);
   } else {
-    const stored = readStoredPicked(key);
-    const same =
-      stored.length === pickedSkuIds.length && stored.every((v, i) => v === pickedSkuIds[i]);
-    pickedSkuIds = stored;
-    if (!same) emitPicked();
+    // 改讀另一把 key 的存檔 = 歸屬換了 → 世代 +1，並且一定要 emit（讓畫面重新讀到新世代）
+    pickedSkuIds = readStoredPicked(key);
+    pickedEpoch += 1;
+    emitPicked();
   }
   pickedOwnerKey = key;
   pickedEverBound = true;
@@ -177,9 +190,9 @@ function syncPickedUser(userId: string | null) {
   pickedOwnerKey = null;      // 新的 key 由 bindPickedStorage 接手；在那之前不准寫
   // ⚠️ 不動 pickedEverBound：留 true 才會讓下一次 bind 走「讀新 key 的存檔」那條路。
   //    若把它設回 false，bind 會把現在這個空陣列當成草稿寫下去，反而洗掉 B 自己存好的清單。
-  const had = pickedSkuIds.length > 0;
   pickedSkuIds = [];
-  if (had) emitPicked();
+  pickedEpoch += 1;           // 換人 = 歸屬換了 → 舊世代的寫入一律作廢
+  emitPicked();
 }
 // 跨分頁：別的分頁改了同一個 key → 重讀，避免兩個分頁互相覆蓋
 function refreshPickedFromStorage(key: string) {
@@ -240,6 +253,8 @@ export default function PickingWorkstationPage() {
   const authUserId = user?.id ?? null;
   const pickedStorageKey = pickedStorageKeyFor(tenant?.id, authUserId);
   const pickedIds = useSyncExternalStore(subscribePicked, getPickedSkuIds, getPickedSkuIds);
+  // 讀到 pickedIds 的那一刻是「第幾世代」。所有寫入都要帶著它，換人後的舊世代寫入會被擋掉。
+  const pickedEpoch = useSyncExternalStore(subscribePicked, getPickedEpoch, getPickedEpoch);
   const pickedSkus = useMemo(() => new Set(pickedIds), [pickedIds]);
   // 換人（user.id 從一個非 null 值變成另一個）→ 立刻清掉畫面上的已挑清單。
   // user.id 比 tenant 早到位，所以 B 不會在 tenant 載回來之前看到 A 挑好的東西。
@@ -267,14 +282,21 @@ export default function PickingWorkstationPage() {
   // 已挑清單失效清理：把「已無可分配量」（被別人派完 / 下架）的品項移除並提示。
   // ⚠️ 比對基準是「未經任何篩選」的 alivePickableSkuIds(demand)，不是搜尋結果 ——
   //    拿目前清單去交集正是舊版「選了 30 樣、按建單只剩 1 樣」的根因。
-  // 放 effect 而不是 fetch 回呼：依賴 pickedIds，storage key 晚一步綁定
-  //    （tenant 是登入後非同步拿到的）而從 localStorage 灌回來的清單也會被重檢，
-  //    不會因為「demand 先到、清單後到」而漏掉。清掉 stale 之後 pickedIds 變動
-  //    會再跑一次，此時已無 stale → 直接 return，不會迴圈。
+  // 放 effect 而不是 fetch 回呼：storage key 晚一步綁定（tenant 是登入後非同步拿到的），
+  //    從 localStorage 灌回來的清單也會被重檢，不會因為「demand 先到、清單後到」而漏掉。
+  //    清掉 stale 之後 pickedIds 變動會再跑一次，此時已無 stale → 直接 return，不會迴圈。
+  // ⚠️⚠️ 一定要讀 live snapshot，不可以用 closure 的 pickedIds：
+  //    同一輪 passive effects 裡，上面兩個 effect（換人重置 / 綁新 key）已經換掉 store 的
+  //    內容與歸屬，但 React **不會**替這個 effect 更新 closure。用舊的 pickedIds 算出來的
+  //    結果會被寫進「新那個人」的 key —— 阿審第三輪抓到的 P0 就是這條。
+  //    pickedIds / pickedStorageKey 在依賴陣列裡只當「什麼時候該重檢」的觸發器，值本身不拿來算。
   useEffect(() => {
     if (!demand) return;
+    const livePicked = getPickedSkuIds();
+    const liveEpoch = getPickedEpoch();
+    if (livePicked.length === 0) return;
     const aliveSkus = alivePickableSkuIds(demand);
-    const stalePicks = pickedIds.filter((id) => !aliveSkus.has(id));
+    const stalePicks = livePicked.filter((id) => !aliveSkus.has(id));
     if (stalePicks.length === 0) return;
     // 對外部系統（module store + localStorage）收斂 + 一次性提示，
     // 本質上就是「effect 同步外部資料」，guard 保證不會連鎖重跑。
@@ -282,8 +304,10 @@ export default function PickingWorkstationPage() {
     setPrunedNotice(
       `已挑清單有 ${stalePicks.length} 個品項已無可分配量（可能被別人派完或已下架），已自動移除。`,
     );
-    setPickedSkuIds(pickedIds.filter((id) => aliveSkus.has(id)));
-  }, [demand, pickedIds]);
+    setPickedSkuIds(livePicked.filter((id) => aliveSkus.has(id)), liveEpoch);
+    // pickedStorageKey 也放進來：明講「這個 effect 是在某個 owner scope 下 prune」，
+    // 換人／換 scope 之後要再檢一次，而不是靠 effect 的宣告順序默契。
+  }, [demand, pickedIds, pickedStorageKey]);
   // 矩陣分頁的兩步驟：select = 先挑商品；confirm = 確認數量並建單
   const [pickStep, setPickStep] = useState<"select" | "confirm">("select");
   // 缺價預警：sku_id → 現行成本/分店價是否存在。null = 未載入或此 role 看不到價格（不顯示）。
@@ -854,13 +878,14 @@ export default function PickingWorkstationPage() {
   function togglePick(skuId: number) {
     setPickedSkuIds(
       pickedIds.includes(skuId) ? pickedIds.filter((id) => id !== skuId) : [...pickedIds, skuId],
+      pickedEpoch,
     );
   }
   // 「全部加入」= 把目前搜尋結果一次丟進已挑清單（是聯集，不會蓋掉先前挑的）
   function addAllVisiblePicks() {
     const next = new Set(pickedIds);
     for (const sk of visiblePickRows) next.add(sk.sku_id);
-    setPickedSkuIds(Array.from(next));
+    setPickedSkuIds(Array.from(next), pickedEpoch);
   }
 
   // 本次建單納入的品項：有挑 → 只取挑中的（⚠️ 從 skuRows 取，不與 filteredSkuRows 交集）；
@@ -1179,7 +1204,8 @@ export default function PickingWorkstationPage() {
         // 「已無可分配量、自動移除」的黃色警示（剛建完單看到會以為出事）；
         // 部分派出的品項則殘留在清單裡、下次又被預填數量順手派出去。
         // 部分失敗（failures > 0）不清 —— 留在原地讓使用者修正後重送。
-        setPickedSkuIds([]);
+        // 帶 render 當下的世代：建單途中若換了人，這個清空會被擋掉（不會清到新那個人的清單）。
+        setPickedSkuIds([], pickedEpoch);
         router.push("/hq/inbox?source=picking");
       } else {
         const okPart =
@@ -1620,7 +1646,7 @@ export default function PickingWorkstationPage() {
                   {hasPicked && (
                     <button
                       type="button"
-                      onClick={() => setPickedSkuIds([])}
+                      onClick={() => setPickedSkuIds([], pickedEpoch)}
                       className="min-h-[44px] rounded-md border border-zinc-300 px-3 text-sm text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
                     >
                       清空

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -209,7 +209,7 @@ export default function PickingWorkstationPage() {
   // 步驟 1「已挑清單」＝ sku_id 集合（與建單 scope 同粒度：submitAll 的 FIFO 是 per sku 運作）。
   // ⚠️ 這是獨立集合，絕不與「目前搜尋結果」做交集 —— 舊版就是死在交集上
   //    （搜商品 → 清單只剩 1 列 → 交集後只剩 1 樣，老闆說的「發現只選了一樣」）。
-  //    已無可分配量的品項由「撈完 demand 之後的失效清理」移除並明示提示（見下面的 fetch effect）。
+  //    已無可分配量的品項由「失效清理 effect」移除並明示提示（見 prunedNotice 底下）。
   // 存在 module store 裡（含 tenant/user scope、跨分頁同步），細節見檔頭。
   const { user, tenant } = useAuth();
   const pickedStorageKey = pickedStorageKeyFor(tenant?.id, user?.id);
@@ -232,6 +232,26 @@ export default function PickingWorkstationPage() {
   }, [pickedStorageKey]);
   // 已挑清單被自動移除時的提示（不靜默處理）
   const [prunedNotice, setPrunedNotice] = useState<string | null>(null);
+  // 已挑清單失效清理：把「已無可分配量」（被別人派完 / 下架）的品項移除並提示。
+  // ⚠️ 比對基準是「未經任何篩選」的 alivePickableSkuIds(demand)，不是搜尋結果 ——
+  //    拿目前清單去交集正是舊版「選了 30 樣、按建單只剩 1 樣」的根因。
+  // 放 effect 而不是 fetch 回呼：依賴 pickedIds，storage key 晚一步綁定
+  //    （tenant 是登入後非同步拿到的）而從 localStorage 灌回來的清單也會被重檢，
+  //    不會因為「demand 先到、清單後到」而漏掉。清掉 stale 之後 pickedIds 變動
+  //    會再跑一次，此時已無 stale → 直接 return，不會迴圈。
+  useEffect(() => {
+    if (!demand) return;
+    const aliveSkus = alivePickableSkuIds(demand);
+    const stalePicks = pickedIds.filter((id) => !aliveSkus.has(id));
+    if (stalePicks.length === 0) return;
+    // 對外部系統（module store + localStorage）收斂 + 一次性提示，
+    // 本質上就是「effect 同步外部資料」，guard 保證不會連鎖重跑。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPrunedNotice(
+      `已挑清單有 ${stalePicks.length} 個品項已無可分配量（可能被別人派完或已下架），已自動移除。`,
+    );
+    setPickedSkuIds(pickedIds.filter((id) => aliveSkus.has(id)));
+  }, [demand, pickedIds]);
   // 矩陣分頁的兩步驟：select = 先挑商品；confirm = 確認數量並建單
   const [pickStep, setPickStep] = useState<"select" | "confirm">("select");
   // 缺價預警：sku_id → 現行成本/分店價是否存在。null = 未載入或此 role 看不到價格（不顯示）。
@@ -286,20 +306,9 @@ export default function PickingWorkstationPage() {
         setError(null);
         setDemand(dRows);
         setRestockDemand(rrRows);
-        // 已挑清單失效清理：資料一到就把「已無可分配量」（被別人派完 / 下架）的品項移除並提示。
-        // ⚠️ 比對基準是「未經任何篩選」的 alivePickableSkuIds(dRows)，不是搜尋結果 ——
-        //    拿目前清單去交集正是舊版「選了 30 樣、按建單只剩 1 樣」的根因。
-        // 讀 module store 的 getPickedSkuIds() 而不是閉包裡的 pickedIds：本回呼是 async 的，
-        // 閉包抓到的是舊快照；module store 永遠是最新值。
-        const aliveSkus = alivePickableSkuIds(dRows);
-        const currentPicks = getPickedSkuIds();
-        const stalePicks = currentPicks.filter((id) => !aliveSkus.has(id));
-        if (stalePicks.length > 0) {
-          setPickedSkuIds(currentPicks.filter((id) => aliveSkus.has(id)));
-          setPrunedNotice(
-            `已挑清單有 ${stalePicks.length} 個品項已無可分配量（可能被別人派完或已下架），已自動移除。`,
-          );
-        }
+        // 已挑清單失效清理在獨立的 effect（依賴 demand + pickedIds），不在這個回呼裡做：
+        // 回呼只跑一次，若 demand 比 tenant 先到位，此刻 store 還是空的、
+        // bind 之後才從 localStorage 灌回來的那批就永遠漏檢（靜默失效）。
         const sm = new Map<number, Supplier>();
         for (const s of supRows) sm.set(s.id, s);
         setSuppliers(sm);
@@ -1134,6 +1143,11 @@ export default function PickingWorkstationPage() {
               results.map((r) => `  ${r.po_no} → ${r.wave_code}`).join("\n"),
           );
         }
+        // 這批已經建完 → 清空已挑清單。留著的話：全派完的品項下次進來會觸發
+        // 「已無可分配量、自動移除」的黃色警示（剛建完單看到會以為出事）；
+        // 部分派出的品項則殘留在清單裡、下次又被預填數量順手派出去。
+        // 部分失敗（failures > 0）不清 —— 留在原地讓使用者修正後重送。
+        setPickedSkuIds([]);
         router.push("/hq/inbox?source=picking");
       } else {
         const okPart =

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -79,6 +79,97 @@ function defaultWaveDate() {
   return d.toLocaleDateString("sv-SE");
 }
 
+// 步驟 1 挑好的「商品 × 採購單」存 localStorage：換分頁、重新整理都不會掉。
+// 慣例照 repo 既有寫法（components/AidShipmentReminder.tsx、transfers/settlement/review）。
+const PICKED_KEY = "wms-picking-picked-v1";
+function loadPickedKeys(): Set<string> {
+  try {
+    const raw = localStorage.getItem(PICKED_KEY);
+    const arr = raw ? (JSON.parse(raw) as unknown) : [];
+    // 只收 `${po_id}:${sku_id}` 形狀的字串，擋掉手改過 / 舊版殘留的髒資料
+    return new Set(
+      Array.isArray(arr) ? arr.map(String).filter((s) => /^\d+:\d+$/.test(s)) : [],
+    );
+  } catch {
+    return new Set(); // 隱私模式 / JSON 壞掉：當作沒挑過，不讓工作台整頁掛掉
+  }
+}
+function savePickedKeys(keys: Set<string>) {
+  try {
+    localStorage.setItem(PICKED_KEY, JSON.stringify(Array.from(keys)));
+  } catch { /* 隱私模式：存不了就算了，畫面照常運作 */ }
+}
+
+// 步驟 1（挑選商品）的一列 = 一個商品 × 一張採購單。只給挑選畫面用，不進建單流程。
+type PickRow = {
+  key: string;                          // `${po_id}:${sku_id}` — 已挑清單存的就是這個
+  po_id: number;
+  po_no: string;
+  sku_id: number;
+  sku_code: string | null;
+  sku_label: string;
+  grQty: number;                        // 這一團（這張採購單）到了多少
+  available: number;                    // 可分配 = 該 PO 該 SKU 已到貨 − 已派（按採購單各自算）
+  campaignIds: number[];
+  isRestockSourced: boolean;
+};
+
+// 從 demand 列組出「商品 × 採購單」清單。
+// 老闆原話：「會一直重覆開團，相同的品名容易搞錯，第一團未到、第二團到了會派錯」
+// → 不能像矩陣那樣把同商品跨團合成一列。
+// ⚠️ 這是純顯示用的衍生資料。矩陣與建單仍走 skuRows(per sku) ＋ submitAll 的 FIFO，
+//    因為 allocs 的 key 是 `${sku_id}:${store_id}`（沒有 po_id），
+//    把 skuRows 拆成 per PO 會讓 FIFO 對同一個 qty 派兩次。那段一個字都沒動。
+// 放模組層是為了讓「已挑清單失效清理」能用同一支算 alive key，避免兩處條件飄移。
+function buildPickRows(
+  demand: DemandRow[] | null,
+  poItemCampaigns: Map<number, number[]> | null,
+): PickRow[] {
+  if (!demand) return [];
+  const m = new Map<string, PickRow>();
+  const cidSets = new Map<string, Set<number>>();
+  for (const r of demand) {
+    if (r.store_id === null) continue; // 與 skuRows 同條件
+    const key = `${r.po_id}:${r.sku_id}`;
+    let row = m.get(key);
+    if (!row) {
+      // gr_qty / po_sku_already_wave 在同 (po, sku) 的各 store row 是同值（view 保證），取首列即可
+      const gr = Number(r.gr_qty);
+      const already = Number(r.po_sku_already_wave ?? 0);
+      row = {
+        key,
+        po_id: r.po_id,
+        po_no: r.po_no,
+        sku_id: r.sku_id,
+        sku_code: r.sku_code,
+        sku_label: r.sku_label,
+        grQty: gr,
+        // 「可分配 = 0 就隱藏」按採購單各自算：第一團未到(到貨 0)或已派完的那列不會掛在畫面上
+        available: Math.max(0, gr - already),
+        campaignIds: [],
+        isRestockSourced: !!r.is_restock_sourced,
+      };
+      m.set(key, row);
+      cidSets.set(key, new Set<number>());
+    }
+    if (r.is_restock_sourced) row.isRestockSourced = true;
+    // 同一張 PO 的同一個 SKU 可能來自多個 po_item → 開團取聯集
+    for (const cid of poItemCampaigns?.get(r.po_item_id) ?? []) cidSets.get(key)!.add(cid);
+  }
+  for (const [key, set] of cidSets) {
+    const row = m.get(key);
+    if (row) row.campaignIds = Array.from(set);
+  }
+  return Array.from(m.values())
+    .filter((p) => p.available > 0)
+    .sort(
+      (a, b) =>
+        (a.sku_code ?? "").localeCompare(b.sku_code ?? "") ||
+        a.sku_label.localeCompare(b.sku_label) ||
+        a.po_id - b.po_id,
+    );
+}
+
 export default function PickingWorkstationPage() {
   const router = useRouter();
   // 矩陣視角只撈「還有庫存可分配」的列（has_stock_left），避免整張 view（線上上萬列）全撈。
@@ -98,8 +189,20 @@ export default function PickingWorkstationPage() {
   const [submitting, setSubmitting] = useState(false);
   const [submittingRrId, setSubmittingRrId] = useState<number | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
-  // 勾選的品項（sku_id）。空集合 = 未篩選 → 建單時納入全部；非空 → 只建選取的品項。
-  const [selectedSkus, setSelectedSkus] = useState<Set<number>>(new Set());
+  // 步驟 1「已挑清單」：key = `${po_id}:${sku_id}`（一列 = 一個商品 × 一張採購單）。
+  // ⚠️ 這是獨立集合，絕不與「目前搜尋結果」做交集 —— 舊版就是死在交集上
+  //    （搜商品 → 清單只剩 1 列 → 交集後只剩 1 樣，老闆說的「發現只選了一樣」）。
+  //    已無可分配量的品項改由「撈完 demand 之後的失效清理」移除並明示提示（見上面的 fetch effect）。
+  // 初值直接讀 localStorage（同 components/AidShipmentReminder.tsx 的慣例）。
+  // 不會有 hydration 落差：demand 還沒撈回來前，畫面上所有跟已挑清單有關的東西
+  // 都是從 allPickRows（此時是空陣列）推出來的，SSR 與 client 首次 render 的輸出相同。
+  const [pickedKeys, setPickedKeys] = useState<Set<string>>(
+    () => (typeof window === "undefined" ? new Set<string>() : loadPickedKeys()),
+  );
+  // 已挑清單被自動移除時的提示（不靜默處理）
+  const [prunedNotice, setPrunedNotice] = useState<string | null>(null);
+  // 矩陣分頁的兩步驟：select = 先挑商品；confirm = 確認數量並建單
+  const [pickStep, setPickStep] = useState<"select" | "confirm">("select");
   // 缺價預警：sku_id → 現行成本/分店價是否存在。null = 未載入或此 role 看不到價格（不顯示）。
   const [priceFlags, setPriceFlags] = useState<Map<number, PriceFlags> | null>(null);
   const [canFixPrices, setCanFixPrices] = useState(false);
@@ -113,7 +216,9 @@ export default function PickingWorkstationPage() {
   // 總倉即時在庫（stock_balances.on_hand @ central_warehouse），純參考顯示。
   const [hqOnHand, setHqOnHand] = useState<Map<number, number> | null>(null);
   const [filterCampaign, setFilterCampaign] = useState<string>("all"); // "all" | "none" | `${campaign_id}`
-  const [filterSku, setFilterSku] = useState<string>("all"); // "all" | `${sku_id}`
+  // 商品搜尋（取代原本的「商品」單選下拉 —— 單選會把清單縮到 1 列，正是掉選的根因）。
+  // 比對 sku_label（商品名稱）＋ sku_code（品號），模糊、不分大小寫、去頭尾空白。
+  const [skuQuery, setSkuQuery] = useState("");
   const [filterTime, setFilterTime] = useState<TimeFilter>("all");
   // 預設只顯示「篩選範圍內還有需求」的分店欄（17 間店的矩陣在平板上塞不下）。
   const [showAllStores, setShowAllStores] = useState(false);
@@ -150,6 +255,22 @@ export default function PickingWorkstationPage() {
         setError(null);
         setDemand(dRows);
         setRestockDemand(rrRows);
+        // 已挑清單失效清理：資料一到就把「已無可分配量」（被別人派完 / 下架）的品項移除並提示。
+        // ⚠️ 比對基準是「未經任何篩選」的 buildPickRows(dRows)，不是搜尋結果 ——
+        //    拿目前清單去交集正是舊版「選了 30 樣、按建單只剩 1 樣」的根因。
+        // 這裡讀 localStorage 而不是 pickedKeys state：本回呼是 async 的，閉包裡的 state 是舊快照，
+        // 而 localStorage 在每次挑選後都會被寫回（見下方 persist effect），永遠是最新值。
+        // 隱私模式下讀不到 → 不清也不提示；已挑清單的顯示與建單範圍本來就只算 allPickRows 裡還在的列，
+        // 殘留的失效 key 不會被派出去。
+        const alivePickKeys = new Set(buildPickRows(dRows, null).map((p) => p.key));
+        const persistedPicks = Array.from(loadPickedKeys());
+        const stalePicks = persistedPicks.filter((k) => !alivePickKeys.has(k));
+        if (stalePicks.length > 0) {
+          setPickedKeys(new Set(persistedPicks.filter((k) => alivePickKeys.has(k))));
+          setPrunedNotice(
+            `已挑清單有 ${stalePicks.length} 個品項已無可分配量（可能被別人派完或已下架），已自動移除。`,
+          );
+        }
         const sm = new Map<number, Supplier>();
         for (const s of supRows) sm.set(s.id, s);
         setSuppliers(sm);
@@ -583,54 +704,112 @@ export default function PickingWorkstationPage() {
         ? filterCampaign
         : "all";
 
-  // 商品下拉選項：通過 開團＋時間 篩選的品項（商品自身的篩選不影響選項清單）。
-  const skuOptions = useMemo(
-    () =>
-      skuRows.filter((sk) => {
-        const cids = Array.from(sk.campaignIds);
-        if (filterTime !== "all" && !cids.some(campaignInTime)) return false;
-        if (effFilterCampaign === "none" && cids.length > 0) return false;
-        if (effFilterCampaign !== "all" && effFilterCampaign !== "none" && !cids.includes(Number(effFilterCampaign))) return false;
-        return true;
-      }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [skuRows, effFilterCampaign, filterTime, timeCutoff, campaignsById],
-  );
-  const effFilterSku =
-    filterSku !== "all" && skuOptions.some((sk) => String(sk.sku_id) === filterSku)
-      ? filterSku
-      : "all";
+  // 商品搜尋比對：名稱 + 品號，模糊、不分大小寫、去頭尾空白（老闆：「我找商品完全是用商品的名稱」）。
+  // 空字串 = 全部通過（等同舊版 filterSku="all"）。自由文字沒有「選中的值會失效」的問題，
+  // 所以不需要舊版 effFilterSku 那種自我修正；搜不到就是 0 筆，由既有空狀態文案接住。
+  const skuQueryNorm = skuQuery.trim().toLowerCase();
+  const skuMatchesQuery = (skuLabel: string, skuCode: string | null): boolean => {
+    if (skuQueryNorm === "") return true;
+    return (
+      skuLabel.toLowerCase().includes(skuQueryNorm) ||
+      (skuCode ?? "").toLowerCase().includes(skuQueryNorm)
+    );
+  };
 
-  const rowPassesFilters = (campaignIds: Iterable<number>, skuId: number): boolean => {
+  const rowPassesFilters = (
+    campaignIds: Iterable<number>,
+    skuLabel: string,
+    skuCode: string | null,
+  ): boolean => {
     const cids = Array.from(campaignIds);
     if (filterTime !== "all" && !cids.some(campaignInTime)) return false;
     if (effFilterCampaign === "none" && cids.length > 0) return false;
     if (effFilterCampaign !== "all" && effFilterCampaign !== "none" && !cids.includes(Number(effFilterCampaign))) return false;
-    if (effFilterSku !== "all" && skuId !== Number(effFilterSku)) return false;
+    if (!skuMatchesQuery(skuLabel, skuCode)) return false;
     return true;
   };
-  const hasActiveFilter = effFilterCampaign !== "all" || effFilterSku !== "all" || filterTime !== "all";
+  const hasActiveFilter = effFilterCampaign !== "all" || skuQueryNorm !== "" || filterTime !== "all";
 
   // 通過全部篩選的矩陣列
   const filteredSkuRows = useMemo(
-    () => skuRows.filter((sk) => rowPassesFilters(sk.campaignIds, sk.sku_id)),
+    () => skuRows.filter((sk) => rowPassesFilters(sk.campaignIds, sk.sku_label, sk.sku_code)),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [skuRows, effFilterCampaign, effFilterSku, filterTime, timeCutoff, campaignsById],
+    [skuRows, effFilterCampaign, skuQueryNorm, filterTime, timeCutoff, campaignsById],
   );
 
-  // 平板塞不下 17 欄 → 預設只顯示「篩選範圍內還有未派需求、或已填擬分量」的分店欄。
+  // ===== 步驟 1 的挑選清單：一列 = 一個商品 × 一張採購單（組法見模組層 buildPickRows）=====
+  const allPickRows: PickRow[] = useMemo(
+    () => buildPickRows(demand, poItemCampaigns),
+    [demand, poItemCampaigns],
+  );
+
+  // 目前搜尋 / 開團 / 時間 篩選後要顯示的挑選列（只影響「看得到什麼」，不影響已挑清單）
+  const visiblePickRows = useMemo(
+    () => allPickRows.filter((p) => rowPassesFilters(p.campaignIds, p.sku_label, p.sku_code)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [allPickRows, effFilterCampaign, skuQueryNorm, filterTime, timeCutoff, campaignsById],
+  );
+
+  // 已挑的列。⚠️ 比對基準是「未經任何篩選」的 allPickRows，不是 visiblePickRows ——
+  // 拿目前搜尋結果去交集，正是老闆遇到的「選了 30 樣、按建單只剩 1 樣」的根因。
+  const pickedPickRows = useMemo(
+    () => allPickRows.filter((p) => pickedKeys.has(p.key)),
+    [allPickRows, pickedKeys],
+  );
+
+  // 已挑清單寫回 localStorage（純粹把 React state 同步到外部系統，正是 effect 該做的事）
+  useEffect(() => {
+    savePickedKeys(pickedKeys);
+  }, [pickedKeys]);
+
+  function togglePick(key: string) {
+    setPickedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+  // 「全部加入」= 把目前搜尋結果一次丟進已挑清單（是聯集，不會蓋掉先前挑的）
+  function addAllVisiblePicks() {
+    setPickedKeys((prev) => {
+      const next = new Set(prev);
+      for (const p of visiblePickRows) next.add(p.key);
+      return next;
+    });
+  }
+  function pickRowCampaigns(p: PickRow): CampaignInfo[] {
+    return p.campaignIds
+      .map((cid) => campaignsById?.get(cid))
+      .filter((c): c is CampaignInfo => !!c);
+  }
+
+  // 一個商品可能跨多張 PO 被挑到 → 去重成 sku 集合（矩陣與 submitAll 的 FIFO 都是 per sku 運作）
+  const pickedSkuIds = useMemo(
+    () => new Set(pickedPickRows.map((p) => p.sku_id)),
+    [pickedPickRows],
+  );
+  const hasPicked = pickedSkuIds.size > 0;
+  // 本次建單納入的品項：有挑 → 只取挑中的（⚠️ 從 skuRows 取，不與 filteredSkuRows 交集）；
+  // 沒挑 → 維持現行「篩選範圍內全部」語意，行為不變。
+  const effectiveSkuRows = useMemo(
+    () => (hasPicked ? skuRows.filter((sk) => pickedSkuIds.has(sk.sku_id)) : filteredSkuRows),
+    [hasPicked, skuRows, pickedSkuIds, filteredSkuRows],
+  );
+
+  // 平板塞不下 17 欄 → 預設只顯示「本次建單範圍內還有未派需求、或已填擬分量」的分店欄。
   // 注意：分配上限（getSkuAllocTotal）永遠算全部分店，隱藏欄的擬分量照樣計入。
   const visibleStores: StoreInfo[] = useMemo(() => {
     if (showAllStores) return allStores;
     const kept = allStores.filter((st) =>
-      filteredSkuRows.some(
+      effectiveSkuRows.some(
         (sk) => storeDemandLeft(sk, st.store_id) > 0 || getAlloc(sk.sku_id, st.store_id) > 0,
       ),
     );
     // 全部被濾光（例如需求都派完了）就退回顯示全部，避免空矩陣看不懂
     return kept.length > 0 ? kept : allStores;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allStores, filteredSkuRows, showAllStores, allocs]);
+  }, [allStores, effectiveSkuRows, showAllStores, allocs]);
   const hiddenStoreCount = allStores.length - visibleStores.length;
 
   // 依分店視角（純檢視）
@@ -647,7 +826,9 @@ export default function PickingWorkstationPage() {
     const grouped = new Map<number, StoreSection>();
     for (const r of fullDemand) {
       if (r.store_id === null) continue;
-      if (!rowPassesFilters(poItemCampaigns?.get(r.po_item_id) ?? [], r.sku_id)) continue;
+      // ⚠️ 商品比對要用「該列自己的名稱/品號」：fullDemand 含缺貨待到的品項，
+      //    拿矩陣那份 sku_id 集合去比會把它們整批濾掉。
+      if (!rowPassesFilters(poItemCampaigns?.get(r.po_item_id) ?? [], r.sku_label, r.sku_code)) continue;
       if (!grouped.has(r.store_id)) {
         grouped.set(r.store_id, {
           storeId: r.store_id,
@@ -660,7 +841,7 @@ export default function PickingWorkstationPage() {
     }
     return Array.from(grouped.values()).sort((a, b) => (a.storeCode ?? "").localeCompare(b.storeCode ?? ""));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fullDemand, poItemCampaigns, effFilterCampaign, effFilterSku, filterTime, timeCutoff, campaignsById]);
+  }, [fullDemand, poItemCampaigns, effFilterCampaign, skuQueryNorm, filterTime, timeCutoff, campaignsById]);
 
   // 補貨申請預設分配 = min(申請量 - 已撿, HQ 庫存) per (rr, sku)
   useEffect(() => {
@@ -680,26 +861,52 @@ export default function PickingWorkstationPage() {
     });
   }, [restockDemand]);
 
-  // 預設分配 = max(0, demand - wave) per (sku, store)
+  // 預設分配 = max(0, demand - wave) per (sku, store)，並夾在該 SKU 的可分配量之內。
   // wave_qty 已含撿貨單與補貨直派 transfer（不論是否已收貨），
   // shipped 是 wave 的子集合（已收貨的部分），再減會重複扣 → 不減。
+  // ⚠️ cap 的由來：訂 108 只到 105 時，舊版預填 108 > 可分配 105 → 整列變紅、
+  //    submitAll 的「超過可分配量」直接 throw → 整批建單失敗（部分到貨很常見）。
   useEffect(() => {
     if (!demand) return;
     setAllocs((prev) => {
       const next = new Map(prev);
       const agg = new Map<AllocKey, { demand: number; wave: number }>();
+      // 每個 SKU 的可分配量，算式與 skuRows.totalAvailable 完全一致：
+      // per (po, sku) 去重後 max(0, Σgr_qty − Σpo_sku_already_wave)。
+      const availBySku = new Map<number, number>();
+      const poSkuSeen = new Set<string>();
       for (const r of demand) {
         if (r.store_id === null) continue;
+        const poSkuKey = `${r.po_id}:${r.sku_id}`;
+        if (!poSkuSeen.has(poSkuKey)) {
+          poSkuSeen.add(poSkuKey);
+          availBySku.set(
+            r.sku_id,
+            (availBySku.get(r.sku_id) ?? 0) + Number(r.gr_qty) - Number(r.po_sku_already_wave ?? 0),
+          );
+        }
         const k: AllocKey = `${r.sku_id}:${r.store_id}`;
         const slot = agg.get(k) ?? { demand: 0, wave: 0 };
         slot.demand += Number(r.demand_qty);
         slot.wave += Number(r.wave_qty);
         agg.set(k, slot);
       }
+      // headroom = 可分配量 − 已經存在的分配量（使用者手動改過的、上一輪預填的都先扣掉）
+      const headroom = new Map<number, number>();
+      for (const [skuId, av] of availBySku) headroom.set(skuId, Math.max(0, av));
+      for (const [k, val] of next) {
+        const skuId = Number(k.split(":")[0]);
+        const room = headroom.get(skuId);
+        if (room !== undefined) headroom.set(skuId, Math.max(0, room - val));
+      }
+      // 依 agg 的插入順序（= 查詢的 po_item_id, store_id 排序）逐格填，順序穩定可預期
       for (const [k, v] of agg.entries()) {
-        if (!next.has(k)) {
-          next.set(k, Math.max(0, v.demand - v.wave));
-        }
+        if (next.has(k)) continue; // 使用者改過 / 已填過的格子不動（既有語意保留）
+        const skuId = Number(k.split(":")[0]);
+        const room = headroom.get(skuId) ?? 0;
+        const give = Math.min(Math.max(0, v.demand - v.wave), room);
+        next.set(k, give);
+        headroom.set(skuId, room - give);
       }
       return next;
     });
@@ -919,33 +1126,10 @@ export default function PickingWorkstationPage() {
   // ============================================================
   // 渲染
   // ============================================================
-  // ===== 勾選品項 =====
-  // 一律以「與目前清單的交集」為準：selectedSkus 可能殘留已消失的 sku_id，
-  // 交集會自動忽略它們（免用 effect 清理、計數也不會超算）。
-  const selectedRows = useMemo(
-    () => filteredSkuRows.filter((s) => selectedSkus.has(s.sku_id)),
-    [filteredSkuRows, selectedSkus],
-  );
-  const hasSelection = selectedRows.length > 0;
-  const allVisibleSelected = filteredSkuRows.length > 0 && selectedRows.length === filteredSkuRows.length;
-  function toggleSku(skuId: number) {
-    setSelectedSkus((prev) => {
-      const next = new Set(prev);
-      if (next.has(skuId)) next.delete(skuId);
-      else next.add(skuId);
-      return next;
-    });
-  }
-  function toggleAllSkus() {
-    setSelectedSkus((prev) =>
-      filteredSkuRows.length > 0 && filteredSkuRows.every((s) => prev.has(s.sku_id))
-        ? new Set()
-        : new Set(filteredSkuRows.map((s) => s.sku_id)),
-    );
-  }
-
-  // 本次建單納入的品項：有勾選 → 只取選取的；未勾選 → 篩選範圍內全部
-  const effectiveSkuRows = hasSelection ? selectedRows : filteredSkuRows;
+  // ===== 本次建單納入的品項 =====
+  // 舊版在這裡做「勾選 ∩ 目前清單」，搜商品時清單只剩 1 列 → 勾好的 30 樣被吃掉只剩 1 樣。
+  // 現在改由步驟 1 的已挑清單決定（effectiveSkuRows 定義在 filteredSkuRows 附近），
+  // 已挑清單完全不與目前清單做交集。
 
   // 本次擬分總量（限納入的品項）
   const totalAllocSum = useMemo(() => {
@@ -993,16 +1177,16 @@ export default function PickingWorkstationPage() {
     [effectiveSkuRows, allStores, demand, allocs], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
-  // 可分配清單中缺成本/分店價的品項數（派貨時會被 DB 守衛擋下）
+  // 本次建單範圍內缺成本/分店價的品項數（派貨時會被 DB 守衛 _missing_dispatch_prices 擋下）
   const missingPriceCount = useMemo(() => {
     if (!canFixPrices || !priceFlags) return 0;
     let n = 0;
-    for (const sk of filteredSkuRows) {
+    for (const sk of effectiveSkuRows) {
       const f = priceFlags.get(sk.sku_id);
       if (f && (!f.cost || !f.branch)) n += 1;
     }
     return n;
-  }, [filteredSkuRows, priceFlags, canFixPrices]);
+  }, [effectiveSkuRows, priceFlags, canFixPrices]);
 
   // ===== 補貨申請(無 PO 來源)分組 =====
   type RestockGroup = {
@@ -1034,13 +1218,15 @@ export default function PickingWorkstationPage() {
     return Array.from(map.values()).sort((a, b) => a.rrId - b.rrId);
   }, [restockDemand]);
 
-  // 補貨申請不屬於任何開團：選了特定開團就整段隱藏；商品篩選則濾到含該品項的申請。
+  // 補貨申請不屬於任何開團：選了特定開團就整段隱藏；商品搜尋則濾到含命中品項的申請。
   const visibleRestockGroups = useMemo(() => {
     if (effFilterCampaign !== "all" && effFilterCampaign !== "none") return [];
-    if (effFilterSku === "all") return restockGroups;
-    const skuId = Number(effFilterSku);
-    return restockGroups.filter((g) => g.lines.some((ln) => ln.sku_id === skuId));
-  }, [restockGroups, effFilterCampaign, effFilterSku]);
+    if (skuQueryNorm === "") return restockGroups;
+    return restockGroups.filter((g) =>
+      g.lines.some((ln) => skuMatchesQuery(ln.sku_label, ln.sku_code)),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [restockGroups, effFilterCampaign, skuQueryNorm]);
 
   function getRestockAlloc(rrId: number, skuId: number): number {
     return restockAllocs.get(`${rrId}:${skuId}`) ?? 0;
@@ -1089,18 +1275,19 @@ export default function PickingWorkstationPage() {
     }
   }
 
-  // KPI 總覽
+  // KPI 總覽 — 口徑對齊「本次建單範圍」（本次擬分 / 預計切幾張 wave 本來就是用 effectiveSkuRows，
+  // 若這裡改用篩選範圍，挑了 30 樣時「可分配庫存」會顯示 180 樣的總和，四格互相打架）
   const kpis = useMemo(() => {
     let totalAvailable = 0, totalInTransit = 0, totalShortage = 0;
     let skuShortageCount = 0;
-    for (const sk of filteredSkuRows) {
+    for (const sk of effectiveSkuRows) {
       totalAvailable += sk.totalAvailable;
       totalInTransit += sk.totalInTransit;
       totalShortage += sk.totalShortage;
       if (sk.totalShortage > 0) skuShortageCount += 1;
     }
     return { totalAvailable, totalInTransit, totalShortage, skuShortageCount };
-  }, [filteredSkuRows]);
+  }, [effectiveSkuRows]);
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
@@ -1108,7 +1295,7 @@ export default function PickingWorkstationPage() {
         <div>
           <h1 className="text-xl font-semibold">🚦 派貨工作台</h1>
           <p className="text-sm text-zinc-500">
-            從總倉已到貨庫存派給各分店 — 先用下拉選「開團 / 商品 / 時間」縮小範圍,再對 品項 × 分店 填配送量;建單時依 PO 自動切分。需求派完的品項會自動下架。
+            從總倉已到貨庫存派給各分店 — <strong>步驟 1</strong> 用商品名稱搜尋、把今天要撿的貨一樣一樣加進「已挑清單」;<strong>步驟 2</strong> 系統帶出各店要的數量,一次建立撿貨單。建單時依 PO 自動切分,需求派完的品項會自動下架。
           </p>
         </div>
         <Link
@@ -1132,20 +1319,30 @@ export default function PickingWorkstationPage() {
               onChange={setFilterCampaign}
             />
           </div>
+          {/* 商品搜尋取代舊的單選下拉：單選會把清單縮到 1 列，把已勾的品項全吃掉。
+              搜尋只影響「看得到什麼」，已挑清單完全不受影響。 */}
           <label className="flex min-w-[220px] flex-1 flex-col gap-1 sm:max-w-xs">
-            <span className="text-xs font-medium text-zinc-500">商品</span>
-            <select
-              value={effFilterSku}
-              onChange={(e) => setFilterSku(e.target.value)}
-              className="h-11 w-full rounded-md border border-zinc-300 bg-white px-3 text-sm dark:border-zinc-700 dark:bg-zinc-800"
-            >
-              <option value="all">全部商品（{skuOptions.length}）</option>
-              {skuOptions.map((sk) => (
-                <option key={sk.sku_id} value={String(sk.sku_id)}>
-                  {sk.sku_code ? `${sk.sku_code} · ` : ""}{sk.sku_label}
-                </option>
-              ))}
-            </select>
+            <span className="text-xs font-medium text-zinc-500">商品搜尋（名稱 / 品號）</span>
+            <div className="relative">
+              <input
+                type="search"
+                value={skuQuery}
+                onChange={(e) => setSkuQuery(e.target.value)}
+                placeholder="打商品名稱,例如 蔥抓餅"
+                aria-label="搜尋商品名稱或品號"
+                className="h-11 w-full rounded-md border border-zinc-300 bg-white px-3 pr-9 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+              />
+              {skuQueryNorm !== "" && (
+                <button
+                  type="button"
+                  onClick={() => setSkuQuery("")}
+                  aria-label="清除搜尋"
+                  className="absolute right-1 top-1 h-9 w-8 rounded text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-700"
+                >
+                  ✕
+                </button>
+              )}
+            </div>
           </label>
           <label className="flex w-40 flex-col gap-1">
             <span className="text-xs font-medium text-zinc-500" title="以開團的結團時間算（沒結團時間就看開團時間），含還沒結團的">時間</span>
@@ -1164,7 +1361,7 @@ export default function PickingWorkstationPage() {
           {hasActiveFilter && (
             <button
               type="button"
-              onClick={() => { setFilterCampaign("all"); setFilterSku("all"); setFilterTime("all"); }}
+              onClick={() => { setFilterCampaign("all"); setSkuQuery(""); setFilterTime("all"); }}
               className="h-11 rounded-md border border-zinc-300 px-4 text-sm text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
             >
               ✕ 清除篩選
@@ -1173,8 +1370,8 @@ export default function PickingWorkstationPage() {
         </div>
       )}
 
-      {/* KPI bar */}
-      {filteredSkuRows.length > 0 && (
+      {/* KPI bar（口徑 = 本次建單範圍；沒挑任何品項時 = 篩選範圍，與舊版相同） */}
+      {effectiveSkuRows.length > 0 && (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           <KpiCard label="可分配庫存" value={kpis.totalAvailable} accent="text-emerald-700 dark:text-emerald-400" hint="HQ 已到貨可派" />
           <KpiCard label="本次擬分" value={totalAllocSum} accent="text-blue-700 dark:text-blue-400" hint={involvedPos > 0 ? `預計切 ${involvedPos} 張 wave` : "尚未填入分配量"} />
@@ -1200,6 +1397,19 @@ export default function PickingWorkstationPage() {
         </nav>
       </div>
 
+      {/* 兩步驟切換：先挑品、再看量。可隨時來回，allocs 是全域 Map，填過的數量不會掉。 */}
+      {viewMode === "matrix" && (
+        <div className="flex flex-wrap items-center gap-2">
+          <StepBtn active={pickStep === "select"} onClick={() => setPickStep("select")}>
+            ① 挑選商品{hasPicked ? `（已挑 ${pickedPickRows.length}）` : ""}
+          </StepBtn>
+          <span className="text-zinc-300 dark:text-zinc-600">→</span>
+          <StepBtn active={pickStep === "confirm"} onClick={() => setPickStep("confirm")}>
+            ② 確認數量並建單
+          </StepBtn>
+        </div>
+      )}
+
       {/* 控制列 */}
       <div className="flex flex-wrap items-end gap-3 rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900">
         <span className="text-xs text-zinc-500" title="建單後到「總倉收件匣 → 撿貨單」點配送日即可修改">
@@ -1209,16 +1419,18 @@ export default function PickingWorkstationPage() {
           {loading
             ? "載入中…"
             : viewMode === "matrix"
-              ? `${filteredSkuRows.length}${hasActiveFilter ? ` / ${skuRows.length}` : ""} 個品項 · ${visibleStores.length}${
-                  hiddenStoreCount > 0 ? ` / ${allStores.length}` : ""
-                } 間分店${
-                  hasSelection ? ` · 已選 ${selectedRows.length} 品項` : ""
-                } · 擬分 ${totalAllocSum}${involvedPos > 0 ? ` · 預計切 ${involvedPos} 張撿貨單` : ""}`
+              ? pickStep === "select"
+                ? `${visiblePickRows.length}${hasActiveFilter ? ` / ${allPickRows.length}` : ""} 筆可挑 (商品 × 採購單) · 已挑 ${pickedPickRows.length} 樣`
+                : `${effectiveSkuRows.length}${hasPicked || hasActiveFilter ? ` / ${skuRows.length}` : ""} 個品項 · ${visibleStores.length}${
+                    hiddenStoreCount > 0 ? ` / ${allStores.length}` : ""
+                  } 間分店${
+                    hasPicked ? ` · 已挑 ${pickedPickRows.length} 樣` : ""
+                  } · 擬分 ${totalAllocSum}${involvedPos > 0 ? ` · 預計切 ${involvedPos} 張撿貨單` : ""}`
               : loadingFull || fullDemand === null
                 ? "載入完整清單中…"
                 : `${storeSections.length} 間分店有待撿貨`}
         </span>
-        {viewMode === "matrix" && hiddenStoreCount > 0 && !showAllStores && (
+        {viewMode === "matrix" && pickStep === "confirm" && hiddenStoreCount > 0 && !showAllStores && (
           <button
             type="button"
             onClick={() => setShowAllStores(true)}
@@ -1228,7 +1440,7 @@ export default function PickingWorkstationPage() {
             另有 {hiddenStoreCount} 間分店無需求 — 顯示全部
           </button>
         )}
-        {viewMode === "matrix" && showAllStores && allStores.length > 0 && (
+        {viewMode === "matrix" && pickStep === "confirm" && showAllStores && allStores.length > 0 && (
           <button
             type="button"
             onClick={() => setShowAllStores(false)}
@@ -1243,17 +1455,8 @@ export default function PickingWorkstationPage() {
           </span>
         )}
 
-        {viewMode === "matrix" && filteredSkuRows.length > 0 && (
+        {viewMode === "matrix" && (
           <div className="ml-auto flex flex-wrap gap-2">
-            {hasSelection && (
-              <button
-                type="button"
-                onClick={() => setSelectedSkus(new Set())}
-                className="rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-              >
-                清除選取 ({selectedRows.length})
-              </button>
-            )}
             <Link
               href="/picking/print-pick-list"
               target="_blank"
@@ -1261,20 +1464,48 @@ export default function PickingWorkstationPage() {
             >
               📄 列印撿貨清單
             </Link>
-            <SpinButton
-              onClick={() => submitAll(effectiveSkuRows)}
-              disabled={submitting || totalAllocSum === 0}
-              className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
-            >
-              {submitting
-                ? "建立中…"
-                : hasSelection
-                  ? `🧾 建立選取撿貨單 (${selectedRows.length} 品項${involvedPos > 1 ? ` · ${involvedPos} 張` : ""})`
-                  : `🧾 建立撿貨單${involvedPos > 1 ? ` (${involvedPos} 張)` : ""}`}
-            </SpinButton>
+            {pickStep === "select" ? (
+              <SpinButton
+                onClick={() => setPickStep("confirm")}
+                disabled={allPickRows.length === 0}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {hasPicked
+                  ? `下一步：確認數量 (${pickedPickRows.length} 樣) →`
+                  : "下一步：確認數量（未挑 = 全部）→"}
+              </SpinButton>
+            ) : (
+              effectiveSkuRows.length > 0 && (
+                <SpinButton
+                  onClick={() => submitAll(effectiveSkuRows)}
+                  disabled={submitting || totalAllocSum === 0}
+                  className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {submitting
+                    ? "建立中…"
+                    : hasPicked
+                      ? `🧾 建立撿貨單 (${effectiveSkuRows.length} 品項${involvedPos > 1 ? ` · ${involvedPos} 張` : ""})`
+                      : `🧾 建立撿貨單${involvedPos > 1 ? ` (${involvedPos} 張)` : ""}`}
+                </SpinButton>
+              )
+            )}
           </div>
         )}
       </div>
+
+      {/* 已挑清單失效提示（驗收 #5：自動移除且要明示，不得靜默） */}
+      {prunedNotice && (
+        <div className="flex items-start justify-between gap-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
+          <span>⚠️ {prunedNotice}</span>
+          <button
+            type="button"
+            onClick={() => setPrunedNotice(null)}
+            className="shrink-0 rounded px-2 text-amber-700 hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-900"
+          >
+            知道了
+          </button>
+        </div>
+      )}
 
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
@@ -1285,11 +1516,152 @@ export default function PickingWorkstationPage() {
       {demand === null ? (
         <div className="text-center text-sm text-zinc-500">載入中…</div>
       ) : viewMode === "matrix" ? (
-        filteredSkuRows.length === 0 ? (
+        pickStep === "select" ? (
+          /* ===== 步驟 1：挑選商品 — 純商品清單，不出現分店矩陣 ===== */
+          <div className="flex flex-col gap-3">
+            {/* 已挑清單：獨立集合，換搜尋字 / 換開團篩選都不會掉 */}
+            <div className="rounded-md border border-blue-200 bg-blue-50/50 p-3 dark:border-blue-900 dark:bg-blue-950/20">
+              <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                <span className="text-sm font-semibold text-blue-900 dark:text-blue-200">
+                  ✅ 已挑選 · {pickedPickRows.length} 樣
+                </span>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={addAllVisiblePicks}
+                    disabled={visiblePickRows.length === 0}
+                    className="min-h-[44px] rounded-md border border-blue-300 bg-white px-3 text-sm font-medium text-blue-700 hover:bg-blue-100 disabled:opacity-40 dark:border-blue-700 dark:bg-zinc-900 dark:text-blue-300 dark:hover:bg-blue-950"
+                  >
+                    ＋ 全部加入（{visiblePickRows.length}）
+                  </button>
+                  {hasPicked && (
+                    <button
+                      type="button"
+                      onClick={() => setPickedKeys(new Set())}
+                      className="min-h-[44px] rounded-md border border-zinc-300 px-3 text-sm text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                    >
+                      清空
+                    </button>
+                  )}
+                </div>
+              </div>
+              {pickedPickRows.length === 0 ? (
+                <p className="text-xs text-zinc-500">
+                  還沒挑任何商品 — 用上面的「商品搜尋」打商品名稱,找到就按「加入」;換搜尋字不會把已挑的洗掉。
+                  不挑直接按「下一步」= 沿用舊行為(整個篩選範圍一起建單)。
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-1.5">
+                  {pickedPickRows.map((p) => (
+                    <span
+                      key={p.key}
+                      className="inline-flex items-center gap-1 rounded-full border border-blue-300 bg-white py-1 pl-2.5 pr-1 text-xs dark:border-blue-800 dark:bg-zinc-900"
+                    >
+                      <span
+                        className="max-w-[220px] truncate"
+                        title={`${p.sku_code ?? ""} ${p.sku_label} · ${p.po_no} · 這團到 ${p.grQty} · 可分配 ${p.available}`}
+                      >
+                        {p.sku_label}
+                      </span>
+                      <span className="font-mono text-[10px] text-zinc-400">{p.po_no}</span>
+                      <button
+                        type="button"
+                        onClick={() => togglePick(p.key)}
+                        aria-label={`移除 ${p.sku_label}（${p.po_no}）`}
+                        className="ml-0.5 h-6 w-6 rounded-full text-zinc-400 hover:bg-rose-100 hover:text-rose-700 dark:hover:bg-rose-950 dark:hover:text-rose-300"
+                      >
+                        ✕
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* 可挑清單：一列 = 一個商品 × 一張採購單（同商品跨三團 → 三列，各自標團號/採購單） */}
+            {allPickRows.length === 0 ? (
+              <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
+                目前沒有可分配的品項(該派的都派完了;在途的等收貨後、新需求進來後會自動回來)。
+              </div>
+            ) : visiblePickRows.length === 0 ? (
+              <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
+                {skuQueryNorm !== ""
+                  ? `找不到符合「${skuQuery.trim()}」的商品 — 換個關鍵字,或清除搜尋 / 篩選。`
+                  : "目前的篩選條件下沒有可挑品項 — 換個開團 / 時間,或清除篩選。"}
+                {pickedPickRows.length > 0 && (
+                  <div className="mt-1 text-xs">（已挑的 {pickedPickRows.length} 樣不受影響,還在上面的清單裡）</div>
+                )}
+              </div>
+            ) : (
+              <ul className="divide-y divide-zinc-200 rounded-md border border-zinc-200 bg-white dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
+                {visiblePickRows.map((p) => {
+                  const picked = pickedKeys.has(p.key);
+                  const cams = pickRowCampaigns(p);
+                  return (
+                    <li
+                      key={p.key}
+                      className={`flex items-center gap-3 p-3 ${picked ? "bg-blue-50/60 dark:bg-blue-950/20" : ""}`}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                          <span className="font-mono text-[11px] text-zinc-500">{p.sku_code ?? "—"}</span>
+                          <span className="text-sm font-medium">{p.sku_label}</span>
+                          {p.isRestockSourced && (
+                            <span
+                              className="rounded bg-amber-100 px-1 py-0.5 text-[9px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                              title="此 PO 來源為補貨申請(restock)"
+                            >
+                              📦 補貨
+                            </span>
+                          )}
+                          {renderPriceTags(p.sku_id)}
+                        </div>
+                        {/* 老闆：「相同的品名容易搞錯,第一團未到、第二團到了會派錯」→ 每列都標團號/團名/採購單/到貨量 */}
+                        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-zinc-500">
+                          {cams.length === 0 ? (
+                            <span className="text-zinc-400">無開團來源</span>
+                          ) : (
+                            cams.map((c) => (
+                              <span key={c.id} className="truncate">
+                                <span className="font-mono text-zinc-400">{c.campaign_no}</span> {c.name}
+                              </span>
+                            ))
+                          )}
+                          <span className="font-mono text-zinc-400" title="採購單號">{p.po_no}</span>
+                          <span className="font-mono tabular-nums" title="這一團(這張採購單)已到貨量">
+                            這團到 {p.grQty}
+                          </span>
+                          <span
+                            className="font-mono font-semibold tabular-nums text-emerald-700 dark:text-emerald-400"
+                            title="可分配 = 這張採購單此商品的已到貨 − 已派"
+                          >
+                            可分配 {p.available}
+                          </span>
+                        </div>
+                      </div>
+                      {/* 觸控目標 ≥ 44px（平板現場單手點） */}
+                      <button
+                        type="button"
+                        onClick={() => togglePick(p.key)}
+                        className={`min-h-[44px] min-w-[104px] shrink-0 rounded-md px-3 text-sm font-semibold ${
+                          picked
+                            ? "border border-blue-300 bg-white text-blue-700 hover:bg-blue-50 dark:border-blue-700 dark:bg-zinc-900 dark:text-blue-300 dark:hover:bg-blue-950"
+                            : "bg-blue-600 text-white hover:bg-blue-700"
+                        }`}
+                      >
+                        {picked ? "✓ 已加入" : "＋ 加入"}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        ) : effectiveSkuRows.length === 0 ? (
           <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
             {skuRows.length === 0
               ? "目前沒有待派的品項(該派的都派完了;在途的等收貨後、新需求進來後會自動回來)。"
-              : "目前的篩選條件下沒有待派品項 — 換個開團 / 商品 / 時間,或清除篩選。"}
+              : "目前的篩選條件下沒有待派品項 — 回步驟 1 挑商品,或換個開團 / 時間、清除篩選。"}
           </div>
         ) : (
           // 只保留水平(左右)捲軸:拿掉高度上限,表格整高展開、跟著整頁一起垂直捲動,
@@ -1315,19 +1687,8 @@ export default function PickingWorkstationPage() {
               </colgroup>
               <thead className="sticky top-0 z-10 bg-zinc-50 dark:bg-zinc-900">
                 <tr>
-                  <Th className="sticky left-0 z-20 bg-zinc-50 py-2 dark:bg-zinc-900">
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="checkbox"
-                        aria-label="全選品項"
-                        checked={allVisibleSelected}
-                        ref={(el) => { if (el) el.indeterminate = hasSelection && !allVisibleSelected; }}
-                        onChange={toggleAllSkus}
-                        className="h-4 w-4 shrink-0 cursor-pointer"
-                      />
-                      品項 / 來源
-                    </div>
-                  </Th>
+                  {/* 勾選欄拿掉：選哪些品項改在步驟 1 決定（舊版勾選會被「目前清單」交集吃掉） */}
+                  <Th className="sticky left-0 z-20 bg-zinc-50 py-2 dark:bg-zinc-900">品項 / 來源</Th>
                   <Th className="py-2 text-center" title="可分配剩餘 = 總倉已到貨 − 已派 − 本次擬分">可分配</Th>
                   <Th className="py-2 text-center" title="本次擬分合計(含被隱藏的分店欄)">擬分</Th>
                   {visibleStores.map((st) => (
@@ -1339,23 +1700,16 @@ export default function PickingWorkstationPage() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
-                {filteredSkuRows.map((sk) => {
+                {/* 只渲染本次建單範圍的品項：有挑 → 挑中的那幾樣；沒挑 → 篩選範圍全部（舊行為） */}
+                {effectiveSkuRows.map((sk) => {
                   const allocSum = getSkuAllocTotal(sk);
                   const overAlloc = allocSum > sk.totalAvailable;
                   const remaining = sk.totalAvailable - allocSum; // 可分配剩餘
-                  const isSel = selectedSkus.has(sk.sku_id);
                   const onHand = hqOnHand?.get(sk.sku_id);
                   return (
-                    <tr key={sk.sku_id} className={overAlloc ? "bg-red-50 dark:bg-red-950/30" : isSel ? "bg-blue-50/60 dark:bg-blue-950/20" : ""}>
-                      <Td className={`sticky left-0 px-3 py-2.5 text-xs ${isSel ? "bg-blue-50 dark:bg-blue-950/30" : "bg-white dark:bg-zinc-900"}`}>
+                    <tr key={sk.sku_id} className={overAlloc ? "bg-red-50 dark:bg-red-950/30" : ""}>
+                      <Td className="sticky left-0 bg-white px-3 py-2.5 text-xs dark:bg-zinc-900">
                         <div className="flex items-start gap-2">
-                          <input
-                            type="checkbox"
-                            aria-label={`選取 ${sk.sku_code ?? sk.sku_label}`}
-                            checked={isSel}
-                            onChange={() => toggleSku(sk.sku_id)}
-                            className="mt-1 h-4 w-4 shrink-0 cursor-pointer"
-                          />
                           <div className="flex min-w-0 flex-1 items-start justify-between gap-2">
                           <div className="min-w-0 flex-1">
                             <div className="font-mono text-[11px] text-zinc-500">{sk.sku_code ?? "—"}</div>
@@ -1844,6 +2198,22 @@ function TabBtn({ active, onClick, children }: { active: boolean; onClick: () =>
         active
           ? "border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400"
           : "border-transparent text-zinc-500 hover:border-zinc-300 hover:text-zinc-700 dark:hover:text-zinc-300"
+      }`}
+    >
+      {children}
+    </SpinButton>
+  );
+}
+
+// 兩步驟切換鈕（平板觸控目標 ≥ 44px）
+function StepBtn({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <SpinButton
+      onClick={onClick}
+      className={`min-h-[44px] rounded-md px-4 text-sm font-semibold transition ${
+        active
+          ? "bg-blue-600 text-white"
+          : "border border-zinc-300 text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
       }`}
     >
       {children}

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -10,11 +10,12 @@
 //   不動 v_picking_demand_by_po（CREATE OR REPLACE VIEW 欄位順序限制多、風險高）。
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import { fetchAllRows } from "@/lib/fetchAllRows";
 import SpinButton from "@/components/SpinButton";
+import { useAuth } from "@/components/AuthProvider";
 
 type DemandRow = {
   po_id: number;
@@ -79,95 +80,96 @@ function defaultWaveDate() {
   return d.toLocaleDateString("sv-SE");
 }
 
-// 步驟 1 挑好的「商品 × 採購單」存 localStorage：換分頁、重新整理都不會掉。
-// 慣例照 repo 既有寫法（components/AidShipmentReminder.tsx、transfers/settlement/review）。
-const PICKED_KEY = "wms-picking-picked-v1";
-function loadPickedKeys(): Set<string> {
+// ===== 已挑清單（步驟 1 挑好的商品）的外部儲存 =====
+// key 帶 tenant + user：樓下的人共用現場 iPad，A 挑的東西不可以殘留給 B。
+// 拿不到 tenant / user（舊 DB 未套 tenants migration、或 session 還沒到）就不落地，
+// 退回純 session 暫存 —— 不用預設值硬湊，寧可不持久化也不要串到別人的清單。
+const PICKED_KEY_PREFIX = "wms-picking-picked-v2";
+function pickedStorageKeyFor(tenantId: string | null | undefined, userId: string | null | undefined) {
+  return tenantId && userId ? `${PICKED_KEY_PREFIX}:${tenantId}:${userId}` : null;
+}
+
+// 用 useSyncExternalStore 訂閱這個 module store，而不是 useState + effect 載入。理由：
+//   1. tenant 是登入後才用 rpc_get_my_tenant 非同步拿到的 → storage key 晚一步才成立。
+//      用 effect 載入會在 key 到位那一刻「用存檔覆蓋掉使用者剛挑好的東西」。
+//   2. 跨分頁同步（storage 事件）天生就是外部 store 的訂閱，順手解掉。
+//   3. 不需要在 effect body 裡 setState。
+let pickedSkuIds: number[] = [];          // 唯一真相；localStorage 只是鏡像
+let pickedOwnerKey: string | null = null; // pickedSkuIds 目前屬於哪個 tenant/user key
+const pickedListeners = new Set<() => void>();
+function emitPicked() { for (const l of pickedListeners) l(); }
+function subscribePicked(cb: () => void) {
+  pickedListeners.add(cb);
+  return () => { pickedListeners.delete(cb); };
+}
+function getPickedSkuIds() { return pickedSkuIds; }
+function readStoredPicked(key: string): number[] {
   try {
-    const raw = localStorage.getItem(PICKED_KEY);
+    const raw = localStorage.getItem(key);
     const arr = raw ? (JSON.parse(raw) as unknown) : [];
-    // 只收 `${po_id}:${sku_id}` 形狀的字串，擋掉手改過 / 舊版殘留的髒資料
-    return new Set(
-      Array.isArray(arr) ? arr.map(String).filter((s) => /^\d+:\d+$/.test(s)) : [],
-    );
+    if (!Array.isArray(arr)) return [];
+    return arr.map(Number).filter((n) => Number.isInteger(n) && n > 0);
   } catch {
-    return new Set(); // 隱私模式 / JSON 壞掉：當作沒挑過，不讓工作台整頁掛掉
+    return []; // 隱私模式 / JSON 壞掉：當作沒挑過，不讓工作台整頁掛掉
   }
 }
-function savePickedKeys(keys: Set<string>) {
+function writeStoredPicked(key: string, ids: number[]) {
   try {
-    localStorage.setItem(PICKED_KEY, JSON.stringify(Array.from(keys)));
+    localStorage.setItem(key, JSON.stringify(ids));
   } catch { /* 隱私模式：存不了就算了，畫面照常運作 */ }
 }
+// 一律寫進 store 目前綁定的 key（pickedOwnerKey）。還沒綁定（拿不到 tenant/user）就只留在記憶體。
+function setPickedSkuIds(ids: number[]) {
+  pickedSkuIds = ids;
+  if (pickedOwnerKey) writeStoredPicked(pickedOwnerKey, ids);
+  emitPicked();
+}
+// storage key 一成立（或換帳號 / 換租戶）就對齊一次。
+// 首次綁定且本機已經挑了東西 → 把它寫下去（tenant 晚到不該讓剛挑的掉）；
+// 換 key → 一律改讀新 key 的存檔，絕不把前一個帳號的清單帶過去。
+function bindPickedStorage(key: string) {
+  if (pickedOwnerKey === key) return;
+  const firstBind = pickedOwnerKey === null;
+  if (firstBind && pickedSkuIds.length > 0) {
+    writeStoredPicked(key, pickedSkuIds);
+  } else {
+    const stored = readStoredPicked(key);
+    const same =
+      stored.length === pickedSkuIds.length && stored.every((v, i) => v === pickedSkuIds[i]);
+    pickedSkuIds = stored;
+    if (!same) emitPicked();
+  }
+  pickedOwnerKey = key;
+}
+// 跨分頁：別的分頁改了同一個 key → 重讀，避免兩個分頁互相覆蓋
+function refreshPickedFromStorage(key: string) {
+  const stored = readStoredPicked(key);
+  const same =
+    stored.length === pickedSkuIds.length && stored.every((v, i) => v === pickedSkuIds[i]);
+  if (same) return;
+  pickedSkuIds = stored;
+  emitPicked();
+}
 
-// 步驟 1（挑選商品）的一列 = 一個商品 × 一張採購單。只給挑選畫面用，不進建單流程。
-type PickRow = {
-  key: string;                          // `${po_id}:${sku_id}` — 已挑清單存的就是這個
-  po_id: number;
-  po_no: string;
-  sku_id: number;
-  sku_code: string | null;
-  sku_label: string;
-  grQty: number;                        // 這一團（這張採購單）到了多少
-  available: number;                    // 可分配 = 該 PO 該 SKU 已到貨 − 已派（按採購單各自算）
-  campaignIds: number[];
-  isRestockSourced: boolean;
-};
-
-// 從 demand 列組出「商品 × 採購單」清單。
-// 老闆原話：「會一直重覆開團，相同的品名容易搞錯，第一團未到、第二團到了會派錯」
-// → 不能像矩陣那樣把同商品跨團合成一列。
-// ⚠️ 這是純顯示用的衍生資料。矩陣與建單仍走 skuRows(per sku) ＋ submitAll 的 FIFO，
-//    因為 allocs 的 key 是 `${sku_id}:${store_id}`（沒有 po_id），
-//    把 skuRows 拆成 per PO 會讓 FIFO 對同一個 qty 派兩次。那段一個字都沒動。
-// 放模組層是為了讓「已挑清單失效清理」能用同一支算 alive key，避免兩處條件飄移。
-function buildPickRows(
-  demand: DemandRow[] | null,
-  poItemCampaigns: Map<number, number[]> | null,
-): PickRow[] {
-  if (!demand) return [];
-  const m = new Map<string, PickRow>();
-  const cidSets = new Map<string, Set<number>>();
+// 從 demand 算出「還有可分配量」的 sku_id 集合 —— 條件與 skuRows 的
+// filter(totalAvailable > 0) 完全一致（per (po, sku) 去重後 Σgr − Σ已派）。
+// 給「已挑清單失效清理」用，避免兩處條件飄移。
+function alivePickableSkuIds(demand: DemandRow[]): Set<number> {
+  const avail = new Map<number, number>();
+  const poSkuSeen = new Set<string>();
   for (const r of demand) {
     if (r.store_id === null) continue; // 與 skuRows 同條件
-    const key = `${r.po_id}:${r.sku_id}`;
-    let row = m.get(key);
-    if (!row) {
-      // gr_qty / po_sku_already_wave 在同 (po, sku) 的各 store row 是同值（view 保證），取首列即可
-      const gr = Number(r.gr_qty);
-      const already = Number(r.po_sku_already_wave ?? 0);
-      row = {
-        key,
-        po_id: r.po_id,
-        po_no: r.po_no,
-        sku_id: r.sku_id,
-        sku_code: r.sku_code,
-        sku_label: r.sku_label,
-        grQty: gr,
-        // 「可分配 = 0 就隱藏」按採購單各自算：第一團未到(到貨 0)或已派完的那列不會掛在畫面上
-        available: Math.max(0, gr - already),
-        campaignIds: [],
-        isRestockSourced: !!r.is_restock_sourced,
-      };
-      m.set(key, row);
-      cidSets.set(key, new Set<number>());
-    }
-    if (r.is_restock_sourced) row.isRestockSourced = true;
-    // 同一張 PO 的同一個 SKU 可能來自多個 po_item → 開團取聯集
-    for (const cid of poItemCampaigns?.get(r.po_item_id) ?? []) cidSets.get(key)!.add(cid);
-  }
-  for (const [key, set] of cidSets) {
-    const row = m.get(key);
-    if (row) row.campaignIds = Array.from(set);
-  }
-  return Array.from(m.values())
-    .filter((p) => p.available > 0)
-    .sort(
-      (a, b) =>
-        (a.sku_code ?? "").localeCompare(b.sku_code ?? "") ||
-        a.sku_label.localeCompare(b.sku_label) ||
-        a.po_id - b.po_id,
+    const poSkuKey = `${r.po_id}:${r.sku_id}`;
+    if (poSkuSeen.has(poSkuKey)) continue;
+    poSkuSeen.add(poSkuKey);
+    avail.set(
+      r.sku_id,
+      (avail.get(r.sku_id) ?? 0) + Number(r.gr_qty) - Number(r.po_sku_already_wave ?? 0),
     );
+  }
+  const alive = new Set<number>();
+  for (const [skuId, v] of avail) if (v > 0) alive.add(skuId);
+  return alive;
 }
 
 export default function PickingWorkstationPage() {
@@ -189,16 +191,28 @@ export default function PickingWorkstationPage() {
   const [submitting, setSubmitting] = useState(false);
   const [submittingRrId, setSubmittingRrId] = useState<number | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
-  // 步驟 1「已挑清單」：key = `${po_id}:${sku_id}`（一列 = 一個商品 × 一張採購單）。
+  // 步驟 1「已挑清單」＝ sku_id 集合（與建單 scope 同粒度：submitAll 的 FIFO 是 per sku 運作）。
   // ⚠️ 這是獨立集合，絕不與「目前搜尋結果」做交集 —— 舊版就是死在交集上
   //    （搜商品 → 清單只剩 1 列 → 交集後只剩 1 樣，老闆說的「發現只選了一樣」）。
-  //    已無可分配量的品項改由「撈完 demand 之後的失效清理」移除並明示提示（見上面的 fetch effect）。
-  // 初值直接讀 localStorage（同 components/AidShipmentReminder.tsx 的慣例）。
-  // 不會有 hydration 落差：demand 還沒撈回來前，畫面上所有跟已挑清單有關的東西
-  // 都是從 allPickRows（此時是空陣列）推出來的，SSR 與 client 首次 render 的輸出相同。
-  const [pickedKeys, setPickedKeys] = useState<Set<string>>(
-    () => (typeof window === "undefined" ? new Set<string>() : loadPickedKeys()),
-  );
+  //    已無可分配量的品項由「撈完 demand 之後的失效清理」移除並明示提示（見下面的 fetch effect）。
+  // 存在 module store 裡（含 tenant/user scope、跨分頁同步），細節見檔頭。
+  const { user, tenant } = useAuth();
+  const pickedStorageKey = pickedStorageKeyFor(tenant?.id, user?.id);
+  const pickedIds = useSyncExternalStore(subscribePicked, getPickedSkuIds, getPickedSkuIds);
+  const pickedSkus = useMemo(() => new Set(pickedIds), [pickedIds]);
+  // storage key 一成立（或換帳號 / 換租戶）就對齊一次；純寫外部系統，沒有 setState
+  useEffect(() => {
+    if (pickedStorageKey) bindPickedStorage(pickedStorageKey);
+  }, [pickedStorageKey]);
+  // 跨分頁：別的分頁改了同一把 key → 重讀（避免兩個分頁互相覆蓋）
+  useEffect(() => {
+    if (!pickedStorageKey) return;
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === pickedStorageKey) refreshPickedFromStorage(pickedStorageKey);
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [pickedStorageKey]);
   // 已挑清單被自動移除時的提示（不靜默處理）
   const [prunedNotice, setPrunedNotice] = useState<string | null>(null);
   // 矩陣分頁的兩步驟：select = 先挑商品；confirm = 確認數量並建單
@@ -256,17 +270,15 @@ export default function PickingWorkstationPage() {
         setDemand(dRows);
         setRestockDemand(rrRows);
         // 已挑清單失效清理：資料一到就把「已無可分配量」（被別人派完 / 下架）的品項移除並提示。
-        // ⚠️ 比對基準是「未經任何篩選」的 buildPickRows(dRows)，不是搜尋結果 ——
+        // ⚠️ 比對基準是「未經任何篩選」的 alivePickableSkuIds(dRows)，不是搜尋結果 ——
         //    拿目前清單去交集正是舊版「選了 30 樣、按建單只剩 1 樣」的根因。
-        // 這裡讀 localStorage 而不是 pickedKeys state：本回呼是 async 的，閉包裡的 state 是舊快照，
-        // 而 localStorage 在每次挑選後都會被寫回（見下方 persist effect），永遠是最新值。
-        // 隱私模式下讀不到 → 不清也不提示；已挑清單的顯示與建單範圍本來就只算 allPickRows 裡還在的列，
-        // 殘留的失效 key 不會被派出去。
-        const alivePickKeys = new Set(buildPickRows(dRows, null).map((p) => p.key));
-        const persistedPicks = Array.from(loadPickedKeys());
-        const stalePicks = persistedPicks.filter((k) => !alivePickKeys.has(k));
+        // 讀 module store 的 getPickedSkuIds() 而不是閉包裡的 pickedIds：本回呼是 async 的，
+        // 閉包抓到的是舊快照；module store 永遠是最新值。
+        const aliveSkus = alivePickableSkuIds(dRows);
+        const currentPicks = getPickedSkuIds();
+        const stalePicks = currentPicks.filter((id) => !aliveSkus.has(id));
         if (stalePicks.length > 0) {
-          setPickedKeys(new Set(persistedPicks.filter((k) => alivePickKeys.has(k))));
+          setPickedSkuIds(currentPicks.filter((id) => aliveSkus.has(id)));
           setPrunedNotice(
             `已挑清單有 ${stalePicks.length} 個品項已無可分配量（可能被別人派完或已下架），已自動移除。`,
           );
@@ -737,65 +749,65 @@ export default function PickingWorkstationPage() {
     [skuRows, effFilterCampaign, skuQueryNorm, filterTime, timeCutoff, campaignsById],
   );
 
-  // ===== 步驟 1 的挑選清單：一列 = 一個商品 × 一張採購單（組法見模組層 buildPickRows）=====
-  const allPickRows: PickRow[] = useMemo(
-    () => buildPickRows(demand, poItemCampaigns),
-    [demand, poItemCampaigns],
-  );
+  // ===== 步驟 1 的挑選清單 =====
+  // 一列 = 一個商品（＝ skuRows 的粒度，與建單 scope 一致：看到多少就派多少）。
+  // 團／採購單資訊在列內攤開顯示，但「不是可選項」——
+  // allocs 的 key 是 `${sku_id}:${store_id}`（沒有 po_id），submitAll 的 FIFO 是 per sku 跑的，
+  // 給使用者一個「只挑某一團」的選項，實際做不到，比沒有團資訊更危險（阿審 P1 判定）。
+  const visiblePickRows = filteredSkuRows;
 
-  // 目前搜尋 / 開團 / 時間 篩選後要顯示的挑選列（只影響「看得到什麼」，不影響已挑清單）
-  const visiblePickRows = useMemo(
-    () => allPickRows.filter((p) => rowPassesFilters(p.campaignIds, p.sku_label, p.sku_code)),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [allPickRows, effFilterCampaign, skuQueryNorm, filterTime, timeCutoff, campaignsById],
-  );
+  // 每張採購單對應哪幾團（poList 只有 po_id，開團對應在 poItemCampaigns 上，需經 po_item 轉一手）
+  const campaignsByPoId = useMemo(() => {
+    const m = new Map<number, Set<number>>();
+    if (!demand) return m;
+    for (const r of demand) {
+      const cids = poItemCampaigns?.get(r.po_item_id);
+      if (!cids || cids.length === 0) continue;
+      let set = m.get(r.po_id);
+      if (!set) { set = new Set<number>(); m.set(r.po_id, set); }
+      for (const cid of cids) set.add(cid);
+    }
+    return m;
+  }, [demand, poItemCampaigns]);
 
-  // 已挑的列。⚠️ 比對基準是「未經任何篩選」的 allPickRows，不是 visiblePickRows ——
+  // 一列要攤開列出的團明細：只列「這一團真的到貨了」的採購單（gr_qty = 0 不列，避免以為有貨）
+  function pickRowPoLines(sk: SkuRow) {
+    return sk.poList
+      .filter((po) => po.gr_qty > 0)
+      .map((po) => ({
+        po_id: po.po_id,
+        po_no: po.po_no,
+        grQty: po.gr_qty,
+        available: Math.max(0, po.gr_qty - po.already_wave_for_sku),
+        campaigns: Array.from(campaignsByPoId.get(po.po_id) ?? [])
+          .map((cid) => campaignsById?.get(cid))
+          .filter((c): c is CampaignInfo => !!c),
+      }));
+  }
+
+  // 已挑的列。⚠️ 比對基準是「未經任何篩選」的 skuRows，不是 filteredSkuRows ——
   // 拿目前搜尋結果去交集，正是老闆遇到的「選了 30 樣、按建單只剩 1 樣」的根因。
-  const pickedPickRows = useMemo(
-    () => allPickRows.filter((p) => pickedKeys.has(p.key)),
-    [allPickRows, pickedKeys],
+  const pickedRows = useMemo(
+    () => skuRows.filter((sk) => pickedSkus.has(sk.sku_id)),
+    [skuRows, pickedSkus],
   );
+  const hasPicked = pickedRows.length > 0;
 
-  // 已挑清單寫回 localStorage（純粹把 React state 同步到外部系統，正是 effect 該做的事）
-  useEffect(() => {
-    savePickedKeys(pickedKeys);
-  }, [pickedKeys]);
-
-  function togglePick(key: string) {
-    setPickedKeys((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
+  function togglePick(skuId: number) {
+    setPickedSkuIds(
+      pickedIds.includes(skuId) ? pickedIds.filter((id) => id !== skuId) : [...pickedIds, skuId],
+    );
   }
   // 「全部加入」= 把目前搜尋結果一次丟進已挑清單（是聯集，不會蓋掉先前挑的）
   function addAllVisiblePicks() {
-    setPickedKeys((prev) => {
-      const next = new Set(prev);
-      for (const p of visiblePickRows) next.add(p.key);
-      return next;
-    });
-  }
-  function pickRowCampaigns(p: PickRow): CampaignInfo[] {
-    return p.campaignIds
-      .map((cid) => campaignsById?.get(cid))
-      .filter((c): c is CampaignInfo => !!c);
+    const next = new Set(pickedIds);
+    for (const sk of visiblePickRows) next.add(sk.sku_id);
+    setPickedSkuIds(Array.from(next));
   }
 
-  // 一個商品可能跨多張 PO 被挑到 → 去重成 sku 集合（矩陣與 submitAll 的 FIFO 都是 per sku 運作）
-  const pickedSkuIds = useMemo(
-    () => new Set(pickedPickRows.map((p) => p.sku_id)),
-    [pickedPickRows],
-  );
-  const hasPicked = pickedSkuIds.size > 0;
   // 本次建單納入的品項：有挑 → 只取挑中的（⚠️ 從 skuRows 取，不與 filteredSkuRows 交集）；
   // 沒挑 → 維持現行「篩選範圍內全部」語意，行為不變。
-  const effectiveSkuRows = useMemo(
-    () => (hasPicked ? skuRows.filter((sk) => pickedSkuIds.has(sk.sku_id)) : filteredSkuRows),
-    [hasPicked, skuRows, pickedSkuIds, filteredSkuRows],
-  );
+  const effectiveSkuRows = hasPicked ? pickedRows : filteredSkuRows;
 
   // 平板塞不下 17 欄 → 預設只顯示「本次建單範圍內還有未派需求、或已填擬分量」的分店欄。
   // 注意：分配上限（getSkuAllocTotal）永遠算全部分店，隱藏欄的擬分量照樣計入。
@@ -1401,7 +1413,7 @@ export default function PickingWorkstationPage() {
       {viewMode === "matrix" && (
         <div className="flex flex-wrap items-center gap-2">
           <StepBtn active={pickStep === "select"} onClick={() => setPickStep("select")}>
-            ① 挑選商品{hasPicked ? `（已挑 ${pickedPickRows.length}）` : ""}
+            ① 挑選商品{hasPicked ? `（已挑 ${pickedRows.length}）` : ""}
           </StepBtn>
           <span className="text-zinc-300 dark:text-zinc-600">→</span>
           <StepBtn active={pickStep === "confirm"} onClick={() => setPickStep("confirm")}>
@@ -1420,11 +1432,11 @@ export default function PickingWorkstationPage() {
             ? "載入中…"
             : viewMode === "matrix"
               ? pickStep === "select"
-                ? `${visiblePickRows.length}${hasActiveFilter ? ` / ${allPickRows.length}` : ""} 筆可挑 (商品 × 採購單) · 已挑 ${pickedPickRows.length} 樣`
+                ? `${visiblePickRows.length}${hasActiveFilter ? ` / ${skuRows.length}` : ""} 樣可挑 · 已挑 ${pickedRows.length} 樣`
                 : `${effectiveSkuRows.length}${hasPicked || hasActiveFilter ? ` / ${skuRows.length}` : ""} 個品項 · ${visibleStores.length}${
                     hiddenStoreCount > 0 ? ` / ${allStores.length}` : ""
                   } 間分店${
-                    hasPicked ? ` · 已挑 ${pickedPickRows.length} 樣` : ""
+                    hasPicked ? ` · 已挑 ${pickedRows.length} 樣` : ""
                   } · 擬分 ${totalAllocSum}${involvedPos > 0 ? ` · 預計切 ${involvedPos} 張撿貨單` : ""}`
               : loadingFull || fullDemand === null
                 ? "載入完整清單中…"
@@ -1457,21 +1469,29 @@ export default function PickingWorkstationPage() {
 
         {viewMode === "matrix" && (
           <div className="ml-auto flex flex-wrap gap-2">
+            {/* 老闆的流程是「挑 30-50 樣 → 列印 → 拿給樓下的人撿」，所以列印要跟著已挑清單走。
+                用 query string 傳 sku_id：列印頁本來就跟工作台零耦合（自己撈 view），
+                走網址參數不必共用 localStorage key（那把 key 綁 tenant/user，列印頁得再算一次）。
+                長度：50 個 id 約 350 字元，遠低於瀏覽器上限。沒挑 → 不帶參數 → 印全部（行為不變）。 */}
             <Link
-              href="/picking/print-pick-list"
+              href={
+                hasPicked
+                  ? `/picking/print-pick-list?skus=${pickedRows.map((sk) => sk.sku_id).join(",")}`
+                  : "/picking/print-pick-list"
+              }
               target="_blank"
               className="rounded-md border border-blue-300 bg-blue-50 px-3 py-2 text-sm font-medium text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
             >
-              📄 列印撿貨清單
+              {hasPicked ? `📄 列印已挑 ${pickedRows.length} 樣` : "📄 列印全部待撿清單"}
             </Link>
             {pickStep === "select" ? (
               <SpinButton
                 onClick={() => setPickStep("confirm")}
-                disabled={allPickRows.length === 0}
+                disabled={skuRows.length === 0}
                 className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
               >
                 {hasPicked
-                  ? `下一步：確認數量 (${pickedPickRows.length} 樣) →`
+                  ? `下一步：確認數量 (${pickedRows.length} 樣) →`
                   : "下一步：確認數量（未挑 = 全部）→"}
               </SpinButton>
             ) : (
@@ -1523,7 +1543,7 @@ export default function PickingWorkstationPage() {
             <div className="rounded-md border border-blue-200 bg-blue-50/50 p-3 dark:border-blue-900 dark:bg-blue-950/20">
               <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
                 <span className="text-sm font-semibold text-blue-900 dark:text-blue-200">
-                  ✅ 已挑選 · {pickedPickRows.length} 樣
+                  ✅ 已挑選 · {pickedRows.length} 樣
                 </span>
                 <div className="flex flex-wrap gap-2">
                   <button
@@ -1537,7 +1557,7 @@ export default function PickingWorkstationPage() {
                   {hasPicked && (
                     <button
                       type="button"
-                      onClick={() => setPickedKeys(new Set())}
+                      onClick={() => setPickedSkuIds([])}
                       className="min-h-[44px] rounded-md border border-zinc-300 px-3 text-sm text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
                     >
                       清空
@@ -1545,29 +1565,30 @@ export default function PickingWorkstationPage() {
                   )}
                 </div>
               </div>
-              {pickedPickRows.length === 0 ? (
+              {pickedRows.length === 0 ? (
                 <p className="text-xs text-zinc-500">
                   還沒挑任何商品 — 用上面的「商品搜尋」打商品名稱,找到就按「加入」;換搜尋字不會把已挑的洗掉。
                   不挑直接按「下一步」= 沿用舊行為(整個篩選範圍一起建單)。
+                  {pickedStorageKey === null && "（目前無法記住已挑清單：讀不到帳號/租戶，重新整理會清空）"}
                 </p>
               ) : (
                 <div className="flex flex-wrap gap-1.5">
-                  {pickedPickRows.map((p) => (
+                  {pickedRows.map((sk) => (
                     <span
-                      key={p.key}
+                      key={sk.sku_id}
                       className="inline-flex items-center gap-1 rounded-full border border-blue-300 bg-white py-1 pl-2.5 pr-1 text-xs dark:border-blue-800 dark:bg-zinc-900"
                     >
                       <span
                         className="max-w-[220px] truncate"
-                        title={`${p.sku_code ?? ""} ${p.sku_label} · ${p.po_no} · 這團到 ${p.grQty} · 可分配 ${p.available}`}
+                        title={`${sk.sku_code ?? ""} ${sk.sku_label} · 可分配 ${sk.totalAvailable}`}
                       >
-                        {p.sku_label}
+                        {sk.sku_label}
                       </span>
-                      <span className="font-mono text-[10px] text-zinc-400">{p.po_no}</span>
+                      <span className="font-mono text-[10px] tabular-nums text-zinc-400">{sk.totalAvailable}</span>
                       <button
                         type="button"
-                        onClick={() => togglePick(p.key)}
-                        aria-label={`移除 ${p.sku_label}（${p.po_no}）`}
+                        onClick={() => togglePick(sk.sku_id)}
+                        aria-label={`移除 ${sk.sku_label}`}
                         className="ml-0.5 h-6 w-6 rounded-full text-zinc-400 hover:bg-rose-100 hover:text-rose-700 dark:hover:bg-rose-950 dark:hover:text-rose-300"
                       >
                         ✕
@@ -1578,8 +1599,8 @@ export default function PickingWorkstationPage() {
               )}
             </div>
 
-            {/* 可挑清單：一列 = 一個商品 × 一張採購單（同商品跨三團 → 三列，各自標團號/採購單） */}
-            {allPickRows.length === 0 ? (
+            {/* 可挑清單：一列 = 一個商品，列內攤開這個商品有哪幾團／哪幾張採購單、各團各到多少 */}
+            {skuRows.length === 0 ? (
               <div className="rounded-md border border-zinc-200 p-12 text-center text-sm text-zinc-500 dark:border-zinc-800">
                 目前沒有可分配的品項(該派的都派完了;在途的等收貨後、新需求進來後會自動回來)。
               </div>
@@ -1588,25 +1609,31 @@ export default function PickingWorkstationPage() {
                 {skuQueryNorm !== ""
                   ? `找不到符合「${skuQuery.trim()}」的商品 — 換個關鍵字,或清除搜尋 / 篩選。`
                   : "目前的篩選條件下沒有可挑品項 — 換個開團 / 時間,或清除篩選。"}
-                {pickedPickRows.length > 0 && (
-                  <div className="mt-1 text-xs">（已挑的 {pickedPickRows.length} 樣不受影響,還在上面的清單裡）</div>
+                {pickedRows.length > 0 && (
+                  <div className="mt-1 text-xs">（已挑的 {pickedRows.length} 樣不受影響,還在上面的清單裡）</div>
                 )}
               </div>
             ) : (
               <ul className="divide-y divide-zinc-200 rounded-md border border-zinc-200 bg-white dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
-                {visiblePickRows.map((p) => {
-                  const picked = pickedKeys.has(p.key);
-                  const cams = pickRowCampaigns(p);
+                {visiblePickRows.map((sk) => {
+                  const picked = pickedSkus.has(sk.sku_id);
+                  const poLines = pickRowPoLines(sk);
                   return (
                     <li
-                      key={p.key}
-                      className={`flex items-center gap-3 p-3 ${picked ? "bg-blue-50/60 dark:bg-blue-950/20" : ""}`}
+                      key={sk.sku_id}
+                      className={`flex items-start gap-3 p-3 ${picked ? "bg-blue-50/60 dark:bg-blue-950/20" : ""}`}
                     >
                       <div className="min-w-0 flex-1">
                         <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                          <span className="font-mono text-[11px] text-zinc-500">{p.sku_code ?? "—"}</span>
-                          <span className="text-sm font-medium">{p.sku_label}</span>
-                          {p.isRestockSourced && (
+                          <span className="font-mono text-[11px] text-zinc-500">{sk.sku_code ?? "—"}</span>
+                          <span className="text-sm font-medium">{sk.sku_label}</span>
+                          <span
+                            className="font-mono text-xs font-semibold tabular-nums text-emerald-700 dark:text-emerald-400"
+                            title="可分配 = 總倉已到貨 − 已派。這就是建單時實際會派出去的上限"
+                          >
+                            可分配 {sk.totalAvailable}
+                          </span>
+                          {sk.poList.some((p) => p.is_restock_sourced) && (
                             <span
                               className="rounded bg-amber-100 px-1 py-0.5 text-[9px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300"
                               title="此 PO 來源為補貨申請(restock)"
@@ -1614,35 +1641,50 @@ export default function PickingWorkstationPage() {
                               📦 補貨
                             </span>
                           )}
-                          {renderPriceTags(p.sku_id)}
+                          {renderPriceTags(sk.sku_id)}
                         </div>
-                        {/* 老闆：「相同的品名容易搞錯,第一團未到、第二團到了會派錯」→ 每列都標團號/團名/採購單/到貨量 */}
-                        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-zinc-500">
-                          {cams.length === 0 ? (
-                            <span className="text-zinc-400">無開團來源</span>
+                        {/* 老闆：「第一頁應該要有詳細開團的資訊」「相同的品名容易搞錯，第一團未到、第二團到了會派錯」
+                            → 攤開列出這個商品有哪幾團／哪幾張採購單、各團各到了多少。
+                            ⚠️ 只是資訊，不是可選項：建單是 per 商品跑 FIFO，挑不了單一團。
+                            沒到貨的團（gr_qty = 0）不列，免得以為有貨。 */}
+                        <ul className="mt-1 flex flex-col gap-0.5">
+                          {poLines.length === 0 ? (
+                            <li className="text-[11px] text-zinc-400">無已到貨的採購單</li>
                           ) : (
-                            cams.map((c) => (
-                              <span key={c.id} className="truncate">
-                                <span className="font-mono text-zinc-400">{c.campaign_no}</span> {c.name}
-                              </span>
+                            poLines.map((po) => (
+                              <li
+                                key={po.po_id}
+                                className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-zinc-500"
+                              >
+                                <span className="text-zinc-300 dark:text-zinc-600">·</span>
+                                {po.campaigns.length === 0 ? (
+                                  <span className="text-zinc-400">無開團來源</span>
+                                ) : (
+                                  po.campaigns.map((c) => (
+                                    <span key={c.id} className="truncate">
+                                      <span className="font-mono text-zinc-400">{c.campaign_no}</span> {c.name}
+                                    </span>
+                                  ))
+                                )}
+                                <span className="font-mono text-zinc-400" title="採購單號">{po.po_no}</span>
+                                <span className="font-mono tabular-nums" title="這一團(這張採購單)已到貨量">
+                                  到 {po.grQty}
+                                </span>
+                                <span
+                                  className="font-mono tabular-nums text-zinc-400"
+                                  title="這張採購單此商品的已到貨 − 已派"
+                                >
+                                  剩 {po.available}
+                                </span>
+                              </li>
                             ))
                           )}
-                          <span className="font-mono text-zinc-400" title="採購單號">{p.po_no}</span>
-                          <span className="font-mono tabular-nums" title="這一團(這張採購單)已到貨量">
-                            這團到 {p.grQty}
-                          </span>
-                          <span
-                            className="font-mono font-semibold tabular-nums text-emerald-700 dark:text-emerald-400"
-                            title="可分配 = 這張採購單此商品的已到貨 − 已派"
-                          >
-                            可分配 {p.available}
-                          </span>
-                        </div>
+                        </ul>
                       </div>
                       {/* 觸控目標 ≥ 44px（平板現場單手點） */}
                       <button
                         type="button"
-                        onClick={() => togglePick(p.key)}
+                        onClick={() => togglePick(sk.sku_id)}
                         className={`min-h-[44px] min-w-[104px] shrink-0 rounded-md px-3 text-sm font-semibold ${
                           picked
                             ? "border border-blue-300 bg-white text-blue-700 hover:bg-blue-50 dark:border-blue-700 dark:bg-zinc-900 dark:text-blue-300 dark:hover:bg-blue-950"

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -1098,7 +1098,92 @@ export default function PickingWorkstationPage() {
     });
   }
 
-  // FIFO 提交：把每個 (sku, store) 的擬分量切分到含此 sku 的多張 PO，再對每張 PO 各別發 RPC。
+  // ===== FIFO 規劃器：把每個 (sku, store) 的擬分量切分到含此 sku 的多張 PO =====
+  // submitAll 與 involvedPosFor 共用（20260816 借調上線前兩處各養一份、已經開始漂移）。
+  // 第一輪（既有跨團守衛，原樣保留）：只倒給「該店在此 PO 確實有需求」的 PO ——
+  //   view 只在某店對某 PO 對應的開團 / 補貨有需求時才產生該 (po,sku,store) 列，
+  //   「有列 = 有需求」，避免把別團需求倒給最舊的 PO。
+  // 第二輪（跨團借調，20260816000050）：第一輪吃完還有剩、且該店該 SKU 確實還有
+  //   未派需求（storeDemandLeft > 0，不是憑空多派）→ 從同 SKU 其他 PO 的「餘量」補。
+  //   餘量 = 該 PO 剩餘容量 − max(0, 該 PO 自己的未派需求 − 第一輪已派給它的量)：
+  //   借調永遠不吃來源 PO 自己團的客人還沒拿到的貨。DB 端步驟 4.5 是同一套算法的守衛，
+  //   wave item 會被 RPC 標成「實際被服務的那一團」，訂單推進不會卡。
+  function planWaveAllocations(scopeRows: SkuRow[]): {
+    perPoAllocs: Map<number, Array<{ sku_id: number; store_id: number; qty: number }>>;
+    insufficient: string[];
+  } {
+    const perPoAllocs = new Map<number, Array<{ sku_id: number; store_id: number; qty: number }>>();
+    const insufficient: string[] = [];
+    if (!demand) return { perPoAllocs, insufficient };
+
+    const demandPoSkuStore = new Set<string>();
+    // 該 PO 該 SKU「自己的未派需求」Σ max(0, demand − wave)，口徑同 view 的 demand_left
+    //（wave_qty 含借調歸屬分支，之前借出去的量不會被重複保留）。
+    const ownUnmet = new Map<string, number>();
+    for (const r of demand) {
+      if (r.store_id === null) continue;
+      demandPoSkuStore.add(`${r.po_id}:${r.sku_id}:${r.store_id}`);
+      const k = `${r.po_id}:${r.sku_id}`;
+      ownUnmet.set(k, (ownUnmet.get(k) ?? 0) + Math.max(0, Number(r.demand_qty) - Number(r.wave_qty)));
+    }
+
+    // 可消耗的 PO 容量表 perPoSkuLeft.get(`${po}:${sku}`) = 該 PO 該 SKU 還可分配
+    const perPoSkuLeft = new Map<string, number>();
+    for (const sk of scopeRows) {
+      for (const po of sk.poList) {
+        perPoSkuLeft.set(`${po.po_id}:${sk.sku_id}`, Math.max(0, po.gr_qty - po.already_wave_for_sku));
+      }
+    }
+    // 第一輪派給各 PO 的量（借調的保留量要先扣掉這些 —— 已經在服務自己團的需求了）
+    const matchedTaken = new Map<string, number>();
+
+    for (const sk of scopeRows) {
+      for (const st of allStores) {
+        const qty = getAlloc(sk.sku_id, st.store_id);
+        if (qty <= 0) continue;
+        let remaining = qty;
+        // 第一輪：有需求的 PO
+        for (const po of sk.poList) {
+          if (remaining <= 0) break;
+          if (!demandPoSkuStore.has(`${po.po_id}:${sk.sku_id}:${st.store_id}`)) continue;
+          const k = `${po.po_id}:${sk.sku_id}`;
+          const av = perPoSkuLeft.get(k) ?? 0;
+          if (av <= 0) continue;
+          const take = Math.min(remaining, av);
+          const slot = perPoAllocs.get(po.po_id) ?? [];
+          slot.push({ sku_id: sk.sku_id, store_id: st.store_id, qty: take });
+          perPoAllocs.set(po.po_id, slot);
+          perPoSkuLeft.set(k, av - take);
+          matchedTaken.set(k, (matchedTaken.get(k) ?? 0) + take);
+          remaining -= take;
+        }
+        // 第二輪：跨團借調（只在該店該 SKU 還有未派需求時啟動）
+        if (remaining > 0 && storeDemandLeft(sk, st.store_id) > 0) {
+          for (const po of sk.poList) {
+            if (remaining <= 0) break;
+            // 有需求的 PO 第一輪拿過了；這一輪只看「對該店沒需求、但有餘量」的 PO
+            if (demandPoSkuStore.has(`${po.po_id}:${sk.sku_id}:${st.store_id}`)) continue;
+            const k = `${po.po_id}:${sk.sku_id}`;
+            const left = perPoSkuLeft.get(k) ?? 0;
+            const reserve = Math.max(0, (ownUnmet.get(k) ?? 0) - (matchedTaken.get(k) ?? 0));
+            const take = Math.min(remaining, Math.max(0, left - reserve));
+            if (take <= 0) continue;
+            const slot = perPoAllocs.get(po.po_id) ?? [];
+            slot.push({ sku_id: sk.sku_id, store_id: st.store_id, qty: take });
+            perPoAllocs.set(po.po_id, slot);
+            perPoSkuLeft.set(k, left - take);
+            remaining -= take;
+          }
+        }
+        if (remaining > 0) {
+          insufficient.push(`「${sk.sku_code ?? ""} ${sk.sku_label}」→ ${st.store_name} 缺 ${remaining}`);
+        }
+      }
+    }
+    return { perPoAllocs, insufficient };
+  }
+
+  // FIFO 提交：規劃（planWaveAllocations）後對每張 PO 各別發 RPC。
   // scopeRows = 本次要納入建單的品項；勾選了部分品項時只傳選取的，未勾選時傳全部。
   async function submitAll(scopeRows: SkuRow[] = skuRows) {
     if (!demand) return;
@@ -1120,51 +1205,7 @@ export default function PickingWorkstationPage() {
       }
       if (overSkus.length > 0) throw new Error("超過可分配量：\n" + overSkus.join("\n"));
 
-      // 該 (po, sku, store) 是否「確實有需求」— 來自 v_picking_demand_by_po 的列。
-      // view 只在某店對某 PO 對應的開團 / 補貨有需求時，才會產生該 (po,sku,store) 列，
-      // 所以「有列 = 有需求」。FIFO 只倒給有需求的 PO，避免把別團需求撿到別團的 PO
-      // （對齊後端 rpc_create_wave_from_po 的跨團守衛）。
-      const demandPoSkuStore = new Set<string>();
-      for (const r of demand) {
-        if (r.store_id !== null) demandPoSkuStore.add(`${r.po_id}:${r.sku_id}:${r.store_id}`);
-      }
-
-      // 建可消耗的 PO 容量表 perPoSkuLeft.get(`${po}:${sku}`) = 該 PO 該 SKU 還可分配
-      const perPoSkuLeft = new Map<string, number>();
-      for (const sk of scopeRows) {
-        for (const po of sk.poList) {
-          const left = Math.max(0, po.gr_qty - po.already_wave_for_sku);
-          perPoSkuLeft.set(`${po.po_id}:${sk.sku_id}`, left);
-        }
-      }
-
-      // 對每個 (sku, store) 的擬分量做 FIFO 切到 PO
-      const perPoAllocs = new Map<number, Array<{ sku_id: number; store_id: number; qty: number }>>();
-      const insufficient: string[] = [];
-      for (const sk of scopeRows) {
-        for (const st of allStores) {
-          const qty = getAlloc(sk.sku_id, st.store_id);
-          if (qty <= 0) continue;
-          let remaining = qty;
-          for (const po of sk.poList) {
-            if (remaining <= 0) break;
-            // 只撿給「該店在此 PO 確實有需求」的 PO（尊重開團邊界，別把別團需求倒給最舊的 PO）
-            if (!demandPoSkuStore.has(`${po.po_id}:${sk.sku_id}:${st.store_id}`)) continue;
-            const k = `${po.po_id}:${sk.sku_id}`;
-            const av = perPoSkuLeft.get(k) ?? 0;
-            if (av <= 0) continue;
-            const take = Math.min(remaining, av);
-            const slot = perPoAllocs.get(po.po_id) ?? [];
-            slot.push({ sku_id: sk.sku_id, store_id: st.store_id, qty: take });
-            perPoAllocs.set(po.po_id, slot);
-            perPoSkuLeft.set(k, av - take);
-            remaining -= take;
-          }
-          if (remaining > 0) {
-            insufficient.push(`「${sk.sku_code ?? ""} ${sk.sku_label}」→ ${st.store_name} 缺 ${remaining}`);
-          }
-        }
-      }
+      const { perPoAllocs, insufficient } = planWaveAllocations(scopeRows);
 
       if (insufficient.length > 0) throw new Error("可分配量不足：\n" + insufficient.join("\n"));
       if (perPoAllocs.size === 0) throw new Error("沒有任何分配 — 請先填數量");
@@ -1241,37 +1282,8 @@ export default function PickingWorkstationPage() {
 
   // 預估會切出幾張 wave（與 submitAll 同 FIFO 邏輯），可限定品項範圍
   function involvedPosFor(scopeRows: SkuRow[]): number {
-    if (!demand) return 0;
-    // 與 submitAll 同邏輯：逐 (sku, store) FIFO，且只算「該店在此 PO 確實有需求」的 PO
-    const demandPoSkuStore = new Set<string>();
-    for (const r of demand) {
-      if (r.store_id !== null) demandPoSkuStore.add(`${r.po_id}:${r.sku_id}:${r.store_id}`);
-    }
-    const perPoSkuLeft = new Map<string, number>();
-    for (const sk of scopeRows) {
-      for (const po of sk.poList) {
-        perPoSkuLeft.set(`${po.po_id}:${sk.sku_id}`, Math.max(0, po.gr_qty - po.already_wave_for_sku));
-      }
-    }
-    const set = new Set<number>();
-    for (const sk of scopeRows) {
-      for (const st of allStores) {
-        let remaining = getAlloc(sk.sku_id, st.store_id);
-        if (remaining <= 0) continue;
-        for (const po of sk.poList) {
-          if (remaining <= 0) break;
-          if (!demandPoSkuStore.has(`${po.po_id}:${sk.sku_id}:${st.store_id}`)) continue;
-          const k = `${po.po_id}:${sk.sku_id}`;
-          const av = perPoSkuLeft.get(k) ?? 0;
-          if (av <= 0) continue;
-          const take = Math.min(remaining, av);
-          if (take > 0) set.add(po.po_id);
-          perPoSkuLeft.set(k, av - take);
-          remaining -= take;
-        }
-      }
-    }
-    return set.size;
+    // 與 submitAll 完全同一支規劃器（含借調第二輪），預估的張數不會再跟實際切的漂移
+    return planWaveAllocations(scopeRows).perPoAllocs.size;
   }
   const involvedPos = useMemo(
     () => involvedPosFor(effectiveSkuRows),

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -95,7 +95,13 @@ function pickedStorageKeyFor(tenantId: string | null | undefined, userId: string
 //   2. 跨分頁同步（storage 事件）天生就是外部 store 的訂閱，順手解掉。
 //   3. 不需要在 effect body 裡 setState。
 let pickedSkuIds: number[] = [];          // 唯一真相；localStorage 只是鏡像
-let pickedOwnerKey: string | null = null; // pickedSkuIds 目前屬於哪個 tenant/user key
+let pickedOwnerKey: string | null = null; // 目前可以寫進哪一把 key；null = 不落地
+// 是否曾經綁定過任何一把 key。用來分辨 pickedOwnerKey === null 的兩種來源：
+//   (a) 從頭到現在都還沒拿到身分（tenant 非同步載入中）→ 記憶體裡的挑選是「還沒存檔的草稿」，
+//       key 一到位要把它寫下去，否則使用者剛挑好的東西會掉。
+//   (b) 曾經有身分、後來沒了（登出／session 失效）→ 記憶體裡的是「上一個人的」，
+//       絕對不可以在下一把 key 綁定時寫進去。
+let pickedEverBound = false;
 const pickedListeners = new Set<() => void>();
 function emitPicked() { for (const l of pickedListeners) l(); }
 function subscribePicked(cb: () => void) {
@@ -125,12 +131,14 @@ function setPickedSkuIds(ids: number[]) {
   emitPicked();
 }
 // storage key 一成立（或換帳號 / 換租戶）就對齊一次。
-// 首次綁定且本機已經挑了東西 → 把它寫下去（tenant 晚到不該讓剛挑的掉）；
-// 換 key → 一律改讀新 key 的存檔，絕不把前一個帳號的清單帶過去。
+// 「還沒綁定過」且本機已經挑了東西 → 把它寫下去（tenant 晚到不該讓剛挑的掉）；
+// 其他情況（換 key、登出後再登入）→ 一律改讀新 key 的存檔，絕不把前一個帳號的清單帶過去。
 function bindPickedStorage(key: string) {
   if (pickedOwnerKey === key) return;
-  const firstBind = pickedOwnerKey === null;
-  if (firstBind && pickedSkuIds.length > 0) {
+  // ⚠️ 判斷依據是 pickedEverBound，不是 pickedOwnerKey === null。
+  //    登出後 pickedOwnerKey 也會是 null，若用它判斷會把上一個人的清單寫進下一個人的 key。
+  const draftBeforeAnyIdentity = !pickedEverBound;
+  if (draftBeforeAnyIdentity && pickedSkuIds.length > 0) {
     writeStoredPicked(key, pickedSkuIds);
   } else {
     const stored = readStoredPicked(key);
@@ -140,6 +148,13 @@ function bindPickedStorage(key: string) {
     if (!same) emitPicked();
   }
   pickedOwnerKey = key;
+  pickedEverBound = true;
+}
+// 身分沒了（登出 / session 失效 / 讀不到 tenant）→ 立刻停止寫 localStorage。
+// ⚠️ 不清空記憶體：key 變 null 也可能只是「tenant 還在載入」，清了會把使用者剛挑好的弄丟。
+//    上一個人的殘留由 bindPickedStorage 擋（pickedEverBound 為 true 時一律改讀新 key 的存檔）。
+function unbindPickedStorage() {
+  pickedOwnerKey = null;
 }
 // 跨分頁：別的分頁改了同一個 key → 重讀，避免兩個分頁互相覆蓋
 function refreshPickedFromStorage(key: string) {
@@ -200,9 +215,11 @@ export default function PickingWorkstationPage() {
   const pickedStorageKey = pickedStorageKeyFor(tenant?.id, user?.id);
   const pickedIds = useSyncExternalStore(subscribePicked, getPickedSkuIds, getPickedSkuIds);
   const pickedSkus = useMemo(() => new Set(pickedIds), [pickedIds]);
-  // storage key 一成立（或換帳號 / 換租戶）就對齊一次；純寫外部系統，沒有 setState
+  // storage key 一成立（或換帳號 / 換租戶）就對齊一次；純寫外部系統，沒有 setState。
+  // key 變回 null（登出 / session 失效）→ 立刻 unbind，之後的挑選不會再寫進上一個人的 key。
   useEffect(() => {
     if (pickedStorageKey) bindPickedStorage(pickedStorageKey);
+    else unbindPickedStorage();
   }, [pickedStorageKey]);
   // 跨分頁：別的分頁改了同一把 key → 重讀（避免兩個分頁互相覆蓋）
   useEffect(() => {

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -156,6 +156,31 @@ function bindPickedStorage(key: string) {
 function unbindPickedStorage() {
   pickedOwnerKey = null;
 }
+
+// 已挑清單目前屬於哪一位使用者（auth user.id）。null = 還不知道是誰。
+let pickedUserId: string | null = null;
+// 換人就把記憶體裡的已挑清單清掉。
+// 為什麼需要這個（storage key 已經隔離了，資料不會汙染）：風險不在資料，在人。
+//   樓下共用現場 iPad，A 登出、B 登入，storage key 要等 tenant 的 RPC 回來才成立；
+//   在那幾百毫秒裡畫面上還掛著 A 挑好的 30 樣，B 很可能以為是自己挑的，
+//   直接按「下一步」→ 建單 → 把 A 要派的貨派出去。這種操作錯誤在現場很難事後發現。
+//   user.id 是同步就有的（不必等 tenant），所以能在那個窗口之前先把畫面清乾淨。
+// ⚠️ 只有「非 null → 另一個不同的非 null」才算換人。其他轉換一律不清：
+//   null → 有值：首次登入 / session 剛載回來，記憶體是這個人自己的草稿，清了就是掉選
+//   有值 → null：登出或 session 暫時失效，交給 unbindPickedStorage 停寫入就好
+//   同一個 user：什麼都不做
+function syncPickedUser(userId: string | null) {
+  if (userId === null) return;
+  if (pickedUserId === null) { pickedUserId = userId; return; }
+  if (pickedUserId === userId) return;
+  pickedUserId = userId;
+  pickedOwnerKey = null;      // 新的 key 由 bindPickedStorage 接手；在那之前不准寫
+  // ⚠️ 不動 pickedEverBound：留 true 才會讓下一次 bind 走「讀新 key 的存檔」那條路。
+  //    若把它設回 false，bind 會把現在這個空陣列當成草稿寫下去，反而洗掉 B 自己存好的清單。
+  const had = pickedSkuIds.length > 0;
+  pickedSkuIds = [];
+  if (had) emitPicked();
+}
 // 跨分頁：別的分頁改了同一個 key → 重讀，避免兩個分頁互相覆蓋
 function refreshPickedFromStorage(key: string) {
   const stored = readStoredPicked(key);
@@ -212,9 +237,16 @@ export default function PickingWorkstationPage() {
   //    已無可分配量的品項由「失效清理 effect」移除並明示提示（見 prunedNotice 底下）。
   // 存在 module store 裡（含 tenant/user scope、跨分頁同步），細節見檔頭。
   const { user, tenant } = useAuth();
-  const pickedStorageKey = pickedStorageKeyFor(tenant?.id, user?.id);
+  const authUserId = user?.id ?? null;
+  const pickedStorageKey = pickedStorageKeyFor(tenant?.id, authUserId);
   const pickedIds = useSyncExternalStore(subscribePicked, getPickedSkuIds, getPickedSkuIds);
   const pickedSkus = useMemo(() => new Set(pickedIds), [pickedIds]);
+  // 換人（user.id 從一個非 null 值變成另一個）→ 立刻清掉畫面上的已挑清單。
+  // user.id 比 tenant 早到位，所以 B 不會在 tenant 載回來之前看到 A 挑好的東西。
+  // ⚠️ 必須排在下面的 bind effect 之前（effect 依宣告順序執行）。
+  useEffect(() => {
+    syncPickedUser(authUserId);
+  }, [authUserId]);
   // storage key 一成立（或換帳號 / 換租戶）就對齊一次；純寫外部系統，沒有 setState。
   // key 變回 null（登出 / session 失效）→ 立刻 unbind，之後的挑選不會再寫進上一個人的 key。
   useEffect(() => {

--- a/scripts/verify-cross-campaign-borrow-dryrun.sql
+++ b/scripts/verify-cross-campaign-borrow-dryrun.sql
@@ -1,0 +1,158 @@
+-- ============================================================
+-- 跨團借調（20260816000050）部署乾跑 / 部署後驗證
+--
+-- 用法（Management API，單一 query 送出）：
+--   部署前乾跑： BEGIN; + <migration 全文> + <本檔 DO 區塊> + ROLLBACK;
+--   部署後驗證： 直接跑本檔 DO 區塊（不要 BEGIN/ROLLBACK 也可以 —— 它只借 1 件
+--               又立刻期望守衛擋下超額，但保險起見還是包在 BEGIN...ROLLBACK 裡跑）。
+--
+-- 六道斷言：
+--   0) 歷史 wave 的 campaign tag 全部落在來源 PO 的團裡 → wave_qty 借調歸屬
+--      分支對既有資料零變動（2026-08-16 乾跑實測 = 0 筆例外）
+--   1) 線上找得到「某店短單有未派需求 + 有人等貨 + 別張 PO 有餘量」的真實案例
+--   2) 借 1 件成功（rpc_create_wave_from_po 走借調分支）
+--   3) wave item 的 tag 非 NULL、不屬於來源 PO 的團、該團在該店確實有人等貨
+--   4) v_picking_wave_campaign_mismatch 不把合法借調列成誤撿
+--   5) 短單那排的未派需求 −1（需求歸屬跟著 tag 走）
+--   6) 超額借調被守衛擋下（own_unmet>0 踩步驟 4.5；=0 踩步驟 4）
+-- ============================================================
+DO $dry$
+DECLARE
+  v_sku BIGINT; v_store BIGINT; v_short_po BIGINT; v_src_po BIGINT;
+  v_avail NUMERIC; v_own_unmet NUMERIC;
+  v_op UUID; v_res JSONB; v_wave BIGINT;
+  v_before NUMERIC; v_after NUMERIC;
+  v_tag BIGINT; v_n INT; v_msg TEXT; v_try NUMERIC;
+BEGIN
+  -- 0. 歷史 wave 的 tag 應全部落在來源 PO 的團裡 → 借調歸屬分支對既有資料 = 空集合
+  --    （= 新版 view 對歷史輸出零變動）
+  SELECT count(*) INTO v_n
+    FROM picking_wave_items pwi
+    JOIN picking_waves pw ON pw.id = pwi.wave_id
+   WHERE pw.status <> 'cancelled' AND pw.source_po_id IS NOT NULL AND pwi.campaign_id IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM (
+         SELECT prc.campaign_id FROM purchase_order_items poi
+           JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+           JOIN purchase_request_campaigns prc ON prc.pr_id = pri.pr_id
+          WHERE poi.po_id = pw.source_po_id
+         UNION
+         SELECT pri.source_campaign_id FROM purchase_order_items poi
+           JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+          WHERE poi.po_id = pw.source_po_id AND pri.source_campaign_id IS NOT NULL
+       ) c WHERE c.campaign_id = pwi.campaign_id);
+  IF v_n <> 0 THEN
+    RAISE EXCEPTION 'ASSERT0 FAIL: 既有 wave 有 % 筆 tag 不在來源 PO 的團（歷史歸屬會變動）', v_n;
+  END IF;
+
+  -- 1. 找真實借調案例：某店在短單有未派需求、且該店有「等貨中」的非內部訂單、
+  --    同 SKU 另張 PO 有餘量、且該店在那張 PO 上沒有需求列（真借調）
+  WITH v AS (
+    SELECT po_id, sku_id, store_id, demand_qty, wave_qty, gr_qty, po_sku_already_wave
+      FROM v_picking_demand_by_po WHERE store_id IS NOT NULL
+  ),
+  po_sku AS (
+    SELECT po_id, sku_id, MAX(gr_qty) AS gr, MAX(po_sku_already_wave) AS aw,
+           SUM(GREATEST(0, demand_qty - wave_qty)) AS own_unmet
+      FROM v GROUP BY po_id, sku_id
+  ),
+  short_side AS (
+    SELECT v.po_id, v.sku_id, v.store_id
+      FROM v JOIN po_sku p USING (po_id, sku_id)
+     WHERE v.demand_qty - v.wave_qty > 0
+       AND GREATEST(0, p.gr - p.aw) = 0
+       AND EXISTS (
+         SELECT 1 FROM customer_orders co
+         JOIN customer_order_items coi ON coi.order_id = co.id
+         LEFT JOIN members m ON m.id = co.member_id
+        WHERE co.pickup_store_id = v.store_id AND co.campaign_id IS NOT NULL
+          AND co.status NOT IN ('cancelled','expired','transferred_out')
+          AND coi.sku_id = v.sku_id AND coi.status IN ('pending','reserved','ready')
+          AND COALESCE(m.member_type,'') <> 'store_internal')
+  ),
+  surplus_side AS (
+    SELECT po_id, sku_id, GREATEST(0, gr - aw) AS avail, own_unmet,
+           GREATEST(0, gr - aw) - own_unmet AS surplus
+      FROM po_sku WHERE GREATEST(0, gr - aw) - own_unmet > 0
+  )
+  SELECT s.sku_id, s.store_id, s.po_id, x.po_id, x.avail, x.own_unmet
+    INTO v_sku, v_store, v_short_po, v_src_po, v_avail, v_own_unmet
+  FROM short_side s
+  JOIN LATERAL (
+    SELECT sp.po_id, sp.avail, sp.own_unmet
+      FROM surplus_side sp
+     WHERE sp.sku_id = s.sku_id AND sp.po_id <> s.po_id
+       AND NOT EXISTS (SELECT 1 FROM v_picking_demand_by_po v2
+                        WHERE v2.po_id = sp.po_id AND v2.sku_id = s.sku_id AND v2.store_id = s.store_id)
+     ORDER BY (sp.own_unmet > 0) DESC, sp.surplus DESC LIMIT 1
+  ) x ON TRUE
+  LIMIT 1;
+  IF v_sku IS NULL THEN RAISE EXCEPTION 'ASSERT1 FAIL: 線上找不到可測的借調案例'; END IF;
+
+  SELECT id INTO v_op FROM auth.users LIMIT 1;
+
+  SELECT COALESCE(SUM(GREATEST(0, demand_qty - wave_qty)), 0) INTO v_before
+    FROM v_picking_demand_by_po
+   WHERE po_id = v_short_po AND sku_id = v_sku AND store_id = v_store;
+
+  -- 2. 借 1 件（應成功）
+  v_res := rpc_create_wave_from_po(
+    v_src_po, CURRENT_DATE + 1,
+    jsonb_build_array(jsonb_build_object('sku_id', v_sku, 'store_id', v_store, 'qty', 1)),
+    v_op);
+  v_wave := (v_res->>'wave_id')::BIGINT;
+
+  -- 3. tag 檢查：非 NULL、不屬於來源 PO 的團、該團在該店確實有人等貨
+  SELECT campaign_id INTO v_tag FROM picking_wave_items WHERE wave_id = v_wave;
+  IF v_tag IS NULL THEN RAISE EXCEPTION 'ASSERT3a FAIL: 借調 wave item 的 campaign_id 是 NULL'; END IF;
+  IF EXISTS (
+    SELECT 1 FROM (
+      SELECT prc.campaign_id FROM purchase_order_items poi
+        JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+        JOIN purchase_request_campaigns prc ON prc.pr_id = pri.pr_id
+       WHERE poi.po_id = v_src_po
+      UNION
+      SELECT pri.source_campaign_id FROM purchase_order_items poi
+        JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+       WHERE poi.po_id = v_src_po AND pri.source_campaign_id IS NOT NULL
+    ) c WHERE c.campaign_id = v_tag
+  ) THEN RAISE EXCEPTION 'ASSERT3b FAIL: tag % 落在來源 PO 自己的團，不是借調解析', v_tag; END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+   WHERE co.campaign_id = v_tag AND co.pickup_store_id = v_store
+     AND co.status NOT IN ('cancelled','expired','transferred_out')
+     AND coi.sku_id = v_sku AND coi.status IN ('pending','reserved','ready')
+  ) THEN RAISE EXCEPTION 'ASSERT3c FAIL: tag % 的團在該店沒有等貨中的訂單', v_tag; END IF;
+
+  -- 4. mismatch 視圖不得把合法借調列成誤撿
+  SELECT count(*) INTO v_n FROM v_picking_wave_campaign_mismatch WHERE wave_id = v_wave;
+  IF v_n <> 0 THEN RAISE EXCEPTION 'ASSERT4 FAIL: 借調被 mismatch 視圖誤列（% 筆）', v_n; END IF;
+
+  -- 5. 需求歸屬：短單那排的未派需求要 −1（wave_qty 借調歸屬分支生效）
+  SELECT COALESCE(SUM(GREATEST(0, demand_qty - wave_qty)), 0) INTO v_after
+    FROM v_picking_demand_by_po
+   WHERE po_id = v_short_po AND sku_id = v_sku AND store_id = v_store;
+  IF v_after <> v_before - 1 THEN
+    RAISE EXCEPTION 'ASSERT5 FAIL: 借調後短單未派需求 % → %（預期 −1）', v_before, v_after;
+  END IF;
+
+  -- 6. 守衛：超額借調要被擋。own_unmet>0 → 借滿 avail 會踩 4.5；own_unmet=0 → avail+1 踩步驟 4
+  v_try := CASE WHEN v_own_unmet > 0 THEN v_avail ELSE v_avail + 1 END;
+  BEGIN
+    PERFORM rpc_create_wave_from_po(
+      v_src_po, CURRENT_DATE + 1,
+      jsonb_build_array(jsonb_build_object('sku_id', v_sku, 'store_id', v_store, 'qty', v_try)),
+      v_op);
+    RAISE EXCEPTION 'ASSERT6 FAIL: 超額借調（qty=%）沒有被任何守衛擋下', v_try;
+  EXCEPTION WHEN OTHERS THEN
+    v_msg := SQLERRM;
+    IF v_msg LIKE 'ASSERT6 FAIL%' THEN RAISE; END IF;
+    IF v_own_unmet > 0 AND position('跨團借調' in v_msg) = 0 THEN
+      RAISE EXCEPTION 'ASSERT6b FAIL: 預期步驟 4.5 借調守衛，實得: %', v_msg;
+    END IF;
+    IF v_own_unmet = 0 AND position('超過可分配量' in v_msg) = 0 THEN
+      RAISE EXCEPTION 'ASSERT6c FAIL: 預期步驟 4 總量守衛，實得: %', v_msg;
+    END IF;
+  END;
+END $dry$;

--- a/supabase/migrations/20260816000050_wave_cross_campaign_borrow.sql
+++ b/supabase/migrations/20260816000050_wave_cross_campaign_borrow.sql
@@ -1,0 +1,781 @@
+-- ============================================================
+-- 跨團借調：第一團短少時，把同 SKU 別張 PO 的「餘量」派給還在等的客人
+--
+-- 背景（老闆實務）：同一賣場每週重開團。第一團短少 / 未到，第二團的貨到了，
+--   實務上店家本來就會拿第二團的貨先給第一團的客人 —— 系統原本在
+--   rpc_create_wave_from_po 硬擋（跨團守衛），結果是客人缺貨、或店家改走
+--   轉單繞路生出重複單。
+-- 線上盤點（2026-08-16，唯讀）：46 組 (PO,店,SKU) 借得到 —— 生煎包三張短單
+--   缺 253 件、同 SKU 兩張 PO 餘 128；土雞蛋缺 150、餘 9。合計缺 403、可借 347。
+--
+-- 設計原則：
+--   1. 只借「餘量」：(GR − 已派) − 該 PO 自己的未派需求。兩團都不夠的真稀缺
+--      不自動借（誰先拿是人的決定，走既有的少發配貨 / 斷貨通知）。
+--   2. wave item 的 campaign_id 一律標「實際被服務的那一團」（不是貨來源的團）。
+--      rpc_mark_orders_shipping_for_wave 要 pwi.campaign_id = co.campaign_id 才推
+--      得動單頭；標錯 = 貨到店、單卡 confirmed（忠順 2026-08-11 的 105 張翻版）。
+--   3. 需求歸屬跟著 campaign 標記走、容量歸屬跟著來源 PO 走：
+--      v_picking_demand_by_po.wave_qty 新增借調歸屬分支（被服務的 (po,sku,store)
+--      需求會歸零、has_demand_left 會下架），po_sku_already_wave 維持算在來源 PO
+--      （可分配量正確遞減）。缺了前者，工作台會永遠邀請對同一批需求重複派貨。
+--   4. 補貨 (restock) 路徑優先且完全不變：有補貨需求的 (store,sku) 照走
+--      campaign NULL + 補貨 cap，借調只在「開團與補貨都沒需求」時啟動。
+--
+-- 基底（皆經 grep 全歷史確認為最新版）：
+--   - rpc_create_wave_from_po      ← 20260807000000（線上版，含補貨 cap hotfix）
+--       新增：步驟 4.5 借調總量守衛、步驟 6 借調 campaign 解析分支。
+--   - v_picking_demand_by_po       ← 20260807000000
+--       只動 wave_qty CTE（借調歸屬分支）＋ 新增 po_campaign_po CTE；
+--       輸出欄位、順序、型別完全不變（CREATE OR REPLACE VIEW 相容）。
+--   - v_picking_wave_campaign_mismatch ← 20260702000010
+--       新增排除 (c)：標記團自身在該店該 SKU 有活訂單需求 = 合法借調，不列。
+-- Rollback：三個物件 CREATE OR REPLACE 回上述基底版本。
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. v_picking_demand_by_po：wave_qty 新增「依 campaign 標記歸屬」的借調分支
+-- ----------------------------------------------------------------
+CREATE OR REPLACE VIEW public.v_picking_demand_by_po AS
+ WITH po_skus AS (
+         SELECT po.id AS po_id,
+            po.tenant_id,
+            po.po_no,
+            po.status AS po_status,
+            po.supplier_id,
+            poi.id AS po_item_id,
+            poi.sku_id,
+            poi.qty_ordered,
+            (EXISTS ( SELECT 1
+                   FROM purchase_request_items pri2
+                     JOIN restock_requests rr ON rr.linked_pr_id = pri2.pr_id
+                  WHERE pri2.po_item_id = poi.id)) AS is_restock_sourced
+           FROM purchase_orders po
+             JOIN purchase_order_items poi ON poi.po_id = po.id
+          WHERE po.status = ANY (ARRAY['sent'::text, 'partially_received'::text, 'fully_received'::text])
+        ), gr_qty AS (
+         SELECT gri.po_item_id,
+            sum(gri.qty_received) AS gr_qty
+           FROM goods_receipt_items gri
+             JOIN goods_receipts gr ON gr.id = gri.gr_id
+          WHERE gr.status = 'confirmed'::text
+          GROUP BY gri.po_item_id
+        ), po_campaigns AS (
+         SELECT DISTINCT u.po_item_id,
+            u.campaign_id
+           FROM ( SELECT poi.id AS po_item_id,
+                    prc.campaign_id
+                   FROM purchase_order_items poi
+                     JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+                     JOIN purchase_requests pr ON pr.id = pri.pr_id
+                     JOIN purchase_request_campaigns prc ON prc.pr_id = pr.id
+                UNION
+                 SELECT poi.id AS po_item_id,
+                    pri.source_campaign_id AS campaign_id
+                   FROM purchase_order_items poi
+                     JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+                  WHERE pri.source_campaign_id IS NOT NULL) u
+        ), po_campaign_po AS (
+         -- PO 層級的開團對應（po_campaigns 是 po_item 粒度），給 wave_qty 的借調歸屬分支用
+         SELECT DISTINCT poi.po_id,
+            pc0.campaign_id
+           FROM po_campaigns pc0
+             JOIN purchase_order_items poi ON poi.id = pc0.po_item_id
+        ), campaign_demand AS (
+         SELECT pc.po_item_id,
+            co.pickup_store_id AS store_id,
+            sum(coi.qty) AS demand_qty
+           FROM po_campaigns pc
+             JOIN customer_orders co ON co.campaign_id = pc.campaign_id AND (co.status <> ALL (ARRAY['cancelled'::text, 'expired'::text, 'transferred_out'::text])) AND (co.transferred_from_order_id IS NULL OR EXISTS ( SELECT 1
+                    FROM customer_orders src
+                   WHERE src.id = co.transferred_from_order_id
+                     AND src.pickup_store_id = co.pickup_store_id))
+             JOIN customer_order_items coi ON coi.order_id = co.id AND (coi.status <> ALL (ARRAY['cancelled'::text, 'expired'::text]))
+             JOIN purchase_order_items poi ON poi.id = pc.po_item_id AND poi.sku_id = coi.sku_id
+          GROUP BY pc.po_item_id, co.pickup_store_id
+        ), restock_demand AS (
+         SELECT poi.id AS po_item_id,
+            rr.requesting_store_id AS store_id,
+            sum(rrl.qty) AS demand_qty
+           FROM purchase_order_items poi
+             JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+             JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id AND (rr.status <> ALL (ARRAY['cancelled'::text, 'rejected'::text]))
+             JOIN restock_request_lines rrl ON rrl.request_id = rr.id AND rrl.sku_id = poi.sku_id
+          GROUP BY poi.id, rr.requesting_store_id
+        ), store_demand AS (
+         SELECT u.po_item_id,
+            u.store_id,
+            sum(u.demand_qty) AS demand_qty
+           FROM ( SELECT campaign_demand.po_item_id,
+                    campaign_demand.store_id,
+                    campaign_demand.demand_qty
+                   FROM campaign_demand
+                UNION ALL
+                 SELECT restock_demand.po_item_id,
+                    restock_demand.store_id,
+                    restock_demand.demand_qty
+                   FROM restock_demand) u
+          GROUP BY u.po_item_id, u.store_id
+        ), wave_qty AS (
+         SELECT u.source_po_id,
+            u.sku_id,
+            u.store_id,
+            sum(u.qty) AS wave_qty
+           FROM ( SELECT pw.source_po_id,
+                    pwi.sku_id,
+                    pwi.store_id,
+                    pwi.qty
+                   FROM picking_wave_items pwi
+                     JOIN picking_waves pw ON pw.id = pwi.wave_id
+                  WHERE pw.status <> 'cancelled'::text AND pw.source_po_id IS NOT NULL
+                UNION ALL
+                 SELECT poi.po_id AS source_po_id,
+                    ti.sku_id,
+                    rr.requesting_store_id AS store_id,
+                    ti.qty_requested
+                   FROM restock_requests rr
+                     JOIN transfers t ON t.id = rr.linked_transfer_id
+                     JOIN transfer_items ti ON ti.transfer_id = t.id
+                     JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+                     JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+                  WHERE t.transfer_type = 'hq_to_store'::text AND t.status <> 'cancelled'::text
+                UNION ALL
+                 -- 跨團借調（20260816000050）：wave item 掛在來源 PO（貨從哪來）、
+                 -- campaign_id 標「實際被服務的團」。需求歸屬要跟著 campaign 標記走，
+                 -- 否則被借調服務的 (po, sku, store) 需求永遠顯示未派，工作台會邀請重複派貨。
+                 -- 只認「標記團不屬於來源 PO」的列（真借調）；一般列走上面第一支，不會重複計。
+                 -- 容量歸屬（po_sku_already_wave）維持跟著來源 PO，兩邊各記各的。
+                 SELECT pcp.po_id AS source_po_id,
+                    pwi.sku_id,
+                    pwi.store_id,
+                    pwi.qty
+                   FROM picking_wave_items pwi
+                     JOIN picking_waves pw ON pw.id = pwi.wave_id
+                     JOIN po_campaign_po pcp ON pcp.campaign_id = pwi.campaign_id
+                  WHERE pw.status <> 'cancelled'::text
+                    AND pw.source_po_id IS NOT NULL
+                    AND pwi.campaign_id IS NOT NULL
+                    AND pcp.po_id <> pw.source_po_id
+                    AND NOT EXISTS ( SELECT 1
+                           FROM po_campaign_po own
+                          WHERE own.po_id = pw.source_po_id
+                            AND own.campaign_id = pwi.campaign_id)) u
+          GROUP BY u.source_po_id, u.sku_id, u.store_id
+        ), po_sku_already_wave AS (
+         SELECT u.po_id,
+            u.sku_id,
+            sum(u.qty) AS already_wave
+           FROM ( SELECT pw.source_po_id AS po_id,
+                    pwi.sku_id,
+                    pwi.qty
+                   FROM picking_wave_items pwi
+                     JOIN picking_waves pw ON pw.id = pwi.wave_id
+                  WHERE pw.status <> 'cancelled'::text AND pw.source_po_id IS NOT NULL
+                UNION ALL
+                 SELECT poi.po_id,
+                    ti.sku_id,
+                    ti.qty_requested AS qty
+                   FROM restock_requests rr
+                     JOIN transfers t ON t.id = rr.linked_transfer_id
+                     JOIN transfer_items ti ON ti.transfer_id = t.id
+                     JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+                     JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+                  WHERE t.transfer_type = 'hq_to_store'::text AND t.status <> 'cancelled'::text) u
+          GROUP BY u.po_id, u.sku_id
+        ), po_sku_demand_left AS (
+         SELECT ps_1.po_id,
+            ps_1.sku_id,
+            sum(GREATEST(0::numeric, COALESCE(sd_1.demand_qty, 0::numeric) - COALESCE(wq_1.wave_qty, 0::numeric))) AS demand_left
+           FROM po_skus ps_1
+             JOIN store_demand sd_1 ON sd_1.po_item_id = ps_1.po_item_id
+             LEFT JOIN wave_qty wq_1 ON wq_1.source_po_id = ps_1.po_id AND wq_1.sku_id = ps_1.sku_id AND wq_1.store_id = sd_1.store_id
+          GROUP BY ps_1.po_id, ps_1.sku_id
+        ), shipped_qty AS (
+         SELECT u.source_po_id,
+            u.sku_id,
+            u.store_id,
+            sum(u.qty_received) AS shipped_qty
+           FROM ( SELECT pw.source_po_id,
+                    ti.sku_id,
+                    "substring"(t.transfer_no, 'WAVE-\d+-S(\d+)'::text)::bigint AS store_id,
+                    ti.qty_received
+                   FROM transfers t
+                     JOIN transfer_items ti ON ti.transfer_id = t.id
+                     JOIN picking_waves pw ON t.transfer_no ~~ (('WAVE-'::text || pw.id) || '-S%'::text)
+                  WHERE t.transfer_type = 'hq_to_store'::text AND (t.status = ANY (ARRAY['received'::text, 'closed'::text])) AND pw.source_po_id IS NOT NULL
+                UNION ALL
+                 SELECT poi.po_id AS source_po_id,
+                    ti.sku_id,
+                    rr.requesting_store_id AS store_id,
+                    ti.qty_received
+                   FROM restock_requests rr
+                     JOIN transfers t ON t.id = rr.linked_transfer_id
+                     JOIN transfer_items ti ON ti.transfer_id = t.id
+                     JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+                     JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+                  WHERE t.transfer_type = 'hq_to_store'::text AND (t.status = ANY (ARRAY['received'::text, 'closed'::text]))) u
+          GROUP BY u.source_po_id, u.sku_id, u.store_id
+        )
+ SELECT ps.tenant_id,
+    ps.po_id,
+    ps.po_no,
+    ps.po_status,
+    ps.supplier_id,
+    ps.po_item_id,
+    ps.sku_id,
+    s.sku_code,
+    COALESCE(s.product_name, ''::text) || COALESCE(' '::text || NULLIF(s.variant_name, ''::text), ''::text) AS sku_label,
+    ps.qty_ordered,
+    COALESCE(g.gr_qty, 0::numeric) AS gr_qty,
+        CASE
+            WHEN ps.po_status <> 'fully_received'::text THEN GREATEST(0::numeric, ps.qty_ordered - COALESCE(g.gr_qty, 0::numeric))
+            ELSE 0::numeric
+        END AS qty_in_transit,
+        CASE
+            WHEN ps.po_status = 'fully_received'::text AND COALESCE(g.gr_qty, 0::numeric) < ps.qty_ordered THEN ps.qty_ordered - COALESCE(g.gr_qty, 0::numeric)
+            ELSE 0::numeric
+        END AS qty_shortage,
+    sd.store_id,
+    st.code AS store_code,
+    st.name AS store_name,
+    COALESCE(sd.demand_qty, 0::numeric) AS demand_qty,
+    COALESCE(wq.wave_qty, 0::numeric) AS wave_qty,
+    COALESCE(sq.shipped_qty, 0::numeric) AS shipped_qty,
+    ps.is_restock_sourced,
+    COALESCE(psaw.already_wave, 0::numeric) AS po_sku_already_wave,
+    COALESCE(g.gr_qty, 0::numeric) > COALESCE(psaw.already_wave, 0::numeric) AS has_stock_left,
+    COALESCE(dl.demand_left, 0::numeric) > 0::numeric AS has_demand_left
+   FROM po_skus ps
+     JOIN skus s ON s.id = ps.sku_id
+     LEFT JOIN gr_qty g ON g.po_item_id = ps.po_item_id
+     LEFT JOIN store_demand sd ON sd.po_item_id = ps.po_item_id
+     LEFT JOIN stores st ON st.id = sd.store_id
+     LEFT JOIN wave_qty wq ON wq.source_po_id = ps.po_id AND wq.sku_id = ps.sku_id AND wq.store_id = sd.store_id
+     LEFT JOIN shipped_qty sq ON sq.source_po_id = ps.po_id AND sq.sku_id = ps.sku_id AND sq.store_id = sd.store_id
+     LEFT JOIN po_sku_already_wave psaw ON psaw.po_id = ps.po_id AND psaw.sku_id = ps.sku_id
+     LEFT JOIN po_sku_demand_left dl ON dl.po_id = ps.po_id AND dl.sku_id = ps.sku_id
+  WHERE COALESCE(sq.shipped_qty, 0::numeric) < GREATEST(COALESCE(g.gr_qty, 0::numeric), 1::numeric) AND (COALESCE(g.gr_qty, 0::numeric) > 0::numeric OR COALESCE(sd.demand_qty, 0::numeric) > 0::numeric);
+
+GRANT SELECT ON public.v_picking_demand_by_po TO authenticated;
+
+COMMENT ON VIEW public.v_picking_demand_by_po IS
+  '撿貨工作站主視圖：PO × SKU × store 矩陣。campaign_demand 排除「跨店」衍生單、保留「同店」衍生單。'
+  'wave_qty 含跨團借調歸屬分支（campaign 標記不屬於來源 PO 的 wave item，需求歸屬跟著標記走）；'
+  'po_sku_already_wave/has_stock_left 維持跟著來源 PO。其餘語意同 20260807000000。';
+
+-- ----------------------------------------------------------------
+-- 2. rpc_create_wave_from_po：步驟 4.5 借調總量守衛 + 步驟 6 借調 campaign 解析
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_wave_from_po(p_po_id bigint, p_wave_date date, p_allocations jsonb, p_operator uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_po                purchase_orders%ROWTYPE;
+  v_tenant            UUID;
+  v_wave_id           BIGINT;
+  v_wave_code         TEXT;
+  v_alloc             JSONB;
+  v_sku_id            BIGINT;
+  v_store_id          BIGINT;
+  v_qty               NUMERIC(18,3);
+  v_line_campaign_id  BIGINT;
+  v_total_qty         NUMERIC(18,3) := 0;
+  v_item_count        INTEGER := 0;
+  v_store_count       INTEGER := 0;
+  v_over              RECORD;
+  v_restock_demand    NUMERIC;
+  v_restock_dispatched NUMERIC;
+  v_restock_left      NUMERIC;
+  v_borrow            RECORD;
+BEGIN
+  -- 1. PO 守衛
+  SELECT * INTO v_po FROM purchase_orders WHERE id = p_po_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '找不到採購單 #%', p_po_id;
+  END IF;
+  IF v_po.status NOT IN ('sent','partially_received','fully_received') THEN
+    RAISE EXCEPTION '採購單 % 狀態為「%」、不可建撿貨單（需為「已發送」/「部分進貨」/「全部進貨」）', v_po.po_no, v_po.status;
+  END IF;
+  v_tenant := v_po.tenant_id;
+
+  -- 2. allocations 守衛
+  IF p_allocations IS NULL OR jsonb_array_length(p_allocations) = 0 THEN
+    RAISE EXCEPTION '請先填寫各分店分配量、不可全為空';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('wave:po:' || p_po_id::text));
+
+  -- 3. 守衛：每個分配 qty > 0
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations) LOOP
+    v_qty := (v_alloc->>'qty')::NUMERIC;
+    IF v_qty IS NULL OR v_qty <= 0 THEN
+      RAISE EXCEPTION '分配數量必須 > 0';
+    END IF;
+  END LOOP;
+
+  -- 4. 守衛：每 sku 的總分配量 ≤ (GR 量 − 已派量)
+  --    已派量 = picking_wave_items ＋ 補貨直派 transfer（linked_transfer_id 路徑），
+  --    與 v_picking_demand_by_po.po_sku_already_wave 對齊。
+  WITH alloc_agg AS (
+    SELECT
+      (a->>'sku_id')::BIGINT  AS sku_id,
+      SUM((a->>'qty')::NUMERIC) AS total_alloc
+    FROM jsonb_array_elements(p_allocations) a
+    GROUP BY (a->>'sku_id')::BIGINT
+  ),
+  po_sku_state AS (
+    SELECT
+      poi.sku_id,
+      COALESCE(SUM(gri.qty_received) FILTER (WHERE gr.status = 'confirmed'), 0) AS gr_qty,
+      COALESCE((
+        SELECT SUM(pwi.qty)
+          FROM picking_wave_items pwi
+          JOIN picking_waves pw ON pw.id = pwi.wave_id
+         WHERE pw.source_po_id = p_po_id
+           AND pwi.sku_id = poi.sku_id
+           AND pw.status <> 'cancelled'
+      ), 0)
+      + COALESCE((
+        SELECT SUM(ti.qty_requested)
+          FROM restock_requests rr
+          JOIN transfers t ON t.id = rr.linked_transfer_id
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+          JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+          JOIN purchase_order_items poi2 ON poi2.id = pri.po_item_id AND poi2.sku_id = ti.sku_id
+         WHERE poi2.po_id = p_po_id
+           AND poi2.sku_id = poi.sku_id
+           AND t.transfer_type = 'hq_to_store'
+           AND t.status <> 'cancelled'
+      ), 0) AS already_wave
+    FROM purchase_order_items poi
+    LEFT JOIN goods_receipt_items gri ON gri.po_item_id = poi.id
+    LEFT JOIN goods_receipts gr ON gr.id = gri.gr_id
+    WHERE poi.po_id = p_po_id
+    GROUP BY poi.sku_id
+  )
+  SELECT
+    s.sku_code,
+    COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+    aa.total_alloc, ps.gr_qty, ps.already_wave,
+    (ps.gr_qty - ps.already_wave) AS available
+  INTO v_over
+  FROM alloc_agg aa
+  JOIN po_sku_state ps ON ps.sku_id = aa.sku_id
+  JOIN skus s ON s.id = aa.sku_id
+  WHERE aa.total_alloc > (ps.gr_qty - ps.already_wave)
+  LIMIT 1;
+
+  IF v_over.sku_code IS NOT NULL THEN
+    RAISE EXCEPTION 'SKU「% %」分配 % 超過可分配量 %（進貨 %、已派 %，含撿貨單與補貨直派）',
+      v_over.sku_code, v_over.sku_label,
+      v_over.total_alloc, v_over.available, v_over.gr_qty, v_over.already_wave;
+  END IF;
+
+  -- 4.5 借調守衛（20260816000050）：分配到「本單開團 / 補貨都沒需求」的 (store, sku)
+  --     ＝ 跨團借調。借調總量（per SKU）不可超過本單餘量
+  --       餘量 = (GR − 已派) − 本單自己的未派需求
+  --     否則會吃掉本單自己團的客人還沒拿到的貨。「未派需求」對齊
+  --     v_picking_demand_by_po 的 demand_left 口徑（Σ GREATEST(0, demand − wave)；
+  --     wave_qty 的借調歸屬分支已含在內）。此守衛在建 wave 之前跑，view 不含本次分配。
+  WITH alloc_rows AS (
+    SELECT
+      (a->>'sku_id')::BIGINT  AS sku_id,
+      (a->>'store_id')::BIGINT AS store_id,
+      SUM((a->>'qty')::NUMERIC) AS qty
+    FROM jsonb_array_elements(p_allocations) a
+    GROUP BY (a->>'sku_id')::BIGINT, (a->>'store_id')::BIGINT
+  ),
+  borrow_alloc AS (
+    SELECT ar.sku_id, SUM(ar.qty) AS borrow_qty
+      FROM alloc_rows ar
+     WHERE NOT EXISTS (               -- 本單開團對該 (store, sku) 沒有訂單需求（鏡射步驟 6 的解析條件）
+             SELECT 1
+               FROM ( SELECT prc.campaign_id
+                        FROM purchase_order_items poi
+                        JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+                        JOIN purchase_request_campaigns prc ON prc.pr_id = pri.pr_id
+                       WHERE poi.po_id = p_po_id
+                      UNION
+                      SELECT pri.source_campaign_id AS campaign_id
+                        FROM purchase_order_items poi
+                        JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+                       WHERE poi.po_id = p_po_id
+                         AND pri.source_campaign_id IS NOT NULL) cand
+              WHERE EXISTS (
+                SELECT 1
+                  FROM customer_orders co
+                  JOIN customer_order_items coi ON coi.order_id = co.id
+                 WHERE co.campaign_id = cand.campaign_id
+                   AND co.pickup_store_id = ar.store_id
+                   AND co.status NOT IN ('cancelled','expired','transferred_out')
+                   AND (co.transferred_from_order_id IS NULL OR EXISTS (
+                         SELECT 1 FROM customer_orders src
+                          WHERE src.id = co.transferred_from_order_id
+                            AND src.pickup_store_id = co.pickup_store_id))
+                   AND coi.sku_id = ar.sku_id
+                   AND coi.status NOT IN ('cancelled','expired')))
+       AND NOT EXISTS (               -- 也不是補貨來源（鏡射步驟 6）
+             SELECT 1
+               FROM purchase_order_items poi
+               JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+               JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                                       AND rr.requesting_store_id = ar.store_id
+                                       AND rr.status NOT IN ('cancelled','rejected')
+               JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                             AND rrl.sku_id = ar.sku_id
+              WHERE poi.po_id = p_po_id
+                AND poi.sku_id = ar.sku_id)
+     GROUP BY ar.sku_id
+  ),
+  own_unmet AS (
+    SELECT v.sku_id, SUM(GREATEST(0, v.demand_qty - v.wave_qty)) AS unmet
+      FROM public.v_picking_demand_by_po v
+     WHERE v.po_id = p_po_id AND v.store_id IS NOT NULL
+     GROUP BY v.sku_id
+  ),
+  po_sku_state2 AS (
+    SELECT
+      poi.sku_id,
+      COALESCE(SUM(gri.qty_received) FILTER (WHERE gr.status = 'confirmed'), 0) AS gr_qty,
+      COALESCE((
+        SELECT SUM(pwi.qty)
+          FROM picking_wave_items pwi
+          JOIN picking_waves pw ON pw.id = pwi.wave_id
+         WHERE pw.source_po_id = p_po_id
+           AND pwi.sku_id = poi.sku_id
+           AND pw.status <> 'cancelled'
+      ), 0)
+      + COALESCE((
+        SELECT SUM(ti.qty_requested)
+          FROM restock_requests rr
+          JOIN transfers t ON t.id = rr.linked_transfer_id
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+          JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+          JOIN purchase_order_items poi2 ON poi2.id = pri.po_item_id AND poi2.sku_id = ti.sku_id
+         WHERE poi2.po_id = p_po_id
+           AND poi2.sku_id = poi.sku_id
+           AND t.transfer_type = 'hq_to_store'
+           AND t.status <> 'cancelled'
+      ), 0) AS already_wave
+    FROM purchase_order_items poi
+    LEFT JOIN goods_receipt_items gri ON gri.po_item_id = poi.id
+    LEFT JOIN goods_receipts gr ON gr.id = gri.gr_id
+    WHERE poi.po_id = p_po_id
+    GROUP BY poi.sku_id
+  )
+  SELECT
+    s.sku_code,
+    COALESCE(s.product_name, '') || COALESCE(' ' || NULLIF(s.variant_name,''), '') AS sku_label,
+    b.borrow_qty,
+    COALESCE(u.unmet, 0) AS own_unmet,
+    GREATEST(0, GREATEST(0, ps.gr_qty - ps.already_wave) - COALESCE(u.unmet, 0)) AS surplus
+  INTO v_borrow
+  FROM borrow_alloc b
+  JOIN po_sku_state2 ps ON ps.sku_id = b.sku_id
+  LEFT JOIN own_unmet u ON u.sku_id = b.sku_id
+  JOIN skus s ON s.id = b.sku_id
+  WHERE b.borrow_qty > GREATEST(0, GREATEST(0, ps.gr_qty - ps.already_wave) - COALESCE(u.unmet, 0))
+  LIMIT 1;
+
+  IF v_borrow.sku_code IS NOT NULL THEN
+    RAISE EXCEPTION 'SKU「% %」跨團借調 % 件超過本單餘量 %（本單自己的團還缺 % 件未派，借調只能動「蓋掉自己需求後剩下的量」）',
+      v_borrow.sku_code, v_borrow.sku_label,
+      v_borrow.borrow_qty, v_borrow.surplus, v_borrow.own_unmet;
+  END IF;
+
+  -- 5. wave header — 用 sequence 產 code,避免同秒撞單
+  v_wave_code := 'WV'
+              || to_char(NOW() AT TIME ZONE 'Asia/Taipei', 'YYMMDD')
+              || LPAD(nextval('public.picking_wave_code_seq')::TEXT, 6, '0');
+
+  INSERT INTO picking_waves (
+    tenant_id, wave_code, wave_date, status, source_po_id,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_wave_code, p_wave_date, 'draft', p_po_id,
+    p_operator, p_operator
+  ) RETURNING id INTO v_wave_id;
+
+  -- 6 + 7. 逐 (sku, store) 解析「實際有需求的那一團」當 campaign_id，並擋跨團誤撿
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations) LOOP
+    v_sku_id   := (v_alloc->>'sku_id')::BIGINT;
+    v_store_id := (v_alloc->>'store_id')::BIGINT;
+    v_qty      := (v_alloc->>'qty')::NUMERIC;
+
+    -- 在「此 PO 對應的開團」裡，挑對該 (store, sku) 確實有訂單需求的一團。
+    -- 涵蓋兩條 PO→campaign 路徑（purchase_request_campaigns 與 source_campaign_id），
+    -- 與 v_picking_demand_by_po 的 po_campaigns 對齊。
+    SELECT cand.campaign_id
+      INTO v_line_campaign_id
+      FROM (
+        SELECT prc.campaign_id
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+          JOIN purchase_request_campaigns prc ON prc.pr_id = pri.pr_id
+         WHERE poi.po_id = p_po_id
+        UNION
+        SELECT pri.source_campaign_id AS campaign_id
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+         WHERE poi.po_id = p_po_id
+           AND pri.source_campaign_id IS NOT NULL
+      ) cand
+     WHERE EXISTS (
+       SELECT 1
+         FROM customer_orders co
+         JOIN customer_order_items coi ON coi.order_id = co.id
+        WHERE co.campaign_id = cand.campaign_id
+          AND co.pickup_store_id = v_store_id
+          AND co.status NOT IN ('cancelled','expired','transferred_out')
+          AND (co.transferred_from_order_id IS NULL OR EXISTS (
+                SELECT 1 FROM customer_orders src
+                 WHERE src.id = co.transferred_from_order_id
+                   AND src.pickup_store_id = co.pickup_store_id))
+          AND coi.sku_id = v_sku_id
+          AND coi.status NOT IN ('cancelled','expired')
+     )
+     ORDER BY cand.campaign_id
+     LIMIT 1;
+
+    IF v_line_campaign_id IS NULL THEN
+      -- 此 (store, sku) 在這張 PO 的開團都沒有需求。兩條出路：
+      --   a) 補貨 (restock) 來源 → campaign_id 掛 NULL ＋ 補貨 cap（沿用既有行為，優先）。
+      --   b) 跨團借調（20260816000050）→ 別的團在該店有客人在等 → 標「被服務的那一團」。
+      IF NOT EXISTS (
+        SELECT 1
+          FROM purchase_order_items poi
+          JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+          JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                                  AND rr.requesting_store_id = v_store_id
+                                  AND rr.status NOT IN ('cancelled','rejected')
+          JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                        AND rrl.sku_id = v_sku_id
+         WHERE poi.po_id = p_po_id
+           AND poi.sku_id = v_sku_id
+      ) THEN
+        -- 跨團借調：wave item 的 campaign_id 一律標「實際被服務的那一團」，
+        -- 出貨時 rpc_mark_orders_shipping_for_wave（pwi.campaign_id = co.campaign_id）
+        -- 才推得動該團的單頭。標成貨來源的團 = 貨到店、單卡 confirmed
+        -- （忠順 2026-08-11 全卡 105 張的翻版），絕對不要。
+        -- 解析規則：該店該 SKU「還在等貨」（pending/reserved/ready）的活訂單裡，
+        -- 挑最早開始等的那一團；內部現貨池（store_internal）不是借調對象。
+        -- 借調總量已由步驟 4.5 擋在本單餘量內。
+        SELECT co.campaign_id
+          INTO v_line_campaign_id
+          FROM customer_orders co
+          JOIN customer_order_items coi ON coi.order_id = co.id
+          LEFT JOIN members m ON m.id = co.member_id
+         WHERE co.pickup_store_id = v_store_id
+           AND co.campaign_id IS NOT NULL
+           AND co.status NOT IN ('cancelled','expired','transferred_out')
+           AND (co.transferred_from_order_id IS NULL OR EXISTS (
+                 SELECT 1 FROM customer_orders src
+                  WHERE src.id = co.transferred_from_order_id
+                    AND src.pickup_store_id = co.pickup_store_id))
+           AND coi.sku_id = v_sku_id
+           AND coi.status IN ('pending','reserved','ready')
+           AND COALESCE(m.member_type, '') <> 'store_internal'
+         GROUP BY co.campaign_id
+         ORDER BY MIN(co.created_at)
+         LIMIT 1;
+
+        IF v_line_campaign_id IS NULL THEN
+          RAISE EXCEPTION
+            '分店「%」在採購單「%」對應的開團沒有 SKU「%」的訂單需求，也沒有別團的客人在該店等這個商品，不能撿到這批貨（若要額外補庫存給分店，請走內部調撥）',
+            COALESCE((SELECT name FROM stores WHERE id = v_store_id), '#' || v_store_id),
+            v_po.po_no,
+            COALESCE((SELECT sku_code FROM skus WHERE id = v_sku_id), '#' || v_sku_id);
+        END IF;
+      ELSE
+
+      -- 20260715 新增：補貨分配不可超過「剩餘補貨需求」= 申請量 − 已派量。
+      -- 申請量：此 PO 對應補貨申請對該 (store, sku) 的 lines 加總。
+      SELECT COALESCE(SUM(rrl.qty), 0) INTO v_restock_demand
+        FROM purchase_order_items poi
+        JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+        JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                                AND rr.requesting_store_id = v_store_id
+                                AND rr.status NOT IN ('cancelled','rejected')
+        JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                      AND rrl.sku_id = v_sku_id
+       WHERE poi.po_id = p_po_id
+         AND poi.sku_id = v_sku_id;
+
+      -- 已派量：此 PO 的 campaign NULL wave items（含本 wave 前面 loop 已插入的列，
+      -- 同批重複 (sku,store) 會累計）＋ 補貨直派 transfer。
+      SELECT
+        COALESCE((
+          SELECT SUM(pwi.qty)
+            FROM picking_wave_items pwi
+            JOIN picking_waves pw ON pw.id = pwi.wave_id
+           WHERE pw.source_po_id = p_po_id
+             AND pw.status <> 'cancelled'
+             AND pwi.sku_id = v_sku_id
+             AND pwi.store_id = v_store_id
+             AND pwi.campaign_id IS NULL
+        ), 0)
+        + COALESCE((
+          SELECT SUM(ti.qty_requested)
+            FROM restock_requests rr
+            JOIN transfers t ON t.id = rr.linked_transfer_id
+            JOIN transfer_items ti ON ti.transfer_id = t.id AND ti.sku_id = v_sku_id
+            JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+            JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = v_sku_id
+           WHERE poi.po_id = p_po_id
+             AND rr.requesting_store_id = v_store_id
+             AND t.transfer_type = 'hq_to_store'
+             AND t.status <> 'cancelled'
+        ), 0)
+      INTO v_restock_dispatched;
+
+      v_restock_left := GREATEST(0, v_restock_demand - v_restock_dispatched);
+      IF v_qty > v_restock_left THEN
+        RAISE EXCEPTION
+          '分店「%」SKU「%」的補貨需求只剩 % 件未派（申請 %、已派 %，含撿貨單與直派），本次分配 % 超過。若要額外補庫存給分店，請走內部調撥。',
+          COALESCE((SELECT name FROM stores WHERE id = v_store_id), '#' || v_store_id),
+          COALESCE((SELECT sku_code FROM skus WHERE id = v_sku_id), '#' || v_sku_id),
+          v_restock_left, v_restock_demand, v_restock_dispatched, v_qty;
+      END IF;
+      END IF;  -- a) restock / b) 借調 分流
+    END IF;
+
+    INSERT INTO picking_wave_items (
+      tenant_id, wave_id, sku_id, store_id, qty, campaign_id,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, v_wave_id, v_sku_id, v_store_id, v_qty, v_line_campaign_id,
+      p_operator, p_operator
+    )
+    ON CONFLICT (wave_id, sku_id, store_id) DO UPDATE
+      SET qty = picking_wave_items.qty + EXCLUDED.qty,
+          updated_by = p_operator,
+          updated_at = NOW();
+  END LOOP;
+
+  -- 8. 統計 wave header
+  SELECT COUNT(*), COUNT(DISTINCT store_id), COALESCE(SUM(qty), 0)
+    INTO v_item_count, v_store_count, v_total_qty
+    FROM picking_wave_items WHERE wave_id = v_wave_id;
+
+  UPDATE picking_waves
+     SET item_count = v_item_count,
+         store_count = v_store_count,
+         total_qty = v_total_qty,
+         updated_at = NOW()
+   WHERE id = v_wave_id;
+
+  RETURN jsonb_build_object(
+    'wave_id', v_wave_id,
+    'wave_code', v_wave_code,
+    'item_count', v_item_count,
+    'store_count', v_store_count,
+    'total_qty', v_total_qty
+  );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_wave_from_po(BIGINT, DATE, JSONB, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_wave_from_po(BIGINT, DATE, JSONB, UUID) IS
+  '由派貨工作台建撿貨單。跨團守衛：本單開團有需求 → 標該團；補貨來源 → NULL + 補貨 cap；'
+  '都沒有 → 跨團借調（標「實際被服務的團」，總量 ≤ 本單餘量 = 可分配 − 自己未派需求，'
+  '步驟 4.5 守衛）。基底 20260807000000。';
+
+-- ----------------------------------------------------------------
+-- 3. v_picking_wave_campaign_mismatch：合法借調不列 mismatch
+-- ----------------------------------------------------------------
+CREATE OR REPLACE VIEW public.v_picking_wave_campaign_mismatch AS
+SELECT
+  p.tenant_id,
+  p.wave_id,
+  pw.wave_code,
+  pw.status        AS wave_status,
+  pw.source_po_id  AS po_id,
+  po.po_no,
+  p.store_id,
+  st.name          AS store_name,
+  p.sku_id,
+  s.sku_code,
+  COALESCE(s.product_name,'') || COALESCE(' ' || NULLIF(s.variant_name,''),'') AS sku_label,
+  p.qty,
+  p.campaign_id    AS tagged_campaign_id,
+  ( SELECT string_agg(DISTINCT c2.campaign_no, ', ' ORDER BY c2.campaign_no)
+      FROM customer_orders co2
+      JOIN customer_order_items coi2 ON coi2.order_id = co2.id
+      JOIN group_buy_campaigns c2 ON c2.id = co2.campaign_id
+     WHERE co2.pickup_store_id = p.store_id
+       AND coi2.sku_id = p.sku_id
+       AND co2.status NOT IN ('cancelled','expired','transferred_out')
+       AND co2.transferred_from_order_id IS NULL
+       AND coi2.status NOT IN ('cancelled','expired')
+  ) AS demand_actually_in
+FROM picking_wave_items p
+JOIN picking_waves pw ON pw.id = p.wave_id
+JOIN purchase_orders po ON po.id = pw.source_po_id
+JOIN skus s ON s.id = p.sku_id
+LEFT JOIN stores st ON st.id = p.store_id
+WHERE pw.status <> 'cancelled'
+  AND pw.source_po_id IS NOT NULL
+  -- (a) 此 PO 的開團都沒有該 (store, sku) 的活訂單需求
+  AND NOT EXISTS (
+    SELECT 1
+    FROM (
+      SELECT prc.campaign_id
+        FROM purchase_order_items poi
+        JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+        JOIN purchase_request_campaigns prc ON prc.pr_id = pri.pr_id
+       WHERE poi.po_id = pw.source_po_id
+      UNION
+      SELECT pri.source_campaign_id
+        FROM purchase_order_items poi
+        JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+       WHERE poi.po_id = pw.source_po_id
+         AND pri.source_campaign_id IS NOT NULL
+    ) cand
+    JOIN customer_orders co ON co.campaign_id = cand.campaign_id
+                           AND co.pickup_store_id = p.store_id
+                           AND co.status NOT IN ('cancelled','expired','transferred_out')
+                           AND co.transferred_from_order_id IS NULL
+    JOIN customer_order_items coi ON coi.order_id = co.id
+                                 AND coi.sku_id = p.sku_id
+                                 AND coi.status NOT IN ('cancelled','expired')
+  )
+  -- (b) 也不是補貨來源
+  AND NOT EXISTS (
+    SELECT 1
+      FROM purchase_order_items poi
+      JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+      JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id
+                              AND rr.requesting_store_id = p.store_id
+                              AND rr.status NOT IN ('cancelled','rejected')
+      JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+                                    AND rrl.sku_id = p.sku_id
+     WHERE poi.po_id = pw.source_po_id
+       AND poi.sku_id = p.sku_id
+  )
+  -- (c) 也不是合法的跨團借調（20260816000050）：wave item 的 campaign_id 標的是
+  --     「實際被服務的那一團」，只要那一團在該店該 SKU 確實有活訂單需求，
+  --     tag 就是誠實的（訂單推進不會卡）→ 不列 mismatch。
+  --     誤標（標了沒需求的團）與 campaign_id NULL 的超撿照舊列出。
+  AND NOT (
+    p.campaign_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+        FROM customer_orders co
+        JOIN customer_order_items coi ON coi.order_id = co.id
+                                     AND coi.sku_id = p.sku_id
+                                     AND coi.status NOT IN ('cancelled','expired')
+       WHERE co.campaign_id = p.campaign_id
+         AND co.pickup_store_id = p.store_id
+         AND co.status NOT IN ('cancelled','expired','transferred_out')
+         AND co.transferred_from_order_id IS NULL
+    )
+  );
+
+GRANT SELECT ON public.v_picking_wave_campaign_mismatch TO authenticated;
+
+COMMENT ON VIEW public.v_picking_wave_campaign_mismatch IS
+  '撿貨單跨開團誤撿 / 無需求超撿偵測（唯讀）。排除合法跨團借調（campaign_id 標記的團'
+  '在該店該 SKU 有活訂單需求）；誤標與 NULL 超撿照舊列出。與 rpc_create_wave_from_po'
+  '的守衛同一不變式。基底 20260702000010。';


### PR DESCRIPTION
老闆：「我明明選了好多商品…正要建立撿貨單，發現只選了一樣。」

根因 1：selectedRows 是「勾選 ∩ 目前清單」（舊 :925-928），
根因 2：唯一的找商品工具「商品」單選下拉會把清單縮到 1 列
→ 用來「找」的工具會毀掉「選」的結果。

做法
- 步驟 1（挑選商品）：純商品清單、不出現分店矩陣。
  一列 = 一個商品 × 一張採購單，標明團號／團名／採購單號／該團到貨量
  （老闆：「相同的品名容易搞錯，第一團未到、第二團到了會派錯」）。
  「可分配 = 0 就隱藏」按採購單各自算，未到貨那團不會出現。
- 商品搜尋（名稱 + 品號，模糊、不分大小寫）取代單選下拉。
- 「已挑清單」是獨立集合，key = `${po_id}:${sku_id}`，
  絕不與目前搜尋結果做交集；存 localStorage，重新整理不掉。
  撈完 demand 後把「已無可分配量」的品項自動移除並明示提示。
- 步驟 2（確認數量並建單）：矩陣只渲染已挑中的品項；
  effectiveSkuRows 改讀已挑清單，移除舊的 filteredSkuRows 交集。
  已挑清單為空 → 維持現行「篩選範圍全部」語意，行為不變。
- 兩步驟可來回切換，allocs 是全域 Map，填過的數量不會掉。

附帶修既有 bug：預填數量夾在可分配量
  訂 108 只到 105 → 舊版預填 108 > 可分配 105 → submitAll 直接
  throw「超過可分配量」，整批建單失敗。部分到貨很常見。

零 DB 改動
- 沒有 migration／view／RPC 異動，沒有新增或修改任何 sb.rpc 呼叫
- submitAll、autoDistribute、setAllocCapped、involvedPosFor
  四支的函式本體與 origin/main 的 SHA-256 逐字相同（建單 FIFO 未動）
- fetchAllRows、has_stock_left/has_demand_left server-side 過濾、
  visibleStores「全濾光退回顯示全部」、effFilterCampaign 自我修正 皆原樣保留

影響面盤點：公司\01_進行中\影響面盤點_派貨工作台選取頁_2026-08-16.md

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>