### PR TITLE
贈品排除零元守衛：從訂單標，整單 / 批次一鍵

### DIFF
--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -37,7 +37,10 @@ type Row = {
   // 漏填金額 —— 取貨時 rpc_record_pickup 的零元守衛會擋下整張單。
   // 【內部】xx 店 / RR- / OV- 容器單（member_type='store_internal'）恆為 0：
   // 池子單價本來就可能是 0，不是漏填。
+  // 20260819000000 起排除已標記的贈品（刻意送的不算漏填）。
   zero_price_lines: number | null;
+  // 贈品行數（開團設定的促銷贈品 + 這張單標的）。跟 $0 提示互斥，純顯示用。
+  gift_lines: number | null;
 };
 
 type Campaign = { id: number; campaign_no: string; name: string; cover_image_url: string | null; start_at: string | null };
@@ -331,6 +334,21 @@ function ZeroPriceBadge({ lines }: { lines: number | null }) {
   );
 }
 
+// 「這張單有贈品」🎁 標 — gift_lines 同樣來自 v_admin_orders_list（20260819000000）。
+// 贈品是刻意送的（促銷 / 補償），不是漏填，所以不紅標；但要看得到，
+// 免得「$0 卻沒被擋」看起來像守衛壞了。
+function GiftBadge({ lines }: { lines: number | null }) {
+  if (!lines || lines <= 0) return null;
+  return (
+    <span
+      title="這張單有被標記為贈品的品項（開團設定的促銷贈品，或這張單標記的）。贈品不受取貨零元守衛限制。"
+      className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+    >
+      🎁 贈品 ×{lines}
+    </span>
+  );
+}
+
 export default function OrdersListPage() {
   return (
     <Suspense fallback={<LoadingBlock />}>
@@ -604,7 +622,7 @@ function OrdersListContent() {
         const base = getSupabase()
           .from("v_admin_orders_list")
           .select(
-            "id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, transferred_from_order_id, created_at, updated_at, zero_price_lines"
+            "id, order_no, campaign_id, member_id, nickname_snapshot, pickup_store_id, pickup_deadline, status, transferred_from_order_id, created_at, updated_at, zero_price_lines, gift_lines"
               + (activeSkuId ? ITEM_EMBED : ""),
             { count: "exact" },
           )
@@ -1168,7 +1186,8 @@ function OrdersListContent() {
       {/* ⚠ 漏填金額提示 — 目前 tab + 篩選底下有幾張訂單含 $0 品項。
           $0 幾乎都是開團 / 代 key 時漏填單價（線上抽查 notes 全為 NULL，沒有一筆是
           刻意的贈品），取貨那一刻就是收錢的時候 → 不補金額等於把貨白送。
-          取貨頁與 rpc_record_pickup 會擋下這種單，所以這裡要讓人一眼看到、點得進去。*/}
+          取貨頁與 rpc_record_pickup 會擋下這種單，所以這裡要讓人一眼看到、點得進去。
+          刻意送的贈品（開團設定的促銷贈品 / 訂單上標的）不算在這裡（20260819000000）。*/}
       {(zeroOnly || (zeroCount ?? 0) > 0) && (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
           <span className="font-semibold">
@@ -1176,6 +1195,7 @@ function OrdersListContent() {
           </span>
           <span className="text-xs">
             可能是開團時漏填金額。這些單在取貨頁會被擋下，請先補上金額（點訂單開明細改單價，或在取貨頁該品項旁直接補填）。
+            促銷贈品請改在開團商品或該品項標「🎁 贈品」，標了就不會再擋。
           </span>
           <SpinButton
             type="button"
@@ -1567,6 +1587,7 @@ function OrdersListContent() {
                 <span>共 {sum?.totalQty ?? 0} 件</span>
                 <span className="font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-100">${sum?.totalAmount ?? 0}</span>
                 <ZeroPriceBadge lines={r.zero_price_lines} />
+                <GiftBadge lines={r.gift_lines} />
                 <span
                   className="ml-auto"
                   title={`訂單日：${new Date(r.created_at).toLocaleString("zh-TW", { hour12: false })}\n更新日：${new Date(r.updated_at).toLocaleString("zh-TW", { hour12: false })}`}
@@ -1699,6 +1720,11 @@ function OrdersListContent() {
                     {(r.zero_price_lines ?? 0) > 0 && (
                       <div className="mt-0.5">
                         <ZeroPriceBadge lines={r.zero_price_lines} />
+                      </div>
+                    )}
+                    {(r.gift_lines ?? 0) > 0 && (
+                      <div className="mt-0.5">
+                        <GiftBadge lines={r.gift_lines} />
                       </div>
                     )}
                   </Td>

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -439,6 +439,7 @@ function OrdersListContent() {
   // 批量列印用的勾選（跨分頁累加；換 tab / 改篩選會清空，避免印到看不見的單）
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [bulkPrintErr, setBulkPrintErr] = useState<string | null>(null);
+  const [bulkGiftMsg, setBulkGiftMsg] = useState<string | null>(null);
 
   // KPI trend (當月 1 號 ~ 今天 每日 + 本月累計、套 filter 開團+店家、排除 transferred_out)
   const [trend, setTrend] = useState<TrendData | null>(null);
@@ -1041,6 +1042,41 @@ function OrdersListContent() {
     }
   }
 
+  // 批次標贈品 —— 促銷活動的正規流程：篩「只看 $0」＋開團／門市 → 選取 → 一次標完。
+  // 贈品是掛在訂單上的（同一個 SKU 有人買、有人是送的），所以入口在訂單這邊，
+  // 不是開團商品那邊（那個一標就把所有人的單價歸零，買的那幾張也跟著變 $0）。
+  // 逐張走 _check_order_edit_notes_perm：選到別人家的單會整批擋下並指名是哪一張。
+  async function bulkMarkGift() {
+    setBulkGiftMsg(null);
+    const ids = Array.from(selected);
+    if (ids.length === 0) return;
+    const reason = prompt(
+      `把選取的 ${ids.length} 張訂單裡「還沒取貨、單價 $0」的品項全部標成贈品。\n` +
+      `這些品項會以 $0 交給客人（不收錢），每一列都會寫進異動紀錄。\n\n` +
+      `請輸入原因（例：週年慶滿額贈 / 買二送一）：`,
+    );
+    if (reason === null) return;
+    if (!reason.trim()) { setBulkGiftMsg("請填寫贈品原因（會寫進異動紀錄）"); return; }
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id ?? null;
+    if (!operator) { setBulkGiftMsg("尚未登入"); return; }
+    const { data, error: rpcErr } = await sb.rpc("rpc_mark_zero_price_items_gift", {
+      p_order_ids: ids,
+      p_operator: operator,
+      p_reason: reason.trim(),
+    });
+    if (rpcErr) { setBulkGiftMsg(translateRpcError(rpcErr)); return; }
+    const r = (data ?? null) as { orders: number; items: number; skipped_internal: number } | null;
+    setBulkGiftMsg(
+      `已把 ${r?.items ?? 0} 個品項（${r?.orders ?? 0} 張訂單）標成贈品，取貨不再被擋`
+      + ((r?.skipped_internal ?? 0) > 0 ? `；略過 ${r?.skipped_internal} 張【內部】容器單` : "")
+      + ((r?.items ?? 0) === 0 ? "（選取的訂單沒有未取貨的 $0 品項）" : ""),
+    );
+    setSelected(new Set());
+    setReloadOrders((n) => n + 1);
+  }
+
   async function bulkPrint(kind: "receipt" | "slip") {
     setBulkPrintErr(null);
     const ids = Array.from(selected);
@@ -1456,7 +1492,7 @@ function OrdersListContent() {
           </span>
           {selected.size > 0 && (
             <SpinButton
-              onClick={() => { setSelected(new Set()); setBulkPrintErr(null); }}
+              onClick={() => { setSelected(new Set()); setBulkPrintErr(null); setBulkGiftMsg(null); }}
               className="text-zinc-500 underline-offset-2 hover:underline"
             >
               清除
@@ -1472,6 +1508,14 @@ function OrdersListContent() {
               🖨️ 補印收據
             </SpinButton>
             <SpinButton
+              onClick={bulkMarkGift}
+              disabled={selected.size === 0}
+              title="把選取訂單裡「還沒取貨、單價 $0」的品項全部標成贈品（不收錢就交給客人）。會要求填原因，每一列都寫入異動紀錄。"
+              className="rounded-md border border-amber-400 px-2 py-1 font-medium text-amber-700 hover:bg-amber-50 disabled:opacity-40 dark:border-amber-700 dark:text-amber-300 dark:hover:bg-amber-950"
+            >
+              🎁 標為贈品
+            </SpinButton>
+            <SpinButton
               onClick={() => bulkPrint("slip")}
               disabled={selected.size === 0}
               title="列印小白單（取貨清單，只列還沒取的品項）— 同一會員的多張單合印一張"
@@ -1482,6 +1526,9 @@ function OrdersListContent() {
           </div>
           {bulkPrintErr && (
             <div className="w-full text-amber-700 dark:text-amber-400">{bulkPrintErr}</div>
+          )}
+          {bulkGiftMsg && (
+            <div className="w-full text-amber-700 dark:text-amber-400">{bulkGiftMsg}</div>
           )}
         </div>
       )}

--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -18,6 +18,7 @@ import { publicProductUrl } from "@/lib/campaignCover";
 import { parseReturnNote } from "@/lib/returnNote";
 import { fetchReprintableEvents, pickupEventLabel, type PickupEventRow } from "@/lib/pickupReceipt";
 import { itemDisplayName } from "@/lib/skuLabel";
+import { GIFT_ITEM_SELECT, giftTitle, isCampaignGiftLine, isGiftLine } from "@/lib/orderGift";
 import { CutoffChip } from "@/components/CampaignCutoff";
 
 type Member = {
@@ -53,6 +54,10 @@ type OpenOrder = {
     qty: number;
     unit_price: number;
     status: string;
+    // 贈品標記（20260819000000）：品項自己標的 + 開團層級的，判定走 lib/orderGift
+    is_gift: boolean | null;
+    gift_reason: string | null;
+    campaign_item: { is_gift: boolean | null; gift_reason: string | null } | null;
     sku: {
       variant_name: string | null;
       product_name: string | null;
@@ -107,6 +112,7 @@ function PickupPageContent() {
   // item.id → 櫃台補填金額的輸入值 / 正在送出的那一筆
   const [zeroFillDraft, setZeroFillDraft] = useState<Map<number, string>>(new Map());
   const [zeroFilling, setZeroFilling] = useState<number | null>(null);
+  const [giftMarking, setGiftMarking] = useState<number | null>(null);
   // member.id → 儲值金餘額（wallet_balances）。取貨頁的「儲值金結帳」用；
   // 查無資料＝沒儲值過，視為 0。
   const [walletBalances, setWalletBalances] = useState<Map<number, number>>(new Map());
@@ -183,9 +189,11 @@ function PickupPageContent() {
   // 所以整張擋下、要求先補金額。rpc_record_pickup 有同款守衛（zero_price:），
   // 這裡是為了讓店員在按下去之前就看到、而且當場補得了。
   // 【內部】xx 店 / RR- / OV- 現貨池容器單的 0 是掛帳用的，不擋。
+  // 刻意送的贈品（開團設定的促銷贈品、或這張單當場標的）也不擋 —— 判定與
+  // rpc_record_pickup 同一套（lib/orderGift），不要在這裡另外寫一份。
   function zeroPriceItems(order: OpenOrder & { member_id?: number }) {
     if (order.member_id != null && internalMemberIds.has(order.member_id)) return [];
-    return pickableItems(order).filter((it) => Number(it.unit_price) === 0);
+    return pickableItems(order).filter((it) => Number(it.unit_price) === 0 && !isGiftLine(it));
   }
   function hasZeroPrice(order: OpenOrder): boolean {
     return zeroPriceItems(order).length > 0;
@@ -321,7 +329,7 @@ function PickupPageContent() {
           `id, order_no, status, pickup_deadline, pickup_store_id, discount_amount, discount_percent, wallet_paid_amount, payment_status, ready_at, transferred_from_order_id, last_notify_pickup_at, notify_pickup_count, member_id,
            campaign:group_buy_campaigns(id, campaign_no, name, cutoff_date),
            store:stores!customer_orders_pickup_store_id_fkey(id, name),
-           items:customer_order_items(id, sku_id, qty, unit_price, status, sku:skus(variant_name, product_name, product:products(images)))`,
+           items:customer_order_items(id, sku_id, qty, unit_price, status, ${GIFT_ITEM_SELECT}, sku:skus(variant_name, product_name, product:products(images)))`,
         )
         .in("member_id", list.map((m) => m.id));
       const { data: ords, error: e2 } = await (
@@ -725,6 +733,37 @@ function PickupPageContent() {
       setReloadTick((n) => n + 1);
     } finally {
       setZeroFilling(null);
+    }
+  }
+
+  // 「這是贈品」—— $0 但刻意送的（促銷贈品 / 客訴補償）。標了就免除零元守衛。
+  // 這是全站唯一「貨不收錢就出去」的入口，所以理由必填、寫 gift_marked_by/at + audit log
+  // （後端 rpc_mark_order_item_gift 有同款檢查）。權限跟補填金額同一套（HQ / 總倉 / 自店）：
+  // 不開到櫃台的話，促銷期間店員一樣只剩「亂填一個金額」或「轉單開新單」兩條爛路。
+  async function markGift(order: OpenOrder, itemId: number) {
+    const reason = prompt(
+      `標記為贈品：${order.order_no}\n這個品項會以 $0 交給客人（不收錢）。\n請輸入原因（例：促銷買二送一 / 客訴補償）：`,
+    );
+    if (reason === null) return;
+    if (!reason.trim()) { setError("請填寫贈品原因（會寫進異動紀錄）"); return; }
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id;
+    if (!operator) { setError("尚未登入"); return; }
+    setGiftMarking(itemId);
+    setError(null);
+    try {
+      const { error: e } = await sb.rpc("rpc_mark_order_item_gift", {
+        p_order_id: order.id,
+        p_item_id: itemId,
+        p_is_gift: true,
+        p_operator: operator,
+        p_reason: reason.trim(),
+      });
+      if (e) { setError(`${order.order_no} 標記贈品失敗：${translateRpcError(e)}`); return; }
+      setReloadTick((n) => n + 1);
+    } finally {
+      setGiftMarking(null);
     }
   }
 
@@ -1233,7 +1272,7 @@ function PickupPageContent() {
                                       <span className="flex items-center gap-1">
                                         <span
                                           className="rounded bg-red-100 px-1 py-0.5 text-[10px] font-semibold text-red-700 dark:bg-red-950 dark:text-red-300"
-                                          title="這個品項的單價是 $0，可能是開團時漏填金額。補上金額才能取貨。"
+                                          title="這個品項的單價是 $0，可能是開團時漏填金額。補上金額才能取貨；若是刻意送的贈品，改按右邊的「🎁 這是贈品」。"
                                         >
                                           ⚠️ 未填金額
                                         </span>
@@ -1262,6 +1301,24 @@ function PickupPageContent() {
                                         >
                                           {zeroFilling === it.id ? "…" : "補填"}
                                         </SpinButton>
+                                        {/* 不是漏填、是真的要送 → 標成贈品就放行（理由必填、會留痕） */}
+                                        <SpinButton
+                                          onClick={() => markGift(o, it.id)}
+                                          disabled={giftMarking === it.id}
+                                          title="這個品項是刻意送的贈品（促銷 / 補償），標記後不用補金額就能取貨。會要求填原因並寫入異動紀錄。"
+                                          className="rounded border border-amber-400 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 hover:bg-amber-50 disabled:opacity-50 dark:border-amber-700 dark:text-amber-300 dark:hover:bg-amber-950"
+                                        >
+                                          {giftMarking === it.id ? "…" : "🎁 這是贈品"}
+                                        </SpinButton>
+                                      </span>
+                                    )}
+                                    {/* 已標記的贈品：直接放行，畫面要看得出來這件是送的 */}
+                                    {isGiftLine(it) && (
+                                      <span
+                                        className="rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                                        title={giftTitle(it)}
+                                      >
+                                        🎁 贈品{isCampaignGiftLine(it) ? "（開團設定）" : ""}
                                       </span>
                                     )}
                                     {returnedOf(it) > 0 && (
@@ -1362,7 +1419,7 @@ function PickupPageContent() {
                               onClick={() => quickPickup(o)}
                               disabled={!canPickup}
                               title={zeroItems.length > 0
-                                ? "有品項的單價是 $0（可能漏填金額），補上金額才能取貨"
+                                ? "有品項的單價是 $0（可能漏填金額），補上金額才能取貨；若是刻意送的贈品，按該品項旁的「🎁 這是贈品」"
                                 : "一鍵取走已到貨品項並列印（不開明細視窗）"}
                               className="rounded-md bg-emerald-600 px-3 py-2 text-xs font-medium text-white transition hover:bg-emerald-700 disabled:opacity-50"
                             >

--- a/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-list/page.tsx
@@ -7,6 +7,7 @@ import { stripTransferNotes, stripItemNotes } from "@/lib/orderNotes";
 import { internalOrderSource } from "@/lib/orderTitle";
 import { parseReturnNote } from "@/lib/returnNote";
 import { itemDisplayName } from "@/lib/skuLabel";
+import { GIFT_ITEM_SELECT, isGiftLine } from "@/lib/orderGift";
 import SpinButton from "@/components/SpinButton";
 import { CutoffText } from "@/components/CampaignCutoff";
 
@@ -27,6 +28,9 @@ type Order = {
     sku_id: number;
     qty: number;
     unit_price: number;
+    is_gift: boolean | null;
+    gift_reason: string | null;
+    campaign_item: { is_gift: boolean | null; gift_reason: string | null } | null;
     discount_amount: number;
     discount_percent: number;
     notes: string | null;
@@ -90,7 +94,7 @@ function Body() {
              member:members(id, member_no, name, phone),
              campaign:group_buy_campaigns(id, campaign_no, name, cutoff_date),
              store:stores!customer_orders_pickup_store_id_fkey(id, name),
-             items:customer_order_items(id, sku_id, qty, unit_price, discount_amount, discount_percent, notes, status, sku:skus(variant_name, product_name))`,
+             items:customer_order_items(id, sku_id, qty, unit_price, discount_amount, discount_percent, notes, status, ${GIFT_ITEM_SELECT}, sku:skus(variant_name, product_name))`,
           )
           .in("id", ids),
         sb.from("transfers")
@@ -264,6 +268,10 @@ function Body() {
                         </span>
                         <span className="whitespace-nowrap text-[15px]">
                           × {qty}
+                          {/* 贈品：$0 是刻意的，小白單上要標，店員才知道那件不用收錢 */}
+                          {isGiftLine(it) && (
+                            <span className="ml-1.5 text-[15px] font-bold">🎁 贈品</span>
+                          )}
                           {discounted ? (
                             <>
                               <span className="ml-1.5 text-[13px] line-through">${gross}</span>

--- a/apps/admin/src/app/(protected)/pickup/print-picked/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print-picked/page.tsx
@@ -14,6 +14,7 @@ import { stripTransferNotes } from "@/lib/orderNotes";
 import { itemDisplayName } from "@/lib/skuLabel";
 import SpinButton from "@/components/SpinButton";
 import { CutoffText } from "@/components/CampaignCutoff";
+import { GIFT_ITEM_SELECT, isGiftLine } from "@/lib/orderGift";
 
 type Item = {
   id: number;
@@ -24,6 +25,9 @@ type Item = {
   discount_percent: number;
   status: string;
   notes: string | null;
+  is_gift: boolean | null;
+  gift_reason: string | null;
+  campaign_item: { is_gift: boolean | null; gift_reason: string | null } | null;
   sku: { product_name: string | null; variant_name: string | null } | null;
 };
 
@@ -71,7 +75,7 @@ function Body() {
       const sb = getSupabase();
       const { data: itms, error: e1 } = await sb
         .from("customer_order_items")
-        .select("id, order_id, qty, unit_price, discount_amount, discount_percent, status, notes, sku:skus(product_name, variant_name)")
+        .select(`id, order_id, qty, unit_price, discount_amount, discount_percent, status, notes, ${GIFT_ITEM_SELECT}, sku:skus(product_name, variant_name)`)
         .in("id", ids)
         .order("id", { ascending: true });
       if (cancelled) return;
@@ -179,6 +183,8 @@ function Body() {
                       </span>
                       <span className="whitespace-nowrap text-[15px]">
                         × {Number(it.qty)}
+                        {/* 贈品：$0 是刻意的，不標會被當成漏打價格 */}
+                        {isGiftLine(it) && <span className="ml-1 font-bold">🎁 贈品</span>}
                         {hasLineDisc(it) ? (
                           <>
                             <span className="ml-1 line-through text-zinc-500">${lineGross(it)}</span>

--- a/apps/admin/src/app/(protected)/pickup/print/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/print/page.tsx
@@ -6,6 +6,7 @@ import { getSupabase } from "@/lib/supabase";
 import { stripTransferNotes, stripItemNotes } from "@/lib/orderNotes";
 import { internalOrderSource } from "@/lib/orderTitle";
 import { itemDisplayName } from "@/lib/skuLabel";
+import { GIFT_ITEM_SELECT, isGiftLine } from "@/lib/orderGift";
 import SpinButton from "@/components/SpinButton";
 import { CutoffText } from "@/components/CampaignCutoff";
 
@@ -42,6 +43,9 @@ type Item = {
   discount_percent: number;
   notes: string | null;
   status: string;
+  is_gift: boolean | null;
+  gift_reason: string | null;
+  campaign_item: { is_gift: boolean | null; gift_reason: string | null } | null;
   sku: { sku_code: string; product_name: string | null; variant_name: string | null } | null;
 };
 
@@ -92,7 +96,7 @@ function Body() {
           .select("id, order_no, status, pickup_store_id, discount_amount, discount_percent, wallet_paid_amount, payment_status, notes, member:members(id, member_no, name, phone), campaign:group_buy_campaigns(id, campaign_no, name, cutoff_date), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .in("id", orderIds),
         allItemIds.length > 0
-          ? sb.from("customer_order_items").select("id, qty, unit_price, discount_amount, discount_percent, notes, status, sku:skus(sku_code, product_name, variant_name)").in("id", allItemIds)
+          ? sb.from("customer_order_items").select(`id, qty, unit_price, discount_amount, discount_percent, notes, status, ${GIFT_ITEM_SELECT}, sku:skus(sku_code, product_name, variant_name)`).in("id", allItemIds)
           : Promise.resolve({ data: [] }),
       ]);
       const ordMap = new Map<number, Order>();
@@ -211,6 +215,10 @@ function Body() {
                         </span>
                         <span className="whitespace-nowrap text-[15px]">
                           × {Number(it.qty)}
+                          {/* 贈品：$0 是刻意的。收據上不標的話，客人與店員都會以為是漏打價格 */}
+                          {isGiftLine(it) && (
+                            <span className="ml-1.5 text-[15px] font-bold">🎁 贈品</span>
+                          )}
                           {discounted ? (
                             <>
                               <span className="ml-1.5 text-[13px] line-through">${gross}</span>

--- a/apps/admin/src/components/CampaignItemsTable.tsx
+++ b/apps/admin/src/components/CampaignItemsTable.tsx
@@ -102,32 +102,28 @@ export function CampaignItemsTable({
 
   useEffect(() => { reload(); }, [campaignId]);
 
-  // 把開團商品標成／取消標成贈品。標下去＝單價設 0 + 該團所有 $0 訂單品項
-  // （既有與未來）免除取貨零元守衛 —— 促銷活動不用一張一張標。
+  // 把開團商品標成／取消標成贈品。**只適用「這一項所有人都是送的」**：
+  // 標下去單價會設成 0，之後新建的訂單那一項全部是 $0。
+  // 買二送一那種「有人買、有人送」要從訂單那邊標（訂單明細 / 訂單列表批次），
+  // 後端也會擋（該商品還有有金額的未取貨品項就 raise campaign_gift）。
   const toggleGift = async (r: Row) => {
     const label = r.variant_name || r.product_name || r.sku_code;
     let reason: string | null = null;
     if (!r.is_gift) {
       reason = prompt(
-        `標記為贈品：${label}
-
-` +
-        `• 這個開團商品的單價會設為 $0（不收錢）
-` +
-        `• 本團所有 $0 的訂單品項（含已建立的）取貨時不再被擋
-` +
-        `• 「重新同步商品/價格」不會再把它改回零售價
-
-` +
-        `請輸入原因（例：週年慶滿額贈）：`,
+        `標記為贈品：${label}\n\n`
+        + `⚠️ 只適用「這一項所有人都是送的」：\n`
+        + `• 這個開團商品的單價會設為 $0，之後建立的訂單那一項全部不收錢\n`
+        + `• 本團所有 $0 的訂單品項（含已建立的）取貨時不再被擋\n`
+        + `• 「重新同步商品/價格」不會再把它改回零售價\n\n`
+        + `只有部分客人要送（買二送一）→ 改到訂單那邊標，不要用這個。\n\n`
+        + `請輸入原因（例：週年慶滿額贈）：`,
       );
       if (reason === null) return;
       if (!reason.trim()) { setError("請填寫贈品原因"); return; }
     } else if (!confirm(
-      `取消贈品設定：${label}
-
-單價會維持 $0（要恢復售價請按「重新同步商品/價格」），` +
-      `但這些 $0 品項取貨時會重新被零元守衛擋下。確定嗎？`,
+      `取消贈品設定：${label}\n\n單價會維持 $0（要恢復售價請按「重新同步商品/價格」），`
+      + `但這些 $0 品項取貨時會重新被零元守衛擋下。確定嗎？`,
     )) {
       return;
     }
@@ -277,7 +273,7 @@ export function CampaignItemsTable({
                       onClick={() => toggleGift(r)}
                       title={r.is_gift
                         ? "取消贈品設定（單價維持 $0，但取貨會重新被零元守衛擋下）"
-                        : "促銷活動送的東西：標成贈品後單價設為 $0，本團所有 $0 訂單品項取貨都不再被擋"}
+                        : "只適用「這一項所有人都是送的」：單價會設成 $0，之後的訂單那一項全部不收錢。買二送一那種請到訂單那邊標贈品。"}
                       className={r.is_gift
                         ? "rounded-md bg-amber-500 px-2 py-1 text-[11px] font-medium text-white hover:bg-amber-600"
                         : "rounded-md border border-zinc-300 px-2 py-1 text-[11px] font-medium text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"}

--- a/apps/admin/src/components/CampaignItemsTable.tsx
+++ b/apps/admin/src/components/CampaignItemsTable.tsx
@@ -22,6 +22,10 @@ type Row = {
   notes: string | null;
   locked_at: string | null;
   stockout_at: string | null;
+  // 贈品（20260819000000）：促銷活動送的東西，單價 0 是刻意的 →
+  // 該團所有 $0 訂單品項免除取貨零元守衛，且不會被「重新同步商品/價格」蓋回零售價
+  is_gift: boolean;
+  gift_reason: string | null;
 };
 
 type ResyncPreview = {
@@ -54,6 +58,9 @@ export function CampaignItemsTable({
   const role = useRole();
   // 僅管理員（owner/admin）可重新同步：對齊 RPC server-side gate
   const canResync = (status === "draft" || status === "open") && isAdmin(role);
+  // 贈品設定不看開團狀態：促銷團結單之後才開始取貨，被零元守衛擋下時多半已經
+  // closed/ordered —— 只放行 draft/open 等於這個功能在最需要的時候用不了。
+  const canSetGift = isAdmin(role);
   // 店長/店員不能跳轉到商品編輯頁
   const isStoreLevel = role === "store_manager" || role === "store_staff";
 
@@ -63,7 +70,7 @@ export function CampaignItemsTable({
     // open / closed 留 row 不破壞訂單，但 UI 不顯示）
     const { data, error: err } = await getSupabase()
       .from("campaign_items")
-      .select("id, sku_id, unit_price, cap_qty, sort_order, notes, locked_at, stockout_at, skus!inner(id, sku_code, status, product_id, variant_name, products!inner(id, name))")
+      .select("id, sku_id, unit_price, cap_qty, sort_order, notes, locked_at, stockout_at, is_gift, gift_reason, skus!inner(id, sku_code, status, product_id, variant_name, products!inner(id, name))")
       .eq("campaign_id", campaignId)
       .order("sort_order");
     if (err) { setError(err.message); return; }
@@ -71,7 +78,7 @@ export function CampaignItemsTable({
       (data as unknown as Array<{
         id: number; sku_id: number; unit_price: number; cap_qty: number | null;
         sort_order: number; notes: string | null; locked_at: string | null;
-        stockout_at: string | null;
+        stockout_at: string | null; is_gift: boolean | null; gift_reason: string | null;
         skus: { id: number; sku_code: string; status: string; product_id: number; variant_name: string | null;
           products: { id: number; name: string };
         };
@@ -88,11 +95,52 @@ export function CampaignItemsTable({
           unit_price: Number(r.unit_price), cap_qty: r.cap_qty != null ? Number(r.cap_qty) : null,
           sort_order: r.sort_order, notes: r.notes, locked_at: r.locked_at,
           stockout_at: r.stockout_at,
+          is_gift: !!r.is_gift, gift_reason: r.gift_reason,
         }))
     );
   };
 
   useEffect(() => { reload(); }, [campaignId]);
+
+  // 把開團商品標成／取消標成贈品。標下去＝單價設 0 + 該團所有 $0 訂單品項
+  // （既有與未來）免除取貨零元守衛 —— 促銷活動不用一張一張標。
+  const toggleGift = async (r: Row) => {
+    const label = r.variant_name || r.product_name || r.sku_code;
+    let reason: string | null = null;
+    if (!r.is_gift) {
+      reason = prompt(
+        `標記為贈品：${label}
+
+` +
+        `• 這個開團商品的單價會設為 $0（不收錢）
+` +
+        `• 本團所有 $0 的訂單品項（含已建立的）取貨時不再被擋
+` +
+        `• 「重新同步商品/價格」不會再把它改回零售價
+
+` +
+        `請輸入原因（例：週年慶滿額贈）：`,
+      );
+      if (reason === null) return;
+      if (!reason.trim()) { setError("請填寫贈品原因"); return; }
+    } else if (!confirm(
+      `取消贈品設定：${label}
+
+單價會維持 $0（要恢復售價請按「重新同步商品/價格」），` +
+      `但這些 $0 品項取貨時會重新被零元守衛擋下。確定嗎？`,
+    )) {
+      return;
+    }
+    setError(null);
+    const { error: err } = await getSupabase().rpc("rpc_set_campaign_item_gift", {
+      p_campaign_item_id: r.id,
+      p_is_gift: !r.is_gift,
+      p_reason: reason?.trim() ?? null,
+    });
+    if (err) { setError(translateRpcError(err)); return; }
+    await reload();
+    onResynced?.();
+  };
 
   const runPreview = async () => {
     setResyncErr(null);
@@ -169,14 +217,14 @@ export function CampaignItemsTable({
         <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
           <thead className="bg-zinc-50 dark:bg-zinc-900">
             <tr>
-              <Th>規格</Th><Th>名稱</Th><Th className="text-right">單價</Th><Th className="text-right">量上限</Th><Th>鎖定時間</Th>
+              <Th>規格</Th><Th>名稱</Th><Th className="text-right">單價</Th><Th className="text-right">量上限</Th><Th>鎖定時間</Th><Th>贈品</Th>
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {rows === null ? (
-              <tr><td colSpan={5} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              <tr><td colSpan={6} className="p-3 text-center text-zinc-500">載入中…</td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={5} className="p-6 text-center text-zinc-500">尚無商品</td></tr>
+              <tr><td colSpan={6} className="p-6 text-center text-zinc-500">尚無商品</td></tr>
             ) : rows.map((r) => (
               <tr key={r.id}>
                 <Td className="font-mono">
@@ -208,12 +256,37 @@ export function CampaignItemsTable({
                         ⛔ 斷貨
                       </span>
                     )}
+                    {r.is_gift && (
+                      <span
+                        title={r.gift_reason ? `贈品：${r.gift_reason}` : "贈品（單價 $0，取貨不受零元守衛限制）"}
+                        className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                      >
+                        🎁 贈品
+                      </span>
+                    )}
                   </div>
                 </Td>
                 <Td className="text-right font-mono">${r.unit_price}</Td>
                 <Td className="text-right text-xs text-zinc-500">{r.cap_qty ?? "—"}</Td>
                 <Td className="text-xs text-zinc-500">
                   {r.locked_at ? new Date(r.locked_at).toLocaleString("zh-TW", { dateStyle: "short", timeStyle: "short" }) : "—"}
+                </Td>
+                <Td className="text-xs">
+                  {canSetGift ? (
+                    <SpinButton
+                      onClick={() => toggleGift(r)}
+                      title={r.is_gift
+                        ? "取消贈品設定（單價維持 $0，但取貨會重新被零元守衛擋下）"
+                        : "促銷活動送的東西：標成贈品後單價設為 $0，本團所有 $0 訂單品項取貨都不再被擋"}
+                      className={r.is_gift
+                        ? "rounded-md bg-amber-500 px-2 py-1 text-[11px] font-medium text-white hover:bg-amber-600"
+                        : "rounded-md border border-zinc-300 px-2 py-1 text-[11px] font-medium text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"}
+                    >
+                      {r.is_gift ? "🎁 贈品" : "設為贈品"}
+                    </SpinButton>
+                  ) : (
+                    <span className="text-zinc-400">{r.is_gift ? "🎁" : "—"}</span>
+                  )}
                 </Td>
               </tr>
             ))}

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -513,6 +513,13 @@ export function OrderDetail({
   // 與 v_customer_order_summary.items_total / rpc_wallet_pay_order 同一套過濾
   //（migration 20260808000010）。
   const activeItems = items.filter((i) => !["cancelled", "expired"].includes(i.status));
+  // 取貨會被零元守衛擋下的品項：還沒取貨、單價 $0、也還沒被標成贈品。
+  // 用 itemEffective（含未存檔的草稿改價），避免「已經改好價還在叫你標贈品」。
+  const zeroPriceItems = items.filter(
+    (i) => ["pending", "reserved", "ready"].includes(i.status)
+      && Number(itemEffective(i).unit_price) === 0
+      && !isGiftLine(i),
+  );
 
   const totalQty = activeItems.reduce((s, i) => s + Number(itemEffective(i).qty), 0);
   const grossTotal = activeItems.reduce((s, i) => {
@@ -850,6 +857,34 @@ export function OrderDetail({
       p_reason: reason?.trim() ?? null,
     });
     if (rpcErr) { alert(`${turningOn ? "標記" : "取消"}贈品失敗：${translateRpcError(rpcErr)}`); return; }
+    setReloadTick((n) => n + 1);
+  }
+
+  // 整張單的 $0 品項一次標成贈品 —— 促銷活動送的東西通常整張單好幾項，
+  // 一列一列點太慢。批次版與逐列版同一套守衛（未取貨 + $0 + 理由必填 + 逐列 audit）。
+  async function markAllZeroGift() {
+    if (!head) return;
+    const targets = zeroPriceItems;
+    if (targets.length === 0) return;
+    const reason = prompt(
+      `把這張單的 ${targets.length} 個 $0 品項全部標成贈品（${head.order_no}）\n` +
+      `這些品項會以 $0 交給客人（不收錢），每一列都會寫進異動紀錄。\n\n` +
+      `請輸入原因（例：週年慶滿額贈 / 買二送一）：`,
+    );
+    if (reason === null) return;
+    if (!reason.trim()) { alert("請填寫贈品原因（會寫進異動紀錄）"); return; }
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id ?? null;
+    if (!operator) { alert("尚未登入"); return; }
+    const { data, error: rpcErr } = await sb.rpc("rpc_mark_zero_price_items_gift", {
+      p_order_ids: [head.id],
+      p_operator: operator,
+      p_reason: reason.trim(),
+    });
+    if (rpcErr) { alert(`標記贈品失敗：${translateRpcError(rpcErr)}`); return; }
+    const r = (data ?? null) as { items: number } | null;
+    alert(`已把 ${r?.items ?? 0} 個品項標成贈品，取貨不再被擋`);
     setReloadTick((n) => n + 1);
   }
 
@@ -1332,6 +1367,23 @@ export function OrderDetail({
             })()}
           </div>
         </div>
+        {/* $0 品項提示 —— 取貨會被擋（rpc_record_pickup 零元守衛）。兩條路：
+            漏填金額就改單價，刻意送的（促銷 / 補償）就標贈品。促銷走這顆一鍵標。*/}
+        {zeroPriceItems.length > 0 && (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-red-200 bg-red-50 px-3 py-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+            <span className="font-semibold">⚠️ 有 {zeroPriceItems.length} 個品項的單價是 $0</span>
+            <span>取貨會被擋下。漏填金額就改單價；刻意送的就標成贈品。</span>
+            {canEditNotes && (
+              <SpinButton
+                onClick={markAllZeroGift}
+                title="把這張單所有未取貨的 $0 品項一次標成贈品（會要求填原因，每一列都寫入異動紀錄）"
+                className="ml-auto shrink-0 rounded-md border border-amber-400 bg-white px-2.5 py-1 font-medium text-amber-700 hover:bg-amber-50 dark:border-amber-700 dark:bg-transparent dark:text-amber-300 dark:hover:bg-amber-950"
+              >
+                🎁 整單標成贈品
+              </SpinButton>
+            )}
+          </div>
+        )}
         <div className="overflow-x-auto">
           <table className="min-w-full divide-y divide-zinc-200 text-xs dark:divide-zinc-800">
             <thead className="bg-zinc-50 dark:bg-zinc-900">

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -23,6 +23,7 @@ import { aidRouteLabel, aidStageLabel, isAidInFlight } from "@/lib/aidTransfer";
 import { internalOrderSource } from "@/lib/orderTitle";
 import { translateRpcError } from "@/lib/rpcError";
 import { parseReturnNote } from "@/lib/returnNote";
+import { GIFT_ITEM_SELECT, giftTitle, isCampaignGiftLine, isGiftLine } from "@/lib/orderGift";
 import {
   fetchReprintableEvents,
   pickupEventLabel,
@@ -59,6 +60,10 @@ type ItemRow = {
   qty: number;
   unit_price: number;
   status: string;
+  // 贈品標記（20260819000000）：品項自己標的 + 開團層級的促銷贈品
+  is_gift: boolean | null;
+  gift_reason: string | null;
+  campaign_item: { is_gift: boolean | null; gift_reason: string | null } | null;
   stockout_at: string | null;
   source: string;
   notes: string | null;
@@ -297,7 +302,7 @@ export function OrderDetail({
           .select("id, order_no, status, stockout_at, pickup_deadline, nickname_snapshot, created_at, updated_at, pickup_store_id, campaign_id, transferred_from_order_id, is_air_transfer, discount_amount, discount_percent, wallet_paid_amount, payment_status, paid_at, notes, member:members(id, name, phone, member_no), campaign:group_buy_campaigns(id, campaign_no, name), store:stores!customer_orders_pickup_store_id_fkey(id, name)")
           .eq("id", orderId).maybeSingle(),
         sb.from("customer_order_items")
-          .select("id, qty, unit_price, status, stockout_at, source, notes, discount_amount, discount_percent, created_at, updated_at, created_by, updated_by, sku:skus(id, sku_code, product_name, variant_name)")
+          .select(`id, qty, unit_price, status, stockout_at, source, notes, discount_amount, discount_percent, created_at, updated_at, created_by, updated_by, ${GIFT_ITEM_SELECT}, sku:skus(id, sku_code, product_name, variant_name)`)
           .eq("order_id", orderId)
           .order("created_at", { ascending: true }),
         sb.from("transfers")
@@ -812,6 +817,39 @@ export function OrderDetail({
     if (rpcErr) { alert(`刪除失敗：${translateRpcError(rpcErr)}`); return; }
     const cancelled = !!(data as { order_cancelled?: boolean } | null)?.order_cancelled;
     alert(cancelled ? "已刪除品項，整單已一併取消" : "已刪除品項");
+    setReloadTick((n) => n + 1);
+  }
+
+  // 標記／取消標記「贈品」（$0 但刻意送的）。標了就免除取貨零元守衛。
+  // 權限與備註同一套（HQ / 總倉 / 自店 = canEditNotes），理由必填、寫 audit log。
+  // 開團層級的促銷贈品（campaign_items.is_gift）在這裡取消不掉 —— 後端會擋並說明
+  // 要去開團商品那邊改，避免「按了沒反應」。
+  async function toggleGift(it: ItemRow) {
+    if (!head) return;
+    const label = it.sku ? (it.sku.variant_name || it.sku.product_name || it.sku.sku_code) : `#${it.id}`;
+    const turningOn = !it.is_gift;
+    let reason: string | null = null;
+    if (turningOn) {
+      reason = prompt(
+        `標記為贈品：${label}（${head.order_no}）\n這個品項會以 $0 交給客人（不收錢）。\n請輸入原因（例：促銷買二送一 / 客訴補償）：`,
+      );
+      if (reason === null) return;
+      if (!reason.trim()) { alert("請填寫贈品原因（會寫進異動紀錄）"); return; }
+    } else if (!confirm(`取消贈品標記：${label}\n取消後這個品項在取貨時會被零元守衛擋下，要補上金額才能取貨。確定嗎？`)) {
+      return;
+    }
+    const sb = getSupabase();
+    const { data: sess } = await sb.auth.getSession();
+    const operator = sess.session?.user?.id ?? null;
+    if (!operator) { alert("尚未登入"); return; }
+    const { error: rpcErr } = await sb.rpc("rpc_mark_order_item_gift", {
+      p_order_id: head.id,
+      p_item_id: it.id,
+      p_is_gift: turningOn,
+      p_operator: operator,
+      p_reason: reason?.trim() ?? null,
+    });
+    if (rpcErr) { alert(`${turningOn ? "標記" : "取消"}贈品失敗：${translateRpcError(rpcErr)}`); return; }
     setReloadTick((n) => n + 1);
   }
 
@@ -1335,6 +1373,29 @@ export function OrderDetail({
                         </span>
                       )}
                       {showItemSource && <ItemSourceBadge source={it.source} className="ml-1.5" />}
+                      {/* 🎁 贈品：$0 但刻意送的（促銷 / 補償）→ 取貨零元守衛放行。
+                          開團設定的贈品整團適用，這裡只顯示、不給取消（後端也會擋）。*/}
+                      {isGiftLine(it) && (
+                        <span
+                          className="ml-1.5 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                          title={giftTitle(it)}
+                        >
+                          🎁 贈品{isCampaignGiftLine(it) ? "（開團設定）" : ""}
+                        </span>
+                      )}
+                      {canEditNotes && !isPicked && !isCampaignGiftLine(it)
+                        && !["cancelled", "expired"].includes(it.status)
+                        && (it.is_gift || Number(eff.unit_price) === 0) && (
+                        <SpinButton
+                          onClick={() => toggleGift(it)}
+                          title={it.is_gift
+                            ? "取消贈品標記（取消後取貨會被零元守衛擋下，要補金額）"
+                            : "這個品項是刻意送的贈品（促銷 / 補償）→ 標記後不用補金額就能取貨。會要求填原因並寫入異動紀錄。"}
+                          className="ml-1.5 rounded border border-amber-400 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 hover:bg-amber-50 dark:border-amber-700 dark:text-amber-300 dark:hover:bg-amber-950"
+                        >
+                          {it.is_gift ? "取消贈品" : "🎁 標為贈品"}
+                        </SpinButton>
+                      )}
                     </td>
                     <td className="px-3 py-2 text-right font-mono">
                       {isPicked ? (

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -12,6 +12,7 @@ import { orderItemStatusLabel } from "@/lib/orderStatus";
 import { parseReturnNote } from "@/lib/returnNote";
 import { itemDisplayName } from "@/lib/skuLabel";
 import { isHqRole, useMyStores, useRole } from "@/lib/role";
+import { GIFT_ITEM_SELECT, giftTitle, isCampaignGiftLine, isGiftLine } from "@/lib/orderGift";
 import { useHasStaffPerm } from "@/lib/staffPerms";
 
 type PickableItem = {
@@ -21,6 +22,10 @@ type PickableItem = {
   discount_amount: number;
   discount_percent: number;
   status: string;
+  // 贈品標記（20260819000000）：品項自己標的 + 開團層級的促銷贈品，判定走 lib/orderGift
+  is_gift: boolean | null;
+  gift_reason: string | null;
+  campaign_item: { is_gift: boolean | null; gift_reason: string | null } | null;
   sku: { id: number; sku_code: string; product_name: string | null; variant_name: string | null } | null;
 };
 
@@ -107,7 +112,7 @@ export function PickupDialog({
       const sb = getSupabase();
       const [iRes, hRes, rRes, arvRes] = await Promise.all([
         sb.from("customer_order_items")
-          .select("id, qty, unit_price, discount_amount, discount_percent, status, sku:skus(id, sku_code, product_name, variant_name)")
+          .select(`id, qty, unit_price, discount_amount, discount_percent, status, ${GIFT_ITEM_SELECT}, sku:skus(id, sku_code, product_name, variant_name)`)
           .eq("order_id", orderId)
           .in("status", ["pending", "reserved", "ready"])
           .order("id"),
@@ -135,7 +140,7 @@ export function PickupDialog({
       const headMember = Array.isArray(hRes.data?.member) ? hRes.data?.member[0] : hRes.data?.member;
       const internalPool = headMember?.member_type === "store_internal";
       setIsInternalPool(internalPool);
-      const zeroPriced = (it: PickableItem) => !internalPool && Number(it.unit_price) === 0;
+      const zeroPriced = (it: PickableItem) => !internalPool && Number(it.unit_price) === 0 && !isGiftLine(it);
 
       // ----- 退貨量依 SKU 聚合，再分攤到各 pending 品項行（list 已 order by id，分攤穩定）-----
       // 只算「未取退貨」：取貨後退回（|取貨後退回）的是客戶已取走的貨，不扣未取品項的可取量
@@ -234,8 +239,9 @@ export function PickupDialog({
   // 該品項是否漏填金額（單價 $0）。取貨＝收錢，$0 收不到錢 → 鎖住不可勾，
   // 後端 rpc_record_pickup 的零元守衛也會擋（migration 20260815000000）。
   // 現貨池容器單（store_internal）的 0 是掛帳用的，不算。
+  // 已標記的贈品（開團設定 / 這張單標的）也不算 —— 那是刻意送的（20260819000000）。
   function zeroPrice(it: PickableItem): boolean {
-    return !isInternalPool && Number(it.unit_price) === 0;
+    return !isInternalPool && Number(it.unit_price) === 0 && !isGiftLine(it);
   }
   function pickableOf(it: PickableItem): number {
     return Math.max(0, Number(it.qty) - returnedOf(it));
@@ -404,7 +410,7 @@ export function PickupDialog({
             <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
               ⚠️ 有 {items.filter((it) => zeroPrice(it)).length} 個品項的單價是 $0（可能是開團時漏填金額），
               已鎖住不能取貨。請到取貨頁該品項旁「補填」金額，或到訂單明細改單價；
-              其餘有價格的品項可以先取。
+              若是刻意送的贈品，改按取貨頁的「🎁 這是贈品」標記；其餘有價格的品項可以先取。
             </div>
           )}
           <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
@@ -454,6 +460,15 @@ export function PickupDialog({
                         {returned > 0 && (
                           <span className="ml-2 rounded bg-orange-100 px-1.5 py-0.5 text-[10px] font-medium text-orange-800 dark:bg-orange-950 dark:text-orange-300">
                             ↩ 已退 {returned}
+                          </span>
+                        )}
+                        {/* 贈品：$0 但刻意送的，可正常勾取，畫面要標出來（收據上也才看得懂） */}
+                        {isGiftLine(it) && (
+                          <span
+                            className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                            title={giftTitle(it)}
+                          >
+                            🎁 贈品{isCampaignGiftLine(it) ? "（開團設定）" : ""}
                           </span>
                         )}
                       </td>

--- a/apps/admin/src/lib/orderGift.ts
+++ b/apps/admin/src/lib/orderGift.ts
@@ -1,0 +1,54 @@
+// 贈品（$0 但刻意送的）判定 —— 全站唯一一份，各頁不要各寫一份。
+//
+// 兩層標記，讀取時 OR（DB 端 rpc_record_pickup / v_admin_orders_list 用同一套）：
+//   1. campaign_items.is_gift       —— 開團層級（促銷活動：一次標，全團訂單生效）
+//   2. customer_order_items.is_gift —— 單張訂單層級（櫃台當場標的個案）
+//
+// 為什麼不在 DB 把 1 同步進 2：有 50 支 migration 會 INSERT customer_order_items
+// （轉單 / 拆行 / 配貨…），同步欄位漏一支就是「贈品變回漏填、櫃台被擋」；
+// 而且 1 要能追溯生效（促銷開跑之後才想到要標）。詳見 20260819000000 檔頭。
+
+type CampaignGift = { is_gift?: boolean | null; gift_reason?: string | null };
+
+export type GiftFlaggedItem = {
+  is_gift?: boolean | null;
+  gift_reason?: string | null;
+  // PostgREST 的 to-one embed 正常回物件，但同一個 select 在別處被當成陣列過
+  // （見 PickupDialog 的 member:members(...)），兩種都收，不要在呼叫端各判一次
+  campaign_item?: CampaignGift | CampaignGift[] | null;
+};
+
+function campaignGift(it: GiftFlaggedItem | null | undefined): CampaignGift | null {
+  const ci = it?.campaign_item;
+  if (!ci) return null;
+  return Array.isArray(ci) ? (ci[0] ?? null) : ci;
+}
+
+/** PostgREST 抓品項時要一起帶的欄位（含開團層級的標記） */
+export const GIFT_ITEM_SELECT =
+  "is_gift, gift_reason, campaign_item:campaign_items(is_gift, gift_reason)";
+
+export function isGiftLine(it: GiftFlaggedItem | null | undefined): boolean {
+  if (!it) return false;
+  return !!it.is_gift || !!campaignGift(it)?.is_gift;
+}
+
+/** 這一列的贈品標記是不是來自開團設定（＝單張訂單這邊取消不掉） */
+export function isCampaignGiftLine(it: GiftFlaggedItem | null | undefined): boolean {
+  return !!campaignGift(it)?.is_gift;
+}
+
+/** 顯示用的贈品原因；開團層級優先（那是整個團的說法） */
+export function giftReasonOf(it: GiftFlaggedItem | null | undefined): string {
+  if (!it) return "";
+  const ci = campaignGift(it);
+  return (ci?.is_gift ? ci.gift_reason : it.gift_reason) || "";
+}
+
+/** 🎁 標籤的 title：把來源與原因一起講清楚 */
+export function giftTitle(it: GiftFlaggedItem | null | undefined): string {
+  if (!isGiftLine(it)) return "";
+  const reason = giftReasonOf(it);
+  const from = isCampaignGiftLine(it) ? "開團設定的贈品（整個團適用）" : "這張訂單標記的贈品";
+  return reason ? `${from}：${reason}` : from;
+}

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -392,6 +392,12 @@ const RULES: Rule[] = [
     pattern: /^zero_price(?:_fill)?:\s*([\s\S]+)$/i,
     render: (m) => m[1],
   },
+  // ===== 贈品標記（rpc_mark_order_item_gift / rpc_set_campaign_item_gift） =====
+  {
+    // 訊息本體已是中文，一樣只把機器前綴拿掉
+    pattern: /^(?:gift_mark|campaign_gift):\s*([\s\S]+)$/i,
+    render: (m) => m[1],
+  },
   {
     // _check_order_edit_notes_perm 的拒絕訊息（補填金額沿用它做權限判斷，
     // 所以字面上會寫「edit notes」）— 對店員講清楚是「不是你們店的單」

--- a/supabase/migrations/20260819000000_gift_exempt_zero_price_guard.sql
+++ b/supabase/migrations/20260819000000_gift_exempt_zero_price_guard.sql
@@ -1,0 +1,1140 @@
+-- ============================================================================
+-- 2026-08-19: 贈品排除零元守衛 —— 「刻意送的」與「漏填金額的」分開
+--
+-- 需求：「單價是零設定阻擋非常好，但有一種是屬贈品的狀況（尤其辦促銷活動）
+--        是否要多一個設定排除」。
+--
+-- 為什麼不做成「一個開關關掉守衛」：
+--   20260815000000 的零元守衛擋的是「開團 / 代 key 漏填金額」，線上已經因此白送
+--   111 列。做成全域（或每店）開關 = 促銷期間關掉、漏填的也一起放行，等於守衛不
+--   存在；而促銷結束沒人記得關回去。所以做成**標記制**：$0 只有被明確標成贈品
+--   才放行，誰標的、什麼時候、為什麼，全部留痕。
+--
+-- 兩層標記（讀取時 OR，不做欄位同步）：
+--   A. campaign_items.is_gift  —— 開團層級（促銷活動主用）。
+--      團購訂單的單價一律來自 campaign_items（rpc_create_customer_orders 只收
+--      {campaign_item_id, qty}，前端根本沒有單價欄），所以促銷贈品的正解是把那個
+--      開團商品標成贈品；標下去**當下就對該團所有既有 / 未來訂單生效**，不用回頭
+--      一張一張處理。
+--   B. customer_order_items.is_gift —— 單一訂單層級（臨時、個案）。
+--      櫃台被守衛擋下時當場標（同 rpc_fill_zero_order_item_price 的權限：
+--      HQ / 總倉 / 自店），或事後在訂單明細標。
+--
+--   判定一律是 `coi.is_gift OR ci.is_gift`（讀取時 join，不寫回 coi）。
+--   刻意不用 trigger 把 A 同步進 B：
+--     - 有 50 支 migration 會 INSERT customer_order_items（轉單 / 拆行 / 配貨…），
+--       同步欄位就要逐一補，漏一支就是「贈品變成漏填、櫃台被擋」。
+--     - A 要能追溯生效（促銷開跑後才想到要標），寫回欄位就得再寫 backfill。
+--
+-- 三個「會把贈品價格改掉」的地方一起關掉，否則標了也會被蓋回零售價（而且是
+-- 連既有 pending 訂單一起蓋 → 贈品變成跟客人收錢）：
+--   - rpc_resync_campaign_from_product（重新同步商品/價格）
+--   - _sync_retail_price_to_campaigns（draft 團跟著零售價走的 trigger）
+--   - rpc_fill_zero_order_item_price（補金額成功 = 這列不是贈品 → 清掉 B 標記）
+--
+-- 基底版本（append-only，逐字保留所有 prior fix；每一支都重新 grep 過）：
+--   - v_admin_orders_list                 ← 20260815000000（本檔加 gift 排除 + gift_lines）
+--   - rpc_record_pickup                   ← 20260815000000（本檔只改零元守衛 + 拆行帶 gift 欄）
+--   - rpc_fill_zero_order_item_price      ← 20260815000000（本檔只加「補完清 gift 標記」）
+--   - rpc_resync_campaign_from_product    ← 20260620000060（本檔只加 6 處 is_gift 排除）
+--   - _sync_retail_price_to_campaigns     ← 20260514000008（本檔只加 1 處 is_gift 排除）
+--
+-- Rollback：
+--   ALTER TABLE customer_order_items DROP COLUMN is_gift, DROP COLUMN gift_reason,
+--     DROP COLUMN gift_marked_by, DROP COLUMN gift_marked_at;
+--   ALTER TABLE campaign_items DROP COLUMN is_gift, DROP COLUMN gift_reason;
+--   customer_order_audit_log_field_check 重跑 20260625000000 的版本（少 'is_gift'；
+--     要先清掉 field='is_gift' 的稽核列，否則 ADD CONSTRAINT 會被既有資料擋下）。
+--   DROP FUNCTION public.rpc_mark_order_item_gift(BIGINT,BIGINT,BOOLEAN,UUID,TEXT);
+--   DROP FUNCTION public.rpc_set_campaign_item_gift(BIGINT,BOOLEAN,TEXT);
+--   重跑 20260815000000（view / rpc_record_pickup / rpc_fill_zero_order_item_price）、
+--   20260620000060（resync）、20260514000008 第 2 段（_sync_retail_price_to_campaigns）。
+--   ⚠ view 少一欄 gift_lines，前端要一起回退。
+--
+-- 對應前端（同一個 commit）：
+--   - apps/admin/src/lib/orderGift.ts（唯一判定 isGiftLine，前端各頁不要各寫一份）
+--   - apps/admin/src/app/(protected)/pickup/page.tsx（贈品不擋 + 當場標記）
+--   - apps/admin/src/components/PickupDialog.tsx（贈品可勾、顯示 🎁）
+--   - apps/admin/src/components/OrderDetail.tsx（品項列 🎁 標記 / 取消標記）
+--   - apps/admin/src/app/(protected)/orders/page.tsx（$0 提示排除贈品 + 🎁 欄）
+--   - apps/admin/src/components/CampaignItemsTable.tsx（開團商品標贈品）
+--   - apps/admin/src/lib/rpcError.ts（gift_mark / campaign_gift 前綴中文化）
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. 欄位
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE campaign_items
+  ADD COLUMN IF NOT EXISTS is_gift     BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS gift_reason TEXT;
+
+COMMENT ON COLUMN campaign_items.is_gift IS
+  '20260819000000：這個開團商品是贈品（促銷活動）。TRUE → 該團所有 $0 訂單品項免除'
+  '取貨零元守衛，且「重新同步商品/價格」與零售價 trigger 都不再改它的單價。'
+  '只能經 rpc_set_campaign_item_gift 設定（管理員限定，會一併把單價設為 0）。';
+
+COMMENT ON COLUMN campaign_items.gift_reason IS
+  '20260819000000：標成贈品的理由（例：週年慶滿額贈）。顯示在開團商品列與訂單品項的 🎁 提示。';
+
+ALTER TABLE customer_order_items
+  ADD COLUMN IF NOT EXISTS is_gift        BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS gift_reason    TEXT,
+  ADD COLUMN IF NOT EXISTS gift_marked_by UUID,
+  ADD COLUMN IF NOT EXISTS gift_marked_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN customer_order_items.is_gift IS
+  '20260819000000：這一列是刻意送的贈品（單一訂單個案）。TRUE → 免除取貨零元守衛。'
+  '開團層級的促銷贈品走 campaign_items.is_gift，不寫回這裡（判定是兩者 OR）。'
+  '只能經 rpc_mark_order_item_gift 設定，每次寫一筆 customer_order_audit_log。';
+
+COMMENT ON COLUMN customer_order_items.gift_reason IS
+  '20260819000000：標成贈品的理由（必填，例：買二送一 / 客訴補償）。';
+COMMENT ON COLUMN customer_order_items.gift_marked_by IS
+  '20260819000000：標記贈品的操作者（櫃台自己標的也留痕，供 HQ 事後檢視）。';
+COMMENT ON COLUMN customer_order_items.gift_marked_at IS
+  '20260819000000：標記贈品的時間。';
+
+-- customer_order_audit_log.field 是白名單 CHECK，沒擴充的話 rpc_mark_order_item_gift
+-- 寫 audit 會直接違反 constraint（＝標記贈品整支失敗）。
+-- 基底清單：20260625000000_pr_create_lock_campaign_and_orders.sql（逐字保留 + 'is_gift'）。
+ALTER TABLE customer_order_audit_log DROP CONSTRAINT customer_order_audit_log_field_check;
+ALTER TABLE customer_order_audit_log
+  ADD CONSTRAINT customer_order_audit_log_field_check
+    CHECK (field IN (
+      'unit_price','item_notes','item_discount_amount','item_discount_percent',
+      'discount_amount','discount_percent','order_notes',
+      'qty',      -- Stage 3 (店家改 qty)
+      'status',   -- Stage 4 (PR auto-confirm)
+      'is_gift'   -- 20260819000000 (標記/取消標記贈品)
+    ));
+
+-- ----------------------------------------------------------------------------
+-- 2. v_admin_orders_list v4 — $0 提示排除贈品，另回 gift_lines
+--    基底 20260815000000 逐字保留，只在 LATERAL 加 campaign_items join、
+--    zero_price_lines 加排除條件、多一個 gift_lines 欄。
+-- ----------------------------------------------------------------------------
+
+DROP VIEW IF EXISTS v_admin_orders_list;
+
+CREATE VIEW v_admin_orders_list
+WITH (security_invoker = true) AS
+SELECT
+  o.*,
+  c.name AS campaign_name,
+  COALESCE(m.name, o.nickname_snapshot) AS member_name,
+  s.name AS store_name,
+  agg.line_count,
+  agg.total_qty,
+  agg.total_amount,
+  agg.source_summary,
+  -- 20260815000000：$0 品項行數（可能漏填金額）。store_internal 的容器單一律 0
+  -- —— 池子單價本來就可能是 0，標紅只會製造雜訊（見 20260815000000 檔頭）。
+  -- 20260819000000：刻意標成贈品的列（品項自己標，或整個開團商品是贈品）不算漏填。
+  CASE WHEN COALESCE(m.member_type, '') = 'store_internal' THEN 0
+       ELSE agg.zero_price_lines END       AS zero_price_lines,
+  -- 20260819000000：贈品行數（列表顯示 🎁，讓 HQ 看得到誰在送東西）
+  agg.gift_lines                           AS gift_lines
+FROM v_admin_orders o
+LEFT JOIN group_buy_campaigns c ON c.id = o.campaign_id
+LEFT JOIN members m ON m.id = o.member_id
+LEFT JOIN stores s ON s.id = o.pickup_store_id
+LEFT JOIN LATERAL (
+  SELECT
+    count(*)::int                          AS line_count,
+    COALESCE(sum(i.qty), 0)                AS total_qty,
+    COALESCE(sum(i.qty * i.unit_price), 0) AS total_amount,
+    CASE WHEN count(DISTINCT i.source) > 1 THEN 'mixed'
+         ELSE min(i.source) END            AS source_summary,
+    count(*) FILTER (
+      WHERE COALESCE(i.unit_price, 0) = 0
+        AND NOT COALESCE(i.is_gift, FALSE)
+        AND NOT COALESCE(gi.is_gift, FALSE)
+    )::int                                 AS zero_price_lines,
+    count(*) FILTER (
+      WHERE COALESCE(i.is_gift, FALSE) OR COALESCE(gi.is_gift, FALSE)
+    )::int                                 AS gift_lines
+  FROM customer_order_items i
+  -- 20260819000000：開團層級的贈品標記（促銷活動一次標、全團訂單生效）
+  LEFT JOIN campaign_items gi ON gi.id = i.campaign_item_id
+  WHERE i.order_id = o.id
+    -- 20260808000010：已取消 / 斷貨的品項不算進項數 / 件數 / 金額
+    AND i.status NOT IN ('cancelled','expired')
+) agg ON true;
+
+COMMENT ON VIEW v_admin_orders_list IS
+  '/orders 列表查詢用：v_admin_orders + 可排序欄位（campaign_name / member_name / '
+  'store_name / line_count / total_qty / total_amount / source_summary）。'
+  '只給列表 + 選取全部用；tab 數量與趨勢的 rpc_order_overview 維持查 v_admin_orders，'
+  '避免整表聚合時多揹 per-row 品項彙總。'
+  '20260808000010：彙總排除 cancelled/expired 品項，與訂單明細的應收同一套語意。'
+  '20260815000000：zero_price_lines = 單價 $0 的品項行數（漏填金額提示 / 「只看 $0」'
+  '伺服端篩選）；store_internal 容器單恆為 0。'
+  '20260819000000：zero_price_lines 排除贈品（customer_order_items.is_gift 或'
+  ' campaign_items.is_gift）；另加 gift_lines = 贈品行數。';
+
+GRANT SELECT ON v_admin_orders_list TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 3. rpc_record_pickup — 零元守衛放行「已標記的贈品」
+--    基底 20260815000000 逐字保留，只動兩處：守衛條件、拆行時帶贈品標記。
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_record_pickup(
+  p_order_id  bigint,
+  p_item_ids  bigint[],
+  p_operator  uuid,
+  p_notes     text  DEFAULT NULL,
+  p_item_qtys jsonb DEFAULT NULL   -- {"<item_id>": <取貨數量>}；缺項或 >=qty 視為整行取
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_pickup_loc       BIGINT;
+  v_item             RECORD;
+  v_ret_guard        RECORD;
+  v_take             NUMERIC;
+  v_picked_disc      NUMERIC;
+  v_movement_id      BIGINT;
+  v_new_item_id      BIGINT;
+  v_picked_item_id   BIGINT;
+  v_picked_count     INT := 0;
+  v_event_item_ids   BIGINT[] := ARRAY[]::BIGINT[];
+  v_active_remaining INT;
+  v_new_status       TEXT;
+  v_event_type       TEXT;
+  v_event_id         BIGINT;
+  v_sku_label        TEXT;
+  v_now              TIMESTAMPTZ := NOW();
+  -- 店家守衛（2026-08-13）
+  v_jwt_role          TEXT  := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_my_stores         JSONB := COALESCE(auth.jwt() -> 'app_metadata' -> 'stores', '[]'::jsonb);
+  v_pickup_store_name TEXT;
+  -- 零元守衛（2026-08-15）
+  v_is_internal_pool  BOOLEAN;
+  v_zero_labels       TEXT[] := ARRAY[]::TEXT[];
+BEGIN
+  IF p_item_ids IS NULL OR array_length(p_item_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_item_ids is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_pickup:' || p_order_id::text));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION '找不到訂單 %', p_order_id;
+  END IF;
+
+  IF v_order.status IN ('completed','expired','cancelled','transferred_out') THEN
+    RAISE EXCEPTION '訂單 % 目前狀態為「%」，無法取貨', p_order_id, v_order.status;
+  END IF;
+
+  -- 店家守衛：分店角色只能替「自己店」的訂單取貨。庫存跟著 pickup_store_id
+  -- 的 location 扣，跨店按取貨會扣到別店的帳、客人也拿不到貨。
+  -- stores 為空（未設定的 legacy 帳號）或含「總倉」不鎖，對齊前端判定。
+  IF v_jwt_role IN ('store_manager','store_staff')
+     AND jsonb_typeof(v_my_stores) = 'array'
+     AND jsonb_array_length(v_my_stores) > 0
+     AND NOT (v_my_stores ? '總倉') THEN
+    SELECT s.name INTO v_pickup_store_name
+      FROM stores s
+     WHERE s.id = v_order.pickup_store_id
+       AND s.tenant_id = v_order.tenant_id;
+    IF v_pickup_store_name IS NULL OR NOT (v_my_stores ? v_pickup_store_name) THEN
+      RAISE EXCEPTION 'wrong_store: 此訂單的取貨店是「%」，分店帳號只能替自己店的訂單取貨，請由該店操作或先轉單',
+        COALESCE(v_pickup_store_name, '未設定');
+    END IF;
+  END IF;
+
+  -- 零元守衛（2026-08-15）：本次要取的品項若單價是 $0，代表開團 / 代 key 時
+  -- 漏填金額 —— 取貨就是收錢的那一刻，放行等於把貨白送出去（線上已經這樣送掉
+  -- 111 列）。擋在扣庫存之前，補填金額後即可重取。
+  -- 例外：【內部】xx 店 / RR- / OV- 容器單（member_type='store_internal'）的
+  -- 池子單價本來就可能是 0，不是漏填。
+  -- 20260819000000：刻意送的贈品也是例外，但必須被明確標記過 ——
+  -- 品項自己標（coi.is_gift，rpc_mark_order_item_gift）或整個開團商品是贈品
+  -- （campaign_items.is_gift，rpc_set_campaign_item_gift，促銷活動一次標全團生效）。
+  -- 兩層讀取時 OR，不做欄位同步（見本檔檔頭）。
+  SELECT EXISTS (
+    SELECT 1 FROM members mb
+     WHERE mb.id = v_order.member_id
+       AND mb.tenant_id = v_order.tenant_id
+       AND mb.member_type = 'store_internal'
+  ) INTO v_is_internal_pool;
+
+  IF NOT v_is_internal_pool THEN
+    SELECT array_agg(COALESCE(sk.variant_name, sk.product_name, sk.sku_code, coi.id::text)
+                     ORDER BY coi.id)
+      INTO v_zero_labels
+      FROM customer_order_items coi
+      LEFT JOIN skus sk ON sk.id = coi.sku_id
+      LEFT JOIN campaign_items gi ON gi.id = coi.campaign_item_id
+     WHERE coi.id = ANY(p_item_ids)
+       AND coi.order_id = p_order_id
+       AND coi.status IN ('pending','reserved','ready')
+       AND COALESCE(coi.unit_price, 0) = 0
+       AND NOT COALESCE(coi.is_gift, FALSE)
+       AND NOT COALESCE(gi.is_gift, FALSE);
+
+    IF v_zero_labels IS NOT NULL AND array_length(v_zero_labels, 1) > 0 THEN
+      RAISE EXCEPTION 'zero_price: 品項「%」的單價是 $0，看起來是開團時漏填金額。請先補上金額再取貨（取貨頁該品項旁可直接補填）；若這是刻意送的贈品，改按該品項旁的「🎁 這是贈品」標記後即可取貨',
+        array_to_string(v_zero_labels, '」、「');
+    END IF;
+  END IF;
+
+  SELECT location_id INTO v_pickup_loc
+    FROM stores
+   WHERE id = v_order.pickup_store_id;
+
+  IF v_pickup_loc IS NULL THEN
+    RAISE EXCEPTION '分店 % 未設定倉庫位置 (location_id)、無法寫 stock_movement', v_order.pickup_store_id;
+  END IF;
+
+  -- 退貨守門：同 SKU「本次取貨量」不得超過「active 品項量 − 未取退貨量」。
+  -- 未取退貨（return_to_hq、notes header 不含 |取貨後退回）的貨已離店，
+  -- 不能再被結帳；取貨後退回不計入（那批貨的錢在取貨時已收）。
+  -- 前端 PickupDialog 有同款防線，但畫面 stale 時會失效，這裡是最後防線。
+  FOR v_ret_guard IN
+    SELECT r.sku_id, r.ret_qty,
+           COALESCE(act.active_qty, 0) AS active_qty,
+           COALESCE(req.take_qty, 0)   AS take_qty
+      FROM (
+        SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+          FROM transfers t
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+         WHERE t.customer_order_id = p_order_id
+           AND t.tenant_id     = v_order.tenant_id
+           AND t.transfer_type = 'return_to_hq'
+           AND t.status IN ('shipped','received')
+           AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+               NOT LIKE '%取貨後退回%'
+         GROUP BY ti.sku_id
+      ) r
+      LEFT JOIN (
+        SELECT coi.sku_id, SUM(coi.qty) AS active_qty
+          FROM customer_order_items coi
+         WHERE coi.order_id = p_order_id
+           AND coi.status IN ('pending','reserved','ready')
+         GROUP BY coi.sku_id
+      ) act ON act.sku_id = r.sku_id
+      LEFT JOIN (
+        -- 本次各 SKU 取貨量（缺項＝整行取；clamp 到行量，超量交給主迴圈報錯）
+        SELECT coi.sku_id,
+               SUM(LEAST(COALESCE((p_item_qtys ->> coi.id::text)::numeric, coi.qty), coi.qty)) AS take_qty
+          FROM customer_order_items coi
+         WHERE coi.id = ANY(p_item_ids)
+           AND coi.order_id = p_order_id
+         GROUP BY coi.sku_id
+      ) req ON req.sku_id = r.sku_id
+     WHERE COALESCE(req.take_qty, 0) > COALESCE(act.active_qty, 0) - r.ret_qty
+  LOOP
+    SELECT COALESCE(s.variant_name, s.product_name, s.sku_code)
+      INTO v_sku_label FROM skus s WHERE s.id = v_ret_guard.sku_id;
+    RAISE EXCEPTION '品項「%」已退貨 % 件，本次最多可取 % 件（畫面資料可能過舊，請重新整理後再取）',
+      COALESCE(v_sku_label, v_ret_guard.sku_id::text),
+      v_ret_guard.ret_qty,
+      GREATEST(v_ret_guard.active_qty - v_ret_guard.ret_qty, 0);
+  END LOOP;
+
+  -- 逐品項：判斷整行取 or 拆行部分取
+  FOR v_item IN
+    SELECT id, sku_id, qty, unit_price, status, source, campaign_item_id,
+           tenant_id, notes, discount_amount, discount_percent, created_by,
+           -- 20260819000000：拆行要把贈品標記帶到 picked_up 那一行，
+           -- 否則部分取貨之後收據 / 明細看不出那一件是送的
+           is_gift, gift_reason, gift_marked_by, gift_marked_at
+      FROM customer_order_items
+     WHERE id = ANY(p_item_ids)
+       AND order_id = p_order_id
+     ORDER BY id
+     FOR UPDATE
+  LOOP
+    IF v_item.status NOT IN ('pending','reserved','ready') THEN
+      RAISE EXCEPTION '品項 % 狀態 % 不可取貨', v_item.id, v_item.status;
+    END IF;
+
+    -- 逐品項到貨擋板（取代舊的整單 is_order_pickup_ready 擋板）：
+    -- 未到貨（該 SKU 分店實收 0）的品項個別擋，已到貨的品項放行先取
+    IF NOT public.is_order_item_pickup_ready(v_item.id) THEN
+      SELECT COALESCE(s.variant_name, s.product_name, s.sku_code)
+        INTO v_sku_label FROM skus s WHERE s.id = v_item.sku_id;
+      RAISE EXCEPTION '品項「%」分店尚未實收到貨，無法取貨（請取消勾選該品項，其餘已到貨品項可先取）',
+        COALESCE(v_sku_label, v_item.sku_id::text);
+    END IF;
+
+    -- 本次取多少：p_item_qtys 指定則用之，否則整行取
+    v_take := COALESCE((p_item_qtys ->> v_item.id::text)::numeric, v_item.qty);
+    IF v_take IS NULL OR v_take <= 0 THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 不合法（須 > 0）', v_item.id, v_take;
+    END IF;
+    IF v_take > v_item.qty THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 超過待取數量 %', v_item.id, v_take, v_item.qty;
+    END IF;
+
+    IF v_take = v_item.qty THEN
+      -- ── 整行取：沿用舊邏輯，直接標 picked_up ──
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_item.id,
+        format('顧客取貨 order=%s item=%s', p_order_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      UPDATE customer_order_items
+         SET status = 'picked_up',
+             pickup_movement_id = v_movement_id,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_item.id;
+    ELSE
+      -- ── 部分取：拆行。新建 picked_up 行，原行扣量留待下次 ──
+      -- line-level 折扣金額按取貨比例分攤，確保兩行小計加總 = 原行
+      v_picked_disc := round(COALESCE(v_item.discount_amount, 0) * v_take / v_item.qty);
+
+      -- 1) 先建 picked_up 行（暫不填 movement，先拿 id）
+      INSERT INTO customer_order_items (
+        tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+        status, source, reserved_movement_id, pickup_movement_id, notes,
+        discount_amount, discount_percent, created_by, updated_by, created_at, updated_at,
+        is_gift, gift_reason, gift_marked_by, gift_marked_at
+      ) VALUES (
+        v_item.tenant_id, p_order_id, v_item.campaign_item_id, v_item.sku_id, v_take, v_item.unit_price,
+        'picked_up', v_item.source, NULL, NULL, v_item.notes,
+        v_picked_disc, v_item.discount_percent, v_item.created_by, p_operator, v_now, v_now,
+        v_item.is_gift, v_item.gift_reason, v_item.gift_marked_by, v_item.gift_marked_at
+      ) RETURNING id INTO v_new_item_id;
+
+      -- 2) sale movement 指向新行
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_new_item_id,
+        format('顧客部分取貨 order=%s item=%s (split from %s)', p_order_id, v_new_item_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      -- 3) 回填新行 movement
+      UPDATE customer_order_items
+         SET pickup_movement_id = v_movement_id
+       WHERE id = v_new_item_id;
+
+      -- 4) 原行扣量、保持 active 狀態，剩餘留待下次取
+      UPDATE customer_order_items
+         SET qty = qty - v_take,
+             discount_amount = COALESCE(discount_amount, 0) - v_picked_disc,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_new_item_id;
+    END IF;
+
+    -- event 記錄「被取走」那一行的 id（拆行時是新行）→ 收據查到正確的 qty
+    v_event_item_ids := v_event_item_ids || v_picked_item_id;
+    v_picked_count := v_picked_count + 1;
+  END LOOP;
+
+  IF v_picked_count = 0 THEN
+    RAISE EXCEPTION 'no items picked (check p_item_ids belongs to order %)', p_order_id;
+  END IF;
+
+  -- 重算 order status（剩餘 active 行 → partially_completed；全取完 → completed）。
+  -- 2026-08-01：剩餘 active 量要扣掉「未取退貨」覆蓋 — 已退回總倉的量不會再被
+  -- 取走，若某 SKU 的 active 量全被退貨蓋掉，該 SKU 的殘行不算「待取」。
+  -- 否則部分退貨後取走剩餘可取量（訂5退2取3）會讓訂單永遠卡在 partially_completed。
+  SELECT COUNT(*) INTO v_active_remaining
+    FROM customer_order_items coi
+    JOIN (
+      SELECT act.sku_id
+        FROM (
+          SELECT sku_id, SUM(qty) AS active_qty
+            FROM customer_order_items
+           WHERE order_id = p_order_id
+             AND status IN ('pending','reserved','ready')
+           GROUP BY sku_id
+        ) act
+        LEFT JOIN (
+          SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+            FROM transfers t
+            JOIN transfer_items ti ON ti.transfer_id = t.id
+           WHERE t.customer_order_id = p_order_id
+             AND t.tenant_id     = v_order.tenant_id
+             AND t.transfer_type = 'return_to_hq'
+             AND t.status IN ('shipped','received')
+             AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+                 NOT LIKE '%取貨後退回%'
+           GROUP BY ti.sku_id
+        ) r ON r.sku_id = act.sku_id
+       WHERE act.active_qty - COALESCE(r.ret_qty, 0) > 0
+    ) open_sku ON open_sku.sku_id = coi.sku_id
+   WHERE coi.order_id = p_order_id
+     AND coi.status IN ('pending','reserved','ready');
+
+  IF v_active_remaining = 0 THEN
+    v_new_status := 'completed';
+    v_event_type := 'picked_up';
+  ELSE
+    v_new_status := 'partially_completed';
+    v_event_type := 'partial_pickup';
+  END IF;
+
+  UPDATE customer_orders
+     SET status       = v_new_status,
+         completed_at = CASE WHEN v_new_status = 'completed' THEN v_now ELSE NULL END,
+         updated_by   = p_operator,
+         updated_at   = v_now
+   WHERE id = p_order_id;
+
+  INSERT INTO order_pickup_events (
+    tenant_id, order_id, pickup_store_id, event_type, item_ids, notes, created_by
+  ) VALUES (
+    v_order.tenant_id, p_order_id, v_order.pickup_store_id, v_event_type,
+    to_jsonb(v_event_item_ids), p_notes, p_operator
+  ) RETURNING id INTO v_event_id;
+
+  RETURN jsonb_build_object(
+    'event_id',        v_event_id,
+    'event_type',      v_event_type,
+    'picked_count',    v_picked_count,
+    'active_remaining', v_active_remaining,
+    'new_status',      v_new_status
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) IS
+  '取貨記帳。p_item_qtys={"<item_id>":<取貨數量>} 可指定部分取貨（拆行）。'
+  '到貨擋板為品項層級（is_order_item_pickup_ready）：未到貨品項個別擋、已到貨可先取。'
+  '退貨守門：同 SKU 取貨量不得超過 active 量 − 未取退貨量（取貨後退回不計）。'
+  'active_remaining 排除量已被未取退貨覆蓋的 SKU（退光的殘行不擋 completed）。'
+  '店家守衛：分店角色（store_manager/store_staff，app_metadata.stores 非空且不含總倉）'
+  '只能替自己店（pickup_store_id 店名 ∈ stores）的訂單取貨，否則 raise wrong_store。'
+  '零元守衛（20260815000000）：本次要取的品項單價為 $0 一律 raise zero_price'
+  '（漏填金額 → 取貨等於白送）；member_type=store_internal 的容器單不受限。'
+  '20260819000000：已標記的贈品（customer_order_items.is_gift 或 campaign_items.is_gift）'
+  '不受零元守衛限制；拆行時贈品標記會複製到 picked_up 那一行。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 4. rpc_fill_zero_order_item_price — 補金額成功就清掉品項層級的贈品標記
+--    基底 20260815000000 逐字保留，只多改那一段 UPDATE。
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_fill_zero_order_item_price(
+  p_order_id       BIGINT,
+  p_item_id        BIGINT,
+  p_new_unit_price NUMERIC,
+  p_operator       UUID,
+  p_reason         TEXT DEFAULT NULL
+) RETURNS customer_order_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order  customer_orders%ROWTYPE;
+  v_old    NUMERIC;
+  v_status TEXT;
+  v_row    customer_order_items;
+BEGIN
+  -- HQ / 總倉 / 該訂單取貨店（app_metadata.stores 店名比對）
+  v_order := public._check_order_edit_notes_perm(p_order_id);
+
+  IF p_new_unit_price IS NULL OR p_new_unit_price <= 0 THEN
+    RAISE EXCEPTION 'zero_price_fill: 補填金額必須大於 0';
+  END IF;
+
+  SELECT unit_price, status INTO v_old, v_status
+    FROM customer_order_items
+   WHERE id = p_item_id AND order_id = p_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'zero_price_fill: 品項 % 不屬於訂單 %', p_item_id, p_order_id;
+  END IF;
+
+  -- 只補填、不改價：非 0 的單價要改一律走 rpc_update_order_item_price（HQ 權限）
+  IF COALESCE(v_old, 0) <> 0 THEN
+    RAISE EXCEPTION 'zero_price_fill: 此品項單價已是 $%，補填功能只處理 $0 的品項；要改價請洽總部',
+      v_old;
+  END IF;
+
+  -- 已取貨 / 已取消的行不補（那是事後改帳，金額已進收據 / 已結案）
+  IF v_status NOT IN ('pending','reserved','ready') THEN
+    RAISE EXCEPTION 'zero_price_fill: 品項狀態為「%」，只有未取貨的品項可以補填金額', v_status;
+  END IF;
+
+  -- 20260819000000：補得出金額 = 這一列不是贈品，順手清掉品項層級的贈品標記
+  -- （不清的話畫面會同時出現「$120」和「🎁 贈品」，而且未來改回 0 就會靜默放行）。
+  -- 開團層級的 campaign_items.is_gift 不在這裡動 —— 那是整個團的設定，
+  -- 要改請走 rpc_set_campaign_item_gift（管理員）。
+  UPDATE customer_order_items
+     SET unit_price     = p_new_unit_price,
+         is_gift        = FALSE,
+         gift_reason    = NULL,
+         gift_marked_by = NULL,
+         gift_marked_at = NULL,
+         updated_by     = p_operator,
+         updated_at     = NOW()
+   WHERE id = p_item_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'item', p_item_id, 'unit_price',
+     to_jsonb(v_old), to_jsonb(p_new_unit_price),
+     COALESCE(NULLIF(p_reason, ''), '補填漏填金額（取貨零元守衛）'), p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_fill_zero_order_item_price(BIGINT, BIGINT, NUMERIC, UUID, TEXT) IS
+  '補填漏填的品項金額：只允許 unit_price 0 → 正數、只允許未取貨品項。'
+  '權限沿用 _check_order_edit_notes_perm（HQ / 總倉 / 自店），讓櫃台被零元守衛擋下時'
+  '自己就能解，不必回頭找總部（分店帳號沒有 app_metadata.store_id，走不了'
+  'rpc_update_order_item_price 的 _check_order_edit_perm）。每次寫一筆 audit log。'
+  '20260819000000：補完一併清掉品項層級的贈品標記（is_gift / gift_reason /'
+  ' gift_marked_by / gift_marked_at）—— 有金額就不是贈品。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_fill_zero_order_item_price(BIGINT, BIGINT, NUMERIC, UUID, TEXT)
+  TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 5. rpc_mark_order_item_gift — 單一訂單品項標／取消標「贈品」
+--    權限沿用 _check_order_edit_notes_perm（HQ / 總倉 / 自店），理由同
+--    rpc_fill_zero_order_item_price：客人站在櫃台前，只能自己解得開，
+--    否則店員只剩「打電話找總部」或「轉單開新單」（＝重複單）兩條路。
+--    代價用留痕補：理由必填 + gift_marked_by/at + 一筆 audit log，
+--    列表也看得到 🎁 行數，HQ 事後查得到誰在送東西。
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_mark_order_item_gift(
+  p_order_id BIGINT,
+  p_item_id  BIGINT,
+  p_is_gift  BOOLEAN,
+  p_operator UUID,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS customer_order_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_order    customer_orders%ROWTYPE;
+  v_price    NUMERIC;
+  v_status   TEXT;
+  v_old      BOOLEAN;
+  v_ci_gift  BOOLEAN;
+  v_reason   TEXT := NULLIF(btrim(COALESCE(p_reason, '')), '');
+  v_row      customer_order_items;
+BEGIN
+  -- HQ / 總倉 / 該訂單取貨店（app_metadata.stores 店名比對）
+  v_order := public._check_order_edit_notes_perm(p_order_id);
+
+  SELECT coi.unit_price, coi.status, COALESCE(coi.is_gift, FALSE),
+         COALESCE(ci.is_gift, FALSE)
+    INTO v_price, v_status, v_old, v_ci_gift
+    FROM customer_order_items coi
+    LEFT JOIN campaign_items ci ON ci.id = coi.campaign_item_id
+   WHERE coi.id = p_item_id AND coi.order_id = p_order_id
+   FOR UPDATE OF coi;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'gift_mark: 品項 % 不屬於訂單 %', p_item_id, p_order_id;
+  END IF;
+
+  -- 已取貨 / 已取消的行不動（那是事後改帳：貨已交付、金額已進收據）
+  IF v_status NOT IN ('pending','reserved','ready') THEN
+    RAISE EXCEPTION 'gift_mark: 品項狀態為「%」，只有未取貨的品項可以標記贈品', v_status;
+  END IF;
+
+  IF p_is_gift THEN
+    -- 贈品＝不收錢。有金額的品項要送，先把金額改成 0（總部改價），
+    -- 否則會出現「$120 的贈品」這種既收錢又標贈品的帳。
+    IF COALESCE(v_price, 0) <> 0 THEN
+      RAISE EXCEPTION 'gift_mark: 此品項單價是 $%，有金額的品項不是贈品；要免費送請先請總部把單價改成 0',
+        v_price;
+    END IF;
+    IF v_reason IS NULL THEN
+      RAISE EXCEPTION 'gift_mark: 請填寫贈品原因（例：促銷活動買二送一 / 客訴補償），這筆會留在異動紀錄裡';
+    END IF;
+  ELSIF v_ci_gift THEN
+    -- 開團層級標成贈品時，個別品項取消標記沒有意義（讀取時是 OR，仍然免除守衛），
+    -- 直接講清楚要去哪裡改，不要讓人以為按了沒反應。
+    RAISE EXCEPTION 'gift_mark: 這是「開團商品」層級的贈品設定（整個團都適用），無法在單張訂單取消；請到該開團的商品明細取消贈品設定';
+  END IF;
+
+  UPDATE customer_order_items
+     SET is_gift        = p_is_gift,
+         gift_reason    = CASE WHEN p_is_gift THEN v_reason ELSE NULL END,
+         gift_marked_by = CASE WHEN p_is_gift THEN p_operator ELSE NULL END,
+         gift_marked_at = CASE WHEN p_is_gift THEN NOW() ELSE NULL END,
+         updated_by     = p_operator,
+         updated_at     = NOW()
+   WHERE id = p_item_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  VALUES
+    (v_order.tenant_id, p_order_id, 'item', p_item_id, 'is_gift',
+     to_jsonb(v_old), to_jsonb(p_is_gift),
+     COALESCE(v_reason, CASE WHEN p_is_gift THEN '標記為贈品' ELSE '取消贈品標記' END),
+     p_operator);
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_mark_order_item_gift(BIGINT, BIGINT, BOOLEAN, UUID, TEXT) IS
+  '標記／取消標記單一訂單品項為贈品（免除取貨零元守衛）。'
+  '只允許未取貨品項；標記時單價必須是 0 且理由必填。'
+  '權限沿用 _check_order_edit_notes_perm（HQ / 總倉 / 自店），每次寫一筆 audit log'
+  '（field=is_gift）。開團層級的贈品（campaign_items.is_gift）要走'
+  ' rpc_set_campaign_item_gift，在這裡取消不了。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_mark_order_item_gift(BIGINT, BIGINT, BOOLEAN, UUID, TEXT)
+  TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 6. rpc_set_campaign_item_gift — 開團商品標／取消標「贈品」（促銷活動主用）
+--    管理員限定（對齊 rpc_resync_campaign_from_product 的 owner/admin/'' 允許清單，
+--    '' 是沒有顯式 role 的 legacy/dev admin，漏掉它會把舊帳號全擋在外面）。
+--    標下去＝該團所有既有 / 未來的 $0 訂單品項一起免除守衛，不用回頭一張一張標。
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_set_campaign_item_gift(
+  p_campaign_item_id BIGINT,
+  p_is_gift          BOOLEAN,
+  p_reason           TEXT DEFAULT NULL
+) RETURNS campaign_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := (auth.jwt() ->> 'tenant_id')::uuid;
+  -- 應用角色一律讀 app_metadata；頂層 role 永遠是 'authenticated'（見 CLAUDE.md）
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_reason TEXT := NULLIF(btrim(COALESCE(p_reason, '')), '');
+  v_row    campaign_items;
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+  IF v_role NOT IN ('owner','admin','') THEN
+    RAISE EXCEPTION 'campaign_gift: 權限不足，只有管理員可以把開團商品設為贈品（role=%）', v_role;
+  END IF;
+
+  IF p_is_gift AND v_reason IS NULL THEN
+    RAISE EXCEPTION 'campaign_gift: 請填寫贈品原因（例：週年慶滿額贈），會顯示在開團商品與訂單品項上';
+  END IF;
+
+  -- 標成贈品＝單價設 0（贈品不收錢），並從此不再被「重新同步商品/價格」與
+  -- 零售價 trigger 蓋回零售價。取消標記時單價維持 0，要恢復售價請按
+  -- 「重新同步商品/價格」（既有訂單的金額是 snapshot，兩個方向都不會被改動）。
+  UPDATE campaign_items
+     SET is_gift     = p_is_gift,
+         gift_reason = CASE WHEN p_is_gift THEN v_reason ELSE NULL END,
+         unit_price  = CASE WHEN p_is_gift THEN 0 ELSE unit_price END,
+         updated_by  = auth.uid(),
+         updated_at  = NOW()
+   WHERE id = p_campaign_item_id AND tenant_id = v_tenant
+   RETURNING * INTO v_row;
+
+  IF v_row.id IS NULL THEN
+    RAISE EXCEPTION 'campaign_gift: 開團商品 % 不在 tenant 內', p_campaign_item_id;
+  END IF;
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_set_campaign_item_gift(BIGINT, BOOLEAN, TEXT) IS
+  '把開團商品標成贈品（促銷活動）：is_gift=TRUE + 單價設 0 + 理由必填。'
+  '效果＝該開團商品的所有 $0 訂單品項（既有與未來）免除取貨零元守衛，'
+  '且 rpc_resync_campaign_from_product 與 _sync_retail_price_to_campaigns 都不再改它的單價。'
+  '管理員限定（app_metadata.role ∈ owner / admin / 空字串）。取消標記不會自動恢復售價。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_set_campaign_item_gift(BIGINT, BOOLEAN, TEXT)
+  TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 7. rpc_resync_campaign_from_product — 重新同步時跳過贈品
+--    基底 20260620000060 逐字保留。不做這段的話：促銷期間按一次「重新同步
+--    商品/價格」，贈品就被蓋回零售價，而且會連既有 pending 訂單一起回填
+--    ——「送的」瞬間變成「跟客人收錢」，而且沒有人會發現。
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_resync_campaign_from_product(
+  p_campaign_id BIGINT,
+  p_dry_run     BOOLEAN DEFAULT TRUE,
+  p_operator    UUID    DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant    UUID := (auth.jwt() ->> 'tenant_id')::uuid;
+  v_role      TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_op        UUID := COALESCE(p_operator, auth.uid());
+  v_camp      group_buy_campaigns%ROWTYPE;
+  v_prod_name TEXT;
+  v_bad_cnt   INT;
+  v_bad_list  TEXT;
+  v_name_changed       BOOLEAN := FALSE;
+  v_items_repriced     INT := 0;
+  v_items_removed_cnt  INT := 0;
+  v_items_removed_json JSONB;
+  v_skus_added         INT := 0;
+  v_orders             INT := 0;
+  v_lines              INT := 0;
+  v_amt_before         NUMERIC := 0;
+  v_amt_after          NUMERIC := 0;
+  v_items_json         JSONB;
+  v_result             JSONB;
+BEGIN
+  -- ---------- 權限：僅管理員 ----------
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+  IF v_role NOT IN ('owner','admin','') THEN
+    RAISE EXCEPTION '權限不足：僅管理員可重新同步開團（role=%）', v_role;
+  END IF;
+
+  -- ---------- 開團 + 狀態守門 ----------
+  SELECT * INTO v_camp
+    FROM group_buy_campaigns
+   WHERE id = p_campaign_id AND tenant_id = v_tenant
+   FOR UPDATE;
+  IF v_camp.id IS NULL THEN
+    RAISE EXCEPTION 'campaign % 不在 tenant 內', p_campaign_id;
+  END IF;
+  IF v_camp.status NOT IN ('draft','open') THEN
+    RAISE EXCEPTION '只有草稿/開團中的開團可以重新同步（目前狀態：%）', v_camp.status;
+  END IF;
+
+  -- ---------- 守門：已在 campaign_items 的 active SKU 必須都有有效零售價 ----------
+  SELECT COUNT(*),
+         string_agg(s.sku_code, ', ' ORDER BY s.sku_code)
+    INTO v_bad_cnt, v_bad_list
+    FROM campaign_items ci
+    JOIN skus s ON s.id = ci.sku_id AND s.tenant_id = ci.tenant_id
+   WHERE ci.campaign_id = p_campaign_id
+     AND ci.tenant_id   = v_tenant
+     AND s.status = 'active'
+     -- 20260819000000：贈品本來就是 $0、也不跟零售價走，缺價不該擋住整支 resync
+     AND NOT COALESCE(ci.is_gift, FALSE)
+     AND COALESCE((
+           SELECT pr.price FROM prices pr
+            WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+              AND pr.scope = 'retail' AND pr.effective_to IS NULL
+            ORDER BY pr.effective_from DESC LIMIT 1
+         ), 0) <= 0;
+  IF v_bad_cnt > 0 THEN
+    RAISE EXCEPTION '仍有 % 個 active SKU 沒有有效零售價，請先到商品頁設定售價（避免回填成 0）：%',
+      v_bad_cnt, v_bad_list;
+  END IF;
+
+  -- ---------- 名稱 ----------
+  IF v_camp.product_id IS NOT NULL THEN
+    SELECT name INTO v_prod_name
+      FROM products WHERE id = v_camp.product_id AND tenant_id = v_tenant;
+  END IF;
+  v_name_changed := (v_prod_name IS NOT NULL AND v_prod_name IS DISTINCT FROM v_camp.name);
+
+  -- ---------- 預覽：reprice 列表 ----------
+  SELECT COUNT(*),
+         jsonb_agg(jsonb_build_object(
+           'sku_id', t.sku_id, 'sku_code', t.sku_code,
+           'old_price', t.old_price, 'new_price', t.new_price
+         ) ORDER BY t.sku_code)
+    INTO v_items_repriced, v_items_json
+    FROM (
+      SELECT ci.sku_id, s.sku_code, ci.unit_price AS old_price,
+             (SELECT pr.price FROM prices pr
+               WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+                 AND pr.scope = 'retail' AND pr.effective_to IS NULL
+               ORDER BY pr.effective_from DESC LIMIT 1) AS new_price
+        FROM campaign_items ci
+        JOIN skus s ON s.id = ci.sku_id AND s.tenant_id = ci.tenant_id
+       WHERE ci.campaign_id = p_campaign_id AND ci.tenant_id = v_tenant
+         AND s.status = 'active'
+         -- 20260819000000：贈品的 $0 是刻意的，不列入重新定價
+         AND NOT COALESCE(ci.is_gift, FALSE)
+    ) t
+   WHERE t.old_price IS DISTINCT FROM t.new_price;
+
+  -- ---------- 預覽：將被移除的 discontinued SKU items（無訂單引用）----------
+  SELECT COUNT(*),
+         jsonb_agg(jsonb_build_object(
+           'ci_id', t.ci_id, 'sku_id', t.sku_id, 'sku_code', t.sku_code,
+           'unit_price', t.unit_price
+         ) ORDER BY t.sku_code)
+    INTO v_items_removed_cnt, v_items_removed_json
+    FROM (
+      SELECT ci.id AS ci_id, ci.sku_id, s.sku_code, ci.unit_price
+        FROM campaign_items ci
+        JOIN skus s ON s.id = ci.sku_id AND s.tenant_id = ci.tenant_id
+       WHERE ci.campaign_id = p_campaign_id AND ci.tenant_id = v_tenant
+         AND s.status = 'discontinued'
+         AND NOT EXISTS (
+           SELECT 1 FROM customer_order_items coi WHERE coi.campaign_item_id = ci.id
+         )
+    ) t;
+
+  -- ---------- 預覽：補進的新 active SKU ----------
+  SELECT COUNT(*) INTO v_skus_added
+    FROM skus s
+   WHERE v_camp.product_id IS NOT NULL
+     AND s.tenant_id  = v_tenant
+     AND s.product_id = v_camp.product_id
+     AND s.status     = 'active'
+     AND NOT EXISTS (SELECT 1 FROM campaign_items ci
+                      WHERE ci.campaign_id = p_campaign_id
+                        AND ci.tenant_id = v_tenant AND ci.sku_id = s.id)
+     AND COALESCE((
+           SELECT pr.price FROM prices pr
+            WHERE pr.tenant_id = v_tenant AND pr.sku_id = s.id
+              AND pr.scope = 'retail' AND pr.effective_to IS NULL
+            ORDER BY pr.effective_from DESC LIMIT 1
+         ), 0) > 0;
+
+  -- 受影響的「待確認」訂單
+  SELECT COUNT(DISTINCT co.id) FILTER (
+           WHERE coi.unit_price IS DISTINCT FROM rc.new_price),
+         COUNT(*) FILTER (
+           WHERE coi.unit_price IS DISTINCT FROM rc.new_price)
+    INTO v_orders, v_lines
+    FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+    JOIN LATERAL (
+      SELECT (SELECT pr.price FROM prices pr
+                WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+                  AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                ORDER BY pr.effective_from DESC LIMIT 1) AS new_price
+    ) rc ON TRUE
+    JOIN skus s ON s.id = coi.sku_id AND s.tenant_id = co.tenant_id AND s.status = 'active'
+   WHERE co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending'
+     -- 20260819000000：贈品列不回填價格
+     AND NOT EXISTS (SELECT 1 FROM campaign_items gi
+                      WHERE gi.id = coi.campaign_item_id AND gi.is_gift)
+     AND NOT COALESCE(coi.is_gift, FALSE);
+
+  SELECT
+    COALESCE(SUM(coi.qty * coi.unit_price), 0),
+    COALESCE(SUM(coi.qty * CASE
+       -- 20260819000000：贈品列不重新定價，預覽金額也要維持現價
+       WHEN COALESCE(coi.is_gift, FALSE) OR COALESCE(gi.is_gift, FALSE) THEN coi.unit_price
+       ELSE COALESCE(
+         CASE WHEN s.status = 'active' THEN
+           (SELECT pr.price FROM prices pr
+             WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+               AND pr.scope = 'retail' AND pr.effective_to IS NULL
+             ORDER BY pr.effective_from DESC LIMIT 1)
+         END, coi.unit_price)
+     END), 0)
+    INTO v_amt_before, v_amt_after
+    FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+    JOIN skus s ON s.id = coi.sku_id AND s.tenant_id = co.tenant_id
+    LEFT JOIN campaign_items gi ON gi.id = coi.campaign_item_id
+   WHERE co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending';
+
+  v_result := jsonb_build_object(
+    'dry_run',             p_dry_run,
+    'campaign_id',         p_campaign_id,
+    'campaign_no',         v_camp.campaign_no,
+    'campaign_status',     v_camp.status,
+    'name_before',         v_camp.name,
+    'name_after',          COALESCE(v_prod_name, v_camp.name),
+    'name_changed',        v_name_changed,
+    'items',               COALESCE(v_items_json, '[]'::jsonb),
+    'items_repriced',      v_items_repriced,
+    'items_removed',       COALESCE(v_items_removed_json, '[]'::jsonb),
+    'items_removed_count', v_items_removed_cnt,
+    'skus_added',          v_skus_added,
+    'pending_orders',      v_orders,
+    'pending_order_lines', v_lines,
+    'amount_before',       v_amt_before,
+    'amount_after',        v_amt_after
+  );
+
+  IF p_dry_run THEN
+    RETURN v_result;
+  END IF;
+
+  -- ================= 實跑（單一交易，出錯全 rollback）=================
+
+  IF v_name_changed THEN
+    UPDATE group_buy_campaigns
+       SET name = v_prod_name, updated_at = NOW()
+     WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  END IF;
+
+  -- 移除 discontinued SKU 的 campaign_items（無訂單引用的才動）
+  DELETE FROM campaign_items ci
+   USING skus s
+   WHERE ci.sku_id = s.id AND s.tenant_id = ci.tenant_id
+     AND ci.campaign_id = p_campaign_id AND ci.tenant_id = v_tenant
+     AND s.status = 'discontinued'
+     AND NOT EXISTS (
+       SELECT 1 FROM customer_order_items coi WHERE coi.campaign_item_id = ci.id
+     );
+
+  UPDATE campaign_items ci
+     SET unit_price = (SELECT pr.price FROM prices pr
+                         WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+                           AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                         ORDER BY pr.effective_from DESC LIMIT 1),
+         updated_at = NOW(),
+         updated_by = v_op
+    FROM skus s
+   WHERE ci.sku_id = s.id AND s.tenant_id = ci.tenant_id
+     AND ci.campaign_id = p_campaign_id AND ci.tenant_id = v_tenant
+     AND s.status = 'active'
+     -- 20260819000000：贈品維持 $0，不被同步蓋回零售價
+     AND NOT COALESCE(ci.is_gift, FALSE)
+     AND ci.unit_price IS DISTINCT FROM (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = ci.sku_id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1);
+
+  INSERT INTO campaign_items
+    (tenant_id, campaign_id, sku_id, unit_price, sort_order, created_by, updated_by)
+  SELECT v_tenant, p_campaign_id, s.id,
+         (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = s.id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1),
+         999, v_op, v_op
+    FROM skus s
+   WHERE v_camp.product_id IS NOT NULL
+     AND s.tenant_id  = v_tenant
+     AND s.product_id = v_camp.product_id
+     AND s.status     = 'active'
+     AND NOT EXISTS (SELECT 1 FROM campaign_items ci
+                      WHERE ci.campaign_id = p_campaign_id
+                        AND ci.tenant_id = v_tenant AND ci.sku_id = s.id)
+     AND COALESCE((SELECT pr.price FROM prices pr
+                    WHERE pr.tenant_id = v_tenant AND pr.sku_id = s.id
+                      AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                    ORDER BY pr.effective_from DESC LIMIT 1), 0) > 0
+  ON CONFLICT (campaign_id, sku_id) DO NOTHING;
+
+  INSERT INTO customer_order_audit_log
+    (tenant_id, order_id, entity_type, entity_id, field,
+     before_value, after_value, edit_reason, operator_id)
+  SELECT co.tenant_id, co.id, 'item', coi.id, 'unit_price',
+         to_jsonb(coi.unit_price),
+         to_jsonb((SELECT pr.price FROM prices pr
+                     WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+                       AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                     ORDER BY pr.effective_from DESC LIMIT 1)),
+         '開團「重新同步商品/價格」批次回填（待確認訂單）',
+         COALESCE(v_op, co.updated_by, co.created_by, v_camp.created_by)
+    FROM customer_orders co
+    JOIN customer_order_items coi ON coi.order_id = co.id
+    JOIN skus s ON s.id = coi.sku_id AND s.tenant_id = co.tenant_id AND s.status = 'active'
+   WHERE co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending'
+     -- 20260819000000：贈品列不回填價格
+     AND NOT EXISTS (SELECT 1 FROM campaign_items gi
+                      WHERE gi.id = coi.campaign_item_id AND gi.is_gift)
+     AND NOT COALESCE(coi.is_gift, FALSE)
+     AND coi.unit_price IS DISTINCT FROM (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1);
+
+  UPDATE customer_order_items coi
+     SET unit_price = (SELECT pr.price FROM prices pr
+                         WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+                           AND pr.scope = 'retail' AND pr.effective_to IS NULL
+                         ORDER BY pr.effective_from DESC LIMIT 1),
+         updated_at = NOW(),
+         updated_by = v_op
+    FROM customer_orders co, skus s
+   WHERE coi.order_id = co.id
+     AND s.id = coi.sku_id AND s.tenant_id = co.tenant_id AND s.status = 'active'
+     AND co.campaign_id = p_campaign_id AND co.tenant_id = v_tenant
+     AND co.status = 'pending'
+     -- 20260819000000：贈品列不回填價格
+     AND NOT EXISTS (SELECT 1 FROM campaign_items gi
+                      WHERE gi.id = coi.campaign_item_id AND gi.is_gift)
+     AND NOT COALESCE(coi.is_gift, FALSE)
+     AND coi.unit_price IS DISTINCT FROM (SELECT pr.price FROM prices pr
+           WHERE pr.tenant_id = v_tenant AND pr.sku_id = coi.sku_id
+             AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC LIMIT 1);
+
+  RETURN v_result || jsonb_build_object('applied', TRUE);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION
+  public.rpc_resync_campaign_from_product(BIGINT, BOOLEAN, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_resync_campaign_from_product(BIGINT, BOOLEAN, UUID) IS
+  '開團重新同步：名稱←product、campaign_items 單價←現行零售價、補 active SKU、'
+  '移除 discontinued SKU（無訂單引用者）、回填 status=pending 訂單明細並寫 customer_order_audit_log。'
+  'draft/open 限定、僅管理員(owner/admin) 限定、active SKU 缺有效零售價則拒跑、p_dry_run 預設只預覽。'
+  '20260819000000：贈品（campaign_items.is_gift / customer_order_items.is_gift）全程跳過'
+  '——不重新定價、不回填訂單、缺零售價也不擋跑。';
+
+-- ----------------------------------------------------------------------------
+-- 8. _sync_retail_price_to_campaigns — 零售價 trigger 不要蓋掉贈品
+--    基底 20260514000008 逐字保留，只多一個 is_gift 條件。
+--    （draft 團的單價跟零售價走；贈品是刻意的 $0，跟著走就變成收錢。）
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public._sync_retail_price_to_campaigns()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.scope IS DISTINCT FROM 'retail' THEN
+    RETURN NEW;
+  END IF;
+  IF NEW.effective_to IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- 只動 draft 階段（open 後鎖定）
+  UPDATE campaign_items ci
+     SET unit_price = NEW.price,
+         updated_at = NOW()
+    FROM group_buy_campaigns gbc
+   WHERE ci.tenant_id  = NEW.tenant_id
+     AND ci.sku_id     = NEW.sku_id
+     AND ci.campaign_id = gbc.id
+     AND gbc.tenant_id = NEW.tenant_id
+     AND gbc.status    = 'draft'
+     -- 20260819000000：贈品的 $0 是刻意的，不跟零售價走
+     AND NOT COALESCE(ci.is_gift, FALSE);
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public._sync_retail_price_to_campaigns() IS
+  'prices(scope=retail, 現行) 異動時同步 draft 開團的 campaign_items.unit_price。'
+  'open 之後鎖定（20260514000008）。20260819000000：贈品（is_gift）不同步。';

--- a/supabase/migrations/20260819000010_bulk_mark_order_zero_price_gift.sql
+++ b/supabase/migrations/20260819000010_bulk_mark_order_zero_price_gift.sql
@@ -1,0 +1,213 @@
+-- ============================================================================
+-- 2026-08-19: 贈品從「訂單」下手 —— 整張單 / 一批訂單的 $0 品項一次標成贈品
+--
+-- 需求：「從訂單下手」。20260819000000 的開團層級（campaign_items.is_gift）對
+--   「整個開團商品都是送的」才成立；促銷實務上贈品是掛在**個別訂單**上的
+--   （同一個 SKU 有人買、有人是送的），開團層級一標就把所有人的單價歸零，
+--   買的那幾張也跟著變 $0。所以主要入口改成訂單側：
+--     - 訂單明細：一鍵把這張單的 $0 品項全標成贈品
+--     - 訂單列表：篩「只看 $0」＋開團／門市 → 選取 → 批次標記（促銷一次收掉）
+--   逐列標記維持 rpc_mark_order_item_gift（櫃台當場那一顆）。
+--
+-- 這支只是上面那支的批次版，判定與守衛完全一樣：
+--   - 權限逐張走 _check_order_edit_notes_perm（HQ / 總倉 / 自店）——
+--     選到別人家的單會整批擋下並指名是哪一張，不會默默略過。
+--   - 只動未取貨（pending/reserved/ready）、單價 $0、還沒標過的列。
+--   - 【內部】xx 店 / RR- / OV- 容器單（member_type='store_internal'）跳過：
+--     那些 $0 是掛帳用的，本來就不受零元守衛限制，標了只是製造雜訊。
+--   - 已被開團層級標成贈品的列跳過（本來就免除守衛，重複標沒有意義）。
+--   - 理由必填，每一列寫一筆 customer_order_audit_log（field='is_gift'）。
+--   - 一次最多 500 張（對齊列表「選全部」的 SELECT_ALL_MAX）。
+--
+-- 前置：20260819000000（欄位 / rpc_mark_order_item_gift / audit CHECK 擴充）
+-- Rollback：DROP FUNCTION public.rpc_mark_zero_price_items_gift(BIGINT[],UUID,TEXT);
+--
+-- 對應前端（同一個 commit）：
+--   - apps/admin/src/app/(protected)/orders/page.tsx（選取後「🎁 標為贈品」）
+--   - apps/admin/src/components/OrderDetail.tsx（整單 $0 一鍵標記）
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_mark_zero_price_items_gift(
+  p_order_ids BIGINT[],
+  p_operator  UUID,
+  p_reason    TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_reason   TEXT := NULLIF(btrim(COALESCE(p_reason, '')), '');
+  v_ids      BIGINT[];
+  v_id       BIGINT;
+  v_order    customer_orders%ROWTYPE;
+  v_n        INT;
+  v_items    INT := 0;
+  v_orders   INT := 0;
+  v_internal INT := 0;
+BEGIN
+  IF v_reason IS NULL THEN
+    RAISE EXCEPTION 'gift_mark: 請填寫贈品原因（例：週年慶滿額贈 / 買二送一），這筆會留在每一列的異動紀錄裡';
+  END IF;
+
+  v_ids := ARRAY(SELECT DISTINCT x FROM unnest(COALESCE(p_order_ids, ARRAY[]::BIGINT[])) AS x);
+  IF array_length(v_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'gift_mark: 沒有選到訂單';
+  END IF;
+  IF array_length(v_ids, 1) > 500 THEN
+    RAISE EXCEPTION 'gift_mark: 一次最多處理 500 張訂單（選到 % 張），請再縮小篩選範圍',
+      array_length(v_ids, 1);
+  END IF;
+
+  FOREACH v_id IN ARRAY v_ids LOOP
+    -- 權限 + 鎖單頭。不是自己店的單直接 raise（訊息會指名是哪一張），
+    -- 不做「默默略過」——批次動作最怕的就是以為標了其實沒標。
+    v_order := public._check_order_edit_notes_perm(v_id);
+
+    IF EXISTS (
+      SELECT 1 FROM members mb
+       WHERE mb.id = v_order.member_id
+         AND mb.tenant_id = v_order.tenant_id
+         AND mb.member_type = 'store_internal'
+    ) THEN
+      v_internal := v_internal + 1;
+      CONTINUE;
+    END IF;
+
+    WITH upd AS (
+      UPDATE customer_order_items coi
+         SET is_gift        = TRUE,
+             gift_reason    = v_reason,
+             gift_marked_by = p_operator,
+             gift_marked_at = NOW(),
+             updated_by     = p_operator,
+             updated_at     = NOW()
+       WHERE coi.order_id = v_id
+         AND coi.status IN ('pending','reserved','ready')
+         AND COALESCE(coi.unit_price, 0) = 0
+         AND NOT COALESCE(coi.is_gift, FALSE)
+         -- 開團層級已經標成贈品的列本來就免除守衛，不重複標
+         AND NOT EXISTS (
+           SELECT 1 FROM campaign_items gi
+            WHERE gi.id = coi.campaign_item_id AND gi.is_gift
+         )
+       RETURNING coi.id
+    ), logged AS (
+      -- 資料異動型 CTE 一定會跑完（不管主查詢有沒有讀它），所以逐列稽核就寫在這裡
+      INSERT INTO customer_order_audit_log
+        (tenant_id, order_id, entity_type, entity_id, field,
+         before_value, after_value, edit_reason, operator_id)
+      SELECT v_order.tenant_id, v_id, 'item', u.id, 'is_gift',
+             to_jsonb(FALSE), to_jsonb(TRUE), v_reason, p_operator
+        FROM upd u
+      RETURNING 1
+    )
+    SELECT count(*)::int INTO v_n FROM upd;
+
+    IF v_n > 0 THEN
+      v_orders := v_orders + 1;
+      v_items  := v_items + v_n;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'requested_orders', array_length(v_ids, 1),
+    'orders',           v_orders,
+    'items',            v_items,
+    'skipped_internal', v_internal
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_mark_zero_price_items_gift(BIGINT[], UUID, TEXT) IS
+  '批次把選取訂單裡「未取貨且單價 $0」的品項標成贈品（免除取貨零元守衛）。'
+  '理由必填、逐列寫 customer_order_audit_log(field=is_gift)、逐張走'
+  ' _check_order_edit_notes_perm（HQ / 總倉 / 自店，不是自己店的單整批 raise）。'
+  '跳過 store_internal 容器單與已被開團層級標成贈品的列；一次最多 500 張。'
+  '回 {requested_orders, orders, items, skipped_internal}。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_mark_zero_price_items_gift(BIGINT[], UUID, TEXT)
+  TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- rpc_set_campaign_item_gift v2 —— 開團層級只留給「整項都是送的」
+--
+-- 基底：20260819000000（逐字保留，只多一道守衛）。
+-- 為什麼要加：開團層級標贈品會把 campaign_items.unit_price 設為 0，之後所有
+-- 新建訂單的那一項都是 $0。促銷常見的「買二送一」是同一個 SKU 有人買、有人送，
+-- 整項標下去等於把還沒建的訂單全部變成免費 —— 這種要從訂單那邊標
+-- （rpc_mark_zero_price_items_gift / rpc_mark_order_item_gift）。
+-- 所以：該開團商品只要還有「有金額」的未取貨訂單品項，就擋下並指路。
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rpc_set_campaign_item_gift(
+  p_campaign_item_id BIGINT,
+  p_is_gift          BOOLEAN,
+  p_reason           TEXT DEFAULT NULL
+) RETURNS campaign_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := (auth.jwt() ->> 'tenant_id')::uuid;
+  -- 應用角色一律讀 app_metadata；頂層 role 永遠是 'authenticated'（見 CLAUDE.md）
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_reason TEXT := NULLIF(btrim(COALESCE(p_reason, '')), '');
+  v_paid   INT;
+  v_row    campaign_items;
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+  IF v_role NOT IN ('owner','admin','') THEN
+    RAISE EXCEPTION 'campaign_gift: 權限不足，只有管理員可以把開團商品設為贈品（role=%）', v_role;
+  END IF;
+
+  IF p_is_gift AND v_reason IS NULL THEN
+    RAISE EXCEPTION 'campaign_gift: 請填寫贈品原因（例：週年慶滿額贈），會顯示在開團商品與訂單品項上';
+  END IF;
+
+  -- 已經有人按原價買的，就不是「整項都是送的」→ 擋下，改走訂單側
+  IF p_is_gift THEN
+    SELECT count(*)::int INTO v_paid
+      FROM customer_order_items coi
+     WHERE coi.campaign_item_id = p_campaign_item_id
+       AND coi.status IN ('pending','reserved','ready')
+       AND COALESCE(coi.unit_price, 0) > 0;
+    IF v_paid > 0 THEN
+      RAISE EXCEPTION 'campaign_gift: 這個開團商品還有 % 筆未取貨的訂單品項是有金額的（客人是買的）。整項設成贈品會把之後建立的訂單全部變成 $0；只有部分客人要送的話，請到訂單那邊標贈品（訂單明細「🎁 整單標成贈品」，或訂單列表篩「只看 $0」後批次標記）',
+        v_paid;
+    END IF;
+  END IF;
+
+  -- 標成贈品＝單價設 0（贈品不收錢），並從此不再被「重新同步商品/價格」與
+  -- 零售價 trigger 蓋回零售價。取消標記時單價維持 0，要恢復售價請按
+  -- 「重新同步商品/價格」（既有訂單的金額是 snapshot，兩個方向都不會被改動）。
+  UPDATE campaign_items
+     SET is_gift     = p_is_gift,
+         gift_reason = CASE WHEN p_is_gift THEN v_reason ELSE NULL END,
+         unit_price  = CASE WHEN p_is_gift THEN 0 ELSE unit_price END,
+         updated_by  = auth.uid(),
+         updated_at  = NOW()
+   WHERE id = p_campaign_item_id AND tenant_id = v_tenant
+   RETURNING * INTO v_row;
+
+  IF v_row.id IS NULL THEN
+    RAISE EXCEPTION 'campaign_gift: 開團商品 % 不在 tenant 內', p_campaign_item_id;
+  END IF;
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_set_campaign_item_gift(BIGINT, BOOLEAN, TEXT) IS
+  '把開團商品標成贈品（整項都是送的才適用）：is_gift=TRUE + 單價設 0 + 理由必填。'
+  '效果＝該開團商品的所有 $0 訂單品項（既有與未來）免除取貨零元守衛，'
+  '且 rpc_resync_campaign_from_product 與 _sync_retail_price_to_campaigns 都不再改它的單價。'
+  '管理員限定（app_metadata.role ∈ owner / admin / 空字串）。取消標記不會自動恢復售價。'
+  '20260819000010：該商品還有「有金額」的未取貨訂單品項時擋下（買二送一那種混合情況'
+  '要走訂單側的 rpc_mark_zero_price_items_gift / rpc_mark_order_item_gift）。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_set_campaign_item_gift(BIGINT, BOOLEAN, TEXT)
+  TO authenticated;


### PR DESCRIPTION
## 問題

零元守衛（`20260815000000`）擋的是「開團／代 key 漏填金額」，但**刻意送的贈品**（尤其辦促銷活動）同樣是 $0，會一起被擋在櫃台 —— 店員只剩「亂填一個金額」或「轉單開新單（＝重複單）」兩條爛路。

## 為什麼不是「一個開關關掉守衛」

做成全域／每店開關 = 促銷期間關掉、漏填的也一起放行（線上已經因此白送過 111 列），而且促銷結束沒人記得關回去。所以改成**標記制**：$0 只有被明確標成贈品才放行，誰標的／什麼時候／為什麼全部留痕。

## 從訂單下手

贈品是掛在**訂單**上的 —— 促銷的「買二送一」是同一個 SKU 有人買、有人是送的。所以入口在訂單這邊：

| 場景 | 入口 |
|---|---|
| 促銷一整批 | 訂單列表：篩「只看 $0」＋開團／門市 → 選取 →「🎁 標為贈品」（一次最多 500 張） |
| 一張單好幾項 | 訂單明細：$0 提示條上的「🎁 整單標成贈品」 |
| 櫃台當場一件 | 取貨頁該品項旁的「🎁 這是贈品」 |
| 整個開團商品都是送的 | 開團商品明細「設為贈品」（管理員；還有人按原價買就會被擋下並指路回訂單側） |

全部理由必填、逐列寫 `customer_order_audit_log(field='is_gift')` + `gift_marked_by/at`，訂單列表看得到 🎁 行數。

## 資料模型

兩層標記，讀取時 OR（`lib/orderGift.ts` 一份判定，DB 端 `rpc_record_pickup` / `v_admin_orders_list` 同一套）：

- `customer_order_items.is_gift` — 主要：掛在訂單品項上
- `campaign_items.is_gift` — 只給「這一項所有人都是送的」；順帶讓那個 $0 不會被重新同步蓋回零售價

刻意**不**用 trigger 把開團層級同步進品項欄位：有 50 支 migration 會 `INSERT customer_order_items`（轉單／拆行／配貨…），同步欄位漏一支就是「贈品變回漏填、櫃台被擋」；而且開團層級要能追溯生效。

## 一併關掉三個「會把贈品價格改回去」的地方

不做這段的話，標了也會被蓋回零售價，而且會**連既有 pending 訂單一起回填** ——「送的」瞬間變成跟客人收錢：

- `rpc_resync_campaign_from_product`（重新同步商品/價格）：贈品不重新定價、不回填訂單、缺零售價也不擋跑
- `_sync_retail_price_to_campaigns`（draft 團跟著零售價走的 trigger）
- `rpc_fill_zero_order_item_price`：補得出金額 = 不是贈品 → 順手清掉標記

## 改動

**DB（每支都以最新版本為基底逐字保留）**

`20260819000000_gift_exempt_zero_price_guard.sql`
- `customer_order_items` 加 `is_gift` / `gift_reason` / `gift_marked_by` / `gift_marked_at`；`campaign_items` 加 `is_gift` / `gift_reason`
- `customer_order_audit_log_field_check` 擴充 `'is_gift'`（白名單 CHECK，不擴充的話標記整支失敗）
- `rpc_record_pickup`：零元守衛放行已標記的贈品；拆行時把標記帶到 `picked_up` 那一行
- `v_admin_orders_list`：`zero_price_lines` 排除贈品，另加 `gift_lines`
- `rpc_mark_order_item_gift`（逐列）、`rpc_set_campaign_item_gift`（開團層級）
- resync / 零售價 trigger / 補金額三處的贈品保護

`20260819000010_bulk_mark_order_zero_price_gift.sql`
- `rpc_mark_zero_price_items_gift(order_ids[], operator, reason)`：批次版。逐張走 `_check_order_edit_notes_perm`（選到別人家的單整批擋下並指名是哪一張，**不默默略過**）、只動未取貨且 $0 且沒標過的列、跳過 `store_internal` 容器單與已被開團層級標掉的列、逐列 audit、一次最多 500 張
- `rpc_set_campaign_item_gift` 加守衛：該開團商品還有「有金額」的未取貨訂單品項 → 擋下並指路到訂單側

**前端**

- `lib/orderGift.ts`：判定收成一份（含 PostgREST to-one embed 可能回陣列的防呆）
- 訂單列表：$0 提示排除贈品、加 🎁 標、選取後可批次標記
- 訂單明細：$0 提示條 +「🎁 整單標成贈品」、逐列 🎁 標記／取消
- 取貨頁 / 取貨視窗：贈品不擋、可勾、顯示 🎁；被擋的 $0 多一顆「🎁 這是贈品」
- 開團商品明細：管理員可設為贈品（文案講清楚只適用「整項都是送的」）
- `lib/rpcError.ts`：`gift_mark:` / `campaign_gift:` 前綴中文化

## 驗證

- `node scripts/check-sql-syntax.cjs`：兩支 migration 的外層 SQL 與每一支 plpgsql 都 parse 過（同檔多支會撞 emscripten 已知的狀態 bug，所以拆開驗）
- `apps/admin`：`npx tsc --noEmit` 乾淨、`npm run build` 綠（含 Safari 15.6 bundle 檢查 100/100）
- lint 只剩既有的 setState-in-effect／unused 警告，都不在本次改動的行上

## 還沒做

線上 DB **尚未套用**（本 session 的 `SUPABASE_ACCESS_TOKEN` 解不開，Management API 回 `JWT could not be decoded`）。合併後要對正式庫依序跑 `20260819000000` → `20260819000010`，再用 `git log origin/main -- supabase/migrations/2026081900000*` 自檢。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BfPYS6RTMHCY19MBzdthP