### PR TITLE
fix(line-notes): 6 碼從會員姓名比對、取貨店跟著會員、發文不再打 legy

### DIFF
--- a/supabase/migrations/20260908030000_line_note_member_by_name.sql
+++ b/supabase/migrations/20260908030000_line_note_member_by_name.sql
@@ -1,0 +1,267 @@
+-- ============================================================================
+-- 20260908030000_line_note_member_by_name.sql
+--
+-- 記事本留言的「6 碼會員編號」對不到人：那 6 碼根本不在 members.member_no，
+-- 而是在**姓名裡**。線上實際長相（松山社群）：
+--   M034027 / '#17645466 : 【安文】298833-松山'        ← 匯入的（多半已 merged）
+--   M20260801074315659 / '安文298833'                  ← LINE 註冊的（active）
+-- 而 member_no 是 M013340～M044518 的流水號，跟社群暱稱的 6 碼是兩回事
+-- （25,996 位會員裡 25,132 位的 name 帶 6 碼，member_no 命中 0 筆）。
+--
+-- 改法：找人時依序試
+--   1. member_no = 'M'||6碼 或 = 6碼（新制若真的這樣編，維持相容）
+--   2. name 內含該 6 碼（前後不是數字，'1232850' 不會命中 '123285'）
+--      → 只收 active（排除 merged / deleted）；只有 merged 命中就跟著
+--        merged_into_member_id 走（最多 5 跳，比照 rpc_search_members）
+--   3. 命中多位活人 → 不猜，標 unmatched 並把候選人列在錯誤訊息裡給小幫手看
+--
+-- 基底：rpc_line_note_apply_comment @ 20260908020000（去重版，已 grep 全 migrations
+--       確認是最新版）；去重、duplicate 狀態、下游呼叫全部原樣保留。
+-- rollback：還原 20260908020000 的 rpc_line_note_apply_comment；
+--           DROP FUNCTION public._line_note_find_member(UUID, TEXT);
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. 6 碼 → 會員
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._line_note_find_member(p_tenant UUID, p_code TEXT)
+RETURNS TABLE (member_id BIGINT, home_store_id BIGINT, ambiguous TEXT)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+AS $$
+DECLARE
+  v_re      TEXT := '(^|[^0-9])' || p_code || '([^0-9]|$)';
+  v_id      BIGINT;
+  v_home    BIGINT;
+  v_cnt     INT;
+  v_who     TEXT;
+  v_status  TEXT;
+  v_next    BIGINT;
+  v_hops    INT := 0;
+BEGIN
+  -- 1) member_no 直接命中
+  SELECT m.id, m.home_store_id INTO v_id, v_home
+    FROM members m
+   WHERE m.tenant_id = p_tenant
+     AND (m.member_no = 'M' || p_code OR m.member_no = p_code)
+     AND m.status NOT IN ('merged','deleted')
+   ORDER BY m.id LIMIT 1;
+  IF v_id IS NOT NULL THEN
+    RETURN QUERY SELECT v_id, v_home, NULL::TEXT; RETURN;
+  END IF;
+
+  -- 2) 姓名帶這 6 碼的活人
+  SELECT count(*) INTO v_cnt
+    FROM members m
+   WHERE m.tenant_id = p_tenant AND m.name ~ v_re AND m.status NOT IN ('merged','deleted');
+
+  IF v_cnt = 1 THEN
+    SELECT m.id, m.home_store_id INTO v_id, v_home
+      FROM members m
+     WHERE m.tenant_id = p_tenant AND m.name ~ v_re AND m.status NOT IN ('merged','deleted');
+    RETURN QUERY SELECT v_id, v_home, NULL::TEXT; RETURN;
+  END IF;
+
+  IF v_cnt > 1 THEN
+    SELECT string_agg(m.member_no || '（' || COALESCE(m.name, '') || '）', '、' ORDER BY m.id)
+      INTO v_who
+      FROM members m
+     WHERE m.tenant_id = p_tenant AND m.name ~ v_re AND m.status NOT IN ('merged','deleted');
+    RETURN QUERY SELECT NULL::BIGINT, NULL::BIGINT,
+                        ('有 ' || v_cnt || ' 位會員的名字都帶 ' || p_code || '：' || v_who || '，請人工確認')::TEXT;
+    RETURN;
+  END IF;
+
+  -- 3) 只有被合併掉的舊帳號帶這組號碼 → 跟著 merged_into_member_id 走到本尊
+  SELECT m.merged_into_member_id INTO v_id
+    FROM members m
+   WHERE m.tenant_id = p_tenant AND m.name ~ v_re
+   ORDER BY m.id LIMIT 1;
+  WHILE v_id IS NOT NULL AND v_hops < 5 LOOP
+    v_hops := v_hops + 1;
+    SELECT m.home_store_id, m.status, m.merged_into_member_id
+      INTO v_home, v_status, v_next
+      FROM members m WHERE m.id = v_id AND m.tenant_id = p_tenant;
+    IF v_status IS NULL THEN EXIT; END IF;                       -- 指到別的 tenant / 不存在
+    IF v_status NOT IN ('merged','deleted') THEN
+      RETURN QUERY SELECT v_id, v_home, NULL::TEXT; RETURN;
+    END IF;
+    v_id := v_next;
+  END LOOP;
+
+  RETURN QUERY SELECT NULL::BIGINT, NULL::BIGINT, NULL::TEXT;
+END;
+$$;
+
+-- ----------------------------------------------------------------------------
+-- 2. 留言 → 訂單（只換掉找人那一段，其餘同 20260908020000）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_apply_comment(p_comment_id BIGINT)
+RETURNS TABLE (out_status TEXT, out_order_id BIGINT, out_error TEXT)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_c            line_note_comments%ROWTYPE;
+  v_tenant       UUID;
+  v_campaign_id  BIGINT;
+  v_channel_id   BIGINT;
+  v_store_id     BIGINT;
+  v_member_id    BIGINT;
+  v_member_home  BIGINT;
+  v_ambiguous    TEXT;
+  v_hint         TEXT;
+  v_items        JSONB := '[]'::jsonb;
+  v_new_items    JSONB := '[]'::jsonb;
+  v_dup_codes    TEXT[] := ARRAY[]::TEXT[];
+  v_dup_order    BIGINT;
+  v_p            JSONB;
+  v_code         TEXT;
+  v_qty          NUMERIC;
+  v_ci           BIGINT;
+  v_item_count   INT;
+  v_order_id     BIGINT;
+  v_err          TEXT;
+  v_claim_tenant TEXT := auth.jwt() ->> 'tenant_id';
+BEGIN
+  SELECT * INTO v_c FROM line_note_comments WHERE id = p_comment_id;
+  IF v_c.id IS NULL THEN RAISE EXCEPTION 'comment % not found', p_comment_id; END IF;
+  v_tenant := v_c.tenant_id;
+
+  -- 呼叫者是後台使用者 → tenant 要對得上；是 service_role → 補 claims 給下游 RPC 用
+  IF v_claim_tenant IS NOT NULL AND v_claim_tenant <> '' THEN
+    IF v_claim_tenant::uuid <> v_tenant THEN RAISE EXCEPTION 'comment % not in tenant', p_comment_id; END IF;
+  ELSE
+    PERFORM set_config('request.jwt.claims',
+      jsonb_build_object('tenant_id', v_tenant,
+                         'app_metadata', jsonb_build_object('tenant_id', v_tenant, 'role', 'admin'))::text,
+      TRUE);
+  END IF;
+
+  IF v_c.status IN ('ordered','ignored','resolved','duplicate') THEN
+    RETURN QUERY SELECT v_c.status, v_c.customer_order_id, v_c.error; RETURN;
+  END IF;
+
+  SELECT p.campaign_id, c.channel_id, lc.home_store_id
+    INTO v_campaign_id, v_channel_id, v_store_id
+    FROM line_note_posts p
+    JOIN line_note_communities c ON c.id = p.community_id
+    JOIN line_channels lc ON lc.id = c.channel_id
+   WHERE p.id = v_c.post_id;
+
+  -- 沒有任何數量 → 不是下單留言
+  IF jsonb_array_length(COALESCE(v_c.parsed, '[]'::jsonb)) = 0 THEN
+    UPDATE line_note_comments SET status = 'no_order', processed_at = NOW() WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'no_order'::TEXT, NULL::BIGINT, NULL::TEXT; RETURN;
+  END IF;
+
+  -- 會員：6 碼 → member_no 或姓名裡的號碼
+  v_hint := NULLIF(TRIM(COALESCE(v_c.member_no_hint, '')), '');
+  IF v_hint IS NULL THEN
+    UPDATE line_note_comments SET status = 'unmatched', error = '留言裡沒有 6 碼會員編號', processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'unmatched'::TEXT, NULL::BIGINT, '留言裡沒有 6 碼會員編號'::TEXT; RETURN;
+  END IF;
+
+  SELECT f.member_id, f.home_store_id, f.ambiguous
+    INTO v_member_id, v_member_home, v_ambiguous
+    FROM public._line_note_find_member(v_tenant, v_hint) f;
+
+  IF v_member_id IS NULL THEN
+    v_err := COALESCE(v_ambiguous, '找不到會員編號 ' || v_hint);
+    UPDATE line_note_comments SET status = 'unmatched', error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'unmatched'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+
+  -- 品項：code → campaign_item；沒 code 且團只有一項 → 那一項
+  SELECT count(*) INTO v_item_count FROM public._line_note_item_codes(v_campaign_id);
+  FOR v_p IN SELECT * FROM jsonb_array_elements(v_c.parsed) LOOP
+    IF COALESCE((v_p ->> 'cancel')::boolean, FALSE) THEN CONTINUE; END IF;  -- 取消留言不自動處理，留給人看
+    v_qty  := (v_p ->> 'qty')::numeric;
+    v_code := UPPER(NULLIF(TRIM(COALESCE(v_p ->> 'code', '')), ''));
+    IF v_qty IS NULL OR v_qty <= 0 THEN CONTINUE; END IF;
+    IF v_code IS NULL THEN
+      IF v_item_count = 1 THEN
+        SELECT ic.campaign_item_id, ic.code INTO v_ci, v_code FROM public._line_note_item_codes(v_campaign_id) ic;
+      ELSE
+        v_err := '沒寫品項代碼（這團有 ' || v_item_count || ' 項）';
+        EXIT;
+      END IF;
+    ELSE
+      SELECT ic.campaign_item_id INTO v_ci FROM public._line_note_item_codes(v_campaign_id) ic WHERE ic.code = v_code;
+      IF v_ci IS NULL THEN v_err := '品項代碼 ' || v_code || ' 不在這團裡'; EXIT; END IF;
+    END IF;
+    v_items := v_items || jsonb_build_object('campaign_item_id', v_ci, 'qty', v_qty, 'code', v_code);
+  END LOOP;
+
+  IF v_err IS NOT NULL THEN
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+  IF jsonb_array_length(v_items) = 0 THEN
+    UPDATE line_note_comments SET status = 'no_order', member_id = v_member_id, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'no_order'::TEXT, NULL::BIGINT, NULL::TEXT; RETURN;
+  END IF;
+
+  -- 去重：這位會員在這團已經有同一品項的有效訂單（任何來源）→ 那一項不再加
+  FOR v_p IN SELECT * FROM jsonb_array_elements(v_items) LOOP
+    SELECT co.id INTO v_order_id
+      FROM customer_order_items coi
+      JOIN customer_orders co ON co.id = coi.order_id
+     WHERE co.tenant_id = v_tenant
+       AND co.campaign_id = v_campaign_id
+       AND co.member_id = v_member_id
+       AND co.status NOT IN ('cancelled','expired','transferred_out')
+       AND coi.campaign_item_id = (v_p ->> 'campaign_item_id')::bigint
+       AND coi.status <> 'cancelled'
+     ORDER BY co.id LIMIT 1;
+    IF v_order_id IS NOT NULL THEN
+      v_dup_codes := v_dup_codes || COALESCE(v_p ->> 'code', '?');
+      v_dup_order := COALESCE(v_dup_order, v_order_id);
+      v_order_id  := NULL;
+    ELSE
+      v_new_items := v_new_items || jsonb_build_object('campaign_item_id', (v_p ->> 'campaign_item_id')::bigint, 'qty', (v_p ->> 'qty')::numeric);
+    END IF;
+  END LOOP;
+
+  IF jsonb_array_length(v_new_items) = 0 THEN
+    v_err := '已有訂單（' || array_to_string(v_dup_codes, '、') || '），未重複加單';
+    UPDATE line_note_comments
+       SET status = 'duplicate', member_id = v_member_id, customer_order_id = v_dup_order,
+           error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'duplicate'::TEXT, v_dup_order, v_err; RETURN;
+  END IF;
+
+  BEGIN
+    SELECT r.out_order_id INTO v_order_id
+      FROM public.rpc_create_customer_orders(
+             v_campaign_id, v_channel_id,
+             jsonb_build_array(jsonb_build_object(
+               'member_id', v_member_id,
+               'nickname', v_c.commenter_name,
+               'pickup_store_id', COALESCE(v_store_id, v_member_home),
+               'items', v_new_items))) r
+     LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    v_err := SQLERRM;
+  END;
+
+  IF v_err IS NOT NULL THEN
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+
+  UPDATE line_note_comments
+     SET status = 'ordered', member_id = v_member_id, customer_order_id = v_order_id,
+         error = NULL, processed_at = NOW(),
+         resolution_note = CASE WHEN array_length(v_dup_codes, 1) > 0
+                                THEN '已略過重複：' || array_to_string(v_dup_codes, '、')
+                                ELSE resolution_note END
+   WHERE id = p_comment_id;
+  RETURN QUERY SELECT 'ordered'::TEXT, v_order_id, NULL::TEXT;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_apply_comment(BIGINT) TO authenticated;

