### PR TITLE
feat(settlement): 月結「總倉→店家」改派車入帳＋短收同意退回自動沖帳＋記帳單防護

### DIFF
--- a/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/page.tsx
@@ -132,8 +132,14 @@ export default function SettlementPage() {
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h1 className="text-xl font-semibold">月結算</h1>
+          {/* ⚠️ 2026-09-01 改寫：原本寫「依 hq_to_store **已收貨** transfers 計算貨款」，
+              那句從 2026-09-01 起是假的 —— 口徑已改成「總倉派車當下、MAX(派出量,實收量)」
+              (20260901000000_settlement_dispatch_basis.sql:148-149 金額、:358-391 明細)。
+              ⛔ 這是給總倉看「錢怎麼算出來的」的唯一一句說明，寫錯就是對帳吵架的起點。 */}
           <p className="text-sm text-zinc-500">
-            總倉對各分店：賣斷制、依 hq_to_store 已收貨 transfers 計算貨款（含空中轉調整）。
+            總倉對各分店：賣斷制。<span className="font-medium">2026-09-01 起，貨款算在總倉派車出貨的那一天</span>，
+            數量取「派出量」與「實際收到量」之中較大的那個（店家超收照實收算、少收先照派出算，
+            總倉在異常同意退回後會自動扣掉）。含空中轉調整。
             應付金額以分店價口徑計；成本口徑另計、供總倉毛利參考。
             流程：產生 → 送店家核對 → （爭議處理）→ 雙方同意鎖定 → 店家匯款 → 收款結案。
           </p>

--- a/apps/admin/src/components/TransferShortageResolveModal.tsx
+++ b/apps/admin/src/components/TransferShortageResolveModal.tsx
@@ -398,6 +398,15 @@ export function TransferShortageResolveModal({
               之後要補給這家店，請該店開一張補貨申請，總倉核准後就能直接派，不用再進一次貨
               （要是這批貨先被別的單配走了，就得等下一批）。
             </div>
+            {/* ⚠️ 錢的話只放在這一塊,不放預設文案 —— 沖帳單只對「總倉派給店家」的單產生
+                (20260901000010_shortage_return_booking.sql:296-300 的四道條件),
+                而 restock_hq 沒有總倉守衛、店↔店的單也按得下去。
+                ⛔ 措辭不寫「一定會退到多少錢」:金額是月結重算時才算出來的,
+                  而且分店價改過版的商品會有差額(見該檔檔頭的⚠️那段)。 */}
+            <div className="mt-0.5">
+              兩顆都會把少收的數量<span className="font-bold">記一筆退回</span>，
+              月結重算時就會從這家店的帳上扣掉，不用另外開人工調整。
+            </div>
           </div>
         )}
         {/* ⚠️⚠️ 五審 P1-2 的落點就在這裡:「會自動開一張撿貨單」這句從第一顆的預設說明
@@ -483,22 +492,36 @@ export function TransferShortageResolveModal({
         {/* 第三個答案「不同意退貨」(＝要跟店家收錢)還沒做 —— ⛔ 刻意做成「說明文字」不是按鈕。
             老闆 2026-08-21 逐字定的話,原因是總倉真的按不出這個結果。
             ⭐ 括號那句是這裡唯一一句「系統會怎樣」的話,出處:
-              月結明細與金額都是按 ti.qty_received 算的
-              (rpc_generate_hq_to_store_settlement 最新版
-               20260807000000_settlement_taipei_month_boundary.sql:103-115 金額、:276-297 明細,
-               兩處都帶 AND ti.qty_received > 0),
-              而 rpc_resolve_transfer_item_shortage 只寫 shortage_* 欄位、
-              **不會動到 qty_received**(20260811020000:262-270 的 UPDATE 欄位清單)
-              ⇒ 上面兩顆按完,少收的那幾件都不會進月結單。
-            ⛔ 這句只描述月結是怎麼算出來的,不寫「一定不會被收錢」——
-              月結另有人工調整那條路(20260801000000_settlement_manual_adjustment),不歸這個視窗管。
-            ⛔⛔ 這一段查到最新版用的是標準查法(帶 public. 選擇性前綴),
-              rpc_generate_hq_to_store_settlement 共 8 版,20260807000000 是最後一支。 */}
+              ⚠️⚠️ 2026-09-01 改寫:這句話原本寫的是「月結單是按店家**實際收到**的數量算錢的,
+              而這兩顆都不會改動實收數量」——**那句話從 2026-09-01 起是假的**,
+              而且是在對總倉講錢怎麼算,錯得最貴。
+              新口徑:hq_inbound 改成 MAX(派出量,實收量) × 分店價、時點是派車日
+              (20260901000000_settlement_dispatch_basis.sql:148-149 金額、:358-391 明細)。
+              ⇒ 現在這句只留**無條件為真**的部分:月結是按送出去的數量算的。
+              (店↔店那一段 2026-08-25 起也已經是按轉出量,所以「按送出去的數量」
+               對這個視窗會遇到的兩種單都成立,不需要條件句。)
+            ⛔⛔ 2026-09-01 二審再修:上一版寫的是「按**總倉**送出去的數量」,
+              那個「總倉」兩個字對店↔店的單不成立 ——
+              v_hq_exceptions 的 transfer_short 分支
+              (20260824020000:1456-1499)WHERE 只有
+              `t.status='received' AND ti.qty_received < ti.qty_shipped`,
+              **沒有限定 transfer_type='hq_to_store'** ⇒ 店↔店短收一樣會進這個視窗。
+              ⇒ 「總倉」只能出現在 srcIsHq === true 那一塊。
+              ⭐ 這是同一個檔案上第七次因為「預設文案講了有條件的話」被抓 ——
+                寫這裡的每一句之前先問:**這句話對店↔店的單成立嗎?**
+            ⛔ 「少收的會自動扣掉」這句**沒有**寫在這裡,因為它有條件:
+              沖帳單只對 hq_to_store 產生(20260901000010_shortage_return_booking.sql:296-300 的四道條件),
+              而 restock_hq 沒有總倉守衛、店↔店的單也按得下去。
+              ⇒ 依本檔既有規矩,有條件的承諾一律只放在 srcIsHq === true 那一塊。
+            ⛔ 不寫「一定不會被收錢」——月結另有人工調整那條路
+              (20260801000000_settlement_manual_adjustment),不歸這個視窗管。
+            ⛔⛔ 查最新版用標準查法(帶 public. 選擇性前綴):
+              rpc_generate_hq_to_store_settlement 共 10 版,20260901000000 是最後一支。 */}
         <div className="rounded border border-zinc-300 bg-zinc-50 p-2 text-[11px] leading-relaxed text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
           🚧 要跟店家收錢（不同意退貨）的功能還在施工，這種先不要按、這筆會留在清單。
           <div className="mt-0.5 opacity-80">
-            （月結單是按店家<span className="font-bold">實際收到</span>的數量算錢的，
-            而這兩顆都不會改動實收數量。）
+            （2026-09-01 起，月結是按<span className="font-bold">送出去</span>的數量算錢的，
+            不再是按實際收到的數量。）
           </div>
         </div>
       </div>

