### PR TITLE
互助板：加搜尋框與分店篩選（列印頁一併，兩頁共用同一份條件）

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/page.tsx
@@ -18,6 +18,9 @@ import {
   TRANSFER_LINK_SELECT, type TransferLink,
   activeQty, aidRouteLabel, aidStageLabel, isAidDead, isAidInFlight, linkItems,
 } from "@/lib/aidTransfer";
+import {
+  AID_SEARCH_SKU_LIMIT, aidBoardFilterParams, applyAidBoardFilters, safeAidKeyword,
+} from "@/lib/aidBoardFilter";
 import { orderStatusLabel } from "@/lib/orderStatus";
 
 type Store = { id: number; code: string; name: string };
@@ -156,6 +159,10 @@ const TYPE_COLOR: Record<PostType, string> = {
   request: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
 };
 
+/** 搜尋框停手多久才真的去查。放在模組層而不是元件裡：它是固定值，
+ *  擺進元件會變成 useEffect 相依陣列要不要收它的無謂爭議。 */
+const KEYWORD_DEBOUNCE_MS = 300;
+
 export default function MutualAidPage() {
   const [posts, setPosts] = useState<Post[] | null>(null);
   const [stores, setStores] = useState<Store[]>([]);
@@ -167,6 +174,19 @@ export default function MutualAidPage() {
   const myStoreId = useUserBranchStoreId(stores);
   const isHq = myStoreId == null;
   const [filter, setFilter] = useState<"all" | "request" | "offer">("all");
+  // 搜尋框：keywordInput 是使用者當下打的字，keyword 是 debounce 過後真正送去查的。
+  // 分成兩個 state 才不會每按一個鍵就打一次資料庫。
+  const [keywordInput, setKeywordInput] = useState("");
+  const [keyword, setKeyword] = useState("");
+  // 分店篩選（offering_store_id）。
+  // ⛔ 這裡故意**不用** lib/useDefaultStoreFromUser 的 useDefaultStoreFromUser ——
+  //    那支的用途是「把分店篩選下拉預設選中自己的店」，放在這一頁會直接把功能關掉：
+  //    互助交流板存在的意義就是看**別家店**貼了什麼，預設只剩自己店等於一片空白。
+  //    分店帳號登入時一樣停在「全部門市」，跟改動前的行為一致。
+  const [storeFilter, setStoreFilter] = useState<number | "all">("all");
+  // 關鍵字命中的商品超過上限、清單被截掉了 → 結果可能不完整。
+  // 這種事一定要講出來：搜尋結果少了幾筆，畫面上跟「本來就沒有」長得一模一樣。
+  const [skuTruncated, setSkuTruncated] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reloadTick, setReloadTick] = useState(0);
   const [requestModalOpen, setRequestModalOpen] = useState(false);
@@ -200,6 +220,21 @@ export default function MutualAidPage() {
     return () => { cancelled = true; };
   }, []);
 
