### PR TITLE
確認取貨後只自動印一張取貨單，不再加印小白單

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -708,7 +708,6 @@ function PickupPageContent() {
       let okCount = 0;
       const errors: string[] = [];
       const eventIds: number[] = [];
-      const okOrderIds: number[] = [];
       // 餘額只有一份，逐張扣、扣到沒有為止（試算與這裡同一套分配法）
       let walletLeft = useWallet ? (walletBalances.get(memberId) ?? 0) : 0;
       let walletUsedTotal = 0;
@@ -753,17 +752,16 @@ function PickupPageContent() {
         if (e) errors.push(`${o.order_no}: ${e.message}`);
         else {
           okCount++;
-          okOrderIds.push(o.id);
           const ev = data as { event_id: number };
           if (ev?.event_id) eventIds.push(ev.event_id);
         }
       }
       if (errors.length > 0) setError(errors.join("\n"));
       if (eventIds.length > 0) {
-        // 自動列印 — 大張取貨單 + 熱感應小白單（隱藏 iframe,不跳新分頁;依序印）
+        // 自動列印只出一張取貨單（隱藏 iframe,不跳新分頁）。留底／剩餘未取
+        // 品項改去「已取貨」分頁補印或按「列印小白單」，不再自動加印第二張。
         // 只印真的取成功的那幾張（扣款失敗／取貨失敗的單不該出單）
         printViaIframe(withBasePath(`/pickup/print?event_ids=${eventIds.join(",")}`));
-        printViaIframe(withBasePath(`/pickup/print-list?order_ids=${okOrderIds.join(",")}`));
       }
       alert(
         `完成 ${okCount}/${memberOrders.length} 張取貨`
@@ -803,11 +801,8 @@ function PickupPageContent() {
     if (e) { setError(`${order.order_no}：${translateRpcError(e)}`); return; }
     const ev = data as { event_id: number; active_remaining: number };
     if (ev?.event_id) {
-      // 取貨單一定印；還有未取品項(部分到貨) → 追加取貨清單提醒剩下未取的
+      // 只印一張取貨單。剩下未取的品項留在取貨頁看得到，要單子就按「列印小白單」。
       printViaIframe(withBasePath(`/pickup/print?event_ids=${ev.event_id}`));
-      if (ev.active_remaining > 0) {
-        printViaIframe(withBasePath(`/pickup/print-list?order_ids=${order.id}`));
-      }
     }
     setReloadTick((n) => n + 1);
   }

--- a/apps/admin/src/components/PickupDialog.tsx
+++ b/apps/admin/src/components/PickupDialog.tsx
@@ -349,12 +349,9 @@ export function PickupDialog({
       });
       if (error) { setErr(error.message); return; }
       const result = data as { event_id: number; new_order_status: string; picked_count: number; active_remaining: number };
-      // 取貨單一定印（收據）— 隱藏 iframe,不跳新分頁
+      // 只印一張取貨單（收據）— 隱藏 iframe,不跳新分頁。
+      // 剩餘未取品項不再自動加印小白單：要單子按「🖨️ 列印小白單」，留底去「已取貨」分頁補印。
       printViaIframe(withBasePath(`/pickup/print?event_ids=${result.event_id}`));
-      // 取貨清單只在「部分取貨」時印（提醒客人剩下未取的 items）；全取完省略
-      if (result.active_remaining > 0) {
-        printViaIframe(withBasePath(`/pickup/print-list?order_ids=${orderId}`));
-      }
       onPickedUp(result);
     } finally {
       setBusy(false);


### PR DESCRIPTION
## 背景

店端回報取貨時重複出單，且兩張的總數量／應付對不上：取貨清單（小白單）列的是所有未取品項（含未到貨），取貨單只列實際取走的 —— 例：古華 269655 小霞，小白單 21 項 $2,029、取貨單 20 項 $1,870，差的是還沒到貨的栗子牛奶。

## 改動

確認取貨成功後一律只自動印一張取貨單，拿掉三條路徑的追加小白單列印：

- 一次全取（`bulkPickAllConfirmed`）：原本每次都加印一張小白單
- 單張一鍵取貨（`quickPickup`）：原本有剩餘未取品項時加印
- `PickupDialog` 確認取貨：原本部分取貨時加印

留底走「已取貨」分頁補印；要剩餘未取清單就按「🖨️ 列印小白單」手動印（手動按鈕全部保留）。

## 驗證

- `tsc --noEmit` 通過；eslint 對兩個檔案僅剩兩筆既有的 `react-hooks/set-state-in-effect`（與本次改動無關）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mphcNQ1xxH9dDKaf6R95i

---
_Generated by [Claude Code](https://claude.ai/code/session_016mphcNQ1xxH9dDKaf6R95i)_