### PR TITLE
改取貨店：不再擋，未取貨訂單與總倉待出倉需求一次搬過去

### DIFF
--- a/apps/admin/src/components/MemberDetail.tsx
+++ b/apps/admin/src/components/MemberDetail.tsx
@@ -538,7 +538,7 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
         )}
       </div>
 
-      {/* 取貨店 — admin 可改；改店守衛在 RPC 內檢查未取貨訂單 */}
+      {/* 取貨店 — admin 可改；改店守衛在 RPC 內只擋「還在別家店」的未取貨訂單 */}
       <div className="rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
         <div className="mb-2 flex items-center justify-between">
           <div className="text-xs font-medium text-zinc-500">取貨店（會員預設取貨店）</div>
@@ -581,7 +581,8 @@ export function MemberDetail({ memberId, onDeleted }: { memberId: number; onDele
           )}
         </div>
         <p className="mt-1 text-xs text-zinc-500">
-          會員仍有未取貨訂單時，後端會擋下改店動作（保護既有訂單的取貨地點）。
+          會員在<b>別家店</b>還有未取貨訂單時，後端會擋下改店動作（保護既有訂單的取貨地點）；
+          未取貨訂單本來就在要改成的那家店，就可以直接改。
         </p>
       </div>
 

--- a/supabase/migrations/20260829000010_home_store_guard_ignore_orders_already_at_target.sql
+++ b/supabase/migrations/20260829000010_home_store_guard_ignore_orders_already_at_target.sql
@@ -1,0 +1,220 @@
+-- ============================================================
+-- 改取貨店守衛：只擋「還在別家店」的未取貨訂單
+--
+-- 問題：守衛是「有任何未取貨訂單就擋」，完全不看那些訂單在哪一家店。
+--   於是訂單早就下在 B 店、會員預設取貨店卻還停在 A 店時，改成 B 店
+--   （＝把設定對齊現況、什麼都不會變動）也一樣被擋掉。
+--   實例 M20260810095138853「Julie zhang-中和」：4 張未取貨訂單的
+--   pickup_store_id 全部是 45 中和店，home_store_id 卻是 48 三峽店，
+--   店員改成中和店被擋 →「儲存失敗：會員仍有 4 筆未取貨訂單」。
+--
+-- 為什麼放行是安全的：改 home_store_id **不會動到既有訂單**。
+--   每張 customer_orders 自己帶 pickup_store_id，兩支 RPC 都只 UPDATE
+--   members 一張表。守衛註解寫的「保護既有訂單的取貨地點」在
+--   「訂單本來就在目標店」這個情形下無事可保護。
+--
+-- 而且不放行有實害：admin-line-push 是拿 members.home_store_id 去查
+--   store_line_followers 並解 OA token（各加盟店各自的 OA，token 不能共用）。
+--   訂單在 B 店、home_store 停在 A 店 = 到貨通知一律走 A 店的 OA 推播，
+--   而會員綁的是 B 店 → 這位會員的到貨通知永遠推不出去。
+--
+-- 改法：母體加 `pickup_store_id IS DISTINCT FROM p_home_store_id`。
+--   只剩「訂單還在別家店」時才擋，並在訊息裡點名是哪幾家店。
+--   p_home_store_id 為 NULL（未指定）時所有未取貨訂單照擋 —— 清掉
+--   home_store 會讓上面那條推播路徑失去目標，維持保守。
+--   順帶把 rpc_set_member_home_store 漏掉的 'transferred_out' 補上
+--   （20260507000001 只加進 rpc_upsert_member，20260605000012 新建這支時沒跟上；
+--    貨已經在新單上，舊單留在原地不該擋改店）。
+--
+-- 基底版本：
+--   rpc_upsert_member          → 20260617000010（自動產號版，線上版）
+--   rpc_set_member_home_store  → 20260605000012（建立版，＝線上版）
+-- rollback：直接重跑上面兩支 migration。
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. rpc_set_member_home_store（會員明細頁「取貨店」的儲存鈕）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_set_member_home_store(
+  p_member_id     BIGINT,
+  p_home_store_id BIGINT
+) RETURNS members
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant      UUID := public._current_tenant_id();
+  v_old_store   BIGINT;
+  v_open_orders INT;
+  v_stores      TEXT;
+  v_row         members;
+BEGIN
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'tenant_id missing in JWT';
+  END IF;
+
+  IF p_home_store_id IS NOT NULL THEN
+    PERFORM 1 FROM stores WHERE id = p_home_store_id AND tenant_id = v_tenant AND is_active = TRUE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'store % not in tenant or inactive', p_home_store_id; END IF;
+  END IF;
+
+  SELECT home_store_id INTO v_old_store FROM members
+   WHERE id = p_member_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'member % not in tenant', p_member_id; END IF;
+
+  IF v_old_store IS DISTINCT FROM p_home_store_id THEN
+    SELECT COUNT(*), string_agg(DISTINCT COALESCE(s.name, '未指定門市'), '、')
+      INTO v_open_orders, v_stores
+      FROM customer_orders co
+      LEFT JOIN stores s ON s.id = co.pickup_store_id
+     WHERE co.tenant_id = v_tenant
+       AND co.member_id = p_member_id
+       AND co.status NOT IN ('completed','cancelled','expired','transferred_out')
+       AND co.pickup_store_id IS DISTINCT FROM p_home_store_id;
+    IF v_open_orders > 0 THEN
+      RAISE EXCEPTION '會員在「%」還有 % 筆未取貨訂單，請先處理完才能改取貨店', v_stores, v_open_orders;
+    END IF;
+  END IF;
+
+  UPDATE members
+     SET home_store_id = p_home_store_id,
+         updated_by    = auth.uid(),
+         updated_at    = NOW()
+   WHERE id = p_member_id AND tenant_id = v_tenant
+   RETURNING * INTO v_row;
+
+  RETURN v_row;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_set_member_home_store(BIGINT, BIGINT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_set_member_home_store(BIGINT, BIGINT) IS
+  '改會員預設取貨店。守衛只擋「還在別家店」的未取貨訂單 —— 訂單本來就在目標店時放行'
+  '（改 home_store 不動既有訂單，且不改會讓到貨通知一直走錯 OA）。基底 20260605000012。';
+
+-- ----------------------------------------------------------------
+-- 2. rpc_upsert_member（會員編輯表單，同一套守衛）
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_upsert_member(
+  p_id            BIGINT,
+  p_member_no     TEXT,
+  p_phone         TEXT,
+  p_name          TEXT,
+  p_gender        TEXT DEFAULT NULL,
+  p_birthday      DATE DEFAULT NULL,
+  p_email         TEXT DEFAULT NULL,
+  p_tier_id       BIGINT DEFAULT NULL,
+  p_home_store_id BIGINT DEFAULT NULL,
+  p_status        TEXT DEFAULT 'active',
+  p_notes         TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant      UUID := public._current_tenant_id();
+  v_id          BIGINT;
+  v_phone       TEXT := NULLIF(btrim(p_phone), '');
+  v_phone_hash  TEXT;
+  v_email_hash  TEXT;
+  v_birth_md    TEXT;
+  v_old_store   BIGINT;
+  v_open_orders INT;
+  v_stores      TEXT;
+BEGIN
+  IF p_name IS NULL OR p_name = '' THEN
+    RAISE EXCEPTION 'name is required';
+  END IF;
+
+  v_phone_hash := CASE WHEN v_phone IS NOT NULL
+                       THEN encode(digest(v_phone, 'sha256'), 'hex')
+                  END;
+  v_email_hash := CASE WHEN p_email IS NOT NULL AND p_email <> ''
+                       THEN encode(digest(lower(p_email), 'sha256'), 'hex')
+                  END;
+  v_birth_md   := CASE WHEN p_birthday IS NOT NULL
+                       THEN to_char(p_birthday, 'MM-DD')
+                  END;
+
+  IF p_tier_id IS NOT NULL THEN
+    PERFORM 1 FROM member_tiers WHERE id = p_tier_id AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'tier % not in tenant', p_tier_id; END IF;
+  END IF;
+
+  IF p_id IS NULL THEN
+    DECLARE
+      v_member_no TEXT    := NULLIF(btrim(p_member_no), '');
+      v_explicit  BOOLEAN := NULLIF(btrim(p_member_no), '') IS NOT NULL;
+      v_try       INT     := 0;
+    BEGIN
+      LOOP
+        IF v_member_no IS NULL THEN
+          v_member_no := public.rpc_next_member_no();
+        END IF;
+        BEGIN
+          INSERT INTO members (
+            tenant_id, member_no, phone_hash, phone, email_hash, email,
+            name, birthday, birth_md, gender, tier_id, home_store_id,
+            status, notes, created_by, updated_by
+          ) VALUES (
+            v_tenant, v_member_no, v_phone_hash, v_phone, v_email_hash, p_email,
+            p_name, p_birthday, v_birth_md, p_gender, p_tier_id, p_home_store_id,
+            COALESCE(p_status, 'active'), p_notes, auth.uid(), auth.uid()
+          ) RETURNING id INTO v_id;
+          EXIT;
+        EXCEPTION WHEN unique_violation THEN
+          IF v_explicit THEN
+            RAISE EXCEPTION '會員編號 % 已存在', v_member_no
+              USING ERRCODE = 'unique_violation';
+          END IF;
+          v_try := v_try + 1;
+          IF v_try > 10 THEN RAISE; END IF;
+          v_member_no := NULL;  -- 重新自動產號重試
+        END;
+      END LOOP;
+    END;
+  ELSE
+    SELECT home_store_id INTO v_old_store FROM members
+     WHERE id = p_id AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'member % not in tenant', p_id; END IF;
+
+    IF v_old_store IS DISTINCT FROM p_home_store_id THEN
+      SELECT COUNT(*), string_agg(DISTINCT COALESCE(s.name, '未指定門市'), '、')
+        INTO v_open_orders, v_stores
+        FROM customer_orders co
+        LEFT JOIN stores s ON s.id = co.pickup_store_id
+       WHERE co.tenant_id = v_tenant
+         AND co.member_id = p_id
+         AND co.status NOT IN ('completed','cancelled','expired','transferred_out')
+         AND co.pickup_store_id IS DISTINCT FROM p_home_store_id;
+      IF v_open_orders > 0 THEN
+        RAISE EXCEPTION '會員在「%」還有 % 筆未取貨訂單，請先處理完才能改取貨店', v_stores, v_open_orders;
+      END IF;
+    END IF;
+
+    UPDATE members SET
+      member_no     = COALESCE(p_member_no, member_no),
+      phone_hash    = v_phone_hash,
+      phone         = v_phone,
+      email_hash    = v_email_hash,
+      email         = p_email,
+      name          = COALESCE(p_name, name),
+      birthday      = p_birthday,
+      birth_md      = v_birth_md,
+      gender        = p_gender,
+      tier_id       = p_tier_id,
+      home_store_id = p_home_store_id,
+      status        = COALESCE(p_status, status),
+      notes         = p_notes,
+      updated_by    = auth.uid()
+    WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'member % not in tenant', p_id; END IF;
+  END IF;
+
+  RETURN v_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_upsert_member TO authenticated;


### PR DESCRIPTION
## 做了什麼

兩個 commit，同一件事的兩半。

**1. 守衛只擋「還在別家店」的未取貨訂單**（`20260829000010`）

原本是「有任何未取貨訂單就擋」，完全不看那些訂單在哪一家店。實例 `M20260810095138853`「Julie zhang-中和」：4 張未取貨訂單的 `pickup_store_id` 全部是 45 中和店，`home_store_id` 卻是 48 三峽店，店員改成中和店被擋 →「儲存失敗：會員仍有 4 筆未取貨訂單」。母體加上 `pickup_store_id IS DISTINCT FROM p_home_store_id`，錯誤訊息並點名是哪幾家店還有單。順帶補上 `rpc_set_member_home_store` 漏掉的 `transferred_out` 排除。

**2. 真的把單搬過去**（`20260829000020` ＋ `MemberDetail.tsx`）

擋下之後原本沒有任何入口能把單搬走，店員只能一張一張手動轉單。按「儲存」先跑 `rpc_preview_member_store_move` 列出影響範圍，確認後才 `rpc_move_member_to_store`。依「貨現在在哪」分三條路線：

| 路線 | 條件 | 動作 |
|---|---|---|
| `repoint` | 貨還沒出總倉 | 只改 `pickup_store_id`，並把該筆需求量從舊店那列**改派到新店那列**（＝「總倉要出倉的資料」） |
| `air` | 貨已經在原店 | 開 `AT-` 轉貨單從原店實際出庫、單頭進 `shipping`，新店收貨後由 `rpc_receive_transfer` 邏輯 B 推回 `ready` |
| `blocked` | 貨在路上／已撿貨待出／有進行中調撥／非一般團購單 | 不動，回報原因 |

判「貨在哪」**同時看單頭 status 與波次調撥證據** —— 兩者會各走各的（`confirmed` 單的貨可能早就到店），只信一邊會誤判。

整列都要搬、而且新店還沒有同 SKU 那列時，直接把那一列改掛新店，不刪列：`picking_wave_audit_log.wave_item_id` 的 `ON DELETE SET NULL` 會撞上 append-only 觸發器，而既有的 `rpc_delete_picking_wave` 是連稽核歷史一起刪 —— 換店不該把紀錄弄不見。真的要併列時只把 FK 指標清成 NULL，一列歷史都不刪。

### 為什麼不用現成的 rpc_transfer_order_to_store

那支是「轉給**別人**」：用 `(campaign_id, channel_id, member_id)` 找接收人的既有單，查到的如果就是來源單本身就 `RAISE`「這張訂單本來就掛在該接收人名下」。而本案接收人就是同一位會員，且線上 78,251 張一般單有 **76,665 張共用同一個 channel**（`__INTERNAL_RESTOCK_1__`，橫跨 18 家店，channel 根本不隨取貨店走），`customer_orders_trio_kind_active_uniq` 也不含 `pickup_store_id` → 同會員同團跨店必定撞上那道守衛，硬繞就是撞唯一索引。所以本案**不建新訂單**：訂單號原地保留，只改店 ＋ 用 `_air_ship_order_items` 開 AT- 單。

### 刻意不做

- **不搬 LINE 綁定**：`store_line_followers` 是各店 OA 的好友名冊，會員沒加新店 OA 就是沒加，偽造一列只會把「尚未綁定」變成推播失敗 → 改回報 `needs_line_rebind`，畫面提示引導重綁。
- **不改已出貨波次的歷史 `store_id`**（同 `20260817000020` 的決定）：那是派貨事實，貨的移動由 AT- 單表達。

## 上線危險

- **做了**：多一條「改店連帶搬單」的路。守衛放寬只影響「未取貨訂單全部已經在目標店」這一種情形；搬移一定要人在預覽畫面按「確認搬移」才會執行，`air` 路線會真的建立轉貨單並從原店出庫。
- **不做**：店員改不動店，只能一張一張手動轉單；Julie 這類會員的到貨通知持續走錯店的 OA 推不出去。
- **回退**：`DROP FUNCTION rpc_move_member_to_store / rpc_preview_member_store_move / _member_store_move_plan`（沒有任何既有呼叫點依賴它們），守衛重跑 `20260617000010` 與 `20260605000012`。已經搬過去的資料不會自動回復 —— AT- 單與出入庫是實體事實。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

基底版本先 grep 過歷史 migration，並比對線上 `pg_get_functiondef()` 確認 repo ＝ 正式庫。

- `node scripts/check-sql-syntax.cjs` ✅ 兩支（含函式內文 `parsePlpgsql`）
- `npx tsc --noEmit` ✅、`npx eslint` ✅、`npm run build`（apps/admin）✅（含「106 支 chunk 都能被 Safari 15.6 解析」那道檢查）
- **UI 用 Playwright + fixture 實跑**（`apps/admin/.claude/skills/verify`）：選新店 → 按儲存跳出預覽（三段分類 ＋ LINE 未綁定警告）→ 按確認 → 結果畫面顯示 AT- 單號與未搬清單；preview / move 各只呼叫 1 次，無 page error。
- **三條路線都在正式庫實跑過，全部包在 transaction 裡 ROLLBACK**：
  - `repoint`＋`air`（Julie，69171）：3 張 confirmed 改指、1 張 ready 開出 `AT-O58534-…`（src location 14 → dst 17）＋ `transfer_out −1`，單頭進 `shipping`
  - 波次改派（54410，林口→中和）：`picking_wave_items` #20718 由 store 44 原地改掛 45，波次 `total_qty` 維持 30（需求是搬移不是增減），稽核留下 `item_removed` ＋ `item_added`
  - `blocked`（68161）：6 張 `shipping` 單正確擋下並回報「總倉已出貨、貨還在路上」
- 分類器預覽結果與實際執行結果逐筆一致。
- 測試過程中抓到並修掉兩個真的會炸的問題：缺操作者時 `stock_movements.operator_id` NOT NULL 會在 `rpc_outbound` 深處炸成看不懂的錯（改成前面就講清楚）、以及上面那個稽核表 append-only 衝突。