### PR TITLE
feat(pos): 現場銷售 —— 賣現場客、當場扣庫存、缺貨可當場補帳

### DIFF
--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -35,6 +35,10 @@ const NAV: NavGroup[] = [
     items: [
       { href: "/orders", label: "訂單", match: /^\/orders/ },
       { href: "/pickup", label: "取貨", match: /^\/pickup/ },
+      // 現場銷售（門市 POS）：賣給沒有訂單的現場客，送出即扣庫存結案。
+      // ⚠ match 要排除 /pos/receipt 以外沒有子頁，維持 ^\/pos 即可；
+      //   分店要用，所以**不要**放進 BRANCH_HIDDEN_HREFS。
+      { href: "/pos", label: "現場銷售", match: /^\/pos/ },
       { href: "/wms/inbound", label: "收貨", match: /^\/wms\/inbound|^\/transfers\/inbox/ },
       { href: "/members", label: "會員", match: /^\/members/ },
       { href: "/wms/transfers", label: "內部調撥", match: /^\/wms\/transfers|^\/transfers\/free|^\/transfers\/dispatch|^\/transfers$|^\/transfers\/?$/ },

--- a/apps/admin/src/app/(protected)/orders/page.tsx
+++ b/apps/admin/src/app/(protected)/orders/page.tsx
@@ -1388,6 +1388,22 @@ function OrdersListContent() {
               ✕
             </SpinButton>
           )}
+          {/* 現場銷售快篩：WS- 單一律是 completed（開單即交貨），所以連 tab 一起切，
+              不然停在「未取貨」會搜出 0 筆，看起來像功能壞了。
+              走 keyword 而不是新開一個篩選維度 —— buildKeywordOr 已經涵蓋
+              order_no.ilike，新維度要同時改 applyOrderFilters / URL state /
+              計數查詢 / 「選取全部符合」四處，漏一處就會各說各話。 */}
+          <SpinButton
+            type="button"
+            onClick={() => { setTab("completed"); setKwInput("WS-"); setKeyword("WS-"); }}
+            title="只看門市現場銷售的單（WS-，臨櫃結帳、當場扣庫存）"
+            className={keyword === "WS-"
+              ? "shrink-0 rounded-md border border-sky-400 bg-sky-100 px-3 py-2 text-sm font-medium text-sky-900 dark:border-sky-700 dark:bg-sky-950 dark:text-sky-300"
+              : "shrink-0 rounded-md border border-zinc-300 px-3 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            }
+          >
+            🛒 現場銷售
+          </SpinButton>
           {internalKeyword && (
             <SpinButton
               type="button"

--- a/apps/admin/src/app/(protected)/pos/page.tsx
+++ b/apps/admin/src/app/(protected)/pos/page.tsx
@@ -1,0 +1,767 @@
+"use client";
+
+// 現場銷售（門市 POS）—— 賣給沒有訂單的現場客。
+//
+// 與「🤝 配給客人（現貨直配）」的分工：
+//   現貨直配 = 開一張「待取」單，客人之後回來取貨時才扣庫存（SpotSaleModal）。
+//   現場銷售 = 客人人就在櫃台，開單與交貨是同一件事 —— 一次可買多樣，
+//              送出當下就扣庫存、收錢、結案（rpc_create_walkin_sale）。
+//
+// 三個一定要記得的規矩（改這頁前先看 docs/PLAN-現場銷售POS.md）：
+//   1. 可賣量是 **free_with_pool**（在庫 − 待客取 − 等貨中 − 在途池子），
+//      不是 on_hand。別的客人正在等的貨不可以被現場客買走。
+//   2. 缺貨可以在同一列勾「補庫存」，但那是**憑空生貨的入口** ——
+//      只有店長以上按得動（RPC 也會再擋一次），而且每一筆都留 manual_adjust
+//      紀錄（reason 以「現場銷售即時入帳」開頭）供事後稽核 / 導向盤點。
+//   3. 商品清單一定要走 rpc_pos_search_products（一次撈），不要每列各打一次
+//      rpc_get_spot_availability —— 那支是 per-SKU 的，一頁 30 列 = 掃 30 遍。
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { Modal } from "@/components/Modal";
+import SpinButton from "@/components/SpinButton";
+import SearchSpinner from "@/components/SearchSpinner";
+import { translateRpcError } from "@/lib/rpcError";
+import { useRole, canSeeBranch } from "@/lib/role";
+import { useUserBranchStoreId, useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
+
+type StoreRow = { id: number; name: string; location_id: number | null; allowed_payment_methods: unknown };
+
+type Product = {
+  sku_id: number;
+  sku_code: string | null;
+  product_name: string | null;
+  variant_name: string | null;
+  on_hand: number;
+  promised: number;
+  waiting: number;
+  pool_claimed: number;
+  pool_arrived: number;
+  free: number;
+  free_with_pool: number;
+  retail_price: number | null;
+  branch_price: number | null;
+  suggest_price: number;
+};
+
+type CartLine = {
+  sku_id: number;
+  label: string;
+  sku_code: string | null;
+  qty: number;
+  unit_price: number;
+  /** 這一列要在結帳當下補幾件庫存（0 = 不補） */
+  addStock: number;
+  /** 下架商品時的可賣量快照，用來畫「超賣」警告 */
+  sellable: number;
+  on_hand: number;
+  promised: number;
+  waiting: number;
+};
+
+type MemberHit = {
+  id: number;
+  member_no: string;
+  name: string;
+  phone: string | null;
+  home_store_name: string | null;
+  no_new_order: boolean;
+};
+
+// 付款方式：值對齊 stores.allowed_payment_methods 的 enum，寫進
+// customer_orders.payment_method。⛔ 不要順手去寫 payment_status='paid' ——
+// 全站有 4 個地方把 'paid' 當「這張單不用再處理」在用（會員端未結金額、
+// 取貨頁的儲值金判斷…），現場銷售開始寫就會靜默改變那些行為。
+// 「收到錢了」用既有語意表達就好：品項 picked_up → 未結金額自動是 0。
+const PAY_LABEL: Record<string, string> = {
+  cash: "現金",
+  transfer: "轉帳",
+  credit_card: "刷卡",
+  linepay: "LINE Pay",
+  wallet: "儲值金",
+};
+const PAY_FALLBACK = ["cash", "transfer"];
+
+const num = (v: unknown) => (v == null ? 0 : Number(v));
+const numOrNull = (v: unknown) => (v == null ? null : Number(v));
+
+function skuLabel(p: Pick<Product, "product_name" | "variant_name">): string {
+  const a = (p.product_name ?? "").trim();
+  const b = (p.variant_name ?? "").trim();
+  if (a && b && a !== b) return `${a} / ${b}`;
+  return a || b || "—";
+}
+
+export default function PosPage() {
+  const role = useRole();
+  const showBranchPrice = canSeeBranch(role);
+  // 補庫存是憑空生貨的入口 —— 角色清單對齊 rpc_create_walkin_sale 的 gate
+  // （'' 是沒有顯式 role 的 legacy / dev admin，漏掉會把舊帳號全擋在外面）。
+  const canAddStock =
+    role !== null && ["owner", "admin", "hq_manager", "store_manager", ""].includes(role);
+
+  const [stores, setStores] = useState<StoreRow[]>([]);
+  const [pickedStoreId, setPickedStoreId] = useState<string>("");
+  const branchStoreId = useUserBranchStoreId(stores);
+  // 分店帳號一律鎖自己店：用**衍生值**而不是在 effect 裡 setState
+  // （react-hooks/set-state-in-effect：effect 裡同步 setState 會 cascading render）
+  const storeId = branchStoreId != null ? String(branchStoreId) : pickedStoreId;
+  useDefaultStoreFromUser(stores, pickedStoreId, setPickedStoreId, branchStoreId == null);
+
+  const [term, setTerm] = useState("");
+  const [products, setProducts] = useState<Product[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [reloadTick, setReloadTick] = useState(0);
+
+  const [cart, setCart] = useState<CartLine[]>([]);
+  const [customerName, setCustomerName] = useState("");
+  const [member, setMember] = useState<MemberHit | null>(null);
+  const [memberOpen, setMemberOpen] = useState(false);
+  const [keepAsMember, setKeepAsMember] = useState(false);
+  const [keepPhone, setKeepPhone] = useState("");
+  const [payPick, setPayPick] = useState("cash");
+  const [discount, setDiscount] = useState<number | "">("");
+  const [notes, setNotes] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState<{ order_id: number; order_no: string; total: number } | null>(null);
+
+  const store = useMemo(() => stores.find((s) => String(s.id) === storeId) ?? null, [stores, storeId]);
+
+  const payOptions = useMemo(() => {
+    const raw = store?.allowed_payment_methods;
+    const list = Array.isArray(raw) ? raw.filter((x): x is string => typeof x === "string") : [];
+    // 門市沒設就給現金 + 轉帳；現金一律排第一（Alex 決議：預設現金）
+    const opts = list.length > 0 ? list : PAY_FALLBACK;
+    return opts.includes("cash") ? ["cash", ...opts.filter((o) => o !== "cash")] : opts;
+  }, [store]);
+  // 選到的方式不在這家店的清單裡（換店、或門市改過設定）就退回第一個
+  // （＝現金，見 payOptions 的排序）。同樣用衍生值避免 effect 裡 setState。
+  const payment = payOptions.includes(payPick) ? payPick : (payOptions[0] ?? "cash");
+
+  // ---- 門市清單 ----
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data, error: e } = await getSupabase()
+        .from("stores")
+        .select("id, name, location_id, allowed_payment_methods")
+        .eq("is_active", true)
+        .order("name");
+      if (cancelled) return;
+      if (e) setError(e.message);
+      else setStores((data as StoreRow[]) ?? []);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // ---- 商品搜尋（debounce 250ms）----
+  useEffect(() => {
+    if (!storeId) return;
+    let cancelled = false;
+    const t = setTimeout(async () => {
+      setSearching(true);
+      const { data, error: e } = await getSupabase().rpc("rpc_pos_search_products", {
+        p_store_id: Number(storeId),
+        p_term: term.trim() || null,
+        p_limit: 40,
+      });
+      if (cancelled) return;
+      if (e) setError(translateRpcError(e));
+      else {
+        setProducts(
+          ((data as Record<string, unknown>[]) ?? []).map((r) => ({
+            sku_id: num(r.sku_id),
+            sku_code: (r.sku_code as string) ?? null,
+            product_name: (r.product_name as string) ?? null,
+            variant_name: (r.variant_name as string) ?? null,
+            on_hand: num(r.on_hand),
+            promised: num(r.promised),
+            waiting: num(r.waiting),
+            pool_claimed: num(r.pool_claimed),
+            pool_arrived: num(r.pool_arrived),
+            free: num(r.free),
+            free_with_pool: num(r.free_with_pool),
+            retail_price: numOrNull(r.retail_price),
+            branch_price: numOrNull(r.branch_price),
+            suggest_price: num(r.suggest_price),
+          })),
+        );
+      }
+      setSearching(false);
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [storeId, term, reloadTick]);
+
+  // 換店就把購物車清掉：可賣量、售價都是綁在店上的，留著只會結出錯的帳。
+  // 放在下拉的 onChange（而不是 effect）—— 分店帳號的 storeId 是鎖死的衍生值，
+  // 只有 HQ 換得動，這裡就是唯一的變更點。
+  const changeStore = useCallback((v: string) => {
+    setPickedStoreId(v);
+    setCart([]);
+    setDone(null);
+  }, []);
+
+  // ---- 會員搜尋 ----
+  const [mTerm, setMTerm] = useState("");
+  const [mHits, setMHits] = useState<MemberHit[]>([]);
+  const [mSearching, setMSearching] = useState(false);
+  useEffect(() => {
+    const qq = mTerm.trim();
+    if (!qq || !memberOpen) return;
+    let cancelled = false;
+    const t = setTimeout(async () => {
+      setMSearching(true);
+      const { data } = await getSupabase().rpc("rpc_search_members", { p_term: qq, p_limit: 8 });
+      if (!cancelled) {
+        setMHits((data as MemberHit[]) ?? []);
+        setMSearching(false);
+      }
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [mTerm, memberOpen]);
+
+  // ---- 購物車操作 ----
+  const addToCart = useCallback((p: Product) => {
+    setDone(null);
+    setCart((prev) => {
+      const i = prev.findIndex((l) => l.sku_id === p.sku_id);
+      if (i >= 0) {
+        const next = [...prev];
+        next[i] = { ...next[i], qty: next[i].qty + 1 };
+        return next;
+      }
+      return [
+        ...prev,
+        {
+          sku_id: p.sku_id,
+          label: skuLabel(p),
+          sku_code: p.sku_code,
+          qty: 1,
+          unit_price: p.suggest_price,
+          addStock: 0,
+          sellable: p.free_with_pool,
+          on_hand: p.on_hand,
+          promised: p.promised,
+          waiting: p.waiting,
+        },
+      ];
+    });
+  }, []);
+
+  const patchLine = useCallback((skuId: number, patch: Partial<CartLine>) => {
+    setCart((prev) => prev.map((l) => (l.sku_id === skuId ? { ...l, ...patch } : l)));
+  }, []);
+  const removeLine = useCallback((skuId: number) => {
+    setCart((prev) => prev.filter((l) => l.sku_id !== skuId));
+  }, []);
+
+  const itemsTotal = cart.reduce((s, l) => s + l.qty * l.unit_price, 0);
+  const discNum = typeof discount === "number" ? discount : 0;
+  const total = Math.max(0, itemsTotal - discNum);
+  const shortLines = cart.filter((l) => l.qty > l.sellable + l.addStock);
+  const zeroPriceLines = cart.filter((l) => l.unit_price <= 0);
+  const addTotal = cart.reduce((s, l) => s + l.addStock, 0);
+  const canCheckout =
+    !busy &&
+    !!storeId &&
+    cart.length > 0 &&
+    shortLines.length === 0 &&
+    zeroPriceLines.length === 0 &&
+    (member != null || customerName.trim().length > 0);
+
+  async function checkout() {
+    if (!canCheckout) return;
+    const who = member?.name ?? customerName.trim();
+    if (
+      !confirm(
+        `向「${who}」收 $${total}（${cart.length} 項 / ${cart.reduce((s, l) => s + l.qty, 0)} 件）？\n\n` +
+          `送出後**立刻扣庫存並結案**（不是待取）。\n` +
+          (addTotal > 0 ? `其中會先補 ${addTotal} 件庫存進帳。\n` : "") +
+          `打錯可在訂單頁「撤銷取貨」還原。`,
+      )
+    )
+      return;
+    setBusy(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) throw new Error("尚未登入");
+
+      // 勾了「順便建會員」→ 先開會員，再把 member_id 帶進結帳。
+      // 撞號 / 停用之類的錯誤由 rpc_upsert_member 自己吐（20260831000050 之後
+      // 它會把死號讓出來、活人回點得出名字的訊息），這裡不要自己判。
+      let memberId = member?.id ?? null;
+      if (!member && keepAsMember) {
+        const { data: mid, error: me } = await sb.rpc("rpc_upsert_member", {
+          p_id: null,
+          p_member_no: null,
+          p_phone: keepPhone.trim() || null,
+          p_name: customerName.trim(),
+          p_gender: null,
+          p_birthday: null,
+          p_email: null,
+          p_tier_id: null,
+          p_home_store_id: Number(storeId),
+          p_status: "active",
+          p_notes: "門市現場銷售建檔",
+        });
+        if (me) throw new Error(translateRpcError(me));
+        memberId = Number(mid);
+      }
+
+      const { data: res, error: e } = await sb.rpc("rpc_create_walkin_sale", {
+        p_store_id: Number(storeId),
+        p_lines: cart.map((l) => ({
+          sku_id: l.sku_id,
+          qty: l.qty,
+          unit_price: l.unit_price,
+          add_stock_qty: l.addStock,
+        })),
+        p_operator: operator,
+        p_member_id: memberId,
+        p_customer_name: member ? null : customerName.trim(),
+        p_payment_method: payment,
+        p_discount_amount: discNum,
+        p_notes: notes.trim() || null,
+      });
+      if (e) throw new Error(translateRpcError(e));
+      const r = (res ?? {}) as { order_id?: number; order_no?: string; total?: number };
+      setDone({
+        order_id: num(r.order_id),
+        order_no: r.order_no ?? "",
+        total: num(r.total),
+      });
+      // 收乾淨，準備下一位客人；商品清單重抓（庫存已經變了）
+      setCart([]);
+      setCustomerName("");
+      setMember(null);
+      setKeepAsMember(false);
+      setKeepPhone("");
+      setDiscount("");
+      setNotes("");
+      setReloadTick((t) => t + 1);
+      // 小票另開分頁，收銀畫面留在原地繼續結下一單
+      window.open(`/pos/receipt?order=${num(r.order_id)}`, "_blank", "noopener");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <h1 className="text-lg font-semibold">🛒 現場銷售</h1>
+        <span className="text-xs text-zinc-500">
+          賣給沒有訂單的現場客：送出當下扣庫存、收錢、結案
+        </span>
+        <Link href="/pos/topups" className="text-xs text-zinc-500 underline">
+          🧾 補庫存紀錄
+        </Link>
+        <span className="flex-1" />
+        {branchStoreId == null ? (
+          <select
+            value={storeId}
+            onChange={(e) => changeStore(e.target.value)}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="">選擇門市…</option>
+            {stores.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span className="rounded-md border border-zinc-200 px-3 py-1.5 text-sm dark:border-zinc-800">
+            {store?.name ?? "—"}
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="whitespace-pre-wrap rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {done && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-200">
+          <span>
+            ✅ 已結帳 <b>{done.order_no}</b>（收 ${done.total}）
+          </span>
+          <Link href={`/pos/receipt?order=${done.order_id}`} target="_blank" className="underline">
+            🧾 重印小票
+          </Link>
+          <Link href={`/orders?id=${done.order_id}`} className="underline">
+            看訂單
+          </Link>
+        </div>
+      )}
+
+      {!storeId ? (
+        <div className="rounded-md border border-zinc-200 p-6 text-center text-sm text-zinc-500 dark:border-zinc-800">
+          請先選擇門市
+        </div>
+      ) : (
+        <div className="grid gap-3 lg:grid-cols-[1fr_420px]">
+          {/* ───────── 左：商品 ───────── */}
+          <div className="rounded-lg border border-zinc-200 dark:border-zinc-800">
+            <div className="flex items-center gap-2 border-b border-zinc-200 p-2 dark:border-zinc-800">
+              <input
+                value={term}
+                onChange={(e) => setTerm(e.target.value)}
+                placeholder="🔍 商品名 / 規格 / SKU 編號 / 條碼"
+                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+              />
+              <SearchSpinner active={searching} />
+            </div>
+            <div className="max-h-[62vh] overflow-y-auto">
+              {products === null ? (
+                <div className="p-4 text-sm text-zinc-500">載入中…</div>
+              ) : products.length === 0 ? (
+                <div className="p-4 text-sm text-zinc-500">
+                  {term.trim() ? "找不到商品" : "這家店目前沒有在庫商品 —— 搜尋商品名可以找出缺貨品項"}
+                </div>
+              ) : (
+                <ul className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                  {products.map((p) => {
+                    const sellable = p.free_with_pool;
+                    const inCart = cart.find((l) => l.sku_id === p.sku_id);
+                    return (
+                      <li key={p.sku_id}>
+                        <SpinButton
+                          onClick={() => addToCart(p)}
+                          className="block w-full px-3 py-2 text-left hover:bg-zinc-50 dark:hover:bg-zinc-800/60"
+                        >
+                          <div className="flex items-baseline gap-2">
+                            <span className="min-w-0 flex-1 break-words text-sm font-medium">
+                              {skuLabel(p)}
+                            </span>
+                            <span className="whitespace-nowrap text-sm font-semibold">
+                              {p.suggest_price > 0 ? `$${p.suggest_price}` : "未設價"}
+                            </span>
+                          </div>
+                          <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-[11px] text-zinc-500">
+                            {p.sku_code && <span className="font-mono">{p.sku_code}</span>}
+                            <span
+                              className={
+                                sellable > 0
+                                  ? "font-semibold text-emerald-700 dark:text-emerald-400"
+                                  : "font-semibold text-rose-600 dark:text-rose-400"
+                              }
+                            >
+                              可賣 {sellable}
+                            </span>
+                            <span>
+                              在庫 {p.on_hand}
+                              {p.promised > 0 && ` · 待客取 ${p.promised}`}
+                              {p.waiting > 0 && ` · 等貨中 ${p.waiting}`}
+                              {p.pool_claimed > 0 && ` · 內部單 ${p.pool_claimed}`}
+                            </span>
+                            {showBranchPrice && p.branch_price != null && (
+                              <span className="rounded bg-amber-100 px-1 font-semibold text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                                分店 ${p.branch_price}
+                              </span>
+                            )}
+                            {inCart && (
+                              <span className="rounded bg-sky-100 px-1 font-semibold text-sky-800 dark:bg-sky-950 dark:text-sky-300">
+                                車內 {inCart.qty}
+                              </span>
+                            )}
+                          </div>
+                        </SpinButton>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+
+          {/* ───────── 右：結帳 ───────── */}
+          <div className="space-y-3">
+            {/* 客人 */}
+            <div className="rounded-lg border border-zinc-200 p-3 dark:border-zinc-800">
+              <div className="mb-1 text-xs text-zinc-500">客人</div>
+              {member ? (
+                <div className="flex items-center gap-2 rounded-md border border-violet-300 bg-violet-50 px-3 py-2 text-sm dark:border-violet-800 dark:bg-violet-950/40">
+                  <span className="min-w-0 flex-1">
+                    <span className="font-medium">{member.name}</span>
+                    <span className="ml-1.5 text-xs text-zinc-500">
+                      {member.member_no}
+                      {member.phone ? ` · ${member.phone}` : ""}
+                    </span>
+                  </span>
+                  <SpinButton
+                    onClick={() => setMember(null)}
+                    className="shrink-0 text-xs text-zinc-500 underline"
+                  >
+                    改現場客
+                  </SpinButton>
+                </div>
+              ) : (
+                <>
+                  <div className="flex gap-2">
+                    <input
+                      value={customerName}
+                      onChange={(e) => setCustomerName(e.target.value)}
+                      placeholder="客人名字（必填，例：王小姐）"
+                      className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                    />
+                    <SpinButton
+                      onClick={() => setMemberOpen(true)}
+                      className="shrink-0 rounded-md border border-zinc-300 px-3 py-2 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                    >
+                      選會員
+                    </SpinButton>
+                  </div>
+                  {/* Alex 決議：預設不留成會員，但要能選擇留 */}
+                  <label className="mt-2 flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-400">
+                    <input
+                      type="checkbox"
+                      checked={keepAsMember}
+                      onChange={(e) => setKeepAsMember(e.target.checked)}
+                    />
+                    順便建立為會員（不勾＝只留名字在這張單上）
+                  </label>
+                  {keepAsMember && (
+                    <input
+                      value={keepPhone}
+                      onChange={(e) => setKeepPhone(e.target.value)}
+                      placeholder="手機（選填，之後才能綁 LINE / 查訂單）"
+                      className="mt-1.5 w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+                    />
+                  )}
+                </>
+              )}
+            </div>
+
+            {/* 購物車 */}
+            <div className="rounded-lg border border-zinc-200 dark:border-zinc-800">
+              <div className="border-b border-zinc-200 px-3 py-2 text-xs text-zinc-500 dark:border-zinc-800">
+                購物車（{cart.length} 項）
+              </div>
+              {cart.length === 0 ? (
+                <div className="p-4 text-center text-sm text-zinc-500">左邊點商品加入</div>
+              ) : (
+                <ul className="max-h-[38vh] divide-y divide-zinc-100 overflow-y-auto dark:divide-zinc-800">
+                  {cart.map((l) => {
+                    const short = Math.max(0, l.qty - l.sellable);
+                    const stillShort = Math.max(0, l.qty - l.sellable - l.addStock);
+                    return (
+                      <li key={l.sku_id} className="px-3 py-2 text-sm">
+                        <div className="flex items-baseline gap-2">
+                          <span className="min-w-0 flex-1 break-words font-medium">{l.label}</span>
+                          <SpinButton
+                            onClick={() => removeLine(l.sku_id)}
+                            className="shrink-0 text-xs text-zinc-400 hover:text-rose-600"
+                            aria-label="移除"
+                          >
+                            ✕
+                          </SpinButton>
+                        </div>
+                        <div className="mt-1 flex items-center gap-2">
+                          <input
+                            type="number"
+                            min={1}
+                            value={l.qty}
+                            onChange={(e) => {
+                              const v = Math.floor(Number(e.target.value));
+                              patchLine(l.sku_id, { qty: Number.isFinite(v) ? Math.max(1, v) : 1 });
+                            }}
+                            className="w-16 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right tabular-nums dark:border-zinc-700 dark:bg-zinc-800"
+                          />
+                          <span className="text-xs text-zinc-400">×</span>
+                          <input
+                            type="number"
+                            min={0}
+                            value={l.unit_price}
+                            onChange={(e) => {
+                              const v = Number(e.target.value);
+                              patchLine(l.sku_id, { unit_price: Number.isFinite(v) ? Math.max(0, v) : 0 });
+                            }}
+                            className="w-24 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right tabular-nums dark:border-zinc-700 dark:bg-zinc-800"
+                          />
+                          <span className="flex-1 text-right font-semibold tabular-nums">
+                            ${l.qty * l.unit_price}
+                          </span>
+                        </div>
+                        {l.unit_price <= 0 && (
+                          <div className="mt-1 text-[11px] font-semibold text-rose-600 dark:text-rose-400">
+                            單價不可為 0（$0 的貨等於白送）
+                          </div>
+                        )}
+                        {short > 0 && (
+                          <div className="mt-1 rounded border border-amber-200 bg-amber-50 px-2 py-1 text-[11px] text-amber-800 dark:border-amber-900 dark:bg-amber-950/50 dark:text-amber-300">
+                            <div>
+                              可賣 <b>{l.sellable}</b> 件（在庫 {l.on_hand}
+                              {l.promised > 0 && `、待客取 ${l.promised}`}
+                              {l.waiting > 0 && `、等貨中 ${l.waiting}`}），這一列要 {l.qty} 件。
+                            </div>
+                            {canAddStock ? (
+                              <label className="mt-1 flex items-center gap-1.5">
+                                <input
+                                  type="checkbox"
+                                  checked={l.addStock > 0}
+                                  onChange={(e) =>
+                                    patchLine(l.sku_id, { addStock: e.target.checked ? short : 0 })
+                                  }
+                                />
+                                架上有貨 → 先補
+                                <input
+                                  type="number"
+                                  min={0}
+                                  value={l.addStock}
+                                  onChange={(e) => {
+                                    const v = Math.floor(Number(e.target.value));
+                                    patchLine(l.sku_id, { addStock: Number.isFinite(v) ? Math.max(0, v) : 0 });
+                                  }}
+                                  className="w-14 rounded border border-amber-300 bg-white px-1 py-0.5 text-right tabular-nums dark:border-amber-800 dark:bg-zinc-800"
+                                />
+                                件庫存
+                              </label>
+                            ) : (
+                              <div className="mt-1">
+                                架上真的有貨請找店長補庫存，或先到「庫存總覽」入帳。
+                              </div>
+                            )}
+                            {stillShort > 0 && (
+                              <div className="mt-1 font-semibold text-rose-700 dark:text-rose-400">
+                                還差 {stillShort} 件，結不了帳。
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+
+            {/* 結帳 */}
+            <div className="space-y-2 rounded-lg border border-zinc-200 p-3 dark:border-zinc-800">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-zinc-500">小計</span>
+                <span className="tabular-nums">${itemsTotal}</span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-zinc-500">整單折扣</span>
+                <input
+                  type="number"
+                  min={0}
+                  value={discount}
+                  onChange={(e) => {
+                    const v = Number(e.target.value);
+                    setDiscount(e.target.value === "" ? "" : Number.isFinite(v) ? Math.max(0, v) : 0);
+                  }}
+                  placeholder="0"
+                  className="w-24 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right tabular-nums dark:border-zinc-700 dark:bg-zinc-800"
+                />
+              </div>
+              <div className="flex items-center justify-between border-t border-zinc-200 pt-2 dark:border-zinc-800">
+                <span className="text-sm text-zinc-500">應收</span>
+                <span className="text-xl font-bold tabular-nums">${total}</span>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {payOptions.map((o) => (
+                  <SpinButton
+                    key={o}
+                    onClick={() => setPayPick(o)}
+                    className={`rounded-md border px-3 py-1.5 text-xs ${
+                      payment === o
+                        ? "border-sky-500 bg-sky-50 font-semibold text-sky-800 dark:bg-sky-950 dark:text-sky-300"
+                        : "border-zinc-300 dark:border-zinc-700"
+                    }`}
+                  >
+                    {PAY_LABEL[o] ?? o}
+                  </SpinButton>
+                ))}
+              </div>
+              <input
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="備註（選填）"
+                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+              />
+              {addTotal > 0 && (
+                <div className="rounded border border-amber-200 bg-amber-50 px-2 py-1.5 text-[11px] text-amber-800 dark:border-amber-900 dark:bg-amber-950/50 dark:text-amber-300">
+                  這筆會先補 <b>{addTotal}</b> 件庫存進帳（留下「現場銷售即時入帳」紀錄）。
+                  常常要補代表帳跟實體長期對不上，記得排一次盤點。
+                </div>
+              )}
+              <SpinButton
+                onClick={checkout}
+                disabled={!canCheckout}
+                className="w-full rounded-md bg-sky-600 px-4 py-2.5 font-semibold text-white hover:bg-sky-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
+              >
+                {busy
+                  ? "結帳中…"
+                  : cart.length === 0
+                    ? "購物車是空的"
+                    : !member && !customerName.trim()
+                      ? "請先填客人名字"
+                      : `結帳 $${total}`}
+              </SpinButton>
+              <div className="text-center text-[11px] text-zinc-400">
+                送出＝當場交貨並扣庫存（不是待取）。打錯可在訂單頁「撤銷取貨」。
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <Modal open={memberOpen} onClose={() => setMemberOpen(false)} title="選會員" maxWidth="max-w-md">
+        <div className="space-y-2 text-sm">
+          <input
+            value={mTerm}
+            onChange={(e) => setMTerm(e.target.value)}
+            placeholder="🔍 姓名 / 電話 / 會員編號…"
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          {mSearching && mHits.length === 0 && <div className="text-xs text-zinc-500">搜尋中…</div>}
+          <div className="max-h-72 overflow-y-auto rounded-md border border-zinc-200 dark:border-zinc-700">
+            {mHits.map((m) => (
+              <SpinButton
+                key={m.id}
+                onClick={() => {
+                  setMember(m);
+                  setMemberOpen(false);
+                  setMTerm("");
+                  setKeepAsMember(false);
+                }}
+                disabled={m.no_new_order}
+                title={m.no_new_order ? "此會員已被標記為不可新增訂單" : undefined}
+                className="block w-full border-b border-zinc-100 px-3 py-2 text-left last:border-b-0 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:hover:bg-zinc-800"
+              >
+                <span className="font-medium">{m.name}</span>
+                <span className="ml-1.5 text-xs text-zinc-500">
+                  {m.member_no}
+                  {m.phone ? ` · ${m.phone}` : ""}
+                  {m.home_store_name ? ` · ${m.home_store_name}` : ""}
+                </span>
+              </SpinButton>
+            ))}
+          </div>
+          <div className="text-[11px] text-zinc-400">
+            不選會員也可以結帳 —— 訂單會掛在該店的「現場客」帳號下，名字記在單上。
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(protected)/pos/receipt/page.tsx
+++ b/apps/admin/src/app/(protected)/pos/receipt/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+// 現場銷售小票（80mm 感熱紙）。版型比照 /pickup/print-list：
+// @page size 80mm auto、等寬字、載入完自動跳列印。
+//
+// 它讀的是**已經結完帳的訂單**（WS- 單，品項一律 picked_up），所以可以重印 ——
+// 客人要收據、或第一次沒印出來，回訂單頁點連結就好。
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { getSupabase } from "@/lib/supabase";
+import SpinButton from "@/components/SpinButton";
+
+type Item = {
+  id: number;
+  qty: number;
+  unit_price: number;
+  status: string;
+  sku: { sku_code: string | null; product_name: string | null; variant_name: string | null } | null;
+};
+
+type Order = {
+  id: number;
+  order_no: string;
+  status: string;
+  nickname_snapshot: string | null;
+  discount_amount: number;
+  payment_method: string | null;
+  notes: string | null;
+  created_at: string;
+  member: { member_no: string; name: string | null; phone: string | null } | null;
+  store: { name: string } | null;
+};
+
+const PAY_LABEL: Record<string, string> = {
+  cash: "現金",
+  transfer: "轉帳",
+  credit_card: "刷卡",
+  linepay: "LINE Pay",
+  wallet: "儲值金",
+};
+
+function itemName(it: Item): string {
+  const a = (it.sku?.product_name ?? "").trim();
+  const b = (it.sku?.variant_name ?? "").trim();
+  if (a && b && a !== b) return `${a} / ${b}`;
+  return a || b || it.sku?.sku_code || "—";
+}
+
+function ReceiptInner() {
+  const sp = useSearchParams();
+  const orderId = sp.get("order");
+  const [order, setOrder] = useState<Order | null>(null);
+  const [items, setItems] = useState<Item[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  // 缺參數是「算得出來」的狀態，不要在 effect 裡 setState（cascading render）
+  const error = loadError ?? (orderId ? null : "缺少訂單編號");
+
+  useEffect(() => {
+    if (!orderId) return;
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const [{ data: o, error: oe }, { data: its, error: ie }] = await Promise.all([
+        sb
+          .from("customer_orders")
+          .select(
+            "id, order_no, status, nickname_snapshot, discount_amount, payment_method, notes, created_at, member:members(member_no, name, phone), store:stores!customer_orders_pickup_store_id_fkey(name)",
+          )
+          .eq("id", Number(orderId))
+          .maybeSingle(),
+        sb
+          .from("customer_order_items")
+          .select("id, qty, unit_price, status, sku:skus(sku_code, product_name, variant_name)")
+          .eq("order_id", Number(orderId))
+          .order("id"),
+      ]);
+      if (cancelled) return;
+      if (oe || ie) {
+        setLoadError((oe ?? ie)?.message ?? "讀取失敗");
+        return;
+      }
+      if (!o) {
+        setLoadError("找不到訂單");
+        return;
+      }
+      setOrder(o as unknown as Order);
+      // 取消 / 作廢的列不印（客人沒付那些錢）
+      setItems(
+        ((its as unknown as Item[]) ?? []).filter((it) => !["cancelled", "expired"].includes(it.status)),
+      );
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [orderId]);
+
+  useEffect(() => {
+    if (order && items) {
+      const t = setTimeout(() => window.print(), 400);
+      return () => clearTimeout(t);
+    }
+  }, [order, items]);
+
+  if (error) return <div className="p-4 text-sm text-red-700">{error}</div>;
+  if (!order || !items) return <div className="p-4 text-sm text-zinc-500">載入中…</div>;
+
+  const subtotal = items.reduce((s, it) => s + Number(it.qty) * Number(it.unit_price), 0);
+  const disc = Number(order.discount_amount ?? 0);
+  const total = Math.max(0, subtotal - disc);
+  const totalQty = items.reduce((s, it) => s + Number(it.qty), 0);
+  const who = order.nickname_snapshot?.trim() || order.member?.name || "現場客";
+
+  return (
+    <>
+      <style jsx global>{`
+        @media print {
+          @page { margin: 3mm; size: 80mm auto; }
+          body { background: white !important; }
+          .no-print { display: none !important; }
+        }
+        body { background: #f0f0f0; }
+      `}</style>
+      <div className="mx-auto my-4 max-w-[80mm] bg-white p-3 font-mono text-[14px] leading-tight text-black shadow print:my-0 print:shadow-none">
+        <div className="no-print mb-3 flex justify-end gap-2">
+          <SpinButton onClick={() => window.print()} className="rounded bg-zinc-900 px-3 py-1 text-xs text-white">
+            🖨️ 列印
+          </SpinButton>
+          <SpinButton onClick={() => window.close()} className="rounded border border-zinc-300 px-3 py-1 text-xs">
+            關閉
+          </SpinButton>
+        </div>
+
+        <div className="text-center">
+          <div className="text-[20px] font-bold">{order.store?.name ?? "門市"}</div>
+          <div className="text-[13px]">銷售明細</div>
+        </div>
+
+        <div className="mt-2 border-y border-dashed border-black py-1.5 text-[13px]">
+          <div className="text-[16px] font-bold">{who}</div>
+          {order.member && !order.member.member_no.startsWith("WALKIN-") && (
+            <div>
+              {order.member.member_no}
+              {order.member.phone && <span className="ml-2">{order.member.phone}</span>}
+            </div>
+          )}
+          <div>單號：{order.order_no}</div>
+          <div>{new Date(order.created_at).toLocaleString("zh-TW", { hour12: false })}</div>
+        </div>
+
+        <div className="mt-2 divide-y divide-dashed divide-zinc-300">
+          {items.map((it) => (
+            <div key={it.id} className="py-1">
+              <div className="break-words text-[15px] font-bold">{itemName(it)}</div>
+              <div className="flex justify-between text-[14px]">
+                <span>
+                  {Number(it.qty)} × ${Number(it.unit_price)}
+                </span>
+                <span className="font-bold">${Number(it.qty) * Number(it.unit_price)}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-2 border-t border-dashed border-black pt-1.5 text-[14px]">
+          <div className="flex justify-between">
+            <span>件數</span>
+            <span>{totalQty}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>小計</span>
+            <span>${subtotal}</span>
+          </div>
+          {disc > 0 && (
+            <div className="flex justify-between font-bold">
+              <span>折扣</span>
+              <span>-${disc}</span>
+            </div>
+          )}
+          <div className="mt-1 flex justify-between border-t border-black pt-1 text-[18px] font-bold">
+            <span>應收</span>
+            <span>${total}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>付款</span>
+            <span>{PAY_LABEL[order.payment_method ?? ""] ?? order.payment_method ?? "—"}</span>
+          </div>
+        </div>
+
+        <div className="mt-3 text-center text-[12px]">謝謝惠顧</div>
+      </div>
+    </>
+  );
+}
+
+export default function PosReceiptPage() {
+  return (
+    <Suspense fallback={<div className="p-4 text-sm text-zinc-500">載入中…</div>}>
+      <ReceiptInner />
+    </Suspense>
+  );
+}

--- a/apps/admin/src/app/(protected)/pos/topups/page.tsx
+++ b/apps/admin/src/app/(protected)/pos/topups/page.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+// 現場銷售「結帳時補庫存」稽核紀錄。
+//
+// 為什麼要有這一頁：結帳畫面上的「架上有貨 → 先補 N 件庫存」是全站少數
+// **憑空生庫存**的入口。它解掉了店員的真實困境（貨在架上、帳上沒有、客人就站
+// 在櫃台前），但沒有人看得到補了多少的話，權宜之計會變成日常，帳與實體越差
+// 越遠而完全沒有訊號 —— CLAUDE.md 記過的幽靈庫存災情都是這個形狀。
+//
+// 這一頁就是那個訊號面板：同一家店天天在補 = 帳跟實體長期脫節，該排盤點。
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
+import { translateRpcError } from "@/lib/rpcError";
+import { useUserBranchStoreId, useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
+
+type StoreRow = { id: number; name: string; location_id: number | null };
+
+type SummaryRow = {
+  ymd: string;
+  store_id: number;
+  store_name: string;
+  movements: number;
+  qty: number;
+  skus: number;
+  operators: number;
+  orders: number;
+};
+
+type DetailRow = {
+  movement_id: number;
+  created_at: string;
+  store_name: string;
+  sku_code: string | null;
+  product_name: string | null;
+  variant_name: string | null;
+  qty: number;
+  unit_cost: number | null;
+  order_no: string | null;
+  operator_id: string | null;
+};
+
+// 日界跟 RPC 一樣切在台北，不然「今天」在午夜前後兩邊會對不上
+function taipeiDate(offsetDays = 0): string {
+  return new Date(Date.now() + 8 * 3600 * 1000 - offsetDays * 86400000).toISOString().slice(0, 10);
+}
+
+function label(r: DetailRow): string {
+  const a = (r.product_name ?? "").trim();
+  const b = (r.variant_name ?? "").trim();
+  if (a && b && a !== b) return `${a} / ${b}`;
+  return a || b || r.sku_code || "—";
+}
+
+export default function PosTopupsPage() {
+  const [stores, setStores] = useState<StoreRow[]>([]);
+  const [pickedStoreId, setPickedStoreId] = useState<string>("");
+  const branchStoreId = useUserBranchStoreId(stores);
+  // 分店帳號鎖自己店（衍生值，不在 effect 裡 setState）
+  const storeId = branchStoreId != null ? String(branchStoreId) : pickedStoreId;
+  useDefaultStoreFromUser(stores, pickedStoreId, setPickedStoreId, branchStoreId == null);
+
+  const [from, setFrom] = useState(taipeiDate(30));
+  const [to, setTo] = useState(taipeiDate(0));
+  const [summary, setSummary] = useState<SummaryRow[] | null>(null);
+  const [rows, setRows] = useState<DetailRow[] | null>(null);
+  const [qtyTotal, setQtyTotal] = useState(0);
+  const [rowsTotal, setRowsTotal] = useState(0);
+  const [staffNames, setStaffNames] = useState<Map<string, string>>(new Map());
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data, error: e } = await getSupabase()
+        .from("stores")
+        .select("id, name, location_id")
+        .eq("is_active", true)
+        .order("name");
+      if (cancelled) return;
+      if (e) setError(e.message);
+      else setStores((data as StoreRow[]) ?? []);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const sb = getSupabase();
+      const { data, error: e } = await sb.rpc("rpc_walkin_stock_topups", {
+        p_store_id: storeId ? Number(storeId) : null,
+        p_date_from: from || null,
+        p_date_to: to || null,
+      });
+      if (cancelled) return;
+      if (e) {
+        setError(translateRpcError(e));
+        setSummary([]);
+        setRows([]);
+        return;
+      }
+      setError(null);
+      const d = (data ?? {}) as Record<string, unknown>;
+      const rs = (d.rows as DetailRow[]) ?? [];
+      setSummary((d.summary as SummaryRow[]) ?? []);
+      setRows(rs);
+      setQtyTotal(Number(d.qty_total ?? 0));
+      setRowsTotal(Number(d.rows_total ?? 0));
+
+      const uids = Array.from(new Set(rs.map((r) => r.operator_id).filter((x): x is string => !!x)));
+      if (uids.length === 0) return;
+      const { data: ns } = await sb.rpc("rpc_get_staff_names", { p_uids: uids });
+      if (cancelled) return;
+      const m = new Map<string, string>();
+      for (const n of (ns as { id: string; display_name: string }[] | null) ?? []) {
+        m.set(n.id, n.display_name);
+      }
+      setStaffNames(m);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [storeId, from, to]);
+
+  // 區間內補過幾天 —— 天數多＝常態性補帳，那是盤點問題，不是結帳問題
+  const busyStores = useMemo(() => {
+    const m = new Map<string, { name: string; days: number; qty: number }>();
+    for (const s of summary ?? []) {
+      const cur = m.get(s.store_name) ?? { name: s.store_name, days: 0, qty: 0 };
+      cur.days += 1;
+      cur.qty += Number(s.qty);
+      m.set(s.store_name, cur);
+    }
+    return [...m.values()].filter((x) => x.days >= 3).sort((a, b) => b.qty - a.qty);
+  }, [summary]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <h1 className="text-lg font-semibold">🧾 現場銷售補庫存紀錄</h1>
+        <span className="text-xs text-zinc-500">結帳當下「架上有貨、帳上沒有」而補進來的庫存</span>
+        <span className="flex-1" />
+        <Link href="/pos" className="text-sm underline">
+          ← 回現場銷售
+        </Link>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        {branchStoreId == null && (
+          <select
+            value={pickedStoreId}
+            onChange={(e) => setPickedStoreId(e.target.value)}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="">全部門市</option>
+            {stores.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        )}
+        <input
+          type="date"
+          value={from}
+          onChange={(e) => setFrom(e.target.value)}
+          className="rounded-md border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+        />
+        <span className="text-zinc-400">～</span>
+        <input
+          type="date"
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+          className="rounded-md border border-zinc-300 bg-white px-2 py-1.5 dark:border-zinc-700 dark:bg-zinc-800"
+        />
+        <span className="text-xs text-zinc-500">
+          共 {rowsTotal} 筆 / {qtyTotal} 件
+        </span>
+      </div>
+
+      {busyStores.length > 0 && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/60 dark:text-amber-200">
+          這幾家店在這段期間經常要補帳，代表帳跟架上長期對不起來 —— 補帳只是應急，
+          該排一次盤點把數字重新對齊：
+          <ul className="mt-1 list-inside list-disc">
+            {busyStores.map((s) => (
+              <li key={s.name}>
+                {s.name}：{s.days} 天、共 {s.qty} 件
+              </li>
+            ))}
+          </ul>
+          <Link href="/inventory/stocktake" className="mt-1 inline-block underline">
+            → 去盤點
+          </Link>
+        </div>
+      )}
+
+      <div>
+        <div className="mb-1 text-xs text-zinc-500">依日期 × 分店</div>
+        <Table>
+          <THead>
+            <Tr>
+              <Th>日期</Th>
+              <Th>分店</Th>
+              <Th className="text-right">筆數</Th>
+              <Th className="text-right">件數</Th>
+              <Th className="text-right">品項數</Th>
+              <Th className="text-right">單數</Th>
+              <Th className="text-right">操作人</Th>
+            </Tr>
+          </THead>
+          <TBody>
+            {summary === null ? (
+              <LoadingRow colSpan={7} />
+            ) : summary.length === 0 ? (
+              <EmptyRow colSpan={7}>這段期間沒有補庫存紀錄 👍</EmptyRow>
+            ) : (
+              summary.map((s) => (
+                <Tr key={`${s.ymd}-${s.store_id}`}>
+                  <Td>{s.ymd}</Td>
+                  <Td>{s.store_name}</Td>
+                  <Td className="text-right tabular-nums">{s.movements}</Td>
+                  <Td className="text-right font-semibold tabular-nums">{Number(s.qty)}</Td>
+                  <Td className="text-right tabular-nums">{s.skus}</Td>
+                  <Td className="text-right tabular-nums">{s.orders}</Td>
+                  <Td className="text-right tabular-nums">{s.operators}</Td>
+                </Tr>
+              ))
+            )}
+          </TBody>
+        </Table>
+      </div>
+
+      <div>
+        <div className="mb-1 text-xs text-zinc-500">明細（最多 500 筆，新到舊）</div>
+        <Table>
+          <THead>
+            <Tr>
+              <Th>時間</Th>
+              <Th>分店</Th>
+              <Th>商品</Th>
+              <Th className="text-right">補入</Th>
+              <Th>單號</Th>
+              <Th>操作人</Th>
+            </Tr>
+          </THead>
+          <TBody>
+            {rows === null ? (
+              <LoadingRow colSpan={6} />
+            ) : rows.length === 0 ? (
+              <EmptyRow colSpan={6}>沒有紀錄</EmptyRow>
+            ) : (
+              rows.map((r) => (
+                <Tr key={r.movement_id}>
+                  <Td className="whitespace-nowrap text-xs">
+                    {new Date(r.created_at).toLocaleString("zh-TW", { hour12: false })}
+                  </Td>
+                  <Td className="whitespace-nowrap">{r.store_name}</Td>
+                  <Td>
+                    <div className="break-words">{label(r)}</div>
+                    {r.sku_code && (
+                      <div className="font-mono text-[11px] text-zinc-500">{r.sku_code}</div>
+                    )}
+                  </Td>
+                  <Td className="text-right font-semibold tabular-nums text-amber-700 dark:text-amber-400">
+                    +{Number(r.qty)}
+                  </Td>
+                  <Td className="whitespace-nowrap font-mono text-xs">{r.order_no ?? "—"}</Td>
+                  <Td className="whitespace-nowrap text-xs">
+                    {r.operator_id ? (staffNames.get(r.operator_id) ?? r.operator_id.slice(0, 8)) : "—"}
+                  </Td>
+                </Tr>
+              ))
+            )}
+          </TBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/lib/orderSource.ts
+++ b/apps/admin/src/lib/orderSource.ts
@@ -35,6 +35,7 @@ export const ORDER_ITEM_SOURCES = [
   "rollover",
   "store_internal",
   "aid_transfer",
+  "walk_in",
 ] as const;
 
 export type OrderItemSource = (typeof ORDER_ITEM_SOURCES)[number];
@@ -58,10 +59,13 @@ export const ORDER_SOURCE_META: Record<OrderItemSource, SourceMeta> = {
   rollover:         { label: "缺貨遞轉", short: "遞轉",   icon: "↪️", cls: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300" },
   store_internal:   { label: "店長叫貨", short: "店叫",   icon: "🏬", cls: "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300" },
   aid_transfer:     { label: "互助轉手", short: "互助",   icon: "🤝", cls: "bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-300" },
+  walk_in:          { label: "現場銷售", short: "現場",   icon: "🛒", cls: "bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-300" },
 };
 
 // 訂單頁「下單來源」折線圖 KPI 的線 —— 只放「人是怎麼下這張單的」三個通路，
 // 系統流程（遞轉/互助/匯入…）不畫線，它們不是通路消長的一部分。
+// ⚠ walk_in（現場銷售）刻意不放：那是臨櫃結帳，不是線上通路，
+//   混進來會讓「App / 商城 / 小幫手」的消長圖說謊。
 // color 直接寫死 rgb：SVG stroke 吃不到 Tailwind class，且深/淺色模式共用同一組
 // （這三個色相在兩種底色上都夠對比）。順序＝圖例順序。
 export const SOURCE_TREND_SERIES: { source: OrderItemSource; label: string; color: string }[] = [

--- a/apps/admin/src/lib/orderTitle.ts
+++ b/apps/admin/src/lib/orderTitle.ts
@@ -67,6 +67,9 @@ export type InternalOrderSource = { label: string; hint: string };
 export function internalOrderSource(orderNo: string | null | undefined): InternalOrderSource | null {
   const no = (orderNo ?? "").trim();
   if (!no) return null;
+  if (no.startsWith("WS-")) {
+    return { label: "🛒 現場銷售", hint: "門市臨櫃結帳，當場交貨扣庫存（開單即完成）" };
+  }
   if (no.startsWith("SP-")) {
     return { label: "🤝 現貨直配", hint: "店內現貨直接配給客人（待取，取貨時才扣庫存收款）" };
   }

--- a/docs/PLAN-現場銷售POS.md
+++ b/docs/PLAN-現場銷售POS.md
@@ -1,6 +1,6 @@
 # PLAN — 現場銷售（門市 POS：沒有訂單的現場客，當場結帳當場扣庫存）
 
-> 狀態：**規劃中，尚未施工**。需求人：Alex（2026-09-01）。
+> 狀態：**規劃已定案（Alex 2026-09-01 回覆四個問題 + 追加訂單頁需求），施工中**。需求人：Alex。
 > 需求原文：「有店家想要賣現場客，但是沒有訂單，然後又想要維護庫存，
 > 可以做一個現場銷售的功能，像是一般超商那樣，可以依照人名跟商品庫存來產生一筆訂單，
 > 並且扣掉庫存，然後銷售當下有可能很多商品沒有庫存，可以在同一個地方假如沒庫存就自動增加一筆記錄到庫存」。
@@ -77,6 +77,8 @@
 
 1. **有會員** → 用既有 `rpc_search_members` 選（跟 `SpotSaleModal` 同一套），訂單掛在他名下，會員中心 / LINE 通知照常。
 2. **純現場客** → 掛在**每店一筆**的「現場客」假會員（`member_type='guest'`、`member_no` 例如 `WALKIN-<store_id>`），**人名存 `nickname_snapshot`**。
+3. **現場客要留下來** → 結帳畫面上一顆「☐ 建立為會員」，勾了就用輸入的名字（＋選填手機）開一筆正式會員，訂單直接掛他名下。
+   **預設不勾**（Alex 決議）。手機有填就會走 `rpc_upsert_member` 的撞號路徑 —— 那支 20260831000050 之後會把死號讓出來、活人吐出點得出名字的錯誤，不要自己另外寫一套。
 
 為什麼不替每個現場客開一筆會員：
 
@@ -105,7 +107,7 @@ CLAUDE.md 已經記過：`payment_status` 全站永遠是 `unpaid`，`WHERE paym
 
 現場銷售如果開始寫 `'paid'`，這些地方的行為會突然改變（而且是靜默的）。
 「收到錢了」用既有語意表達就好：**品項 `picked_up`** → `v_customer_order_summary.outstanding_amount` 自動是 0。
-要分現金 / 轉帳做日結分項，用 `payment_method` 欄位（目前沒人寫）+ 日結報表多一個 group by。
+**付款方式做成可選、預設現金**（Alex 決議）：選項來源 `stores.allowed_payment_methods`（預設 `["cash"]`），寫進 `payment_method` 欄位（目前全站沒人寫），日結報表多一個 group by。
 
 ---
 
@@ -162,7 +164,7 @@ rpc_create_walkin_sale(
 
 1. **成本要帶**：`manual_adjust` 不帶成本時，若該倉 `avg_cost` 是 0，後面那筆 `sale` 的 COGS 就是 0、毛利虛高。
    補帳時帶 `_current_cost_price(tenant, sku)` 當 fallback（同 `_air_ship_order_items` 的做法）。
-2. **權限**：預設只有 `store_manager` 以上可以用；`store_staff` 看得到缺貨提示但按不下去（前端擋 + RPC 再擋一次，
+2. **權限（Alex 決議：店長）**：只有 `store_manager` 以上可以用；`store_staff` 看得到缺貨提示但按不下去（前端擋 + RPC 再擋一次，
    「按鈕拿掉但 EXECUTE 還通等於沒停」—— 自由轉貨那次的教訓）。
 3. **單頭留痕**：notes 寫「本單有 N 件是現場補帳（未經收貨）」，`/orders` 明細看得到。
 4. **報表**：新增一張「現場銷售補庫存」清單（依店 / 日期 / 操作人 / SKU / 數量），
@@ -205,7 +207,7 @@ rpc_create_walkin_sale(
 - 單價 0 要擋（零元守衛的同一個理由：$0 = 把貨白送出去）。
 - 缺貨列一律顯示拆解「在庫 X、待客取 Y、等貨中 Z」，不要只寫「可賣 0」——
   那正是 8/24「調整庫存完不能把庫存再轉出去」那次店員繞不出來的原因。
-- 結帳完直接出小票（可重用 `/pickup/print` 的版型）。
+- **結帳完直接出小票（Alex 決議：要）** —— 列為 P0，不是 P1。版型重用 `/pickup/print`，走 `/pos/receipt?order=<id>`：店名、單號、日期、人名、逐列品項 / 數量 / 單價 / 小計、折扣、合計、付款方式、操作人。
 
 ---
 
@@ -240,9 +242,11 @@ rpc_create_walkin_sale(
 |---|---|---|
 | 1 | migration A：唯一索引 predicate 加 `order_no !~~ 'WS-%'`；每店建立「現場客」guest 會員的 helper `_walkin_member(store)` | SQL |
 | 2 | migration B：`rpc_create_walkin_sale`（含店家守衛、free_with_pool 閘門、缺貨補帳、扣池、pickup event） | SQL |
-| 3 | migration C：`rpc_get_stock_commitment_bulk` 擴充建議售價欄位（一次撈，不要 per-row LATERAL） | SQL |
-| 4 | 前端 `/pos` 頁 + 側欄入口 + 小票 | TSX |
-| 5 | 日結分項 + 補庫存報表 | SQL + TSX |
+| 3 | migration C：`customer_order_items.source` CHECK 加 `walk_in`；`rpc_get_stock_commitment_bulk` 擴充建議售價欄位（一次撈，不要 per-row LATERAL） | SQL |
+| 4 | 前端 `/pos` 頁 + 側欄入口 | TSX |
+| 5 | 小票 `/pos/receipt`（P0，決議 4） | TSX |
+| 6 | 訂單頁調整：`internalOrderSource()` 加 `WS-`（admin + member 兩份）、`walk_in` badge、`/orders` 快篩 | TSX |
+| 7 | 日結分項（付款方式）+ 補庫存報表 | SQL + TSX |
 
 每支 migration 送出前：
 
@@ -269,9 +273,54 @@ git fetch origin main -q && git ls-tree --name-only origin/main supabase/migrati
 
 ---
 
-## 11. 要 Alex 決定的四件事
+## 11. 決議（Alex 2026-09-01）
 
-1. **現場客要不要留成會員？** 建議：預設不留（只存名字），要留就在同一個畫面選「建立會員」。
-2. **缺貨補庫存誰能按？** 建議：店長以上；店員只看得到提示。
-3. **付款方式要分嗎？** 建議：現金 / 轉帳兩個，日結分項。
-4. **要印小票嗎？** 建議 P1（版型可重用取貨單）。
+| # | 問題 | 決議 |
+|---|---|---|
+| 1 | 現場客要不要留成會員？ | **預設不留，但畫面上要能選擇留**（勾「建立為會員」）→ §3.2 第 3 點 |
+| 2 | 缺貨補庫存誰能按？ | **店長（`store_manager` 以上）** → §5.2 |
+| 3 | 付款方式要分嗎？ | **做成選項、預設現金** → §3.3 |
+| 4 | 要印小票嗎？ | **要**，列入 P0 → §6 |
+| 5 | （追加）訂單頁 | 現場銷售**要產生訂單**，但**不跟著任何團** → 見 §12 |
+
+---
+
+## 12. 訂單頁的調整（Alex 追加）
+
+現場銷售會產生一張真的顧客訂單，但它不屬於任何團。系統裡**已經有這條路**：
+現貨直配 / 補貨 / 轉單的單一律掛在共用假團 `__INTERNAL_RESTOCK__`「【內部】補貨申請」底下，
+而訂單列表與明細早就會把那個名字換掉、改標「實際來源」（2026-08-16 回報後做的）。
+現場銷售**接上同一套**就好，不要另外發明。
+
+### 12.1 已經現成、只要接上去的
+
+| 位置 | 現成機制 | 要做的事 |
+|---|---|---|
+| `/orders` 列表的「開團」欄 | `CampaignOrSource`：`campaign_no` 以 `__` 開頭 → 改印 `internalOrderSource(order_no)` | 在 `internalOrderSource()` 加 `WS-` → **「🛒 現場銷售」**／hint「門市現場結帳，當場扣庫存收款」 |
+| 訂單明細的「開團」欄 | `OrderDetail` 同一段判斷 | 同上，一改兩處都生效 |
+| 會員 App 的訂單卡標題 | `orderCardTitle()`：內部團改印品項名 | 自動生效（`WS-` 掛 sentinel 團）。⚠ `lib/orderTitle.ts` 在 admin 與 member **各有一份副本**，改一定要兩邊一起改 |
+| 手機卡片的品項名 | `itemLabel()`：開團名 ≠ 商品名時補上商品名 | 自動生效 |
+
+### 12.2 要新增的
+
+1. **品項來源新增 `walk_in`**（`customer_order_items.source`）。
+   照 `lib/orderSource.ts` 檔頭寫好的三步驟做：
+   (a) 加進 `ORDER_ITEM_SOURCES` + `ORDER_SOURCE_META`（label「現場銷售」/ short「現場」/ icon 🛒）；
+   (b) migration 改 CHECK constraint（現行 `20260808000020_order_item_source_pwa.sql`）；
+   (c) **不要**加進 `SOURCE_TREND_SERIES` —— 那張折線圖只畫「人是怎麼下這張單的」三個通路（App / 商城 / 小幫手），
+   現場銷售不是線上通路，混進去會讓通路消長的圖說謊。
+2. **`/orders` 加一個「現場銷售」快篩**（單號前綴 `WS-`），店長對帳時要能一眼把今天的現場單撈出來。
+3. **訂單明細對 `WS-` 單要收掉不適用的動作**：轉單給別人、標到貨、少發配貨、催取貨通知 ——
+   單頭出生就是 `completed`，多數按鈕本來就不會出現，但要逐一確認（尤其「轉單給客人」，
+   貨已經交出去了還能轉會生出幽靈品項，那正是 20260810010000 修過的那類 bug）。
+   留著的只有：撤銷取貨、退貨、改備註。
+4. **明細上要標「本單有 N 件是現場補帳」**（§5.3），並列出那幾筆 `manual_adjust`。
+
+### 12.3 明確不做
+
+- **不新開 sentinel 團給現場銷售用。** 共用 `__INTERNAL_RESTOCK__` 是刻意的：全站 10+ 處濾網
+  （`campaigns`、`purchase/requests`、`ProductCampaignsPanel`、`/shop`…）都寫死排除它，
+  另開一個新 sentinel 只要漏掉一處，現場銷售的假團就會外顯給客人看到。
+- **不新增 `order_kind`。** 理由同 §3.1。
+- **不改 `v_admin_orders_list` 的口徑。** 現場銷售是 `order_kind='normal'` 的正常單，
+  本來就該進訂單數 / 金額 / 營收；要區分靠來源 badge 與快篩，不是靠把它從母體挖掉。

--- a/docs/PLAN-現場銷售POS.md
+++ b/docs/PLAN-現場銷售POS.md
@@ -1,6 +1,7 @@
 # PLAN — 現場銷售（門市 POS：沒有訂單的現場客，當場結帳當場扣庫存）
 
-> 狀態：**規劃已定案（Alex 2026-09-01 回覆四個問題 + 追加訂單頁需求），施工中**。需求人：Alex。
+> 狀態：**P0 已施工完成，尚未部署正式庫**（2026-09-01）。分支 `claude/point-of-sale-feature-plan-ezpz4x`。
+> 需求人：Alex。決議見 §11、施工結果見 §9。
 > 需求原文：「有店家想要賣現場客，但是沒有訂單，然後又想要維護庫存，
 > 可以做一個現場銷售的功能，像是一般超商那樣，可以依照人名跟商品庫存來產生一筆訂單，
 > 並且扣掉庫存，然後銷售當下有可能很多商品沒有庫存，可以在同一個地方假如沒庫存就自動增加一筆記錄到庫存」。
@@ -53,6 +54,20 @@
 | 成本 / 均成本 | `stock_movements('sale')` | 毛利算不出來 |
 
 **結論：現場銷售就是一張顧客訂單，只是它出生的時候就已經取完貨了。**
+
+### ⚠ 不要用 day-1 留下來的 `pos_sales`
+
+線上**真的有**一組 `pos_sales` / `pos_sale_items` 表，還有一支 `rpc_complete_pos_sale`
+（`20260422120005_sales_schema.sql`，通用 ERP 骨架）。看起來像正主，但它是死的：
+
+| 檢查 | 結果 |
+|---|---|
+| `pos_sales` 資料 | **0 筆** |
+| `pos_sale_items` 資料 | **0 筆** |
+| 前端引用 | **完全沒有**（`grep -rn "pos_sale" apps/` 沒有命中） |
+| `pos_sales.customer_id` 指向 | `customers` 表 —— 也是 **0 筆**，全站其實用 `members` |
+
+它跟現在這套系統（會員、團購、取貨、日結）沒有任何接點。用它等於重蓋一套平行帳。
 
 ---
 
@@ -238,15 +253,29 @@ rpc_create_walkin_sale(
 
 ## 9. 施工順序
 
-| # | 內容 | 產出 |
-|---|---|---|
-| 1 | migration A：唯一索引 predicate 加 `order_no !~~ 'WS-%'`；每店建立「現場客」guest 會員的 helper `_walkin_member(store)` | SQL |
-| 2 | migration B：`rpc_create_walkin_sale`（含店家守衛、free_with_pool 閘門、缺貨補帳、扣池、pickup event） | SQL |
-| 3 | migration C：`customer_order_items.source` CHECK 加 `walk_in`；`rpc_get_stock_commitment_bulk` 擴充建議售價欄位（一次撈，不要 per-row LATERAL） | SQL |
-| 4 | 前端 `/pos` 頁 + 側欄入口 | TSX |
-| 5 | 小票 `/pos/receipt`（P0，決議 4） | TSX |
-| 6 | 訂單頁調整：`internalOrderSource()` 加 `WS-`（admin + member 兩份）、`walk_in` badge、`/orders` 快篩 | TSX |
-| 7 | 日結分項（付款方式）+ 補庫存報表 | SQL + TSX |
+| # | 內容 | 檔案 | 狀態 |
+|---|---|---|---|
+| 1 | 唯一索引 predicate 加 `order_no NOT LIKE 'WS-%'`、`source` CHECK 加 `walk_in`、`_walkin_member(tenant, store)` | `20260901000000_walkin_sale_schema.sql` | ✅ |
+| 2 | `rpc_create_walkin_sale`（店家守衛、free_with_pool 閘門、缺貨補帳、扣池、pickup event） | `20260901000010_rpc_create_walkin_sale.sql` | ✅ |
+| 3 | `rpc_pos_search_products`（結帳頁商品搜尋，一次撈可賣量＋售價） | `20260901000020_rpc_pos_search_products.sql` | ✅ |
+| 4 | 補庫存稽核報表 `rpc_walkin_stock_topups` | `20260901000030_rpc_walkin_stock_topups.sql` | ✅ |
+| 5 | 結帳頁 + 側欄入口 | `app/(protected)/pos/page.tsx`、`layout.tsx` | ✅ |
+| 6 | 小票（80mm，決議 4） | `app/(protected)/pos/receipt/page.tsx` | ✅ |
+| 7 | 補庫存紀錄頁（§5 配套 4） | `app/(protected)/pos/topups/page.tsx` | ✅ |
+| 8 | 訂單頁：`internalOrderSource()` 加 `WS-`、`walk_in` badge、`/orders` 快篩 | `lib/orderTitle.ts`、`lib/orderSource.ts`、`orders/page.tsx` | ✅ |
+| 9 | 日結報表依付款方式分項 | `rpc_daily_pickup_settlement` | ⏳ **還沒做**，見下 |
+
+### ⏳ 還沒做：日結依付款方式分項
+
+現場銷售**已經**會進日結（§10 情境 6 實測過），只是還沒有「現金 / 轉帳」的拆分。
+沒有一起做的原因：`rpc_daily_pickup_settlement` 最新版是 `20260831000040`（245 行、
+兩支函式，而且兩支的 `picked` 母體必須逐字一致），為了加一個分項欄位去整支重寫
+是這個 PR 裡風險最高、價值最低的一段。等現場銷售真的跑起來、確定要拆的維度之後
+再單獨做一支 migration 比較安全。
+
+要做的時候：基底是 `20260831000040`，`days[]` 比照 `store_campaign_*` 那組的做法
+多回 `cash_amount` / `other_amount_by_method`，**既有欄位一個都不要動**
+（前端沒改也不會壞，那是該檔自己立的規矩）。
 
 每支 migration 送出前：
 
@@ -259,17 +288,25 @@ git fetch origin main -q && git ls-tree --name-only origin/main supabase/migrati
 
 ---
 
-## 10. 驗收情境
+## 10. 驗收情境（✅ = 已對正式庫實測，執行後 ROLLBACK）
 
-1. 現場客買 3 樣（其中 1 樣缺 1 件 → 勾補庫存）→ 一張 `WS-` 單、`completed`、3 列 `picked_up`、
-   3 筆 `sale` + 1 筆 `manual_adjust`，`on_hand` 正確。
-2. 同一家店連開 5 張現場銷售單 → 不撞唯一索引。
-3. 某 SKU 在庫 5、其中 5 件是別的客人的待取 → 現場銷售可賣量顯示 **0**，硬打 RPC 也被擋。
-4. 某 SKU 的貨掛在【內部】店現貨池（已到貨）→ 賣得掉，且池子跟著少（留一列刪除線）。
-5. 分店帳號打別店的 `p_store_id` → `wrong_store`。
-6. 賣完當天開日結 → 金額對得上，且分得出現金 / 轉帳。
-7. 按錯 → 撤銷取貨 → `on_hand` 回來、日結金額跟著回去。
-8. 補庫存報表查得到那 1 件，且點得進盤點。
+
+| # | 情境 | 實測結果 |
+|---|---|---|
+| 1 | 買 3 樣、其中 1 樣缺 2 件勾補庫存 | ✅ `WS-1-0001`、3 列 `picked_up`、3 筆 `sale` + 1 筆 `manual_adjust(+2, cost 2.2)` |
+| 2 | 同店連開多張 | ✅ `WS-1-0001` / `0002` / `0003`，沒撞唯一索引 |
+| 3 | 超過可賣量 | ✅ 擋下，訊息帶「在庫 3 / 待客取 0 / 等貨中 0」＋下一步 |
+| 4 | 池子有貨（on_hand 6、free 1、cap 5）賣 4 件 | ✅ `from_pool=3`，池子 4→1（OV- 單留一列刪除線 `[已現場售出 WS-1-0001]`），on_hand 6→2 |
+| 5 | 分店帳號打別店 | ✅ `wrong_store` |
+| 6 | 賣完當天開日結 | ✅ 平鎮店 746 → 996（+250），`/orders` 列表 `source_summary='walk_in'` |
+| 7 | 按錯 → `rpc_undo_pickup` | ✅ 兩筆 `reversal`、品項回 `pending`、`on_hand` 完全復原 |
+| 8 | 補庫存報表 | ✅ 對得回 `WS-1-0001`，summary/明細都出得來 |
+| 9 | `store_staff` 勾補庫存 | ✅ `permission denied`（不勾則正常結帳） |
+| 10 | 單價 0 / 空購物車 / 賣給【內部】店帳號 | ✅ 三個都擋下 |
+
+前端（Playwright + fixture，`apps/admin:verify`）：結帳頁缺貨列出現補庫存勾選、
+勾了才給結帳、付款方式吃 `stores.allowed_payment_methods`、小票金額與折扣正確
+且不印出 `WALKIN-` 帳號、`/orders` 快篩按下去 keyword 變 `WS-`、側欄出現「現場銷售」。
 
 ---
 

--- a/docs/PLAN-現場銷售POS.md
+++ b/docs/PLAN-現場銷售POS.md
@@ -1,0 +1,277 @@
+# PLAN — 現場銷售（門市 POS：沒有訂單的現場客，當場結帳當場扣庫存）
+
+> 狀態：**規劃中，尚未施工**。需求人：Alex（2026-09-01）。
+> 需求原文：「有店家想要賣現場客，但是沒有訂單，然後又想要維護庫存，
+> 可以做一個現場銷售的功能，像是一般超商那樣，可以依照人名跟商品庫存來產生一筆訂單，
+> 並且扣掉庫存，然後銷售當下有可能很多商品沒有庫存，可以在同一個地方假如沒庫存就自動增加一筆記錄到庫存」。
+
+---
+
+## 0. 一句話
+
+現場銷售 = 把「開單」和「取貨」壓進**同一個交易**、支援**多品項購物車**、
+客人可以只有**一個名字**（不必是會員）；缺貨的品項可以在同一個畫面上**先補庫存再賣**。
+帳走既有的 `customer_orders` + `picked_up` + `stock_movements('sale')`，
+**不新開一套銷售表**。
+
+---
+
+## 1. 現況：這件事已經有人在做，只是很難用
+
+線上已經有 `rpc_create_spot_sale`（現貨直配，2026-08-16 上線，單號 `SP-`）：
+店員在庫存總覽選一個商品、選一位客人、送出 → 開一張「待取」單，客人來取貨時才扣庫存。
+
+線上實測（2026-09-01）：
+
+| 指標 | 數字 | 解讀 |
+|---|---|---|
+| `SP-` 訂單數 | 111（全部在近 30 天） | 功能有人用 |
+| 平均品項數 | **1.00** | 一次只能賣一項 —— 買三樣要開三張單 |
+| 開單後 6 小時內就取貨 | 41 / 111（37%） | **店員已經在拿它當現場銷售用**，只是要按兩次（配單 → 取貨頁再結一次） |
+
+所以本案不是從零長一個新模組，而是把現貨直配補成「一次買多樣、當場結掉」的版本。
+凡是現貨直配已經踩過的坑（可配量口徑、池子扣帳、店家守衛、零售價預填），**照抄**，不要重新發明。
+
+其他相關現況：
+
+- **零售價已經備好**：5,497 個 SKU 有 5,471 個掛著有效零售價 → 掃到/選到商品可以自動帶價。
+- **條碼幾乎沒有**：`barcodes` 表線上只有 10 筆 → 掃碼**不能當 P0**，P0 靠名稱搜尋。
+- **會員庫已經很髒**：25,715 位會員裡有 21,538 位沒有電話 → **不要**替每個現場客開一筆會員（見 §3.2）。
+
+---
+
+## 2. 為什麼不開一張新的 `pos_sales` 表
+
+因為下游全部掛在 `customer_orders` / `customer_order_items` 上，另開一張表要把它們**全部再實作一次**，而且漏掉的那幾支不會報錯、只會靜靜地少算：
+
+| 下游 | 靠什麼認 | 新表的話 |
+|---|---|---|
+| 日結報表 `rpc_daily_pickup_settlement` | `coi.status='picked_up'` | 現場銷售當天收的錢**不會出現在日結** |
+| `/orders` 列表、營收 / 商品分析 | `customer_orders` + `order_kind='normal'` | 現場銷售不進任何報表 |
+| 退貨 `rpc_create_order_return` | 訂單 + 品項 | 現場客退貨無路可走 |
+| 撤銷 `rpc_undo_pickup` | `order_pickup_events` + `pickup_movement_id` | 按錯無法還原 |
+| 成本 / 均成本 | `stock_movements('sale')` | 毛利算不出來 |
+
+**結論：現場銷售就是一張顧客訂單，只是它出生的時候就已經取完貨了。**
+
+---
+
+## 3. 資料模型
+
+### 3.1 單頭 / 品項 / 庫存
+
+| 東西 | 值 | 為什麼 |
+|---|---|---|
+| `order_no` | **`WS-<store_id>-0001`**（walk-in sale） | 線上已驗：`WS-` / `POS-` 兩個前綴**都沒人用**（現有前綴只有 GRP- 69,314 / RR- 552 / SP- 111 / OV- 23 / AB- 10）。序號一律 **MAX-based**，不要 `COUNT(*)+1`（20260813000010 湖口 RR-435 事故） |
+| `status` | `completed` | 當場付清、當場交貨，沒有待取這一段 |
+| `order_kind` | **`normal`** | ⛔ 不要新增 kind：全站 100 支檔案、188 處用 `order_kind='normal' OR IS NULL` 當口徑，新 kind 會被整批排除（營收、未結金額、商品分析…） |
+| `campaign_id / channel_id / campaign_item_id` | 既有 sentinel trio（`_restock_sentinel_*`） | `customer_order_items.campaign_item_id` 是 **NOT NULL**，沒有團就只能掛 sentinel。現貨直配已經這樣做 |
+| `nickname_snapshot` | **店員輸入的人名** | 這就是需求說的「依照人名產生訂單」 |
+| `payment_method` | `cash` / `transfer` / …（來源 `stores.allowed_payment_methods`） | 目前全站沒有任何路徑寫這一欄，可以安心用 |
+| `payment_status` | **維持 `unpaid`，不要寫 `paid`** | 見 §3.3 |
+| 品項 | 建立時**直接** `status='picked_up'` + `pickup_movement_id` | 日結、營收、退貨全部靠這個狀態認 |
+| 庫存 | 每列一筆 `stock_movements(-qty, 'sale', source_doc_type='customer_order', source_doc_id=訂單, source_doc_line_id=品項)` | 與 `rpc_record_pickup` **逐欄相同**，所以撤銷 / 退貨 / 月結 / 成本全部通用 |
+| 取貨事件 | 一筆 `order_pickup_events(event_type='picked_up')` | ⚠ **不寫就不能撤銷**：`rpc_undo_pickup` 第一件事就是找最後一筆取貨事件，找不到直接 `RAISE` |
+
+### 3.2 客人：兩種都要，預設不開新會員
+
+1. **有會員** → 用既有 `rpc_search_members` 選（跟 `SpotSaleModal` 同一套），訂單掛在他名下，會員中心 / LINE 通知照常。
+2. **純現場客** → 掛在**每店一筆**的「現場客」假會員（`member_type='guest'`、`member_no` 例如 `WALKIN-<store_id>`），**人名存 `nickname_snapshot`**。
+
+為什麼不替每個現場客開一筆會員：
+
+- 線上已有 21,538 位沒電話的 active 會員，一天幾十筆現場客會把會員庫沖爛（搜尋、合併、標籤全部跟著爛）。
+- 手機唯一索引那組雷（20260831000050：merged 殘骸佔號、林口店 83 筆）會被新路徑再踩一次。
+
+為什麼是 `guest` 不是 `store_internal`：
+
+- `store_internal` 被**日結報表明文排除**（`rpc_daily_pickup_settlement` 排掉容器單），掛上去 = 現場銷售收的錢在日結看不到 —— 正好把最重要的那件事弄壞。
+- `store_internal` 還被 `_sku_commitment` 的池子口徑、零元守衛特判，語意完全不同。
+- `member_type='guest'` 在 CHECK 裡合法（20260429120000）、後台 `MemberDetail` 已經會顯示「訪客」標籤，而線上**一筆都沒有** → 乾淨的新語意，不會污染既有查詢。
+
+⚠ 連帶要處理：`customer_orders_trio_kind_active_uniq` 是「同 (tenant, campaign, channel, member, order_kind) 只能有一張 active 單」，
+predicate 目前排除 `order_kind='restock'` 與 `order_no LIKE 'SP-%'`，
+**但 `completed` 沒有被排除** → 同一家店第二筆現場銷售會直接撞唯一索引。
+migration 必須把 predicate 加上 `AND order_no !~~ 'WS-%'`（照 SP- 那次的做法）。
+
+### 3.3 付款：`payment_status` 一律維持 `unpaid`
+
+CLAUDE.md 已經記過：`payment_status` 全站永遠是 `unpaid`，`WHERE payment_status='unpaid'` 等於沒有 WHERE。
+現在有 3 支前端**反過來**把 `'paid'` 當「這張單不用再處理」在用：
+
+- `apps/member/src/components/SettlementCard.tsx` — 會員端未結金額
+- `apps/admin/src/app/(protected)/pickup/page.tsx:220` — `payment_status==='paid'` 直接歸零跳過
+- `apps/admin/src/components/OrderDetail.tsx:1451` / `PickupDialog.tsx:192` — 儲值金付款判斷
+
+現場銷售如果開始寫 `'paid'`，這些地方的行為會突然改變（而且是靜默的）。
+「收到錢了」用既有語意表達就好：**品項 `picked_up`** → `v_customer_order_summary.outstanding_amount` 自動是 0。
+要分現金 / 轉帳做日結分項，用 `payment_method` 欄位（目前沒人寫）+ 日結報表多一個 group by。
+
+---
+
+## 4. 核心：`rpc_create_walkin_sale`（一支 RPC、一個交易）
+
+```
+rpc_create_walkin_sale(
+  p_store_id  BIGINT,
+  p_lines     JSONB,    -- [{sku_id, qty, unit_price, add_stock_qty}]
+  p_member_id BIGINT,   -- NULL = 用該店的現場客假會員
+  p_name      TEXT,     -- 現場客人名（存 nickname_snapshot）
+  p_payment_method TEXT,
+  p_discount_amount NUMERIC,
+  p_operator  UUID,
+  p_notes     TEXT
+) RETURNS JSONB
+```
+
+執行順序（**順序本身就是設計**）：
+
+1. **店家守衛** —— 逐字沿用 `rpc_create_spot_sale` / `rpc_add_stock_by_product` 的那一段：
+   `app_metadata.role ∈ (store_manager, store_staff)` 且 `app_metadata.stores` 非空、不含「總倉」→ 目標店必須在清單裡。
+   ⚠ 一律用 `app_metadata.stores`（**店名陣列**），不可以用 `store_id`（線上 33 個分店帳號沒有任何一個有 store_id）。
+   角色一律讀 `auth.jwt() -> 'app_metadata' ->> 'role'`，不要用頂層 `role`（那永遠是 `authenticated`）。
+2. 每個 (店, SKU) 各取一次 `pg_advisory_xact_lock`（同現貨直配），併發結帳序列化。
+3. **可賣量閘門**：上限是 **`_sku_free_qty_with_pool(store, sku)`**，不是 `on_hand`。
+   別的客人在等的貨（待客取 / 等貨中 / 在途池子）不可以被現場客買走 —— 那正是取貨閘門實體庫存守衛（20260818000010）在擋的事，
+   而現場銷售**直接寫 sale、不經過取貨閘門**，所以這裡是唯一防線。
+4. **缺貨補帳**（見 §5）：`add_stock_qty > 0` 的列先寫 `manual_adjust(+N)`，再回到步驟 3 重算。
+5. 開單頭（`WS-` 序號、`completed`）→ 開品項（直接 `picked_up`）→ 每列寫 `sale` movement 並回填 `pickup_movement_id`。
+6. **扣內部現貨池**：成交量超出純自由量的部分，呼叫既有的 `_consume_internal_pool(store, sku, qty, operator, now, '[已現場售出 WS-x-xxxx]')`
+   —— 不呼叫的話同一批貨會掛兩份承諾，下一位客人的取貨閘門會被擋掉。
+   **不要再抄一份拆行邏輯**（CLAUDE.md 明文）。
+7. 寫 `order_pickup_events`（`picked_up`）。
+8. 回傳 `{order_id, order_no, total, lines[], stock_added[]}` 給前端印小票。
+
+明確**不做**的事：
+
+- 不呼叫 `rpc_record_pickup`（它會跑取貨閘門，而現場銷售的貨不必「到過店」）。
+- 不寫 `backorder_at`（那是少發配貨的語意，寫下去會多一道人工解除的關卡）。
+- 不動 `payment_status`。
+
+---
+
+## 5. 「沒庫存就自動補一筆」—— 這是本案唯一的高風險設計
+
+需求要的是：結帳當下發現帳上沒貨，可以在同一個畫面補一筆庫存再賣掉。
+這等於在系統裡開一個**憑空生貨**的入口，而 CLAUDE.md 有一整節在講幽靈庫存造成的災情。所以要配套：
+
+**做法**：同一個交易內先寫 `stock_movements(+N, 'manual_adjust')`，`reason` 固定格式
+`現場銷售即時入帳 WS-<store>-<seq>`，再寫 `sale(-N)`。要嘛全成、要嘛整筆 rollback。
+
+**五個必要的配套**：
+
+1. **成本要帶**：`manual_adjust` 不帶成本時，若該倉 `avg_cost` 是 0，後面那筆 `sale` 的 COGS 就是 0、毛利虛高。
+   補帳時帶 `_current_cost_price(tenant, sku)` 當 fallback（同 `_air_ship_order_items` 的做法）。
+2. **權限**：預設只有 `store_manager` 以上可以用；`store_staff` 看得到缺貨提示但按不下去（前端擋 + RPC 再擋一次，
+   「按鈕拿掉但 EXECUTE 還通等於沒停」—— 自由轉貨那次的教訓）。
+3. **單頭留痕**：notes 寫「本單有 N 件是現場補帳（未經收貨）」，`/orders` 明細看得到。
+4. **報表**：新增一張「現場銷售補庫存」清單（依店 / 日期 / 操作人 / SKU / 數量），
+   查法就是 `movement_type='manual_adjust' AND reason LIKE '現場銷售即時入帳%'`。
+   帳一直要補 = 實體與帳面長期脫節，那是**盤點**要解的問題，報表要能一鍵導到盤點頁。
+5. **不要用減抵單（DN）繞過**：`rpc_create_inventory_deduction` 自己就強制 `on_hand - reserved >= qty`，
+   而 Path D 的無條件豁免正是 2026-08-18 松山「庫存 0 還能一直取貨」的元凶。現場銷售**不碰 DN**。
+
+**明確不做**：不做負庫存直售（`p_allow_negative`）。負庫存只有在「貨確實離開了店」時才是誠實的記錄
+（空中轉出庫那種），現場銷售是店員當下數得出來的東西，數得出來就補得出正確的數字。
+
+---
+
+## 6. 前端
+
+新頁 `/pos`（暫名「現場銷售」），入口放在 `/inventory` 旁與側欄；分店角色一律鎖自己店。
+
+```
+┌──────────────────────────┬─────────────────────────┐
+│ 商品搜尋（名稱 / SKU code）  │ 客人：[🔍 搜會員] 或 [打名字]  │
+│  ─ 商品 A  可賣 5  $109    │ ─────────────────────── │
+│  ─ 商品 B  可賣 0  $85 ⚠   │ 商品 A  ×2  $109   $218  │
+│  ─ 商品 C  可賣 12 $60     │ 商品 B  ×1  $85    $85   │
+│                          │   ⚠ 可賣 0（在庫 3、待客取 3）│
+│                          │   ☑ 先補 1 件庫存再賣        │
+│                          │ ─────────────────────── │
+│                          │ 整單折扣 [   ]   合計 $303  │
+│                          │ 付款：◉ 現金 ○ 轉帳         │
+│                          │      〔 結帳 〕            │
+└──────────────────────────┴─────────────────────────┘
+```
+
+要點：
+
+- 可賣量、建議售價一次撈：擴充既有 `rpc_get_stock_commitment_bulk`（它已經回 `free_with_pool`），
+  **不要**每列各打一次 `rpc_get_spot_availability`（那是 `ARRAY[單一變數]` 那個坑，一頁 50 列就是掃 50 遍，
+  文山店實測 3.8 秒 → 收斂後 60ms）。
+- 售價預填**零售價**（`suggest_price = COALESCE(retail, branch, 0)`，20260827020000 已定案），可改；
+  分店價只給 `canSeeBranch` 的角色看。
+- 單價 0 要擋（零元守衛的同一個理由：$0 = 把貨白送出去）。
+- 缺貨列一律顯示拆解「在庫 X、待客取 Y、等貨中 Z」，不要只寫「可賣 0」——
+  那正是 8/24「調整庫存完不能把庫存再轉出去」那次店員繞不出來的原因。
+- 結帳完直接出小票（可重用 `/pickup/print` 的版型）。
+
+---
+
+## 7. 退貨 / 按錯 / 作廢
+
+| 情境 | 走哪一支 | 要驗什麼 |
+|---|---|---|
+| 品項打錯、金額打錯（當天） | `rpc_undo_pickup` → 還原庫存 → 再開一張 | 它需要 `order_pickup_events`，所以 §4 步驟 7 不能省；權限已含 `store_manager`（20260807000010） |
+| 客人事後退貨 | 既有 `rpc_create_order_return` | 對 `completed` 的 `WS-` 單能不能跑，要實測 |
+| 整單作廢 | 撤銷取貨後 `cancelled` | 撤銷後記得接 `_close_orders_all_items_settled` 的既有收尾 |
+
+---
+
+## 8. 報表：什麼會自動對、什麼要改
+
+**自動就會對**（選 `guest` 而不是 `store_internal` 的關鍵理由）：
+
+- 日結 `rpc_daily_pickup_settlement`：口徑是「`picked_up` 品項 + 排除 `store_internal`」→ 現場銷售當天自動入帳。
+- `/orders` 列表、營收 / 商品分析：`order_kind='normal'` → 自動涵蓋。
+- 月結算：`store_monthly_settlement_items` 以 `transfers` 為母體，現場銷售一列都不產生 → **結構性地不入月結**（正確，這批貨本來就在店裡）。
+
+**要改**：
+
+- 日結多一個「現場銷售」分項 + 付款方式（現金 / 轉帳）小計。
+- 新增「現場銷售補庫存」報表（§5.4）。
+
+---
+
+## 9. 施工順序
+
+| # | 內容 | 產出 |
+|---|---|---|
+| 1 | migration A：唯一索引 predicate 加 `order_no !~~ 'WS-%'`；每店建立「現場客」guest 會員的 helper `_walkin_member(store)` | SQL |
+| 2 | migration B：`rpc_create_walkin_sale`（含店家守衛、free_with_pool 閘門、缺貨補帳、扣池、pickup event） | SQL |
+| 3 | migration C：`rpc_get_stock_commitment_bulk` 擴充建議售價欄位（一次撈，不要 per-row LATERAL） | SQL |
+| 4 | 前端 `/pos` 頁 + 側欄入口 + 小票 | TSX |
+| 5 | 日結分項 + 補庫存報表 | SQL + TSX |
+
+每支 migration 送出前：
+
+```bash
+node scripts/check-sql-syntax.cjs supabase/migrations/<檔名>.sql   # 每個檔案開新 wasm instance
+git fetch origin main -q && git ls-tree --name-only origin/main supabase/migrations/ | tail -5   # 檢查撞號
+```
+
+套上正式庫走 Management API（不要戳 pooler），而且**當天就要把 migration 合進 main**。
+
+---
+
+## 10. 驗收情境
+
+1. 現場客買 3 樣（其中 1 樣缺 1 件 → 勾補庫存）→ 一張 `WS-` 單、`completed`、3 列 `picked_up`、
+   3 筆 `sale` + 1 筆 `manual_adjust`，`on_hand` 正確。
+2. 同一家店連開 5 張現場銷售單 → 不撞唯一索引。
+3. 某 SKU 在庫 5、其中 5 件是別的客人的待取 → 現場銷售可賣量顯示 **0**，硬打 RPC 也被擋。
+4. 某 SKU 的貨掛在【內部】店現貨池（已到貨）→ 賣得掉，且池子跟著少（留一列刪除線）。
+5. 分店帳號打別店的 `p_store_id` → `wrong_store`。
+6. 賣完當天開日結 → 金額對得上，且分得出現金 / 轉帳。
+7. 按錯 → 撤銷取貨 → `on_hand` 回來、日結金額跟著回去。
+8. 補庫存報表查得到那 1 件，且點得進盤點。
+
+---
+
+## 11. 要 Alex 決定的四件事
+
+1. **現場客要不要留成會員？** 建議：預設不留（只存名字），要留就在同一個畫面選「建立會員」。
+2. **缺貨補庫存誰能按？** 建議：店長以上；店員只看得到提示。
+3. **付款方式要分嗎？** 建議：現金 / 轉帳兩個，日結分項。
+4. **要印小票嗎？** 建議 P1（版型可重用取貨單）。

--- a/supabase/migrations/20260901000000_walkin_sale_schema.sql
+++ b/supabase/migrations/20260901000000_walkin_sale_schema.sql
@@ -1,0 +1,168 @@
+-- ============================================================================
+-- 現場銷售 (1/3)：schema —— 唯一索引開洞、品項來源 walk_in、每店現場客假會員
+-- ============================================================================
+-- 需求（Alex 2026-09-01）：「有店家想要賣現場客，但是沒有訂單，然後又想要維護
+--   庫存，可以做一個現場銷售的功能，像是一般超商那樣，可以依照人名跟商品庫存來
+--   產生一筆訂單，並且扣掉庫存」。規劃見 docs/PLAN-現場銷售POS.md。
+--
+-- 現場銷售 = 一張「出生時就已經取完貨」的顧客訂單：
+--   單頭 completed、品項直接 picked_up、每列寫 sale movement。
+--   走既有 customer_orders 這條路，日結 / 營收 / 退貨 / 撤銷取貨 / 成本
+--   才會自動涵蓋（另開表的話 rpc_daily_pickup_settlement 會整批漏掉）。
+--
+-- ⚠ 不要用 day-1 留下來的 pos_sales / pos_sale_items：
+--   那是 20260422120005 通用 ERP 骨架的殘留，線上 0 筆、沒接任何前端、
+--   `customer_id` 指的還是空的 customers 表（全站其實用 members）。
+--   rpc_complete_pos_sale 也從沒被呼叫過。看到它不要以為那是正主。
+--
+-- 本檔內容：
+--   1. customer_orders_trio_kind_active_uniq：predicate 加排除 'WS-%'。
+--   2. customer_order_items.source：CHECK 加 'walk_in'。
+--   3. _walkin_member(tenant, store) — 每店一筆「現場客」guest 假會員。
+--
+-- 基底版本：
+--   customer_orders_trio_kind_active_uniq = 20260824060000（線上 pg_indexes
+--     逐字抽出：含 order_kind<>'restock'、order_no !~~ 'SP-%'、aid_board_id IS NULL）
+--   customer_order_items_source_check     = 20260808000020（線上 pg_constraint 逐字抽出）
+--   _walkin_member                        = 無（新函式）
+--
+-- Rollback：
+--   DROP INDEX customer_orders_trio_kind_active_uniq; 再建回不含 'WS-%' 的版本
+--     （見下方 §1 註解裡的原版 SQL）；
+--   CHECK 改回不含 'walk_in' 的清單（先確認沒有 walk_in 列，否則加不回去）；
+--   DROP FUNCTION public._walkin_member(UUID, BIGINT);
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. 唯一索引排除 WS- 單
+--
+-- 為什麼一定要開這個洞：同一家店的現場銷售全部掛在
+--   （同 tenant、同 sentinel 團、同 sentinel 頻道、同一筆「現場客」假會員、
+--     order_kind='normal'）
+-- 底下 → 第二張單必然撞這支 partial UNIQUE。而且 predicate 只排除
+-- transferred_out / expired / cancelled，**completed 仍在索引母體內**，
+-- 所以「上一張已經結掉了」救不了，第二筆現場銷售就會失敗。
+--
+-- 同 SP- 那次（20260816000060）的作法：只在索引 predicate 開洞，
+-- **不新增 order_kind** —— 全站 188 處用 `order_kind='normal' OR IS NULL`
+-- 當口徑（營收、未結金額、商品分析…），新 kind 會讓現場銷售整批消失。
+--
+-- 原版（rollback 用）：
+--   CREATE UNIQUE INDEX customer_orders_trio_kind_active_uniq
+--     ON public.customer_orders (tenant_id, campaign_id, channel_id, member_id, order_kind)
+--    WHERE status <> ALL (ARRAY['transferred_out'::text,'expired'::text,'cancelled'::text])
+--      AND order_kind <> 'restock'::text
+--      AND order_no NOT LIKE 'SP-%'
+--      AND aid_board_id IS NULL;
+-- ----------------------------------------------------------------------------
+DROP INDEX IF EXISTS public.customer_orders_trio_kind_active_uniq;
+
+CREATE UNIQUE INDEX customer_orders_trio_kind_active_uniq
+  ON public.customer_orders (tenant_id, campaign_id, channel_id, member_id, order_kind)
+ WHERE status <> ALL (ARRAY['transferred_out'::text, 'expired'::text, 'cancelled'::text])
+   AND order_kind <> 'restock'::text
+   AND order_no NOT LIKE 'SP-%'
+   AND order_no NOT LIKE 'WS-%'
+   AND aid_board_id IS NULL;
+
+COMMENT ON INDEX public.customer_orders_trio_kind_active_uniq IS
+  '一會員一活動一張 active 單（真團的核心不變量，rpc_create_customer_orders 靠它合併）。'
+  'restock（RR- 補貨容器單）、SP-（現貨直配，20260816000060）、'
+  'WS-（現場銷售，20260901000000）、互助認領單（aid_board_id）除外 —— '
+  '那些是「一次動作一張單」的語意，不該被合併。';
+
+-- ----------------------------------------------------------------------------
+-- 2. 品項來源新增 walk_in
+--
+-- 對齊 apps/admin/src/lib/orderSource.ts 檔頭寫的三步驟（(a) 前端 tuple + meta、
+-- (b) 本 CHECK、(c) 是否進 SOURCE_TREND_SERIES）。現場銷售**不進**那張折線圖：
+-- 它畫的是「人是怎麼下這張單的」三個線上通路（App / 商城 / 小幫手），
+-- 把臨櫃結帳混進去會讓通路消長的圖說謊。
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.customer_order_items
+  DROP CONSTRAINT IF EXISTS customer_order_items_source_check;
+
+ALTER TABLE public.customer_order_items
+  ADD CONSTRAINT customer_order_items_source_check CHECK (
+    source = ANY (ARRAY[
+      'manual'::text,
+      'screenshot_parse'::text,
+      'csv'::text,
+      'rollover'::text,
+      'liff'::text,
+      'pwa'::text,
+      'store_internal'::text,
+      'aid_transfer'::text,
+      'walk_in'::text
+    ])
+  );
+
+-- ----------------------------------------------------------------------------
+-- 3. _walkin_member — 每店一筆「現場客」共用收件人
+--
+-- 為什麼不替每位現場客開一筆會員：線上已有 21,538 位沒有電話的 active 會員，
+--   一天幾十筆現場客會把會員庫沖爛（搜尋 / 合併 / 標籤跟著爛），而且手機唯一
+--   索引那組雷（20260831000050：merged 殘骸佔號、林口 83 筆）會被新路徑再踩一次。
+--   真正的客人名字存在訂單的 nickname_snapshot（＝需求說的「依照人名產生訂單」）。
+--   店員想把人留下來時，前端改帶真的 member_id 進來，不走這支。
+--
+-- 為什麼 member_type 用 'guest' 不用 'store_internal'：
+--   store_internal 被 rpc_daily_pickup_settlement **明文排除**（那是現貨池帳本
+--   搬運，不是對客人收的錢）→ 掛上去等於現場銷售收的錢在日結看不到，
+--   正好把最重要的那件事弄壞。它還被 _sku_commitment 的池子口徑、
+--   rpc_record_pickup 的零元守衛特判，語意完全不同。
+--   'guest' 在 CHECK 裡合法（20260429120000）、後台 MemberDetail 已經會顯示
+--   「訪客」標籤，而線上一筆都沒有 → 乾淨的新語意。
+--
+-- phone / phone_hash 一律留 NULL：不佔號，也就繞開唯一索引那整組問題。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._walkin_member(
+  p_tenant   UUID,
+  p_store_id BIGINT
+) RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_store stores%ROWTYPE;
+  v_no    TEXT;
+  v_id    BIGINT;
+BEGIN
+  SELECT * INTO v_store FROM stores WHERE id = p_store_id AND tenant_id = p_tenant;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '分店 % 不存在（tenant %）', p_store_id, p_tenant;
+  END IF;
+
+  v_no := 'WALKIN-' || p_store_id::TEXT;
+
+  SELECT id INTO v_id FROM members WHERE tenant_id = p_tenant AND member_no = v_no;
+  IF v_id IS NOT NULL THEN
+    RETURN v_id;
+  END IF;
+
+  INSERT INTO members (
+    tenant_id, member_no, name, member_type, home_store_id, status, notes
+  ) VALUES (
+    p_tenant, v_no, '現場客（' || v_store.name || '）', 'guest', p_store_id, 'active',
+    '門市現場銷售的共用收件人（20260901000000）。真正的客人名字存在該筆訂單的 '
+    'nickname_snapshot；不要拿它當真的會員做行銷 / 通知 / 合併。'
+  )
+  ON CONFLICT (tenant_id, member_no) DO NOTHING
+  RETURNING id INTO v_id;
+
+  -- 併發時另一個交易先插入 → ON CONFLICT 不回列，補撈一次
+  IF v_id IS NULL THEN
+    SELECT id INTO v_id FROM members WHERE tenant_id = p_tenant AND member_no = v_no;
+  END IF;
+
+  RETURN v_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public._walkin_member(UUID, BIGINT) IS
+  '取得（沒有就建）某店的「現場客」共用假會員 WALKIN-<store_id>（member_type=guest）。'
+  '現場銷售不替每位客人開會員，人名存訂單的 nickname_snapshot。'
+  '不可用 store_internal —— 那會被日結報表排除掉。';
+
+REVOKE ALL ON FUNCTION public._walkin_member(UUID, BIGINT) FROM PUBLIC, anon, authenticated;

--- a/supabase/migrations/20260901000010_rpc_create_walkin_sale.sql
+++ b/supabase/migrations/20260901000010_rpc_create_walkin_sale.sql
@@ -1,0 +1,411 @@
+-- ============================================================================
+-- 現場銷售 (2/3)：rpc_create_walkin_sale —— 一支 RPC、一個交易、多品項、當場扣庫存
+-- ============================================================================
+-- 需求（Alex 2026-09-01），規劃見 docs/PLAN-現場銷售POS.md。
+--
+-- 它跟現貨直配（rpc_create_spot_sale，20260824060000）差在哪：
+--   現貨直配 = 開一張「待取」單，客人回來取貨時才由 rpc_record_pickup 扣庫存。
+--   現場銷售 = 客人**人就在櫃台**，開單與交貨是同一件事 → 單頭直接 completed、
+--              品項直接 picked_up、當場寫 sale movement，而且一次可以買很多樣。
+--   線上實測（2026-09-01）：SP- 單 111 張、平均品項數 1.00、37% 在 6 小時內
+--   就取貨 —— 店員本來就在拿現貨直配當現場銷售用，只是一次只能一項、要按兩次。
+--
+-- 為什麼不呼叫 rpc_record_pickup：它會跑 is_order_item_pickup_ready 到貨閘門，
+--   而現場銷售的貨**不需要「到過店」**（本來就在架上）。閘門那一整套是為了
+--   「總倉發的貨到了沒」設計的，套在臨櫃結帳上只會誤擋。
+--   代價是閘門的實體庫存守衛（20260818000010）也不會跑 → **本函式自己的
+--   可賣量閘門就是唯一防線**（見 §可賣量）。
+--
+-- 可賣量 = _sku_free_qty_with_pool（在庫 − 待客取 − 等貨中 − 在途池子），
+--   ⛔ 不是 on_hand。別的客人正在等的貨不可以被現場客買走 —— 那是
+--   2026-08-18 松山「on_hand=0 還一直放行取貨」的同一個坑。
+--   超出純自由量的部分成交後呼叫 _consume_internal_pool 扣【內部】店現貨池，
+--   否則同一批貨掛兩份承諾，下一位客人的取貨閘門會被擋掉（忠順 ×10 事故）。
+--
+-- 缺貨補帳（p_lines[].add_stock_qty）：
+--   店員在結帳當下發現帳上沒貨、但架上有 → 同一個交易內先寫
+--   manual_adjust(+N) 再賣。要嘛全成、要嘛整筆 rollback。
+--   這是本案唯一的高風險設計，四道配套一個都不能少：
+--     1. 限 store_manager 以上（Alex 決議）；store_staff 直接 RAISE。
+--     2. 帶 _current_cost_price 當成本 —— 不帶的話該倉 avg_cost 是 0 時，
+--        後面那筆 sale 的 COGS 就是 0、毛利虛高。
+--     3. reason 固定 '現場銷售即時入帳 <單號>'，事後查得出來（報表靠這個字串）。
+--     4. 單頭 notes 標明有幾件是補帳的。
+--   明確不做：不碰減抵單（Path D 無條件豁免正是松山那次的元凶）、
+--   不做負庫存直售（p_allow_negative）—— 現場的東西店員數得出來。
+--
+-- 參數：
+--   p_lines = [{sku_id, qty, unit_price, add_stock_qty?}]（同一個 SKU 可以有
+--     多列，價格可以不同；閘門依 SKU 聚合後判斷）。
+--   p_member_id NULL → 用該店的「現場客」共用假會員（_walkin_member）。
+--     店員勾了「建立為會員」時，前端先開會員再把 member_id 帶進來，不走假會員。
+--   p_customer_name → nickname_snapshot（＝需求說的「依照人名產生訂單」）。
+--
+-- 基底版本：無（新函式）。用到的既有零件全部照原樣呼叫，沒有複製任何一份邏輯：
+--   _walkin_member(20260901000000) / _restock_sentinel_*(20260612000020) /
+--   _sku_free_qty + _sku_commitment(20260816000000) /
+--   _sku_free_qty_with_pool + _consume_internal_pool(20260824060000) /
+--   _current_cost_price(20260705000000)
+-- Rollback：DROP FUNCTION public.rpc_create_walkin_sale(BIGINT, JSONB, UUID,
+--   BIGINT, TEXT, TEXT, NUMERIC, TEXT);
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_create_walkin_sale(
+  p_store_id        BIGINT,
+  p_lines           JSONB,
+  p_operator        UUID,
+  p_member_id       BIGINT  DEFAULT NULL,
+  p_customer_name   TEXT    DEFAULT NULL,
+  p_payment_method  TEXT    DEFAULT 'cash',
+  p_discount_amount NUMERIC DEFAULT 0,
+  p_notes           TEXT    DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_jwt_role   TEXT  := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_my_stores  JSONB := COALESCE(auth.jwt() -> 'app_metadata' -> 'stores', '[]'::jsonb);
+  v_store      stores%ROWTYPE;
+  v_now        TIMESTAMPTZ := NOW();
+  v_member     members%ROWTYPE;
+  v_member_id  BIGINT;
+  v_name       TEXT;
+  v_l          RECORD;
+  v_s          RECORD;
+  v_free       NUMERIC;
+  v_cap        NUMERIC;
+  v_from_pool  NUMERIC;
+  v_pool_plan  JSONB := '{}'::jsonb;
+  v_pool_total NUMERIC := 0;
+  v_added      JSONB := '[]'::jsonb;
+  v_add_total  NUMERIC := 0;
+  v_c          RECORD;
+  v_on_hand    NUMERIC;
+  v_over       NUMERIC;
+  v_hint       TEXT;
+  v_sku_label  TEXT;
+  v_campaign   BIGINT;
+  v_channel    BIGINT;
+  v_ci         BIGINT;
+  v_order_id   BIGINT;
+  v_order_no   TEXT;
+  v_seq        INT;
+  v_item_id    BIGINT;
+  v_move_id    BIGINT;
+  v_item_ids   BIGINT[] := ARRAY[]::BIGINT[];
+  v_items_out  JSONB := '[]'::jsonb;
+  v_total      NUMERIC := 0;
+  v_discount   NUMERIC := GREATEST(COALESCE(p_discount_amount, 0), 0);
+BEGIN
+  -- ==========================================================================
+  -- 1. 參數與權限
+  -- ==========================================================================
+  IF p_operator IS NULL THEN
+    RAISE EXCEPTION '缺少操作人';
+  END IF;
+  IF p_lines IS NULL OR jsonb_typeof(p_lines) <> 'array' OR jsonb_array_length(p_lines) = 0 THEN
+    RAISE EXCEPTION '沒有任何品項，無法結帳';
+  END IF;
+
+  SELECT * INTO v_store FROM stores WHERE id = p_store_id;
+  IF NOT FOUND OR v_store.location_id IS NULL THEN
+    RAISE EXCEPTION '分店 % 不存在或未綁定倉別', p_store_id;
+  END IF;
+
+  -- 店家守衛：逐字對齊 rpc_record_pickup（20260813000000）/ rpc_create_spot_sale。
+  -- ⚠ 一律用 app_metadata.stores（**店名陣列**），不可以用 store_id ——
+  --    線上 33 個分店帳號沒有任何一個有 store_id（20260808000020）。
+  IF v_jwt_role IN ('store_manager', 'store_staff')
+     AND jsonb_typeof(v_my_stores) = 'array'
+     AND jsonb_array_length(v_my_stores) > 0
+     AND NOT (v_my_stores ? '總倉')
+     AND NOT (v_my_stores ? v_store.name) THEN
+    RAISE EXCEPTION 'wrong_store: 這是「%」的庫存，分店帳號只能賣自己店的貨', v_store.name;
+  END IF;
+
+  -- 逐列驗證（值不合法要在動任何一筆庫存之前就擋掉）
+  FOR v_l IN
+    SELECT (e ->> 'sku_id')::BIGINT                        AS sku_id,
+           (e ->> 'qty')::NUMERIC                          AS qty,
+           (e ->> 'unit_price')::NUMERIC                   AS unit_price,
+           COALESCE((e ->> 'add_stock_qty')::NUMERIC, 0)   AS add_qty,
+           ord
+      FROM jsonb_array_elements(p_lines) WITH ORDINALITY AS t(e, ord)
+     ORDER BY ord
+  LOOP
+    IF v_l.sku_id IS NULL OR NOT EXISTS (SELECT 1 FROM skus WHERE id = v_l.sku_id) THEN
+      RAISE EXCEPTION '第 % 列：品項 % 不存在', v_l.ord, COALESCE(v_l.sku_id::TEXT, 'NULL');
+    END IF;
+    IF v_l.qty IS NULL OR v_l.qty <= 0 OR v_l.qty <> FLOOR(v_l.qty) THEN
+      RAISE EXCEPTION '第 % 列：數量必須是正整數', v_l.ord;
+    END IF;
+    -- 零元守衛的同一個理由（20260815000000）：$0 = 把貨白送出去。
+    -- 現場銷售當場收錢，沒有「事後補填金額」的機會，所以擋在這裡。
+    IF v_l.unit_price IS NULL OR v_l.unit_price <= 0 THEN
+      RAISE EXCEPTION '第 % 列：單價必須大於 0', v_l.ord;
+    END IF;
+    IF v_l.add_qty < 0 OR v_l.add_qty <> FLOOR(v_l.add_qty) THEN
+      RAISE EXCEPTION '第 % 列：補庫存數量必須是非負整數', v_l.ord;
+    END IF;
+  END LOOP;
+
+  -- 收件人：有帶會員就用會員，沒有就用該店的「現場客」共用假會員
+  IF p_member_id IS NOT NULL THEN
+    SELECT * INTO v_member FROM members WHERE id = p_member_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION '會員 % 不存在', p_member_id;
+    END IF;
+    IF COALESCE(v_member.member_type, '') = 'store_internal' THEN
+      RAISE EXCEPTION '不能把貨賣給【內部】店帳號 —— 那是現貨池容器，不是客人';
+    END IF;
+    IF COALESCE(v_member.no_new_order, FALSE) THEN
+      RAISE EXCEPTION '會員「%」已被標記為不可新增訂單', COALESCE(v_member.name, p_member_id::TEXT);
+    END IF;
+    v_member_id := v_member.id;
+    v_name      := COALESCE(NULLIF(TRIM(p_customer_name), ''), v_member.name);
+  ELSE
+    v_member_id := public._walkin_member(v_store.tenant_id, p_store_id);
+    v_name      := COALESCE(NULLIF(TRIM(p_customer_name), ''), '現場客');
+  END IF;
+
+  -- ==========================================================================
+  -- 2. 先取單號
+  --
+  -- 刻意排在開單之前：缺貨補帳寫的 manual_adjust 要在 reason 裡帶單號，
+  -- 事後才對得回「哪一筆現場銷售補的」（稽核報表 rpc_walkin_stock_topups
+  -- 就是靠這個字串）。晚一步生號的話那些 movement 只剩時間可以猜。
+  --
+  -- MAX-based，不用 COUNT(*)+1 —— 單被硬刪後 COUNT 會倒退、重發已用過的號碼
+  -- 撞 unique（20260813000010 湖口 RR-435 事故）。
+  -- ==========================================================================
+  PERFORM pg_advisory_xact_lock(hashtext('walkin_sale_seq:' || p_store_id::TEXT));
+  SELECT COALESCE(MAX(substring(order_no FROM '^WS-' || p_store_id::TEXT || '-([0-9]+)$')::INT), 0) + 1
+    INTO v_seq
+    FROM customer_orders
+   WHERE tenant_id = v_store.tenant_id
+     AND order_no ~ ('^WS-' || p_store_id::TEXT || '-[0-9]+$');
+  -- lpad 超寬會截斷（lpad('10001',4)='1000'），寬度要跟著位數長
+  v_order_no := 'WS-' || p_store_id::TEXT || '-' ||
+                LPAD(v_seq::TEXT, GREATEST(length(v_seq::TEXT), 4), '0');
+
+  -- ==========================================================================
+  -- 3. 逐 SKU：鎖 → 補庫存（選配）→ 可賣量閘門 → 記下要從池子扣多少
+  --
+  -- 依 sku_id 排序取鎖，兩個櫃台同時結帳到同一組商品時不會互相死鎖。
+  -- 這一整段**必須在寫任何 sale movement 之前跑完**：sale 會把 on_hand 打下去，
+  -- 之後再算 _sku_free_qty 就不是「這批貨賣掉前的自由量」了，from_pool 會算錯。
+  -- ==========================================================================
+  FOR v_s IN
+    SELECT (e ->> 'sku_id')::BIGINT                      AS sku_id,
+           SUM((e ->> 'qty')::NUMERIC)                   AS need,
+           SUM(COALESCE((e ->> 'add_stock_qty')::NUMERIC, 0)) AS add_qty
+      FROM jsonb_array_elements(p_lines) AS t(e)
+     GROUP BY 1
+     ORDER BY 1
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtext(format('walkinsale:%s:%s:%s',
+      v_store.tenant_id, p_store_id, v_s.sku_id)));
+
+    -- ---- 缺貨補帳 ----
+    IF v_s.add_qty > 0 THEN
+      -- Alex 決議：只有店長以上能補。角色清單對齊 rpc_undo_pickup（20260807000010），
+      -- '' 是沒有顯式 role 的 legacy / dev admin，漏掉會把舊帳號全擋在外面。
+      IF v_jwt_role NOT IN ('owner', 'admin', 'hq_manager', 'store_manager', '') THEN
+        RAISE EXCEPTION 'permission denied: 「%」沒有權限在結帳時補庫存，'
+          '請店長操作，或先到「庫存總覽」把現貨入帳', v_jwt_role;
+      END IF;
+
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        unit_cost, reason, operator_id
+      ) VALUES (
+        v_store.tenant_id, v_store.location_id, v_s.sku_id, v_s.add_qty, 'manual_adjust',
+        -- 成本一定要帶：沒帶的話該倉 avg_cost 若是 0，後面那筆 sale 的 COGS
+        -- 就是 0、毛利虛高（同 _air_ship_order_items 的 p_fallback_unit_cost）
+        public._current_cost_price(v_store.tenant_id, v_s.sku_id),
+        '現場銷售即時入帳 ' || v_order_no || '（結帳時架上有貨、帳上沒有）', p_operator
+      ) RETURNING id INTO v_move_id;
+
+      v_add_total := v_add_total + v_s.add_qty;
+      v_added := v_added || jsonb_build_object(
+        'sku_id', v_s.sku_id, 'qty', v_s.add_qty, 'movement_id', v_move_id);
+    END IF;
+
+    -- ---- 可賣量閘門 ----
+    v_free := public._sku_free_qty(p_store_id, v_s.sku_id);
+    v_cap  := public._sku_free_qty_with_pool(p_store_id, v_s.sku_id);
+
+    IF v_cap < v_s.need THEN
+      -- 錯誤訊息要講得出「那些貨去哪了」＋「下一步做什麼」，
+      -- 不然店員只看到「不足」會以為系統壞了（同 20260824060000 的教訓）
+      SELECT * INTO v_c FROM public._sku_commitment(p_store_id, ARRAY[v_s.sku_id]);
+      SELECT COALESCE(sb.on_hand, 0) INTO v_on_hand
+        FROM stock_balances sb
+       WHERE sb.tenant_id   = v_store.tenant_id
+         AND sb.location_id = v_store.location_id
+         AND sb.sku_id      = v_s.sku_id;
+      SELECT COALESCE(s.product_name, '') ||
+             CASE WHEN s.variant_name IS NOT NULL THEN ' / ' || s.variant_name ELSE '' END
+        INTO v_sku_label FROM skus s WHERE s.id = v_s.sku_id;
+
+      v_over := GREATEST(COALESCE(v_c.promised, 0) + COALESCE(v_c.waiting, 0)
+                         + COALESCE(v_c.pool_claimed, 0) - COALESCE(v_on_hand, 0), 0);
+
+      -- 三種原因講三句不同的話。分不清楚的話店員只會看到同一句罐頭訊息，
+      -- 照著去「新增庫存」補了 N 件回來發現可賣量還是 0（20260824060000 的災情）。
+      IF v_over > 0 THEN
+        v_hint := '帳上已超額 ' || v_over || ' 件（承諾多於在庫）：'
+                  || '架上真的有貨就在這一列勾「補庫存」補超過 ' || v_over || ' 件，'
+                  || '數量對不上請改走「庫存盤點」重盤一次。';
+      ELSIF COALESCE(v_c.promised, 0) + COALESCE(v_c.waiting, 0)
+            + COALESCE(v_c.pool_claimed, 0) > 0 THEN
+        v_hint := '這批貨被別的客人佔著（待客取 / 等貨中）。'
+                  || '架上實際有更多貨的話，在這一列勾「補庫存」把現貨入帳。';
+      ELSE
+        v_hint := '這家店帳上就只有 ' || COALESCE(v_on_hand, 0) || ' 件。'
+                  || '架上真的有更多，在這一列勾「補庫存」把差額入帳再賣。';
+      END IF;
+
+      RAISE EXCEPTION '「%」可賣 % 件、要賣 % 件。'
+        '（在庫 %，其中待客取 %、等貨中 %、內部單 %（已到 %））%',
+        COALESCE(v_sku_label, v_s.sku_id::TEXT), v_cap, v_s.need,
+        COALESCE(v_on_hand, 0), COALESCE(v_c.promised, 0),
+        COALESCE(v_c.waiting, 0), COALESCE(v_c.pool_claimed, 0),
+        COALESCE(v_c.pool_arrived, 0), v_hint;
+    END IF;
+
+    -- 超出純自由量的部分＝從【內部】店現貨池賣掉的，開完單要扣池子
+    v_from_pool := GREATEST(v_s.need - v_free, 0);
+    IF v_from_pool > 0 THEN
+      v_pool_plan  := v_pool_plan || jsonb_build_object(v_s.sku_id::TEXT, v_from_pool);
+      v_pool_total := v_pool_total + v_from_pool;
+    END IF;
+  END LOOP;
+
+  -- ==========================================================================
+  -- 4. 開單（sentinel trio → 單頭 → 品項 + sale movement）
+  -- ==========================================================================
+  v_campaign := public._restock_sentinel_campaign(v_store.tenant_id);
+  v_channel  := public._restock_sentinel_channel(v_store.tenant_id, p_store_id);
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id,
+    nickname_snapshot, pickup_store_id, status,
+    ready_at, completed_at, ordered_at,
+    order_kind, order_type, payment_method, discount_amount, notes,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_store.tenant_id, v_order_no, v_campaign, v_channel, v_member_id,
+    v_name, p_store_id, 'completed',
+    v_now, v_now, v_now,
+    -- ⛔ order_kind 維持 'normal'：全站 188 處用 `order_kind='normal' OR IS NULL`
+    --    當口徑，新 kind 會讓現場銷售從營收 / 商品分析整批消失。
+    'normal', 'regular', NULLIF(TRIM(p_payment_method), ''), v_discount,
+    '【現場銷售】門市臨櫃結帳，當場交貨扣庫存' ||
+      CASE WHEN v_add_total > 0
+             THEN E'\n其中 ' || v_add_total || ' 件是結帳時現場補帳入庫（架上有貨、帳上沒有）'
+           ELSE '' END ||
+      CASE WHEN v_pool_total > 0
+             THEN E'\n其中 ' || v_pool_total || ' 件來自【內部】' || v_store.name || '現貨池（已從池子扣除）'
+           ELSE '' END ||
+      COALESCE(E'\n' || NULLIF(TRIM(p_notes), ''), ''),
+    p_operator, p_operator, v_now, v_now
+  ) RETURNING id INTO v_order_id;
+
+  -- 逐列：品項（直接 picked_up）→ sale movement → 回填 pickup_movement_id。
+  -- 欄位與寫法逐字對齊 rpc_record_pickup 的「整行取」分支，撤銷取貨 / 退貨 /
+  -- 月結 / 成本才會把它當成一般的取貨看待。
+  FOR v_l IN
+    SELECT (e ->> 'sku_id')::BIGINT      AS sku_id,
+           (e ->> 'qty')::NUMERIC        AS qty,
+           (e ->> 'unit_price')::NUMERIC AS unit_price,
+           ord
+      FROM jsonb_array_elements(p_lines) WITH ORDINALITY AS t(e, ord)
+     ORDER BY ord
+  LOOP
+    v_ci := public._restock_sentinel_campaign_item(
+              v_store.tenant_id, v_campaign, v_l.sku_id, v_l.unit_price);
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      v_store.tenant_id, v_order_id, v_ci, v_l.sku_id, v_l.qty, v_l.unit_price,
+      'picked_up', 'walk_in', p_operator, p_operator, v_now, v_now
+    ) RETURNING id INTO v_item_id;
+
+    INSERT INTO stock_movements (
+      tenant_id, location_id, sku_id, quantity, movement_type,
+      source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+    ) VALUES (
+      v_store.tenant_id, v_store.location_id, v_l.sku_id, -v_l.qty, 'sale',
+      'customer_order', v_order_id, v_item_id,
+      format('現場銷售 order=%s item=%s', v_order_id, v_item_id), p_operator
+    ) RETURNING id INTO v_move_id;
+
+    UPDATE customer_order_items
+       SET pickup_movement_id = v_move_id
+     WHERE id = v_item_id;
+
+    v_item_ids  := v_item_ids || v_item_id;
+    v_total     := v_total + v_l.qty * v_l.unit_price;
+    v_items_out := v_items_out || jsonb_build_object(
+      'item_id', v_item_id, 'sku_id', v_l.sku_id, 'qty', v_l.qty,
+      'unit_price', v_l.unit_price, 'subtotal', v_l.qty * v_l.unit_price);
+  END LOOP;
+
+  -- ==========================================================================
+  -- 5. 扣【內部】店現貨池
+  --
+  -- 不扣的話同一批貨掛兩份承諾：池子還寫著 ×N、但貨已經賣掉了 —— 就是
+  -- 2026-08-11 忠順「池子掛 ×10、實際只剩 2」那件事。扣法沿用共用 helper，
+  -- **不要再抄一份拆行邏輯**（CLAUDE.md 明文）。
+  -- ==========================================================================
+  FOR v_s IN SELECT key::BIGINT AS sku_id, value::TEXT::NUMERIC AS qty
+               FROM jsonb_each(v_pool_plan)
+  LOOP
+    PERFORM public._consume_internal_pool(
+      p_store_id, v_s.sku_id, v_s.qty, p_operator, v_now,
+      '[已現場售出 ' || v_order_no || ']');
+  END LOOP;
+
+  -- ==========================================================================
+  -- 6. 取貨事件
+  --
+  -- ⚠ 這一段不能省：rpc_undo_pickup 第一件事就是找最後一筆取貨事件，
+  --    找不到會直接 RAISE「沒有取貨事件可撤銷」→ 店員按錯就救不回來。
+  -- ==========================================================================
+  INSERT INTO order_pickup_events (
+    tenant_id, order_id, pickup_store_id, event_type, item_ids, notes, created_by
+  ) VALUES (
+    v_store.tenant_id, v_order_id, p_store_id, 'picked_up',
+    to_jsonb(v_item_ids), '現場銷售 ' || v_order_no, p_operator
+  );
+
+  RETURN jsonb_build_object(
+    'order_id',       v_order_id,
+    'order_no',       v_order_no,
+    'member_id',      v_member_id,
+    'customer_name',  v_name,
+    'items',          v_items_out,
+    'items_total',    v_total,
+    'discount',       v_discount,
+    'total',          GREATEST(v_total - v_discount, 0),
+    'payment_method', NULLIF(TRIM(p_payment_method), ''),
+    'from_pool',      v_pool_total,
+    'stock_added',    v_added
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_create_walkin_sale(BIGINT, JSONB, UUID, BIGINT, TEXT, TEXT, NUMERIC, TEXT) IS
+  '現場銷售（門市臨櫃結帳）：多品項、當場交貨扣庫存，開一張 WS- 顧客訂單'
+  '（單頭 completed、品項 picked_up、每列一筆 sale movement）。'
+  '可賣量閘門用 _sku_free_qty_with_pool（不是 on_hand），成交後扣內部現貨池；'
+  '缺貨可在同一交易補 manual_adjust（限 store_manager 以上，帶成本、留 reason）。'
+  '20260901000010。';
+
+REVOKE ALL ON FUNCTION public.rpc_create_walkin_sale(BIGINT, JSONB, UUID, BIGINT, TEXT, TEXT, NUMERIC, TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_create_walkin_sale(BIGINT, JSONB, UUID, BIGINT, TEXT, TEXT, NUMERIC, TEXT) TO authenticated;

--- a/supabase/migrations/20260901000020_rpc_pos_search_products.sql
+++ b/supabase/migrations/20260901000020_rpc_pos_search_products.sql
@@ -1,0 +1,141 @@
+-- ============================================================================
+-- 現場銷售 (3/3)：rpc_pos_search_products —— 結帳畫面的商品搜尋（含可賣量與售價）
+-- ============================================================================
+-- 結帳頁一次要畫一排商品，每一列都要「這家店還能賣幾件」＋「賣多少錢」。
+--
+-- ⚠ 為什麼不是前端每列各打一次 rpc_get_spot_availability：
+--   那支內部是 `LATERAL _sku_commitment(store, ARRAY[p_sku_id])` —— 一次一個 SKU。
+--   一頁 30 列就是把該店的訂單掃 30 遍，正是 CLAUDE.md 記過的
+--   「吃陣列的批次函式不要包一層 per-row LATERAL」（文山店實測 3.8s → 收斂後 60ms，
+--   63 倍）。本函式**先選出候選 SKU、再一次呼叫 _sku_commitment(store, 整包陣列)**。
+--
+-- 可賣量的公式與 _sku_free_qty_with_pool（20260824060000）逐字相同：
+--   free           = on_hand − promised − waiting − pool_claimed
+--   free_with_pool = on_hand − promised − waiting − (pool_claimed − pool_arrived)
+--   兩者都夾 GREATEST(...,0)。**不要在這裡自己改公式** —— 列表、篩選、結帳閘門
+--   三邊算法不一致就會出現「列表寫可賣 3、結帳說可賣 0」（20260824060000 修過）。
+--   真正的閘門在 rpc_create_walkin_sale 裡會再驗一次，這裡只是畫面預檢。
+--
+-- 建議售價：零售價優先（20260827020000 定案，賣給終端客人收零售價），
+--   零售/分店兩個價都回，前端照 canSeeBranch 決定分店價要不要顯示。
+--
+-- p_term 空 → 回該店「架上有貨」的品項（依在庫多寡排），當作結帳頁的預設清單。
+--   （自由轉貨的虛擬 SKU MISC-01 一律排除，它不是真商品。）
+-- p_term 有值 → 搜商品名 / 規格 / SKU 編號 / 條碼，**不限在庫**
+--   （缺貨的也要找得到，才有辦法在結帳當下勾「補庫存」）。
+--
+-- 基底版本：無（新函式）。
+-- Rollback：DROP FUNCTION public.rpc_pos_search_products(BIGINT, TEXT, INT);
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_pos_search_products(
+  p_store_id BIGINT,
+  p_term     TEXT DEFAULT NULL,
+  p_limit    INT  DEFAULT 30
+) RETURNS TABLE (
+  sku_id         BIGINT,
+  sku_code       TEXT,
+  product_name   TEXT,
+  variant_name   TEXT,
+  on_hand        NUMERIC,
+  promised       NUMERIC,
+  waiting        NUMERIC,
+  pool_claimed   NUMERIC,
+  pool_arrived   NUMERIC,
+  free           NUMERIC,
+  free_with_pool NUMERIC,
+  retail_price   NUMERIC,
+  branch_price   NUMERIC,
+  suggest_price  NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH st AS (
+    SELECT s.id, s.tenant_id, s.location_id
+      FROM stores s
+     WHERE s.id = p_store_id
+  ),
+  term AS (
+    SELECT NULLIF(TRIM(COALESCE(p_term, '')), '') AS t
+  ),
+  -- 候選集合：先收斂到最多 p_limit 筆，後面所有昂貴計算都只對這幾筆做
+  cand AS (
+    SELECT sk.id, sk.sku_code, sk.product_name, sk.variant_name,
+           COALESCE(sb.on_hand, 0) AS on_hand
+      FROM skus sk
+      CROSS JOIN st
+      CROSS JOIN term
+      LEFT JOIN stock_balances sb
+             ON sb.tenant_id   = st.tenant_id
+            AND sb.location_id = st.location_id
+            AND sb.sku_id      = sk.id
+     WHERE sk.tenant_id = st.tenant_id
+       AND sk.status = 'active'
+       -- 自由轉貨的虛擬佔位 SKU（MISC-01「虛擬轉貨商品」，20260614000060）不是
+       -- 真商品，實際品名放在 transfer_items.description 上。平鎮店身上就掛著
+       -- 219 件，不排掉的話它會霸佔預設清單第一列。
+       AND sk.sku_code <> 'MISC-01'
+       AND (
+             CASE
+               -- 沒打字：只列架上有貨的（結帳頁的預設清單）
+               WHEN term.t IS NULL THEN COALESCE(sb.on_hand, 0) > 0
+               -- 打了字：不限在庫 —— 缺貨的也要找得到才勾得到「補庫存」
+               ELSE sk.product_name ILIKE '%' || term.t || '%'
+                 OR sk.variant_name ILIKE '%' || term.t || '%'
+                 OR sk.sku_code     ILIKE '%' || term.t || '%'
+                 OR EXISTS (SELECT 1 FROM barcodes b
+                             WHERE b.sku_id = sk.id AND b.barcode_value = term.t)
+             END
+           )
+     ORDER BY COALESCE(sb.on_hand, 0) DESC, sk.product_name, sk.variant_name
+     LIMIT GREATEST(COALESCE(p_limit, 30), 1)
+  ),
+  -- ★ 一次呼叫、一趟 GROUP BY（不要 per-row LATERAL，見檔頭）
+  com AS (
+    SELECT c.*
+      FROM public._sku_commitment(p_store_id, ARRAY(SELECT id FROM cand)) c
+  )
+  SELECT
+    cand.id,
+    cand.sku_code,
+    cand.product_name,
+    cand.variant_name,
+    cand.on_hand,
+    COALESCE(com.promised, 0),
+    COALESCE(com.waiting, 0),
+    COALESCE(com.pool_claimed, 0),
+    COALESCE(com.pool_arrived, 0),
+    GREATEST(cand.on_hand - COALESCE(com.promised, 0) - COALESCE(com.waiting, 0)
+             - COALESCE(com.pool_claimed, 0), 0),
+    GREATEST(cand.on_hand - COALESCE(com.promised, 0) - COALESCE(com.waiting, 0)
+             - (COALESCE(com.pool_claimed, 0) - COALESCE(com.pool_arrived, 0)), 0),
+    px.retail_price,
+    px.branch_price,
+    COALESCE(px.retail_price, px.branch_price, 0)
+    FROM cand
+    CROSS JOIN st
+    LEFT JOIN com ON com.sku_id = cand.id
+    LEFT JOIN LATERAL (
+      SELECT
+        (SELECT p.price FROM prices p
+          WHERE p.tenant_id = st.tenant_id AND p.sku_id = cand.id AND p.scope = 'retail'
+            AND p.effective_from <= NOW() AND (p.effective_to IS NULL OR p.effective_to > NOW())
+          ORDER BY p.effective_from DESC LIMIT 1) AS retail_price,
+        (SELECT p.price FROM prices p
+          WHERE p.tenant_id = st.tenant_id AND p.sku_id = cand.id AND p.scope = 'branch'
+            AND p.effective_from <= NOW() AND (p.effective_to IS NULL OR p.effective_to > NOW())
+          ORDER BY p.effective_from DESC LIMIT 1) AS branch_price
+    ) px ON TRUE
+   ORDER BY cand.on_hand DESC, cand.product_name, cand.variant_name;
+$$;
+
+COMMENT ON FUNCTION public.rpc_pos_search_products(BIGINT, TEXT, INT) IS
+  '現場銷售結帳頁的商品搜尋：回該店的在庫 / 承諾拆解 / 可賣量（free_with_pool）'
+  '與建議售價（零售價優先）。候選收斂後只呼叫一次 _sku_commitment（吃陣列），'
+  '不做 per-row LATERAL。20260901000020。';
+
+REVOKE ALL ON FUNCTION public.rpc_pos_search_products(BIGINT, TEXT, INT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_pos_search_products(BIGINT, TEXT, INT) TO authenticated;

--- a/supabase/migrations/20260901000030_rpc_walkin_stock_topups.sql
+++ b/supabase/migrations/20260901000030_rpc_walkin_stock_topups.sql
@@ -1,0 +1,134 @@
+-- ============================================================================
+-- 現場銷售：補庫存稽核報表 rpc_walkin_stock_topups
+-- ============================================================================
+-- 為什麼一定要有這一支：
+--   rpc_create_walkin_sale 的 add_stock_qty 是全站少數「憑空生庫存」的入口
+--   （同一交易內寫 manual_adjust(+N) 再賣掉）。它解掉了店員的真實困境
+--   —— 架上有貨、帳上沒有、客人正站在櫃台前 —— 但沒有人看得到「補了多少」
+--   的話，它就會從權宜之計變成日常，帳與實體越差越遠而沒有任何訊號。
+--   CLAUDE.md 記過的幽靈庫存災情（忠順池子 ×10、松山 on_hand=0 還能取貨）
+--   都是「有人默默生了貨、沒有人在看」的變體。
+--
+-- 查法：movement_type='manual_adjust' AND reason LIKE '現場銷售即時入帳%'。
+--   單號嵌在 reason 裡（'現場銷售即時入帳 WS-1-0007（…）'），所以對得回是哪一單。
+--   ⚠ 改 rpc_create_walkin_sale 的 reason 字串就會弄斷這支，兩邊要一起改。
+--
+-- 回傳兩塊：
+--   summary[]  依 日期 × 分店 聚合（筆數 / 件數 / 幾個 SKU / 幾位操作人）
+--              —— 這是「要不要排盤點」的訊號面板。
+--   rows[]     明細（最多 500 列，新到舊）：時間 / 分店 / 商品 / 數量 /
+--              當下在庫 / 單號 / 操作人。
+--
+-- 日界與參數比照 rpc_daily_pickup_settlement（20260826010000）：
+--   Asia/Taipei 切日、預設今天、區間上限 92 天（超過自動夾住，避免全表掃描）。
+--
+-- 權限：LANGUAGE sql STABLE、**不是** SECURITY DEFINER —— 以呼叫者身分跑，
+--   tenant 隔離交給 RLS（同 rpc_daily_pickup_settlement）。
+--
+-- 基底版本：無（新函式）。
+-- Rollback：DROP FUNCTION public.rpc_walkin_stock_topups(bigint, date, date);
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_walkin_stock_topups(
+  p_store_id  BIGINT DEFAULT NULL,
+  p_date_from DATE   DEFAULT NULL,
+  p_date_to   DATE   DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  WITH params AS (
+    SELECT
+      COALESCE(p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date) AS d_from,
+      LEAST(
+        COALESCE(p_date_to, p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date),
+        COALESCE(p_date_from, (now() AT TIME ZONE 'Asia/Taipei')::date) + 92
+      ) AS d_to
+  ),
+  bounds AS (
+    SELECT (p.d_from::timestamp AT TIME ZONE 'Asia/Taipei')     AS ts_from,
+           ((p.d_to + 1)::timestamp AT TIME ZONE 'Asia/Taipei') AS ts_to
+      FROM params p
+  ),
+  topups AS (
+    SELECT
+      sm.id,
+      sm.created_at,
+      (sm.created_at AT TIME ZONE 'Asia/Taipei')::date AS ymd,
+      st.id   AS store_id,
+      st.name AS store_name,
+      sm.sku_id,
+      sm.quantity AS qty,
+      sm.unit_cost,
+      sm.operator_id,
+      -- 單號嵌在 reason 裡（見檔頭）；抓不到就留 NULL，不要讓整列消失
+      substring(sm.reason FROM 'WS-[0-9]+-[0-9]+') AS order_no,
+      sk.sku_code,
+      sk.product_name,
+      sk.variant_name
+    FROM stock_movements sm
+    CROSS JOIN bounds b
+    JOIN stores st ON st.location_id = sm.location_id AND st.tenant_id = sm.tenant_id
+    LEFT JOIN skus sk ON sk.id = sm.sku_id
+   WHERE sm.movement_type = 'manual_adjust'
+     AND sm.reason LIKE '現場銷售即時入帳%'
+     AND sm.created_at >= b.ts_from
+     AND sm.created_at <  b.ts_to
+     AND (p_store_id IS NULL OR st.id = p_store_id)
+  )
+  SELECT jsonb_build_object(
+    'date_from', (SELECT d_from FROM params),
+    'date_to',   (SELECT d_to   FROM params),
+    'summary', COALESCE((
+      SELECT jsonb_agg(x ORDER BY x ->> 'ymd' DESC, x ->> 'store_name')
+        FROM (
+          SELECT jsonb_build_object(
+                   'ymd',        t.ymd,
+                   'store_id',   t.store_id,
+                   'store_name', t.store_name,
+                   'movements',  count(*),
+                   'qty',        sum(t.qty),
+                   'skus',       count(DISTINCT t.sku_id),
+                   'operators',  count(DISTINCT t.operator_id),
+                   'orders',     count(DISTINCT t.order_no)
+                 ) AS x
+            FROM topups t
+           GROUP BY t.ymd, t.store_id, t.store_name
+        ) g
+    ), '[]'::jsonb),
+    'rows', COALESCE((
+      SELECT jsonb_agg(y ORDER BY y ->> 'created_at' DESC)
+        FROM (
+          SELECT jsonb_build_object(
+                   'movement_id', t.id,
+                   'created_at',  t.created_at,
+                   'ymd',         t.ymd,
+                   'store_id',    t.store_id,
+                   'store_name',  t.store_name,
+                   'sku_id',      t.sku_id,
+                   'sku_code',    t.sku_code,
+                   'product_name', t.product_name,
+                   'variant_name', t.variant_name,
+                   'qty',         t.qty,
+                   'unit_cost',   t.unit_cost,
+                   'order_no',    t.order_no,
+                   'operator_id', t.operator_id
+                 ) AS y
+            FROM topups t
+           ORDER BY t.created_at DESC
+           LIMIT 500
+        ) d
+    ), '[]'::jsonb),
+    'rows_total', (SELECT count(*) FROM topups),
+    'qty_total',  COALESCE((SELECT sum(qty) FROM topups), 0)
+  );
+$$;
+
+COMMENT ON FUNCTION public.rpc_walkin_stock_topups(BIGINT, DATE, DATE) IS
+  '現場銷售「結帳時補庫存」稽核報表：manual_adjust + reason 以「現場銷售即時入帳」'
+  '開頭的異動，依 日期 × 分店 聚合＋明細（含單號）。常態性補帳＝帳跟實體長期'
+  '脫節，該排盤點。20260901000030。';
+
+REVOKE ALL ON FUNCTION public.rpc_walkin_stock_topups(BIGINT, DATE, DATE) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_walkin_stock_topups(BIGINT, DATE, DATE) TO authenticated;


### PR DESCRIPTION
## 做了什麼

門市現場銷售（POS）：賣給**沒有訂單**的現場客，一次可買多樣，送出當下就扣庫存、收錢、結案；缺貨的品項可以在同一個畫面上先補庫存再賣。規劃全文見 `docs/PLAN-現場銷售POS.md`。

**核心決定：現場銷售就是一張「出生時已經取完貨」的顧客訂單** —— 單頭 `completed`、品項直接 `picked_up`、每列一筆 `sale` movement。走既有 `customer_orders` 這條路，日結／營收／退貨／撤銷取貨／成本才會自動涵蓋（另開表的話 `rpc_daily_pickup_settlement` 會整批漏掉現場收的錢）。

> ⚠️ 順帶記錄：day-1 留下來的 `pos_sales` / `pos_sale_items` / `rpc_complete_pos_sale` 是**死 schema** —— 線上 0 筆、沒接任何前端、`customer_id` 指向同樣空的 `customers` 表（全站其實用 `members`）。看起來像正主，但用它等於重蓋一套平行帳。

### SQL（4 支 migration，全新，不改任何既有函式）

| 檔案 | 內容 |
|---|---|
| `20260901000000_walkin_sale_schema.sql` | `customer_orders_trio_kind_active_uniq` predicate 加排除 `WS-%`（predicate 沒排除 `completed`，不加的話同店第二張單就撞）；`customer_order_items.source` CHECK 加 `walk_in`；`_walkin_member()` 每店一筆 `guest` 假會員 |
| `20260901000010_rpc_create_walkin_sale.sql` | 主結帳 RPC（多品項、一個交易） |
| `20260901000020_rpc_pos_search_products.sql` | 結帳頁商品搜尋（可賣量＋建議售價，一次撈） |
| `20260901000030_rpc_walkin_stock_topups.sql` | 補庫存稽核報表 |

幾個刻意的決定：

- **可賣量用 `_sku_free_qty_with_pool`，不是 `on_hand`** —— 別的客人正在等的貨不可以被現場客買走。現場銷售直接寫 `sale`、不經過取貨閘門，所以這道閘門是唯一防線。成交後呼叫既有的 `_consume_internal_pool` 扣【內部】店現貨池（不扣的話同一批貨掛兩份承諾，下一位客人的取貨閘門會被擋掉）。
- **`order_kind` 維持 `normal`** —— 全站 188 處用 `order_kind='normal' OR IS NULL` 當口徑，新 kind 會讓現場銷售從營收 / 商品分析整批消失。
- **假會員用 `member_type='guest'` 不用 `store_internal`** —— 後者被日結報表明文排除，掛上去等於現場銷售收的錢在日結看不到。真正的客人名字存 `nickname_snapshot`；線上已有 21,538 位沒電話的會員，不替每位現場客再開一筆。
- **`payment_status` 一律維持 `unpaid`** —— 有 4 個地方把 `'paid'` 當「這張單不用再處理」在用（會員端未結金額、取貨頁儲值金判斷…），開始寫就會靜默改變那些行為。付款方式寫 `payment_method`（目前全站沒人寫）。
- **寫 `order_pickup_events`** —— 不寫的話 `rpc_undo_pickup` 找不到取貨事件會直接 RAISE，店員按錯就救不回來。

### 缺貨補帳（本案唯一的高風險設計）

`add_stock_qty` 讓店員在結帳當下把架上的貨補進帳再賣，是全站少數**憑空生庫存**的入口。四道配套：

1. 限 `store_manager` 以上（前端擋 + RPC 再擋一次）
2. 帶 `_current_cost_price` 當成本（不帶的話 `avg_cost=0` 時 COGS 是 0、毛利虛高）
3. `reason` 固定 `現場銷售即時入帳 <單號>`，單頭 notes 也標明幾件是補帳
4. `/pos/topups` 稽核頁：同店補超過 3 天就跳提示，一鍵導到盤點

明確不做：不碰減抵單（Path D 無條件豁免正是 8/18 松山那次的元凶）、不做負庫存直售。

### 前端

- `/pos` 結帳頁（商品搜尋 + 購物車 + 缺貨列可勾補庫存 + 付款方式預設現金 + 可選會員或只留名字，另有「順便建立為會員」選項）
- `/pos/receipt` 80mm 感熱紙小票（可重印）
- `/pos/topups` 補庫存紀錄
- 訂單頁：`internalOrderSource()` 加 `WS-` → 「🛒 現場銷售」（沿用既有的「sentinel 團改標實際來源」機制，不另開 sentinel 團）、`walk_in` 來源 badge、`/orders` 加一顆快篩鈕

### 尚未做

日結報表依付款方式分項。現場銷售**已經**會進日結（下面實測過），只是還沒拆現金／轉帳。`rpc_daily_pickup_settlement` 最新版是 245 行兩支函式、母體必須逐字一致，為了加一個分項欄位整支重寫是這個 PR 裡風險最高、價值最低的一段，等真的跑起來確定要拆的維度再單獨做。作法寫在 PLAN §9。

## 上線危險

- 做了：
  - **改了一支既有唯一索引的 predicate**（`customer_orders_trio_kind_active_uniq`，DROP + CREATE）。只是多一條排除 `WS-%`，對既有資料是純放寬，不會讓任何現有的單失效；重建期間該表短暫上鎖（線上 69k 列，秒級）。
  - **改了 `customer_order_items_source_check`**，只是多允許 `walk_in` 一個值。
  - 新增 4 支函式、`_walkin_member` 只 GRANT 給內部（`REVOKE` 掉 authenticated），另外三支照既有慣例 GRANT `authenticated`。
  - **`rpc_create_walkin_sale` 會寫 `manual_adjust` 憑空增加庫存**（缺貨補帳）。限 `store_manager` 以上，留 reason 與稽核頁。
- 不做：沒有動任何既有函式（`rpc_record_pickup` / `rpc_create_spot_sale` / `_consume_internal_pool` / 日結報表都是原樣呼叫，一個字沒改）；沒有新增 `order_kind` / `status` 值；不碰 `payment_status`。
- 回退：4 支 migration 檔頭各自寫了 rollback SQL。索引回到不含 `WS-%` 的版本、CHECK 回到不含 `walk_in` 的清單（要先確認沒有 `walk_in` 列）、其餘 `DROP FUNCTION`。前端刪 `/pos` 目錄 + revert 4 個檔案。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

（RPC 內的角色守衛沿用既有的兩套 gate，逐字對齊 `rpc_record_pickup`（取貨店守衛）與 `rpc_undo_pickup`（店長以上）；一律讀 `app_metadata.stores` 店名陣列，不用 `store_id`。）

## 驗證

**SQL — 對正式庫「執行 → 驗證 → ROLLBACK」實測 10 個情境，全過：**

| # | 情境 | 結果 |
|---|---|---|
| 1 | 買 3 樣、其中 1 樣缺 2 件勾補庫存 | `WS-1-0001`、3 列 `picked_up`、3 筆 `sale` + 1 筆 `manual_adjust(+2, cost 2.2)` |
| 2 | 同店連開多張 | `0001`/`0002`/`0003`，沒撞唯一索引 |
| 3 | 超過可賣量 | 擋下，訊息帶「在庫 3、待客取 0、等貨中 0」＋下一步 |
| 4 | 池子有貨（on_hand 6 / free 1 / cap 5）賣 4 件 | `from_pool=3`，池子 4→1（OV- 單留刪除線 `[已現場售出 WS-1-0001]`），on_hand 6→2 |
| 5 | 分店帳號打別店 | `wrong_store` |
| 6 | 賣完當天開日結 | 平鎮店 746 → 996（+250）；`/orders` 列表 `source_summary='walk_in'` |
| 7 | 按錯 → `rpc_undo_pickup` | 兩筆 `reversal`、品項回 `pending`、`on_hand` 完全復原 |
| 8 | 補庫存報表 | 對得回 `WS-1-0001`，summary 與明細都正確 |
| 9 | `store_staff` 勾補庫存 | `permission denied`（不勾則正常結帳） |
| 10 | 單價 0 / 空購物車 / 賣給【內部】店帳號 | 三個都擋下 |

四支 migration 都過 `node scripts/check-sql-syntax.cjs`（含 `parsePlpgsql`）。編號前有 `git ls-tree origin/main` 確認沒撞號；`WS-` / `POS-` 前綴確認線上未被任何 RPC 或訂單使用。

**前端 — `apps/admin:verify`（Playwright + fixture，無真實登入）：**
結帳頁缺貨列出現補庫存勾選、勾了才給結帳、付款方式吃 `stores.allowed_payment_methods`、小票金額／折扣正確且不印出 `WALKIN-` 帳號、`/orders` 快篩按下去 keyword 變 `WS-`、側欄出現「現場銷售」、補庫存頁的常態補帳提示與盤點連結都正確；page error 0。

`npm run build` 綠（含 `check-bundle-browser-support`：109 支 chunk 都能被 Safari 15.6 解析）。新增的 4 個前端檔案 `eslint` 零錯誤（repo 既有的 164 個問題未動）。

## 部署紀錄

**✅ 2026-09-01 已套上正式庫**（Management API，四支依序 `BEGIN … COMMIT`），並於同日隨本 PR 進 main（base = main）。

線上覆核：
- `rpc_create_walkin_sale` / `rpc_pos_search_products` / `rpc_walkin_stock_topups` 三支存在且 `authenticated` 可執行；`_walkin_member` 已 REVOKE（內部用）
- `customer_orders_trio_kind_active_uniq` 的 predicate 含 `WS-%`
- `customer_order_items_source_check` 含 `walk_in`
- 對**已部署的**函式再跑一次端對端（開單 → completed / picked_up / walk_in、補庫存進稽核報表），確認後 ROLLBACK，線上未留測試資料

`git log origin/main -- supabase/migrations/2026090100000*.sql` 四支都查得到（commit `79f940b`）—— repo 與正式庫同步。