### PR TITLE
商城左右滑切換世界＋返回列表不再閃（＋修 piaopiao-api 傳圖參數）

### DIFF
--- a/apps/member/src/app/shop/page.tsx
+++ b/apps/member/src/app/shop/page.tsx
@@ -51,6 +51,34 @@ type ShopCache = {
 let shopCache: ShopCache | null = null;
 // 漂漂館清單另一份快取（免登入公開 API，第一次切到該分頁才抓）
 let piaoCache: { items: PiaoCampaign[]; ts: number } | null = null;
+
+// 進場動畫（卡片逐張淡入）只在本次 session「第一次看到該世界的清單」時播。
+// 不記的話，進詳情頁再返回會整組重播一次 —— 資料明明有快取沒重抓，
+// 畫面看起來卻像重載閃一下。
+const animatedWorlds = new Set<WorldKey>();
+
+/** 漂漂館清單 → 詳情頁預填 hint（詳情頁只用 名稱/封面/結單/價格/瀏覽數，
+ *  其餘欄位補中性值即可）。沒餵的話從漂漂館進詳情永遠是整頁轉圈。 */
+function setPiaoHints(items: PiaoCampaign[]) {
+  setCampaignHints(items.map((c) => ({
+    id: c.id,
+    campaign_no: "",
+    name: c.name,
+    description: null,
+    cover_image_url: c.cover_image_url,
+    close_type: "regular",
+    total_cap_qty: null,
+    ordered_qty: c.ordered_qty ?? 0,
+    order_count: 0,
+    recent_order_count: 0,
+    view_count: c.view_count,
+    end_at: c.end_at,
+    pickup_deadline: null,
+    item_count: 0,
+    min_price: c.min_price,
+    max_price: c.max_price,
+  })));
+}
 // 返回時若資料已超過這個毫秒數，背景靜默重抓（不擋畫面、不動捲動）。
 const SHOP_REVALIDATE_MS = 60_000;
 
@@ -77,9 +105,12 @@ export default function ShopPage() {
   );
   const [world, setWorld] = useState<WorldKey>(() => shopCache?.world ?? "group");
   const [query, setQuery] = useState("");
-  const [piaoItems, setPiaoItems] = useState<PiaoCampaign[]>(
-    () => piaoCache?.items ?? [],
-  );
+  const [piaoItems, setPiaoItems] = useState<PiaoCampaign[]>(() => {
+    const cached = piaoCache?.items ?? [];
+    // 從快取還原時 hint 也要塞回去（同 campaigns 的做法）
+    if (cached.length > 0) setPiaoHints(cached);
+    return cached;
+  });
   const [piaoLoading, setPiaoLoading] = useState(false);
   const [piaoErr, setPiaoErr] = useState<string | null>(null);
 
@@ -134,11 +165,19 @@ export default function ShopPage() {
       if (!res.ok) throw new Error((body as { error?: string }).error || "讀取失敗");
       const items = (body as { campaigns: PiaoCampaign[] }).campaigns;
       setPiaoItems(items);
+      setPiaoHints(items);
       piaoCache = { items, ts: Date.now() };
     } catch (e) {
       if (!silent) setPiaoErr(e instanceof Error ? e.message : String(e));
     }
   }, []);
