### PR TITLE
訂單口徑續修：後台會員畫面撈到見底＋應付總金額改後端計算

### DIFF
--- a/apps/admin/src/components/MemberOrdersAppView.tsx
+++ b/apps/admin/src/components/MemberOrdersAppView.tsx
@@ -9,8 +9,10 @@
  * 客服看到的數字 = 團友手機上的數字，一眼就能對。
  *
  * 「一樣」是硬需求，四個地方要跟會員端同步（改那邊記得改這邊）：
- *   - 資料管線 = liff-api listMyOrders：v_customer_order_summary、半年內、
- *     active / history 各最多 100 筆、一般取消不顯示但斷貨取消要顯示、已轉讓隱藏
+ *   - 資料管線 = liff-api listMyOrders：v_customer_order_summary、半年內
+ *     **逐頁撈到見底**（不能 limit(100) 砍最新 100 筆 —— 重度團友半年 200+ 張
+ *     「已完成」，砍尾巴會讓舊單在兩邊一起「消失」；同 PR #858）、
+ *     一般取消不顯示但斷貨取消要顯示、已轉讓隱藏
  *   - orderPhase / itemPhase 分桶（**依品項行**拆分身，2026-08-14 起）
  *     = apps/member/src/components/OrderCard.tsx
  *   - 應付總金額只在「待到貨」「待取貨」顯示、用 outstanding_amount
