### PR TITLE
日結報表：明細點了才載（20 筆分頁）＋彙總改表格＋訂單頁同款樣式

### DIFF
--- a/apps/admin/src/app/(protected)/finance/daily/page.tsx
+++ b/apps/admin/src/app/(protected)/finance/daily/page.tsx
@@ -3,6 +3,7 @@
 // 日結報表：依日期 × 分店統計「已取走品項」的金額（已完成 + 部分取貨已取走的部分）。
 // 口徑 = rpc_daily_pickup_settlement（picked_up 逐行、qty×單價、不扣折扣、
 // 排除內部容器單），與 /orders KPI「今日取貨金額」同一套，兩邊數字對得起來。
+// 訂單明細不預載：點「查看訂單明細」才打 rpc_daily_pickup_orders，一頁 20 筆。
 // 分店帳號鎖自己店（比照 /pickup 的 branchLocked 慣例）；HQ 可切全部分店。
 
 import { useEffect, useMemo, useState } from "react";
@@ -10,8 +11,9 @@ import { getSupabase } from "@/lib/supabase";
 import { useDefaultStoreFromUser, useUserBranchStoreId } from "@/lib/useDefaultStoreFromUser";
 import { useMyStores, useRole } from "@/lib/role";
 import { orderStatusLabel } from "@/lib/orderStatus";
-import { withBasePath } from "@/lib/basePath";
 import { DatePicker } from "@/components/DatePicker";
+import { Modal } from "@/components/Modal";
+import { OrderDetail } from "@/components/OrderDetail";
 import SpinButton from "@/components/SpinButton";
 
 type Store = { id: number; code: string; name: string };
@@ -30,6 +32,12 @@ type DayRow = {
   other_amount: number;
 };
 
