### PR TITLE
互助板：手動新增現貨的商品改回選填（可手打、也可從商品庫選）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -711,6 +711,20 @@ EXECUTE 還被 REVOKE 著 = 使用者按下去拿到 `permission denied for func
   扣量、`qty_available`/`qty_remaining` 一起覆寫」的假設就不成立了 ——
   改總量要保留已認領量（`remaining = 新 available − 已認領`）。
 
+### 手動新增現貨的「商品」是**選填**，不要再改回必填
+
+20260816000000 的前端把它改成必填（不選就沒人能認領），2026-08-26 依老闆指示
+改回選填（要能隨意手打，也能從商品庫選）。看到那支 migration 檔頭寫「商品改必填」
+不要照著改回去 —— DB 從頭到尾都收 `sku_id IS NULL`（`rpc_post_manual_spot`
+的 `p_sku_id` 可為 NULL，只要求有 `spot_title`），擋著的一直只是前端那行檢查。
+
+沒選 SKU 的貼文＝**純公告**：`rpc_claim_manual_spot` 直接擋（沒訂單可轉），
+`customer_order_items.sku_id` 又是 NOT NULL → 也開不了單、配不給客人，
+因此不進庫存 / 月結 / 銷售報表，只能靠會員按「用 LINE 詢問店家」線下處理。
+要救就用「✏️ 修改內容」補選商品（`p_sku_id`，NULL = 不動、不是清除）。
+⚠ 補選時挑錯 SKU 會扣錯商品的庫存：認領走 `_air_ship_order_items`，
+`p_allow_negative => TRUE`，扣成負的也不會擋。
+
 ### 新開 order_no 前綴之前，先查線上有沒有人用了
 
 `SP-` 已經被「現貨直配」(`rpc_create_spot_sale`) 用掉了，而**那支 RPC 在

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -419,7 +419,7 @@ export default function MutualAidPage() {
                     )}
                     {/* 沒選商品的手動現貨別店認領不了 —— 在列表就標出來，
                         不用點進去才發現（20260816000000） */}
-                    {p.post_type === "offer" && p.sku_id == null && (
+                    {p.post_type === "offer" && p.status === "active" && p.sku_id == null && (
                       <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800 dark:bg-amber-950 dark:text-amber-300" title="沒有選商品，別的分店無法認領；請點進貼文用「✏️ 修改內容」補選">
                         待補商品
                       </span>
@@ -1526,9 +1526,11 @@ function ManualSpotModal({
     setErr(null);
     if (!storeId) { setErr("請選釋出店"); return; }
     const titleTrim = title.trim();
-    // 商品必選：別店認領＝把這個 SKU 轉單過去，沒 SKU 就沒東西可以轉
-    // （20260816000000；主檔沒有的商品請先去「商品」頁建一筆）
-    if (!picked) { setErr("請從商品庫選商品 —— 沒選商品的話別的分店無法認領"); return; }
+    // 商品選填：主檔有的就挑 SKU（挑了才能被別店認領、才配得給客人）；
+    // 店裡自製 / 臨時進的貨主檔根本沒有，允許純手打，那種貼文只能當公告。
+    // 沒 SKU 時標題是會員端唯一顯示得出來的東西 → 必填
+    // （DB 的 chk_aid_board_displayable 也會擋，這裡先講人話）
+    if (!picked && titleTrim === "") { setErr("沒有從商品庫選商品時，商品標題必填"); return; }
     const qtyN = Number(qty);
     if (!Number.isFinite(qtyN) || qtyN <= 0) { setErr("數量需 > 0"); return; }
     let priceN: number | null = null;
@@ -1580,8 +1582,9 @@ function ManualSpotModal({
         <p className="rounded-md border border-emerald-200 bg-emerald-50/50 p-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300">
           直接上架店裡現有的東西，不需要來源訂單。名稱 / 說明 / 圖片都可以自己改寫。
           <br />
-          <strong>商品要從商品庫選</strong>：別店認領＝把這個商品轉單過去，沒選就沒東西可以轉
-          （主檔還沒有的商品，請先到「商品」頁建一筆）。
+          <strong>商品庫有的請盡量選</strong>：選了才能被別店認領、才配得給客人（會走訂單、扣庫存、進月結）。
+          店裡自製、臨時進的貨主檔沒有，可以不選、直接手打標題 —— 但那種貼文只能當公告，
+          之後要認領或開單得先用「✏️ 修改內容」補選商品。
         </p>
 
         <label>
@@ -1598,11 +1601,11 @@ function ManualSpotModal({
 
         <div>
           <span className="mb-1 block text-xs text-zinc-500">
-            從商品庫選商品 <span className="text-red-500">*</span>
-            <span className="ml-1 text-zinc-400">（帶出名稱與圖片；別店要認領一定要有它）</span>
+            從商品庫選商品
+            <span className="ml-1 text-zinc-400">（帶出名稱與圖片；別店要認領、要配給客人一定要有它）</span>
           </span>
           <SkuSearchInput value={picked} onChange={pickSku} />
-          {picked && (
+          {picked ? (
             <SpinButton
               type="button"
               onClick={() => setPicked(null)}
@@ -1610,6 +1613,10 @@ function ManualSpotModal({
             >
               清除選擇，重新搜尋
             </SpinButton>
+          ) : (
+            <p className="mt-1 text-[11px] text-amber-600 dark:text-amber-400">
+              不選也可以上架（純公告）：會員看得到、可以用 LINE 問，但別店認領不了、也不能配給客人。
+            </p>
           )}
         </div>
 
@@ -2577,7 +2584,7 @@ function ThreadModal({
                     ✋ 我要認領
                   </SpinButton>
                 )}
-                {post.post_type === "offer" && !canClaim && (
+                {post.post_type === "offer" && post.status === "active" && isManual && savedSkuId == null && (
                   <span className="self-center text-[11px] text-amber-600 dark:text-amber-400">
                     這則還沒選商品 → 別店認領不了，請按「✏️ 修改內容」補選商品
                   </span>


### PR DESCRIPTION
## 做了什麼

「➕ 手動新增現貨」的商品欄位改回**選填**：主檔有的就從商品庫選，店裡自製 / 臨時進的貨可以直接手打標題。

20260816000000 那次為了讓別店認領得到，把商品改成必填，等於逼店家先去「商品」頁建一筆才能上架。改回選填後兩種都能用：

- **選了 SKU**：跟以前完全一樣 —— 別店按「✋ 我要認領」走 `rpc_claim_manual_spot`（建 AB- 載體單 → 轉單），也配得給客人。
- **沒選（純手打）**：純公告。會員在現貨專區看得到、能按「用 LINE 詢問店家」，但別店認領不了、也開不了單；之後要認領再用「✏️ 修改內容」補選商品（既有功能）。

**DB 端一行都沒動** —— `rpc_post_manual_spot` 的 `p_sku_id` 從 20260802000040 起就可以是 NULL（只要求有 `spot_title`，對齊 `chk_aid_board_displayable`），擋著的一直只有前端那行檢查。所以本 PR 沒有 migration。

改動細節：

- 上架表單：商品欄拿掉必填星號；改成「沒選商品時標題必填」（不然會噴 RPC 的英文錯誤 `manual spot without sku_id requires spot_title`）
- 沒選商品時當場在欄位下方提醒「純公告：別店認領不了、也不能配給客人」，不用貼完才發現
- 順手修既有小 bug：貼文詳情那句「這則還沒選商品 → 別店認領不了」原本只看 `!canClaim`，已結束 / 已認領的貼文也會誤顯示；列表的「待補商品」標記同理，只有進行中的貼文才是待辦
- CLAUDE.md 記一條：商品是選填、不要再照 20260816000000 的檔頭改回必填，並寫下沒 SKU 的貼文有哪些事做不到

## 上線危險

- 做了：手打的貼文（`sku_id IS NULL`）無法被別店認領、無法配給客人開單，因此不進庫存 / 月結 / 銷售報表 —— 這是 20260816000000 之前的既有行為，資料模型與各下游查詢本來就吃得下 `sku_id IS NULL`（會員端 `list_spot_products` / `get_spot_product`、admin 列表、列印頁都已處理 null）。店家若想事後補救，「✏️ 修改內容」可補選商品。
- 不做：維持必填的話，店裡自製 / 臨時進的貨得先去建商品主檔才貼得上來，店家實務上會直接放棄使用這個功能。
- 回退：`git revert` 本 PR 即可（純前端 + 文件，沒有 migration、沒有線上 SQL）。已經貼出去的手打貼文不會壞，只是新貼文又要求選商品。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `npx tsc --noEmit`（apps/admin）：通過
- `npm run build`（apps/admin，含 `check-bundle-browser-support`）：通過，103 支 chunk 都能被 Safari 15.6 解析
- `npx eslint` 該檔：7 個 error 與改動前完全相同（都是既有的 `react-hooks/set-state-in-effect`，不在本次改動的行上）

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwT7QPv9gRy6S7R28T18WV)_