### PR TITLE
feat(tools): LINE 社群／群組記事本留言爬蟲 CLI

### DIFF
--- a/tools/line-note-scraper/.gitignore
+++ b/tools/line-note-scraper/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+storage.json
+out/
+*.log

--- a/tools/line-note-scraper/README.md
+++ b/tools/line-note-scraper/README.md
@@ -1,0 +1,62 @@
+# line-note-scraper — LINE 記事本留言爬蟲
+
+把 LINE **群組**／**社群（OpenChat）** 記事本裡的貼文與留言抓下來，順手把「+1」解析成訂單行，輸出 JSON / CSV。跑在自己電腦上，不碰主站。
+
+> ⚠️ 走的是 LINE **非官方**客戶端協定（[linejs](https://github.com/evex-dev/linejs)），違反 LINE 使用條款、帳號可能被停權。
+> **只能用備用帳號**，把那支帳號拉進要抓的群組／社群就好，不要用本人或公司主帳號。
+
+## 安裝（Node 22+）
+
+```bash
+cd tools/line-note-scraper
+npx jsr add @evex/linejs      # 會寫 .npmrc（@jsr registry）並補 package.json 相依
+npm install
+```
+
+## 使用
+
+```bash
+npm run login                       # 印出 QR，用備用帳號的手機掃；再輸入畫面上的 PIN
+npm run groups                      # 列出群組(c…) / 社群(s…) / 社群聊天室(m…) 的 homeId
+npm run posts -- <homeId>           # 最近 20 篇貼文
+npm run comments -- <homeId> <postId>
+npm run scrape -- <homeId> --since 2026-09-01     # 全部貼文 + 留言 → out/<homeId>/<時間>/
+```
+
+輸出檔：
+
+| 檔案 | 內容 |
+|---|---|
+| `posts.json` / `comments.json` | 正規化後的貼文與留言（含 `raw` 原始回應） |
+| `comments.csv` | 一則留言一列 |
+| `orders.csv` | 解析出來的 +1（一筆一列：貼文、留言者、品項代碼、數量、是否取消、原文） |
+| `summary.csv` | 每篇貼文 × 品項代碼的數量小計 |
+
++1 的寫法支援 `+1`、`＋２`、`A+1`、`B-2 +1`、`+1 A`、`A x2`、`A 2份`、`2份`、`-1` / `取消 A+1`（負數）。
+規則在 `src/parse.mjs`，測試 `npm test`。純數字、`A2` 這種分不清品號還是數量的**不猜**，留給人看 `comments.csv`。
+
+## 打不通的時候
+
+第一次一定加 `--verbose`：
+
+```bash
+node src/cli.mjs posts <homeId> --verbose
+```
+
+記事本 API 沒有 wire trace，程式會依序試 host × 路徑前綴 × channel，第一組回 `code: 0` 的就記住。
+全部失敗會把每次嘗試印出來，整段貼回來就能調。也可以用環境變數硬指定：
+
+| 變數 | 說明 |
+|---|---|
+| `LINE_DEVICE` | 模擬的裝置，預設 `ANDROIDSECONDARY`（`DESKTOPWIN` 拿不到 channel token） |
+| `LINE_NOTE_HOST` | 記事本 host，候選：登入用的 endpoint、`gw.line.naver.jp`、`ga2.line.naver.jp` |
+| `LINE_NOTE_PREFIX` | 路徑前綴：群組 `/mh` 或 `/ext/note/nt`，社群 `/sn` |
+| `LINE_NOTE_CHANNEL` | channel id：HOME `1341209850`、TIMELINE `1341209950`、NOTE `1655599932`、SQUARE_NOTE `1657618623` |
+| `LINE_STORAGE` | token 存放檔，預設 `./storage.json`（**不要 commit**） |
+
+回應欄位名沒實測過，`normalizePost` / `normalizeComment` 寫成寬鬆版；欄位對不上時開 `--raw`，看 `raw.json` 再對。
+
+## 身分辨識
+
+- 群組：留言帶留言者的 LINE mid（`u…`）＋當下暱稱。
+- 社群：只有社群成員 id（`p…`）＋社群暱稱，**拿不到真實帳號**。要歸戶只能靠暱稱對會員，或讓客人自己點連結綁定。

--- a/tools/line-note-scraper/package.json
+++ b/tools/line-note-scraper/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "line-note-scraper",
+  "private": true,
+  "version": "0.1.0",
+  "description": "LINE 群組／社群記事本貼文留言爬蟲（+1 收單用）。用一般 LINE 帳號登入，非官方 API，請用備用帳號。",
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "bin": {
+    "line-notes": "./src/cli.mjs"
+  },
+  "scripts": {
+    "login": "node src/cli.mjs login",
+    "groups": "node src/cli.mjs groups",
+    "posts": "node src/cli.mjs posts",
+    "comments": "node src/cli.mjs comments",
+    "scrape": "node src/cli.mjs scrape",
+    "test": "node --test src/parse.test.mjs"
+  },
+  "dependencies": {
+    "@evex/linejs": "npm:@jsr/evex__linejs@^3.4.2",
+    "qrcode-terminal": "^0.12.0"
+  }
+}

