### PR TITLE
開團編輯的「收單類型」下拉加「漂漂館」選項

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -444,7 +444,7 @@ export default function CampaignsListPage() {
   async function openEdit(id: number) {
     const { data, error: err } = await getSupabase()
       .from("group_buy_campaigns")
-      .select("id, campaign_no, name, description, status, close_type, start_at, end_at, pickup_deadline, pickup_days, total_cap_qty, notes, is_for_shop")
+      .select("id, campaign_no, name, description, status, close_type, start_at, end_at, pickup_deadline, pickup_days, total_cap_qty, notes, is_for_shop, sales_channel")
       .eq("id", id).maybeSingle();
     if (err || !data) { setError(err?.message ?? "找不到開團"); return; }
     setModal({
@@ -456,6 +456,7 @@ export default function CampaignsListPage() {
         description: data.description,
         status: data.status as CampaignFormValues["status"],
         close_type: data.close_type as CampaignFormValues["close_type"],
+        sales_channel: data.sales_channel === "piaopiao" ? "piaopiao" : "main",
         start_at: data.start_at,
         end_at: data.end_at,
         pickup_deadline: data.pickup_deadline,
@@ -520,7 +521,9 @@ export default function CampaignsListPage() {
           q = q.or(`name.ilike.%${safe}%,campaign_no.ilike.%${safe}%`);
         }
         if (status) q = q.eq("status", status);
-        if (closeTypeFilter) q = q.eq("close_type", closeTypeFilter);
+        // 「漂漂館」不是 close_type，是 sales_channel（與編輯 modal 的下拉同一套語意）
+        if (closeTypeFilter === "piaopiao") q = q.eq("sales_channel", "piaopiao");
+        else if (closeTypeFilter) q = q.eq("close_type", closeTypeFilter);
 
         const { data, count, error } = await q;
         if (cancelled) return;
@@ -852,6 +855,7 @@ export default function CampaignsListPage() {
             <option value="fast">快團</option>
             <option value="limited">限量</option>
             <option value="food_train">美食列車</option>
+            <option value="piaopiao">漂漂館</option>
           </select>
         </div>
       )}

--- a/apps/admin/src/components/CampaignForm.tsx
+++ b/apps/admin/src/components/CampaignForm.tsx
@@ -9,6 +9,9 @@ import { CAMPAIGN_STATUS_LABEL, type CampaignStatus } from "@/lib/campaignStatus
 
 export type { CampaignStatus };
 export type CloseType = "regular" | "fast" | "limited" | "food_train";
+// 漂漂館不是 close_type（DB 欄位註解明寫），是 sales_channel='piaopiao'。
+// UI 上併進「收單類型」下拉：選「漂漂館」= close_type='regular' + sales_channel='piaopiao'。
+export type SalesChannel = "main" | "piaopiao";
 
 export type CampaignFormValues = {
   id: number | null;
@@ -17,6 +20,7 @@ export type CampaignFormValues = {
   description: string | null;
   status: CampaignStatus;
   close_type: CloseType;
+  sales_channel: SalesChannel;
   start_at: string | null;
   end_at: string | null;
   pickup_deadline: string | null;
@@ -33,6 +37,7 @@ export const emptyCampaignValues: CampaignFormValues = {
   description: null,
   status: "draft",
   close_type: "regular",
+  sales_channel: "main",
   start_at: null,
   end_at: null,
   pickup_deadline: null,
@@ -125,6 +130,7 @@ export function CampaignForm({
         p_total_cap_qty: v.total_cap_qty,
         p_notes: v.notes,
         p_is_for_shop: v.is_for_shop,
+        p_sales_channel: v.sales_channel,
       });
       if (err) throw err;
       const newId = Number(data);
@@ -182,12 +188,29 @@ export function CampaignForm({
         </Field>
 
         <Field label="收單類型">
-          <select value={v.close_type} onChange={(e) => update("close_type", e.target.value as CloseType)} className={inputCls}>
+          <select
+            value={v.sales_channel === "piaopiao" ? "piaopiao" : v.close_type}
+            onChange={(e) => {
+              const val = e.target.value;
+              if (val === "piaopiao") {
+                setV((prev) => ({ ...prev, close_type: "regular", sales_channel: "piaopiao" }));
+              } else {
+                setV((prev) => ({ ...prev, close_type: val as CloseType, sales_channel: "main" }));
+              }
+            }}
+            className={inputCls}
+          >
             <option value="regular">常規</option>
             <option value="fast">快團</option>
             <option value="limited">限量</option>
             <option value="food_train">美食列車</option>
+            <option value="piaopiao">漂漂館</option>
           </select>
+          {v.sales_channel === "piaopiao" && (
+            <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400">
+              漂漂館的團只出現在漂漂館專區，不會出現在主商城。
+            </p>
+          )}
           {v.close_type === "food_train" && v.status === "open" && (initial?.status ?? null) !== "open" && (
             <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400">
               儲存後將推播給所有未取消通知的顧客。

--- a/supabase/migrations/20260822001000_upsert_campaign_sales_channel.sql
+++ b/supabase/migrations/20260822001000_upsert_campaign_sales_channel.sql
@@ -1,0 +1,95 @@
+-- ============================================================================
+-- rpc_upsert_campaign 收入 15 參數 (加 p_sales_channel)
+--
+-- 開團編輯 modal 的「收單類型」下拉加「漂漂館」選項。漂漂館不是 close_type
+-- (見 20260820000100 的欄位註解)，而是 sales_channel='piaopiao'；前端把該
+-- 選項映射成 close_type='regular' + sales_channel='piaopiao'，所以本 RPC
+-- 需要能寫 sales_channel。
+--
+-- 基底版本：20260629000000_campaign_is_for_shop.sql (14 參數版)，
+-- 僅新增 p_sales_channel，其餘行為不變。rollback 指回 20260629000000。
+--
+-- p_sales_channel 語意：
+--   NULL   = insert 時取 'main'；update 時保留原值 (舊呼叫端不受影響，
+--            quick-control / 從商品開團 都沒帶此參數)
+--   'main' / 'piaopiao' = 明確指定；其他值直接擋下
+-- ============================================================================
+
+-- 用動態 DROP 處理所有 overload (14 / 15 參數版本都清掉, 避免 ambiguous)
+DO $$
+DECLARE r RECORD;
+BEGIN
+  FOR r IN
+    SELECT oid::regprocedure::text AS sig
+      FROM pg_proc WHERE proname = 'rpc_upsert_campaign'
+  LOOP
+    EXECUTE 'DROP FUNCTION ' || r.sig;
+  END LOOP;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.rpc_upsert_campaign(
+  p_id               BIGINT,
+  p_campaign_no      TEXT,
+  p_name             TEXT,
+  p_description      TEXT        DEFAULT NULL,
+  p_cover_image_url  TEXT        DEFAULT NULL,
+  p_status           TEXT        DEFAULT 'draft',
+  p_close_type       TEXT        DEFAULT 'regular',
+  p_start_at         TIMESTAMPTZ DEFAULT NULL,
+  p_end_at           TIMESTAMPTZ DEFAULT NULL,
+  p_pickup_deadline  DATE        DEFAULT NULL,
+  p_pickup_days      INTEGER     DEFAULT NULL,
+  p_total_cap_qty    NUMERIC     DEFAULT NULL,
+  p_notes            TEXT        DEFAULT NULL,
+  p_is_for_shop      BOOLEAN     DEFAULT TRUE,
+  p_sales_channel    TEXT        DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_id     BIGINT;
+BEGIN
+  IF p_sales_channel IS NOT NULL AND p_sales_channel NOT IN ('main', 'piaopiao') THEN
+    RAISE EXCEPTION 'invalid sales_channel: %', p_sales_channel;
+  END IF;
+
+  IF p_id IS NULL THEN
+    INSERT INTO group_buy_campaigns (
+      tenant_id, campaign_no, name, description, cover_image_url,
+      status, close_type, start_at, end_at, pickup_deadline, pickup_days,
+      total_cap_qty, notes, is_for_shop, sales_channel, created_by, updated_by
+    ) VALUES (
+      v_tenant, p_campaign_no, p_name, p_description, p_cover_image_url,
+      COALESCE(p_status,'draft'), COALESCE(p_close_type,'regular'),
+      p_start_at, p_end_at, p_pickup_deadline, p_pickup_days,
+      p_total_cap_qty, p_notes, COALESCE(p_is_for_shop, TRUE),
+      COALESCE(p_sales_channel, 'main'),
+      auth.uid(), auth.uid()
+    ) RETURNING id INTO v_id;
+  ELSE
+    UPDATE group_buy_campaigns SET
+      campaign_no = COALESCE(p_campaign_no, campaign_no),
+      name = COALESCE(p_name, name),
+      description = p_description,
+      cover_image_url = p_cover_image_url,
+      status = COALESCE(p_status, status),
+      close_type = COALESCE(p_close_type, close_type),
+      start_at = p_start_at,
+      end_at = p_end_at,
+      pickup_deadline = p_pickup_deadline,
+      pickup_days = p_pickup_days,
+      total_cap_qty = p_total_cap_qty,
+      notes = p_notes,
+      is_for_shop = COALESCE(p_is_for_shop, is_for_shop),
+      sales_channel = COALESCE(p_sales_channel, sales_channel),
+      updated_by = auth.uid()
+    WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'campaign % not in tenant', p_id; END IF;
+  END IF;
+  RETURN v_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_upsert_campaign TO authenticated;


### PR DESCRIPTION
## 做了什麼

開團編輯 modal 的「收單類型」下拉加第 5 個選項「漂漂館」。漂漂館不是 `close_type`（20260820000100 欄位註解明寫「不是 close_type，不能拿一般團代替」），是 `sales_channel='piaopiao'`，所以不新開 close_type 值，而是把下拉做成合一選單：

- 選「漂漂館」＝ `close_type='regular'` + `sales_channel='piaopiao'`；選其他類型寫回 `sales_channel='main'`
- 外部上架入口建的團（regular + piaopiao）在編輯 modal 正確回顯「漂漂館」；後台選了漂漂館的團會真的進到漂漂館專區（會員端本來就依 `sales_channel` 分流：主商城只撈 main、`/piaopiao` 只撈 piaopiao）
- `/campaigns` 列表的類型篩選同步加「漂漂館」（映射到 `sales_channel`）
- migration `20260822001000`：`rpc_upsert_campaign` 收入 15 參數（加 `p_sales_channel`）。基底 20260629000000（14 參數版），rollback 指回該版

## 上線危險

- 做了：`rpc_upsert_campaign` DROP 舊 overload 後重建為 15 參數；`p_sales_channel` NULL 時 insert 取 'main'、update 保留原值，舊呼叫端（quick-control、從商品開團）不帶此參數、行為不變
- 不做：不動 close_type CHECK、不動任何既有團資料、不動會員端
- 回退：重跑 20260629000000 的函式定義（14 參數版）＋ revert 前端

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `scripts/check-sql-syntax.cjs` 過（parse + parsePlpgsql）
- migration 已套上正式庫（Management API），`pg_proc` 確認單一 overload、15 參數
- `tsc --noEmit` 乾淨；eslint 僅既有舊錯誤（未動的行）
- Playwright + fixture（apps/admin verify 流程）：main 團回顯「常規」→ 選「漂漂館」出現提示、送出帶 `p_sales_channel='piaopiao'` + `p_close_type='regular'`；piaopiao 團回顯「漂漂館」→ 改回「常規」送出 `p_sales_channel='main'`。全過


---
_Generated by [Claude Code](https://claude.ai/code/session_01MAiFwFnWtfpkKZJnqNyha3)_