+  // 搜尋框 debounce：打完字停 300ms 才真的去查，不然每個鍵都是一發查詢。
+  // 早退的那一行不能省 —— 沒有它，掛載當下（兩邊都是空字串）也會排一次 timer，
+  // 白白多打一發查詢並把清單閃成 loading。
+  useEffect(() => {
+    if (keywordInput === keyword) return;
+    const t = setTimeout(() => {
+      setKeyword(keywordInput);
+      // 換了關鍵字＝換了一份母體，歷史要收回第一頁（照分頁鈕 / 類型鈕的既有做法）。
+      // setState 寫在 timeout 裡不是 render 期間的同步 setState，不會踩 cascading render。
+      setHistoryLimit(HISTORY_PAGE);
+      setPosts(null);
+    }, KEYWORD_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [keywordInput, keyword]);
+
   // 載入 posts（「我提供出去的」是另一份資料來源，由 ProvidedList 自己撈）
   useEffect(() => {
     if (view === "provided" || view === "received" || view === "same_store") return;
@@ -217,7 +252,16 @@ export default function MutualAidPage() {
         q = q.order("created_at", { ascending: false })
              .limit(view === "history" ? historyLimit : 200);
         if (filter !== "all") q = q.eq("post_type", filter);
-        const { data, error: e } = await q;
+        // 搜尋關鍵字與分店一律**送後端**篩，不在前端 filter：歷史一次只讀
+        // historyLimit（20）筆，在已載入的那 20 筆裡篩會讓有 500 筆歷史的店
+        // 看起來一筆都沒有。列印頁走同一支，兩邊才不會篩出不一樣的東西。
+        const filtered = await applyAidBoardFilters(sb, q, {
+          storeId: storeFilter === "all" ? null : storeFilter,
+          keyword,
+        });
+        if (cancelled) return;
+        setSkuTruncated(filtered.skuTruncated);
+        const { data, error: e } = await filtered.q;
         if (e) throw new Error(e.message);
         const rows = ((data as Post[] | null) ?? []);
         if (!cancelled && view === "history") setHistoryFetched(rows.length);
@@ -269,7 +313,16 @@ export default function MutualAidPage() {
       }
     })();
     return () => { cancelled = true; };
-  }, [view, filter, reloadTick, historyLimit]);
+  }, [view, filter, reloadTick, historyLimit, keyword, storeFilter]);
+
+  // 搜尋框的轉圈圈要涵蓋「還在等 debounce」＋「查詢在路上」兩段。
+  // 只涵蓋其中一段的話，圈圈會先停下來、清單卻還是舊的那一份，看起來像沒反應。
+  const searching = keywordInput !== keyword || posts === null;
+
+  // 畫面上講「有在篩什麼」時，一律講**實際送出去的**那一份，不要講使用者原本打的字。
+  // 只打了 `%%%` 或 `()` 的話清洗完是空字串、後端根本沒加條件，照原字顯示就會變成
+  // 畫面說「有篩選」但其實沒篩 —— 畫面自己騙人。
+  const effectiveKeyword = safeAidKeyword(keyword);
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
@@ -286,8 +339,13 @@ export default function MutualAidPage() {
           {view !== "provided" && view !== "received" && view !== "same_store" && (
             <SpinButton
               type="button"
-              onClick={() => printViaIframe(withBasePath(`/inventory/mutual-aid/print?type=${filter}&view=${view}`))}
-              title="列印目前這個分頁的整份貼文清單（A4 橫式）；單獨一則請按該列右邊的 🖨️"
+              // 搜尋 / 分店也要一起帶過去。少帶一個，畫面上篩到剩 3 筆、
+              // 印出來卻是全部 —— 紙拿在手上看不出來被騙了，比沒有篩選更糟。
+              onClick={() => printViaIframe(withBasePath(
+                `/inventory/mutual-aid/print?type=${filter}&view=${view}`
+                + aidBoardFilterParams({ storeId: storeFilter === "all" ? null : storeFilter, keyword }),
+              ))}
+              title="列印目前這個分頁的整份貼文清單（A4 橫式，含目前的搜尋與分店篩選）；單獨一則請按該列右邊的 🖨️"
               className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
             >
               🖨️ 列印
@@ -352,22 +410,63 @@ export default function MutualAidPage() {
         />
       ) : (
       <>
-      <div className="inline-flex w-fit overflow-hidden rounded-md border border-zinc-300 text-xs dark:border-zinc-700">
-        {(["all", "request", "offer"] as const).map((opt) => (
-          <SpinButton
-            key={opt}
-            type="button"
-            onClick={() => { setFilter(opt); setHistoryLimit(HISTORY_PAGE); setPosts(null); }}
-            className={`px-3 py-1.5 ${
-              filter === opt
-                ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
-                : "bg-white text-zinc-600 hover:bg-zinc-50 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
-            }`}
-          >
-            {opt === "all" ? "全部" : opt === "request" ? "需求中" : "釋出中"}
-          </SpinButton>
-        ))}
+      {/* 三個篩選可以疊加：類型（下面這排鈕）× 關鍵字 × 分店，全部一起送後端 */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="inline-flex w-fit overflow-hidden rounded-md border border-zinc-300 text-xs dark:border-zinc-700">
+          {(["all", "request", "offer"] as const).map((opt) => (
+            <SpinButton
+              key={opt}
+              type="button"
+              onClick={() => { setFilter(opt); setHistoryLimit(HISTORY_PAGE); setPosts(null); }}
+              className={`px-3 py-1.5 ${
+                filter === opt
+                  ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                  : "bg-white text-zinc-600 hover:bg-zinc-50 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+              }`}
+            >
+              {opt === "all" ? "全部" : opt === "request" ? "需求中" : "釋出中"}
+            </SpinButton>
+          ))}
+        </div>
+
+        {/* 打字搜尋：比對 商品名 / 商品編號 / 手打現貨的標題 / 備註。
+            怎麼比對、為什麼要兩段式，全部在 lib/aidBoardFilter 裡（列印頁共用同一支）。 */}
+        <div className="relative">
+          <input
+            value={keywordInput}
+            onChange={(e) => setKeywordInput(e.target.value)}
+            placeholder="搜尋商品 / 編號 / 備註"
+            aria-label="搜尋貼文"
+            className="w-52 rounded-md border border-zinc-300 bg-white px-2 py-1.5 pr-7 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          <SearchSpinner active={searching} className="right-1" />
+        </div>
+
+        {/* 分店：用畫面上已經載好的 stores（:193-201），⛔ 不要為了這個下拉另外發查詢 */}
+        <select
+          value={storeFilter}
+          onChange={(e) => {
+            setStoreFilter(e.target.value === "all" ? "all" : Number(e.target.value));
+            setHistoryLimit(HISTORY_PAGE);
+            setPosts(null);
+          }}
+          aria-label="依分店篩選"
+          className="rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+        >
+          <option value="all">全部門市</option>
+          {stores.map((s) => (
+            <option key={s.id} value={s.id}>{s.name}</option>
+          ))}
+        </select>
       </div>
+
+      {/* 命中的商品破 500 上限被截掉時一定要講。少了幾筆的搜尋結果，
+          畫面上跟「本來就沒有這筆」長得一模一樣 —— 不講就是在騙人。 */}
+      {skuTruncated && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
+          符合「{effectiveKeyword}」的商品超過 {AID_SEARCH_SKU_LIMIT} 項，結果可能不完整。請打得更完整一點（例如加上口味或規格）。
+        </div>
+      )}
 
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
@@ -381,6 +480,18 @@ export default function MutualAidPage() {
         <div className="rounded-md border border-dashed border-zinc-300 p-8 text-center text-sm text-zinc-500 dark:border-zinc-700">
           {view === "active" ? "目前沒有進行中的" : "沒有已結束的"}
           {filter === "request" ? "需求" : filter === "offer" ? "釋出" : ""}貼文
+          {/* 有篩選卻是空的，一定要講「是篩掉了」——不然跟「板上真的沒東西」
+              長得一模一樣，人會直接下錯結論走人 */}
+          {(effectiveKeyword !== "" || storeFilter !== "all") && (
+            <div className="mt-1 text-xs">
+              （目前有篩選：
+              {effectiveKeyword !== "" && `關鍵字「${effectiveKeyword}」`}
+              {effectiveKeyword !== "" && storeFilter !== "all" && "、"}
+              {storeFilter !== "all" &&
+                `分店「${stores.find((s) => s.id === storeFilter)?.name ?? `#${storeFilter}`}」`}
+              ）
+            </div>
+          )}
         </div>
       ) : (
         <Table>

--- a/apps/admin/src/app/(protected)/inventory/mutual-aid/print/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/mutual-aid/print/page.tsx
@@ -7,9 +7,15 @@
 //                              （created_at desc、limit 200）。
 //   &view=active|history     → 搭配清單模式：active（預設）= status=active，
 //                              history = status<>active（已認領／已過期／已取消）。
+//   &store=<store_id>&kw=…   → 搭配清單模式：列表頁上的分店篩選與打字搜尋。
+//                              ⚠ 這兩個**一定要跟列表頁吃同一份條件**（兩邊都走
+//                              lib/aidBoardFilter），否則會出現「畫面上剩 3 筆、
+//                              印出來是全部」——紙已經拿在手上，看不出來被騙了。
 //   ?id=<board_id>           → 單則模式（A4 直式單張）。板上每一則貼文自己的列印鈕，
 //                              **不濾 status** —— 已認領 / 已過期的也要印得出來，
 //                              店家常常是事後要補一張紙歸檔或跟對方對帳。
+//                              單則模式**不吃** store / kw：那是「印這一則」，
+//                              不是「印篩選結果」。
 //
 // 兩種都自己抓資料、抓完自動 window.print()。
 
@@ -17,6 +23,7 @@ import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
+import { AID_SEARCH_SKU_LIMIT, applyAidBoardFilters, parseAidBoardFilters } from "@/lib/aidBoardFilter";
 
 type PostType = "offer" | "request";
 type PostStatus = "active" | "exhausted" | "expired" | "cancelled";
@@ -58,6 +65,16 @@ const SELECT_COLS =
   "id, post_type, status, offering_store_id, sku_id, qty_available, qty_remaining, expires_at, note, " +
   "source_customer_order_id, spot_price, spot_title, spot_unit, spot_description, " +
   "spot_visible_to_other_stores, created_at";
+
+/**
+ * 清單模式一次印幾則（進行中與已結束都用這個數字，對齊列表頁「進行中」的上限）。
+ *
+ * ⚠ 已結束分頁的畫面一次只顯示 20 則（列表頁 HISTORY_PAGE，按「載入更多」才加），
+ *   所以**印出來會比畫面多**。老闆 2026-08-31 裁示維持現狀（印多比印少安全，
+ *   列印歷史多半是為了留存），代價是紙上必須寫明「本清單為最近 200 筆」。
+ *   ⇒ 下面頁首那一行小字是這個裁示的配套，⛔ 不要把它跟數字拆開改。
+ */
+const LIST_PRINT_LIMIT = 200;
 
 const TYPE_LABEL: Record<PostType, string> = { offer: "釋出", request: "需求" };
 
@@ -106,11 +123,20 @@ function Body() {
   const filter: "all" | "request" | "offer" =
     typeParam === "request" || typeParam === "offer" ? typeParam : "all";
   const view: "active" | "history" = sp.get("view") === "history" ? "history" : "active";
+  // 列表頁帶過來的分店 / 關鍵字。拆成兩個原始值才放得進 useEffect 的相依陣列
+  // （物件每次 render 都是新的，放進去會變成每次都重查）。
+  const { storeId: filterStoreId, keyword: filterKeyword } = parseAidBoardFilters((k) => sp.get(k));
 
   const [rows, setRows] = useState<Row[] | null>(null);
   const [replies, setReplies] = useState<Reply[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [printedAt, setPrintedAt] = useState<string>("");
+  // 紙上要寫出「這份是哪一家店的」。不能等 rows 來拿店名 —— 篩到 0 筆時
+  // 一筆列都沒有，那正是最需要在紙上講清楚篩了什麼的時候。
+  const [filterStoreName, setFilterStoreName] = useState<string | null>(null);
+  // 關鍵字命中的商品破上限被截掉了。列表頁會跳黃字，紙上更要印 ——
+  // 螢幕還能重按一次，紙拿在手上完全沒有第二個管道能發現資料不完整。
+  const [skuTruncated, setSkuTruncated] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -125,8 +151,24 @@ function Body() {
           q = q.eq("id", singleId);
         } else {
           q = view === "active" ? q.eq("status", "active") : q.neq("status", "active");
-          q = q.order("created_at", { ascending: false }).limit(200);
+          q = q.order("created_at", { ascending: false }).limit(LIST_PRINT_LIMIT);
           if (filter !== "all") q = q.eq("post_type", filter);
+          // ⭐ 分店 / 關鍵字走與列表頁**同一支** lib/aidBoardFilter，
+          //    兩邊才不可能篩出不一樣的東西（見本檔檔頭）。
+          const applied = await applyAidBoardFilters(sb, q, {
+            storeId: filterStoreId,
+            keyword: filterKeyword,
+          });
+          q = applied.q;
+          // ⛔ 這個旗標不可以丟掉：丟掉就等於印一張不完整、又沒說自己不完整的紙。
+          if (!cancelled) setSkuTruncated(applied.skuTruncated);
+          if (filterStoreId != null) {
+            const { data: st } = await sb
+              .from("stores").select("name").eq("id", filterStoreId).maybeSingle();
+            if (!cancelled) {
+              setFilterStoreName(((st as { name: string } | null)?.name) ?? `#${filterStoreId}`);
+            }
+          }
         }
         const { data, error: e } = await q;
         if (e) throw new Error(e.message);
@@ -201,7 +243,7 @@ function Body() {
     return () => {
       cancelled = true;
     };
-  }, [filter, view, singleId]);
+  }, [filter, view, singleId, filterStoreId, filterKeyword]);
 
   // 載入完自動觸發列印（沒資料也印，讓「今天板上是空的」也留得下紙本）
   useEffect(() => {
@@ -243,13 +285,31 @@ function Body() {
           <span>列印時間 {printedAt}</span>
           <span>共 {rows.length} 則（需求 {requestCount}・釋出 {offerCount}）</span>
           <span>{view === "active" ? "僅列出進行中的貼文" : "僅列出已結束（已認領／已過期／已取消）的貼文"}</span>
+          {/* 篩過的紙一定要在紙上寫明篩了什麼。少了這一行，這張紙看起來就是
+              「全部」，而拿紙的人沒有第二個管道可以發現它其實只是一部分。 */}
+          {filterStoreId != null && <span>僅限分店：{filterStoreName ?? `#${filterStoreId}`}</span>}
+          {filterKeyword !== "" && <span>搜尋關鍵字：「{filterKeyword}」</span>}
+          {/* 老闆 2026-08-31 裁示的配套：已結束分頁畫面一次 20 則、這裡印 200 則，
+              紙比畫面多是刻意的，但一定要寫出來。進行中分頁不顯示（它本來就一次撈完）。 */}
+          {view === "history" && <span>本清單為最近 {LIST_PRINT_LIMIT} 筆</span>}
         </div>
+        {/* 命中的商品破上限 → 這張紙是不完整的，而且紙沒辦法「重按一次看看」。
+            用整行紅字，不要混在上面那排灰色小字裡被滑過去。 */}
+        {skuTruncated && (
+          <div className="mt-1 border border-red-600 px-2 py-1 text-xs font-semibold text-red-700">
+            ⚠ 符合「{filterKeyword}」的商品超過 {AID_SEARCH_SKU_LIMIT} 項，本清單可能不完整；
+            請回系統把關鍵字打得更完整後重印。
+          </div>
+        )}
       </header>
 
       {rows.length === 0 ? (
         <div className="border border-dashed border-zinc-400 p-8 text-center text-sm text-zinc-500">
           {view === "active" ? "目前沒有進行中的" : "沒有已結束的"}
           {filter === "request" ? "需求" : filter === "offer" ? "釋出" : ""}貼文
+          {(filterStoreId != null || filterKeyword !== "") && (
+            <div className="mt-1 text-xs">（這份有篩選，不代表整個板上是空的）</div>
+          )}
         </div>
       ) : (
         <table className="w-full border-collapse text-sm">

--- a/apps/admin/src/lib/aidBoardFilter.ts
+++ b/apps/admin/src/lib/aidBoardFilter.ts
@@ -1,0 +1,175 @@
+// 互助交流板的「打字搜尋」與「分店篩選」—— 兩個入口共用的唯一一份條件。
+//
+// 為什麼要獨立成一支 lib：板上對 mutual_aid_board 的查詢有**兩個**入口，各查各的 ——
+// 列表頁 inventory/mutual-aid/page.tsx，以及列印頁 inventory/mutual-aid/print/page.tsx
+// （它不吃列表頁的結果，自己重新查一次資料庫）。條件複製成兩份、哪天只改到其中一份，
+// 就會變成「畫面上篩到剩 3 筆、按列印印出來是全部」—— 而且紙已經拿在手上了，
+// 完全看不出來哪裡不對。條件收在這裡，兩邊只可能一起對、或一起錯。
+//
+// ⛔ 這兩個條件一定要**送後端**，不可以改成把列撈回來再 Array.filter：
+//    歷史分頁一次只讀 20 筆（列表頁的 HISTORY_PAGE），在那 20 筆裡篩，
+//    會讓「其實有 500 筆歷史」的店看起來一筆貼文都沒有。那是靜默的錯，
+//    比沒有這個功能還糟 —— 使用者不會知道自己被騙了。
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * 關鍵字換算 sku_id 時一次最多取幾筆。
+ *
+ * 500 不是隨手挑的，是本 repo 對 `.in()` 的既有慣例
+ * （campaigns/page.tsx:336-340「避免 .in() 把 URL 塞爆」，該頁三處都切 500）：
+ * postgrest-js 的 `.in()` 走 query string，一個 5 位數 id 編碼後約 8 字元
+ * （逗號會變 %2C）→ 500 個 ≈ 4KB，還在安全範圍內。
+ *
+ * ⚠ 另一個非它不可的理由：PostgREST 單次 select 的 max_rows 就是 1000
+ * （supabase/config.toml、lib/fetchAllRows.ts 檔頭有實測），不寫 limit 一樣會被
+ * 截在 1000，只是截得**沒有聲音**。寫死 500 並回報有沒有截到，至少是講得出來的。
+ */
+export const AID_SEARCH_SKU_LIMIT = 500;
+
+export type AidBoardFilters = {
+  /** 只看這家店貼的（mutual_aid_board.offering_store_id）；null = 全部門市 */
+  storeId: number | null;
+  /** 打字搜尋的關鍵字；空字串 = 不搜尋 */
+  keyword: string;
+};
+
+/**
+ * PostgREST 的 `or()` 用逗號分條件、括號分群，`%` 是 ilike 的萬用字元 ——
+ * 這四個字元原樣送進去會把查詢字串切壞（例如打「(」會讓整發查詢 400）。
+ *
+ * 這個寫法源自全 repo 搜尋框的共同慣例（products / campaigns / orders / stores /
+ * members… 共 15 處，互助板自己的 SkuSearchInput 也是同一行），⛔ 不要另外發明一套。
+ *
+ * ⭐ 但比那 15 處**多擋一個 `*`**（2026-08-31 審查抓到）：PostgREST 為了讓人不必在
+ *    網址裡編碼 `%`，官方允許用 `*` 當 like/ilike 的萬用字元別名（URL Grammar 把
+ *    `*` 列為 reserved）。不擋的話，使用者搜「5*10 規格」會被展開成萬用字元，
+ *    撈回一堆不相關的商品，還可能把真正要找的那個擠出 500 筆上限之外。
+ *    ⛔ 那 15 處的同一個洞**不要在這個 PR 一起改** —— 那是全站的舊缺口，
+ *       另開技術債單處理，不要把這個功能 PR 擴大成全站掃射。
+ *
+ * 兩個**刻意不擋**的字元，不是漏掉：
+ *   - `'` 單引號：這裡組的是 query string、不是 SQL，PostgREST 的 logic value
+ *     只有 `,` `(` `)` 是結構字元，`'` 會被當成一般文字帶進 ilike。擋掉反而會讓
+ *     「Lay's」這種帶撇號的品名搜不到。（2026-08-31 阿審查 PostgREST 文件與
+ *     QueryParams.hs 原始碼確認過。）
+ *   - `_` 底線：它在 SQL LIKE 是「任一個字元」，確實會多撈一點點。但擋掉的代價
+ *     更大 —— 本系統真的有商品編號帶底線（例：`__叉燒肉(克)`），把 `_` 換成空白
+ *     會讓「A_B」變成「A B」而**再也對不到 A_B**。多撈一格 vs 整個找不到，
+ *     照「漏的時候往哪邊倒」的原則選多撈。
+ */
+export function safeAidKeyword(raw: string): string {
+  return raw.replace(/[%*,()]/g, " ").trim();
+}
+
+export type AidKeywordCondition = {
+  /** 丟給 `.or()` 的字串；null = 這個關鍵字不必加條件（空字串／只打了特殊字元） */
+  or: string | null;
+  /** 符合關鍵字的商品**超過上限被截掉了** → 結果可能不完整，畫面必須講出來 */
+  skuTruncated: boolean;
+};
+
+/**
+ * 關鍵字 → 貼文查詢要加的 `.or()` 條件。**兩段式**，因為商品名不在板上：
+ * mutual_aid_board 只有 `sku_id`，品名是列表頁第二段另外查 `skus` 補的
+ * （page.tsx:236）→ 沒辦法一發查完，得先把關鍵字換成 sku_id 清單。
+ */
+export async function buildAidKeywordCondition(
+  sb: SupabaseClient,
+  keyword: string,
+): Promise<AidKeywordCondition> {
+  const safe = safeAidKeyword(keyword);
+  if (!safe) return { or: null, skuTruncated: false };
+
+  // ⚠ 這一發**不可以**加 `.eq("status", "active")` 濾商品。
+  //   SkuSearchInput（page.tsx:1246）有加是對的 —— 那是「要挑一個商品來貼文」，
+  //   本來就只該挑還在賣的。但這裡是「回頭找貼文」，歷史貼文引用的商品
+  //   很可能早就停用了，濾掉的話「歷史」分頁會搜不到它們，而且畫面上
+  //   長得跟「真的沒這筆」一模一樣。
+  //
+  // ⚠ error 一定要接（2026-08-31 審查抓到）。只取 data 的話，這發查詢失敗
+  //   （斷網、RLS、逾時）會被 `data ?? []` 當成「0 個商品命中」，接著只靠
+  //   spot_title / note 去查板子 —— 靠商品名命中的貼文**安靜地消失**，
+  //   畫面只是「結果比較少」，沒有任何錯誤提示。那正好是本檔檔頭寫的那種
+  //   靜默錯誤。丟出去讓呼叫端既有的 catch 去顯示。
+  //
+  // 取 LIMIT+1 筆是為了分辨「剛好 500 筆」與「超過 500 筆」：
+  // 用 `>= 500` 判斷的話，資料庫剛好只有 500 筆符合時會跳假警告。
+  // 多的那一筆只用來判斷，不會送進 in.() 條件。
+  const { data, error } = await sb
+    .from("skus")
+    .select("id")
+    .or(`sku_code.ilike.%${safe}%,product_name.ilike.%${safe}%,variant_name.ilike.%${safe}%`)
+    .limit(AID_SEARCH_SKU_LIMIT + 1);
+  if (error) throw new Error(error.message);
+  const matched = ((data ?? []) as { id: number }[]).map((s) => s.id);
+  const skuTruncated = matched.length > AID_SEARCH_SKU_LIMIT;
+  const skuIds = skuTruncated ? matched.slice(0, AID_SEARCH_SKU_LIMIT) : matched;
+
+  // 手打的手動現貨**沒有 sku_id**，名字只存在 spot_title
+  // （sku_id 在 20260802000040 放寬成 nullable；page.tsx:212 的 select 也證實）
+  // → 少了 spot_title 這一條，手動現貨就整批搜不到。
+  const conds = [`spot_title.ilike.%${safe}%`, `note.ilike.%${safe}%`];
+
+  // `in.(...)` 放在 `or()` 裡是 PostgREST 支援的寫法，本 repo 已經在用
+  //（hq/inbox/page.tsx:451 `status.in.(draft,confirmed),and(...)`）。
+  // ⛔ 空清單不能寫成 `in.()` —— 那是語法錯誤，整發查詢會 400，
+  //    而「關鍵字一個商品都沒對到」是很常見的情況，不是例外。
+  if (skuIds.length > 0) conds.unshift(`sku_id.in.(${skuIds.join(",")})`);
+
+  return { or: conds.join(","), skuTruncated };
+}
+
+/**
+ * 把兩個篩選套到「查 mutual_aid_board 的那發查詢」上。
+ * ⭐ 列表頁與列印頁都只能走這支，不要各自 `.eq()` / `.or()`。
+ *
+ * q 收 supabase query builder。泛型只用來把型別原樣還給呼叫端；內部轉 any 是
+ * 本 repo 對「拿 query builder 當參數」的既有寫法（lib/fetchAllRows.ts:11），
+ * PostgrestFilterBuilder 的泛型串不進來。
+ */
+type AidQueryBuilder = {
+  eq(column: string, value: unknown): AidQueryBuilder;
+  or(filters: string): AidQueryBuilder;
+};
+
+export async function applyAidBoardFilters<Q>(
+  sb: SupabaseClient,
+  q: Q,
+  f: AidBoardFilters,
+): Promise<{ q: Q; skuTruncated: boolean }> {
+  let out = q as unknown as AidQueryBuilder;
+  if (f.storeId != null) out = out.eq("offering_store_id", f.storeId);
+  const kw = await buildAidKeywordCondition(sb, f.keyword);
+  if (kw.or) out = out.or(kw.or);
+  return { q: out as unknown as Q, skuTruncated: kw.skuTruncated };
+}
+
+/**
+ * 列表頁 → 列印頁的網址參數（接在既有的 `?type=…&view=…` 後面，含開頭的 `&`）。
+ *
+ * ⚠ kw 一定要 `encodeURIComponent`：它是使用者打的自由文字，帶一個 `&` 或 `#`
+ *   就會把後面的參數整段吃掉 —— 印出來會變成「沒篩到那個關鍵字」的全部清單，
+ *   剛好是本案最想避免的那種錯。既有的 type / view 沒編碼是因為它們是固定的
+ *   列舉值，不是使用者打的字。
+ */
+export function aidBoardFilterParams(f: AidBoardFilters): string {
+  const parts: string[] = [];
+  if (f.storeId != null) parts.push(`store=${f.storeId}`);
+  const safe = safeAidKeyword(f.keyword);
+  if (safe) parts.push(`kw=${encodeURIComponent(safe)}`);
+  return parts.length > 0 ? `&${parts.join("&")}` : "";
+}
+
+/**
+ * 列印頁反過來把參數讀回 AidBoardFilters。
+ * get 直接吃 `useSearchParams().get`（它回來的值已經解過碼）。
+ * 判法對齊列印頁既有的 id 參數寫法（print/page.tsx:103-104）。
+ */
+export function parseAidBoardFilters(get: (key: string) => string | null): AidBoardFilters {
+  const storeParam = Number(get("store"));
+  return {
+    storeId: Number.isFinite(storeParam) && storeParam > 0 ? storeParam : null,
+    keyword: get("kw") ?? "",
+  };
+}


### PR DESCRIPTION
## 做了什麼

互助交流板的**列表頁與列印頁**新增兩個篩選，與既有的「全部／需求中／釋出中」可疊加：

- **關鍵字搜尋** —— 比對商品名、商品編號、手動現貨標題（`spot_title`）、備註（`note`）
- **分店下拉** —— 只看某一家店貼的（`offering_store_id`）

實作上的幾個取捨，先說明免得看 diff 時有疑問：

**1. 篩選送後端，不是前端過濾。**
歷史分頁一次只撈 20 筆（`HISTORY_PAGE`），前端過濾會在已載入的那 20 筆裡找，
讓人誤以為某分店沒有貼文 —— 這種靜默錯誤比沒有功能更糟。
作法照既有 `post_type` 篩選的模式（`q.eq(...)`），沒有另立架構。

**2. 抽出 `apps/admin/src/lib/aidBoardFilter.ts` 給兩頁共用。**
列印頁會自己重新查一次資料庫，若兩邊各寫一份條件，遲早出現
「畫面篩到剩 3 筆、印出來卻是全部」。共用同一支函式從結構上排除這件事。

**3. 清洗 `% * , ( )`，但刻意保留 `_`。**
`_` 在 `ilike` 是單字元萬用字元，留著的代價是「可能多撈一兩筆」；
但系統存在帶底線的品號（例如 `__叉燒肉(克)`），把 `_` 換成空白會讓該品號
**再也搜不到**，代價是「完全找不到」。兩害相權取多撈。
（更完美的作法是跳脫 `\_` 而非替換，已記錄為後續優化，本 PR 未做。）

**4. `skus` 查詢上限 500，並多抓一筆判斷是否截斷。**
截斷時列表頁顯示黃字警告、**列印紙本顯示紅框警告** —— 螢幕可以重按一次，
紙拿在手上沒有第二個管道能發現資料不完整。

**5. 列印歷史分頁標示「本清單為最近 200 筆」。**
既有行為是列印一律撈 200 筆、畫面一次顯示 20 筆，兩者本來就對不上。
維持既有行為，改為在紙上標示清楚；該數字與 `.limit()` **共用同一個常數**
（`LIST_PRINT_LIMIT`），避免日後改了一邊、紙上寫的與實際撈的不一致。

**沒有動到的：**

- **`myStoreId` / `isHq` 的分店權限邏輯完全未更動**（#857 的範圍）。
  新增的分店下拉只是在既有可見範圍內再縮小，未繞過任何權限。
- 單則列印（`?id=`）不吃這兩個新參數，行為不變。
- 全站另有 15 處搜尋框有同樣的「未擋 `*`」缺口（同一行 regex），**本 PR 刻意不碰**，
  避免把單一功能改動擴大成全站掃射。已另行記錄為技術債。

## 上線危險

- **做了**：更動互助板列表頁與列印頁的**查詢組裝邏輯**。若條件組錯，最壞情況是
  篩選結果不正確或查詢報錯（畫面會顯示錯誤），**影響範圍僅限互助板這兩頁**。
  全部是讀取（`select`），**沒有任何寫入、沒有資料庫結構變更、沒有資料遷移**。
  列印紙本會多一行「本清單為最近 200 筆」與（必要時）截斷警告。
- **不做**：互助板貼文累積後只能靠捲動尋找，**歷史分頁尤其找不到東西**
  （一次只顯示 20 筆，要一直按「載入更多」）。分店多、貼文多的時候幾乎不可用。
- **回退**：單一 commit，`git revert` 即可完全還原。
  **無資料庫變更、無資料遷移、無設定變更**，回退後不留任何殘跡。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

| 項目 | 結果 |
|---|---|
| `tsc --noEmit` | exit 0 |
| `next build` | exit 0 |
| `eslint` | 維持既有 7 項，**無新增** |
| 離線測試 | **44 項全數通過**（以編譯後模組實測，含 PostgREST 網址組裝與字元跳脫） |

⚠️ **資料庫實環境驗收尚未執行**（開發環境無可用連線設定，未使用正式庫金鑰）。
需要在真實環境確認：歷史分頁跨頁篩選是否正確、PostgREST 對 `or()` 內 `in.()` 的處理、
以及紙本紅框警告的實際版面。

---

**與其他 PR 的關係**：本 PR 動到 `inventory/mutual-aid/page.tsx` 與 `print/page.tsx`，
與 @alexktchen 於 8/25–8/26 的 #845、#847、#848、#849、#850、#857 **為同一組檔案、不同區塊**
（那幾個 PR 已合併，本 PR 基於其後的 `60dbbc8f`，無衝突）。

**附註**：程式碼由 AI 協助產生，經另一模型（Codex gpt-5.5）獨立審查兩輪，P0/P1 已清零，
尚餘 2 項不影響正確性的 P2（註解完整度、手動竄改列印網址時的顯示一致性）。