### PR TITLE
訂單頁：貨已到店的品項不再顯示「從庫存配貨」

### DIFF
--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -1577,9 +1577,13 @@ export function OrderDetail({
                           {/* 從庫存配貨：把取貨門市的現貨指派給這一行 → 品項變「可取貨」。
                               不扣庫存、不結案（客人到店在取貨頁交貨才扣帳）。
                               草稿沒存的時候先擋下：這一顆會動到 qty（配不滿會拆行），
-                              和未儲存的數量草稿混在一起會互蓋。 */}
+                              和未儲存的數量草稿混在一起會互蓋。
+                              ⚠ 貨已經到店、這一行本來就可以交貨（取貨閘門放行）時不要出這顆 ——
+                              按了也不會有任何改變（閘門已經是 true），店員只會誤以為
+                              「還要再配一次才發得出去」。2026-08-25 松山回報。 */}
                           {canAssignStock
                             && !isPicked
+                            && itemReady.get(it.id) !== true
                             && !["cancelled", "expired"].includes(it.status) && (
                             <SpinButton
                               onClick={() => {


### PR DESCRIPTION
## 做了什麼

閘門已經放行的品項還掛著「📦 從庫存配貨」，按了也不會有任何改變（DN 覆蓋是 Path D，閘門本來就已經是 `true`），店員反而誤以為「還要再配一次才發得出去」。

2026-08-25 松山回報 `GRP-20260806-016-0030`：單頭已是「可取貨」、分店收貨完成，四個品項線上實測全是 `is_order_item_pickup_ready = true`，按鈕照樣出現。

判準用**該行自己的取貨閘門**（`v_order_item_pickup_ready`，畫面上已經在載了），不是單頭狀態 —— `ready` 單裡混著待補貨的行時，那些行才正是需要從庫存配貨的，用單頭判會把它們一起藏掉。

「↩️ 取消配貨」刻意不套同一個條件：配過貨的行閘門必為 `true`，跟著藏就沒人收得回來了。

## 上線危險

- **做了**：純顯示條件，一顆按鈕在「已可交貨」的行上不再出現。沒有 SQL、沒有權限、沒有資料異動。
- **不做**：店員繼續在已到貨的行上看到「從庫存配貨」，按下去沒有任何效果（會多開一張沒有意義的 DN 覆蓋）。
- **回退**：revert 這一個 commit（單檔單 hunk）。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- 線上資料確認回報單的四個品項 `is_order_item_pickup_ready` / `v_order_item_pickup_ready.pickup_ready` 皆為 `true` → 正是本 PR 要藏掉的情形。
- Playwright + fixture（`apps/admin:verify`）：閘門放行的品項只剩「↩️ 取消配貨」，還在等貨的品項仍有「📦 從庫存配貨」。
- `tsc --noEmit` 乾淨；`npm run build` 綠（含 Safari 15.6 chunk 檢查）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4VS8PnQad8tSU1TaauxuB)_