### PR TITLE
互助轉單：補齊 pending 狀態、轉出記錄、單則列印

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,6 +497,36 @@ Leg-2 總倉 → 收貨店（`customer_order_id` = 轉入單）。所以**只看
   `customer_order_id IS NULL` 就往 `next_transfer_id` 追一段再拿訂單。
 - 空中轉（`is_air_transfer`）只有一段、直送收貨店，沒有這個問題。
 
+### 經總倉的轉入單一開始是 `pending`，不是 `confirmed` —— 轉出店的畫面別漏掉這一段
+
+`rpc_transfer_order_to_store` / `rpc_transfer_order_partial` 建轉入單時的 status：
+同店 mirror 原單、**跨店空中轉 `confirmed`**（尾端 helper 立刻推 shipping）、
+**跨店經總倉 `pending`**（維持總倉確認 gate）。而 `pending → confirmed` 的語意是
+「總倉收到貨了」（`AidOrderStatusActions` + 訂單進度條的「總倉收到」），
+也就是**箱子已經離開分店之後**才會發生。
+
+所以「轉出店還要為這批貨做事」的狀態集合是 `pending / confirmed / shipping`
+（`apps/admin/src/lib/aidTransfer.ts` 的 `AID_IN_FLIGHT_STATUSES`），
+漏掉 `pending` = 貨還在店裡、最需要印隨貨單的那一整段畫面上什麼都沒有。
+2026-08-18 南平→三峽就是這樣：儀表板的互助出貨提醒只撈 `confirmed/shipping`，
+店家原話「三峽可以看見，南平自己看不到轉給三峽的資料，找不到轉貨單可印」。
+
+連帶兩個一定要一起做的：
+
+- **轉入單掛在收貨店名下，轉出店的訂單列表一列都撈不到。** 來源單上要自己把
+  「轉出記錄」寫出來（`OrderDetail` 反查 `transferred_from_order_id = 本單`，
+  **不要用 `transferred_to_order_id`** —— 部分轉出不寫那一欄），
+  否則貨從店裡出去 = 系統上查無此事。
+- **連到 `/orders` 的連結一定要帶 `&storeId=<收貨店>`。** 門市篩選對分店帳號會
+  預設帶回自家店（`useDefaultStoreFromUser`，只在 storeId 為空時套），
+  不帶就是搜出 0 筆，看起來像貨憑空消失。
+
+⚠ 已知還沒補的洞：**「追加轉入（併入既有單）」那條分支不寫 `transferred_from_order_id`**
+（兩支 RPC 的 `v_appended` 分支都只加一行 notes）。同一團第二次轉到同一家店的
+同一個收件人時就會走到它 —— 反查撈不到，上面兩個畫面又會一起變成「查無此事」，
+而且既有單身上那一欄還指著更早的來源單、數量也是整張單的 aid 品項總和（會重複算）。
+真的要修得靠一張 order↔order 的連結表（一張轉入單可能有多個來源），不是補寫一欄就好。
+
 ### 自由轉貨（rpc_create_free_transfer）：停用過一次，2026-08-16 又打開
 
 時間軸：8/14 停用（`/wms/transfers` 的「+ 建自由轉貨」與 `/transfers/free`

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -220,7 +220,7 @@ export default function MutualAidPage() {
           <SpinButton
             type="button"
             onClick={() => printViaIframe(withBasePath(`/inventory/mutual-aid/print?type=${filter}`))}
-            title="列印目前這個分頁的貼文清單（A4 橫式）"
+            title="列印目前這個分頁的整份貼文清單（A4 橫式）；單獨一則請按該列右邊的 🖨️"
             className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
           >
             🖨️ 列印
@@ -281,11 +281,11 @@ export default function MutualAidPage() {
       ) : (
         <ul className="space-y-2">
           {posts.map((p) => (
-            <li key={p.id}>
+            <li key={p.id} className="flex items-start gap-2 rounded-md border border-zinc-200 bg-white p-3 transition hover:border-zinc-400 hover:shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-600">
               <SpinButton
                 type="button"
                 onClick={() => setThreadPost(p)}
-                className="block w-full rounded-md border border-zinc-200 bg-white p-3 text-left transition hover:border-zinc-400 hover:shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-600"
+                className="block min-w-0 flex-1 text-left"
               >
                 <div className="mb-1 flex flex-wrap items-center gap-2">
                   <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${TYPE_COLOR[p.post_type]}`}>
@@ -329,6 +329,16 @@ export default function MutualAidPage() {
                   )}
                   {p.note && <span className="text-zinc-700 dark:text-zinc-300">「{p.note}」</span>}
                 </div>
+              </SpinButton>
+              {/* 每一則都要能單獨印（不論狀態）—— 板上的貨常常是靠紙本在店裡流動，
+                  已認領 / 已過期的也要印得回來歸檔、對帳 */}
+              <SpinButton
+                type="button"
+                onClick={() => printViaIframe(withBasePath(`/inventory/mutual-aid/print?id=${p.id}`))}
+                title="列印這一則（A4 直式：內容 + 留言 + 認領簽收欄）"
+                className="shrink-0 rounded-md border border-zinc-300 px-2 py-1.5 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+              >
+                🖨️
               </SpinButton>
             </li>
           ))}
@@ -1498,6 +1508,14 @@ function ThreadModal({
                 App 標題：{savedSpotTitle}
               </span>
             )}
+            <SpinButton
+              type="button"
+              onClick={() => printViaIframe(withBasePath(`/inventory/mutual-aid/print?id=${post.id}`))}
+              title="列印這一則（A4 直式：內容 + 留言 + 認領簽收欄）"
+              className="ml-auto shrink-0 rounded-md border border-zinc-300 px-2 py-0.5 text-[11px] text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              🖨️ 列印
+            </SpinButton>
           </div>
           <div className="flex flex-wrap gap-x-4 gap-y-1 text-zinc-500">
             <span>

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -1482,7 +1482,7 @@ function ThreadModal({
   }
 
   return (
-    <Modal open={true} onClose={onClose} title="互助貼文 #" maxWidth="max-w-2xl">
+    <Modal open={true} onClose={onClose} title={`互助貼文 #${post.id}`} maxWidth="max-w-2xl">
       <div className="flex flex-col gap-3 text-sm">
         {/* Post header */}
         <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs dark:border-zinc-800 dark:bg-zinc-950">

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/print/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/print/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-// 互助交流板列印頁（A4）。
-// 由 /inventory/mutual-aid 的「🖨️ 列印」用隱藏 iframe 載入（printViaIframe），
-// 所以這頁要自己抓資料、抓完自動 window.print()，查詢條件完全對齊列表頁
-// （status = active、created_at desc、limit 200，type 由 query 帶入）。
+// 互助交流板列印頁。兩種模式，由 query 決定：
+//
+//   ?type=all|request|offer  → 清單模式（A4 橫式表格）。由 /inventory/mutual-aid 的
+//                              「🖨️ 列印」用隱藏 iframe 載入，查詢條件完全對齊列表頁
+//                              （status = active、created_at desc、limit 200）。
+//   ?id=<board_id>           → 單則模式（A4 直式單張）。板上每一則貼文自己的列印鈕，
+//                              **不濾 status** —— 已認領 / 已過期的也要印得出來，
+//                              店家常常是事後要補一張紙歸檔或跟對方對帳。
+//
+// 兩種都自己抓資料、抓完自動 window.print()。
 
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
@@ -11,10 +17,12 @@ import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 
 type PostType = "offer" | "request";
+type PostStatus = "active" | "exhausted" | "expired" | "cancelled";
 
 type Row = {
   id: number;
   post_type: PostType;
+  status: PostStatus;
   offering_store_id: number;
   sku_id: number | null;
   qty_available: number;
@@ -25,23 +33,60 @@ type Row = {
   spot_price: number | null;
   spot_title: string | null;
   spot_unit: string | null;
+  spot_description: string | null;
   spot_visible_to_other_stores: boolean;
   created_at: string;
   store_name: string;
+  sku_code: string | null;
   sku_label: string;
   source_order_no: string | null;
   replies_count: number;
 };
 
+type Reply = {
+  id: number;
+  author_label: string | null;
+  body: string;
+  created_at: string;
+};
+
 type SkuOption = { id: number; sku_code: string; product_name: string; variant_name: string | null };
 
+const SELECT_COLS =
+  "id, post_type, status, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, " +
+  "source_customer_order_id, spot_price, spot_title, spot_unit, spot_description, " +
+  "spot_visible_to_other_stores, created_at";
+
 const TYPE_LABEL: Record<PostType, string> = { offer: "釋出", request: "需求" };
+
+const STATUS_LABEL: Record<PostStatus, string> = {
+  active: "進行中",
+  exhausted: "已認領",
+  expired: "已過期",
+  cancelled: "已取消",
+};
 
 const FILTER_LABEL: Record<"all" | "request" | "offer", string> = {
   all: "全部",
   request: "需求中",
   offer: "釋出中",
 };
+
+/** TipTap HTML → 純文字（紙上不需要標籤） */
+function htmlToText(raw: string | null | undefined): string {
+  if (!raw) return "";
+  return raw
+    .replace(/<\/(p|div|h[1-6]|li|tr|blockquote)\s*>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
 
 export default function MutualAidPrintPage() {
   return (
@@ -53,11 +98,14 @@ export default function MutualAidPrintPage() {
 
 function Body() {
   const sp = useSearchParams();
+  const idParam = Number(sp.get("id"));
+  const singleId = Number.isFinite(idParam) && idParam > 0 ? idParam : null;
   const typeParam = sp.get("type");
   const filter: "all" | "request" | "offer" =
     typeParam === "request" || typeParam === "offer" ? typeParam : "all";
 
   const [rows, setRows] = useState<Row[] | null>(null);
+  const [replies, setReplies] = useState<Reply[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [printedAt, setPrintedAt] = useState<string>("");
 
@@ -68,16 +116,18 @@ function Body() {
       setPrintedAt(fmtDt(new Date().toISOString()));
       try {
         const sb = getSupabase();
-        let q = sb
-          .from("mutual_aid_board")
-          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, source_customer_order_id, spot_price, spot_title, spot_unit, spot_visible_to_other_stores, created_at")
-          .eq("status", "active")
-          .order("created_at", { ascending: false })
-          .limit(200);
-        if (filter !== "all") q = q.eq("post_type", filter);
+        let q = sb.from("mutual_aid_board").select(SELECT_COLS);
+        if (singleId != null) {
+          // 單則：不濾 status（已認領 / 已過期也要印得出來）
+          q = q.eq("id", singleId);
+        } else {
+          q = q.eq("status", "active").order("created_at", { ascending: false }).limit(200);
+          if (filter !== "all") q = q.eq("post_type", filter);
+        }
         const { data, error: e } = await q;
         if (e) throw new Error(e.message);
-        const base = (data ?? []) as Omit<Row, "store_name" | "sku_label" | "source_order_no" | "replies_count">[];
+        type Base = Omit<Row, "store_name" | "sku_code" | "sku_label" | "source_order_no" | "replies_count">;
+        const base = (data ?? []) as unknown as Base[];
         if (base.length === 0) {
           if (!cancelled) setRows([]);
           return;
@@ -95,7 +145,13 @@ function Body() {
             ? sb.from("skus").select("id, sku_code, product_name, variant_name").in("id", skuIds)
             : Promise.resolve({ data: [], error: null }),
           sb.from("stores").select("id, name").in("id", storeIds),
-          sb.from("mutual_aid_replies").select("board_id").in("board_id", boardIds),
+          // 單則要印出留言內容，清單只要則數
+          singleId != null
+            ? sb.from("mutual_aid_replies")
+                .select("id, board_id, author_label, body, created_at")
+                .in("board_id", boardIds)
+                .order("created_at", { ascending: true })
+            : sb.from("mutual_aid_replies").select("board_id").in("board_id", boardIds),
           orderIds.length > 0
             ? sb.from("customer_orders").select("id, order_no").in("id", orderIds)
             : Promise.resolve({ data: [], error: null }),
@@ -107,15 +163,21 @@ function Body() {
         const orderMap = new Map<number, string>(
           ((orderRes.data ?? []) as { id: number; order_no: string }[]).map((o) => [o.id, o.order_no]),
         );
+        const replyRows = (replyRes.data ?? []) as { board_id: number }[];
         const replyCount = new Map<number, number>();
-        for (const r of (replyRes.data ?? []) as { board_id: number }[]) {
+        for (const r of replyRows) {
           replyCount.set(r.board_id, (replyCount.get(r.board_id) ?? 0) + 1);
+        }
+        if (cancelled) return;
+        if (singleId != null) {
+          setReplies(replyRows as unknown as Reply[]);
         }
         const enriched: Row[] = base.map((r) => {
           const sku = r.sku_id != null ? skuMap.get(r.sku_id) : undefined;
           return {
             ...r,
             store_name: storeMap.get(r.offering_store_id) ?? `#${r.offering_store_id}`,
+            sku_code: sku?.sku_code ?? null,
             sku_label: sku
               ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} (${sku.sku_code})`
               : r.sku_id != null
@@ -135,7 +197,7 @@ function Body() {
     return () => {
       cancelled = true;
     };
-  }, [filter]);
+  }, [filter, singleId]);
 
   // 載入完自動觸發列印（沒資料也印，讓「今天板上是空的」也留得下紙本）
   useEffect(() => {
@@ -146,6 +208,10 @@ function Body() {
 
   if (error) return <div className="p-6 text-sm text-red-700">{error}</div>;
   if (rows === null) return <div className="p-6 text-sm text-zinc-500">載入中…</div>;
+
+  if (singleId != null) {
+    return <SinglePost row={rows[0] ?? null} replies={replies} printedAt={printedAt} />;
+  }
 
   const requestCount = rows.filter((r) => r.post_type === "request").length;
   const offerCount = rows.filter((r) => r.post_type === "offer").length;
@@ -163,14 +229,7 @@ function Body() {
         }
       `}</style>
 
-      <div className="no-print mb-4 flex justify-end gap-2">
-        <SpinButton
-          onClick={() => window.print()}
-          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500"
-        >
-          🖨️ 列印
-        </SpinButton>
-      </div>
+      <PrintBar />
 
       <header className="mb-3">
         <h1 className="text-xl font-bold">互助交流板 — {FILTER_LABEL[filter]}</h1>
@@ -243,10 +302,185 @@ function Body() {
   );
 }
 
-function Th({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+// ============================================================
+// 單則貼文（A4 直式）—— 夾在貨上 / 歸檔用，底下留簽收欄
+// ============================================================
+function SinglePost({
+  row, replies, printedAt,
+}: {
+  row: Row | null;
+  replies: Reply[];
+  printedAt: string;
+}) {
+  if (!row) {
+    return (
+      <div className="bg-white p-8 text-black">
+        <style>{`@media print { @page { size: A4 portrait; margin: 1.2cm; } .no-print { display: none !important; } }`}</style>
+        <PrintBar />
+        <div className="border border-dashed border-zinc-400 p-8 text-center text-sm text-zinc-500">
+          找不到這則貼文（可能已被刪除）
+        </div>
+      </div>
+    );
+  }
+  const isManual = row.post_type === "offer" && row.source_customer_order_id == null;
+  const desc = htmlToText(row.spot_description);
+  return (
+    <div className="bg-white p-8 text-black print:p-0">
+      <style>{`
+        @media print {
+          @page { size: A4 portrait; margin: 1.2cm; }
+          .no-print { display: none !important; }
+          body { background: white; }
+          .avoid-break { break-inside: avoid; }
+        }
+      `}</style>
+
+      <PrintBar />
+
+      <header className="mb-4 border-b-2 border-black pb-2">
+        <div className="flex items-baseline justify-between">
+          <h1 className="text-2xl font-bold">
+            互助交流單 — {TYPE_LABEL[row.post_type]}
+          </h1>
+          <span className="text-sm">貼文 #{row.id}</span>
+        </div>
+        <div className="mt-1 flex flex-wrap gap-x-4 text-xs text-zinc-600">
+          <span>狀態：{STATUS_LABEL[row.status]}</span>
+          <span>張貼 {fmtDt(row.created_at)}</span>
+          <span>列印時間 {printedAt}</span>
+        </div>
+      </header>
+
+      <table className="mb-4 w-full border-collapse text-sm avoid-break">
+        <tbody>
+          <FieldRow label={row.post_type === "offer" ? "釋出店" : "求助店"} value={row.store_name} />
+          <FieldRow
+            label="商品 / 品項"
+            value={
+              <>
+                <span className="text-base font-semibold">{row.sku_label}</span>
+                {isManual && <span className="ml-2 text-xs text-zinc-500">[手動新增現貨]</span>}
+                {row.sku_id == null && (
+                  <span className="ml-2 text-xs text-zinc-500">[未選商品，其他分店無法認領]</span>
+                )}
+                {row.spot_title && row.sku_id != null && (
+                  <div className="text-xs text-zinc-500">App 標題：{row.spot_title}</div>
+                )}
+              </>
+            }
+          />
+          <FieldRow
+            label={row.post_type === "offer" ? "可釋出數量" : "需求數量"}
+            value={
+              <span className="font-mono text-base">
+                {row.qty_remaining}{row.spot_unit ?? ""}
+                {row.qty_remaining !== row.qty_available && (
+                  <span className="ml-2 text-xs text-zinc-500">（原 {row.qty_available}）</span>
+                )}
+              </span>
+            }
+          />
+          <FieldRow
+            label="單價"
+            value={row.spot_price != null ? `$${row.spot_price.toLocaleString()}` : "—"}
+          />
+          <FieldRow label="到期" value={fmtDt(row.expires_at)} />
+          <FieldRow label="源訂單" value={row.source_order_no ?? "—（沒有掛訂單，跨店認領會走載體單）"} />
+          {row.post_type === "offer" && (
+            <FieldRow
+              label="會員可見"
+              value={row.spot_visible_to_other_stores ? "全部門市會員" : "🔒 僅限本店會員"}
+            />
+          )}
+          <FieldRow label="備註" value={row.note ?? "—"} />
+        </tbody>
+      </table>
+
+      {desc && (
+        <section className="mb-4 avoid-break">
+          <h2 className="mb-1 text-sm font-semibold">商品說明</h2>
+          <div className="whitespace-pre-wrap border border-zinc-300 p-2 text-sm">{desc}</div>
+        </section>
+      )}
+
+      <section className="mb-6">
+        <h2 className="mb-1 text-sm font-semibold">留言（{replies.length}）</h2>
+        {replies.length === 0 ? (
+          <div className="border border-dashed border-zinc-400 p-3 text-center text-xs text-zinc-500">
+            尚無留言
+          </div>
+        ) : (
+          <ul className="divide-y divide-zinc-300 border border-zinc-300">
+            {replies.map((rp) => (
+              <li key={rp.id} className="avoid-break p-2 text-sm">
+                <div className="text-xs text-zinc-500">
+                  {rp.author_label ?? "—"}・{fmtDt(rp.created_at)}
+                </div>
+                <div className="whitespace-pre-wrap">{htmlToText(rp.body) || rp.body}</div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="avoid-break">
+        <h2 className="mb-1 text-sm font-semibold">認領 / 點交</h2>
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="border border-zinc-500 bg-zinc-100 text-xs">
+              <Th className="border border-zinc-400">認領店</Th>
+              <Th className="w-24 border border-zinc-400 text-right">數量</Th>
+              <Th className="w-32 border border-zinc-400">日期</Th>
+              <Th className="w-40 border border-zinc-400">簽收</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {[0, 1, 2].map((i) => (
+              <tr key={i}>
+                <Td className="h-9 border border-zinc-400" />
+                <Td className="h-9 border border-zinc-400" />
+                <Td className="h-9 border border-zinc-400" />
+                <Td className="h-9 border border-zinc-400" />
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p className="mt-2 text-xs text-zinc-500">
+          ※ 這張是溝通 / 歸檔用的交流單，不是出貨單。實際跨店認領成立後，貨會走訂單轉移，
+          隨貨的「互助出貨單」請到該筆轉入單或儀表板的互助提醒列印。
+        </p>
+      </section>
+    </div>
+  );
+}
+
+function PrintBar() {
+  return (
+    <div className="no-print mb-4 flex justify-end gap-2">
+      <SpinButton
+        onClick={() => window.print()}
+        className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500"
+      >
+        🖨️ 列印
+      </SpinButton>
+    </div>
+  );
+}
+
+function FieldRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <tr className="border-b border-zinc-300 align-top">
+      <th className="w-28 bg-zinc-100 px-2 py-1.5 text-left text-xs font-semibold">{label}</th>
+      <td className="px-2 py-1.5">{value}</td>
+    </tr>
+  );
+}
+
+function Th({ children, className = "" }: { children?: React.ReactNode; className?: string }) {
   return <th className={`px-2 py-1 text-left font-semibold ${className}`}>{children}</th>;
 }
-function Td({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+function Td({ children, className = "" }: { children?: React.ReactNode; className?: string }) {
   return <td className={`px-2 py-1 ${className}`}>{children}</td>;
 }
 

--- a/apps/admin/src/components/AidShipmentReminder.tsx
+++ b/apps/admin/src/components/AidShipmentReminder.tsx
@@ -1,18 +1,23 @@
 "use client";
 
-// 儀表板提醒：本店有互助的貨要交出去，提醒店家把出貨單印出來給司機。
+// 儀表板提醒：本店名下**還在路上的互助轉移**，轉出（要交出去）與轉入（在等的貨）
+// 兩個方向都列出來，每一筆都能就地列印互助出貨單。
 //
-// 為什麼要主動提醒：互助的貨是「別人來拿」，出貨動作不像取貨那樣有客人站在櫃檯催。
-// 店家不知道自己名下有貨等著被載走，就不會去印單 —— 司機來了拿了貨、紙上什麼都沒有，
-// 中途少一箱沒人說得清（2026-08-15 店家回報）。
+// 為什麼要主動提醒：互助的貨是「別人來拿 / 別人送來」，不像顧客取貨有人站在櫃檯催。
+// 轉出店不知道自己名下有貨等著被載走，就不會去印單 —— 司機來了拿了貨、紙上什麼都沒有，
+// 中途少一箱沒人說得清（2026-08-15 店家回報）。轉入店同理：不知道有貨在路上，
+// 箱子到了也不會去「收貨」頁收單，訂單就一直卡著。
 //
-// 判定：轉入單（互助單）還沒被收貨店收掉（pending / confirmed / shipping），
-// 而它的來源單是本店。
+// 判定：轉入單（互助單）還沒被收貨店收掉（pending / confirmed / shipping）。
 //   - pending   = 剛轉出、總倉還沒收到（**經總倉的轉入單一開始就是這個狀態**，
 //                 見 rpc_transfer_order_to_store / _partial：跨店非空中轉建成 pending）
 //   - confirmed = 總倉已收、還沒派貨；空中轉的話是自動出貨上線前卡住的舊單
 //   - shipping  = 已建 AT- 轉移單，但收貨店還沒收 → 貨可能還在店裡等司機
-//   收貨店收掉就變 ready，提醒自動消失。
+//   收貨店收掉就變 ready，兩邊的提醒都自動消失。
+//
+// 方向：轉出＝來源單的 pickup_store 是本店；轉入＝這張轉入單的 pickup_store 是本店。
+// 同店轉單（只是換客人）貨沒離開本店，兩邊都不算。
+// 儀表板選「全部門市」（HQ）時不分方向，一份清單看全站在途的互助。
 //
 // ⚠ pending 不可以漏（2026-08-18 南平→三峽）：原本只撈 confirmed/shipping，而
 // 經總倉的單要等總倉「收到貨」才被推 confirmed —— 也就是箱子早就離開店裡了提醒才出現。
@@ -27,7 +32,7 @@ import { printViaIframe } from "@/lib/printIframe";
 import { withBasePath } from "@/lib/basePath";
 import { AID_IN_FLIGHT_STATUSES, aidRouteLabel, aidStageLabel } from "@/lib/aidTransfer";
 
-type PendingShip = {
+type AidShipment = {
   id: number;
   order_no: string;
   status: string;
@@ -35,6 +40,7 @@ type PendingShip = {
   dest_store: string;
   dest_store_id: number | null;
   source_store: string;
+  source_store_id: number | null;
   qty: number;
 };
 
@@ -51,7 +57,7 @@ function loadPrinted(): Set<number> {
 }
 
 export default function AidShipmentReminder({ storeId }: { storeId: number | null }) {
-  const [rows, setRows] = useState<PendingShip[] | null>(null);
+  const [rows, setRows] = useState<AidShipment[] | null>(null);
   // rows 還沒載完（含 SSR）時整個元件回 null，所以這裡讀 localStorage 不會有 hydration 落差
   const [printed, setPrinted] = useState<Set<number>>(
     () => (typeof window === "undefined" ? new Set<number>() : loadPrinted()),
@@ -102,14 +108,12 @@ export default function AidShipmentReminder({ storeId }: { storeId: number | nul
           ((srcData ?? []) as unknown as SrcRaw[]).map((s) => [s.id, s]),
         );
 
-        const list = raw.flatMap((r): PendingShip[] => {
+        const list = raw.flatMap((r): AidShipment[] => {
           const src = srcMap.get(r.transferred_from_order_id);
           if (!src) return [];
-          // 同店轉單（只是換客人）貨沒離開本店，不用出貨也不用印
+          // 同店轉單（只是換客人）貨沒離開本店，不用出貨也不用收貨
           if (src.pickup_store_id === r.pickup_store_id) return [];
-          // 儀表板選了門市（分店帳號一律鎖自己那家）→ 只提醒「要出貨的是本店」
-          if (storeId != null && src.pickup_store_id !== storeId) return [];
-          // 品項全被取消掉的單沒有實體貨要交，別再叫人去印一張空白單
+          // 品項全被取消掉的單沒有實體貨在走，別再叫人去印一張空白單
           const qty = (r.items ?? [])
             .filter((it) => !["cancelled", "expired"].includes(it.status))
             .reduce((s, it) => s + Number(it.qty), 0);
@@ -122,6 +126,7 @@ export default function AidShipmentReminder({ storeId }: { storeId: number | nul
             dest_store: nameOf(r.store),
             dest_store_id: r.pickup_store_id,
             source_store: nameOf(src.store),
+            source_store_id: src.pickup_store_id,
             qty,
           }];
         });
@@ -132,7 +137,8 @@ export default function AidShipmentReminder({ storeId }: { storeId: number | nul
       }
     })();
     return () => { cancelled = true; };
-  }, [storeId]);
+    // 查詢是全 tenant 的，方向與門市過濾都在 render 時做 —— 換門市不需要重打
+  }, []);
 
   const markPrinted = useCallback((id: number) => {
     setPrinted((prev) => {
@@ -145,24 +151,108 @@ export default function AidShipmentReminder({ storeId }: { storeId: number | nul
 
   if (!rows || rows.length === 0) return null;
 
-  const todo = rows.filter((r) => !printed.has(r.id)).length;
+  // 選了門市（分店帳號一律鎖自己那家）→ 拆成轉出 / 轉入兩區；
+  // 全部門市（HQ）→ 不分方向，一份在途清單
+  const outgoing = storeId == null ? [] : rows.filter((r) => r.source_store_id === storeId);
+  const incoming = storeId == null ? [] : rows.filter((r) => r.dest_store_id === storeId);
+  const both = storeId == null ? rows : [];
+  if (outgoing.length === 0 && incoming.length === 0 && both.length === 0) return null;
 
   return (
-    <section className="rounded-md border border-fuchsia-300 bg-fuchsia-50 p-4 dark:border-fuchsia-800 dark:bg-fuchsia-950/40">
+    <div className="space-y-3">
+      {both.length > 0 && (
+        <AidSection
+          tone="all"
+          title={`🤝 全站有 ${both.length} 筆互助的貨在路上`}
+          hint="收貨店收貨後就會從這裡消失"
+          rows={both}
+          printed={printed}
+          showPrinted={false}
+          onPrinted={markPrinted}
+        />
+      )}
+      {outgoing.length > 0 && (
+        <AidSection
+          tone="out"
+          title={`🤝 有 ${outgoing.length} 筆互助的貨要交出去`}
+          subtitle={(() => {
+            const todo = outgoing.filter((r) => !printed.has(r.id)).length;
+            return todo > 0 ? `（${todo} 筆還沒列印）` : undefined;
+          })()}
+          hint="印出來夾在箱子上交給司機；收貨店收貨後這裡就會消失"
+          rows={outgoing}
+          printed={printed}
+          showPrinted
+          onPrinted={markPrinted}
+        />
+      )}
+      {incoming.length > 0 && (
+        <AidSection
+          tone="in"
+          title={`📥 有 ${incoming.length} 筆互助的貨要進來`}
+          hint="貨到了請到「收貨」頁收單；印一張對照著點收，數量不對當場就看得出來"
+          rows={incoming}
+          printed={printed}
+          showPrinted={false}
+          onPrinted={markPrinted}
+        />
+      )}
+    </div>
+  );
+}
+
+const TONE = {
+  out: {
+    section: "border-fuchsia-300 bg-fuchsia-50 dark:border-fuchsia-800 dark:bg-fuchsia-950/40",
+    heading: "text-fuchsia-900 dark:text-fuchsia-200",
+    hint: "text-fuchsia-700 dark:text-fuchsia-300",
+    item: "border-fuchsia-200 dark:border-fuchsia-900",
+    button: "border-fuchsia-400 text-fuchsia-700 hover:bg-fuchsia-50 dark:border-fuchsia-700 dark:text-fuchsia-300 dark:hover:bg-fuchsia-950",
+  },
+  in: {
+    section: "border-sky-300 bg-sky-50 dark:border-sky-800 dark:bg-sky-950/40",
+    heading: "text-sky-900 dark:text-sky-200",
+    hint: "text-sky-700 dark:text-sky-300",
+    item: "border-sky-200 dark:border-sky-900",
+    button: "border-sky-400 text-sky-700 hover:bg-sky-50 dark:border-sky-700 dark:text-sky-300 dark:hover:bg-sky-950",
+  },
+  all: {
+    section: "border-zinc-300 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900",
+    heading: "text-zinc-900 dark:text-zinc-100",
+    hint: "text-zinc-600 dark:text-zinc-400",
+    item: "border-zinc-200 dark:border-zinc-800",
+    button: "border-zinc-400 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-800",
+  },
+} as const;
+
+function AidSection({
+  tone, title, subtitle, hint, rows, printed, showPrinted, onPrinted,
+}: {
+  tone: keyof typeof TONE;
+  title: string;
+  subtitle?: string;
+  hint: string;
+  rows: AidShipment[];
+  printed: Set<number>;
+  // 「✓ 已列印」只對轉出方有意義（該印的人是他）；轉入方印的是核對聯，不要標
+  showPrinted: boolean;
+  onPrinted: (id: number) => void;
+}) {
+  const t = TONE[tone];
+  return (
+    <section className={`rounded-md border p-4 ${t.section}`}>
       <div className="flex flex-wrap items-baseline justify-between gap-2">
-        <h2 className="text-sm font-semibold text-fuchsia-900 dark:text-fuchsia-200">
-          🤝 有 {rows.length} 筆互助的貨要交出去
-          {todo > 0 && <span className="ml-2 font-normal">（{todo} 筆還沒列印）</span>}
+        <h2 className={`text-sm font-semibold ${t.heading}`}>
+          {title}
+          {subtitle && <span className="ml-2 font-normal">{subtitle}</span>}
         </h2>
-        <span className="text-xs text-fuchsia-700 dark:text-fuchsia-300">
-          印出來夾在箱子上交給司機；收貨店收貨後這裡就會消失
-        </span>
+        <span className={`text-xs ${t.hint}`}>{hint}</span>
       </div>
       <ul className="mt-3 space-y-2">
         {rows.map((r) => (
           <li
             key={r.id}
-            className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded border border-fuchsia-200 bg-white px-3 py-2 text-sm dark:border-fuchsia-900 dark:bg-zinc-900"
+            className={`flex flex-wrap items-center gap-x-3 gap-y-1 rounded border bg-white px-3 py-2 text-sm dark:bg-zinc-900 ${t.item}`}
           >
             <span className="font-mono text-xs">{r.order_no}</span>
             <span className="font-medium">
@@ -174,10 +264,18 @@ export default function AidShipmentReminder({ storeId }: { storeId: number | nul
             <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
               {aidRouteLabel(r.is_air_transfer)}・{aidStageLabel(r.status, r.is_air_transfer)}
             </span>
-            {printed.has(r.id) && (
+            {showPrinted && printed.has(r.id) && (
               <span className="text-[11px] text-emerald-600 dark:text-emerald-400">✓ 已列印</span>
             )}
             <div className="ml-auto flex items-center gap-2">
+              {tone === "in" && (
+                <Link
+                  href="/wms/inbound"
+                  className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  去收貨
+                </Link>
+              )}
               <Link
                 // 一定要帶 storeId=收貨店：訂單列表的門市篩選對分店帳號會預設帶回自家店，
                 // 而這張轉入單掛在收貨店名下 —— 不帶就會搜出 0 筆（看起來像貨消失了）
@@ -191,10 +289,10 @@ export default function AidShipmentReminder({ storeId }: { storeId: number | nul
               </Link>
               <SpinButton
                 onClick={async () => {
-                  markPrinted(r.id);
+                  onPrinted(r.id);
                   await printViaIframe(withBasePath(`/transfers/print-aid?order_id=${r.id}`));
                 }}
-                className="rounded-md border border-fuchsia-400 bg-white px-3 py-1 text-xs font-medium text-fuchsia-700 hover:bg-fuchsia-50 dark:border-fuchsia-700 dark:bg-zinc-900 dark:text-fuchsia-300 dark:hover:bg-fuchsia-950"
+                className={`rounded-md border bg-white px-3 py-1 text-xs font-medium dark:bg-zinc-900 ${t.button}`}
                 title="列印互助出貨單（司機聯 + 店家存根聯），格式跟內部調撥的轉貨單一樣"
               >
                 🖨 列印出貨單

--- a/apps/admin/src/components/AidShipmentReminder.tsx
+++ b/apps/admin/src/components/AidShipmentReminder.tsx
@@ -6,10 +6,18 @@
 // 店家不知道自己名下有貨等著被載走，就不會去印單 —— 司機來了拿了貨、紙上什麼都沒有，
 // 中途少一箱沒人說得清（2026-08-15 店家回報）。
 //
-// 判定：轉入單（互助單）還沒被收貨店收掉（confirmed / shipping），而它的來源單是本店。
-//   - confirmed = 還沒派貨（經總倉的互助等總倉派）
+// 判定：轉入單（互助單）還沒被收貨店收掉（pending / confirmed / shipping），
+// 而它的來源單是本店。
+//   - pending   = 剛轉出、總倉還沒收到（**經總倉的轉入單一開始就是這個狀態**，
+//                 見 rpc_transfer_order_to_store / _partial：跨店非空中轉建成 pending）
+//   - confirmed = 總倉已收、還沒派貨；空中轉的話是自動出貨上線前卡住的舊單
 //   - shipping  = 已建 AT- 轉移單，但收貨店還沒收 → 貨可能還在店裡等司機
 //   收貨店收掉就變 ready，提醒自動消失。
+//
+// ⚠ pending 不可以漏（2026-08-18 南平→三峽）：原本只撈 confirmed/shipping，而
+// 經總倉的單要等總倉「收到貨」才被推 confirmed —— 也就是箱子早就離開店裡了提醒才出現。
+// 轉出店在最需要印隨貨單的那一段（貨還在自己手上）畫面上什麼都沒有，
+// 店家的原話是「南平自己看不到轉給三峽的資料，找不到轉貨單可印」。
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
@@ -17,6 +25,7 @@ import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import { printViaIframe } from "@/lib/printIframe";
 import { withBasePath } from "@/lib/basePath";
+import { AID_IN_FLIGHT_STATUSES, aidRouteLabel, aidStageLabel } from "@/lib/aidTransfer";
 
 type PendingShip = {
   id: number;
@@ -24,6 +33,7 @@ type PendingShip = {
   status: string;
   is_air_transfer: boolean;
   dest_store: string;
+  dest_store_id: number | null;
   source_store: string;
   qty: number;
 };
@@ -61,7 +71,7 @@ export default function AidShipmentReminder({ storeId }: { storeId: number | nul
               "items:customer_order_items!inner(qty, status, source)",
           )
           .eq("items.source", "aid_transfer")
-          .in("status", ["confirmed", "shipping"])
+          .in("status", [...AID_IN_FLIGHT_STATUSES])
           .not("transferred_from_order_id", "is", null)
           .order("created_at", { ascending: true })
           .limit(200);
@@ -99,16 +109,20 @@ export default function AidShipmentReminder({ storeId }: { storeId: number | nul
           if (src.pickup_store_id === r.pickup_store_id) return [];
           // 儀表板選了門市（分店帳號一律鎖自己那家）→ 只提醒「要出貨的是本店」
           if (storeId != null && src.pickup_store_id !== storeId) return [];
+          // 品項全被取消掉的單沒有實體貨要交，別再叫人去印一張空白單
+          const qty = (r.items ?? [])
+            .filter((it) => !["cancelled", "expired"].includes(it.status))
+            .reduce((s, it) => s + Number(it.qty), 0);
+          if (qty <= 0) return [];
           return [{
             id: r.id,
             order_no: r.order_no,
             status: r.status,
             is_air_transfer: r.is_air_transfer === true,
             dest_store: nameOf(r.store),
+            dest_store_id: r.pickup_store_id,
             source_store: nameOf(src.store),
-            qty: (r.items ?? [])
-              .filter((it) => !["cancelled", "expired"].includes(it.status))
-              .reduce((s, it) => s + Number(it.qty), 0),
+            qty,
           }];
         });
         setRows(list);
@@ -158,15 +172,19 @@ export default function AidShipmentReminder({ storeId }: { storeId: number | nul
             </span>
             <span className="text-xs text-zinc-500">{r.qty} 件</span>
             <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
-              {r.is_air_transfer ? "✈ 空中轉直送" : "🏬 經總倉"}
-              {r.status === "confirmed" ? "・等派貨" : "・已出貨待收"}
+              {aidRouteLabel(r.is_air_transfer)}・{aidStageLabel(r.status, r.is_air_transfer)}
             </span>
             {printed.has(r.id) && (
               <span className="text-[11px] text-emerald-600 dark:text-emerald-400">✓ 已列印</span>
             )}
             <div className="ml-auto flex items-center gap-2">
               <Link
-                href={`/orders?q=${encodeURIComponent(r.order_no)}`}
+                // 一定要帶 storeId=收貨店：訂單列表的門市篩選對分店帳號會預設帶回自家店，
+                // 而這張轉入單掛在收貨店名下 —— 不帶就會搜出 0 筆（看起來像貨消失了）
+                href={
+                  `/orders?q=${encodeURIComponent(r.order_no)}` +
+                  (r.dest_store_id != null ? `&storeId=${r.dest_store_id}` : "")
+                }
                 className="text-xs text-blue-600 hover:underline dark:text-blue-400"
               >
                 查看訂單

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -1500,18 +1500,20 @@ export function OrderDetail({
                   {aidRouteLabel(o.is_air_transfer)}・{aidStageLabel(o.status, o.is_air_transfer)}
                 </span>
                 <span className="text-zinc-500">{fmtDt(o.created_at)}</span>
-                {isAidInFlight(o.status) && (
-                  <SpinButton
-                    onClick={() => printViaIframe(withBasePath(`/transfers/print-aid?order_id=${o.id}`))}
-                    className="ml-auto rounded-md border border-fuchsia-300 px-2 py-1 text-[11px] font-medium text-fuchsia-700 hover:bg-fuchsia-50 dark:border-fuchsia-800 dark:text-fuchsia-300 dark:hover:bg-fuchsia-950"
-                    title={
-                      `列印互助出貨單（${o.order_no}）：隨貨聯夾在箱子上，` +
-                      `${o.is_air_transfer ? "" : "總倉、"}${o.store_name}照單點收簽名`
-                    }
-                  >
-                    🖨 出貨單
-                  </SpinButton>
-                )}
+                {/* 每一筆都能印（含已收貨 / 已取消的舊單）—— 事後補一張歸檔、對帳
+                    是店家的日常，不要只給還在路上的那幾張 */}
+                <SpinButton
+                  onClick={() => printViaIframe(withBasePath(`/transfers/print-aid?order_id=${o.id}`))}
+                  className="ml-auto rounded-md border border-fuchsia-300 px-2 py-1 text-[11px] font-medium text-fuchsia-700 hover:bg-fuchsia-50 dark:border-fuchsia-800 dark:text-fuchsia-300 dark:hover:bg-fuchsia-950"
+                  title={
+                    isAidInFlight(o.status)
+                      ? `列印互助出貨單（${o.order_no}）：隨貨聯夾在箱子上，` +
+                        `${o.is_air_transfer ? "" : "總倉、"}${o.store_name}照單點收簽名`
+                      : `補印互助出貨單（${o.order_no}・${o.store_name}）`
+                  }
+                >
+                  🖨 出貨單
+                </SpinButton>
               </li>
             ))}
           </ul>

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -19,6 +19,7 @@ import { summarizeOrderSource } from "@/lib/orderSource";
 import { ItemSourceBadge, OrderSourceBadge } from "@/components/OrderSourceBadge";
 import { withBasePath } from "@/lib/basePath";
 import { printViaIframe } from "@/lib/printIframe";
+import { aidRouteLabel, aidStageLabel, isAidInFlight } from "@/lib/aidTransfer";
 import { internalOrderSource } from "@/lib/orderTitle";
 import { translateRpcError } from "@/lib/rpcError";
 import { parseReturnNote } from "@/lib/returnNote";
@@ -99,14 +100,25 @@ type PendingAirShipment = {
   qty: number;
 };
 
-// 從本單互助 / 空中轉出去、貨還在路上的轉入單（給轉出店印出貨單隨貨走）。
-// 跟 PendingAirShipment 不同：不限空中轉、也不限 confirmed —— 經總倉的互助派貨後
-// 是 shipping，那才是最需要印單的時候（總倉要照單把貨轉給收貨店）。
+// 從本單互助 / 空中轉出去的轉入單（本單 → 別家店）。
+// 跟 PendingAirShipment 不同：不限空中轉、也不限 confirmed —— 經總倉的轉入單一開始
+// 是 pending（等總倉收）、派貨後才 shipping，兩段都是轉出店要印單隨貨走的時候。
+//
+// 這裡**收全部狀態**（含已收貨 / 已取貨的舊單）當「轉出記錄」給轉出店看：
+// 轉入單掛在收貨店名下，轉出店的訂單列表一列都撈不到，來源單上不寫就等於
+// 「貨從店裡出去了、系統上查無此事」（2026-08-18 南平→三峽）。
+// 頂部那排列印鈕另外只取還在路上的（isAidInFlight），不用舊單洗版。
 type OutgoingAidOrder = {
   id: number;
   order_no: string;
+  // 收貨店 —— 連到訂單列表時一定要一起帶（列表的門市篩選對分店帳號會預設帶回自家店，
+  // 不帶就會搜出 0 筆，看起來像貨憑空消失）
+  store_id: number | null;
   store_name: string;
   is_air_transfer: boolean;
+  status: string;
+  qty: number;
+  created_at: string;
 };
 
 // 品項狀態標籤（部分取貨會把一行拆成「已取」+「待取」兩行，標籤讓兩者一眼可分）
@@ -286,13 +298,17 @@ export function OrderDetail({
           .select("item_id, pickup_ready")
           .eq("order_id", orderId),
         fetchReprintableEvents([orderId]),
-        // 從本單互助 / 空中轉出去的轉入單。兩個用途：
+        // 從本單互助 / 空中轉出去的轉入單。三個用途：
         //   1. 還卡在 confirmed 的空中轉 → 「✈ 補出貨」（自動出貨上線前的舊單，
         //      空中轉不經總倉，補推要由轉出店＝正在看本單的人按下，否則沒人有入口）
-        //   2. 貨還沒交到客人手上的（含經總倉、含已出貨）→ 「🖨 出貨單」隨貨走
+        //   2. 收貨店還沒收到的（pending/confirmed/shipping）→ 「🖨 出貨單」隨貨走
+        //   3. 全部（含已收貨、已取消）→ 下方的「↗ 轉出記錄」。轉入單掛在收貨店名下，
+        //      轉出店的訂單列表撈不到，不在這裡寫出來就等於系統上查無此事
+        // 反查 transferred_from_order_id，不要用 transferred_to_order_id：部分轉出不寫那一欄
         sb.from("customer_orders")
-          .select("id, order_no, pickup_store_id, status, is_air_transfer, store:stores!customer_orders_pickup_store_id_fkey(name), items:customer_order_items(qty, status, source)")
-          .eq("transferred_from_order_id", orderId),
+          .select("id, order_no, pickup_store_id, status, is_air_transfer, created_at, store:stores!customer_orders_pickup_store_id_fkey(name), items:customer_order_items(qty, status, source)")
+          .eq("transferred_from_order_id", orderId)
+          .order("created_at", { ascending: false }),
       ]);
       if (cancelled) return;
       if (hRes.error) { setError(hRes.error.message); return; }
@@ -313,7 +329,7 @@ export function OrderDetail({
       // ========== 從本單轉出去的互助 / 空中轉（本單 → 其他店）==========
       type AirRow = {
         id: number; order_no: string; pickup_store_id: number | null;
-        status: string; is_air_transfer: boolean | null;
+        status: string; is_air_transfer: boolean | null; created_at: string;
         store: { name: string } | { name: string }[] | null;
         items: { qty: number; status: string; source: string | null }[] | null;
       };
@@ -338,16 +354,21 @@ export function OrderDetail({
               .reduce((s, it) => s + Number(it.qty), 0),
           })),
       );
-      // 出貨單入口：貨還在路上（未取貨、未取消）的才印，已完成的舊單不用洗版
+      // 轉出記錄：全部留著（含已取消的，店家要看得出「那批貨後來怎麼了」）。
+      // 頂部的列印鈕另外只取還在路上的那幾張。
       setOutgoingAid(
-        childRows
-          .filter((r) => ["pending", "confirmed", "shipping", "ready", "partially_completed"].includes(r.status))
-          .map((r): OutgoingAidOrder => ({
-            id: r.id,
-            order_no: r.order_no,
-            store_name: storeNameOf(r),
-            is_air_transfer: r.is_air_transfer === true,
-          })),
+        childRows.map((r): OutgoingAidOrder => ({
+          id: r.id,
+          order_no: r.order_no,
+          store_id: r.pickup_store_id,
+          store_name: storeNameOf(r),
+          is_air_transfer: r.is_air_transfer === true,
+          status: r.status,
+          created_at: r.created_at,
+          qty: (r.items ?? [])
+            .filter((it) => it.source === "aid_transfer" && !["cancelled", "expired"].includes(it.status))
+            .reduce((s, it) => s + Number(it.qty), 0),
+        })),
       );
 
       // 本單自己就是等出貨的空中轉轉入單 → 讓接收店看得到在等哪一家出貨
@@ -618,6 +639,10 @@ export function OrderDetail({
 
   // 互助單：有來源單 + 至少一個 aid_transfer 品項（對齊 rpc_return_aid_order 的判定）
   const isAidOrder = head.transferred_from_order_id != null && items.some((it) => it.source === "aid_transfer");
+  // 還在路上（收貨店還沒收）的轉出單 —— 頂部的「🖨 出貨單」鈕只掛這幾張，
+  // 已收貨 / 已取消的舊單留在下面「轉出記錄」區塊即可
+  const outgoingAidInFlight = outgoingAid.filter((o) => isAidInFlight(o.status));
+  const totalOutgoingQty = outgoingAid.reduce((s, o) => s + o.qty, 0);
   // 跨店轉單要等到貨（status='ready'）；同店換客人到貨前也可轉
   // (跟 DB rpc_transfer_order_* 20260814000020 的 gate 一致；modal 會鎖定接收店＝原店)
   const transferBeforeArrival = ["pending", "confirmed", "reserved", "shipping"].includes(head.status);
@@ -893,7 +918,7 @@ export function OrderDetail({
           </SpinButton>
         </div>
       )}
-      {(canPrintSlip || canReprintReceipt || canTransfer || canPickup || canUndoPickup || canCancel || canRestoreCancel || canReturn || canAidReturn || isTransferredOut || pendingAirOut.length > 0 || outgoingAid.length > 0 || awaitingAirFrom) && (
+      {(canPrintSlip || canReprintReceipt || canTransfer || canPickup || canUndoPickup || canCancel || canRestoreCancel || canReturn || canAidReturn || isTransferredOut || pendingAirOut.length > 0 || outgoingAidInFlight.length > 0 || awaitingAirFrom) && (
         <div className="flex flex-wrap items-center justify-end gap-2">
           {awaitingAirFrom && (
             <span className="text-xs text-amber-700 dark:text-amber-400">
@@ -912,7 +937,7 @@ export function OrderDetail({
           )}
           {/* 本單把貨互助給別店 → 轉出店裝箱時印一張夾在貨上，
               經總倉的單上面就寫著最終要送到哪一家店，總倉照單轉交、不會掉 */}
-          {outgoingAid.map((o) => (
+          {outgoingAidInFlight.map((o) => (
             <SpinButton
               key={`aid-print-${o.id}`}
               onClick={() => printViaIframe(withBasePath(`/transfers/print-aid?order_id=${o.id}`))}
@@ -1436,6 +1461,63 @@ export function OrderDetail({
         </div>
       )}
 
+      {/* 轉出記錄（本單 → 別家店）。轉入單掛在收貨店名下、轉出店的訂單列表撈不到，
+          不在來源單上寫出來，貨從店裡出去就等於系統上查無此事（2026-08-18 南平→三峽）。 */}
+      {outgoingAid.length > 0 && (
+        <div className="rounded-md border border-fuchsia-200 dark:border-fuchsia-900">
+          <div className="border-b border-fuchsia-200 bg-fuchsia-50 px-3 py-2 text-xs font-medium text-fuchsia-900 dark:border-fuchsia-900 dark:bg-fuchsia-950/40 dark:text-fuchsia-200">
+            ↗ 轉出記錄（{outgoingAid.length} 張單 · 共 {totalOutgoingQty} 件）
+            <span className="ml-2 font-normal">貨從本店出去，隨貨的出貨單在這裡印</span>
+          </div>
+          <ul className="divide-y divide-zinc-200 dark:divide-zinc-800">
+            {outgoingAid.map((o) => (
+              <li key={`aid-out-${o.id}`} className="flex flex-wrap items-center gap-x-3 gap-y-1 p-3 text-xs">
+                {onNavigate ? (
+                  <button
+                    type="button"
+                    onClick={() => onNavigate(o.id, o.order_no)}
+                    className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                    title="開啟轉入單"
+                  >
+                    {o.order_no}
+                  </button>
+                ) : (
+                  <a
+                    href={withBasePath(
+                      `/orders?q=${encodeURIComponent(o.order_no)}` +
+                      (o.store_id != null ? `&storeId=${o.store_id}` : ""),
+                    )}
+                    className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {o.order_no}
+                  </a>
+                )}
+                <span className="font-medium">
+                  → {o.is_air_transfer ? "" : "總倉 → "}{o.store_name}
+                </span>
+                <span className="font-mono">{o.qty} 件</span>
+                <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+                  {aidRouteLabel(o.is_air_transfer)}・{aidStageLabel(o.status, o.is_air_transfer)}
+                </span>
+                <span className="text-zinc-500">{fmtDt(o.created_at)}</span>
+                {isAidInFlight(o.status) && (
+                  <SpinButton
+                    onClick={() => printViaIframe(withBasePath(`/transfers/print-aid?order_id=${o.id}`))}
+                    className="ml-auto rounded-md border border-fuchsia-300 px-2 py-1 text-[11px] font-medium text-fuchsia-700 hover:bg-fuchsia-50 dark:border-fuchsia-800 dark:text-fuchsia-300 dark:hover:bg-fuchsia-950"
+                    title={
+                      `列印互助出貨單（${o.order_no}）：隨貨聯夾在箱子上，` +
+                      `${o.is_air_transfer ? "" : "總倉、"}${o.store_name}照單點收簽名`
+                    }
+                  >
+                    🖨 出貨單
+                  </SpinButton>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       {/* 進度 timeline（採購到貨 → 撿貨 → 派貨 → 分店收貨） */}
       <Timeline steps={timeline} />
 
@@ -1464,10 +1546,22 @@ export function OrderDetail({
             variant_name: it.sku?.variant_name ?? null,
             sku_code: it.sku?.sku_code ?? null,
           }))}
-        onSubmitted={(newId) => {
+        onSubmitted={(r) => {
           setTransferOpen(false);
-          alert(`轉出完成 → 訂單 #${newId}（部分轉出時原單保留未轉出品項）`);
           setReloadTick((n) => n + 1);
+          if (!r.crossStore) {
+            // 同店換客人：貨沒離開本店，沒有隨貨單要印
+            alert(`轉出完成 → 訂單 #${r.newOrderId}（部分轉出時原單保留未轉出品項）`);
+            return;
+          }
+          // 跨店＝貨要離開本店，裝箱當下就該把隨貨單印出來夾在箱子上。
+          // 事後才想到要印的話，本單下方的「↗ 轉出記錄」還可以再印一次。
+          const ok = confirm(
+            `轉出完成 → ${r.toStoreName}（部分轉出時原單保留未轉出品項）\n\n` +
+            `要現在列印互助出貨單嗎？\n` +
+            `隨貨聯夾在箱子上，${r.isAir ? "" : "總倉、"}${r.toStoreName} 照單點收簽名。`,
+          );
+          if (ok) void printViaIframe(withBasePath(`/transfers/print-aid?order_id=${r.newOrderId}`));
         }}
       />
       <PickupDialog

--- a/apps/admin/src/components/OrderTransferModal.tsx
+++ b/apps/admin/src/components/OrderTransferModal.tsx
@@ -26,6 +26,15 @@ type MemberHit = {
   admin_note: string | null;
 };
 
+// 轉出結果 —— 呼叫端要知道貨有沒有離開本店（跨店才需要印隨貨的互助出貨單）
+export type TransferResult = {
+  newOrderId: number;
+  toStoreId: number;
+  toStoreName: string;
+  isAir: boolean;
+  crossStore: boolean;
+};
+
 function itemLabel(it: TransferItem): string {
   const base = it.product_name ?? `SKU #${it.sku_id}`;
   return it.variant_name ? `${base} / ${it.variant_name}` : base;
@@ -51,7 +60,7 @@ export function OrderTransferModal({
   items: TransferItem[];
   open: boolean;
   onClose: () => void;
-  onSubmitted: (newOrderId: number) => void;
+  onSubmitted: (result: TransferResult) => void;
   // 貨還沒到店（status != 'ready'）只能同店換客人：接收店鎖定原店
   // (跟 DB rpc_transfer_order_* 20260807000000 的 gate 一致)
   sameStoreOnly?: boolean;
@@ -226,7 +235,13 @@ export function OrderTransferModal({
         if (e) throw new Error(e.message);
         newId = data as number;
       }
-      onSubmitted(newId);
+      onSubmitted({
+        newOrderId: newId,
+        toStoreId: Number(toStore),
+        toStoreName: stores.find((s) => s.id === Number(toStore))?.name ?? "接收店",
+        isAir: airFlag,
+        crossStore: toStore !== currentPickupStoreId,
+      });
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {

--- a/apps/admin/src/lib/aidTransfer.ts
+++ b/apps/admin/src/lib/aidTransfer.ts
@@ -1,0 +1,52 @@
+// 互助 / 轉單（訂單轉給別店）在「轉出店」視角的階段文字與狀態集合。
+//
+// 為什麼要收在同一支：轉出店的貨走到哪裡，這個判斷散在三個地方（儀表板提醒、
+// 來源訂單的轉出記錄、來源訂單的列印鈕）。分開寫的後果 2026-08-18 已經發生過一次
+// —— 儀表板只認 confirmed/shipping，而**經總倉的轉入單一開始是 `pending`**
+// （rpc_transfer_order_to_store / _partial：跨店非空中轉一律建成 pending，
+// 要等總倉在 /hq/inbox 收到貨才推 confirmed）。結果轉出店在「貨還在自己手上、
+// 最需要印隨貨單」的那一段完全收不到提醒。
+//
+// 空中轉不同：轉單當下就自動出貨（20260814030000），轉入單直接進 shipping，
+// confirmed 只會是自動出貨上線前卡住的舊單。
+
+// 「貨還沒交到收貨店手上」的轉入單狀態 —— 轉出店還需要為它做事（印單、交貨）。
+// pending 一定要在裡面，見上面。
+export const AID_IN_FLIGHT_STATUSES = ["pending", "confirmed", "shipping"] as const;
+
+export function isAidInFlight(status: string): boolean {
+  return (AID_IN_FLIGHT_STATUSES as readonly string[]).includes(status);
+}
+
+// 路徑（貨怎麼走）
+export function aidRouteLabel(isAir: boolean): string {
+  return isAir ? "✈ 空中轉直送" : "🏬 經總倉";
+}
+
+// 轉出店視角的階段文字。收貨店收掉（ready）之後轉出店就沒事了，但記錄還是要看得懂。
+export function aidStageLabel(status: string, isAir: boolean): string {
+  switch (status) {
+    case "pending":
+      return isAir ? "等出貨" : "等總倉收貨";
+    case "confirmed":
+      return isAir ? "等出貨" : "總倉已收・等派貨";
+    case "reserved":
+      return "已保留";
+    case "shipping":
+      return isAir ? "已出貨・等收貨店收" : "總倉已派貨・等收貨店收";
+    case "ready":
+      return "收貨店已收貨";
+    case "partially_completed":
+      return "收貨店部分取貨";
+    case "completed":
+      return "收貨店已取貨";
+    case "cancelled":
+      return "已取消";
+    case "expired":
+      return "已逾期";
+    case "transferred_out":
+      return "已再轉出";
+    default:
+      return status;
+  }
+}


### PR DESCRIPTION
## 概述

互助轉單（跨店轉給別家分店）的轉出店視角補齊三個缺口：

1. **經總倉的轉入單一開始是 `pending`，不是 `confirmed`** —— 儀表板提醒與列印鈕都漏掉了「貨還在自己手上」的那一段，導致轉出店看不到提醒、找不到隨貨單可印（2026-08-18 南平→三峽）
2. **轉入單掛在收貨店名下，轉出店的訂單列表撈不到** —— 來源訂單上要自己寫出「轉出記錄」，否則貨從店裡出去 = 系統上查無此事
3. **互助交流板單則列印** —— 店家常常事後要補一張紙歸檔或跟對方對帳，新增 `?id=<board_id>` 模式列印單張貼文（A4 直式）含留言與簽收欄

## 主要改動

### 互助轉單狀態與提醒

- **新增 `apps/admin/src/lib/aidTransfer.ts`**：集中管理轉出店視角的狀態判定
  - `AID_IN_FLIGHT_STATUSES = ['pending', 'confirmed', 'shipping']` —— 貨還沒交到收貨店手上的狀態
  - `aidRouteLabel()` / `aidStageLabel()` —— 路徑與階段文字（區分空中轉 vs 經總倉、pending 時的語意差異）
  
- **`AidShipmentReminder.tsx`**：儀表板提醒改為雙向視角
  - 轉出（本店要交出去）與轉入（本店在等的貨）分開列示，各自有不同的色調與提示文字
  - 查詢改為全 tenant 撈一次，方向與門市過濾在 render 時做（換門市不需重打）
  - 轉出方顯示「✓ 已列印」標記；轉入方顯示「去收貨」連結
  - 連到訂單列表時一定帶 `&storeId=<收貨店>`（否則分店帳號會預設帶回自家店、搜出 0 筆）

### 訂單詳情頁的轉出記錄

- **`OrderDetail.tsx`**：新增「↗ 轉出記錄」區塊
  - 反查 `transferred_from_order_id = 本單` 列出所有轉出去的轉入單（含已收貨 / 已取消的舊單）
  - 每一筆都能印出貨單（事後補印歸檔是店家日常）
  - 頂部的「🖨 出貨單」列印鈕另外只取還在路上的（`isAidInFlight`），不用舊單洗版
  - 轉出結果新增 `TransferResult` 型別，包含收貨店 ID 與是否跨店等資訊

### 互助交流板單則列印

- **`/inventory/mutual-aid/print/page.tsx`**：新增單則模式（`?id=<board_id>`）
  - 清單模式（`?type=all|request|offer`）保持

https://claude.ai/code/session_01BpwAFd3vUuKGc8uGdNBfjn