### PR TITLE
fix: 多收少收分頁納入總倉配貨差異

### DIFF
--- a/apps/admin/src/app/(protected)/transfers/print/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/print/page.tsx
@@ -5,6 +5,7 @@
 //   transfer_id: 轉貨單 id (必填)
 //   copies: 逗號分隔; 預設 "driver,stub"。可傳 "driver" 只印一份。
 //   receipt=1: 收貨差異單，列出派出／實收／差異，供司機帶回總倉。
+//   demand_over / demand_short: 派出量相對訂單需求的多給／少給件數。
 
 import { Fragment, Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
@@ -91,6 +92,8 @@ function Body() {
   const transferId = Number(sp.get("transfer_id"));
   const copiesParam = sp.get("copies") ?? "driver,stub";
   const receiptMode = sp.get("receipt") === "1";
+  const demandOver = Math.max(0, Number(sp.get("demand_over")) || 0);
+  const demandShort = Math.max(0, Number(sp.get("demand_short")) || 0);
   const copies: CopyKind[] = useMemo(() => {
     const raw = copiesParam.split(",").map((s) => s.trim()).filter(Boolean);
     const valid = raw.filter((k): k is CopyKind => k === "driver" || k === "stub");
@@ -285,15 +288,30 @@ function Body() {
         </div>
 
         {copies.map((kind, idx) => (
-          <Slip key={`${kind}-${idx}`} kind={kind} tx={tx} items={items} linkedOrder={linkedOrder} receiptMode={receiptMode} />
+          <Slip
+            key={`${kind}-${idx}`}
+            kind={kind}
+            tx={tx}
+            items={items}
+            linkedOrder={linkedOrder}
+            receiptMode={receiptMode}
+            demandOver={demandOver}
+            demandShort={demandShort}
+          />
         ))}
       </div>
     </>
   );
 }
 
-function Slip({ kind, tx, items, linkedOrder, receiptMode }: {
-  kind: CopyKind; tx: Transfer; items: Item[]; linkedOrder: LinkedOrder | null; receiptMode: boolean;
+function Slip({ kind, tx, items, linkedOrder, receiptMode, demandOver, demandShort }: {
+  kind: CopyKind;
+  tx: Transfer;
+  items: Item[];
+  linkedOrder: LinkedOrder | null;
+  receiptMode: boolean;
+  demandOver: number;
+  demandShort: number;
 }) {
   const { tenant } = useAuth();
   const tenantName = tenant?.name ?? getTenantName();
@@ -417,6 +435,15 @@ function Slip({ kind, tx, items, linkedOrder, receiptMode }: {
           )}
         </tfoot>
       </table>
+
+      {receiptMode && (demandOver > 0 || demandShort > 0) && (
+        <div className="mt-1.5 border-2 border-black p-1.5 text-[13px] font-bold">
+          配單差異：
+          {demandOver > 0 && <span> 總倉多給 {demandOver} 件（超過訂單需求）</span>}
+          {demandOver > 0 && demandShort > 0 && <span>；</span>}
+          {demandShort > 0 && <span> 總倉少給 {demandShort} 件（低於訂單需求）</span>}
+        </div>
+      )}
 
       {tx.notes && (
         <div className="mt-1.5 border border-black p-1.5 text-[12px]">

--- a/apps/admin/src/app/(protected)/transfers/print/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/print/page.tsx
@@ -4,6 +4,7 @@
 // query params:
 //   transfer_id: 轉貨單 id (必填)
 //   copies: 逗號分隔; 預設 "driver,stub"。可傳 "driver" 只印一份。
+//   receipt=1: 收貨差異單，列出派出／實收／差異，供司機帶回總倉。
 
 import { Fragment, Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
@@ -46,6 +47,7 @@ type Item = {
   id: number;
   qty_requested: number;
   qty_shipped: number;
+  qty_received: number;
   description: string | null;
   estimated_amount: number | null;
   sku_code: string | null;
@@ -88,6 +90,7 @@ function Body() {
   const sp = useSearchParams();
   const transferId = Number(sp.get("transfer_id"));
   const copiesParam = sp.get("copies") ?? "driver,stub";
+  const receiptMode = sp.get("receipt") === "1";
   const copies: CopyKind[] = useMemo(() => {
     const raw = copiesParam.split(",").map((s) => s.trim()).filter(Boolean);
     const valid = raw.filter((k): k is CopyKind => k === "driver" || k === "stub");
@@ -122,7 +125,7 @@ function Body() {
         sb.from("locations").select("id, name").in("id", [t.source_location, t.dest_location]),
         sb
           .from("transfer_items")
-          .select("id, sku_id, qty_requested, qty_shipped, description, estimated_amount, notes")
+          .select("id, sku_id, qty_requested, qty_shipped, qty_received, description, estimated_amount, notes")
           .eq("transfer_id", transferId)
           .order("id"),
       ]);
@@ -135,6 +138,7 @@ function Body() {
         sku_id: number | null;
         qty_requested: number | null;
         qty_shipped: number | null;
+        qty_received: number | null;
         description: string | null;
         estimated_amount: number | null;
         notes: string | null;
@@ -173,6 +177,7 @@ function Body() {
           id: r.id,
           qty_requested: Number(r.qty_requested ?? 0),
           qty_shipped: Number(r.qty_shipped ?? 0),
+          qty_received: Number(r.qty_received ?? 0),
           description: r.description,
           estimated_amount: r.estimated_amount == null ? null : Number(r.estimated_amount),
           sku_code: sku?.code ?? null,
@@ -231,9 +236,9 @@ function Body() {
   useEffect(() => {
     if (!tx) return;
     const original = document.title;
-    document.title = tx.transfer_no;
+    document.title = receiptMode ? `${tx.transfer_no}-收貨差異單` : tx.transfer_no;
     return () => { document.title = original; };
-  }, [tx]);
+  }, [tx, receiptMode]);
 
   // 資料載入完成 → 自動跳列印
   useEffect(() => {
@@ -280,28 +285,29 @@ function Body() {
         </div>
 
         {copies.map((kind, idx) => (
-          <Slip key={`${kind}-${idx}`} kind={kind} tx={tx} items={items} linkedOrder={linkedOrder} />
+          <Slip key={`${kind}-${idx}`} kind={kind} tx={tx} items={items} linkedOrder={linkedOrder} receiptMode={receiptMode} />
         ))}
       </div>
     </>
   );
 }
 
-function Slip({ kind, tx, items, linkedOrder }: {
-  kind: CopyKind; tx: Transfer; items: Item[]; linkedOrder: LinkedOrder | null;
+function Slip({ kind, tx, items, linkedOrder, receiptMode }: {
+  kind: CopyKind; tx: Transfer; items: Item[]; linkedOrder: LinkedOrder | null; receiptMode: boolean;
 }) {
   const { tenant } = useAuth();
   const tenantName = tenant?.name ?? getTenantName();
   const typeLabel = TYPE_LABEL[tx.transfer_type] ?? tx.transfer_type;
   const tempLabel = tx.shipping_temp ? (TEMP_LABEL[tx.shipping_temp] ?? tx.shipping_temp) : "—";
   const totalQty = items.reduce((s, it) => s + it.qty_shipped, 0);
+  const totalReceived = items.reduce((s, it) => s + it.qty_received, 0);
   const totalEst = items.reduce((s, it) => s + (it.estimated_amount ?? 0), 0);
 
   return (
     <div className="copy-page bg-white p-2 font-mono text-[13px] leading-tight text-black shadow print:shadow-none">
       <div className="border-b-2 border-black pb-1 text-center">
         <div className="text-[14px] font-bold">{tenantName}</div>
-        <div className="text-[20px] font-bold">{typeLabel}出貨單</div>
+        <div className="text-[20px] font-bold">{receiptMode ? "收貨差異單" : `${typeLabel}出貨單`}</div>
         <div className="mt-0.5 flex items-center justify-center gap-2">
           <span className="inline-block rounded border-2 border-black px-1.5 py-0.5 text-[13px] font-bold">
             {COPY_LABEL[kind]}
@@ -323,6 +329,11 @@ function Slip({ kind, tx, items, linkedOrder }: {
         {tx.shipped_at && (
           <div className="text-[12px]">
             出貨 {new Date(tx.shipped_at).toLocaleString("zh-TW", { hour12: false })}
+          </div>
+        )}
+        {receiptMode && tx.received_at && (
+          <div className="text-[12px] font-bold">
+            收貨 {new Date(tx.received_at).toLocaleString("zh-TW", { hour12: false })}
           </div>
         )}
         {linkedOrder ? (
@@ -348,9 +359,9 @@ function Slip({ kind, tx, items, linkedOrder }: {
           <tr className="border-b border-black text-[12px]">
             <th className="w-5 py-1 text-left">#</th>
             <th className="py-1 text-left">品名 / 描述</th>
-            <th className="w-9 py-1 text-right">應出</th>
-            <th className="w-9 py-1 text-right">實出</th>
-            <th className="w-8 py-1 text-center">點收</th>
+            <th className="w-9 py-1 text-right">{receiptMode ? "派出" : "應出"}</th>
+            <th className="w-9 py-1 text-right">{receiptMode ? "實收" : "實出"}</th>
+            <th className="w-8 py-1 text-center">{receiptMode ? "差異" : "點收"}</th>
           </tr>
         </thead>
         <tbody>
@@ -377,9 +388,13 @@ function Slip({ kind, tx, items, linkedOrder }: {
                       <div className="text-[11px] italic">↳ {it.notes}</div>
                     )}
                   </td>
-                  <td className="py-1 text-right align-top">{it.qty_requested}</td>
-                  <td className="py-1 text-right align-top font-bold">{it.qty_shipped}</td>
-                  <td className="py-1 text-center align-top text-[15px]">☐</td>
+                  <td className="py-1 text-right align-top">{receiptMode ? it.qty_shipped : it.qty_requested}</td>
+                  <td className="py-1 text-right align-top font-bold">{receiptMode ? it.qty_received : it.qty_shipped}</td>
+                  <td className={`py-1 text-center align-top font-bold ${receiptMode && it.qty_received !== it.qty_shipped ? "text-[14px]" : "text-[15px]"}`}>
+                    {receiptMode
+                      ? `${it.qty_received - it.qty_shipped > 0 ? "+" : ""}${it.qty_received - it.qty_shipped}`
+                      : "☐"}
+                  </td>
                 </tr>
               </Fragment>
             ))
@@ -388,9 +403,11 @@ function Slip({ kind, tx, items, linkedOrder }: {
         <tfoot>
           <tr className="border-t-2 border-black font-bold">
             <td colSpan={2} className="py-1 text-right">合計</td>
-            <td className="py-1 text-right">{items.reduce((s, it) => s + it.qty_requested, 0)}</td>
-            <td className="py-1 text-right">{totalQty}</td>
-            <td className="py-1 text-center text-[11px]">{items.length} 項</td>
+            <td className="py-1 text-right">{receiptMode ? totalQty : items.reduce((s, it) => s + it.qty_requested, 0)}</td>
+            <td className="py-1 text-right">{receiptMode ? totalReceived : totalQty}</td>
+            <td className="py-1 text-center text-[11px]">
+              {receiptMode ? `${totalReceived - totalQty > 0 ? "+" : ""}${totalReceived - totalQty}` : `${items.length} 項`}
+            </td>
           </tr>
           {totalEst > 0 && (
             <tr>
@@ -405,6 +422,13 @@ function Slip({ kind, tx, items, linkedOrder }: {
         <div className="mt-1.5 border border-black p-1.5 text-[12px]">
           <span className="font-bold">備註：</span>
           {tx.notes}
+        </div>
+      )}
+
+      {receiptMode && (
+        <div className="mt-3 grid grid-cols-2 gap-3 text-[12px]">
+          <div className="border-t border-black pt-1">門市確認：</div>
+          <div className="border-t border-black pt-1">司機簽收：</div>
         </div>
       )}
 

--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -766,10 +766,17 @@ export default function TransfersInboxPage() {
     return (transfers ?? []).filter((t) => {
       if (locationFilter !== "all" && t.dest_location !== locationFilter) return false;
       if (!matchSearch(t)) return false;
-      // 分頁為主篩選：多收／少收皆只看已收貨，並以「實收 vs 派出」判斷。
+      // 分頁為主篩選：現場把「派出 vs 訂單需求」和「實收 vs 派出」都視為收貨差異。
+      // 例如總倉派 2、訂單只需 1，門市照單實收 2：實收沒有偏離派出，但仍是多收 1。
       if (tab === "received") return t.status === "received";
-      if (tab === "over") return t.status === "received" && (itemSummary.get(t.id)?.receiveOverQty ?? 0) > 0;
-      if (tab === "short") return t.status === "received" && (itemSummary.get(t.id)?.receiveShortQty ?? 0) > 0;
+      if (tab === "over") {
+        const s = itemSummary.get(t.id);
+        return t.status === "received" && ((s?.receiveOverQty ?? 0) > 0 || (s?.extraQty ?? 0) > 0);
+      }
+      if (tab === "short") {
+        const s = itemSummary.get(t.id);
+        return t.status === "received" && ((s?.receiveShortQty ?? 0) > 0 || (s?.shortQty ?? 0) > 0);
+      }
       if (t.status !== "shipped") return false;
       if (dateFilter === null || dateFilter === "all_pending") return true;
       const wid = parseWaveId(t.transfer_no);
@@ -1065,8 +1072,8 @@ export default function TransfersInboxPage() {
       if (t.status === "received") {
         acc.done += 1;
         const s = itemSummary.get(t.id);
-        if ((s?.receiveOverQty ?? 0) > 0) acc.over += 1;
-        if ((s?.receiveShortQty ?? 0) > 0) acc.short += 1;
+        if ((s?.receiveOverQty ?? 0) > 0 || (s?.extraQty ?? 0) > 0) acc.over += 1;
+        if ((s?.receiveShortQty ?? 0) > 0 || (s?.shortQty ?? 0) > 0) acc.short += 1;
         continue;
       }
       if (t.status !== "shipped") continue;
@@ -2386,9 +2393,12 @@ export default function TransfersInboxPage() {
                                 </div>
                               ) : (
                                 <div className="flex justify-end gap-1">
-                                  {(summary?.receiveOverQty ?? 0) > 0 || (summary?.receiveShortQty ?? 0) > 0 ? (
+                                  {(summary?.receiveOverQty ?? 0) > 0 ||
+                                  (summary?.receiveShortQty ?? 0) > 0 ||
+                                  (summary?.extraQty ?? 0) > 0 ||
+                                  (summary?.shortQty ?? 0) > 0 ? (
                                     <Link
-                                      href={`/transfers/print?transfer_id=${t.id}&copies=driver&receipt=1`}
+                                      href={`/transfers/print?transfer_id=${t.id}&copies=driver&receipt=1&demand_over=${summary?.extraQty ?? 0}&demand_short=${summary?.shortQty ?? 0}`}
                                       target="_blank"
                                       className="rounded-md border border-blue-300 px-2 py-1 text-xs text-blue-700 hover:bg-blue-50 dark:border-blue-800 dark:text-blue-400 dark:hover:bg-blue-950"
                                       title="列印收貨差異單，交由司機帶回總倉"

--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -54,7 +54,7 @@ type StoreCampaign = {
 // codes：本張 transfer 涵蓋的品項編號(sku_code) / 商品編號(product_code)，僅供搜尋比對用
 // items：拆開的品項行（key = 合併同品相用的識別；自由轉貨掛虛擬 SKU，要用 description 當 key）
 // product = 只有商品名（不含規格），給群組標題用；name = 商品名 / 規格，明細表用
-type ItemLine = { key: string; skuId: number | null; product: string; name: string; skuCode: string | null; qty: number };
+type ItemLine = { key: string; skuId: number | null; product: string; name: string; skuCode: string | null; qty: number; receivedQty: number };
 // extraQty / shortQty：這張單的派出量 vs 訂單需求量差額（見下方查詢註解）
 //   extraQty = 多給、沒有訂單對應；shortQty = 不夠分，會有客人領不到
 //   coveredQty = 缺口中已用「店內現貨減抵單」吸收的件數（shortQty 已淨掉這部分）
@@ -78,6 +78,9 @@ type ItemSummary = {
   bySku: Record<string, { short: number; backorder: number }>;
   // 總倉對短少/多收的處理回覆（含重派補單 wave）— 店家連回去追蹤用
   hqReplies: Array<{ sku_id: number; resolution: string | null; wave_code: string | null; wave_status: string | null }>;
+  // 店家實際點收 vs 總倉派出。這才是收貨差異；不要和上面的「派出 vs 訂單需求」混用。
+  receiveOverQty: number;
+  receiveShortQty: number;
 };
 
 // 列表上的一個可收合群組（product 模式＝同品相，wave 模式＝同撿貨單號）
@@ -96,6 +99,8 @@ type Group = {
   coveredQty: number;      // 這組用店內現貨減抵掉幾件
   prefilledQty: number;    // 這組有幾件是補回店家先墊的現貨
   backorderQty: number;    // 這組還有幾件掛著待補貨（少發配貨沒配到）
+  receiveOverQty: number;  // 已收貨後，實收比派出多
+  receiveShortQty: number; // 已收貨後，實收比派出少
 };
 
 // 「已收」分頁單次查詢的筆數天花板。
@@ -236,7 +241,7 @@ export default function TransfersInboxPage() {
   type DateFilter = "tomorrow" | "today_or_earlier" | "all_pending" | null;
   const [dateFilter, setDateFilter] = useState<DateFilter>(null);
   // 分頁：未收(shipped) / 已收(received)，預設未收
-  type InboxTab = "unreceived" | "received";
+  type InboxTab = "unreceived" | "received" | "over" | "short";
   const [tab, setTab] = useState<InboxTab>("unreceived");
   // 搜尋：撿貨單號(wave_code) / 調撥單號 / 分店 / 商品名 / 商品編號(product_code) / 品項編號(sku_code)
   const [search, setSearch] = useState("");
@@ -466,12 +471,13 @@ export default function TransfersInboxPage() {
             transfer_id: number;
             sku_id: number;
             qty_shipped: number;
+            qty_received: number;
             description: string | null;
           }>(
             () =>
               sb
                 .from("transfer_items")
-                .select("transfer_id, sku_id, qty_shipped, description")
+                .select("transfer_id, sku_id, qty_shipped, qty_received, description")
                 .in("transfer_id", transferIds)
                 .order("id"),
           );
@@ -506,13 +512,16 @@ export default function TransfersInboxPage() {
               if (code) skuCodeMap.set(s.id, code);
             }
           }
-          const emptySummary = (): ItemSummary => ({ lines: 0, totalQty: 0, names: [], codes: [], items: [], extraQty: 0, shortQty: 0, coveredQty: 0, prefilledQty: 0, backorderQty: 0, bySku: {}, hqReplies: [] });
+          const emptySummary = (): ItemSummary => ({ lines: 0, totalQty: 0, names: [], codes: [], items: [], extraQty: 0, shortQty: 0, coveredQty: 0, prefilledQty: 0, backorderQty: 0, bySku: {}, hqReplies: [], receiveOverQty: 0, receiveShortQty: 0 });
           for (const tid of transferIds) summary.set(tid, emptySummary());
           for (const it of items) {
             const cur = summary.get(it.transfer_id) ?? emptySummary();
             cur.lines += 1;
             const qty = Number(it.qty_shipped);
+            const receivedQty = Number(it.qty_received);
             cur.totalQty += qty;
+            cur.receiveOverQty += Math.max(0, receivedQty - qty);
+            cur.receiveShortQty += Math.max(0, qty - receivedQty);
             const desc = it.description?.trim();
             const name = desc || (skuNameMap.get(it.sku_id) ?? `#${it.sku_id}`);
             cur.names.push(`${name} × ${qty}`);
@@ -524,6 +533,7 @@ export default function TransfersInboxPage() {
               name,
               skuCode: desc ? null : skuOnlyCodeMap.get(it.sku_id) ?? null,
               qty,
+              receivedQty,
             });
             const code = skuCodeMap.get(it.sku_id);
             if (code) cur.codes.push(code);
@@ -756,8 +766,10 @@ export default function TransfersInboxPage() {
     return (transfers ?? []).filter((t) => {
       if (locationFilter !== "all" && t.dest_location !== locationFilter) return false;
       if (!matchSearch(t)) return false;
-      // 分頁為主篩選：已收 = received；未收 = shipped（再套待收子篩選）
+      // 分頁為主篩選：多收／少收皆只看已收貨，並以「實收 vs 派出」判斷。
       if (tab === "received") return t.status === "received";
+      if (tab === "over") return t.status === "received" && (itemSummary.get(t.id)?.receiveOverQty ?? 0) > 0;
+      if (tab === "short") return t.status === "received" && (itemSummary.get(t.id)?.receiveShortQty ?? 0) > 0;
       if (t.status !== "shipped") return false;
       if (dateFilter === null || dateFilter === "all_pending") return true;
       const wid = parseWaveId(t.transfer_no);
@@ -794,6 +806,8 @@ export default function TransfersInboxPage() {
             coveredQty: 0,
             prefilledQty: 0,
             backorderQty: 0,
+            receiveOverQty: 0,
+            receiveShortQty: 0,
           };
           map.set(key, entry);
         }
@@ -804,6 +818,8 @@ export default function TransfersInboxPage() {
         entry.coveredQty += itemSummary.get(t.id)?.coveredQty ?? 0;
         entry.prefilledQty += itemSummary.get(t.id)?.prefilledQty ?? 0;
         entry.backorderQty += itemSummary.get(t.id)?.backorderQty ?? 0;
+        entry.receiveOverQty += itemSummary.get(t.id)?.receiveOverQty ?? 0;
+        entry.receiveShortQty += itemSummary.get(t.id)?.receiveShortQty ?? 0;
       }
       return Array.from(map.values()).sort((a, b) => {
         // 「其他調撥」永遠墊底，其餘依撿貨單號遞減
@@ -847,6 +863,8 @@ export default function TransfersInboxPage() {
           coveredQty: 0,
           prefilledQty: 0,
           backorderQty: 0,
+          receiveOverQty: 0,
+          receiveShortQty: 0,
         };
         map.set(key, entry);
       }
@@ -857,6 +875,8 @@ export default function TransfersInboxPage() {
       entry.coveredQty += s?.coveredQty ?? 0;
       entry.prefilledQty += s?.prefilledQty ?? 0;
       entry.backorderQty += s?.backorderQty ?? 0;
+      entry.receiveOverQty += s?.receiveOverQty ?? 0;
+      entry.receiveShortQty += s?.receiveShortQty ?? 0;
     }
     const asc = tab === "unreceived";
     return Array.from(map.values()).sort((a, b) =>
@@ -1032,7 +1052,7 @@ export default function TransfersInboxPage() {
 
   // KPI summaries: 4 個分類,點 KPI card 就 filter list
   const summaries = useMemo(() => {
-    const empty = { tomorrow: 0, todayOrEarlier: 0, allPending: 0, done: 0 };
+    const empty = { tomorrow: 0, todayOrEarlier: 0, allPending: 0, done: 0, over: 0, short: 0 };
     if (!transfers) return empty;
     const today = new Date();
     const tomorrow = new Date();
@@ -1042,7 +1062,13 @@ export default function TransfersInboxPage() {
     const acc = { ...empty };
     for (const t of transfers) {
       if (locationFilter !== "all" && t.dest_location !== locationFilter) continue;
-      if (t.status === "received") { acc.done += 1; continue; }
+      if (t.status === "received") {
+        acc.done += 1;
+        const s = itemSummary.get(t.id);
+        if ((s?.receiveOverQty ?? 0) > 0) acc.over += 1;
+        if ((s?.receiveShortQty ?? 0) > 0) acc.short += 1;
+        continue;
+      }
       if (t.status !== "shipped") continue;
       acc.allPending += 1;
       const wid = parseWaveId(t.transfer_no);
@@ -1052,7 +1078,7 @@ export default function TransfersInboxPage() {
       else if (w.wave_date <= todayStr) acc.todayOrEarlier += 1;
     }
     return acc;
-  }, [transfers, waves, locationFilter]);
+  }, [transfers, waves, locationFilter, itemSummary]);
 
   // ─────────────────────────────────────────────────────────────────
   // 「已收」那個數字（頁首、分頁標籤、KPI 卡三處共用同一個值）
@@ -1449,13 +1475,15 @@ export default function TransfersInboxPage() {
         )}
       </header>
 
-      {/* 分頁：未收 / 已收（預設未收） */}
+      {/* 分頁：多收／少收是已收歷史的差異子集，數字是目前載入範圍。 */}
       <div className="flex items-center gap-1 border-b border-zinc-200 dark:border-zinc-800">
         {([
           // 已收那格拿得到真實總數時就顯示總數；拿不到時會是「已載入 N」
           // （見上方 doneKpiTabCount）→ 兩個都當字串處理
           { value: "unreceived", label: "未收", count: String(summaries.allPending) },
           { value: "received", label: "已收", count: doneKpiTabCount },
+          { value: "over", label: "多收", count: `已載入 ${summaries.over}` },
+          { value: "short", label: "少收", count: `已載入 ${summaries.short}` },
         ] as const).map((tb) => {
           const active = tab === tb.value;
           return (
@@ -1631,7 +1659,7 @@ export default function TransfersInboxPage() {
           不填＝維持原本「最近 doneLimit 筆」；填了才把查詢視窗換成這段期間。
           搜尋框的商品名比對是在「已載入的單」上做的 → 要找幾天前的貨，
           先用這裡把那幾天撈進來，再搜商品名才找得到。 */}
-      {tab === "received" && (
+      {tab !== "unreceived" && (
         <div className="flex flex-wrap items-center gap-2 rounded-md border border-zinc-200 bg-zinc-50 p-3 text-sm dark:border-zinc-800 dark:bg-zinc-900">
           <span className="shrink-0 text-xs text-zinc-500">收貨日期</span>
           <input
@@ -2001,6 +2029,8 @@ export default function TransfersInboxPage() {
                     <Pill tone="violet">🔄 補回先墊 {g.prefilledQty} 件</Pill>
                   )}
                   {g.extraQty > 0 && <Pill tone="blue">🎁 總倉多給 {g.extraQty} 件</Pill>}
+                  {g.receiveOverQty > 0 && <Pill tone="blue">＋ 實收多 {g.receiveOverQty} 件</Pill>}
+                  {g.receiveShortQty > 0 && <Pill tone="rose">− 實收少 {g.receiveShortQty} 件</Pill>}
                 </div>
 
                 {pendingCount > 0 && (
@@ -2304,6 +2334,16 @@ export default function TransfersInboxPage() {
                                   🎁 多給 {summary.extraQty}
                                 </div>
                               )}
+                              {summary && summary.receiveOverQty > 0 && (
+                                <div className="text-[10px] font-bold text-blue-700 dark:text-blue-400">
+                                  ＋ 實收多 {summary.receiveOverQty}
+                                </div>
+                              )}
+                              {summary && summary.receiveShortQty > 0 && (
+                                <div className="text-[10px] font-bold text-rose-700 dark:text-rose-400">
+                                  − 實收少 {summary.receiveShortQty}
+                                </div>
+                              )}
                             </td>
                             <td className="whitespace-nowrap px-3 py-2 text-right align-top">
                               {isShipped ? (
@@ -2346,6 +2386,16 @@ export default function TransfersInboxPage() {
                                 </div>
                               ) : (
                                 <div className="flex justify-end gap-1">
+                                  {(summary?.receiveOverQty ?? 0) > 0 || (summary?.receiveShortQty ?? 0) > 0 ? (
+                                    <Link
+                                      href={`/transfers/print?transfer_id=${t.id}&copies=driver&receipt=1`}
+                                      target="_blank"
+                                      className="rounded-md border border-blue-300 px-2 py-1 text-xs text-blue-700 hover:bg-blue-50 dark:border-blue-800 dark:text-blue-400 dark:hover:bg-blue-950"
+                                      title="列印收貨差異單，交由司機帶回總倉"
+                                    >
+                                      🖨 列印差異單
+                                    </Link>
+                                  ) : null}
                                   {/* ⛔ 舊 title 寫「純紀錄…庫存與客人取貨不受影響」，
                                       20260904010000 起實收調整會連動店家庫存（沖舊立新、
                                       扣不動就擋下來），那句話已經是錯的，不要改回去。 */}
@@ -2393,7 +2443,7 @@ export default function TransfersInboxPage() {
           `.limit(12244)`，PostgREST 只回 1000 筆且不報錯（見上方 DONE_MAX），
           總部視角實際少看 11,000 多張、單店最多也少看 400 多張，正好是月結對帳
           回頭查最需要看到的那一段。 */}
-      {tab === "received" && doneSettled && doneLoaded < doneTotal && (
+      {tab !== "unreceived" && doneSettled && doneLoaded < doneTotal && (
         <div className="flex flex-wrap items-center justify-center gap-3 py-2 text-xs text-zinc-500">
           {/* ⚠ 總部在右上角挑了單一分店時，這裡【不能】顯示 doneLoaded / doneTotal ——
               doneQ 只套 branchLocationId（:273），沒有套 locationFilter，所以那兩個


### PR DESCRIPTION
## 修正
- 多收分頁同時包含總倉多給與門市實收多於派出
- 少收分頁同時包含總倉少給與門市實收少於派出
- 司機差異單增加配單差異說明

## 情境
總倉派 2、訂單需求 1、門市實收 2，現在會以多給 1 件出現在多收分頁。

## 驗證
- npm run build --workspace apps/admin 通過
- git diff --check 通過