### PR TITLE
日結報表：統計已完成／部分取貨已取走的金額

### DIFF
--- a/apps/admin/src/app/(protected)/finance/daily/page.tsx
+++ b/apps/admin/src/app/(protected)/finance/daily/page.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+// 日結報表：依日期 × 分店統計「已取走品項」的金額（已完成 + 部分取貨已取走的部分）。
+// 口徑 = rpc_daily_pickup_settlement（picked_up 逐行、qty×單價、不扣折扣、
+// 排除內部容器單），與 /orders KPI「今日取貨金額」同一套，兩邊數字對得起來。
+// 分店帳號鎖自己店（比照 /pickup 的 branchLocked 慣例）；HQ 可切全部分店。
+
+import { useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
+import { useMyStores, useRole } from "@/lib/role";
+import { orderStatusLabel } from "@/lib/orderStatus";
+import { withBasePath } from "@/lib/basePath";
+import { DatePicker } from "@/components/DatePicker";
+import SpinButton from "@/components/SpinButton";
+
+type Store = { id: number; code: string; name: string };
+
+type DayRow = {
+  ymd: string;
+  store_id: number;
+  store_name: string;
+  orders: number;
+  qty: number;
+  amount: number;
+  completed_orders: number;
+  completed_amount: number;
+  partial_orders: number;
+  partial_amount: number;
+  other_amount: number;
+};
+
+type OrderRow = {
+  ymd: string;
+  store_id: number;
+  store_name: string;
+  order_id: number;
+  order_no: string;
+  status: string;
+  member_name: string | null;
+  item_count: number;
+  qty: number;
+  amount: number;
+  picked_at: string;
+};
+
+type Report = {
+  date_from: string;
+  date_to: string;
+  days: DayRow[];
+  orders: OrderRow[];
+  orders_total: number;
+  orders_truncated: boolean;
+};
+
+function localYmd(d = new Date()): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
+}
+
+function addDays(ymd: string, n: number): string {
+  const d = new Date(`${ymd}T12:00:00`);
+  d.setDate(d.getDate() + n);
+  return localYmd(d);
+}
+
+function money(n: number): string {
+  return `$${Math.round(Number(n)).toLocaleString()}`;
+}
+
+export default function DailySettlementPage() {
+  const today = localYmd();
+  const [dateFrom, setDateFrom] = useState(today);
+  const [dateTo, setDateTo] = useState(today);
+  const [storeFilter, setStoreFilter] = useState<string>("");
+
+  const [stores, setStores] = useState<Store[]>([]);
+  const [report, setReport] = useState<Report | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 分店帳號鎖自己店（比照 /pickup）：錢的報表不給跨店看
+  const role = useRole();
+  const myStores = useMyStores();
+  const branchLocked =
+    (role === "store_manager" || role === "store_staff") &&
+    myStores.length > 0 &&
+    !myStores.includes("總倉");
+  const branchStoreId = useUserBranchStoreId(stores);
+  useDefaultStoreFromUser(stores, storeFilter, setStoreFilter, !branchLocked);
+
+  useEffect(() => {
+    if (branchLocked && branchStoreId != null && storeFilter !== String(branchStoreId)) {
+      setStoreFilter(String(branchStoreId));
+    }
+  }, [branchLocked, branchStoreId, storeFilter]);
+
+  useEffect(() => {
+    (async () => {
+      const sb = getSupabase();
+      const { data } = await sb.from("stores").select("id, code, name").order("name");
+      setStores((data ?? []) as Store[]);
+    })();
+  }, []);
+
+  useEffect(() => {
+    // 分店帳號要等鎖店解析完成才打，避免先閃一下全站金額
+    if (branchLocked && branchStoreId == null) return;
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data, error: e1 } = await sb.rpc("rpc_daily_pickup_settlement", {
+          p_store_id: storeFilter ? Number(storeFilter) : null,
+          p_date_from: dateFrom,
+          p_date_to: dateTo,
+        });
+        if (cancelled) return;
+        if (e1) { setError(e1.message); return; }
+        setError(null);
+        setReport(data as Report);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [storeFilter, dateFrom, dateTo, branchLocked, branchStoreId]);
+
+  const totals = useMemo(() => {
+    const t = {
+      orders: 0, qty: 0, amount: 0,
+      completedOrders: 0, completedAmount: 0,
+      partialOrders: 0, partialAmount: 0,
+      otherAmount: 0,
+    };
+    for (const d of report?.days ?? []) {
+      t.orders += Number(d.orders);
+      t.qty += Number(d.qty);
+      t.amount += Number(d.amount);
+      t.completedOrders += Number(d.completed_orders);
+      t.completedAmount += Number(d.completed_amount);
+      t.partialOrders += Number(d.partial_orders);
+      t.partialAmount += Number(d.partial_amount);
+      t.otherAmount += Number(d.other_amount);
+    }
+    return t;
+  }, [report]);
+
+  const multiDay = dateFrom !== dateTo;
+  const showStoreCol = !storeFilter;
+  const lockedStoreName = branchLocked
+    ? stores.find((s) => s.id === branchStoreId)?.name ?? myStores[0] ?? ""
+    : "";
+
+  function setRange(from: string, to: string) {
+    setDateFrom(from);
+    setDateTo(to);
+  }
+
+  const quickRanges: { label: string; from: string; to: string }[] = [
+    { label: "今天", from: today, to: today },
+    { label: "昨天", from: addDays(today, -1), to: addDays(today, -1) },
+    { label: "近 7 天", from: addDays(today, -6), to: today },
+    { label: "本月", from: `${today.slice(0, 8)}01`, to: today },
+  ];
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header>
+        <h1 className="text-xl font-semibold">日結報表</h1>
+        <p className="text-sm text-zinc-500">
+          每天實際取走的貨（已完成＋部分取貨已取走的部分）＝當天收的現金。
+          {loading ? " 載入中…" : ""}
+        </p>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {quickRanges.map((r) => {
+          const active = dateFrom === r.from && dateTo === r.to;
+          return (
+            <SpinButton
+              key={r.label}
+              onClick={() => setRange(r.from, r.to)}
+              className={`rounded-md border px-3 py-1.5 text-sm ${
+                active
+                  ? "border-blue-500 bg-blue-50 font-medium text-blue-700 dark:border-blue-600 dark:bg-blue-950 dark:text-blue-300"
+                  : "border-zinc-300 hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              }`}
+            >
+              {r.label}
+            </SpinButton>
+          );
+        })}
+        <div className="flex items-center gap-1 text-sm">
+          <DatePicker
+            value={dateFrom}
+            onChange={(v) => { setDateFrom(v); if (v > dateTo) setDateTo(v); }}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-left text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <span className="text-zinc-400">～</span>
+          <DatePicker
+            value={dateTo}
+            onChange={(v) => { setDateTo(v); if (v < dateFrom) setDateFrom(v); }}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-left text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </div>
+        {branchLocked ? (
+          <span className="rounded-md border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-sm text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">
+            {lockedStoreName || "本店"}
+          </span>
+        ) : (
+          <select
+            value={storeFilter}
+            onChange={(e) => setStoreFilter(e.target.value)}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="">全部分店</option>
+            {stores.map((s) => (
+              <option key={s.id} value={s.id}>{s.code} {s.name}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Stat label="取貨金額" value={money(totals.amount)} accent="positive" />
+        <Stat
+          label={`已完成訂單（${totals.completedOrders} 張）`}
+          value={money(totals.completedAmount)}
+        />
+        <Stat
+          label={`部分取貨訂單（${totals.partialOrders} 張）`}
+          value={money(totals.partialAmount)}
+        />
+        <Stat label="取貨件數" value={`${Math.round(totals.qty).toLocaleString()} 件`} />
+      </div>
+      {totals.otherAmount > 0 && (
+        <p className="text-xs text-amber-600">
+          ⚠ 另有 {money(totals.otherAmount)} 取貨掛在非「已完成／部分取貨」狀態的訂單上（可能剛被轉單或人工改過狀態）。
+        </p>
+      )}
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          <p className="font-mono text-xs">{error}</p>
+        </div>
+      )}
+
+      {(multiDay || showStoreCol) && (
+        <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+          <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+            <thead className="bg-zinc-50 dark:bg-zinc-900">
+              <tr>
+                <Th>日期</Th>
+                {showStoreCol && <Th>分店</Th>}
+                <Th className="text-right">單數</Th>
+                <Th className="text-right">件數</Th>
+                <Th className="text-right">已完成</Th>
+                <Th className="text-right">部分取貨</Th>
+                <Th className="text-right">取貨金額</Th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {report === null ? (
+                <tr><td colSpan={7} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              ) : report.days.length === 0 ? (
+                <tr><td colSpan={7} className="p-6 text-center text-zinc-500">這段期間沒有取貨。</td></tr>
+              ) : report.days.map((d) => (
+                <tr key={`${d.ymd}-${d.store_id}`} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
+                  <Td className="text-xs">{d.ymd}</Td>
+                  {showStoreCol && <Td className="text-xs">{d.store_name}</Td>}
+                  <Td className="text-right font-mono">{d.orders}</Td>
+                  <Td className="text-right font-mono">{Math.round(Number(d.qty))}</Td>
+                  <Td className="text-right font-mono">{money(d.completed_amount)}</Td>
+                  <Td className="text-right font-mono">{Number(d.partial_amount) > 0 ? money(d.partial_amount) : "—"}</Td>
+                  <Td className="text-right font-mono font-medium">{money(d.amount)}</Td>
+                </tr>
+              ))}
+            </tbody>
+            {report !== null && report.days.length > 1 && (
+              <tfoot className="bg-zinc-50 dark:bg-zinc-900">
+                <tr>
+                  <Td className="text-xs font-medium" colSpan={showStoreCol ? 2 : 1}>合計</Td>
+                  <Td className="text-right font-mono font-medium">{totals.orders}</Td>
+                  <Td className="text-right font-mono font-medium">{Math.round(totals.qty)}</Td>
+                  <Td className="text-right font-mono font-medium">{money(totals.completedAmount)}</Td>
+                  <Td className="text-right font-mono font-medium">{totals.partialAmount > 0 ? money(totals.partialAmount) : "—"}</Td>
+                  <Td className="text-right font-mono font-semibold">{money(totals.amount)}</Td>
+                </tr>
+              </tfoot>
+            )}
+          </table>
+        </div>
+      )}
+
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-sm font-medium">
+            取貨訂單明細（{report?.orders_total ?? 0} 筆
+            {report?.orders_truncated ? `，僅顯示最近 ${report.orders.length} 筆` : ""}）
+          </span>
+        </div>
+        <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+          <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+            <thead className="bg-zinc-50 dark:bg-zinc-900">
+              <tr>
+                <Th>取貨時間</Th>
+                <Th>訂單編號</Th>
+                {showStoreCol && <Th>分店</Th>}
+                <Th>會員</Th>
+                <Th>狀態</Th>
+                <Th className="text-right">品項</Th>
+                <Th className="text-right">數量</Th>
+                <Th className="text-right">金額</Th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {report === null ? (
+                <tr><td colSpan={8} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+              ) : report.orders.length === 0 ? (
+                <tr><td colSpan={8} className="p-6 text-center text-zinc-500">這段期間沒有取貨。</td></tr>
+              ) : report.orders.map((o) => (
+                <tr key={`${o.order_id}-${o.ymd}`} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
+                  <Td className="whitespace-nowrap text-xs text-zinc-500">
+                    {multiDay ? `${o.ymd} ` : ""}
+                    {new Date(o.picked_at).toLocaleTimeString("zh-TW", { hour: "2-digit", minute: "2-digit", hour12: false })}
+                  </Td>
+                  <Td className="font-mono text-xs">
+                    <a
+                      href={withBasePath(`/orders?q=${encodeURIComponent(o.order_no)}&storeId=${o.store_id}`)}
+                      className="text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      {o.order_no}
+                    </a>
+                  </Td>
+                  {showStoreCol && <Td className="text-xs">{o.store_name}</Td>}
+                  <Td className="text-xs">{o.member_name ?? "—"}</Td>
+                  <Td>
+                    <span className={`inline-block rounded px-2 py-0.5 text-xs ${
+                      o.status === "completed"
+                        ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
+                        : o.status === "partially_completed"
+                        ? "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                        : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+                    }`}>
+                      {orderStatusLabel(o.status)}
+                    </span>
+                  </Td>
+                  <Td className="text-right font-mono">{o.item_count}</Td>
+                  <Td className="text-right font-mono">{Math.round(Number(o.qty))}</Td>
+                  <Td className="text-right font-mono">{money(o.amount)}</Td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <p className="text-xs text-zinc-400">
+        金額＝取走品項的 數量 × 單價（不含折扣、運費），與訂單頁「今日取貨金額」同口徑；
+        部分取貨的訂單只計已取走的品項。內部單（RR-／【內部】xx 店）不計。
+        撤銷取貨後自動從報表移除。
+      </p>
+    </div>
+  );
+}
+
+function Stat({ label, value, accent }: { label: string; value: string; accent?: "positive" | "negative" | "neutral" }) {
+  const cls =
+    accent === "positive" ? "text-emerald-600" :
+    accent === "negative" ? "text-rose-600" :
+    "text-zinc-700 dark:text-zinc-200";
+  return (
+    <div className="rounded-md border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="text-xs text-zinc-500">{label}</div>
+      <div className={`mt-1 text-base font-medium ${cls}`}>{value}</div>
+    </div>
+  );
+}
+
+function Th({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  return <th className={`px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 ${className}`}>{children}</th>;
+}
+function Td({ children, className = "", colSpan }: { children: React.ReactNode; className?: string; colSpan?: number }) {
+  return <td colSpan={colSpan} className={`px-3 py-2 ${className}`}>{children}</td>;
+}

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -67,6 +67,7 @@ const NAV: NavGroup[] = [
   {
     title: "財務",
     items: [
+      { href: "/finance/daily", label: "日結報表", match: /^\/finance\/daily/ },
       { href: "/finance/receivables", label: "HQ 應收", match: /^\/finance\/receivables(?!\/print)/ },
       { href: "/transfers/settlement", label: "月結算", match: /^\/transfers\/settlement/ },
     ],

--- a/apps/admin/src/lib/menuSections.ts
+++ b/apps/admin/src/lib/menuSections.ts
@@ -9,7 +9,7 @@ export type MenuKey =
   | "orders" | "pickup" | "inbound" | "members" | "transfers" | "restock" | "mutual-aid"
   | "pr" | "po" | "inventory" | "reorder-rules" | "stocktake"
   | "hq-inbox" | "receiving" | "picking"
-  | "receivables" | "settlement"
+  | "daily-report" | "receivables" | "settlement"
   | "candidates" | "calendar"
   | "staff" | "stores" | "fb-pages"
   | "general";
@@ -61,6 +61,7 @@ export const MENU_GROUPS: MenuGroup[] = [
   {
     group: "財務",
     items: [
+      { key: "daily-report", label: "日結報表" },
       { key: "receivables", label: "HQ 應收" },
       { key: "settlement", label: "月結算" },
     ],

--- a/supabase/migrations/20260826010000_rpc_daily_pickup_settlement.sql
+++ b/supabase/migrations/20260826010000_rpc_daily_pickup_settlement.sql
@@ -1,0 +1,168 @@
+-- ============================================================
+-- 2026-08-26: 日結報表 rpc_daily_pickup_settlement（新函式）
+--
+-- 需求（Alex）：要有日結報表，統計「已完成」與「部分取貨」訂單當天
+--   實際取走的金額 —— 門市每天關帳時要知道今天交了多少貨、收了多少錢。
+--
+-- 口徑（對齊 rpc_order_overview 的 pickup 聚合，20260803000020）：
+--   * 取貨明細 = customer_order_items.status='picked_up'。
+--     rpc_record_pickup 整行取直接標 picked_up、部分取則拆出一行 picked_up
+--     （qty=本次取貨量），逐行加總不重複也不漏；rpc_undo_pickup 改回
+--     pending，撤銷的取貨自動不計。
+--   * 金額 = qty * unit_price（不扣折扣），與 /orders KPI「今日取貨金額」
+--     同一公式，兩邊數字才對得起來。
+--   * 取貨時間 = customer_order_items.updated_at，日界以 Asia/Taipei 切。
+--     2026-08-26 重驗：picked_up 全量 57,938 筆與 pickup_movement_id →
+--     stock_movements.created_at 完全相等（max drift 0 秒、無 NULL），
+--     20260803000020 檔頭的「若日後有 RPC 會改 picked_up 行要改 join
+--     stock_movements」警語仍未觸發。
+--   * 排除 cancelled / expired / transferred_out 訂單（同 overview）。
+--   * 排除內部容器單（members.member_type='store_internal'：RR- /
+--     【內部】xx 店 / AB- 載體）—— 那是現貨池帳本搬運，不是對客人收的錢。
+--     線上實測這類單身上掛著 437 筆 picked_up / 約 NT$13.8 萬，不排除
+--     日結會多算。⚠ 判準是 member_type，不是 order_kind / 單號前綴：
+--     29 張 RR- 單已換到真會員名下（picked_up $10,496），那些是真的收錢。
+--   * 已完成 / 部分取貨的拆分依單頭「目前」status：completed /
+--     partially_completed；其他 status（理論上不會有，防禦用）歸 other，
+--     金額照列不丟。
+--
+-- 回傳 jsonb：
+--   date_from / date_to      實際套用的日期（Asia/Taipei，含頭尾）
+--   days[]                   依 日期 × 分店 聚合（orders / qty / amount /
+--                            completed_* / partial_* / other_amount）
+--   orders[]                 依 訂單 × 日期 的明細列（最多 800 列，
+--                            picked_at DESC），orders_total / orders_truncated
+--                            告知有沒有被截斷
+--
+-- 參數：p_store_id NULL=全部分店；日期預設今天（台北）；區間上限 92 天
+--   （超過自動夾住，避免全站掃描 timeout）。
+--
+-- 權限：LANGUAGE sql STABLE、無 SECURITY DEFINER → 以呼叫者身分跑，
+--   tenant 隔離交給 RLS（與 rpc_order_overview 同一套）。
+--
+-- 附帶：customer_order_items 新增 partial index
+--   idx_coi_picked_up_updated_at (tenant_id, updated_at) WHERE status='picked_up'
+--   —— 本函式與 rpc_order_overview 的 pickup 聚合都是「picked_up + 時間區間」
+--   的掃法，之前只能全表掃 picked_up。
+--
+-- 基底版本：無（新函式、新 index）。
+-- rollback：DROP FUNCTION rpc_daily_pickup_settlement(bigint, date, date);
+--           DROP INDEX idx_coi_picked_up_updated_at;
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS idx_coi_picked_up_updated_at
+  ON customer_order_items (tenant_id, updated_at)
+  WHERE status = 'picked_up';
+
+CREATE OR REPLACE FUNCTION rpc_daily_pickup_settlement(
+  p_store_id  bigint DEFAULT NULL,
+  p_date_from date   DEFAULT NULL,
+  p_date_to   date   DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH params AS (
+    SELECT
+      COALESCE(p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date) AS d_from,
+      LEAST(
+        COALESCE(p_date_to, p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date),
+        COALESCE(p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date) + 92
+      ) AS d_to
+  ),
+  bounds AS (
+    SELECT
+      (p.d_from::timestamp AT TIME ZONE 'Asia/Taipei')       AS ts_from,
+      ((p.d_to + 1)::timestamp AT TIME ZONE 'Asia/Taipei')   AS ts_to
+    FROM params p
+  ),
+  picked AS (
+    SELECT
+      to_char((i.updated_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd,
+      co.pickup_store_id                            AS store_id,
+      COALESCE(s.name, '#' || co.pickup_store_id)   AS store_name,
+      co.id                                         AS order_id,
+      co.order_no,
+      co.status,
+      CASE
+        WHEN co.status = 'completed'           THEN 'completed'
+        WHEN co.status = 'partially_completed' THEN 'partial'
+        ELSE 'other'
+      END                                           AS grp,
+      COALESCE(m.name, co.nickname_snapshot)        AS member_name,
+      i.qty::numeric                                AS qty,
+      (i.qty * i.unit_price)::numeric               AS amount,
+      i.updated_at                                  AS picked_at
+    FROM customer_order_items i
+    JOIN customer_orders co ON co.id = i.order_id
+    JOIN bounds b ON TRUE
+    LEFT JOIN members m ON m.id = co.member_id
+    LEFT JOIN stores  s ON s.id = co.pickup_store_id
+    WHERE i.status = 'picked_up'
+      AND i.updated_at >= b.ts_from
+      AND i.updated_at <  b.ts_to
+      AND co.status NOT IN ('cancelled','expired','transferred_out')
+      AND COALESCE(m.member_type, '') <> 'store_internal'
+      AND (p_store_id IS NULL OR co.pickup_store_id = p_store_id)
+  ),
+  day_agg AS (
+    SELECT
+      p.ymd,
+      p.store_id,
+      p.store_name,
+      count(DISTINCT p.order_id)                                          AS orders,
+      SUM(p.qty)::numeric                                                 AS qty,
+      SUM(p.amount)::numeric                                              AS amount,
+      count(DISTINCT p.order_id) FILTER (WHERE p.grp = 'completed')       AS completed_orders,
+      COALESCE(SUM(p.amount) FILTER (WHERE p.grp = 'completed'), 0)::numeric AS completed_amount,
+      count(DISTINCT p.order_id) FILTER (WHERE p.grp = 'partial')         AS partial_orders,
+      COALESCE(SUM(p.amount) FILTER (WHERE p.grp = 'partial'), 0)::numeric   AS partial_amount,
+      COALESCE(SUM(p.amount) FILTER (WHERE p.grp = 'other'), 0)::numeric     AS other_amount
+    FROM picked p
+    GROUP BY p.ymd, p.store_id, p.store_name
+  ),
+  order_day AS (
+    SELECT
+      p.ymd,
+      p.store_id,
+      p.store_name,
+      p.order_id,
+      p.order_no,
+      p.status,
+      p.member_name,
+      count(*)               AS item_count,
+      SUM(p.qty)::numeric    AS qty,
+      SUM(p.amount)::numeric AS amount,
+      max(p.picked_at)       AS picked_at
+    FROM picked p
+    GROUP BY p.ymd, p.store_id, p.store_name, p.order_id, p.order_no, p.status, p.member_name
+  ),
+  order_rows AS (
+    SELECT * FROM order_day ORDER BY picked_at DESC LIMIT 800
+  )
+  SELECT jsonb_build_object(
+    'date_from', (SELECT to_char(d_from, 'YYYY-MM-DD') FROM params),
+    'date_to',   (SELECT to_char(d_to,   'YYYY-MM-DD') FROM params),
+    'days', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(d.*) ORDER BY d.ymd DESC, d.store_name)
+       FROM day_agg d),
+      '[]'::jsonb
+    ),
+    'orders', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(o.*) ORDER BY o.picked_at DESC)
+       FROM order_rows o),
+      '[]'::jsonb
+    ),
+    'orders_total',     (SELECT count(*) FROM order_day),
+    'orders_truncated', (SELECT count(*) > 800 FROM order_day)
+  );
+$$;
+
+COMMENT ON FUNCTION rpc_daily_pickup_settlement(bigint, date, date) IS
+  '日結報表：依日期×分店聚合「已取走品項」金額（picked_up 逐行、qty*unit_price、'
+  'Asia/Taipei 日界、updated_at 當取貨時間），拆已完成 / 部分取貨，附訂單明細列'
+  '（上限 800）。排除 cancelled/expired/transferred_out 訂單與內部容器單'
+  '（member_type=store_internal）。口徑同 rpc_order_overview 的 pickup 聚合，'
+  '不扣折扣。';
+
+GRANT EXECUTE ON FUNCTION rpc_daily_pickup_settlement(bigint, date, date) TO authenticated;


### PR DESCRIPTION
財務選單新增「日結報表」（/finance/daily）：依日期 × 分店統計每天實際取走的金額（已完成訂單＋部分取貨訂單已取走的品項）。全部做成表格：彙總表（日期×分店＋合計列）；訂單明細不預載，點「查看訂單明細」才查、一頁 20 筆分頁。分店帳號鎖自己店；日期可單日或區間（今天／昨天／近 7 天／本月）。

- 新 RPC `rpc_daily_pickup_settlement`（只回彙總）＋ `rpc_daily_pickup_orders`（明細分頁，預設 20 / 上限 100）：picked_up 品項逐行加總、qty × 單價（不扣折扣，口徑同 /orders KPI「今日取貨金額」）、Asia/Taipei 日界、排除 cancelled/expired/transferred_out 訂單與內部容器單（member_type=store_internal，線上實測掛著 437 筆 picked_up ≈ NT$13.8 萬，不排除會多算）
- `customer_order_items` 新增 partial index `(tenant_id, updated_at) WHERE status='picked_up'`
- **SQL 已於 2026-08-26 套上正式庫**（Management API），本 PR 需當天合併進 main

驗證：pg-query-emscripten 語法檢查 ✅、線上實跑兩支 RPC 數字合理 ✅、Playwright fixture 煙測（彙總表／預設不載明細／點了才打 RPC／20 筆分頁翻頁）✅、`npm run build` ✅