--- a/tools/line-note-scraper/src/line.mjs
+++ b/tools/line-note-scraper/src/line.mjs
@@ -170,20 +170,29 @@ function baseHeaders(client, token) {
 const routeCache = new Map();
 
 /**
- * 對記事本 REST 打一次 GET。回 { code, message, result }。
- * 會依序試 host × prefix × channel，直到有一組回 code 0。
+ * 對記事本 REST 打一次請求。回 { code, message, result }。
+ * 會依序試 host × prefix × channel，直到有一組回 code 0，然後記住那組。
+ *
+ * ⚠ 不要改用 linejs 內建的 timeline.createPost/listPost —— 它把網址寫死成
+ * `https://${client.request.endpoint}/…`，而 endpoint 預設是 legy.line-apps.com
+ * （LEGY 加密閘道，不吃這種純 HTTPS JSON），直接丟 `fetch failed`。
  */
-export async function noteGet(client, homeId, path, params, verbose = false) {
-  const qs = new URLSearchParams(Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined && v !== null && v !== "")));
+export async function noteRequest(client, homeId, path, params, { method = "GET", body, verbose = false } = {}) {
+  const qs = new URLSearchParams(Object.fromEntries(Object.entries(params ?? {}).filter(([, v]) => v !== undefined && v !== null && v !== "")));
   const tryOne = async (host, prefix, channelId) => {
     const token = await channelToken(client, channelId, verbose);
     const url = `https://${host}${prefix}${path}?${qs}`;
-    const res = await client.base.fetch(url, { method: "GET", headers: baseHeaders(client, token) });
+    const res = await client.base.fetch(url, {
+      method,
+      headers: { ...baseHeaders(client, token), "x-lhm": method },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
     const text = await res.text();
-    let body;
-    try { body = JSON.parse(text); } catch { body = { code: res.status, message: text.slice(0, 200), result: null }; }
-    log(verbose, `${res.status} ${url} ch=${channelId} → code=${body?.code} ${body?.message ?? ""}`);
-    return { httpStatus: res.status, body };
+    // ⚠ 不要叫 body —— 外層參數就叫 body，同一個 scope 會 TDZ 炸掉
+    let json;
+    try { json = JSON.parse(text); } catch { json = { code: res.status, message: text.slice(0, 200), result: null }; }
+    log(verbose, `${res.status} ${url} ch=${channelId} → code=${json?.code} ${json?.message ?? ""}`);
+    return { httpStatus: res.status, body: json };
   };
 
   const cached = routeCache.get(homeId);
@@ -210,6 +219,11 @@ export async function noteGet(client, homeId, path, params, verbose = false) {
     }
   }
   throw new Error(`記事本 API 全部打不通（homeId=${homeId}）。把下面這段貼回來：\n` + attempts.join("\n"));
+}
+
+/** GET 版（大部分呼叫點用這支） */
+export async function noteGet(client, homeId, path, params, verbose = false) {
+  return await noteRequest(client, homeId, path, params, { method: "GET", verbose });
 }
 
 // ── 回應解析（結構沒 wire trace，寫成寬鬆版；raw 一律保留） ──────────────
@@ -336,23 +350,45 @@ export async function listComments(client, homeId, postId, { verbose = false, on
  */
 export async function createNotePost(client, homeId, { text, images = [], sourceType, verbose = false } = {}) {
   if (!text && images.length === 0) throw new Error("貼文至少要有文字或圖片");
-  const tl = client.base.timeline;
-  const mediaObjectIds = [];
-  const mediaObjectTypes = [];
+
+  // 圖片上傳走 obs.line-apps.com（linejs 的 uploadNoteMedia），失敗就只發文字，
+  // 不要讓整篇貼文因為一張圖掛掉。
+  const media = [];
   for (const file of images) {
-    const buf = Buffer.isBuffer(file) ? file : fs.readFileSync(file);
-    const { objId } = await tl.uploadNoteMedia("image", new Blob([buf], { type: "image/jpeg" }));
-    log(verbose, `uploaded ${file} → ${objId}`);
-    mediaObjectIds.push(objId);
-    mediaObjectTypes.push("PHOTO");
+    try {
+      const buf = Buffer.isBuffer(file) ? file : fs.readFileSync(file);
+      const { objId } = await client.base.timeline.uploadNoteMedia("image", new Blob([buf], { type: "image/jpeg" }));
+      media.push({ objectId: objId, type: "PHOTO", obsFace: "[]" });
+      log(verbose, `uploaded ${Buffer.isBuffer(file) ? "<buffer>" : file} → ${objId}`);
+    } catch (e) {
+      log(true, `圖片上傳失敗，這張跳過：${e?.message ?? e}`);
+    }
   }
-  const res = await tl.createPost({
-    homeId,
-    text,
-    mediaObjectIds,
-    mediaObjectTypes,
-    ...(sourceType ? { sourceType } : {}),
-  });
+
+  // 先打一次 list 把路由（host/prefix/channel）探出來並記住，create 才不會在探路
+  // 的過程中對不同前綴各發一篇（重複貼文）。
+  try {
+    await noteGet(client, homeId, "/api/v57/post/list.json",
+      { homeId, sourceType: sourceType ?? "TALKROOM", likeLimit: "0", commentLimit: "0" }, verbose);
+  } catch (e) {
+    log(verbose, "探路用的 list 失敗（照樣試發文）:", e?.message ?? e);
+  }
+
+  const body = {
+    postInfo: { readPermission: { type: "ALL", gids: [] } },
+    contents: {
+      contentsStyle: {
+        textStyle: { textSizeMode: "AUTO", backgroundColor: "", textAnimation: "NONE" },
+        mediaStyle: { displayType: "GRID_1_A" },
+      },
+      stickers: [],
+      locations: [],
+      media,
+      ...(text ? { text } : {}),
+    },
+  };
+  const res = await noteRequest(client, homeId, "/api/v57/post/create.json",
+    { homeId, sourceType: sourceType ?? "TALKROOM" }, { method: "POST", body, verbose });
   log(verbose, "createPost →", JSON.stringify(res).slice(0, 500));
   if (!res || res.code !== 0) {
     throw new Error(`發文失敗：code=${res?.code} ${res?.message ?? ""}\n${JSON.stringify(res).slice(0, 800)}`);


### PR DESCRIPTION
實際跑起來抓到的三個問題。**三支 migration 都已套上正式庫**，合併後 repo 才跟線上一致。

## 1. 每一則都「找不到會員」（`20260908030000`）

那 6 碼**不在 `member_no`**，在**姓名裡**：`#17645466 : 【安文】298833-松山`／`安文298833`。
`member_no` 是 `M013340`～`M044518` 流水號，用 6 碼比對全站命中 0 筆；反過來 25,996 位裡 25,132 位的 `name` 帶 6 碼。

新增 `_line_note_find_member`：`member_no` → 姓名（前後不是數字）只收 active → 只有 merged 就跟 `merged_into_member_id` 走到本尊 → 多位活人同號**不猜**，把候選人列給小幫手。災情那 6 組實測全部對到人。

## 2. 加出來的單掛錯店（`20260909000000`）

松山社群綁的渠道是「主社群（測試）」（home_store = 平鎮店），於是松山／中和／泰山會員的單全掛平鎮店（9 張，已取消）。取貨店改成 **`members.home_store_id` 優先**，沒有才退回渠道店。channel 不動（線上訂單的 channel 本來就不代表店）。

## 3. 發文 `fetch failed`

linejs 的 `timeline.createPost` 把網址寫死成 `legy.line-apps.com`（LEGY 加密閘道，不吃純 HTTPS JSON）。改走跟讀留言同一套 host × prefix × channel 探測，create 前先打一次 list 探路，避免探路時重複貼文；圖片上傳失敗只跳過那張。

驗證：三支 migration 過 pg-query 語法檢查（含 plpgsql body）；解析器測試 13/13。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