### PR TITLE
訂單頁「從庫存配貨」上限不夠時可一鍵新增庫存再配貨

### DIFF
--- a/apps/admin/src/components/AssignStockModal.tsx
+++ b/apps/admin/src/components/AssignStockModal.tsx
@@ -21,7 +21,10 @@ import { translateRpcError } from "@/lib/rpcError";
 // 配掉時 RPC 會同步從池子扣。
 
 type Budget = {
+  order_no: string;
   store_name: string;
+  location_id: number | null;
+  sku_id: number | null;
   sku_label: string;
   item_qty: number;
   assigned: number;
@@ -54,6 +57,8 @@ export function AssignStockModal({
   const [reason, setReason] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  // 上限不夠時「架上其實有貨、只是沒入帳」→ 送出前先幫忙新增庫存，不用跳去庫存總覽
+  const [topUp, setTopUp] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -68,7 +73,10 @@ export function AssignStockModal({
       }
       const a = (data ?? {}) as Record<string, unknown>;
       const parsed: Budget = {
+        order_no: String(a.order_no ?? ""),
         store_name: String(a.store_name ?? ""),
+        location_id: a.location_id == null ? null : Number(a.location_id),
+        sku_id: a.sku_id == null ? null : Number(a.sku_id),
         sku_label: String(a.sku_label ?? ""),
         item_qty: num(a.item_qty),
         assigned: num(a.assigned),
@@ -94,16 +102,24 @@ export function AssignStockModal({
   const cap = b?.assignable_with_pool ?? 0;
   const free = b?.assignable ?? 0;
   const room = b ? Math.max(b.item_qty - b.assigned, 0) : 0;
+  // 開了「一鍵新增庫存」就不受 cap 限制，只受這一行剩餘數量限制
+  const effectiveCap = topUp ? room : Math.min(cap, room);
   const fromPool = Math.max(0, Math.min(qty, cap) - free);
-  // 配不滿整行 → 伺服端會拆行，餘量掛待補貨
+  const shortfall = topUp ? Math.max(qty - Math.max(cap, 0), 0) : 0;
+  // 配不滿整行 → 伺服端會拆行，餘量掛待補貨（開了 topUp 之後不會發生，量會補到剛好夠）
   const splitQty = b ? Math.max(room - qty, 0) : 0;
-  const canSubmit = !busy && !!b && qty > 0 && qty <= cap && qty <= room;
+  const canSubmit = !busy && !!b && qty > 0 && qty <= effectiveCap && qty <= room;
 
   async function save() {
     if (!canSubmit || !b) return;
     if (
       !confirm(
-        `把「${skuLabel}」×${qty} 從「${b.store_name}」的庫存配給這張單？\n\n` +
+        (shortfall > 0
+          ? `店內庫存不足，會先在「${b.store_name}」幫這個商品新增庫存 +${shortfall} 件`
+            + `（手動調整，寫進去就無法刪除／修改，只能之後盤點更正）。\n`
+            + `請先確認架上真的有這批貨再送出！\n\n`
+          : "") +
+          `把「${skuLabel}」×${qty} 從「${b.store_name}」的庫存配給這張單？\n\n` +
           `品項會變成「已到貨・可取貨」，現在不扣庫存、不收款；\n` +
           `客人到店在「取貨」頁完成交貨時才扣庫存收款。\n` +
           (fromPool > 0 ? `其中 ${fromPool} 件來自【內部】${b.store_name}現貨池，會自動從池子扣。\n` : "") +
@@ -118,6 +134,19 @@ export function AssignStockModal({
       const { data: sess } = await sb.auth.getSession();
       const operator = sess.session?.user?.id;
       if (!operator) throw new Error("尚未登入");
+      if (shortfall > 0) {
+        if (b.location_id == null || b.sku_id == null) {
+          throw new Error("這張單的取貨門市沒有綁定倉別，無法新增庫存");
+        }
+        const { error: e0 } = await sb.rpc("rpc_add_stock_by_product", {
+          p_location_id: b.location_id,
+          p_sku_id: b.sku_id,
+          p_qty: shortfall,
+          p_reason: reason.trim() || `訂單頁強制配貨・一鍵新增庫存（${b.order_no ?? ""}）`,
+          p_operator: operator,
+        });
+        if (e0) throw new Error(translateRpcError(e0));
+      }
       const { data: res, error: e } = await sb.rpc("rpc_assign_stock_to_order_item", {
         p_item_id: itemId,
         p_qty: qty,
@@ -133,6 +162,7 @@ export function AssignStockModal({
       };
       alert(
         `✅ 已配 ${qty} 件給這張單（減抵單 ${r.note_no ?? ""}）。\n` +
+          (shortfall > 0 ? `其中已先新增庫存 +${shortfall} 件。\n` : "") +
           (num(r.from_pool) > 0 ? `其中 ${num(r.from_pool)} 件從【內部】${b.store_name}現貨池扣掉。\n` : "") +
           (num(r.split_qty) > 0 ? `沒配到的 ${num(r.split_qty)} 件已拆成一行、標成「待補貨」。\n` : "") +
           (r.advanced ? "整張單都到齊了，狀態已推到「已到貨」。\n" : "") +
@@ -192,13 +222,40 @@ export function AssignStockModal({
               沒配到的 <b>{splitQty}</b> 件會拆成一行、標成「待補貨」（下一批貨到店時會自動解除）。
             </div>
           )}
-          {b && cap <= 0 && (
+          {b && cap <= 0 && !topUp && (
             <div className="mt-1.5 text-[11px] text-amber-700 dark:text-amber-400">
               {b.on_hand <= 0 ? (
-                <>店倉帳上這個商品是 0 件。架上實際有貨 → 先到「庫存總覽」用「＋ 新增庫存」入帳。</>
+                <>店倉帳上這個商品是 0 件。架上實際有貨 → 先到「庫存總覽」用「＋ 新增庫存」入帳，</>
               ) : (
-                <>在庫 {b.on_hand} 件已經被別的單佔走 {b.committed} 件（已承諾未取 ＋ 已配過的單）。</>
+                <>在庫 {b.on_hand} 件已經被別的單佔走 {b.committed} 件（已承諾未取 ＋ 已配過的單），</>
               )}
+              或
+              <SpinButton
+                onClick={() => {
+                  setTopUp(true);
+                  setQty(Math.max(1, room));
+                }}
+                className="ml-1 font-medium text-amber-900 underline dark:text-amber-200"
+              >
+                架上其實有貨、一鍵新增庫存再配貨
+              </SpinButton>
+              。
+            </div>
+          )}
+          {b && topUp && (
+            <div className="mt-1.5 rounded-md border border-amber-300 bg-amber-50 px-2 py-1.5 text-[11px] text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
+              已開啟「一鍵新增庫存」：送出時會先幫「{b.store_name}」把這個商品的庫存補到
+              {" "}{shortfall > 0 ? `+${shortfall}` : "夠"}，再配給這張單。
+              新增庫存<b>無法刪除／修改</b>，請先確認架上真的有貨。{" "}
+              <SpinButton
+                onClick={() => {
+                  setTopUp(false);
+                  setQty((q) => Math.min(q, Math.max(Math.min(cap, room), 1)));
+                }}
+                className="underline"
+              >
+                取消
+              </SpinButton>
             </div>
           )}
         </div>
@@ -208,17 +265,18 @@ export function AssignStockModal({
           <input
             type="number"
             min={1}
-            max={Math.max(Math.min(cap, room), 1)}
+            max={Math.max(effectiveCap, 1)}
             value={qty}
             onChange={(e) => {
               const v = Math.floor(Number(e.target.value));
-              setQty(Number.isFinite(v) ? Math.max(0, Math.min(v, Math.min(cap, room))) : 0);
+              setQty(Number.isFinite(v) ? Math.max(0, Math.min(v, effectiveCap)) : 0);
             }}
             className="w-28 rounded-md border border-zinc-300 bg-white px-3 py-2 text-right tabular-nums dark:border-zinc-700 dark:bg-zinc-800"
           />
           <span className="ml-2 text-[11px] text-zinc-400">
-            上限 {Math.min(cap, room)}
-            {cap > free ? `（自由量 ${free} ＋ 池子 ${cap - free}）` : ""}
+            上限 {effectiveCap}
+            {!topUp && cap > free ? `（自由量 ${free} ＋ 池子 ${cap - free}）` : ""}
+            {topUp && shortfall > 0 ? `（含一鍵新增 ${shortfall} 件）` : ""}
           </span>
         </label>
 

--- a/supabase/migrations/20260827040000_order_item_budget_expose_location.sql
+++ b/supabase/migrations/20260827040000_order_item_budget_expose_location.sql
@@ -1,0 +1,57 @@
+-- ============================================================================
+-- rpc_get_order_item_stock_budget 補回 location_id
+--
+-- 需求（Alex 2026-08-27）：訂單頁「📦 從庫存配貨」彈窗，可配上限是 0 時
+-- 想直接在彈窗裡「一鍵新增庫存」再配掉，不要跳去庫存總覽另開一次。
+-- 前端要呼叫 rpc_add_stock_by_product(p_location_id, p_sku_id, ...) 幫店家補帳，
+-- 但 JSON 包裝只回了 sku_id、沒有 location_id —— _order_item_stock_budget 本體
+-- 已經算出來了（st.s_location_id），只是包裝時漏掉沒放進去。
+--
+-- 基底：rpc_get_order_item_stock_budget = 20260824070000（唯一版本，本檔只加一個
+-- JSON 欄位，_order_item_stock_budget / rpc_assign_stock_to_order_item 皆不改）。
+-- Rollback：指回 20260824070000 的版本（拿掉 'location_id' 那一行）。
+--
+-- 對應前端（同一個 commit）：apps/admin/src/components/AssignStockModal.tsx
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_get_order_item_stock_budget(
+  p_item_id BIGINT
+) RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'item_id',              p_item_id,
+    'order_id',             b.order_id,
+    'order_no',             b.order_no,
+    'order_status',         b.order_status,
+    'store_id',             b.store_id,
+    'store_name',           b.store_name,
+    'location_id',          b.location_id,
+    'sku_id',               b.sku_id,
+    'sku_label',            b.sku_label,
+    'item_qty',             b.item_qty,
+    'item_status',          b.item_status,
+    'backordered',          b.backordered,
+    'assigned',             b.assigned,
+    'on_hand',              b.on_hand,
+    'committed',            b.committed,
+    'waiting',              b.waiting,
+    'pool',                 b.pool,
+    'pool_arrived',         b.pool_arrived,
+    'assignable',           LEAST(b.assignable,           GREATEST(b.item_qty - b.assigned, 0)),
+    'assignable_with_pool', LEAST(b.assignable_with_pool, GREATEST(b.item_qty - b.assigned, 0)),
+    'gate_ready',           public.is_order_item_pickup_ready(p_item_id)
+  )
+    FROM public._order_item_stock_budget(p_item_id) b;
+$$;
+
+COMMENT ON FUNCTION public.rpc_get_order_item_stock_budget(BIGINT) IS
+  '訂單頁「從庫存配貨」彈窗的預檢：在庫 / 別人的主張 / 等貨 / 內部池 / 還能指派幾件 / '
+  '這一行目前過不過取貨閘門。上限已夾到「本行還沒被指派的量」。'
+  '含 location_id，供前端「上限不夠時一鍵新增庫存」呼叫 rpc_add_stock_by_product。';
+
+REVOKE ALL ON FUNCTION public.rpc_get_order_item_stock_budget(BIGINT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_get_order_item_stock_budget(BIGINT) TO authenticated;


### PR DESCRIPTION
## 做了什麼

「📦 從庫存配貨給這張單」彈窗（`AssignStockModal.tsx`）上限是 0 或不夠時，加一顆「架上其實有貨、一鍵新增庫存再配貨」——送出時先呼叫 `rpc_add_stock_by_product` 補差額，再照舊呼叫 `rpc_assign_stock_to_order_item`，不用再另外跳去「庫存總覽」新增庫存。

配套：`rpc_get_order_item_stock_budget` 補回 `location_id`（`_order_item_stock_budget` 本來就算出來了，只是 JSON 包裝漏掉），前端才能直接呼叫新增庫存的 RPC。已用 Management API 套上正式庫並驗證過回傳內容。

## 上線危險

- 做了：多一個選填的一鍵新增庫存按鈕，預設不開啟，不影響原本的配貨流程。
- 不做：沒有改動 `_order_item_stock_budget` / `rpc_assign_stock_to_order_item` 的算法。
- 回退：`rpc_get_order_item_stock_budget` 指回 20260824070000 的版本（拿掉 `location_id` 那行）；前端 revert 這個 commit 即可。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `node scripts/check-sql-syntax.cjs` 通過
- `npx tsc --noEmit`、`npx eslint` 皆無錯誤
- migration 已用 Management API 套上正式庫，`pg_get_functiondef` 驗證 `location_id` 欄位已在回傳的 JSON 裡

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCYYcLW1Yk9b3i97YLBjof)_