### PR TITLE
feat(wms): 樓下 iPad 收貨一鍵傳撿貨草稿＋採購單 iPad 查看頁

### DIFF
--- a/apps/admin/src/app/(protected)/wms/receiving/ipad/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/receiving/ipad/page.tsx
@@ -86,6 +86,13 @@ import {
   type WorkbenchPO,
 } from "@/lib/receivingBatch";
 import { publicProductUrl } from "@/lib/campaignCover";
+import { describeDraftDbError } from "@/lib/pickingDraftView";
+import {
+  handoffMessage,
+  handoffToDraft,
+  type HandoffSku,
+  type HandoffSource,
+} from "@/lib/pickingDraftHandoff";
 import { useAuth } from "@/components/AuthProvider";
 import SpinButton from "@/components/SpinButton";
 
@@ -129,6 +136,30 @@ type PoOutcome = {
   kind: "ok" | "duplicate" | "error";
   gr_no?: string;
   message?: string;
+};
+
+/**
+ * 「這一批真的收進去了什麼」—— 送出成功那一刻拍下來，給「📋 傳到撿貨草稿」用。
+ *
+ * ⛔⛔ 一定要在 doSubmit 當下就拍：送出成功之後那幾張單的勾選會被清掉
+ *   （setEntries）、rows 會被 reloadPos 換成最新的 —— 事後**再也拼不回**
+ *   這一批是哪些東西、各幾件。
+ *
+ * ⭐ 只收 `kind === "ok"` 的採購單：
+ *   · `error` ＝ 根本沒入庫，帶進草稿就是叫樓下去撿不存在的貨。
+ *   · `duplicate` ＝ 後端回的是**先前那張**進貨單，這次填的件數不見得一樣
+ *     （本頁 OutcomePanel 已經立好這條規則：「duplicate 時不可以顯示這次填的件數」）
+ *     ⇒ 一樣不帶，改成在訊息裡明講有幾張是這種情況。
+ */
+type HandoffPayload = {
+  /** 同一樣商品跨多張採購單會先合併（qty 相加）＝ 這次實收的量 */
+  skus: HandoffSku[];
+  source: HandoffSource;
+  /** 這次有幾張是「先前就收過了」→ 沒帶進草稿，要在訊息裡講 */
+  duplicatePos: number;
+  /** 已經按過一次「傳到撿貨草稿」（改按鈕字樣用；⛔ 不用來擋第二次按，
+   *  部分失敗時本來就要能原封不動再按一次重試） */
+  sent: boolean;
 };
 
 // 數量不符時的常用原因（一鍵填進既有 variance_reason 欄位，不新增資料表）
