### PR TITLE
訂單頁「取消配單」：把波次到貨自動配單配到的貨收回可配量

### DIFF
--- a/apps/admin/src/components/CancelAllocationModal.tsx
+++ b/apps/admin/src/components/CancelAllocationModal.tsx
@@ -38,7 +38,7 @@ export function CancelAllocationModal({
     if (
       !confirm(
         `取消「${skuLabel}」${qty} 件的配單？\n\n` +
-          `這一行會變成「待補貨」（取貨頁就勾不到了），那 ${qty} 件回到可配量、` +
+          `這一行會退回「等貨中」（取貨頁就勾不到了），那 ${qty} 件回到可配量、` +
           `可以配給別的客人。\n` +
           `庫存數量不會變動（配單本來就沒扣庫存）。\n`,
       )
@@ -60,7 +60,7 @@ export function CancelAllocationModal({
       const r = (res ?? {}) as { qty?: number; reverted?: boolean };
       alert(
         `✅ 已取消配單（${Number(r.qty ?? qty)} 件），這些貨回到可配量了。\n` +
-          `這一行變成「待補貨」，要重新配就按「📦 從庫存配貨」，` +
+          `這一行退回「等貨中」，要重新配就按「📦 從庫存配貨」，` +
           `下一批貨收進來時數量夠也會自動重配。\n` +
           (r.reverted ? "整張單退回「已確認（等貨中）」。\n" : "") +
           `⚠️ 客人若已收過「到貨通知」，請記得自行知會。`,
@@ -105,7 +105,7 @@ export function CancelAllocationModal({
           <b>庫存數量不會變</b> —— 配單本來就沒扣庫存，取消只是把「這批貨有主人」的
           標記拿掉，那幾件馬上回到可配量、可以配給別的客人。
           <br />
-          這一行會變成「待補貨」、整張單退回「已確認」；客人若已收過到貨通知請自行知會。
+          這一行會退回「等貨中」（系統標記為待補貨）、整張單退回「已確認」；客人若已收過到貨通知請自行知會。
         </div>
 
         <div className="flex items-center justify-end gap-2 pt-1">

--- a/apps/admin/src/components/CancelAllocationModal.tsx
+++ b/apps/admin/src/components/CancelAllocationModal.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "@/components/Modal";
+import SpinButton from "@/components/SpinButton";
+import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
+
+// 取消配單：把波次到貨自動配單配給這一行的貨收回可配量。
+// 見 20260827010000 migration（rpc_unallocate_order_item）。
+//
+// 跟「↩️ 取消配貨」（UnassignStockModal）的分工：那顆收的是「📦 從庫存配貨」
+// 開的 DN 覆蓋；這顆收的是波次到貨自動配單（身上沒有 DN、閘門靠 Path A/B/C
+// 放行）。做法是把品項標成「待補貨」—— 取貨閘門立刻關掉、貨回到別張單的
+// 可配量。要重新配就按「📦 從庫存配貨」，或等下一批貨收進來自動重配。
+//
+// 整行一起退（不拆行）：qty>1 只想退一部分，先到訂單頁改數量再取消。
+
+export function CancelAllocationModal({
+  itemId,
+  skuLabel,
+  qty,
+  onClose,
+  onSaved,
+}: {
+  itemId: number;
+  skuLabel: string;
+  qty: number;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function save() {
+    if (busy) return;
+    if (
+      !confirm(
+        `取消「${skuLabel}」${qty} 件的配單？\n\n` +
+          `這一行會變成「待補貨」（取貨頁就勾不到了），那 ${qty} 件回到可配量、` +
+          `可以配給別的客人。\n` +
+          `庫存數量不會變動（配單本來就沒扣庫存）。\n`,
+      )
+    )
+      return;
+    setBusy(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) throw new Error("尚未登入");
+      const { data: res, error: e } = await sb.rpc("rpc_unallocate_order_item", {
+        p_item_id: itemId,
+        p_operator: operator,
+        p_reason: reason.trim() || null,
+      });
+      if (e) throw new Error(translateRpcError(e));
+      const r = (res ?? {}) as { qty?: number; reverted?: boolean };
+      alert(
+        `✅ 已取消配單（${Number(r.qty ?? qty)} 件），這些貨回到可配量了。\n` +
+          `這一行變成「待補貨」，要重新配就按「📦 從庫存配貨」，` +
+          `下一批貨收進來時數量夠也會自動重配。\n` +
+          (r.reverted ? "整張單退回「已確認（等貨中）」。\n" : "") +
+          `⚠️ 客人若已收過「到貨通知」，請記得自行知會。`,
+      );
+      onSaved();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal open onClose={onClose} title="↩️ 取消配單（收回可配量）" maxWidth="max-w-lg">
+      <div className="space-y-3 text-sm">
+        {error && (
+          <div className="whitespace-pre-wrap rounded-md border border-red-200 bg-red-50 p-3 text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        <div className="rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 dark:border-zinc-800 dark:bg-zinc-900/60">
+          <div className="font-medium text-zinc-900 dark:text-zinc-100">{skuLabel}</div>
+          <div className="mt-0.5 text-xs text-zinc-500">
+            這一行已由到貨自動配單配到 <b className="text-violet-700 dark:text-violet-400">{qty}</b> 件
+            —— 整行一起取消（只想退一部分請先改訂單數量）。
+          </div>
+        </div>
+
+        <label className="block">
+          <span className="mb-1 block text-xs text-zinc-500">原因（選填）</span>
+          <input
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="例：客人晚點才來拿／貨要先給更急的單"
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+        </label>
+
+        <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300">
+          <b>庫存數量不會變</b> —— 配單本來就沒扣庫存，取消只是把「這批貨有主人」的
+          標記拿掉，那幾件馬上回到可配量、可以配給別的客人。
+          <br />
+          這一行會變成「待補貨」、整張單退回「已確認」；客人若已收過到貨通知請自行知會。
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <SpinButton
+            onClick={onClose}
+            className="rounded-md border border-zinc-300 px-4 py-2 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            關閉
+          </SpinButton>
+          <SpinButton
+            onClick={save}
+            disabled={busy}
+            className="rounded-md bg-amber-600 px-5 py-2 font-semibold text-white hover:bg-amber-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
+          >
+            {busy ? "處理中…" : `取消配單 ${qty} 件`}
+          </SpinButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+export default CancelAllocationModal;

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -11,6 +11,7 @@ import { OrderAuditDrawer } from "@/components/OrderAuditDrawer";
 import { WalletPayOrderModal } from "@/components/WalletPayOrderModal";
 import { AssignStockModal } from "@/components/AssignStockModal";
 import { UnassignStockModal } from "@/components/UnassignStockModal";
+import { CancelAllocationModal } from "@/components/CancelAllocationModal";
 import { EditableNumber, EditableText } from "@/components/EditableCell";
 import { EditableDiscount, deriveDiscount, type DiscountValue } from "@/components/EditableDiscount";
 import { useAuth } from "@/components/AuthProvider";
@@ -242,6 +243,10 @@ export function OrderDetail({
   const [unassignTarget, setUnassignTarget] = useState<
     { itemId: number; skuLabel: string; assigned: number; fromPool: number } | null
   >(null);
+  // 「↩️ 取消配單」目標品項（波次到貨自動配單配到的行 —— 閘門放行、沒有 DN）
+  const [unallocTarget, setUnallocTarget] = useState<
+    { itemId: number; skuLabel: string; qty: number } | null
+  >(null);
   // 該訂單的取貨事件（append-only）— 取貨後補印收據用，見 /pickup/print?event_ids=
   const [pickupEvents, setPickupEvents] = useState<PickupEventRow[]>([]);
   const [timeline, setTimeline] = useState<TimelineStep[] | null>(null);
@@ -314,6 +319,14 @@ export function OrderDetail({
   const canAssignStock = (canEdit || isStoreOfThisOrder)
     && !!head
     && !["cancelled", "expired", "transferred_out", "completed"].includes(head.status);
+
+  // 「↩️ 取消配單」：波次到貨自動配單推上去的行（閘門放行、身上沒有 DN 覆蓋）。
+  // SP-（現貨直配）整張單就是配單、RR-/AB-/OV- 是容器單，都不出這顆
+  // （伺服端 rpc_unallocate_order_item 也擋）。shipping 單貨還在路上，也不出。
+  const canUnallocate = canAssignStock
+    && !!head
+    && ["confirmed", "ready", "partially_completed"].includes(head.status)
+    && !/^(SP|RR|AB|OV)-/.test(head.order_no);
 
   // 備註（單頭/品項）：店長店員也可編自店訂單，對齊 _check_order_edit_notes_perm
   const canEditNotes = canEdit || isStoreOfThisOrder;
@@ -1634,6 +1647,35 @@ export function OrderDetail({
                               ↩️ 取消配貨 {assigned.get(it.id)?.qty}
                             </SpinButton>
                           )}
+                          {/* 取消配單：波次到貨自動配單配到的行（閘門放行、沒有 DN 覆蓋）。
+                              標成待補貨 → 取貨閘門關掉、貨回到別張單的可配量；
+                              重新配走「📦 從庫存配貨」或等下一批收貨自動重配。
+                              見 20260827010000 migration。 */}
+                          {canUnallocate
+                            && !isPicked
+                            && !["cancelled", "expired"].includes(it.status)
+                            && itemReady.get(it.id) === true
+                            && (assigned.get(it.id)?.qty ?? 0) === 0 && (
+                            <SpinButton
+                              onClick={() => {
+                                if (draftCount > 0) {
+                                  alert("請先儲存或放棄未儲存的修改，再取消配單。");
+                                  return;
+                                }
+                                setUnallocTarget({
+                                  itemId: it.id,
+                                  skuLabel: it.sku
+                                    ? `${it.sku.product_name ?? ""}${it.sku.variant_name ? ` / ${it.sku.variant_name}` : ""}`.trim()
+                                    : `#${it.id}`,
+                                  qty: Number(it.qty),
+                                });
+                              }}
+                              title="把到貨自動配單配給這一行的貨收回 —— 這一行變「待補貨」、那幾件回到可配量（庫存數量不變）"
+                              className="rounded-md border border-amber-300 px-2 py-1 text-[11px] font-medium text-amber-700 hover:bg-amber-50 dark:border-amber-700 dark:text-amber-300 dark:hover:bg-amber-950 whitespace-nowrap"
+                            >
+                              ↩️ 取消配單
+                            </SpinButton>
+                          )}
                           {canEditQty
                             && !["cancelled", "expired"].includes(it.status)
                             && !isPicked && (
@@ -1892,6 +1934,15 @@ export function OrderDetail({
           assigned={unassignTarget.assigned}
           fromPool={unassignTarget.fromPool}
           onClose={() => setUnassignTarget(null)}
+          onSaved={() => setReloadTick((n) => n + 1)}
+        />
+      )}
+      {unallocTarget && (
+        <CancelAllocationModal
+          itemId={unallocTarget.itemId}
+          skuLabel={unallocTarget.skuLabel}
+          qty={unallocTarget.qty}
+          onClose={() => setUnallocTarget(null)}
           onSaved={() => setReloadTick((n) => n + 1)}
         />
       )}

--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -1670,7 +1670,7 @@ export function OrderDetail({
                                   qty: Number(it.qty),
                                 });
                               }}
-                              title="把到貨自動配單配給這一行的貨收回 —— 這一行變「待補貨」、那幾件回到可配量（庫存數量不變）"
+                              title="把到貨自動配單配給這一行的貨收回 —— 這一行退回「等貨中」、那幾件回到可配量（庫存數量不變）"
                               className="rounded-md border border-amber-300 px-2 py-1 text-[11px] font-medium text-amber-700 hover:bg-amber-50 dark:border-amber-700 dark:text-amber-300 dark:hover:bg-amber-950 whitespace-nowrap"
                             >
                               ↩️ 取消配單

--- a/supabase/migrations/20260827010000_rpc_unallocate_order_item.sql
+++ b/supabase/migrations/20260827010000_rpc_unallocate_order_item.sql
@@ -1,0 +1,231 @@
+-- ============================================================================
+-- 訂單頁「取消配單」：把波次到貨自動配單配給這一行的貨收回可配量
+--
+-- 需求（Alex 2026-08-27）：「可以針對訂單取消配單嗎」＋截圖 GRP-20260727-015-0050
+--   （泰山，收 WAVE-2151-S50 時被自動配單推成可取貨）—— 訂單頁沒有按鈕。
+--
+-- 現況：既有的「↩️ 取消配貨」（rpc_unassign_stock_from_order_item，20260825020000）
+--   只認 DN 覆蓋 —— 它是「📦 從庫存配貨」的反向。但線上大多數「可取貨」的單
+--   是**波次到貨自動配單**推上去的（rpc_receive_transfer 邏輯 C/E、
+--   _advance_arrived_confirmed_orders）：身上沒有任何 DN，
+--   rpc_get_order_stock_assignments 回空 → 按鈕不出現，配單收不回來。
+--
+-- 本檔新增：rpc_unallocate_order_item(item_id, operator, reason)
+--   1. 品項標 backorder_at / backorder_by ＋ notes 蓋 [取消配單] 章。
+--      取貨閘門內含 backorder_at IS NULL（20260818000010 gate 版本第 165 行）
+--      → 閘門立刻關掉，取貨頁勾不到、店員發不出去。
+--   2. 單頭 ready → confirmed（判準同 rpc_unassign_stock_from_order_item：
+--      整單 active 品項 bool_and(閘門) 不成立才退）。ready_at 清掉。
+--   3. 不動 stock_balances —— 自動配單本來就沒扣庫存（取貨那一刻才扣），
+--      取消只是把「這批貨有主人」的主張拿掉。
+--
+-- 取消之後那幾件去哪（各算法怎麼看待補貨列）：
+--   · 配貨預算 _order_item_stock_budget 的 committed **整列排除**
+--     backorder_at IS NOT NULL 的行 → 馬上可以「📦 從庫存配貨」給別張單。
+--   · 閘門實體庫存守衛（20260818000010）母體只算 ready/partially_completed/
+--     shipping 單頭 → 單頭退回 confirmed 後不再佔額度。
+--   · _sku_commitment：這一行從 promised 移到 waiting（waiting 不濾 backorder，
+--     刻意不改 —— 現貨直配 SP- 的自由量因此**不會**因取消配單而放大：
+--     這位客人的需求還在，下一批貨仍是他的）。
+--
+-- 怎麼「重新配」（本檔不新增解除路徑，四條既有的都接得上）：
+--   · 訂單頁「📦 從庫存配貨」（rpc_assign_stock_to_order_item 會清 backorder_at）
+--   · 收貨頁「⚖️ 配貨」（rpc_allocate_shortage）
+--   · 下一批貨收進來時 _settle_arrived_backorders（邏輯 A0）數量夠就自動解除
+--   · rpc_create_inventory_deduction / rpc_create_offset_sale
+--
+-- 與「↩️ 取消配貨」的分工（前端也照這條路由）：
+--   身上有有效 DN 覆蓋 → 走 rpc_unassign_stock_from_order_item（釋放覆蓋＋還池子）；
+--   沒有 DN 而閘門放行（Path A/B/C 波次供貨）→ 走本函式。
+--   本函式對有覆蓋的行直接擋下並指路，兩邊不會互踩。
+--
+-- 守衛（不給取消的）：
+--   · picked_up —— 貨真的交出去了，走退貨。
+--   · 單頭 shipping —— 波次已派出、貨還在路上，要退走收貨端（拒收/退回）。
+--   · 容器單（member_type='store_internal'）／offset 單／SP- 現貨直配 ——
+--     它們不是「等貨的客人單」：容器單是現貨池帳本，SP- 整張就是配單
+--     （要取消請直接取消訂單，20260816000070 已放行 ready 的 SP-）。
+--   · 已經掛 backorder_at 的行 —— 沒有配單可取消。
+--
+-- 已知取捨：
+--   · 整行一起退（不拆行）。qty>1 只想退一部分：先到訂單頁改數量再取消。
+--   · 客人若已收過「到貨通知」，取消後要店家自行知會（本檔不發通知 ——
+--     比照 rpc_unassign_stock_from_order_item，取消配貨也沒發）。
+--   · 下一批同 SKU 收貨時 A0 數量夠會自動重配回這張單（它本來就在排隊）。
+--
+-- 基底版本：本檔一支函式為新增，不改任何既有函式。
+--   守衛與鎖對齊 rpc_unassign_stock_from_order_item（20260825020000）。
+-- Rollback：
+--   DROP FUNCTION public.rpc_unallocate_order_item(BIGINT, UUID, TEXT);
+--   已標掉的列要復原：訂單頁「📦 從庫存配貨」重配，或
+--   UPDATE customer_order_items SET backorder_at=NULL, backorder_by=NULL WHERE ...
+--
+-- 對應前端（同一個 commit）：
+--   apps/admin/src/components/CancelAllocationModal.tsx（新）
+--   apps/admin/src/components/OrderDetail.tsx（閘門放行且無 DN 的行多一顆「↩️ 取消配單」）
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_unallocate_order_item(
+  p_item_id  BIGINT,
+  p_operator UUID,
+  p_reason   TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_jwt_role  TEXT  := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_my_stores JSONB := COALESCE(auth.jwt() -> 'app_metadata' -> 'stores', '[]'::jsonb);
+  v           RECORD;
+  v_now       TIMESTAMPTZ := NOW();
+  v_status2   TEXT;
+  v_bo2       TIMESTAMPTZ;
+  v_cov       NUMERIC;
+  v_all_ready BOOLEAN;
+  v_reverted  BOOLEAN := FALSE;
+  v_tag       TEXT;
+BEGIN
+  IF p_operator IS NULL THEN
+    RAISE EXCEPTION '缺少操作人';
+  END IF;
+
+  SELECT coi.id           AS item_id,
+         coi.status       AS item_status,
+         coi.qty          AS item_qty,
+         coi.backorder_at AS backorder_at,
+         coi.sku_id       AS sku_id,
+         co.id            AS order_id,
+         co.order_no      AS order_no,
+         co.status        AS order_status,
+         co.tenant_id     AS tenant_id,
+         co.pickup_store_id AS store_id,
+         COALESCE(co.order_kind, 'normal') AS order_kind,
+         COALESCE(m.member_type, '')       AS member_type,
+         s.name           AS store_name
+    INTO v
+    FROM customer_order_items coi
+    JOIN customer_orders co ON co.id = coi.order_id
+    LEFT JOIN members m ON m.id = co.member_id
+    LEFT JOIN stores  s ON s.id = co.pickup_store_id
+   WHERE coi.id = p_item_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '找不到訂單品項 #%', p_item_id;
+  END IF;
+
+  IF v.item_status = 'picked_up' THEN
+    RAISE EXCEPTION '這個品項已經取貨了，要收回請走退貨流程（不是取消配單）';
+  END IF;
+  IF v.item_status NOT IN ('pending', 'reserved', 'ready') THEN
+    RAISE EXCEPTION '這個品項是「%」，沒有配單可取消', v.item_status;
+  END IF;
+  IF v.order_status IN ('cancelled', 'expired', 'transferred_out') THEN
+    RAISE EXCEPTION '訂單狀態為「%」，沒有配單可取消', v.order_status;
+  END IF;
+  IF v.order_status = 'shipping' THEN
+    RAISE EXCEPTION '這張單在出貨中（波次已派出），貨還在路上 —— 要退請走收貨端流程';
+  END IF;
+  IF v.member_type = 'store_internal' THEN
+    RAISE EXCEPTION '這是【內部】容器單（店端現貨池帳本），不能取消配單';
+  END IF;
+  IF v.order_kind = 'offset' OR v.order_no LIKE 'SP-%' THEN
+    RAISE EXCEPTION '現貨直配／減抵單整張就是配單，要收回請直接取消該張訂單';
+  END IF;
+  IF v.backorder_at IS NOT NULL THEN
+    RAISE EXCEPTION '這一行已經是「待補貨」（配單早已取消或從未配到）';
+  END IF;
+
+  -- 店家守衛：同 rpc_assign_stock_to_order_item / rpc_unassign_stock_from_order_item
+  IF v_jwt_role IN ('store_manager', 'store_staff')
+     AND jsonb_typeof(v_my_stores) = 'array'
+     AND jsonb_array_length(v_my_stores) > 0
+     AND NOT (v_my_stores ? '總倉')
+     AND NOT (v_my_stores ? v.store_name) THEN
+    RAISE EXCEPTION 'wrong_store: 這是「%」的單，分店帳號只能動自己店的貨', v.store_name;
+  END IF;
+
+  -- 與配貨 / 取消配貨搶同一把鎖：動的是同一批實體庫存的主張
+  PERFORM pg_advisory_xact_lock(hashtext(format('spotsale:%s:%s:%s',
+    v.tenant_id, v.store_id, v.sku_id)));
+
+  -- 拿鎖之後鎖列重讀（併發取貨 / 配貨會改 status / backorder_at）
+  SELECT coi.status, coi.backorder_at INTO v_status2, v_bo2
+    FROM customer_order_items coi
+   WHERE coi.id = p_item_id
+     FOR UPDATE;
+  IF v_status2 NOT IN ('pending', 'reserved', 'ready') THEN
+    RAISE EXCEPTION '這個品項剛被別的作業改成「%」了，請重新整理後再試', v_status2;
+  END IF;
+  IF v_bo2 IS NOT NULL THEN
+    RAISE EXCEPTION '這一行剛被標成「待補貨」了，請重新整理後再試';
+  END IF;
+
+  -- 身上有有效 DN 覆蓋的行不歸這裡管：那是「從庫存配貨」配的，
+  -- 要用「↩️ 取消配貨」收（會一併釋放覆蓋、還現貨池）。
+  SELECT COALESCE(SUM(GREATEST(ni.qty - COALESCE(ni.released_qty, 0), 0)), 0)
+    INTO v_cov
+    FROM inventory_deduction_note_items ni
+    JOIN inventory_deduction_notes n ON n.id = ni.note_id AND n.cancelled_at IS NULL
+   WHERE ni.order_item_id = p_item_id;
+  IF v_cov > 0 THEN
+    RAISE EXCEPTION '這一行是「從庫存配貨」配的（覆蓋 % 件），請改用「↩️ 取消配貨」', v_cov;
+  END IF;
+
+  v_tag := CASE WHEN NULLIF(TRIM(COALESCE(p_reason, '')), '') IS NULL
+                THEN '[取消配單]'
+                ELSE '[取消配單｜' || TRIM(p_reason) || ']' END;
+
+  -- 標待補貨＝關取貨閘門（backorder_at IS NULL 那一關）。
+  -- 待補貨列同時退出配貨預算的 committed 與 _sku_commitment 的 promised_active，
+  -- 這幾件立刻回到別張單的可配量。
+  UPDATE customer_order_items
+     SET backorder_at = v_now,
+         backorder_by = p_operator,
+         notes        = TRIM(BOTH E'\n' FROM COALESCE(notes || E'\n', '') || v_tag),
+         updated_by   = p_operator,
+         updated_at   = v_now
+   WHERE id = p_item_id;
+
+  -- 單頭：自動配單推上去的 ready 退回 confirmed（判準同推進時：整單 active
+  -- 品項是不是都還過得了閘門）。有取過貨的單（partially_completed）不動。
+  IF v.order_status = 'ready' THEN
+    SELECT bool_and(public.is_order_item_pickup_ready(c.id)) INTO v_all_ready
+      FROM customer_order_items c
+     WHERE c.order_id = v.order_id
+       AND c.status IN ('pending', 'reserved', 'ready');
+    IF NOT COALESCE(v_all_ready, TRUE) THEN
+      UPDATE customer_orders
+         SET status     = 'confirmed',
+             ready_at   = NULL,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v.order_id
+         AND status = 'ready';
+      v_reverted := TRUE;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'item_id',      p_item_id,
+    'order_id',     v.order_id,
+    'order_no',     v.order_no,
+    'qty',          v.item_qty,
+    'order_status', CASE WHEN v_reverted THEN 'confirmed' ELSE v.order_status END,
+    'reverted',     v_reverted,
+    'gate_ready',   public.is_order_item_pickup_ready(p_item_id)
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_unallocate_order_item(BIGINT, UUID, TEXT) IS
+  '訂單頁「取消配單」：把波次到貨自動配單配給這一行的貨收回可配量 —— 品項標'
+  ' backorder_at（取貨閘門立刻關掉）＋ notes 蓋 [取消配單] 章，單頭 ready 退回 confirmed。'
+  '不動 stock_balances（自動配單本來就沒扣庫存）。有 DN 覆蓋的行請改用'
+  ' rpc_unassign_stock_from_order_item；重新配走「📦 從庫存配貨」／「⚖️ 配貨」／'
+  '下一批收貨的 _settle_arrived_backorders。';
+
+REVOKE ALL ON FUNCTION public.rpc_unallocate_order_item(BIGINT, UUID, TEXT)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_unallocate_order_item(BIGINT, UUID, TEXT)
+  TO authenticated;


### PR DESCRIPTION
## 做了什麼

「↩️ 取消配貨」（#839）只認 DN 覆蓋，但線上大多數「可取貨」的單是**波次到貨自動配單**推上去的（身上沒有 DN），訂單頁沒有任何收回入口（Alex 2026-08-27 回報，GRP-20260727-015-0050）。

- 新增 `rpc_unallocate_order_item`（`20260827010000`）：品項標 `backorder_at`（取貨閘門內含 `backorder_at IS NULL` → 立刻關掉）＋ notes 蓋 `[取消配單]` 章，單頭 ready 退回 confirmed。不動庫存（自動配單本來就沒扣，取貨那一刻才扣）。
- 待補貨列會退出配貨預算的 committed 與 promised_active → 那幾件立刻回到別張單的可配量。重新配走既有四條路：訂單頁「📦 從庫存配貨」、收貨頁「⚖️ 配貨」、下一批收貨 `_settle_arrived_backorders` 自動重配、減抵單。
- 前端 `OrderDetail`：閘門放行且無 DN 覆蓋的品項列出「↩️ 取消配單」（新 `CancelAllocationModal`）。有 DN 的行維持走「↩️ 取消配貨」，兩顆不會同時出現。
- 守衛：已取貨（走退貨）、shipping（貨在路上，走收貨端）、容器單／offset／SP-（整張單就是配單，直接取消訂單）都擋下；分店帳號只能動自己店的單；與配貨／取消配貨搶同一把 advisory lock。

## 上線危險

- 做了：新增一支 RPC ＋ 前端一顆按鈕/彈窗。不改任何既有函式。
- 不做：不動 stock_balances、不發通知（客人若已收過到貨通知，彈窗提醒店家自行知會）、不拆行（整行一起退，qty>1 想退一部分先改訂單數量）、`_sku_commitment.waiting` 不濾 backorder 維持原樣（現貨直配自由量刻意不因取消配單放大）。
- 回退：`DROP FUNCTION public.rpc_unallocate_order_item(BIGINT, UUID, TEXT);` 已標掉的列用「📦 從庫存配貨」重配或手動清 `backorder_at`。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `node scripts/check-sql-syntax.cjs`（parse ＋ parsePlpgsql）通過；admin `tsc --noEmit`、eslint 乾淨。
- migration 已於 2026-08-27 套上正式庫（Management API），並以 ROLLBACK 交易對 GRP-20260727-015-0050（item 76498）實測：閘門 true→false、單頭 ready→confirmed、`ready_at` 清空、notes 蓋章、`_sku_commitment.promised` 4→3。實測後回滾，線上訂單原封不動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAy3ojTdgfB7NDDyCBCSGn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAy3ojTdgfB7NDDyCBCSGn)_