### PR TITLE
互助頁：對方簽收後轉出方不能再撤銷；撤銷 icon 改用 ↩

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -947,14 +947,8 @@ function ProvidedList({ stores, direction }: {
       ? `撤銷本次變更（${items}）？\n商品將掛回原客人 ${r.from_party ?? ""} 的訂單。`
       : kind === "cancel"
       ? `取消本次轉出（${items}）？\n商品將退回來源訂單，互助板貼文的數量也會一併還原。`
-      : direction === "in"
-        // 收貨方退回：貨在自己架上，按下去就是把它送回去
-        ? `將本批商品退回 ${r.source_store}？\n系統將建立反向調撥單，來源訂單與貼文數量一併還原。`
-        // 轉出方要求退回：貨在對方店裡，按下去會從**對方**店出庫、送回本店。
-        // 對方沒有按鈕可擋，所以話要講白（老闆 2026-08-25：兩邊都要能退回）。
-        : `要求 ${r.dest_store} 將本批商品退回本店（${items}）？\n` +
-          `系統將立即建立反向調撥單，自 ${r.dest_store} 出庫送回本店，來源訂單與貼文數量一併還原。\n` +
-          `商品目前仍在對方店內，請先與對方確認後再執行。`;
+      // 退回只由收貨方發動（貨在自己架上）—— 已簽收之後轉出方不再有退回鈕
+      : `將本批商品退回 ${r.source_store}？\n系統將建立反向調撥單，來源訂單與貼文數量一併還原。`;
     if (!confirm(what)) return;
     setBusyLink(r.linkId);
     try {
@@ -1030,8 +1024,8 @@ function ProvidedList({ stores, direction }: {
             : myStoreId == null
               ? "全站店對店轉移（總倉視角），含互助認領與訂單轉單"
               : direction === "out"
-                ? "本店轉出的商品（互助認領＋訂單轉單）。未送達可「取消提供」，已送達可「要求退回」"
-                : "其他分店轉入本店的商品（互助認領＋訂單轉單）。未送達可「取消轉入」，已送達可「退回原店」"}
+                ? "本店轉出的商品（互助認領＋訂單轉單）。未簽收可「取消提供」；對方簽收後就不能再撤銷，需由對方退回"
+                : "其他分店轉入本店的商品（互助認領＋訂單轉單）。未簽收可「取消轉入」，已簽收可「退回原店」"}
         </span>
       </div>
 
@@ -1139,7 +1133,8 @@ function ProvidedList({ stores, direction }: {
                           title="撤銷變更：把商品掛回原客人的訂單"
                           className="h-8 w-8 shrink-0 rounded-md border text-sm leading-none disabled:opacity-50 flex items-center justify-center border-red-300 text-red-700 hover:bg-red-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950"
                         >
-                          {busyLink === r.linkId ? "…" : "⎌"}
+                          {/* ⎌ (U+238C) 多數字型沒有字，會變成豆腐方框 → 用 ↩ */}
+                          {busyLink === r.linkId ? "…" : "↩"}
                         </SpinButton>
                       ) : r.link_count !== 1 ? (
                         <span
@@ -1191,21 +1186,17 @@ function ProvidedList({ stores, direction }: {
                         </span>
                       )
                     )}
-                    {/* 已到貨（ready）→ 兩邊都能退回（老闆 2026-08-25）。
-                        收貨方＝貨在自己架上，直接送回；轉出方＝要求對方退回，
-                        同一支 rpc_return_aid_order（它沒有「限收貨店」的守衛），
-                        會從對方店出庫、建反向調撥。文案在 cancelLeg 裡分開講。 */}
-                    {r.dest_status === "ready" && (
+                    {/* 已簽收（ready）→ **只有收貨方**能退回（老闆 2026-08-25：
+                        「收貨店已簽收 不能再撤銷了」）。貨已經點收進對方店裡，
+                        這一趟就成立了；要退只能由手上有貨的收貨店自己送回，
+                        轉出方不再出「要求退回」。未簽收前兩邊都還能取消（上一段）。 */}
+                    {r.dest_status === "ready" && direction === "in" && (
                       r.link_count === 1 ? (
                         <SpinButton
                           type="button"
                           disabled={busyLink != null}
                           onClick={() => cancelLeg(r, "return")}
-                          title={
-                            direction === "in"
-                              ? "把這批貨送回原店（建反向調撥、來源單還原、貼文數量還回去）"
-                              : "貨已經在對方店裡：按下去會從對方店出庫、送回本店。請先跟對方講一聲"
-                          }
+                          title="把這批貨送回原店（建反向調撥、來源單還原、貼文數量還回去）"
                           className="h-8 w-8 shrink-0 rounded-md border text-sm leading-none disabled:opacity-50 flex items-center justify-center border-red-300 text-red-700 hover:bg-red-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950"
                         >
                           {busyLink === r.linkId ? "…" : "↩"}


### PR DESCRIPTION
## 做了什麼

### 一、對方簽收後，轉出方不能再撤銷

老闆回報：「收貨店已簽收 不能再撤銷了」。

貨已經點收進對方店裡，這一趟就成立了 —— 之前「我轉出」那側在 `ready` 仍會出「要求退回」，等於可以單方面從對方店把貨拉回來。現在拿掉：

| 這一趟的狀態 | 我轉出 | 我接收 |
|---|---|---|
| 未簽收（pending／confirmed／shipping） | ✕ 取消提供 | ✕ 取消轉入 |
| **已簽收（ready）** | **（無）** | ↩ 退回原店 |

要退貨只能由**手上有貨的收貨店**自己送回。連帶把確認對話框文案與兩個分頁的說明改成同一套口徑（「未簽收可…；對方簽收後就不能再撤銷，需由對方退回」）。

### 二、撤銷 icon 改用 ↩

`⎌`（U+238C）多數字型沒有那個字，畫面上是豆腐方框（老闆截圖）。改用 `↩`。

## 上線危險

- 做了：純前端，互助頁一支檔案；只是**收掉**一個按鈕，不新增任何操作路徑。
- 不做：不動 `rpc_return_aid_order` 本身（收貨方仍照原路徑退回）、不動未簽收的取消規則、無 DB 變更。
- 回退：revert 本 PR 即可（會回到轉出方也能要求退回的行為）。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- Playwright fixture（綁分店帳號，跨店已簽收各一筆）：**我轉出・已簽收沒有退回鈕**、列印鈕仍在、**我接收・已簽收保留「退回原店」**、無 JS 錯誤。
- 既有суite 全過：貼文表 7 項、轉移表 10 項、手機 4 項。
- 本分支已 rebase 到含 #847（已取消分頁）、#848 的最新 main，確認兩邊改動並存無衝突。
- tsc --noEmit 乾淨；eslint 7 則與 base 相同；`npm run build` 綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAhCJKvHw5Z9FoY7V8kse6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAhCJKvHw5Z9FoY7V8kse6)_