### PR TITLE
feat(wms): 店家退貨頁——送出不扣庫存、總倉同意才扣；分店收貨按鈕改字

### DIFF
--- a/apps/admin/src/app/(protected)/inventory/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/page.tsx
@@ -154,6 +154,10 @@ export default function InventoryOverviewPage() {
   // 算式留在伺服端（rpc_get_stock_commitment_bulk）—— 前端只顯示，不重算，
   // 否則等於把自由量公式又抄一份到前端。
   const [commitMap, setCommitMap] = useState<Map<string, Commitment>>(new Map());
+  // 「退貨中 N」（2026-09-04 老闆裁示 2，乙案）：店家已經送出退貨、總倉還沒回覆，
+  // 而且**還沒扣過庫存**的件數。key = `${location_id}-${sku_id}`。
+  // 資料來源 v_store_pending_returns（20260904020000，母體定義寫在那支檔頭）。
+  const [returningMap, setReturningMap] = useState<Map<string, number>>(new Map());
   const [moveCache, setMoveCache] = useState<Map<string, Movement[]>>(new Map());
   const [moveLoading, setMoveLoading] = useState(false);
   // 依商品新增庫存（manual_adjust +N）— 開庫存減抵單前把帳外現貨補進帳用
@@ -252,7 +256,7 @@ export default function InventoryOverviewPage() {
           if (apErr) throw apErr;
           const pairs = (ap as { location_id: number; sku_id: number }[]) ?? [];
           if (pairs.length === 0) {
-            if (!cancelled) { setRows([]); setTotal(0); setTruncated(false); setCommitMap(new Map()); }
+            if (!cancelled) { setRows([]); setTotal(0); setTruncated(false); setCommitMap(new Map()); setReturningMap(new Map()); }
             return;
           }
           allocSet = new Set(pairs.map((p) => `${p.location_id}-${p.sku_id}`));
@@ -333,7 +337,7 @@ export default function InventoryOverviewPage() {
         // 補 sku + reorder_rules + 承諾量拆解（僅本頁可見列）
         const skuIds = Array.from(new Set(pageRows.map((r) => r.sku_id)));
         if (skuIds.length > 0) {
-          const [sk, rr, cm, pr] = await Promise.all([
+          const [sk, rr, cm, pr, ret] = await Promise.all([
             sb.from("skus").select("id, sku_code, product_name, variant_name, base_unit").in("id", skuIds),
             sb.from("reorder_rules").select("location_id, sku_id, safety_stock, reorder_point").in("sku_id", skuIds),
             // 一頁一次，不要每列各打一次
@@ -348,6 +352,21 @@ export default function InventoryOverviewPage() {
               .in("scope", ["retail", "branch"])
               .is("effective_to", null)
               .order("effective_from", { ascending: false }),
+            // 退貨中（2026-09-04 乙案）：只撈本頁看得到的 SKU，跟上面四支同一個節奏。
+            // ⚠ 這個 view 只收「還沒扣過庫存」的退貨單（out_movement_id IS NULL）——
+            //   舊路徑（內部調撥 → ↩ 退貨回總倉）建單當下就扣掉了，不該再提醒一次。
+            // ⚠ 有選倉別就一起帶上去：stock_balances 對分店帳號是**只讀自己那家**
+            //   （store_read_own，20260707000070:65），但這支 view 沒有那道 RLS
+            //   （比照 v_hq_exceptions 的既有寫法，不加 security_invoker）。
+            //   不帶條件的話分店帳號會白拿到別家店的列 —— 畫面上不會顯示（key 對不上），
+            //   但沒必要送過來。
+            (() => {
+              const q = sb
+                .from("v_store_pending_returns")
+                .select("location_id, sku_id, pending_qty")
+                .in("sku_id", skuIds);
+              return locationId ? q.eq("location_id", Number(locationId)) : q;
+            })(),
           ]);
           if (cancelled) return;
           const sm = new Map<number, Sku>();
@@ -374,15 +393,21 @@ export default function InventoryOverviewPage() {
               free_with_pool: num(c.free_with_pool),
             });
           }
+          const retm = new Map<string, number>();
+          for (const x of (ret.data as { location_id: number; sku_id: number; pending_qty: number }[]) ?? []) {
+            retm.set(`${x.location_id}-${x.sku_id}`, num(x.pending_qty));
+          }
           setSkuMap(sm);
           setPriceMap(pm);
           setReorderMap(rm);
           setCommitMap(cmap);
+          setReturningMap(retm);
         } else {
           setSkuMap(new Map());
           setPriceMap(new Map());
           setReorderMap(new Map());
           setCommitMap(new Map());
+          setReturningMap(new Map());
         }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
@@ -620,6 +645,7 @@ export default function InventoryOverviewPage() {
               const prices = priceMap.get(r.sku_id);
               const rule = reorderMap.get(key);
               const commit = commitMap.get(key) ?? null;
+              const returningQty = returningMap.get(key) ?? 0;
               const isLow = rule != null && r.on_hand <= num(rule.reorder_point);
               const open = expanded === key;
               const out: React.ReactNode[] = [
@@ -661,6 +687,29 @@ export default function InventoryOverviewPage() {
                         title={`其中 ${fmtQty(r.reserved)} 件被 stock_balances.reserved 鎖住`}
                       >
                         (保留 {fmtQty(r.reserved)})
+                      </span>
+                    )}
+                    {/* 退貨中（2026-09-04 老闆裁示 2 乙案）：
+                        「先不扣 → 帳上還是 10，旁邊標『退貨中 3』讓人看得到」。
+                        ⚠ 這個數字**已經算在左邊的在庫裡**（乙案就是還沒扣），
+                          不是額外的、也不是被鎖住的 —— title 要把這件事講白，
+                          不然店員會以為在庫 10 只剩 7 能賣。
+                        ⚠ 大於在庫時轉紅：那代表總倉按同意時會扣不動而失敗
+                          （20260904020010 會擋下來），要讓人在庫存頁就看得到。 */}
+                    {returningQty > 0 && (
+                      <span
+                        className={`ml-1 text-[10px] ${
+                          returningQty > r.on_hand
+                            ? "font-semibold text-red-600 dark:text-red-400"
+                            : "text-amber-700 dark:text-amber-400"
+                        }`}
+                        title={
+                          returningQty > r.on_hand
+                            ? `已送出 ${fmtQty(returningQty)} 件退貨在等總倉回覆，但店裡帳上只剩 ${fmtQty(r.on_hand)} 件 —— 總倉按「同意收回」時會扣不動而失敗，請先確認貨還在。`
+                            : `已送出 ${fmtQty(returningQty)} 件退貨、還在等總倉回覆。這些件數還算在左邊的「在庫」裡（總倉同意的那一刻才會扣掉）。`
+                        }
+                      >
+                        (退貨中 {fmtQty(returningQty)})
                       </span>
                     )}
                     {isLow && (

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -40,6 +40,10 @@ const NAV: NavGroup[] = [
       //   分店要用，所以**不要**放進 BRANCH_HIDDEN_HREFS。
       { href: "/pos", label: "現場銷售", match: /^\/pos/ },
       { href: "/wms/inbound", label: "收貨", match: /^\/wms\/inbound|^\/transfers\/inbox/ },
+      // 退貨（2026-09-04）：店家要退回總倉的貨從這裡送出，總倉回覆與收貨差額進度也在這一頁。
+      // ⚠ match 不可以寫成 /^\/wms\/re/ 之類 —— 那會連 /wms/receiving（進貨待辦）一起點亮。
+      // ⚠ 刻意**不放**進 BRANCH_HIDDEN_HREFS：這一頁就是給分店用的。
+      { href: "/wms/returns", label: "退貨", match: /^\/wms\/returns/ },
       { href: "/members", label: "會員", match: /^\/members/ },
       { href: "/wms/transfers", label: "內部調撥", match: /^\/wms\/transfers|^\/transfers\/free|^\/transfers\/dispatch|^\/transfers$|^\/transfers\/?$/ },
       { href: "/restock", label: "補貨申請", match: /^\/restock(?!\/inbox)/ },

--- a/apps/admin/src/app/(protected)/wms/inbound/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/inbound/page.tsx
@@ -1744,7 +1744,12 @@ export default function TransfersInboxPage() {
             title="先跳出這批單對到的訂單勾選要配給誰,按「確認收貨」才完成收貨(限同一家分店)"
             className={`rounded-md border border-emerald-600 px-4 py-1.5 text-sm font-semibold text-emerald-700 hover:bg-emerald-50 disabled:cursor-not-allowed disabled:border-zinc-300 disabled:text-zinc-400 dark:text-emerald-400 dark:hover:bg-emerald-950 dark:disabled:border-zinc-700 dark:disabled:text-zinc-500 ${selectedStore ? "ml-auto" : ""}`}
           >
-            {`✋ 批次配單${selected.size > 0 ? ` (${selected.size})` : ""}`}
+            {/* ⛔ 字樣分兩邊,不要改成單一字串:分店只有這一顆(自動配已被上面
+                !selectedStore 藏掉),對店家來說它就是「收貨」(老闆 2026-08-22:
+                「合併成一顆,就寫收貨兩個字」);總倉同時看得到「✓ 批次收貨·自動配」,
+                兩顆都叫收貨會分不出來按哪顆 → 總倉端維持「✋ 批次配單」。
+                判準沿用同一顆自動配在用的 selectedStore,沒有新增任何邏輯。 */}
+            {`${selectedStore ? "收貨" : "✋ 批次配單"}${selected.size > 0 ? ` (${selected.size})` : ""}`}
           </SpinButton>
         </div>
       )}
@@ -2032,7 +2037,10 @@ export default function TransfersInboxPage() {
                       }
                       title="先跳出這批單對到的訂單勾選要配給誰,按「確認收貨」才完成收貨(取消=不收貨)"
                     >
-                      ✋ 配單{pendingCount > 1 ? ` ${pendingCount} 單` : ""}
+                      {/* ⛔ 同批次區:分店端這是唯一一顆 → 寫「收貨」;總倉端上面還有
+                          「✓ 收貨·自動配」→ 維持「✋ 配單」以免兩顆同名。
+                          判準用 gStore(上面藏自動配、下面切按鈕顏色都在用它)。 */}
+                      {`${gStore ? "收貨" : "✋ 配單"}${pendingCount > 1 ? ` ${pendingCount} 單` : ""}`}
                     </SpinButton>
                   </div>
                 )}
@@ -2330,7 +2338,10 @@ export default function TransfersInboxPage() {
                                     }
                                     title="勾選要配給誰、實收數量也在同一個視窗調,按「確認收貨」才完成收貨(取消=不收貨)"
                                   >
-                                    ✋ 配單
+                                    {/* ⛔ 同上:分店端只有這一顆(左邊自動配、右邊「✎ 調整」
+                                        都被 !storeForLocation 藏掉)→ 寫「收貨」;
+                                        總倉端三顆並排,維持「✋ 配單」才分得出來。 */}
+                                    {storeForLocation(t.dest_location) ? "收貨" : "✋ 配單"}
                                   </SpinButton>
                                   {/* 「✎ 調整」只留給總倉調撥(沒有配單視窗可用)；
                                       分店的實收調整已併進配單視窗 */}

--- a/apps/admin/src/app/(protected)/wms/returns/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/returns/page.tsx
@@ -1,0 +1,722 @@
+"use client";
+
+// 店家「退貨」頁（2026-09-04，老闆草圖版三段式）
+//
+// ① 發起退貨   ＋我要退貨 → 選商品＋數量 → 原因四選 → 送出
+// ② 進度列表   日期｜商品｜數量｜原因｜狀態｜總倉回覆（誰按的／自動）
+// ③ 收貨差額   店家回報過的少收／多給 → 總倉處理結果（唯讀，讀既有 shortage_resolution 家族）
+//
+// ⭐ 老闆 2026-09-04 裁示 2（乙案）：送出**不扣庫存**，總倉按「同意收回」那一刻才扣，
+//   不同意＝什麼都沒動過。後端三支：20260904020000／020010／020020。
+// ⭐ 老闆 2026-09-04 裁示 3：收貨差額的處理進度**搬進這一頁**一起看（＝③）。
+//
+// ⛔ 這一頁完全不改總倉端 —— 退貨單走既有的 return_to_hq 隊伍，
+//   總倉那兩顆鈕與 48 小時自動同意（20260903010020）零改動就吃得到。
+
+import { useEffect, useMemo, useState } from "react";
+import { LoadingBlock } from "@/components/Spinner";
+import { getSupabase } from "@/lib/supabase";
+import { fetchAllRows } from "@/lib/fetchAllRows";
+import { parseReturnNote } from "@/lib/returnNote";
+import { useUserBranchStoreId, useDefaultStoreFromUser } from "@/lib/useDefaultStoreFromUser";
+import SpinButton from "@/components/SpinButton";
+import StoreReturnCreateModal from "@/components/StoreReturnCreateModal";
+
+// 48h 自動同意寫的操作者就是這個全零 sentinel（20260903010020:129、:69）——
+// 「received_by = 全零 ⇒ 自動；其餘 ⇒ 有人按的」是那支檔自己定的判準，這裡逐字沿用。
+const SYSTEM_OPERATOR = "00000000-0000-0000-0000-000000000000";
+
+// ③ 差額只看最近這段時間，避免一次撈整間店的歷史。
+const DIFF_WINDOW_DAYS = 90;
+
+type StoreRow = { id: number; name: string; location_id: number | null };
+
+type TransferRow = {
+  id: number;
+  transfer_no: string;
+  status: string;
+  notes: string | null;
+  created_at: string;
+  shipped_at: string | null;
+  received_at: string | null;
+  received_by: string | null;
+  updated_by: string | null;
+  updated_at: string | null;
+  dest_location: number;
+};
+
+type ItemRow = {
+  id: number;
+  transfer_id: number;
+  sku_id: number | null;
+  qty_shipped: number;
+  qty_received: number | null;
+  out_movement_id: number | null;
+  shortage_resolution: string | null;
+  shortage_resolution_at: string | null;
+  shortage_resolution_by: string | null;
+  /**
+   * 「不同意退貨」把實收補回派出量**之前**的實收量（20260903000200:99 新增的欄位）。
+   * ⚠️ 只有 shortage_resolution === "reject_return" 的列上才有意義 —— 其他 resolution
+   * 的列 DB 一律寫 NULL，⛔ 不要拿它算別的東西（出處：ExceptionsContent.tsx:312-316、:693）。
+   */
+  shortage_prev_qty_received: number | null;
+  damage_qty: number | null;
+};
+
+type SkuRow = { id: number; sku_code: string | null; product_name: string | null; variant_name: string | null };
+
+// ⛔ 判準逐字對齊三個現成的地方，改了退貨單就會在總倉那邊消失：
+//   hq/inbox/page.tsx:189-191（那兩顆鈕的出現條件）
+//   wms/transfers/page.tsx:181-183（內部調撥頁的橘色標籤）
+//   20260903010020:143（48 小時自動同意的母體 LIKE '[order return%'）
+function isOrderReturn(notes: string | null): boolean {
+  return !!notes && notes.startsWith("[order return");
+}
+
+// 老闆逐字定的三種狀態字樣（需求暨計畫_店家退貨頁_2026-09-04.md:23）
+const STATUS_VIEW: Record<string, { label: string; cls: string }> = {
+  shipped: {
+    label: "🚚 等總倉",
+    cls: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  },
+  received: {
+    label: "✅ 已入倉",
+    cls: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+  },
+  cancelled: {
+    label: "❌ 不同意 · 自己收回",
+    cls: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+  },
+};
+
+// ③ 的處理結果字樣。
+//
+// ⭐⭐ 字樣的**正本在總倉端**：apps/admin/src/components/ExceptionsContent.tsx 的
+//   RESOLUTION_LABEL。店家看到的字必須跟總倉那個人按下去時看到的字一模一樣，
+//   不然兩邊會以為在講不同的事。
+//
+// 🔴 第一輪抄錯了版本：這個工地的基準是 7587aba7（#904），那時候 repo 裡的
+//   ExceptionsContent 還寫著老闆 2026-09-02 §刀2 明令禁用的那種「連字號」舊字樣，
+//   #906 已經把它改掉並上線了。
+//   ⚠️ 本檔刻意**連註解都不寫出那個舊字串**（寫法沿用 TransferShortageResolveModal:171），
+//     這樣驗證腳本掃「禁用字樣 0 次」才是真的 0。
+//   ⇒ 本輪改成照抄**已上線 main（1c35b0d1，含 #906）**的版本：
+//      git show main:apps/admin/src/components/ExceptionsContent.tsx  ← :206-233
+//      （鏡像庫 D:\1人公司\_備份_GitHub_20260831\new_erp.git，零網路撈得到）
+//   ⛔ label 的字**一個字都不要動**。驗證腳本會直接從那個鏡像撈出來逐字比對，
+//     改了就 FAIL。
+//   ⛔ 待辦（技術債）：#906 合併進本分支之後，這一份要改成從共用常數 import，
+//     不要長期留兩份。
+//
+// ⚠️ emoji 刻意**不寫進 label**，另外放 icon 欄位 —— label 要能跟正本逐字相等。
+// ⚠️ note 是我自己寫給店家看的白話，不是抄的；每一句都只留「不管出貨端是誰都成立」
+//   的話（③ 這一區的單有可能是總倉派的，也有可能是別家店調過來的）。
+//   ⛔ 所以不可以寫「總倉會再送一批」「照總倉送出去的數量算錢」這種把出貨端
+//     講死成總倉的句子 —— 那是 TransferShortageResolveModal 六審學到的同一課。
+const RESOLUTION_VIEW: Record<string, { icon: string; label: string; note: string; cls: string }> = {
+  redispatch: {
+    icon: "🔁",
+    label: "同意退・補貨",
+    note: "少收的數量以原出庫成本記回「原本送貨出去的那一邊」。",
+    cls: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+  },
+  restock_hq: {
+    icon: "🏭",
+    label: "同意退・不補貨",
+    note: "少收的數量以原出庫成本記回「原本送貨出去的那一邊」，不會自動再送給店家。",
+    cls: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+  },
+  reject_return: {
+    // ⛔ 不可以寫成「系統會去跟店家收錢」—— 沒有任何程式在加錢，
+    //   差別只在「沒有產生那張會扣錢的沖帳單」。
+    // ⚠️ 「實收被改成派出量」只改數字、不動庫存（20260903000200 那一段一筆
+    //   stock_movements 都沒寫）⇒ 不可以寫成「貨補進店裡的庫存」。
+    icon: "💰",
+    label: "不同意退貨-跟店家收錢",
+    note: "這一批照送出去的數量跟你們算錢（少收的部分不會退），你們的實收也被改成派出量 —— 只改數字，架上的貨沒有變多。",
+    cls: "bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-300",
+  },
+  over_ack: {
+    icon: "👍",
+    label: "多收知道了",
+    // 出處：rpc_ack_transfer_over（20260824020000:1571-1617）整支只有一個 UPDATE
+    //   transfer_items，**一筆庫存都不寫** —— 多出來那幾件是收貨當下就照實收入帳的。
+    note: "多出來的那幾件收貨當下就已經入你們店的帳了，總倉只是確認知道（這一步不動庫存）。",
+    cls: "bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-300",
+  },
+  // ── 以下 4 個是畫面已經不給按的舊值，但歷史資料還有（DB CHECK 仍允許八值：
+  //    20260903000020:44-49）⇒ 照正本的字樣顯示並標「（舊）」。
+  //    ⚠️⚠️ accept 與 reject_return **後端行為相同、語意相反**
+  //    （accept＝舊月結按實收收錢時代的「公司吃」；reject_return＝派出量制的「店家吃」），
+  //    ⛔ 兩者的說明絕對不可以寫成一樣（出處：ExceptionsContent.tsx:235-240）。
+  accept: {
+    icon: "",
+    label: "當作沒了（舊）",
+    note: "舊制的處理方式：那幾件當作沒了，當時是按實收算錢的（＝公司吸收）。現在畫面上已經沒有這顆鈕。",
+    cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+  },
+  vendor_claim: {
+    icon: "",
+    label: "供應商求償（舊）",
+    note: "舊制的處理方式，現在畫面上已經沒有這顆鈕。",
+    cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+  },
+  cancel_orders: {
+    icon: "",
+    label: "取消客戶訂單（舊）",
+    note: "舊制的處理方式，現在畫面上已經沒有這顆鈕。",
+    cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+  },
+  replenish: {
+    icon: "",
+    label: "補出貨（舊）",
+    note: "舊制的處理方式，現在畫面上已經沒有這顆鈕。",
+    cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+  },
+};
+
+function skuLabel(s: SkuRow | undefined, id: number | null): string {
+  if (!s) return id != null ? `品項#${id}` : "—";
+  return `${s.product_name ?? ""}${s.variant_name ? ` / ${s.variant_name}` : ""}`.trim() || (s.sku_code ?? `#${s.id}`);
+}
+
+function fmtDate(v: string | null): string {
+  return v ? new Date(v).toLocaleDateString("zh-TW") : "—";
+}
+function fmtDateTime(v: string | null): string {
+  return v ? new Date(v).toLocaleString("zh-TW") : "—";
+}
+function num(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export default function StoreReturnsPage() {
+  const [stores, setStores] = useState<StoreRow[]>([]);
+  const [storeId, setStoreId] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  // ② 的資料
+  const [returns, setReturns] = useState<TransferRow[]>([]);
+  const [returnItems, setReturnItems] = useState<ItemRow[]>([]);
+  // ③ 的資料
+  const [diffItems, setDiffItems] = useState<ItemRow[]>([]);
+  const [diffTransfers, setDiffTransfers] = useState<Map<number, TransferRow>>(new Map());
+  // 共用
+  const [skus, setSkus] = useState<Map<number, SkuRow>>(new Map());
+  const [names, setNames] = useState<Map<string, string>>(new Map());
+  const [onHand, setOnHand] = useState<Map<number, number>>(new Map());
+
+  const branchStoreId = useUserBranchStoreId(stores);
+  useDefaultStoreFromUser(stores, storeId, setStoreId);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data, error: e } = await getSupabase()
+        .from("stores")
+        .select("id, name, location_id")
+        .eq("is_active", true)
+        .order("name");
+      if (cancelled) return;
+      if (e) setError(e.message);
+      else setStores((data ?? []) as StoreRow[]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const store = useMemo(
+    () => stores.find((s) => String(s.id) === storeId) ?? null,
+    [stores, storeId],
+  );
+  const storeLoc = store?.location_id ?? null;
+
+  useEffect(() => {
+    if (storeLoc == null) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const TCOLS =
+          "id, transfer_no, status, notes, created_at, shipped_at, received_at, received_by, updated_by, updated_at, dest_location";
+
+        // ── ② 這家店送出的退貨單（含舊路徑那條，兩種 notes 都以 [order return 開頭）──
+        //
+        // 🔴 第一輪是「先撈最近 200 張 return_to_hq、再在前端濾 notes 前綴」。那是錯的：
+        //   9/01 起每一次「同意退回」都會自動產一張 return_to_hq 的**短收沖帳單**
+        //   （20260901000010:317-324、20260903000020:268、20260903000200:375），
+        //   出貨端剛好也寫這家店 ⇒ 它們跟真的退貨單搶同一個 200 張的名額。
+        //   一家店一天被總倉處理十幾筆短收，兩三個星期就能把 200 張吃光，
+        //   店家真正送出的退貨單**整批消失在畫面上**（而且什麼錯誤都不會報）。
+        // ⇒ 改成把前綴條件**下推到 SQL**，讓「最近 200 張」是從真退貨單裡數的。
+        //   `.like` 用 % 當萬用字元：本 repo 既有用法 stores/page.tsx:114
+        //   `q.like("code", "LELE-%")`。⛔ 前綴字串與 isOrderReturn / 總倉收件匣 /
+        //   48h cron 必須完全一致，驗證腳本 B 段會拿四邊互比。
+        const { data: retRaw, error: e1 } = await sb
+          .from("transfers")
+          .select(TCOLS)
+          .eq("transfer_type", "return_to_hq")
+          .eq("source_location", storeLoc)
+          .like("notes", "[order return%")
+          .order("id", { ascending: false })
+          .limit(200);
+        if (e1) throw new Error(e1.message);
+        // 第二層（同一個判準，前端再濾一次）：SQL 的 LIKE 與 JS 的 startsWith 對
+        // 「notes 是 NULL」等邊界的處理不完全一樣，留著這一層才不會有漏網的。
+        // ⚠️ 它**不是**第一輪那個「唯一的過濾」了 —— 現在真正在防漏單的是上面那行 .like。
+        const rets = ((retRaw ?? []) as TransferRow[]).filter((t) => isOrderReturn(t.notes));
+
+        // ── ③ 這家店收到的貨裡，實收 ≠ 派出的那些 ──
+        const since = new Date(Date.now() - DIFF_WINDOW_DAYS * 86400_000).toISOString();
+        const { data: diffTRaw, error: e2 } = await sb
+          .from("transfers")
+          .select(TCOLS)
+          .eq("dest_location", storeLoc)
+          .eq("status", "received")
+          .gte("received_at", since)
+          .order("id", { ascending: false })
+          .limit(500);
+        if (e2) throw new Error(e2.message);
+        const diffTs = (diffTRaw ?? []) as TransferRow[];
+
+        // ── 明細（兩段共用一次查詢；分頁走 fetchAllRows 避開 PostgREST 1000 列截斷）──
+        const allTIds = [...rets.map((t) => t.id), ...diffTs.map((t) => t.id)];
+        let items: ItemRow[] = [];
+        if (allTIds.length > 0) {
+          items = await fetchAllRows<ItemRow>(() =>
+            sb
+              .from("transfer_items")
+              .select(
+                "id, transfer_id, sku_id, qty_shipped, qty_received, out_movement_id, shortage_resolution, shortage_resolution_at, shortage_resolution_by, shortage_prev_qty_received, damage_qty",
+              )
+              .in("transfer_id", allTIds)
+              .order("id", { ascending: true }),
+          );
+        }
+        const retIdSet = new Set(rets.map((t) => t.id));
+        const diffIdSet = new Set(diffTs.map((t) => t.id));
+        const retItems = items.filter((it) => retIdSet.has(it.transfer_id));
+        // ③ 的母體。⚠️ 兩欄相減 PostgREST 做不到，只能撈回來自己比。
+        //
+        // 🔴 第一輪的條件只有「實收 ≠ 派出」，所以總倉按「不同意退貨」之後那一列會
+        //   **整列從店家畫面消失**：20260903000200:412 起 reject_return 會把
+        //   qty_received 補成 qty_shipped（舊值搬進 shortage_prev_qty_received）
+        //   ⇒ 差額變 0 ⇒ 被這個條件濾掉。
+        //   店家回報少收、總倉決定不同意（＝要照派出量跟他收錢），他卻只會看到
+        //   「那一列不見了」，什麼都不知道 —— 這正是要付錢的那一種結果。
+        // ⇒ 改成「有差額**或**有處理結果」都要顯示。
+        // ⭐ 撤銷（rpc_undo_transfer_item_shortage，20260903000200）會把
+        //   shortage_resolution 清成 NULL、把實收改回舊值 ⇒ 差額回來、resolution 沒了，
+        //   這一列自動回到「⏳ 未處理」，與總倉那一頁 #904 的行為一致。
+        const dItems = items.filter(
+          (it) =>
+            diffIdSet.has(it.transfer_id) &&
+            (num(it.qty_received) !== num(it.qty_shipped) || it.shortage_resolution != null),
+        );
+
+        // ── 商品名 ──
+        const skuIds = Array.from(
+          new Set([...retItems, ...dItems].map((it) => it.sku_id).filter((x): x is number => x != null)),
+        );
+        const skuMap = new Map<number, SkuRow>();
+        if (skuIds.length > 0) {
+          const rows = await fetchAllRows<SkuRow>(() =>
+            sb
+              .from("skus")
+              .select("id, sku_code, product_name, variant_name")
+              .in("id", skuIds)
+              .order("id", { ascending: true }),
+          );
+          for (const s of rows) skuMap.set(s.id, s);
+        }
+
+        // ── 店裡現在還有幾件（給「等總倉」那些單做扣不動的預警）──
+        const holdMap = new Map<number, number>();
+        if (skuIds.length > 0) {
+          const bals = await fetchAllRows<{ sku_id: number; on_hand: number }>(() =>
+            sb
+              .from("stock_balances")
+              .select("sku_id, on_hand")
+              .eq("location_id", storeLoc)
+              .in("sku_id", skuIds)
+              .order("sku_id", { ascending: true }),
+          );
+          for (const b of bals) holdMap.set(b.sku_id, num(b.on_hand));
+        }
+
+        // ── 誰按的（既有機制 rpc_get_staff_names，20260428170000，回 { id, display_name }）──
+        const uids = Array.from(
+          new Set(
+            [
+              ...rets.map((t) => (t.status === "cancelled" ? t.updated_by : t.received_by)),
+              ...dItems.map((it) => it.shortage_resolution_by),
+            ].filter((x): x is string => !!x && x !== SYSTEM_OPERATOR),
+          ),
+        );
+        const nameMap = new Map<string, string>();
+        if (uids.length > 0) {
+          const { data: ns } = await sb.rpc("rpc_get_staff_names", { p_uids: uids });
+          for (const n of (ns as { id: string; display_name: string }[] | null) ?? []) {
+            nameMap.set(n.id, n.display_name);
+          }
+        }
+
+        if (cancelled) return;
+        setReturns(rets);
+        setReturnItems(retItems);
+        setDiffItems(dItems);
+        setDiffTransfers(new Map(diffTs.map((t) => [t.id, t])));
+        setSkus(skuMap);
+        setNames(nameMap);
+        setOnHand(holdMap);
+        setError(null);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [storeLoc, reloadKey]);
+
+  const returnById = useMemo(() => new Map(returns.map((t) => [t.id, t])), [returns]);
+
+  // 每個 SKU「還在等總倉回覆、而且還沒扣過庫存」的總件數 —— 用來跟在庫比對，
+  // 比不過就代表總倉按同意時會扣不動（20260904020010 會擋下來），要當場提醒店家。
+  const pendingBySku = useMemo(() => {
+    const m = new Map<number, number>();
+    for (const it of returnItems) {
+      const t = returnById.get(it.transfer_id);
+      if (!t || t.status !== "shipped" || it.out_movement_id != null || it.sku_id == null) continue;
+      m.set(it.sku_id, (m.get(it.sku_id) ?? 0) + num(it.qty_shipped));
+    }
+    return m;
+  }, [returnItems, returnById]);
+
+  function replyOf(t: TransferRow): string {
+    if (t.status === "shipped") return "—";
+    if (t.status === "received") {
+      const who =
+        t.received_by === SYSTEM_OPERATOR
+          ? "自動（滿 48 小時沒人處理）"
+          : (t.received_by ? names.get(t.received_by) : null) ?? "總倉";
+      return `${who}・${fmtDateTime(t.received_at)}`;
+    }
+    if (t.status === "cancelled") {
+      const who = (t.updated_by ? names.get(t.updated_by) : null) ?? "總倉";
+      const m = (t.notes ?? "").match(/\[rejected:\s*([^\]]*)\]/);
+      const why = m && m[1].trim() ? `（${m[1].trim()}）` : "";
+      return `${who}${why}・${fmtDateTime(t.updated_at)}`;
+    }
+    return "—";
+  }
+
+  const branchLocked = branchStoreId != null;
+  const visibleStores = branchLocked ? stores.filter((s) => s.id === branchStoreId) : stores;
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">↩ 退貨</h1>
+          <p className="text-sm text-zinc-500">
+            要退回總倉的貨在這裡送出，總倉回你什麼也在這裡看。收貨數量對不上的處理進度在最下面。
+          </p>
+          <p className="mt-0.5 text-xs text-zinc-400">
+            送出<strong>不會</strong>馬上扣庫存 —— 帳上的數字不變，旁邊標「退貨中 N」；
+            總倉按「同意收回」那一刻才真的扣，不同意就什麼都沒動過。
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            value={storeId}
+            onChange={(e) => setStoreId(e.target.value)}
+            disabled={branchLocked}
+            className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm disabled:opacity-70 dark:border-zinc-700 dark:bg-zinc-800"
+          >
+            <option value="">— 選門市 —</option>
+            {visibleStores.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          <SpinButton
+            onClick={() => setShowCreate(true)}
+            disabled={storeLoc == null}
+            className="rounded-md bg-orange-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-orange-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
+          >
+            ＋ 我要退貨
+          </SpinButton>
+        </div>
+      </header>
+
+      {/* ⭐ 用 showCreate 決定「掛不掛上去」而不是只傳 open —— 關掉時整個 unmount，
+          彈窗裡選到一半的商品/數量/原因就跟著歸零，不必在元件裡再寫一段清空邏輯。 */}
+      {showCreate && store && storeLoc != null && (
+        <StoreReturnCreateModal
+          open
+          onClose={() => setShowCreate(false)}
+          onCreated={() => {
+            setShowCreate(false);
+            setReloadKey((k) => k + 1);
+          }}
+          storeId={store.id}
+          storeName={store.name}
+          storeLocationId={storeLoc}
+        />
+      )}
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {store == null ? (
+        <div className="rounded-md border border-zinc-200 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900">
+          請先在右上角選一家門市。
+        </div>
+      ) : storeLoc == null ? (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
+          「{store.name}」還沒設定倉庫位置（location），不能退貨。請聯繫總部。
+        </div>
+      ) : (
+        <>
+          {/* ── ② 進度列表 ── */}
+          <section className="flex flex-col gap-2">
+            <h2 className="text-base font-semibold">我送出的退貨</h2>
+            <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+              <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+                <thead className="bg-zinc-50 dark:bg-zinc-900">
+                  <tr className="text-left text-xs uppercase tracking-wide text-zinc-500">
+                    <th className="px-3 py-2">日期</th>
+                    <th className="px-3 py-2">單號</th>
+                    <th className="px-3 py-2">商品</th>
+                    <th className="px-3 py-2 text-right">數量</th>
+                    <th className="px-3 py-2">原因</th>
+                    <th className="px-3 py-2">狀態</th>
+                    <th className="px-3 py-2">總倉回覆</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                  {loading ? (
+                    <tr>
+                      <td colSpan={7}>
+                        <LoadingBlock />
+                      </td>
+                    </tr>
+                  ) : returnItems.length === 0 ? (
+                    <tr>
+                      <td colSpan={7} className="p-6 text-center text-zinc-500">
+                        還沒有送出過退貨。
+                      </td>
+                    </tr>
+                  ) : (
+                    returnItems.map((it) => {
+                      const t = returnById.get(it.transfer_id);
+                      if (!t) return null;
+                      const parsed = parseReturnNote(t.notes);
+                      const reasonText = parsed.isDamage ? "破損" : parsed.reason ?? "退貨";
+                      const sv = STATUS_VIEW[t.status] ?? {
+                        label: t.status,
+                        cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+                      };
+                      // 這一列會不會扣不動：只有「等總倉、而且還沒扣過」的才要問這件事
+                      const waiting = t.status === "shipped" && it.out_movement_id == null;
+                      const short =
+                        waiting &&
+                        it.sku_id != null &&
+                        (onHand.get(it.sku_id) ?? 0) < (pendingBySku.get(it.sku_id) ?? 0);
+                      return (
+                        <tr key={it.id} className="align-top">
+                          <td className="px-3 py-2 text-xs text-zinc-500">
+                            {fmtDate(t.shipped_at ?? t.created_at)}
+                          </td>
+                          <td className="px-3 py-2 font-mono text-xs">{t.transfer_no}</td>
+                          <td className="px-3 py-2 text-xs">
+                            {skuLabel(it.sku_id != null ? skus.get(it.sku_id) : undefined, it.sku_id)}
+                            {waiting ? (
+                              <span className="ml-2 inline-block rounded bg-amber-100 px-1 py-0.5 text-[10px] text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                                退貨中 · 還沒扣
+                              </span>
+                            ) : it.out_movement_id != null && t.status === "shipped" ? (
+                              <span
+                                className="ml-2 inline-block rounded bg-zinc-100 px-1 py-0.5 text-[10px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+                                title="這張是從「內部調撥 → ↩ 退貨回總倉」建的舊式退貨單，送出當下就把貨從店裡扣掉了"
+                              >
+                                送出時已扣
+                              </span>
+                            ) : null}
+                            {short && (
+                              <div className="mt-0.5 text-[11px] text-red-600 dark:text-red-400">
+                                ⚠ 店裡現在只剩 {onHand.get(it.sku_id!) ?? 0} 件，
+                                但還在等回覆的退貨有 {pendingBySku.get(it.sku_id!) ?? 0} 件 ——
+                                總倉按同意時會扣不動而失敗。請先把貨留回來。
+                              </div>
+                            )}
+                          </td>
+                          <td className="px-3 py-2 text-right tabular-nums">{num(it.qty_shipped)}</td>
+                          <td className="px-3 py-2 text-xs">{reasonText}</td>
+                          <td className="px-3 py-2">
+                            <span className={`inline-flex whitespace-nowrap rounded px-2 py-0.5 text-xs font-medium ${sv.cls}`}>
+                              {sv.label}
+                            </span>
+                          </td>
+                          <td className="px-3 py-2 text-xs text-zinc-500">{replyOf(t)}</td>
+                        </tr>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-[11px] text-zinc-400">
+              只列這家店送出的退貨（最近 200 張單）。⛔ 系統為了對帳自動產生的「短收沖帳單」不會列在這裡。
+            </p>
+          </section>
+
+          {/* ── ③ 收貨差額進度（唯讀）── */}
+          <section className="flex flex-col gap-2">
+            <h2 className="text-base font-semibold">收貨數量對不上的處理進度</h2>
+            <p className="text-xs text-zinc-500">
+              你們在「收貨」頁填的實收跟送貨那一邊派出的數量不一樣時，那筆差額會排到總倉那邊等處理。
+              這一區<strong>只能看</strong>，要處理是總倉那邊按。
+            </p>
+            <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+              <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+                <thead className="bg-zinc-50 dark:bg-zinc-900">
+                  <tr className="text-left text-xs uppercase tracking-wide text-zinc-500">
+                    <th className="px-3 py-2">收貨日</th>
+                    <th className="px-3 py-2">調撥單號</th>
+                    <th className="px-3 py-2">商品</th>
+                    {/* ⚠️ 這一區的單不一定是總倉派的（店↔店調撥也會進來，dest 是你們就算），
+                        所以欄位名不可以寫死「總倉派出」—— 同 P1-3 那一課。 */}
+                    <th className="px-3 py-2 text-right">派出量</th>
+                    <th className="px-3 py-2 text-right">你們實收</th>
+                    <th className="px-3 py-2 text-right">差額</th>
+                    <th className="px-3 py-2">總倉處理結果</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                  {loading ? (
+                    <tr>
+                      <td colSpan={7}>
+                        <LoadingBlock />
+                      </td>
+                    </tr>
+                  ) : diffItems.length === 0 ? (
+                    <tr>
+                      <td colSpan={7} className="p-6 text-center text-zinc-500">
+                        最近 {DIFF_WINDOW_DAYS} 天收的貨數量都對得上，沒有差額。
+                      </td>
+                    </tr>
+                  ) : (
+                    diffItems.map((it) => {
+                      const t = diffTransfers.get(it.transfer_id);
+                      // ⭐ 「不同意退貨」那一列的 qty_received 已經被後端補成 qty_shipped
+                      //   （20260903000200:412），現值算出來是 0 ⇒ 要顯示「當初少收幾件」
+                      //   必須用補回前的舊值。判準逐字對齊總倉那一頁
+                      //   （ExceptionsContent.tsx:693-697 的 baseRecv）。
+                      //   ⛔ 不要對所有 resolution 都套 prev：DB 只在 reject_return 的列上寫它。
+                      const rejected = it.shortage_resolution === "reject_return";
+                      const baseRecv =
+                        rejected && it.shortage_prev_qty_received != null
+                          ? num(it.shortage_prev_qty_received)
+                          : num(it.qty_received);
+                      const diff = baseRecv - num(it.qty_shipped);
+                      const rv = it.shortage_resolution ? RESOLUTION_VIEW[it.shortage_resolution] : undefined;
+                      const who = it.shortage_resolution_by ? names.get(it.shortage_resolution_by) : null;
+                      return (
+                        <tr key={it.id} className="align-top">
+                          <td className="px-3 py-2 text-xs text-zinc-500">{fmtDate(t?.received_at ?? null)}</td>
+                          <td className="px-3 py-2 font-mono text-xs">{t?.transfer_no ?? `#${it.transfer_id}`}</td>
+                          <td className="px-3 py-2 text-xs">
+                            {skuLabel(it.sku_id != null ? skus.get(it.sku_id) : undefined, it.sku_id)}
+                            {num(it.damage_qty) > 0 && (
+                              <span className="ml-2 text-[11px] text-zinc-500">（含破損 {num(it.damage_qty)}）</span>
+                            )}
+                          </td>
+                          <td className="px-3 py-2 text-right tabular-nums">{num(it.qty_shipped)}</td>
+                          <td className="px-3 py-2 text-right tabular-nums">
+                            {baseRecv}
+                            {/* 實收被總倉改過的話要講出來，不然店家會以為自己當初填錯了 */}
+                            {rejected && it.shortage_prev_qty_received != null && (
+                              <div className="text-[10px] font-normal text-zinc-400">
+                                （已被改成 {num(it.qty_shipped)}）
+                              </div>
+                            )}
+                          </td>
+                          <td
+                            className={`px-3 py-2 text-right tabular-nums font-medium ${
+                              diff < 0
+                                ? "text-red-600 dark:text-red-400"
+                                : diff > 0
+                                  ? "text-sky-700 dark:text-sky-400"
+                                  : "text-zinc-400"
+                            }`}
+                          >
+                            {diff > 0 ? `多收 +${diff}` : diff < 0 ? `少收 ${diff}` : "—"}
+                          </td>
+                          <td className="px-3 py-2">
+                            {rv ? (
+                              <>
+                                <span className={`inline-flex whitespace-nowrap rounded px-2 py-0.5 text-xs font-medium ${rv.cls}`}>
+                                  {rv.icon ? `${rv.icon} ` : ""}
+                                  {rv.label}
+                                </span>
+                                <div className="mt-0.5 text-[11px] text-zinc-500">{rv.note}</div>
+                                <div className="text-[11px] text-zinc-400">
+                                  {(who ?? "總倉")}・{fmtDateTime(it.shortage_resolution_at)}
+                                </div>
+                              </>
+                            ) : it.shortage_resolution ? (
+                              // 安全網：DB CHECK 現在的八個值 RESOLUTION_VIEW 都認得
+                              //（20260903000020:44-49）⇒ 這一支今天走不到。
+                              // 留著是因為哪天有人加了第九個值，店家會看到英文代碼但**不會白畫面**，
+                              // 而且看得出「總倉已經處理過了」。⛔ 不要在這裡自己編一套翻譯。
+                              <>
+                                <span className="inline-flex whitespace-nowrap rounded bg-zinc-100 px-2 py-0.5 text-xs text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+                                  {it.shortage_resolution}
+                                </span>
+                                <div className="mt-0.5 text-[11px] text-zinc-500">總倉處理過了，但這個畫面還不認得這種處理方式，請問總部。</div>
+                              </>
+                            ) : (
+                              <>
+                                <span className="inline-flex whitespace-nowrap rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                                  ⏳ 未處理
+                                </span>
+                                <div className="mt-0.5 text-[11px] text-zinc-500">總倉還沒回覆這一筆。</div>
+                              </>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-[11px] text-zinc-400">
+              只列最近 {DIFF_WINDOW_DAYS} 天、實收跟派出不一樣的品項；
+              總倉按了「不同意退貨」之後實收會被改成派出量（差額歸零），那幾列<strong>還是會留在這裡</strong>，
+              上面顯示的是被改之前的數字。
+            </p>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/components/ManualAllocateModal.tsx
+++ b/apps/admin/src/components/ManualAllocateModal.tsx
@@ -717,7 +717,14 @@ export function ManualAllocateModal({
     <Modal
       open
       onClose={onClose}
-      title={isReceive ? `✋ 配單 — ${storeName}` : `✋ 手動配單 — ${storeName}`}
+      title={
+        // ⛔ receive 分支寫「收貨」是對的,不要改回「配單」:receive 模式的唯一入口
+        // 是 inbound 的 openManualReceive,它在建 modal 前就先擋掉「目的地不是分店」
+        // (「這批單的目的地不是分店…」那句 alert)→ 進得來這裡的一定是分店,
+        // 而分店那顆入口鈕現在就寫「收貨」,標題跟著才不會按鈕寫收貨、點進去寫配單。
+        // store 分支(收完貨之後的「✋ 手動配單」常駐入口)總倉分店都用得到,維持原字。
+        isReceive ? `收貨 — ${storeName}` : `✋ 手動配單 — ${storeName}`
+      }
       maxWidth="max-w-4xl"
     >
       <div className="space-y-3">

--- a/apps/admin/src/components/StoreReturnCreateModal.tsx
+++ b/apps/admin/src/components/StoreReturnCreateModal.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Modal } from "@/components/Modal";
+import SpinButton from "@/components/SpinButton";
+import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
+
+// 店家退貨頁「＋ 我要退貨」彈窗。
+//
+// ⭐ 老闆 2026-09-04 裁示 2（乙案）：送出的那一刻**一筆庫存都不動** ——
+//   帳上還是原本的數字，旁邊標「退貨中 N」；總倉按「同意收回」那一刻才真的扣。
+//   後端是 rpc_create_store_return（20260904020000），前端不做任何庫存動作。
+//
+// ⛔ 這一支跟 OrderReturnCreateModal（內部調撥頁那顆橘色鈕）是**兩條不同的路**，
+//   不要合併：那一支必須先挑一張客人訂單、建單當下就扣庫存、而且會把客人訂單收尾
+//   （20260801000000:279-330）。本頁不綁訂單，所以那些事一件都不會發生。
+
+/** 老闆 2026-09-04 逐字定的四個原因。⛔ 後端 rpc_create_store_return 也有同一份白名單，要改兩邊一起改。 */
+const REASONS = ["少收", "破損", "過期", "客人退"] as const;
+type Reason = (typeof REASONS)[number];
+
+const REASON_HINT: Record<Reason, string> = {
+  少收: "這批貨總倉派了、但店裡沒收到那麼多。",
+  破損: "貨到店裡就是壞的、或在店裡壞掉了。",
+  過期: "效期到了賣不掉，要退回總倉。",
+  客人退: "客人買了又拿回來還。",
+};
+
+type SkuHit = {
+  id: number;
+  sku_code: string | null;
+  product_name: string | null;
+  variant_name: string | null;
+};
+
+type PickedLine = SkuHit & {
+  qty: number;
+  onHand: number;   // 店裡帳上有幾件
+  pending: number;  // 已經送出、還在等總倉回覆的件數
+};
+
+function skuLabel(s: SkuHit): string {
+  return `${s.product_name ?? ""}${s.variant_name ? ` / ${s.variant_name}` : ""}`.trim() || `#${s.id}`;
+}
+
+export default function StoreReturnCreateModal({
+  open,
+  onClose,
+  onCreated,
+  storeId,
+  storeName,
+  storeLocationId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (transferId: number) => void;
+  storeId: number;
+  storeName: string;
+  storeLocationId: number;
+}) {
+  const [search, setSearch] = useState("");
+  const [hits, setHits] = useState<SkuHit[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [lines, setLines] = useState<PickedLine[]>([]);
+  const [reason, setReason] = useState<Reason | "">("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // ⭐ 關掉要整個清空（不然下次打開會帶著上一次沒送出的東西，很容易送錯）——
+  //   做法是**由呼叫端在關閉時整個 unmount 這支元件**（wms/returns/page.tsx 用
+  //   `{showCreate && <StoreReturnCreateModal .../>}`），state 自然歸零。
+  //   ⛔ 不要改成「在 useEffect 裡逐一 setXxx 清掉」：那是多寫一段會壞掉的程式碼，
+  //     而且會踩 react-hooks/set-state-in-effect。
+
+  // 商品搜尋（編號 / 品名 / 規格），debounce 300ms —— 寫法沿用 AddStockModal:65-89
+  useEffect(() => {
+    const q = search.replace(/[,()%*]/g, " ").trim();
+    if (!open || !q) {
+      setHits([]);
+      return;
+    }
+    let cancelled = false;
+    setSearching(true);
+    const t = setTimeout(async () => {
+      const { data } = await getSupabase()
+        .from("skus")
+        .select("id, sku_code, product_name, variant_name")
+        .or(`sku_code.ilike.%${q}%,product_name.ilike.%${q}%,variant_name.ilike.%${q}%`)
+        .order("id", { ascending: false })
+        .limit(20);
+      if (!cancelled) {
+        setHits((data as SkuHit[]) ?? []);
+        setSearching(false);
+      }
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [search, open]);
+
+  async function pick(s: SkuHit) {
+    setError(null);
+    if (lines.some((l) => l.id === s.id)) {
+      setSearch("");
+      setHits([]);
+      return;
+    }
+    const sb = getSupabase();
+    // 在庫與「已經在等總倉回覆」的件數 —— 兩個數字都要，因為可退上限 = 在庫 − 退貨中。
+    // v_store_pending_returns 是 20260904020000 建的 view（母體定義寫在那支檔頭）。
+    const [{ data: bal }, { data: pend }] = await Promise.all([
+      sb
+        .from("stock_balances")
+        .select("on_hand")
+        .eq("location_id", storeLocationId)
+        .eq("sku_id", s.id)
+        .maybeSingle(),
+      sb
+        .from("v_store_pending_returns")
+        .select("pending_qty")
+        .eq("location_id", storeLocationId)
+        .eq("sku_id", s.id)
+        .maybeSingle(),
+    ]);
+    const onHand = Number((bal as { on_hand: number } | null)?.on_hand ?? 0);
+    const pending = Number((pend as { pending_qty: number } | null)?.pending_qty ?? 0);
+    const room = Math.max(onHand - pending, 0);
+    if (room <= 0) {
+      setError(
+        `「${skuLabel(s)}」現在退不了：店裡帳上有 ${onHand} 件，` +
+          `其中 ${pending} 件已經送出在等總倉回覆了。`,
+      );
+      return;
+    }
+    setLines((prev) => [...prev, { ...s, qty: 1, onHand, pending }]);
+    setSearch("");
+    setHits([]);
+  }
+
+  function setQty(skuId: number, raw: string) {
+    const v = Math.floor(Number(raw));
+    setLines((prev) =>
+      prev.map((l) =>
+        l.id === skuId
+          ? { ...l, qty: Number.isFinite(v) ? Math.max(0, Math.min(v, Math.max(l.onHand - l.pending, 0))) : 0 }
+          : l,
+      ),
+    );
+  }
+
+  const totalQty = useMemo(() => lines.reduce((a, l) => a + l.qty, 0), [lines]);
+  const canSubmit = !busy && reason !== "" && lines.length > 0 && lines.every((l) => l.qty > 0);
+
+  async function submit() {
+    // canSubmit 裡已經有 reason !== ""，TypeScript 會沿著它把型別收斂掉，
+    // 這裡再寫一次 reason === "" 會被判成永遠不成立的比較（TS2367）。
+    if (!canSubmit) return;
+    const summary = lines.map((l) => `　・${skuLabel(l)} × ${l.qty}`).join("\n");
+    if (
+      !confirm(
+        `送出退貨給總倉？\n\n店家：${storeName}\n原因：${reason}\n${summary}\n\n` +
+          `送出後庫存不會馬上扣 —— 帳上的數字不變，只是旁邊會標「退貨中」。\n` +
+          `總倉按「同意收回」的那一刻才真的扣；不同意的話什麼都不會動。`,
+      )
+    )
+      return;
+    setBusy(true);
+    setError(null);
+    try {
+      const sb = getSupabase();
+      const { data: sess } = await sb.auth.getSession();
+      const operator = sess.session?.user?.id;
+      if (!operator) throw new Error("尚未登入");
+      const { data: res, error: e } = await sb.rpc("rpc_create_store_return", {
+        p_store_id: storeId,
+        p_lines: lines.map((l) => ({ sku_id: l.id, qty: l.qty })),
+        p_reason: reason,
+        p_operator: operator,
+      });
+      if (e) throw new Error(translateRpcError(e));
+      const r = (res ?? {}) as { transfer_id?: number; transfer_no?: string };
+      alert(
+        `✅ 已送出退貨單 ${r.transfer_no ?? ""}（共 ${totalQty} 件）。\n\n` +
+          `庫存還沒扣 —— 要等總倉按「同意收回」。\n` +
+          `48 小時內總倉沒處理的話，系統會自動視同同意。`,
+      );
+      onCreated(Number(r.transfer_id ?? 0));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title="＋ 我要退貨（退回總倉）" maxWidth="max-w-2xl">
+      <div className="space-y-4 text-sm">
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        <div className="rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+          退貨店家：<strong className="text-zinc-800 dark:text-zinc-200">{storeName}</strong>
+        </div>
+
+        {/* ── 步驟 1：選商品 ── */}
+        <div>
+          <span className="mb-1 block text-xs font-medium text-zinc-500">1. 要退什麼商品</span>
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="🔍 搜尋 商品名 / 編號 / 規格…"
+            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
+          />
+          {(hits.length > 0 || searching) && (
+            <div className="mt-1 max-h-56 overflow-y-auto rounded-md border border-zinc-200 dark:border-zinc-700">
+              {searching && hits.length === 0 && (
+                <div className="px-3 py-2 text-xs text-zinc-500">搜尋中…</div>
+              )}
+              {hits.map((s) => (
+                <SpinButton
+                  key={s.id}
+                  onClick={() => pick(s)}
+                  className="block w-full border-b border-zinc-100 px-3 py-2 text-left last:border-b-0 hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-800"
+                >
+                  <span className="font-mono text-xs text-zinc-500">{s.sku_code}</span> {skuLabel(s)}
+                </SpinButton>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ── 步驟 2：數量 ── */}
+        {lines.length > 0 && (
+          <div>
+            <span className="mb-1 block text-xs font-medium text-zinc-500">2. 各退幾件</span>
+            <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-800">
+              <table className="min-w-full text-xs">
+                <thead className="bg-zinc-50 text-zinc-500 dark:bg-zinc-900">
+                  <tr>
+                    <th className="px-3 py-1.5 text-left">商品</th>
+                    <th className="px-3 py-1.5 text-right">店裡帳上</th>
+                    <th className="px-3 py-1.5 text-right">已在等回覆</th>
+                    <th className="px-3 py-1.5 text-right">這次退</th>
+                    <th className="px-3 py-1.5"></th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+                  {lines.map((l) => (
+                    <tr key={l.id}>
+                      <td className="px-3 py-1.5">
+                        <span className="font-mono text-[11px] text-zinc-500">{l.sku_code}</span>{" "}
+                        {skuLabel(l)}
+                      </td>
+                      <td className="px-3 py-1.5 text-right tabular-nums">{l.onHand}</td>
+                      <td className="px-3 py-1.5 text-right tabular-nums text-amber-700 dark:text-amber-400">
+                        {l.pending > 0 ? l.pending : "—"}
+                      </td>
+                      <td className="px-3 py-1.5 text-right">
+                        <input
+                          type="number"
+                          min={1}
+                          max={Math.max(l.onHand - l.pending, 0)}
+                          value={l.qty}
+                          onChange={(e) => setQty(l.id, e.target.value)}
+                          className="w-20 rounded-md border border-zinc-300 bg-white px-2 py-1 text-right tabular-nums dark:border-zinc-700 dark:bg-zinc-800"
+                        />
+                      </td>
+                      <td className="px-3 py-1.5 text-right">
+                        <SpinButton
+                          onClick={() => setLines((prev) => prev.filter((x) => x.id !== l.id))}
+                          className="text-xs text-zinc-500 underline"
+                        >
+                          移除
+                        </SpinButton>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="mt-1 text-[11px] text-zinc-500">
+              上限 ＝ 店裡帳上的件數 −「已在等回覆」的件數。
+            </p>
+          </div>
+        )}
+
+        {/* ── 步驟 3：原因 ── */}
+        <div>
+          <span className="mb-1 block text-xs font-medium text-zinc-500">3. 為什麼要退（選一個）</span>
+          <div className="flex flex-wrap gap-2">
+            {REASONS.map((r) => (
+              <SpinButton
+                key={r}
+                onClick={() => setReason(r)}
+                title={REASON_HINT[r]}
+                className={`rounded-md border px-3 py-1.5 text-sm ${
+                  reason === r
+                    ? "border-orange-500 bg-orange-50 font-semibold text-orange-700 dark:border-orange-600 dark:bg-orange-950 dark:text-orange-300"
+                    : "border-zinc-300 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                }`}
+              >
+                {r}
+              </SpinButton>
+            ))}
+          </div>
+          {reason !== "" && (
+            <p className="mt-1 text-[11px] text-zinc-500">{REASON_HINT[reason]}</p>
+          )}
+          {/* ⚠⚠ 「客人退」有兩種完全不同的情況，只有一種可以走這一頁。
+              查證（三處都是現行程式碼）：
+                ① 這一頁建的退貨單 customer_order_id 是 NULL（20260904020000 刻意的）；
+                ② 取貨守門只算「掛在同一張訂單上」的退貨
+                   （rpc_record_pickup 最新版 20260801000000:695 `t.customer_order_id = p_order_id`）；
+                ③ 訂單收尾與應收扣減同樣只吃掛訂單的退貨（同檔 :279-330）。
+              ⇒ 客人**還沒取**就不要了，走這一頁的話：訂單不會結掉、客人照樣被收錢、
+                 而且他還是可以來取貨 —— 那是實際會出事的，所以這裡要講出來。
+              ⛔ 這段話只是告訴店家走哪條路，**沒有**把「客人退」這個選項拿掉
+                 （四個原因是老闆 2026-09-04 逐字定的）。 */}
+          {reason === "客人退" && (
+            <p className="mt-1 rounded-md border border-amber-300 bg-amber-50 p-2 text-[11px] text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
+              ⚠ 這個選項是給「<strong>客人已經領走了、又拿回來還</strong>」用的。
+              <br />
+              如果是「客人還沒來領就說不要了」，<strong>請不要用這一頁</strong> ——
+              要到那張訂單上處理（退貨或轉給別人）。從這裡送出的話，那張訂單不會結掉、
+              客人照樣要付錢，而且他還是領得到貨。
+            </p>
+          )}
+          {reason === "少收" && (
+            <p className="mt-1 rounded-md border border-amber-300 bg-amber-50 p-2 text-[11px] text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
+              ⚠ 如果是<strong>某一張調撥單收到的數量不對</strong>，請直接在「收貨」頁把實收數字改對 ——
+              那條路總倉會看到差額、錢也會自動跟著算。這裡送出的是「把貨退回總倉」，兩邊都做會重複。
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <SpinButton
+            onClick={onClose}
+            className="rounded-md border border-zinc-300 px-4 py-2 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            取消
+          </SpinButton>
+          <SpinButton
+            onClick={submit}
+            disabled={!canSubmit}
+            className="rounded-md bg-orange-600 px-5 py-2 font-semibold text-white hover:bg-orange-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
+          >
+            {busy ? "送出中…" : `送出退貨（${totalQty} 件）`}
+          </SpinButton>
+        </div>
+
+        {/* ⚠ 這段講的是「按下去之後會發生什麼」，兩邊都講（做了會怎樣／不做會怎樣）。
+            每一句的出處：不扣庫存＝20260904020000 建單段刻意不呼叫 rpc_outbound；
+            同意才扣＝20260904020010；不同意零動作＝20260904020020；
+            48 小時＝20260903010020（cron jobid=5，老闆 2026-09-04 已貼上線）。 */}
+        <div className="rounded-md border border-zinc-200 bg-zinc-50 p-2 text-[11px] leading-relaxed text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+          送出之後會發生什麼：
+          <br />・庫存<strong>不會</strong>馬上扣，帳上的數字不變，只是旁邊多一個「退貨中 N」。
+          <br />・總倉按「同意收回」<strong>那一刻</strong>才真的從店裡扣掉、記進總倉。
+          <br />・總倉按「不同意退貨」＝什麼都沒動過，貨還是在店裡。
+          <br />・總倉 48 小時沒處理，系統會自動視同同意收回。
+          <br />・⚠ 送出之後如果把這批貨賣掉或給客人取走了，總倉按同意時會<strong>扣不動而失敗</strong>，
+          那張單會一直卡著。請把貨留著。
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/admin/src/components/TransferReceiveModal.tsx
+++ b/apps/admin/src/components/TransferReceiveModal.tsx
@@ -496,7 +496,14 @@ export function TransferReceiveModal({
                         : "rounded-md border border-emerald-600 px-3 py-1.5 text-xs font-semibold text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 dark:text-emerald-400 dark:hover:bg-emerald-950"
                     }
                   >
-                    ✋ 配單
+                    {/* 跟 inbound 三顆入口鈕同一套字樣規則(分店=收貨、總倉=配單)。
+                        hideAutoAllocate 就是呼叫端的 !!storeForLocation(dest),全庫
+                        只有 wms/inbound 一個呼叫點,所以它 = 「目的地是分店」。
+                        ⚠️ 誠實標註:這一段目前分店碰不到 —— 開這個彈窗的「✎ 調整」
+                        本身就被 !storeForLocation 藏起來(只有總倉看得到),
+                        所以實際跑起來這裡永遠走 false 分支。留條件式是為了
+                        以後真的開放分店進來時字樣自動對,不是現在會變的畫面。 */}
+                    {hideAutoAllocate ? "收貨" : "✋ 配單"}
                   </SpinButton>
                 )}
                 {isWaveDispatch ? (

--- a/supabase/migrations/20260904020000_store_return_create_no_stock.sql
+++ b/supabase/migrations/20260904020000_store_return_create_no_stock.sql
@@ -1,0 +1,469 @@
+-- ============================================================================
+-- 2026-09-04（店家退貨頁 · 第 1 支）：店家自建退貨單 —— 送出時「不動庫存」
+--
+-- ============================================================================
+-- 【一】老闆 2026-09-04 裁示 2（乙案），逐字錨定
+-- ============================================================================
+--   「先不扣 → 帳上還是 10，旁邊標『退貨中 3』讓人看得到；
+--     **總倉按同意的那一刻才真的扣**。不同意的話什麼都沒動過，乾乾淨淨」
+--     （出處：需求暨計畫_店家退貨頁_2026-09-04.md 第 10-11 行）
+--
+--   ⇒ 本檔負責「送出不扣」那一半。另外兩半在：
+--       20260904020010 —— 總倉同意（rpc_receive_transfer）那一刻才扣店家、入總倉
+--       20260904020020 —— 總倉不同意（rpc_reject_transfer）零庫存動作
+--
+-- ⛔⛔ 【三支必須一起貼，順序不可顛倒】
+--   1️⃣ 20260904020000（本檔：建單不扣）
+--   2️⃣ 20260904020010（同意才扣）
+--   3️⃣ 20260904020020（不同意零動作）
+--   只貼 1️⃣ 不貼 2️⃣ ＝ 店家退的貨會**憑空進總倉庫存**（店家那邊沒扣），總倉帳面虛胖。
+--   只貼 1️⃣ 不貼 3️⃣ ＝ 總倉按「不同意」時會對店家 rpc_inbound 一次，
+--                       而店家從來沒被扣過 ⇒ **憑空生貨**。
+--   ⇒ 三支要嘛一起貼，要嘛一支都不要貼。
+--
+-- ============================================================================
+-- 【二】做了會怎樣／不做會怎樣（兩邊都講）
+-- ============================================================================
+--   做了：店家送出退貨之後、總倉還沒回覆之前，店家帳上那幾件**還在**。
+--     ⇒ 好處：總倉不同意時，貨帳兩邊都不用回復，乾乾淨淨（老闆要的）。
+--     ⇒ 代價：等待期間店家帳面看起來比實際多。所以庫存頁那一格會標「退貨中 N」，
+--             退貨頁的進度列表也會即時比對「在庫 vs 退貨中」並示警。
+--     ⇒ 代價二：等待期間店家把那批貨賣掉／取貨掉，總倉按同意時會**扣不動而失敗**
+--             （處置見 20260904020010 檔頭【四】，那是本系統既有慣例，不是新規則）。
+--   不做（維持現行 rpc_create_order_return 建單即扣）：
+--     總倉還沒回答，貨已經從店家帳上消失；不同意的話要靠 rpc_reject_transfer
+--     再 inbound 回去 —— 貨帳來回搬，老闆原話「貨來來回回浪費時間」。
+--
+-- ============================================================================
+-- 【三】為什麼 notes 一定要以「[order return」開頭（⛔ 不可改字）
+-- ============================================================================
+--   總倉端那兩顆鈕與 48 小時自動同意**都是靠這個前綴認人的**，本檔照抄，
+--   才能做到老闆要的「總倉端零改動」：
+--     ① 畫面（hq/inbox/page.tsx:181-183 isOrderReturnTransfer、:2937-2959 兩顆鈕）
+--        ＝ notes.startsWith("[order return")
+--     ② 48h 自動同意（20260903010020:143）＝ COALESCE(t.notes,'') LIKE '[order return%'
+--   ⚠️ ②那支還在 PR #906、本檔基準（7587aba7）裡沒有它，但老闆 2026-09-04 已經把它
+--      貼進正式庫（cron jobid=5）⇒ 本檔建出來的單**上線當天就會被它掃到**。
+--   ⇒ 改這個前綴 ＝ 退貨單在總倉收件匣上完全消失、也不會自動同意。⛔ 不要改。
+--
+--   格式沿用 rpc_create_order_return（20260801000000:146-159）與前端解析器
+--   returnNote.ts 的既有約定：`[order return{|破損}{: 原因}]`
+--     少收   → [order return: 少收]      → 畫面顯示「退貨：少收」
+--     破損   → [order return|破損]        → 畫面顯示「退貨・破損」
+--     過期   → [order return: 過期]
+--     客人退 → [order return: 客人退]
+--   ⭐ 四個原因都是**系統固定字串**、沒有使用者自由文字進到方括號裡
+--      ⇒ returnNote.ts 的 regex（/^\[order return([^\]:]*)(?::\s*([^\]]*))?\]/）
+--        不可能被使用者輸入的 `]` 打斷。這比既有路徑（把 p_reason 塞進括號）更安全。
+--
+-- ============================================================================
+-- 【四】跟既有東西的關係（每一條都查過）
+-- ============================================================================
+--   ① ⛔ 不碰 rpc_create_order_return（20260801000000:59）。
+--      那條路（內部調撥頁 →「↩ 退貨回總倉」→ 必須先挑一張客人訂單）**照舊完整保留**，
+--      它建單即扣庫存、會做「全數退貨收尾」（把訂單推成 cancelled/completed）、
+--      取貨守門與應收扣減都吃它建的單。本檔是**另開一條**，不是取代。
+--      ⇒ 兩條路建出來的單 notes 都以 [order return 開頭，所以退貨頁的進度列表兩種都看得到。
+--
+--   ② customer_order_id 刻意留 NULL（本頁不綁訂單）。查證過三個下游都因此自動跳過：
+--      - rpc_receive_transfer 邏輯 B（20260827000000:256-265）條件是
+--        `v_customer_order_id IS NOT NULL` ⇒ 不會誤把別人的訂單推成 ready
+--        （這正是 20260903010020 檔頭第 22-31 行列為「連帶行為」的那一條，本頁天生沒有）
+--      - rpc_reject_transfer 的 return_to_hq 復原分支（20260827020000）條件同樣是
+--        v_co_id IS NOT NULL ⇒ 不會亂改訂單狀態
+--      - rpc_unreject_transfer（20260731000000:291-293）綁訂單才擋，本頁的單不受影響
+--        （但它另有一條限制，見 20260904020020 檔頭【五】）
+--
+--   ③ ⛔ 虛擬商品（products.is_virtual，自由轉貨的 MISC-01 之類）本頁一律拒收。
+--      理由：rpc_inbound 從 20260903000100:56-64 起對虛擬 SKU 直接 RETURN NULL、
+--      但 rpc_outbound（最新版 20260705000000:121）**沒有**同一道守衛
+--      ⇒ 若讓虛擬商品走本流程，同意時會變成「店家扣了、總倉沒進」＝ 只出不進，
+--        正好把 #902 才修好的「只進不出」倒過來再犯一次。
+--      擋在建單這一步最乾淨：店家在畫面上就看得到為什麼不能退。
+--
+--   ④ 9/01 起的「短收沖帳單」（20260901000010:317-324、20260903000020:268、
+--      20260903000200:370）也是 transfer_type='return_to_hq'，但它們
+--      **生而 status='received'、notes 以 '[短收沖帳]' 開頭、out_movement_id 指向原出庫**。
+--      ⇒ 本檔的 view 與退貨頁都用「status='shipped' ＋ notes LIKE '[order return%'」框母體，
+--        它們三種一個都框不進來。⛔ 這是刻意的：那是純記帳單，動到它就會做出錯帳。
+--
+-- ============================================================================
+-- 【五】Rollback
+-- ============================================================================
+--   DROP VIEW IF EXISTS public.v_store_pending_returns;
+--   DROP FUNCTION IF EXISTS public.rpc_create_store_return(BIGINT, JSONB, TEXT, UUID);
+--   ⚠️ 三支一組：要回就三支一起回（見上面【一】）。
+--   ⚠️ 已經建出來、還沒被總倉處理的單（status='shipped'、out_movement_id IS NULL）
+--     回滾後會變成「總倉一按同意就把貨憑空記進總倉」——
+--     所以回滾前要先把那些單處理掉或改成 cancelled。
+--
+-- ============================================================================
+-- 【六】2026-09-04 第二輪（阿審審查報告）改了兩處，都在本檔
+-- ============================================================================
+--   P0 店別守門：原本「空白身分不驗店」⇒ 有 tenant_id、沒有 role 的登入者可以
+--     指定同公司任一家店建退貨單，48h 自動同意後真的扣那家店的庫存。
+--     改成「只有總部三個角色可代操，其餘含空白身分一律驗 _jwt_store_ids()」。
+--     詳細出處寫在函式內店別守門那一段。
+--   P1 併發：原本沒有鎖，兩張單同時建可以各自看到舊的「已在等回覆」數字而都通過，
+--     加起來超過在庫 ⇒ 兩張都卡死在總倉。改成「先鎖 (店,SKU) 餘額列 → 重讀 → 才比」，
+--     鎖序與 20260904010000 家族一致。⚠️ 鎖只是排隊點，本檔**仍然一筆庫存都不寫**（乙案）。
+--
+-- 本檔不改任何既有函式、不改任何既有 view、不改任何 schema、無資料異動。
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. v_store_pending_returns —— 「退貨中 N」的唯一資料來源
+-- ----------------------------------------------------------------------------
+-- 給兩個地方用：庫存總覽那一格的「退貨中 N」小標、退貨頁的示警比對。
+-- ⭐ 用 out_movement_id IS NULL 當判準，不是用什麼旗標欄位：
+--   「有沒有出庫異動」就是「有沒有真的扣過」這件事本身，不會過期、不會被改壞。
+--   舊路徑（rpc_create_order_return）建的單一定有 out_movement_id
+--   （20260801000000:248-265 建單當下就寫）⇒ 它們不會被算進「退貨中」，
+--   這是對的：那些貨已經從店家帳上扣掉了，沒有「帳面比實際多」的問題要提醒。
+CREATE OR REPLACE VIEW public.v_store_pending_returns AS
+SELECT
+  t.tenant_id,
+  t.source_location             AS location_id,
+  ti.sku_id,
+  SUM(ti.qty_shipped)::NUMERIC  AS pending_qty,
+  COUNT(DISTINCT t.id)::INT     AS doc_count,
+  -- 2026-09-04 第二輪：擋下來的時候要講得出「被誰占著」，不然店家只看到一個數字，
+  -- 不知道要去看哪一張單。⭐ 單號從**同一個母體**算出來，⛔ 不要在別的地方
+  -- 另寫一份 WHERE 去撈單號 —— 那兩份遲早會漂移。
+  -- 寫法沿用既有的 20260702000010:39（同樣是 view 裡的 string_agg(DISTINCT …, … ORDER BY …)）；
+  -- 加 ORDER BY 是為了每次列出來的順序一樣，不然同一個錯誤訊息會忽前忽後。
+  STRING_AGG(DISTINCT t.transfer_no, '、' ORDER BY t.transfer_no)  AS doc_nos
+FROM public.transfers t
+JOIN public.transfer_items ti ON ti.transfer_id = t.id
+WHERE t.transfer_type = 'return_to_hq'
+  AND t.status        = 'shipped'          -- 已送出、總倉還沒回覆
+  AND COALESCE(t.notes, '') LIKE '[order return%'
+  AND ti.out_movement_id IS NULL           -- ＝ 還沒扣過店家庫存
+  AND ti.qty_shipped > 0
+  AND ti.sku_id IS NOT NULL
+GROUP BY t.tenant_id, t.source_location, ti.sku_id;
+
+GRANT SELECT ON public.v_store_pending_returns TO authenticated;
+
+COMMENT ON VIEW public.v_store_pending_returns IS
+  '每家店每個 SKU「已送出退貨、總倉還沒回覆、而且還沒扣過庫存」的件數（乙案）。'
+  '母體＝return_to_hq ＋ status=shipped ＋ notes 以 [order return 開頭 ＋ out_movement_id IS NULL。'
+  'doc_nos＝占著這些量的退貨單單號（給「退不了」的錯誤訊息指路用，與 pending_qty 同一個母體）。'
+  '⛔ 短收沖帳單（notes 以 [短收沖帳 開頭、生而 received）不在母體內，那是純記帳單。';
+
+-- ----------------------------------------------------------------------------
+-- 2. rpc_create_store_return —— 店家從商品下手建退貨單（不綁訂單、不動庫存）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_store_return(
+  p_store_id  BIGINT,
+  p_lines     JSONB,      -- [{"sku_id": 123, "qty": 3}, ...]
+  p_reason    TEXT,       -- 少收 / 破損 / 過期 / 客人退（四選一，⛔ 不吃自由文字）
+  p_operator  UUID DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  -- 角色與租戶：寫法逐字沿用 rpc_create_order_return（20260801000000:71-73）
+  v_tenant       UUID := public._current_tenant_id();
+  v_user         UUID := COALESCE(p_operator, auth.uid());
+  v_role         TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_store_loc    BIGINT;
+  v_store_name   TEXT;
+  v_hq_loc       BIGINT;
+  v_transfer_id  BIGINT;
+  v_transfer_no  TEXT;
+  v_line         JSONB;
+  v_sku_id       BIGINT;
+  v_qty          NUMERIC;
+  v_sku_label    TEXT;
+  v_on_hand      NUMERIC;
+  v_pending      NUMERIC;
+  v_pending_nos  TEXT;
+  v_lock         RECORD;   -- 2026-09-04 第二輪：預鎖用（(店, SKU) 去重排序）
+  v_need         RECORD;   -- 2026-09-04 第二輪：鎖到手之後逐 SKU 重驗用
+  v_notes        TEXT;
+  v_count        INT   := 0;
+  v_total_qty    NUMERIC := 0;
+  v_result_lines JSONB := '[]'::JSONB;
+BEGIN
+  -- 原因四選一（老闆 2026-09-04 逐字定：少收／破損／過期／客人退）
+  IF p_reason IS NULL OR p_reason NOT IN ('少收','破損','過期','客人退') THEN
+    RAISE EXCEPTION '退貨原因必須是「少收／破損／過期／客人退」其中一個，收到的是「%」',
+      COALESCE(p_reason, '(空白)');
+  END IF;
+
+  -- 角色白名單逐字沿用 rpc_create_order_return（20260801000000:99-101）。
+  -- ⚠️ 空字串仍在清單裡（＝進得了這道門），但它**不再是店別守門的例外**，見下面。
+  IF v_role NOT IN ('owner','admin','hq_manager','store_manager','store_staff','clerk','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot create store return', v_role;
+  END IF;
+
+  SELECT location_id, name INTO v_store_loc, v_store_name
+    FROM stores
+   WHERE id = p_store_id AND tenant_id = v_tenant;
+  IF v_store_loc IS NULL THEN
+    RAISE EXCEPTION '門市 % 沒有設定倉庫位置（location_id），無法建退貨單', p_store_id;
+  END IF;
+
+  -- ==========================================================================
+  -- 店別守門（2026-09-04 第二輪 · 阿審 P0）
+  -- ==========================================================================
+  -- 🔴 第一輪寫成「只有 store_manager/store_staff/clerk 才驗自己店」，那是照抄
+  --   rpc_create_order_return（20260801000000:139-143）的形狀 —— 但**抄錯了殺傷力**：
+  --   舊介面必須先挑一張既有的客人訂單，退的是那張單上的品項；本頁是**直接選店家、
+  --   直接選商品**，所以「空白身分不驗店」在這裡等於「有 tenant_id、沒有 role 的
+  --   登入者可以指定同公司任何一家店建退貨單」，48 小時自動同意
+  --   （20260903010020）之後就真的把那家店的庫存扣掉了。
+  --
+  -- ⇒ 本函式改成：**只有總部三個角色可以代任一家店操作，其餘（含空白身分）
+  --   一律要證明自己屬於該店。**
+  --
+  -- 「總部帳號可以代操」是本系統的既有慣例，不是我新開的口子，出處三處：
+  --   ① 20260831000000:60-61（_is_branch_scoped_user 的檔頭）：
+  --      「其餘（owner / admin / hq_manager / purchaser / assistant / '' legacy）都不鎖」
+  --   ② 20260826010000:56-58（_assert_stocktake_store_scope）：
+  --      「stores 為空的 legacy 帳號、含「總倉」者、HQ 角色不鎖」
+  --   ③ 20260714000090:93-98（rpc_create_restock_request）：
+  --      店端角色才比對 _jwt_store_ids()，HQ 角色直接過。
+  -- 「自己店」的推導同樣沿用 _jwt_store_ids()（20260707000070:26）——
+  --   本系統 JWT 沒有 store_id claim，只有 app_metadata.stores 的**店名**陣列。
+  --
+  -- ⚠️ 跟慣例不一樣的**那一點**（刻意的）：慣例把空白身分歸在「HQ 那一邊、不鎖」，
+  --   本函式把它歸在「要驗」那一邊。理由就是上面那段殺傷力差異。
+  --   ⇒ 代價：真的用空白身分的舊管理員帳號，在這一頁會被擋（訊息有講怎麼辦）。
+  --     不做的代價：任何一個 role 掉了的 token 都能扣別家店的庫存。兩者取後者。
+  -- ⛔ 舊函式 rpc_create_order_return 的同款寫法**本波不動**（那是別人的檔、
+  --   而且它必須先挑既有訂單，殺傷面小），已登記技術債。
+  IF v_role NOT IN ('owner','admin','hq_manager') THEN
+    IF NOT (p_store_id = ANY (public._jwt_store_ids())) THEN
+      RAISE EXCEPTION '這個帳號不能幫「%」建退貨單 —— 只有這家店自己的帳號、或總部帳號（owner／admin／hq_manager）可以。如果你就是這家店的人卻被擋，請總部確認你的帳號有掛到這家店。',
+        v_store_name;
+    END IF;
+  END IF;
+
+  -- 總倉 location 取法逐字沿用 rpc_create_order_return（20260801000000:122-131），
+  -- 也與 48h 自動同意的母體（20260903010020:149-156）同一個口徑：
+  -- type='central_warehouse' AND is_active ORDER BY id LIMIT 1（單數一個）。
+  SELECT id INTO v_hq_loc
+    FROM locations
+   WHERE tenant_id = v_tenant AND type = 'central_warehouse' AND is_active = TRUE
+   ORDER BY id LIMIT 1;
+  IF v_hq_loc IS NULL THEN
+    RAISE EXCEPTION '找不到啟用中的總倉，無法建退貨單';
+  END IF;
+  IF v_hq_loc = v_store_loc THEN
+    RAISE EXCEPTION '這個帳號的位置就是總倉，不能退貨給自己';
+  END IF;
+
+  IF p_lines IS NULL OR jsonb_array_length(p_lines) = 0 THEN
+    RAISE EXCEPTION '請至少選一項商品';
+  END IF;
+
+  -- ==========================================================================
+  -- 第 1 趟：**只檢查形狀、不讀庫存、不寫任何東西**
+  --
+  -- ⛔ 順序不可以顛倒成「先建單、邊檢查邊寫明細」（我第一版就是那樣，錯的）：
+  --   第 2 趟的防線要讀 v_store_pending_returns，而那個 view 的母體是
+  --   「status='shipped' ＋ notes 以 [order return 開頭 ＋ out_movement_id IS NULL」
+  --   —— 本單自己**完全符合**。單建下去、明細寫進去之後，同一個交易裡再讀那個 view，
+  --   就會把「這張單自己剛寫的行」也算成「已經在等回覆的量」
+  --   ⇒ 同一張單重複選到同一個商品時，第二行會被自己擋掉（而且訊息完全看不出原因）。
+  --   ⇒ 檢查全部做完才建單，順便也符合「要嘛整張成立、要嘛什麼都沒發生」。
+  -- ⭐ 2026-09-04 第二輪把「讀庫存比數量」整段搬到第 2 趟（鎖之後）——
+  --   在鎖之前讀到的數字隨時可能被別人改掉，比了也不算數。
+  -- ==========================================================================
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines)
+  LOOP
+    v_sku_id := (v_line ->> 'sku_id')::BIGINT;
+    v_qty    := (v_line ->> 'qty')::NUMERIC;
+
+    IF v_sku_id IS NULL OR v_qty IS NULL OR v_qty <= 0 THEN
+      RAISE EXCEPTION '品項資料不完整（商品 %、數量 %），請重新選一次', v_sku_id, v_qty;
+    END IF;
+
+    SELECT COALESCE(NULLIF(TRIM(COALESCE(s.product_name,'')
+             || COALESCE(' / ' || NULLIF(s.variant_name,''), '')), ''), s.sku_code)
+      INTO v_sku_label
+      FROM skus s
+     WHERE s.id = v_sku_id AND s.tenant_id = v_tenant;
+    IF v_sku_label IS NULL THEN
+      RAISE EXCEPTION '找不到商品 %（或不屬於本公司）', v_sku_id;
+    END IF;
+
+    -- ⛔ 虛擬商品擋在這裡，理由見檔頭【四】③
+    IF EXISTS (
+      SELECT 1 FROM skus s JOIN products p ON p.id = s.product_id
+       WHERE s.id = v_sku_id AND p.is_virtual
+    ) THEN
+      RAISE EXCEPTION '「%」是系統用的虛擬商品（沒有實體），不能用退貨頁退回總倉', v_sku_label;
+    END IF;
+
+    -- 檢查過的行先收進來，第 3 趟才真的寫（這一趟一個字都沒寫進資料庫）
+    v_result_lines := v_result_lines || jsonb_build_object(
+      'sku_id', v_sku_id,
+      'sku_label', v_sku_label,
+      'qty', v_qty
+    );
+    v_count     := v_count + 1;
+    v_total_qty := v_total_qty + v_qty;
+  END LOOP;
+
+  IF v_count = 0 THEN
+    RAISE EXCEPTION '請至少選一項商品';
+  END IF;
+
+  -- ==========================================================================
+  -- 第 2 趟：**先鎖再驗**（2026-09-04 第二輪 · 阿審 P1）
+  --
+  -- 🔴 第一輪是「讀 stock_balances → 讀 v_store_pending_returns → 比一比」，
+  --   全程沒有鎖。兩個人（或同一個人按兩次）同時對同一家店同一個商品送退貨，
+  --   兩邊都讀到「還沒有人在等」的舊數字、兩邊都通過，結果**加起來超過店裡有的量**
+  --   ⇒ 總倉按同意時扣不動，兩張單都卡死（48h cron 每 30 分鐘重試一次也一樣失敗）。
+  --
+  -- ⭐ 為什麼「鎖 stock_balances」擋得住「兩張 transfers 互相看不到」：
+  --   鎖是**排隊點**，不是要保護 stock_balances 本身（本函式一筆庫存都不寫，乙案）。
+  --   PostgreSQL 預設 READ COMMITTED 下，B 交易卡在 FOR UPDATE 等 A 提交，
+  --   放行之後 B **下一個 SELECT 會拿新的快照** ⇒ 讀 v_store_pending_returns 時
+  --   看得到 A 剛寫進去的那張單。⇒ 「鎖住 → 重讀 → 再比」這個順序不可以顛倒，
+  --   顛倒了就等於沒鎖。
+  --   ⚠️ 餘額列不存在時 FOR UPDATE 鎖不到東西（沒有排隊點）—— 但那代表 on_hand 視同 0，
+  --     下面一定擋下來（本次量 > 0），不會有漏網。同 20260904020010:233-234。
+  --
+  -- ⛔ 鎖序＝ORDER BY location_id, sku_id，與 20260904010000（✎修改實收）／010010（取貨）／
+  --   010020（現場銷售）／20260904020010（本案同意扣庫存）**完全一致**，
+  --   四支才不會各拿一半互相等（死鎖）。⛔ 只改一邊等於沒改。
+  -- ==========================================================================
+  FOR v_lock IN
+    SELECT DISTINCT v_store_loc AS location_id, (l ->> 'sku_id')::BIGINT AS sku_id
+      FROM jsonb_array_elements(p_lines) AS l
+     ORDER BY 1, 2
+  LOOP
+    PERFORM 1
+       FROM stock_balances
+      WHERE tenant_id   = v_tenant
+        AND location_id = v_lock.location_id
+        AND sku_id      = v_lock.sku_id
+      FOR UPDATE;
+  END LOOP;
+
+  -- 鎖到手才重讀、才比。⭐ 同一張單重複選到同一個商品要**先加總再比** ——
+  --   逐行比會讓「每一行看起來都夠、加起來卻不夠」整批漏過去
+  --   （同 20260904020010:252-254 那一課）。
+  -- ⚠️ 這道防線**不是**新規則，是把「總倉同意那一刻扣不動就會失敗」（20260904020010）
+  --   這件事提前講 —— 不擋的話店家可以退 100 件他只有 10 件的貨，
+  --   那張單會永遠卡在總倉那邊按不下去。
+  -- ⚠️ 它擋不住「送出之後才把貨賣掉」那一種（那要到同意那一刻才知道），
+  --   所以退貨頁的進度列表另外做了即時比對示警。
+  FOR v_need IN
+    SELECT g.sku_id,
+           g.need,
+           COALESCE(NULLIF(TRIM(COALESCE(s.product_name,'')
+             || COALESCE(' / ' || NULLIF(s.variant_name,''), '')), ''),
+             s.sku_code, '品項#' || g.sku_id::TEXT) AS sku_label
+      FROM (
+        SELECT (l ->> 'sku_id')::BIGINT      AS sku_id,
+               SUM((l ->> 'qty')::NUMERIC)   AS need
+          FROM jsonb_array_elements(p_lines) AS l
+         GROUP BY 1
+      ) g
+      LEFT JOIN skus s ON s.id = g.sku_id AND s.tenant_id = v_tenant
+     ORDER BY g.sku_id
+  LOOP
+    SELECT COALESCE(on_hand, 0) INTO v_on_hand
+      FROM stock_balances
+     WHERE tenant_id = v_tenant AND location_id = v_store_loc AND sku_id = v_need.sku_id;
+    v_on_hand := COALESCE(v_on_hand, 0);
+
+    SELECT COALESCE(pending_qty, 0), doc_nos
+      INTO v_pending, v_pending_nos
+      FROM v_store_pending_returns
+     WHERE tenant_id = v_tenant AND location_id = v_store_loc AND sku_id = v_need.sku_id;
+    v_pending := COALESCE(v_pending, 0);
+
+    IF v_on_hand < v_pending + v_need.need THEN
+      -- 大聲擋下、整筆回滾（一張單都沒建、一筆明細都沒寫）。
+      -- ⭐ 訊息要講得出「被誰占著」：只給數字的話，店家不知道要去看哪一張單。
+      RAISE EXCEPTION '「%」退不了：店裡帳上 % 件，其中 % 件已經在等總倉回覆（單號 %），這次要退 % 件 —— 最多只能再退 % 件。',
+        v_need.sku_label,
+        trim_scale(v_on_hand),
+        trim_scale(v_pending),
+        COALESCE(v_pending_nos, '無'),
+        trim_scale(v_need.need),
+        trim_scale(GREATEST(v_on_hand - v_pending, 0));
+    END IF;
+  END LOOP;
+
+  -- ==========================================================================
+  -- 第 3 趟：檢查全過了，這時候才建單
+  -- ==========================================================================
+
+  -- notes：⛔ 前綴與格式不可改，理由見檔頭【三】
+  v_notes := CASE WHEN p_reason = '破損'
+                  THEN '[order return|破損]'
+                  ELSE '[order return: ' || p_reason || ']'
+             END;
+
+  v_transfer_no := public._next_transfer_no();
+
+  -- 建單欄位寫法沿用 rpc_create_order_return（20260801000000:161-171），
+  -- 兩處刻意不同：
+  --   ① customer_order_id 留 NULL（本頁不綁訂單，理由見檔頭【四】②）
+  --   ② status 仍是 'shipped' —— 總倉那兩顆鈕與 48h cron 都只認 shipped，
+  --      改成別的狀態＝總倉收件匣上看不到這張單。
+  INSERT INTO transfers (
+    tenant_id, transfer_no, source_location, dest_location,
+    status, transfer_type, customer_order_id,
+    requested_by, shipped_by, shipped_at,
+    notes, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_transfer_no, v_store_loc, v_hq_loc,
+    'shipped', 'return_to_hq', NULL,
+    v_user, v_user, NOW(),
+    v_notes, v_user, v_user
+  ) RETURNING id INTO v_transfer_id;
+
+  -- ⭐⭐ 乙案核心：這裡**刻意什麼庫存都不寫**。
+  --   ⛔ 不呼叫 rpc_outbound（那是 rpc_create_order_return:248-257 在做的事）。
+  --   out_movement_id 留 NULL —— 它同時就是「還沒扣過」這件事的判準，
+  --   20260904020010（同意才扣）與 20260904020020（不同意零動作）都靠它認人。
+  --   ⛔ 誰要在這裡補上 rpc_outbound，請先讀老闆 2026-09-04 裁示 2（檔頭【一】）。
+  FOR v_line IN SELECT * FROM jsonb_array_elements(v_result_lines)
+  LOOP
+    INSERT INTO transfer_items (
+      transfer_id, sku_id, qty_requested, qty_shipped,
+      out_movement_id, created_by, updated_by
+    ) VALUES (
+      v_transfer_id,
+      (v_line ->> 'sku_id')::BIGINT,
+      (v_line ->> 'qty')::NUMERIC,
+      (v_line ->> 'qty')::NUMERIC,
+      NULL, v_user, v_user
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'transfer_id',  v_transfer_id,
+    'transfer_no',  v_transfer_no,
+    'store_id',     p_store_id,
+    'store_name',   v_store_name,
+    'reason',       p_reason,
+    'lines',        v_count,
+    'total_qty',    v_total_qty,
+    'stock_moved',  FALSE,     -- ⭐ 乙案：送出這一刻一筆庫存都沒動
+    'items',        v_result_lines
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_store_return(BIGINT, JSONB, TEXT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_store_return(BIGINT, JSONB, TEXT, UUID) IS
+  '店家退貨頁：從商品下手建 return_to_hq 退貨單，⛔ 送出時一筆庫存都不動（老闆 2026-09-04 乙案）。'
+  '庫存在總倉按「同意收回」那一刻才扣（20260904020010）；按「不同意」則零庫存動作（20260904020020）。'
+  'notes 以 [order return 開頭 ⇒ 總倉那兩顆鈕與 48h 自動同意（20260903010020）零改動就吃得到。'
+  'customer_order_id 留 NULL（不綁訂單）⇒ 不會誤動客人訂單狀態。'
+  '原因四選：少收／破損／過期／客人退。虛擬商品一律擋（rpc_outbound 沒有虛擬守衛、會只出不進）。'
+  '前置防線：先鎖 (店, SKU) 的 stock_balances 列、鎖到手才重讀在庫與「已在等回覆的量」，'
+  '在庫 < 已在等回覆 ＋ 本次量 → 擋（訊息含占著量的單號、最多還能退幾件）。鎖只為讀一致，不寫庫存。'
+  '店別守門：總部帳號（owner/admin/hq_manager）可代任一店；其餘含空白身分一律要通過 _jwt_store_ids()。';

--- a/supabase/migrations/20260904020010_accept_store_return_deducts_stock.sql
+++ b/supabase/migrations/20260904020010_accept_store_return_deducts_stock.sql
@@ -1,0 +1,681 @@
+-- ============================================================================
+-- 2026-09-04（店家退貨頁 · 第 2 支）：總倉「同意收回」的那一刻才扣店家庫存
+--
+-- ============================================================================
+-- 【一】老闆 2026-09-04 裁示 2（乙案），逐字錨定
+-- ============================================================================
+--   「先不扣 → 帳上還是 10，旁邊標『退貨中 3』讓人看得到；
+--     **總倉按同意的那一刻才真的扣**。不同意的話什麼都沒動過，乾乾淨淨」
+--     （出處：需求暨計畫_店家退貨頁_2026-09-04.md 第 10-11 行）
+--
+-- ⛔⛔ 【三支必須一起貼，順序不可顛倒】
+--   1️⃣ 20260904020000（建單不扣）→ 2️⃣ 本檔（同意才扣）→ 3️⃣ 20260904020020（不同意零動作）
+--   只貼 1️⃣ 不貼本檔 ＝ 店家退的貨會**憑空進總倉庫存**（店家那邊永遠不會被扣）。
+--
+-- ============================================================================
+-- 【二】為什麼非得改 rpc_receive_transfer 這支共用函式不可（我找過別條路）
+-- ============================================================================
+--   「同意收回」只有兩個入口，而兩個最後都走這一支：
+--     ① 總倉收件匣那顆鈕（單筆與批次都是）→ rpc_transfer_arrive_at_hq_batch
+--        （hq/inbox/page.tsx:1583-1586、:1752-1754）→ 該支 20260508000000:82
+--        `PERFORM rpc_receive_transfer(v_id, NULL, p_operator, NULL);`
+--     ② 48 小時自動同意（20260903010020:174-181）→ 直接 PERFORM rpc_receive_transfer
+--   ⇒ 掛在這一支，兩個入口一次到位，**總倉端前端一行都不用改**（老闆要的「零改動」）。
+--
+--   ⛔ 試過但走不通的三條：
+--     - 掛 trigger 在 transfers 狀態變更上：那個 UPDATE 在主迴圈**之後**（基底 :163），
+--       出庫異動晚一步建，總倉就會用 0 成本入庫（成本口徑沖成 0）。
+--     - 讓店家端自己先扣：那就是甲案，老闆已經否決。
+--     - 另外做一顆「同意」鈕：要改 hq/inbox/page.tsx，那支檔在 PR #906 手上（禁碰），
+--       而且違反老闆「總倉端零改動」。
+--
+-- ============================================================================
+-- 【三】改了什麼（基底逐字自證）
+-- ============================================================================
+--   基底＝ 20260827000000_receive_gate_only_batch_sku_orders.sql:30
+--     （用定義鏈查法自排確認：git grep -nE "CREATE (OR REPLACE )?FUNCTION (public\.)?rpc_receive_transfer"
+--       ⇒ 最後一支就是它；本機 12 個近期分支逐一掃過，沒有任何一支重定義它）
+--
+--   對基底做 diff：
+--     被刪／改的行 = **2 行**，而且都是同一件事 ——
+--         <          customer_order_id, next_transfer_id
+--         <          v_customer_order_id, v_next_transfer_id
+--       既有 7 個欄位與 7 個變數**一字未動**，只在尾巴各加一個 source_location /
+--       v_source_location（扣店家庫存要知道出貨端是哪一個位置，基底沒取這一欄）。
+--     其餘 diff 區塊全是 a（append）：DECLARE 加 8 個變數、主迴圈之前插入一段。
+--
+--   ⛔ 沒有動到的（Alex 與歷次修法的設計決定，逐字保留）：
+--     邏輯 A0（解除待補貨）／B（訂單推 ready）／C（取貨閘門前濾，20260827 的效能修法）／
+--     D（補貨申請狀態同步）／E（自動配單）／F（現貨池），以及多收放行、
+--     qty_received 寫法、notes append 規則、回傳欄位 —— 全部一字未改。
+--
+-- ============================================================================
+-- 【四】⚠️⚠️ 扣不動的時候會怎樣（做了會怎樣／不做會怎樣，兩邊都講）
+-- ============================================================================
+--   情境：店家送出退貨之後、總倉按同意之前，把那批貨賣掉或被客人取走了。
+--
+--   本檔的處置＝**大聲擋下、整筆回滾**（單維持待處理、貨與帳都沒動）。
+--   ⭐ 這不是我自己定的新規則，是本系統退貨路徑的**既有慣例**：
+--       rpc_outbound 預設 p_allow_negative=FALSE（20260705000000:156-166）本來就丟
+--       Insufficient stock；rpc_create_order_return 的 COMMENT（20260801000000:356）
+--       白紙黑字寫著「非 restock 路徑不夠店端庫存時由 rpc_outbound 擋 Insufficient stock」。
+--       本檔只是把訊息從英文換成店員看得懂的話，並且在扣之前先鎖再驗（不靠負庫存兜底）。
+--
+--   做了（擋下來）的代價：
+--     - 總倉那個人會看到「成功 0 / 失敗 1  #<單號>: 這張退貨單扣不動…」，這張單留在待處理。
+--     - 48 小時自動同意那支（20260903010020）每 30 分鐘會再試一次，每次都失敗，
+--       失敗被它自己的 EXCEPTION 收進 failed 清單裡 ⇒ **不會有人被通知**，
+--       這張單會一直卡著，直到店家把貨補回來或有人手動處理。
+--       ⚠️ 這一條請老闆知道。緩解做在店家端：退貨頁的進度列表會**即時**比對
+--       「店裡在庫 vs 這張單要退的量」，不夠時當場標紅字提醒店家先處理。
+--   不做（放行、允許扣成負）的代價：
+--     - 店家庫存變負數，而 on_hand 被全站好幾道閘門讀著（取貨閘門的實體側、
+--       現場銷售可賣量、派貨可配量）⇒ 會誤擋別人的取貨，變成更難查的問題。
+--     - 這正是 20260904010010／010020 那一組鎖在防的事，反著做等於把它推回去。
+--
+-- ============================================================================
+-- 【五】鎖：與 9/04 上午那三支同一家族、同一個鎖序（⛔ 要改就四支一起改）
+-- ============================================================================
+--   四支都是「ORDER BY location_id, sku_id 去重後逐列 FOR UPDATE、放在主迴圈之前」：
+--     20260904010000（✎修改實收）／20260904010010（取貨）／20260904010020（現場銷售）／本檔。
+--   順序不一致就會各拿一半互相等（死鎖）。⛔ 只改一邊等於沒改。
+--   ⚠️ 那三支在 PR #909 裡，本檔基準（7587aba7）沒有它們 —— 本檔**不依賴**它們，
+--     鎖序寫成一樣是為了它們合併之後不會打架。
+--
+-- ============================================================================
+-- 【六】確認過不會誤傷的三種既有單據
+-- ============================================================================
+--   ① 舊路徑退貨（rpc_create_order_return，內部調撥頁那顆橘色鈕）：
+--      建單當下就寫了 out_movement_id（20260801000000:248-265）
+--      ⇒ 新增那段的 EXISTS 為假、整段跳過，行為與上線前**一模一樣**。
+--   ② 短收沖帳單（20260901000010:317 / 20260903000020:268 / 20260903000200:370）：
+--      三種都生而 status='received'，進不了本函式（基底 :82-84 只收 shipped）。
+--   ③ 一般派貨／補貨／店對店（hq_to_store、store_to_store）：
+--      新增那段第一個條件就是 v_transfer_type = 'return_to_hq' ⇒ 碰都碰不到。
+--
+-- Rollback：CREATE OR REPLACE 回 20260827000000:30 的版本即可
+--   （本檔沒有動任何 schema、沒有新增欄位、沒有改 CHECK、沒有資料異動）。
+--   ⚠️ 三支一組：回滾任一支，乙案就變成半套（見【一】）。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_receive_transfer(p_transfer_id bigint, p_lines jsonb, p_operator uuid, p_notes text DEFAULT NULL::text, p_auto_allocate boolean DEFAULT true)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_tenant_id            UUID;
+  v_status               TEXT;
+  v_transfer_type        TEXT;
+  v_dest_location        BIGINT;
+  v_existing_notes       TEXT;
+  v_customer_order_id    BIGINT;
+  v_next_transfer_id     BIGINT;
+  v_item                 RECORD;
+  v_qty_received         NUMERIC;
+  v_unit_cost            NUMERIC;
+  v_in_mov_id            BIGINT;
+  v_total_qty            NUMERIC := 0;
+  v_total_variance       NUMERIC := 0;
+  v_items_received       INTEGER := 0;
+  v_lines_consumed       INTEGER := 0;
+  v_lines_count          INTEGER;
+  v_orders_advanced      INTEGER := 0;
+  v_next_shipped         BOOLEAN := FALSE;
+  v_leg2                 transfers%ROWTYPE;
+  v_leg2_item            RECORD;
+  v_leg2_mov             BIGINT;
+  v_dest_store_id        BIGINT;
+  v_restock_received     INTEGER := 0;
+  v_rr                   RECORD;
+  v_prog                 RECORD;
+  v_recv_skus            BIGINT[];   -- 20260811(3)：本次實收 > 0 的 SKU
+  v_backorders_freed     INTEGER := 0;   -- 20260811(6)：本次到貨解除的待補貨列數
+  v_sk                   RECORD;     -- 20260814(2)：逐 SKU 算本批多給
+  v_grown                NUMERIC;
+  v_surplus              JSONB := '[]'::jsonb;
+  v_gate_candidates      BIGINT[];   -- 20260827：邏輯 C 的前濾母體
+  -- ↓↓ 20260904020010 新增（店家退貨頁乙案：同意那一刻才扣店家庫存）
+  v_source_location      BIGINT;     -- 基底沒取這一欄，扣店家庫存要用
+  v_defer_lock           RECORD;
+  v_defer                RECORD;
+  v_defer_item           RECORD;
+  v_defer_on_hand        NUMERIC;
+  v_defer_mtype          TEXT;
+  v_defer_out_mov        BIGINT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('transfer:' || p_transfer_id));
+
+  SELECT tenant_id, status, transfer_type, dest_location, notes,
+         customer_order_id, next_transfer_id, source_location
+    INTO v_tenant_id, v_status, v_transfer_type, v_dest_location, v_existing_notes,
+         v_customer_order_id, v_next_transfer_id, v_source_location
+    FROM transfers
+   WHERE id = p_transfer_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transfer % not found', p_transfer_id;
+  END IF;
+
+  IF v_status <> 'shipped' THEN
+    RAISE EXCEPTION 'transfer % is in status %, expected shipped', p_transfer_id, v_status;
+  END IF;
+
+  IF p_lines IS NOT NULL THEN
+    v_lines_count := jsonb_array_length(p_lines);
+    IF EXISTS (
+      SELECT 1
+        FROM jsonb_array_elements(p_lines) AS l
+        LEFT JOIN transfer_items ti
+          ON ti.id = (l->>'transfer_item_id')::BIGINT
+         AND ti.transfer_id = p_transfer_id
+       WHERE ti.id IS NULL
+    ) THEN
+      RAISE EXCEPTION 'p_lines contains transfer_item_id not belonging to transfer %', p_transfer_id;
+    END IF;
+  END IF;
+
+  -- ==========================================================================
+  -- 20260904020010（店家退貨頁 · 乙案）：「同意收回」的那一刻才扣店家庫存
+  --   老闆 2026-09-04 原話：「總倉按同意的那一刻才真的扣」。
+  --   完整推導見檔頭。本檔唯一新增的行為就是這一段。
+  --
+  -- 為什麼一定要放在主迴圈**之前**：下面那個迴圈是靠
+  --   LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id 取 out_cost，
+  --   再用它當入總倉的成本（:132 v_unit_cost := COALESCE(ABS(v_item.out_cost), 0)）。
+  --   出庫異動晚一步建，總倉就會用 0 成本入庫 —— 短收沖帳單那支檔
+  --   （20260901000010）檔頭已經寫過同型的坑：「留白會讓成本口徑沖成 0」。
+  -- ==========================================================================
+  -- ⛔ 兩層 IF 不是多寫的：外層先用一個變數比對擋掉，裡面那個 EXISTS 才不會對
+  --   每一張 hq_to_store 派貨單都跑一次。這支函式是 8/27 那次 DB OOM 的主角
+  --   （檔頭:4-11 記著批次收貨單張 2,685ms），熱路徑上不可以無條件多一個子查詢。
+  IF v_transfer_type = 'return_to_hq' THEN
+   IF EXISTS (
+       SELECT 1 FROM transfer_items ti
+        WHERE ti.transfer_id = p_transfer_id
+          AND ti.out_movement_id IS NULL
+          AND ti.qty_shipped > 0
+          AND ti.sku_id IS NOT NULL
+     ) THEN
+
+    -- 舊路徑（rpc_create_order_return，20260801000000:248-265）建單當下就寫了
+    -- out_movement_id ⇒ 整段 EXISTS 為假、完全跳過，行為與本檔上線前一模一樣。
+    -- 短收沖帳單（20260901000010 / 20260903000020 / 20260903000200）生而 status='received'，
+    -- 進不了這支函式（:82-84 只收 shipped）⇒ 也碰不到這一段。
+
+    IF v_source_location IS NULL THEN
+      RAISE EXCEPTION '退貨單 % 沒有出貨端位置，無法扣店家庫存', p_transfer_id;
+    END IF;
+
+    -- ⛔ 這種單不接受「只收一部分」。
+    --   下面扣的是 qty_shipped 全額，而主迴圈會照 p_lines 決定總倉入幾件 ——
+    --   兩個數字不一樣的話，差額會**憑空從店家消失**（店家扣 10、總倉只進 8）。
+    --   今天沒有任何入口會走到這裡（總倉那顆鈕與 48h cron 都傳 p_lines = NULL，
+    --   出處 20260508000000:82、20260903010020:174-181），所以這道守衛擋不到任何現有流程；
+    --   它是留給「哪天有人給退貨單加了部分收貨」的那個人看的 —— 讓他當場失敗，
+    --   而不是讓庫存無聲無息少掉。
+    IF p_lines IS NOT NULL THEN
+      RAISE EXCEPTION '退貨單不支援「只收一部分」：這張單有還沒扣過店家庫存的品項，必須整張收（請不要帶 p_lines）。';
+    END IF;
+
+    -- 破損 / 一般退貨：tag 與 movement_type 的對應逐字沿用
+    -- rpc_create_order_return（20260801000000:95-97 的 CHECK、:149-151 的 tag）。
+    v_defer_mtype := CASE
+      WHEN COALESCE(v_existing_notes, '') LIKE '[order return|破損%' THEN 'damage'
+      ELSE 'customer_return'
+    END;
+
+    -- ① 預鎖：把這次會扣到的 (location_id, sku_id) 去重、**排序後**逐列鎖起來。
+    --    ⛔ ORDER BY location_id, sku_id 這個順序與 20260904010000（✎修改實收）、
+    --      20260904010010（取貨）、20260904010020（現場銷售）**完全一致**，
+    --      四支才不會各拿一半互相等（死鎖）。只改一邊等於沒改。
+    --    餘額列不存在時 FOR UPDATE 鎖不到東西 —— 那代表 on_hand 視同 0，
+    --    下面②一定擋下來，不會有漏網。
+    FOR v_defer_lock IN
+      SELECT DISTINCT v_source_location AS location_id, ti.sku_id
+        FROM transfer_items ti
+       WHERE ti.transfer_id = p_transfer_id
+         AND ti.out_movement_id IS NULL
+         AND ti.qty_shipped > 0
+         AND ti.sku_id IS NOT NULL
+       ORDER BY 1, 2
+    LOOP
+      PERFORM 1
+         FROM stock_balances
+        WHERE tenant_id   = v_tenant_id
+          AND location_id = v_defer_lock.location_id
+          AND sku_id      = v_defer_lock.sku_id
+        FOR UPDATE;
+    END LOOP;
+
+    -- ② 鎖到手才重驗夠不夠扣。⭐ 同一個 SKU 分散在多行時要**加總**再比 ——
+    --   逐行比會讓「每一行看起來都夠、加起來卻不夠」整批漏過去
+    --   （這是 20260904010010 第二輪學到的同一課，寫在那支的②③段）。
+    --   ⛔ 虛擬商品（is_virtual）整個跳過：rpc_inbound 從 20260903000100:56-64 起
+    --     對虛擬 SKU 直接 RETURN NULL，這裡若照扣就變成「店家扣了、總倉沒進」＝只出不進。
+    --     進出都不寫才是一致的。（建單那支 20260904020000 已經擋掉虛擬商品，
+    --     這裡是給歷史資料的第二層防線。）
+    FOR v_defer IN
+      SELECT ti.sku_id,
+             SUM(ti.qty_shipped) AS need,
+             COALESCE(NULLIF(TRIM(COALESCE(s.product_name,'')
+               || COALESCE(' / ' || NULLIF(s.variant_name,''), '')), ''),
+               s.sku_code, '品項#' || ti.sku_id::TEXT) AS sku_label
+        FROM transfer_items ti
+        LEFT JOIN skus s ON s.id = ti.sku_id
+       WHERE ti.transfer_id = p_transfer_id
+         AND ti.out_movement_id IS NULL
+         AND ti.qty_shipped > 0
+         AND ti.sku_id IS NOT NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM skus s2 JOIN products p2 ON p2.id = s2.product_id
+            WHERE s2.id = ti.sku_id AND p2.is_virtual
+         )
+       GROUP BY ti.sku_id, s.product_name, s.variant_name, s.sku_code
+       ORDER BY ti.sku_id
+    LOOP
+      SELECT COALESCE(on_hand, 0) INTO v_defer_on_hand
+        FROM stock_balances
+       WHERE tenant_id   = v_tenant_id
+         AND location_id = v_source_location
+         AND sku_id      = v_defer.sku_id;
+
+      IF COALESCE(v_defer_on_hand, 0) < v_defer.need THEN
+        -- ⛔ 大聲擋下、整筆回滾（＝這張單維持待處理、貨帳都沒動）。
+        --   這是本系統退貨路徑的**既有慣例**，不是新規則：
+        --   rpc_outbound 預設 p_allow_negative=FALSE（20260705000000:156-166）就會
+        --   丟 Insufficient stock，rpc_create_order_return 的 COMMENT
+        --   （20260801000000:356）白紙黑字寫著「非 restock 路徑不夠店端庫存時
+        --   由 rpc_outbound 擋 Insufficient stock」。這裡只是把訊息換成店家看得懂的話。
+        --   ⭐ 訊息刻意不帶前綴（像 stock_short:）—— rpcError.ts 在 PR #909 裡，本波不碰，
+        --     加了前綴店員會看到掛在句子前面的英文。批次那層（rpc_transfer_arrive_at_hq_batch
+        --     20260508000000:84-87）會把它包成「#<單號id>: <訊息>」顯示，單號那半不用自己寫。
+        RAISE EXCEPTION '這張退貨單扣不動：「%」店裡現在只有 % 件、這張單要退 % 件。貨可能已經賣掉或被客人取走了 —— 這張單維持在待處理，庫存與帳都沒有變動。',
+          v_defer.sku_label,
+          trim_scale(COALESCE(v_defer_on_hand, 0)), trim_scale(v_defer.need);
+      END IF;
+    END LOOP;
+
+    -- ③ 逐行真的扣。走 rpc_outbound（不是自己 INSERT）＝ 白吃它既有的
+    --   可用量守衛與 avg_cost 取價，成本才會跟著這批貨進總倉。
+    FOR v_defer_item IN
+      SELECT ti.id, ti.sku_id, ti.qty_shipped
+        FROM transfer_items ti
+       WHERE ti.transfer_id = p_transfer_id
+         AND ti.out_movement_id IS NULL
+         AND ti.qty_shipped > 0
+         AND ti.sku_id IS NOT NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM skus s2 JOIN products p2 ON p2.id = s2.product_id
+            WHERE s2.id = ti.sku_id AND p2.is_virtual
+         )
+       ORDER BY ti.id
+    LOOP
+      v_defer_out_mov := rpc_outbound(
+        p_tenant_id       => v_tenant_id,
+        p_location_id     => v_source_location,
+        p_sku_id          => v_defer_item.sku_id,
+        p_quantity        => v_defer_item.qty_shipped,
+        p_movement_type   => v_defer_mtype,
+        p_source_doc_type => 'transfer',
+        p_source_doc_id   => p_transfer_id,
+        p_operator        => p_operator
+      );
+
+      UPDATE transfer_items
+         SET out_movement_id = v_defer_out_mov,
+             updated_by      = p_operator
+       WHERE id = v_defer_item.id;
+    END LOOP;
+   END IF;
+  END IF;
+
+  -- ===== 原有邏輯：寫 qty_received + dest_location inbound =====
+  FOR v_item IN
+    SELECT ti.id, ti.sku_id, ti.qty_shipped, sm.unit_cost AS out_cost
+      FROM transfer_items ti
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE ti.transfer_id = p_transfer_id
+     ORDER BY ti.id
+  LOOP
+    v_qty_received := v_item.qty_shipped;
+
+    IF p_lines IS NOT NULL THEN
+      SELECT (l->>'qty_received')::NUMERIC
+        INTO v_qty_received
+        FROM jsonb_array_elements(p_lines) AS l
+       WHERE (l->>'transfer_item_id')::BIGINT = v_item.id
+       LIMIT 1;
+
+      IF FOUND THEN
+        v_lines_consumed := v_lines_consumed + 1;
+      ELSE
+        v_qty_received := v_item.qty_shipped;
+      END IF;
+    END IF;
+
+    IF v_qty_received IS NULL OR v_qty_received < 0 THEN
+      RAISE EXCEPTION 'transfer_item % qty_received must be >= 0, got %', v_item.id, v_qty_received;
+    END IF;
+    -- 20260824020000：允許多收（實收 > 派出）。總倉實際多裝了就照實入庫，
+    -- 差異走 v_hq_exceptions 的 transfer_over 分支回報總倉（同短少那套收件匣）。
+    -- 上限守衛拿掉的是「帳跟不上實物」的錯：擋下來店家只能少報，貨照樣在店裡。
+
+    IF v_qty_received > 0 THEN
+      v_unit_cost := COALESCE(ABS(v_item.out_cost), 0);
+
+      v_in_mov_id := rpc_inbound(
+        p_tenant_id       => v_tenant_id,
+        p_location_id     => v_dest_location,
+        p_sku_id          => v_item.sku_id,
+        p_quantity        => v_qty_received,
+        p_unit_cost       => v_unit_cost,
+        p_movement_type   => 'transfer_in',
+        p_source_doc_type => 'transfer',
+        p_source_doc_id   => p_transfer_id,
+        p_operator        => p_operator
+      );
+
+      UPDATE transfer_items
+         SET qty_received   = v_qty_received,
+             in_movement_id = v_in_mov_id,
+             updated_by     = p_operator
+       WHERE id = v_item.id;
+    ELSE
+      UPDATE transfer_items
+         SET qty_received = 0,
+             updated_by   = p_operator
+       WHERE id = v_item.id;
+    END IF;
+
+    v_total_qty      := v_total_qty + v_qty_received;
+    v_total_variance := v_total_variance + (v_qty_received - v_item.qty_shipped);
+    v_items_received := v_items_received + 1;
+  END LOOP;
+
+  UPDATE transfers
+     SET status      = 'received',
+         received_by = p_operator,
+         received_at = NOW(),
+         notes       = CASE
+                         WHEN p_notes IS NULL OR p_notes = '' THEN v_existing_notes
+                         WHEN v_existing_notes IS NULL OR v_existing_notes = '' THEN p_notes
+                         ELSE v_existing_notes || E'\n' || p_notes
+                       END,
+         updated_by  = p_operator
+   WHERE id = p_transfer_id;
+
+  -- ===== 邏輯 A0（20260811(6)）：本次到貨 → 解除待補貨 =====
+  -- 少發配貨（rpc_allocate_shortage）把沒配到的品項標 backorder_at，取貨閘門
+  -- 因此回 false。在這支之前，全 DB 沒有任何路徑會在「補的那批貨到店」時把它
+  -- 清掉 —— 補出第二批、店家收了貨，品項還是掛「待補貨」，要有人記得回收貨頁
+  -- 再點一次「⚖️ 配貨」才解得開。
+  --
+  -- **必須排在邏輯 A/B/C/E 之前**：邏輯 C 的 is_order_pickup_ready() 與
+  -- 邏輯 E 的 _advance_arrived_confirmed_orders 都含 backorder_at IS NULL，
+  -- 先解除才推得動單頭；順序反了這批單要等下一次收貨才會動。
+  --
+  -- 20260813：手動配單模式（p_auto_allocate = FALSE）**仍照跑** —— 這是
+  -- 「先前⚖️配貨決定」的完成、有帳面+實體雙守衛，不是新的配單決策；
+  -- 關掉會重演松山單卡 6 天災情。要重新決定配給誰請用 ⚖️ 配貨。
+  IF v_transfer_type = 'hq_to_store' THEN
+    SELECT id INTO v_dest_store_id
+      FROM stores
+     WHERE tenant_id = v_tenant_id
+       AND location_id = v_dest_location
+     LIMIT 1;
+
+    SELECT ARRAY_AGG(DISTINCT ti.sku_id)
+      INTO v_recv_skus
+      FROM transfer_items ti
+     WHERE ti.transfer_id = p_transfer_id
+       AND ti.qty_received > 0;
+
+    IF v_dest_store_id IS NOT NULL AND v_recv_skus IS NOT NULL THEN
+      v_backorders_freed := public._settle_arrived_backorders(
+        v_dest_store_id, v_recv_skus, p_operator, NOW());
+    END IF;
+  END IF;
+
+  -- ===== 邏輯 A：自動 ship 下一段（aid chain B 模型）=====
+  IF v_next_transfer_id IS NOT NULL THEN
+    SELECT * INTO v_leg2 FROM transfers
+     WHERE id = v_next_transfer_id FOR UPDATE;
+
+    IF v_leg2.id IS NOT NULL AND v_leg2.status = 'draft' THEN
+      FOR v_leg2_item IN
+        SELECT ti.id AS leg2_item_id, ti.sku_id, ti2.qty_received
+          FROM transfer_items ti
+          JOIN transfer_items ti2
+            ON ti2.transfer_id = p_transfer_id AND ti2.sku_id = ti.sku_id
+         WHERE ti.transfer_id = v_leg2.id
+      LOOP
+        IF v_leg2_item.qty_received > 0 THEN
+          v_leg2_mov := rpc_outbound(
+            p_tenant_id       => v_leg2.tenant_id,
+            p_location_id     => v_leg2.source_location,
+            p_sku_id          => v_leg2_item.sku_id,
+            p_quantity        => v_leg2_item.qty_received,
+            p_movement_type   => 'transfer_out',
+            p_source_doc_type => 'transfer',
+            p_source_doc_id   => v_leg2.id,
+            p_operator        => p_operator
+          );
+          UPDATE transfer_items
+             SET qty_shipped     = v_leg2_item.qty_received,
+                 qty_requested   = v_leg2_item.qty_received,
+                 out_movement_id = v_leg2_mov,
+                 updated_by      = p_operator
+           WHERE id = v_leg2_item.leg2_item_id;
+        ELSE
+          UPDATE transfer_items
+             SET qty_shipped   = 0,
+                 qty_requested = 0,
+                 updated_by    = p_operator
+           WHERE id = v_leg2_item.leg2_item_id;
+        END IF;
+      END LOOP;
+
+      UPDATE transfers
+         SET status      = 'shipped',
+             shipped_by  = p_operator,
+             shipped_at  = NOW(),
+             updated_by  = p_operator
+       WHERE id = v_leg2.id;
+      v_next_shipped := TRUE;
+    END IF;
+  END IF;
+
+  -- ===== 邏輯 B：aid 單 FK 直接推 customer_order → ready =====
+  IF v_customer_order_id IS NOT NULL THEN
+    UPDATE customer_orders
+       SET status     = 'ready',
+           ready_at   = NOW(),
+           updated_by = p_operator,
+           updated_at = NOW()
+     WHERE id = v_customer_order_id
+       AND status = 'shipping';
+    GET DIAGNOSTICS v_orders_advanced = ROW_COUNT;
+
+  -- ===== 邏輯 C：hq_to_store wave transfer → 推該分店訂單 → ready =====
+  -- 修：不再無條件推該店「所有」shipping 訂單；改成只推
+  --     is_order_pickup_ready=true（依該訂單的團真的到齊、shortage-aware）的訂單，
+  --     避免收到別團波次時把尚未出貨的團一起誤標為可取貨。
+  ELSIF v_transfer_type = 'hq_to_store' THEN
+    SELECT id INTO v_dest_store_id
+      FROM stores
+     WHERE tenant_id = v_tenant_id
+       AND location_id = v_dest_location
+     LIMIT 1;
+
+    -- 20260827000000：只對「有本批 SKU active 品項」的派貨中訂單跑閘門。
+    -- 閘門 ~8ms/張、原本逐張調撥單掃該店**全部** shipping 單（實測松山 236 張
+    -- ＝每張調撥單 ~2 秒；批次收 8~14 張 = 16~27 秒，8/27 把 1GB 機器壓掛的主因）。
+    -- 收貨只改變本批 SKU 的到貨／庫存事實，沒含這些 SKU 的訂單閘門結果與收貨前
+    -- 相同，濾掉語意不變；歷史卡住的單改由「收到它的 SKU 那批」或手動 ⚖️ 配貨
+    -- 觸發。v_recv_skus 為 NULL（本批零實收）整段跳過。
+    -- **一定要兩步走**：前濾寫成同一句的 IN (子查詢) 時 planner 會把閘門函式
+    -- 下推到 customer_orders 掃描層、先於 semi-join 執行（實測 2.4s，等於沒濾），
+    -- 先收斂成陣列再 UPDATE 就沒有重排空間。
+    IF v_dest_store_id IS NOT NULL AND v_recv_skus IS NOT NULL THEN
+      SELECT COALESCE(ARRAY_AGG(DISTINCT coi.order_id), '{}'::BIGINT[])
+        INTO v_gate_candidates
+        FROM customer_orders co
+        JOIN customer_order_items coi ON coi.order_id = co.id
+       WHERE co.tenant_id       = v_tenant_id
+         AND co.pickup_store_id = v_dest_store_id
+         AND co.status          = 'shipping'
+         AND coi.status IN ('pending','reserved','ready')
+         AND coi.sku_id = ANY (v_recv_skus);
+
+      IF cardinality(v_gate_candidates) > 0 THEN
+        WITH advanced AS (
+          UPDATE customer_orders co
+             SET status     = 'ready',
+                 ready_at   = NOW(),
+                 updated_by = p_operator,
+                 updated_at = NOW()
+           WHERE co.id = ANY (v_gate_candidates)
+             AND co.status = 'shipping'
+             AND public.is_order_pickup_ready(co.id)
+          RETURNING co.id
+        )
+        SELECT COUNT(*) INTO v_orders_advanced FROM advanced;
+      END IF;
+    END IF;
+  END IF;
+
+  -- ===== 邏輯 D：linked 補貨申請 → 已收貨；ride-along 單 → ready =====
+  -- 店家收貨即補貨流程終點：把 linked_transfer_id 指向本單的補貨申請
+  -- 推到 received。approved_transfer 為 legacy 防禦（現行直派皆直接 shipped）。
+  FOR v_rr IN
+    SELECT id FROM restock_requests
+     WHERE linked_transfer_id = p_transfer_id
+       AND status IN ('shipped', 'approved_transfer')
+  LOOP
+    UPDATE restock_requests
+       SET status = 'received', updated_by = p_operator
+     WHERE id = v_rr.id;
+    v_restock_received := v_restock_received + 1;
+
+    -- 20260810：ride-along 內部單改由 settle helper 收尾 —— 品項先對齊實收
+    -- （短收 0 → cancelled、部分 → 拆行），再推 ready / 全未到自動取消。
+    PERFORM public._settle_restock_ride_along(v_rr.id, p_operator, NOW());
+  END LOOP;
+
+  -- ===== 邏輯 D2（20260717）：wave 路徑補貨申請 → 已出貨/已收貨 =====
+  -- 本調撥若為撿貨單產物（picking_wave_items.generated_transfer_id 指向本單），
+  -- 歸屬的補貨申請（歸屬原則同 20260715000020）「全數出貨且全數到店」→ received、
+  -- ride-along 單推 ready；已全數出貨但仍有他張在途 → 至少推 shipped。
+  FOR v_rr IN
+    SELECT DISTINCT rr.id
+      FROM picking_wave_items pwi
+      JOIN picking_waves pw ON pw.id = pwi.wave_id AND pw.status <> 'cancelled'
+      JOIN restock_requests rr
+        ON rr.tenant_id = v_tenant_id
+       AND rr.requesting_store_id = pwi.store_id
+     WHERE pwi.generated_transfer_id = p_transfer_id
+       AND rr.status IN ('approved_pr', 'approved_transfer', 'shipped')
+       AND (pw.source_restock_request_id = rr.id
+            OR (pwi.campaign_id IS NULL
+                AND rr.linked_pr_id IS NOT NULL
+                AND pw.source_po_id IN (
+                  SELECT DISTINCT poi.po_id
+                    FROM purchase_request_items pri
+                    JOIN purchase_order_items poi ON poi.id = pri.po_item_id
+                   WHERE pri.pr_id = rr.linked_pr_id)))
+       AND pwi.sku_id IN (SELECT sku_id FROM restock_request_lines
+                           WHERE request_id = rr.id AND cancelled_at IS NULL)
+  LOOP
+    SELECT * INTO v_prog FROM public._restock_wave_progress(v_rr.id);
+    IF v_prog.fully_dispatched AND v_prog.all_arrived THEN
+      UPDATE restock_requests
+         SET status = 'received', updated_by = p_operator
+       WHERE id = v_rr.id AND status IN ('approved_pr', 'approved_transfer', 'shipped');
+      v_restock_received := v_restock_received + 1;
+
+      -- 20260810：ride-along 單交給 settle helper —— 短收品項對齊實收後
+      -- 才推 ready；全未到則整單自動取消，不再掛在店身上。
+      PERFORM public._settle_restock_ride_along(v_rr.id, p_operator, NOW());
+    ELSIF v_prog.fully_dispatched THEN
+      UPDATE restock_requests
+         SET status = 'shipped', updated_by = p_operator
+       WHERE id = v_rr.id AND status IN ('approved_pr', 'approved_transfer');
+    END IF;
+  END LOOP;
+
+  -- ===== 邏輯 E（20260811(3)，20260811(5) 從邏輯 C 搬到這裡）=====
+  -- 補貨路線發的團沒有 campaign 對齊波次，客人單從來沒被推到 'shipping'，
+  -- 邏輯 C 接不到。這裡把「對得上本次到貨 SKU」的 confirmed 單依訂單時間、
+  -- 在可配量內推 ready，並把【內部】xx 店現貨池扣掉相應的量。
+  --
+  -- **必須排在 D/D2 之後**：ride-along 單要先被 _settle_restock_ride_along
+  -- 推成 ready（並對齊實收量）， _trim_internal_pool 才吃得到它 ——
+  -- 那支只認已到貨的容器單（20260811000040）。
+  --
+  -- 20260813：p_auto_allocate = FALSE（手動配單模式）時跳過 —— 收貨只入庫，
+  -- 配給哪些 confirmed 單由店家在收貨頁「手動配單」彈窗自己勾
+  -- （rpc_manual_allocate_confirmed_orders，同一支 helper 推進）。
+  IF p_auto_allocate AND v_customer_order_id IS NULL AND v_transfer_type = 'hq_to_store' THEN
+    IF v_dest_store_id IS NOT NULL THEN
+      SELECT ARRAY_AGG(DISTINCT ti.sku_id)
+        INTO v_recv_skus
+        FROM transfer_items ti
+       WHERE ti.transfer_id = p_transfer_id
+         AND ti.qty_received > 0;
+
+      IF v_recv_skus IS NOT NULL THEN
+        v_orders_advanced := v_orders_advanced
+          + public._advance_arrived_confirmed_orders(
+              v_dest_store_id, v_recv_skus, p_operator, NOW());
+      END IF;
+    END IF;
+  END IF;
+
+  -- ===== 邏輯 F（20260814(2)）：多給的跳出【內部】店 =====
+  -- 本批實收扣掉「本店對這個 SKU 還沒交出去的帳」之後仍有剩 → 沒有訂單主人，
+  -- 掛進【內部】xx 店現貨池，店員才轉得出去（在這之前只進 on_hand，
+  -- 池子看不到 → 帳上等於隱形，只能靠人工開內部單）。
+  --
+  -- **必須排在邏輯 B/C/E 之後**：那些是把貨配給客人的路徑，配掉的量會變成
+  -- 「已承諾未取」，_grow_internal_pool 的自由量才扣得到；順序反了會把
+  -- 客人的貨掛進池子，重演 20260811000030 忠順那種「團友撲空」。
+  -- 手動配單模式（p_auto_allocate=FALSE）在這裡通常算不出剩餘（沒配的單
+  -- 還是 confirmed，自由量已扣掉它們），真正的結算在
+  -- rpc_receive_transfer_manual 配完單之後再跑一次 —— 同一支 helper，
+  -- 依當下自由量重算，不會重複掛。
+  IF v_customer_order_id IS NULL AND v_transfer_type = 'hq_to_store'
+     AND v_dest_store_id IS NOT NULL THEN
+    FOR v_sk IN
+      SELECT ti.sku_id, SUM(ti.qty_received) AS received
+        FROM transfer_items ti
+       WHERE ti.transfer_id = p_transfer_id
+         AND ti.qty_received > 0
+       GROUP BY ti.sku_id
+       ORDER BY ti.sku_id
+    LOOP
+      v_grown := public._grow_internal_pool(
+        v_dest_store_id, v_sk.sku_id, v_sk.received, p_operator, NOW(),
+        '[收貨多給|TF#' || p_transfer_id::TEXT || ']');
+      IF v_grown > 0 THEN
+        v_surplus := v_surplus
+          || jsonb_build_object('sku_id', v_sk.sku_id, 'qty', v_grown);
+      END IF;
+    END LOOP;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'transfer_id',            p_transfer_id,
+    'items_received',         v_items_received,
+    'total_qty_received',     v_total_qty,
+    'total_variance',         v_total_variance,
+    'orders_advanced',        v_orders_advanced,
+    'next_transfer_shipped',  v_next_shipped,
+    'restock_received',       v_restock_received,
+    'backorders_freed',       v_backorders_freed,
+    'auto_allocate',          p_auto_allocate,
+    'surplus',                v_surplus
+  );
+END;
+$function$;

--- a/supabase/migrations/20260904020020_reject_store_return_no_phantom_stock.sql
+++ b/supabase/migrations/20260904020020_reject_store_return_no_phantom_stock.sql
@@ -1,0 +1,368 @@
+-- ============================================================================
+-- 2026-09-04（店家退貨頁 · 第 3 支）：總倉「不同意退貨」對乙案的單零庫存動作
+--
+-- ============================================================================
+-- 【一】老闆 2026-09-04 裁示 2（乙案）後半段，逐字錨定
+-- ============================================================================
+--   「…**總倉按同意的那一刻才真的扣**。**不同意的話什麼都沒動過，乾乾淨淨**」
+--     （出處：需求暨計畫_店家退貨頁_2026-09-04.md 第 10-11 行）
+--
+-- ⛔⛔ 【三支必須一起貼，順序不可顛倒】
+--   1️⃣ 20260904020000（建單不扣）→ 2️⃣ 20260904020010（同意才扣）→ 3️⃣ 本檔（不同意零動作）
+--   只貼 1️⃣ 不貼本檔 ＝ 總倉按「不同意退貨」時會對店家 rpc_inbound 一次，
+--   而店家從來沒被扣過 ⇒ **憑空生貨、店家庫存變兩份**。
+--   ⚠️ 這是三支裡「漏貼會直接做出錯帳」的那一支。
+--
+-- ============================================================================
+-- 【二】壞在哪（不是理論，是現行程式碼逐字讀出來的）
+-- ============================================================================
+--   rpc_reject_transfer 的第 1 段（基底 :51-70）無條件把每一個 qty_shipped > 0 的行
+--   rpc_inbound 回 source_location —— 它的前提是「這批貨出庫過」。
+--   對舊路徑（rpc_create_order_return，建單即扣）那是對的；
+--   對乙案的單（送出時一筆庫存都沒動、out_movement_id 是 NULL）就變成憑空加貨。
+--
+--   ⇒ 修法：那個迴圈的 WHERE 多一條 ——
+--       AND NOT (v_xfer.transfer_type = 'return_to_hq' AND out_movement_id IS NULL)
+--     「沒有出庫紀錄」就是「沒扣過」這件事本身，沒扣過就沒有東西要退回去。
+--
+--   ⚠️ 條件刻意綁死 return_to_hq、不放寬成「只要 out_movement_id IS NULL 就跳過」：
+--     本機碰不到正式庫，我**無法證明**歷史上沒有「shipped 但 out_movement_id 是 NULL」
+--     的一般調撥單；綁死單型之後，這個條件對所有非退貨單恆為假 ⇒
+--     行為與本檔上線前一模一樣，不會改到任何我沒查證過的資料。
+--
+-- ============================================================================
+-- 【三】改了什麼（基底逐字自證）
+-- ============================================================================
+--   基底＝ 20260827020000_reject_return_reopens_closed_order.sql:41
+--     ⚠️ **不是** 20260801000000_full_return_closes_order.sql:363 ——
+--       那是舊版。用定義鏈查法自排（git grep -nE
+--       "CREATE (OR REPLACE )?FUNCTION (public\.)?rpc_reject_transfer"）得到 6 支，
+--       最後一支是 20260827020000。⚠️ 20260801000000 有**兩個同號檔**
+--       （_full_return_closes_order 與 _reject_return_to_hq_keep_original_order），
+--       後者後套把前者的復原分支整個蓋掉 —— 20260827020000 的檔頭就是在修那次撞號。
+--       照舊版當基底會把 Alex/歷次修好的東西洗掉。
+--
+--   對基底做 diff：**刪 0 行、改 0 行**，只有一個 append 區塊（13 行，其中 12 行是註解）。
+--   ⛔ 沒有動到的：波次派貨單守衛、cancel 後續 chain、customer_order 取消／復原分支、
+--     source order 回 confirmed、決策 Y（Leg-3）、回傳欄位 —— 全部一字未改。
+--
+--   ⚠️ 第 2 段（往後 walk、cancel next chain 的那個迴圈，基底 :85）**刻意沒動**：
+--     那個迴圈處理的是 v_next（另一張單）。乙案的退貨單不會出現在任何 next-chain 裡
+--     —— rpc_create_store_return（20260904020000）沒有寫 next_transfer_id，
+--     也沒有任何路徑會把 next_transfer_id 指向它。改它等於在沒有問題的地方動刀。
+--
+--   ⚠️ 本檔**沒有**重跑 20260827020000 檔尾那段 4 張壞單的資料修復 ——
+--     那是一次性的，已經跑過；再跑一次會再摸一次那些訂單。
+--
+-- ============================================================================
+-- 【四】做了會怎樣／不做會怎樣
+-- ============================================================================
+--   做了：總倉按「不同意退貨」→ 退貨單變 cancelled、貨與帳**一動都沒動**（乙案的單）。
+--     ⇒ 店家庫存頁那格的「退貨中 N」會消失（view 只看 status='shipped'），
+--       帳上的數字從頭到尾就是對的。
+--   不做：如上，憑空生貨。而且**看不出來** —— 店家庫存多了幾件、
+--     總倉沒有任何一張單對得上，等到盤點才會發現，那時已經無從追。
+--
+-- ============================================================================
+-- 【五】⚠️ 一個已知限制（誠實列出，本檔不修）
+-- ============================================================================
+--   總倉收件匣有一顆「恢復在途」（rpc_unreject_transfer，20260731000000:267）。
+--   對乙案的單按它會**失敗**，訊息是：
+--     「調撥單 N 沒有拒收回流紀錄可沖銷（非拒收取消、或已由工程處理過），無法恢復在途」
+--   原因：那支是靠「找 movement_type='transfer_reject' 的異動來沖銷」運作的
+--   （:303-310），而本檔讓乙案的單一筆都不寫 ⇒ v_reversed = 0 ⇒ 它自己 RAISE（:346-348）。
+--
+--   ⭐ 判斷：**不修**。
+--     ① 它只是拒絕，不會弄壞任何資料（沖銷迴圈一圈都沒跑就丟例外、整筆回滾）。
+--     ② 乙案的「不同意」本來就什麼都沒動 —— 要反悔，店家在退貨頁重按一次
+--        「＋我要退貨」就好，比恢復在途更直觀。
+--     ③ 老闆 2026-08-21 定的模型是「總倉回覆只有接受／不接受」，沒有第三顆。
+--   ⚠️ 但訊息會誤導（它說「非拒收取消、或已由工程處理過」，其實是「這張單本來就沒扣過貨」）。
+--     要修就是動 rpc_unreject_transfer 那支的訊息，那是另一支函式、另一個 PR，
+--     ⛔ 本波不做，登記在施工回報的「技術債」節。
+--
+-- Rollback：CREATE OR REPLACE 回 20260827020000:41 的版本即可
+--   （本檔沒有動 schema、沒有資料異動）。⚠️ 三支一組，要回就三支一起回。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION rpc_reject_transfer(
+  p_transfer_id BIGINT,
+  p_reason      TEXT,
+  p_operator    UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_xfer            transfers%ROWTYPE;
+  v_ti              RECORD;
+  v_next            transfers%ROWTYPE;
+  v_prev            transfers%ROWTYPE;
+  v_co_id           BIGINT;
+  v_co              customer_orders%ROWTYPE;
+  v_ret_co          customer_orders%ROWTYPE;
+  v_restored_co_id  BIGINT;
+  v_restored_status TEXT;
+  v_leg3_id         BIGINT;
+  v_leg3_no         TEXT;
+  v_leg3_dest_loc   BIGINT;
+  v_leg3_mov        BIGINT;
+  v_reason_note     TEXT;
+  v_cancelled_ids   BIGINT[] := ARRAY[]::BIGINT[];
+  v_epoch           BIGINT;
+  v_src_pickable    BOOLEAN := FALSE;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('transfer:' || p_transfer_id));
+
+  SELECT * INTO v_xfer FROM transfers WHERE id = p_transfer_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'transfer % not found', p_transfer_id;
+  END IF;
+  IF v_xfer.status <> 'shipped' THEN
+    RAISE EXCEPTION 'transfer % is %, only shipped can be rejected', p_transfer_id, v_xfer.status;
+  END IF;
+
+  -- ── 守衛（2026-07-31）：撿貨波次派貨單，分店不可拒收 ──
+  -- 波次派貨單背後掛著多張顧客訂單（customer_order_id 為 NULL、訂單不會被
+  -- 本 RPC 一併處理），店端拒收會讓訂單卡在 shipping、庫存虛回總倉。
+  -- 只擋「JWT store scope 涵蓋 dest 的分店帳號」；總倉帳號維持可操作（清理用）。
+  IF v_xfer.dest_location = ANY (public._jwt_store_location_ids())
+     AND EXISTS (
+       SELECT 1 FROM picking_wave_items pwi
+        WHERE pwi.generated_transfer_id = p_transfer_id
+     ) THEN
+    RAISE EXCEPTION '總倉派貨單（%）不可由分店拒收：貨還沒到請等貨到再收；貨品有誤或毀損請聯繫總倉處理',
+      v_xfer.transfer_no;
+  END IF;
+
+  v_reason_note := '[rejected: ' || COALESCE(p_reason, '') || ']';
+
+  -- 1. 反向：把 outbound 過的貨退回 source_location
+  FOR v_ti IN
+    SELECT id, sku_id, qty_shipped FROM transfer_items
+     WHERE transfer_id = p_transfer_id AND qty_shipped > 0
+       -- ↓↓ 20260904020020 新增（店家退貨頁乙案）：沒出過庫的行不可以「退回去」
+       --   店家退貨頁（rpc_create_store_return，20260904020000）建的單，
+       --   送出時**一筆庫存都沒扣**，out_movement_id 是 NULL。
+       --   對這種行做 rpc_inbound ＝ 憑空生貨（店裡本來就還有那批貨，再加一次就變兩份）。
+       --   ⭐ 老闆 2026-09-04 原話：「不同意的話什麼都沒動過，乾乾淨淨」——
+       --     零庫存動作才是「乾乾淨淨」。
+       --   ⚠️ 條件刻意綁死 return_to_hq：舊路徑的退貨（rpc_create_order_return）
+       --     與所有 hq_to_store / store_to_store 單，建單／派貨當下就寫了 out_movement_id
+       --     （20260801000000:248-265、20260508000000:150-166）⇒ 這個條件對它們恆為假、
+       --     行為與本檔上線前**一模一樣**。
+       --     ⛔ 不要放寬成「只要 out_movement_id IS NULL 就跳過」——那會改到我沒查證過的
+       --       歷史資料（本機碰不到正式庫，我無法證明沒有那種列）。
+       AND NOT (v_xfer.transfer_type = 'return_to_hq' AND out_movement_id IS NULL)
+  LOOP
+    PERFORM rpc_inbound(
+      p_tenant_id       => v_xfer.tenant_id,
+      p_location_id     => v_xfer.source_location,
+      p_sku_id          => v_ti.sku_id,
+      p_quantity        => v_ti.qty_shipped,
+      p_unit_cost       => 0,
+      p_movement_type   => 'transfer_reject',
+      p_source_doc_type => 'transfer',
+      p_source_doc_id   => p_transfer_id,
+      p_operator        => p_operator
+    );
+  END LOOP;
+
+  UPDATE transfers
+     SET status = 'cancelled',
+         notes = CASE
+                   WHEN notes IS NULL OR notes = '' THEN v_reason_note
+                   ELSE notes || E'\n' || v_reason_note
+                 END,
+         updated_by = p_operator
+   WHERE id = p_transfer_id;
+  v_cancelled_ids := v_cancelled_ids || p_transfer_id;
+
+  -- 2. 往後 walk：next chain 的 draft/shipped cancel 掉
+  IF v_xfer.next_transfer_id IS NOT NULL THEN
+    SELECT * INTO v_next FROM transfers WHERE id = v_xfer.next_transfer_id FOR UPDATE;
+    IF v_next.id IS NOT NULL AND v_next.status IN ('draft', 'shipped') THEN
+      IF v_next.status = 'shipped' THEN
+        FOR v_ti IN
+          SELECT id, sku_id, qty_shipped FROM transfer_items
+           WHERE transfer_id = v_next.id AND qty_shipped > 0
+        LOOP
+          PERFORM rpc_inbound(
+            p_tenant_id       => v_next.tenant_id,
+            p_location_id     => v_next.source_location,
+            p_sku_id          => v_ti.sku_id,
+            p_quantity        => v_ti.qty_shipped,
+            p_unit_cost       => 0,
+            p_movement_type   => 'transfer_reject',
+            p_source_doc_type => 'transfer',
+            p_source_doc_id   => v_next.id,
+            p_operator        => p_operator
+          );
+        END LOOP;
+      END IF;
+      UPDATE transfers
+         SET status = 'cancelled',
+             notes = CASE
+                       WHEN notes IS NULL OR notes = '' THEN v_reason_note
+                       ELSE notes || E'\n' || v_reason_note
+                     END,
+             updated_by = p_operator
+       WHERE id = v_next.id;
+      v_cancelled_ids := v_cancelled_ids || v_next.id;
+    END IF;
+  END IF;
+
+  -- 3. 找 customer_order 並取消 —— 僅互助/派貨鏈適用（2026-08-01 加判斷）。
+  -- return_to_hq（分店退訂單回總倉）的 customer_order_id 是「被退貨的原訂單」：
+  -- rpc_create_order_return 建單時訂單狀態保留不動，拒收（退訂單取消）只應
+  -- 作廢退貨單本身、貨帳退回店端，原訂單不得取消（30709 / 37587 事故）。
+  IF v_xfer.transfer_type <> 'return_to_hq' THEN
+    v_co_id := v_xfer.customer_order_id;
+    IF v_co_id IS NULL AND v_next.id IS NOT NULL THEN
+      v_co_id := v_next.customer_order_id;
+    END IF;
+
+    IF v_co_id IS NOT NULL THEN
+      SELECT * INTO v_co FROM customer_orders WHERE id = v_co_id;
+      UPDATE customer_orders
+         SET status       = 'cancelled',
+             cancelled_at = NOW(),
+             updated_by   = p_operator,
+             updated_at   = NOW()
+       WHERE id = v_co_id;
+
+      -- ── source order 退回 ──（20260713 修法，與 rpc_cancel_aid_order 一致）
+      IF v_co.transferred_from_order_id IS NOT NULL THEN
+        UPDATE customer_orders
+           SET status                  = 'confirmed',
+               transferred_to_order_id = NULL,
+               updated_by              = p_operator,
+               updated_at              = NOW()
+         WHERE id = v_co.transferred_from_order_id
+           AND status = 'transferred_out';
+
+        v_src_pickable := public.is_order_pickup_ready(v_co.transferred_from_order_id);
+        IF v_src_pickable THEN
+          UPDATE customer_orders
+             SET status     = 'ready',
+                 ready_at   = COALESCE(ready_at, NOW()),
+                 updated_by = p_operator,
+                 updated_at = NOW()
+           WHERE id = v_co.transferred_from_order_id
+             AND status = 'confirmed';
+        END IF;
+      END IF;
+    END IF;
+  ELSE
+    -- ── return_to_hq 拒收 → 復原「因退貨被收尾」的原訂單（2026-08-27 補回）──
+    -- 這段在 20260801000000_full_return_closes_order 寫過，被同號的
+    -- keep_original_order 版蓋掉、從未上線（見檔頭）。貨已由上面的
+    -- transfer_reject inbound 回到店端，原訂單要跟著復原可取：
+    --   - 曾因全數退貨收尾成 cancelled（有 active 品項、無已取）→ 回 ready
+    --   - 曾因收尾成 completed（仍有 active 品項）→ 回 partially_completed
+    --   - 其他（正常 ready / partially_completed / expired…）→ 不動
+    --     （退貨單已 cancelled，可取量／應收扣減查詢自動不再計入）
+    IF v_xfer.customer_order_id IS NOT NULL THEN
+      SELECT * INTO v_ret_co FROM customer_orders
+       WHERE id = v_xfer.customer_order_id FOR UPDATE;
+      IF v_ret_co.status = 'cancelled'
+         AND EXISTS (SELECT 1 FROM customer_order_items
+                      WHERE order_id = v_ret_co.id AND status IN ('pending','reserved','ready'))
+         AND NOT EXISTS (SELECT 1 FROM customer_order_items
+                          WHERE order_id = v_ret_co.id AND status = 'picked_up') THEN
+        v_restored_co_id  := v_ret_co.id;
+        v_restored_status := 'ready';
+        UPDATE customer_orders
+           SET status       = 'ready',
+               ready_at     = COALESCE(ready_at, NOW()),
+               cancelled_at = NULL,
+               updated_by   = p_operator,
+               updated_at   = NOW()
+         WHERE id = v_ret_co.id;
+      ELSIF v_ret_co.status = 'completed'
+         AND EXISTS (SELECT 1 FROM customer_order_items
+                      WHERE order_id = v_ret_co.id AND status IN ('pending','reserved','ready')) THEN
+        v_restored_co_id  := v_ret_co.id;
+        v_restored_status := 'partially_completed';
+        UPDATE customer_orders
+           SET status       = 'partially_completed',
+               completed_at = NULL,
+               updated_by   = p_operator,
+               updated_at   = NOW()
+         WHERE id = v_ret_co.id;
+      END IF;
+    END IF;
+  END IF;
+
+  -- 4. 決策 Y：若往前有 received 的 leg，自動建 Leg-3 退回原 source
+  SELECT * INTO v_prev
+    FROM transfers
+   WHERE next_transfer_id = p_transfer_id
+   LIMIT 1;
+
+  IF v_prev.id IS NOT NULL AND v_prev.status = 'received' THEN
+    v_leg3_dest_loc := v_prev.source_location;  -- 退回原 source 店
+
+    v_epoch := EXTRACT(EPOCH FROM NOW())::BIGINT;
+    v_leg3_no := 'AT-RET-' || p_transfer_id || '-' || v_epoch;
+
+    INSERT INTO transfers (
+      tenant_id, transfer_no, source_location, dest_location,
+      status, transfer_type, customer_order_id, next_transfer_id,
+      requested_by, shipped_by, shipped_at,
+      created_by, updated_by, notes
+    ) VALUES (
+      v_xfer.tenant_id, v_leg3_no, v_xfer.source_location, v_leg3_dest_loc,
+      'shipped', 'hq_to_store', NULL, NULL,
+      p_operator, p_operator, NOW(),
+      p_operator, p_operator, '[Leg-3 退回 source after reject]'
+    ) RETURNING id INTO v_leg3_id;
+
+    FOR v_ti IN
+      SELECT sku_id, qty_shipped FROM transfer_items
+       WHERE transfer_id = p_transfer_id AND qty_shipped > 0
+    LOOP
+      v_leg3_mov := rpc_outbound(
+        p_tenant_id       => v_xfer.tenant_id,
+        p_location_id     => v_xfer.source_location,
+        p_sku_id          => v_ti.sku_id,
+        p_quantity        => v_ti.qty_shipped,
+        p_movement_type   => 'transfer_out',
+        p_source_doc_type => 'transfer',
+        p_source_doc_id   => v_leg3_id,
+        p_operator        => p_operator
+      );
+      INSERT INTO transfer_items (
+        transfer_id, sku_id, qty_requested, qty_shipped,
+        out_movement_id, created_by, updated_by
+      ) VALUES (
+        v_leg3_id, v_ti.sku_id, v_ti.qty_shipped, v_ti.qty_shipped,
+        v_leg3_mov, p_operator, p_operator
+      );
+    END LOOP;
+
+    UPDATE transfers SET next_transfer_id = v_leg3_id, updated_by = p_operator
+     WHERE id = p_transfer_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'rejected_transfer_id', p_transfer_id,
+    'cancelled_transfer_ids', to_jsonb(v_cancelled_ids),
+    'cancelled_co_id', v_co_id,
+    'restored_co_id', v_restored_co_id,
+    'restored_status', v_restored_status,
+    'leg3_transfer_id', v_leg3_id,
+    'source_order_reverted', v_co.transferred_from_order_id IS NOT NULL,
+    'source_order_pickable', v_src_pickable
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION rpc_reject_transfer IS
+  'Aid transfer 拒收：反向 inbound、cancel 後續 chain、customer_order 取消、source order 回 confirmed。'
+  '經總倉 dest 拒 Leg-2 自動建 Leg-3 退回原 source（決策 Y）。'
+  '原單退回時若貨已在店(is_order_pickup_ready) 直接推到 ready（2026-07-13）。'
+  '撿貨波次派貨單分店不可拒收，僅總倉帳號可操作（2026-07-31）。'
+  'return_to_hq 拒收只作廢退貨單、貨帳退回店端，不取消原顧客訂單（2026-08-01）；'
+  '並復原因退貨被收尾的訂單（cancelled→ready / completed→partially_completed，2026-08-27）。'
+  '⭐ 2026-09-04：店家退貨頁（乙案）建的 return_to_hq 行送出時沒扣過店家庫存'
+  '（out_movement_id IS NULL），拒收時**不做** inbound —— 沒扣過就沒有東西要退回去，'
+  '做了就是憑空生貨。老闆原話「不同意的話什麼都沒動過，乾乾淨淨」。';


### PR DESCRIPTION
老闆裁示的乙案退貨模型：店家發起退貨當下零庫存動作（帳上標
「退貨中 N」），總倉按同意那一刻才鎖定重驗並扣店入倉；不同意
＝零動作乾乾淨淨。總倉端零改動——退貨單走既有 return_to_hq
隊伍，二鈕與 48h 自動同意原樣繼承。

- 20260904020000：rpc_create_store_return——建單零庫存；角色 守衛（僅總部三角色可代店，其餘含空白身分一律 _jwt_store_ids 驗證）；鎖(店,SKU)重讀＋加計其他 pending 退貨防併發超退
- 20260904020010：同意入倉時扣店＋入總倉（原子；鎖序沿 20260904010000 家族；扣不動大聲擋含占用明細）
- 20260904020020：不同意（reject）對乙案單跳過 inbound—— 未出庫的單不得憑空生貨；傳統已出庫退貨照舊回店；9/1 純記帳 沖帳單永不經此路
- 新頁 wms/returns：三段式（發起／進度含自動標示／差額處理 結果——含「不同意退・跟店家收錢」可見、撤銷回未處理）； 清單過濾下推 SQL 防記帳單洗版；標籤與 #906 兩步式逐字一致
- 庫存頁「退貨中 N」小標；選單入口
- G 改字：分店情境「✋ 配單」→「收貨」（三處沿既有店家判準 條件字樣＋配單視窗標題同步；總倉端逐字元零變動）

驗證：施工 4 輪 × Codex 唯讀審查 4 輪 P0/P1=0（首輪 P0 空白
身分跨店洞、P1 洗版漏單/併發超退/禁令字樣/不同意隱形均修畢
並逐條複驗）；畫面斷言 131 條＋八注入負向對照；重墊 1c35b0d1
後全量重驗、原 7 檔 SHA 不變。⚠ 未連庫實測；三支 migration
綁定依序套用；.like 空白 pattern 待實機驗（錯亦僅列表空、
不涉帳）。

## 做了什麼


## 上線危險

- 做了：
- 不做：
- 回退：

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [ ] 本 PR 沒有碰上述敏感設定。

## 驗證


