### PR TITLE
Optimize RLS policies and picking wave joins for performance

### DIFF
--- a/supabase/migrations/20260818000020_rls_initplan_wrap.sql
+++ b/supabase/migrations/20260818000020_rls_initplan_wrap.sql
@@ -1,0 +1,770 @@
+-- ============================================================================
+-- 2026-08-18: RLS policy 的 auth.jwt() 提升成 InitPlan（每查詢一次，不要每列一次）
+--
+-- 症狀：全站「什麼都慢」。線上 pg_stat_statements（3 小時視窗）裡幾乎每一支
+--   PostgREST 查詢的成本都跟掃過的列數等比成長，連只有 22,212 列 / 4.3MB 的
+--   stock_balances 列表都要 3.5 秒（max 5.5s）。
+--
+-- 原因：policy 的 USING / WITH CHECK 直接寫 `auth.jwt()`。auth.jwt() 是 STABLE
+--   不是 IMMUTABLE，寫在裸運算式裡時 planner 無法提出去，於是**每一列都重跑一次**
+--   `current_setting('request.jwt.claims')::jsonb` —— 也就是每列都把 JWT 的 JSON
+--   字串重新 parse 一遍。stock_balances 的 policy 一列要跑 6 次這個運算式，
+--   再加上每列呼叫一次 _jwt_store_location_ids()。
+--
+--   實測（authenticated + admin claims，熱快取）：
+--     SELECT ... FROM stock_balances ORDER BY last_movement_at DESC LIMIT 50
+--       修正前：156.9 ms，shared hit=18,018
+--       修正後： 17.5 ms，shared hit=   306      ← 9 倍 / buffer 59 倍
+--
+-- 修法：把 auth.jwt() / auth.uid() / auth.role() / _jwt_store_ids() /
+--   _jwt_store_location_ids() 包進 scalar subquery `(SELECT ...)`。Postgres 會把
+--   它變成 InitPlan，整個查詢只求值一次。這是 Supabase 官方 linter
+--   `auth_rls_initplan` 指的同一件事。
+--
+--   `= ANY(<回傳陣列的函式>)` 要特別處理：`= ANY ((SELECT f()))` 會被當成
+--   ANY(subquery) 而報 `operator does not exist: bigint = bigint[]`，所以寫成
+--   `= ANY (COALESCE((SELECT f()), '{}'::bigint[]))` —— 包一層 COALESCE 之後
+--   parser 才會走陣列語意。（4 條 policy 用到：restock_requests / stock_balances /
+--   stock_movements / store_settlement_disputes）
+--
+-- 語意不變，這裡逐條驗證過：
+--   在一個 transaction 內先以舊 policy、再以新 policy，對 103 張受影響的表 ×
+--   9 種身分（admin / owner / hq_manager / store_manager / store_staff / clerk /
+--   warehouse / legacy_admin(role='') / 無 claims）各數一次可見列數，
+--   共 927 組比對 → **mismatch 0、error 0**。
+--
+-- 基底版本：本檔的 169 條 policy 全部是從**線上 pg_catalog 現況**
+--   （pg_policies.qual / with_check）產生的，不是從 repo 的 migration 重寫，
+--   所以歷來散落在各 migration 的修正（例如 20260502010000 / 20260807000040
+--   的 app_metadata role path、legacy admin 的 '' 允許值）都逐字保留。
+--   ⚠ 若在本檔套用之前線上又改過任何 policy，要重新產生一次再套。
+--
+-- Rollback：把 (SELECT auth.xxx()) 改回 auth.xxx()、
+--   ANY (COALESCE((SELECT f()), '{}'::bigint[])) 改回 ANY (f())。
+--   純效能改動，不還原也不影響正確性。
+--
+-- 沒有對應的前端改動。
+-- ============================================================================
+
+DROP POLICY IF EXISTS clr_owner_write ON public.aid_clearance_offers;
+CREATE POLICY clr_owner_write ON public.aid_clearance_offers AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text])))));
+
+DROP POLICY IF EXISTS clr_read_all ON public.aid_clearance_offers;
+CREATE POLICY clr_read_all ON public.aid_clearance_offers AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS bo_hq_all ON public.backorders;
+CREATE POLICY bo_hq_all ON public.backorders AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS bo_store_read ON public.backorders;
+CREATE POLICY bo_store_read ON public.backorders AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS read_tenant_barcodes ON public.barcodes;
+CREATE POLICY read_tenant_barcodes ON public.barcodes AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS read_tenant_brands ON public.brands;
+CREATE POLICY read_tenant_brands ON public.brands AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS camp_audit_hq_read ON public.campaign_audit_log;
+CREATE POLICY camp_audit_hq_read ON public.campaign_audit_log AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS auth_read_campaign_channels ON public.campaign_channels;
+CREATE POLICY auth_read_campaign_channels ON public.campaign_channels AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS cc_hq_all ON public.campaign_channels;
+CREATE POLICY cc_hq_all ON public.campaign_channels AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS cfp_hq_all ON public.campaign_fb_posts;
+CREATE POLICY cfp_hq_all ON public.campaign_fb_posts AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS auth_read_campaign_items ON public.campaign_items;
+CREATE POLICY auth_read_campaign_items ON public.campaign_items AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS ci_hq_all ON public.campaign_items;
+CREATE POLICY ci_hq_all ON public.campaign_items AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
+
+DROP POLICY IF EXISTS ci_store_read ON public.campaign_items;
+CREATE POLICY ci_store_read ON public.campaign_items AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_campaign_views ON public.campaign_views;
+CREATE POLICY auth_read_campaign_views ON public.campaign_views AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS read_tenant_categories ON public.categories;
+CREATE POLICY read_tenant_categories ON public.categories AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS client_error_logs_hq_all ON public.client_error_logs;
+CREATE POLICY client_error_logs_hq_all ON public.client_error_logs AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'hq'::text)));
+
+DROP POLICY IF EXISTS ccp_hq_all ON public.community_product_candidates;
+CREATE POLICY ccp_hq_all ON public.community_product_candidates AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'assistant'::text, ''::text]))))
+  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'assistant'::text, ''::text]))));
+
+DROP POLICY IF EXISTS auth_read_customer_line_aliases ON public.customer_line_aliases;
+CREATE POLICY auth_read_customer_line_aliases ON public.customer_line_aliases AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS cla_hq_all ON public.customer_line_aliases;
+CREATE POLICY cla_hq_all ON public.customer_line_aliases AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS cla_store_access ON public.customer_line_aliases;
+CREATE POLICY cla_store_access ON public.customer_line_aliases AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (channel_id IN ( SELECT line_channels.id
+   FROM line_channels
+  WHERE (line_channels.home_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
+
+DROP POLICY IF EXISTS coa_hq_read ON public.customer_order_audit_log;
+CREATE POLICY coa_hq_read ON public.customer_order_audit_log AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE(NULLIF((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text), NULLIF(((SELECT auth.jwt()) ->> 'role'::text), 'authenticated'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, ''::text]))));
+
+DROP POLICY IF EXISTS coa_store_read ON public.customer_order_audit_log;
+CREATE POLICY coa_store_read ON public.customer_order_audit_log AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((EXISTS ( SELECT 1
+   FROM jsonb_array_elements_text(COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) -> 'stores'::text), '[]'::jsonb)) s(name)
+  WHERE (s.name = '總倉'::text))) OR (order_id IN ( SELECT co.id
+   FROM (customer_orders co
+     JOIN stores st ON ((st.id = co.pickup_store_id)))
+  WHERE ((st.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (st.name IN ( SELECT jsonb_array_elements_text(COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) -> 'stores'::text), '[]'::jsonb)) AS jsonb_array_elements_text))))))));
+
+DROP POLICY IF EXISTS auth_read_customer_order_items ON public.customer_order_items;
+CREATE POLICY auth_read_customer_order_items ON public.customer_order_items AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS coi_hq_all ON public.customer_order_items;
+CREATE POLICY coi_hq_all ON public.customer_order_items AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS coi_store_access ON public.customer_order_items;
+CREATE POLICY coi_store_access ON public.customer_order_items AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (order_id IN ( SELECT customer_orders.id
+   FROM customer_orders
+  WHERE (customer_orders.pickup_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
+
+DROP POLICY IF EXISTS cos_hq_read ON public.customer_order_sources;
+CREATE POLICY cos_hq_read ON public.customer_order_sources AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS auth_read_customer_orders ON public.customer_orders;
+CREATE POLICY auth_read_customer_orders ON public.customer_orders AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS corders_hq_all ON public.customer_orders;
+CREATE POLICY corders_hq_all ON public.customer_orders AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS corders_store_access ON public.customer_orders;
+CREATE POLICY corders_store_access ON public.customer_orders AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (pickup_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS dr_hq_all ON public.demand_requests;
+CREATE POLICY dr_hq_all ON public.demand_requests AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS dr_store_own ON public.demand_requests;
+CREATE POLICY dr_store_own ON public.demand_requests AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (requester_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS ec_admin_write ON public.expense_categories;
+CREATE POLICY ec_admin_write ON public.expense_categories AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS ec_read_all ON public.expense_categories;
+CREATE POLICY ec_read_all ON public.expense_categories AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS exp_admin_all ON public.expenses;
+CREATE POLICY exp_admin_all ON public.expenses AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
+
+DROP POLICY IF EXISTS exp_applicant ON public.expenses;
+CREATE POLICY exp_applicant ON public.expenses AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (applicant_id = (((SELECT auth.jwt()) ->> 'sub'::text))::uuid)));
+
+DROP POLICY IF EXISTS eoi_hq_all ON public.external_order_imports;
+CREATE POLICY eoi_hq_all ON public.external_order_imports AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS epi_admin_all ON public.external_purchase_imports;
+CREATE POLICY epi_admin_all ON public.external_purchase_imports AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
+
+DROP POLICY IF EXISTS fb_pages_hq_all ON public.fb_pages;
+CREATE POLICY fb_pages_hq_all ON public.fb_pages AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS gr_warehouse ON public.goods_receipts;
+CREATE POLICY gr_warehouse ON public.goods_receipts AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'warehouse'::text) AND (dest_location_id = (((SELECT auth.jwt()) ->> 'location_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS auth_read_group_buy_campaigns ON public.group_buy_campaigns;
+CREATE POLICY auth_read_group_buy_campaigns ON public.group_buy_campaigns AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS gbc_hq_all ON public.group_buy_campaigns;
+CREATE POLICY gbc_hq_all ON public.group_buy_campaigns AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
+
+DROP POLICY IF EXISTS gbc_store_read ON public.group_buy_campaigns;
+CREATE POLICY gbc_store_read ON public.group_buy_campaigns AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (status = ANY (ARRAY['open'::text, 'closed'::text, 'locked'::text, 'ordered'::text, 'receiving'::text, 'ready'::text, 'completed'::text]))));
+
+DROP POLICY IF EXISTS p_lele_imports_tenant_read ON public.lele_order_imports;
+CREATE POLICY p_lele_imports_tenant_read ON public.lele_order_imports AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS p_lele_imports_tenant_write ON public.lele_order_imports;
+CREATE POLICY p_lele_imports_tenant_write ON public.lele_order_imports AS PERMISSIVE FOR INSERT TO public
+  WITH CHECK ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_line_channels ON public.line_channels;
+CREATE POLICY auth_read_line_channels ON public.line_channels AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS lc_hq_all ON public.line_channels;
+CREATE POLICY lc_hq_all ON public.line_channels AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS lc_store_read ON public.line_channels;
+CREATE POLICY lc_store_read ON public.line_channels AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (home_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS line_push_logs_tenant_read ON public.line_push_logs;
+CREATE POLICY line_push_logs_tenant_read ON public.line_push_logs AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_locations ON public.locations;
+CREATE POLICY auth_read_locations ON public.locations AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_member_cards ON public.member_cards;
+CREATE POLICY auth_read_member_cards ON public.member_cards AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_member_imports ON public.member_imports;
+CREATE POLICY auth_read_member_imports ON public.member_imports AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS mi_hq_all ON public.member_imports;
+CREATE POLICY mi_hq_all ON public.member_imports AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS mlb_hq_all ON public.member_line_bindings;
+CREATE POLICY mlb_hq_all ON public.member_line_bindings AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'hq'::text)));
+
+DROP POLICY IF EXISTS mlb_self_read ON public.member_line_bindings;
+CREATE POLICY mlb_self_read ON public.member_line_bindings AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (member_id = (NULLIF(((SELECT auth.jwt()) ->> 'member_id'::text), ''::text))::bigint)));
+
+DROP POLICY IF EXISTS mlb_store_read ON public.member_line_bindings;
+CREATE POLICY mlb_store_read ON public.member_line_bindings AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (store_id = (NULLIF(((SELECT auth.jwt()) ->> 'store_id'::text), ''::text))::bigint) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['store_manager'::text, 'store_staff'::text]))));
+
+DROP POLICY IF EXISTS auth_read_member_merges ON public.member_merges;
+CREATE POLICY auth_read_member_merges ON public.member_merges AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_member_points_balance ON public.member_points_balance;
+CREATE POLICY auth_read_member_points_balance ON public.member_points_balance AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_member_tiers ON public.member_tiers;
+CREATE POLICY auth_read_member_tiers ON public.member_tiers AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_members ON public.members;
+CREATE POLICY auth_read_members ON public.members AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS hq_read_members ON public.members;
+CREATE POLICY hq_read_members ON public.members AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'marketer'::text]))));
+
+DROP POLICY IF EXISTS store_read_members ON public.members;
+CREATE POLICY store_read_members ON public.members AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['store_manager'::text, 'clerk'::text])) AND (home_store_id = (((SELECT auth.jwt()) ->> 'location_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS aid_board_owner_delete ON public.mutual_aid_board;
+CREATE POLICY aid_board_owner_delete ON public.mutual_aid_board AS PERMISSIVE FOR DELETE TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text])))));
+
+DROP POLICY IF EXISTS aid_board_owner_insert ON public.mutual_aid_board;
+CREATE POLICY aid_board_owner_insert ON public.mutual_aid_board AS PERMISSIVE FOR INSERT TO public
+  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text])))));
+
+DROP POLICY IF EXISTS aid_board_owner_update ON public.mutual_aid_board;
+CREATE POLICY aid_board_owner_update ON public.mutual_aid_board AS PERMISSIVE FOR UPDATE TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text])))))
+  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text])))));
+
+DROP POLICY IF EXISTS aid_board_read_all ON public.mutual_aid_board;
+CREATE POLICY aid_board_read_all ON public.mutual_aid_board AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND can_see_aid_post(offering_store_id, spot_visible_to_other_stores)));
+
+DROP POLICY IF EXISTS aid_claims_hq_all ON public.mutual_aid_claims;
+CREATE POLICY aid_claims_hq_all ON public.mutual_aid_claims AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS aid_claims_store_read ON public.mutual_aid_claims;
+CREATE POLICY aid_claims_store_read ON public.mutual_aid_claims AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((claiming_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (board_id IN ( SELECT mutual_aid_board.id
+   FROM mutual_aid_board
+  WHERE (mutual_aid_board.offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint))))));
+
+DROP POLICY IF EXISTS replies_authenticated_insert ON public.mutual_aid_replies;
+CREATE POLICY replies_authenticated_insert ON public.mutual_aid_replies AS PERMISSIVE FOR INSERT TO public
+  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (author_id = (SELECT auth.uid()))));
+
+DROP POLICY IF EXISTS replies_read_all ON public.mutual_aid_replies;
+CREATE POLICY replies_read_all ON public.mutual_aid_replies AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (EXISTS ( SELECT 1
+   FROM mutual_aid_board b
+  WHERE ((b.id = mutual_aid_replies.board_id) AND can_see_aid_post(b.offering_store_id, b.spot_visible_to_other_stores))))));
+
+DROP POLICY IF EXISTS notifications_hq_all ON public.notifications;
+CREATE POLICY notifications_hq_all ON public.notifications AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'hq'::text)));
+
+DROP POLICY IF EXISTS notifications_self_all ON public.notifications;
+CREATE POLICY notifications_self_all ON public.notifications AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (member_id = (((SELECT auth.jwt()) ->> 'member_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS oee_hq_all ON public.order_expiry_events;
+CREATE POLICY oee_hq_all ON public.order_expiry_events AS PERMISSIVE FOR ALL TO authenticated
+  USING (((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text) = 'hq'::text));
+
+DROP POLICY IF EXISTS oee_store_read ON public.order_expiry_events;
+CREATE POLICY oee_store_read ON public.order_expiry_events AS PERMISSIVE FOR SELECT TO authenticated
+  USING (((tenant_id = ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'tenant_id'::text))::uuid) AND (order_id IN ( SELECT customer_orders.id
+   FROM customer_orders
+  WHERE (customer_orders.pickup_store_id = ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'store_id'::text))::bigint)))));
+
+DROP POLICY IF EXISTS auth_read_order_pickup_events ON public.order_pickup_events;
+CREATE POLICY auth_read_order_pickup_events ON public.order_pickup_events AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS pickup_ev_hq_read ON public.order_pickup_events;
+CREATE POLICY pickup_ev_hq_read ON public.order_pickup_events AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS pickup_ev_store_read ON public.order_pickup_events;
+CREATE POLICY pickup_ev_store_read ON public.order_pickup_events AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (pickup_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS ose_hq_all ON public.order_shortage_events;
+CREATE POLICY ose_hq_all ON public.order_shortage_events AS PERMISSIVE FOR ALL TO authenticated
+  USING (((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text) = 'hq'::text));
+
+DROP POLICY IF EXISTS ose_store_read ON public.order_shortage_events;
+CREATE POLICY ose_store_read ON public.order_shortage_events AS PERMISSIVE FOR SELECT TO authenticated
+  USING (((tenant_id = ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'tenant_id'::text))::uuid) AND (order_id IN ( SELECT customer_orders.id
+   FROM customer_orders
+  WHERE (customer_orders.pickup_store_id = ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'store_id'::text))::bigint)))));
+
+DROP POLICY IF EXISTS wl_hq_all ON public.order_waitlist;
+CREATE POLICY wl_hq_all ON public.order_waitlist AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS wl_store_read ON public.order_waitlist;
+CREATE POLICY wl_store_read ON public.order_waitlist AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (channel_id IN ( SELECT line_channels.id
+   FROM line_channels
+  WHERE (line_channels.home_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
+
+DROP POLICY IF EXISTS pca_admin_all ON public.petty_cash_accounts;
+CREATE POLICY pca_admin_all ON public.petty_cash_accounts AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
+
+DROP POLICY IF EXISTS pca_store_own ON public.petty_cash_accounts;
+CREATE POLICY pca_store_own ON public.petty_cash_accounts AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS pct_admin_all ON public.petty_cash_transactions;
+CREATE POLICY pct_admin_all ON public.petty_cash_transactions AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
+
+DROP POLICY IF EXISTS pct_store_access ON public.petty_cash_transactions;
+CREATE POLICY pct_store_access ON public.petty_cash_transactions AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (account_id IN ( SELECT petty_cash_accounts.id
+   FROM petty_cash_accounts
+  WHERE (petty_cash_accounts.store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
+
+DROP POLICY IF EXISTS pdi_hq_all ON public.picking_draft_items;
+CREATE POLICY pdi_hq_all ON public.picking_draft_items AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'assistant'::text, ''::text]))))
+  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'assistant'::text, ''::text]))));
+
+DROP POLICY IF EXISTS pd_hq_all ON public.picking_drafts;
+CREATE POLICY pd_hq_all ON public.picking_drafts AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'assistant'::text, ''::text]))))
+  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'assistant'::text, ''::text]))));
+
+DROP POLICY IF EXISTS pwal_hq_read ON public.picking_wave_audit_log;
+CREATE POLICY pwal_hq_read ON public.picking_wave_audit_log AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS pwi_hq_all ON public.picking_wave_items;
+CREATE POLICY pwi_hq_all ON public.picking_wave_items AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'warehouse'::text]))));
+
+DROP POLICY IF EXISTS pwi_store_read ON public.picking_wave_items;
+CREATE POLICY pwi_store_read ON public.picking_wave_items AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS pw_hq_all ON public.picking_waves;
+CREATE POLICY pw_hq_all ON public.picking_waves AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'warehouse'::text]))));
+
+DROP POLICY IF EXISTS pw_store_read ON public.picking_waves;
+CREATE POLICY pw_store_read ON public.picking_waves AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (id IN ( SELECT picking_wave_items.wave_id
+   FROM picking_wave_items
+  WHERE (picking_wave_items.store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
+
+DROP POLICY IF EXISTS auth_read_points_ledger ON public.points_ledger;
+CREATE POLICY auth_read_points_ledger ON public.points_ledger AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS hq_full_read_pos ON public.pos_sales;
+CREATE POLICY hq_full_read_pos ON public.pos_sales AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'accountant'::text]))));
+
+DROP POLICY IF EXISTS pos_store_scope ON public.pos_sales;
+CREATE POLICY pos_store_scope ON public.pos_sales AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (location_id = (((SELECT auth.jwt()) ->> 'location_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS auth_read_post_templates ON public.post_templates;
+CREATE POLICY auth_read_post_templates ON public.post_templates AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS pt_hq_all ON public.post_templates;
+CREATE POLICY pt_hq_all ON public.post_templates AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS read_prices_role_scoped ON public.prices;
+CREATE POLICY read_prices_role_scoped ON public.prices AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((scope = ANY (ARRAY['retail'::text, 'store'::text, 'member_tier'::text, 'promo'::text])) OR ((scope = 'cost'::text) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, ''::text]))) OR ((scope = 'branch'::text) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'store_manager'::text, ''::text]))))));
+
+DROP POLICY IF EXISTS ptm_read ON public.product_tag_map;
+CREATE POLICY ptm_read ON public.product_tag_map AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS ptr_read ON public.product_tag_rules;
+CREATE POLICY ptr_read ON public.product_tag_rules AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS pt_read ON public.product_tags;
+CREATE POLICY pt_read ON public.product_tags AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS read_tenant_products ON public.products;
+CREATE POLICY read_tenant_products ON public.products AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS read_tenant_promotions ON public.promotions;
+CREATE POLICY read_tenant_promotions ON public.promotions AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS pat_admin_all ON public.purchase_approval_thresholds;
+CREATE POLICY pat_admin_all ON public.purchase_approval_thresholds AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS pat_others_read ON public.purchase_approval_thresholds;
+CREATE POLICY pat_others_read ON public.purchase_approval_thresholds AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_purchase_order_items ON public.purchase_order_items;
+CREATE POLICY auth_read_purchase_order_items ON public.purchase_order_items AS PERMISSIVE FOR SELECT TO public
+  USING ((EXISTS ( SELECT 1
+   FROM purchase_orders po
+  WHERE ((po.id = purchase_order_items.po_id) AND (po.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid)))));
+
+DROP POLICY IF EXISTS poi_hq_all ON public.purchase_order_items;
+CREATE POLICY poi_hq_all ON public.purchase_order_items AS PERMISSIVE FOR ALL TO public
+  USING (((EXISTS ( SELECT 1
+   FROM purchase_orders po
+  WHERE ((po.id = purchase_order_items.po_id) AND (po.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid)))) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, ''::text]))));
+
+DROP POLICY IF EXISTS auth_read_purchase_orders ON public.purchase_orders;
+CREATE POLICY auth_read_purchase_orders ON public.purchase_orders AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS po_hq_all ON public.purchase_orders;
+CREATE POLICY po_hq_all ON public.purchase_orders AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, ''::text]))));
+
+DROP POLICY IF EXISTS purchase_full ON public.purchase_orders;
+CREATE POLICY purchase_full ON public.purchase_orders AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'purchaser'::text, 'accountant'::text]))));
+
+DROP POLICY IF EXISTS auth_read_prc ON public.purchase_request_campaigns;
+CREATE POLICY auth_read_prc ON public.purchase_request_campaigns AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_write_prc ON public.purchase_request_campaigns;
+CREATE POLICY auth_write_prc ON public.purchase_request_campaigns AS PERMISSIVE FOR ALL TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid))
+  WITH CHECK ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_purchase_request_items ON public.purchase_request_items;
+CREATE POLICY auth_read_purchase_request_items ON public.purchase_request_items AS PERMISSIVE FOR SELECT TO public
+  USING ((EXISTS ( SELECT 1
+   FROM purchase_requests pr
+  WHERE ((pr.id = purchase_request_items.pr_id) AND (pr.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid)))));
+
+DROP POLICY IF EXISTS pri_hq_all ON public.purchase_request_items;
+CREATE POLICY pri_hq_all ON public.purchase_request_items AS PERMISSIVE FOR ALL TO public
+  USING (((EXISTS ( SELECT 1
+   FROM purchase_requests pr
+  WHERE ((pr.id = purchase_request_items.pr_id) AND (pr.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid)))) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, ''::text]))));
+
+DROP POLICY IF EXISTS auth_read_purchase_requests ON public.purchase_requests;
+CREATE POLICY auth_read_purchase_requests ON public.purchase_requests AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS pr_helper ON public.purchase_requests;
+CREATE POLICY pr_helper ON public.purchase_requests AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'helper'::text) AND (created_by = (SELECT auth.uid()))));
+
+DROP POLICY IF EXISTS pr_hq_all ON public.purchase_requests;
+CREATE POLICY pr_hq_all ON public.purchase_requests AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, ''::text]))));
+
+DROP POLICY IF EXISTS pr_store_manager ON public.purchase_requests;
+CREATE POLICY pr_store_manager ON public.purchase_requests AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'store_manager'::text) AND (source_location_id = (((SELECT auth.jwt()) ->> 'location_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS push_subs_hq_all ON public.push_subscriptions;
+CREATE POLICY push_subs_hq_all ON public.push_subscriptions AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'hq'::text)));
+
+DROP POLICY IF EXISTS push_subs_self_all ON public.push_subscriptions;
+CREATE POLICY push_subs_self_all ON public.push_subscriptions AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (member_id = (((SELECT auth.jwt()) ->> 'member_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS hq_full_read_ar ON public.receivables;
+CREATE POLICY hq_full_read_ar ON public.receivables AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'accountant'::text]))));
+
+DROP POLICY IF EXISTS hq_admin_read ON public.reorder_rules;
+CREATE POLICY hq_admin_read ON public.reorder_rules AS PERMISSIVE FOR SELECT TO authenticated
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, 'warehouse'::text, 'reporter'::text]))));
+
+DROP POLICY IF EXISTS restock_lines_select ON public.restock_request_lines;
+CREATE POLICY restock_lines_select ON public.restock_request_lines AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (request_id IN ( SELECT restock_requests.id
+   FROM restock_requests))));
+
+DROP POLICY IF EXISTS restock_select ON public.restock_requests;
+CREATE POLICY restock_select ON public.restock_requests AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'assistant'::text, ''::text])) OR ((COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['store_manager'::text, 'store_staff'::text])) AND (requesting_store_id = ANY (COALESCE((SELECT _jwt_store_ids()), '{}'::bigint[])))))));
+
+DROP POLICY IF EXISTS hq_full_read_so ON public.sales_orders;
+CREATE POLICY hq_full_read_so ON public.sales_orders AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'accountant'::text, 'purchaser'::text]))));
+
+DROP POLICY IF EXISTS read_tenant_skus ON public.skus;
+CREATE POLICY read_tenant_skus ON public.skus AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_spot_views ON public.spot_views;
+CREATE POLICY auth_read_spot_views ON public.spot_views AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS hq_admin_read ON public.stock_balances;
+CREATE POLICY hq_admin_read ON public.stock_balances AS PERMISSIVE FOR SELECT TO authenticated
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS hq_full_read ON public.stock_balances;
+CREATE POLICY hq_full_read ON public.stock_balances AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'purchaser'::text, 'warehouse'::text, 'reporter'::text]))));
+
+DROP POLICY IF EXISTS store_read_own ON public.stock_balances;
+CREATE POLICY store_read_own ON public.stock_balances AS PERMISSIVE FOR SELECT TO authenticated
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['store_manager'::text, 'store_staff'::text, 'clerk'::text])) AND (location_id = ANY (COALESCE((SELECT _jwt_store_location_ids()), '{}'::bigint[])))));
+
+DROP POLICY IF EXISTS hq_full_read ON public.stock_movements;
+CREATE POLICY hq_full_read ON public.stock_movements AS PERMISSIVE FOR SELECT TO authenticated
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, 'warehouse'::text, 'reporter'::text]))));
+
+DROP POLICY IF EXISTS store_read_own ON public.stock_movements;
+CREATE POLICY store_read_own ON public.stock_movements AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['store_manager'::text, 'store_staff'::text, 'clerk'::text])) AND (location_id = ANY (COALESCE((SELECT _jwt_store_location_ids()), '{}'::bigint[])))));
+
+DROP POLICY IF EXISTS hq_admin_read ON public.stocktake_items;
+CREATE POLICY hq_admin_read ON public.stocktake_items AS PERMISSIVE FOR SELECT TO authenticated
+  USING (((EXISTS ( SELECT 1
+   FROM stocktakes s
+  WHERE ((s.id = stocktake_items.stocktake_id) AND (s.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid)))) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'warehouse'::text, 'purchaser'::text, 'reporter'::text]))));
+
+DROP POLICY IF EXISTS hq_admin_read ON public.stocktakes;
+CREATE POLICY hq_admin_read ON public.stocktakes AS PERMISSIVE FOR SELECT TO authenticated
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'warehouse'::text, 'purchaser'::text, 'reporter'::text]))));
+
+DROP POLICY IF EXISTS slf_hq_all ON public.store_line_followers;
+CREATE POLICY slf_hq_all ON public.store_line_followers AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq'::text, 'hq_manager'::text, ''::text]))));
+
+DROP POLICY IF EXISTS slf_store_read ON public.store_line_followers;
+CREATE POLICY slf_store_read ON public.store_line_followers AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['store_manager'::text, 'store_staff'::text])) AND (EXISTS ( SELECT 1
+   FROM stores s
+  WHERE ((s.id = store_line_followers.store_id) AND (s.tenant_id = store_line_followers.tenant_id) AND (s.name IN ( SELECT jsonb_array_elements_text((((SELECT auth.jwt()) -> 'app_metadata'::text) -> 'stores'::text)) AS jsonb_array_elements_text)))))));
+
+DROP POLICY IF EXISTS auth_read_smsi ON public.store_monthly_settlement_items;
+CREATE POLICY auth_read_smsi ON public.store_monthly_settlement_items AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS smsi_hq_all ON public.store_monthly_settlement_items;
+CREATE POLICY smsi_hq_all ON public.store_monthly_settlement_items AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
+
+DROP POLICY IF EXISTS auth_read_sms ON public.store_monthly_settlements;
+CREATE POLICY auth_read_sms ON public.store_monthly_settlements AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS sms_hq_all ON public.store_monthly_settlements;
+CREATE POLICY sms_hq_all ON public.store_monthly_settlements AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
+
+DROP POLICY IF EXISTS sms_store_read ON public.store_monthly_settlements;
+CREATE POLICY sms_store_read ON public.store_monthly_settlements AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((((SELECT auth.jwt()) ->> 'store_id'::text))::bigint = store_id)));
+
+DROP POLICY IF EXISTS auth_read_srp ON public.store_receivable_payments;
+CREATE POLICY auth_read_srp ON public.store_receivable_payments AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_write_srp ON public.store_receivable_payments;
+CREATE POLICY auth_write_srp ON public.store_receivable_payments AS PERMISSIVE FOR ALL TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid))
+  WITH CHECK ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_sr ON public.store_receivables;
+CREATE POLICY auth_read_sr ON public.store_receivables AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_write_sr ON public.store_receivables;
+CREATE POLICY auth_write_sr ON public.store_receivables AS PERMISSIVE FOR ALL TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid))
+  WITH CHECK ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_ssa ON public.store_settlement_adjustments;
+CREATE POLICY auth_read_ssa ON public.store_settlement_adjustments AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS ssd_select ON public.store_settlement_disputes;
+CREATE POLICY ssd_select ON public.store_settlement_disputes AS PERMISSIVE FOR SELECT TO authenticated
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY[''::text, 'owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text])) OR (EXISTS ( SELECT 1
+   FROM store_monthly_settlements s
+  WHERE ((s.id = store_settlement_disputes.settlement_id) AND (s.store_id = ANY (COALESCE((SELECT _jwt_store_ids()), '{}'::bigint[])))))))));
+
+DROP POLICY IF EXISTS auth_read_stores ON public.stores;
+CREATE POLICY auth_read_stores ON public.stores AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS stores_hq_all ON public.stores;
+CREATE POLICY stores_hq_all ON public.stores AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+
+DROP POLICY IF EXISTS stores_store_read_own ON public.stores;
+CREATE POLICY stores_store_read_own ON public.stores AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
+
+DROP POLICY IF EXISTS stores_store_update_own ON public.stores;
+CREATE POLICY stores_store_update_own ON public.stores AS PERMISSIVE FOR UPDATE TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['store_owner'::text, 'store_manager'::text]))));
+
+DROP POLICY IF EXISTS auth_read_supplier_skus ON public.supplier_skus;
+CREATE POLICY auth_read_supplier_skus ON public.supplier_skus AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_suppliers ON public.suppliers;
+CREATE POLICY auth_read_suppliers ON public.suppliers AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS tenants_self_read ON public.tenants;
+CREATE POLICY tenants_self_read ON public.tenants AS PERMISSIVE FOR SELECT TO public
+  USING ((id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS tsi_hq_all ON public.transfer_settlement_items;
+CREATE POLICY tsi_hq_all ON public.transfer_settlement_items AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
+
+DROP POLICY IF EXISTS ts_hq_all ON public.transfer_settlements;
+CREATE POLICY ts_hq_all ON public.transfer_settlements AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
+
+DROP POLICY IF EXISTS ts_store_read ON public.transfer_settlements;
+CREATE POLICY ts_store_read ON public.transfer_settlements AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((((SELECT auth.jwt()) ->> 'store_id'::text))::bigint = store_a_id) OR ((((SELECT auth.jwt()) ->> 'store_id'::text))::bigint = store_b_id))));
+
+DROP POLICY IF EXISTS vbi_admin_all ON public.vendor_bill_items;
+CREATE POLICY vbi_admin_all ON public.vendor_bill_items AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
+
+DROP POLICY IF EXISTS vb_admin_all ON public.vendor_bills;
+CREATE POLICY vb_admin_all ON public.vendor_bills AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
+
+DROP POLICY IF EXISTS vb_store_read ON public.vendor_bills;
+CREATE POLICY vb_store_read ON public.vendor_bills AS PERMISSIVE FOR SELECT TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (supplier_id = ( SELECT stores.supplier_id
+   FROM stores
+  WHERE (stores.id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
+
+DROP POLICY IF EXISTS vpa_admin_all ON public.vendor_payment_allocations;
+CREATE POLICY vpa_admin_all ON public.vendor_payment_allocations AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
+
+DROP POLICY IF EXISTS vp_admin_all ON public.vendor_payments;
+CREATE POLICY vp_admin_all ON public.vendor_payments AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
+
+DROP POLICY IF EXISTS auth_read_wallet_balances ON public.wallet_balances;
+CREATE POLICY auth_read_wallet_balances ON public.wallet_balances AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS auth_read_wallet_ledger ON public.wallet_ledger;
+CREATE POLICY auth_read_wallet_ledger ON public.wallet_ledger AS PERMISSIVE FOR SELECT TO public
+  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
+
+DROP POLICY IF EXISTS xa_admin_all ON public.xiaolan_arrivals;
+CREATE POLICY xa_admin_all ON public.xiaolan_arrivals AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
+
+DROP POLICY IF EXISTS xt_admin_all ON public.xiaolan_order_tracking;
+CREATE POLICY xt_admin_all ON public.xiaolan_order_tracking AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
+
+DROP POLICY IF EXISTS xpp_admin_all ON public.xiaolan_piaopiao;
+CREATE POLICY xpp_admin_all ON public.xiaolan_piaopiao AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
+
+DROP POLICY IF EXISTS xp_admin_all ON public.xiaolan_purchases;
+CREATE POLICY xp_admin_all ON public.xiaolan_purchases AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
+
+DROP POLICY IF EXISTS xr_admin_all ON public.xiaolan_returns;
+CREATE POLICY xr_admin_all ON public.xiaolan_returns AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
+
+DROP POLICY IF EXISTS xs_admin_all ON public.xiaolan_settings;
+CREATE POLICY xs_admin_all ON public.xiaolan_settings AS PERMISSIVE FOR ALL TO public
+  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));

--- a/supabase/migrations/20260818000020_rls_initplan_wrap.sql
+++ b/supabase/migrations/20260818000020_rls_initplan_wrap.sql
@@ -15,756 +15,120 @@
 --     SELECT ... FROM stock_balances ORDER BY last_movement_at DESC LIMIT 50
 --       修正前：156.9 ms，shared hit=18,018
 --       修正後： 17.5 ms，shared hit=   306      ← 9 倍 / buffer 59 倍
+--     notifications 全表          184.9 ms → 23.9 ms
 --
 -- 修法：把 auth.jwt() / auth.uid() / auth.role() / _jwt_store_ids() /
 --   _jwt_store_location_ids() 包進 scalar subquery `(SELECT ...)`。Postgres 會把
 --   它變成 InitPlan，整個查詢只求值一次。這是 Supabase 官方 linter
---   `auth_rls_initplan` 指的同一件事。
+--   `auth_rls_initplan` 指的同一件事。線上 175 條 policy 有 169 條中這個招
+--   （103 張表）。
 --
---   `= ANY(<回傳陣列的函式>)` 要特別處理：`= ANY ((SELECT f()))` 會被當成
---   ANY(subquery) 而報 `operator does not exist: bigint = bigint[]`，所以寫成
---   `= ANY (COALESCE((SELECT f()), '{}'::bigint[]))` —— 包一層 COALESCE 之後
---   parser 才會走陣列語意。（4 條 policy 用到：restock_requests / stock_balances /
---   stock_movements / store_settlement_disputes）
+-- 為什麼是 DO block 而不是 169 條寫死的 CREATE POLICY：
+--   這是同一個機械式轉換重複 169 次，展開寫死是 770 行沒有人審得動的樣板碼，
+--   而且會把「產生當下的 policy 內文」凍進 repo —— 只要在合併前有人改過任何一條
+--   policy，套用時就會把對方的改動蓋掉。改成套用當下讀 pg_policies 現況去改寫，
+--   既短又不會蓋掉別人，歷來散落各 migration 的修正（20260502010000 /
+--   20260807000040 的 app_metadata role path、legacy admin 的 '' 允許值等）
+--   也自然逐字保留。
 --
--- 語意不變，這裡逐條驗證過：
---   在一個 transaction 內先以舊 policy、再以新 policy，對 103 張受影響的表 ×
---   9 種身分（admin / owner / hq_manager / store_manager / store_staff / clerk /
---   warehouse / legacy_admin(role='') / 無 claims）各數一次可見列數，
---   共 927 組比對 → **mismatch 0、error 0**。
+--   代價是 repo 裡看不到轉換後的 policy 內文，要查得問線上：
+--     SELECT tablename, policyname, qual FROM pg_policies WHERE schemaname='public';
 --
--- 基底版本：本檔的 169 條 policy 全部是從**線上 pg_catalog 現況**
---   （pg_policies.qual / with_check）產生的，不是從 repo 的 migration 重寫，
---   所以歷來散落在各 migration 的修正（例如 20260502010000 / 20260807000040
---   的 app_metadata role path、legacy admin 的 '' 允許值）都逐字保留。
---   ⚠ 若在本檔套用之前線上又改過任何 policy，要重新產生一次再套。
+-- 兩個轉換上的雷：
+--   1. `= ANY(<回傳陣列的函式>)` 不能只包 (SELECT f())：那樣會被 parser 當成
+--      ANY(subquery) 而報 `operator does not exist: bigint = bigint[]`。要寫成
+--      `= ANY (COALESCE((SELECT f()), '{}'::bigint[]))`，多包一層 COALESCE 之後
+--      才會走陣列語意。（4 條 policy 用到：restock_requests / stock_balances /
+--      stock_movements / store_settlement_disputes）
+--   2. 已經包好的不要再包一層 —— WHERE 用 negative lookbehind `(?<!SELECT )`
+--      篩掉，重跑這支 migration 是 no-op。
 --
--- Rollback：把 (SELECT auth.xxx()) 改回 auth.xxx()、
+-- 語意不變，逐條驗證過：在一個 transaction 內先以舊 policy、再以新 policy，
+--   對 103 張受影響的表 × 9 種身分（admin / owner / hq_manager / store_manager /
+--   store_staff / clerk / warehouse / legacy_admin(role='') / 無 claims）
+--   各數一次可見列數，共 927 組比對 → **mismatch 0、error 0**。
+--
+--   ⚠ 這種對拍一定要 `BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ`。
+--   預設的 READ COMMITTED 下，兩次探測各自取新快照，正式庫**同時間的真實寫入**
+--   會被算成 policy 差異：實測就出現過 campaign_views 3253→3254、
+--   customer_orders 72030→72038 這種「after 一律比 before 多」的假 mismatch。
+--   辨識法同 CLAUDE.md 那條「收斂前後對拍」——差異若是**均勻同向、且與身分無關**
+--   （店員跟 owner 增量一樣），那就是母體不一致，不是算法錯。
+--
+-- Rollback：純效能改動，不還原也不影響正確性。真要還原就把
+--   (SELECT auth.xxx()) 改回 auth.xxx()、
 --   ANY (COALESCE((SELECT f()), '{}'::bigint[])) 改回 ANY (f())。
---   純效能改動，不還原也不影響正確性。
 --
 -- 沒有對應的前端改動。
 -- ============================================================================
 
-DROP POLICY IF EXISTS clr_owner_write ON public.aid_clearance_offers;
-CREATE POLICY clr_owner_write ON public.aid_clearance_offers AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text])))));
-
-DROP POLICY IF EXISTS clr_read_all ON public.aid_clearance_offers;
-CREATE POLICY clr_read_all ON public.aid_clearance_offers AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS bo_hq_all ON public.backorders;
-CREATE POLICY bo_hq_all ON public.backorders AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS bo_store_read ON public.backorders;
-CREATE POLICY bo_store_read ON public.backorders AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS read_tenant_barcodes ON public.barcodes;
-CREATE POLICY read_tenant_barcodes ON public.barcodes AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS read_tenant_brands ON public.brands;
-CREATE POLICY read_tenant_brands ON public.brands AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS camp_audit_hq_read ON public.campaign_audit_log;
-CREATE POLICY camp_audit_hq_read ON public.campaign_audit_log AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS auth_read_campaign_channels ON public.campaign_channels;
-CREATE POLICY auth_read_campaign_channels ON public.campaign_channels AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS cc_hq_all ON public.campaign_channels;
-CREATE POLICY cc_hq_all ON public.campaign_channels AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS cfp_hq_all ON public.campaign_fb_posts;
-CREATE POLICY cfp_hq_all ON public.campaign_fb_posts AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS auth_read_campaign_items ON public.campaign_items;
-CREATE POLICY auth_read_campaign_items ON public.campaign_items AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS ci_hq_all ON public.campaign_items;
-CREATE POLICY ci_hq_all ON public.campaign_items AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
-
-DROP POLICY IF EXISTS ci_store_read ON public.campaign_items;
-CREATE POLICY ci_store_read ON public.campaign_items AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_campaign_views ON public.campaign_views;
-CREATE POLICY auth_read_campaign_views ON public.campaign_views AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS read_tenant_categories ON public.categories;
-CREATE POLICY read_tenant_categories ON public.categories AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS client_error_logs_hq_all ON public.client_error_logs;
-CREATE POLICY client_error_logs_hq_all ON public.client_error_logs AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'hq'::text)));
-
-DROP POLICY IF EXISTS ccp_hq_all ON public.community_product_candidates;
-CREATE POLICY ccp_hq_all ON public.community_product_candidates AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'assistant'::text, ''::text]))))
-  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'assistant'::text, ''::text]))));
-
-DROP POLICY IF EXISTS auth_read_customer_line_aliases ON public.customer_line_aliases;
-CREATE POLICY auth_read_customer_line_aliases ON public.customer_line_aliases AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS cla_hq_all ON public.customer_line_aliases;
-CREATE POLICY cla_hq_all ON public.customer_line_aliases AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS cla_store_access ON public.customer_line_aliases;
-CREATE POLICY cla_store_access ON public.customer_line_aliases AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (channel_id IN ( SELECT line_channels.id
-   FROM line_channels
-  WHERE (line_channels.home_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
-
-DROP POLICY IF EXISTS coa_hq_read ON public.customer_order_audit_log;
-CREATE POLICY coa_hq_read ON public.customer_order_audit_log AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE(NULLIF((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text), NULLIF(((SELECT auth.jwt()) ->> 'role'::text), 'authenticated'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, ''::text]))));
-
-DROP POLICY IF EXISTS coa_store_read ON public.customer_order_audit_log;
-CREATE POLICY coa_store_read ON public.customer_order_audit_log AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((EXISTS ( SELECT 1
-   FROM jsonb_array_elements_text(COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) -> 'stores'::text), '[]'::jsonb)) s(name)
-  WHERE (s.name = '總倉'::text))) OR (order_id IN ( SELECT co.id
-   FROM (customer_orders co
-     JOIN stores st ON ((st.id = co.pickup_store_id)))
-  WHERE ((st.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (st.name IN ( SELECT jsonb_array_elements_text(COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) -> 'stores'::text), '[]'::jsonb)) AS jsonb_array_elements_text))))))));
-
-DROP POLICY IF EXISTS auth_read_customer_order_items ON public.customer_order_items;
-CREATE POLICY auth_read_customer_order_items ON public.customer_order_items AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS coi_hq_all ON public.customer_order_items;
-CREATE POLICY coi_hq_all ON public.customer_order_items AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS coi_store_access ON public.customer_order_items;
-CREATE POLICY coi_store_access ON public.customer_order_items AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (order_id IN ( SELECT customer_orders.id
-   FROM customer_orders
-  WHERE (customer_orders.pickup_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
-
-DROP POLICY IF EXISTS cos_hq_read ON public.customer_order_sources;
-CREATE POLICY cos_hq_read ON public.customer_order_sources AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS auth_read_customer_orders ON public.customer_orders;
-CREATE POLICY auth_read_customer_orders ON public.customer_orders AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS corders_hq_all ON public.customer_orders;
-CREATE POLICY corders_hq_all ON public.customer_orders AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS corders_store_access ON public.customer_orders;
-CREATE POLICY corders_store_access ON public.customer_orders AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (pickup_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS dr_hq_all ON public.demand_requests;
-CREATE POLICY dr_hq_all ON public.demand_requests AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS dr_store_own ON public.demand_requests;
-CREATE POLICY dr_store_own ON public.demand_requests AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (requester_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS ec_admin_write ON public.expense_categories;
-CREATE POLICY ec_admin_write ON public.expense_categories AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS ec_read_all ON public.expense_categories;
-CREATE POLICY ec_read_all ON public.expense_categories AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS exp_admin_all ON public.expenses;
-CREATE POLICY exp_admin_all ON public.expenses AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
-
-DROP POLICY IF EXISTS exp_applicant ON public.expenses;
-CREATE POLICY exp_applicant ON public.expenses AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (applicant_id = (((SELECT auth.jwt()) ->> 'sub'::text))::uuid)));
-
-DROP POLICY IF EXISTS eoi_hq_all ON public.external_order_imports;
-CREATE POLICY eoi_hq_all ON public.external_order_imports AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS epi_admin_all ON public.external_purchase_imports;
-CREATE POLICY epi_admin_all ON public.external_purchase_imports AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
-
-DROP POLICY IF EXISTS fb_pages_hq_all ON public.fb_pages;
-CREATE POLICY fb_pages_hq_all ON public.fb_pages AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS gr_warehouse ON public.goods_receipts;
-CREATE POLICY gr_warehouse ON public.goods_receipts AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'warehouse'::text) AND (dest_location_id = (((SELECT auth.jwt()) ->> 'location_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS auth_read_group_buy_campaigns ON public.group_buy_campaigns;
-CREATE POLICY auth_read_group_buy_campaigns ON public.group_buy_campaigns AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS gbc_hq_all ON public.group_buy_campaigns;
-CREATE POLICY gbc_hq_all ON public.group_buy_campaigns AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
-
-DROP POLICY IF EXISTS gbc_store_read ON public.group_buy_campaigns;
-CREATE POLICY gbc_store_read ON public.group_buy_campaigns AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (status = ANY (ARRAY['open'::text, 'closed'::text, 'locked'::text, 'ordered'::text, 'receiving'::text, 'ready'::text, 'completed'::text]))));
-
-DROP POLICY IF EXISTS p_lele_imports_tenant_read ON public.lele_order_imports;
-CREATE POLICY p_lele_imports_tenant_read ON public.lele_order_imports AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS p_lele_imports_tenant_write ON public.lele_order_imports;
-CREATE POLICY p_lele_imports_tenant_write ON public.lele_order_imports AS PERMISSIVE FOR INSERT TO public
-  WITH CHECK ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_line_channels ON public.line_channels;
-CREATE POLICY auth_read_line_channels ON public.line_channels AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS lc_hq_all ON public.line_channels;
-CREATE POLICY lc_hq_all ON public.line_channels AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS lc_store_read ON public.line_channels;
-CREATE POLICY lc_store_read ON public.line_channels AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (home_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS line_push_logs_tenant_read ON public.line_push_logs;
-CREATE POLICY line_push_logs_tenant_read ON public.line_push_logs AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_locations ON public.locations;
-CREATE POLICY auth_read_locations ON public.locations AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_member_cards ON public.member_cards;
-CREATE POLICY auth_read_member_cards ON public.member_cards AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_member_imports ON public.member_imports;
-CREATE POLICY auth_read_member_imports ON public.member_imports AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS mi_hq_all ON public.member_imports;
-CREATE POLICY mi_hq_all ON public.member_imports AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS mlb_hq_all ON public.member_line_bindings;
-CREATE POLICY mlb_hq_all ON public.member_line_bindings AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'hq'::text)));
-
-DROP POLICY IF EXISTS mlb_self_read ON public.member_line_bindings;
-CREATE POLICY mlb_self_read ON public.member_line_bindings AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (member_id = (NULLIF(((SELECT auth.jwt()) ->> 'member_id'::text), ''::text))::bigint)));
-
-DROP POLICY IF EXISTS mlb_store_read ON public.member_line_bindings;
-CREATE POLICY mlb_store_read ON public.member_line_bindings AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (store_id = (NULLIF(((SELECT auth.jwt()) ->> 'store_id'::text), ''::text))::bigint) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['store_manager'::text, 'store_staff'::text]))));
-
-DROP POLICY IF EXISTS auth_read_member_merges ON public.member_merges;
-CREATE POLICY auth_read_member_merges ON public.member_merges AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_member_points_balance ON public.member_points_balance;
-CREATE POLICY auth_read_member_points_balance ON public.member_points_balance AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_member_tiers ON public.member_tiers;
-CREATE POLICY auth_read_member_tiers ON public.member_tiers AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_members ON public.members;
-CREATE POLICY auth_read_members ON public.members AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS hq_read_members ON public.members;
-CREATE POLICY hq_read_members ON public.members AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'marketer'::text]))));
-
-DROP POLICY IF EXISTS store_read_members ON public.members;
-CREATE POLICY store_read_members ON public.members AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['store_manager'::text, 'clerk'::text])) AND (home_store_id = (((SELECT auth.jwt()) ->> 'location_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS aid_board_owner_delete ON public.mutual_aid_board;
-CREATE POLICY aid_board_owner_delete ON public.mutual_aid_board AS PERMISSIVE FOR DELETE TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text])))));
-
-DROP POLICY IF EXISTS aid_board_owner_insert ON public.mutual_aid_board;
-CREATE POLICY aid_board_owner_insert ON public.mutual_aid_board AS PERMISSIVE FOR INSERT TO public
-  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text])))));
-
-DROP POLICY IF EXISTS aid_board_owner_update ON public.mutual_aid_board;
-CREATE POLICY aid_board_owner_update ON public.mutual_aid_board AS PERMISSIVE FOR UPDATE TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text])))))
-  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text])))));
-
-DROP POLICY IF EXISTS aid_board_read_all ON public.mutual_aid_board;
-CREATE POLICY aid_board_read_all ON public.mutual_aid_board AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND can_see_aid_post(offering_store_id, spot_visible_to_other_stores)));
-
-DROP POLICY IF EXISTS aid_claims_hq_all ON public.mutual_aid_claims;
-CREATE POLICY aid_claims_hq_all ON public.mutual_aid_claims AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS aid_claims_store_read ON public.mutual_aid_claims;
-CREATE POLICY aid_claims_store_read ON public.mutual_aid_claims AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((claiming_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) OR (board_id IN ( SELECT mutual_aid_board.id
-   FROM mutual_aid_board
-  WHERE (mutual_aid_board.offering_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint))))));
-
-DROP POLICY IF EXISTS replies_authenticated_insert ON public.mutual_aid_replies;
-CREATE POLICY replies_authenticated_insert ON public.mutual_aid_replies AS PERMISSIVE FOR INSERT TO public
-  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (author_id = (SELECT auth.uid()))));
-
-DROP POLICY IF EXISTS replies_read_all ON public.mutual_aid_replies;
-CREATE POLICY replies_read_all ON public.mutual_aid_replies AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (EXISTS ( SELECT 1
-   FROM mutual_aid_board b
-  WHERE ((b.id = mutual_aid_replies.board_id) AND can_see_aid_post(b.offering_store_id, b.spot_visible_to_other_stores))))));
-
-DROP POLICY IF EXISTS notifications_hq_all ON public.notifications;
-CREATE POLICY notifications_hq_all ON public.notifications AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'hq'::text)));
-
-DROP POLICY IF EXISTS notifications_self_all ON public.notifications;
-CREATE POLICY notifications_self_all ON public.notifications AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (member_id = (((SELECT auth.jwt()) ->> 'member_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS oee_hq_all ON public.order_expiry_events;
-CREATE POLICY oee_hq_all ON public.order_expiry_events AS PERMISSIVE FOR ALL TO authenticated
-  USING (((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text) = 'hq'::text));
-
-DROP POLICY IF EXISTS oee_store_read ON public.order_expiry_events;
-CREATE POLICY oee_store_read ON public.order_expiry_events AS PERMISSIVE FOR SELECT TO authenticated
-  USING (((tenant_id = ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'tenant_id'::text))::uuid) AND (order_id IN ( SELECT customer_orders.id
-   FROM customer_orders
-  WHERE (customer_orders.pickup_store_id = ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'store_id'::text))::bigint)))));
-
-DROP POLICY IF EXISTS auth_read_order_pickup_events ON public.order_pickup_events;
-CREATE POLICY auth_read_order_pickup_events ON public.order_pickup_events AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS pickup_ev_hq_read ON public.order_pickup_events;
-CREATE POLICY pickup_ev_hq_read ON public.order_pickup_events AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS pickup_ev_store_read ON public.order_pickup_events;
-CREATE POLICY pickup_ev_store_read ON public.order_pickup_events AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (pickup_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS ose_hq_all ON public.order_shortage_events;
-CREATE POLICY ose_hq_all ON public.order_shortage_events AS PERMISSIVE FOR ALL TO authenticated
-  USING (((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text) = 'hq'::text));
-
-DROP POLICY IF EXISTS ose_store_read ON public.order_shortage_events;
-CREATE POLICY ose_store_read ON public.order_shortage_events AS PERMISSIVE FOR SELECT TO authenticated
-  USING (((tenant_id = ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'tenant_id'::text))::uuid) AND (order_id IN ( SELECT customer_orders.id
-   FROM customer_orders
-  WHERE (customer_orders.pickup_store_id = ((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'store_id'::text))::bigint)))));
-
-DROP POLICY IF EXISTS wl_hq_all ON public.order_waitlist;
-CREATE POLICY wl_hq_all ON public.order_waitlist AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS wl_store_read ON public.order_waitlist;
-CREATE POLICY wl_store_read ON public.order_waitlist AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (channel_id IN ( SELECT line_channels.id
-   FROM line_channels
-  WHERE (line_channels.home_store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
-
-DROP POLICY IF EXISTS pca_admin_all ON public.petty_cash_accounts;
-CREATE POLICY pca_admin_all ON public.petty_cash_accounts AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
-
-DROP POLICY IF EXISTS pca_store_own ON public.petty_cash_accounts;
-CREATE POLICY pca_store_own ON public.petty_cash_accounts AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS pct_admin_all ON public.petty_cash_transactions;
-CREATE POLICY pct_admin_all ON public.petty_cash_transactions AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
-
-DROP POLICY IF EXISTS pct_store_access ON public.petty_cash_transactions;
-CREATE POLICY pct_store_access ON public.petty_cash_transactions AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (account_id IN ( SELECT petty_cash_accounts.id
-   FROM petty_cash_accounts
-  WHERE (petty_cash_accounts.store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
-
-DROP POLICY IF EXISTS pdi_hq_all ON public.picking_draft_items;
-CREATE POLICY pdi_hq_all ON public.picking_draft_items AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'assistant'::text, ''::text]))))
-  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'assistant'::text, ''::text]))));
-
-DROP POLICY IF EXISTS pd_hq_all ON public.picking_drafts;
-CREATE POLICY pd_hq_all ON public.picking_drafts AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'assistant'::text, ''::text]))))
-  WITH CHECK (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'assistant'::text, ''::text]))));
-
-DROP POLICY IF EXISTS pwal_hq_read ON public.picking_wave_audit_log;
-CREATE POLICY pwal_hq_read ON public.picking_wave_audit_log AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS pwi_hq_all ON public.picking_wave_items;
-CREATE POLICY pwi_hq_all ON public.picking_wave_items AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'warehouse'::text]))));
-
-DROP POLICY IF EXISTS pwi_store_read ON public.picking_wave_items;
-CREATE POLICY pwi_store_read ON public.picking_wave_items AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS pw_hq_all ON public.picking_waves;
-CREATE POLICY pw_hq_all ON public.picking_waves AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'warehouse'::text]))));
-
-DROP POLICY IF EXISTS pw_store_read ON public.picking_waves;
-CREATE POLICY pw_store_read ON public.picking_waves AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (id IN ( SELECT picking_wave_items.wave_id
-   FROM picking_wave_items
-  WHERE (picking_wave_items.store_id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
-
-DROP POLICY IF EXISTS auth_read_points_ledger ON public.points_ledger;
-CREATE POLICY auth_read_points_ledger ON public.points_ledger AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS hq_full_read_pos ON public.pos_sales;
-CREATE POLICY hq_full_read_pos ON public.pos_sales AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'accountant'::text]))));
-
-DROP POLICY IF EXISTS pos_store_scope ON public.pos_sales;
-CREATE POLICY pos_store_scope ON public.pos_sales AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (location_id = (((SELECT auth.jwt()) ->> 'location_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS auth_read_post_templates ON public.post_templates;
-CREATE POLICY auth_read_post_templates ON public.post_templates AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS pt_hq_all ON public.post_templates;
-CREATE POLICY pt_hq_all ON public.post_templates AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS read_prices_role_scoped ON public.prices;
-CREATE POLICY read_prices_role_scoped ON public.prices AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((scope = ANY (ARRAY['retail'::text, 'store'::text, 'member_tier'::text, 'promo'::text])) OR ((scope = 'cost'::text) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, ''::text]))) OR ((scope = 'branch'::text) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'store_manager'::text, ''::text]))))));
-
-DROP POLICY IF EXISTS ptm_read ON public.product_tag_map;
-CREATE POLICY ptm_read ON public.product_tag_map AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS ptr_read ON public.product_tag_rules;
-CREATE POLICY ptr_read ON public.product_tag_rules AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS pt_read ON public.product_tags;
-CREATE POLICY pt_read ON public.product_tags AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS read_tenant_products ON public.products;
-CREATE POLICY read_tenant_products ON public.products AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS read_tenant_promotions ON public.promotions;
-CREATE POLICY read_tenant_promotions ON public.promotions AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS pat_admin_all ON public.purchase_approval_thresholds;
-CREATE POLICY pat_admin_all ON public.purchase_approval_thresholds AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS pat_others_read ON public.purchase_approval_thresholds;
-CREATE POLICY pat_others_read ON public.purchase_approval_thresholds AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_purchase_order_items ON public.purchase_order_items;
-CREATE POLICY auth_read_purchase_order_items ON public.purchase_order_items AS PERMISSIVE FOR SELECT TO public
-  USING ((EXISTS ( SELECT 1
-   FROM purchase_orders po
-  WHERE ((po.id = purchase_order_items.po_id) AND (po.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid)))));
-
-DROP POLICY IF EXISTS poi_hq_all ON public.purchase_order_items;
-CREATE POLICY poi_hq_all ON public.purchase_order_items AS PERMISSIVE FOR ALL TO public
-  USING (((EXISTS ( SELECT 1
-   FROM purchase_orders po
-  WHERE ((po.id = purchase_order_items.po_id) AND (po.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid)))) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, ''::text]))));
-
-DROP POLICY IF EXISTS auth_read_purchase_orders ON public.purchase_orders;
-CREATE POLICY auth_read_purchase_orders ON public.purchase_orders AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS po_hq_all ON public.purchase_orders;
-CREATE POLICY po_hq_all ON public.purchase_orders AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, ''::text]))));
-
-DROP POLICY IF EXISTS purchase_full ON public.purchase_orders;
-CREATE POLICY purchase_full ON public.purchase_orders AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'purchaser'::text, 'accountant'::text]))));
-
-DROP POLICY IF EXISTS auth_read_prc ON public.purchase_request_campaigns;
-CREATE POLICY auth_read_prc ON public.purchase_request_campaigns AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_write_prc ON public.purchase_request_campaigns;
-CREATE POLICY auth_write_prc ON public.purchase_request_campaigns AS PERMISSIVE FOR ALL TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid))
-  WITH CHECK ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_purchase_request_items ON public.purchase_request_items;
-CREATE POLICY auth_read_purchase_request_items ON public.purchase_request_items AS PERMISSIVE FOR SELECT TO public
-  USING ((EXISTS ( SELECT 1
-   FROM purchase_requests pr
-  WHERE ((pr.id = purchase_request_items.pr_id) AND (pr.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid)))));
-
-DROP POLICY IF EXISTS pri_hq_all ON public.purchase_request_items;
-CREATE POLICY pri_hq_all ON public.purchase_request_items AS PERMISSIVE FOR ALL TO public
-  USING (((EXISTS ( SELECT 1
-   FROM purchase_requests pr
-  WHERE ((pr.id = purchase_request_items.pr_id) AND (pr.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid)))) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, ''::text]))));
-
-DROP POLICY IF EXISTS auth_read_purchase_requests ON public.purchase_requests;
-CREATE POLICY auth_read_purchase_requests ON public.purchase_requests AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS pr_helper ON public.purchase_requests;
-CREATE POLICY pr_helper ON public.purchase_requests AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'helper'::text) AND (created_by = (SELECT auth.uid()))));
-
-DROP POLICY IF EXISTS pr_hq_all ON public.purchase_requests;
-CREATE POLICY pr_hq_all ON public.purchase_requests AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, ''::text]))));
-
-DROP POLICY IF EXISTS pr_store_manager ON public.purchase_requests;
-CREATE POLICY pr_store_manager ON public.purchase_requests AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'store_manager'::text) AND (source_location_id = (((SELECT auth.jwt()) ->> 'location_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS push_subs_hq_all ON public.push_subscriptions;
-CREATE POLICY push_subs_hq_all ON public.push_subscriptions AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = 'hq'::text)));
-
-DROP POLICY IF EXISTS push_subs_self_all ON public.push_subscriptions;
-CREATE POLICY push_subs_self_all ON public.push_subscriptions AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (member_id = (((SELECT auth.jwt()) ->> 'member_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS hq_full_read_ar ON public.receivables;
-CREATE POLICY hq_full_read_ar ON public.receivables AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'accountant'::text]))));
-
-DROP POLICY IF EXISTS hq_admin_read ON public.reorder_rules;
-CREATE POLICY hq_admin_read ON public.reorder_rules AS PERMISSIVE FOR SELECT TO authenticated
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, 'warehouse'::text, 'reporter'::text]))));
-
-DROP POLICY IF EXISTS restock_lines_select ON public.restock_request_lines;
-CREATE POLICY restock_lines_select ON public.restock_request_lines AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (request_id IN ( SELECT restock_requests.id
-   FROM restock_requests))));
-
-DROP POLICY IF EXISTS restock_select ON public.restock_requests;
-CREATE POLICY restock_select ON public.restock_requests AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text, 'assistant'::text, ''::text])) OR ((COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['store_manager'::text, 'store_staff'::text])) AND (requesting_store_id = ANY (COALESCE((SELECT _jwt_store_ids()), '{}'::bigint[])))))));
-
-DROP POLICY IF EXISTS hq_full_read_so ON public.sales_orders;
-CREATE POLICY hq_full_read_so ON public.sales_orders AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'accountant'::text, 'purchaser'::text]))));
-
-DROP POLICY IF EXISTS read_tenant_skus ON public.skus;
-CREATE POLICY read_tenant_skus ON public.skus AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_spot_views ON public.spot_views;
-CREATE POLICY auth_read_spot_views ON public.spot_views AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS hq_admin_read ON public.stock_balances;
-CREATE POLICY hq_admin_read ON public.stock_balances AS PERMISSIVE FOR SELECT TO authenticated
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS hq_full_read ON public.stock_balances;
-CREATE POLICY hq_full_read ON public.stock_balances AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'purchaser'::text, 'warehouse'::text, 'reporter'::text]))));
-
-DROP POLICY IF EXISTS store_read_own ON public.stock_balances;
-CREATE POLICY store_read_own ON public.stock_balances AS PERMISSIVE FOR SELECT TO authenticated
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['store_manager'::text, 'store_staff'::text, 'clerk'::text])) AND (location_id = ANY (COALESCE((SELECT _jwt_store_location_ids()), '{}'::bigint[])))));
-
-DROP POLICY IF EXISTS hq_full_read ON public.stock_movements;
-CREATE POLICY hq_full_read ON public.stock_movements AS PERMISSIVE FOR SELECT TO authenticated
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text, 'warehouse'::text, 'reporter'::text]))));
-
-DROP POLICY IF EXISTS store_read_own ON public.stock_movements;
-CREATE POLICY store_read_own ON public.stock_movements AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['store_manager'::text, 'store_staff'::text, 'clerk'::text])) AND (location_id = ANY (COALESCE((SELECT _jwt_store_location_ids()), '{}'::bigint[])))));
-
-DROP POLICY IF EXISTS hq_admin_read ON public.stocktake_items;
-CREATE POLICY hq_admin_read ON public.stocktake_items AS PERMISSIVE FOR SELECT TO authenticated
-  USING (((EXISTS ( SELECT 1
-   FROM stocktakes s
-  WHERE ((s.id = stocktake_items.stocktake_id) AND (s.tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid)))) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'warehouse'::text, 'purchaser'::text, 'reporter'::text]))));
-
-DROP POLICY IF EXISTS hq_admin_read ON public.stocktakes;
-CREATE POLICY hq_admin_read ON public.stocktakes AS PERMISSIVE FOR SELECT TO authenticated
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ((SELECT auth.jwt()) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'warehouse'::text, 'purchaser'::text, 'reporter'::text]))));
-
-DROP POLICY IF EXISTS slf_hq_all ON public.store_line_followers;
-CREATE POLICY slf_hq_all ON public.store_line_followers AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq'::text, 'hq_manager'::text, ''::text]))));
-
-DROP POLICY IF EXISTS slf_store_read ON public.store_line_followers;
-CREATE POLICY slf_store_read ON public.store_line_followers AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY['store_manager'::text, 'store_staff'::text])) AND (EXISTS ( SELECT 1
-   FROM stores s
-  WHERE ((s.id = store_line_followers.store_id) AND (s.tenant_id = store_line_followers.tenant_id) AND (s.name IN ( SELECT jsonb_array_elements_text((((SELECT auth.jwt()) -> 'app_metadata'::text) -> 'stores'::text)) AS jsonb_array_elements_text)))))));
-
-DROP POLICY IF EXISTS auth_read_smsi ON public.store_monthly_settlement_items;
-CREATE POLICY auth_read_smsi ON public.store_monthly_settlement_items AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS smsi_hq_all ON public.store_monthly_settlement_items;
-CREATE POLICY smsi_hq_all ON public.store_monthly_settlement_items AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
-
-DROP POLICY IF EXISTS auth_read_sms ON public.store_monthly_settlements;
-CREATE POLICY auth_read_sms ON public.store_monthly_settlements AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS sms_hq_all ON public.store_monthly_settlements;
-CREATE POLICY sms_hq_all ON public.store_monthly_settlements AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
-
-DROP POLICY IF EXISTS sms_store_read ON public.store_monthly_settlements;
-CREATE POLICY sms_store_read ON public.store_monthly_settlements AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((((SELECT auth.jwt()) ->> 'store_id'::text))::bigint = store_id)));
-
-DROP POLICY IF EXISTS auth_read_srp ON public.store_receivable_payments;
-CREATE POLICY auth_read_srp ON public.store_receivable_payments AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_write_srp ON public.store_receivable_payments;
-CREATE POLICY auth_write_srp ON public.store_receivable_payments AS PERMISSIVE FOR ALL TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid))
-  WITH CHECK ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_sr ON public.store_receivables;
-CREATE POLICY auth_read_sr ON public.store_receivables AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_write_sr ON public.store_receivables;
-CREATE POLICY auth_write_sr ON public.store_receivables AS PERMISSIVE FOR ALL TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid))
-  WITH CHECK ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_ssa ON public.store_settlement_adjustments;
-CREATE POLICY auth_read_ssa ON public.store_settlement_adjustments AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS ssd_select ON public.store_settlement_disputes;
-CREATE POLICY ssd_select ON public.store_settlement_disputes AS PERMISSIVE FOR SELECT TO authenticated
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND ((COALESCE((((SELECT auth.jwt()) -> 'app_metadata'::text) ->> 'role'::text), ''::text) = ANY (ARRAY[''::text, 'owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text])) OR (EXISTS ( SELECT 1
-   FROM store_monthly_settlements s
-  WHERE ((s.id = store_settlement_disputes.settlement_id) AND (s.store_id = ANY (COALESCE((SELECT _jwt_store_ids()), '{}'::bigint[])))))))));
-
-DROP POLICY IF EXISTS auth_read_stores ON public.stores;
-CREATE POLICY auth_read_stores ON public.stores AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS stores_hq_all ON public.stores;
-CREATE POLICY stores_hq_all ON public.stores AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
-
-DROP POLICY IF EXISTS stores_store_read_own ON public.stores;
-CREATE POLICY stores_store_read_own ON public.stores AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)));
-
-DROP POLICY IF EXISTS stores_store_update_own ON public.stores;
-CREATE POLICY stores_store_update_own ON public.stores AS PERMISSIVE FOR UPDATE TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['store_owner'::text, 'store_manager'::text]))));
-
-DROP POLICY IF EXISTS auth_read_supplier_skus ON public.supplier_skus;
-CREATE POLICY auth_read_supplier_skus ON public.supplier_skus AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_suppliers ON public.suppliers;
-CREATE POLICY auth_read_suppliers ON public.suppliers AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS tenants_self_read ON public.tenants;
-CREATE POLICY tenants_self_read ON public.tenants AS PERMISSIVE FOR SELECT TO public
-  USING ((id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS tsi_hq_all ON public.transfer_settlement_items;
-CREATE POLICY tsi_hq_all ON public.transfer_settlement_items AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
-
-DROP POLICY IF EXISTS ts_hq_all ON public.transfer_settlements;
-CREATE POLICY ts_hq_all ON public.transfer_settlements AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
-
-DROP POLICY IF EXISTS ts_store_read ON public.transfer_settlements;
-CREATE POLICY ts_store_read ON public.transfer_settlements AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((((SELECT auth.jwt()) ->> 'store_id'::text))::bigint = store_a_id) OR ((((SELECT auth.jwt()) ->> 'store_id'::text))::bigint = store_b_id))));
-
-DROP POLICY IF EXISTS vbi_admin_all ON public.vendor_bill_items;
-CREATE POLICY vbi_admin_all ON public.vendor_bill_items AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
-
-DROP POLICY IF EXISTS vb_admin_all ON public.vendor_bills;
-CREATE POLICY vb_admin_all ON public.vendor_bills AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
-
-DROP POLICY IF EXISTS vb_store_read ON public.vendor_bills;
-CREATE POLICY vb_store_read ON public.vendor_bills AS PERMISSIVE FOR SELECT TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (supplier_id = ( SELECT stores.supplier_id
-   FROM stores
-  WHERE (stores.id = (((SELECT auth.jwt()) ->> 'store_id'::text))::bigint)))));
-
-DROP POLICY IF EXISTS vpa_admin_all ON public.vendor_payment_allocations;
-CREATE POLICY vpa_admin_all ON public.vendor_payment_allocations AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
-
-DROP POLICY IF EXISTS vp_admin_all ON public.vendor_payments;
-CREATE POLICY vp_admin_all ON public.vendor_payments AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'hq_accountant'::text]))));
-
-DROP POLICY IF EXISTS auth_read_wallet_balances ON public.wallet_balances;
-CREATE POLICY auth_read_wallet_balances ON public.wallet_balances AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS auth_read_wallet_ledger ON public.wallet_ledger;
-CREATE POLICY auth_read_wallet_ledger ON public.wallet_ledger AS PERMISSIVE FOR SELECT TO public
-  USING ((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid));
-
-DROP POLICY IF EXISTS xa_admin_all ON public.xiaolan_arrivals;
-CREATE POLICY xa_admin_all ON public.xiaolan_arrivals AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
-
-DROP POLICY IF EXISTS xt_admin_all ON public.xiaolan_order_tracking;
-CREATE POLICY xt_admin_all ON public.xiaolan_order_tracking AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
-
-DROP POLICY IF EXISTS xpp_admin_all ON public.xiaolan_piaopiao;
-CREATE POLICY xpp_admin_all ON public.xiaolan_piaopiao AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
-
-DROP POLICY IF EXISTS xp_admin_all ON public.xiaolan_purchases;
-CREATE POLICY xp_admin_all ON public.xiaolan_purchases AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
-
-DROP POLICY IF EXISTS xr_admin_all ON public.xiaolan_returns;
-CREATE POLICY xr_admin_all ON public.xiaolan_returns AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text, 'purchaser'::text]))));
-
-DROP POLICY IF EXISTS xs_admin_all ON public.xiaolan_settings;
-CREATE POLICY xs_admin_all ON public.xiaolan_settings AS PERMISSIVE FOR ALL TO public
-  USING (((tenant_id = (((SELECT auth.jwt()) ->> 'tenant_id'::text))::uuid) AND (((SELECT auth.jwt()) ->> 'role'::text) = ANY (ARRAY['owner'::text, 'admin'::text, 'hq_manager'::text]))));
+DO $migration$
+DECLARE
+  r        RECORD;
+  v_qual   TEXT;
+  v_check  TEXT;
+  v_roles  TEXT;
+  v_n      INT := 0;
+
+  -- 把每列都會重算的呼叫提升成 InitPlan。
+  -- 回傳陣列的兩支要多包一層 COALESCE，否則 = ANY 會被當成 ANY(subquery)。
+  FUNCTION_WRAP CONSTANT TEXT[][] := ARRAY[
+    ['_jwt_store_location_ids\(\)', 'COALESCE((SELECT _jwt_store_location_ids()), ''{}''::bigint[])'],
+    ['_jwt_store_ids\(\)',          'COALESCE((SELECT _jwt_store_ids()), ''{}''::bigint[])'],
+    ['auth\.jwt\(\)',               '(SELECT auth.jwt())'],
+    ['auth\.uid\(\)',               '(SELECT auth.uid())'],
+    ['auth\.role\(\)',              '(SELECT auth.role())']
+  ];
+BEGIN
+  FOR r IN
+    SELECT p.tablename, p.policyname, p.permissive, p.cmd, p.roles, p.qual, p.with_check
+    FROM pg_policies p
+    WHERE p.schemaname = 'public'
+      -- 只挑還沒包過的（negative lookbehind），重跑是 no-op
+      AND (COALESCE(p.qual, '') || ' ' || COALESCE(p.with_check, ''))
+          ~ '(?<!SELECT )(auth\.(jwt|uid|role)\(\)|_jwt_store(_location)?_ids\()'
+    ORDER BY p.tablename, p.policyname
+  LOOP
+    v_qual  := r.qual;
+    v_check := r.with_check;
+
+    FOR i IN 1 .. array_length(FUNCTION_WRAP, 1) LOOP
+      -- 同樣用 negative lookbehind，避免把已經包好的再包一次
+      v_qual  := regexp_replace(v_qual,  '(?<!SELECT )' || FUNCTION_WRAP[i][1],
+                                FUNCTION_WRAP[i][2], 'g');
+      v_check := regexp_replace(v_check, '(?<!SELECT )' || FUNCTION_WRAP[i][1],
+                                FUNCTION_WRAP[i][2], 'g');
+    END LOOP;
+
+    SELECT string_agg(quote_ident(role_name), ', ')
+      INTO v_roles
+      FROM unnest(r.roles) AS role_name;
+
+    EXECUTE format('DROP POLICY %I ON public.%I', r.policyname, r.tablename);
+
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I AS %s FOR %s TO %s%s%s',
+      r.policyname, r.tablename,
+      CASE WHEN r.permissive = 'PERMISSIVE' THEN 'PERMISSIVE' ELSE 'RESTRICTIVE' END,
+      r.cmd,
+      v_roles,
+      CASE WHEN v_qual  IS NOT NULL THEN ' USING (' || v_qual || ')'      ELSE '' END,
+      CASE WHEN v_check IS NOT NULL THEN ' WITH CHECK (' || v_check || ')' ELSE '' END
+    );
+
+    v_n := v_n + 1;
+  END LOOP;
+
+  RAISE NOTICE 'rls_initplan_wrap: rewrote % policies', v_n;
+
+  -- 收尾自檢：跑完不該再有任何裸呼叫，否則整支回退
+  PERFORM 1
+  FROM pg_policies p
+  WHERE p.schemaname = 'public'
+    AND (COALESCE(p.qual, '') || ' ' || COALESCE(p.with_check, ''))
+        ~ '(?<!SELECT )(auth\.(jwt|uid|role)\(\)|_jwt_store(_location)?_ids\()';
+  IF FOUND THEN
+    RAISE EXCEPTION 'rls_initplan_wrap: 仍有 policy 帶著未提升的 auth 呼叫，已回退';
+  END IF;
+END
+$migration$;

