### PR TITLE
漂漂館卡片補「已訂購件數」與「瀏覽數」

### DIFF
--- a/apps/member/src/app/piaopiao/page.tsx
+++ b/apps/member/src/app/piaopiao/page.tsx
@@ -3,8 +3,10 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import PageShell from "@/components/PageShell";
+import OrderedCount from "@/components/OrderedCount";
+import ViewCount from "@/components/ViewCount";
 
-type Campaign = { id: number; name: string; cover_image_url: string | null; end_at: string | null; min_price: number; max_price: number };
+type Campaign = { id: number; name: string; cover_image_url: string | null; end_at: string | null; min_price: number; max_price: number; ordered_qty?: number; view_count?: number };
 
 export default function PiaopiaoShopPage() {
   const [items, setItems] = useState<Campaign[]>([]);
@@ -31,7 +33,13 @@ export default function PiaopiaoShopPage() {
               </div>
               <div className="space-y-1 p-3">
                 <p className="line-clamp-2 min-h-10 text-[15px] font-semibold leading-5">{item.name}</p>
-                <p className="font-bold text-[var(--brand-strong)]">${item.min_price.toLocaleString()}{item.max_price > item.min_price ? " 起" : ""}</p>
+                <div className="flex flex-wrap items-baseline justify-between gap-x-2 gap-y-1">
+                  <p className="whitespace-nowrap font-bold text-[var(--brand-strong)]">${item.min_price.toLocaleString()}{item.max_price > item.min_price ? " 起" : ""}</p>
+                  <div className="ml-auto flex shrink-0 flex-col items-end gap-1">
+                    <OrderedCount count={item.ordered_qty} size="sm" />
+                    <ViewCount count={item.view_count} />
+                  </div>
+                </div>
               </div>
             </Link>
           ))}

--- a/apps/member/src/app/shop/page.tsx
+++ b/apps/member/src/app/shop/page.tsx
@@ -9,6 +9,8 @@ import PageShell from "@/components/PageShell";
 import PullToRefresh from "@/components/PullToRefresh";
 import CampaignCard, { type CampaignSummary } from "@/components/CampaignCard";
 import Countdown from "@/components/Countdown";
+import OrderedCount from "@/components/OrderedCount";
+import ViewCount from "@/components/ViewCount";
 import ShopBannerCarousel from "@/components/ShopBannerCarousel";
 import { cleanCampaignText } from "@/lib/text";
 import { setCampaignHints } from "@/lib/campaignHints";
