### PR TITLE
feat(line-notes): LINE 記事本整合——後台登入帳號、綁社群、開團自動發文、定時讀留言加單

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -20,7 +20,7 @@ type Channel = { id: number; code: string; name: string; channel_type: string; h
 type Community = {
   id: number; account_id: number; channel_id: number; home_id: string; home_name: string | null;
   home_kind: "group" | "square" | "square_chat"; listen_enabled: boolean; read_times: string[];
-  auto_post_on_open: boolean; post_template: string | null; last_read_at: string | null; last_error: string | null;
+  auto_post_on_open: boolean; post_template: string | null; read_days: number; last_read_at: string | null; last_error: string | null;
 };
 type Post = {
   id: number; community_id: number; campaign_id: number; line_post_id: string | null; text: string | null;
@@ -31,9 +31,11 @@ type Post = {
 type Comment = {
   id: number; line_comment_id: string; commenter_id: string | null; commenter_name: string | null; text: string;
   commented_at: string | null; member_no_hint: string | null; parsed: { code: string | null; qty: number; cancel: boolean }[];
-  status: "pending" | "ordered" | "unmatched" | "no_order" | "error" | "ignored";
+  status: "pending" | "ordered" | "unmatched" | "no_order" | "error" | "ignored" | "resolved";
   member_id: number | null; customer_order_id: number | null; error: string | null;
+  resolved_at: string | null; resolution_note: string | null;
 };
+type Todo = Comment & { line_note_posts: { community_id: number; campaign_id: number; group_buy_campaigns: { name: string; campaign_no: string } | null } | null };
 type Home = { kind: string; homeId: string; name: string };
 type Campaign = { id: number; campaign_no: string; name: string; status: string };
 
@@ -42,7 +44,7 @@ const ACCOUNT_STATUS: Record<Account["status"], string> = {
 };
 const POST_STATUS: Record<Post["status"], string> = { queued: "排隊中", posted: "已發文", failed: "失敗", closed: "已結束" };
 const COMMENT_STATUS: Record<Comment["status"], string> = {
-  pending: "待處理", ordered: "已加單", unmatched: "找不到會員", no_order: "非下單", error: "錯誤", ignored: "忽略",
+  pending: "待處理", ordered: "已加單", unmatched: "找不到會員", no_order: "非下單", error: "錯誤", ignored: "忽略", resolved: "已解決",
 };
 const KIND_LABEL: Record<string, string> = { group: "群組", square: "社群", square_chat: "社群聊天室" };
 
@@ -201,7 +203,7 @@ function AccountsTab({ accounts, reload, notify, fail }: {
         <SpinButton type="button" className={btnPrimary} loading={busy === "new"} onClick={addAccount}>＋ 新增帳號</SpinButton>
       </div>
       <Table>
-        <THead><Tr><Th>名稱</Th><Th>狀態</Th><Th>LINE 顯示名稱</Th><Th>最後活動</Th><Th>錯誤</Th><Th align="right">操作</Th></Tr></THead>
+        <THead><Th>名稱</Th><Th>狀態</Th><Th>LINE 顯示名稱</Th><Th>最後活動</Th><Th>錯誤</Th><Th align="right">操作</Th></THead>
         <TBody>
           {accounts === null ? <LoadingRow colSpan={6} /> : accounts.length === 0 ? <EmptyRow colSpan={6}>還沒有帳號</EmptyRow> : accounts.map((a) => (
             <Tr key={a.id}>
@@ -256,11 +258,11 @@ function AccountsTab({ accounts, reload, notify, fail }: {
 // ── 社群設定 ─────────────────────────────────────────────────────────────────
 type CommunityForm = {
   id: number | null; account_id: number | ""; channel_id: number | ""; home_id: string; home_name: string;
-  listen_enabled: boolean; read_times: string; auto_post_on_open: boolean; post_template: string;
+  listen_enabled: boolean; read_times: string; auto_post_on_open: boolean; post_template: string; read_days: number;
 };
 const EMPTY_FORM: CommunityForm = {
   id: null, account_id: "", channel_id: "", home_id: "", home_name: "",
-  listen_enabled: true, read_times: "12:00", auto_post_on_open: true, post_template: "",
+  listen_enabled: true, read_times: "12:00", auto_post_on_open: true, post_template: "", read_days: 3,
 };
 
 function CommunitiesTab({ communities, accounts, channels, accountById, channelById, reload, reloadPosts, notify, fail }: {
@@ -277,7 +279,7 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
   const openEdit = (c: Community) => {
     setHomes(null);
     setForm({ id: c.id, account_id: c.account_id, channel_id: c.channel_id, home_id: c.home_id, home_name: c.home_name ?? "",
-      listen_enabled: c.listen_enabled, read_times: c.read_times.join(", "), auto_post_on_open: c.auto_post_on_open, post_template: c.post_template ?? "" });
+      listen_enabled: c.listen_enabled, read_times: c.read_times.join(", "), auto_post_on_open: c.auto_post_on_open, post_template: c.post_template ?? "", read_days: c.read_days ?? 3 });
   };
 
   const loadHomes = async () => {
@@ -306,6 +308,7 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
       p_listen_enabled: form.listen_enabled,
       p_read_times: form.read_times.split(/[,\s，、]+/).map((s) => s.trim()).filter(Boolean),
       p_auto_post_on_open: form.auto_post_on_open, p_post_template: form.post_template || null,
+      p_read_days: Math.min(30, Math.max(1, Math.round(form.read_days || 3))),
     });
     setBusy(null);
     if (error) return fail(error);
@@ -338,7 +341,7 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
         <button type="button" className={btnPrimary} onClick={openNew} disabled={accounts.length === 0}>＋ 新增社群</button>
       </div>
       <Table>
-        <THead><Tr><Th>社群</Th><Th>帳號</Th><Th>渠道 / 取貨店</Th><Th>監聽</Th><Th>讀取時間</Th><Th>開團自動發文</Th><Th>最後讀取</Th><Th align="right">操作</Th></Tr></THead>
+        <THead><Th>社群</Th><Th>帳號</Th><Th>渠道 / 取貨店</Th><Th>監聽</Th><Th>讀取時間</Th><Th>開團自動發文</Th><Th>最後讀取</Th><Th align="right">操作</Th></THead>
         <TBody>
           {communities === null ? <LoadingRow colSpan={8} /> : communities.length === 0 ? <EmptyRow colSpan={8}>還沒有社群</EmptyRow> : communities.map((c) => {
             const a = accountById.get(c.account_id);
@@ -352,7 +355,7 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
                 <Td>{a ? <>{a.label} <Badge tone={a.status === "active" ? "green" : "red"}>{ACCOUNT_STATUS[a.status]}</Badge></> : "—"}</Td>
                 <Td>{channelById.get(c.channel_id)?.name ?? c.channel_id}</Td>
                 <Td><Badge tone={c.listen_enabled ? "green" : "gray"}>{c.listen_enabled ? "監聽中" : "停用"}</Badge></Td>
-                <Td className="font-mono text-xs">{c.read_times.join(" ")}</Td>
+                <Td className="font-mono text-xs">{c.read_times.join(" ")}<div className="text-zinc-400">近 {c.read_days} 天</div></Td>
                 <Td>{c.auto_post_on_open ? "是" : "否"}</Td>
                 <Td>{fmt(c.last_read_at)}</Td>
                 <Td align="right">
@@ -401,6 +404,9 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
             </div>
             <label className="text-sm">顯示名稱
               <input className={input} value={form.home_name} onChange={(e) => setForm({ ...form, home_name: e.target.value })} />
+            </label>
+            <label className="text-sm">讀取範圍（最近幾天的貼文；也用來認小幫手手貼的團）
+              <input type="number" min={1} max={30} className={input} value={form.read_days} onChange={(e) => setForm({ ...form, read_days: Number(e.target.value) })} />
             </label>
             <label className="text-sm">讀留言時間（台北，HH:MM，逗號分隔）
               <input className={`${input} font-mono`} value={form.read_times} onChange={(e) => setForm({ ...form, read_times: e.target.value })} placeholder="09:00, 12:00, 18:00" />
@@ -472,7 +478,18 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
 }) {
   const [selected, setSelected] = useState<Post | null>(null);
   const [comments, setComments] = useState<Comment[] | null>(null);
+  const [todos, setTodos] = useState<Todo[] | null>(null);
   const [busy, setBusy] = useState<number | null>(null);
+
+  // 待人工處理：找不到會員 / 品項對不上 / 加單失敗 / 有會員編號卻沒數量
+  const loadTodos = useCallback(async () => {
+    const { data, error } = await getSupabase().from("line_note_comments")
+      .select("*,line_note_posts(community_id,campaign_id,group_buy_campaigns(name,campaign_no))")
+      .or("status.in.(unmatched,error),and(status.eq.no_order,member_no_hint.not.is.null)")
+      .order("commented_at", { ascending: false }).limit(200);
+    if (error) fail(error); else setTodos((data ?? []) as Todo[]);
+  }, [fail]);
+  useEffect(() => { void loadTodos(); }, [loadTodos]);
 
   const loadComments = useCallback(async (post: Post) => {
     const { data, error } = await getSupabase().from("line_note_comments").select("*").eq("post_id", post.id).order("commented_at", { ascending: true }).order("id");
@@ -488,13 +505,23 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
     const r = (Array.isArray(data) ? data[0] : data) as { out_status?: string; out_error?: string } | null;
     notify(r?.out_status === "ordered" ? "已加單" : `結果：${COMMENT_STATUS[(r?.out_status ?? "error") as Comment["status"]] ?? r?.out_status}${r?.out_error ? "：" + r.out_error : ""}`);
     if (selected) await loadComments(selected);
+    await loadTodos();
   };
   const setStatus = async (c: Comment, status: Comment["status"]) => {
+    let note: string | null = null;
+    if (status === "resolved") {
+      note = window.prompt("怎麼處理的？（選填，例：已用小幫手加單 / 客人說不要了）", c.resolution_note ?? "");
+      if (note === null) return;
+    }
     setBusy(c.id);
-    const { error } = await getSupabase().from("line_note_comments").update({ status, error: null }).eq("id", c.id);
+    const body = status === "resolved"
+      ? { status, resolved_at: new Date().toISOString(), resolution_note: note || null }
+      : { status };
+    const { error } = await getSupabase().from("line_note_comments").update(body).eq("id", c.id);
     setBusy(null);
     if (error) return fail(error);
     if (selected) await loadComments(selected);
+    await loadTodos();
   };
   const readNow = async (p: Post) => {
     const c = communityById.get(p.community_id);
@@ -509,17 +536,56 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
   const summary = useMemo(() => {
     if (!comments) return null;
     const n = (s: Comment["status"]) => comments.filter((c) => c.status === s).length;
-    return { ordered: n("ordered"), pending: n("pending"), unmatched: n("unmatched"), error: n("error"), no_order: n("no_order"), ignored: n("ignored") };
+    return { ordered: n("ordered"), pending: n("pending"), unmatched: n("unmatched"), error: n("error"), no_order: n("no_order"), ignored: n("ignored"), resolved: n("resolved") };
   }, [comments]);
+
+  const todoActions = (c: Comment) => (
+    <div className="flex justify-end gap-1">
+      {!["ordered", "ignored", "resolved"].includes(c.status) && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => retry(c)}>重試</SpinButton>}
+      {!["ordered", "ignored", "resolved"].includes(c.status) && <SpinButton type="button" className={`${btn} text-emerald-700`} loading={busy === c.id} onClick={() => setStatus(c, "resolved")}>已解決</SpinButton>}
+      {!["ordered", "ignored", "resolved"].includes(c.status) && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => setStatus(c, "ignored")}>忽略</SpinButton>}
+      {(c.status === "ignored" || c.status === "resolved") && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => setStatus(c, "pending")}>退回待處理</SpinButton>}
+    </div>
+  );
+  const commentTone = (s: Comment["status"]) =>
+    s === "ordered" || s === "resolved" ? "green" : s === "pending" ? "amber" : s === "unmatched" || s === "error" ? "red" : "gray";
 
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <p className="text-sm text-zinc-500">點一篇貼文看底下留言與加單結果。「找不到會員」「錯誤」可以修正後按「重試」，或標「忽略」。</p>
-        <button type="button" className={btn} onClick={() => void reload()}>重新整理</button>
+        <p className="text-sm text-zinc-500">點一篇貼文看底下留言與加單結果。「找不到會員」「錯誤」可以修正後按「重試」，小幫手手動加完單按「已解決」，紀錄會留著。</p>
+        <button type="button" className={btn} onClick={() => { void reload(); void loadTodos(); }}>重新整理</button>
       </div>
+
+      <section className="rounded border border-amber-300 bg-amber-50/60 p-3 dark:border-amber-800 dark:bg-amber-950/30">
+        <div className="mb-2 flex items-center justify-between">
+          <h2 className="font-medium">⚠️ 待小幫手處理 {todos ? `（${todos.length}）` : ""}</h2>
+          <span className="text-xs text-zinc-500">系統拆不出來或對不到的留言。加完單後按「已解決」。</span>
+        </div>
+        <Table>
+          <THead><Th>時間</Th><Th>團</Th><Th>留言者</Th><Th>留言</Th><Th>原因</Th><Th align="right">操作</Th></THead>
+          <TBody>
+            {todos === null ? <LoadingRow colSpan={6} /> : todos.length === 0 ? <EmptyRow colSpan={6}>目前沒有要人工處理的留言 🎉</EmptyRow> : todos.map((c) => (
+              <Tr key={c.id}>
+                <Td className="whitespace-nowrap text-xs">{fmt(c.commented_at)}</Td>
+                <Td className="text-sm">
+                  <div>{c.line_note_posts?.group_buy_campaigns?.name ?? "—"}</div>
+                  <div className="text-xs text-zinc-500">{c.line_note_posts?.group_buy_campaigns?.campaign_no} · {communityById.get(c.line_note_posts?.community_id ?? -1)?.home_name ?? ""}</div>
+                </Td>
+                <Td>{c.commenter_name ?? "—"}</Td>
+                <Td className="max-w-sm whitespace-pre-wrap text-sm">{c.text}</Td>
+                <Td className="text-xs">
+                  <Badge tone={commentTone(c.status)}>{COMMENT_STATUS[c.status]}</Badge>
+                  <div className="text-red-600">{c.error ?? (c.status === "no_order" ? "有會員編號但看不出數量" : "")}</div>
+                </Td>
+                <Td align="right">{todoActions(c)}</Td>
+              </Tr>
+            ))}
+          </TBody>
+        </Table>
+      </section>
       <Table>
-        <THead><Tr><Th>團</Th><Th>社群</Th><Th>狀態</Th><Th>發文時間</Th><Th>最後讀取</Th><Th align="right">留言數</Th><Th align="right">操作</Th></Tr></THead>
+        <THead><Th>團</Th><Th>社群</Th><Th>狀態</Th><Th>發文時間</Th><Th>最後讀取</Th><Th align="right">留言數</Th><Th align="right">操作</Th></THead>
         <TBody>
           {posts === null ? <LoadingRow colSpan={7} /> : posts.length === 0 ? <EmptyRow colSpan={7}>還沒有貼文</EmptyRow> : posts.map((p) => {
             const c = communityById.get(p.community_id);
@@ -560,12 +626,13 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
                 <Badge tone="red">錯誤 {summary.error}</Badge>
                 <Badge tone="gray">非下單 {summary.no_order}</Badge>
                 <Badge tone="gray">忽略 {summary.ignored}</Badge>
+                <Badge tone="green">已解決 {summary.resolved}</Badge>
               </div>
             )}
           </div>
           {selected.text && <details className="text-xs text-zinc-500"><summary>貼文內容</summary><pre className="whitespace-pre-wrap">{selected.text}</pre></details>}
           <Table>
-            <THead><Tr><Th>時間</Th><Th>留言者</Th><Th>留言</Th><Th>會員編號</Th><Th>解析</Th><Th>狀態</Th><Th align="right">操作</Th></Tr></THead>
+            <THead><Th>時間</Th><Th>留言者</Th><Th>留言</Th><Th>會員編號</Th><Th>解析</Th><Th>狀態</Th><Th align="right">操作</Th></THead>
             <TBody>
               {comments === null ? <LoadingRow colSpan={7} /> : comments.length === 0 ? <EmptyRow colSpan={7}>還沒讀到留言</EmptyRow> : comments.map((c) => (
                 <Tr key={c.id}>
@@ -575,17 +642,12 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
                   <Td className="font-mono">{c.member_no_hint ?? "—"}</Td>
                   <Td className="font-mono text-xs">{(c.parsed ?? []).map((o, i) => <div key={i}>{o.cancel ? "取消 " : ""}{o.code ?? "(單品)"} ×{o.qty}</div>)}</Td>
                   <Td>
-                    <Badge tone={c.status === "ordered" ? "green" : c.status === "pending" ? "amber" : c.status === "unmatched" || c.status === "error" ? "red" : "gray"}>{COMMENT_STATUS[c.status]}</Badge>
+                    <Badge tone={commentTone(c.status)}>{COMMENT_STATUS[c.status]}</Badge>
                     {c.error && <div className="max-w-xs text-xs text-red-600">{c.error}</div>}
+                    {c.resolution_note && <div className="max-w-xs text-xs text-zinc-500">處理：{c.resolution_note}</div>}
                     {c.customer_order_id && <div className="text-xs text-zinc-500">訂單 #{c.customer_order_id}</div>}
                   </Td>
-                  <Td align="right">
-                    <div className="flex justify-end gap-1">
-                      {c.status !== "ordered" && c.status !== "ignored" && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => retry(c)}>重試</SpinButton>}
-                      {c.status !== "ordered" && c.status !== "ignored" && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => setStatus(c, "ignored")}>忽略</SpinButton>}
-                      {c.status === "ignored" && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => setStatus(c, "pending")}>取消忽略</SpinButton>}
-                    </div>
-                  </Td>
+                  <Td align="right">{todoActions(c)}</Td>
                 </Tr>
               ))}
             </TBody>

--- a/supabase/migrations/20260908010000_line_note_bridge.sql
+++ b/supabase/migrations/20260908010000_line_note_bridge.sql
@@ -441,15 +441,17 @@ GRANT EXECUTE ON FUNCTION public.rpc_line_note_queue_post(BIGINT, BIGINT) TO aut
 -- ----------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public._line_note_item_codes(p_campaign_id BIGINT)
 RETURNS TABLE (code TEXT, campaign_item_id BIGINT, sku_id BIGINT,
-               item_name TEXT, unit_price NUMERIC, cap_qty NUMERIC)
+               item_name TEXT, unit_price NUMERIC, cap_qty NUMERIC, images JSONB)
 LANGUAGE sql STABLE SECURITY DEFINER
 AS $$
   SELECT chr(64 + (ROW_NUMBER() OVER (ORDER BY ci.sort_order, ci.id))::int) AS code,
          ci.id, ci.sku_id,
          TRIM(COALESCE(s.product_name, '') || CASE WHEN COALESCE(s.variant_name, '') <> '' THEN ' ' || s.variant_name ELSE '' END),
-         ci.unit_price, ci.cap_qty
+         ci.unit_price, ci.cap_qty,
+         COALESCE(p.images, '[]'::jsonb)   -- 商品圖（storage 相對路徑或完整網址），worker 發文時附上
     FROM campaign_items ci
     JOIN skus s ON s.id = ci.sku_id
+    LEFT JOIN products p ON p.id = s.product_id
    WHERE ci.campaign_id = p_campaign_id
      AND COALESCE(ci.is_gift, FALSE) = FALSE
    ORDER BY ci.sort_order, ci.id
@@ -474,7 +476,8 @@ AS $$
        'start_at', g.start_at, 'end_at', g.end_at, 'pickup_deadline', g.pickup_deadline),
     'items', COALESCE((SELECT jsonb_agg(jsonb_build_object(
                 'code', ic.code, 'campaign_item_id', ic.campaign_item_id,
-                'name', ic.item_name, 'unit_price', ic.unit_price, 'cap_qty', ic.cap_qty)
+                'name', ic.item_name, 'unit_price', ic.unit_price, 'cap_qty', ic.cap_qty,
+                'images', ic.images)
                 ORDER BY ic.code)
                FROM public._line_note_item_codes(g.id) ic), '[]'::jsonb)
   )

--- a/supabase/migrations/20260908010000_line_note_bridge.sql
+++ b/supabase/migrations/20260908010000_line_note_bridge.sql
@@ -470,6 +470,7 @@ AS $$
     'campaign', jsonb_build_object(
        'id', g.id, 'campaign_no', g.campaign_no, 'name', g.name,
        'description', g.description, 'status', g.status,
+       'cover_image_url', g.cover_image_url,
        'start_at', g.start_at, 'end_at', g.end_at, 'pickup_deadline', g.pickup_deadline),
     'items', COALESCE((SELECT jsonb_agg(jsonb_build_object(
                 'code', ic.code, 'campaign_item_id', ic.campaign_item_id,

--- a/supabase/migrations/20260908010000_line_note_bridge.sql
+++ b/supabase/migrations/20260908010000_line_note_bridge.sql
@@ -79,6 +79,8 @@ CREATE TABLE line_note_communities (
   listen_enabled     BOOLEAN NOT NULL DEFAULT FALSE,
   read_times         TEXT[] NOT NULL DEFAULT ARRAY['12:00'],  -- 台北時間 HH:MM，可多個
   auto_post_on_open  BOOLEAN NOT NULL DEFAULT TRUE,
+  read_days          INT NOT NULL DEFAULT 3 CHECK (read_days BETWEEN 1 AND 30),
+                                       -- 讀留言／認貼文的範圍：最近 N 天的貼文
   post_template      TEXT,             -- NULL → worker 用預設模板
   last_read_at       TIMESTAMPTZ,
   last_error         TEXT,
@@ -155,11 +157,15 @@ CREATE TABLE line_note_comments (
   member_no_hint     TEXT,             -- 留言裡抓到的 6 碼
   parsed             JSONB NOT NULL DEFAULT '[]'::jsonb,
   status             TEXT NOT NULL DEFAULT 'pending'
-                       CHECK (status IN ('pending','ordered','unmatched','no_order','error','ignored')),
+                       CHECK (status IN ('pending','ordered','unmatched','no_order','error','ignored','resolved')),
+                       -- unmatched：找不到會員；error：品項對不上／加單失敗；resolved：小幫手手動處理完
   member_id          BIGINT REFERENCES members(id),
   customer_order_id  BIGINT,
-  error              TEXT,
+  error              TEXT,             -- 為什麼沒自動加單（保留當紀錄，不清）
   processed_at       TIMESTAMPTZ,
+  resolved_at        TIMESTAMPTZ,
+  resolved_by        UUID,
+  resolution_note    TEXT,
   created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE (post_id, line_comment_id)
@@ -275,7 +281,8 @@ CREATE OR REPLACE FUNCTION public.rpc_line_note_community_upsert(
   p_listen_enabled    BOOLEAN,
   p_read_times        TEXT[],
   p_auto_post_on_open BOOLEAN,
-  p_post_template     TEXT
+  p_post_template     TEXT,
+  p_read_days         INT DEFAULT 3
 ) RETURNS BIGINT
 LANGUAGE plpgsql SECURITY DEFINER
 AS $$
@@ -298,7 +305,7 @@ BEGIN
   IF p_id IS NULL THEN
     INSERT INTO line_note_communities
       (tenant_id, account_id, channel_id, home_id, home_name, home_kind,
-       listen_enabled, read_times, auto_post_on_open, post_template, created_by, updated_by)
+       listen_enabled, read_times, auto_post_on_open, post_template, read_days, created_by, updated_by)
     VALUES
       (v_tenant, p_account_id, p_channel_id, TRIM(p_home_id), p_home_name,
        COALESCE(p_home_kind, 'square_chat'),
@@ -306,6 +313,7 @@ BEGIN
        COALESCE(NULLIF(p_read_times, ARRAY[]::TEXT[]), ARRAY['12:00']),
        COALESCE(p_auto_post_on_open, TRUE),
        NULLIF(TRIM(COALESCE(p_post_template, '')), ''),
+       COALESCE(p_read_days, 3),
        auth.uid(), auth.uid())
     RETURNING id INTO v_id;
   ELSE
@@ -319,6 +327,7 @@ BEGIN
            read_times        = COALESCE(NULLIF(p_read_times, ARRAY[]::TEXT[]), read_times),
            auto_post_on_open = COALESCE(p_auto_post_on_open, auto_post_on_open),
            post_template     = NULLIF(TRIM(COALESCE(p_post_template, '')), ''),
+           read_days         = COALESCE(p_read_days, read_days),
            updated_by        = auth.uid()
      WHERE id = p_id AND tenant_id = v_tenant
     RETURNING id INTO v_id;
@@ -328,7 +337,7 @@ BEGIN
 END;
 $$;
 GRANT EXECUTE ON FUNCTION public.rpc_line_note_community_upsert(
-  BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT, BOOLEAN, TEXT[], BOOLEAN, TEXT) TO authenticated;
+  BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT, BOOLEAN, TEXT[], BOOLEAN, TEXT, INT) TO authenticated;
 
 CREATE OR REPLACE FUNCTION public.rpc_line_note_community_delete(p_id BIGINT)
 RETURNS VOID
@@ -519,7 +528,7 @@ BEGIN
       TRUE);
   END IF;
 
-  IF v_c.status IN ('ordered','ignored') THEN
+  IF v_c.status IN ('ordered','ignored','resolved') THEN
     RETURN QUERY SELECT v_c.status, v_c.customer_order_id, v_c.error; RETURN;
   END IF;
 

--- a/tools/line-note-scraper/.env.example
+++ b/tools/line-note-scraper/.env.example
@@ -5,3 +5,6 @@ SUPABASE_SERVICE_ROLE_KEY=<service_role key；Dashboard → Settings → API>
 # LINE_STORAGE_DIR=./storage
 # POLL_MS=5000
 # VERBOSE=1
+# LINE_POST_MAX_IMAGES=10   # 自動發文最多帶幾張圖（封面 + 商品圖，PNG/WebP 自動轉 JPEG）
+# LINE_POST_NO_IMAGE=1      # 自動發文不帶圖
+# PRODUCTS_BUCKET=products  # 商品圖的 storage bucket

--- a/tools/line-note-scraper/package.json
+++ b/tools/line-note-scraper/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@evex/linejs": "npm:@jsr/evex__linejs@^3.4.2",
     "qrcode": "^1.5.4",
-    "qrcode-terminal": "^0.12.0"
+    "qrcode-terminal": "^0.12.0",
+    "sharp": "^0.34.3"
   }
 }

--- a/tools/line-note-scraper/src/line.mjs
+++ b/tools/line-note-scraper/src/line.mjs
@@ -332,7 +332,7 @@ export async function listComments(client, homeId, postId, { verbose = false, on
  * 圖片先上傳到 obs（myhome/h）拿 objId 再掛進 contents.media。
  * @param {object} opts
  * @param {string} opts.text
- * @param {string[]} [opts.images]  JPEG 檔路徑（上傳時 content-type 固定 image/jpeg）
+ * @param {(string|Buffer)[]} [opts.images]  JPEG 檔路徑或 Buffer（上傳時 content-type 固定 image/jpeg）
  */
 export async function createNotePost(client, homeId, { text, images = [], sourceType, verbose = false } = {}) {
   if (!text && images.length === 0) throw new Error("貼文至少要有文字或圖片");
@@ -340,7 +340,7 @@ export async function createNotePost(client, homeId, { text, images = [], source
   const mediaObjectIds = [];
   const mediaObjectTypes = [];
   for (const file of images) {
-    const buf = fs.readFileSync(file);
+    const buf = Buffer.isBuffer(file) ? file : fs.readFileSync(file);
     const { objId } = await tl.uploadNoteMedia("image", new Blob([buf], { type: "image/jpeg" }));
     log(verbose, `uploaded ${file} → ${objId}`);
     mediaObjectIds.push(objId);

--- a/tools/line-note-scraper/src/parse.mjs
+++ b/tools/line-note-scraper/src/parse.mjs
@@ -29,6 +29,11 @@ const UNIT = "(?:份|個|组|組|包|盒|箱|瓶|罐|袋|條|片|支|入|件|套
 const CODE = "([A-Za-z][A-Za-z0-9-]{0,7})";
 const CANCEL_WORDS = /(取消|退|刪|删|不要了|改為0|改成0)/;
 
+const MULTI_CODE_FIRST = /^\s*(?:[A-Za-z][A-Za-z0-9-]{0,7}\s*[+-]\s*\d{1,3}\s*){2,}$/;
+const MULTI_QTY_FIRST = /^\s*(?:[+-]\s*\d{1,3}\s*[A-Za-z][A-Za-z0-9-]{0,7}\s*){2,}$/;
+const TOKEN_CODE_FIRST = /[A-Za-z][A-Za-z0-9-]{0,7}\s*[+-]\s*\d{1,3}/g;
+const TOKEN_QTY_FIRST = /[+-]\s*\d{1,3}\s*[A-Za-z][A-Za-z0-9-]{0,7}/g;
+
 const PATTERNS = [
   // A+1 / A +2 / B-2+1 / 取消 A-1
   { re: new RegExp(`^\\s*${CODE}\\s*([+-])\\s*(\\d{1,3})${UNIT}\\s*$`), map: (m) => ({ code: m[1], sign: m[2], qty: m[3] }) },
@@ -49,7 +54,15 @@ const PATTERNS = [
 export function parseOrderLines(text) {
   const out = [];
   const norm = normalize(text);
-  for (const rawLine of norm.split(/\r?\n|[,，;；、]/)) {
+  const segments = [];
+  for (const rawLine of norm.split(/\r?\n|[,，;；、/]/)) {
+    // 同一行寫多筆：整行都是「代碼+號+數」重複（A+1 B+5）或「號+數+代碼」重複（+1 A +2 B）才拆，
+    // 其他（B-2 +1 這種代碼帶連字號的）交給下面的單筆規則
+    if (MULTI_CODE_FIRST.test(rawLine)) segments.push(...(rawLine.match(TOKEN_CODE_FIRST) ?? []));
+    else if (MULTI_QTY_FIRST.test(rawLine)) segments.push(...(rawLine.match(TOKEN_QTY_FIRST) ?? []));
+    else segments.push(rawLine);
+  }
+  for (const rawLine of segments) {
     const line = rawLine.trim();
     if (!line) continue;
     const cancelWord = CANCEL_WORDS.test(line);
@@ -80,16 +93,22 @@ export function parseOrderLines(text) {
  */
 export function extractMemberNo(text) {
   const norm = normalize(text);
-  const m = norm.match(/(?<![0-9A-Za-z])[Mm]?([0-9]{6})(?![0-9])/);
+  const m = norm.match(/(?<![0-9])[Mm]?([0-9]{6})(?![0-9])/);
   if (!m) return { hint: null, rest: norm };
   const rest = (norm.slice(0, m.index) + " " + norm.slice(m.index + m[0].length)).trim();
   return { hint: m[1], rest };
 }
 
-/** 留言 → { memberNo, orders[] }，給 worker 落地用 */
-export function parseNoteComment(text) {
+/**
+ * 留言 → { memberNo, memberNoSource, orders[] }，給 worker 落地用。
+ * 6 碼先從留言內文找；沒有就看留言者的暱稱（很多社群規定暱稱要帶會員編號：
+ * 「涂003886」「Sherry061016/松山」「Ting/616582松山」）。
+ */
+export function parseNoteComment(text, authorName = "") {
   const { hint, rest } = extractMemberNo(text);
-  return { memberNo: hint, orders: parseOrderLines(rest) };
+  if (hint) return { memberNo: hint, memberNoSource: "text", orders: parseOrderLines(rest) };
+  const fromName = extractMemberNo(authorName).hint;
+  return { memberNo: fromName, memberNoSource: fromName ? "name" : null, orders: parseOrderLines(rest) };
 }
 
 /** 貼文標題：取第一個非空白行，最多 60 字 */

--- a/tools/line-note-scraper/src/parse.test.mjs
+++ b/tools/line-note-scraper/src/parse.test.mjs
@@ -17,7 +17,18 @@ test("parseNoteComment", () => {
   assert.deepEqual(r.orders.map((o) => [o.code, o.qty]), [["A", 1], ["B", 2]]);
   const single = parseNoteComment("654321 +3");
   assert.deepEqual(single.orders.map((o) => [o.code, o.qty]), [[null, 3]]);
-  assert.deepEqual(parseNoteComment("請問還有嗎"), { memberNo: null, orders: [] });
+  assert.deepEqual(parseNoteComment("請問還有嗎"), { memberNo: null, memberNoSource: null, orders: [] });
+});
+
+test("member no from commenter name", () => {
+  assert.equal(parseNoteComment("A+1", "涂003886").memberNo, "003886");
+  assert.equal(parseNoteComment("A+1", "Sherry061016/松山").memberNo, "061016");
+  assert.equal(parseNoteComment("A+1", "Ting/616582松山").memberNo, "616582");
+  assert.equal(parseNoteComment("A+1", "Ting/616582松山").memberNoSource, "name");
+  // 內文有 6 碼優先於暱稱
+  assert.equal(parseNoteComment("123456 A+1", "Ting/616582松山").memberNo, "123456");
+  assert.equal(parseNoteComment("A+1", "小明").memberNo, null);
+  assert.equal(parseNoteComment("A+1", "0912345678").memberNo, null);
 });
 
 const one = (text) => parseOrderLines(text).map(({ code, qty, cancel }) => ({ code, qty, cancel }));
@@ -58,6 +69,31 @@ test("multi-line and separators", () => {
     { code: "A", qty: 1, cancel: false },
     { code: "B", qty: 2, cancel: false },
     { code: "C", qty: 3, cancel: false },
+  ]);
+});
+
+test("multiple items on one line", () => {
+  assert.deepEqual(one("A+1 B+5"), [
+    { code: "A", qty: 1, cancel: false },
+    { code: "B", qty: 5, cancel: false },
+  ]);
+  assert.deepEqual(one("A+1, B+5"), [
+    { code: "A", qty: 1, cancel: false },
+    { code: "B", qty: 5, cancel: false },
+  ]);
+  assert.deepEqual(one("a +1  b +2 c+3"), [
+    { code: "A", qty: 1, cancel: false },
+    { code: "B", qty: 2, cancel: false },
+    { code: "C", qty: 3, cancel: false },
+  ]);
+  assert.deepEqual(one("+1 A +2 B"), [
+    { code: "A", qty: 1, cancel: false },
+    { code: "B", qty: 2, cancel: false },
+  ]);
+  assert.deepEqual(one("A/B+1"), [{ code: "B", qty: 1, cancel: false }]); // 「/」當分隔：A 沒數量
+  assert.deepEqual(one("A-1 B+2"), [
+    { code: "A", qty: 1, cancel: true },
+    { code: "B", qty: 2, cancel: false },
   ]);
 });
 

--- a/tools/line-note-scraper/src/worker.mjs
+++ b/tools/line-note-scraper/src/worker.mjs
@@ -171,8 +171,21 @@ async function jobPost(job) {
   const account = await loadAccount(payload.account_id);
   const client = await clientFor(account);
   const text = renderTemplate(payload.post_template, payload);
+  // 開團封面圖（group_buy_campaigns.cover_image_url）一起貼；只收 JPEG（LINE 上傳固定 image/jpeg）
+  const images = [];
+  const cover = payload.campaign?.cover_image_url;
+  if (cover && !process.env.LINE_POST_NO_IMAGE) {
+    try {
+      const r = await fetch(cover);
+      const ct = r.headers.get("content-type") ?? "";
+      if (r.ok && (/image\/jpe?g/i.test(ct) || /\.jpe?g(\?|$)/i.test(cover))) images.push(Buffer.from(await r.arrayBuffer()));
+      else log(`封面不是 JPEG（${ct}），這篇不帶圖：${cover}`);
+    } catch (e) {
+      log("封面下載失敗，這篇不帶圖:", e?.message ?? e);
+    }
+  }
   try {
-    const post = await createNotePost(client, payload.home_id, { text, verbose: VERBOSE });
+    const post = await createNotePost(client, payload.home_id, { text, images, verbose: VERBOSE });
     await patch("line_note_posts", `id=eq.${job.post_id}`, {
       status: "posted", line_post_id: post.postId ?? null, text, posted_at: new Date().toISOString(), last_error: null,
     });

--- a/tools/line-note-scraper/src/worker.mjs
+++ b/tools/line-note-scraper/src/worker.mjs
@@ -163,6 +163,51 @@ export function renderTemplate(template, payload) {
     .trim();
 }
 
+
+// ── 發文附圖：開團封面 + 每個品項的商品圖，全部轉成 JPEG ──────────────────
+// 圖片來源：group_buy_campaigns.cover_image_url、products.images[]（storage 相對路徑或完整網址）。
+// LINE 記事本上傳固定 image/jpeg，所以 PNG/WebP 用 sharp 轉；sharp 沒裝就只收原本就是 JPEG 的。
+const MAX_POST_IMAGES = Number(process.env.LINE_POST_MAX_IMAGES || 10);
+const PRODUCTS_BUCKET = process.env.PRODUCTS_BUCKET || "products";
+
+function resolveImageUrl(p) {
+  if (!p || typeof p !== "string") return null;
+  if (/^https?:\/\//i.test(p)) return p;
+  return `${SUPABASE_URL}/storage/v1/object/public/${PRODUCTS_BUCKET}/${p.replace(/^\/+/, "")}`;
+}
+
+let sharpMod;
+async function toJpeg(buf, contentType) {
+  if (!sharpMod) {
+    try { sharpMod = (await import("sharp")).default; } catch { sharpMod = null; }
+  }
+  if (sharpMod) {
+    return await sharpMod(buf).rotate().jpeg({ quality: 88 }).toBuffer();
+  }
+  if (/image\/jpe?g/i.test(contentType)) return buf;
+  throw new Error(`不是 JPEG（${contentType}）且沒裝 sharp，無法轉檔`);
+}
+
+async function collectPostImages(payload) {
+  if (process.env.LINE_POST_NO_IMAGE) return [];
+  const urls = [];
+  const push = (u) => { const r = resolveImageUrl(u); if (r && !urls.includes(r)) urls.push(r); };
+  push(payload.campaign?.cover_image_url);
+  for (const it of payload.items ?? []) for (const img of it.images ?? []) push(img);
+  const out = [];
+  for (const url of urls.slice(0, MAX_POST_IMAGES)) {
+    try {
+      const r = await fetch(url);
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const ct = r.headers.get("content-type") ?? "";
+      out.push(await toJpeg(Buffer.from(await r.arrayBuffer()), ct));
+    } catch (e) {
+      log(`圖片略過 ${url}：${e?.message ?? e}`);
+    }
+  }
+  return out;
+}
+
 async function jobPost(job) {
   const cur = await rest(`line_note_posts?id=eq.${job.post_id}&select=status,line_post_id`);
   if (cur?.[0]?.status === "posted") return { skipped: "already posted", postId: cur[0].line_post_id };
@@ -171,19 +216,7 @@ async function jobPost(job) {
   const account = await loadAccount(payload.account_id);
   const client = await clientFor(account);
   const text = renderTemplate(payload.post_template, payload);
-  // 開團封面圖（group_buy_campaigns.cover_image_url）一起貼；只收 JPEG（LINE 上傳固定 image/jpeg）
-  const images = [];
-  const cover = payload.campaign?.cover_image_url;
-  if (cover && !process.env.LINE_POST_NO_IMAGE) {
-    try {
-      const r = await fetch(cover);
-      const ct = r.headers.get("content-type") ?? "";
-      if (r.ok && (/image\/jpe?g/i.test(ct) || /\.jpe?g(\?|$)/i.test(cover))) images.push(Buffer.from(await r.arrayBuffer()));
-      else log(`封面不是 JPEG（${ct}），這篇不帶圖：${cover}`);
-    } catch (e) {
-      log("封面下載失敗，這篇不帶圖:", e?.message ?? e);
-    }
-  }
+  const images = await collectPostImages(payload);
   try {
     const post = await createNotePost(client, payload.home_id, { text, images, verbose: VERBOSE });
     await patch("line_note_posts", `id=eq.${job.post_id}`, {

--- a/tools/line-note-scraper/src/worker.mjs
+++ b/tools/line-note-scraper/src/worker.mjs
@@ -18,7 +18,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { loginWithAuthToken, loginWithQR } from "@evex/linejs";
 import { FileStorage } from "@evex/linejs/storage";
-import { createNotePost, listComments, listHomes, whoami } from "./line.mjs";
+import { createNotePost, listComments, listHomes, listPosts, whoami } from "./line.mjs";
 import { parseNoteComment, postTitle } from "./parse.mjs";
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
@@ -164,6 +164,8 @@ export function renderTemplate(template, payload) {
 }
 
 async function jobPost(job) {
+  const cur = await rest(`line_note_posts?id=eq.${job.post_id}&select=status,line_post_id`);
+  if (cur?.[0]?.status === "posted") return { skipped: "already posted", postId: cur[0].line_post_id };
   const payload = await rpc("rpc_line_note_post_payload", { p_post_id: job.post_id });
   if (!payload) throw new Error(`post ${job.post_id} not found`);
   const account = await loadAccount(payload.account_id);
@@ -185,7 +187,7 @@ async function readPost(client, post) {
   const comments = await listComments(client, post.home_id, post.line_post_id, { verbose: VERBOSE });
   if (comments.length) {
     const rows = comments.map((c) => {
-      const parsed = parseNoteComment(c.text);
+      const parsed = parseNoteComment(c.text, c.authorName ?? "");
       return {
         tenant_id: post.tenant_id, post_id: post.id, line_comment_id: String(c.commentId ?? ""),
         commenter_id: c.authorMid ?? null, commenter_name: c.authorName ?? null, text: c.text ?? "",
@@ -213,8 +215,48 @@ async function readPost(client, post) {
   return { comments: comments.length, pending: pending?.length ?? 0, ordered, other };
 }
 
+// 認貼文：小幫手自己手動貼到記事本的團（不是系統發的），最近 read_days 天內的貼文
+// 只要文字裡有「開團中／已收單」的團名或團號，就綁進 line_note_posts，留言一樣會讀。
+async function discoverPosts(client, community) {
+  const since = new Date(Date.now() - community.read_days * 86400_000).toISOString();
+  const notes = await listPosts(client, community.home_id, { limit: 100, since, verbose: VERBOSE });
+  if (notes.length === 0) return 0;
+  const known = await rest(`line_note_posts?community_id=eq.${community.id}&select=id,status,line_post_id,campaign_id`);
+  const knownByLineId = new Map((known ?? []).filter((p) => p.line_post_id).map((p) => [p.line_post_id, p]));
+  const campaigns = await rest(`group_buy_campaigns?tenant_id=eq.${community.tenant_id}&status=in.(open,closed)&select=id,name,campaign_no&order=id.desc&limit=200`);
+  let linked = 0;
+  for (const n of notes) {
+    if (!n.postId || knownByLineId.has(String(n.postId))) continue;
+    const text = String(n.text ?? "");
+    const hit = (campaigns ?? []).find((c) => (c.name && text.includes(c.name)) || (c.campaign_no && text.includes(c.campaign_no)));
+    if (!hit) continue;
+    const existing = (known ?? []).find((p) => p.campaign_id === hit.id);
+    const row = { status: "posted", line_post_id: String(n.postId), text, posted_at: n.createdAt ?? new Date().toISOString(), last_error: null };
+    if (existing) {
+      if (existing.status === "posted") continue;      // 同一團已經有另一篇，不重綁
+      await patch("line_note_posts", `id=eq.${existing.id}`, row);
+    } else {
+      await rest("line_note_posts", { method: "POST", body: { tenant_id: community.tenant_id, community_id: community.id, campaign_id: hit.id, ...row }, prefer: "return=minimal" });
+    }
+    linked++;
+    log(`🔗 認到貼文 ${n.postId} → 團 ${hit.campaign_no} ${hit.name}`);
+  }
+  return linked;
+}
+
 async function jobRead(job) {
-  const filter = job.post_id ? `id=eq.${job.post_id}` : `community_id=eq.${job.community_id}`;
+  let discovered = 0;
+  let sinceFilter = "";
+  if (!job.post_id && job.community_id) {
+    const c = (await rest(`line_note_communities?id=eq.${job.community_id}&select=id,tenant_id,home_id,account_id,read_days`))?.[0];
+    if (c) {
+      const account = await loadAccount(c.account_id);
+      const client = await clientFor(account);
+      try { discovered = await discoverPosts(client, c); } catch (e) { log("認貼文失敗（略過）:", e?.message ?? e); }
+      sinceFilter = `&posted_at=gte.${new Date(Date.now() - c.read_days * 86400_000).toISOString()}`;
+    }
+  }
+  const filter = job.post_id ? `id=eq.${job.post_id}` : `community_id=eq.${job.community_id}${sinceFilter}`;
   const posts = await rest(`line_note_posts?${filter}&status=eq.posted&select=id,tenant_id,line_post_id,community_id,group_buy_campaigns(status),line_note_communities(home_id,account_id)`);
   const out = [];
   for (const p of posts ?? []) {
@@ -236,7 +278,7 @@ async function jobRead(job) {
   if (job.community_id) {
     await patch("line_note_communities", `id=eq.${job.community_id}`, { last_read_at: new Date().toISOString(), last_error: null });
   }
-  return { posts: out };
+  return { discovered, posts: out };
 }
 
 const HANDLERS = { login: jobLogin, logout: jobLogout, list_homes: jobListHomes, post: jobPost, read: jobRead };


### PR DESCRIPTION
接 #920（它被合併時已經帶進第一版整合：後台頁、migration、worker）。這支是後續三個 commit：

- **待小幫手處理清單**：找不到會員／品項對不上／有編號沒數量的留言留在頁面上，可重試、已解決（留備註）、忽略；紀錄不刪（`line_note_comments` 加 `resolved` 狀態與 `resolved_at / resolution_note`）
- **留言解析**：`A+1 B+5` 同行多筆、`+1 A +2 B`；6 碼先看內文再看暱稱（涂003886 / Sherry061016/松山 / Ting/616582松山）
- **讀取範圍 `read_days`**（預設 3）：只讀最近 N 天的貼文，並把小幫手手貼、內文含開團中團名的貼文自動認進來
- **自動發文帶圖**：開團封面 + 各品項商品圖（最多 10 張），PNG/WebP 用 sharp 轉 JPEG
- 修 DataTable `THead` 內多包一層 `Tr`（nested tr）

⚠️ migration `20260908010000_line_note_bridge.sql` 跟 main 上那支同名，內容是這支的完整版（含 `read_days`、`resolved`、`images`）；正式庫套的是這支的版本，合併後 repo 才跟線上一致。

驗證：解析器測試 13/13、`tsc --noEmit` 通過、migration 過語法檢查、後台畫面 Playwright 截圖確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