### PR TITLE
會員端「已完成」依客人那一次到店結單分組，看得到當次拿走的組合

### DIFF
--- a/apps/admin/src/components/MemberOrdersAppView.tsx
+++ b/apps/admin/src/components/MemberOrdersAppView.tsx
@@ -16,6 +16,8 @@
  *     = apps/member/src/app/orders/page.tsx（2026-08-11 起「全部」不顯示金額）
  *   - 卡片標題 orderCardTitle（內部 sentinel 團改印品項名）
  *     = apps/member/src/lib/orderTitle.ts 的副本 lib/orderTitle.ts
+ *   - 「已完成」依「那一次到店結單」分組（order_pickup_events）
+ *     = apps/member/src/lib/pickups.ts 的副本 lib/pickupVisits.ts
  *
  * 後台加值：點卡片可直接開訂單明細（會員 app 沒有這個）。
  */
@@ -23,6 +25,13 @@
 import { useEffect, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { orderCardTitle } from "@/lib/orderTitle";
+import { fetchReprintableEvents } from "@/lib/pickupReceipt";
+import {
+  buildDoneNodes,
+  formatVisitWhen,
+  visibleTotals,
+  type PickupVisit,
+} from "@/lib/pickupVisits";
 
 type AppOrderItem = {
   id: number;
@@ -53,6 +62,8 @@ export type AppOrderRow = {
   campaign_name: string | null;
   campaign_cutoff_date: string | null;
   store_name: string | null;
+  /** 這張單的取貨紀錄（order_pickup_events；撤銷掉的那幾次已濾除）—— 「已完成」分組用 */
+  pickups?: { id: number; picked_at: string; item_ids: number[] }[];
 };
 
 type Phase = "waiting" | "pickup" | "done" | "void" | "transferred";
@@ -150,6 +161,19 @@ export function useMemberAppOrders(memberId: number, reloadTick = 0) {
       ]
         .filter((o) => orderPhase(o).phase !== "transferred")
         .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+
+      // 取貨紀錄 —— 「已完成」要依「客人那一次到店結單」分組（= 會員 app）。
+      // 拿不到就只是少了分組（卡片照列），不要讓整個視圖掛掉。
+      const eventsByOrder = await fetchReprintableEvents(rows.map((o) => o.id));
+      if (cancelled) return;
+      for (const o of rows) {
+        o.pickups = (eventsByOrder.get(o.id) ?? []).map((ev) => ({
+          id: ev.id,
+          picked_at: ev.created_at,
+          item_ids: ev.item_ids,
+        }));
+      }
+
       setOrders(rows);
       setLoading(false);
     })();
@@ -201,6 +225,11 @@ export function MemberOrdersAppView({
 }) {
   const { buckets, loading, err } = data;
   const [tab, setTab] = useState<Tab>("waiting");
+
+  // 「已完成」依「那一次到店結單」分組（= 會員 app 的同一支演算法）：客人一趟
+  // 拿走好幾個團的貨、當場付一次現金，平鋪的訂單列表拼不回那一次拿了什麼。
+  // 一張單分兩次取完會拆成兩張卡，各自掛在自己那一次底下。
+  const doneNodes = useMemo(() => buildDoneNodes(buckets.done), [buckets.done]);
 
   const bucket = buckets[tab];
   // = 會員 app orders/page.tsx：應付總金額只在待到貨 / 待取貨顯示
@@ -263,15 +292,53 @@ export function MemberOrdersAppView({
 
       {!loading && (
         <div className="max-h-[560px] space-y-3 overflow-auto pr-1">
-          {bucket.map((o) => (
-            <AppOrderCard key={o.id} order={o} onClick={() => onOpenOrder(o.id, o.order_no)} />
-          ))}
+          {tab === "done"
+            ? doneNodes.map((node) =>
+                node.kind === "visit" ? (
+                  <PickupVisitHeader key={node.key} visit={node.visit} />
+                ) : (
+                  <AppOrderCard
+                    key={node.key}
+                    order={node.order}
+                    visitSlice
+                    onClick={() => onOpenOrder(node.order.id, node.order.order_no)}
+                  />
+                ),
+              )
+            : bucket.map((o) => (
+                <AppOrderCard key={o.id} order={o} onClick={() => onOpenOrder(o.id, o.order_no)} />
+              ))}
         </div>
       )}
 
       <p className="text-[11px] text-zinc-400">
-        與會員 app「我的訂單」同一套資料與口徑（半年內、每類最多 100 筆）；點卡片可開後台訂單明細。
+        與會員 app「我的訂單」同一套資料與口徑（半年內、每類最多 100 筆）；「已完成」依客人
+        到店結單的那一次分組；點卡片可開後台訂單明細。
       </p>
+    </div>
+  );
+}
+
+// 一次到店結單的標題（= 會員 app 的 PickupVisitHeader）。
+// 措辭避開「結單」兩個字：卡片上的「結單日」是開團收單日，兩種意思擺一起會誤讀。
+function PickupVisitHeader({ visit }: { visit: PickupVisit }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-xl border border-rose-200 bg-rose-50/60 px-4 py-2.5 dark:border-rose-900 dark:bg-rose-950/30">
+      <div className="min-w-0">
+        <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          🧾 {formatVisitWhen(visit.pickedAt)} 取貨
+        </div>
+        <div className="text-xs text-zinc-500">
+          {visit.storeName && <>{visit.storeName} · </>}
+          {visit.orderCount} 筆訂單 · {visit.qty} 件
+        </div>
+      </div>
+      <div className="flex-shrink-0 text-right">
+        <div className="text-[11px] text-zinc-500">本次取貨金額</div>
+        <div className="text-lg font-semibold tabular-nums text-rose-700 dark:text-rose-400">
+          ${fmtAmount(visit.amount)}
+        </div>
+      </div>
     </div>
   );
 }
