### PR TITLE
互助一趟一張單：不再併進容器單、看得到誰提供了、單號不再印內部代號

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -10,6 +10,7 @@ import { ProductImagesField } from "@/components/ProductImagesField";
 import { printViaIframe } from "@/lib/printIframe";
 import { withBasePath } from "@/lib/basePath";
 import { useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
+import { shortOrderNo } from "@/lib/orderTitle";
 import {
   TRANSFER_LINK_SELECT, type TransferLink,
   activeQty, aidRouteLabel, aidStageLabel, isAidInFlight, linkItems,
@@ -448,6 +449,151 @@ export default function MutualAidPage() {
 }
 
 // ============================================================
+// 提供紀錄 —— 這則貼文被哪幾家店接走 / 補上了
+//
+// 點開貼文只看得到留言、看不到「誰真的出了貨」（2026-08-24 回報）。
+// 認領／提供的本體是訂單轉移，所以紀錄在 customer_order_transfer_links，
+// 不在 mutual_aid_board 也不在留言。
+//
+// ⚠ 這裡用 reason 認貼文，不是用 aid_board_id：那一欄是 20260824060000 才加的，
+// SQL 有沒有先套上正式庫不是前端控制得了的（#827 就發生過「PR 合併了、
+// migration 沒套」）。撈不存在的欄位整段會 400。伺服端先用 `#<id>` 收窄，
+// 再在前端用嚴格的 regex 濾掉 #2490 這種誤中。
+// ============================================================
+function AidClaimLog({ post }: { post: Post }) {
+  const [rows, setRows] = useState<ProvidedRow[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data, error } = await sb
+          .from("customer_order_transfer_links")
+          .select(
+            TRANSFER_LINK_SELECT + ", reason, " +
+              "src:customer_orders!customer_order_transfer_links_source_order_id_fkey(" +
+              "id, order_no, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)), " +
+              "dest:customer_orders!customer_order_transfer_links_dest_order_id_fkey(" +
+              "id, order_no, status, pickup_store_id, " +
+              "store:stores!customer_orders_pickup_store_id_fkey(name), " +
+              "items:customer_order_items(id, qty, status, source, " +
+              "sku:skus(sku_code, product_name, variant_name)))",
+          )
+          .ilike("reason", `%#${post.id}%`)
+          .order("transferred_at", { ascending: true })
+          .limit(50);
+        if (cancelled) return;
+        if (error) { setRows([]); return; }
+        // 「互助板提供 #249」/「互助板認領 #249」；#2490 不能算進來
+        const exact = new RegExp(`互助板[^#]*#${post.id}(?!\\d)`);
+        type StoreRef = { name: string } | { name: string }[] | null;
+        type RawSku = { sku_code: string; product_name: string; variant_name: string | null };
+        type Raw = TransferLink & {
+          reason: string | null;
+          src: { id: number; order_no: string; pickup_store_id: number | null; store: StoreRef } | null;
+          dest: {
+            id: number; order_no: string; status: string; pickup_store_id: number | null;
+            store: StoreRef;
+            items: { id: number; qty: number; status: string; source: string | null; sku: RawSku | RawSku[] | null }[] | null;
+          } | null;
+        };
+        const nameOf = (s: StoreRef) => (Array.isArray(s) ? s[0]?.name : s?.name) ?? "—";
+        const list = ((data ?? []) as unknown as Raw[]).flatMap((r): ProvidedRow[] => {
+          if (!exact.test(r.reason ?? "")) return [];
+          const src = r.src, dest = r.dest;
+          if (!src || !dest) return [];
+          const mine = linkItems(r, dest.items ?? []);
+          const qty = activeQty(mine);
+          return [{
+            linkId: r.id,
+            transferred_at: r.transferred_at,
+            is_air_transfer: r.is_air_transfer === true,
+            board_id: post.id,
+            reason: r.reason,
+            source_store: nameOf(src.store),
+            source_order_no: src.order_no,
+            dest_store: nameOf(dest.store),
+            dest_store_id: dest.pickup_store_id,
+            dest_order_id: dest.id,
+            dest_order_no: dest.order_no,
+            dest_status: dest.status,
+            qty,
+            labels: mine
+              .filter((it) => !["cancelled", "expired"].includes(it.status))
+              .map((it) => {
+                const sku = Array.isArray(it.sku) ? it.sku[0] : it.sku;
+                return sku
+                  ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} ×${Number(it.qty)}`
+                  : `品項 ×${Number(it.qty)}`;
+              }),
+          }];
+        });
+        setRows(list);
+      } catch {
+        if (!cancelled) setRows([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [post.id]);
+
+  if (rows === null) return <div className="text-xs text-zinc-500">載入提供紀錄…</div>;
+  if (rows.length === 0) return null;
+
+  // 需求貼文＝別人「提供」給貼文店；釋出貼文＝別人「認領」走
+  const verb = post.post_type === "request" ? "提供" : "認領";
+
+  return (
+    <div className="rounded-md border border-zinc-200 bg-zinc-50 p-2 dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="mb-1.5 text-[11px] font-semibold text-zinc-600 dark:text-zinc-400">
+        {verb}紀錄（{rows.length} 筆）
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {rows.map((r) => (
+          <div
+            key={r.linkId}
+            className="rounded border border-zinc-200 bg-white p-2 text-xs dark:border-zinc-800 dark:bg-zinc-900"
+          >
+            <div className="mb-1 flex flex-wrap items-center gap-1.5">
+              <span className="rounded bg-pink-100 px-1.5 py-0.5 text-[10px] font-semibold text-pink-800 dark:bg-pink-950 dark:text-pink-300">
+                {post.post_type === "request" ? r.source_store : r.dest_store}
+              </span>
+              <span className="text-[10px] text-zinc-500">{aidRouteLabel(r.is_air_transfer)}</span>
+              <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+                {aidStageLabel(r.dest_status, r.is_air_transfer)}
+              </span>
+              <span className="ml-auto text-[10px] text-zinc-500">{fmtDt(r.transferred_at)}</span>
+            </div>
+            <div className="text-zinc-700 dark:text-zinc-300">{r.labels.join("、") || `共 ${r.qty}`}</div>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-zinc-500">
+              <span>
+                {post.post_type === "request" ? "送到" : "送給"}{" "}
+                <span className="text-zinc-700 dark:text-zinc-300">{r.dest_store}</span>
+              </span>
+              <span>
+                單號 <span className="font-mono text-zinc-700 dark:text-zinc-300">{shortOrderNo(r.dest_order_no)}</span>
+              </span>
+              <SpinButton
+                type="button"
+                onClick={() =>
+                  printViaIframe(
+                    withBasePath(`/transfers/print-aid?order_id=${r.dest_order_id}&link=${r.linkId}`),
+                  )
+                }
+                title="列印這一趟的互助出貨單（兩聯：司機聯 + 存查聯）"
+                className="ml-auto rounded border border-zinc-300 px-1.5 py-0.5 text-[10px] text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+              >
+                🖨️ 隨貨單
+              </SpinButton>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
 // 我提供出去的 —— 本店轉出去的互助，一趟轉移一列
 //
 // 為什麼不是查訂單而是查 customer_order_transfer_links：
@@ -624,7 +770,7 @@ function ProvidedList({ stores }: { stores: Store[] }) {
                     className="text-blue-600 underline dark:text-blue-400"
                     href={`/orders?q=${encodeURIComponent(r.dest_order_no)}${r.dest_store_id != null ? `&storeId=${r.dest_store_id}` : ""}`}
                   >
-                    轉入單 {r.dest_order_no}
+                    轉入單 {shortOrderNo(r.dest_order_no)}
                   </Link>
                   {r.reason && !r.reason.startsWith("[回填]") && (
                     <span className="text-zinc-700 dark:text-zinc-300">「{r.reason}」</span>
@@ -1942,6 +2088,9 @@ function ThreadModal({
             </div>
           </div>
         )}
+
+        {/* 提供紀錄：這則貼文被哪幾家店接走 / 補上了 */}
+        <AidClaimLog post={post} />
 
         {/* Replies thread */}
         <div className="flex flex-col gap-2 max-h-80 overflow-y-auto pr-1">

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -468,24 +468,45 @@ function AidClaimLog({ post }: { post: Post }) {
     (async () => {
       try {
         const sb = getSupabase();
-        const { data, error } = await sb
-          .from("customer_order_transfer_links")
-          .select(
-            TRANSFER_LINK_SELECT + ", reason, " +
-              "src:customer_orders!customer_order_transfer_links_source_order_id_fkey(" +
-              "id, order_no, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)), " +
-              "dest:customer_orders!customer_order_transfer_links_dest_order_id_fkey(" +
-              "id, order_no, status, pickup_store_id, " +
-              "store:stores!customer_orders_pickup_store_id_fkey(name), " +
-              "items:customer_order_items(id, qty, status, source, " +
-              "sku:skus(sku_code, product_name, variant_name)))",
-          )
-          .ilike("reason", `%#${post.id}%`)
-          .order("transferred_at", { ascending: true })
-          .limit(50);
+        const SEL =
+          TRANSFER_LINK_SELECT + ", reason, " +
+          "src:customer_orders!customer_order_transfer_links_source_order_id_fkey(" +
+          "id, order_no, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)), " +
+          "dest:customer_orders!customer_order_transfer_links_dest_order_id_fkey(" +
+          "id, order_no, status, pickup_store_id, " +
+          "store:stores!customer_orders_pickup_store_id_fkey(name), " +
+          "items:customer_order_items(id, qty, status, source, " +
+          "sku:skus(sku_code, product_name, variant_name)))";
+
+        // 兩條路一起撈，因為單靠 reason 只找得到新資料：
+        //   (1) reason 帶貼文編號 —— 兩個對話框的預設值都是「互助板提供／認領 #N」。
+        //   (2) 載體單反查 —— 手動現貨認領時 rpc_claim_manual_spot 會在載體單
+        //       （AB-xx-000n）的品項 notes 蓋「[互助板認領 #N]」，而那張載體單
+        //       只為這一次認領而生 → 從它轉出去的那一趟就是這次認領。
+        //       線上 4 筆歷史認領（#119/#206/#207/#208）全靠這條才查得到是古華店；
+        //       它們的 reason 在連結表回填時已經被換成「[回填] …」了。
+        const [reasonRes, carrierRes] = await Promise.all([
+          sb.from("customer_order_transfer_links").select(SEL)
+            .ilike("reason", `%#${post.id}%`)
+            .order("transferred_at", { ascending: true }).limit(50),
+          sb.from("customer_order_items").select("order_id")
+            .ilike("notes", `%互助板認領 #${post.id}%`).limit(50),
+        ]);
         if (cancelled) return;
-        if (error) { setRows([]); return; }
-        // 「互助板提供 #249」/「互助板認領 #249」；#2490 不能算進來
+
+        const carrierIds = Array.from(
+          new Set(((carrierRes.data ?? []) as { order_id: number }[]).map((r) => r.order_id)),
+        );
+        const byCarrier = carrierIds.length > 0
+          ? await sb.from("customer_order_transfer_links").select(SEL)
+              .in("source_order_id", carrierIds)
+              .order("transferred_at", { ascending: true }).limit(50)
+          : { data: [], error: null };
+        if (cancelled) return;
+        if (reasonRes.error && carrierRes.error) { setRows([]); return; }
+
+        // 「互助板提供 #249」/「互助板認領 #249」；#2490 不能算進來。
+        // 只用來濾 (1) —— (2) 是從載體單直接反查的，本身就精準。
         const exact = new RegExp(`互助板[^#]*#${post.id}(?!\\d)`);
         type StoreRef = { name: string } | { name: string }[] | null;
         type RawSku = { sku_code: string; product_name: string; variant_name: string | null };
@@ -499,8 +520,16 @@ function AidClaimLog({ post }: { post: Post }) {
           } | null;
         };
         const nameOf = (s: StoreRef) => (Array.isArray(s) ? s[0]?.name : s?.name) ?? "—";
-        const list = ((data ?? []) as unknown as Raw[]).flatMap((r): ProvidedRow[] => {
-          if (!exact.test(r.reason ?? "")) return [];
+        // 一趟轉移可能兩條路都撈到（新資料的 reason 有編號、又剛好是手動現貨），
+        // 以 link id 去重
+        const merged = new Map<number, Raw>();
+        for (const r of (reasonRes.data ?? []) as unknown as Raw[]) {
+          if (exact.test(r.reason ?? "")) merged.set(r.id, r);
+        }
+        for (const r of (byCarrier.data ?? []) as unknown as Raw[]) merged.set(r.id, r);
+        const list = [...merged.values()]
+          .sort((a, b) => a.transferred_at.localeCompare(b.transferred_at))
+          .flatMap((r): ProvidedRow[] => {
           const src = r.src, dest = r.dest;
           if (!src || !dest) return [];
           const mine = linkItems(r, dest.items ?? []);
@@ -537,17 +566,40 @@ function AidClaimLog({ post }: { post: Post }) {
     return () => { cancelled = true; };
   }, [post.id]);
 
-  if (rows === null) return <div className="text-xs text-zinc-500">載入提供紀錄…</div>;
-  if (rows.length === 0) return null;
-
   // 需求貼文＝別人「提供」給貼文店；釋出貼文＝別人「認領」走
   const verb = post.post_type === "request" ? "提供" : "認領";
 
+  if (rows === null) {
+    return <div className="text-xs text-zinc-500">載入{verb}紀錄…</div>;
+  }
+
+  // 貼文自己記的已成交量 vs 查得到明細的量。
+  // 兩者對不起來只有一個原因：那些轉移發生在 customer_order_transfer_links
+  // （20260824000100）之前，回填時原始 reason 已經遺失、認不出屬於哪一則貼文。
+  // 這種時候要明講「有人接走但查不到是誰」—— 直接不顯示會被當成沒人認領。
+  const settled = Number(post.qty_available) - Number(post.qty_remaining);
+  const logged = rows.reduce((s, r) => s + r.qty, 0);
+  const untraced = Math.max(0, settled - logged);
+
   return (
     <div className="rounded-md border border-zinc-200 bg-zinc-50 p-2 dark:border-zinc-800 dark:bg-zinc-950">
-      <div className="mb-1.5 text-[11px] font-semibold text-zinc-600 dark:text-zinc-400">
-        {verb}紀錄（{rows.length} 筆）
+      <div className="mb-1.5 flex items-center gap-2 text-[11px] font-semibold text-zinc-600 dark:text-zinc-400">
+        <span>{verb}紀錄</span>
+        {rows.length > 0 && <span className="font-normal text-zinc-500">{rows.length} 筆</span>}
       </div>
+
+      {rows.length === 0 && untraced === 0 && (
+        <div className="text-xs text-zinc-500">
+          尚無人{verb}。{post.post_type === "request" ? "別家店按「🤝 我可以提供」後會出現在這裡。" : "別家店按「✋ 我要認領」後會出現在這裡。"}
+        </div>
+      )}
+
+      {untraced > 0 && (
+        <div className="rounded border border-amber-200 bg-amber-50 p-2 text-[11px] text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
+          另有 {untraced} 件已被{verb}，但這批轉移早於系統開始記錄明細，查不到是哪一家店。
+        </div>
+      )}
+
       <div className="flex flex-col gap-1.5">
         {rows.map((r) => (
           <div

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { Modal } from "@/components/Modal";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
@@ -8,6 +9,11 @@ import SearchSpinner from "@/components/SearchSpinner";
 import { ProductImagesField } from "@/components/ProductImagesField";
 import { printViaIframe } from "@/lib/printIframe";
 import { withBasePath } from "@/lib/basePath";
+import { useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
+import {
+  TRANSFER_LINK_SELECT, type TransferLink,
+  activeQty, aidRouteLabel, aidStageLabel, isAidInFlight, linkItems,
+} from "@/lib/aidTransfer";
 
 type Store = { id: number; code: string; name: string };
 type SkuOption = { id: number; sku_code: string; product_name: string; variant_name: string | null };
@@ -59,6 +65,25 @@ type PendingOrder = {
     unit_price: number | null;
     product_description: string | null;
   }[];
+};
+
+/** 「我提供出去的」一列 = 一趟轉移（customer_order_transfer_links 一列） */
+type ProvidedRow = {
+  linkId: number;
+  transferred_at: string;
+  is_air_transfer: boolean;
+  /** 這趟是哪一則互助貼文促成的；舊資料（連結表回填出來的）認不出來就是 null */
+  board_id: number | null;
+  reason: string | null;
+  source_store: string;
+  source_order_no: string;
+  dest_store: string;
+  dest_store_id: number | null;
+  dest_order_id: number;
+  dest_order_no: string;
+  dest_status: string;
+  qty: number;
+  labels: string[];
 };
 
 type Reply = {
@@ -115,7 +140,7 @@ const TYPE_COLOR: Record<PostType, string> = {
 export default function MutualAidPage() {
   const [posts, setPosts] = useState<Post[] | null>(null);
   const [stores, setStores] = useState<Store[]>([]);
-  const [view, setView] = useState<"active" | "history">("active");
+  const [view, setView] = useState<"active" | "history" | "provided">("active");
   const [filter, setFilter] = useState<"all" | "request" | "offer">("all");
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
@@ -142,8 +167,9 @@ export default function MutualAidPage() {
     return () => { cancelled = true; };
   }, []);
 
-  // 載入 posts
+  // 載入 posts（「我提供出去的」是另一份資料來源，由 ProvidedList 自己撈）
   useEffect(() => {
+    if (view === "provided") return;
     let cancelled = false;
     (async () => {
       try {
@@ -219,14 +245,18 @@ export default function MutualAidPage() {
           </p>
         </div>
         <div className="flex gap-2">
-          <SpinButton
-            type="button"
-            onClick={() => printViaIframe(withBasePath(`/inventory/mutual-aid/print?type=${filter}&view=${view}`))}
-            title="列印目前這個分頁的整份貼文清單（A4 橫式）；單獨一則請按該列右邊的 🖨️"
-            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-          >
-            🖨️ 列印
-          </SpinButton>
+          {/* 「我提供出去的」列的是轉移紀錄不是貼文，整份清單列印不適用；
+              那一頁每一列有自己的隨貨單列印鈕（走 /transfers/print-aid 兩聯） */}
+          {view !== "provided" && (
+            <SpinButton
+              type="button"
+              onClick={() => printViaIframe(withBasePath(`/inventory/mutual-aid/print?type=${filter}&view=${view}`))}
+              title="列印目前這個分頁的整份貼文清單（A4 橫式）；單獨一則請按該列右邊的 🖨️"
+              className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              🖨️ 列印
+            </SpinButton>
+          )}
           <SpinButton
             type="button"
             onClick={() => setRequestModalOpen(true)}
@@ -252,7 +282,7 @@ export default function MutualAidPage() {
       </header>
 
       <div className="flex gap-1 border-b border-zinc-200 dark:border-zinc-800">
-        {(["active", "history"] as const).map((v) => (
+        {(["active", "history", "provided"] as const).map((v) => (
           <SpinButton
             key={v}
             type="button"
@@ -263,11 +293,15 @@ export default function MutualAidPage() {
                 : "px-4 py-2 text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
             }
           >
-            {v === "active" ? "進行中" : "歷史"}
+            {v === "active" ? "進行中" : v === "history" ? "歷史" : "我提供出去的"}
           </SpinButton>
         ))}
       </div>
 
+      {view === "provided" ? (
+        <ProvidedList stores={stores} />
+      ) : (
+      <>
       <div className="inline-flex w-fit overflow-hidden rounded-md border border-zinc-300 text-xs dark:border-zinc-700">
         {(["all", "request", "offer"] as const).map((opt) => (
           <SpinButton
@@ -364,6 +398,8 @@ export default function MutualAidPage() {
           ))}
         </ul>
       )}
+      </>
+      )}
 
       <RequestModal
         open={requestModalOpen}
@@ -406,6 +442,212 @@ export default function MutualAidPage() {
             reloadAndRefreshBadge();
           }}
         />
+      )}
+    </div>
+  );
+}
+
+// ============================================================
+// 我提供出去的 —— 本店轉出去的互助，一趟轉移一列
+//
+// 為什麼不是查訂單而是查 customer_order_transfer_links：
+// 轉入單掛在**收貨店**名下，轉出店的訂單列表一列都撈不到；而且一張轉入單可以
+// 有多個來源（追加轉入把好幾家店的貨併進同一張，線上 TF0486 有 3 家店的 5 個
+// 品項），拿訂單當單位就會把別家店的貨也算成自己的。連結表才是 1:1 的「一趟」。
+// 2026-08-24 起互助轉單一律開新單（20260824060000），但舊資料還是併在一起的，
+// 所以這裡一律用 linkItems() 只取這一趟真正搬過去的品項。
+//
+// 母體＝跨店的轉出（同店轉單只是換客人，貨沒離開本店，不算互助）。
+// 分店帳號鎖自己店；總倉／未綁店看全站。
+// ============================================================
+function ProvidedList({ stores }: { stores: Store[] }) {
+  const myStoreId = useUserBranchStoreId(stores);
+  const [rows, setRows] = useState<ProvidedRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showDone, setShowDone] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data, error: e } = await sb
+          .from("customer_order_transfer_links")
+          // ⚠ 這裡刻意**不撈** customer_order_transfer_links.aid_board_id：
+          // 那一欄是 20260824060000 才加的，而 SQL 有沒有先套上正式庫不是這支
+          // 前端控制得了的（#827 就發生過「PR 合併了、migration 沒套」）。
+          // 撈一個還不存在的欄位會讓整個查詢 400、整頁掛掉；貼文編號只是徽章，
+          // 從 reason 認就夠（RPC 寫的預設是「互助板提供 #N」/「互助板認領 #N」）。
+          .select(
+            TRANSFER_LINK_SELECT + ", reason, " +
+              "src:customer_orders!customer_order_transfer_links_source_order_id_fkey(" +
+              "id, order_no, pickup_store_id, store:stores!customer_orders_pickup_store_id_fkey(name)), " +
+              "dest:customer_orders!customer_order_transfer_links_dest_order_id_fkey(" +
+              "id, order_no, status, pickup_store_id, " +
+              "store:stores!customer_orders_pickup_store_id_fkey(name), " +
+              "items:customer_order_items(id, qty, status, source, " +
+              "sku:skus(sku_code, product_name, variant_name)))",
+          )
+          .order("transferred_at", { ascending: false })
+          .limit(300);
+        if (cancelled) return;
+        if (e) throw new Error(e.message);
+        type StoreRef = { name: string } | { name: string }[] | null;
+        type RawSku = { sku_code: string; product_name: string; variant_name: string | null };
+        type Raw = TransferLink & {
+          reason: string | null;
+          src: { id: number; order_no: string; pickup_store_id: number | null; store: StoreRef } | null;
+          dest: {
+            id: number; order_no: string; status: string; pickup_store_id: number | null;
+            store: StoreRef;
+            items: { id: number; qty: number; status: string; source: string | null; sku: RawSku | RawSku[] | null }[] | null;
+          } | null;
+        };
+        const nameOf = (s: StoreRef) => (Array.isArray(s) ? s[0]?.name : s?.name) ?? "—";
+        const list = ((data ?? []) as unknown as Raw[]).flatMap((r): ProvidedRow[] => {
+          const src = r.src, dest = r.dest;
+          if (!src || !dest) return [];
+          // 同店轉單貨沒離開本店
+          if (src.pickup_store_id === dest.pickup_store_id) return [];
+          // 分店帳號只看自己轉出去的；HQ 看全站
+          if (myStoreId != null && src.pickup_store_id !== myStoreId) return [];
+          const mine = linkItems(r, dest.items ?? []);
+          const qty = activeQty(mine);
+          if (qty <= 0) return [];
+          return [{
+            linkId: r.id,
+            transferred_at: r.transferred_at,
+            is_air_transfer: r.is_air_transfer === true,
+            board_id: Number(/互助板[^#]*#(\d+)/.exec(r.reason ?? "")?.[1]) || null,
+            reason: r.reason,
+            source_store: nameOf(src.store),
+            source_order_no: src.order_no,
+            dest_store: nameOf(dest.store),
+            dest_store_id: dest.pickup_store_id,
+            dest_order_id: dest.id,
+            dest_order_no: dest.order_no,
+            dest_status: dest.status,
+            qty,
+            labels: mine
+              .filter((it) => !["cancelled", "expired"].includes(it.status))
+              .map((it) => {
+                const sku = Array.isArray(it.sku) ? it.sku[0] : it.sku;
+                return sku
+                  ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} ×${Number(it.qty)}`
+                  : `品項 ×${Number(it.qty)}`;
+              }),
+          }];
+        });
+        setRows(list);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [myStoreId]);
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+        {error}
+      </div>
+    );
+  }
+  if (rows === null) return <div className="text-sm text-zinc-500">載入中…</div>;
+
+  const inFlight = rows.filter((r) => isAidInFlight(r.dest_status));
+  const done = rows.filter((r) => !isAidInFlight(r.dest_status));
+  const shown = showDone ? done : inFlight;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="inline-flex w-fit overflow-hidden rounded-md border border-zinc-300 text-xs dark:border-zinc-700">
+          {([false, true] as const).map((v) => (
+            <SpinButton
+              key={String(v)}
+              type="button"
+              onClick={() => setShowDone(v)}
+              className={`px-3 py-1.5 ${
+                showDone === v
+                  ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                  : "bg-white text-zinc-600 hover:bg-zinc-50 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+              }`}
+            >
+              {v ? `已完成 (${done.length})` : `在跑的 (${inFlight.length})`}
+            </SpinButton>
+          ))}
+        </div>
+        <span className="text-xs text-zinc-500">
+          {myStoreId == null
+            ? "全站的店對店轉出（總倉視角）"
+            : "本店轉出去的貨。收貨店收掉之後就會移到「已完成」"}
+        </span>
+      </div>
+
+      {shown.length === 0 ? (
+        <div className="rounded-md border border-dashed border-zinc-300 p-8 text-center text-sm text-zinc-500 dark:border-zinc-700">
+          {showDone ? "沒有已完成的轉出紀錄" : "目前沒有在路上的轉出"}
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {shown.map((r) => (
+            <li
+              key={r.linkId}
+              className="flex items-start gap-2 rounded-md border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="mb-1 flex flex-wrap items-center gap-2">
+                  <span className="rounded bg-pink-100 px-1.5 py-0.5 text-[10px] font-semibold text-pink-800 dark:bg-pink-950 dark:text-pink-300">
+                    給 {r.dest_store}
+                  </span>
+                  <span className="text-[10px] text-zinc-500">{aidRouteLabel(r.is_air_transfer)}</span>
+                  <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+                    {aidStageLabel(r.dest_status, r.is_air_transfer)}
+                  </span>
+                  {r.board_id != null && (
+                    <span className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-800 dark:bg-blue-950 dark:text-blue-300">
+                      互助板 #{r.board_id}
+                    </span>
+                  )}
+                  {myStoreId == null && (
+                    <span className="text-[10px] text-zinc-500">從 {r.source_store}</span>
+                  )}
+                  <span className="ml-auto text-xs text-zinc-500">{fmtDt(r.transferred_at)}</span>
+                </div>
+                <div className="text-sm">{r.labels.join("、") || `共 ${r.qty}`}</div>
+                <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">
+                  <span>來源單 <span className="font-mono text-zinc-700 dark:text-zinc-300">{r.source_order_no}</span></span>
+                  {/* 轉入單掛在收貨店名下 —— 連結一定要帶 storeId，否則分店帳號的
+                      門市篩選會預設帶回自己店、搜出 0 筆（看起來像貨憑空消失） */}
+                  <Link
+                    className="text-blue-600 underline dark:text-blue-400"
+                    href={`/orders?q=${encodeURIComponent(r.dest_order_no)}${r.dest_store_id != null ? `&storeId=${r.dest_store_id}` : ""}`}
+                  >
+                    轉入單 {r.dest_order_no}
+                  </Link>
+                  {r.reason && !r.reason.startsWith("[回填]") && (
+                    <span className="text-zinc-700 dark:text-zinc-300">「{r.reason}」</span>
+                  )}
+                </div>
+              </div>
+              {/* 隨貨單走 /transfers/print-aid（兩聯：司機聯 + 存查聯），
+                  帶 link 才只印這一趟的貨、來源店也才標得對 */}
+              <SpinButton
+                type="button"
+                onClick={() =>
+                  printViaIframe(
+                    withBasePath(`/transfers/print-aid?order_id=${r.dest_order_id}&link=${r.linkId}`),
+                  )
+                }
+                title="列印這一趟的互助出貨單（兩聯：司機聯 + 存查聯）"
+                className="shrink-0 rounded-md border border-zinc-300 px-2 py-1.5 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+              >
+                🖨️
+              </SpinButton>
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );
@@ -1902,6 +2144,8 @@ function ClaimOfferDialog({
         p_reason: reason || null,
         p_items: [{ sku_id: post.sku_id, qty: qtyN }],
         p_is_air_transfer: isAir,
+        // 互助的轉單一律開自己的新單，不併進收貨店既有的容器單（20260824060000）
+        p_aid_board_id: post.id,
       });
       if (e1) { setErr(e1.message); return; }
       // 統一走 consume RPC：reach 0 自動 exhausted、>0 保持 active 可分批
@@ -2087,6 +2331,8 @@ function FulfillRequestDialog({
         p_reason: reason || null,
         p_items: [{ sku_id: post.sku_id, qty: qtyN }],
         p_is_air_transfer: isAir,
+        // 互助的轉單一律開自己的新單，不併進求助店既有的容器單（20260824060000）
+        p_aid_board_id: post.id,
       });
       if (e1) { setErr(e1.message); return; }
       const { error: e2 } = await sb.rpc("rpc_consume_aid_board", {

--- a/apps/admin/src/lib/orderTitle.ts
+++ b/apps/admin/src/lib/orderTitle.ts
@@ -85,6 +85,23 @@ export function internalOrderSource(orderNo: string | null | undefined): Interna
   return null;
 }
 
+/**
+ * 單號的「給人看」版本。
+ *
+ * 內部共用假團底下的單號長這樣：`__INTERNAL_RESTOCK__-TF0497`。前綴是帳本代號，
+ * 店員看不懂也不該看到（2026-08-24 回報：互助板上印出來整串沒人知道是什麼），
+ * 但尾碼 TF0497 是店裡真的會拿來對帳的號 —— 所以只砍前綴、留尾碼並補上中文。
+ * 一般單號（GRP-…、RR-…、AB-…）原樣回傳。
+ */
+export function shortOrderNo(orderNo: string | null | undefined): string {
+  const no = (orderNo ?? "").trim();
+  if (!no) return "—";
+  const m = /^__[A-Z_]+__-(.+)$/.exec(no);
+  if (!m) return no;
+  const tail = m[1];
+  return /^TF\d+$/i.test(tail) ? `轉單 ${tail}` : tail;
+}
+
 export function orderCardTitle(order: TitleOrderLike): string {
   const campaign = cleanCampaignText(order.campaign_name);
   if (!isInternalCampaign(order)) return campaign || "訂單";

--- a/supabase/migrations/20260824060000_aid_transfer_own_order.sql
+++ b/supabase/migrations/20260824060000_aid_transfer_own_order.sql
@@ -1,0 +1,731 @@
+-- ============================================================
+-- 2026-08-24: 互助的貨要看得出「哪一趟是哪一趟」—— 互助轉單一律開新單
+--
+-- 症狀（店家回報）：「為什麼我都找不到 #249 其中一筆提供給互助的單？」
+--   互助板 #249 是平鎮店的需求貼文（艋舺嫩煎雞腿排 (C)紐奧良 ×2）。
+--   松山店 8/24 12:27 從 OV-2-0001 提供 1 件過去，但那件**沒有自己的單**：
+--   它被併進平鎮店既有的 __INTERNAL_RESTOCK__-TF0497。那張單身上已經有
+--   皮蛋醬（文山 8/21）、堅果（SP-1-0002 8/21）、牛肉絲（古華 8/22）——
+--   4 家店、跨 4 天、4 件不相干的貨掛在同一張單上，店員看不出哪一件是
+--   哪一次互助來的，也印不出只有自己那批貨的隨貨單。
+--
+-- 為什麼會併：rpc_transfer_order_partial 建轉入單前會找
+--   (tenant, campaign, channel, member) 都相同的 active 單，找到就併進去。
+--   這把 key 是為了「同一位客人同一團只有一張單」而設，對互助卻是**退化**的：
+--   收件人固定是接收店的「【內部】xx 店」、來源又常是 __INTERNAL_RESTOCK__
+--   sentinel 團 → 一家店所有的互助收貨，永遠都是同一把 key。
+--   而併單那條路是被 customer_orders_trio_kind_active_uniq 這個唯一索引
+--   逼出來的，不是可以單純拿掉的分支。
+--
+-- 做法：
+--   1. customer_orders 加 aid_board_id（哪一則互助貼文帶來的這張單）。
+--   2. customer_orders_trio_kind_active_uniq 的 predicate 加
+--      「AND aid_board_id IS NULL」—— 互助單不受「一團一頻道一會員一張單」限制，
+--      其餘完全不變（restock / SP- 的既有豁免原樣保留）。
+--   3. rpc_transfer_order_partial 加 p_aid_board_id：非 NULL 時跳過併單、
+--      一律開新單，並把 board id 蓋在新單與 customer_order_transfer_links 上。
+--   4. rpc_claim_manual_spot 透傳 p_board_id。
+--   5. 回填：把已經被併進容器單、且辨識得出屬於互助板的品項搬成獨立單
+--      （線上剛好 1 筆 = #249 那筆；更早的轉移在連結表回填時原始 reason 就
+--       已經遺失，辨識不出來，留給新分頁用「一趟轉移一列」的方式呈現）。
+--
+-- 基底版本（⚠ 一律以**線上 prosrc** 為基底重寫，不是 repo 檔案）：
+--   - rpc_transfer_order_partial：線上版（含 20260824000100 的
+--     customer_order_transfer_links 寫入段）。repo 最新的
+--     20260814030000_air_transfer_ship_on_transfer.sql 少了那一段，
+--     照 repo 改會把 #826 的連結表修正整個蓋掉。
+--   - rpc_claim_manual_spot：線上版（= 20260816000000_manual_spot_claimable.sql）。
+--
+-- 沒有動到的：
+--   - 非互助的轉單（p_aid_board_id 預設 NULL）行為一字未改，照樣併單。
+--   - 現貨池：池子是獨立的 OV- 單（_get_or_create_surplus_pool_order），
+--     _trim_internal_pool / _sku_commitment 都是逐品項加總，
+--     同一批貨拆成兩張單不影響任何數量。
+--   - 取貨閘門、月結、撿貨：都以品項為單位，品項 id 在回填時是**搬列不是複製**
+--     （同 _stockout_po_items 的原則），所有既有引用都還指得到。
+--
+-- Rollback：
+--   DROP INDEX customer_orders_trio_kind_active_uniq;
+--   CREATE UNIQUE INDEX customer_orders_trio_kind_active_uniq ON public.customer_orders
+--     USING btree (tenant_id, campaign_id, channel_id, member_id, order_kind)
+--     WHERE ((status <> ALL (ARRAY['transferred_out'::text,'expired'::text,'cancelled'::text]))
+--            AND (order_kind <> 'restock'::text) AND (order_no !~~ 'SP-%'::text));
+--   -- 並把 rpc_transfer_order_partial / rpc_claim_manual_spot 重跑線上舊版
+--   -- （DROP FUNCTION rpc_transfer_order_partial(bigint,bigint,bigint,bigint,uuid,text,jsonb,boolean,bigint) 之後）
+--   ALTER TABLE customer_order_transfer_links DROP COLUMN aid_board_id;
+--   ALTER TABLE customer_orders DROP COLUMN aid_board_id;
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. 互助貼文 → 轉入單 的印記
+-- ------------------------------------------------------------
+ALTER TABLE public.customer_orders
+  ADD COLUMN IF NOT EXISTS aid_board_id BIGINT
+    REFERENCES public.mutual_aid_board(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.customer_orders.aid_board_id IS
+  '這張轉入單是哪一則互助貼文帶來的（一趟互助 = 一張單）。'
+  '非 NULL 的單不受 customer_orders_trio_kind_active_uniq 限制 —— '
+  '同一家店對同一個 sentinel 團會有很多趟互助收貨，本來就不該只有一張單。';
+
+CREATE INDEX IF NOT EXISTS idx_customer_orders_aid_board
+  ON public.customer_orders (aid_board_id) WHERE aid_board_id IS NOT NULL;
+
+ALTER TABLE public.customer_order_transfer_links
+  ADD COLUMN IF NOT EXISTS aid_board_id BIGINT
+    REFERENCES public.mutual_aid_board(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.customer_order_transfer_links.aid_board_id IS
+  '這一趟轉移是哪一則互助貼文促成的（互助板的「我提供出去的」分頁靠它撈）。';
+
+CREATE INDEX IF NOT EXISTS idx_transfer_links_aid_board
+  ON public.customer_order_transfer_links (aid_board_id) WHERE aid_board_id IS NOT NULL;
+
+-- ------------------------------------------------------------
+-- 2. 唯一索引放行互助單
+--    predicate 其餘部分逐字照抄線上定義，只多一個 aid_board_id IS NULL
+-- ------------------------------------------------------------
+DROP INDEX IF EXISTS public.customer_orders_trio_kind_active_uniq;
+
+CREATE UNIQUE INDEX customer_orders_trio_kind_active_uniq
+  ON public.customer_orders
+  USING btree (tenant_id, campaign_id, channel_id, member_id, order_kind)
+  WHERE ((status <> ALL (ARRAY['transferred_out'::text, 'expired'::text, 'cancelled'::text]))
+         AND (order_kind <> 'restock'::text)
+         AND (order_no !~~ 'SP-%'::text)
+         AND (aid_board_id IS NULL));
+
+-- ------------------------------------------------------------
+-- 3. rpc_transfer_order_partial：加 p_aid_board_id
+--    舊的 8 參數版本一定要 DROP —— 只 CREATE OR REPLACE 會多出一個
+--    overload，8 個位置參數的呼叫會變成 "function is not unique"。
+-- ------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.rpc_transfer_order_partial(
+  bigint, bigint, bigint, bigint, uuid, text, jsonb, boolean);
+
+CREATE OR REPLACE FUNCTION public.rpc_transfer_order_partial(
+  p_order_id bigint,
+  p_to_pickup_store_id bigint,
+  p_to_member_id bigint,
+  p_to_channel_id bigint,
+  p_operator uuid,
+  p_reason text,
+  p_items jsonb,
+  p_is_air_transfer boolean DEFAULT false,
+  p_aid_board_id bigint DEFAULT NULL)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $fn$
+DECLARE
+  v_orig             customer_orders%ROWTYPE;
+  v_tenant_id        UUID;
+  v_to_member_id     BIGINT;
+  v_to_channel_id    BIGINT;
+  v_new_order_id     BIGINT;
+  v_new_order_no     TEXT;
+  v_seq              INT;
+  v_campaign_no      TEXT;
+  v_p_item           JSONB;
+  v_p_sku_id         BIGINT;
+  v_p_qty            NUMERIC;
+  v_src_item_id      BIGINT;
+  v_src_item_qty     NUMERIC;
+  v_src_item_ci      BIGINT;
+  v_src_item_price   NUMERIC;
+  v_src_item_reserved BIGINT;
+  v_remaining_count  INT;
+  v_now              TIMESTAMPTZ := NOW();
+  v_existing_order   BIGINT;
+  v_appended         BOOLEAN := FALSE;
+  v_new_status       TEXT;
+  v_src_is_internal  BOOLEAN := FALSE;
+  v_dst_is_internal  BOOLEAN := FALSE;
+  v_retail_price     NUMERIC;
+  v_item_price       NUMERIC;
+  v_reopened         TEXT;
+  v_new_item_id      BIGINT;
+  v_new_item_ids     BIGINT[] := '{}'::BIGINT[];
+BEGIN
+  IF p_items IS NULL OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION '未指定任何要轉移的品項';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_transfer:' || p_order_id::text));
+
+  SELECT * INTO v_orig FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_orig.id IS NULL THEN
+    RAISE EXCEPTION '找不到訂單 #%', p_order_id;
+  END IF;
+  v_tenant_id := v_orig.tenant_id;
+
+  -- 跨店轉單維持「貨到店才能轉」：ready 之外也放行 partially_completed ——
+  -- 已取走過品項代表貨到過店，剩餘 active 品項物理上就在店裡（內部現貨池
+  -- 臨櫃賣掉一件就進 partially_completed，不放行等於池子賣過一次就不能再轉，
+  -- 2026-08-14 湖口 INT0116）。品項挑選本來就限 active，picked_up 不會被轉走。
+  -- 同店互轉（換客人）貨進同一間店、不影響總倉派貨量，到貨前也可轉。
+  -- 同店預轉仍排除三種「貨不走本店波次」的單（轉走會斷到貨推進鏈）：
+  --   a. 非一般團購單（restock ride-along 靠 order_no='RR-x' 特判推 ready、offset 無實貨）
+  --   b. 有進行中的調撥 FK 指著它（互助/空中轉/補貨直派 → 到貨判定綁原單 id）
+  --   c. 自己就是跨店轉入、貨還沒到的單（到貨判定同樣綁 transfer FK）
+  IF v_orig.status NOT IN ('ready','partially_completed') THEN
+    IF p_to_pickup_store_id <> v_orig.pickup_store_id THEN
+      RAISE EXCEPTION '貨還沒到分店、訂單 % 不可跨店轉單 (status=%)；同店換客人不受此限',
+                      p_order_id, v_orig.status;
+    END IF;
+    IF v_orig.status NOT IN ('pending','confirmed','reserved','shipping') THEN
+      RAISE EXCEPTION '訂單 % 狀態（%）不可轉單', p_order_id, v_orig.status;
+    END IF;
+    IF COALESCE(v_orig.order_kind, 'normal') <> 'normal' THEN
+      RAISE EXCEPTION '訂單 % 不是一般團購單（%），須等分店收貨後再轉單',
+                      p_order_id, v_orig.order_kind;
+    END IF;
+    IF EXISTS (SELECT 1 FROM transfers t
+                WHERE t.customer_order_id = p_order_id
+                  AND t.tenant_id = v_tenant_id
+                  AND t.status <> 'cancelled') THEN
+      RAISE EXCEPTION '訂單 % 有進行中的調撥，請等分店收貨後再轉單', p_order_id;
+    END IF;
+    IF v_orig.transferred_from_order_id IS NOT NULL AND EXISTS (
+         SELECT 1 FROM customer_orders src
+          WHERE src.id = v_orig.transferred_from_order_id
+            AND src.pickup_store_id IS DISTINCT FROM v_orig.pickup_store_id) THEN
+      RAISE EXCEPTION '訂單 % 是跨店轉入、貨還沒到，請等分店收貨後再轉單', p_order_id;
+    END IF;
+  END IF;
+
+  IF v_orig.transferred_to_order_id IS NOT NULL THEN
+    RAISE EXCEPTION '訂單 #% 已轉出至訂單 #%，不可重複轉出',
+                    p_order_id, v_orig.transferred_to_order_id;
+  END IF;
+
+  PERFORM 1 FROM stores WHERE id = p_to_pickup_store_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '接收店（ID %）不存在或不屬於目前商戶', p_to_pickup_store_id;
+  END IF;
+
+  v_to_member_id := COALESCE(
+    p_to_member_id,
+    rpc_get_or_create_store_member(p_to_pickup_store_id, p_operator)
+  );
+
+  PERFORM 1 FROM members WHERE id = v_to_member_id AND tenant_id = v_tenant_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '接收會員（ID %）不存在或不屬於目前商戶', v_to_member_id;
+  END IF;
+
+  -- 內部單（【內部】xx店）轉給真會員 = 門市現貨銷售 → 轉出價改鎖現售價。
+  -- 店↔店互助（目標也是 store_internal）維持原價不變。
+  SELECT (m.member_type = 'store_internal') INTO v_src_is_internal
+    FROM members m WHERE m.id = v_orig.member_id;
+  v_src_is_internal := COALESCE(v_src_is_internal, FALSE);
+  SELECT (m.member_type = 'store_internal') INTO v_dst_is_internal
+    FROM members m WHERE m.id = v_to_member_id;
+  v_dst_is_internal := COALESCE(v_dst_is_internal, FALSE);
+
+  v_to_channel_id := p_to_channel_id;
+  IF v_to_channel_id IS NULL THEN
+    SELECT id INTO v_to_channel_id
+      FROM line_channels
+     WHERE tenant_id = v_tenant_id AND home_store_id = p_to_pickup_store_id
+     LIMIT 1;
+    IF v_to_channel_id IS NULL THEN
+      SELECT id INTO v_to_channel_id
+        FROM line_channels
+       WHERE tenant_id = v_tenant_id
+       LIMIT 1;
+    END IF;
+  END IF;
+  IF v_to_channel_id IS NULL THEN
+    RAISE EXCEPTION '接收店找不到可用的 LINE 頻道，無法建立轉入訂單';
+  END IF;
+
+  SELECT id INTO v_existing_order
+    FROM customer_orders
+   WHERE tenant_id = v_tenant_id
+     AND campaign_id = v_orig.campaign_id
+     AND channel_id  = v_to_channel_id
+     AND member_id   = v_to_member_id
+     AND status NOT IN ('expired','cancelled','transferred_out');
+
+  -- 查到的既有單 = 來源單本身（同活動＋同頻道＋同會員轉給自己）→ 擋下，
+  -- 否則會把品項「轉進」它自己（同 20260806000010 對整單轉的守衛）
+  IF v_existing_order = p_order_id THEN
+    RAISE EXCEPTION '這張訂單本來就掛在該接收人（同活動、同頻道）名下，不需要轉出';
+  END IF;
+
+  -- 互助板的轉單一律開新單，不併進既有的容器單（20260824060000）。
+  -- (團, 頻道, 會員) 這把併單 key 對互助來說是退化的：收件人固定是接收店的
+  -- 「【內部】xx 店」、來源又常是 __INTERNAL_RESTOCK__ sentinel 團 —— 於是
+  -- 同一家店所有的互助收貨永遠併成同一張。2026-08-24 平鎮店 TF0497 就堆了
+  -- 4 家店、跨 4 天的 4 件不相干的貨（皮蛋醬／堅果／牛肉絲／雞腿排），
+  -- 店員看不出哪一件是哪一次互助來的，也印不出只有自己那批貨的單。
+  -- 新單身上會蓋 aid_board_id，而 customer_orders_trio_kind_active_uniq
+  -- 的 predicate 已排除蓋過章的單，所以第二張開得出來。
+  IF p_aid_board_id IS NOT NULL THEN
+    v_existing_order := NULL;
+  END IF;
+
+  IF v_existing_order IS NOT NULL THEN
+    v_new_order_id := v_existing_order;
+    v_appended := TRUE;
+    SELECT order_no INTO v_new_order_no FROM customer_orders WHERE id = v_existing_order;
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[追加轉入 (部分, ' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+                   ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS') ||
+                   COALESCE(' / ' || p_reason, ''),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = v_new_order_id;
+  ELSE
+    SELECT campaign_no INTO v_campaign_no FROM group_buy_campaigns WHERE id = v_orig.campaign_id;
+    -- TF 序號 = 該團既有 -TF 尾碼最大值 + 1。
+    -- COUNT(*)+1 在 RR- 單被硬刪（rpc_delete_restock_request）後會倒退、
+    -- 重發已用過的號碼 → duplicate key（2026-08-13 湖口 RR-435 事故）。
+    -- 團鎖：來源單鎖擋不住兩張不同來源單同時轉出算出同一號。
+    PERFORM pg_advisory_xact_lock(hashtext('order_tf_seq:' || v_orig.campaign_id::text));
+    SELECT COALESCE(MAX(substring(order_no FROM '-TF([0-9]+)$')::INT), 0) + 1
+      INTO v_seq
+      FROM customer_orders
+     WHERE tenant_id = v_tenant_id
+       AND campaign_id = v_orig.campaign_id
+       AND order_no ~ '-TF[0-9]+$';
+    -- lpad 超寬會截斷（lpad('10001',4)='1000'），寬度要跟著位數長
+    v_new_order_no := v_campaign_no || '-TF' ||
+                      lpad(v_seq::text, GREATEST(length(v_seq::text), 4), '0');
+
+    -- 同店：mirror source.status，但 partially_completed 映成 'ready' ——
+    -- 新單一件都還沒取走，掛「部分取貨」是錯的（取貨頁與收尾邏輯都會誤判）；
+    -- 跨店空中轉：confirmed（尾端 helper 會接著建 AT- 單並推 shipping）；
+    -- 跨店經總倉：'pending'（維持總倉確認 gate）
+    v_new_status := CASE
+      WHEN p_to_pickup_store_id = v_orig.pickup_store_id THEN
+        CASE WHEN v_orig.status = 'partially_completed' THEN 'ready' ELSE v_orig.status END
+      WHEN p_is_air_transfer THEN 'confirmed'
+      ELSE 'pending'
+    END;
+
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id,
+      nickname_snapshot, pickup_store_id, status, notes,
+      transferred_from_order_id, is_air_transfer, aid_board_id,
+      created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      v_tenant_id, v_new_order_no, v_orig.campaign_id, v_to_channel_id, v_to_member_id,
+      v_orig.nickname_snapshot, p_to_pickup_store_id, v_new_status,
+      COALESCE(p_reason, '') ||
+        E'\n[轉入 (部分, ' || CASE WHEN p_is_air_transfer THEN '空中轉' ELSE '經總倉' END ||
+        ') ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')] ' ||
+        to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+      p_order_id, p_is_air_transfer, p_aid_board_id,
+      p_operator, p_operator, v_now, v_now
+    ) RETURNING id INTO v_new_order_id;
+  END IF;
+
+  FOR v_p_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_p_sku_id := (v_p_item ->> 'sku_id')::BIGINT;
+    v_p_qty    := (v_p_item ->> 'qty')::NUMERIC;
+    IF v_p_qty IS NULL OR v_p_qty <= 0 THEN
+      RAISE EXCEPTION '轉移數量必須大於 0';
+    END IF;
+
+    SELECT id, qty, campaign_item_id, unit_price, reserved_movement_id
+      INTO v_src_item_id, v_src_item_qty, v_src_item_ci, v_src_item_price, v_src_item_reserved
+      FROM customer_order_items
+     WHERE order_id = p_order_id
+       AND sku_id   = v_p_sku_id
+       -- 只挑 active 品項當轉出來源；picked_up（貨已交付）/ expired 的列
+       -- 拿來轉會把已交付的貨再轉給別人（同 2026-08-10 整單轉出復活 cancelled 品項的事故類型）
+       AND status   IN ('pending','reserved','ready')
+     ORDER BY id
+     LIMIT 1
+     FOR UPDATE;
+    IF v_src_item_id IS NULL THEN
+      RAISE EXCEPTION 'SKU % 不在訂單 #% 內（或品項已取消／已取走），無法轉移', v_p_sku_id, p_order_id;
+    END IF;
+    IF v_src_item_reserved IS NOT NULL THEN
+      RAISE EXCEPTION 'SKU % 已有庫存配貨紀錄（#%），請先釋放配貨再轉移',
+                      v_p_sku_id, v_src_item_reserved;
+    END IF;
+    IF v_src_item_qty < v_p_qty THEN
+      RAISE EXCEPTION 'SKU % 可轉數量不足：來源剩 %、要求轉出 %',
+                      v_p_sku_id, v_src_item_qty, v_p_qty;
+    END IF;
+
+    -- 內部單 → 真會員：轉出價鎖定當下 SKU 現售價（scope='retail' 最新生效版）；
+    -- 查無現售價 fallback 來源價。其餘情境維持原價。
+    v_item_price := v_src_item_price;
+    IF v_src_is_internal AND NOT v_dst_is_internal THEN
+      SELECT price INTO v_retail_price
+        FROM prices
+       WHERE tenant_id = v_tenant_id
+         AND sku_id    = v_p_sku_id
+         AND scope     = 'retail'
+         AND effective_from <= v_now
+         AND (effective_to IS NULL OR effective_to > v_now)
+       ORDER BY effective_from DESC
+       LIMIT 1;
+      v_item_price := COALESCE(v_retail_price, v_src_item_price);
+    END IF;
+
+    IF v_src_item_qty = v_p_qty THEN
+      UPDATE customer_order_items
+         SET status = 'cancelled', updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    ELSE
+      UPDATE customer_order_items
+         SET qty = qty - v_p_qty, updated_by = p_operator, updated_at = v_now
+       WHERE id = v_src_item_id;
+    END IF;
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by
+    ) VALUES (
+      v_tenant_id, v_new_order_id, v_src_item_ci, v_p_sku_id, v_p_qty, v_item_price,
+      'pending', 'aid_transfer', p_operator, p_operator
+    ) RETURNING id INTO v_new_item_id;
+    -- 本次搬進去的品項 id 留給空中轉出貨（helper 只出這一批，
+    -- 不能整張單重出 —— 之前分次追加的品項已經有自己的 AT- 單了）
+    v_new_item_ids := array_append(v_new_item_ids, v_new_item_id);
+  END LOOP;
+
+  SELECT COUNT(*) INTO v_remaining_count
+    FROM customer_order_items
+   WHERE order_id = p_order_id AND status != 'cancelled';
+
+  IF v_remaining_count = 0 THEN
+    UPDATE customer_orders
+       SET status = 'transferred_out',
+           transferred_to_order_id = v_new_order_id,
+           notes = COALESCE(notes, '') ||
+                   E'\n[全部轉出 → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  ELSE
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[' || CASE WHEN v_appended THEN '部分追加' ELSE '部分轉出' END ||
+                   ' → 訂單 #' || v_new_order_id || ' (' || v_new_order_no || ')] ' ||
+                   to_char(v_now, 'YYYY-MM-DD HH24:MI:SS'),
+           updated_by = p_operator,
+           updated_at = v_now
+     WHERE id = p_order_id;
+  END IF;
+
+  -- 部分取貨的來源單把剩餘 active 全轉走後要收尾成 completed：
+  -- remaining_count 算 status != 'cancelled' 會數到 picked_up 列，永遠走不到
+  -- transferred_out 分支（這是對的 —— 已取走的營收要留在原單），但也因此
+  -- 沒人關單頭。helper 自帶守衛（無 active + 至少一件 picked_up 才動作），
+  -- 其餘情境呼叫等於 no-op。
+  PERFORM public._close_orders_all_items_settled(ARRAY[p_order_id], p_operator, v_now);
+
+  -- 追加到「已取貨完成」的既有單時，把它重開 —— 否則新品項會被埋在 completed
+  -- 單裡：待取清單看不到、is_order_item_pickup_ready 也擋著不給取（見 20260805000140）。
+  IF v_appended THEN
+    v_reopened := public._reopen_order_if_completed(
+      v_new_order_id, p_operator,
+      '追加轉入 ← 訂單 #' || p_order_id || ' (' || v_orig.order_no || ')');
+  END IF;
+
+  -- 這一趟轉移的 order↔order 連結。**兩條分支都要寫**（新建轉入單 / 追加併入
+  -- 既有單）—— 只有前者會寫 transferred_from_order_id，追加分支以前什麼線索都
+  -- 沒留下，轉出店的儀表板提醒、轉出記錄、隨貨單三個畫面同時查無此事
+  -- （2026-08-24 松山→古華喜願蛋）。dest_item_ids 只放本次搬進去的品項，
+  -- 轉出店才不會看到／印到別家店在同一張轉入單上的貨。
+  INSERT INTO public.customer_order_transfer_links (
+    tenant_id, source_order_id, dest_order_id, dest_item_ids,
+    is_air_transfer, is_partial, appended, reason, transferred_at, created_by,
+    aid_board_id)
+  VALUES (
+    v_tenant_id, p_order_id, v_new_order_id, COALESCE(v_new_item_ids, '{}'::BIGINT[]),
+    COALESCE(p_is_air_transfer, FALSE), TRUE, v_appended, p_reason, v_now, p_operator,
+    p_aid_board_id)
+  ON CONFLICT (source_order_id, dest_order_id, transferred_at) DO NOTHING;
+
+  -- 空中轉：貨當下就從轉出店出去 → 建 AT- 轉移單 + 出庫，轉入單進 shipping。
+  -- 接收店在收貨頁收掉就可取貨，沒有「派貨」這一步。同店由 helper 判掉。
+  IF COALESCE(p_is_air_transfer, FALSE) THEN
+    PERFORM public._air_ship_order_items(
+      v_new_order_id, v_orig.pickup_store_id, v_new_item_ids, p_operator, v_now);
+  END IF;
+
+  RETURN v_new_order_id;
+END;
+$fn$;
+
+-- 線上 ACL 原樣還原（DROP 會一起帶走 GRANT）
+GRANT EXECUTE ON FUNCTION public.rpc_transfer_order_partial(
+  bigint, bigint, bigint, bigint, uuid, text, jsonb, boolean, bigint)
+  TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.rpc_transfer_order_partial(
+  bigint, bigint, bigint, bigint, uuid, text, jsonb, boolean, bigint) IS
+  '部分轉單。p_aid_board_id 非 NULL = 這是互助板的轉單：一律開新單（不併進'
+  '既有容器單）、並把貼文 id 蓋在轉入單與 customer_order_transfer_links 上。';
+
+-- ------------------------------------------------------------
+-- 4. rpc_claim_manual_spot：透傳 board id（簽名不變，直接 REPLACE）
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_claim_manual_spot(
+  p_board_id bigint,
+  p_to_store_id bigint,
+  p_qty numeric,
+  p_operator uuid,
+  p_reason text,
+  p_is_air_transfer boolean)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $claim$
+DECLARE
+  v_board        mutual_aid_board%ROWTYPE;
+  v_tenant       UUID;
+  v_store_name   TEXT;
+  v_member       BIGINT;
+  v_campaign     BIGINT;
+  v_channel      BIGINT;
+  v_ci           BIGINT;
+  v_price        NUMERIC;
+  v_seq          INT;
+  v_order_no     TEXT;
+  v_order_id     BIGINT;
+  v_dest_order   BIGINT;
+  v_board_status TEXT;
+  v_now          TIMESTAMPTZ := NOW();
+BEGIN
+  IF p_qty IS NULL OR p_qty <= 0 THEN
+    RAISE EXCEPTION '認領數量需 > 0';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('aid_board_claim:' || p_board_id::TEXT));
+
+  SELECT * INTO v_board FROM mutual_aid_board WHERE id = p_board_id FOR UPDATE;
+  IF v_board.id IS NULL THEN
+    RAISE EXCEPTION '找不到互助貼文 #%', p_board_id;
+  END IF;
+  IF v_board.post_type <> 'offer' THEN
+    RAISE EXCEPTION '只有「釋出」貼文可以認領';
+  END IF;
+  IF v_board.status <> 'active' THEN
+    RAISE EXCEPTION '此貼文已結束（%），不能認領', v_board.status;
+  END IF;
+  -- 有來源訂單的貼文走原本那條（前端直接呼叫 rpc_transfer_order_partial），
+  -- 不要在這裡另外生一張載體單、憑空多出一份貨
+  IF v_board.source_customer_order_id IS NOT NULL THEN
+    RAISE EXCEPTION '此貼文有來源訂單，請走原本的認領流程';
+  END IF;
+  IF v_board.sku_id IS NULL THEN
+    RAISE EXCEPTION '此貼文還沒選商品，釋出店要先用「✏️ 修改內容」補選商品才能被認領';
+  END IF;
+  IF v_board.qty_remaining < p_qty THEN
+    RAISE EXCEPTION '認領數量超過剩餘量（剩 %）', v_board.qty_remaining;
+  END IF;
+  IF p_to_store_id = v_board.offering_store_id THEN
+    RAISE EXCEPTION '接收店不能是釋出店本身';
+  END IF;
+
+  SELECT tenant_id, name INTO v_tenant, v_store_name
+    FROM stores WHERE id = v_board.offering_store_id;
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION '釋出店（ID %）不存在', v_board.offering_store_id;
+  END IF;
+
+  v_member   := rpc_get_or_create_store_member(v_board.offering_store_id, p_operator);
+  v_campaign := _restock_sentinel_campaign(v_tenant);
+  v_channel  := _restock_sentinel_channel(v_tenant, v_board.offering_store_id);
+
+  -- 單價：貼文自訂價 → 分店價 → 零售價 → 0（同 _grow_internal_pool）
+  v_price := v_board.spot_price;
+  IF v_price IS NULL THEN
+    SELECT price INTO v_price
+      FROM prices
+     WHERE tenant_id = v_tenant AND sku_id = v_board.sku_id AND scope = 'branch'
+       AND effective_from <= v_now AND (effective_to IS NULL OR effective_to > v_now)
+     ORDER BY effective_from DESC
+     LIMIT 1;
+  END IF;
+  IF v_price IS NULL THEN
+    SELECT price INTO v_price
+      FROM prices
+     WHERE tenant_id = v_tenant AND sku_id = v_board.sku_id AND scope = 'retail'
+       AND effective_from <= v_now AND (effective_to IS NULL OR effective_to > v_now)
+     ORDER BY effective_from DESC
+     LIMIT 1;
+  END IF;
+  v_price := COALESCE(v_price, 0);
+
+  SELECT COUNT(*) + 1 INTO v_seq
+    FROM customer_orders
+   WHERE tenant_id = v_tenant
+     AND order_no LIKE 'AB-' || v_board.offering_store_id::TEXT || '-%';
+  v_order_no := 'AB-' || v_board.offering_store_id::TEXT || '-' || LPAD(v_seq::TEXT, 4, '0');
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id, pickup_store_id,
+    status, ready_at, order_kind, order_type, notes,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_tenant, v_order_no, v_campaign, v_channel, v_member, v_board.offering_store_id,
+    'ready', v_now, 'restock', 'regular',
+    '【內部】互助板現貨載體 #' || p_board_id ||
+      COALESCE('（' || NULLIF(trim(v_board.spot_title), '') || '）', ''),
+    p_operator, p_operator, v_now, v_now
+  ) RETURNING id INTO v_order_id;
+
+  v_ci := _restock_sentinel_campaign_item(v_tenant, v_campaign, v_board.sku_id, v_price);
+
+  INSERT INTO customer_order_items (
+    tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+    status, source, notes, created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_tenant, v_order_id, v_ci, v_board.sku_id, p_qty, v_price,
+    'pending', 'store_internal', '[互助板認領 #' || p_board_id || ']',
+    p_operator, p_operator, v_now, v_now
+  );
+
+  -- 轉給認領店：空中轉當下就建 AT- 單並從釋出店出庫（20260814030000），
+  -- 沒勾則走經總倉兩段（總倉收件匣派貨）
+  v_dest_order := rpc_transfer_order_partial(
+    p_order_id           => v_order_id,
+    p_to_pickup_store_id => p_to_store_id,
+    p_to_member_id       => NULL,
+    p_to_channel_id      => NULL,
+    p_operator           => p_operator,
+    p_reason             => COALESCE(NULLIF(trim(p_reason), ''), '互助板認領 #' || p_board_id),
+    p_items              => jsonb_build_array(
+                              jsonb_build_object('sku_id', v_board.sku_id, 'qty', p_qty)
+                            ),
+    p_is_air_transfer    => COALESCE(p_is_air_transfer, FALSE),
+    -- 互助認領一律開新單、並把貼文 id 蓋在轉入單與轉移連結上（20260824060000）
+    p_aid_board_id       => p_board_id
+  );
+
+  v_board_status := rpc_consume_aid_board(p_board_id, p_qty, p_operator);
+
+  RETURN jsonb_build_object(
+    'board_id',         p_board_id,
+    'board_status',     v_board_status,
+    'carrier_order_id', v_order_id,
+    'carrier_order_no', v_order_no,
+    'dest_order_id',    v_dest_order,
+    'qty',              p_qty
+  );
+END;
+$claim$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_claim_manual_spot(
+  bigint, bigint, numeric, uuid, text, boolean)
+  TO anon, authenticated, service_role;
+
+-- ------------------------------------------------------------
+-- 5. 回填：已被併進容器單的互助品項 → 拆成獨立轉入單
+--
+--    只處理「辨識得出是互助板」的轉移（reason 帶「互助板」）。更早的併入在
+--    20260824000100 回填連結表時原始 reason 就已經遺失，硬猜會把一般的店對店
+--    轉貨也拆掉 —— 那些改用新分頁「一趟轉移一列」呈現就夠了，不動資料。
+--
+--    ⚠ 搬列（UPDATE order_id）不是複製：品項 id 不變，
+--      customer_order_transfer_links.dest_item_ids、撿貨、月結的既有引用
+--      才不會斷（同 _stockout_po_items 的原則）。
+-- ------------------------------------------------------------
+DO $backfill$
+DECLARE
+  r              RECORD;
+  v_seq          INT;
+  v_campaign_no  TEXT;
+  v_new_order_id BIGINT;
+  v_new_order_no TEXT;
+  v_new_status   TEXT;
+  v_split        INT := 0;
+  v_now          TIMESTAMPTZ := NOW();
+BEGIN
+  FOR r IN
+    SELECT l.id AS link_id, l.source_order_id, l.dest_order_id, l.dest_item_ids,
+           l.is_air_transfer, l.reason, l.transferred_at,
+           (regexp_match(l.reason, '互助板[^#]*#([0-9]+)'))[1]::BIGINT AS board_id,
+           d.tenant_id, d.campaign_id, d.channel_id, d.member_id,
+           d.pickup_store_id, d.status AS dest_status, d.nickname_snapshot,
+           s.order_no AS src_no
+      FROM customer_order_transfer_links l
+      JOIN customer_orders d ON d.id = l.dest_order_id
+      JOIN customer_orders s ON s.id = l.source_order_id
+     WHERE l.appended
+       AND l.reason ~ '互助板'
+       AND s.pickup_store_id IS DISTINCT FROM d.pickup_store_id
+     ORDER BY l.transferred_at
+  LOOP
+    -- 只搬還在店裡的品項；已取貨 / 已取消的動了就是改到歷史
+    IF NOT EXISTS (
+      SELECT 1 FROM customer_order_items i
+       WHERE i.id = ANY (r.dest_item_ids)
+         AND i.order_id = r.dest_order_id
+         AND i.status IN ('pending','reserved','ready')
+    ) THEN CONTINUE; END IF;
+
+    -- 搬走之後容器單不能一件都不剩（那是把容器單搬空、留一張空殼）
+    IF NOT EXISTS (
+      SELECT 1 FROM customer_order_items i
+       WHERE i.order_id = r.dest_order_id
+         AND NOT (i.id = ANY (r.dest_item_ids))
+    ) THEN CONTINUE; END IF;
+
+    SELECT campaign_no INTO v_campaign_no
+      FROM group_buy_campaigns WHERE id = r.campaign_id;
+
+    -- TF 序號比照 rpc_transfer_order_partial：MAX+1，不是 COUNT+1
+    PERFORM pg_advisory_xact_lock(hashtext('order_tf_seq:' || r.campaign_id::text));
+    SELECT COALESCE(MAX(substring(order_no FROM '-TF([0-9]+)$'))::INT, 0) + 1
+      INTO v_seq
+      FROM customer_orders
+     WHERE tenant_id = r.tenant_id AND campaign_id = r.campaign_id
+       AND order_no ~ '-TF[0-9]+$';
+    v_new_order_no := v_campaign_no || '-TF' ||
+                      lpad(v_seq::text, GREATEST(length(v_seq::text), 4), '0');
+
+    -- 容器單掛 partially_completed 是因為**別的**品項被取走了；
+    -- 拆出來這張一件都還沒取，掛 ready 才對（同 RPC 的 mirror 規則）
+    v_new_status := CASE WHEN r.dest_status = 'partially_completed'
+                         THEN 'ready' ELSE r.dest_status END;
+
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id, nickname_snapshot,
+      pickup_store_id, status, notes, transferred_from_order_id, is_air_transfer,
+      aid_board_id, created_at, updated_at
+    ) VALUES (
+      r.tenant_id, v_new_order_no, r.campaign_id, r.channel_id, r.member_id,
+      r.nickname_snapshot, r.pickup_store_id, v_new_status,
+      '[回填拆單] 原本併在訂單 #' || r.dest_order_id || '，依來源單 #' ||
+        r.source_order_id || ' (' || r.src_no || ') 拆成獨立轉入單' ||
+        COALESCE(' / ' || r.reason, ''),
+      r.source_order_id, COALESCE(r.is_air_transfer, FALSE),
+      r.board_id, r.transferred_at, v_now
+    ) RETURNING id INTO v_new_order_id;
+
+    UPDATE customer_order_items
+       SET order_id = v_new_order_id, updated_at = v_now
+     WHERE id = ANY (r.dest_item_ids) AND order_id = r.dest_order_id;
+
+    UPDATE customer_order_transfer_links
+       SET dest_order_id = v_new_order_id, appended = FALSE, aid_board_id = r.board_id
+     WHERE id = r.link_id;
+
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[拆單] 來源單 #' || r.source_order_id || ' 那一趟的貨已拆到 ' ||
+                   v_new_order_no || '（' || to_char(v_now, 'YYYY-MM-DD HH24:MI:SS') || '）',
+           updated_at = v_now
+     WHERE id = r.dest_order_id;
+
+    v_split := v_split + 1;
+  END LOOP;
+
+  RAISE NOTICE '互助回填拆單：% 筆', v_split;
+END;
+$backfill$;


### PR DESCRIPTION
## 做了什麼

店家回報「為什麼我都找不到 #249 其中一筆提供給互助的單」。查下來是**那件貨根本沒有自己的單**：互助轉單被 `rpc_transfer_order_partial` 的併單邏輯（同團＋同頻道＋同會員）併進接收店既有的 `__INTERNAL_RESTOCK__` 容器單 —— 互助的收件人固定是「【內部】xx 店」、團又是 sentinel，一家店所有互助收貨永遠同一把 key，4 家店的貨混在一張單上。

### 一、一趟互助 = 一張單
- `customer_orders` / `customer_order_transfer_links` 加 `aid_board_id`；唯一索引 `customer_orders_trio_kind_active_uniq` 的 predicate 加 `AND aid_board_id IS NULL`（其餘豁免逐字不變）
- `rpc_transfer_order_partial` 加 `p_aid_board_id`：非 NULL 一律開新單並蓋章；`rpc_claim_manual_spot` 透傳
- 回填：把已併入且辨識得出貼文的品項搬成獨立單（`20260824060000`）

### 二、總倉收件匣一店一單＋修假狀態（`20260824070000`）
- 舊的併入拆成獨立單（三條認法：reason 編號／載體單 notes／來源單+SKU 反查），`transfers` 一併改指新單
- **併單會讓貨繼承容器單的狀態**：平鎮容器單因另一趟到貨變 ready，還沒出貨的雞腿排跟著顯示「可取貨」（取貨閘門會放行 → on_hand 扣負）。拆出來的單依「自己那一趟」重算：有轉移單已收→ready、未收→shipping、空中轉→shipping、經總倉→pending

### 三、看得到貨去哪了
- 互助板加「**我提供出去的**」「**我收到的**」分頁：一趟轉移一列（查 links，不查訂單 —— 一張轉入單可有多個來源），分「還在路上／對方已收」，每列可印兩聯隨貨單
- 點開貼文有「**提供／認領紀錄**」：哪家店、什麼貨、走哪條路、跑到哪、單號；沒人接手／查不到明細時明講，不留空白
- `shortOrderNo()`：`__INTERNAL_RESTOCK__-TF0497` → 「轉單 TF0497」，內部代號不再外顯

### 四、取消（`20260824080000`）
- 分界線是「貨到收貨店了沒」：未到 → 兩邊都能取消（`rpc_cancel_aid_order`）；已到 → 收貨方「退回原店」（`rpc_return_aid_order`）、提供方標「需對方退回」；舊的多趟併單不出鈕（整張取消會殃及別家店的貨）
- **取消／退回自動把數量還給貼文**（`_restore_aid_board_qty`：逐 link 還量、上限夾 `qty_available`、`exhausted` 未過期回 `active`）。先前完全不還，貼文永遠卡「已認領」
- 一次性補回 #249 被取消的那 1 件

## 上線危險
- 做了：改三支高頻 RPC（partial 為 DROP+CREATE 加參數；兩支取消 RPC 以**線上 prosrc** 為基底插入，diff 過只有預期改動）、重建一個唯一索引（短暫鎖表）、兩批資料回填。
- 不做：非互助轉單（`p_aid_board_id` NULL）行為一字未改；現貨池／月結／撿貨以品項為單位，回填是搬列不是複製（品項 id 不變）。
- 回退：各 migration 檔頭附 rollback；前端 `git revert`。

## 敏感設定
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證
- 四支 migration 全部**已套上正式庫**並逐項驗證：唯一索引帶 `aid_board_id IS NULL`；partial 僅一個 9 參數版本（無 overload 歧義）；兩支取消 RPC 線上 prosrc 含還量迴圈；#249 拆出 TF0506、取消後貼文回到尚需 2／原 2；收件匣 TF0486 拆成 4 張一店一單、來源店正確；TF0506 假 ready 修回 pending。
- `check-sql-syntax.cjs`（parse + parsePlpgsql）全過；`apps/admin` `tsc --noEmit` 過、eslint 無新增錯誤。
- 套線上時踩到的坑已寫回 migration 註解：`CREATE OR REPLACE` 少寫參數預設值會被 42P13 擋；transfers 對 links 要用 `[transferred_at, +1s)` 區間（回填截秒、transfers 留毫秒）。
