### PR TITLE
/shop 頂部 banner 一次只顯示一張，在同一個框裡跑馬

### DIFF
--- a/apps/member/src/components/ShopBannerCarousel.tsx
+++ b/apps/member/src/components/ShopBannerCarousel.tsx
@@ -15,7 +15,14 @@ type Banner = {
  * - 1 張 → 單張顯示, 不啟用 scroll/auto-play/dots
  * - 2+ 張 → horizontal scroll-snap, auto-play 4s, 觸碰暫停 8s
  *
- * scroll-snap-x mandatory + 每張寬 88% 露出右邊一點點提示可滑。
+ * scroll-snap-x mandatory，每張**整框寬**（w-full）：一次只看得到一張，
+ * 在同一個框裡換頁。可滑的提示交給下面的 dots，不要靠露出下一張的邊
+ * —— 露邊會把 banner 裡的標題／價格／倒數切一半，看起來像壞掉的版。
+ *
+ * ⚠ slideWidth 的算式（offsetWidth + 12）跟這裡的 gap-3 綁在一起，
+ *   改 gap 要三處一起改（scroll 同步、auto-play、dots 點擊）。
+ *   snapAlign 用 center：左右 padding 對稱時 scrollLeft 剛好 = i × slideWidth，
+ *   跟那三處的算法對得上。
  */
 export default function ShopBannerCarousel({ banners }: { banners: Banner[] }) {
   const scrollerRef = useRef<HTMLDivElement>(null);
@@ -87,7 +94,7 @@ export default function ShopBannerCarousel({ banners }: { banners: Banner[] }) {
           <div
             key={b.key}
             data-slide
-            className="w-[88%] shrink-0"
+            className="w-full shrink-0"
             style={{ scrollSnapAlign: "center" }}
           >
             {b.node}


### PR DESCRIPTION
## 做了什麼

老闆回報（附圖）：門市限定的 banner 右邊露出下一張的一角，把標題／價格／倒數切一半，看起來像版壞掉。「應該在同一個框裡面再跑馬。」

`ShopBannerCarousel` 每張 slide 從 `w-[88%]` 改成 `w-full`——**一行**。原本那 12% 是拿來當「還可以滑」的視覺提示，但 banner 內容是滿版的大標＋價格＋倒數膠囊，露邊等於固定切掉一塊；而可滑的提示下面本來就有 dots，不需要靠露邊。

`gap-3`、`scrollSnapAlign: center`、auto-play 4s／觸碰暫停 8s 都沒動。auto-play 與 dots 共用的算式 `scrollLeft = i × (offsetWidth + 12)` 也不用改：snapAlign 是 center 且左右 padding 對稱時，兩者剛好相等（下面有實測）。

順手把這個約束寫進元件檔頭註解——`slideWidth` 的 `+12` 跟 `gap-3` 是綁在一起的，散落在三個地方（scroll 同步、auto-play、dots 點擊），改 gap 要三處一起改。

## 上線危險

- **做了**：只影響 `/shop` 頂部 banner 的寬度，三個世界（門市限定 / 美食列車 / 限時）共用同一個元件，一起變成整框寬。
- **不做**：banner 繼續被切一半。
- **回退**：`w-full` 改回 `w-[88%]`（單行 revert）。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

純 CSS class 改動，沒有碰 DB、RPC、RLS、edge function、環境變數或任何部署設定。

## 驗證

`apps/member` `tsc --noEmit` 0 error、`npm run build` 過（含 iPhone 7 bundle 相容性檢查：48 支 chunk 都能被 Safari 15.6 解析）。ESLint 對該檔 0 問題。

幾何實測（headless Chromium，390×844，複製同一份 flex / gap / snap 結構）：

| auto-play 目標 | 實際 scrollLeft | 反算 idx | 三張各露出 |
|---|---|---|---|
| 0 | 0 | 0 | **358** / 0 / 0 |
| 1 | 370 | 1 | 0 / **358** / 0 |
| 2 | 740 | 2 | 0 / 0 / **358** |

每個 snap 位置都只有一張露出、另兩張 0px（＝不露邊），且 `scrollLeft` 與元件的算式逐格相符 → auto-play 與 dots 不會失準。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019t17YjcZJQNM4pZWYRaHeT

---
_Generated by [Claude Code](https://claude.ai/code/session_019t17YjcZJQNM4pZWYRaHeT)_