--- a/supabase/migrations/20260818000030_wave_transfer_join_by_id.sql
+++ b/supabase/migrations/20260818000030_wave_transfer_join_by_id.sql
@@ -1,0 +1,307 @@
+-- ============================================================================
+-- 2026-08-18: 撿貨波次 ↔ 轉移單改用「解析出來的 wave id」等值 join，不要用單號 LIKE
+--
+-- 症狀：/wms 派貨工作台的來源查詢（v_picking_demand_by_po，篩
+--   has_stock_left = true AND has_demand_left = true）線上 mean 4.4s / max 5.0s，
+--   帶 RLS 實測 **7.0 秒** —— PostgREST 的上限是 8 秒，已經在 timeout 邊緣。
+--
+-- 原因：transfers 沒有 wave_id 欄位，跟 picking_waves 的唯一關聯是單號字串
+--   `WAVE-<wave_id>-S<store_id>`，於是 view 裡寫成
+--
+--     JOIN picking_waves pw ON t.transfer_no LIKE 'WAVE-' || pw.id || '-S%'
+--
+--   LIKE 的右手邊帶著另一張表的欄位 → 既不能走索引也不能 hash join，planner
+--   只能做巢狀迴圈把兩邊乘開。線上 10,737 張 hq_to_store 轉移單 × 1,160 個有
+--   source_po_id 的波次：
+--
+--     Nested Loop (actual time=0.077..5629.448 rows=10395)
+--       Join Filter: (t_1.transfer_no ~~ (('WAVE-' || pw_1.id) || '-S%'))
+--       Rows Removed by Join Filter: 12,444,525     ← 1,244 萬次字串串接 + LIKE
+--
+--   單這一個節點就 5.6 秒，佔整支 7 秒的 80%。
+--
+-- 修法：把 wave id 從單號解析出來做**等值** join，planner 就能改用 hash join：
+--
+--     JOIN picking_waves pw ON pw.id = substring(t.transfer_no, '^WAVE-(\d+)-S')::bigint
+--
+--   同一個 CTE 裡取 store_id 本來就是這樣寫的（`substring(t.transfer_no,
+--   'WAVE-\d+-S(\d+)')::bigint`），只是 join 這一側沒跟上。
+--
+--   語意相同：substring 對非 WAVE- 開頭的單號回 NULL，`pw.id = NULL` 永遠不成立，
+--   跟 LIKE 一樣把它們排除；而 'WAVE-1-S%' 也不會誤中 'WAVE-12-S3'（LIKE 要求
+--   'WAVE-1' 後面緊接 '-S'）。線上 11,765 張轉移單裡 11,488 張是 WAVE- 開頭，
+--   全部嚴格符合 `^WAVE-\d+-S\d+$`，0 個例外。
+--
+-- 驗證（transaction 內建新 view、對拍後 ROLLBACK）：
+--   v_picking_demand_by_po：兩側各 24,600 列，EXCEPT ALL 雙向都是 **0 筆**差異。
+--     速度 4,188ms → 1,204ms（3.5 倍；上面那個 7 秒是帶 RLS 的數字，
+--     搭配同批的 20260818000020 會再降）。
+--   v_pr_progress：兩側 EXCEPT ALL 雙向 0 筆差異。
+--     它今天還不慢（purchase_requests 只有 298 列，而且 LATERAL 內先用
+--     `pw.source_po_id = poi.po_id` 收斂過），純粹是把同一顆未爆彈一起拆掉。
+--
+-- 基底版本：兩支 view 都是從**線上 pg_get_viewdef() 現況**取出、只替換那一行
+--   join 條件，其餘逐字保留（v_picking_demand_by_po 最近一次是
+--   20260709000000_v_picking_demand_has_stock_left.sql，但不要信這行 —— 依
+--   CLAUDE.md，改之前請重新 grep 一次）。
+--
+-- Rollback：把 `pw.id = substring(...)::bigint` 改回
+--   `t.transfer_no LIKE 'WAVE-' || pw.id || '-S%'`（會慢回去，但語意一樣）。
+--
+-- 沒有對應的前端改動。
+--
+-- ⚠ 後續：同樣的字串 join 在 migration 歷史裡還有十幾處（RPC / 函式內），
+--   grep `WAVE-' ||` 找得到。那些多半是單一 wave id 的等值比對（`t.transfer_no =
+--   'WAVE-' || pwi.wave_id || '-S' || co.pickup_store_id`），常數對常數不會乘開，
+--   所以不在這次範圍。真正的根治是給 transfers 加一個 wave_id 欄位。
+-- ============================================================================
+
+CREATE OR REPLACE VIEW public.v_picking_demand_by_po AS
+WITH po_skus AS (
+         SELECT po.id AS po_id,
+            po.tenant_id,
+            po.po_no,
+            po.status AS po_status,
+            po.supplier_id,
+            poi.id AS po_item_id,
+            poi.sku_id,
+            poi.qty_ordered,
+            (EXISTS ( SELECT 1
+                   FROM purchase_request_items pri2
+                     JOIN restock_requests rr ON rr.linked_pr_id = pri2.pr_id
+                  WHERE pri2.po_item_id = poi.id)) AS is_restock_sourced
+           FROM purchase_orders po
+             JOIN purchase_order_items poi ON poi.po_id = po.id
+          WHERE po.status = ANY (ARRAY['sent'::text, 'partially_received'::text, 'fully_received'::text])
+        ), gr_qty AS (
+         SELECT gri.po_item_id,
+            sum(gri.qty_received) AS gr_qty
+           FROM goods_receipt_items gri
+             JOIN goods_receipts gr ON gr.id = gri.gr_id
+          WHERE gr.status = 'confirmed'::text
+          GROUP BY gri.po_item_id
+        ), po_campaigns AS (
+         SELECT DISTINCT u.po_item_id,
+            u.campaign_id
+           FROM ( SELECT poi.id AS po_item_id,
+                    prc.campaign_id
+                   FROM purchase_order_items poi
+                     JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+                     JOIN purchase_requests pr ON pr.id = pri.pr_id
+                     JOIN purchase_request_campaigns prc ON prc.pr_id = pr.id
+                UNION
+                 SELECT poi.id AS po_item_id,
+                    pri.source_campaign_id AS campaign_id
+                   FROM purchase_order_items poi
+                     JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+                  WHERE pri.source_campaign_id IS NOT NULL) u
+        ), po_campaign_po AS (
+         SELECT DISTINCT poi.po_id,
+            pc0.campaign_id
+           FROM po_campaigns pc0
+             JOIN purchase_order_items poi ON poi.id = pc0.po_item_id
+        ), campaign_demand AS (
+         SELECT pc.po_item_id,
+            co.pickup_store_id AS store_id,
+            sum(coi.qty) AS demand_qty
+           FROM po_campaigns pc
+             JOIN customer_orders co ON co.campaign_id = pc.campaign_id AND (co.status <> ALL (ARRAY['cancelled'::text, 'expired'::text, 'transferred_out'::text])) AND (co.transferred_from_order_id IS NULL OR (EXISTS ( SELECT 1
+                   FROM customer_orders src
+                  WHERE src.id = co.transferred_from_order_id AND src.pickup_store_id = co.pickup_store_id)))
+             JOIN customer_order_items coi ON coi.order_id = co.id AND (coi.status <> ALL (ARRAY['cancelled'::text, 'expired'::text]))
+             JOIN purchase_order_items poi ON poi.id = pc.po_item_id AND poi.sku_id = coi.sku_id
+          GROUP BY pc.po_item_id, co.pickup_store_id
+        ), restock_demand AS (
+         SELECT poi.id AS po_item_id,
+            rr.requesting_store_id AS store_id,
+            sum(rrl.qty) AS demand_qty
+           FROM purchase_order_items poi
+             JOIN purchase_request_items pri ON pri.po_item_id = poi.id
+             JOIN restock_requests rr ON rr.linked_pr_id = pri.pr_id AND (rr.status <> ALL (ARRAY['cancelled'::text, 'rejected'::text]))
+             JOIN restock_request_lines rrl ON rrl.request_id = rr.id AND rrl.sku_id = poi.sku_id
+          GROUP BY poi.id, rr.requesting_store_id
+        ), store_demand AS (
+         SELECT u.po_item_id,
+            u.store_id,
+            sum(u.demand_qty) AS demand_qty
+           FROM ( SELECT campaign_demand.po_item_id,
+                    campaign_demand.store_id,
+                    campaign_demand.demand_qty
+                   FROM campaign_demand
+                UNION ALL
+                 SELECT restock_demand.po_item_id,
+                    restock_demand.store_id,
+                    restock_demand.demand_qty
+                   FROM restock_demand) u
+          GROUP BY u.po_item_id, u.store_id
+        ), wave_qty AS (
+         SELECT u.source_po_id,
+            u.sku_id,
+            u.store_id,
+            sum(u.qty) AS wave_qty
+           FROM ( SELECT pw.source_po_id,
+                    pwi.sku_id,
+                    pwi.store_id,
+                    pwi.qty
+                   FROM picking_wave_items pwi
+                     JOIN picking_waves pw ON pw.id = pwi.wave_id
+                  WHERE pw.status <> 'cancelled'::text AND pw.source_po_id IS NOT NULL
+                UNION ALL
+                 SELECT poi.po_id AS source_po_id,
+                    ti.sku_id,
+                    rr.requesting_store_id AS store_id,
+                    ti.qty_requested
+                   FROM restock_requests rr
+                     JOIN transfers t ON t.id = rr.linked_transfer_id
+                     JOIN transfer_items ti ON ti.transfer_id = t.id
+                     JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+                     JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+                  WHERE t.transfer_type = 'hq_to_store'::text AND t.status <> 'cancelled'::text
+                UNION ALL
+                 SELECT pcp.po_id AS source_po_id,
+                    pwi.sku_id,
+                    pwi.store_id,
+                    pwi.qty
+                   FROM picking_wave_items pwi
+                     JOIN picking_waves pw ON pw.id = pwi.wave_id
+                     JOIN po_campaign_po pcp ON pcp.campaign_id = pwi.campaign_id
+                  WHERE pw.status <> 'cancelled'::text AND pw.source_po_id IS NOT NULL AND pwi.campaign_id IS NOT NULL AND pcp.po_id <> pw.source_po_id AND NOT (EXISTS ( SELECT 1
+                           FROM po_campaign_po own
+                          WHERE own.po_id = pw.source_po_id AND own.campaign_id = pwi.campaign_id))) u
+          GROUP BY u.source_po_id, u.sku_id, u.store_id
+        ), po_sku_already_wave AS (
+         SELECT u.po_id,
+            u.sku_id,
+            sum(u.qty) AS already_wave
+           FROM ( SELECT pw.source_po_id AS po_id,
+                    pwi.sku_id,
+                    pwi.qty
+                   FROM picking_wave_items pwi
+                     JOIN picking_waves pw ON pw.id = pwi.wave_id
+                  WHERE pw.status <> 'cancelled'::text AND pw.source_po_id IS NOT NULL
+                UNION ALL
+                 SELECT poi.po_id,
+                    ti.sku_id,
+                    ti.qty_requested AS qty
+                   FROM restock_requests rr
+                     JOIN transfers t ON t.id = rr.linked_transfer_id
+                     JOIN transfer_items ti ON ti.transfer_id = t.id
+                     JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+                     JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+                  WHERE t.transfer_type = 'hq_to_store'::text AND t.status <> 'cancelled'::text) u
+          GROUP BY u.po_id, u.sku_id
+        ), po_sku_demand_left AS (
+         SELECT ps_1.po_id,
+            ps_1.sku_id,
+            sum(GREATEST(0::numeric, COALESCE(sd_1.demand_qty, 0::numeric) - COALESCE(wq_1.wave_qty, 0::numeric))) AS demand_left
+           FROM po_skus ps_1
+             JOIN store_demand sd_1 ON sd_1.po_item_id = ps_1.po_item_id
+             LEFT JOIN wave_qty wq_1 ON wq_1.source_po_id = ps_1.po_id AND wq_1.sku_id = ps_1.sku_id AND wq_1.store_id = sd_1.store_id
+          GROUP BY ps_1.po_id, ps_1.sku_id
+        ), shipped_qty AS (
+         SELECT u.source_po_id,
+            u.sku_id,
+            u.store_id,
+            sum(u.qty_received) AS shipped_qty
+           FROM ( SELECT pw.source_po_id,
+                    ti.sku_id,
+                    "substring"(t.transfer_no, 'WAVE-\d+-S(\d+)'::text)::bigint AS store_id,
+                    ti.qty_received
+                   FROM transfers t
+                     JOIN transfer_items ti ON ti.transfer_id = t.id
+                     JOIN picking_waves pw ON pw.id = ("substring"(t.transfer_no, '^WAVE-(\d+)-S'::text))::bigint
+                  WHERE t.transfer_type = 'hq_to_store'::text AND (t.status = ANY (ARRAY['received'::text, 'closed'::text])) AND pw.source_po_id IS NOT NULL
+                UNION ALL
+                 SELECT poi.po_id AS source_po_id,
+                    ti.sku_id,
+                    rr.requesting_store_id AS store_id,
+                    ti.qty_received
+                   FROM restock_requests rr
+                     JOIN transfers t ON t.id = rr.linked_transfer_id
+                     JOIN transfer_items ti ON ti.transfer_id = t.id
+                     JOIN purchase_request_items pri ON pri.pr_id = rr.linked_pr_id
+                     JOIN purchase_order_items poi ON poi.id = pri.po_item_id AND poi.sku_id = ti.sku_id
+                  WHERE t.transfer_type = 'hq_to_store'::text AND (t.status = ANY (ARRAY['received'::text, 'closed'::text]))) u
+          GROUP BY u.source_po_id, u.sku_id, u.store_id
+        )
+ SELECT ps.tenant_id,
+    ps.po_id,
+    ps.po_no,
+    ps.po_status,
+    ps.supplier_id,
+    ps.po_item_id,
+    ps.sku_id,
+    s.sku_code,
+    COALESCE(s.product_name, ''::text) || COALESCE(' '::text || NULLIF(s.variant_name, ''::text), ''::text) AS sku_label,
+    ps.qty_ordered,
+    COALESCE(g.gr_qty, 0::numeric) AS gr_qty,
+        CASE
+            WHEN ps.po_status <> 'fully_received'::text THEN GREATEST(0::numeric, ps.qty_ordered - COALESCE(g.gr_qty, 0::numeric))
+            ELSE 0::numeric
+        END AS qty_in_transit,
+        CASE
+            WHEN ps.po_status = 'fully_received'::text AND COALESCE(g.gr_qty, 0::numeric) < ps.qty_ordered THEN ps.qty_ordered - COALESCE(g.gr_qty, 0::numeric)
+            ELSE 0::numeric
+        END AS qty_shortage,
+    sd.store_id,
+    st.code AS store_code,
+    st.name AS store_name,
+    COALESCE(sd.demand_qty, 0::numeric) AS demand_qty,
+    COALESCE(wq.wave_qty, 0::numeric) AS wave_qty,
+    COALESCE(sq.shipped_qty, 0::numeric) AS shipped_qty,
+    ps.is_restock_sourced,
+    COALESCE(psaw.already_wave, 0::numeric) AS po_sku_already_wave,
+    COALESCE(g.gr_qty, 0::numeric) > COALESCE(psaw.already_wave, 0::numeric) AS has_stock_left,
+    COALESCE(dl.demand_left, 0::numeric) > 0::numeric AS has_demand_left
+   FROM po_skus ps
+     JOIN skus s ON s.id = ps.sku_id
+     LEFT JOIN gr_qty g ON g.po_item_id = ps.po_item_id
+     LEFT JOIN store_demand sd ON sd.po_item_id = ps.po_item_id
+     LEFT JOIN stores st ON st.id = sd.store_id
+     LEFT JOIN wave_qty wq ON wq.source_po_id = ps.po_id AND wq.sku_id = ps.sku_id AND wq.store_id = sd.store_id
+     LEFT JOIN shipped_qty sq ON sq.source_po_id = ps.po_id AND sq.sku_id = ps.sku_id AND sq.store_id = sd.store_id
+     LEFT JOIN po_sku_already_wave psaw ON psaw.po_id = ps.po_id AND psaw.sku_id = ps.sku_id
+     LEFT JOIN po_sku_demand_left dl ON dl.po_id = ps.po_id AND dl.sku_id = ps.sku_id
+  WHERE COALESCE(sq.shipped_qty, 0::numeric) < GREATEST(COALESCE(g.gr_qty, 0::numeric), 1::numeric) AND (COALESCE(g.gr_qty, 0::numeric) > 0::numeric OR COALESCE(sd.demand_qty, 0::numeric) > 0::numeric);
+
+CREATE OR REPLACE VIEW public.v_pr_progress AS
+SELECT pr.id AS pr_id,
+    pr.tenant_id,
+    pr.source_close_date,
+    COALESCE(po_agg.po_total, 0::bigint) AS po_total,
+    COALESCE(po_agg.po_sent, 0::bigint) AS po_sent,
+    COALESCE(po_agg.po_received_fully, 0::bigint) AS po_received_fully,
+    COALESCE(xfer_agg.transfer_total, 0::bigint) AS transfer_total,
+    COALESCE(xfer_agg.transfer_shipped, 0::bigint) AS transfer_shipped,
+    COALESCE(xfer_agg.transfer_delivered, 0::bigint) AS transfer_delivered,
+    COALESCE(item_agg.item_count, 0::bigint) AS item_count,
+    COALESCE(item_agg.unassigned_supplier_count, 0::bigint) AS unassigned_supplier_count,
+        CASE
+            WHEN pr.source_close_date IS NULL THEN false
+            WHEN cmp.total_campaigns = 0 THEN false
+            ELSE cmp.completed_campaigns = cmp.total_campaigns
+        END AS all_campaigns_finalized
+   FROM purchase_requests pr
+     LEFT JOIN LATERAL ( SELECT count(DISTINCT po.id) AS po_total,
+            count(DISTINCT po.id) FILTER (WHERE po.status = ANY (ARRAY['sent'::text, 'partially_received'::text, 'fully_received'::text, 'closed'::text])) AS po_sent,
+            count(DISTINCT po.id) FILTER (WHERE po.status = ANY (ARRAY['fully_received'::text, 'closed'::text])) AS po_received_fully
+           FROM purchase_request_items pri
+             JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+             JOIN purchase_orders po ON po.id = poi.po_id
+          WHERE pri.pr_id = pr.id) po_agg ON true
+     LEFT JOIN LATERAL ( SELECT count(DISTINCT t.id) AS transfer_total,
+            count(DISTINCT t.id) FILTER (WHERE t.status = ANY (ARRAY['shipped'::text, 'received'::text, 'closed'::text])) AS transfer_shipped,
+            count(DISTINCT t.id) FILTER (WHERE t.status = ANY (ARRAY['received'::text, 'closed'::text])) AS transfer_delivered
+           FROM purchase_request_items pri
+             JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+             JOIN picking_waves pw ON pw.source_po_id = poi.po_id
+             JOIN transfers t ON t.tenant_id = pr.tenant_id AND t.transfer_type = 'hq_to_store'::text AND pw.id = ("substring"(t.transfer_no, '^WAVE-(\d+)-S'::text))::bigint
+          WHERE pri.pr_id = pr.id AND pri.po_item_id IS NOT NULL) xfer_agg ON true
+     LEFT JOIN LATERAL ( SELECT count(*) AS item_count,
+            count(*) FILTER (WHERE pri.suggested_supplier_id IS NULL) AS unassigned_supplier_count
+           FROM purchase_request_items pri
+          WHERE pri.pr_id = pr.id) item_agg ON true
+     LEFT JOIN LATERAL ( SELECT count(*) AS total_campaigns,
+            count(*) FILTER (WHERE gbc.status = 'completed'::text) AS completed_campaigns
+           FROM group_buy_campaigns gbc
+          WHERE gbc.tenant_id = pr.tenant_id AND pr.source_close_date IS NOT NULL AND date((gbc.end_at AT TIME ZONE 'Asia/Taipei'::text)) = pr.source_close_date AND gbc.status <> 'cancelled'::text) cmp ON true;