--- a/tools/line-note-scraper/src/cli.mjs
+++ b/tools/line-note-scraper/src/cli.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// line-notes：LINE 群組／社群記事本留言爬蟲 CLI。
+//
+//   node src/cli.mjs login                      掃 QR 登入（存 storage.json）
+//   node src/cli.mjs groups                     列出群組 / 社群 / 社群聊天室的 homeId
+//   node src/cli.mjs posts <homeId> [--limit 20] [--since 2026-09-01]
+//   node src/cli.mjs comments <homeId> <postId>
+//   node src/cli.mjs scrape <homeId> [--since …] [--limit …] [--out out] [--raw]
+//
+// 共用選項：--verbose（把每次 API 嘗試印到 stderr）、--json（posts/groups 以 JSON 輸出）
+
+import fs from "node:fs";
+import path from "node:path";
+import {
+  ensureDir, getClient, listComments, listHomes, listPosts, whoami,
+} from "./line.mjs";
+import { parseOrderLines, postTitle } from "./parse.mjs";
+
+function parseArgs(argv) {
+  const args = { _: [], flags: {} };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith("--")) { args.flags[key] = next; i++; }
+      else args.flags[key] = true;
+    } else args._.push(a);
+  }
+  return args;
+}
+
+function csvEscape(v) {
+  const s = v == null ? "" : String(v);
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+function writeCsv(file, rows, columns) {
+  const lines = [columns.join(",")];
+  for (const r of rows) lines.push(columns.map((c) => csvEscape(r[c])).join(","));
+  fs.writeFileSync(file, "﻿" + lines.join("\n") + "\n", "utf8"); // BOM 給 Excel
+}
+
+function printTable(rows, columns) {
+  if (rows.length === 0) { console.log("(空)"); return; }
+  const widths = columns.map((c) => Math.max(c.length, ...rows.map((r) => String(r[c] ?? "").length)));
+  const line = (r) => columns.map((c, i) => String(r[c] ?? "").padEnd(widths[i])).join("  ");
+  console.log(line(Object.fromEntries(columns.map((c) => [c, c]))));
+  console.log(widths.map((w) => "-".repeat(w)).join("  "));
+  for (const r of rows) console.log(line(r));
+}
+
+async function main() {
+  const { _: [cmd, ...rest], flags } = parseArgs(process.argv.slice(2));
+  const verbose = !!flags.verbose;
+
+  if (!cmd || cmd === "help" || flags.help) {
+    console.log(fs.readFileSync(new URL(import.meta.url)).toString().split("\n").slice(1, 11).map((l) => l.replace(/^\/\/ ?/, "")).join("\n"));
+    return;
+  }
+
+  if (cmd === "login") {
+    const client = await getClient({ interactive: true, verbose });
+    const me = whoami(client);
+    console.log(`登入成功：${me.displayName} (${me.mid})，token 已存到 storage.json`);
+    process.exit(0);
+  }
+
+  const client = await getClient({ interactive: false, verbose });
+  const me = whoami(client);
+  console.error(`[line-notes] 登入身分：${me.displayName} (${me.mid})`);
+
+  if (cmd === "groups") {
+    const homes = await listHomes(client, verbose);
+    if (flags.json) console.log(JSON.stringify(homes, null, 2));
+    else {
+      printTable(homes, ["kind", "homeId", "name"]);
+      console.log("\n群組用 c… 的 id；社群記事本先試 m…（聊天室），不行再試 s…（社群本體）。");
+    }
+    process.exit(0);
+  }
+
+  const homeId = rest[0];
+  if (!homeId) throw new Error(`用法：${cmd} <homeId> …（homeId 用 groups 指令查）`);
+  const limit = flags.limit ? Number(flags.limit) : (cmd === "posts" ? 20 : 500);
+  const since = flags.since || null;
+
+  if (cmd === "posts") {
+    const posts = await listPosts(client, homeId, { limit, since, verbose });
+    if (flags.json) console.log(JSON.stringify(posts.map(({ raw, ...p }) => p), null, 2));
+    else printTable(posts.map((p) => ({ postId: p.postId, createdAt: p.createdAt ?? "", author: p.authorName ?? p.authorMid ?? "", comments: p.commentCount, title: postTitle(p.text) })), ["postId", "createdAt", "author", "comments", "title"]);
+    process.exit(0);
+  }
+
+  if (cmd === "comments") {
+    const postId = rest[1];
+    if (!postId) throw new Error("用法：comments <homeId> <postId>");
+    const comments = await listComments(client, homeId, postId, { verbose });
+    console.log(JSON.stringify(comments.map(({ raw, ...c }) => ({ ...c, orders: parseOrderLines(c.text) })), null, 2));
+    process.exit(0);
+  }
+
+  if (cmd === "scrape") {
+    const outDir = ensureDir(path.join(flags.out || "out", homeId, new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)));
+    const rawDump = flags.raw ? [] : null;
+    const onRaw = rawDump ? (b) => rawDump.push(b) : undefined;
+
+    const posts = await listPosts(client, homeId, { limit, since, verbose, onRaw });
+    console.error(`[line-notes] 貼文 ${posts.length} 篇`);
+    const comments = [];
+    const orders = [];
+    for (const p of posts) {
+      const cs = await listComments(client, homeId, p.postId, { verbose, onRaw });
+      console.error(`[line-notes]   ${p.postId} ${postTitle(p.text)} → 留言 ${cs.length}`);
+      for (const c of cs) {
+        comments.push(c);
+        for (const o of parseOrderLines(c.text)) {
+          orders.push({
+            homeId, postId: p.postId, postTitle: postTitle(p.text), postCreatedAt: p.createdAt,
+            commentId: c.commentId, commenter: c.authorName ?? "", commenterMid: c.authorMid ?? "",
+            commentedAt: c.createdAt ?? "", code: o.code ?? "", qty: o.cancel ? -o.qty : o.qty,
+            cancel: o.cancel ? "Y" : "", line: o.line, text: c.text,
+          });
+        }
+      }
+    }
+
+    fs.writeFileSync(path.join(outDir, "posts.json"), JSON.stringify(posts, null, 2));
+    fs.writeFileSync(path.join(outDir, "comments.json"), JSON.stringify(comments, null, 2));
+    writeCsv(path.join(outDir, "comments.csv"), comments.map((c) => ({ ...c, text: c.text })),
+      ["homeId", "postId", "commentId", "authorName", "authorMid", "createdAt", "text"]);
+    writeCsv(path.join(outDir, "orders.csv"), orders,
+      ["homeId", "postId", "postTitle", "postCreatedAt", "commentId", "commenter", "commenterMid", "commentedAt", "code", "qty", "cancel", "line", "text"]);
+    if (rawDump) fs.writeFileSync(path.join(outDir, "raw.json"), JSON.stringify(rawDump, null, 2));
+
+    // 每篇貼文的小計，方便對帳
+    const summary = new Map();
+    for (const o of orders) {
+      const k = `${o.postId}\t${o.code}`;
+      const s = summary.get(k) ?? { postId: o.postId, postTitle: o.postTitle, code: o.code, qty: 0, people: new Set() };
+      s.qty += o.qty;
+      s.people.add(o.commenterMid || o.commenter);
+      summary.set(k, s);
+    }
+    writeCsv(path.join(outDir, "summary.csv"), [...summary.values()].map((s) => ({ ...s, people: s.people.size })),
+      ["postId", "postTitle", "code", "qty", "people"]);
+
+    console.log(`完成：${posts.length} 篇貼文、${comments.length} 則留言、${orders.length} 筆 +1\n輸出：${outDir}`);
+    process.exit(0);
+  }
+
+  throw new Error(`不認識的指令：${cmd}`);
+}
+
+main().catch((e) => {
+  console.error("錯誤：" + (e?.message ?? e));
+  if (process.argv.includes("--verbose") && e?.stack) console.error(e.stack);
+  process.exit(1);
+});

