### PR TITLE
轉貨出去之後「查無此事」：追加轉入補上 order↔order 連結表（含回填），自由轉貨建單頁不再導去分店看不到的頁

### DIFF
--- a/apps/admin/src/app/(protected)/transfers/free/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/free/page.tsx
@@ -13,7 +13,7 @@ export default function FreeTransferPage() {
         <h1 className="text-xl font-semibold">自由轉貨</h1>
       </header>
       <FreeTransferCreateForm
-        onCreated={(id) => router.push(`/hq/inbox?source=transfer&id=${id}`)}
+        onCreated={(id) => router.push(`/wms/transfers?open=${id}`)}
         onCancel={() => router.back()}
       />
     </div>

--- a/apps/admin/src/app/(protected)/transfers/print-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/print-aid/page.tsx
@@ -22,6 +22,7 @@ import { getSupabase } from "@/lib/supabase";
 import { getTenantName } from "@/lib/tenant";
 import { useAuth } from "@/components/AuthProvider";
 import SpinButton from "@/components/SpinButton";
+import { TRANSFER_LINK_SELECT, type TransferLink, linkItems } from "@/lib/aidTransfer";
 
 type SkuRef = { sku_code: string | null; product_name: string | null; variant_name: string | null };
 
@@ -91,6 +92,9 @@ export default function AidTransferPrintPage() {
 function Body() {
   const sp = useSearchParams();
   const orderId = Number(sp.get("order_id"));
+  // 這一趟轉移（customer_order_transfer_links.id）。追加轉入會把好幾家店的貨
+  // 併進同一張轉入單，不指定就會把別家店的品項也印進來、來源店也標成別人。
+  const linkId = Number(sp.get("link")) || null;
   const copiesParam = sp.get("copies") ?? "driver,stub";
   const copies: CopyKind[] = useMemo(() => {
     const raw = copiesParam.split(",").map((s) => s.trim()).filter(Boolean);
@@ -139,10 +143,39 @@ function Body() {
       // 互助品項一律是 source='aid_transfer'；混到別的來源（同一張單後來又加了團購品項）
       // 時只印互助那些 —— 出貨店裝箱時不該把不屬於這次互助的貨也寄出去。
       const aidItems = active.filter((it) => it.source === "aid_transfer");
-      setItems(aidItems.length > 0 ? aidItems : active);
+
+      // 指定了 link → 只印那一趟搬過去的品項，來源店也從那條連結拿。
+      // 沒指定（舊連結／手動開網址）→ 沿用整張單的舊行為。
+      let link: TransferLink | null = null;
+      let linkSourceStore: string | null = null;
+      if (linkId != null) {
+        const { data: lRow } = await sb
+          .from("customer_order_transfer_links")
+          .select(
+            TRANSFER_LINK_SELECT +
+              ", src:customer_orders!customer_order_transfer_links_source_order_id_fkey(" +
+              "store:stores!customer_orders_pickup_store_id_fkey(name))",
+          )
+          .eq("id", linkId)
+          .eq("dest_order_id", orderId)
+          .maybeSingle();
+        if (cancelled) return;
+        const l = lRow as unknown as
+          (TransferLink & { src: { store: { name: string } | { name: string }[] | null } | null }) | null;
+        if (l) {
+          link = l;
+          const st = l.src?.store;
+          linkSourceStore = (Array.isArray(st) ? st[0]?.name : st?.name) ?? null;
+        }
+      }
+
+      const scoped = link ? linkItems(link, active) : [];
+      setItems(scoped.length > 0 ? scoped : aidItems.length > 0 ? aidItems : active);
 
       // 來源店（貨從哪一家出去）
-      if (h.transferred_from_order_id != null) {
+      if (linkSourceStore != null) {
+        setSourceStore(linkSourceStore);
+      } else if (h.transferred_from_order_id != null) {
         const { data: srcRow } = await sb
           .from("customer_orders")
           .select("store:stores!customer_orders_pickup_store_id_fkey(name)")
@@ -207,7 +240,7 @@ function Body() {
       }
     })();
     return () => { cancelled = true; };
-  }, [orderId, paramError]);
+  }, [orderId, linkId, paramError]);
 
   // PDF 存檔 / 列印對話框預設檔名 → 用訂單號
   useEffect(() => {

--- a/apps/admin/src/components/AidShipmentReminder.tsx
+++ b/apps/admin/src/components/AidShipmentReminder.tsx
@@ -30,9 +30,15 @@ import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import { printViaIframe } from "@/lib/printIframe";
 import { withBasePath } from "@/lib/basePath";
-import { AID_IN_FLIGHT_STATUSES, aidRouteLabel, aidStageLabel } from "@/lib/aidTransfer";
+import {
+  AID_IN_FLIGHT_STATUSES, TRANSFER_LINK_SELECT, type TransferLink,
+  activeQty, aidRouteLabel, aidStageLabel, linkItems,
+} from "@/lib/aidTransfer";
 
 type AidShipment = {
+  // 一列 = 一次轉移（一條 link），不是一張轉入單：追加分支會把多家店的貨併進
+  // 同一張轉入單，每家店只該看到自己那一趟。key 用 link id。
+  linkId: number;
   id: number;
   order_no: string;
   status: string;
@@ -68,63 +74,56 @@ export default function AidShipmentReminder({ storeId }: { storeId: number | nul
     (async () => {
       try {
         const sb = getSupabase();
-        // 還沒被收貨店收掉的互助轉入單（全 tenant，數量很少）
+        // 從連結表出發（不是從轉入單），一趟轉移一列 —— 追加轉入把多家店的貨
+        // 併進同一張轉入單時，每家店都要看得到自己那一趟（見 lib/aidTransfer 的說明）
         const { data } = await sb
-          .from("customer_orders")
+          .from("customer_order_transfer_links")
           .select(
-            "id, order_no, status, is_air_transfer, pickup_store_id, transferred_from_order_id, created_at, " +
+            TRANSFER_LINK_SELECT + ", " +
+              "src:customer_orders!customer_order_transfer_links_source_order_id_fkey(" +
+              "pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)), " +
+              // !inner + dest.status 篩選要在**伺服端**做：連結表只增不減
+              // （567 筆起跳、每次轉單再加一列），拉回來才在前端濾會愈來愈慢，
+              // 而且一旦超過 limit 就會靜默漏掉最舊的那幾筆 —— 提醒漏掉＝貨沒人送
+              "dest:customer_orders!customer_order_transfer_links_dest_order_id_fkey!inner(" +
+              "id, order_no, status, pickup_store_id, " +
               "store:stores!customer_orders_pickup_store_id_fkey(name), " +
-              "items:customer_order_items!inner(qty, status, source)",
+              "items:customer_order_items(id, qty, status, source))",
           )
-          .eq("items.source", "aid_transfer")
-          .in("status", [...AID_IN_FLIGHT_STATUSES])
-          .not("transferred_from_order_id", "is", null)
-          .order("created_at", { ascending: true })
-          .limit(200);
+          .in("dest.status", [...AID_IN_FLIGHT_STATUSES])
+          .order("transferred_at", { ascending: true })
+          .limit(500);
         if (cancelled) return;
-        type Raw = {
-          id: number; order_no: string; status: string; is_air_transfer: boolean | null;
-          pickup_store_id: number | null; transferred_from_order_id: number;
-          store: { name: string } | { name: string }[] | null;
-          items: { qty: number; status: string; source: string | null }[] | null;
+        type StoreRef = { name: string } | { name: string }[] | null;
+        type Raw = TransferLink & {
+          src: { pickup_store_id: number | null; store: StoreRef } | null;
+          dest: {
+            id: number; order_no: string; status: string; pickup_store_id: number | null;
+            store: StoreRef;
+            items: { id: number; qty: number; status: string; source: string | null }[] | null;
+          } | null;
         };
         const raw = (data ?? []) as unknown as Raw[];
-        if (raw.length === 0) { setRows([]); return; }
-
-        // 來源單 → 出貨店（貨從誰手上出去）
-        const srcIds = Array.from(new Set(raw.map((r) => r.transferred_from_order_id)));
-        const { data: srcData } = await sb
-          .from("customer_orders")
-          .select("id, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)")
-          .in("id", srcIds);
-        if (cancelled) return;
-        type SrcRaw = {
-          id: number; pickup_store_id: number | null;
-          store: { name: string } | { name: string }[] | null;
-        };
-        const nameOf = (s: { name: string } | { name: string }[] | null) =>
-          (Array.isArray(s) ? s[0]?.name : s?.name) ?? "—";
-        const srcMap = new Map<number, SrcRaw>(
-          ((srcData ?? []) as unknown as SrcRaw[]).map((s) => [s.id, s]),
-        );
+        const nameOf = (s: StoreRef) => (Array.isArray(s) ? s[0]?.name : s?.name) ?? "—";
 
         const list = raw.flatMap((r): AidShipment[] => {
-          const src = srcMap.get(r.transferred_from_order_id);
-          if (!src) return [];
+          const src = r.src, dest = r.dest;
+          if (!src || !dest) return [];
+          // 收貨店收掉（ready 之後）就沒人需要為它做事了
+          if (!(AID_IN_FLIGHT_STATUSES as readonly string[]).includes(dest.status)) return [];
           // 同店轉單（只是換客人）貨沒離開本店，不用出貨也不用收貨
-          if (src.pickup_store_id === r.pickup_store_id) return [];
+          if (src.pickup_store_id === dest.pickup_store_id) return [];
           // 品項全被取消掉的單沒有實體貨在走，別再叫人去印一張空白單
-          const qty = (r.items ?? [])
-            .filter((it) => !["cancelled", "expired"].includes(it.status))
-            .reduce((s, it) => s + Number(it.qty), 0);
+          const qty = activeQty(linkItems(r, dest.items ?? []));
           if (qty <= 0) return [];
           return [{
-            id: r.id,
-            order_no: r.order_no,
-            status: r.status,
+            linkId: r.id,
+            id: dest.id,
+            order_no: dest.order_no,
+            status: dest.status,
             is_air_transfer: r.is_air_transfer === true,
-            dest_store: nameOf(r.store),
-            dest_store_id: r.pickup_store_id,
+            dest_store: nameOf(dest.store),
+            dest_store_id: dest.pickup_store_id,
             source_store: nameOf(src.store),
             source_store_id: src.pickup_store_id,
             qty,
@@ -251,7 +250,7 @@ function AidSection({
       <ul className="mt-3 space-y-2">
         {rows.map((r) => (
           <li
-            key={r.id}
+            key={r.linkId}
             className={`flex flex-wrap items-center gap-x-3 gap-y-1 rounded border bg-white px-3 py-2 text-sm dark:bg-zinc-900 ${t.item}`}
           >
             <span className="font-mono text-xs">{r.order_no}</span>
@@ -264,7 +263,7 @@ function AidSection({
             <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
               {aidRouteLabel(r.is_air_transfer)}・{aidStageLabel(r.status, r.is_air_transfer)}
             </span>
-            {showPrinted && printed.has(r.id) && (
+            {showPrinted && printed.has(r.linkId) && (
               <span className="text-[11px] text-emerald-600 dark:text-emerald-400">✓ 已列印</span>
             )}
             <div className="ml-auto flex items-center gap-2">
@@ -289,8 +288,12 @@ function AidSection({
               </Link>
               <SpinButton
                 onClick={async () => {
-                  onPrinted(r.id);
-                  await printViaIframe(withBasePath(`/transfers/print-aid?order_id=${r.id}`));
+                  onPrinted(r.linkId);
+                  // 一定要帶 link：同一張轉入單可能併了好幾家店的貨，
+                  // 只帶 order_id 會把別家店的品項也印進這張隨貨單
+                  await printViaIframe(
+                    withBasePath(`/transfers/print-aid?order_id=${r.id}&link=${r.linkId}`),
+                  );
                 }}
                 className={`rounded-md border bg-white px-3 py-1 text-xs font-medium dark:bg-zinc-900 ${t.button}`}
                 title="列印互助出貨單（司機聯 + 店家存根聯），格式跟內部調撥的轉貨單一樣"

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -19,7 +19,10 @@ import { summarizeOrderSource } from "@/lib/orderSource";
 import { ItemSourceBadge, OrderSourceBadge } from "@/components/OrderSourceBadge";
 import { withBasePath } from "@/lib/basePath";
 import { printViaIframe } from "@/lib/printIframe";
-import { aidRouteLabel, aidStageLabel, isAidInFlight } from "@/lib/aidTransfer";
+import {
+  TRANSFER_LINK_SELECT, type TransferLink,
+  activeQty, aidRouteLabel, aidStageLabel, isAidInFlight, linkItems,
+} from "@/lib/aidTransfer";
 import { internalOrderSource } from "@/lib/orderTitle";
 import { translateRpcError } from "@/lib/rpcError";
 import { parseReturnNote } from "@/lib/returnNote";
@@ -114,6 +117,10 @@ type PendingAirShipment = {
 // 「貨從店裡出去了、系統上查無此事」（2026-08-18 南平→三峽）。
 // 頂部那排列印鈕另外只取還在路上的（isAidInFlight），不用舊單洗版。
 type OutgoingAidOrder = {
+  // 一列 = 一趟轉移（customer_order_transfer_links.id），不是一張轉入單：
+  // 追加轉入會把好幾趟（甚至好幾家店）的貨併進同一張轉入單，本店只該看到
+  // 自己那幾趟、印出來也只有自己那幾件（見 lib/aidTransfer）
+  link_id: number;
   id: number;
   order_no: string;
   // 收貨店 —— 連到訂單列表時一定要一起帶（列表的門市篩選對分店帳號會預設帶回自家店，
@@ -321,11 +328,19 @@ export function OrderDetail({
         //   2. 收貨店還沒收到的（pending/confirmed/shipping）→ 「🖨 出貨單」隨貨走
         //   3. 全部（含已收貨、已取消）→ 下方的「↗ 轉出記錄」。轉入單掛在收貨店名下，
         //      轉出店的訂單列表撈不到，不在這裡寫出來就等於系統上查無此事
-        // 反查 transferred_from_order_id，不要用 transferred_to_order_id：部分轉出不寫那一欄
-        sb.from("customer_orders")
-          .select("id, order_no, pickup_store_id, status, is_air_transfer, created_at, store:stores!customer_orders_pickup_store_id_fkey(name), items:customer_order_items(qty, status, source)")
-          .eq("transferred_from_order_id", orderId)
-          .order("created_at", { ascending: false }),
+        // ⚠ 走連結表，不要反查 transferred_from_order_id：那一欄只有「建新轉入單」
+        // 那條分支會寫，追加轉入（併入既有單）完全不寫 —— 2026-08-24 松山認領互助板
+        // 喜願蛋轉給古華就是走到追加，來源單上一列都撈不到（見 lib/aidTransfer）
+        sb.from("customer_order_transfer_links")
+          .select(
+            TRANSFER_LINK_SELECT + ", " +
+              "dest:customer_orders!customer_order_transfer_links_dest_order_id_fkey(" +
+              "id, order_no, pickup_store_id, status, is_air_transfer, " +
+              "store:stores!customer_orders_pickup_store_id_fkey(name), " +
+              "items:customer_order_items(id, qty, status, source))",
+          )
+          .eq("source_order_id", orderId)
+          .order("transferred_at", { ascending: false }),
       ]);
       if (cancelled) return;
       if (hRes.error) { setError(hRes.error.message); return; }
@@ -344,47 +359,52 @@ export function OrderDetail({
       setPickupEvents(pevRes.get(orderId) ?? []);
 
       // ========== 從本單轉出去的互助 / 空中轉（本單 → 其他店）==========
-      type AirRow = {
-        id: number; order_no: string; pickup_store_id: number | null;
-        status: string; is_air_transfer: boolean | null; created_at: string;
-        store: { name: string } | { name: string }[] | null;
-        items: { qty: number; status: string; source: string | null }[] | null;
+      type LinkRow = TransferLink & {
+        dest: {
+          id: number; order_no: string; pickup_store_id: number | null;
+          status: string; is_air_transfer: boolean | null;
+          store: { name: string } | { name: string }[] | null;
+          items: { id: number; qty: number; status: string; source: string | null }[] | null;
+        } | null;
       };
-      const childRows = ((airRes.data ?? []) as unknown as AirRow[])
-        // 同店轉單（換客人）不是出貨，貨沒離開本店；rpc_ship_aid_order 也會以
-        //「source/dest 同 location」擋下 —— 不算互助出貨，兩個用途都不該出現
-        .filter((r) => r.pickup_store_id !== headData.pickup_store_id)
-        // 互助品項才是真的要寄出去的貨
-        .filter((r) => (r.items ?? []).some((it) => it.source === "aid_transfer"));
-      const storeNameOf = (r: AirRow) =>
-        (Array.isArray(r.store) ? r.store[0]?.name : r.store?.name) ?? "—";
+      type OutRow = { link: LinkRow; dest: NonNullable<LinkRow["dest"]>; qty: number };
+      const childRows = ((airRes.data ?? []) as unknown as LinkRow[])
+        .flatMap((r): OutRow[] => {
+          const dest = r.dest;
+          if (!dest) return [];
+          // 同店轉單（換客人）不是出貨，貨沒離開本店；rpc_ship_aid_order 也會以
+          //「source/dest 同 location」擋下 —— 不算互助出貨，兩個用途都不該出現
+          if (dest.pickup_store_id === headData.pickup_store_id) return [];
+          // 這一趟真正搬過去的品項（不是整張轉入單），未取消的才算
+          const qty = activeQty(linkItems(r, dest.items ?? []));
+          return [{ link: r, dest, qty }];
+        });
+      const storeNameOf = (d: NonNullable<LinkRow["dest"]>) =>
+        (Array.isArray(d.store) ? d.store[0]?.name : d.store?.name) ?? "—";
       setPendingAirOut(
         childRows
-          .filter((r) => r.is_air_transfer === true && r.status === "confirmed")
-          .map((r): PendingAirShipment => ({
-            id: r.id,
-            order_no: r.order_no,
-            pickup_store_id: r.pickup_store_id,
-            store_name: storeNameOf(r),
-            qty: (r.items ?? [])
-              .filter((it) => !["cancelled", "expired"].includes(it.status))
-              .reduce((s, it) => s + Number(it.qty), 0),
+          .filter(({ link, dest }) => link.is_air_transfer === true && dest.status === "confirmed")
+          .map(({ dest, qty }): PendingAirShipment => ({
+            id: dest.id,
+            order_no: dest.order_no,
+            pickup_store_id: dest.pickup_store_id,
+            store_name: storeNameOf(dest),
+            qty,
           })),
       );
       // 轉出記錄：全部留著（含已取消的，店家要看得出「那批貨後來怎麼了」）。
       // 頂部的列印鈕另外只取還在路上的那幾張。
       setOutgoingAid(
-        childRows.map((r): OutgoingAidOrder => ({
-          id: r.id,
-          order_no: r.order_no,
-          store_id: r.pickup_store_id,
-          store_name: storeNameOf(r),
-          is_air_transfer: r.is_air_transfer === true,
-          status: r.status,
-          created_at: r.created_at,
-          qty: (r.items ?? [])
-            .filter((it) => it.source === "aid_transfer" && !["cancelled", "expired"].includes(it.status))
-            .reduce((s, it) => s + Number(it.qty), 0),
+        childRows.map(({ link, dest, qty }): OutgoingAidOrder => ({
+          link_id: link.id,
+          id: dest.id,
+          order_no: dest.order_no,
+          store_id: dest.pickup_store_id,
+          store_name: storeNameOf(dest),
+          is_air_transfer: link.is_air_transfer === true,
+          status: dest.status,
+          created_at: link.transferred_at,
+          qty,
         })),
       );
 
@@ -1045,8 +1065,10 @@ export function OrderDetail({
               經總倉的單上面就寫著最終要送到哪一家店，總倉照單轉交、不會掉 */}
           {outgoingAidInFlight.map((o) => (
             <SpinButton
-              key={`aid-print-${o.id}`}
-              onClick={() => printViaIframe(withBasePath(`/transfers/print-aid?order_id=${o.id}`))}
+              key={`aid-print-${o.link_id}`}
+              onClick={() =>
+                printViaIframe(withBasePath(`/transfers/print-aid?order_id=${o.id}&link=${o.link_id}`))
+              }
               className="rounded-md border border-fuchsia-300 px-3 py-1 text-xs font-medium text-fuchsia-700 hover:bg-fuchsia-50 dark:border-fuchsia-800 dark:text-fuchsia-300 dark:hover:bg-fuchsia-950"
               title={
                 `列印互助出貨單（${o.order_no}・${o.is_air_transfer ? "空中轉直送" : "經總倉中轉"}）：` +
@@ -1621,12 +1643,12 @@ export function OrderDetail({
       {outgoingAid.length > 0 && (
         <div className="rounded-md border border-fuchsia-200 dark:border-fuchsia-900">
           <div className="border-b border-fuchsia-200 bg-fuchsia-50 px-3 py-2 text-xs font-medium text-fuchsia-900 dark:border-fuchsia-900 dark:bg-fuchsia-950/40 dark:text-fuchsia-200">
-            ↗ 轉出記錄（{outgoingAid.length} 張單 · 共 {totalOutgoingQty} 件）
+            ↗ 轉出記錄（{outgoingAid.length} 趟 · 共 {totalOutgoingQty} 件）
             <span className="ml-2 font-normal">貨從本店出去，隨貨的出貨單在這裡印</span>
           </div>
           <ul className="divide-y divide-zinc-200 dark:divide-zinc-800">
             {outgoingAid.map((o) => (
-              <li key={`aid-out-${o.id}`} className="flex flex-wrap items-center gap-x-3 gap-y-1 p-3 text-xs">
+              <li key={`aid-out-${o.link_id}`} className="flex flex-wrap items-center gap-x-3 gap-y-1 p-3 text-xs">
                 {onNavigate ? (
                   <button
                     type="button"
@@ -1658,7 +1680,9 @@ export function OrderDetail({
                 {/* 每一筆都能印（含已收貨 / 已取消的舊單）—— 事後補一張歸檔、對帳
                     是店家的日常，不要只給還在路上的那幾張 */}
                 <SpinButton
-                  onClick={() => printViaIframe(withBasePath(`/transfers/print-aid?order_id=${o.id}`))}
+                  onClick={() =>
+                    printViaIframe(withBasePath(`/transfers/print-aid?order_id=${o.id}&link=${o.link_id}`))
+                  }
                   className="ml-auto rounded-md border border-fuchsia-300 px-2 py-1 text-[11px] font-medium text-fuchsia-700 hover:bg-fuchsia-50 dark:border-fuchsia-800 dark:text-fuchsia-300 dark:hover:bg-fuchsia-950"
                   title={
                     isAidInFlight(o.status)

--- a/apps/admin/src/lib/aidTransfer.ts
+++ b/apps/admin/src/lib/aidTransfer.ts
@@ -9,6 +9,14 @@
 //
 // 空中轉不同：轉單當下就自動出貨（20260814030000），轉入單直接進 shipping，
 // confirmed 只會是自動出貨上線前卡住的舊單。
+//
+// ⚠ 這三個地方一律走 customer_order_transfer_links（20260824000100），
+// **不要**回頭反查 customer_orders.transferred_from_order_id —— 那一欄只有
+// 「建新轉入單」那條分支會寫，「追加轉入（併入同活動＋同頻道＋同會員的既有
+// active 單）」什麼都不寫，於是三個畫面同時查無此事：2026-08-24 松山認領互助板
+// 的喜願蛋轉給古華，貨併進古華既有的 TF0486（那張單身上有 3 家店的 5 次認領），
+// 該欄指著最早的中和店 —— 松山端完全查不到，儀表板還把整張單算成「中和 → 古華」。
+// 一張轉入單可以有多個來源，是 1:N，補寫一欄救不了。
 
 // 「貨還沒交到收貨店手上」的轉入單狀態 —— 轉出店還需要為它做事（印單、交貨）。
 // pending 一定要在裡面，見上面。
@@ -16,6 +24,49 @@ export const AID_IN_FLIGHT_STATUSES = ["pending", "confirmed", "shipping"] as co
 
 export function isAidInFlight(status: string): boolean {
   return (AID_IN_FLIGHT_STATUSES as readonly string[]).includes(status);
+}
+
+// ---- 訂單轉移連結（customer_order_transfer_links） ----
+
+export const TRANSFER_LINK_SELECT =
+  "id, source_order_id, dest_order_id, dest_item_ids, is_air_transfer, appended, transferred_at";
+
+export type TransferLink = {
+  id: number;
+  source_order_id: number;
+  dest_order_id: number;
+  dest_item_ids: number[] | null;
+  is_air_transfer: boolean | null;
+  appended: boolean | null;
+  transferred_at: string;
+};
+
+/** 這一趟轉移真正搬過去的品項。
+ *
+ *  為什麼不能直接用整張轉入單的品項：追加分支會把好幾家店的貨併進同一張單
+ *  （線上 TF0486 有 5 個品項來自 3 家店）。轉出店的提醒數量與隨貨單只該算
+ *  自己那一批，否則松山會看到「5 件」、印出來把中和店的 3 件也一起寄走。
+ *
+ *  dest_item_ids 是空的只會發生在回填抓不到對應品項的極舊資料 —— 退回
+ *  「整張單的互助品項」，寧可多印也不要印出一張空白單。 */
+export function linkItems<T extends { id: number; source?: string | null }>(
+  link: Pick<TransferLink, "dest_item_ids">,
+  items: T[],
+): T[] {
+  const ids = link.dest_item_ids;
+  if (ids && ids.length > 0) {
+    const set = new Set(ids.map(Number));
+    return items.filter((it) => set.has(Number(it.id)));
+  }
+  return items.filter((it) => it.source === "aid_transfer");
+}
+
+/** 未取消品項的數量加總（提醒與轉出記錄都用這個口徑：
+ *  品項全被取消的單沒有實體貨在走，不該叫人去印一張空白單）。 */
+export function activeQty(items: { qty: number | string; status: string }[]): number {
+  return items
+    .filter((it) => !["cancelled", "expired"].includes(it.status))
+    .reduce((s, it) => s + Number(it.qty), 0);
 }
 
 // 路徑（貨怎麼走）

--- a/supabase/migrations/20260824000100_order_transfer_links.sql
+++ b/supabase/migrations/20260824000100_order_transfer_links.sql
@@ -1,0 +1,833 @@
+-- ============================================================
+-- 訂單轉移連結表 customer_order_transfer_links
+--
+-- 為什麼要有這張表（2026-08-24 松山→古華「喜願蛋看不到單」）：
+--   轉單有兩條分支，只有一條留得下可查詢的線索 ——
+--     · 建新轉入單   → 寫 customer_orders.transferred_from_order_id ✅
+--     · 追加轉入（併入同活動＋同頻道＋同會員的既有 active 單）→ **只加一行 notes** ❌
+--   而轉出店視角的三個畫面全部反查那一欄（CLAUDE.md 明列的已知洞）：
+--     · 儀表板互助出貨提醒 AidShipmentReminder
+--     · 來源訂單的「轉出記錄」 OrderDetail
+--     · 互助隨貨單 /transfers/print-aid 的來源店
+--   → 追加分支在三個畫面同時變成「查無此事」，貨從店裡出去、系統上沒有這件事。
+--
+--   線上實例：古華店 __INTERNAL_RESTOCK__-TF0486 (#79997) 身上有 5 個品項、
+--   來自 3 家店的 5 次認領（中和 ×3、松山 ×2），但 transferred_from_order_id
+--   只指得到第一筆的中和店。松山 8/24 認領的喜願蛋（品項 #102081）與六色海藻
+--   （#102083）在松山端完全查不到，儀表板還把整張單算成「中和店 → 古華店」。
+--
+--   ⚠ 補寫一欄救不了：一張轉入單可以有多個來源（上例 5 個），這是 1:N，
+--   必須另開連結表 —— CLAUDE.md 早已寫明。
+--
+-- 全站盤點（套用前）：37 張轉入單、62 條隱形連結；其中 8 條的真實來源店
+--   跟 transferred_from_order_id 指的店不同（＝來源店真的查無此事），
+--   3 條還在途中。
+--
+-- 品項歸屬：連結帶 dest_item_ids —— 轉出店只該看到／列印**自己那次**搬過去的
+--   品項，不是整張轉入單（上例松山印出來會變成 5 件，含中和店的 3 件）。
+--   兩支 RPC 本來就備好 v_new_item_ids（空中轉出貨用的同一個陣列）。
+--
+-- 基底：rpc_transfer_order_to_store / rpc_transfer_order_partial 皆為
+--       20260814030000_air_transfer_ship_on_transfer（本次逐字保留，只在
+--       兩條分支的尾端各加一段 INSERT INTO customer_order_transfer_links）。
+-- Rollback：
+--   DROP TABLE public.customer_order_transfer_links;
+--   重新 apply 20260814030000 的兩支 function。
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.customer_order_transfer_links (
+  id              BIGSERIAL PRIMARY KEY,
+  tenant_id       UUID        NOT NULL,
+  source_order_id BIGINT      NOT NULL REFERENCES public.customer_orders(id) ON DELETE CASCADE,
+  dest_order_id   BIGINT      NOT NULL REFERENCES public.customer_orders(id) ON DELETE CASCADE,
+  -- 本次搬進轉入單的品項（轉出店的提醒數量／隨貨單只認這一批）
+  dest_item_ids   BIGINT[]    NOT NULL DEFAULT '{}',
+  is_air_transfer BOOLEAN     NOT NULL DEFAULT FALSE,
+  is_partial      BOOLEAN     NOT NULL DEFAULT FALSE,
+  -- TRUE = 併入既有單（就是原本查不到的那條分支）
+  appended        BOOLEAN     NOT NULL DEFAULT FALSE,
+  reason          TEXT,
+  transferred_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by      UUID,
+  CONSTRAINT cotl_no_self CHECK (source_order_id <> dest_order_id)
+);
+
+-- 同一對來源／轉入單可以被追加很多次（每次一列），用時間戳分辨；
+-- 這個 unique 同時讓下面的回填可以重跑不重複。
+CREATE UNIQUE INDEX IF NOT EXISTS cotl_src_dest_at_uniq
+  ON public.customer_order_transfer_links (source_order_id, dest_order_id, transferred_at);
+CREATE INDEX IF NOT EXISTS cotl_source_idx ON public.customer_order_transfer_links (source_order_id);
+CREATE INDEX IF NOT EXISTS cotl_dest_idx   ON public.customer_order_transfer_links (dest_order_id);
+
+ALTER TABLE public.customer_order_transfer_links ENABLE ROW LEVEL SECURITY;
+
+-- 讀取比照 customer_orders 的 auth_read_customer_orders（同租戶全開）：
+-- 轉出店與收貨店在這張表的兩端，任何一邊只開自己那半都會讓對面看不到在等誰。
+-- 寫入只走 SECURITY DEFINER 的兩支轉單 RPC，不開任何 policy。
+DROP POLICY IF EXISTS auth_read_order_transfer_links ON public.customer_order_transfer_links;
+CREATE POLICY auth_read_order_transfer_links
+  ON public.customer_order_transfer_links FOR SELECT
+  USING (tenant_id = (auth.jwt() ->> 'tenant_id')::UUID);
+
+GRANT SELECT ON public.customer_order_transfer_links TO authenticated;
+
+COMMENT ON TABLE public.customer_order_transfer_links IS
+  '訂單轉移的 order↔order 連結（1 張轉入單可有多個來源單）。'
+  '建新轉入單與「追加轉入（併入既有單）」兩條分支都寫，'
+  '取代只在前者才有的 customer_orders.transferred_from_order_id 反查。'
+  'dest_item_ids = 本次搬進去的品項，轉出店的提醒數量與隨貨單只認這一批。';
+
+-- ------------------------------------------------------------
+-- 回填 1：建新轉入單那條分支（transferred_from_order_id 有值）
+-- transferred_at 用轉入單的 created_at —— 那就是轉單當下。
+-- ------------------------------------------------------------
+INSERT INTO public.customer_order_transfer_links (
+  tenant_id, source_order_id, dest_order_id, dest_item_ids,
+  is_air_transfer, is_partial, appended, reason, transferred_at, created_by)
+SELECT d.tenant_id, d.transferred_from_order_id, d.id,
+       COALESCE((SELECT array_agg(i.id ORDER BY i.id)
+                   FROM customer_order_items i
+                  WHERE i.order_id = d.id
+                    AND i.source = 'aid_transfer'
+                    -- 建單當下一起塞進去的品項；之後的追加另有自己的連結列
+                    AND i.created_at < d.created_at + INTERVAL '2 seconds'),
+                '{}'::BIGINT[]),
+       COALESCE(d.is_air_transfer, FALSE),
+       -- 來源單沒被整張標 transferred_out ⇒ 當初是部分轉出
+       (SELECT s.status <> 'transferred_out' FROM customer_orders s
+         WHERE s.id = d.transferred_from_order_id),
+       FALSE, '[回填] 由 transferred_from_order_id 推得', d.created_at, d.created_by
+  FROM customer_orders d
+ WHERE d.transferred_from_order_id IS NOT NULL
+ON CONFLICT (source_order_id, dest_order_id, transferred_at) DO NOTHING;
+
+-- ------------------------------------------------------------
+-- 回填 2：追加轉入分支 —— 唯一留下的線索是 notes，格式由 RPC 固定產生：
+--   [追加轉入 (經總倉) ← 訂單 #75264 (OV-2-0001)] 2026-08-24 04:18:07 / 互助板認領 #227
+--   [追加轉入 (部分, 空中轉) ← 訂單 #82833 (AB-2-0001)] 2026-08-24 04:18:45
+-- 時間戳是 to_char(NOW(),...) 的產物、DB 時區為 UTC（實測：notes 04:18:07
+-- 對得上品項 created_at 04:18:07.206331+00），所以下面按 UTC 解讀。
+-- ------------------------------------------------------------
+WITH parsed AS (
+  SELECT d.id AS dest_id, d.tenant_id, d.created_by,
+         m[1] AS variant,                       -- '經總倉' / '部分, 空中轉' …
+         m[2]::BIGINT AS src_id,
+         (m[3] || '+00')::TIMESTAMPTZ AS at
+    FROM customer_orders d
+    CROSS JOIN LATERAL regexp_matches(
+      d.notes,
+      '\[追加轉入 \(([^)]*)\) ← 訂單 #(\d+) \([^)]*\)\] (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})',
+      'g') AS m
+   WHERE d.notes LIKE '%追加轉入%'
+)
+INSERT INTO public.customer_order_transfer_links (
+  tenant_id, source_order_id, dest_order_id, dest_item_ids,
+  is_air_transfer, is_partial, appended, reason, transferred_at, created_by)
+SELECT p.tenant_id, p.src_id, p.dest_id,
+       -- 追加當下建的品項：RPC 用同一個 v_now 寫 notes 與品項，秒級對得上
+       COALESCE((SELECT array_agg(i.id ORDER BY i.id)
+                   FROM customer_order_items i
+                  WHERE i.order_id = p.dest_id
+                    AND i.source = 'aid_transfer'
+                    AND i.created_at >= p.at
+                    AND i.created_at <  p.at + INTERVAL '1 second'),
+                '{}'::BIGINT[]),
+       p.variant LIKE '%空中轉%',
+       p.variant LIKE '%部分%',
+       TRUE, '[回填] 由 notes 的「追加轉入」推得', p.at, p.created_by
+  FROM parsed p
+ WHERE EXISTS (SELECT 1 FROM customer_orders s WHERE s.id = p.src_id)
+ON CONFLICT (source_order_id, dest_order_id, transferred_at) DO NOTHING;
+
+
+-- ------------------------------------------------------------
+-- rpc_transfer_order_to_store — 逐字沿用 20260814030000，
+-- 只在尾端加寫 customer_order_transfer_links。
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_to_store(p_order_id bigint, p_to_pickup_store_id bigint, p_to_member_id bigint, p_to_channel_id bigint, p_operator uuid, p_reason text DEFAULT NULL::text, p_is_air_transfer boolean DEFAULT false)
+ RETURNS bigint
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_item             RECORD;
+  v_orig_mov         RECORD;
+  v_rev_id           BIGINT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_note_out         TEXT;
+  v_note_in          TEXT;
+  v_new_status       TEXT;
+  v_src_is_internal  BOOLEAN := FALSE;
+  v_dst_is_internal  BOOLEAN := FALSE;
+  v_dup_order_id     BIGINT;
+  v_dup_order_no     TEXT;
+  v_appended         BOOLEAN := FALSE;
+  v_active_count     INT;
+  v_new_item_ids     BIGINT[];
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION '找不到訂單 #%', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  -- 部分取貨的單不可整單轉出：整單轉出會把來源單標 transferred_out
+  -- （整張不入統計），已取走品項的營收會跟著被歸零。剩餘品項請走
+  -- rpc_transfer_order_partial（來源列標 cancelled、單頭由
+  -- _close_orders_all_items_settled 收尾），營收留在原單上。
+  IF v_orig.status = 'partially_completed' THEN
+    RAISE EXCEPTION '訂單 % 已有品項取走（部分取貨），不可整單轉出；請改用部分轉出（只轉剩餘品項）',
+                    p_order_id;
+  END IF;
+
+  -- 跨店轉單維持「貨到店 (status='ready') 才能轉」；
+  -- 同店互轉（換客人）貨進同一間店、不影響總倉派貨量，到貨前也可轉。
+  -- 同店預轉仍排除三種「貨不走本店波次」的單（轉走會斷到貨推進鏈）：
+  --   a. 非一般團購單（restock ride-along 靠 order_no='RR-x' 特判推 ready、offset 無實貨）
+  --   b. 有進行中的調撥 FK 指著它（互助/空中轉/補貨直派 → 到貨判定綁原單 id）
+  --   c. 自己就是跨店轉入、貨還沒到的單（到貨判定同樣綁 transfer FK）
+  IF v_orig.status <> 'ready' THEN
+    IF p_to_pickup_store_id <> v_orig.pickup_store_id THEN
+      RAISE EXCEPTION '貨還沒到分店、訂單 % 不可跨店轉單 (status=%)；同店換客人不受此限',
+                      p_order_id, v_orig.status;
+    END IF;
+    IF v_orig.status NOT IN ('pending','confirmed','reserved','shipping') THEN
+      RAISE EXCEPTION '訂單 % 狀態（%）不可轉單', p_order_id, v_orig.status;
+    END IF;
+    IF COALESCE(v_orig.order_kind, 'normal') <> 'normal' THEN
+      RAISE EXCEPTION '訂單 % 不是一般團購單（%），須等分店收貨後再轉單',
+                      p_order_id, v_orig.order_kind;
+    END IF;
+    IF EXISTS (SELECT 1 FROM transfers t
+                WHERE t.customer_order_id = p_order_id
+                  AND t.tenant_id = v_tenant_id
+                  AND t.status <> 'cancelled') THEN
+      RAISE EXCEPTION '訂單 % 有進行中的調撥，請等分店收貨後再轉單', p_order_id;
+    END IF;
+    IF v_orig.transferred_from_order_id IS NOT NULL AND EXISTS (
+         SELECT 1 FROM customer_orders src
+          WHERE src.id = v_orig.transferred_from_order_id
+            AND src.pickup_store_id IS DISTINCT FROM v_orig.pickup_store_id) THEN
+      RAISE EXCEPTION '訂單 % 是跨店轉入、貨還沒到，請等分店收貨後再轉單', p_order_id;
+    END IF;
+  END IF;
+
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION '訂單 #% 已轉出至訂單 #%，不可重複轉出',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  -- 整單轉出只帶 active（未取消、未取走）品項；一件都沒有就沒東西可轉
+  SELECT COUNT(*) INTO v_active_count
+    FROM customer_order_items
+   WHERE order_id = p_order_id
+     AND status IN ('pending','reserved','ready');
+  IF v_active_count = 0 THEN
+    RAISE EXCEPTION '訂單 #% 沒有可轉移的品項（未取消／未取走的品項為 0）', p_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '接收店（ID %）不存在或不屬於目前商戶', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '接收會員（ID %）不存在或不屬於目前商戶', v_to_member_id;
+  END IF;
+
+  -- 內部單（【內部】xx店）轉給真會員 = 門市現貨銷售 → 轉出價改鎖現售價。
+  -- 店↔店互助（目標也是 store_internal）維持原價不變。（同 20260714000090 partial 版規則）
+  SELECT (m.member_type = 'store_internal') INTO v_src_is_internal
+    FROM members m WHERE m.id = v_orig.member_id;
+  v_src_is_internal := COALESCE(v_src_is_internal, FALSE);
+  SELECT (m.member_type = 'store_internal') INTO v_dst_is_internal
+    FROM members m WHERE m.id = v_to_member_id;
+  v_dst_is_internal := COALESCE(v_dst_is_internal, FALSE);
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION '接收店找不到可用的 LINE 頻道，無法建立轉入訂單';
+  END IF;
+
+  PERFORM 1 FROM line_channels
+   WHERE id = v_to_channel_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'LINE 頻道（ID %）不屬於目前商戶', v_to_channel_id;
+  END IF;
+
+  -- 接收人在同一檔活動已有 active 單（對齊 customer_orders_trio_kind_active_uniq）
+  -- → 不再擋下，改為「併入該張既有訂單」（與 rpc_transfer_order_partial 同語意）。
+  SELECT id, order_no INTO v_dup_order_id, v_dup_order_no
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id
+     AND status NOT IN ('transferred_out', 'expired', 'cancelled')
+   LIMIT 1;
+
+  -- 查到的既有單 = 來源單本身（轉給自己）→ 擋下，否則會把訂單併進它自己
+  IF v_dup_order_id = p_order_id THEN
+    RAISE EXCEPTION '這張訂單本來就掛在該接收人（同活動、同頻道）名下，不需要轉出';
+  END IF;
+
+  -- E2: 釋放 reserved_movement（無條件、跟以前一致；同店也走這條）
+  FOR v_item IN
+    SELECT id, reserved_movement_id FROM customer_order_items
+     WHERE order_id = p_order_id AND reserved_movement_id IS NOT NULL
+  LOOP
+    SELECT * INTO v_orig_mov FROM stock_movements WHERE id = v_item.reserved_movement_id;
+    IF FOUND THEN
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+        source_doc_type, source_doc_id, reverses, reason, operator_id
+      ) VALUES (
+        v_orig_mov.tenant_id, v_orig_mov.location_id, v_orig_mov.sku_id,
+        -v_orig_mov.quantity, v_orig_mov.unit_cost, 'reversal',
+        'order_transfer', p_order_id, v_orig_mov.id,
+        'order #' || p_order_id || ' transferred out, release allocation', p_operator
+      ) RETURNING id INTO v_rev_id;
+
+      UPDATE stock_movements SET reversed_by = v_rev_id WHERE id = v_orig_mov.id;
+      UPDATE customer_order_items SET reserved_movement_id = NULL WHERE id = v_item.id;
+    END IF;
+  END LOOP;
+
+  IF v_dup_order_id IS NOT NULL THEN
+    -- 併入既有單：不另建新單、不改既有單 status / pickup_store / is_air_transfer
+    -- （與 partial 追加分支一致；notes 格式同 partial 的「追加轉入」）
+    v_appended     := TRUE;
+    v_new_order_id := v_dup_order_id;
+    v_new_order_no := v_dup_order_no;
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[追加轉入 (' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+                   ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS') ||
+                   COALESCE(' / ' || p_reason, ''),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = v_new_order_id;
+  ELSE
+    SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+    -- TF 序號 = 該團既有 -TF 尾碼最大值 + 1。
+    -- COUNT(*)+1 在 RR- 單被硬刪（rpc_delete_restock_request）後會倒退、
+    -- 重發已用過的號碼 → duplicate key（2026-08-13 湖口 RR-435 事故）。
+    -- 團鎖：來源單鎖擋不住兩張不同來源單同時轉出算出同一號。
+    PERFORM pg_advisory_xact_lock(hashtext('order_tf_seq:' || v_orig.campaign_id::text));
+    SELECT COALESCE(MAX(substring(order_no FROM '-TF([0-9]+)$')::INT), 0) + 1
+      INTO v_seq
+      FROM customer_orders
+     WHERE tenant_id = v_tenant_id
+       AND campaign_id = v_orig.campaign_id
+       AND order_no ~ '-TF[0-9]+$';
+    -- lpad 超寬會截斷（lpad('10001',4)='1000'），寬度要跟著位數長
+    v_new_order_no := v_campaign_no || '-TF' ||
+                      lpad(v_seq::text, GREATEST(length(v_seq::text), 4), '0');
+
+    v_note_in := COALESCE(p_reason, '') ||
+                 E'\n[轉入 (' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+                 ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+                 to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+    -- 同店：mirror source.status；跨店空中轉：confirmed（尾端 helper 會接著
+    -- 建 AT- 單並推 shipping）；跨店經總倉：'pending'（維持總倉確認 gate）
+    v_new_status := CASE
+      WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN v_orig.status
+      WHEN p_is_air_transfer THEN 'confirmed'
+      ELSE 'pending'
+    END;
+
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id,
+      nickname_snapshot, pickup_store_id, status, notes,
+      transferred_from_order_id, is_air_transfer,
+      created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+      v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status, v_note_in,
+      p_order_id, p_is_air_transfer,
+      p_operator, p_operator, v_now, v_now
+    ) RETURNING id INTO v_new_order_id;
+  END IF;
+
+  -- 內部單 → 真會員：轉出價鎖定當下 SKU 現售價（scope='retail' 最新生效版）；
+  -- 查無現售價 fallback 來源價。其餘情境維持原價。
+  -- RETURNING：本次搬進去的品項 id 要留給空中轉出貨（helper 只出這一批）
+  WITH ins AS (
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, notes, created_by, updated_by
+    )
+    SELECT coi.tenant_id, v_new_order_id, coi.campaign_item_id, coi.sku_id, coi.qty,
+           CASE WHEN v_src_is_internal AND NOT v_dst_is_internal
+                THEN COALESCE(pr.price, coi.unit_price)
+                ELSE coi.unit_price
+           END,
+           'pending', 'aid_transfer', coi.notes, p_operator, p_operator
+      FROM customer_order_items coi
+      LEFT JOIN LATERAL (
+        SELECT p2.price
+          FROM prices p2
+         WHERE v_src_is_internal AND NOT v_dst_is_internal
+           AND p2.tenant_id = v_tenant_id
+           AND p2.sku_id    = coi.sku_id
+           AND p2.scope     = 'retail'
+           AND p2.effective_from <= v_now
+           AND (p2.effective_to IS NULL OR p2.effective_to > v_now)
+         ORDER BY p2.effective_from DESC
+         LIMIT 1
+      ) pr ON TRUE
+     WHERE coi.order_id = p_order_id
+       -- 只複製 active 品項。cancelled（含部分轉出後留下的殘骸）/ expired /
+       -- picked_up（貨已交付）帶過去 = 無中生有的重複品項（2026-08-10 忠順事故）
+       AND coi.status IN ('pending','reserved','ready')
+    RETURNING id
+  )
+  SELECT COALESCE(array_agg(id), '{}'::BIGINT[]) INTO v_new_item_ids FROM ins;
+
+  v_note_out := COALESCE(p_reason, '') ||
+                E'\n[轉出' || CASE WHEN v_appended THEN '（併入既有單）' ELSE '' END ||
+                ' → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                to_char(v_now, 'YYYY-MM-DD HH24:MI:SS');
+
+  UPDATE customer_orders
+     SET status                   = 'transferred_out',
+         transferred_to_order_id  = v_new_order_id,
+         notes                    = COALESCE(notes, '') || v_note_out,
+         updated_by               = p_operator,
+         updated_at               = v_now
+   WHERE id = p_order_id;
+
+  -- 併入的既有單若已 completed → 重開，否則追加品項會變幽靈：
+  -- 待取清單看不到、is_order_item_pickup_ready 也擋著不給取（見 20260805000140）
+  IF v_appended THEN
+    PERFORM public._reopen_order_if_completed(
+      v_new_order_id, p_operator,
+      '追加轉入 ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')');
+  END IF;
+
+  -- 這一趟轉移的 order↔order 連結。**兩條分支都要寫**（新建轉入單 / 追加併入
+  -- 既有單）—— 只有前者會寫 transferred_from_order_id，追加分支以前什麼線索都
+  -- 沒留下，轉出店的儀表板提醒、轉出記錄、隨貨單三個畫面同時查無此事
+  -- （2026-08-24 松山→古華喜願蛋）。dest_item_ids 只放本次搬進去的品項，
+  -- 轉出店才不會看到／印到別家店在同一張轉入單上的貨。
+  INSERT INTO public.customer_order_transfer_links (
+    tenant_id, source_order_id, dest_order_id, dest_item_ids,
+    is_air_transfer, is_partial, appended, reason, transferred_at, created_by)
+  VALUES (
+    v_tenant_id, p_order_id, v_new_order_id, COALESCE(v_new_item_ids, '{}'::BIGINT[]),
+    COALESCE(p_is_air_transfer, FALSE), FALSE, v_appended, p_reason, v_now, p_operator)
+  ON CONFLICT (source_order_id, dest_order_id, transferred_at) DO NOTHING;
+
+  -- 空中轉：貨當下就從轉出店出去 → 建 AT- 轉移單 + 出庫，轉入單進 shipping。
+  -- 接收店在收貨頁收掉就可取貨，沒有「派貨」這一步。同店由 helper 判掉。
+  IF COALESCE(p_is_air_transfer, FALSE) THEN
+    PERFORM public._air_ship_order_items(
+      v_new_order_id, v_orig.pickup_store_id, v_new_item_ids, p_operator, v_now);
+  END IF;
+
+  RETURN v_new_order_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_to_store(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, BOOLEAN
+) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_transfer_order_to_store(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, BOOLEAN
+) IS
+  '整單轉出：跨店需 status=ready；同店互轉（換客人）pending/confirmed/reserved/shipping 也可轉，'
+  '但排除非 normal 單、有進行中調撥、跨店轉入未到貨單。partially_completed 明確拒絕'
+  '（會把已取走營收標成 transferred_out 歸零，改走部分轉出）。'
+  '接收人已有 active 單則併入（completed 會重開）。'
+  '空中轉當下就建 AT- 轉移單＋轉出店出庫、轉入單進 shipping（不需要派貨）；'
+  '經總倉建 pending、同店 mirror 原單 status。'
+  '內部單轉真會員鎖現售價。品項只複製 active（pending/reserved/ready）。'
+  'TF 序號 = 該團既有 -TF 尾碼 MAX+1（campaign 級 advisory lock 序列化）。'
+  '錯誤訊息繁體中文。尾端寫 customer_order_transfer_links（追加分支也寫）。'
+  '基底 20260814030000。';
+
+
+-- ------------------------------------------------------------
+-- rpc_transfer_order_partial — 同上，逐字沿用 20260814030000。
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_partial(p_order_id bigint, p_to_pickup_store_id bigint, p_to_member_id bigint, p_to_channel_id bigint, p_operator uuid, p_reason text, p_items jsonb, p_is_air_transfer boolean DEFAULT false)
+ RETURNS bigint
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_p_item           JSONB;
+  v_p_sku_id         BIGINT;
+  v_p_qty            NUMERIC;
+  v_src_item_id      BIGINT;
+  v_src_item_qty     NUMERIC;
+  v_src_item_ci      BIGINT;
+  v_src_item_price   NUMERIC;
+  v_src_item_reserved BIGINT;
+  v_remaining_count  INT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_existing_order   BIGINT;
+  v_appended         BOOLEAN := FALSE;
+  v_new_status       TEXT;
+  v_src_is_internal  BOOLEAN := FALSE;
+  v_dst_is_internal  BOOLEAN := FALSE;
+  v_retail_price     NUMERIC;
+  v_item_price       NUMERIC;
+  v_reopened         TEXT;
+  v_new_item_id      BIGINT;
+  v_new_item_ids     BIGINT[] := '{}'::BIGINT[];
+BEGIN
+  IF p_items IS NULL OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION '未指定任何要轉移的品項';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION '找不到訂單 #%', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  -- 跨店轉單維持「貨到店才能轉」：ready 之外也放行 partially_completed ——
+  -- 已取走過品項代表貨到過店，剩餘 active 品項物理上就在店裡（內部現貨池
+  -- 臨櫃賣掉一件就進 partially_completed，不放行等於池子賣過一次就不能再轉，
+  -- 2026-08-14 湖口 INT0116）。品項挑選本來就限 active，picked_up 不會被轉走。
+  -- 同店互轉（換客人）貨進同一間店、不影響總倉派貨量，到貨前也可轉。
+  -- 同店預轉仍排除三種「貨不走本店波次」的單（轉走會斷到貨推進鏈）：
+  --   a. 非一般團購單（restock ride-along 靠 order_no='RR-x' 特判推 ready、offset 無實貨）
+  --   b. 有進行中的調撥 FK 指著它（互助/空中轉/補貨直派 → 到貨判定綁原單 id）
+  --   c. 自己就是跨店轉入、貨還沒到的單（到貨判定同樣綁 transfer FK）
+  IF v_orig.status NOT IN ('ready','partially_completed') THEN
+    IF p_to_pickup_store_id <> v_orig.pickup_store_id THEN
+      RAISE EXCEPTION '貨還沒到分店、訂單 % 不可跨店轉單 (status=%)；同店換客人不受此限',
+                      p_order_id, v_orig.status;
+    END IF;
+    IF v_orig.status NOT IN ('pending','confirmed','reserved','shipping') THEN
+      RAISE EXCEPTION '訂單 % 狀態（%）不可轉單', p_order_id, v_orig.status;
+    END IF;
+    IF COALESCE(v_orig.order_kind, 'normal') <> 'normal' THEN
+      RAISE EXCEPTION '訂單 % 不是一般團購單（%），須等分店收貨後再轉單',
+                      p_order_id, v_orig.order_kind;
+    END IF;
+    IF EXISTS (SELECT 1 FROM transfers t
+                WHERE t.customer_order_id = p_order_id
+                  AND t.tenant_id = v_tenant_id
+                  AND t.status <> 'cancelled') THEN
+      RAISE EXCEPTION '訂單 % 有進行中的調撥，請等分店收貨後再轉單', p_order_id;
+    END IF;
+    IF v_orig.transferred_from_order_id IS NOT NULL AND EXISTS (
+         SELECT 1 FROM customer_orders src
+          WHERE src.id = v_orig.transferred_from_order_id
+            AND src.pickup_store_id IS DISTINCT FROM v_orig.pickup_store_id) THEN
+      RAISE EXCEPTION '訂單 % 是跨店轉入、貨還沒到，請等分店收貨後再轉單', p_order_id;
+    END IF;
+  END IF;
+
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION '訂單 #% 已轉出至訂單 #%，不可重複轉出',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '接收店（ID %）不存在或不屬於目前商戶', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '接收會員（ID %）不存在或不屬於目前商戶', v_to_member_id;
+  END IF;
+
+  -- 內部單（【內部】xx店）轉給真會員 = 門市現貨銷售 → 轉出價改鎖現售價。
+  -- 店↔店互助（目標也是 store_internal）維持原價不變。
+  SELECT (m.member_type = 'store_internal') INTO v_src_is_internal
+    FROM members m WHERE m.id = v_orig.member_id;
+  v_src_is_internal := COALESCE(v_src_is_internal, FALSE);
+  SELECT (m.member_type = 'store_internal') INTO v_dst_is_internal
+    FROM members m WHERE m.id = v_to_member_id;
+  v_dst_is_internal := COALESCE(v_dst_is_internal, FALSE);
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION '接收店找不到可用的 LINE 頻道，無法建立轉入訂單';
+  END IF;
+
+  SELECT id INTO v_existing_order
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id
+     AND status NOT IN ('expired','cancelled','transferred_out');
+
+  -- 查到的既有單 = 來源單本身（同活動＋同頻道＋同會員轉給自己）→ 擋下，
+  -- 否則會把品項「轉進」它自己（同 20260806000010 對整單轉的守衛）
+  IF v_existing_order = p_order_id THEN
+    RAISE EXCEPTION '這張訂單本來就掛在該接收人（同活動、同頻道）名下，不需要轉出';
+  END IF;
+
+  IF v_existing_order IS NOT NULL THEN
+    v_new_order_id := v_existing_order;
+    v_appended := TRUE;
+    SELECT order_no INTO v_new_order_no FROM customer_orders WHERE id = v_existing_order;
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[追加轉入 (部分, ' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+                   ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS') ||
+                   COALESCE(' / ' || p_reason, ''),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = v_new_order_id;
+  ELSE
+    SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+    -- TF 序號 = 該團既有 -TF 尾碼最大值 + 1。
+    -- COUNT(*)+1 在 RR- 單被硬刪（rpc_delete_restock_request）後會倒退、
+    -- 重發已用過的號碼 → duplicate key（2026-08-13 湖口 RR-435 事故）。
+    -- 團鎖：來源單鎖擋不住兩張不同來源單同時轉出算出同一號。
+    PERFORM pg_advisory_xact_lock(hashtext('order_tf_seq:' || v_orig.campaign_id::text));
+    SELECT COALESCE(MAX(substring(order_no FROM '-TF([0-9]+)$')::INT), 0) + 1
+      INTO v_seq
+      FROM customer_orders
+     WHERE tenant_id = v_tenant_id
+       AND campaign_id = v_orig.campaign_id
+       AND order_no ~ '-TF[0-9]+$';
+    -- lpad 超寬會截斷（lpad('10001',4)='1000'），寬度要跟著位數長
+    v_new_order_no := v_campaign_no || '-TF' ||
+                      lpad(v_seq::text, GREATEST(length(v_seq::text), 4), '0');
+
+    -- 同店：mirror source.status，但 partially_completed 映成 'ready' ——
+    -- 新單一件都還沒取走，掛「部分取貨」是錯的（取貨頁與收尾邏輯都會誤判）；
+    -- 跨店空中轉：confirmed（尾端 helper 會接著建 AT- 單並推 shipping）；
+    -- 跨店經總倉：'pending'（維持總倉確認 gate）
+    v_new_status := CASE
+      WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN
+        CASE WHEN v_orig.status = 'partially_completed' THEN 'ready' ELSE v_orig.status END
+      WHEN p_is_air_transfer THEN 'confirmed'
+      ELSE 'pending'
+    END;
+
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id,
+      nickname_snapshot, pickup_store_id, status, notes,
+      transferred_from_order_id, is_air_transfer,
+      created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+      v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status,
+      COALESCE(p_reason, '') ||
+        E'\n[轉入 (部分, ' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+        ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+        to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+      p_order_id, p_is_air_transfer,
+      p_operator, p_operator, v_now, v_now
+    ) RETURNING id INTO v_new_order_id;
+  END IF;
+
+  FOR v_p_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_p_sku_id := (v_p_item ->> 'sku_id')::BIGINT;
+    v_p_qty    := (v_p_item ->> 'qty')::NUMERIC;
+    IF v_p_qty IS NULL OR v_p_qty <= 0 THEN
+      RAISE EXCEPTION '轉移數量必須大於 0';
+    END IF;
+
+    SELECT id, qty, campaign_item_id, unit_price, reserved_movement_id
+      INTO v_src_item_id, v_src_item_qty, v_src_item_ci, v_src_item_price, v_src_item_reserved
+      FROM customer_order_items
+     WHERE order_id = p_order_id
+       AND sku_id   = v_p_sku_id
+       -- 只挑 active 品項當轉出來源；picked_up（貨已交付）/ expired 的列
+       -- 拿來轉會把已交付的貨再轉給別人（同 2026-08-10 整單轉出復活 cancelled 品項的事故類型）
+       AND status   IN ('pending','reserved','ready')
+     ORDER BY id
+     LIMIT 1
+     FOR UPDATE;
+    IF v_src_item_id IS NULL THEN
+      RAISE EXCEPTION 'SKU % 不在訂單 #% 內（或品項已取消／已取走），無法轉移', v_p_sku_id, p_order_id;
+    END IF;
+    IF v_src_item_reserved IS NOT NULL THEN
+      RAISE EXCEPTION 'SKU % 已有庫存配貨紀錄（#%），請先釋放配貨再轉移',
+                      v_p_sku_id, v_src_item_reserved;
+    END IF;
+    IF v_src_item_qty < v_p_qty THEN
+      RAISE EXCEPTION 'SKU % 可轉數量不足：來源剩 %、要求轉出 %',
+                      v_p_sku_id, v_src_item_qty, v_p_qty;
+    END IF;
+
+    -- 內部單 → 真會員：轉出價鎖定當下 SKU 現售價（scope='retail' 最新生效版）；
+    -- 查無現售價 fallback 來源價。其餘情境維持原價。
+    v_item_price := v_src_item_price;
+    IF v_src_is_internal AND NOT v_dst_is_internal THEN
+      SELECT price INTO v_retail_price
+        FROM prices
+       WHERE tenant_id = v_tenant_id
+         AND sku_id    = v_p_sku_id
+         AND scope     = 'retail'
+         AND effective_from <= v_now
+         AND (effective_to IS NULL OR effective_to > v_now)
+       ORDER BY effective_from DESC
+       LIMIT 1;
+      v_item_price := COALESCE(v_retail_price, v_src_item_price);
+    END IF;
+
+    IF v_src_item_qty = v_p_qty THEN
+      UPDATE customer_order_items
+         SET status = 'cancelled', updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    ELSE
+      UPDATE customer_order_items
+         SET qty = qty - v_p_qty, updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    END IF;
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by
+    ) VALUES (
+      v_tenant_id, v_new_order_id, v_src_item_ci, v_p_sku_id, v_p_qty, v_item_price,
+      'pending', 'aid_transfer', p_operator, p_operator
+    ) RETURNING id INTO v_new_item_id;
+    -- 本次搬進去的品項 id 留給空中轉出貨（helper 只出這一批，
+    -- 不能整張單重出 —— 之前分次追加的品項已經有自己的 AT- 單了）
+    v_new_item_ids := array_append(v_new_item_ids, v_new_item_id);
+  END LOOP;
+
+  SELECT COUNT(*) INTO v_remaining_count
+    FROM customer_order_items
+   WHERE order_id = p_order_id AND status != 'cancelled';
+
+  IF v_remaining_count = 0 THEN
+    UPDATE customer_orders
+       SET status = 'transferred_out',
+           transferred_to_order_id = v_new_order_id,
+           notes = COALESCE(notes, '') ||
+                   E'\n[全部轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  ELSE
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[' || CASE WHEN v_appended THEN '部分追加' ELSE '部分轉出' END ||
+                   ' → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  END IF;
+
+  -- 部分取貨的來源單把剩餘 active 全轉走後要收尾成 completed：
+  -- remaining_count 算 status != 'cancelled' 會數到 picked_up 列，永遠走不到
+  -- transferred_out 分支（這是對的 —— 已取走的營收要留在原單），但也因此
+  -- 沒人關單頭。helper 自帶守衛（無 active + 至少一件 picked_up 才動作），
+  -- 其餘情境呼叫等於 no-op。
+  PERFORM public._close_orders_all_items_settled(ARRAY[p_order_id], p_operator, v_now);
+
+  -- 追加到「已取貨完成」的既有單時，把它重開 —— 否則新品項會被埋在 completed
+  -- 單裡：待取清單看不到、is_order_item_pickup_ready 也擋著不給取（見 20260805000140）。
+  IF v_appended THEN
+    v_reopened := public._reopen_order_if_completed(
+      v_new_order_id, p_operator,
+      '追加轉入 ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')');
+  END IF;
+
+  -- 這一趟轉移的 order↔order 連結。**兩條分支都要寫**（新建轉入單 / 追加併入
+  -- 既有單）—— 只有前者會寫 transferred_from_order_id，追加分支以前什麼線索都
+  -- 沒留下，轉出店的儀表板提醒、轉出記錄、隨貨單三個畫面同時查無此事
+  -- （2026-08-24 松山→古華喜願蛋）。dest_item_ids 只放本次搬進去的品項，
+  -- 轉出店才不會看到／印到別家店在同一張轉入單上的貨。
+  INSERT INTO public.customer_order_transfer_links (
+    tenant_id, source_order_id, dest_order_id, dest_item_ids,
+    is_air_transfer, is_partial, appended, reason, transferred_at, created_by)
+  VALUES (
+    v_tenant_id, p_order_id, v_new_order_id, COALESCE(v_new_item_ids, '{}'::BIGINT[]),
+    COALESCE(p_is_air_transfer, FALSE), TRUE, v_appended, p_reason, v_now, p_operator)
+  ON CONFLICT (source_order_id, dest_order_id, transferred_at) DO NOTHING;
+
+  -- 空中轉：貨當下就從轉出店出去 → 建 AT- 轉移單 + 出庫，轉入單進 shipping。
+  -- 接收店在收貨頁收掉就可取貨，沒有「派貨」這一步。同店由 helper 判掉。
+  IF COALESCE(p_is_air_transfer, FALSE) THEN
+    PERFORM public._air_ship_order_items(
+      v_new_order_id, v_orig.pickup_store_id, v_new_item_ids, p_operator, v_now);
+  END IF;
+
+  RETURN v_new_order_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_partial(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB, BOOLEAN
+) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_transfer_order_partial(
+  BIGINT, BIGINT, BIGINT, BIGINT, UUID, TEXT, JSONB, BOOLEAN
+) IS
+  '部分轉出：跨店需 status=ready 或 partially_completed（貨已到店）；'
+  '同店互轉（換客人）pending/confirmed/reserved/shipping 也可轉，排除名單同整單版。'
+  '「轉給自己」守衛。追加到既有 active 單不改其 status（completed 會重開）。'
+  '轉出來源只挑 active 品項（pending/reserved/ready）。'
+  '同店新單 status：partially_completed 映成 ready，其餘 mirror 原單。'
+  '空中轉當下就建 AT- 轉移單＋轉出店出庫（只出本次搬進去的品項）、轉入單進 shipping。'
+  '尾端接 _close_orders_all_items_settled（部分取貨單轉空 active 後收尾 completed）。'
+  'TF 序號 = 該團既有 -TF 尾碼 MAX+1（campaign 級 advisory lock 序列化）。'
+  '錯誤訊息繁體中文。尾端寫 customer_order_transfer_links（追加分支也寫）。'
+  '基底 20260814030000。';


### PR DESCRIPTION
## 做了什麼

店家回報「松山轉一盒喜願蛋給古華，但是都看不到單」。查下來是兩件事，都是「貨從店裡出去了、系統上查不到」。

### 1️⃣ 主要：追加轉入（併入既有單）不留任何可查詢的線索

互助板認領走 `rpc_transfer_order_partial`。接收人已有同活動＋同頻道的 active 單時會走**「追加轉入（併入既有單）」**分支 —— 那條分支**只加一行 notes**，不寫 `transferred_from_order_id`。

而轉出店視角的三個畫面**全部**反查那一欄：

| 畫面 | 原本的反查 |
|---|---|
| 儀表板互助出貨提醒 `AidShipmentReminder` | `.not("transferred_from_order_id","is",null)` → 再 map 來源店 |
| 來源訂單的「轉出記錄」`OrderDetail` | `.eq("transferred_from_order_id", orderId)` |
| 互助隨貨單 `/transfers/print-aid` 的來源店 | 讀 `h.transferred_from_order_id` |

→ 追加分支在三個畫面**同時**變成查無此事，店家連隨貨單都印不出來。

線上實例：松山 8/24 認領互助板 #227 的喜願蛋轉給古華，貨併進古華既有的 `__INTERNAL_RESTOCK__-TF0486`（#79997）。那張單身上有 **3 家店的 5 次認領**（中和 ×3、松山 ×2），`transferred_from_order_id` 只指得到最早的中和店 —— 松山端完全查不到，儀表板還把整張單算成「中和 → 古華」。

**一張轉入單可以有多個來源，是 1:N，補寫一欄救不了**（CLAUDE.md 早已記下這個洞）。所以新增連結表：

- `customer_order_transfer_links`（source / dest / `dest_item_ids` / `appended` / `is_air_transfer` / `is_partial` / `transferred_at`）
- 兩支轉單 RPC 的**兩條分支都寫**（新建轉入單 + 追加）。RPC 本體逐字沿用基底 `20260814030000`，只在尾端各加一段 INSERT。
- **回填**：`transferred_from_order_id` 一批 ＋ notes 的「追加轉入」一批（格式由 RPC 固定產生，可解析）。
- `dest_item_ids` 讓轉出店只看到／只印**自己那一趟**：松山看到「蛋 1 件」「海藻 1 件」，不是 TF0486 整張 5 件（含中和店的 3 件）。
- 三個讀取路徑改走連結表，判斷收在 `lib/aidTransfer` 一支裡（那支檔頭本來就寫著「為什麼要收在同一支」）；隨貨單新增 `?link=` 參數。

### 2️⃣ 順手：`/transfers/free` 建完單導去 `/hq/inbox`

`/hq/inbox` 對分店帳號是隱藏頁（`BRANCH_HIDDEN_HREFS`），UI 也不是為店↔店轉貨設計。改導去 `/wms/transfers?open=<id>`（月結對帳單已在用的同一套深連結），該頁對分店開放、也是自由轉貨真正該管理的地方。

## 上線危險

- 做了：
  - **SQL 已於 2026-08-24 套上正式庫**（Management API）。純新增：一張新表 + 兩支 RPC `CREATE OR REPLACE`（本體逐字保留基底版本，只多一段 INSERT）。回填是 `ON CONFLICT DO NOTHING`，可重跑。
  - 套用前先以 `BEGIN; …; ROLLBACK;` 在線上跑過一次驗語法（`scripts/check-sql-syntax.cjs` 在目前的 pg-query-emscripten 版本會炸 `Ma[...] is not a function`，連已上線的 `20260814030000` 也一樣，是工具的 wasm 狀態問題不是 SQL 有錯）。
- 不做：
  - 不動 `transferred_from_order_id` 既有語意，也沒改任何既有欄位／狀態機。舊資料照常運作。
  - 連結表只開 `SELECT` 給 `authenticated`（policy 比照 `auth_read_customer_orders` 的同租戶全開 —— 轉出店與收貨店在連結的兩端，只開一半會讓對面看不到在等誰）。寫入只走 SECURITY DEFINER 的兩支 RPC，沒有任何 INSERT/UPDATE policy。
  - 隨貨單沒帶 `?link=` 時（舊連結、手動開網址）沿用整張單的舊行為，不會壞掉。
- 回退：
  - 前端 revert 本 PR 即可（讀取路徑全部回到 `transferred_from_order_id`）。
  - SQL：`DROP TABLE public.customer_order_transfer_links;` ＋ 重新 apply `20260814030000` 的兩支 function。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

（新表帶 RLS policy，但那是資料表的一般存取控制、比照既有 `customer_orders` 的讀取政策，不是門禁／環境／密鑰設定。）

## 驗證

線上實測（套用後）：

- 回填 **567 條**連結，其中 **62 條**是原本完全查不到的「追加轉入」，`dest_item_ids` **全部**對得上品項（0 筆空陣列）。
- 松山 `OV-2-0001` 的轉出記錄現在查得到那一趟：link #508 → 古華店 `TF0486`、`appended=true`、`dest_item_ids=[102081]` = 「大溪順羽牧場囍願土雞蛋 ×1」——**只有蛋**，不是整張 5 件。
- 以松山（store 2）的視角撈「要交出去」的在途互助，回 3 列：蛋 1 件 → 古華、六色海藻 1 件 → 古華、小卷炊粉 1 件 → 南平。修改前松山這裡是空的。
- RLS：灌 `request.jwt.claims`（tenant + `store_manager`）以 `authenticated` 角色讀 → 567 筆；沒有 tenant claim → 0 筆。
- PostgREST：實打 `/rest/v1/customer_order_transfer_links`（含兩個具名 FK embed ＋ `!inner` ＋ `dest.status` 篩選）回 **HTTP 200**，embed 關係解得到、schema cache 已更新。
- `tsc --noEmit` 通過（另以一支故意寫錯的檔案確認 typecheck 真的有在跑）；`eslint` 0 error（OrderDetail 的 2 個 `react-hooks/exhaustive-deps` warning 是既有的，非本 PR 產生）。

### 全站盤點（套用前）

37 張轉入單、62 條隱形連結；其中 **8 條**的真實來源店跟 `transferred_from_order_id` 指的店不同（＝來源店真的查無此事），**3 條還在途中**：

| 轉入單 | 收貨店 | 真實來源 | 該欄指到 | 狀態 |
|---|---|---|---|---|
| `TF0486` | 古華店 | 松山店 `OV-2-0001` | 中和店 | pending ← 本次回報 |
| `TF0486` | 古華店 | 松山店 `AB-2-0001` | 中和店 | pending |
| `TF0497` | 平鎮店 | 古華店 `OV-41-0001` | 另一家 | ready |

### 已知未處理

`AidShipmentReminder` 的查詢加了 `!inner` ＋ 伺服端 `dest.status` 篩選並保留 `limit(500)`。連結表只增不減，日後若在途單量逼近 500 需要改成分頁 —— 目前在途數量遠低於此。