### PR TITLE
fix(tools): line-note-scraper 的 @jsr .npmrc 要 commit，否則 npm install 一定 404

### DIFF
--- a/tools/line-note-scraper/.npmrc
+++ b/tools/line-note-scraper/.npmrc
@@ -1,0 +1,1 @@
+@jsr:registry=https://npm.jsr.io

--- a/tools/line-note-scraper/README.md
+++ b/tools/line-note-scraper/README.md
@@ -9,9 +9,13 @@
 
 ```bash
 cd tools/line-note-scraper
-npx jsr add @evex/linejs      # 會寫 .npmrc（@jsr registry）並補 package.json 相依
 npm install
 ```
+
+`.npmrc`（`@jsr:registry`）已經 commit 進來了，直接 `npm install` 就好。
+**不要再跑 `npx jsr add @evex/linejs`** —— 這個 repo 根目錄有 package.json，
+jsr 會把 `.npmrc` 寫到 **repo 根目錄**而不是這個資料夾，而 npm 只讀 cwd 的 `.npmrc`
+（不會往上層找），於是 `@jsr/evex__linejs` 照樣去打 registry.npmjs.org、回 404 Not Found。
 
 ## 使用
 

--- a/tools/line-note-scraper/package-lock.json
+++ b/tools/line-note-scraper/package-lock.json
@@ -1,0 +1,222 @@
+{
+  "name": "line-note-scraper",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "line-note-scraper",
+      "version": "0.1.0",
+      "dependencies": {
+        "@evex/linejs": "npm:@jsr/evex__linejs@^3.4.2",
+        "qrcode-terminal": "^0.12.0"
+      },
+      "bin": {
+        "line-notes": "src/cli.mjs"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@evex/linejs": {
+      "name": "@jsr/evex__linejs",
+      "version": "3.4.2",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/evex__linejs/3.4.2.tgz",
+      "integrity": "sha512-nq7q2DKMdOUn1bK5I2sdTb0waaD0JkK/8Zi18T8iQA+nsHLJSlXuTYpvQcfrY2EFPu5IJ5HEUaiJfOkVIzTWIg==",
+      "dependencies": {
+        "@jsr/evex__linejs-types": "^3.4.2",
+        "@jsr/evex__loose-types": "^1.0.1",
+        "@noble/ciphers": "^2.2",
+        "@types/node-int64": "^0.4.32",
+        "@types/thrift": "^0.10.17",
+        "crypto-js": "^4.2.0",
+        "curve25519-js": "^0.0.4",
+        "node-bignumber": "^1.2.2",
+        "node-int64": "^0.4.0",
+        "opusscript": "^0.1.1",
+        "thrift": "^0.20.0",
+        "tweetnacl": "^1.0.3",
+        "undici": "^7"
+      }
+    },
+    "node_modules/@jsr/evex__linejs-types": {
+      "version": "3.4.2",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/evex__linejs-types/3.4.2.tgz",
+      "integrity": "sha512-3eQqLqjf4y2RINj2LD4HM+sApxZF54y8+GxredjzuS1yw5ppvtNhhzMkIEDqFlsMnbE0drSCAySKNo3USiKMzA==",
+      "dependencies": {
+        "@jsr/evex__loose-types": "^1.0.1"
+      }
+    },
+    "node_modules/@jsr/evex__loose-types": {
+      "version": "1.0.1",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/evex__loose-types/1.0.1.tgz",
+      "integrity": "sha512-ENNSHt+xHtkMJj+wp4dGWpLVY3J/BPSfXOo2u6ObFCuLN/hL71HUNQ/xB32jiqQj+u8nqWlGuenH1toFLDYM6Q=="
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.4.0.tgz",
+      "integrity": "sha512-AnjFn0Jv92laAkvMrghlFZq4qQCIN/4DxFV/eooqtC2YTjB7kBeLMS2T9KJX4Dn+ZVXLOwK0lSgqDtx9gvxtiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.9.0"
+      }
+    },
+    "node_modules/@types/node-int64": {
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@types/node-int64/-/node-int64-0.4.32.tgz",
+      "integrity": "sha512-xf/JsSlnXQ+mzvc0IpXemcrO4BrCfpgNpMco+GLcXkFk01k/gW9lGJu+Vof0ZSvHK6DsHJDPSbjFPs36QkWXqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/q": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.8.tgz",
+      "integrity": "sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/thrift": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@types/thrift/-/thrift-0.10.17.tgz",
+      "integrity": "sha512-bDX6d5a5ZDWC81tgDv224n/3PKNYfIQJTPHzlbk4vBWJrYXF6Tg1ncaVmP/c3JbGN2AK9p7zmHorJC2D6oejGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/node-int64": "*",
+        "@types/q": "*"
+      }
+    },
+    "node_modules/async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "license": "MIT"
+    },
+    "node_modules/browser-or-node": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.3.0.tgz",
+      "integrity": "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==",
+      "license": "MIT"
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "deprecated": "Active development of CryptoJS has been discontinued. This library is no longer maintained.",
+      "license": "MIT"
+    },
+    "node_modules/curve25519-js": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/curve25519-js/-/curve25519-js-0.0.4.tgz",
+      "integrity": "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==",
+      "license": "MIT"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/node-bignumber": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/node-bignumber/-/node-bignumber-1.2.2.tgz",
+      "integrity": "sha512-VoTZHmdFQpZH1+q1dz2qcHNCwTWsJg2T3PYwlAyDNFOfVhSYUKQBLFcCpCud+wJBGgCttGavZILaIggDIKqEQQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT"
+    },
+    "node_modules/opusscript": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.1.1.tgz",
+      "integrity": "sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA==",
+      "license": "MIT"
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/thrift": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.20.0.tgz",
+      "integrity": "sha512-oSmJTaoIAGolpupVHFfsWcmdEKX81fcDI6ty0hhezzdgZvp0XyXgMe9+1YusI8Ahy0HK4n8jlNrkPjOPeHZjdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "browser-or-node": "^1.2.1",
+        "isomorphic-ws": "^4.0.1",
+        "node-int64": "^0.4.0",
+        "q": "^1.5.0",
+        "ws": "^5.2.3"
+      },
+      "engines": {
+        "node": ">= 10.18.0"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/undici": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.7.tgz",
+      "integrity": "sha512-Yp1RXz/2h2qC/Gy7d5mqQcpuCWbXiO6FgYw/jTbSvytZF9wD7fh7od+6WzWR/y9EAnXcJjQZpPkYVmj3T2bj+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 問題

照 README 走安裝步驟會失敗：

```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@jsr%2fevex__linejs - Not found
```

`npx jsr add @evex/linejs` 會找「專案根目錄」寫 `.npmrc`，而這個 repo 根目錄有 package.json
→ 檔案被寫到 **repo 根目錄**，不是 `tools/line-note-scraper/`。
npm 只讀 cwd 的 `.npmrc`、**不會往上層目錄找**，所以在工具資料夾底下跑 install 時
`@jsr` scope 沒有 registry，照樣去打 registry.npmjs.org，回 404。

## 改法

- 把 `.npmrc`（`@jsr:registry=https://npm.jsr.io`）commit 進 `tools/line-note-scraper/`
- 附上 `package-lock.json`，版本可重現
- README 安裝步驟簡化成 `npm install`，並標注不要再跑 `npx jsr add`

## 實測

| 步驟 | 結果 |
|---|---|
| `npm install` | 23 個套件，含 `@evex/linejs` |
| `npm run login` | 掃 QR + PIN 成功，token 寫進 storage.json（已 gitignore） |
| `npm run groups` | 列出 70 個 home（60 群組 / 5 社群 / 5 社群聊天室） |

沒有動 `src/` 任何一行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)