### PR TITLE
互助訂單顯示「從哪一家店 → 到哪一家店」：收件匣列標題與訂單明細都補上轉移路徑

### DIFF
--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -122,6 +122,12 @@ type AidRaw = {
   updated_at: string;
   line_count: number;
   items_summary: string;
+  // 來源（轉出）端 —— 轉入單本身只寫得出取貨店＝收貨的那一頭，
+  // 總倉光看「→ 三峽店」不知道要跟誰收貨、也不知道經不經自己的手。
+  transferred_from_order_id: number | null;
+  from_order_no: string | null;
+  from_store_id: number | null;
+  from_store_name: string | null;
 };
 
 type ShortageRaw = {
@@ -488,6 +494,87 @@ async function fetchTransferRows(
   return { rows, total: count ?? 0 };
 }
 
+const AID_SELECT = `id, order_no, status, is_air_transfer, pickup_store_id, transferred_from_order_id, updated_at,
+       campaign:group_buy_campaigns(id, campaign_no, name),
+       store:stores!customer_orders_pickup_store_id_fkey(id, name),
+       items:customer_order_items!inner(id, source)`;
+
+type AidQueryRow = {
+  id: number;
+  order_no: string;
+  status: AidStatus;
+  is_air_transfer: boolean | null;
+  pickup_store_id: number | null;
+  transferred_from_order_id: number | null;
+  updated_at: string;
+  campaign?: { id: number; campaign_no: string; name: string } | null;
+  store?: { id: number; name: string } | null;
+  items?: { id: number }[];
+};
+
+// 來源單 → 轉出店。查失敗不擋收件匣(路徑欄退回「—」而已),所以不 throw。
+async function fetchAidSourceMap(
+  sb: SBClient,
+  srcIds: number[],
+): Promise<Map<number, { order_no: string; store_id: number | null; store_name: string | null }>> {
+  const map = new Map<number, { order_no: string; store_id: number | null; store_name: string | null }>();
+  const ids = Array.from(new Set(srcIds));
+  if (ids.length === 0) return map;
+  const { data } = await sb
+    .from("customer_orders")
+    .select("id, order_no, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)")
+    .in("id", ids);
+  const rows = (data ?? []) as unknown as Array<{
+    id: number;
+    order_no: string;
+    pickup_store_id: number | null;
+    store: { name: string } | { name: string }[] | null;
+  }>;
+  for (const r of rows) {
+    map.set(r.id, {
+      order_no: r.order_no,
+      store_id: r.pickup_store_id,
+      store_name: (Array.isArray(r.store) ? r.store[0]?.name : r.store?.name) ?? null,
+    });
+  }
+  return map;
+}
+
+async function toAidRows(sb: SBClient, aidRows: AidQueryRow[], airMode: "aid" | "air"): Promise<Row[]> {
+  const [itemsMap, srcMap] = await Promise.all([
+    fetchItemsSummaryMap(sb, "customer_order_items", "order_id", aidRows.map((a) => a.id), "qty"),
+    fetchAidSourceMap(
+      sb,
+      aidRows.map((a) => a.transferred_from_order_id).filter((x): x is number => x != null),
+    ),
+  ]);
+  return aidRows.map((a) => {
+    const src = a.transferred_from_order_id != null ? srcMap.get(a.transferred_from_order_id) : undefined;
+    return {
+      key: `${airMode}-${a.id}`,
+      source: airMode,
+      ts: new Date(a.updated_at).getTime(),
+      stage: classifyAid(a.status),
+      raw: {
+        id: a.id,
+        order_no: a.order_no,
+        status: a.status,
+        is_air_transfer: a.is_air_transfer,
+        pickup_store_id: a.pickup_store_id,
+        store_name: a.store?.name ?? null,
+        campaign_no: a.campaign?.campaign_no ?? null,
+        updated_at: a.updated_at,
+        line_count: a.items?.length ?? 0,
+        items_summary: itemsMap.get(a.id) ?? "",
+        transferred_from_order_id: a.transferred_from_order_id,
+        from_order_no: src?.order_no ?? null,
+        from_store_id: src?.store_id ?? null,
+        from_store_name: src?.store_name ?? null,
+      },
+    };
+  });
+}
+
 // airMode: "aid" = 互助訂單(排除空中轉,只 is_air_transfer 為 null/false)
 //          "air" = 空中轉(只 is_air_transfer=true)
 async function fetchAidRows(
@@ -502,13 +589,7 @@ async function fetchAidRows(
   if (stage === "standby") return { rows: [], total: 0 }; // 只有 restock 有候補
   let q = sb
     .from("customer_orders")
-    .select(
-      `id, order_no, status, is_air_transfer, pickup_store_id, updated_at,
-       campaign:group_buy_campaigns(id, campaign_no, name),
-       store:stores!customer_orders_pickup_store_id_fkey(id, name),
-       items:customer_order_items!inner(id, source)`,
-      { count: "exact" },
-    )
+    .select(AID_SELECT, { count: "exact" })
     .eq("items.source", "aid_transfer")
     .order("updated_at", { ascending: false });
   if (stage) q = q.in("status", AID_STATUS_BY_STAGE[stage] as string[]);
@@ -522,39 +603,7 @@ async function fetchAidRows(
   const { data, count, error } = await q;
   if (error) throw new Error("aid: " + error.message);
 
-  const aidRows = (data ?? []) as unknown as Array<{
-    id: number;
-    order_no: string;
-    status: AidStatus;
-    is_air_transfer: boolean | null;
-    pickup_store_id: number | null;
-    updated_at: string;
-    campaign?: { id: number; campaign_no: string; name: string } | null;
-    store?: { id: number; name: string } | null;
-    items?: { id: number }[];
-  }>;
-
-  const aidIds = aidRows.map((a) => a.id);
-  const itemsMap = await fetchItemsSummaryMap(sb, "customer_order_items", "order_id", aidIds, "qty");
-
-  const rows: Row[] = aidRows.map((a) => ({
-    key: `${airMode}-${a.id}`,
-    source: airMode,
-    ts: new Date(a.updated_at).getTime(),
-    stage: classifyAid(a.status),
-    raw: {
-      id: a.id,
-      order_no: a.order_no,
-      status: a.status,
-      is_air_transfer: a.is_air_transfer,
-      pickup_store_id: a.pickup_store_id,
-      store_name: a.store?.name ?? null,
-      campaign_no: a.campaign?.campaign_no ?? null,
-      updated_at: a.updated_at,
-      line_count: a.items?.length ?? 0,
-      items_summary: itemsMap.get(a.id) ?? "",
-    },
-  }));
+  const rows = await toAidRows(sb, (data ?? []) as unknown as AidQueryRow[], airMode);
   return { rows, total: count ?? 0 };
 }
 
@@ -781,48 +830,14 @@ async function fetchAidRowsByIds(sb: SBClient, ids: number[], airMode: "aid" | "
   if (ids.length === 0) return [];
   let q = sb
     .from("customer_orders")
-    .select(
-      `id, order_no, status, is_air_transfer, pickup_store_id, updated_at,
-       campaign:group_buy_campaigns(id, campaign_no, name),
-       store:stores!customer_orders_pickup_store_id_fkey(id, name),
-       items:customer_order_items!inner(id, source)`,
-    )
+    .select(AID_SELECT)
     .eq("items.source", "aid_transfer")
     .in("id", ids);
   if (airMode === "air") q = q.eq("is_air_transfer", true);
   else q = q.or("is_air_transfer.is.null,is_air_transfer.eq.false");
   const { data, error } = await q;
   if (error) throw new Error("aid: " + error.message);
-  const aidRows = (data ?? []) as unknown as Array<{
-    id: number;
-    order_no: string;
-    status: AidStatus;
-    is_air_transfer: boolean | null;
-    pickup_store_id: number | null;
-    updated_at: string;
-    campaign?: { id: number; campaign_no: string; name: string } | null;
-    store?: { id: number; name: string } | null;
-    items?: { id: number }[];
-  }>;
-  const itemsMap = await fetchItemsSummaryMap(sb, "customer_order_items", "order_id", aidRows.map((a) => a.id), "qty");
-  return aidRows.map((a) => ({
-    key: `${airMode}-${a.id}`,
-    source: airMode,
-    ts: new Date(a.updated_at).getTime(),
-    stage: classifyAid(a.status),
-    raw: {
-      id: a.id,
-      order_no: a.order_no,
-      status: a.status,
-      is_air_transfer: a.is_air_transfer,
-      pickup_store_id: a.pickup_store_id,
-      store_name: a.store?.name ?? null,
-      campaign_no: a.campaign?.campaign_no ?? null,
-      updated_at: a.updated_at,
-      line_count: a.items?.length ?? 0,
-      items_summary: itemsMap.get(a.id) ?? "",
-    },
-  }));
+  return toAidRows(sb, (data ?? []) as unknown as AidQueryRow[], airMode);
 }
 
 async function fetchShortageRowsByIds(sb: SBClient, ids: number[]): Promise<Row[]> {
@@ -1188,7 +1203,9 @@ function HqInboxContent() {
           .filter((x): x is string => !!x).some((x) => x.toLowerCase().includes(q));
       }
       const a = r.raw;
-      return [a.order_no, a.store_name, a.campaign_no].filter((x): x is string => !!x).some((x) => x.toLowerCase().includes(q));
+      // 轉出店 / 來源單號也要搜得到 —— 列上顯示的就是「轉出店 → 收貨店」
+      return [a.order_no, a.store_name, a.campaign_no, a.from_store_name, a.from_order_no]
+        .filter((x): x is string => !!x).some((x) => x.toLowerCase().includes(q));
     });
   }, [rows, search]);
 
