### PR TITLE
漂漂彤廠商選單新增固定廠商

### DIFF
--- a/apps/member/src/app/piaopiao/publisher/page.tsx
+++ b/apps/member/src/app/piaopiao/publisher/page.tsx
@@ -21,7 +21,7 @@ const emptyProduct = (): Product => ({
 });
 const REQUEST_KEY = "piaopiao_pending_request_id";
 const MAX_BATCH_VARIANTS = 100;
-const SUPPLIER_OPTIONS = ["包子媽", "山瀾商行"];
+const SUPPLIER_OPTIONS = ["包子媽", "山瀾商行", "NO21", "精品", "599", "Diz.o", "芭斯特", "祥美", "亞諾"];
 
 export default function PiaopiaoPublisherPage() {
   const [token, setToken] = useState("");


### PR DESCRIPTION
只改漂漂館上架頁的漂漂彤廠商下拉選單。

新增選項：
NO21、精品、599、Diz.o、芭斯特、祥美、亞諾

保留：
包子媽、山瀾商行、自訂

漂漂潮仍固定潮包子，不動。
沒有 SQL、沒有 Edge Function、沒有碰一般團購、訂單、取貨、帳務。