### PR TITLE
商城 banner 文案不再被倒數膠囊擋住：標題獨占整行

### DIFF
--- a/apps/member/src/app/shop/page.tsx
+++ b/apps/member/src/app/shop/page.tsx
@@ -871,20 +871,22 @@ function FoodTrainItemBanner({ campaign }: { campaign: CampaignSummary }) {
               <span className="text-[14px] font-bold text-white">美食列車</span>
             </span>
           </div>
-          <div className="flex items-end justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              <div className="line-clamp-1 text-[17px] font-bold text-white drop-shadow">
-                {cleanCampaignText(campaign.name)}
-              </div>
+          <div className="space-y-1">
+            {/* 標題獨占整行 —— 跟倒數膠囊同列的話，左欄會被膠囊寬度
+                （帶「天」約 150px）壓到只剩幾個字，文案被擋住。 */}
+            <div className="line-clamp-2 text-[17px] font-bold leading-snug text-white drop-shadow">
+              {cleanCampaignText(campaign.name)}
+            </div>
+            <div className="flex items-center justify-between gap-3">
               <div className="text-[24px] font-extrabold tabular-nums text-white drop-shadow">
                 {priceText(campaign)}
               </div>
+              {campaign.end_at && (
+                <div className="shrink-0 rounded-full bg-black/35 px-2.5 py-1 text-[13px] font-semibold tabular-nums text-white backdrop-blur">
+                  <Countdown target={campaign.end_at} compact />
+                </div>
+              )}
             </div>
-            {campaign.end_at && (
-              <div className="shrink-0 rounded-full bg-black/35 px-2.5 py-1 text-[13px] font-semibold tabular-nums text-white backdrop-blur">
-                <Countdown target={campaign.end_at} compact />
-              </div>
-            )}
           </div>
         </div>
       </div>
@@ -915,20 +917,21 @@ function FlashItemBanner({ campaign }: { campaign: CampaignSummary }) {
               <span className="text-[14px] font-bold text-white">限時</span>
             </span>
           </div>
-          <div className="flex items-end justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              <div className="line-clamp-1 text-[17px] font-bold text-white drop-shadow">
-                {cleanCampaignText(campaign.name)}
-              </div>
+          <div className="space-y-1">
+            {/* 標題獨占整行（理由同 FoodTrainItemBanner：跟倒數膠囊同列會被壓爛） */}
+            <div className="line-clamp-2 text-[17px] font-bold leading-snug text-white drop-shadow">
+              {cleanCampaignText(campaign.name)}
+            </div>
+            <div className="flex items-center justify-between gap-3">
               <div className="text-[24px] font-extrabold tabular-nums text-white drop-shadow">
                 {priceText(campaign)}
               </div>
+              {campaign.end_at && (
+                <div className="shrink-0 rounded-full bg-black/35 px-2.5 py-1 text-[13px] font-semibold tabular-nums text-white backdrop-blur">
+                  <Countdown target={campaign.end_at} compact />
+                </div>
+              )}
             </div>
-            {campaign.end_at && (
-              <div className="shrink-0 rounded-full bg-black/35 px-2.5 py-1 text-[13px] font-semibold tabular-nums text-white backdrop-blur">
-                <Countdown target={campaign.end_at} compact />
-              </div>
-            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 問題

商城首頁頂部輪播的單團 banner（美食列車 / 限時），標題與價格擠在倒數膠囊旁邊的左欄。帶「天」的倒數膠囊約 150px 寬，把標題壓到只剩 7 個字：畫面顯示「金山老街人氣古...」，右側卻是一大片空白（實際團名「金山老街人氣古早味蜜地瓜 240g」）。

## 修法

`FoodTrainItemBanner` / `FlashItemBanner` 版型調整（純前端、零 SQL）：

- 標題獨占整行，`line-clamp-1` 放寬為 `line-clamp-2`，長團名顯示得完
- 價格與倒數膠囊改為同一列（左價格、右倒數）

`FoodTrainStackBanner`（群組模式）倒數本來就在右上、標題整行，不用動。

## 驗證

- `tsc --noEmit` 通過

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUbgk1EjcdUmFNkcQmtWvx)_