### PR TITLE
四號店收攤：訂單/會員/庫存整批轉到中和店 ＋ 兩店合併功能

### DIFF
--- a/apps/admin/src/app/(protected)/stores/page.tsx
+++ b/apps/admin/src/app/(protected)/stores/page.tsx
@@ -6,6 +6,7 @@ import SpinButton from "@/components/SpinButton";
 import SearchSpinner from "@/components/SearchSpinner";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 import { StoreLineOaField } from "@/components/StoreLineOaField";
+import { isAdmin, useRole } from "@/lib/role";
 
 const PAGE_SIZE = 20;
 
@@ -70,6 +71,8 @@ export default function StoresPage() {
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState<Store | null>(null);
   const [creating, setCreating] = useState(false);
+  const [merging, setMerging] = useState<Store | null>(null);
+  const role = useRole();
   const [page, setPage] = useState(1);
 
   useEffect(() => {
@@ -372,6 +375,15 @@ export default function StoresPage() {
                           編輯
                         </SpinButton>
                       )}
+                      {/* 兩店合併：rpc_merge_stores 本體限 owner/admin，按鈕同步只給管理員層級 */}
+                      {!r.deleted_at && isAdmin(role) && (
+                        <SpinButton
+                          onClick={() => setMerging(r)}
+                          className="text-xs text-purple-600 hover:underline dark:text-purple-400"
+                        >
+                          合併
+                        </SpinButton>
+                      )}
                       {!r.deleted_at && (
                         <SpinButton
                           onClick={() => handleDelete(r)}
@@ -396,6 +408,17 @@ export default function StoresPage() {
           )}
         </TBody>
       </Table>
+
+      {merging && (
+        <MergeStoreDialog
+          source={merging}
+          onClose={() => setMerging(null)}
+          onDone={async () => {
+            setMerging(null);
+            await reload();
+          }}
+        />
+      )}
 
       {(rows?.length ?? 0) > PAGE_SIZE && (
         <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
@@ -669,3 +692,179 @@ function parseCoord(s: string): number | null {
 
 const inputCls =
   "rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800";
+
+type MergeTarget = { id: number; code: string; name: string };
+
+// rpc_merge_stores 回傳的 jsonb → 畫面文案
+const MERGE_RESULT_LABELS: [string, string][] = [
+  ["bindings_moved", "LINE 綁定改掛目標店"],
+  ["bindings_deduped", "LINE 綁定去重刪除（兩店都綁過）"],
+  ["members_moved", "會員改隸目標店"],
+  ["orders_moved", "訂單改掛目標店"],
+  ["stock_lines", "庫存移轉 SKU 數"],
+  ["stock_qty", "庫存移轉件數"],
+];
+
+function MergeStoreDialog({
+  source,
+  onClose,
+  onDone,
+}: {
+  source: { id: number; code: string; name: string };
+  onClose: () => void;
+  onDone: () => void | Promise<void>;
+}) {
+  const [targets, setTargets] = useState<MergeTarget[]>([]);
+  const [targetId, setTargetId] = useState<number | "">("");
+  const [confirmText, setConfirmText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<Record<string, unknown> | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data, error: err } = await getSupabase()
+        .from("stores")
+        .select("id, code, name")
+        .eq("is_active", true)
+        .is("deleted_at", null)
+        .neq("id", source.id)
+        .order("name");
+      if (err) setError(err.message);
+      else setTargets((data ?? []) as MergeTarget[]);
+    })();
+  }, [source.id]);
+
+  async function run() {
+    if (targetId === "") return;
+    setBusy(true);
+    setError(null);
+    try {
+      const { data, error: err } = await getSupabase().rpc("rpc_merge_stores", {
+        p_source_store_id: source.id,
+        p_target_store_id: targetId,
+      });
+      if (err) throw err;
+      setResult((data ?? {}) as Record<string, unknown>);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const target = targets.find((t) => t.id === targetId);
+  const canRun = targetId !== "" && confirmText.trim() === source.code && !busy;
+  const pendingAid = Number(result?.aid_listings_open ?? 0);
+  const pendingStaff = Number(result?.staff_assignments_pending ?? 0);
+  const negLeft = Number(result?.negative_balances_left ?? 0);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-lg rounded-lg bg-white p-5 shadow-xl dark:bg-zinc-900">
+        {result === null ? (
+          <>
+            <h2 className="text-base font-semibold">
+              合併門市：{source.name}（{source.code}）
+            </h2>
+            <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+              會把 <b>{source.name}</b> 的 LINE 綁定（兩店重複的自動去重）、會員、
+              全部訂單改掛到目標店，店倉庫存開正式調撥單（MG-）整批移轉並自動收貨，
+              完成後停用來源店。<b>此動作無法自動復原。</b>
+            </p>
+            <p className="mt-1 text-xs text-zinc-500">
+              來源店若還有在途入庫調撥單或進行中補貨申請，後端會拒絕 —— 先收完或取消再合併。
+            </p>
+
+            <label className="mt-4 block text-sm">
+              <span className="text-zinc-600 dark:text-zinc-400">目標店（承接方，須為啟用中門市）</span>
+              <select
+                value={targetId}
+                onChange={(e) => setTargetId(e.target.value === "" ? "" : Number(e.target.value))}
+                className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+              >
+                <option value="">— 選擇目標店 —</option>
+                {targets.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name}（{t.code}）
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="mt-3 block text-sm">
+              <span className="text-zinc-600 dark:text-zinc-400">
+                輸入來源店代碼 <b className="font-mono">{source.code}</b> 以確認
+              </span>
+              <input
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder={source.code}
+                className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-2 py-1.5 font-mono text-sm dark:border-zinc-700 dark:bg-zinc-950"
+              />
+            </label>
+
+            {error && (
+              <div className="mt-3 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+                {error}
+              </div>
+            )}
+
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={onClose}
+                disabled={busy}
+                className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700"
+              >
+                取消
+              </button>
+              <SpinButton
+                onClick={run}
+                disabled={!canRun}
+                className="rounded-md bg-purple-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-purple-700 disabled:opacity-40"
+              >
+                {busy ? "合併中…" : `合併到 ${target ? target.name : "…"}`}
+              </SpinButton>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="text-base font-semibold">
+              ✅ 合併完成：{String(result.source_store)} → {String(result.target_store)}
+            </h2>
+            <ul className="mt-3 space-y-1 text-sm">
+              {MERGE_RESULT_LABELS.map(([k, label]) => (
+                <li key={k} className="flex justify-between gap-4">
+                  <span className="text-zinc-600 dark:text-zinc-400">{label}</span>
+                  <span className="font-mono">{String(result[k] ?? 0)}</span>
+                </li>
+              ))}
+              {result.stock_transfer_no ? (
+                <li className="flex justify-between gap-4">
+                  <span className="text-zinc-600 dark:text-zinc-400">庫存調撥單</span>
+                  <span className="font-mono text-xs">{String(result.stock_transfer_no)}</span>
+                </li>
+              ) : null}
+            </ul>
+            {(pendingAid > 0 || pendingStaff > 0 || negLeft > 0) && (
+              <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
+                需要人工收尾：
+                {pendingAid > 0 && <div>・互助板還有 {pendingAid} 則進行中釋出掛在來源店，請手動結掉或改店。</div>}
+                {pendingStaff > 0 && <div>・{pendingStaff} 個員工帳號的分店指派（app_metadata.stores）還指著來源店名，請到員工管理更新。</div>}
+                {negLeft > 0 && <div>・來源店倉還有 {negLeft} 筆負庫存留在原地，請盤點處理。</div>}
+              </div>
+            )}
+            <div className="mt-4 flex justify-end">
+              <SpinButton
+                onClick={onDone}
+                className="rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white dark:bg-zinc-50 dark:text-zinc-900"
+              >
+                完成
+              </SpinButton>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260817000020_migrate_store4_orders_members_to_zhonghe.sql
+++ b/supabase/migrations/20260817000020_migrate_store4_orders_members_to_zhonghe.sql
@@ -1,0 +1,65 @@
+-- 四號店（store_id=37，已停用）收攤：訂單與會員整批轉到中和店（store_id=45）。
+-- 一次性資料搬移（data migration），不動 schema、不動函式。
+--
+-- 搬移範圍（只搬「訂單跟會員」，其餘刻意不動）：
+--   1. member_line_bindings：四號店的 LINE 綁定改掛中和店。
+--      唯一鍵是 (tenant_id, store_id, line_user_id) / (tenant_id, store_id, member_id)，
+--      同一人已經在中和店有綁定的（兩店都綁過）→ 先刪四號店那筆，留中和店既有的。
+--   2. members.home_store_id：37 → 45（members 的唯一鍵都是 tenant 層級，不會撞）。
+--   3. customer_orders.pickup_store_id：37 → 45（全部 1,543 張，含歷史單，
+--      全是 order_kind='normal' 的 GRP-/GB- 單；四號店沒有 RR-/SP- 容器單，
+--      trio 唯一索引不含 pickup_store_id，不會撞）。
+--
+-- 刻意不搬（不在本次範圍，見 PR 說明）：
+--   - stock_balances / stock_movements / transfers（四號店倉 location_id=8 還有
+--     24 筆結餘、合計 59 件）→ 庫存搬移另案處理。
+--   - picking_wave_items.store_id（805 筆派貨紀錄）→ 歷史派貨事實，
+--     不改寫；後果是舊單在中和的取貨閘門 Path A/B 對不上波次，
+--     要靠 Path C（中和實收過該 SKU）或後續收貨推進。
+--   - order_pickup_events / store_monthly_settlements / member_imports → 歷史紀錄。
+--
+-- rollback：本檔案跑完會留下 migration_note（見檔尾 DO 區塊的 RAISE NOTICE 數字），
+-- 反向即 45→37 同樣三步，但重複綁定那 3 筆刪掉就回不來（原本就是冗餘資料）。
+
+
+-- 1a. 兩店都綁過的人：刪四號店那筆綁定，保留中和店既有綁定
+DELETE FROM member_line_bindings b
+ WHERE b.store_id = 37
+   AND EXISTS (
+     SELECT 1 FROM member_line_bindings b2
+      WHERE b2.tenant_id = b.tenant_id
+        AND b2.store_id = 45
+        AND (b2.line_user_id = b.line_user_id OR b2.member_id = b.member_id)
+   );
+
+-- 1b. 其餘綁定改掛中和店
+UPDATE member_line_bindings
+   SET store_id = 45
+ WHERE store_id = 37;
+
+-- 2. 會員改隸中和店
+UPDATE members
+   SET home_store_id = 45
+ WHERE home_store_id = 37;
+
+-- 3. 訂單取貨店改為中和店（含歷史單，全數搬移）
+UPDATE customer_orders
+   SET pickup_store_id = 45
+ WHERE pickup_store_id = 37;
+
+-- 自檢：搬完四號店身上不應該再掛任何訂單 / 會員 / 綁定
+DO $$
+DECLARE
+  v_orders   BIGINT;
+  v_members  BIGINT;
+  v_bindings BIGINT;
+BEGIN
+  SELECT count(*) INTO v_orders   FROM customer_orders     WHERE pickup_store_id = 37;
+  SELECT count(*) INTO v_members  FROM members              WHERE home_store_id   = 37;
+  SELECT count(*) INTO v_bindings FROM member_line_bindings WHERE store_id        = 37;
+  IF v_orders > 0 OR v_members > 0 OR v_bindings > 0 THEN
+    RAISE EXCEPTION 'store-4 migration incomplete: orders=%, members=%, bindings=%',
+      v_orders, v_members, v_bindings;
+  END IF;
+END $$;
+

--- a/supabase/migrations/20260817000030_migrate_store4_stock_to_zhonghe.sql
+++ b/supabase/migrations/20260817000030_migrate_store4_stock_to_zhonghe.sql
@@ -1,0 +1,121 @@
+-- 四號店收攤（續 20260817000020 訂單/會員遷移）：店倉庫存整批移轉中和店。
+-- 四號店倉 location_id=8 → 中和店倉 location_id=14。
+--
+-- 做法：不直接改 stock_balances（帳要靠 stock_movements 觸發器維護），
+-- 而是開一張正式的店對店調撥單 MIG-S37-ZH-20260817，走既有機制：
+--   1. transfers（store_to_store / shipped）＋逐 SKU rpc_outbound(transfer_out)
+--      —— 比照 _air_ship_order_items：allow_negative + fallback 成本價。
+--   2. rpc_receive_transfer 標準收貨 —— inbound 移動、qty_received，
+--      並自然帶動邏輯 A0–E（解待補貨、推進中和身上那批 confirmed 遷移單、
+--      自動配單、內部池收斂），跟總倉派貨到店走同一條路。
+--   3. 月結：customer_order_id IS NULL 的店對店單走 free_in / free_out 口徑，
+--      以 transfer_items.estimated_amount 計價 —— 這裡填 qty × 分店價
+--      （缺分店價退回出庫成本），中和實拿貨入帳、四號店側貸記，帳才收得攏。
+--
+-- 遷移當下盤點：24 個 SKU、合計 59 件，全部 on_hand > 0、reserved = 0、無在途。
+-- 冪等：transfer_no 已存在就整段跳過（tenant+transfer_no 唯一鍵）。
+-- rollback：反向再開一張 14 → 8 的同品項調撥單（不要刪 movements，帳是 append-only）。
+
+DO $$
+DECLARE
+  v_tenant      UUID   := '00000000-0000-0000-0000-000000000001';
+  v_operator    UUID   := '39fd694d-3af6-4978-beab-6e826dff7246';  -- cktalex（admin）
+  v_src         BIGINT := 8;    -- 四號店倉 WH-LELE-四號
+  v_dst         BIGINT := 14;   -- 中和店倉 WH-LELE-中和
+  v_no          TEXT   := 'MIG-S37-ZH-20260817';
+  v_transfer_id BIGINT;
+  v_mov_id      BIGINT;
+  v_est         NUMERIC;
+  v_desc        TEXT;
+  v_lines       INT    := 0;
+  v_leftover    INT;
+  r             RECORD;
+BEGIN
+  IF EXISTS (SELECT 1 FROM transfers WHERE tenant_id = v_tenant AND transfer_no = v_no) THEN
+    RAISE NOTICE 'store-4 stock migration already applied, skipping';
+    RETURN;
+  END IF;
+
+  INSERT INTO transfers (
+    tenant_id, transfer_no, source_location, dest_location,
+    status, transfer_type, is_air_transfer,
+    notes, shipped_by, shipped_at, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_no, v_src, v_dst,
+    'shipped', 'store_to_store', FALSE,
+    '四號店收攤：店倉庫存整批移轉中和店（資料遷移，配合訂單/會員遷移 20260817000020）',
+    v_operator, NOW(), v_operator, v_operator
+  ) RETURNING id INTO v_transfer_id;
+
+  FOR r IN
+    SELECT sb.sku_id, sb.on_hand
+      FROM stock_balances sb
+     WHERE sb.tenant_id = v_tenant
+       AND sb.location_id = v_src
+       AND sb.on_hand > 0
+     ORDER BY sb.sku_id
+  LOOP
+    -- 比照 _air_ship_order_items：allow_negative（reserved 殘值不擋收攤）、
+    -- avg_cost 缺值退現行成本價，月結才不會記 0 元
+    v_mov_id := rpc_outbound(
+      p_tenant_id          => v_tenant,
+      p_location_id        => v_src,
+      p_sku_id             => r.sku_id,
+      p_quantity           => r.on_hand,
+      p_movement_type      => 'transfer_out',
+      p_source_doc_type    => 'transfer',
+      p_source_doc_id      => v_transfer_id,
+      p_operator           => v_operator,
+      p_allow_negative     => TRUE,
+      p_fallback_unit_cost => public._current_cost_price(v_tenant, r.sku_id)
+    );
+
+    -- free_in / free_out 口徑用 estimated_amount：qty × 分店價，缺價退出庫成本。
+    -- transfer_items 的 CHECK 要求 estimated_amount 與 description 成對，
+    -- description 填 SKU 碼＋品名，月結明細才看得懂這批是什麼。
+    SELECT r.on_hand * COALESCE(
+             NULLIF(public._branch_price_at(v_tenant, r.sku_id, NOW()), 0),
+             sm.unit_cost, 0)
+      INTO v_est
+      FROM stock_movements sm
+     WHERE sm.id = v_mov_id;
+
+    SELECT trim(k.sku_code || ' ' || COALESCE(k.product_name, '')
+             || COALESCE(' ' || NULLIF(k.variant_name, ''), ''))
+      INTO v_desc
+      FROM skus k
+     WHERE k.id = r.sku_id;
+
+    INSERT INTO transfer_items (
+      transfer_id, sku_id, qty_requested, qty_shipped,
+      out_movement_id, estimated_amount, description, created_by, updated_by
+    ) VALUES (
+      v_transfer_id, r.sku_id, r.on_hand, r.on_hand,
+      v_mov_id, v_est, v_desc, v_operator, v_operator
+    );
+    v_lines := v_lines + 1;
+  END LOOP;
+
+  IF v_lines = 0 THEN
+    DELETE FROM transfers WHERE id = v_transfer_id;
+    RAISE NOTICE 'store-4 warehouse already empty, nothing to move';
+    RETURN;
+  END IF;
+
+  -- 標準收貨：p_lines NULL = 全數照出貨量入帳；邏輯 A0–E 照跑
+  -- （解待補貨、推進 confirmed 遷移單、自動配單、內部池收斂）
+  PERFORM rpc_receive_transfer(
+    v_transfer_id, NULL, v_operator,
+    '四號店收攤移轉收貨（資料遷移）', TRUE
+  );
+
+  -- 自檢：四號店倉不應再有任何非零結餘
+  SELECT count(*) INTO v_leftover
+    FROM stock_balances
+   WHERE tenant_id = v_tenant AND location_id = v_src AND on_hand <> 0;
+  IF v_leftover > 0 THEN
+    RAISE EXCEPTION 'store-4 stock migration incomplete: % non-zero balances left', v_leftover;
+  END IF;
+
+  RAISE NOTICE 'store-4 stock migration done: transfer % (% lines)', v_no, v_lines;
+END $$;

--- a/supabase/migrations/20260817000040_rpc_merge_stores.sql
+++ b/supabase/migrations/20260817000040_rpc_merge_stores.sql
@@ -1,0 +1,296 @@
+-- ============================================================
+-- rpc_merge_stores：兩店合併（來源店 → 目標店）
+--
+-- 把 2026-08-17 四號店 → 中和店的手工遷移（20260817000020 訂單/會員、
+-- 20260817000030 庫存）收斂成一支可重複使用的 RPC，之後收店直接在
+-- 後台門市頁按「合併」。
+--
+-- 搬移內容（與該次遷移同一套語意）：
+--   1. LINE 綁定 member_line_bindings：改掛目標店；同一人兩店都綁過
+--      （line_user_id 或 member_id 撞 (tenant,store) 唯一鍵）→ 刪來源側、
+--      保留目標店既有綁定。
+--   2. 會員 members.home_store_id → 目標店。**排除 member_type='store_internal'**：
+--      【內部】xx 店是店的固定裝置、目標店有自己的一個，搬過去會出現兩個。
+--      它名下的單照搬（見 3），現貨池帳本跟著貨走（池子口徑看
+--      pickup_store_id + member_type，不看內部會員的 home_store）。
+--   3. 訂單 customer_orders.pickup_store_id → 目標店（全部，含歷史單與
+--      RR-/AB- 容器單；trio 唯一索引不含 pickup_store_id、restock 又被
+--      predicate 排除，不會撞）。
+--   4. 庫存：來源店倉 on_hand > 0 的 SKU 開一張正式店對店調撥單
+--      MG-S<src>-S<dst>-<時間戳>，逐 SKU rpc_outbound(transfer_out) 後走
+--      rpc_receive_transfer 標準收貨 —— 邏輯 A0–E 照跑（解待補貨、推進
+--      confirmed 單、自動配單、內部池收斂），月結走 free_in/free_out
+--      （estimated_amount = qty × 分店價，缺價退出庫成本；CHECK 要求與
+--      description 成對，填 SKU 碼＋品名）。負庫存留在來源店倉、
+--      回報 negative_balances_left 交給盤點，不硬搬。
+--   5. p_deactivate_source（預設 TRUE）：搬完停用來源店。
+--
+-- 守衛：
+--   - owner / admin / ''（legacy dev admin）限定，路徑走 app_metadata
+--     （頂層 role 永遠是 'authenticated'，見 20260502010000 / 20260807000040）。
+--   - 目標店必須啟用中且未刪除；來源店未刪除（停用中可合併——收店常態）。
+--   - 來源店有「在途入庫」（draft/confirmed/shipped 且 dest = 來源店倉的
+--     transfers）或進行中補貨申請 → 擋下。先收完或取消，否則那批貨會
+--     派到一間死店。
+--
+-- 刻意不搬（歷史事實 / 另有正主，呼叫端要知道）：
+--   - 歷史財務：expenses / petty_cash / store_monthly_settlements /
+--     store_receivables → 留在來源店，月結歸檔本來就按店別。
+--   - 歷史物流：picking_wave_items / restock_requests / order_pickup_events。
+--   - 店務設定：LINE OA（store_line_oa_credentials / line_channels）、
+--     promotions.applicable_store_ids、互助板進行中釋出（回報
+--     aid_listings_open 讓人工收尾）。
+--   - 員工指派 app_metadata.stores 存的是**店名**（見 role.ts useMyStores），
+--     在 auth 端要人工改 → 回報 staff_assignments_pending。
+--
+-- rollback：資料搬移不可逆轉自動回復；反向再呼叫一次（target→source）可把
+-- 訂單/會員/庫存搬回去，但被去重刪掉的綁定與已觸發的訂單推進不會還原。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_merge_stores(
+  p_source_store_id   BIGINT,
+  p_target_store_id   BIGINT,
+  p_operator          UUID DEFAULT NULL,
+  p_deactivate_source BOOLEAN DEFAULT TRUE
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant   UUID := (auth.jwt() ->> 'tenant_id')::uuid;
+  v_role     TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_operator UUID := COALESCE(p_operator, auth.uid());
+  v_src      stores;
+  v_dst      stores;
+  v_inflight        INT;
+  v_open_restocks   INT;
+  v_bind_deduped    INT := 0;
+  v_bind_moved      INT := 0;
+  v_members_moved   INT := 0;
+  v_orders_moved    INT := 0;
+  v_transfer_id     BIGINT;
+  v_transfer_no     TEXT;
+  v_mov_id          BIGINT;
+  v_est             NUMERIC;
+  v_desc            TEXT;
+  v_stock_lines     INT := 0;
+  v_stock_qty       NUMERIC := 0;
+  v_neg_left        INT := 0;
+  v_aid_open        INT := 0;
+  v_staff_pending   INT := 0;
+  r                 RECORD;
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+  IF v_role NOT IN ('owner','admin','') THEN
+    RAISE EXCEPTION 'permission denied: only owner/admin can merge stores';
+  END IF;
+  IF p_source_store_id = p_target_store_id THEN
+    RAISE EXCEPTION '來源店與目標店不能是同一間';
+  END IF;
+
+  -- 固定依 id 順序鎖兩間店，避免同時兩筆反向合併互相死鎖
+  FOR r IN
+    SELECT * FROM stores
+     WHERE tenant_id = v_tenant AND id IN (p_source_store_id, p_target_store_id)
+     ORDER BY id
+       FOR UPDATE
+  LOOP
+    IF r.id = p_source_store_id THEN v_src := r; ELSE v_dst := r; END IF;
+  END LOOP;
+
+  IF v_src.id IS NULL THEN
+    RAISE EXCEPTION 'source store % not found', p_source_store_id;
+  END IF;
+  IF v_dst.id IS NULL THEN
+    RAISE EXCEPTION 'target store % not found', p_target_store_id;
+  END IF;
+  IF v_src.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION '來源店 %（%）已被刪除，先還原再合併', v_src.name, v_src.code;
+  END IF;
+  IF v_dst.deleted_at IS NOT NULL OR NOT v_dst.is_active THEN
+    RAISE EXCEPTION '目標店 %（%）必須是啟用中的門市', v_dst.name, v_dst.code;
+  END IF;
+
+  -- 在途入庫：這批貨正派往來源店，先收完或取消再合併
+  IF v_src.location_id IS NOT NULL THEN
+    SELECT count(*) INTO v_inflight
+      FROM transfers t
+     WHERE t.tenant_id = v_tenant
+       AND t.dest_location = v_src.location_id
+       AND t.status IN ('draft','confirmed','shipped');
+    IF v_inflight > 0 THEN
+      RAISE EXCEPTION '來源店 % 還有 % 張在途/待出貨的入庫調撥單，先收貨或取消再合併',
+        v_src.code, v_inflight;
+    END IF;
+  END IF;
+
+  SELECT count(*) INTO v_open_restocks
+    FROM restock_requests
+   WHERE tenant_id = v_tenant
+     AND requesting_store_id = p_source_store_id
+     AND status NOT IN ('cancelled','received','rejected');
+  IF v_open_restocks > 0 THEN
+    RAISE EXCEPTION '來源店 % 還有 % 筆進行中補貨申請，先結掉再合併',
+      v_src.code, v_open_restocks;
+  END IF;
+
+  -- 1a. 兩店都綁過的人：刪來源側綁定，保留目標店既有的
+  DELETE FROM member_line_bindings b
+   WHERE b.tenant_id = v_tenant
+     AND b.store_id = p_source_store_id
+     AND EXISTS (
+       SELECT 1 FROM member_line_bindings b2
+        WHERE b2.tenant_id = b.tenant_id
+          AND b2.store_id = p_target_store_id
+          AND (b2.line_user_id = b.line_user_id OR b2.member_id = b.member_id)
+     );
+  GET DIAGNOSTICS v_bind_deduped = ROW_COUNT;
+
+  -- 1b. 其餘綁定改掛目標店
+  UPDATE member_line_bindings
+     SET store_id = p_target_store_id
+   WHERE tenant_id = v_tenant AND store_id = p_source_store_id;
+  GET DIAGNOSTICS v_bind_moved = ROW_COUNT;
+
+  -- 2. 會員改隸目標店（內部池容器會員留在來源店，見檔頭）
+  UPDATE members
+     SET home_store_id = p_target_store_id
+   WHERE tenant_id = v_tenant
+     AND home_store_id = p_source_store_id
+     AND member_type IS DISTINCT FROM 'store_internal';
+  GET DIAGNOSTICS v_members_moved = ROW_COUNT;
+
+  -- 3. 訂單取貨店改為目標店（全部，含歷史單與容器單）
+  UPDATE customer_orders
+     SET pickup_store_id = p_target_store_id
+   WHERE tenant_id = v_tenant AND pickup_store_id = p_source_store_id;
+  GET DIAGNOSTICS v_orders_moved = ROW_COUNT;
+
+  -- 4. 庫存：正式調撥單 + 標準收貨（比照 20260817000030）
+  IF v_src.location_id IS NOT NULL AND v_dst.location_id IS NOT NULL
+     AND v_src.location_id <> v_dst.location_id THEN
+
+    v_transfer_no := 'MG-S' || p_source_store_id || '-S' || p_target_store_id
+                  || '-' || to_char(NOW() AT TIME ZONE 'utc', 'YYYYMMDDHH24MISS');
+
+    INSERT INTO transfers (
+      tenant_id, transfer_no, source_location, dest_location,
+      status, transfer_type, is_air_transfer,
+      notes, shipped_by, shipped_at, created_by, updated_by
+    ) VALUES (
+      v_tenant, v_transfer_no, v_src.location_id, v_dst.location_id,
+      'shipped', 'store_to_store', FALSE,
+      format('兩店合併：%s（%s）庫存整批移轉 %s（%s）', v_src.name, v_src.code, v_dst.name, v_dst.code),
+      v_operator, NOW(), v_operator, v_operator
+    ) RETURNING id INTO v_transfer_id;
+
+    FOR r IN
+      SELECT sb.sku_id, sb.on_hand
+        FROM stock_balances sb
+       WHERE sb.tenant_id = v_tenant
+         AND sb.location_id = v_src.location_id
+         AND sb.on_hand > 0
+       ORDER BY sb.sku_id
+    LOOP
+      v_mov_id := rpc_outbound(
+        p_tenant_id          => v_tenant,
+        p_location_id        => v_src.location_id,
+        p_sku_id             => r.sku_id,
+        p_quantity           => r.on_hand,
+        p_movement_type      => 'transfer_out',
+        p_source_doc_type    => 'transfer',
+        p_source_doc_id      => v_transfer_id,
+        p_operator           => v_operator,
+        p_allow_negative     => TRUE,
+        p_fallback_unit_cost => public._current_cost_price(v_tenant, r.sku_id)
+      );
+
+      SELECT r.on_hand * COALESCE(
+               NULLIF(public._branch_price_at(v_tenant, r.sku_id, NOW()), 0),
+               sm.unit_cost, 0)
+        INTO v_est
+        FROM stock_movements sm
+       WHERE sm.id = v_mov_id;
+
+      SELECT trim(k.sku_code || ' ' || COALESCE(k.product_name, '')
+               || COALESCE(' ' || NULLIF(k.variant_name, ''), ''))
+        INTO v_desc
+        FROM skus k
+       WHERE k.id = r.sku_id;
+
+      INSERT INTO transfer_items (
+        transfer_id, sku_id, qty_requested, qty_shipped,
+        out_movement_id, estimated_amount, description, created_by, updated_by
+      ) VALUES (
+        v_transfer_id, r.sku_id, r.on_hand, r.on_hand,
+        v_mov_id, v_est, v_desc, v_operator, v_operator
+      );
+
+      v_stock_lines := v_stock_lines + 1;
+      v_stock_qty   := v_stock_qty + r.on_hand;
+    END LOOP;
+
+    IF v_stock_lines = 0 THEN
+      DELETE FROM transfers WHERE id = v_transfer_id;
+      v_transfer_id := NULL;
+      v_transfer_no := NULL;
+    ELSE
+      PERFORM rpc_receive_transfer(
+        v_transfer_id, NULL, v_operator,
+        format('兩店合併收貨：%s → %s', v_src.code, v_dst.code), TRUE
+      );
+    END IF;
+
+    SELECT count(*) INTO v_neg_left
+      FROM stock_balances
+     WHERE tenant_id = v_tenant
+       AND location_id = v_src.location_id
+       AND on_hand < 0;
+  END IF;
+
+  -- 5. 停用來源店
+  IF p_deactivate_source THEN
+    UPDATE stores
+       SET is_active = FALSE, updated_by = v_operator, updated_at = NOW()
+     WHERE id = p_source_store_id AND tenant_id = v_tenant;
+  END IF;
+
+  -- 人工收尾項（只回報、不動手）
+  SELECT count(*) INTO v_aid_open
+    FROM mutual_aid_board
+   WHERE tenant_id = v_tenant
+     AND offering_store_id = p_source_store_id
+     AND status = 'active';
+
+  SELECT count(*) INTO v_staff_pending
+    FROM auth.users u
+   WHERE u.raw_app_meta_data -> 'stores' ? v_src.name;
+
+  RETURN jsonb_build_object(
+    'source_store',            v_src.code,
+    'target_store',            v_dst.code,
+    'bindings_moved',          v_bind_moved,
+    'bindings_deduped',        v_bind_deduped,
+    'members_moved',           v_members_moved,
+    'orders_moved',            v_orders_moved,
+    'stock_transfer_no',       v_transfer_no,
+    'stock_lines',             v_stock_lines,
+    'stock_qty',               v_stock_qty,
+    'negative_balances_left',  v_neg_left,
+    'source_deactivated',      p_deactivate_source,
+    'aid_listings_open',       v_aid_open,
+    'staff_assignments_pending', v_staff_pending
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_merge_stores(BIGINT, BIGINT, UUID, BOOLEAN) IS
+  '兩店合併：來源店的 LINE 綁定（去重）/ 會員（排除內部池容器）/ 全部訂單改掛目標店，'
+  '店倉庫存開 MG- 調撥單走標準收貨，預設停用來源店。owner/admin 限定。'
+  '在途入庫或進行中補貨申請未結會擋下。回傳各項搬移數量與人工收尾項。';
+
+REVOKE ALL ON FUNCTION public.rpc_merge_stores(BIGINT, BIGINT, UUID, BOOLEAN) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_merge_stores(BIGINT, BIGINT, UUID, BOOLEAN) TO authenticated;


### PR DESCRIPTION
## 摘要

三支 migration ＋ 一個前端入口。前三項 SQL **已於 2026-08-17 透過 Management API 套上正式庫並驗證**，依 CLAUDE.md 規則今天要進 main（本 PR base = main ✅）。

### 1. 四號店 → 中和店：訂單與會員（`20260817000020`）
- LINE 綁定 11 筆改掛中和店（兩店都綁過的先去重）
- 會員 802 位改隸中和店
- 訂單 1,543 張 `pickup_store_id` 改為中和店
- 驗證：四號店身上歸零，中和店側數量對上

### 2. 四號店 → 中和店：庫存（`20260817000030`）
- 不直接改 `stock_balances`，開正式店對店調撥單 `MIG-S37-ZH-20260817`（四號店倉 → 中和店倉），24 個 SKU / 59 件，逐 SKU `rpc_outbound(transfer_out)` 後走 `rpc_receive_transfer` 標準收貨（邏輯 A0–E 照跑，收貨後自動推進了 7 張等貨中的遷移單到 `ready`）
- 月結：`customer_order_id IS NULL` 的店對店單走 free_in/free_out 口徑，`estimated_amount` = 數量 × 分店價（缺價退出庫成本），總計 NT$4,962；`transfer_items` 的 CHECK 要求與 `description` 成對，填 SKU 碼＋品名
- 驗證：四號店倉非零結餘 0 筆、中和店倉 4,674 → 4,733（+59）、調撥單 `received` 59/59

### 3. 兩店合併功能（`20260817000040` ＋ 門市頁 UI）
把上面那套手工流程收斂成 `rpc_merge_stores(來源店, 目標店)`：
- 搬移：LINE 綁定（去重）→ 會員（**排除 `store_internal` 池容器會員**，它是店的固定裝置；名下容器單照搬，池子帳本跟著貨走）→ 全部訂單 → 店倉庫存（MG- 調撥單 + 標準收貨）→ 停用來源店
- 守衛：owner/admin 限定（走 `app_metadata` 路徑，不是頂層 role claim）；來源店有在途入庫調撥單或進行中補貨申請先擋下；目標店必須啟用中；雙店鎖依 id 排序避免死鎖
- 回傳 jsonb 搬移統計 + 人工收尾項：互助板進行中釋出、員工 `app_metadata.stores` 店名指派、留在原地的負庫存（不硬搬、交盤點）
- 前端：門市列表「合併」鈕（僅管理員層級可見）→ 對話框選目標店、輸入來源店代碼確認，完成後顯示統計與收尾提醒

## 測試

- 三支 migration 均過 `scripts/check-sql-syntax.cjs`（parse + parsePlpgsql）
- `apps/admin` `tsc --noEmit` 通過
- 遷移結果已對線上逐項驗證（數字見上）
- ⚠️ `rpc_merge_stores` 已部署但**尚未在線上實跑過完整合併**（灌 claims 的乾跑測試在這個環境被權限攔下）；其核心流程與 20260817000020/30 手工路徑等價。建議首次使用挑一間小店、合併前後對照回傳統計

## 刻意不搬（rpc_merge_stores）

歷史財務（expenses / 月結 / 應收）、歷史物流（波次 / 補貨 / 取貨事件）、店務設定（LINE OA、promotions.applicable_store_ids）—— 歷史事實留在原店，月結歸檔本來就按店別。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1jQAztZmUnQWr9zHG9ivS

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1jQAztZmUnQWr9zHG9ivS)_