@@ -280,8 +347,22 @@ export function MemberOrdersAppView({
 const ACTIVE_ITEM_STATUSES = ["pending", "reserved", "ready"];
 
 // = apps/member/src/components/OrderCard.tsx 的卡片內容（後台配色 + 可點擊）
-function AppOrderCard({ order, onClick }: { order: AppOrderRow; onClick: () => void }) {
+function AppOrderCard({
+  order,
+  onClick,
+  /**
+   * 這張卡是「某一次結單的分片」（只帶那一次取走的品項）—— 金額要照卡片上真的
+   * 列出來的行算，掛整張單的 items_total / payable_amount 會出現「1 件 $278」
+   * 這種對不起來的畫面。= 會員 app OrderCard 的 viewPhase 分身卡同一套。
+   */
+  visitSlice = false,
+}: {
+  order: AppOrderRow;
+  onClick: () => void;
+  visitSlice?: boolean;
+}) {
   const phase = orderPhase(order);
+  const visible = visibleTotals(order.items ?? []);
   // 內部 sentinel 團（店內現貨轉手單）印品項名，其餘印開團名稱 —— 見 lib/orderTitle
   const title = orderCardTitle(order);
   const totalQty = (order.items ?? []).reduce(
@@ -369,7 +450,9 @@ function AppOrderCard({ order, onClick }: { order: AppOrderRow; onClick: () => v
       <div className="space-y-1 border-t border-zinc-100 px-4 py-2.5 text-sm dark:border-zinc-800">
         <div className="flex justify-between text-xs text-zinc-500">
           <span>商品（{totalQty} 件）</span>
-          <span className="tabular-nums">{fmtAmount(order.items_total)}</span>
+          <span className="tabular-nums">
+            {fmtAmount(visitSlice ? visible.amount : order.items_total)}
+          </span>
         </div>
         {Number(order.shipping_fee) > 0 && (
           <div className="flex justify-between text-xs text-zinc-500">
@@ -394,7 +477,7 @@ function AppOrderCard({ order, onClick }: { order: AppOrderRow; onClick: () => v
                 : "text-lg font-semibold tabular-nums text-rose-700 dark:text-rose-400"
             }
           >
-            ${fmtAmount(order.payable_amount)}
+            ${fmtAmount(visitSlice ? visible.amount : order.payable_amount)}
           </span>
         </div>
         {partlyPaid && (

--- a/apps/admin/src/components/MemberOrdersAppView.tsx
+++ b/apps/admin/src/components/MemberOrdersAppView.tsx
@@ -11,7 +11,8 @@
  * 「一樣」是硬需求，四個地方要跟會員端同步（改那邊記得改這邊）：
  *   - 資料管線 = liff-api listMyOrders：v_customer_order_summary、半年內、
  *     active / history 各最多 100 筆、一般取消不顯示但斷貨取消要顯示、已轉讓隱藏
- *   - orderPhase 分桶 = apps/member/src/components/OrderCard.tsx
+ *   - orderPhase / itemPhase 分桶（**依品項行**拆分身，2026-08-14 起）
+ *     = apps/member/src/components/OrderCard.tsx
  *   - 應付總金額只在「待到貨」「待取貨」顯示、用 outstanding_amount
  *     = apps/member/src/app/orders/page.tsx（2026-08-11 起「全部」不顯示金額）
  *   - 卡片標題 orderCardTitle（內部 sentinel 團改印品項名）
@@ -42,6 +43,13 @@ type AppOrderItem = {
   subtotal: number;
   status: string;
   stockout?: boolean;
+  /**
+   * 這一行到店了沒（v_customer_order_summary.items[].arrived @20260814070000）。
+   * 只有 active 行（pending/reserved/ready）有值，其餘是 null。
+   * ⚠️ 不可以用單頭的 arrived 代替：那一欄有快路徑，單頭一到 ready /
+   * partially_completed 就無條件 true（短收時會謊報到貨）。
+   */
+  arrived?: boolean | null;
 };
 
 export type AppOrderRow = {
@@ -101,6 +109,55 @@ function orderPhase(o: Pick<AppOrderRow, "status" | "arrived">): {
   if (o.status === "shipping")
     return { phase: "waiting", label: "運送中", className: "text-amber-700 dark:text-amber-400" };
   return { phase: "waiting", label: "待到貨", className: "text-amber-700 dark:text-amber-400" };
+}
+
+/** 分身卡右上角的狀態字（= 會員 app 的 PHASE_LABEL，換成後台配色） */
+const PHASE_LABEL: Record<Phase, { label: string; className: string }> = {
+  waiting: { label: "待到貨", className: "text-amber-700 dark:text-amber-400" },
+  pickup: { label: "待取貨", className: "text-amber-700 dark:text-amber-400" },
+  done: { label: "已完成", className: "text-rose-700 dark:text-rose-400" },
+  void: { label: "訂單不成立", className: "text-red-700 dark:text-red-400" },
+  transferred: { label: "已轉讓", className: "text-zinc-400" },
+};
+
+/**
+ * 單一品項行屬於哪個分頁 = apps/member/src/components/OrderCard.tsx 的 itemPhase。
+ *
+ * 短收之後一張單常常是「一件已領走、一件根本還沒到」，整張塞同一個分頁
+ * 等於叫客人來拿沒到的貨 —— 團友手機上是依行分的，客服這邊也必須依行分，
+ * 否則兩邊的分頁筆數與金額直接對不起來。
+ */
+function itemPhase(order: Pick<AppOrderRow, "status">, item: AppOrderItem): Phase {
+  switch (order.status) {
+    case "cancelled":
+    case "expired":
+      return "void";
+    case "transferred_out":
+      return "transferred";
+  }
+  if (item.status === "picked_up") return "done";
+  if (["cancelled", "expired"].includes(item.status)) return "void";
+  // arrived 缺值一律當「沒到」，寧可少報到貨也不要叫客人白跑一趟
+  return item.arrived === true ? "pickup" : "waiting";
+}
+
+/** = 會員 app 的 splitOrderByPhase：一張單拆成數個只帶該分頁品項的分身 */
+function splitOrderByPhase(order: AppOrderRow): Map<Phase, AppOrderRow> {
+  const out = new Map<Phase, AppOrderRow>();
+  for (const it of order.items ?? []) {
+    const ph = itemPhase(order, it);
+    const cur = out.get(ph);
+    if (cur) (cur.items as AppOrderItem[]).push(it);
+    else out.set(ph, { ...order, items: [it] });
+  }
+  return out;
+}
+
+/** 這一組品項行還沒領走的貨值（把單頭應付分攤到各分頁用）= 會員 app 同名函式 */
+function unpickedSubtotal(items: AppOrderItem[]): number {
+  return items
+    .filter((i) => !["cancelled", "expired", "picked_up"].includes(i.status))
+    .reduce((s, i) => s + Number(i.subtotal ?? 0), 0);
 }
 
 function fmtAmount(n: number | string | null | undefined): string {
@@ -182,11 +239,33 @@ export function useMemberAppOrders(memberId: number, reloadTick = 0) {
     };
   }, [memberId, reloadTick]);
 
+  // 依**品項行**分桶 = 會員 app orders/page.tsx（2026-08-14 起）。整張單塞同一個
+  // 分頁會讓「一件已領走、一件還沒到」的單整張跑到待取貨 —— 團友手機上不是這樣分的。
+  //
+  // 「不成立」是後台才有的分頁（會員 app 2026-08-17 拿掉了），維持原本的**整張單**
+  // 語意：只有整張取消 / 逾期的單才進去，活單裡的斷貨行不另外拆一張卡進來。
   const buckets = useMemo(() => {
     const b: Record<Tab, AppOrderRow[]> = { all: orders, waiting: [], pickup: [], done: [], void: [] };
     for (const o of orders) {
-      const { phase } = orderPhase(o);
-      if (phase !== "transferred") b[phase].push(o);
+      if (orderPhase(o).phase === "void") {
+        b.void.push(o);
+        continue;
+      }
+      // 應付金額要**分攤**到各分身，不能每個分身都掛整張單的 outstanding ——
+      // 一張單同時出現在「待到貨」和「待取貨」時會被算兩次（未結金額重複計算是
+      // 這個 repo 踩過的雷）。分攤法與會員 app 逐字相同，表尾總金額才對得上。
+      const wholeUnpicked = unpickedSubtotal(o.items ?? []);
+      const outstanding = Number(o.outstanding_amount ?? o.payable_amount ?? 0);
+      for (const [phase, part] of splitOrderByPhase(o)) {
+        if (phase === "transferred" || phase === "void") continue;
+        b[phase as Exclude<Tab, "all" | "void">].push({
+          ...part,
+          outstanding_amount:
+            wholeUnpicked > 0
+              ? (outstanding * unpickedSubtotal(part.items ?? [])) / wholeUnpicked
+              : 0,
+        });
+      }
     }
     return b;
   }, [orders]);
@@ -199,6 +278,11 @@ export type MemberAppOrders = ReturnType<typeof useMemberAppOrders>;
 /**
  * 一個分桶的應付加總 = 會員 app orders/page.tsx 的 sumOrders：
  * outstanding_amount（還沒領走的貨），排除 cancelled / expired。
+ *
+ * 吃的是**分身**（依品項行拆過、outstanding 已按比例分攤），所以「待到貨 +
+ * 待取貨」相加仍等於整張單的未結金額，不會把同一張單算兩次。hasPicked 刻意
+ * 拿分身的 outstanding 比整張單的 payable_amount —— 逐字照抄會員 app，
+ * 兩邊的副標才會同時出現 / 同時消失。
  */
 export function outstandingTotals(list: AppOrderRow[]) {
   const active = list.filter((o) => !["cancelled", "expired"].includes(String(o.status ?? "")));
@@ -300,13 +384,20 @@ export function MemberOrdersAppView({
                   <AppOrderCard
                     key={node.key}
                     order={node.order}
-                    visitSlice
+                    viewPhase="done"
                     onClick={() => onOpenOrder(node.order.id, node.order.order_no)}
                   />
                 ),
               )
-            : bucket.map((o) => (
-                <AppOrderCard key={o.id} order={o} onClick={() => onOpenOrder(o.id, o.order_no)} />
+            : bucket.map((o, i) => (
+                // 分身卡的右上角狀態字要講「這一頁」的語意；「全部」不拆頁，維持整張單。
+                // 一張單會拆成數個分身，key 不能只用 order.id。
+                <AppOrderCard
+                  key={`${o.id}:${(o.items ?? [])[0]?.id ?? i}`}
+                  order={o}
+                  viewPhase={tab === "all" ? undefined : (tab as Phase)}
+                  onClick={() => onOpenOrder(o.id, o.order_no)}
+                />
               ))}
         </div>
       )}
@@ -351,17 +442,19 @@ function AppOrderCard({
   order,
   onClick,
   /**
-   * 這張卡是「某一次結單的分片」（只帶那一次取走的品項）—— 金額要照卡片上真的
-   * 列出來的行算，掛整張單的 items_total / payable_amount 會出現「1 件 $278」
-   * 這種對不起來的畫面。= 會員 app OrderCard 的 viewPhase 分身卡同一套。
+   * 這張卡是「某個分頁的分身」（只帶屬於該分頁的品項行）時傳入該分頁 ——
+   * 右上角狀態字改用分頁的語意，金額也要照卡片上真的列出來的行算
+   * （掛整張單的 items_total / payable_amount 會出現「1 件 $278」這種對不起來的
+   * 畫面）。不傳（「全部」分頁）就照舊顯示整張單。= 會員 app OrderCard 同一套。
    */
-  visitSlice = false,
+  viewPhase,
 }: {
   order: AppOrderRow;
   onClick: () => void;
-  visitSlice?: boolean;
+  viewPhase?: Phase;
 }) {
-  const phase = orderPhase(order);
+  const phase = viewPhase ? { ...orderPhase(order), ...PHASE_LABEL[viewPhase] } : orderPhase(order);
+  // 分身卡實際列出來的貨值（斷貨 / 取消的行不算，跟件數同一套）
   const visible = visibleTotals(order.items ?? []);
   // 內部 sentinel 團（店內現貨轉手單）印品項名，其餘印開團名稱 —— 見 lib/orderTitle
   const title = orderCardTitle(order);
@@ -369,24 +462,29 @@ function AppOrderCard({
     (s, i) => (["cancelled", "expired"].includes(i.status) ? s : s + Number(i.qty ?? 0)),
     0,
   );
-  // = 會員端 OrderCard：部分取貨時逐行標「已取 / 未取」，客服看到的跟
-  // 團友手機上的一致（2026-08-13 中和店客訴：分不出哪行取了）
-  const showPickChips =
-    (order.items ?? []).some((i) => i.status === "picked_up") &&
-    (order.items ?? []).some((i) => ACTIVE_ITEM_STATUSES.includes(i.status));
-  const pickChip = (status: string) =>
-    !showPickChips ? null : status === "picked_up" ? (
-      <span className="ml-1.5 inline-block rounded bg-green-100 px-1 py-0.5 text-[10px] font-medium text-green-800 dark:bg-green-950 dark:text-green-300">
-        已取
-      </span>
-    ) : ACTIVE_ITEM_STATUSES.includes(status) ? (
+  // = 會員端 OrderCard：同一張卡裡混著不同階段的行時才逐行標，客服看到的跟
+  // 團友手機上的一致（2026-08-13 中和店客訴：分不出哪行取了）。
+  // 沒到貨的行講「未到貨」不講「未取」—— 後者會被讀成「貨在店裡等你」。
+  const phasesInCard = new Set((order.items ?? []).map((it) => itemPhase(order, it)));
+  const showPickChips = phasesInCard.size > 1;
+  const pickChip = (it: AppOrderItem) => {
+    if (!showPickChips) return null;
+    if (it.status === "picked_up")
+      return (
+        <span className="ml-1.5 inline-block rounded bg-green-100 px-1 py-0.5 text-[10px] font-medium text-green-800 dark:bg-green-950 dark:text-green-300">
+          已取
+        </span>
+      );
+    if (!ACTIVE_ITEM_STATUSES.includes(it.status)) return null;
+    return (
       <span className="ml-1.5 inline-block rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">
-        未取
+        {it.arrived === true ? "未取" : "未到貨"}
       </span>
-    ) : null;
+    );
+  };
+  const cardPayable = viewPhase ? visible.amount : Number(order.payable_amount ?? 0);
   const outstanding = Number(order.outstanding_amount ?? NaN);
-  const partlyPaid =
-    Number.isFinite(outstanding) && outstanding > 0 && outstanding < Number(order.payable_amount ?? 0);
+  const partlyPaid = Number.isFinite(outstanding) && outstanding > 0 && outstanding < cardPayable;
 
   return (
     <article
@@ -430,7 +528,7 @@ function AppOrderCard({
                     斷貨
                   </span>
                 )}
-                {pickChip(it.status)}
+                {pickChip(it)}
               </div>
               <div className="text-xs text-zinc-500">
                 {fmtAmount(it.unit_price)} × {it.qty}
@@ -451,7 +549,7 @@ function AppOrderCard({
         <div className="flex justify-between text-xs text-zinc-500">
           <span>商品（{totalQty} 件）</span>
           <span className="tabular-nums">
-            {fmtAmount(visitSlice ? visible.amount : order.items_total)}
+            {fmtAmount(viewPhase ? visible.amount : order.items_total)}
           </span>
         </div>
         {Number(order.shipping_fee) > 0 && (
@@ -477,7 +575,7 @@ function AppOrderCard({
                 : "text-lg font-semibold tabular-nums text-rose-700 dark:text-rose-400"
             }
           >
-            ${fmtAmount(visitSlice ? visible.amount : order.payable_amount)}
+            ${fmtAmount(viewPhase ? visible.amount : order.payable_amount)}
           </span>
         </div>
         {partlyPaid && (

--- a/apps/admin/src/lib/pickupReceipt.ts
+++ b/apps/admin/src/lib/pickupReceipt.ts
@@ -11,6 +11,8 @@ export type PickupEventRow = {
   event_type: string;      // picked_up | partial_pickup | pickup_undone
   created_at: string;
   notes: string | null;
+  /** 這一次取走的 customer_order_items.id（部分數量取貨會拆行，帶的是拆出來那一行） */
+  item_ids: number[];
 };
 
 // 撤銷取貨不刪原事件（表禁改禁刪），而是補一筆 pickup_undone，
@@ -35,11 +37,15 @@ export async function fetchReprintableEvents(
   if (orderIds.length === 0) return out;
   const { data } = await getSupabase()
     .from("order_pickup_events")
-    .select("id, order_id, event_type, created_at, notes")
+    .select("id, order_id, event_type, created_at, notes, item_ids")
     .in("order_id", orderIds)
     .in("event_type", ["picked_up", "partial_pickup", "pickup_undone"])
     .order("id", { ascending: true });
-  const rows = (data ?? []) as unknown as PickupEventRow[];
+  const rows = ((data ?? []) as unknown as PickupEventRow[]).map((r) => ({
+    ...r,
+    // item_ids 是 jsonb，缺值 / 型別歪掉都當空陣列（收據頁只用 id，分組才用得到它）
+    item_ids: Array.isArray(r.item_ids) ? r.item_ids.map(Number).filter(Number.isFinite) : [],
+  }));
   const undone = undonePickupEventIds(rows);
   for (const r of rows) {
     if (r.event_type === "pickup_undone" || undone.has(r.id)) continue;

--- a/apps/admin/src/lib/pickupVisits.ts
+++ b/apps/admin/src/lib/pickupVisits.ts
@@ -1,0 +1,167 @@
+// 「一次到店結單」分組 —— 把已取貨的品項還原成「客人那一次拿走的組合」。
+//
+// ⚠️ 這份邏輯在會員 app 有一份一模一樣的副本（客服要看到跟團友手機上完全相同的
+//    畫面）：apps/member/src/lib/pickups.ts。改這邊記得改那邊。
+//
+// 為什麼要有這個：訂單是**依團**開的，取貨是**依人**結的。客人一趟到店常常一次
+// 拿走三、四個團的貨、當場付一次現金；平鋪的「已完成」列表拼不回那一次拿了什麼。
+// 資料來源是 order_pickup_events（append-only，`/pickup/print` 的收據印的也是它）：
+// 一次櫃台結單 = 每張訂單各一筆事件（「一次全取」逐張呼叫 rpc_record_pickup），
+// 把時間相近、同一家店的事件併回一組，就是那一次的結單組合。
+
+/**
+ * 同一「次」結單的判定：同一家店 + 相鄰兩筆事件間隔 ≤ 10 分鐘。
+ * 店員「一次全取」是一張單一張單連續呼叫 RPC，實務上整批落在幾秒內；10 分鐘是
+ * 留給「先結一張、翻單、再結一張」的櫃台節奏。同一天再跑一趟會正確地分成兩次。
+ */
+const VISIT_GAP_MS = 10 * 60 * 1000;
+
+export type VisitItemLike = {
+  id: number;
+  qty: number;
+  subtotal: number;
+  status: string;
+};
+
+export type VisitPickupLike = {
+  id: number;
+  picked_at: string;
+  item_ids: number[];
+};
+
+export type VisitOrderLike = {
+  id: number;
+  store_name: string | null;
+  items: VisitItemLike[] | null;
+  pickups?: VisitPickupLike[];
+};
+
+/** 一次到店結單 */
+export type PickupVisit = {
+  key: string;
+  /** 這一次最後一筆取貨事件的時間（＝櫃台結單完成的時間） */
+  pickedAt: string;
+  storeName: string | null;
+  orderCount: number;
+  qty: number;
+  amount: number;
+};
+
+/** 「已完成」的渲染節點：結單標題，或標題底下的一張訂單卡 */
+export type DoneNode<T> =
+  | { kind: "visit"; key: string; visit: PickupVisit }
+  | { kind: "order"; key: string; order: T };
+
+/** 這張卡片實際列出來的貨值 / 件數（斷貨 / 取消的行不算，跟卡片上的件數同一套） */
+export function visibleTotals(items: VisitItemLike[]): { qty: number; amount: number } {
+  let qty = 0;
+  let amount = 0;
+  for (const it of items) {
+    if (["cancelled", "expired"].includes(it.status)) continue;
+    qty += Number(it.qty ?? 0);
+    amount += Number(it.subtotal ?? 0);
+  }
+  return { qty, amount };
+}
+
+/**
+ * 把訂單依取貨事件拆片，再把時間相近的併成一次結單。
+ *
+ * 一張單分兩次取完 → 拆成兩張卡，各自掛在自己那一次結單底下（這正是要看的東西）。
+ * 對不到任何事件的品項（撤銷取貨、舊資料）→ 收在最後，維持原本的平鋪樣子。
+ */
+export function buildDoneNodes<T extends VisitOrderLike>(doneOrders: T[]): DoneNode<T>[] {
+  type Slice = { order: T; pickedAt: string; storeKey: string };
+  const slices: Slice[] = [];
+  const orphans: T[] = [];
+
+  for (const o of doneOrders) {
+    const all = o.items ?? [];
+    const events = [...(o.pickups ?? [])].sort((a, b) => a.id - b.id);
+    const used = new Set<number>();
+    for (const ev of events) {
+      const ids = new Set((ev.item_ids ?? []).map(Number));
+      // 只認現在還在這張單上的行：撤銷取貨會把行改回去，事件卻永遠留著
+      const items = all.filter((it) => ids.has(Number(it.id)));
+      if (items.length === 0) continue;
+      for (const it of items) used.add(Number(it.id));
+      slices.push({
+        order: { ...o, items },
+        pickedAt: ev.picked_at,
+        storeKey: String(o.store_name ?? ""),
+      });
+    }
+    const rest = all.filter((it) => !used.has(Number(it.id)));
+    if (rest.length > 0) orphans.push({ ...o, items: rest });
+  }
+
+  // 新的結單排前面（「已完成」看的是「最近拿了什麼」，不是「最早訂了什麼」）
+  slices.sort((a, b) => new Date(b.pickedAt).getTime() - new Date(a.pickedAt).getTime());
+
+  const nodes: DoneNode<T>[] = [];
+  let group: Slice[] = [];
+
+  const flush = () => {
+    if (group.length === 0) return;
+    let qty = 0;
+    let amount = 0;
+    for (const s of group) {
+      const t = visibleTotals(s.order.items ?? []);
+      qty += t.qty;
+      amount += t.amount;
+    }
+    // group 已依時間新→舊，第一筆就是這次結單的最後一個動作
+    const head = group[0];
+    const key = `v:${head.pickedAt}:${head.order.id}`;
+    nodes.push({
+      kind: "visit",
+      key,
+      visit: {
+        key,
+        pickedAt: head.pickedAt,
+        storeName: head.order.store_name,
+        orderCount: new Set(group.map((s) => s.order.id)).size,
+        qty,
+        amount,
+      },
+    });
+    // 標題用最後一個動作的時間（＝結單完成），底下的卡片照櫃台實際結的順序
+    // 由舊到新排 —— 一路往下讀就是那一次結單的過程，像一張收據。
+    for (const s of [...group].reverse()) {
+      nodes.push({
+        kind: "order",
+        key: `${key}:${s.order.id}:${(s.order.items ?? [])[0]?.id ?? 0}`,
+        order: s.order,
+      });
+    }
+    group = [];
+  };
+
+  for (const s of slices) {
+    const prev = group[group.length - 1];
+    const sameVisit =
+      prev != null &&
+      prev.storeKey === s.storeKey &&
+      new Date(prev.pickedAt).getTime() - new Date(s.pickedAt).getTime() <= VISIT_GAP_MS;
+    if (!sameVisit) flush();
+    group.push(s);
+  }
+  flush();
+
+  for (const o of orphans) {
+    nodes.push({ kind: "order", key: `o:${o.id}:${(o.items ?? [])[0]?.id ?? 0}`, order: o });
+  }
+  return nodes;
+}
+
+const WEEKDAY = ["日", "一", "二", "三", "四", "五", "六"];
+
+/** 結單標題的時間字樣：`8/12（三）15:32`（今年不印年份） */
+export function formatVisitWhen(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const y = d.getFullYear() === new Date().getFullYear() ? "" : `${d.getFullYear()}/`;
+  return `${y}${d.getMonth() + 1}/${d.getDate()}（${WEEKDAY[d.getDay()]}）${hh}:${mm}`;
+}

--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -14,6 +14,8 @@ import OrderCard, {
   type OrderPhase,
   type OrderRow,
 } from "@/components/OrderCard";
+import PickupVisitHeader from "@/components/PickupVisitHeader";
+import { buildDoneNodes, countOrderNodes, takeOrderNodes } from "@/lib/pickups";
 
 // 蝦皮式分頁。我們取貨時付現金，所以沒有「待付款」；「待收貨」＝到店「待取貨」。
 // 分桶跟卡片右上角的狀態字共用 orderPhase()，兩邊永遠一致。
@@ -143,9 +145,18 @@ export default function OrdersPage() {
 
   const [visible, setVisible] = useState(PAGE_SIZE);
 
+  // 「已完成」改依「那一次到店結單」分組 —— 客人一趟拿走好幾個團的貨、當場付一次
+  // 現金，平鋪的訂單列表拼不回那一次到底拿了什麼（見 lib/pickups.ts）。
+  // 一張單分兩次取完會拆成兩張卡，所以這一頁的卡片數 ≠ bucket.length，
+  // 分頁要照節點自己算。
+  const doneNodes = useMemo(() => buildDoneNodes(buckets.done), [buckets.done]);
+
   const bucket = buckets[tab];
-  const display = bucket.slice(0, visible);
-  const hasMore = bucket.length > visible;
+  const isDone = tab === "done";
+  const display = isDone ? [] : bucket.slice(0, visible);
+  const displayNodes = isDone ? takeOrderNodes(doneNodes, visible) : [];
+  const cardCount = isDone ? countOrderNodes(doneNodes) : bucket.length;
+  const hasMore = cardCount > visible;
   // 總金額卡只在「待到貨」「待取貨」出現（理由見 sumOrders 註解），照整個分頁算
   const showTotals = tab === "waiting" || tab === "pickup";
   const totals = sumOrders(bucket);
@@ -214,7 +225,7 @@ export default function OrdersPage() {
           </div>
         )}
 
-        {!loading && !err && display.length === 0 && (
+        {!loading && !err && cardCount === 0 && (
           <div className="flex flex-col items-center py-20 text-center">
             <div
               className="flex h-24 w-24 items-center justify-center rounded-full text-5xl"
@@ -228,25 +239,43 @@ export default function OrdersPage() {
           </div>
         )}
 
-        {display.map((o, i) => (
-          <div
-            key={o.id}
-            className="animate-in"
-            style={{ animationDelay: `${Math.min(i % PAGE_SIZE, 8) * 50}ms` }}
-          >
-            {/* 分身卡的右上角狀態字要講「這一頁」的語意；「全部」不拆頁，維持整張單的狀態 */}
-            <OrderCard order={o} viewPhase={tab === "all" ? undefined : (tab as OrderPhase)} />
-          </div>
-        ))}
+        {/* 已完成：一次到店結單的標題 + 這次拿走的訂單卡；沒有取貨紀錄的卡片
+            （舊資料 / liff-api 還沒補上 pickups）就是沒有標題的一張卡，維持原樣。 */}
+        {isDone &&
+          displayNodes.map((node, i) => (
+            <div
+              key={node.key}
+              className={`animate-in ${node.kind === "visit" && i > 0 ? "pt-2" : ""}`}
+              style={{ animationDelay: `${Math.min(i % (PAGE_SIZE * 2), 8) * 50}ms` }}
+            >
+              {node.kind === "visit" ? (
+                <PickupVisitHeader visit={node.visit} />
+              ) : (
+                <OrderCard order={node.order} viewPhase="done" />
+              )}
+            </div>
+          ))}
+
+        {!isDone &&
+          display.map((o, i) => (
+            <div
+              key={o.id}
+              className="animate-in"
+              style={{ animationDelay: `${Math.min(i % PAGE_SIZE, 8) * 50}ms` }}
+            >
+              {/* 分身卡的右上角狀態字要講「這一頁」的語意；「全部」不拆頁，維持整張單的狀態 */}
+              <OrderCard order={o} viewPhase={tab === "all" ? undefined : (tab as OrderPhase)} />
+            </div>
+          ))}
 
         {!loading && hasMore && (
           <div ref={sentinelRef} className="py-4 text-center text-[13px] text-[var(--ios-gray)]">
             載入更多…
           </div>
         )}
-        {!loading && !hasMore && bucket.length > PAGE_SIZE && (
+        {!loading && !hasMore && cardCount > PAGE_SIZE && (
           <div className="py-4 text-center text-[13px] text-[var(--tertiary-label)]">
-            已顯示全部 {bucket.length} 筆
+            已顯示全部 {cardCount} 筆
           </div>
         )}
       </div>

--- a/apps/member/src/components/OrderCard.tsx
+++ b/apps/member/src/components/OrderCard.tsx
@@ -28,6 +28,25 @@ export type OrderItem = {
   arrived?: boolean | null;
 };
 
+/**
+ * 一次取貨事件（order_pickup_events，append-only）。liff-api 的 list_my_orders
+ * 把它掛在訂單上（撤銷掉的那幾次伺服端已經濾掉）。
+ *
+ * 這就是「客人該次到店結單拿走的組合」的權威來源 —— 一次櫃台結單常橫跨好幾張
+ * 訂單（/pickup 的「一次全取」逐張呼叫 rpc_record_pickup），每張各留一筆事件。
+ *
+ * 舊版 liff-api 還沒部署時整個欄位會是 undefined，前端要當「沒有取貨紀錄」處理
+ * （lib/pickups.ts 會退回原本的平鋪列表，不能整頁壞掉）。
+ */
+export type PickupEvent = {
+  id: number;
+  /** picked_up（整張取完）/ partial_pickup（還有品項沒取） */
+  event_type: string;
+  picked_at: string;
+  /** 這一次取走的 customer_order_items.id（部分數量取貨會拆行，帶的是拆出來那一行） */
+  item_ids: number[];
+};
+
 export type OrderRow = {
   id: number;
   order_no: string;
@@ -62,6 +81,8 @@ export type OrderRow = {
   campaign_cutoff_date: string | null;
   store_name: string | null;
   settlement_no: string;
+  /** 這張單的取貨紀錄（liff-api list_my_orders @2026-08-18）；舊版沒有這欄 */
+  pickups?: PickupEvent[];
 };
 
 /**

--- a/apps/member/src/components/PickupVisitHeader.tsx
+++ b/apps/member/src/components/PickupVisitHeader.tsx
@@ -1,0 +1,53 @@
+import type { PickupVisit } from "@/lib/pickups";
+
+// 「已完成」分頁裡，一次到店結單的標題卡：時間 / 門市 / 這次拿了幾筆幾件 / 金額。
+// 底下緊接著的訂單卡就是這一次拿走的東西（見 lib/pickups.ts）。
+//
+// 措辭刻意避開「結單」兩個字：同一頁的訂單卡上「結單日」是**開團收單日**，
+// 兩種意思擺在一起客人一定誤讀。這裡一律講「取貨」。
+
+const WEEKDAY = ["日", "一", "二", "三", "四", "五", "六"];
+
+function fmtWhen(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  // 今年不印年份（一行塞得下、也是團友講日期的方式）
+  const y = d.getFullYear() === new Date().getFullYear() ? "" : `${d.getFullYear()}/`;
+  return `${y}${d.getMonth() + 1}/${d.getDate()}（${WEEKDAY[d.getDay()]}）${hh}:${mm}`;
+}
+
+function fmtAmount(n: number): string {
+  return Number(n ?? 0).toLocaleString();
+}
+
+export default function PickupVisitHeader({ visit }: { visit: PickupVisit }) {
+  return (
+    <div className="card flex items-center justify-between gap-3 bg-[var(--brand-soft)]/45 px-4 py-3">
+      <div className="min-w-0">
+        <div className="text-[16px] font-semibold text-[var(--foreground)]">
+          <span aria-hidden className="mr-1">🧾</span>
+          {fmtWhen(visit.pickedAt)} 取貨
+        </div>
+        <div className="mt-0.5 text-[13px] text-[var(--secondary-label)]">
+          {visit.storeName && (
+            <>
+              {visit.storeName}
+              <span className="mx-1.5 text-[var(--tertiary-label)]">·</span>
+            </>
+          )}
+          {visit.orderCount} 筆訂單
+          <span className="mx-1.5 text-[var(--tertiary-label)]">·</span>
+          {visit.qty} 件
+        </div>
+      </div>
+      <div className="flex-shrink-0 text-right">
+        <div className="text-[12px] text-[var(--tertiary-label)]">本次取貨金額</div>
+        <div className="text-[22px] font-semibold tabular-nums text-[var(--brand-strong)]">
+          ${fmtAmount(visit.amount)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/member/src/lib/pickups.ts
+++ b/apps/member/src/lib/pickups.ts
@@ -1,0 +1,182 @@
+// 「已完成」分頁的結單分組 —— 把已取貨的品項還原成「客人那一次到店拿走的組合」。
+//
+// 為什麼要有這個：訂單是**依團**開的，取貨是**依人**結的。客人一趟到店常常一次
+// 拿走三、四個團的貨、當場付一次現金；但「已完成」分頁是照訂單平鋪的，那一次
+// 到底拿了什麼、付了多少，客人自己在 app 上永遠拼不回來（店裡有印小白單，
+// 手機上沒有）。店家因此要客人傳截圖、再由客服對著後台一張一張猜。
+//
+// 資料來源是 order_pickup_events（append-only，`/pickup/print` 的收據也是印它）：
+// 一次櫃台結單 = 每張訂單各一筆事件（「一次全取」逐張呼叫 rpc_record_pickup），
+// 所以把時間相近、同一家店的事件併回一組，就是那一次的結單組合。
+//
+// ⚠️ 這份邏輯在後台「會員畫面」有一份一模一樣的副本（會員來問時客服要看到跟團友
+//    手機上完全相同的畫面）：apps/admin/src/lib/pickupVisits.ts。改這邊記得改那邊。
+//
+// 金額刻意不另立口徑：一次結單的金額 = 底下那幾張卡片各自的金額相加
+// （＝該次取走品項的貨值）。訂單層級的折扣 / 運費沒有按行分攤，分身卡本來就是
+// 這個算法（見 OrderCard 的 cardPayable），跟著它走畫面才會自洽 —— 標題的數字
+// 跟卡片加起來對不上，是這個 repo 反覆被回報的老問題。
+
+import type { OrderItem, OrderRow, PickupEvent } from "@/components/OrderCard";
+
+/**
+ * 同一「次」結單的判定：同一家店 + 相鄰兩筆事件間隔 ≤ 10 分鐘。
+ *
+ * 店員「一次全取」是一張單一張單連續呼叫 RPC，實務上整批落在幾秒內；抓 10 分鐘
+ * 是留給「先結一張、翻單、再結一張」這種櫃台節奏。同一天下午再跑一趟（間隔以
+ * 小時計）會正確地分成兩次。
+ */
+const VISIT_GAP_MS = 10 * 60 * 1000;
+
+/** 一次到店結單 */
+export type PickupVisit = {
+  key: string;
+  /** 這一次最後一筆取貨事件的時間（＝櫃台結單完成的時間） */
+  pickedAt: string;
+  storeName: string | null;
+  /** 這一次涉及幾張訂單 */
+  orderCount: number;
+  /** 這一次拿走幾件 */
+  qty: number;
+  /** 這一次的商品金額（＝底下各卡片金額相加） */
+  amount: number;
+};
+
+/**
+ * 「已完成」分頁的渲染節點：結單標題，或標題底下的一張訂單卡。
+ * 沒有取貨紀錄的卡片（舊資料 / liff-api 還沒部署）就是沒有標題的 order 節點。
+ */
+export type DoneNode =
+  | { kind: "visit"; key: string; visit: PickupVisit }
+  | { kind: "order"; key: string; order: OrderRow };
+
+/** 這張卡片實際列出來的貨值 / 件數（＝ OrderCard 的 visibleItemsTotal / totalQty） */
+function cardTotals(items: OrderItem[]): { qty: number; amount: number } {
+  let qty = 0;
+  let amount = 0;
+  for (const it of items) {
+    if (["cancelled", "expired"].includes(it.status)) continue;
+    qty += Number(it.qty ?? 0);
+    amount += Number(it.subtotal ?? 0);
+  }
+  return { qty, amount };
+}
+
+type Slice = {
+  order: OrderRow;
+  pickedAt: string;
+  /** 分組用：同一家店才可能是同一次到店（跨店不可能同時發生） */
+  storeKey: string;
+};
+
+/**
+ * 把「已完成」分桶（每張單只帶已取品項的分身）再依取貨事件拆一次，
+ * 然後把時間相近的併成一次結單。
+ *
+ * 一張單分兩次取完 → 拆成兩張卡，各自掛在自己那一次結單底下（這正是要看的東西）。
+ * 對不到任何事件的品項 → 收在最後，維持原本的平鋪樣子。
+ */
+export function buildDoneNodes(doneOrders: OrderRow[]): DoneNode[] {
+  const slices: Slice[] = [];
+  const orphans: OrderRow[] = [];
+
+  for (const o of doneOrders) {
+    const events: PickupEvent[] = [...(o.pickups ?? [])].sort((a, b) => a.id - b.id);
+    const used = new Set<number>();
+    for (const ev of events) {
+      const ids = new Set((ev.item_ids ?? []).map(Number));
+      // 只認「現在還是已取貨」的行：撤銷取貨會把行改回去，事件卻永遠留著
+      const items = o.items.filter((it) => ids.has(Number(it.id)));
+      if (items.length === 0) continue;
+      for (const it of items) used.add(Number(it.id));
+      slices.push({
+        order: { ...o, items },
+        pickedAt: ev.picked_at,
+        storeKey: String(o.store_name ?? ""),
+      });
+    }
+    const rest = o.items.filter((it) => !used.has(Number(it.id)));
+    if (rest.length > 0) orphans.push({ ...o, items: rest });
+  }
+
+  // 新的結單排前面（「已完成」看的是「我最近拿了什麼」，不是「我最早訂了什麼」）
+  slices.sort((a, b) => new Date(b.pickedAt).getTime() - new Date(a.pickedAt).getTime());
+
+  const nodes: DoneNode[] = [];
+  let group: Slice[] = [];
+
+  const flush = () => {
+    if (group.length === 0) return;
+    let qty = 0;
+    let amount = 0;
+    for (const s of group) {
+      const t = cardTotals(s.order.items);
+      qty += t.qty;
+      amount += t.amount;
+    }
+    // group 已依時間新→舊，第一筆就是這次結單的最後一個動作
+    const head = group[0];
+    const key = `v:${head.pickedAt}:${head.order.id}`;
+    nodes.push({
+      kind: "visit",
+      key,
+      visit: {
+        key,
+        pickedAt: head.pickedAt,
+        storeName: head.order.store_name,
+        orderCount: new Set(group.map((s) => s.order.id)).size,
+        qty,
+        amount,
+      },
+    });
+    // 標題用最後一個動作的時間（＝結單完成），底下的卡片照櫃台實際結的順序
+    // 由舊到新排 —— 一路往下讀就是那一次結單的過程，像一張收據。
+    for (const s of [...group].reverse()) {
+      nodes.push({
+        kind: "order",
+        key: `${key}:${s.order.id}:${s.order.items[0]?.id ?? 0}`,
+        order: s.order,
+      });
+    }
+    group = [];
+  };
+
+  for (const s of slices) {
+    const prev = group[group.length - 1];
+    const sameVisit =
+      prev != null &&
+      prev.storeKey === s.storeKey &&
+      new Date(prev.pickedAt).getTime() - new Date(s.pickedAt).getTime() <= VISIT_GAP_MS;
+    if (!sameVisit) flush();
+    group.push(s);
+  }
+  flush();
+
+  for (const o of orphans) {
+    nodes.push({ kind: "order", key: `o:${o.id}:${o.items[0]?.id ?? 0}`, order: o });
+  }
+  return nodes;
+}
+
+/** 節點列表裡的訂單卡數量（分頁用；結單標題不算一筆） */
+export function countOrderNodes(nodes: DoneNode[]): number {
+  return nodes.reduce((n, x) => (x.kind === "order" ? n + 1 : n), 0);
+}
+
+/**
+ * 只取前 n 張訂單卡（結單標題跟著它的卡片走）。
+ * 標題落在切點上、底下一張卡都沒有時要丟掉，不然會出現孤兒標題。
+ */
+export function takeOrderNodes(nodes: DoneNode[], n: number): DoneNode[] {
+  const out: DoneNode[] = [];
+  let count = 0;
+  for (const node of nodes) {
+    if (node.kind === "order") {
+      if (count >= n) break;
+      count += 1;
+    }
+    out.push(node);
+  }
+  while (out.length > 0 && out[out.length - 1].kind === "visit") out.pop();
+  return out;
+}

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -330,6 +330,56 @@ async function getOverview(sb: any, tenantId: string, storeId: number, memberId:
   return json({ store: storeRow, receivable_amount: receivable, active_orders_count: activeCount ?? 0 });
 }
 
+/**
+ * 取貨事件（order_pickup_events，append-only）→ 依訂單分組。
+ *
+ * 會員端「已完成」分頁靠它把品項還原成「客人那一次到店結單拿走的組合」：
+ * 一次櫃台結單 = 每張訂單各一筆事件（/pickup 的「一次全取」是逐張呼叫
+ * rpc_record_pickup），所以事件本身就是那一次拿走的品項清單。
+ *
+ * 撤銷取貨（rpc_undo_pickup，20260704000010）不刪原事件 —— 該表禁改禁刪 ——
+ * 而是補一筆 pickup_undone、notes 固定 `撤銷取貨事件 #<id>`。被撤銷的那一次
+ * 不能再算數，判法與後台 apps/admin/src/lib/pickupReceipt.ts 的
+ * undonePickupEventIds 同一套（改一邊記得改另一邊）。
+ *
+ * notes 不外露：那是店員的內部備註（「一次全取（儲值金 $500）」之類）。
+ */
+async function fetchPickupEventsByOrder(
+  sb: any,
+  orderIds: number[],
+): Promise<Map<number, { id: number; event_type: string; picked_at: string; item_ids: number[] }[]>> {
+  const out = new Map<number, { id: number; event_type: string; picked_at: string; item_ids: number[] }[]>();
+  if (orderIds.length === 0) return out;
+  const { data, error } = await sb
+    .from("order_pickup_events")
+    .select("id, order_id, event_type, item_ids, notes, created_at")
+    .in("order_id", orderIds)
+    .in("event_type", ["picked_up", "partial_pickup", "pickup_undone"])
+    .order("id", { ascending: true });
+  // 取貨紀錄拿不到只是少了分組，訂單本身照列 —— 不要讓整頁掛掉
+  if (error) { console.error("fetchPickupEventsByOrder:", error.message); return out; }
+
+  const rows = (data ?? []) as any[];
+  const undone = new Set<number>();
+  for (const r of rows) {
+    if (r.event_type !== "pickup_undone") continue;
+    const m = /撤銷取貨事件 #(\d+)/.exec(String(r.notes ?? ""));
+    if (m) undone.add(Number(m[1]));
+  }
+  for (const r of rows) {
+    if (r.event_type === "pickup_undone" || undone.has(Number(r.id))) continue;
+    const list = out.get(Number(r.order_id)) ?? [];
+    list.push({
+      id: Number(r.id),
+      event_type: String(r.event_type),
+      picked_at: String(r.created_at),
+      item_ids: Array.isArray(r.item_ids) ? r.item_ids.map(Number).filter(Number.isFinite) : [],
+    });
+    out.set(Number(r.order_id), list);
+  }
+  return out;
+}
+
 async function listMyOrders(sb: any, tenantId: string, _storeId: number, memberId: number, tab: string) {
   const cutoff = new Date(); cutoff.setMonth(cutoff.getMonth() - 6);
   // 不依 store_id 過濾：同一 line_user 可能綁多店 OA，但 member_id 是 tenant 級；
@@ -345,6 +395,11 @@ async function listMyOrders(sb: any, tenantId: string, _storeId: number, memberI
     ? (data ?? []).filter((o: any) => o.status !== "cancelled" || o.stockout_at)
     : (data ?? []);
 
+  // 每張單掛上自己的取貨事件 —— 會員端「已完成」分頁要能把品項還原成
+  // 「客人那一次到店結單的組合」（同一次結單常橫跨好幾張單）。
+  // 多一次查詢就好，不要每張單各查一次。
+  const pickupsByOrder = await fetchPickupEventsByOrder(sb, rows.map((o: any) => Number(o.id)));
+
   // 把 items.image_url + campaign_cover_url 轉成 storage public URL
   const supabaseUrl = requireEnv("SUPABASE_URL");
   const orders = rows.map((o: any) => ({
@@ -354,6 +409,7 @@ async function listMyOrders(sb: any, tenantId: string, _storeId: number, memberI
       ...it,
       image_url: toPublicUrl(supabaseUrl, "products", it.image_url),
     })),
+    pickups: pickupsByOrder.get(Number(o.id)) ?? [],
   }));
   return json({ orders });
 }


### PR DESCRIPTION
訂單是依團開的、取貨是依人結的：客人一趟到店常常一次拿走三、四個團的貨、
當場付一次現金，但「已完成」分頁是照訂單平鋪的 —— 那一次到底拿了什麼、
付了多少，客人在 app 上永遠拼不回來（店裡印得出小白單，手機上沒有），
只能傳截圖進來、由客服對著後台一張一張猜。

資料來源用 order_pickup_events（append-only，/pickup/print 的收據印的也是它）：
一次櫃台結單 = 每張訂單各一筆事件（「一次全取」逐張呼叫 rpc_record_pickup），
把同一家店、間隔 10 分鐘內的事件併回一組，就是那一次的結單組合。

- liff-api list_my_orders：每張單掛上自己的取貨事件（多一次查詢，不是每張單各查
  一次）。撤銷取貨那幾次伺服端就濾掉（判法比照後台 lib/pickupReceipt.ts 的
  undonePickupEventIds）；notes 是店員內部備註，不外露。
- 會員端「已完成」：每一組上方一張標題卡（取貨時間 / 門市 / 幾筆訂單 / 幾件 /
  本次取貨金額），底下是那一次拿走的訂單卡。一張單分兩次取完會拆成兩張卡，
  各自掛在自己那一次底下；排序改成依取貨時間新→舊。
- 金額不另立口徑：標題的金額 = 底下那幾張卡片的金額相加（＝該次取走品項的貨值），
  跟現有的分身卡同一套算法，畫面才會自洽。
- 對不到取貨事件的卡片（舊資料、或 liff-api 還沒部署）收在最後、維持原本平鋪的
  樣子 —— 函式沒部署時整頁行為與現在完全相同，不會壞掉。
- 後台「會員畫面」跟著做同一套分組（客服要看到跟團友手機上一樣的畫面），
  演算法副本放 apps/admin/src/lib/pickupVisits.ts。

措辭上一律講「取貨」不講「結單」：同一頁的訂單卡上「結單日」是開團收單日，
兩種意思擺在一起客人一定誤讀。

⚠️ 部署：supabase/functions/liff-api 要重新部署（curl + Management API，見
CLAUDE.md）才會回 pickups 欄位；沒部署前前端只是照舊平鋪，不會出錯。
本次沒有 migration，DB 不用動。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SVQgTp4PSm5NqfbTpg7MnQ