### PR TITLE
會員端訂單頁移除「不成立」分頁

### DIFF
--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -17,18 +17,19 @@ import OrderCard, {
 
 // 蝦皮式分頁。我們取貨時付現金，所以沒有「待付款」；「待收貨」＝到店「待取貨」。
 // 分桶跟卡片右上角的狀態字共用 orderPhase()，兩邊永遠一致。
-// 「不成立」（斷貨取消）要顯示 —— 團友得知道那筆單為什麼消失（⛔ 斷貨說明）。
+// 「不成立」分頁 2026-08-17 應店家要求拿掉（大多時候是空的）。單子**沒有**藏：
+// 取消 / 逾期的單仍出現在「全部」，紅字「訂單不成立」＋ ⛔ 斷貨說明照畫 ——
+// 團友還是得知道那筆單為什麼消失。要連「全部」也不出現才加進 HIDDEN_PHASES。
 // 「已轉讓」目前先隱藏（連「全部」也不出現），之後要開再把它移出 HIDDEN_PHASES。
 //
 // 「全部」放最後、預設落在「待到貨」（2026-08-13 門市回報）：預設開在「全部」時
 // 待取貨跟還沒到貨的單混排，客人以為全部到貨就跑來，結果要的那件還在路上。
-type Tab = "all" | "waiting" | "pickup" | "done" | "void";
+type Tab = "all" | "waiting" | "pickup" | "done";
 
 const TAB_LABEL: Record<Tab, string> = {
   waiting: "待到貨",
   pickup: "待取貨",
   done: "已完成",
-  void: "不成立",
   all: "全部",
 };
 
@@ -46,7 +47,7 @@ function fmtAmount(n: number): string {
  * 一個分頁的金額加總。**只有「待到貨」「待取貨」會顯示這張卡**（見 showTotals）：
  * 「全部」混著幾十張早就取貨付清的已完成單，掛一個「應付總金額」會讓團友以為
  * 還欠那麼多（2026-08-11 會員 109814 的回報：$13,845 裡有 $9,959 是歷史已完成單，
- * 真正沒領的只有 $3,886）；「已完成」「不成立」則根本沒有應付。與其在「全部」
+ * 真正沒領的只有 $3,886）；「已完成」則根本沒有應付。與其在「全部」
  * 解釋口徑，不如不顯示 —— 應付金額只出現在真的還有貨要領的分頁。
  *
  * 「應付」一律用 outstanding_amount（＝還沒領走的貨），**不可以用 payable_amount**。
@@ -115,7 +116,7 @@ export default function OrdersPage() {
   // 所以一張單會拆成數個分身，各自進自己的分頁（例：已取的行 → 已完成、
   // 沒到貨的行 → 待到貨）。「全部」維持整張單不拆。
   const buckets = useMemo(() => {
-    const b: Record<Tab, OrderRow[]> = { all: orders, waiting: [], pickup: [], done: [], void: [] };
+    const b: Record<Tab, OrderRow[]> = { all: orders, waiting: [], pickup: [], done: [] };
     for (const o of orders) {
       const parts = splitOrderByPhase(o);
       // 應付金額要**分攤**到各分身，不能每個分身都掛整張單的 outstanding ——
@@ -125,7 +126,9 @@ export default function OrdersPage() {
       const wholeUnpicked = unpickedSubtotal(o.items);
       const outstanding = Number(o.outstanding_amount ?? o.payable_amount ?? 0);
       for (const [phase, part] of parts) {
-        if (phase === "transferred") continue; // 已轉讓不出現在任何分頁
+        // 已轉讓不出現在任何分頁；「不成立」分頁已拿掉，void 分身沒地方去
+        //（整張取消 / 逾期的單照樣以整單型態出現在「全部」，不會消失）
+        if (phase === "transferred" || phase === "void") continue;
         b[phase as Exclude<Tab, "all">].push({
           ...part,
           outstanding_amount:


### PR DESCRIPTION
## 摘要

應店家要求，把會員 app「我的訂單」的「不成立」分頁屏蔽（**僅會員 app**，admin 的 `MemberOrdersAppView` 不動）。分頁列剩：待到貨、待取貨、已完成、全部。

## 行為說明

- 取消／逾期的訂單**沒有**從系統裡藏起來：仍以整張單的型態出現在「全部」分頁，紅字「訂單不成立」與 ⛔ 斷貨說明照畫 —— 團友還是查得到那筆單為什麼消失。
- 依品項行拆桶時，`void` 分身比照 `transferred` 直接跳過（沒有分頁可去）。
- 之後要連「全部」也不顯示，把 `"void"` 加進 `HIDDEN_PHASES` 即可（註解已寫明）。

## 變更檔案

- `apps/member/src/app/orders/page.tsx`：`Tab` 型別與 `TAB_LABEL` 移除 `void`、分桶迴圈跳過 `void` 分身、更新相關註解。

## 驗證

- `tsc --noEmit` 通過
- `eslint src/app/orders/page.tsx` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138jrVJBEzxded4WoXK47e5

---
_Generated by [Claude Code](https://claude.ai/code/session_0138jrVJBEzxded4WoXK47e5)_