### PR TITLE
fix(inventory): 修改實收連動庫存＋三個扣庫存入口統一上鎖

### DIFF
--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -2346,10 +2346,13 @@ export default function TransfersInboxPage() {
                                 </div>
                               ) : (
                                 <div className="flex justify-end gap-1">
+                                  {/* ⛔ 舊 title 寫「純紀錄…庫存與客人取貨不受影響」，
+                                      20260904010000 起實收調整會連動店家庫存（沖舊立新、
+                                      扣不動就擋下來），那句話已經是錯的，不要改回去。 */}
                                   <SpinButton
                                     onClick={() => setOpening(t)}
                                     className="rounded-md border border-zinc-300 px-2 py-1 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
-                                    title="看這張單的明細；要更正實收數量在裡面按「✎ 修改實收」（純紀錄：月結數量跟著改、少收走總倉收件匣同一條流程，庫存與客人取貨不受影響）"
+                                    title="看這張單的明細；要更正實收數量在裡面按「✎ 修改實收」（月結數量跟著改、少收走總倉收件匣同一條流程；改大會把差額補進店裡庫存、改小會扣回來，扣不動會擋下來）"
                                   >
                                     明細 / 改實收
                                   </SpinButton>

--- a/apps/admin/src/components/ExceptionsContent.tsx
+++ b/apps/admin/src/components/ExceptionsContent.tsx
@@ -704,7 +704,10 @@ export default function ExceptionsContent({
                 共 3 版、20260824020000 是最後一支)⇒ 清掉就會自己回到清單。
             ② 「店家的實收也就改得動了」→ rpc_adjust_received_transfer 守衛 B 擋的條件就是
                shortage_resolution IS NOT NULL(且不是 over_ack)
-               —— 20260903000005 定的,20260903000200 只改它的錯誤訊息、判定一字未改。
+               —— 20260903000005 定的,20260903000200 只改它的錯誤訊息、
+               20260904010000 只在同一支加了庫存連動,兩次判定都一字未改。
+               ⚠️ 20260904010000 起這道守衛更重要:放行不再只是帳對不上,
+               而是「總倉已把短少的貨記回出貨端、店家又把它補進自己的庫存」＝貨變兩份。
             ③ 「撤銷紀錄會寫進那張派貨單的備註」→ 同一支 RPC 最後 UPDATE transfers.notes
                追加一行「撤銷處理(MM/DD HH:MI)：…」;而 v_hq_exceptions 的 reason 欄就是
                「店家收貨備註：」|| t.notes(20260824020000:1467 transfer_short、

--- a/apps/admin/src/components/TransferReceiveModal.tsx
+++ b/apps/admin/src/components/TransferReceiveModal.tsx
@@ -228,8 +228,10 @@ export function TransferReceiveModal({
   }
 
   // 「💾 儲存實收」：已收貨的單改數量 —— 走 rpc_adjust_received_transfer
-  // （20260903000005）。**純紀錄**：只改 qty_received，不寫庫存、不動單頭狀態、
-  // 不碰訂單／取貨／配單（老闆 2026-09-03：跟會員端脫鉤）。
+  // （20260903000005 建立，20260904010000 起**會連動店家庫存**）：
+  // 改 qty_received，並沖掉舊的入庫、用新實收量重開一筆 → 淨效果就是差額。
+  // 往下改扣不動（貨已賣掉／被取走）時 RPC 會 RAISE，整批不存檔（守衛 D）。
+  // 仍不動單頭狀態、不碰訂單／配單／到貨通知（老闆 2026-09-03：跟會員端脫鉤）。
   // 改小之後那一列會自己回到總倉收件匣的「收貨短少」，跟收貨當下填少同一條路。
   async function submitAdjust() {
     setSubmitting(true);
@@ -255,6 +257,19 @@ export function TransferReceiveModal({
         | {
             items_changed: number;
             qty_delta: number;
+            // 20260904010000：庫存實際動了多少。⚠️ 不一定等於 qty_delta ——
+            // 20260903000005 純紀錄期間被調過的列，入庫量早就 ≠ 實收量，
+            // 這次會一次校正回來，所以兩個數字要分開講，不能只報一個。
+            stock_delta: number;
+            stock_note: string | null;
+            // 這次改到的列裡有幾列是虛擬商品（自由轉貨的 MISC-01 之類）。
+            // 它們不進庫存，所以「庫存沒變動」的原因跟一般商品不一樣，要分開講。
+            virtual_lines: number;
+            // 20260904010000（第三輪）：有幾列因為「原批進貨成本是 0」而沒有校正
+            // 庫存均價。數量是照改的，只有金額那段跳過 ⇒ 庫存價值會偏高。
+            // 後端刻意不擋（擋了連數量都改不了），所以畫面是唯一看得見的訊號。
+            avg_cost_uncorrected: number;
+            avg_cost_uncorrected_note: string | null;
             total_received: number;
             short_lines: number;
             over_lines: number;
@@ -266,9 +281,36 @@ export function TransferReceiveModal({
           : "";
       const overNote =
         Number(r?.over_lines ?? 0) > 0 ? `\n🎁 有 ${r?.over_lines} 項多收，已回報總倉` : "";
+      const sd = Number(r?.stock_delta ?? 0);
+      const qd = Number(r?.qty_delta ?? 0);
+      // 「庫存沒變動」有兩種原因，講錯會讓人以為系統漏做事：
+      //   ① 本來就跟新的實收數一樣（一般商品）
+      //   ② 改到的是自由轉貨的商品 —— 它沒有實體，本來就不進庫存（#902）
+      const vl = Number(r?.virtual_lines ?? 0);
+      const stockLine =
+        sd === 0
+          ? vl > 0
+            ? `\n📦 店裡的庫存沒有變動（這 ${vl} 項是店對店自由轉貨的商品，本來就不算庫存）`
+            : "\n📦 店裡的庫存沒有變動（本來就跟新的實收數一樣）"
+          : `\n📦 已同步庫存 ${sd > 0 ? "+" : ""}${sd} 件${r?.stock_note ? `（${r.stock_note}）` : ""}`;
+      // 兩個數字不一樣時一定要說明，否則老闆會以為系統算錯。
+      const mismatchLine =
+        sd !== 0 && sd !== qd
+          ? `\n※ 實收數字改了 ${qd > 0 ? "+" : ""}${qd}、庫存動了 ${sd > 0 ? "+" : ""}${sd}：` +
+            `這一批先前用「純紀錄」調整過（當時刻意沒動庫存），這次一併校正成「庫存＝實收數」。`
+          : "";
+      // 原批成本是 0 的列：數量照調，但庫存均價沒有跟著校正 ⇒ 庫存價值會偏高。
+      // ⛔ 這句不能吞掉：後端刻意不擋（擋了連數量都改不了），畫面就是唯一的訊號。
+      const cu = Number(r?.avg_cost_uncorrected ?? 0);
+      const costLine =
+        cu > 0
+          ? `\n⚠ 有 ${cu} 項的進貨成本是 0，數量已經改好，但庫存成本沒有跟著校正` +
+            `${r?.avg_cost_uncorrected_note ? `（${r.avg_cost_uncorrected_note}）` : ""}。` +
+            `\n　 這不影響數量，只影響庫存金額。要修請走「庫存總覽 → 盤點」重估。`
+          : "";
       alert(
         `實收紀錄已更新：${r?.items_changed ?? 0} 項，實收合計 ${r?.total_received ?? 0}` +
-          `${shortNote}${overNote}\n（庫存沒有變動；架上數量對不上請到庫存總覽盤點）`,
+          `${stockLine}${mismatchLine}${costLine}${shortNote}${overNote}`,
       );
       onSubmitted();
     } catch (e) {
@@ -402,7 +444,7 @@ export function TransferReceiveModal({
                       setAdjusting(true);
                     }}
                     className="rounded-md border border-amber-500 px-3 py-1.5 text-xs font-semibold text-amber-700 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-950"
-                    title="更正這張單的實收數量（給總倉的紀錄）：月結數量跟著走、少收／多收進總倉收件匣；庫存與客人取貨不受影響"
+                    title="更正這張單的實收數量：月結數量跟著走、少收／多收進總倉收件匣；改大會自動把差額補進店裡庫存，改小會從店裡扣回來（不夠扣會擋下來）"
                   >
                     ✎ 修改實收
                   </SpinButton>
@@ -413,7 +455,7 @@ export function TransferReceiveModal({
                 <SpinButton
                   onClick={submitAdjust}
                   disabled={submitting || !items}
-                  title="只改實收數量的紀錄，不動庫存、不重跑配單；改少的部分會回到總倉收件匣等總倉決定"
+                  title="更正實收數量，店裡的庫存跟著同步（改大補、改小扣，不夠扣會擋下來）；不重跑配單，改少的部分會回到總倉收件匣等總倉決定"
                   className="rounded-md bg-amber-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-700 disabled:opacity-50"
                 >
                   {submitting ? "儲存中…" : "💾 儲存實收"}
@@ -493,24 +535,37 @@ export function TransferReceiveModal({
         )}
 
         {/* 調整已收模式的說明 —— 每一句都要對得上程式（本檔第一鐵則）：
-            ① 「這是給總倉的紀錄」：rpc_adjust_received_transfer（20260903000005）
-               只 UPDATE qty_received，一筆 stock_movements 都不寫。
+            ① 「更正這批到底來了幾件」：rpc_adjust_received_transfer 改 qty_received。
             ② 「月結數量跟著走」：月結 hq_to_store 的量是 GREATEST(派出, 實收)
                （20260901000000 派車制）→ 改大就跟著大；改小維持派出量，
                那一段錢要總倉在收件匣按「同意退回」才沖掉（20260901000010）。
                ⛔ 不可以寫成「改小月結就會變少」——那是錯的。
-            ③ 「庫存不會跟著改」＋「客人不受影響」：老闆 2026-09-03 要求跟會員端脫鉤，
-               函式因此不碰庫存／訂單／取貨閘門／配單。 */}
+            ③ 「改大補庫存／改小扣庫存」：20260904010000 起這支會連動庫存 ——
+               沖掉舊的入庫、用新實收量重開一筆 transfer_in，淨效果＝差額。
+               ⛔ 舊文案寫「庫存不會跟著改」從 20260904010000 起是錯的，不要改回去。
+            ④ 「不夠扣會擋下來」：守衛 D（同檔）先查 stock_balances.on_hand，
+               不足就 RAISE、整批不存檔，絕不把庫存扣成負的。
+            ⑤ 「客人的訂單不受影響」：函式仍然不碰 customer_orders／配單／到貨通知。
+               ⛔ 但**不可以**再寫「取貨不受影響」：取貨閘門的實體側守衛
+                  （on_hand − 已承諾未取，20260818000010）本來就跟著真實庫存走，
+                  補了貨才取得到、扣了貨就會擋住。 */}
         {adjusting && (
           <div className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200">
-            <div className="font-semibold">✎ 修改實收數量（給總倉的紀錄）</div>
+            <div className="font-semibold">✎ 修改實收數量</div>
             <div className="mt-0.5">
-              用途是回頭跟總倉更正「這批到底來了幾件」：月結數量跟著這裡的實收走，
+              用途是回頭更正「這批到底來了幾件」：月結數量跟著這裡的實收走，
               少收／多收會出現在總倉的收件匣。
             </div>
             <div className="mt-0.5">
-              <span className="font-semibold">庫存不會跟著改，客人的訂單與取貨也不受影響。</span>
-              架上數量對不上請到「庫存總覽」新增庫存／盤點。
+              <span className="font-semibold">
+                改大 → 差額自動補進店裡的庫存；改小 → 從店裡扣回來。
+              </span>
+              要扣的時候店裡剩的不夠（貨已經賣掉或被客人取走），會直接擋下來不給存檔，
+              不會把庫存扣成負的。
+            </div>
+            <div className="mt-0.5">
+              客人的訂單、到貨通知與配單決策不會被動到；取貨能不能領則跟著真實庫存走
+              （補了貨才領得到，扣了貨就會擋住）。
             </div>
           </div>
         )}
@@ -549,10 +604,15 @@ export function TransferReceiveModal({
               ⚠️ 少收 {shortQty} 件：這等於向總倉提出退回 {shortQty} 件。
             </div>
             <div className="mt-0.5">
+              {/* 調整模式：20260904010000 起庫存會同步成你填的實收數
+                  ⛔ 舊文案「庫存不會跟著扣」已經是錯的，不要改回去。
+                  扣不動（貨已賣掉／被取走）時 RPC 的守衛 D 會擋下來、整批不存檔。 */}
               {adjusting ? (
                 <>
                   <span className="font-semibold">總倉會在收件匣決定接不接受</span>；
-                  這裡只改紀錄，<span className="font-semibold">庫存不會跟著扣</span>。
+                  店裡的庫存會
+                  <span className="font-semibold">同步成你填的實收數</span>
+                  （扣不動會擋下來，不會扣成負的）。
                 </>
               ) : (
                 <>

--- a/apps/admin/src/lib/rpcError.ts
+++ b/apps/admin/src/lib/rpcError.ts
@@ -406,6 +406,13 @@ const RULES: Rule[] = [
     pattern: /^zero_price(?:_fill)?:\s*([\s\S]+)$/i,
     render: (m) => m[1],
   },
+  // ===== 實體庫存守衛（rpc_record_pickup，20260904010010） =====
+  {
+    // 取貨扣庫存前鎖住餘額列後重驗，不夠就擋。訊息本體已是中文
+    //（「這次要取「X」5 件，但「三峽店」現在架上只剩 2 件…」），只把機器前綴拿掉。
+    pattern: /^stock_short:\s*([\s\S]+)$/i,
+    render: (m) => m[1],
+  },
   // ===== 贈品標記（rpc_mark_order_item_gift / rpc_set_campaign_item_gift） =====
   {
     // 訊息本體已是中文，一樣只把機器前綴拿掉

--- a/supabase/migrations/20260904010000_adjust_received_syncs_stock.sql
+++ b/supabase/migrations/20260904010000_adjust_received_syncs_stock.sql
@@ -1,0 +1,802 @@
+-- ============================================================
+-- 2026-09-04：「✎ 修改實收」改成會連動店家庫存（不再是純紀錄）
+--
+-- ⚠️⚠️ 本檔改寫的是 PR #900（rpc_adjust_received_transfer）的行為，
+--   那是另一位工程師（@alexktchen）做的功能。老闆 2026-09-04 親自裁示要改，
+--   比照 PR #903 的做法：**紀錄、月結對應、撤銷語意逐字保留，只加庫存那一段**，
+--   並在 PR 說明裡向原作者完整揭露改了哪一段、為什麼改。
+--
+-- ------------------------------------------------------------
+-- 一、為什麼要改（2026-09-04 平鎮真實事故）
+-- ------------------------------------------------------------
+-- 平鎮實際收到 5 件，店員在收貨畫面誤鍵成 2 → 庫存只入了 2。
+-- 老闆用「✎ 修改實收」把數字改回 5，以為貨就回來了 —— **庫存還是 2**
+-- （20260903000005 的定位是純紀錄，一筆 stock_movements 都不寫）。
+-- 要讓架上數字對，還得再去「庫存總覽 → ＋新增庫存」補 3 件。
+-- 現場的店員不會知道有第二步，也沒有任何畫面提醒他 ⇒ 帳實不符會一直累積。
+--
+-- 老闆裁示（2026-09-04）：
+--   ①「往上改（新 > 舊）：差額自動補進店家庫存，要留痕、寫明是哪張單的實收更正。」
+--   ②「往下改（新 < 舊）：先看店家現在的庫存扣不扣得動。夠就自動扣；
+--      不夠（貨已經賣掉／被客人取走）就**大聲擋下來並講原因**。」
+--   ③「⛔ 不准扣成負的，⛔ 不准靜默跳過。」
+--
+-- ⛔ 沒有動的部分（20260903000005 / 20260903000200 的定位原封不動）：
+--   ⛔ 不碰 customer_orders / customer_order_items / 取貨閘門 / 到貨通知
+--   ⛔ 不重跑配單、不清 backorder_at、不動單頭 status / received_at
+--   ⛔ 不碰 RR- 內部單（ride-along）、不碰現貨池（_grow_internal_pool）
+--   ⇒ 老闆 2026-09-03「跟會員端都要脫鉤」那條**仍然成立**：這次只多寫庫存異動，
+--     客人的訂單狀態、到貨通知、配單決策一個都沒動。
+--   ⚠️ 唯一的間接效果是取貨閘門的**實體側**守衛（on_hand − 已承諾未取，
+--     20260818000010）會跟著真實庫存走 —— 補了貨就放行、扣了貨就擋住。
+--     這正是它該有的行為（貨真的在／真的不在），不是副作用。
+--
+-- ------------------------------------------------------------
+-- 二、庫存記在哪、用什麼 movement_type（沒有新增任何 type）
+-- ------------------------------------------------------------
+-- 補進去那筆：`transfer_in`，location = 收貨端 v_dest_location，欄位與收貨路徑
+--   （rpc_receive_transfer 最新版 20260827000000:131-150）走的 rpc_inbound 一致
+--   ⇒ 跟原路同一套帳。單價見「五、」。
+-- 沖掉那筆：`reversal` + `reverses` 指回原入庫 —— 逐字比照
+--   rpc_unreceive_transfer 最新版（20260903000010:185-198）⇒ 跟「退回收貨」同一種痕跡。
+-- 兩個值都在 stock_movements 現行 CHECK 清單裡（最新清單 20260713000000:28-42）
+-- ⇒ **本檔不需要動 stock_movements 的 CHECK，也沒有新增 movement_type。**
+--
+-- ⭐ 虛擬商品（MISC-01 之類）：整段庫存連動 no-op，判斷提在迴圈最上面。
+--   🔴 2026-09-04 第二輪修正 —— 第一輪的做法（補那筆走 rpc_inbound、白吃它的
+--     虛擬商品守衛）**有 bug**：立新被守衛擋掉回 NULL，沖舊卻是自己 INSERT、
+--     照寫不誤 ⇒ 虛擬商品被**單向沖掉**，正好把 #902 修好的「只進不出」
+--     倒過來再犯一次。現在改成整段跳過，進出都不寫。
+--   代價是虛擬商品判斷式在本檔多了一份（與 rpc_inbound 20260903000100:56-64
+--     同源，⛔ 那邊改要跟著改）。換到的是新入庫那筆能帶 source_doc_line_id
+--     與 reason —— rpc_inbound 不吃這兩個參數，而 movement 是 append-only、
+--     補不回來，給它加 DEFAULT 參數又會撞出 ambiguous 重載害全站入庫爆掉。
+--     詳細取捨寫在「立新」那段的註解裡。
+--
+-- ------------------------------------------------------------
+-- 三、為什麼是「沖舊立新」而不是「只補一筆差額」⭐ 本檔最關鍵的一段
+-- ------------------------------------------------------------
+-- 直覺做法是「改 2→5 就寫一筆 +3」。**那樣會弄壞「↩ 返回收貨配單」。**
+-- rpc_unreceive_transfer（20260903000010:159-200）逐項沖銷時，
+-- 沖的量取自 `in_movement_id` 指著的那筆異動本身（v_orig.quantity），
+-- 不是 qty_received。所以只補差額的話：
+--   • 2→5 之後取消收貨 → 它只沖回當初那 2 件，我補的 3 件憑空留在店裡（生貨）。
+--   • 5→3 之後取消收貨 → 它要沖 5 件但店裡剩 3 件，撞上它的實體守衛
+--     （20260903000010:180-183）整張單退不掉，訊息還會誤導成「貨被取走了」。
+--
+-- ⇒ 本檔改成：**沖掉舊的那筆入庫、用新實收量重開一筆**，並把 in_movement_id 指到新的。
+--   由此建立一條不變式：
+--
+--       ⭐ in_movement_id 指著的異動，quantity 永遠 = 該列的 qty_received。
+--
+--   維持這條不變式，rpc_unreceive_transfer **一行都不用改**就永遠沖對量，
+--   而且新開的那筆通過它的三項身分檢查（transfer_in / source_doc_type='transfer' /
+--   source_doc_id 相符，20260903000010:162-167），舊的那筆已被我們 reverses 掉、
+--   新的沒有 ⇒ 它的「已被沖銷過」守衛（:169-171）也不會誤擋。
+--   ⛔ 誰要把這裡改回「只寫一筆差額」，請先讀完這一段。
+--
+-- 淨效果 = 新實收量 − 舊入庫量，跟「補差額」在正常情況下完全一樣
+-- （收貨後直接改，舊入庫量 == 舊實收量）。
+--
+-- ⚠️ 唯一會不一樣的情況：**20260903000005 上線（2026-09-03）到本檔上線之間，
+--   被「純紀錄」調整過的列** —— 那些列的 in_movement.quantity 已經 ≠ qty_received。
+--   例：入庫真的入了 4、純紀錄把實收改成 1，今天再改成 2
+--       → 庫存從 4 變成 2（−2），不是「1→2 所以 +1」。
+--   這是**對的**（改完庫存 = 實收 = 2，帳實一致），但數字跟直覺不同，
+--   所以回傳值與畫面把「實收變動」與「庫存變動」分開顯示，不讓人誤會。
+--   上線前請先查有幾列是這種（查詢附在施工回報裡）。
+--
+-- ------------------------------------------------------------
+-- 四、寫入順序：先立新、後沖舊（⛔ 不可對調）
+-- ------------------------------------------------------------
+-- stock_balances **沒有** on_hand >= 0 的 CHECK（20260422120003:30-41），
+-- trg_apply_movement 也只是加減不擋負（:210-247）⇒ 負庫存只能靠呼叫端自己擋。
+-- 先扣後補的話中間會短暫變負；先補後扣則中間值 = on_hand + 新實收量 ≥ 0 恆成立。
+-- 再加上寫入前的淨額守衛（on_hand ≥ 舊入庫量 − 新實收量），
+-- 帳面**任何一刻**都不會是負的。
+--
+-- ------------------------------------------------------------
+-- 四之二、鎖：⛔ 只鎖自己這一邊等於沒鎖（2026-09-04 第二輪補，審查 P0）
+-- ------------------------------------------------------------
+-- 本檔讓「往下改實收」會真的扣庫存之後，扣庫存就有了**兩個入口**：
+-- 取貨（rpc_record_pickup）與本函式。兩邊都是「先讀 on_hand 判斷夠不夠 →
+-- 再寫異動」，中間沒有鎖，兩人同時做就會扣成負的：
+--
+--     [改實收] 讀 on_hand = 5，準備扣 3            ┐
+--     [取 貨 ] 閘門讀 on_hand = 5，準備取 5        │ 兩邊都覺得自己夠
+--     [改實收] 寫 −3 → on_hand = 2  (commit)      │
+--     [取 貨 ] 寫 sale −5 → on_hand = **−3**  ⛔  ┘
+--
+-- ⇒ 扣庫存其實有**三個**入口（第三個是現場銷售，第二輪審查才抓到）：
+--     ① 本檔        rpc_adjust_received_transfer  ✎ 修改實收
+--     ② 20260904010010  rpc_record_pickup         取貨
+--     ③ 20260904010020  rpc_create_walkin_sale    現場銷售（門市臨櫃結帳）
+--   **三支必須一起在線上**，少任何一支，另外兩支的鎖都擋不住那一邊趁隙寫進來
+--   （三支中任兩支的組合都湊得出上面那張圖）。
+-- ⇒ 三支的鎖序都是「ORDER BY location_id, sku_id 去重後逐列 FOR UPDATE，
+--   而且放在主迴圈之前」。順序不一致就會各拿一半互相等（死鎖）。
+--   ⛔ 要改鎖序就三支一起改。
+-- ⚠ 但三支的**性格不同**，⛔ 不要抄錯邊：
+--     本檔與取貨 → 鎖完發現不夠就**大聲失敗**（貨不能憑空生出來給客人）
+--     現場銷售   → 鎖完發現不夠就**多補一點照樣結帳**
+--                 （客人站在櫃台前、貨一定會離開，擋下來只會讓帳跟現實脫節。
+--                   老闆 2026-09-01 親自定的，見 20260904010020 檔頭【二】）
+--
+-- ------------------------------------------------------------
+-- 四之三、成本口徑：avg_cost 要跟「只補差額」等價（第二輪補，審查 P1）
+-- ------------------------------------------------------------
+-- trg_apply_movement 只在 quantity > 0 時重算加權平均（20260422120003:230-237）。
+-- 「沖舊立新」的立新那筆被完整加權一次、沖舊那筆一毛都沒退 ⇒ avg_cost 被多拉
+-- 一次，而後續出庫是讀 avg_cost 當成本的（20260705000000:144-181）⇒ 會一路髒下去。
+--
+-- 修法：兩筆寫完後把 avg_cost 拉回「只補差額」該有的值 ——
+--   目標價值 = 調整前價值 + (新實收 − 舊入庫) × 這批貨的單價
+-- 單價優先取**原入庫那筆**的 unit_cost（這批貨實際入帳的價），沒有才退回出庫單價。
+--
+-- 驗收（寫死在程式碼註解裡當回歸基準）：原有 10 件 @$100、這批單價 $80，
+--   「一次收 8」與「先收 5 再改成 8」**兩條路徑的最終 avg_cost 都必須 = 91.1111**。
+--
+-- ------------------------------------------------------------
+-- 五、跟「短少處理」「撤銷」的互鎖 —— 查證後結論：既有守衛 B 已經夠，不加新的
+-- ------------------------------------------------------------
+-- 會不會「總倉已按同意退回把貨記回總倉，店家再往上改實收 ⇒ 貨變兩份」？
+-- **不會**：守衛 B（本檔逐字保留）擋掉所有 shortage_resolution 非 NULL 的列。
+-- 逐一查證（rpc_resolve_transfer_item_shortage 最新版 20260903000200:111-313）：
+--   restock_hq / redispatch → 寫 rpc_inbound(...,'transfer_cancel') 記回出貨端 → 守衛 B 擋 ✅
+--   reject_return           → 補回 qty_received（純紀錄）                → 守衛 B 擋 ✅
+--   cancel_orders / vendor_claim / accept / replenish → 純標記            → 守衛 B 擋 ✅
+--   over_ack（唯一放行的）  → rpc_ack_transfer_over（20260824020000:1600-1616）
+--                             只 UPDATE 一個標記欄位，一筆庫存／金流都沒有 ✅
+-- ⇒ 唯一能走到庫存那段的，是「總倉還沒處理」或「只按過多收知道了」的列，不可能雙算。
+-- ⚠️ 但守衛 B 的份量因為本檔而**變重了**：以前它擋的是「帳對不上」，
+--   現在它擋的是「貨會變兩份」。⛔ 誰想放寬它，先把上面這張表重跑一遍。
+--
+-- 撤銷（rpc_undo_transfer_item_shortage，20260903000200:429）之後再調整：
+--   撤銷把 restock_hq/redispatch 記回**出貨端**的那筆沖掉、清空 shortage_* 欄位
+--   ⇒ 該列回到未處理，守衛 B 放行。此時店家庫存從頭到尾沒被撤銷動過
+--   （撤銷動的是出貨端），所以接著調整就是單純的「店家庫存 = 新實收量」⇒ 帳對 ✅
+-- 調整完再處理短少：調整後那一列的 qty_received 是新值，
+--   resolve 依 `qty_shipped - qty_received` 算短少量（20260903000200:158-161）
+--   ⇒ 拿到的是更正後的數字 ⇒ 帳對 ✅
+--
+-- ------------------------------------------------------------
+-- 基底版本
+-- ------------------------------------------------------------
+--   rpc_adjust_received_transfer ← **20260903000200:704**（第 2 版；共 2 版：
+--     20260903000005 建立、20260903000200 改守衛 B 的錯誤訊息）。
+--     ⚠️ 不是 20260903000005 —— 用標準查法確認：
+--        git grep -nE "CREATE (OR REPLACE )?FUNCTION (public\.)?rpc_adjust_received_transfer" \
+--          origin/main -- supabase/migrations | sort   → 最後一行是 20260903000200。
+--     本檔為第 3 版：DECLARE 加變數、迴圈查詢多取三個欄位、迴圈裡插入庫存段、
+--     UPDATE 多寫 in_movement_id、備註與回傳多帶庫存資訊。**其餘逐字保留。**
+--   ⛔ 沒有動 rpc_receive_transfer / rpc_unreceive_transfer / rpc_inbound /
+--     rpc_resolve_transfer_item_shortage / rpc_undo_transfer_item_shortage —— 一行都沒有。
+--
+-- 上線順序（⛔ 不可顛倒，完整說明見修復腳本檔頭）：
+--   1️⃣ 本檔 → 2️⃣ 20260904010010 → 3️⃣ 20260904010020
+--   → 4️⃣ 跑 D:\1人公司\公司\01_進行中\實收連動_修復不一致列_2026-09-04.sql
+--        第 ① 段預覽 → 第 ② 段修復 → 第 ③ 段驗證
+--   ⚠️ 第 4 步**不是選配**：純紀錄期間（20260903000005 起）留下的
+--     「帳面實收 ≠ 實際入庫」歷史列，本檔開頭的 `CONTINUE WHEN new_qty = old_qty`
+--     會直接跳過（比的是帳面實收），⇒ 老闆在畫面上重存同一個數字**不會有反應**，
+--     那些列只有靠那支腳本才修得掉。
+--
+-- Rollback：
+--   CREATE OR REPLACE 回 20260903000200:704 那一版（純紀錄）。
+--   ⚠️ 本檔 / 20260904010010 / 20260904010020 **三支是一組**，要回就三支一起回；
+--     只回一支等於把負庫存的洞留兩邊。
+--   ⚠️ 已經寫下去的庫存異動是 append-only、不會自動回滾；要還原就對每一筆
+--     開反向 manual_adjust。回滾前先撈：
+--       SELECT * FROM stock_movements
+--        WHERE source_doc_type = 'transfer' AND reason LIKE '實收更正 transfer=%';
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_adjust_received_transfer(
+  p_transfer_id BIGINT,
+  p_lines       JSONB,
+  p_operator    UUID,
+  p_notes       TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_tenant_id       UUID;
+  v_status          TEXT;
+  v_transfer_type   TEXT;
+  v_dest_location   BIGINT;
+  v_shipped_at      TIMESTAMPTZ;
+  v_existing_notes  TEXT;
+  v_line            RECORD;
+  v_label           TEXT;
+  v_changes         TEXT[] := '{}'::TEXT[];
+  v_items_changed   INTEGER := 0;
+  v_qty_delta       NUMERIC := 0;
+  v_locked          TEXT;
+  v_dest_store_id   BIGINT;
+  v_log             TEXT;
+  -- 20260904010000 庫存連動用
+  -- %ROWTYPE 不是 RECORD：逐字比照 rpc_unreceive_transfer（20260903000010:42）。
+  -- 差別在查無資料時 —— %ROWTYPE 的欄位結構永遠存在，v_orig.id 讀得到 NULL；
+  -- 裸 RECORD 在第一次就查不到列時可能是「尚未指派」，底下的 IS NULL 檢查就接不住。
+  v_orig            stock_movements%ROWTYPE;   -- 該列當初真的入過庫的那筆 transfer_in
+  v_old_stock       NUMERIC;   -- ↑ 的數量（沒有入庫紀錄就是 0）
+  v_need            NUMERIC;   -- 要淨扣的量（> 0 才要問庫存夠不夠）
+  v_new_mov_id      BIGINT;
+  v_line_delta      NUMERIC;   -- 這一列真正的庫存變動
+  v_stock_delta     NUMERIC := 0;
+  v_stock_changes   TEXT[] := '{}'::TEXT[];
+  -- 2026-09-04 第二輪（審查 P0 / P1-1 / P2）新增
+  v_lock            RECORD;    -- 預鎖用（鎖序與 20260904010010 一致）
+  v_is_virtual      BOOLEAN;   -- 虛擬商品（MISC-01 之類）整段跳過
+  v_unit_cost       NUMERIC;   -- 這批貨真正的入庫單價 = avg_cost 校正的基準
+  v_onhand_before   NUMERIC;   -- 寫任何異動**之前**的 on_hand
+  v_avg_before      NUMERIC;   -- 寫任何異動**之前**的 avg_cost
+  v_onhand_after    NUMERIC;   -- 兩筆都寫完之後的 on_hand
+  v_transfer_no     TEXT;      -- 給人看的單號（寫進新入庫異動的 reason）
+  v_virtual_lines   INTEGER := 0;  -- 這次改到幾列是虛擬商品（不進庫存）
+  -- 2026-09-04 第三輪（審查 P1-1）：成本為 0 的批次 ⇒ 均價校正跳過，⛔ 但不准靜默
+  v_cost_skipped     BOOLEAN;             -- 這一列的均價校正跳過了嗎
+  v_cost_warn        TEXT;                -- ↑ 掛在兩筆異動 reason 尾巴的警語
+  v_cost_warn_lines  INTEGER := 0;        -- 這次總共幾列是這種情況
+  v_cost_warn_labels TEXT[] := '{}'::TEXT[];   -- 是哪幾樣商品（回傳給前端 / 寫進備註）
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('transfer:' || p_transfer_id));
+
+  IF p_lines IS NULL
+     OR jsonb_typeof(p_lines) <> 'array'
+     OR jsonb_array_length(p_lines) = 0 THEN
+    RAISE EXCEPTION '沒有要調整的品項';
+  END IF;
+
+  -- 2026-09-04 第二輪：多取 transfer_no —— 新寫的那筆入庫異動 reason 要給人看，
+  -- 而人看得懂的是單號，不是 transfer 的內部 id。
+  SELECT tenant_id, status, transfer_type, dest_location, shipped_at, notes, transfer_no
+    INTO v_tenant_id, v_status, v_transfer_type, v_dest_location, v_shipped_at, v_existing_notes,
+         v_transfer_no
+    FROM transfers
+   WHERE id = p_transfer_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transfer % not found', p_transfer_id;
+  END IF;
+
+  IF COALESCE(auth.jwt() ->> 'tenant_id', '') <> ''
+     AND (auth.jwt() ->> 'tenant_id')::UUID <> v_tenant_id THEN
+    RAISE EXCEPTION 'transfer not in current tenant';
+  END IF;
+
+  IF v_status <> 'received' THEN
+    RAISE EXCEPTION '調撥單 % 目前狀態為「%」，只有「已收貨」的單可以調整實收數量', p_transfer_id, v_status;
+  END IF;
+
+  -- 守衛 A：短收沖帳記帳單本身
+  IF EXISTS (SELECT 1 FROM transfer_items ti
+              WHERE ti.shortage_return_transfer_id = p_transfer_id) THEN
+    RAISE EXCEPTION '調撥單 % 是短收沖帳用的記帳單（月結靠它退錢給店家），不能改它的實收數量。', p_transfer_id;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM jsonb_array_elements(p_lines) AS l
+      LEFT JOIN transfer_items ti
+        ON ti.id = (l->>'transfer_item_id')::BIGINT
+       AND ti.transfer_id = p_transfer_id
+     WHERE ti.id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'p_lines 含有不屬於調撥單 % 的品項', p_transfer_id;
+  END IF;
+
+  -- 同一個品項在 p_lines 出現兩次 → 第二次拿到的是過期的 old_qty，備註會寫錯。
+  IF EXISTS (
+    SELECT 1
+      FROM jsonb_array_elements(p_lines) AS l
+     GROUP BY (l->>'transfer_item_id')
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'p_lines 有重複的品項';
+  END IF;
+
+  -- ==========================================================================
+  -- 預鎖（2026-09-04 第二輪補；配 20260904010010）
+  --   把這次會碰到的 (location_id, sku_id) 去重、**排序後**逐列鎖起來。
+  --   ⛔ ORDER BY location_id, sku_id 這個順序與 20260904010010（取貨扣庫存）
+  --     完全一致 —— 兩支都會鎖到同一批餘額列，各用各的順序就會各拿一半、
+  --     互相等到天亮（死鎖）。只改一邊等於沒改。
+  --   ⚠ 放在主迴圈**之前**：主迴圈的 FOR UPDATE OF ti 會鎖 transfer_items，
+  --     先鎖 stock_balances 再鎖 transfer_items，順序與取貨那支
+  --     （stock_balances → customer_order_items）同向，兩支不會反向交錯。
+  --   餘額列不存在時鎖不到東西 —— 那代表 on_hand 視同 0，守衛 D 一樣擋得住。
+  -- ==========================================================================
+  FOR v_lock IN
+    SELECT DISTINCT v_dest_location AS location_id, ti.sku_id
+      FROM jsonb_array_elements(p_lines) AS l
+      JOIN transfer_items ti
+        ON ti.id = (l->>'transfer_item_id')::BIGINT
+       AND ti.transfer_id = p_transfer_id
+     WHERE ti.sku_id IS NOT NULL
+     ORDER BY 1, 2
+  LOOP
+    PERFORM 1
+       FROM stock_balances
+      WHERE tenant_id   = v_tenant_id
+        AND location_id = v_lock.location_id
+        AND sku_id      = v_lock.sku_id
+      FOR UPDATE;
+  END LOOP;
+
+  FOR v_line IN
+    -- 20260904010000：多取 sku_id / in_movement_id / out_cost 三個欄位給庫存段用。
+    -- out_cost 的取法逐字比照收貨路徑（20260827000000:101-105）：
+    -- LEFT JOIN 出庫那筆異動拿 unit_cost，補進去的那筆才跟原路同一個單價口徑。
+    -- FOR UPDATE OF ti 只鎖 transfer_items，多一個 LEFT JOIN 不影響（同 skus 那個）。
+    SELECT ti.id,
+           ti.sku_id,
+           ti.in_movement_id,
+           om.unit_cost                          AS out_cost,
+           ti.qty_shipped,
+           ti.qty_received                       AS old_qty,
+           ti.shortage_resolution,
+           (l->>'qty_received')::NUMERIC         AS new_qty,
+           COALESCE(NULLIF(TRIM(ti.description), ''),
+                    NULLIF(TRIM(COALESCE(s.product_name, '')
+                                || COALESCE(' / ' || NULLIF(s.variant_name, ''), '')), ''),
+                    '品項#' || ti.id::TEXT)      AS label
+      FROM jsonb_array_elements(p_lines) AS l
+      JOIN transfer_items ti
+        ON ti.id = (l->>'transfer_item_id')::BIGINT
+       AND ti.transfer_id = p_transfer_id
+      LEFT JOIN skus s ON s.id = ti.sku_id
+      LEFT JOIN stock_movements om ON om.id = ti.out_movement_id
+     ORDER BY ti.id
+     FOR UPDATE OF ti
+  LOOP
+    IF v_line.new_qty IS NULL OR v_line.new_qty < 0 THEN
+      RAISE EXCEPTION '「%」的實收「%」不是有效數量，請填 0 或正整數',
+        v_line.label, COALESCE(v_line.new_qty::TEXT, 'null');
+    END IF;
+
+    CONTINUE WHEN v_line.new_qty = v_line.old_qty;
+
+    v_label := v_line.label;
+
+    -- 守衛 B：總倉已處理過的短少／多收
+    -- ⚠️ 20260903000200 只改這段的**錯誤訊息**：撤銷不再需要「整張重來」——
+    --   總倉可以到「收件匣 → 異常 → 已處理」單筆按「撤銷」
+    --   （rpc_undo_transfer_item_shortage），撤完這一列就回到未處理、實收也就改得動了。
+    --   ⛔ 判定條件一字未改（含 over_ack 的例外）。
+    -- ⚠️ 20260904010000：這道守衛的份量變重了。以前放行只會讓帳面對不上，
+    --   現在放行會讓**貨變兩份**（總倉已把短少的貨記回出貨端，這裡又補進店家庫存）。
+    --   ⛔ 要放寬它之前，先重跑本檔檔頭「五、」那張逐一查證表。
+    IF v_line.shortage_resolution IS NOT NULL
+       AND v_line.shortage_resolution <> 'over_ack' THEN
+      RAISE EXCEPTION '「%」的差異總倉已經處理過（%），不能再改實收。請總倉到「收件匣 → 異常 → 已處理」把那一筆「撤銷」，或用「↩ 返回收貨配單」整張重來。',
+        v_label, v_line.shortage_resolution;
+    END IF;
+
+    -- 守衛 C：會讓月結數量變動，且該月對帳單已鎖定 → 擋
+    -- 月結 hq_to_store 的量 = GREATEST(派出, 實收)（20260901000000），
+    -- 所以只有「新舊兩邊的 GREATEST 不同」才真的動到金額（改小通常不會動到）。
+    IF v_transfer_type = 'hq_to_store'
+       AND GREATEST(v_line.qty_shipped, v_line.old_qty)
+           <> GREATEST(v_line.qty_shipped, v_line.new_qty) THEN
+      SELECT string_agg(DISTINCT st.name || '（' || sms.status || '）', '、')
+        INTO v_locked
+        FROM stores st
+        JOIN store_monthly_settlements sms
+          ON sms.store_id = st.id
+         AND sms.settlement_month
+             = DATE_TRUNC('month', COALESCE(v_shipped_at, NOW()) AT TIME ZONE 'Asia/Taipei')::DATE
+       WHERE st.location_id = v_dest_location
+         AND sms.status IN ('confirmed', 'settled', 'remitted');
+      IF v_locked IS NOT NULL THEN
+        RAISE EXCEPTION '「%」改了會動到月結金額，但該月對帳單已鎖定：%。請聯繫總倉人工處理。',
+          v_label, v_locked;
+      END IF;
+    END IF;
+
+    -- ============================================================
+    -- 守衛 D ＋ 庫存連動（20260904010000 新增；本檔唯一新增的行為）
+    --   ⛔ 這裡以前寫的是「刻意什麼庫存都不寫」。老闆 2026-09-04 裁示改掉，
+    --     理由與完整推導見本檔檔頭「一、」「三、」「四、」。
+    -- ============================================================
+    v_new_mov_id := v_line.in_movement_id;   -- 沒進到底下的 swap 就維持原狀
+    v_old_stock  := 0;
+    -- ⚠ 每一圈都要重置：v_orig 是 %ROWTYPE 變數，這一圈若沒有 in_movement_id
+    --   就**不會**執行底下那個 SELECT INTO，殘值會原封不動留到這一圈被讀到
+    --   （寫 reason 時要拿 v_orig.id 判斷「原本有沒有入庫紀錄」，讀到上一圈的
+    --   id 會寫出一句看起來很具體、其實指著別的品項的鬼話）。
+    v_orig       := NULL;
+
+    -- ------------------------------------------------------------------
+    -- 虛擬商品：整段庫存連動一律 no-op（2026-09-04 第二輪補）
+    --
+    -- 🔴 這修掉的是第一輪的一個真 bug（審查沒抓到，我自己複查時發現）：
+    --   第一輪「立新」走 rpc_inbound（虛擬 SKU 回 NULL、什麼都不寫），
+    --   但「沖舊」是自己 INSERT、**照寫不誤** ⇒ 虛擬商品會被**單向沖掉**
+    --   （只出不進），正好把 #902 修好的「只進不出」倒過來再犯一次，
+    --   而且會把 MISC-01 的 on_hand 一路扣成負的。
+    --
+    -- 判斷式與 rpc_inbound（20260903000100:56-64）同源。
+    -- ⛔ 那邊改了虛擬商品的規則，這裡要跟著改。
+    -- （沒有直接沿用 rpc_inbound 的守衛，是因為它不吃 reason /
+    --   source_doc_line_id —— 見下面「立新」那段的說明。）
+    SELECT EXISTS (
+      SELECT 1 FROM skus s JOIN products p ON p.id = s.product_id
+       WHERE s.id = v_line.sku_id AND p.is_virtual
+    ) INTO v_is_virtual;
+    IF v_is_virtual THEN
+      -- 回傳給前端：庫存 0 變動有兩種原因（「本來就一樣」vs「這商品不進庫存」），
+      -- 畫面要講對，不然改了自由轉貨的實收會看到一句對不上的解釋。
+      v_virtual_lines := v_virtual_lines + 1;
+    END IF;
+    -- ------------------------------------------------------------------
+
+    IF v_line.in_movement_id IS NOT NULL AND NOT v_is_virtual THEN
+      SELECT * INTO v_orig FROM stock_movements WHERE id = v_line.in_movement_id;
+      -- 身分檢查：三項條件逐字取自 rpc_unreceive_transfer（20260903000010:162-167）。
+      -- 指到別張單的異動就不是我們有資格沖的，寧可擋下來也不要亂動別人的庫存。
+      -- （SELECT INTO 查無資料時整個 record 會是 NULL ⇒ v_orig.id IS NULL 接得住，
+      --   不會讀到上一圈的殘值。）
+      IF v_orig.id IS NULL
+         OR v_orig.movement_type <> 'transfer_in'
+         OR v_orig.source_doc_type <> 'transfer'
+         OR v_orig.source_doc_id <> p_transfer_id THEN
+        RAISE EXCEPTION '「%」的入庫紀錄（異動 %）不是這張調撥單入的庫，系統不敢動它的庫存。請聯繫總倉人工處理。',
+          v_label, v_line.in_movement_id;
+      END IF;
+      IF EXISTS (SELECT 1 FROM stock_movements sm WHERE sm.reverses = v_orig.id) THEN
+        RAISE EXCEPTION '「%」的入庫紀錄（異動 %）已經被沖銷過，不能再改實收。請用「↩ 返回收貨配單」整張重來。',
+          v_label, v_orig.id;
+      END IF;
+      v_old_stock := v_orig.quantity;
+    END IF;
+
+    -- 庫存本來就等於新實收量 → 什麼都不寫（不留兩筆互相抵銷的異動），
+    -- 而且 in_movement_id 維持指著它，不變式照樣成立。
+    -- 虛擬商品（本迴圈最上面查過）連沖舊都不寫，整段跳過。
+    IF NOT v_is_virtual AND v_old_stock <> v_line.new_qty THEN
+
+      -- ------------------------------------------------------------------
+      -- 這批貨真正的入庫單價 —— 也是下面 avg_cost 校正的基準（P1-1）
+      --   優先用**原入庫那筆**的 unit_cost：那就是這批貨當初實際入帳的價，
+      --   比出庫那筆更貼近「這批貨值多少」。原入庫不存在或沒有單價時
+      --   （純紀錄期間沒有 in_movement_id、或早期資料）才退回出庫單價 ——
+      --   那是收貨路徑（20260827000000:101-105）本來就在用的口徑。
+      -- ------------------------------------------------------------------
+      v_unit_cost := COALESCE(NULLIF(v_orig.unit_cost, 0),
+                              ABS(NULLIF(v_line.out_cost, 0)),
+                              0);
+
+      -- ------------------------------------------------------------------
+      -- 成本為 0 的批次：均價校正會跳過 —— ⛔ 但不准靜默（2026-09-04 第三輪，審查 P1-1）
+      --
+      -- 【什麼時候會發生】v_unit_cost 只有在「原入庫那筆的 unit_cost 是 0 或 NULL」
+      --   **而且**「出庫那筆的 unit_cost 也是 0 或 NULL」時才會是 0。實務上是：
+      --     · 該列在純紀錄期間（20260903000005 起）被改過、沒有 in_movement_id
+      --       可沿用，而它的出庫異動又是早期沒帶成本的資料
+      --     · 這商品在出貨端本來就沒有成本（從沒進過貨、成本從沒建過）
+      --   ⇒ 正常收貨路徑走 rpc_inbound 一定帶成本。這是**邊界情況、不是常態**。
+      --
+      -- 【為什麼是「跳過校正」而不是「照公式算」】
+      --   trigger（20260422120003:232-237）對 unit_cost = 0 的入庫**刻意不重算**
+      --   avg_cost —— 0 被當成「成本未知」，不拿去稀釋均價。於是：
+      --     路徑一 一次收 8 件 @0        → avg_cost 不動
+      --     路徑二 先收 5 @0、再改成 8   → 立新 +8@0 不重算、沖舊 −5 也不重算
+      --                                   → avg_cost 也不動
+      --   **兩條路徑本來就一致（都是「不動」）**。這時候硬套本檔的校正公式
+      --   反而會讓兩條路徑分岔：審查舉例的 1,000 ÷ 13 = 76.9231 是「改實收」
+      --   這條路獨有的數字，「一次收 8」永遠算不出它。⇒ 跳過才是對的。
+      --
+      -- 【但它確實留下一個問題，所以要大聲】
+      --   avg_cost 沒動 ⇒ 這批 0 成本的貨是用**店裡原本的均價**在計價，庫存價值
+      --   偏高（後續出庫的 COGS 也是）。這不是本檔造成的（trigger 對「0 成本入庫」
+      --   一直都這樣），但本檔多寫了兩筆異動，不講清楚，事後查帳會以為是這次調整
+      --   弄出來的。⇒ 兩筆異動的 reason 掛警語、單頭備註寫一句、回傳 JSON 帶旗標。
+      --   ⛔ 不 RAISE：擋下來會讓老闆連數量都改不了，而數量那部分完全正確。
+      --     老闆 2026-09-04「不准靜默跳過」要的是**看得見**，不是**做不了**。
+      --
+      -- ⚠ 還有一種更窄的偏差，本段管不到、也不打算管：原入庫成本是 0、但出庫那筆
+      --   有成本時，v_unit_cost 會取到出庫價 ⇒ 校正照跑，可是當初那筆 0 成本入庫
+      --   從沒稀釋過均價 ⇒ 校正後的值仍與「一次收足」不同。那個差是**歷史那筆
+      --   0 成本入庫**留下的，要修得回頭改歷史，超出本案範圍。若真的碰上，
+      --   走「庫存總覽 → 盤點」重估比在這裡硬算安全。
+      --
+      --   【為什麼不在畫面上標它】（2026-09-04 第四輪，審查 P2，⛔ 這是刻意的決定）
+      --     1. 標了老闆也**沒辦法在這個畫面上處理它** —— 要修得走「庫存總覽 → 盤點」
+      --        重估。收貨畫面多一個看不懂又按不掉的紅字，只會讓人開始忽略紅字，
+      --        連上面那個「原批成本為 0」的真警語都跟著被略過。
+      --     2. 它**不是這次調整造成的**，是歷史那筆 0 成本入庫留下的。掛在
+      --        「✎ 修改實收」的結果上，反而會讓事後查帳的人以為是這次弄出來的。
+      --     3. 數量完全正確，差的只有庫存金額；真正會看到它的人是查庫存價值的時候，
+      --        那個入口本來就不是收貨畫面。
+      --     ⇒ 改成「**看得到有幾列**」而不是「每列都跳警語」：修復腳本第 ①／①-2 段
+      --       各加了一欄（成本備註 ／ 均價校正後仍略有出入），老闆上線前一定會跑那段。
+      --   ⚠ 這個偏差要成立，得「原入庫寫 0 成本、同一批的出庫卻有成本」。現行收貨路徑
+      --     的入庫成本是從出庫那筆帶過來的（20260827000000:101-105），兩邊不會這樣打架
+      --     ⇒ 推斷**是歷史資料才有、上線後不會再長**。⛔ 但我沒有連資料庫查過實際
+      --     有幾列，這是照程式邏輯推的 —— 請以修復腳本 ①-2 跑出來的數字為準。
+      -- ------------------------------------------------------------------
+      v_cost_skipped := (v_old_stock > 0 AND v_unit_cost = 0);
+      v_cost_warn    := CASE WHEN v_cost_skipped
+                             THEN '｜⚠ 原批成本為 0，均價未校正'
+                             ELSE '' END;
+      IF v_cost_skipped THEN
+        v_cost_warn_lines  := v_cost_warn_lines + 1;
+        v_cost_warn_labels := v_cost_warn_labels || v_label;
+      END IF;
+
+      -- 寫任何異動**之前**先把餘額記下來（avg_cost 校正要用）。
+      -- 這一列在函式開頭的預鎖段就已經鎖住了，這裡再 FOR UPDATE 是同一把鎖，
+      -- 讀到的值別人動不了。
+      SELECT on_hand, avg_cost INTO v_onhand_before, v_avg_before
+        FROM stock_balances
+       WHERE tenant_id   = v_tenant_id
+         AND location_id = v_dest_location
+         AND sku_id      = v_line.sku_id
+       FOR UPDATE;
+      v_onhand_before := COALESCE(v_onhand_before, 0);
+      v_avg_before    := COALESCE(v_avg_before, 0);
+
+      -- 守衛 D：往下扣之前先問店裡夠不夠。⛔ 不夠一律擋下、不扣成負的、不靜默跳過。
+      v_need := v_old_stock - v_line.new_qty;   -- > 0 代表這一列要淨扣
+      IF v_need > 0 AND v_onhand_before < v_need THEN
+        RAISE EXCEPTION
+          '「%」改小要從店裡扣回 % 件，但店裡現在只有 % 件 —— 這批貨可能已經賣掉或被客人取走了。這次調整**整批都沒有存檔**。請先確認實際數量：真的少了就走「庫存總覽 → 盤點」，或請總倉在收件匣處理。',
+          v_label, trim_scale(v_need), trim_scale(v_onhand_before);
+      END IF;
+
+      -- ① 先立新（+ 新實收量）
+      -- ② 後沖舊（− 舊入庫量）
+      -- ⛔ 順序不可對調：先扣後補中間會出現負庫存（檔頭「四、」）。
+      v_new_mov_id := NULL;
+      IF v_line.new_qty > 0 THEN
+        -- 欄位與收貨路徑（rpc_receive_transfer 最新版 20260827000000:131-150）
+        -- 走的 rpc_inbound 完全一致：同 'transfer_in'、同 source_doc、
+        -- 同 v_dest_location ⇒ 補進去的貨跟原本收貨那批走同一套帳。
+        --
+        -- ⭐ 為什麼是自己 INSERT，而不是呼叫 rpc_inbound（第一輪的做法，本輪改掉）：
+        --   rpc_inbound 的參數只到 source_doc_id，**不吃 source_doc_line_id、
+        --   也不吃 reason**。少了這兩個，「舊入庫量 0 → 新實收 > 0」那條路
+        --   （純紀錄期間調過、或本來就實收 0）寫出來的異動只留得下 transfer
+        --   層級的痕跡，事後查不出「哪一列、為什麼多這些貨」。
+        --   而這條路又補不回來：
+        --     · stock_movements 是 append-only（trg_no_update_mov，
+        --       20260422120003:259-270 無條件 RAISE）⇒ 寫完再補 reason 不可能
+        --     · 給 rpc_inbound 加 DEFAULT 參數會多出一支 11 參數的重載，
+        --       跟現有 9 參數版撞成 ambiguous ⇒ **全站入庫一起爆**，⛔ 不能做
+        --   ⇒ 只剩自己 INSERT。代價是虛擬商品守衛要自己判一次，已經提到本迴圈
+        --     最上面（v_is_virtual），並註明與 rpc_inbound 同源、那邊改要跟著改。
+        INSERT INTO stock_movements (
+          tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+          source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+        ) VALUES (
+          v_tenant_id, v_dest_location, v_line.sku_id,
+          v_line.new_qty, v_unit_cost, 'transfer_in',
+          'transfer', p_transfer_id, v_line.id,
+          -- 尾巴的 v_cost_warn：原批成本為 0 時掛「⚠ 原批成本為 0，均價未校正」，
+          -- 否則是空字串。⛔ 不准拿掉 —— 那是這種列唯一看得見的訊號（P1-1）。
+          format('實收更正（調撥單 %s／品項 #%s）：實收由 %s 改為 %s，本筆是改後重記的入庫%s%s%s',
+                 COALESCE(v_transfer_no, '#' || p_transfer_id::TEXT), v_line.id,
+                 trim_scale(v_line.old_qty), trim_scale(v_line.new_qty),
+                 COALESCE('，沖銷原入庫 movement ' || v_orig.id::TEXT, '（原本沒有入庫紀錄）'),
+                 COALESCE('；' || NULLIF(TRIM(p_notes), ''), ''),
+                 v_cost_warn),
+          p_operator
+        ) RETURNING id INTO v_new_mov_id;
+      END IF;
+
+      IF v_old_stock > 0 THEN
+        -- 寫法逐字比照 rpc_unreceive_transfer（20260903000010:185-198）：
+        -- 'reversal' + reverses 指回原入庫 ⇒ 稽核上跟「退回收貨」同一種痕跡，
+        -- 而且原入庫被 reverses 佔掉之後不會再被沖第二次。
+        -- reason 就是老闆要的留痕：哪張單、哪一列、實收從幾改到幾、改由哪筆重記。
+        INSERT INTO stock_movements (
+          tenant_id, location_id, sku_id, quantity, unit_cost, movement_type,
+          source_doc_type, source_doc_id, source_doc_line_id, reverses, reason, operator_id
+        ) VALUES (
+          v_orig.tenant_id, v_orig.location_id, v_orig.sku_id,
+          -v_orig.quantity, v_orig.unit_cost, 'reversal',
+          'transfer', p_transfer_id, v_line.id, v_orig.id,
+          format('實收更正 transfer=%s item=%s：實收 %s → %s（沖銷入庫 movement %s，改由 movement %s 重記）%s%s',
+                 p_transfer_id, v_line.id,
+                 trim_scale(v_line.old_qty), trim_scale(v_line.new_qty), v_orig.id,
+                 COALESCE(v_new_mov_id::TEXT, '無（實收改成 0）'),
+                 COALESCE('：' || NULLIF(TRIM(p_notes), ''), ''),
+                 v_cost_warn),   -- 同上：原批成本為 0 時的警語，⛔ 不准拿掉
+          p_operator
+        );
+      END IF;
+
+      -- ==================================================================
+      -- avg_cost 校正（2026-09-04 第二輪，審查 P1-1）
+      --
+      -- 【問題】trg_apply_movement（20260422120003:230-237）只在 quantity > 0
+      --   時重算加權平均。「沖舊立新」寫的是 +新實收 與 −舊入庫 兩筆，於是
+      --   **立新那筆被完整加權了一次、沖舊那筆一毛都沒退回去** ⇒ avg_cost 被
+      --   這批貨的成本多拉一次。這不只是看起來不準：後續出庫是讀 avg_cost 當
+      --   成本的（20260705000000:144-181），會一路髒下去。
+      --
+      -- 【正解】這次調整對庫存價值的真正影響 = 淨變動量 × 這批貨的單價，
+      --   跟「只補一筆差額」完全一樣。所以兩筆寫完後把 avg_cost 拉回該有的值：
+      --       目標庫存價值 = 調整前價值 + (新實收 − 舊入庫) × 單價
+      --       目標 avg_cost = 目標庫存價值 ÷ 調整後 on_hand
+      --
+      -- 【驗收基準（審查給的數字，寫死在這裡當回歸依據）】
+      --   店裡原有 10 件、avg_cost $100（價值 $1,000），這批貨單價 $80：
+      --
+      --     路徑一「一次就收 8 件」
+      --       +8@80 → avg = (1,000 + 8×80) ÷ 18 = 1,640 ÷ 18 = 91.1111
+      --
+      --     路徑二「先收 5 件、再用『✎ 修改實收』改成 8」
+      --       收 5    → avg = (1,000 + 5×80) ÷ 15 = 1,400 ÷ 15 = 93.3333
+      --       改 5→8  → 兩筆寫完後 trigger 會算成 88.6956  ⛔ 錯
+      --                 本段校正：目標價值 = 1,400 + (8−5)×80 = 1,640
+      --                           目標 avg  = 1,640 ÷ 18       = 91.1111  ✅
+      --
+      --   ⇒ **兩條路徑的最終 avg_cost 都必須是 91.1111**，這就是本段的驗收條件。
+      --   （avg_cost 是 NUMERIC(18,4)，讀回來的 93.3333 已經是四捨五入過的值，
+      --     所以實際算出來是 1,639.9995 ÷ 18 = 91.11108…，存回去仍是 91.1111。
+      --     這種尾差是 trigger 本來就有的近似，不是本段引入的。）
+      --
+      -- 【為什麼是直接 UPDATE stock_balances】
+      --   全庫目前只有 trigger 一處寫這張表，本段是**第二處** —— 這件事我清楚，
+      --   而且是找不到更輕的做法才這樣做：
+      --     · 只寫一筆差額 → 弄壞 rpc_unreceive_transfer（檔頭「三、」已論證）
+      --     · 把「補償單價」塞進立新那筆讓 trigger 自己算對 → 那個假單價會進
+      --       stock_movements.unit_cost，污染成本稽核，比 avg_cost 偏差更糟
+      --     · movement 是 append-only，寫完不能回頭改
+      --   ⚠ 只碰 avg_cost 一個欄位，on_hand 仍然完全由 trigger 維護。
+      --   ⚠ 該列此刻被預鎖與上面的 FOR UPDATE 鎖著，讀寫都在鎖的保護內。
+      -- ==================================================================
+      -- ⚠ 這個條件與上面 v_cost_skipped 是同一件事的兩面：
+      --     v_old_stock > 0 AND v_unit_cost = 0  → v_cost_skipped，跳過校正並留痕
+      --     v_old_stock > 0 AND v_unit_cost > 0  → 就是下面這個 IF，正常校正
+      --   ⛔ 要改其中一個，另一個要一起改，否則會變成「跳過了卻沒留痕」。
+      IF v_old_stock > 0 AND v_unit_cost > 0 THEN
+        -- 舊入庫量 = 0 時沒有「沖舊」那筆，trigger 算的本來就是對的，不必校正。
+        SELECT on_hand INTO v_onhand_after
+          FROM stock_balances
+         WHERE tenant_id   = v_tenant_id
+           AND location_id = v_dest_location
+           AND sku_id      = v_line.sku_id;
+
+        -- on_hand <= 0 就不動 avg_cost，與 trigger 同一個口徑
+        -- （20260422120003:234 也是 (on_hand + quantity) > 0 才重算）。
+        IF COALESCE(v_onhand_after, 0) > 0 THEN
+          UPDATE stock_balances
+             SET avg_cost   = GREATEST(
+                   (v_onhand_before * v_avg_before
+                    + (v_line.new_qty - v_old_stock) * v_unit_cost) / v_onhand_after,
+                   0),
+                 updated_at = NOW()
+           WHERE tenant_id   = v_tenant_id
+             AND location_id = v_dest_location
+             AND sku_id      = v_line.sku_id;
+        END IF;
+      END IF;
+
+      -- 真正落地的庫存變動。（虛擬商品在本迴圈最上面就整段跳過了，走不到這裡。）
+      v_line_delta := v_line.new_qty - v_old_stock;
+      IF v_line_delta <> 0 THEN
+        v_stock_delta   := v_stock_delta + v_line_delta;
+        v_stock_changes := v_stock_changes
+                           || format('%s %s%s', v_label,
+                                     CASE WHEN v_line_delta > 0 THEN '+' ELSE '' END,
+                                     trim_scale(v_line_delta));
+      END IF;
+    END IF;
+
+    UPDATE transfer_items
+       SET qty_received = v_line.new_qty,
+           -- 20260904010000：in_movement_id 跟著改指到重記的那筆
+           -- ⇒ 維持「它的 quantity 永遠 = qty_received」的不變式（檔頭「三、」）。
+           in_movement_id = v_new_mov_id,
+           -- over_ack 只是「知道了」的記號，數量改了就讓它重新回總倉收件匣
+           shortage_resolution    = CASE WHEN shortage_resolution = 'over_ack'
+                                         THEN NULL ELSE shortage_resolution END,
+           shortage_resolution_at = CASE WHEN shortage_resolution = 'over_ack'
+                                         THEN NULL ELSE shortage_resolution_at END,
+           shortage_resolution_by = CASE WHEN shortage_resolution = 'over_ack'
+                                         THEN NULL ELSE shortage_resolution_by END,
+           updated_by     = p_operator,
+           updated_at     = NOW()
+     WHERE id = v_line.id;
+
+    -- trim_scale：qty 是 numeric(18,3)，直接印會變成「10.000 → 8」，備註要給人看的
+    v_changes       := v_changes || format('%s %s → %s', v_label,
+                                          trim_scale(v_line.old_qty), trim_scale(v_line.new_qty));
+    v_items_changed := v_items_changed + 1;
+    v_qty_delta     := v_qty_delta + (v_line.new_qty - v_line.old_qty);
+  END LOOP;
+
+  IF v_items_changed = 0 THEN
+    RAISE EXCEPTION '沒有任何數量被改動';
+  END IF;
+
+  -- 單頭備註：總倉收件匣的短少／多收列會把 transfers.notes 當「店家收貨備註」顯示
+  -- （v_hq_exceptions 20260824020000），所以調整紀錄寫在這裡總倉看得到。
+  -- 20260904010000：多寫一段庫存同步結果 —— 店家與總倉都要看得到貨到底動了沒有。
+  v_log := format('實收調整（%s）：%s',
+                  to_char(NOW() AT TIME ZONE 'Asia/Taipei', 'MM/DD HH24:MI'),
+                  array_to_string(v_changes, '、'))
+           || CASE WHEN array_length(v_stock_changes, 1) IS NULL
+                   THEN '｜庫存未變動'
+                   ELSE '｜庫存同步：' || array_to_string(v_stock_changes, '、') END
+           -- P1-1 留痕：成本為 0 的批次數量照調，但均價沒有校正。寫進單頭是因為
+           -- stock_movements.reason 埋得太深，總倉收件匣看得到的只有這裡。
+           || CASE WHEN v_cost_warn_lines = 0 THEN ''
+                   ELSE '｜⚠ ' || array_to_string(v_cost_warn_labels, '、')
+                        || ' 原批成本為 0，數量已更正、均價未校正（庫存價值偏高，'
+                        || '要修請走「庫存總覽 → 盤點」重估）' END
+           || COALESCE('｜' || NULLIF(TRIM(p_notes), ''), '');
+
+  UPDATE transfers
+     SET notes = CASE
+                   WHEN v_existing_notes IS NULL OR TRIM(v_existing_notes) = '' THEN v_log
+                   ELSE v_existing_notes || E'\n' || v_log
+                 END,
+         updated_by = p_operator
+   WHERE id = p_transfer_id;
+
+  SELECT id INTO v_dest_store_id
+    FROM stores
+   WHERE tenant_id = v_tenant_id AND location_id = v_dest_location
+   LIMIT 1;
+
+  RETURN jsonb_build_object(
+    'transfer_id',    p_transfer_id,
+    'items_changed',  v_items_changed,
+    'qty_delta',      v_qty_delta,
+    -- 20260904010000：庫存實際動了多少，另外回報。
+    -- ⚠️ 跟 qty_delta 不一定相等 —— 20260903000005 純紀錄期間被調過的列，
+    --   入庫量早就 ≠ 實收量，這次會一次校正回來（檔頭「三、」最後一段）。
+    --   前端偵測到兩者不同時要分開講清楚，不要只報一個數字。
+    'stock_delta',    v_stock_delta,
+    'stock_note',     CASE WHEN array_length(v_stock_changes, 1) IS NULL
+                           THEN NULL ELSE array_to_string(v_stock_changes, '、') END,
+    -- 這次改到的列裡，有幾列是虛擬商品（自由轉貨的 MISC-01 之類，不進庫存）。
+    -- 給前端分辨「庫存 0 變動」的兩種原因用：本來就一樣 vs 這商品不進庫存。
+    'virtual_lines',  v_virtual_lines,
+    -- P1-1（2026-09-04 第三輪）：這次有幾列因為「原批成本為 0」而**沒有校正均價**。
+    -- 數量是照做的，只有均價那一段跳過。> 0 時前端要把 note 那句顯示出來
+    -- ⛔ 不要吞掉 —— 這是這種列唯一會浮到畫面上的訊號。
+    'avg_cost_uncorrected',      v_cost_warn_lines,
+    'avg_cost_uncorrected_note', CASE WHEN v_cost_warn_lines = 0 THEN NULL
+                                      ELSE array_to_string(v_cost_warn_labels, '、')
+                                           || ' 原批成本為 0，數量已更正、均價未校正' END,
+    'dest_store_id',  v_dest_store_id,
+    'total_received', (SELECT COALESCE(SUM(qty_received), 0)
+                         FROM transfer_items WHERE transfer_id = p_transfer_id),
+    'total_shipped',  (SELECT COALESCE(SUM(qty_shipped), 0)
+                         FROM transfer_items WHERE transfer_id = p_transfer_id),
+    'short_lines',    (SELECT COUNT(*) FROM transfer_items
+                        WHERE transfer_id = p_transfer_id
+                          AND qty_received < qty_shipped
+                          AND shortage_resolution IS NULL),
+    'over_lines',     (SELECT COUNT(*) FROM transfer_items
+                        WHERE transfer_id = p_transfer_id
+                          AND qty_received > qty_shipped
+                          AND shortage_resolution IS NULL)
+  );
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.rpc_adjust_received_transfer(BIGINT, JSONB, UUID, TEXT) IS
+  '已收貨調撥單的實收數量再調整（2026-09-03 建立，20260904010000 起**會連動店家庫存**）：'
+  '改 qty_received，並把該列的入庫異動沖舊立新，使 in_movement_id 指著的異動'
+  'quantity 永遠 = qty_received ⇒ rpc_unreceive_transfer 沖得回正確的量。'
+  '往上改自動補庫存（transfer_in，同收貨路徑）；往下改先檢查 on_hand，'
+  '不夠就整批擋下（守衛 D）⛔ 不扣成負的、不靜默跳過。'
+  '沖舊立新會讓 trigger 多加權一次成本，所以函式內手動把 avg_cost 校正回'
+  '「等同一次收足」的值；原批成本為 0 時**刻意不校正**（trigger 對 0 成本入庫'
+  '本來就不重算，硬校正反而讓兩條路徑分岔），改成大聲留痕：'
+  '兩筆異動 reason 掛警語、單頭備註寫一句、回傳 avg_cost_uncorrected(_note)。'
+  '仍**不碰**訂單／取貨閘門／配單／現貨池（老闆 2026-09-03「跟會員端脫鉤」）。'
+  '少收／多收沿用 v_hq_exceptions 既有流程（總倉收件匣 → 同意退回 → 20260901000010 沖帳單），'
+  '月結量因 GREATEST(派出, 實收) 自動跟著走。連帶依賴 20260903000010。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_adjust_received_transfer(BIGINT, JSONB, UUID, TEXT)
+  TO authenticated, service_role;

--- a/supabase/migrations/20260904010010_pickup_locks_stock_before_deduct.sql
+++ b/supabase/migrations/20260904010010_pickup_locks_stock_before_deduct.sql
@@ -1,0 +1,515 @@
+-- ============================================================================
+-- 20260904010010：取貨扣庫存前先鎖住餘額列，鎖完重驗一次夠不夠
+--
+-- 【為什麼要有這一支】
+-- 20260904010000 讓「✎ 修改實收」往下改時會真的從店裡扣庫存。扣庫存這件事
+-- 從此有了**兩個入口**（取貨、改實收），而這兩個入口都是「先讀 on_hand 判斷
+-- 夠不夠 → 再寫異動」，中間**沒有任何鎖**。兩人同時做就會這樣：
+--
+--     [改實收] 讀 on_hand = 5，準備扣 3            ┐
+--     [取 貨 ] 閘門讀 on_hand = 5，準備取 5        │ 兩邊都覺得自己夠
+--     [改實收] 寫 −3 → on_hand = 2  (commit)      │
+--     [取 貨 ] 寫 sale −5 → on_hand = **−3**  ⛔  ┘ 貨變負的，客人拿了不存在的貨
+--
+-- 老闆 2026-09-04 裁示「⛔ 不准扣成負的」。20260904010000 已經把改實收那側
+-- 鎖起來了（守衛 D），但只鎖一邊等於沒鎖 —— 另一邊照樣可以趁隙寫進去。
+-- 所以取貨這側必須一起補，兩支才構成一道完整的防線。
+--
+-- 【為什麼 trigger 自己的 FOR UPDATE 不夠】
+-- trg_apply_movement（20260422120003:212-251）確實有 SELECT ... FOR UPDATE，
+-- 但它保護的是「兩筆異動的加總不會互相蓋掉」，**不是**「餘額不會變負」——
+-- 它只做 on_hand + NEW.quantity，一個下限都沒有。真正的下限檢查一直在呼叫端。
+--
+-- 【鎖序：⛔ 三支必須一致，不可以只改一邊】
+-- 扣庫存的入口有三個（第三個是現場銷售，第二輪審查才抓到）：
+--     ① 20260904010000  rpc_adjust_received_transfer  ✎ 修改實收
+--     ② 本檔            rpc_record_pickup             取貨
+--     ③ 20260904010020  rpc_create_walkin_sale        現場銷售（門市臨櫃結帳）
+-- 三支會鎖到同一批 (location_id, sku_id)。若各用各的迴圈順序，兩人各拿一半就
+-- 互相等到天亮（死鎖）。三支一律：
+--     ORDER BY location_id, sku_id 去重後逐列 FOR UPDATE
+-- 而且都放在「進主迴圈之前」，先把這次要碰的列一次鎖齊。
+--
+-- ⚠ 但三支的**性格不同**，⛔ 不要抄錯邊：本檔與改實收是「不夠就大聲失敗」，
+--   現場銷售是「不夠就多補一點照樣結帳」（老闆 2026-09-01 親自定的：客人站在
+--   櫃台前、貨一定會離開這家店，擋下來只會讓帳跟現實脫節）。
+--   ⛔ 不要把本檔的 RAISE 抄到現場銷售那支去。
+--
+-- 【豁免口徑逐字對齊取貨閘門，⛔ 不可以比閘門嚴】
+-- is_order_item_pickup_ready 的門市實體守衛（20260901020000:266-283）刻意
+-- 豁免兩種單：member_type='store_internal' 的容器單（RR- / OV- / AB- /
+-- 【內部】xx 店）與 order_kind='offset' 的抵減單。理由是它們被排除在「已承諾」
+-- 母體之外，再要它們自己過 on_hand 守衛會被擋死。
+-- ⚠ 本檔這一段是「把閘門**已經有的**判準，在寫入前用鎖再確認一次」，不是新規則。
+--   嚴一格就會擋掉閘門明明放行的正常取貨 —— 現貨池單第一個卡死。
+--
+-- 【對正常取貨的影響：零】
+-- 閘門的實體守衛算的是「跨團累計承諾 ≤ on_hand」，比本檔的「本次取貨量 ≤
+-- on_hand」**更嚴**。閘門放行得了的，本檔一定也放行得了。本檔只會在
+-- 「閘門讀完之後、寫入之前，貨被別人扣走」這個瞬間擋下來 —— 那本來就該擋。
+--
+-- 【基底】
+-- 20260819000000_gift_exempt_zero_price_guard.sql:183（rpc_record_pickup 第 13 版；
+-- 用 CREATE (OR REPLACE) FUNCTION (public.)?rpc_record_pickup 查定義鏈確認是最後一支。
+-- ⚠ 帶 public. 前綴查只抓得到 8 支、會漏掉前 5 支早期版本）。
+-- 基底函式本體 329 行**逐字保留**，只在兩處插入：
+--   ① DECLARE 加 4 個變數
+--   ② 取得 v_pickup_loc 之後、退貨守門之前，插入預鎖段與重驗段
+-- 既有的守衛（訂單狀態、店家守衛、零元/贈品守衛、退貨守門、逐品項閘門、
+-- 拆行邏輯、狀態重算、事件寫入、回傳欄位）一行都沒有改。
+--
+-- 【上線順序（⛔ 不可顛倒）】
+--   1️⃣ 20260904010000（改實收會動庫存）
+--   2️⃣ 本檔（取貨先鎖再扣）
+--   3️⃣ 20260904010020（現場銷售先鎖再補）
+--   4️⃣ 跑 D:\1人公司\公司\01_進行中\實收連動_修復不一致列_2026-09-04.sql
+--      第 ① 段預覽 → **停下來看** → 第 ② 段（先演練，再把 v_dry_run 改 FALSE 正式跑）
+--      → 第 ③ 段驗證
+--   ⚠️ 第 4 步**不是選配**：純紀錄期間（20260903000005 起）留下的
+--     「帳面實收 ≠ 實際入庫」歷史列，在畫面上重存同一個數字不會有反應
+--     （20260904010000 開頭就 CONTINUE 掉了，比的是帳面實收），只有那支腳本修得掉。
+--     完整說明在那支腳本的檔頭。
+--
+-- 【Rollback】
+-- CREATE OR REPLACE 回 20260819000000:183-511 的版本即可（本檔沒有動任何 schema、
+-- 沒有新增欄位、沒有改 CHECK；純函式覆寫）。
+-- ⚠ 但 20260904010000 / 本檔 / 20260904010020 **三支是一組**：回滾任一支，
+--   負庫存的洞就從三邊變兩邊 —— 要回就三支一起回。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_record_pickup(
+  p_order_id  bigint,
+  p_item_ids  bigint[],
+  p_operator  uuid,
+  p_notes     text  DEFAULT NULL,
+  p_item_qtys jsonb DEFAULT NULL   -- {"<item_id>": <取貨數量>}；缺項或 >=qty 視為整行取
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_order            customer_orders%ROWTYPE;
+  v_pickup_loc       BIGINT;
+  v_item             RECORD;
+  v_ret_guard        RECORD;
+  v_take             NUMERIC;
+  v_picked_disc      NUMERIC;
+  v_movement_id      BIGINT;
+  v_new_item_id      BIGINT;
+  v_picked_item_id   BIGINT;
+  v_picked_count     INT := 0;
+  v_event_item_ids   BIGINT[] := ARRAY[]::BIGINT[];
+  v_active_remaining INT;
+  v_new_status       TEXT;
+  v_event_type       TEXT;
+  v_event_id         BIGINT;
+  v_sku_label        TEXT;
+  v_now              TIMESTAMPTZ := NOW();
+  -- 店家守衛（2026-08-13）
+  v_jwt_role          TEXT  := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_my_stores         JSONB := COALESCE(auth.jwt() -> 'app_metadata' -> 'stores', '[]'::jsonb);
+  v_pickup_store_name TEXT;
+  -- 零元守衛（2026-08-15）
+  v_is_internal_pool  BOOLEAN;
+  v_zero_labels       TEXT[] := ARRAY[]::TEXT[];
+  -- 實體庫存鎖（20260904010010）
+  v_lock              RECORD;
+  v_stock_short       RECORD;
+  v_stock_exempt      BOOLEAN;
+  v_stock_store_name  TEXT;
+BEGIN
+  IF p_item_ids IS NULL OR array_length(p_item_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_item_ids is empty';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('order_pickup:' || p_order_id::text));
+
+  SELECT * INTO v_order FROM customer_orders WHERE id = p_order_id FOR UPDATE;
+  IF v_order.id IS NULL THEN
+    RAISE EXCEPTION '找不到訂單 %', p_order_id;
+  END IF;
+
+  IF v_order.status IN ('completed','expired','cancelled','transferred_out') THEN
+    RAISE EXCEPTION '訂單 % 目前狀態為「%」，無法取貨', p_order_id, v_order.status;
+  END IF;
+
+  -- 店家守衛：分店角色只能替「自己店」的訂單取貨。庫存跟著 pickup_store_id
+  -- 的 location 扣，跨店按取貨會扣到別店的帳、客人也拿不到貨。
+  -- stores 為空（未設定的 legacy 帳號）或含「總倉」不鎖，對齊前端判定。
+  IF v_jwt_role IN ('store_manager','store_staff')
+     AND jsonb_typeof(v_my_stores) = 'array'
+     AND jsonb_array_length(v_my_stores) > 0
+     AND NOT (v_my_stores ? '總倉') THEN
+    SELECT s.name INTO v_pickup_store_name
+      FROM stores s
+     WHERE s.id = v_order.pickup_store_id
+       AND s.tenant_id = v_order.tenant_id;
+    IF v_pickup_store_name IS NULL OR NOT (v_my_stores ? v_pickup_store_name) THEN
+      RAISE EXCEPTION 'wrong_store: 此訂單的取貨店是「%」，分店帳號只能替自己店的訂單取貨，請由該店操作或先轉單',
+        COALESCE(v_pickup_store_name, '未設定');
+    END IF;
+  END IF;
+
+  -- 零元守衛（2026-08-15）：本次要取的品項若單價是 $0，代表開團 / 代 key 時
+  -- 漏填金額 —— 取貨就是收錢的那一刻，放行等於把貨白送出去（線上已經這樣送掉
+  -- 111 列）。擋在扣庫存之前，補填金額後即可重取。
+  -- 例外：【內部】xx 店 / RR- / OV- 容器單（member_type='store_internal'）的
+  -- 池子單價本來就可能是 0，不是漏填。
+  -- 20260819000000：刻意送的贈品也是例外，但必須被明確標記過 ——
+  -- 品項自己標（coi.is_gift，rpc_mark_order_item_gift）或整個開團商品是贈品
+  -- （campaign_items.is_gift，rpc_set_campaign_item_gift，促銷活動一次標全團生效）。
+  -- 兩層讀取時 OR，不做欄位同步（見本檔檔頭）。
+  SELECT EXISTS (
+    SELECT 1 FROM members mb
+     WHERE mb.id = v_order.member_id
+       AND mb.tenant_id = v_order.tenant_id
+       AND mb.member_type = 'store_internal'
+  ) INTO v_is_internal_pool;
+
+  IF NOT v_is_internal_pool THEN
+    SELECT array_agg(COALESCE(sk.variant_name, sk.product_name, sk.sku_code, coi.id::text)
+                     ORDER BY coi.id)
+      INTO v_zero_labels
+      FROM customer_order_items coi
+      LEFT JOIN skus sk ON sk.id = coi.sku_id
+      LEFT JOIN campaign_items gi ON gi.id = coi.campaign_item_id
+     WHERE coi.id = ANY(p_item_ids)
+       AND coi.order_id = p_order_id
+       AND coi.status IN ('pending','reserved','ready')
+       AND COALESCE(coi.unit_price, 0) = 0
+       AND NOT COALESCE(coi.is_gift, FALSE)
+       AND NOT COALESCE(gi.is_gift, FALSE);
+
+    IF v_zero_labels IS NOT NULL AND array_length(v_zero_labels, 1) > 0 THEN
+      RAISE EXCEPTION 'zero_price: 品項「%」的單價是 $0，看起來是開團時漏填金額。請先補上金額再取貨（取貨頁該品項旁可直接補填）；若這是刻意送的贈品，改按該品項旁的「🎁 這是贈品」標記後即可取貨',
+        array_to_string(v_zero_labels, '」、「');
+    END IF;
+  END IF;
+
+  SELECT location_id INTO v_pickup_loc
+    FROM stores
+   WHERE id = v_order.pickup_store_id;
+
+  IF v_pickup_loc IS NULL THEN
+    RAISE EXCEPTION '分店 % 未設定倉庫位置 (location_id)、無法寫 stock_movement', v_order.pickup_store_id;
+  END IF;
+
+  -- ==========================================================================
+  -- 20260904010010：扣庫存前先鎖住餘額列，鎖完重驗一次夠不夠
+  --   （本檔唯一新增的行為，完整推導見檔頭）
+  -- ==========================================================================
+
+  -- ① 預鎖：把這次會扣到的 (location_id, sku_id) 去重、**排序後**逐列鎖起來。
+  --    ⛔ ORDER BY location_id, sku_id 這個順序與 20260904010000（✎修改實收
+  --      往下扣）完全一致，兩支才不會各拿一半互相等（死鎖）。只改一邊等於沒改。
+  --    取貨永遠只扣 v_pickup_loc 一個倉，所以實際上是照 sku_id 排；location_id
+  --    仍然寫進 ORDER BY，是為了讓兩支的規則長得一模一樣、將來誰都不會看錯。
+  --    餘額列**不存在**時 FOR UPDATE 鎖不到任何東西 —— 那代表 on_hand 視同 0，
+  --    下面的重驗一定擋下來（豁免單除外），不會有漏網。
+  FOR v_lock IN
+    SELECT DISTINCT v_pickup_loc AS location_id, coi.sku_id
+      FROM customer_order_items coi
+     WHERE coi.id = ANY(p_item_ids)
+       AND coi.order_id = p_order_id
+       AND coi.sku_id IS NOT NULL
+     ORDER BY 1, 2
+  LOOP
+    PERFORM 1
+       FROM stock_balances
+      WHERE tenant_id   = v_order.tenant_id
+        AND location_id = v_lock.location_id
+        AND sku_id      = v_lock.sku_id
+      FOR UPDATE;
+  END LOOP;
+
+  -- ② 豁免：口徑**逐字對齊**取貨閘門的門市實體守衛（20260901020000:266-283）。
+  --    容器單（member_type='store_internal'：RR- / OV- / AB- /【內部】xx 店）與
+  --    offset 抵減單在閘門那邊就刻意不受 on_hand 管 —— 它們被排除在「已承諾」
+  --    母體之外，再要它們自己過守衛會被 on_hand 擋死。
+  --    ⚠ 這裡**不可以**比閘門嚴。嚴一格就會擋掉閘門明明放行的正常取貨，
+  --      現貨池單第一個卡死（#901 才剛修好「整店現貨池轉不出去」）。
+  --    v_is_internal_pool 是零元守衛（20260815000000）算好的同一個值，直接沿用，
+  --    不另外查一次 —— 兩處判準永遠一致。
+  v_stock_exempt := v_is_internal_pool
+                    OR COALESCE(v_order.order_kind, 'normal') = 'offset';
+
+  -- ③ 重驗：鎖已經到手，這時候讀到的 on_hand 才是別人動不了的。
+  --    量的算法比照上面的退貨守門：缺項＝整行取、LEAST clamp 到行量
+  --    （超量交給主迴圈報錯）；狀態限定 pending/reserved/ready，與主迴圈的
+  --    放行條件一致，已取走的行不會被重複算進來。
+  --    同一個 SKU 分散在多行時要**加總**再比 —— 逐行比會讓「各行都夠、加起來
+  --    不夠」漏過去。
+  IF NOT v_stock_exempt THEN
+    SELECT s.name INTO v_stock_store_name
+      FROM stores s
+     WHERE s.id = v_order.pickup_store_id
+       AND s.tenant_id = v_order.tenant_id;
+
+    FOR v_stock_short IN
+      SELECT req.sku_id,
+             req.take_qty,
+             COALESCE(sb.on_hand, 0) AS on_hand
+        FROM (
+          SELECT coi.sku_id,
+                 SUM(LEAST(COALESCE((p_item_qtys ->> coi.id::text)::numeric, coi.qty),
+                           coi.qty)) AS take_qty
+            FROM customer_order_items coi
+           WHERE coi.id = ANY(p_item_ids)
+             AND coi.order_id = p_order_id
+             AND coi.status IN ('pending','reserved','ready')
+           GROUP BY coi.sku_id
+        ) req
+        LEFT JOIN stock_balances sb
+               ON sb.tenant_id   = v_order.tenant_id
+              AND sb.location_id = v_pickup_loc
+              AND sb.sku_id      = req.sku_id
+       WHERE req.take_qty > COALESCE(sb.on_hand, 0)
+       ORDER BY req.sku_id
+    LOOP
+      SELECT COALESCE(s.variant_name, s.product_name, s.sku_code)
+        INTO v_sku_label FROM skus s WHERE s.id = v_stock_short.sku_id;
+      RAISE EXCEPTION 'stock_short: 這次要取「%」% 件，但「%」現在架上只剩 % 件，取了會變成負庫存。這批貨可能剛被別人取走、或是「✎ 修改實收」剛把數量改小了。請重新整理畫面確認；如果貨其實在架上只是帳沒入，請到「庫存總覽 → ＋新增庫存」把帳補上再取。',
+        COALESCE(v_sku_label, v_stock_short.sku_id::text),
+        trim_scale(v_stock_short.take_qty),
+        COALESCE(v_stock_store_name, '這家店'),
+        trim_scale(v_stock_short.on_hand);
+    END LOOP;
+  END IF;
+
+  -- 退貨守門：同 SKU「本次取貨量」不得超過「active 品項量 − 未取退貨量」。
+  -- 未取退貨（return_to_hq、notes header 不含 |取貨後退回）的貨已離店，
+  -- 不能再被結帳；取貨後退回不計入（那批貨的錢在取貨時已收）。
+  -- 前端 PickupDialog 有同款防線，但畫面 stale 時會失效，這裡是最後防線。
+  FOR v_ret_guard IN
+    SELECT r.sku_id, r.ret_qty,
+           COALESCE(act.active_qty, 0) AS active_qty,
+           COALESCE(req.take_qty, 0)   AS take_qty
+      FROM (
+        SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+          FROM transfers t
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+         WHERE t.customer_order_id = p_order_id
+           AND t.tenant_id     = v_order.tenant_id
+           AND t.transfer_type = 'return_to_hq'
+           AND t.status IN ('shipped','received')
+           AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+               NOT LIKE '%取貨後退回%'
+         GROUP BY ti.sku_id
+      ) r
+      LEFT JOIN (
+        SELECT coi.sku_id, SUM(coi.qty) AS active_qty
+          FROM customer_order_items coi
+         WHERE coi.order_id = p_order_id
+           AND coi.status IN ('pending','reserved','ready')
+         GROUP BY coi.sku_id
+      ) act ON act.sku_id = r.sku_id
+      LEFT JOIN (
+        -- 本次各 SKU 取貨量（缺項＝整行取；clamp 到行量，超量交給主迴圈報錯）
+        SELECT coi.sku_id,
+               SUM(LEAST(COALESCE((p_item_qtys ->> coi.id::text)::numeric, coi.qty), coi.qty)) AS take_qty
+          FROM customer_order_items coi
+         WHERE coi.id = ANY(p_item_ids)
+           AND coi.order_id = p_order_id
+         GROUP BY coi.sku_id
+      ) req ON req.sku_id = r.sku_id
+     WHERE COALESCE(req.take_qty, 0) > COALESCE(act.active_qty, 0) - r.ret_qty
+  LOOP
+    SELECT COALESCE(s.variant_name, s.product_name, s.sku_code)
+      INTO v_sku_label FROM skus s WHERE s.id = v_ret_guard.sku_id;
+    RAISE EXCEPTION '品項「%」已退貨 % 件，本次最多可取 % 件（畫面資料可能過舊，請重新整理後再取）',
+      COALESCE(v_sku_label, v_ret_guard.sku_id::text),
+      v_ret_guard.ret_qty,
+      GREATEST(v_ret_guard.active_qty - v_ret_guard.ret_qty, 0);
+  END LOOP;
+
+  -- 逐品項：判斷整行取 or 拆行部分取
+  FOR v_item IN
+    SELECT id, sku_id, qty, unit_price, status, source, campaign_item_id,
+           tenant_id, notes, discount_amount, discount_percent, created_by,
+           -- 20260819000000：拆行要把贈品標記帶到 picked_up 那一行，
+           -- 否則部分取貨之後收據 / 明細看不出那一件是送的
+           is_gift, gift_reason, gift_marked_by, gift_marked_at
+      FROM customer_order_items
+     WHERE id = ANY(p_item_ids)
+       AND order_id = p_order_id
+     ORDER BY id
+     FOR UPDATE
+  LOOP
+    IF v_item.status NOT IN ('pending','reserved','ready') THEN
+      RAISE EXCEPTION '品項 % 狀態 % 不可取貨', v_item.id, v_item.status;
+    END IF;
+
+    -- 逐品項到貨擋板（取代舊的整單 is_order_pickup_ready 擋板）：
+    -- 未到貨（該 SKU 分店實收 0）的品項個別擋，已到貨的品項放行先取
+    IF NOT public.is_order_item_pickup_ready(v_item.id) THEN
+      SELECT COALESCE(s.variant_name, s.product_name, s.sku_code)
+        INTO v_sku_label FROM skus s WHERE s.id = v_item.sku_id;
+      RAISE EXCEPTION '品項「%」分店尚未實收到貨，無法取貨（請取消勾選該品項，其餘已到貨品項可先取）',
+        COALESCE(v_sku_label, v_item.sku_id::text);
+    END IF;
+
+    -- 本次取多少：p_item_qtys 指定則用之，否則整行取
+    v_take := COALESCE((p_item_qtys ->> v_item.id::text)::numeric, v_item.qty);
+    IF v_take IS NULL OR v_take <= 0 THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 不合法（須 > 0）', v_item.id, v_take;
+    END IF;
+    IF v_take > v_item.qty THEN
+      RAISE EXCEPTION '品項 % 取貨數量 % 超過待取數量 %', v_item.id, v_take, v_item.qty;
+    END IF;
+
+    IF v_take = v_item.qty THEN
+      -- ── 整行取：沿用舊邏輯，直接標 picked_up ──
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_item.id,
+        format('顧客取貨 order=%s item=%s', p_order_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      UPDATE customer_order_items
+         SET status = 'picked_up',
+             pickup_movement_id = v_movement_id,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_item.id;
+    ELSE
+      -- ── 部分取：拆行。新建 picked_up 行，原行扣量留待下次 ──
+      -- line-level 折扣金額按取貨比例分攤，確保兩行小計加總 = 原行
+      v_picked_disc := round(COALESCE(v_item.discount_amount, 0) * v_take / v_item.qty);
+
+      -- 1) 先建 picked_up 行（暫不填 movement，先拿 id）
+      INSERT INTO customer_order_items (
+        tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+        status, source, reserved_movement_id, pickup_movement_id, notes,
+        discount_amount, discount_percent, created_by, updated_by, created_at, updated_at,
+        is_gift, gift_reason, gift_marked_by, gift_marked_at
+      ) VALUES (
+        v_item.tenant_id, p_order_id, v_item.campaign_item_id, v_item.sku_id, v_take, v_item.unit_price,
+        'picked_up', v_item.source, NULL, NULL, v_item.notes,
+        v_picked_disc, v_item.discount_percent, v_item.created_by, p_operator, v_now, v_now,
+        v_item.is_gift, v_item.gift_reason, v_item.gift_marked_by, v_item.gift_marked_at
+      ) RETURNING id INTO v_new_item_id;
+
+      -- 2) sale movement 指向新行
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+      ) VALUES (
+        v_order.tenant_id, v_pickup_loc, v_item.sku_id, -v_take, 'sale',
+        'customer_order', p_order_id, v_new_item_id,
+        format('顧客部分取貨 order=%s item=%s (split from %s)', p_order_id, v_new_item_id, v_item.id), p_operator
+      ) RETURNING id INTO v_movement_id;
+
+      -- 3) 回填新行 movement
+      UPDATE customer_order_items
+         SET pickup_movement_id = v_movement_id
+       WHERE id = v_new_item_id;
+
+      -- 4) 原行扣量、保持 active 狀態，剩餘留待下次取
+      UPDATE customer_order_items
+         SET qty = qty - v_take,
+             discount_amount = COALESCE(discount_amount, 0) - v_picked_disc,
+             updated_by = p_operator,
+             updated_at = v_now
+       WHERE id = v_item.id;
+
+      v_picked_item_id := v_new_item_id;
+    END IF;
+
+    -- event 記錄「被取走」那一行的 id（拆行時是新行）→ 收據查到正確的 qty
+    v_event_item_ids := v_event_item_ids || v_picked_item_id;
+    v_picked_count := v_picked_count + 1;
+  END LOOP;
+
+  IF v_picked_count = 0 THEN
+    RAISE EXCEPTION 'no items picked (check p_item_ids belongs to order %)', p_order_id;
+  END IF;
+
+  -- 重算 order status（剩餘 active 行 → partially_completed；全取完 → completed）。
+  -- 2026-08-01：剩餘 active 量要扣掉「未取退貨」覆蓋 — 已退回總倉的量不會再被
+  -- 取走，若某 SKU 的 active 量全被退貨蓋掉，該 SKU 的殘行不算「待取」。
+  -- 否則部分退貨後取走剩餘可取量（訂5退2取3）會讓訂單永遠卡在 partially_completed。
+  SELECT COUNT(*) INTO v_active_remaining
+    FROM customer_order_items coi
+    JOIN (
+      SELECT act.sku_id
+        FROM (
+          SELECT sku_id, SUM(qty) AS active_qty
+            FROM customer_order_items
+           WHERE order_id = p_order_id
+             AND status IN ('pending','reserved','ready')
+           GROUP BY sku_id
+        ) act
+        LEFT JOIN (
+          SELECT ti.sku_id, SUM(ti.qty_shipped) AS ret_qty
+            FROM transfers t
+            JOIN transfer_items ti ON ti.transfer_id = t.id
+           WHERE t.customer_order_id = p_order_id
+             AND t.tenant_id     = v_order.tenant_id
+             AND t.transfer_type = 'return_to_hq'
+             AND t.status IN ('shipped','received')
+             AND COALESCE(substring(t.notes FROM '^\[order return([^\]:]*)'), '')
+                 NOT LIKE '%取貨後退回%'
+           GROUP BY ti.sku_id
+        ) r ON r.sku_id = act.sku_id
+       WHERE act.active_qty - COALESCE(r.ret_qty, 0) > 0
+    ) open_sku ON open_sku.sku_id = coi.sku_id
+   WHERE coi.order_id = p_order_id
+     AND coi.status IN ('pending','reserved','ready');
+
+  IF v_active_remaining = 0 THEN
+    v_new_status := 'completed';
+    v_event_type := 'picked_up';
+  ELSE
+    v_new_status := 'partially_completed';
+    v_event_type := 'partial_pickup';
+  END IF;
+
+  UPDATE customer_orders
+     SET status       = v_new_status,
+         completed_at = CASE WHEN v_new_status = 'completed' THEN v_now ELSE NULL END,
+         updated_by   = p_operator,
+         updated_at   = v_now
+   WHERE id = p_order_id;
+
+  INSERT INTO order_pickup_events (
+    tenant_id, order_id, pickup_store_id, event_type, item_ids, notes, created_by
+  ) VALUES (
+    v_order.tenant_id, p_order_id, v_order.pickup_store_id, v_event_type,
+    to_jsonb(v_event_item_ids), p_notes, p_operator
+  ) RETURNING id INTO v_event_id;
+
+  RETURN jsonb_build_object(
+    'event_id',        v_event_id,
+    'event_type',      v_event_type,
+    'picked_count',    v_picked_count,
+    'active_remaining', v_active_remaining,
+    'new_status',      v_new_status
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) IS
+  '取貨記帳。p_item_qtys={"<item_id>":<取貨數量>} 可指定部分取貨（拆行）。'
+  '到貨擋板為品項層級（is_order_item_pickup_ready）：未到貨品項個別擋、已到貨可先取。'
+  '退貨守門：同 SKU 取貨量不得超過 active 量 − 未取退貨量（取貨後退回不計）。'
+  'active_remaining 排除量已被未取退貨覆蓋的 SKU（退光的殘行不擋 completed）。'
+  '店家守衛：分店角色（store_manager/store_staff，app_metadata.stores 非空且不含總倉）'
+  '只能替自己店（pickup_store_id 店名 ∈ stores）的訂單取貨，否則 raise wrong_store。'
+  '零元守衛（20260815000000）：本次要取的品項單價為 $0 一律 raise zero_price'
+  '（漏填金額 → 取貨等於白送）；member_type=store_internal 的容器單不受限。'
+  '20260819000000：已標記的贈品（customer_order_items.is_gift 或 campaign_items.is_gift）'
+  '不受零元守衛限制；拆行時贈品標記會複製到 picked_up 那一行。'
+  '20260904010010：扣庫存前先按 (location_id, sku_id) 排序鎖住 stock_balances，'
+  '鎖到手才重驗 on_hand 夠不夠本次取貨量，不夠 raise stock_short。'
+  '豁免口徑對齊 is_order_item_pickup_ready 的門市實體守衛（容器單與 offset 單不受限）。'
+  '鎖序與 rpc_adjust_received_transfer（20260904010000）、'
+  'rpc_create_walkin_sale（20260904010020）一致，三支不會互鎖。'
+  '⚠ 三支性格不同：本檔與改實收「不夠就失敗」，現場銷售「不夠就補到夠、照樣結帳」。';
+
+GRANT EXECUTE ON FUNCTION public.rpc_record_pickup(bigint, bigint[], uuid, text, jsonb) TO authenticated;

--- a/supabase/migrations/20260904010020_walkin_locks_stock_before_topup.sql
+++ b/supabase/migrations/20260904010020_walkin_locks_stock_before_topup.sql
@@ -1,0 +1,554 @@
+-- ============================================================================
+-- 20260904010020：現場銷售補庫存之前先鎖住餘額列，鎖完重讀一次 on_hand
+--
+-- ⛔⛔ 先讀這一段再改任何一行：本檔的鎖跟 20260904010010（取貨）**性格相反**。
+--     取貨那支：鎖完發現不夠 → **大聲失敗**，不准取。
+--     本檔這支：鎖完發現不夠 → **多補一點**，照樣結帳成功。
+--     ⛔ 不准把取貨那支的 RAISE 抄過來。抄過來就等於把老闆 2026-09-01 親自定的
+--       「現場銷售永不因缺貨被擋」推翻掉 —— 那條規矩底下有一整段推導，見下方【二】。
+--
+-- ----------------------------------------------------------------------------
+-- 【一】為什麼要有這一支（它是同一個 P0 的第三個入口）
+-- ----------------------------------------------------------------------------
+-- 20260904010000 讓「✎ 修改實收」往下改會真的扣店家庫存，20260904010010 把
+-- 取貨那側鎖起來。審查第二輪（2026-09-04）指出扣庫存其實有**三個**入口，
+-- 第三個是現場銷售 rpc_create_walkin_sale（20260901010010 起的 walkin 家族）。
+--
+-- 它原本只拿 advisory lock `walkinsale:租戶:店:商品`，接著**無鎖**讀 on_hand 與
+-- 可賣量、用舊值算「要補幾件」。advisory lock 只擋得住「另一台收銀機」——
+-- 改實收與取貨拿的是 `transfer:*` / 什麼都不拿，跟它是不同把鎖，不會互相等：
+--
+--     店裡 on_hand = 10
+--     [現場銷售] 讀 on_hand = 10、可賣量 10，客人買 5 → 算出「不用補」  ┐
+--     [取  貨 ] 鎖住餘額列、驗過 10 ≥ 10，寫 sale −10 → on_hand = 0     │
+--     [現場銷售] 寫 sale −5 → trigger 這時才排到鎖 → 0 + (−5) = **−5** ⛔┘
+--
+-- 這正是老闆 2026-09-04「⛔ 不准扣成負的」要擋的東西，而且 20260901040000
+-- 檔頭第 15-16 行自己就寫著「走 +N/−N 而不是負庫存，是因為 on_hand 被全站
+-- 好幾道閘門讀著，讓它變負數會誤擋別人的取貨」—— 它的設計目標本來就是
+-- 「絕不讓 on_hand 變負」，只是少了鎖，目標達不到。本檔補的就是那把鎖。
+--
+-- ----------------------------------------------------------------------------
+-- 【二】⛔ 老闆的鐵律逐字保留：現場銷售永不因缺貨被擋
+-- ----------------------------------------------------------------------------
+-- Alex 2026-09-01（20260901040000 檔頭第 5-6 行逐字抄回來）：
+--   「其實根本不用介面上選補貨，背後幫它自動補就好，反正就是 +n -n，
+--     只要在銷售頁上顯示貨不足但是它也可以結單。」
+--
+-- 為什麼「不擋」是對的（同檔第 8-13 行，逐字保留）：
+--   客人就站在櫃台前、東西在店員手上，貨**一定會**離開這家店。系統擋下來不會
+--   讓貨留下，只會讓帳跟現實脫節 —— 店員繞過系統手收現金，那筆交易就完全消失
+--   （沒有銷售、沒有扣庫存、沒有日結）。把它記成「+N 入帳 → −N 賣掉」才是那
+--   一刻真正發生的事。
+--
+-- ⇒ 本檔**只加鎖、不加守衛**。加完之後這支函式能失敗的理由，跟加之前
+--   一模一樣（分店帳號賣別店的貨、單價 ≤ 0、空購物車、賣給【內部】店容器帳號、
+--   不可新增訂單的會員）—— **數量仍然不是其中之一**。
+--
+-- ----------------------------------------------------------------------------
+-- 【三】鎖了為什麼就不會變負（不必再加任何檢查）
+-- ----------------------------------------------------------------------------
+-- 可賣量 _sku_walkin_qty（20260901020000:68）＝
+--     GREATEST(on_hand − promised − (pool_claimed − pool_arrived), 0)
+-- pool_arrived 是 pool_claimed 的子集：兩者在 _sku_commitment（20260816000000）
+-- 是同一個 base、同樣 `mtype='store_internal' AND kind<>'offset'`，只差狀態條件 ——
+-- pool_claimed 是 `NOT IN (cancelled, expired, transferred_out, completed)`（:123-126），
+-- pool_arrived 是 `IN (ready, partially_completed)`（:127-130），後者被前者完全包住，
+-- 且 base 已經濾掉 qty ≤ 0（:105）⇒ 括號內恆 ≥ 0 ⇒ **可賣量 ≤ on_hand**。
+--
+-- 這支對庫存的淨影響：
+--     補進來 v_add = GREATEST(需求 − 可賣量, 0)，賣掉 −需求
+--     ⇒ 淨變動 = v_add − 需求 = −LEAST(可賣量, 需求) ≥ −on_hand
+-- ⇒ 只要 on_hand 與可賣量是**當下鎖住、沒有人能動**的值，賣完不可能低於 0。
+--   會變負，唯一的原因就是那兩個數字是舊的。所以本檔要做的只有一件事：
+--   **鎖了再讀**。讀到新鮮的數字，補的量自然就夠。
+--
+-- 反過來說，讀到偏低的舊值（例如剛好有人正在補貨）只會讓它「多補一點」——
+-- 補進來的當場全部賣掉，淨變動仍是 −LEAST(可賣量, 需求)，不會多也不會少。
+-- 這個方向本來就安全，不需要處理。
+--
+-- ----------------------------------------------------------------------------
+-- 【四】鎖序：⛔ 三支必須一致，只改一支等於沒改
+-- ----------------------------------------------------------------------------
+-- 20260904010000（改實收）、20260904010010（取貨）、本檔（現場銷售）會鎖到
+-- 同一批 (location_id, sku_id)。三支一律：
+--     ORDER BY location_id, sku_id 去重後逐列 FOR UPDATE，放在進主迴圈之前
+-- 各用各的順序，兩人各拿一半就互相等到天亮（死鎖）。
+-- 現場銷售永遠只碰 v_store.location_id 一個倉，所以實際上是照 sku_id 排；
+-- location_id 仍然寫進 ORDER BY，讓三支的規則長得一模一樣。
+--
+-- 與既有 advisory lock 的先後：本檔的餘額列鎖放在
+--   `walkin_sale_seq:店`（取單號，基底 20260901040000:171）之後、
+--   `walkinsale:租戶:店:商品`（基底 :196，在主迴圈裡）之前。
+-- 全庫只有現場銷售家族會拿這兩把 advisory lock —— 查過：
+--     git grep -n "walkinsale:\|walkin_sale_seq:" HEAD -- supabase/migrations
+--   8 個命中全部落在 20260901010010 / 20260901020000 / 20260901030000 /
+--   20260901040000，也就是同一支函式的四個版本，沒有第二支函式在拿。
+-- ⇒ 拿 advisory lock 的順序全站一致，三支拿餘額列鎖的順序又一致 ⇒ 湊不出互等的環。
+--
+-- ----------------------------------------------------------------------------
+-- 【五】餘額列不存在時鎖不到東西 —— 這件事查過了，安全
+-- ----------------------------------------------------------------------------
+-- 該 (倉, 商品) 從沒進過貨時 stock_balances 沒有那一列，FOR UPDATE 鎖不到。
+-- 此時讀到的 on_hand 是 0（原本就 COALESCE 成 0）⇒ 可賣量 0 ⇒ 補的量 = 全部需求
+-- ⇒ 淨變動 0 ⇒ 不可能變負。就算此刻剛好有人正在建那一列（收貨、改實收往上補），
+-- 對方加多少就是多少，我們 +N/−N 淨變動 0，加起來仍然是對的。
+--
+-- ⚠ 審查建議「先 INSERT ... ON CONFLICT DO NOTHING 把列生出來再鎖」——
+--   **刻意不做**：那會在庫存總覽長出一堆 on_hand = 0 的空列（現在只有真的
+--   進過貨才有列），是看得見的行為改變；而上面已經證明不做也不會變負。
+--   ⇒ 用不到的代價不要付。
+--
+-- ----------------------------------------------------------------------------
+-- 【六】代價（老闆要知道的那一面）
+-- ----------------------------------------------------------------------------
+-- 做了：同一家店同一個商品，若總倉正在改實收／別的客人正在取貨，收銀機會多等
+--       那筆交易做完（通常是零點幾秒）才結帳成功。**不會失敗，只會慢一下。**
+-- 不做：就是上面那張圖 —— 現場銷售把 on_hand 扣成負數。負庫存會讓取貨閘門的
+--       實體守衛把**別的客人**的貨擋下來（明明架上有貨卻取不了），而且現場銷售
+--       這支本來的設計就是要避免這件事。
+--
+-- ----------------------------------------------------------------------------
+-- 【七】基底
+-- ----------------------------------------------------------------------------
+-- 20260901040000_walkin_auto_topup_never_blocks.sql:43（rpc_create_walkin_sale
+-- 第 4 版）。用定義鏈查法確認它是最後一支：
+--     git grep -nE "CREATE (OR REPLACE )?FUNCTION (public\.)?rpc_create_walkin_sale" \
+--       HEAD -- supabase/migrations | sort
+--   → 20260901010010:53 / 20260901020000:106 / 20260901030000:30 / 20260901040000:43
+--   最後一行就是基底。（20260901010030 是 rpc_walkin_stock_topups 那支稽核報表，
+--    20260901010020 是 rpc_pos_search_products，都沒有重定義本函式。）
+--
+-- 基底函式本體 347 行**逐字保留**，只在兩處插入：
+--   ① DECLARE 加 1 個變數（v_lock）
+--   ② 第 3 段主迴圈**之前**插入預鎖段
+-- 既有的參數驗證、店家守衛、會員守衛、單號規則、補帳算式、from_pool 夾擠、
+-- 開單、sale movement、扣現貨池、取貨事件、回傳欄位 —— 一行都沒有改。
+-- ⛔ 特別是 `v_add := GREATEST(v_s.need - v_cap, 0)` 這一行原封不動：
+--   本檔改的是「v_cap 讀的時候有沒有鎖」，不是「怎麼算補多少」。
+--
+-- ----------------------------------------------------------------------------
+-- 【八】上線順序（⛔ 不可顛倒）
+-- ----------------------------------------------------------------------------
+--   1️⃣ 20260904010000（改實收會動庫存）
+--   2️⃣ 20260904010010（取貨先鎖再扣）
+--   3️⃣ 本檔（現場銷售先鎖再補）
+--   4️⃣ 跑 D:\1人公司\公司\01_進行中\實收連動_修復不一致列_2026-09-04.sql
+--      第 ① 段預覽 → 第 ② 段修復 → 第 ③ 段驗證
+--   ⚠️ 第 4 步**不是選配**：純紀錄期間留下的「帳面實收 ≠ 實際入庫」歷史列，
+--     在畫面上重存同一個數字不會有反應（20260904010000 開頭就 CONTINUE 掉了），
+--     只有那支腳本修得掉。完整說明在那支腳本的檔頭。
+--
+-- ----------------------------------------------------------------------------
+-- 【九】Rollback
+-- ----------------------------------------------------------------------------
+-- CREATE OR REPLACE 回 20260901040000:43-389 那一版即可（沒有動 schema、
+-- 沒有新增欄位、沒有改 CHECK；純函式覆寫）。
+-- ⚠ 但 20260904010000 / 20260904010010 / 本檔**三支是一組**：回滾任一支，
+--   負庫存的洞就從三邊變兩邊 —— 要回就三支一起回。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_create_walkin_sale(
+  p_store_id        BIGINT,
+  p_lines           JSONB,
+  p_operator        UUID,
+  p_member_id       BIGINT  DEFAULT NULL,
+  p_customer_name   TEXT    DEFAULT NULL,
+  p_payment_method  TEXT    DEFAULT 'cash',
+  p_discount_amount NUMERIC DEFAULT 0,
+  p_notes           TEXT    DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_jwt_role   TEXT  := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_my_stores  JSONB := COALESCE(auth.jwt() -> 'app_metadata' -> 'stores', '[]'::jsonb);
+  v_store      stores%ROWTYPE;
+  v_now        TIMESTAMPTZ := NOW();
+  v_member     members%ROWTYPE;
+  v_member_id  BIGINT;
+  v_name       TEXT;
+  v_l          RECORD;
+  v_s          RECORD;
+  v_plain      NUMERIC;
+  v_add        NUMERIC;
+  v_cap        NUMERIC;
+  v_from_pool  NUMERIC;
+  v_pool_plan  JSONB := '{}'::jsonb;
+  v_pool_total NUMERIC := 0;
+  v_added      JSONB := '[]'::jsonb;
+  v_add_total  NUMERIC := 0;
+  v_c          RECORD;
+  v_on_hand    NUMERIC;
+  v_campaign   BIGINT;
+  v_channel    BIGINT;
+  v_ci         BIGINT;
+  v_order_id   BIGINT;
+  v_order_no   TEXT;
+  v_seq        INT;
+  v_item_id    BIGINT;
+  v_move_id    BIGINT;
+  v_item_ids   BIGINT[] := ARRAY[]::BIGINT[];
+  v_items_out  JSONB := '[]'::jsonb;
+  v_total      NUMERIC := 0;
+  v_discount   NUMERIC := GREATEST(COALESCE(p_discount_amount, 0), 0);
+  -- 實體庫存鎖（20260904010020）：鎖序與 20260904010000 / 20260904010010 一致
+  v_lock       RECORD;
+BEGIN
+  -- ==========================================================================
+  -- 1. 參數與權限
+  -- ==========================================================================
+  IF p_operator IS NULL THEN
+    RAISE EXCEPTION '缺少操作人';
+  END IF;
+  IF p_lines IS NULL OR jsonb_typeof(p_lines) <> 'array' OR jsonb_array_length(p_lines) = 0 THEN
+    RAISE EXCEPTION '沒有任何品項，無法結帳';
+  END IF;
+
+  SELECT * INTO v_store FROM stores WHERE id = p_store_id;
+  IF NOT FOUND OR v_store.location_id IS NULL THEN
+    RAISE EXCEPTION '分店 % 不存在或未綁定倉別', p_store_id;
+  END IF;
+
+  -- 店家守衛：逐字對齊 rpc_record_pickup（20260813000000）/ rpc_create_spot_sale。
+  -- ⚠ 一律用 app_metadata.stores（**店名陣列**），不可以用 store_id ——
+  --    線上 33 個分店帳號沒有任何一個有 store_id（20260808000020）。
+  IF v_jwt_role IN ('store_manager', 'store_staff')
+     AND jsonb_typeof(v_my_stores) = 'array'
+     AND jsonb_array_length(v_my_stores) > 0
+     AND NOT (v_my_stores ? '總倉')
+     AND NOT (v_my_stores ? v_store.name) THEN
+    RAISE EXCEPTION 'wrong_store: 這是「%」的庫存，分店帳號只能賣自己店的貨', v_store.name;
+  END IF;
+
+  -- 逐列驗證（值不合法要在動任何一筆庫存之前就擋掉）
+  FOR v_l IN
+    SELECT (e ->> 'sku_id')::BIGINT                        AS sku_id,
+           (e ->> 'qty')::NUMERIC                          AS qty,
+           (e ->> 'unit_price')::NUMERIC                   AS unit_price,
+           COALESCE((e ->> 'add_stock_qty')::NUMERIC, 0)   AS add_qty,
+           ord
+      FROM jsonb_array_elements(p_lines) WITH ORDINALITY AS t(e, ord)
+     ORDER BY ord
+  LOOP
+    IF v_l.sku_id IS NULL OR NOT EXISTS (SELECT 1 FROM skus WHERE id = v_l.sku_id) THEN
+      RAISE EXCEPTION '第 % 列：品項 % 不存在', v_l.ord, COALESCE(v_l.sku_id::TEXT, 'NULL');
+    END IF;
+    IF v_l.qty IS NULL OR v_l.qty <= 0 OR v_l.qty <> FLOOR(v_l.qty) THEN
+      RAISE EXCEPTION '第 % 列：數量必須是正整數', v_l.ord;
+    END IF;
+    -- 零元守衛的同一個理由（20260815000000）：$0 = 把貨白送出去。
+    -- 現場銷售當場收錢，沒有「事後補填金額」的機會，所以擋在這裡。
+    IF v_l.unit_price IS NULL OR v_l.unit_price <= 0 THEN
+      RAISE EXCEPTION '第 % 列：單價必須大於 0', v_l.ord;
+    END IF;
+    IF v_l.add_qty < 0 OR v_l.add_qty <> FLOOR(v_l.add_qty) THEN
+      RAISE EXCEPTION '第 % 列：補庫存數量必須是非負整數', v_l.ord;
+    END IF;
+  END LOOP;
+
+  -- 收件人：有帶會員就用會員，沒有就用該店的「現場客」共用假會員
+  IF p_member_id IS NOT NULL THEN
+    SELECT * INTO v_member FROM members WHERE id = p_member_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION '會員 % 不存在', p_member_id;
+    END IF;
+    IF COALESCE(v_member.member_type, '') = 'store_internal' THEN
+      RAISE EXCEPTION '不能把貨賣給【內部】店帳號 —— 那是現貨池容器，不是客人';
+    END IF;
+    IF COALESCE(v_member.no_new_order, FALSE) THEN
+      RAISE EXCEPTION '會員「%」已被標記為不可新增訂單', COALESCE(v_member.name, p_member_id::TEXT);
+    END IF;
+    v_member_id := v_member.id;
+    v_name      := COALESCE(NULLIF(TRIM(p_customer_name), ''), v_member.name);
+  ELSE
+    v_member_id := public._walkin_member(v_store.tenant_id, p_store_id);
+    v_name      := COALESCE(NULLIF(TRIM(p_customer_name), ''), '現場客');
+  END IF;
+
+  -- ==========================================================================
+  -- 2. 先取單號
+  --
+  -- 刻意排在開單之前：缺貨補帳寫的 manual_adjust 要在 reason 裡帶單號，
+  -- 事後才對得回「哪一筆現場銷售補的」（稽核報表 rpc_walkin_stock_topups
+  -- 就是靠這個字串）。晚一步生號的話那些 movement 只剩時間可以猜。
+  --
+  -- MAX-based，不用 COUNT(*)+1 —— 單被硬刪後 COUNT 會倒退、重發已用過的號碼
+  -- 撞 unique（20260813000010 湖口 RR-435 事故）。
+  -- ==========================================================================
+  PERFORM pg_advisory_xact_lock(hashtext('walkin_sale_seq:' || p_store_id::TEXT));
+  SELECT COALESCE(MAX(substring(order_no FROM '^WS-' || p_store_id::TEXT || '-([0-9]+)$')::INT), 0) + 1
+    INTO v_seq
+    FROM customer_orders
+   WHERE tenant_id = v_store.tenant_id
+     AND order_no ~ ('^WS-' || p_store_id::TEXT || '-[0-9]+$');
+  -- lpad 超寬會截斷（lpad('10001',4)='1000'），寬度要跟著位數長
+  v_order_no := 'WS-' || p_store_id::TEXT || '-' ||
+                LPAD(v_seq::TEXT, GREATEST(length(v_seq::TEXT), 4), '0');
+
+  -- ==========================================================================
+  -- 3. 逐 SKU：鎖 → 補庫存（選配）→ 可賣量閘門 → 記下要從池子扣多少
+  --
+  -- 依 sku_id 排序取鎖，兩個櫃台同時結帳到同一組商品時不會互相死鎖。
+  -- 這一整段**必須在寫任何 sale movement 之前跑完**：sale 會把 on_hand 打下去，
+  -- 之後再算 _sku_free_qty 就不是「這批貨賣掉前的自由量」了，from_pool 會算錯。
+  -- ==========================================================================
+  -- ==========================================================================
+  -- 20260904010020：**鎖了再讀** —— 先把這次會碰到的餘額列鎖起來
+  --   （本檔唯一新增的行為，完整推導見檔頭）
+  --
+  -- ⛔ 這裡只鎖、**不擋**。鎖的用途是讓下面那兩個數字（on_hand 與 v_cap 可賣量）
+  --   在讀的當下沒有人能動 —— 讀到新鮮的值，「缺多少補多少」自然就補得夠。
+  --   ⛔ 不准在這裡（或這個迴圈裡）加任何數量相關的 RAISE：
+  --     **現場銷售永不因缺貨被擋**（Alex 2026-09-01；檔頭【二】逐字保留）。
+  --     20260904010010（取貨）鎖完不夠是大聲失敗 —— 那是**相反的性格**，
+  --     它守的是「客人拿走不存在的貨」，這裡守的是「帳跟現實脫節」。
+  --     ⛔ 不要抄錯邊。
+  --
+  -- ⛔ ORDER BY location_id, sku_id 這個順序與 20260904010000（✎ 修改實收）、
+  --   20260904010010（取貨）完全一致 —— 三支會鎖到同一批餘額列，各用各的順序
+  --   就會各拿一半、互相等到天亮（死鎖）。只改一支等於沒改。
+  --   現場銷售永遠只碰 v_store.location_id 一個倉，所以實際上是照 sku_id 排；
+  --   location_id 照樣寫進 ORDER BY，讓三支的規則長得一模一樣。
+  --
+  -- 位置：放在主迴圈**之前**，這次要碰的列一次鎖齊（同另外兩支）。
+  -- 迴圈裡那把 advisory lock（walkinsale:*）保留 —— 它擋的是另一台收銀機，
+  -- 跟餘額列鎖擋的東西不同，兩個都要。
+  --
+  -- 餘額列不存在時 FOR UPDATE 鎖不到任何東西 —— 那代表 on_hand 視同 0、
+  -- 可賣量 0，於是整筆需求都會被補進來、當場賣掉，淨變動 0，不可能變負
+  -- （檔頭【五】有完整推導；那裡也寫了為什麼不先 INSERT 一列空的）。
+  -- ==========================================================================
+  FOR v_lock IN
+    SELECT DISTINCT v_store.location_id            AS location_id,
+                    (e ->> 'sku_id')::BIGINT       AS sku_id
+      FROM jsonb_array_elements(p_lines) AS t(e)
+     ORDER BY 1, 2
+  LOOP
+    PERFORM 1
+       FROM stock_balances
+      WHERE tenant_id   = v_store.tenant_id
+        AND location_id = v_lock.location_id
+        AND sku_id      = v_lock.sku_id
+      FOR UPDATE;
+  END LOOP;
+
+  FOR v_s IN
+    SELECT (e ->> 'sku_id')::BIGINT                      AS sku_id,
+           SUM((e ->> 'qty')::NUMERIC)                   AS need,
+           SUM(COALESCE((e ->> 'add_stock_qty')::NUMERIC, 0)) AS add_qty
+      FROM jsonb_array_elements(p_lines) AS t(e)
+     GROUP BY 1
+     ORDER BY 1
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtext(format('walkinsale:%s:%s:%s',
+      v_store.tenant_id, p_store_id, v_s.sku_id)));
+
+    -- ---- 先算「不補的話能賣幾件」 ----
+    -- 承諾分項與在庫一次取齊：補帳上限、from_pool、錯誤訊息都要用。
+    SELECT * INTO v_c FROM public._sku_commitment(p_store_id, ARRAY[v_s.sku_id]);
+    SELECT COALESCE(sb.on_hand, 0) INTO v_on_hand
+      FROM stock_balances sb
+     WHERE sb.tenant_id   = v_store.tenant_id
+       AND sb.location_id = v_store.location_id
+       AND sb.sku_id      = v_s.sku_id;
+    -- 沒有 balance 列時 SELECT INTO 給的是 NULL，不是 0
+    v_on_hand := COALESCE(v_on_hand, 0);
+
+    -- ★ 可賣量：**不扣 waiting**（見 20260901020000 檔頭）。canonical 算法在
+    --   _sku_walkin_qty，這裡一定要呼叫它、不要就地抄公式 —— 列表
+    --   （rpc_pos_search_products）跟這道閘門各算各的，就是「列表寫可用 3、
+    --   視窗說 0」那個坑。
+    v_cap := public._sku_walkin_qty(p_store_id, v_s.sku_id);
+
+    -- ---- 缺貨自動補帳：缺多少補多少，補進來的當場全部賣掉 ----
+    --
+    -- Alex 2026-09-01：「其實根本不用介面上選補貨，背後幫它自動補就好，
+    --   反正就是 +n -n，只要在銷售頁上顯示貨不足但是它也可以結單。」
+    --
+    -- 為什麼「不擋」是對的：客人就站在櫃台前、東西在店員手上，貨**一定會**離開
+    --   這家店。系統擋下來不會讓貨留下，只會讓帳跟現實脫節。把它記成
+    --   「+N 入帳 → −N 賣掉」才是那一刻真正發生的事。
+    --   （同 CLAUDE.md 空中轉出庫 p_allow_negative 的理由：「貨實際上離開轉出店了，
+    --     記下這筆出庫比拒絕記錄準確」。這裡走 +N/−N 而不是負庫存，是因為
+    --     on_hand 被全站好幾道閘門讀著，讓它變負數會誤擋別人的取貨。）
+    --
+    -- 代價是帳面差異被抹平（on_hand 淨變化 0），所以**紀錄就是唯一的訊號**：
+    --   每一筆都寫 manual_adjust ＋ reason 帶單號，`/pos/topups` 是那份稽核清單，
+    --   同一家店常態性補帳會在那裡跳出來提醒去盤點。刪那支報表＝這個口就沒人看著了。
+    --
+    -- p_lines[].add_stock_qty 已經沒有作用（保留只為了不讓舊版前端送過來時報錯）：
+    --   補多少完全由「缺多少」決定，店員填不了、也不用填。
+    --
+    -- ⚠ 沒有角色守衛是刻意的：一旦自動化，擋 store_staff 就等於「店員結不了帳」，
+    --   而結不了帳的後果是貨照樣出去、系統上沒有這筆。操作人記在 movement 上。
+    v_add := GREATEST(v_s.need - v_cap, 0);
+
+    IF v_add > 0 THEN
+      INSERT INTO stock_movements (
+        tenant_id, location_id, sku_id, quantity, movement_type,
+        unit_cost, reason, operator_id
+      ) VALUES (
+        v_store.tenant_id, v_store.location_id, v_s.sku_id, v_add, 'manual_adjust',
+        -- 成本一定要帶：沒帶的話該倉 avg_cost 若是 0，後面那筆 sale 的 COGS
+        -- 就是 0、毛利虛高（同 _air_ship_order_items 的 p_fallback_unit_cost）
+        public._current_cost_price(v_store.tenant_id, v_s.sku_id),
+        '現場銷售即時入帳 ' || v_order_no || '（結帳時架上有貨、帳上沒有，系統自動補）',
+        p_operator
+      ) RETURNING id INTO v_move_id;
+
+      v_add_total := v_add_total + v_add;
+      v_added := v_added || jsonb_build_object(
+        'sku_id', v_s.sku_id, 'qty', v_add, 'movement_id', v_move_id);
+
+      -- 補進來的量 1:1 加到在庫與可賣量（promised / 池子都沒動）
+      v_on_hand := v_on_hand + v_add;
+      v_cap     := v_cap + v_add;
+    END IF;
+
+    -- 完全不動池子就能賣的量（要從池子吃掉多少，拿這個當基準）
+    v_plain := GREATEST(v_on_hand - COALESCE(v_c.promised, 0)
+                        - COALESCE(v_c.pool_claimed, 0), 0);
+
+    -- 超出「不動池子的量」的部分＝從【內部】店已到貨池子賣掉的，開完單要扣池子。
+    -- 夾在 pool_arrived 以內：叫 _consume_internal_pool 吃超過池子有的量，
+    -- 單頭 notes 會寫出一個根本沒發生的數字。
+    v_from_pool := LEAST(GREATEST(v_s.need - v_plain, 0), COALESCE(v_c.pool_arrived, 0));
+    IF v_from_pool > 0 THEN
+      v_pool_plan  := v_pool_plan || jsonb_build_object(v_s.sku_id::TEXT, v_from_pool);
+      v_pool_total := v_pool_total + v_from_pool;
+    END IF;
+  END LOOP;
+
+  -- ==========================================================================
+  -- 4. 開單（sentinel trio → 單頭 → 品項 + sale movement）
+  -- ==========================================================================
+  v_campaign := public._restock_sentinel_campaign(v_store.tenant_id);
+  v_channel  := public._restock_sentinel_channel(v_store.tenant_id, p_store_id);
+
+  INSERT INTO customer_orders (
+    tenant_id, order_no, campaign_id, channel_id, member_id,
+    nickname_snapshot, pickup_store_id, status,
+    ready_at, completed_at, ordered_at,
+    order_kind, order_type, payment_method, discount_amount, notes,
+    created_by, updated_by, created_at, updated_at
+  ) VALUES (
+    v_store.tenant_id, v_order_no, v_campaign, v_channel, v_member_id,
+    v_name, p_store_id, 'completed',
+    v_now, v_now, v_now,
+    -- ⛔ order_kind 維持 'normal'：全站 188 處用 `order_kind='normal' OR IS NULL`
+    --    當口徑，新 kind 會讓現場銷售從營收 / 商品分析整批消失。
+    'normal', 'regular', NULLIF(TRIM(p_payment_method), ''), v_discount,
+    '【現場銷售】門市臨櫃結帳，當場交貨扣庫存' ||
+      CASE WHEN v_add_total > 0
+             THEN E'\n其中 ' || v_add_total || ' 件結帳時帳上沒有，系統自動補帳入庫（見 /pos/topups）'
+           ELSE '' END ||
+      CASE WHEN v_pool_total > 0
+             THEN E'\n其中 ' || v_pool_total || ' 件來自【內部】' || v_store.name || '現貨池（已從池子扣除）'
+           ELSE '' END ||
+      COALESCE(E'\n' || NULLIF(TRIM(p_notes), ''), ''),
+    p_operator, p_operator, v_now, v_now
+  ) RETURNING id INTO v_order_id;
+
+  -- 逐列：品項（直接 picked_up）→ sale movement → 回填 pickup_movement_id。
+  -- 欄位與寫法逐字對齊 rpc_record_pickup 的「整行取」分支，撤銷取貨 / 退貨 /
+  -- 月結 / 成本才會把它當成一般的取貨看待。
+  FOR v_l IN
+    SELECT (e ->> 'sku_id')::BIGINT      AS sku_id,
+           (e ->> 'qty')::NUMERIC        AS qty,
+           (e ->> 'unit_price')::NUMERIC AS unit_price,
+           ord
+      FROM jsonb_array_elements(p_lines) WITH ORDINALITY AS t(e, ord)
+     ORDER BY ord
+  LOOP
+    v_ci := public._restock_sentinel_campaign_item(
+              v_store.tenant_id, v_campaign, v_l.sku_id, v_l.unit_price);
+
+    INSERT INTO customer_order_items (
+      tenant_id, order_id, campaign_item_id, sku_id, qty, unit_price,
+      status, source, created_by, updated_by, created_at, updated_at
+    ) VALUES (
+      v_store.tenant_id, v_order_id, v_ci, v_l.sku_id, v_l.qty, v_l.unit_price,
+      'picked_up', 'walk_in', p_operator, p_operator, v_now, v_now
+    ) RETURNING id INTO v_item_id;
+
+    INSERT INTO stock_movements (
+      tenant_id, location_id, sku_id, quantity, movement_type,
+      source_doc_type, source_doc_id, source_doc_line_id, reason, operator_id
+    ) VALUES (
+      v_store.tenant_id, v_store.location_id, v_l.sku_id, -v_l.qty, 'sale',
+      'customer_order', v_order_id, v_item_id,
+      format('現場銷售 order=%s item=%s', v_order_id, v_item_id), p_operator
+    ) RETURNING id INTO v_move_id;
+
+    UPDATE customer_order_items
+       SET pickup_movement_id = v_move_id
+     WHERE id = v_item_id;
+
+    v_item_ids  := v_item_ids || v_item_id;
+    v_total     := v_total + v_l.qty * v_l.unit_price;
+    v_items_out := v_items_out || jsonb_build_object(
+      'item_id', v_item_id, 'sku_id', v_l.sku_id, 'qty', v_l.qty,
+      'unit_price', v_l.unit_price, 'subtotal', v_l.qty * v_l.unit_price);
+  END LOOP;
+
+  -- ==========================================================================
+  -- 5. 扣【內部】店現貨池
+  --
+  -- 不扣的話同一批貨掛兩份承諾：池子還寫著 ×N、但貨已經賣掉了 —— 就是
+  -- 2026-08-11 忠順「池子掛 ×10、實際只剩 2」那件事。扣法沿用共用 helper，
+  -- **不要再抄一份拆行邏輯**（CLAUDE.md 明文）。
+  -- ==========================================================================
+  FOR v_s IN SELECT key::BIGINT AS sku_id, value::TEXT::NUMERIC AS qty
+               FROM jsonb_each(v_pool_plan)
+  LOOP
+    PERFORM public._consume_internal_pool(
+      p_store_id, v_s.sku_id, v_s.qty, p_operator, v_now,
+      '[已現場售出 ' || v_order_no || ']');
+  END LOOP;
+
+  -- ==========================================================================
+  -- 6. 取貨事件
+  --
+  -- ⚠ 這一段不能省：rpc_undo_pickup 第一件事就是找最後一筆取貨事件，
+  --    找不到會直接 RAISE「沒有取貨事件可撤銷」→ 店員按錯就救不回來。
+  -- ==========================================================================
+  INSERT INTO order_pickup_events (
+    tenant_id, order_id, pickup_store_id, event_type, item_ids, notes, created_by
+  ) VALUES (
+    v_store.tenant_id, v_order_id, p_store_id, 'picked_up',
+    to_jsonb(v_item_ids), '現場銷售 ' || v_order_no, p_operator
+  );
+
+  RETURN jsonb_build_object(
+    'order_id',       v_order_id,
+    'order_no',       v_order_no,
+    'member_id',      v_member_id,
+    'customer_name',  v_name,
+    'items',          v_items_out,
+    'items_total',    v_total,
+    'discount',       v_discount,
+    'total',          GREATEST(v_total - v_discount, 0),
+    'payment_method', NULLIF(TRIM(p_payment_method), ''),
+    'from_pool',      v_pool_total,
+    'stock_added',    v_added
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_create_walkin_sale(BIGINT, JSONB, UUID, BIGINT, TEXT, TEXT, NUMERIC, TEXT) IS
+  '現場銷售（門市臨櫃結帳）：多品項、當場交貨扣庫存，開一張 WS- 顧客訂單'
+  '（單頭 completed、品項 picked_up、每列一筆 sale movement）。'
+  '**數量不會擋結帳**：帳上不夠的部分自動寫 manual_adjust 補進來再賣掉'
+  '（on_hand 淨變化 0，reason 帶單號，稽核看 /pos/topups）。'
+  '成交後扣【內部】店已到貨現貨池。'
+  '20260904010020 起：算補帳量之前先鎖住 stock_balances 餘額列，'
+  '讀到的 on_hand／可賣量才不會是舊值（否則與取貨／改實收併發會扣成負庫存）。'
+  '⛔ 那把鎖**只是為了讀到新鮮數字**，不是閘門 —— 不准在它後面加任何'
+  '會讓結帳失敗的數量守衛（Alex 2026-09-01「顯示貨不足但是它也可以結單」）。'
+  '20260904010020。';
+
+REVOKE ALL ON FUNCTION public.rpc_create_walkin_sale(BIGINT, JSONB, UUID, BIGINT, TEXT, TEXT, NUMERIC, TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_create_walkin_sale(BIGINT, JSONB, UUID, BIGINT, TEXT, TEXT, NUMERIC, TEXT) TO authenticated;


### PR DESCRIPTION
今日實案：平鎮收 5 誤鍵 2，「✎ 修改實收」改回 5 後庫存不跟著動
（原設計純紀錄），店員無從得知還要手動補庫存。老闆裁示做連動，
審查沿途揪出兩個既有併發洞，一併鎖齊。

- 20260904010000：rpc_adjust_received_transfer 連動庫存—— 往上改自動補、往下改鎖後重驗夠才扣（不夠大聲失敗）； 「沖舊立新」維持不變式 in_movement.quantity ≡ qty_received （rpc_unreceive_transfer 因此零改動）；avg_cost 校正以原入庫 unit_cost 為基準（兩路徑收斂驗算 91.1111，附手算表）； 零成本批次照做數量、成本跳過並雙處留痕（對齊既有 trigger 語意）
- 20260904010010：rpc_record_pickup 扣庫存前 FOR UPDATE 鎖 stock_balances＋鎖內重驗（修「看完庫存到動手中間可插隊」的 既有洞；豁免口徑與取貨閘門逐字等價——store_internal/offset 照舊，不動 #901 現貨池修復）
- 20260904010020：rpc_create_walkin_sale 鎖了再讀再補—— ⛔ 保留鐵律「現場銷售永不因缺貨被擋」（鎖只保證讀到新鮮數字， 能失敗的理由集合前後一字不差），四處註記防後人抄錯邊
- 三支鎖序一致（location,sku）防死鎖；三支必須一起上線（檔頭紅字）
- 配套修復腳本（營運端執行）：歷史「紀錄期間」帳實不符列重建， 預覽/演練/正式/驗證四段，後悔藥含先鎖重讀守衛

⚠ 動到 Alex 三支既有函式（#900 adjust／pickup／#899-era walkin）， 均為 append-only 或單欄尾加，基底逐字保留，詳 PR 說明揭露段。

驗證：施工 4 輪 × Codex 唯讀審查 4 輪（含兩次審方藥方被施工者
以實據推翻並經終審確認撤回）P0/P1=0；tsc/ESLint/SQL 皆負向對照
實跑。⚠ 未連庫實測；migration 由營運端依 010000→010010→010020
順序套用後執行修復腳本。

## 做了什麼


## 上線危險

- 做了：
- 不做：
- 回退：

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [ ] 本 PR 沒有碰上述敏感設定。

## 驗證


