### PR TITLE
庫存頁顯示零售／分店價、現貨直配改收零售價；取貨閘門 Path D 改逐品項

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/page.tsx
@@ -8,7 +8,7 @@ import SpinButton from "@/components/SpinButton";
 import SearchSpinner from "@/components/SearchSpinner";
 import { useUserBranchStoreId, useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
 import { maskLineUserId } from "@/lib/maskLineUserId";
-import { useRole, canSeeCost } from "@/lib/role";
+import { useRole, canSeeCost, canSeeBranch } from "@/lib/role";
 import { AddStockModal } from "@/components/AddStockModal";
 import { SpotSaleModal } from "@/components/SpotSaleModal";
 import { translateRpcError } from "@/lib/rpcError";
@@ -25,6 +25,8 @@ type Balance = {
   last_movement_at: string | null;
 };
 type Sku = { id: number; sku_code: string; product_name: string | null; variant_name: string | null; base_unit: string };
+// 每個 SKU 的現行售價（effective_to IS NULL 的那筆；同 scope 多筆取 effective_from 最新）
+type SkuPrices = { retail?: number; branch?: number };
 type Reorder = { location_id: number; sku_id: number; safety_stock: number; reorder_point: number };
 // rpc_get_stock_commitment_bulk 的一列：這個 (倉別, SKU) 的貨被誰佔著、還剩幾件能配
 type Commitment = {
@@ -113,6 +115,8 @@ export default function InventoryOverviewPage() {
   // 成本只給總倉層級看（分店 store_manager / store_staff 一律遮掉）
   const role = useRole();
   const showCost = canSeeCost(role);
+  // 分店價只給 canSeeBranch 的角色看（store_staff 只看零售價）
+  const showBranchPrice = canSeeBranch(role);
   // 商品/倉別/在庫/待客取/內部單/可分配/在途/(均成本)/最後異動/展開箭頭
   const colCount = showCost ? 10 : 9;
 
@@ -139,6 +143,9 @@ export default function InventoryOverviewPage() {
   const [error, setError] = useState<string | null>(null);
 
   const [skuMap, setSkuMap] = useState<Map<number, Sku>>(new Map());
+  // 零售價／分店價（老闆 2026-08-27：庫存頁要看得到兩個價；分店價照 canSeeBranch 收斂，
+  // RLS 那層對 store_staff 本來就不回 branch 列，這裡只是雙保險）
+  const [priceMap, setPriceMap] = useState<Map<number, SkuPrices>>(new Map());
   const [reorderMap, setReorderMap] = useState<Map<string, Reorder>>(new Map());
   const [truncated, setTruncated] = useState(false);
 
@@ -326,17 +333,33 @@ export default function InventoryOverviewPage() {
         // 補 sku + reorder_rules + 承諾量拆解（僅本頁可見列）
         const skuIds = Array.from(new Set(pageRows.map((r) => r.sku_id)));
         if (skuIds.length > 0) {
-          const [sk, rr, cm] = await Promise.all([
+          const [sk, rr, cm, pr] = await Promise.all([
             sb.from("skus").select("id, sku_code, product_name, variant_name, base_unit").in("id", skuIds),
             sb.from("reorder_rules").select("location_id, sku_id, safety_stock, reorder_point").in("sku_id", skuIds),
             // 一頁一次，不要每列各打一次
             sb.rpc("rpc_get_stock_commitment_bulk", {
               p_pairs: pageRows.map((r) => ({ location_id: r.location_id, sku_id: r.sku_id })),
             }),
+            // 現行售價（RLS 依 role × scope 過濾：store_staff 拿不到 branch）
+            sb
+              .from("prices")
+              .select("sku_id, scope, price, effective_from")
+              .in("sku_id", skuIds)
+              .in("scope", ["retail", "branch"])
+              .is("effective_to", null)
+              .order("effective_from", { ascending: false }),
           ]);
           if (cancelled) return;
           const sm = new Map<number, Sku>();
           for (const s of (sk.data as Sku[]) ?? []) sm.set(s.id, s);
+          const pm = new Map<number, SkuPrices>();
+          for (const p of (pr.data as { sku_id: number; scope: string; price: number }[]) ?? []) {
+            const slot = pm.get(p.sku_id) ?? {};
+            // 已依 effective_from 倒序 → 同 scope 只收第一筆（最新生效的）
+            if (p.scope === "retail" && slot.retail === undefined) slot.retail = Number(p.price);
+            if (p.scope === "branch" && slot.branch === undefined) slot.branch = Number(p.price);
+            pm.set(p.sku_id, slot);
+          }
           const rm = new Map<string, Reorder>();
           for (const r of (rr.data as Reorder[]) ?? []) rm.set(`${r.location_id}-${r.sku_id}`, r);
           const cmap = new Map<string, Commitment>();
@@ -352,10 +375,12 @@ export default function InventoryOverviewPage() {
             });
           }
           setSkuMap(sm);
+          setPriceMap(pm);
           setReorderMap(rm);
           setCommitMap(cmap);
         } else {
           setSkuMap(new Map());
+          setPriceMap(new Map());
           setReorderMap(new Map());
           setCommitMap(new Map());
         }
@@ -592,6 +617,7 @@ export default function InventoryOverviewPage() {
             rows.flatMap((r) => {
               const key = `${r.location_id}-${r.sku_id}`;
               const sku = skuMap.get(r.sku_id);
+              const prices = priceMap.get(r.sku_id);
               const rule = reorderMap.get(key);
               const commit = commitMap.get(key) ?? null;
               const isLow = rule != null && r.on_hand <= num(rule.reorder_point);
@@ -608,6 +634,21 @@ export default function InventoryOverviewPage() {
                       {sku?.variant_name ? <span className="ml-1 text-zinc-500">/ {sku.variant_name}</span> : null}
                     </div>
                     <div className="font-mono text-xs text-zinc-500">{sku?.sku_code ?? `sku#${r.sku_id}`}</div>
+                    {/* 零售/分店價（老闆 2026-08-27）：配給客人用零售價，這裡先看得到 */}
+                    {(prices?.retail !== undefined || (showBranchPrice && prices?.branch !== undefined)) && (
+                      <div className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[10px]">
+                        {prices?.retail !== undefined && (
+                          <span className="rounded bg-emerald-100 px-1 py-0.5 font-bold text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+                            零售 ${prices.retail}
+                          </span>
+                        )}
+                        {showBranchPrice && prices?.branch !== undefined && (
+                          <span className="rounded bg-amber-100 px-1 py-0.5 font-bold text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                            分店 ${prices.branch}
+                          </span>
+                        )}
+                      </div>
+                    )}
                   </Td>
                   <Td className="text-xs">{locLabel(r.location_id)}</Td>
                   <Td align="right" className="font-mono">

--- a/apps/admin/src/components/SpotSaleModal.tsx
+++ b/apps/admin/src/components/SpotSaleModal.tsx
@@ -5,6 +5,7 @@ import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
+import { useRole, canSeeBranch } from "@/lib/role";
 
 // 現貨直配：把店內現貨直接配給客人，不需要先開團。
 // 配單＝待取 —— 當下不扣庫存、不收款，客人到店取貨時才寫 sale 並結案
@@ -37,10 +38,14 @@ type Availability = {
   pool_arrived: number;    // 其中已到店的部分 —— 這些配得掉
   free: number;            // 純自由量（沒有任何單掛著）
   free_with_pool: number;  // 可配上限＝自由量 ＋ 已到貨池子
+  // 零售價優先（20260827020000 起；之前是分店價優先）。賣給終端客人收零售價。
   suggest_price: number;
+  retail_price: number | null;  // 沒設價 = null（跟 0 元區分開）
+  branch_price: number | null;
 };
 
 const num = (v: unknown) => (v == null ? 0 : Number(v));
+const numOrNull = (v: unknown) => (v == null ? null : Number(v));
 
 export function SpotSaleModal({
   storeId,
@@ -59,6 +64,9 @@ export function SpotSaleModal({
   onClose: () => void;
   onSaved: () => void;
 }) {
+  // 分店價只給 canSeeBranch 的角色看（跟商品編輯頁同一套收斂）
+  const role = useRole();
+  const showBranchPrice = canSeeBranch(role);
   const [avail, setAvail] = useState<Availability | null>(null);
   const [term, setTerm] = useState("");
   const [hits, setHits] = useState<MemberHit[]>([]);
@@ -93,6 +101,8 @@ export function SpotSaleModal({
         free: num(a.free),
         free_with_pool: num(a.free_with_pool),
         suggest_price: num(a.suggest_price),
+        retail_price: numOrNull(a.retail_price),
+        branch_price: numOrNull(a.branch_price),
       };
       setAvail(parsed);
       setQty((q) => Math.max(1, Math.min(q, parsed.free_with_pool)));
@@ -231,6 +241,21 @@ export function SpotSaleModal({
               )}
             </div>
           )}
+          {/* 零售/分店價並列：預填的是零售價，店員要看得出另一個是多少 */}
+          {avail && (avail.retail_price != null || avail.branch_price != null) && (
+            <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px]">
+              {avail.retail_price != null && (
+                <span className="rounded bg-emerald-100 px-1.5 py-0.5 font-bold text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+                  零售 ${avail.retail_price}
+                </span>
+              )}
+              {showBranchPrice && avail.branch_price != null && (
+                <span className="rounded bg-amber-100 px-1.5 py-0.5 font-bold text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                  分店 ${avail.branch_price}
+                </span>
+              )}
+            </div>
+          )}
           {/* 會動到池子時一定要講：店家看的可轉出量會跟著少，不講就是憑空消失 */}
           {avail && fromPool > 0 && (
             <div className="mt-1.5 text-[11px] text-amber-700 dark:text-amber-400">
@@ -350,7 +375,11 @@ export function SpotSaleModal({
               className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-right tabular-nums dark:border-zinc-700 dark:bg-zinc-800"
             />
             <span className="mt-1 block text-[11px] text-zinc-400">
-              {priceNum > 0 ? "預填現售價，可改" : "必填，不可為 0"}
+              {priceNum <= 0
+                ? "必填，不可為 0"
+                : avail?.retail_price != null
+                  ? "預填零售價，可改"
+                  : "未設零售價，預填分店價，可改"}
             </span>
           </label>
         </div>

--- a/supabase/migrations/20260827020000_spot_sale_suggest_retail_price.sql
+++ b/supabase/migrations/20260827020000_spot_sale_suggest_retail_price.sql
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- 現貨直配的建議售價改成「零售價優先」，並把零售/分店兩個價都回給前端
+-- ============================================================================
+-- 老闆 2026-08-27 交代：庫存總覽要看得到分店價跟零售價，「配給客人」要用零售價。
+-- 原本 suggest_price 是 COALESCE(branch, retail, 0) —— 分店價優先，所以彈窗
+-- 預填 $85（分店價）而不是 $109（零售價）。現貨直配是賣給終端客人，收零售價。
+--
+-- 基底版本：20260824060000（rpc_get_spot_availability 最新版，含池子拆解
+--   pool_arrived / pool_in_transit / free_with_pool）。
+-- rollback：重跑 20260824060000 該函式段落即可（本支只動 suggest_price 的
+--   COALESCE 順序、多回 retail_price / branch_price 兩個 key，其餘逐字保留）。
+--
+-- 變更：
+--   1. suggest_price = COALESCE(retail, branch, 0)（原本 branch 優先）。
+--   2. 多回 'retail_price' / 'branch_price'（沒設價 = null）：
+--      彈窗與庫存頁要同時顯示兩個價，讓店員看得出預填的是哪一個。
+--      注意這支是 SECURITY DEFINER，branch_price 對 store_staff 也回得出來
+--      —— 舊版 suggest_price 本來就是分店價、早就給 store_staff 看了，
+--      沒有多洩漏；前端顯示照 canSeeBranch 收斂。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_get_spot_availability(
+  p_store_id BIGINT,
+  p_sku_id   BIGINT
+) RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'on_hand',      COALESCE(oh.on_hand, 0),
+    'promised',     COALESCE(c.promised, 0),
+    'waiting',      COALESCE(c.waiting, 0),
+    'pool',         COALESCE(c.pool_claimed, 0),
+    'free',         public._sku_free_qty(p_store_id, p_sku_id),
+    -- 池子拆解：已到貨的可以配（配掉會自動扣池子），在途的維持保留
+    'pool_arrived',    COALESCE(c.pool_arrived, 0),
+    'pool_in_transit', COALESCE(c.pool_claimed, 0) - COALESCE(c.pool_arrived, 0),
+    'free_with_pool',  public._sku_free_qty_with_pool(p_store_id, p_sku_id),
+    -- 賣給終端客人 → 零售價優先（2026-08-27 前是分店價優先）
+    'suggest_price', COALESCE(px.retail_price, px.branch_price, 0),
+    'retail_price',  px.retail_price,
+    'branch_price',  px.branch_price
+  )
+    FROM (
+      SELECT st.tenant_id, sb.on_hand
+        FROM stores st
+        LEFT JOIN stock_balances sb
+               ON sb.tenant_id   = st.tenant_id
+              AND sb.location_id = st.location_id
+              AND sb.sku_id      = p_sku_id
+       WHERE st.id = p_store_id
+    ) oh
+    LEFT JOIN LATERAL public._sku_commitment(p_store_id, ARRAY[p_sku_id]) c ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT
+        (SELECT p.price FROM prices p
+          WHERE p.tenant_id = oh.tenant_id AND p.sku_id = p_sku_id AND p.scope = 'retail'
+            AND p.effective_from <= NOW() AND (p.effective_to IS NULL OR p.effective_to > NOW())
+          ORDER BY p.effective_from DESC LIMIT 1) AS retail_price,
+        (SELECT p.price FROM prices p
+          WHERE p.tenant_id = oh.tenant_id AND p.sku_id = p_sku_id AND p.scope = 'branch'
+            AND p.effective_from <= NOW() AND (p.effective_to IS NULL OR p.effective_to > NOW())
+          ORDER BY p.effective_from DESC LIMIT 1) AS branch_price
+    ) px ON TRUE;
+$$;
+
+COMMENT ON FUNCTION public.rpc_get_spot_availability(BIGINT, BIGINT) IS
+  '現貨直配彈窗的預檢：在庫 / 待客取 / 等貨中 / 內部池（含拆已到貨與在途）/ '
+  '自由量 / 含池子可配量 / 建議售價（零售價優先）＋ 零售/分店價各自回傳。'
+  '伺服端開單時會再驗一次 _sku_free_qty(_with_pool)，這裡只是畫面預檢。';
+
+REVOKE ALL ON FUNCTION public.rpc_get_spot_availability(BIGINT, BIGINT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_get_spot_availability(BIGINT, BIGINT) TO authenticated;

--- a/supabase/migrations/20260827030000_pickup_gate_dn_per_item.sql
+++ b/supabase/migrations/20260827030000_pickup_gate_dn_per_item.sql
@@ -1,0 +1,380 @@
+-- ============================================================================
+-- 取貨閘門 Path D 改成「逐品項」：減抵單只放行它指名的那一行
+-- ============================================================================
+-- 災情（Alex 2026-08-27 回報：「為什麼我配一個人卻有兩個人可以拿貨」）：
+--   松山店 GRP-20260826-052 / sku 5938（304 不銹鋼便攜餐具）on_hand = 1。
+--   店員在訂單頁對 -0004（陳麗文）按「📦 從庫存配貨」→ 開了一張 DN（qty 1，
+--   reason「訂單頁從庫存配貨 GRP-20260826-052-0004」）。
+--   結果 -0003（安文）也一起亮出「✅ 去取貨」—— 那張單完全沒有供給
+--   （supplied = 0、available = 0、沒有 transfer、沒有自己的 DN）。
+--
+-- 原因：Path D 的判準只有 (tenant, campaign, store, sku) —— **不看是哪一行**。
+--   同團同店同 SKU 只要有任何一張未作廢的 DN，整組每一行都被放行；
+--   而 Path D 同時也是 campaign-local 數量守衛的豁免條件，所以量也不擋。
+--   第二道（實體庫存守衛，20260818000010）擋不住這一組：它的母體只算
+--   「單頭已承諾（ready / partially_completed / shipping）」的行，而這兩張單頭
+--   都還是 pending → 各自累計都只有自己 1 件 ≤ on_hand 1，兩張都過。
+--   → 一件貨、兩個客人都能領走，先到的領完第二位撲空，庫存扣成負的
+--     （rpc_record_pickup 不做庫存檢查，閘門是唯一防線）。
+--
+-- 修法：Path D 改問 inventory_deduction_note_items.order_item_id —— 這一行
+--   身上有沒有還沒釋放的覆蓋量（口徑與 _order_item_stock_budget 的 `mine`
+--   完全一致：qty − released_qty > 0、單未作廢）。
+--   兩處 Path D（主判斷、campaign-local 守衛的豁免）都改，共用同一支 helper
+--   `_pickup_dn_covers_item` —— 兩邊各寫一份正是這種 bug 的來源。
+--
+--   ⚠ 舊 DN 相容：`inventory_deduction_note_items` 是 20260805000170 才有的，
+--     線上還有 2 張未作廢的 DN 沒有任何明細列。那種一律維持**整組放行**
+--     （沒有明細就無從判斷指名誰），否則舊單會突然取不了貨。
+--     有明細的 DN（線上 110 列，order_item_id NOT NULL、0 筆缺連結）一律逐行判。
+--
+-- 影響範圍（套用前對線上實測，見 PR 說明）：
+--   閘門由 true 轉 false 的品項＝那些「沾別人的 DN 才亮著」的行。
+--
+-- 基底版本：20260818000010_pickup_gate_store_stock_guard.sql
+--   （逐字抽出線上定義後只改兩處 Path D；其餘 Path A/B/C/D'、兩道數量守衛
+--     一字未動。20260819000000 之後沒有人再改過這支函式。）
+-- Rollback：重跑 20260818000010 的 is_order_item_pickup_ready 段落，
+--   再 DROP FUNCTION public._pickup_dn_covers_item(BIGINT, UUID, BIGINT, BIGINT, BIGINT);
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. _pickup_dn_covers_item — 「這一行有沒有被減抵單覆蓋」的唯一算法
+--    簡單 SQL 函式，planner 會 inline，不會多一層呼叫成本。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._pickup_dn_covers_item(
+  p_item_id     BIGINT,
+  p_tenant_id   UUID,
+  p_campaign_id BIGINT,
+  p_store_id    BIGINT,
+  p_sku_id      BIGINT
+) RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    -- 指名這一行的覆蓋（口徑同 _order_item_stock_budget 的 mine）
+    EXISTS (
+      SELECT 1
+        FROM inventory_deduction_note_items ni
+        JOIN inventory_deduction_notes n ON n.id = ni.note_id
+       WHERE ni.order_item_id = p_item_id
+         AND n.cancelled_at IS NULL
+         AND GREATEST(ni.qty - COALESCE(ni.released_qty, 0), 0) > 0
+    )
+    -- 舊 DN（沒有逐品項明細）維持整組放行，不然舊單會突然取不了貨
+    OR EXISTS (
+      SELECT 1
+        FROM inventory_deduction_notes n
+       WHERE n.tenant_id   = p_tenant_id
+         AND n.campaign_id = p_campaign_id
+         AND n.store_id    = p_store_id
+         AND n.sku_id      = p_sku_id
+         AND n.cancelled_at IS NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM inventory_deduction_note_items ni2 WHERE ni2.note_id = n.id
+         )
+    );
+$$;
+
+COMMENT ON FUNCTION public._pickup_dn_covers_item(BIGINT, UUID, BIGINT, BIGINT, BIGINT) IS
+  '取貨閘門 Path D 的唯一判準：這一行有沒有被未作廢的庫存減抵單指名覆蓋'
+  '（qty − released_qty > 0）。沒有逐品項明細的舊 DN 維持整組放行。'
+  '2026-08-27 前是只看 (團,店,SKU) 的整組判斷 —— 配給一位客人會讓同組每個人都可取。';
+
+REVOKE ALL ON FUNCTION public._pickup_dn_covers_item(BIGINT, UUID, BIGINT, BIGINT, BIGINT)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public._pickup_dn_covers_item(BIGINT, UUID, BIGINT, BIGINT, BIGINT)
+  TO authenticated, service_role;
+
+-- ----------------------------------------------------------------------------
+-- 2. is_order_item_pickup_ready — 兩處 Path D 換成 helper
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_order_item_pickup_ready(p_item_id BIGINT)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+      FROM customer_order_items coi
+      JOIN customer_orders co ON co.id = coi.order_id
+     WHERE coi.id = p_item_id
+       AND co.status NOT IN ('completed','expired','cancelled','transferred_out')
+       -- 只有未取的 active item 才有「可取貨」可言
+       AND coi.status IN ('pending','reserved','ready')
+       -- 少發配貨：沒配到的品項標成待補貨，在補到之前不可取
+       --（rpc_allocate_shortage 寫入 / 清除；沒有缺貨的單這欄永遠是 NULL，行為不變）
+       AND coi.backorder_at IS NULL
+       AND CASE
+         -- aid_transfer + 跨店：只認自己的 transfer 被收貨 (Path A)
+         WHEN EXISTS (
+                SELECT 1 FROM customer_order_items x
+                 WHERE x.order_id = co.id AND x.source = 'aid_transfer'
+              )
+              AND co.transferred_from_order_id IS NOT NULL
+              AND (
+                SELECT src.pickup_store_id FROM customer_orders src
+                 WHERE src.id = co.transferred_from_order_id
+              ) IS DISTINCT FROM co.pickup_store_id
+         THEN EXISTS (
+           SELECT 1 FROM transfers t
+            WHERE t.customer_order_id = co.id
+              AND t.tenant_id = co.tenant_id
+              AND t.status IN ('received','closed')
+         )
+         ELSE (
+           -- Path A：aid 單 transfer FK 收貨
+           EXISTS (
+             SELECT 1 FROM transfers t
+              WHERE t.customer_order_id = co.id
+                AND t.tenant_id = co.tenant_id
+                AND t.status IN ('received','closed')
+           )
+           OR
+           -- Path B：campaign 對齊且該波次該 SKU 實收 qty>0
+           EXISTS (
+             SELECT 1
+               FROM picking_wave_items pwi
+               JOIN transfers t ON t.id = pwi.generated_transfer_id
+               JOIN transfer_items ti ON ti.transfer_id = t.id
+                                     AND ti.sku_id = coi.sku_id
+              WHERE pwi.tenant_id   = co.tenant_id
+                AND pwi.campaign_id = co.campaign_id
+                AND pwi.store_id    = co.pickup_store_id
+                AND pwi.sku_id      = coi.sku_id
+                AND t.status IN ('received','closed')
+                AND ti.qty_received > 0
+           )
+           OR
+           -- Path C：該 (campaign,store,sku) 完全無對齊波次（彙整 PR）才退用 store+sku 實收。
+           -- 2026-08-14：實收加時間下限 —— 只認「開團之後」收的貨。開團前的實收一定是
+           -- 上一團 / 補貨的貨，拿來開門會讓完全沒採購的新團在取貨頁放行（GRP-20260807-001 災情）。
+           (
+             NOT EXISTS (
+               SELECT 1 FROM picking_wave_items pwi
+                WHERE pwi.tenant_id   = co.tenant_id
+                  AND pwi.campaign_id = co.campaign_id
+                  AND pwi.store_id    = co.pickup_store_id
+                  AND pwi.sku_id      = coi.sku_id
+             )
+             AND EXISTS (
+               SELECT 1
+                 FROM stores st
+                 JOIN transfers t ON t.transfer_type = 'hq_to_store'
+                                 AND t.dest_location = st.location_id
+                                 AND t.tenant_id     = co.tenant_id
+                                 AND t.status IN ('received','closed')
+                 JOIN transfer_items ti ON ti.transfer_id = t.id
+                                       AND ti.sku_id = coi.sku_id
+                                       AND ti.qty_received > 0
+                WHERE st.id = co.pickup_store_id
+                  AND (
+                    co.campaign_id IS NULL   -- 無團的單沒有「開團時間」可比，維持舊行為
+                    OR t.received_at >= (
+                         SELECT gc.created_at FROM group_buy_campaigns gc
+                          WHERE gc.id = co.campaign_id
+                       )
+                  )
+             )
+           )
+           OR
+           -- Path D：庫存減抵單 — 店家用店內現貨吸收這組缺口
+           -- 2026-08-27：改成**逐品項**（只放行 DN 指名的那一行）。
+           -- 整組放行會讓「配給一位客人」等於「同組每個人都可取」。
+           public._pickup_dn_covers_item(
+             coi.id, co.tenant_id, co.campaign_id, co.pickup_store_id, coi.sku_id
+           )
+           OR
+           -- Path D'：抵減單（order_kind='offset' 負數訂單）— 開團時就宣告
+           -- 這組有店內現貨吸收，等同貨到（哪些行可取仍由 backorder_at 控管）
+           EXISTS (
+             SELECT 1
+               FROM customer_orders oo
+               JOIN customer_order_items oi
+                 ON oi.order_id = oo.id
+                AND oi.sku_id   = coi.sku_id
+                AND oi.qty < 0
+                AND oi.status NOT IN ('cancelled','expired')
+              WHERE oo.tenant_id       = co.tenant_id
+                AND oo.campaign_id     = co.campaign_id
+                AND oo.pickup_store_id = co.pickup_store_id
+                AND oo.order_kind      = 'offset'
+                AND oo.status NOT IN ('cancelled','expired','transferred_out')
+           )
+         )
+       END
+       -- ------------------------------------------------------------------
+       -- 2026-08-14：數量守衛（campaign-local）。上面的 Path B / C 是 qty-blind 的
+       -- ——「該組到過貨」就整組放行 —— 短收時會讓沒進店的那幾件也亮著可取。
+       -- 這裡再問一次「這一行輪得到嗎」：同組依 (下單時間, 單號, 行 id) 累加，
+       -- 累計量超過可配量的行回 false。
+       --
+       -- 只作用在 Path B / C。Path A / D / D' 是「這一組明確被宣告覆蓋」的路徑，
+       -- 量由那些單據自己管，一律跳過守衛（HQ 要放行帳面不足的組 → 開庫存減抵單）。
+       -- 2026-08-27：Path D 的豁免跟著改成逐品項 —— 別人的 DN 不能豁免我這一行，
+       -- 否則量守衛等於對整組失效。
+       -- ------------------------------------------------------------------
+       AND (
+         co.campaign_id IS NULL   -- 無團的單沒有「同組」可算，維持舊行為
+         -- Path A：這張單有自己的 transfer 被收貨（含 aid 跨店分支）
+         OR EXISTS (
+           SELECT 1 FROM transfers t
+            WHERE t.customer_order_id = co.id
+              AND t.tenant_id = co.tenant_id
+              AND t.status IN ('received','closed')
+         )
+         -- Path D：庫存減抵單（逐品項）
+         OR public._pickup_dn_covers_item(
+              coi.id, co.tenant_id, co.campaign_id, co.pickup_store_id, coi.sku_id
+            )
+         -- Path D'：offset 抵減單
+         OR EXISTS (
+           SELECT 1
+             FROM customer_orders oo
+             JOIN customer_order_items oi
+               ON oi.order_id = oo.id
+              AND oi.sku_id   = coi.sku_id
+              AND oi.qty < 0
+              AND oi.status NOT IN ('cancelled','expired')
+            WHERE oo.tenant_id       = co.tenant_id
+              AND oo.campaign_id     = co.campaign_id
+              AND oo.pickup_store_id = co.pickup_store_id
+              AND oo.order_kind      = 'offset'
+              AND oo.status NOT IN ('cancelled','expired','transferred_out')
+         )
+         -- 數量守衛本體：這一行的累計需求 ≤ 該組可配量
+         OR (
+           SELECT COALESCE(SUM(x.qty), 0)
+             FROM customer_order_items x
+             JOIN customer_orders xo ON xo.id = x.order_id
+             LEFT JOIN members xm ON xm.id = xo.member_id
+            WHERE xo.tenant_id       = co.tenant_id
+              AND xo.campaign_id     = co.campaign_id
+              AND xo.pickup_store_id = co.pickup_store_id
+              AND x.sku_id           = coi.sku_id
+              AND x.status IN ('pending','reserved','ready')
+              -- 掛著待補貨的行已經被少發配貨擋掉了，不佔預算
+              --（算進來會自己擋自己，20260811000050 踩過）
+              AND x.backorder_at IS NULL
+              AND xo.status NOT IN ('completed','expired','cancelled','transferred_out')
+              -- 現貨池容器（RR- /【內部】xx 店）不是對客人的承諾，不佔預算
+              AND COALESCE(xm.member_type, '') <> 'store_internal'
+              -- offset 抵減單是負數行，不是需求
+              AND COALESCE(xo.order_kind, 'normal') <> 'offset'
+              -- 有自己 transfer 的單（Path A）走 store_to_store 供給，不吃這份 hq 預算
+              AND NOT EXISTS (
+                SELECT 1 FROM transfers t2
+                 WHERE t2.customer_order_id = xo.id
+                   AND t2.tenant_id = xo.tenant_id
+                   AND t2.status IN ('received','closed')
+              )
+              -- 排在自己前面（含自己）的行才計入累計
+              AND (xo.created_at, xo.order_no, x.id) <= (co.created_at, co.order_no, coi.id)
+         ) <= public._pickup_group_available(
+                co.tenant_id, co.campaign_id, co.pickup_store_id, coi.sku_id
+              )
+       )
+       -- ------------------------------------------------------------------
+       -- 2026-08-18：門市實體庫存守衛。上面那道的帳本是 campaign-local，
+       -- 但實體庫存是**整間店共用**的 —— 同一批貨會被多個團各自當成自己的供給
+       -- （_pickup_group_supplied 沒有依 campaign 切分），而別團 / 現貨直配 SP- /
+       -- 池子轉單把貨領走時也不會扣到本團的 available。結果就是「貨發完了，
+       -- 單還亮著已到貨」（松山 #16360812）。
+       --
+       -- 這裡改問實體：本行的累計承諾（跨所有團、依 (下單時間, 單號, 行 id) 排序）
+       -- 有沒有超過該店該 SKU 的 on_hand。口徑對齊
+       -- _advance_arrived_confirmed_orders 的可配量（on_hand − 已承諾未取）
+       -- ＝ _sku_commitment 的 promised_active。
+       --
+       -- 豁免：容器單與 offset 單本身（它們被排除在「已承諾」母體外，再要它們
+       -- 自己過守衛會被 on_hand 擋死）。Path A / D / D' **不**豁免。
+       -- ------------------------------------------------------------------
+       AND (
+         -- 沒有取貨店 / 店沒綁倉別 → 算不出 on_hand，維持舊行為
+         --（比照 _advance_arrived_confirmed_orders「沒設倉庫位置的店直接不動」）
+         NOT EXISTS (
+           SELECT 1 FROM stores st
+            WHERE st.id = co.pickup_store_id
+              AND st.location_id IS NOT NULL
+         )
+         -- 容器單（RR- / OV- / AB- /【內部】xx 店）與 offset 抵減單不是對客人的
+         -- 承諾，也不在下面的母體裡；它們的取貨 / 轉單不受實體守衛影響
+         OR COALESCE(co.order_kind, 'normal') = 'offset'
+         OR EXISTS (
+           SELECT 1 FROM members m
+            WHERE m.id = co.member_id
+              AND COALESCE(m.member_type, '') = 'store_internal'
+         )
+         -- ⚠ Path A / D / D' **刻意不在這裡豁免**（與上面那道守衛不同）。
+         --   那三條回答的是「這批貨算不算到過店」，屬於**到貨**問題；本守衛問的是
+         --   「現在還在不在架上」，是**當下**的問題 —— 任何單據都不能宣告一批
+         --   已經被領走的貨還在。
+         --   減抵單尤其不行：rpc_create_inventory_deduction 開單時就強制
+         --   `on_hand - reserved >= qty`，錯誤訊息還寫「請先到『庫存總覽』對該商品
+         --   新增庫存，再開減抵單」——「貨在架上但帳沒入」根本不是它的使用情境，
+         --   帳早就被要求先補正了。拿它豁免 on_hand 檢查等於讓同一批貨無限次交付。
+         --
+         -- 帳面不足但貨真的在架上時的正解 = **到庫存總覽把庫存補上**（＋新增庫存 /
+         -- 盤點），不是開減抵單繞過去 —— 減抵單自己也是這樣要求的。
+         --
+         -- 實體守衛本體：跨團累計承諾 ≤ on_hand
+         --
+         -- 2026-08-27：母體多算「還在等貨但已被 DN 指名覆蓋」的行。
+         --   原本只算單頭已承諾（ready/partially_completed/shipping）的行，於是
+         --   兩張都還 pending 的單各自只算到自己 1 件 ≤ on_hand 1，一件貨兩個人過。
+         --   口徑對齊 _order_item_stock_budget 的 others（開單那端早就這樣算了，
+         --   所以這是把閘門補齊到跟預算同一套，不是新規則）。
+         --   ⚠ 仍然**不算**沒有 DN 的 pending/confirmed 行 —— 那些是還在等貨的需求，
+         --     算進來會讓舊的等貨單擋掉新的已到貨單（20260818000010 的原始理由）。
+         OR (
+           SELECT COALESCE(SUM(
+                    CASE WHEN yo.status IN ('ready','partially_completed','shipping')
+                              OR y.id = coi.id
+                         THEN y.qty
+                         ELSE LEAST(y.qty, COALESCE(cov.q, 0)) END), 0)
+             FROM customer_order_items y
+             JOIN customer_orders yo ON yo.id = y.order_id
+             LEFT JOIN members ym ON ym.id = yo.member_id
+             LEFT JOIN LATERAL (
+               SELECT SUM(GREATEST(ni.qty - COALESCE(ni.released_qty, 0), 0)) AS q
+                 FROM inventory_deduction_note_items ni
+                 JOIN inventory_deduction_notes n ON n.id = ni.note_id
+                                                 AND n.cancelled_at IS NULL
+                WHERE ni.order_item_id = y.id
+             ) cov ON TRUE
+            WHERE yo.tenant_id       = co.tenant_id
+              AND yo.pickup_store_id = co.pickup_store_id
+              AND y.sku_id           = coi.sku_id
+              AND y.status IN ('pending','reserved','ready')
+              AND y.qty > 0
+              -- 待補貨的行已被少發配貨擋掉，不佔預算（同上一道）
+              AND y.backorder_at IS NULL
+              AND yo.status NOT IN ('completed','expired','cancelled','transferred_out')
+              -- 現貨池容器不是對客人的承諾
+              AND COALESCE(ym.member_type, '') <> 'store_internal'
+              -- offset 抵減單是負數行，不是需求
+              AND COALESCE(yo.order_kind, 'normal') <> 'offset'
+              -- 排在自己前面（含自己）的行才計入累計 —— on_hand 不夠時
+              -- 讓最早下單的人先拿，不是整組一起關掉
+              AND (yo.created_at, yo.order_no, y.id) <= (co.created_at, co.order_no, coi.id)
+         ) <= COALESCE((
+             SELECT sb.on_hand
+               FROM stores st
+               JOIN stock_balances sb
+                 ON sb.tenant_id   = st.tenant_id
+                AND sb.location_id = st.location_id
+                AND sb.sku_id      = coi.sku_id
+              WHERE st.id = co.pickup_store_id
+           ), 0)
+       )
+  );
+$$;
+
+COMMENT ON FUNCTION public.is_order_item_pickup_ready(BIGINT) IS
+  '取貨閘門（逐品項）：Path A 自己的 transfer 收貨 / B 對齊波次實收 / C 本店實收退路 / '
+  'D 庫存減抵單（**逐品項**，2026-08-27 起）/ D'' offset 抵減單，'
+  '外加兩道數量守衛：campaign-local 供給、門市實體 on_hand（後者含 DN 覆蓋的等貨行）。';


### PR DESCRIPTION
## 做了什麼

兩件事，都跟「店內現貨配給客人」有關。

**1. 價格（Alex 交代）**

- 庫存總覽每列商品名下方多兩顆徽章：`零售 $x` / `分店 $x`。分店價依 `canSeeBranch` 收斂（store_staff 只看零售）。價格一頁一次批次撈 `prices`，不逐列打。
- 「🤝 配給客人（現貨直配）」的建議售價從**分店價優先改成零售價優先** —— 配給的是終端客人，收零售價（截圖那筆原本預填 $85 分店價，應為 $109 零售價）。彈窗同時把兩個價列出來，店員看得出預填的是哪一個。
- `rpc_get_spot_availability` 多回 `retail_price` / `branch_price`；`suggest_price` 改 `COALESCE(retail, branch, 0)`。既有欄位一個沒動。

**2. 取貨閘門 Path D 改逐品項（回報：「為什麼我配一個人卻有兩個人可以拿貨」）**

松山 `GRP-20260826-052` / 304 餐具，`on_hand = 1`。店員在訂單頁對 `-0004`（陳麗文）按「📦 從庫存配貨」開了一張 DN，結果 `-0003`（安文）也一起亮出「✅ 去取貨」—— 那張單 `supplied 0`、`available 0`、沒有 transfer、沒有自己的 DN。

原因兩層：

- Path D 的判準只有 `(tenant, campaign, store, sku)`，**不看是哪一行** → 同團同店同 SKU 只要有任一張未作廢 DN，整組每一行都放行；而 Path D 同時是 campaign-local 數量守衛的豁免條件，所以量也不擋。
- 實體庫存守衛（20260818000010）擋不住這一組：它的母體只算「單頭已承諾（ready/partially_completed/shipping）」的行，而兩張單頭都還是 `pending` → 各自累計都只有自己 1 件 ≤ `on_hand` 1，兩張都過。

修法：

- 新增 `_pickup_dn_covers_item(...)`：Path D 改問 `inventory_deduction_note_items.order_item_id`（`qty − released_qty > 0`），口徑與 `_order_item_stock_budget` 的 `mine` 一致。主判斷與 campaign-local 豁免**兩處共用同一支 helper**，不各寫一份。
- 舊 DN 相容：沒有逐品項明細的 DN（線上 2 張，`inventory_deduction_note_items` 是 20260805000170 才有的）維持整組放行，否則舊單會突然取不了貨。
- 實體庫存守衛的母體多算「還在等貨但已被 DN 指名覆蓋」的行，對齊 `_order_item_stock_budget` 的 `others`（開單那端早就這樣算，這是把閘門補齊到同一套）。**沒有 DN 的 pending/confirmed 行維持不算** —— 算進來會讓舊的等貨單擋掉新的已到貨單。

## 上線危險

- **做了**：兩支 migration 都**已經套上正式庫**（Management API），本 PR 是把 migration 回寫進 repo。閘門收緊後，全站有 7 個品項從「可取」變成「不可取」（見下），店員在取貨頁會看到那幾筆的按鈕消失。其中 2 筆單頭是 `ready`（客人可能已收到到貨通知）。補救路徑很乾淨：貨真的在架上就到庫存總覽補庫存，或在訂單頁對**那一位客人**按「📦 從庫存配貨」，DN 一開閘門就會重新放行。
- **不做**：一件貨可以被兩位以上客人領走。`rpc_record_pickup` 不做任何庫存檢查，閘門是唯一防線 —— 放行等於直接把 `on_hand` 扣成負的，先到的領完後面的客人撲空。線上此刻就有 3 位客人同時掛在古華店同一顆奶油上（`on_hand = 1`）。
- **回退**：重跑 `20260818000010` 的 `is_order_item_pickup_ready` 段落 + `DROP FUNCTION public._pickup_dn_covers_item(BIGINT,UUID,BIGINT,BIGINT,BIGINT);`；價格那支重跑 `20260824060000` 的 `rpc_get_spot_availability` 段落。前端回退即 revert 本 PR。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

**離線**：`node scripts/check-sql-syntax.cjs` 兩支皆過（含 `parsePlpgsql`）。`npx tsc --noEmit` 乾淨。ESLint 兩支前端檔的 3 個 `react-hooks/set-state-in-effect` 在乾淨樹上就已存在，非本次引入。

**正式庫（交易內對拍後 ROLLBACK）**：候選母體＝任何有未作廢 DN 的 (店,SKU) 底下的 active 品項，共 159 筆。

| | |
|---|---|
| `true → false` | 7 |
| `false → true` | 0 |
| 影響訂單 / 分店 | 7 張 / 4 家 |

七筆全部 `own_dn_cover = 0` —— 都是沾別人的 DN 才亮著：

| 分店 | 訂單 | 單頭 | 商品 | 在庫 |
|---|---|---|---|---|
| 三峽店 | GRP-20260817-006-0032 | ready | 包子媽家醬燒豬腳 ×1 | 8（該團 available 3） |
| 古華店 | GRP-20260813-023-0035 | ready | 火鍋肉片 ×1 | 8（該團 available −2） |
| 古華店 | GRP-20260818-020-0012 | confirmed | 歐登堡奶油 ×1 | 1 |
| 古華店 | GRP-20260818-020-0036 | confirmed | 歐登堡奶油 ×1 | 1 |
| 古華店 | GRP-20260818-020-0060 | confirmed | 歐登堡奶油 ×1 | 1 |
| 文山店 | GRP-20260710-010-0004 | confirmed | 抹茶拿鐵粉 ×1 | 3（前面已排滿 3 件） |
| 松山店 | GRP-20260826-052-0003 | pending | 304 餐具 ×1 | 1（回報的那筆） |

古華那三張是同一顆奶油、`on_hand = 1`、三位客人同時亮著可取，跟松山是同一個形狀。

**目標案例**（套用後對線上實查）：`-0004` 陳麗文（真的被配到的那位）維持 `true`，`-0003` 安文轉 `false`，其餘三張不受影響。

**效能**：閘門 4.33 ms/次（200 筆連續呼叫平均），與修改前的 ~5 ms 持平。

**價格**：線上 `pg_get_functiondef` 確認 `suggest_price` 已走 `COALESCE(px.retail_price, px.branch_price, 0)`。

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hxxe5AAwmDuDLxtkzSyMX)_