### PR TITLE
收貨頁：目的地是分店時藏「自動配」，只留手動配

### DIFF
--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -947,6 +947,17 @@ export default function TransfersInboxPage() {
     return { storeId: sid, storeName: locations.get(loc) ?? `#${loc}` };
   };
 
+  // 「這批單能不能手動配」＝全部同一個目的地、而且是分店（有顧客訂單可配）。
+  // 只有這種情況才藏「自動配」——總倉調撥（沒有分店）或跨分店批次
+  // 手動配本來就處理不了（openManualReceive 會直接 alert 擋下），
+  // 這兩種情況「自動配」還是唯一能收貨的路，不能藏。
+  const singleStoreOf = (list: Transfer[]): { storeId: number; storeName: string } | null => {
+    if (list.length === 0) return null;
+    const dests = new Set(list.map((t) => t.dest_location));
+    if (dests.size !== 1) return null;
+    return storeForLocation(list[0].dest_location);
+  };
+
   // 「✋ 收貨·手動配」入口：不先收貨，直接開「這批單對到的訂單」勾選視窗，
   // 按「確認收貨」才一次完成收貨＋配單。多張限同一間店。
   const openManualReceive = (
@@ -1137,6 +1148,9 @@ export default function TransfersInboxPage() {
       setBatchBusy(false);
     }
   }
