### PR TITLE
互助頁改表格；同店變更取貨人可撤銷；歷史移到最後並分頁

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -6,6 +6,8 @@ import { Modal } from "@/components/Modal";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import SearchSpinner from "@/components/SearchSpinner";
+import Spinner, { LoadingBlock } from "@/components/Spinner";
+import { Table, THead, TBody, Tr, Th, Td } from "@/components/DataTable";
 import { ProductImagesField } from "@/components/ProductImagesField";
 import { printViaIframe } from "@/lib/printIframe";
 import { withBasePath } from "@/lib/basePath";
@@ -171,6 +173,14 @@ export default function MutualAidPage() {
   const [offerModalOpen, setOfferModalOpen] = useState(false);
   const [manualModalOpen, setManualModalOpen] = useState(false);
   const [threadPost, setThreadPost] = useState<Post | null>(null);
+  // 歷史是回頭查的，一次只讀 20 筆，滑到底再按「載入更多」（老闆 2026-08-25）。
+  // 進行中維持一次撈完 —— 那是每天要看的工作清單，分頁只會礙事。
+  const HISTORY_PAGE = 20;
+  const [historyLimit, setHistoryLimit] = useState(HISTORY_PAGE);
+  // 這次查詢實際回了幾筆：回的比要的少 ＝ 沒有更多了（不必另外查 count）
+  const [historyFetched, setHistoryFetched] = useState(0);
+  // 切分頁／換篩選時把歷史收回第一頁（在 handler 裡重設，不用 effect ——
+  // effect 裡同步 setState 會觸發 cascading render 的 lint 規則）
 
   // 貼文數變動（發文/關貼/認領）後重載列表，並通知側欄「互助交流板」badge 重抓
   // (見 layout AID_BADGE_REFRESH_EVENT)
@@ -203,11 +213,14 @@ export default function MutualAidPage() {
         // 歷史 = 已結束（已認領／已過期／已取消），對齊 rpc_purge_expired_aid_board
         // 20260824000000 起到期不再刪除，這三種狀態才查得到完整歷史
         q = view === "active" ? q.eq("status", "active") : q.neq("status", "active");
-        q = q.order("created_at", { ascending: false }).limit(200);
+        // 歷史分頁讀 historyLimit 筆；進行中維持一次撈完（上限 200）
+        q = q.order("created_at", { ascending: false })
+             .limit(view === "history" ? historyLimit : 200);
         if (filter !== "all") q = q.eq("post_type", filter);
         const { data, error: e } = await q;
         if (e) throw new Error(e.message);
         const rows = ((data as Post[] | null) ?? []);
+        if (!cancelled && view === "history") setHistoryFetched(rows.length);
         if (rows.length === 0) {
           if (!cancelled) setPosts([]);
           return;
@@ -256,7 +269,7 @@ export default function MutualAidPage() {
       }
     })();
     return () => { cancelled = true; };
-  }, [view, filter, reloadTick]);
+  }, [view, filter, reloadTick, historyLimit]);
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
@@ -305,14 +318,15 @@ export default function MutualAidPage() {
       </header>
 
       <div className="flex gap-1 overflow-x-auto border-b border-zinc-200 dark:border-zinc-800">
+        {/* 歷史擺最後：它是回頭查的，不該卡在每天要看的分頁中間（老闆 2026-08-25） */}
         {(isHq
-            ? (["active", "history", "provided", "same_store"] as const)
-            : (["active", "history", "provided", "received", "same_store"] as const)
+            ? (["active", "provided", "same_store", "history"] as const)
+            : (["active", "provided", "received", "same_store", "history"] as const)
           ).map((v) => (
           <SpinButton
             key={v}
             type="button"
-            onClick={() => setView(v)}
+            onClick={() => { setView(v); setHistoryLimit(HISTORY_PAGE); }}
             className={
               view === v
                 ? "shrink-0 whitespace-nowrap border-b-2 border-zinc-900 px-4 py-2 text-sm font-medium text-zinc-900 dark:border-zinc-100 dark:text-zinc-100"
@@ -341,7 +355,7 @@ export default function MutualAidPage() {
           <SpinButton
             key={opt}
             type="button"
-            onClick={() => setFilter(opt)}
+            onClick={() => { setFilter(opt); setHistoryLimit(HISTORY_PAGE); }}
             className={`px-3 py-1.5 ${
               filter === opt
                 ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
@@ -360,7 +374,7 @@ export default function MutualAidPage() {
       )}
 
       {posts === null ? (
-        <div className="text-sm text-zinc-500">載入中…</div>
+        <LoadingBlock />
       ) : posts.length === 0 ? (
         <div className="rounded-md border border-dashed border-zinc-300 p-8 text-center text-sm text-zinc-500 dark:border-zinc-700">
           {view === "active" ? "目前沒有進行中的" : "沒有已結束的"}
@@ -431,6 +445,18 @@ export default function MutualAidPage() {
             </li>
           ))}
         </ul>
+      )}
+
+      {/* 歷史的「載入更多」：回的筆數 < 要求的筆數 ＝ 已經到底，就不畫按鈕
+          （不必為了這顆鈕多打一發 count 查詢） */}
+      {view === "history" && posts !== null && historyFetched >= historyLimit && (
+        <SpinButton
+          type="button"
+          onClick={() => setHistoryLimit((n) => n + HISTORY_PAGE)}
+          className="mx-auto rounded-md border border-zinc-300 px-4 py-1.5 text-sm text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+        >
+          載入更多（目前 {posts.length} 筆）
+        </SpinButton>
       )}
       </>
       )}
@@ -611,7 +637,11 @@ function AidClaimLog({ post }: { post: Post }) {
   const verb = post.post_type === "request" ? "提供" : "認領";
 
   if (rows === null) {
-    return <div className="text-xs text-zinc-500">載入{verb}紀錄…</div>;
+    return (
+      <div className="flex items-center gap-2 text-xs text-zinc-500">
+        <Spinner size={14} /> 載入{verb}紀錄…
+      </div>
+    );
   }
 
   // 貼文自己記的已成交量 vs 查得到明細的量。
@@ -803,10 +833,15 @@ function ProvidedList({ stores, direction }: {
           }) | null;
         };
         const nameOf = (s: StoreRef) => (Array.isArray(s) ? s[0]?.name : s?.name) ?? "—";
-        // 同店互轉的「對面那位客人」：訂單暱稱優先、退會員名（內部單＝【內部】xx店）
+        // 同店變更取貨人的「這張單掛在誰名下」：一律以**會員**為準。
+        // ⛔ 不要用 nickname_snapshot —— 轉單 RPC 建轉入單時是把來源單的
+        //    nickname_snapshot 原封複製過去（v_orig.nickname_snapshot），
+        //    所以接收人那一側會顯示成原客人的名字（2026-08-25 回報「Peggy → Peggy」，
+        //    實際是 Peggy → Alex Chen）。暱稱只在查無會員名時當後備。
         const nickOf = (o: RawOrder) =>
+          ((Array.isArray(o.member) ? o.member[0]?.name : o.member?.name) ?? null) ||
           o.nickname_snapshot?.trim() ||
-          ((Array.isArray(o.member) ? o.member[0]?.name : o.member?.name) ?? null);
+          null;
         const raws = (data ?? []) as unknown as Raw[];
         // 同一張轉入單有幾趟：舊的併入單（多店混一張）取消整張會殃及別家店的貨，
         // 要在列上把取消鈕關掉。要在「店別過濾之前」算 —— 別家店那幾趟不在
@@ -878,7 +913,10 @@ function ProvidedList({ stores, direction }: {
   async function cancelLeg(r: ProvidedRow, kind: "cancel" | "return") {
     if (busyLink != null) return;
     const items = r.labels.join("、") || `共 ${r.qty}`;
-    const what = kind === "cancel"
+    const what = r.same_store
+      // 同店變更取貨人：貨沒離開本店，撤銷＝把商品掛回原客人的單
+      ? `撤銷本次變更（${items}）？\n商品將掛回原客人 ${r.from_party ?? ""} 的訂單。`
+      : kind === "cancel"
       ? `取消本次轉出（${items}）？\n商品將退回來源訂單，互助板貼文的數量也會一併還原。`
       : direction === "in"
         // 收貨方退回：貨在自己架上，按下去就是把它送回去
@@ -896,7 +934,13 @@ function ProvidedList({ stores, direction }: {
       if (!user?.id) { alert("尚未登入"); return; }
       const { error: e } = await sb.rpc(
         kind === "cancel" ? "rpc_cancel_aid_order" : "rpc_return_aid_order",
-        { p_order_id: r.dest_order_id, p_reason: `互助板${direction === "out" ? "提供方" : "收貨方"}${kind === "cancel" ? "取消" : "退回"}`, p_operator: user.id },
+        {
+          p_order_id: r.dest_order_id,
+          p_reason: r.same_store
+            ? "撤銷同店變更取貨人"
+            : `互助板${direction === "out" ? "提供方" : "收貨方"}${kind === "cancel" ? "取消" : "退回"}`,
+          p_operator: user.id,
+        },
       );
       if (e) { alert(translateRpcError(e)); return; }
       setReloadTick((n) => n + 1);
@@ -913,7 +957,7 @@ function ProvidedList({ stores, direction }: {
       </div>
     );
   }
-  if (rows === null) return <div className="text-sm text-zinc-500">載入中…</div>;
+  if (rows === null) return <LoadingBlock />;
 
   const inFlight = rows.filter((r) => isAidInFlight(r.dest_status));
   const done = rows.filter((r) => !isAidInFlight(r.dest_status));
@@ -970,34 +1014,56 @@ function ProvidedList({ stores, direction }: {
                   : `目前無運送中的${direction === "out" ? "轉出" : "轉入"}`)}
         </div>
       ) : (
-        <ul className="space-y-2">
-          {shown.map((r) => (
-            <li
-              key={r.linkId}
-              className="flex flex-col gap-2 rounded-md border border-zinc-200 bg-white p-3 sm:flex-row sm:items-start sm:gap-4 dark:border-zinc-800 dark:bg-zinc-900"
-            >
-              {/* 左：這一趟是誰給誰、什麼東西、對應哪兩張單 */}
-              <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                  <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">
-                    {myStoreId == null
-                      ? (r.same_store
-                          ? `${r.source_store}：${r.from_party ?? "原客人"} → ${r.to_party ?? "新客人"}`
-                          : `${r.source_store} → ${r.dest_store}`)
-                      : r.same_store
-                        ? `${r.from_party ?? "原客人"} → ${r.to_party ?? "新客人"}`
-                        : `${direction === "out" ? "轉予" : "來自"} ${direction === "out" ? r.dest_store : r.source_store}`}
-                  </span>
-                  <span className="shrink-0 text-xs text-zinc-400">{fmtDt(r.transferred_at)}</span>
-                </div>
-                <div className="mt-1 text-sm text-zinc-800 dark:text-zinc-100">
-                  {r.labels.join("、") || `共 ${r.qty}`}
-                </div>
-                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-zinc-500">
-                  <span>
-                    來源單 <span className="font-mono text-zinc-700 dark:text-zinc-300">{r.source_order_no}</span>
-                  </span>
-                  <span aria-hidden className="text-zinc-300 dark:text-zinc-600">→</span>
+<Table>
+          <THead>
+            <Th className="min-w-[12rem]">商品</Th>
+            <Th className="whitespace-nowrap">{direction === "same" ? "原客人 → 新客人" : "轉出 → 轉入"}</Th>
+            <Th className="whitespace-nowrap">種類</Th>
+            <Th className="whitespace-nowrap">來源</Th>
+            <Th className="whitespace-nowrap" align="right">數量</Th>
+            <Th className="whitespace-nowrap">單號</Th>
+            <Th className="whitespace-nowrap" align="right">日期</Th>
+            <Th className="whitespace-nowrap">狀態</Th>
+            <Th className="whitespace-nowrap" align="right">操作</Th>
+          </THead>
+          <TBody>
+            {shown.map((r) => (
+              <Tr key={r.linkId}>
+                <Td className="align-top">
+                  <div className="text-zinc-800 dark:text-zinc-100">
+                    {r.labels.join("、") || `共 ${r.qty}`}
+                  </div>
+                  {r.reason && !r.reason.startsWith("[回填]") && (
+                    <div className="mt-0.5 text-xs text-zinc-500">「{r.reason}」</div>
+                  )}
+                </Td>
+                <Td className="whitespace-nowrap align-top font-medium">
+                  {/* 一律把兩端都寫出來（老闆 2026-08-25：「直接寫松山店 → 南平店，
+                      不要給予」）—— 分店帳號原本只顯示對面那一家，看不出方向 */}
+                  {r.same_store
+                    ? `${r.from_party ?? "原客人"} → ${r.to_party ?? "新客人"}`
+                    : `${r.source_store} → ${r.dest_store}`}
+                  {r.same_store && myStoreId == null && (
+                    <div className="text-xs font-normal text-zinc-500">{r.source_store}（店內）</div>
+                  )}
+                </Td>
+                <Td className="align-top">
+                  {r.same_store ? (
+                    <Chip tone="violet" title="同店變更取貨人：商品未離開本店，只是把訂單改掛給另一位客人">
+                      🔁 同店
+                    </Chip>
+                  ) : (
+                    <Chip tone={r.is_air_transfer ? "sky" : "amber"}
+                          title={r.is_air_transfer ? "店對店直送，不經總倉" : "先送到總倉，再由總倉派送到收貨店"}>
+                      {aidRouteLabel(r.is_air_transfer)}
+                    </Chip>
+                  )}
+                </Td>
+                <Td className="align-top">{originChip(r.origin, r.board_id)}</Td>
+                <Td className="whitespace-nowrap align-top tabular-nums" align="right">{r.qty}</Td>
+                <Td className="whitespace-nowrap align-top text-xs text-zinc-500">
+                  <span className="font-mono" title={r.source_order_no}>{shortOrderNo(r.source_order_no)}</span>
+                  <span aria-hidden className="mx-1 text-zinc-300 dark:text-zinc-600">→</span>
                   {/* 轉入單掛在收貨店名下 —— 連結一定要帶 storeId，否則分店帳號的
                       門市篩選會預設帶回自己店、搜出 0 筆（看起來像貨憑空消失） */}
                   <Link
@@ -1006,112 +1072,123 @@ function ProvidedList({ stores, direction }: {
                   >
                     {shortOrderNo(r.dest_order_no)}
                   </Link>
-                  {r.reason && !r.reason.startsWith("[回填]") && (
-                    <span className="text-zinc-700 dark:text-zinc-300">「{r.reason}」</span>
+                </Td>
+                <Td className="whitespace-nowrap align-top text-xs text-zinc-500" align="right"
+                    title={fmtDt(r.transferred_at)}>
+                  {fmtDt(r.transferred_at).slice(5)}
+                </Td>
+                <Td className="align-top">
+                  {r.same_store ? (
+                    <Chip tone={stageTone(r.dest_status)} title="轉入單目前的狀態（同店變更取貨人無配送階段）">
+                      {orderStatusLabel(r.dest_status)}
+                    </Chip>
+                  ) : (
+                    <Chip tone={stageTone(r.dest_status)} title="本次轉移的進度（非來源訂單的狀態）">
+                      {aidStageLabel(r.dest_status, r.is_air_transfer)}
+                    </Chip>
                   )}
-                </div>
-              </div>
-
-              {/* 中：標籤靠右橫排 —— 種類（空中轉／經總倉）→ 來源 → 狀態，
-                  三種語意三個顏色。順序是老闆 2026-08-25 指定的。 */}
-              <div className="flex flex-wrap items-center gap-1.5 sm:w-[15rem] sm:shrink-0 sm:justify-end">
-                {r.same_store ? (
-                  <Chip tone="violet" title="商品未離開本店，只是把訂單改掛給另一位客人">
-                    🔁 同店變更取貨人
-                  </Chip>
-                ) : (
-                  <Chip tone={r.is_air_transfer ? "sky" : "amber"}
-                        title={r.is_air_transfer ? "店對店直送，不經總倉" : "先送到總倉，再由總倉派送到收貨店"}>
-                    {aidRouteLabel(r.is_air_transfer)}
-                  </Chip>
-                )}
-                {originChip(r.origin, r.board_id)}
-                {r.same_store ? (
-                  <Chip tone={stageTone(r.dest_status)} title="轉入單目前的狀態（同店變更取貨人無配送階段）">
-                    {orderStatusLabel(r.dest_status)}
-                  </Chip>
-                ) : (
-                  <Chip tone={stageTone(r.dest_status)} title="本次轉移的進度（非來源訂單的狀態）">
-                    {aidStageLabel(r.dest_status, r.is_air_transfer)}
-                  </Chip>
-                )}
-              </div>
-
-              {/* 同店互轉：沒有隨貨單（貨沒出門）、也不走互助的取消／退回 RPC
-                  （要反悔就到轉入單用「轉給別人」轉回來）→ 整欄不出 */}
-              {!r.same_store && (
-              <div className="flex flex-row flex-wrap gap-1.5 sm:shrink-0 sm:flex-col sm:items-stretch">
-                {/* 隨貨單走 /transfers/print-aid（兩聯：司機聯 + 存查聯），
-                    帶 link 才只印這一趟的貨、來源店也才標得對 */}
-                <SpinButton
-                  type="button"
-                  onClick={() =>
-                    printViaIframe(
-                      withBasePath(`/transfers/print-aid?order_id=${r.dest_order_id}&link=${r.linkId}`),
-                    )
-                  }
-                  title="列印這一趟的互助出貨單（兩聯：司機聯 + 存查聯）"
-                  className="rounded-md border border-zinc-300 px-2 py-1.5 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                >
-                  🖨️
-                </SpinButton>
-                {/* 取消規則：分界線是「貨到收貨店了沒」。
-                    未到（pending/confirmed/shipping）→ 兩邊都能取消（rpc_cancel_aid_order）；
-                    已到（ready）→ 只有收貨方能退回原店（rpc_return_aid_order，貨在他們架上）；
-                    completed/cancelled → 沒有動作。
-                    舊的併入單（link_count > 1）整張取消會殃及別家店的貨 → 導去訂單頁。 */}
-                {isAidInFlight(r.dest_status) && (
-                  r.link_count === 1 ? (
-                    <SpinButton
-                      type="button"
-                      disabled={busyLink != null}
-                      onClick={() => cancelLeg(r, "cancel")}
-                      className="rounded-md border border-red-300 px-2 py-1.5 text-xs text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950"
-                    >
-                      {busyLink === r.linkId ? "處理中…" : direction === "out" ? "取消提供" : "取消轉入"}
-                    </SpinButton>
+                </Td>
+                <Td className="align-top" align="right">
+                  <div className="flex justify-end">
+                  {/* 同店變更取貨人：貨沒出門 → 沒有隨貨單、也沒有「退回原店」，
+                      但要能撤銷（把商品掛回原客人的單，20260825050000 放行 ready）。
+                      已取走的單（partially_completed/completed）RPC 會擋，所以不出鈕。 */}
+                  {r.same_store ? (
+                    <div className="flex flex-row flex-wrap gap-1.5 sm:shrink-0 sm:flex-col sm:items-stretch">
+                      {r.link_count === 1 && ["pending", "confirmed", "shipping", "ready"].includes(r.dest_status) ? (
+                        <SpinButton
+                          type="button"
+                          disabled={busyLink != null}
+                          onClick={() => cancelLeg(r, "cancel")}
+                          className="whitespace-nowrap rounded-md border border-red-300 px-2 py-1.5 text-xs text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950"
+                        >
+                          {busyLink === r.linkId ? "處理中…" : "撤銷變更"}
+                        </SpinButton>
+                      ) : r.link_count !== 1 ? (
+                        <span
+                          className="whitespace-nowrap rounded-md border border-dashed border-zinc-300 px-2 py-1.5 text-center text-[10px] text-zinc-400 dark:border-zinc-700"
+                          title="此轉入單併有其他筆轉移（舊資料），整張撤銷會一併影響；請至轉入單的訂單頁個別處理"
+                        >
+                          多筆併單
+                        </span>
+                      ) : null}
+                    </div>
                   ) : (
-                    <span
-                      className="rounded-md border border-dashed border-zinc-300 px-2 py-1.5 text-center text-[10px] text-zinc-400 dark:border-zinc-700"
-                      title="此轉入單併有其他分店的商品（舊資料），整張取消會一併取消他店商品；請至轉入單的訂單頁個別處理"
-                    >
-                      多筆併單
-                    </span>
-                  )
-                )}
-                {/* 已到貨（ready）→ 兩邊都能退回（老闆 2026-08-25）。
-                    收貨方＝貨在自己架上，直接送回；轉出方＝要求對方退回，
-                    同一支 rpc_return_aid_order（它沒有「限收貨店」的守衛），
-                    會從對方店出庫、建反向調撥。文案在 cancelLeg 裡分開講。 */}
-                {r.dest_status === "ready" && (
-                  r.link_count === 1 ? (
+                  <div className="flex flex-row flex-wrap gap-1.5 sm:shrink-0 sm:flex-col sm:items-stretch">
+                    {/* 隨貨單走 /transfers/print-aid（兩聯：司機聯 + 存查聯），
+                        帶 link 才只印這一趟的貨、來源店也才標得對 */}
                     <SpinButton
                       type="button"
-                      disabled={busyLink != null}
-                      onClick={() => cancelLeg(r, "return")}
-                      title={
-                        direction === "in"
-                          ? "把這批貨送回原店（建反向調撥、來源單還原、貼文數量還回去）"
-                          : "貨已經在對方店裡：按下去會從對方店出庫、送回本店。請先跟對方講一聲"
+                      onClick={() =>
+                        printViaIframe(
+                          withBasePath(`/transfers/print-aid?order_id=${r.dest_order_id}&link=${r.linkId}`),
+                        )
                       }
-                      className="rounded-md border border-red-300 px-2 py-1.5 text-xs text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950"
+                      title="列印這一趟的互助出貨單（兩聯：司機聯 + 存查聯）"
+                      className="rounded-md border border-zinc-300 px-2 py-1.5 text-xs text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
                     >
-                      {busyLink === r.linkId ? "處理中…" : direction === "in" ? "退回原店" : "要求退回"}
+                      🖨️
                     </SpinButton>
-                  ) : (
-                    <span
-                      className="rounded-md border border-dashed border-zinc-300 px-2 py-1.5 text-center text-[10px] text-zinc-400 dark:border-zinc-700"
-                      title="此轉入單併有其他分店的商品（舊資料），整張退回會一併退回他店商品；請至轉入單的訂單頁個別處理"
-                    >
-                      多筆併單
-                    </span>
-                  )
-                )}
-              </div>
-              )}
-            </li>
-          ))}
-        </ul>
+                    {/* 取消規則：分界線是「貨到收貨店了沒」。
+                        未到（pending/confirmed/shipping）→ 兩邊都能取消（rpc_cancel_aid_order）；
+                        已到（ready）→ 只有收貨方能退回原店（rpc_return_aid_order，貨在他們架上）；
+                        completed/cancelled → 沒有動作。
+                        舊的併入單（link_count > 1）整張取消會殃及別家店的貨 → 導去訂單頁。 */}
+                    {isAidInFlight(r.dest_status) && (
+                      r.link_count === 1 ? (
+                        <SpinButton
+                          type="button"
+                          disabled={busyLink != null}
+                          onClick={() => cancelLeg(r, "cancel")}
+                          className="rounded-md border border-red-300 px-2 py-1.5 text-xs text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950"
+                        >
+                          {busyLink === r.linkId ? "處理中…" : direction === "out" ? "取消提供" : "取消轉入"}
+                        </SpinButton>
+                      ) : (
+                        <span
+                          className="rounded-md border border-dashed border-zinc-300 px-2 py-1.5 text-center text-[10px] text-zinc-400 dark:border-zinc-700"
+                          title="此轉入單併有其他分店的商品（舊資料），整張取消會一併取消他店商品；請至轉入單的訂單頁個別處理"
+                        >
+                          多筆併單
+                        </span>
+                      )
+                    )}
+                    {/* 已到貨（ready）→ 兩邊都能退回（老闆 2026-08-25）。
+                        收貨方＝貨在自己架上，直接送回；轉出方＝要求對方退回，
+                        同一支 rpc_return_aid_order（它沒有「限收貨店」的守衛），
+                        會從對方店出庫、建反向調撥。文案在 cancelLeg 裡分開講。 */}
+                    {r.dest_status === "ready" && (
+                      r.link_count === 1 ? (
+                        <SpinButton
+                          type="button"
+                          disabled={busyLink != null}
+                          onClick={() => cancelLeg(r, "return")}
+                          title={
+                            direction === "in"
+                              ? "把這批貨送回原店（建反向調撥、來源單還原、貼文數量還回去）"
+                              : "貨已經在對方店裡：按下去會從對方店出庫、送回本店。請先跟對方講一聲"
+                          }
+                          className="rounded-md border border-red-300 px-2 py-1.5 text-xs text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950"
+                        >
+                          {busyLink === r.linkId ? "處理中…" : direction === "in" ? "退回原店" : "要求退回"}
+                        </SpinButton>
+                      ) : (
+                        <span
+                          className="rounded-md border border-dashed border-zinc-300 px-2 py-1.5 text-center text-[10px] text-zinc-400 dark:border-zinc-700"
+                          title="此轉入單併有其他分店的商品（舊資料），整張退回會一併退回他店商品；請至轉入單的訂單頁個別處理"
+                        >
+                          多筆併單
+                        </span>
+                      )
+                    )}
+                  </div>
+                  )}
+                  </div>
+                </Td>
+              </Tr>
+            ))}
+          </TBody>
+        </Table>
       )}
     </div>
   );

--- a/supabase/migrations/20260825050000_cancel_same_store_swap.sql
+++ b/supabase/migrations/20260825050000_cancel_same_store_swap.sql
@@ -1,0 +1,284 @@
+-- ============================================================
+-- 2026-08-25: 同店變更取貨人也要能撤銷
+--
+-- 老闆要求：互助頁「同店變更取貨人」那一頁的每一筆都要能撤銷。
+--
+-- 為什麼原本不行：撤銷走的是 rpc_cancel_aid_order（它已經把該做的都做了 ——
+--   還原來源單品項 _restore_transfer_source_items、把來源單頭從
+--   transferred_out 退回 confirmed／ready、取消轉入單），但狀態守衛只放行
+--   pending / confirmed / shipping（外加 SP- 現貨直配的 ready）。
+--   同店變更取貨人的轉入單是 mirror 來源單的狀態，實務上幾乎都是 'ready'
+--   → 一律被擋。
+--
+-- 為什麼放行是安全的：同店＝轉出店與接收店是同一家，
+--   · 不會有調撥單（_air_ship_order_items 判到 source location = dest location
+--     就回 NULL 不建單），本檔仍再確認一次「沒有未取消的 transfers」；
+--   · 沒有任何庫存異動要沖（庫存只在 rpc_record_pickup 那一刻扣）；
+--   · 貨實體上就在店裡沒動過，撤銷只是把品項掛回原客人的單。
+--   已經取走的單（partially_completed / completed）維持擋下 —— 那不是撤銷
+--   得掉的事，要走退貨。
+--
+-- 基底：rpc_cancel_aid_order 線上 prosrc md5 8996a335f63fda4f5c18626e5149962a
+--       （= 20260824080000 的版本），逐字保留，只加一個變數與守衛的第三個例外。
+-- Rollback：重跑 20260824080000_cancel_restores_aid_board.sql。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_cancel_aid_order(p_order_id bigint, p_reason text, p_operator uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $fn$
+
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_terminal_id      BIGINT;
+  v_xfer             transfers%ROWTYPE;
+  v_ti               RECORD;
+  v_cancelled_ids    BIGINT[] := ARRAY[]::BIGINT[];
+  v_reason_note      TEXT;
+  v_refund_ledger_id BIGINT;
+  v_refunded_amount  NUMERIC := 0;
+  v_src_id           BIGINT;
+  v_src_pickable     BOOLEAN := FALSE;
+  v_is_aid           BOOLEAN := FALSE;
+  v_restored         INTEGER := 0;
+  v_ab               RECORD;
+  v_ab_qty           NUMERIC := 0;
+  v_aid_restored     INTEGER := 0;
+  v_same_store_swap  BOOLEAN := FALSE;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('aid_order:' || p_order_id));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'order % not found', p_order_id;
+  END IF;
+  -- 現貨直配（SP-）單一建立就是 'ready'（貨就在店裡、等客人來拿），
+  -- 但它**還沒扣庫存**（配單＝待取，rpc_record_pickup 才扣）→ 取消是安全的，
+  -- 只是把可分配量放回去。原本的守衛把它擋在外面，等於做得出單卻取消不掉
+  -- （2026-08-16 回報）。其餘單型維持原規則不動。
+  -- 同店變更取貨人（轉出店＝接收店）：貨從頭到尾沒離開本店，沒有調撥單、
+  -- 也沒有任何庫存異動（庫存只在取貨那一刻扣），所以停在 'ready' 也能撤銷 ——
+  -- 撤銷＝把品項還給原客人的單。已經取走的（partially_completed / completed）
+  -- 仍然擋著，那不是撤銷得掉的事（2026-08-25 老闆要求）。
+  SELECT (v_order.transferred_from_order_id IS NOT NULL
+          AND EXISTS (SELECT 1 FROM customer_orders s
+                       WHERE s.id = v_order.transferred_from_order_id
+                         AND s.pickup_store_id IS NOT DISTINCT FROM v_order.pickup_store_id)
+          AND NOT EXISTS (SELECT 1 FROM transfers t
+                           WHERE t.customer_order_id = p_order_id
+                             AND t.status <> 'cancelled'))
+    INTO v_same_store_swap;
+
+  IF v_order.status NOT IN ('pending', 'confirmed', 'shipping')
+     AND NOT (v_order.status = 'ready' AND v_order.order_no LIKE 'SP-%')
+     AND NOT (v_order.status = 'ready' AND v_same_store_swap) THEN
+    RAISE EXCEPTION 'order % is %, only pending/confirmed/shipping can be cancelled', p_order_id, v_order.status;
+  END IF;
+
+  -- ── 互助板數量歸還 ──（20260824080000）
+  -- 這張單是互助板帶來的 → 取消／退回時把量還給貼文，貼文若還沒過期就從
+  -- exhausted 轉回 active，釋出店才放得出去。先前這裡完全不碰互助板，
+  -- 取消完貼文永遠卡在「已認領」（2026-08-24 松山取消 #249 那趟就是）。
+  -- 一張單可能有多趟（舊的併入資料），逐 link 還各自的量；
+  -- 要在品項被標 cancelled **之前**算。
+  FOR v_ab IN
+    SELECT l.aid_board_id AS board_id,
+           (SELECT COALESCE(SUM(i.qty), 0) FROM customer_order_items i
+             WHERE i.id = ANY (l.dest_item_ids)
+               AND i.order_id = p_order_id
+               AND i.status IN ('pending','reserved','ready')) AS qty
+      FROM customer_order_transfer_links l
+     WHERE l.dest_order_id = p_order_id
+       AND l.aid_board_id IS NOT NULL
+  LOOP
+    IF v_ab.qty > 0 THEN
+      PERFORM public._restore_aid_board_qty(v_ab.board_id, v_ab.qty, p_operator);
+      v_aid_restored := v_aid_restored + 1;
+    END IF;
+  END LOOP;
+  -- 舊資料：links 沒蓋章但單頭有（新單兩邊都有，這條只是備援）
+  IF v_aid_restored = 0 AND v_order.aid_board_id IS NOT NULL THEN
+    SELECT COALESCE(SUM(i.qty), 0) INTO v_ab_qty
+      FROM customer_order_items i
+     WHERE i.order_id = p_order_id
+       AND i.status IN ('pending','reserved','ready');
+    IF v_ab_qty > 0 THEN
+      PERFORM public._restore_aid_board_qty(v_order.aid_board_id, v_ab_qty, p_operator);
+      v_aid_restored := 1;
+    END IF;
+  END IF;
+
+  v_reason_note := '[cancelled by source: ' || COALESCE(p_reason, '') || ']';
+
+  -- 場景 B：已派貨，要回收 transfer chain
+  IF v_order.status = 'shipping' THEN
+    SELECT id INTO v_terminal_id
+      FROM transfers
+     WHERE customer_order_id = p_order_id
+       AND tenant_id = v_order.tenant_id
+     LIMIT 1;
+
+    -- 沒有掛在此單上的 transfer：
+    --   互助單 → 真的資料不一致，擋下來；
+    --   一般（波次出貨）訂單 → 本來就沒有 per-order transfer，直接往下取消。
+    IF v_terminal_id IS NULL THEN
+      v_is_aid := v_order.transferred_from_order_id IS NOT NULL
+                  OR EXISTS (
+                       SELECT 1 FROM customer_order_items coi
+                        WHERE coi.order_id = p_order_id
+                          AND coi.source = 'aid_transfer'
+                          AND coi.status <> 'cancelled'
+                     );
+      IF v_is_aid THEN
+        RAISE EXCEPTION 'order % is shipping but has no terminal transfer', p_order_id;
+      END IF;
+    END IF;
+
+    IF v_terminal_id IS NOT NULL THEN
+      FOR v_xfer IN
+        WITH RECURSIVE chain_back AS (
+          SELECT * FROM transfers WHERE id = v_terminal_id
+          UNION ALL
+          SELECT t.* FROM transfers t
+            JOIN chain_back c ON c.id = ANY(
+              SELECT id FROM transfers WHERE next_transfer_id = c.id
+            )
+        ),
+        head AS (
+          SELECT id FROM chain_back
+           WHERE id NOT IN (SELECT next_transfer_id FROM transfers WHERE next_transfer_id IS NOT NULL)
+           LIMIT 1
+        ),
+        chain_forward AS (
+          SELECT * FROM transfers WHERE id = (SELECT id FROM head)
+          UNION ALL
+          SELECT t.* FROM transfers t
+            JOIN chain_forward c ON t.id = c.next_transfer_id
+        )
+        SELECT * FROM chain_forward ORDER BY id
+      LOOP
+        IF v_xfer.status = 'received' THEN
+          RAISE EXCEPTION 'transfer % already received, cannot cancel chain', v_xfer.id;
+        END IF;
+
+        IF v_xfer.status = 'shipped' THEN
+          FOR v_ti IN
+            SELECT id, sku_id, qty_shipped FROM transfer_items
+             WHERE transfer_id = v_xfer.id AND qty_shipped > 0
+          LOOP
+            PERFORM rpc_inbound(
+              p_tenant_id       => v_xfer.tenant_id,
+              p_location_id     => v_xfer.source_location,
+              p_sku_id          => v_ti.sku_id,
+              p_quantity        => v_ti.qty_shipped,
+              p_unit_cost       => 0,
+              p_movement_type   => 'transfer_cancel',
+              p_source_doc_type => 'transfer',
+              p_source_doc_id   => v_xfer.id,
+              p_operator        => p_operator
+            );
+          END LOOP;
+        END IF;
+
+        UPDATE transfers
+           SET status = 'cancelled',
+               notes = CASE
+                         WHEN notes IS NULL OR notes = '' THEN v_reason_note
+                         ELSE notes || E'\n' || v_reason_note
+                       END,
+               updated_by = p_operator
+         WHERE id = v_xfer.id;
+        v_cancelled_ids := v_cancelled_ids || v_xfer.id;
+      END LOOP;
+    END IF;
+  END IF;
+
+  -- 若有用儲值金結帳，自動 refund 回會員餘額
+  IF v_order.wallet_paid_amount > 0 AND v_order.member_id IS NOT NULL THEN
+    v_refund_ledger_id := rpc_wallet_refund(
+      v_order.tenant_id,
+      v_order.member_id,
+      v_order.wallet_paid_amount,
+      'customer_order',
+      p_order_id,
+      'order_cancelled: ' || COALESCE(p_reason, '(no reason)'),
+      p_operator
+    );
+    v_refunded_amount := v_order.wallet_paid_amount;
+    -- wallet_paid_amount 保留歷史值，不清零
+  END IF;
+
+  -- 標記訂單 cancelled
+  -- 現貨直配單取消 → 把它開的 DN 減抵單一併作廢。
+  -- 留著不會讓庫存算錯（自由量不看 DN），但 is_order_item_pickup_ready 的
+  -- Path D 是以 (tenant, campaign, store, sku) 整組查有效減抵，而現貨直配全部
+  -- 掛在共用 sentinel 團底下 —— 一張孤兒 DN 會讓**同團同店同 SKU 的其他單**
+  -- （RR- / OV- 容器單也在這個團）憑空通過到貨閘門。
+  IF v_order.order_no LIKE 'SP-%' THEN
+    UPDATE inventory_deduction_notes n
+       SET cancelled_at = NOW(), cancelled_by = p_operator
+     WHERE n.cancelled_at IS NULL
+       AND EXISTS (SELECT 1 FROM inventory_deduction_note_items li
+                    WHERE li.note_id = n.id AND li.order_id = p_order_id);
+  END IF;
+
+  UPDATE customer_orders
+     SET status       = 'cancelled',
+         cancelled_at = NOW(),
+         updated_by   = p_operator,
+         updated_at   = NOW()
+   WHERE id = p_order_id;
+
+  -- ── 來源單品項回補 ──（2026-08-18）
+  -- 部分轉出（rpc_transfer_order_partial）把來源列扣掉了（等量→整列 cancelled、
+  -- 部分→qty 遞減），下面那段只還單頭，品項不會自己長回來 → 取消之後貨在來源單
+  -- 上憑空消失。必須排在單頭 UPDATE **之前**：helper 要靠 source.status 還是不是
+  -- 'transferred_out' 來分辨整單轉出（品項沒被動過，不能重複加）。
+  v_restored := public._restore_transfer_source_items(p_order_id, p_operator, NOW());
+
+  -- ── source order 退回 ──（2026-07-13）
+  -- 先解除轉出鎖定回到 confirmed；若原店的貨其實已到（波次已收 → is_order_pickup_ready），
+  -- 直接推到 ready 讓它立刻可取貨，避免波次早跑完、confirmed 再也不會被 mark_shipping 推進而永遠卡住。
+  v_src_id := v_order.transferred_from_order_id;
+  IF v_src_id IS NOT NULL THEN
+    UPDATE customer_orders
+       SET status                   = 'confirmed',
+           transferred_to_order_id  = NULL,
+           updated_by               = p_operator,
+           updated_at               = NOW()
+     WHERE id = v_src_id
+       AND status = 'transferred_out';
+
+    v_src_pickable := public.is_order_pickup_ready(v_src_id);
+    IF v_src_pickable THEN
+      UPDATE customer_orders
+         SET status     = 'ready',
+             ready_at   = COALESCE(ready_at, NOW()),
+             updated_by = p_operator,
+             updated_at = NOW()
+       WHERE id = v_src_id
+         AND status = 'confirmed';
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'order_id', p_order_id,
+    'cancelled_transfer_ids', to_jsonb(v_cancelled_ids),
+    'source_order_reverted', v_src_id IS NOT NULL,
+    'source_order_pickable', v_src_pickable,
+    'source_items_restored', v_restored,
+    'wallet_refunded',       v_refunded_amount,
+    'wallet_refund_ledger_id', v_refund_ledger_id,
+    'aid_board_restored',    v_aid_restored
+  );
+END;
+$fn$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_cancel_aid_order(bigint, text, uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_cancel_aid_order(bigint, text, uuid) IS
+  '取消轉入單：還原來源單品項與單頭、取消調撥鏈、退儲值金、歸還互助板數量。'
+  '可取消狀態＝pending/confirmed/shipping，外加兩種 ready 例外：SP- 現貨直配、'
+  '同店變更取貨人（轉出店＝接收店、無調撥單，貨沒離開本店）。'
+  '基底 20260824080000。';


### PR DESCRIPTION
## 做了什麼

### 一、轉移清單改成表格

從卡片改成表格（沿用共用的 `DataTable`，與 `/orders` 同一套樣式）：

| 商品 | 轉出 → 轉入 | 種類 | 來源 | 數量 | 單號 | 日期 | 狀態 | 操作 |

- **兩端一律寫出來**：「松山店 → 南平店」，不再用「轉予 X／來自 X」只顯示對面那一家（老闆：「直接寫松山店 → 南平店，不要給予」）。同店分頁那一欄則是「原客人 → 新客人」。
- 欄寬調整讓「操作」在 1280px 內看得到（實測按鈕右緣 1248 < 1280）：商品欄縮窄、日期省年份（完整時間放 tooltip）、來源單改短碼、同店 chip 縮成「🔁 同店」。

### 二、同店變更取貨人可以撤銷

`rpc_cancel_aid_order` 本來就把該做的都做完了（還原來源單品項 `_restore_transfer_source_items`、把來源單頭從 `transferred_out` 退回 confirmed／ready、取消轉入單），只是**狀態守衛擋掉 `ready`** —— 而同店單是 mirror 來源單的狀態，實務上幾乎都是 ready，所以一律撤不掉。

`20260825050000` 加第三個例外：**同店（轉出店＝接收店）且沒有未取消的調撥單**。

安全性：同店不會有調撥單（`_air_ship_order_items` 判到同 location 就回 NULL），也沒有任何庫存異動要沖（庫存只在 `rpc_record_pickup` 那一刻扣）；**已取走的（partially_completed／completed）維持擋下**，那要走退貨。

### 三、其他修正

- **「Peggy → Peggy」修掉**：轉入單的 `nickname_snapshot` 是轉單 RPC 從來源單**原封複製**過去的，所以接收人那側顯示成原客人。改成以**會員**為準（線上實測該單暱稱是 Peggy💕、會員其實是 Alex Chen11）。
- **歷史移到最後一個分頁**，且只讀 **20 筆**、可「載入更多」（回的筆數 < 要求筆數就不畫按鈕，不必多打一發 count）。進行中維持一次撈完 —— 那是每天要看的工作清單。
- 三處載入狀態從裸文字改成 `Spinner` / `LoadingBlock`。

## 上線危險

- 做了：`20260825050000` 只放寬 `rpc_cancel_aid_order` 的狀態守衛（多一個同店例外），**已套正式庫**；前端一支檔案。
- 不做：不動轉單／退回 RPC、不動庫存與調撥、不改跨店的取消規則。
- 回退：重跑 `20260824080000_cancel_restores_aid_board.sql`（檔頭有寫），前端 revert 本 PR。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `check-sql-syntax.cjs` 過。正式庫 `BEGIN…ROLLBACK` 乾跑，拿**線上真實**的同店 ready 單測：撤銷成功、來源單回到 `confirmed`；反面測試「已取貨完成的單」仍被擋下。確認後才正式套用。
- Playwright fixture：表格 10 項（表頭 9 欄齊全、列數、來源 tag、同店表頭與客人欄、撤銷鈕存在且在畫面內、無隨貨單鈕、歷史排最後、無 JS 錯誤）、總倉 4 項、分店 4 項（含「一律寫出兩端」「不再出現轉予／來自」）全過。
- tsc --noEmit 乾淨；eslint 7 則與 base 相同（全在未改動的 effect）；`npm run build` 綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAhCJKvHw5Z9FoY7V8kse6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAhCJKvHw5Z9FoY7V8kse6)_