--- a/supabase/migrations/20260818000030_wave_transfer_join_by_id.sql
+++ b/supabase/migrations/20260818000030_wave_transfer_join_by_id.sql
@@ -32,7 +32,9 @@
 --   'WAVE-1' 後面緊接 '-S'）。線上 11,765 張轉移單裡 11,488 張是 WAVE- 開頭，
 --   全部嚴格符合 `^WAVE-\d+-S\d+$`，0 個例外。
 --
--- 驗證（transaction 內建新 view、對拍後 ROLLBACK）：
+-- 驗證（transaction 內建新 view、對拍後 ROLLBACK；一定要開
+--   `ISOLATION LEVEL REPEATABLE READ`，否則正式庫同時間的寫入會被算成假差異，
+--   理由見同批的 20260818000020 檔頭）：
 --   v_picking_demand_by_po：兩側各 24,600 列，EXCEPT ALL 雙向都是 **0 筆**差異。
 --     速度 4,188ms → 1,204ms（3.5 倍；上面那個 7 秒是帶 RLS 的數字，
 --     搭配同批的 20260818000020 會再降）。


### PR DESCRIPTION
## Summary

Two performance optimizations targeting slow query execution in production:

1. **RLS policy InitPlan wrapping** (20260818000020): Wrap `auth.jwt()` and related functions in scalar subqueries to force Postgres to evaluate them once per query instead of once per row, eliminating redundant JWT parsing.

