### PR TITLE
fix: 多收少收分頁納入總倉配貨差異

### DIFF
--- a/apps/admin/src/app/(protected)/transfers/print/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/print/page.tsx
@@ -5,6 +5,7 @@
 //   transfer_id: 轉貨單 id (必填)
 //   copies: 逗號分隔; 預設 "driver,stub"。可傳 "driver" 只印一份。
 //   receipt=1: 收貨差異單，列出派出／實收／差異，供司機帶回總倉。
+//   demand_over / demand_short: 派出量相對訂單需求的多給／少給件數。
 
 import { Fragment, Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
@@ -91,6 +92,8 @@ function Body() {
   const transferId = Number(sp.get("transfer_id"));
   const copiesParam = sp.get("copies") ?? "driver,stub";
   const receiptMode = sp.get("receipt") === "1";
+  const demandOver = Math.max(0, Number(sp.get("demand_over")) || 0);
+  const demandShort = Math.max(0, Number(sp.get("demand_short")) || 0);
   const copies: CopyKind[] = useMemo(() => {
     const raw = copiesParam.split(",").map((s) => s.trim()).filter(Boolean);
     const valid = raw.filter((k): k is CopyKind => k === "driver" || k === "stub");
@@ -285,15 +288,30 @@ function Body() {
         </div>
 
         {copies.map((kind, idx) => (
-          <Slip key={`${kind}-${idx}`} kind={kind} tx={tx} items={items} linkedOrder={linkedOrder} receiptMode={receiptMode} />
+          <Slip
+            key={`${kind}-${idx}`}
+            kind={kind}
+            tx={tx}
+            items={items}
+            linkedOrder={linkedOrder}
+            receiptMode={receiptMode}
+            demandOver={demandOver}
+            demandShort={demandShort}
+          />
         ))}
       </div>
     </>
   );
 }
 
-function Slip({ kind, tx, items, linkedOrder, receiptMode }: {
-  kind: CopyKind; tx: Transfer; items: Item[]; linkedOrder: LinkedOrder | null; receiptMode: boolean;
+function Slip({ kind, tx, items, linkedOrder, receiptMode, demandOver, demandShort }: {
+  kind: CopyKind;
+  tx: Transfer;
+  items: Item[];
+  linkedOrder: LinkedOrder | null;
+  receiptMode: boolean;
+  demandOver: number;
+  demandShort: number;
 }) {
   const { tenant } = useAuth();
   const tenantName = tenant?.name ?? getTenantName();
@@ -417,6 +435,15 @@ function Slip({ kind, tx, items, linkedOrder, receiptMode }: {
           )}
         </tfoot>
       </table>
+
+      {receiptMode && (demandOver > 0 || demandShort > 0) && (
+        <div className="mt-1.5 border-2 border-black p-1.5 text-[13px] font-bold">
+          配單差異：
+          {demandOver > 0 && <span> 總倉多給 {demandOver} 件（超過訂單需求）</span>}
+          {demandOver > 0 && demandShort > 0 && <span>；</span>}
+          {demandShort > 0 && <span> 總倉少給 {demandShort} 件（低於訂單需求）</span>}
+        </div>
+      )}
 
       {tx.notes && (
         <div className="mt-1.5 border border-black p-1.5 text-[12px]">

--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -766,10 +766,17 @@ export default function TransfersInboxPage() {
     return (transfers ?? []).filter((t) => {
       if (locationFilter !== "all" && t.dest_location !== locationFilter) return false;
       if (!matchSearch(t)) return false;
-      // 分頁為主篩選：多收／少收皆只看已收貨，並以「實收 vs 派出」判斷。
+      // 分頁為主篩選：現場把「派出 vs 訂單需求」和「實收 vs 派出」都視為收貨差異。
+      // 例如總倉派 2、訂單只需 1，門市照單實收 2：實收沒有偏離派出，但仍是多收 1。
       if (tab === "received") return t.status === "received";
-      if (tab === "over") return t.status === "received" && (itemSummary.get(t.id)?.receiveOverQty ?? 0) > 0;
-      if (tab === "short") return t.status === "received" && (itemSummary.get(t.id)?.receiveShortQty ?? 0) > 0;
+      if (tab === "over") {
+        const s = itemSummary.get(t.id);
+        return t.status === "received" && ((s?.receiveOverQty ?? 0) > 0 || (s?.extraQty ?? 0) > 0);
+      }
+      if (tab === "short") {
+        const s = itemSummary.get(t.id);
+        return t.status === "received" && ((s?.receiveShortQty ?? 0) > 0 || (s?.shortQty ?? 0) > 0);
+      }
       if (t.status !== "shipped") return false;
       if (dateFilter === null || dateFilter === "all_pending") return true;
       const wid = parseWaveId(t.transfer_no);
@@ -1065,8 +1072,8 @@ export default function TransfersInboxPage() {
       if (t.status === "received") {
         acc.done += 1;
         const s = itemSummary.get(t.id);
-        if ((s?.receiveOverQty ?? 0) > 0) acc.over += 1;
-        if ((s?.receiveShortQty ?? 0) > 0) acc.short += 1;
+        if ((s?.receiveOverQty ?? 0) > 0 || (s?.extraQty ?? 0) > 0) acc.over += 1;
+        if ((s?.receiveShortQty ?? 0) > 0 || (s?.shortQty ?? 0) > 0) acc.short += 1;
         continue;
       }
       if (t.status !== "shipped") continue;
@@ -2386,9 +2393,12 @@ export default function TransfersInboxPage() {
                                 </div>
                               ) : (
                                 <div className="flex justify-end gap-1">
-                                  {(summary?.receiveOverQty ?? 0) > 0 || (summary?.receiveShortQty ?? 0) > 0 ? (
+                                  {(summary?.receiveOverQty ?? 0) > 0 ||
+                                  (summary?.receiveShortQty ?? 0) > 0 ||
+                                  (summary?.extraQty ?? 0) > 0 ||
+                                  (summary?.shortQty ?? 0) > 0 ? (
                                     <Link
-                                      href={`/transfers/print?transfer_id=${t.id}&copies=driver&receipt=1`}
+                                      href={`/transfers/print?transfer_id=${t.id}&copies=driver&receipt=1&demand_over=${summary?.extraQty ?? 0}&demand_short=${summary?.shortQty ?? 0}`}
                                       target="_blank"
                                       className="rounded-md border border-blue-300 px-2 py-1 text-xs text-blue-700 hover:bg-blue-50 dark:border-blue-800 dark:text-blue-400 dark:hover:bg-blue-950"
                                       title="列印收貨差異單，交由司機帶回總倉"


### PR DESCRIPTION
## 修正
- 多收分頁同時包含總倉多給與門市實收多於派出
- 少收分頁同時包含總倉少給與門市實收少於派出
- 司機差異單增加配單差異說明

## 情境
總倉派 2、訂單需求 1、門市實收 2，現在會以多給 1 件出現在多收分頁。

## 驗證
- npm run build --workspace apps/admin 通過
- git diff --check 通過