--- a/tools/line-note-scraper/src/line.mjs
+++ b/tools/line-note-scraper/src/line.mjs
@@ -1,0 +1,330 @@
+// linejs 包裝：登入、列群組／社群、讀記事本貼文與留言。
+//
+// 記事本不是 Thrift，是 LINE 內部的 JSON REST（myhome / square-note）：
+//   群組  GET https://<host>/mh/api/v57/post/list.json?homeId=<c…>&sourceType=TALKROOM
+//   社群  GET https://<host>/sn/api/v57/post/list.json?homeId=<m…或 s…>
+//   留言  GET …/comment/getList.json?homeId=&contentId=<postId>[&scrollId=]
+// header 要 X-Line-Access（登入 token）+ X-Line-ChannelToken（channel token）+ X-Line-Mid。
+// 沒有 wire trace，所以 host / 路徑前綴 / channel 都做了候選清單，第一個回 code 0 的就記住。
+// 打不通時用 --verbose 看每一次嘗試的回應，把輸出貼回來就能調。
+
+import { loginWithAuthToken, loginWithQR } from "@evex/linejs";
+import { FileStorage } from "@evex/linejs/storage";
+import fs from "node:fs";
+
+export const DEFAULT_DEVICE = process.env.LINE_DEVICE || "ANDROIDSECONDARY";
+export const STORAGE_PATH = process.env.LINE_STORAGE || "./storage.json";
+
+const CHANNEL_IDS = {
+  HOME: "1341209850",
+  TIMELINE: "1341209950",
+  NOTE: "1655599932",
+  SQUARE_NOTE: "1657618623",
+};
+
+export function log(verbose, ...args) {
+  if (verbose) console.error("[line-notes]", ...args);
+}
+
+export async function getClient({ interactive = false, verbose = false, device = DEFAULT_DEVICE } = {}) {
+  const storage = new FileStorage(STORAGE_PATH);
+  const cached = await storage.get(".auth");
+  const init = { device, storage };
+
+  if (typeof cached === "string" && cached) {
+    log(verbose, `using cached auth token from ${STORAGE_PATH}`);
+    try {
+      const client = await loginWithAuthToken(cached, init);
+      client.base.on("update:authtoken", (t) => storage.set(".auth", t));
+      return client;
+    } catch (e) {
+      if (!interactive) throw new Error(`cached token rejected (${e?.message ?? e}); run "login" again`);
+      log(verbose, "cached token rejected, falling back to QR login:", e?.message ?? e);
+    }
+  }
+  if (!interactive) throw new Error(`no auth token in ${STORAGE_PATH}; run "login" first`);
+
+  const client = await loginWithQR({
+    async onReceiveQRUrl(url) {
+      console.log("\n用要當爬蟲的那支 LINE 帳號掃這個 QR（備用帳號！）：\n");
+      try {
+        const qr = await import("qrcode-terminal");
+        (qr.default ?? qr).generate(url, { small: true });
+      } catch {
+        // qrcode-terminal 沒裝也沒關係，下面有網址
+      }
+      console.log("\n或把這個網址貼到手機 LINE 開啟：\n" + url + "\n");
+    },
+    onPincodeRequest(pin) {
+      console.log(`\n手機 LINE 會要你輸入 PIN：  ${pin}\n`);
+    },
+  }, init);
+  client.base.on("update:authtoken", (t) => storage.set(".auth", t));
+  await storage.set(".auth", client.base.authToken);
+  return client;
+}
+
+export function whoami(client) {
+  const p = client.base.profile ?? {};
+  return { mid: p.mid, displayName: p.displayName };
+}
+
+/** 加入中的群組（c…）、社群（s…）與社群聊天室（m…）。 */
+export async function listHomes(client, verbose = false) {
+  const homes = [];
+  try {
+    const chats = await client.fetchJoinedChats();
+    for (const c of chats) {
+      const type = c.raw?.type;
+      if (type === "GROUP" || type === 0 || String(c.mid).startsWith("c")) {
+        homes.push({ kind: "group", homeId: c.mid, name: c.name ?? "" });
+      }
+    }
+  } catch (e) {
+    log(true, "fetchJoinedChats failed:", e?.message ?? e);
+  }
+  try {
+    const squares = await client.fetchJoinedSquares();
+    for (const s of squares) {
+      homes.push({ kind: "square", homeId: s.raw?.mid, name: s.raw?.name ?? "" });
+    }
+  } catch (e) {
+    log(true, "fetchJoinedSquares failed:", e?.message ?? e);
+  }
+  try {
+    const chats = await client.fetchJoinedSquareChats();
+    for (const c of chats) {
+      const raw = c.raw ?? c;
+      homes.push({ kind: "square_chat", homeId: raw.squareChatMid ?? c.mid, name: raw.name ?? c.name ?? "", squareMid: raw.squareMid });
+    }
+  } catch (e) {
+    log(verbose, "fetchJoinedSquareChats failed (可忽略，用 s… 的 id 也行):", e?.message ?? e);
+  }
+  return homes;
+}
+
+// ── 記事本 REST ────────────────────────────────────────────────────────────
+
+function prefixCandidates(homeId) {
+  const forced = process.env.LINE_NOTE_PREFIX;
+  if (forced) return [forced];
+  const first = String(homeId)[0];
+  if (first === "s" || first === "m") return ["/sn", "/mh", "/ext/note/nt"];
+  return ["/mh", "/ext/note/nt"];
+}
+
+function hostCandidates(client) {
+  const forced = process.env.LINE_NOTE_HOST;
+  if (forced) return [forced];
+  const ep = client.base.request?.endpoint;
+  return [...new Set([ep, "gw.line.naver.jp", "ga2.line.naver.jp"].filter(Boolean))];
+}
+
+function channelCandidates(homeId) {
+  const forced = process.env.LINE_NOTE_CHANNEL;
+  if (forced) return [forced];
+  const first = String(homeId)[0];
+  return first === "s" || first === "m"
+    ? [CHANNEL_IDS.SQUARE_NOTE, CHANNEL_IDS.HOME, CHANNEL_IDS.TIMELINE, CHANNEL_IDS.NOTE]
+    : [CHANNEL_IDS.HOME, CHANNEL_IDS.NOTE, CHANNEL_IDS.TIMELINE, CHANNEL_IDS.SQUARE_NOTE];
+}
+
+const tokenCache = new Map();
+async function channelToken(client, channelId, verbose) {
+  if (tokenCache.has(channelId)) return tokenCache.get(channelId);
+  let token;
+  try {
+    const r = await client.base.channel.approveChannelAndIssueChannelToken({ channelId });
+    token = r?.channelAccessToken ?? r?.token;
+  } catch (e) {
+    log(verbose, `approveChannelAndIssueChannelToken(${channelId}) failed:`, e?.message ?? e);
+  }
+  if (!token) {
+    const r = await client.base.channel.issueChannelToken({ channelId });
+    token = r?.token ?? r?.channelAccessToken;
+  }
+  if (!token) throw new Error(`no channel token for ${channelId}`);
+  tokenCache.set(channelId, token);
+  return token;
+}
+
+function baseHeaders(client, token) {
+  return {
+    accept: "application/json",
+    "content-type": "application/json",
+    "user-agent": client.base.request.userAgent,
+    "x-line-application": client.base.request.systemType,
+    "x-line-mid": client.base.profile?.mid ?? "",
+    "x-line-access": client.base.authToken,
+    "x-line-channeltoken": token,
+    "x-lal": process.env.LINE_LANG || "zh-Hant_TW",
+    "x-lsr": process.env.LINE_REGION || "TW",
+    "x-lpv": "1",
+    "x-lhm": "GET",
+    "x-line-bdbtemplateversion": "v1",
+    "x-line-global-config": "discover.enable=true; follow.enable=true",
+  };
+}
+
+// 記住第一個打通的組合，之後同一個 homeId 直接用。
+const routeCache = new Map();
+
+/**
+ * 對記事本 REST 打一次 GET。回 { code, message, result }。
+ * 會依序試 host × prefix × channel，直到有一組回 code 0。
+ */
+export async function noteGet(client, homeId, path, params, verbose = false) {
+  const qs = new URLSearchParams(Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined && v !== null && v !== "")));
+  const tryOne = async (host, prefix, channelId) => {
+    const token = await channelToken(client, channelId, verbose);
+    const url = `https://${host}${prefix}${path}?${qs}`;
+    const res = await client.base.fetch(url, { method: "GET", headers: baseHeaders(client, token) });
+    const text = await res.text();
+    let body;
+    try { body = JSON.parse(text); } catch { body = { code: res.status, message: text.slice(0, 200), result: null }; }
+    log(verbose, `${res.status} ${url} ch=${channelId} → code=${body?.code} ${body?.message ?? ""}`);
+    return { httpStatus: res.status, body };
+  };
+
+  const cached = routeCache.get(homeId);
+  if (cached) {
+    const { body } = await tryOne(cached.host, cached.prefix, cached.channelId);
+    return body;
+  }
+  const attempts = [];
+  for (const host of hostCandidates(client)) {
+    for (const prefix of prefixCandidates(homeId)) {
+      for (const channelId of channelCandidates(homeId)) {
+        try {
+          const { httpStatus, body } = await tryOne(host, prefix, channelId);
+          if (body && body.code === 0) {
+            routeCache.set(homeId, { host, prefix, channelId });
+            log(verbose, `route ok: host=${host} prefix=${prefix} channel=${channelId}`);
+            return body;
+          }
+          attempts.push(`${httpStatus} ${host}${prefix}${path} ch=${channelId} code=${body?.code} ${body?.message ?? ""}`);
+        } catch (e) {
+          attempts.push(`ERR ${host}${prefix}${path} ch=${channelId}: ${e?.message ?? e}`);
+        }
+      }
+    }
+  }
+  throw new Error(`記事本 API 全部打不通（homeId=${homeId}）。把下面這段貼回來：\n` + attempts.join("\n"));
+}
+
+// ── 回應解析（結構沒 wire trace，寫成寬鬆版；raw 一律保留） ──────────────
+
+function pick(obj, ...paths) {
+  for (const p of paths) {
+    const v = p.split(".").reduce((o, k) => (o == null ? undefined : o[k]), obj);
+    if (v !== undefined && v !== null && v !== "") return v;
+  }
+  return undefined;
+}
+
+function toIso(ms) {
+  const n = Number(ms);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return new Date(n < 1e12 ? n * 1000 : n).toISOString();
+}
+
+export function normalizePost(p, homeId) {
+  const post = p?.post ?? p; // feeds[] 會包一層 { post: {...} }
+  return {
+    homeId,
+    postId: pick(post, "id", "postInfo.postId", "postId"),
+    authorMid: pick(post, "userInfo.mid", "userInfo.writerMid", "postInfo.userInfo.mid", "actorId"),
+    authorName: pick(post, "userInfo.nickname", "userInfo.displayName", "postInfo.userInfo.nickname"),
+    createdAt: toIso(pick(post, "postInfo.createdTime", "createdTime")),
+    updatedAt: toIso(pick(post, "postInfo.updatedTime", "updatedTime")),
+    text: pick(post, "contents.text", "contents.textMeta.text", "text") ?? "",
+    commentCount: Number(pick(post, "postInfo.commentCount", "commentCount") ?? 0),
+    likeCount: Number(pick(post, "postInfo.likeCount", "likeCount") ?? 0),
+    raw: post,
+  };
+}
+
+export function normalizeComment(c, homeId, postId) {
+  return {
+    homeId,
+    postId,
+    commentId: pick(c, "id", "commentId"),
+    authorMid: pick(c, "userInfo.mid", "userInfo.writerMid", "actorId", "mid"),
+    authorName: pick(c, "userInfo.nickname", "userInfo.displayName", "nickname"),
+    createdAt: toIso(pick(c, "createdTime", "postInfo.createdTime")),
+    text: pick(c, "commentText", "text", "contents.text") ?? "",
+    raw: c,
+  };
+}
+
+function extractPosts(result) {
+  if (!result) return [];
+  if (Array.isArray(result.posts)) return result.posts;
+  if (Array.isArray(result.feeds)) return result.feeds;
+  if (Array.isArray(result)) return result;
+  return [];
+}
+
+function extractComments(result) {
+  if (!result) return [];
+  if (Array.isArray(result.comments)) return result.comments;
+  if (Array.isArray(result.commentList)) return result.commentList;
+  if (Array.isArray(result)) return result;
+  return [];
+}
+
+/** 列貼文，自動翻頁（用最後一篇的 postId + updatedTime 當游標）。 */
+export async function listPosts(client, homeId, { limit = 200, since = null, verbose = false, onRaw } = {}) {
+  const out = [];
+  let postId, updatedTime;
+  const sinceMs = since ? new Date(since).getTime() : null;
+  for (let page = 0; page < 50 && out.length < limit; page++) {
+    const body = await noteGet(client, homeId, "/api/v57/post/list.json", {
+      homeId, sourceType: "TALKROOM", likeLimit: "0", commentLimit: "0", postId, updatedTime,
+    }, verbose);
+    onRaw?.(body);
+    const posts = extractPosts(body.result).map((p) => normalizePost(p, homeId));
+    if (posts.length === 0) break;
+    let stop = false;
+    for (const p of posts) {
+      if (out.some((x) => x.postId === p.postId)) { stop = true; break; }
+      if (sinceMs && p.createdAt && new Date(p.createdAt).getTime() < sinceMs) { stop = true; break; }
+      out.push(p);
+    }
+    if (stop) break;
+    const last = posts[posts.length - 1];
+    postId = last.postId;
+    updatedTime = pick(last.raw, "postInfo.updatedTime", "updatedTime");
+    if (!postId || !updatedTime) break;
+  }
+  return out.slice(0, limit);
+}
+
+/** 列一篇貼文的全部留言，用 scrollId 翻頁。 */
+export async function listComments(client, homeId, postId, { verbose = false, onRaw } = {}) {
+  const out = [];
+  let scrollId;
+  for (let page = 0; page < 200; page++) {
+    const body = await noteGet(client, homeId, "/api/v57/comment/getList.json", {
+      homeId, contentId: postId, limit: "50", scrollId,
+    }, verbose);
+    onRaw?.(body);
+    const comments = extractComments(body.result).map((c) => normalizeComment(c, homeId, postId));
+    if (comments.length === 0) break;
+    let added = 0;
+    for (const c of comments) {
+      if (out.some((x) => x.commentId === c.commentId)) continue;
+      out.push(c);
+      added++;
+    }
+    const next = pick(body.result, "scrollId", "nextScrollId", "cursor", "nextCursor");
+    if (!next || next === scrollId || added === 0) break;
+    scrollId = next;
+  }
+  return out;
+}
+
+export function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}