--- a/supabase/migrations/20260901000000_settlement_dispatch_basis.sql
+++ b/supabase/migrations/20260901000000_settlement_dispatch_basis.sql
@@ -1,0 +1,769 @@
+-- ============================================================
+-- 2026-09-01: 月結「總倉→店家」改成派車入帳（老闆 2026-08-31 四項拍板）
+--
+-- 老闆拍板（《交給Alex_退貨大案_一頁版.md》v2）：
+--   「錢在總倉派出去那一刻就算。」
+--   口徑 = MAX(派出量, 實收量) × 分店價 —— 超收的店照實收計（不會少收），
+--   未收／短收的照派出量計（店家不按收貨不再等於不用付錢）。
+--   時程追溯：上線後 9/1 起整月用新制重算（9 月全是 draft，重產即可；
+--   confirmed 以上的 gate 不受影響 —— 兩道：迴圈開頭「跳過已鎖定」那個 IF EXISTS，
+--   與 upsert 的 WHERE store_monthly_settlements.status IN ('draft','sent','disputed')）。
+--   8 月不進系統（老闆用系統外臨時帳收），系統裡 8 月草稿留 draft 不要送。
+--
+-- 改了什麼（只有這些，其餘逐字保留 20260825030000）：
+--   0. **月份硬擋**：函式 BEGIN 之後第一件事，p_month 早於 2026-09-01 直接 RAISE
+--      （grep "IF v_month_start < DATE" 找得到）。
+--      ⚠️ 副作用是故意的：7/8 月從此不能重產；且會連帶讓
+--      rpc_update_free_transfer_amount 對舊月份的估價修改整個失敗。理由寫在該段註解裡。
+--   1. rpc_generate_hq_to_store_settlement v10 —— 只動 hq_inbound 一段：
+--      a) 時窗   received_at → shipped_at（月界變數語意同步改）
+--      b) 狀態   IN ('received','closed') → IN ('shipped','received','closed')
+--         （照 20260825030000:82 的樣板，天然排除 cancelled ——
+--           ⚠ 作廢單身上是帶著 shipped_at 的，靠白名單擋、不是靠時窗擋）
+--      c) 數量   qty_received → GREATEST(qty_shipped, COALESCE(qty_received,0))
+--      d) 分店價／明細列的時點一併改用 shipped_at
+--      e) 張數／筆數統計的 hq_to_store 母體同步移到派出制（見該段註解）
+--   2. _store_inbound_lines（每日進貨對帳的口徑來源）—— 追上 hq_inbound 新口徑，
+--      並補上 20260825030000 之後就沒跟到的三處（Leg-2 排除／air 改吃 view／
+--      free 排除 Leg-1），否則檔頭自承的「每日加總 = 該月月結 branch_amount」不成立。
+--
+-- ⛔ 一個字都沒動、也不准掉的（20260825030000 剛修好的「提供店白給、收貨店付兩次」）：
+--
+--   ⭐ 以下**刻意不寫絕對行號**：本檔頭前後已經因為自己被編輯而讓行號過期三次
+--      （阿審連三輪都抓到同一條 P2）。改成寫「怎麼自己數」——這種寫法不會過期：
+--
+--      ⚠️ 一定要先把註解行濾掉再數，否則會數到這段說明文字本身：
+--          grep -v "^\s*--" <本檔> | grep -c "<下面的字串>"
+--
+--        經總倉 Leg-2 排除     next_transfer_id = t.id       → 應為 4
+--        free 排除 Leg-1       next_transfer_id IS NULL      → 應為 7
+--        air 吃 view           v_store_aid_transfer_legs     → 應為 9
+--        沒有重建 view         grep -c "^CREATE OR REPLACE VIEW" → 應為 0（這個不必濾註解）
+--
+--   - hq_inbound 的「經總倉 Leg-2 排除」NOT EXISTS：引擎彙總 / 張數統計 / 引擎明細
+--     ＋ 每日對帳 helper，共 4 處，掉任何一處＝收貨店被收兩次錢
+--   - air_in / air_out 吃 v_store_aid_transfer_legs
+--   - free_in / free_out 的 next_transfer_id IS NULL（排除 Leg-1），共 7 處
+--   - v_store_aid_transfer_legs 本身（本檔完全沒有重建它）
+--
+-- ⛔ 刻意維持收貨時點的（不是漏改）：
+--   - F) return_to_hq 退貨沖帳 —— 那正是拍板 1「總倉同意才沖帳」的語意。
+--   - free_in / free_out 自由轉貨 —— 20260825030000:29-33 說明的跨月資料問題未解，
+--     且 rpc_update_free_transfer_amount 的月鎖判定仍依 received_at（見下）。
+--
+-- ⚠ 已知後果（老闆知情拍板）：
+--   - 撤銷收貨（rpc_unreceive_transfer）從此不影響月結金額。
+--   - 短收差額**由同批的 20260901000010 負責沖帳**（不是這一支做的）：
+--     總倉「同意退回」兩顆鈕原本只寫一筆 transfer_cancel 庫存異動
+--     （20260811020000:152-162／:194-204）、不建任何 return_to_hq 調撥單，
+--     下面的 F 段因此接不到。20260901000010 補上「順手產一張純記帳 return_to_hq」，
+--     F 段就接得住了。
+--     ⛔⛔ 所以這一支**不可以單獨上線** —— 只貼這支＝短收照派出量跟店家收錢，
+--       與老闆 2026-08-31 拍板 1 相反。三支要一起貼
+--       （20260901000000 → 20260901000010 → 20260901000020）。
+--
+-- 基底：20260825030000_settlement_ship_time_matching.sql（v9，該檔為現行最新版；
+--       8/25 之後無任何 migration 再動過本函式與該 view，已 grep 確認）。
+--       本檔以 sed 逐段複製基底、再外科手術修改，改動範圍見施工回報的 diff。
+-- Rollback：貼 `切片1_回滾SQL_貼了就回到8月25日版_2026-09-01.sql`
+--       （內含 20260825030000 的引擎全文 ＋ 20260803000000/20260805000160 的
+--         每日對帳三支全文，一貼即回到 8/25 狀態；無 schema 變動）。
+--       回滾後需重跑 rpc_generate_hq_to_store_settlement 該月以重建 draft。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_generate_hq_to_store_settlement(
+  p_month date,
+  p_operator uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $fn$
+
+DECLARE
+  v_tenant         UUID;
+  v_month_start    DATE := DATE_TRUNC('month', p_month)::DATE;
+  v_month_end      DATE := (DATE_TRUNC('month', p_month) + INTERVAL '1 month')::DATE;
+  -- 月界（台北時區）：[該月1號00:00, 次月1號00:00) Asia/Taipei。
+  -- ⚠ 拿來比對的欄位**每一段不一樣**（2026-09-01 起）：
+  --   hq_inbound      → shipped_at（總倉派車日；本次改動）
+  --   air_in/air_out  → v_store_aid_transfer_legs.booked_at（＝轉出店 shipped_at，2026-08-25 起）
+  --   free_*/return_* → received_at（維持收貨日，刻意沒動）
+  v_range_start    TIMESTAMPTZ := v_month_start::TIMESTAMP AT TIME ZONE 'Asia/Taipei';
+  v_range_end      TIMESTAMPTZ := v_month_end::TIMESTAMP AT TIME ZONE 'Asia/Taipei';
+  v_store          RECORD;
+  v_settlement_id  BIGINT;
+  v_hq_inbound     NUMERIC(18,4);
+  v_air_in         NUMERIC(18,4);
+  v_air_out        NUMERIC(18,4);
+  v_free_in        NUMERIC(18,4);
+  v_free_out       NUMERIC(18,4);
+  v_return_out     NUMERIC(18,4);
+  v_hq_inbound_b   NUMERIC(18,4);  -- 分店價口徑
+  v_air_in_b       NUMERIC(18,4);
+  v_air_out_b      NUMERIC(18,4);
+  v_return_out_b   NUMERIC(18,4);
+  v_adjust         NUMERIC(18,4);  -- 人工調整（active 合計）
+  v_cost_total     NUMERIC(18,4);
+  v_branch_total   NUMERIC(18,4);
+  v_payable        NUMERIC(18,4);
+  v_xfer_count     INTEGER;
+  v_item_count     INTEGER;
+  v_total_stores   INTEGER := 0;
+  v_total_amount   NUMERIC(18,4) := 0;
+  v_total_cost     NUMERIC(18,4) := 0;
+  v_total_branch   NUMERIC(18,4) := 0;
+  v_total_adjust   NUMERIC(18,4) := 0;
+BEGIN
+  -- ⛔ 8 月以前一律擋在資料庫這一層（老闆 2026-08-31 裁示「8 月不進系統」）。
+  --
+  -- 為什麼要擋在這裡而不是只擋前端：這支是 SECURITY DEFINER RPC，
+  -- 任何登入帳號都叫得動（下面有 GRANT ... TO authenticated），
+  -- 前端月份選擇器擋不住直接打 API 的人，也擋不住下面那個內部呼叫者。
+  --
+  -- ⚠️ **這是故意的副作用，不是漏想**：從此 7 月、8 月**再也不能重產**。
+  --   要動舊月份，先貼回滾檔回到 8/25 版，跑完再貼回來。
+  -- ⚠️ **會連帶擋掉一條既有功能**：rpc_update_free_transfer_amount
+  --   （最新版 20260807000000:517）改完估價會 PERFORM 這支重跑該月 ——
+  --   若那筆自由轉貨是 8 月以前收貨的，**整個估價修改會失敗**（不是只跳過重算）。
+  --   這是刻意選的方向：讓它「大聲失敗」，好過讓它把舊月份用新制重算掉。
+  --   要改成「舊月份就跳過重算、估價照改」是另一支 migration 的事。
+  IF v_month_start < DATE '2026-09-01' THEN
+    RAISE EXCEPTION '月結從 2026 年 9 月起改用「派車就算錢」的新算法；% 月以及更早的月份已經凍結，不能再重新產生（老闆 2026-08-31 決定：8 月以前用系統外的對帳單處理）。真的要重算舊月份，請先請工程師把系統換回 8 月 25 日的版本。',
+      to_char(v_month_start, 'YYYY-MM');
+  END IF;
+
+  SELECT tenant_id INTO v_tenant FROM stores LIMIT 1;
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'no stores found, cannot infer tenant_id';
+  END IF;
+
+  FOR v_store IN
+    SELECT s.id, s.code, s.name, s.location_id
+      FROM stores s
+     WHERE s.tenant_id = v_tenant
+       AND s.location_id IS NOT NULL
+  LOOP
+    -- 跳過已鎖定/結案/作廢（confirmed 起不再重算；cancelled 舊版會 NULL crash，一併跳過）
+    IF EXISTS (
+      SELECT 1 FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status IN ('confirmed','settled','remitted','cancelled')
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    -- A) hq_inbound: 總倉派給店家（成本口徑 + 分店價口徑）
+    -- 記帳時點＝**總倉派車出貨當下**（老闆 2026-08-31：「錢在總倉派出去那一刻就算」）。
+    -- 數量＝MAX(派出量, 實收量)：超收的店照實收收（不會少收）、
+    -- 未收／短收的照派出量收（店家不按收貨不再等於不用付錢）。
+    -- 狀態白名單加 'shipped'：照 20260825030000:82 的樣板 ——
+    --   ⚠ 作廢單（cancelled）身上**是帶著 shipped_at 的**，靠這串白名單擋掉，
+    --     不是靠時窗擋。⛔ 不可以改寫成 status <> 'draft' 之類的黑名單。
+    SELECT
+      COALESCE(SUM(GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.shipped_at), 0)), 0)
+      INTO v_hq_inbound, v_hq_inbound_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('shipped','received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.shipped_at >= v_range_start
+       AND t.shipped_at < v_range_end
+       AND GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) > 0
+       -- 經總倉互助的 Leg-2 不算 hq_inbound：那批貨是別家店給的，已經在
+       -- Leg-1 出貨當下由 air_in/air_out 兩邊媒合入帳（20260825030000）
+       AND NOT EXISTS (
+             SELECT 1 FROM transfers t1
+              WHERE t1.next_transfer_id = t.id
+                AND t1.transfer_type = 'store_to_store'
+                AND t1.status <> 'cancelled');
+
+    -- B) air_in: 店↔店轉貨收進來（該店是收貨店）
+    -- 記帳時點＝**轉出店出貨當下**（老闆 2026-08-25：「轉出店一轉出這筆帳就
+    -- 成立，兩邊就媒合完成」）→ 走 v_store_aid_transfer_legs，它已把經總倉的
+    -- Leg-1 對到 Leg-2 的收貨店，兩邊同一時點、同一金額。
+    SELECT
+      COALESCE(SUM(l.qty * l.unit_cost), 0),
+      COALESCE(SUM(l.qty * COALESCE(public._branch_price_at(v_tenant, l.sku_id, l.booked_at), 0)), 0)
+      INTO v_air_in, v_air_in_b
+      FROM public.v_store_aid_transfer_legs l
+     WHERE l.tenant_id = v_tenant
+       AND l.dst_location = v_store.location_id
+       AND l.booked_at >= v_range_start
+       AND l.booked_at < v_range_end;
+
+    -- C) air_out: 店↔店轉貨送出去（該店是轉出店）—— 同 B 的時點與母體，只是
+    -- 站在轉出店那一側（貸記）。經總倉的提供店以前掉進 free_out、用「估價」計價，
+    -- 而真商品沒有估價 → 一律 0，兩邊的帳從來沒鏡像過。本次修正。
+    SELECT
+      COALESCE(SUM(l.qty * l.unit_cost), 0),
+      COALESCE(SUM(l.qty * COALESCE(public._branch_price_at(v_tenant, l.sku_id, l.booked_at), 0)), 0)
+      INTO v_air_out, v_air_out_b
+      FROM public.v_store_aid_transfer_legs l
+     WHERE l.tenant_id = v_tenant
+       AND l.src_location = v_store.location_id
+       AND l.booked_at >= v_range_start
+       AND l.booked_at < v_range_end;
+
+    -- D) free_in: 自由轉貨收進來（估價入帳、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_in
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       -- 經總倉互助的 Leg-1 不是自由轉貨：它有真商品、沒有估價，留在這裡等於
+       -- 計價 0（20260825030000 起改由 air_out 以成本／分店價入帳）
+       AND t.next_transfer_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out: 自由轉貨送出去（估價入帳、貸記、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_out
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       -- 經總倉互助的 Leg-1 不是自由轉貨：它有真商品、沒有估價，留在這裡等於
+       -- 計價 0（20260825030000 起改由 air_out 以成本／分店價入帳）
+       AND t.next_transfer_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out: 退貨回總倉（成本沖回 + 分店價沖回）
+    SELECT
+      COALESCE(SUM(ti.qty_received * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_return_out, v_return_out_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    -- G) 人工調整（active 合計；只進 payable，不動貨款兩口徑）
+    SELECT COALESCE(SUM(a.amount), 0)
+      INTO v_adjust
+      FROM store_settlement_adjustments a
+     WHERE a.tenant_id = v_tenant
+       AND a.settlement_month = v_month_start
+       AND a.store_id = v_store.id
+       AND a.status = 'active';
+
+    v_cost_total   := v_hq_inbound   + v_air_in   - v_air_out   + v_free_in - v_free_out - v_return_out;
+    v_branch_total := v_hq_inbound_b + v_air_in_b - v_air_out_b + v_free_in - v_free_out - v_return_out_b;
+    -- 賣斷制：總倉出給分店、跟分店收「分店價」；成本口徑僅供總倉毛利參考
+    v_payable      := v_branch_total + v_adjust;
+
+    -- 沒任何活動就 skip + 砍 draft（兩口徑皆 0 且無 active 調整才算無活動；
+    -- 只砍 draft，sent/disputed 已進流程不自動刪）
+    IF v_hq_inbound = 0 AND v_air_in = 0 AND v_air_out = 0
+       AND v_free_in = 0 AND v_free_out = 0 AND v_return_out = 0
+       AND v_hq_inbound_b = 0 AND v_air_in_b = 0 AND v_air_out_b = 0
+       AND v_return_out_b = 0 AND v_adjust = 0 THEN
+      DELETE FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status = 'draft';
+      CONTINUE;
+    END IF;
+
+    -- 計 transfer_count + item_count
+    -- 張數／筆數要跟上面的分錄同母體。分錄現在有三種時點，所以這裡拆三段：
+    --   1) hq_to_store           → 派車時點（2026-09-01 起，條件與 A 段逐條相同）
+    --   2) 自由轉貨／退貨回總倉  → 收貨時點（未改）
+    --   3) 店↔店訂單相關腿       → 轉出時點（20260825030000，未改）
+    -- ⚠ 第 1 段是**跟著 A 段一起改的**，不是順手改的：
+    --   不改的話，「派了但店家從沒按收貨」那批（正是本案要處理的主要對象）
+    --   會算出 payable_amount 幾萬元、transfer_count 卻是 0，
+    --   而下面的 A) items 明細又真的插了列 ⇒ 同一張對帳單自己打自己的臉。
+    SELECT COUNT(DISTINCT x.tid), COUNT(*)
+      INTO v_xfer_count, v_item_count
+      FROM (
+        -- 1) hq_to_store：派車時點
+        SELECT t.id AS tid, ti.id AS iid
+          FROM transfers t
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+         WHERE t.tenant_id = v_tenant
+           AND t.transfer_type = 'hq_to_store'
+           AND t.status IN ('shipped','received','closed')
+           AND t.dest_location = v_store.location_id
+           AND t.shipped_at >= v_range_start
+           AND t.shipped_at < v_range_end
+           AND GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) > 0
+           AND NOT EXISTS (SELECT 1 FROM transfers t1
+                            WHERE t1.next_transfer_id = t.id
+                              AND t1.transfer_type = 'store_to_store'
+                              AND t1.status <> 'cancelled')
+        UNION ALL
+        -- 2) 自由轉貨／退貨回總倉：收貨時點
+        SELECT t.id AS tid, ti.id AS iid
+          FROM transfers t
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+         WHERE t.tenant_id = v_tenant
+           AND t.status IN ('received','closed')
+           AND t.received_at >= v_range_start
+           AND t.received_at < v_range_end
+           AND ti.qty_received > 0
+           AND (
+             (t.transfer_type = 'store_to_store' AND t.customer_order_id IS NULL
+              AND t.next_transfer_id IS NULL
+              AND (t.dest_location = v_store.location_id OR t.source_location = v_store.location_id))
+             OR
+             (t.transfer_type = 'return_to_hq' AND t.source_location = v_store.location_id)
+           )
+        UNION ALL
+        -- 3) 店↔店訂單相關腿：轉出時點
+        SELECT l.transfer_id, l.transfer_item_id
+          FROM public.v_store_aid_transfer_legs l
+         WHERE l.tenant_id = v_tenant
+           AND (l.dst_location = v_store.location_id OR l.src_location = v_store.location_id)
+           AND l.booked_at >= v_range_start
+           AND l.booked_at < v_range_end
+      ) x;
+
+    -- upsert（鎖定前狀態 draft/sent/disputed 都重算；status 本身不動）
+    INSERT INTO store_monthly_settlements (
+      tenant_id, settlement_month, store_id,
+      payable_amount, cost_amount, branch_amount, adjustment_amount,
+      transfer_count, item_count,
+      status, created_by, updated_by
+    ) VALUES (
+      v_tenant, v_month_start, v_store.id,
+      v_payable, v_cost_total, v_branch_total, v_adjust,
+      v_xfer_count, v_item_count,
+      'draft', p_operator, p_operator
+    )
+    ON CONFLICT (tenant_id, settlement_month, store_id)
+    DO UPDATE SET
+      payable_amount    = EXCLUDED.payable_amount,
+      cost_amount       = EXCLUDED.cost_amount,
+      branch_amount     = EXCLUDED.branch_amount,
+      adjustment_amount = EXCLUDED.adjustment_amount,
+      transfer_count    = EXCLUDED.transfer_count,
+      item_count        = EXCLUDED.item_count,
+      updated_by        = p_operator,
+      updated_at        = NOW()
+    WHERE store_monthly_settlements.status IN ('draft','sent','disputed')
+    RETURNING id INTO v_settlement_id;
+
+    -- 重建 items
+    DELETE FROM store_monthly_settlement_items WHERE settlement_id = v_settlement_id;
+
+    -- A) hq_inbound items（雙口徑）
+    -- ⚠ 欄位名沿用 qty_received / received_at 不改名（改名會連動前端 14 檔），
+    --   但存進去的是「這筆帳的計價數量」＝MAX(派出量,實收量) 與
+    --   「這筆帳成立的時間」＝總倉派車當下 —— 同 20260825030000:398 的處理慣例。
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)), COALESCE(sm.unit_cost, 0),
+      GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) * COALESCE(sm.unit_cost, 0),
+      t.shipped_at, 'hq_inbound',
+      bp.p, GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.shipped_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('shipped','received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.shipped_at >= v_range_start
+       AND t.shipped_at < v_range_end
+       AND GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) > 0
+       -- 經總倉互助的 Leg-2 不算 hq_inbound：那批貨是別家店給的，已經在
+       -- Leg-1 出貨當下由 air_in/air_out 兩邊媒合入帳（20260825030000）
+       AND NOT EXISTS (
+             SELECT 1 FROM transfers t1
+              WHERE t1.next_transfer_id = t.id
+                AND t1.transfer_type = 'store_to_store'
+                AND t1.status <> 'cancelled');
+
+    -- B) air_in items（雙口徑）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, l.transfer_id, l.transfer_item_id,
+      l.sku_id, l.qty, l.unit_cost,
+      l.qty * l.unit_cost,
+      -- received_at 欄位存的是**這筆帳成立的時間**＝轉出店出貨當下
+      l.booked_at, 'air_in',
+      bp.p, l.qty * bp.p
+      FROM public.v_store_aid_transfer_legs l
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, l.sku_id, l.booked_at), 0) AS p
+      ) bp
+     WHERE l.tenant_id = v_tenant
+       AND l.dst_location = v_store.location_id
+       AND l.booked_at >= v_range_start
+       AND l.booked_at < v_range_end;
+
+    -- C) air_out items（兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, l.transfer_id, l.transfer_item_id,
+      l.sku_id, l.qty, l.unit_cost,
+      -1 * l.qty * l.unit_cost,  -- 負值
+      l.booked_at, 'air_out',
+      bp.p, -1 * l.qty * bp.p
+      FROM public.v_store_aid_transfer_legs l
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, l.sku_id, l.booked_at), 0) AS p
+      ) bp
+     WHERE l.tenant_id = v_tenant
+       AND l.src_location = v_store.location_id
+       AND l.booked_at >= v_range_start
+       AND l.booked_at < v_range_end;
+
+    -- D) free_in items（估價入帳、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      COALESCE(ti.estimated_amount, 0),
+      t.received_at, 'free_in', ti.description,
+      0, COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       -- 經總倉互助的 Leg-1 不是自由轉貨：它有真商品、沒有估價，留在這裡等於
+       -- 計價 0（20260825030000 起改由 air_out 以成本／分店價入帳）
+       AND t.next_transfer_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out items（估價入帳、負值、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      -1 * COALESCE(ti.estimated_amount, 0),  -- 負值
+      t.received_at, 'free_out', ti.description,
+      0, -1 * COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       -- 經總倉互助的 Leg-1 不是自由轉貨：它有真商品、沒有估價，留在這裡等於
+       -- 計價 0（20260825030000 起改由 air_out 以成本／分店價入帳）
+       AND t.next_transfer_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out items（沖回、兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, COALESCE(sm.unit_cost, 0),
+      -1 * ti.qty_received * COALESCE(sm.unit_cost, 0),  -- 負值
+      t.received_at, 'return_out',
+      bp.p, -1 * ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    v_total_stores := v_total_stores + 1;
+    v_total_amount := v_total_amount + v_payable;
+    v_total_cost   := v_total_cost + v_cost_total;
+    v_total_branch := v_total_branch + v_branch_total;
+    v_total_adjust := v_total_adjust + v_adjust;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'month',                to_char(v_month_start, 'YYYY-MM'),
+    'stores_count',         v_total_stores,
+    'total_amount',         v_total_amount,
+    'total_cost_amount',    v_total_cost,
+    'total_branch_amount',  v_total_branch,
+    'total_adjustment',     v_total_adjust
+  );
+END;
+$fn$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_generate_hq_to_store_settlement(date, uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_generate_hq_to_store_settlement(date, uuid) IS
+  'HQ→店月結算。payable = hq_inbound + air_in − air_out + free_in − free_out − return_out + 人工調整（分店價口徑）。'
+  'hq_inbound 以**總倉派車出貨當下**入帳（老闆 2026-08-31「錢在總倉派出去那一刻就算」），'
+  '數量 = MAX(派出量, 實收量)，狀態白名單 shipped/received/closed（作廢單有 shipped_at，靠白名單擋）。'
+  '店↔店訂單相關轉貨（空中轉／經總倉互助）以**轉出店出貨當下**入帳、兩邊鏡像同額'
+  '（v_store_aid_transfer_legs）；經總倉 Leg-2 不重複計 hq_inbound、Leg-1 不再誤入 free_out。'
+  '自由轉貨、return_to_hq 維持收貨時點（return_to_hq 是「總倉同意才沖帳」的語意，刻意不改）。'
+  '短收差額由 20260901000010 產生的純記帳 return_to_hq 沖掉（restock_hq/redispatch 兩顆鈕都會產），'
+  '⚠ 沖帳的分店價以「按鈕當下」計價，與原扣款的「派車當下」在改過價的商品上會有差額。'
+  '已 confirmed/settled/remitted/cancelled 不重算。基底 20260825030000。';
+
+-- ============================================================
+-- 二、每日進貨對帳：口徑追上上面的生成器
+--
+-- 為什麼一定要一起改：20260803000000 檔頭第 :13-14 行自承
+-- 「每日金額加總 = 該月月結的 branch_amount（不含人工調整）」——
+-- 那是這三支函式存在的意義（店家當天就看得到要付多少）。
+-- 上面 hq_inbound 換成派出制之後不跟著換，店家看到的每日金額
+-- 會跟月底收到的帳單對不起來，而且是**每天都對不起來**。
+--
+-- ⚠ 順帶追上 20260825030000（8/25 起就沒跟到，本次一併補齊）：
+--   這三支的基底是 20260801000000 版生成器（檔頭 :10-11 自己寫的），
+--   而 8/25 生成器改了三處，這裡一處都沒跟：
+--     (1) hq_inbound 少了「經總倉 Leg-2 排除」→ 收貨店被算兩次
+--     (2) air_in/air_out 還在用 customer_order_id IS NOT NULL + 收貨時點
+--         → 經總倉互助的提供店（Leg-1）在每日對帳裡完全看不到
+--     (3) free_in/free_out 少了 next_transfer_id IS NULL → Leg-1 重複計入
+--   ⇒ 只改 hq_inbound 的話，「每日加總 = 月結 branch_amount」還是不成立。
+--
+-- ⭐ 只動 _store_inbound_lines 一支：另外兩支 RPC
+--   （rpc_store_inbound_daily_summary / rpc_store_inbound_day_items）
+--   本身沒有任何口徑邏輯，只是把這支的輸出包成 JSON，
+--   ⇒ 函式本體一個字都不動，只更新它們的 COMMENT 說明新口徑。
+--   （重貼一份一模一樣的函式本體只會增加抄錯的風險，不會增加正確性。）
+--
+-- 輸出欄位名沿用 received_at / biz_date 不改名：那是回傳型別的一部分，
+-- 改名會連動兩支 RPC 與前端。語意改成「這筆帳成立的時間」——
+-- 與 20260825030000:398 對 store_monthly_settlement_items.received_at
+-- 的處理方式完全一致（同一套慣例，不另創第二套）。
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. helper：某店在 [p_from, p_to) 之間的分店價分錄（逐行）
+--    正負號與 store_monthly_settlement_items.branch_amount 一致。
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._store_inbound_lines(
+  p_store_id BIGINT,
+  p_from     TIMESTAMPTZ,
+  p_to       TIMESTAMPTZ
+) RETURNS TABLE (
+  transfer_id       BIGINT,
+  transfer_item_id  BIGINT,
+  sku_id            BIGINT,
+  qty               NUMERIC,
+  unit_branch_price NUMERIC,
+  amount            NUMERIC,
+  entry_type        TEXT,
+  description       TEXT,
+  received_at       TIMESTAMPTZ,
+  biz_date          DATE
+)
+LANGUAGE sql STABLE
+AS $$
+  WITH st AS (
+    SELECT s.id, s.tenant_id, s.location_id
+      FROM public.stores s
+     WHERE s.id = p_store_id
+       AND s.location_id IS NOT NULL
+  )
+  -- A) hq_inbound：總倉派給店家（+）
+  --    時點＝派車出貨當下、數量＝MAX(派出量,實收量)、狀態白名單含 shipped
+  --    ——與生成器 A 段逐條相同（20260901000000）。
+  --    ⛔ NOT EXISTS 那段是「經總倉互助 Leg-2 排除」，掉了收貨店會被算兩次。
+  SELECT t.id, ti.id, ti.sku_id, GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)),
+         bp.p, GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) * bp.p,
+         'hq_inbound'::TEXT, ti.description, t.shipped_at,
+         (t.shipped_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.transfers t ON t.tenant_id = st.tenant_id
+    JOIN public.transfer_items ti ON ti.transfer_id = t.id
+    CROSS JOIN LATERAL (
+      SELECT COALESCE(public._branch_price_at(st.tenant_id, ti.sku_id, t.shipped_at), 0) AS p
+    ) bp
+   WHERE t.transfer_type = 'hq_to_store'
+     AND t.status IN ('shipped','received','closed')
+     AND t.dest_location = st.location_id
+     AND t.shipped_at >= p_from
+     AND t.shipped_at <  p_to
+     AND GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) > 0
+     AND NOT EXISTS (
+           SELECT 1 FROM public.transfers t1
+            WHERE t1.next_transfer_id = t.id
+              AND t1.transfer_type = 'store_to_store'
+              AND t1.status <> 'cancelled')
+
+  UNION ALL
+  -- B) air_in：店↔店轉貨收進來（+）
+  --    改吃 v_store_aid_transfer_legs（20260825030000）：時點＝轉出店出貨當下、
+  --    數量＝qty_shipped，且已把「經總倉互助」的 Leg-1 對到 Leg-2 的收貨店。
+  --    ⛔ 不可以退回 customer_order_id IS NOT NULL 的舊寫法 ——
+  --      那樣經總倉互助的提供店在每日對帳裡會整個看不到。
+  --    description 補 join transfer_items 取回（view 沒帶這欄；訂單相關轉貨用真商品，
+  --    現網此欄皆為 NULL，join 只是保證輸出與改動前一致）。
+  SELECT l.transfer_id, l.transfer_item_id, l.sku_id, l.qty,
+         bp.p, l.qty * bp.p,
+         'air_in'::TEXT, ti.description, l.booked_at,
+         (l.booked_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.v_store_aid_transfer_legs l ON l.tenant_id = st.tenant_id
+    LEFT JOIN public.transfer_items ti ON ti.id = l.transfer_item_id
+    CROSS JOIN LATERAL (
+      SELECT COALESCE(public._branch_price_at(st.tenant_id, l.sku_id, l.booked_at), 0) AS p
+    ) bp
+   WHERE l.dst_location = st.location_id
+     AND l.booked_at >= p_from
+     AND l.booked_at <  p_to
+
+  UNION ALL
+  -- C) air_out：店↔店轉貨送出去（−）—— 同 B 的母體，站在轉出店那一側
+  SELECT l.transfer_id, l.transfer_item_id, l.sku_id, l.qty,
+         bp.p, -1 * l.qty * bp.p,
+         'air_out'::TEXT, ti.description, l.booked_at,
+         (l.booked_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.v_store_aid_transfer_legs l ON l.tenant_id = st.tenant_id
+    LEFT JOIN public.transfer_items ti ON ti.id = l.transfer_item_id
+    CROSS JOIN LATERAL (
+      SELECT COALESCE(public._branch_price_at(st.tenant_id, l.sku_id, l.booked_at), 0) AS p
+    ) bp
+   WHERE l.src_location = st.location_id
+     AND l.booked_at >= p_from
+     AND l.booked_at <  p_to
+
+  UNION ALL
+  -- D) free_in：自由轉入（+，估價；維持收貨時點）
+  SELECT t.id, ti.id, ti.sku_id, ti.qty_received,
+         0, COALESCE(ti.estimated_amount, 0),
+         'free_in'::TEXT, ti.description, t.received_at,
+         (t.received_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.transfers t ON t.tenant_id = st.tenant_id
+    JOIN public.transfer_items ti ON ti.transfer_id = t.id
+   WHERE t.transfer_type = 'store_to_store'
+     AND t.customer_order_id IS NULL
+     -- 經總倉互助的 Leg-1 不是自由轉貨（20260825030000）：它有真商品、沒有估價，
+     -- 留在這裡等於計價 0，已改由上面的 air_out 以分店價入帳
+     AND t.next_transfer_id IS NULL
+     AND t.status IN ('received','closed')
+     AND t.dest_location = st.location_id
+     AND t.received_at >= p_from
+     AND t.received_at <  p_to
+     AND ti.qty_received > 0
+
+  UNION ALL
+  -- E) free_out：自由轉出（−，估價；維持收貨時點）
+  SELECT t.id, ti.id, ti.sku_id, ti.qty_received,
+         0, -1 * COALESCE(ti.estimated_amount, 0),
+         'free_out'::TEXT, ti.description, t.received_at,
+         (t.received_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.transfers t ON t.tenant_id = st.tenant_id
+    JOIN public.transfer_items ti ON ti.transfer_id = t.id
+   WHERE t.transfer_type = 'store_to_store'
+     AND t.customer_order_id IS NULL
+     -- 經總倉互助的 Leg-1 不是自由轉貨（20260825030000）：見上面 D) 的說明
+     AND t.next_transfer_id IS NULL
+     AND t.status IN ('received','closed')
+     AND t.source_location = st.location_id
+     AND t.received_at >= p_from
+     AND t.received_at <  p_to
+     AND ti.qty_received > 0
+
+  UNION ALL
+  -- F) return_out：退貨回總倉（−）
+  SELECT t.id, ti.id, ti.sku_id, ti.qty_received,
+         bp.p, -1 * ti.qty_received * bp.p,
+         'return_out'::TEXT, ti.description, t.received_at,
+         (t.received_at AT TIME ZONE 'Asia/Taipei')::DATE
+    FROM st
+    JOIN public.transfers t ON t.tenant_id = st.tenant_id
+    JOIN public.transfer_items ti ON ti.transfer_id = t.id
+    CROSS JOIN LATERAL (
+      SELECT COALESCE(public._branch_price_at(st.tenant_id, ti.sku_id, t.received_at), 0) AS p
+    ) bp
+   WHERE t.transfer_type = 'return_to_hq'
+     AND t.status IN ('received','closed')
+     AND t.source_location = st.location_id
+     AND t.received_at >= p_from
+     AND t.received_at <  p_to
+     AND ti.qty_received > 0
+$$;
+
+COMMENT ON FUNCTION public._store_inbound_lines(BIGINT, TIMESTAMPTZ, TIMESTAMPTZ) IS
+  '某分店在指定期間的分店價分錄逐行（口徑同月結 branch_amount，正負號一致）。'
+  '內部 helper：不開放直接呼叫，只給 rpc_store_inbound_* 用。'
+  '時點：hq_inbound=總倉派車日（2026-09-01 起，數量取 MAX(派出量,實收量)）、'
+  'air_in/air_out=轉出店出貨日（2026-08-25 起，走 v_store_aid_transfer_legs）、'
+  'free_*/return_*=收貨日。回傳欄位 received_at 存的是「這筆帳成立的時間」。';
+
+REVOKE ALL ON FUNCTION public._store_inbound_lines(BIGINT, TIMESTAMPTZ, TIMESTAMPTZ) FROM PUBLIC;
+
+-- ------------------------------------------------------------
+-- 兩支對外 RPC：函式本體不動（無口徑邏輯），只更新說明。
+-- 最新版分別是 20260803000000（daily_summary）與
+-- 20260805000160（day_items，虛擬 SKU 顯示名）—— 兩支都保持原樣。
+-- ------------------------------------------------------------
+COMMENT ON FUNCTION public.rpc_store_inbound_daily_summary(BIGINT, DATE) IS
+  '分店某月「每日進貨金額」彙總（分店價口徑，日界 Asia/Taipei）。'
+  '月合計 = 該月月結 branch_amount（不含人工調整）。分店只能查自己店、HQ 可查全部。'
+  '2026-09-01 起：總倉→分店那一段的日期＝總倉派車日（不是店家收貨日），'
+  '數量＝MAX(派出量, 實收量)；店↔店訂單相關轉貨＝轉出店出貨日（2026-08-25 起）。';
+
+COMMENT ON FUNCTION public.rpc_store_inbound_day_items(BIGINT, DATE) IS
+  '分店某日進貨明細（品項/數量/分店價/小計）＋當日總金額，日界 Asia/Taipei。'
+  '口徑同月結對帳單（分店價），分店只能查自己店、HQ 可查全部。'
+  '自由轉貨的虛擬 SKU 以 transfer_items.description 當品名，不回佔位 SKU 的編號/規格。'
+  '2026-09-01 起：總倉→分店那一段的日期＝總倉派車日、數量＝MAX(派出量, 實收量)；'
+  '回傳欄位 received_at 存的是「這筆帳成立的時間」，不一定是收貨時間。';

