### PR TITLE
「一鍵新增庫存」改成明顯的按鈕

### DIFF
--- a/apps/admin/src/components/AssignStockModal.tsx
+++ b/apps/admin/src/components/AssignStockModal.tsx
@@ -223,23 +223,23 @@ export function AssignStockModal({
             </div>
           )}
           {b && cap <= 0 && !topUp && (
-            <div className="mt-1.5 text-[11px] text-amber-700 dark:text-amber-400">
-              {b.on_hand <= 0 ? (
-                <>店倉帳上這個商品是 0 件。架上實際有貨 → 先到「庫存總覽」用「＋ 新增庫存」入帳，</>
-              ) : (
-                <>在庫 {b.on_hand} 件已經被別的單佔走 {b.committed} 件（已承諾未取 ＋ 已配過的單），</>
-              )}
-              或
+            <div className="mt-1.5">
+              <div className="text-[11px] text-amber-700 dark:text-amber-400">
+                {b.on_hand <= 0 ? (
+                  <>店倉帳上這個商品是 0 件。架上實際有貨的話：</>
+                ) : (
+                  <>在庫 {b.on_hand} 件已經被別的單佔走 {b.committed} 件（已承諾未取 ＋ 已配過的單）。架上實際有更多貨的話：</>
+                )}
+              </div>
               <SpinButton
                 onClick={() => {
                   setTopUp(true);
                   setQty(Math.max(1, room));
                 }}
-                className="ml-1 font-medium text-amber-900 underline dark:text-amber-200"
+                className="mt-1.5 w-full rounded-md border border-amber-400 bg-amber-100 px-3 py-2 text-center text-xs font-semibold text-amber-900 hover:bg-amber-200 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200 dark:hover:bg-amber-900"
               >
-                架上其實有貨、一鍵新增庫存再配貨
+                🏗 架上其實有貨、一鍵新增庫存再配貨
               </SpinButton>
-              。
             </div>
           )}
           {b && topUp && (


### PR DESCRIPTION
## 做了什麼

#866 上的「架上其實有貨、一鍵新增庫存再配貨」原本是藏在文字裡的底線連結，太不明顯。改成獨立一整排的黃底按鈕。

## 上線危險

- 做了：純樣式調整，把 `AssignStockModal.tsx` 裡的文字連結換成 `<SpinButton>` 區塊按鈕。
- 不做：沒有動任何邏輯、RPC 呼叫、資料庫。
- 回退：revert 這個 commit 即可。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `npx tsc --noEmit`、`npx eslint` 皆無錯誤

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCYYcLW1Yk9b3i97YLBjof)_