--- a/tools/line-note-scraper/src/parse.mjs
+++ b/tools/line-note-scraper/src/parse.mjs
@@ -1,0 +1,80 @@
+// 記事本留言 → 「+1」訂單行的解析器。純函式、無相依，方便測試。
+//
+// 支援的寫法（每一行各自解析，一則留言可以有多筆）：
+//   +1            → qty 1
+//   ＋２ / + 3     → 全形、空白都吃
+//   A+1 / A +2    → code A, qty
+//   A1+1 / B-2+1  → code 可含數字、連字號（品項編號）
+//   +1 A          → qty 在前、code 在後
+//   A x2 / A*2 / A×2 / A２個 / A 2份 → code + 數量
+//   2份 / 3組 / 1個（沒 code）→ qty
+//   -1 / A-1 / 取消 / 退 → cancel:true（qty 為負或標記）
+//
+// 不猜的：純數字「2」、只有品名沒數量的行、聊天內容。這些回空陣列。
+
+const FULLWIDTH_DIGITS = "０１２３４５６７８９";
+
+export function normalize(text) {
+  return String(text ?? "")
+    .replace(/[０-９]/g, (ch) => String(FULLWIDTH_DIGITS.indexOf(ch)))
+    .replace(/[＋]/g, "+")
+    .replace(/[－—–]/g, "-")
+    .replace(/[×Ｘｘ＊]/g, "x")
+    .replace(/[　]/g, " ")
+    .replace(/[：]/g, ":");
+}
+
+const UNIT = "(?:份|個|组|組|包|盒|箱|瓶|罐|袋|條|片|支|入|件|套|杯|顆|粒|斤|台|本)?";
+// 品項代碼：英文字母開頭，可接數字／連字號（A、B2、C-1、AB）
+const CODE = "([A-Za-z][A-Za-z0-9-]{0,7})";
+const CANCEL_WORDS = /(取消|退|刪|删|不要了|改為0|改成0)/;
+
+const PATTERNS = [
+  // A+1 / A +2 / B-2+1 / 取消 A-1
+  { re: new RegExp(`^\\s*${CODE}\\s*([+-])\\s*(\\d{1,3})${UNIT}\\s*$`), map: (m) => ({ code: m[1], sign: m[2], qty: m[3] }) },
+  // +1 A / +2 B2
+  { re: new RegExp(`^\\s*([+-])\\s*(\\d{1,3})${UNIT}\\s*${CODE}\\s*$`), map: (m) => ({ code: m[3], sign: m[1], qty: m[2] }) },
+  // +1 / + 3
+  { re: new RegExp(`^\\s*([+-])\\s*(\\d{1,3})${UNIT}\\s*$`), map: (m) => ({ code: null, sign: m[1], qty: m[2] }) },
+  // A x2 / A*2 / A 2份 / A2份（要有單位或 x，避免把 A2 品號當成 A×2）
+  { re: new RegExp(`^\\s*${CODE}\\s*(?:x\\s*(\\d{1,3})${UNIT}|(\\d{1,3})(?:份|個|组|組|包|盒|箱|瓶|罐|袋|條|片|支|件|套|杯|顆|粒|斤|台|本))\\s*$`), map: (m) => ({ code: m[1], sign: "+", qty: m[2] ?? m[3] }) },
+  // 2份 / 3組（沒 code，但有單位）
+  { re: /^\s*(\d{1,3})(?:份|個|组|組|包|盒|箱|瓶|罐|袋|條|片|支|件|套|杯|顆|粒|斤|台|本)\s*$/, map: (m) => ({ code: null, sign: "+", qty: m[1] }) },
+];
+
+/**
+ * @param {string} text 留言原文
+ * @returns {{code:string|null, qty:number, cancel:boolean, line:string}[]}
+ */
+export function parseOrderLines(text) {
+  const out = [];
+  const norm = normalize(text);
+  for (const rawLine of norm.split(/\r?\n|[,，;；、]/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const cancelWord = CANCEL_WORDS.test(line);
+    // 把「取消」「退」這類字先拿掉再比對數量
+    const body = line.replace(CANCEL_WORDS, " ").trim();
+    let hit = null;
+    for (const p of PATTERNS) {
+      const m = body.match(p.re);
+      if (m) { hit = p.map(m); break; }
+    }
+    if (!hit) {
+      // 「取消」單獨一行也算一筆取消（qty 0，讓人工看）
+      if (cancelWord && body === "") out.push({ code: null, qty: 0, cancel: true, line });
+      continue;
+    }
+    const qty = Number(hit.qty);
+    if (!Number.isFinite(qty) || qty <= 0) continue;
+    const cancel = cancelWord || hit.sign === "-";
+    out.push({ code: hit.code ? hit.code.toUpperCase() : null, qty, cancel, line });
+  }
+  return out;
+}
+
+/** 貼文標題：取第一個非空白行，最多 60 字 */
+export function postTitle(text) {
+  const first = String(text ?? "").split(/\r?\n/).map((s) => s.trim()).find(Boolean) ?? "";
+  return first.length > 60 ? first.slice(0, 60) + "…" : first;
+}

--- a/tools/line-note-scraper/src/parse.test.mjs
+++ b/tools/line-note-scraper/src/parse.test.mjs
@@ -1,0 +1,72 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseOrderLines, postTitle, normalize } from "./parse.mjs";
+
+const one = (text) => parseOrderLines(text).map(({ code, qty, cancel }) => ({ code, qty, cancel }));
+
+test("plain +1 variants", () => {
+  assert.deepEqual(one("+1"), [{ code: null, qty: 1, cancel: false }]);
+  assert.deepEqual(one("＋２"), [{ code: null, qty: 2, cancel: false }]);
+  assert.deepEqual(one(" + 3 "), [{ code: null, qty: 3, cancel: false }]);
+  assert.deepEqual(one("+2份"), [{ code: null, qty: 2, cancel: false }]);
+});
+
+test("code before qty", () => {
+  assert.deepEqual(one("A+1"), [{ code: "A", qty: 1, cancel: false }]);
+  assert.deepEqual(one("b +2"), [{ code: "B", qty: 2, cancel: false }]);
+  assert.deepEqual(one("A1+1"), [{ code: "A1", qty: 1, cancel: false }]);
+  assert.deepEqual(one("B-2 +1"), [{ code: "B-2", qty: 1, cancel: false }]);
+  assert.deepEqual(one("A x2"), [{ code: "A", qty: 2, cancel: false }]);
+  assert.deepEqual(one("A×2"), [{ code: "A", qty: 2, cancel: false }]);
+  assert.deepEqual(one("C 3份"), [{ code: "C", qty: 3, cancel: false }]);
+});
+
+test("qty before code", () => {
+  assert.deepEqual(one("+1 A"), [{ code: "A", qty: 1, cancel: false }]);
+  assert.deepEqual(one("+2 b2"), [{ code: "B2", qty: 2, cancel: false }]);
+});
+
+test("units without code", () => {
+  assert.deepEqual(one("2份"), [{ code: null, qty: 2, cancel: false }]);
+  assert.deepEqual(one("3組"), [{ code: null, qty: 3, cancel: false }]);
+});
+
+test("multi-line and separators", () => {
+  assert.deepEqual(one("A+1\nB+2"), [
+    { code: "A", qty: 1, cancel: false },
+    { code: "B", qty: 2, cancel: false },
+  ]);
+  assert.deepEqual(one("A+1, B+2、C+3"), [
+    { code: "A", qty: 1, cancel: false },
+    { code: "B", qty: 2, cancel: false },
+    { code: "C", qty: 3, cancel: false },
+  ]);
+});
+
+test("cancellations", () => {
+  assert.deepEqual(one("-1"), [{ code: null, qty: 1, cancel: true }]);
+  assert.deepEqual(one("A-1"), [{ code: "A", qty: 1, cancel: true }]);
+  assert.deepEqual(one("取消 A+1"), [{ code: "A", qty: 1, cancel: true }]);
+  assert.deepEqual(one("退1"), []);
+  assert.deepEqual(one("取消"), [{ code: null, qty: 0, cancel: true }]);
+});
+
+test("ignores chatter and ambiguous lines", () => {
+  assert.deepEqual(one("請問還有嗎"), []);
+  assert.deepEqual(one("2"), []);
+  assert.deepEqual(one("A2"), []); // 品號還是 A×2 分不清 → 不猜
+  assert.deepEqual(one("好吃+1"), []); // 不是下單
+  assert.deepEqual(one(""), []);
+  assert.deepEqual(one(null), []);
+});
+
+test("code is limited to 8 chars", () => {
+  assert.deepEqual(one("ABCDEFGHI+1"), []);
+  assert.deepEqual(one("ABCDEFGH+1"), [{ code: "ABCDEFGH", qty: 1, cancel: false }]);
+});
+
+test("normalize + title", () => {
+  assert.equal(normalize("Ａ＋１"), "Ａ+1");
+  assert.equal(postTitle("\n  🍓 草莓開團  \n價格 100"), "🍓 草莓開團");
+  assert.equal(postTitle("x".repeat(70)).length, 61);
+});