--- a/supabase/migrations/20260901000010_shortage_return_booking.sql
+++ b/supabase/migrations/20260901000010_shortage_return_booking.sql
@@ -1,0 +1,368 @@
+-- ============================================================
+-- 2026-09-01（切片 1.5）：短收「同意退回」→ 自動產一張純記帳的退貨單沖帳
+--
+-- ⛔⛔ 這支跟 20260901000000_settlement_dispatch_basis.sql **必須同一天一起貼**。
+--     只貼 20260901000000 不貼這支 ＝ 短收的貨照派出量跟店家收錢，
+--     跟老闆 2026-08-31 拍板 1「同意退回就自動沖帳」正好相反。
+--
+-- 老闆拍板 1：「短收：總倉在異常按『同意退回』→ 該筆自動沖帳（派 10 收 8 → 淨收 8）」。
+--
+-- 壞在哪：總倉那兩顆「同意退回」鈕（畫面字樣見
+--   apps/admin/src/components/TransferShortageResolveModal.tsx:105/:122/:155）
+--   按下去只寫**一筆庫存異動**（20260811020000:152-162 restock_hq、
+--   :194-204 redispatch，都是 movement_type='transfer_cancel'），
+--   **從來沒有建立任何 return_to_hq 調撥單**。
+--   而月結的退貨沖帳（F 段）是靠 transfer_type='return_to_hq' 認的
+--   ⇒ 接不到，一毛都沖不掉。
+--   舊制（按實收量算錢）下這個缺口看不出來，因為短收的本來就沒被收錢；
+--   改成派車制之後它就變成「店家被多收」。
+--
+-- 改法（CEO 2026-09-01 在老闆拍板 1 範圍內選定的甲案）：
+--   兩顆鈕在原有動作之後，**額外**產生一張 transfer_type='return_to_hq'、
+--   status='received' 的調撥單，讓月結 F 段現成接住。
+--   ⇒ 月結引擎一行都不用再動。
+--
+-- ⛔⛔ 這張單是「**純記帳單**」——它不可以動任何庫存：
+--   貨已經由既有的 transfer_cancel 異動記回出貨端了（上面那兩處），
+--   再動一次庫存 ＝ 同一批貨入庫兩次。
+--   ✅ 已查證安全：全庫唯一會改庫存餘額的 trigger 是 trg_apply_movement，
+--      它掛在 **AFTER INSERT ON stock_movements**
+--      （20260422120003_inventory_schema.sql:254-256）；
+--      transfers / transfer_items 上只有 trg_touch_*（BEFORE UPDATE 改 updated_at，
+--      同檔 :282／:284）。
+--   ⇒ 只 INSERT transfers + transfer_items、**不呼叫 rpc_inbound/rpc_outbound**，
+--     庫存就一定不會動。
+--   ⛔ 所以本檔**刻意沒有**照抄範本 20260801000000_full_return_closes_order.sql
+--     裡的 rpc_outbound 那一段（該檔 :248-257）——那段是給「真的有貨在搬」的
+--     客人退貨用的。範本只借它的**建單欄位寫法**（:161-171 建 transfers、
+--     :259-266 建 transfer_items）。
+--
+-- 金額怎麼對上原本被收的錢：
+--   數量  = 本次同意退回的短收量（qty_shipped − qty_received），
+--           三個數量欄位都填它，qty_variance 生成欄自然是 0。
+--   成本  = transfer_items.out_movement_id **指向原單那一筆出庫異動**
+--           ⇒ F 段的 LEFT JOIN stock_movements 取到的 unit_cost
+--             與原本被收錢時**完全同一個值**（精準鏡像）。
+--   月份  = received_at = 按鈕當下 ⇒ F 段自然歸到「按鈕那個月」。
+--
+-- ⚠️⚠️ **一個沒有做到的地方，必須知道（見施工回報「第二輪／甲案的一半」）**：
+--   分店價這一側**沒有辦法精準鏡像**。F 段的分店價是用
+--   `_branch_price_at(..., t.received_at)` 查的（20260901000000:229-230），
+--   也就是**按鈕當下**的價；原本被收錢時用的是**派車當下**的價
+--   （同檔 :144）。這兩個時點之間如果那個商品的分店價改過版
+--   （prices.effective_from/effective_to 是真的分版的，見
+--    20260715000000:83-114），沖回去的金額就會跟當初收的不一樣。
+--   ⇒ 為什麼還是選「按鈕當下」：如果改成用派車日，沖帳會掉進**派車那個月**，
+--     而那個月很可能已經鎖定（confirmed 以上生成器直接跳過）或已被
+--     20260901000000:108 的 9 月硬擋擋住 ⇒ **這筆錢會安靜地永遠回不到店家**。
+--     兩害相權，寧可價差、不要整筆消失。
+--   ⇒ 驗證腳本 §8-c 會把「兩個時點價格不同」的筆數與金額抓出來給人看，
+--     不讓它安靜發生。要做到精準鏡像需要動 F 段（見施工回報的提案），
+--     ⛔ 本檔沒有做，等裁示。
+--
+-- 只做 hq_to_store（⚠️ 這是施工者的判斷，規格沒指定，見施工回報）：
+--   restock_hq 這一支**沒有**總倉守衛（redispatch 有，20260811020000:173-177），
+--   所以店↔店的單也按得下去。但店↔店那一段的錢走的是 air_in/air_out
+--   （8/25 起用 qty_shipped 兩邊鏡像），不是 hq_inbound；
+--   對它產 return_to_hq 會變成「用退貨去沖一筆不是這樣收的錢」＝製造新的錯帳。
+--   而 20260825030000:40-42 檔頭已經寫明店↔店短收「需要時用
+--   store_settlement_adjustments 人工調整」。⇒ 本檔只對 hq_to_store 產沖帳單。
+--
+-- 不會重複產（冪等）：
+--   新欄位 transfer_items.shortage_return_transfer_id 有值就不再產。
+--   ⚠️ 這道防線是必要的，不能只靠原本那兩個守衛：
+--     先按 restock_hq（設 shortage_restock_movement_id）、再按 redispatch，
+--     第二次會通過 redispatch 自己的守衛（它只看 shortage_redispatch_wave_id）
+--     ⇒ 沒有這個新欄位就會產出**兩張**沖帳單 ＝ 退兩次錢。
+--
+-- 基底版本：rpc_resolve_transfer_item_shortage ← 20260811020000（v3，現行最新版；
+--   已用標準查法確認共 3 版：20260607000040 / 20260810000010 / 20260811020000，
+--   且 8/24 那兩支重做只在註解裡提到它、沒有重新定義）。
+--   本檔逐字保留 v3 全文，只加：DECLARE 兩個變數、末尾一段建單、UPDATE 多寫一欄。
+-- Rollback：見 切片1_回滾SQL_貼了就回到8月25日版_2026-09-01.sql 的**第 1 段**
+--   （⛔ 第 1 段要在第 3 段「引擎回舊版」之前跑；
+--     ⛔ 而且回滾之後一定要跑那份檔案的「附錄 B」把已產生的沖帳單作廢，
+--       否則舊月結配上還留著的沖帳單 ＝ 店家被退兩次錢。
+--     新欄位 shortage_return_transfer_id 可留著不刪，留著無害，
+--     附錄 A／B 正是靠它找到那些單）。
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. schema：冪等用的欄位（有值＝這筆短收已經產過沖帳單）
+-- ------------------------------------------------------------
+ALTER TABLE transfer_items
+  ADD COLUMN IF NOT EXISTS shortage_return_transfer_id BIGINT REFERENCES transfers(id);
+
+COMMENT ON COLUMN transfer_items.shortage_return_transfer_id IS
+  '短收「同意退回」自動產生的純記帳退貨單 transfer id（有值＝已沖過帳，不可重複沖）。'
+  '該退貨單只為了讓月結 F 段沖帳，不代表有貨在搬——庫存另由 transfer_cancel 異動處理。';
+
+-- ------------------------------------------------------------
+-- 2. rpc_resolve_transfer_item_shortage v4
+--    ＝ 20260811020000 v3 逐字 ＋ 末尾的沖帳單
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_resolve_transfer_item_shortage(
+  p_transfer_item_id BIGINT,
+  p_resolution       TEXT,
+  p_notes            TEXT,
+  p_operator         UUID
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role        TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_item        transfer_items%ROWTYPE;
+  v_transfer    transfers%ROWTYPE;
+  v_shortage    NUMERIC;
+  v_unit_cost   NUMERIC;
+  v_mov_id      BIGINT;
+  -- redispatch 用
+  v_src_type    TEXT;
+  v_store_id    BIGINT;
+  v_campaign_id BIGINT;
+  v_src_po_id   BIGINT;
+  v_wave_id     BIGINT;
+  v_wave_code   TEXT;
+  -- 2026-09-01 切片 1.5：沖帳用的純記帳退貨單
+  v_ret_no          TEXT;
+  v_ret_transfer_id BIGINT;
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot resolve shortage', v_role;
+  END IF;
+  IF p_resolution NOT IN ('replenish','cancel_orders','vendor_claim','accept','restock_hq','redispatch') THEN
+    RAISE EXCEPTION 'invalid resolution: %', p_resolution;
+  END IF;
+
+  SELECT * INTO v_item FROM transfer_items
+   WHERE id = p_transfer_item_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transfer_item % not found', p_transfer_item_id;
+  END IF;
+
+  -- restock_hq / redispatch 共同前置：算短收量、鎖調撥單、驗狀態
+  IF p_resolution IN ('restock_hq','redispatch') THEN
+    v_shortage := COALESCE(v_item.qty_shipped, 0) - COALESCE(v_item.qty_received, 0);
+    IF v_shortage <= 0 THEN
+      RAISE EXCEPTION '此明細沒有短收數量（出 % / 收 %），不需處理',
+        v_item.qty_shipped, v_item.qty_received;
+    END IF;
+
+    SELECT * INTO v_transfer FROM transfers
+     WHERE id = v_item.transfer_id
+     FOR UPDATE;
+    IF v_transfer.status NOT IN ('received','closed') THEN
+      RAISE EXCEPTION '調撥單 % 狀態為「%」，僅已收貨(received/closed)可處理短收',
+        v_item.transfer_id, v_transfer.status;
+    END IF;
+  END IF;
+
+  -- restock_hq：短收量以原出庫成本記回出貨端庫存（20260810000010 原行為）
+  IF p_resolution = 'restock_hq' THEN
+    IF v_item.shortage_restock_movement_id IS NOT NULL THEN
+      RAISE EXCEPTION '此明細已沖回過出貨端庫存（movement %），不可重複沖回',
+        v_item.shortage_restock_movement_id;
+    END IF;
+
+    SELECT COALESCE(ABS(unit_cost), 0) INTO v_unit_cost
+      FROM stock_movements
+     WHERE id = v_item.out_movement_id;
+
+    -- 語意同 transfer_cancel（20260713000000）：對方沒收到的貨記回出貨端
+    v_mov_id := rpc_inbound(
+      p_tenant_id       => v_transfer.tenant_id,
+      p_location_id     => v_transfer.source_location,
+      p_sku_id          => v_item.sku_id,
+      p_quantity        => v_shortage,
+      p_unit_cost       => COALESCE(v_unit_cost, 0),
+      p_movement_type   => 'transfer_cancel',
+      p_source_doc_type => 'transfer',
+      p_source_doc_id   => v_item.transfer_id,
+      p_operator        => p_operator
+    );
+  END IF;
+
+  -- redispatch：拒絕短收 — 沖回總倉 + 自動開撿貨單重派回原店
+  IF p_resolution = 'redispatch' THEN
+    IF v_item.shortage_redispatch_wave_id IS NOT NULL THEN
+      RAISE EXCEPTION '此明細已重派過（撿貨單 wave %），不可重複重派',
+        v_item.shortage_redispatch_wave_id;
+    END IF;
+
+    -- 重派 = 從總倉再撿一次；店對店短收沒有這個語意 → 擋下，請走自由轉貨
+    SELECT l.type INTO v_src_type FROM locations l WHERE l.id = v_transfer.source_location;
+    IF COALESCE(v_src_type, '') <> 'central_warehouse' THEN
+      RAISE EXCEPTION '調撥單 % 的出貨端不是總倉，無法自動重派；店對店短收請改用「補出貨」走自由轉貨',
+        v_transfer.transfer_no;
+    END IF;
+
+    SELECT ds.id INTO v_store_id
+      FROM stores ds
+     WHERE ds.location_id = v_transfer.dest_location
+     ORDER BY ds.id
+     LIMIT 1;
+    IF v_store_id IS NULL THEN
+      RAISE EXCEPTION '調撥單 % 的收貨端對不到分店，無法自動重派', v_transfer.transfer_no;
+    END IF;
+
+    -- a) 沖回總倉（同 restock_hq；先前已用 restock_hq 沖回過就不重複沖）
+    IF v_item.shortage_restock_movement_id IS NULL THEN
+      SELECT COALESCE(ABS(unit_cost), 0) INTO v_unit_cost
+        FROM stock_movements
+       WHERE id = v_item.out_movement_id;
+
+      v_mov_id := rpc_inbound(
+        p_tenant_id       => v_transfer.tenant_id,
+        p_location_id     => v_transfer.source_location,
+        p_sku_id          => v_item.sku_id,
+        p_quantity        => v_shortage,
+        p_unit_cost       => COALESCE(v_unit_cost, 0),
+        p_movement_type   => 'transfer_cancel',
+        p_source_doc_type => 'transfer',
+        p_source_doc_id   => v_item.transfer_id,
+        p_operator        => p_operator
+      );
+    END IF;
+
+    -- b) 繼承原出貨 wave 的 campaign / source_po：
+    --    campaign 對上 → 出貨時 rpc_mark_orders_shipping_for_wave 推得動原訂單；
+    --    source_po 對上 → rpc_create_wave_from_po 的 already_wave 帳把沖回的貨
+    --    視為已被本次重派佔用，工作台不會再派給別人。
+    --    補貨直派 transfer 沒有 wave item → 兩者為 NULL，收貨端仍有
+    --    _advance_arrived_confirmed_orders（20260811000020）接手推單。
+    SELECT pwi.campaign_id, pw.source_po_id
+      INTO v_campaign_id, v_src_po_id
+      FROM picking_wave_items pwi
+      JOIN picking_waves pw ON pw.id = pwi.wave_id
+     WHERE pwi.generated_transfer_id = v_item.transfer_id
+       AND pwi.sku_id = v_item.sku_id
+     LIMIT 1;
+
+    -- c) 開 draft 撿貨單（wave_code 用 sequence，同 20260609000001）
+    v_wave_code := 'WV'
+                || to_char(NOW() AT TIME ZONE 'Asia/Taipei', 'YYMMDD')
+                || LPAD(nextval('public.picking_wave_code_seq')::TEXT, 6, '0');
+
+    INSERT INTO picking_waves (
+      tenant_id, wave_code, wave_date, status, source_po_id,
+      store_count, item_count, total_qty, note, created_by, updated_by
+    ) VALUES (
+      v_transfer.tenant_id, v_wave_code, CURRENT_DATE + 1, 'draft', v_src_po_id,
+      1, 1, v_shortage,
+      '短收重派 ← ' || v_transfer.transfer_no || '（短收 ' || v_shortage || ' 件）',
+      p_operator, p_operator
+    ) RETURNING id INTO v_wave_id;
+
+    INSERT INTO picking_wave_items (
+      tenant_id, wave_id, sku_id, store_id, qty, campaign_id, note,
+      created_by, updated_by
+    ) VALUES (
+      v_transfer.tenant_id, v_wave_id, v_item.sku_id, v_store_id, v_shortage,
+      v_campaign_id, '短收重派 ← ' || v_transfer.transfer_no,
+      p_operator, p_operator
+    );
+
+    INSERT INTO picking_wave_audit_log (
+      tenant_id, wave_id, action, after_value, note, created_by
+    ) VALUES (
+      v_transfer.tenant_id, v_wave_id, 'wave_created',
+      jsonb_build_object(
+        'redispatch_from_transfer_id', v_item.transfer_id,
+        'transfer_item_id', v_item.id,
+        'sku_id', v_item.sku_id,
+        'store_id', v_store_id,
+        'qty', v_shortage,
+        'campaign_id', v_campaign_id,
+        'source_po_id', v_src_po_id
+      ),
+      '收貨短少拒絕短收自動重派', p_operator
+    );
+  END IF;
+
+  -- ============================================================
+  -- 2026-09-01 切片 1.5：同意退回 → 產一張純記帳的 return_to_hq 讓月結 F 段沖帳
+  --
+  -- ⛔⛔ 這一段**只 INSERT 兩張表，絕對不可以呼叫 rpc_inbound / rpc_outbound**。
+  --    貨已經在上面用 transfer_cancel 記回出貨端了（:152-162 / :194-204），
+  --    這裡再動一次庫存 ＝ 同一批貨入庫兩次。
+  --    （安全性依據：唯一改庫存餘額的 trigger trg_apply_movement 掛在
+  --      AFTER INSERT ON stock_movements，transfers/transfer_items 上沒有。）
+  --
+  -- 四道條件缺一不可：
+  --   1. 只有兩顆「同意退回」會沖帳（不同意/認賠那些只打標記，本來就該照收）
+  --   2. 只做 hq_to_store —— 店↔店的錢走 air_in/air_out，用退貨去沖會做出新的錯帳
+  --      （restock_hq 沒有總倉守衛，店↔店的單真的按得下去，所以這條一定要擋）
+  --   3. 沒沖過才沖（先按 restock_hq 再按 redispatch 會走到這裡第二次）
+  --   4. 真的有短收
+  -- ============================================================
+  IF p_resolution IN ('restock_hq','redispatch')
+     AND v_transfer.transfer_type = 'hq_to_store'
+     AND v_item.shortage_return_transfer_id IS NULL
+     AND COALESCE(v_shortage, 0) > 0
+  THEN
+    v_ret_no := public._next_transfer_no();
+
+    -- 建單欄位寫法沿用 20260801000000_full_return_closes_order.sql:161-171，
+    -- 但狀態直接寫 'received'＋received_at：F 段只吃 received/closed，
+    -- 且用 received_at 分月份 ⇒ 沖帳落在「按鈕當下」那個月。
+    -- ⛔ 不掛 customer_order_id：這不是客人退貨，掛了會被訂單收尾邏輯誤判。
+    INSERT INTO transfers (
+      tenant_id, transfer_no, source_location, dest_location,
+      status, transfer_type,
+      requested_by, shipped_by, shipped_at, received_by, received_at,
+      notes, created_by, updated_by
+    ) VALUES (
+      v_transfer.tenant_id, v_ret_no,
+      v_transfer.dest_location,     -- 從「收貨的那家店」退回
+      v_transfer.source_location,   -- 回到「原本出貨的那一端」
+      'received', 'return_to_hq',
+      p_operator, p_operator, NOW(), p_operator, NOW(),
+      '[短收沖帳] 原調撥 ' || v_transfer.transfer_no
+        || '（品項 #' || v_item.id || '，短收 ' || trim_scale(v_shortage) || '）'
+        || ' — 純記帳單，庫存已由 transfer_cancel 異動處理，本單不動庫存',
+      p_operator, p_operator
+    ) RETURNING id INTO v_ret_transfer_id;
+
+    -- out_movement_id **指向原單那一筆出庫異動**：F 段的
+    -- LEFT JOIN stock_movements 會取到與原本收錢時完全同一個 unit_cost。
+    -- ⛔ 不要為了「乾淨」把它留白 —— 留白會讓成本口徑沖成 0，只沖掉分店價那一半。
+    -- ⚠️ in_movement_id 刻意留 NULL（本單沒有真的入庫）。
+    INSERT INTO transfer_items (
+      transfer_id, sku_id, qty_requested, qty_shipped, qty_received,
+      out_movement_id, notes, created_by, updated_by
+    ) VALUES (
+      v_ret_transfer_id, v_item.sku_id, v_shortage, v_shortage, v_shortage,
+      v_item.out_movement_id,
+      '短收沖帳：成本沿用原出庫異動 '
+        || COALESCE(v_item.out_movement_id::TEXT, '(原單無出庫異動，成本以 0 計)'),
+      p_operator, p_operator
+    );
+  END IF;
+
+  UPDATE transfer_items
+     SET shortage_resolution          = p_resolution,
+         shortage_resolution_at       = NOW(),
+         shortage_resolution_by       = p_operator,
+         shortage_resolution_notes    = NULLIF(TRIM(p_notes), ''),
+         shortage_restock_movement_id = COALESCE(v_mov_id, shortage_restock_movement_id),
+         shortage_redispatch_wave_id  = COALESCE(v_wave_id, shortage_redispatch_wave_id),
+         shortage_return_transfer_id  = COALESCE(v_ret_transfer_id, shortage_return_transfer_id),
+         updated_by                   = p_operator
+   WHERE id = p_transfer_item_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_resolve_transfer_item_shortage(BIGINT, TEXT, TEXT, UUID)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_resolve_transfer_item_shortage(BIGINT, TEXT, TEXT, UUID) IS
+  '2026-09-01 起(切片1.5):restock_hq/redispatch 且原單是 hq_to_store 時,額外產一張'
+  'status=received 的純記帳 return_to_hq(不動庫存),讓月結 F 段自動沖掉短收那筆錢;'
+  '冪等靠 transfer_items.shortage_return_transfer_id。'
+  '⚠ 分店價以「按鈕當下」計價,與原扣款的「派車當下」在改過價的商品上會有差額。'
+  'HQ 處理收貨短少:標記 resolution(replenish/cancel_orders/vendor_claim/accept/restock_hq/redispatch)+ 備註。'
+  'restock_hq 把短收量以原出庫成本沖回出貨端庫存(transfer_cancel movement,防重複);'
+  'redispatch=拒絕短收:沖回總倉＋自動開 draft 撿貨單重派回原店(繼承原 wave 的 campaign/source_po,'
+  '出貨收貨後原訂單自動推進);其餘 resolution 僅打標記。';

