### PR TITLE
樞紐表日期篩選改成以「日」為單位，並修正 UTC/台北的 8 小時偏移

### DIFF
--- a/apps/admin/src/app/(protected)/orders/pivot/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/pivot/page.tsx
@@ -83,39 +83,51 @@ const DEFAULT_INCLUDED: OrderStatus[] = ORDER_STATUSES.filter(
 );
 const LS_KEY = "new_erp-orders-pivot-filters";
 
-function fmtMonthInput(d: Date): string {
+// 以「當地日」格式化成 <input type="date"> 吃的 YYYY-MM-DD
+function fmtDateInput(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
-  return `${y}-${m}`;
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
 }
 
-// 預設: 當月 ~ 當月 (1 個月範圍, 想看更多月使用者自己拉)
-function defaultMonthRange(): { from: string; to: string } {
+// 預設: 當月 1 日 ~ 當月最後一日（想看更多天使用者自己拉）
+function defaultDateRange(): { from: string; to: string } {
   const today = new Date();
-  const cur = fmtMonthInput(today);
-  return { from: cur, to: cur };
+  const y = today.getFullYear();
+  const m = today.getMonth();
+  return {
+    from: fmtDateInput(new Date(y, m, 1)),
+    to: fmtDateInput(new Date(y, m + 1, 0)), // 下個月的第 0 天 = 本月最後一天
+  };
 }
 
-// 把 LS 舊版的 YYYY-MM-DD 截成 YYYY-MM
-function normalizeMonth(v: string | undefined | null): string | null {
+// LS / URL 可能殘留月選單時代的 "YYYY-MM"（2026-08-29 之前）→ 展開成該月
+// 第一天（from）/ 最後一天（to），使用者原本的範圍語意才不會被截掉。
+function normalizeDate(
+  v: string | undefined | null,
+  edge: "start" | "end",
+): string | null {
   if (!v) return null;
-  if (/^\d{4}-\d{2}$/.test(v)) return v;
-  if (/^\d{4}-\d{2}-\d{2}/.test(v)) return v.slice(0, 7);
+  if (/^\d{4}-\d{2}-\d{2}/.test(v)) return v.slice(0, 10);
+  const m = /^(\d{4})-(\d{2})$/.exec(v);
+  if (m) {
+    if (edge === "start") return `${m[1]}-${m[2]}-01`;
+    // new Date(y, 月份 1-based, 0) = 該月最後一天
+    return fmtDateInput(new Date(Number(m[1]), Number(m[2]), 0));
+  }
   return null;
 }
 
-// "2026-05" → "2026-05-01" (含當月 1 日 00:00)
-function monthStartDate(ym: string): string {
-  return `${ym}-01`;
-}
-
-// "2026-05" → "2026-06-01" (下個月 1 日 00:00, 用 < 比較)
-function nextMonthStartDate(ym: string): string {
-  const [y, m] = ym.split("-").map(Number);
-  const next = new Date(Date.UTC(y, m, 1)); // m: 1-based 過了一個月 → 0-based 即下個月
+// "2026-08-20" → "2026-08-21"（下一天 00:00）。RPC 的上界是 `<`，要送下一天
+// 才含得到使用者選的那一天整天。用 UTC 進位，不受瀏覽器時區影響。
+function nextDayDate(ymd: string): string {
+  const [y, m, d] = ymd.split("-").map(Number);
+  const next = new Date(Date.UTC(y, m - 1, d + 1));
   const ny = next.getUTCFullYear();
   const nm = String(next.getUTCMonth() + 1).padStart(2, "0");
-  return `${ny}-${nm}-01`;
+  const nd = String(next.getUTCDate()).padStart(2, "0");
+  return `${ny}-${nm}-${nd}`;
 }
 
 function fmtMD(iso: string | null): string {
@@ -141,7 +153,7 @@ export default function OrdersPivotPage() {
 
 function PivotContent() {
   const searchParams = useSearchParams();
-  const def = useMemo(defaultMonthRange, []);
+  const def = useMemo(defaultDateRange, []);
 
   const initialCampaignIds = ((): string[] => {
     const multi = searchParams.get("campaignIds");
@@ -154,9 +166,11 @@ function PivotContent() {
     normalizeViewBy(searchParams.get("viewBy")) ?? "campaign",
   );
   const [dateFrom, setDateFrom] = useState(
-    normalizeMonth(searchParams.get("from")) ?? def.from,
+    normalizeDate(searchParams.get("from"), "start") ?? def.from,
   );
-  const [dateTo, setDateTo] = useState(normalizeMonth(searchParams.get("to")) ?? def.to);
+  const [dateTo, setDateTo] = useState(
+    normalizeDate(searchParams.get("to"), "end") ?? def.to,
+  );
   const [statusSet, setStatusSet] = useState<Set<OrderStatus>>(new Set(DEFAULT_INCLUDED));
   const [storeId, setStoreId] = useState(searchParams.get("storeId") ?? "");
   const [metric, setMetric] = useState<Metric>(
@@ -224,11 +238,11 @@ function PivotContent() {
           if (v) setViewBy(v);
         }
         if (!searchParams.get("from")) {
-          const m = normalizeMonth(saved.dateFrom);
+          const m = normalizeDate(saved.dateFrom, "start");
           if (m) setDateFrom(m);
         }
         if (!searchParams.get("to")) {
-          const m = normalizeMonth(saved.dateTo);
+          const m = normalizeDate(saved.dateTo, "end");
           if (m) setDateTo(m);
         }
         if (Array.isArray(saved.status) && saved.status.length > 0) {
@@ -379,8 +393,10 @@ function PivotContent() {
           setLoading(false);
           return;
         }
-        const fromBoundary = dateFrom ? monthStartDate(dateFrom) : null;
-        const toBoundary = dateTo ? nextMonthStartDate(dateTo) : null;
+        // p_date_to 是排他上界（RPC 用 `<`）→ 送使用者選的日子 +1 天，
+        // 才會含到那一天整天。
+        const fromBoundary = dateFrom || null;
+        const toBoundary = dateTo ? nextDayDate(dateTo) : null;
         const { data, error: rpcErr } = await sb.rpc("rpc_orders_pivot", {
           p_view_by: viewBy,
           p_date_from: fromBoundary,
@@ -707,17 +723,17 @@ function PivotContent() {
           <option value="campaign">分組：開團（收單期間）</option>
         </select>
 
-        {/* Month range — 以月為單位、可跨多月 */}
+        {/* Date range — 以日為單位、可跨多月；預設當月 1 日 ~ 當月最後一日 */}
         <div
           className="flex items-center gap-1 rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800"
           title={
             viewBy === "campaign"
-              ? "依開團模式：套用至 campaign 收單月份 (end_at)"
-              : "依訂單日：套用至訂單 created_at 月份"
+              ? "依開團模式：套用至 campaign 收單日 (end_at)，起訖日都含在內"
+              : "依訂單日：套用至訂單 created_at 日期，起訖日都含在內"
           }
         >
           <input
-            type="month"
+            type="date"
             value={dateFrom}
             max={dateTo || undefined}
             onChange={(e) => setDateFrom(e.target.value)}
@@ -725,7 +741,7 @@ function PivotContent() {
           />
           <span className="text-zinc-400">~</span>
           <input
-            type="month"
+            type="date"
             value={dateTo}
             min={dateFrom || undefined}
             onChange={(e) => setDateTo(e.target.value)}

--- a/supabase/migrations/20260829000000_orders_pivot_taipei_day_boundaries.sql
+++ b/supabase/migrations/20260829000000_orders_pivot_taipei_day_boundaries.sql
@@ -1,0 +1,135 @@
+-- 20260829000000 — rpc_orders_pivot：日期界線與日分組改用 Asia/Taipei
+--
+-- 起因：樞紐表的日期篩選從「月」改成「日」（<input type="date">，預設當月 1 日 ~
+-- 當月最後一日）。改成日之後，原本被月粒度蓋住的時區偏移就會天天出現。
+--
+-- 問題：資料庫 session TimeZone 是 UTC（實測 current_setting('TimeZone') = 'UTC'），
+-- 所以 `p_date_from::timestamptz` = 該日 00:00 UTC = 台北時間 08:00。使用者選
+-- 「8/16 ~ 8/20」實際撈到的是台北 8/16 08:00 ~ 8/21 08:00：
+--   - 8/16 凌晨 0~8 點下的單被漏掉
+--   - 8/21 凌晨 0~8 點下的單被誤算進來
+-- 線上 79,677 張訂單裡有 10,522 張（13.2%）落在台北 00:00~08:00 這一段，
+-- 不是邊角案例。同樣的偏移也在 group_key：`f.created_at::date` 取的是 UTC 日，
+-- 台北 8/16 03:00 的單會被標成 8/15 那一列。
+--
+-- 修法：所有 date 參數與 timestamptz 欄位的換算一律套 `AT TIME ZONE 'Asia/Taipei'`，
+-- 與全 repo 既有慣例一致（close_date 那一系列 view / RPC 從 20260426 就這樣寫）。
+--   p_date_from::timestamp AT TIME ZONE 'Asia/Taipei'  → 台北當日 00:00 的 timestamptz
+--   (f.created_at AT TIME ZONE 'Asia/Taipei')::date     → 台北日
+-- p_date_to 維持排他上界（`<`）—— 前端送「使用者選的結束日 + 1 天」，所以起訖
+-- 兩天都完整含在範圍內。
+--
+-- pickup_deadline 是 date 欄位（非 timestamptz），本來就沒有時區問題，比較式不動；
+-- 只有它的 group_key fallback 用到 created_at，一併改成台北日。
+-- （'pickup_date' 分組 2026-05-21 已從前端下架，這裡只是保持內部一致。）
+--
+-- 基底版本：20260808000000_stats_exclude_transferred_out_items.sql
+--           （已與線上 pg_get_functiondef 逐字對過，無 drift）
+-- rollback：重跑 20260808000000 那一支即可回到 UTC 界線版本。
+
+CREATE OR REPLACE FUNCTION public.rpc_orders_pivot(p_view_by text, p_date_from date, p_date_to date, p_campaign_ids bigint[], p_store_id bigint, p_statuses text[], p_closed_only boolean DEFAULT NULL::boolean)
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH filtered AS (
+    SELECT o.*
+    FROM customer_orders o
+    LEFT JOIN group_buy_campaigns c ON c.id = o.campaign_id
+    WHERE o.status = ANY(p_statuses)
+      AND (p_store_id IS NULL OR o.pickup_store_id = p_store_id)
+      AND (
+        p_campaign_ids IS NULL
+        OR cardinality(p_campaign_ids) = 0
+        OR o.campaign_id = ANY(p_campaign_ids)
+      )
+      AND (
+        p_closed_only IS NULL
+        OR (p_closed_only IS TRUE
+            AND c.status IN ('closed','locked','ordered','receiving','ready','completed'))
+        OR (p_closed_only IS FALSE
+            AND c.status NOT IN ('closed','locked','ordered','receiving','ready','completed'))
+      )
+      AND CASE p_view_by
+        WHEN 'pickup_date' THEN
+          -- pickup_deadline 是 date，直接比，沒有時區問題
+          (p_date_from IS NULL OR o.pickup_deadline >= p_date_from)
+          AND (p_date_to IS NULL OR o.pickup_deadline <  p_date_to)
+        WHEN 'order_date' THEN
+          (p_date_from IS NULL
+             OR o.created_at >= (p_date_from::timestamp AT TIME ZONE 'Asia/Taipei'))
+          AND (p_date_to IS NULL
+             OR o.created_at <  (p_date_to::timestamp AT TIME ZONE 'Asia/Taipei'))
+        WHEN 'campaign' THEN
+          c.end_at IS NULL
+          OR (
+            (p_date_from IS NULL
+               OR c.end_at >= (p_date_from::timestamp AT TIME ZONE 'Asia/Taipei'))
+            AND (p_date_to IS NULL
+               OR c.end_at <  (p_date_to::timestamp AT TIME ZONE 'Asia/Taipei'))
+          )
+        ELSE TRUE
+      END
+  ),
+  base AS (
+    SELECT
+      CASE p_view_by
+        WHEN 'campaign'    THEN 'c' || f.campaign_id::text
+        WHEN 'pickup_date' THEN 'd' || to_char(COALESCE(f.pickup_deadline, (f.created_at AT TIME ZONE 'Asia/Taipei')::date), 'YYYY-MM-DD')
+        WHEN 'order_date'  THEN 'd' || to_char((f.created_at AT TIME ZONE 'Asia/Taipei')::date, 'YYYY-MM-DD')
+      END                                              AS group_key,
+      CASE WHEN p_view_by = 'campaign' THEN f.campaign_id ELSE NULL::bigint END
+                                                       AS group_id,
+      i.sku_id,
+      s.product_name                                   AS sku_product_name,
+      s.variant_name                                   AS sku_variant_name,
+      f.pickup_store_id,
+      f.id                                             AS order_id,
+      -- 排除旗標：訂單層級（取消/過期/轉出）或品項層級（部分轉出把來源品項
+      -- 標 cancelled 但留在原單）任一成立，這一列就不算進正單數量
+      (f.status IN ('cancelled','expired','transferred_out')
+       OR i.status IN ('cancelled','expired'))         AS excluded,
+      i.qty,
+      i.unit_price
+    FROM filtered f
+    JOIN customer_order_items i ON i.order_id = f.id
+    LEFT JOIN skus s ON s.id = i.sku_id
+  ),
+  agg AS (
+    SELECT
+      b.group_key,
+      b.group_id,
+      b.sku_id,
+      b.sku_product_name,
+      b.sku_variant_name,
+      b.pickup_store_id,
+      SUM(CASE WHEN b.excluded THEN 0 ELSE b.qty END)::numeric                AS qty_sum,
+      SUM(CASE WHEN b.excluded THEN 0 ELSE b.qty * b.unit_price END)::numeric AS amount,
+      SUM(CASE WHEN b.excluded THEN b.qty ELSE 0 END)::numeric                AS neg_qty_sum,
+      SUM(CASE WHEN b.excluded THEN b.qty * b.unit_price ELSE 0 END)::numeric AS neg_amount,
+      COALESCE(
+        ARRAY_AGG(DISTINCT b.order_id) FILTER (WHERE NOT b.excluded),
+        '{}'::bigint[]
+      )                                                                       AS pos_order_ids,
+      COALESCE(
+        ARRAY_AGG(DISTINCT b.order_id) FILTER (WHERE b.excluded),
+        '{}'::bigint[]
+      )                                                                       AS neg_order_ids
+    FROM base b
+    GROUP BY
+      b.group_key,
+      b.group_id,
+      b.sku_id,
+      b.sku_product_name,
+      b.sku_variant_name,
+      b.pickup_store_id
+  )
+  SELECT COALESCE(jsonb_agg(to_jsonb(agg.*)), '[]'::jsonb)
+  FROM agg;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_orders_pivot(text, date, date, bigint[], bigint, text[], boolean) IS
+  '訂單樞紐：qty_sum/amount 只算「訂單未取消/過期/轉出」且「品項未取消/過期」的量；'
+  '被排除的量進 neg_qty_sum/neg_amount。p_date_from / p_date_to 以 Asia/Taipei 解讀'
+  '（DB session 是 UTC，直接 ::timestamptz 會差 8 小時），p_date_to 為排他上界；'
+  'order_date 的日分組同樣取台北日。基底：20260808000000。';


### PR DESCRIPTION
## 做了什麼

**前端** `apps/admin/src/app/(protected)/orders/pivot/page.tsx`

- 日期篩選 `<input type="month">` → `<input type="date">`，可以選到日。
- 預設範圍改成「當月 1 日 ~ 當月最後一日」（原本是當月 ~ 當月）。
- `p_date_to` 維持排他上界，改送「使用者選的結束日 + 1 天」，所以起訖兩天都完整含在範圍內。
- localStorage / URL 殘留的舊 `"YYYY-MM"` 值展開成該月第一天（from）／最後一天（to），既有使用者的範圍語意不會被截掉。

**DB** `supabase/migrations/20260829000000_orders_pivot_taipei_day_boundaries.sql`

DB session 的 `TimeZone` 是 `UTC`，所以 `p_date_from::timestamptz` 等於台北時間 08:00。月粒度時這個偏移被蓋住，改成日之後天天都會出現：

- 使用者選「8/16 ~ 8/20」，實際撈到的是台北 8/16 08:00 ~ 8/21 08:00。
- 線上 79,677 張訂單有 **10,522 張（13.2%）** 落在台北 00:00~08:00 這一段，不是邊角案例。
- 同樣的偏移也在 `group_key`：`f.created_at::date` 取的是 UTC 日，台北 8/16 凌晨 3 點的單會被標成 8/15 那一列。

修法（與 repo 從 20260426 就在用的 `AT TIME ZONE 'Asia/Taipei'` 慣例一致）：

- `order_date` / `campaign` 的界線改用 `p_date_x::timestamp AT TIME ZONE 'Asia/Taipei'`。
- `order_date` 的 `group_key` 改取台北日。
- `pickup_deadline` 是 `date` 欄位、本來就沒有時區問題，比較式不動；只改它 fallback 到 `created_at` 那一段。

基底：`20260808000000_stats_exclude_transferred_out_items.sql`（已與線上 `pg_get_functiondef` 逐字對過，無 drift）。

## 上線危險

- **做了**：日期篩選的界線與日分組會從 UTC 日改成台北日，同一組篩選條件撈到的訂單集合會變動（變正確）。以 2026-08-16 單日為例，數字會從 855 張變成 1,054 張。既有使用者瀏覽器裡存的 `"YYYY-MM"` 篩選會自動展開成整個月，不會失效。
- **不做**：日期篩選繼續差 8 小時。改成可選到日之後，使用者選單日會漏掉當天凌晨 0~8 點的單、又誤含隔天凌晨的單，數字對不起來且沒有任何提示。
- **回退**：重跑 `supabase/migrations/20260808000000_stats_exclude_transferred_out_items.sql` 即可把 `rpc_orders_pivot` 還原成 UTC 界線版本；前端 revert 本 PR 的 commit。兩者互相獨立（舊前端送月初/次月初的界線，新 RPC 一樣算得對；新前端配舊 RPC 只是回到 8 小時偏移），不必同時回退。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `node scripts/check-sql-syntax.cjs supabase/migrations/20260829000000_orders_pivot_taipei_day_boundaries.sql` → ✓（含 `parsePlpgsql`）
- `npx tsc --noEmit -p apps/admin/tsconfig.json` → 0 錯
- `npm run build`（含 `check-bundle-browser-support`）→ 通過，106 支 chunk 都能被 Safari 15.6 解析
- `npx eslint` 該檔：6 個 error，全部是 `react-hooks/set-state-in-effect` 等既有問題（改動前是 7 個），本 PR 沒有引入新的
- 線上實測（`BEGIN` → 套新函式 → 比對 → `ROLLBACK`），`order_date` 模式取台北日 2026-08-16 單日：

  | | 撈到訂單數 | 誤含 | 漏掉 |
  |---|---|---|---|
  | 線上現況 | 855 | 5 | 204 |
  | 本 PR | **1,054** | **0** | **0** |

  對照組是 `WHERE (created_at AT TIME ZONE 'Asia/Taipei')::date = DATE '2026-08-16'`，共 1,054 張，逐筆相符；`group_key` 也只回一個 `d2026-08-16`。

⚠️ **migration 尚未套上正式庫** —— 用 Management API 部署時被權限攔下了。合併前要跑：

```
POST https://api.supabase.com/v1/projects/{ref}/database/query
{ "query": "<20260829000000 的內容>" }
```

在那之前線上 RPC 還是 UTC 界線版，前端的日選擇器會差 8 小時。

---
_Generated by [Claude Code](https://claude.ai/code/session_012oLz34W6cdwp59PgPgNVNd)_