### PR TITLE
同店轉單不進總倉待辦：不用總倉確認、也不用派貨

### DIFF
--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -494,10 +494,13 @@ async function fetchTransferRows(
   return { rows, total: count ?? 0 };
 }
 
-const AID_SELECT = `id, order_no, status, is_air_transfer, pickup_store_id, transferred_from_order_id, updated_at,
-       campaign:group_buy_campaigns(id, campaign_no, name),
-       store:stores!customer_orders_pickup_store_id_fkey(id, name),
-       items:customer_order_items!inner(id, source)`;
+// 收件匣的互助 / 空中轉列一律走 v_hq_inbox_aid（20260818000040）：
+// 它已經排除同店轉單（貨沒有移動、總倉不用確認也不用派貨），並把轉出端
+// （來源單 / 轉出店）查好 —— PostgREST 直查 customer_orders 做不到
+// 「來源單.pickup_store_id = 本單.pickup_store_id」這種欄位對欄位比較。
+const AID_SELECT = `id, order_no, status, is_air_transfer, pickup_store_id,
+       transferred_from_order_id, updated_at, campaign_no, store_name,
+       from_order_no, from_store_id, from_store_name, line_count`;
 
 type AidQueryRow = {
   id: number;
@@ -507,76 +510,42 @@ type AidQueryRow = {
   pickup_store_id: number | null;
   transferred_from_order_id: number | null;
   updated_at: string;
-  campaign?: { id: number; campaign_no: string; name: string } | null;
-  store?: { id: number; name: string } | null;
-  items?: { id: number }[];
+  campaign_no: string | null;
+  store_name: string | null;
+  from_order_no: string | null;
+  from_store_id: number | null;
+  from_store_name: string | null;
+  line_count: number | null;
 };
 
-// 來源單 → 轉出店。查失敗不擋收件匣(路徑欄退回「—」而已),所以不 throw。
-async function fetchAidSourceMap(
-  sb: SBClient,
-  srcIds: number[],
-): Promise<Map<number, { order_no: string; store_id: number | null; store_name: string | null }>> {
-  const map = new Map<number, { order_no: string; store_id: number | null; store_name: string | null }>();
-  const ids = Array.from(new Set(srcIds));
-  if (ids.length === 0) return map;
-  const { data } = await sb
-    .from("customer_orders")
-    .select("id, order_no, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)")
-    .in("id", ids);
-  const rows = (data ?? []) as unknown as Array<{
-    id: number;
-    order_no: string;
-    pickup_store_id: number | null;
-    store: { name: string } | { name: string }[] | null;
-  }>;
-  for (const r of rows) {
-    map.set(r.id, {
-      order_no: r.order_no,
-      store_id: r.pickup_store_id,
-      store_name: (Array.isArray(r.store) ? r.store[0]?.name : r.store?.name) ?? null,
-    });
-  }
-  return map;
-}
-
 async function toAidRows(sb: SBClient, aidRows: AidQueryRow[], airMode: "aid" | "air"): Promise<Row[]> {
-  const [itemsMap, srcMap] = await Promise.all([
-    fetchItemsSummaryMap(sb, "customer_order_items", "order_id", aidRows.map((a) => a.id), "qty"),
-    fetchAidSourceMap(
-      sb,
-      aidRows.map((a) => a.transferred_from_order_id).filter((x): x is number => x != null),
-    ),
-  ]);
-  return aidRows.map((a) => {
-    const src = a.transferred_from_order_id != null ? srcMap.get(a.transferred_from_order_id) : undefined;
-    return {
-      key: `${airMode}-${a.id}`,
-      source: airMode,
-      ts: new Date(a.updated_at).getTime(),
-      stage: classifyAid(a.status),
-      raw: {
-        id: a.id,
-        order_no: a.order_no,
-        status: a.status,
-        is_air_transfer: a.is_air_transfer,
-        pickup_store_id: a.pickup_store_id,
-        store_name: a.store?.name ?? null,
-        campaign_no: a.campaign?.campaign_no ?? null,
-        updated_at: a.updated_at,
-        line_count: a.items?.length ?? 0,
-        items_summary: itemsMap.get(a.id) ?? "",
-        transferred_from_order_id: a.transferred_from_order_id,
-        from_order_no: src?.order_no ?? null,
-        from_store_id: src?.store_id ?? null,
-        from_store_name: src?.store_name ?? null,
-      },
-    };
-  });
+  const itemsMap = await fetchItemsSummaryMap(
+    sb, "customer_order_items", "order_id", aidRows.map((a) => a.id), "qty",
+  );
+  return aidRows.map((a) => ({
+    key: `${airMode}-${a.id}`,
+    source: airMode,
+    ts: new Date(a.updated_at).getTime(),
+    stage: classifyAid(a.status),
+    raw: {
+      id: a.id,
+      order_no: a.order_no,
+      status: a.status,
+      is_air_transfer: a.is_air_transfer,
+      pickup_store_id: a.pickup_store_id,
+      store_name: a.store_name,
+      campaign_no: a.campaign_no,
+      updated_at: a.updated_at,
+      line_count: a.line_count ?? 0,
+      items_summary: itemsMap.get(a.id) ?? "",
+      transferred_from_order_id: a.transferred_from_order_id,
+      from_order_no: a.from_order_no,
+      from_store_id: a.from_store_id,
+      from_store_name: a.from_store_name,
+    },
+  }));
 }
 
-// airMode: "aid" = 互助訂單(排除空中轉,只 is_air_transfer 為 null/false)
-//          "air" = 空中轉(只 is_air_transfer=true)
 async function fetchAidRows(
   sb: SBClient,
   stage: Stage | null,
@@ -588,14 +557,13 @@ async function fetchAidRows(
 ): Promise<{ rows: Row[]; total: number }> {
   if (stage === "standby") return { rows: [], total: 0 }; // 只有 restock 有候補
   let q = sb
-    .from("customer_orders")
+    .from("v_hq_inbox_aid")
     .select(AID_SELECT, { count: "exact" })
-    .eq("items.source", "aid_transfer")
     .order("updated_at", { ascending: false });
   if (stage) q = q.in("status", AID_STATUS_BY_STAGE[stage] as string[]);
   if (aidStatus) q = q.eq("status", aidStatus);
-  if (airMode === "air") q = q.eq("is_air_transfer", true);
-  else q = q.or("is_air_transfer.is.null,is_air_transfer.eq.false");
+  // view 的 is_air_transfer 已 COALESCE 成 false,不會有 null
+  q = q.eq("is_air_transfer", airMode === "air");
   if (dateFrom) q = q.gte("updated_at", `${dateFrom}T00:00:00`);
   if (dateTo) q = q.lte("updated_at", `${dateTo}T23:59:59.999`);
   const start = (page - 1) * PAGE_SIZE;
@@ -829,12 +797,11 @@ async function fetchTransferRowsByIds(sb: SBClient, ids: number[]): Promise<Row[
 async function fetchAidRowsByIds(sb: SBClient, ids: number[], airMode: "aid" | "air" = "aid"): Promise<Row[]> {
   if (ids.length === 0) return [];
   let q = sb
-    .from("customer_orders")
+    .from("v_hq_inbox_aid")
     .select(AID_SELECT)
-    .eq("items.source", "aid_transfer")
     .in("id", ids);
-  if (airMode === "air") q = q.eq("is_air_transfer", true);
-  else q = q.or("is_air_transfer.is.null,is_air_transfer.eq.false");
+  // view 的 is_air_transfer 已 COALESCE 成 false,不會有 null
+  q = q.eq("is_air_transfer", airMode === "air");
   const { data, error } = await q;
   if (error) throw new Error("aid: " + error.message);
   return toAidRows(sb, (data ?? []) as unknown as AidQueryRow[], airMode);
@@ -1032,9 +999,8 @@ function HqInboxContent() {
           (async () => {
             const result: Record<Stage, number> = { ...fallback };
             const { data: rows } = await sb
-              .from("customer_orders")
-              .select("status, items:customer_order_items!inner(source)")
-              .eq("items.source", "aid_transfer")
+              .from("v_hq_inbox_aid")
+              .select("status")
               .eq("is_air_transfer", true);
             for (const r of (rows as { status: AidStatus }[] | null) ?? []) {
               const stg = classifyAid(r.status);

--- a/apps/admin/src/app/(protected)/hq/inbox/page.tsx
+++ b/apps/admin/src/app/(protected)/hq/inbox/page.tsx
@@ -240,7 +240,9 @@ const AID_STATUS_BY_STAGE: Record<Stage, AidStatus[]> = {
   standby: [],
   in_transit: ["shipping"],
   done: ["ready", "completed", "partially_completed"],
-  rejected: ["cancelled"],
+  // view 的 stage CASE 是 ELSE 'rejected',所以 cancelled 以外的終態也要列進來,
+  // 否則 badge 數字(rpc_inbox_counts 走 view)會比列表多
+  rejected: ["cancelled", "expired", "transferred_out"],
 };
 const PICKING_STATUS_BY_STAGE: Record<Stage, string[]> = {
   pending: ["draft", "picking", "picked"],
@@ -794,17 +796,25 @@ async function fetchTransferRowsByIds(sb: SBClient, ids: number[]): Promise<Row[
 }
 
 // airMode: "aid" 排除空中轉 / "air" 只留空中轉(tag 用,決定 row.source 與 key 前綴)
-async function fetchAidRowsByIds(sb: SBClient, ids: number[], airMode: "aid" | "air" = "aid"): Promise<Row[]> {
+// v_hq_inbox 的 aid 分支不分空中轉(row_key 一律 aid-<id>),所以這裡**不能**濾
+// is_air_transfer —— 濾掉的話那幾列在「全部」分頁會被 detailMap 查不到而靜靜消失,
+// 但 total 仍然把它們算進去(筆數對不上列數)。列的 source 改成逐列判定。
+async function fetchAidRowsByIds(sb: SBClient, ids: number[]): Promise<Row[]> {
   if (ids.length === 0) return [];
-  let q = sb
+  const { data, error } = await sb
     .from("v_hq_inbox_aid")
     .select(AID_SELECT)
     .in("id", ids);
-  // view 的 is_air_transfer 已 COALESCE 成 false,不會有 null
-  q = q.eq("is_air_transfer", airMode === "air");
-  const { data, error } = await q;
   if (error) throw new Error("aid: " + error.message);
-  return toAidRows(sb, (data ?? []) as unknown as AidQueryRow[], airMode);
+  const rows = (data ?? []) as unknown as AidQueryRow[];
+  const built = await Promise.all(
+    rows.map(async (r) => {
+      const [row] = await toAidRows(sb, [r], r.is_air_transfer ? "air" : "aid");
+      // key 要對回 v_hq_inbox 的 row_key(aid-<id>),空中轉才不會落空
+      return { ...row, key: `aid-${r.id}` };
+    }),
+  );
+  return built;
 }
 
 async function fetchShortageRowsByIds(sb: SBClient, ids: number[]): Promise<Row[]> {
@@ -2688,9 +2698,9 @@ function MailRow({
 // 互助 / 空中轉列的標題：貨「從哪一家店 → 到哪一家店」。
 // 原本標的是「開團 → 取貨店」——取貨店只是收貨的那一頭，總倉看不出要跟誰收貨，
 // 而經總倉的互助正是總倉要親手轉交的（Leg-1 來源店 → 總倉、Leg-2 總倉 → 收貨店，
-// 20260510000004）。另外全站 375 張互助轉入單裡有 359 張其實是同店轉單
-// （只是換客人、貨沒離開本店，rpc_ship_aid_order 也會擋下派貨），標出來才不會
-// 跟真的要中轉的混在一起。
+// 20260510000004）。同店轉單（只是換客人、貨沒離開本店）在「待處理 / 在途」已經
+// 被 v_hq_inbox_aid 濾掉（20260818000040），但已完成 / 已取消的歷史還看得到，
+// 所以這個標記留著 —— 全站 375 張轉入單裡有 359 張是這種。
 function AidRouteTitle({ a }: { a: AidRaw }) {
   const dest = a.store_name ?? "—";
   const sameStore = a.from_store_id != null && a.from_store_id === a.pickup_store_id;

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -696,7 +696,13 @@ export function OrderDetail({
   // 一般顧客訂單退回總倉（rpc_create_order_return）— 互助單不走這條（貨應退回原 source 店）
   const canReturn = !isAidOrder && ["shipping", "ready", "partially_completed", "completed", "expired"].includes(head.status);
   // 互助單已收貨未取貨（status=ready）退單：退回原 source 店（rpc_return_aid_order，#234）
-  const canAidReturn = isAidOrder && head.status === "ready";
+  // 同店轉單（換客人）不給按：貨沒離開本店、從來不會有 AT- 轉移單，
+  // rpc_return_aid_order 兩道守衛（no received transfer / source and dest share
+  // location_id）一定擋下 —— 線上 85 張同店 ready 單全部按了只會拿到錯誤訊息。
+  // 要換回原客人請走「訂單轉給別人」。
+  const isSameStoreTransfer =
+    transferSource?.store_id != null && transferSource.store_id === head.pickup_store_id;
+  const canAidReturn = isAidOrder && head.status === "ready" && !isSameStoreTransfer;
   const isTransferredOut = head.status === "transferred_out";
   // 復原取消（rpc_restore_cancelled_order）。伺服端還有一輪守衛，這裡先把三種
   // 一定會被擋的單藏起來，免得店員按了只拿到錯誤訊息：

--- a/supabase/migrations/20260818000040_hq_inbox_exclude_same_store_transfers.sql
+++ b/supabase/migrations/20260818000040_hq_inbox_exclude_same_store_transfers.sql
@@ -27,8 +27,14 @@
 -- 線上母體（2026-08-18）：375 張轉入單裡 359 張是同店轉單，其中
 --   10 張落在「待處理」、3 張落在「配送中」——總倉每天看到的就是這些。
 --
+-- 藏的範圍刻意只到「待處理 / 在途」：/hq/inbox?source=aid 是全站唯一的互助 /
+-- 轉單清單（/transfers/aid 只是 router.replace 過來），ready 之後的 300 多張
+-- 歷史單一起藏掉等於查不到。判準另外排除兩種「看起來同店、其實貨有動」的單，
+-- 見 _is_same_store_transfer_todo 的註解。
+--
 -- 改動：
---   1. v_hq_inbox 的 aid 分支排除同店轉單
+--   0. 新增 _is_same_store_transfer_todo(order_id)：兩支 view 共用的唯一口徑
+--   1. v_hq_inbox 的 aid 分支排除同店轉單（待處理 / 在途）
 --      → rpc_inbox_counts（badge 數字）與「全部」分頁一起乾淨。
 --   2. 新增 v_hq_inbox_aid：收件匣「互助訂單 / 空中轉」分頁專用的列來源，
 --      同樣排除同店轉單，並把轉出端（來源單／轉出店）直接查好。
@@ -42,6 +48,47 @@
 -- Rollback：v_hq_inbox CREATE OR REPLACE 回 20260722000020 的版本；
 --           DROP VIEW public.v_hq_inbox_aid（前端要一起還原成直查 customer_orders）。
 -- ============================================================
+
+-- ----------------------------------------------------------------
+-- 0. _is_same_store_transfer_todo — 「這張轉入單是總倉不用管的同店轉單嗎」
+--    唯一口徑，v_hq_inbox 與 v_hq_inbox_aid 共用。
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._is_same_store_transfer_todo(p_order_id BIGINT)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    -- 只藏「總倉待辦」那段（待處理 / 在途）。ready 之後的歷史留著 ——
+    -- /hq/inbox?source=aid 是全站唯一的互助 / 轉單清單
+    -- （/transfers/aid 只是 router.replace 到這裡），整批藏掉等於歷史查不到。
+    co.status IN ('pending','confirmed','shipping')
+    -- 來源單同店 = 貨沒有離開這家店
+    AND EXISTS (
+      SELECT 1 FROM customer_orders src
+       WHERE src.id = co.transferred_from_order_id
+         AND src.pickup_store_id = co.pickup_store_id
+    )
+    -- 有轉移單 = 貨真的搬過（例：rpc_merge_stores 事後把兩店併成一個
+    -- pickup_store_id，歷史上真的跨店轉過的單會被誤判成同店）→ 不藏
+    AND NOT EXISTS (
+      SELECT 1 FROM transfers t
+       WHERE t.customer_order_id = co.id AND t.status <> 'cancelled'
+    )
+    -- 「追加轉入（併入既有單）」分支不寫 transferred_from_order_id、只加一行
+    -- notes（CLAUDE.md 已記的洞），所以同店 FK 不代表後來追加進來的貨也是同店
+    -- （互助板認領 rpc_claim_manual_spot 走 partial，很容易併進既有容器單）。
+    -- 判不出來就不藏，寧可讓總倉多看到一列。真正的修法要一張 order↔order 連結表。
+    AND COALESCE(co.notes, '') NOT LIKE '%追加轉入%'
+  FROM customer_orders co
+ WHERE co.id = p_order_id;
+$$;
+
+COMMENT ON FUNCTION public._is_same_store_transfer_todo(BIGINT) IS
+  '轉入單是不是「總倉不用處理的同店轉單」：同店來源 + 沒有轉移單 + 沒被追加轉入，'
+  '且還停在待處理 / 在途。v_hq_inbox 與 v_hq_inbox_aid 共用（20260818000040）。';
 
 -- ----------------------------------------------------------------
 -- 1. v_hq_inbox — aid 分支排除同店轉單
@@ -95,12 +142,7 @@ WHERE EXISTS (
   SELECT 1 FROM public.customer_order_items coi
   WHERE coi.order_id = co.id AND coi.source = 'aid_transfer'
 )
--- 同店轉單（換客人／併單）貨沒有離開本店，總倉全程不參與 → 不是收件匣的事
-AND NOT EXISTS (
-  SELECT 1 FROM public.customer_orders src
-  WHERE src.id = co.transferred_from_order_id
-    AND src.pickup_store_id = co.pickup_store_id
-)
+AND NOT public._is_same_store_transfer_todo(co.id)
 
 UNION ALL
 
@@ -151,8 +193,7 @@ WHERE EXISTS (
   SELECT 1 FROM public.customer_order_items coi
   WHERE coi.order_id = co.id AND coi.source = 'aid_transfer'
 )
-AND (src.id IS NULL OR src.pickup_store_id IS NULL
-     OR src.pickup_store_id <> co.pickup_store_id);
+AND NOT public._is_same_store_transfer_todo(co.id);
 
 GRANT SELECT ON public.v_hq_inbox_aid TO authenticated;
 

--- a/supabase/migrations/20260818000040_hq_inbox_exclude_same_store_transfers.sql
+++ b/supabase/migrations/20260818000040_hq_inbox_exclude_same_store_transfers.sql
@@ -1,0 +1,161 @@
+-- ============================================================
+-- 2026-08-18: 同店轉單不進總倉收件匣（不用總倉確認、也不用派貨）
+--
+-- 現象（使用者回報）：/hq/inbox「互助訂單」列出一堆標著
+--   「（同店轉單・貨沒有移動）」的單，掛在「待處理」而且長著
+--   「派貨 / 取消 / → 已確認」三顆鈕。
+--
+-- 這三顆對同店轉單全部沒有意義：
+--   - 派貨（rpc_ship_aid_order）自己就擋：
+--       IF v_src_location = v_dst_location THEN
+--         RAISE EXCEPTION 'source and dest store share location_id %, cannot ship'
+--     → 按下去只會拿到錯誤訊息，是一顆死鈕。
+--   - 「總倉確認」(pending → confirmed) 的語意是「總倉收到貨了」
+--     （見 CLAUDE.md「經總倉的轉入單一開始是 pending」），同店轉單
+--     的貨從頭到尾沒離開那家店，總倉根本不會收到。
+--   - 同店轉單建單時 status 是 mirror 來源單（20260629000020），
+--     之後的推進完全走該店自己的團購流程：
+--       pending/confirmed → shipping：rpc_mark_orders_shipping_for_wave
+--         （同 campaign + 同店即推，不排除衍生單）
+--       confirmed → ready：rpc_receive_transfer 邏輯 E
+--         （_advance_arrived_confirmed_orders）
+--       shipping → ready：rpc_receive_transfer 邏輯 C
+--     → 沒有任何一步需要總倉，隱藏這些列不會讓狀態機卡住
+--       （CLAUDE.md「把某個角色的動作按鈕拿掉之前，先確認狀態機還有別人推得動」）。
+--   - 取消入口也不會消失：訂單明細頁本來就有（rpc_cancel_aid_order）。
+--
+-- 線上母體（2026-08-18）：375 張轉入單裡 359 張是同店轉單，其中
+--   10 張落在「待處理」、3 張落在「配送中」——總倉每天看到的就是這些。
+--
+-- 改動：
+--   1. v_hq_inbox 的 aid 分支排除同店轉單
+--      → rpc_inbox_counts（badge 數字）與「全部」分頁一起乾淨。
+--   2. 新增 v_hq_inbox_aid：收件匣「互助訂單 / 空中轉」分頁專用的列來源，
+--      同樣排除同店轉單，並把轉出端（來源單／轉出店）直接查好。
+--      前端原本用 PostgREST 直查 customer_orders，沒辦法做
+--      「來源單.pickup_store_id = 本單.pickup_store_id」這種欄位對欄位比較，
+--      所以把這段收進 view，順便省掉一趟反查來源單的 round trip。
+--
+-- 基底：v_hq_inbox ← 20260722000020_restock_standby_zone.sql
+--       （逐字保留 restock standby / transfer return_to_hq / shortage 三段，
+--         只動 aid 分支的 WHERE；已與線上 pg_get_viewdef 對過）。
+-- Rollback：v_hq_inbox CREATE OR REPLACE 回 20260722000020 的版本；
+--           DROP VIEW public.v_hq_inbox_aid（前端要一起還原成直查 customer_orders）。
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. v_hq_inbox — aid 分支排除同店轉單
+-- ----------------------------------------------------------------
+CREATE OR REPLACE VIEW public.v_hq_inbox AS
+SELECT
+  'restock-' || id::text                                AS row_key,
+  'restock'::text                                       AS source,
+  CASE
+    WHEN status = 'pending' AND standby_at IS NOT NULL                          THEN 'standby'
+    WHEN status = 'pending'                                                     THEN 'pending'
+    WHEN status IN ('approved_transfer','approved_pr','shipped')                THEN 'in_transit'
+    WHEN status = 'received'                                                    THEN 'done'
+    ELSE 'rejected'
+  END                                                   AS stage,
+  requested_at                                          AS ts,
+  id                                                    AS source_id
+FROM public.restock_requests
+
+UNION ALL
+
+SELECT
+  'transfer-' || id::text,
+  'transfer',
+  CASE
+    WHEN status IN ('draft','confirmed')                       THEN 'pending'
+    WHEN status = 'shipped' AND transfer_type = 'return_to_hq' THEN 'pending'
+    WHEN status = 'shipped'                                    THEN 'in_transit'
+    WHEN status = 'received'                                   THEN 'done'
+    ELSE 'rejected'
+  END,
+  created_at,
+  id
+FROM public.transfers
+
+UNION ALL
+
+SELECT
+  'aid-' || co.id::text,
+  'aid',
+  CASE
+    WHEN co.status IN ('pending','confirmed')                     THEN 'pending'
+    WHEN co.status = 'shipping'                                   THEN 'in_transit'
+    WHEN co.status IN ('ready','completed','partially_completed') THEN 'done'
+    ELSE 'rejected'
+  END,
+  co.updated_at,
+  co.id
+FROM public.customer_orders co
+WHERE EXISTS (
+  SELECT 1 FROM public.customer_order_items coi
+  WHERE coi.order_id = co.id AND coi.source = 'aid_transfer'
+)
+-- 同店轉單（換客人／併單）貨沒有離開本店，總倉全程不參與 → 不是收件匣的事
+AND NOT EXISTS (
+  SELECT 1 FROM public.customer_orders src
+  WHERE src.id = co.transferred_from_order_id
+    AND src.pickup_store_id = co.pickup_store_id
+)
+
+UNION ALL
+
+SELECT DISTINCT
+  'shortage-' || order_id::text,
+  'shortage',
+  CASE
+    WHEN shortage_resolution IS NULL                              THEN 'pending'
+    WHEN shortage_resolution IN ('notified','waiting_next_po')    THEN 'in_transit'
+    WHEN shortage_resolution IN ('cancelled','reallocated')       THEN 'done'
+    ELSE 'pending'
+  END,
+  order_updated_at,
+  order_id
+FROM public.v_order_shortage;
+
+COMMENT ON VIEW public.v_hq_inbox IS
+  'HQ 收件匣的列鍵來源（restock / transfer / aid / shortage）。aid 只收跨店轉入單：'
+  '同店轉單貨沒有移動、總倉不經手，推進全由該店自己的團購流程負責（20260818000040）。';
+
+-- ----------------------------------------------------------------
+-- 2. v_hq_inbox_aid — 收件匣「互助訂單 / 空中轉」分頁的列
+--    security_invoker = true：RLS 套用 caller（同 v_admin_orders 慣例）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE VIEW public.v_hq_inbox_aid
+WITH (security_invoker = true) AS
+SELECT
+  co.id,
+  co.order_no,
+  co.status,
+  COALESCE(co.is_air_transfer, FALSE)          AS is_air_transfer,
+  co.pickup_store_id,
+  co.transferred_from_order_id,
+  co.updated_at,
+  c.campaign_no,
+  st.name                                      AS store_name,
+  src.order_no                                 AS from_order_no,
+  src.pickup_store_id                          AS from_store_id,
+  fst.name                                     AS from_store_name,
+  (SELECT COUNT(*) FROM public.customer_order_items coi2
+    WHERE coi2.order_id = co.id AND coi2.source = 'aid_transfer')::int AS line_count
+FROM public.customer_orders co
+LEFT JOIN public.group_buy_campaigns c ON c.id  = co.campaign_id
+LEFT JOIN public.stores st              ON st.id = co.pickup_store_id
+LEFT JOIN public.customer_orders src    ON src.id = co.transferred_from_order_id
+LEFT JOIN public.stores fst             ON fst.id = src.pickup_store_id
+WHERE EXISTS (
+  SELECT 1 FROM public.customer_order_items coi
+  WHERE coi.order_id = co.id AND coi.source = 'aid_transfer'
+)
+AND (src.id IS NULL OR src.pickup_store_id IS NULL
+     OR src.pickup_store_id <> co.pickup_store_id);
+
+GRANT SELECT ON public.v_hq_inbox_aid TO authenticated;
+
+COMMENT ON VIEW public.v_hq_inbox_aid IS
+  '收件匣「互助訂單 / 空中轉」分頁的列：轉入單 + 轉出端（來源單／轉出店）。'
+  '排除同店轉單（貨沒有移動、總倉不經手），與 v_hq_inbox 的 aid 分支同一套口徑。';


### PR DESCRIPTION
## 問題

`/hq/inbox` 的「互助訂單」把**同店轉單**（換客人／併單，標著「同店轉單・貨沒有移動」）列成待處理，還長著三顆對它沒有意義的鈕：

| 鈕 | 對同店轉單 |
|---|---|
| 派貨 | `rpc_ship_aid_order` 自己就擋（`source and dest store share location_id`）→ 按下去只有錯誤訊息 |
| →已確認 | 「總倉確認」的語意是「總倉收到貨了」，同店的貨從頭到尾沒離開那家店 |
| 取消 | 訂單明細頁本來就有，不會因此少一個入口 |

同店轉入單的推進全走該店自己的團購流程，沒有一步需要總倉：

- `pending`/`confirmed` → `shipping`：`rpc_mark_orders_shipping_for_wave`（同 campaign + 同店即推，不排除衍生單）
- `confirmed` → `ready`：`rpc_receive_transfer` 邏輯 E（`_advance_arrived_confirmed_orders`）
- `shipping` → `ready`：`rpc_receive_transfer` 邏輯 C
- `pending` → `confirmed`：PR 彙總（`_lock_orders_after_pr_aggregation`）

線上母體：375 張轉入單裡 359 張是同店轉單，其中 10 張卡在待處理、3 張在在途。

## 改動

**DB（`20260818000040`，已套上正式庫）**

- 新增 `_is_same_store_transfer_todo(order_id)`：兩支 view 共用的唯一口徑。
  - 只認 **待處理 / 在途**（`pending`/`confirmed`/`shipping`）—— `ready` 之後的歷史留著，因為 `/hq/inbox?source=aid` 是全站唯一的互助／轉單清單（`/transfers/aid` 只是 `router.replace` 過來），整批藏掉等於 316 張歷史單查不到。
  - **有非取消的轉移單 → 不藏**：`rpc_merge_stores` 會回寫歷史單的 `pickup_store_id`，真的跨店轉過的單事後會被誤判成同店。
  - **notes 有「追加轉入」→ 不藏**：併入既有單的分支不寫 `transferred_from_order_id`，同店 FK 不代表後來追加進來的貨也是同店（互助板認領走 partial，很容易併進既有容器單）。真正的修法要一張 order↔order 連結表。
- `v_hq_inbox` 的 aid 分支套用該判準 → badge 數字與「全部」分頁一起乾淨（基底 `20260722000020`，其餘三段逐字保留）。
- 新增 `v_hq_inbox_aid`（`security_invoker`）：收件匣互助／空中轉分頁的列來源，同一套判準，並把轉出端（來源單／轉出店）查好 —— PostgREST 直查 `customer_orders` 做不到「來源單.pickup_store_id = 本單.pickup_store_id」這種欄位對欄位比較，順便省掉一趟反查。

**前端**

- 收件匣改查 `v_hq_inbox_aid`。
- 「全部」分頁不再吞掉空中轉：`v_hq_inbox` 的 aid key 不分空中轉，by-id 反查卻濾 `is_air_transfer=false`，那幾列查不到被丟掉、`total` 卻照算。改成逐列判定 source、key 對回 `aid-<id>`。
- `AID_STATUS_BY_STAGE.rejected` 補成 `cancelled/expired/transferred_out`，對齊 view 的 `ELSE`（badge 9、列表 8 的差就是這個）。
- 訂單明細的「退回原店」對同店轉單藏起來：同店從來不會有 AT- 轉移單，`rpc_return_aid_order` 兩道守衛一定擋下 —— 線上 85 張同店 ready 單按了只會拿到錯誤訊息，跟這次回報的「派貨」是同一類死鈕。

## 驗證

- `node scripts/check-sql-syntax.cjs`（含 plpgsql）通過；migration 已用 Management API 套上正式庫。
- 套用後線上：aid 待處理 17 → 7、在途 3 → 2，已完成 322 / 已取消 43 完整保留。
- 以 `SET LOCAL ROLE authenticated` + admin claims 實測 `v_hq_inbox_aid` 讀得到全部列、join 欄位不為空；PostgREST 端以 anon key 打過確認 schema cache 已載入、欄位名稱全對。
- `tsc --noEmit` 通過；eslint 無新增問題（既有 3 個 setState-in-effect error 不變）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BbUxizizBHVsmEPbrfnvd

---
_Generated by [Claude Code](https://claude.ai/code/session_011BbUxizizBHVsmEPbrfnvd)_