+type Report = {
+  date_from: string;
+  date_to: string;
+  days: DayRow[];
+};
+
 type OrderRow = {
   ymd: string;
   store_id: number;
@@ -44,14 +52,9 @@ type OrderRow = {
   picked_at: string;
 };
 
-type Report = {
-  date_from: string;
-  date_to: string;
-  days: DayRow[];
-  orders: OrderRow[];
-  orders_total: number;
-  orders_truncated: boolean;
-};
+type OrdersPage = { total: number; rows: OrderRow[] };
+
+const ORDERS_PAGE_SIZE = 20;
 
 function localYmd(d = new Date()): string {
   const y = d.getFullYear();
@@ -80,6 +83,19 @@ export default function DailySettlementPage() {
   const [report, setReport] = useState<Report | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // 訂單明細：點了才載、分頁
+  const [ordersOpen, setOrdersOpen] = useState(false);
+  const [ordersPage, setOrdersPage] = useState(1);
+  const [ordersData, setOrdersData] = useState<OrdersPage | null>(null);
+  const [ordersLoading, setOrdersLoading] = useState(false);
+  const [ordersError, setOrdersError] = useState<string | null>(null);
+
+  // 點訂單 → 開訂單明細 Modal（與 /orders 同一個 OrderDetail）
+  const [detailId, setDetailId] = useState<number | null>(null);
+  const [detailNo, setDetailNo] = useState<string>("");
+  // Modal 裡可能撤銷取貨 / 改單，關掉後重抓彙總與明細
+  const [reloadTick, setReloadTick] = useState(0);
 
   // 分店帳號鎖自己店（比照 /pickup）：錢的報表不給跨店看
   const role = useRole();
@@ -129,22 +145,49 @@ export default function DailySettlementPage() {
       }
     })();
     return () => { cancelled = true; };
-  }, [storeFilter, dateFrom, dateTo, branchLocked, branchStoreId]);
+  }, [storeFilter, dateFrom, dateTo, branchLocked, branchStoreId, reloadTick]);
+
+  // 換條件 → 明細回到第 1 頁（面板開著就會自動重查）
+  useEffect(() => { setOrdersPage(1); }, [storeFilter, dateFrom, dateTo]);
+
+  useEffect(() => {
+    if (!ordersOpen) return;
+    if (branchLocked && branchStoreId == null) return;
+    let cancelled = false;
+    setOrdersLoading(true);
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data, error: e1 } = await sb.rpc("rpc_daily_pickup_orders", {
+          p_store_id: storeFilter ? Number(storeFilter) : null,
+          p_date_from: dateFrom,
+          p_date_to: dateTo,
+          p_limit: ORDERS_PAGE_SIZE,
+          p_offset: (ordersPage - 1) * ORDERS_PAGE_SIZE,
+        });
+        if (cancelled) return;
+        if (e1) { setOrdersError(e1.message); return; }
+        setOrdersError(null);
+        setOrdersData(data as OrdersPage);
+      } catch (err) {
+        if (!cancelled) setOrdersError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setOrdersLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [ordersOpen, ordersPage, storeFilter, dateFrom, dateTo, branchLocked, branchStoreId, reloadTick]);
 
   const totals = useMemo(() => {
     const t = {
       orders: 0, qty: 0, amount: 0,
-      completedOrders: 0, completedAmount: 0,
-      partialOrders: 0, partialAmount: 0,
-      otherAmount: 0,
+      completedAmount: 0, partialAmount: 0, otherAmount: 0,
     };
     for (const d of report?.days ?? []) {
       t.orders += Number(d.orders);
       t.qty += Number(d.qty);
       t.amount += Number(d.amount);
-      t.completedOrders += Number(d.completed_orders);
       t.completedAmount += Number(d.completed_amount);
-      t.partialOrders += Number(d.partial_orders);
       t.partialAmount += Number(d.partial_amount);
       t.otherAmount += Number(d.other_amount);
     }
@@ -168,6 +211,9 @@ export default function DailySettlementPage() {
     { label: "近 7 天", from: addDays(today, -6), to: today },
     { label: "本月", from: `${today.slice(0, 8)}01`, to: today },
   ];
+
+  const ordersTotal = ordersData?.total ?? 0;
+  const ordersTotalPages = Math.max(1, Math.ceil(ordersTotal / ORDERS_PAGE_SIZE));
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
@@ -227,17 +273,55 @@ export default function DailySettlementPage() {
         )}
       </div>
 
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <Stat label="取貨金額" value={money(totals.amount)} accent="positive" />
-        <Stat
-          label={`已完成訂單（${totals.completedOrders} 張）`}
-          value={money(totals.completedAmount)}
-        />
-        <Stat
-          label={`部分取貨訂單（${totals.partialOrders} 張）`}
-          value={money(totals.partialAmount)}
-        />
-        <Stat label="取貨件數" value={`${Math.round(totals.qty).toLocaleString()} 件`} />
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          <p className="font-mono text-xs">{error}</p>
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+        <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+          <thead className="bg-zinc-50 dark:bg-zinc-900">
+            <tr>
+              <Th>日期</Th>
+              {showStoreCol && <Th>分店</Th>}
+              <Th className="text-right">單數</Th>
+              <Th className="text-right">件數</Th>
+              <Th className="text-right">已完成</Th>
+              <Th className="text-right">部分取貨</Th>
+              <Th className="text-right">取貨金額</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+            {report === null ? (
+              <tr><td colSpan={7} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+            ) : report.days.length === 0 ? (
+              <tr><td colSpan={7} className="p-6 text-center text-zinc-500">這段期間沒有取貨。</td></tr>
+            ) : report.days.map((d) => (
+              <tr key={`${d.ymd}-${d.store_id}`} className="odd:bg-white even:bg-zinc-50 hover:bg-zinc-100 dark:odd:bg-zinc-950 dark:even:bg-zinc-900 dark:hover:bg-zinc-800">
+                <Td className="text-xs">{d.ymd}</Td>
+                {showStoreCol && <Td className="text-xs">{d.store_name}</Td>}
+                <Td className="text-right font-mono">{d.orders}</Td>
+                <Td className="text-right font-mono">{Math.round(Number(d.qty))}</Td>
+                <Td className="text-right font-mono">{money(d.completed_amount)}</Td>
+                <Td className="text-right font-mono">{Number(d.partial_amount) > 0 ? money(d.partial_amount) : "—"}</Td>
+                <Td className="text-right font-mono font-medium">{money(d.amount)}</Td>
+              </tr>
+            ))}
+          </tbody>
+          {report !== null && report.days.length > 1 && (
+            <tfoot className="bg-zinc-50 dark:bg-zinc-900">
+              <tr>
+                <Td className="text-xs font-medium" colSpan={showStoreCol ? 2 : 1}>合計</Td>
+                <Td className="text-right font-mono font-medium">{totals.orders}</Td>
+                <Td className="text-right font-mono font-medium">{Math.round(totals.qty)}</Td>
+                <Td className="text-right font-mono font-medium">{money(totals.completedAmount)}</Td>
+                <Td className="text-right font-mono font-medium">{totals.partialAmount > 0 ? money(totals.partialAmount) : "—"}</Td>
+                <Td className="text-right font-mono font-semibold">{money(totals.amount)}</Td>
+              </tr>
+            </tfoot>
+          )}
+        </table>
       </div>
       {totals.otherAmount > 0 && (
         <p className="text-xs text-amber-600">
@@ -245,120 +329,104 @@ export default function DailySettlementPage() {
         </p>
       )}
 
-      {error && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
-          <p className="font-mono text-xs">{error}</p>
-        </div>
-      )}
-
-      {(multiDay || showStoreCol) && (
-        <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
-          <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
-            <thead className="bg-zinc-50 dark:bg-zinc-900">
-              <tr>
-                <Th>日期</Th>
-                {showStoreCol && <Th>分店</Th>}
-                <Th className="text-right">單數</Th>
-                <Th className="text-right">件數</Th>
-                <Th className="text-right">已完成</Th>
-                <Th className="text-right">部分取貨</Th>
-                <Th className="text-right">取貨金額</Th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
-              {report === null ? (
-                <tr><td colSpan={7} className="p-3 text-center text-zinc-500">載入中…</td></tr>
-              ) : report.days.length === 0 ? (
-                <tr><td colSpan={7} className="p-6 text-center text-zinc-500">這段期間沒有取貨。</td></tr>
-              ) : report.days.map((d) => (
-                <tr key={`${d.ymd}-${d.store_id}`} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
-                  <Td className="text-xs">{d.ymd}</Td>
-                  {showStoreCol && <Td className="text-xs">{d.store_name}</Td>}
-                  <Td className="text-right font-mono">{d.orders}</Td>
-                  <Td className="text-right font-mono">{Math.round(Number(d.qty))}</Td>
-                  <Td className="text-right font-mono">{money(d.completed_amount)}</Td>
-                  <Td className="text-right font-mono">{Number(d.partial_amount) > 0 ? money(d.partial_amount) : "—"}</Td>
-                  <Td className="text-right font-mono font-medium">{money(d.amount)}</Td>
-                </tr>
-              ))}
-            </tbody>
-            {report !== null && report.days.length > 1 && (
-              <tfoot className="bg-zinc-50 dark:bg-zinc-900">
-                <tr>
-                  <Td className="text-xs font-medium" colSpan={showStoreCol ? 2 : 1}>合計</Td>
-                  <Td className="text-right font-mono font-medium">{totals.orders}</Td>
-                  <Td className="text-right font-mono font-medium">{Math.round(totals.qty)}</Td>
-                  <Td className="text-right font-mono font-medium">{money(totals.completedAmount)}</Td>
-                  <Td className="text-right font-mono font-medium">{totals.partialAmount > 0 ? money(totals.partialAmount) : "—"}</Td>
-                  <Td className="text-right font-mono font-semibold">{money(totals.amount)}</Td>
-                </tr>
-              </tfoot>
-            )}
-          </table>
-        </div>
-      )}
-
       <div>
         <div className="mb-2 flex items-center justify-between">
           <span className="text-sm font-medium">
-            取貨訂單明細（{report?.orders_total ?? 0} 筆
-            {report?.orders_truncated ? `，僅顯示最近 ${report.orders.length} 筆` : ""}）
+            訂單明細
+            {ordersOpen && ordersData !== null ? `（${ordersTotal} 筆）` : ""}
+            {ordersLoading ? " 載入中…" : ""}
           </span>
+          <SpinButton
+            onClick={() => setOrdersOpen((v) => !v)}
+            className="rounded-md border border-zinc-300 px-3 py-1 text-xs hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            {ordersOpen ? "收合" : "📋 查看訂單明細"}
+          </SpinButton>
         </div>
-        <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
-          <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
-            <thead className="bg-zinc-50 dark:bg-zinc-900">
-              <tr>
-                <Th>取貨時間</Th>
-                <Th>訂單編號</Th>
-                {showStoreCol && <Th>分店</Th>}
-                <Th>會員</Th>
-                <Th>狀態</Th>
-                <Th className="text-right">品項</Th>
-                <Th className="text-right">數量</Th>
-                <Th className="text-right">金額</Th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
-              {report === null ? (
-                <tr><td colSpan={8} className="p-3 text-center text-zinc-500">載入中…</td></tr>
-              ) : report.orders.length === 0 ? (
-                <tr><td colSpan={8} className="p-6 text-center text-zinc-500">這段期間沒有取貨。</td></tr>
-              ) : report.orders.map((o) => (
-                <tr key={`${o.order_id}-${o.ymd}`} className="hover:bg-zinc-50 dark:hover:bg-zinc-900">
-                  <Td className="whitespace-nowrap text-xs text-zinc-500">
-                    {multiDay ? `${o.ymd} ` : ""}
-                    {new Date(o.picked_at).toLocaleTimeString("zh-TW", { hour: "2-digit", minute: "2-digit", hour12: false })}
-                  </Td>
-                  <Td className="font-mono text-xs">
-                    <a
-                      href={withBasePath(`/orders?q=${encodeURIComponent(o.order_no)}&storeId=${o.store_id}`)}
-                      className="text-blue-600 hover:underline dark:text-blue-400"
-                    >
-                      {o.order_no}
-                    </a>
-                  </Td>
-                  {showStoreCol && <Td className="text-xs">{o.store_name}</Td>}
-                  <Td className="text-xs">{o.member_name ?? "—"}</Td>
-                  <Td>
-                    <span className={`inline-block rounded px-2 py-0.5 text-xs ${
-                      o.status === "completed"
-                        ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
-                        : o.status === "partially_completed"
-                        ? "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300"
-                        : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
-                    }`}>
-                      {orderStatusLabel(o.status)}
-                    </span>
-                  </Td>
-                  <Td className="text-right font-mono">{o.item_count}</Td>
-                  <Td className="text-right font-mono">{Math.round(Number(o.qty))}</Td>
-                  <Td className="text-right font-mono">{money(o.amount)}</Td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+
+        {ordersOpen && (
+          <>
+            {ordersError && (
+              <div className="mb-2 rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+                <p className="font-mono">{ordersError}</p>
+              </div>
+            )}
+            <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+              <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+                <thead className="bg-zinc-50 dark:bg-zinc-900">
+                  <tr>
+                    <Th>取貨時間</Th>
+                    <Th>訂單編號</Th>
+                    {showStoreCol && <Th>分店</Th>}
+                    <Th>會員</Th>
+                    <Th>狀態</Th>
+                    <Th className="text-right">品項</Th>
+                    <Th className="text-right">數量</Th>
+                    <Th className="text-right">金額</Th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                  {ordersData === null ? (
+                    <tr><td colSpan={8} className="p-3 text-center text-zinc-500">載入中…</td></tr>
+                  ) : ordersData.rows.length === 0 ? (
+                    <tr><td colSpan={8} className="p-6 text-center text-zinc-500">這段期間沒有取貨。</td></tr>
+                  ) : ordersData.rows.map((o) => (
+                    <tr key={`${o.order_id}-${o.ymd}`} className="odd:bg-white even:bg-zinc-50 hover:bg-zinc-100 dark:odd:bg-zinc-950 dark:even:bg-zinc-900 dark:hover:bg-zinc-800">
+                      <Td className="whitespace-nowrap text-xs text-zinc-500">
+                        {multiDay ? `${o.ymd} ` : ""}
+                        {new Date(o.picked_at).toLocaleTimeString("zh-TW", { hour: "2-digit", minute: "2-digit", hour12: false })}
+                      </Td>
+                      <Td className="font-mono text-xs">
+                        <SpinButton
+                          onClick={() => { setDetailId(o.order_id); setDetailNo(o.order_no); }}
+                          className="text-blue-600 hover:underline dark:text-blue-400"
+                          title={`開啟訂單明細 ${o.order_no}`}
+                        >
+                          {o.order_no}
+                        </SpinButton>
+                      </Td>
+                      {showStoreCol && <Td className="text-xs">{o.store_name}</Td>}
+                      <Td className="text-xs">{o.member_name ?? "—"}</Td>
+                      <Td>
+                        <span className={`inline-block rounded px-2 py-0.5 text-xs ${
+                          o.status === "completed"
+                            ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
+                            : o.status === "partially_completed"
+                            ? "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                            : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+                        }`}>
+                          {orderStatusLabel(o.status)}
+                        </span>
+                      </Td>
+                      <Td className="text-right font-mono">{o.item_count}</Td>
+                      <Td className="text-right font-mono">{Math.round(Number(o.qty))}</Td>
+                      <Td className="text-right font-mono">{money(o.amount)}</Td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {ordersData !== null && ordersTotalPages > 1 && (
+              <div className="mt-2 flex items-center justify-end gap-2 text-sm">
+                <SpinButton
+                  disabled={ordersPage <= 1 || ordersLoading}
+                  onClick={() => setOrdersPage((p) => Math.max(1, p - 1))}
+                  className="rounded-md border border-zinc-300 px-3 py-1 disabled:opacity-50 dark:border-zinc-700"
+                >
+                  上一頁
+                </SpinButton>
+                <span className="text-zinc-500">{ordersPage} / {ordersTotalPages}</span>
+                <SpinButton
+                  disabled={ordersPage >= ordersTotalPages || ordersLoading}
+                  onClick={() => setOrdersPage((p) => Math.min(ordersTotalPages, p + 1))}
+                  className="rounded-md border border-zinc-300 px-3 py-1 disabled:opacity-50 dark:border-zinc-700"
+                >
+                  下一頁
+                </SpinButton>
+              </div>
+            )}
+          </>
+        )}
       </div>
 
       <p className="text-xs text-zinc-400">
@@ -366,26 +434,28 @@ export default function DailySettlementPage() {
         部分取貨的訂單只計已取走的品項。內部單（RR-／【內部】xx 店）不計。
         撤銷取貨後自動從報表移除。
       </p>
+
+      <Modal
+        open={detailId !== null}
+        onClose={() => { setDetailId(null); setReloadTick((t) => t + 1); }}
+        title={`訂單明細 ${detailNo}`}
+        maxWidth="max-w-4xl"
+      >
+        {detailId !== null && (
+          <OrderDetail
+            orderId={detailId}
+            onNavigate={(id, no) => { setDetailId(id); setDetailNo(no); }}
+          />
+        )}
+      </Modal>
     </div>
   );
 }
 
-function Stat({ label, value, accent }: { label: string; value: string; accent?: "positive" | "negative" | "neutral" }) {
-  const cls =
-    accent === "positive" ? "text-emerald-600" :
-    accent === "negative" ? "text-rose-600" :
-    "text-zinc-700 dark:text-zinc-200";
-  return (
-    <div className="rounded-md border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
-      <div className="text-xs text-zinc-500">{label}</div>
-      <div className={`mt-1 text-base font-medium ${cls}`}>{value}</div>
-    </div>
-  );
-}
-
+// 與 /orders 的 Th / Td 同一套樣式（px-4）
 function Th({ children, className = "" }: { children: React.ReactNode; className?: string }) {
-  return <th className={`px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 ${className}`}>{children}</th>;
+  return <th className={`px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-500 ${className}`}>{children}</th>;
 }
 function Td({ children, className = "", colSpan }: { children: React.ReactNode; className?: string; colSpan?: number }) {
-  return <td colSpan={colSpan} className={`px-3 py-2 ${className}`}>{children}</td>;
+  return <td colSpan={colSpan} className={`px-4 py-2 ${className}`}>{children}</td>;
 }

--- a/supabase/migrations/20260828010000_rpc_daily_pickup_orders_paged.sql
+++ b/supabase/migrations/20260828010000_rpc_daily_pickup_orders_paged.sql
@@ -1,0 +1,194 @@
+-- ============================================================
+-- 2026-08-28: 日結報表訂單明細改「點了才載、分頁 20 筆」（Alex 8/26 補充指示）
+--
+-- 拆兩支：rpc_daily_pickup_settlement 只回彙總（拿掉 orders / orders_total /
+-- orders_truncated 三個 key），明細改走新函式 rpc_daily_pickup_orders
+-- （p_limit 預設 20、上限 100，p_offset 分頁，picked_at DESC）。
+-- 口徑（picked_up 逐行、qty*unit_price、Asia/Taipei 日界、排除
+-- cancelled/expired/transferred_out 訂單與 member_type='store_internal'
+-- 容器單）與基底版本完全相同，只動回傳形狀，詳見基底檔頭。
+--
+-- ⚠ 兩支函式的 picked 母體（WHERE 那五個條件）必須逐字一致，
+--   改其中一支記得同步另一支，否則彙總跟明細對不上。
+--
+-- 基底版本：20260826010000_rpc_daily_pickup_settlement.sql
+--   （settlement 簽章不變，CREATE OR REPLACE 覆寫；orders 為新函式）。
+-- 此版 SQL 已於 2026-08-26 套上正式庫（Management API），線上一直是本檔的行為；
+--   基底檔進 main 的是初版（settlement 帶 orders），從零重跑時會被本檔蓋掉，一致。
+-- rollback：settlement CREATE OR REPLACE 回 20260826010000 版本；
+--           DROP FUNCTION rpc_daily_pickup_orders(bigint, date, date, integer, integer);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION rpc_daily_pickup_settlement(
+  p_store_id  bigint DEFAULT NULL,
+  p_date_from date   DEFAULT NULL,
+  p_date_to   date   DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH params AS (
+    SELECT
+      COALESCE(p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date) AS d_from,
+      LEAST(
+        COALESCE(p_date_to, p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date),
+        COALESCE(p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date) + 92
+      ) AS d_to
+  ),
+  bounds AS (
+    SELECT
+      (p.d_from::timestamp AT TIME ZONE 'Asia/Taipei')       AS ts_from,
+      ((p.d_to + 1)::timestamp AT TIME ZONE 'Asia/Taipei')   AS ts_to
+    FROM params p
+  ),
+  picked AS (
+    SELECT
+      to_char((i.updated_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd,
+      co.pickup_store_id                            AS store_id,
+      COALESCE(s.name, '#' || co.pickup_store_id)   AS store_name,
+      co.id                                         AS order_id,
+      CASE
+        WHEN co.status = 'completed'           THEN 'completed'
+        WHEN co.status = 'partially_completed' THEN 'partial'
+        ELSE 'other'
+      END                                           AS grp,
+      i.qty::numeric                                AS qty,
+      (i.qty * i.unit_price)::numeric               AS amount
+    FROM customer_order_items i
+    JOIN customer_orders co ON co.id = i.order_id
+    JOIN bounds b ON TRUE
+    LEFT JOIN members m ON m.id = co.member_id
+    LEFT JOIN stores  s ON s.id = co.pickup_store_id
+    WHERE i.status = 'picked_up'
+      AND i.updated_at >= b.ts_from
+      AND i.updated_at <  b.ts_to
+      AND co.status NOT IN ('cancelled','expired','transferred_out')
+      AND COALESCE(m.member_type, '') <> 'store_internal'
+      AND (p_store_id IS NULL OR co.pickup_store_id = p_store_id)
+  ),
+  day_agg AS (
+    SELECT
+      p.ymd,
+      p.store_id,
+      p.store_name,
+      count(DISTINCT p.order_id)                                          AS orders,
+      SUM(p.qty)::numeric                                                 AS qty,
+      SUM(p.amount)::numeric                                              AS amount,
+      count(DISTINCT p.order_id) FILTER (WHERE p.grp = 'completed')       AS completed_orders,
+      COALESCE(SUM(p.amount) FILTER (WHERE p.grp = 'completed'), 0)::numeric AS completed_amount,
+      count(DISTINCT p.order_id) FILTER (WHERE p.grp = 'partial')         AS partial_orders,
+      COALESCE(SUM(p.amount) FILTER (WHERE p.grp = 'partial'), 0)::numeric   AS partial_amount,
+      COALESCE(SUM(p.amount) FILTER (WHERE p.grp = 'other'), 0)::numeric     AS other_amount
+    FROM picked p
+    GROUP BY p.ymd, p.store_id, p.store_name
+  )
+  SELECT jsonb_build_object(
+    'date_from', (SELECT to_char(d_from, 'YYYY-MM-DD') FROM params),
+    'date_to',   (SELECT to_char(d_to,   'YYYY-MM-DD') FROM params),
+    'days', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(d.*) ORDER BY d.ymd DESC, d.store_name)
+       FROM day_agg d),
+      '[]'::jsonb
+    )
+  );
+$$;
+
+COMMENT ON FUNCTION rpc_daily_pickup_settlement(bigint, date, date) IS
+  '日結報表彙總：依日期×分店聚合「已取走品項」金額（picked_up 逐行、qty*unit_price、'
+  'Asia/Taipei 日界、updated_at 當取貨時間），拆已完成 / 部分取貨。排除 cancelled/'
+  'expired/transferred_out 訂單與內部容器單（member_type=store_internal）。'
+  '口徑同 rpc_order_overview 的 pickup 聚合，不扣折扣。訂單明細走 '
+  'rpc_daily_pickup_orders（分頁），兩支的 picked 母體必須一致。';
+
+GRANT EXECUTE ON FUNCTION rpc_daily_pickup_settlement(bigint, date, date) TO authenticated;
+
+-- ------------------------------------------------------------
+-- 訂單明細（點了才載、分頁）。picked 母體與上面那支逐字相同。
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION rpc_daily_pickup_orders(
+  p_store_id  bigint  DEFAULT NULL,
+  p_date_from date    DEFAULT NULL,
+  p_date_to   date    DEFAULT NULL,
+  p_limit     integer DEFAULT 20,
+  p_offset    integer DEFAULT 0
+)
+RETURNS jsonb
+LANGUAGE sql STABLE
+AS $$
+  WITH params AS (
+    SELECT
+      COALESCE(p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date) AS d_from,
+      LEAST(
+        COALESCE(p_date_to, p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date),
+        COALESCE(p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date) + 92
+      ) AS d_to
+  ),
+  bounds AS (
+    SELECT
+      (p.d_from::timestamp AT TIME ZONE 'Asia/Taipei')       AS ts_from,
+      ((p.d_to + 1)::timestamp AT TIME ZONE 'Asia/Taipei')   AS ts_to
+    FROM params p
+  ),
+  picked AS (
+    SELECT
+      to_char((i.updated_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD') AS ymd,
+      co.pickup_store_id                            AS store_id,
+      COALESCE(s.name, '#' || co.pickup_store_id)   AS store_name,
+      co.id                                         AS order_id,
+      co.order_no,
+      co.status,
+      COALESCE(m.name, co.nickname_snapshot)        AS member_name,
+      i.qty::numeric                                AS qty,
+      (i.qty * i.unit_price)::numeric               AS amount,
+      i.updated_at                                  AS picked_at
+    FROM customer_order_items i
+    JOIN customer_orders co ON co.id = i.order_id
+    JOIN bounds b ON TRUE
+    LEFT JOIN members m ON m.id = co.member_id
+    LEFT JOIN stores  s ON s.id = co.pickup_store_id
+    WHERE i.status = 'picked_up'
+      AND i.updated_at >= b.ts_from
+      AND i.updated_at <  b.ts_to
+      AND co.status NOT IN ('cancelled','expired','transferred_out')
+      AND COALESCE(m.member_type, '') <> 'store_internal'
+      AND (p_store_id IS NULL OR co.pickup_store_id = p_store_id)
+  ),
+  order_day AS (
+    SELECT
+      p.ymd,
+      p.store_id,
+      p.store_name,
+      p.order_id,
+      p.order_no,
+      p.status,
+      p.member_name,
+      count(*)               AS item_count,
+      SUM(p.qty)::numeric    AS qty,
+      SUM(p.amount)::numeric AS amount,
+      max(p.picked_at)       AS picked_at
+    FROM picked p
+    GROUP BY p.ymd, p.store_id, p.store_name, p.order_id, p.order_no, p.status, p.member_name
+  ),
+  page AS (
+    SELECT *
+    FROM order_day
+    ORDER BY picked_at DESC, order_id DESC
+    LIMIT LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100)
+    OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+  )
+  SELECT jsonb_build_object(
+    'total', (SELECT count(*) FROM order_day),
+    'rows', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(o.*) ORDER BY o.picked_at DESC, o.order_id DESC)
+       FROM page o),
+      '[]'::jsonb
+    )
+  );
+$$;
+
+COMMENT ON FUNCTION rpc_daily_pickup_orders(bigint, date, date, integer, integer) IS
+  '日結報表訂單明細（分頁，預設 20 筆／上限 100）：依 訂單×日期 聚合已取走品項，'
+  'picked_at DESC。母體與 rpc_daily_pickup_settlement 完全一致，改任一支要同步另一支。';
+
+GRANT EXECUTE ON FUNCTION rpc_daily_pickup_orders(bigint, date, date, integer, integer) TO authenticated;


### PR DESCRIPTION
#854 的後續（8/26 合併時只含初版，本 PR 是之後的三項調整）：

- 訂單明細預設不載，點「查看訂單明細」才查，一頁 20 筆、可翻頁
- KPI 卡片拿掉，彙總改成 日期×分店 表格（含合計列）
- 明細表比照 /orders：斑馬紋列、點訂單編號直接開 OrderDetail 視窗（可在裡面撤銷取貨，關掉後報表重算）

DB：新 migration `20260828010000`（已進 main 的 `20260826010000` 不動）——`rpc_daily_pickup_settlement` 改只回彙總、新增 `rpc_daily_pickup_orders`（分頁，預設 20／上限 100）。**此版 SQL 8/26 已套上正式庫**，線上一直是這個行為，合併後前後端就對齊。

驗證：語法檢查 ✅、線上實跑兩支 RPC ✅、Playwright 煙測（預設不載明細／點了才打 RPC／翻頁 offset／點訂單開 Modal）✅、`npm run build` ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01TavUJjAieArtP8PEC9TGhz)_