### PR TITLE
互助取消一條龍：兩邊都有入口、數量自動還回貼文；收件匣一店一單（舊資料拆完）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,9 +288,13 @@ PERFORM public._close_orders_all_items_settled(v_order_ids, p_operator, NOW());
 cancelled 列 / 補列），並把轉入單的品項標 `cancelled`，避免兩張單掛同一批貨。
 來源單 notes 蓋回補標記 → 重跑不會加倍。
 
-**互助板的認領量不會自動還**（`rpc_cancel_aid_order` / `rpc_return_aid_order` 都刻意
-不動 `mutual_aid_board`）。取消互助認領之後，`qty_remaining` 要人工加回去，
-否則那則貼文卡在 `exhausted`、釋出店再也放不出來。
+**互助板的認領量 20260824080000 起會自動還**：`rpc_cancel_aid_order` /
+`rpc_return_aid_order` 逐 link 把該趟數量還給 `mutual_aid_board`
+（`_restore_aid_board_qty`，上限夾 `qty_available`，`exhausted` 未過期 → 回
+`active`）。認貼文靠 `customer_order_transfer_links.aid_board_id` /
+`customer_orders.aid_board_id`（20260824060000）——**兩邊都沒蓋章的舊單取消
+還是不會還**，那種要人工加回去。新增任何取消／退回互助單的路徑，記得一樣
+接 `_restore_aid_board_qty`，而且要在品項被標 `cancelled` **之前**算量。
 
 ### 搬品項的 SQL 一律只挑 active（`pending`/`reserved`/`ready`）
 

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -772,20 +772,23 @@ function ProvidedList({ stores }: { stores: Store[] }) {
                   : "bg-white text-zinc-600 hover:bg-zinc-50 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
               }`}
             >
-              {v ? `已完成 (${done.length})` : `在跑的 (${inFlight.length})`}
+              {/* ⚠ 不要叫「已完成」：這一格說的是**這趟貨**對方收到了，
+                  不是來源單完成了。來源單（OV-/AB-/RR- 現貨池）通常還掛著
+                  一堆沒動過的品項，2026-08-24 就被誤讀成「OV-2-0001 變已完成」。 */}
+              {v ? `對方已收 (${done.length})` : `還在路上 (${inFlight.length})`}
             </SpinButton>
           ))}
         </div>
         <span className="text-xs text-zinc-500">
           {myStoreId == null
             ? "全站的店對店轉出（總倉視角）"
-            : "本店轉出去的貨。收貨店收掉之後就會移到「已完成」"}
+            : "本店轉出去的貨。狀態說的是「這一趟」走到哪，不是來源單的狀態"}
         </span>
       </div>
 
       {shown.length === 0 ? (
         <div className="rounded-md border border-dashed border-zinc-300 p-8 text-center text-sm text-zinc-500 dark:border-zinc-700">
-          {showDone ? "沒有已完成的轉出紀錄" : "目前沒有在路上的轉出"}
+          {showDone ? "沒有對方已收的轉出紀錄" : "目前沒有在路上的轉出"}
         </div>
       ) : (
         <ul className="space-y-2">
@@ -800,8 +803,11 @@ function ProvidedList({ stores }: { stores: Store[] }) {
                     給 {r.dest_store}
                   </span>
                   <span className="text-[10px] text-zinc-500">{aidRouteLabel(r.is_air_transfer)}</span>
-                  <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
-                    {aidStageLabel(r.dest_status, r.is_air_transfer)}
+                  <span
+                    className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+                    title="這一趟貨走到哪了（不是來源單的狀態）"
+                  >
+                    這趟：{aidStageLabel(r.dest_status, r.is_air_transfer)}
                   </span>
                   {r.board_id != null && (
                     <span className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-800 dark:bg-blue-950 dark:text-blue-300">

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -11,6 +11,7 @@ import { printViaIframe } from "@/lib/printIframe";
 import { withBasePath } from "@/lib/basePath";
 import { useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 import { shortOrderNo } from "@/lib/orderTitle";
+import { translateRpcError } from "@/lib/rpcError";
 import {
   TRANSFER_LINK_SELECT, type TransferLink,
   activeQty, aidRouteLabel, aidStageLabel, isAidInFlight, linkItems,
@@ -68,7 +69,7 @@ type PendingOrder = {
   }[];
 };
 
-/** 「我提供出去的」一列 = 一趟轉移（customer_order_transfer_links 一列） */
+/** 「我提供出去的／我收到的」一列 = 一趟轉移（customer_order_transfer_links 一列） */
 type ProvidedRow = {
   linkId: number;
   transferred_at: string;
@@ -77,6 +78,7 @@ type ProvidedRow = {
   board_id: number | null;
   reason: string | null;
   source_store: string;
+  source_store_id: number | null;
   source_order_no: string;
   dest_store: string;
   dest_store_id: number | null;
@@ -85,6 +87,9 @@ type ProvidedRow = {
   dest_status: string;
   qty: number;
   labels: string[];
+  /** 這張轉入單身上總共有幾趟轉移。>1 = 舊的併入單（多店混一張），
+   *  取消整張會把別家店的貨一起取消掉 → 不出取消鈕 */
+  link_count: number;
 };
 
 type Reply = {
@@ -141,7 +146,7 @@ const TYPE_COLOR: Record<PostType, string> = {
 export default function MutualAidPage() {
   const [posts, setPosts] = useState<Post[] | null>(null);
   const [stores, setStores] = useState<Store[]>([]);
-  const [view, setView] = useState<"active" | "history" | "provided">("active");
+  const [view, setView] = useState<"active" | "history" | "provided" | "received">("active");
   const [filter, setFilter] = useState<"all" | "request" | "offer">("all");
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
@@ -283,7 +288,7 @@ export default function MutualAidPage() {
       </header>
 
       <div className="flex gap-1 border-b border-zinc-200 dark:border-zinc-800">
-        {(["active", "history", "provided"] as const).map((v) => (
+        {(["active", "history", "provided", "received"] as const).map((v) => (
           <SpinButton
             key={v}
             type="button"
@@ -294,13 +299,13 @@ export default function MutualAidPage() {
                 : "px-4 py-2 text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
             }
           >
-            {v === "active" ? "進行中" : v === "history" ? "歷史" : "我提供出去的"}
+            {v === "active" ? "進行中" : v === "history" ? "歷史" : v === "provided" ? "我提供出去的" : "我收到的"}
           </SpinButton>
         ))}
       </div>
 
-      {view === "provided" ? (
-        <ProvidedList stores={stores} />
+      {view === "provided" || view === "received" ? (
+        <ProvidedList stores={stores} direction={view === "provided" ? "out" : "in"} />
       ) : (
       <>
       <div className="inline-flex w-fit overflow-hidden rounded-md border border-zinc-300 text-xs dark:border-zinc-700">
@@ -533,7 +538,10 @@ function AidClaimLog({ post }: { post: Post }) {
           const src = r.src, dest = r.dest;
           if (!src || !dest) return [];
           const mine = linkItems(r, dest.items ?? []);
-          const qty = activeQty(mine);
+          const active = mine.filter((it) => !["cancelled", "expired"].includes(it.status));
+          // 這趟被取消（品項全滅）也要顯示原本搬過什麼，不能只寫「共 0」——
+          // 狀態徽章會講「已取消」，內容退回全品項
+          const shown = active.length > 0 ? active : mine;
           return [{
             linkId: r.id,
             transferred_at: r.transferred_at,
@@ -541,21 +549,21 @@ function AidClaimLog({ post }: { post: Post }) {
             board_id: post.id,
             reason: r.reason,
             source_store: nameOf(src.store),
+            source_store_id: src.pickup_store_id,
             source_order_no: src.order_no,
             dest_store: nameOf(dest.store),
             dest_store_id: dest.pickup_store_id,
             dest_order_id: dest.id,
             dest_order_no: dest.order_no,
             dest_status: dest.status,
-            qty,
-            labels: mine
-              .filter((it) => !["cancelled", "expired"].includes(it.status))
-              .map((it) => {
-                const sku = Array.isArray(it.sku) ? it.sku[0] : it.sku;
-                return sku
-                  ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} ×${Number(it.qty)}`
-                  : `品項 ×${Number(it.qty)}`;
-              }),
+            qty: activeQty(mine),
+            labels: shown.map((it) => {
+              const sku = Array.isArray(it.sku) ? it.sku[0] : it.sku;
+              return sku
+                ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} ×${Number(it.qty)}`
+                : `品項 ×${Number(it.qty)}`;
+            }),
+            link_count: 1,
           }];
         });
         setRows(list);
@@ -658,11 +666,13 @@ function AidClaimLog({ post }: { post: Post }) {
 // 母體＝跨店的轉出（同店轉單只是換客人，貨沒離開本店，不算互助）。
 // 分店帳號鎖自己店；總倉／未綁店看全站。
 // ============================================================
-function ProvidedList({ stores }: { stores: Store[] }) {
+function ProvidedList({ stores, direction }: { stores: Store[]; direction: "out" | "in" }) {
   const myStoreId = useUserBranchStoreId(stores);
   const [rows, setRows] = useState<ProvidedRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showDone, setShowDone] = useState(false);
+  const [busyLink, setBusyLink] = useState<number | null>(null);
+  const [reloadTick, setReloadTick] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -702,16 +712,30 @@ function ProvidedList({ stores }: { stores: Store[] }) {
           } | null;
         };
         const nameOf = (s: StoreRef) => (Array.isArray(s) ? s[0]?.name : s?.name) ?? "—";
-        const list = ((data ?? []) as unknown as Raw[]).flatMap((r): ProvidedRow[] => {
+        const raws = (data ?? []) as unknown as Raw[];
+        // 同一張轉入單有幾趟：舊的併入單（多店混一張）取消整張會殃及別家店的貨，
+        // 要在列上把取消鈕關掉。要在「店別過濾之前」算 —— 別家店那幾趟不在
+        // 過濾後的清單裡，但它們的貨還是掛在同一張單上。
+        const linkCountByDest = new Map<number, number>();
+        for (const r of raws) {
+          if (r.dest) linkCountByDest.set(r.dest.id, (linkCountByDest.get(r.dest.id) ?? 0) + 1);
+        }
+        const list = raws.flatMap((r): ProvidedRow[] => {
           const src = r.src, dest = r.dest;
           if (!src || !dest) return [];
           // 同店轉單貨沒離開本店
           if (src.pickup_store_id === dest.pickup_store_id) return [];
-          // 分店帳號只看自己轉出去的；HQ 看全站
-          if (myStoreId != null && src.pickup_store_id !== myStoreId) return [];
+          // 分店帳號：out 看自己轉出去的、in 看轉進自己店的；HQ 看全站
+          if (myStoreId != null) {
+            const mineStore = direction === "out" ? src.pickup_store_id : dest.pickup_store_id;
+            if (mineStore !== myStoreId) return [];
+          }
           const mine = linkItems(r, dest.items ?? []);
+          const active = mine.filter((it) => !["cancelled", "expired"].includes(it.status));
           const qty = activeQty(mine);
-          if (qty <= 0) return [];
+          // 這趟被取消（品項全滅）也要留在列表上 —— 不然取消完那一列就人間蒸發，
+          // 兩邊都以為沒發生過；顯示退回全品項並讓狀態徽章講「已取消」
+          const shown = active.length > 0 ? active : mine;
           return [{
             linkId: r.id,
             transferred_at: r.transferred_at,
@@ -719,6 +743,7 @@ function ProvidedList({ stores }: { stores: Store[] }) {
             board_id: Number(/互助板[^#]*#(\d+)/.exec(r.reason ?? "")?.[1]) || null,
             reason: r.reason,
             source_store: nameOf(src.store),
+            source_store_id: src.pickup_store_id,
             source_order_no: src.order_no,
             dest_store: nameOf(dest.store),
             dest_store_id: dest.pickup_store_id,
@@ -726,14 +751,13 @@ function ProvidedList({ stores }: { stores: Store[] }) {
             dest_order_no: dest.order_no,
             dest_status: dest.status,
             qty,
-            labels: mine
-              .filter((it) => !["cancelled", "expired"].includes(it.status))
-              .map((it) => {
-                const sku = Array.isArray(it.sku) ? it.sku[0] : it.sku;
-                return sku
-                  ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} ×${Number(it.qty)}`
-                  : `品項 ×${Number(it.qty)}`;
-              }),
+            labels: shown.map((it) => {
+              const sku = Array.isArray(it.sku) ? it.sku[0] : it.sku;
+              return sku
+                ? `${sku.product_name}${sku.variant_name ? ` / ${sku.variant_name}` : ""} ×${Number(it.qty)}`
+                : `品項 ×${Number(it.qty)}`;
+            }),
+            link_count: linkCountByDest.get(dest.id) ?? 1,
           }];
         });
         setRows(list);
