### PR TITLE
取貨頁：可取的單排最前面，不再夾在未到貨的單中間

### DIFF
--- a/apps/admin/src/app/(protected)/pickup/page.tsx
+++ b/apps/admin/src/app/(protected)/pickup/page.tsx
@@ -152,7 +152,20 @@ function PickupPageContent() {
   // 分店帳號看到的該會員訂單（其他店的單以摘要提示呈現，不進這份清單）
   function visibleOrdersOf(memberId: number): OpenOrder[] {
     const all = orders.get(memberId) ?? [];
-    return branchLocked ? all.filter(isOwnStoreOrder) : all;
+    const vis = branchLocked ? all.filter(isOwnStoreOrder) : all;
+    if (mode !== "open") return vis;
+    // 未取貨模式：有可取品項的單一律排最前面。search() 那層只看單頭
+    // status='ready' / ready_at，但 pending / confirmed / shipping 單可以靠取貨閘門
+    // 逐品項放行（現貨配單、補貨 ride-along、部分到貨…）—— 單頭沒動、ready_at 是 NULL，
+    // 就被當成未到貨混在中間（2026-09-02 松山：畫著「✅ 已到貨・4 項可取」卻夾在
+    // 三張未到貨的單之間）。閘門結果在 itemReady state 裡、search() 排序時還拿不到，
+    // 所以在這裡（render 時）再排一次；sort 是穩定的，同組內沿用原本 ready_at 順序。
+    return vis.slice().sort((a, b) => {
+      const ap = pickableItems(a).length > 0;
+      const bp = pickableItems(b).length > 0;
+      if (ap !== bp) return ap ? -1 : 1;
+      return 0;
+    });
   }
 
   // 該品項未取退貨量 / 扣掉已退後仍可取量


### PR DESCRIPTION
## 症狀

取貨頁同一位會員底下，一張寫著「✅ 已到貨・4 項可取」的單夾在三張「分店尚未收貨，無法取貨」的單中間。

## 原因

`search()` 的排序只看單頭：`status='ready'` 在前、其餘照 `ready_at ASC NULLS LAST`。但 `pending` / `confirmed` / `shipping` 的單可以靠取貨閘門逐品項放行（現貨配單、補貨 ride-along、部分到貨），這些單頭沒有被推成 `ready`、`ready_at` 也是 NULL，於是被當成未到貨排在中間。

閘門結果（`itemReady`）是排序完之後才查回來的，所以那一層排不到它。

## 修法

`visibleOrdersOf` 在 render 時再排一次：有可取品項（`pickableItems().length > 0`）的排前面，同組內沿用原本的 `ready_at` 順序（`Array.sort` 穩定）。只在未取貨模式生效，已取貨模式維持 `completed_at DESC`。

## 驗證

`tsc --noEmit` 通過；`eslint` 對該檔只剩一個既有的 `set-state-in-effect`（line 999，與本次改動無關）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8Bd9f7pKVuKmdretKgcaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8Bd9f7pKVuKmdretKgcaP)_