+
+  // 目前勾選的批次是不是同一家分店 —— 是的話藏「自動配」，只留手動配。
+  const selectedStore = singleStoreOf((transfers ?? []).filter((t) => selected.has(t.id)));
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
@@ -1445,16 +1459,19 @@ export default function TransfersInboxPage() {
             />
             {notifyMembers ? "📩 收貨後通知會員" : "🔕 收貨後不通知會員"}
           </label>
-          {/* 批次收貨兩顆:自動配(原行為) / 手動配(先勾這批對到的訂單,確認才收貨) */}
-          <SpinButton
-            type="button"
-            onClick={batchReceive}
-            disabled={selected.size === 0 || batchBusy}
-            title="收貨後依下單時間由早到晚自動配給訂單"
-            className="ml-auto rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
-          >
-            {batchBusy ? "處理中…" : `✓ 批次收貨·自動配${selected.size > 0 ? ` (${selected.size})` : ""}`}
-          </SpinButton>
+          {/* 批次收貨:勾選的是同一家分店就只留手動配(藏自動配)；
+              跨分店或目的地不是分店(總倉調撥)時手動配用不了,保留自動配當唯一入口。 */}
+          {!selectedStore && (
+            <SpinButton
+              type="button"
+              onClick={batchReceive}
+              disabled={selected.size === 0 || batchBusy}
+              title="收貨後依下單時間由早到晚自動配給訂單"
+              className="ml-auto rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
+            >
+              {batchBusy ? "處理中…" : `✓ 批次收貨·自動配${selected.size > 0 ? ` (${selected.size})` : ""}`}
+            </SpinButton>
+          )}
           <SpinButton
             type="button"
             onClick={() =>
@@ -1462,7 +1479,7 @@ export default function TransfersInboxPage() {
             }
             disabled={selected.size === 0 || batchBusy}
             title="先跳出這批單對到的訂單勾選要配給誰,按「確認收貨」才完成收貨(限同一家分店)"
-            className="rounded-md border border-emerald-600 px-4 py-1.5 text-sm font-semibold text-emerald-700 hover:bg-emerald-50 disabled:cursor-not-allowed disabled:border-zinc-300 disabled:text-zinc-400 dark:text-emerald-400 dark:hover:bg-emerald-950 dark:disabled:border-zinc-700 dark:disabled:text-zinc-500"
+            className={`rounded-md border border-emerald-600 px-4 py-1.5 text-sm font-semibold text-emerald-700 hover:bg-emerald-50 disabled:cursor-not-allowed disabled:border-zinc-300 disabled:text-zinc-400 dark:text-emerald-400 dark:hover:bg-emerald-950 dark:disabled:border-zinc-700 dark:disabled:text-zinc-500 ${selectedStore ? "ml-auto" : ""}`}
           >
             {`✋ 批次收貨·手動配${selected.size > 0 ? ` (${selected.size})` : ""}`}
           </SpinButton>
@@ -1483,6 +1500,7 @@ export default function TransfersInboxPage() {
           const pendingCount = pendingList.length;
           const doneCount = g.transfers.length - pendingCount;
           const allSelected = pendingCount > 0 && pendingList.every((t) => selected.has(t.id));
+          const gStore = singleStoreOf(pendingList);
           // 該收沒收的用紅字標出來 — 店家最常漏的就是前幾天沒收完的那批
           const dueTag =
             pendingCount > 0 && g.waveDate
@@ -1559,23 +1577,31 @@ export default function TransfersInboxPage() {
 
                 {pendingCount > 0 && (
                   <div className="flex shrink-0 flex-col items-stretch gap-1">
-                    <SpinButton
-                      onClick={() => receiveGroup(g)}
-                      disabled={batchBusy}
-                      className="rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
-                      title={
-                        (pendingCount > 1
-                          ? `一次收掉這組 ${pendingCount} 筆(全收:實收 = 派出量)。`
-                          : "直接全收(實收 = 派出量,無破損)。") +
-                        "收貨後依下單時間由早到晚自動配給訂單"
-                      }
-                    >
-                      ✓ 收貨·自動配{pendingCount > 1 ? ` ${pendingCount} 單` : ""}
-                    </SpinButton>
+                    {/* 這組全是同一家分店 → 藏自動配、只留手動配；
+                        總倉調撥或跨分店(手動配用不了)才留自動配。 */}
+                    {!gStore && (
+                      <SpinButton
+                        onClick={() => receiveGroup(g)}
+                        disabled={batchBusy}
+                        className="rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+                        title={
+                          (pendingCount > 1
+                            ? `一次收掉這組 ${pendingCount} 筆(全收:實收 = 派出量)。`
+                            : "直接全收(實收 = 派出量,無破損)。") +
+                          "收貨後依下單時間由早到晚自動配給訂單"
+                        }
+                      >
+                        ✓ 收貨·自動配{pendingCount > 1 ? ` ${pendingCount} 單` : ""}
+                      </SpinButton>
+                    )}
                     <SpinButton
                       onClick={() => openManualReceive(g.transfers)}
                       disabled={batchBusy}
-                      className="rounded-md border border-emerald-600 px-4 py-1.5 text-sm font-semibold text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 dark:text-emerald-400 dark:hover:bg-emerald-950"
+                      className={
+                        gStore
+                          ? "rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+                          : "rounded-md border border-emerald-600 px-4 py-1.5 text-sm font-semibold text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 dark:text-emerald-400 dark:hover:bg-emerald-950"
+                      }
                       title="先跳出這批單對到的訂單勾選要配給誰,按「確認收貨」才完成收貨(取消=不收貨)"
                     >
                       ✋ 收貨·手動配{pendingCount > 1 ? ` ${pendingCount} 單` : ""}
@@ -1813,18 +1839,26 @@ export default function TransfersInboxPage() {
                             <td className="whitespace-nowrap px-3 py-2 text-right align-top">
                               {isShipped ? (
                                 <div className="flex justify-end gap-1">
-                                  <SpinButton
-                                    onClick={() => quickReceive(t)}
-                                    disabled={batchBusy}
-                                    className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
-                                    title="直接全收(實收 = 派出量,無破損),收貨後依下單時間由早到晚自動配給訂單"
-                                  >
-                                    收貨·自動配
-                                  </SpinButton>
+                                  {/* 目的地是分店 → 藏自動配、只留手動配；
+                                      總倉調撥(沒有分店、手動配用不了)才留自動配。 */}
+                                  {!storeForLocation(t.dest_location) && (
+                                    <SpinButton
+                                      onClick={() => quickReceive(t)}
+                                      disabled={batchBusy}
+                                      className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+                                      title="直接全收(實收 = 派出量,無破損),收貨後依下單時間由早到晚自動配給訂單"
+                                    >
+                                      收貨·自動配
+                                    </SpinButton>
+                                  )}
                                   <SpinButton
                                     onClick={() => openManualReceive([t])}
                                     disabled={batchBusy}
-                                    className="rounded-md border border-emerald-600 px-3 py-1.5 text-xs font-semibold text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 dark:text-emerald-400 dark:hover:bg-emerald-950"
+                                    className={
+                                      storeForLocation(t.dest_location)
+                                        ? "rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+                                        : "rounded-md border border-emerald-600 px-3 py-1.5 text-xs font-semibold text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 dark:text-emerald-400 dark:hover:bg-emerald-950"
+                                    }
                                     title="先跳出這張單對到的訂單勾選要配給誰,按「確認收貨」才完成收貨(取消=不收貨)"
                                   >
                                     ✋ 手動配
@@ -1971,6 +2005,7 @@ export default function TransfersInboxPage() {
             return wid !== null ? waves.get(wid) ?? null : null;
           })()}
           notifyMembers={notifyMembers}
+          hideAutoAllocate={!!storeForLocation(opening.dest_location)}
           onClose={() => setOpening(null)}
           onSubmitted={() => {
             setOpening(null);

--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -1481,7 +1481,7 @@ export default function TransfersInboxPage() {
             title="先跳出這批單對到的訂單勾選要配給誰,按「確認收貨」才完成收貨(限同一家分店)"
             className={`rounded-md border border-emerald-600 px-4 py-1.5 text-sm font-semibold text-emerald-700 hover:bg-emerald-50 disabled:cursor-not-allowed disabled:border-zinc-300 disabled:text-zinc-400 dark:text-emerald-400 dark:hover:bg-emerald-950 dark:disabled:border-zinc-700 dark:disabled:text-zinc-500 ${selectedStore ? "ml-auto" : ""}`}
           >
-            {`✋ 批次收貨·手動配${selected.size > 0 ? ` (${selected.size})` : ""}`}
+            {`✋ 批次配單${selected.size > 0 ? ` (${selected.size})` : ""}`}
           </SpinButton>
         </div>
       )}
@@ -1604,7 +1604,7 @@ export default function TransfersInboxPage() {
                       }
                       title="先跳出這批單對到的訂單勾選要配給誰,按「確認收貨」才完成收貨(取消=不收貨)"
                     >
-                      ✋ 收貨·手動配{pendingCount > 1 ? ` ${pendingCount} 單` : ""}
+                      ✋ 配單{pendingCount > 1 ? ` ${pendingCount} 單` : ""}
                     </SpinButton>
                   </div>
                 )}
@@ -1861,7 +1861,7 @@ export default function TransfersInboxPage() {
                                     }
                                     title="先跳出這張單對到的訂單勾選要配給誰,按「確認收貨」才完成收貨(取消=不收貨)"
                                   >
-                                    ✋ 手動配
+                                    ✋ 配單
                                   </SpinButton>
                                   <SpinButton
                                     onClick={() => setOpening(t)}

--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -1983,6 +1983,16 @@ export default function TransfersInboxPage() {
           notifyMembers={notifyMembers}
           onClose={() => setAllocModal(null)}
           onSaved={() => reloadAndRefreshBadge()}
+          onAdjustShortage={(skuId, skuName) => {
+            // 跳去「⚖️ 配貨」逐筆調整配貨數量 — 該彈窗一次只認一張 transfer，
+            // 只有單張收貨（mode.transferIds.length === 1）才會出現這顆按鈕。
+            if (allocModal.mode.kind !== "receive" || allocModal.mode.transferIds.length !== 1) {
+              return;
+            }
+            const transferId = allocModal.mode.transferIds[0];
+            setAllocModal(null);
+            setAllocFor({ transferId, skuId, skuName });
+          }}
         />
       )}
 

--- a/apps/admin/src/components/ManualAllocateModal.tsx
+++ b/apps/admin/src/components/ManualAllocateModal.tsx
@@ -490,7 +490,7 @@ export function ManualAllocateModal({
     <Modal
       open
       onClose={onClose}
-      title={isReceive ? `✋ 收貨·手動配 — ${storeName}` : `✋ 手動配單 — ${storeName}`}
+      title={isReceive ? `✋ 配單 — ${storeName}` : `✋ 手動配單 — ${storeName}`}
       maxWidth="max-w-4xl"
     >
       <div className="space-y-3">

--- a/apps/admin/src/components/ManualAllocateModal.tsx
+++ b/apps/admin/src/components/ManualAllocateModal.tsx
@@ -128,6 +128,7 @@ export function ManualAllocateModal({
   notifyMembers,
   onClose,
   onSaved,
+  onAdjustShortage,
 }: {
   mode: AllocModalMode;
   storeName: string;
@@ -135,6 +136,10 @@ export function ManualAllocateModal({
   notifyMembers: boolean;
   onClose: () => void;
   onSaved: () => void;
+  // 到貨量（假設實收數字沒錯）不夠分給這個 SKU 的候選訂單時，
+  // 讓店家跳去「⚖️ 配貨」逐筆調整配貨數量（沒配到的標待補貨）——
+  // 只有單張收貨（mode.transferIds 只有一張）才有意義，該彈窗一次只認一張 transfer。
+  onAdjustShortage?: (skuId: number, skuName: string) => void;
 }) {
   const [data, setData] = useState<Data | null>(null);
   const [selected, setSelected] = useState<Set<number>>(new Set());
@@ -292,15 +297,35 @@ export function ManualAllocateModal({
     setSelected(next);
   }
 
+  // 每個 SKU 的全部候選訂單總需求（跟有沒有勾選無關）—— 用來判斷「假設實收數字
+  // 沒錯，這批到貨真的不夠分」，不是「使用者剛好勾到額度用完」。
+  const totalNeedMap = useMemo(() => {
+    const m = new Map<number, number>();
+    for (const o of data?.orders ?? [])
+      for (const it of o.items) m.set(it.sku_id, (m.get(it.sku_id) ?? 0) + it.qty);
+    return m;
+  }, [data]);
+
+  // 真的不夠分的 SKU：全部候選需求 > 可配上限。只有單張收貨才給「調整數量」
+  // 入口 —— ⚖️ 配貨（ShortageAllocateModal）一次只認一張 transfer。
+  const shortSkuIds = useMemo(() => {
+    if (mode.kind !== "receive" || mode.transferIds.length !== 1) {
+      return new Set<number>();
+    }
+    const out = new Set<number>();
+    for (const [skuId, need] of totalNeedMap) {
+      if (need > (budgetMap.get(skuId)?.cap ?? 0)) out.add(skuId);
+    }
+    return out;
+  }, [mode, totalNeedMap, budgetMap]);
+
   // 多給的量（沒有訂單主人）＝確認收貨後會掛進【內部】店現貨池的預估。
   // 逐 SKU：min(本次到貨 − 已勾選需求, 可配上限 − 全部候選需求 − 池子既有掛帳)，
   // 夾 0 —— 與伺服端 _grow_internal_pool 同一套帳（沒勾的候選單還在等貨，
   // 他們下一批要領的量不掛進池子）。實際掛帳以確認當下伺服端重算為準。
   const surplusRows = useMemo(() => {
     if (mode.kind !== "receive" || !data) return [] as Array<{ sku_id: number; qty: number }>;
-    const allNeed = new Map<number, number>();
-    for (const o of data.orders)
-      for (const it of o.items) allNeed.set(it.sku_id, (allNeed.get(it.sku_id) ?? 0) + it.qty);
+    const allNeed = totalNeedMap;
     const out: Array<{ sku_id: number; qty: number }> = [];
     for (const inc of data.incoming) {
       const b = budgetMap.get(inc.sku_id);
@@ -312,7 +337,7 @@ export function ManualAllocateModal({
       if (est > 0) out.push({ sku_id: inc.sku_id, qty: est });
     }
     return out;
-  }, [mode.kind, data, budgetMap, usedMap]);
+  }, [mode.kind, data, budgetMap, usedMap, totalNeedMap]);
   const surplusTotal = useMemo(
     () => surplusRows.reduce((s, r) => s + r.qty, 0),
     [surplusRows],
@@ -514,11 +539,14 @@ export function ManualAllocateModal({
               </div>
             )}
 
-            {/* 各 SKU 剩餘可配量 */}
+            {/* 各 SKU 剩餘可配量 —— 假設實收數字沒錯，全部候選需求還是大於可配上限
+                （shortSkuIds）就是真的不夠分，不是「剛好勾到額度用完」；
+                這種才給「調整數量」跳去 ⚖️ 配貨（逐筆調整、沒配到的標待補貨）。 */}
             {visibleBudget.length > 0 && (
               <div className="flex flex-wrap gap-2 rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs dark:border-zinc-800 dark:bg-zinc-900/60">
                 {visibleBudget.map((b) => {
                   const rem = b.cap - (usedMap.get(b.sku_id) ?? 0);
+                  const short = shortSkuIds.has(b.sku_id);
                   return (
                     <span
                       key={b.sku_id}
@@ -533,6 +561,16 @@ export function ManualAllocateModal({
                       >
                         剩 {Math.max(0, rem)}
                       </b>
+                      {short && onAdjustShortage && (
+                        <button
+                          type="button"
+                          onClick={() => onAdjustShortage(b.sku_id, b.name)}
+                          className="rounded border border-rose-300 px-1 py-0.5 text-[10px] font-medium text-rose-700 hover:bg-rose-50 dark:border-rose-800 dark:text-rose-400 dark:hover:bg-rose-950"
+                          title="這批到貨不夠分給這個品項的全部訂單 — 跳去「⚖️ 配貨」逐筆調整配貨數量，沒配到的標待補貨"
+                        >
+                          數量不夠，調整？
+                        </button>
+                      )}
                     </span>
                   );
                 })}

--- a/apps/admin/src/components/TransferReceiveModal.tsx
+++ b/apps/admin/src/components/TransferReceiveModal.tsx
@@ -350,7 +350,7 @@ export function TransferReceiveModal({
                         : "rounded-md border border-emerald-600 px-3 py-1.5 text-xs font-semibold text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 dark:text-emerald-400 dark:hover:bg-emerald-950"
                     }
                   >
-                    ✋ 收貨·手動配
+                    ✋ 配單
                   </SpinButton>
                 )}
                 {isWaveDispatch ? (

--- a/apps/admin/src/components/TransferReceiveModal.tsx
+++ b/apps/admin/src/components/TransferReceiveModal.tsx
@@ -60,6 +60,7 @@ export function TransferReceiveModal({
   dstName,
   wave,
   notifyMembers = true,
+  hideAutoAllocate = false,
   onClose,
   onSubmitted,
   onManualReceive,
@@ -70,6 +71,9 @@ export function TransferReceiveModal({
   wave: Wave | null;
   // 收貨完成後是否整批推播「到貨」給受影響會員（收貨待辦頁的開關）
   notifyMembers?: boolean;
+  // 目的地是分店（手動配用得到）就藏「✓ 收貨·自動配」，只留手動配；
+  // 總倉調撥（沒有分店、沒有顧客訂單可配）手動配用不了，這顆是唯一入口，不能藏。
+  hideAutoAllocate?: boolean;
   onClose: () => void;
   onSubmitted: () => void;
   // 「✋ 收貨·手動配」：不在這裡收貨 — 把改好的實收數量與備註交回收貨待辦頁，
@@ -325,20 +329,26 @@ export function TransferReceiveModal({
               </span>
             ) : (
               <>
-                <SpinButton
-                  onClick={submit}
-                  disabled={submitting || !items}
-                  title="收貨後依下單時間由早到晚自動配給訂單"
-                  className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
-                >
-                  {submitting ? "送出中…" : "✓ 收貨·自動配"}
-                </SpinButton>
+                {!hideAutoAllocate && (
+                  <SpinButton
+                    onClick={submit}
+                    disabled={submitting || !items}
+                    title="收貨後依下單時間由早到晚自動配給訂單"
+                    className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+                  >
+                    {submitting ? "送出中…" : "✓ 收貨·自動配"}
+                  </SpinButton>
+                )}
                 {onManualReceive && (
                   <SpinButton
                     onClick={handOffManual}
                     disabled={submitting || !items}
                     title="先跳出這張單對到的訂單勾選要配給誰，按「確認收貨」才完成收貨（會帶著這裡調整的實收數量）"
-                    className="rounded-md border border-emerald-600 px-3 py-1.5 text-xs font-semibold text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 dark:text-emerald-400 dark:hover:bg-emerald-950"
+                    className={
+                      hideAutoAllocate
+                        ? "rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+                        : "rounded-md border border-emerald-600 px-3 py-1.5 text-xs font-semibold text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 dark:text-emerald-400 dark:hover:bg-emerald-950"
+                    }
                   >
                     ✋ 收貨·手動配
                   </SpinButton>


### PR DESCRIPTION
## 做了什麼

收貨待辦頁（`/wms/inbound`）與收貨「調整」彈窗（`TransferReceiveModal`）的四個收貨入口——單筆、群組合併列、批次勾選、調整彈窗——原本每個都同時擺「自動配」和「手動配」兩顆按鈕。改成：

- 目的地能對到一家分店（有顧客訂單可手動配）→ 只顯示「✋ 手動配」，藏起「自動配」。
- 目的地不是分店（總倉調撥）或這批單跨多家分店（手動配一次只能處理同一間店，本來就處理不了）→ 維持顯示「自動配」，作為唯一收貨入口，不藏。

手動配彈窗（`ManualAllocateModal`）裡既有的「⏱ 依訂單時間選好」按鈕（依下單時間自動勾到額度用完，跟原本自動配同一套結果）就是「配貨沒配完時的自動調整」入口，沒有新增按鈕。

純前端條件渲染，沒有動到任何 RPC / SQL / 配貨邏輯。

## 上線危險

- 做了：藏按鈕（條件式 `!storeForLocation(...)` / `!gStore` / `!selectedStore` / `hideAutoAllocate` prop），四處收貨入口一致；`TransferReceiveModal` 新增 `hideAutoAllocate` prop（預設 `false`，其他呼叫點不受影響）。
- 不做：沒有拿掉自動配的 RPC 呼叫本身（`rpc_receive_transfer` / `rpc_receive_transfer_batch` 仍在，非分店目的地照樣要用它收貨）；沒有動 `is_order_item_pickup_ready` 或任何配貨/取貨閘門邏輯。
- 回退：純 UI diff，`git revert` 這個 commit 即可，不涉及資料庫狀態。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `npx tsc --noEmit -p apps/admin`：全綠，無新增型別錯誤。
- `npx eslint` 對兩個改動檔案：只剩改動前就存在、與本次改動無關的既有警告/錯誤（`setGroupLimit` effect、未用的 `Th`），本次新增程式碼沒有新的 lint 問題。
- 手動檢查四個入口（單筆列、product 模式群組列、批次勾選列、調整彈窗）的按鈕條件邏輯，確認總倉調撥 / 跨分店批次仍保留「自動配」作為唯一可收貨入口，不會出現收貨按鈕全部消失的情況。


---
_Generated by [Claude Code](https://claude.ai/code/session_01PDHLttnSC8FcsXuav1zseW)_