--- a/supabase/migrations/20260901000020_shortage_return_booking_guards.sql
+++ b/supabase/migrations/20260901000020_shortage_return_booking_guards.sql
@@ -1,0 +1,603 @@
+-- ============================================================
+-- 2026-09-01（切片 1.5 補強）：保護「短收沖帳記帳單」不被誤操作成幽靈庫存
+--
+-- ⛔⛔ 這支跟 20260901000000 / 20260901000010 **必須同一天一起貼**。
+--
+-- 阿審第 2 輪抓到的兩個洞（都在 rpc_unreceive_transfer 這一支上）：
+--
+-- 【洞 1 · 幽靈庫存】20260901000010 產生的沖帳單是 status='received' 且
+--   in_movement_id 為 NULL 的「純記帳單」。有人在 WMS 已收清單對它按「取消收貨」
+--   → 它變成 status='shipped'
+--   → 符合 v_hq_inbox 的待辦條件（20260818000040:118
+--      `WHEN status = 'shipped' AND transfer_type = 'return_to_hq' THEN 'pending'`）
+--   → 出現在總倉收貨待辦裡，長得跟普通調撥單一樣
+--   → 有人照常按收貨（預設全收）
+--   → rpc_receive_transfer 對它跑 rpc_inbound，**憑空生出根本不存在的貨**。
+--   而且沖帳也同時消失（qty_received 歸零，F 段吃不到）。
+--
+-- 【洞 2 · 沖過的記號沒清】對「原本那張短收單」按取消收貨時，
+--   反向邏輯 H 會清掉 shortage_resolution / restock / redispatch 三組欄位，
+--   但**沒有清 shortage_return_transfer_id、也沒有作廢沖帳單**
+--   → 重新收貨、短收數量改變時，20260901000010 的冪等條件會以為「已經沖過帳」
+--     而不再沖，同時舊的沖帳單還掛在帳上 ⇒ 兩頭錯帳。
+--
+-- ------------------------------------------------------------
+-- 為什麼閘門放在這一支（施工者自己驗過，不是照抄審查意見）：
+--   「進得了收貨待辦」的前提是先變成 status='shipped'。
+--   全庫共 29 處會把 transfers.status 設成 'shipped'，逐一看過它們的 WHERE：
+--     - 派車那幾支（rpc_transfer_distribute_batch 各版）：status IN ('draft','confirmed') 才動
+--     - 互助接力自動出貨那幾支：打在 v_leg2.id（下一段），我們這張不是任何人的 next_transfer_id
+--     - generate_transfer_from_wave：WHERE status='confirmed' AND transfer_type='hq_to_store'
+--     - 其餘 WHERE id = p_transfer_id 的，全部是 rpc_unreceive_transfer 的歷代版本
+--   ⇒ **對一張「已 received、無鏈結的 return_to_hq」而言，唯一入口就是這一支。**
+--   另外查過 rpc_unreject_transfer（20260731000000，cancelled → shipped）：
+--     它要求「有拒收回流 movement 可沖銷」，否則 :344-346 直接 RAISE。
+--     純記帳單從來沒有任何庫存異動 ⇒ v_reversed=0 ⇒ 進不來。**不是第二條路。**
+--   ⇒ 所以只在這一支加閘門就夠，不必動 rpc_receive_transfer（447 行）。
+--     ⛔ 不動它也是為了少一次 447 行的逐字重抄 —— 重抄本身就是風險。
+-- ------------------------------------------------------------
+--
+-- 改法（兩個守衛 + 一段連帶處理，其餘逐字保留）：
+--   A. 這張單**本身就是沖帳記帳單** → 一律拒絕取消收貨（洞 1）。
+--   B. 這張單**有沖過帳的品項**：
+--        B-1 沖帳單所在月份已鎖定（confirmed/settled/remitted）→ 拒絕，請人工處理。
+--            （硬要放行就會變成：鎖定的對帳單上有一筆沒有憑證的退款，
+--              而生成器不會重算鎖定月份 ⇒ 帳面永遠對不回來。）
+--        B-2 沒鎖定 → 在反向邏輯 H 裡**連帶作廢沖帳單並清掉記號**，世界回到處理前。
+--
+-- ⭐ 語意選擇（CEO 要求先定語意）：**B 走「甲案（連帶作廢）」，只有在月份鎖定時退回「乙案（拒絕）」。**
+--   理由：
+--   - 新制下對原單取消收貨**並不會改變原單的收費**
+--     （金額是 GREATEST(派出量, 實收量)，實收歸零後仍等於派出量）
+--     ⇒ 唯一會動到的錢就是沖帳那一筆，把它作廢剛好就回到「沒處理過」的狀態，
+--       重新收貨後短收多少就重新沖多少，數字自己會對。
+--   - 純乙案（一律拒絕）會讓人卡死：今天沒有任何畫面可以單獨作廢一張沖帳單，
+--     使用者會被逼去直接改資料庫，那更危險。
+--   - 但「已鎖定月份」是真的不能自動處理的情況 ⇒ 那時才退回乙案，並把話講白。
+--   ⚠️ 與洞 1 的守衛方向一致：**沖帳單自己永遠不能被取消收貨**（A 擋死），
+--     它只會被「原單取消收貨」這條路連帶作廢（B-2）—— 不會一邊擋一邊放。
+--
+-- ⛔ 作廢沖帳單用 UPDATE status='cancelled'，**不碰任何庫存**：
+--   那張單本來就沒有庫存異動（貨是由 transfer_cancel 記回去的），
+--   F 段白名單只吃 received/closed ⇒ 一改成 cancelled 就自動不再沖帳。
+--
+-- 基底版本：rpc_unreceive_transfer ← 20260828000000（最新版；已用標準查法確認共 9 版，
+--   20260828000000 是最後一支）。逐字保留全文，只加上述兩個守衛、邏輯 H 裡一段、
+--   DECLARE 兩個變數、回傳多一個欄位。
+-- Rollback：見 切片1_回滾SQL_... 的第 1 段。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_unreceive_transfer(p_transfer_id bigint, p_operator uuid, p_notes text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET statement_timeout TO '60000'
+AS $function$
+DECLARE
+  v_tenant_id         UUID;
+  v_status            TEXT;
+  v_transfer_type     TEXT;
+  v_dest_location     BIGINT;
+  v_existing_notes    TEXT;
+  v_customer_order_id BIGINT;
+  v_next_transfer_id  BIGINT;
+  v_leg2_status       TEXT;
+  v_item              RECORD;
+  v_orig              stock_movements%ROWTYPE;
+  v_on_hand           NUMERIC;
+  v_rev_id            BIGINT;
+  v_items_reversed    INTEGER := 0;
+  v_total_qty         NUMERIC := 0;
+  v_dest_store_id     BIGINT;
+  v_orders_reverted   INTEGER := 0;
+  v_ord               RECORD;
+  v_restock_reverted  INTEGER := 0;
+  v_rr                RECORD;
+  v_prog              RECORD;
+  v_surplus_orders    BIGINT[] := '{}'::BIGINT[];
+  v_received_at       TIMESTAMPTZ;
+  v_backorder_cleared INTEGER := 0;
+  v_pullback_restored INTEGER := 0;
+  v_hq                RECORD;
+  v_hq_orig           stock_movements%ROWTYPE;
+  v_hq_onhand         NUMERIC;
+  v_marks_cleared     INTEGER := 0;
+  v_restock_reversed  NUMERIC := 0;
+  v_waves_cancelled   INTEGER := 0;
+  v_batch_skus        BIGINT[];   -- 20260828：本批品項的 SKU（反向邏輯 C 前濾用）
+  v_gate_candidates   BIGINT[];
+  -- 2026-09-01 切片 1.5 補強：短收沖帳記帳單
+  v_ret_cancelled     INTEGER := 0;
+  v_locked            TEXT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('transfer:' || p_transfer_id));
+
+  SELECT tenant_id, status, transfer_type, dest_location, notes,
+         customer_order_id, next_transfer_id, received_at
+    INTO v_tenant_id, v_status, v_transfer_type, v_dest_location, v_existing_notes,
+         v_customer_order_id, v_next_transfer_id, v_received_at
+    FROM transfers
+   WHERE id = p_transfer_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transfer % not found', p_transfer_id;
+  END IF;
+
+  IF v_status <> 'received' THEN
+    RAISE EXCEPTION '調撥單 % 目前狀態為「%」，僅「已收貨(received)」可退回取消收貨', p_transfer_id, v_status;
+  END IF;
+
+  -- ===== 守衛 A（2026-09-01）：沖帳記帳單本身，一律不准取消收貨 =====
+  -- 這種單沒有實體貨（in_movement_id 全為 NULL），它 status='received' 只是為了
+  -- 讓月結的退貨段沖得到帳。一旦被退回 shipped，它就會混進總倉收貨待辦
+  -- （v_hq_inbox 20260818000040:118 把 shipped 的 return_to_hq 當 pending），
+  -- 被照常收貨後 rpc_receive_transfer 會寫出真的入庫異動 ＝ 憑空生出不存在的貨。
+  IF EXISTS (
+    SELECT 1 FROM transfer_items ti
+     WHERE ti.shortage_return_transfer_id = p_transfer_id) THEN
+    RAISE EXCEPTION '調撥單 % 是短收沖帳用的記帳單，沒有實體貨，不能取消收貨、也不能再收一次。要撤銷這筆沖帳，請對「原本那張短收的調撥單」按取消收貨。', p_transfer_id;
+  END IF;
+
+  -- ===== 守衛 B-1（2026-09-01）：沖帳已落在鎖定月份 → 擋 =====
+  -- 下面反向邏輯 H 會連帶作廢沖帳單，但鎖定月份的對帳單生成器不會重算
+  -- （20260901000000:130 跳過 confirmed/settled/remitted/cancelled）
+  -- ⇒ 硬放行的話，已鎖定的對帳單上會留下一筆沒有憑證的退款，而且永遠算不回來。
+  SELECT string_agg(DISTINCT st.name || '（' || sms.status || '）', '、')
+    INTO v_locked
+    FROM transfer_items ti
+    JOIN transfers rt  ON rt.id = ti.shortage_return_transfer_id
+    JOIN stores    st  ON st.location_id = rt.source_location
+    JOIN store_monthly_settlements sms
+      ON sms.store_id = st.id
+     AND sms.settlement_month = DATE_TRUNC('month', rt.received_at AT TIME ZONE 'Asia/Taipei')::DATE
+   WHERE ti.transfer_id = p_transfer_id
+     AND rt.status IN ('received','closed')
+     AND sms.status IN ('confirmed','settled','remitted');
+  IF v_locked IS NOT NULL THEN
+    RAISE EXCEPTION '這張單的短收已經沖帳，而那筆沖帳所在月份的對帳單已經鎖定：%。鎖定後不能自動撤回，請聯繫總倉人工處理。', v_locked;
+  END IF;
+
+  -- ===== 邏輯 H 守衛（20260824030000）：總倉已做出不可逆的短少處理 → 擋 =====
+  -- cancel_orders：客戶訂單已被取消（客人已收到通知），不可自動復原。
+  -- redispatch 且重派單已離開 draft：貨已在重撿/重派路上，退回原單會兩頭錯帳。
+  IF EXISTS (
+    SELECT 1 FROM transfer_items ti
+     WHERE ti.transfer_id = p_transfer_id
+       AND ti.shortage_resolution = 'cancel_orders') THEN
+    RAISE EXCEPTION '總倉已依這張單的短少取消客戶訂單，無法一鍵返回 — 請聯繫總倉人工處理';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM transfer_items ti
+     JOIN picking_waves pw ON pw.id = ti.shortage_redispatch_wave_id
+     WHERE ti.transfer_id = p_transfer_id
+       AND pw.status NOT IN ('draft','cancelled')) THEN
+    RAISE EXCEPTION '總倉已為這張單的短少開重派撿貨單且已在進行中，無法一鍵返回 — 請先聯繫總倉處理重派單';
+  END IF;
+
+  -- 守衛：多段接力且後段已自動出貨（收貨時 ship 過），不允許直接退回本段
+  IF v_next_transfer_id IS NOT NULL THEN
+    SELECT status INTO v_leg2_status FROM transfers WHERE id = v_next_transfer_id FOR UPDATE;
+    IF v_leg2_status IS NOT NULL AND v_leg2_status <> 'draft' THEN
+      RAISE EXCEPTION '此調撥為多段接力，後段調撥 %（狀態 %）已出貨，請先處理後段後再退回本段收貨',
+        v_next_transfer_id, v_leg2_status;
+    END IF;
+  END IF;
+
+  -- 逐項沖銷 transfer_in 入庫、並把 qty_received 歸零
+  FOR v_item IN
+    SELECT id, sku_id, qty_received, in_movement_id
+      FROM transfer_items
+     WHERE transfer_id = p_transfer_id
+     ORDER BY id
+     FOR UPDATE
+  LOOP
+    IF v_item.qty_received > 0 AND v_item.in_movement_id IS NOT NULL THEN
+      SELECT * INTO v_orig FROM stock_movements WHERE id = v_item.in_movement_id;
+
+      IF v_orig.id IS NULL
+         OR v_orig.movement_type <> 'transfer_in'
+         OR v_orig.source_doc_type <> 'transfer'
+         OR v_orig.source_doc_id <> p_transfer_id THEN
+        RAISE EXCEPTION 'transfer_item % 的 movement % 非本調撥入庫，無法退回收貨',
+          v_item.id, v_item.in_movement_id;
+      END IF;
+      IF EXISTS (SELECT 1 FROM stock_movements sm WHERE sm.reverses = v_orig.id) THEN
+        RAISE EXCEPTION 'movement % 已被沖銷過，不可重複退回收貨', v_orig.id;
+      END IF;
+
+      -- 物理守衛：入庫貨若已被取貨/售出使 on_hand 不足以沖銷 → 擋（避免庫存變負）
+      SELECT on_hand INTO v_on_hand
+        FROM stock_balances
+       WHERE tenant_id   = v_orig.tenant_id
+         AND location_id = v_orig.location_id
+         AND sku_id      = v_orig.sku_id
+       FOR UPDATE;
+      IF COALESCE(v_on_hand, 0) < v_orig.quantity THEN
+        RAISE EXCEPTION '分店庫存不足以退回收貨（SKU %：現有 %、需沖銷 %）：該批貨可能已被取貨/售出，無法退回',
+          v_orig.sku_id, COALESCE(v_on_hand, 0), v_orig.quantity;
+      END IF;
+
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reverses, reason, operator_id
+      ) VALUES (
+        v_orig.tenant_id, v_orig.location_id, v_orig.sku_id,
+        -v_orig.quantity, v_orig.unit_cost, 'reversal',
+        'transfer', p_transfer_id, v_item.id, v_orig.id,
+        format('退回收貨 transfer=%s item=%s（沖銷 movement %s）%s',
+               p_transfer_id, v_item.id, v_orig.id,
+               COALESCE('：' || NULLIF(TRIM(p_notes), ''), '')),
+        p_operator
+      ) RETURNING id INTO v_rev_id;
+
+      v_total_qty      := v_total_qty + v_orig.quantity;
+      v_items_reversed := v_items_reversed + 1;
+    END IF;
+
+    UPDATE transfer_items
+       SET qty_received   = 0,
+           in_movement_id = NULL,
+           updated_by     = p_operator,
+           updated_at     = NOW()
+     WHERE id = v_item.id;
+  END LOOP;
+
+  -- 調撥單退回 shipped
+  UPDATE transfers
+     SET status      = 'shipped',
+         received_by = NULL,
+         received_at = NULL,
+         notes       = CASE
+                         WHEN p_notes IS NULL OR TRIM(p_notes) = '' THEN v_existing_notes
+                         WHEN v_existing_notes IS NULL OR v_existing_notes = '' THEN '退回收貨：' || p_notes
+                         ELSE v_existing_notes || E'\n退回收貨：' || p_notes
+                       END,
+         updated_by  = p_operator
+   WHERE id = p_transfer_id;
+
+  -- 反向邏輯 B（aid 單 FK）/ 邏輯 C（hq_to_store）：
+  -- 把因本次收貨被推到 ready、沖銷後已不再 pickup_ready 的訂單退回 shipping。
+  -- 因其他已收波次而仍到貨的訂單維持 ready。已取貨(partially_completed/completed)不動。
+  IF v_customer_order_id IS NOT NULL THEN
+    FOR v_ord IN
+      SELECT id FROM customer_orders
+       WHERE id = v_customer_order_id AND status = 'ready'
+       FOR UPDATE
+    LOOP
+      IF NOT public.is_order_pickup_ready(v_ord.id) THEN
+        UPDATE customer_orders
+           SET status = 'shipping', ready_at = NULL, updated_by = p_operator, updated_at = NOW()
+         WHERE id = v_ord.id;
+        PERFORM rpc_log_order_status_change(v_ord.id, 'ready', 'shipping', p_operator,
+          format('退回收貨（調撥 %s）：該訂單的貨已退回在途，恢復未到貨', p_transfer_id));
+        v_orders_reverted := v_orders_reverted + 1;
+      END IF;
+    END LOOP;
+
+  ELSIF v_transfer_type = 'hq_to_store' THEN
+    SELECT id INTO v_dest_store_id
+      FROM stores
+     WHERE tenant_id = v_tenant_id AND location_id = v_dest_location
+     LIMIT 1;
+
+    -- 20260828000000：只對「有本批 SKU active 品項」的 ready 訂單重驗閘門。
+    -- 閘門 ~8ms/張，原本掃該店**全部** ready 單（中和 2,280 張＝18 秒；線上
+    -- 實測古華 788 張仍要 10.5 秒，8/28 06:44 / 07:06 兩次 DB 當機前都跑過它）。
+    -- 撤銷收貨只把本批 SKU 的貨退回在途，沒有這些 SKU 的訂單閘門結果不變
+    -- （撤銷前是 ready＝閘門 true，撤銷後仍 true），濾掉語意相同。
+    -- **兩步走**：同一句 IN (子查詢) 會被 planner 把閘門下推到掃描層先跑，
+    -- 等於沒濾（見 CLAUDE.md「昂貴函式當 WHERE 條件」）。
+    SELECT ARRAY_AGG(DISTINCT ti.sku_id) INTO v_batch_skus
+      FROM transfer_items ti WHERE ti.transfer_id = p_transfer_id;
+
+    IF v_dest_store_id IS NOT NULL AND v_batch_skus IS NOT NULL THEN
+      SELECT COALESCE(ARRAY_AGG(DISTINCT coi.order_id), '{}'::BIGINT[])
+        INTO v_gate_candidates
+        FROM customer_orders co
+        JOIN customer_order_items coi ON coi.order_id = co.id
+       WHERE co.tenant_id       = v_tenant_id
+         AND co.pickup_store_id = v_dest_store_id
+         AND co.status          = 'ready'
+         AND coi.status IN ('pending','reserved','ready')
+         AND coi.sku_id = ANY (v_batch_skus);
+
+      FOR v_ord IN
+        SELECT id FROM customer_orders
+         WHERE id = ANY (v_gate_candidates)
+           AND status = 'ready'
+         FOR UPDATE
+      LOOP
+        IF NOT public.is_order_pickup_ready(v_ord.id) THEN
+          UPDATE customer_orders
+             SET status = 'shipping', ready_at = NULL, updated_by = p_operator, updated_at = NOW()
+           WHERE id = v_ord.id;
+          PERFORM rpc_log_order_status_change(v_ord.id, 'ready', 'shipping', p_operator,
+            format('退回收貨（調撥 %s）：該訂單的貨已退回在途，恢復未到貨', p_transfer_id));
+          v_orders_reverted := v_orders_reverted + 1;
+        END IF;
+      END LOOP;
+    END IF;
+  END IF;
+
+  -- ===== 反向邏輯 D：linked 補貨申請退回 shipped；ride-along 單退回 pending =====
+  FOR v_rr IN
+    SELECT id FROM restock_requests
+     WHERE linked_transfer_id = p_transfer_id
+       AND status = 'received'
+  LOOP
+    UPDATE restock_requests
+       SET status = 'shipped', updated_by = p_operator
+     WHERE id = v_rr.id;
+    v_restock_reverted := v_restock_reverted + 1;
+
+    -- 20260810：settle 的反向 —— 短收被取消/拆行的品項還原，整單短收取消的單重開
+    PERFORM public._unsettle_restock_ride_along(v_rr.id, p_operator);
+  END LOOP;
+
+  UPDATE customer_orders co
+     SET status     = 'pending',
+         ready_at   = NULL,
+         updated_by = p_operator,
+         updated_at = NOW()
+    FROM restock_requests rr
+   WHERE rr.linked_transfer_id = p_transfer_id
+     AND co.tenant_id  = rr.tenant_id
+     AND co.order_no   = 'RR-' || rr.id::TEXT
+     AND co.order_kind = 'restock'
+     AND co.status = 'ready';
+
+  -- ===== 反向邏輯 D2（20260717）：wave 路徑申請退回 shipped =====
+  -- 本調撥退回在途後，歸屬的 received 申請若不再「全數出貨且全數到店」
+  -- → 退回 shipped、ride-along 單 ready → pending。
+  FOR v_rr IN
+    SELECT DISTINCT rr.id
+      FROM picking_wave_items pwi
+      JOIN picking_waves pw ON pw.id = pwi.wave_id AND pw.status <> 'cancelled'
+      JOIN restock_requests rr
+        ON rr.tenant_id = v_tenant_id
+       AND rr.requesting_store_id = pwi.store_id
+     WHERE pwi.generated_transfer_id = p_transfer_id
+       AND rr.status = 'received'
+       AND (pw.source_restock_request_id = rr.id
+            OR (pwi.campaign_id IS NULL
+                AND rr.linked_pr_id IS NOT NULL
+                AND pw.source_po_id IN (
+                  SELECT DISTINCT poi.po_id
+                    FROM purchase_request_items pri
+                    JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+                   WHERE pri.pr_id = rr.linked_pr_id)))
+       AND pwi.sku_id IN (SELECT sku_id FROM restock_request_lines
+                           WHERE request_id = rr.id AND cancelled_at IS NULL)
+  LOOP
+    SELECT * INTO v_prog FROM public._restock_wave_progress(v_rr.id);
+    IF NOT (v_prog.fully_dispatched AND v_prog.all_arrived) THEN
+      UPDATE restock_requests
+         SET status = 'shipped', updated_by = p_operator
+       WHERE id = v_rr.id AND status = 'received';
+      v_restock_reverted := v_restock_reverted + 1;
+
+      -- 20260810：settle 的反向（同反向邏輯 D）
+      PERFORM public._unsettle_restock_ride_along(v_rr.id, p_operator);
+
+      UPDATE customer_orders co
+         SET status     = 'pending',
+             ready_at   = NULL,
+             updated_by = p_operator,
+             updated_at = NOW()
+       WHERE co.tenant_id  = v_tenant_id
+         AND co.order_no   = 'RR-' || v_rr.id::TEXT
+         AND co.order_kind = 'restock'
+         AND co.status = 'ready';
+    END IF;
+  END LOOP;
+
+  -- ===== 反向邏輯 F（20260814(2)）：收貨多給掛進現貨池的列跟著沖銷 =====
+  -- 手動收貨會把本批沒有訂單主人的剩餘量掛進【內部】xx 店現貨池
+  -- （notes 標 [收貨多給|TF#<ids>]）。退回收貨後這批貨已不在店裡，
+  -- 池子繼續掛著＝店員會把不存在的貨轉出去（20260811000030 忠順同型）。
+  -- 已被轉單吃掉的部分（qty 遞減 / 整列 cancelled）不再處理 ——
+  -- 重新收貨時 _grow_internal_pool 依當下自由量重算，不會重複掛回。
+  WITH hit AS (
+    UPDATE customer_order_items coi
+       SET status     = 'cancelled',
+           notes      = TRIM(BOTH E'\n' FROM COALESCE(coi.notes || E'\n', '')
+                        || '[退回收貨沖銷|TF#' || p_transfer_id || ']'),
+           updated_by = p_operator,
+           updated_at = NOW()
+      FROM customer_orders co
+     WHERE co.id = coi.order_id
+       AND co.tenant_id = v_tenant_id
+       AND coi.status IN ('pending','reserved','ready')
+       AND coi.notes ~ ('\[收貨多給\|TF#([0-9]+,)*' || p_transfer_id::TEXT || '(,[0-9]+)*\]')
+    RETURNING coi.order_id
+  )
+  SELECT COALESCE(ARRAY_AGG(DISTINCT order_id), '{}'::BIGINT[])
+    INTO v_surplus_orders FROM hit;
+
+  IF cardinality(v_surplus_orders) > 0 THEN
+    -- CLAUDE.md：品項改 cancelled 後接單頭收尾；OV- 容器整張被沖光且
+    -- 一件都沒取過 → 整單 cancelled（不留空殼佔 trio 唯一索引 slot）。
+    PERFORM public._close_orders_all_items_settled(v_surplus_orders, p_operator, NOW());
+
+    UPDATE customer_orders co
+       SET status     = 'cancelled',
+           updated_by = p_operator,
+           updated_at = NOW()
+     WHERE co.id = ANY (v_surplus_orders)
+       AND co.status IN ('pending','confirmed','ready','shipping')
+       AND NOT EXISTS (SELECT 1 FROM customer_order_items x
+                        WHERE x.order_id = co.id
+                          AND x.status NOT IN ('cancelled','expired'));
+  END IF;
+
+  -- ===== 反向邏輯 G（20260824020000）：一鍵返回配單決策 =====
+  -- 手動配單在收貨同一交易做了兩類決策，退回收貨要一起還原：
+  --   G1 沒勾的候選標了 backorder_at（值 = 本單 received_at —— 同交易 NOW()
+  --      恆等）→ 清掉，否則退回重來後那些人仍被鎖住。
+  --   G2 沒勾的派貨中單被拉回 confirmed（updated_at 同樣 = received_at，該
+  --      交易裡唯一會把單寫成 confirmed 的就是拉回）→ 還原 shipping，
+  --      下次配單才會再被預設勾選。
+  -- 範圍限本店 ＋ 本單 SKU；照 received_at 精準對時（timestamptz 微秒級，
+  -- 別次操作不可能撞到同一個值）。
+  IF v_dest_store_id IS NULL THEN
+    SELECT id INTO v_dest_store_id
+      FROM stores
+     WHERE tenant_id = v_tenant_id AND location_id = v_dest_location
+     LIMIT 1;
+  END IF;
+
+  IF v_received_at IS NOT NULL AND v_dest_store_id IS NOT NULL THEN
+    UPDATE customer_order_items coi
+       SET backorder_at = NULL, backorder_by = NULL,
+           updated_by = p_operator, updated_at = NOW()
+      FROM customer_orders co
+     WHERE co.id = coi.order_id
+       AND co.tenant_id       = v_tenant_id
+       AND co.pickup_store_id = v_dest_store_id
+       AND coi.backorder_at   = v_received_at
+       AND coi.sku_id IN (SELECT sku_id FROM transfer_items WHERE transfer_id = p_transfer_id);
+    GET DIAGNOSTICS v_backorder_cleared = ROW_COUNT;
+
+    FOR v_ord IN
+      SELECT co.id FROM customer_orders co
+       WHERE co.tenant_id       = v_tenant_id
+         AND co.pickup_store_id = v_dest_store_id
+         AND co.status          = 'confirmed'
+         AND co.updated_at      = v_received_at
+         AND (co.order_kind = 'normal' OR co.order_kind IS NULL)
+         AND EXISTS (SELECT 1 FROM customer_order_items coi
+                      WHERE coi.order_id = co.id
+                        AND coi.status IN ('pending','reserved','ready')
+                        AND coi.sku_id IN (SELECT sku_id FROM transfer_items
+                                            WHERE transfer_id = p_transfer_id))
+       FOR UPDATE
+    LOOP
+      UPDATE customer_orders
+         SET status = 'shipping', updated_by = p_operator, updated_at = NOW()
+       WHERE id = v_ord.id;
+      PERFORM rpc_log_order_status_change(v_ord.id, 'confirmed', 'shipping', p_operator,
+        format('退回收貨（調撥 %s）：還原配單時拉回的派貨中狀態', p_transfer_id));
+      v_pullback_restored := v_pullback_restored + 1;
+    END LOOP;
+  END IF;
+
+  -- ===== 反向邏輯 H（20260824030000）：撤回開給總倉的短少/多收處理 =====
+  -- 待處理中的短少/多收列不用動 —— v_hq_exceptions 兩個分支都掛
+  -- t.status='received'，本函式把單退回 shipped 它們就自動從收件匣消失。
+  -- 要撤的是總倉**已經按過處理**留下的東西：
+  --   純標記（accept / vendor_claim / replenish / over_ack）→ 清掉，
+  --     否則重新收貨再短少/多收時會被 shortage_resolution IS NOT NULL 濾掉、
+  --     總倉再也看不到新的異常。
+  --   restock_hq / redispatch 沖回總倉的庫存（transfer_cancel movement）→
+  --     反向沖銷，否則重新全收之後總倉會多出這批幽靈庫存。
+  --   redispatch 開的 draft 重派撿貨單 → 取消（離開 draft 的在守衛就擋掉了）。
+  --   cancel_orders 在守衛擋下，走不到這裡。
+  FOR v_hq IN
+    SELECT ti.id, ti.sku_id, ti.shortage_resolution,
+           ti.shortage_restock_movement_id, ti.shortage_redispatch_wave_id,
+           ti.shortage_return_transfer_id
+      FROM transfer_items ti
+     WHERE ti.transfer_id = p_transfer_id
+       AND ti.shortage_resolution IS NOT NULL
+     ORDER BY ti.id
+     FOR UPDATE
+  LOOP
+    IF v_hq.shortage_restock_movement_id IS NOT NULL THEN
+      SELECT * INTO v_hq_orig FROM stock_movements
+       WHERE id = v_hq.shortage_restock_movement_id;
+      IF v_hq_orig.id IS NOT NULL
+         AND NOT EXISTS (SELECT 1 FROM stock_movements sm
+                          WHERE sm.reverses = v_hq_orig.id) THEN
+        SELECT on_hand INTO v_hq_onhand
+          FROM stock_balances
+         WHERE tenant_id   = v_hq_orig.tenant_id
+           AND location_id = v_hq_orig.location_id
+           AND sku_id      = v_hq_orig.sku_id
+         FOR UPDATE;
+        IF COALESCE(v_hq_onhand, 0) < v_hq_orig.quantity THEN
+          RAISE EXCEPTION '總倉庫存不足以撤回短少沖回（SKU %：現有 %、需沖銷 %）— 沖回的貨可能已被派出，請聯繫總倉',
+            v_hq_orig.sku_id, COALESCE(v_hq_onhand, 0), v_hq_orig.quantity;
+        END IF;
+        INSERT INTO stock_movements (
+          tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+          source_doc_type, source_doc_id, source_doc_line_id, reverses, reason, operator_id
+        ) VALUES (
+          v_hq_orig.tenant_id, v_hq_orig.location_id, v_hq_orig.sku_id,
+          -v_hq_orig.quantity, v_hq_orig.unit_cost, 'reversal',
+          'transfer', p_transfer_id, v_hq.id, v_hq_orig.id,
+          format('返回收貨撤回短少沖回 transfer=%s item=%s（沖銷 movement %s）',
+                 p_transfer_id, v_hq.id, v_hq_orig.id),
+          p_operator
+        );
+        v_restock_reversed := v_restock_reversed + v_hq_orig.quantity;
+      END IF;
+    END IF;
+
+    IF v_hq.shortage_redispatch_wave_id IS NOT NULL THEN
+      UPDATE picking_waves
+         SET status = 'cancelled', updated_by = p_operator, updated_at = NOW()
+       WHERE id = v_hq.shortage_redispatch_wave_id
+         AND status = 'draft';
+      IF FOUND THEN
+        INSERT INTO picking_wave_audit_log (
+          tenant_id, wave_id, action, after_value, note, created_by
+        ) VALUES (
+          v_tenant_id, v_hq.shortage_redispatch_wave_id, 'wave_cancelled',
+          jsonb_build_object('unreceive_transfer_id', p_transfer_id,
+                             'transfer_item_id', v_hq.id),
+          '分店返回收貨，撤回短收重派', p_operator
+        );
+        v_waves_cancelled := v_waves_cancelled + 1;
+      END IF;
+    END IF;
+
+    -- 2026-09-01：連帶作廢短收沖帳的記帳單（守衛 B-2）。
+    -- ⛔ 只改狀態，不碰庫存 —— 那張單本來就沒有任何庫存異動，
+    --   貨是由 transfer_cancel 記回去的（上面剛剛才反向沖銷掉）。
+    -- F 段白名單只吃 received/closed ⇒ 改成 cancelled 就自動不再沖帳。
+    IF v_hq.shortage_return_transfer_id IS NOT NULL THEN
+      UPDATE transfers
+         SET status     = 'cancelled',
+             notes      = COALESCE(notes, '')
+                          || ' [原單取消收貨，連帶作廢 '
+                          || to_char(NOW() AT TIME ZONE 'Asia/Taipei', 'YYYY-MM-DD') || ']',
+             updated_by = p_operator,
+             updated_at = NOW()
+       WHERE id = v_hq.shortage_return_transfer_id
+         AND status IN ('received','closed');
+      IF FOUND THEN
+        v_ret_cancelled := v_ret_cancelled + 1;
+      END IF;
+    END IF;
+
+    UPDATE transfer_items
+       SET shortage_resolution          = NULL,
+           shortage_resolution_at       = NULL,
+           shortage_resolution_by       = NULL,
+           shortage_resolution_notes    = NULL,
+           shortage_restock_movement_id = NULL,
+           shortage_redispatch_wave_id  = NULL,
+           shortage_return_transfer_id  = NULL,
+           updated_by                   = p_operator,
+           updated_at                   = NOW()
+     WHERE id = v_hq.id;
+    v_marks_cleared := v_marks_cleared + 1;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'transfer_id',        p_transfer_id,
+    'items_reversed',     v_items_reversed,
+    'total_qty_reversed', v_total_qty,
+    'orders_reverted',    v_orders_reverted,
+    'restock_reverted',   v_restock_reverted,
+    'surplus_reversed',   COALESCE(cardinality(v_surplus_orders), 0),
+    'backorder_cleared',  v_backorder_cleared,
+    'pullback_restored',  v_pullback_restored,
+    'hq_marks_cleared',   v_marks_cleared,
+    'hq_restock_reversed_qty', v_restock_reversed,
+    'hq_redispatch_cancelled', v_waves_cancelled,
+    'shortage_return_cancelled', v_ret_cancelled
+  );
+END;
+$function$;