+
+  // 該世界的清單這一輪要不要播進場動畫（第一次看到才播，之後返回/切回不重播）
+  const animateCards = !animatedWorlds.has(world);
+  useEffect(() => {
+    if (world === "group" && campaigns.length > 0) animatedWorlds.add("group");
+    if (world === "piaopiao" && piaoItems.length > 0) animatedWorlds.add("piaopiao");
+  }, [world, campaigns.length, piaoItems.length]);
 
   // 切到漂漂館世界才抓（首次顯示 skeleton；快取偏舊就背景靜默更新）
   useEffect(() => {
@@ -355,6 +394,7 @@ export default function ShopPage() {
             items={shownPiao}
             searching={searching}
             query={query.trim()}
+            animate={animateCards}
           />
         ) : (
         <>
@@ -480,8 +520,8 @@ export default function ShopPage() {
                 {shown.map((c, i) => (
                   <div
                     key={c.id}
-                    className="animate-in"
-                    style={{ animationDelay: `${Math.min(i, 8) * 55}ms` }}
+                    className={animateCards ? "animate-in" : undefined}
+                    style={animateCards ? { animationDelay: `${Math.min(i, 8) * 55}ms` } : undefined}
                   >
                     <CampaignCard campaign={c} />
                   </div>
@@ -528,12 +568,15 @@ function PiaoWorld({
   items,
   searching,
   query,
+  animate,
 }: {
   loading: boolean;
   err: string | null;
   items: PiaoCampaign[];
   searching: boolean;
   query: string;
+  /** false = 返回列表 / 再切回來的重繪，不重播進場動畫 */
+  animate: boolean;
 }) {
   return (
     <>
@@ -595,8 +638,8 @@ function PiaoWorld({
             {items.map((c, i) => (
               <div
                 key={c.id}
-                className="animate-in"
-                style={{ animationDelay: `${Math.min(i, 8) * 55}ms` }}
+                className={animate ? "animate-in" : undefined}
+                style={animate ? { animationDelay: `${Math.min(i, 8) * 55}ms` } : undefined}
               >
                 <PiaoCard item={c} />
               </div>

--- a/apps/member/src/app/shop/page.tsx
+++ b/apps/member/src/app/shop/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { consumeFragmentToSession, getSession, loginPath } from "@/lib/session";
@@ -222,6 +222,38 @@ export default function ShopPage() {
   const shown = sorted.filter((c) => matchName(c.name));
   const shownPiao = piaoItems.filter((c) => matchName(c.name));
 
+  // 左右滑切換世界（momo 式）。只在手指放開時看位移向量：水平位移夠大、
+  // 且明顯大於垂直位移才算數 —— 直向捲動與下拉刷新（純垂直）都不受影響。
+  // 起點落在可橫向捲動的元素（banner 輪播）內就不接手，讓它自己捲。
+  const swipeRef = useRef<{ x: number; y: number; skip: boolean } | null>(null);
+  const onSwipeStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    const t = e.touches[0];
+    let el = e.target as HTMLElement | null;
+    let skip = false;
+    while (el && el !== e.currentTarget) {
+      if (el.scrollWidth > el.clientWidth + 1) {
+        const ox = getComputedStyle(el).overflowX;
+        if (ox === "auto" || ox === "scroll") {
+          skip = true;
+          break;
+        }
+      }
+      el = el.parentElement;
+    }
+    swipeRef.current = { x: t.clientX, y: t.clientY, skip };
+  };
+  const onSwipeEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+    const start = swipeRef.current;
+    swipeRef.current = null;
+    if (!start || start.skip) return;
+    const t = e.changedTouches[0];
+    const dx = t.clientX - start.x;
+    const dy = t.clientY - start.y;
+    if (Math.abs(dx) < 56 || Math.abs(dx) < Math.abs(dy) * 1.4) return;
+    // 往左滑 → 右邊那頁（漂漂館）；往右滑 → 回團購
+    setWorld(dx < 0 ? "piaopiao" : "group");
+  };
+
   const headerContent = (
     <div className="space-y-2.5">
       {/* 搜尋列（取代原本的「商品」大標題，momo 式頂欄） */}
@@ -310,7 +342,12 @@ export default function ShopPage() {
       headerContent={headerContent}
     >
       <PullToRefresh onRefresh={world === "piaopiao" ? fetchPiao : fetchCampaigns}>
-      <div className="space-y-5 px-4 pt-3 pb-6">
+      {/* min-h：內容很短（漂漂館空清單）時，下方空白也要吃得到左右滑 */}
+      <div
+        className="min-h-[70dvh] space-y-5 px-4 pt-3 pb-6"
+        onTouchStart={onSwipeStart}
+        onTouchEnd={onSwipeEnd}
+      >
         {world === "piaopiao" ? (
           <PiaoWorld
             loading={piaoLoading}

--- a/supabase/functions/piaopiao-api/index.ts
+++ b/supabase/functions/piaopiao-api/index.ts
@@ -13,7 +13,7 @@ Deno.serve(async (req) => {
     if (action === "list_public_campaigns") return await listPublicCampaigns(sb);
     const session = await sessionFrom(sb, req);
     if (action === "bootstrap") return await bootstrap(sb, session);
-    if (action === "upload_image") return await uploadImage(session, body);
+    if (action === "upload_image") return await uploadImage(sb, session, body);
     if (action === "publish") return await publish(sb, session, body);
     return json({ error: "unknown action" }, 400);
   } catch (e) {
@@ -81,7 +81,9 @@ async function bootstrap(sb: any, session: Session) {
   return json({ publisher: { name: publisher.display_name, lane: publisher.lane } });
 }
 
-async function uploadImage(session: Session, body: Record<string, unknown>) {
+// 第一參數 sb 不能拿掉：函式內 sb.storage 上傳要用（#809 移除每日上限時
+// 誤刪過一次，部署後上架傳圖直接 ReferenceError）。
+async function uploadImage(sb: any, session: Session, body: Record<string, unknown>) {
   const mime = String(body.mime ?? "");
   const encoded = String(body.base64 ?? "").replace(/^data:[^;]+;base64,/, "");
   if (!new Set(["image/jpeg", "image/png", "image/webp"]).has(mime)) throw new Error("只接受 JPG、PNG 或 WEBP 圖片");


### PR DESCRIPTION
三件事，同一支：

1. **左右滑切換**：`/shop` 內容區往左滑進漂漂館、往右滑回團購。只在放開手指時看位移向量（水平 ≥56px 且明顯大於垂直），直向捲動與下拉刷新不受影響；起點在 banner 輪播內就不接手。
2. **進詳情頁再返回不閃**：資料本來就有快取沒重抓，會閃是因為卡片的進場動畫（逐張淡入）每次返回都整組重播 —— 改成每個世界只在本次 session 第一次看到清單時播。另外從漂漂館列表進詳情頁原本每次都整頁轉圈，現在把清單摘要餵進 hint（跟團購同一套），點進去立刻有標題／封面／價格。
3. **修 main 上 #809 的 bug**：`uploadImage` 的 `sb` 參數被誤刪但函式內 `sb.storage` 還在用，下次部署 piaopiao-api 後上架傳圖會 `ReferenceError`。

驗證（Playwright）：左滑／右滑／垂直拖曳不誤觸；兩個世界「首次載入有動畫 → 進詳情返回後清單直接在、無 skeleton、動畫不重播」；漂漂館詳情 hint 秒顯示。`npm run build`（member）綠 ✅

⚠️ 合併後記得部署一次 `piaopiao-api`（傳圖修復＋ #811 的訂購/瀏覽數都靠它生效）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4PGpgh8bSZ6XZASTHbBeb