### PR TITLE
訂單頁「📦 從庫存配貨」：把店內現貨指派給這張單的品項

### DIFF
--- a/apps/admin/src/components/AssignStockModal.tsx
+++ b/apps/admin/src/components/AssignStockModal.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Modal } from "@/components/Modal";
+import SpinButton from "@/components/SpinButton";
+import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
+
+// 從庫存配貨：把取貨門市的現貨指派給這張單的這一個品項。
+// 見 20260824070000 migration。
+//
+// 與旁邊兩條路的分工（不要混用）：
+//   - 這一支：客人還沒來 → 只開 DN 覆蓋（取貨閘門 Path D 放行）＋清待補貨旗標，
+//     **不扣庫存、不結案**。客人到店在「取貨」頁完成交貨才扣帳。
+//   - 庫存減抵單（/inventory/deductions）：客人就在現場 → 開單當下扣庫存、
+//     品項標已取貨、訂單結案。
+//   - 現貨直配（庫存總覽「🤝 配給客人」）：沒有既有訂單，開一張新的 SP- 單。
+//
+// 可配量走伺服端 _order_item_stock_budget：**不扣 waiting** —— 這一行自己就是
+// 「還在等貨」的需求之一，扣了會自己擋自己。已到貨的【內部】店現貨池算可配，
+// 配掉時 RPC 會同步從池子扣。
+
+type Budget = {
+  store_name: string;
+  sku_label: string;
+  item_qty: number;
+  assigned: number;
+  backordered: boolean;
+  on_hand: number;
+  committed: number;
+  waiting: number;
+  pool: number;
+  pool_arrived: number;
+  assignable: number;
+  assignable_with_pool: number;
+  gate_ready: boolean;
+};
+
+const num = (v: unknown) => (v == null ? 0 : Number(v));
+
+export function AssignStockModal({
+  itemId,
+  skuLabel,
+  onClose,
+  onSaved,
+}: {
+  itemId: number;
+  skuLabel: string;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [b, setB] = useState<Budget | null>(null);
+  const [qty, setQty] = useState(1);
+  const [reason, setReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data, error: e } = await getSupabase().rpc("rpc_get_order_item_stock_budget", {
+        p_item_id: itemId,
+      });
+      if (cancelled) return;
+      if (e) {
+        setError(translateRpcError(e));
+        return;
+      }
+      const a = (data ?? {}) as Record<string, unknown>;
+      const parsed: Budget = {
+        store_name: String(a.store_name ?? ""),
+        sku_label: String(a.sku_label ?? ""),
+        item_qty: num(a.item_qty),
+        assigned: num(a.assigned),
+        backordered: !!a.backordered,
+        on_hand: num(a.on_hand),
+        committed: num(a.committed),
+        waiting: num(a.waiting),
+        pool: num(a.pool),
+        pool_arrived: num(a.pool_arrived),
+        assignable: num(a.assignable),
+        assignable_with_pool: num(a.assignable_with_pool),
+        gate_ready: !!a.gate_ready,
+      };
+      setB(parsed);
+      // 預設就給滿：店員多半是「有多少配多少」
+      setQty(Math.max(1, parsed.assignable_with_pool));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [itemId]);
+
+  const cap = b?.assignable_with_pool ?? 0;
+  const free = b?.assignable ?? 0;
+  const room = b ? Math.max(b.item_qty - b.assigned, 0) : 0;
+  const fromPool = Math.max(0, Math.min(qty, cap) - free);
+  // 配不滿整行 → 伺服端會拆行，餘量掛待補貨
+  const splitQty = b ? Math.max(room - qty, 0) : 0;
+  const canSubmit = !busy && !!b && qty > 0 && qty <= cap && qty <= room;
+
+  async function save() {
+    if (!canSubmit || !b) return;
+    if (
+      !confirm(
+        `把「${skuLabel}」×${qty} 從「${b.store_name}」的庫存配給這張單？\n\n` +
+          `品項會變成「已到貨・可取貨」，現在不扣庫存、不收款；\n` +
+          `客人到店在「取貨」頁完成交貨時才扣庫存收款。\n` +
+          (fromPool > 0 ? `其中 ${fromPool} 件來自【內部】${b.store_name}現貨池，會自動從池子扣。\n` : "") +
+          (splitQty > 0 ? `沒配到的 ${splitQty} 件會拆成一行、標成「待補貨」。\n` : ""),
+      )
+    )
+      return;
+    setBusy(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) throw new Error("尚未登入");
+      const { data: res, error: e } = await sb.rpc("rpc_assign_stock_to_order_item", {
+        p_item_id: itemId,
+        p_qty: qty,
+        p_operator: operator,
+        p_reason: reason.trim() || null,
+        // 已到貨的內部現貨池也算可配，超出的部分由 RPC 同步扣池子（20260824070000）
+        p_use_pool: true,
+      });
+      if (e) throw new Error(translateRpcError(e));
+      const r = (res ?? {}) as {
+        note_no?: string; from_pool?: number; split_qty?: number;
+        advanced?: boolean; gate_ready?: boolean;
+      };
+      alert(
+        `✅ 已配 ${qty} 件給這張單（減抵單 ${r.note_no ?? ""}）。\n` +
+          (num(r.from_pool) > 0 ? `其中 ${num(r.from_pool)} 件從【內部】${b.store_name}現貨池扣掉。\n` : "") +
+          (num(r.split_qty) > 0 ? `沒配到的 ${num(r.split_qty)} 件已拆成一行、標成「待補貨」。\n` : "") +
+          (r.advanced ? "整張單都到齊了，狀態已推到「已到貨」。\n" : "") +
+          (r.gate_ready ? "客人現在可以在「取貨」頁領走。" : "⚠️ 這一行的取貨閘門仍未放行，請檢查是否還有待補貨。"),
+      );
+      onSaved();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal open onClose={onClose} title="📦 從庫存配貨給這張單" maxWidth="max-w-lg">
+      <div className="space-y-3 text-sm">
+        {error && (
+          <div className="whitespace-pre-wrap rounded-md border border-red-200 bg-red-50 p-3 text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        <div className="rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 dark:border-zinc-800 dark:bg-zinc-900/60">
+          <div className="font-medium text-zinc-900 dark:text-zinc-100">{skuLabel}</div>
+          <div className="mt-0.5 text-xs text-zinc-500">
+            {b === null ? (
+              "載入可配量…"
+            ) : (
+              <>
+                {b.store_name} · 這一行 {b.item_qty} 件
+                {b.assigned > 0 && <span className="ml-1">（已配 {b.assigned} 件）</span>} · 可配{" "}
+                <b className={cap > 0 ? "text-emerald-700 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"}>
+                  {Math.min(cap, room)}
+                </b>{" "}
+                件
+                {cap > free && (
+                  <span className="ml-1 text-zinc-400">（自由量 {free} ＋ 內部現貨池 {cap - free}）</span>
+                )}
+              </>
+            )}
+          </div>
+          {b && (
+            <div className="mt-1 text-[11px] text-zinc-400">
+              店倉在庫 {b.on_hand} − 別的單已佔 {b.committed}
+              {b.pool > b.pool_arrived && <> − 在途內部單 {b.pool - b.pool_arrived}</>}
+              {b.waiting > 0 && <>｜同店還在等這個商品的單共 {b.waiting} 件</>}
+            </div>
+          )}
+          {b && fromPool > 0 && (
+            <div className="mt-1.5 text-[11px] text-amber-700 dark:text-amber-400">
+              其中 <b>{fromPool}</b> 件掛在【內部】{b.store_name}現貨池，送出後會自動從池子扣掉。
+            </div>
+          )}
+          {b && splitQty > 0 && (
+            <div className="mt-1.5 text-[11px] text-amber-700 dark:text-amber-400">
+              沒配到的 <b>{splitQty}</b> 件會拆成一行、標成「待補貨」（下一批貨到店時會自動解除）。
+            </div>
+          )}
+          {b && cap <= 0 && (
+            <div className="mt-1.5 text-[11px] text-amber-700 dark:text-amber-400">
+              {b.on_hand <= 0 ? (
+                <>店倉帳上這個商品是 0 件。架上實際有貨 → 先到「庫存總覽」用「＋ 新增庫存」入帳。</>
+              ) : (
+                <>在庫 {b.on_hand} 件已經被別的單佔走 {b.committed} 件（已承諾未取 ＋ 已配過的單）。</>
+              )}
+            </div>
+          )}
+        </div>
+
+        <label className="block">
+          <span className="mb-1 block text-xs text-zinc-500">配貨數量</span>
+          <input
+            type="number"
+            min={1}
+            max={Math.max(Math.min(cap, room), 1)}
+            value={qty}
+            onChange={(e) => {
+              const v = Math.floor(Number(e.target.value));
+              setQty(Number.isFinite(v) ? Math.max(0, Math.min(v, Math.min(cap, room))) : 0);
+            }}
+            className="w-28 rounded-md border border-zinc-300 bg-white px-3 py-2 text-right tabular-nums dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <span className="ml-2 text-[11px] text-zinc-400">
+            上限 {Math.min(cap, room)}
+            {cap > free ? `（自由量 ${free} ＋ 池子 ${cap - free}）` : ""}
+          </span>
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-xs text-zinc-500">原因（選填）</span>
+          <input
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="例：店內現貨先給這位客人"
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+
+        <div className="rounded-md border border-violet-200 bg-violet-50 px-3 py-2 text-xs text-violet-800 dark:border-violet-900 dark:bg-violet-950/40 dark:text-violet-300">
+          送出＝這一行變成<b>已到貨、可取貨</b>。現在不扣庫存、不收款；
+          客人到店在「取貨」頁完成交貨時才扣庫存、收款。
+          <br />
+          客人就在現場、想當場交貨結案 → 請改走「庫存減抵單」。
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <SpinButton
+            onClick={onClose}
+            className="rounded-md border border-zinc-300 px-4 py-2 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            取消
+          </SpinButton>
+          <SpinButton
+            onClick={save}
+            disabled={!canSubmit}
+            className="rounded-md bg-violet-600 px-5 py-2 font-semibold text-white hover:bg-violet-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
+          >
+            {busy ? "處理中…" : `配 ${qty} 件給這張單`}
+          </SpinButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+export default AssignStockModal;

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -9,6 +9,7 @@ import { PickupDialog } from "@/components/PickupDialog";
 import { AidOrderTimeline } from "@/components/AidOrderTimeline";
 import { OrderAuditDrawer } from "@/components/OrderAuditDrawer";
 import { WalletPayOrderModal } from "@/components/WalletPayOrderModal";
+import { AssignStockModal } from "@/components/AssignStockModal";
 import { EditableNumber, EditableText } from "@/components/EditableCell";
 import { EditableDiscount, deriveDiscount, type DiscountValue } from "@/components/EditableDiscount";
 import { useAuth } from "@/components/AuthProvider";
@@ -231,6 +232,8 @@ export function OrderDetail({
   // item.id → 是否已到貨可取（v_order_item_pickup_ready）。shipping 單部分到貨時，已到品項可先取
   const [itemReady, setItemReady] = useState<Map<number, boolean>>(new Map());
   const [returnDetailId, setReturnDetailId] = useState<number | null>(null);
+  // 「📦 從庫存配貨」目標品項（把取貨門市的現貨指派給這一行）
+  const [assignTarget, setAssignTarget] = useState<{ itemId: number; skuLabel: string } | null>(null);
   // 該訂單的取貨事件（append-only）— 取貨後補印收據用，見 /pickup/print?event_ids=
   const [pickupEvents, setPickupEvents] = useState<PickupEventRow[]>([]);
   const [timeline, setTimeline] = useState<TimelineStep[] | null>(null);
@@ -296,6 +299,13 @@ export function OrderDetail({
 
   // qty 只有 pending 訂單可改;一旦被 PR 鎖定變 confirmed 就唯讀
   const canEditQty = (canEdit || isStoreOfThisOrder) && head?.status === "pending";
+
+  // 「📦 從庫存配貨」：把取貨門市的現貨指派給這一行（開 DN、不扣庫存不結案）。
+  // 跟 qty 編輯不同，這個在 confirmed / 等貨中的單上才最有用，所以不綁 pending。
+  // 伺服端 rpc_assign_stock_to_order_item 另有分店只能配自己店的守衛。
+  const canAssignStock = (canEdit || isStoreOfThisOrder)
+    && !!head
+    && !["cancelled", "expired", "transferred_out", "completed"].includes(head.status);
 
   // 備註（單頭/品項）：店長店員也可編自店訂單，對齊 _check_order_edit_notes_perm
   const canEditNotes = canEdit || isStoreOfThisOrder;
@@ -1419,12 +1429,14 @@ export function OrderDetail({
                 <th className="px-3 py-2 text-left font-medium text-zinc-500">備註</th>
                 <th className="px-3 py-2 text-left font-medium text-zinc-500">第一次加</th>
                 <th className="px-3 py-2 text-left font-medium text-zinc-500">最後更新</th>
-                {canEditQty && <th className="px-3 py-2 text-right font-medium text-zinc-500">操作</th>}
+                {(canEditQty || canAssignStock) && (
+                  <th className="px-3 py-2 text-right font-medium text-zinc-500">操作</th>
+                )}
               </tr>
             </thead>
             <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
               {items.length === 0 ? (
-                <tr><td colSpan={canEditQty ? 10 : 9} className="p-4 text-center text-zinc-500">尚無明細</td></tr>
+                <tr><td colSpan={canEditQty || canAssignStock ? 10 : 9} className="p-4 text-center text-zinc-500">尚無明細</td></tr>
               ) : items.map((it) => {
                 const eff = itemEffective(it);
                 const sub = computeLineSubtotal(Number(eff.qty), eff.unit_price, eff.discount);
@@ -1536,17 +1548,47 @@ export function OrderDetail({
                       {fmtDt(it.updated_at)}<br />
                       <span className="text-[10px]">by {staffLabel(it.updated_by, staffNames)}</span>
                     </td>
-                    {canEditQty && (
+                    {(canEditQty || canAssignStock) && (
                       <td className="px-3 py-2 text-right">
-                        {!["cancelled", "expired"].includes(it.status) && !isPicked ? (
-                          <SpinButton
-                            onClick={() => deleteItem(it)}
-                            title="刪除此品項（待確認訂單，刪到最後一項會自動取消整單）"
-                            className="rounded-md border border-red-300 px-2 py-1 text-[11px] font-medium text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
-                          >
-                            刪除
-                          </SpinButton>
-                        ) : null}
+                        <div className="flex items-center justify-end gap-1.5">
+                          {/* 從庫存配貨：把取貨門市的現貨指派給這一行 → 品項變「可取貨」。
+                              不扣庫存、不結案（客人到店在取貨頁交貨才扣帳）。
+                              草稿沒存的時候先擋下：這一顆會動到 qty（配不滿會拆行），
+                              和未儲存的數量草稿混在一起會互蓋。 */}
+                          {canAssignStock
+                            && !isPicked
+                            && !["cancelled", "expired"].includes(it.status) && (
+                            <SpinButton
+                              onClick={() => {
+                                if (draftCount > 0) {
+                                  alert("請先儲存或放棄未儲存的修改，再從庫存配貨。");
+                                  return;
+                                }
+                                setAssignTarget({
+                                  itemId: it.id,
+                                  skuLabel: it.sku
+                                    ? `${it.sku.product_name ?? ""}${it.sku.variant_name ? ` / ${it.sku.variant_name}` : ""}`.trim()
+                                    : `#${it.id}`,
+                                });
+                              }}
+                              title="把取貨門市的店內現貨指派給這一行 —— 品項會變成「已到貨・可取貨」，取貨時才扣庫存收款"
+                              className="rounded-md border border-violet-300 px-2 py-1 text-[11px] font-medium text-violet-700 hover:bg-violet-50 dark:border-violet-700 dark:text-violet-300 dark:hover:bg-violet-950"
+                            >
+                              📦 從庫存配貨
+                            </SpinButton>
+                          )}
+                          {canEditQty
+                            && !["cancelled", "expired"].includes(it.status)
+                            && !isPicked && (
+                            <SpinButton
+                              onClick={() => deleteItem(it)}
+                              title="刪除此品項（待確認訂單，刪到最後一項會自動取消整單）"
+                              className="rounded-md border border-red-300 px-2 py-1 text-[11px] font-medium text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950"
+                            >
+                              刪除
+                            </SpinButton>
+                          )}
+                        </div>
                       </td>
                     )}
                   </tr>
@@ -1776,6 +1818,14 @@ export function OrderDetail({
           memberId={head.member.id}
           memberName={head.member.name}
           balanceDue={Math.max(0, payableAmount - Number(head.wallet_paid_amount ?? 0))}
+        />
+      )}
+      {assignTarget && (
+        <AssignStockModal
+          itemId={assignTarget.itemId}
+          skuLabel={assignTarget.skuLabel}
+          onClose={() => setAssignTarget(null)}
+          onSaved={() => setReloadTick((n) => n + 1)}
         />
       )}
     </div>

--- a/supabase/migrations/20260824070000_assign_store_stock_to_order_item.sql
+++ b/supabase/migrations/20260824070000_assign_store_stock_to_order_item.sql
@@ -1,0 +1,473 @@
+-- ============================================================================
+-- 訂單頁「從庫存配貨」：把店內現貨指派給這張單的某個品項
+--
+-- 需求（Alex 2026-08-24）：「可以有一個方式讓我直接從庫存配貨給某個訂單，
+--   直接做在訂單的詳細頁面，打開後就可以直接調整訂單數量，要可以從庫存指派
+--   給那張訂單」。
+--
+-- 現況：把店內現貨變成「這位客人可以取」只有三條路，全都不在訂單頁：
+--   1. rpc_create_inventory_deduction（庫存減抵單）—— 只吃**已標待補貨**的品項，
+--      而且開單當下就 rpc_record_pickup 結案（＝直接交貨，客人還沒來就不能用）。
+--   2. rpc_allocate_shortage（少發配貨）—— 綁在收貨頁的某一張 transfer 上。
+--   3. rpc_create_spot_sale（現貨直配）—— 只能開**新的** SP- 單，不能配給既有訂單。
+--   店員手上有貨、客人有一張還在等貨的單，中間沒有橋。
+--
+-- 本檔新增：
+--   1. _order_item_stock_budget(item_id) — 這一行「還能從店內庫存指派幾件」的
+--      唯一算法（含拆解，給畫面顯示用）。
+--   2. rpc_get_order_item_stock_budget(item_id) — 上面那支的 JSONB 包裝（前端預檢）。
+--   3. rpc_assign_stock_to_order_item(item_id, qty, operator, reason, use_pool)
+--      —— 開一張 DN 覆蓋這一行（取貨閘門 Path D 放行）、清掉待補貨旗標、
+--      需要時從【內部】店現貨池扣（同 20260824060000 的現貨直配），
+--      整單都可取時把單頭 confirmed → ready。
+--      **不扣庫存、不結案** —— 客人到店取貨時才走 rpc_record_pickup 扣帳，
+--      與到店取貨同一套帳。要「當場交貨結案」請照舊用庫存減抵單。
+--
+-- 預算算法（為什麼不是直接用 _sku_free_qty_with_pool）：
+--   自由量把 waiting（confirmed 還在等貨的需求）整個扣掉，而這一行**自己就是**
+--   那些 waiting 之一 —— 用自由量會變成「自己擋自己」，一件也指派不出去
+--   （同 20260811000050 _settle_arrived_backorders 檔頭的坑）。
+--   所以這裡的母體是「對這批實體庫存已經有主張的量」：
+--     committed = Σ 同店同 SKU 的 active 品項（排除本行、內部容器單、offset、待補貨）
+--                 · 單頭已承諾（ready / partially_completed / shipping）→ 整行 qty
+--                 · 其餘（還在 confirmed / pending 等貨）→ 只算它身上已開的 DN 覆蓋量
+--     assignable            = on_hand − committed − 在途池子 − 已到貨池子
+--     assignable_with_pool  = on_hand − committed − 在途池子
+--   母體刻意跟取貨閘門的實體庫存守衛（20260818000010）對齊：那道守衛只算
+--   「單頭已承諾」的行，所以還在等貨的單不會互相擋；但**已經被 DN 指派過**的行
+--   要算進來，否則同一批貨可以指派給無限多張 confirmed 單（那正是 2026-08-18
+--   松山「on_hand = 0 還說可取」的形狀）。
+--
+-- 為什麼用 DN 而不是把單頭推 ready 就好：
+--   取貨閘門 Path C（本店該 SKU 有收過貨）是 qty-blind 而且要看歷史，店內現貨
+--   可能是盤盈 / 自購 / 手動入帳，根本沒有 transfer 紀錄；DN 是 Path D，
+--   對「貨就在架上」這件事是唯一誠實的表達（rpc_create_spot_sale 同理由）。
+--   DN 的覆蓋在訂單被取消 / 逾期時會自動釋放（20260813002000 的 trigger），
+--   不會留下殭屍覆蓋。
+--
+-- 配不滿一整行時要**拆行**（同 rpc_allocate_shortage 20260805000100）：
+--   取貨閘門與 rpc_record_pickup 看到的永遠是「整行可取」或「整行待補」——
+--   閘門的實體庫存守衛把本行的 **整行 qty** 算進累計，所以「4 件的行只配 3 件」
+--   不拆的話閘門照樣回 false，等於白配（實測：松山 76737 配 3/4 後 gate 仍是 f）。
+--   拆法比照少發配貨：原行留下已配到的量，餘量另開一行標 backorder_at（待補貨），
+--   折扣按數量比例分攤。
+--
+-- 單頭處理：整單的 active 品項都通過閘門才把 confirmed 推 ready
+--   （同 _advance_arrived_confirmed_orders 的「整單裝得下才推」）。只指派到其中
+--   一項時單頭不動 —— 取貨頁本來就逐品項放行（20260824050000），confirmed 單
+--   靠 Path D 的品項也勾得到。
+--
+-- 基底版本：本檔三支函式皆為新增，不改任何既有函式。
+-- Rollback：
+--   DROP FUNCTION public.rpc_assign_stock_to_order_item(BIGINT,NUMERIC,UUID,TEXT,BOOLEAN);
+--   DROP FUNCTION public.rpc_get_order_item_stock_budget(BIGINT);
+--   DROP FUNCTION public._order_item_stock_budget(BIGINT);
+--   已經指派出去的 DN 不會被 rollback 清掉：要收回請取消該訂單（覆蓋會自動釋放）
+--   或人工把 inventory_deduction_notes.cancelled_at 補上。
+--
+-- 對應前端（同一個 commit）：
+--   apps/admin/src/components/AssignStockModal.tsx（新）
+--   apps/admin/src/components/OrderDetail.tsx（品項列多一顆「📦 從庫存配貨」）
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. _order_item_stock_budget — 這一行還能從店內庫存指派幾件（唯一算法）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._order_item_stock_budget(
+  p_item_id BIGINT
+) RETURNS TABLE (
+  tenant_id            UUID,
+  order_id             BIGINT,
+  order_no             TEXT,
+  order_status         TEXT,
+  campaign_id          BIGINT,
+  store_id             BIGINT,
+  store_name           TEXT,
+  location_id          BIGINT,
+  sku_id               BIGINT,
+  sku_label            TEXT,
+  item_qty             NUMERIC,
+  item_status          TEXT,
+  backordered          BOOLEAN,
+  assigned             NUMERIC,  -- 這一行已經被 DN 覆蓋的量
+  on_hand              NUMERIC,
+  committed            NUMERIC,  -- 別行對這批實體庫存的主張
+  waiting              NUMERIC,  -- 同店同 SKU 還在等貨的需求（顯示用，不進算式）
+  pool                 NUMERIC,  -- 內部現貨池（含在途）
+  pool_arrived         NUMERIC,
+  assignable           NUMERIC,  -- 不動池子時還能指派幾件
+  assignable_with_pool NUMERIC   -- 允許扣池子時還能指派幾件
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH it AS (
+    SELECT coi.id, coi.order_id, coi.sku_id, coi.qty, coi.status AS item_status,
+           coi.backorder_at,
+           co.tenant_id, co.order_no, co.status AS order_status, co.campaign_id,
+           co.pickup_store_id
+      FROM customer_order_items coi
+      JOIN customer_orders co ON co.id = coi.order_id
+     WHERE coi.id = p_item_id
+  ),
+  st AS (
+    SELECT it.*, s.id AS s_store_id, s.name AS s_store_name, s.location_id AS s_location_id
+      FROM it LEFT JOIN stores s ON s.id = it.pickup_store_id
+  ),
+  -- 這一行身上還有效的 DN 覆蓋量（作廢的單不算，released 的部分不算）
+  mine AS (
+    SELECT COALESCE(SUM(GREATEST(ni.qty - COALESCE(ni.released_qty, 0), 0)), 0) AS assigned
+      FROM inventory_deduction_note_items ni
+      JOIN inventory_deduction_notes n ON n.id = ni.note_id AND n.cancelled_at IS NULL
+     WHERE ni.order_item_id = p_item_id
+  ),
+  bal AS (
+    SELECT COALESCE(sb.on_hand, 0) AS on_hand
+      FROM st LEFT JOIN stock_balances sb
+             ON sb.tenant_id   = st.tenant_id
+            AND sb.location_id = st.s_location_id
+            AND sb.sku_id      = st.sku_id
+  ),
+  -- 別行的主張：單頭已承諾 → 整行；還在等貨 → 只算它身上的 DN 覆蓋
+  others AS (
+    SELECT COALESCE(SUM(
+             CASE WHEN yo.status IN ('ready','partially_completed','shipping') THEN y.qty
+                  ELSE LEAST(y.qty, COALESCE(cov.q, 0)) END), 0) AS committed
+      FROM st
+      JOIN customer_orders yo
+        ON yo.tenant_id       = st.tenant_id
+       AND yo.pickup_store_id = st.s_store_id
+       AND yo.status NOT IN ('cancelled','expired','transferred_out')
+      JOIN customer_order_items y
+        ON y.order_id = yo.id
+       AND y.sku_id   = st.sku_id
+       AND y.status IN ('pending','reserved','ready')
+       AND y.qty > 0
+       AND y.id <> p_item_id
+       -- 待補貨的行已被少發配貨擋掉，不佔預算（同取貨閘門的實體守衛）
+       AND y.backorder_at IS NULL
+      LEFT JOIN members ym ON ym.id = yo.member_id
+      LEFT JOIN LATERAL (
+        SELECT SUM(GREATEST(ni.qty - COALESCE(ni.released_qty, 0), 0)) AS q
+          FROM inventory_deduction_note_items ni
+          JOIN inventory_deduction_notes n ON n.id = ni.note_id AND n.cancelled_at IS NULL
+         WHERE ni.order_item_id = y.id
+      ) cov ON TRUE
+     WHERE COALESCE(ym.member_type, '') <> 'store_internal'
+       AND COALESCE(yo.order_kind, 'normal') <> 'offset'
+  ),
+  k AS (
+    SELECT COALESCE(c.waiting, 0)      AS waiting,
+           COALESCE(c.pool_claimed, 0) AS pool,
+           COALESCE(c.pool_arrived, 0) AS pool_arrived
+      FROM st
+      LEFT JOIN LATERAL public._sku_commitment(st.s_store_id, ARRAY[st.sku_id]) c ON TRUE
+  )
+  SELECT st.tenant_id,
+         st.order_id,
+         st.order_no,
+         st.order_status,
+         st.campaign_id,
+         st.s_store_id,
+         st.s_store_name,
+         st.s_location_id,
+         st.sku_id,
+         COALESCE(sk.product_name, '') ||
+           CASE WHEN sk.variant_name IS NOT NULL THEN ' / ' || sk.variant_name ELSE '' END,
+         st.qty,
+         st.item_status,
+         st.backorder_at IS NOT NULL,
+         mine.assigned,
+         bal.on_hand,
+         others.committed,
+         k.waiting,
+         k.pool,
+         k.pool_arrived,
+         GREATEST(bal.on_hand - others.committed - (k.pool - k.pool_arrived) - k.pool_arrived, 0),
+         GREATEST(bal.on_hand - others.committed - (k.pool - k.pool_arrived), 0)
+    FROM st
+    LEFT JOIN skus sk ON sk.id = st.sku_id
+    CROSS JOIN mine
+    CROSS JOIN bal
+    CROSS JOIN others
+    CROSS JOIN k;
+$$;
+
+COMMENT ON FUNCTION public._order_item_stock_budget(BIGINT) IS
+  '訂單品項「還能從店內庫存指派幾件」的唯一算法（含拆解，畫面與 RPC 共用）。'
+  '母體＝別行對這批實體庫存的主張：單頭已承諾的整行算，還在等貨的只算它身上的 DN 覆蓋。'
+  '刻意不扣 waiting —— 本行自己就是 waiting 之一，扣了會自己擋自己。';
+
+REVOKE ALL ON FUNCTION public._order_item_stock_budget(BIGINT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public._order_item_stock_budget(BIGINT) TO authenticated, service_role;
+
+-- ----------------------------------------------------------------------------
+-- 2. rpc_get_order_item_stock_budget — 前端預檢（伺服端開單時會再驗一次）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_get_order_item_stock_budget(
+  p_item_id BIGINT
+) RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'item_id',              p_item_id,
+    'order_id',             b.order_id,
+    'order_no',             b.order_no,
+    'order_status',         b.order_status,
+    'store_id',             b.store_id,
+    'store_name',           b.store_name,
+    'sku_id',               b.sku_id,
+    'sku_label',            b.sku_label,
+    'item_qty',             b.item_qty,
+    'item_status',          b.item_status,
+    'backordered',          b.backordered,
+    'assigned',             b.assigned,
+    'on_hand',              b.on_hand,
+    'committed',            b.committed,
+    'waiting',              b.waiting,
+    'pool',                 b.pool,
+    'pool_arrived',         b.pool_arrived,
+    'assignable',           LEAST(b.assignable,           GREATEST(b.item_qty - b.assigned, 0)),
+    'assignable_with_pool', LEAST(b.assignable_with_pool, GREATEST(b.item_qty - b.assigned, 0)),
+    'gate_ready',           public.is_order_item_pickup_ready(p_item_id)
+  )
+    FROM public._order_item_stock_budget(p_item_id) b;
+$$;
+
+COMMENT ON FUNCTION public.rpc_get_order_item_stock_budget(BIGINT) IS
+  '訂單頁「從庫存配貨」彈窗的預檢：在庫 / 別人的主張 / 等貨 / 內部池 / 還能指派幾件 / '
+  '這一行目前過不過取貨閘門。上限已夾到「本行還沒被指派的量」。';
+
+REVOKE ALL ON FUNCTION public.rpc_get_order_item_stock_budget(BIGINT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_get_order_item_stock_budget(BIGINT) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 3. rpc_assign_stock_to_order_item — 把店內現貨指派給這一行
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_assign_stock_to_order_item(
+  p_item_id  BIGINT,
+  p_qty      NUMERIC,
+  p_operator UUID,
+  p_reason   TEXT    DEFAULT NULL,
+  p_use_pool BOOLEAN DEFAULT FALSE
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_jwt_role  TEXT  := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_my_stores JSONB := COALESCE(auth.jwt() -> 'app_metadata' -> 'stores', '[]'::jsonb);
+  v_b         RECORD;
+  v_now       TIMESTAMPTZ := NOW();
+  v_room      NUMERIC;
+  v_cap       NUMERIC;
+  v_from_pool NUMERIC := 0;
+  v_pool_done NUMERIC;
+  v_note_id   BIGINT;
+  v_note_no   TEXT;
+  v_all_ready BOOLEAN;
+  v_advanced  BOOLEAN := FALSE;
+  v_hint      TEXT;
+  v_keep      NUMERIC;
+  v_rest      NUMERIC := 0;
+  v_rest_id   BIGINT;
+  v_row       customer_order_items%ROWTYPE;
+  v_new_disc  NUMERIC;
+BEGIN
+  IF p_qty IS NULL OR p_qty <= 0 OR p_qty <> FLOOR(p_qty) THEN
+    RAISE EXCEPTION '配貨數量必須是正整數';
+  END IF;
+  IF p_operator IS NULL THEN
+    RAISE EXCEPTION '缺少操作人';
+  END IF;
+
+  SELECT * INTO v_b FROM public._order_item_stock_budget(p_item_id);
+  IF NOT FOUND OR v_b.order_id IS NULL THEN
+    RAISE EXCEPTION '找不到訂單品項 #%', p_item_id;
+  END IF;
+  IF v_b.store_id IS NULL OR v_b.location_id IS NULL THEN
+    RAISE EXCEPTION '這張單的取貨門市沒有綁定倉別，算不出店內庫存';
+  END IF;
+  IF v_b.item_status NOT IN ('pending','reserved','ready') THEN
+    RAISE EXCEPTION '這個品項是「%」，不能再配貨（已取貨 / 已取消的行不動）', v_b.item_status;
+  END IF;
+  IF v_b.order_status IN ('cancelled','expired','transferred_out') THEN
+    RAISE EXCEPTION '訂單狀態為「%」，不能配貨', v_b.order_status;
+  END IF;
+
+  -- 店家守衛：分店角色只能配自己店的貨（規則對齊 rpc_create_spot_sale /
+  -- rpc_record_pickup —— 線上分店帳號沒有 store_id，一律看 app_metadata.stores 店名陣列）
+  IF v_jwt_role IN ('store_manager', 'store_staff')
+     AND jsonb_typeof(v_my_stores) = 'array'
+     AND jsonb_array_length(v_my_stores) > 0
+     AND NOT (v_my_stores ? '總倉')
+     AND NOT (v_my_stores ? v_b.store_name) THEN
+    RAISE EXCEPTION 'wrong_store: 這是「%」的單，分店帳號只能配自己店的貨', v_b.store_name;
+  END IF;
+
+  -- 同一個 (店, SKU) 併發配貨會各自過預算，鎖住整組序列化
+  -- （與 rpc_create_spot_sale 同一把鎖：兩邊搶的是同一批實體庫存）
+  PERFORM pg_advisory_xact_lock(hashtext(format('spotsale:%s:%s:%s',
+    v_b.tenant_id, v_b.store_id, v_b.sku_id)));
+
+  -- 拿鎖之後重算一次（前面那次只是為了驗參數）
+  SELECT * INTO v_b FROM public._order_item_stock_budget(p_item_id);
+
+  v_room := GREATEST(v_b.item_qty - v_b.assigned, 0);
+  IF v_room <= 0 THEN
+    RAISE EXCEPTION '這一行 % 件已經全部配過了（已指派 % 件），要再給請先改訂單數量',
+      v_b.item_qty, v_b.assigned;
+  END IF;
+  IF p_qty > v_room THEN
+    RAISE EXCEPTION '這一行只剩 % 件還沒配（共 % 件、已指派 % 件），不能配 % 件',
+      v_room, v_b.item_qty, v_b.assigned, p_qty;
+  END IF;
+
+  v_cap := CASE WHEN p_use_pool THEN v_b.assignable_with_pool ELSE v_b.assignable END;
+  IF v_cap < p_qty THEN
+    IF NOT p_use_pool AND v_b.pool_arrived > 0 THEN
+      v_hint := '這批貨掛在【內部】' || v_b.store_name || '現貨池（已到貨 '
+                || v_b.pool_arrived || ' 件），從訂單頁的「📦 從庫存配貨」配就會自動從池子扣。';
+    ELSIF v_b.on_hand <= 0 THEN
+      v_hint := '店倉帳上這個商品是 0 件。架上實際有貨的話，請先到「庫存總覽」'
+                || '對這個商品「＋ 新增庫存」把現貨入帳。';
+    ELSE
+      v_hint := '在庫 ' || v_b.on_hand || ' 件已經被別的單佔走 ' || v_b.committed
+                || ' 件（已承諾未取 ＋ 已配過的單）。架上實際有更多貨請先「＋ 新增庫存」。';
+    END IF;
+    RAISE EXCEPTION '「%」在「%」可配 % 件、要配 % 件。%',
+      COALESCE(NULLIF(v_b.sku_label, ''), v_b.sku_id::TEXT), v_b.store_name,
+      v_cap, p_qty, v_hint;
+  END IF;
+
+  -- 超出「不動池子」的部分要從已到貨的池子扣（同 rpc_create_spot_sale）
+  v_from_pool := GREATEST(p_qty - v_b.assignable, 0);
+
+  -- 待補貨旗標：這批貨到位了就該解除，否則閘門 backorder_at IS NULL 那關過不了
+  UPDATE customer_order_items
+     SET backorder_at = NULL,
+         backorder_by = NULL,
+         updated_by   = p_operator,
+         updated_at   = v_now
+   WHERE id = p_item_id
+     AND backorder_at IS NOT NULL;
+
+  -- 配不滿整行 → 拆行（同 rpc_allocate_shortage 20260805000100）。
+  -- 閘門的實體庫存守衛算的是**整行 qty**，不拆的話「4 件只配 3 件」照樣過不了，
+  -- 等於白配。原行留下已配到的量，餘量另開一行掛待補貨。
+  v_keep := v_b.assigned + p_qty;
+  IF v_keep < v_b.item_qty THEN
+    SELECT * INTO v_row FROM customer_order_items WHERE id = p_item_id FOR UPDATE;
+    v_rest := v_row.qty - v_keep;
+    -- 折扣按數量比例分攤（與 rpc_record_pickup / 少發配貨拆行同一套算法）
+    v_new_disc := COALESCE(v_row.discount_amount, 0)
+                  - round(COALESCE(v_row.discount_amount, 0) * v_keep / v_row.qty);
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, notes, discount_amount, discount_percent,
+      backorder_at, backorder_by,
+      is_gift, gift_reason, gift_marked_by, gift_marked_at,
+      created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      v_row.tenant_id, v_row.order_id, v_row.campaign_item_id, v_row.sku_id,
+      v_rest, v_row.unit_price,
+      v_row.status, v_row.source,
+      TRIM(BOTH E'\n' FROM COALESCE(v_row.notes || E'\n', '')
+           || '[未配到，待補貨｜拆分自#' || v_row.id || ']'),
+      v_new_disc, v_row.discount_percent,
+      v_now, p_operator,
+      -- 贈品旗標要跟著拆，不然餘量那行會被取貨的零元守衛擋下
+      v_row.is_gift, v_row.gift_reason, v_row.gift_marked_by, v_row.gift_marked_at,
+      p_operator, p_operator, v_now, v_now
+    ) RETURNING id INTO v_rest_id;
+
+    UPDATE customer_order_items
+       SET qty             = v_keep,
+           discount_amount = COALESCE(v_row.discount_amount, 0) - v_new_disc,
+           updated_by      = p_operator,
+           updated_at      = v_now
+     WHERE id = p_item_id;
+  END IF;
+
+  -- DN 覆蓋：取貨閘門 Path D 放行。**不扣庫存、不結案** ——
+  -- 客人到店取貨時才由 rpc_record_pickup 寫 sale，與到店取貨同一套帳。
+  INSERT INTO inventory_deduction_notes (
+    tenant_id, note_no, campaign_id, store_id, sku_id, transfer_id,
+    qty, reason, created_by
+  ) VALUES (
+    v_b.tenant_id,
+    'DN' || to_char(v_now, 'YYMMDD') || lpad(nextval('deduction_note_seq')::text, 4, '0'),
+    v_b.campaign_id, v_b.store_id, v_b.sku_id, NULL,
+    p_qty,
+    COALESCE(NULLIF(TRIM(p_reason), ''), '訂單頁從庫存配貨 ' || v_b.order_no),
+    p_operator
+  ) RETURNING id, note_no INTO v_note_id, v_note_no;
+
+  INSERT INTO inventory_deduction_note_items (note_id, order_id, order_item_id, qty)
+  VALUES (v_note_id, v_b.order_id, p_item_id, p_qty);
+
+  -- 現貨池：這批貨改掛在客人頭上了，池子要同額扣掉（承諾總量不變）
+  IF v_from_pool > 0 THEN
+    v_pool_done := public._consume_internal_pool(
+      v_b.store_id, v_b.sku_id, v_from_pool, p_operator, v_now,
+      '[已配給訂單 ' || v_b.order_no || ']');
+    IF v_pool_done < v_from_pool THEN
+      RAISE EXCEPTION '【內部】%現貨池只扣得到 % 件、需要 % 件（可能同時有人在動同一批貨），請重新整理後再試',
+        v_b.store_name, v_pool_done, v_from_pool;
+    END IF;
+  END IF;
+
+  -- 單頭：整單的 active 品項都過得了閘門才把 confirmed 推 ready
+  -- （同 _advance_arrived_confirmed_orders 的「整單裝得下才推」；只配到其中一項時
+  --  單頭不動 —— 取貨頁逐品項放行，confirmed 單靠 Path D 的品項也勾得到）
+  IF v_b.order_status = 'confirmed' THEN
+    SELECT bool_and(public.is_order_item_pickup_ready(c.id)) INTO v_all_ready
+      FROM customer_order_items c
+     WHERE c.order_id = v_b.order_id
+       AND c.status IN ('pending','reserved','ready');
+    IF COALESCE(v_all_ready, FALSE) THEN
+      UPDATE customer_orders
+         SET status     = 'ready',
+             ready_at   = v_now,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_b.order_id
+         AND status = 'confirmed';
+      v_advanced := TRUE;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'item_id',      p_item_id,
+    'order_id',     v_b.order_id,
+    'order_no',     v_b.order_no,
+    'qty',          p_qty,
+    'from_pool',    v_from_pool,
+    'note_no',      v_note_no,
+    'split_qty',    v_rest,      -- 拆出去掛待補貨的量（0 = 整行都配到了）
+    'split_item_id', v_rest_id,
+    'order_status', CASE WHEN v_advanced THEN 'ready' ELSE v_b.order_status END,
+    'advanced',     v_advanced,
+    'gate_ready',   public.is_order_item_pickup_ready(p_item_id)
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_assign_stock_to_order_item(BIGINT, NUMERIC, UUID, TEXT, BOOLEAN) IS
+  '訂單頁「從庫存配貨」：把店內現貨指派給這張單的某個品項 —— 開 DN 覆蓋（取貨閘門 '
+  'Path D 放行）＋清待補貨旗標，需要時從【內部】店現貨池扣（p_use_pool），'
+  '整單都可取時把 confirmed 推 ready。不扣庫存、不結案（取貨時才走 rpc_record_pickup）。'
+  '要「當場交貨結案」請用庫存減抵單 rpc_create_inventory_deduction。'
+  '可配量走 _order_item_stock_budget（不扣 waiting —— 本行自己就是 waiting）。';
+
+REVOKE ALL ON FUNCTION public.rpc_assign_stock_to_order_item(BIGINT, NUMERIC, UUID, TEXT, BOOLEAN)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_assign_stock_to_order_item(BIGINT, NUMERIC, UUID, TEXT, BOOLEAN)
+  TO authenticated;


### PR DESCRIPTION
## 做了什麼

需求（接 #834 的後續）：「直接從庫存配貨給某個訂單，直接做在訂單的詳細頁面」。

原本把店內現貨變成「這位客人可取」的三條路全不在訂單頁：減抵單只吃**已標待補貨**的品項而且開單當下就結案（客人還沒來就不能用）；少發配貨綁在收貨頁的某張 transfer 上；現貨直配只能開**新的** SP- 單。店員手上有貨、客人有一張等貨中的單，中間沒有橋。

**DB `20260824070000`（已用 Management API 套上正式庫；三支函式全為新增，不改既有函式）**

- `_order_item_stock_budget`：這一行還能從店內庫存指派幾件的唯一算法。**刻意不扣 waiting** —— 本行自己就是「還在等貨」的需求之一，扣了會自己擋自己；母體對齊取貨閘門的實體庫存守衛：單頭已承諾（ready/部分取貨/shipping）的行整行算、還在等貨的行只算它身上已開的有效 DN 覆蓋 —— 否則同一批貨可以指派給無限多張 confirmed 單（松山 8/18 事故的形狀）。
- `rpc_get_order_item_stock_budget`：前端預檢（含拆解與 gate_ready）。
- `rpc_assign_stock_to_order_item(item_id, qty, operator, reason, use_pool)`：
  - 開 DN 覆蓋 → 取貨閘門 Path D 放行（Path C 是 qty-blind 又要看歷史，盤盈/自購的現貨沒有 transfer 紀錄）；訂單取消/逾期時 `20260813002000` 的 trigger 會自動釋放覆蓋，不留殭屍。
  - 清掉 `backorder_at`（不清的話閘門 `backorder_at IS NULL` 那關過不了）。
  - 超出自由量的部分從【內部】店現貨池扣（共用 #834 的 `_consume_internal_pool`，標 `[已配給訂單 <單號>]`），扣不滿整筆回滾。
  - **配不滿整行就拆行**（餘量另開一行標待補貨，折扣按比例分攤，同少發配貨 20260805000100）—— 閘門的實體守衛算的是整行 qty，不拆等於白配（實測 4 件配 3 件、不拆閘門仍 false）。
  - 整單 active 品項都過閘門才把 confirmed 推 ready（同 `_advance_arrived_confirmed_orders` 的「整單裝得下才推」）；只配到其中一項時單頭不動，取貨頁本來就逐品項放行。
  - **不扣庫存、不結案** —— 客人到店取貨時才走 `rpc_record_pickup`，與到店取貨同一套帳。當場交貨結案照舊走庫存減抵單。

**前端**

- `OrderDetail` 品項列多一顆「📦 從庫存配貨」（新 `AssignStockModal`）：顯示可配量拆解（自由量＋內部現貨池）、會扣池子 / 會拆行時先提示，confirm 與成功訊息都寫清楚。有未儲存的數量草稿時先擋（配貨會動 qty，混著存會互蓋）。
- 按鈕出現條件：HQ / 總倉 / 本店帳號，單頭不在 cancelled/expired/transferred_out/completed；伺服端另有分店只能配自己店的守衛。

## 上線危險

- 做了：訂單頁多一顆配貨鈕；配出去的是 DN 覆蓋（可取貨），庫存在取貨那一刻才扣。
- 不做：等貨中的訂單只能繞收貨頁配貨、或轉單才吃得到店內現貨；`#834` 開出來的可配量在訂單側仍用不到。
- 回退：DROP 三支新函式（檔頭有完整 rollback）。已配出去的覆蓋不用清 —— 取消訂單會自動釋放。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

（RPC `authenticated`、helper `authenticated, service_role`、`anon` 全 REVOKE。）

## 驗證

- SQL：`check-sql-syntax.cjs` 三支函式 `parse`＋`parsePlpgsql` 全過。
- 線上**唯讀 dry-run**（包在 `RAISE ROLLBACK_TEST` 回滾、事後確認零殘留）：
  - 平鎮 85887（3 件、貨全在池子、assignable 0 / with_pool 5）配 3 件 → DN 開出、`from_pool=3`、`pool_arrived` 5→2、單頭 confirmed→**ready**（整單到齊）、gate_ready=true。
  - 松山 76737（4 件、可配 3）配 3 件 → 拆行（`split_qty=1` 標待補貨）、該行閘門 **f→t**、單頭不動（同單另一項還沒到）。
  - 同一行再超配 → 被擋（「已指派 3 件」）。
- PostgREST schema cache 解析得到新函式（42501，非 PGRST202）。
- 前端：`tsc` 乾淨、eslint 只剩 HEAD 既有警告、`npm run build` 綠（含 Safari 15.6 bundle 檢查）。
- UI（Playwright + fixture，不碰線上 DB）：訂單明細 → 品項列「📦 從庫存配貨」→ 彈窗顯示「可配 3 件（自由量 0 ＋ 內部現貨池 3）」＋池子提示 → 送出帶 `p_use_pool:true`，confirm / 成功訊息正確。

（首發時這個 commit 誤疊在 #834 上、且在 #834 合併後才推 —— 已把分支重架在最新 main 上，本 PR 只含這一個變更。）


---
_Generated by [Claude Code](https://claude.ai/code/session_01K289gL6W6KWqES6mBgoX1A)_