@@ -742,7 +766,33 @@ function ProvidedList({ stores }: { stores: Store[] }) {
       }
     })();
     return () => { cancelled = true; };
-  }, [myStoreId]);
+  }, [myStoreId, direction, reloadTick]);
+
+  // 取消這一趟：未到貨（pending/confirmed/shipping）走 rpc_cancel_aid_order，
+  // 已到貨（ready）由收貨方走 rpc_return_aid_order 退回原店。
+  // 兩支 RPC 取消後都會把數量還給互助板貼文（20260824080000）。
+  async function cancelLeg(r: ProvidedRow, kind: "cancel" | "return") {
+    if (busyLink != null) return;
+    const what = kind === "cancel"
+      ? `取消這趟提供（${r.labels.join("、") || `共 ${r.qty}`}）？\n貨會回到來源單、互助板貼文的數量會還回去。`
+      : `把這批貨退回 ${r.source_store}？\n會建一張反向調撥、來源單還原、貼文數量還回去。`;
+    if (!confirm(what)) return;
+    setBusyLink(r.linkId);
+    try {
+      const sb = getSupabase();
+      const { data: { user } } = await sb.auth.getUser();
+      if (!user?.id) { alert("尚未登入"); return; }
+      const { error: e } = await sb.rpc(
+        kind === "cancel" ? "rpc_cancel_aid_order" : "rpc_return_aid_order",
+        { p_order_id: r.dest_order_id, p_reason: `互助板${direction === "out" ? "提供方" : "收貨方"}${kind === "cancel" ? "取消" : "退回"}`, p_operator: user.id },
+      );
+      if (e) { alert(translateRpcError(e)); return; }
+      setReloadTick((n) => n + 1);
+      window.dispatchEvent(new Event("aid-badge-refresh"));
+    } finally {
+      setBusyLink(null);
+    }
+  }
 
   if (error) {
     return (
@@ -772,23 +822,29 @@ function ProvidedList({ stores }: { stores: Store[] }) {
                   : "bg-white text-zinc-600 hover:bg-zinc-50 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
               }`}
             >
-              {/* ⚠ 不要叫「已完成」：這一格說的是**這趟貨**對方收到了，
+              {/* ⚠ 不要叫「已完成」：這一格說的是**這趟貨**收到了，
                   不是來源單完成了。來源單（OV-/AB-/RR- 現貨池）通常還掛著
                   一堆沒動過的品項，2026-08-24 就被誤讀成「OV-2-0001 變已完成」。 */}
-              {v ? `對方已收 (${done.length})` : `還在路上 (${inFlight.length})`}
+              {v
+                ? `${direction === "out" ? "對方已收" : "已收貨"} (${done.length})`
+                : `還在路上 (${inFlight.length})`}
             </SpinButton>
           ))}
         </div>
         <span className="text-xs text-zinc-500">
           {myStoreId == null
-            ? "全站的店對店轉出（總倉視角）"
-            : "本店轉出去的貨。狀態說的是「這一趟」走到哪，不是來源單的狀態"}
+            ? `全站的店對店${direction === "out" ? "轉出" : "轉入"}（總倉視角）`
+            : direction === "out"
+              ? "本店轉出去的貨。狀態說的是「這一趟」走到哪，不是來源單的狀態"
+              : "別店轉給本店的貨。未到貨可「取消這批」；已到貨可「退回原店」"}
         </span>
       </div>
 
       {shown.length === 0 ? (
         <div className="rounded-md border border-dashed border-zinc-300 p-8 text-center text-sm text-zinc-500 dark:border-zinc-700">
-          {showDone ? "沒有對方已收的轉出紀錄" : "目前沒有在路上的轉出"}
+          {showDone
+            ? `沒有${direction === "out" ? "對方已收的轉出" : "已收貨的轉入"}紀錄`
+            : `目前沒有在路上的${direction === "out" ? "轉出" : "轉入"}`}
         </div>
       ) : (
         <ul className="space-y-2">
@@ -800,7 +856,7 @@ function ProvidedList({ stores }: { stores: Store[] }) {
               <div className="min-w-0 flex-1">
                 <div className="mb-1 flex flex-wrap items-center gap-2">
                   <span className="rounded bg-pink-100 px-1.5 py-0.5 text-[10px] font-semibold text-pink-800 dark:bg-pink-950 dark:text-pink-300">
-                    給 {r.dest_store}
+                    {direction === "out" ? `給 ${r.dest_store}` : `來自 ${r.source_store}`}
                   </span>
                   <span className="text-[10px] text-zinc-500">{aidRouteLabel(r.is_air_transfer)}</span>
                   <span
@@ -815,7 +871,9 @@ function ProvidedList({ stores }: { stores: Store[] }) {
                     </span>
                   )}
                   {myStoreId == null && (
-                    <span className="text-[10px] text-zinc-500">從 {r.source_store}</span>
+                    <span className="text-[10px] text-zinc-500">
+                      {direction === "out" ? `從 ${r.source_store}` : `到 ${r.dest_store}`}
+                    </span>
                   )}
                   <span className="ml-auto text-xs text-zinc-500">{fmtDt(r.transferred_at)}</span>
                 </div>
@@ -835,20 +893,74 @@ function ProvidedList({ stores }: { stores: Store[] }) {
                   )}
                 </div>
               </div>
-              {/* 隨貨單走 /transfers/print-aid（兩聯：司機聯 + 存查聯），
-                  帶 link 才只印這一趟的貨、來源店也才標得對 */}
-              <SpinButton
-                type="button"
-                onClick={() =>
-                  printViaIframe(
-                    withBasePath(`/transfers/print-aid?order_id=${r.dest_order_id}&link=${r.linkId}`),
+              <div className="flex shrink-0 flex-col items-stretch gap-1.5">
+                {/* 隨貨單走 /transfers/print-aid（兩聯：司機聯 + 存查聯），
+                    帶 link 才只印這一趟的貨、來源店也才標得對 */}
+                <SpinButton
+                  type="button"
+                  onClick={() =>
+                    printViaIframe(
+                      withBasePath(`/transfers/print-aid?order_id=${r.dest_order_id}&link=${r.linkId}`),
+                    )
+                  }
+                  title="列印這一趟的互助出貨單（兩聯：司機聯 + 存查聯）"
+                  className="rounded-md border border-zinc-300 px-2 py-1.5 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                >
+                  🖨️
+                </SpinButton>
+                {/* 取消規則：分界線是「貨到收貨店了沒」。
+                    未到（pending/confirmed/shipping）→ 兩邊都能取消（rpc_cancel_aid_order）；
+                    已到（ready）→ 只有收貨方能退回原店（rpc_return_aid_order，貨在他們架上）；
+                    completed/cancelled → 沒有動作。
+                    舊的併入單（link_count > 1）整張取消會殃及別家店的貨 → 導去訂單頁。 */}
+                {isAidInFlight(r.dest_status) && (
+                  r.link_count === 1 ? (
+                    <SpinButton
+                      type="button"
+                      disabled={busyLink != null}
+                      onClick={() => cancelLeg(r, "cancel")}
+                      className="rounded-md border border-red-300 px-2 py-1.5 text-xs text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950"
+                    >
+                      {busyLink === r.linkId ? "處理中…" : direction === "out" ? "取消提供" : "取消這批"}
+                    </SpinButton>
+                  ) : (
+                    <span
+                      className="rounded-md border border-dashed border-zinc-300 px-2 py-1.5 text-center text-[10px] text-zinc-400 dark:border-zinc-700"
+                      title="這張轉入單上還混有其他店的貨（舊資料），整張取消會把別人的一起取消掉；請到轉入單的訂單頁處理"
+                    >
+                      多趟併單
+                    </span>
                   )
-                }
-                title="列印這一趟的互助出貨單（兩聯：司機聯 + 存查聯）"
-                className="shrink-0 rounded-md border border-zinc-300 px-2 py-1.5 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-              >
-                🖨️
-              </SpinButton>
+                )}
+                {r.dest_status === "ready" && (
+                  direction === "in" ? (
+                    r.link_count === 1 ? (
+                      <SpinButton
+                        type="button"
+                        disabled={busyLink != null}
+                        onClick={() => cancelLeg(r, "return")}
+                        className="rounded-md border border-red-300 px-2 py-1.5 text-xs text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950"
+                      >
+                        {busyLink === r.linkId ? "處理中…" : "退回原店"}
+                      </SpinButton>
+                    ) : (
+                      <span
+                        className="rounded-md border border-dashed border-zinc-300 px-2 py-1.5 text-center text-[10px] text-zinc-400 dark:border-zinc-700"
+                        title="這張轉入單上還混有其他趟的貨（舊資料），請到轉入單的訂單頁處理"
+                      >
+                        多趟併單
+                      </span>
+                    )
+                  ) : (
+                    <span
+                      className="rounded-md border border-dashed border-zinc-300 px-2 py-1.5 text-center text-[10px] text-zinc-400 dark:border-zinc-700"
+                      title="貨已經在對方店裡，要由收貨店按「退回原店」"
+                    >
+                      需對方退回
+                    </span>
+                  )
+                )}
+              </div>
             </li>
           ))}
         </ul>

--- a/supabase/migrations/20260824060000_aid_transfer_own_order.sql
+++ b/supabase/migrations/20260824060000_aid_transfer_own_order.sql
@@ -472,13 +472,15 @@ COMMENT ON FUNCTION public.rpc_transfer_order_partial(
 -- ------------------------------------------------------------
 -- 4. rpc_claim_manual_spot：透傳 board id（簽名不變，直接 REPLACE）
 -- ------------------------------------------------------------
+-- ⚠ 參數預設值要跟線上一字不差，少寫會被擋：
+--   ERROR 42P13: cannot remove parameter defaults from existing function
 CREATE OR REPLACE FUNCTION public.rpc_claim_manual_spot(
   p_board_id bigint,
   p_to_store_id bigint,
   p_qty numeric,
   p_operator uuid,
-  p_reason text,
-  p_is_air_transfer boolean)
+  p_reason text DEFAULT NULL::text,
+  p_is_air_transfer boolean DEFAULT false)
 RETURNS jsonb
 LANGUAGE plpgsql
 SECURITY DEFINER

--- a/supabase/migrations/20260824070000_split_legacy_aid_appends.sql
+++ b/supabase/migrations/20260824070000_split_legacy_aid_appends.sql
@@ -1,0 +1,209 @@
+-- ============================================================
+-- 2026-08-24: 總倉收件匣一店一單 —— 舊的互助併入拆開，並修正繼承來的假狀態
+--
+-- 症狀一（店家回報）：「松山 → 古華、囍願土雞蛋這一筆為什麼沒有在總倉收件匣？」
+--   其實有，但它掛在**中和店**名下。那批貨被併進古華既有的
+--   __INTERNAL_RESTOCK__-TF0486，而那張單身上有 3 家店的 5 次轉入；
+--   v_hq_inbox_aid 顯示來源用的是 customer_orders.transferred_from_order_id，
+--   那一欄只有「建立這張單」的第一趟會寫（= 中和店 AB-45-0001）→ 整張單被
+--   算成「中和 → 古華」、5 個品項混成一列，松山端在收件匣裡找不到自己那批。
+--
+-- 症狀二（比較嚴重，是併單的連帶傷害）：**併進去的貨會繼承容器單的狀態**。
+--   平鎮 TF0497 在 8/24 13:39 因為另一趟空中轉到貨而變 ready；而雞腿排那趟
+--   （松山 → 平鎮、經總倉、12:27）被併進同一張單，於是也跟著顯示「可取貨」——
+--   但它連 transfers 都沒有一張，貨根本還沒離開松山。20260824060000 的回填
+--   把這個錯狀態原樣抄到拆出來的 TF0506 上（status=ready 但 ready_at 是空的，
+--   就是繼承來的痕跡）。取貨閘門放行 = 直接把 on_hand 扣成負的，要修。
+--
+-- 做法：
+--   1. 把還併在一起、且認得出屬於哪則互助貼文的轉入趟次拆成獨立單
+--      （搬列不是複製，品項 id 不變）。
+--   2. 每一張拆出來的單，狀態**依它自己那一趟**重算，不抄容器單：
+--        有轉移單且已收貨 → ready；有轉移單未收 → shipping；
+--        沒有轉移單但是空中轉（舊資料，自動出貨上線前） → shipping；
+--        其餘（經總倉，等總倉收） → pending。
+--      並把對應的那張 transfers 改指到新單，收貨時才推得動正確的單。
+--   3. 20260824060000 已經拆出來的單一併重算（TF0506 就是靠這步修回 pending）。
+--
+-- 認貼文的三條路（依序取第一個認得出的）：
+--   (a) reason 帶貼文編號 —— 20260824060000 之後的新資料。
+--   (b) 手動現貨：rpc_claim_manual_spot 會在載體單（AB-xx-000n）品項的 notes
+--       蓋「[互助板認領 #N]」，而那張載體單只為那一次認領而生 → 從它轉出去的
+--       那一趟就是那次認領。線上 #119/#206/#207/#208 靠這條。
+--   (c) 有來源訂單的釋出貼文：來源單 + SKU 對得起來，且貼文早於這趟轉移。
+--       線上 #227（松山 OV-2-0001 的囍願土雞蛋）靠這條。
+--   認不出來的**不動** —— 拆了卻沒有 aid_board_id 可蓋，會撞
+--   customer_orders_trio_kind_active_uniq（那個唯一索引只放行蓋過章的單）。
+--
+-- ⚠ transfers 對到哪一趟：t.shipped_at 落在 [l.transferred_at, +1 秒) 之內。
+--   不能用等號 —— 連結表回填時 transferred_at 被截到秒，而 transfers 留著毫秒
+--   （線上 link 516 就是 09:13:06 對 09:13:06.810991，等號比不出來）。
+--
+-- 只搬還在店裡的品項（pending/reserved/ready）；已取貨 / 已取消的動了就是改到歷史。
+-- 容器單至少留一件，不生空殼單。
+--
+-- Rollback：拆出來的單都帶 [回填拆單] notes 且 aid_board_id 非空，
+--   把品項搬回 notes 裡寫的原單、transfers 改回原單、刪掉新單、
+--   把 link 的 dest_order_id 改回去即可。
+-- ============================================================
+
+DO $backfill$
+DECLARE
+  r              RECORD;
+  v_seq          INT;
+  v_campaign_no  TEXT;
+  v_new_order_id BIGINT;
+  v_new_order_no TEXT;
+  v_split        INT := 0;
+  v_fixed        INT := 0;
+BEGIN
+  -- ------------------------------------------------------------
+  -- 1. 拆併入
+  -- ------------------------------------------------------------
+  FOR r IN
+    SELECT l.id AS link_id, l.source_order_id, l.dest_order_id, l.dest_item_ids,
+           l.is_air_transfer, l.transferred_at,
+           d.tenant_id, d.campaign_id, d.channel_id, d.member_id,
+           d.pickup_store_id, d.nickname_snapshot,
+           s.order_no AS src_no,
+           COALESCE(
+             (regexp_match(l.reason, '互助板[^#]*#([0-9]+)'))[1]::BIGINT,
+             (SELECT b.id FROM mutual_aid_board b
+                JOIN customer_order_items ci
+                  ON ci.notes LIKE '%互助板認領 #' || b.id || '%'
+               WHERE ci.order_id = l.source_order_id
+               ORDER BY b.id DESC LIMIT 1),
+             (SELECT b2.id FROM mutual_aid_board b2
+               WHERE b2.source_customer_order_id = l.source_order_id
+                 AND b2.sku_id = (SELECT i2.sku_id FROM customer_order_items i2
+                                   WHERE i2.id = l.dest_item_ids[1])
+                 AND b2.created_at <= l.transferred_at
+               ORDER BY b2.created_at DESC LIMIT 1)
+           ) AS board_id
+      FROM customer_order_transfer_links l
+      JOIN customer_orders d ON d.id = l.dest_order_id
+      JOIN customer_orders s ON s.id = l.source_order_id
+     WHERE l.appended
+       AND s.pickup_store_id IS DISTINCT FROM d.pickup_store_id
+     ORDER BY l.transferred_at
+  LOOP
+    -- 認不出屬於哪則貼文的不動（沒有 aid_board_id 可蓋 → 會撞唯一索引）
+    IF r.board_id IS NULL THEN CONTINUE; END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM customer_order_items i
+       WHERE i.id = ANY (r.dest_item_ids)
+         AND i.order_id = r.dest_order_id
+         AND i.status IN ('pending','reserved','ready')
+    ) THEN CONTINUE; END IF;
+
+    -- 容器單至少留一件，不生空殼單
+    IF NOT EXISTS (
+      SELECT 1 FROM customer_order_items i
+       WHERE i.order_id = r.dest_order_id
+         AND NOT (i.id = ANY (r.dest_item_ids))
+    ) THEN CONTINUE; END IF;
+
+    SELECT campaign_no INTO v_campaign_no
+      FROM group_buy_campaigns WHERE id = r.campaign_id;
+
+    -- TF 序號比照 rpc_transfer_order_partial：MAX+1，不是 COUNT+1
+    PERFORM pg_advisory_xact_lock(hashtext('order_tf_seq:' || r.campaign_id::text));
+    SELECT COALESCE(MAX(substring(order_no FROM '-TF([0-9]+)$'))::INT, 0) + 1
+      INTO v_seq
+      FROM customer_orders
+     WHERE tenant_id = r.tenant_id AND campaign_id = r.campaign_id
+       AND order_no ~ '-TF[0-9]+$';
+    v_new_order_no := v_campaign_no || '-TF' ||
+                      lpad(v_seq::text, GREATEST(length(v_seq::text), 4), '0');
+
+    -- 狀態先建成 pending，第 2 段統一依「自己那一趟」重算（含既有的拆出單）
+    INSERT INTO customer_orders (
+      tenant_id, order_no, campaign_id, channel_id, member_id, nickname_snapshot,
+      pickup_store_id, status, notes, transferred_from_order_id, is_air_transfer,
+      aid_board_id, created_at, updated_at
+    ) VALUES (
+      r.tenant_id, v_new_order_no, r.campaign_id, r.channel_id, r.member_id,
+      r.nickname_snapshot, r.pickup_store_id, 'pending',
+      '[回填拆單] 原本併在訂單 #' || r.dest_order_id || '，依來源單 #' ||
+        r.source_order_id || ' (' || r.src_no || ') 拆成獨立轉入單（互助板 #' ||
+        r.board_id || '）',
+      r.source_order_id, COALESCE(r.is_air_transfer, FALSE),
+      r.board_id, r.transferred_at, NOW()
+    ) RETURNING id INTO v_new_order_id;
+
+    UPDATE customer_order_items
+       SET order_id = v_new_order_id, updated_at = NOW()
+     WHERE id = ANY (r.dest_item_ids) AND order_id = r.dest_order_id;
+
+    -- 這一趟自己的轉移單也要跟著改指過去，否則收貨時推的是容器單
+    UPDATE transfers t
+       SET customer_order_id = v_new_order_id
+     WHERE t.customer_order_id = r.dest_order_id
+       AND t.status <> 'cancelled'
+       AND t.shipped_at >= r.transferred_at
+       AND t.shipped_at <  r.transferred_at + INTERVAL '1 second';
+
+    UPDATE customer_order_transfer_links
+       SET dest_order_id = v_new_order_id, appended = FALSE, aid_board_id = r.board_id
+     WHERE id = r.link_id;
+
+    UPDATE customer_orders
+       SET notes = COALESCE(notes, '') ||
+                   E'\n[拆單] 來源單 #' || r.source_order_id || ' 那一趟的貨已拆到 ' ||
+                   v_new_order_no || '（' || to_char(NOW(), 'YYYY-MM-DD HH24:MI:SS') || '）',
+           updated_at = NOW()
+     WHERE id = r.dest_order_id;
+
+    v_split := v_split + 1;
+  END LOOP;
+
+  -- ------------------------------------------------------------
+  -- 2. 拆出來的單，狀態依「自己那一趟」重算
+  --    20260824060000 的回填直接抄容器單的狀態，於是雞腿排（經總倉、
+  --    連轉移單都沒有）繼承到平鎮容器單的 ready，變成「還沒出貨卻可取貨」。
+  -- ------------------------------------------------------------
+  FOR r IN
+    SELECT co.id, co.status AS cur_status,
+           l.is_air_transfer, l.transferred_at,
+           t.id AS transfer_id, t.received_at
+      FROM customer_orders co
+      JOIN customer_order_transfer_links l ON l.dest_order_id = co.id
+      LEFT JOIN transfers t
+        ON t.customer_order_id = co.id
+       AND t.status <> 'cancelled'
+       AND t.shipped_at >= l.transferred_at
+       AND t.shipped_at <  l.transferred_at + INTERVAL '1 second'
+     WHERE co.aid_board_id IS NOT NULL
+       AND co.notes LIKE '[回填拆單]%'
+       -- 已取貨 / 已取消的不要回頭改
+       AND co.status IN ('pending','confirmed','shipping','ready')
+  LOOP
+    DECLARE
+      v_want TEXT := CASE
+        WHEN r.transfer_id IS NOT NULL AND r.received_at IS NOT NULL THEN 'ready'
+        WHEN r.transfer_id IS NOT NULL THEN 'shipping'
+        -- 空中轉＝轉單當下貨就離開轉出店（20260814030000）；舊資料可能沒建轉移單
+        WHEN r.is_air_transfer THEN 'shipping'
+        ELSE 'pending'   -- 經總倉：等總倉收貨
+      END;
+    BEGIN
+      IF v_want IS DISTINCT FROM r.cur_status THEN
+        UPDATE customer_orders
+           SET status   = v_want,
+               -- ready_at 只有真的到貨才留；退回 pending 要一起清掉，
+               -- 否則畫面會顯示一個根本沒發生過的到貨時間
+               ready_at = CASE WHEN v_want = 'ready' THEN COALESCE(ready_at, r.received_at) ELSE NULL END,
+               notes    = COALESCE(notes, '') ||
+                          E'\n[狀態修正] ' || r.cur_status || ' → ' || v_want ||
+                          '（原本抄的是容器單狀態，改成依這一趟自己的進度）',
+               updated_at = NOW()
+         WHERE id = r.id;
+        v_fixed := v_fixed + 1;
+      END IF;
+    END;
+  END LOOP;
+
+  RAISE NOTICE '互助併入拆單：拆 % 筆、狀態修正 % 筆', v_split, v_fixed;
+END;
+$backfill$;

--- a/supabase/migrations/20260824080000_cancel_restores_aid_board.sql
+++ b/supabase/migrations/20260824080000_cancel_restores_aid_board.sql
@@ -1,0 +1,521 @@
+-- ============================================================
+-- 2026-08-24: 取消／退回互助轉單時，把數量還給互助板貼文
+--
+-- 症狀：松山取消了提供給 #249 的那一趟，貼文的「尚需」停在 1 沒有回到 2。
+--   rpc_cancel_aid_order / rpc_return_aid_order 從頭到尾不碰 mutual_aid_board
+--  （20260615000050 起刻意如此），CLAUDE.md 也記載「認領量要人工加回去」。
+--   現在 links / orders 都有 aid_board_id（20260824060000），可以自動還了。
+--
+-- 基底：兩支函式都以**線上 prosrc** 為基底程式化插入（不是照 repo 檔重打），
+--   已 diff 確認只有三處改動：declare 三個變數、還量迴圈、回傳多一個欄位。
+--   還量迴圈逐 link 算各自的量（舊的併入單一張可能有多趟），並在品項被標
+--   cancelled 之前執行；沒有 link 蓋章但單頭有的舊資料走備援路徑。
+--
+-- Rollback：兩支函式重跑上一版（線上 prosrc 存於 session scratchpad，或依
+--   20260818000030 / 20260615000050 重建）；DROP FUNCTION _restore_aid_board_qty；
+--   資料補回那段自行反向 UPDATE。
+-- ============================================================
+
+-- 內部 helper：把一趟互助的量還給貼文。
+-- 上限夾在 qty_available（重複呼叫或資料異常也不會加超過原釋出量）；
+-- exhausted 且未過期 → 回 active（重新開放），已過期 → 標 expired。
+CREATE OR REPLACE FUNCTION public._restore_aid_board_qty(
+  p_board_id BIGINT, p_qty NUMERIC, p_operator UUID)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE mutual_aid_board b
+     SET qty_remaining = LEAST(b.qty_available, b.qty_remaining + p_qty),
+         status = CASE
+                    WHEN b.status = 'exhausted' AND b.expires_at > NOW() THEN 'active'
+                    WHEN b.status = 'exhausted' THEN 'expired'
+                    ELSE b.status
+                  END,
+         updated_by = p_operator,
+         updated_at = NOW()
+   WHERE b.id = p_board_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public._restore_aid_board_qty(BIGINT, NUMERIC, UUID)
+  FROM PUBLIC, anon, authenticated;
+
+COMMENT ON FUNCTION public._restore_aid_board_qty IS
+  '取消/退回互助轉單時把該趟數量還給 mutual_aid_board 貼文（20260824080000）。'
+  '只由 rpc_cancel_aid_order / rpc_return_aid_order 內部呼叫。';
+
+
+CREATE OR REPLACE FUNCTION public.rpc_cancel_aid_order(p_order_id bigint, p_reason text, p_operator uuid)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_terminal_id      BIGINT;
+  v_xfer             transfers%ROWTYPE;
+  v_ti               RECORD;
+  v_cancelled_ids    BIGINT[] := ARRAY[]::BIGINT[];
+  v_reason_note      TEXT;
+  v_refund_ledger_id BIGINT;
+  v_refunded_amount  NUMERIC := 0;
+  v_src_id           BIGINT;
+  v_src_pickable     BOOLEAN := FALSE;
+  v_is_aid           BOOLEAN := FALSE;
+  v_restored         INTEGER := 0;
+  v_ab               RECORD;
+  v_ab_qty           NUMERIC := 0;
+  v_aid_restored     INTEGER := 0;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('aid_order:' || p_order_id));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  -- 現貨直配（SP-）單一建立就是 'ready'（貨就在店裡、等客人來拿），
+  -- 但它**還沒扣庫存**（配單＝待取，rpc_record_pickup 才扣）→ 取消是安全的，
+  -- 只是把可分配量放回去。原本的守衛把它擋在外面，等於做得出單卻取消不掉
+  -- （2026-08-16 回報）。其餘單型維持原規則不動。
+  IF v_order.status NOT IN ('pending', 'confirmed', 'shipping')
+     AND NOT (v_order.status = 'ready' AND v_order.order_no LIKE 'SP-%') THEN
+    RAISE EXCEPTION 'order % is %, only pending/confirmed/shipping can be cancelled', p_order_id, v_order.status;
+  END IF;
+
+  -- ── 互助板數量歸還 ──（20260824080000）
+  -- 這張單是互助板帶來的 → 取消／退回時把量還給貼文，貼文若還沒過期就從
+  -- exhausted 轉回 active，釋出店才放得出去。先前這裡完全不碰互助板，
+  -- 取消完貼文永遠卡在「已認領」（2026-08-24 松山取消 #249 那趟就是）。
+  -- 一張單可能有多趟（舊的併入資料），逐 link 還各自的量；
+  -- 要在品項被標 cancelled **之前**算。
+  FOR v_ab IN
+    SELECT l.aid_board_id AS board_id,
+           (SELECT COALESCE(SUM(i.qty), 0) FROM customer_order_items i
+             WHERE i.id = ANY (l.dest_item_ids)
+               AND i.order_id = p_order_id
+               AND i.status IN ('pending','reserved','ready')) AS qty
+      FROM customer_order_transfer_links l
+     WHERE l.dest_order_id = p_order_id
+       AND l.aid_board_id IS NOT NULL
+  LOOP
+    IF v_ab.qty > 0 THEN
+      PERFORM public._restore_aid_board_qty(v_ab.board_id, v_ab.qty, p_operator);
+      v_aid_restored := v_aid_restored + 1;
+    END IF;
+  END LOOP;
+  -- 舊資料：links 沒蓋章但單頭有（新單兩邊都有，這條只是備援）
+  IF v_aid_restored = 0 AND v_order.aid_board_id IS NOT NULL THEN
+    SELECT COALESCE(SUM(i.qty), 0) INTO v_ab_qty
+      FROM customer_order_items i
+     WHERE i.order_id = p_order_id
+       AND i.status IN ('pending','reserved','ready');
+    IF v_ab_qty > 0 THEN
+      PERFORM public._restore_aid_board_qty(v_order.aid_board_id, v_ab_qty, p_operator);
+      v_aid_restored := 1;
+    END IF;
+  END IF;
+
+  v_reason_note := '[cancelled by source: ' || COALESCE(p_reason, '') || ']';
+
+  -- 場景 B：已派貨，要回收 transfer chain
+  IF v_order.status = 'shipping' THEN
+    SELECT id INTO v_terminal_id
+      FROM transfers
+     WHERE customer_order_id = p_order_id
+       AND tenant_id = v_order.tenant_id
+     LIMIT 1;
+
+    -- 沒有掛在此單上的 transfer：
+    --   互助單 → 真的資料不一致，擋下來；
+    --   一般（波次出貨）訂單 → 本來就沒有 per-order transfer，直接往下取消。
+    IF v_terminal_id IS NULL THEN
+      v_is_aid := v_order.transferred_from_order_id IS NOT NULL
+                  OR EXISTS (
+                       SELECT 1 FROM customer_order_items coi
+                        WHERE coi.order_id = p_order_id
+                          AND coi.source = 'aid_transfer'
+                          AND coi.status <> 'cancelled'
+                     );
+      IF v_is_aid THEN
+        RAISE EXCEPTION 'order % is shipping but has no terminal transfer', p_order_id;
+      END IF;
+    END IF;
+
+    IF v_terminal_id IS NOT NULL THEN
+      FOR v_xfer IN
+        WITH RECURSIVE chain_back AS (
+          SELECT * FROM transfers WHERE id = v_terminal_id
+          UNION ALL
+          SELECT t.* FROM transfers t
+            JOIN chain_back c ON c.id = ANY(
+              SELECT id FROM transfers WHERE next_transfer_id = c.id
+            )
+        ),
+        head AS (
+          SELECT id FROM chain_back
+           WHERE id NOT IN (SELECT next_transfer_id FROM transfers WHERE next_transfer_id IS NOT NULL)
+           LIMIT 1
+        ),
+        chain_forward AS (
+          SELECT * FROM transfers WHERE id = (SELECT id FROM head)
+          UNION ALL
+          SELECT t.* FROM transfers t
+            JOIN chain_forward c ON t.id = c.next_transfer_id
+        )
+        SELECT * FROM chain_forward ORDER BY id
+      LOOP
+        IF v_xfer.status = 'received' THEN
+          RAISE EXCEPTION 'transfer % already received, cannot cancel chain', v_xfer.id;
+        END IF;
+
+        IF v_xfer.status = 'shipped' THEN
+          FOR v_ti IN
+            SELECT id, sku_id, qty_shipped FROM transfer_items
+             WHERE transfer_id = v_xfer.id AND qty_shipped > 0
+          LOOP
+            PERFORM rpc_inbound(
+              p_tenant_id       => v_xfer.tenant_id,
+              p_location_id     => v_xfer.source_location,
+              p_sku_id          => v_ti.sku_id,
+              p_quantity        => v_ti.qty_shipped,
+              p_unit_cost       => 0,
+              p_movement_type   => 'transfer_cancel',
+              p_source_doc_type => 'transfer',
+              p_source_doc_id   => v_xfer.id,
+              p_operator        => p_operator
+            );
+          END LOOP;
+        END IF;
+
+        UPDATE transfers
+           SET status = 'cancelled',
+               notes = CASE
+                         WHEN notes IS NULL OR notes = '' THEN v_reason_note
+                         ELSE notes || E'\n' || v_reason_note
+                       END,
+               updated_by = p_operator
+         WHERE id = v_xfer.id;
+        v_cancelled_ids := v_cancelled_ids || v_xfer.id;
+      END LOOP;
+    END IF;
+  END IF;
+
+  -- 若有用儲值金結帳，自動 refund 回會員餘額
+  IF v_order.wallet_paid_amount > 0 AND v_order.member_id IS NOT NULL THEN
+    v_refund_ledger_id := rpc_wallet_refund(
+      v_order.tenant_id,
+      v_order.member_id,
+      v_order.wallet_paid_amount,
+      'customer_order',
+      p_order_id,
+      'order_cancelled: ' || COALESCE(p_reason, '(no reason)'),
+      p_operator
+    );
+    v_refunded_amount := v_order.wallet_paid_amount;
+    -- wallet_paid_amount 保留歷史值，不清零
+  END IF;
+
+  -- 標記訂單 cancelled
+  -- 現貨直配單取消 → 把它開的 DN 減抵單一併作廢。
+  -- 留著不會讓庫存算錯（自由量不看 DN），但 is_order_item_pickup_ready 的
+  -- Path D 是以 (tenant, campaign, store, sku) 整組查有效減抵，而現貨直配全部
+  -- 掛在共用 sentinel 團底下 —— 一張孤兒 DN 會讓**同團同店同 SKU 的其他單**
+  -- （RR- / OV- 容器單也在這個團）憑空通過到貨閘門。
+  IF v_order.order_no LIKE 'SP-%' THEN
+    UPDATE inventory_deduction_notes n
+       SET cancelled_at = NOW(), cancelled_by = p_operator
+     WHERE n.cancelled_at IS NULL
+       AND EXISTS (SELECT 1 FROM inventory_deduction_note_items li
+                    WHERE li.note_id = n.id AND li.order_id = p_order_id);
+  END IF;
+
+  UPDATE customer_orders
+     SET status       = 'cancelled',
+         cancelled_at = NOW(),
+         updated_by   = p_operator,
+         updated_at   = NOW()
+   WHERE id = p_order_id;
+
+  -- ── 來源單品項回補 ──（2026-08-18）
+  -- 部分轉出（rpc_transfer_order_partial）把來源列扣掉了（等量→整列 cancelled、
+  -- 部分→qty 遞減），下面那段只還單頭，品項不會自己長回來 → 取消之後貨在來源單
+  -- 上憑空消失。必須排在單頭 UPDATE **之前**：helper 要靠 source.status 還是不是
+  -- 'transferred_out' 來分辨整單轉出（品項沒被動過，不能重複加）。
+  v_restored := public._restore_transfer_source_items(p_order_id, p_operator, NOW());
+
+  -- ── source order 退回 ──（2026-07-13）
+  -- 先解除轉出鎖定回到 confirmed；若原店的貨其實已到（波次已收 → is_order_pickup_ready），
+  -- 直接推到 ready 讓它立刻可取貨，避免波次早跑完、confirmed 再也不會被 mark_shipping 推進而永遠卡住。
+  v_src_id := v_order.transferred_from_order_id;
+  IF v_src_id IS NOT NULL THEN
+    UPDATE customer_orders
+       SET status                   = 'confirmed',
+           transferred_to_order_id  = NULL,
+           updated_by               = p_operator,
+           updated_at               = NOW()
+     WHERE id = v_src_id
+       AND status = 'transferred_out';
+
+    v_src_pickable := public.is_order_pickup_ready(v_src_id);
+    IF v_src_pickable THEN
+      UPDATE customer_orders
+         SET status     = 'ready',
+             ready_at   = COALESCE(ready_at, NOW()),
+             updated_by = p_operator,
+             updated_at = NOW()
+       WHERE id = v_src_id
+         AND status = 'confirmed';
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'order_id', p_order_id,
+    'cancelled_transfer_ids', to_jsonb(v_cancelled_ids),
+    'source_order_reverted', v_src_id IS NOT NULL,
+    'source_order_pickable', v_src_pickable,
+    'source_items_restored', v_restored,
+    'wallet_refunded',       v_refunded_amount,
+    'wallet_refund_ledger_id', v_refund_ledger_id,
+    'aid_board_restored',    v_aid_restored
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_return_aid_order(p_order_id bigint, p_reason text, p_operator uuid)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_src_order        customer_orders%ROWTYPE;
+  v_src_store_id     BIGINT;
+  v_src_location     BIGINT;
+  v_recv_xfer        transfers%ROWTYPE;
+  v_dest_location    BIGINT;
+  v_ret_id           BIGINT;
+  v_ret_no           TEXT;
+  v_ti               RECORD;
+  v_out_mov          BIGINT;
+  v_in_mov           BIGINT;
+  v_epoch            BIGINT;
+  v_reason_note      TEXT;
+  v_items            INTEGER := 0;
+  v_total_qty        NUMERIC := 0;
+  v_refund_ledger_id BIGINT;
+  v_refunded_amount  NUMERIC := 0;
+  v_ab               RECORD;
+  v_ab_qty           NUMERIC := 0;
+  v_aid_restored     INTEGER := 0;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('aid_order:' || p_order_id));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+
+  -- 必須是互助單
+  IF v_order.transferred_from_order_id IS NULL
+     OR NOT EXISTS (
+       SELECT 1 FROM customer_order_items
+        WHERE order_id = p_order_id AND source = 'aid_transfer'
+     ) THEN
+    RAISE EXCEPTION 'order % is not an aid order', p_order_id;
+  END IF;
+
+  -- 狀態閘
+  IF v_order.status IN ('pending','confirmed','shipping') THEN
+    RAISE EXCEPTION 'aid order % is % (not yet received) — use rpc_cancel_aid_order to cancel before receipt',
+      p_order_id, v_order.status;
+  ELSIF v_order.status = 'completed' THEN
+    RAISE EXCEPTION 'aid order % already completed (picked up) — goods no longer at store; handle customer return first. rpc_return_aid_order only supports received-not-picked (status=ready)',
+      p_order_id;
+  ELSIF v_order.status <> 'ready' THEN
+    RAISE EXCEPTION 'aid order % status=% cannot be returned (expected ready)', p_order_id, v_order.status;
+  END IF;
+
+  -- ── 互助板數量歸還 ──（20260824080000）
+  -- 這張單是互助板帶來的 → 取消／退回時把量還給貼文，貼文若還沒過期就從
+  -- exhausted 轉回 active，釋出店才放得出去。先前這裡完全不碰互助板，
+  -- 取消完貼文永遠卡在「已認領」（2026-08-24 松山取消 #249 那趟就是）。
+  -- 一張單可能有多趟（舊的併入資料），逐 link 還各自的量；
+  -- 要在品項被標 cancelled **之前**算。
+  FOR v_ab IN
+    SELECT l.aid_board_id AS board_id,
+           (SELECT COALESCE(SUM(i.qty), 0) FROM customer_order_items i
+             WHERE i.id = ANY (l.dest_item_ids)
+               AND i.order_id = p_order_id
+               AND i.status IN ('pending','reserved','ready')) AS qty
+      FROM customer_order_transfer_links l
+     WHERE l.dest_order_id = p_order_id
+       AND l.aid_board_id IS NOT NULL
+  LOOP
+    IF v_ab.qty > 0 THEN
+      PERFORM public._restore_aid_board_qty(v_ab.board_id, v_ab.qty, p_operator);
+      v_aid_restored := v_aid_restored + 1;
+    END IF;
+  END LOOP;
+  -- 舊資料：links 沒蓋章但單頭有（新單兩邊都有，這條只是備援）
+  IF v_aid_restored = 0 AND v_order.aid_board_id IS NOT NULL THEN
+    SELECT COALESCE(SUM(i.qty), 0) INTO v_ab_qty
+      FROM customer_order_items i
+     WHERE i.order_id = p_order_id
+       AND i.status IN ('pending','reserved','ready');
+    IF v_ab_qty > 0 THEN
+      PERFORM public._restore_aid_board_qty(v_order.aid_board_id, v_ab_qty, p_operator);
+      v_aid_restored := 1;
+    END IF;
+  END IF;
+
+  -- dest-facing 已收貨 transfer（air = 唯一 store_to_store；經總倉 = Leg-2 hq_to_store）
+  SELECT * INTO v_recv_xfer
+    FROM transfers
+   WHERE customer_order_id = p_order_id
+     AND tenant_id = v_order.tenant_id
+     AND status = 'received'
+   ORDER BY id DESC
+   LIMIT 1;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'no received transfer found for aid order %', p_order_id;
+  END IF;
+  v_dest_location := v_recv_xfer.dest_location;
+
+  -- 原 source 店 location（同 rpc_ship_aid_order 的推導）
+  SELECT * INTO v_src_order
+    FROM customer_orders WHERE id = v_order.transferred_from_order_id;
+  IF NOT FOUND OR v_src_order.pickup_store_id IS NULL THEN
+    RAISE EXCEPTION 'source order % has no pickup_store', v_order.transferred_from_order_id;
+  END IF;
+  v_src_store_id := v_src_order.pickup_store_id;
+  SELECT location_id INTO v_src_location FROM stores WHERE id = v_src_store_id;
+  IF v_src_location IS NULL THEN
+    RAISE EXCEPTION 'source store % has no location_id', v_src_store_id;
+  END IF;
+  IF v_src_location = v_dest_location THEN
+    RAISE EXCEPTION 'source and dest share location_id %, cannot return', v_src_location;
+  END IF;
+
+  v_epoch := EXTRACT(EPOCH FROM NOW())::BIGINT;
+  v_ret_no := 'AT-RET-O' || p_order_id || '-' || v_epoch;
+  v_reason_note := '[aid return: ' || COALESCE(p_reason, '') || ']';
+
+  -- 退貨 transfer：dest 店 → 原 source 店，一次反向（status=received 紙上即完成）
+  INSERT INTO transfers (
+    tenant_id, transfer_no, source_location, dest_location,
+    status, transfer_type, customer_order_id, next_transfer_id,
+    requested_by, shipped_by, shipped_at, received_by, received_at,
+    notes, created_by, updated_by
+  ) VALUES (
+    v_order.tenant_id, v_ret_no, v_dest_location, v_src_location,
+    'received', 'store_to_store', NULL, NULL,
+    p_operator, p_operator, NOW(), p_operator, NOW(),
+    v_reason_note, p_operator, p_operator
+  ) RETURNING id INTO v_ret_id;
+
+  -- 依實收量反向：dest outbound → source inbound
+  FOR v_ti IN
+    SELECT sku_id, COALESCE(qty_received, qty_shipped) AS qty
+      FROM transfer_items
+     WHERE transfer_id = v_recv_xfer.id
+       AND COALESCE(qty_received, qty_shipped) > 0
+  LOOP
+    v_out_mov := rpc_outbound(
+      p_tenant_id       => v_order.tenant_id,
+      p_location_id     => v_dest_location,
+      p_sku_id          => v_ti.sku_id,
+      p_quantity        => v_ti.qty,
+      p_movement_type   => 'transfer_out',
+      p_source_doc_type => 'transfer',
+      p_source_doc_id   => v_ret_id,
+      p_operator        => p_operator
+    );
+    v_in_mov := rpc_inbound(
+      p_tenant_id       => v_order.tenant_id,
+      p_location_id     => v_src_location,
+      p_sku_id          => v_ti.sku_id,
+      p_quantity        => v_ti.qty,
+      p_unit_cost       => 0,
+      p_movement_type   => 'transfer_in',
+      p_source_doc_type => 'transfer',
+      p_source_doc_id   => v_ret_id,
+      p_operator        => p_operator
+    );
+    INSERT INTO transfer_items (
+      transfer_id, sku_id, qty_requested, qty_shipped, qty_received,
+      out_movement_id, in_movement_id, created_by, updated_by
+    ) VALUES (
+      v_ret_id, v_ti.sku_id, v_ti.qty, v_ti.qty, v_ti.qty,
+      v_out_mov, v_in_mov, p_operator, p_operator
+    );
+    v_items := v_items + 1;
+    v_total_qty := v_total_qty + v_ti.qty;
+  END LOOP;
+
+  IF v_items = 0 THEN
+    RAISE EXCEPTION 'received transfer % has no items to return', v_recv_xfer.id;
+  END IF;
+
+  -- 串接 timeline（received aid leg 是終端、next 應為 NULL）
+  UPDATE transfers
+     SET next_transfer_id = v_ret_id, updated_by = p_operator
+   WHERE id = v_recv_xfer.id AND next_transfer_id IS NULL;
+
+  -- aid 單 → cancelled
+  UPDATE customer_orders
+     SET status       = 'cancelled',
+         cancelled_at = NOW(),
+         updated_by   = p_operator,
+         updated_at   = NOW()
+   WHERE id = p_order_id;
+
+  -- 來源單回 confirmed（mirror rpc_cancel_aid_order）
+  IF v_order.transferred_from_order_id IS NOT NULL THEN
+    UPDATE customer_orders
+       SET status                  = 'confirmed',
+           transferred_to_order_id = NULL,
+           updated_by              = p_operator,
+           updated_at              = NOW()
+     WHERE id = v_order.transferred_from_order_id
+       AND status = 'transferred_out';
+  END IF;
+
+  -- wallet 有付則 refund（mirror rpc_cancel_aid_order）
+  IF v_order.wallet_paid_amount > 0 AND v_order.member_id IS NOT NULL THEN
+    v_refund_ledger_id := rpc_wallet_refund(
+      v_order.tenant_id,
+      v_order.member_id,
+      v_order.wallet_paid_amount,
+      'customer_order',
+      p_order_id,
+      'aid_order_returned: ' || COALESCE(p_reason, '(no reason)'),
+      p_operator
+    );
+    v_refunded_amount := v_order.wallet_paid_amount;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'order_id',                p_order_id,
+    'return_transfer_id',      v_ret_id,
+    'reversed_items',          v_items,
+    'reversed_qty',            v_total_qty,
+    'source_order_reverted',   v_order.transferred_from_order_id IS NOT NULL,
+    'wallet_refunded',         v_refunded_amount,
+    'wallet_refund_ledger_id', v_refund_ledger_id,
+    'aid_board_restored',    v_aid_restored
+  );
+END;
+$function$;
+
+-- 一次性資料補回：松山提供給 #249 的那趟（TF0506）在本修正上線前被取消，
+-- 量沒還。守衛齊全，重跑不會重複加。
+UPDATE mutual_aid_board b
+   SET qty_remaining = LEAST(b.qty_available, b.qty_remaining + 1),
+       status = CASE WHEN b.status = 'exhausted' AND b.expires_at > NOW()
+                     THEN 'active' ELSE b.status END,
+       updated_at = NOW()
+ WHERE b.id = 249
+   AND b.qty_remaining = 1
+   AND EXISTS (SELECT 1 FROM customer_orders co
+                WHERE co.id = 83362 AND co.status = 'cancelled'
+                  AND co.aid_board_id = 249);


### PR DESCRIPTION
## 做了什麼

接在 #833（互助一趟一張單）後面的第二批。四支 migration **都已套上正式庫並驗證**，這支 PR 是把 repo 對齊線上。

### 一、取消／退回自動把數量還給貼文（`20260824080000`）
松山取消了提供給 #249 的那趟，貼文的「尚需」停在 1 沒回到 2 —— `rpc_cancel_aid_order` / `rpc_return_aid_order` 從頭到尾不碰 `mutual_aid_board`，取消完貼文永遠卡在「已認領」。

- 新 helper `_restore_aid_board_qty`：把一趟的量還給貼文，上限夾 `qty_available`，`exhausted` 未過期 → 回 `active`
- 兩支取消 RPC 以**線上 prosrc** 為基底插入還量迴圈：逐 link 還各自的量（舊併入單一張多趟），在品項被標 `cancelled` 之前算
- 一次性補回 #249 被取消的那 1 件（已生效，貼文回到尚需 2／原 2）

### 二、總倉收件匣一店一單（`20260824070000`）
「松山→古華的囍願土雞蛋為什麼沒在總倉收件匣」——有，但掛在中和店名下：那批貨併在古華的 TF0486（3 家店 5 次轉入），收件匣的來源只看 `transferred_from_order_id`（只有第一趟會寫）。

- 舊的併入拆成獨立單（三條認法：reason 編號／載體單 notes／來源單+SKU 反查），`transfers` 一併改指新單。線上拆了 4 筆（TF0507~0510），收件匣現在每列一店一單、來源店正確
- **併單會讓貨繼承容器單的狀態**：還沒出貨的雞腿排因容器單另一趟到貨而顯示「可取貨」（閘門會放行 → on_hand 扣負）。拆出來的單依「自己那一趟」重算狀態，TF0506 的假 ready 修回 pending

### 三、前端：取消入口＋「我收到的」分頁
- 「我提供出去的」每列掛動作鈕；新增「**我收到的**」分頁（同一套資料反向過濾）
- 取消規則的分界線是「貨到收貨店了沒」：未到 → 兩邊都能取消；已到 → 收貨方「退回原店」、提供方標「需對方退回」；舊的多趟併單不出鈕（整張取消會殃及別家店的貨），導去訂單頁
- 已取消的趟次保留在列表與提供紀錄上並顯示原品項，不再「共 0」或直接消失
- 分組改名「還在路上／對方已收」——先前叫「已完成」被誤讀成來源單 OV-2-0001 被結掉了

### 四、雜項
- `rpc_claim_manual_spot` 簽名補參數預設值（`CREATE OR REPLACE` 少寫會被 42P13 擋，套線上時踩到）
- CLAUDE.md「認領量不會自動還」那條已過時，改寫成新行為

## 上線危險

- 做了：改兩支取消 RPC（以線上 prosrc 為基底，diff 過只有三處預期改動）、一支 helper、兩批資料回填。
- 不做：非互助單的取消行為不變（沒蓋 `aid_board_id` 的單 → 還量迴圈是 no-op）；回填是搬列不是複製（品項 id 不變）。
- 回退：migration 檔頭附 rollback；前端 `git revert`。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- 四支 migration 已套正式庫並逐項驗證：兩支取消 RPC 線上 prosrc 含還量迴圈；#249 取消後回到尚需 2；TF0486 拆成 4 張一店一單；TF0506 假 ready 修回 pending；`transfers` 對 links 用 `[transferred_at, +1s)` 區間（回填截秒、transfers 留毫秒，等號比不到）。
- `check-sql-syntax.cjs`（parse + parsePlpgsql）全過；`apps/admin` `tsc --noEmit` 過、eslint 無新增錯誤（既有 7 個 `react-hooks/set-state-in-effect` 與本次無關）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDUgyM9AusgWnGxP7FDBcZ)_