@@ -25,6 +27,9 @@ type PiaoCampaign = {
   end_at: string | null;
   min_price: number;
   max_price: number;
+  /** 已訂購件數 / 瀏覽數。piaopiao-api 舊版沒有這兩欄（當 0 處理、不顯示）。 */
+  ordered_qty?: number;
+  view_count?: number;
 };
 
 /**
@@ -601,8 +606,17 @@ function PiaoCard({ item }: { item: PiaoCampaign }) {
         <h3 className="line-clamp-2 min-h-[2.6em] text-[16px] font-semibold leading-tight text-[var(--foreground)]">
           {cleanCampaignText(item.name)}
         </h3>
-        <div className="brand-gradient-text text-[24px] font-extrabold tabular-nums leading-none">
-          {priceText}
+        {/* 已訂購 / 瀏覽數直向堆疊在價格右邊，排版比照 CampaignCard grid 卡。
+            flex-wrap + 價格 nowrap：窄卡擠不下時統計整組掉到下一行靠右，
+            價格「$199 起」不會被折成兩行。 */}
+        <div className="flex flex-wrap items-baseline justify-between gap-x-2 gap-y-1">
+          <div className="brand-gradient-text whitespace-nowrap text-[24px] font-extrabold tabular-nums leading-none">
+            {priceText}
+          </div>
+          <div className="ml-auto flex shrink-0 flex-col items-end gap-1">
+            <OrderedCount count={item.ordered_qty} size="sm" />
+            <ViewCount count={item.view_count} />
+          </div>
         </div>
         {item.end_at && (
           <div className="inline-flex items-center gap-1 rounded-md bg-[var(--brand-soft)] px-1.5 py-0.5 text-[12px] font-semibold tabular-nums text-[var(--brand-strong)]">

--- a/supabase/functions/piaopiao-api/index.ts
+++ b/supabase/functions/piaopiao-api/index.ts
@@ -23,20 +23,39 @@ Deno.serve(async (req) => {
 });
 
 async function listPublicCampaigns(sb: any) {
+  const tenantId = mustEnv("DEFAULT_TENANT_ID");
   const { data, error } = await sb.from("group_buy_campaigns")
     .select("id, name, cover_image_url, end_at, campaign_items(unit_price, sort_order, sku:skus(product:products(images)))")
-    .eq("tenant_id", mustEnv("DEFAULT_TENANT_ID"))
+    .eq("tenant_id", tenantId)
     .eq("status", "open").eq("is_for_shop", true).eq("sales_channel", "piaopiao")
     .neq("campaign_no", "__INTERNAL_RESTOCK__")
     .or(`end_at.is.null,end_at.gt.${new Date().toISOString()}`)
     .order("end_at", { ascending: true, nullsFirst: false });
   if (error) throw new Error(error.message);
+
+  // 瀏覽數 / 已訂購件數：跟 liff-api list_active_campaigns 同一套 RPC
+  // （不要退回撈訂單在 JS 加總 —— PostgREST 1000 列靜默截斷 + 轉單重複計算，
+  // 兩個坑都收在 RPC 裡）。RPC 失敗當 0，不影響列表本體。
+  const ids = (data ?? []).map((c: any) => c.id);
+  const viewMap = new Map<number, number>();
+  const orderedMap = new Map<number, number>();
+  if (ids.length > 0) {
+    const [viewsRes, aggRes] = await Promise.all([
+      sb.rpc("rpc_campaign_view_counts", { p_tenant: tenantId, p_campaign_ids: ids }),
+      sb.rpc("rpc_member_campaign_aggregates", { p_tenant: tenantId, p_recent_days: 7, p_campaign_ids: ids }),
+    ]);
+    if (viewsRes.error) console.error("[list_public_campaigns] view counts rpc failed", viewsRes.error);
+    for (const r of viewsRes.data ?? []) viewMap.set(Number(r.campaign_id), Number(r.view_count ?? 0));
+    if (aggRes.error) console.error("[list_public_campaigns] aggregates rpc failed", aggRes.error);
+    for (const r of aggRes.data ?? []) orderedMap.set(Number(r.campaign_id), Number(r.ordered_qty ?? 0));
+  }
+
   const base = mustEnv("SUPABASE_URL");
   return json({ campaigns: (data ?? []).map((c: any) => {
     const items = [...(c.campaign_items ?? [])].sort((a: any, b: any) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
     const prices = items.map((i: any) => Number(i.unit_price)).filter(Number.isFinite);
     const image = c.cover_image_url ?? items[0]?.sku?.product?.images?.[0]?.url ?? items[0]?.sku?.product?.images?.[0] ?? null;
-    return { id: c.id, name: c.name, end_at: c.end_at, cover_image_url: image ? `${base}/storage/v1/object/public/products/${String(image).split("/").map(encodeURIComponent).join("/")}` : null, min_price: prices.length ? Math.min(...prices) : 0, max_price: prices.length ? Math.max(...prices) : 0 };
+    return { id: c.id, name: c.name, end_at: c.end_at, cover_image_url: image ? `${base}/storage/v1/object/public/products/${String(image).split("/").map(encodeURIComponent).join("/")}` : null, min_price: prices.length ? Math.min(...prices) : 0, max_price: prices.length ? Math.max(...prices) : 0, ordered_qty: orderedMap.get(Number(c.id)) ?? 0, view_count: viewMap.get(Number(c.id)) ?? 0 };
   }) });
 }
 


### PR DESCRIPTION
- `piaopiao-api list_public_campaigns` 回傳加 `ordered_qty` / `view_count`，走 liff-api 同一套 RPC（`rpc_member_campaign_aggregates` / `rpc_campaign_view_counts`），避開 PostgREST 1000 列靜默截斷與轉單重複計算的坑；RPC 失敗當 0，不影響列表本體。
- 前端 `/shop` 漂漂館分頁與 `/piaopiao` 獨立入口的卡片顯示這兩個數字，排版比照團購卡（價格右側直向堆疊，0 不顯示）；後端未部署新版前欄位缺失一律當 0，不會壞。
- 瀏覽數的累計本來就有（詳情頁 `track_campaign_view` 帶 piaopiao 通路），這次只是把讀取接上列表。

⚠️ **合併後 `piaopiao-api` 要重新部署**才會看到數字（環境裡的 `SUPABASE_ACCESS_TOKEN` 目前是壞的，我部署不了 —— 見對話）。

`npm run build`（member）綠 ✅；Playwright 截圖驗過顯示與窄卡排版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4PGpgh8bSZ6XZASTHbBeb

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4PGpgh8bSZ6XZASTHbBeb)_