### PR DESCRIPTION
## 做什麼

`tools/line-note-scraper/`：獨立的地端 CLI（不在 npm workspaces 內、不碰主站），用 [linejs](https://github.com/evex-dev/linejs) 以**備用 LINE 帳號**登入，讀 LINE 群組（`/mh`）與社群 OpenChat（`/sn`）記事本的貼文與留言，把 `+1` 留言解析成訂單行，輸出 JSON / CSV。

- `login`（QR + PIN）、`groups`（列群組 c… / 社群 s… / 社群聊天室 m…）、`posts`、`comments`、`scrape`
- `scrape` 產出 `posts.json`、`comments.json`、`comments.csv`、`orders.csv`（每筆 +1 一列）、`summary.csv`（貼文 × 品項小計）
- `+1` 解析器支援 `+1`、`＋２`、`A+1`、`B-2 +1`、`+1 A`、`A x2`、`A 2份`、`2份`、`-1` / `取消`；純數字、`A2` 這種分不清的不猜
- 記事本 REST 沒有 wire trace：host × 路徑前綴 × channel 做成候選清單，第一組回 `code 0` 的記住，全部失敗會列出每次嘗試；也可用環境變數硬指定

## 沒驗到的

- 本沙盒連不到 LINE、也裝不了 linejs，**只有 `+1` 解析器有單元測試（9/9）**；登入與記事本 API 要在地端實跑。
- 社群留言只有社群成員 id（p…）＋暱稱，拿不到真實帳號。

## 風險

走 LINE 非官方協定，違反使用條款、帳號可能被停權。README 有寫：只用備用帳號。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ)_