### PR TITLE
互助板：分店帳號認領／提供只能選自己的店

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -2677,7 +2677,17 @@ function ClaimOfferDialog({
   onCancel: () => void;
   onDone: () => void;
 }) {
-  const [toStore, setToStore] = useState<number | "">("");
+  // 分店帳號只能認到自己店（2026-08-26 指示）；總倉／未綁分店的帳號照舊全列。
+  // 自己店就是釋出店時選項會是空的 —— 本來就不該認自己的釋出。
+  // Dialog 點了才掛載、stores / user 都已就緒 → 直接當初始值帶入，不走 effect
+  //（effect 裡同步 setState 會觸發 cascading render 的 lint 規則）。
+  const myStoreId = useUserBranchStoreId(stores);
+  const storeOptions = stores.filter(
+    (s) => s.id !== post.offering_store_id && (myStoreId == null || s.id === myStoreId),
+  );
+  const [toStore, setToStore] = useState<number | "">(
+    myStoreId != null && myStoreId !== post.offering_store_id ? myStoreId : "",
+  );
   const [qty, setQty] = useState(String(post.qty_remaining));
   const [isAir, setIsAir] = useState(false);
   const [reason, setReason] = useState(`互助板認領 #${post.id}`);
@@ -2771,7 +2781,7 @@ function ClaimOfferDialog({
               className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
             >
               <option value="">— 選店 —</option>
-              {stores.filter((s) => s.id !== post.offering_store_id).map((s) => (
+              {storeOptions.map((s) => (
                 <option key={s.id} value={s.id}>{s.name} ({s.code})</option>
               ))}
             </select>
@@ -2834,7 +2844,17 @@ function FulfillRequestDialog({
   onCancel: () => void;
   onDone: () => void;
 }) {
-  const [myStore, setMyStore] = useState<number | "">("");
+  // 分店帳號的「提供店」只能是自己的店（2026-08-26 指示）；總倉照舊全列。
+  // 自己店就是求助店時選項會是空的 —— 本來就不該自己供自己的需求。
+  // Dialog 點了才掛載、stores / user 都已就緒 → 直接當初始值帶入，不走 effect
+  //（effect 裡同步 setState 會觸發 cascading render 的 lint 規則）。
+  const myStoreId = useUserBranchStoreId(stores);
+  const storeOptions = stores.filter(
+    (s) => s.id !== post.offering_store_id && (myStoreId == null || s.id === myStoreId),
+  );
+  const [myStore, setMyStore] = useState<number | "">(
+    myStoreId != null && myStoreId !== post.offering_store_id ? myStoreId : "",
+  );
   const [orders, setOrders] = useState<PendingOrder[] | null>(null);
   const [pickedOrderId, setPickedOrderId] = useState<number | null>(null);
   const [qty, setQty] = useState(String(post.qty_remaining));
@@ -2956,7 +2976,7 @@ function FulfillRequestDialog({
             className="w-full rounded border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
           >
             <option value="">— 選店 —</option>
-            {stores.filter((s) => s.id !== post.offering_store_id).map((s) => (
+            {storeOptions.map((s) => (
               <option key={s.id} value={s.id}>{s.name} ({s.code})</option>
             ))}
           </select>


### PR DESCRIPTION
## 做了什麼

互助板的「認領釋出（接收店）」與「提供需求（提供店）」下拉，分店帳號原本可以選全站任何一家店。改成：

- 分店帳號只列自己的店，並自動帶入（少一次點選）
- 總倉／未綁分店的帳號維持原本全列（排除貼文店）
- 自己店＝貼文店時選項為空 —— 本來就不該認自己的釋出／供自己的需求

只動 `apps/admin` 前端這一個檔，發文彈窗（求助／釋出／手動現貨）與 RPC 都沒動。

## 上線危險

- 做了：分店帳號在互助板認領/提供時，店別被鎖成自己，避免代別店操作造成貨對錯店
- 不做：沒有加後端守衛 —— 直接打 RPC 仍可指定任意接收店（與現況相同）
- 回退：revert 本 PR 即恢復原行為，無資料面影響

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `tsc --noEmit` 0 錯；eslint 僅剩 7 個既有的 setState-in-effect（本次未新增）
- Playwright + fixture 假登入實測（分店三峽店／總倉各一輪）：
  - 分店認領：接收店只列「三峽店」且預選 ✅；提供需求同 ✅
  - 總倉：兩個下拉照舊列出貼文店以外全部店、不預選 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yLRrNy48fVv6cCmNnDzWS

---
_Generated by [Claude Code](https://claude.ai/code/session_016yLRrNy48fVv6cCmNnDzWS)_