2. **Picking wave transfer join optimization** (20260818000030): Replace string LIKE pattern matching with equality join on parsed wave IDs to enable hash joins instead of nested loops.

## Key Changes

### RLS Policy InitPlan Wrapping (20260818000020)
- Wrapped all `auth.jwt()`, `auth.uid()`, `auth.role()` calls in `(SELECT ...)` scalar subqueries across 169 RLS policies on 103 tables
- Special handling for `= ANY()` array comparisons: wrapped in `COALESCE((SELECT f()), '{}'::bigint[])` to preserve array semantics
- Affected policies: `aid_clearance_offers`, `backorders`, `barcodes`, `brands`, `campaign_*`, `customer_*`, `demand_requests`, `expenses`, `goods_receipts`, `group_buy_campaigns`, `line_channels`, `member_*`, `mutual_aid_*`, `notifications`, `order_*`, `petty_cash_*`, `picking_*`, `points_ledger`, `pos_sales`, `post_templates`, `products`, `purchase_*`, `restock_requests`, `stock_*`, `store_*`, `transfer_*`, `user_profiles`, `warehouse_*`

**Performance impact**: 9× speedup on stock_balances list (156.9ms → 17.5ms), 59× reduction in buffer hits

**Verification**: 927 test cases (103 tables × 9 identity types) with 0 mismatches and 0 errors