### PR DESCRIPTION
老闆 2026-08-31 四項拍板：錢在總倉派出去那一刻就算（MAX(派出量,實收量)×分店價）； 短收經總倉「同意退回」自動沖帳；9/1 起追溯；8 月不進系統（月份硬擋在 DB 層）。

三支 migration 缺一不可（順序 000000→000010→000020）：
- 000000 引擎 v10：hq_inbound 段改 shipped 時窗＋GREATEST 數量＋白名單排除作廢； 每日對帳三支同步改口徑（並補齊 8/25 起未跟上的 Leg-2/air/free 三處）
- 000010 沖帳水管：restock_hq/redispatch 補產純記帳 return_to_hq（不動庫存， 成本指向原出庫異動精準鏡像；冪等靠新欄位 shortage_return_transfer_id）
- 000020 防護：沖帳記帳單禁止取消收貨（防幽靈庫存）；原單取消收貨連帶作廢 沖帳單並清記號；沖帳落在鎖定月份則拒絕

前端兩檔：畫面文案不再宣稱「按實際收到數量算錢」；「自動扣掉」限定總倉貨源。

驗證：施工3輪×Codex審查3輪 P0/P1=0；staging 三支全上、5 項結構驗證全綠、
8月硬擋行為實測通過；回滾檔五段逐字保真（含沖帳單善後附錄）。
⚠ 正式庫尚未套用（PR 先於貼，#793 鐵則）；數字恆等式待正式庫資料驗證。

