### PR TITLE
店家自開團：常態團「再開一團」，店長自己操作得到自己的團

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -212,6 +212,7 @@ export default function CampaignsListPage() {
   const [fbPublishId, setFbPublishId] = useState<number | null>(null);
   const [bulkFbOpen, setBulkFbOpen] = useState(false);
   const [closingId, setClosingId] = useState<number | null>(null);
+  const [cloningId, setCloningId] = useState<number | null>(null);
   const [finalizingId, setFinalizingId] = useState<number | null>(null);
 
   // 多選 + 批次操作
@@ -410,8 +411,12 @@ export default function CampaignsListPage() {
     });
   }
 
-  async function closeCampaign(id: number, name: string) {
-    if (!confirm(`確定結單「${name}」？結單後可從${PR_TERM_ZH}頁面「帶入該日商品」產生 PR。`)) return;
+  async function closeCampaign(id: number, name: string, isStore = false) {
+    // 自開團不經總倉，講 PR 只會讓店長困惑
+    const msg = isStore
+      ? `確定關團（結單）「${name}」？訂單會立刻變成「已確認」，這團會出現在「收貨」等你收貨。`
+      : `確定結單「${name}」？結單後可從${PR_TERM_ZH}頁面「帶入該日商品」產生 PR。`;
+    if (!confirm(msg)) return;
     setClosingId(id);
     try {
       const { error: rpcErr } = await getSupabase().rpc("rpc_close_campaign", {
@@ -424,6 +429,40 @@ export default function CampaignsListPage() {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setClosingId(null);
+    }
+  }
+
+  /** 常態團的下一輪：一律複製成**新的一團**，不會有「把已結單的團退回開團中」
+   *  這個選項 —— 同一團跑兩輪的話，上一輪收的貨會被算成這一輪的供給
+   *  （收貨頁與取貨閘門的帳都會歪），訂單也會兩輪混在一起分不開。 */
+  async function cloneStoreCampaign(id: number, name: string) {
+    const end = prompt(
+      `再開一團「${name}」：新的結單時間（YYYY-MM-DD HH:mm，可留空）`,
+      "",
+    );
+    if (end === null) return;
+    let endAt: string | null = null;
+    if (end.trim()) {
+      const d = new Date(end.trim().replace(" ", "T"));
+      if (Number.isNaN(d.getTime())) { setError("結單時間格式看不懂，請用 YYYY-MM-DD HH:mm"); return; }
+      endAt = d.toISOString();
+    }
+    setCloningId(id);
+    try {
+      const { data, error: rpcErr } = await getSupabase().rpc("rpc_clone_store_campaign", {
+        p_campaign_id: id,
+        p_name: null,
+        p_end_at: endAt,
+        p_pickup_deadline: null,
+        p_status: "open",
+      });
+      if (rpcErr) throw new Error(translateRpcError(rpcErr.message));
+      setReloadTick((t) => t + 1);
+      if (data) openEdit(Number(data));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setCloningId(null);
     }
   }
 
@@ -767,9 +806,16 @@ export default function CampaignsListPage() {
     ) : null;
 
   // 操作鈕（編輯 / 結單 / 發 FB / 結算 / 刪除）— 桌機表格與手機卡片共用，單一維護點
-  const campaignActions = (r: Row) => (
+  //
+  // 店家自開團是店長自己的團：編輯 / 開關團 / 再開一團都要讓他自己按，
+  // 不能跟總倉團一樣鎖在 isAdmin 後面（否則店長開得了團卻結不了單）。
+  // 真正的權限在 DB：那幾支 RPC 都過 _assert_own_store，分店只能動自己店的。
+  const campaignActions = (r: Row) => {
+    const isStore = r.owner_store_id != null;
+    const canAct = showAdminActions || isStore;
+    return (
     <>
-      {showAdminActions && (
+      {canAct && (
         <SpinButton
           onClick={() => openEdit(r.id)}
           className="text-xs text-blue-600 hover:underline dark:text-blue-400"
@@ -777,13 +823,23 @@ export default function CampaignsListPage() {
           編輯
         </SpinButton>
       )}
-      {showAdminActions && r.status === "open" && (
+      {canAct && r.status === "open" && (
         <SpinButton
-          onClick={() => closeCampaign(r.id, r.name)}
+          onClick={() => closeCampaign(r.id, r.name, isStore)}
           disabled={closingId === r.id}
           className="text-xs text-amber-600 hover:underline disabled:opacity-50 dark:text-amber-400"
         >
-          {closingId === r.id ? "結單中…" : "結單"}
+          {closingId === r.id ? "結單中…" : isStore ? "關團結單" : "結單"}
+        </SpinButton>
+      )}
+      {/* 常態團（豆漿那種）的下一輪：複製成新的一團 */}
+      {isStore && (
+        <SpinButton
+          onClick={() => cloneStoreCampaign(r.id, r.name)}
+          disabled={cloningId === r.id}
+          className="text-xs text-indigo-600 hover:underline disabled:opacity-50 dark:text-indigo-400"
+        >
+          {cloningId === r.id ? "複製中…" : "再開一團"}
         </SpinButton>
       )}
       {showAdminActions && (["open", "closed", "locked", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
@@ -812,7 +868,8 @@ export default function CampaignsListPage() {
         </SpinButton>
       )}
     </>
-  );
+    );
+  };
 
   // 開團視窗要選門市；分店帳號只留自己那幾家
   useEffect(() => {

--- a/supabase/migrations/20260831000070_store_campaign_clone.sql
+++ b/supabase/migrations/20260831000070_store_campaign_clone.sql
@@ -1,0 +1,120 @@
+-- ============================================================================
+-- 店家自開團：常態團「再開一團」
+-- ============================================================================
+-- 需求（Alex 2026-08-31）：
+--   「我有常態要開團的，可能是豆漿，關團就結單，但我過陣子可以再開。」
+--   「再開不要用同一個團，要再開新的團，因為訂單有可能會錯亂。」
+--
+-- 所以只有一個動作：rpc_clone_store_campaign —— 把一個自開團複製成**新的一團**
+--   （新團號），帶團名 / 收單類型 / 上限 / 封面 / 說明 / 全部品項與售價，
+--   不帶訂單、收貨、以及上一輪的履約狀態。舊團原封不動。
+--   店長開下一輪豆漿團不用重打任何東西。
+--
+-- 為什麼一定要新的一團，不是把同一團反覆開關（老闆的直覺是對的，而且技術上
+-- 也非做不可）：自開團的每一筆帳都掛在 campaign id 上 ——
+--   * _store_campaign_demand 的「已收」＝掛在該團的入庫異動總和
+--   * _pickup_group_supplied 的供給側也是同一份
+-- 同一團開第二輪的話，第一輪收的貨會被算成第二輪的供給：
+-- 需求 5、已收 10（第一輪的）→ 未收 0 → **第二輪永遠不會出現在收貨頁**，
+-- 而取貨閘門那邊卻覺得供給充足。訂單也會兩輪混在同一個團底下分不開。
+-- 一團一輪，帳才切得乾淨；日結的「店家自開團結算」也才分得出哪一輪賺多少。
+--
+-- ⚠ 因此本檔**刻意不提供**「把已結單的團退回開團中」的函式。
+--   先前草稿有一支 rpc_reopen_store_campaign，依老闆指示拿掉，
+--   並在本檔一併 DROP（它今天曾被套上正式庫，沒有任何呼叫端）。
+--
+-- Rollback：DROP FUNCTION public.rpc_clone_store_campaign(BIGINT, TEXT, TIMESTAMPTZ, DATE, TEXT);
+-- ============================================================================
+
+-- 先前草稿的產物，沒有呼叫端；一團一輪的原則不允許它存在
+DROP FUNCTION IF EXISTS public.rpc_reopen_store_campaign(BIGINT, UUID);
+
+-- ----------------------------------------------------------------------------
+-- rpc_clone_store_campaign — 再開一團（常態團的唯一做法）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_clone_store_campaign(
+  p_campaign_id     BIGINT,
+  p_name            TEXT        DEFAULT NULL,
+  p_end_at          TIMESTAMPTZ DEFAULT NULL,
+  p_pickup_deadline DATE        DEFAULT NULL,
+  p_status          TEXT        DEFAULT 'open'
+) RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_src    group_buy_campaigns%ROWTYPE;
+  v_id     BIGINT;
+  v_no     TEXT;
+  v_items  INT;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','assistant','store_manager','store_staff','') THEN
+    RAISE EXCEPTION 'insufficient_role: % 不能開團', v_role;
+  END IF;
+
+  IF p_status NOT IN ('draft','open') THEN
+    RAISE EXCEPTION 'p_status must be draft or open, got %', p_status;
+  END IF;
+
+  SELECT * INTO v_src FROM group_buy_campaigns
+   WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id;
+  END IF;
+  IF v_src.owner_store_id IS NULL THEN
+    RAISE EXCEPTION 'campaign % 不是店家自開團，請用總倉的開團流程', p_campaign_id;
+  END IF;
+  PERFORM public._assert_own_store(v_src.owner_store_id);
+
+  IF v_src.close_type = 'fast' AND p_end_at IS NULL THEN
+    RAISE EXCEPTION 'fast campaign requires end_at';
+  END IF;
+
+  v_no := public.rpc_next_campaign_no();
+
+  INSERT INTO group_buy_campaigns (
+    tenant_id, campaign_no, name, description, cover_image_url,
+    status, close_type, start_at, end_at, pickup_deadline, pickup_days,
+    total_cap_qty, is_for_shop, sales_channel, owner_store_id,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_no, COALESCE(NULLIF(btrim(p_name), ''), v_src.name),
+    v_src.description, v_src.cover_image_url,
+    p_status, v_src.close_type, NOW(),
+    p_end_at, p_pickup_deadline, v_src.pickup_days,
+    v_src.total_cap_qty, v_src.is_for_shop, 'main', v_src.owner_store_id,
+    auth.uid(), auth.uid()
+  ) RETURNING id INTO v_id;
+
+  -- 品項：只複製「賣什麼、賣多少錢」。刻意不帶 locked_at / stockout_at /
+  -- stockout_po_id —— 那些是上一輪的履約狀態，新的一輪從乾淨的開始。
+  INSERT INTO campaign_items (
+    tenant_id, campaign_id, sku_id, unit_price, cap_qty, sort_order,
+    notes, is_gift, gift_reason, created_by, updated_by
+  )
+  SELECT v_tenant, v_id, ci.sku_id, ci.unit_price, ci.cap_qty, ci.sort_order,
+         ci.notes, ci.is_gift, ci.gift_reason, auth.uid(), auth.uid()
+    FROM campaign_items ci
+   WHERE ci.campaign_id = p_campaign_id
+     AND ci.tenant_id   = v_tenant
+     AND ci.stockout_at IS NULL;   -- 上一輪斷貨的品項不要再帶進來
+
+  GET DIAGNOSTICS v_items = ROW_COUNT;
+  IF v_items = 0 THEN
+    RAISE EXCEPTION '來源團沒有可複製的品項';
+  END IF;
+
+  RETURN v_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_clone_store_campaign(BIGINT, TEXT, TIMESTAMPTZ, DATE, TEXT) IS
+  '把一個店家自開團複製成新的一團（常態團的下一輪）：帶團名 / 收單類型 / 上限 / '
+  '封面 / 說明 / 品項與售價，不帶訂單、收貨與上一輪的履約狀態。'
+  '一團一輪，帳才切得乾淨（見檔頭）。';
+
+REVOKE ALL ON FUNCTION public.rpc_clone_store_campaign(BIGINT, TEXT, TIMESTAMPTZ, DATE, TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_clone_store_campaign(BIGINT, TEXT, TIMESTAMPTZ, DATE, TEXT) TO authenticated;


### PR DESCRIPTION
## 做了什麼

老闆需求：

> 「這樣我就可以一直重覆開團不用再輸入很多東西」
> 「再開不要用同一個團，要再開新的團，因為訂單有可能會錯亂」
> 「店長自己的團要可以她自己操作」

### 一、再開一團（`rpc_clone_store_campaign`）

常態團（豆漿那種）的下一輪：把一個自開團複製成**新的一團**（新團號），帶團名 / 收單類型 / 上限 / 封面 / 說明 / 全部品項與售價，**不帶**訂單、收貨、以及上一輪的履約狀態（`locked_at` / `stockout_at` 都不複製，上一輪斷貨的品項也不帶）。舊團原封不動。店長開下一輪不用重打任何東西。

列表上每個自開團都多一顆「**再開一團**」，按下去問新的結單時間，建好直接跳編輯視窗讓她微調。

### 二、刻意不做「把已結單的團退回開團中」

老闆的直覺跟技術上的限制剛好一致，這裡寫清楚免得日後有人「順手加回去」：

自開團的每一筆帳都掛在 campaign id 上——

- `_store_campaign_demand` 的「已收」＝掛在該團的入庫異動總和
- `_pickup_group_supplied` 的供給側也是同一份

同一團跑第二輪的話，第一輪收的貨會被算成第二輪的供給：需求 5、已收 10（第一輪的）→ 未收 0 → **第二輪永遠不會出現在收貨頁**，而取貨閘門那邊卻覺得供給充足。訂單也會兩輪混在同一個團底下分不開，日結的「店家自開團結算」更分不出哪一輪賺多少。

**一團一輪，帳才切得乾淨。** 草稿階段曾有一支 `rpc_reopen_store_campaign` 並套過正式庫（沒有任何呼叫端），本 PR 的 migration 一併 `DROP`。

⚠️ 連帶取捨：誤按「關團結單」目前**沒有復原**。要繼續收單就按「再開一團」開一張新的；那張誤關的團會留在收貨頁上。如果實際用起來會卡，我再加一個「作廢」給自開團（同樣不重用團 id），跟我說。

### 三、店長操作得到自己的團

「編輯」「結單」兩顆鈕原本都鎖在 `isAdmin` 後面——也就是說**店長開得了自己的團，卻結不了單**，而整個功能就是給店長用的。自開團的那幾列改成店長自己按得到；真正的權限守在 DB（`rpc_clone_store_campaign` / `rpc_store_create_campaign` 都過 `_assert_own_store`，分店只能動自己店的）。**總倉團的鎖一字未動。**

結單確認文案也依團別分開：自開團不提請購單，改講「訂單會立刻變成『已確認』，這團會出現在『收貨』」。

## 上線危險

- **做了**：migration **已套上正式庫**（新增 `rpc_clone_store_campaign`、DROP 草稿的 `rpc_reopen_store_campaign`）。合併後 repo 與線上一致。
- **不做**：店長每次開常態團都要重打商品與售價；而且她結不了自己的團（要找管理員代按），功能等於半殘。
- **回退**：`DROP FUNCTION public.rpc_clone_store_campaign(BIGINT, TEXT, TIMESTAMPTZ, DATE, TEXT);`，前端 revert 即可。被 DROP 的 `rpc_reopen_store_campaign` 不需要救回來——它沒有任何呼叫端，且一團一輪的原則不允許它存在。
- **權限面的實質改動**：自開團的「編輯 / 結單 / 再開一團」對 `store_manager` / `store_staff` 開放。這是刻意的（見第三段），且每一支對應的 RPC 都有 `_assert_own_store`；跨店操作實測被 `wrong_store` 擋下。總倉團對分店角色仍然一顆按鈕都沒有。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

沒有動 RLS、環境變數或任何部署設定。前端按鈕的顯示條件放寬屬於 UI 層，實際授權由既有的 `_assert_own_store` 守在 DB（上一段已說明並實測）。

## 驗證

`scripts/check-sql-syntax.cjs`（含 `parsePlpgsql`）通過。`apps/admin` `tsc --noEmit` 0 error、`npm run build` 過（含 iPhone 7 bundle 相容性檢查）。ESLint 對 `campaigns/page.tsx` 是既有的 5 個錯誤，與 HEAD 版逐一比對過，沒有新增。

線上實測，全程包在交易裡最後 `ROLLBACK`，**以 `store_manager` / 松山店 身分跑**：

| 檢查 | 結果 |
|---|---|
| 第一輪：開團 → 關團 → 收貨 → 訂單 | **`ready`** |
| `rpc_reopen_store_campaign` 是否還在 | **0**（已移除） |
| 再開一團 → 新團狀態 | **`open`** |
| 新舊團號 | `GRP-20260831-017` vs `GRP-20260831-016`（不同） |
| 團名沿用 | **常態豆漿團** |
| 品項與售價 | **1 項 / $60**（照抄） |
| 新團訂單數 | **0** |
| 新團已收量 | **0**（不沾上一輪） |
| 舊團 | **`ready` / 訂單 `ready`**（不受影響） |
| 兩輪供給分得開 | **3 vs 0** |
| 平鎮店店長複製松山的團 | **被 `wrong_store` 擋下** |

畫面驗證（Playwright + fixture，`store_manager` 身分）：自開團列出現「編輯 / 關團結單 / 再開一團」，總倉團零按鈕，側欄總倉頁面也照常隱藏。

## 相關

- #876 店家自開團（已合併）
- #877 補第四個結單入口 + 跟總倉完全脫鉤（待合併；與本 PR 互不相依，兩支都以 main 為 base）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019t17YjcZJQNM4pZWYRaHeT

---
_Generated by [Claude Code](https://claude.ai/code/session_019t17YjcZJQNM4pZWYRaHeT)_