### Picking Wave Transfer Join Optimization (20260818000030)
- `v_picking_demand_by_po`: Changed join from `LIKE 'WAVE-' || pw.id || '-S%'` to equality on parsed wave ID: `pw.id = substring(t.transfer_no, '^WAVE-(\d+)-S')::bigint`
- `v_pr_progress`: Applied same optimization to transfer-to-wave join
- Enables hash join instead of nested loop with 12.4M join filter iterations

**Performance impact**: 3.5× speedup on v_picking_demand_by_po (4,188ms → 1,204ms)

**Verification**: Both views produce identical result sets (0 EXCEPT ALL differences)

## Implementation Details

- All 169 RLS policies regenerated from live `pg_catalog` (pg_policies.qual/with_check) to preserve all prior fixes including app_metadata role path corrections and legacy admin empty-string allowances
- Wave ID extraction uses regex `^WAVE-(\d+)-S` matching the existing store ID extraction pattern `WAVE-\d+-S(\d+)`
- No semantic changes: substring returns NULL for non-WAVE transfers (same exclusion as LIKE), and strict format validation confirms all 11,488 WAVE transfers match `^WAVE-\d+-S\d+$` with zero exceptions
- No frontend changes required

## Rollback

- RLS: Replace `(SELECT auth.xxx())` with `auth.xxx()` and `ANY (COALESCE((SELECT f()), '{}'))` with `ANY (f())`
- Views: Revert join conditions to original LIKE patterns
- Pure performance changes with no correctness impact

https://claude.ai/code/session_01HLTZEhSk4SHXdEkL5WTqYD