@@ -2582,7 +2599,7 @@ function MailRow({
     // (之前做成純唯讀 + 分店看不到 /hq/inbox,結果全站沒人有入口,線上卡了 5 張)。
     const a = row.raw;
     idText = a.order_no;
-    title = <>{a.campaign_no ?? "—"} <span className="text-zinc-400 mx-1">→</span> {a.store_name ?? "—"}</>;
+    title = <AidRouteTitle a={a} />;
     subtitle = (
       <>
         {a.line_count} 項
@@ -2601,7 +2618,7 @@ function MailRow({
   } else {
     const a = row.raw;
     idText = a.order_no;
-    title = <>{a.campaign_no ?? "—"} <span className="text-zinc-400 mx-1">→</span> {a.store_name ?? "—"}</>;
+    title = <AidRouteTitle a={a} />;
     subtitle = (
       <>
         {a.line_count} 項
@@ -2699,6 +2716,30 @@ function MailRow({
         <span className="text-[11px] text-zinc-400 sm:text-right">{time}</span>
       </div>
     </div>
+  );
+}
+
+// 互助 / 空中轉列的標題：貨「從哪一家店 → 到哪一家店」。
+// 原本標的是「開團 → 取貨店」——取貨店只是收貨的那一頭，總倉看不出要跟誰收貨，
+// 而經總倉的互助正是總倉要親手轉交的（Leg-1 來源店 → 總倉、Leg-2 總倉 → 收貨店，
+// 20260510000004）。另外全站 375 張互助轉入單裡有 359 張其實是同店轉單
+// （只是換客人、貨沒離開本店，rpc_ship_aid_order 也會擋下派貨），標出來才不會
+// 跟真的要中轉的混在一起。
+function AidRouteTitle({ a }: { a: AidRaw }) {
+  const dest = a.store_name ?? "—";
+  const sameStore = a.from_store_id != null && a.from_store_id === a.pickup_store_id;
+  if (sameStore) {
+    return (
+      <>
+        {dest}
+        <span className="ml-1 text-xs font-normal text-zinc-500">（同店轉單・貨沒有移動）</span>
+      </>
+    );
+  }
+  return (
+    <>
+      {a.from_store_name ?? "—"} <span className="text-zinc-400 mx-1">→</span> {dest}
+    </>
   );
 }
 

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -109,6 +109,16 @@ type OutgoingAidOrder = {
   is_air_transfer: boolean;
 };
 
+// 本單是「轉入單」時的來源（貨從哪一家店、哪一張單轉過來的）。
+// 互助 / 空中轉 / 同店換客人都走 transferred_from_order_id，
+// 差別只在兩邊的取貨店是不是同一家（同店＝貨沒有移動）。
+type TransferSource = {
+  id: number;
+  order_no: string;
+  store_id: number | null;
+  store_name: string;
+};
+
 // 品項狀態標籤（部分取貨會把一行拆成「已取」+「待取」兩行，標籤讓兩者一眼可分）
 function itemStatusBadge(status: string, stockout = false): { label: string; cls: string } | null {
   // 斷貨取消（stockout_at 有值）與一般取消區分顯示
@@ -207,6 +217,8 @@ export function OrderDetail({
   const [outgoingAid, setOutgoingAid] = useState<OutgoingAidOrder[]>([]);
   // 本單自己是空中轉轉入單且還在等出貨時，轉出店店名（給接收店看「在等誰」）
   const [awaitingAirFrom, setAwaitingAirFrom] = useState<string | null>(null);
+  // 本單是轉入單時的來源單／轉出店（單頭「轉移路徑」欄用）
+  const [transferSource, setTransferSource] = useState<TransferSource | null>(null);
   // sku_id → 現行分店價（prices scope=branch, effective_to IS NULL）
   const [branchPrices, setBranchPrices] = useState<Map<number, number>>(new Map());
   const [error, setError] = useState<string | null>(null);
@@ -350,22 +362,37 @@ export function OrderDetail({
           })),
       );
 
-      // 本單自己就是等出貨的空中轉轉入單 → 讓接收店看得到在等哪一家出貨
-      if (headData.is_air_transfer && headData.status === "confirmed" && headData.transferred_from_order_id) {
+      // ========== 本單是轉入單 → 貨是從哪一家店轉過來的 ==========
+      // 單頭只寫得出「取貨店」（＝收貨的那一端），看不出貨的來處；經總倉的互助更
+      // 是三方（轉出店 → 總倉 → 收貨店），總倉在收件匣點進來只看到「→ 三峽店」，
+      // 不知道要跟誰收貨。所以一律把來源查出來，單頭補一欄「轉移路徑」。
+      if (headData.transferred_from_order_id) {
         const { data: srcRow } = await sb
           .from("customer_orders")
-          .select("pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)")
+          .select("id, order_no, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)")
           .eq("id", headData.transferred_from_order_id)
           .maybeSingle();
+        if (cancelled) return;
         const src = srcRow as unknown as
-          { pickup_store_id: number | null; store: { name: string } | { name: string }[] | null } | null;
+          {
+            id: number; order_no: string; pickup_store_id: number | null;
+            store: { name: string } | { name: string }[] | null;
+          } | null;
         const st = src?.store;
+        const srcStoreName = (Array.isArray(st) ? st[0]?.name : st?.name) ?? "轉出店";
+        setTransferSource(
+          src
+            ? { id: src.id, order_no: src.order_no, store_id: src.pickup_store_id, store_name: srcStoreName }
+            : null,
+        );
+        // 本單自己就是等出貨的空中轉轉入單 → 讓接收店看得到在等哪一家出貨。
         // 同店不需要出貨（rpc_ship_aid_order 也會擋），不掛「等出貨」
         const sameStore = src?.pickup_store_id === headData.pickup_store_id;
-        if (!cancelled) {
-          setAwaitingAirFrom(sameStore ? null : (Array.isArray(st) ? st[0]?.name : st?.name) ?? "轉出店");
-        }
+        setAwaitingAirFrom(
+          headData.is_air_transfer && headData.status === "confirmed" && !sameStore ? srcStoreName : null,
+        );
       } else if (!cancelled) {
+        setTransferSource(null);
         setAwaitingAirFrom(null);
       }
 
@@ -1136,6 +1163,15 @@ export function OrderDetail({
           );
         })()}
         <Field label="取貨店" value={head.store?.name ?? "—"} />
+        {head.transferred_from_order_id != null && (
+          <TransferRouteField
+            source={transferSource}
+            destName={head.store?.name ?? "—"}
+            destStoreId={head.pickup_store_id}
+            isAir={head.is_air_transfer === true}
+            onNavigate={onNavigate}
+          />
+        )}
         <Field
           label="下單來源"
           value={
@@ -1866,6 +1902,75 @@ function Timeline({ steps }: { steps: TimelineStep[] | null }) {
         ))}
       </ol>
     </div>
+  );
+}
+
+// 轉入單的「貨從哪一家店來、要到哪一家店」。
+// 經總倉的互助中間還會過總倉一手（20260510000004 拆成 Leg-1 / Leg-2），
+// 那一段對總倉自己最重要 —— 他們要照單把貨轉交出去，所以整條路徑都寫出來。
+function TransferRouteField({
+  source,
+  destName,
+  destStoreId,
+  isAir,
+  onNavigate,
+}: {
+  source: TransferSource | null;
+  destName: string;
+  destStoreId: number | null;
+  isAir: boolean;
+  onNavigate?: (orderId: number, orderNo: string) => void;
+}) {
+  // 同店轉單（換客人／併單）貨沒有離開本店，畫成「A → A」會被當成要出貨
+  const sameStore = source != null && source.store_id != null && source.store_id === destStoreId;
+  const srcLabel = `來源訂單 ${source?.order_no ?? ""}`;
+  return (
+    <Field
+      label="轉移路徑"
+      value={
+        <div>
+          {sameStore ? (
+            <span>
+              {destName}
+              <span className="ml-1 text-xs text-zinc-500">（同店轉單・貨沒有移動）</span>
+            </span>
+          ) : (
+            <span className="inline-flex flex-wrap items-baseline gap-x-1">
+              <span className="font-medium">{source?.store_name ?? "—"}</span>
+              <span className="text-zinc-400">→</span>
+              {!isAir && (
+                <>
+                  <span className="text-zinc-500">總倉</span>
+                  <span className="text-zinc-400">→</span>
+                </>
+              )}
+              <span className="font-medium">{destName}</span>
+              <span className="text-xs text-zinc-500">{isAir ? "（✈ 空中轉直送）" : "（經總倉）"}</span>
+            </span>
+          )}
+          {source && (
+            <div className="text-xs">
+              {onNavigate ? (
+                <button
+                  type="button"
+                  onClick={() => onNavigate(source.id, source.order_no)}
+                  className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {srcLabel}
+                </button>
+              ) : (
+                <a
+                  href={withBasePath(`/orders?id=${source.id}`)}
+                  className="font-mono text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {srcLabel}
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+      }
+    />
   );
 }
 


### PR DESCRIPTION
總倉收件匣的互助訂單列標的是「開團 → 取貨店」，而取貨店只是收貨的那一頭 ——
經總倉的互助正好是總倉要親手轉交的（Leg-1 來源店 → 總倉、Leg-2 總倉 → 收貨店，
20260510000004），總倉看著「GRP-20260721-025 → 三峽店」不知道要跟誰收貨。
明細 modal 也一樣：單頭只有「取貨店 三峽店」，來源只藏在備註那句
「[轉入 (經總倉) ← 訂單 #58792]」裡，是訂單 id、不是店名。

- /hq/inbox 互助訂單 / 空中轉列：標題改成「轉出店 → 收貨店」（來源單的
  pickup_store_id）。開團編號本來就在旁邊的單號裡，沒有資訊損失。
- 訂單明細單頭新增「轉移路徑」欄：經總倉畫成「A → 總倉 → B」、空中轉畫成
  「A → B（✈ 空中轉直送）」，底下掛可點的來源單號。
- 搜尋列一併吃轉出店店名與來源單號。

順帶把同店轉單標出來（「三峽店（同店轉單・貨沒有移動）」）：那是換客人／併單，
貨沒有離開本店、rpc_ship_aid_order 也會擋下派貨。線上 375 張互助轉入單裡有
359 張是這種，目前收件匣待處理的 17 張裡佔 10 張，跟真的要中轉的混在一起
看不出差別。

實作上兩支 aid fetcher（列表 / 批次 by ids）本來各自展開一份一模一樣的
mapping，收斂成共用的 AID_SELECT + toAidRows，來源店只多一趟 in.(ids) 查詢。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A14sKGdFNxVgvsXocCzBkg