## 做了什麼

老闆 2026-08-31 拍板：**「錢在總倉派出去那一刻就算」**。本 PR 實作四項裁示：

1. **hq_inbound 段改派車入帳**：時窗 `received_at`→`shipped_at`、數量 `MAX(派出量,實收量)`、
   白名單 `shipped/received/closed`（作廢單帶著 shipped_at，靠白名單擋）。
2. **短收「同意退回」自動沖帳**：restock_hq／redispatch 兩顆鈕補產一張**純記帳**
   `return_to_hq`（不動庫存——庫存已由既有 transfer_cancel 異動處理；成本指向
   原出庫異動精準鏡像；冪等靠新欄位 `transfer_items.shortage_return_transfer_id`）。
3. **記帳單防護**：沖帳單本身禁止取消收貨（否則會混進收貨待辦被再收一次＝
   憑空生出庫存）；對原單取消收貨則**連帶作廢沖帳單**；沖帳落在已鎖定月份時拒絕。
4. **月份硬擋（DB 層）**：2026-09 之前的月份一律 RAISE——8 月以前老闆改用系統外
   對帳單，7/8 月凍結。⚠️ 副作用（故意的）：改 8 月以前自由轉貨估價會大聲失敗。

**每日對帳三支同步改口徑**，並補齊 **8/25 起就沒跟上的三處**（Leg-2 排除／air 改吃
view／free 排除 Leg-1）——`20260825030000` 改引擎時這三支沒跟，「每日加總＝月結
branch_amount」的檔頭承諾其實已壞了六天，本 PR 一併修復。

