### PR TITLE
規劃：Observability 架構

### DIFF
--- a/docs/PLAN-AI-SRE工作流程.md
+++ b/docs/PLAN-AI-SRE工作流程.md
@@ -1,0 +1,233 @@
+# PLAN — AI + SRE 工作流程
+
+> 狀態：**規劃中**，尚未實作。依賴 `docs/PLAN-observability架構.md`（PR #868）的
+> Layer C 健檢表 `ops_health_checks` 當輸入，這份定「查到異常之後誰做什麼」。
+
+---
+
+## 0. 一句話
+
+這系統唯一的「維運人力」是 Alex 叫 Claude session 現查現修。現況每次都是
+從零開始診斷（重新 grep migration 歷史、重新寫驗證 SQL），而且完全靠 Alex
+主動開口才會有人去查。這份計畫把「查到 → 分級 → 修 → 驗證 → 部署 → 寫回
+CLAUDE.md」定成固定流程，讓例行的、已知模式的問題不用等 Alex 開口，
+同時劃清楚「Claude 可以自己動手」跟「一定要先問 Alex」的邊界。
+
+---
+
+## 1. 現況與缺口
+
+已經有的（不用重做）：
+
+- **CI/PR 收斂**：本 session 的 harness 規則本身就是一套 AI SRE 流程——
+  `subscribe_pr_activity` 訂閱 PR、CI 紅了自動修、merge conflict 自動處理、
+  review comment 自動接。這條**只管「程式碼要不要進 main」**，不管「進了
+  main 之後有沒有套上線」。
+- **事後寫回 CLAUDE.md**：這個習慣已經在做（本檔開頭一堆「已修」段落），
+  只是全部發生在 Alex 主動追問之後，不是流程的固定步驟。
+- **診斷工具**：`scripts/check-sql-syntax.cjs`（部署前語法驗證）、
+  `pg_get_functiondef`/`pg_get_viewdef` 對線上驗證的習慣、
+  `PROD-fix-*.sql` 一次性資料修復的慣例。
+
+缺口：
+
+1. **沒有人主動去查**——都是 Alex 先發現異常才會有 session 去看。
+2. **沒有分級**——「可以自己修」跟「要先問」目前純靠當下 session 自己判斷，
+   沒有寫下來的標準，容易因為判斷失誤搞出 2026-08-16 那種「以為是 bug、
+   實際是母體沒濾」的誤判。
+3. **沒有稽核記錄**——自動/半自動修過什麼，除了 git log 沒有集中的地方看。
+4. **沒有 runbook**——每次都重新診斷，即使是同一種卡單模式。
+
+---
+
+## 2. 角色分工
+
+| 角色 | 職責 | 對應機制 |
+|---|---|---|
+| **健檢 Routine** | 排程跑 `ops_health_checks`，把新異常/惡化的項目丟給診斷 session | Claude Code Remote Routine，daily/hourly |
+| **診斷－修復 session** | 認領一個異常，跑 runbook 診斷、分級、Tier 1 就直接修，Tier 2 就整理好診斷結果去問 Alex | `create_session` 開一個乾淨 session，帶著異常的 `check_name` + 樣本 id |
+| **PR 收斂**（既有機制） | 診斷－修復 session 開的 PR，由既有 steward/babysit 規則帶到綠燈、合併 | `subscribe_pr_activity` |
+| **Alex** | 只在 Tier 2（會動到判斷、金流、安全性的事）被問，其餘看每日摘要或 `/admin/ops-health` | 通知 / push notification |
+
+不要把自動修復塞進 Alex 平常聊天的那個 session——診斷是背景工作，
+噪音（跑一堆 SQL、讀一堆 migration）不該洗掉 Alex 正在看的對話。
+異常和結論才需要出現在 Alex 面前。
+
+---
+
+## 3. 流程五階段
+
+```
+① 偵測                ② 分級                ③ 修復                  ④ 驗證與部署          ⑤ 寫回
+ops_health_checks  →  對照 runbook /   →  Tier 1: 直接修       →  同一天內：套上線   →  CLAUDE.md
+新增/惡化的異常        分級標準（§4）        Tier 2: 整理診斷        + PR 進 main         追加一段
+                                            結果，AskUser/推播      + pg_get_*def 讀回
+                                            給 Alex 決定             驗證
+```
+
+### ① 偵測
+沿用 `docs/PLAN-observability架構.md` 的 Layer A~D，不重複定義。
+
+### ② 分級
+先查 `docs/RUNBOOK-<check_name>.md` 存不存在：
+- **有 runbook 且屬於 Tier 1** → 照 runbook 的修復程序直接做。
+- **沒有 runbook，或屬於 Tier 2** → 診斷到有結論為止，寫成給 Alex 的
+  精簡摘要（結論＋要他決定什麼，不要證據表格——照 CLAUDE.md 的回覆風格），
+  用 `AskUserQuestion`（如果 Alex 就在看）或推播通知，等回覆才動手。
+  **診斷本身永遠可以做**，只有「動手改資料/改程式碼」才需要按分級規則卡住。
+
+### ③ 修復
+Tier 1 的動作範圍限定在 runbook 裡寫好的**已知修復程序**（例如：套一支已經
+存在、已經在別的情境驗證過的 helper function；或依照 `_settle_*`/`_restore_*`
+這類既有的「收斂」函式模式新增一個小 migration）。不即興發揮新的資料修復邏輯——
+即興修復是 Tier 2 的事，因為出錯的代價（2026-08 曾經因為母體沒濾對錯把好資料
+當壞資料處理）比多等 Alex 一輪確認高。
+
+### ④ 驗證與部署
+完全照 CLAUDE.md 既有規則，不另立新規則：
+1. `node scripts/check-sql-syntax.cjs` 過語法。
+2. Management API 套上正式庫。
+3. `pg_get_functiondef`/`pg_get_viewdef` 讀回驗證，不是只看「有沒有報錯」。
+4. Migration 檔當天 commit、push、開 PR，base 選 main。
+5. `subscribe_pr_activity` 交給既有 steward 流程帶到合併——
+   `git log origin/main -- <檔名>` 查得到才算收工。
+
+### ⑤ 寫回
+不管 Tier 1 自動修好、還是 Tier 2 跟 Alex 討論後修好，**收尾前都要回頭把
+根因、修法、（如果有）已知殘留寫進 CLAUDE.md**，格式比照現有段落
+（一句話結論起頭、含具體數字、標明對應 migration 版本）。這步不是可選的——
+現有的 CLAUDE.md 之所以有用，是因為每次事故都被壓縮成「不寫進來就會再犯」
+的一條規則；自動化修復如果跳過這步，下次同類異常又要重新診斷一次。
+
+---
+
+## 4. 分級標準
+
+**Tier 1（可以自動動手）** 必須同時符合：
+
+- 有對應 runbook，且 runbook 標記「安全可自動化」。
+- 修復是**可逆**的（新增 migration 可 rollback、或只是把已知安全的 helper
+  函式套用到多一批資料，不是刪除）。
+- 不碰金流（`payment_status`、`wallet_transactions`、訂單金額欄位）、
+  不碰 RLS/權限（`policy`、`role` 判斷）、不碰跨租戶資料。
+- 影響範圍在診斷時就能算出精確筆數（不是「大概」）。
+
+**Tier 2（一定要先問 Alex）**，符合任一項就是：
+
+- 沒有現成 runbook——代表這是新模式，比照 §3③ 的理由，先不要即興發揮。
+- 動到金流、安全性判斷、跨租戶。
+- 修復需要刪除資料，或需要覆蓋掉別人已經做的操作（例如取消一張已確認的訂單）。
+- 診斷過程中發現「表面異常、但可能是母體定義錯誤」（見本檔 CLAUDE.md
+  §「收斂前後對拍」那條教訓）——這類永遠要先跟 Alex 對過母體定義，
+  不要自己認定是 bug 就動手改資料。
+- 需要動 UI/前端邏輯，且會改變某個角色能不能操作某個按鈕
+  （對照「把某個角色的動作按鈕拿掉之前」那條教訓——這類改動即使看起來只是
+  拿掉一顆按鈕，也可能讓某個狀態變成沒有人推得動，必須讓 Alex 確認正主是誰）。
+
+---
+
+## 5. Runbook 庫慣例
+
+新開 `docs/RUNBOOK-<check_name>.md`，`<check_name>` 對齊
+`ops_health_checks.check_name`（例如 `RUNBOOK-stuck-confirmed-no-transfer.md`）。
+固定格式：
+
+```md
+# RUNBOOK — <check_name>
+
+## 症狀
+（health check 撈到什麼）
+
+## 根因類別
+（對應 CLAUDE.md 哪一條教訓，或全新模式）
+
+## 診斷查詢
+```sql
+-- 貼可以直接跑的 SQL
+```
+
+## 修復程序
+- Tier: 1 / 2
+- （Tier 1 才需要）具體步驟，含要套用哪支既有 helper function
+
+## 驗證查詢
+```sql
+-- 修完之後怎麼確認真的解決了
+```
+```
+
+每次 Tier 2 事故收尾、確定是「以後還會再發生」的模式時，順手把它升級成
+一份 runbook，下次同類異常就能自動處理，分級標準自然往 Tier 1 移動。
+**不要一開始就寫一大批 runbook**——沒有實際發生過的模式寫出來的診斷/修復
+程序多半是猜的，等真的遇到再補，比較準。
+
+---
+
+## 6. 稽核記錄
+
+```sql
+CREATE TABLE ops_actions_log (
+  id BIGSERIAL PRIMARY KEY,
+  check_name TEXT NOT NULL,
+  tier INT NOT NULL,                 -- 1 或 2
+  action TEXT NOT NULL,              -- 'auto_fixed' / 'escalated' / 'diagnosed_no_action'
+  migration_file TEXT,               -- Tier 1 且產生了 migration 時填
+  affected_count INT,
+  summary TEXT,                      -- 給 Alex 事後回顧用的一句話
+  session_ref TEXT,                  -- 對應的 Claude session id，方便回頭找完整過程
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+`/admin/ops-health` 頁面（Observability 計畫 Phase 2）除了顯示
+`ops_health_checks` 的異常，也顯示這張表——Alex 想確認「上週那次自動修的
+到底做了什麼」時查得到，不用回頭挖 git log 或聊天記錄。
+
+---
+
+## 7. 排程機制
+
+用 Claude Code Remote 的 Routine，不另外接第三方排程：
+
+1. `sre-health-scan`（cron，例如每 4 小時）：`create_new_session_on_fire=true`，
+   跑 `rpc_run_health_checks()`（Observability 計畫 Phase 1 產物），
+   對每一筆新增/惡化的異常，`create_session` 開一個診斷 session 帶著
+   `check_name` + 樣本 id 過去。
+2. 診斷 session 依 §3 走完流程，Tier 1 自己收尾，Tier 2 用 push notification
+   或訊息把摘要交給 Alex，等回覆。
+3. Tier 2 的討論**留在跟 Alex 對話的主 session**（不是背景 session），
+   因為那類問題本來就需要 Alex 的判斷輸入，不是純執行。
+
+## 8. 跟既有 PR 流程銜接
+
+Tier 1 修復如果需要新 migration，走的還是「先套上線、當天進 main」那條規則
+（見 CLAUDE.md 開頭），不是先開 PR 等合併才套用。開出的 PR 一律
+`subscribe_pr_activity` 交給既有 steward/babysit 規則帶到綠燈——這條本來就
+存在，AI SRE 流程不用另外重做一套 CI 收斂邏輯，只需要在 §3④ 最後一步接上它。
+
+---
+
+## 9. 護欄（Never）
+
+- 不刪除資料、不下 `DROP`/`TRUNCATE`，即使 Tier 1 也一樣——回復用「標記
+  取消/歸零」而不是刪除，這是整個系統既有的一貫作法（斷貨/取消都是狀態轉換，
+  不是刪列）。
+- 不繞過「套上線當天進 main」的規則，不管多小的修復。
+- 不在沒有 runbook 的情況下自動修復——沒有 runbook 就是 Tier 2。
+- 不因為「看起來很像」上次的異常就套用舊 runbook——先確認 `check_name`
+  完全對應，母體定義變過的話 runbook 要跟著更新，不是硬套。
+- 一律不動用 `--force`/`git push --force`/`rm -rf` 這類破壞性操作，
+  即使是自動化流程；卡住了就升級成 Tier 2 讓 Alex 決定。
+
+---
+
+## 10. 建議的實作順序
+
+1. 先落地 Observability 計畫 Phase 1（`ops_health_checks` + 5 支健檢 SQL）——
+   這份的 §3① 完全依賴它。
+2. 建 `ops_actions_log` 表（§6，成本很低，跟健檢表一起建掉）。
+3. 挑 CLAUDE.md 裡**已經發生過至少兩次**的模式先寫 runbook（例如「migration
+   進 main 沒套上線」「backorder_at 未解除」），這兩類最容易被誤觸也最好驗證。
+4. 接 `sre-health-scan` Routine，先只做「發現異常就通知 Alex」（等於全部
+   Tier 2），確認通知的頻率跟品質沒問題之後，再挑第 3 步寫好 runbook 的
+   項目升級成 Tier 1 自動修復。

--- a/docs/PLAN-observability架構.md
+++ b/docs/PLAN-observability架構.md
@@ -1,0 +1,178 @@
+# PLAN — Observability 架構
+
+> 狀態：**規劃中**，尚未實作。這份只定架構與優先順序，Phase 1 動手前請 Alex 過目。
+
+---
+
+## 0. 一句話
+
+這系統沒有維運團隊、也沒有 Grafana/Datadog 這類基礎設施——所有「觀測」目前是
+Alex 出事後叫 Claude session 現查 Management API。目標不是導入一整套監控平台，
+而是把「現查」的診斷 SQL 常駐成排程，事故**發生當下**就有人（Claude Routine）
+先看到，而不是等 Alex 回報或下次剛好有人重跑那支 verify SQL。
+
+---
+
+## 1. 現況（已經有的，不用重做）
+
+| 層 | 現有機制 |
+|---|---|
+| 前端錯誤 | `client_error_logs` + `ErrorLogger`（僅 apps/member，`20260803000010`） |
+| 前端存活 | `bootGuard.ts`（ES5，framework chunk 全滅時的最後防線） |
+| 前端相容性 | `check-bundle-browser-support.mjs`、`check-boot-guard-es5.mjs`（build-time gate） |
+| 在線人數 | `app_presence` + `rpc_online_stats`（`20260827010000`，admin 儀表板卡片） |
+| DB 排程 | 既有 `pg_cron` job 若干（過期團購自動關閉、互助板到期清除…） |
+| QPS/API 量 | 不重做，用 Supabase Dashboard → Reports（現成的） |
+
+沒有的：任何一種「線上跟 repo 是否一致」「效能有沒有退化」「業務單據卡住」的
+**自動巡檢**——這三類全部是本檔開頭累積的事故根因。
+
+---
+
+## 2. 要接住的事故類型（對應 CLAUDE.md 累積的教訓）
+
+1. **Repo/線上脫鉤**：套過 SQL 沒進 main（PR base 選錯）、或進了 main 沒真的套上線
+   （migration 檔頭「已實測」≠ 已部署）。兩次都是脫鉤超過一週才被發現。
+2. **效能悄悄退化**：純效能 migration 沒套，症狀只是「慢」，沒人報。9 天後
+   把 Micro(1GB) 壓到 OOM，全站當機兩次才被回溯出來。
+3. **單據卡住沒人知道**：訂單卡 `confirmed`/`partially_completed` 不動、
+   `backorder_at` 沒有自動解除路徑、狀態機某個角色的按鈕被拿掉後沒人推得動。
+   這類全部是「畫面上不會報錯，只是安靜地不動」，能卡 6～13 天才被回報。
+4. **閘門邏輯的隱性放行**：qty-blind 的豁免路徑（Path A/D/D'）在特定組合下
+   會放行不該放行的取貨，只能靠人工回報「怎麼還能取貨」才發現。
+
+四類的共同點：**沒有東西在 blast radius 還小的時候主動說話**，全部靠事後
+人工回報或下一次剛好手動查。
+
+---
+
+## 3. 架構：四層巡檢 + 一個通知管道
+
+不新增基礎設施（沒有 Grafana/Prometheus 的操作與帳號成本），全部用現有的
+Management API + pg_cron + 既有 LINE OA 推播機制組出來。
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Layer A  部署一致性        repo migrations ⇄ 線上 schema  │
+│ Layer B  DB 效能回歸       pg_stat_statements 週期採樣     │
+│ Layer C  業務健康檢查      stuck-state SQL 集合            │
+│ Layer D  前端錯誤          client_error_logs 擴到 admin    │
+└─────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+              ops_health_checks（結果落地表，存歷史/防重複通知）
+                          │
+                          ▼
+        Claude Routine（daily cron）跑健檢 → 有異常才推播
+                          │
+                          ▼
+          LINE 推給 Alex（複用 admin-line-push 現有機制）
+          ＋ /admin/ops-health 頁面（人要細看時才點進去）
+```
+
+### Layer A — 部署一致性
+
+新增 `scripts/check-deploy-drift.mjs`：
+
+- 對「近 N 天有變動」的 function / view，用 Management API 查
+  `pg_get_functiondef` / `pg_get_viewdef`，跟 repo 裡最新一支相關 migration
+  的 `CREATE OR REPLACE` 內文做正規化後比對（去空白/註解後 hash）。
+- 對「近 N 天 merge 進 main 的 migration 檔」，反查線上是否真的存在對應物件
+  （函式簽章、view 名稱、新表）。
+- 兩個方向都要有：**repo 有線上沒有**（進 main 沒套）與
+  **線上有 repo 沒有**（套了沒進 main，或直接在 SQL Editor 手改）。
+
+跑法：CI 不行（連不到正式庫），走 daily Routine（見下方通知管道）。
+
+### Layer B — DB 效能回歸
+
+不做即時監控，做「週期採樣＋比對前一次」：
+
+- 排程呼叫 Management API 查 `pg_stat_statements`，取
+  `calls / total_exec_time / mean_exec_time`，依 `queryid` 存一份快照。
+- 跟上一次快照比，`mean_exec_time` 顯著上升（例如 >2 倍且 calls 夠多、
+  排除單筆 outlier）的查詢列出來。
+- 目的不是抓單次慢查詢，是抓「這支東西上週 5ms、這週 50ms 但沒人管」——
+  正是 8/18 那次 OOM 的模式。
+
+### Layer C — 業務健康檢查
+
+把 CLAUDE.md 裡已經寫死的診斷 SQL（本來就是事後在用的那幾支）改成常駐巡檢，
+每支對應一種「安靜卡住」：
+
+| 檢查 | 對應教訓 |
+|---|---|
+| `confirmed`/`partially_completed` 超過 X 小時未變動，且無對應 transfer/AT 單 | 空中轉沒人能派貨、經總倉單卡 pending 沒人看得到 |
+| `backorder_at` 已標超過 X 天未解除，且該 SKU 近期有到貨紀錄 | 少發配貨的旗標沒有自動解除路徑 |
+| 取貨閘門 `true` 但 `_pickup_group_available < 0`（且非容器/offset 單） | Path A/D/D' 隱性放行 |
+| 斷貨單（`status='cancelled' AND stockout_at IS NOT NULL`）超過 X 天未回復也未關閉 | 斷貨單堆積沒人清 |
+| 互助認領 `customer_order_transfer_links.aid_board_id` 為空但來源是認領單 | 認領量沒還導致貼文庫存錯 |
+
+每支查詢的「母體」定義直接抄 CLAUDE.md 裡已經驗證過的版本（例如 Path C 的
+qty-blind 陷阱、`ACTIVE_STATUSES` 集合），不要重新發明——那些都是踩過雷校準過的。
+
+結果寫進新表：
+
+```sql
+CREATE TABLE ops_health_checks (
+  id BIGSERIAL PRIMARY KEY,
+  check_name TEXT NOT NULL,
+  severity TEXT NOT NULL,        -- info/warn/critical
+  hit_count INT NOT NULL,
+  sample_ids JSONB,              -- 前 20 筆，方便直接點進 admin 查
+  checked_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+只在 `hit_count` 較上次**上升**或首次出現時才推播，避免每天洗版同一批
+已知待處理項。
+
+### Layer D — 前端錯誤
+
+`client_error_logs` 的 schema/RPC 已經是通用的（`env` 欄位分 admin/member），
+只是 apps/admin 沒接。直接照 `apps/member/src/lib/clientLog.ts` 的模式在
+apps/admin 掛一份，不用新設計。
+
+### 通知管道
+
+沒有內部 Slack/Discord，兩個現成選項擇一或並行：
+
+1. **Claude Routine**（本 session 就在用的機制）：daily cron 觸發，跑
+   Layer A~C 的查詢，有異常才用一兩句話講重點（不列證據表格，按 CLAUDE.md
+   的回覆風格），透過 push notification 或訊息告知 Alex。**這條最低成本，
+   不用另外接 LINE token。**
+2. `/admin/ops-health` 頁面：讀 `ops_health_checks` 畫成列表，Alex 想細看
+   哪一類卡住可以自己點進去，不用等通知。
+
+兩者互補：Routine 負責「有事發生時主動講」，頁面負責「Alex 想看時查得到」。
+**不做**額外的 LINE OA 推播給 Alex 本人——那套是給客人用的，channel token
+管理增加維運負擔，Routine 已經能推播。
+
+---
+
+## 4. Phase 1（建議先做，成本最低、對應最痛的事故）
+
+1. Layer C 的健檢表 + 5 支 SQL（stuck confirmed、backorder 未解、閘門隱性放行、
+   斷貨單堆積、互助量未還）——全部是 CLAUDE.md 裡現成驗證過的查詢，改寫成
+   常駐版本工作量最小。
+2. 建 `ops_health_checks` 表 + 一支 `rpc_run_health_checks()` 跑全部檢查。
+3. 建 daily Routine 呼叫 Management API 跑 `rpc_run_health_checks()`，
+   有異常才通知 Alex。
+4. Layer D：apps/admin 接 `clientLog.ts` 同款模式。
+
+## 5. Phase 2（次要，实作成本較高）
+
+1. Layer A 部署一致性比對（需要處理 SQL 正規化去噪音，容易誤報）。
+2. Layer B 效能回歸採樣（`pg_stat_statements` 快照需要額外一張歷史表，
+   而且 Micro tier 上 `pg_stat_statements` 本身也吃資源，要控制採樣頻率）。
+3. `/admin/ops-health` 頁面（Phase 1 先靠 Routine 通知就夠用，頁面是錦上添花）。
+
+---
+
+## 6. 不做的
+
+- 不導入 Sentry/Datadog/Grafana 這類第三方 SaaS——現有規模一個人維運，
+  多一個帳號多一份要顧的東西，且大多數事故的根因是「業務狀態機卡住」，
+  不是「哪支 API 慢」，通用 APM 工具接不住這類問題。
+- 不做即時（sub-minute）監控。目前所有事故的教訓都是「幾天內發現就好」，
+  daily 巡檢已經比現況（沒有巡檢）快得多，不需要為此養一套即時 pipeline。


### PR DESCRIPTION
## Summary
- 新增 `docs/PLAN-observability架構.md`：規劃文件，尚未實作
- 四層巡檢（部署一致性 / DB 效能回歸 / 業務健康檢查 / 前端錯誤）+ Claude Routine 通知管道，不導入第三方 APM
- 分 Phase 1（低成本、對應已知事故）/ Phase 2

## Test plan
- 純文件變更，無程式碼修改

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGTxXTHQyH1cM4Kznz5f7x)_