### PR TITLE
互助頁：救回舊資料的互助來源（「來源未記錄」歸零）、總倉只給一個店對店分頁

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -1012,7 +1012,8 @@ function ProvidedList({ stores, direction }: {
                 </div>
               </div>
 
-              {/* 中：標籤靠右橫排 —— 路徑／狀態／來源，三種語意三個顏色 */}
+              {/* 中：標籤靠右橫排 —— 種類（空中轉／經總倉）→ 來源 → 狀態，
+                  三種語意三個顏色。順序是老闆 2026-08-25 指定的。 */}
               <div className="flex flex-wrap items-center gap-1.5 sm:w-[15rem] sm:shrink-0 sm:justify-end">
                 {r.same_store ? (
                   <Chip tone="violet" title="商品未離開本店，只是把訂單改掛給另一位客人">
@@ -1024,6 +1025,7 @@ function ProvidedList({ stores, direction }: {
                     {aidRouteLabel(r.is_air_transfer)}
                   </Chip>
                 )}
+                {originChip(r.origin, r.board_id)}
                 {r.same_store ? (
                   <Chip tone={stageTone(r.dest_status)} title="轉入單目前的狀態（同店變更取貨人無配送階段）">
                     {orderStatusLabel(r.dest_status)}
@@ -1033,7 +1035,6 @@ function ProvidedList({ stores, direction }: {
                     {aidStageLabel(r.dest_status, r.is_air_transfer)}
                   </Chip>
                 )}
-                {originChip(r.origin, r.board_id)}
               </div>
 
               {/* 同店互轉：沒有隨貨單（貨沒出門）、也不走互助的取消／退回 RPC

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -93,9 +93,11 @@ type ProvidedRow = {
   link_count: number;
   /** 同店互轉（變更取貨人）：商品未離開本店，無配送階段、不出取消／退回／隨貨單鈕 */
   same_store: boolean;
-  /** 這一趟是怎麼來的：aid=互助板認領、order=訂單轉單、unknown=連結表上線前的舊資料
-   *  （2026-08-24 之前的轉移由回填補建，原始 reason 已遺失，判不出來就不要猜） */
-  origin: "aid" | "order" | "unknown";
+  /** 這一趟是怎麼來的：aid=互助板認領、order=訂單轉單。
+   *  舊資料的原始 reason 曾被回填蓋掉，20260825040000 已從轉入單 notes 救回
+   *  貼文編號；救不回但確實有互助痕跡的會蓋「互助（貼文編號不明）」，
+   *  其餘（線上 593 筆，三個訊號全查過都沒有互助痕跡）就是訂單轉單。 */
+  origin: "aid" | "order";
   /** 同店互轉的兩位客人（原客人 → 新客人）；跨店列不用 */
   from_party: string | null;
   to_party: string | null;
@@ -158,6 +160,10 @@ export default function MutualAidPage() {
   // same_store 是獨立分頁：同店變更取貨人的轉出店＝接收店，掛在「我轉出／我接收」
   // 底下會變成同一筆出現兩次（2026-08-25 回報）→ 拉到與「進行中」同層。
   const [view, setView] = useState<"active" | "history" | "provided" | "received" | "same_store">("active");
+  // 總倉／未綁分店的帳號沒有「自己這一側」→ 我轉出與我接收會列出一模一樣的
+  // 全站清單（2026-08-25 回報）。這種帳號只給一個「店對店轉移」分頁。
+  const myStoreId = useUserBranchStoreId(stores);
+  const isHq = myStoreId == null;
   const [filter, setFilter] = useState<"all" | "request" | "offer">("all");
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
@@ -299,7 +305,10 @@ export default function MutualAidPage() {
       </header>
 
       <div className="flex gap-1 overflow-x-auto border-b border-zinc-200 dark:border-zinc-800">
-        {(["active", "history", "provided", "received", "same_store"] as const).map((v) => (
+        {(isHq
+            ? (["active", "history", "provided", "same_store"] as const)
+            : (["active", "history", "provided", "received", "same_store"] as const)
+          ).map((v) => (
           <SpinButton
             key={v}
             type="button"
@@ -312,7 +321,7 @@ export default function MutualAidPage() {
           >
             {v === "active" ? "進行中"
               : v === "history" ? "歷史"
-              : v === "provided" ? "我轉出"
+              : v === "provided" ? (isHq ? "店對店轉移" : "我轉出")
               : v === "received" ? "我接收"
               : "同店變更取貨人"}
           </SpinButton>
@@ -322,7 +331,8 @@ export default function MutualAidPage() {
       {view === "provided" || view === "received" || view === "same_store" ? (
         <ProvidedList
           stores={stores}
-          direction={view === "provided" ? "out" : view === "received" ? "in" : "same"}
+          // 總倉沒有轉出／轉入之分，一律走同一份全站清單
+          direction={view === "same_store" ? "same" : isHq ? "out" : view === "provided" ? "out" : "in"}
         />
       ) : (
       <>
@@ -726,15 +736,15 @@ function stageTone(status: string): keyof typeof CHIP_TONE {
 
 /** 來源標籤：這一趟是怎麼發生的。 */
 function originChip(origin: ProvidedRow["origin"], boardId: number | null) {
-  if (origin === "aid") {
-    return <Chip tone="blue" title="由互助交流板的貼文認領而來">互助板 #{boardId}</Chip>;
-  }
-  if (origin === "order") {
+  if (origin !== "aid") {
     return <Chip tone="teal" title="由訂單頁的「轉給別人」直接轉移">訂單轉單</Chip>;
   }
+  if (boardId != null) {
+    return <Chip tone="blue" title="由互助交流板的貼文認領而來">互助板 #{boardId}</Chip>;
+  }
   return (
-    <Chip tone="faint" title="2026-08-24 轉移連結表上線前的舊資料，當時未記錄來源，無法判定">
-      來源未記錄
+    <Chip tone="faint" title="確定是互助轉移，但這張轉入單併了多筆轉移、對不出是哪一則貼文（連結表上線前的舊資料）">
+      互助板（編號不明）
     </Chip>
   );
 }
@@ -829,12 +839,9 @@ function ProvidedList({ stores, direction }: {
             transferred_at: r.transferred_at,
             is_air_transfer: r.is_air_transfer === true,
             board_id: r.aid_board_id ?? (Number(/互助板[^#]*#(\d+)/.exec(r.reason ?? "")?.[1]) || null),
-            // 判來源：有貼文編號＝互助；reason 空＝轉單 RPC 當下寫的（互助對話框
-            // 一定會預填「互助板認領 #N」，所以空的只可能是訂單頁轉單）；
-            // 「[回填]」是連結表上線前補建的舊資料，原始 reason 已遺失 → 不猜。
-            origin: (r.aid_board_id ?? (Number(/互助板[^#]*#(\d+)/.exec(r.reason ?? "")?.[1]) || null)) != null
-              ? "aid"
-              : r.reason == null ? "order" : "unknown",
+            // 判來源：有貼文編號、或 reason 提到互助（20260825040000 對舊資料蓋的
+            // 「互助（貼文編號不明）」）＝互助；其餘都是訂單頁轉單。
+            origin: (r.aid_board_id != null || /互助/.test(r.reason ?? "")) ? "aid" : "order",
             reason: r.reason,
             source_store: nameOf(src.store),
             source_store_id: src.pickup_store_id,
@@ -934,7 +941,7 @@ function ProvidedList({ stores, direction }: {
                     一堆沒動過的品項，2026-08-24 就被誤讀成「OV-2-0001 變已完成」。 */}
                 {v === "transit"
                   ? `運送中 (${inFlight.length})`
-                  : `${direction === "out" ? "對方已簽收" : "已簽收"} (${done.length})`}
+                  : `${myStoreId != null && direction === "out" ? "對方已簽收" : "已簽收"} (${done.length})`}
               </SpinButton>
             ))}
           </div>
@@ -943,7 +950,7 @@ function ProvidedList({ stores, direction }: {
           {direction === "same"
             ? "商品未離開本店，僅將訂單改掛至另一位客人；如需還原請至轉入單再次轉移"
             : myStoreId == null
-              ? `全站店對店${direction === "out" ? "轉出" : "轉入"}（總倉視角），含互助認領與訂單轉單`
+              ? "全站店對店轉移（總倉視角），含互助認領與訂單轉單"
               : direction === "out"
                 ? "本店轉出的商品（互助認領＋訂單轉單）。未送達可「取消提供」，已送達可「要求退回」"
                 : "其他分店轉入本店的商品（互助認領＋訂單轉單）。未送達可「取消轉入」，已送達可「退回原店」"}
@@ -955,8 +962,12 @@ function ProvidedList({ stores, direction }: {
           {direction === "same"
             ? "本店沒有同店變更取貨人的紀錄"
             : bucket === "done"
-              ? `無${direction === "out" ? "對方已簽收的轉出" : "已簽收的轉入"}紀錄`
-              : `目前無運送中的${direction === "out" ? "轉出" : "轉入"}`}
+              ? (myStoreId == null
+                  ? "無已簽收的轉移紀錄"
+                  : `無${direction === "out" ? "對方已簽收的轉出" : "已簽收的轉入"}紀錄`)
+              : (myStoreId == null
+                  ? "目前無運送中的轉移"
+                  : `目前無運送中的${direction === "out" ? "轉出" : "轉入"}`)}
         </div>
       ) : (
         <ul className="space-y-2">

--- a/supabase/migrations/20260825040000_backfill_link_aid_board_from_notes.sql
+++ b/supabase/migrations/20260825040000_backfill_link_aid_board_from_notes.sql
@@ -1,0 +1,109 @@
+-- ============================================================
+-- 2026-08-25: 回填 customer_order_transfer_links.aid_board_id
+--             —— 讓「來源未記錄」只剩真的查不出來的那幾筆
+--
+-- 背景：互助頁的每一筆轉移現在會標來源（互助板 #N ／ 訂單轉單）。判定依據是
+--   aid_board_id（20260824060000 才有的欄位）或 reason 裡的貼文編號，而
+--   20260824000100 的回填把舊資料的 reason 一律蓋成「[回填] …」，原始的
+--   「互助板認領 #N」就消失了 → 608 筆舊轉移全部只能標「來源未記錄」。
+--
+-- 但原始 reason 其實還留在**轉入單的 notes** 裡：兩支轉單 RPC 建單時把
+--   p_reason 併進 notes（新建單放最前面、追加轉入放在時間戳後面 ' / ' 之後）。
+--
+-- 線上盤點（2026-08-25，608 筆無來源的舊 link）：
+--     15 筆 轉入單 notes 找得到「互助板 #N」  → 本檔回填
+--    593 筆 三個訊號全查過都沒有互助痕跡      → 確定是訂單轉單
+--         （notes 沒提互助板、來源單不是 AB- 互助載體單、
+--           來源單品項 notes 也沒有「[互助板認領 #N]」的蓋章）
+--   ⇒ 回填後前端就能把「沒有 aid_board_id」直接視為訂單轉單。
+--
+-- 對應方式（同 20260824070000 的教訓）：notes 裡每一段轉入紀錄都帶
+--   to_char(v_now,'YYYY-MM-DD HH24:MI:SS')，而 link.transferred_at 正是同一個
+--   v_now（回填時被截到秒）。所以用「該段時間戳 = link.transferred_at 截到秒」
+--   對趟；一張轉入單只有一筆 link 且 notes 只提到一個編號時可直接對上。
+--   兩者都對不上的不動（寧可留「來源未記錄」，不要猜錯）。
+--
+-- Rollback：
+--   UPDATE customer_order_transfer_links SET aid_board_id = NULL
+--    WHERE reason LIKE '[回填]%';
+-- ============================================================
+
+-- 候選：還沒有 aid_board_id、reason 也認不出編號的舊 link
+WITH bf AS (
+  SELECT l.id AS link_id, l.dest_order_id, l.transferred_at, d.notes
+    FROM customer_order_transfer_links l
+    JOIN customer_orders d ON d.id = l.dest_order_id
+   WHERE l.aid_board_id IS NULL
+     AND COALESCE(l.reason, '') NOT LIKE '互助板%'
+     AND (l.reason LIKE '[回填]%' OR l.reason IS NULL)
+     AND d.notes ~ '互助板[^#]*#[0-9]+'
+),
+-- notes 裡出現過的所有貼文編號（不限位置）——
+-- ⚠ 兩支 RPC 擺 reason 的位置不同：建新轉入單放 notes 第一行、追加轉入放在
+--    時間戳後面的 ' / ' 之後。只認後者的話會漏掉一大半（實測只救到 2/15）。
+boards AS (
+  SELECT bf.link_id, bf.dest_order_id, m[1]::BIGINT AS board_id
+    FROM bf
+    CROSS JOIN LATERAL regexp_matches(bf.notes, '互助板[^#]*#(\d+)', 'g') AS m
+),
+-- (a) 追加轉入格式：同一行帶時間戳，可以精準對到是哪一趟
+seg AS (
+  SELECT bf.link_id, bf.transferred_at,
+         (m[1] || '+00')::TIMESTAMPTZ AS seg_at,
+         m[2]::BIGINT AS board_id
+    FROM bf
+    CROSS JOIN LATERAL regexp_matches(
+      bf.notes,
+      '\] (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})[^\n]*互助板[^#]*#(\d+)',
+      'g') AS m
+),
+by_time AS (
+  SELECT link_id, MIN(board_id) AS board_id
+    FROM seg
+   WHERE date_trunc('second', seg_at) = date_trunc('second', transferred_at)
+   GROUP BY link_id
+  HAVING COUNT(DISTINCT board_id) = 1
+),
+-- (b) 對不到時間戳，但該轉入單只有這一筆 link、notes 也只提到一個編號
+by_unique AS (
+  SELECT b.link_id, MIN(b.board_id) AS board_id
+    FROM boards b
+   WHERE NOT EXISTS (SELECT 1 FROM by_time t WHERE t.link_id = b.link_id)
+     AND (SELECT COUNT(*) FROM customer_order_transfer_links l2
+           WHERE l2.dest_order_id = b.dest_order_id) = 1
+   GROUP BY b.link_id
+  HAVING COUNT(DISTINCT b.board_id) = 1
+),
+resolved AS (
+  SELECT link_id, board_id FROM by_time
+  UNION
+  SELECT link_id, board_id FROM by_unique
+)
+UPDATE customer_order_transfer_links l
+   SET aid_board_id = r.board_id
+  FROM resolved r
+ WHERE l.id = r.link_id
+   AND EXISTS (SELECT 1 FROM mutual_aid_board b WHERE b.id = r.board_id);
+
+-- 驗證（套用後跑）：
+--   SELECT COUNT(*) FILTER (WHERE aid_board_id IS NOT NULL) AS 有貼文編號,
+--          COUNT(*) FILTER (WHERE aid_board_id IS NULL
+--                             AND (reason LIKE '[回填]%' OR reason IS NULL)
+--                             AND EXISTS (SELECT 1 FROM customer_orders d
+--                                          WHERE d.id = dest_order_id
+--                                            AND d.notes ~ '互助板[^#]*#[0-9]+')) AS 仍不明
+--     FROM customer_order_transfer_links;
+
+-- ------------------------------------------------------------
+-- 對不出貼文編號、但確實查得到互助痕跡的（線上 6 筆：轉入單上有多筆 link、
+-- 時間戳又對不起來）→ 蓋一個標記，前端才不會把它們誤標成「訂單轉單」。
+-- 這幾筆會顯示「互助板（編號不明）」。
+-- ------------------------------------------------------------
+UPDATE customer_order_transfer_links l
+   SET reason = COALESCE(l.reason, '') || ' ｜ 互助（貼文編號不明）'
+ WHERE l.aid_board_id IS NULL
+   AND COALESCE(l.reason, '') NOT LIKE '%互助%'
+   AND (l.reason LIKE '[回填]%' OR l.reason IS NULL)
+   AND EXISTS (SELECT 1 FROM customer_orders d
+                WHERE d.id = l.dest_order_id
+                  AND d.notes ~ '互助板[^#]*#[0-9]+');


### PR DESCRIPTION
## 做了什麼

### 一、「來源未記錄」不是全部都等於訂單轉單 —— 救回來

老闆問「來源未記錄是不是就是訂單轉的」。查了正式庫：**大部分是，但有 15 筆其實是互助**。

原因：`20260824000100` 的回填把舊 link 的 reason 一律蓋成「[回填] …」，互助板編號就消失了 → 608 筆舊轉移全部只能標「來源未記錄」。但那個編號其實還留在**轉入單的 notes** 裡（兩支轉單 RPC 都會把 `p_reason` 併進 notes）。

`20260825040000` 從 notes 救回：能對上時間戳的、或「該轉入單只有一筆 link 且只提到一個編號」的，回填 `aid_board_id`。

> ⚠ 踩到的坑：兩支 RPC 擺 reason 的位置不同 —— 建新轉入單放 notes **第一行**、追加轉入放在**時間戳後面**的 `/` 之後。第一版只認後者，15 筆只救到 2 筆；兩種格式都吃才對。

線上盤點結果（616 筆 link）：

| 前端標籤 | 筆數 | 依據 |
|---|---|---|
| 訂單轉單 | **593** | 三個訊號全查過都無互助痕跡：notes 沒提互助板、來源單不是 `AB-` 互助載體單、來源單品項也沒有「[互助板認領 #N]」蓋章 |
| 互助板 #N | **17** | 原本 7 筆 ＋ 本次從 notes 救回 10 筆 |
| 互助板（編號不明） | **6** | 確定是互助，但轉入單併了多筆轉移、時間戳對不出是哪一則 → 蓋標記，避免被誤標成訂單轉單 |

⇒ **「來源未記錄」歸零**，而且沒有任何一筆是用猜的。

### 二、總倉的「我轉出／我接收」內容一模一樣

總倉／未綁分店的帳號沒有「自己這一側」，`ProvidedList` 的過濾只在 `myStoreId != null` 時生效 → 兩個分頁列出完全相同的全站清單（老闆回報「為什麼內容一模一樣」）。

總倉改成只給一個 **「店對店轉移」** 分頁（連帶把「全站店對店轉出／轉入」「對方已簽收」等分店視角的字眼改成中性）；分店帳號維持「我轉出／我接收」兩邊不變。

### 三、標籤順序改成 種類 → 來源 → 狀態

老闆 2026-08-25 指定。原本是 種類 → 狀態 → 來源。

## 上線危險

- 做了：`20260825040000` 只 UPDATE `customer_order_transfer_links` 的 `aid_board_id` 與 `reason`（僅限本來就沒有來源資訊的舊 link），**已套正式庫**；前端一支檔案。
- 不做：不動任何 RPC、不動 transfers／orders、不改新資料的寫入路徑（新轉移本來就會寫 `aid_board_id`）。
- 回退：`UPDATE customer_order_transfer_links SET aid_board_id = NULL WHERE reason LIKE '[回填]%';`（檔頭有寫），前端 revert 本 PR。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `check-sql-syntax.cjs` 過；正式庫 `BEGIN…ROLLBACK` 乾跑確認分佈後才正式套用，套用後實測：訂單轉單 593／互助板 #N 17／互助板（編號不明）6，**來源未記錄 0**。
- Playwright fixture：**總倉帳號** 4 項（單一「店對店轉移」分頁、沒有重複的我接收、不出現我轉出、同店分頁仍在）、**分店帳號** 2 項（我轉出／我接收都在、不誤用總倉標題）全過。
- 標籤順序實測：`["✈ 空中轉直送", "互助板 #77", "已出貨・待收貨店簽收"]`。
- 手機 390×844：無橫向溢出。
- tsc --noEmit 乾淨、`npm run build` 綠。

> #843 合併後本分支已 rebase 到最新 main（拿掉重複的手機版面 commit），現在只有自己的 2 顆 commit、無衝突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAhCJKvHw5Z9FoY7V8kse6