### PR TITLE
限量商品下單前先綁定店家 LINE：一鍵綁定碼（棄單聯絡得到人）

### DIFF
--- a/apps/admin/src/app/(protected)/members/page.tsx
+++ b/apps/admin/src/app/(protected)/members/page.tsx
@@ -100,6 +100,11 @@ function MembersListBody() {
   // 有 web push 訂閱（=已安裝 PWA + 開啟通知）的 member id；走 SECURITY DEFINER RPC，
   // 因 push_subscriptions RLS 對 admin（role 非 hq）會靜默回 0 列。
   const [pushSet, setPushSet] = useState<Set<number>>(new Set());
+  // 有「店家 LINE 訊息綁定」的 member id（store_line_followers.member_id 已配對）。
+  // 這是到貨通知推播 / 限量下單閘門認的那本名冊 —— 跟 line_user_id（登入綁定）
+  // 是兩回事，兩個徽章分開畫。分店角色的 RLS 只看得到自己店的列，
+  // 所以他們的徽章只反映自己店的綁定（正是他們該關心的範圍）。
+  const [msgBindSet, setMsgBindSet] = useState<Set<number>>(new Set());
   const [reloadTick, setReloadTick] = useState(0);
   const role = useRole();
   const canBulkDelete = isAdmin(role);
@@ -244,13 +249,18 @@ function MembersListBody() {
 
         const ids = resolved.map((r) => r.id);
         if (ids.length) {
-          const [ord, wal, push] = await Promise.all([
+          const [ord, wal, push, slf] = await Promise.all([
             getSupabase()
               .from("customer_orders")
               .select("id, member_id, status")
               .in("member_id", ids),
             getSupabase().from("wallet_balances").select("member_id, balance").in("member_id", ids),
             getSupabase().rpc("rpc_members_with_push", { p_member_ids: ids }),
+            getSupabase()
+              .from("store_line_followers")
+              .select("member_id")
+              .in("member_id", ids)
+              .eq("followed", true),
           ]);
           // 訂單數量 不計取消/過期/轉出（視為 void）
           const VOID_STATUSES = new Set<string>(["cancelled", "expired", "transferred_out"]);
@@ -289,13 +299,19 @@ function MembersListBody() {
           for (const row of (push.data ?? []) as { member_id: number }[]) {
             if (row?.member_id != null) ps.add(Number(row.member_id));
           }
+          const ms = new Set<number>();
+          for (const row of (slf.data ?? []) as { member_id: number | null }[]) {
+            if (row?.member_id != null) ms.add(Number(row.member_id));
+          }
           if (!cancelled) {
             setBalances(m);
             setPushSet(ps);
+            setMsgBindSet(ms);
           }
         } else {
           setBalances(new Map());
           setPushSet(new Set());
+          setMsgBindSet(new Set());
         }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
@@ -492,10 +508,18 @@ function MembersListBody() {
                       <span className="flex w-12 shrink-0 flex-col items-end gap-0.5">
                         {r.line_user_id && (
                           <span
-                            title="已綁定 LINE"
+                            title="已綁定 LINE 登入"
                             className="whitespace-nowrap rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-normal text-green-700 dark:bg-green-950 dark:text-green-300"
                           >
                             LINE
+                          </span>
+                        )}
+                        {msgBindSet.has(r.id) && (
+                          <span
+                            title="已綁定店家 LINE 官方帳號 — 可接收訊息推播（到貨通知），限量商品下單免再綁定"
+                            className="whitespace-nowrap rounded bg-teal-100 px-1.5 py-0.5 text-[10px] font-normal text-teal-700 dark:bg-teal-950 dark:text-teal-300"
+                          >
+                            訊息
                           </span>
                         )}
                         {pushSet.has(r.id) && (

--- a/apps/admin/src/components/LineFollowerPicker.tsx
+++ b/apps/admin/src/components/LineFollowerPicker.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+// 該店 OA 好友名冊的「配對選單」：從還沒對應到會員的 LINE 使用者裡挑一位，
+// 綁定給指定會員（rpc_bind_store_line_follower）。
+//
+// 從 LineMessageModal 抽出來共用 —— 發訊息彈窗（推不到時補救）與
+// 會員詳細頁的「店家 LINE 綁定」卡片都用這一份，配對的坑（排序、確認、
+// 疑似本人加星）只修一處。
+
+import { useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import SpinButton from "@/components/SpinButton";
+
+type Follower = { line_user_id: string; display_name: string | null; picture_url: string | null };
+
+/** 選單一次最多畫幾顆（超過的用搜尋縮小範圍，不然是一面牆的頭像） */
+const FOLLOWER_RENDER_MAX = 50;
+
+/**
+ * 抓該店「還沒配對到會員」的好友名冊，**最近有動靜的排最前面**。
+ *
+ * 排序不能省：之前沒排序就 `limit(50)`，PostgREST 回的是最舊的 50 筆 ——
+ * 名冊一超過 50 人，「剛加好友的顧客」（正是店員此刻要配對的人）反而
+ * 永遠不在選單裡。2026-08-13 三峽店實際踩到：名冊 104 人，會員當天加好友
+ * 加入會員，選單裡卻找不到她，變成「綁定了但不能發 LINE」的死路。
+ */
+async function fetchUnpairedFollowers(storeId: number) {
+  return await getSupabase()
+    .from("store_line_followers")
+    .select("line_user_id, display_name, picture_url")
+    .eq("store_id", storeId)
+    .is("member_id", null)
+    .eq("followed", true)
+    .order("last_event_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false })
+    .limit(200);
+}
+
+export function LineFollowerPicker({
+  storeId,
+  member,
+  onBound,
+}: {
+  /** 要看哪一家店的 OA 名冊（= 會員的取貨店） */
+  storeId: number;
+  member: { id: number; name: string | null; member_no: string };
+  /** 綁定成功後呼叫 —— 呼叫端自己重新載入綁定狀態 / 可達性 */
+  onBound: () => void;
+}) {
+  const [followers, setFollowers] = useState<Follower[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [filter, setFilter] = useState("");
+  const [binding, setBinding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data, error: fErr } = await fetchUnpairedFollowers(storeId);
+      if (cancelled) return;
+      // 不能吞掉錯誤：查詢失敗時清單會是空的，選單就整個不見，
+      // 畫面上卻什麼都沒說 —— 店員只會覺得「這功能壞了」而無從回報。
+      if (fErr) { setError(`讀取本店 LINE 名冊失敗：${fErr.message}`); return; }
+      setFollowers((data as Follower[]) ?? []);
+      setLoaded(true);
+    })();
+    return () => { cancelled = true; };
+  }, [storeId]);
+
+  // 關鍵字過濾 + 「LINE 名稱出現在會員姓名裡」的排最前。
+  // 這個租戶的會員名慣例是「LINE名稱＋電話末碼-店」（例：珍珠貝（Fang Cheng)922278-三峽），
+  // 所以名稱包含是很強的「疑似本人」訊號 —— 但只拿來排序加星，綁定仍要店員確認，
+  // 自動綁過會綁錯人（2026-08-10 平鎮兩筆）。
+  const visibleFollowers = useMemo(() => {
+    const kw = filter.trim().toLowerCase();
+    const memberName = (member.name ?? "").toLowerCase();
+    return followers
+      .filter((f) => !kw || (f.display_name ?? "").toLowerCase().includes(kw))
+      .map((f) => {
+        const n = (f.display_name ?? "").trim().toLowerCase();
+        return { ...f, suggested: n.length >= 2 && memberName.includes(n) };
+      })
+      // sort 是穩定排序：同組之間維持後端給的「最近有動靜優先」順序
+      .sort((a, b) => Number(b.suggested) - Number(a.suggested));
+  }, [followers, filter, member.name]);
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+        {error}
+      </div>
+    );
+  }
+
+  if (loaded && followers.length === 0) {
+    return (
+      <div className="rounded-md border border-sky-200 bg-sky-50 p-2 text-[11px] text-sky-800/80 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-300/80">
+        本店官方帳號名冊裡目前沒有「未配對」的人 —— 請先請顧客加入本店 LINE
+        官方帳號並傳一則訊息（傳什麼都可以），名冊收到人之後再回來這裡挑選。
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-sky-200 bg-sky-50 p-2 dark:border-sky-900 dark:bg-sky-950/40">
+      <div className="mb-1 text-xs font-medium text-sky-900 dark:text-sky-200">
+        這位會員在本店官方帳號是哪一個？
+      </div>
+      <p className="mb-2 text-[11px] text-sky-800/80 dark:text-sky-300/80">
+        以下是已加入本店官方帳號、但還沒對應到會員的人（最近有動靜的排前面，⭐ = LINE 名稱與會員姓名相符）。
+      </p>
+      {followers.length > 10 && (
+        <input
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder={`搜尋 LINE 名稱（共 ${followers.length} 人）…`}
+          className="mb-2 w-full rounded-md border border-sky-300 bg-white px-2 py-1 text-xs dark:border-sky-800 dark:bg-zinc-900"
+        />
+      )}
+      <div className="flex flex-wrap gap-2">
+        {visibleFollowers.slice(0, FOLLOWER_RENDER_MAX).map((f) => (
+          <SpinButton
+            key={f.line_user_id}
+            disabled={binding}
+            onClick={async () => {
+              // 人工配對點錯過（2026-08-10 平鎮兩筆）— 綁定前把兩個名字並列確認
+              if (!window.confirm(`把 LINE「${f.display_name ?? f.line_user_id.slice(0, 8)}」綁定為會員「${member.name ?? member.member_no}」？`)) return;
+              setBinding(true);
+              try {
+                const { error: bErr } = await getSupabase().rpc("rpc_bind_store_line_follower", {
+                  p_member_id: member.id,
+                  p_line_user_id: f.line_user_id,
+                });
+                if (bErr) { setError(bErr.message); return; }
+                onBound();
+              } finally {
+                setBinding(false);
+              }
+            }}
+            className="flex items-center gap-2 rounded-md border border-sky-300 bg-white px-2 py-1 text-xs hover:bg-sky-100 disabled:opacity-50 dark:border-sky-800 dark:bg-zinc-900 dark:hover:bg-sky-950"
+          >
+            {f.picture_url && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={f.picture_url} alt="" className="h-5 w-5 rounded-full object-cover" />
+            )}
+            {f.suggested && <span title="LINE 名稱與會員姓名相符，疑似本人">⭐</span>}
+            {f.display_name ?? f.line_user_id.slice(0, 8) + "…"}
+          </SpinButton>
+        ))}
+      </div>
+      {visibleFollowers.length === 0 && (
+        <p className="text-[11px] text-sky-800/80 dark:text-sky-300/80">
+          沒有符合「{filter.trim()}」的人 —— 顧客的 LINE 名稱可能跟會員姓名不同，清空搜尋看看全部。
+        </p>
+      )}
+      {visibleFollowers.length > FOLLOWER_RENDER_MAX && (
+        <p className="mt-2 text-[11px] text-sky-800/80 dark:text-sky-300/80">
+          還有 {visibleFollowers.length - FOLLOWER_RENDER_MAX} 人未顯示，請輸入名稱縮小範圍。
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/components/LineMessageModal.tsx
+++ b/apps/admin/src/components/LineMessageModal.tsx
@@ -15,6 +15,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import { Modal } from "@/components/Modal";
+import { LineFollowerPicker } from "@/components/LineFollowerPicker";
 import SpinButton from "@/components/SpinButton";
 import { renderPickupImage, type PickupOrder } from "@/lib/pickupImage";
 
@@ -37,37 +38,8 @@ type Quota = { limit: number | null; used: number };
 // chatMode "bot" = 後台把「聊天」關掉了、只走 webhook，連過去也不能回。
 type Chat = { url: string | null; mode: string | null };
 
-/**
- * 該店 OA 好友名冊裡「還沒配對到會員」的人。
- *
- * webhook 只收得到 LINE 使用者，收不到「他是哪位會員」—— 官方的 account link
- * 是自動化正解但要碰顧客端，還沒做。在那之前讓店員自己挑：他們本來就認得
- * 顧客的 LINE 名稱與頭像，這是最直覺的補救。
- */
-type Follower = { line_user_id: string; display_name: string | null; picture_url: string | null };
-
-/**
- * 抓該店「還沒配對到會員」的好友名冊，**最近有動靜的排最前面**。
- *
- * 排序不能省：之前沒排序就 `limit(50)`，PostgREST 回的是最舊的 50 筆 ——
- * 名冊一超過 50 人，「剛加好友的顧客」（正是店員此刻要配對的人）反而
- * 永遠不在選單裡。2026-08-13 三峽店實際踩到：名冊 104 人，會員當天加好友
- * 加入會員，選單裡卻找不到她，變成「綁定了但不能發 LINE」的死路。
- */
-async function fetchUnpairedFollowers(storeId: number) {
-  return await getSupabase()
-    .from("store_line_followers")
-    .select("line_user_id, display_name, picture_url")
-    .eq("store_id", storeId)
-    .is("member_id", null)
-    .eq("followed", true)
-    .order("last_event_at", { ascending: false, nullsFirst: false })
-    .order("created_at", { ascending: false })
-    .limit(200);
-}
-
-/** 選單一次最多畫幾顆（超過的用搜尋縮小範圍，不然是一面牆的頭像） */
-const FOLLOWER_RENDER_MAX = 50;
+// 配對選單（該店 OA 名冊裡還沒對應到會員的人）抽到 LineFollowerPicker，
+// 跟會員詳細頁的「店家 LINE 綁定」卡片共用同一份。
 
 // 訊息樣板。連結由後端 links action 給（來自 MEMBER_FRONT_BASE_URL），
 // 不在這裡寫死網址 —— 換網域時只要改 secret，不用重新部署前端。
@@ -141,9 +113,6 @@ export function LineMessageModal({
   const [quota, setQuota] = useState<Quota | null>(null);
   const [chat, setChat] = useState<Chat | null>(null);
   const [ordersUrl, setOrdersUrl] = useState<string | null>(null);
-  const [followers, setFollowers] = useState<Follower[]>([]);
-  const [followerFilter, setFollowerFilter] = useState("");
-  const [binding, setBinding] = useState(false);
   const [buildingImage, setBuildingImage] = useState(false);
   const [text, setText] = useState("");
   const [image, setImage] = useState<File | null>(null);
@@ -185,16 +154,6 @@ export function LineMessageModal({
         if (!cancelled && result.ok) setQuota({ limit: result.limit ?? null, used: result.used ?? 0 });
       } catch { /* 額度顯示是輔助資訊，抓不到就算了 */ }
     })();
-    // 該店還沒配對的 OA 好友：推不到時要讓店員手動挑
-    (async () => {
-      if (homeStoreId == null) return;
-      const { data, error: fErr } = await fetchUnpairedFollowers(homeStoreId);
-      if (cancelled) return;
-      // 不能吞掉錯誤：查詢失敗時清單會是空的，選單就整個不見，
-      // 畫面上卻什麼都沒說 —— 店員只會覺得「這功能壞了」而無從回報。
-      if (fErr) { setError(`讀取本店 LINE 名冊失敗：${fErr.message}`); return; }
-      setFollowers((data as Follower[]) ?? []);
-    })();
     // 樣板用的會員站連結（不需要 LINE token，所以 token 沒設也拿得到）
     (async () => {
       try {
@@ -226,23 +185,6 @@ export function LineMessageModal({
   useEffect(() => {
     return () => { if (imagePreview) URL.revokeObjectURL(imagePreview); };
   }, [imagePreview]);
-
-  // 配對選單的顯示清單：關鍵字過濾 + 「LINE 名稱出現在會員姓名裡」的排最前。
-  // 這個租戶的會員名慣例是「LINE名稱＋電話末碼-店」（例：珍珠貝（Fang Cheng)922278-三峽），
-  // 所以名稱包含是很強的「疑似本人」訊號 —— 但只拿來排序加星，綁定仍要店員確認，
-  // 自動綁過會綁錯人（2026-08-10 平鎮兩筆）。
-  const visibleFollowers = useMemo(() => {
-    const kw = followerFilter.trim().toLowerCase();
-    const memberName = (member.name ?? "").toLowerCase();
-    return followers
-      .filter((f) => !kw || (f.display_name ?? "").toLowerCase().includes(kw))
-      .map((f) => {
-        const n = (f.display_name ?? "").trim().toLowerCase();
-        return { ...f, suggested: n.length >= 2 && memberName.includes(n) };
-      })
-      // sort 是穩定排序：同組之間維持後端給的「最近有動靜優先」順序
-      .sort((a, b) => Number(b.suggested) - Number(a.suggested));
-  }, [followers, followerFilter, member.name]);
 
   /**
    * 把該會員的可取貨品項畫成一張圖，直接放進附圖欄。
@@ -398,14 +340,11 @@ export function LineMessageModal({
                 const { error: uErr } = await getSupabase().rpc("rpc_unbind_store_line_follower", { p_member_id: member.id });
                 if (uErr) { setError(uErr.message); return; }
                 // 解除後重新預檢，畫面翻回「推不到 + 配對選單」
+                // （配對選單由 LineFollowerPicker 在條件成立時掛載並自抓名冊）
                 setReachable({ state: "checking" });
                 const { result } = await callFn({ action: "check", member_id: member.id });
                 if (result.ok && result.reachable) setReachable({ state: "ok", displayName: result.display_name ?? null });
                 else setReachable({ state: "unreachable", message: result.message ?? "尚未綁定" });
-                if (homeStoreId != null) {
-                  const { data } = await fetchUnpairedFollowers(homeStoreId);
-                  setFollowers((data as Follower[]) ?? []);
-                }
               }}
               title="配對錯人時，解除後可重新從名冊挑選"
               className="shrink-0 rounded border border-emerald-300 px-2 py-0.5 text-[11px] text-emerald-700 hover:bg-emerald-100 dark:border-emerald-800 dark:text-emerald-300 dark:hover:bg-emerald-900"
@@ -438,74 +377,23 @@ export function LineMessageModal({
           )
         )}
 
-        {/* 推不到 + 該店名冊有人 → 讓店員手動配對 */}
+        {/* 推不到 → 讓店員手動配對（選單抽在 LineFollowerPicker，綁完重新預檢） */}
         {(reachable.state === "unreachable" || reachable.state === "error")
-          && followers.length > 0 && (
-          <div className="rounded-md border border-sky-200 bg-sky-50 p-2 dark:border-sky-900 dark:bg-sky-950/40">
-            <div className="mb-1 text-xs font-medium text-sky-900 dark:text-sky-200">
-              這位會員在本店官方帳號是哪一個？
-            </div>
-            <p className="mb-2 text-[11px] text-sky-800/80 dark:text-sky-300/80">
-              以下是已加入本店官方帳號、但還沒對應到會員的人（最近有動靜的排前面，⭐ = LINE 名稱與會員姓名相符）。選對之後就能發送。
-            </p>
-            {followers.length > 10 && (
-              <input
-                value={followerFilter}
-                onChange={(e) => setFollowerFilter(e.target.value)}
-                placeholder={`搜尋 LINE 名稱（共 ${followers.length} 人）…`}
-                className="mb-2 w-full rounded-md border border-sky-300 bg-white px-2 py-1 text-xs dark:border-sky-800 dark:bg-zinc-900"
-              />
-            )}
-            <div className="flex flex-wrap gap-2">
-              {visibleFollowers.slice(0, FOLLOWER_RENDER_MAX).map((f) => (
-                <SpinButton
-                  key={f.line_user_id}
-                  disabled={binding}
-                  onClick={async () => {
-                    // 人工配對點錯過（2026-08-10 平鎮兩筆）— 綁定前把兩個名字並列確認
-                    if (!window.confirm(`把 LINE「${f.display_name ?? f.line_user_id.slice(0, 8)}」綁定為會員「${member.name ?? member.member_no}」？`)) return;
-                    setBinding(true);
-                    try {
-                      const { error } = await getSupabase().rpc("rpc_bind_store_line_follower", {
-                        p_member_id: member.id,
-                        p_line_user_id: f.line_user_id,
-                      });
-                      if (error) { setError(error.message); return; }
-                      // 綁完重新預檢，畫面才會從「推不到」翻成「可發送」
-                      setReachable({ state: "checking" });
-                      const { result } = await callFn({ action: "check", member_id: member.id });
-                      if (result.ok && result.reachable) {
-                        setReachable({ state: "ok", displayName: result.display_name ?? null });
-                        setFollowers([]);
-                      } else {
-                        setReachable({ state: "unreachable", message: result.message ?? "仍然推不到" });
-                      }
-                    } finally {
-                      setBinding(false);
-                    }
-                  }}
-                  className="flex items-center gap-2 rounded-md border border-sky-300 bg-white px-2 py-1 text-xs hover:bg-sky-100 disabled:opacity-50 dark:border-sky-800 dark:bg-zinc-900 dark:hover:bg-sky-950"
-                >
-                  {f.picture_url && (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img src={f.picture_url} alt="" className="h-5 w-5 rounded-full object-cover" />
-                  )}
-                  {f.suggested && <span title="LINE 名稱與會員姓名相符，疑似本人">⭐</span>}
-                  {f.display_name ?? f.line_user_id.slice(0, 8) + "…"}
-                </SpinButton>
-              ))}
-            </div>
-            {visibleFollowers.length === 0 && (
-              <p className="text-[11px] text-sky-800/80 dark:text-sky-300/80">
-                沒有符合「{followerFilter.trim()}」的人 —— 顧客的 LINE 名稱可能跟會員姓名不同，清空搜尋看看全部。
-              </p>
-            )}
-            {visibleFollowers.length > FOLLOWER_RENDER_MAX && (
-              <p className="mt-2 text-[11px] text-sky-800/80 dark:text-sky-300/80">
-                還有 {visibleFollowers.length - FOLLOWER_RENDER_MAX} 人未顯示，請輸入名稱縮小範圍。
-              </p>
-            )}
-          </div>
+          && homeStoreId != null && (
+          <LineFollowerPicker
+            storeId={homeStoreId}
+            member={member}
+            onBound={async () => {
+              // 綁完重新預檢，畫面才會從「推不到」翻成「可發送」
+              setReachable({ state: "checking" });
+              const { result } = await callFn({ action: "check", member_id: member.id });
+              if (result.ok && result.reachable) {
+                setReachable({ state: "ok", displayName: result.display_name ?? null });
+              } else {
+                setReachable({ state: "unreachable", message: result.message ?? "仍然推不到" });
+              }
+            }}
+          />
         )}
 
         {/* 免額度替代路徑：OA 後台 1:1 聊天室。額度用完時這條仍然能發。 */}

--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -6,6 +6,7 @@ import { getSupabase } from "@/lib/supabase";
 import { MemberMergeModal } from "@/components/MemberMergeModal";
 import { MemberDeleteModal } from "@/components/MemberDeleteModal";
 import { LineMessageModal } from "@/components/LineMessageModal";
+import { MemberLineBindingCard } from "@/components/MemberLineBindingCard";
 import { WalletActionModal, type WalletActionMode } from "@/components/WalletActionModal";
 import { Modal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
@@ -583,6 +584,17 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
           會員仍有未取貨訂單時，後端會擋下改店動作（保護既有訂單的取貨地點）。
         </p>
       </div>
+
+      {/* 店家 LINE 訊息綁定 — 獨立卡片，一眼看到綁了沒、當場能綁能解。
+          （以前只藏在「發送 LINE 訊息」彈窗、推不到才出現配對選單） */}
+      {!isMerged && !isDeleted && (
+        <MemberLineBindingCard
+          member={{ id: member.id, name: member.name, member_no: member.member_no }}
+          homeStoreId={member.home_store_id}
+          storeName={memberStoreName}
+          onChanged={() => setReloadTick((n) => n + 1)}
+        />
+      )}
 
       <div className="grid gap-3 sm:grid-cols-3">
         <Card label="等級">{tier?.name ?? "—"}</Card>

--- a/apps/admin/src/components/MemberLineBindingCard.tsx
+++ b/apps/admin/src/components/MemberLineBindingCard.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+// 會員詳細頁的「店家 LINE 訊息綁定」卡片。
+//
+// 為什麼獨立成卡片：綁定原本只藏在「發送 LINE 訊息」彈窗裡（而且要推不到
+// 才會出現配對選單），店員找不到；限量商品下單又以這個綁定當門檻之後，
+// 「這位會員綁了沒」必須一眼看得到、當場能綁能解。
+//
+// 「綁定」= store_line_followers 有這位會員（該店 OA provider 的 LINE 身分）。
+// 到貨通知推播（admin-line-push）與限量下單閘門（liff-api）都認這一筆。
+// members.line_user_id 是**登入用**的另一個 provider，跟這裡無關。
+
+import { useEffect, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { LineFollowerPicker } from "@/components/LineFollowerPicker";
+import SpinButton from "@/components/SpinButton";
+
+type Binding = {
+  line_user_id: string;
+  display_name: string | null;
+  picture_url: string | null;
+  followed: boolean;
+  linked_at: string | null;
+  last_event_at: string | null;
+};
+
+export function MemberLineBindingCard({
+  member,
+  homeStoreId,
+  storeName,
+  onChanged,
+}: {
+  member: { id: number; name: string | null; member_no: string };
+  homeStoreId: number | null;
+  storeName: string | null;
+  /** 綁定 / 解除後呼叫（讓外層重抓 hasStoreLineBinding 等狀態） */
+  onChanged?: () => void;
+}) {
+  const [binding, setBinding] = useState<Binding | null>(null);
+  const [oaId, setOaId] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [unbinding, setUnbinding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (homeStoreId == null) { setLoaded(true); return; }
+    let cancelled = false;
+    setLoaded(false);
+    (async () => {
+      const sb = getSupabase();
+      const [fol, st] = await Promise.all([
+        sb.from("store_line_followers")
+          .select("line_user_id, display_name, picture_url, followed, linked_at, last_event_at")
+          .eq("store_id", homeStoreId)
+          .eq("member_id", member.id)
+          .order("linked_at", { ascending: false, nullsFirst: false })
+          .limit(1)
+          .maybeSingle(),
+        sb.from("stores").select("line_oa_basic_id").eq("id", homeStoreId).maybeSingle(),
+      ]);
+      if (cancelled) return;
+      if (fol.error) setError(fol.error.message);
+      setBinding((fol.data as Binding | null) ?? null);
+      setOaId(String(st.data?.line_oa_basic_id ?? "").trim() || null);
+      setLoaded(true);
+    })();
+    return () => { cancelled = true; };
+  }, [member.id, homeStoreId, tick]);
+
+  const refresh = () => {
+    setPickerOpen(false);
+    setError(null);
+    setTick((t) => t + 1);
+    onChanged?.();
+  };
+
+  async function unbind() {
+    if (!window.confirm(
+      `解除「${binding?.display_name ?? "此 LINE 身分"}」與會員「${member.name ?? member.member_no}」的綁定？\n\n`
+      + `解除後將無法對此會員推播到貨通知；下單限量商品時也會再次被要求綁定。`,
+    )) return;
+    setUnbinding(true);
+    setError(null);
+    try {
+      const { error: uErr } = await getSupabase().rpc("rpc_unbind_store_line_follower", {
+        p_member_id: member.id,
+      });
+      if (uErr) { setError(uErr.message); return; }
+      refresh();
+    } finally {
+      setUnbinding(false);
+    }
+  }
+
+  return (
+    <div className="rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="text-xs font-medium text-zinc-500">
+          店家 LINE 訊息綁定{storeName ? `（${storeName}）` : ""}
+        </div>
+        {oaId && <span className="font-mono text-xs text-zinc-400">{oaId}</span>}
+      </div>
+
+      {homeStoreId == null ? (
+        <p className="text-sm text-zinc-500">此會員沒有取貨店 —— 請先在上方設定取貨店，才能決定要綁哪一家店的官方帳號。</p>
+      ) : !loaded ? (
+        <p className="text-sm text-zinc-500">載入中…</p>
+      ) : binding ? (
+        <div className="flex flex-wrap items-center gap-3">
+          {binding.picture_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={binding.picture_url} alt="" className="h-9 w-9 rounded-full object-cover" />
+          ) : (
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-zinc-200 text-xs text-zinc-500 dark:bg-zinc-800">
+              {binding.display_name?.[0] ?? "?"}
+            </div>
+          )}
+          <div className="flex-1 min-w-[180px]">
+            <div className="text-sm font-medium">
+              {binding.display_name ?? binding.line_user_id.slice(0, 10) + "…"}
+              <span className="ml-2 rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-normal text-green-700 dark:bg-green-950 dark:text-green-300">
+                ✓ 已綁定
+              </span>
+            </div>
+            <div className="text-xs text-zinc-500">
+              {binding.linked_at ? `綁定於 ${new Date(binding.linked_at).toLocaleString("zh-TW")}` : "綁定時間不明"}
+              {binding.last_event_at && `　最後互動 ${new Date(binding.last_event_at).toLocaleDateString("zh-TW")}`}
+            </div>
+            {!binding.followed && (
+              <div className="mt-0.5 text-[11px] text-amber-700 dark:text-amber-400">
+                ⚠ 此顧客已封鎖或移除本店官方帳號，訊息推播無法送達（綁定仍保留，重新加好友即恢復）
+              </div>
+            )}
+          </div>
+          <SpinButton
+            onClick={unbind}
+            disabled={unbinding}
+            title="配對錯人時解除；解除後可重新從名冊挑選"
+            className="rounded-md border border-red-300 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950"
+          >
+            解除綁定
+          </SpinButton>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            尚未綁定 —— 無法對此會員推播到貨通知；下單<strong className="font-semibold">限量商品</strong>時會被要求先完成綁定。
+          </p>
+          <p className="text-[11px] text-zinc-500">
+            綁定有兩條路：① 會員自己來 —— 在商城下單限量商品時照指示傳「綁定碼」訊息，或對本店官方帳號傳任意訊息後點回覆的「查看我的訂單」連結；
+            ② 店員手動配對 —— 從下方名冊挑出這位顧客。
+          </p>
+          {pickerOpen ? (
+            <LineFollowerPicker storeId={homeStoreId} member={member} onBound={refresh} />
+          ) : (
+            <SpinButton
+              onClick={() => setPickerOpen(true)}
+              className="rounded-md border border-sky-300 px-3 py-1 text-xs font-medium text-sky-700 hover:bg-sky-50 dark:border-sky-800 dark:text-sky-300 dark:hover:bg-sky-950"
+            >
+              🔗 從名冊挑人綁定
+            </SpinButton>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-2 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/member/src/app/shop/c/[id]/CampaignDetailClient.tsx
+++ b/apps/member/src/app/shop/c/[id]/CampaignDetailClient.tsx
@@ -17,6 +17,7 @@ import { cleanCampaignText } from "@/lib/text";
 import { getCampaignHint } from "@/lib/campaignHints";
 import { logCaught } from "@/lib/clientLog";
 import { detectClientChannel } from "@/lib/clientChannel";
+import LineBindGate from "@/components/LineBindGate";
 
 /** 把 children 渲染到 document.body（保證 fixed 相對 viewport）。 */
 function Portal({ enabled, children }: { enabled: boolean; children: React.ReactNode }) {
@@ -128,6 +129,9 @@ export default function CampaignDetailClient({ salesChannel }: { salesChannel?: 
   const [notes, setNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [doneOrderNo, setDoneOrderNo] = useState<string | null>(null);
+  // 限量團的 LINE 綁定閘門：下單被 line_binding_required 擋下時記下取貨店，
+  // 彈出綁定視窗；綁完自動重送同一張訂單（qtyMap / notes 都還在）。
+  const [bindStoreId, setBindStoreId] = useState<number | null>(null);
   // 把常駐下單列 / sheet portal 到 body，確保一定釘在 viewport（不受任何祖先
   // transform / filter 形成的 containing block 影響、不用滑到底才看得到）
   const [mounted, setMounted] = useState(false);
@@ -253,6 +257,15 @@ export default function CampaignDetailClient({ salesChannel }: { salesChannel?: 
       });
       setDoneOrderNo(r.order_no);
     } catch (e) {
+      // 限量團要求先綁定店家 LINE：不 alert，改開綁定彈窗（綁完自動重送）
+      if ((e as { code?: unknown })?.code === "line_binding_required") {
+        const d = (e as { detail?: { store_id?: number } }).detail;
+        const sid = Number(d?.store_id ?? 0);
+        if (sid > 0) {
+          setBindStoreId(sid);
+          return;
+        }
+      }
       const message = e instanceof Error ? e.message : String(e);
       const soldOut = message.includes("sold out");
       // 售完是熱團的正常結果不記；其餘下單失敗會員只看得到 alert，一定要留 log
@@ -518,6 +531,20 @@ export default function CampaignDetailClient({ salesChannel }: { salesChannel?: 
           onSubmit={submit}
           submitting={submitting}
         />
+      </Portal>
+
+      {/* 限量團的 LINE 綁定閘門（z-[70]，蓋過 BuySheet z-50） */}
+      <Portal enabled={mounted && bindStoreId != null}>
+        {bindStoreId != null && (
+          <LineBindGate
+            storeId={bindStoreId}
+            onBound={() => {
+              setBindStoreId(null);
+              void submit();
+            }}
+            onClose={() => setBindStoreId(null)}
+          />
+        )}
       </Portal>
 
       {/* Done sheet */}

--- a/apps/member/src/components/LineBindGate.tsx
+++ b/apps/member/src/components/LineBindGate.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+// 限量商品下單前的「店家 LINE 綁定」彈窗。
+//
+// 觸發：place_member_order 回 code === "line_binding_required"。
+// 流程：start_line_binding 拿綁定碼 → 開店家 OA 對話（訊息已預填）→ 會員按
+// 送出（順手加了好友）→ line-webhook 完成綁定 → 這裡輪詢到 bound=true →
+// onBound()（呼叫端自動重送訂單）。會員視角：按一次「前往 LINE」再按一次
+// 「送出」，回來訂單自己完成 —— 不需要理解「綁定」是什麼。
+//
+// 沒辦法真的全程無感：LINE 不允許替使用者加好友 / 代發訊息，
+// 「預填好、按一下送出」已是平台允許的最短路徑。
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getSession } from "@/lib/session";
+import { callLiffApi } from "@/lib/supabase";
+import { openLineOaChat } from "@/lib/lineInquiry";
+import { logCaught } from "@/lib/clientLog";
+import Spinner from "@/components/Spinner";
+
+type StartResp = {
+  bound: boolean;
+  code?: string;
+  oa_id?: string | null;
+  store_name?: string | null;
+  message_text?: string;
+};
+
+type StateResp = { bound: boolean; bindable: boolean };
+
+export default function LineBindGate({
+  storeId,
+  onBound,
+  onClose,
+}: {
+  storeId: number;
+  /** 綁定完成（含「其實早就綁好」）。呼叫端拿到這個訊號後自動重送訂單 */
+  onBound: () => void;
+  onClose: () => void;
+}) {
+  const [info, setInfo] = useState<StartResp | null>(null);
+  const [waiting, setWaiting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // onBound 只能發一次：輪詢與 visibilitychange 可能同時命中
+  const firedRef = useRef(false);
+
+  const fireBound = useCallback(() => {
+    if (firedRef.current) return;
+    firedRef.current = true;
+    onBound();
+  }, [onBound]);
+
+  // 進場就發碼（已綁定的話後端直接回 bound=true，彈窗一閃而過）
+  useEffect(() => {
+    const s = getSession();
+    if (!s) return;
+    (async () => {
+      try {
+        const r = await callLiffApi<StartResp>(s.token, {
+          action: "start_line_binding",
+          store_id: storeId,
+        });
+        if (r.bound) {
+          fireBound();
+          return;
+        }
+        setInfo(r);
+      } catch (e) {
+        // 會員只會卡在這個彈窗裡，一定要留 log（clientLog 規則）
+        logCaught("start_line_binding_failed", e, { store_id: storeId });
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+  }, [storeId, fireBound]);
+
+  // 輪詢綁定狀態；切回前景（從 LINE 回來的那一刻）立刻補查一次
+  useEffect(() => {
+    const s = getSession();
+    if (!s) return;
+    let stopped = false;
+    const check = async () => {
+      try {
+        const r = await callLiffApi<StateResp>(s.token, {
+          action: "get_line_bind_state",
+          store_id: storeId,
+        });
+        if (!stopped && r.bound) fireBound();
+      } catch {
+        // 輪詢失敗下一輪再試；不打擾使用者
+      }
+    };
+    const timer = window.setInterval(check, 3000);
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void check();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+    return () => {
+      stopped = true;
+      window.clearInterval(timer);
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+    };
+  }, [storeId, fireBound]);
+
+  const goLine = async () => {
+    if (!info?.oa_id || !info.message_text) return;
+    setWaiting(true);
+    await openLineOaChat(info.oa_id, info.message_text);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/50 px-6">
+      <div className="w-full max-w-sm rounded-2xl bg-white p-6 text-center">
+        <div className="text-5xl">🔒</div>
+        <h3 className="mt-3 text-[20px] font-bold text-[var(--foreground)]">
+          限量商品需要綁定店家 LINE
+        </h3>
+
+        {error ? (
+          <p className="mt-3 text-[14px] text-red-600">{error}</p>
+        ) : !info ? (
+          <div className="mt-5 flex justify-center"><Spinner /></div>
+        ) : (
+          <>
+            <p className="mt-2 text-[14px] leading-relaxed text-[var(--secondary-label)]">
+              限量商品到貨與訂單通知會從
+              {info.store_name ? `「${info.store_name}」` : "店家"}
+              的 LINE 發送。點下方按鈕開啟 LINE，
+              <span className="font-semibold text-[var(--foreground)]">
+                把已填好的訊息按「送出」
+              </span>
+              就完成綁定，回來會自動繼續下單。
+            </p>
+
+            <button
+              onClick={goLine}
+              className="mt-5 w-full rounded-xl bg-[#06C755] py-3.5 text-[16px] font-bold text-white active:opacity-80"
+            >
+              前往 LINE 完成綁定
+            </button>
+
+            {waiting && (
+              <div className="mt-3 flex items-center justify-center gap-2 text-[13px] text-[var(--secondary-label)]">
+                <Spinner />
+                等待綁定完成…送出訊息後回到這裡即可
+              </div>
+            )}
+          </>
+        )}
+
+        <button
+          onClick={onClose}
+          className="mt-4 w-full rounded-xl bg-[#7676801f] py-3 text-[15px] font-medium text-[var(--foreground)] active:bg-[#76768033]"
+        >
+          先不要，返回
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/member/src/lib/lineInquiry.ts
+++ b/apps/member/src/lib/lineInquiry.ts
@@ -54,6 +54,26 @@ export function buildLineOaMessageUrl(basicId: string, text: string): string {
   return `https://line.me/R/oaMessage/${encodeURIComponent(id)}/?${encodeURIComponent(text)}`;
 }
 
+/**
+ * 開啟與指定 LINE@ 的對話並預填文字（universal link）。
+ * LIFF 內要用 openWindow(external) 跳出內建瀏覽器；其餘用導頁而不是
+ * window.open —— 非同步之後才開新視窗會被彈出視窗阻擋器擋掉（不算 user
+ * gesture）。universal link 用導頁一樣會交棒給 LINE app，PWA 本身留在原地。
+ */
+export async function openLineOaChat(basicId: string, text: string): Promise<void> {
+  const url = buildLineOaMessageUrl(basicId, text);
+  try {
+    const liff = await initLiff();
+    if (liff?.isInClient() && typeof liff.openWindow === "function") {
+      liff.openWindow({ url, external: true });
+      return;
+    }
+  } catch {
+    // 落到一般導頁
+  }
+  window.location.href = url;
+}
+
 export type SendResult = "sent_in_liff" | "opened_line" | "copied" | "failed";
 
 /**
@@ -103,21 +123,7 @@ export async function sendLineInquiry(
       return "failed";
     }
   }
-  const url = buildLineOaMessageUrl(oa, text);
-  try {
-    const liff = await initLiff();
-    // LIFF 內要用 openWindow(external) 才會跳出 LINE 內建瀏覽器開對話
-    if (liff?.isInClient() && typeof liff.openWindow === "function") {
-      liff.openWindow({ url, external: true });
-      return "opened_line";
-    }
-  } catch {
-    // 落到一般 window.open
-  }
-  // 用 location 導頁而不是 window.open：非同步之後才開新視窗會被彈出視窗
-  // 阻擋器擋掉（已經不算 user gesture）。universal link 用導頁一樣會交棒給
-  // LINE app，PWA 本身留在原地。
-  window.location.href = url;
+  await openLineOaChat(oa, text);
   return "opened_line";
 }
 

--- a/apps/member/src/lib/supabase.ts
+++ b/apps/member/src/lib/supabase.ts
@@ -73,6 +73,8 @@ export async function callLiffApi<T = unknown>(
 
     const err = new Error(msg);
     (err as Error & { detail?: unknown }).detail = (data as { detail?: unknown }).detail;
+    // 機器可判別的錯誤代碼（例：line_binding_required），讓呼叫端不用 parse 中文訊息
+    (err as Error & { code?: unknown }).code = (data as { code?: unknown }).code;
     throw err;
   }
 

--- a/supabase/functions/_shared/lineBinding.ts
+++ b/supabase/functions/_shared/lineBinding.ts
@@ -1,0 +1,36 @@
+// 限量商品下單前的「店家 LINE 一鍵綁定」—— 綁定碼的產生 / 訊息格式 / 解析。
+//
+// 這支被兩個 function 共用，格式只能在這裡改：
+//   liff-api  (start_line_binding)：generateBindCode + buildBindMessage 發碼
+//   line-webhook：extractBindCode 從會員送進 OA 的訊息裡把碼撈出來核銷
+// 兩邊各自部署，若訊息格式跟解析對不上，綁定會整條靜默失效 —— 所以
+// buildBindMessage 與 BIND_CODE_RE 必須永遠成對維護在這個檔案裡。
+
+/** 綁定碼有效時間（分鐘）。過期後前端要重新按一次下單取得新碼 */
+export const BIND_CODE_TTL_MIN = 30;
+
+// 32 個字元、去除易混淆的 0/O/1/I。crypto 亂數 byte % 32 沒有 modulo bias（256 = 32×8）
+const CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+/** 產生 6 碼綁定碼（使用者不用手打，只是跟著預填訊息一起送出） */
+export function generateBindCode(): string {
+  const bytes = new Uint8Array(6);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (const b of bytes) out += CODE_CHARS[b % CODE_CHARS.length];
+  return out;
+}
+
+/** 預填進 OA 對話框的訊息本文。會員只要按「送出」，不需要理解綁定碼是什麼 */
+export function buildBindMessage(code: string): string {
+  return `我要綁定商城會員，完成後就可以下單限量商品 🛍️\n綁定碼：${code}`;
+}
+
+// 只認「綁定碼：XXXXXX」這個片段，前後多打字（或 LINE 自動加的東西）不影響
+const BIND_CODE_RE = /綁定碼[:：]\s*([A-HJ-NP-Z2-9]{6})/;
+
+/** 從訊息文字裡撈綁定碼；沒有就回 null（= 一般訊息，走原本的 account link 邀請） */
+export function extractBindCode(text: string): string | null {
+  const m = BIND_CODE_RE.exec(text ?? "");
+  return m ? m[1] : null;
+}

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -3,6 +3,7 @@ import { corsHeaders } from "../_shared/cors.ts";
 import { verifyJwtHs256, type JwtClaims } from "../_shared/jwt.ts";
 import { renewSessionTokenIfNeeded } from "../_shared/session.ts";
 import { isMissingSalesChannelColumn } from "../_shared/salesChannelGuard.ts";
+import { BIND_CODE_TTL_MIN, buildBindMessage, generateBindCode } from "../_shared/lineBinding.ts";
 import webpush from "https://esm.sh/web-push@3.6.7";
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -103,6 +104,125 @@ async function createAccountLinkNonce(
   });
   if (error) return json({ error: error.message }, 500);
   return json({ nonce });
+}
+
+// ─── 限量商品下單前的「店家 LINE 綁定」 ──────────────────────────────────────
+//
+// 「綁定」= store_line_followers 有這位會員（member_id 已填、followed=true）。
+// 那張表的 line_user_id 是**該店 OA provider** 的 ID，店家用它推「到貨通知」、
+// 棄單時也聯絡得到人 —— 這正是限量商品要求先綁定的原因。
+//
+// 寫入端有兩條路，都在 line-webhook：
+//   1. 綁定碼（本次新增）：start_line_binding 發碼 → 前端開 OA 對話預填
+//      「綁定碼：XXXXXX」→ 會員按送出 → webhook 核銷 + 綁定。一則訊息完成。
+//   2. account link（既有）：會員隨便傳訊息 → webhook 回「查看我的訂單」連結。
+// 這裡只負責發碼與回報狀態，不寫 store_line_followers。
+
+/** 取貨店的綁定目標：OA basic id + 是否具備完成綁定的條件（憑證齊全才有 webhook） */
+async function resolveLineBindTarget(sb: any, tenantId: string, storeId: number) {
+  const { data: store } = await sb
+    .from("stores")
+    .select("id, name, line_oa_basic_id")
+    .eq("tenant_id", tenantId)
+    .eq("id", storeId)
+    .maybeSingle();
+  const oaId = String(store?.line_oa_basic_id ?? "").trim() || null;
+  let hasCreds = false;
+  if (oaId) {
+    // 憑證（channel secret）沒設就收不到 webhook，綁定永遠完不成 → 視為不可綁
+    const { data: cred } = await sb
+      .from("store_line_oa_credentials")
+      .select("store_id")
+      .eq("store_id", storeId)
+      .maybeSingle();
+    hasCreds = !!cred;
+  }
+  return {
+    storeName: (store?.name as string | undefined) ?? null,
+    oaId,
+    bindable: !!oaId && hasCreds,
+  };
+}
+
+async function memberBoundToStore(sb: any, storeId: number, memberId: number): Promise<boolean> {
+  const { data } = await sb
+    .from("store_line_followers")
+    .select("id")
+    .eq("store_id", storeId)
+    .eq("member_id", memberId)
+    .eq("followed", true)
+    .limit(1)
+    .maybeSingle();
+  return !!data;
+}
+
+/** 前端輪詢用：這位會員對這家店綁好了沒 */
+async function getLineBindState(sb: any, tenantId: string, memberId: number, storeId: number) {
+  if (!storeId) return json({ error: "store_id required" }, 400);
+  const target = await resolveLineBindTarget(sb, tenantId, storeId);
+  const bound = target.bindable ? await memberBoundToStore(sb, storeId, memberId) : false;
+  return json({
+    store_id: storeId,
+    store_name: target.storeName,
+    oa_id: target.oaId,
+    bindable: target.bindable,
+    bound,
+  });
+}
+
+/**
+ * 發（或重用）綁定碼。回傳前端開 OA 對話要用的一切：oa_id + 預填訊息。
+ * 同會員同店還有活著的碼就直接重用 —— 會員反覆按下單不會把表灌爆，
+ * 也不會讓「已經開著的 LINE 對話框」裡那組碼突然失效。
+ */
+async function startLineBinding(sb: any, tenantId: string, memberId: number, storeId: number) {
+  if (!storeId) return json({ error: "store_id required" }, 400);
+  const target = await resolveLineBindTarget(sb, tenantId, storeId);
+  if (!target.bindable) return json({ error: "此店家尚未啟用 LINE 綁定" }, 400);
+  if (await memberBoundToStore(sb, storeId, memberId)) {
+    return json({ bound: true });
+  }
+
+  // 重用還有 5 分鐘以上效期的碼；快過期就發新的，免得會員送出時剛好失效
+  const { data: existing } = await sb
+    .from("line_binding_codes")
+    .select("code, expires_at")
+    .eq("member_id", memberId)
+    .eq("store_id", storeId)
+    .is("used_at", null)
+    .gt("expires_at", new Date(Date.now() + 5 * 60_000).toISOString())
+    .order("id", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  let code = existing?.code as string | undefined;
+  if (!code) {
+    const expiresAt = new Date(Date.now() + BIND_CODE_TTL_MIN * 60_000).toISOString();
+    // 活著的碼全域唯一（partial unique index）；撞號就重生，最多試 3 次
+    for (let i = 0; i < 3 && !code; i++) {
+      const candidate = generateBindCode();
+      const { error } = await sb.from("line_binding_codes").insert({
+        tenant_id: tenantId,
+        member_id: memberId,
+        store_id: storeId,
+        code: candidate,
+        expires_at: expiresAt,
+      });
+      if (!error) code = candidate;
+      else if (!String(error.message ?? "").includes("duplicate")) {
+        return json({ error: error.message }, 500);
+      }
+    }
+    if (!code) return json({ error: "無法產生綁定碼，請稍後再試" }, 500);
+  }
+
+  return json({
+    bound: false,
+    code,
+    oa_id: target.oaId,
+    store_name: target.storeName,
+    message_text: buildBindMessage(code),
+  });
 }
 
 async function listStores(sb: any, tenantId: string) {
@@ -1132,7 +1252,7 @@ async function placeMemberOrder(
   const requiredSalesChannel = p.sales_channel === "piaopiao" ? "piaopiao" : "main";
   const { data: campaign, error: campaignErr } = await sb
     .from("group_buy_campaigns")
-    .select("id")
+    .select("id, close_type, total_cap_qty, campaign_items(cap_qty)")
     .eq("tenant_id", tenantId)
     .eq("id", campaignId)
     .eq("sales_channel", requiredSalesChannel)
@@ -1155,6 +1275,37 @@ async function placeMemberOrder(
 
   const pickupStoreId = Number(p.pickup_store_id ?? member.home_store_id ?? 0);
   if (!pickupStoreId) return json({ error: "pickup_store_id required" }, 400);
+
+  // ── 限量團閘門：先綁定取貨店的 LINE 官方帳號才能下單 ──────────────────────
+  // 「限量」判準與商城「限量搶購」分頁同一套（listActiveCampaigns 的 sale_limit）：
+  // fast / limited、或非 food_train 而設了總量 / 單品上限。要求綁定的原因：
+  // 限量品搶到就是承諾，棄單店家要聯絡得到人（同一條綁定也餵「到貨通知」推播）。
+  // 店家沒設 OA / 憑證不擋 —— 擋了也沒有任何路可以完成綁定。
+  // 閘門查詢失敗一律放行：這是商業規則不是安全邊界，不能因基礎設施出錯全面擋單。
+  const closeType = String(campaign.close_type ?? "");
+  const isLimitedSale = closeType === "fast" || closeType === "limited" || (
+    closeType !== "food_train" && (
+      Number(campaign.total_cap_qty ?? 0) > 0
+      || (campaign.campaign_items ?? []).some((i: any) => Number(i.cap_qty ?? 0) > 0)
+    )
+  );
+  if (isLimitedSale) {
+    try {
+      const target = await resolveLineBindTarget(sb, tenantId, pickupStoreId);
+      if (target.bindable && !(await memberBoundToStore(sb, pickupStoreId, memberId))) {
+        // error 字串是舊版前端唯一看得到的東西（alert 原文照噴），要能照著做：
+        // 加好友 → 傳一則訊息 → webhook 會回 account link 連結完成綁定。
+        // 新版前端認 code 欄位，改走綁定碼彈窗（一鍵完成），不會看到這段字。
+        return json({
+          error: `此為限量商品，請先加入${target.storeName ?? "店家"}的 LINE 官方帳號（${target.oaId}）並傳一則訊息完成綁定，再回來下單`,
+          code: "line_binding_required",
+          detail: { store_id: pickupStoreId, store_name: target.storeName, oa_id: target.oaId },
+        }, 403);
+      }
+    } catch (e) {
+      console.error("[place_member_order] line bind gate check failed, allowing order:", e);
+    }
+  }
 
   const requested = new Map<number, number>();
   for (const it of items) {
@@ -1540,6 +1691,8 @@ Deno.serve(async (req) => {
         case "get_spot_product": return await getSpotProduct(sb, tenantId, storeId, memberId, Number(body.id ?? 0));
         case "track_spot_view": if (!memberId) return json({ error: "no member_id" }, 401); return await trackSpotView(sb, tenantId, memberId, Number(body.id ?? 0));
         case "place_member_order": if (!memberId) return json({ error: "no member_id" }, 401); return await placeMemberOrder(sb, tenantId, memberId, body);
+        case "get_line_bind_state": if (!memberId) return json({ error: "no member_id" }, 401); return await getLineBindState(sb, tenantId, memberId, Number(body.store_id ?? 0) || storeId);
+        case "start_line_binding": if (!memberId) return json({ error: "no member_id" }, 401); return await startLineBinding(sb, tenantId, memberId, Number(body.store_id ?? 0) || storeId);
         default: return json({ error: `unknown action: ${action}` }, 400);
       }
     })();

--- a/supabase/functions/line-webhook/index.ts
+++ b/supabase/functions/line-webhook/index.ts
@@ -15,6 +15,7 @@
 //   驗簽（HMAC-SHA256 + channel secret），驗不過一律 403。
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.8";
+import { extractBindCode } from "../_shared/lineBinding.ts";
 
 const LINE_PROFILE_URL = "https://api.line.me/v2/bot/profile";
 const LINE_REPLY_URL = "https://api.line.me/v2/bot/message/reply";
@@ -71,6 +72,20 @@ async function inviteAccountLink(
   } catch (e) {
     console.error("inviteAccountLink error:", String(e));
     return false;
+  }
+}
+
+/** 用 replyToken 回一則純文字（免推播額度）。失敗吞掉 —— 不影響 webhook 回 200 */
+async function replyText(accessToken: string, replyToken: string, text: string): Promise<void> {
+  try {
+    const resp = await fetch(LINE_REPLY_URL, {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${accessToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ replyToken, messages: [{ type: "text", text }] }),
+    });
+    if (!resp.ok) console.error("replyText failed:", resp.status, await resp.text());
+  } catch (e) {
+    console.error("replyText error:", String(e));
   }
 }
 
@@ -250,6 +265,52 @@ Deno.serve(async (req) => {
         .from("store_line_followers")
         .upsert(row, { onConflict: "store_id,line_user_id", ignoreDuplicates: false });
       if (upErr) console.error("binding upsert failed:", upErr.message);
+
+      // ── 綁定碼（限量商品下單前的一鍵綁定）────────────────────────────────
+      // 商城端（liff-api start_line_binding）發碼並預填在訊息裡，會員按送出
+      // 就會走到這裡：核銷綁定碼、把這個 OA provider 的 line_user_id 連上會員。
+      // 效果等同 account link，但不用經過 LINE 的 accountLink 對話框。
+      // 一定要放在上面的名冊 upsert 之後（那段順手補 display_name），
+      // 並在 account link 邀請之前 —— 綁定訊息不該再收到「查看我的訂單」邀請。
+      const msgText = type === "message" && (ev.message as Record<string, unknown> | undefined)?.type === "text"
+        ? String((ev.message as Record<string, unknown>).text ?? "")
+        : "";
+      const bindCode = msgText ? extractBindCode(msgText) : null;
+      if (bindCode) {
+        const { data: codeRow } = await sb
+          .from("line_binding_codes")
+          .select("id, member_id, expires_at")
+          .eq("code", bindCode)
+          .eq("store_id", cred.store_id)
+          .is("used_at", null)
+          .maybeSingle();
+        const valid = !!codeRow && Date.parse(codeRow.expires_at) > Date.now();
+        if (valid) {
+          const { error: bindErr } = await sb.from("store_line_followers").upsert({
+            tenant_id: cred.tenant_id,
+            store_id: cred.store_id,
+            line_user_id: lineUserId,
+            member_id: codeRow.member_id,
+            followed: true,
+            linked_at: at,
+            last_event_at: at,
+          }, { onConflict: "store_id,line_user_id" });
+          if (bindErr) console.error("bind-code link failed:", bindErr.message);
+          else {
+            await sb.from("line_binding_codes")
+              .update({ used_at: new Date().toISOString(), line_user_id: lineUserId })
+              .eq("id", codeRow.id);
+          }
+        }
+        // 回覆是加值，不是綁定成立的條件：沒 token / reply 失敗，App 端輪詢照樣看得到結果
+        const bindReplyToken = ev.replyToken as string | undefined;
+        if (bindReplyToken && cred.access_token) {
+          await replyText(cred.access_token, bindReplyToken, valid
+            ? "✅ 綁定完成！請回到商城，繼續完成下單。"
+            : "這個綁定碼已過期或無效，請回到商城重新按一次「送出訂單」取得新的綁定訊息。");
+        }
+        continue;
+      }
 
       // 還不知道他是哪位會員 → 回一則帶 account link 的「查看我的訂單」。
       // 只在有 replyToken 時做（reply 免額度，且 linkToken 只有 10 分鐘效期，

--- a/supabase/migrations/20260822000000_line_binding_codes.sql
+++ b/supabase/migrations/20260822000000_line_binding_codes.sql
@@ -1,0 +1,55 @@
+-- ============================================================================
+-- 2026-08-22: line_binding_codes —— 限量商品下單前的「店家 LINE 一鍵綁定」
+--
+-- 問題：會員拿到商城連結、LINE Login 登入就能下單，但店家沒有他的聯絡方式，
+-- 棄單就找不到人。既有的 account link 綁定（line-webhook 邀請 → /link 頁）
+-- 只有「會員主動傳訊息給店家 OA」才會啟動，覆蓋不到下單這條路。
+--
+-- 解法：會員在商城按「下單限量商品」時，liff-api（start_line_binding）發一組
+-- 綁定碼，前端開店家 OA 對話並預填「綁定碼：XXXXXX」訊息；會員按送出（順手
+-- 加了好友），line-webhook 收到訊息、比對這張表，直接把該 OA provider 的
+-- line_user_id 連上會員（寫 store_line_followers.member_id）—— 效果等同
+-- account link，但不用經過 LINE 的 accountLink 對話框，一則訊息就完成。
+--
+-- 這張表只有 edge function（service_role）讀寫：
+--   liff-api  start_line_binding：發碼（同會員同店 30 分鐘內重複使用同一組）
+--   line-webhook：訊息帶碼 → 核銷（used_at + line_user_id）並完成綁定
+-- 前端拿不到別人的碼（無 RLS policy = anon / authenticated 全零列），
+-- 碼本身也只是「這位會員要綁這家店」的一次性憑據，不含任何敏感資料。
+--
+-- Rollback：DROP TABLE IF EXISTS line_binding_codes;
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS line_binding_codes (
+  id           BIGSERIAL   PRIMARY KEY,
+  tenant_id    UUID        NOT NULL,
+  member_id    BIGINT      NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+  store_id     BIGINT      NOT NULL REFERENCES stores(id) ON DELETE CASCADE,
+  code         TEXT        NOT NULL,
+  -- 核銷時回填：送出綁定訊息的那個 LINE 使用者（該店 OA provider 的 ID）
+  line_user_id TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at   TIMESTAMPTZ NOT NULL,
+  used_at      TIMESTAMPTZ
+);
+
+COMMENT ON TABLE line_binding_codes IS
+  '限量商品下單前的 LINE 綁定碼。liff-api 發碼、line-webhook 核銷；只有 service_role 讀寫';
+COMMENT ON COLUMN line_binding_codes.code IS
+  '預填進 OA 訊息的一次性綁定碼（6 碼，去除易混淆字元）。活著的碼全域唯一';
+COMMENT ON COLUMN line_binding_codes.line_user_id IS
+  '核銷時回填：送碼進來的 LINE 使用者（店家 OA provider 的 ID），除錯 / 稽核用';
+
+-- 活著的碼（還沒核銷）全域唯一 —— webhook 只憑 code + store 就要找得到唯一一筆。
+-- 過期未用的碼會繼續佔號到被核銷或刪除；發碼端撞號時重生一組即可（機率極低）。
+CREATE UNIQUE INDEX IF NOT EXISTS idx_line_binding_codes_active_code
+  ON line_binding_codes (code) WHERE used_at IS NULL;
+
+-- 發碼端查「這位會員在這家店有沒有還活著的碼」（重複按下單不重發）
+CREATE INDEX IF NOT EXISTS idx_line_binding_codes_member_active
+  ON line_binding_codes (member_id, store_id) WHERE used_at IS NULL;
+
+-- 前端一律讀不到：不給任何 policy，service_role bypass 不受影響
+-- （同 store_line_oa_credentials 的做法，見 20260807000030）
+ALTER TABLE line_binding_codes ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON line_binding_codes FROM anon, authenticated;


### PR DESCRIPTION
## 做了什麼

會員拿商城連結 LINE Login 登入就能下單，但店家沒有聯絡方式，棄單找不到人。本 PR 把既有的「LINE@ 到貨通知」綁定拉高成**限量商品的下單門檻**，且做成一鍵完成：

- 會員按「送出訂單」→ 若是限量團且未綁定，彈出綁定視窗 → 開店家 OA 對話（訊息含綁定碼、已預填）→ 會員按一次「送出」（順手加了好友）→ webhook 核銷綁定 → 商城**自動重送同一張訂單**。會員不需要理解「綁定」是什麼。
- 真正全程無感做不到（LINE 不允許代加好友 / 代發訊息），這已是平台允許的最短路徑。
- 綁定寫進 `store_line_followers.member_id`，跟到貨通知推播是同一本名冊 —— 綁完店家就推得到他、棄單也聯絡得到。

實作（會員端 + 後端）：

- 新表 `line_binding_codes`（service_role only）：`liff-api` 發碼、`line-webhook` 核銷；訊息格式與解析收在 `_shared/lineBinding.ts` 一處。
- `liff-api`：`place_member_order` 對限量團擋未綁定（判準同商城「限量搶購」分頁：`fast`/`limited` 或非 `food_train` 設了總量/單品上限）；新 action `start_line_binding` / `get_line_bind_state`。
- `line-webhook`：訊息帶「綁定碼：XXXXXX」→ 直接把該 OA provider 的 `line_user_id` 連上會員（效果同 account link，免對話框），replyToken 回覆確認（免推播額度）。
- 會員端：`LineBindGate` 彈窗（開 OA 對話 + 輪詢 + 自動重送）；`callLiffApi` 錯誤物件帶出 `code` 欄位。

後台（第二個 commit）：

- 會員列表：綠色「LINE」徽章維持（登入綁定），另加 teal「訊息」徽章 = `store_line_followers` 已配對（推播 / 限量閘門認的那本名冊）。
- 會員詳細頁新增獨立「店家 LINE 訊息綁定」卡片：顯示綁定的 LINE 身分（名稱 / 頭像 / 綁定時間 / 封鎖警示）＋**解除綁定**；未綁時可展開名冊挑人**綁定**（原本只藏在「發送 LINE 訊息」彈窗、推不到才出現）。
- 配對選單抽成 `LineFollowerPicker` 共用（發訊息彈窗改用同一份）；綁定 / 解除沿用既有 `rpc_bind_store_line_follower` / `rpc_unbind_store_line_follower`，後台部分零 migration。

## 上線危險

- 做了：限量團 + 未綁定 + 取貨店有 OA 憑證 → 下單回 403（可循指示綁定後通過）。**線上此刻 0 個進行中限量團**，合併前後都不會有人被擋。
- 不做：店家沒設 OA 或沒設 channel 憑證 → 不擋（擋了也無路可綁）；閘門查詢失敗一律放行（商業規則，不是安全邊界）；非限量團完全不受影響；既有 373 位已綁定會員直接通過。後台徽章 / 卡片是唯讀查詢＋既有 RPC，無新權限面。
- 回退：revert 本 PR + 重部署 `liff-api`（閘門就消失）；`DROP TABLE line_binding_codes`（獨立新表，無人相依）。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- migration 已於 2026-08-22 套上正式庫（Management API），`line_binding_codes` 表 + 3 個索引確認存在；SQL 過 `check-sql-syntax.cjs`。
- `liff-api` / `line-webhook` 已部署（HTTP 201、status ACTIVE）；OPTIONS preflight 200、無 auth POST 回函式自家錯誤（非 gateway 404）。
- `apps/member`、`apps/admin` `npm run build` 皆通過（含 Safari 15.6 bundle 檢查）。
- 後台 UI 走 `apps/admin:verify` 流程（Playwright + fixture 假登入）：列表徽章有/無、已綁卡片 + 解除按鈕、未綁 → 名冊挑人 → confirm → `rpc_bind_store_line_follower` 實際被呼叫，全數通過。
- 線上唯讀查核：14 家店設了 OA、其中 13 家憑證齊全（閘門生效範圍）；進行中限量團 0 個；已綁定會員 373 位。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBcSE7o1wE6vXJaiP8VrXq