@@ -196,11 +198,27 @@ export function useMemberAppOrders(memberId: number, reloadTick = 0) {
           .eq("member_id", memberId)
           .gte("created_at", cutoff.toISOString())
           .order("created_at", { ascending: false })
-          .limit(100);
-      // = liff-api listMyOrders 的兩個 tab（active / history），各自 limit 100
+          .order("id", { ascending: false });
+      // = liff-api listMyOrders 的兩個 tab（active / history）。跟那邊一樣
+      // 逐頁 100 筆撈到見底（半年 cutoff 天然有界、2000 筆 runaway 保險），
+      // id tiebreaker 避免同秒建單跨頁漏抓或重複。
+      const fetchAll = async (
+        applyFilter: (q: ReturnType<typeof base>) => ReturnType<typeof base>,
+      ): Promise<{ data?: AppOrderRow[]; error?: { message: string } }> => {
+        const PAGE = 100;
+        const MAX_ROWS = 2000;
+        const all: AppOrderRow[] = [];
+        for (let from = 0; from < MAX_ROWS; from += PAGE) {
+          const { data, error } = await applyFilter(base().range(from, from + PAGE - 1));
+          if (error) return { error };
+          all.push(...((data ?? []) as AppOrderRow[]));
+          if ((data ?? []).length < PAGE) break;
+        }
+        return { data: all };
+      };
       const [activeQ, historyQ] = await Promise.all([
-        base().not("status", "in", "(completed,expired)"),
-        base().eq("status", "completed"),
+        fetchAll((q) => q.not("status", "in", "(completed,expired)")),
+        fetchAll((q) => q.eq("status", "completed")),
       ]);
       if (cancelled) return;
       const qErr = activeQ.error ?? historyQ.error;
@@ -419,7 +437,7 @@ export function MemberOrdersAppView({
       )}
 
       <p className="text-[11px] text-zinc-400">
-        與會員 app「我的訂單」同一套資料與口徑（半年內、每類最多 100 筆）；「已完成」依客人
+        與會員 app「我的訂單」同一套資料與口徑（半年內全部）；「已完成」依客人
         到店結單的那一次分組；點卡片可開後台訂單明細。
       </p>
     </div>

--- a/apps/member/src/app/orders/page.tsx
+++ b/apps/member/src/app/orders/page.tsx
@@ -47,39 +47,26 @@ function fmtAmount(n: number): string {
 }
 
 /**
- * 一個分頁的金額加總。**只有「待到貨」「待取貨」會顯示這張卡**（見 showTotals）：
- * 「全部」混著幾十張早就取貨付清的已完成單，掛一個「應付總金額」會讓團友以為
- * 還欠那麼多（2026-08-11 會員 109814 的回報：$13,845 裡有 $9,959 是歷史已完成單，
- * 真正沒領的只有 $3,886）；「已完成」則根本沒有應付。與其在「全部」
- * 解釋口徑，不如不顯示 —— 應付金額只出現在真的還有貨要領的分頁。
+ * 「應付總金額」卡的數字**由 liff-api 後端算完直接給**（list_my_orders active tab
+ * 回的 totals），前端不做列表加總（2026-08-27 Alex 指示）—— 前端自己加總的口徑
+ * 跟著分桶 / 過濾 / 截斷走，任何一邊改了數字就歪。分桶與分攤規則見 liff-api 的
+ * computePayableTotals（跟這頁的 splitOrderByPhase 分攤同一套，改哪邊都要同步）。
  *
- * 「應付」一律用 outstanding_amount（＝還沒領走的貨），**不可以用 payable_amount**。
- * 取貨當下就收現金，已取貨的單早就付清了，payable_amount 是「這張單本身多少錢」，
- * 不是「還欠多少」（2026-08-11 團友 528204 的災情，20260810000000 有完整脈絡）。
- *
- * 排除 cancelled / expired 是保險：待到貨 / 待取貨兩個分桶本來就不含它們，
- * 但口徑寫在這裡，之後誰把這張卡開到別的分頁也不會把不用付錢的單算進去。
+ * 只有「待到貨」「待取貨」會顯示這張卡（見 showTotals）：「全部」混著幾十張
+ * 早就取貨付清的已完成單，掛一個「應付總金額」會讓團友以為還欠那麼多
+ * （2026-08-11 會員 109814：$13,845 裡有 $9,959 是歷史已完成單，真正沒領的
+ * 只有 $1,110 → $3,886）；「已完成」則根本沒有應付。
+ * 「應付」一律是 outstanding_amount 口徑（＝還沒領走的貨），不是 payable_amount
+ * （2026-08-11 團友 528204 的災情，20260810000000 有完整脈絡）。
  */
-function sumOrders(list: OrderRow[]) {
-  const active = list.filter((o) => !["cancelled", "expired"].includes(String(o.status ?? "")));
-  return {
-    count: active.length,
-    amount: active.reduce(
-      (s, o) => s + Number(o.outstanding_amount ?? o.payable_amount ?? 0),
-      0,
-    ),
-    // 這個分頁裡有沒有「已經領走一部分」的單 —— 有的話總金額不等於
-    // 各卡的應付金額相加，要在副標講清楚，不然團友手動加總又會對不上。
-    hasPicked: active.some(
-      (o) => Number(o.outstanding_amount ?? o.payable_amount ?? 0) < Number(o.payable_amount ?? 0),
-    ),
-  };
-}
+type TabTotals = { count: number; amount: number; has_picked: boolean };
+type PayableTotals = { waiting: TabTotals; pickup: TabTotals };
 
 export default function OrdersPage() {
   const router = useRouter();
   const [tab, setTab] = useState<Tab>("waiting");
   const [orders, setOrders] = useState<OrderRow[]>([]);
+  const [payableTotals, setPayableTotals] = useState<PayableTotals | null>(null);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
 
@@ -95,9 +82,13 @@ export default function OrdersPage() {
       setErr(null);
       try {
         const [active, history] = await Promise.all([
-          callLiffApi<{ orders: OrderRow[] }>(s.token, { action: "list_my_orders", tab: "active" }),
+          callLiffApi<{ orders: OrderRow[]; totals?: PayableTotals }>(s.token, {
+            action: "list_my_orders",
+            tab: "active",
+          }),
           callLiffApi<{ orders: OrderRow[] }>(s.token, { action: "list_my_orders", tab: "history" }),
         ]);
+        setPayableTotals(active.totals ?? null);
         // 「全部」要照時間混排，不是先進行中再歷史；隱藏的階段在這裡就過濾掉
         setOrders(
           [...active.orders, ...history.orders]
@@ -158,9 +149,10 @@ export default function OrdersPage() {
   const displayGroups = isDone ? takeGroupOrders(doneGroups, visible) : [];
   const cardCount = isDone ? countGroupOrders(doneGroups) : bucket.length;
   const hasMore = cardCount > visible;
-  // 總金額卡只在「待到貨」「待取貨」出現（理由見 sumOrders 註解），照整個分頁算
+  // 總金額卡只在「待到貨」「待取貨」出現（理由見 PayableTotals 註解）；
+  // 數字直接用後端回的，舊版函式沒回 totals 時整張卡不畫（不退回前端加總）
   const showTotals = tab === "waiting" || tab === "pickup";
-  const totals = sumOrders(bucket);
+  const totals = showTotals ? payableTotals?.[tab as "waiting" | "pickup"] : undefined;
 
   // 捲到底自動載入下一頁（sentinel 進到視窗下方 300px 內就先載，捲起來無縫）
   const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -199,14 +191,14 @@ export default function OrdersPage() {
         {loading && <LoadingScreen />}
 
         {/* 這個分頁的應付總金額 — 客人最常問的就是「這些加起來多少錢」。
-            只在待到貨 / 待取貨出現：其他分頁掛金額只會誤導（見 sumOrders） */}
-        {!loading && !err && showTotals && totals.count > 0 && (
+            只在待到貨 / 待取貨出現：其他分頁掛金額只會誤導（見 PayableTotals） */}
+        {!loading && !err && totals && totals.count > 0 && (
           <div className="card flex items-center justify-between gap-3 px-4 py-3">
             <div className="min-w-0">
               <div className="text-[16px] text-[var(--foreground)]">應付總金額</div>
               <div className="mt-0.5 text-[13px] text-[var(--secondary-label)]">
                 共 {totals.count} 筆訂單
-                {totals.hasPicked && (
+                {totals.has_picked && (
                   <>
                     <span className="mx-1.5 text-[var(--tertiary-label)]">·</span>
                     已取貨的不計（取貨時付現）

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -535,6 +535,47 @@ async function fetchAllOrderSummaries(
   return { data: all };
 }
 
+/**
+ * 「待到貨」「待取貨」的應付總金額 —— **後端算完直接回，前端不准再從列表加總**
+ * （2026-08-27 Alex 指示）。前端自己加總的問題：口徑跟著前端的分桶 / 過濾走，
+ * 任何一邊改了（隱藏分頁、截斷、拆分身）數字就跟著歪，客訴對帳只能猜。
+ *
+ * 分桶與分攤規則**逐字對齊**會員端（改這裡記得改那邊，反之亦然）：
+ *   - itemPhase：apps/member/src/components/OrderCard.tsx —— 單頭 cancelled/expired/
+ *     transferred_out 整張跳過；行 picked_up → 已完成、cancelled/expired → 不成立；
+ *     其餘 arrived===true → 待取貨、否則待到貨（缺值當沒到，寧可少報）。
+ *   - 金額分攤：apps/member/src/app/orders/page.tsx —— 單頭 outstanding_amount 依
+ *     「該分身未取貨值 / 整張單未取貨值」等比分攤，兩個分頁相加 = 整張單未結金額，
+ *     不會把同一張單算兩次。
+ *   - has_picked：分身分攤額 < 整張單 payable_amount → 副標「已取貨的不計」。
+ * 後台複製品 apps/admin/src/components/MemberOrdersAppView.tsx 的 outstandingTotals
+ * 也是同一套，四份要一起動。
+ */
+function computePayableTotals(rows: any[]) {
+  const totals = {
+    waiting: { count: 0, amount: 0, has_picked: false },
+    pickup: { count: 0, amount: 0, has_picked: false },
+  };
+  for (const o of rows) {
+    if (["cancelled", "expired", "transferred_out"].includes(String(o.status ?? ""))) continue;
+    const items = Array.isArray(o.items) ? o.items : [];
+    const active = items.filter((it: any) => !["cancelled", "expired", "picked_up"].includes(String(it.status ?? "")));
+    const wholeUnpicked = active.reduce((s: number, it: any) => s + Number(it.subtotal ?? 0), 0);
+    const outstanding = Number(o.outstanding_amount ?? o.payable_amount ?? 0);
+    const payable = Number(o.payable_amount ?? 0);
+    for (const phase of ["waiting", "pickup"] as const) {
+      const part = active.filter((it: any) => (it.arrived === true) === (phase === "pickup"));
+      if (part.length === 0) continue;
+      const partSubtotal = part.reduce((s: number, it: any) => s + Number(it.subtotal ?? 0), 0);
+      const partAmount = wholeUnpicked > 0 ? (outstanding * partSubtotal) / wholeUnpicked : 0;
+      totals[phase].count += 1;
+      totals[phase].amount += partAmount;
+      if (partAmount < payable) totals[phase].has_picked = true;
+    }
+  }
+  return totals;
+}
+
 async function listMyOrders(sb: any, tenantId: string, _storeId: number, memberId: number, tab: string) {
   const cutoff = new Date(); cutoff.setMonth(cutoff.getMonth() - 6);
   // 不依 store_id 過濾：同一 line_user 可能綁多店 OA，但 member_id 是 tenant 級；
@@ -564,6 +605,9 @@ async function listMyOrders(sb: any, tenantId: string, _storeId: number, memberI
     })),
     pickups: pickupsByOrder.get(Number(o.id)) ?? [],
   }));
+  // 應付總金額只跟 active 分頁的單有關（completed 的行全是已取 / 取消，
+  // 不會落在待到貨 / 待取貨），history 就不用多付一次計算
+  if (tab === "active") return json({ orders, totals: computePayableTotals(rows) });
   return json({ orders });
 }
 


### PR DESCRIPTION
#858 的兩個後續，同一條線的口徑修正：

## 1. 後台「會員畫面」同步撈到見底

`MemberOrdersAppView`（會員明細裡給客服對帳的視圖）還是舊的「active / history 各砍最新 100 筆」——重度團友的舊已完成單手機上看得到、後台卻沒有。比照 liff-api 的 `fetchAllOrderSummaries` 逐頁撈到見底，並更新畫面上的口徑說明文字。

## 2. 會員 app「應付總金額」改由後端算完直接回

前端不再從列表自己加總：`list_my_orders` active tab 多回一個 `totals`（waiting / pickup 各 `{count, amount, has_picked}`），分桶與等比分攤規則逐字對齊會員端 `itemPhase` / `splitOrderByPhase`。前端只負責顯示；舊版函式沒回 `totals` 時整張卡不畫、不退回前端加總。

## 驗證

- liff-api 已部署（version 81），用實際會員 token 打線上：`totals` 與前端舊演算法逐欄位一致（待到貨 97 筆 $43,094、待取貨 9 筆 $2,969）。
- admin / member 兩個 app `tsc --noEmit`、`eslint` 皆過。