### PR TITLE
feat(tools): line-note-scraper 新增 post 指令（發文到記事本）

### DIFF
--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -106,6 +106,7 @@ const NAV: NavGroup[] = [
       { href: "/staff", label: "員工管理", match: /^\/staff/ },
       { href: "/stores", label: "門市", match: /^\/stores/ },
       { href: "/fb-pages", label: "FB 粉絲團", match: /^\/fb-pages/ },
+      { href: "/line-notes", label: "LINE 記事本", match: /^\/line-notes/ },
     ],
   },
 ];
@@ -140,6 +141,7 @@ const BRANCH_HIDDEN_HREFS = new Set([
   "/finance/receivables", // HQ 應收
   "/stores",              // 門市設定 (HQ 管理)
   "/fb-pages",            // 粉絲團設定 (HQ 管理)
+  "/line-notes",          // LINE 記事本 (HQ 管理；帳號登入 token 在這)
 ]);
 const BRANCH_HIDDEN_GROUPS = new Set([
   "社群選品", // 整個 group 隱藏

--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -1,0 +1,612 @@
+"use client";
+
+// LINE 記事本：帳號（備用 LINE 帳號登入）→ 社群設定 → 開團自動發文 → 定時讀留言加單。
+// 真正跟 LINE 講話的是地端 worker（tools/line-note-scraper/src/worker.mjs），
+// 這頁只做設定、丟工作（line_note_jobs）、看結果。
+
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { getSupabase } from "@/lib/supabase";
+import SpinButton from "@/components/SpinButton";
+import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
+import { translateRpcError } from "@/lib/rpcError";
+
+type Account = {
+  id: number; label: string; status: "logged_out" | "pending_qr" | "active" | "error";
+  line_mid: string | null; display_name: string | null;
+  qr_image: string | null; qr_url: string | null; pin_code: string | null;
+  last_error: string | null; last_seen_at: string | null;
+};
+type Channel = { id: number; code: string; name: string; channel_type: string; home_store_id: number };
+type Community = {
+  id: number; account_id: number; channel_id: number; home_id: string; home_name: string | null;
+  home_kind: "group" | "square" | "square_chat"; listen_enabled: boolean; read_times: string[];
+  auto_post_on_open: boolean; post_template: string | null; last_read_at: string | null; last_error: string | null;
+};
+type Post = {
+  id: number; community_id: number; campaign_id: number; line_post_id: string | null; text: string | null;
+  status: "queued" | "posted" | "failed" | "closed"; posted_at: string | null; last_read_at: string | null;
+  comment_count: number; last_error: string | null; created_at: string;
+  group_buy_campaigns: { id: number; campaign_no: string; name: string; status: string } | null;
+};
+type Comment = {
+  id: number; line_comment_id: string; commenter_id: string | null; commenter_name: string | null; text: string;
+  commented_at: string | null; member_no_hint: string | null; parsed: { code: string | null; qty: number; cancel: boolean }[];
+  status: "pending" | "ordered" | "unmatched" | "no_order" | "error" | "ignored";
+  member_id: number | null; customer_order_id: number | null; error: string | null;
+};
+type Home = { kind: string; homeId: string; name: string };
+type Campaign = { id: number; campaign_no: string; name: string; status: string };
+
+const ACCOUNT_STATUS: Record<Account["status"], string> = {
+  logged_out: "未登入", pending_qr: "等待掃 QR", active: "已登入", error: "錯誤",
+};
+const POST_STATUS: Record<Post["status"], string> = { queued: "排隊中", posted: "已發文", failed: "失敗", closed: "已結束" };
+const COMMENT_STATUS: Record<Comment["status"], string> = {
+  pending: "待處理", ordered: "已加單", unmatched: "找不到會員", no_order: "非下單", error: "錯誤", ignored: "忽略",
+};
+const KIND_LABEL: Record<string, string> = { group: "群組", square: "社群", square_chat: "社群聊天室" };
+
+const fmt = (iso: string | null | undefined) =>
+  iso ? new Date(iso).toLocaleString("zh-TW", { hour12: false, month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" }) : "—";
+const kindOf = (homeId: string): Community["home_kind"] =>
+  homeId.startsWith("c") ? "group" : homeId.startsWith("s") ? "square" : "square_chat";
+
+function Badge({ tone, children }: { tone: "gray" | "green" | "amber" | "red" | "blue"; children: ReactNode }) {
+  const cls = {
+    gray: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+    green: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
+    amber: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+    red: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
+    blue: "bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-300",
+  }[tone];
+  return <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${cls}`}>{children}</span>;
+}
+
+const btn = "rounded border border-zinc-300 px-2.5 py-1 text-sm hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800";
+const btnPrimary = "rounded bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900";
+const input = "w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900";
+
+export default function LineNotesPage() {
+  const [tab, setTab] = useState<"accounts" | "communities" | "posts">("accounts");
+  const [accounts, setAccounts] = useState<Account[] | null>(null);
+  const [channels, setChannels] = useState<Channel[]>([]);
+  const [communities, setCommunities] = useState<Community[] | null>(null);
+  const [posts, setPosts] = useState<Post[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const notify = useCallback((msg: string) => { setToast(msg); setTimeout(() => setToast(null), 3000); }, []);
+  const fail = useCallback((e: unknown) => setError(translateRpcError(e)), []);
+
+  const loadAccounts = useCallback(async () => {
+    const { data, error } = await getSupabase().from("v_line_note_accounts").select("*").order("id");
+    if (error) fail(error); else setAccounts((data ?? []) as Account[]);
+  }, [fail]);
+  const loadCommunities = useCallback(async () => {
+    const sb = getSupabase();
+    const [c, ch] = await Promise.all([
+      sb.from("line_note_communities").select("*").order("id"),
+      sb.from("line_channels").select("id,code,name,channel_type,home_store_id").eq("is_active", true).order("name"),
+    ]);
+    if (c.error) fail(c.error); else setCommunities((c.data ?? []) as Community[]);
+    if (!ch.error) setChannels((ch.data ?? []) as Channel[]);
+  }, [fail]);
+  const loadPosts = useCallback(async () => {
+    const { data, error } = await getSupabase()
+      .from("line_note_posts")
+      .select("*,group_buy_campaigns(id,campaign_no,name,status)")
+      .order("created_at", { ascending: false })
+      .limit(100);
+    if (error) fail(error); else setPosts((data ?? []) as Post[]);
+  }, [fail]);
+
+  useEffect(() => { void loadAccounts(); void loadCommunities(); void loadPosts(); }, [loadAccounts, loadCommunities, loadPosts]);
+
+  // 帳號狀態每 3 秒刷新（登入中 / worker 有沒有在跑）
+  useEffect(() => {
+    const t = setInterval(() => { void loadAccounts(); }, 3000);
+    return () => clearInterval(t);
+  }, [loadAccounts]);
+
+  const accountById = useMemo(() => new Map((accounts ?? []).map((a) => [a.id, a])), [accounts]);
+  const channelById = useMemo(() => new Map(channels.map((c) => [c.id, c])), [channels]);
+  const communityById = useMemo(() => new Map((communities ?? []).map((c) => [c.id, c])), [communities]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-2">
+        <div>
+          <h1 className="text-xl font-semibold">LINE 記事本</h1>
+          <p className="text-sm text-zinc-500">
+            備用 LINE 帳號登入 → 綁社群 → 開團自動發文 → 定時讀留言，留言裡的「會員編號 6 碼 ＋ A+1」自動加單。
+            要有地端 worker 在跑（<code>tools/line-note-scraper</code>：<code>npm run worker</code>）。
+          </p>
+        </div>
+        <nav className="flex gap-1 rounded-lg bg-zinc-100 p-1 dark:bg-zinc-800">
+          {([["accounts", "帳號"], ["communities", "社群設定"], ["posts", "貼文與留言"]] as const).map(([k, l]) => (
+            <button key={k} type="button" onClick={() => setTab(k)}
+              className={`rounded-md px-3 py-1 text-sm ${tab === k ? "bg-white shadow dark:bg-zinc-900" : "text-zinc-600 dark:text-zinc-300"}`}>
+              {l}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {error && (
+        <div className="flex items-start justify-between rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
+          <span className="whitespace-pre-wrap">{error}</span>
+          <button type="button" className="ml-3 text-xs underline" onClick={() => setError(null)}>關閉</button>
+        </div>
+      )}
+      {toast && <div className="rounded bg-emerald-600 px-3 py-2 text-sm text-white">{toast}</div>}
+
+      {tab === "accounts" && (
+        <AccountsTab accounts={accounts} reload={loadAccounts} notify={notify} fail={fail} />
+      )}
+      {tab === "communities" && (
+        <CommunitiesTab
+          communities={communities} accounts={accounts ?? []} channels={channels}
+          accountById={accountById} channelById={channelById}
+          reload={loadCommunities} reloadPosts={loadPosts} notify={notify} fail={fail}
+        />
+      )}
+      {tab === "posts" && (
+        <PostsTab posts={posts} communityById={communityById} reload={loadPosts} notify={notify} fail={fail} />
+      )}
+    </div>
+  );
+}
+
+// ── 帳號 ────────────────────────────────────────────────────────────────────
+function AccountsTab({ accounts, reload, notify, fail }: {
+  accounts: Account[] | null; reload: () => Promise<void>; notify: (m: string) => void; fail: (e: unknown) => void;
+}) {
+  const [busy, setBusy] = useState<number | "new" | null>(null);
+  const [loginId, setLoginId] = useState<number | null>(null);
+  const loginAccount = loginId == null ? null : accounts?.find((a) => a.id === loginId) ?? null;
+
+  const addAccount = async () => {
+    const label = window.prompt("帳號名稱（例：社群小幫手 1）");
+    if (!label?.trim()) return;
+    setBusy("new");
+    const { error } = await getSupabase().rpc("rpc_line_note_account_upsert", { p_id: null, p_label: label.trim() });
+    setBusy(null);
+    if (error) return fail(error);
+    notify("已新增帳號");
+    await reload();
+  };
+  const enqueue = async (a: Account, kind: "login" | "logout") => {
+    setBusy(a.id);
+    const { error } = await getSupabase().rpc("rpc_line_note_enqueue", { p_kind: kind, p_account_id: a.id });
+    setBusy(null);
+    if (error) return fail(error);
+    if (kind === "login") setLoginId(a.id);
+    else notify("已送出登出");
+    await reload();
+  };
+  const remove = async (a: Account) => {
+    if (!window.confirm(`刪除帳號「${a.label}」？底下的社群設定與貼文紀錄會一起刪掉。`)) return;
+    setBusy(a.id);
+    const { error } = await getSupabase().rpc("rpc_line_note_account_delete", { p_id: a.id });
+    setBusy(null);
+    if (error) return fail(error);
+    notify("已刪除");
+    await reload();
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-zinc-500">一個帳號可以進多個社群；不同社群要用不同帳號就多建幾個。<b>只用備用帳號</b>，可能被 LINE 停權。</p>
+        <SpinButton type="button" className={btnPrimary} loading={busy === "new"} onClick={addAccount}>＋ 新增帳號</SpinButton>
+      </div>
+      <Table>
+        <THead><Tr><Th>名稱</Th><Th>狀態</Th><Th>LINE 顯示名稱</Th><Th>最後活動</Th><Th>錯誤</Th><Th align="right">操作</Th></Tr></THead>
+        <TBody>
+          {accounts === null ? <LoadingRow colSpan={6} /> : accounts.length === 0 ? <EmptyRow colSpan={6}>還沒有帳號</EmptyRow> : accounts.map((a) => (
+            <Tr key={a.id}>
+              <Td>{a.label}</Td>
+              <Td>
+                <Badge tone={a.status === "active" ? "green" : a.status === "pending_qr" ? "amber" : a.status === "error" ? "red" : "gray"}>
+                  {ACCOUNT_STATUS[a.status]}
+                </Badge>
+              </Td>
+              <Td>{a.display_name ?? "—"}</Td>
+              <Td>{fmt(a.last_seen_at)}</Td>
+              <Td className="max-w-xs truncate text-xs text-red-600" title={a.last_error ?? ""}>{a.last_error ?? ""}</Td>
+              <Td align="right">
+                <div className="flex justify-end gap-1">
+                  {a.status === "pending_qr" && <button type="button" className={btn} onClick={() => setLoginId(a.id)}>看 QR</button>}
+                  {a.status !== "active" && <SpinButton type="button" className={btn} loading={busy === a.id} onClick={() => enqueue(a, "login")}>登入</SpinButton>}
+                  {a.status === "active" && <SpinButton type="button" className={btn} loading={busy === a.id} onClick={() => enqueue(a, "logout")}>登出</SpinButton>}
+                  <SpinButton type="button" className={`${btn} text-red-600`} loading={busy === a.id} onClick={() => remove(a)}>刪除</SpinButton>
+                </div>
+              </Td>
+            </Tr>
+          ))}
+        </TBody>
+      </Table>
+
+      {loginAccount && (
+        <Modal title={`登入「${loginAccount.label}」`} onClose={() => setLoginId(null)}>
+          {loginAccount.status === "active" ? (
+            <p className="text-emerald-700">✅ 已登入：{loginAccount.display_name}</p>
+          ) : loginAccount.status === "error" ? (
+            <p className="whitespace-pre-wrap text-red-600">登入失敗：{loginAccount.last_error}</p>
+          ) : !loginAccount.qr_image && !loginAccount.qr_url ? (
+            <p className="text-zinc-500">等待 worker 產生 QR…（worker 沒在跑的話會一直停在這裡）</p>
+          ) : (
+            <div className="space-y-3 text-center">
+              {loginAccount.qr_image
+                // eslint-disable-next-line @next/next/no-img-element -- data URL，不走 next/image
+                ? <img src={loginAccount.qr_image} alt="LINE 登入 QR" className="mx-auto h-64 w-64" />
+                : <a className="break-all text-sky-700 underline" href={loginAccount.qr_url ?? "#"} target="_blank" rel="noreferrer">{loginAccount.qr_url}</a>}
+              <p className="text-sm">用<b>備用帳號</b>的手機 LINE 掃描（LINE → 加入好友 → 行動條碼）。</p>
+              {loginAccount.pin_code && (
+                <p className="text-lg">手機會要你輸入 PIN：<b className="font-mono text-2xl tracking-widest">{loginAccount.pin_code}</b></p>
+              )}
+            </div>
+          )}
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+// ── 社群設定 ─────────────────────────────────────────────────────────────────
+type CommunityForm = {
+  id: number | null; account_id: number | ""; channel_id: number | ""; home_id: string; home_name: string;
+  listen_enabled: boolean; read_times: string; auto_post_on_open: boolean; post_template: string;
+};
+const EMPTY_FORM: CommunityForm = {
+  id: null, account_id: "", channel_id: "", home_id: "", home_name: "",
+  listen_enabled: true, read_times: "12:00", auto_post_on_open: true, post_template: "",
+};
+
+function CommunitiesTab({ communities, accounts, channels, accountById, channelById, reload, reloadPosts, notify, fail }: {
+  communities: Community[] | null; accounts: Account[]; channels: Channel[];
+  accountById: Map<number, Account>; channelById: Map<number, Channel>;
+  reload: () => Promise<void>; reloadPosts: () => Promise<void>; notify: (m: string) => void; fail: (e: unknown) => void;
+}) {
+  const [form, setForm] = useState<CommunityForm | null>(null);
+  const [busy, setBusy] = useState<number | "save" | "homes" | null>(null);
+  const [homes, setHomes] = useState<Home[] | null>(null);
+  const [postFor, setPostFor] = useState<Community | null>(null);
+
+  const openNew = () => { setHomes(null); setForm({ ...EMPTY_FORM, account_id: accounts[0]?.id ?? "", channel_id: channels[0]?.id ?? "" }); };
+  const openEdit = (c: Community) => {
+    setHomes(null);
+    setForm({ id: c.id, account_id: c.account_id, channel_id: c.channel_id, home_id: c.home_id, home_name: c.home_name ?? "",
+      listen_enabled: c.listen_enabled, read_times: c.read_times.join(", "), auto_post_on_open: c.auto_post_on_open, post_template: c.post_template ?? "" });
+  };
+
+  const loadHomes = async () => {
+    if (!form || form.account_id === "") return;
+    setBusy("homes");
+    try {
+      const sb = getSupabase();
+      const { data: jobId, error } = await sb.rpc("rpc_line_note_enqueue", { p_kind: "list_homes", p_account_id: form.account_id });
+      if (error) throw error;
+      for (let i = 0; i < 40; i++) {
+        await new Promise((r) => setTimeout(r, 1500));
+        const { data } = await sb.from("line_note_jobs").select("status,result,error").eq("id", jobId).single();
+        if (data?.status === "done") { setHomes(((data.result as { homes?: Home[] })?.homes) ?? []); return; }
+        if (data?.status === "failed") throw new Error(data.error ?? "worker 回報失敗");
+      }
+      throw new Error("等太久沒回應：worker 有在跑嗎？帳號登入了嗎？");
+    } catch (e) { fail(e); } finally { setBusy(null); }
+  };
+
+  const save = async () => {
+    if (!form) return;
+    setBusy("save");
+    const { error } = await getSupabase().rpc("rpc_line_note_community_upsert", {
+      p_id: form.id, p_account_id: form.account_id || null, p_channel_id: form.channel_id || null,
+      p_home_id: form.home_id.trim(), p_home_name: form.home_name.trim() || null, p_home_kind: kindOf(form.home_id.trim()),
+      p_listen_enabled: form.listen_enabled,
+      p_read_times: form.read_times.split(/[,\s，、]+/).map((s) => s.trim()).filter(Boolean),
+      p_auto_post_on_open: form.auto_post_on_open, p_post_template: form.post_template || null,
+    });
+    setBusy(null);
+    if (error) return fail(error);
+    notify("已儲存");
+    setForm(null);
+    await reload();
+  };
+  const remove = async (c: Community) => {
+    if (!window.confirm(`刪除社群「${c.home_name || c.home_id}」的設定？`)) return;
+    setBusy(c.id);
+    const { error } = await getSupabase().rpc("rpc_line_note_community_delete", { p_id: c.id });
+    setBusy(null);
+    if (error) return fail(error);
+    await reload();
+  };
+  const readNow = async (c: Community) => {
+    setBusy(c.id);
+    const { error } = await getSupabase().rpc("rpc_line_note_enqueue", { p_kind: "read", p_account_id: c.account_id, p_community_id: c.id });
+    setBusy(null);
+    if (error) return fail(error);
+    notify("已排立即讀取，worker 跑完後到「貼文與留言」看");
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-zinc-500">
+          「取貨門市」跟開團的 LINE 渠道共用（line_channels）：開團時有勾到這個渠道，才會自動發到這個社群；加單的取貨店也用渠道的主店。
+        </p>
+        <button type="button" className={btnPrimary} onClick={openNew} disabled={accounts.length === 0}>＋ 新增社群</button>
+      </div>
+      <Table>
+        <THead><Tr><Th>社群</Th><Th>帳號</Th><Th>渠道 / 取貨店</Th><Th>監聽</Th><Th>讀取時間</Th><Th>開團自動發文</Th><Th>最後讀取</Th><Th align="right">操作</Th></Tr></THead>
+        <TBody>
+          {communities === null ? <LoadingRow colSpan={8} /> : communities.length === 0 ? <EmptyRow colSpan={8}>還沒有社群</EmptyRow> : communities.map((c) => {
+            const a = accountById.get(c.account_id);
+            return (
+              <Tr key={c.id}>
+                <Td>
+                  <div>{c.home_name || c.home_id}</div>
+                  <div className="text-xs text-zinc-500">{KIND_LABEL[c.home_kind]} · <span className="font-mono">{c.home_id}</span></div>
+                  {c.last_error && <div className="text-xs text-red-600">{c.last_error}</div>}
+                </Td>
+                <Td>{a ? <>{a.label} <Badge tone={a.status === "active" ? "green" : "red"}>{ACCOUNT_STATUS[a.status]}</Badge></> : "—"}</Td>
+                <Td>{channelById.get(c.channel_id)?.name ?? c.channel_id}</Td>
+                <Td><Badge tone={c.listen_enabled ? "green" : "gray"}>{c.listen_enabled ? "監聽中" : "停用"}</Badge></Td>
+                <Td className="font-mono text-xs">{c.read_times.join(" ")}</Td>
+                <Td>{c.auto_post_on_open ? "是" : "否"}</Td>
+                <Td>{fmt(c.last_read_at)}</Td>
+                <Td align="right">
+                  <div className="flex justify-end gap-1">
+                    <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => readNow(c)}>立即讀取</SpinButton>
+                    <button type="button" className={btn} onClick={() => setPostFor(c)}>發文</button>
+                    <button type="button" className={btn} onClick={() => openEdit(c)}>編輯</button>
+                    <SpinButton type="button" className={`${btn} text-red-600`} loading={busy === c.id} onClick={() => remove(c)}>刪除</SpinButton>
+                  </div>
+                </Td>
+              </Tr>
+            );
+          })}
+        </TBody>
+      </Table>
+
+      {form && (
+        <Modal title={form.id ? "編輯社群" : "新增社群"} onClose={() => setForm(null)} wide>
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="text-sm">帳號
+              <select className={input} value={form.account_id} onChange={(e) => setForm({ ...form, account_id: Number(e.target.value) })}>
+                {accounts.map((a) => <option key={a.id} value={a.id}>{a.label}（{ACCOUNT_STATUS[a.status]}）</option>)}
+              </select>
+            </label>
+            <label className="text-sm">渠道（決定取貨店）
+              <select className={input} value={form.channel_id} onChange={(e) => setForm({ ...form, channel_id: Number(e.target.value) })}>
+                {channels.map((ch) => <option key={ch.id} value={ch.id}>{ch.name}（{ch.code}）</option>)}
+              </select>
+            </label>
+            <div className="text-sm md:col-span-2">
+              <div className="flex items-end gap-2">
+                <label className="flex-1">社群 homeId
+                  <input className={`${input} font-mono`} value={form.home_id} placeholder="m… / c… / s…"
+                    onChange={(e) => setForm({ ...form, home_id: e.target.value })} />
+                </label>
+                <SpinButton type="button" className={btn} loading={busy === "homes"} onClick={loadHomes}>從帳號載入清單</SpinButton>
+              </div>
+              {homes && (
+                <select className={`${input} mt-2`} size={Math.min(8, Math.max(2, homes.length))}
+                  onChange={(e) => { const h = homes.find((x) => x.homeId === e.target.value); if (h) setForm({ ...form, home_id: h.homeId, home_name: h.name }); }}>
+                  {homes.length === 0 && <option disabled>這個帳號沒有加入任何群組／社群</option>}
+                  {homes.map((h) => <option key={h.homeId} value={h.homeId}>[{KIND_LABEL[h.kind] ?? h.kind}] {h.name} — {h.homeId}</option>)}
+                </select>
+              )}
+              <p className="mt-1 text-xs text-zinc-500">社群記事本先選「社群聊天室」（m…）；不行再試「社群」（s…）。群組用 c…。</p>
+            </div>
+            <label className="text-sm">顯示名稱
+              <input className={input} value={form.home_name} onChange={(e) => setForm({ ...form, home_name: e.target.value })} />
+            </label>
+            <label className="text-sm">讀留言時間（台北，HH:MM，逗號分隔）
+              <input className={`${input} font-mono`} value={form.read_times} onChange={(e) => setForm({ ...form, read_times: e.target.value })} placeholder="09:00, 12:00, 18:00" />
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={form.listen_enabled} onChange={(e) => setForm({ ...form, listen_enabled: e.target.checked })} /> 啟用監聽（到時間自動讀留言加單）
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={form.auto_post_on_open} onChange={(e) => setForm({ ...form, auto_post_on_open: e.target.checked })} /> 開團（狀態變「開團中」）時自動發文
+            </label>
+            <label className="text-sm md:col-span-2">發文模板（留空用預設；可用 {"{{name}} {{description}} {{items}} {{end_at}} {{pickup_deadline}}"}）
+              <textarea className={`${input} h-40 font-mono text-xs`} value={form.post_template} onChange={(e) => setForm({ ...form, post_template: e.target.value })}
+                placeholder={"📣 {{name}}\n{{description}}\n\n{{items}}\n\n⏰ 收單：{{end_at}}\n📝 留言「會員編號 6 碼 ＋ A+1」"} />
+            </label>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <button type="button" className={btn} onClick={() => setForm(null)}>取消</button>
+            <SpinButton type="button" className={btnPrimary} loading={busy === "save"} onClick={save}>儲存</SpinButton>
+          </div>
+        </Modal>
+      )}
+
+      {postFor && <PostCampaignModal community={postFor} onClose={() => setPostFor(null)} notify={notify} fail={fail} reloadPosts={reloadPosts} />}
+    </div>
+  );
+}
+
+function PostCampaignModal({ community, onClose, notify, fail, reloadPosts }: {
+  community: Community; onClose: () => void; notify: (m: string) => void; fail: (e: unknown) => void; reloadPosts: () => Promise<void>;
+}) {
+  const [campaigns, setCampaigns] = useState<Campaign[] | null>(null);
+  const [campaignId, setCampaignId] = useState<number | "">("");
+  const [busy, setBusy] = useState(false);
+  useEffect(() => {
+    void (async () => {
+      const { data, error } = await getSupabase().from("group_buy_campaigns")
+        .select("id,campaign_no,name,status").in("status", ["open", "closed"]).order("id", { ascending: false }).limit(50);
+      if (error) fail(error); else { setCampaigns((data ?? []) as Campaign[]); setCampaignId((data?.[0] as Campaign | undefined)?.id ?? ""); }
+    })();
+  }, [fail]);
+  const submit = async () => {
+    if (campaignId === "") return;
+    setBusy(true);
+    const { error } = await getSupabase().rpc("rpc_line_note_queue_post", { p_community_id: community.id, p_campaign_id: campaignId });
+    setBusy(false);
+    if (error) return fail(error);
+    notify("已排發文，worker 跑完後到「貼文與留言」看");
+    onClose();
+    await reloadPosts();
+  };
+  return (
+    <Modal title={`發文到「${community.home_name || community.home_id}」`} onClose={onClose}>
+      <label className="text-sm">選擇要發的團（開團中／已收單）
+        <select className={input} value={campaignId} onChange={(e) => setCampaignId(Number(e.target.value))}>
+          {(campaigns ?? []).map((c) => <option key={c.id} value={c.id}>{c.campaign_no} {c.name}（{c.status}）</option>)}
+        </select>
+      </label>
+      <div className="mt-4 flex justify-end gap-2">
+        <button type="button" className={btn} onClick={onClose}>取消</button>
+        <SpinButton type="button" className={btnPrimary} loading={busy} disabled={campaignId === ""} onClick={submit}>發文</SpinButton>
+      </div>
+    </Modal>
+  );
+}
+
+// ── 貼文與留言 ───────────────────────────────────────────────────────────────
+function PostsTab({ posts, communityById, reload, notify, fail }: {
+  posts: Post[] | null; communityById: Map<number, Community>; reload: () => Promise<void>; notify: (m: string) => void; fail: (e: unknown) => void;
+}) {
+  const [selected, setSelected] = useState<Post | null>(null);
+  const [comments, setComments] = useState<Comment[] | null>(null);
+  const [busy, setBusy] = useState<number | null>(null);
+
+  const loadComments = useCallback(async (post: Post) => {
+    const { data, error } = await getSupabase().from("line_note_comments").select("*").eq("post_id", post.id).order("commented_at", { ascending: true }).order("id");
+    if (error) fail(error); else setComments((data ?? []) as Comment[]);
+  }, [fail]);
+  useEffect(() => { if (selected) void loadComments(selected); else setComments(null); }, [selected, loadComments]);
+
+  const retry = async (c: Comment) => {
+    setBusy(c.id);
+    const { data, error } = await getSupabase().rpc("rpc_line_note_apply_comment", { p_comment_id: c.id });
+    setBusy(null);
+    if (error) return fail(error);
+    const r = (Array.isArray(data) ? data[0] : data) as { out_status?: string; out_error?: string } | null;
+    notify(r?.out_status === "ordered" ? "已加單" : `結果：${COMMENT_STATUS[(r?.out_status ?? "error") as Comment["status"]] ?? r?.out_status}${r?.out_error ? "：" + r.out_error : ""}`);
+    if (selected) await loadComments(selected);
+  };
+  const setStatus = async (c: Comment, status: Comment["status"]) => {
+    setBusy(c.id);
+    const { error } = await getSupabase().from("line_note_comments").update({ status, error: null }).eq("id", c.id);
+    setBusy(null);
+    if (error) return fail(error);
+    if (selected) await loadComments(selected);
+  };
+  const readNow = async (p: Post) => {
+    const c = communityById.get(p.community_id);
+    if (!c) return;
+    setBusy(p.id);
+    const { error } = await getSupabase().rpc("rpc_line_note_enqueue", { p_kind: "read", p_account_id: c.account_id, p_community_id: c.id, p_post_id: p.id });
+    setBusy(null);
+    if (error) return fail(error);
+    notify("已排讀取這篇");
+  };
+
+  const summary = useMemo(() => {
+    if (!comments) return null;
+    const n = (s: Comment["status"]) => comments.filter((c) => c.status === s).length;
+    return { ordered: n("ordered"), pending: n("pending"), unmatched: n("unmatched"), error: n("error"), no_order: n("no_order"), ignored: n("ignored") };
+  }, [comments]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-zinc-500">點一篇貼文看底下留言與加單結果。「找不到會員」「錯誤」可以修正後按「重試」，或標「忽略」。</p>
+        <button type="button" className={btn} onClick={() => void reload()}>重新整理</button>
+      </div>
+      <Table>
+        <THead><Tr><Th>團</Th><Th>社群</Th><Th>狀態</Th><Th>發文時間</Th><Th>最後讀取</Th><Th align="right">留言數</Th><Th align="right">操作</Th></Tr></THead>
+        <TBody>
+          {posts === null ? <LoadingRow colSpan={7} /> : posts.length === 0 ? <EmptyRow colSpan={7}>還沒有貼文</EmptyRow> : posts.map((p) => {
+            const c = communityById.get(p.community_id);
+            return (
+              <Tr key={p.id} onClick={() => setSelected(p)} className={selected?.id === p.id ? "bg-zinc-100 dark:bg-zinc-800" : ""}>
+                <Td>
+                  <div>{p.group_buy_campaigns?.name ?? p.campaign_id}</div>
+                  <div className="text-xs text-zinc-500">{p.group_buy_campaigns?.campaign_no}（{p.group_buy_campaigns?.status}）</div>
+                </Td>
+                <Td>{c?.home_name || c?.home_id || p.community_id}</Td>
+                <Td>
+                  <Badge tone={p.status === "posted" ? "green" : p.status === "queued" ? "amber" : p.status === "failed" ? "red" : "gray"}>{POST_STATUS[p.status]}</Badge>
+                  {p.last_error && <div className="max-w-xs truncate text-xs text-red-600" title={p.last_error}>{p.last_error}</div>}
+                </Td>
+                <Td>{fmt(p.posted_at)}</Td>
+                <Td>{fmt(p.last_read_at)}</Td>
+                <Td align="right">{p.comment_count}</Td>
+                <Td align="right">
+                  {p.status === "posted" && (
+                    <SpinButton type="button" className={btn} loading={busy === p.id} onClick={(e) => { e.stopPropagation(); void readNow(p); }}>立即讀取</SpinButton>
+                  )}
+                </Td>
+              </Tr>
+            );
+          })}
+        </TBody>
+      </Table>
+
+      {selected && (
+        <div className="space-y-2 rounded border border-zinc-200 p-3 dark:border-zinc-800">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="font-medium">留言：{selected.group_buy_campaigns?.name}</h2>
+            {summary && (
+              <div className="flex flex-wrap gap-1 text-xs">
+                <Badge tone="green">已加單 {summary.ordered}</Badge>
+                <Badge tone="amber">待處理 {summary.pending}</Badge>
+                <Badge tone="red">找不到會員 {summary.unmatched}</Badge>
+                <Badge tone="red">錯誤 {summary.error}</Badge>
+                <Badge tone="gray">非下單 {summary.no_order}</Badge>
+                <Badge tone="gray">忽略 {summary.ignored}</Badge>
+              </div>
+            )}
+          </div>
+          {selected.text && <details className="text-xs text-zinc-500"><summary>貼文內容</summary><pre className="whitespace-pre-wrap">{selected.text}</pre></details>}
+          <Table>
+            <THead><Tr><Th>時間</Th><Th>留言者</Th><Th>留言</Th><Th>會員編號</Th><Th>解析</Th><Th>狀態</Th><Th align="right">操作</Th></Tr></THead>
+            <TBody>
+              {comments === null ? <LoadingRow colSpan={7} /> : comments.length === 0 ? <EmptyRow colSpan={7}>還沒讀到留言</EmptyRow> : comments.map((c) => (
+                <Tr key={c.id}>
+                  <Td className="whitespace-nowrap text-xs">{fmt(c.commented_at)}</Td>
+                  <Td><div>{c.commenter_name ?? "—"}</div><div className="font-mono text-[10px] text-zinc-400">{c.commenter_id}</div></Td>
+                  <Td className="max-w-sm whitespace-pre-wrap text-sm">{c.text}</Td>
+                  <Td className="font-mono">{c.member_no_hint ?? "—"}</Td>
+                  <Td className="font-mono text-xs">{(c.parsed ?? []).map((o, i) => <div key={i}>{o.cancel ? "取消 " : ""}{o.code ?? "(單品)"} ×{o.qty}</div>)}</Td>
+                  <Td>
+                    <Badge tone={c.status === "ordered" ? "green" : c.status === "pending" ? "amber" : c.status === "unmatched" || c.status === "error" ? "red" : "gray"}>{COMMENT_STATUS[c.status]}</Badge>
+                    {c.error && <div className="max-w-xs text-xs text-red-600">{c.error}</div>}
+                    {c.customer_order_id && <div className="text-xs text-zinc-500">訂單 #{c.customer_order_id}</div>}
+                  </Td>
+                  <Td align="right">
+                    <div className="flex justify-end gap-1">
+                      {c.status !== "ordered" && c.status !== "ignored" && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => retry(c)}>重試</SpinButton>}
+                      {c.status !== "ordered" && c.status !== "ignored" && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => setStatus(c, "ignored")}>忽略</SpinButton>}
+                      {c.status === "ignored" && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => setStatus(c, "pending")}>取消忽略</SpinButton>}
+                    </div>
+                  </Td>
+                </Tr>
+              ))}
+            </TBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── 小元件 ───────────────────────────────────────────────────────────────────
+function Modal({ title, onClose, children, wide }: { title: string; onClose: () => void; children: ReactNode; wide?: boolean }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
+      <div className={`max-h-[90vh] w-full overflow-y-auto rounded-lg bg-white p-5 shadow-xl dark:bg-zinc-900 ${wide ? "max-w-3xl" : "max-w-md"}`} onClick={(e) => e.stopPropagation()}>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">{title}</h2>
+          <button type="button" className="text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100" onClick={onClose} aria-label="關閉">✕</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/lib/menuSections.ts
+++ b/apps/admin/src/lib/menuSections.ts
@@ -11,7 +11,7 @@ export type MenuKey =
   | "hq-inbox" | "receiving" | "picking"
   | "daily-report" | "receivables" | "settlement"
   | "candidates" | "calendar"
-  | "staff" | "stores" | "fb-pages"
+  | "staff" | "stores" | "fb-pages" | "line-notes"
   | "general";
 
 export type MenuItem = { key: MenuKey; label: string };
@@ -87,6 +87,7 @@ export const MENU_GROUPS: MenuGroup[] = [
       { key: "staff", label: "員工管理" },
       { key: "stores", label: "門市" },
       { key: "fb-pages", label: "FB 粉絲團" },
+      { key: "line-notes", label: "LINE 記事本" },
     ],
   },
   {

--- a/supabase/migrations/20260908010000_line_note_bridge.sql
+++ b/supabase/migrations/20260908010000_line_note_bridge.sql
@@ -1,0 +1,655 @@
+-- ============================================================================
+-- 20260908010000_line_note_bridge.sql
+--
+-- LINE 群組／社群「記事本」整合（愛+1 那種玩法）：
+--   後台登入一般 LINE 帳號（備用帳號）→ 綁社群 → 開團時自動發文到記事本
+--   → 定時讀底下留言 → 留言裡的 6 碼會員編號 + 品項代碼 → 自動加單。
+--
+-- 實際跟 LINE 講話的是地端 worker（tools/line-note-scraper/src/worker.mjs，
+-- 用 service_role 輪詢 line_note_jobs）。DB 這邊只管：設定、佇列、留言落地、
+-- 留言→訂單的轉換（rpc_line_note_apply_comment，呼叫既有 rpc_create_customer_orders）。
+--
+-- 全部是新物件，沒有覆蓋既有 function。group_buy_campaigns 只「加一支 trigger」
+-- （status 變 open → 排發文），不動它本身。
+--
+-- rollback：
+--   DROP TRIGGER trg_line_note_on_campaign_open ON group_buy_campaigns;
+--   DROP FUNCTION _line_note_on_campaign_open, rpc_line_note_apply_comment,
+--                 rpc_line_note_post_payload, _line_note_item_codes,
+--                 rpc_line_note_enqueue, rpc_line_note_queue_post,
+--                 rpc_line_note_community_upsert, rpc_line_note_community_delete,
+--                 rpc_line_note_account_upsert, rpc_line_note_account_delete;
+--   DROP VIEW v_line_note_accounts;
+--   DROP TABLE line_note_jobs, line_note_comments, line_note_posts,
+--              line_note_communities, line_note_accounts;
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. 帳號（含登入 token → 秘密，不開 RLS policy、只透過 view 讀非敏感欄位）
+-- ----------------------------------------------------------------------------
+CREATE TABLE line_note_accounts (
+  id            BIGSERIAL PRIMARY KEY,
+  tenant_id     UUID NOT NULL,
+  label         TEXT NOT NULL,
+  status        TEXT NOT NULL DEFAULT 'logged_out'
+                  CHECK (status IN ('logged_out','pending_qr','active','error')),
+  line_mid      TEXT,
+  display_name  TEXT,
+  auth_token    TEXT,          -- 秘密：linejs 的 X-Line-Access
+  qr_image      TEXT,          -- 登入中：data:image/png;base64,…（worker 產生）
+  qr_url        TEXT,          -- 登入中：手機可直接開的網址
+  pin_code      TEXT,          -- 登入中：手機 LINE 要輸入的 PIN
+  last_error    TEXT,
+  last_seen_at  TIMESTAMPTZ,
+  created_by    UUID,
+  updated_by    UUID,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_line_note_accounts_tenant ON line_note_accounts (tenant_id);
+CREATE TRIGGER trg_touch_line_note_accounts
+  BEFORE UPDATE ON line_note_accounts
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+ALTER TABLE line_note_accounts ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON line_note_accounts FROM anon, authenticated;
+
+-- 後台讀這個 view（沒有 token）
+CREATE VIEW v_line_note_accounts AS
+  SELECT id, tenant_id, label, status, line_mid, display_name,
+         qr_image, qr_url, pin_code, last_error, last_seen_at, created_at, updated_at
+    FROM line_note_accounts
+   WHERE tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+     AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+         = ANY (ARRAY['owner','admin','hq_manager','assistant','']);
+GRANT SELECT ON v_line_note_accounts TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 2. 社群設定：哪個帳號、哪個記事本、對應哪個 line_channels（決定取貨店）
+-- ----------------------------------------------------------------------------
+CREATE TABLE line_note_communities (
+  id                 BIGSERIAL PRIMARY KEY,
+  tenant_id          UUID NOT NULL,
+  account_id         BIGINT NOT NULL REFERENCES line_note_accounts(id) ON DELETE CASCADE,
+  channel_id         BIGINT NOT NULL REFERENCES line_channels(id),
+  home_id            TEXT NOT NULL,     -- c…（群組）/ m…（社群聊天室）/ s…（社群）
+  home_name          TEXT,
+  home_kind          TEXT NOT NULL DEFAULT 'square_chat'
+                       CHECK (home_kind IN ('group','square','square_chat')),
+  listen_enabled     BOOLEAN NOT NULL DEFAULT FALSE,
+  read_times         TEXT[] NOT NULL DEFAULT ARRAY['12:00'],  -- 台北時間 HH:MM，可多個
+  auto_post_on_open  BOOLEAN NOT NULL DEFAULT TRUE,
+  post_template      TEXT,             -- NULL → worker 用預設模板
+  last_read_at       TIMESTAMPTZ,
+  last_error         TEXT,
+  created_by         UUID,
+  updated_by         UUID,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, home_id)
+);
+CREATE INDEX idx_line_note_communities_channel ON line_note_communities (channel_id);
+CREATE TRIGGER trg_touch_line_note_communities
+  BEFORE UPDATE ON line_note_communities
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+ALTER TABLE line_note_communities ENABLE ROW LEVEL SECURITY;
+CREATE POLICY lnc_hq_all ON line_note_communities FOR ALL
+  USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+             = ANY (ARRAY['owner','admin','hq_manager','assistant','']))
+  WITH CHECK (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+             = ANY (ARRAY['owner','admin','hq_manager','assistant','']));
+GRANT SELECT ON line_note_communities TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 3. 貼文：一個社群 × 一個團 = 一篇
+-- ----------------------------------------------------------------------------
+CREATE TABLE line_note_posts (
+  id             BIGSERIAL PRIMARY KEY,
+  tenant_id      UUID NOT NULL,
+  community_id   BIGINT NOT NULL REFERENCES line_note_communities(id) ON DELETE CASCADE,
+  campaign_id    BIGINT NOT NULL REFERENCES group_buy_campaigns(id) ON DELETE CASCADE,
+  line_post_id   TEXT,
+  text           TEXT,
+  status         TEXT NOT NULL DEFAULT 'queued'
+                   CHECK (status IN ('queued','posted','failed','closed')),
+  posted_at      TIMESTAMPTZ,
+  last_read_at   TIMESTAMPTZ,
+  comment_count  INT NOT NULL DEFAULT 0,
+  last_error     TEXT,
+  created_by     UUID,
+  updated_by     UUID,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (community_id, campaign_id)
+);
+CREATE INDEX idx_line_note_posts_campaign ON line_note_posts (campaign_id);
+CREATE TRIGGER trg_touch_line_note_posts
+  BEFORE UPDATE ON line_note_posts
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+ALTER TABLE line_note_posts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY lnp_hq_all ON line_note_posts FOR ALL
+  USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+             = ANY (ARRAY['owner','admin','hq_manager','assistant','']))
+  WITH CHECK (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+             = ANY (ARRAY['owner','admin','hq_manager','assistant','']));
+GRANT SELECT ON line_note_posts TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 4. 留言：worker 落地，parsed = [{code, qty, cancel, line}]，member_no_hint = 6 碼
+-- ----------------------------------------------------------------------------
+CREATE TABLE line_note_comments (
+  id                 BIGSERIAL PRIMARY KEY,
+  tenant_id          UUID NOT NULL,
+  post_id            BIGINT NOT NULL REFERENCES line_note_posts(id) ON DELETE CASCADE,
+  line_comment_id    TEXT NOT NULL,
+  commenter_id       TEXT,             -- 群組：u…（= LINE userId）；社群：p…（社群成員 id）
+  commenter_name     TEXT,
+  text               TEXT NOT NULL,
+  commented_at       TIMESTAMPTZ,
+  member_no_hint     TEXT,             -- 留言裡抓到的 6 碼
+  parsed             JSONB NOT NULL DEFAULT '[]'::jsonb,
+  status             TEXT NOT NULL DEFAULT 'pending'
+                       CHECK (status IN ('pending','ordered','unmatched','no_order','error','ignored')),
+  member_id          BIGINT REFERENCES members(id),
+  customer_order_id  BIGINT,
+  error              TEXT,
+  processed_at       TIMESTAMPTZ,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (post_id, line_comment_id)
+);
+CREATE INDEX idx_line_note_comments_status ON line_note_comments (tenant_id, status);
+CREATE TRIGGER trg_touch_line_note_comments
+  BEFORE UPDATE ON line_note_comments
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+ALTER TABLE line_note_comments ENABLE ROW LEVEL SECURITY;
+CREATE POLICY lncm_hq_all ON line_note_comments FOR ALL
+  USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+             = ANY (ARRAY['owner','admin','hq_manager','assistant','']))
+  WITH CHECK (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+             = ANY (ARRAY['owner','admin','hq_manager','assistant','']));
+GRANT SELECT, UPDATE ON line_note_comments TO authenticated;  -- UPDATE：後台可標「忽略」
+
+-- ----------------------------------------------------------------------------
+-- 5. 工作佇列：後台丟、worker 撿
+-- ----------------------------------------------------------------------------
+CREATE TABLE line_note_jobs (
+  id            BIGSERIAL PRIMARY KEY,
+  tenant_id     UUID NOT NULL,
+  kind          TEXT NOT NULL CHECK (kind IN ('login','logout','list_homes','post','read')),
+  account_id    BIGINT NOT NULL REFERENCES line_note_accounts(id) ON DELETE CASCADE,
+  community_id  BIGINT REFERENCES line_note_communities(id) ON DELETE SET NULL,
+  post_id       BIGINT REFERENCES line_note_posts(id) ON DELETE SET NULL,
+  payload       JSONB NOT NULL DEFAULT '{}'::jsonb,
+  status        TEXT NOT NULL DEFAULT 'queued'
+                  CHECK (status IN ('queued','running','done','failed')),
+  result        JSONB,
+  error         TEXT,
+  created_by    UUID,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  started_at    TIMESTAMPTZ,
+  finished_at   TIMESTAMPTZ
+);
+CREATE INDEX idx_line_note_jobs_queue ON line_note_jobs (status, created_at) WHERE status IN ('queued','running');
+
+ALTER TABLE line_note_jobs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY lnj_hq_read ON line_note_jobs FOR SELECT
+  USING (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+         AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+             = ANY (ARRAY['owner','admin','hq_manager','assistant','']));
+GRANT SELECT ON line_note_jobs TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 6. 帳號 / 社群 CRUD RPC（tenant 由 JWT 決定，前端不用帶）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._line_note_require_admin()
+RETURNS UUID
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_role   TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+BEGIN
+  IF v_role NOT IN ('owner','admin','hq_manager','assistant','') THEN
+    RAISE EXCEPTION 'insufficient_role';
+  END IF;
+  RETURN v_tenant;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.rpc_line_note_account_upsert(
+  p_id BIGINT, p_label TEXT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+  v_id     BIGINT;
+BEGIN
+  IF COALESCE(TRIM(p_label), '') = '' THEN RAISE EXCEPTION '請輸入帳號名稱'; END IF;
+  IF p_id IS NULL THEN
+    INSERT INTO line_note_accounts (tenant_id, label, created_by, updated_by)
+    VALUES (v_tenant, TRIM(p_label), auth.uid(), auth.uid())
+    RETURNING id INTO v_id;
+  ELSE
+    UPDATE line_note_accounts
+       SET label = TRIM(p_label), updated_by = auth.uid()
+     WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'account % not in tenant', p_id; END IF;
+  END IF;
+  RETURN v_id;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_account_upsert(BIGINT, TEXT) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_line_note_account_delete(p_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+BEGIN
+  DELETE FROM line_note_accounts WHERE id = p_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'account % not in tenant', p_id; END IF;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_account_delete(BIGINT) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_line_note_community_upsert(
+  p_id                BIGINT,
+  p_account_id        BIGINT,
+  p_channel_id        BIGINT,
+  p_home_id           TEXT,
+  p_home_name         TEXT,
+  p_home_kind         TEXT,
+  p_listen_enabled    BOOLEAN,
+  p_read_times        TEXT[],
+  p_auto_post_on_open BOOLEAN,
+  p_post_template     TEXT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+  v_id     BIGINT;
+  v_t      TEXT;
+BEGIN
+  PERFORM 1 FROM line_note_accounts WHERE id = p_account_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'account % not in tenant', p_account_id; END IF;
+  PERFORM 1 FROM line_channels WHERE id = p_channel_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'channel % not in tenant', p_channel_id; END IF;
+  IF COALESCE(TRIM(p_home_id), '') = '' THEN RAISE EXCEPTION '請選擇社群'; END IF;
+  FOREACH v_t IN ARRAY COALESCE(p_read_times, ARRAY[]::TEXT[]) LOOP
+    IF v_t !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$' THEN
+      RAISE EXCEPTION '讀取時間格式要是 HH:MM（收到「%」）', v_t;
+    END IF;
+  END LOOP;
+
+  IF p_id IS NULL THEN
+    INSERT INTO line_note_communities
+      (tenant_id, account_id, channel_id, home_id, home_name, home_kind,
+       listen_enabled, read_times, auto_post_on_open, post_template, created_by, updated_by)
+    VALUES
+      (v_tenant, p_account_id, p_channel_id, TRIM(p_home_id), p_home_name,
+       COALESCE(p_home_kind, 'square_chat'),
+       COALESCE(p_listen_enabled, FALSE),
+       COALESCE(NULLIF(p_read_times, ARRAY[]::TEXT[]), ARRAY['12:00']),
+       COALESCE(p_auto_post_on_open, TRUE),
+       NULLIF(TRIM(COALESCE(p_post_template, '')), ''),
+       auth.uid(), auth.uid())
+    RETURNING id INTO v_id;
+  ELSE
+    UPDATE line_note_communities
+       SET account_id        = p_account_id,
+           channel_id        = p_channel_id,
+           home_id           = TRIM(p_home_id),
+           home_name         = p_home_name,
+           home_kind         = COALESCE(p_home_kind, home_kind),
+           listen_enabled    = COALESCE(p_listen_enabled, listen_enabled),
+           read_times        = COALESCE(NULLIF(p_read_times, ARRAY[]::TEXT[]), read_times),
+           auto_post_on_open = COALESCE(p_auto_post_on_open, auto_post_on_open),
+           post_template     = NULLIF(TRIM(COALESCE(p_post_template, '')), ''),
+           updated_by        = auth.uid()
+     WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'community % not in tenant', p_id; END IF;
+  END IF;
+  RETURN v_id;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_community_upsert(
+  BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT, BOOLEAN, TEXT[], BOOLEAN, TEXT) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_line_note_community_delete(p_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+BEGIN
+  DELETE FROM line_note_communities WHERE id = p_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'community % not in tenant', p_id; END IF;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_community_delete(BIGINT) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 7. 佇列：登入 / 登出 / 列社群 / 立即讀取 / 手動發文
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_enqueue(
+  p_kind         TEXT,
+  p_account_id   BIGINT,
+  p_community_id BIGINT DEFAULT NULL,
+  p_post_id      BIGINT DEFAULT NULL,
+  p_payload      JSONB  DEFAULT '{}'::jsonb
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+  v_id     BIGINT;
+BEGIN
+  IF p_kind NOT IN ('login','logout','list_homes','read') THEN
+    RAISE EXCEPTION 'kind % not allowed here', p_kind;
+  END IF;
+  PERFORM 1 FROM line_note_accounts WHERE id = p_account_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'account % not in tenant', p_account_id; END IF;
+  IF p_community_id IS NOT NULL THEN
+    PERFORM 1 FROM line_note_communities WHERE id = p_community_id AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'community % not in tenant', p_community_id; END IF;
+  END IF;
+
+  -- 同種類還在排隊的就不重複丟
+  SELECT id INTO v_id FROM line_note_jobs
+   WHERE tenant_id = v_tenant AND kind = p_kind AND account_id = p_account_id
+     AND community_id IS NOT DISTINCT FROM p_community_id
+     AND status IN ('queued','running')
+   ORDER BY id DESC LIMIT 1;
+  IF v_id IS NOT NULL THEN RETURN v_id; END IF;
+
+  IF p_kind = 'login' THEN
+    UPDATE line_note_accounts
+       SET status = 'pending_qr', qr_image = NULL, qr_url = NULL, pin_code = NULL, last_error = NULL
+     WHERE id = p_account_id;
+  END IF;
+
+  INSERT INTO line_note_jobs (tenant_id, kind, account_id, community_id, post_id, payload, created_by)
+  VALUES (v_tenant, p_kind, p_account_id, p_community_id, p_post_id, COALESCE(p_payload, '{}'::jsonb), auth.uid())
+  RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_enqueue(TEXT, BIGINT, BIGINT, BIGINT, JSONB) TO authenticated;
+
+-- 手動把某個團發到某個社群（自動發文漏掉、或想補發時用）
+CREATE OR REPLACE FUNCTION public.rpc_line_note_queue_post(
+  p_community_id BIGINT, p_campaign_id BIGINT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant  UUID := public._line_note_require_admin();
+  v_account BIGINT;
+  v_post    BIGINT;
+BEGIN
+  SELECT account_id INTO v_account FROM line_note_communities
+   WHERE id = p_community_id AND tenant_id = v_tenant;
+  IF v_account IS NULL THEN RAISE EXCEPTION 'community % not in tenant', p_community_id; END IF;
+  PERFORM 1 FROM group_buy_campaigns WHERE id = p_campaign_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id; END IF;
+
+  INSERT INTO line_note_posts (tenant_id, community_id, campaign_id, status, created_by, updated_by)
+  VALUES (v_tenant, p_community_id, p_campaign_id, 'queued', auth.uid(), auth.uid())
+  ON CONFLICT (community_id, campaign_id) DO UPDATE
+     SET status = CASE WHEN line_note_posts.status = 'posted' THEN 'posted' ELSE 'queued' END,
+         last_error = NULL, updated_by = auth.uid()
+  RETURNING id INTO v_post;
+
+  IF (SELECT status FROM line_note_posts WHERE id = v_post) = 'posted' THEN
+    RAISE EXCEPTION '這個團已經發過文了';
+  END IF;
+
+  INSERT INTO line_note_jobs (tenant_id, kind, account_id, community_id, post_id, created_by)
+  VALUES (v_tenant, 'post', v_account, p_community_id, v_post, auth.uid());
+  RETURN v_post;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_queue_post(BIGINT, BIGINT) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 8. 品項代碼：A/B/C… 依 campaign_items.sort_order, id。發文與解析都用這一支，
+--    才不會「貼文寫 A、解析當成 B」。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._line_note_item_codes(p_campaign_id BIGINT)
+RETURNS TABLE (code TEXT, campaign_item_id BIGINT, sku_id BIGINT,
+               item_name TEXT, unit_price NUMERIC, cap_qty NUMERIC)
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT chr(64 + (ROW_NUMBER() OVER (ORDER BY ci.sort_order, ci.id))::int) AS code,
+         ci.id, ci.sku_id,
+         TRIM(COALESCE(s.product_name, '') || CASE WHEN COALESCE(s.variant_name, '') <> '' THEN ' ' || s.variant_name ELSE '' END),
+         ci.unit_price, ci.cap_qty
+    FROM campaign_items ci
+    JOIN skus s ON s.id = ci.sku_id
+   WHERE ci.campaign_id = p_campaign_id
+     AND COALESCE(ci.is_gift, FALSE) = FALSE
+   ORDER BY ci.sort_order, ci.id
+   LIMIT 26;   -- 超過 26 項就沒代碼了，那種團不適合記事本 +1
+$$;
+
+-- worker 發文用：把團的內容整包回來（模板由 worker 套）
+CREATE OR REPLACE FUNCTION public.rpc_line_note_post_payload(p_post_id BIGINT)
+RETURNS JSONB
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT jsonb_build_object(
+    'post_id',       p.id,
+    'home_id',       c.home_id,
+    'home_kind',     c.home_kind,
+    'account_id',    c.account_id,
+    'post_template', c.post_template,
+    'campaign', jsonb_build_object(
+       'id', g.id, 'campaign_no', g.campaign_no, 'name', g.name,
+       'description', g.description, 'status', g.status,
+       'start_at', g.start_at, 'end_at', g.end_at, 'pickup_deadline', g.pickup_deadline),
+    'items', COALESCE((SELECT jsonb_agg(jsonb_build_object(
+                'code', ic.code, 'campaign_item_id', ic.campaign_item_id,
+                'name', ic.item_name, 'unit_price', ic.unit_price, 'cap_qty', ic.cap_qty)
+                ORDER BY ic.code)
+               FROM public._line_note_item_codes(g.id) ic), '[]'::jsonb)
+  )
+  FROM line_note_posts p
+  JOIN line_note_communities c ON c.id = p.community_id
+  JOIN group_buy_campaigns g ON g.id = p.campaign_id
+  WHERE p.id = p_post_id;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_post_payload(BIGINT) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 9. 留言 → 訂單
+--    parsed = [{"code":"A","qty":2,"cancel":false,"line":"A+2"}, …]
+--    member_no_hint = 留言裡的 6 碼 → members.member_no = 'M' || 6 碼（或原樣）
+--    走既有 rpc_create_customer_orders（同團同人已有單會併入）
+--    worker 用 service_role 呼叫 → 沒有 tenant claim，這裡用留言的 tenant 補進 JWT claims
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_apply_comment(p_comment_id BIGINT)
+RETURNS TABLE (out_status TEXT, out_order_id BIGINT, out_error TEXT)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_c            line_note_comments%ROWTYPE;
+  v_tenant       UUID;
+  v_campaign_id  BIGINT;
+  v_channel_id   BIGINT;
+  v_store_id     BIGINT;
+  v_member_id    BIGINT;
+  v_member_home  BIGINT;
+  v_hint         TEXT;
+  v_items        JSONB := '[]'::jsonb;
+  v_p            JSONB;
+  v_code         TEXT;
+  v_qty          NUMERIC;
+  v_ci           BIGINT;
+  v_item_count   INT;
+  v_order_id     BIGINT;
+  v_err          TEXT;
+  v_claim_tenant TEXT := auth.jwt() ->> 'tenant_id';
+BEGIN
+  SELECT * INTO v_c FROM line_note_comments WHERE id = p_comment_id;
+  IF v_c.id IS NULL THEN RAISE EXCEPTION 'comment % not found', p_comment_id; END IF;
+  v_tenant := v_c.tenant_id;
+
+  -- 呼叫者是後台使用者 → tenant 要對得上；是 service_role → 補 claims 給下游 RPC 用
+  IF v_claim_tenant IS NOT NULL AND v_claim_tenant <> '' THEN
+    IF v_claim_tenant::uuid <> v_tenant THEN RAISE EXCEPTION 'comment % not in tenant', p_comment_id; END IF;
+  ELSE
+    PERFORM set_config('request.jwt.claims',
+      jsonb_build_object('tenant_id', v_tenant,
+                         'app_metadata', jsonb_build_object('tenant_id', v_tenant, 'role', 'admin'))::text,
+      TRUE);
+  END IF;
+
+  IF v_c.status IN ('ordered','ignored') THEN
+    RETURN QUERY SELECT v_c.status, v_c.customer_order_id, v_c.error; RETURN;
+  END IF;
+
+  SELECT p.campaign_id, c.channel_id, lc.home_store_id
+    INTO v_campaign_id, v_channel_id, v_store_id
+    FROM line_note_posts p
+    JOIN line_note_communities c ON c.id = p.community_id
+    JOIN line_channels lc ON lc.id = c.channel_id
+   WHERE p.id = v_c.post_id;
+
+  -- 沒有任何數量 → 不是下單留言
+  IF jsonb_array_length(COALESCE(v_c.parsed, '[]'::jsonb)) = 0 THEN
+    UPDATE line_note_comments SET status = 'no_order', processed_at = NOW() WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'no_order'::TEXT, NULL::BIGINT, NULL::TEXT; RETURN;
+  END IF;
+
+  -- 會員：6 碼 → M000000
+  v_hint := NULLIF(TRIM(COALESCE(v_c.member_no_hint, '')), '');
+  IF v_hint IS NULL THEN
+    UPDATE line_note_comments SET status = 'unmatched', error = '留言裡沒有 6 碼會員編號', processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'unmatched'::TEXT, NULL::BIGINT, '留言裡沒有 6 碼會員編號'::TEXT; RETURN;
+  END IF;
+  SELECT m.id, m.home_store_id INTO v_member_id, v_member_home
+    FROM members m
+   WHERE m.tenant_id = v_tenant
+     AND (m.member_no = 'M' || v_hint OR m.member_no = v_hint)
+     AND m.status IS DISTINCT FROM 'merged'
+   ORDER BY m.id LIMIT 1;
+  IF v_member_id IS NULL THEN
+    UPDATE line_note_comments SET status = 'unmatched', error = '找不到會員編號 ' || v_hint, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'unmatched'::TEXT, NULL::BIGINT, ('找不到會員編號 ' || v_hint)::TEXT; RETURN;
+  END IF;
+
+  -- 品項：code → campaign_item；沒 code 且團只有一項 → 那一項
+  SELECT count(*) INTO v_item_count FROM public._line_note_item_codes(v_campaign_id);
+  FOR v_p IN SELECT * FROM jsonb_array_elements(v_c.parsed) LOOP
+    IF COALESCE((v_p ->> 'cancel')::boolean, FALSE) THEN CONTINUE; END IF;  -- 取消留言不自動處理，留給人看
+    v_qty  := (v_p ->> 'qty')::numeric;
+    v_code := UPPER(NULLIF(TRIM(COALESCE(v_p ->> 'code', '')), ''));
+    IF v_qty IS NULL OR v_qty <= 0 THEN CONTINUE; END IF;
+    IF v_code IS NULL THEN
+      IF v_item_count = 1 THEN
+        SELECT ic.campaign_item_id INTO v_ci FROM public._line_note_item_codes(v_campaign_id) ic;
+      ELSE
+        v_err := '沒寫品項代碼（這團有 ' || v_item_count || ' 項）';
+        EXIT;
+      END IF;
+    ELSE
+      SELECT ic.campaign_item_id INTO v_ci FROM public._line_note_item_codes(v_campaign_id) ic WHERE ic.code = v_code;
+      IF v_ci IS NULL THEN v_err := '品項代碼 ' || v_code || ' 不在這團裡'; EXIT; END IF;
+    END IF;
+    v_items := v_items || jsonb_build_object('campaign_item_id', v_ci, 'qty', v_qty);
+  END LOOP;
+
+  IF v_err IS NOT NULL THEN
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+  IF jsonb_array_length(v_items) = 0 THEN
+    UPDATE line_note_comments SET status = 'no_order', member_id = v_member_id, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'no_order'::TEXT, NULL::BIGINT, NULL::TEXT; RETURN;
+  END IF;
+
+  BEGIN
+    SELECT r.out_order_id INTO v_order_id
+      FROM public.rpc_create_customer_orders(
+             v_campaign_id, v_channel_id,
+             jsonb_build_array(jsonb_build_object(
+               'member_id', v_member_id,
+               'nickname', v_c.commenter_name,
+               'pickup_store_id', COALESCE(v_store_id, v_member_home),
+               'items', v_items))) r
+     LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    v_err := SQLERRM;
+  END;
+
+  IF v_err IS NOT NULL THEN
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+
+  UPDATE line_note_comments
+     SET status = 'ordered', member_id = v_member_id, customer_order_id = v_order_id,
+         error = NULL, processed_at = NOW()
+   WHERE id = p_comment_id;
+  RETURN QUERY SELECT 'ordered'::TEXT, v_order_id, NULL::TEXT;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_apply_comment(BIGINT) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 10. 開團（status → open）就排發文：團有掛在哪些 line_channels（campaign_channels），
+--     那些 channel 底下有設「自動發文」的社群就各排一篇。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._line_note_on_campaign_open()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_c RECORD;
+  v_post BIGINT;
+BEGIN
+  IF NEW.status <> 'open' OR OLD.status = 'open' THEN RETURN NEW; END IF;
+  FOR v_c IN
+    SELECT c.id AS community_id, c.account_id
+      FROM line_note_communities c
+      JOIN line_note_accounts a ON a.id = c.account_id AND a.status = 'active'
+      JOIN campaign_channels cc ON cc.channel_id = c.channel_id AND cc.campaign_id = NEW.id
+     WHERE c.tenant_id = NEW.tenant_id AND c.auto_post_on_open
+  LOOP
+    INSERT INTO line_note_posts (tenant_id, community_id, campaign_id, status, created_by, updated_by)
+    VALUES (NEW.tenant_id, v_c.community_id, NEW.id, 'queued', NEW.updated_by, NEW.updated_by)
+    ON CONFLICT (community_id, campaign_id) DO NOTHING
+    RETURNING id INTO v_post;
+    IF v_post IS NOT NULL THEN
+      INSERT INTO line_note_jobs (tenant_id, kind, account_id, community_id, post_id, created_by)
+      VALUES (NEW.tenant_id, 'post', v_c.account_id, v_c.community_id, v_post, NEW.updated_by);
+    END IF;
+  END LOOP;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_line_note_on_campaign_open ON group_buy_campaigns;
+CREATE TRIGGER trg_line_note_on_campaign_open
+  AFTER UPDATE OF status ON group_buy_campaigns
+  FOR EACH ROW EXECUTE FUNCTION public._line_note_on_campaign_open();

--- a/tools/line-note-scraper/.env.example
+++ b/tools/line-note-scraper/.env.example
@@ -1,0 +1,7 @@
+# worker 用（npm run worker）
+SUPABASE_URL=https://<project-ref>.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=<service_role key；Dashboard → Settings → API>
+# LINE_DEVICE=ANDROIDSECONDARY
+# LINE_STORAGE_DIR=./storage
+# POLL_MS=5000
+# VERBOSE=1

--- a/tools/line-note-scraper/.gitignore
+++ b/tools/line-note-scraper/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 storage.json
+storage/
+.env
 out/
 *.log

--- a/tools/line-note-scraper/README.md
+++ b/tools/line-note-scraper/README.md
@@ -45,6 +45,26 @@ node src/cli.mjs post <homeId> --file post.txt --image 1.jpg --image 2.jpg   # �
 +1 的寫法支援 `+1`、`＋２`、`A+1`、`B-2 +1`、`+1 A`、`A x2`、`A 2份`、`2份`、`-1` / `取消 A+1`（負數）。
 規則在 `src/parse.mjs`，測試 `npm test`。純數字、`A2` 這種分不清品號還是數量的**不猜**，留給人看 `comments.csv`。
 
+## 接後台（worker 模式）
+
+後台「設定 → LINE 記事本」頁面負責帳號登入、社群設定、看留言結果；真的跟 LINE 講話的是這支 worker，
+跑在你自己的電腦或 VPS 上，用 service_role 輪詢 `line_note_jobs`。
+
+```bash
+cp .env.example .env      # 填 SUPABASE_URL、SUPABASE_SERVICE_ROLE_KEY
+npm run worker
+```
+
+流程：
+
+1. 後台 → 帳號 → 新增 → 登入：worker 把 QR 寫進 DB，後台顯示，備用帳號手機掃、輸入 PIN。
+2. 後台 → 社群設定 → 新增：選帳號、按「從帳號載入清單」挑社群（m…）、選渠道（決定取貨店）、讀留言時間、開團自動發文。
+3. 開團：團的狀態變成「開團中」且有勾到該渠道 → 自動排一篇貼文（套模板，A/B/C 依開團品項順序）。
+4. 到讀留言時間（或按「立即讀取」）：worker 讀留言 → 抓「會員編號 6 碼 + A+1」→ `rpc_line_note_apply_comment` 用既有加單 RPC 建單。
+5. 後台 → 貼文與留言：看每則留言的結果，「找不到會員」「錯誤」可重試或忽略。
+
+worker 一次只跑一支，多個帳號各自有 `storage/account-<id>.json`。登出會清 token。
+
 ## 打不通的時候
 
 第一次一定加 `--verbose`：

--- a/tools/line-note-scraper/README.md
+++ b/tools/line-note-scraper/README.md
@@ -23,6 +23,16 @@ npm run comments -- <homeId> <postId>
 npm run scrape -- <homeId> --since 2026-09-01     # 全部貼文 + 留言 → out/<homeId>/<時間>/
 ```
 
+發文到記事本（文字＋圖片）：
+
+```bash
+node src/cli.mjs post <homeId> --text "🍓 草莓開團
+A 大盒 250
+B 小盒 150
+留言 A+1 / B+2"
+node src/cli.mjs post <homeId> --file post.txt --image 1.jpg --image 2.jpg   # 圖片要 JPEG
+```
+
 輸出檔：
 
 | 檔案 | 內容 |

--- a/tools/line-note-scraper/package.json
+++ b/tools/line-note-scraper/package.json
@@ -16,10 +16,12 @@
     "posts": "node src/cli.mjs posts",
     "comments": "node src/cli.mjs comments",
     "scrape": "node src/cli.mjs scrape",
+    "worker": "node --env-file-if-exists=.env src/worker.mjs",
     "test": "node --test src/parse.test.mjs"
   },
   "dependencies": {
     "@evex/linejs": "npm:@jsr/evex__linejs@^3.4.2",
+    "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0"
   }
 }

--- a/tools/line-note-scraper/src/cli.mjs
+++ b/tools/line-note-scraper/src/cli.mjs
@@ -6,25 +6,29 @@
 //   node src/cli.mjs posts <homeId> [--limit 20] [--since 2026-09-01]
 //   node src/cli.mjs comments <homeId> <postId>
 //   node src/cli.mjs scrape <homeId> [--since …] [--limit …] [--out out] [--raw]
+//   node src/cli.mjs post <homeId> --text "…" | --file post.txt [--image a.jpg …]
 //
 // 共用選項：--verbose（把每次 API 嘗試印到 stderr）、--json（posts/groups 以 JSON 輸出）
 
 import fs from "node:fs";
 import path from "node:path";
 import {
-  ensureDir, getClient, listComments, listHomes, listPosts, whoami,
+  createNotePost, ensureDir, getClient, listComments, listHomes, listPosts, whoami,
 } from "./line.mjs";
 import { parseOrderLines, postTitle } from "./parse.mjs";
 
 function parseArgs(argv) {
-  const args = { _: [], flags: {} };
+  const args = { _: [], flags: {}, multi: {} };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a.startsWith("--")) {
       const key = a.slice(2);
       const next = argv[i + 1];
-      if (next !== undefined && !next.startsWith("--")) { args.flags[key] = next; i++; }
-      else args.flags[key] = true;
+      if (next !== undefined && !next.startsWith("--")) {
+        args.flags[key] = next;
+        (args.multi[key] ??= []).push(next); // 同一個旗標重複給（--image a --image b）
+        i++;
+      } else args.flags[key] = true;
     } else args._.push(a);
   }
   return args;
@@ -51,7 +55,7 @@ function printTable(rows, columns) {
 }
 
 async function main() {
-  const { _: [cmd, ...rest], flags } = parseArgs(process.argv.slice(2));
+  const { _: [cmd, ...rest], flags, multi } = parseArgs(process.argv.slice(2));
   const verbose = !!flags.verbose;
 
   if (!cmd || cmd === "help" || flags.help) {
@@ -89,6 +93,15 @@ async function main() {
     const posts = await listPosts(client, homeId, { limit, since, verbose });
     if (flags.json) console.log(JSON.stringify(posts.map(({ raw, ...p }) => p), null, 2));
     else printTable(posts.map((p) => ({ postId: p.postId, createdAt: p.createdAt ?? "", author: p.authorName ?? p.authorMid ?? "", comments: p.commentCount, title: postTitle(p.text) })), ["postId", "createdAt", "author", "comments", "title"]);
+    process.exit(0);
+  }
+
+  if (cmd === "post") {
+    const text = flags.file ? fs.readFileSync(String(flags.file), "utf8") : (typeof flags.text === "string" ? flags.text : "");
+    const images = multi.image ?? [];
+    for (const f of images) if (!fs.existsSync(f)) throw new Error(`找不到圖片：${f}`);
+    const post = await createNotePost(client, homeId, { text, images, sourceType: flags["source-type"], verbose });
+    console.log(`已發文：postId=${post.postId ?? "?"}  ${postTitle(post.text) || "(無文字)"}  圖片 ${images.length} 張`);
     process.exit(0);
   }
 

--- a/tools/line-note-scraper/src/line.mjs
+++ b/tools/line-note-scraper/src/line.mjs
@@ -324,6 +324,42 @@ export async function listComments(client, homeId, postId, { verbose = false, on
   return out;
 }
 
+// ── 發文 ───────────────────────────────────────────────────────────────────
+
+/**
+ * 在記事本發一篇貼文（文字 + 可選圖片）。走 linejs 內建的 createPost：
+ * 群組 → /mh/api/v57/post/create.json、社群（s…）→ /sn/…，
+ * 圖片先上傳到 obs（myhome/h）拿 objId 再掛進 contents.media。
+ * @param {object} opts
+ * @param {string} opts.text
+ * @param {string[]} [opts.images]  JPEG 檔路徑（上傳時 content-type 固定 image/jpeg）
+ */
+export async function createNotePost(client, homeId, { text, images = [], sourceType, verbose = false } = {}) {
+  if (!text && images.length === 0) throw new Error("貼文至少要有文字或圖片");
+  const tl = client.base.timeline;
+  const mediaObjectIds = [];
+  const mediaObjectTypes = [];
+  for (const file of images) {
+    const buf = fs.readFileSync(file);
+    const { objId } = await tl.uploadNoteMedia("image", new Blob([buf], { type: "image/jpeg" }));
+    log(verbose, `uploaded ${file} → ${objId}`);
+    mediaObjectIds.push(objId);
+    mediaObjectTypes.push("PHOTO");
+  }
+  const res = await tl.createPost({
+    homeId,
+    text,
+    mediaObjectIds,
+    mediaObjectTypes,
+    ...(sourceType ? { sourceType } : {}),
+  });
+  log(verbose, "createPost →", JSON.stringify(res).slice(0, 500));
+  if (!res || res.code !== 0) {
+    throw new Error(`發文失敗：code=${res?.code} ${res?.message ?? ""}\n${JSON.stringify(res).slice(0, 800)}`);
+  }
+  return normalizePost(res.result?.post ?? res.result, homeId);
+}
+
 export function ensureDir(dir) {
   fs.mkdirSync(dir, { recursive: true });
   return dir;

--- a/tools/line-note-scraper/src/parse.mjs
+++ b/tools/line-note-scraper/src/parse.mjs
@@ -73,6 +73,25 @@ export function parseOrderLines(text) {
   return out;
 }
 
+/**
+ * 從留言抓「6 碼會員編號」（members.member_no = 'M' + 6 碼）。
+ * 只認獨立的 6 位數（前後不是數字），所以手機號碼（10 碼）、A1 這種品號都不會誤抓；
+ * 允許寫成 M123456。回 { hint, rest }，rest 是把編號拿掉後的文字（拿去解析 +1）。
+ */
+export function extractMemberNo(text) {
+  const norm = normalize(text);
+  const m = norm.match(/(?<![0-9A-Za-z])[Mm]?([0-9]{6})(?![0-9])/);
+  if (!m) return { hint: null, rest: norm };
+  const rest = (norm.slice(0, m.index) + " " + norm.slice(m.index + m[0].length)).trim();
+  return { hint: m[1], rest };
+}
+
+/** 留言 → { memberNo, orders[] }，給 worker 落地用 */
+export function parseNoteComment(text) {
+  const { hint, rest } = extractMemberNo(text);
+  return { memberNo: hint, orders: parseOrderLines(rest) };
+}
+
 /** 貼文標題：取第一個非空白行，最多 60 字 */
 export function postTitle(text) {
   const first = String(text ?? "").split(/\r?\n/).map((s) => s.trim()).find(Boolean) ?? "";

--- a/tools/line-note-scraper/src/parse.test.mjs
+++ b/tools/line-note-scraper/src/parse.test.mjs
@@ -1,6 +1,24 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseOrderLines, postTitle, normalize } from "./parse.mjs";
+import { parseOrderLines, postTitle, normalize, extractMemberNo, parseNoteComment } from "./parse.mjs";
+
+test("extractMemberNo", () => {
+  assert.deepEqual(extractMemberNo("123456 A+1"), { hint: "123456", rest: "A+1" });
+  assert.deepEqual(extractMemberNo("A+1 M123456"), { hint: "123456", rest: "A+1" });
+  assert.deepEqual(extractMemberNo("１２３４５６ +2"), { hint: "123456", rest: "+2" });
+  assert.equal(extractMemberNo("0912345678 +1").hint, null);   // 手機 10 碼不算
+  assert.equal(extractMemberNo("A1+1").hint, null);
+  assert.equal(extractMemberNo("+1").hint, null);
+});
+
+test("parseNoteComment", () => {
+  const r = parseNoteComment("123456\nA+1\nB+2");
+  assert.equal(r.memberNo, "123456");
+  assert.deepEqual(r.orders.map((o) => [o.code, o.qty]), [["A", 1], ["B", 2]]);
+  const single = parseNoteComment("654321 +3");
+  assert.deepEqual(single.orders.map((o) => [o.code, o.qty]), [[null, 3]]);
+  assert.deepEqual(parseNoteComment("請問還有嗎"), { memberNo: null, orders: [] });
+});
 
 const one = (text) => parseOrderLines(text).map(({ code, qty, cancel }) => ({ code, qty, cancel }));
 

--- a/tools/line-note-scraper/src/worker.mjs
+++ b/tools/line-note-scraper/src/worker.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+// line-notes worker：跟後台（Supabase）之間的橋。
+//
+// 跑在你自己的電腦／VPS 上，用 service_role 輪詢 line_note_jobs：
+//   login       → 產 QR 寫進 line_note_accounts（後台顯示），掃完存 token
+//   logout      → 清 token
+//   list_homes  → 這個帳號加入的群組／社群清單（後台選社群用）
+//   post        → 把團的內容套模板發到記事本
+//   read        → 讀貼文底下留言 → 落地 line_note_comments → rpc_line_note_apply_comment 加單
+// 另外每分鐘看一次社群設定的 read_times（台北時間），到點就自己排 read。
+//
+// 環境變數：SUPABASE_URL、SUPABASE_SERVICE_ROLE_KEY（必填）、
+//           LINE_DEVICE（預設 ANDROIDSECONDARY）、LINE_STORAGE_DIR（預設 ./storage）、POLL_MS（預設 5000）
+//
+//   node src/worker.mjs            # 或 npm run worker
+
+import fs from "node:fs";
+import path from "node:path";
+import { loginWithAuthToken, loginWithQR } from "@evex/linejs";
+import { FileStorage } from "@evex/linejs/storage";
+import { createNotePost, listComments, listHomes, whoami } from "./line.mjs";
+import { parseNoteComment, postTitle } from "./parse.mjs";
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error("缺 SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY（放在 .env 或環境變數）");
+  process.exit(1);
+}
+const DEVICE = process.env.LINE_DEVICE || "ANDROIDSECONDARY";
+const STORAGE_DIR = process.env.LINE_STORAGE_DIR || "./storage";
+const POLL_MS = Number(process.env.POLL_MS || 5000);
+const TZ = "Asia/Taipei";
+const VERBOSE = !!process.env.VERBOSE;
+
+fs.mkdirSync(STORAGE_DIR, { recursive: true });
+
+const log = (...a) => console.log(new Date().toISOString(), ...a);
+
+// ── Supabase REST ──────────────────────────────────────────────────────────
+async function rest(pathAndQuery, { method = "GET", body, prefer } = {}) {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${pathAndQuery}`, {
+    method,
+    headers: {
+      apikey: SERVICE_KEY,
+      Authorization: `Bearer ${SERVICE_KEY}`,
+      "Content-Type": "application/json",
+      Prefer: prefer ?? (method === "GET" ? "" : "return=representation"),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`${method} ${pathAndQuery} → ${res.status} ${text.slice(0, 300)}`);
+  return text ? JSON.parse(text) : null;
+}
+const rpc = (name, args) => rest(`rpc/${name}`, { method: "POST", body: args, prefer: "" });
+const patch = (table, filter, body) => rest(`${table}?${filter}`, { method: "PATCH", body });
+
+// ── LINE client（每個帳號一個） ─────────────────────────────────────────────
+const clients = new Map();
+const storageFor = (accountId) => new FileStorage(path.join(STORAGE_DIR, `account-${accountId}.json`));
+
+async function clientFor(account) {
+  if (clients.has(account.id)) return clients.get(account.id);
+  if (!account.auth_token) throw new Error(`帳號「${account.label}」還沒登入`);
+  const client = await loginWithAuthToken(account.auth_token, { device: DEVICE, storage: storageFor(account.id) });
+  client.base.on("update:authtoken", (t) => patch("line_note_accounts", `id=eq.${account.id}`, { auth_token: t }).catch(() => {}));
+  clients.set(account.id, client);
+  return client;
+}
+
+async function loadAccount(id) {
+  const rows = await rest(`line_note_accounts?id=eq.${id}&select=*`);
+  if (!rows?.[0]) throw new Error(`account ${id} not found`);
+  return rows[0];
+}
+
+// ── 工作 ────────────────────────────────────────────────────────────────────
+async function jobLogin(job) {
+  const account = await loadAccount(job.account_id);
+  clients.delete(account.id);
+  const client = await loginWithQR({
+    async onReceiveQRUrl(url) {
+      let qr_image = null;
+      try {
+        const QR = await import("qrcode");
+        qr_image = await (QR.default ?? QR).toDataURL(url, { width: 320, margin: 1 });
+      } catch (e) {
+        log("qrcode 產圖失敗（後台會只顯示網址）:", e?.message ?? e);
+      }
+      await patch("line_note_accounts", `id=eq.${account.id}`, { status: "pending_qr", qr_url: url, qr_image, pin_code: null });
+      log(`[login ${account.label}] QR 已送到後台`);
+    },
+    async onPincodeRequest(pin) {
+      await patch("line_note_accounts", `id=eq.${account.id}`, { pin_code: pin });
+      log(`[login ${account.label}] PIN ${pin}`);
+    },
+  }, { device: DEVICE, storage: storageFor(account.id) });
+  const me = whoami(client);
+  await storageFor(account.id).set(".auth", client.base.authToken);
+  await patch("line_note_accounts", `id=eq.${account.id}`, {
+    status: "active", auth_token: client.base.authToken, line_mid: me.mid, display_name: me.displayName,
+    qr_image: null, qr_url: null, pin_code: null, last_error: null, last_seen_at: new Date().toISOString(),
+  });
+  client.base.on("update:authtoken", (t) => patch("line_note_accounts", `id=eq.${account.id}`, { auth_token: t }).catch(() => {}));
+  clients.set(account.id, client);
+  return { mid: me.mid, displayName: me.displayName };
+}
+
+async function jobLogout(job) {
+  const account = await loadAccount(job.account_id);
+  const client = clients.get(account.id);
+  if (client) {
+    try { await client.base.auth.logoutZ(); } catch (e) { log("logoutZ 失敗（略過）:", e?.message ?? e); }
+    clients.delete(account.id);
+  }
+  try { fs.rmSync(path.join(STORAGE_DIR, `account-${account.id}.json`), { force: true }); } catch { /* ignore */ }
+  await patch("line_note_accounts", `id=eq.${account.id}`, {
+    status: "logged_out", auth_token: null, qr_image: null, qr_url: null, pin_code: null, last_error: null,
+  });
+  return { ok: true };
+}
+
+async function jobListHomes(job) {
+  const account = await loadAccount(job.account_id);
+  const client = await clientFor(account);
+  const homes = await listHomes(client, VERBOSE);
+  return { homes };
+}
+
+const DEFAULT_TEMPLATE = `📣 {{name}}
+{{description}}
+
+{{items}}
+
+⏰ 收單：{{end_at}}
+📝 下單方式：留言「會員編號 6 碼 ＋ 品項代碼＋數量」
+　例：123456 A+1 B+2`;
+
+function fmtTaipei(iso) {
+  if (!iso) return "";
+  const d = new Date(iso);
+  const p = new Intl.DateTimeFormat("zh-TW", { timeZone: TZ, month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: false }).formatToParts(d);
+  const g = (t) => p.find((x) => x.type === t)?.value ?? "";
+  return `${g("month")}/${g("day")} ${g("hour")}:${g("minute")}`;
+}
+
+export function renderTemplate(template, payload) {
+  const c = payload.campaign ?? {};
+  const items = (payload.items ?? []).map((it) => {
+    const price = it.unit_price == null ? "" : ` $${Number(it.unit_price)}`;
+    return `${it.code}. ${it.name}${price}`;
+  }).join("\n");
+  return (template || DEFAULT_TEMPLATE)
+    .replaceAll("{{name}}", c.name ?? "")
+    .replaceAll("{{campaign_no}}", c.campaign_no ?? "")
+    .replaceAll("{{description}}", c.description ?? "")
+    .replaceAll("{{items}}", items)
+    .replaceAll("{{end_at}}", fmtTaipei(c.end_at))
+    .replaceAll("{{start_at}}", fmtTaipei(c.start_at))
+    .replaceAll("{{pickup_deadline}}", fmtTaipei(c.pickup_deadline))
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function jobPost(job) {
+  const payload = await rpc("rpc_line_note_post_payload", { p_post_id: job.post_id });
+  if (!payload) throw new Error(`post ${job.post_id} not found`);
+  const account = await loadAccount(payload.account_id);
+  const client = await clientFor(account);
+  const text = renderTemplate(payload.post_template, payload);
+  try {
+    const post = await createNotePost(client, payload.home_id, { text, verbose: VERBOSE });
+    await patch("line_note_posts", `id=eq.${job.post_id}`, {
+      status: "posted", line_post_id: post.postId ?? null, text, posted_at: new Date().toISOString(), last_error: null,
+    });
+    return { postId: post.postId, title: postTitle(text) };
+  } catch (e) {
+    await patch("line_note_posts", `id=eq.${job.post_id}`, { status: "failed", text, last_error: String(e?.message ?? e).slice(0, 1000) });
+    throw e;
+  }
+}
+
+async function readPost(client, post) {
+  const comments = await listComments(client, post.home_id, post.line_post_id, { verbose: VERBOSE });
+  if (comments.length) {
+    const rows = comments.map((c) => {
+      const parsed = parseNoteComment(c.text);
+      return {
+        tenant_id: post.tenant_id, post_id: post.id, line_comment_id: String(c.commentId ?? ""),
+        commenter_id: c.authorMid ?? null, commenter_name: c.authorName ?? null, text: c.text ?? "",
+        commented_at: c.createdAt ?? null, member_no_hint: parsed.memberNo, parsed: parsed.orders,
+      };
+    }).filter((r) => r.line_comment_id);
+    // 已經有的留言不動（on_conflict 忽略），所以人工標過「忽略」的不會被洗掉
+    await rest(`line_note_comments?on_conflict=post_id,line_comment_id`, {
+      method: "POST", body: rows, prefer: "resolution=ignore-duplicates,return=minimal",
+    });
+  }
+  const pending = await rest(`line_note_comments?post_id=eq.${post.id}&status=eq.pending&select=id&order=commented_at.asc,id.asc`);
+  let ordered = 0, other = 0;
+  for (const c of pending ?? []) {
+    try {
+      const r = await rpc("rpc_line_note_apply_comment", { p_comment_id: c.id });
+      const st = Array.isArray(r) ? r[0]?.out_status : r?.out_status;
+      if (st === "ordered") ordered++; else other++;
+    } catch (e) {
+      other++;
+      await patch("line_note_comments", `id=eq.${c.id}`, { status: "error", error: String(e?.message ?? e).slice(0, 1000) }).catch(() => {});
+    }
+  }
+  await patch("line_note_posts", `id=eq.${post.id}`, { last_read_at: new Date().toISOString(), comment_count: comments.length, last_error: null });
+  return { comments: comments.length, pending: pending?.length ?? 0, ordered, other };
+}
+
+async function jobRead(job) {
+  const filter = job.post_id ? `id=eq.${job.post_id}` : `community_id=eq.${job.community_id}`;
+  const posts = await rest(`line_note_posts?${filter}&status=eq.posted&select=id,tenant_id,line_post_id,community_id,group_buy_campaigns(status),line_note_communities(home_id,account_id)`);
+  const out = [];
+  for (const p of posts ?? []) {
+    const cst = p.group_buy_campaigns?.status;
+    if (cst && !["open", "closed"].includes(cst)) {
+      await patch("line_note_posts", `id=eq.${p.id}`, { status: "closed" });
+      continue;
+    }
+    const account = await loadAccount(p.line_note_communities.account_id);
+    const client = await clientFor(account);
+    try {
+      const r = await readPost(client, { ...p, home_id: p.line_note_communities.home_id });
+      out.push({ post_id: p.id, ...r });
+    } catch (e) {
+      await patch("line_note_posts", `id=eq.${p.id}`, { last_error: String(e?.message ?? e).slice(0, 1000) });
+      out.push({ post_id: p.id, error: String(e?.message ?? e) });
+    }
+  }
+  if (job.community_id) {
+    await patch("line_note_communities", `id=eq.${job.community_id}`, { last_read_at: new Date().toISOString(), last_error: null });
+  }
+  return { posts: out };
+}
+
+const HANDLERS = { login: jobLogin, logout: jobLogout, list_homes: jobListHomes, post: jobPost, read: jobRead };
+
+async function claimNextJob() {
+  const rows = await rest(`line_note_jobs?status=eq.queued&select=*&order=created_at.asc&limit=1`);
+  const job = rows?.[0];
+  if (!job) return null;
+  const claimed = await patch("line_note_jobs", `id=eq.${job.id}&status=eq.queued`, { status: "running", started_at: new Date().toISOString() });
+  return claimed?.[0] ?? null;
+}
+
+async function runJob(job) {
+  log(`▶ job#${job.id} ${job.kind} account=${job.account_id} community=${job.community_id ?? "-"} post=${job.post_id ?? "-"}`);
+  try {
+    const result = await HANDLERS[job.kind](job);
+    await patch("line_note_jobs", `id=eq.${job.id}`, { status: "done", result, finished_at: new Date().toISOString() });
+    if (job.account_id) await patch("line_note_accounts", `id=eq.${job.account_id}`, { last_seen_at: new Date().toISOString() }).catch(() => {});
+    log(`✔ job#${job.id}`, JSON.stringify(result).slice(0, 300));
+  } catch (e) {
+    const msg = String(e?.message ?? e);
+    log(`✖ job#${job.id}`, msg.slice(0, 500));
+    await patch("line_note_jobs", `id=eq.${job.id}`, { status: "failed", error: msg.slice(0, 2000), finished_at: new Date().toISOString() });
+    if (job.kind === "login") {
+      await patch("line_note_accounts", `id=eq.${job.account_id}`, { status: "error", last_error: msg.slice(0, 1000), qr_image: null, qr_url: null, pin_code: null }).catch(() => {});
+    } else if (/還沒登入|NotAuthorized|token/i.test(msg) && job.account_id) {
+      clients.delete(job.account_id);
+      await patch("line_note_accounts", `id=eq.${job.account_id}`, { status: "error", last_error: msg.slice(0, 1000) }).catch(() => {});
+    }
+  }
+}
+
+// ── 排程：到 read_times 就排 read ───────────────────────────────────────────
+let lastTick = "";
+function nowHHMM() {
+  const p = new Intl.DateTimeFormat("en-GB", { timeZone: TZ, hour: "2-digit", minute: "2-digit", hour12: false }).formatToParts(new Date());
+  const g = (t) => p.find((x) => x.type === t)?.value ?? "00";
+  return `${g("hour")}:${g("minute")}`;
+}
+async function scheduleTick() {
+  const hhmm = nowHHMM();
+  const key = new Date().toISOString().slice(0, 10) + " " + hhmm;
+  if (key === lastTick) return;
+  lastTick = key;
+  const communities = await rest(`line_note_communities?listen_enabled=eq.true&read_times=cs.{${hhmm}}&select=id,tenant_id,account_id`);
+  for (const c of communities ?? []) {
+    const dup = await rest(`line_note_jobs?kind=eq.read&community_id=eq.${c.id}&status=in.(queued,running)&select=id&limit=1`);
+    if (dup?.length) continue;
+    await rest("line_note_jobs", { method: "POST", body: { tenant_id: c.tenant_id, kind: "read", account_id: c.account_id, community_id: c.id }, prefer: "return=minimal" });
+    log(`⏰ ${hhmm} 排 read：community#${c.id}`);
+  }
+}
+
+// ── 主迴圈 ──────────────────────────────────────────────────────────────────
+async function main() {
+  log(`worker 啟動：${SUPABASE_URL}  device=${DEVICE}  poll=${POLL_MS}ms`);
+  // 開機時把上次沒跑完的 running 退回 queued
+  await patch("line_note_jobs", "status=eq.running", { status: "queued", started_at: null }).catch(() => {});
+  for (;;) {
+    try {
+      await scheduleTick();
+      const job = await claimNextJob();
+      if (job) { await runJob(job); continue; }
+    } catch (e) {
+      log("loop error:", e?.message ?? e);
+    }
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === new URL(import.meta.url).pathname) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}


### PR DESCRIPTION
接 #918。`tools/line-note-scraper` 加 `post` 指令：

```bash
node src/cli.mjs post <homeId> --text "…"
node src/cli.mjs post <homeId> --file post.txt --image 1.jpg --image 2.jpg
```

- 走 linejs 內建 `timeline.createPost`（群組 `/mh`、社群 `/sn` 自動分流），圖片先用 `uploadNoteMedia` 上傳 obs 再掛進貼文；圖片限 JPEG。
- `--source-type` 可覆寫 sourceType，發不出去時調這個。

後台整合（帳號登入／社群設定／自動發文／讀留言加單）另開一支 PR，已含這個 commit。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