### PR TITLE
儀表板「在線狀態」卡：同時在線／今日活躍（店員・會員・商城訪客）

### DIFF
--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -10,6 +10,7 @@ import { TrialBanner, TrialExpiredScreen } from "@/components/TrialGate";
 import { getTenantName } from "@/lib/tenant";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import PresenceBeacon from "@/components/PresenceBeacon";
 
 type NavItem = { href: string; label: string; match: RegExp };
 type NavGroup = { title?: string; items: NavItem[] };
@@ -324,6 +325,7 @@ export default function ProtectedLayout({ children }: { children: ReactNode }) {
 
   return (
     <ReleaseNotesProvider>
+    <PresenceBeacon />
     <div className="flex min-h-full flex-1 flex-col md:flex-row">
       <aside className="hidden w-52 shrink-0 flex-col border-r border-zinc-200 bg-zinc-50 md:flex print:hidden dark:border-zinc-800 dark:bg-zinc-950">
         <div className="border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">

--- a/apps/admin/src/app/(protected)/page.tsx
+++ b/apps/admin/src/app/(protected)/page.tsx
@@ -6,6 +6,7 @@ import { getSupabase } from "@/lib/supabase";
 import AidShipmentReminder from "@/components/AidShipmentReminder";
 import StoreHeatMap from "@/components/StoreHeatMap";
 import RegionPreferenceSummary from "@/components/RegionPreferenceSummary";
+import OnlineStatsCard from "@/components/OnlineStatsCard";
 import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 
 type Counts = {
@@ -204,6 +205,8 @@ export default function Dashboard() {
           <StatCard href="/suppliers" label="供應商（啟用）" value={counts?.suppliers} accent="text-purple-600 dark:text-purple-400" />
           <StatCard href="/campaigns" label="全部開團" value={counts?.campaigns} accent="text-zinc-600 dark:text-zinc-400" />
         </section>
+
+        <OnlineStatsCard />
 
         <StoreHeatMap focusStoreId={storeId ? Number(storeId) : null} />
 

--- a/apps/admin/src/components/OnlineStatsCard.tsx
+++ b/apps/admin/src/components/OnlineStatsCard.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+// 首頁「在線狀態」卡：同時在線（最近 3 分鐘有心跳）＋ 今日活躍（DAU），
+// 店員端／會員端分開數。資料來自 rpc_online_stats（app_presence 彙總，
+// 心跳由 PresenceBeacon / 會員端 PresenceHeartbeat 每 60 秒回報）。
+// QPS 不自己做 —— 右上角連去 Supabase Reports 現成的 API 流量圖。
+
+import { useEffect, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+
+type OnlineStats = {
+  online_staff: number;
+  online_members: number;
+  online_guests: number;
+  dau_staff: number;
+  dau_members: number;
+  dau_guests: number;
+  daily: { date: string; staff: number; members: number; guests: number }[];
+};
+
+const REFRESH_MS = 60_000;
+
+export default function OnlineStatsCard() {
+  const [stats, setStats] = useState<OnlineStats | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const { data, error } = await getSupabase().rpc("rpc_online_stats");
+      // 首頁的摘要壞掉不該擋住整個儀表板，維持上一筆靜靜等下一輪
+      if (!cancelled && !error && data) setStats(data as OnlineStats);
+    };
+    void load();
+    const timer = setInterval(load, REFRESH_MS);
+    window.addEventListener("focus", load);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+      window.removeEventListener("focus", load);
+    };
+  }, []);
+
+  const projectRef =
+    process.env.NEXT_PUBLIC_SUPABASE_URL?.match(/^https:\/\/([^.]+)\./)?.[1];
+  const days = (stats?.daily ?? []).slice(-7);
+
+  return (
+    <section className="rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <h2 className="text-sm font-semibold">
+          在線狀態 <span className="ml-1 text-xs font-normal text-zinc-500">每分鐘更新</span>
+        </h2>
+        {projectRef && (
+          <a
+            href={`https://supabase.com/dashboard/project/${projectRef}/reports/api-overview`}
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+          >
+            QPS／API 流量（Supabase Reports）→
+          </a>
+        )}
+      </div>
+
+      <div className="grid gap-3 p-4 sm:grid-cols-3 lg:grid-cols-6">
+        <Num label="同時在線・店員" value={stats?.online_staff} accent="text-emerald-600 dark:text-emerald-400" />
+        <Num label="同時在線・會員" value={stats?.online_members} accent="text-emerald-600 dark:text-emerald-400" />
+        <Num label="同時在線・商城訪客" value={stats?.online_guests} accent="text-emerald-600 dark:text-emerald-400" />
+        <Num label="今日活躍・店員" value={stats?.dau_staff} accent="text-blue-600 dark:text-blue-400" />
+        <Num label="今日活躍・會員" value={stats?.dau_members} accent="text-blue-600 dark:text-blue-400" />
+        <Num label="今日活躍・商城訪客" value={stats?.dau_guests} accent="text-blue-600 dark:text-blue-400" />
+      </div>
+
+      {days.length > 1 && (
+        <div className="overflow-x-auto border-t border-zinc-200 dark:border-zinc-800">
+          <table className="min-w-full text-xs">
+            <thead className="bg-zinc-50 dark:bg-zinc-950/40">
+              <tr>
+                <th className="px-3 py-1.5 text-left font-medium text-zinc-500">近 7 日活躍</th>
+                {days.map((d) => (
+                  <th key={d.date} className="px-2 py-1.5 text-right font-normal text-zinc-500">
+                    {d.date.slice(5)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-t border-zinc-100 dark:border-zinc-800">
+                <td className="px-3 py-1.5 text-zinc-500">店員</td>
+                {days.map((d) => (
+                  <td key={d.date} className="px-2 py-1.5 text-right font-mono">{d.staff}</td>
+                ))}
+              </tr>
+              <tr className="border-t border-zinc-100 dark:border-zinc-800">
+                <td className="px-3 py-1.5 text-zinc-500">會員</td>
+                {days.map((d) => (
+                  <td key={d.date} className="px-2 py-1.5 text-right font-mono">{d.members}</td>
+                ))}
+              </tr>
+              <tr className="border-t border-zinc-100 dark:border-zinc-800">
+                <td className="px-3 py-1.5 text-zinc-500">商城訪客</td>
+                {days.map((d) => (
+                  <td key={d.date} className="px-2 py-1.5 text-right font-mono">{d.guests ?? 0}</td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="border-t border-zinc-100 px-4 py-2 text-[11px] text-zinc-400 dark:border-zinc-800">
+        同時在線＝最近 3 分鐘有心跳；活躍＝當天開過後台／會員站／商城（訪客＝未登入逛商城）。指標自 2026-08-27 起累計。
+      </div>
+    </section>
+  );
+}
+
+function Num({ label, value, accent }: { label: string; value: number | undefined; accent?: string }) {
+  return (
+    <div className="rounded-md border border-zinc-100 p-3 dark:border-zinc-800">
+      <div className="text-xs text-zinc-500">{label}</div>
+      <div className={`mt-1 text-2xl font-semibold ${accent ?? ""}`}>{value ?? "…"}</div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/PresenceBeacon.tsx
+++ b/apps/admin/src/components/PresenceBeacon.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { useAuth } from "@/components/AuthProvider";
+
+const INTERVAL_MS = 60_000;
+
+/**
+ * 在線心跳（app_presence）：登入後每 60 秒回報一次，儀表板「同時在線／今日活躍」
+ * 數的就是這個。分頁在背景不打，回到前景立刻補一發（防抖 55 秒）。
+ * 純加值訊號：失敗安靜吞掉，下一分鐘自然重試。
+ */
+export default function PresenceBeacon() {
+  const { session } = useAuth();
+
+  useEffect(() => {
+    if (!session) return;
+    let last = 0;
+    const beat = () => {
+      if (document.visibilityState !== "visible") return;
+      if (Date.now() - last < INTERVAL_MS - 5_000) return;
+      last = Date.now();
+      void getSupabase().rpc("rpc_heartbeat").then(() => {});
+    };
+    beat();
+    const timer = setInterval(beat, INTERVAL_MS);
+    document.addEventListener("visibilitychange", beat);
+    return () => {
+      clearInterval(timer);
+      document.removeEventListener("visibilitychange", beat);
+    };
+  }, [session]);
+
+  return null;
+}

--- a/apps/member/src/app/layout.tsx
+++ b/apps/member/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import ServiceWorkerRegister from "@/components/ServiceWorkerRegister";
 import ErrorLogger from "@/components/ErrorLogger";
+import PresenceHeartbeat from "@/components/PresenceHeartbeat";
 import { bootGuardScript } from "@/lib/bootGuard";
 import { SITE_NAME, SITE_OG_IMAGE, SITE_URL } from "@/lib/site";
 
@@ -74,6 +75,7 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: BOOT_GUARD }} />
         <ErrorLogger />
         <ServiceWorkerRegister />
+        <PresenceHeartbeat />
         {children}
       </body>
     </html>

--- a/apps/member/src/components/PresenceHeartbeat.tsx
+++ b/apps/member/src/components/PresenceHeartbeat.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect } from "react";
+import { getSession } from "@/lib/session";
+import { callLiffApi } from "@/lib/supabase";
+
+const INTERVAL_MS = 60_000;
+const ANON_KEY = "presence_anon_id";
+
+/** 訪客匿名 id：localStorage 一顆 UUID（舊 iOS 沒有 crypto.randomUUID，手拼一顆）。 */
+function getAnonId(): string | null {
+  try {
+    let v = localStorage.getItem(ANON_KEY);
+    if (!v) {
+      if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+        v = crypto.randomUUID();
+      } else {
+        const hex = (n: number) =>
+          Array.from({ length: n }, () => Math.floor(Math.random() * 16).toString(16)).join("");
+        v = `${hex(8)}-${hex(4)}-4${hex(3)}-${hex(4)}-${hex(12)}`;
+      }
+      localStorage.setItem(ANON_KEY, v);
+    }
+    return v;
+  } catch {
+    return null; // localStorage 不可用（無痕/封鎖）就不統計，功能照常
+  }
+}
+
+/**
+ * 在線心跳：admin 儀表板的「同時在線 / 今日活躍」數的就是這個。
+ * - 已登入會員：走 liff-api 的 heartbeat（身分取自 token），每頁都算。
+ * - 未登入訪客：只在商城（/shop*）頁面，用匿名 id 走免 token 的
+ *   guest_heartbeat —— 分享連結點進來還沒登入的人也要算（Alex 2026-08-27）。
+ * - 分頁在背景不打；回到前景立刻補一發（防抖 55 秒）。
+ * - 純加值訊號：失敗安靜吞掉 —— 不進 client_error_logs，網路差時每分鐘
+ *   記一筆只會把真正的錯誤淹掉；下一分鐘自然重試。
+ */
+export default function PresenceHeartbeat() {
+  useEffect(() => {
+    let last = 0;
+    const beat = () => {
+      if (document.visibilityState !== "visible") return;
+      if (Date.now() - last < INTERVAL_MS - 5_000) return;
+
+      const s = getSession();
+      if (s?.token && s.bound) {
+        last = Date.now();
+        callLiffApi(s.token, { action: "heartbeat" }).catch(() => {});
+        return;
+      }
+
+      if (!window.location.pathname.startsWith("/shop")) return;
+      const anon = getAnonId();
+      const base = process.env.NEXT_PUBLIC_SUPABASE_URL;
+      if (!anon || !base) return;
+      last = Date.now();
+      void fetch(`${base}/functions/v1/liff-api`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "guest_heartbeat", anon_id: anon }),
+      }).catch(() => {});
+    };
+    beat();
+    const timer = setInterval(beat, INTERVAL_MS);
+    document.addEventListener("visibilitychange", beat);
+    return () => {
+      clearInterval(timer);
+      document.removeEventListener("visibilitychange", beat);
+    };
+  }, []);
+
+  return null;
+}

--- a/supabase/functions/liff-api/index.ts
+++ b/supabase/functions/liff-api/index.ts
@@ -1709,6 +1709,18 @@ Deno.serve(async (req) => {
     if (action === "get_campaign_preview") {
       return await getCampaignPreview(sb, requireEnv("DEFAULT_TENANT_ID"), Number(body.campaign_id ?? 0), typeof body.sales_channel === "string" ? body.sales_channel : null);
     }
+    if (action === "guest_heartbeat") {
+      // 商城訪客心跳（未登入逛 /shop 的人也要算進在線統計）：免 token。
+      // anon id 由前端 localStorage 產生；UUID 格式檢查與灌水守衛（新列
+      // 速率上限）都在 rpc_guest_heartbeat 裡，這裡照單轉交即可。
+      const { error: ghErr } = await sb.rpc("rpc_guest_heartbeat", {
+        p_tenant: requireEnv("DEFAULT_TENANT_ID"),
+        p_anon_id: String(body.anon_id ?? ""),
+        p_store_id: Number(body.store_id ?? 0) > 0 ? Number(body.store_id) : null,
+      });
+      if (ghErr) console.error("guest_heartbeat failed:", ghErr);
+      return json({ ok: true });
+    }
     if (action === "log_client_error" || action === "report_client_logs") {
       // 有帶 token 就順便解出來補會員資訊；解不開不算錯（登入前的錯誤本來就沒 token）
       let logClaims: Record<string, unknown> | null = null;
@@ -1765,6 +1777,13 @@ Deno.serve(async (req) => {
         case "list_spot_products": return await listSpotProducts(sb, tenantId, storeId, memberId);
         case "get_spot_product": return await getSpotProduct(sb, tenantId, storeId, memberId, Number(body.id ?? 0));
         case "track_spot_view": if (!memberId) return json({ error: "no member_id" }, 401); return await trackSpotView(sb, tenantId, memberId, Number(body.id ?? 0));
+        case "heartbeat": {
+          // 在線心跳（admin 儀表板「同時在線 / DAU」）。身分一律取自驗過的 JWT。
+          if (!memberId) return json({ error: "no member_id" }, 401);
+          const { error: hbErr } = await sb.rpc("rpc_member_heartbeat", { p_tenant: tenantId, p_member_id: memberId, p_store_id: storeId || null });
+          if (hbErr) { console.error("heartbeat failed:", hbErr); return json({ ok: false }, 500); }
+          return json({ ok: true });
+        }
         case "place_member_order": if (!memberId) return json({ error: "no member_id" }, 401); return await placeMemberOrder(sb, tenantId, memberId, body);
         case "get_line_bind_state": if (!memberId) return json({ error: "no member_id" }, 401); return await getLineBindState(sb, tenantId, memberId, Number(body.store_id ?? 0) || storeId);
         case "start_line_binding": if (!memberId) return json({ error: "no member_id" }, 401); return await startLineBinding(sb, tenantId, memberId, Number(body.store_id ?? 0) || storeId);

--- a/supabase/migrations/20260827010000_online_presence_metrics.sql
+++ b/supabase/migrations/20260827010000_online_presence_metrics.sql
@@ -1,0 +1,150 @@
+-- ============================================================================
+-- 2026-08-27: 在線人數 / DAU 指標（admin 儀表板用）
+--
+-- Alex：想看「多少人同時上線」「QPS / DAU」。QPS 不自己做（Supabase Dashboard
+--   → Reports → API 現成就有，前端卡片放連結）；這支只做 presence / DAU：
+--   - 兩個 app 登入後每 60 秒打一次心跳（admin 走 rpc_heartbeat、member 走
+--     liff-api 的 heartbeat action → rpc_member_heartbeat）。
+--   - 「同時在線」＝最近 3 分鐘有心跳的不重複人數（心跳 60s，3 分鐘容錯）。
+--   - DAU＝當天（台北時區日界線）有心跳的不重複人數；一列 = (人,天)，
+--     列數即 DAU，量級每天數百列，保留 90 天由 cron 清理。
+--
+-- 設計取捨：
+--   - 不用 Realtime Presence（要開 channel、會員端 LIFF 不掛 supabase-js 連線），
+--     心跳寫表最笨最穩，量也小（尖峰 ~200 人 × 每分鐘 1 列 upsert）。
+--   - app_presence 開 RLS 但不開任何 policy —— 讀寫全走 SECURITY DEFINER RPC
+--     與 service_role（liff-api），前端拿不到明細，只拿得到 rpc_online_stats
+--     的彙總數字。
+--   - auth.* 一律包 (SELECT ...)（見 20260818000020 RLS initplan 的教訓）。
+--
+-- Rollback：cron.unschedule('presence-prune-daily')；DROP FUNCTION
+--   rpc_online_stats / rpc_member_heartbeat / rpc_heartbeat；DROP TABLE
+--   app_presence。純新增，無既有物件被改動。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.app_presence (
+  tenant_id     UUID        NOT NULL,
+  kind          TEXT        NOT NULL CHECK (kind IN ('staff', 'member')),
+  subject_id    TEXT        NOT NULL,  -- staff: auth.uid()；member: members.id
+  seen_date     DATE        NOT NULL,  -- 台北時區日界線
+  store_id      BIGINT,
+  first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_seen_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT app_presence_pkey PRIMARY KEY (tenant_id, kind, subject_id, seen_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_presence_tenant_last_seen
+  ON public.app_presence (tenant_id, last_seen_at DESC);
+
+ALTER TABLE public.app_presence ENABLE ROW LEVEL SECURITY;
+-- 刻意不開任何 policy：讀寫全走 SECURITY DEFINER RPC / service_role。
+
+-- ---------------------------------------------------------------------------
+-- 店員心跳（admin 前端每 60 秒呼叫；身分取自 JWT，前端帶不了別人的身分）
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_heartbeat(p_store_id BIGINT DEFAULT NULL)
+RETURNS VOID
+LANGUAGE sql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  INSERT INTO app_presence (tenant_id, kind, subject_id, seen_date, store_id, last_seen_at)
+  SELECT ((SELECT auth.jwt()) ->> 'tenant_id')::uuid,
+         'staff',
+         (SELECT auth.uid())::text,
+         (NOW() AT TIME ZONE 'Asia/Taipei')::date,
+         p_store_id,
+         NOW()
+   WHERE (SELECT auth.uid()) IS NOT NULL
+     AND COALESCE((SELECT auth.jwt()) ->> 'tenant_id', '') <> ''
+  ON CONFLICT (tenant_id, kind, subject_id, seen_date)
+  DO UPDATE SET last_seen_at = NOW(),
+                store_id     = COALESCE(EXCLUDED.store_id, app_presence.store_id);
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_heartbeat(BIGINT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_heartbeat(BIGINT) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 會員心跳（只給 liff-api（service_role）呼叫；member 身分由 liff-api 驗過
+-- session 後帶進來，authenticated / anon 一律不可執行）
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_member_heartbeat(
+  p_tenant UUID, p_member_id BIGINT, p_store_id BIGINT DEFAULT NULL)
+RETURNS VOID
+LANGUAGE sql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  INSERT INTO app_presence (tenant_id, kind, subject_id, seen_date, store_id, last_seen_at)
+  SELECT p_tenant, 'member', p_member_id::text,
+         (NOW() AT TIME ZONE 'Asia/Taipei')::date, p_store_id, NOW()
+   WHERE p_tenant IS NOT NULL AND p_member_id IS NOT NULL
+  ON CONFLICT (tenant_id, kind, subject_id, seen_date)
+  DO UPDATE SET last_seen_at = NOW(),
+                store_id     = COALESCE(EXCLUDED.store_id, app_presence.store_id);
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_member_heartbeat(UUID, BIGINT, BIGINT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_member_heartbeat(UUID, BIGINT, BIGINT) FROM authenticated, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_member_heartbeat(UUID, BIGINT, BIGINT) TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 儀表板彙總（任何登入的後台使用者可讀；只回數字不回明細）
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_online_stats()
+RETURNS JSONB
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  WITH me AS (
+    SELECT (((SELECT auth.jwt()) ->> 'tenant_id'))::uuid AS tenant
+     WHERE COALESCE((SELECT auth.jwt()) ->> 'tenant_id', '') <> ''
+  ),
+  today AS (SELECT (NOW() AT TIME ZONE 'Asia/Taipei')::date AS d)
+  SELECT jsonb_build_object(
+    'online_staff', (
+      SELECT COUNT(*) FROM app_presence p, me, today
+       WHERE p.tenant_id = me.tenant AND p.kind = 'staff'
+         AND p.seen_date = today.d
+         AND p.last_seen_at > NOW() - INTERVAL '3 minutes'),
+    'online_members', (
+      SELECT COUNT(*) FROM app_presence p, me, today
+       WHERE p.tenant_id = me.tenant AND p.kind = 'member'
+         AND p.seen_date = today.d
+         AND p.last_seen_at > NOW() - INTERVAL '3 minutes'),
+    'dau_staff', (
+      SELECT COUNT(*) FROM app_presence p, me, today
+       WHERE p.tenant_id = me.tenant AND p.kind = 'staff' AND p.seen_date = today.d),
+    'dau_members', (
+      SELECT COUNT(*) FROM app_presence p, me, today
+       WHERE p.tenant_id = me.tenant AND p.kind = 'member' AND p.seen_date = today.d),
+    'daily', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+               'date', x.d, 'staff', x.staff, 'members', x.members)
+               ORDER BY x.d), '[]'::jsonb)
+        FROM (
+          SELECT p.seen_date AS d,
+                 COUNT(*) FILTER (WHERE p.kind = 'staff')  AS staff,
+                 COUNT(*) FILTER (WHERE p.kind = 'member') AS members
+            FROM app_presence p, me, today
+           WHERE p.tenant_id = me.tenant
+             AND p.seen_date >= today.d - 13
+           GROUP BY p.seen_date
+        ) x)
+  )
+  FROM (SELECT 1) _one
+  WHERE EXISTS (SELECT 1 FROM me);
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_online_stats() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_online_stats() TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 保留 90 天（cron.schedule 同名 job 為 idempotent，重複 run migration 不會炸）
+-- 20:30 UTC = 台北 04:30 離峰
+-- ---------------------------------------------------------------------------
+SELECT cron.schedule(
+  'presence-prune-daily',
+  '30 20 * * *',
+  $$DELETE FROM public.app_presence
+     WHERE seen_date < ((NOW() AT TIME ZONE 'Asia/Taipei')::date - 90)$$
+);

--- a/supabase/migrations/20260827020000_presence_guest_kind.sql
+++ b/supabase/migrations/20260827020000_presence_guest_kind.sql
@@ -1,0 +1,122 @@
+-- ============================================================================
+-- 2026-08-27 (2): 在線統計加「商城訪客」—— 沒登入逛 /shop 的人也要算
+--
+-- Alex：「商城頁面也要一起統計」。會員端的 /shop 分享連結點進來的人很多
+--   還沒登入（沒有 member session），20260827010000 的心跳只數得到已綁定
+--   會員。這支加第三種 kind='guest'：前端在 /shop* 頁、無會員 session 時，
+--   用 localStorage 隨機 anon id 打 liff-api 免 token 的 guest_heartbeat。
+--
+-- 防灌水：免 token 端點任何人打得到，rpc_guest_heartbeat 內建兩道守衛 ——
+--   anon id 必須是 UUID 格式；當天新訪客列建立速率超過 600 列/分鐘時
+--   只更新既有列、不再新增（正常商城流量遠低於此，灌水最多讓「訪客數」
+--   停止上升，不會撐爆表）。
+--
+-- 基底：app_presence / rpc_online_stats ← 20260827010000（今天剛建，無其他修改）。
+-- Rollback：DROP FUNCTION rpc_guest_heartbeat；rpc_online_stats 重跑
+--   20260827010000 的版本；CHECK constraint 改回 ('staff','member')
+--   （先 DELETE kind='guest' 的列）。
+-- ============================================================================
+
+ALTER TABLE public.app_presence DROP CONSTRAINT IF EXISTS app_presence_kind_check;
+ALTER TABLE public.app_presence
+  ADD CONSTRAINT app_presence_kind_check CHECK (kind IN ('staff', 'member', 'guest'));
+
+-- ---------------------------------------------------------------------------
+-- 訪客心跳（只給 liff-api（service_role）呼叫；anon id 由前端 localStorage 產生）
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_guest_heartbeat(
+  p_tenant UUID, p_anon_id TEXT, p_store_id BIGINT DEFAULT NULL)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_today DATE := (NOW() AT TIME ZONE 'Asia/Taipei')::date;
+BEGIN
+  IF p_tenant IS NULL
+     OR p_anon_id IS NULL
+     OR p_anon_id !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+    RETURN;
+  END IF;
+
+  -- 新列速率守衛：這一分鐘內新建的訪客列已超過 600 → 只更新既有列
+  IF NOT EXISTS (SELECT 1 FROM app_presence
+                  WHERE tenant_id = p_tenant AND kind = 'guest'
+                    AND subject_id = p_anon_id AND seen_date = v_today)
+     AND (SELECT COUNT(*) FROM app_presence
+           WHERE kind = 'guest' AND seen_date = v_today
+             AND first_seen_at > NOW() - INTERVAL '1 minute') > 600 THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO app_presence (tenant_id, kind, subject_id, seen_date, store_id, last_seen_at)
+  VALUES (p_tenant, 'guest', p_anon_id, v_today, p_store_id, NOW())
+  ON CONFLICT (tenant_id, kind, subject_id, seen_date)
+  DO UPDATE SET last_seen_at = NOW(),
+                store_id     = COALESCE(EXCLUDED.store_id, app_presence.store_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_guest_heartbeat(UUID, TEXT, BIGINT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_guest_heartbeat(UUID, TEXT, BIGINT) FROM authenticated, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_guest_heartbeat(UUID, TEXT, BIGINT) TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 彙總加訪客（基底 20260827010000，加 online_guests / dau_guests / daily.guests）
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_online_stats()
+RETURNS JSONB
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  WITH me AS (
+    SELECT (((SELECT auth.jwt()) ->> 'tenant_id'))::uuid AS tenant
+     WHERE COALESCE((SELECT auth.jwt()) ->> 'tenant_id', '') <> ''
+  ),
+  today AS (SELECT (NOW() AT TIME ZONE 'Asia/Taipei')::date AS d)
+  SELECT jsonb_build_object(
+    'online_staff', (
+      SELECT COUNT(*) FROM app_presence p, me, today
+       WHERE p.tenant_id = me.tenant AND p.kind = 'staff'
+         AND p.seen_date = today.d
+         AND p.last_seen_at > NOW() - INTERVAL '3 minutes'),
+    'online_members', (
+      SELECT COUNT(*) FROM app_presence p, me, today
+       WHERE p.tenant_id = me.tenant AND p.kind = 'member'
+         AND p.seen_date = today.d
+         AND p.last_seen_at > NOW() - INTERVAL '3 minutes'),
+    'online_guests', (
+      SELECT COUNT(*) FROM app_presence p, me, today
+       WHERE p.tenant_id = me.tenant AND p.kind = 'guest'
+         AND p.seen_date = today.d
+         AND p.last_seen_at > NOW() - INTERVAL '3 minutes'),
+    'dau_staff', (
+      SELECT COUNT(*) FROM app_presence p, me, today
+       WHERE p.tenant_id = me.tenant AND p.kind = 'staff' AND p.seen_date = today.d),
+    'dau_members', (
+      SELECT COUNT(*) FROM app_presence p, me, today
+       WHERE p.tenant_id = me.tenant AND p.kind = 'member' AND p.seen_date = today.d),
+    'dau_guests', (
+      SELECT COUNT(*) FROM app_presence p, me, today
+       WHERE p.tenant_id = me.tenant AND p.kind = 'guest' AND p.seen_date = today.d),
+    'daily', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+               'date', x.d, 'staff', x.staff, 'members', x.members, 'guests', x.guests)
+               ORDER BY x.d), '[]'::jsonb)
+        FROM (
+          SELECT p.seen_date AS d,
+                 COUNT(*) FILTER (WHERE p.kind = 'staff')  AS staff,
+                 COUNT(*) FILTER (WHERE p.kind = 'member') AS members,
+                 COUNT(*) FILTER (WHERE p.kind = 'guest')  AS guests
+            FROM app_presence p, me, today
+           WHERE p.tenant_id = me.tenant
+             AND p.seen_date >= today.d - 13
+           GROUP BY p.seen_date
+        ) x)
+  )
+  FROM (SELECT 1) _one
+  WHERE EXISTS (SELECT 1 FROM me);
+$$;
+
+REVOKE ALL ON FUNCTION public.rpc_online_stats() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_online_stats() TO authenticated;


### PR DESCRIPTION
## 做了什麼

- 新增 `app_presence` 心跳表（一列＝人×天，台北日界線；`20260827010000` / `20260827020000`），三種來源每 60 秒回報一次：
  - **後台店員**：`PresenceBeacon`（掛 protected layout）打 `rpc_heartbeat`，身分取自 JWT。
  - **會員**：`PresenceHeartbeat`（掛會員站 root layout）走 liff-api 新增的 `heartbeat` action，member_id 只認驗過的 token。
  - **商城訪客**：未登入逛 `/shop*` 用 localStorage 匿名 UUID 走免 token 的 `guest_heartbeat`。
- 儀表板新增「在線狀態」卡（`OnlineStatsCard` + `rpc_online_stats`）：同時在線（最近 3 分鐘有心跳）、今日活躍、近 7 日活躍表，三種身分分開數；右上角連去 Supabase Reports 的現成 API 流量圖（QPS 不自己造輪子）。
- 資料保留 90 天，`presence-prune-daily` cron（台北 04:30）自動清。

## 上線危險

- 做了：純新增（新表、新 RPC、liff-api 新 action、前端心跳與卡片），不動任何既有物件。心跳負載：尖峰 ~每分鐘數百次單列 upsert，可忽略。免 token 的 `guest_heartbeat` 有兩道防灌水：UUID 格式檢查＋當天新列速率上限（600 列/分鐘，超過只更新不新增）。
- 不做：`app_presence` 開 RLS 但不開任何 policy —— 讀寫全走 SECURITY DEFINER RPC 與 service_role，前端只拿得到 `rpc_online_stats` 的彙總數字，拿不到誰在線的明細。心跳失敗一律安靜吞掉，不會影響任何功能、也不寫 client_error_logs。
- 回退：前端拆掉三個元件；DB 照 `20260827020000` 檔頭的 rollback（unschedule cron、DROP 三支 RPC 與表）。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- 兩支 migration 過 `check-sql-syntax.cjs`，已套上正式庫；三支 RPC 在 transaction 內實測後 ROLLBACK（staff／member／stats 數字正確）。
- liff-api 已用 Management API 部署（v83）：OPTIONS 200、無 token `heartbeat` 回 401、簽測試 token 打 `heartbeat` 與免 token `guest_heartbeat` 都落表成功，測試列已清除。
- `apps/member`、`apps/admin` `npm run build` 均綠（含舊機 Safari 15.6 相容檢查）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013K4MYsuYw9wpFiC8Bc93zz

---
_Generated by [Claude Code](https://claude.ai/code/session_013K4MYsuYw9wpFiC8Bc93zz)_