@@ -535,8 +566,18 @@ export default function IpadReceivingPage() {
   const [staleWarning, setStaleWarning] = useState<string | null>(null);
   const [reloadingPo, setReloadingPo] = useState<number | null>(null);
 
+  /** 這一批收好了什麼（給「📋 傳到撿貨草稿」用）。null ＝ 這次沒有任何真的收進去的單。 */
+  const [handoff, setHandoff] = useState<HandoffPayload | null>(null);
+  /** 傳草稿的結果。⛔ 與收貨本身的 error / staleWarning **分開放**：
+   *  草稿沒傳成功 ≠ 貨沒收到，兩件事混在同一個紅框會讓樓下以為貨也沒收進去。 */
+  const [draftNotice, setDraftNotice] = useState<string | null>(null);
+  const [draftError, setDraftError] = useState<string | null>(null);
+  /** 傳草稿的進度（已處理/總數）。⛔ 不是裝飾：逐樣往返 30 樣要等十秒上下，
+   *  只寫「傳送中…」樓下會以為當掉。null ＝ 現在沒在傳。 */
+  const [draftProgress, setDraftProgress] = useState<{ done: number; total: number } | null>(null);
+
   /**
-   * ⭐ 全頁**只有一把鎖**：整頁重撈 / 單張重撈 / 送出，三者互斥。
+   * ⭐ 全頁**只有一把鎖**：整頁重撈 / 單張重撈 / 送出 / 傳草稿，四者互斥。
    *   規則本身在 @/lib/receivingBatch 的 runExclusive()（那裡有完整推導，
    *   而且驗得到）。這裡只有兩份存放處：
    *     · busyRef —— 真正的鎖。⛔ 一定要用 ref，state 擋不住同一 tick 連點
@@ -544,14 +585,18 @@ export default function IpadReceivingPage() {
    *     · busy    —— 給畫面用的鏡像。按鈕變灰、而且**要看得出來為什麼**
    *       （iPad 沒有 tooltip，停用原因只能寫在畫面上）。
    *
-   * ⚠️ 為什麼三者非互斥不可：重撈會清掉那幾張單的 entries 與 subsRef（冪等鍵），
+   * ⚠️ 為什麼非互斥不可：重撈會清掉那幾張單的 entries 與 subsRef（冪等鍵），
    *   跑在送出中途等於把防重複的鍵抽掉；反過來送出中途重撈，畫面上的
    *   「之前已收」會在送出的一連串 await 中間被換掉。
    *   帳本身有後端的樂觀鎖兜著（失敗是吵的），但畫面會變得沒辦法判讀。
+   * ⚠️ 「傳草稿」也納進同一把鎖：它要逐樣讀需求再寫入（好幾趟往返），
+   *   跑到一半如果還按得動「🔄 重新載入這張單」，結果面板會被抽掉、
+   *   而草稿還在寫 —— 樓下會完全不知道現在到底傳完了沒。
    */
   const busyRef = useRef<BusyKind | null>(null);
   const [busy, setBusy] = useState<BusyKind | null>(null);
   const submitting = busy === "submit";
+  const draftSending = busy === "draft";
 
   /**
    * 每一張採購單自己的冪等鍵 ＋ 當時送出的內容。
@@ -866,12 +911,18 @@ export default function IpadReceivingPage() {
     });
     if (held === "load") {
       setError("清單正在重新載入，等它跑完再按「確認收貨」。");
+    } else if (held === "draft") {
+      setError("正在把上一批傳到撿貨草稿，等它跑完再按「確認收貨」。");
     }
   }
 
   async function doSubmit() {
     setError(null);
     setStaleWarning(null);
+    // 上一批的草稿訊息講的是上一批，留著會跟這次的結果對不上
+    setDraftNotice(null);
+    setDraftError(null);
+    setHandoff(null);
 
     try {
       const { data: userRes } = await getSupabase().auth.getUser();
@@ -928,6 +979,49 @@ export default function IpadReceivingPage() {
       });
       const donedPoIds = raw.filter((o) => o.kind !== "error").map((o) => o.po_id);
 
+      // ⭐ 拍下「這一批真的收進去了什麼」給「📋 傳到撿貨草稿」用。
+      //   ⛔ 一定要在這裡拍（見 HandoffPayload 的說明）：下面幾行就會把成功那幾張的
+      //     勾選清掉、把 rows 重撈成最新的，之後再也拼不回這一批。
+      //   ⭐ 同一樣商品跨多張採購單要**合併相加**：老闆要的是「這樣商品這次收了幾件」，
+      //     分成兩列傳過去只會撞上草稿的 UNIQUE(draft_id, sku_id, store_id)。
+      {
+        const okPoIds = new Set(raw.filter((o) => o.kind === "ok").map((o) => o.po_id));
+        const rowByItemId = new Map(selectedRows.map((r) => [r.po_item_id, r]));
+        const bySku = new Map<number, HandoffSku>();
+        for (const it of items) {
+          if (!okPoIds.has(it.po_id)) continue;
+          const r = rowByItemId.get(it.po_item_id);
+          // ⓘ items 就是從 selectedRows 攤出來的，理論上一定找得到；
+          //   找不到就跳過而不是硬填 —— 沒有品名的列在草稿上是查不回來的孤兒。
+          if (!r) continue;
+          const cur = bySku.get(it.sku_id);
+          if (cur) cur.qty += it.qty;
+          else
+            bySku.set(it.sku_id, {
+              sku_id: it.sku_id,
+              sku_code: r.sku_code,
+              label: rowTitle(r),
+              qty: it.qty,
+            });
+        }
+        const okOutcomes = results.filter((o) => o.kind === "ok");
+        const source: HandoffSource = {
+          po_nos: okOutcomes.map((o) => o.po_no),
+          gr_nos: okOutcomes.map((o) => o.gr_no).filter((v): v is string => !!v),
+          at: new Date().toISOString(),
+        };
+        setHandoff(
+          bySku.size > 0
+            ? {
+                skus: Array.from(bySku.values()),
+                source,
+                duplicatePos: raw.filter((o) => o.kind === "duplicate").length,
+                sent: false,
+              }
+            : null,
+        );
+      }
+
       // 成功的那幾張：清掉使用者輸入（貨已經收了，留著只會被誤按第二次），
       // 並重撈它們的最新已收量。
       // ⚠️ 失敗的那幾張**刻意不動**：保留原樣才能「原內容再按一次」＝ 帶同一把鍵重試。
@@ -972,6 +1066,93 @@ export default function IpadReceivingPage() {
       setError(translateRpcError(e));
     }
     // ⓘ 鎖的釋放在 runExclusive 的 finally，⛔ 不要在這裡再放一次。
+  }
+
+  // ------------------------------------------------------------ 傳到撿貨草稿
+
+  /**
+   * 把剛收好的這批商品傳進「今天的撿貨草稿」。
+   *
+   * ⛔ 這條路**完全不碰庫存、不建任何單**：只寫 picking_drafts /
+   *   picking_draft_items 兩張草稿自己的表（規則與推導在 @/lib/pickingDraftHandoff）。
+   *   收貨已經在上一步完成了 —— 這裡失敗只代表「草稿沒加到」，**貨還是收進來了**，
+   *   所以訊息與收貨的紅框刻意分開放。
+   *
+   * ⭐ 可以重複按：已經在草稿裡的商品會被略過（不重複加、也不動原本的數量），
+   *   所以部分失敗時「原封不動再按一次」就是正確的重試方式。
+   */
+  async function runHandoff() {
+    const payload = handoff;
+    if (!payload) return;
+    const held = await runExclusive(busyRef, "draft", setBusy, async () => {
+      setDraftNotice(null);
+      setDraftError(null);
+      setDraftProgress({ done: 0, total: payload.skus.length });
+      const sb = getSupabase();
+      try {
+        const report = await handoffToDraft(
+          {
+            db: sb,
+            fetchAll: fetchAllRows,
+            describeError: describeDraftDbError,
+            onProgress: (done, total) => setDraftProgress({ done, total }),
+            session: async () => {
+              // ⚠️ 與草稿頁的 sessionInfo()（picking/drafts/edit/page.tsx:361-367）
+              //   逐字同一套：tenant_id 拿不到就 throw，⛔ 不可以退回空值硬寫
+              //   （RLS 會擋，但擋出來的錯誤是天書）。
+              const { data } = await sb.auth.getSession();
+              const tenantId = (
+                data.session?.user?.app_metadata as Record<string, unknown> | undefined
+              )?.tenant_id as string | undefined;
+              if (!tenantId) throw new Error("JWT 缺 tenant_id claim、無法寫入撿貨草稿");
+              return { tenantId, uid: data.session?.user?.id ?? null };
+            },
+          },
+          {
+            skus: payload.skus,
+            source: payload.source,
+            duplicatePos: payload.duplicatePos,
+            // ⭐ 這一頁餵的是「剛剛那一次送出真的收進來的量」。
+            //   ⛔ 採購單查看頁餵的是**累計實收**，兩邊的措辭必須不一樣
+            //   （阿審 2026-09-02 P1）。
+            qtyBasis: "this_receipt",
+          },
+        );
+        const msg = handoffMessage(report);
+        setDraftNotice(msg.notice);
+        setDraftError(msg.error);
+        // ⭐ 只要有東西真的進去（或本來就在裡面／被別台搶先加）就記成「傳過了」——
+        //   按鈕字樣改成「再傳一次」，讓樓下看得出這批已經處理過。
+        //   ⛔ 但不停用：部分失敗要能再按一次重試。
+        if (report.added.length > 0 || report.skipped.length > 0 || report.raced.length > 0) {
+          setHandoff((cur) => (cur ? { ...cur, sent: true } : cur));
+        }
+      } catch (e) {
+        // handoffToDraft 自己會把預期內的失敗收進 report，走到這裡代表**預期外**
+        // （例如連 supabase client 都拿不到）。⛔ 不可以讓它變成 unhandled rejection：
+        //   那樣畫面只會靜靜地回到原樣，樓下會以為傳成功了。
+        setDraftError(
+          `傳到撿貨草稿時發生預期外的錯誤：${describeDraftDbError(e)}` +
+            `（貨已經收進來了，這只是撿貨草稿沒加到。）`,
+        );
+      } finally {
+        // ⛔ 一定要放在 finally：中途丟例外時進度若留在「12 / 30」，
+        //   畫面會永遠停在一個看起來還在跑、其實早就停了的數字。
+        setDraftProgress(null);
+      }
+    });
+    // ⛔ 三種佔用都要各講各的（阿審 2026-09-02 P2）：原本只分 "submit" 與「其他」，
+    //   同一 tick 連點兩下時 runExclusive 回的是 "draft"，卻會被說成
+    //   「清單正在重新載入」—— 那是一句不成立的話，而且會叫他去等一件根本沒在跑的事。
+    if (held) {
+      setDraftError(
+        held === "submit"
+          ? "正在送出收貨，等它跑完再按「傳到撿貨草稿」。"
+          : held === "draft"
+            ? "已經在傳到撿貨草稿了，等它跑完（不用再按一次，不會漏掉）。"
+            : "清單正在重新載入，等它跑完再按「傳到撿貨草稿」。",
+      );
+    }
   }
 
   /** 按下「確認收貨」。已勾但畫面上看不到的列 → 先攤開讓他看過再送。 */
@@ -1074,6 +1255,15 @@ export default function IpadReceivingPage() {
             {/* SpinButton 會自己在 promise 未完成時顯示 spinner，不必另外接 loading state */}
             🔄
           </SpinButton>
+          {/* 採購單查看（老闆 2026-08-31 ⑦「補貨申請跟採購單，我想要有 ipad 版本」，
+              9-01 補充「採購單做查看」）。唯讀，不能在那邊收貨。 */}
+          <Link
+            href="/wms/receiving/ipad/po"
+            className={`${BTN_GHOST} shrink-0`}
+            aria-label="查看採購單"
+          >
+            📄 採購單
+          </Link>
           {/* 出口：不然樓下會被困在這一頁出不去 */}
           <Link href="/wms/receiving" className={`${BTN_GHOST} shrink-0`}>
             離開
@@ -1163,7 +1353,29 @@ export default function IpadReceivingPage() {
             // ⛔ 送出中、或別張單正在重撈時，這幾顆全部要變灰
             //   （不是只灰掉自己那一顆）—— 見 busyRef 的說明。
             locked={busy !== null}
-            onDismiss={() => setOutcomes(null)}
+            handoff={handoff}
+            draftSending={draftSending}
+            draftProgress={draftProgress}
+            draftNotice={draftNotice}
+            draftError={draftError}
+            onHandoff={runHandoff}
+            onDismiss={() => {
+              // ⚠️ 面板收掉之後，「📋 傳到撿貨草稿」就再也按不到了（payload 只活在這一批）。
+              //   還沒傳過就先問一聲 —— ⛔ 不可以靜默丟掉：樓下按「知道了」是想關掉提示，
+              //   不是想放棄傳草稿，而且關掉之後畫面上完全看不出來少做了一件事。
+              //   （貨已經收進來了，所以這裡只是少一個便利入口，不是資料遺失。）
+              if (handoff && !handoff.sent) {
+                const ok = confirm(
+                  `這批還沒有傳到撿貨草稿（${handoff.skus.length} 樣）。` +
+                    `關掉之後就要自己到撿貨草稿頁一樣一樣加。\n\n確定要關掉嗎？`,
+                );
+                if (!ok) return;
+              }
+              setOutcomes(null);
+              setHandoff(null);
+              setDraftNotice(null);
+              setDraftError(null);
+            }}
             // ⭐ 2026-08-20 複審 P1：這條路徑以前**沒有取互斥鎖**，
             //   重撈跑到一半還按得下「確認收貨」。現在跟整頁重撈走同一把鎖。
             onReloadPo={async (poId) => {
@@ -1366,15 +1578,22 @@ export default function IpadReceivingPage() {
               ? "送出中…"
               : busy === "load"
                 ? "重新載入中…"
-                : `✅ 確認收貨${summary.lines > 0 ? ` (${summary.lines})` : ""}`}
+                : draftSending
+                  ? "傳草稿中…"
+                  : `✅ 確認收貨${summary.lines > 0 ? ` (${summary.lines})` : ""}`}
           </SpinButton>
         </div>
-        {/* ⛔ 停用原因一定要看得見，不可以只放 title：iPad 上沒有 tooltip */}
+        {/* ⛔ 停用原因一定要看得見，不可以只放 title：iPad 上沒有 tooltip。
+            ⚠️ busy 每多一種就要在這裡補一句 —— 少補就是「按鈕變灰但沒說為什麼」。 */}
         {blockReason ? (
           <p className="mt-2 text-sm font-medium text-rose-600 dark:text-rose-400">{blockReason}</p>
         ) : busy === "load" ? (
           <p className="mt-2 text-sm font-medium text-amber-700 dark:text-amber-300">
             清單正在重新載入，等它跑完才能送出（免得送出的內容跟畫面上看到的對不起來）。
+          </p>
+        ) : draftSending ? (
+          <p className="mt-2 text-sm font-medium text-amber-700 dark:text-amber-300">
+            正在把上一批傳到撿貨草稿，等它跑完才能再收下一批。
           </p>
         ) : null}
       </footer>
@@ -1404,19 +1623,34 @@ function OutcomePanel({
   outcomes,
   busyPo,
   locked,
+  handoff,
+  draftSending,
+  draftProgress,
+  draftNotice,
+  draftError,
+  onHandoff,
   onDismiss,
   onReloadPo,
 }: {
   outcomes: PoOutcome[];
   /** 正在重撈的那一張（顯示「載入中…」用） */
   busyPo: number | null;
-  /** 全頁有別的非同步流程在跑（送出／別張重撈）→ 這裡的按鈕全部要停用 */
+  /** 全頁有別的非同步流程在跑（送出／別張重撈／傳草稿）→ 這裡的按鈕全部要停用 */
   locked: boolean;
+  /** 這批真的收進去的商品；null ＝ 沒有任何一張是「新收進來的」，那就不出現草稿區塊 */
+  handoff: HandoffPayload | null;
+  draftSending: boolean;
+  /** 傳送進度（已處理/總數）。null ＝ 現在沒在傳 */
+  draftProgress: { done: number; total: number } | null;
+  draftNotice: string | null;
+  draftError: string | null;
+  onHandoff: () => Promise<void>;
   onDismiss: () => void;
   onReloadPo: (poId: number) => Promise<void>;
 }) {
   const ok = outcomes.filter((o) => o.kind !== "error").length;
   const bad = outcomes.length - ok;
+  const handoffQty = handoff ? handoff.skus.reduce((s, k) => s + k.qty, 0) : 0;
   return (
     <div className="mb-4 rounded-2xl border-2 border-zinc-300 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
       <div className="flex items-start justify-between gap-3">
@@ -1503,6 +1737,85 @@ function OutcomePanel({
           </li>
         ))}
       </ul>
+
+      {/* ---- 傳到撿貨草稿（老闆 2026-08-31 ②）----
+          ⛔ 只有「真的新收進來」的貨才會出現這一區（handoff 為 null 就整個不畫）：
+             全部失敗、或全部是「先前就收過了」時，這裡沒有東西可以傳。 */}
+      {handoff && (
+        <div className="mt-4 rounded-xl border-2 border-indigo-300 bg-indigo-50 p-3 dark:border-indigo-800 dark:bg-indigo-950/40">
+          <div className="flex flex-wrap items-center gap-3">
+            <SpinButton
+              type="button"
+              disabled={locked && !draftSending}
+              onClick={onHandoff}
+              className={`${BTN_BASE} bg-indigo-600 text-base text-white active:bg-indigo-700 disabled:bg-zinc-300 dark:disabled:bg-zinc-700`}
+            >
+              {/* ⭐ 進度要數得出來：逐樣往返，30 樣要等十秒上下。
+                  只寫「傳送中…」樓下會以為當掉而去戳別的東西。 */}
+              {draftSending
+                ? draftProgress
+                  ? `傳送中… ${draftProgress.done} / ${draftProgress.total}`
+                  : "傳送中…"
+                : handoff.sent
+                  ? "📋 再傳一次"
+                  : `📋 傳到撿貨草稿 (${handoff.skus.length})`}
+            </SpinButton>
+            <div className="min-w-0 flex-1 text-sm text-zinc-700 dark:text-zinc-300">
+              {/* ⭐ 畫面上的每一句都要是查得到出處的事實：
+                  · 「N 樣 · M 件」＝ 這次送出成功（kind === "ok"）那幾張單的品項合計
+                  · 「今天的撿貨草稿」＝ findOrCreateTodayDraft 的判定（台北時區今天、
+                    狀態還是進行中、最新建立的那一張；沒有就開一張）
+                  ⛔ 不寫「一定會…」「絕對不會…」這種絕對句。 */}
+              把這次收好的 {handoff.skus.length} 樣 · {fmtQty(handoffQty)} 件送進
+              <span className="font-semibold">今天的撿貨草稿</span>
+              （沒有就開一張新的）。各店數量會依「還沒派的需求」自動帶出來，
+              合計不超過這次收的量；不會動到庫存，也不會建任何出貨單。
+              {handoff.duplicatePos > 0 && (
+                <>
+                  {" "}
+                  <span className="text-amber-800 dark:text-amber-300">
+                    （另外 {handoff.duplicatePos} 張是「先前就收過了」，沒有算在裡面。）
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* 停用原因要看得見（iPad 沒有 tooltip） */}
+          {locked && !draftSending && (
+            <p className="mt-2 text-sm font-medium text-amber-700 dark:text-amber-300">
+              現在有別的動作在跑，等它跑完再按這裡。
+            </p>
+          )}
+
+          {draftNotice && (
+            <p className="mt-3 rounded-lg bg-white/70 p-3 text-sm text-zinc-800 dark:bg-zinc-900/60 dark:text-zinc-200">
+              {draftNotice}
+            </p>
+          )}
+          {/* ⛔ 草稿失敗與收貨失敗**分開講**：貨已經收進來了，
+              混在一起會讓樓下以為要重收一次貨。 */}
+          {draftError && (
+            <p className="mt-3 rounded-lg border border-rose-300 bg-rose-50 p-3 text-sm font-medium text-rose-800 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-200">
+              {draftError}
+              <span className="mt-1 block font-normal">
+                （貨已經收進來了，這只是撿貨草稿沒加到。）
+              </span>
+            </p>
+          )}
+
+          {handoff.sent && (
+            <p className="mt-3 text-sm">
+              <Link
+                href="/picking/drafts"
+                className="font-semibold text-indigo-700 underline dark:text-indigo-300"
+              >
+                去撿貨草稿頁分各店 →
+              </Link>
+            </p>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/admin/src/app/(protected)/wms/receiving/ipad/po/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/receiving/ipad/po/page.tsx
@@ -1,0 +1,665 @@
+"use client";
+
+// 📄 採購單查看（iPad 專用頁）—— 唯讀 ＋ 逐列「寫入撿貨草稿」
+//
+// 這一頁在解什麼（老闆 2026-08-31 ⑦，9-01 補充）：
+//   「補貨申請跟採購單，我想要有 ipad 版本」
+//   → 「採購單我想要做**查看**，但是寫入撿貨草稿要能帶出數量」
+//   樓下拿 iPad 想翻某張採購單看「訂多少 / 到多少 / 還差多少」，
+//   順手把某一項寫進今天的撿貨草稿（數量自動帶）。
+//
+// ⛔⛔ 這一頁是**唯讀**的（除了寫撿貨草稿那條）：
+//   · 不收貨、不改數量、不斷貨、不建單、不碰庫存。
+//   · 要收貨請走 /wms/receiving/ipad（本頁 header 有出口）。
+//   · 對既有頁面一行不改：/purchase/orders 與 /purchase/orders/receive 原封不動。
+//
+// ⛔ 範圍外（老闆 2026-09-02 問題 1 裁示「這次不做」）：補貨申請的 iPad 版。
+//
+// 設計約束（沿用 /wms/receiving/ipad 那一頁，⛔ 不要各走各的）：
+//   1. 觸控目標 min-h-[44px]／主要按鈕 56px ＋ touch-manipulation；輸入框 ≥16px
+//      （低於 16px 一 focus，iOS 就把整頁放大）。
+//   2. ⛔ 重要資訊不可以只放在 title tooltip —— iPad 上根本沒有 tooltip。
+//      按鈕變灰**一定要在畫面上寫出為什麼**。
+//   3. 側欄：不改全站 layout.tsx，本頁自己 fixed 全屏蓋掉（z-40，讓 Modal 的 z-50 蓋得住）。
+//      高度用 dvh 不用 vh（iPad 工具列收合時 vh 比可視高度大，底部會被切掉）。
+//   4. 權限：/purchase/orders 在 layout 的 BRANCH_HIDDEN_HREFS 裡對分店帳號隱藏
+//      （layout.tsx:130），本頁是它的 iPad 入口 ⇒ **不可以比它寬**，照同一條判定擋掉。
+//
+// 資料來源（都是既有的，⛔ 沒有新增任何 RPC / migration）：
+//   · 清單 ＝ rpc_po_list（最新版 20260812000000_po_stockout_split_and_restore.sql:804；
+//     server-side 搜尋／排序／分頁，搜的是單號/廠商/來源請購單/商品名）
+//   · 明細 ＝ purchase_orders + purchase_order_items + skus
+//     （查法逐項對齊 purchase/orders/receive/page.tsx:118-119,:130）
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { getSupabase } from "@/lib/supabase";
+import { fetchAllRows } from "@/lib/fetchAllRows";
+import { translateRpcError } from "@/lib/rpcError";
+import { describeDraftDbError } from "@/lib/pickingDraftView";
+import { handoffMessage, handoffToDraft } from "@/lib/pickingDraftHandoff";
+import { runExclusive, type BusyKind } from "@/lib/receivingBatch";
+import { useAuth } from "@/components/AuthProvider";
+import SpinButton from "@/components/SpinButton";
+
+// ---------------------------------------------------------------- 共用樣式
+// ⓘ 與 /wms/receiving/ipad/page.tsx:248-255 同一組。⛔ 兩頁要一起改，
+//   否則樓下在兩頁按到大小不一樣的按鈕。
+const BTN_BASE =
+  "inline-flex items-center justify-center gap-1 rounded-xl font-semibold touch-manipulation " +
+  "min-h-[56px] min-w-[56px] px-4 text-base disabled:cursor-not-allowed disabled:opacity-40";
+const BTN_PRIMARY = `${BTN_BASE} bg-blue-600 text-white active:bg-blue-700`;
+const BTN_GHOST = `${BTN_BASE} border border-zinc-300 bg-white text-zinc-800 active:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:active:bg-zinc-800`;
+const BTN_SMALL =
+  "inline-flex items-center justify-center gap-1 rounded-lg font-semibold touch-manipulation " +
+  "min-h-[44px] px-3 text-sm disabled:cursor-not-allowed disabled:opacity-40";
+
+const PAGE_SIZE = 30;
+
+// ---------------------------------------------------------------- helpers
+
+/** 分店帳號判定 —— 與 (protected)/layout.tsx:134 的 isBranchUser()、
+ *  以及 /wms/receiving/ipad/page.tsx:200-204 的同名函式**逐字相同**。
+ *  ⚠ 那兩支一個住在禁改的全站 layout、一個住在收貨頁，這裡是第三份抄本；
+ *    改任何一份都要三份一起改。 */
+function isBranchAccount(user: { app_metadata?: Record<string, unknown> } | null | undefined): boolean {
+  const stores = user?.app_metadata?.stores;
+  if (!Array.isArray(stores) || stores.length === 0) return false;
+  return !stores.includes("總倉");
+}
+
+/** 商品名一律帶 variant_name —— 與 /wms/receiving/ipad/page.tsx:225-234 的 rowTitle() 同一條規則：
+ *  product_name 常常是上層品名，只印它現場會抓錯貨
+ *  （G00213-01 的 product_name 是「台南日曬手工麵」，真正的東西
+ *   「(A)關廟刀削麵」在 variant_name）。 */
+function skuTitle(r: {
+  product_name: string | null;
+  variant_name: string | null;
+  sku_code: string | null;
+  sku_id: number;
+}): string {
+  const main = r.product_name?.trim() || r.sku_code || `#${r.sku_id}`;
+  const sub = r.variant_name?.trim();
+  return sub ? `${main} / ${sub}` : main;
+}
+
+/** 整數就不要拖著 .000（numeric(18,3) 的浮點尾巴很難看） */
+function fmtQty(n: number): string {
+  return Number.isInteger(n) ? String(n) : String(Number(n.toFixed(3)));
+}
+
+const STATUS_ZH: Record<string, string> = {
+  draft: "草稿",
+  sent: "已下單",
+  partially_received: "部分到貨",
+  fully_received: "已收齊",
+  closed: "已結案",
+  cancelled: "已取消",
+};
+
+// ---------------------------------------------------------------- 外殼
+
+function Shell({
+  title,
+  subtitle,
+  right,
+  children,
+}: {
+  title: string;
+  subtitle?: React.ReactNode;
+  right?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="fixed inset-x-0 top-0 z-40 flex h-[100dvh] flex-col bg-zinc-100 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100">
+      <header className="shrink-0 border-b border-zinc-300 bg-white px-4 py-3 dark:border-zinc-700 dark:bg-zinc-900">
+        <div className="flex items-center gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-xl font-bold">{title}</div>
+            {subtitle && (
+              <div className="truncate text-sm text-zinc-600 dark:text-zinc-400">{subtitle}</div>
+            )}
+          </div>
+          {right}
+        </div>
+      </header>
+      <main className="min-h-0 flex-1 overflow-y-auto px-4 py-4">{children}</main>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- 清單
+
+type PoRow = {
+  id: number;
+  po_no: string;
+  supplier_name: string | null;
+  status: string;
+  expected_date: string | null;
+  item_count: number;
+  stockout_items: number;
+};
+
+function PoList() {
+  const [rows, setRows] = useState<PoRow[] | null>(null);
+  const [total, setTotal] = useState(0);
+  const [search, setSearch] = useState("");
+  const [dSearch, setDSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [error, setError] = useState<string | null>(null);
+
+  // 搜尋 debounce 300ms —— 與 purchase/orders/page.tsx:175-178 同一個數字
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setDSearch(search);
+      setPage(1); // 換關鍵字就回第一頁，否則會停在空白的第 3 頁
+    }, 300);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data, error: err } = await getSupabase().rpc("rpc_po_list", {
+          p_status: null, // 全部狀態；樓下要翻的常常是已結案的舊單
+          p_supplier_id: null,
+          p_search: dSearch.trim() || null,
+          p_date_from: null,
+          p_date_to: null,
+          p_sort: "updated_at",
+          p_dir: "desc",
+          p_page: page,
+          p_page_size: PAGE_SIZE,
+        });
+        if (cancelled) return;
+        if (err) throw err;
+        const resp = data as { total: number; rows: PoRow[] } | null;
+        setRows(resp?.rows ?? []);
+        setTotal(Number(resp?.total ?? 0));
+        setError(null);
+      } catch (e) {
+        if (!cancelled) {
+          setError(translateRpcError(e));
+          // ⛔ 失敗時**不要**把 rows 設成空陣列：那會畫出「沒有符合的採購單」，
+          //   跟「查詢壞了」長得一模一樣。留 null 讓下面只顯示錯誤。
+          setRows(null);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dSearch, page]);
+
+  const maxPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <Shell
+      title="📄 採購單（查看）"
+      subtitle="只能看，不能在這裡收貨或改數量"
+      right={
+        <Link href="/wms/receiving/ipad" className={`${BTN_GHOST} shrink-0`}>
+          回收貨
+        </Link>
+      }
+    >
+      <div className="mb-4">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          type="text"
+          enterKeyHint="search"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+          placeholder="🔍 打單號、廠商名或商品名"
+          aria-label="搜尋採購單"
+          className="min-h-[56px] w-full rounded-xl border-2 border-zinc-300 bg-white px-4 text-lg dark:border-zinc-600 dark:bg-zinc-950"
+        />
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-xl border border-red-300 bg-red-50 p-4 text-base font-medium text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
+          ⚠ 採購單清單載入失敗：{error}
+        </div>
+      )}
+
+      {rows === null && !error && <p className="text-lg text-zinc-500">載入中…</p>}
+
+      {rows !== null && rows.length === 0 && (
+        <p className="text-lg text-zinc-500">
+          {dSearch.trim() ? `找不到符合「${dSearch.trim()}」的採購單。` : "目前沒有採購單。"}
+        </p>
+      )}
+
+      {rows !== null && rows.length > 0 && (
+        <>
+          {/* ⭐ 數字要誠實：講「第幾頁 / 共幾張」，⛔ 不寫「全部」——
+              這裡拿到的只有當頁 PAGE_SIZE 筆（分頁在 DB 做）。 */}
+          <p className="mb-2 text-sm text-zinc-600 dark:text-zinc-400">
+            共 {total} 張，這是第 {page} / {maxPage} 頁（每頁 {PAGE_SIZE} 張）
+          </p>
+          <ul className="flex flex-col gap-3">
+            {rows.map((r) => (
+              <li key={r.id}>
+                <Link
+                  href={`/wms/receiving/ipad/po?po=${r.id}`}
+                  className="block min-h-[56px] touch-manipulation rounded-2xl border-2 border-zinc-300 bg-white p-3 active:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900 dark:active:bg-zinc-800"
+                >
+                  <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <span className="font-mono text-lg font-bold">{r.po_no}</span>
+                    <span className="rounded-md bg-zinc-100 px-2 py-0.5 text-sm dark:bg-zinc-800">
+                      {STATUS_ZH[r.status] ?? r.status}
+                    </span>
+                    {r.stockout_items > 0 && (
+                      <span className="rounded-md bg-rose-100 px-2 py-0.5 text-sm text-rose-800 dark:bg-rose-950 dark:text-rose-200">
+                        斷貨 {r.stockout_items} 項
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 text-base text-zinc-700 dark:text-zinc-300">
+                    {r.supplier_name || "（沒有廠商）"} · {r.item_count} 項
+                    {r.expected_date && ` · 預計 ${r.expected_date}`}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-4 flex items-center justify-between gap-3">
+            <SpinButton
+              type="button"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className={BTN_GHOST}
+            >
+              ← 上一頁
+            </SpinButton>
+            <span className="text-base">
+              {page} / {maxPage}
+            </span>
+            <SpinButton
+              type="button"
+              disabled={page >= maxPage}
+              onClick={() => setPage((p) => p + 1)}
+              className={BTN_GHOST}
+            >
+              下一頁 →
+            </SpinButton>
+          </div>
+        </>
+      )}
+    </Shell>
+  );
+}
+
+// ---------------------------------------------------------------- 明細
+
+type PoHead = { id: number; po_no: string; status: string; sent_at: string | null; supplier_name: string };
+type PoItem = {
+  id: number;
+  sku_id: number;
+  qty_ordered: number;
+  qty_received: number;
+  stockout_at: string | null;
+  sku_code: string | null;
+  product_name: string | null;
+  variant_name: string | null;
+};
+
+function PoDetail({ poId }: { poId: number }) {
+  const [head, setHead] = useState<PoHead | null>(null);
+  const [items, setItems] = useState<PoItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // ⭐ 防連點走與收貨頁同一套 runExclusive（@/lib/receivingBatch）：
+  //   ref 才擋得住同一 tick 的連點，state 只是給畫面用的鏡像。
+  const busyRef = useRef<BusyKind | null>(null);
+  const [busy, setBusy] = useState<BusyKind | null>(null);
+  /** 正在寫哪一列（顯示 spinner 用）。⛔ 與 busy 分開：busy 決定「全部變灰」。 */
+  const [writingSku, setWritingSku] = useState<number | null>(null);
+  /** 已經寫進草稿的 sku（改按鈕字樣；⛔ 不用來擋，重按會被草稿那邊略過並講出來） */
+  const [written, setWritten] = useState<Set<number>>(new Set());
+  const [draftNotice, setDraftNotice] = useState<string | null>(null);
+  const [draftError, setDraftError] = useState<string | null>(null);
+
+  // ⭐ 載入寫成 effect 裡的 async IIFE ＋ cancelled 旗標
+  //   （同 purchase/orders/page.tsx:183-209 的既有寫法），⛔ 不用 useCallback + void load()：
+  //   1. 樓下在清單與明細之間跳來跳去時，前一張單的回應可能晚於後一張 ——
+  //      cancelled 保證只有最後一次的結果會進畫面（沒有它就會看到別張單的品項）。
+  //   2. 那種寫法會踩 react-hooks/set-state-in-effect（本 repo 已有 13 處，
+  //      ⛔ 不要再多一處）。
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const sb = getSupabase();
+        // 查法逐項對齊 purchase/orders/receive/page.tsx:118-119
+        const [{ data: po, error: poErr }, { data: rawItems, error: itemErr }] = await Promise.all([
+          sb
+            .from("purchase_orders")
+            .select("id, po_no, status, sent_at, suppliers(name)")
+            .eq("id", poId)
+            .single(),
+          sb
+            .from("purchase_order_items")
+            .select("id, sku_id, qty_ordered, qty_received, stockout_at")
+            .eq("po_id", poId)
+            .order("id"),
+        ]);
+        if (poErr) throw poErr;
+        if (itemErr) throw itemErr;
+        if (!po) throw new Error(`找不到採購單 #${poId}`);
+
+        type Raw = {
+          id: number;
+          sku_id: number;
+          qty_ordered: number;
+          qty_received: number | null;
+          stockout_at: string | null;
+        };
+        const raws = (rawItems ?? []) as Raw[];
+        const skuIds = Array.from(new Set(raws.map((r) => Number(r.sku_id))));
+        const skuMap = new Map<
+          number,
+          { sku_code: string | null; product_name: string | null; variant_name: string | null }
+        >();
+        if (skuIds.length > 0) {
+          // ⚠ 分批 300 個 id：PostgREST 單次 1000 列上限 ＋ 網址長度（414）兩邊都要顧
+          //   （同 /wms/receiving/ipad/page.tsx:149-152 的 SKU_CHUNK）。
+          for (let i = 0; i < skuIds.length; i += 300) {
+            const { data: sk, error: skErr } = await sb
+              .from("skus")
+              .select("id, sku_code, product_name, variant_name")
+              .in("id", skuIds.slice(i, i + 300));
+            if (skErr) throw skErr;
+            for (const s of (sk ?? []) as {
+              id: number;
+              sku_code: string | null;
+              product_name: string | null;
+              variant_name: string | null;
+            }[]) {
+              skuMap.set(Number(s.id), {
+                sku_code: s.sku_code,
+                product_name: s.product_name,
+                variant_name: s.variant_name,
+              });
+            }
+          }
+        }
+
+        // ⛔ setState 全部集中在這裡（所有 await 都跑完之後）：中途才發現商品撈失敗時，
+        //   畫面不會停在「表頭已換、品項還是上一張」的半新半舊狀態。
+        if (cancelled) return;
+        const sup = (po as { suppliers?: { name: string } | { name: string }[] | null }).suppliers;
+        const supplierName = Array.isArray(sup) ? sup[0]?.name ?? "" : sup?.name ?? "";
+        setHead({
+          id: Number((po as { id: number }).id),
+          po_no: (po as { po_no: string }).po_no,
+          status: (po as { status: string }).status,
+          sent_at: (po as { sent_at: string | null }).sent_at,
+          supplier_name: supplierName,
+        });
+        setItems(
+          raws.map((r) => {
+            const s = skuMap.get(Number(r.sku_id));
+            return {
+              id: Number(r.id),
+              sku_id: Number(r.sku_id),
+              qty_ordered: Number(r.qty_ordered),
+              qty_received: Number(r.qty_received ?? 0),
+              stockout_at: r.stockout_at,
+              sku_code: s?.sku_code ?? null,
+              product_name: s?.product_name ?? null,
+              variant_name: s?.variant_name ?? null,
+            };
+          }),
+        );
+        setError(null);
+      } catch (e) {
+        if (cancelled) return;
+        setError(translateRpcError(e));
+        // ⛔ 不要把 items 設成 []：那會畫出「這張單沒有品項」，與「查詢失敗」混淆
+        setItems(null);
+        setHead(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [poId]);
+
+  /**
+   * 把這一列寫進今天的撿貨草稿。
+   *
+   * ⭐⭐ 帶出的數量 ＝ **這一列的累計實收量（qty_received）**。
+   *   ⚠ 與收貨頁那顆鈕（帶「這次實收」）**不是同一個數字** ——
+   *     這一頁看的是整張單的累計，沒有「這一次」可言。
+   *     ⇒ 畫面上一定要把數字寫出來，⛔ 不可以只寫「帶出數量」讓人自己猜是哪個。
+   *
+   * ⛔ 實收 0 的列不給按：帶 0 過去會建出一排 0 的格子，
+   *   跟「查詢失敗」與「真的沒人要」三種情況在畫面上分不出來。
+   */
+  async function writeToDraft(it: PoItem) {
+    if (!head) return;
+    const label = skuTitle(it);
+    const held = await runExclusive(busyRef, "draft", setBusy, async () => {
+      setWritingSku(it.sku_id);
+      setDraftNotice(null);
+      setDraftError(null);
+      try {
+        const sb = getSupabase();
+        const report = await handoffToDraft(
+          {
+            db: sb,
+            fetchAll: fetchAllRows,
+            describeError: describeDraftDbError,
+            session: async () => {
+              const { data } = await sb.auth.getSession();
+              const tenantId = (
+                data.session?.user?.app_metadata as Record<string, unknown> | undefined
+              )?.tenant_id as string | undefined;
+              if (!tenantId) throw new Error("JWT 缺 tenant_id claim、無法寫入撿貨草稿");
+              return { tenantId, uid: data.session?.user?.id ?? null };
+            },
+          },
+          {
+            skus: [
+              { sku_id: it.sku_id, sku_code: it.sku_code, label, qty: it.qty_received },
+            ],
+            source: {
+              po_nos: [head.po_no],
+              // ⓘ 這一頁帶的是**累計**實收，不對應單一張進貨單 → gr_nos 留空才誠實。
+              gr_nos: [],
+              at: new Date().toISOString(),
+            },
+            // ⭐⭐ ⛔ 不可以是 "this_receipt"（阿審 2026-09-02 P1）：
+            //   這一頁餵的是 qty_received ＝ **整張單累計實收**，沒有「這一次」可言。
+            //   標錯口徑，共用訊息就會把「累計 80」講成「這次收 80」，
+            //   老闆會以為今天真的到了 80 件。
+            qtyBasis: "cumulative",
+          },
+        );
+        const msg = handoffMessage(report);
+        setDraftNotice(msg.notice);
+        setDraftError(msg.error);
+        // ⓘ raced（被別台搶先加）也算「這一列處理過了」：商品確實在草稿裡，
+        //   按鈕字樣要跟著改，不然他會一直重按。
+        if (report.added.length > 0 || report.skipped.length > 0 || report.raced.length > 0) {
+          setWritten((prev) => new Set(prev).add(it.sku_id));
+        }
+      } finally {
+        setWritingSku(null);
+      }
+    });
+    // ⓘ 這一頁的 busyRef 只有 writeToDraft 在用（唯一的 kind 是 "draft"），
+    //   所以 held 只可能是 "draft" ⇒ 不必像收貨頁那樣分三種講法。
+    //   ⚠ 哪天這一頁多一個非同步動作，這裡就要跟著分支。
+    if (held) {
+      setDraftError("上一筆還在寫入撿貨草稿，等它跑完再按。");
+    }
+  }
+
+  return (
+    <Shell
+      title={head ? `📄 ${head.po_no}` : `📄 採購單 #${poId}`}
+      subtitle={
+        head
+          ? `${head.supplier_name || "（沒有廠商）"} · ${STATUS_ZH[head.status] ?? head.status}${
+              head.sent_at ? ` · 送單 ${head.sent_at.slice(0, 10)}` : ""
+            }`
+          : undefined
+      }
+      right={
+        <Link href="/wms/receiving/ipad/po" className={`${BTN_GHOST} shrink-0`}>
+          ← 清單
+        </Link>
+      }
+    >
+      {error && (
+        <div className="mb-4 rounded-xl border border-red-300 bg-red-50 p-4 text-base font-medium text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
+          ⚠ 這張採購單載入失敗：{error}
+        </div>
+      )}
+
+      {draftNotice && (
+        <div className="mb-4 rounded-xl border-2 border-indigo-300 bg-indigo-50 p-3 text-base text-zinc-800 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-zinc-200">
+          {draftNotice}
+          <p className="mt-2">
+            <Link
+              href="/picking/drafts"
+              className="font-semibold text-indigo-700 underline dark:text-indigo-300"
+            >
+              去撿貨草稿頁分各店 →
+            </Link>
+          </p>
+        </div>
+      )}
+      {draftError && (
+        <div className="mb-4 rounded-xl border-2 border-rose-300 bg-rose-50 p-3 text-base font-medium text-rose-800 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-200">
+          {draftError}
+        </div>
+      )}
+
+      {items === null && !error && <p className="text-lg text-zinc-500">載入中…</p>}
+
+      {items !== null && items.length === 0 && (
+        <p className="text-lg text-zinc-500">這張採購單沒有任何品項。</p>
+      )}
+
+      {items !== null && items.length > 0 && (
+        <ul className="flex flex-col gap-3">
+          {items.map((it) => {
+            const short = it.qty_ordered - it.qty_received;
+            const canWrite = it.qty_received > 0;
+            return (
+              <li
+                key={it.id}
+                className="rounded-2xl border-2 border-zinc-300 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-900"
+              >
+                <div className="text-lg font-bold">{skuTitle(it)}</div>
+                <div className="mt-0.5 font-mono text-sm text-zinc-500">{it.sku_code ?? "—"}</div>
+
+                <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 text-base">
+                  <span>
+                    訂購 <span className="font-bold">{fmtQty(it.qty_ordered)}</span>
+                  </span>
+                  <span>
+                    實收 <span className="font-bold">{fmtQty(it.qty_received)}</span>
+                  </span>
+                  {/* ⛔ 只在真的少於訂購時才講「短少」：超收時 short 是負數，
+                      印成「短少 -5」是說了一件不是事實的事。 */}
+                  {short > 0 && (
+                    <span className="text-amber-800 dark:text-amber-300">
+                      短少 <span className="font-bold">{fmtQty(short)}</span>
+                    </span>
+                  )}
+                  {short < 0 && (
+                    <span className="text-sky-800 dark:text-sky-300">
+                      超收 <span className="font-bold">{fmtQty(-short)}</span>
+                    </span>
+                  )}
+                  {it.stockout_at && (
+                    <span className="rounded-md bg-rose-100 px-2 py-0.5 text-sm text-rose-800 dark:bg-rose-950 dark:text-rose-200">
+                      已標斷貨
+                    </span>
+                  )}
+                </div>
+
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <SpinButton
+                    type="button"
+                    disabled={!canWrite || (busy !== null && writingSku !== it.sku_id)}
+                    onClick={() => writeToDraft(it)}
+                    className={`${BTN_SMALL} bg-indigo-600 text-white active:bg-indigo-700 disabled:bg-zinc-300 dark:disabled:bg-zinc-700`}
+                  >
+                    {writingSku === it.sku_id
+                      ? "寫入中…"
+                      : written.has(it.sku_id)
+                        ? "📋 再寫一次"
+                        : "📋 寫入撿貨草稿"}
+                  </SpinButton>
+                  {/* ⛔ 停用原因與帶出的數字都要看得見（iPad 沒有 tooltip）。
+                      ⭐ 這句話要精確到「哪一個數字」：這一頁帶的是**累計實收**，
+                         與收貨頁那顆鈕（帶「這次實收」）不是同一個數字。 */}
+                  <span className="text-sm text-zinc-600 dark:text-zinc-400">
+                    {!canWrite
+                      ? "這一項還沒有收到任何貨，沒有數量可以帶。"
+                      : busy !== null && writingSku !== it.sku_id
+                        ? "上一筆還在寫，等它跑完。"
+                        : `會把累計實收 ${fmtQty(it.qty_received)} 件帶進今天的撿貨草稿（各店依未派需求分，不扣庫存）。`}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Shell>
+  );
+}
+
+// ---------------------------------------------------------------- 入口
+
+function PoPageInner() {
+  const { user, loading: authLoading } = useAuth();
+  const params = useSearchParams();
+  const raw = params.get("po");
+  const poId = raw && /^\d+$/.test(raw) ? Number(raw) : null;
+
+  // 分店帳號：明確擋下並給出口。⛔ 不可以白畫面、不可以無聲失敗。
+  // （與 /wms/receiving/ipad/page.tsx:992-1018 同一套處理）
+  if (authLoading || isBranchAccount(user)) {
+    return (
+      <div className="fixed inset-x-0 top-0 z-40 flex h-[100dvh] flex-col items-center justify-center gap-5 bg-zinc-100 px-6 text-center dark:bg-zinc-950">
+        {authLoading ? (
+          <p className="text-lg text-zinc-500">載入中…</p>
+        ) : (
+          <>
+            <div className="text-5xl">🔒</div>
+            <div className="text-2xl font-bold">這個功能限總部使用</div>
+            <p className="max-w-md text-base text-zinc-600 dark:text-zinc-400">
+              採購單是總部的單據，分店帳號不能看這一頁。
+            </p>
+            <Link href="/" className={`${BTN_PRIMARY} text-lg`}>
+              回首頁
+            </Link>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  return poId === null ? <PoList /> : <PoDetail poId={poId} />;
+}
+
+export default function IpadPoPage() {
+  // useSearchParams 需要 Suspense 邊界（同 purchase/orders/receive/page.tsx:74-79）
+  return (
+    <Suspense fallback={<div className="p-6 text-lg text-zinc-500">載入中…</div>}>
+      <PoPageInner />
+    </Suspense>
+  );
+}

--- a/apps/admin/src/lib/pickingDraftHandoff.ts
+++ b/apps/admin/src/lib/pickingDraftHandoff.ts
@@ -1,0 +1,744 @@
+// 📦 → 📋 「傳到撿貨草稿」的共用邏輯
+//
+// 這支在解什麼（老闆 2026-08-31 ②、9-01 補充）：
+//   「樓下 ipad 進貨按了之後 要多一個鈕是傳送到撿貨草稿」
+//   「採購單我想要做查看，但是寫入撿貨草稿要能帶出數量」
+//   → 收完貨當場一顆鈕，貨直接進今天的撿貨草稿，樓下接著就能分各店。
+//
+// 為什麼抽成 lib 而不是寫在頁面裡（兩個理由，缺一不可）：
+//   1. **兩個呼叫點**：iPad 收貨頁（送出成功後）與 iPad 採購單查看頁（逐列寫入）。
+//      兩邊各寫一份遲早飄移，而飄移的下場是「同一顆鈕在兩頁寫進不一樣的東西」。
+//   2. 純計算的部分（capPrefill / buildHandoffCells / handoffMessage）**離線驗得到**
+//      —— 這是本 repo 既有的作法（見 pickingDraftView.ts 檔頭與 receivingBatch.ts）。
+//
+// ⛔⛔ 硬規定（與 20260817000000_picking_drafts.sql 檔頭同一套）：
+//   · 只讀寫 picking_drafts / picking_draft_items 兩張草稿自己的表，
+//     以及**唯讀** stores 與 loadPrefill 內部那兩張 view。
+//   · 不呼叫任何庫存／建單 RPC、不扣庫存、不回寫任何既有表。
+//   · ⛔ 一個字都不動 computePrefill / computePrefillEven（老闆 2026-08-17、
+//     阿審 2026-09-01 兩次拍板）—— 本檔只在它們**算完之後**再夾一次上限，
+//     見 capPrefill。
+//
+// ⛔ 沒有新增任何 migration：草稿走 PostgREST 直寫 + RLS，本案沿用，
+//    不新增 SECURITY DEFINER RPC（那會繞過 RLS，反而讓「這條路碰不到別的表」
+//    變成要讀 code 才能相信）。
+
+import {
+  loadPrefill,
+  type FetchAll,
+  type Prefill,
+  type PrefillResult,
+  type ReadOnlyDb,
+} from "./pickingDraftView";
+
+// ============================================================
+// 1. 「今天」是哪一天
+// ============================================================
+
+// 老闆裁示（2026-09-02 問題 2 選甲）：自動進「今天的草稿」，沒有就自動開一份。
+//
+// ⭐⭐ 「今天」一律以**台北時區**判定，⛔ 不用裝置本地時區。
+//   · 既有慣例有兩種寫法，本檔刻意只採其中一種：
+//       - 顯示用日期字串：`new Date().toLocaleDateString("sv-SE")`（裝置本地）
+//         —— 草稿列表頁 picking/drafts/page.tsx:41 的 defaultDraftName() 就是這個
+//       - timestamptz 查詢邊界：明寫 `+08:00` 字面量
+//         —— wms/inbound/page.tsx:399-400（PR #819）
+//   · ⛔ **兩種混用會出事**：拿「裝置本地日期」去配「+08:00 邊界」，
+//     iPad 時區被設錯（或人在國外）時，算出來的視窗**根本不包含當下這一刻**
+//     → 每按一次就開一張新草稿，而且畫面上看不出來。
+//   · 所以日期字串與視窗邊界**同一個時區算出來**，結構上不可能對不起來。
+//   · 寫法照抄 transfers/settlement/daily/page.tsx:62-72 的 taipeiParts()
+//     （Intl + timeZone: "Asia/Taipei"，⛔ 不自己加 8 小時：那種寫法遇到
+//       日光節約或時區調整就是錯的，而 Intl 是查表的）。
+const TAIPEI_DATE = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "Asia/Taipei",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+/** 台北時區的「今天」，格式 YYYY-MM-DD */
+export function taipeiToday(now: Date = new Date()): string {
+  return TAIPEI_DATE.format(now); // en-CA 給的就是 YYYY-MM-DD
+}
+
+/**
+ * 台北那一天在 timestamptz 上的半開區間 [from, to)。
+ *
+ * ⭐ 用半開區間（gte / lt）而不是 `23:59:59.999`：
+ *   created_at 是 timestamptz（微秒精度），23:59:59.9995 這種值會掉在
+ *   `lte 23:59:59.999` 之外 —— 那一刻建的草稿會變成「今天找不到、明天也找不到」。
+ *   ⓘ wms/inbound:400 用的是 lte 23:59:59.999，那裡是使用者手選的日期範圍、
+ *     漏掉半毫秒無所謂；這裡是**自動判定要不要開新草稿**，漏掉就多開一張。
+ */
+export function taipeiDayBounds(dateStr: string): { from: string; to: string } {
+  const next = new Date(`${dateStr}T00:00:00+08:00`);
+  next.setUTCDate(next.getUTCDate() + 1);
+  return {
+    from: `${dateStr}T00:00:00+08:00`,
+    to: `${taipeiToday(next)}T00:00:00+08:00`,
+  };
+}
+
+/** 今天這張草稿要叫什麼名字。
+ *  ⓘ 形狀刻意與草稿列表頁的 defaultDraftName()（picking/drafts/page.tsx:41）一致
+ *    —— 老闆在兩個地方看到的名字要長一樣。差別只有時區來源（見上面那段）。 */
+export function draftNameFor(dateStr: string): string {
+  return `${dateStr} 撿貨`;
+}
+
+// ============================================================
+// 2. 這次要帶出多少（純計算）
+// ============================================================
+
+/**
+ * 把 computePrefill 算好的分配，**再夾一次上限**。
+ *
+ * 為什麼要這一層（老闆 2026-09-02 問題 3 選甲）：
+ *   帶出的數量＝「**這次實收的量**」，不是「這樣商品現在總共可分配多少」。
+ *   兩者在「先前收過、還沒派出去」時會差很多：
+ *   昨天收 50 沒派、今天收 30 → computePrefill 的 available ＝ 80，
+ *   但老闆要的是 30（「剛收的這批」直覺對應）。
+ *
+ * ⛔⛔ 這支**不是** computePrefill 的替代品，也沒有改它一個字：
+ *   分配規則（先來後到、前面吃滿後面掛 0）完全沿用 —— 老闆 2026-08-17 拍板
+ *   「貨不夠時讓一家真的能開賣，好過五家都缺貨賣不動」。
+ *   這裡只是把「可以分下去的總量」從 available 換成 min(cap, available)，
+ *   走同一個貪心迴圈、同一個順序。
+ *
+ * ⭐ 順序：直接沿用 `pre.byStore` 的插入順序。
+ *   那個順序來自 loadPrefill 的 `.order("po_item_id").order("store_id")`，
+ *   是 computePrefill 自己逐格分配時用的同一個順序（JS 的 Map 保證維持插入序），
+ *   所以 `capPrefill(pre, pre.available)` 的結果與 `pre` **逐格相同** ——
+ *   這是可以離線驗證的性質，也是「我沒有偷偷換掉分配規則」的證據。
+ *
+ * ⚠ `available` 欄位**原封不動回傳**（不是回傳夾過的值）：
+ *   它會被寫進 snapshot_available_qty，而那一欄的語意是「這樣商品當下真正的可分配量」，
+ *   紅字缺口（rowShortfall，#896）拿它跟需求比。寫成「這次實收」會讓那行紅字說謊。
+ *
+ * @param cap 這次實收的量。負數／NaN 一律當 0（⛔ 不猜、不放行）。
+ */
+export function capPrefill(pre: Prefill, cap: number): Prefill {
+  const safeCap = Number.isFinite(cap) && cap > 0 ? cap : 0;
+  let room = Math.min(safeCap, pre.available);
+  const byStore = new Map<number, { demandLeft: number; give: number }>();
+  for (const [storeId, v] of pre.byStore) {
+    const give = Math.min(v.demandLeft, room);
+    byStore.set(storeId, { demandLeft: v.demandLeft, give });
+    room -= give;
+  }
+  return { available: pre.available, byStore };
+}
+
+// ============================================================
+// 3. 要寫進去的列（純計算）
+// ============================================================
+
+export type HandoffStore = { id: number; code: string | null; name: string | null };
+
+/**
+ * `HandoffSku.qty` 是**哪一種**實收量。
+ *
+ * ⭐⭐ 為什麼要有這個參數（阿審 2026-09-02 P1）：兩個入口餵的是**不同的數字**——
+ *   · 收貨頁：`this_receipt` ＝ 剛剛那一次送出真的收進來的量
+ *   · 採購單查看頁：`cumulative` ＝ 這一列的 `qty_received`（整張單累計）
+ *   共用訊息如果一律寫死「這次收」，採購單頁就會把「累計實收 80」講成「這次收 80」，
+ *   而老闆看到那句話會以為今天真的到了 80 件。⛔ 這正是本專案最忌諱的畫面斷言。
+ * ⇒ 口徑由呼叫端宣告，訊息與快照都跟著它走。
+ */
+export type QtyBasis = "this_receipt" | "cumulative";
+
+/** 口徑的中文說法。⭐ 兩個都刻意選 4 個字、而且在下面每一個句型裡都讀得通
+ *  （「比X少」「比X多」「夾在「X」」「不是X」「X的量」「（X 30、…）」）。 */
+export const QTY_BASIS_LABEL: Record<QtyBasis, string> = {
+  this_receipt: "這次實收",
+  cumulative: "累計實收",
+};
+
+/** 這次要傳過去的一樣商品。qty ＝ 這次實收的量（跨採購單同一樣商品已先合併）。 */
+export type HandoffSku = {
+  sku_id: number;
+  sku_code: string | null;
+  /** 畫面與快照用的品名（product_name + variant_name） */
+  label: string;
+  qty: number;
+};
+
+/** 這批貨是打哪來的 —— 只寫進 snapshot_extra 當來源記錄，不參與任何計算。 */
+export type HandoffSource = {
+  po_nos: string[];
+  gr_nos: string[];
+  /** 送出成功的那一刻（ISO 字串） */
+  at: string;
+};
+
+/**
+ * 一樣商品 → 要 insert 的那一排列（每家分店一列）。
+ *
+ * ⭐ 欄位**逐項對齊** picking/drafts/edit/page.tsx:798-829 的 addSkus()。
+ *   ⛔ 不可以少填任何一個 snapshot 欄位：
+ *     · snapshot_demand_qty / snapshot_available_qty 少填 → 紅字缺口
+ *       （rowShortfall，pickingDraftView.ts:590「缺一格就整列不顯示」）
+ *       會對這一列**整列失效**，而畫面上看不出來是壞掉還是真的沒缺口。
+ *     · snapshot_source 少填 → isLegacyDraftCell（同檔 :915）會把這幾列
+ *       判成「結單日功能上線前加的舊列」，列印頁會多一句不成立的警語。
+ *
+ * ⚠ 分店是 **stores 全表（含停用）**，與 addSkus 同一條規則：
+ *   停用分店幾乎不會有未派需求 → qty = 0 → buildStoreColumns 會把那一欄藏起來。
+ *   真的還有未派需求時那一欄會照樣出現並標「已停用」—— 那正是要保住的東西。
+ */
+export function buildHandoffCells(args: {
+  tenantId: string;
+  uid: string | null;
+  draftId: number;
+  stores: HandoffStore[];
+  sku: HandoffSku;
+  /** 已經過 capPrefill 夾住的分配 */
+  capped: Prefill;
+  /** loadPrefill 帶回來的結單日與 extra（原樣沿用，⛔ 不重算） */
+  pre: PrefillResult;
+  source: HandoffSource;
+  /** `sku.qty` 是哪一種實收量（寫進快照，之後才查得出來這一列的數字是什麼口徑） */
+  qtyBasis: QtyBasis;
+  /** 這一批的快照時間點；同一次傳送的所有列要用**同一個值** */
+  snapshotAt: string;
+}): Record<string, unknown>[] {
+  const { tenantId, uid, draftId, stores, sku, capped, pre, source, qtyBasis, snapshotAt } = args;
+  return stores.map((st) => {
+    const p = capped.byStore.get(st.id);
+    return {
+      tenant_id: tenantId,
+      draft_id: draftId,
+      sku_id: sku.sku_id,
+      store_id: st.id,
+      // 這家店帶出的量：未派需求，且整列合計不超過「這次實收」（見 capPrefill）
+      qty: p?.give ?? 0,
+      snapshot_at: snapshotAt,
+      snapshot_sku_code: sku.sku_code,
+      snapshot_sku_label: sku.label,
+      snapshot_store_code: st.code,
+      snapshot_store_name: st.name,
+      // ⚠ 快照記的是「當下真正的」需求與可分配量，⛔ 不是夾過的那個數字。
+      //   紅字缺口要拿這兩個數字比，寫成夾過的值會讓它說謊。
+      snapshot_demand_qty: p?.demandLeft ?? 0,
+      snapshot_available_qty: capped.available,
+      snapshot_close_date: pre.closeDate,
+      snapshot_extra: {
+        ...pre.extra,
+        snapshot_source: "ipad_receiving",
+        // 來源記錄：哪張採購單、哪張進貨單、收了幾件、帶出幾件。
+        // ⭐ 這是「同一批不要重複加」出問題時唯一查得回去的線索，
+        //   也是老闆事後問「這列是怎麼跑進來的」的答案。
+        // ⭐⭐ `qty_basis` ⛔ 不可以省（阿審 2026-09-02 P1）：`received_qty` 兩個入口
+        //   餵的是不同口徑的數字（收貨頁＝這一次收的、採購單頁＝整張單累計），
+        //   不記下來的話，事後看到「received_qty: 80」根本分不出那是哪一種 80。
+        handoff: {
+          received_qty: sku.qty,
+          qty_basis: qtyBasis,
+          given_qty: sumGive(capped),
+          po_nos: source.po_nos,
+          gr_nos: source.gr_nos,
+          at: source.at,
+        },
+      },
+      created_by: uid,
+      updated_by: uid,
+    };
+  });
+}
+
+/** 這一列實際帶出去的總量（各店 give 相加） */
+export function sumGive(pre: Prefill): number {
+  let s = 0;
+  for (const v of pre.byStore.values()) s += v.give;
+  return s;
+}
+
+/** 這一列當下的全店未派需求總量 */
+export function sumDemand(pre: Prefill): number {
+  let s = 0;
+  for (const v of pre.byStore.values()) s += v.demandLeft;
+  return s;
+}
+
+// ============================================================
+// 4. 要對老闆說什麼（純計算）
+// ============================================================
+
+export type HandoffAdded = {
+  name: string;
+  /** 這次實收 */
+  receivedQty: number;
+  /** 實際帶出（各店 give 相加） */
+  giveTotal: number;
+  /** 當下全店未派需求 */
+  demandTotal: number;
+  /** 當下可分配量 */
+  available: number;
+};
+
+export type HandoffReport = {
+  draftId: number | null;
+  draftName: string | null;
+  /** 這張草稿是這次才開的 */
+  draftCreated: boolean;
+  added: HandoffAdded[];
+  /** 本來就在這張草稿裡 → 略過。不算失敗，但**一定要講** */
+  skipped: string[];
+  /**
+   * 我們讀「已經有哪些商品」之後、寫進去之前，被**別人搶先加**進同一張草稿的
+   * （DB 的 UNIQUE 擋下來，Postgres 23505）。
+   *
+   * ⭐⭐ 為什麼要跟 skipped、failed 都分開（阿審 2026-09-02 P2）：
+   *   結局跟 skipped 一樣（商品在草稿裡、沒有重複加、原數量沒被動），
+   *   但**原因**不一樣，而且會勾起「那我剛剛看到的清單是不是舊的」這個疑問。
+   *   · 併進 failed → 會說「沒有傳進草稿」，但它其實在草稿裡 ＝ 說謊
+   *   · 併進 skipped → 會說「本來就在」，但按之前它不在 ＝ 也不對
+   *   ⇒ 自成一類，並叫他去草稿頁看最新的。
+   */
+  raced: string[];
+  failed: { name: string; reason: string }[];
+  /** 整批一樣都沒進去（拿不到身分／撈不到分店／開不了草稿）。⛔ 有值時上面幾個陣列都不算數 */
+  fatal: string | null;
+  /** 這次送出有幾張採購單是「先前就收過了」→ 沒有被帶進草稿。0 = 沒有 */
+  duplicatePos: number;
+  /** `added[].receivedQty` 是哪一種實收量 —— 訊息的措辭跟著它走 */
+  qtyBasis: QtyBasis;
+};
+
+/**
+ * 傳送結果要顯示的字。
+ *
+ * ⭐ 規則與 addBatchMessage（pickingDraftView.ts:779）同一套，⛔ 不另發明：
+ *   1. 失敗的**逐樣列出名字**放紅框；成功／略過放藍框；兩框可同時出現
+ *   2. 「查詢正常但沒需求」一定要單獨講 —— 它在畫面上跟「讀取失敗」
+ *      一樣是一排 0，不講的話分不出這兩件事
+ *   3. 被夾住的一定要講**為什麼**被夾（實收 vs 需求），並講出兩個數字
+ *   ⓘ 不用 `**粗體**`：這幾段字是純文字渲染，星號會原封不動印出來。
+ *
+ * ⭐⭐ 所有講到「收了多少」的地方一律用 `L`（＝口徑的中文說法），
+ *   ⛔ 不可以再寫死「這次收」——採購單查看頁餵的是**累計實收**，
+ *   寫死就會把整張單累計講成今天到的量（阿審 2026-09-02 P1）。
+ */
+export function handoffMessage(r: HandoffReport): { notice: string | null; error: string | null } {
+  if (r.fatal) return { notice: null, error: r.fatal };
+
+  const parts: string[] = [];
+  const L = QTY_BASIS_LABEL[r.qtyBasis];
+  const where = r.draftName
+    ? `〈${r.draftName}〉${r.draftCreated ? "（這是剛開的一張新草稿）" : ""}`
+    : "今天的草稿";
+
+  if (r.added.length > 0) {
+    const give = r.added.reduce((s, a) => s + a.giveTotal, 0);
+    parts.push(
+      `已把 ${r.added.length} 樣傳進 ${where}，各店合計帶出 ${give} 件：` +
+        `${r.added.map((a) => a.name).join("、")}。`,
+    );
+
+    // 沒有任何分店有未派需求 → 建了列但整排都是 0。
+    // ⛔ 這件事一定要單獨講：畫面上它跟「讀取失敗」長得一模一樣。
+    const none = r.added.filter((a) => a.demandTotal === 0).map((a) => a.name);
+    if (none.length > 0) {
+      parts.push(
+        `其中 ${none.length} 樣查詢正常、但目前沒有任何分店有未派需求` +
+          `（列已經建好，各店數量請在草稿頁自己填）：${none.join("、")}。`,
+      );
+    }
+
+    // 帶出的量 < 實收 —— 兩種原因，措辭要分開，⛔ 不可以混成一句。
+    const byDemand = r.added.filter(
+      (a) => a.demandTotal > 0 && a.giveTotal < a.receivedQty && a.giveTotal >= a.demandTotal,
+    );
+    if (byDemand.length > 0) {
+      parts.push(
+        `其中 ${byDemand.length} 樣帶出的比${L}少，因為各店加起來只缺這麼多：` +
+          byDemand
+            .map((a) => `${a.name}（${L} ${a.receivedQty}、各店共缺 ${a.demandTotal}、帶出 ${a.giveTotal}）`)
+            .join("、") +
+          "。",
+      );
+    }
+
+    // 需求分不完 —— ⭐⭐ 卡在哪一個上限**要分開講**，⛔ 不可以一律說成「夾在實收」。
+    //   room = min(實收, 可分配量)（見 capPrefill），所以兩種都可能是真正的瓶頸：
+    //     · 可分配量 ≥ 實收 → 是老闆選的甲案在夾（＝設計就是這樣）
+    //     · 可分配量 < 實收 → 是**貨已經被派掉了**，跟這顆鈕的設計無關
+    //   兩者的下一步完全不同（前者等下批貨、後者要去看是不是已經派過），
+    //   講錯就是又一個沒查證的畫面斷言。
+    const shortAll = r.added.filter((a) => a.demandTotal > a.giveTotal);
+    const numbers = (a: HandoffAdded) =>
+      `${a.name}（${L} ${a.receivedQty}、各店共缺 ${a.demandTotal}、` +
+      `目前可分配 ${a.available}、帶出 ${a.giveTotal}）`;
+
+    const byReceipt = shortAll.filter((a) => a.receivedQty <= a.available);
+    if (byReceipt.length > 0) {
+      parts.push(
+        `其中 ${byReceipt.length} 樣的需求比${L}多，帶出的量已經夾在「${L}」：` +
+          byReceipt.map(numbers).join("、") +
+          "。差額請到草稿頁自己補，或等下一批貨到再傳一次。",
+      );
+    }
+    const byAvailable = shortAll.filter((a) => a.receivedQty > a.available);
+    if (byAvailable.length > 0) {
+      parts.push(
+        `其中 ${byAvailable.length} 樣帶出的量卡在「目前可分配量」而不是${L}` +
+          `（這批的貨有一部分已經派出去了）：` +
+          byAvailable.map(numbers).join("、") +
+          "。請到派貨工作台確認是不是已經派過。",
+      );
+    }
+  }
+
+  if (r.skipped.length > 0) {
+    parts.push(
+      `${r.skipped.length} 樣本來就在這張草稿裡，這次沒有重複加、` +
+        `原本填好的數量也沒有被動到：${r.skipped.join("、")}。` +
+        `${L}的量要併進去的話，請到草稿頁自己改數量。`,
+    );
+  }
+
+  // 讀完清單之後才被別人加進去的（DB 的 UNIQUE 擋下來）。
+  // ⛔ 不可以併進 skipped 或 failed —— 兩邊都會講成不是事實的話（見 HandoffReport.raced）。
+  if (r.raced.length > 0) {
+    parts.push(
+      `${r.raced.length} 樣在這幾秒之內被另一台裝置（或另一個分頁）加進同一張草稿了，` +
+        `所以這次沒有重複加、對方填的數量也沒有被蓋掉：${r.raced.join("、")}。` +
+        `請到撿貨草稿頁看一下最新的清單，確認數量是不是你要的。`,
+    );
+  }
+
+  if (r.duplicatePos > 0) {
+    // 「先前就收過了」的採購單：後端回的是舊的那張進貨單，這次填的件數不算數
+    //（同 wms/receiving/ipad/page.tsx:1467-1468 已經立好的規則）→ ⛔ 不可以帶進草稿。
+    parts.push(
+      `另外有 ${r.duplicatePos} 張採購單是「先前就收過了」，` +
+        `這次沒有真的收進新的貨，所以也沒有傳進草稿（要的話請到草稿頁自己加）。`,
+    );
+  }
+
+  let error: string | null = null;
+  if (r.failed.length > 0) {
+    error =
+      `⚠ 有 ${r.failed.length} 樣沒有傳進草稿（貨已經收進來了，只是草稿沒加到）：` +
+      r.failed.map((f) => `${f.name}（${f.reason}）`).join("、") +
+      "。可以再按一次「傳到撿貨草稿」重試，已經進去的不會重複加。";
+  }
+
+  return { notice: parts.length > 0 ? parts.join(" ") : null, error };
+}
+
+// ============================================================
+// 5. 真的去寫（IO 全部注入，才驗得起來）
+// ============================================================
+
+/**
+ * 這個錯誤是不是「這一格已經有人建了」（Postgres unique_violation）。
+ *
+ * ⭐ 為什麼判在這裡、⛔ 不是去改 describeDraftDbError（pickingDraftView.ts:38）：
+ *   1. 那支是**兩個 PR 剛動過的熱點檔**（#892、#896），這個 PR 刻意讓它的 diff 維持 0 行。
+ *   2. 更重要的是**語意只在這裡成立**：23505 在草稿頁的其他寫入點（改數量、補格子）
+ *      代表的是別的事，翻成「這樣商品已經在草稿裡」到那邊就是錯的。
+ *      ⇒ 通用的錯誤翻譯器不該知道這件事，知道了就會在別處說謊。
+ *
+ * ⚠ 只認 `code`，⛔ 不去比對訊息字串：PostgREST 的訊息會帶約束名稱，
+ *   而那個名稱是 Postgres 自動產的（`picking_draft_items_draft_id_sku_id_store_id_key`），
+ *   改一次表就變了 —— 拿它當判準是把測試綁在會漂移的東西上。
+ */
+function isUniqueViolation(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null | undefined)?.code;
+  return code === "23505";
+}
+
+/** 需要寫入，所以不能沿用 pickingDraftView 的 ReadOnlyDb */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DraftDb = { from: (table: string) => any };
+
+export type HandoffDeps = {
+  db: DraftDb;
+  fetchAll: FetchAll;
+  /** 取 tenant_id 與 uid；拿不到要 throw（整批不進去，⛔ 不可以退回空值硬寫） */
+  session: () => Promise<{ tenantId: string; uid: string | null }>;
+  /** 把 DB 錯誤翻成老闆看得懂的話（傳 pickingDraftView 的 describeDraftDbError 進來） */
+  describeError: (e: unknown) => string;
+  now?: () => Date;
+  /**
+   * 每處理完一樣就回報一次（done, total），給畫面顯示「12 / 30」。
+   *
+   * ⭐ 為什麼需要：這支是**逐樣往返**的（見 handoffToDraft ⑤ 的說明），
+   *   30 樣 ≈ 90 趟。iPad 現場等 10 秒卻只看到「傳送中…」三個字，
+   *   樓下會以為當掉而去戳別的東西。⛔ 進度不是裝飾，是「還在跑」的證據。
+   */
+  onProgress?: (done: number, total: number) => void;
+};
+
+/** 今天最多看幾張草稿。與草稿列表頁的 LIST_LIMIT（picking/drafts/page.tsx:37）同一個數字。 */
+const TODAY_DRAFT_SCAN = 50;
+
+/**
+ * 找出「今天那張還能用的草稿」，沒有就開一張。
+ *
+ * 判定（老闆 2026-09-02 問題 2 選甲「自動進今天的草稿」）——
+ * **台北時區的今天建立的草稿裡，最新建立、而且同時滿足下面兩條的那一張**：
+ *
+ *   ① `status = 'draft'`（還在進行中）
+ *      ⛔ 不可以往「已完成／已收起」的草稿塞東西：那張已經印出來給樓下了，
+ *        事後多一樣商品＝紙上沒有、系統上有。
+ *
+ *   ② `dispatched_at IS NULL`（**還沒送到派貨工作台**）
+ *      ⭐⭐ 這一條是踩過才知道的：草稿送出去之後 status 會變 `done`，
+ *        但老闆可以按「重新開啟」把它轉回 `draft`
+ *        —— **而 dispatched_at 永不清空，送出鈕的條件是 `.is("dispatched_at", null)`**
+ *        （picking/drafts/edit/page.tsx:349-352,:993；欄位 COMMENT 在
+ *          20260818000000_picking_draft_dispatched.sql:59-60 明寫「一旦有值就永遠不清空」）。
+ *      ⇒ 往一張「已送出但被重新開啟」的草稿加商品，那幾樣**永遠送不出去**，
+ *        而且畫面上完全看不出來 —— 正是本專案最痛的那種靜默丟失。
+ *        所以這種草稿一律當成不能用，另開一張。
+ *
+ * ⭐ 為什麼用 created_at 排序而不是 updated_at：
+ *   picking_drafts 的 updated_at 只有那張草稿的**單頭**被 UPDATE 時才會動
+ *   （trg_touch_picking_drafts 掛在 picking_drafts 上，明細有自己的 trigger，
+ *     20260817000000:176-182）→ 加商品**不會**讓單頭的 updated_at 前進。
+ *   拿它當「樓下正在用哪一張」的線索是錯的。
+ *
+ * ⚠ 已知限制（既有設計，本案沒有加重）：草稿名稱**沒有 unique**
+ *   （picking/drafts/page.tsx:40 的註解：「老闆的實務是早上一批、下午一批
+ *     → 預設帶日期，重複也沒關係」）。所以：
+ *   · 老闆自己下午另開一張，這顆鈕之後就會進**下午那張**（最新的）—— 這是對的。
+ *   · 同一天要開第 2 張以上時，名字**通常**會帶「（第N批）」以免同名分不出來。
+ *
+ * ⚠⚠ 「（第N批）」**不是保證**（阿審 2026-09-02 P2）。這支是「查一次、再寫一次」，
+ *   中間沒有鎖也沒有 unique 約束，所以有一段窄縫：
+ *   **兩台 iPad 在今天還沒有草稿時同時按，兩邊都查到空清單，就會各建一張
+ *   一模一樣叫「YYYY-MM-DD 撿貨」的草稿**（都沒有帶「（第2批）」）。
+ *   ⛔ 不要把上面那句「會帶（第N批）」讀成不變式 —— 它只在「查的時候已經看得到前一張」時成立。
+ *
+ *   **為什麼不修**（選擇不加防重，理由三條）：
+ *   1. 要真的保證，需要 DB 的 unique 約束、advisory lock 或一支 RPC —— 三者都要動資料庫，
+ *      而本案「零 migration、零新 RPC」是刻意的設計（見檔頭），為了一個名字去破它不划算。
+ *   2. **後果只是多一張同名草稿，不會弄丟任何東西**：兩張都在列表上看得到、
+ *      各自的明細都完整、⛔ 沒有任何一筆資料被覆蓋或吞掉
+ *      （每一格的寫入都受 UNIQUE (draft_id, sku_id, store_id) 保護，而且只 insert 不 update）。
+ *   3. 而且**看得見**：成功訊息一定會把草稿名字印出來、新開的還會標
+ *      「（這是剛開的一張新草稿）」⇒ 樓下當場就會發現「怎麼開了兩張」，
+ *      不是那種要等對帳才發現的錯。
+ *   ⇒ 這是**已知且可接受**的競態，不是漏想。真的變成困擾再回頭加 unique。
+ */
+export async function findOrCreateTodayDraft(
+  deps: HandoffDeps,
+  ids: { tenantId: string; uid: string | null },
+): Promise<{ id: number; name: string; created: boolean }> {
+  const today = taipeiToday(deps.now ? deps.now() : new Date());
+  const { from, to } = taipeiDayBounds(today);
+
+  // 今天全部的草稿（含已完成／已送出）——⛔ 刻意不在 SQL 就篩掉：
+  //   還要用「今天總共幾張」來決定新草稿的名字要不要帶「（第N批）」。
+  const { data, error } = await deps.db
+    .from("picking_drafts")
+    .select("id, name, status, dispatched_at")
+    .gte("created_at", from)
+    .lt("created_at", to)
+    .order("created_at", { ascending: false })
+    .order("id", { ascending: false })
+    .limit(TODAY_DRAFT_SCAN);
+  if (error) throw error;
+
+  const todays = (data ?? []) as {
+    id: number;
+    name: string;
+    status: string;
+    dispatched_at: string | null;
+  }[];
+  const usable = todays.find((d) => d.status === "draft" && d.dispatched_at === null);
+  if (usable) return { id: Number(usable.id), name: usable.name, created: false };
+
+  // ⚠ 這裡的「第N批」是**盡力而為**，不是保證：todays 是幾百毫秒前查的，
+  //   另一台同時按就會兩邊都拿到同一個 N（見上面那段的窄縫說明）。
+  const name =
+    todays.length === 0 ? draftNameFor(today) : `${draftNameFor(today)}（第${todays.length + 1}批）`;
+  const { data: made, error: insErr } = await deps.db
+    .from("picking_drafts")
+    .insert({ tenant_id: ids.tenantId, name, created_by: ids.uid, updated_by: ids.uid })
+    .select("id, name")
+    .single();
+  if (insErr) throw insErr;
+  return { id: Number((made as { id: number }).id), name, created: true };
+}
+
+/**
+ * 把「這次收到的商品」傳進今天的撿貨草稿。
+ *
+ * 流程（⛔ 順序不可以換）：
+ *   ① 身分 → ② 分店全表 → ③ 今天的草稿 → ④ 這張草稿已經有哪些商品
+ *   → ⑤ 逐樣 loadPrefill + capPrefill + insert
+ *
+ * ①②③④ 任何一步失敗＝**整批都沒進去**（fatal），因為後面每一樣都要用到它們。
+ * ⑤ 是逐樣的：某一樣壞掉，其他樣照樣進得去 —— 與 addSkus 同一條規則
+ *   （picking/drafts/edit/page.tsx:747-751 有完整推導）。
+ *
+ * ⭐⭐ 防重（老闆驗收條件「同一批按兩次不會重複加」）＝
+ *   **「這樣商品已經在這張草稿裡就略過」**，⛔ 不是另發明一把批次鍵。
+ *   三個理由：
+ *   1. 它是 DB 保證的：picking_draft_items 有 UNIQUE (draft_id, sku_id, store_id)
+ *      （20260817000000:133）—— 就算前端判斷漏了，第二次也插不進去。
+ *   2. 它比批次鍵**強**：批次鍵只擋得住「同一次送出按兩次」；這條連
+ *      「不同批次但同一樣商品」都不會重複長出第二份矩陣。
+ *   3. 它與草稿頁「加入商品」的行為**一模一樣**（addSkus 的 inDraft 集合），
+ *      老闆已經熟悉這個行為，兩個入口不會給他兩種答案。
+ *   ⚠ 代價：同一樣商品今天分兩批到貨時，第二批**不會**自動累加。
+ *     這是刻意的 —— 要累加就得決定「多出來的量給哪一家」，那是分配決策，
+ *     ⛔ 不可以由一顆鈕默默替老闆做。訊息會明講「請到草稿頁自己改數量」。
+ */
+export async function handoffToDraft(
+  deps: HandoffDeps,
+  args: {
+    skus: HandoffSku[];
+    source: HandoffSource;
+    /** `skus[].qty` 是哪一種實收量。⛔ 必填：預設值會讓呼叫端「不小心正確」，
+     *  而錯的那一邊剛好是不會被發現的那一邊（阿審 2026-09-02 P1）。 */
+    qtyBasis: QtyBasis;
+    duplicatePos?: number;
+  },
+): Promise<HandoffReport> {
+  const base: HandoffReport = {
+    draftId: null,
+    draftName: null,
+    draftCreated: false,
+    added: [],
+    skipped: [],
+    raced: [],
+    failed: [],
+    fatal: null,
+    duplicatePos: args.duplicatePos ?? 0,
+    qtyBasis: args.qtyBasis,
+  };
+
+  if (args.skus.length === 0) {
+    // ⓘ 措辭刻意不提「收貨」：這支是兩個入口共用的，採購單查看頁沒有「這次收好的」這回事。
+    return { ...base, fatal: "沒有任何商品可以傳到撿貨草稿。" };
+  }
+
+  // ---- ① 身分 ----
+  let ids: { tenantId: string; uid: string | null };
+  try {
+    ids = await deps.session();
+  } catch (e) {
+    return { ...base, fatal: `${deps.describeError(e)}（一樣都沒有傳進草稿。）` };
+  }
+
+  // ---- ② 分店全表（含停用）----
+  // ⛔ 不可以在查詢就 .eq("is_active", true)：與 drafts/edit/page.tsx:195-199 同一條規則
+  //   ——「停用但草稿裡有數量」的店會被標成「已刪除」，那是說了一件不是事實的事。
+  let stores: HandoffStore[];
+  try {
+    const { data, error } = await deps.db.from("stores").select("id, code, name").order("code");
+    if (error) throw error;
+    stores = ((data ?? []) as HandoffStore[]).map((s) => ({
+      id: Number(s.id),
+      code: s.code,
+      name: s.name,
+    }));
+    // 撈到 0 家店一定要吭聲：靜靜寫下去會建出一張沒有任何分店欄位的草稿列。
+    if (stores.length === 0) throw new Error("撈不到任何分店");
+  } catch (e) {
+    return { ...base, fatal: `撈分店清單失敗：${deps.describeError(e)}（一樣都沒有傳進草稿。）` };
+  }
+
+  // ---- ③ 今天的草稿 ----
+  let draft: { id: number; name: string; created: boolean };
+  try {
+    draft = await findOrCreateTodayDraft(deps, ids);
+  } catch (e) {
+    return { ...base, fatal: `開不了今天的撿貨草稿：${deps.describeError(e)}（一樣都沒有傳進草稿。）` };
+  }
+  base.draftId = draft.id;
+  base.draftName = draft.name;
+  base.draftCreated = draft.created;
+
+  // ---- ④ 這張草稿已經有哪些商品 ----
+  // ⚠ 走 fetchAll 分頁：一張草稿 = 商品數 × 分店數，50 樣 × 十幾家店就 ~700 列，
+  //   PostgREST 預設 1000 列會靜默截斷 —— 截斷的後果是「以為沒加過」而重複嘗試，
+  //   雖然 UNIQUE 會擋下來，但錯誤訊息會變成一堆看不懂的 23505。
+  // ⭐ 剛開的草稿一定是空的（③ 才 insert 出來的）⇒ 這一趟直接省下來。
+  //   省的不只是時間，還少一種失敗方式：新草稿不可能走進下面那個 fatal。
+  let inDraft: Set<number>;
+  try {
+    const cells = draft.created
+      ? []
+      : await deps.fetchAll<{ sku_id: number }>(() =>
+          deps.db
+            .from("picking_draft_items")
+            .select("sku_id")
+            .eq("draft_id", draft.id)
+            .order("id", { ascending: true }),
+        );
+    inDraft = new Set(cells.map((c) => Number(c.sku_id)));
+  } catch (e) {
+    return {
+      ...base,
+      fatal:
+        `讀不到草稿〈${draft.name}〉現有的商品：${deps.describeError(e)}` +
+        `（一樣都沒有傳進草稿 —— 讀不到就不知道哪些已經加過，硬加會重複。）`,
+    };
+  }
+
+  // ---- ⑤ 逐樣寫入 ----
+  //
+  // ⚠ 成本：每一樣 ＝ loadPrefill 的 2 次讀 ＋ 1 次寫 ≒ 3 趟往返。
+  //   30 樣 ≒ 90 趟。這是**刻意付的代價**，與 addSkus 同一個理由
+  //   （picking/drafts/edit/page.tsx:747-751）：逐樣跑才講得出「哪幾樣沒進去」，
+  //   合併成一次大查詢就只剩「整批失敗」。⇒ 改用 onProgress 讓等待看得見。
+  // ⓘ 有一支批次版的預覽查詢（pickingDraftView 的 SkuPreviewBatch），
+  //   但它只算得出每樣的「可分配量」，**沒有各店 demandLeft**，
+  //   建不出格子 ⇒ ⛔ 不能拿來取代 loadPrefill。
+  const snapshotAt = new Date().toISOString();
+  let done = 0;
+  const total = args.skus.length;
+  deps.onProgress?.(0, total);
+  for (const sku of args.skus) {
+    if (inDraft.has(sku.sku_id)) {
+      base.skipped.push(sku.label);
+      deps.onProgress?.(++done, total);
+      continue;
+    }
+    try {
+      // ⛔ loadPrefill 刻意不 catch（見該函式）：讀不到需求就**這一樣不加**。
+      //   退回「空需求」會建出一排 0，畫面跟「真的沒人要」一模一樣。
+      const pre = await loadPrefill({ db: deps.db as ReadOnlyDb, fetchAll: deps.fetchAll }, sku.sku_id);
+      const capped = capPrefill(pre, sku.qty);
+      const cells = buildHandoffCells({
+        tenantId: ids.tenantId,
+        uid: ids.uid,
+        draftId: draft.id,
+        stores,
+        sku,
+        capped,
+        pre,
+        source: args.source,
+        qtyBasis: args.qtyBasis,
+        snapshotAt,
+      });
+      const { error } = await deps.db.from("picking_draft_items").insert(cells);
+      if (error) throw error;
+
+      base.added.push({
+        name: sku.label,
+        receivedQty: sku.qty,
+        giveTotal: sumGive(capped),
+        demandTotal: sumDemand(capped),
+        available: capped.available,
+      });
+      // 同一次呼叫裡若同一樣商品出現兩次（理論上不會，來源已合併），第二次就會被略過
+      inDraft.add(sku.sku_id);
+    } catch (e) {
+      // ⭐ 被別人搶先加進去（DB 的 UNIQUE 擋下）自成一類，⛔ 不可以當成一般失敗：
+      //   一般失敗會說「沒有傳進草稿」，但這個情況商品**確實在草稿裡**（只是不是我們加的）。
+      if (isUniqueViolation(e)) base.raced.push(sku.label);
+      else base.failed.push({ name: sku.label, reason: deps.describeError(e) });
+    }
+    // ⛔ 成功失敗都要往前走一格：進度停住會被當成當掉
+    deps.onProgress?.(++done, total);
+  }
+
+  return base;
+}

--- a/apps/admin/src/lib/receivingBatch.ts
+++ b/apps/admin/src/lib/receivingBatch.ts
@@ -429,7 +429,7 @@ export function blockReasonFor(c: SelectionCounts): string | null {
 // ---------------------------------------------------------------- 互斥鎖
 
 /**
- * 全頁共用的一把鎖：**整頁重撈 / 單張重撈 / 送出，三者不可以同時跑。**
+ * 全頁共用的一把鎖：**整頁重撈 / 單張重撈 / 送出 / 傳到撿貨草稿，四者不可以同時跑。**
  *
  * ⭐ 2026-08-20 複審 P1：原本只有「整頁重撈」與「送出」互斥，
  *   失敗採購單那顆「🔄 重新載入這張單」沒有納入 ⇒ 重撈跑到一半還可以按
@@ -448,7 +448,22 @@ export function blockReasonFor(c: SelectionCounts): string | null {
  *          取得到並跑完 → 回傳 null。⚠️ fn 丟出來的例外會原樣往外拋，
  *          但鎖一定會在 finally 放掉（⛔ 不可以改成吞掉例外）。
  */
-export type BusyKind = "load" | "submit";
+// ⭐ "draft" ＝ 送出成功後那顆「📋 傳到撿貨草稿」（2026-09-02 加）。
+//   它跟送出／重撈用**同一把鎖**，理由與上面那條複審 P1 一樣：
+//   傳草稿要逐樣 loadPrefill + insert（好幾趟往返），跑到一半如果還按得動
+//   「🔄 重新載入這張單」，畫面上的結果面板會被抽掉，而草稿還在寫。
+// ⚠ 新增一個成員就要回頭看**所有讀 busy 的地方**有沒有漏講原因：
+//   本 repo 的規則是「按鈕變灰一定要看得出為什麼」（iPad 上沒有 tooltip）。
+//   2026-09-02 盤點：**用到這個型別的檔案只有兩支**，兩支都只做等值比較
+//   （`busy !== null` / `=== "submit"` / `=== "load"` / `=== "draft"`），
+//   ⛔ 沒有任何 switch 需要補 case：
+//     · wms/receiving/ipad/page.tsx（收貨頁）
+//     · wms/receiving/ipad/po/page.tsx（採購單查看頁）
+//   查法：git grep -l "BusyKind" -- apps/admin/src
+//   ⚠ ⛔ 不要改用 `git grep "busy ==="` 去盤：hq/inbox、purchase/requests/edit、
+//     restock/inbox 各自有**同名但不同型別**的區域 busy state（字串 id / 自己的 union），
+//     跟這個型別無關，混進來只會讓人以為漏改了一堆地方。
+export type BusyKind = "load" | "submit" | "draft";
 
 export async function runExclusive(
   ref: { current: BusyKind | null },


### PR DESCRIPTION
樓下 iPad 收完貨要上樓開桌機、從派貨工作台找商品加草稿。改為收貨
送出成功後一鍵「傳到撿貨草稿」；另加採購單 iPad 唯讀查看頁，每列
可寫入草稿（帶累計實收量）。

- 新 lib/pickingDraftHandoff.ts：共用傳草稿邏輯（自動找/建「今天的 草稿」——台北時區、status=draft 且 dispatched_at IS NULL，避開 「重新開啟的草稿加商品永遠送不出去」的既有暗坑）；數量口徑 QtyBasis 必填無預設（收貨頁=這次實收、採購單頁=累計實收，漏傳 編譯不過）；23505 撞列獨立 raced 分類（只認 code 不比對字串）
- 新 wms/receiving/ipad/po/page.tsx：採購單 iPad 查看（唯讀）＋逐列 寫入草稿
- wms/receiving/ipad/page.tsx：送出成功後新增傳草稿分支（沿 runExclusive 慣例）；receivingBatch.ts 曝露本批 sku×qty
- 寫入沿 #892 慣例：insert 帶完整 snapshot_*、⛔ 不 upsert； pickingDraftView.ts 零改動（#892/#896 熱點檔 diff=0）
- capPrefill 夾量在 computePrefill 之後，cap=可分配時逐格等同原函式 （離線 40 萬組驗證；computePrefill/Even 未動）

零 migration 零 RPC，純前端。

驗證：施工 2 輪 × Codex 唯讀審查 2 輪 P0/P1=0；同刻雙開草稿競態為
刻意接受（僅可能多一張同名草稿、零資料遺失，訊息明示）。
⚠ 未實機跑（零網路鐵則）；建議合併後平板實測「同批按兩次」與
「兩台同時按」兩情境。

## 做了什麼


## 上線危險

- 做了：
- 不做：
- 回退：

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [ ] 本 PR 沒有碰上述敏感設定。

## 驗證


