### PR TITLE
互助交流板加「進行中／歷史」分頁，到期貼文不再整筆刪除

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -115,6 +115,7 @@ const TYPE_COLOR: Record<PostType, string> = {
 export default function MutualAidPage() {
   const [posts, setPosts] = useState<Post[] | null>(null);
   const [stores, setStores] = useState<Store[]>([]);
+  const [view, setView] = useState<"active" | "history">("active");
   const [filter, setFilter] = useState<"all" | "request" | "offer">("all");
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
@@ -149,10 +150,11 @@ export default function MutualAidPage() {
         const sb = getSupabase();
         let q = sb
           .from("mutual_aid_board")
-          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, status, source_customer_order_id, spot_price, spot_description, spot_title, spot_unit, spot_images, spot_visible_to_other_stores, created_at, created_by")
-          .eq("status", "active")
-          .order("created_at", { ascending: false })
-          .limit(200);
+          .select("id, post_type, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, status, source_customer_order_id, spot_price, spot_description, spot_title, spot_unit, spot_images, spot_visible_to_other_stores, created_at, created_by");
+        // 歷史 = 已結束（已認領／已過期／已取消），對齊 rpc_purge_expired_aid_board
+        // 20260824000000 起到期不再刪除，這三種狀態才查得到完整歷史
+        q = view === "active" ? q.eq("status", "active") : q.neq("status", "active");
+        q = q.order("created_at", { ascending: false }).limit(200);
         if (filter !== "all") q = q.eq("post_type", filter);
         const { data, error: e } = await q;
         if (e) throw new Error(e.message);
@@ -205,7 +207,7 @@ export default function MutualAidPage() {
       }
     })();
     return () => { cancelled = true; };
-  }, [filter, reloadTick]);
+  }, [view, filter, reloadTick]);
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
@@ -219,7 +221,7 @@ export default function MutualAidPage() {
         <div className="flex gap-2">
           <SpinButton
             type="button"
-            onClick={() => printViaIframe(withBasePath(`/inventory/mutual-aid/print?type=${filter}`))}
+            onClick={() => printViaIframe(withBasePath(`/inventory/mutual-aid/print?type=${filter}&view=${view}`))}
             title="列印目前這個分頁的整份貼文清單（A4 橫式）；單獨一則請按該列右邊的 🖨️"
             className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
           >
@@ -249,6 +251,23 @@ export default function MutualAidPage() {
         </div>
       </header>
 
+      <div className="flex gap-1 border-b border-zinc-200 dark:border-zinc-800">
+        {(["active", "history"] as const).map((v) => (
+          <SpinButton
+            key={v}
+            type="button"
+            onClick={() => setView(v)}
+            className={
+              view === v
+                ? "border-b-2 border-zinc-900 px-4 py-2 text-sm font-medium text-zinc-900 dark:border-zinc-100 dark:text-zinc-100"
+                : "px-4 py-2 text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+            }
+          >
+            {v === "active" ? "進行中" : "歷史"}
+          </SpinButton>
+        ))}
+      </div>
+
       <div className="inline-flex w-fit overflow-hidden rounded-md border border-zinc-300 text-xs dark:border-zinc-700">
         {(["all", "request", "offer"] as const).map((opt) => (
           <SpinButton
@@ -276,7 +295,8 @@ export default function MutualAidPage() {
         <div className="text-sm text-zinc-500">載入中…</div>
       ) : posts.length === 0 ? (
         <div className="rounded-md border border-dashed border-zinc-300 p-8 text-center text-sm text-zinc-500 dark:border-zinc-700">
-          目前沒有進行中的{filter === "request" ? "需求" : filter === "offer" ? "釋出" : ""}貼文
+          {view === "active" ? "目前沒有進行中的" : "沒有已結束的"}
+          {filter === "request" ? "需求" : filter === "offer" ? "釋出" : ""}貼文
         </div>
       ) : (
         <ul className="space-y-2">

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/print/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/print/page.tsx
@@ -4,7 +4,9 @@
 //
 //   ?type=all|request|offer  → 清單模式（A4 橫式表格）。由 /inventory/mutual-aid 的
 //                              「🖨️ 列印」用隱藏 iframe 載入，查詢條件完全對齊列表頁
-//                              （status = active、created_at desc、limit 200）。
+//                              （created_at desc、limit 200）。
+//   &view=active|history     → 搭配清單模式：active（預設）= status=active，
+//                              history = status<>active（已認領／已過期／已取消）。
 //   ?id=<board_id>           → 單則模式（A4 直式單張）。板上每一則貼文自己的列印鈕，
 //                              **不濾 status** —— 已認領 / 已過期的也要印得出來，
 //                              店家常常是事後要補一張紙歸檔或跟對方對帳。
@@ -103,6 +105,7 @@ function Body() {
   const typeParam = sp.get("type");
   const filter: "all" | "request" | "offer" =
     typeParam === "request" || typeParam === "offer" ? typeParam : "all";
+  const view: "active" | "history" = sp.get("view") === "history" ? "history" : "active";
 
   const [rows, setRows] = useState<Row[] | null>(null);
   const [replies, setReplies] = useState<Reply[]>([]);
@@ -121,7 +124,8 @@ function Body() {
           // 單則：不濾 status（已認領 / 已過期也要印得出來）
           q = q.eq("id", singleId);
         } else {
-          q = q.eq("status", "active").order("created_at", { ascending: false }).limit(200);
+          q = view === "active" ? q.eq("status", "active") : q.neq("status", "active");
+          q = q.order("created_at", { ascending: false }).limit(200);
           if (filter !== "all") q = q.eq("post_type", filter);
         }
         const { data, error: e } = await q;
@@ -197,7 +201,7 @@ function Body() {
     return () => {
       cancelled = true;
     };
-  }, [filter, singleId]);
+  }, [filter, view, singleId]);
 
   // 載入完自動觸發列印（沒資料也印，讓「今天板上是空的」也留得下紙本）
   useEffect(() => {
@@ -232,17 +236,20 @@ function Body() {
       <PrintBar />
 
       <header className="mb-3">
-        <h1 className="text-xl font-bold">互助交流板 — {FILTER_LABEL[filter]}</h1>
+        <h1 className="text-xl font-bold">
+          互助交流板 — {FILTER_LABEL[filter]}・{view === "active" ? "進行中" : "歷史"}
+        </h1>
         <div className="mt-1 flex flex-wrap gap-x-4 text-xs text-zinc-600">
           <span>列印時間 {printedAt}</span>
           <span>共 {rows.length} 則（需求 {requestCount}・釋出 {offerCount}）</span>
-          <span>僅列出進行中的貼文</span>
+          <span>{view === "active" ? "僅列出進行中的貼文" : "僅列出已結束（已認領／已過期／已取消）的貼文"}</span>
         </div>
       </header>
 
       {rows.length === 0 ? (
         <div className="border border-dashed border-zinc-400 p-8 text-center text-sm text-zinc-500">
-          目前沒有進行中的{filter === "request" ? "需求" : filter === "offer" ? "釋出" : ""}貼文
+          {view === "active" ? "目前沒有進行中的" : "沒有已結束的"}
+          {filter === "request" ? "需求" : filter === "offer" ? "釋出" : ""}貼文
         </div>
       ) : (
         <table className="w-full border-collapse text-sm">
@@ -250,6 +257,7 @@ function Body() {
             <tr className="border-b border-zinc-500 bg-zinc-100 text-xs">
               <Th className="w-8">#</Th>
               <Th className="w-12">類型</Th>
+              {view === "history" && <Th className="w-14">狀態</Th>}
               <Th className="w-24">店別</Th>
               <Th>商品 / 品項</Th>
               <Th className="w-20 text-right">數量</Th>
@@ -267,6 +275,7 @@ function Body() {
                 <tr key={r.id} className="border-b border-zinc-300 align-top">
                   <Td>{idx + 1}</Td>
                   <Td className="font-medium">{TYPE_LABEL[r.post_type]}</Td>
+                  {view === "history" && <Td>{STATUS_LABEL[r.status]}</Td>}
                   <Td>{r.store_name}</Td>
                   <Td>
                     {r.sku_label}

--- a/supabase/migrations/20260824000000_aid_board_history.sql
+++ b/supabase/migrations/20260824000000_aid_board_history.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- 2026-08-24: 互助交流板要有歷史 —— 到期貼文不再整筆刪除
+--
+-- 現況（20260720000030 rpc_purge_expired_aid_board，唯一版本，已 grep 確認）：
+--   到期（expires_at < NOW()）且「沒人認領」（qty_remaining = qty_available
+--   且無 mutual_aid_claims 紀錄）的貼文會被整筆 DELETE（cascade 帶掉
+--   mutual_aid_replies）。這是絕大多數貼文的結局（沒人接手、自然到期），
+--   所以現行行為等於「大部分貼文都不留任何紀錄」——
+--   前端 /inventory/mutual-aid 又只查 status='active'，兩邊疊起來，
+--   一則貼文一旦不是進行中，店家就再也查不到「我們之前貼過什麼、
+--   誰接過」。
+--
+-- 改法：cron 到期清理**不再刪除**，一律和「有被部分認領」的分支一樣，
+--   標成 status='expired' 保留紀錄。deleted 分支整段拿掉。
+--   mutual_aid_claims 是死表（20260509000000 起 rpc_claim_aid 就廢了，
+--   apps/ 全站沒有寫入路徑），這裡不用再查它。
+--
+-- 沒有動到的：
+--   - rpc_close_aid_board（手動關貼 → cancelled）本來就不會被 purge 動到，
+--     一直都留著紀錄，這次沒改。
+--   - forbid_aid_reply_mutation / app.aid_board_purge 那組 escape hatch
+--     （20260720000030）：purge 不再 DELETE，這組用不到了，但留著無害
+--     （trigger 本體照樣擋一般的 UPDATE/DELETE），沒有必要在同一支
+--     migration 裡把它退回 forbid_append_only_mutation。
+--   - rpc_aid_board_active_count：badge 只算 status='active'，語意不變。
+--
+-- 前端另開 PR 補「進行中／歷史」分頁（apps/admin 的
+-- inventory/mutual-aid/page.tsx、print/page.tsx），純前端零 migration。
+--
+-- Rollback（回 20260720000030 的版本）：
+--   CREATE OR REPLACE FUNCTION public.rpc_purge_expired_aid_board()
+--   RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+--   AS $$
+--   DECLARE v_deleted INT; v_expired INT;
+--   BEGIN
+--     PERFORM set_config('app.aid_board_purge', 'on', true);
+--     WITH doomed AS (
+--       DELETE FROM mutual_aid_board b
+--        WHERE b.status = 'active' AND b.expires_at < NOW()
+--          AND b.qty_remaining = b.qty_available
+--          AND NOT EXISTS (SELECT 1 FROM mutual_aid_claims c WHERE c.board_id = b.id)
+--       RETURNING b.id
+--     )
+--     SELECT COUNT(*) INTO v_deleted FROM doomed;
+--     PERFORM set_config('app.aid_board_purge', '', true);
+--     WITH marked AS (
+--       UPDATE mutual_aid_board b SET status = 'expired'
+--        WHERE b.status = 'active' AND b.expires_at < NOW()
+--       RETURNING b.id
+--     )
+--     SELECT COUNT(*) INTO v_expired FROM marked;
+--     RETURN jsonb_build_object('deleted', v_deleted, 'marked_expired', v_expired);
+--   END;
+--   $$;
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_purge_expired_aid_board()
+RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_expired INT;
+BEGIN
+  -- 到期一律標 expired 保留紀錄，不再整筆刪除（互助交流板要有歷史）
+  WITH marked AS (
+    UPDATE mutual_aid_board b
+       SET status = 'expired'
+     WHERE b.status = 'active'
+       AND b.expires_at < NOW()
+    RETURNING b.id
+  )
+  SELECT COUNT(*) INTO v_expired FROM marked;
+
+  RETURN jsonb_build_object('marked_expired', v_expired);
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_purge_expired_aid_board IS
+  '互助板到期清理（cron 每 10 分鐘）：到期貼文一律標 status=expired 保留紀錄，'
+  '2026-08-24 起不再刪除（互助交流板要有歷史）。回 {marked_expired}。';


### PR DESCRIPTION
## 做了什麼

「互助交流要有歷史」：

- `rpc_purge_expired_aid_board`（cron 每 10 分鐘跑）：到期貼文一律標 `status=expired` 保留紀錄，不再對「沒人認領」的到期貼文整筆刪除。這是絕大多數貼文的結局，改之前等於大部分貼文都不留任何紀錄。
- `/inventory/mutual-aid`：加「進行中／歷史」分頁（歷史 = `status <> active`，即已認領／已過期／已取消），跟既有「全部／需求中／釋出中」的商品類型篩選並存。
- `/inventory/mutual-aid/print`：清單列印模式同步支援 `&view=history`，歷史模式的表格多一欄「狀態」（進行中列印時原本就都是 active，不需要這欄）。

## 上線危險

- 做了：改一支既有 RPC（`rpc_purge_expired_aid_board`，只改它自己，不動其他函式）；純前端加分頁與查詢條件，零其他行為改動。
- 不做：不動貼文的認領／關貼／編輯邏輯；不動 `mutual_aid_replies` 的 append-only 守門（trigger 本體不變，只是它的 purge escape hatch 現在用不到了，留著無害）。
- 回退：migration 檔頭附了 rollback SQL（改回 20260720000030 版本的整筆刪除行為）；前端兩個檔案是加法為主，`git revert` 即可。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `node scripts/check-sql-syntax.cjs supabase/migrations/20260824000000_aid_board_history.sql` 通過。
- `apps/admin`: `tsc --noEmit` 通過；`eslint` 兩個改動檔案都沒有新增錯誤（既有的 7 個 `react-hooks/set-state-in-effect` 是改動前就存在，跟這次改動無關）。
- ⚠️ **這支 migration 還沒套上正式庫** —— sandbox 的權限分類器擋下了直打 Management API 的動作，需要人工用 CLAUDE.md 記載的方式（`POST /v1/projects/anfyoeviuhmzzrhilwtm/database/query`）手動套用，套完當天記得確認這個 PR 真的合併進 main（`git log origin/main -- supabase/migrations/20260824000000_aid_board_history.sql`）。套用前建議先重查一次線上 `rpc_purge_expired_aid_board` 的 `prosrc` 有沒有跟 repo 的 20260720000030 版本一致（我套用前查過，當時一致）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDUgyM9AusgWnGxP7FDBcZ)_