前端兩檔：把「按實際收到數量算錢」等已不成立的文案改掉；「少收會自動扣掉」
限定總倉貨源（店↔店短收不經此路）。

## 上線危險

- **做了**：全公司收錢算法改變（草稿層）。任何錯誤都停留在 **draft**——帳單要月底
  人工按送出才會寄給店家，有一整個月觀察期。引擎零庫存操作。
  已知取捨：沖帳分店價以「按鈕當下」計價，與原扣款「派車當下」在改過價的商品上
  會有小額價差（掉進鎖定月＝整筆消失，兩害相權；差額有查詢可逐筆列出）。
- **不做**：店家不按收貨＝不用付錢的現況繼續；已 440 組／$94,585 的「派了收不到錢」
  黑洞持續擴大。
- **回退**：`切片1_回滾SQL_貼了就回到8月25日版_2026-09-01.sql` 一貼即回 8/25 版
  （五段逐字保真＋沖帳單善後附錄），重產該月草稿即完成。無 schema 破壞
  （新欄位可留，附錄靠它找單）。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

| 項目 | 結果 |
|---|---|
| 施工 × 審查 | 3 輪 × 3 輪（Codex gpt-5.5），P0/P1 = 0 |
| staging 實跑 | 三支全上（1,740 行零語法錯誤）、5 項結構驗證全 true |
| 8 月硬擋 | **行為實測**：故意跑 8 月被中文訊息擋下、9 月正常 |
| 前端 | tsc exit 0 |
| 回滾檔 | 五段與原版逐字比對相同（197/479/434/285/74 行） |

⚠️ **數字恆等式（每日加總＝月結）尚未在真資料上驗**（staging 是空庫）——
套用正式庫後、月底送帳單前會以唯讀對照查詢驗證。

---

**與其他 PR 的關係**：基於 `6d0fc5e5`（8/31 晚）。改到 `20260825030000` 引擎的
後繼版本與 `TransferShortageResolveModal`（@alexktchen 8/24-8/25 範圍）——
基底逐字保留、只動列明處，排除鏈（Leg-2/air/free）經三輪審查確認一處未掉。
⚠️ **本 PR 合併前 SQL 就會先套用至正式庫**（PR 先於貼的留痕鐵則），合併只是讓
main 跟上正式庫。**引擎已變版，之後要再動月結請以本 PR 的三支為基底。**

**附註**：程式碼由 AI 協助產生；審查過程含 40 萬組隨機對撞、全庫 29 處狀態賦值
掃描等驗證，詳 `切片1_施工回報_2026-09-01.md`（未入 repo）。


