### PR TITLE
互助板：「已取消」自成一個分頁，不再混在已簽收裡

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -16,7 +16,7 @@ import { shortOrderNo } from "@/lib/orderTitle";
 import { translateRpcError } from "@/lib/rpcError";
 import {
   TRANSFER_LINK_SELECT, type TransferLink,
-  activeQty, aidRouteLabel, aidStageLabel, isAidInFlight, linkItems,
+  activeQty, aidRouteLabel, aidStageLabel, isAidDead, isAidInFlight, linkItems,
 } from "@/lib/aidTransfer";
 import { orderStatusLabel } from "@/lib/orderStatus";
 
@@ -787,8 +787,10 @@ function ProvidedList({ stores, direction }: {
   const myStoreId = useUserBranchStoreId(stores);
   const [rows, setRows] = useState<ProvidedRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  // 只有跨店才分階段：transit=運送中（預設）、done=已簽收。同店沒有配送階段。
-  const [bucket, setBucket] = useState<"transit" | "done">("transit");
+  // 只有跨店才分階段：transit=運送中（預設）、done=已簽收、dead=已取消。
+  // 已取消要自成一格：混在「已簽收」裡會讓人以為那些貨都送到了
+  // （2026-08-25 回報：「對方已簽收 (8)」其實有 5 筆是已取消）。同店沒有配送階段。
+  const [bucket, setBucket] = useState<"transit" | "done" | "dead">("transit");
   const [busyLink, setBusyLink] = useState<number | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
 
@@ -960,16 +962,19 @@ function ProvidedList({ stores, direction }: {
   if (rows === null) return <LoadingBlock />;
 
   const inFlight = rows.filter((r) => isAidInFlight(r.dest_status));
-  const done = rows.filter((r) => !isAidInFlight(r.dest_status));
+  const dead = rows.filter((r) => isAidDead(r.dest_status));
+  const done = rows.filter((r) => !isAidInFlight(r.dest_status) && !isAidDead(r.dest_status));
   // 同店沒有配送階段（商品未離開本店）→ 不分籤，整份一起看
-  const shown = direction === "same" ? rows : bucket === "done" ? done : inFlight;
+  const shown = direction === "same"
+    ? rows
+    : bucket === "done" ? done : bucket === "dead" ? dead : inFlight;
 
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-2">
         {direction !== "same" && (
           <div className="inline-flex w-fit overflow-hidden rounded-md border border-zinc-300 text-xs dark:border-zinc-700">
-            {(["transit", "done"] as const).map((v) => (
+            {(["transit", "done", "dead"] as const).map((v) => (
               <SpinButton
                 key={v}
                 type="button"
@@ -985,7 +990,9 @@ function ProvidedList({ stores, direction }: {
                     一堆沒動過的品項，2026-08-24 就被誤讀成「OV-2-0001 變已完成」。 */}
                 {v === "transit"
                   ? `運送中 (${inFlight.length})`
-                  : `${myStoreId != null && direction === "out" ? "對方已簽收" : "已簽收"} (${done.length})`}
+                  : v === "dead"
+                    ? `已取消 (${dead.length})`
+                    : `${myStoreId != null && direction === "out" ? "對方已簽收" : "已簽收"} (${done.length})`}
               </SpinButton>
             ))}
           </div>
@@ -1009,9 +1016,11 @@ function ProvidedList({ stores, direction }: {
               ? (myStoreId == null
                   ? "無已簽收的轉移紀錄"
                   : `無${direction === "out" ? "對方已簽收的轉出" : "已簽收的轉入"}紀錄`)
-              : (myStoreId == null
-                  ? "目前無運送中的轉移"
-                  : `目前無運送中的${direction === "out" ? "轉出" : "轉入"}`)}
+              : bucket === "dead"
+                ? `無已取消的${direction === "out" ? "轉出" : "轉入"}紀錄`
+                : (myStoreId == null
+                    ? "目前無運送中的轉移"
+                    : `目前無運送中的${direction === "out" ? "轉出" : "轉入"}`)}
         </div>
       ) : (
 <Table>

--- a/apps/admin/src/lib/aidTransfer.ts
+++ b/apps/admin/src/lib/aidTransfer.ts
@@ -26,6 +26,16 @@ export function isAidInFlight(status: string): boolean {
   return (AID_IN_FLIGHT_STATUSES as readonly string[]).includes(status);
 }
 
+// 這一趟沒走成（取消提供 / 取消轉入 / 退回原店 / 逾期）。
+// 互助板的分頁用它把「已取消」從「已簽收」裡拆出來 —— 兩者混在一起時，
+// 看起來像一堆已送達的紀錄，實際上大半是取消掉的（2026-08-25 回報：
+// 「對方已簽收 (8)」裡有 5 筆是已取消）。
+export const AID_DEAD_STATUSES = ["cancelled", "expired"] as const;
+
+export function isAidDead(status: string): boolean {
+  return (AID_DEAD_STATUSES as readonly string[]).includes(status);
+}
+
 // ---- 訂單轉移連結（customer_order_transfer_links） ----
 
 export const TRANSFER_LINK_SELECT =


### PR DESCRIPTION
## 做了什麼

互助交流板「我轉出／我接收」原本只有兩格：運送中 / 已簽收。取消掉的那幾趟因為「不在運送中」全部掉進**已簽收**那一格 —— 畫面上寫「對方已簽收 (8)」，點進去有 5 筆狀態是「已取消」，看起來像一堆貨都送到了，實際上大半沒走成（2026-08-25 回報）。

- 新增第三格「已取消 (N)」：`cancelled` / `expired`。
- 「已簽收」只留真的送達的（`ready` / `partially_completed` / `completed` / …）。
- 判準收在 `lib/aidTransfer` 的 `isAidDead()`，跟既有的 `isAidInFlight()` 放同一支（那支檔頭已經寫過「散在三個地方就會各走各的」的教訓）。三格互斥、不重疊、加總＝全部。
- 空清單文案跟著補一句；「同店變更取貨人」維持不分頁（貨沒離開本店，本來就沒有配送階段）。

## 上線危險

- **做了**：純前端顯示分組，同一份資料換一種分格。沒有 SQL、沒有 RPC、沒有權限異動；每一列的狀態徽章、操作鈕邏輯完全沒動。
- **不做**：已取消的紀錄繼續混在「已簽收」裡，店家把沒送成的當成已送達。
- **回退**：revert 這一個 commit（兩個檔案、純顯示）。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

Playwright + fixture（`apps/admin:verify`）餵 6 筆轉移（2 運送中 / 1 ready / 1 completed / 1 cancelled / 1 expired）：

- 分頁計數：`運送中 (2) | 已簽收 (2) | 已取消 (2)` —— 三格互斥、加總等於全部。
- 點進「已取消」只列到 cancelled / expired 兩筆，頁面上不再出現「收貨店已簽收 / 已取貨完成」字樣。
- 無 console error。

`tsc --noEmit` 乾淨；`npm run build` 綠（含 Safari 15.6 chunk 檢查）；`eslint` 對這兩個檔案的錯誤數與改動前相同（7 個既有問題，沒有新增）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4VS8PnQad8tSU1TaauxuB)_