### PR TITLE
Fix HQ return disposition stock handling

### DIFF
--- a/apps/admin/src/app/(protected)/finance/receivables/print/page.tsx
+++ b/apps/admin/src/app/(protected)/finance/receivables/print/page.tsx
@@ -23,8 +23,8 @@ type SettlementItem = {
   transfer_id: number;
   sku_id: number;
   qty_received: number;
-  unit_cost: number;
-  line_amount: number;
+  unit_cost: number | null;
+  line_amount: number | null;
   unit_branch_price: number;
   branch_amount: number;
   received_at: string;
@@ -52,6 +52,18 @@ const ENTRY_TYPE_LABEL: Record<SettlementItem["entry_type"], string> = {
   free_out: "自由轉出",
   return_out: "退貨沖回",
 };
+
+function fmtCost(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "未提供成本";
+  const n = Number(v);
+  return Number.isFinite(n) ? `$${n.toFixed(2)}` : "未提供成本";
+}
+
+function fmtAmount(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "未提供成本";
+  const n = Number(v);
+  return Number.isFinite(n) ? `$${n.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}` : "未提供成本";
+}
 
 // 分店版（預設）：給店家的對帳單，只列分店價，不露總倉成本。
 // 內部版：加列成本單價/成本小計與口徑差額（總部毛利），總部對帳用。
@@ -168,7 +180,7 @@ export default function PrintSettlementPage() {
   }
 
   const monthLabel = settlement.settlement_month?.slice(0, 7);
-  const totalCost = items.reduce((s, it) => s + Number(it.line_amount), 0);
+  const totalCost = items.reduce((s, it) => s + Number(it.line_amount ?? 0), 0);
   const totalBranch = items.reduce((s, it) => s + Number(it.branch_amount ?? 0), 0);
   const adjTotal = adjustments.reduce((s, a) => s + Number(a.amount), 0);
   const today = new Date().toLocaleDateString("zh-TW");
@@ -315,10 +327,10 @@ export default function PrintSettlementPage() {
                     {internal && (
                       <>
                         <td className="border border-zinc-400 px-2 py-1 text-right font-mono whitespace-nowrap">
-                          {isFree ? "—" : `$${Number(it.unit_cost).toFixed(2)}`}
+                          {isFree ? "—" : fmtCost(it.unit_cost)}
                         </td>
                         <td className={`border border-zinc-400 px-2 py-1 text-right font-mono whitespace-nowrap ${Number(it.line_amount) < 0 ? "text-amber-600" : ""}`}>
-                          ${Number(it.line_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                          {fmtAmount(it.line_amount)}
                         </td>
                       </>
                     )}

--- a/apps/admin/src/app/(protected)/inventory/page.tsx
+++ b/apps/admin/src/app/(protected)/inventory/page.tsx
@@ -117,7 +117,7 @@ export default function InventoryOverviewPage() {
   const showCost = canSeeCost(role);
   // 分店價只給 canSeeBranch 的角色看（store_staff 只看零售價）
   const showBranchPrice = canSeeBranch(role);
-  // 商品/倉別/在庫/待客取/內部單/可分配/在途/(均成本)/最後異動/展開箭頭
+  // 商品/倉別/帳面庫存/待客取/內部單/可分配/在途/(均成本)/最後異動/展開箭頭
   const colCount = showCost ? 10 : 9;
 
   const [locs, setLocs] = useState<Loc[]>([]);
@@ -428,6 +428,10 @@ export default function InventoryOverviewPage() {
     for (const s of stores) if (s.location_id != null) m.set(s.location_id, s.name);
     return m;
   }, [stores]);
+  const locTypeById = useMemo(
+    () => new Map(locs.map((l) => [l.id, l.type])),
+    [locs],
+  );
   // 現貨直配要的是 store_id（承諾量/訂單都掛在店上，不是倉別上）；
   // 總倉這類沒有對應分店的倉別查不到 → 不出「配給客人」按鈕。
   const storeObjByLoc = useMemo(() => {
@@ -614,13 +618,9 @@ export default function InventoryOverviewPage() {
         <THead>
           <Th>商品 / SKU</Th>
           <Th>倉別</Th>
-          <Th align="right">在庫</Th>
-          {/* 「保留 / 可用」拿掉了：stock_balances.reserved 全站沒在維護
-              （2026-08-16 實測 7,712 筆有庫存的列，reserved<>0 的是 0 筆）
-              → 可用 恆等於 在庫，是一欄假數字，而且會跟「可分配」互相打臉
-              （截圖回報：列表寫可用 3、配單視窗寫自由量 0）。
-              換成真的有意義的三欄。reserved 若哪天真的開始用，會以標記
-              形式掛在「在庫」旁邊（見下方 rows 渲染）。 */}
+          <Th align="right" title="帳面數量；總倉列會另外列出凍結與目前可派量，不代表樓下已完成實物檢查">
+            帳面庫存
+          </Th>
           <Th align="right">待客取</Th>
           <Th align="right">內部單</Th>
           {/* 可分配含「已到店的內部現貨池」：那些貨在架上、配得掉，配的當下
@@ -646,6 +646,8 @@ export default function InventoryOverviewPage() {
               const rule = reorderMap.get(key);
               const commit = commitMap.get(key) ?? null;
               const returningQty = returningMap.get(key) ?? 0;
+              const isHq = locTypeById.get(r.location_id) === "central_warehouse";
+              const hqAvailable = Math.max(r.on_hand - r.reserved, 0);
               const isLow = rule != null && r.on_hand <= num(rule.reorder_point);
               const open = expanded === key;
               const out: React.ReactNode[] = [
@@ -678,16 +680,27 @@ export default function InventoryOverviewPage() {
                   </Td>
                   <Td className="text-xs">{locLabel(r.location_id)}</Td>
                   <Td align="right" className="font-mono">
-                    {fmtQty(r.on_hand)}
-                    {/* reserved 目前全站恆為 0，所以不給一整欄；真的開始用的話
-                        這個標記會自己冒出來，不會靜靜地被吃掉 */}
-                    {r.reserved !== 0 && (
-                      <span
-                        className="ml-1 text-[10px] text-zinc-400"
-                        title={`其中 ${fmtQty(r.reserved)} 件被 stock_balances.reserved 鎖住`}
+                    {isHq ? (
+                      <div
+                        className="flex flex-col items-end gap-0.5 text-[11px] leading-tight"
+                        title="凍結包含各種尚未可派的貨；可派＝帳上扣掉凍結，下限為 0。這些都是帳面數量，不代表實物已驗完。"
                       >
-                        (保留 {fmtQty(r.reserved)})
-                      </span>
+                        <span>帳上 <strong className="text-zinc-800 dark:text-zinc-200">{fmtQty(r.on_hand)}</strong></span>
+                        <span className="text-amber-700 dark:text-amber-400">凍結 {fmtQty(r.reserved)}</span>
+                        <span className="font-semibold text-emerald-700 dark:text-emerald-400">可派 {fmtQty(hqAvailable)}</span>
+                      </div>
+                    ) : (
+                      <>
+                        {fmtQty(r.on_hand)}
+                        {r.reserved !== 0 && (
+                          <span
+                            className="ml-1 text-[10px] text-zinc-400"
+                            title={`其中 ${fmtQty(r.reserved)} 件目前凍結，不算在可使用數量內`}
+                          >
+                            (凍結 {fmtQty(r.reserved)})
+                          </span>
+                        )}
+                      </>
                     )}
                     {/* 退貨中（2026-09-04 老闆裁示 2 乙案）：
                         「先不扣 → 帳上還是 10，旁邊標『退貨中 3』讓人看得到」。

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -68,6 +68,9 @@ const NAV: NavGroup[] = [
     title: "倉儲 (WMS)",
     items: [
       { href: "/hq/inbox", label: "總倉收件匣", match: /^\/hq\/inbox/ },
+      // 總倉退回貨待處理（2026-09-07）：店退/短少回到總倉的批次在這裡分配好/破/失。
+      // ⚠ 僅 HQ 角色（owner/admin/hq_manager），分店不看 → 要加進 BRANCH_HIDDEN_HREFS。
+      { href: "/wms/return-disposition", label: "退回貨處理", match: /^\/wms\/return-disposition/ },
       { href: "/wms/receiving", label: "進貨待辦", match: /^\/wms\/receiving/ },
       // 選單順序＝工作流程順序：先在草稿上挑好給樓下撿，撿完確定了才到工作台建正式單。
       // ⚠ 路徑刻意不放在 /wms/picking 底下 —— 派貨工作台的 match 是 ^\/wms\/picking(?!\/history)，
@@ -128,6 +131,7 @@ const NAV_COLLAPSE_KEY = "new_erp-nav-collapsed";
 // 分店帳號 (app_metadata.stores 有值且不含「總倉」) 隱藏的項目
 const BRANCH_HIDDEN_HREFS = new Set([
   "/hq/inbox",            // 總倉收件匣
+  "/wms/return-disposition", // 退回貨處理 (HQ)
   "/products",            // 商品主檔 (HQ 管理)
   "/suppliers",           // 供應商 (HQ 管理)
   "/purchase/requests",   // 請購單 (PR)

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -69,7 +69,7 @@ const NAV: NavGroup[] = [
     items: [
       { href: "/hq/inbox", label: "總倉收件匣", match: /^\/hq\/inbox/ },
       // 總倉退回貨待處理（2026-09-07）：店退/短少回到總倉的批次在這裡分配好/破/失。
-      // ⚠ 僅 HQ 角色（owner/admin/hq_manager），分店不看 → 要加進 BRANCH_HIDDEN_HREFS。
+      // ⚠ 僅 owner/admin/hq_manager；由 filterNavForRole 精確過濾，不靠門市欄位猜權限。
       { href: "/wms/return-disposition", label: "退回貨處理", match: /^\/wms\/return-disposition/ },
       { href: "/wms/receiving", label: "進貨待辦", match: /^\/wms\/receiving/ },
       // 選單順序＝工作流程順序：先在草稿上挑好給樓下撿，撿完確定了才到工作台建正式單。
@@ -121,9 +121,21 @@ function canManageStaff(user: { app_metadata?: Record<string, unknown> } | null 
   return r === "owner" || r === "admin";
 }
 
+function canDisposeHqReturn(user: { app_metadata?: Record<string, unknown> } | null | undefined): boolean {
+  const role = user?.app_metadata?.role;
+  return role === "owner" || role === "admin" || role === "hq_manager";
+}
+
 function filterNavForRole(nav: NavGroup[], user: { app_metadata?: Record<string, unknown> } | null | undefined): NavGroup[] {
-  if (canManageStaff(user)) return nav;
-  return nav.filter((g) => !g.title || !ADMIN_ONLY_GROUPS.has(g.title));
+  return nav
+    .filter((group) => canManageStaff(user) || !group.title || !ADMIN_ONLY_GROUPS.has(group.title))
+    .map((group) => ({
+      ...group,
+      items: group.items.filter(
+        (item) => item.href !== "/wms/return-disposition" || canDisposeHqReturn(user),
+      ),
+    }))
+    .filter((group) => group.items.length > 0);
 }
 
 const NAV_COLLAPSE_KEY = "new_erp-nav-collapsed";
@@ -131,7 +143,6 @@ const NAV_COLLAPSE_KEY = "new_erp-nav-collapsed";
 // 分店帳號 (app_metadata.stores 有值且不含「總倉」) 隱藏的項目
 const BRANCH_HIDDEN_HREFS = new Set([
   "/hq/inbox",            // 總倉收件匣
-  "/wms/return-disposition", // 退回貨處理 (HQ)
   "/products",            // 商品主檔 (HQ 管理)
   "/suppliers",           // 供應商 (HQ 管理)
   "/purchase/requests",   // 請購單 (PR)

--- a/apps/admin/src/app/(protected)/transfers/settlement/detail/page.tsx
+++ b/apps/admin/src/app/(protected)/transfers/settlement/detail/page.tsx
@@ -40,8 +40,8 @@ type Item = {
   transfer_item_id: number;
   sku_id: number;
   qty_received: number;
-  unit_cost: number;
-  line_amount: number;
+  unit_cost: number | null;
+  line_amount: number | null;
   unit_branch_price: number;
   branch_amount: number;
   received_at: string;
@@ -103,6 +103,18 @@ const ENTRY_TYPE_COLOR: Record<Item["entry_type"], string> = {
   free_out: "bg-violet-100 text-violet-800 dark:bg-violet-950 dark:text-violet-300",
   return_out: "bg-rose-100 text-rose-800 dark:bg-rose-950 dark:text-rose-300",
 };
+
+function fmtCost(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "未提供成本";
+  const n = Number(v);
+  return Number.isFinite(n) ? `$${n.toFixed(2)}` : "未提供成本";
+}
+
+function fmtAmount(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "未提供成本";
+  const n = Number(v);
+  return Number.isFinite(n) ? `$${n.toLocaleString("zh-TW", { maximumFractionDigits: 0 })}` : "未提供成本";
+}
 
 const STATUS_LABEL: Record<SettlementStatus, string> = {
   draft: "草稿",
@@ -788,10 +800,10 @@ export default function HqSettlementDetailPage() {
                     </Td>
                     <Td className="text-right font-mono">{Number(it.qty_received).toLocaleString()}</Td>
                     <Td className="whitespace-nowrap text-right font-mono text-zinc-500">
-                      {isFree ? "—" : `$${Number(it.unit_cost).toFixed(2)}`}
+                      {isFree ? "—" : fmtCost(it.unit_cost)}
                     </Td>
                     <Td className={`whitespace-nowrap text-right font-mono ${isNeg ? "text-amber-600" : ""}`}>
-                      ${Number(it.line_amount).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                      {fmtAmount(it.line_amount)}
                     </Td>
                     <Td className="whitespace-nowrap text-right font-mono text-zinc-500">
                       {isFree ? "—" : `$${Number(it.unit_branch_price ?? 0).toFixed(2)}`}
@@ -805,7 +817,7 @@ export default function HqSettlementDetailPage() {
                           <SpinButton
                             onClick={() => {
                               setEditItem(it);
-                              setEditAmount(String(Math.abs(Number(it.line_amount))));
+                              setEditAmount(String(Math.abs(Number(it.line_amount ?? 0))));
                               setEditReason("");
                               setErr(null);
                             }}
@@ -825,7 +837,7 @@ export default function HqSettlementDetailPage() {
                 <tr>
                   <td colSpan={6} className="px-3 py-2 text-right text-xs text-zinc-500">合計</td>
                   <td className="px-3 py-2 text-right font-mono font-medium text-zinc-500">
-                    ${items.reduce((sum, it) => sum + Number(it.line_amount), 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
+                    ${items.reduce((sum, it) => sum + Number(it.line_amount ?? 0), 0).toLocaleString("zh-TW", { maximumFractionDigits: 0 })}
                   </td>
                   <td></td>
                   <td className="px-3 py-2 text-right font-mono font-medium text-sky-700 dark:text-sky-400">

--- a/apps/admin/src/app/(protected)/wms/picking/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/picking/page.tsx
@@ -85,7 +85,7 @@ type RestockRow = {
   sku_code: string | null;
   sku_label: string;
   demand_qty: number;
-  gr_qty: number;        // HQ on_hand
+  gr_qty: number;        // HQ 可派（on_hand - reserved，下限 0）
   wave_qty: number;      // 已撿
 };
 
@@ -1277,7 +1277,7 @@ function Body() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fullDemand, poItemCampaigns, skuSoldCampaigns, effFilterCampaign, skuQueryNorm, filterTime, timeCutoff, campaignsById]);
 
-  // 補貨申請預設分配 = min(申請量 - 已撿, HQ 庫存) per (rr, sku)
+  // 補貨申請預設分配 = min(申請量 - 已撿, HQ 可派) per (rr, sku)
   useEffect(() => {
     if (!restockDemand) return;
     setRestockAllocs((prev) => {
@@ -2005,7 +2005,7 @@ function Body() {
                       <tr>
                         <Th>品項</Th>
                         <Th className="text-center">申請量</Th>
-                        <Th className="text-center" title="HQ 即時庫存 (on_hand)">HQ 庫存</Th>
+                        <Th className="text-center" title="總倉帳上扣除凍結後，目前能派的數量">HQ 可派</Th>
                         <Th className="text-center">已撿</Th>
                         <Th className="text-center">本次撿</Th>
                       </tr>
@@ -2056,7 +2056,7 @@ function Body() {
                                   )
                                 }
                                 onFocus={(e) => e.currentTarget.select()}
-                                title={`最多可撿 ${maxForLine}(申請 ${ln.demand_qty}、庫存 ${ln.gr_qty}、已撿 ${ln.wave_qty})`}
+                                title={`最多可撿 ${maxForLine}（申請 ${ln.demand_qty}、可派 ${ln.gr_qty}、已撿 ${ln.wave_qty}）`}
                                 className={`h-10 w-full max-w-[96px] rounded-md border px-1 text-center font-mono text-base font-semibold tabular-nums dark:bg-zinc-800 ${
                                   value === 0
                                     ? "border-zinc-200 text-zinc-300 dark:border-zinc-700"

--- a/apps/admin/src/app/(protected)/wms/return-disposition/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/return-disposition/page.tsx
@@ -11,10 +11,11 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAuth } from "@/components/AuthProvider";
 import { getSupabase } from "@/lib/supabase";
 import { fetchAllRows } from "@/lib/fetchAllRows";
 import { translateRpcError } from "@/lib/rpcError";
-import { useRole, isHqRole, canSeeCost } from "@/lib/role";
+import { useRole, canSeeCost, type Role } from "@/lib/role";
 import { LoadingBlock } from "@/components/Spinner";
 import SpinButton from "@/components/SpinButton";
 
@@ -67,11 +68,43 @@ type SkuRow = {
   variant_name: string | null;
 };
 
+type SourceInfo = {
+  transferNo: string;
+  sourceName: string | null;
+  destName: string | null;
+};
+
+type DisposePayload = {
+  p_batch_id: number;
+  p_request_id: string;
+  p_qty_good: number;
+  p_qty_damaged: number;
+  p_qty_lost: number;
+  p_damage_reason: string | null;
+  p_loss_reason: string | null;
+  p_goods_confirmed: boolean;
+  p_notes: string | null;
+};
+
+type PendingRequest = {
+  schemaVersion: 1;
+  tenantId: string;
+  operatorId: string;
+  batchId: number;
+  requestId: string;
+  createdAt: string;
+  payload: DisposePayload;
+};
+
 // ── helper ──
 
 function num(v: unknown): number {
   const n = Number(v);
   return Number.isFinite(n) ? n : 0;
+}
+
+function canDisposeReturn(role: Role | null): boolean {
+  return role === "owner" || role === "admin" || role === "hq_manager";
 }
 
 function fmtDate(v: string | null): string {
@@ -114,68 +147,198 @@ const STATUS_ZH: Record<string, { label: string; cls: string }> = {
   },
 };
 
-/** Safari-safe UUID（比照 wms/receiving/ipad/page.tsx:247-250） */
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** Safari-safe RFC 4122 v4 UUID。 */
 function newRequestId(): string {
-  return typeof crypto !== "undefined" && "randomUUID" in crypto
-    ? crypto.randomUUID()
-    : `r_${Date.now()}_${Math.random().toString(36).slice(2)}`;
-}
-
-/** 小數最多 3 位（不截整），用來把 input 值夾到合法範圍 */
-function clampDecimal(v: string, max: number): string {
-  // 保留使用者輸入的小數位，但不能超過 3 位
-  const m = v.match(/^(\d+)(?:\.(\d{0,3}))?/);
-  if (!m) return "";
-  const clamped = Math.min(Number(m[0]), max);
-  // 維持使用者打的小數型態
-  if (m[2] !== undefined) {
-    const decimals = Math.min(m[2].length, 3);
-    return clamped.toFixed(decimals);
+  if (typeof crypto === "undefined") {
+    throw new Error("這台裝置無法安全產生送出識別碼，請改用支援的瀏覽器。");
   }
-  return String(Math.floor(clamped));
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
-const MAX_ROWS = 200;
+/** 編輯中保留原字串；合法性只在送出時完整檢查。 */
+function clampDecimal(v: string, _max: number): string {
+  void _max;
+  return v;
+}
+
+const QTY_RE = /^\d+(?:\.\d{1,3})?$/;
+const PAGE_SIZE = 200;
+const STORAGE_PREFIX = "new-erp:hq-return-disposition:pending:v1";
+
+function toThousandths(value: string): number | null {
+  if (!QTY_RE.test(value)) return null;
+  const [whole, fraction = ""] = value.split(".");
+  const result = Number(whole) * 1000 + Number(fraction.padEnd(3, "0"));
+  return Number.isSafeInteger(result) ? result : null;
+}
+
+function storedNumberIsValid(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && toThousandths(String(value)) !== null;
+}
+
+function storageKey(tenantId: string, operatorId: string): string {
+  return `${STORAGE_PREFIX}:${tenantId}:${operatorId}`;
+}
+
+function isPendingRequest(value: unknown, tenantId: string, operatorId: string): value is PendingRequest {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Partial<PendingRequest>;
+  const p = v.payload as Partial<DisposePayload> | undefined;
+  if (
+    !p ||
+    !storedNumberIsValid(p.p_qty_good) ||
+    !storedNumberIsValid(p.p_qty_damaged) ||
+    !storedNumberIsValid(p.p_qty_lost)
+  ) return false;
+  const total = p.p_qty_good + p.p_qty_damaged + p.p_qty_lost;
+  return (
+    v.schemaVersion === 1 &&
+    v.tenantId === tenantId &&
+    v.operatorId === operatorId &&
+    typeof v.batchId === "number" && Number.isSafeInteger(v.batchId) && v.batchId > 0 &&
+    typeof v.requestId === "string" && UUID_V4_RE.test(v.requestId) &&
+    typeof v.createdAt === "string" && Number.isFinite(Date.parse(v.createdAt)) &&
+    p.p_batch_id === v.batchId && p.p_request_id === v.requestId &&
+    total > 0 && Number.isFinite(total) &&
+    (p.p_damage_reason === null || typeof p.p_damage_reason === "string") &&
+    (p.p_loss_reason === null || typeof p.p_loss_reason === "string") &&
+    p.p_goods_confirmed === (p.p_qty_good > 0) &&
+    (p.p_qty_damaged === 0 ? p.p_damage_reason === null : !!p.p_damage_reason?.trim()) &&
+    (p.p_qty_lost === 0 ? p.p_loss_reason === null : !!p.p_loss_reason?.trim()) &&
+    (p.p_notes === null || typeof p.p_notes === "string")
+  );
+}
+
+function readPendingRequest(
+  key: string,
+  tenantId: string,
+  operatorId: string,
+): { request: PendingRequest | null; error: string | null } {
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return { request: null, error: null };
+    const parsed: unknown = JSON.parse(raw);
+    return isPendingRequest(parsed, tenantId, operatorId)
+      ? { request: parsed, error: null }
+      : {
+          request: null,
+          error: "上次待確認的送出資料不完整。為避免重複處理，請先由工程人員查明後再操作。",
+        };
+  } catch {
+    return {
+      request: null,
+      error: "無法讀取上次待確認的送出資料。為避免重複處理，請先由工程人員查明後再操作。",
+    };
+  }
+}
+
+function isDefiniteDatabaseRejection(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" && (/^[0-9A-Z]{5}$/.test(code) || code.startsWith("PGRST"));
+}
 
 // ── 主元件 ──
 
 export default function HqReturnDispositionPage() {
   const role = useRole();
+  const { user, tenant, loading: authLoading } = useAuth();
+  const tenantFromToken = user?.app_metadata?.tenant_id;
+  const tenantId = tenant?.id ?? (typeof tenantFromToken === "string" ? tenantFromToken : null);
+
+  if (role === null || authLoading) return <LoadingBlock />;
+
+  if (!canDisposeReturn(role)) {
+    return (
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <h1 className="text-xl font-semibold">退回貨處理</h1>
+        <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          權限不足：此頁面只開放負責人、管理員與總倉主管。
+        </div>
+      </div>
+    );
+  }
+
+  if (!user?.id || !tenantId) {
+    return (
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <h1 className="text-xl font-semibold">退回貨處理</h1>
+        <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          登入資料不完整，為避免把處理資料記到錯的公司，這一頁暫時不能操作。請重新登入後再試。
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ReturnDispositionWorkspace
+      key={`${tenantId}:${user.id}`}
+      role={role}
+      tenantId={tenantId}
+      operatorId={user.id}
+    />
+  );
+}
+
+function ReturnDispositionWorkspace({
+  role,
+  tenantId,
+  operatorId,
+}: {
+  role: Role;
+  tenantId: string;
+  operatorId: string;
+}) {
   const showCost = canSeeCost(role);
-  const allowed = isHqRole(role);
+  const pendingStorageKey = storageKey(tenantId, operatorId);
+  const [storedLoad] = useState(() => readPendingRequest(pendingStorageKey, tenantId, operatorId));
+  const [pendingRequest, setPendingRequest] = useState<PendingRequest | null>(() =>
+    storedLoad.request,
+  );
+  const storageLoadError = storedLoad.error;
 
   // ── 批次列表 ──
   const [batches, setBatches] = useState<BatchRow[]>([]);
   const [skuMap, setSkuMap] = useState<Map<number, SkuRow>>(new Map());
-  // source_transfer_item_id → 店名
-  const [storeNameMap, setStoreNameMap] = useState<Map<number, string>>(new Map());
+  const [sourceInfoMap, setSourceInfoMap] = useState<Map<number, SourceInfo>>(new Map());
   const [listLoading, setListLoading] = useState(true);
   const [listError, setListError] = useState<string | null>(null);
   const [includeHistory, setIncludeHistory] = useState(false);
-  const [reloadKey, setReloadKey] = useState(0);
+  const [page, setPage] = useState(0);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const listRequestRef = useRef(0);
 
   // ── 選中的批次 ──
-  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(pendingRequest?.batchId ?? null);
 
   // ── 事件列表（選中批次的） ──
   const [events, setEvents] = useState<EventRow[]>([]);
-  const [eventsLoading, setEventsLoading] = useState(false);
+  const [eventsLoading, setEventsLoading] = useState(pendingRequest !== null);
   const [eventsError, setEventsError] = useState<string | null>(null);
   const [operatorNames, setOperatorNames] = useState<Map<string, string>>(new Map());
+  const [eventsReloadKey, setEventsReloadKey] = useState(0);
 
   // ── 處理表單 ──
-  const [fGood, setFGood] = useState("");
-  const [fDamaged, setFDamaged] = useState("");
-  const [fLost, setFLost] = useState("");
-  const [fDamageReason, setFDamageReason] = useState("");
-  const [fLossReason, setFLossReason] = useState("");
-  const [fGoodsConfirmed, setFGoodsConfirmed] = useState(false);
-  const [fNotes, setFNotes] = useState("");
+  const [fGood, setFGood] = useState(() => pendingRequest ? String(pendingRequest.payload.p_qty_good) : "");
+  const [fDamaged, setFDamaged] = useState(() => pendingRequest ? String(pendingRequest.payload.p_qty_damaged) : "");
+  const [fLost, setFLost] = useState(() => pendingRequest ? String(pendingRequest.payload.p_qty_lost) : "");
+  const [fDamageReason, setFDamageReason] = useState(() => pendingRequest?.payload.p_damage_reason ?? "");
+  const [fLossReason, setFLossReason] = useState(() => pendingRequest?.payload.p_loss_reason ?? "");
+  const [fGoodsConfirmed, setFGoodsConfirmed] = useState(() => pendingRequest?.payload.p_goods_confirmed ?? false);
+  const [fNotes, setFNotes] = useState(() => pendingRequest?.payload.p_notes ?? "");
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitOk, setSubmitOk] = useState<string | null>(null);
-  // 冪等 UUID：每次送出用同一個，成功或改 payload 後換新
-  const requestIdRef = useRef(newRequestId());
+  const submittingRef = useRef(false);
 
   const selected = useMemo(
     () => batches.find((b) => b.id === selectedId) ?? null,
@@ -183,145 +346,173 @@ export default function HqReturnDispositionPage() {
   );
 
   // ── 載入批次列表 ──
-  useEffect(() => {
-    if (role === null) return; // 還在讀 role
-    if (!allowed) {
-      setListLoading(false);
-      return;
+  const fetchBatchPage = useCallback(async () => {
+    const sb = getSupabase();
+    let q = sb
+        .from("v_hq_return_batches_list")
+        .select("*")
+        .order("created_at", { ascending: false })
+        .order("id", { ascending: false });
+
+    if (!includeHistory) q = q.in("status", ["pending", "partial"]);
+
+    const from = page * PAGE_SIZE;
+    const { data, error } = await q.range(from, from + PAGE_SIZE);
+    if (error) throw error;
+    const fetched = (data ?? []) as BatchRow[];
+    const rows = fetched.slice(0, PAGE_SIZE);
+
+    // ── 解析 SKU 名稱 ──
+    const skuIds = Array.from(new Set(rows.map((r) => r.sku_id)));
+    const nextSkuMap = new Map<number, SkuRow>();
+    if (skuIds.length > 0) {
+      const skuRows = await fetchAllRows<SkuRow>(() =>
+        sb
+          .from("skus")
+          .select("id, sku_code, product_name, variant_name")
+          .in("id", skuIds)
+          .order("id", { ascending: true }),
+      );
+      for (const sku of skuRows) nextSkuMap.set(sku.id, sku);
     }
+
+    // ── 解析店名：source_transfer_item_id → transfer_items → transfers → locations ──
+    const uniqueTiIds = Array.from(new Set(
+      rows
+        .map((row) => row.source_transfer_item_id)
+        .filter((id): id is number => id != null),
+    ));
+    const nextSourceMap = new Map<number, SourceInfo>();
+
+    if (uniqueTiIds.length > 0) {
+      const tiRows = await fetchAllRows<{ id: number; transfer_id: number }>(() =>
+        sb
+          .from("transfer_items")
+          .select("id, transfer_id")
+          .in("id", uniqueTiIds)
+          .order("id", { ascending: true }),
+      );
+      const tiToTransfer = new Map<number, number>();
+      for (const item of tiRows) tiToTransfer.set(item.id, item.transfer_id);
+
+      const transferIds = Array.from(new Set(tiRows.map((item) => item.transfer_id)));
+      if (transferIds.length > 0) {
+        const transferRows = await fetchAllRows<{
+          id: number;
+          transfer_no: string;
+          source_location: number;
+          dest_location: number;
+        }>(() =>
+          sb
+            .from("transfers")
+            .select("id, transfer_no, source_location, dest_location")
+            .in("id", transferIds)
+            .order("id", { ascending: true }),
+        );
+
+        const locationIds = Array.from(new Set(
+          transferRows.flatMap((transfer) => [transfer.source_location, transfer.dest_location]),
+        ));
+        const locationNames = new Map<number, string>();
+        if (locationIds.length > 0) {
+          const locationRows = await fetchAllRows<{ id: number; name: string }>(() =>
+            sb
+              .from("locations")
+              .select("id, name")
+              .in("id", locationIds)
+              .order("id", { ascending: true }),
+          );
+          for (const location of locationRows) locationNames.set(location.id, location.name);
+        }
+
+        const transferMap = new Map<number, SourceInfo>();
+        for (const transfer of transferRows) {
+          transferMap.set(transfer.id, {
+            transferNo: transfer.transfer_no,
+            sourceName: locationNames.get(transfer.source_location) ?? null,
+            destName: locationNames.get(transfer.dest_location) ?? null,
+          });
+        }
+        for (const itemId of uniqueTiIds) {
+          const transferId = tiToTransfer.get(itemId);
+          const info = transferId == null ? null : transferMap.get(transferId);
+          if (info) nextSourceMap.set(itemId, info);
+        }
+      }
+    }
+
+    return { fetched, rows, nextSkuMap, nextSourceMap };
+  }, [includeHistory, page]);
+
+  const loadBatchPage = useCallback(async (): Promise<boolean> => {
+    const requestNo = ++listRequestRef.current;
+    try {
+      const result = await fetchBatchPage();
+      if (requestNo !== listRequestRef.current) return false;
+
+      setBatches(result.rows);
+      setHasNextPage(result.fetched.length > PAGE_SIZE);
+      setSkuMap(result.nextSkuMap);
+      setSourceInfoMap(result.nextSourceMap);
+      setSelectedId((current) => {
+        return current != null && result.rows.some((row) => row.id === current) ? current : null;
+      });
+      setListError(null);
+      return true;
+    } catch (err) {
+      if (requestNo === listRequestRef.current) setListError(translateRpcError(err));
+      return false;
+    } finally {
+      if (requestNo === listRequestRef.current) setListLoading(false);
+    }
+  }, [fetchBatchPage]);
+
+  useEffect(() => {
+    const requestNo = ++listRequestRef.current;
     let cancelled = false;
-    setListLoading(true);
     (async () => {
       try {
-        const sb = getSupabase();
-        let q = sb
-          .from("v_hq_return_batches_list")
-          .select("*")
-          .order("created_at", { ascending: false })
-          .limit(MAX_ROWS);
-
-        if (!includeHistory) {
-          q = q.in("status", ["pending", "partial"]);
-        }
-
-        const { data, error } = await q;
-        if (error) throw error;
-        if (cancelled) return;
-        const rows = (data ?? []) as BatchRow[];
-
-        // ── 解析 SKU 名稱 ──
-        const skuIds = Array.from(new Set(rows.map((r) => r.sku_id)));
-        const newSkuMap = new Map<number, SkuRow>();
-        if (skuIds.length > 0) {
-          const skuRows = await fetchAllRows<SkuRow>(() =>
-            sb
-              .from("skus")
-              .select("id, sku_code, product_name, variant_name")
-              .in("id", skuIds)
-              .order("id", { ascending: true }),
-          );
-          for (const s of skuRows) newSkuMap.set(s.id, s);
-        }
-
-        // ── 解析店名：source_transfer_item_id → transfer_items → transfers → locations ──
-        const tiIds = rows
-          .map((r) => r.source_transfer_item_id)
-          .filter((x): x is number => x != null);
-        const uniqueTiIds = Array.from(new Set(tiIds));
-        const newStoreMap = new Map<number, string>();
-
-        if (uniqueTiIds.length > 0) {
-          // 1) transfer_items → 拿 transfer_id
-          const tiRows = await fetchAllRows<{ id: number; transfer_id: number }>(() =>
-            sb
-              .from("transfer_items")
-              .select("id, transfer_id")
-              .in("id", uniqueTiIds)
-              .order("id", { ascending: true }),
-          );
-          const tiToTransfer = new Map<number, number>();
-          for (const ti of tiRows) tiToTransfer.set(ti.id, ti.transfer_id);
-
-          // 2) transfers → 拿 source_location
-          const transferIds = Array.from(new Set(tiRows.map((t) => t.transfer_id)));
-          if (transferIds.length > 0) {
-            const trRows = await fetchAllRows<{
-              id: number;
-              transfer_no: string;
-              source_location: number;
-            }>(() =>
-              sb
-                .from("transfers")
-                .select("id, transfer_no, source_location")
-                .in("id", transferIds)
-                .order("id", { ascending: true }),
-            );
-            const trMap = new Map<number, number>();
-            for (const tr of trRows) trMap.set(tr.id, tr.source_location);
-
-            // 3) locations → 拿 name
-            const locIds = Array.from(new Set(trRows.map((t) => t.source_location)));
-            if (locIds.length > 0) {
-              const { data: lr } = await sb
-                .from("locations")
-                .select("id, name")
-                .in("id", locIds);
-              const locName = new Map<number, string>();
-              for (const l of (lr ?? []) as { id: number; name: string }[])
-                locName.set(l.id, l.name);
-
-              // 組合：tiId → storeName
-              for (const tiId of uniqueTiIds) {
-                const trId = tiToTransfer.get(tiId);
-                if (trId == null) continue;
-                const locId = trMap.get(trId);
-                if (locId == null) continue;
-                const name = locName.get(locId);
-                if (name) newStoreMap.set(tiId, name);
-              }
-            }
-          }
-        }
-
-        if (cancelled) return;
-        setBatches(rows);
-        setSkuMap(newSkuMap);
-        setStoreNameMap(newStoreMap);
+        const result = await fetchBatchPage();
+        if (cancelled || requestNo !== listRequestRef.current) return;
+        setBatches(result.rows);
+        setHasNextPage(result.fetched.length > PAGE_SIZE);
+        setSkuMap(result.nextSkuMap);
+        setSourceInfoMap(result.nextSourceMap);
+        setSelectedId((current) => (
+          current != null && result.rows.some((row) => row.id === current) ? current : null
+        ));
         setListError(null);
       } catch (err) {
-        if (!cancelled) setListError(translateRpcError(err));
+        if (!cancelled && requestNo === listRequestRef.current) setListError(translateRpcError(err));
       } finally {
-        if (!cancelled) setListLoading(false);
+        if (!cancelled && requestNo === listRequestRef.current) setListLoading(false);
       }
     })();
     return () => {
       cancelled = true;
+      listRequestRef.current += 1;
     };
-  }, [role, allowed, includeHistory, reloadKey]);
+  }, [fetchBatchPage]);
 
   // ── 載入選中批次的事件 ──
   useEffect(() => {
-    if (selectedId == null) {
-      setEvents([]);
-      setEventsError(null);
-      return;
-    }
+    if (selectedId == null) return;
     let cancelled = false;
-    setEventsLoading(true);
-    setEventsError(null);
     (async () => {
       try {
         const sb = getSupabase();
-        const { data, error } = await sb
-          .from("hq_return_events")
-          .select(
-            "id, batch_id, request_id, qty_good, qty_damaged, qty_lost, damage_reason, loss_reason, goods_confirmed, damage_movement_id, loss_movement_id, notes, operator_id, created_at",
-          )
-          .eq("batch_id", selectedId)
-          .order("created_at", { ascending: true });
-        if (error) throw error;
+        const evts = await fetchAllRows<EventRow>(() =>
+          sb
+            .from("hq_return_events")
+            .select(
+              "id, batch_id, request_id, qty_good, qty_damaged, qty_lost, damage_reason, loss_reason, goods_confirmed, damage_movement_id, loss_movement_id, notes, operator_id, created_at",
+            )
+            .eq("batch_id", selectedId)
+            .order("created_at", { ascending: true })
+            .order("id", { ascending: true }),
+        );
         if (cancelled) return;
-        const evts = (data ?? []) as EventRow[];
+        setEvents(evts);
 
         // 操作人名稱
         const uids = Array.from(
@@ -329,15 +520,15 @@ export default function HqReturnDispositionPage() {
         );
         const nameMap = new Map<string, string>();
         if (uids.length > 0) {
-          const { data: ns } = await sb.rpc("rpc_get_staff_names", {
+          const { data: ns, error: namesError } = await sb.rpc("rpc_get_staff_names", {
             p_uids: uids,
           });
+          if (namesError) throw namesError;
           for (const n of (ns as { id: string; display_name: string }[] | null) ?? [])
             nameMap.set(n.id, n.display_name);
         }
 
         if (cancelled) return;
-        setEvents(evts);
         setOperatorNames(nameMap);
       } catch (err) {
         if (!cancelled) setEventsError(translateRpcError(err));
@@ -348,7 +539,7 @@ export default function HqReturnDispositionPage() {
     return () => {
       cancelled = true;
     };
-  }, [selectedId, reloadKey]);
+  }, [selectedId, eventsReloadKey]);
 
   // 清空表單
   const resetForm = useCallback(() => {
@@ -361,117 +552,269 @@ export default function HqReturnDispositionPage() {
     setFNotes("");
     setSubmitError(null);
     setSubmitOk(null);
-    requestIdRef.current = newRequestId();
   }, []);
 
   // 選批次時清表單
   const handleSelect = useCallback(
     (id: number) => {
-      setSelectedId((prev) => (prev === id ? null : id));
+      if (pendingRequest) {
+        setSubmitError("上一筆送出結果還沒查明，現在不能關閉或切換批次。");
+        return;
+      }
+      const isClosing = selectedId === id;
+      setSelectedId(isClosing ? null : id);
+      setEvents([]);
+      setOperatorNames(new Map());
+      setEventsError(null);
+      setEventsLoading(!isClosing);
       resetForm();
     },
-    [resetForm],
+    [pendingRequest, resetForm, selectedId],
   );
+
+  const clearStoredRequest = useCallback((): boolean => {
+    try {
+      window.localStorage.removeItem(pendingStorageKey);
+      return true;
+    } catch {
+      setSubmitError("無法清除已確認的送出資料。為避免下次重複處理，請先不要繼續操作。");
+      return false;
+    }
+  }, [pendingStorageKey]);
+
+  const eventMatchesRequest = useCallback((event: EventRow, request: PendingRequest): boolean => {
+    const p = request.payload;
+    return (
+      event.batch_id === p.p_batch_id &&
+      event.request_id === p.p_request_id &&
+      num(event.qty_good) === p.p_qty_good &&
+      num(event.qty_damaged) === p.p_qty_damaged &&
+      num(event.qty_lost) === p.p_qty_lost &&
+      event.damage_reason === p.p_damage_reason &&
+      event.loss_reason === p.p_loss_reason &&
+      event.goods_confirmed === p.p_goods_confirmed &&
+      event.notes === p.p_notes &&
+      event.operator_id === request.operatorId
+    );
+  }, []);
+
+  const confirmStoredRequest = useCallback(async (
+    request: PendingRequest,
+    successPrefix = "處理完成",
+  ): Promise<boolean> => {
+    try {
+      const sb = getSupabase();
+      const { data, error } = await sb
+        .from("hq_return_events")
+        .select(
+          "id, batch_id, request_id, qty_good, qty_damaged, qty_lost, damage_reason, loss_reason, goods_confirmed, damage_movement_id, loss_movement_id, notes, operator_id, created_at",
+        )
+        .eq("tenant_id", request.tenantId)
+        .eq("batch_id", request.batchId)
+        .eq("request_id", request.requestId)
+        .limit(1);
+      if (error) throw error;
+      const event = ((data ?? []) as EventRow[])[0];
+      if (!event) {
+        setSubmitError("目前還查不到這筆送出結果。數量已鎖定，請稍後再查，或原封不動重新傳送同一筆資料。");
+        return false;
+      }
+      if (!eventMatchesRequest(event, request)) {
+        setSubmitError("查到的處理紀錄與本機保留資料不一致。為避免錯帳，已停止後續操作，請交由工程人員查明。");
+        return false;
+      }
+      setListLoading(true);
+      if (!(await loadBatchPage())) {
+        setSubmitError("已查到處理紀錄，但清單還沒重新整理成功。資料仍鎖定，請按「查詢送出結果」再試一次。");
+        return false;
+      }
+      if (!clearStoredRequest()) return false;
+
+      setPendingRequest(null);
+      resetForm();
+      setSubmitOk(`✓ ${successPrefix}（處理紀錄 #${event.id}）`);
+      setEventsLoading(true);
+      setEventsReloadKey((value) => value + 1);
+      return true;
+    } catch (err) {
+      setSubmitError(`送出結果仍無法確認：${translateRpcError(err)}。原資料已保留並鎖定，請稍後再查。`);
+      return false;
+    }
+  }, [clearStoredRequest, eventMatchesRequest, loadBatchPage, resetForm]);
+
+  const sendStoredRequest = useCallback(async (request: PendingRequest) => {
+    if (submittingRef.current) return;
+    submittingRef.current = true;
+    setSubmitting(true);
+    setSubmitError(null);
+    setSubmitOk(null);
+    try {
+      const sb = getSupabase();
+      const { data, error } = await sb.rpc("rpc_dispose_hq_return", request.payload);
+      if (error) {
+        if (isDefiniteDatabaseRejection(error)) {
+          if (clearStoredRequest()) {
+            setPendingRequest(null);
+            setSubmitError(`${translateRpcError(error)}。這次送出已被系統明確拒絕，可修正內容後再送。`);
+          }
+          return;
+        }
+        await confirmStoredRequest(request);
+        return;
+      }
+
+      const result = data as { idempotent?: boolean } | null;
+      await confirmStoredRequest(request, result?.idempotent ? "原資料重送確認完成" : "處理完成");
+    } catch (err) {
+      await confirmStoredRequest(request);
+      if (!isDefiniteDatabaseRejection(err)) return;
+      if (clearStoredRequest()) {
+        setPendingRequest(null);
+        setSubmitError(`${translateRpcError(err)}。這次送出已被系統明確拒絕，可修正內容後再送。`);
+      }
+    } finally {
+      submittingRef.current = false;
+      setSubmitting(false);
+    }
+  }, [clearStoredRequest, confirmStoredRequest]);
 
   // ── 送出處理 ──
   const handleSubmit = useCallback(async () => {
-    if (!selected) return;
+    if (pendingRequest) {
+      await sendStoredRequest(pendingRequest);
+      return;
+    }
+    if (!selected || storageLoadError) return;
+    const storedNow = readPendingRequest(pendingStorageKey, tenantId, operatorId);
+    if (storedNow.error) {
+      setSubmitError(storedNow.error);
+      return;
+    }
+    if (storedNow.request) {
+      const request = storedNow.request;
+      setPendingRequest(request);
+      setSelectedId(request.batchId);
+      setFGood(String(request.payload.p_qty_good));
+      setFDamaged(String(request.payload.p_qty_damaged));
+      setFLost(String(request.payload.p_qty_lost));
+      setFDamageReason(request.payload.p_damage_reason ?? "");
+      setFLossReason(request.payload.p_loss_reason ?? "");
+      setFGoodsConfirmed(request.payload.p_goods_confirmed);
+      setFNotes(request.payload.p_notes ?? "");
+      setSubmitError("另一個頁籤已有一筆送出結果尚未查明；原資料已恢復並鎖定，請先查詢結果。");
+      return;
+    }
     setSubmitError(null);
     setSubmitOk(null);
 
-    const qGood = num(fGood);
-    const qDamaged = num(fDamaged);
-    const qLost = num(fLost);
-    const total = qGood + qDamaged + qLost;
+    const inputs = [
+      ["完好數量", fGood],
+      ["破損數量", fDamaged],
+      ["遺失數量", fLost],
+    ] as const;
+    const parsed = inputs.map(([label, value]) => {
+      const thousandths = value === "" ? 0 : toThousandths(value);
+      if (thousandths === null) {
+        setSubmitError(`${label}只能填 0 以上的數字，且最多 3 位小數。`);
+      }
+      return thousandths;
+    });
+    if (parsed.some((value) => value === null)) return;
 
-    if (total <= 0) {
-      setSubmitError("至少要填一種數量（完好/破損/遺失），不能全部是 0。");
+    const [goodThousandths, damagedThousandths, lostThousandths] = parsed as number[];
+    const totalThousandths = goodThousandths + damagedThousandths + lostThousandths;
+    const pendingThousandths = toThousandths(String(selected.qty_pending));
+    if (pendingThousandths === null) {
+      setSubmitError("尚待確認量的格式不正確，已停止送出，請交由工程人員查明。");
       return;
     }
-    if (total > num(selected.qty_pending)) {
-      setSubmitError(
-        `本次處理合計 ${total} 超過尚待確認量 ${num(selected.qty_pending)}。`,
-      );
+    if (totalThousandths <= 0) {
+      setSubmitError("至少要填一種數量（完好、破損或遺失），不能全部是 0。");
       return;
     }
+    if (totalThousandths > pendingThousandths) {
+      setSubmitError(`本次處理合計 ${totalThousandths / 1000} 超過尚待確認量 ${pendingThousandths / 1000}。`);
+      return;
+    }
+
+    const qGood = goodThousandths / 1000;
+    const qDamaged = damagedThousandths / 1000;
+    const qLost = lostThousandths / 1000;
     if (qGood > 0 && !fGoodsConfirmed) {
-      setSubmitError("完好數量 > 0 時必須勾選「實物已到」。");
+      setSubmitError("有填完好數量時，必須勾選「實物已到總倉」。");
       return;
     }
     if (qDamaged > 0 && !fDamageReason.trim()) {
-      setSubmitError("破損數量 > 0 時必須填寫破損原因。");
+      setSubmitError("有填破損數量時，必須填寫破損原因。");
       return;
     }
     if (qLost > 0 && !fLossReason.trim()) {
-      setSubmitError("遺失數量 > 0 時必須填寫遺失原因。");
+      setSubmitError("有填遺失數量時，必須填寫遺失原因。");
+      return;
+    }
+    if (selected.tenant_id !== tenantId) {
+      setSubmitError("這筆批次不屬於目前登入的公司，已停止送出。請重新登入後再試。");
       return;
     }
 
-    setSubmitting(true);
+    let requestId: string;
     try {
-      const sb = getSupabase();
-      const { data, error } = await sb.rpc("rpc_dispose_hq_return", {
-        p_batch_id: selected.id,
-        p_request_id: requestIdRef.current,
-        p_qty_good: qGood,
-        p_qty_damaged: qDamaged,
-        p_qty_lost: qLost,
-        p_damage_reason: qDamaged > 0 ? fDamageReason.trim() : null,
-        p_loss_reason: qLost > 0 ? fLossReason.trim() : null,
-        p_goods_confirmed: qGood > 0 ? true : false,
-        p_notes: fNotes.trim() || null,
-      });
-      if (error) throw error;
-
-      const result = data as {
-        event_id: number;
-        batch_id: number;
-        idempotent: boolean;
-        new_status?: string;
-      };
-
-      setSubmitOk(
-        result.idempotent
-          ? `✓ 重試成功（同一筆 request，事件 #${result.event_id}）`
-          : `✓ 處理完成（事件 #${result.event_id}${result.new_status === "completed" ? "，此批已全部處理完畢" : ""}）`,
-      );
-
-      // 成功後刷新列表與事件、重設表單
-      // ⚠ 新 requestId 讓下次送出用新的冪等碼
-      requestIdRef.current = newRequestId();
-      setFGood("");
-      setFDamaged("");
-      setFLost("");
-      setFDamageReason("");
-      setFLossReason("");
-      setFGoodsConfirmed(false);
-      setFNotes("");
-      setReloadKey((k) => k + 1);
+      requestId = newRequestId();
     } catch (err) {
       setSubmitError(translateRpcError(err));
-      // ⚠ 不確定是否已經成功（網路錯誤）→ 保留同一個 requestId，讓使用者可以安全重試
-      // 如果使用者想改 payload，下面有「重新產生」按鈕會換新 id
-    } finally {
-      setSubmitting(false);
+      return;
     }
-  }, [selected, fGood, fDamaged, fLost, fDamageReason, fLossReason, fGoodsConfirmed, fNotes]);
+    const payload: DisposePayload = {
+      p_batch_id: selected.id,
+      p_request_id: requestId,
+      p_qty_good: qGood,
+      p_qty_damaged: qDamaged,
+      p_qty_lost: qLost,
+      p_damage_reason: qDamaged > 0 ? fDamageReason.trim() : null,
+      p_loss_reason: qLost > 0 ? fLossReason.trim() : null,
+      p_goods_confirmed: qGood > 0,
+      p_notes: fNotes.trim() || null,
+    };
+    const request: PendingRequest = {
+      schemaVersion: 1,
+      tenantId,
+      operatorId,
+      batchId: selected.id,
+      requestId,
+      createdAt: new Date().toISOString(),
+      payload,
+    };
+    try {
+      window.localStorage.setItem(pendingStorageKey, JSON.stringify(request));
+    } catch {
+      setSubmitError("這台裝置無法安全保留待確認資料，因此沒有送出。請確認瀏覽器允許本機儲存後再試。");
+      return;
+    }
 
-  // 等 role 載入
-  if (role === null) return <LoadingBlock />;
-
-  // 權限不足
-  if (!allowed) {
-    return (
-      <div className="flex flex-1 flex-col gap-4 p-6">
-        <h1 className="text-xl font-semibold">退回貨處理</h1>
-        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
-          權限不足：此頁面僅限總倉管理角色（owner / admin / hq_manager）。
-        </div>
-      </div>
-    );
-  }
+    setPendingRequest(request);
+    await sendStoredRequest(request);
+  }, [
+    pendingRequest,
+    selected,
+    storageLoadError,
+    fGood,
+    fDamaged,
+    fLost,
+    fGoodsConfirmed,
+    fDamageReason,
+    fLossReason,
+    fNotes,
+    tenantId,
+    operatorId,
+    pendingStorageKey,
+    sendStoredRequest,
+  ]);
 
   const pending = selected ? num(selected.qty_pending) : 0;
+  const selectedSourceInfo = selected?.source_transfer_item_id == null
+    ? undefined
+    : sourceInfoMap.get(selected.source_transfer_item_id);
+  const formLocked = submitting || pendingRequest !== null || storageLoadError !== null;
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-6">
@@ -479,10 +822,10 @@ export default function HqReturnDispositionPage() {
       <header>
         <h1 className="text-xl font-semibold">退回貨處理</h1>
         <p className="text-sm text-zinc-500">
-          門市退貨與收貨短少回到總倉的批次在這裡處理。完好的會放回可派庫存，破損與遺失會扣總倉帳。
+          總倉收到門市退貨，或門市收貨時發現短少，請在這裡確認貨況。完好的貨可重新派出，破損與遺失會記入總倉損失。
         </p>
         <p className="mt-0.5 text-xs text-zinc-400">
-          破損/遺失<strong>不會</strong>對店家收退款；責任歸屬待定，來源成本不等於正式損失認列。
+          本頁不會再自動向店家收款或退款；責任歸屬另依老闆規則處理，來源成本也不等於最後認列的損失。
         </p>
       </header>
 
@@ -492,13 +835,23 @@ export default function HqReturnDispositionPage() {
           <input
             type="checkbox"
             checked={includeHistory}
-            onChange={(e) => setIncludeHistory(e.target.checked)}
+            onChange={(e) => {
+              setListLoading(true);
+              setIncludeHistory(e.target.checked);
+              setPage(0);
+              setSelectedId(null);
+              resetForm();
+            }}
+            disabled={pendingRequest !== null}
             className="rounded border-zinc-300 dark:border-zinc-600"
           />
-          含已完成/已撤回
+          顯示已完成與已撤回
         </label>
         <SpinButton
-          onClick={() => setReloadKey((k) => k + 1)}
+          onClick={() => {
+            setListLoading(true);
+            return loadBatchPage();
+          }}
           className="rounded-md border border-zinc-300 bg-white px-3 py-1 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700"
         >
           重新整理
@@ -506,9 +859,47 @@ export default function HqReturnDispositionPage() {
       </div>
 
       {/* ── 錯誤 ── */}
+      {storageLoadError && (
+        <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {storageLoadError}
+        </div>
+      )}
       {listError && (
-        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+        <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
           {listError}
+        </div>
+      )}
+      {submitError && (
+        <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {submitError}
+        </div>
+      )}
+      {submitOk && (
+        <div aria-live="polite" className="rounded border border-emerald-200 bg-emerald-50 p-2 text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300">
+          {submitOk}
+        </div>
+      )}
+      {pendingRequest && (
+        <div role="status" className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+          <strong>上一筆送出結果還沒查明。</strong> 批次 #{pendingRequest.batchId} 的原數量已保留並鎖定；現在不能改數量、切換批次或開新一筆。
+          <div className="mt-2 flex flex-wrap gap-2">
+            <SpinButton
+              onClick={() => confirmStoredRequest(pendingRequest)}
+              disabled={submitting}
+              loading={submitting}
+              className="rounded-md border border-amber-400 bg-white px-3 py-1.5 text-xs font-medium hover:bg-amber-100 disabled:opacity-60 dark:border-amber-700 dark:bg-amber-900 dark:hover:bg-amber-800"
+            >
+              查詢送出結果
+            </SpinButton>
+            <SpinButton
+              onClick={() => sendStoredRequest(pendingRequest)}
+              disabled={submitting}
+              loading={submitting}
+              className="rounded-md bg-amber-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-800 disabled:opacity-60"
+            >
+              重新傳送原資料
+            </SpinButton>
+          </div>
         </div>
       )}
 
@@ -523,7 +914,7 @@ export default function HqReturnDispositionPage() {
                 <th className="px-3 py-2">店名</th>
                 <th className="px-3 py-2">品項</th>
                 <th className="px-3 py-2">原因</th>
-                <th className="px-3 py-2 text-right">回帳量</th>
+                <th className="px-3 py-2 text-right">退回量</th>
                 <th className="px-3 py-2 text-right">待確認</th>
                 <th className="px-3 py-2 text-right">已處理</th>
                 {showCost && <th className="px-3 py-2 text-right">來源單價</th>}
@@ -545,41 +936,61 @@ export default function HqReturnDispositionPage() {
                     className="p-6 text-center text-zinc-500"
                   >
                     {includeHistory
-                      ? "此 tenant 沒有任何退回貨批次（並非代表全系統無資料，僅為本次查詢結果）。"
-                      : "目前沒有待處理的退回貨批次。勾選「含已完成/已撤回」可看歷史。"}
+                      ? "這一頁沒有退回貨批次。可回上一頁繼續查看。"
+                      : "目前沒有待處理的退回貨批次。勾選「顯示已完成與已撤回」可看歷史。"}
                   </td>
                 </tr>
               ) : (
                 batches.map((b) => {
                   const sv = STATUS_ZH[b.status] ?? {
-                    label: b.status,
+                    label: "狀態待確認",
                     cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
                   };
-                  const storeName = b.source_transfer_item_id != null
-                    ? storeNameMap.get(b.source_transfer_item_id) ??
-                      `調撥明細#${b.source_transfer_item_id}`
-                    : "—";
+                  const sourceInfo = b.source_transfer_item_id == null
+                    ? undefined
+                    : sourceInfoMap.get(b.source_transfer_item_id);
+                  const storeName = sourceInfo
+                    ? (b.source_kind === "shortage" ? sourceInfo.destName : sourceInfo.sourceName) ?? "店名未查到"
+                    : b.source_transfer_item_id == null ? "—" : "店名未查到";
                   const isSelected = selectedId === b.id;
                   return (
                     <tr
                       key={b.id}
-                      onClick={() => handleSelect(b.id)}
-                      className={`cursor-pointer align-top transition-colors ${
+                      className={`align-top transition-colors ${
                         isSelected
                           ? "bg-blue-50 dark:bg-blue-950"
                           : "hover:bg-zinc-50 dark:hover:bg-zinc-800"
                       }`}
                     >
-                      <td className="px-3 py-2 font-mono text-xs">#{b.id}</td>
+                      <td className="px-3 py-2">
+                        <button
+                          type="button"
+                          onClick={() => handleSelect(b.id)}
+                          disabled={pendingRequest !== null}
+                          aria-pressed={isSelected}
+                          aria-label={`${isSelected ? "收起" : "查看"}批次 ${b.id}`}
+                          className="rounded px-1 py-0.5 font-mono text-xs text-blue-700 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:text-zinc-400 disabled:no-underline dark:text-blue-300"
+                        >
+                          #{b.id}
+                        </button>
+                      </td>
                       <td className="px-3 py-2 text-xs">
-                        {SOURCE_KIND_ZH[b.source_kind] ?? b.source_kind}
+                        {SOURCE_KIND_ZH[b.source_kind] ?? "其他來源"}
                         {b.auto_flag && (
                           <span className="ml-1 text-[10px] text-zinc-400">
                             ({b.auto_flag === "system" ? "系統" : "人工"})
                           </span>
                         )}
                       </td>
-                      <td className="px-3 py-2 text-xs">{storeName}</td>
+                      <td className="px-3 py-2 text-xs">
+                        <div>{storeName}</div>
+                        {b.source_transfer_item_id != null && (
+                          <div className="mt-0.5 whitespace-nowrap text-[10px] text-zinc-400">
+                            {sourceInfo?.transferNo ? `原單 ${sourceInfo.transferNo}` : "原單號未查到"}
+                            {` · 明細 #${b.source_transfer_item_id}`}
+                          </div>
+                        )}
+                      </td>
                       <td className="px-3 py-2 text-xs">
                         {skuLabel(skuMap.get(b.sku_id), b.sku_id)}
                       </td>
@@ -617,12 +1028,42 @@ export default function HqReturnDispositionPage() {
             </tbody>
           </table>
         </div>
-        <p className="text-[11px] text-zinc-400">
-          本次已載入 {batches.length} 筆（上限 {MAX_ROWS}）。
-          {batches.length >= MAX_ROWS &&
-            "已達上限，可能有更多批次未顯示。請縮小條件或聯繫工程師。"}
-          此數字<strong>不代表</strong>全系統總數。
-        </p>
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-zinc-500">
+          <span>
+            第 {page + 1} 頁，本頁 {batches.length} 筆
+            {batches.length > 0 && `（第 ${page * PAGE_SIZE + 1}–${page * PAGE_SIZE + batches.length} 筆）`}。
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setListLoading(true);
+                setPage((value) => Math.max(0, value - 1));
+                setSelectedId(null);
+                setEvents([]);
+                resetForm();
+              }}
+              disabled={page === 0 || listLoading || pendingRequest !== null}
+              className="rounded border border-zinc-300 px-3 py-1 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              上一頁
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setListLoading(true);
+                setPage((value) => value + 1);
+                setSelectedId(null);
+                setEvents([]);
+                resetForm();
+              }}
+              disabled={!hasNextPage || listLoading || pendingRequest !== null}
+              className="rounded border border-zinc-300 px-3 py-1 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              下一頁
+            </button>
+          </div>
+        </div>
       </section>
 
       {/* ── 選中批次的詳情 ── */}
@@ -637,8 +1078,14 @@ export default function HqReturnDispositionPage() {
                 </span>
               </h2>
               <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">
+                {selected.source_transfer_item_id != null && (
+                  <span>
+                    原單 <strong>{selectedSourceInfo?.transferNo ?? "號碼未查到"}</strong>
+                    {` / 明細 #${selected.source_transfer_item_id}`}
+                  </span>
+                )}
                 <span>
-                  回帳量 <strong>{num(selected.total_qty)}</strong>
+                  退回量 <strong>{num(selected.total_qty)}</strong>
                 </span>
                 <span>
                   完好 <strong>{num(selected.qty_good)}</strong>
@@ -660,17 +1107,18 @@ export default function HqReturnDispositionPage() {
               </div>
               {showCost && (
                 <div className="mt-0.5 text-xs text-zinc-400">
-                  來源單價依據 ${num(selected.unit_cost).toFixed(2)}
-                  （不是售價，是原出庫 movement 的 unit_cost）
+                  來源入庫紀錄單價 ${num(selected.unit_cost).toFixed(2)}（不是售價，也不是最後認列的損失）
                 </div>
               )}
             </div>
             <button
+              type="button"
               onClick={() => {
                 setSelectedId(null);
                 resetForm();
               }}
-              className="text-xs text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+              disabled={pendingRequest !== null}
+              className="rounded text-xs text-zinc-400 hover:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:text-zinc-300"
             >
               ✕ 關閉
             </button>
@@ -680,20 +1128,20 @@ export default function HqReturnDispositionPage() {
           <div>
             <h3 className="mb-1 text-sm font-semibold">處理紀錄</h3>
             {eventsError && (
-              <div className="mb-2 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+              <div role="alert" className="mb-2 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
                 {eventsError}
               </div>
             )}
             {eventsLoading ? (
               <LoadingBlock />
-            ) : events.length === 0 ? (
+            ) : events.length === 0 && !eventsError ? (
               <p className="text-xs text-zinc-500">尚未有任何處理事件。</p>
-            ) : (
+            ) : events.length > 0 ? (
               <div className="overflow-x-auto">
                 <table className="min-w-full divide-y divide-zinc-200 text-xs dark:divide-zinc-800">
                   <thead>
                     <tr className="text-left text-[10px] uppercase tracking-wide text-zinc-400">
-                      <th className="px-2 py-1">事件</th>
+                      <th className="px-2 py-1">紀錄</th>
                       <th className="px-2 py-1 text-right">完好</th>
                       <th className="px-2 py-1 text-right">破損</th>
                       <th className="px-2 py-1 text-right">遺失</th>
@@ -743,82 +1191,83 @@ export default function HqReturnDispositionPage() {
                   </tbody>
                 </table>
               </div>
-            )}
+            ) : null}
           </div>
 
-          {/* ── 處理表單（只在有 pending 時顯示） ── */}
-          {pending > 0 ? (
+          {/* ── 處理表單（有待確認量或尚待查明的送出資料時顯示） ── */}
+          {pending > 0 || pendingRequest?.batchId === selected.id ? (
             <div className="rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800">
               <h3 className="mb-2 text-sm font-semibold">
-                處理此批（尚待 {pending}）
+                {pendingRequest ? "這筆資料正在等待確認" : `處理此批（尚待 ${pending}）`}
               </h3>
               <p className="mb-3 text-xs text-zinc-500">
-                完好會放回可派庫存（reserved → available）；破損/遺失會寫負 movement 扣總倉帳。
-                不一定要一次全部處理完，剩餘的尚待量會留著。
+                完好的貨會恢復成可重新派出的庫存；破損與遺失會記入總倉損失。
+                不必一次處理完，未處理的數量會繼續保留。
               </p>
 
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
                 {/* 完好 */}
                 <div>
-                  <label className="mb-1 block text-xs font-medium">
+                  <label htmlFor="return-good-qty" className="mb-1 block text-xs font-medium">
                     完好數量
                   </label>
                   <input
-                    type="number"
+                    id="return-good-qty"
+                    type="text"
                     inputMode="decimal"
-                    step="any"
-                    min="0"
-                    max={pending}
                     value={fGood}
                     onChange={(e) =>
                       setFGood(clampDecimal(e.target.value, pending))
                     }
-                    disabled={submitting}
+                    disabled={formLocked}
                     className="w-full rounded-md border border-zinc-300 px-2 py-1.5 text-sm tabular-nums disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
                     placeholder="0"
                   />
                   {num(fGood) > 0 && (
                     <label className="mt-1 flex items-center gap-1.5 text-xs">
                       <input
+                        id="return-goods-confirmed"
                         type="checkbox"
                         checked={fGoodsConfirmed}
                         onChange={(e) => setFGoodsConfirmed(e.target.checked)}
-                        disabled={submitting}
+                        disabled={formLocked}
                         className="rounded border-zinc-300 dark:border-zinc-600"
                       />
-                      實物已到（必勾）
+                      <span>實物已到總倉（必勾）</span>
                     </label>
                   )}
                 </div>
 
                 {/* 破損 */}
                 <div>
-                  <label className="mb-1 block text-xs font-medium">
+                  <label htmlFor="return-damaged-qty" className="mb-1 block text-xs font-medium">
                     破損數量
                   </label>
                   <input
-                    type="number"
+                    id="return-damaged-qty"
+                    type="text"
                     inputMode="decimal"
-                    step="any"
-                    min="0"
-                    max={pending}
                     value={fDamaged}
                     onChange={(e) =>
                       setFDamaged(clampDecimal(e.target.value, pending))
                     }
-                    disabled={submitting}
+                    disabled={formLocked}
                     className="w-full rounded-md border border-zinc-300 px-2 py-1.5 text-sm tabular-nums disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
                     placeholder="0"
                   />
                   {num(fDamaged) > 0 && (
                     <div className="mt-1">
+                      <label htmlFor="return-damage-reason" className="mb-1 block text-xs text-zinc-500">
+                        破損原因（必填）
+                      </label>
                       <input
+                        id="return-damage-reason"
                         type="text"
                         value={fDamageReason}
                         onChange={(e) => setFDamageReason(e.target.value)}
-                        disabled={submitting}
+                        disabled={formLocked}
                         className="w-full rounded-md border border-zinc-300 px-2 py-1 text-xs disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
-                        placeholder="破損原因（必填）"
+                        placeholder="例如：外箱破裂、商品滲漏"
                       />
                     </div>
                   )}
@@ -826,32 +1275,34 @@ export default function HqReturnDispositionPage() {
 
                 {/* 遺失 */}
                 <div>
-                  <label className="mb-1 block text-xs font-medium">
+                  <label htmlFor="return-lost-qty" className="mb-1 block text-xs font-medium">
                     遺失數量
                   </label>
                   <input
-                    type="number"
+                    id="return-lost-qty"
+                    type="text"
                     inputMode="decimal"
-                    step="any"
-                    min="0"
-                    max={pending}
                     value={fLost}
                     onChange={(e) =>
                       setFLost(clampDecimal(e.target.value, pending))
                     }
-                    disabled={submitting}
+                    disabled={formLocked}
                     className="w-full rounded-md border border-zinc-300 px-2 py-1.5 text-sm tabular-nums disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
                     placeholder="0"
                   />
                   {num(fLost) > 0 && (
                     <div className="mt-1">
+                      <label htmlFor="return-loss-reason" className="mb-1 block text-xs text-zinc-500">
+                        遺失原因（必填）
+                      </label>
                       <input
+                        id="return-loss-reason"
                         type="text"
                         value={fLossReason}
                         onChange={(e) => setFLossReason(e.target.value)}
-                        disabled={submitting}
+                        disabled={formLocked}
                         className="w-full rounded-md border border-zinc-300 px-2 py-1 text-xs disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
-                        placeholder="遺失原因（必填）"
+                        placeholder="例如：清點後未找到"
                       />
                     </div>
                   )}
@@ -860,57 +1311,30 @@ export default function HqReturnDispositionPage() {
 
               {/* 備註 */}
               <div className="mt-3">
-                <label className="mb-1 block text-xs font-medium">
+                <label htmlFor="return-notes" className="mb-1 block text-xs font-medium">
                   備註（選填）
                 </label>
                 <input
+                  id="return-notes"
                   type="text"
                   value={fNotes}
                   onChange={(e) => setFNotes(e.target.value)}
-                  disabled={submitting}
+                  disabled={formLocked}
                   className="w-full rounded-md border border-zinc-300 px-2 py-1.5 text-sm disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
                   placeholder="處理備註"
                 />
               </div>
 
-              {/* 提交結果 */}
-              {submitError && (
-                <div className="mt-2 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
-                  {submitError}
-                  <div className="mt-1 text-[10px] text-zinc-400">
-                    如果是網路中斷，可以直接再按一次送出（同一個 request UUID 會安全重試）。
-                    如果你想<strong>改數量</strong>再送，請先按下面的「重新產生 Request ID」。
-                  </div>
-                </div>
-              )}
-              {submitOk && (
-                <div className="mt-2 rounded border border-emerald-200 bg-emerald-50 p-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300">
-                  {submitOk}
-                </div>
-              )}
-
               {/* 按鈕列 */}
               <div className="mt-3 flex flex-wrap items-center gap-2">
                 <SpinButton
                   onClick={handleSubmit}
-                  disabled={submitting}
+                  disabled={formLocked}
                   loading={submitting}
                   className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
                 >
-                  送出處理
+                  {pendingRequest ? "資料已鎖定" : "送出處理"}
                 </SpinButton>
-                <button
-                  type="button"
-                  onClick={() => {
-                    requestIdRef.current = newRequestId();
-                    setSubmitError(null);
-                    setSubmitOk(null);
-                  }}
-                  disabled={submitting}
-                  className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs text-zinc-600 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-600 dark:text-zinc-400 dark:hover:bg-zinc-700"
-                >
-                  重新產生 Request ID（改 payload 後按）
-                </button>
               </div>
             </div>
           ) : (
@@ -925,16 +1349,16 @@ export default function HqReturnDispositionPage() {
 
           {/* ── 寫錯數量的指引 ── */}
           <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800">
-            <strong>寫錯數量？</strong>{" "}
-            處理事件一旦送出無法直接修改。如需更正，請前往{" "}
+            <strong>原單收貨數量寫錯：</strong>請前往{" "}
             <Link
               href="/wms/inbound"
               className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400"
             >
-              收貨頁（/wms/inbound）
+              收貨頁
             </Link>{" "}
-            找到原單處理。已處理的批次或已鎖月份需依原單保護機制，不能直接硬改。
-            <strong>不要</strong>用手動調整庫存來「修正」——那會讓帳對不上。
+            找到原單更正。<br />
+            <strong>這次完好、破損或遺失填錯：</strong>處理紀錄目前不能直接修改，也不能靠更改原單收貨量修正；請先停止後續處理並交由主管查核。
+            兩種情況都不要用手動調整庫存硬改，否則實物與帳會對不上。
           </div>
         </section>
       )}

--- a/apps/admin/src/app/(protected)/wms/return-disposition/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/return-disposition/page.tsx
@@ -31,7 +31,7 @@ type BatchRow = {
   source_kind: string;
   source_reason: string | null;
   total_qty: number;
-  unit_cost: number;
+  unit_cost: number | null;
   qty_good: number;
   qty_damaged: number;
   qty_lost: number;
@@ -101,6 +101,12 @@ type PendingRequest = {
 function num(v: unknown): number {
   const n = Number(v);
   return Number.isFinite(n) ? n : 0;
+}
+
+function fmtUnitCost(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "未提供成本";
+  const n = Number(v);
+  return Number.isFinite(n) ? `$${n.toFixed(2)}` : "未提供成本";
 }
 
 function canDisposeReturn(role: Role | null): boolean {
@@ -1008,7 +1014,7 @@ function ReturnDispositionWorkspace({
                       </td>
                       {showCost && (
                         <td className="px-3 py-2 text-right tabular-nums text-xs text-zinc-500">
-                          ${num(b.unit_cost).toFixed(2)}
+                          {fmtUnitCost(b.unit_cost)}
                         </td>
                       )}
                       <td className="px-3 py-2">
@@ -1107,7 +1113,7 @@ function ReturnDispositionWorkspace({
               </div>
               {showCost && (
                 <div className="mt-0.5 text-xs text-zinc-400">
-                  來源入庫紀錄單價 ${num(selected.unit_cost).toFixed(2)}（不是售價，也不是最後認列的損失）
+                  來源入庫紀錄單價 {fmtUnitCost(selected.unit_cost)}（不是售價，也不是最後認列的損失）
                 </div>
               )}
             </div>
@@ -1174,7 +1180,7 @@ function ReturnDispositionWorkspace({
                         </td>
                         {showCost && (
                           <td className="px-2 py-1 text-right tabular-nums text-zinc-400">
-                            ${num(selected.unit_cost).toFixed(2)}
+                            {fmtUnitCost(selected.unit_cost)}
                           </td>
                         )}
                         <td className="px-2 py-1 text-zinc-500">

--- a/apps/admin/src/app/(protected)/wms/return-disposition/page.tsx
+++ b/apps/admin/src/app/(protected)/wms/return-disposition/page.tsx
@@ -1,0 +1,943 @@
+"use client";
+
+// 總倉退回貨待處理（2026-09-07，D 段前端）
+//
+// 資料來源：v_hq_return_batches_list（security_invoker，同 tenant RLS）
+// 處理 RPC：rpc_dispose_hq_return（role 白名單 owner/admin/hq_manager）
+//
+// 店名解析鏈：batch.source_transfer_item_id → transfer_items.transfer_id
+//   → transfers.source_location → locations.name
+// ⛔ 不能猜店名，缺名以 id 明示。
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { fetchAllRows } from "@/lib/fetchAllRows";
+import { translateRpcError } from "@/lib/rpcError";
+import { useRole, isHqRole, canSeeCost } from "@/lib/role";
+import { LoadingBlock } from "@/components/Spinner";
+import SpinButton from "@/components/SpinButton";
+
+// ── 型別 ──
+
+type BatchRow = {
+  id: number;
+  tenant_id: string;
+  location_id: number;
+  sku_id: number;
+  source_movement_id: number;
+  source_transfer_item_id: number | null;
+  source_kind: string;
+  source_reason: string | null;
+  total_qty: number;
+  unit_cost: number;
+  qty_good: number;
+  qty_damaged: number;
+  qty_lost: number;
+  qty_revoked: number;
+  qty_pending: number;
+  status: string;
+  auto_flag: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+};
+
+type EventRow = {
+  id: number;
+  batch_id: number;
+  request_id: string;
+  qty_good: number;
+  qty_damaged: number;
+  qty_lost: number;
+  damage_reason: string | null;
+  loss_reason: string | null;
+  goods_confirmed: boolean;
+  damage_movement_id: number | null;
+  loss_movement_id: number | null;
+  notes: string | null;
+  operator_id: string;
+  created_at: string;
+};
+
+type SkuRow = {
+  id: number;
+  sku_code: string | null;
+  product_name: string | null;
+  variant_name: string | null;
+};
+
+// ── helper ──
+
+function num(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function fmtDate(v: string | null): string {
+  return v ? new Date(v).toLocaleDateString("zh-TW") : "—";
+}
+function fmtDateTime(v: string | null): string {
+  return v ? new Date(v).toLocaleString("zh-TW") : "—";
+}
+
+function skuLabel(s: SkuRow | undefined, id: number): string {
+  if (!s) return `品項#${id}`;
+  return (
+    `${s.product_name ?? ""}${s.variant_name ? ` / ${s.variant_name}` : ""}`.trim() ||
+    s.sku_code ||
+    `#${s.id}`
+  );
+}
+
+const SOURCE_KIND_ZH: Record<string, string> = {
+  store_return: "門市退貨",
+  shortage: "短少",
+};
+
+const STATUS_ZH: Record<string, { label: string; cls: string }> = {
+  pending: {
+    label: "待處理",
+    cls: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  },
+  partial: {
+    label: "部分處理",
+    cls: "bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-300",
+  },
+  completed: {
+    label: "已完成",
+    cls: "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+  },
+  revoked: {
+    label: "已撤回",
+    cls: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400",
+  },
+};
+
+/** Safari-safe UUID（比照 wms/receiving/ipad/page.tsx:247-250） */
+function newRequestId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `r_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+}
+
+/** 小數最多 3 位（不截整），用來把 input 值夾到合法範圍 */
+function clampDecimal(v: string, max: number): string {
+  // 保留使用者輸入的小數位，但不能超過 3 位
+  const m = v.match(/^(\d+)(?:\.(\d{0,3}))?/);
+  if (!m) return "";
+  const clamped = Math.min(Number(m[0]), max);
+  // 維持使用者打的小數型態
+  if (m[2] !== undefined) {
+    const decimals = Math.min(m[2].length, 3);
+    return clamped.toFixed(decimals);
+  }
+  return String(Math.floor(clamped));
+}
+
+const MAX_ROWS = 200;
+
+// ── 主元件 ──
+
+export default function HqReturnDispositionPage() {
+  const role = useRole();
+  const showCost = canSeeCost(role);
+  const allowed = isHqRole(role);
+
+  // ── 批次列表 ──
+  const [batches, setBatches] = useState<BatchRow[]>([]);
+  const [skuMap, setSkuMap] = useState<Map<number, SkuRow>>(new Map());
+  // source_transfer_item_id → 店名
+  const [storeNameMap, setStoreNameMap] = useState<Map<number, string>>(new Map());
+  const [listLoading, setListLoading] = useState(true);
+  const [listError, setListError] = useState<string | null>(null);
+  const [includeHistory, setIncludeHistory] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  // ── 選中的批次 ──
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  // ── 事件列表（選中批次的） ──
+  const [events, setEvents] = useState<EventRow[]>([]);
+  const [eventsLoading, setEventsLoading] = useState(false);
+  const [eventsError, setEventsError] = useState<string | null>(null);
+  const [operatorNames, setOperatorNames] = useState<Map<string, string>>(new Map());
+
+  // ── 處理表單 ──
+  const [fGood, setFGood] = useState("");
+  const [fDamaged, setFDamaged] = useState("");
+  const [fLost, setFLost] = useState("");
+  const [fDamageReason, setFDamageReason] = useState("");
+  const [fLossReason, setFLossReason] = useState("");
+  const [fGoodsConfirmed, setFGoodsConfirmed] = useState(false);
+  const [fNotes, setFNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitOk, setSubmitOk] = useState<string | null>(null);
+  // 冪等 UUID：每次送出用同一個，成功或改 payload 後換新
+  const requestIdRef = useRef(newRequestId());
+
+  const selected = useMemo(
+    () => batches.find((b) => b.id === selectedId) ?? null,
+    [batches, selectedId],
+  );
+
+  // ── 載入批次列表 ──
+  useEffect(() => {
+    if (role === null) return; // 還在讀 role
+    if (!allowed) {
+      setListLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setListLoading(true);
+    (async () => {
+      try {
+        const sb = getSupabase();
+        let q = sb
+          .from("v_hq_return_batches_list")
+          .select("*")
+          .order("created_at", { ascending: false })
+          .limit(MAX_ROWS);
+
+        if (!includeHistory) {
+          q = q.in("status", ["pending", "partial"]);
+        }
+
+        const { data, error } = await q;
+        if (error) throw error;
+        if (cancelled) return;
+        const rows = (data ?? []) as BatchRow[];
+
+        // ── 解析 SKU 名稱 ──
+        const skuIds = Array.from(new Set(rows.map((r) => r.sku_id)));
+        const newSkuMap = new Map<number, SkuRow>();
+        if (skuIds.length > 0) {
+          const skuRows = await fetchAllRows<SkuRow>(() =>
+            sb
+              .from("skus")
+              .select("id, sku_code, product_name, variant_name")
+              .in("id", skuIds)
+              .order("id", { ascending: true }),
+          );
+          for (const s of skuRows) newSkuMap.set(s.id, s);
+        }
+
+        // ── 解析店名：source_transfer_item_id → transfer_items → transfers → locations ──
+        const tiIds = rows
+          .map((r) => r.source_transfer_item_id)
+          .filter((x): x is number => x != null);
+        const uniqueTiIds = Array.from(new Set(tiIds));
+        const newStoreMap = new Map<number, string>();
+
+        if (uniqueTiIds.length > 0) {
+          // 1) transfer_items → 拿 transfer_id
+          const tiRows = await fetchAllRows<{ id: number; transfer_id: number }>(() =>
+            sb
+              .from("transfer_items")
+              .select("id, transfer_id")
+              .in("id", uniqueTiIds)
+              .order("id", { ascending: true }),
+          );
+          const tiToTransfer = new Map<number, number>();
+          for (const ti of tiRows) tiToTransfer.set(ti.id, ti.transfer_id);
+
+          // 2) transfers → 拿 source_location
+          const transferIds = Array.from(new Set(tiRows.map((t) => t.transfer_id)));
+          if (transferIds.length > 0) {
+            const trRows = await fetchAllRows<{
+              id: number;
+              transfer_no: string;
+              source_location: number;
+            }>(() =>
+              sb
+                .from("transfers")
+                .select("id, transfer_no, source_location")
+                .in("id", transferIds)
+                .order("id", { ascending: true }),
+            );
+            const trMap = new Map<number, number>();
+            for (const tr of trRows) trMap.set(tr.id, tr.source_location);
+
+            // 3) locations → 拿 name
+            const locIds = Array.from(new Set(trRows.map((t) => t.source_location)));
+            if (locIds.length > 0) {
+              const { data: lr } = await sb
+                .from("locations")
+                .select("id, name")
+                .in("id", locIds);
+              const locName = new Map<number, string>();
+              for (const l of (lr ?? []) as { id: number; name: string }[])
+                locName.set(l.id, l.name);
+
+              // 組合：tiId → storeName
+              for (const tiId of uniqueTiIds) {
+                const trId = tiToTransfer.get(tiId);
+                if (trId == null) continue;
+                const locId = trMap.get(trId);
+                if (locId == null) continue;
+                const name = locName.get(locId);
+                if (name) newStoreMap.set(tiId, name);
+              }
+            }
+          }
+        }
+
+        if (cancelled) return;
+        setBatches(rows);
+        setSkuMap(newSkuMap);
+        setStoreNameMap(newStoreMap);
+        setListError(null);
+      } catch (err) {
+        if (!cancelled) setListError(translateRpcError(err));
+      } finally {
+        if (!cancelled) setListLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [role, allowed, includeHistory, reloadKey]);
+
+  // ── 載入選中批次的事件 ──
+  useEffect(() => {
+    if (selectedId == null) {
+      setEvents([]);
+      setEventsError(null);
+      return;
+    }
+    let cancelled = false;
+    setEventsLoading(true);
+    setEventsError(null);
+    (async () => {
+      try {
+        const sb = getSupabase();
+        const { data, error } = await sb
+          .from("hq_return_events")
+          .select(
+            "id, batch_id, request_id, qty_good, qty_damaged, qty_lost, damage_reason, loss_reason, goods_confirmed, damage_movement_id, loss_movement_id, notes, operator_id, created_at",
+          )
+          .eq("batch_id", selectedId)
+          .order("created_at", { ascending: true });
+        if (error) throw error;
+        if (cancelled) return;
+        const evts = (data ?? []) as EventRow[];
+
+        // 操作人名稱
+        const uids = Array.from(
+          new Set(evts.map((e) => e.operator_id).filter(Boolean)),
+        );
+        const nameMap = new Map<string, string>();
+        if (uids.length > 0) {
+          const { data: ns } = await sb.rpc("rpc_get_staff_names", {
+            p_uids: uids,
+          });
+          for (const n of (ns as { id: string; display_name: string }[] | null) ?? [])
+            nameMap.set(n.id, n.display_name);
+        }
+
+        if (cancelled) return;
+        setEvents(evts);
+        setOperatorNames(nameMap);
+      } catch (err) {
+        if (!cancelled) setEventsError(translateRpcError(err));
+      } finally {
+        if (!cancelled) setEventsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId, reloadKey]);
+
+  // 清空表單
+  const resetForm = useCallback(() => {
+    setFGood("");
+    setFDamaged("");
+    setFLost("");
+    setFDamageReason("");
+    setFLossReason("");
+    setFGoodsConfirmed(false);
+    setFNotes("");
+    setSubmitError(null);
+    setSubmitOk(null);
+    requestIdRef.current = newRequestId();
+  }, []);
+
+  // 選批次時清表單
+  const handleSelect = useCallback(
+    (id: number) => {
+      setSelectedId((prev) => (prev === id ? null : id));
+      resetForm();
+    },
+    [resetForm],
+  );
+
+  // ── 送出處理 ──
+  const handleSubmit = useCallback(async () => {
+    if (!selected) return;
+    setSubmitError(null);
+    setSubmitOk(null);
+
+    const qGood = num(fGood);
+    const qDamaged = num(fDamaged);
+    const qLost = num(fLost);
+    const total = qGood + qDamaged + qLost;
+
+    if (total <= 0) {
+      setSubmitError("至少要填一種數量（完好/破損/遺失），不能全部是 0。");
+      return;
+    }
+    if (total > num(selected.qty_pending)) {
+      setSubmitError(
+        `本次處理合計 ${total} 超過尚待確認量 ${num(selected.qty_pending)}。`,
+      );
+      return;
+    }
+    if (qGood > 0 && !fGoodsConfirmed) {
+      setSubmitError("完好數量 > 0 時必須勾選「實物已到」。");
+      return;
+    }
+    if (qDamaged > 0 && !fDamageReason.trim()) {
+      setSubmitError("破損數量 > 0 時必須填寫破損原因。");
+      return;
+    }
+    if (qLost > 0 && !fLossReason.trim()) {
+      setSubmitError("遺失數量 > 0 時必須填寫遺失原因。");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const sb = getSupabase();
+      const { data, error } = await sb.rpc("rpc_dispose_hq_return", {
+        p_batch_id: selected.id,
+        p_request_id: requestIdRef.current,
+        p_qty_good: qGood,
+        p_qty_damaged: qDamaged,
+        p_qty_lost: qLost,
+        p_damage_reason: qDamaged > 0 ? fDamageReason.trim() : null,
+        p_loss_reason: qLost > 0 ? fLossReason.trim() : null,
+        p_goods_confirmed: qGood > 0 ? true : false,
+        p_notes: fNotes.trim() || null,
+      });
+      if (error) throw error;
+
+      const result = data as {
+        event_id: number;
+        batch_id: number;
+        idempotent: boolean;
+        new_status?: string;
+      };
+
+      setSubmitOk(
+        result.idempotent
+          ? `✓ 重試成功（同一筆 request，事件 #${result.event_id}）`
+          : `✓ 處理完成（事件 #${result.event_id}${result.new_status === "completed" ? "，此批已全部處理完畢" : ""}）`,
+      );
+
+      // 成功後刷新列表與事件、重設表單
+      // ⚠ 新 requestId 讓下次送出用新的冪等碼
+      requestIdRef.current = newRequestId();
+      setFGood("");
+      setFDamaged("");
+      setFLost("");
+      setFDamageReason("");
+      setFLossReason("");
+      setFGoodsConfirmed(false);
+      setFNotes("");
+      setReloadKey((k) => k + 1);
+    } catch (err) {
+      setSubmitError(translateRpcError(err));
+      // ⚠ 不確定是否已經成功（網路錯誤）→ 保留同一個 requestId，讓使用者可以安全重試
+      // 如果使用者想改 payload，下面有「重新產生」按鈕會換新 id
+    } finally {
+      setSubmitting(false);
+    }
+  }, [selected, fGood, fDamaged, fLost, fDamageReason, fLossReason, fGoodsConfirmed, fNotes]);
+
+  // 等 role 載入
+  if (role === null) return <LoadingBlock />;
+
+  // 權限不足
+  if (!allowed) {
+    return (
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <h1 className="text-xl font-semibold">退回貨處理</h1>
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          權限不足：此頁面僅限總倉管理角色（owner / admin / hq_manager）。
+        </div>
+      </div>
+    );
+  }
+
+  const pending = selected ? num(selected.qty_pending) : 0;
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-6">
+      {/* ── 頁首 ── */}
+      <header>
+        <h1 className="text-xl font-semibold">退回貨處理</h1>
+        <p className="text-sm text-zinc-500">
+          門市退貨與收貨短少回到總倉的批次在這裡處理。完好的會放回可派庫存，破損與遺失會扣總倉帳。
+        </p>
+        <p className="mt-0.5 text-xs text-zinc-400">
+          破損/遺失<strong>不會</strong>對店家收退款；責任歸屬待定，來源成本不等於正式損失認列。
+        </p>
+      </header>
+
+      {/* ── 篩選與操作列 ── */}
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex items-center gap-1.5 text-sm">
+          <input
+            type="checkbox"
+            checked={includeHistory}
+            onChange={(e) => setIncludeHistory(e.target.checked)}
+            className="rounded border-zinc-300 dark:border-zinc-600"
+          />
+          含已完成/已撤回
+        </label>
+        <SpinButton
+          onClick={() => setReloadKey((k) => k + 1)}
+          className="rounded-md border border-zinc-300 bg-white px-3 py-1 text-sm hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700"
+        >
+          重新整理
+        </SpinButton>
+      </div>
+
+      {/* ── 錯誤 ── */}
+      {listError && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+          {listError}
+        </div>
+      )}
+
+      {/* ── 批次表格 ── */}
+      <section className="flex flex-col gap-2">
+        <div className="overflow-x-auto rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+          <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+            <thead className="bg-zinc-50 dark:bg-zinc-900">
+              <tr className="text-left text-xs uppercase tracking-wide text-zinc-500">
+                <th className="px-3 py-2">批次</th>
+                <th className="px-3 py-2">來源</th>
+                <th className="px-3 py-2">店名</th>
+                <th className="px-3 py-2">品項</th>
+                <th className="px-3 py-2">原因</th>
+                <th className="px-3 py-2 text-right">回帳量</th>
+                <th className="px-3 py-2 text-right">待確認</th>
+                <th className="px-3 py-2 text-right">已處理</th>
+                {showCost && <th className="px-3 py-2 text-right">來源單價</th>}
+                <th className="px-3 py-2">狀態</th>
+                <th className="px-3 py-2">建立</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {listLoading ? (
+                <tr>
+                  <td colSpan={showCost ? 11 : 10}>
+                    <LoadingBlock />
+                  </td>
+                </tr>
+              ) : batches.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={showCost ? 11 : 10}
+                    className="p-6 text-center text-zinc-500"
+                  >
+                    {includeHistory
+                      ? "此 tenant 沒有任何退回貨批次（並非代表全系統無資料，僅為本次查詢結果）。"
+                      : "目前沒有待處理的退回貨批次。勾選「含已完成/已撤回」可看歷史。"}
+                  </td>
+                </tr>
+              ) : (
+                batches.map((b) => {
+                  const sv = STATUS_ZH[b.status] ?? {
+                    label: b.status,
+                    cls: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+                  };
+                  const storeName = b.source_transfer_item_id != null
+                    ? storeNameMap.get(b.source_transfer_item_id) ??
+                      `調撥明細#${b.source_transfer_item_id}`
+                    : "—";
+                  const isSelected = selectedId === b.id;
+                  return (
+                    <tr
+                      key={b.id}
+                      onClick={() => handleSelect(b.id)}
+                      className={`cursor-pointer align-top transition-colors ${
+                        isSelected
+                          ? "bg-blue-50 dark:bg-blue-950"
+                          : "hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                      }`}
+                    >
+                      <td className="px-3 py-2 font-mono text-xs">#{b.id}</td>
+                      <td className="px-3 py-2 text-xs">
+                        {SOURCE_KIND_ZH[b.source_kind] ?? b.source_kind}
+                        {b.auto_flag && (
+                          <span className="ml-1 text-[10px] text-zinc-400">
+                            ({b.auto_flag === "system" ? "系統" : "人工"})
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-xs">{storeName}</td>
+                      <td className="px-3 py-2 text-xs">
+                        {skuLabel(skuMap.get(b.sku_id), b.sku_id)}
+                      </td>
+                      <td className="px-3 py-2 text-xs">
+                        {b.source_reason || "—"}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums">
+                        {num(b.total_qty)}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums font-medium text-amber-700 dark:text-amber-400">
+                        {num(b.qty_pending)}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums">
+                        {num(b.qty_good) + num(b.qty_damaged) + num(b.qty_lost)}
+                      </td>
+                      {showCost && (
+                        <td className="px-3 py-2 text-right tabular-nums text-xs text-zinc-500">
+                          ${num(b.unit_cost).toFixed(2)}
+                        </td>
+                      )}
+                      <td className="px-3 py-2">
+                        <span
+                          className={`inline-flex whitespace-nowrap rounded px-2 py-0.5 text-xs font-medium ${sv.cls}`}
+                        >
+                          {sv.label}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-xs text-zinc-500">
+                        {fmtDate(b.created_at)}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+        <p className="text-[11px] text-zinc-400">
+          本次已載入 {batches.length} 筆（上限 {MAX_ROWS}）。
+          {batches.length >= MAX_ROWS &&
+            "已達上限，可能有更多批次未顯示。請縮小條件或聯繫工程師。"}
+          此數字<strong>不代表</strong>全系統總數。
+        </p>
+      </section>
+
+      {/* ── 選中批次的詳情 ── */}
+      {selected && (
+        <section className="flex flex-col gap-4 rounded-md border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div>
+              <h2 className="text-base font-semibold">
+                批次 #{selected.id}
+                <span className="ml-2 text-sm font-normal text-zinc-500">
+                  {skuLabel(skuMap.get(selected.sku_id), selected.sku_id)}
+                </span>
+              </h2>
+              <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">
+                <span>
+                  回帳量 <strong>{num(selected.total_qty)}</strong>
+                </span>
+                <span>
+                  完好 <strong>{num(selected.qty_good)}</strong>
+                </span>
+                <span>
+                  破損 <strong>{num(selected.qty_damaged)}</strong>
+                </span>
+                <span>
+                  遺失 <strong>{num(selected.qty_lost)}</strong>
+                </span>
+                {num(selected.qty_revoked) > 0 && (
+                  <span>
+                    撤回 <strong>{num(selected.qty_revoked)}</strong>
+                  </span>
+                )}
+                <span className="font-medium text-amber-700 dark:text-amber-400">
+                  尚待確認 <strong>{num(selected.qty_pending)}</strong>
+                </span>
+              </div>
+              {showCost && (
+                <div className="mt-0.5 text-xs text-zinc-400">
+                  來源單價依據 ${num(selected.unit_cost).toFixed(2)}
+                  （不是售價，是原出庫 movement 的 unit_cost）
+                </div>
+              )}
+            </div>
+            <button
+              onClick={() => {
+                setSelectedId(null);
+                resetForm();
+              }}
+              className="text-xs text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+            >
+              ✕ 關閉
+            </button>
+          </div>
+
+          {/* ── 處理事件歷史 ── */}
+          <div>
+            <h3 className="mb-1 text-sm font-semibold">處理紀錄</h3>
+            {eventsError && (
+              <div className="mb-2 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+                {eventsError}
+              </div>
+            )}
+            {eventsLoading ? (
+              <LoadingBlock />
+            ) : events.length === 0 ? (
+              <p className="text-xs text-zinc-500">尚未有任何處理事件。</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-zinc-200 text-xs dark:divide-zinc-800">
+                  <thead>
+                    <tr className="text-left text-[10px] uppercase tracking-wide text-zinc-400">
+                      <th className="px-2 py-1">事件</th>
+                      <th className="px-2 py-1 text-right">完好</th>
+                      <th className="px-2 py-1 text-right">破損</th>
+                      <th className="px-2 py-1 text-right">遺失</th>
+                      <th className="px-2 py-1">破損原因</th>
+                      <th className="px-2 py-1">遺失原因</th>
+                      {showCost && <th className="px-2 py-1 text-right">單價依據</th>}
+                      <th className="px-2 py-1">操作人</th>
+                      <th className="px-2 py-1">時間</th>
+                      <th className="px-2 py-1">備註</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                    {events.map((ev) => (
+                      <tr key={ev.id} className="align-top">
+                        <td className="px-2 py-1 font-mono">#{ev.id}</td>
+                        <td className="px-2 py-1 text-right tabular-nums">
+                          {num(ev.qty_good) || "—"}
+                        </td>
+                        <td className="px-2 py-1 text-right tabular-nums">
+                          {num(ev.qty_damaged) || "—"}
+                        </td>
+                        <td className="px-2 py-1 text-right tabular-nums">
+                          {num(ev.qty_lost) || "—"}
+                        </td>
+                        <td className="px-2 py-1 text-zinc-500">
+                          {ev.damage_reason || "—"}
+                        </td>
+                        <td className="px-2 py-1 text-zinc-500">
+                          {ev.loss_reason || "—"}
+                        </td>
+                        {showCost && (
+                          <td className="px-2 py-1 text-right tabular-nums text-zinc-400">
+                            ${num(selected.unit_cost).toFixed(2)}
+                          </td>
+                        )}
+                        <td className="px-2 py-1 text-zinc-500">
+                          {operatorNames.get(ev.operator_id) ?? ev.operator_id}
+                        </td>
+                        <td className="px-2 py-1 text-zinc-500">
+                          {fmtDateTime(ev.created_at)}
+                        </td>
+                        <td className="px-2 py-1 text-zinc-400">
+                          {ev.notes || "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          {/* ── 處理表單（只在有 pending 時顯示） ── */}
+          {pending > 0 ? (
+            <div className="rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800">
+              <h3 className="mb-2 text-sm font-semibold">
+                處理此批（尚待 {pending}）
+              </h3>
+              <p className="mb-3 text-xs text-zinc-500">
+                完好會放回可派庫存（reserved → available）；破損/遺失會寫負 movement 扣總倉帳。
+                不一定要一次全部處理完，剩餘的尚待量會留著。
+              </p>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                {/* 完好 */}
+                <div>
+                  <label className="mb-1 block text-xs font-medium">
+                    完好數量
+                  </label>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    step="any"
+                    min="0"
+                    max={pending}
+                    value={fGood}
+                    onChange={(e) =>
+                      setFGood(clampDecimal(e.target.value, pending))
+                    }
+                    disabled={submitting}
+                    className="w-full rounded-md border border-zinc-300 px-2 py-1.5 text-sm tabular-nums disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
+                    placeholder="0"
+                  />
+                  {num(fGood) > 0 && (
+                    <label className="mt-1 flex items-center gap-1.5 text-xs">
+                      <input
+                        type="checkbox"
+                        checked={fGoodsConfirmed}
+                        onChange={(e) => setFGoodsConfirmed(e.target.checked)}
+                        disabled={submitting}
+                        className="rounded border-zinc-300 dark:border-zinc-600"
+                      />
+                      實物已到（必勾）
+                    </label>
+                  )}
+                </div>
+
+                {/* 破損 */}
+                <div>
+                  <label className="mb-1 block text-xs font-medium">
+                    破損數量
+                  </label>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    step="any"
+                    min="0"
+                    max={pending}
+                    value={fDamaged}
+                    onChange={(e) =>
+                      setFDamaged(clampDecimal(e.target.value, pending))
+                    }
+                    disabled={submitting}
+                    className="w-full rounded-md border border-zinc-300 px-2 py-1.5 text-sm tabular-nums disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
+                    placeholder="0"
+                  />
+                  {num(fDamaged) > 0 && (
+                    <div className="mt-1">
+                      <input
+                        type="text"
+                        value={fDamageReason}
+                        onChange={(e) => setFDamageReason(e.target.value)}
+                        disabled={submitting}
+                        className="w-full rounded-md border border-zinc-300 px-2 py-1 text-xs disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
+                        placeholder="破損原因（必填）"
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {/* 遺失 */}
+                <div>
+                  <label className="mb-1 block text-xs font-medium">
+                    遺失數量
+                  </label>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    step="any"
+                    min="0"
+                    max={pending}
+                    value={fLost}
+                    onChange={(e) =>
+                      setFLost(clampDecimal(e.target.value, pending))
+                    }
+                    disabled={submitting}
+                    className="w-full rounded-md border border-zinc-300 px-2 py-1.5 text-sm tabular-nums disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
+                    placeholder="0"
+                  />
+                  {num(fLost) > 0 && (
+                    <div className="mt-1">
+                      <input
+                        type="text"
+                        value={fLossReason}
+                        onChange={(e) => setFLossReason(e.target.value)}
+                        disabled={submitting}
+                        className="w-full rounded-md border border-zinc-300 px-2 py-1 text-xs disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
+                        placeholder="遺失原因（必填）"
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* 備註 */}
+              <div className="mt-3">
+                <label className="mb-1 block text-xs font-medium">
+                  備註（選填）
+                </label>
+                <input
+                  type="text"
+                  value={fNotes}
+                  onChange={(e) => setFNotes(e.target.value)}
+                  disabled={submitting}
+                  className="w-full rounded-md border border-zinc-300 px-2 py-1.5 text-sm disabled:opacity-60 dark:border-zinc-600 dark:bg-zinc-700"
+                  placeholder="處理備註"
+                />
+              </div>
+
+              {/* 提交結果 */}
+              {submitError && (
+                <div className="mt-2 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+                  {submitError}
+                  <div className="mt-1 text-[10px] text-zinc-400">
+                    如果是網路中斷，可以直接再按一次送出（同一個 request UUID 會安全重試）。
+                    如果你想<strong>改數量</strong>再送，請先按下面的「重新產生 Request ID」。
+                  </div>
+                </div>
+              )}
+              {submitOk && (
+                <div className="mt-2 rounded border border-emerald-200 bg-emerald-50 p-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300">
+                  {submitOk}
+                </div>
+              )}
+
+              {/* 按鈕列 */}
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <SpinButton
+                  onClick={handleSubmit}
+                  disabled={submitting}
+                  loading={submitting}
+                  className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
+                >
+                  送出處理
+                </SpinButton>
+                <button
+                  type="button"
+                  onClick={() => {
+                    requestIdRef.current = newRequestId();
+                    setSubmitError(null);
+                    setSubmitOk(null);
+                  }}
+                  disabled={submitting}
+                  className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs text-zinc-600 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-600 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                >
+                  重新產生 Request ID（改 payload 後按）
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300">
+              {selected.status === "completed"
+                ? "✓ 此批已全部處理完畢。"
+                : selected.status === "revoked"
+                  ? "此批已被撤回。"
+                  : "此批尚待量為 0。"}
+            </div>
+          )}
+
+          {/* ── 寫錯數量的指引 ── */}
+          <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800">
+            <strong>寫錯數量？</strong>{" "}
+            處理事件一旦送出無法直接修改。如需更正，請前往{" "}
+            <Link
+              href="/wms/inbound"
+              className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400"
+            >
+              收貨頁（/wms/inbound）
+            </Link>{" "}
+            找到原單處理。已處理的批次或已鎖月份需依原單保護機制，不能直接硬改。
+            <strong>不要</strong>用手動調整庫存來「修正」——那會讓帳對不上。
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/components/StoreReturnCreateModal.tsx
+++ b/apps/admin/src/components/StoreReturnCreateModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Modal } from "@/components/Modal";
 import SpinButton from "@/components/SpinButton";
+import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
 
@@ -151,11 +152,14 @@ export default function StoreReturnCreateModal({
   }
 
   const totalQty = useMemo(() => lines.reduce((a, l) => a + l.qty, 0), [lines]);
-  const canSubmit = !busy && reason !== "" && lines.length > 0 && lines.every((l) => l.qty > 0);
+  // ⛔ 「少收」不可以從這裡送出通用退貨（會跟收貨差額重複），canSubmit 直接擋掉。
+  const canSubmit =
+    !busy && reason !== "" && reason !== "少收" && lines.length > 0 && lines.every((l) => l.qty > 0);
 
-  async function submit() {
-    // canSubmit 裡已經有 reason !== ""，TypeScript 會沿著它把型別收斂掉，
-    // 這裡再寫一次 reason === "" 會被判成永遠不成立的比較（TS2367）。
+ async function submit() {
+    // 雙重防衛：即使按鈕 disabled 被繞過，少收也絕對不能走通用退貨。先擋少收再查 canSubmit，
+    // 避免 canSubmit 把 reason 窄化後 TypeScript 判定 reason === "少收" 永假（TS2367）。
+    if (reason === "少收") return;
     if (!canSubmit) return;
     const summary = lines.map((l) => `　・${skuLabel(l)} × ${l.qty}`).join("\n");
     if (
@@ -331,10 +335,29 @@ export default function StoreReturnCreateModal({
             </p>
           )}
           {reason === "少收" && (
-            <p className="mt-1 rounded-md border border-amber-300 bg-amber-50 p-2 text-[11px] text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
-              ⚠ 如果是<strong>某一張調撥單收到的數量不對</strong>，請直接在「收貨」頁把實收數字改對 ——
-              那條路總倉會看到差額、錢也會自動跟著算。這裡送出的是「把貨退回總倉」，兩邊都做會重複。
-            </p>
+            <div className="mt-1 rounded-md border border-amber-300 bg-amber-50 p-3 text-[11px] text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
+              <p className="font-semibold">⛔ 少收不能從這裡送出退貨。</p>
+             <p className="mt-1">
+                已收過的派貨單，請{" "}
+                <Link
+                  href="/wms/inbound"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-semibold text-amber-800 underline hover:text-amber-600 dark:text-amber-200 dark:hover:text-amber-100"
+                >
+                  另開收貨頁處理少收
+                </Link>
+                ，切到「已收」分頁，挑原本那張派貨單，按「明細 / 改實收」把數字改對。差額會送到總倉處理，後續依總倉回覆與月結規則算帳。
+                尚未收貨的，選原單核對實收即可。
+                從這裡送退貨的話，兩邊都做會重複。
+              </p>
+              {lines.length > 0 && (
+                <p className="mt-1.5 rounded border border-amber-400/50 bg-amber-100/50 px-2 py-1 dark:border-amber-700 dark:bg-amber-900/50">
+                  ⚠ 你已經選了 {lines.length} 項商品，選「少收」不會送出這些品項。
+                  如果要退破損／過期／客人退的貨，請改選其他原因。
+                </p>
+              )}
+            </div>
           )}
         </div>
 

--- a/apps/admin/src/components/TransferShortageResolveModal.tsx
+++ b/apps/admin/src/components/TransferShortageResolveModal.tsx
@@ -18,10 +18,8 @@
 //   2026-08-21 上一版在紅框裡寫了一句沒查證的推論(「古華那筆沒有任何人能再派它」),
 //   Codex 審的是「程式對不對」,抓不到「畫面上寫的話是不是真的」⇒ 整輪審過了還是錯的。
 //   ⛔ 查不到出處的話寧可少講一句。⛔ 不要寫「永遠」「沒有任何人」這種絕對句。
-//   (那句話錯在只查了派貨工作台的路 1。路 2 補貨申請的可配量直接讀總倉真實庫存
-//    stock_balances.on_hand —— v_picking_demand_no_po 最新版
-//    20260612000040_approve_restock_via_picking_workstation.sql:73-78 的 hq_supply CTE
-//    ⇒ 貨記回總倉之後,開一張補貨申請就派得出去。古華等兩個月的真因是沒人知道要開申請。)
+//   (2026-09-07 起補貨工作台只把「帳上扣掉凍結」算成可派量；短少記回總倉後會先凍結，
+//    必須完成貨況確認才可能再派，不能把記回帳上直接說成貨已經可用。)
 //
 // ⭐⭐ 2026-08-21 複審抓到的病(留著當通則,原始情境已隨「客人在等」那一塊移除):
 //   「畫面上先寫一句只在某些情況成立的話,再靠另一個查詢/另一個框去更正它」。
@@ -80,8 +78,10 @@
 //   ⛔ 只動畫面,零 RPC 變更、零 migration。
 //   📌 那 31 筆要不要把貨沖回總倉＝**另一個案子**(老闆已裁示要做),不在本檔。
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { useRole } from "@/lib/role";
 import { translateRpcError } from "@/lib/rpcError";
 import SpinButton from "@/components/SpinButton";
 import { Modal } from "@/components/Modal";
@@ -191,7 +191,7 @@ const RESOLUTION_OPTIONS: Array<OptionDef<"redispatch" | "restock_hq">> = [
     //   ⚠️ 兩顆的 desc 因此變得很像 —— 差別靠標題(補貨/不補貨)、
     //     靠 srcIsHq === true 那塊講清楚,而 srcIsHq 還在查的時候送出鈕是鎖住的
     //     (見下面 srcChecking),所以那段時間看不懂也按不下去。
-    desc: "少收的數量以原出庫成本記回「原本送貨出去的那一邊」。",
+    desc: "少收的數量會先記回原本送貨出去那一邊的帳；補派會另外開單，不代表這批貨已經找到或驗完。",
     warnTone: "info",
     // 出處:記回原出貨端 20260811020000:194-204
     //      (rpc_inbound 的 p_location_id => v_transfer.source_location,不是寫死總倉)。
@@ -202,7 +202,8 @@ const RESOLUTION_OPTIONS: Array<OptionDef<"redispatch" | "restock_hq">> = [
     // ⛔ 六審一併清掉:原本開頭寫「要再送一批給這家店 → 選這顆」——那也是一句隱含的承諾
     //   (「選這顆＝會再送一批」),對非總倉的單同樣不成立。要選哪顆看標題就好。
     warn:
-      "送出後這一筆會從「異常」清單消失。按錯了可以到「異常 → 已處理」按「撤銷」，" +
+      "若來源是總倉，這次記回的數量會先凍結等貨況確認，不能直接拿來補派。送出後這一筆會從「異常」清單消失。" +
+      "按錯了可以到「異常 → 已處理」按「撤銷」，" +
       "但補派的撿貨單一旦「派貨出倉」就撤不掉了。",
   },
   {
@@ -210,16 +211,13 @@ const RESOLUTION_OPTIONS: Array<OptionDef<"redispatch" | "restock_hq">> = [
     icon: "🏭",
     // ⛔ 同上（老闆 2026-09-02 §刀2 的新定案）。
     title: "不補貨",
-    desc: "少收的數量以原出庫成本記回「原本送貨出去的那一邊」，不會自動再送給店家。",
+    desc: "少收的數量會先記回原本送貨出去那一邊的帳，不代表實物已經退回，也不會自動再送給店家。",
     warnTone: "caution",
     // 出處:記回原出貨端 20260811020000:152-162
     //      (同樣是 p_location_id => v_transfer.source_location;
     //       ⚠️ restock_hq 這一支「沒有」總倉守衛 —— redispatch 有 :173-177 擋非總倉,
     //       restock_hq 沒有 ⇒ 店對店的單按這顆,貨是回到原本那家店,不是總倉)。
-    // ⛔ 這裡刻意不寫「開補貨申請就派得出去」:那條路的可配量 hq_supply 讀的是
-    //    「總倉的」stock_balances.on_hand(v_picking_demand_no_po 最新版
-    //    20260612000040:60-78)⇒ 只有貨真的回到總倉才成立。
-    //    它被移到下面 srcIsHq === true 才顯示的那一塊。
+    // 2026-09-07 起，總倉短少記回會先凍結；貨況確認完好前不會算進補貨工作台的可派量。
     warn:
       "送出後這一筆會從「異常」清單消失，而且系統不會自動再送貨給這家店 —— " +
       "之後要補給這家店，得另外開單。按錯了可以到「異常 → 已處理」按「撤銷」，" +
@@ -241,7 +239,7 @@ const REPLY_OPTIONS: Array<OptionDef<Reply>> = [
     value: "agree",
     icon: "✅",
     title: "同意退",
-    desc: "少收的數量記回「原本送貨出去的那一邊」。選了之後再決定要不要補貨給這家店。",
+    desc: "少收的數量會先記回「原本送貨出去的那一邊」的帳，不代表實物已經退回。選了之後再決定要不要補貨給這家店。",
     warnTone: "info",
     warn: "選「同意退」還要再選一次「補貨」或「不補貨」，才會真的送出。",
   },
@@ -331,6 +329,8 @@ export function TransferShortageResolveModal({
   onClose: () => void;
   onSubmitted: () => void;
 }) {
+  const role = useRole();
+  const canOpenDisposition = role === "owner" || role === "admin" || role === "hq_manager";
   // 刀 2 v2：兩步。第 1 步選同意/不同意，第 2 步（只有同意才出現）選補貨/不補貨。
   const [reply, setReply] = useState<Reply | null>(null);
   const [restock, setRestock] = useState<"redispatch" | "restock_hq" | null>(null);
@@ -563,7 +563,7 @@ export function TransferShortageResolveModal({
           <div className="rounded border border-zinc-300 bg-zinc-50 p-2 text-[11px] leading-relaxed text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
             這張單是<span className="font-bold">總倉</span>派出去的。
             <div className="mt-0.5">
-              選「<span className="font-bold">同意退</span>」→ 系統會把少收的數量<span className="font-bold">記一筆退回</span>，
+              選「<span className="font-bold">同意退</span>」→ 系統會把少收的數量<span className="font-bold">記一筆帳務退回</span>，
               月結重算時就會從這家店的帳上扣掉，不用另外開人工調整。
             </div>
             <div className="mt-0.5">
@@ -635,13 +635,22 @@ export function TransferShortageResolveModal({
             這張單是<span className="font-bold">總倉</span>派出去的 →
             下面兩顆說的「原本送貨出去的那一邊」就是總倉。
             <div className="mt-0.5">
-              選「<span className="font-bold">補貨</span>」會自動開一張撿貨單給這家店，
-              出現在收件匣的「📋 撿貨單」，樓下撿完再送一次。
+              選「<span className="font-bold">補貨</span>」會另外開一張補派撿貨單。
+              出貨時只能拿<span className="font-bold">其他已確認可派的好貨</span>；
+              這次記回的數量會先凍結等貨況確認，不能直接拿來補派。
+              其他可派貨不夠時，剩下的需求會保留，等有可派貨再處理。
             </div>
             <div className="mt-0.5">
-              選「<span className="font-bold">不補貨</span>」的話，貨記回總倉之後就算進總倉的可配量 ——
-              之後要補給這家店，請該店開一張補貨申請，總倉核准後就能直接派，不用再進一次貨
-              （要是這批貨先被別的單配走了，就得等下一批）。
+              選「<span className="font-bold">不補貨</span>」會先把數量記回總倉帳上並凍結。
+              總倉確認貨況完好後，這批才會變成可派；帳回不表示實物已到或已驗完。
+              {canOpenDisposition && (
+                <>
+                  {" "}
+                  <Link href="/wms/return-disposition" className="font-semibold text-blue-700 underline underline-offset-2 dark:text-blue-300">
+                    前往退回貨處理
+                  </Link>
+                </>
+              )}
             </div>
             {/* ⚠️ 錢的話只放在這一塊,不放預設文案 —— 沖帳單只對「總倉派給店家」的單產生
                 (20260901000010_shortage_return_booking.sql:296-300 的四道條件),
@@ -649,8 +658,9 @@ export function TransferShortageResolveModal({
                 ⛔ 措辭不寫「一定會退到多少錢」:金額是月結重算時才算出來的,
                   而且分店價改過版的商品會有差額(見該檔檔頭的⚠️那段)。 */}
             <div className="mt-0.5">
-              兩顆都會把少收的數量<span className="font-bold">記一筆退回</span>，
+              兩顆都會把少收的數量<span className="font-bold">記一筆帳務退回</span>，
               月結重算時就會從這家店的帳上扣掉，不用另外開人工調整。
+              若處理當下的分店價和原本派車時不同，退回金額可能會有價差，請核對月結明細。
             </div>
           </div>
         )}
@@ -660,10 +670,8 @@ export function TransferShortageResolveModal({
             ⇒ 查詢還沒回來 / 查不到的時候,畫面上不會有這句話,自然不會說謊。
             出處:自動開 draft 撿貨單 20260811020000:221-243(wave_code → picking_waves →
             picking_wave_items);draft 在收件匣撿貨單匣算待處理 = hq/inbox/page.tsx 的 classifyPicking(:208-212,draft/picking/picked 都算 pending)。
-            出處:可配量 hq_supply 直接讀總倉 stock_balances.on_hand
-            (v_picking_demand_no_po 最新版 20260612000040:60-78),不需要採購單、不需要進貨單。
-            ⚠️ 最後那個括號不是廢話:hq_supply 讀的是「當下的」on_hand,回總倉的貨並沒有被
-            這家店保留住,別的需求先配走就沒了 ⇒ 不加這句就會變成一句「一定派得到」的保證。 */}
+            2026-09-07 新口徑：補派單可以建立，但實際出貨只能用總倉當下未凍結的可派量；
+            本次短少記回的量會先凍結，貨況確認完好前不能拿來補派。 */}
 
         {/* ⛔ 這裡刻意不寫「退回原本那家店」,而是沿用上面兩顆的同一個講法。
             locations.type 現在的 CHECK 只有 'central_warehouse' / 'store' 兩種

--- a/docs/return-disposition-available-contract.md
+++ b/docs/return-disposition-available-contract.md
@@ -1,0 +1,31 @@
+# 總倉退回貨處理 — F 後端可派量契約
+
+Migration: `20260907040000_hq_return_disposition_available.sql`
+
+## 後端規則
+
+- `rpc_create_store_return` 公開 signature 與原本的 tenant、店別、預鎖、待退量、建單和回傳行為不變。
+- 通用退貨只收「破損／過期／客人退」。傳「少收」會整筆拒絕，並引導回 `/wms/inbound` 找原派貨單「修改實收」。
+- 通用退貨在 cast、聚合或寫入 `NUMERIC(18,3)` 前先驗原始 `qty`：只收有限正數且最多 3 位小數；不接受 `NaN`、`Infinity`、0、負數或 `1.0001`，也不靜默四捨五入。
+- `v_picking_demand_no_po.gr_qty` 的對外欄名不變，數字改為 `GREATEST(HQ on_hand - HQ reserved, 0)`。PO 的累計實收 `gr_qty` 沒有被改口徑。
+- `rpc_create_wave_from_restock` 公開 signature、`approved_transfer`、只派申請店、申請剩餘量、已 wave 去重、建單與回傳行為不變。
+- 這支舊 RPC 原本沒有額外的角色白名單；本輪仍以補貨申請的 tenant 為資料邊界，`p_operator` 沿用原行為只寫建單人。F 沒有宣稱補齊全站舊 RPC 權限。
+- 建 wave 前先依 SKU 固定順序鎖住 HQ `stock_balances`，再驗 `on_hand - reserved`。不足時整筆 rollback，不建 wave，補貨需求仍留在原狀態。
+- 分配數量只收有限正數、最多 3 位小數；SKU 不屬本 tenant 會直接拒絕，不會在聚合時靜默消失。
+
+## 與 B 的實物／帳務分界
+
+- 店家真退貨的 `transfer_in` 只建一筆待確認保留量。
+- `restock_hq` / `redispatch` 真回帳的 `transfer_cancel` 也各只建一筆待確認保留量。
+- 它們另建的 `return_to_hq` 短收沖帳子單沒有 `in_movement_id`，不是第二批實物，不可重複建保留量。
+
+## 本輪不改、F-UI 下輪必須收斂的文字
+
+- `TransferShortageResolveModal.tsx` 仍寫 `hq_supply` 直接讀 `stock_balances.on_hand`；必須改成「可派 = 帳上 - 待確認保留量」，並刪掉「回帳後沒有被保留」的過期說法。
+- `wms/picking/page.tsx` 的 `RestockRow.gr_qty`、「HQ 庫存」tooltip與「庫存」字樣仍把欄位說成 `on_hand`；必須改為「HQ 可派」，不可再冒充帳上數。
+- `inventory/page.tsx` 已經讀到 `reserved`，但仍留著「reserved 全站沒維護／恒為 0」舊說法。總倉列必須明列「帳上」「待確認」「可派」三個不混用的數字。
+
+## 整合依賴
+
+- F 要吃到 A/B 已把未確認量正確加入 `stock_balances.reserved`；A 仍要保留現有公開 signature 與必要欄位。
+- C 還必須負責原單撤回／更正時把保留量一起撤掉或拒絕；F 單獨正確不代表整包已可上線。

--- a/docs/return-disposition-available-review.md
+++ b/docs/return-disposition-available-review.md
@@ -1,0 +1,131 @@
+# 總倉退回貨處理：F 可派量／一般退貨複審
+
+審查者：Codex GPT-5.5 阿審
+日期：2026-09-07
+範圍：只審 F 最新版 `supabase/migrations/20260907040000_hq_return_disposition_available.sql` 與 `docs/return-disposition-available-contract.md`。不審 C 撤回／原單更正，不碰功能碼，不連 GitHub / Supabase / 正式資料。
+
+結論：F 補貨「只能吃已確認好貨」主線已守住；但一般店家退貨 RPC 仍接受四位小數數量，列 P1，建議退修後再放行整包。
+
+## P0
+
+- 0。
+
+## P1
+
+### P1-1：一般店家退貨仍接受四位小數數量
+
+位置：
+
+- `supabase/migrations/20260907040000_hq_return_disposition_available.sql:88-92`
+
+實碼目前在通用退貨 `rpc_create_store_return` 裡直接做：
+
+```sql
+v_qty := (v_line ->> 'qty')::NUMERIC;
+```
+
+這和同一支 F 裡補貨建單的寫法不同。補貨建單已先用文字規則擋有限正數與最多 3 位小數，位置 `:359-384`；一般退貨沒有同等檢查。
+
+本機實測：
+
+```powershell
+node tests\return-disposition-review\source-available-runtime.cjs --db-name return_disposition_test_bf_review --case f_restock_available,f_restock_inputs,f_old_restock_available_baseline,f_restock_balance_race,f_store_return
+```
+
+結果：exit 1。
+
+- `f_store_return` FAIL：`qty='1.0001'` 應拒絕但實際成功。
+- 同組測試中 `NaN`、`Infinity` 沒出現在失敗清單，表示本次未觀察到它們被接受；目前紅點是四位小數已確定可送過。
+
+白話風險：
+
+- 做了現在這版：店家退貨數量可以送 `1.0001` 這種系統不該接受的數字，後面進 `numeric(18,3)` 或 transfer line 時可能被四捨五入或用不一致的數量記帳。
+- 不修：補貨那邊已經要求「最多 3 位小數」，一般退貨卻比較鬆，之後對帳時會出現「使用者送的數字」和「系統留下的數字」不完全一致。
+
+最小修法：
+
+- `rpc_create_store_return` 也改成和 `rpc_create_wave_from_restock` 一樣，先保留原始文字 `qty_text`。
+- 用同等規則拒絕空值、NaN、Infinity、負數、0、超過 3 位小數，再 cast 成 numeric。
+- 不要靠 numeric 欄位或後段 insert 自動幫忙修正。
+
+## P2
+
+- 0。
+
+## 已核實正確 / 不列問題
+
+- 一般退貨「少收」已被擋在通用退貨入口，位置 `supabase/migrations/20260907040000_hq_return_disposition_available.sql:45`；本機 `f_store_return` 也驗到「少收」會拒絕。
+- 一般退貨的三個合法原因 `破損`、`過期`、`客人退` 仍可建單，且結果 `stock_moved=false`，沒有回到舊版直接搬庫存的行為。
+- 補貨需求 view 已把總倉供給改成 `on_hand - reserved`，位置 `:258`，並有 `GRANT SELECT` 給 authenticated，位置 `:304`。
+- 補貨建 wave 前會鎖補貨申請與總倉 balance，位置 `:336`、`:409-420`，再用 `on_hand - reserved` 後端守門，位置 `:451-462`。
+- 補貨分配已驗 raw qty：有限正數、最多 3 位小數，位置 `:359-384`。
+- 建 draft wave 不會先加 reserved；本機 `f_restock_available` 驗證建 10 件 draft 後 `stock_balances.reserved` 不變。
+
+## 本機實跑證據
+
+### B/F 測試器語法
+
+```powershell
+node --check tests\return-disposition-review\source-available-runtime.cjs
+```
+
+結果：exit 0。
+
+### F 主測群
+
+資料庫：`return_disposition_test_bf_review`，由 `return_disposition_test_flow_base1` 複製，已套本輪 F 與真 `20260612000060` 前置。只是假庫。
+
+```powershell
+node tests\return-disposition-review\source-available-runtime.cjs --db-name return_disposition_test_bf_review --case f_restock_available,f_restock_inputs,f_old_restock_available_baseline,f_restock_balance_race,f_store_return
+```
+
+結果：exit 1。
+
+- PASS `f_restock_available`：15 帳 / 5 reserved 時 view 只顯示 10 可派；draft 15 被拒；draft 10 不增加 reserved；同申請剩 5 時再配 6 被拒。
+- PASS `f_restock_inputs`：補貨 qty 四位小數、NaN、錯 tenant SKU、錯店都拒絕；同 SKU 重複兩行 4+6 會累加成 10。
+- PASS `f_old_restock_available_baseline`：同一測試把舊版 `rpc_create_wave_from_restock` 套回去時，15 帳 / 5 reserved 仍會建 draft 15，證明測試抓得到舊錯版。
+- PASS `f_restock_balance_race`：一條連線先把同一總倉 SKU reserved 從 0 改成 5 且不提交，另一條同時建 draft 15 會真的等 row lock；第一條提交後，第二條重看可派量並拒絕。
+- FAIL `f_store_return`：一般退貨 `qty='1.0001'` 被接受。
+
+### 連線收尾
+
+```powershell
+node -e 'const {Client}=require("pg");(async()=>{const c=new Client({host:"127.0.0.1",port:56427,user:"returnlocal",database:"postgres"});await c.connect();const sql="select datname,count(*)::int as n from pg_stat_activity where datname = any($1::text[]) and pid <> pg_backend_pid() group by datname order by datname";const r=await c.query(sql,[["return_disposition_test_core_a_fix","return_disposition_test_bf_review","return_disposition_test_flow_base1"]]);console.log(JSON.stringify(r.rows));await c.end();})().catch(e=>{console.error(e.stack||e.message);process.exit(1);})'
+```
+
+結果：`[]`，沒有殘留連線。
+
+## 邊界說明
+
+- F 沒有宣稱重做舊 `rpc_create_wave_from_restock` 的完整角色白名單與 caller tenant 比對；這是舊入口既有邊界，本輪只核它沒有因「可派量」修改而退化。
+- C 撤回／原單更正尚未納入本報告；不能把本報告當整包退貨流程驗收。
+- 本報告只用本機假資料庫驗證，不是正式系統驗收。
+
+## 2026-09-07 F P1 小修複審
+
+資料庫：`return_disposition_test_full_v1`
+
+F SQL hash（CEO 建庫時回報）：`3349DFFD8F091BFF71617240C4851C3C341E47D07B01F2D49C694B8B1B50DDA2`
+
+阿審獨立實跑：
+
+```powershell
+node --check tests\return-disposition-review\source-available-runtime.cjs
+node tests\return-disposition-review\source-available-runtime.cjs --db-name return_disposition_test_full_v1 --case f_store_return
+```
+
+結果：
+
+- `node --check`：exit 0。
+- `f_store_return`：PASS。
+
+複審結論：
+
+- 原 P1「一般店家退貨仍接受四位小數數量」已關閉。
+- 同一組測試仍確認：少收不可從一般退貨入口送出；`破損`、`過期`、`客人退` 三個合法原因仍可建單，且沒有直接搬庫存。
+
+本輪 F 判定：
+
+- P0：0。
+- P1：0。
+- P2：0。

--- a/docs/return-disposition-core-contract.md
+++ b/docs/return-disposition-core-contract.md
@@ -1,0 +1,46 @@
+# 總倉退回貨處理 — A 核心 API 契約
+
+Migration: `20260907010000_hq_return_disposition_core.sql`
+
+## 表
+
+| 表 | 用途 |
+|---|---|
+| `hq_return_batches` | 批次：每筆來源 movement 唯一，追蹤 good/damaged/lost/revoked/pending |
+| `hq_return_events` | 處理事件：append-only，每次分配一筆，request_id 冪等 |
+
+## 內部 Helper
+
+### `_hq_hold_return(...) → BIGINT`
+
+建批次＋凍結 `reserved`。**REVOKE** PUBLIC/anon/authenticated，僅供後端安全呼叫（B 段接線）。同 `source_movement_id` 冪等回傳既有 id。需：movement quantity > 0、同 tenant、SKU 匹配、location type = `central_warehouse`。
+
+## 前端 RPC
+
+### `rpc_dispose_hq_return(p_batch_id, p_request_id, p_qty_good, p_qty_damaged, p_qty_lost, p_damage_reason, p_loss_reason, p_goods_confirmed, p_notes) → JSONB`
+
+處理退回批次。Role 白名單：owner/admin/hq_manager。`auth.uid()` 為操作者。
+
+- 分次或一次處理（如 10 = 7好 + 2破 + 1失）
+- 全 0 / 負數 / 超過 pending → 拒絕
+- 破損/遺失需原因；好貨需 `goods_confirmed = true`
+- `p_request_id` UUID 冪等：重試回原結果，payload 不同拒絕
+- 破損寫 `hq_return_damage` 負 movement；遺失寫 `hq_return_loss` 負 movement
+- 好貨不寫 movement（從 reserved 釋放回 available）
+- 鎖順序：batch → balance
+
+回傳：`{ event_id, batch_id, idempotent, qty_good, qty_damaged, qty_lost, damage_movement_id, loss_movement_id, new_status }`
+
+## Guard Trigger
+
+`trg_guard_hq_pending`（BEFORE INSERT on stock_movements）：有 pending 批次的 (tenant, location, sku)，任何負 movement 不能讓 on_hand 跌破 pending 總量。本案自己先減 pending 再寫 movement，不被擋。無 pending 的 SKU 與店鋪不受影響。
+
+## List View
+
+`v_hq_return_batches_list`（security_invoker）：同 tenant 可讀，帶 `qty_pending` 計算欄。UI 可依 `sku_id` / `source_transfer_item_id` join 品名店名，不跨 tenant。
+
+## 不在 A 範圍
+
+- B：來源接線（store_return / shortage → `_hq_hold_return`）
+- C：原單更正/撤回、月鎖
+- D：前端 UI、本機測試

--- a/docs/return-disposition-core-contract.md
+++ b/docs/return-disposition-core-contract.md
@@ -13,7 +13,9 @@ Migration: `20260907010000_hq_return_disposition_core.sql`
 
 ### `_hq_hold_return(...) → BIGINT`
 
-建批次＋凍結 `reserved`。**REVOKE** PUBLIC/anon/authenticated，僅供後端安全呼叫（B 段接線）。同 `source_movement_id` 冪等回傳既有 id。需：movement quantity > 0、同 tenant、SKU 匹配、location type = `central_warehouse`。
+建批次＋凍結 `reserved`。**REVOKE** PUBLIC/anon/authenticated，僅供後端安全呼叫（B 段接線）。`source_transfer_item_id` 必填；movement、item、父 transfer 必須逐項吻合 tenant、HQ location、SKU、來源種類、原單與數量。movement 的 `source_doc_line_id` 可為 NULL（真收貨既有行為），有值時必須等於 item id；item 的 `in_movement_id`／`shortage_restock_movement_id` 必須反向指回 movement。同 `source_movement_id` 重試會核對完整 payload，一致才回既有 id，不一致拒絕。來源成本原值保存，NULL 不猜成 0。
+
+鎖順序：先鎖同 tenant/location/SKU 的 `stock_balances`，再讀／鎖既有 batch；與處理 RPC、負異動 guard 一致。
 
 ## 前端 RPC
 
@@ -22,22 +24,23 @@ Migration: `20260907010000_hq_return_disposition_core.sql`
 處理退回批次。Role 白名單：owner/admin/hq_manager。`auth.uid()` 為操作者。
 
 - 分次或一次處理（如 10 = 7好 + 2破 + 1失）
-- 全 0 / 負數 / 超過 pending → 拒絕
+- NULL／非有限值／負數／超過 3 位小數／超界／全 0／超過 pending → 精準拒絕，不先 cast 四捨五入
 - 破損/遺失需原因；好貨需 `goods_confirmed = true`
-- `p_request_id` UUID 冪等：重試回原結果，payload 不同拒絕
-- 破損寫 `hq_return_damage` 負 movement；遺失寫 `hq_return_loss` 負 movement
+- `p_request_id` UUID 必填；同 tenant/request 由 transaction advisory lock 序列化。重試核對三個數量、兩個原因、`goods_confirmed`、備註，NULL／空白先用同一規則正規化；一致回第一次完整原結果（含當時 `new_status`），不同拒絕且不重扣
+- 破損沿用 `damage` 負 movement；遺失沿用 `manual_adjust`，兩者皆以 `source_doc_type='hq_return_batch'` 與 batch id 留單據鏈，不新增全域 movement 類型
 - 好貨不寫 movement（從 reserved 釋放回 available）
-- 鎖順序：batch → balance
+- 鎖順序：先未鎖查 batch 定位鍵，再 `balance → batch`，鎖後重讀 batch 與 pending
+- 處理前要求 `reserved >=` 同 tenant/location/SKU 的全部 pending，且 `on_hand` 足夠本次破損＋遺失實際扣量；不一致直接拒絕
 
 回傳：`{ event_id, batch_id, idempotent, qty_good, qty_damaged, qty_lost, damage_movement_id, loss_movement_id, new_status }`
 
 ## Guard Trigger
 
-`trg_guard_hq_pending`（BEFORE INSERT on stock_movements）：有 pending 批次的 (tenant, location, sku)，任何負 movement 不能讓 on_hand 跌破 pending 總量。本案自己先減 pending 再寫 movement，不被擋。無 pending 的 SKU 與店鋪不受影響。
+`trg_guard_hq_pending`（BEFORE INSERT on stock_movements）：負 movement 一律先鎖同 (tenant, location, sku) balance，再重讀全部 pending；因此即使鎖前 pending=0，也不會漏掉同時建立中的 hold。任何負 movement 不能讓 on_hand 跌破 pending 總量。本案自己在同一把鎖內先減 pending 再寫 movement，不被擋。鎖後仍無 pending 的 SKU 不改原負庫存政策。trigger function 為固定 search_path 的 SECURITY DEFINER，且撤銷前端執行權。
 
 ## List View
 
-`v_hq_return_batches_list`（security_invoker）：同 tenant 可讀，帶 `qty_pending` 計算欄。UI 可依 `sku_id` / `source_transfer_item_id` join 品名店名，不跨 tenant。
+`v_hq_return_batches_list`（security_invoker）：只授權 authenticated 中同 tenant 的 owner/admin/hq_manager 讀取，帶 `qty_pending` 計算欄。底表、事件表與 view 同刀設定 SELECT grant + role RLS；anon、店端、空 role、跨 tenant 均不可讀。UI 可依 `sku_id` / `source_transfer_item_id` join 品名店名。
 
 ## 不在 A 範圍
 

--- a/docs/return-disposition-core-review.md
+++ b/docs/return-disposition-core-review.md
@@ -206,3 +206,65 @@ reserved = reserved - v_this_total
 2. 再修 P0-2：讓負異動 guard 在併發下也看得到待處理量。
 3. 接著修 P1-1 / P1-2：權限與冪等。
 4. 最後修 P1-3 / P1-4 / P1-5：數字、reserved、movement_type 瘦身。
+
+---
+
+## 2026-09-07 Codex GPT-5.5 阿審正式複審（A 修版，靜態）
+
+範圍：只複審 A 段 `supabase/migrations/20260907010000_hq_return_disposition_core.sql` 與 `docs/return-disposition-core-contract.md`。未審 B/F/E/C 作者包；未連 GitHub / Supabase / 正式資料；未讀 `.env`；未改功能碼；本段尚未在 `return_disposition_test_core_a_fix` 跑 runtime。
+
+### 複審結論
+
+靜態看 A 修版，首審列的 A 自身 P0/P1 已有對應修補；目前未新增 A 自身 P0/P1。這只代表 SQL 邏輯文字審查通過到「可交假庫 runtime 驗」這一步，不是正式功能驗收。
+
+P0：0
+
+P1：0
+
+P2：0
+
+runtime：新假庫 `return_disposition_test_core_a_fix` 已由阿審獨立執行 16 群，16/16 PASS、exit 0。C 的撤回/更正/月鎖不在 A 範圍，不能因 A 通過就視為整包已完成。
+
+A 載入 SHA256：`3B007711260B8D255F9B7574BD38865B25644534BB9F722BB709265C93CC4FC7`
+
+B 載入 SHA256：`3D0FE235F04913DE67088495DAF28A8EED02A2F28F0B5C2E98A1C55EFA681042`
+
+### 已核對的 A 邊界
+
+- 來源防偽已收緊：`_hq_hold_return` 現在要求 `p_source_transfer_item_id` 必填，並檢查 movement tenant / location / sku / qty / source_doc 與 transfer item、父單位置、來源種類一致，見 `supabase/migrations/20260907010000_hq_return_disposition_core.sql:233-384`。其中 `source_doc_line_id` 可為 NULL；有值時才要求等於 item id，見 `:354-360`，符合真收貨既有路徑。
+- 真收貨不因父單當下仍是 `shipped` 被 A 擋：A 的 store_return 驗證看 `transfer_type='return_to_hq'`、dest/source location、`in_movement_id`、`qty_received`、movement type，見 `:362-370`，沒有要求父單已改成 received。B 的 operator 取值時序若仍誤標 system，是 B 缺陷，不列 A。
+- hold 冪等已改成鎖 balance 後重讀既有 batch，且比對 tenant、location、sku、source item、source_kind、source_reason、total_qty、unit_cost、auto_flag、created_by，見 `:386-415`。同 source movement 不同 payload 不會靜默當重試。
+- 權限已補到表與 view：表 RLS 限同 tenant 且 role 為 owner/admin/hq_manager，見 `:164-178`；底表有 `GRANT SELECT`，見 `:180-182`；view 用 `security_invoker` 並 grant 給 authenticated，見 `:858-885`。前端處理 RPC 也要求 `auth.uid()` 與同三個 HQ 角色，見 `:500-508`。
+- request_id 冪等已改成同 tenant/request advisory lock，且完整比對 batch、三個數量、兩個原因、goods_confirmed、notes；重播回第一次 event 的原 `new_status`，見 `:572-603`。
+- 數字已逐欄拒絕 NULL、NaN、Infinity、負數、超界、超過 3 位小數，見 `:517-545`；hold 量也同樣逐項檢查，見 `:246-257`。
+- reserved / pending 一致性已補：dispose 先鎖 balance 再鎖 batch，鎖後重讀本批 pending、同 SKU 全部 pending，並要求 `reserved >= total_pending`，見 `:606-665`。這可擋先前人為破壞 reserved 後仍處理的缺口。
+- 破損/遺失 movement 已瘦身回既有類型：破損用 `damage`，遺失用 `manual_adjust` 搭配 `source_doc_type='hq_return_batch'`，見 `:697-722`；A 修版沒有再新增 `hq_return_damage` / `hq_return_loss` 全域 movement type。
+- 負異動 guard 已改為先建立/鎖同一筆 balance，再重讀全部 pending，見 `:797-817`；`pending=0` 的放行點已移到鎖後，見 `:819-822`，方向符合首審要求。
+
+### runtime 證據
+
+命令：
+
+```powershell
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_a_fix --case all
+```
+
+結果：exit 0，16/16 PASS。
+
+補驗包含：
+
+- 原 13 群：NULL line 正向來源、source_validation 四個單點負例、reserved_corruption、race_same_request、race_hold_negative。
+- 新增 3 群：同 UUID 跨 tenant 不干擾、hold 同來源完整 payload 重送、同 SKU 多批 pending 的 reserved/available 總額保護。
+
+本輪 race 留存：
+
+- `race_same_request` tenant：`dbfd3cb1-43ca-4af6-9881-9afe7560322d`
+- `race_hold_negative` tenant：`8e57b58e-c946-4a7d-b8ef-94812560ab8c`
+
+連線收尾：`other_open_connections=0`。
+
+### 仍未覆蓋
+
+- C：原單更正 / 撤回 / 月鎖。
+- E/F：前端與可派量包。
+- 正式資料庫：本輪只跑本機假庫，不代表正式資料已驗收。

--- a/docs/return-disposition-core-review.md
+++ b/docs/return-disposition-core-review.md
@@ -1,0 +1,208 @@
+# 阿審審查報告：總倉退回貨處理 A 核心
+
+日期：2026-09-07  
+範圍：只審 A 段 `supabase/migrations/20260907010000_hq_return_disposition_core.sql` 與 `docs/return-disposition-core-contract.md`。  
+不審 B/C 尚未接的來源接線、撤回、月鎖；不連 GitHub / Supabase / API；沒有執行正式庫 db push。
+
+CEO 已回報 SQL parser：34 statements / 4 funcs 通過。以下是邏輯審查，不是正式資料庫驗收。
+
+## 結論
+
+A 目前不建議直接交給 B/C 往下接，先修 P0/P1 比較安全。
+
+最重的問題不是語法，而是「核心保護層本身還沒把來源、凍結量、併發與權限鎖死」。如果 B 段照預期接對，很多問題不一定立刻爆；但 A 是共用底座，應該要防 B 接錯，而不是相信 B 永遠接對。
+
+## P0
+
+### P0-1：`_hq_hold_return` 沒驗來源 movement 真的屬於這個總倉、這個品項批次，且 `p_qty` 可異於來源數量
+
+位置：`supabase/migrations/20260907010000_hq_return_disposition_core.sql:245-317`
+
+目前有驗：
+
+- source movement 存在：`:245-253`
+- tenant 相同：`:255-257`
+- quantity > 0：`:259-261`
+- sku 相同：`:263-265`
+- 傳入 location 是總倉：`:267-278`
+
+但還少三道核心防線：
+
+- 沒驗 `v_mov.location_id = p_location_id`。也就是「來源 movement」可能其實不是這個總倉的入庫，A 仍會在總倉建立待處理批次並加 reserved。
+- 沒驗 `p_qty` 必須等於來源 movement 的 quantity。`source_movement_id` 又是唯一鍵 `:72-73`，如果 `p_qty` 小於來源 movement，剩下那段永遠不能再建第二批；如果大於來源 movement，會凍結出超過實際來源的待處理量。
+- 沒驗 `p_source_transfer_item_id` 跟來源 movement 的關係。B 之後會傳 `transfer_items.in_movement_id` / `shortage_restock_movement_id`，但 A 本身沒驗 item 是否真的指向這筆 movement、同 SKU、同 tenant。
+
+白話風險：
+
+- 做了現在這版：B 只要傳錯一個 movement id，就可能在總倉帳上生出一批「看起來待處理、其實來源不對」的貨。
+- 不修：後面 UI、報表、補貨保護都會相信這批 reserved，錯會一路擴散。
+
+最小修法：
+
+- 在 `_hq_hold_return` 內補：
+  - `v_mov.location_id = p_location_id`
+  - `v_hold_qty = v_mov.quantity`，不要只檢查 `> 0`
+  - 若 `p_source_transfer_item_id IS NOT NULL`，查 `transfer_items`，確認同 SKU，且 `in_movement_id = p_source_movement_id OR shortage_restock_movement_id = p_source_movement_id`
+- 介面簽名可不改。
+
+### P0-2：負異動 guard 先算 pending、沒 pending 就直接放行；遇到同 SKU 新增 hold 的併發會漏看
+
+位置：`supabase/migrations/20260907010000_hq_return_disposition_core.sql:581-632`
+
+目前流程：
+
+1. 負 movement 進來。
+2. 先 `SUM(hq_return_batches pending)`：`:592-600`
+3. 如果當下看起來 pending = 0，就直接 `RETURN NEW`：`:602-605`
+4. 有 pending 才鎖 `stock_balances`：`:607-616`
+
+問題是：A 的任務就是保護「剛回總倉、還待確認的那批不能被派走」。如果另一個交易正在對同一個總倉/SKU 建 hold，這支 guard 可能在 hold 完成前先看到 pending = 0，於是直接放行負出庫。
+
+白話風險：
+
+- 做了現在這版：剛回來、正要被凍結的那批貨，遇到同時間出庫，有機會被先派掉。
+- 不修：後面即使 B 有正確呼叫 `_hq_hold_return`，共用保護仍不是穩的。
+
+最小修法：
+
+- 對負 movement，先鎖同一筆 `stock_balances`，再重讀 pending；不要在鎖 balance 前因 pending = 0 直接 return。
+- `_hq_hold_return` 建 hold / 加 reserved 也要走同一個鎖序，避免跟 guard 互相錯過。
+- guard function 建議補 `SECURITY DEFINER SET search_path = public, pg_temp`；現在是一般 trigger function，後續若 RLS/權限收緊，或 search_path 不乾淨，讀 pending 可能失準。
+
+## P1
+
+### P1-1：RLS / GRANT / 契約三者不一致；修 GRANT 時還會變成分店可看成本
+
+位置：
+
+- RLS policy：`supabase/migrations/20260907010000_hq_return_disposition_core.sql:185-196`
+- view：`supabase/migrations/20260907010000_hq_return_disposition_core.sql:645-673`
+- 契約：`docs/return-disposition-core-contract.md`
+
+目前 migration 只建了同 tenant SELECT policy，沒有 `GRANT SELECT` 給 `authenticated`。照 Postgres 權限，policy 不是 grant；沒有表/視圖權限時，前端不一定讀得到。這跟契約「同 tenant 可讀」不一致。
+
+但如果只是補 `GRANT SELECT`，又會變成同 tenant 的分店帳號也可查 `unit_cost`、全部總倉待處理批次與事件，因為 policy 只有 tenant，沒有 role 白名單。
+
+白話風險：
+
+- 做了現在這版：UI 可能讀不到。
+- 只補 GRANT 不補 role：分店可能看得到不該看的成本與總倉內部處理資料。
+
+最小修法：
+
+- 決定 A 的讀取對象：若這是總倉處理頁，SELECT policy 與 view 都應限制 `owner/admin/hq_manager`。
+- 補對應的 `GRANT SELECT ON ... TO authenticated`，但要跟 role policy 同刀完成。
+- 若分店日後也要看自己的進度，另開低敏 view，不要把 `unit_cost` 與全部 batch 直接放給同 tenant 所有人。
+
+### P1-2：`request_id` 冪等沒有 tenant 範圍、payload 比對不完整，併發重試也可能不是冪等
+
+位置：`supabase/migrations/20260907010000_hq_return_disposition_core.sql:418-437`
+
+目前有做：
+
+- 同 `request_id` 查既有 event。
+- 比對 `batch_id / qty_good / qty_damaged / qty_lost`。
+- 相同就回 `idempotent = true`。
+
+還缺：
+
+- 查 existing event 時沒有加 `tenant_id = v_tenant`，而且發生在 batch tenant 驗證之前。雖然 UUID 猜中機率低，但這是 SECURITY DEFINER RPC，不應跨 tenant 回別人的 event/batch id。
+- payload 沒比 `damage_reason / loss_reason / goods_confirmed / notes`。同 request id 換原因或備註，現在會被當成同一筆重試放過。
+- 兩個完全同時的相同 request，可能都先查不到 existing，最後靠 unique constraint 擋第二筆；第二筆會噴錯，不會回 idempotent。
+- `p_request_id IS NULL` 沒先擋，會一路做到最後 INSERT 才撞 NOT NULL，錯誤點太晚。
+
+白話風險：
+
+- 做了現在這版：重送按鈕的「同一包」定義不完整；真的網路重試或雙擊，還是可能讓使用者看到錯誤。
+- 不修：稽核備註/原因可能被靜默忽略，跨 tenant 的安全邊界也不夠乾淨。
+
+最小修法：
+
+- existing 查詢加 `tenant_id = v_tenant`。
+- 一開始擋 `p_request_id IS NULL`。
+- payload 比對補齊 reason、notes、goods_confirmed；文字欄位用同一個空白/null 規則。
+- INSERT event 遇到 `unique_violation` 時，重新 SELECT existing 並跑同一套 payload 比對後回 idempotent。
+
+### P1-3：NUMERIC 會被 `NUMERIC(18,3)` 靜默四捨五入，可能讓 pending / reserved / event 數字不照使用者輸入
+
+位置：
+
+- batch qty 欄：`supabase/migrations/20260907010000_hq_return_disposition_core.sql:55-64`
+- event qty 欄：`:122-124`
+- `v_this_total NUMERIC(18,3)`：`:367-392`
+
+目前有擋負數、NaN、Infinity，但沒有明確拒絕超過 3 位小數。Postgres 寫入 `NUMERIC(18,3)` 會四捨五入，不是拒絕。
+
+白話風險：
+
+- 做了現在這版：如果前端或未來 RPC 傳 `0.0005`，資料庫可能記成 `0.001`，使用者輸入跟帳上留痕不同。
+- 不修：部分處理的 pending、reserved、事件紀錄會出現很難追的零碎差異。
+
+最小修法：
+
+- 在 `_hq_hold_return` 與 `rpc_dispose_hq_return` 對所有數量輸入補共同檢查：`value = ROUND(value, 3)`。
+- 對 `p_qty_good / p_qty_damaged / p_qty_lost / p_qty` 都要逐欄檢查，不要只檢查總和。
+
+### P1-4：`reserved` 直接扣，沒確認這批凍結量還在，可能把共用 reserved 扣成負數或吃到別人的 reserved
+
+位置：`supabase/migrations/20260907010000_hq_return_disposition_core.sql:465-480`
+
+`rpc_dispose_hq_return` 先鎖 balance，再直接：
+
+```sql
+reserved = reserved - v_this_total
+```
+
+但沒有檢查目前 `reserved >= v_this_total`。既有 `stock_balances` 本身也沒有 `reserved >= 0` 的 CHECK，見 `supabase/migrations/20260422120003_inventory_schema.sql:29-41`。
+
+白話風險：
+
+- 做了現在這版：只要前面曾經漏加、被手動改、或未來別的機制共用 reserved，這裡就可能把 reserved 扣成負數，讓「可派貨」看起來比實物更多。
+- 不修：A 的「待確認這批不能派」保護會變得不好對帳。
+
+最小修法：
+
+- 鎖 balance 後讀 `reserved`，若 `reserved < v_this_total` 直接 raise。
+- 不要用 `GREATEST(reserved - v_this_total, 0)` 靜默吞錯；那會把錯帳藏起來。
+
+### P1-5：新增 `hq_return_damage` / `hq_return_loss` 不必要，會把全域 CHECK 變成本案負擔
+
+位置：
+
+- CHECK 重建：`supabase/migrations/20260907010000_hq_return_disposition_core.sql:16-38`
+- 寫 movement：`:498-523`
+
+本機 grep 到最後一次正式重建 `stock_movements_movement_type_check` 是 `20260713000000_stock_movements_allow_transfer_cancel.sql:25-41`；A 目前沒有漏掉本機主線已合法的 type。
+
+但依 ponytail，這兩個新 type 不值得。既有合法 type 已有：
+
+- `damage`
+- `manual_adjust`
+- `stocktake_loss`
+
+而且 `stock_movements` 本來就有 `source_doc_type / source_doc_id / reason / notes` 可以標明這是 `hq_return_batch`。
+
+白話風險：
+
+- 做了現在這版：每次有人加 movement_type，都要重建同一個全域 CHECK；未來別的分支也動這裡時，很容易互蓋。
+- 不修：不是今天一定壞，但會把一個局部功能變成全系統庫存型別維護成本。
+
+最小修法：
+
+- 破損用既有 `damage`，搭配 `source_doc_type='hq_return_batch'`、`source_doc_id=p_batch_id`、`reason=p_damage_reason`。
+- 遺失若不是盤點，不要硬用 `stocktake_loss`；可用 `manual_adjust` 搭配 `source_doc_type='hq_return_batch'`、`reason='退回總倉遺失：...'`。
+- 移除本檔 movement_type CHECK 重建。
+
+## 已看但不列為 A 缺陷
+
+- `rpc_dispose_hq_return` 有 `auth.uid()` 必填與 role 白名單，見 `:363-383`。這段方向正確。
+- `qty_good > 0` 時要求 `p_goods_confirmed = true`，見 `:413-416`。這段符合「好貨要實物確認」。
+- `p_allow_negative=true` 與直接 insert 負 movement 的旁路，A 有放在同一個 stock_movements BEFORE trigger 保護，方向正確；問題在 P0-2 的鎖序/競態，而不是「完全沒 guard」。
+- A 文件明列 B/C 尚未包含來源接線、撤回、月鎖；本報告未把這些刻意未做的範圍當缺陷。
+
+## 建議修正順序
+
+1. 先修 P0-1：把 `_hq_hold_return` 變成可信入口。
+2. 再修 P0-2：讓負異動 guard 在併發下也看得到待處理量。
+3. 接著修 P1-1 / P1-2：權限與冪等。
+4. 最後修 P1-3 / P1-4 / P1-5：數字、reserved、movement_type 瘦身。

--- a/docs/return-disposition-core-runtime-test-report.md
+++ b/docs/return-disposition-core-runtime-test-report.md
@@ -17,7 +17,7 @@
 - 固定 user `returnlocal`
 - 不讀 password / `.env`
 - DB 名稱不符合 `^return_disposition_test_[A-Za-z0-9_]+$` 直接拒絕
-- 預設跑全部 13 組；也可用 `--case` 指定單組或 `--case all`
+- 預設跑全部 16 組；也可用 `--case` 指定單組或 `--case all`
 
 用法：
 
@@ -31,7 +31,7 @@ node tests/return-disposition-review/core-runtime.cjs --db-name return_dispositi
 node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial --case list
 ```
 
-目前 case：`dispose_split`、`source_validation`、`source_line_null_positive`、`idempotency`、`idempotency_replay_after_complete`、`idempotency_payload_fields`、`bad_numbers`、`reserved_corruption`、`pending_guard`、`role_edges`、`rls_roles`、`race_same_request`、`race_hold_negative`。
+目前 case：`dispose_split`、`source_validation`、`source_line_null_positive`、`idempotency`、`idempotency_replay_after_complete`、`idempotency_payload_fields`、`request_id_tenant_scoped`、`hold_full_payload_replay`、`bad_numbers`、`multi_batch_reserved_total`、`reserved_corruption`、`pending_guard`、`role_edges`、`rls_roles`、`race_same_request`、`race_hold_negative`。
 
 ## 最小檢查
 
@@ -43,9 +43,9 @@ node --check tests/return-disposition-review/core-runtime.cjs
 
 結果：exit 0。這只代表測試器語法可解析，不代表資料庫整合已通過。
 
-## 20:46 後實跑結果（核心初版假庫）
+## 20:46 後實跑結果（核心初版假庫，保留紅燈歷史）
 
-### 1. 全 13 組
+### 1. 當時全 13 組
 
 命令：
 
@@ -53,7 +53,7 @@ node --check tests/return-disposition-review/core-runtime.cjs
 node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial --case all
 ```
 
-結果：exit 1。13 組中 4 組 PASS、9 組 FAIL。這是初版 A/B 的紅燈結果，不是修版驗收。
+結果：exit 1。當時 13 組中 4 組 PASS、9 組 FAIL。這是初版 A/B 的紅燈結果，不是修版驗收；本段保留歷史，不用它覆蓋 A 修版結果。
 
 逐組結果：
 
@@ -122,6 +122,49 @@ node -e 'const {Client}=require("pg");(async()=>{const c=new Client({host:"127.0
 
 結果：`other_open_connections=0`，測試器沒有留下開著的連線。
 
+## A 修版實跑結果（新假庫）
+
+DB：`return_disposition_test_core_a_fix`
+
+A 載入 SHA256：`3B007711260B8D255F9B7574BD38865B25644534BB9F722BB709265C93CC4FC7`
+
+B 載入 SHA256：`3D0FE235F04913DE67088495DAF28A8EED02A2F28F0B5C2E98A1C55EFA681042`
+
+阿審獨立實跑：
+
+```powershell
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_a_fix --case all
+```
+
+結果：exit 0。16/16 PASS。
+
+新增 3 組補驗：
+
+```powershell
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_a_fix --case request_id_tenant_scoped,hold_full_payload_replay,multi_batch_reserved_total
+```
+
+結果：exit 0。3/3 PASS。
+
+新增補驗重點：
+
+- `request_id_tenant_scoped`：同一個 UUID 在不同 tenant 各自可成立，且各自重送只回自己的事件。
+- `hold_full_payload_replay`：同來源 movement 重送完整 payload 一致才回既有批次；改 reason / auto_flag / operator 會拒絕且無副作用。
+- `multi_batch_reserved_total`：同 SKU 兩批 pending 共 12 時，既有好貨 20 可出；多出到只剩 11 會被 guard 擋。
+
+本輪 race 留存：
+
+- `race_same_request` tenant：`dbfd3cb1-43ca-4af6-9881-9afe7560322d`
+- `race_hold_negative` tenant：`8e57b58e-c946-4a7d-b8ef-94812560ab8c`
+
+連線收尾確認：
+
+```powershell
+node -e 'const {Client}=require("pg");(async()=>{const c=new Client({host:"127.0.0.1",port:56427,user:"returnlocal",database:"return_disposition_test_core_a_fix"});await c.connect();const r=await c.query("select count(*)::int as n from pg_stat_activity where datname=$1 and pid<>pg_backend_pid()",["return_disposition_test_core_a_fix"]);console.log("other_open_connections="+r.rows[0].n);await c.end();})().catch(e=>{console.error(e.stack||e.message);process.exit(1);})'
+```
+
+結果：`other_open_connections=0`。
+
 ## 覆蓋重點
 
 這支測試器目前抓以下幾類：
@@ -130,17 +173,20 @@ node -e 'const {Client}=require("pg");(async()=>{const c=new Client({host:"127.0
 2. 來源防偽：來源數量、地點、品項、原單行不符必須拒絕。這組現在備料時先掛好合法來源指標，並有合法來源正向 control，避免只測到「未掛來源」或既有 batch 早退。
 3. 真收貨相容：movement 的 `source_doc_line_id` 可為 NULL；此時必須靠 `transfer_items.in_movement_id` / `shortage_restock_movement_id` 反向指標、原單、位置、品項、數量來驗，不可把真收貨擋死。
 4. 重複提交：同 request 同 payload 要冪等；第一包 partial 後續被重送時要回第一包原結果；同 request 不同 goods_confirmed / reason / notes 要拒絕。
-5. 壞數字：`NULL`、`NaN`、`Infinity`、超過 3 位小數不能默默收下。
-6. 待確認保護：正常資料下既有好貨可派，但不能派到吃掉待確認量；另外故意破壞 reserved 小於 pending 時，dispose 必須拒絕。
-7. `p_allow_negative=true` 與直接寫負庫存都不能繞過待確認保護。
-8. 權限：HQ manager 應能讀；同 tenant 店家、跨 tenant、匿名、`hq_accountant`、空 role、缺 `auth.uid()` 不能讀或處理總倉批次。
-9. 兩連線併發：
+5. 同 UUID 跨 tenant 不互相干擾。
+6. hold 同來源完整 payload 重送才冪等；payload 不同要拒絕。
+7. 壞數字：`NULL`、`NaN`、`Infinity`、超過 3 位小數不能默默收下。
+8. 待確認保護：正常資料下既有好貨可派，但不能派到吃掉待確認量；另外故意破壞 reserved 小於 pending 時，dispose 必須拒絕。
+9. 同 SKU 多批 pending 要用總額保護 available。
+10. `p_allow_negative=true` 與直接寫負庫存都不能繞過待確認保護。
+11. 權限：HQ manager 應能讀；同 tenant 店家、跨 tenant、匿名、`hq_accountant`、空 role、缺 `auth.uid()` 不能讀或處理總倉批次。
+12. 兩連線併發：
    - 同 request 同時送，不可多扣或變成 `already completed`。
    - hold 建立中遇到直接負異動，不可因為先查 pending 後鎖 balance 而吃掉待確認量。
 
 ## 覆蓋限制
 
-- 目前只在 `return_disposition_test_core_initial` 初版假庫跑過；還沒在 D 最終 fixture / A 修版上完整跑完，不能當成「已驗收通過」。
+- 初版紅燈歷史只代表 `return_disposition_test_core_initial`；A 修版綠燈代表 `return_disposition_test_core_a_fix` 本機假庫，不代表正式資料庫。
 - 一般案例用交易 `ROLLBACK` 清假資料；兩連線 race 因為兩個連線必須互相看得到資料，使用專屬 tenant 造資料並保留 tenant id 供追查，不關 trigger、不硬刪 append-only 表、不自稱已清乾淨。
 - 錯誤檢查不是「任意 error 算過」：每個負案例都有指定錯誤訊息關鍵字，並比對狀態快照。
 - RLS 讀取不是「看不到就算安全」：測試器先驗 HQ 角色確實讀得到 view，再驗店家/跨租戶/匿名讀不到或被 42501 權限錯擋。
@@ -148,7 +194,7 @@ node -e 'const {Client}=require("pg");(async()=>{const c=new Client({host:"127.0
 - RLS/GRANT 使用 `SET LOCAL ROLE authenticated/anon` 與 fixture 的 `request.jwt.*` stub；若 D fixture 改 auth stub 名稱，需同步調整 `setAuth()`。
 - 本支不測瀏覽器畫面、不測 C 撤回/更正完整流程、不測月鎖結帳金額；那些要等 B/C/D 全包完成後另跑整合驗收。
 
-## 目前判斷
+## 初版判斷（保留歷史）
 
 P0：3 類
 
@@ -166,4 +212,12 @@ P2：0
 
 已通過但仍需修版後重跑確認：分次 7/2/1、真收貨 NULL line 但 item 反向指標正確時可建待處理、正常資料下既有好貨可派且 pending 不可被一般出庫 / allow_negative / 直接負 movement 吃掉、`hq_accountant` / 空 role / 缺 auth.uid 的越權處理被拒絕。
 
-交付前置條件：等 D fixture 修版與 A 修版載入後，重新執行本測試器；若測試失敗，再依錯誤回報 A/B/C 實際缺口。
+## A 修版目前判斷
+
+P0：0
+
+P1：0
+
+P2：0
+
+A 修版已通過本機假庫 16 群 runtime。仍未覆蓋 C：原單更正 / 撤回 / 月鎖；也未代表 E/F 前端或可派量包已通過。

--- a/docs/return-disposition-core-runtime-test-report.md
+++ b/docs/return-disposition-core-runtime-test-report.md
@@ -1,40 +1,15 @@
 # 總倉退回貨處理 — 阿審核心 runtime 驗收器報告
 
-日期：2026-09-07  
-角色：阿審（獨立驗收準備）  
-限制：只新增測試碼與本報告；未改功能碼；未連 GitHub / Supabase；未讀 `.env`；目前 D fixture 修版尚未完成，所以本輪只做「可執行測試準備」，不宣稱測試已綠。
+日期：2026-09-07
 
-本輪最小檢查：
+角色：阿審（獨立驗收準備 / 初版假庫實測）
+限制：只改測試碼與本報告；未改 A/B/E 功能碼；未連 GitHub / Supabase；未讀 `.env`。本輪只在本機假庫 `return_disposition_test_core_initial` 收集初版 A/B 的真結果，不代表 A 修版或 D 最終 fixture 已驗收。
 
-```powershell
-node --check D:\1人公司\_本機工地\new_erp_return_disposition_20260907\tests\return-disposition-review\core-runtime.cjs
-```
+## 測試器
 
-結果：exit 0。這只代表測試器語法可解析，不代表資料庫整合已通過。
-
-2026-09-07 追加初版假庫反例：
-
-```powershell
-node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial
-```
-
-結果：exit 1，測試器先通過「10 件分 7 好 2 破 1 失、含分次處理」，接著在來源防偽案例停止：
-
-```text
-AssertionError [ERR_ASSERTION]: hold qty 大於來源 movement 應該拒絕，但實際成功
-```
-
-白話解讀：這證明驗收器不是空測；這次流程是先由 `inboundMovement` 讓 B 依同一筆來源 movement 建出 10 件 batch，再用同來源呼叫 `_hq_hold_return(... p_qty=11)`。初版 A 把這個「同來源、不同數量」的請求當成可接受的冪等回傳，沒有拒絕。這次反例沒有證明真的又多凍結 11 件，但已證明 A 來源防偽/冪等 payload 檢查不足；需等 A 修版後再重跑。
-
-## 本輪新增
+檔案：
 
 - `tests/return-disposition-review/core-runtime.cjs`
-
-用途：在老闆指定的本機 PostgreSQL 測試庫跑 A/B 核心驗收。它只接受：
-
-```powershell
-node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_<name>
-```
 
 安全邊界：
 
@@ -42,11 +17,80 @@ node tests/return-disposition-review/core-runtime.cjs --db-name return_dispositi
 - 固定 user `returnlocal`
 - 不讀 password / `.env`
 - DB 名稱不符合 `^return_disposition_test_[A-Za-z0-9_]+$` 直接拒絕
-- D fixture 未通知 ready 前，不應執行
+- 預設跑全部 8 組；也可用 `--case` 指定單組或 `--case all`
+
+用法：
+
+```powershell
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_<name> [--case case_name]
+```
+
+可列 case：
+
+```powershell
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial --case list
+```
+
+目前 case：`dispose_split`、`source_validation`、`idempotency`、`bad_numbers`、`pending_guard`、`rls_roles`、`race_same_request`、`race_hold_negative`。
+
+## 最小檢查
+
+命令：
+
+```powershell
+node --check tests/return-disposition-review/core-runtime.cjs
+```
+
+結果：exit 0。這只代表測試器語法可解析，不代表資料庫整合已通過。
+
+## 20:46 後實跑結果（核心初版假庫）
+
+### 1. 全 8 組
+
+命令：
+
+```powershell
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial
+```
+
+結果：exit 1。此命令目前等同全驗；也可明確寫 `--case all`。8 組中 2 組 PASS、6 組 FAIL。
+
+逐組結果：
+
+| 測試組 | 結果 | 真結果 |
+|---|---:|---|
+| `dispose_split` | PASS | 10 件分次處理成 7 好、2 破、1 失；reserved 歸 0；on_hand 剩 7。 |
+| `source_validation` | FAIL | 數量不符未擋：同來源已建 10 件後，11 件的不一致 hold 請求仍成功；原單行不符也未擋。地點不符、品項不符有被擋。 |
+| `idempotency` | FAIL | 同 request id、同數量但不同 reason/notes 未被拒絕。 |
+| `bad_numbers` | FAIL | `NULL` 三欄、`NaN`、`Infinity` 未報失敗；但 `1.0001` 四位小數被接受，代表初版沒有逐欄拒絕超過 3 位小數。 |
+| `pending_guard` | PASS | 既有好貨 20 可派；第 21 件、`p_allow_negative=true`、直接負 movement 都被擋。 |
+| `rls_roles` | FAIL | HQ 正向讀 `v_hq_return_batches_list` 失敗：`permission denied for view v_hq_return_batches_list`。店家、跨租戶、匿名限制未報失敗。 |
+| `race_same_request` | FAIL | 第二個連線等第一個交易完成後，沒有重新吃到同 request 的冪等事件，反而回 `rpc_dispose_hq_return: batch 28 already completed`。不會直接多扣，但會讓安全重試失敗。保留追查 tenant：`0a9fd33b-d5d5-47e9-9d88-2269ff1050b8`。 |
+| `race_hold_negative` | FAIL | hold 建立中遇到直接負異動，第二連線沒有被拒絕，錯在「應回錯誤物件」但實際不是 Error。符合先查 pending、後等 balance lock、commit 後未重讀 pending 的競態疑慮。保留追查 tenant：`4288326c-ca13-46c6-9bab-fa43749cf1ae`。 |
+
+另單跑 `bad_numbers` 的確認命令：
+
+```powershell
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial --case bad_numbers
+```
+
+結果：exit 1，實際失敗為：
+
+```text
+FAIL bad_numbers: 四位小數拒絕: 四位小數拒絕 應該拒絕，但實際成功
+```
+
+連線收尾確認：
+
+```powershell
+node -e '...pg_stat_activity...'
+```
+
+結果：`other_open_connections=0`，測試器沒有留下開著的連線。
 
 ## 覆蓋重點
 
-這支測試器準備抓以下幾類錯：
+這支測試器目前抓以下幾類：
 
 1. `10 = 7 好 + 2 破 + 1 失`，含分次處理。
 2. 來源防偽：來源數量、地點、品項、原單行不符必須拒絕。
@@ -54,14 +98,14 @@ node tests/return-disposition-review/core-runtime.cjs --db-name return_dispositi
 4. 壞數字：`NULL`、`NaN`、`Infinity`、超過 3 位小數不能默默收下。
 5. 待確認保護：`reserved >= pending`，既有好貨可派，但不能派到吃掉待確認量。
 6. `p_allow_negative=true` 與直接寫負庫存都不能繞過待確認保護。
-7. 權限：同 tenant 店家、跨 tenant、匿名都不能讀或處理總倉批次。
+7. 權限：HQ 應能讀；同 tenant 店家、跨 tenant、匿名不能讀或處理總倉批次。
 8. 兩連線併發：
    - 同 request 同時送，不可多扣或變成 `already completed`。
    - hold 建立中遇到直接負異動，不可因為先查 pending 後鎖 balance 而吃掉待確認量。
 
 ## 覆蓋限制
 
-- 這是 runtime 驗收器；目前只在 `return_disposition_test_core_initial` 初版假庫跑到第一個反例，還沒在 D 最終 fixture / A 修版上完整跑完，不能當成「已驗收通過」。
+- 目前只在 `return_disposition_test_core_initial` 初版假庫跑過；還沒在 D 最終 fixture / A 修版上完整跑完，不能當成「已驗收通過」。
 - 一般案例用交易 `ROLLBACK` 清假資料；兩連線 race 因為兩個連線必須互相看得到資料，使用專屬 tenant 造資料並保留 tenant id 供追查，不關 trigger、不硬刪 append-only 表、不自稱已清乾淨。
 - 錯誤檢查不是「任意 error 算過」：每個負案例都有指定錯誤訊息關鍵字，並比對狀態快照。
 - RLS 讀取不是「看不到就算安全」：測試器先驗 HQ 角色確實讀得到 view，再驗店家/跨租戶/匿名讀不到或被 42501 權限錯擋。
@@ -71,20 +115,11 @@ node tests/return-disposition-review/core-runtime.cjs --db-name return_dispositi
 
 ## 目前判斷
 
-P0：1（初版假庫反例已抓到：同來源已建 10 件後，11 件的不一致 hold 請求未被拒絕；這是 A 功能已知問題，不是測試器問題）  
-P1：0（測試器語法檢查通過；完整 D fixture / A 修版 ready 後才會有完整功能結果）  
+P0：2（初版假庫已抓到來源防偽不足：數量不符、原單行不符未拒絕；併發 hold vs 直接負異動也未拒絕）
+
+P1：3（冪等/安全重試不足：同 request 不同 reason/notes 未拒絕，且併發同 request 變 already completed；4 位小數未精準拒絕；HQ 角色無法讀 view）
 P2：0
 
-交付前置條件：等 D fixture 修版載入真正 schema/RPC 後，執行本測試器；若測試失敗，再依錯誤回報 A/B/C 實際缺口。
+已通過但仍需修版後重跑確認：分次 7/2/1、既有好貨可派且 pending 不可被一般出庫/allow_negative/直接負 movement 吃掉。
 
-## 目前不可執行整合的原因
-
-CEO 目前回報的 D2 狀態是：已載入基底 DDL，但尚無 A/B，且 `_current_tenant_id` 漏載；A 修版、B/F、E、C 都尚未交到可驗收 patch。因此現在若硬跑 `core-runtime.cjs`，會只得到「缺核心函式 / 缺租戶 helper」這類前置環境錯，不是功能驗收結果。
-
-等可以跑時，最低條件是：
-
-- 測試 DB 名稱符合 `return_disposition_test_...`
-- D fixture 已載入 `_current_tenant_id`、`auth.uid()`、`auth.jwt()` 的本機 stub
-- A 核心已載入 `_hq_hold_return`、`rpc_dispose_hq_return`、`trg_guard_hq_pending`、`v_hq_return_batches_list`
-- B 來源接線若要驗自動建批，需載入；本測試器主體仍可用 helper 直接建待處理批次驗 A 核心
-- `authenticated` / `anon` 角色存在，且能用 `SET LOCAL ROLE` 真測 RLS/GRANT
+交付前置條件：等 D fixture 修版與 A 修版載入後，重新執行本測試器；若測試失敗，再依錯誤回報 A/B/C 實際缺口。

--- a/docs/return-disposition-core-runtime-test-report.md
+++ b/docs/return-disposition-core-runtime-test-report.md
@@ -221,3 +221,34 @@ P1：0
 P2：0
 
 A 修版已通過本機假庫 16 群 runtime。仍未覆蓋 C：原單更正 / 撤回 / 月鎖；也未代表 E/F 前端或可派量包已通過。
+
+## 2026-09-07 full_v1：deferred 準備資料適配
+
+背景：full_v1 加入 C 後，`source_validation` 與 `hold_full_payload_replay` 的測試準備階段會暫停 B 的 `trg_hq_return_source`，手動掛好 `transfer_items.in_movement_id`。原測試在 `ALTER TABLE ... DISABLE TRIGGER` 前後沒有先排空合法 deferred trigger queue，導致 PostgreSQL 以 `55006` 擋住 ALTER；這是測試準備順序問題，不是 A/B/C 功能結論。
+
+本輪只改測試碼：
+
+- 在 `tests/return-disposition-review/core-runtime.cjs` 新增 `flushDeferredConstraints()`。
+- `linkedRawInboundMovement()` 在關 B trigger 前、手動掛來源後、恢復 trigger 後，都先 `SET CONSTRAINTS ALL IMMEDIATE` 再回 `DEFERRED`。
+- 沒有關 C trigger，沒有放寬任何 assert，也沒有把錯碼行為改成 expected。
+
+實跑：
+
+```powershell
+node --check tests\return-disposition-review\core-runtime.cjs
+node tests\return-disposition-review\core-runtime.cjs --db-name return_disposition_test_full_v1 --case source_validation,hold_full_payload_replay
+node tests\return-disposition-review\core-runtime.cjs --db-name return_disposition_test_core_initial --case source_validation,hold_full_payload_replay
+node tests\return-disposition-review\core-runtime.cjs --db-name return_disposition_test_full_v1 --case all
+```
+
+結果：
+
+- `node --check`：exit 0。
+- `full_v1` 指定 2 群：2/2 PASS。
+- `core_initial` 指定 2 群：exit 1，仍抓到舊 A 的來源防偽與 hold payload 缺口；表示這次沒有把測試改軟。
+- `full_v1 --case all`：16/16 PASS。
+
+`full_v1 --case all` 本輪 race 留存：
+
+- `race_same_request` tenant：`2a0a36bc-42ec-4e98-8d63-7da3a23a6cc1`
+- `race_hold_negative` tenant：`33b8e5eb-23c9-40f4-a11a-d12e6343d041`

--- a/docs/return-disposition-core-runtime-test-report.md
+++ b/docs/return-disposition-core-runtime-test-report.md
@@ -2,7 +2,7 @@
 
 日期：2026-09-07
 
-角色：阿審（獨立驗收準備 / 初版假庫實測）
+角色：Codex 側 GPT-5.5 阿審（獨立驗收準備 / 初版假庫實測）
 限制：只改測試碼與本報告；未改 A/B/E 功能碼；未連 GitHub / Supabase；未讀 `.env`。本輪只在本機假庫 `return_disposition_test_core_initial` 收集初版 A/B 的真結果，不代表 A 修版或 D 最終 fixture 已驗收。
 
 ## 測試器
@@ -17,7 +17,7 @@
 - 固定 user `returnlocal`
 - 不讀 password / `.env`
 - DB 名稱不符合 `^return_disposition_test_[A-Za-z0-9_]+$` 直接拒絕
-- 預設跑全部 8 組；也可用 `--case` 指定單組或 `--case all`
+- 預設跑全部 13 組；也可用 `--case` 指定單組或 `--case all`
 
 用法：
 
@@ -31,7 +31,7 @@ node tests/return-disposition-review/core-runtime.cjs --db-name return_dispositi
 node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial --case list
 ```
 
-目前 case：`dispose_split`、`source_validation`、`idempotency`、`bad_numbers`、`pending_guard`、`rls_roles`、`race_same_request`、`race_hold_negative`。
+目前 case：`dispose_split`、`source_validation`、`source_line_null_positive`、`idempotency`、`idempotency_replay_after_complete`、`idempotency_payload_fields`、`bad_numbers`、`reserved_corruption`、`pending_guard`、`role_edges`、`rls_roles`、`race_same_request`、`race_hold_negative`。
 
 ## 最小檢查
 
@@ -45,28 +45,62 @@ node --check tests/return-disposition-review/core-runtime.cjs
 
 ## 20:46 後實跑結果（核心初版假庫）
 
-### 1. 全 8 組
+### 1. 全 13 組
 
 命令：
 
 ```powershell
-node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial --case all
 ```
 
-結果：exit 1。此命令目前等同全驗；也可明確寫 `--case all`。8 組中 2 組 PASS、6 組 FAIL。
+結果：exit 1。13 組中 4 組 PASS、9 組 FAIL。這是初版 A/B 的紅燈結果，不是修版驗收。
 
 逐組結果：
 
 | 測試組 | 結果 | 真結果 |
 |---|---:|---|
 | `dispose_split` | PASS | 10 件分次處理成 7 好、2 破、1 失；reserved 歸 0；on_hand 剩 7。 |
-| `source_validation` | FAIL | 數量不符未擋：同來源已建 10 件後，11 件的不一致 hold 請求仍成功；原單行不符也未擋。地點不符、品項不符有被擋。 |
+| `source_validation` | FAIL | 已修正測試資料：備料時短暫停用已查證的 B trigger `trg_hq_return_source`、把正確 `transfer_items.in_movement_id` 掛好、再恢復 trigger 後才跑斷言。目前實測數量不符、同租戶別總倉地點不符、原單行不符都未擋；品項不符有被擋。 |
+| `source_line_null_positive` | PASS | 真收貨 movement 沒有 `source_doc_line_id`、但 `transfer_items.in_movement_id` 指回該 movement 時，由 B trigger 自動建批成功；batch 數量、成本與凍結數都對齊來源。這條是防止 A 修版把真收貨擋死的回歸保護。 |
 | `idempotency` | FAIL | 同 request id、同數量但不同 reason/notes 未被拒絕。 |
+| `idempotency_replay_after_complete` | FAIL | 第一包 partial、第二包結案後，重送第一包沒有回第一包原本的 partial 結果，實測 `new_status` 變成 `undefined`。 |
+| `idempotency_payload_fields` | FAIL | 同 request id 改 notes、damage_reason、loss_reason 仍被接受；改 goods_confirmed 這筆有被既有檢查擋下。 |
 | `bad_numbers` | FAIL | `NULL` 三欄、`NaN`、`Infinity` 未報失敗；但 `1.0001` 四位小數被接受，代表初版沒有逐欄拒絕超過 3 位小數。 |
+| `reserved_corruption` | FAIL | 交易內人為把 reserved 改成小於同 SKU 全部 pending 後，dispose 仍成功；代表初版沒有在處理前檢查「凍結數不能小於待處理數」。 |
 | `pending_guard` | PASS | 既有好貨 20 可派；第 21 件、`p_allow_negative=true`、直接負 movement 都被擋。 |
+| `role_edges` | PASS | `hq_accountant`、空 role、缺 `auth.uid()` 都被拒絕。 |
 | `rls_roles` | FAIL | HQ 正向讀 `v_hq_return_batches_list` 失敗：`permission denied for view v_hq_return_batches_list`。店家、跨租戶、匿名限制未報失敗。 |
-| `race_same_request` | FAIL | 第二個連線等第一個交易完成後，沒有重新吃到同 request 的冪等事件，反而回 `rpc_dispose_hq_return: batch 28 already completed`。不會直接多扣，但會讓安全重試失敗。保留追查 tenant：`0a9fd33b-d5d5-47e9-9d88-2269ff1050b8`。 |
-| `race_hold_negative` | FAIL | hold 建立中遇到直接負異動，第二連線沒有被拒絕，錯在「應回錯誤物件」但實際不是 Error。符合先查 pending、後等 balance lock、commit 後未重讀 pending 的競態疑慮。保留追查 tenant：`4288326c-ca13-46c6-9bab-fa43749cf1ae`。 |
+| `race_same_request` | FAIL | 第二個連線等第一個交易完成後，沒有重新吃到同 request 的冪等事件，反而回 `rpc_dispose_hq_return: batch 120 already completed`。不會直接多扣，但會讓安全重試失敗。保留追查 tenant：`7300f39c-1942-4678-89dd-d5f4d1b490f7`。 |
+| `race_hold_negative` | FAIL | hold 建立中遇到直接負異動，第二連線沒有被拒絕，錯在「應回錯誤物件」但實際不是 Error。符合先查 pending、後等 balance lock、commit 後未重讀 pending 的競態疑慮。保留追查 tenant：`66a7d81e-5f08-465b-8e3d-500bd8c5dbd9`。 |
+
+另單跑真收貨 NULL line 正向案例：
+
+```powershell
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial --case source_line_null_positive
+```
+
+結果：exit 0。這表示測試器已補上「真 `rpc_receive_transfer` / shortage 入庫 movement 可能沒有 line id」的實際路徑；A 修版不得無條件要求 movement.line_id 非 NULL。
+
+### 2. 本輪忠實度修正
+
+本輪重點不是多加功能測，而是修正測試是否真的打到要害：
+
+- `source_line_null_positive` 原本先讓 B trigger 自動建批，再手動呼叫 `_hq_hold_return(... source_reason='review fixture', auto_flag='manual')`。未來若 A 做完整 payload 去重，第二次手動 hold 可能應該被拒；所以已改成只驗 B 自動建出的批次，不再多呼叫一次 hold。
+- `source_validation` 原本用 `inboundMovement()` 更新 `transfer_items.in_movement_id`，也會先觸發 B 建批；後面的負例容易撞到「同 source_movement 已存在」早退，沒有忠實測來源防偽。現在改成備料階段短暫停用 `trg_hq_return_source`，把正確 `in_movement_id` 掛好後立刻恢復；assertion 開始時 trigger 已正常，且合法來源 control 先證明全對時可建批，再逐項測錯數量、錯地點、錯品項、錯原單行。
+
+來源證據：
+
+- `supabase/migrations/20260904020010_accept_store_return_deducts_stock.sql:368` 呼叫 `rpc_inbound`，`:376` 只傳 `p_source_doc_id => p_transfer_id`，沒有傳 `source_doc_line_id`；`:380` 才把 `transfer_items.in_movement_id` 指回該 movement。
+- `supabase/migrations/20260903000200_shortage_resolution_undo.sql:229`、`:271` 的短少回總倉也呼叫 `rpc_inbound`，`:237`、`:279` 只傳 `p_source_doc_id => v_item.transfer_id`，沒有傳 line id；`:404` 才寫 `shortage_restock_movement_id`。
+- `supabase/migrations/20260907020000_hq_return_disposition_sources.sql:242` 掛載的 trigger 名稱是 `trg_hq_return_source`；`:126`、`:210` 是 B trigger 把 `NEW.id` 作為 `p_source_transfer_item_id` 交給 A helper。
+
+另單跑本輪新增 4 組：
+
+```powershell
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial --case idempotency_replay_after_complete,idempotency_payload_fields,reserved_corruption,role_edges
+```
+
+結果：exit 1。`role_edges` PASS；另外 3 組 FAIL，與全驗結果一致。
 
 另單跑 `bad_numbers` 的確認命令：
 
@@ -83,7 +117,7 @@ FAIL bad_numbers: 四位小數拒絕: 四位小數拒絕 應該拒絕，但實�
 連線收尾確認：
 
 ```powershell
-node -e '...pg_stat_activity...'
+node -e 'const {Client}=require("pg");(async()=>{const c=new Client({host:"127.0.0.1",port:56427,user:"returnlocal",database:"return_disposition_test_core_initial"});await c.connect();const r=await c.query("select count(*)::int as n from pg_stat_activity where datname=$1 and pid<>pg_backend_pid()",["return_disposition_test_core_initial"]);console.log("other_open_connections="+r.rows[0].n);await c.end();})().catch(e=>{console.error(e.stack||e.message);process.exit(1);})'
 ```
 
 結果：`other_open_connections=0`，測試器沒有留下開著的連線。
@@ -93,13 +127,14 @@ node -e '...pg_stat_activity...'
 這支測試器目前抓以下幾類：
 
 1. `10 = 7 好 + 2 破 + 1 失`，含分次處理。
-2. 來源防偽：來源數量、地點、品項、原單行不符必須拒絕。
-3. 重複提交：同 request 同 payload 要冪等；同 request 不同 reason / notes 要拒絕。
-4. 壞數字：`NULL`、`NaN`、`Infinity`、超過 3 位小數不能默默收下。
-5. 待確認保護：`reserved >= pending`，既有好貨可派，但不能派到吃掉待確認量。
-6. `p_allow_negative=true` 與直接寫負庫存都不能繞過待確認保護。
-7. 權限：HQ 應能讀；同 tenant 店家、跨 tenant、匿名不能讀或處理總倉批次。
-8. 兩連線併發：
+2. 來源防偽：來源數量、地點、品項、原單行不符必須拒絕。這組現在備料時先掛好合法來源指標，並有合法來源正向 control，避免只測到「未掛來源」或既有 batch 早退。
+3. 真收貨相容：movement 的 `source_doc_line_id` 可為 NULL；此時必須靠 `transfer_items.in_movement_id` / `shortage_restock_movement_id` 反向指標、原單、位置、品項、數量來驗，不可把真收貨擋死。
+4. 重複提交：同 request 同 payload 要冪等；第一包 partial 後續被重送時要回第一包原結果；同 request 不同 goods_confirmed / reason / notes 要拒絕。
+5. 壞數字：`NULL`、`NaN`、`Infinity`、超過 3 位小數不能默默收下。
+6. 待確認保護：正常資料下既有好貨可派，但不能派到吃掉待確認量；另外故意破壞 reserved 小於 pending 時，dispose 必須拒絕。
+7. `p_allow_negative=true` 與直接寫負庫存都不能繞過待確認保護。
+8. 權限：HQ manager 應能讀；同 tenant 店家、跨 tenant、匿名、`hq_accountant`、空 role、缺 `auth.uid()` 不能讀或處理總倉批次。
+9. 兩連線併發：
    - 同 request 同時送，不可多扣或變成 `already completed`。
    - hold 建立中遇到直接負異動，不可因為先查 pending 後鎖 balance 而吃掉待確認量。
 
@@ -115,11 +150,20 @@ node -e '...pg_stat_activity...'
 
 ## 目前判斷
 
-P0：2（初版假庫已抓到來源防偽不足：數量不符、原單行不符未拒絕；併發 hold vs 直接負異動也未拒絕）
+P0：3 類
 
-P1：3（冪等/安全重試不足：同 request 不同 reason/notes 未拒絕，且併發同 request 變 already completed；4 位小數未精準拒絕；HQ 角色無法讀 view）
+- 來源防偽不足：數量不符、同租戶別總倉地點不符、原單行不符未拒絕。
+- reserved 一致性不足：人為破壞 reserved 小於 pending 後仍可 dispose。
+- 併發 hold vs 直接負異動未拒絕，可能吃掉待確認量。
+
+P1：3 類
+
+- 冪等 / 安全重試不足：同 request 不同 reason/notes 未拒絕；第一包 partial 後重送沒有回原結果；併發同 request 變 `already completed`。
+- 4 位小數未精準拒絕。
+- HQ manager 無法讀 view。
+
 P2：0
 
-已通過但仍需修版後重跑確認：分次 7/2/1、既有好貨可派且 pending 不可被一般出庫/allow_negative/直接負 movement 吃掉。
+已通過但仍需修版後重跑確認：分次 7/2/1、真收貨 NULL line 但 item 反向指標正確時可建待處理、正常資料下既有好貨可派且 pending 不可被一般出庫 / allow_negative / 直接負 movement 吃掉、`hq_accountant` / 空 role / 缺 auth.uid 的越權處理被拒絕。
 
 交付前置條件：等 D fixture 修版與 A 修版載入後，重新執行本測試器；若測試失敗，再依錯誤回報 A/B/C 實際缺口。

--- a/docs/return-disposition-core-runtime-test-report.md
+++ b/docs/return-disposition-core-runtime-test-report.md
@@ -1,0 +1,90 @@
+# 總倉退回貨處理 — 阿審核心 runtime 驗收器報告
+
+日期：2026-09-07  
+角色：阿審（獨立驗收準備）  
+限制：只新增測試碼與本報告；未改功能碼；未連 GitHub / Supabase；未讀 `.env`；目前 D fixture 修版尚未完成，所以本輪只做「可執行測試準備」，不宣稱測試已綠。
+
+本輪最小檢查：
+
+```powershell
+node --check D:\1人公司\_本機工地\new_erp_return_disposition_20260907\tests\return-disposition-review\core-runtime.cjs
+```
+
+結果：exit 0。這只代表測試器語法可解析，不代表資料庫整合已通過。
+
+2026-09-07 追加初版假庫反例：
+
+```powershell
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial
+```
+
+結果：exit 1，測試器先通過「10 件分 7 好 2 破 1 失、含分次處理」，接著在來源防偽案例停止：
+
+```text
+AssertionError [ERR_ASSERTION]: hold qty 大於來源 movement 應該拒絕，但實際成功
+```
+
+白話解讀：這證明驗收器不是空測；這次流程是先由 `inboundMovement` 讓 B 依同一筆來源 movement 建出 10 件 batch，再用同來源呼叫 `_hq_hold_return(... p_qty=11)`。初版 A 把這個「同來源、不同數量」的請求當成可接受的冪等回傳，沒有拒絕。這次反例沒有證明真的又多凍結 11 件，但已證明 A 來源防偽/冪等 payload 檢查不足；需等 A 修版後再重跑。
+
+## 本輪新增
+
+- `tests/return-disposition-review/core-runtime.cjs`
+
+用途：在老闆指定的本機 PostgreSQL 測試庫跑 A/B 核心驗收。它只接受：
+
+```powershell
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_<name>
+```
+
+安全邊界：
+
+- 固定連 `127.0.0.1:56427`
+- 固定 user `returnlocal`
+- 不讀 password / `.env`
+- DB 名稱不符合 `^return_disposition_test_[A-Za-z0-9_]+$` 直接拒絕
+- D fixture 未通知 ready 前，不應執行
+
+## 覆蓋重點
+
+這支測試器準備抓以下幾類錯：
+
+1. `10 = 7 好 + 2 破 + 1 失`，含分次處理。
+2. 來源防偽：來源數量、地點、品項、原單行不符必須拒絕。
+3. 重複提交：同 request 同 payload 要冪等；同 request 不同 reason / notes 要拒絕。
+4. 壞數字：`NULL`、`NaN`、`Infinity`、超過 3 位小數不能默默收下。
+5. 待確認保護：`reserved >= pending`，既有好貨可派，但不能派到吃掉待確認量。
+6. `p_allow_negative=true` 與直接寫負庫存都不能繞過待確認保護。
+7. 權限：同 tenant 店家、跨 tenant、匿名都不能讀或處理總倉批次。
+8. 兩連線併發：
+   - 同 request 同時送，不可多扣或變成 `already completed`。
+   - hold 建立中遇到直接負異動，不可因為先查 pending 後鎖 balance 而吃掉待確認量。
+
+## 覆蓋限制
+
+- 這是 runtime 驗收器；目前只在 `return_disposition_test_core_initial` 初版假庫跑到第一個反例，還沒在 D 最終 fixture / A 修版上完整跑完，不能當成「已驗收通過」。
+- 一般案例用交易 `ROLLBACK` 清假資料；兩連線 race 因為兩個連線必須互相看得到資料，使用專屬 tenant 造資料並保留 tenant id 供追查，不關 trigger、不硬刪 append-only 表、不自稱已清乾淨。
+- 錯誤檢查不是「任意 error 算過」：每個負案例都有指定錯誤訊息關鍵字，並比對狀態快照。
+- RLS 讀取不是「看不到就算安全」：測試器先驗 HQ 角色確實讀得到 view，再驗店家/跨租戶/匿名讀不到或被 42501 權限錯擋。
+- 併發測試不是只睡一下：測試器會用 `pg_stat_activity` 看到第二連線正在等 Lock，才繼續放行第一個交易。
+- RLS/GRANT 使用 `SET LOCAL ROLE authenticated/anon` 與 fixture 的 `request.jwt.*` stub；若 D fixture 改 auth stub 名稱，需同步調整 `setAuth()`。
+- 本支不測瀏覽器畫面、不測 C 撤回/更正完整流程、不測月鎖結帳金額；那些要等 B/C/D 全包完成後另跑整合驗收。
+
+## 目前判斷
+
+P0：1（初版假庫反例已抓到：同來源已建 10 件後，11 件的不一致 hold 請求未被拒絕；這是 A 功能已知問題，不是測試器問題）  
+P1：0（測試器語法檢查通過；完整 D fixture / A 修版 ready 後才會有完整功能結果）  
+P2：0
+
+交付前置條件：等 D fixture 修版載入真正 schema/RPC 後，執行本測試器；若測試失敗，再依錯誤回報 A/B/C 實際缺口。
+
+## 目前不可執行整合的原因
+
+CEO 目前回報的 D2 狀態是：已載入基底 DDL，但尚無 A/B，且 `_current_tenant_id` 漏載；A 修版、B/F、E、C 都尚未交到可驗收 patch。因此現在若硬跑 `core-runtime.cjs`，會只得到「缺核心函式 / 缺租戶 helper」這類前置環境錯，不是功能驗收結果。
+
+等可以跑時，最低條件是：
+
+- 測試 DB 名稱符合 `return_disposition_test_...`
+- D fixture 已載入 `_current_tenant_id`、`auth.uid()`、`auth.jwt()` 的本機 stub
+- A 核心已載入 `_hq_hold_return`、`rpc_dispose_hq_return`、`trg_guard_hq_pending`、`v_hq_return_batches_list`
+- B 來源接線若要驗自動建批，需載入；本測試器主體仍可用 helper 直接建待處理批次驗 A 核心
+- `authenticated` / `anon` 角色存在，且能用 `SET LOCAL ROLE` 真測 RLS/GRANT

--- a/docs/return-disposition-f-ui-review.md
+++ b/docs/return-disposition-f-ui-review.md
@@ -1,0 +1,104 @@
+# 總倉退回貨 F-UI：補貨可派量／短少文案入口審查
+
+審查時間：2026-09-07
+
+審查者：Codex GPT-5.5 阿審。
+
+範圍：
+
+- `apps/admin/src/app/(protected)/inventory/page.tsx`
+- `apps/admin/src/app/(protected)/wms/picking/page.tsx`
+- `apps/admin/src/components/TransferShortageResolveModal.tsx`
+- `tests/return-disposition-review/f-ui-copy-runtime.cjs`
+
+禁止事項遵守：未連 GitHub、未連 Supabase、未碰正式資料、未讀 `.env`、未改功能碼、未 commit。
+
+## 結論
+
+F-UI 目前可交下一輪整包驗收；本輪未發現 F-UI 自身 P0/P1/P2。
+
+這三檔主要把畫面文字從「庫存」改成「帳面／凍結／可派」，並把短少「記回總倉」改成不承諾實物已到、不承諾立刻可補派。這個方向符合老闆拍板的規則：帳回總倉不等於貨已確認；補貨只能用已確認可派的好貨。
+
+## P0
+
+- 0。
+
+## P1
+
+- 0。
+
+## P2
+
+- 0。
+
+## 已核實正確 / 不列問題
+
+### inventory：總倉列沒有再把帳面數說成可用貨
+
+依據：
+
+- `inventory/page.tsx:621-622` 欄名改為「帳面庫存」，tooltip 說明總倉列會另列凍結與可派，且不代表實物已完成檢查。
+- `inventory/page.tsx:650` 用 `Math.max(r.on_hand - r.reserved, 0)` 算 `hqAvailable`。
+- `inventory/page.tsx:686-690` 總倉列清楚分三行：「帳上」「凍結」「可派」。
+- `inventory/page.tsx:698-700` 非總倉若有 reserved，也只顯示「凍結」，不再使用舊的「保留／可用」假欄位語氣。
+
+白話判斷：畫面現在有把「帳上看到」和「真的能拿去派」分開，沒有再把待確認退回貨包進可派量。
+
+### picking：補貨工作台文案對齊後端可派量
+
+依據：
+
+- `wms/picking/page.tsx:88` 型別註解把 `gr_qty` 標成「HQ 可派（on_hand - reserved，下限 0）」。
+- `wms/picking/page.tsx:1280` 預設分配註解改成用 HQ 可派。
+- `wms/picking/page.tsx:2008` 表頭改成「HQ 可派」。
+- `wms/picking/page.tsx:2059` input tooltip 改成「申請、可派、已撿」。
+
+白話判斷：補貨畫面沒有再說「HQ 庫存」讓員工以為帳面全部都能派；文案跟 F 後端 `on_hand - reserved` 口徑一致。
+
+### TransferShortageResolveModal：短少不再承諾未知貨可補派
+
+依據：
+
+- `TransferShortageResolveModal.tsx:566` 把「記一筆退回」改成「記一筆帳務退回」。
+- `TransferShortageResolveModal.tsx:639-645` 明列補派只能拿「其他已確認可派的好貨」，這次記回的數量會先凍結，帳回不表示實物已到或已驗完。
+- `TransferShortageResolveModal.tsx:661-663` 月結文字改成待月結重算，並提醒分店價差需核對月結明細，沒有承諾固定退款金額。
+- `TransferShortageResolveModal.tsx:332-333` 退回貨處理入口只給 `owner`、`admin`、`hq_manager`。
+- `TransferShortageResolveModal.tsx:649` 入口指向 `/wms/return-disposition`。
+
+白話判斷：短少同意後，畫面現在講的是「先記帳、先凍結、等確認」，沒有再暗示貨已回來或一定派得出去。
+
+## 本機實跑證據
+
+### 離線新舊文案測試
+
+```powershell
+node --check tests\return-disposition-review\f-ui-copy-runtime.cjs
+node tests\return-disposition-review\f-ui-copy-runtime.cjs
+```
+
+結果：exit 0。
+
+重點：
+
+- 目前三檔通過新口徑斷言。
+- 同一支測試會讀 `85c06f44` 舊版三檔，舊版如預期失敗；所以不是只 grep 新檔有沒有幾個字。
+
+### 三檔 lint
+
+```powershell
+npm run lint --workspace apps/admin -- 'src/app/(protected)/inventory/page.tsx' 'src/app/(protected)/wms/picking/page.tsx' 'src/components/TransferShortageResolveModal.tsx'
+```
+
+結果：exit 1，6 error / 2 warning。
+
+本次判斷：
+
+- `TransferShortageResolveModal.tsx` 沒有 lint error。
+- inventory 3 個 effect setState error、picking 3 個 effect setState error + 2 warning，與 CEO 用 ESLint API 對照舊版／新版的結果一致，屬既有 lint 債，不是本次 F-UI 新增。
+- 仍不能把「三檔 lint exit 1」回報成乾淨；只能說本次 F-UI 差異沒有新增這些 lint 問題。
+
+## 邊界
+
+- 這是 UI 文案／入口審查，不是瀏覽器人工操作驗收。
+- 這份不驗 C 撤回、不驗 D fixture、不驗 F SQL；那些已有各自報告。
+- 沒有跑正式系統，不能視為上線驗收。

--- a/docs/return-disposition-fixture-review.md
+++ b/docs/return-disposition-fixture-review.md
@@ -88,3 +88,63 @@ node -e 'const {Client}=require("pg"); const c=new Client({host:"127.0.0.1",port
 
 - 我沒有重跑 `node tests/return-disposition/fixture.cjs --db-name ...`，因為那會建立新假 DB；本輪只做靜態 review、語法檢查、diff whitespace 檢查，以及對既有 `return_disposition_test_d3` 的只讀查詢。
 - 本 loader 是最小測試載入器，不含完整 ERP。C/F 未交件、以及業務 helper 仍 fail-closed，不算 D 小修自己的 P1；若未來宣稱支援某條完整路徑，就要載入該路徑真 helper 或補明確測試。
+
+## 2026-09-07 D3 / 040 view / 真月結前置複審
+
+範圍：只審 `tests/return-disposition/fixture.cjs`、`tests/return-disposition/README.md`、以及 CEO 後補的 `tests/return-disposition-review/README.md` 說明；未改功能碼、未連外、未碰正式資料。
+
+### 結論
+
+D3 小修目前可作為本案假庫載入器使用；未發現 D 自身 P0/P1/P2。
+
+它已把 `--with-all` 從「只湊到能載 C/F」推進到「能讓 C 內重建的真月結產生器實際跑完、且 draft 明細可重建」。但這仍是本案有界 fixture，不是完整 ERP 載入器，也不是全 ERP 權限驗收。
+
+### 本輪新增核對
+
+已實跑：
+
+```powershell
+node --check tests\return-disposition\fixture.cjs
+node tests\return-disposition\fixture.cjs --db-name return_disposition_test_d3_review_20260907 --with-all
+```
+
+結果：exit 0。`return_disposition_test_d3_review_20260907` 是本輪新建假庫；loader 若同名 DB 已存在會直接拒絕，沒有 drop 或覆蓋既有假庫。
+
+已確認 `--with-all`：
+
+- F 的 `v_picking_demand_no_po` 只從 `20260612000040_approve_restock_via_picking_workstation.sql` 用 AST 抽真正 view，不整支載入 040，避免把新版 `rpc_create_wave_from_restock` 蓋回舊版。
+- 真月結前置只從明確檔名、明確 AST selector 抽指定物件；每個 selector 必須剛好一筆，找不到或多筆都 fail。
+- 前置包含：`entry_type`、draft 可重建 trigger、六種月結明細 CHECK 與 `description`、雙口徑欄位與真 `_branch_price_at`、真 `store_settlement_adjustments`、真 `v_store_aid_transfer_legs`。
+- README 已說明：基底 schema 抽取會跳過 RLS/POLICY/GRANT/COMMENT；但 A/B/C/F 候選 migration 是原樣全載，包含本案自己的 policy/grant。不能把這句擴大解讀成「全 ERP 權限都驗過」。
+- `tests/return-disposition-review/README.md` 已把舊 `review_assertions.sql` 標成歷史草稿；該檔用名字猜表、不含 `hq_return_batches`，不應再當現行驗收依據。
+
+真月結正向 control：
+
+```powershell
+node -e 'const {Client}=require("pg");(async()=>{const c=new Client({host:"127.0.0.1",port:56427,user:"returnlocal",database:"return_disposition_test_d3_review_20260907"});await c.connect();await c.query("begin");try{await c.query("update prices set effective_from = now() - make_interval(days => 30)");const r1=await c.query("select public.rpc_generate_hq_to_store_settlement($1::date,$2::uuid) as result",["2026-09-01","22222222-2222-2222-2222-222222222222"]);const n1=await c.query("select count(*)::int n from store_monthly_settlement_items");const r2=await c.query("select public.rpc_generate_hq_to_store_settlement($1::date,$2::uuid) as result",["2026-09-01","22222222-2222-2222-2222-222222222222"]);const n2=await c.query("select count(*)::int n from store_monthly_settlement_items");console.log(JSON.stringify({first:r1.rows[0].result,itemsAfterFirst:n1.rows[0].n,second:r2.rows[0].result,itemsAfterSecond:n2.rows[0].n}));}finally{await c.query("rollback");await c.end();}})().catch(e=>{console.error(e.stack||e.message);process.exit(1);});'
+```
+
+結果：
+
+```json
+{"first":{"month":"2026-09","stores_count":1,"total_amount":750,"total_adjustment":0,"total_cost_amount":500,"total_branch_amount":750},"itemsAfterFirst":1,"second":{"month":"2026-09","stores_count":1,"total_amount":750,"total_adjustment":0,"total_cost_amount":500,"total_branch_amount":750},"itemsAfterSecond":1}
+```
+
+這個 control 有在交易內把假 prices 的 `effective_from` 前移 30 天，避免因 fixture 價格日期晚於假派車日而查不到分店價。這不是改財務算法，也不是 stub `_branch_price_at`；只是讓假資料具備可核對的有效價格。
+
+### P0
+
+- 0。
+
+### P1
+
+- 0。
+
+### P2
+
+- 0。首輪 P2-1（040 view 不是最新版）已關閉：現在抽 `20260612000040` 的真正 view。首輪 P2-2（README/註解殘留 trim_scale 輕量 stub 說法）已關閉：README 與程式註解已改成不提供 `trim_scale` stub。
+
+### 邊界
+
+- D3 fixture 只保證本案 A/B/C/F 與指定真前置可載入、可支撐本案 runtime；不代表完整 ERP 所有 migration、所有 RLS/GRANT、所有月結送出／確認／收款流程都已驗。
+- 本輪沒有 drop 任何既有假庫；新建 `return_disposition_test_d3_review_20260907` 只供本地驗證保留。

--- a/docs/return-disposition-fixture-review.md
+++ b/docs/return-disposition-fixture-review.md
@@ -1,0 +1,90 @@
+# 總倉退回貨處理 — D 測試載入器小修審查
+
+日期：2026-09-07
+
+角色：Codex 側 GPT-5.5 阿審（獨立 review）
+範圍：只審本輪作者修改 `tests/return-disposition/fixture.cjs`、`tests/return-disposition/README.md`。未修改功能碼、SQL、既有測試或其他報告；未連 GitHub / Supabase；未讀 env / 密鑰；未安裝套件；未重跑會建立資料庫的 fixture loader。
+
+## 實際檢查
+
+已讀：
+
+- `tests/return-disposition/fixture.cjs`
+- `tests/return-disposition/README.md`
+- `supabase/migrations/20260707000020_trial_expiry_enforcement.sql`
+- `supabase/migrations/20260515000002_rpc_store_self_service.sql`
+- `supabase/migrations/20260612000030_v_picking_demand_no_po.sql`
+- `supabase/migrations/20260612000040_approve_restock_via_picking_workstation.sql`
+- `supabase/migrations/20260907010000_hq_return_disposition_core.sql`
+- `supabase/migrations/20260907020000_hq_return_disposition_sources.sql`
+
+已執行：
+
+```powershell
+node --check tests/return-disposition/fixture.cjs
+```
+
+結果：exit 0。
+
+```powershell
+git diff --check -- tests/return-disposition/fixture.cjs tests/return-disposition/README.md
+```
+
+結果：exit 0；只有 Git 對 LF/CRLF 的提醒，沒有 whitespace error。
+
+```powershell
+node -e 'const {Client}=require("pg"); const c=new Client({host:"127.0.0.1",port:56427,user:"returnlocal",database:"return_disposition_test_d3"}); const q="SELECT to_regprocedure(''public._current_tenant_id()'') IS NOT NULL AS tenanthelper, to_regprocedure(''public._next_transfer_no()'') IS NOT NULL AS transferhelper, to_regprocedure(''public.trim_scale(numeric)'') IS NULL AS no_trim_scale, EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = ''public'' AND p.proname = ''rpc_mark_orders_shipping_for_wave'' AND pg_get_functiondef(p.oid) LIKE ''%RAISE EXCEPTION%'') AS shippingstub_raise"; c.connect().then(()=>c.query(q)).then(r=>{console.log(JSON.stringify(r.rows[0]));}).finally(()=>c.end()).catch(e=>{console.error(e.message); process.exit(1);});'
+```
+
+結果：exit 0。
+
+```json
+{"tenanthelper":true,"transferhelper":true,"no_trim_scale":true,"shippingstub_raise":true}
+```
+
+另有一次 `psql` 查詢嘗試失敗，原因是本機 PATH 找不到 `psql`，未查到 DB、未改資料。
+
+## 核對結果
+
+- `_current_tenant_id`：loader 從 `20260707000020_trial_expiry_enforcement.sql` 載入，該檔是真正加上 `tenants.status` 守門的版本；全 migrations 搜到後續沒有再重建 `_current_tenant_id`。
+- `_next_transfer_no`：loader 從 `20260515000002_rpc_store_self_service.sql` 載入，該檔定義 `TR{YYMMDD}{seq4}`；全 migrations 搜到後續沒有再重建 `_next_transfer_no`。
+- `trim_scale`：本輪已從 fake helper 刪除；只讀假 DB 查到 `public.trim_scale(numeric)` 不存在，符合「不要用假 trim_scale 掩蓋缺依賴」。
+- `rpc_mark_orders_shipping_for_wave`：本輪從 no-op 改成 RAISE；只讀假 DB 查到 stub 內含 `RAISE EXCEPTION`，符合 fail-closed。
+- `--with-all`：程式碼採明確檔名載入 A/B/C/F，不掃 pattern；本工地目前只有 A、B，C/F 未交件不算 D 自身缺陷。
+
+## P0
+
+無。
+
+## P1
+
+無。
+
+## P2
+
+### P2-1：`--with-all` 的 `v_picking_demand_no_po` 前置不是最新版，文件要講清楚這是輕量載入限制
+
+證據：
+
+- `fixture.cjs:827` 載入 `20260612000030_v_picking_demand_no_po.sql`。
+- 全 migrations 搜到 `20260612000040_approve_restock_via_picking_workstation.sql:53` 後續又 `CREATE OR REPLACE VIEW public.v_picking_demand_no_po AS`。
+
+影響：目前 CEO 已驗 `--with-all` 可套前置 030/A/B，到 C 缺檔才停，這對「缺檔即 fail」是有用的；但不能把它說成完整 ERP 最新狀態。若 F 未來依賴 040 收緊後的 view 語意，這個 loader 會偏離正式系統。
+
+建議：README 明寫 `--with-all` 目前只載 F 所需的輕量前置，不代表完整 ERP 最新 view；若 F 測試需要派貨工作台最新語意，再改載 040 或補明確對拍。
+
+### P2-2：README / 程式註解仍殘留「真實輕量（trim_scale 等）」說法
+
+證據：
+
+- `fixture.cjs:399` 註解仍寫 `🔧 真實輕量（trim_scale 等）`。
+- README 載入流程仍寫 helper stubs 分成「通知類 no-op / 庫存類 RAISE / 真實輕量」，但本輪已刻意刪掉 fake `trim_scale`。
+
+影響：不影響 loader 執行；但下一個人可能誤以為 `trim_scale` 已由 fixture 提供，進而誤判缺依賴。
+
+建議：之後順手把註解改成「sequences / 簡單 stub」，不要再點名 `trim_scale`。
+
+## 限制
+
+- 我沒有重跑 `node tests/return-disposition/fixture.cjs --db-name ...`，因為那會建立新假 DB；本輪只做靜態 review、語法檢查、diff whitespace 檢查，以及對既有 `return_disposition_test_d3` 的只讀查詢。
+- 本 loader 是最小測試載入器，不含完整 ERP。C/F 未交件、以及業務 helper 仍 fail-closed，不算 D 小修自己的 P1；若未來宣稱支援某條完整路徑，就要載入該路徑真 helper 或補明確測試。

--- a/docs/return-disposition-local-verification.md
+++ b/docs/return-disposition-local-verification.md
@@ -14,8 +14,10 @@
 | E 待處理畫面初版 | 完整 tsc exit 0；新增頁 lint 有 2 項 set-state-in-effect 錯誤；阿審訂正版 P0=0／P1=8／P2=4 | 輸入、重送、權限、來源等問題未修，未放行 |
 | D 測試載入器第二版 | 新假庫 d2 真載入基底 DDL 44／29／43／21／13／9 statements，seed 成功，exit 0 | `_current_tenant_id` 仍漏載，不是整合驗收通過 |
 | 初版 A/B 實際載入假庫 | 真 PostgreSQL 成功套入 core_initial；匿名 auth.uid() 回 NULL | 只是安裝測試，不是業務／安全驗收 |
-| 阿審 runtime 驗收器，CEO 複跑 | 第1組 10件分次成7好／2破／1失通過；第2組來源數量不一致反例失敗，整支 exit 1 | 初版接受同來源10件卻送11件的請求，尚未通過；後面權限／並行等案例未跑到 |
+| 下午 runtime 驗收器，CEO 複跑 | 第1組 10件分次成7好／2破／1失通過；第2組來源數量不一致反例失敗，整支 exit 1 | 初版接受同來源10件卻送11件的請求，尚未通過；當時後面權限／並行等案例未跑到 |
 | E 實碼小數輸入抽驗 | 從 TS AST 取實際 clampDecimal 執行：`1.`→`1`，`1e3`→`1`，上限0.75時`1`→`0`，`0.0009`→`0.000` | 會靜默改輸入值，不是合格的小數驗證；阿審已更正初審的可接受判斷，列 P1 |
+| E 阿審離線回歸測試，CEO 複跑 | 真實函式 AST 抽取後執行，4 項小數檢查＋3 項 UUID fallback 檢查均失敗，exit 1；測試檔語法 exit 0 | 7 項斷言失敗不是 7 個獨立漏洞；只證明輸入及識別碼問題，尚未驗到完整畫面重送流程 |
+| 晚間 core 全 8 群，CEO 複跑 | 2 PASS（分次7/2/1、一般出庫保護）；6 FAIL（來源、重送、小數、HQ讀取、並行同請求、並行凍結／負異動），exit 1 | 實際是未退修 A/B 初版；拆開收集錯誤不等於已修正，不能交付現場 |
 
 完整指令均只在本機執行：
 
@@ -27,6 +29,8 @@ node scripts/check-sql-syntax.cjs supabase/migrations/20260907010000_hq_return_d
 node tests/return-disposition/fixture.cjs --db-name return_disposition_test_d2
 node D:\1人公司\_本機工地\return-disposition-tools\probe-initial-core.cjs
 node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial --case all
+node tests/return-disposition-review/ui-input-runtime.cjs
 ```
 
 其中 D1 初版失敗：用 regex 判斷含前置註解的 SQL，必要表全被略過且吞掉 missing-object 錯誤，最後失敗。D2 改 AST 判斷後能載入，但真查 `_current_tenant_id` 仍報不存在；摘要說有載不能當證據。
@@ -49,4 +53,14 @@ Claude 交件原始紀錄在 `D:\1人公司\_本機工地\return-disposition-too
 
 本檔記錄已執行證據，不替代主需求單第九節；不得因本機存檔就宣稱本案完成或 WV260831002454 已救回。
 
-收尾：本案專用 PostgreSQL 已用已核對的 `return-disposition-tools/pgdata` 路徑正常停止，原啟動會話也已結束；假庫／測試檔保留，沒有刪資料。所有 Claude 本案派工程序均已結束。恢復施工需先啟動同一個本機假庫，不能改用真正系統來補驗。
+下午收尾：本案專用 PostgreSQL 已用已核對的 `return-disposition-tools/pgdata` 路徑正常停止，原啟動會話也已結束；假庫／測試檔保留，沒有刪資料。當時所有 Claude 本案派工程序均已結束。
+
+## 晚間續工的實際阻擋（2026-09-07，20:46 後）
+
+已過先前顯示的額度恢復時間，依老闆「繼續啊」實際重派 A/D，兩筆皆 `is_error=true`，回覆 `Your organization does not have access to Claude. Please login again or contact your administrator.`，沒有可套用修版。原始結果保存在工具資料夾 `writer-core-a-resume-result.jsonl` 與 `writer-fixture-d-resume-result.jsonl`。停止其餘派工，不換帳號／購買額度／重試權限拒絕。
+
+唯讀登入查核顯示 loggedIn=true、claude.ai／firstParty／max，exit 0；只代表本機登入狀態，不能用來否定服務端拒絕。沒有重新登入或讀取憑證。須使用者處理原 Claude 帳號登入／權限後才可恢復阿寫施工，不能再說只是等 20:10。
+
+本案專用假庫曾重新啟動並確認 127.0.0.1:56427 接受本機連線。阿審完成本輪獨立測群與 UI 實碼回歸檢查，CEO 複跑結果相同；功能候選仍是未退修初版，不得將測試新增等同修好。UI 測試存檔 `89aaa0d6`，完整結果見 `return-disposition-ui-runtime-test-report.md` 與 `return-disposition-core-runtime-test-report.md`。
+
+21:00 收尾：CEO 查核心假庫其他連線為 0 後，正常停止專用 PostgreSQL（exit 0），確認 127.0.0.1:56427 無回應。一般案例交易回滾，並行測試用的專屬假資料保留供追查，未刪除任何資料。所有阿審工作與本輪 Claude 程序均已結束；沒有背景施工或自動續跑。阿寫仍須原帳號登入／權限恢復，GitHub／Supabase／真帳禁令不變。

--- a/docs/return-disposition-local-verification.md
+++ b/docs/return-disposition-local-verification.md
@@ -11,10 +11,11 @@
 | 少收檔 lint | 改前／改後同一項既有 set-state-in-effect 錯誤，無新增 | 不是全站 lint 全綠 |
 | A 核心 SQL 初版 | parser 34 statements／4 函式通過 | 阿審仍有 2 P0／5 P1，未放行 |
 | B 來源 SQL 初版 | parser 7 statements／1 函式通過 | 阿審仍有 2 P1／1 P2，未放行 |
-| E 待處理畫面初版 | 完整 tsc exit 0；新增頁 lint 有 2 項 set-state-in-effect 錯誤 | 輸入、重送、權限、來源等抽驗問題未修 |
+| E 待處理畫面初版 | 完整 tsc exit 0；新增頁 lint 有 2 項 set-state-in-effect 錯誤；阿審訂正版 P0=0／P1=8／P2=4 | 輸入、重送、權限、來源等問題未修，未放行 |
 | D 測試載入器第二版 | 新假庫 d2 真載入基底 DDL 44／29／43／21／13／9 statements，seed 成功，exit 0 | `_current_tenant_id` 仍漏載，不是整合驗收通過 |
 | 初版 A/B 實際載入假庫 | 真 PostgreSQL 成功套入 core_initial；匿名 auth.uid() 回 NULL | 只是安裝測試，不是業務／安全驗收 |
 | 阿審 runtime 驗收器，CEO 複跑 | 第1組 10件分次成7好／2破／1失通過；第2組來源數量不一致反例失敗，整支 exit 1 | 初版接受同來源10件卻送11件的請求，尚未通過；後面權限／並行等案例未跑到 |
+| E 實碼小數輸入抽驗 | 從 TS AST 取實際 clampDecimal 執行：`1.`→`1`，`1e3`→`1`，上限0.75時`1`→`0`，`0.0009`→`0.000` | 會靜默改輸入值，不是合格的小數驗證；阿審已更正初審的可接受判斷，列 P1 |
 
 完整指令均只在本機執行：
 
@@ -38,13 +39,13 @@ node tests/return-disposition-review/core-runtime.cjs --db-name return_dispositi
 - B：人工／系統操作者時序、原單 source_doc 核對；說清原因快照不含收貨當下新增備註。以 `return-disposition-source-review.md` 為準。
 - E：UUID fallback 非 UUID、輸入小數會被悄悄改值、未知送達時不能換新碼重扣、精確 HQ 角色、shortage 應顯示原收貨門市、原單號、分頁／完整事件、鍵盤與標籤、移除技術詞、新 lint 錯誤。具體退修已派 `writer-front-e-fix.md`，尚未收到有效修版。
 - D：漏載租戶 helper、手抄／stub 的覆蓋限制、完整 A/B/C/F 載入；本機實測不可只看 setup exit 0。
-- C／F：原單更正／撤回／真退貨月鎖、補貨可派量、後端通用少收阻擋與相關画面口徑，尚未整包交件。
+- C／F：原單更正／撤回／真退貨月鎖、補貨可派量、後端通用少收阻擋與相關畫面口徑，尚未整包交件。
 
 ## 施工來源與中斷原因
 
 Claude 交件原始紀錄在 `D:\1人公司\_本機工地\return-disposition-tools\writer-*-result.jsonl`。部分結果是 `is_error=true`，即使工具同時標 subtype=success，也不能當成功交件。
 
-首輪 A/D 大退修曾超過 16,000 輸出長度，沒有套用任何半截。調高接收上限後 D 修版成功；A 修版、E 修版、B/F、D 小修、C 全部被 Claude 額度上限擋下，工具顯示台北 20:10 恢復。未重試限額、未切換帳號、未取得新額度或付費。沒有把候選初版當成已修清問題。F 前端派工稿已備妥，但沒有实际派出。
+首輪 A/D 大退修曾超過 16,000 輸出長度，沒有套用任何半截。調高接收上限後 D 修版成功；A 修版、E 修版、B/F、D 小修、C 全部被 Claude 額度上限擋下，工具顯示台北 20:10 恢復。未重試限額、未切換帳號、未取得新額度或付費。沒有把候選初版當成已修清問題。F 前端派工稿已備妥，但沒有實際派出。
 
 本檔記錄已執行證據，不替代主需求單第九節；不得因本機存檔就宣稱本案完成或 WV260831002454 已救回。
 

--- a/docs/return-disposition-local-verification.md
+++ b/docs/return-disposition-local-verification.md
@@ -12,12 +12,15 @@
 | A 核心 SQL 初版 | parser 34 statements／4 函式通過 | 阿審仍有 2 P0／5 P1，未放行 |
 | B 來源 SQL 初版 | parser 7 statements／1 函式通過 | 阿審仍有 2 P1／1 P2，未放行 |
 | E 待處理畫面初版 | 完整 tsc exit 0；新增頁 lint 有 2 項 set-state-in-effect 錯誤；阿審訂正版 P0=0／P1=8／P2=4 | 輸入、重送、權限、來源等問題未修，未放行 |
-| D 測試載入器第二版 | 新假庫 d2 真載入基底 DDL 44／29／43／21／13／9 statements，seed 成功，exit 0 | `_current_tenant_id` 仍漏載，不是整合驗收通過 |
+| D 測試載入器第二版（歷史） | 新假庫 d2 真載入基底 DDL 44／29／43／21／13／9 statements，seed 成功，exit 0 | 當時 `_current_tenant_id` 仍漏載，不是整合驗收通過 |
+| D 登入後小修 | d3 新假庫載入 exit 0；真租戶／單號 helper 存在、假 trim_scale 不存在、出貨 stub 會 RAISE，四項 true；阿審 P0=0／P1=0／P2=2 | `--with-all` 在未交件 C 缺檔而 exit 1；不含完整 ERP，不能當整合通過 |
 | 初版 A/B 實際載入假庫 | 真 PostgreSQL 成功套入 core_initial；匿名 auth.uid() 回 NULL | 只是安裝測試，不是業務／安全驗收 |
 | 下午 runtime 驗收器，CEO 複跑 | 第1組 10件分次成7好／2破／1失通過；第2組來源數量不一致反例失敗，整支 exit 1 | 初版接受同來源10件卻送11件的請求，尚未通過；當時後面權限／並行等案例未跑到 |
 | E 實碼小數輸入抽驗 | 從 TS AST 取實際 clampDecimal 執行：`1.`→`1`，`1e3`→`1`，上限0.75時`1`→`0`，`0.0009`→`0.000` | 會靜默改輸入值，不是合格的小數驗證；阿審已更正初審的可接受判斷，列 P1 |
 | E 阿審離線回歸測試，CEO 複跑 | 真實函式 AST 抽取後執行，4 項小數檢查＋3 項 UUID fallback 檢查均失敗，exit 1；測試檔語法 exit 0 | 7 項斷言失敗不是 7 個獨立漏洞；只證明輸入及識別碼問題，尚未驗到完整畫面重送流程 |
 | 晚間 core 全 8 群，CEO 複跑 | 2 PASS（分次7/2/1、一般出庫保護）；6 FAIL（來源、重送、小數、HQ讀取、並行同請求、並行凍結／負異動），exit 1 | 實際是未退修 A/B 初版；拆開收集錯誤不等於已修正，不能交付現場 |
+| 登入後 core 擴充 13 群，CEO 複跑 | 4 PASS／9 FAIL，exit 1；新增來源 line 可空、完成後重送、完整 payload、reserved 不足及角色邊界 | 仍是未退修 A/B 初版；多通過兩群不是修好，9 群失敗也不是 9 個獨立缺陷 |
+| Codex 阿審 E 重送元件測試，CEO 複跑 | jsdom + ReactDOM 真渲染初版；未知結果後改量／換 ID／重開頁，5 項 runtime FAIL，exit 1；另 3 項 OBSERVE 不計斷言 | 外部依賴全部 stub，只證明頁面會送出不同請求，不是對真帳實做重複扣量；不可宣稱重送安全 |
 
 完整指令均只在本機執行：
 
@@ -42,7 +45,7 @@ node tests/return-disposition-review/ui-input-runtime.cjs
 - A：來源量／位置／原單防偽、並行凍結與出庫、HQ 讀取權限和授權、重送完整比對、小數精度、reserved 一致性、沿用既有異動類型。以 `return-disposition-core-review.md` 為準。
 - B：人工／系統操作者時序、原單 source_doc 核對；說清原因快照不含收貨當下新增備註。以 `return-disposition-source-review.md` 為準。
 - E：UUID fallback 非 UUID、輸入小數會被悄悄改值、未知送達時不能換新碼重扣、精確 HQ 角色、shortage 應顯示原收貨門市、原單號、分頁／完整事件、鍵盤與標籤、移除技術詞、新 lint 錯誤。具體退修已派 `writer-front-e-fix.md`，尚未收到有效修版。
-- D：漏載租戶 helper、手抄／stub 的覆蓋限制、完整 A/B/C/F 載入；本機實測不可只看 setup exit 0。
+- D：漏載租戶 helper 已由 Claude 小修修正並真跑；仍是輕量載入器，兩項文件 P2 與完整業務依賴限制見 `return-disposition-fixture-review.md`。C/F 未交件使 `--with-all` 正確失敗，不能宣稱全鏈驗收。
 - C／F：原單更正／撤回／真退貨月鎖、補貨可派量、後端通用少收阻擋與相關畫面口徑，尚未整包交件。
 
 ## 施工來源與中斷原因
@@ -64,3 +67,30 @@ Claude 交件原始紀錄在 `D:\1人公司\_本機工地\return-disposition-too
 本案專用假庫曾重新啟動並確認 127.0.0.1:56427 接受本機連線。阿審完成本輪獨立測群與 UI 實碼回歸檢查，CEO 複跑結果相同；功能候選仍是未退修初版，不得將測試新增等同修好。UI 測試存檔 `89aaa0d6`，完整結果見 `return-disposition-ui-runtime-test-report.md` 與 `return-disposition-core-runtime-test-report.md`。
 
 21:00 收尾：CEO 查核心假庫其他連線為 0 後，正常停止專用 PostgreSQL（exit 0），確認 127.0.0.1:56427 無回應。一般案例交易回滾，並行測試用的專屬假資料保留供追查，未刪除任何資料。所有阿審工作與本輪 Claude 程序均已結束；沒有背景施工或自動續跑。阿寫仍須原帳號登入／權限恢復，GitHub／Supabase／真帳禁令不變。
+
+## 原帳號登入後的本輪事實（2026-09-07 21:38）
+
+老闆自行完成可見視窗的登入並回覆「好了」。真實 Claude 恢復讀檔，D 有效交件 `writer-fixture-d-afterlogin-result.jsonl` 已機械轉換 unified diff 外框後套用，未改作者的增刪內容。A／B-F／E 後續皆 `is_error=true`，回報 `You've hit your limit · resets 2:20am (Asia/Taipei)`，三個程序已結束、沒有有效修版。不反覆重試、切換帳號、付費，也不再把先前組織權限拒絕說成現況。9/8 02:20 是服務回報時間，不保證屆時必定可用。
+
+本輪 CEO 已實跑：
+
+```powershell
+node --check tests/return-disposition/fixture.cjs
+node tests/return-disposition/fixture.cjs --db-name return_disposition_test_d3
+node tests/return-disposition/fixture.cjs --db-name return_disposition_test_d3_all --with-all
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial
+```
+
+依序結果 0／0／1／1；第三筆通過輕量前置 030 及 A/B，因尚缺 C 而停止，並非前置 view 無法建立；第四筆 13 群 4 PASS／9 FAIL。D3 四個 helper／stub 查證全 true，Codex GPT-5.5 阿審獨立唯讀重查也全 true；D 審查 P0=0／P1=0／P2=2，報告已落檔。P2 是載入器範圍說明與殘留註解，暫留不影響本輪真租戶 helper / fail-closed 修正；不可用 D 放行整案。
+
+老闆新指示「換 CODEX 的阿審來審」後，實際續派兩位 Codex 側 GPT-5.5 獨立審查員：一位查來源測試準備資料是否忠實，一位補未知送達／關頁重開的畫面重送證據。尚無阿寫功能修版，不由 CEO 或阿審包辦施工。專用假庫目前只供本輪本機測試，假資料全保留；GitHub／Supabase／真帳禁令不變。
+
+CEO 另以本機 JSONL 核對失敗前的已顯示訊息：A 與 E 都先出現 `response exceeded the 48000 output token maximum`，才到額度用完；沒有完整 patch 或 StructuredOutput 可以救回，不套半截。已更新原退修母稿，下一輪要拆有界小包、medium effort 逐包收齊，不原樣重送大包或再拉高輸出上限；這是派工方式修正，未新增 Claude 請求，也不是功能交件。D 已本機存檔 `2a151fdd`，包含 Claude 原改動與 Codex 阿審報告。
+
+## Codex 阿審本輪定稿與安全收尾
+
+- 兩位獨立阿審均為 Codex 側 GPT-5.5，已交件。核心測試修正準備資料：NULL line 正向案例只驗 B 自動建批；來源負例在假庫交易內短暫停用精確 B trigger 掛回正確來源，立即恢復，再先跑合法 control、逐項改一個維度做反例。沒有為了讓初版過關而放寬期待。
+- CEO 複跑定稿核心 13 群仍 4 PASS／9 FAIL。正常完好／破損／遺失拆量等正向案例通過，不代表來源防偽、凍結一致性、並行及重送等失敗案例已修；完整判斷見 core runtime 報告。
+- UI 定稿測試已改成接受「暫不產生新寫入」或「原 ID + 原完整包安全重試」，不綁死 useRef／儲存工具。初版真渲染仍 5 項 runtime FAIL，3 項原碼/畫面觀察另列。CEO 已複跑相同結果；切批主要是原碼查核，元件重載才是真跑，沒有把兩者混稱全部已操作。
+- 假庫只讀收尾檢查：其他 client 連線 0、`trg_hq_return_source` 狀態 O（已啟用）。一次診斷字串串接因 char 型別歧義 exit 1，改為明確轉 text 的單一唯讀查詢後 exit 0；未改資料。再以已核對完整 pgdata 路徑正常停止專用 PostgreSQL，exit 0；pg_isready 確認 127.0.0.1:56427 no response。沒有刪假資料。
+- 本案阿寫派工與阿審本輪均已結束，沒有背景施工／自動續跑。登入視窗屬使用者操作範圍，未擅自關閉。Claude 阿寫仍受額度限制，最新「換 Codex 的阿審」不被擴張為更換功能作者的授權；不擅自換作者、買額度或重試。整案仍未驗收，真正庫存／帳款與 GitHub／Supabase 均未動。

--- a/docs/return-disposition-local-verification.md
+++ b/docs/return-disposition-local-verification.md
@@ -1,0 +1,51 @@
+# 本機抽驗紀錄：退回總倉處理（2026-09-07）
+
+**這是未驗收的候選程式，禁止據此套用真正系統。** CEO 只統籌、機械套用阿寫差異、抽驗；正式審查由 GPT-5.5 阿審執行。GitHub、Supabase、正式資料與環境密鑰均未連線／讀取／修改。
+
+## 已驗證的範圍
+
+| 項目 | 真正結果 | 不代表什麼 |
+|---|---|---|
+| 改前完整 TypeScript 檢查 | exit 0 | 不代表功能原本正確 |
+| 店家少收前端第二版 | tsc exit 0；獨立靜態測試 exit 0；相同測試用 cf10338c 原錯版 exit 1 | 只完成前端，後端阻擋未完成 |
+| 少收檔 lint | 改前／改後同一項既有 set-state-in-effect 錯誤，無新增 | 不是全站 lint 全綠 |
+| A 核心 SQL 初版 | parser 34 statements／4 函式通過 | 阿審仍有 2 P0／5 P1，未放行 |
+| B 來源 SQL 初版 | parser 7 statements／1 函式通過 | 阿審仍有 2 P1／1 P2，未放行 |
+| E 待處理畫面初版 | 完整 tsc exit 0；新增頁 lint 有 2 項 set-state-in-effect 錯誤 | 輸入、重送、權限、來源等抽驗問題未修 |
+| D 測試載入器第二版 | 新假庫 d2 真載入基底 DDL 44／29／43／21／13／9 statements，seed 成功，exit 0 | `_current_tenant_id` 仍漏載，不是整合驗收通過 |
+| 初版 A/B 實際載入假庫 | 真 PostgreSQL 成功套入 core_initial；匿名 auth.uid() 回 NULL | 只是安裝測試，不是業務／安全驗收 |
+| 阿審 runtime 驗收器，CEO 複跑 | 第1組 10件分次成7好／2破／1失通過；第2組來源數量不一致反例失敗，整支 exit 1 | 初版接受同來源10件卻送11件的請求，尚未通過；後面權限／並行等案例未跑到 |
+
+完整指令均只在本機執行：
+
+```powershell
+node D:\7月營運ERP-new_erp\node_modules\typescript\bin\tsc --noEmit --incremental false --project apps/admin/tsconfig.json
+node tests/return-disposition-review/shortage-ui-check.cjs
+node tests/return-disposition-review/shortage-ui-check.cjs --baseline
+node scripts/check-sql-syntax.cjs supabase/migrations/20260907010000_hq_return_disposition_core.sql supabase/migrations/20260907020000_hq_return_disposition_sources.sql
+node tests/return-disposition/fixture.cjs --db-name return_disposition_test_d2
+node D:\1人公司\_本機工地\return-disposition-tools\probe-initial-core.cjs
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_initial
+```
+
+其中 D1 初版失敗：用 regex 判斷含前置註解的 SQL，必要表全被略過且吞掉 missing-object 錯誤，最後失敗。D2 改 AST 判斷後能載入，但真查 `_current_tenant_id` 仍報不存在；摘要說有載不能當證據。
+
+`probe-initial-core.cjs` 是 CEO 的測試基礎設施：複製 d2 純假庫為 `return_disposition_test_core_initial`，只從本機原檔 AST 機械取出真正 `_current_tenant_id`，再原樣套用 A/B。沒有替阿寫修功能。測試連線固定 `127.0.0.1:56427`、`returnlocal`，無遠端參數／環境變數。
+
+## 仍須阿寫修的問題
+
+- A：來源量／位置／原單防偽、並行凍結與出庫、HQ 讀取權限和授權、重送完整比對、小數精度、reserved 一致性、沿用既有異動類型。以 `return-disposition-core-review.md` 為準。
+- B：人工／系統操作者時序、原單 source_doc 核對；說清原因快照不含收貨當下新增備註。以 `return-disposition-source-review.md` 為準。
+- E：UUID fallback 非 UUID、輸入小數會被悄悄改值、未知送達時不能換新碼重扣、精確 HQ 角色、shortage 應顯示原收貨門市、原單號、分頁／完整事件、鍵盤與標籤、移除技術詞、新 lint 錯誤。具體退修已派 `writer-front-e-fix.md`，尚未收到有效修版。
+- D：漏載租戶 helper、手抄／stub 的覆蓋限制、完整 A/B/C/F 載入；本機實測不可只看 setup exit 0。
+- C／F：原單更正／撤回／真退貨月鎖、補貨可派量、後端通用少收阻擋與相關画面口徑，尚未整包交件。
+
+## 施工來源與中斷原因
+
+Claude 交件原始紀錄在 `D:\1人公司\_本機工地\return-disposition-tools\writer-*-result.jsonl`。部分結果是 `is_error=true`，即使工具同時標 subtype=success，也不能當成功交件。
+
+首輪 A/D 大退修曾超過 16,000 輸出長度，沒有套用任何半截。調高接收上限後 D 修版成功；A 修版、E 修版、B/F、D 小修、C 全部被 Claude 額度上限擋下，工具顯示台北 20:10 恢復。未重試限額、未切換帳號、未取得新額度或付費。沒有把候選初版當成已修清問題。F 前端派工稿已備妥，但沒有实际派出。
+
+本檔記錄已執行證據，不替代主需求單第九節；不得因本機存檔就宣稱本案完成或 WV260831002454 已救回。
+
+收尾：本案專用 PostgreSQL 已用已核對的 `return-disposition-tools/pgdata` 路徑正常停止，原啟動會話也已結束；假庫／測試檔保留，沒有刪資料。所有 Claude 本案派工程序均已結束。恢復施工需先啟動同一個本機假庫，不能改用真正系統來補驗。

--- a/docs/return-disposition-local-verification.md
+++ b/docs/return-disposition-local-verification.md
@@ -1,8 +1,65 @@
 # 本機抽驗紀錄：退回總倉處理（2026-09-07）
 
-**這是未驗收的候選程式，禁止據此套用真正系統。** CEO 只統籌、機械套用阿寫差異、抽驗；正式審查由 GPT-5.5 阿審執行。GitHub、Supabase、正式資料與環境密鑰均未連線／讀取／修改。
+**這是本機候選程式，禁止據此套用真正系統。** CEO 只統籌、機械套用阿寫差異、抽驗；GitHub、Supabase、正式資料與環境密鑰均未連線／讀取／修改。2026-09-08 fresh 假庫驗收已通過；Codex 阿審最後複核 P0=0／P1=0，P2 只剩「本機假帳與離線前台不等於正式上線」。
 
-## 已驗證的範圍
+**最新授權**：老闆已同意「好，讓 CODEX 接著」，阿寫改為 Codex GPT-5.6-sol 直接在本機 apply_patch，阿審仍是不同模型 GPT-5.5；CEO 統籌、抽驗、紀錄，不包辦功能或正式自審。三份有界派工 A／E／B-F 已實際啟動，沿 `85c06f44` 保存點修正。下方初版紅燈與 Claude 阻擋均保留歷史證據，不代表本轮要繼續等額度或再次取得更換作者批准。測試假庫已重啟，連線驗明 return_disposition_test_d3／returnlocal／127.0.0.1／56427；無外部資料。
+
+## 2026-09-08 本機收尾結果
+
+- fresh 假庫：`node tests/return-disposition/fixture.cjs --db-name return_disposition_test_full_v3 --with-all`，exit 0。A/B/C/F 四支候選 SQL 及 D 月結前置均重新載入，不沿用舊假庫。
+- 核心：`core-runtime.cjs --case all`，16／16 PASS。
+- 流程：`flow-smoke.cjs`，13／13 PASS。
+- 來源／可派：`source-available-runtime.cjs` 七群，7／7 PASS；含一般退貨 `1.0001` 不能被四捨五入偷過。
+- 月結並行：`reversal-runtime.cjs`，5／5 PASS；確認真正月結產生器會等同月 advisory lock、放鎖後可完成、C 更正／撤收遇月結鎖會快速整筆拒絕、多行同交易不自鎖、未知成本保持 NULL 不變 0。
+- 前台：`ui-input-runtime.cjs`、`ui-submit-runtime.cjs`、`shortage-ui-check.cjs`、`f-ui-copy-runtime.cjs`、`tsc --noEmit --incremental false --project apps/admin/tsconfig.json` 均 exit 0。
+- 阿審最後複核：C 月結 mutex、未知成本 NULL、F `1.0001` 原始數量、FUI 文案、送出防重送與 D 夾具均未見 P0/P1。
+- 限制：這不是真正瀏覽器人工驗收，不含正式資料、不含 GitHub PR、不含 Supabase 寫入，也沒有回補 WV260831002454 的歷史庫存。
+
+## Codex 續工：先辨別基底測試環境缺口
+
+CEO 建立 `return_disposition_test_flow_base1`，只載基底與原版真 RPC，沒有 A/B/C/F 候選。fixture 建立 exit 0。以下探針都在 BEGIN／ROLLBACK 內，錯誤時 psql 斷線回滾；只留假庫與序號消耗，不改正式資料。
+
+- 原 `rpc_create_store_return → rpc_receive_transfer → rpc_adjust_received_transfer → rpc_unreceive_transfer → rpc_resolve_transfer_item_shortage(restock_hq) → rpc_undo_transfer_item_shortage`：第一跑在 unreceive 發現 fixture 少 `customer_orders.order_kind`，exit 1。按真 `20260516000000:19` 的型別/default 在同一假資料交易暫加欄位後，六段真 RPC 與數量／狀態斷言全部走完，exit 0，再 ROLLBACK（欄位也回滾）。實際最新 CHECK 含 restock 的來源為 `20260612000020:18`，後續 fixture 作者必一併核對，不能只把缺欄補成任意型別。
+- 原 48h 自動同意與短少 redispatch：真 RPC 各跑到 received／全零系統操作者、真回帳指標／純帳務子單／重派 draft 指標，斷言全過、exit 0、ROLLBACK。沒有把 draft 當成已出貨。
+- 原 `rpc_create_wave_from_restock`：第一跑在建 approved_transfer 測試申請時被 fixture 的舊 `restock_requests_check` 擋，exit 1。真 `20260612000060_relax_restock_check_for_wave_flow.sql` 已放寬此條件；同交易機械套該檔兩段 ALTER 後，原 RPC 建 2 件 draft 成功，exit 0，再 ROLLBACK。這是第二個 fixture 缺口，不是 F 候選錯誤。
+- 可派量原錯版反例已重現：同一假資料交易設 HQ 帳上 15、reserved 5，原 restock RPC 仍准建 15 件 draft（應只可派 10）；斷言確實重現舊行為、exit 0、ROLLBACK。這是缺陷重現成功，不是功能驗收通過；修版要用同一情境拒絕超用。
+
+兩個 fixture 前置已交作者知悉。業務 helper 沒有改成假成功；本轮探針不宣稱覆蓋完整 ERP、真正月結或出貨全链。
+
+## Codex 續工：修版抽驗（尚非整包驗收）
+
+- A 阿寫交回修版後，CEO 以 fixture `--with-core` 建立全新 `return_disposition_test_core_a_fix`，載入及 seed exit 0；再跑 `node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_core_a_fix --case all`，13／13 PASS、exit 0。A SHA256 `3B007711260B8D255F9B7574BD38865B25644534BB9F722BB709265C93CC4FC7`，B SHA256 `3D0FE235F04913DE67088495DAF28A8EED02A2F28F0B5C2E98A1C55EFA681042`。一般案例回滾；兩個競跑假租戶留存供追查（`df6a8b82-797b-4044-be36-92c9716d878c`、`99464653-1dcc-4ec2-a123-fd8a455aef37`）。GPT-5.5 阿審的靜態複審 P0／P1／P2 均為 0，獨立 runtime 複驗另行執行；不能用 CEO 的通過代替獨立驗收。
+- B／F 阿寫已真交件，parser 與 diff 檢查通過。CEO 在 `return_disposition_test_flow_base1` 的單一假資料交易內，原樣載入真 060 CHECK 修正及 F 候選，再測：帳上 15／保留 5 時 view 供給量 = 10；建 15 件被拒、建 10 件成功且帳上／保留量仍是 15／5（只是草稿，不重複扣庫存或保留）；剩餘申請 5 時再建 6 被拒。NULL／0／負數／NaN／Infinity／四位小數／指數字串／空字串／布林數量、NULL／不存在 SKU、非原申請店、通用退貨「少收」都被拒。exit 0，全部 ROLLBACK，F 沒留在基底假庫。這是有界 CEO 抽驗，尚未涵蓋 F 並行、整包或正式權限全貌。
+- C 撤回／更正保護已實派 Codex 阿寫（由 B/F 完成交接後接續），E 修版仍在施工。C、F 及 E 尚須不同模型阿審正式審查，D 的兩個已查證欄位／限制前置仍須作者補齊。未連真系統，未宣稱 WV260831002454 已修帳。
+- A 獨立 runtime 複驗已收齊：阿審新增跨租戶同 UUID、hold 完整包重送、同 SKU 多批保留總額 3 群，16／16 PASS；CEO 再跑同一支也是 16／16 PASS、exit 0，原 A/B hash 不變。A 功能／契約／兩份獨立報告及 runtime 測試已範圍存檔 `815a9ee8`，存前 diff check exit 0。這個存檔只代表 A 通過；B/F 審查、C/E 施工與整合驗收繼續。
+- 測試有效性抽查：CEO 將同一支 16 群測試跑回保留的初版 `return_disposition_test_core_initial`，結果 5 PASS／11 FAIL、exit 1。新補的跨租戶同 UUID 與 hold 完整包能抓到初版缺陷；多批總額群在初版已 PASS，屬保護原有正常行為，不能把 16 群說成 16 個新修漏洞。舊版與新版假庫分開保留，沒有覆蓋舊紅燈現場。
+- B/F 獨立審查已交：B 兩路真測試通過、P0／P1／P2 = 0；F 補貨供給、非法輸入、舊錯版反例、balance 並行鎖 4 群通過，但一般退貨 `qty='1.0001'` 實際被接受，列 P1，已交回阿寫修。完整證據與固定假庫見 source／available review 及 `source-available-runtime.cjs`；不把 CEO 先前有界 F 抽驗當成整包通過。
+- E 阿寫交回 page／layout 修版，自跑全站 tsc、頁面 lint、input runtime 為 0；CEO 複跑 input runtime 也為 0（只驗輸入保留與 UUID，不代表整個送出流程）。新版 AuthProvider／range／文字輸入／真 button 需阿審更新舊 jsdom 測試接點後驗；舊測試載入失敗不能算新功能斷言失敗。GPT-5.5 已實接 E 正式複審，F-UI 另由阿寫接續既有三畫面小改。
+- CEO 新增 `tests/return-disposition/flow-smoke.cjs`：13 群真 RPC 有界抽驗（含撤回身份完整性）、固定假庫、每例回滾，語法檢查 0，尚待 C/D 整合真跑。正向與拒絕案例均強制 `SET CONSTRAINTS ALL IMMEDIATE`，不能因回滾而根本漏跑 C 的延後數量一致性守門。此腳本不代替阿審正式審查，也不改功能。
+- E 獨立複審收齊：GPT-5.5 的 P0／P1／P2 = 0；真 jsdom 元件測試驗到未知結果鎖定／原包重送／跨重載、儲存失敗不送、不同人／公司不誤恢復等，page lint 0。CEO 複跑 `ui-submit-runtime.cjs` 與 B 兩群來源測試亦為 0。E page／layout／兩份報告／送出測試已本機存檔 `d72c2c68`；尚不是實際瀏覽器／正式系統驗收。
+- F-UI 三畫面與純離線測試已交，CEO 複跑 `f-ui-copy-runtime.cjs`（新過／85c06f44 舊錯版失敗）及 `shortage-ui-check.cjs` 均為 0，尚待阿審。F 一般退貨小數 P1 修版已交，SQL SHA256 `3349DFFD8F091BFF71617240C4851C3C341E47D07B01F2D49C694B8B1B50DDA2`，待整包假庫測試與複審。
+
+### 本輪檢查工具的被擋操作
+
+F-UI 阿寫曾誤用兩條 `pnpm exec` 執行 tsc／eslint；pnpm 警告要把 acorn、pg、pg-query-emscripten 搬到共用 `node_modules/.ignored`，隨後兩命令各因 rename pg／acorn 的 EPERM exit 1。這不是語法檢查結果，不能算檢查成功。只讀限制擋住目標 `D:\7月營運ERP-new_erp\node_modules` 的搬移。作者停止 pnpm，沒有擅自恢復／刪除／整理依賴，改直接跑現有工具。
+
+CEO 已獨立唯讀核對被點名的三個原資料夾皆存在、三個 `.ignored/<name>` 皆不存在；能確認這三個目標沒有成功搬移，未宣稱對整個依賴樹做過逐檔前後雜湊比較。GitHub／Supabase／真正庫存並未因此被操作。
+
+### 整包 fresh 假庫抽驗
+
+- D 三個前置已交，`--with-all` 只從真 040 抽 view，不蓋回舊補貨函式。CEO 真建 `return_disposition_test_full_v1`：A/B/C/F 全部載入、seed 成功、exit 0；全站 `tsc --noEmit --incremental false --project apps/admin/tsconfig.json` exit 0。
+- `flow-smoke.cjs --db-name return_disposition_test_full_v1`：13／13 PASS、exit 0，所有案例含延後限制驗證後再 ROLLBACK。這是 CEO 抽驗，C 正式獨立審查另行進行。
+- 同庫 `source-available-runtime.cjs` 的 B 兩群＋F 五群：7／7 PASS、exit 0，F 一般退貨四位小數退修已真驗到拒絕；包含原錯版可派量反例及真正兩連線等待 balance 後拒絕超用。
+- 同庫 core16 第一跑：14 PASS／2 FAIL、exit 1。兩個失敗都是測試準備資料在 ALTER 停／啟 B trigger 時遇到 C 的尚未執行延後事件，還沒走到來源／重送業務斷言。已交原阿審適配準備流程，必須先驗合法 queue，不能停 C 或放寬期待；未把這一跑說成全綠。
+- 測試有效性：新 D `--with-core` 建 `return_disposition_test_no_c_baseline`，僅 A/B、無 C/F，載入 exit 0。完全相同 `flow-smoke.cjs` 得 1 PASS／12 FAIL、exit 1：合法人工收貨 control 通過；其餘是舊 batch 留 pending／幽靈凍結／已處理仍准改／來源與月鎖旁路等業務反例，不是缺表欄位。這是缺 C 保護的對照版，不能籠統稱為完全未修改的線上版本；假庫分開保留。
+- C 獨立審查未放行：阿審真跑月結產生器競跑，發現現行產生器並未取得 C 所用 advisory lock，18ms 穿過，列 P1。CEO 已對照真最新版 `20260901000000`（先算帳再 upsert，無該鎖）及確認函式（有已存在 row 的 FOR UPDATE），交阿寫限縮修正：只在本案新增 SQL 原樣重建真產生器、加共用同步鎖，不改任何計價／月界／狀態條件／公開簽名，不能以晚到的表寫入 trigger 假裝在算帳前有保護。這是針對必修項的派工調整；沒有改真帳或執行實際月結。C 鎖缺陷、full_v1 及 no-C 對照均保留。
+- CEO 以 ESLint API 對 85c06f44 原文和目前五個畫面各跑一次（不是只 grep）：layout 舊 2 error／新 2、inventory 舊 3／新 3、picking 舊 3 error＋2 warning／新相同、ShortageResolveModal 舊 0／新 0、E 新頁舊 2／新 0。直接五檔 lint exit 1，共 8 個既有 error＋2 warning；不可宣稱全站 lint 綠。TypeScript 檢查為 0，兩種檢查不混稱。
+- C 月結 P1 修版已交：SQL SHA256 `F486AA6A5141973AEBA65F58D1267DF11D6D0FBF12B9A76EC5D2183F6E7D767B`。真產生器在讀帳前拿共用月鎖，C 撤回採 try-lock，月份忙則立即整筆拒絕，不持庫存鎖硬等月份鎖；移除新增鎖與註解後的產生器內容，作者機械比對與真原文一致。獨立競跑複審仍待收齊。
+- D 月結前置再補成可重現載入：真 entry_type／draft-aware items trigger／雙價欄與 `_branch_price_at`／adjustment 欄表／aid legs view，均取真正來源、不載舊產生器。CEO fresh `return_disposition_test_full_v2 --with-all` 成功，再跑修過準備資料的核心 16／流程 13／B-F 7 群，36 群全 PASS、exit 0；這才是適配後的全綠，不塗改 full_v1 曾有 2 個測試準備失敗的紀錄。
+- full_v2 真產生器正向抽驗：同一交易只把 seed 4 筆假價格生效日前移 30 天，連跑兩次九月月結，每次假 A 店應付 750、成本 500、分店價 750、一筆明細，第二次 draft 明細刪除重建也成功且不重複，exit 0 後全 ROLLBACK。沒有把空表、零價 stub 或等鎖 timeout 當成正常月結完成；不代表完整收款／確認財務流程驗收。
+- CEO 末輪追加 E 抽驗：資料庫 unit_cost=NULL 明確保留「沒有成本依據」，頁面三處 `num(unit_cost).toFixed(2)` 卻會顯示 $0.00。已交原 E 作者只修型別／三處成本呈現，並交阿審補 NULL 與真 0 的元件反例；這是先前 E 通過後追加查到的顯示問題，未假裝原審已涵蓋。不能把未知成本當作零元。
+
+## 先前各輪驗證的範圍（保留紅燈證據，不代表最新修版仍未交件）
 
 | 項目 | 真正結果 | 不代表什麼 |
 |---|---|---|
@@ -40,7 +97,7 @@ node tests/return-disposition-review/ui-input-runtime.cjs
 
 `probe-initial-core.cjs` 是 CEO 的測試基礎設施：複製 d2 純假庫為 `return_disposition_test_core_initial`，只從本機原檔 AST 機械取出真正 `_current_tenant_id`，再原樣套用 A/B。沒有替阿寫修功能。測試連線固定 `127.0.0.1:56427`、`returnlocal`，無遠端參數／環境變數。
 
-## 仍須阿寫修的問題
+## 首輪退修清單（最新進度以上方 Codex 續工段落為準）
 
 - A：來源量／位置／原單防偽、並行凍結與出庫、HQ 讀取權限和授權、重送完整比對、小數精度、reserved 一致性、沿用既有異動類型。以 `return-disposition-core-review.md` 為準。
 - B：人工／系統操作者時序、原單 source_doc 核對；說清原因快照不含收貨當下新增備註。以 `return-disposition-source-review.md` 為準。

--- a/docs/return-disposition-preflight-review.md
+++ b/docs/return-disposition-preflight-review.md
@@ -1,0 +1,194 @@
+# 總倉退回貨處理：阿審開工前審查筆記
+
+日期：2026-09-07  
+角色：阿審，開工前本機唯讀審查  
+範圍：本機 clone `D:\1人公司\_本機工地\new_erp_return_disposition_20260907`，基底 `cf10338cdfa05ee838a6dec86773eb5bc7e2f51e`。  
+限制：不連 GitHub、不連 Supabase、不查線上、不讀 `.env`、不安裝下載、不跑資料庫腳本。這不是程式驗收；目前沒有阿寫 patch 可審。
+
+---
+
+## 一、開工四問
+
+### 1. 這系統有沒有現成機制能借？
+
+有，且應優先借，避免重寫一套庫存世界。
+
+- `stock_balances.reserved` 已存在；`rpc_outbound` 的最新版在 `20260705000000_dispatch_price_guard.sql:121`，仍沿用「可出貨量 = on_hand - reserved」的概念，但 `:157` 有 `p_allow_negative`，表示呼叫端仍可能繞過 reserved。  
+  因此 `reserved` 只能當可借機制，不能說成完整保護。待確認貨仍需要負異動 trigger 或同等共用後端保護；任何直接 `INSERT stock_movements` 的路也會繞過 `rpc_outbound`。
+- `stock_movements` 是 append-only，庫存餘額由 trigger 維護：`20260422120003_inventory_schema.sql:254`。  
+  報廢／遺失要用新異動或明確反向紀錄，不要直接改舊 movement。
+- 店家退貨待扣量已有 `v_store_pending_returns`：`20260904020000_store_return_create_no_stock.sql:123`。  
+  可借它的母體口徑：`return_to_hq + shipped + [order return + out_movement_id IS NULL`。
+- 同意收回的共用入口是 `rpc_receive_transfer`，人工同意和自動同意都會走到這裡：`20260904020010_accept_store_return_deducts_stock.sql:101`、`20260903010020_return_to_hq_auto_accept.sql:174`。  
+  所以待處理紀錄不能只做在前端按鈕，否則 48 小時自動同意會漏。
+- 收貨短少已有 `rpc_resolve_transfer_item_shortage`，含 `restock_hq` / `redispatch` / `reject_return`：`20260903000200_shortage_resolution_undo.sql:111`、`:142`。  
+  「少收」要接這套原單差額，不要做成一般自由退貨。
+- 撤銷短少已有 `rpc_undo_transfer_item_shortage`：`20260903000200_shortage_resolution_undo.sql:429`。  
+  後續若總倉待處理也要撤銷，應抄「單筆撤銷、保留軌跡」的精神，不要整張退回重來。
+- `rpc_adjust_received_transfer` 與 `rpc_unreceive_transfer` 是已收單的兩個逃逸口：`20260904010000_adjust_received_syncs_stock.sql:194`、`20260903000010_unreceive_reverse_inbound_regardless_of_qty.sql:26`。  
+  新待確認批次若不擋這兩個，員工可從已收清單改掉數字或退回收貨配單，讓待處理紀錄和庫存保留量脫鉤。
+
+### 2. 最新真正 CREATE 定義是哪幾支？
+
+本輪用 `git grep -nE "CREATE (OR REPLACE )?FUNCTION/VIEW ..."` 在本機 HEAD 查，不用檔名猜。
+
+- `rpc_receive_transfer`：`20260904020010_accept_store_return_deducts_stock.sql:101`
+- `rpc_reject_transfer`：`20260904020020_reject_store_return_no_phantom_stock.sql:88`
+- `rpc_create_store_return`：`20260904020000_store_return_create_no_stock.sql:157`
+- `rpc_auto_accept_overdue_returns`：`20260903010020_return_to_hq_auto_accept.sql:120`
+- `rpc_resolve_transfer_item_shortage`：`20260903000200_shortage_resolution_undo.sql:111`
+- `rpc_undo_transfer_item_shortage`：`20260903000200_shortage_resolution_undo.sql:429`
+- `rpc_adjust_received_transfer`：`20260904010000_adjust_received_syncs_stock.sql:194`
+- `rpc_unreceive_transfer`：`20260903000010_unreceive_reverse_inbound_regardless_of_qty.sql:26`
+- `rpc_transfer_arrive_at_hq_batch`：`20260508000000_transfer_hq_dispatch.sql:44`
+- `rpc_create_wave_from_restock`：`20260715000020_restock_dispatch_dedup_guards.sql:485`
+- `v_store_pending_returns`：`20260904020000_store_return_create_no_stock.sql:123`
+- `v_picking_demand_no_po`：`20260612000040_approve_restock_via_picking_workstation.sql:53`
+- `v_hq_exceptions`：`20260903010000_hq_po_exception_resolution.sql:296`
+- `v_hq_inbox`：`20260818000040_hq_inbox_exclude_same_store_transfers.sql:96`
+
+### 3. 誰在呼叫？
+
+前端呼叫點：
+
+- 店家送退貨：`apps/admin/src/components/StoreReturnCreateModal.tsx:176` → `rpc_create_store_return`
+- 總倉收件匣不同意：`apps/admin/src/app/(protected)/hq/inbox/page.tsx:1628` → `rpc_reject_transfer`
+- 收貨頁收貨：`apps/admin/src/app/(protected)/wms/inbound/page.tsx:1222`、`apps/admin/src/components/TransferReceiveModal.tsx:335` → `rpc_receive_transfer`
+- 收貨頁退回收貨配單：`apps/admin/src/app/(protected)/wms/inbound/page.tsx:1335` → `rpc_unreceive_transfer`
+- 明細修改實收：`apps/admin/src/components/TransferReceiveModal.tsx:248` → `rpc_adjust_received_transfer`
+- 異常短少處理：`apps/admin/src/components/TransferShortageResolveModal.tsx:455` → `rpc_resolve_transfer_item_shortage`
+- 異常已處理撤銷：`apps/admin/src/components/ExceptionsContent.tsx:453` → `rpc_undo_transfer_item_shortage`
+- 補貨工作台建單：`apps/admin/src/app/(protected)/wms/picking/page.tsx:1786` → `rpc_create_wave_from_restock`
+
+後端串接點：
+
+- 總倉批次到倉函式內部呼叫 `rpc_receive_transfer`：`20260508000000_transfer_hq_dispatch.sql:82`
+- 48 小時自動同意內部呼叫 `rpc_receive_transfer`：`20260903010020_return_to_hq_auto_accept.sql:174`
+- 短少 `restock_hq` / `redispatch` 會用 `transfer_cancel` 把短收量記回出貨端，且 `redispatch` 會開重派撿貨單：`20260903000200_shortage_resolution_undo.sql:217`、`:242`、`:265`
+- 短少沖帳會產 `return_to_hq` 純記帳單，且註解明寫「本單不動庫存」：`20260903000200_shortage_resolution_undo.sql:340`、`:379`
+
+### 4. 本機 PR 905-915 快照有誰碰同檔？
+
+只讀本機 bare 鏡像 `D:\1人公司\_備份_GitHub_20260831\new_erp.git` 的 `refs/pull/*/head`。這是過期快照，不代表現在 GitHub 狀態。
+
+- #905-#910 都碰到：`hq/inbox/page.tsx`、`wms/inbound/page.tsx`、`wms/picking/page.tsx`、`ExceptionsContent.tsx`、`StoreReturnCreateModal.tsx`、`TransferReceiveModal.tsx`、`TransferShortageResolveModal.tsx`，以及 9/03-9/04 一批 migration。
+- #911-#913 都碰到：`wms/inbound/page.tsx`、`StoreReturnCreateModal.tsx`、`TransferReceiveModal.tsx`、三支店家退貨 migration。
+- #914 只在快照中看到 `wms/inbound/page.tsx`。
+- #915 另需列入目標檔：本機 `cf10338c...refs/pull/915/head` 實查只差 `apps/admin/src/app/(protected)/wms/returns/page.tsx`。
+
+結論：這段只能當本機 refs 的過期線索。若前述清單是用 `main..head` 反向 diff 得到，不能據此斷言它就是該 PR 的實際變更清單，也不能判斷線上作者、狀態或權限。未來要送出等簽收前，仍需在允許連線時重新查證。
+
+---
+
+## 二、阿寫最小切點建議
+
+### 最小落地方案 A：待確認明細表 + 同步 reserved
+
+這是目前看起來最少改、又能卡住共用出庫的路。
+
+1. 新增一張總倉退回貨待處理明細表，記原 transfer / transfer_item、sku、原因、原數量、待確認量、已放行量、破損量、遺失量、處理人與時間。
+2. `rpc_receive_transfer` 收到「店家退貨回總倉」時，同步建立待處理明細，並把同 sku 的 HQ `stock_balances.reserved` 加上待確認量。
+3. 總倉後續處理時：
+   - 完好：扣掉 reserved，變可派。
+   - 破損／遺失：先扣 reserved，再寫庫存扣減異動，保留成本依據。
+   - 寫錯：必須連回原單處理，不給自由加減。
+4. 取消或退回收貨配單時，要同步撤回待處理明細與 reserved，否則會留下卡死的保留量。
+
+做了會怎樣：一般走 `rpc_outbound` 且未開 `p_allow_negative` 的出庫會先被 `on_hand - reserved` 擋住；但這不是完整防線，仍需補負異動 trigger 或同等共用後端保護，並檢查直接寫 `stock_movements` 的路。  
+不做會怎樣：只做待辦清單的話，畫面提醒歸提醒，出庫守衛仍可能把未確認貨派出去。
+
+### 為什麼不是只改畫面？
+
+人工同意與 48 小時自動同意都會進 `rpc_receive_transfer`。只改總倉收件匣或某個按鈕，自動同意那條會漏。
+
+### 為什麼不能只改 `v_picking_demand_no_po`？
+
+補貨工作台畫面和 `rpc_create_wave_from_restock` 都直接看 HQ `stock_balances.on_hand`：`20260612000040:75`、`20260715000020:579`、`:591`。  
+只改畫面會擋不住送出；只改送出會讓畫面說有貨、送出才失敗。兩邊要同口徑，或用 `reserved` 讓共用守衛先兜住。
+
+---
+
+## 三、容易漏的出口
+
+### P0 待驗風險：未確認貨不能派出去，必須有後端共用保護
+
+檢查點：
+
+- `rpc_receive_transfer` 手動／自動同意都要建立待處理與保留量。
+- `rpc_outbound` 一般路徑會吃 `reserved`，但 `p_allow_negative`、直接 `INSERT stock_movements`、補貨工作台 `v_picking_demand_no_po` 與 `rpc_create_wave_from_restock` 直接吃 `on_hand` 的路，都要改成扣掉 reserved 或用同等共用後端保護。
+- `wms/picking/page.tsx` 的 `totalAvailable`、KPI、送出前校驗，必須和後端一致。
+
+### P0 待驗風險：同一批不能被重複處理或併發扣兩次
+
+檢查點：
+
+- 待處理明細需要唯一約束，例如同一 `transfer_item_id` 只能有一筆主處理紀錄，或用狀態/序號嚴格控管。
+- 部分處理要保證：完好 + 破損 + 遺失 + 寫錯/撤銷 + 未處理 = 原回帳量。
+- 同一批兩個總倉人同時處理，要鎖同一批明細與 `stock_balances`，鎖序要跟既有庫存家族一致。
+
+### P0 待驗風險：短收沖帳單不能被當成退貨實物待驗
+
+檢查點：
+
+- 一般店家退貨母體應該是 `[order return%`，不要把 `[短收沖帳]` 的 `return_to_hq` 純記帳單抓進來。
+- `restock_hq` / `redispatch` 已會產生 `transfer_cancel` 入庫與沖帳單；短少的 `transfer_cancel` 若是真正回到總倉或出貨端的貨帳，也必須建立一次待處理實物紀錄，但它產生的 `[短收沖帳]` 純記帳單不能再進總倉實物待驗。本案不能對同一短少重複加總倉或重複退款。
+
+### P1 待驗風險：修改實收與退回收貨配單會逃逸
+
+檢查點：
+
+- `rpc_adjust_received_transfer` 現在可改已收單數量；若 `return_to_hq` 退貨單已有待處理，改實收必須同步調整待處理/保留量，或直接擋。
+- `rpc_unreceive_transfer` 可把已收退回待收；它也必須同步撤回待處理/保留量，不然總倉保留量會卡住。
+- `TransferReceiveModal` 與 `wms/inbound/page.tsx` 目前都看得到修改／退回入口，不能只靠隱藏按鈕，後端要守。
+
+### P1 待驗風險：角色與租戶
+
+檢查點：
+
+- 新處理 RPC 至少要和短少處理同級：`owner/admin/hq_manager` 可處理，店端不可任意處理總倉內部報廢／遺失。
+- 所有查詢要吃 tenant；空 role 的 legacy 行為不能放大成任意店可動總倉處理。
+- 自動同意的全零操作者要保留標示，不要拿來當真人。
+
+### P1 待驗風險：錢和成本只留依據，不自動再動店家錢
+
+檢查點：
+
+- 店家退貨沖回和總倉內部報廢／遺失是兩件事。總倉後續處理不可再自動產生店家退款或再向店家收款。
+- 破損／遺失扣總倉庫存時要保留成本依據：原 out movement / in movement 單價、處理數量、原因、操作者、時間。
+- 月結已鎖月份不要被自由更正繞過。若有錢的影響，要和現有鎖月守衛一致。
+
+### P2 待驗風險：畫面文字不要說謊
+
+檢查點：
+
+- 「可派貨」只能顯示扣掉待確認後的數字。
+- 「待確認」要明確是這一批，不是整個商品都不能派。
+- 自動同意要標示系統自動、時間、原單。
+- 未查清時只能留待確認，不能逼員工填破損／遺失／完好。
+
+---
+
+## 四、施工完成後阿審要驗的測試清單
+
+最少要有這些情境；可以是本機型別檢查、單元測試、SQL 靜態檢查或可重跑的本機驗證腳本，但不能連正式庫。
+
+1. 手動同意退貨：建立待處理明細，HQ `reserved` 增加，未確認量不可派。
+2. 48 小時自動同意：同樣建立待處理明細，標明自動與時間。
+3. 同商品已有好貨 20、待確認 3：可派應為 20，不是 23，也不是 0。
+4. 同批 10 件拆成 7 完好、2 破損、1 遺失：最後待確認 0，可派只增加 7，破損/遺失扣帳有紀錄。
+5. 部分處理：10 件先放行 4，待確認剩 6，不能整批結案。
+6. 同一批重按處理：不能重複扣 reserved、不能重複扣庫存。
+7. 兩個人同時處理同一批：其中一邊要等或失敗，合計不能超過原數量。
+8. 補貨工作台畫面與送出守衛同口徑：畫面可派多少，送出就只能用多少。
+9. `restock_hq` / `redispatch` 的 `transfer_cancel` 真回帳必須建立一次待處理實物紀錄；同時，它們產生的 `[短收沖帳]` 純記帳單不進總倉實物待處理。
+10. `rpc_adjust_received_transfer` 對已有待處理退貨單不能讓數字和保留量脫鉤。
+11. `rpc_unreceive_transfer` 對已有待處理退貨單不能留下幽靈 reserved。
+12. 店端帳單沖回已發生後，總倉內部報廢／遺失不再自動收店家或退店家一次。
+13. 舊庫存不自動回補、不批次清理，只影響新流程。
+
+---
+
+## 五、目前狀態
+
+阿寫 Claude CLI 被自動安全審查拒絕，原因是會把私人程式碼送外部 Claude 模型，需要老闆額外明確同意；不應重試或繞過。  
+因此目前沒有程式 patch 可審。本輪是外部 Claude 傳送授權阻擋，不能繞過。

--- a/docs/return-disposition-reversal-contract.md
+++ b/docs/return-disposition-reversal-contract.md
@@ -1,0 +1,35 @@
+# 總倉退回貨 C：原單更正／撤回契約
+
+## 範圍
+
+C 不重建 `rpc_adjust_received_transfer`、`rpc_unreceive_transfer`、`rpc_undo_transfer_item_shortage`。三支既有流程都會先寫一筆完整 `stock_movements.reversal`，再清除或替換 `transfer_items` 的來源欄位；C 在這兩個共同接點與 `return_to_hq` 單頭加守門。
+
+## 真撤回
+
+- 只有 `NEW.reverses` 指向 `hq_return_batches.source_movement_id`，且 reversal 與原 movement 的 tenant、location、SKU、成本、數量、transfer、item、operator 全部一致，才算真撤回。
+- 原 item 必須仍指向該 movement。門市退貨另核對 `qty_received`；短收另核對 `qty_shipped - qty_received`。
+- 鎖序沿用 A：先 `stock_balances`、再 `hq_return_batches`。釋放前確認 `reserved` 足以涵蓋同 tenant/location/SKU 的全部 pending。
+- 只有完全未處理的 pending 批次可撤回：good/damaged/lost/revoked 全為 0，且沒有處理事件。partial、completed 或已有事件會 raise，外層 RPC 的新 movement、單據、庫存及財務變更一起 rollback。
+- 成功時 `reserved -= total_qty`，批次寫成 `qty_revoked=total_qty,status='revoked'` 並保存 operator、時間與原因；reversal row 落表後，AFTER hook 立即把 append-only movement id 的 FK 補回批次。任一 hook 失敗都會讓整筆 INSERT 與外層 RPC rollback。
+
+## item／header 守門
+
+- `in_movement_id` 或 `shortage_restock_movement_id` 被清除／替換前，舊 batch 必須已由對應原 movement 的真 reversal 完整撤回。
+- item 仍指著來源 movement 時，門市退貨的 `qty_received`、短收的 `qty_shipped - qty_received` 必須等於 batch 總量。這是 deferred final-state 檢查：合法整張 unreceive 可在同一交易內先把實收歸零、再撤 shortage；若交易結束時仍掛來源 movement，直接改 `qty_shipped` 或 `qty_received` 會讓整筆失敗。
+- received/closed 的 `return_to_hq` item 新增、刪除、改量或移到別張單，也會檢查原單與新單月份；因此沒有 batch 的純短收 credit 子單不能靠直接改 item 繞過月鎖。
+- 有 batch 的 item 不可刪除或改寫 item/transfer/SKU 歷史歸屬；有 batch 的 transfer 不可刪除或改 tenant/type/location。
+- `return_to_hq` 尚有 pending/partial batch 時，不可直接離開 received/closed，也不可清空 `received_at`。合法 unreceive 會先逐項 reversal，最後才更新單頭，因此可通過。
+
+## 月份鎖
+
+- 月份一律用 `received_at AT TIME ZONE 'Asia/Taipei'`，店家一律取 return transfer 的 `source_location`，並同時帶 tenant。
+- 真門市退貨 reversal 先檢查原 return transfer；短收 reversal 先檢查 `shortage_return_transfer_id` 指向的純記帳 credit 子單。檢查在釋放 batch/reserved 之前，直接寫 reversal 也無法繞過。
+- return header 改 `received_at`、來源店、tenant、type、status 或刪除時，OLD 與 NEW 涉及月份都會依固定順序檢查。
+- C 本案新增 tenant＋month advisory transaction lock，並讓真正最新版月結生成器共用；這不是原生成器既有機制。C 使用 `pg_try_advisory_xact_lock`，月份忙碌就立即讓外層整筆 rollback，避免舊撤收已持有 balance 時等待月份鎖形成死鎖；生成器用同 key 的 blocking lock，C 持鎖時必須等待。取得月份鎖後再 `FOR UPDATE` 鎖該店該月 `store_monthly_settlements` row；`confirmed`、`settled`、`remitted` 一律拒絕。純 `[短收沖帳]` 子單沒有 batch，仍由 `shortage_return_transfer_id` 關係保護。
+
+## 不在 C 內重寫的邊界
+
+- C 原樣重建真正最新版 `rpc_generate_hq_to_store_settlement(date,uuid)`，唯一行為差異是在鎖定判斷與金額讀取前取得同 tenant／month lock；公開 signature、權限、計價、月界、狀態條件與回傳不變。C 不改短收 credit 子單、退款或庫存會計規則，也不做歷史 backfill。
+- A 處理破損／遺失產生的 `source_doc_type='hq_return_batch'` 負 movement 目前沒有完整 event reversal 財務流程，禁止直接反向；需人工盤點與對帳。
+- 其他沒有 `hq_return_batches` 的歷史 stock movement 仍沿用舊 reversal 規則。
+- 真撤回一律要求 `auth.uid()`，movement operator 必須相同，tenant 經 `_current_tenant_id()` 核對；缺 JWT 不會被當成 service 特權。自動接貨是正向 movement，不會進撤回分支，因此既有 autoaccept 不受影響。沒有使用可偽造的 session flag。

--- a/docs/return-disposition-reversal-review.md
+++ b/docs/return-disposition-reversal-review.md
@@ -1,0 +1,152 @@
+# 總倉退回貨 C：原單更正／撤回保護審查
+
+審查時間：2026-09-07
+
+審查身分：Codex GPT-5.5 阿審，獨立審查。
+
+範圍：只審 C 這包「原單更正／撤回保護」：
+
+- `supabase/migrations/20260907030000_hq_return_disposition_reversals.sql`
+- `docs/return-disposition-reversal-contract.md`
+- 對照真正既有流程：`rpc_adjust_received_transfer`、`rpc_unreceive_transfer`、`rpc_undo_transfer_item_shortage`、店家月結產生／確認流程
+
+禁止事項遵守：未連 GitHub、未連 Supabase、未碰正式資料、未讀 `.env`、未改功能碼、未 commit。
+
+首審讀到的 C 檔案 SHA256：
+
+- C SQL：`09C1B31D48E6C9F97C235EC185D3804EF89A6A5126B640B34A9DF49853EF748D`
+- C contract：`19B150CD8740E1A470B83B26F66BCC164BEBABD9FD41A2DE71E537598D11494C`
+
+## 結論
+
+首審 C 不可直接放行：審查有 1 個 P1，集中在「月份鎖」的併發保護說法和真月結流程不一致；這點已用本機假庫補測重現。
+
+其他主線目前靜態看起來方向正確：C 有把真 reversal、操作者、租戶、來源 movement、原 item、未處理批次、reserved 釋放綁在同一個後端守門點；也有擋掉不走 reversal 就清來源 ID、直接改 item 數量、partial 批次撤回、缺 `auth.uid()` 或 operator 冒用。
+
+注意：這份是 C 的需求／程式審查，不是完整系統驗收。阿審已在本機假庫獨立跑 C flow-smoke 與 1 個月結鎖反例；仍未代表正式系統已驗收。
+
+## P0
+
+目前未發現 C 自身 P0。
+
+## P1
+
+### P1-1：C 的「月結 advisory lock」沒有跟真正店家月結產生器共用，帳單尚未存在時仍可能競跑
+
+依據：
+
+- C `_hq_assert_return_month_open` 在 `20260907030000_hq_return_disposition_reversals.sql:46` 建立，`78-80` 拿 `hashtext('settlement:' || tenant || ':' || month)` advisory lock，`82-88` 再鎖 `store_monthly_settlements` row，`90` 開始拒絕 confirmed/settled/remitted。
+- C contract 寫「每個月份先取得既有月結 advisory lock」，C SQL 註解也寫「advisory lock 仍與既有月結生成器序列化」。
+- 但真正最新店家月結產生器是 `20260901000000_settlement_dispatch_basis.sql:74` 的 `rpc_generate_hq_to_store_settlement`；實查此函式內沒有 `pg_advisory_xact_lock`。同檔 `148-152` 只是在已存在 row 時檢查 locked status，`348-369` upsert draft/sent/disputed。
+- 全 migrations 目前同 key `pg_advisory_xact_lock(hashtext('settlement:'...))` 只查到舊 `20260423120001_inventory_v02_demand_aid_settlement.sql:483` 與 C；不是最新店家月結產生器共用的鎖。
+- 店家月結確認流程在 `20260715000120_settlement_estatement_flow.sql:542`；確認時會 `WHERE id = p_settlement_id FOR UPDATE`，但這只能鎖已存在的 row，不能保護「C 檢查時 row 還不存在、月結另一邊同時建立」的空窗。
+
+白話風險：
+
+如果某店某月帳單還沒建出來，C 會先拿一把「自己以為大家都會拿」的鎖，看到沒有已鎖帳單就放行；但真正產生店家月結的流程沒有拿這把鎖，可能同時把同一月份帳單生出來、甚至被送出或確認。結果就是退回貨撤回／更正已經改了貨和待處理數，帳單那邊卻可能用舊狀態結算，後面只能人工對帳。
+
+本機反例：
+
+- 新增阿審測試 `tests/return-disposition-review/reversal-runtime.cjs`。
+- 命令：`node tests\return-disposition-review\reversal-runtime.cjs --db-name return_disposition_test_full_v1`
+- 結果：FAIL，訊息為「月結產生器沒有等待 C 使用的 settlement advisory lock；finished=true result=completed」。
+- 意義：連線 A 已先拿住 C 使用的同一個 settlement advisory lock；連線 B 在交易中跑真正 `rpc_generate_hq_to_store_settlement`，測試用 `pg_locks` / `pg_stat_activity` 觀察 B 是否真的在等 advisory lock。如果真共用鎖，B 應先進入 advisory lock wait，等 A 放鎖後才完成；實際 B 直接完成，證明最新月結產生器沒有被這把鎖序列化。
+- 測試沒有載入或手刻 generator；`return_disposition_test_full_v1` 內的月結函式、helper、view、schema 是 CEO 建庫時載入的真本機 SQL。阿審本支只呼叫已安裝的 `rpc_generate_hq_to_store_settlement`。若 fresh full_v2 缺少月結函式依賴，這支會報出實際缺物件／缺欄位，而不是假通過。
+
+最小修法：
+
+- 讓真正 `rpc_generate_hq_to_store_settlement` 在處理每個店家月份前，拿與 C 完全相同的 advisory lock key；相關「送出／確認／結清」若會改同一張 `store_monthly_settlements`，也要確認鎖序一致，至少不能在 C 檢查空窗內完成狀態切換。
+- 或者 C 改用真正月結流程已經會拿的同一把鎖；但目前實碼沒有看到最新店家月結產生器拿這把鎖，所以不能只改文件。
+- 補一個雙連線測試：連線 A 在 C 月份檢查處持鎖未提交，連線 B 同月同店跑月結產生／確認，必須能觀察到等待或被安全拒絕；不能兩邊各做各的。
+
+## P2
+
+目前未列 C 自身 P2。C contract 的「既有月結 advisory lock」文字若 P1 採用修程式解掉，就一起修正；若不修程式，文件必須降級成限制說明，但那不建議當作放行方案。
+
+## 已靜態核對且暫未發現阻擋的點
+
+### 真 reversal 與操作者
+
+- `20260907030000_hq_return_disposition_reversals.sql:123-124` 對正向 movement 直接 return，所以自動同意／正常收貨這類不是 reversal 的路徑不會被 C 誤擋。
+- `171-180` 要求 `auth.uid()` 非空、`NEW.operator_id = auth.uid()`，並用 `_current_tenant_id()` 比對 batch tenant。這符合「撤回一定要真人，不能把缺 JWT 當特權」的契約。
+- 既有 `rpc_adjust_received_transfer`、`rpc_unreceive_transfer`、`rpc_undo_transfer_item_shortage` 都會建立 `movement_type='reversal'` 且帶 `operator_id=p_operator`；C 在真正碰到總倉退回批次時補上後端核對。
+
+### 來源鏈與 `source_doc_line_id`
+
+- C 對 reversal row 要求 `source_doc_type='transfer'`、`source_doc_id` 等於父單、`source_doc_line_id` 等於 item id、數量／成本／位置／SKU 全部對齊（`184-193`）。
+- C 對原正向 movement 的檢查允許 `v_orig.source_doc_line_id IS NULL`，只有原 movement 有 line id 時才要求等於 item id（`197-201`）。這點有對上真收貨來源：真 `rpc_receive_transfer`／shortage restock 可能只在 movement 寫原單 id，反向指標主要在 `transfer_items.in_movement_id` 或 `shortage_restock_movement_id`。
+- 既有更正／撤回／短收撤銷三支 reversal，實查都會把 reversal 自己的 `source_doc_line_id` 寫成 item id，所以 C 要求 reversal line id 不會擋住真路徑。
+
+### 未處理批次才能撤回
+
+- C 先鎖 `stock_balances` 再鎖 `hq_return_batches`（`253-268`），與 A 的核心鎖序一致。
+- `270-280` 要求 batch 仍是 pending，且 good/damaged/lost/revoked 都是 0、沒有 event。也就是總倉一旦已部分處理，就不允許原單更正悄悄把整批沖掉。
+- `282-295` 在釋放 reserved 前檢查同 tenant/location/SKU 全部 pending/partial 的總 reserved 仍足夠，能擋住 reserved 已被其他路徑破壞後繼續扣成負數。
+- `326-357` 的 AFTER hook 會在 reversal row 真落表後，把 `revoked_by_movement_id` 補回 batch；失敗會讓同交易 rollback。
+
+### item/header 守門
+
+- `381` 開始的 item guard 會擋刪除、改 item/transfer/SKU 歷史歸屬，且舊 `in_movement_id` 或 `shortage_restock_movement_id` 被清／換前，對應 batch 必須已經由真 reversal 完整撤回。
+- `551-554` 是 deferred final-state constraint trigger，交易最後才檢查 item 仍掛來源 movement 時，店退 `qty_received` 或短收 `qty_shipped - qty_received` 必須等於 batch 總量。這適合既有 unreceive 先歸零再撤短收的暫態。
+- `563-659` 的 header guard 會擋有 batch 的 return transfer 被刪除、改 tenant/type/location；有 active pending/partial 時不能直接離開 received/closed，也不能清空 `received_at`。
+- 真 `rpc_adjust_received_transfer` 實查順序是先寫新入庫、再寫舊 reversal、最後更新 item pointer；C 的 hook 先撤舊 batch，B 再按新 pointer 建新 batch，順序合理。
+- 真 `rpc_unreceive_transfer` 實查順序是逐 item 寫 reversal、清 item pointer，最後才把單頭改回 shipped；C 會在 active batch 被撤完後才允許 header 離開 received/closed。
+- 真 `rpc_undo_transfer_item_shortage` 實查會先 reversal `shortage_restock_movement_id`，再清短收欄位；C 的 deferred final-state 可避免把同交易合法暫態誤判為錯。
+
+## 待補 runtime 驗證
+
+阿審已獨立完成：
+
+- `node --check tests\return-disposition\flow-smoke.cjs`：exit 0。
+- `node tests\return-disposition\flow-smoke.cjs --db-name return_disposition_test_full_v1`：13/13 PASS，全部交易 rollback。
+- `node tests\return-disposition\flow-smoke.cjs --db-name return_disposition_test_no_c_baseline`：1/13 PASS、12/13 FAIL；同一支測試能抓到沒有 C 時的舊洞，不是只檢查 trigger 存在。
+- `node --check tests\return-disposition-review\reversal-runtime.cjs`：exit 0。
+- `node tests\return-disposition-review\reversal-runtime.cjs --db-name return_disposition_test_full_v1`：exit 1，打中 P1 月結鎖未共用。
+- 殘留連線查核：`return_disposition_test_full_v1` 的 `returnlocal` 其他連線數為 0。
+
+仍待 C 修版後重跑：
+
+- P1 的月結併發：同店同月 C 月份檢查與月結產生／確認必須共用鎖，不能各自通過。
+- C 修版後需重跑 flow-smoke 13 群與 no-C baseline 對照，確認不是為了修月結鎖而破壞正常更正／撤收／短少撤銷。
+
+## 2026-09-07 C P1 修版複審
+
+C 修版 SQL SHA256：`F486AA6A5141973AEBA65F58D1267DF11D6D0FBF12B9A76EC5D2183F6E7D767B`
+
+資料庫：`return_disposition_test_full_v2`
+
+修版重點：
+
+- `_hq_assert_return_month_open` 改用 `pg_try_advisory_xact_lock`（C SQL `:82`），月鎖忙時快速拒絕，不讓舊 RPC 已拿住庫存／單據鎖後再反向等月結鎖。
+- 同一支 C migration 後段重建真正 `rpc_generate_hq_to_store_settlement`（C SQL `:685`），在確認 tenant 後、任何算帳前拿同一把 blocking 月結鎖。
+- 作者回報剝除新增鎖與 comment 後，generator 真定義 SHA 為 `CA5E84E9E9F037E7A7AF791E3E4A2958B89BD2A0F277EA0797F7D1713C12736D`；本輪阿審沒有重寫 generator，也沒有改財務算法。
+
+阿審獨立實跑：
+
+```powershell
+node --check tests\return-disposition-review\reversal-runtime.cjs
+node tests\return-disposition-review\reversal-runtime.cjs --db-name return_disposition_test_full_v2
+node tests\return-disposition\flow-smoke.cjs --db-name return_disposition_test_full_v2
+```
+
+結果：
+
+- `node --check`：exit 0。
+- `reversal-runtime`：4/4 PASS。
+  - `settlement_generator_shares_c_advisory_lock`：連線 A 拿 C 月結鎖；連線 B 跑真 generator，已用 `pg_locks` / `pg_stat_activity` 看到 B 等 advisory lock；放鎖後真 generator 完成。
+  - `settlement_generator_completes_twice`：交易內把假 prices 的 `effective_from` 前移 30 天，真 generator 連跑兩次；第一次有真明細，第二次 draft 重建沒有被舊 immutable trigger 擋住，也沒有重複膨脹。
+  - `busy_month_rejects_c_without_side_effects`：另一連線持有同月鎖時，真 `rpc_adjust_received_transfer` 走到 C 後快速業務拒絕，不是拖到 statement timeout；庫存、批次、item 快照不變。
+  - `trylock_reentrant_multi_item`：同一交易兩個 SKU 更正，C helper 同 session 重入同月鎖不誤拒；兩個舊 batch revoked、兩個新 batch pending。
+- `flow-smoke`：13/13 PASS，全部交易 rollback。
+
+複審結論：
+
+- 首審 P1「C 月結 advisory lock 未與真正店家月結產生器共用」已關閉。
+- C 修版目前未發現新 P0/P1/P2。
+- C 仍不是整包正式驗收；它不涵蓋 D fixture 完整 ERP、F-UI、正式資料，也不代表已上線。
+
+本輪 C 判定：
+
+- P0：0。
+- P1：0。
+- P2：0。

--- a/docs/return-disposition-shortage-ui-review.md
+++ b/docs/return-disposition-shortage-ui-review.md
@@ -1,0 +1,140 @@
+# 阿審複核報告：少收 UI 切片
+
+### CEO 收件驗證補充（2026-09-07）
+
+- 修正版全案 `tsc --noEmit --incremental false --project apps/admin/tsconfig.json`：exit 0；首輪候選真實失敗 TS2367 已消除。
+- CEO 重跑阿審同一支靜態檢查：現版 exit 0；`--baseline` 直接讀本機基準 cf10338c 的舊真檔，exit 1，明確失敗於「submit() 必須明確擋少收」。不是瀏覽器實測。
+- 該檔 ESLint 現版與基準版都恰有一個 `react-hooks/set-state-in-effect`：舊檔80行／現檔81行的 `setHits([])`，差一行來自新增 Link import，該效果區塊沒有修改。沒有新增 lint 問題；不是宣稱 lint 全綠，也不為本案改動無關的既有搜尋行為。
+- `git diff --check` 通過。本切片完成不等於整個總倉退回貨後端已驗收。
+
+日期：2026-09-07  
+範圍：只審 `apps/admin/src/components/StoreReturnCreateModal.tsx` 這次少收 UI 切片，並用本機相關頁面確認導路是否成立。未審後端、未連服務、未跑資料庫、未視為功能驗收。
+
+## 結論
+
+目前有 2 個 P1、1 個 P2。沒有看到 P0，但 P1 需要先修再交下一輪，因為其中一個已經讓 `tsc` 失敗，另一個會把店家導到不夠精準的地方。
+
+## 退修複審結論（2026-09-07）
+
+本次只複審原本 2 個 P1、1 個 P2，沒有擴查後端主案。
+
+結果：原 2 個 P1、1 個 P2 均已補足；此少收 UI 切片目前沒有阻擋交回 CEO 繼續收斂的問題。CEO 已回報修後全案 `tsc` 重跑 exit 0。
+
+已另留一個最小靜態檢查：`tests/return-disposition-review/shortage-ui-check.cjs`，本機執行結果為 `shortage-ui-check ok`。
+
+- 原 P1-1 已補：`submit()` 先擋 `reason === "少收"`，再跑 `if (!canSubmit) return;`，不再讓 TypeScript 把少收判成永遠不可能。現行位置：`apps/admin/src/components/StoreReturnCreateModal.tsx:159-163`。
+- 原 P1-2 已補：少收連結已改到 `/wms/inbound`，並明講「已收」分頁、「明細 / 改實收」；也補了尚未收貨要走原單核對實收。現行位置：`apps/admin/src/components/StoreReturnCreateModal.tsx:341-352`。
+- 原 P2-1 已補：已刪掉「錢也會自動跟著算」，改成「差額會送到總倉處理，後續依總倉回覆與月結規則算帳」。現行位置：`apps/admin/src/components/StoreReturnCreateModal.tsx:350`。
+- 退貨草稿保留已補：連結用 `target="_blank"` 並加 `rel="noopener noreferrer"`，店家點去收貨頁時不會直接把目前退貨視窗切走。現行位置：`apps/admin/src/components/StoreReturnCreateModal.tsx:342-346`。
+
+這份複審仍不是後端驗收，也不是整個總倉退回貨功能驗收。
+
+## 反例保護補驗（2026-09-07）
+
+為避免「測試全綠但其實沒保護到」的情況，已把同一份靜態檢查加上 `--baseline`：
+
+- 現版檢查：`node tests/return-disposition-review/shortage-ui-check.cjs` → exit 0，輸出 `shortage-ui-check ok (working tree)`。
+- 舊真檔反例：`node tests/return-disposition-review/shortage-ui-check.cjs --baseline` → exit 1，從本機 git 執行 `git -c safe.directory=<工地> show cf10338c:apps/admin/src/components/StoreReturnCreateModal.tsx` 取舊版檔案，失敗訊息為 `submit() 必須明確擋少收`。
+
+這表示同一套檢查能抓到舊版「少收仍可能走送出流程」的問題，不只是對新版放行。
+
+目前此 UI 切片問題數：
+
+- P0：0
+- P1：0
+- P2：0
+
+首輪歷史問題數：
+
+- P0：0
+- P1：2
+- P2：1
+
+界線：這是靜態保護與型別結果佐證，沒有開瀏覽器點畫面，也沒有驗後端資料流。
+
+## P0
+
+無。
+
+## P1
+
+### P1-1：少收防線造成 TypeScript 編譯失敗
+
+位置：`apps/admin/src/components/StoreReturnCreateModal.tsx:157`、`:162`、`:164`
+
+依據：
+
+- `canSubmit` 已經寫成 `reason !== "少收"`。
+- `submit()` 先跑 `if (!canSubmit) return;`，TypeScript 會因此判定後面能走到的 `reason` 不可能是「少收」。
+- 下一行又寫 `if (reason === "少收") return;`，CEO 實跑已出現 `TS2367`。
+
+白話風險：
+
+- 做了這個改法，少收確實比較不容易被送出，但整個前端型別檢查會紅，不能乾淨交付。
+- 不修的話，後面後端做好也會被這個 UI 小錯卡住。
+
+最小修法：
+
+把少收的 handler 防線移到 `if (!canSubmit) return;` 前面：
+
+```ts
+if (reason === "少收") return;
+if (!canSubmit) return;
+```
+
+這樣保留「即使按鈕狀態被繞過也不能送少收」的防線，又不會讓 TypeScript 判成不可能。
+
+### P1-2：少收連到「內部調撥」不夠精準，已全收後才發現少收時容易找不到正確操作
+
+位置：`apps/admin/src/components/StoreReturnCreateModal.tsx:343`、`:349`
+
+依據：
+
+- 這次連結是 `href="/wms/transfers"`，頁面標題是「內部調撥」；本機頁面註解也寫它涵蓋店對店與退貨回總倉，不含客戶訂單派貨：`apps/admin/src/app/(protected)/wms/transfers/page.tsx:3-11`。
+- 「已收貨也能改實收」的按鈕不在這頁，而是在「收貨」頁已收分頁：`apps/admin/src/app/(protected)/wms/inbound/page.tsx:2423-2429` 的「明細 / 改實收」。
+- `TransferReceiveModal` 也明寫已收貨的單按「✎ 修改實收」才是走 `rpc_adjust_received_transfer`，改小後回總倉收件匣的「收貨短少」：`apps/admin/src/components/TransferReceiveModal.tsx:100-105`、`:230-235`。
+- 分店角色可達性本身不是問題：`/wms/transfers` 與 `/wms/inbound` 都沒有放進分店隱藏清單，見 `apps/admin/src/app/(protected)/layout.tsx:42`、`:48`、`:128-139`。
+
+白話風險：
+
+- 做了現在這版，店家會被叫去「內部調撥」，但真正要改「已收過的派貨單少收」是在「收貨」頁的已收紀錄裡。
+- 不修的話，店家可能又回到錯的地方找單，最後還是問人，或誤以為少收沒有地方可以改。
+
+最小修法：
+
+把連結改到 `/wms/inbound`，文字改成更直白：
+
+> 請到「收貨」頁，切到「已收」，找到原本那張派貨單，按「明細 / 改實收」把數字改對。
+
+若產品刻意要先帶到「內部調撥」查單號，至少也要補一句：「真正更正實收是在收貨頁，不是在這頁送退貨。」
+
+## P2
+
+### P2-1：「錢也會自動跟著算」承諾太滿，應改成等總倉處理後依規則算
+
+位置：`apps/admin/src/components/StoreReturnCreateModal.tsx:349`
+
+依據：
+
+- 現行 `TransferReceiveModal` 對少收的說法是：差額會進總倉收件匣等總倉決定；且不可以寫成系統自動補回總倉：`apps/admin/src/components/TransferReceiveModal.tsx:587-605`。
+- 收貨頁已收分頁的按鈕說明也寫「少收走總倉收件匣同一條流程」，不是店端送出後立刻把錢定案：`apps/admin/src/app/(protected)/wms/inbound/page.tsx:2423-2429`。
+
+白話風險：
+
+- 做了現在這句，店家可能以為只要改實收，店家帳款一定馬上、一定自動完成。
+- 不修的話，日後若總倉不同意、月結鎖住、或需人工判責，畫面文字會像是先答應店家了。
+
+最小修法：
+
+把：
+
+> 錢也會自動跟著算
+
+改成：
+
+> 差額會送到總倉那邊處理，後續依總倉回覆和月結規則算帳
+
+## 已看但不列問題
+
+- `Link href="/wms/transfers"` 這種 Next `Link` 內部路徑本身沒有看到 basePath 問題；`withBasePath` 主要出現在列印 iframe 這類手動組 URL 的地方。
+- 已填退貨品項時，畫面有提醒「選少收不會送出這些品項」；但如果照 P1-2 改成導去收貨頁，建議順手補「會離開此視窗，已選品項不會保留」會更白話。這點不足以單獨擋交付。

--- a/docs/return-disposition-source-contract.md
+++ b/docs/return-disposition-source-contract.md
@@ -29,6 +29,12 @@ Migration: `20260907020000_hq_return_disposition_sources.sql`
     └─ 同上觸發
 ```
 
+`store_return` 的操作者以來源 `stock_movements.operator_id` 為準。觸發器執行時，
+父單 `transfers.received_by` 還沒有被 `rpc_receive_transfer` 更新，不能拿它判斷人工／系統收回。
+
+`store_return.source_reason` 是觸發當下父單已有 `notes` 的快照，不含
+`rpc_receive_transfer` 本次收貨才傳入的 `p_notes`；本次 `p_notes` 之後才會合併回父單。
+
 ## 核心匹配條件
 
 | 條件 | store_return | shortage |
@@ -37,6 +43,7 @@ Migration: `20260907020000_hq_return_disposition_sources.sql`
 | transfer_type | `return_to_hq` | 任意（靠 location type 過濾） |
 | movement_type | `transfer_in` | `transfer_cancel` |
 | movement.quantity | > 0 | > 0 |
+| movement source | `transfer` + 當前 `transfer_id` | 同左 |
 | location type | dest = `central_warehouse` | source = `central_warehouse` |
 | tenant 一致 | movement.tenant = transfer.tenant | 同左 |
 | SKU 一致 | movement.sku = item.sku | 同左 |
@@ -66,3 +73,8 @@ C 段（原單更正/撤回）需處理以下情境：
 
 入口建議：C 在 hq_return_batches 上提供 `_hq_revoke_return(p_source_movement_id)` 函式，
 B 的 trigger 不負責減量/撤回（B 只建不拆）。
+
+## 整合前提
+
+- A 的 `_hq_hold_return` 必須保留現有公開 signature 與 B 所傳的必要欄位；B 不依賴 A 其他新欄位。
+- A helper 的來源防偽與 C 的撤回／改實收必須另行整合驗收；B 單獨完成不等於整包可放行。

--- a/docs/return-disposition-source-contract.md
+++ b/docs/return-disposition-source-contract.md
@@ -1,0 +1,68 @@
+# 總倉退回貨處理 — B 來源接線契約
+
+Migration: `20260907020000_hq_return_disposition_sources.sql`
+
+## 時序
+
+```
+[store_return 路徑]
+  rpc_receive_transfer (return_to_hq, shipped→received)
+    ├─ rpc_inbound → stock_movements INSERT (transfer_in, qty>0, HQ location)
+    ├─ UPDATE transfer_items SET in_movement_id = v_in_mov_id   ← 觸發點
+    └─ trg_hq_return_source (AFTER UPDATE)
+        └─ _hq_hold_return → hq_return_batches + reserved
+
+[48h auto-accept 路徑]
+  rpc_auto_accept_overdue_returns → PERFORM rpc_receive_transfer(...)
+    └─ 同上路徑，operator='00000000-…-0000' → auto_flag='system'
+
+[shortage restock_hq 路徑]
+  rpc_resolve_transfer_item_shortage (restock_hq)
+    ├─ rpc_inbound → stock_movements INSERT (transfer_cancel, qty>0, source_location)
+    ├─ UPDATE transfer_items SET shortage_restock_movement_id = v_mov_id   ← 觸發點
+    └─ trg_hq_return_source (AFTER UPDATE)
+        └─ _hq_hold_return → hq_return_batches + reserved
+
+[shortage redispatch 路徑]
+  rpc_resolve_transfer_item_shortage (redispatch)
+    ├─ rpc_inbound (若尚未 restock) → shortage_restock_movement_id 寫入
+    └─ 同上觸發
+```
+
+## 核心匹配條件
+
+| 條件 | store_return | shortage |
+|------|-------------|----------|
+| 觸發欄位 | `in_movement_id` NULL→非NULL | `shortage_restock_movement_id` NULL→非NULL |
+| transfer_type | `return_to_hq` | 任意（靠 location type 過濾） |
+| movement_type | `transfer_in` | `transfer_cancel` |
+| movement.quantity | > 0 | > 0 |
+| location type | dest = `central_warehouse` | source = `central_warehouse` |
+| tenant 一致 | movement.tenant = transfer.tenant | 同左 |
+| SKU 一致 | movement.sku = item.sku | 同左 |
+| source_kind | `store_return` | `shortage` |
+
+## 不觸發的情境
+
+- 一般到貨（hq_to_store）：transfer_type ≠ return_to_hq → 跳過
+- 商店收 HQ 派貨（store_to_store）：同上
+- 短收沖帳 return_to_hq（純帳務單）：in_movement_id IS NULL → 不觸發
+- 店對店短少 restock：source_location type ≠ central_warehouse → 跳過
+- UPDATE 同值（冪等保護）：OLD.col IS NOT DISTINCT FROM NEW.col → 跳過
+
+## C 段需接的入口
+
+C 段（原單更正/撤回）需處理以下情境：
+
+1. **撤回收貨 (rpc_unreceive_transfer)**：transfer_items.in_movement_id 被清空
+   → 需減量或撤回對應 hq_return_batches（依 source_movement_id 找批次）
+   → 若批次 status=pending 可整批 revoke；partial/有 events 需依規則處理
+
+2. **撤回短少處理 (rpc_undo_transfer_item_shortage)**：shortage_restock_movement_id 被清空
+   → 同上邏輯找對應批次並處理
+
+3. **修改實收 (rpc_adjust_received_transfer)**：qty_received 變更
+   → 若 in_movement_id 沒變（movement 本身被 reversal），C 需偵測並調整批次
+
+入口建議：C 在 hq_return_batches 上提供 `_hq_revoke_return(p_source_movement_id)` 函式，
+B 的 trigger 不負責減量/撤回（B 只建不拆）。

--- a/docs/return-disposition-source-review.md
+++ b/docs/return-disposition-source-review.md
@@ -183,3 +183,53 @@ B 的大方向正確：用 `transfer_items.in_movement_id` 接「退回總倉真
 2. B 再補 source_doc 防偽：兩條來源都核 `source_doc_type/source_doc_id`。
 3. source contract 補 return notes 時序與 A 前置條件。
 4. C 採 reversal hook + transfer_items 清 ID 守門，不重抄三支大 RPC。
+
+---
+
+## 修版複審（2026-09-07，Codex GPT-5.5 阿審）
+
+結論：B 最新版本輪沒有 P0/P1/P2 阻擋。首審兩個 P1 已補上，P2 文件邊界也已在 contract 說清楚。這只代表 B 來源建批這一段可交下一段整包驗收；不代表 C 撤回／原單更正已完成，也不代表正式系統驗收。
+
+### 本輪範圍
+
+- 檔案：`supabase/migrations/20260907020000_hq_return_disposition_sources.sql`
+- 契約：`docs/return-disposition-source-contract.md`
+- 對照原始路徑：
+  - `rpc_receive_transfer` 最新定義：`supabase/migrations/20260904020010_accept_store_return_deducts_stock.sql:101`，入庫 movement 與 `transfer_items.in_movement_id` 先寫，父單 `received_by` 後寫。
+  - `rpc_resolve_transfer_item_shortage` 最新定義：`supabase/migrations/20260903000200_shortage_resolution_undo.sql:111`，少收回總倉與 redispatch 回帳 movement 都用 `source_doc_type='transfer'`、`source_doc_id=transfer_id`。
+
+### P0
+
+- 0。
+
+### P1
+
+- 0。
+
+首審 P1-1 已修：return 路現在從 `stock_movements.operator_id` 取操作者，位置 `supabase/migrations/20260907020000_hq_return_disposition_sources.sql:59`、`:117-124`，不再在 trigger 時讀尚未更新的父單 `received_by`。
+
+首審 P1-2 已修：return 與 shortage 都補核 `source_doc_type='transfer'`、`source_doc_id=NEW.transfer_id`，位置 `:109-113`、`:203-208`。白話講，就是待處理批次只能由「這張原單自己的回帳異動」建立，不能把同品項同倉但別張單的異動接進來。
+
+### P2
+
+- 0。
+
+首審 P2-1 已收斂：contract 已寫明 return 的 `source_reason` 取觸發當下父單既有 notes，不承諾包含收貨當下新輸入的 `p_notes`。實碼位置 `:124`。
+
+### 本機實跑
+
+命令：
+
+```powershell
+node tests\return-disposition-review\source-available-runtime.cjs --db-name return_disposition_test_core_a_fix --case b_store_return,b_shortage
+```
+
+結果：exit 0。
+
+- `b_store_return` PASS：退貨回總倉只建一批；人工 operator 記 manual；全零 operator 記 system；錯 source_doc 原單會拒絕。
+- `b_shortage` PASS：少收 `restock_hq` 回帳只建一批；重複更新不重建；錯 source_doc 原單會拒絕。
+
+### 交付前置條件（不算 B 自身缺陷）
+
+- C 撤回／原單更正仍要接上。B 只負責「來源正確時建批」，不負責「原收貨撤回、改實收、撤銷少收時把舊批撤掉」。
+- 整包最後仍要在包含 A/B/C/F 的同一假庫跑 flow 與核心回歸；本段不是正式系統驗收。

--- a/docs/return-disposition-source-review.md
+++ b/docs/return-disposition-source-review.md
@@ -1,0 +1,185 @@
+# 阿審審查報告：總倉退回貨處理 B 來源接線
+
+日期：2026-09-07  
+範圍：只審 B 段 `supabase/migrations/20260907020000_hq_return_disposition_sources.sql` 與 `docs/return-disposition-source-contract.md`。  
+不審 A 已知退修項，不把 C 尚未接的撤回、原單更正、月鎖完整實作算成 B 自身缺陷；不連 GitHub / Supabase / API；沒有執行正式庫 db push。
+
+## 結論
+
+B 的大方向正確：用 `transfer_items.in_movement_id` 接「退回總倉真入庫」，用 `transfer_items.shortage_restock_movement_id` 接「短少沖回總倉」，欄位名稱也對。
+
+按目前 patch 實際缺陷計：
+
+- B 自身 P0：0
+- B 自身 P1：2
+- B 自身 P2：1
+
+另外有 2 個「整包交付前置條件」：A helper 必須先修完來源防偽；C 必須接撤回/改實收，不然整包不能放行。這兩項不重複計入 B 自身 P1。
+
+## B 自身 P0
+
+無。
+
+## B 自身 P1
+
+### P1-1：人工退回總倉會被誤標成 system，處理人也會變全零
+
+位置：
+
+- B 讀父單 `received_by`：`supabase/migrations/20260907020000_hq_return_disposition_sources.sql:49-53`
+- B 用 `received_by` 判斷 system/manual：`:109-115`
+- B 傳給 A helper：`:120-131`
+- 最新 `rpc_receive_transfer` 先寫 item `in_movement_id`：`supabase/migrations/20260904020010_accept_store_return_deducts_stock.sql:380-384`
+- 最新 `rpc_receive_transfer` 後面才寫父單 `received_by = p_operator`：`:397-400`
+
+實際時序：
+
+1. `rpc_receive_transfer` 對每個 item 先呼叫 `rpc_inbound` 建正向入庫 movement。
+2. 同一圈立刻 `UPDATE transfer_items SET in_movement_id = v_in_mov_id`。
+3. B 的 AFTER UPDATE trigger 此時被觸發。
+4. B 去讀 parent `transfers.received_by`，但父單還沒更新，所以很可能是 NULL。
+5. B 把 NULL coalesce 成全零 UUID，再把 `auto_flag` 記成 `system`。
+6. 迴圈跑完後，`rpc_receive_transfer` 才 `UPDATE transfers SET received_by = p_operator`。
+
+白話風險：
+
+- 做了現在這版：店員或總倉人員明明手動同意收回，待處理批次卻會寫成「系統自動」，處理人變全零。
+- 不修：後面查誰同意、48 小時自動同意、人工責任歸屬會混在一起。這是稽核錯，但尚未證實會造成不可恢復大量資料或全系統破壞，所以列 P1，不升 P0。
+
+最小修法：
+
+- return 路不要讀父單 `received_by` 當 operator。
+- 直接從 `stock_movements.operator_id` 取操作者；B 的 `v_mov` SELECT 補 `operator_id`。
+- `auto_flag` 用 `v_mov.operator_id = '00000000-0000-0000-0000-000000000000'::uuid` 判 system，其餘 manual。
+
+### P1-2：B 沒核對 movement 的 `source_doc_type/source_doc_id`，來源防偽少一層
+
+位置：
+
+- return movement 查詢只取 id/tenant/location/sku/quantity/type：`supabase/migrations/20260907020000_hq_return_disposition_sources.sql:58-63`
+- shortage movement 查詢只取 id/tenant/location/sku/quantity/type：`:148-153`
+- 最新 receive 建入庫時 source 是 `transfer / p_transfer_id`：`supabase/migrations/20260904020010_accept_store_return_deducts_stock.sql:368-378`
+- 最新 shortage restock/redispatch 建回帳 movement 時 source 是 `transfer / v_item.transfer_id`：`supabase/migrations/20260903000200_shortage_resolution_undo.sql:229-239`、`:271-281`
+- 既有 `rpc_adjust_received_transfer` 對 `in_movement_id` 也會核 `movement_type='transfer_in' AND source_doc_type='transfer' AND source_doc_id=p_transfer_id`：`supabase/migrations/20260904010000_adjust_received_syncs_stock.sql:437-449`
+
+目前 B 有核：
+
+- tenant
+- sku
+- location
+- movement_type
+- quantity > 0
+
+但沒核：
+
+- `source_doc_type = 'transfer'`
+- `source_doc_id = NEW.transfer_id`
+
+白話風險：
+
+- 做了現在這版：如果 `in_movement_id` 或 `shortage_restock_movement_id` 被接到同倉同品項、但不是這張調撥單的 movement，B 仍會建總倉待處理批次。
+- 不修：A 即使後續加強 helper，B 這層還是沒有把「這筆異動就是這張原單」說清楚，出錯時比較難定位。
+
+最小修法：
+
+- B 查 `stock_movements` 時補取 `source_doc_type, source_doc_id, operator_id`。
+- return / shortage 兩條都加：
+  - `v_mov.source_doc_type = 'transfer'`
+  - `v_mov.source_doc_id = NEW.transfer_id`
+
+## B 自身 P2
+
+### P2-1：return 原因只取父單 notes，而且是在父單收貨 notes 合併前讀；這可以接受但文件要講清楚
+
+位置：
+
+- B 取 `v_transfer.notes`：`supabase/migrations/20260907020000_hq_return_disposition_sources.sql:49-53`
+- B 設 `v_source_reason := LEFT(v_transfer.notes, 200)`：`:117-118`
+- 最新 `rpc_receive_transfer` 是最後才把 `p_notes` 合併回父單 notes：`supabase/migrations/20260904020010_accept_store_return_deducts_stock.sql:397-405`
+
+這不擋 B，因為退貨原因通常在建退貨單時已在父單 notes；收貨當下補的 notes 不一定需要當 source_reason。  
+但契約若寫成「收貨備註也會進 source_reason」就不成立。
+
+最小修法：
+
+- source contract 補一句：return `source_reason` 只取觸發當下父單既有 notes，不含本次收貨 `p_notes`。
+
+## 整包交付前置條件（不算 B 自身缺陷）
+
+### 前置條件 1：A helper 必須先修完來源防偽，B 才可放行
+
+位置：
+
+- B 呼叫 A helper：`supabase/migrations/20260907020000_hq_return_disposition_sources.sql:120-131`、`:205-216`
+- A 前審已指出 `_hq_hold_return` 尚需補 source movement location、qty、transfer_item 關係防偽。
+
+這不是 B 單獨缺陷；但整包交付要明列：B 只有在 A helper 已經防偽完成後，才算安全入口。
+
+### 前置條件 2：C 必須接撤回與原單更正，否則 B 建出的 pending 會留下假量
+
+位置：
+
+- B 觸發條件：`supabase/migrations/20260907020000_hq_return_disposition_sources.sql:45-47`、`:139-140`
+- `rpc_adjust_received_transfer` 會把 `in_movement_id` 指到新 movement：`supabase/migrations/20260904010000_adjust_received_syncs_stock.sql:692-696`
+- `rpc_unreceive_transfer` 會先寫 reversal，再清 `in_movement_id`：`supabase/migrations/20260903000010_unreceive_reverse_inbound_regardless_of_qty.sql:185-207`
+- `rpc_undo_transfer_item_shortage` 會 reversal `shortage_restock_movement_id`，再清短少欄位：`supabase/migrations/20260903000200_shortage_resolution_undo.sql:565-590`、`:636-646`
+
+這不是 B 自身 P1，因為 B 本來只負責「建批」，C 負責「拆批/撤回」。但整包不能漏。
+
+## C 最小接法獨立評估
+
+結論：用 `stock_movements.reverses` hook 比重抄三支大 RPC 小，也比較不容易漏，方向可採；但不能只做一個 stock_movement hook，還要補 transfer_items 清 ID 守門，防止「不寫 reversal、只清欄位」繞過。
+
+### 建議形狀
+
+1. 新增 `_hq_revoke_return(p_source_movement_id, p_operator_id, p_reason)` 或等價 helper。
+   - 找 `hq_return_batches.source_movement_id = p_source_movement_id`。
+   - 只允許未處理批次撤回：`status='pending'` 且 `qty_good = qty_damaged = qty_lost = 0`。
+   - 撤回時扣回 `stock_balances.reserved`、標 `status='revoked'`，並留事件或欄位紀錄。
+   - partial / completed 一律 raise，讓外層 RPC 整筆 rollback。
+
+2. 新增 `stock_movements BEFORE INSERT` hook，專門處理 reversal。
+   - 條件：`NEW.reverses IS NOT NULL`，且被 reverses 的原 movement 有 hq_return batch。
+   - 在負異動 guard 前先呼叫 `_hq_revoke_return`。
+   - trigger 名稱要排在 `trg_guard_hq_pending` 前面，否則舊入庫 movement 被 reversal 時，負異動 guard 會先看到 pending 還在而擋掉。
+
+3. 新增 `transfer_items BEFORE UPDATE OF in_movement_id, shortage_restock_movement_id` 守門。
+   - 如果 OLD movement 有 hq_return batch，NEW 清成 NULL 或換成別筆 movement，必須確認舊 batch 已撤回，或同交易中已有對 OLD movement 的 reversal。
+   - 若沒有，就 raise。這是防「清 ID 不寫 reversal」旁路。
+
+### 為什麼比重抄三支大 RPC 小
+
+- `rpc_unreceive_transfer` 已經先寫 reversal，再清 `in_movement_id`，行號 `supabase/migrations/20260903000010_unreceive_reverse_inbound_regardless_of_qty.sql:185-207`。
+- `rpc_undo_transfer_item_shortage` 已經先 reversal `shortage_restock_movement_id`，再清欄位，行號 `supabase/migrations/20260903000200_shortage_resolution_undo.sql:565-590`、`:636-646`。
+- `rpc_adjust_received_transfer` 是先立新、再沖舊、最後把 `in_movement_id` 換成新 movement，行號 `supabase/migrations/20260904010000_adjust_received_syncs_stock.sql:591-610`、`:692-696`。
+
+所以 C 可以貼在共同的 movement reversal 與 transfer_items 欄位變更點，不必把三支 RPC 各自重抄一段 hq_return 邏輯。
+
+### 需要注意的邊界
+
+- 月鎖：現有大 RPC 內已有月鎖/狀態守衛；C hook 不應假裝替代月鎖。若有人繞過大 RPC 直接寫 reversal，transfer_items 清 ID 守門仍要擋住狀態不一致。
+- 先立新後沖舊：`rpc_adjust_received_transfer` 會先寫新入庫 movement，再 reversal 舊 movement，最後更新 item 指向新 movement。C 應在舊 reversal 時撤舊 batch，讓 B 在 item 換新 id 時建新 batch。
+- partial 拒絕：只要舊 batch 已有 good/damaged/lost 任何處理，C 必須 raise，讓外層整筆 rollback，不能自動拆。
+- 清 ID 不 reversal 旁路：只靠 stock_movement hook 抓不到「直接把 `in_movement_id` 清 NULL」；所以 transfer_items 欄位守門是必要配套。
+
+### C 必測
+
+- `rpc_unreceive_transfer`：pending return batch 可隨 reversal 撤回；partial batch 會擋，整張取消收貨 rollback。
+- `rpc_undo_transfer_item_shortage`：pending shortage batch 可隨 reversal 撤回；partial batch 會擋，撤銷短少 rollback。
+- `rpc_adjust_received_transfer`：先立新後沖舊時，舊 batch 被撤，新 movement 經 B 建新 batch；partial 舊 batch 擋下。
+- 直接 UPDATE `transfer_items.in_movement_id = NULL` 或清 `shortage_restock_movement_id`、但沒有 reversal：必須被 transfer_items 守門擋。
+
+## 已核實正確 / 不列問題
+
+- 短少欄位名是真的：`shortage_resolution`、`shortage_resolution_at`、`shortage_resolution_by`、`shortage_resolution_notes`、`shortage_restock_movement_id` 都由最新版 `rpc_resolve_transfer_item_shortage` 寫入，見 `supabase/migrations/20260903000200_shortage_resolution_undo.sql:399-405`。
+- shortage 的 operator 用 `NEW.shortage_resolution_by` 是合理的，因為 resolve 同一個 UPDATE 會同時寫 `shortage_resolution_by = p_operator` 與 `shortage_restock_movement_id`，見 `supabase/migrations/20260903000200_shortage_resolution_undo.sql:399-405`。
+- shortage restock/redispatch 的回帳 movement type 是 `transfer_cancel`，B 檢查 `transfer_cancel` 方向正確，見 `supabase/migrations/20260903000200_shortage_resolution_undo.sql:229-239`、`:271-281`。
+- return path 檢查 `transfer_type='return_to_hq'`、movement type `transfer_in`、movement location = dest、dest 是 central_warehouse，方向正確。
+- B trigger 是 `SECURITY DEFINER SET search_path = public, pg_temp`，且 revoke PUBLIC/anon/authenticated；作為 trigger 內部函式，不直接開給前端，方向正確。
+
+## 建議修正順序
+
+1. B 先修人工/系統來源：return operator 改取 movement.operator_id。
+2. B 再補 source_doc 防偽：兩條來源都核 `source_doc_type/source_doc_id`。
+3. source contract 補 return notes 時序與 A 前置條件。
+4. C 採 reversal hook + transfer_items 清 ID 守門，不重抄三支大 RPC。

--- a/docs/return-disposition-test-design.md
+++ b/docs/return-disposition-test-design.md
@@ -1,0 +1,233 @@
+# 總倉退回貨處理：本機整合測試設計
+
+日期：2026-09-07  
+角色：阿審，並行驗收準備  
+限制：只設計本機測試，不連 GitHub/Supabase，不讀 `.env`，不跑現有可能連線腳本，不碰阿寫的 `tests/return-disposition/fixture.sql` 或 `test.sql`。
+
+---
+
+## 一、測試目標
+
+這組測試不是要複製整套正式系統，而是用最小假資料跑「真正最新版函式」：
+
+- `apply_movement_to_balance` / `trg_apply_movement`
+- `rpc_outbound`
+- `rpc_receive_transfer`
+- `rpc_create_store_return`
+- `rpc_resolve_transfer_item_shortage`
+- `rpc_undo_transfer_item_shortage`
+- `rpc_adjust_received_transfer`
+- `rpc_unreceive_transfer`
+- 阿寫新增的總倉退回貨待處理 migration
+
+不能把核心函式抄成簡化版測試，否則只是在測自己寫的假世界。
+
+---
+
+## 二、最小本機庫載入方式
+
+本機 PostgreSQL 18 預計位置：
+
+```powershell
+psql -h 127.0.0.1 -p 56427 -U returnlocal -d return_disposition_review
+```
+
+建議建立兩種資料庫：
+
+- `return_disposition_review_fixture`：阿寫 fixture/test 用。
+- `return_disposition_review_check`：阿審可重跑審查斷言用。
+
+最低限度要載入這幾類東西：
+
+1. 基礎 schema，不要手刻假表：
+   - `supabase/migrations/20260422120001_product_schema.sql`：`products` / `skus` / `prices`
+   - `supabase/migrations/20260422120003_inventory_schema.sql`：`locations` / `stock_balances` / `stock_movements` / `transfers` / `transfer_items` / trigger
+   - `supabase/migrations/20260423120000_stores_order_schema.sql`：`stores` / `customer_orders` / `customer_order_items`
+   - `supabase/migrations/20260423120002_picking_waves.sql`：`picking_waves` / `picking_wave_items`
+   - `supabase/migrations/20260512000009_store_monthly_settlement.sql`：鎖月表
+   - `supabase/migrations/20260515000001_restock_requests_schema.sql`：補貨申請表
+2. 會被最新版函式引用的欄位追加 migration。不要只靠最早建表檔，因為後面有追加欄位：
+   - `transfer_type`、`customer_order_id`、`next_transfer_id`
+   - `transfer_items.description`、`estimated_amount`
+   - `shortage_resolution`、`shortage_restock_movement_id`、`shortage_redispatch_wave_id`、`shortage_return_transfer_id`、`shortage_prev_qty_received`
+   - `stock_movements` 的最新 movement type、`source_doc_line_id`、`reverses`
+3. 真正最新版函式按最後 CREATE 載入：
+   - `rpc_outbound`：`20260705000000_dispatch_price_guard.sql:121`
+   - `rpc_receive_transfer`：`20260904020010_accept_store_return_deducts_stock.sql:101`
+   - `rpc_create_store_return`：`20260904020000_store_return_create_no_stock.sql:157`
+   - `rpc_resolve_transfer_item_shortage`：`20260903000200_shortage_resolution_undo.sql:111`
+   - `rpc_undo_transfer_item_shortage`：`20260903000200_shortage_resolution_undo.sql:429`
+   - `rpc_adjust_received_transfer`：`20260904010000_adjust_received_syncs_stock.sql:194`
+   - `rpc_unreceive_transfer`：`20260903000010_unreceive_reverse_inbound_regardless_of_qty.sql:26`
+4. 阿寫新增 migration 最後載入。
+
+如果完整 migration 串太重，允許做「最小 schema 載入檔」，但限制是：
+
+- 表、欄位、CHECK、trigger 必須照真 schema。
+- 上面列的函式必須從正式 migration 原文載入，不可在 fixture 內重寫簡版。
+- 可以 stub 掉本測試完全不會走到的通知、報表、外部整合，但 stub 名稱要集中列在 fixture 檔頭。
+
+---
+
+## 三、真 schema 錨點
+
+本輪已讀到的真 schema／真定義錨點：
+
+- `stock_balances.reserved` 欄位存在於 `20260422120003_inventory_schema.sql:34`。
+- `stock_movements` movement type 最初清單在 `20260422120003_inventory_schema.sql:54`，後續有 migration 擴充，不能只拿最早清單。
+- `transfers` / `transfer_items` 基礎表在 `20260422120003_inventory_schema.sql:84`、`:107`。
+- `trg_apply_movement` 在 `20260422120003_inventory_schema.sql:254`。
+- `rpc_outbound` 最新版在 `20260705000000_dispatch_price_guard.sql:121`，`SELECT on_hand - reserved` 在 `:144`，`p_allow_negative` 判斷在 `:157`。
+- `rpc_receive_transfer` 最新版在 `20260904020010_accept_store_return_deducts_stock.sql:101`。
+- `rpc_create_store_return` 最新版在 `20260904020000_store_return_create_no_stock.sql:157`。
+- `rpc_resolve_transfer_item_shortage` 最新版在 `20260903000200_shortage_resolution_undo.sql:111`。
+- `rpc_undo_transfer_item_shortage` 最新版在 `20260903000200_shortage_resolution_undo.sql:429`。
+- `rpc_adjust_received_transfer` 最新版在 `20260904010000_adjust_received_syncs_stock.sql:194`。
+- `rpc_unreceive_transfer` 最新版在 `20260903000010_unreceive_reverse_inbound_regardless_of_qty.sql:26`。
+
+---
+
+## 四、最小 fixture 必備角色
+
+假資料至少要有：
+
+- 1 個 tenant。
+- 1 個總倉 location。
+- 2 個店 location：A 店、B 店。
+- 2 個 store：A、B，分別連到 location。
+- 2 個 SKU：
+  - SKU-GOOD：一般商品，用來測完好/破損/遺失/待確認。
+  - SKU-OTHER：同商品或不同商品皆可，用來證明同商品好貨照派、不整個商品鎖死。
+- HQ `stock_balances`：
+  - SKU-GOOD 在庫 20，好貨已確認。
+  - 另有 3 件待確認來源，測試後可派應是 20，不是 23。
+- A 店 `stock_balances`：
+  - SKU-GOOD 在庫足夠送退貨，能測 `rpc_create_store_return` → `rpc_receive_transfer`。
+- 一筆 `hq_to_store` 已收但短收的 transfer，用來測 `restock_hq` / `redispatch`。
+- 一筆鎖月 `store_monthly_settlements`，用來測跨月/已鎖月份不可靜默改錢。
+- 至少一筆直接負異動嘗試，用來驗 trigger 或同等保護是否擋住繞過 `rpc_outbound`。
+
+---
+
+## 五、必要測試情境
+
+### A. 店家退貨同意後形成待確認
+
+1. A 店送退貨 3 件，送出時不扣庫存。
+2. 總倉手動同意。
+3. 預期：
+   - transfer 變 `received`。
+   - HQ on_hand 增加 3。
+   - 新待處理明細出現 3。
+   - HQ reserved 或同等保護增加 3。
+   - 可派量仍只算原本好貨，不把這 3 件算進去。
+
+### B. 48 小時自動同意也要一樣
+
+1. 建一張超過 48 小時的店家退貨。
+2. 呼叫真正的自動同意函式，或用阿寫測試鉤子只處理該單。
+3. 預期和手動同意一致，且處理紀錄標示系統自動、時間、原單。
+
+### C. 同商品好貨照派，不整個 SKU 鎖死
+
+1. HQ SKU-GOOD on_hand 23，其中 3 待確認、20 是好貨。
+2. 對 B 店派 20 應成功。
+3. 派第 21 件應失敗。
+4. 不能出現「因有 3 件待確認，所以整個 SKU 都不能派」。
+
+### D. 同批部分處理
+
+1. 同一批 10 件待確認。
+2. 先處理 4 完好。
+3. 再處理 2 破損、1 遺失。
+4. 預期：
+   - 完好 4 從待確認轉可派。
+   - 破損/遺失扣總倉數量且留成本依據。
+   - 待確認剩 3。
+   - 完好 + 破損 + 遺失 + 未處理 = 10。
+
+### E. 重複提交與兩連線併發
+
+1. 同一筆待確認，連續按兩次處理，第二次不能再扣。
+2. 雙 session 同時處理同一批：
+   - session A 開交易後鎖住同一批。
+   - session B 應等待或失敗。
+   - 最終合計不能超過原數量。
+3. 同時派貨與處理破損：
+   - 派貨不能把待確認量吃掉。
+   - 破損扣減不能把 on_hand 扣成負數。
+
+### F. `p_allow_negative` 與直接負異動旁路
+
+1. 呼叫 `rpc_outbound(..., p_allow_negative => false)` 應被 `reserved` 或同等可用量擋住。
+2. 呼叫 `rpc_outbound(..., p_allow_negative => true)` 不應能繞過本案「待確認不可派」規則；若本案選擇用 trigger，應由 trigger 擋。
+3. 直接 `INSERT stock_movements` 寫負數也應被 trigger 或同等共用保護擋住。
+
+這三條是用來防 fixture 太簡化：只測一般 `rpc_outbound` 不夠。
+
+### G. 短少路徑
+
+1. `restock_hq` 真回帳：`transfer_cancel` 回到出貨端的那批實物/貨帳，必須建立一次待處理來源。
+2. `redispatch` 真回帳：同上，且不能因為重派再建第二批待處理。
+3. `[短收沖帳]` 純記帳 `return_to_hq` 單不能進實物待驗。
+4. 同一短少已處理過，再送一般少收退貨，應防重複扣/加/退款。
+
+### H. 修改實收與退回收貨配單
+
+1. 已有待處理的 `return_to_hq` 單，走 `rpc_adjust_received_transfer`：
+   - 要嘛後端擋。
+   - 要嘛同步調整待處理量與保留量。
+2. 走 `rpc_unreceive_transfer`：
+   - 待處理明細與保留量要撤回。
+   - 不能留下幽靈 reserved。
+
+### I. 錢與鎖月
+
+1. 店家帳單沖回只發生一次。
+2. 總倉內部破損/遺失不自動再向店家收款或退款。
+3. 已鎖月份不准被原單更正或後續處理靜默重算。
+4. 成本依據至少能追到原出庫/入庫 movement 或候選規則明確標記成本未知。
+
+---
+
+## 六、審查用跑法
+
+阿寫完成後，建議 CEO 在本機新 cluster 依序跑：
+
+```powershell
+psql -h 127.0.0.1 -p 56427 -U returnlocal -d return_disposition_review -v ON_ERROR_STOP=1 -f .\tests\return-disposition\fixture.sql
+psql -h 127.0.0.1 -p 56427 -U returnlocal -d return_disposition_review -v ON_ERROR_STOP=1 -f .\tests\return-disposition\test.sql
+psql -h 127.0.0.1 -p 56427 -U returnlocal -d return_disposition_review -v ON_ERROR_STOP=1 -f .\tests\return-disposition-review\review_assertions.sql
+```
+
+雙 session 併發測試不能只靠單一 SQL 檔證明。若阿寫沒有提供兩連線腳本，阿審要手動用兩個 psql 視窗驗一次：
+
+```sql
+-- session A
+BEGIN;
+-- 呼叫阿寫的處理函式，故意先不 COMMIT。
+
+-- session B
+BEGIN;
+-- 對同一批呼叫處理或派貨，應等待或失敗，不能成功吃掉同一批。
+
+-- session A
+COMMIT;
+
+-- session B
+-- 若等待後繼續，必須重讀新狀態並拒絕超量。
+```
+
+---
+
+## 七、阿審正式審查時的判準
+
+- 測試有跑真正最新版函式，不是 fixture 裡另寫簡版。
+- 測試能抓出只改畫面、沒改共用後端保護的錯。
+- 測試能抓出只靠 `reserved`、卻漏掉 `p_allow_negative` 或直接負 movement 的錯。
+- 測試能抓出短少 `transfer_cancel` 真回帳未建待處理的錯。
+- 測試能抓出 `[短收沖帳]` 純記帳單被誤抓進實物待驗的錯。
+- 測試能抓出 `adjust` / `unreceive` 讓保留量脫鉤的錯。
+- 測試能抓出鎖月、重複提交、兩連線併發缺測。
+
+沒有上述證據，就不能只憑「測試綠」放行。

--- a/docs/return-disposition-ui-review.md
+++ b/docs/return-disposition-ui-review.md
@@ -189,3 +189,68 @@ CEO 已回報全站 `tsc` exit 0；本審查未重跑全站 tsc。
 E 初版 UI 目前 P0 = 0、P1 = 8、P2 = 4。  
 
 不建議在未退修前交給現場使用。最大問題不是畫面風格，而是：短少店名會顯示錯方、原單號沒列出、角色放行不一致、Safari request id 可能送不出去、未知送達後換新 request id 可能重複處理、小數輸入會靜默改數、200 筆後批次不可達，外加 lint 會卡收工。
+
+---
+
+## E 修版正式複審（2026-09-07，Codex GPT-5.5 阿審）
+
+結論：E 修版目前未見阻擋 page/layout 放行給下一段整包驗收的 P0/P1/P2。首審 8 個 P1、4 個 P2 已逐條補足；但這不是正式瀏覽器驗收，也不是後端 SQL 驗收。
+
+### 本輪範圍
+
+- `apps/admin/src/app/(protected)/wms/return-disposition/page.tsx`
+- `apps/admin/src/app/(protected)/layout.tsx`
+- `tests/return-disposition-review/ui-input-runtime.cjs`
+- `tests/return-disposition-review/ui-submit-runtime.cjs`
+
+已讀派工稿：`D:\1人公司\_本機工地\return-disposition-tools\writer-front-e-fix.md`，但以下判定以本機實碼與測試為準，不照抄作者說法。
+
+### P0
+
+- 0。
+
+### P1
+
+- 0。
+
+首審 P1 結案狀態：
+
+1. 角色放行已收窄：頁面 `canDisposeReturn` 只允許 `owner/admin/hq_manager`，位置 `page.tsx:106-108`；layout 入口同樣用 `canDisposeHqReturn` 過濾，位置 `layout.tsx:124-136`。
+2. 短少店名已分流：`source_kind === "shortage"` 用原單 `dest_location`，店退才用 `source_location`，位置 `page.tsx:431-433`、`:951-954`。
+3. 原單號已顯示：列表與詳情都有「原單 + 明細 #」，位置 `page.tsx:989-990`、`:1083-1084`。
+4. Safari fallback UUID 已改成 `crypto.getRandomValues` 產生 RFC4122 v4，不用 `Math.random`，位置 `page.tsx:153-166`；`ui-input-runtime.cjs` 已實跑通過。
+5. 未知送達已鎖原包：待確認包存入 localStorage，綁 tenant/operator/batch/request/payload，位置 `page.tsx:188-242`、`:778-788`；未知時表單/切批鎖住，重送只送原 payload，位置 `:645-669`、`:817`、`:886-901`；`ui-submit-runtime.cjs` 已用真元件跑過未知送達、重送、關頁重開、切批。
+6. 小數輸入不再靜默改值：`clampDecimal` 編輯中直接保留原字串，位置 `page.tsx:168-171`；送出才用 `toThousandths` 驗完整字串、非負、最多 3 位小數與總額，位置 `:177-185`、`:706-735`；runtime 已驗 `1e3`、`-1`、`1.0001`、`11` 不送 RPC，`0.125` 可送。
+7. 200 筆後不可達已補分頁：清單用 `.range(from, from + PAGE_SIZE)` 多抓 1 筆判斷下一頁，位置 `page.tsx:360`、`:1034-1065`；歷史切換/翻頁會清 selected 與表單，避免拿舊批次送出。
+8. 單頁 lint 已過：本輪實跑 `npm run lint --workspace apps/admin -- 'src/app/(protected)/wms/return-disposition/page.tsx'`，exit 0。layout 原有 effect lint 兩條不是本次 E 新增，本輪未把它算成 E 缺陷。
+
+### P2
+
+- 0。
+
+首審 P2 結案狀態：
+
+1. 表格選批已改成真正 `<button type="button">`，含 `aria-pressed` 與 disabled 狀態，位置 `page.tsx:966-975`。
+2. 錢的文案已改成「本頁不會再自動向店家收款或退款；責任歸屬另依老闆規則處理」，位置 `page.tsx:828`。
+3. 事件列表改用 `fetchAllRows<EventRow>`，位置 `page.tsx:504-512`。
+4. 查詢錯誤有往 `listError/eventsError` 或畫面警示走；locations/staff 錯誤不再安靜吞掉，相關位置 `page.tsx:354-442`、`:504-535`、`:862-878`、`:1131`。
+
+### 本機實跑
+
+```powershell
+node --check tests\return-disposition-review\ui-input-runtime.cjs
+node --check tests\return-disposition-review\ui-submit-runtime.cjs
+node tests\return-disposition-review\ui-input-runtime.cjs
+node tests\return-disposition-review\ui-submit-runtime.cjs
+npm run lint --workspace apps/admin -- 'src/app/(protected)/wms/return-disposition/page.tsx'
+```
+
+結果全部 exit 0。
+
+`ui-submit-runtime.cjs` 這輪不是只 grep：它用 jsdom + ReactDOM 真渲染頁面，stub AuthProvider、Supabase、Next Link、SpinButton，再點真 button、填真 input、看實際送出的 `rpc_dispose_hq_return` payload。
+
+### 未覆蓋 / 仍需整包驗收
+
+- 未啟動真 Next 瀏覽器，所以沒有人工驗 Safari/iPad 實機輸入法。
+- 沒連 Supabase；列表、事件、staff、RLS 的真資料權限由 SQL/flow 測試負責。
+- C 撤回／原單更正、F 一般退貨四位小數 P1 不在 E 範圍；不能把 E 綠燈視為整包完成。

--- a/docs/return-disposition-ui-review.md
+++ b/docs/return-disposition-ui-review.md
@@ -1,0 +1,191 @@
+# 總倉退回貨處理 — E 初版 UI 審查（訂正版）
+
+日期：2026-09-07  
+角色：阿審（獨立審查）  
+範圍：只審 `apps/admin/src/app/(protected)/wms/return-disposition/page.tsx` 與 `apps/admin/src/app/(protected)/layout.tsx` 新入口。未改功能碼；未連 GitHub / Supabase；未把 C/F 尚未交付項目算成 E 自身缺陷。
+
+補充訂正：已讀正確派工稿 `D:\1人公司\_本機工地\return-disposition-tools\writer-front-e-fix.md`。先前報告說 `tools/writer-front-e-fix.md` 不存在，是因為查了 repo 內 `tools/`，不是正確外層工具資料夾。
+
+本頁實際行數：`page.tsx` 共 943 行；下列超過 900 的行號是有效行號，不是作者摘要錯字。
+
+## 實跑檢查
+
+```powershell
+npm run lint --workspace apps/admin -- 'src/app/(protected)/wms/return-disposition/page.tsx'
+```
+
+結果：exit 1，2 個 error：
+
+- `page.tsx:189`：effect 內同步 `setListLoading(false)`
+- `page.tsx:305`：effect 內同步 `setEvents([])`
+
+CEO 已回報全站 `tsc` exit 0；本審查未重跑全站 tsc。
+
+## P0
+
+目前未見 E 初版 UI 自身會直接繞過後端寫錯帳的 P0。  
+但 P1-5 的「未知送達 + request id」若修錯，會變成重複處理同一件的實際事故；因此修法不可採用自動換新 request id。
+
+## P1
+
+### P1-1：前端放行角色比後端 RPC 寬，會讓部分總部帳號看得到頁面但送不出去
+
+依據：
+
+- `page.tsx:145` 用 `isHqRole(role)` 判斷可進頁。
+- `role.ts:18` 的 `HQ_ROLES` 包含 `hq_accountant` 與空字串 legacy。
+- `page.tsx:468` 文字卻寫只限 `owner / admin / hq_manager`。
+- A 契約與 `page.tsx:6` 都寫 `rpc_dispose_hq_return` 白名單是 `owner/admin/hq_manager`。
+- `layout.tsx:73` 新增入口；`layout.tsx:134` 只對分店隱藏，`hq_accountant` 仍會看見。
+
+影響：會計或 legacy 總部帳號可能看得到「退回貨處理」入口與列表，但按送出才被後端擋。這不是資料破壞，但會造成現場誤以為系統壞掉。
+
+最小修法：E 頁不要直接用通用 `isHqRole`，改成此頁自己的 `canDisposeReturn(role)`，只放 `owner/admin/hq_manager`；layout 入口也要同一個角色集合。
+
+### P1-2：短少來源店會顯示錯方，把總倉當店名
+
+依據：
+
+- `page.tsx:226-280` 店名解析一律走 `source_transfer_item_id → transfers.source_location → locations.name`。
+- B 實碼 `20260907020000_hq_return_disposition_sources.sql:175-184` 明寫 shortage 的 `source_location` 是出貨端，且必須是 `central_warehouse`。
+- B 實碼 `:205-212` 對 shortage 建 batch 時 `source_kind='shortage'`，但 E 頁沒有依 `source_kind` 分流。
+
+影響：短少批次的「店名」欄會顯示總倉，不是發現短少的店。總倉人員可能找錯單、問錯店。
+
+最小修法：抓 transfers 時同時取 `transfer_no/source_location/dest_location/transfer_type`；`source_kind === 'shortage'` 時店名用 `dest_location`，`store_return` 才用 `source_location`。
+
+### P1-3：頁面沒有列出原調撥單號，只顯示批次號；現場難以核對
+
+依據：
+
+- `page.tsx:248-255` 查了 `transfer_no`，但後面只把 `source_location` 放進 `trMap`（`:259-280`）。
+- 表格欄位 `page.tsx:521-531` 沒有原單號；詳情 `:633-665` 也沒有。
+- fallback 只顯示 `調撥明細#id`（`:558-560`），不是現場會拿來找單的單號。
+
+影響：使用者只能看到批次 # 與品項，缺少原單號；同店同品項多批時，很容易處理錯批或花時間回查。
+
+最小修法：保留 `transfer_no` map，表格或詳情至少顯示「原單號 TRxxx / 明細 #xxx」。
+
+### P1-4：Safari fallback 產生的 request id 不是 PostgreSQL UUID
+
+依據：
+
+- `page.tsx:118-121` 若沒有 `crypto.randomUUID()`，回傳 `r_${Date.now()}_...`。
+- `page.tsx:415` 把它送進 `p_request_id`。
+- A 契約 `rpc_dispose_hq_return(p_request_id UUID)`；PostgreSQL UUID 不接受 `r_...`。
+- 專案 browserslist 包含 `safari >= 13.1` / `ios_saf >= 13.4`，這些環境不保證有 `crypto.randomUUID()`。
+
+影響：部分仍在支援範圍內的 Safari/iPad 會按送出才出 UUID 格式錯誤，現場會以為不能處理退回貨。
+
+最小修法：fallback 必須產生標準 UUID v4。不可用 `Math.random` 當安全 id；用 `crypto.getRandomValues`，或若專案已有安全 UUID helper 就直接重用。
+
+### P1-5：未知送達後的 request id / payload 管理會讓使用者有機會重複處理同一件
+
+依據：
+
+- request id 建在 `page.tsx:178`。
+- RPC 失敗時保留同一 request id，註解說網路錯誤可直接重試（`:450-453`）。
+- UI 同時提供「重新產生 Request ID（改 payload 後按）」按鈕（`:902-913`）。
+- 先前報告建議「payload 變更自動換 request id」是危險修法，已撤回。
+
+危險情境：第一次送 `good=1` 其實後端已成功，但前端回應丟失；畫面仍顯示舊 pending。若使用者按「重新產生 Request ID」或系統自動換新 id，再送同樣 `good=1`，後端會把它當第二次處理，若餘量還夠就會再扣一件。
+
+影響：這會造成同一批被多處理，不是單純操作不方便。
+
+最小修法：不讓使用者手動管 request id。送出後若結果未知，必須綁住原 payload + 原 request id，鎖住表單或切成「待確認送出結果」狀態；只能重送原包，或先查 `hq_return_events.request_id` / 刷新確認結果後，才允許開新包。資料庫明確 reject 才能讓使用者修改 payload 形成新包；網路未知不能當 reject。
+
+### P1-6：小數輸入會靜默改數，可能讓使用者送出非本意數量
+
+依據：
+
+- `clampDecimal` 在 `page.tsx:125-135` 用 regex 只吃前綴，且會立刻改 input value。
+- 三個數量欄位都用它：完好 `:773-775`、破損 `:806-808`、遺失 `:839-841`。
+- CEO 以實碼 AST 轉 JS 抽驗結果：
+  - `clampDecimal('1.',10) → '1'`，使用者無法自然輸入小數。
+  - `clampDecimal('1e3',10000) → '1'`，非法格式被吃前綴。
+  - `clampDecimal('1',0.75) → '0'`，超上限被靜默改成 0。
+  - `clampDecimal('0.0009',10) → '0.000'`，超過 3 位被靜默改成 0。
+
+影響：現場以為自己輸入的是 A，畫面/送出變成 B；退回貨數量是實物帳，不能靜默改。
+
+最小修法：保留原輸入字串；送出時用完整 regex 驗「有限、非負、最多 3 位小數」，非法就明確顯示錯誤，不吃前綴、不自動截斷。合計改用整數千分位計算，避免 `0.1 + 0.2` 這種浮點誤差。
+
+### P1-7：批次列表只有前 200 筆，沒有下一頁，較舊待處理批次可能完全不可達
+
+依據：
+
+- `MAX_ROWS = 200`（`page.tsx:138`）。
+- 查詢 `.limit(MAX_ROWS)`（`:197-201`）。
+- `page.tsx:620-625` 有提醒「可能有更多批次」，但沒有下一頁或縮小條件。
+
+影響：如果待處理/歷史超過 200 筆，使用者無法從畫面處理較舊批次。提醒「可能有更多」不能算完成，因為本案是要讓總倉處理待確認貨。
+
+最小修法：用穩定排序 `created_at + id` 做最小分頁，或至少提供批次/原單號搜尋；歷史切換時要重置 selected 或明確保留舊 selected，避免拿舊資料送出。
+
+### P1-8：單檔 lint 目前 2 error，會卡收斂檢查
+
+依據：本機單檔 lint exit 1：
+
+- `page.tsx:189`：effect 內同步 `setListLoading(false)`
+- `page.tsx:305`：effect 內同步 `setEvents([])`
+
+影響：不是帳務 P0，但會讓「lint 必過」的收工門檻失敗。
+
+最小修法：把「未授權」與「未選批次」的清空狀態移到事件/渲染邏輯可接受的位置；或改成 derived state，避免 effect 入口同步 setState。不要用 eslint-disable 或 timeout 掩蓋。
+
+## P2
+
+### P2-1：表格列用 `<tr onClick>`，鍵盤操作不容易選批次
+
+依據：
+
+- `page.tsx:564-567` 在 `<tr>` 上綁 `onClick`。
+- 沒有 `tabIndex`、`role="button"`、Enter/Space 鍵處理。
+
+影響：滑鼠可用，但鍵盤使用者或部分輔助工具不容易選批次。
+
+最小修法：在第一欄放一顆真正的 `<button type="button">選取</button>`，或讓列具備 button role、tabIndex 與鍵盤事件。
+
+### P2-2：錢的文案過於絕對
+
+依據：
+
+- `page.tsx:485` 寫「破損/遺失不會對店家收退款」。
+
+影響：本頁確實不應自動再動店家錢；但「不會」容易被看成業務上永遠不追責/不調帳。需求目前只拍板「總倉內部損失不自動再動店家錢，責任歸屬待決」。
+
+最小修法：改成「本頁不會再自動對店家收款或退款；責任歸屬另依老闆規則處理」。
+
+### P2-3：事件列表沒有分頁或 fetchAllRows，完整歷史可能被截斷
+
+依據：
+
+- `page.tsx:315-321` 直接 `.from("hq_return_events").select(...).eq(...).order(...)`，沒有 `.range()`，也沒有 `fetchAllRows`。
+- 畫面標題寫「處理紀錄」（`:681`），沒有提示只顯示前 N 筆。
+
+影響：單批事件通常不會很多，所以先列 P2；但如果同批長期分次處理，畫面可能不是完整歷史。
+
+最小修法：要嘛改用 `fetchAllRows`，要嘛明確加 range/下一頁與「本次載入 N 筆」。
+
+### P2-4：部分查詢錯誤被吞，會讓畫面用 fallback 卻不告訴使用者
+
+依據：
+
+- locations 查詢 `page.tsx:265-268` 沒有接 `error`，後面拿不到店名只 fallback 成 `調撥明細#id`。
+- staff 名稱 RPC `page.tsx:331-336` 也沒檢查 error；實際 `rpc_get_staff_names` 回傳欄位包含 `display_name`，此點沒有欄位錯，但錯誤仍被吞。
+
+影響：不會改帳，但總倉可能看不到店名/操作人，卻不知道是資料缺還是查詢失敗。
+
+最小修法：查詢錯誤要顯示在 `listError/eventsError`，或明確標「店名查詢失敗，請用原單號核對」。
+
+## 可接受點
+
+- 送出錯誤時保留同一 request id，對「網路斷線、不確定是否已送達」這個方向本身是對的；問題是現在又讓使用者/修法可能換新 id，必須改成「未知送達時只允許原包重試或先查事件」。
+- layout 已把入口加入側欄，且分店帳號會被 `BRANCH_HIDDEN_HREFS` 隱藏；問題只在 HQ 角色集合比後端寬。
+- `rpc_get_staff_names` 實際回傳 `display_name`，E 頁欄位名沒有錯；問題是 RPC error 沒處理。
+
+## 結論
+
+E 初版 UI 目前 P0 = 0、P1 = 8、P2 = 4。  
+
+不建議在未退修前交給現場使用。最大問題不是畫面風格，而是：短少店名會顯示錯方、原單號沒列出、角色放行不一致、Safari request id 可能送不出去、未知送達後換新 request id 可能重複處理、小數輸入會靜默改數、200 筆後批次不可達，外加 lint 會卡收工。

--- a/docs/return-disposition-ui-runtime-test-report.md
+++ b/docs/return-disposition-ui-runtime-test-report.md
@@ -2,8 +2,8 @@
 
 日期：2026-09-07
 
-角色：阿審（獨立測試）
-範圍：只新增離線測試 `tests/return-disposition-review/ui-input-runtime.cjs`；未修改功能頁、SQL、既有 core 測試或 UI 審查報告；未連 GitHub / Supabase；未讀 env / 密鑰；未啟動真 app。
+角色：Codex 側 GPT-5.5 阿審（獨立測試）
+範圍：新增離線測試 `tests/return-disposition-review/ui-input-runtime.cjs` 與 `tests/return-disposition-review/ui-submit-runtime.cjs`；未修改功能頁、SQL、既有 core 測試或主 UI 審查報告；未連 GitHub / Supabase；未讀 env / 密鑰；未啟動真 app 或整站 Next。
 
 ## 測試方式
 
@@ -63,4 +63,83 @@ FAIL - newRequestId fallback 不可使用 Math.random
 
 ## 未涵蓋
 
-這支是離線單函式執行期測試，只證明輸入轉換與 request id fallback。它不能證明 UI 在「送出已到後端但前端沒收到回應」時有鎖住原 payload，也不能證明畫面重送安全；該項仍需用元件層或流程層測試另外補。
+`ui-input-runtime.cjs` 是離線單函式執行期測試，只證明輸入轉換與 request id fallback。它不能證明 UI 在「送出已到後端但前端沒收到回應」時有鎖住原 payload，也不能證明畫面重送安全；該項已由下方 `ui-submit-runtime.cjs` 補做元件層查核。
+
+## 重送實碼查核（本輪新增）
+
+新增測試：
+
+```powershell
+node tests/return-disposition-review/ui-submit-runtime.cjs
+```
+
+做法：用 TypeScript 轉譯現有 `apps/admin/src/app/(protected)/wms/return-disposition/page.tsx`，在 jsdom + ReactDOM 裡真的渲染頁面；VM sandbox 提供正常 `window` / `document` / `localStorage` / `sessionStorage`，Next、Supabase、role、SpinButton 等外部依賴全部 stub。`rpc_dispose_hq_return` 固定回「timeout after commit is unknown」，模擬「可能已到後端、前端沒收到結果」。
+
+結果：exit 1，5 個 runtime FAIL、3 個 OBSERVE。這是目前 E 初版的預期結果，代表重送保護未完成；不是修版已通過。
+
+```text
+rendered apps/admin/src/app/(protected)/wms/return-disposition/page.tsx
+rpc calls: 00000000-0000-4000-8000-000000000004:1, 00000000-0000-4000-8000-000000000012:2, 00000000-0000-4000-8000-000000000020:1
+OBSERVE - 未知錯誤後數量欄位啟用數
+  actual:   3 enabled number input(s)
+OBSERVE - 原碼觀察：待確認包恢復機制
+  actual:   durableStorage=false; eventLookupByRequestId=false; memoryRequestRef=true (request ref L178)
+OBSERVE - 原碼觀察：切批是否會重設 request
+  actual:   handleSelectCallsReset=true (L368); resetRegeneratesRequest=true (L354)
+FAIL - 未知送出結果後不可提供可按的換 request id 按鈕
+  actual:   button enabled=true (L882)
+  expected: button absent or disabled until request is confirmed/rejected
+FAIL - 未知結果後若再次送出，payload 要維持原包
+  actual:   second p_batch_id=101, p_request_id="00000000-0000-4000-8000-000000000012", p_qty_good=2, p_qty_damaged=0, p_qty_lost=0, p_damage_reason=null, p_loss_reason=null, p_goods_confirmed=true, p_notes=null; first p_batch_id=101, p_request_id="00000000-0000-4000-8000-000000000004", p_qty_good=1, p_qty_damaged=0, p_qty_lost=0, p_damage_reason=null, p_loss_reason=null, p_goods_confirmed=true, p_notes=null
+  expected: no new write, or same full payload as first unknown request
+FAIL - 未知結果後若再次送出，不得換新 request id
+  actual:   second request=00000000-0000-4000-8000-000000000012; first request=00000000-0000-4000-8000-000000000004
+  expected: no new write, or same request id as first unknown request
+FAIL - 關頁重開後不得用新 request id 重送待確認包
+  actual:   reopened request=00000000-0000-4000-8000-000000000020; first request=00000000-0000-4000-8000-000000000004
+  expected: no new write until confirmation, or same pending request id restored after remount/reload
+FAIL - 關頁重開後若允許重送，payload 要維持原包
+  actual:   reopened p_batch_id=101, p_request_id="00000000-0000-4000-8000-000000000020", p_qty_good=1, p_qty_damaged=0, p_qty_lost=0, p_damage_reason=null, p_loss_reason=null, p_goods_confirmed=true, p_notes=null; first p_batch_id=101, p_request_id="00000000-0000-4000-8000-000000000004", p_qty_good=1, p_qty_damaged=0, p_qty_lost=0, p_damage_reason=null, p_loss_reason=null, p_goods_confirmed=true, p_notes=null
+  expected: no new write until confirmation, or same full payload restored after remount/reload
+5 failed
+```
+
+另跑：
+
+```powershell
+node --check tests/return-disposition-review/ui-submit-runtime.cjs
+```
+
+結果：exit 0。
+
+## 重送查核判定
+
+P0：無。未看到前端能直接繞過後端扣超過 `qty_pending` 的證據；真正扣帳仍由 `rpc_dispose_hq_return` 後端守住。
+
+P1：未知送出結果後，使用者可以改數量、換新 request id、切批或重開頁面後再送，可能把同一件實體處理成兩筆事件。
+
+元件實跑證據：
+
+- 第一次送出：request `...0004`、`p_qty_good=1`。
+- 模擬未知 timeout 後，測試改成 `p_qty_good=2`、按現有「重新產生 Request ID」，第二次送出變 request `...0012`、`p_qty_good=2`。這證明初版可送出新 ID + 新內容，不只是畫面上按鈕存在。
+- 元件 unmount/remount 模擬關頁重開後，再送同一批變 request `...0020`，原本 `...0004` 已遺失。
+
+原碼觀察：
+
+- `requestIdRef` 只放在 React 記憶體：`page.tsx:178` `useRef(newRequestId())`。
+- RPC catch 只 `setSubmitError(...)`，註解說保留同一 request id，但沒有進入「待確認」狀態，也沒有鎖 payload。
+- 錯誤提示明確引導「改數量再送，請先按重新產生 Request ID」。
+- 換 ID 按鈕在 `page.tsx:882`，未知錯誤後仍可按。
+- 三個數量欄只在 `submitting` 時 disabled；catch/finally 後 `submitting=false`。元件測試觀察到未知錯誤後 3 個數量欄仍啟用，但這一點只作觀察，真正判定看後續是否會送出新內容。
+- `handleSelect` 在 `page.tsx:368` 會呼叫 `resetForm()`；`resetForm` 在 `page.tsx:354` 會換新 request id，切批會清掉待確認包。
+- 源碼未使用 `localStorage` / `sessionStorage` / `indexedDB`，也沒有以 `request_id` 查 `hq_return_events` 的恢復流程。這一點只作原碼觀察，不作 runtime PASS/FAIL；合法修法可以是 `useRef + 持久保存`，也可以是伺服器查回/拒絕新送出。
+
+判定：若要支援「關頁重開或重新整理後仍不重複扣」，頁面必須做到其中一種安全行為：未知後不再送出新寫入，或只能用原 request id + 原完整 payload 重試。實作可以持久保存待確認送出包（至少 batch id、request id、三個數量、原因/備註、goods_confirmed、建立時間），也可以用伺服器端 pending/outbox/事件查回來恢復或擋新送出；測試不綁死哪一種。現有初版只靠 `useRef`，重新整理或關頁會整包消失。
+
+P2：無新增。這次問題是會造成重複處理的流程風險，不是單純文案或便利性。
+
+## 重送測試限制
+
+- 此測試沒有啟動 Next 整站，沒有打真 Supabase；所有網路/DB 都是 stub。
+- 此測試證明的是目前頁面狀態流和送出 payload，可作為 Claude 修版回歸保護；它不驗後端 `rpc_dispose_hq_return` 本身的冪等與扣帳 SQL。
+- 為避免綁死實作，測試接受「未知後沒有第二次 RPC」或「第二次 RPC 使用原 request id + 原完整 payload」。原碼 regex 只列 `OBSERVE`，不計入 PASS/FAIL。

--- a/docs/return-disposition-ui-runtime-test-report.md
+++ b/docs/return-disposition-ui-runtime-test-report.md
@@ -1,0 +1,63 @@
+# 總倉退回貨處理 — UI 輸入執行期回歸測試報告
+
+日期：2026-09-07  
+角色：阿審（獨立測試）  
+範圍：只新增離線測試 `tests/return-disposition-review/ui-input-runtime.cjs`；未修改功能頁、SQL、既有 core 測試或 UI 審查報告；未連 GitHub / Supabase；未讀 env / 密鑰；未啟動真 app。
+
+## 測試方式
+
+測試檔用 TypeScript AST 從 `apps/admin/src/app/(protected)/wms/return-disposition/page.tsx` 精確抽出真實 `newRequestId` 與 `clampDecimal` 後轉成 JavaScript 執行。若抽不到函式會直接失敗，不會 skip。
+
+檢查目的：
+
+- 小數輸入不可在使用者編輯時被靜默改字串。
+- Safari / 舊瀏覽器沒有 `crypto.randomUUID()`、但有 `crypto.getRandomValues()` 時，request id fallback 必須仍是 PostgreSQL 可收的 RFC4122 v4 UUID。
+- UUID fallback 不可用 `Math.random`。
+
+## 實跑命令
+
+```powershell
+node tests/return-disposition-review/ui-input-runtime.cjs
+```
+
+結果：exit 1，7 個 FAIL。這是目前 E 初版的預期結果，代表測試已抓到既有缺陷；不是修版已完成。
+
+```text
+extracted newRequestId:L118, clampDecimal:L125 from apps/admin/src/app/(protected)/wms/return-disposition/page.tsx
+FAIL - clampDecimal 編輯中小數點要保留
+  actual:   "1"
+  expected: "1."
+FAIL - clampDecimal 非法格式不可吃前綴改數
+  actual:   "1"
+  expected: "1e3"
+FAIL - clampDecimal 超過上限不可靜默改成別的數
+  actual:   "0"
+  expected: "1"
+FAIL - clampDecimal 超過三位小數不可靜默截斷
+  actual:   "0.000"
+  expected: "0.0009"
+FAIL - newRequestId fallback 要產生 RFC4122 v4 UUID
+  actual:   "r_1700000000000_4fzzzxjylrx"
+  expected: RFC4122 v4 UUID（xxxxxxxx-xxxx-4xxx-[89ab]xxx-xxxxxxxxxxxx）
+FAIL - newRequestId fallback 要使用 crypto.getRandomValues
+  actual:   0
+  expected: > 0
+FAIL - newRequestId fallback 不可使用 Math.random
+  actual:   1
+  expected: 0
+7 failed
+```
+
+## 判定
+
+現有錯版不合格。
+
+- `clampDecimal("1.", 10)` 目前變 `"1"`；正確期待是保留 `"1."`。
+- `clampDecimal("1e3", 10000)` 目前變 `"1"`；正確期待是保留 `"1e3"`，由送出驗證明確擋非法格式。
+- `clampDecimal("1", 0.75)` 目前變 `"0"`；正確期待是保留 `"1"`，不可把超上限輸入靜默改成另一個數。
+- `clampDecimal("0.0009", 10)` 目前變 `"0.000"`；正確期待是保留 `"0.0009"`，不可靜默截斷。
+- `newRequestId()` fallback 目前產出 `r_...`，不是 UUID；也未使用 `crypto.getRandomValues`，且用了 `Math.random`。
+
+## 未涵蓋
+
+這支是離線單函式執行期測試，只證明輸入轉換與 request id fallback。它不能證明 UI 在「送出已到後端但前端沒收到回應」時有鎖住原 payload，也不能證明畫面重送安全；該項仍需用元件層或流程層測試另外補。

--- a/docs/return-disposition-ui-runtime-test-report.md
+++ b/docs/return-disposition-ui-runtime-test-report.md
@@ -143,3 +143,56 @@ P2：無新增。這次問題是會造成重複處理的流程風險，不是單
 - 此測試沒有啟動 Next 整站，沒有打真 Supabase；所有網路/DB 都是 stub。
 - 此測試證明的是目前頁面狀態流和送出 payload，可作為 Claude 修版回歸保護；它不驗後端 `rpc_dispose_hq_return` 本身的冪等與扣帳 SQL。
 - 為避免綁死實作，測試接受「未知後沒有第二次 RPC」或「第二次 RPC 使用原 request id + 原完整 payload」。原碼 regex 只列 `OBSERVE`，不計入 PASS/FAIL。
+
+---
+
+## E 修版複跑（2026-09-07，Codex GPT-5.5 阿審）
+
+本輪只修測試接點，不改功能頁。原因是 E 修版已把數量欄從 `type="number"` 改成 `type="text" inputMode="decimal"`，並新增 `useAuth()`；舊測試仍找 `input[type="number"]` 且沒 stub AuthProvider，會誤報。
+
+### 實跑命令
+
+```powershell
+node --check tests\return-disposition-review\ui-input-runtime.cjs
+node --check tests\return-disposition-review\ui-submit-runtime.cjs
+node tests\return-disposition-review\ui-input-runtime.cjs
+node tests\return-disposition-review\ui-submit-runtime.cjs
+```
+
+結果：
+
+- `ui-input-runtime.cjs`：exit 0。
+- `ui-submit-runtime.cjs`：exit 0。
+
+### 本輪新增/保留的真元件斷言
+
+- 小數輸入編輯中保留原字串，不靜默吃前綴、不截斷、不因超上限改成別的值。
+- UUID fallback 產生 PostgreSQL 可收的 RFC4122 v4，且使用 `crypto.getRandomValues`，不使用 `Math.random`。
+- 未知送達後，數量欄鎖住；沒有可按的「重新產生 Request ID」。
+- 未知送達後若按「重新傳送原資料」，必須用原 request id + 原完整 payload。
+- 未知送達時不能切到另一批。
+- 關頁重開後會恢復同一筆待確認包；若重送，仍用原 request id + 原完整 payload。
+- 本機儲存失敗時不打 `rpc_dispose_hq_return`。
+- 不同租戶/使用者不會恢復別人的待確認包；若畫面資料 tenant 與目前登入 tenant 不符，前端會在送 RPC 前擋下。
+- 合法三位小數 `0.125` 可送；非法格式、負數、四位小數、超過尚待量不送 RPC。
+
+### 修版觀察
+
+```text
+extracted newRequestId:L153, clampDecimal:L168 from apps/admin/src/app/(protected)/wms/return-disposition/page.tsx
+ok - return-disposition UI input runtime checks
+
+rendered apps/admin/src/app/(protected)/wms/return-disposition/page.tsx
+OBSERVE - 未知錯誤後數量欄位啟用數
+  actual:   0 enabled decimal input(s)
+OBSERVE - 原碼觀察：待確認包恢復機制
+  actual:   durableStorage=true; eventLookupByRequestId=true; memoryRequestRef=false (request ref L?)
+OBSERVE - 原碼觀察：切批是否會重設 request
+  actual:   handleSelectCallsReset=false (L558); resetRegeneratesRequest=false (L545)
+ok - return-disposition submit retry runtime checks
+```
+
+### 限制
+
+- 這仍是 jsdom + stub 的元件層離線測試，不是瀏覽器人工操作，也不是正式 Supabase 實測。
+- 測試驗的是 E 頁對未知送達與輸入的保護；後端真正冪等、扣帳與 RLS 已由核心 SQL 測試另驗。

--- a/docs/return-disposition-ui-runtime-test-report.md
+++ b/docs/return-disposition-ui-runtime-test-report.md
@@ -1,7 +1,8 @@
 # 總倉退回貨處理 — UI 輸入執行期回歸測試報告
 
-日期：2026-09-07  
-角色：阿審（獨立測試）  
+日期：2026-09-07
+
+角色：阿審（獨立測試）
 範圍：只新增離線測試 `tests/return-disposition-review/ui-input-runtime.cjs`；未修改功能頁、SQL、既有 core 測試或 UI 審查報告；未連 GitHub / Supabase；未讀 env / 密鑰；未啟動真 app。
 
 ## 測試方式
@@ -21,6 +22,8 @@ node tests/return-disposition-review/ui-input-runtime.cjs
 ```
 
 結果：exit 1，7 個 FAIL。這是目前 E 初版的預期結果，代表測試已抓到既有缺陷；不是修版已完成。
+
+CEO 已複跑同一命令，得到相同 7 項失敗；`node --check` exit 0。本輪沒有修改功能碼，僅把已發現的錯誤變成可重跑的檢查。
 
 ```text
 extracted newRequestId:L118, clampDecimal:L125 from apps/admin/src/app/(protected)/wms/return-disposition/page.tsx

--- a/supabase/migrations/20260907010000_hq_return_disposition_core.sql
+++ b/supabase/migrations/20260907010000_hq_return_disposition_core.sql
@@ -3,39 +3,10 @@
 -- 20260907010000_hq_return_disposition_core.sql
 --
 -- 依賴：20260422120003（stock_movements / stock_balances / locations / transfers / transfer_items）
---       20260713000000（movement_type CHECK 最新清單）
 --       20260424120000（_current_tenant_id helper）
 --
--- 本檔 append-only，不改任何既有表結構（movement_type CHECK 除外：新增兩值）。
+-- 本檔 append-only，不改任何既有表結構。
 -- ============================================================
-
--- ============================================================
--- 0. movement_type 擴充：hq_return_damage / hq_return_loss
---    基底＝20260713000000 的清單，僅新增，其餘原封不動。
--- ============================================================
-ALTER TABLE public.stock_movements
-  DROP CONSTRAINT IF EXISTS stock_movements_movement_type_check;
-
-ALTER TABLE public.stock_movements
-  ADD CONSTRAINT stock_movements_movement_type_check CHECK (
-    movement_type = ANY (ARRAY[
-      'purchase_receipt',
-      'return_to_supplier',
-      'sale',
-      'customer_return',
-      'transfer_out',
-      'transfer_in',
-      'transfer_reject',
-      'transfer_cancel',
-      'stocktake_gain',
-      'stocktake_loss',
-      'damage',
-      'manual_adjust',
-      'reversal',
-      'hq_return_damage',
-      'hq_return_loss'
-    ])
-  );
 
 -- ============================================================
 -- 1. hq_return_batches — 總倉退回貨批次
@@ -53,11 +24,12 @@ CREATE TABLE public.hq_return_batches (
   source_kind          TEXT        NOT NULL CHECK (source_kind IN ('store_return','shortage')),
   source_reason        TEXT,
   total_qty            NUMERIC(18,3) NOT NULL CHECK (total_qty > 0),
-  unit_cost            NUMERIC(18,4) NOT NULL DEFAULT 0
-                       CHECK (unit_cost >= 0
+  unit_cost            NUMERIC(18,4)
+                       CHECK (unit_cost IS NULL OR (
+                              unit_cost >= 0
                               AND unit_cost != 'NaN'::NUMERIC
                               AND unit_cost != 'Infinity'::NUMERIC
-                              AND unit_cost != '-Infinity'::NUMERIC),
+                              AND unit_cost != '-Infinity'::NUMERIC)),
   qty_good             NUMERIC(18,3) NOT NULL DEFAULT 0 CHECK (qty_good >= 0),
   qty_damaged          NUMERIC(18,3) NOT NULL DEFAULT 0 CHECK (qty_damaged >= 0),
   qty_lost             NUMERIC(18,3) NOT NULL DEFAULT 0 CHECK (qty_lost >= 0),
@@ -98,7 +70,7 @@ CREATE TABLE public.hq_return_batches (
 );
 
 COMMENT ON TABLE public.hq_return_batches IS '總倉退回貨批次：每筆來源 movement 唯一，追蹤好/破/失/撤/pending';
-COMMENT ON COLUMN public.hq_return_batches.unit_cost IS '來源成本依據（來自 movement.unit_cost 或 0 表示未知），不從售價猜';
+COMMENT ON COLUMN public.hq_return_batches.unit_cost IS '逐字保存來源 movement.unit_cost；NULL 代表來源未記成本，不猜值';
 COMMENT ON COLUMN public.hq_return_batches.source_kind IS 'store_return＝門市退貨, shortage＝短少';
 
 CREATE INDEX idx_hq_return_batches_tenant_status
@@ -129,10 +101,11 @@ CREATE TABLE public.hq_return_events (
   loss_movement_id     BIGINT      REFERENCES public.stock_movements(id),
   notes                TEXT,
   operator_id          UUID        NOT NULL,
+  new_status           TEXT        NOT NULL CHECK (new_status IN ('partial','completed')),
   created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
-  -- 同 request_id 不可二建
-  CONSTRAINT uq_hq_return_event_request UNIQUE (request_id),
+  -- 每個 tenant 內同 request_id 不可二建
+  CONSTRAINT uq_hq_return_event_request UNIQUE (tenant_id, request_id),
 
   -- 不能全 0
   CONSTRAINT chk_hq_return_event_nonzero CHECK (qty_good + qty_damaged + qty_lost > 0),
@@ -153,12 +126,10 @@ CREATE TABLE public.hq_return_events (
 COMMENT ON TABLE public.hq_return_events IS '總倉退回貨處理事件：append-only，每次處理一筆';
 COMMENT ON COLUMN public.hq_return_events.request_id IS '前端冪等 UUID：重試回原結果，payload 不同拒絕';
 COMMENT ON COLUMN public.hq_return_events.goods_confirmed IS '好貨實物已到確認（前端必傳 true 才計入 qty_good）';
+COMMENT ON COLUMN public.hq_return_events.new_status IS '本次事件完成當下的批次狀態；冪等重播不得用後來狀態重算';
 
 CREATE INDEX idx_hq_return_events_batch
   ON public.hq_return_events (batch_id, created_at);
-
-CREATE INDEX idx_hq_return_events_request
-  ON public.hq_return_events (request_id);
 
 -- 禁止 UPDATE / DELETE（append-only）
 CREATE OR REPLACE FUNCTION public._forbid_hq_return_event_mutation()
@@ -176,24 +147,39 @@ CREATE TRIGGER trg_no_delete_hq_return_events
   BEFORE DELETE ON public.hq_return_events
   FOR EACH ROW EXECUTE FUNCTION public._forbid_hq_return_event_mutation();
 
+REVOKE ALL ON FUNCTION public._forbid_hq_return_event_mutation() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._forbid_hq_return_event_mutation() FROM anon;
+REVOKE ALL ON FUNCTION public._forbid_hq_return_event_mutation() FROM authenticated;
+
 -- ============================================================
 -- 3. RLS
 --
--- 兩表都開 RLS。authenticated 只讀同 tenant，INSERT/UPDATE/DELETE 全封。
+-- 兩表都開 RLS。authenticated 中只有同 tenant 的 owner/admin/hq_manager 可讀，
+-- INSERT/UPDATE/DELETE 全封。
 -- 資料寫入只透過 SECURITY DEFINER 函式。
 -- ============================================================
 ALTER TABLE public.hq_return_batches ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.hq_return_events  ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY hq_return_batches_tenant_read ON public.hq_return_batches
+CREATE POLICY hq_return_batches_hq_read ON public.hq_return_batches
   FOR SELECT TO authenticated
-  USING (tenant_id = public._current_tenant_id());
+  USING (
+    tenant_id = public._current_tenant_id()
+    AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+        IN ('owner','admin','hq_manager')
+  );
 
-CREATE POLICY hq_return_events_tenant_read ON public.hq_return_events
+CREATE POLICY hq_return_events_hq_read ON public.hq_return_events
   FOR SELECT TO authenticated
-  USING (tenant_id = public._current_tenant_id());
+  USING (
+    tenant_id = public._current_tenant_id()
+    AND COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+        IN ('owner','admin','hq_manager')
+  );
 
 -- 明確不給 INSERT/UPDATE/DELETE policy → authenticated 直接寫會被 RLS 擋
+REVOKE ALL ON TABLE public.hq_return_batches, public.hq_return_events FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.hq_return_batches, public.hq_return_events TO authenticated;
 
 -- ============================================================
 -- 4. _hq_hold_return — 內部 helper：建批次＋同步 reserved
@@ -203,18 +189,18 @@ CREATE POLICY hq_return_events_tenant_read ON public.hq_return_events
 --   p_location_id         BIGINT   — 總倉 location（必須 type='central_warehouse'）
 --   p_sku_id              BIGINT   — SKU
 --   p_source_movement_id  BIGINT   — 正向入庫 movement（quantity > 0，同 tenant）
---   p_source_transfer_item_id BIGINT — 可選，對應 transfer_item
+--   p_source_transfer_item_id BIGINT — 簽名保留預設，但實際必填且須反向指回 movement
 --   p_source_kind         TEXT     — 'store_return' 或 'shortage'
 --   p_source_reason       TEXT     — 原因文字
---   p_qty                 NUMERIC  — 回帳量（正數）
+--   p_qty                 NUMERIC  — 回帳量（必填，正數，須等於 movement 與 item 來源量）
 --   p_operator_id         UUID     — 操作者
 --   p_auto_flag           TEXT     — 'system' 或 'manual'
 --
 -- 行為：
---   1. 驗證 movement 存在、quantity > 0、同 tenant、SKU 匹配
---   2. 驗證 location type = central_warehouse
---   3. 若同 source_movement_id 已有批次 → 回傳既有 batch_id（冪等，不二建）
---   4. 建批次，同步 stock_balances.reserved += p_qty
+--   1. 驗證 movement、item、父 transfer 的 tenant/location/SKU/種類/數量/單據鏈
+--   2. movement.source_doc_line_id 可 NULL；有值時須等於 item id
+--   3. 先鎖 balance；若同 source_movement_id 已有批次，完整 payload 一致才回既有 id
+--   4. 建批次，來源成本原值保存，同步 stock_balances.reserved += p_qty
 --   5. 回傳 batch_id
 --
 -- ⛔ REVOKE PUBLIC / anon / authenticated — 不作前端 RPC，僅供後端安全呼叫。
@@ -235,15 +221,48 @@ LANGUAGE plpgsql SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
-  v_mov         RECORD;
-  v_loc_type    TEXT;
-  v_existing_id BIGINT;
-  v_batch_id    BIGINT;
-  v_hold_qty    NUMERIC(18,3);
-  v_unit_cost   NUMERIC(18,4);
+  v_mov            RECORD;
+  v_source         RECORD;
+  v_loc_type       TEXT;
+  v_existing       RECORD;
+  v_batch_id       BIGINT;
+  v_hold_qty       NUMERIC;
+  v_operator_id    UUID;
+  v_source_reason  TEXT;
 BEGIN
+  IF p_tenant_id IS NULL OR p_location_id IS NULL OR p_sku_id IS NULL
+  OR p_source_movement_id IS NULL OR p_source_transfer_item_id IS NULL THEN
+    RAISE EXCEPTION '_hq_hold_return: tenant, location, sku, source movement and source transfer item are required';
+  END IF;
+
+  IF p_source_kind IS NULL OR p_source_kind NOT IN ('store_return','shortage') THEN
+    RAISE EXCEPTION '_hq_hold_return: invalid source_kind %', p_source_kind;
+  END IF;
+
+  IF p_auto_flag IS NULL OR p_auto_flag NOT IN ('system','manual') THEN
+    RAISE EXCEPTION '_hq_hold_return: invalid auto_flag %', p_auto_flag;
+  END IF;
+
+  IF p_qty IS NULL THEN
+    RAISE EXCEPTION '_hq_hold_return: hold quantity is required';
+  END IF;
+  IF p_qty = 'NaN'::NUMERIC OR p_qty = 'Infinity'::NUMERIC OR p_qty = '-Infinity'::NUMERIC THEN
+    RAISE EXCEPTION '_hq_hold_return: hold quantity must be finite';
+  END IF;
+  IF p_qty <= 0 OR p_qty > 999999999999999.999::NUMERIC THEN
+    RAISE EXCEPTION '_hq_hold_return: hold quantity out of range: %', p_qty;
+  END IF;
+  IF p_qty != ROUND(p_qty, 3) THEN
+    RAISE EXCEPTION '_hq_hold_return: hold quantity must have at most 3 decimal places';
+  END IF;
+
+  v_hold_qty := p_qty;
+  v_operator_id := COALESCE(p_operator_id, '00000000-0000-0000-0000-000000000000'::UUID);
+  v_source_reason := NULLIF(BTRIM(p_source_reason), '');
+
   -- 1. 驗證來源 movement
-  SELECT id, tenant_id, location_id, sku_id, quantity, unit_cost
+  SELECT id, tenant_id, location_id, sku_id, quantity, unit_cost,
+         movement_type, source_doc_type, source_doc_id, source_doc_line_id
     INTO v_mov
     FROM stock_movements
    WHERE id = p_source_movement_id;
@@ -252,19 +271,40 @@ BEGIN
     RAISE EXCEPTION '_hq_hold_return: source movement % not found', p_source_movement_id;
   END IF;
 
-  IF v_mov.tenant_id != p_tenant_id THEN
+  IF v_mov.tenant_id IS DISTINCT FROM p_tenant_id THEN
     RAISE EXCEPTION '_hq_hold_return: movement % belongs to different tenant', p_source_movement_id;
   END IF;
 
-  IF v_mov.quantity <= 0 THEN
+  IF v_mov.quantity <= 0
+  OR v_mov.quantity = 'NaN'::NUMERIC
+  OR v_mov.quantity = 'Infinity'::NUMERIC
+  OR v_mov.quantity = '-Infinity'::NUMERIC THEN
     RAISE EXCEPTION '_hq_hold_return: movement % quantity must be positive (got %)', p_source_movement_id, v_mov.quantity;
   END IF;
 
-  IF v_mov.sku_id != p_sku_id THEN
+  IF v_mov.sku_id IS DISTINCT FROM p_sku_id THEN
     RAISE EXCEPTION '_hq_hold_return: movement % sku_id=% does not match p_sku_id=%', p_source_movement_id, v_mov.sku_id, p_sku_id;
   END IF;
 
-  -- 2. 驗證 location type
+  IF v_mov.location_id IS DISTINCT FROM p_location_id THEN
+    RAISE EXCEPTION '_hq_hold_return: movement % location=% does not match p_location_id=%',
+      p_source_movement_id, v_mov.location_id, p_location_id;
+  END IF;
+
+  IF v_mov.quantity IS DISTINCT FROM v_hold_qty THEN
+    RAISE EXCEPTION '_hq_hold_return: hold qty % does not match source movement quantity %',
+      v_hold_qty, v_mov.quantity;
+  END IF;
+
+  IF v_mov.unit_cost IS NOT NULL AND (
+       v_mov.unit_cost = 'NaN'::NUMERIC
+    OR v_mov.unit_cost = 'Infinity'::NUMERIC
+    OR v_mov.unit_cost = '-Infinity'::NUMERIC
+  ) THEN
+    RAISE EXCEPTION '_hq_hold_return: source movement % unit_cost must be finite', p_source_movement_id;
+  END IF;
+
+  -- 2. 驗證 location 與 transfer item / 父單 / movement 單據鏈
   SELECT type INTO v_loc_type
     FROM locations
    WHERE id = p_location_id AND tenant_id = p_tenant_id;
@@ -277,21 +317,102 @@ BEGIN
     RAISE EXCEPTION '_hq_hold_return: location % type=% is not central_warehouse', p_location_id, v_loc_type;
   END IF;
 
-  -- 3. 冪等：同 source_movement_id 已有批次 → 回傳既有 id
-  SELECT id INTO v_existing_id
-    FROM hq_return_batches
-   WHERE source_movement_id = p_source_movement_id;
-
-  IF FOUND THEN
-    RETURN v_existing_id;
+  IF NOT EXISTS (
+    SELECT 1 FROM skus WHERE id = p_sku_id AND tenant_id = p_tenant_id
+  ) THEN
+    RAISE EXCEPTION '_hq_hold_return: sku % not found for tenant', p_sku_id;
   END IF;
 
-  -- 4. 決定凍結量與成本
-  v_hold_qty  := COALESCE(p_qty, v_mov.quantity);
-  v_unit_cost := COALESCE(v_mov.unit_cost, 0);
+  SELECT ti.id AS item_id, ti.transfer_id, ti.sku_id AS item_sku_id,
+         ti.qty_received, ti.qty_shipped,
+         ti.in_movement_id, ti.shortage_restock_movement_id,
+         t.tenant_id AS transfer_tenant_id, t.transfer_type,
+         t.source_location, t.dest_location,
+         src.tenant_id AS source_location_tenant, src.type AS source_location_type,
+         dst.tenant_id AS dest_location_tenant, dst.type AS dest_location_type
+    INTO v_source
+    FROM transfer_items ti
+    JOIN transfers t ON t.id = ti.transfer_id
+    JOIN locations src ON src.id = t.source_location
+    JOIN locations dst ON dst.id = t.dest_location
+   WHERE ti.id = p_source_transfer_item_id;
 
-  IF v_hold_qty <= 0 THEN
-    RAISE EXCEPTION '_hq_hold_return: hold qty must be positive, got %', v_hold_qty;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '_hq_hold_return: source transfer item % not found', p_source_transfer_item_id;
+  END IF;
+
+  IF v_source.transfer_tenant_id IS DISTINCT FROM p_tenant_id THEN
+    RAISE EXCEPTION '_hq_hold_return: source transfer item % belongs to different tenant', p_source_transfer_item_id;
+  END IF;
+  IF v_source.source_location_tenant IS DISTINCT FROM p_tenant_id
+  OR v_source.dest_location_tenant IS DISTINCT FROM p_tenant_id THEN
+    RAISE EXCEPTION '_hq_hold_return: source transfer item % parent locations belong to different tenant', p_source_transfer_item_id;
+  END IF;
+  IF v_source.item_sku_id IS DISTINCT FROM p_sku_id THEN
+    RAISE EXCEPTION '_hq_hold_return: source transfer item % sku does not match source movement', p_source_transfer_item_id;
+  END IF;
+  IF v_mov.source_doc_type IS DISTINCT FROM 'transfer'
+  OR v_mov.source_doc_id IS DISTINCT FROM v_source.transfer_id
+  OR (v_mov.source_doc_line_id IS NOT NULL
+      AND v_mov.source_doc_line_id IS DISTINCT FROM p_source_transfer_item_id) THEN
+    RAISE EXCEPTION '_hq_hold_return: source movement % does not match transfer item % document chain',
+      p_source_movement_id, p_source_transfer_item_id;
+  END IF;
+
+  IF p_source_kind = 'store_return' THEN
+    IF v_source.transfer_type IS DISTINCT FROM 'return_to_hq'
+    OR v_source.dest_location IS DISTINCT FROM p_location_id
+    OR v_source.source_location_type IS DISTINCT FROM 'store'
+    OR v_source.dest_location_type IS DISTINCT FROM 'central_warehouse'
+    OR v_source.in_movement_id IS DISTINCT FROM p_source_movement_id
+    OR v_source.qty_received IS DISTINCT FROM v_hold_qty
+    OR v_mov.movement_type IS DISTINCT FROM 'transfer_in' THEN
+      RAISE EXCEPTION '_hq_hold_return: source movement % is not the matching store-return receipt for item %',
+        p_source_movement_id, p_source_transfer_item_id;
+    END IF;
+  ELSE
+    IF v_source.transfer_type IS DISTINCT FROM 'hq_to_store'
+    OR v_source.source_location IS DISTINCT FROM p_location_id
+    OR v_source.source_location_type IS DISTINCT FROM 'central_warehouse'
+    OR v_source.dest_location_type IS DISTINCT FROM 'store'
+    OR v_source.shortage_restock_movement_id IS DISTINCT FROM p_source_movement_id
+    OR (v_source.qty_shipped - v_source.qty_received) IS DISTINCT FROM v_hold_qty
+    OR v_mov.movement_type IS DISTINCT FROM 'transfer_cancel' THEN
+      RAISE EXCEPTION '_hq_hold_return: source movement % is not the matching shortage return for item %',
+        p_source_movement_id, p_source_transfer_item_id;
+    END IF;
+  END IF;
+
+  -- 3. 所有同 (tenant, location, sku) 寫入一律先鎖 balance。
+  --    guard、hold、dispose 共用 balance → batch 鎖序，避免競態與死鎖。
+  INSERT INTO stock_balances (tenant_id, location_id, sku_id)
+  VALUES (p_tenant_id, p_location_id, p_sku_id)
+  ON CONFLICT (tenant_id, location_id, sku_id) DO NOTHING;
+
+  PERFORM 1 FROM stock_balances
+   WHERE tenant_id = p_tenant_id AND location_id = p_location_id AND sku_id = p_sku_id
+   FOR UPDATE;
+
+  -- 4. 冪等：鎖後核對完整 payload，不能把錯誤來源靜默當重試。
+  SELECT * INTO v_existing
+    FROM hq_return_batches
+   WHERE source_movement_id = p_source_movement_id
+   FOR UPDATE;
+
+  IF FOUND THEN
+    IF v_existing.tenant_id IS DISTINCT FROM p_tenant_id
+    OR v_existing.location_id IS DISTINCT FROM p_location_id
+    OR v_existing.sku_id IS DISTINCT FROM p_sku_id
+    OR v_existing.source_transfer_item_id IS DISTINCT FROM p_source_transfer_item_id
+    OR v_existing.source_kind IS DISTINCT FROM p_source_kind
+    OR v_existing.source_reason IS DISTINCT FROM v_source_reason
+    OR v_existing.total_qty IS DISTINCT FROM v_hold_qty
+    OR v_existing.unit_cost IS DISTINCT FROM v_mov.unit_cost
+    OR v_existing.auto_flag IS DISTINCT FROM p_auto_flag
+    OR v_existing.created_by IS DISTINCT FROM v_operator_id THEN
+      RAISE EXCEPTION '_hq_hold_return: source movement % already held with different payload', p_source_movement_id;
+    END IF;
+    RETURN v_existing.id;
   END IF;
 
   -- 5. 建批次
@@ -304,17 +425,15 @@ BEGIN
   ) VALUES (
     p_tenant_id, p_location_id, p_sku_id,
     p_source_movement_id, p_source_transfer_item_id,
-    p_source_kind, p_source_reason,
-    v_hold_qty, v_unit_cost,
-    p_auto_flag, COALESCE(p_operator_id, '00000000-0000-0000-0000-000000000000'::UUID)
+    p_source_kind, v_source_reason,
+    v_hold_qty, v_mov.unit_cost,
+    p_auto_flag, v_operator_id
   ) RETURNING id INTO v_batch_id;
 
-  -- 6. 同步 reserved（鎖 balance 列）
-  INSERT INTO stock_balances (tenant_id, location_id, sku_id, reserved)
-  VALUES (p_tenant_id, p_location_id, p_sku_id, v_hold_qty)
-  ON CONFLICT (tenant_id, location_id, sku_id) DO UPDATE
-    SET reserved   = stock_balances.reserved + v_hold_qty,
-        updated_at = NOW();
+  -- 6. 同步 reserved（balance 已鎖）
+  UPDATE stock_balances
+     SET reserved = reserved + v_hold_qty, updated_at = NOW()
+   WHERE tenant_id = p_tenant_id AND location_id = p_location_id AND sku_id = p_sku_id;
 
   RETURN v_batch_id;
 END;
@@ -343,7 +462,7 @@ COMMENT ON FUNCTION public._hq_hold_return IS
 --   p_goods_confirmed BOOLEAN — 好貨實物已到確認（好貨 > 0 時必須 true）
 --   p_notes          TEXT     — 備註
 --
--- 鎖順序：hq_return_batches(id) FOR UPDATE → stock_balances(tenant, location, sku) FOR UPDATE
+-- 鎖順序：未鎖讀 batch 定位鍵 → stock_balances FOR UPDATE → hq_return_batches FOR UPDATE
 -- ============================================================
 CREATE OR REPLACE FUNCTION public.rpc_dispose_hq_return(
   p_batch_id        BIGINT,
@@ -360,17 +479,23 @@ LANGUAGE plpgsql SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
-  v_user          UUID := auth.uid();
-  v_tenant        UUID := public._current_tenant_id();
-  v_role          TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
-  v_batch         RECORD;
-  v_pending       NUMERIC(18,3);
-  v_this_total    NUMERIC(18,3);
-  v_existing      RECORD;
-  v_damage_mov_id BIGINT;
-  v_loss_mov_id   BIGINT;
-  v_event_id      BIGINT;
-  v_new_status    TEXT;
+  v_user           UUID := auth.uid();
+  v_tenant         UUID := public._current_tenant_id();
+  v_role           TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_batch_key      RECORD;
+  v_batch          RECORD;
+  v_balance        RECORD;
+  v_pending        NUMERIC;
+  v_total_pending  NUMERIC;
+  v_this_total     NUMERIC;
+  v_existing       RECORD;
+  v_damage_reason  TEXT := NULLIF(BTRIM(p_damage_reason), '');
+  v_loss_reason    TEXT := NULLIF(BTRIM(p_loss_reason), '');
+  v_notes          TEXT := NULLIF(BTRIM(p_notes), '');
+  v_damage_mov_id  BIGINT;
+  v_loss_mov_id    BIGINT;
+  v_event_id       BIGINT;
+  v_new_status     TEXT;
 BEGIN
   -- 0. auth 必須有值
   IF v_user IS NULL THEN
@@ -382,11 +507,41 @@ BEGIN
     RAISE EXCEPTION 'rpc_dispose_hq_return: permission denied for role %', v_role;
   END IF;
 
-  -- 2. 數量基本檢查
-  IF p_qty_good    IS NULL OR p_qty_good    < 0
-  OR p_qty_damaged IS NULL OR p_qty_damaged < 0
-  OR p_qty_lost    IS NULL OR p_qty_lost    < 0 THEN
+  IF p_request_id IS NULL THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: request_id is required';
+  END IF;
+  IF p_batch_id IS NULL THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: batch_id is required';
+  END IF;
+
+  -- 2. 數量逐欄驗證；不可先塞入 NUMERIC(18,3) 讓資料庫四捨五入。
+  IF p_qty_good IS NULL OR p_qty_damaged IS NULL OR p_qty_lost IS NULL THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: quantity values cannot be NULL';
+  END IF;
+  IF p_goods_confirmed IS NULL THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: goods_confirmed cannot be NULL';
+  END IF;
+
+  IF p_qty_good IN ('NaN'::NUMERIC, 'Infinity'::NUMERIC, '-Infinity'::NUMERIC)
+  OR p_qty_damaged IN ('NaN'::NUMERIC, 'Infinity'::NUMERIC, '-Infinity'::NUMERIC)
+  OR p_qty_lost IN ('NaN'::NUMERIC, 'Infinity'::NUMERIC, '-Infinity'::NUMERIC) THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: quantity values must be finite numeric values';
+  END IF;
+
+  IF p_qty_good < 0 OR p_qty_damaged < 0 OR p_qty_lost < 0 THEN
     RAISE EXCEPTION 'rpc_dispose_hq_return: quantities must be non-negative';
+  END IF;
+
+  IF p_qty_good > 999999999999999.999::NUMERIC
+  OR p_qty_damaged > 999999999999999.999::NUMERIC
+  OR p_qty_lost > 999999999999999.999::NUMERIC THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: quantity value exceeds NUMERIC(18,3) range';
+  END IF;
+
+  IF p_qty_good != ROUND(p_qty_good, 3)
+  OR p_qty_damaged != ROUND(p_qty_damaged, 3)
+  OR p_qty_lost != ROUND(p_qty_lost, 3) THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: quantities must have at most 3 decimal places';
   END IF;
 
   v_this_total := p_qty_good + p_qty_damaged + p_qty_lost;
@@ -395,18 +550,17 @@ BEGIN
     RAISE EXCEPTION 'rpc_dispose_hq_return: total disposition quantity must be > 0';
   END IF;
 
-  -- NaN / Infinity 防護
-  IF v_this_total = 'NaN'::NUMERIC OR v_this_total = 'Infinity'::NUMERIC OR v_this_total = '-Infinity'::NUMERIC THEN
-    RAISE EXCEPTION 'rpc_dispose_hq_return: invalid numeric value in quantities';
+  IF v_this_total > 999999999999999.999::NUMERIC THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: total quantity exceeds NUMERIC(18,3) range';
   END IF;
 
   -- 破損需原因
-  IF p_qty_damaged > 0 AND (p_damage_reason IS NULL OR TRIM(p_damage_reason) = '') THEN
+  IF p_qty_damaged > 0 AND v_damage_reason IS NULL THEN
     RAISE EXCEPTION 'rpc_dispose_hq_return: damage_reason required when qty_damaged > 0';
   END IF;
 
   -- 遺失需原因
-  IF p_qty_lost > 0 AND (p_loss_reason IS NULL OR TRIM(p_loss_reason) = '') THEN
+  IF p_qty_lost > 0 AND v_loss_reason IS NULL THEN
     RAISE EXCEPTION 'rpc_dispose_hq_return: loss_reason required when qty_lost > 0';
   END IF;
 
@@ -415,46 +569,81 @@ BEGIN
     RAISE EXCEPTION 'rpc_dispose_hq_return: goods_confirmed must be true when qty_good > 0';
   END IF;
 
-  -- 3. 冪等：同 request_id 已存在 → 驗 payload 一致後回傳原結果
+  -- 3. 同 tenant + request_id 序列化。第二個請求等第一個完成後重讀事件。
+  PERFORM pg_advisory_xact_lock(hashtext(v_tenant::TEXT), hashtext(p_request_id::TEXT));
+
+  -- 冪等：核對完整標準化 payload，並回傳第一次的完整原結果。
   SELECT * INTO v_existing
     FROM hq_return_events
-   WHERE request_id = p_request_id;
+   WHERE tenant_id = v_tenant
+     AND request_id = p_request_id;
 
   IF FOUND THEN
-    -- payload 驗證：batch_id + 三個數量必須一致
-    IF v_existing.batch_id    != p_batch_id
-    OR v_existing.qty_good    != p_qty_good
-    OR v_existing.qty_damaged != p_qty_damaged
-    OR v_existing.qty_lost    != p_qty_lost THEN
+    IF v_existing.batch_id IS DISTINCT FROM p_batch_id
+    OR v_existing.qty_good IS DISTINCT FROM p_qty_good
+    OR v_existing.qty_damaged IS DISTINCT FROM p_qty_damaged
+    OR v_existing.qty_lost IS DISTINCT FROM p_qty_lost
+    OR v_existing.damage_reason IS DISTINCT FROM v_damage_reason
+    OR v_existing.loss_reason IS DISTINCT FROM v_loss_reason
+    OR v_existing.goods_confirmed IS DISTINCT FROM p_goods_confirmed
+    OR v_existing.notes IS DISTINCT FROM v_notes THEN
       RAISE EXCEPTION 'rpc_dispose_hq_return: request_id % already used with different payload', p_request_id;
     END IF;
 
     RETURN jsonb_build_object(
-      'event_id',    v_existing.id,
-      'batch_id',    v_existing.batch_id,
-      'idempotent',  TRUE
+      'event_id',           v_existing.id,
+      'batch_id',           v_existing.batch_id,
+      'idempotent',         TRUE,
+      'qty_good',           v_existing.qty_good,
+      'qty_damaged',        v_existing.qty_damaged,
+      'qty_lost',           v_existing.qty_lost,
+      'damage_movement_id', v_existing.damage_movement_id,
+      'loss_movement_id',   v_existing.loss_movement_id,
+      'new_status',         v_existing.new_status
     );
   END IF;
 
-  -- 4. 鎖批次（鎖順序第一：batch）
-  SELECT * INTO v_batch
+  -- 4. 未鎖查定位鍵，接著一律 balance → batch；鎖後重新讀完整批次。
+  SELECT tenant_id, location_id, sku_id INTO v_batch_key
     FROM hq_return_batches
-   WHERE id = p_batch_id
-   FOR UPDATE;
+   WHERE id = p_batch_id;
 
   IF NOT FOUND THEN
     RAISE EXCEPTION 'rpc_dispose_hq_return: batch % not found', p_batch_id;
   END IF;
 
-  IF v_batch.tenant_id != v_tenant THEN
+  IF v_batch_key.tenant_id IS DISTINCT FROM v_tenant THEN
     RAISE EXCEPTION 'rpc_dispose_hq_return: batch % belongs to different tenant', p_batch_id;
+  END IF;
+
+  INSERT INTO stock_balances (tenant_id, location_id, sku_id)
+  VALUES (v_tenant, v_batch_key.location_id, v_batch_key.sku_id)
+  ON CONFLICT (tenant_id, location_id, sku_id) DO NOTHING;
+
+  SELECT * INTO v_balance
+    FROM stock_balances
+   WHERE tenant_id = v_tenant
+     AND location_id = v_batch_key.location_id
+     AND sku_id = v_batch_key.sku_id
+   FOR UPDATE;
+
+  SELECT * INTO v_batch
+    FROM hq_return_batches
+   WHERE id = p_batch_id
+     AND tenant_id = v_tenant
+   FOR UPDATE;
+
+  IF NOT FOUND
+  OR v_batch.location_id IS DISTINCT FROM v_batch_key.location_id
+  OR v_batch.sku_id IS DISTINCT FROM v_batch_key.sku_id THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: batch % changed while locking', p_batch_id;
   END IF;
 
   IF v_batch.status IN ('completed','revoked') THEN
     RAISE EXCEPTION 'rpc_dispose_hq_return: batch % already %', p_batch_id, v_batch.status;
   END IF;
 
-  -- 5. pending 剩餘量檢查
+  -- 5. 鎖後檢查本批 pending、同 SKU 全部 pending、reserved 與實際庫存。
   v_pending := v_batch.total_qty - v_batch.qty_good - v_batch.qty_damaged - v_batch.qty_lost - v_batch.qty_revoked;
 
   IF v_this_total > v_pending THEN
@@ -462,15 +651,25 @@ BEGIN
       v_this_total, v_pending, p_batch_id;
   END IF;
 
-  -- 6. 鎖 balance（鎖順序第二：balance）
-  PERFORM 1
-    FROM stock_balances
-   WHERE tenant_id   = v_batch.tenant_id
+  SELECT COALESCE(SUM(total_qty - qty_good - qty_damaged - qty_lost - qty_revoked), 0)
+    INTO v_total_pending
+    FROM hq_return_batches
+   WHERE tenant_id = v_batch.tenant_id
      AND location_id = v_batch.location_id
-     AND sku_id      = v_batch.sku_id
-   FOR UPDATE;
+     AND sku_id = v_batch.sku_id
+     AND status IN ('pending','partial');
 
-  -- 7. 先減 pending/reserved（在寫負 movement 之前，避免被 guard trigger 擋）
+  IF v_balance.reserved < v_total_pending THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: reserved (%) is below total pending (%) for sku %',
+      v_balance.reserved, v_total_pending, v_batch.sku_id;
+  END IF;
+
+  IF v_balance.on_hand < p_qty_damaged + p_qty_lost THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: on_hand (%) is below damaged/lost deduction (%) for sku %',
+      v_balance.on_hand, p_qty_damaged + p_qty_lost, v_batch.sku_id;
+  END IF;
+
+  -- 6. 先減 pending/reserved（在寫負 movement 之前，避免被 guard trigger 擋）
   --    reserved 減去破損＋遺失＋好貨（好貨釋回 available，不再凍結）
   UPDATE stock_balances
      SET reserved   = reserved - v_this_total,
@@ -479,7 +678,7 @@ BEGIN
      AND location_id = v_batch.location_id
      AND sku_id      = v_batch.sku_id;
 
-  -- 8. 更新批次累積
+  -- 7. 更新批次累積
   v_new_status := CASE
     WHEN (v_batch.qty_good + p_qty_good) + (v_batch.qty_damaged + p_qty_damaged)
        + (v_batch.qty_lost + p_qty_lost) + v_batch.qty_revoked = v_batch.total_qty
@@ -495,7 +694,7 @@ BEGIN
          updated_at  = NOW()
    WHERE id = p_batch_id;
 
-  -- 9. 破損 → 寫負 movement（hq_return_damage）
+  -- 8. 破損 → 沿用既有 damage
   IF p_qty_damaged > 0 THEN
     INSERT INTO stock_movements (
       tenant_id, location_id, sku_id, quantity, unit_cost,
@@ -504,12 +703,12 @@ BEGIN
     ) VALUES (
       v_batch.tenant_id, v_batch.location_id, v_batch.sku_id,
       -p_qty_damaged, v_batch.unit_cost,
-      'hq_return_damage', 'hq_return_batch', p_batch_id,
-      p_damage_reason, v_user, p_notes
+      'damage', 'hq_return_batch', p_batch_id,
+      v_damage_reason, v_user, v_notes
     ) RETURNING id INTO v_damage_mov_id;
   END IF;
 
-  -- 10. 遺失 → 寫負 movement（hq_return_loss）
+  -- 9. 遺失 → 沿用既有 manual_adjust，單據鏈與原因明確標示本案
   IF p_qty_lost > 0 THEN
     INSERT INTO stock_movements (
       tenant_id, location_id, sku_id, quantity, unit_cost,
@@ -518,29 +717,29 @@ BEGIN
     ) VALUES (
       v_batch.tenant_id, v_batch.location_id, v_batch.sku_id,
       -p_qty_lost, v_batch.unit_cost,
-      'hq_return_loss', 'hq_return_batch', p_batch_id,
-      p_loss_reason, v_user, p_notes
+      'manual_adjust', 'hq_return_batch', p_batch_id,
+      '退回總倉遺失：' || v_loss_reason, v_user, v_notes
     ) RETURNING id INTO v_loss_mov_id;
   END IF;
 
-  -- 11. 好貨：不寫 movement（已經在 on_hand 上，只是從 reserved 釋放回 available）
+  -- 10. 好貨：不寫 movement（已經在 on_hand 上，只是從 reserved 釋放回 available）
   --     on_hand 不變，reserved 已在步驟 7 減掉了
 
-  -- 12. 建事件
+  -- 11. 建 append-only 事件，保存本次當時結果供日後重播。
   INSERT INTO hq_return_events (
     batch_id, tenant_id, request_id,
     qty_good, qty_damaged, qty_lost,
     damage_reason, loss_reason,
     goods_confirmed,
     damage_movement_id, loss_movement_id,
-    notes, operator_id
+    notes, operator_id, new_status
   ) VALUES (
     p_batch_id, v_tenant, p_request_id,
     p_qty_good, p_qty_damaged, p_qty_lost,
-    p_damage_reason, p_loss_reason,
+    v_damage_reason, v_loss_reason,
     p_goods_confirmed,
     v_damage_mov_id, v_loss_mov_id,
-    p_notes, v_user
+    v_notes, v_user, v_new_status
   ) RETURNING id INTO v_event_id;
 
   RETURN jsonb_build_object(
@@ -557,13 +756,16 @@ BEGIN
 END;
 $$;
 
+REVOKE ALL ON FUNCTION public.rpc_dispose_hq_return(BIGINT, UUID, NUMERIC, NUMERIC, NUMERIC, TEXT, TEXT, BOOLEAN, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_dispose_hq_return(BIGINT, UUID, NUMERIC, NUMERIC, NUMERIC, TEXT, TEXT, BOOLEAN, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_dispose_hq_return(BIGINT, UUID, NUMERIC, NUMERIC, NUMERIC, TEXT, TEXT, BOOLEAN, TEXT) FROM authenticated;
 GRANT EXECUTE ON FUNCTION public.rpc_dispose_hq_return(BIGINT, UUID, NUMERIC, NUMERIC, NUMERIC, TEXT, TEXT, BOOLEAN, TEXT) TO authenticated;
 
 COMMENT ON FUNCTION public.rpc_dispose_hq_return IS
   '總倉退回貨處理 RPC：分配好/破/失數量，寫負 movement 扣庫存（破/失），'
   '好貨釋放 reserved。request_id 冪等，payload 不同拒絕。'
   'role 白名單 owner/admin/hq_manager，auth.uid 操作者不可冒名。'
-  '鎖順序：batch FOR UPDATE → balance FOR UPDATE。';
+  '鎖順序：balance FOR UPDATE → batch FOR UPDATE。';
 
 -- ============================================================
 -- 6. trg_guard_hq_pending — 核心負異動 guard
@@ -579,7 +781,10 @@ COMMENT ON FUNCTION public.rpc_dispose_hq_return IS
 -- 沒有本案 pending 的 SKU 不受影響；店鋪也不受影響。
 -- ============================================================
 CREATE OR REPLACE FUNCTION public._guard_hq_pending_stock()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
 DECLARE
   v_total_pending NUMERIC;
   v_balance_after NUMERIC;
@@ -589,7 +794,19 @@ BEGIN
     RETURN NEW;
   END IF;
 
-  -- 查這個 (tenant, location, sku) 有沒有 pending/partial 批次
+  -- 先建立並鎖 balance；即使起初 pending=0，也要等同 SKU 正在建立的 hold。
+  INSERT INTO stock_balances (tenant_id, location_id, sku_id)
+  VALUES (NEW.tenant_id, NEW.location_id, NEW.sku_id)
+  ON CONFLICT (tenant_id, location_id, sku_id) DO NOTHING;
+
+  SELECT on_hand INTO v_balance_after
+    FROM stock_balances
+   WHERE tenant_id   = NEW.tenant_id
+     AND location_id = NEW.location_id
+     AND sku_id      = NEW.sku_id
+   FOR UPDATE;
+
+  -- 鎖到 balance 後才重讀全部 pending。
   SELECT COALESCE(SUM(
     total_qty - qty_good - qty_damaged - qty_lost - qty_revoked
   ), 0) INTO v_total_pending
@@ -599,22 +816,14 @@ BEGIN
      AND sku_id      = NEW.sku_id
      AND status IN ('pending','partial');
 
-  -- 沒有 pending → 不干預（不改原系統負庫存政策）
+  -- 鎖後仍沒有 pending → 不干預（不改原系統負庫存政策）
   IF v_total_pending <= 0 THEN
     RETURN NEW;
   END IF;
 
-  -- 有 pending → 鎖 balance 後算帳
   -- 注意：apply_movement_to_balance (AFTER INSERT) 還沒跑，
   --       所以 on_hand 還是「加上這筆 movement 之前」的值。
   --       加上 NEW.quantity（負數）之後的 on_hand 不能低於 pending。
-  SELECT COALESCE(on_hand, 0) INTO v_balance_after
-    FROM stock_balances
-   WHERE tenant_id   = NEW.tenant_id
-     AND location_id = NEW.location_id
-     AND sku_id      = NEW.sku_id
-   FOR UPDATE;
-
   v_balance_after := COALESCE(v_balance_after, 0) + NEW.quantity;  -- NEW.quantity is negative
 
   IF v_balance_after < v_total_pending THEN
@@ -624,7 +833,11 @@ BEGIN
 
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
+
+REVOKE ALL ON FUNCTION public._guard_hq_pending_stock() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._guard_hq_pending_stock() FROM anon;
+REVOKE ALL ON FUNCTION public._guard_hq_pending_stock() FROM authenticated;
 
 -- BEFORE INSERT：在 apply_movement_to_balance (AFTER INSERT) 之前檢查
 CREATE TRIGGER trg_guard_hq_pending
@@ -667,6 +880,9 @@ SELECT
   b.created_at,
   b.updated_at
 FROM public.hq_return_batches b;
+
+REVOKE ALL ON TABLE public.v_hq_return_batches_list FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.v_hq_return_batches_list TO authenticated;
 
 COMMENT ON VIEW public.v_hq_return_batches_list IS
   '總倉退回貨批次列表（security_invoker）：同 tenant 總倉角色可讀，'

--- a/supabase/migrations/20260907010000_hq_return_disposition_core.sql
+++ b/supabase/migrations/20260907010000_hq_return_disposition_core.sql
@@ -1,0 +1,677 @@
+-- ============================================================
+-- 總倉退回貨處理 — A 核心（資料與處理）
+-- 20260907010000_hq_return_disposition_core.sql
+--
+-- 依賴：20260422120003（stock_movements / stock_balances / locations / transfers / transfer_items）
+--       20260713000000（movement_type CHECK 最新清單）
+--       20260424120000（_current_tenant_id helper）
+--
+-- 本檔 append-only，不改任何既有表結構（movement_type CHECK 除外：新增兩值）。
+-- ============================================================
+
+-- ============================================================
+-- 0. movement_type 擴充：hq_return_damage / hq_return_loss
+--    基底＝20260713000000 的清單，僅新增，其餘原封不動。
+-- ============================================================
+ALTER TABLE public.stock_movements
+  DROP CONSTRAINT IF EXISTS stock_movements_movement_type_check;
+
+ALTER TABLE public.stock_movements
+  ADD CONSTRAINT stock_movements_movement_type_check CHECK (
+    movement_type = ANY (ARRAY[
+      'purchase_receipt',
+      'return_to_supplier',
+      'sale',
+      'customer_return',
+      'transfer_out',
+      'transfer_in',
+      'transfer_reject',
+      'transfer_cancel',
+      'stocktake_gain',
+      'stocktake_loss',
+      'damage',
+      'manual_adjust',
+      'reversal',
+      'hq_return_damage',
+      'hq_return_loss'
+    ])
+  );
+
+-- ============================================================
+-- 1. hq_return_batches — 總倉退回貨批次
+--
+-- 每筆代表「一條正向 stock_movement 送回總倉的那批貨」。
+-- source_movement_id UNIQUE 防重複建批。
+-- ============================================================
+CREATE TABLE public.hq_return_batches (
+  id                   BIGSERIAL PRIMARY KEY,
+  tenant_id            UUID        NOT NULL,
+  location_id          BIGINT      NOT NULL REFERENCES public.locations(id),
+  sku_id               BIGINT      NOT NULL,
+  source_movement_id   BIGINT      NOT NULL REFERENCES public.stock_movements(id),
+  source_transfer_item_id BIGINT   REFERENCES public.transfer_items(id),
+  source_kind          TEXT        NOT NULL CHECK (source_kind IN ('store_return','shortage')),
+  source_reason        TEXT,
+  total_qty            NUMERIC(18,3) NOT NULL CHECK (total_qty > 0),
+  unit_cost            NUMERIC(18,4) NOT NULL DEFAULT 0
+                       CHECK (unit_cost >= 0
+                              AND unit_cost != 'NaN'::NUMERIC
+                              AND unit_cost != 'Infinity'::NUMERIC
+                              AND unit_cost != '-Infinity'::NUMERIC),
+  qty_good             NUMERIC(18,3) NOT NULL DEFAULT 0 CHECK (qty_good >= 0),
+  qty_damaged          NUMERIC(18,3) NOT NULL DEFAULT 0 CHECK (qty_damaged >= 0),
+  qty_lost             NUMERIC(18,3) NOT NULL DEFAULT 0 CHECK (qty_lost >= 0),
+  qty_revoked          NUMERIC(18,3) NOT NULL DEFAULT 0 CHECK (qty_revoked >= 0),
+  status               TEXT        NOT NULL DEFAULT 'pending'
+                       CHECK (status IN ('pending','partial','completed','revoked')),
+  auto_flag            TEXT        CHECK (auto_flag IS NULL OR auto_flag IN ('system','manual')),
+  created_by           UUID        NOT NULL,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- 來源 movement 唯一：同一筆正向 movement 不能建兩個批次
+  CONSTRAINT uq_hq_return_source_movement UNIQUE (source_movement_id),
+
+  -- 累積不超過總量（含撤回）
+  CONSTRAINT chk_hq_return_qty_sum
+    CHECK (qty_good + qty_damaged + qty_lost + qty_revoked <= total_qty),
+
+  -- pending = total - good - damaged - lost - revoked
+  -- status 與累積一致
+  CONSTRAINT chk_hq_return_status_consistent CHECK (
+    CASE
+      WHEN qty_good + qty_damaged + qty_lost + qty_revoked = 0 THEN status IN ('pending','revoked')
+      WHEN qty_good + qty_damaged + qty_lost + qty_revoked < total_qty THEN status = 'partial'
+      WHEN qty_good + qty_damaged + qty_lost + qty_revoked = total_qty THEN status IN ('completed','revoked')
+      ELSE FALSE
+    END
+  ),
+
+  -- NaN / Infinity 防護（數量欄）
+  CONSTRAINT chk_hq_return_qty_finite CHECK (
+        total_qty    != 'NaN'::NUMERIC AND total_qty    != 'Infinity'::NUMERIC AND total_qty    != '-Infinity'::NUMERIC
+    AND qty_good     != 'NaN'::NUMERIC AND qty_good     != 'Infinity'::NUMERIC AND qty_good     != '-Infinity'::NUMERIC
+    AND qty_damaged  != 'NaN'::NUMERIC AND qty_damaged  != 'Infinity'::NUMERIC AND qty_damaged  != '-Infinity'::NUMERIC
+    AND qty_lost     != 'NaN'::NUMERIC AND qty_lost     != 'Infinity'::NUMERIC AND qty_lost     != '-Infinity'::NUMERIC
+    AND qty_revoked  != 'NaN'::NUMERIC AND qty_revoked  != 'Infinity'::NUMERIC AND qty_revoked  != '-Infinity'::NUMERIC
+  )
+);
+
+COMMENT ON TABLE public.hq_return_batches IS '總倉退回貨批次：每筆來源 movement 唯一，追蹤好/破/失/撤/pending';
+COMMENT ON COLUMN public.hq_return_batches.unit_cost IS '來源成本依據（來自 movement.unit_cost 或 0 表示未知），不從售價猜';
+COMMENT ON COLUMN public.hq_return_batches.source_kind IS 'store_return＝門市退貨, shortage＝短少';
+
+CREATE INDEX idx_hq_return_batches_tenant_status
+  ON public.hq_return_batches (tenant_id, status, created_at DESC);
+
+CREATE INDEX idx_hq_return_batches_tenant_loc_sku
+  ON public.hq_return_batches (tenant_id, location_id, sku_id)
+  WHERE status IN ('pending','partial');
+
+-- ============================================================
+-- 2. hq_return_events — 處理事件（append-only）
+--
+-- 每次處理（好/破/失分配）產生一筆事件。
+-- request_id 冪等：同 UUID 重試回原結果，payload 不同拒絕。
+-- ============================================================
+CREATE TABLE public.hq_return_events (
+  id                   BIGSERIAL PRIMARY KEY,
+  batch_id             BIGINT      NOT NULL REFERENCES public.hq_return_batches(id),
+  tenant_id            UUID        NOT NULL,
+  request_id           UUID        NOT NULL,
+  qty_good             NUMERIC(18,3) NOT NULL DEFAULT 0 CHECK (qty_good >= 0),
+  qty_damaged          NUMERIC(18,3) NOT NULL DEFAULT 0 CHECK (qty_damaged >= 0),
+  qty_lost             NUMERIC(18,3) NOT NULL DEFAULT 0 CHECK (qty_lost >= 0),
+  damage_reason        TEXT,
+  loss_reason          TEXT,
+  goods_confirmed      BOOLEAN     NOT NULL DEFAULT FALSE,
+  damage_movement_id   BIGINT      REFERENCES public.stock_movements(id),
+  loss_movement_id     BIGINT      REFERENCES public.stock_movements(id),
+  notes                TEXT,
+  operator_id          UUID        NOT NULL,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- 同 request_id 不可二建
+  CONSTRAINT uq_hq_return_event_request UNIQUE (request_id),
+
+  -- 不能全 0
+  CONSTRAINT chk_hq_return_event_nonzero CHECK (qty_good + qty_damaged + qty_lost > 0),
+
+  -- 破損需原因
+  CONSTRAINT chk_hq_return_event_damage_reason CHECK (qty_damaged = 0 OR damage_reason IS NOT NULL),
+  -- 遺失需原因
+  CONSTRAINT chk_hq_return_event_loss_reason CHECK (qty_lost = 0 OR loss_reason IS NOT NULL),
+
+  -- NaN / Infinity 防護
+  CONSTRAINT chk_hq_return_event_qty_finite CHECK (
+        qty_good    != 'NaN'::NUMERIC AND qty_good    != 'Infinity'::NUMERIC AND qty_good    != '-Infinity'::NUMERIC
+    AND qty_damaged != 'NaN'::NUMERIC AND qty_damaged != 'Infinity'::NUMERIC AND qty_damaged != '-Infinity'::NUMERIC
+    AND qty_lost    != 'NaN'::NUMERIC AND qty_lost    != 'Infinity'::NUMERIC AND qty_lost    != '-Infinity'::NUMERIC
+  )
+);
+
+COMMENT ON TABLE public.hq_return_events IS '總倉退回貨處理事件：append-only，每次處理一筆';
+COMMENT ON COLUMN public.hq_return_events.request_id IS '前端冪等 UUID：重試回原結果，payload 不同拒絕';
+COMMENT ON COLUMN public.hq_return_events.goods_confirmed IS '好貨實物已到確認（前端必傳 true 才計入 qty_good）';
+
+CREATE INDEX idx_hq_return_events_batch
+  ON public.hq_return_events (batch_id, created_at);
+
+CREATE INDEX idx_hq_return_events_request
+  ON public.hq_return_events (request_id);
+
+-- 禁止 UPDATE / DELETE（append-only）
+CREATE OR REPLACE FUNCTION public._forbid_hq_return_event_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'hq_return_events is append-only';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_no_update_hq_return_events
+  BEFORE UPDATE ON public.hq_return_events
+  FOR EACH ROW EXECUTE FUNCTION public._forbid_hq_return_event_mutation();
+
+CREATE TRIGGER trg_no_delete_hq_return_events
+  BEFORE DELETE ON public.hq_return_events
+  FOR EACH ROW EXECUTE FUNCTION public._forbid_hq_return_event_mutation();
+
+-- ============================================================
+-- 3. RLS
+--
+-- 兩表都開 RLS。authenticated 只讀同 tenant，INSERT/UPDATE/DELETE 全封。
+-- 資料寫入只透過 SECURITY DEFINER 函式。
+-- ============================================================
+ALTER TABLE public.hq_return_batches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hq_return_events  ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY hq_return_batches_tenant_read ON public.hq_return_batches
+  FOR SELECT TO authenticated
+  USING (tenant_id = public._current_tenant_id());
+
+CREATE POLICY hq_return_events_tenant_read ON public.hq_return_events
+  FOR SELECT TO authenticated
+  USING (tenant_id = public._current_tenant_id());
+
+-- 明確不給 INSERT/UPDATE/DELETE policy → authenticated 直接寫會被 RLS 擋
+
+-- ============================================================
+-- 4. _hq_hold_return — 內部 helper：建批次＋同步 reserved
+--
+-- 參數：
+--   p_tenant_id           UUID     — 租戶
+--   p_location_id         BIGINT   — 總倉 location（必須 type='central_warehouse'）
+--   p_sku_id              BIGINT   — SKU
+--   p_source_movement_id  BIGINT   — 正向入庫 movement（quantity > 0，同 tenant）
+--   p_source_transfer_item_id BIGINT — 可選，對應 transfer_item
+--   p_source_kind         TEXT     — 'store_return' 或 'shortage'
+--   p_source_reason       TEXT     — 原因文字
+--   p_qty                 NUMERIC  — 回帳量（正數）
+--   p_operator_id         UUID     — 操作者
+--   p_auto_flag           TEXT     — 'system' 或 'manual'
+--
+-- 行為：
+--   1. 驗證 movement 存在、quantity > 0、同 tenant、SKU 匹配
+--   2. 驗證 location type = central_warehouse
+--   3. 若同 source_movement_id 已有批次 → 回傳既有 batch_id（冪等，不二建）
+--   4. 建批次，同步 stock_balances.reserved += p_qty
+--   5. 回傳 batch_id
+--
+-- ⛔ REVOKE PUBLIC / anon / authenticated — 不作前端 RPC，僅供後端安全呼叫。
+-- ============================================================
+CREATE OR REPLACE FUNCTION public._hq_hold_return(
+  p_tenant_id                UUID,
+  p_location_id              BIGINT,
+  p_sku_id                   BIGINT,
+  p_source_movement_id       BIGINT,
+  p_source_transfer_item_id  BIGINT DEFAULT NULL,
+  p_source_kind              TEXT DEFAULT 'store_return',
+  p_source_reason            TEXT DEFAULT NULL,
+  p_qty                      NUMERIC DEFAULT NULL,
+  p_operator_id              UUID DEFAULT NULL,
+  p_auto_flag                TEXT DEFAULT 'system'
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_mov         RECORD;
+  v_loc_type    TEXT;
+  v_existing_id BIGINT;
+  v_batch_id    BIGINT;
+  v_hold_qty    NUMERIC(18,3);
+  v_unit_cost   NUMERIC(18,4);
+BEGIN
+  -- 1. 驗證來源 movement
+  SELECT id, tenant_id, location_id, sku_id, quantity, unit_cost
+    INTO v_mov
+    FROM stock_movements
+   WHERE id = p_source_movement_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '_hq_hold_return: source movement % not found', p_source_movement_id;
+  END IF;
+
+  IF v_mov.tenant_id != p_tenant_id THEN
+    RAISE EXCEPTION '_hq_hold_return: movement % belongs to different tenant', p_source_movement_id;
+  END IF;
+
+  IF v_mov.quantity <= 0 THEN
+    RAISE EXCEPTION '_hq_hold_return: movement % quantity must be positive (got %)', p_source_movement_id, v_mov.quantity;
+  END IF;
+
+  IF v_mov.sku_id != p_sku_id THEN
+    RAISE EXCEPTION '_hq_hold_return: movement % sku_id=% does not match p_sku_id=%', p_source_movement_id, v_mov.sku_id, p_sku_id;
+  END IF;
+
+  -- 2. 驗證 location type
+  SELECT type INTO v_loc_type
+    FROM locations
+   WHERE id = p_location_id AND tenant_id = p_tenant_id;
+
+  IF v_loc_type IS NULL THEN
+    RAISE EXCEPTION '_hq_hold_return: location % not found for tenant', p_location_id;
+  END IF;
+
+  IF v_loc_type != 'central_warehouse' THEN
+    RAISE EXCEPTION '_hq_hold_return: location % type=% is not central_warehouse', p_location_id, v_loc_type;
+  END IF;
+
+  -- 3. 冪等：同 source_movement_id 已有批次 → 回傳既有 id
+  SELECT id INTO v_existing_id
+    FROM hq_return_batches
+   WHERE source_movement_id = p_source_movement_id;
+
+  IF FOUND THEN
+    RETURN v_existing_id;
+  END IF;
+
+  -- 4. 決定凍結量與成本
+  v_hold_qty  := COALESCE(p_qty, v_mov.quantity);
+  v_unit_cost := COALESCE(v_mov.unit_cost, 0);
+
+  IF v_hold_qty <= 0 THEN
+    RAISE EXCEPTION '_hq_hold_return: hold qty must be positive, got %', v_hold_qty;
+  END IF;
+
+  -- 5. 建批次
+  INSERT INTO hq_return_batches (
+    tenant_id, location_id, sku_id,
+    source_movement_id, source_transfer_item_id,
+    source_kind, source_reason,
+    total_qty, unit_cost,
+    auto_flag, created_by
+  ) VALUES (
+    p_tenant_id, p_location_id, p_sku_id,
+    p_source_movement_id, p_source_transfer_item_id,
+    p_source_kind, p_source_reason,
+    v_hold_qty, v_unit_cost,
+    p_auto_flag, COALESCE(p_operator_id, '00000000-0000-0000-0000-000000000000'::UUID)
+  ) RETURNING id INTO v_batch_id;
+
+  -- 6. 同步 reserved（鎖 balance 列）
+  INSERT INTO stock_balances (tenant_id, location_id, sku_id, reserved)
+  VALUES (p_tenant_id, p_location_id, p_sku_id, v_hold_qty)
+  ON CONFLICT (tenant_id, location_id, sku_id) DO UPDATE
+    SET reserved   = stock_balances.reserved + v_hold_qty,
+        updated_at = NOW();
+
+  RETURN v_batch_id;
+END;
+$$;
+
+-- ⛔ 安全：不開放給任何前端角色
+REVOKE ALL ON FUNCTION public._hq_hold_return(UUID, BIGINT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, NUMERIC, UUID, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._hq_hold_return(UUID, BIGINT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, NUMERIC, UUID, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public._hq_hold_return(UUID, BIGINT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, NUMERIC, UUID, TEXT) FROM authenticated;
+
+COMMENT ON FUNCTION public._hq_hold_return IS
+  '內部 helper：建總倉退回貨批次＋凍結 reserved。僅供後端安全呼叫，'
+  'REVOKE 了 PUBLIC/anon/authenticated。同 source_movement_id 冪等回傳既有 id。';
+
+-- ============================================================
+-- 5. rpc_dispose_hq_return — 前端 RPC：處理退回批次
+--
+-- 參數：
+--   p_batch_id       BIGINT   — 批次 id
+--   p_request_id     UUID     — 冪等 UUID（同 UUID 重試回原結果）
+--   p_qty_good       NUMERIC  — 完好數量
+--   p_qty_damaged    NUMERIC  — 破損數量
+--   p_qty_lost       NUMERIC  — 遺失數量
+--   p_damage_reason  TEXT     — 破損原因（破損 > 0 時必填）
+--   p_loss_reason    TEXT     — 遺失原因（遺失 > 0 時必填）
+--   p_goods_confirmed BOOLEAN — 好貨實物已到確認（好貨 > 0 時必須 true）
+--   p_notes          TEXT     — 備註
+--
+-- 鎖順序：hq_return_batches(id) FOR UPDATE → stock_balances(tenant, location, sku) FOR UPDATE
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.rpc_dispose_hq_return(
+  p_batch_id        BIGINT,
+  p_request_id      UUID,
+  p_qty_good        NUMERIC DEFAULT 0,
+  p_qty_damaged     NUMERIC DEFAULT 0,
+  p_qty_lost        NUMERIC DEFAULT 0,
+  p_damage_reason   TEXT    DEFAULT NULL,
+  p_loss_reason     TEXT    DEFAULT NULL,
+  p_goods_confirmed BOOLEAN DEFAULT FALSE,
+  p_notes           TEXT    DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user          UUID := auth.uid();
+  v_tenant        UUID := public._current_tenant_id();
+  v_role          TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_batch         RECORD;
+  v_pending       NUMERIC(18,3);
+  v_this_total    NUMERIC(18,3);
+  v_existing      RECORD;
+  v_damage_mov_id BIGINT;
+  v_loss_mov_id   BIGINT;
+  v_event_id      BIGINT;
+  v_new_status    TEXT;
+BEGIN
+  -- 0. auth 必須有值
+  IF v_user IS NULL THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: not authenticated';
+  END IF;
+
+  -- 1. role 白名單
+  IF v_role NOT IN ('owner','admin','hq_manager') THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: permission denied for role %', v_role;
+  END IF;
+
+  -- 2. 數量基本檢查
+  IF p_qty_good    IS NULL OR p_qty_good    < 0
+  OR p_qty_damaged IS NULL OR p_qty_damaged < 0
+  OR p_qty_lost    IS NULL OR p_qty_lost    < 0 THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: quantities must be non-negative';
+  END IF;
+
+  v_this_total := p_qty_good + p_qty_damaged + p_qty_lost;
+
+  IF v_this_total <= 0 THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: total disposition quantity must be > 0';
+  END IF;
+
+  -- NaN / Infinity 防護
+  IF v_this_total = 'NaN'::NUMERIC OR v_this_total = 'Infinity'::NUMERIC OR v_this_total = '-Infinity'::NUMERIC THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: invalid numeric value in quantities';
+  END IF;
+
+  -- 破損需原因
+  IF p_qty_damaged > 0 AND (p_damage_reason IS NULL OR TRIM(p_damage_reason) = '') THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: damage_reason required when qty_damaged > 0';
+  END IF;
+
+  -- 遺失需原因
+  IF p_qty_lost > 0 AND (p_loss_reason IS NULL OR TRIM(p_loss_reason) = '') THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: loss_reason required when qty_lost > 0';
+  END IF;
+
+  -- 好貨需實物確認
+  IF p_qty_good > 0 AND NOT p_goods_confirmed THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: goods_confirmed must be true when qty_good > 0';
+  END IF;
+
+  -- 3. 冪等：同 request_id 已存在 → 驗 payload 一致後回傳原結果
+  SELECT * INTO v_existing
+    FROM hq_return_events
+   WHERE request_id = p_request_id;
+
+  IF FOUND THEN
+    -- payload 驗證：batch_id + 三個數量必須一致
+    IF v_existing.batch_id    != p_batch_id
+    OR v_existing.qty_good    != p_qty_good
+    OR v_existing.qty_damaged != p_qty_damaged
+    OR v_existing.qty_lost    != p_qty_lost THEN
+      RAISE EXCEPTION 'rpc_dispose_hq_return: request_id % already used with different payload', p_request_id;
+    END IF;
+
+    RETURN jsonb_build_object(
+      'event_id',    v_existing.id,
+      'batch_id',    v_existing.batch_id,
+      'idempotent',  TRUE
+    );
+  END IF;
+
+  -- 4. 鎖批次（鎖順序第一：batch）
+  SELECT * INTO v_batch
+    FROM hq_return_batches
+   WHERE id = p_batch_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: batch % not found', p_batch_id;
+  END IF;
+
+  IF v_batch.tenant_id != v_tenant THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: batch % belongs to different tenant', p_batch_id;
+  END IF;
+
+  IF v_batch.status IN ('completed','revoked') THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: batch % already %', p_batch_id, v_batch.status;
+  END IF;
+
+  -- 5. pending 剩餘量檢查
+  v_pending := v_batch.total_qty - v_batch.qty_good - v_batch.qty_damaged - v_batch.qty_lost - v_batch.qty_revoked;
+
+  IF v_this_total > v_pending THEN
+    RAISE EXCEPTION 'rpc_dispose_hq_return: disposition qty (%) exceeds pending (%) for batch %',
+      v_this_total, v_pending, p_batch_id;
+  END IF;
+
+  -- 6. 鎖 balance（鎖順序第二：balance）
+  PERFORM 1
+    FROM stock_balances
+   WHERE tenant_id   = v_batch.tenant_id
+     AND location_id = v_batch.location_id
+     AND sku_id      = v_batch.sku_id
+   FOR UPDATE;
+
+  -- 7. 先減 pending/reserved（在寫負 movement 之前，避免被 guard trigger 擋）
+  --    reserved 減去破損＋遺失＋好貨（好貨釋回 available，不再凍結）
+  UPDATE stock_balances
+     SET reserved   = reserved - v_this_total,
+         updated_at = NOW()
+   WHERE tenant_id   = v_batch.tenant_id
+     AND location_id = v_batch.location_id
+     AND sku_id      = v_batch.sku_id;
+
+  -- 8. 更新批次累積
+  v_new_status := CASE
+    WHEN (v_batch.qty_good + p_qty_good) + (v_batch.qty_damaged + p_qty_damaged)
+       + (v_batch.qty_lost + p_qty_lost) + v_batch.qty_revoked = v_batch.total_qty
+    THEN 'completed'
+    ELSE 'partial'
+  END;
+
+  UPDATE hq_return_batches
+     SET qty_good    = qty_good    + p_qty_good,
+         qty_damaged = qty_damaged + p_qty_damaged,
+         qty_lost    = qty_lost    + p_qty_lost,
+         status      = v_new_status,
+         updated_at  = NOW()
+   WHERE id = p_batch_id;
+
+  -- 9. 破損 → 寫負 movement（hq_return_damage）
+  IF p_qty_damaged > 0 THEN
+    INSERT INTO stock_movements (
+      tenant_id, location_id, sku_id, quantity, unit_cost,
+      movement_type, source_doc_type, source_doc_id,
+      reason, operator_id, notes
+    ) VALUES (
+      v_batch.tenant_id, v_batch.location_id, v_batch.sku_id,
+      -p_qty_damaged, v_batch.unit_cost,
+      'hq_return_damage', 'hq_return_batch', p_batch_id,
+      p_damage_reason, v_user, p_notes
+    ) RETURNING id INTO v_damage_mov_id;
+  END IF;
+
+  -- 10. 遺失 → 寫負 movement（hq_return_loss）
+  IF p_qty_lost > 0 THEN
+    INSERT INTO stock_movements (
+      tenant_id, location_id, sku_id, quantity, unit_cost,
+      movement_type, source_doc_type, source_doc_id,
+      reason, operator_id, notes
+    ) VALUES (
+      v_batch.tenant_id, v_batch.location_id, v_batch.sku_id,
+      -p_qty_lost, v_batch.unit_cost,
+      'hq_return_loss', 'hq_return_batch', p_batch_id,
+      p_loss_reason, v_user, p_notes
+    ) RETURNING id INTO v_loss_mov_id;
+  END IF;
+
+  -- 11. 好貨：不寫 movement（已經在 on_hand 上，只是從 reserved 釋放回 available）
+  --     on_hand 不變，reserved 已在步驟 7 減掉了
+
+  -- 12. 建事件
+  INSERT INTO hq_return_events (
+    batch_id, tenant_id, request_id,
+    qty_good, qty_damaged, qty_lost,
+    damage_reason, loss_reason,
+    goods_confirmed,
+    damage_movement_id, loss_movement_id,
+    notes, operator_id
+  ) VALUES (
+    p_batch_id, v_tenant, p_request_id,
+    p_qty_good, p_qty_damaged, p_qty_lost,
+    p_damage_reason, p_loss_reason,
+    p_goods_confirmed,
+    v_damage_mov_id, v_loss_mov_id,
+    p_notes, v_user
+  ) RETURNING id INTO v_event_id;
+
+  RETURN jsonb_build_object(
+    'event_id',          v_event_id,
+    'batch_id',          p_batch_id,
+    'idempotent',        FALSE,
+    'qty_good',          p_qty_good,
+    'qty_damaged',       p_qty_damaged,
+    'qty_lost',          p_qty_lost,
+    'damage_movement_id', v_damage_mov_id,
+    'loss_movement_id',  v_loss_mov_id,
+    'new_status',        v_new_status
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_dispose_hq_return(BIGINT, UUID, NUMERIC, NUMERIC, NUMERIC, TEXT, TEXT, BOOLEAN, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_dispose_hq_return IS
+  '總倉退回貨處理 RPC：分配好/破/失數量，寫負 movement 扣庫存（破/失），'
+  '好貨釋放 reserved。request_id 冪等，payload 不同拒絕。'
+  'role 白名單 owner/admin/hq_manager，auth.uid 操作者不可冒名。'
+  '鎖順序：batch FOR UPDATE → balance FOR UPDATE。';
+
+-- ============================================================
+-- 6. trg_guard_hq_pending — 核心負異動 guard
+--
+-- 保護總倉 pending 批次的 SKU：任何 INSERT 負 movement 到該
+-- (tenant, location, sku) 時，驗證 on_hand - 該 SKU 全部 pending ≥ 0。
+--
+-- ⛔ 本案自己的 rpc_dispose_hq_return 先減 pending/reserved 再寫負 movement，
+--    所以不會被自己擋。但 rpc_outbound(p_allow_negative=true) 或直接 INSERT
+--    負 movement 會被擋（如果會吃掉 pending 的量）。
+--
+-- 只在「該 SKU 在該 location 有 pending/partial 批次」時才生效，
+-- 沒有本案 pending 的 SKU 不受影響；店鋪也不受影響。
+-- ============================================================
+CREATE OR REPLACE FUNCTION public._guard_hq_pending_stock()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_total_pending NUMERIC;
+  v_balance_after NUMERIC;
+BEGIN
+  -- 只管負數 movement
+  IF NEW.quantity >= 0 THEN
+    RETURN NEW;
+  END IF;
+
+  -- 查這個 (tenant, location, sku) 有沒有 pending/partial 批次
+  SELECT COALESCE(SUM(
+    total_qty - qty_good - qty_damaged - qty_lost - qty_revoked
+  ), 0) INTO v_total_pending
+    FROM hq_return_batches
+   WHERE tenant_id   = NEW.tenant_id
+     AND location_id = NEW.location_id
+     AND sku_id      = NEW.sku_id
+     AND status IN ('pending','partial');
+
+  -- 沒有 pending → 不干預（不改原系統負庫存政策）
+  IF v_total_pending <= 0 THEN
+    RETURN NEW;
+  END IF;
+
+  -- 有 pending → 鎖 balance 後算帳
+  -- 注意：apply_movement_to_balance (AFTER INSERT) 還沒跑，
+  --       所以 on_hand 還是「加上這筆 movement 之前」的值。
+  --       加上 NEW.quantity（負數）之後的 on_hand 不能低於 pending。
+  SELECT COALESCE(on_hand, 0) INTO v_balance_after
+    FROM stock_balances
+   WHERE tenant_id   = NEW.tenant_id
+     AND location_id = NEW.location_id
+     AND sku_id      = NEW.sku_id
+   FOR UPDATE;
+
+  v_balance_after := COALESCE(v_balance_after, 0) + NEW.quantity;  -- NEW.quantity is negative
+
+  IF v_balance_after < v_total_pending THEN
+    RAISE EXCEPTION 'guard_hq_pending: negative movement would reduce on_hand (%) below pending hq_return qty (%) for sku % at location %',
+      v_balance_after, v_total_pending, NEW.sku_id, NEW.location_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- BEFORE INSERT：在 apply_movement_to_balance (AFTER INSERT) 之前檢查
+CREATE TRIGGER trg_guard_hq_pending
+  BEFORE INSERT ON public.stock_movements
+  FOR EACH ROW EXECUTE FUNCTION public._guard_hq_pending_stock();
+
+COMMENT ON FUNCTION public._guard_hq_pending_stock IS
+  '核心負異動 guard：保護總倉 pending 退回貨批次的 SKU 不被負 movement 吃掉。'
+  '只在該 (tenant, location, sku) 有 pending/partial 批次時生效，'
+  '其他 SKU 與店鋪完全不受影響。rpc_dispose_hq_return 先減 pending 再寫 movement 所以不被擋。';
+
+-- ============================================================
+-- 7. v_hq_return_batches_list — 同 tenant 總倉 list view
+--
+-- security_invoker=true → RLS 以呼叫者身分執行。
+-- 欄位帶 pending 數、可讀狀態、來源 IDs（UI 可依此 join 品名店名）。
+-- ============================================================
+CREATE OR REPLACE VIEW public.v_hq_return_batches_list
+WITH (security_invoker = true)
+AS
+SELECT
+  b.id,
+  b.tenant_id,
+  b.location_id,
+  b.sku_id,
+  b.source_movement_id,
+  b.source_transfer_item_id,
+  b.source_kind,
+  b.source_reason,
+  b.total_qty,
+  b.unit_cost,
+  b.qty_good,
+  b.qty_damaged,
+  b.qty_lost,
+  b.qty_revoked,
+  (b.total_qty - b.qty_good - b.qty_damaged - b.qty_lost - b.qty_revoked) AS qty_pending,
+  b.status,
+  b.auto_flag,
+  b.created_by,
+  b.created_at,
+  b.updated_at
+FROM public.hq_return_batches b;
+
+COMMENT ON VIEW public.v_hq_return_batches_list IS
+  '總倉退回貨批次列表（security_invoker）：同 tenant 總倉角色可讀，'
+  '帶 qty_pending 計算欄。UI 可依 sku_id / source_transfer_item_id join 品名店名。';
+
+-- ============================================================
+-- End of migration
+-- ============================================================

--- a/supabase/migrations/20260907020000_hq_return_disposition_sources.sql
+++ b/supabase/migrations/20260907020000_hq_return_disposition_sources.sql
@@ -1,0 +1,249 @@
+-- ============================================================
+-- 總倉退回貨處理 — B 來源接線
+-- 20260907020000_hq_return_disposition_sources.sql
+--
+-- 依賴：20260907010000（_hq_hold_return helper、hq_return_batches 表）
+--       20260422120003（transfer_items、stock_movements、locations）
+--       20260904020010（rpc_receive_transfer 寫 in_movement_id）
+--       20260903000200（rpc_resolve_transfer_item_shortage 寫 shortage_restock_movement_id）
+--
+-- 本檔 append-only，不改任何既有表結構、不改 A 檔函式、不改任何 RPC。
+-- ============================================================
+
+-- ============================================================
+-- 1. _hq_return_source_on_ti — trigger 函式
+--
+-- AFTER INSERT OR UPDATE OF in_movement_id, shortage_restock_movement_id
+-- ON transfer_items FOR EACH ROW
+--
+-- 兩條來源各自檢查，同一列理論上只會命中一條：
+--   A) in_movement_id 從 NULL→非NULL：store_return（退貨回總倉入庫）
+--   B) shortage_restock_movement_id 從 NULL→非NULL：shortage（短少沖回）
+--
+-- 觸發時機：在入庫完成後（rpc_receive_transfer / rpc_resolve 已寫完
+-- stock_movement 和 balance），同一交易內呼叫 _hq_hold_return 建批次＋凍結。
+-- 不能留時間窗讓庫存先可派再凍結。
+-- ============================================================
+CREATE OR REPLACE FUNCTION public._hq_return_source_on_ti()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_transfer      RECORD;
+  v_mov           RECORD;
+  v_loc_type      TEXT;
+  v_operator_id   UUID;
+  v_auto_flag     TEXT;
+  v_source_reason TEXT;
+  v_batch_id      BIGINT;
+BEGIN
+  -- ================================================================
+  -- 來源 A：in_movement_id（店家退貨回總倉的真入庫 movement）
+  -- ================================================================
+  IF  NEW.in_movement_id IS NOT NULL
+  AND (TG_OP = 'INSERT' OR OLD.in_movement_id IS DISTINCT FROM NEW.in_movement_id)
+  THEN
+    -- 取父調撥單
+    SELECT t.tenant_id, t.transfer_type, t.dest_location, t.notes,
+           t.received_by
+      INTO v_transfer
+      FROM transfers t
+     WHERE t.id = NEW.transfer_id;
+
+    -- 只處理 return_to_hq（一般到貨 hq_to_store / store_to_store 跳過）
+    IF v_transfer.transfer_type = 'return_to_hq' THEN
+
+      -- 驗證 movement 存在且為正向入庫
+      SELECT m.id, m.tenant_id, m.location_id, m.sku_id, m.quantity,
+             m.movement_type
+        INTO v_mov
+        FROM stock_movements m
+       WHERE m.id = NEW.in_movement_id;
+
+      IF NOT FOUND THEN
+        RAISE EXCEPTION '_hq_return_source: in_movement_id % not found', NEW.in_movement_id;
+      END IF;
+
+      -- 必須是正向 movement（quantity > 0）；短收沖帳單 in_movement_id IS NULL，
+      -- 不會進到這裡；但 defensive check
+      IF v_mov.quantity <= 0 THEN
+        RAISE EXCEPTION '_hq_return_source: in_movement_id % quantity=% is not positive',
+          NEW.in_movement_id, v_mov.quantity;
+      END IF;
+
+      -- tenant 一致
+      IF v_mov.tenant_id != v_transfer.tenant_id THEN
+        RAISE EXCEPTION '_hq_return_source: movement % tenant mismatch', NEW.in_movement_id;
+      END IF;
+
+      -- SKU 一致
+      IF v_mov.sku_id != NEW.sku_id THEN
+        RAISE EXCEPTION '_hq_return_source: movement % sku_id=% != item sku_id=%',
+          NEW.in_movement_id, v_mov.sku_id, NEW.sku_id;
+      END IF;
+
+      -- movement location 必須是 dest_location（HQ）
+      IF v_mov.location_id != v_transfer.dest_location THEN
+        RAISE EXCEPTION '_hq_return_source: movement % location=% != transfer dest=%',
+          NEW.in_movement_id, v_mov.location_id, v_transfer.dest_location;
+      END IF;
+
+      -- dest 必須是 central_warehouse
+      SELECT l.type INTO v_loc_type
+        FROM locations l
+       WHERE l.id = v_transfer.dest_location;
+
+      IF COALESCE(v_loc_type, '') != 'central_warehouse' THEN
+        -- 不是總倉，跳過（不凍結）
+        RETURN NEW;
+      END IF;
+
+      -- movement_type 必須是 transfer_in（防禦性）
+      IF v_mov.movement_type != 'transfer_in' THEN
+        RAISE EXCEPTION '_hq_return_source: in_movement_id % type=% expected transfer_in',
+          NEW.in_movement_id, v_mov.movement_type;
+      END IF;
+
+      -- operator / auto_flag：全零 sentinel → system，其餘 → manual
+      v_operator_id := COALESCE(v_transfer.received_by,
+                                '00000000-0000-0000-0000-000000000000'::UUID);
+      v_auto_flag := CASE
+        WHEN v_operator_id = '00000000-0000-0000-0000-000000000000'::UUID
+        THEN 'system' ELSE 'manual'
+      END;
+
+      -- 原因：從 transfer notes 取（[order return: 少收] 等）
+      v_source_reason := LEFT(v_transfer.notes, 200);
+
+      -- 呼叫 A helper 建批次（冪等：同 source_movement_id 回傳既有 id）
+      v_batch_id := public._hq_hold_return(
+        p_tenant_id               => v_transfer.tenant_id,
+        p_location_id             => v_transfer.dest_location,
+        p_sku_id                  => NEW.sku_id,
+        p_source_movement_id      => NEW.in_movement_id,
+        p_source_transfer_item_id => NEW.id,
+        p_source_kind             => 'store_return',
+        p_source_reason           => v_source_reason,
+        p_qty                     => v_mov.quantity,
+        p_operator_id             => v_operator_id,
+        p_auto_flag               => v_auto_flag
+      );
+    END IF;
+  END IF;
+
+  -- ================================================================
+  -- 來源 B：shortage_restock_movement_id（短少沖回的真入庫 movement）
+  -- ================================================================
+  IF  NEW.shortage_restock_movement_id IS NOT NULL
+  AND (TG_OP = 'INSERT' OR OLD.shortage_restock_movement_id IS DISTINCT FROM NEW.shortage_restock_movement_id)
+  THEN
+    -- 取父調撥單
+    SELECT t.tenant_id, t.transfer_type, t.source_location
+      INTO v_transfer
+      FROM transfers t
+     WHERE t.id = NEW.transfer_id;
+
+    -- 驗證 movement
+    SELECT m.id, m.tenant_id, m.location_id, m.sku_id, m.quantity,
+           m.movement_type
+      INTO v_mov
+      FROM stock_movements m
+     WHERE m.id = NEW.shortage_restock_movement_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION '_hq_return_source: shortage_restock_movement_id % not found',
+        NEW.shortage_restock_movement_id;
+    END IF;
+
+    IF v_mov.quantity <= 0 THEN
+      RAISE EXCEPTION '_hq_return_source: shortage_restock_movement_id % quantity=% not positive',
+        NEW.shortage_restock_movement_id, v_mov.quantity;
+    END IF;
+
+    IF v_mov.tenant_id != v_transfer.tenant_id THEN
+      RAISE EXCEPTION '_hq_return_source: shortage movement % tenant mismatch',
+        NEW.shortage_restock_movement_id;
+    END IF;
+
+    IF v_mov.sku_id != NEW.sku_id THEN
+      RAISE EXCEPTION '_hq_return_source: shortage movement % sku_id=% != item sku_id=%',
+        NEW.shortage_restock_movement_id, v_mov.sku_id, NEW.sku_id;
+    END IF;
+
+    -- movement location 必須是 source_location（短少沖回出貨端）
+    IF v_mov.location_id != v_transfer.source_location THEN
+      RAISE EXCEPTION '_hq_return_source: shortage movement % location=% != transfer source=%',
+        NEW.shortage_restock_movement_id, v_mov.location_id, v_transfer.source_location;
+    END IF;
+
+    -- 出貨端必須是 central_warehouse（店對店短少不是本案 HQ 批次，不假移總倉）
+    SELECT l.type INTO v_loc_type
+      FROM locations l
+     WHERE l.id = v_transfer.source_location;
+
+    IF COALESCE(v_loc_type, '') != 'central_warehouse' THEN
+      RETURN NEW;
+    END IF;
+
+    -- movement_type 必須是 transfer_cancel（防禦性）
+    IF v_mov.movement_type != 'transfer_cancel' THEN
+      RAISE EXCEPTION '_hq_return_source: shortage movement % type=% expected transfer_cancel',
+        NEW.shortage_restock_movement_id, v_mov.movement_type;
+    END IF;
+
+    -- shortage 的 operator：取 rpc_resolve 傳入的 p_operator（存在 shortage_resolution_by）
+    v_operator_id := COALESCE(NEW.shortage_resolution_by,
+                              '00000000-0000-0000-0000-000000000000'::UUID);
+    v_auto_flag := 'manual';  -- shortage resolution 必定是人工操作
+
+    v_source_reason := 'shortage:'
+      || COALESCE(NEW.shortage_resolution, '')
+      || COALESCE(' ' || LEFT(NEW.shortage_resolution_notes, 150), '');
+
+    v_batch_id := public._hq_hold_return(
+      p_tenant_id               => v_transfer.tenant_id,
+      p_location_id             => v_transfer.source_location,
+      p_sku_id                  => NEW.sku_id,
+      p_source_movement_id      => NEW.shortage_restock_movement_id,
+      p_source_transfer_item_id => NEW.id,
+      p_source_kind             => 'shortage',
+      p_source_reason           => v_source_reason,
+      p_qty                     => v_mov.quantity,
+      p_operator_id             => v_operator_id,
+      p_auto_flag               => v_auto_flag
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ⛔ 安全：不開放給任何前端角色
+REVOKE ALL ON FUNCTION public._hq_return_source_on_ti() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._hq_return_source_on_ti() FROM anon;
+REVOKE ALL ON FUNCTION public._hq_return_source_on_ti() FROM authenticated;
+
+COMMENT ON FUNCTION public._hq_return_source_on_ti IS
+  'B段接線 trigger 函式：transfer_items 的 in_movement_id（store_return）'
+  '或 shortage_restock_movement_id（shortage）從 NULL 變非NULL 時，'
+  '驗證 movement 真實性後呼叫 _hq_hold_return 建批次＋凍結。'
+  'SECURITY DEFINER，REVOKE PUBLIC/anon/authenticated。';
+
+-- ============================================================
+-- 2. trigger 掛載
+--
+-- AFTER INSERT OR UPDATE：在 rpc_receive_transfer / rpc_resolve 已完成
+-- stock_movement 寫入與 balance 更新之後，同一交易內建批次。
+-- 不是 BEFORE（BEFORE 時 movement 還沒寫完 balance）。
+-- ============================================================
+CREATE TRIGGER trg_hq_return_source
+  AFTER INSERT OR UPDATE OF in_movement_id, shortage_restock_movement_id
+  ON public.transfer_items
+  FOR EACH ROW
+  EXECUTE FUNCTION public._hq_return_source_on_ti();
+
+COMMENT ON TRIGGER trg_hq_return_source ON public.transfer_items IS
+  'B段接線：store_return（in_movement_id）與 shortage（shortage_restock_movement_id）'
+  '真來源寫入時建 hq_return_batches 批次。同一交易內，不留時間窗。';

--- a/supabase/migrations/20260907020000_hq_return_disposition_sources.sql
+++ b/supabase/migrations/20260907020000_hq_return_disposition_sources.sql
@@ -46,8 +46,7 @@ BEGIN
   AND (TG_OP = 'INSERT' OR OLD.in_movement_id IS DISTINCT FROM NEW.in_movement_id)
   THEN
     -- 取父調撥單
-    SELECT t.tenant_id, t.transfer_type, t.dest_location, t.notes,
-           t.received_by
+    SELECT t.tenant_id, t.transfer_type, t.dest_location, t.notes
       INTO v_transfer
       FROM transfers t
      WHERE t.id = NEW.transfer_id;
@@ -57,7 +56,7 @@ BEGIN
 
       -- 驗證 movement 存在且為正向入庫
       SELECT m.id, m.tenant_id, m.location_id, m.sku_id, m.quantity,
-             m.movement_type
+             m.movement_type, m.source_doc_type, m.source_doc_id, m.operator_id
         INTO v_mov
         FROM stock_movements m
        WHERE m.id = NEW.in_movement_id;
@@ -106,15 +105,22 @@ BEGIN
           NEW.in_movement_id, v_mov.movement_type;
       END IF;
 
-      -- operator / auto_flag：全零 sentinel → system，其餘 → manual
-      v_operator_id := COALESCE(v_transfer.received_by,
-                                '00000000-0000-0000-0000-000000000000'::UUID);
+      -- movement 必須真的屬於這張 transfer；NULL 也要擋，不可當成通過
+      IF v_mov.source_doc_type IS DISTINCT FROM 'transfer'
+      OR v_mov.source_doc_id IS DISTINCT FROM NEW.transfer_id
+      THEN
+        RAISE EXCEPTION '_hq_return_source: movement % source=%/% expected transfer/%',
+          NEW.in_movement_id, v_mov.source_doc_type, v_mov.source_doc_id, NEW.transfer_id;
+      END IF;
+
+      -- transfer_items 觸發時 parent.received_by 尚未更新；操作者以來源 movement 為準
+      v_operator_id := v_mov.operator_id;
       v_auto_flag := CASE
         WHEN v_operator_id = '00000000-0000-0000-0000-000000000000'::UUID
         THEN 'system' ELSE 'manual'
       END;
 
-      -- 原因：從 transfer notes 取（[order return: 少收] 等）
+      -- 原因：只快照觸發當下父單已有 notes；不含本次收貨 p_notes
       v_source_reason := LEFT(v_transfer.notes, 200);
 
       -- 呼叫 A helper 建批次（冪等：同 source_movement_id 回傳既有 id）
@@ -147,7 +153,7 @@ BEGIN
 
     -- 驗證 movement
     SELECT m.id, m.tenant_id, m.location_id, m.sku_id, m.quantity,
-           m.movement_type
+           m.movement_type, m.source_doc_type, m.source_doc_id, m.operator_id
       INTO v_mov
       FROM stock_movements m
      WHERE m.id = NEW.shortage_restock_movement_id;
@@ -191,6 +197,15 @@ BEGIN
     IF v_mov.movement_type != 'transfer_cancel' THEN
       RAISE EXCEPTION '_hq_return_source: shortage movement % type=% expected transfer_cancel',
         NEW.shortage_restock_movement_id, v_mov.movement_type;
+    END IF;
+
+    -- movement 必須真的屬於這張 transfer；NULL 也要擋，不可當成通過
+    IF v_mov.source_doc_type IS DISTINCT FROM 'transfer'
+    OR v_mov.source_doc_id IS DISTINCT FROM NEW.transfer_id
+    THEN
+      RAISE EXCEPTION '_hq_return_source: shortage movement % source=%/% expected transfer/%',
+        NEW.shortage_restock_movement_id,
+        v_mov.source_doc_type, v_mov.source_doc_id, NEW.transfer_id;
     END IF;
 
     -- shortage 的 operator：取 rpc_resolve 傳入的 p_operator（存在 shortage_resolution_by）

--- a/supabase/migrations/20260907030000_hq_return_disposition_reversals.sql
+++ b/supabase/migrations/20260907030000_hq_return_disposition_reversals.sql
@@ -1,0 +1,1186 @@
+-- ============================================================
+-- 總倉退回貨處理 — C 原單更正／撤回保護
+-- 20260907030000_hq_return_disposition_reversals.sql
+--
+-- 不重抄三支既有大 RPC；共同卡在：
+--   1. stock_movements 真 reversal 寫入前
+--   2. transfer_items 來源欄位／數量被改寫前
+--   3. return_to_hq 單頭月份或狀態被改寫前
+--   4. 真正最新版月結生成器開始判斷／計價前
+-- ============================================================
+
+-- 撤回軌跡直接連到 append-only stock_movements。BEFORE hook 先原子撤批，
+-- reversal row 落表後再由 AFTER hook 補 FK，避免依賴 deferred FK 時序。
+ALTER TABLE public.hq_return_batches
+  ADD COLUMN revoked_by_movement_id BIGINT,
+  ADD COLUMN revoked_by UUID,
+  ADD COLUMN revoked_at TIMESTAMPTZ,
+  ADD COLUMN revoke_reason TEXT,
+  ADD CONSTRAINT uq_hq_return_batch_revoke_movement UNIQUE (revoked_by_movement_id),
+  ADD CONSTRAINT fk_hq_return_batch_revoke_movement
+    FOREIGN KEY (revoked_by_movement_id)
+    REFERENCES public.stock_movements(id),
+  ADD CONSTRAINT chk_hq_return_batch_revoke_evidence CHECK (
+    (status = 'revoked') =
+    (revoked_by IS NOT NULL
+     AND revoked_at IS NOT NULL
+     AND revoke_reason IS NOT NULL)
+    AND (revoked_by_movement_id IS NULL OR status = 'revoked')
+  ) NOT VALID;
+
+COMMENT ON COLUMN public.hq_return_batches.revoked_by_movement_id IS
+  '真正沖銷 source_movement_id 的 append-only reversal movement；C hook 寫入';
+COMMENT ON COLUMN public.hq_return_batches.revoked_by IS
+  '撤回操作者，取真正 reversal movement.operator_id';
+COMMENT ON COLUMN public.hq_return_batches.revoked_at IS
+  'C hook 實際撤回時間';
+COMMENT ON COLUMN public.hq_return_batches.revoke_reason IS
+  '真正 reversal movement.reason 的不可空快照';
+
+ALTER TABLE public.store_monthly_settlement_items
+  ALTER COLUMN unit_cost DROP NOT NULL,
+  ALTER COLUMN line_amount DROP NOT NULL;
+
+-- ============================================================
+-- 1. 月鎖 primitive
+--
+-- return_to_hq 的金額月份＝來源店＋received_at 台北月份。
+-- C 新增 settlement advisory lock，並在本檔末讓真正最新版月結生成器
+-- 共用；再鎖該店該月 row，避免「檢查時尚無 row、另一邊同時建帳」。
+-- ============================================================
+CREATE OR REPLACE FUNCTION public._hq_assert_return_month_open(
+  p_tenant_id       UUID,
+  p_source_location BIGINT,
+  p_received_at     TIMESTAMPTZ
+) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_month       DATE;
+  v_store_id    BIGINT;
+  v_store_name  TEXT;
+  v_status      TEXT;
+BEGIN
+  IF p_received_at IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT s.id, s.name
+    INTO v_store_id, v_store_name
+    FROM public.stores s
+   WHERE s.tenant_id = p_tenant_id
+     AND s.location_id = p_source_location
+   ORDER BY s.id
+   LIMIT 1;
+
+  IF v_store_id IS NULL THEN
+    RAISE EXCEPTION '_hq_return_month: source location % is not a store of tenant %',
+      p_source_location, p_tenant_id;
+  END IF;
+
+  v_month := DATE_TRUNC('month', p_received_at AT TIME ZONE 'Asia/Taipei')::DATE;
+  -- 舊撤收 RPC 在進入本 helper 前可能已鎖 balance。不可在此等待月份鎖，
+  -- 否則多品項撤收會形成 balance→month／month→balance 的死鎖環；忙碌時
+  -- 立即拒絕並讓外層整筆 rollback，生成器則使用同 key 的 blocking lock。
+  IF NOT pg_try_advisory_xact_lock(
+    hashtext('settlement:' || p_tenant_id::TEXT || ':' || v_month::TEXT)
+  ) THEN
+    RAISE EXCEPTION '該月份正在產生或更正對帳單，這次退貨操作未執行，請稍後重試';
+  END IF;
+
+  SELECT sms.status
+    INTO v_status
+    FROM public.store_monthly_settlements sms
+   WHERE sms.tenant_id = p_tenant_id
+     AND sms.store_id = v_store_id
+     AND sms.settlement_month = v_month
+   FOR UPDATE;
+
+  IF v_status IN ('confirmed','settled','remitted') THEN
+    RAISE EXCEPTION '退貨／短收沖帳落在已鎖定月份：% %（%）。不能自動更正或撤回，請人工對帳。',
+      v_store_name, TO_CHAR(v_month, 'YYYY-MM'), v_status;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._hq_assert_return_month_open(UUID, BIGINT, TIMESTAMPTZ) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._hq_assert_return_month_open(UUID, BIGINT, TIMESTAMPTZ) FROM anon;
+REVOKE ALL ON FUNCTION public._hq_assert_return_month_open(UUID, BIGINT, TIMESTAMPTZ) FROM authenticated;
+
+-- ============================================================
+-- 2. 共同 reversal hook
+--
+-- trigger 名稱刻意排在 trg_guard_hq_pending 前：先把完整 pending 批次撤回、
+-- 釋放 reserved，A 的負異動 guard 才能用撤回後的 pending 驗這筆負數。
+-- ============================================================
+CREATE OR REPLACE FUNCTION public._hq_revoke_return_on_reversal()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_orig             public.stock_movements%ROWTYPE;
+  v_batch            public.hq_return_batches%ROWTYPE;
+  v_item             public.transfer_items%ROWTYPE;
+  v_transfer         public.transfers%ROWTYPE;
+  v_credit           public.transfers%ROWTYPE;
+  v_balance_reserved NUMERIC;
+  v_total_pending    NUMERIC;
+  v_auth_uid         UUID;
+  v_claim_tenant     UUID;
+BEGIN
+  IF NEW.reverses IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO v_orig
+    FROM public.stock_movements
+   WHERE id = NEW.reverses;
+
+  IF NOT FOUND THEN
+    RETURN NEW; -- 原 FK 會給一致的不存在錯誤；C 不接管無批次的歷史路徑。
+  END IF;
+
+  -- A 處理破損／遺失所產生的負 movement 不可再私自反向；目前沒有
+  -- event reversal 財務流程，必須保留 append-only 證據後人工盤點／對帳。
+  IF v_orig.source_doc_type = 'hq_return_batch'
+     AND EXISTS (
+       SELECT 1 FROM public.hq_return_batches b
+        WHERE b.id = v_orig.source_doc_id
+     ) THEN
+    RAISE EXCEPTION '已處理的總倉退回貨異動 % 不能直接反向；請走人工盤點與對帳',
+      v_orig.id;
+  END IF;
+
+  SELECT * INTO v_batch
+    FROM public.hq_return_batches
+   WHERE source_movement_id = v_orig.id;
+
+  IF NOT FOUND THEN
+    RETURN NEW; -- 其他既有 reversal 完全沿用原行為。
+  END IF;
+
+  SELECT * INTO v_item
+    FROM public.transfer_items
+   WHERE id = v_batch.source_transfer_item_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '_hq_return_reversal: source item % not found',
+      v_batch.source_transfer_item_id;
+  END IF;
+
+  SELECT * INTO v_transfer
+    FROM public.transfers
+   WHERE id = v_item.transfer_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '_hq_return_reversal: source transfer % not found', v_item.transfer_id;
+  END IF;
+
+  -- 真撤回一律需要可歸責的真人 JWT，不把「缺 JWT」當成 service 特權。
+  -- 自動接貨是正向 movement（NEW.reverses IS NULL），在上方已直接放行。
+  v_auth_uid := auth.uid();
+  IF v_auth_uid IS NULL THEN
+    RAISE EXCEPTION '_hq_return_reversal: authenticated operator is required';
+  END IF;
+  IF NEW.operator_id IS DISTINCT FROM v_auth_uid THEN
+    RAISE EXCEPTION '_hq_return_reversal: operator must equal auth.uid()';
+  END IF;
+  v_claim_tenant := public._current_tenant_id();
+  IF v_claim_tenant IS DISTINCT FROM v_batch.tenant_id THEN
+    RAISE EXCEPTION '_hq_return_reversal: batch not in current tenant';
+  END IF;
+
+  -- reversal 本身與原 movement、batch、item、父單必須逐項相符。
+  IF NEW.movement_type IS DISTINCT FROM 'reversal'
+  OR NEW.quantity IS DISTINCT FROM -v_orig.quantity
+  OR NEW.tenant_id IS DISTINCT FROM v_orig.tenant_id
+  OR NEW.location_id IS DISTINCT FROM v_orig.location_id
+  OR NEW.sku_id IS DISTINCT FROM v_orig.sku_id
+  OR NEW.unit_cost IS DISTINCT FROM v_orig.unit_cost
+  OR NEW.source_doc_type IS DISTINCT FROM 'transfer'
+  OR NEW.source_doc_id IS DISTINCT FROM v_transfer.id
+  OR NEW.source_doc_line_id IS DISTINCT FROM v_item.id
+  OR NULLIF(BTRIM(NEW.reason), '') IS NULL THEN
+    RAISE EXCEPTION '_hq_return_reversal: movement does not exactly reverse source %', v_orig.id;
+  END IF;
+
+  IF v_orig.quantity <= 0
+  OR v_orig.source_doc_type IS DISTINCT FROM 'transfer'
+  OR v_orig.source_doc_id IS DISTINCT FROM v_transfer.id
+  OR (v_orig.source_doc_line_id IS NOT NULL
+      AND v_orig.source_doc_line_id IS DISTINCT FROM v_item.id)
+  OR v_orig.tenant_id IS DISTINCT FROM v_batch.tenant_id
+  OR v_orig.location_id IS DISTINCT FROM v_batch.location_id
+  OR v_orig.sku_id IS DISTINCT FROM v_batch.sku_id
+  OR v_orig.quantity IS DISTINCT FROM v_batch.total_qty
+  OR v_item.sku_id IS DISTINCT FROM v_batch.sku_id
+  OR v_transfer.tenant_id IS DISTINCT FROM v_batch.tenant_id THEN
+    RAISE EXCEPTION '_hq_return_reversal: source movement/batch/item chain is inconsistent';
+  END IF;
+
+  IF v_batch.source_kind = 'store_return' THEN
+    IF v_orig.movement_type IS DISTINCT FROM 'transfer_in'
+    OR v_transfer.transfer_type IS DISTINCT FROM 'return_to_hq'
+    OR v_transfer.dest_location IS DISTINCT FROM v_batch.location_id
+    OR v_item.in_movement_id IS DISTINCT FROM v_orig.id
+    OR v_item.qty_received IS DISTINCT FROM v_orig.quantity THEN
+      RAISE EXCEPTION '_hq_return_reversal: store-return source is no longer current';
+    END IF;
+
+    -- 真退貨原單自己的月份（舊 RPC 只查短收 credit 子單，這裡補齊）。
+    PERFORM public._hq_assert_return_month_open(
+      v_transfer.tenant_id, v_transfer.source_location, v_transfer.received_at
+    );
+  ELSE
+    IF v_batch.source_kind IS DISTINCT FROM 'shortage'
+    OR v_orig.movement_type IS DISTINCT FROM 'transfer_cancel'
+    OR v_transfer.transfer_type IS DISTINCT FROM 'hq_to_store'
+    OR v_transfer.source_location IS DISTINCT FROM v_batch.location_id
+    OR v_item.shortage_restock_movement_id IS DISTINCT FROM v_orig.id THEN
+      RAISE EXCEPTION '_hq_return_reversal: shortage source is no longer current';
+    END IF;
+
+    -- 短收回帳的錢落在純記帳 return_to_hq 子單月份。
+    IF v_item.shortage_return_transfer_id IS NOT NULL THEN
+      SELECT * INTO v_credit
+        FROM public.transfers
+       WHERE id = v_item.shortage_return_transfer_id;
+      IF NOT FOUND OR v_credit.transfer_type IS DISTINCT FROM 'return_to_hq' THEN
+        RAISE EXCEPTION '_hq_return_reversal: shortage credit transfer is invalid';
+      END IF;
+      PERFORM public._hq_assert_return_month_open(
+        v_credit.tenant_id, v_credit.source_location, v_credit.received_at
+      );
+    END IF;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.stock_movements r WHERE r.reverses = v_orig.id
+  ) THEN
+    RAISE EXCEPTION '_hq_return_reversal: source movement % was already reversed', v_orig.id;
+  END IF;
+
+  -- A 的共同鎖序：balance → batch。鎖後重讀 batch，避免同時處理／撤回。
+  INSERT INTO public.stock_balances (tenant_id, location_id, sku_id)
+  VALUES (v_batch.tenant_id, v_batch.location_id, v_batch.sku_id)
+  ON CONFLICT (tenant_id, location_id, sku_id) DO NOTHING;
+
+  SELECT reserved INTO v_balance_reserved
+    FROM public.stock_balances
+   WHERE tenant_id = v_batch.tenant_id
+     AND location_id = v_batch.location_id
+     AND sku_id = v_batch.sku_id
+   FOR UPDATE;
+
+  SELECT * INTO v_batch
+    FROM public.hq_return_batches
+   WHERE source_movement_id = v_orig.id
+   FOR UPDATE;
+
+  IF v_batch.status IS DISTINCT FROM 'pending'
+  OR v_batch.qty_good <> 0
+  OR v_batch.qty_damaged <> 0
+  OR v_batch.qty_lost <> 0
+  OR v_batch.qty_revoked <> 0
+  OR EXISTS (
+    SELECT 1 FROM public.hq_return_events e WHERE e.batch_id = v_batch.id
+  ) THEN
+    RAISE EXCEPTION '總倉退回貨批次 % 已開始處理，不能局部撤回；本次原單操作已整筆取消',
+      v_batch.id;
+  END IF;
+
+  SELECT COALESCE(SUM(
+           total_qty - qty_good - qty_damaged - qty_lost - qty_revoked
+         ), 0)
+    INTO v_total_pending
+    FROM public.hq_return_batches
+   WHERE tenant_id = v_batch.tenant_id
+     AND location_id = v_batch.location_id
+     AND sku_id = v_batch.sku_id
+     AND status IN ('pending','partial');
+
+  IF COALESCE(v_balance_reserved, 0) < v_total_pending THEN
+    RAISE EXCEPTION '_hq_return_reversal: reserved % is below all pending return qty %',
+      COALESCE(v_balance_reserved, 0), v_total_pending;
+  END IF;
+
+  UPDATE public.stock_balances
+     SET reserved = reserved - v_batch.total_qty,
+         version = version + 1,
+         updated_at = NOW()
+   WHERE tenant_id = v_batch.tenant_id
+     AND location_id = v_batch.location_id
+     AND sku_id = v_batch.sku_id;
+
+  UPDATE public.hq_return_batches
+     SET qty_revoked = total_qty,
+         status = 'revoked',
+         revoked_by = NEW.operator_id,
+         revoked_at = NOW(),
+         revoke_reason = BTRIM(NEW.reason),
+         updated_at = NOW()
+   WHERE id = v_batch.id;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._hq_revoke_return_on_reversal() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._hq_revoke_return_on_reversal() FROM anon;
+REVOKE ALL ON FUNCTION public._hq_revoke_return_on_reversal() FROM authenticated;
+
+CREATE TRIGGER trg_00_hq_return_reversal
+  BEFORE INSERT ON public.stock_movements
+  FOR EACH ROW EXECUTE FUNCTION public._hq_revoke_return_on_reversal();
+
+CREATE OR REPLACE FUNCTION public._hq_link_return_reversal()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_batch public.hq_return_batches%ROWTYPE;
+BEGIN
+  IF NEW.reverses IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO v_batch
+    FROM public.hq_return_batches
+   WHERE source_movement_id = NEW.reverses
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN NEW;
+  END IF;
+
+  IF v_batch.status IS DISTINCT FROM 'revoked'
+  OR v_batch.qty_revoked IS DISTINCT FROM v_batch.total_qty
+  OR v_batch.revoked_by_movement_id IS NOT NULL
+  OR v_batch.revoked_by IS DISTINCT FROM NEW.operator_id
+  OR v_batch.revoke_reason IS DISTINCT FROM BTRIM(NEW.reason) THEN
+    RAISE EXCEPTION '_hq_return_reversal: batch % revocation evidence is inconsistent', v_batch.id;
+  END IF;
+
+  UPDATE public.hq_return_batches
+     SET revoked_by_movement_id = NEW.id,
+         updated_at = NOW()
+   WHERE id = v_batch.id;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._hq_link_return_reversal() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._hq_link_return_reversal() FROM anon;
+REVOKE ALL ON FUNCTION public._hq_link_return_reversal() FROM authenticated;
+
+-- AFTER trigger 名稱排在 trg_apply_movement 後；若補證據失敗，整筆 INSERT
+-- （包含 apply_movement_to_balance 的庫存變更）仍在同一交易一起 rollback。
+CREATE TRIGGER trg_zz_hq_return_reversal_link
+  AFTER INSERT ON public.stock_movements
+  FOR EACH ROW EXECUTE FUNCTION public._hq_link_return_reversal();
+
+-- ============================================================
+-- 3. item 守門
+--
+-- 防止不寫 reversal 就清／換來源 id；同時持續核對 store return 的
+-- qty_received，以及 shortage 的 qty_shipped - qty_received。數量採 deferred
+-- final-state 檢查：整張 unreceive 會先把 qty_received 歸零，稍後才撤 shortage，
+-- 不可把同一交易中的合法暫態誤判成旁路。
+-- ============================================================
+CREATE OR REPLACE FUNCTION public._guard_hq_return_item_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_source RECORD;
+  v_batch  public.hq_return_batches%ROWTYPE;
+  v_return RECORD;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    SELECT t.tenant_id, t.source_location, t.received_at
+      INTO v_return
+      FROM public.transfers t
+     WHERE t.id = NEW.transfer_id
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed');
+    IF FOUND THEN
+      PERFORM public._hq_assert_return_month_open(
+        v_return.tenant_id, v_return.source_location, v_return.received_at
+      );
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    SELECT t.tenant_id, t.source_location, t.received_at
+      INTO v_return
+      FROM public.transfers t
+     WHERE t.id = OLD.transfer_id
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed');
+    IF FOUND THEN
+      PERFORM public._hq_assert_return_month_open(
+        v_return.tenant_id, v_return.source_location, v_return.received_at
+      );
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM public.hq_return_batches b
+       WHERE b.source_transfer_item_id = OLD.id
+    ) THEN
+      RAISE EXCEPTION 'transfer_item % 已有總倉退回貨軌跡，不能刪除', OLD.id;
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  -- return_to_hq item 會直接影響退貨月結；即使純短收 credit 子單沒有
+  -- hq_return batch，新增／刪除／改量也不能穿過月份鎖。
+  IF NEW.transfer_id IS DISTINCT FROM OLD.transfer_id
+  OR NEW.sku_id IS DISTINCT FROM OLD.sku_id
+  OR NEW.qty_shipped IS DISTINCT FROM OLD.qty_shipped
+  OR NEW.qty_received IS DISTINCT FROM OLD.qty_received THEN
+    FOR v_return IN
+      SELECT DISTINCT t.tenant_id, t.source_location, t.received_at
+        FROM public.transfers t
+       WHERE t.id IN (OLD.transfer_id, NEW.transfer_id)
+         AND t.transfer_type = 'return_to_hq'
+         AND t.status IN ('received','closed')
+         AND t.received_at IS NOT NULL
+       ORDER BY t.received_at, t.tenant_id, t.source_location
+    LOOP
+      PERFORM public._hq_assert_return_month_open(
+        v_return.tenant_id, v_return.source_location, v_return.received_at
+      );
+    END LOOP;
+  END IF;
+
+  -- item/父單/SKU 是永久來源鏈；即使批次已撤回也不可改寫歷史歸屬。
+  IF (NEW.id IS DISTINCT FROM OLD.id
+      OR NEW.transfer_id IS DISTINCT FROM OLD.transfer_id
+      OR NEW.sku_id IS DISTINCT FROM OLD.sku_id)
+     AND EXISTS (
+       SELECT 1 FROM public.hq_return_batches b
+        WHERE b.source_transfer_item_id = OLD.id
+     ) THEN
+    RAISE EXCEPTION 'transfer_item % 已有總倉退回貨軌跡，不能改 item/transfer/SKU 歸屬', OLD.id;
+  END IF;
+
+  -- 舊指標若被清掉或換掉，對應 batch 必須已由「那一筆真 reversal」完整撤回。
+  FOR v_source IN
+    SELECT OLD.in_movement_id AS movement_id
+     WHERE OLD.in_movement_id IS NOT NULL
+       AND NEW.in_movement_id IS DISTINCT FROM OLD.in_movement_id
+    UNION ALL
+    SELECT OLD.shortage_restock_movement_id
+     WHERE OLD.shortage_restock_movement_id IS NOT NULL
+       AND NEW.shortage_restock_movement_id IS DISTINCT FROM OLD.shortage_restock_movement_id
+  LOOP
+    SELECT * INTO v_batch
+      FROM public.hq_return_batches
+     WHERE source_movement_id = v_source.movement_id;
+
+    IF FOUND AND (
+         v_batch.status IS DISTINCT FROM 'revoked'
+      OR v_batch.qty_revoked IS DISTINCT FROM v_batch.total_qty
+      OR v_batch.revoked_by_movement_id IS NULL
+      OR NOT EXISTS (
+        SELECT 1
+          FROM public.stock_movements r
+         WHERE r.id = v_batch.revoked_by_movement_id
+           AND r.reverses = v_source.movement_id
+           AND r.quantity = -v_batch.total_qty
+           AND r.movement_type = 'reversal'
+      )
+    ) THEN
+      RAISE EXCEPTION '來源 movement % 尚未真實完整沖銷，不能清除或替換 item 指標',
+        v_source.movement_id;
+    END IF;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._guard_hq_return_item_mutation() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._guard_hq_return_item_mutation() FROM anon;
+REVOKE ALL ON FUNCTION public._guard_hq_return_item_mutation() FROM authenticated;
+
+CREATE TRIGGER trg_00_guard_hq_return_item_write
+  BEFORE INSERT OR UPDATE ON public.transfer_items
+  FOR EACH ROW EXECUTE FUNCTION public._guard_hq_return_item_mutation();
+
+CREATE TRIGGER trg_00_guard_hq_return_item_delete
+  BEFORE DELETE ON public.transfer_items
+  FOR EACH ROW EXECUTE FUNCTION public._guard_hq_return_item_mutation();
+
+CREATE OR REPLACE FUNCTION public._assert_hq_return_item_sources_current()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_item  public.transfer_items%ROWTYPE;
+  v_batch public.hq_return_batches%ROWTYPE;
+BEGIN
+  -- Constraint trigger 可能在同一 item 的後續 UPDATE 之後才執行，必須讀
+  -- 當下最終 row，不能使用較早事件攜帶的 NEW 快照。
+  SELECT * INTO v_item
+    FROM public.transfer_items
+   WHERE id = NEW.id;
+  IF NOT FOUND THEN
+    RETURN NULL; -- DELETE 已由 BEFORE guard 另行保護。
+  END IF;
+
+  FOR v_batch IN
+    SELECT b.*
+      FROM public.hq_return_batches b
+     WHERE b.source_transfer_item_id = v_item.id
+  LOOP
+    IF v_batch.source_kind = 'store_return'
+       AND v_item.in_movement_id IS NOT DISTINCT FROM v_batch.source_movement_id
+       AND v_item.qty_received IS DISTINCT FROM v_batch.total_qty THEN
+      RAISE EXCEPTION 'store return item % 的 qty_received 與來源批次不一致；請用完整實收更正流程', v_item.id;
+    END IF;
+
+    IF v_batch.source_kind = 'shortage'
+       AND v_item.shortage_restock_movement_id IS NOT DISTINCT FROM v_batch.source_movement_id
+       AND (v_item.qty_shipped - v_item.qty_received) IS DISTINCT FROM v_batch.total_qty THEN
+      RAISE EXCEPTION 'shortage item % 的 qty_shipped/qty_received 與來源批次不一致；請先完整撤銷短少處理', v_item.id;
+    END IF;
+  END LOOP;
+
+  RETURN NULL;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._assert_hq_return_item_sources_current() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._assert_hq_return_item_sources_current() FROM anon;
+REVOKE ALL ON FUNCTION public._assert_hq_return_item_sources_current() FROM authenticated;
+
+CREATE CONSTRAINT TRIGGER trg_assert_hq_return_item_sources_current
+  AFTER INSERT OR UPDATE ON public.transfer_items
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION public._assert_hq_return_item_sources_current();
+
+-- ============================================================
+-- 4. header 守門
+--
+-- 同時驗 OLD/NEW 的來源店與台北月份。短收純記帳子單沒有 batch，仍由
+-- shortage_return_transfer_id 關係辨認。真正退貨尚有 active batch 時，
+-- 不能跳過 reversal 直接離開 received/closed。
+-- ============================================================
+CREATE OR REPLACE FUNCTION public._guard_hq_return_transfer_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_has_batch  BOOLEAN;
+  v_has_active BOOLEAN;
+  v_is_credit  BOOLEAN;
+  v_guard      RECORD;
+BEGIN
+  SELECT EXISTS (
+           SELECT 1
+             FROM public.transfer_items ti
+             JOIN public.hq_return_batches b ON b.source_transfer_item_id = ti.id
+            WHERE ti.transfer_id = OLD.id
+         ),
+         EXISTS (
+           SELECT 1
+             FROM public.transfer_items ti
+             JOIN public.hq_return_batches b ON b.source_transfer_item_id = ti.id
+            WHERE ti.transfer_id = OLD.id
+              AND b.status IN ('pending','partial')
+         ),
+         EXISTS (
+           SELECT 1 FROM public.transfer_items ti
+            WHERE ti.shortage_return_transfer_id = OLD.id
+         )
+    INTO v_has_batch, v_has_active, v_is_credit;
+
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.transfer_type = 'return_to_hq'
+       AND (OLD.status IN ('received','closed') OR v_has_batch OR v_is_credit) THEN
+      PERFORM public._hq_assert_return_month_open(
+        OLD.tenant_id, OLD.source_location, OLD.received_at
+      );
+    END IF;
+    IF v_has_batch THEN
+      RAISE EXCEPTION 'return transfer % 已有總倉退回貨軌跡，不能刪除', OLD.id;
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF v_has_batch AND (
+       NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+    OR NEW.transfer_type IS DISTINCT FROM OLD.transfer_type
+    OR NEW.source_location IS DISTINCT FROM OLD.source_location
+    OR NEW.dest_location IS DISTINCT FROM OLD.dest_location
+  ) THEN
+    RAISE EXCEPTION 'return transfer % 已有總倉退回貨軌跡，不能改 tenant/type/location', OLD.id;
+  END IF;
+
+  IF v_has_active
+     AND OLD.status IN ('received','closed')
+     AND NEW.status NOT IN ('received','closed') THEN
+    RAISE EXCEPTION 'return transfer % 仍有未處理退回貨，必須先由真 reversal 完整撤回', OLD.id;
+  END IF;
+
+  IF v_has_active AND NEW.status IN ('received','closed') AND NEW.received_at IS NULL THEN
+    RAISE EXCEPTION 'return transfer % 有未處理退回貨，received_at 不可清空', OLD.id;
+  END IF;
+
+  -- 排序後依序鎖 OLD/NEW 可能涉及的月份，避免跨月互換產生反向鎖序。
+  FOR v_guard IN
+    SELECT DISTINCT x.tenant_id, x.source_location, x.received_at
+      FROM (VALUES
+        (OLD.tenant_id, OLD.source_location, OLD.received_at,
+         OLD.transfer_type, OLD.status),
+        (NEW.tenant_id, NEW.source_location, NEW.received_at,
+         NEW.transfer_type, NEW.status)
+      ) AS x(tenant_id, source_location, received_at, transfer_type, status)
+     WHERE x.transfer_type = 'return_to_hq'
+       AND x.received_at IS NOT NULL
+       AND (x.status IN ('received','closed') OR v_has_batch OR v_is_credit)
+     ORDER BY x.received_at, x.tenant_id, x.source_location
+  LOOP
+    PERFORM public._hq_assert_return_month_open(
+      v_guard.tenant_id, v_guard.source_location, v_guard.received_at
+    );
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._guard_hq_return_transfer_mutation() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._guard_hq_return_transfer_mutation() FROM anon;
+REVOKE ALL ON FUNCTION public._guard_hq_return_transfer_mutation() FROM authenticated;
+
+CREATE TRIGGER trg_00_guard_hq_return_transfer_update
+  BEFORE UPDATE OF tenant_id, transfer_type, source_location, dest_location, status, received_at
+  ON public.transfers
+  FOR EACH ROW EXECUTE FUNCTION public._guard_hq_return_transfer_mutation();
+
+CREATE TRIGGER trg_00_guard_hq_return_transfer_delete
+  BEFORE DELETE ON public.transfers
+  FOR EACH ROW EXECUTE FUNCTION public._guard_hq_return_transfer_mutation();
+
+COMMENT ON FUNCTION public._hq_revoke_return_on_reversal() IS
+  'C共同撤回 hook：真 reversal 才能原子撤回未處理 batch、釋放 reserved；partial/completed 拒絕。'
+  '先驗 return/shortage 月鎖，並拒絕反向 A 已產生的處理負異動。';
+COMMENT ON FUNCTION public._hq_link_return_reversal() IS
+  'C AFTER hook：真正 reversal row 落表後，把 immutable movement id 補回已撤 batch；失敗整筆 rollback。';
+COMMENT ON FUNCTION public._guard_hq_return_item_mutation() IS
+  'C item 守門：來源 id 必須先真 reversal；不可刪除或改寫來源歸屬。';
+COMMENT ON FUNCTION public._assert_hq_return_item_sources_current() IS
+  'C deferred item 守門：交易最終狀態仍掛來源 movement 時，qty_received 與 shortage 的 qty_shipped-qty_received 必須一致。';
+COMMENT ON FUNCTION public._guard_hq_return_transfer_mutation() IS
+  'C header 守門：return_to_hq OLD/NEW 台北月份均驗月鎖；active batch 不可直接取消或撤回。';
+
+-- ============================================================
+-- 5. 月結生成器共用同一把 tenant/month lock
+--
+-- 真正最後 CREATE 原樣取自 20260901000000_settlement_dispatch_basis.sql:74。
+-- 唯一行為差異：取得 tenant 後、任何鎖定判斷／金額讀取前拿 C 同 key。
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.rpc_generate_hq_to_store_settlement(
+  p_month date,
+  p_operator uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $fn$
+
+DECLARE
+  v_tenant         UUID;
+  v_month_start    DATE := DATE_TRUNC('month', p_month)::DATE;
+  v_month_end      DATE := (DATE_TRUNC('month', p_month) + INTERVAL '1 month')::DATE;
+  -- 月界（台北時區）：[該月1號00:00, 次月1號00:00) Asia/Taipei。
+  -- ⚠ 拿來比對的欄位**每一段不一樣**（2026-09-01 起）：
+  --   hq_inbound      → shipped_at（總倉派車日；本次改動）
+  --   air_in/air_out  → v_store_aid_transfer_legs.booked_at（＝轉出店 shipped_at，2026-08-25 起）
+  --   free_*/return_* → received_at（維持收貨日，刻意沒動）
+  v_range_start    TIMESTAMPTZ := v_month_start::TIMESTAMP AT TIME ZONE 'Asia/Taipei';
+  v_range_end      TIMESTAMPTZ := v_month_end::TIMESTAMP AT TIME ZONE 'Asia/Taipei';
+  v_store          RECORD;
+  v_settlement_id  BIGINT;
+  v_hq_inbound     NUMERIC(18,4);
+  v_air_in         NUMERIC(18,4);
+  v_air_out        NUMERIC(18,4);
+  v_free_in        NUMERIC(18,4);
+  v_free_out       NUMERIC(18,4);
+  v_return_out     NUMERIC(18,4);
+  v_hq_inbound_b   NUMERIC(18,4);  -- 分店價口徑
+  v_air_in_b       NUMERIC(18,4);
+  v_air_out_b      NUMERIC(18,4);
+  v_return_out_b   NUMERIC(18,4);
+  v_adjust         NUMERIC(18,4);  -- 人工調整（active 合計）
+  v_cost_total     NUMERIC(18,4);
+  v_branch_total   NUMERIC(18,4);
+  v_payable        NUMERIC(18,4);
+  v_xfer_count     INTEGER;
+  v_item_count     INTEGER;
+  v_total_stores   INTEGER := 0;
+  v_total_amount   NUMERIC(18,4) := 0;
+  v_total_cost     NUMERIC(18,4) := 0;
+  v_total_branch   NUMERIC(18,4) := 0;
+  v_total_adjust   NUMERIC(18,4) := 0;
+BEGIN
+  -- ⛔ 8 月以前一律擋在資料庫這一層（老闆 2026-08-31 裁示「8 月不進系統」）。
+  --
+  -- 為什麼要擋在這裡而不是只擋前端：這支是 SECURITY DEFINER RPC，
+  -- 任何登入帳號都叫得動（下面有 GRANT ... TO authenticated），
+  -- 前端月份選擇器擋不住直接打 API 的人，也擋不住下面那個內部呼叫者。
+  --
+  -- ⚠️ **這是故意的副作用，不是漏想**：從此 7 月、8 月**再也不能重產**。
+  --   要動舊月份，先貼回滾檔回到 8/25 版，跑完再貼回來。
+  -- ⚠️ **會連帶擋掉一條既有功能**：rpc_update_free_transfer_amount
+  --   （最新版 20260807000000:517）改完估價會 PERFORM 這支重跑該月 ——
+  --   若那筆自由轉貨是 8 月以前收貨的，**整個估價修改會失敗**（不是只跳過重算）。
+  --   這是刻意選的方向：讓它「大聲失敗」，好過讓它把舊月份用新制重算掉。
+  --   要改成「舊月份就跳過重算、估價照改」是另一支 migration 的事。
+  IF v_month_start < DATE '2026-09-01' THEN
+    RAISE EXCEPTION '月結從 2026 年 9 月起改用「派車就算錢」的新算法；% 月以及更早的月份已經凍結，不能再重新產生（老闆 2026-08-31 決定：8 月以前用系統外的對帳單處理）。真的要重算舊月份，請先請工程師把系統換回 8 月 25 日的版本。',
+      to_char(v_month_start, 'YYYY-MM');
+  END IF;
+
+  SELECT tenant_id INTO v_tenant FROM stores LIMIT 1;
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'no stores found, cannot infer tenant_id';
+  END IF;
+
+  -- C：與退貨更正／撤回共用 tenant＋month transaction lock。
+  -- 必須早於任何 locked-status 判斷與金額來源讀取。
+  PERFORM pg_advisory_xact_lock(
+    hashtext('settlement:' || v_tenant::TEXT || ':' || v_month_start::TEXT)
+  );
+
+  FOR v_store IN
+    SELECT s.id, s.code, s.name, s.location_id
+      FROM stores s
+     WHERE s.tenant_id = v_tenant
+       AND s.location_id IS NOT NULL
+  LOOP
+    -- 跳過已鎖定/結案/作廢（confirmed 起不再重算；cancelled 舊版會 NULL crash，一併跳過）
+    IF EXISTS (
+      SELECT 1 FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status IN ('confirmed','settled','remitted','cancelled')
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    -- A) hq_inbound: 總倉派給店家（成本口徑 + 分店價口徑）
+    -- 記帳時點＝**總倉派車出貨當下**（老闆 2026-08-31：「錢在總倉派出去那一刻就算」）。
+    -- 數量＝MAX(派出量, 實收量)：超收的店照實收收（不會少收）、
+    -- 未收／短收的照派出量收（店家不按收貨不再等於不用付錢）。
+    -- 狀態白名單加 'shipped'：照 20260825030000:82 的樣板 ——
+    --   ⚠ 作廢單（cancelled）身上**是帶著 shipped_at 的**，靠這串白名單擋掉，
+    --     不是靠時窗擋。⛔ 不可以改寫成 status <> 'draft' 之類的黑名單。
+    SELECT
+      COALESCE(SUM(GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) * COALESCE(sm.unit_cost, 0)), 0),
+      COALESCE(SUM(GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.shipped_at), 0)), 0)
+      INTO v_hq_inbound, v_hq_inbound_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('shipped','received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.shipped_at >= v_range_start
+       AND t.shipped_at < v_range_end
+       AND GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) > 0
+       -- 經總倉互助的 Leg-2 不算 hq_inbound：那批貨是別家店給的，已經在
+       -- Leg-1 出貨當下由 air_in/air_out 兩邊媒合入帳（20260825030000）
+       AND NOT EXISTS (
+             SELECT 1 FROM transfers t1
+              WHERE t1.next_transfer_id = t.id
+                AND t1.transfer_type = 'store_to_store'
+                AND t1.status <> 'cancelled');
+
+    -- B) air_in: 店↔店轉貨收進來（該店是收貨店）
+    -- 記帳時點＝**轉出店出貨當下**（老闆 2026-08-25：「轉出店一轉出這筆帳就
+    -- 成立，兩邊就媒合完成」）→ 走 v_store_aid_transfer_legs，它已把經總倉的
+    -- Leg-1 對到 Leg-2 的收貨店，兩邊同一時點、同一金額。
+    SELECT
+      COALESCE(SUM(l.qty * l.unit_cost), 0),
+      COALESCE(SUM(l.qty * COALESCE(public._branch_price_at(v_tenant, l.sku_id, l.booked_at), 0)), 0)
+      INTO v_air_in, v_air_in_b
+      FROM public.v_store_aid_transfer_legs l
+     WHERE l.tenant_id = v_tenant
+       AND l.dst_location = v_store.location_id
+       AND l.booked_at >= v_range_start
+       AND l.booked_at < v_range_end;
+
+    -- C) air_out: 店↔店轉貨送出去（該店是轉出店）—— 同 B 的時點與母體，只是
+    -- 站在轉出店那一側（貸記）。經總倉的提供店以前掉進 free_out、用「估價」計價，
+    -- 而真商品沒有估價 → 一律 0，兩邊的帳從來沒鏡像過。本次修正。
+    SELECT
+      COALESCE(SUM(l.qty * l.unit_cost), 0),
+      COALESCE(SUM(l.qty * COALESCE(public._branch_price_at(v_tenant, l.sku_id, l.booked_at), 0)), 0)
+      INTO v_air_out, v_air_out_b
+      FROM public.v_store_aid_transfer_legs l
+     WHERE l.tenant_id = v_tenant
+       AND l.src_location = v_store.location_id
+       AND l.booked_at >= v_range_start
+       AND l.booked_at < v_range_end;
+
+    -- D) free_in: 自由轉貨收進來（估價入帳、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_in
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       -- 經總倉互助的 Leg-1 不是自由轉貨：它有真商品、沒有估價，留在這裡等於
+       -- 計價 0（20260825030000 起改由 air_out 以成本／分店價入帳）
+       AND t.next_transfer_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out: 自由轉貨送出去（估價入帳、貸記、兩口徑同額）
+    SELECT
+      COALESCE(SUM(COALESCE(ti.estimated_amount, 0)), 0)
+      INTO v_free_out
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       -- 經總倉互助的 Leg-1 不是自由轉貨：它有真商品、沒有估價，留在這裡等於
+       -- 計價 0（20260825030000 起改由 air_out 以成本／分店價入帳）
+       AND t.next_transfer_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out: 退貨回總倉（成本沖回 + 分店價沖回）
+    SELECT
+      COALESCE(SUM(ti.qty_received * sm.unit_cost), 0),
+      COALESCE(SUM(ti.qty_received * COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0)), 0)
+      INTO v_return_out, v_return_out_b
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    -- G) 人工調整（active 合計；只進 payable，不動貨款兩口徑）
+    SELECT COALESCE(SUM(a.amount), 0)
+      INTO v_adjust
+      FROM store_settlement_adjustments a
+     WHERE a.tenant_id = v_tenant
+       AND a.settlement_month = v_month_start
+       AND a.store_id = v_store.id
+       AND a.status = 'active';
+
+    v_cost_total   := v_hq_inbound   + v_air_in   - v_air_out   + v_free_in - v_free_out - v_return_out;
+    v_branch_total := v_hq_inbound_b + v_air_in_b - v_air_out_b + v_free_in - v_free_out - v_return_out_b;
+    -- 賣斷制：總倉出給分店、跟分店收「分店價」；成本口徑僅供總倉毛利參考
+    v_payable      := v_branch_total + v_adjust;
+
+    -- 沒任何活動就 skip + 砍 draft（兩口徑皆 0 且無 active 調整才算無活動；
+    -- 只砍 draft，sent/disputed 已進流程不自動刪）
+    IF v_hq_inbound = 0 AND v_air_in = 0 AND v_air_out = 0
+       AND v_free_in = 0 AND v_free_out = 0 AND v_return_out = 0
+       AND v_hq_inbound_b = 0 AND v_air_in_b = 0 AND v_air_out_b = 0
+       AND v_return_out_b = 0 AND v_adjust = 0 THEN
+      DELETE FROM store_monthly_settlements
+       WHERE tenant_id = v_tenant
+         AND settlement_month = v_month_start
+         AND store_id = v_store.id
+         AND status = 'draft';
+      CONTINUE;
+    END IF;
+
+    -- 計 transfer_count + item_count
+    -- 張數／筆數要跟上面的分錄同母體。分錄現在有三種時點，所以這裡拆三段：
+    --   1) hq_to_store           → 派車時點（2026-09-01 起，條件與 A 段逐條相同）
+    --   2) 自由轉貨／退貨回總倉  → 收貨時點（未改）
+    --   3) 店↔店訂單相關腿       → 轉出時點（20260825030000，未改）
+    -- ⚠ 第 1 段是**跟著 A 段一起改的**，不是順手改的：
+    --   不改的話，「派了但店家從沒按收貨」那批（正是本案要處理的主要對象）
+    --   會算出 payable_amount 幾萬元、transfer_count 卻是 0，
+    --   而下面的 A) items 明細又真的插了列 ⇒ 同一張對帳單自己打自己的臉。
+    SELECT COUNT(DISTINCT x.tid), COUNT(*)
+      INTO v_xfer_count, v_item_count
+      FROM (
+        -- 1) hq_to_store：派車時點
+        SELECT t.id AS tid, ti.id AS iid
+          FROM transfers t
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+         WHERE t.tenant_id = v_tenant
+           AND t.transfer_type = 'hq_to_store'
+           AND t.status IN ('shipped','received','closed')
+           AND t.dest_location = v_store.location_id
+           AND t.shipped_at >= v_range_start
+           AND t.shipped_at < v_range_end
+           AND GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) > 0
+           AND NOT EXISTS (SELECT 1 FROM transfers t1
+                            WHERE t1.next_transfer_id = t.id
+                              AND t1.transfer_type = 'store_to_store'
+                              AND t1.status <> 'cancelled')
+        UNION ALL
+        -- 2) 自由轉貨／退貨回總倉：收貨時點
+        SELECT t.id AS tid, ti.id AS iid
+          FROM transfers t
+          JOIN transfer_items ti ON ti.transfer_id = t.id
+         WHERE t.tenant_id = v_tenant
+           AND t.status IN ('received','closed')
+           AND t.received_at >= v_range_start
+           AND t.received_at < v_range_end
+           AND ti.qty_received > 0
+           AND (
+             (t.transfer_type = 'store_to_store' AND t.customer_order_id IS NULL
+              AND t.next_transfer_id IS NULL
+              AND (t.dest_location = v_store.location_id OR t.source_location = v_store.location_id))
+             OR
+             (t.transfer_type = 'return_to_hq' AND t.source_location = v_store.location_id)
+           )
+        UNION ALL
+        -- 3) 店↔店訂單相關腿：轉出時點
+        SELECT l.transfer_id, l.transfer_item_id
+          FROM public.v_store_aid_transfer_legs l
+         WHERE l.tenant_id = v_tenant
+           AND (l.dst_location = v_store.location_id OR l.src_location = v_store.location_id)
+           AND l.booked_at >= v_range_start
+           AND l.booked_at < v_range_end
+      ) x;
+
+    -- upsert（鎖定前狀態 draft/sent/disputed 都重算；status 本身不動）
+    INSERT INTO store_monthly_settlements (
+      tenant_id, settlement_month, store_id,
+      payable_amount, cost_amount, branch_amount, adjustment_amount,
+      transfer_count, item_count,
+      status, created_by, updated_by
+    ) VALUES (
+      v_tenant, v_month_start, v_store.id,
+      v_payable, v_cost_total, v_branch_total, v_adjust,
+      v_xfer_count, v_item_count,
+      'draft', p_operator, p_operator
+    )
+    ON CONFLICT (tenant_id, settlement_month, store_id)
+    DO UPDATE SET
+      payable_amount    = EXCLUDED.payable_amount,
+      cost_amount       = EXCLUDED.cost_amount,
+      branch_amount     = EXCLUDED.branch_amount,
+      adjustment_amount = EXCLUDED.adjustment_amount,
+      transfer_count    = EXCLUDED.transfer_count,
+      item_count        = EXCLUDED.item_count,
+      updated_by        = p_operator,
+      updated_at        = NOW()
+    WHERE store_monthly_settlements.status IN ('draft','sent','disputed')
+    RETURNING id INTO v_settlement_id;
+
+    -- 重建 items
+    DELETE FROM store_monthly_settlement_items WHERE settlement_id = v_settlement_id;
+
+    -- A) hq_inbound items（雙口徑）
+    -- ⚠ 欄位名沿用 qty_received / received_at 不改名（改名會連動前端 14 檔），
+    --   但存進去的是「這筆帳的計價數量」＝MAX(派出量,實收量) 與
+    --   「這筆帳成立的時間」＝總倉派車當下 —— 同 20260825030000:398 的處理慣例。
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)), sm.unit_cost,
+      CASE
+        WHEN sm.unit_cost IS NULL THEN NULL
+        ELSE GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) * sm.unit_cost
+      END,
+      t.shipped_at, 'hq_inbound',
+      bp.p, GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.shipped_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'hq_to_store'
+       AND t.status IN ('shipped','received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.shipped_at >= v_range_start
+       AND t.shipped_at < v_range_end
+       AND GREATEST(ti.qty_shipped, COALESCE(ti.qty_received, 0)) > 0
+       -- 經總倉互助的 Leg-2 不算 hq_inbound：那批貨是別家店給的，已經在
+       -- Leg-1 出貨當下由 air_in/air_out 兩邊媒合入帳（20260825030000）
+       AND NOT EXISTS (
+             SELECT 1 FROM transfers t1
+              WHERE t1.next_transfer_id = t.id
+                AND t1.transfer_type = 'store_to_store'
+                AND t1.status <> 'cancelled');
+
+    -- B) air_in items（雙口徑）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, l.transfer_id, l.transfer_item_id,
+      l.sku_id, l.qty, l.unit_cost,
+      l.qty * l.unit_cost,
+      -- received_at 欄位存的是**這筆帳成立的時間**＝轉出店出貨當下
+      l.booked_at, 'air_in',
+      bp.p, l.qty * bp.p
+      FROM public.v_store_aid_transfer_legs l
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, l.sku_id, l.booked_at), 0) AS p
+      ) bp
+     WHERE l.tenant_id = v_tenant
+       AND l.dst_location = v_store.location_id
+       AND l.booked_at >= v_range_start
+       AND l.booked_at < v_range_end;
+
+    -- C) air_out items（兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, l.transfer_id, l.transfer_item_id,
+      l.sku_id, l.qty, l.unit_cost,
+      -1 * l.qty * l.unit_cost,  -- 負值
+      l.booked_at, 'air_out',
+      bp.p, -1 * l.qty * bp.p
+      FROM public.v_store_aid_transfer_legs l
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, l.sku_id, l.booked_at), 0) AS p
+      ) bp
+     WHERE l.tenant_id = v_tenant
+       AND l.src_location = v_store.location_id
+       AND l.booked_at >= v_range_start
+       AND l.booked_at < v_range_end;
+
+    -- D) free_in items（估價入帳、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      COALESCE(ti.estimated_amount, 0),
+      t.received_at, 'free_in', ti.description,
+      0, COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       -- 經總倉互助的 Leg-1 不是自由轉貨：它有真商品、沒有估價，留在這裡等於
+       -- 計價 0（20260825030000 起改由 air_out 以成本／分店價入帳）
+       AND t.next_transfer_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.dest_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    -- E) free_out items（估價入帳、負值、兩口徑同額；帶描述）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type, description,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, 0,
+      -1 * COALESCE(ti.estimated_amount, 0),  -- 負值
+      t.received_at, 'free_out', ti.description,
+      0, -1 * COALESCE(ti.estimated_amount, 0)
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'store_to_store'
+       AND t.customer_order_id IS NULL
+       -- 經總倉互助的 Leg-1 不是自由轉貨：它有真商品、沒有估價，留在這裡等於
+       -- 計價 0（20260825030000 起改由 air_out 以成本／分店價入帳）
+       AND t.next_transfer_id IS NULL
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    -- F) return_out items（沖回、兩口徑皆負值）
+    INSERT INTO store_monthly_settlement_items (
+      tenant_id, settlement_id, transfer_id, transfer_item_id,
+      sku_id, qty_received, unit_cost, line_amount, received_at, entry_type,
+      unit_branch_price, branch_amount
+    )
+    SELECT
+      v_tenant, v_settlement_id, t.id, ti.id,
+      ti.sku_id, ti.qty_received, sm.unit_cost,
+      CASE WHEN sm.unit_cost IS NULL THEN NULL ELSE -1 * ti.qty_received * sm.unit_cost END,  -- 負值
+      t.received_at, 'return_out',
+      bp.p, -1 * ti.qty_received * bp.p
+      FROM transfers t
+      JOIN transfer_items ti ON ti.transfer_id = t.id
+      LEFT JOIN stock_movements sm ON sm.id = ti.out_movement_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(public._branch_price_at(v_tenant, ti.sku_id, t.received_at), 0) AS p
+      ) bp
+     WHERE t.tenant_id = v_tenant
+       AND t.transfer_type = 'return_to_hq'
+       AND t.status IN ('received','closed')
+       AND t.source_location = v_store.location_id
+       AND t.received_at >= v_range_start
+       AND t.received_at < v_range_end
+       AND ti.qty_received > 0;
+
+    v_total_stores := v_total_stores + 1;
+    v_total_amount := v_total_amount + v_payable;
+    v_total_cost   := v_total_cost + v_cost_total;
+    v_total_branch := v_total_branch + v_branch_total;
+    v_total_adjust := v_total_adjust + v_adjust;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'month',                to_char(v_month_start, 'YYYY-MM'),
+    'stores_count',         v_total_stores,
+    'total_amount',         v_total_amount,
+    'total_cost_amount',    v_total_cost,
+    'total_branch_amount',  v_total_branch,
+    'total_adjustment',     v_total_adjust
+  );
+END;
+$fn$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_generate_hq_to_store_settlement(date, uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_generate_hq_to_store_settlement(date, uuid) IS
+  'HQ→店月結算。payable = hq_inbound + air_in − air_out + free_in − free_out − return_out + 人工調整（分店價口徑）。'
+  'hq_inbound 以**總倉派車出貨當下**入帳（老闆 2026-08-31「錢在總倉派出去那一刻就算」），'
+  '數量 = MAX(派出量, 實收量)，狀態白名單 shipped/received/closed（作廢單有 shipped_at，靠白名單擋）。'
+  '店↔店訂單相關轉貨（空中轉／經總倉互助）以**轉出店出貨當下**入帳、兩邊鏡像同額'
+  '（v_store_aid_transfer_legs）；經總倉 Leg-2 不重複計 hq_inbound、Leg-1 不再誤入 free_out。'
+  '自由轉貨、return_to_hq 維持收貨時點（return_to_hq 是「總倉同意才沖帳」的語意，刻意不改）。'
+  '短收差額由 20260901000010 產生的純記帳 return_to_hq 沖掉（restock_hq/redispatch 兩顆鈕都會產），'
+  '⚠ 沖帳的分店價以「按鈕當下」計價，與原扣款的「派車當下」在改過價的商品上會有差額。'
+  '已 confirmed/settled/remitted/cancelled 不重算。基底 20260825030000。'
+  'C 起與退貨月份守門共用 tenant＋month advisory transaction lock，鎖在狀態判斷與金額讀取之前。';

--- a/supabase/migrations/20260907040000_hq_return_disposition_available.sql
+++ b/supabase/migrations/20260907040000_hq_return_disposition_available.sql
@@ -1,0 +1,539 @@
+-- ============================================================
+-- 總倉退回貨處理 — F 後端可派量
+--
+-- 只重建三個現有物件：
+--   1. 通用店家退貨不再接受「少收」
+--   2. 無 PO 補貨需求的 HQ 供給量改為 on_hand - reserved
+--   3. 建補貨撿貨單前鎖 balance，並用同一可派量後端守門
+--
+-- 不改公開 signature，不回填歷史資料。
+-- ============================================================
+
+-- 1. 店家通用退貨：少收必須回原派貨單更正實收。
+CREATE OR REPLACE FUNCTION public.rpc_create_store_return(
+  p_store_id  BIGINT,
+  p_lines     JSONB,
+  p_reason    TEXT,
+  p_operator  UUID DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tenant       UUID := public._current_tenant_id();
+  v_user         UUID := COALESCE(p_operator, auth.uid());
+  v_role         TEXT := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '');
+  v_store_loc    BIGINT;
+  v_store_name   TEXT;
+  v_hq_loc       BIGINT;
+  v_transfer_id  BIGINT;
+  v_transfer_no  TEXT;
+  v_line         JSONB;
+  v_sku_id       BIGINT;
+  v_qty          NUMERIC;
+  v_qty_text     TEXT;
+  v_sku_label    TEXT;
+  v_on_hand      NUMERIC;
+  v_pending      NUMERIC;
+  v_pending_nos  TEXT;
+  v_lock         RECORD;
+  v_need         RECORD;
+  v_notes        TEXT;
+  v_count        INT := 0;
+  v_total_qty    NUMERIC := 0;
+  v_result_lines JSONB := '[]'::JSONB;
+BEGIN
+  IF p_reason = '少收' THEN
+    RAISE EXCEPTION '「少收」不能用一般退貨建單。請到 /wms/inbound 找到原派貨單，用「修改實收」更正實收數量。';
+  END IF;
+
+  IF p_reason IS NULL OR p_reason NOT IN ('破損','過期','客人退') THEN
+    RAISE EXCEPTION '退貨原因必須是「破損／過期／客人退」其中一個，收到的是「%」',
+      COALESCE(p_reason, '(空白)');
+  END IF;
+
+  IF v_role NOT IN ('owner','admin','hq_manager','store_manager','store_staff','clerk','') THEN
+    RAISE EXCEPTION 'permission denied: role % cannot create store return', v_role;
+  END IF;
+
+  SELECT location_id, name INTO v_store_loc, v_store_name
+    FROM stores
+   WHERE id = p_store_id AND tenant_id = v_tenant;
+  IF v_store_loc IS NULL THEN
+    RAISE EXCEPTION '門市 % 沒有設定倉庫位置（location_id），無法建退貨單', p_store_id;
+  END IF;
+
+  IF v_role NOT IN ('owner','admin','hq_manager') THEN
+    IF NOT (p_store_id = ANY (public._jwt_store_ids())) THEN
+      RAISE EXCEPTION '這個帳號不能幫「%」建退貨單 —— 只有這家店自己的帳號、或總部帳號（owner／admin／hq_manager）可以。如果你就是這家店的人卻被擋，請總部確認你的帳號有掛到這家店。',
+        v_store_name;
+    END IF;
+  END IF;
+
+  SELECT id INTO v_hq_loc
+    FROM locations
+   WHERE tenant_id = v_tenant AND type = 'central_warehouse' AND is_active = TRUE
+   ORDER BY id LIMIT 1;
+  IF v_hq_loc IS NULL THEN
+    RAISE EXCEPTION '找不到啟用中的總倉，無法建退貨單';
+  END IF;
+  IF v_hq_loc = v_store_loc THEN
+    RAISE EXCEPTION '這個帳號的位置就是總倉，不能退貨給自己';
+  END IF;
+
+  IF p_lines IS NULL OR jsonb_array_length(p_lines) = 0 THEN
+    RAISE EXCEPTION '請至少選一項商品';
+  END IF;
+
+  -- 第 1 趟：只驗輸入，先不建單。
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines)
+  LOOP
+    v_sku_id := (v_line ->> 'sku_id')::BIGINT;
+    v_qty_text := v_line ->> 'qty';
+
+    -- 先驗原始文字，不能讓後段 NUMERIC(18,3) 靜默四捨五入。
+    IF COALESCE(v_qty_text, '') !~ '^[0-9]+([.][0-9]{1,3})?$' THEN
+      RAISE EXCEPTION '退貨數量必須是有限正數，且最多 3 位小數';
+    END IF;
+
+    v_qty := v_qty_text::NUMERIC;
+
+    IF v_sku_id IS NULL OR v_qty IS NULL OR v_qty <= 0 THEN
+      RAISE EXCEPTION '品項資料不完整（商品 %、數量 %），請重新選一次', v_sku_id, v_qty;
+    END IF;
+
+    SELECT COALESCE(NULLIF(TRIM(COALESCE(s.product_name,'')
+             || COALESCE(' / ' || NULLIF(s.variant_name,''), '')), ''), s.sku_code)
+      INTO v_sku_label
+      FROM skus s
+     WHERE s.id = v_sku_id AND s.tenant_id = v_tenant;
+    IF v_sku_label IS NULL THEN
+      RAISE EXCEPTION '找不到商品 %（或不屬於本公司）', v_sku_id;
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM skus s JOIN products p ON p.id = s.product_id
+       WHERE s.id = v_sku_id AND p.is_virtual
+    ) THEN
+      RAISE EXCEPTION '「%」是系統用的虛擬商品（沒有實體），不能用退貨頁退回總倉', v_sku_label;
+    END IF;
+
+    v_result_lines := v_result_lines || jsonb_build_object(
+      'sku_id', v_sku_id,
+      'sku_label', v_sku_label,
+      'qty', v_qty
+    );
+    v_count     := v_count + 1;
+    v_total_qty := v_total_qty + v_qty;
+  END LOOP;
+
+  IF v_count = 0 THEN
+    RAISE EXCEPTION '請至少選一項商品';
+  END IF;
+
+  -- 第 2 趟：依固定順序鎖住店倉 balance，再重讀可退量。
+  FOR v_lock IN
+    SELECT DISTINCT v_store_loc AS location_id, (l ->> 'sku_id')::BIGINT AS sku_id
+      FROM jsonb_array_elements(p_lines) AS l
+     ORDER BY 1, 2
+  LOOP
+    PERFORM 1
+       FROM stock_balances
+      WHERE tenant_id   = v_tenant
+        AND location_id = v_lock.location_id
+        AND sku_id      = v_lock.sku_id
+      FOR UPDATE;
+  END LOOP;
+
+  FOR v_need IN
+    SELECT g.sku_id,
+           g.need,
+           COALESCE(NULLIF(TRIM(COALESCE(s.product_name,'')
+             || COALESCE(' / ' || NULLIF(s.variant_name,''), '')), ''),
+             s.sku_code, '品項#' || g.sku_id::TEXT) AS sku_label
+      FROM (
+        SELECT (l ->> 'sku_id')::BIGINT AS sku_id,
+               SUM((l ->> 'qty')::NUMERIC) AS need
+          FROM jsonb_array_elements(p_lines) AS l
+         GROUP BY 1
+      ) g
+      LEFT JOIN skus s ON s.id = g.sku_id AND s.tenant_id = v_tenant
+     ORDER BY g.sku_id
+  LOOP
+    SELECT COALESCE(on_hand, 0) INTO v_on_hand
+      FROM stock_balances
+     WHERE tenant_id = v_tenant AND location_id = v_store_loc AND sku_id = v_need.sku_id;
+    v_on_hand := COALESCE(v_on_hand, 0);
+
+    SELECT COALESCE(pending_qty, 0), doc_nos
+      INTO v_pending, v_pending_nos
+      FROM v_store_pending_returns
+     WHERE tenant_id = v_tenant AND location_id = v_store_loc AND sku_id = v_need.sku_id;
+    v_pending := COALESCE(v_pending, 0);
+
+    IF v_on_hand < v_pending + v_need.need THEN
+      RAISE EXCEPTION '「%」退不了：店裡帳上 % 件，其中 % 件已經在等總倉回覆（單號 %），這次要退 % 件 —— 最多只能再退 % 件。',
+        v_need.sku_label,
+        trim_scale(v_on_hand),
+        trim_scale(v_pending),
+        COALESCE(v_pending_nos, '無'),
+        trim_scale(v_need.need),
+        trim_scale(GREATEST(v_on_hand - v_pending, 0));
+    END IF;
+  END LOOP;
+
+  -- 第 3 趟：驗證全過才建單；這裡不動庫存。
+  v_notes := CASE WHEN p_reason = '破損'
+                  THEN '[order return|破損]'
+                  ELSE '[order return: ' || p_reason || ']'
+             END;
+
+  v_transfer_no := public._next_transfer_no();
+
+  INSERT INTO transfers (
+    tenant_id, transfer_no, source_location, dest_location,
+    status, transfer_type, customer_order_id,
+    requested_by, shipped_by, shipped_at,
+    notes, created_by, updated_by
+  ) VALUES (
+    v_tenant, v_transfer_no, v_store_loc, v_hq_loc,
+    'shipped', 'return_to_hq', NULL,
+    v_user, v_user, NOW(),
+    v_notes, v_user, v_user
+  ) RETURNING id INTO v_transfer_id;
+
+  FOR v_line IN SELECT * FROM jsonb_array_elements(v_result_lines)
+  LOOP
+    INSERT INTO transfer_items (
+      transfer_id, sku_id, qty_requested, qty_shipped,
+      out_movement_id, created_by, updated_by
+    ) VALUES (
+      v_transfer_id,
+      (v_line ->> 'sku_id')::BIGINT,
+      (v_line ->> 'qty')::NUMERIC,
+      (v_line ->> 'qty')::NUMERIC,
+      NULL, v_user, v_user
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'transfer_id',  v_transfer_id,
+    'transfer_no',  v_transfer_no,
+    'store_id',     p_store_id,
+    'store_name',   v_store_name,
+    'reason',       p_reason,
+    'lines',        v_count,
+    'total_qty',    v_total_qty,
+    'stock_moved',  FALSE,
+    'items',        v_result_lines
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_store_return(BIGINT, JSONB, TEXT, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_store_return(BIGINT, JSONB, TEXT, UUID) IS
+  '店家退貨頁：從商品下手建 return_to_hq 退貨單，送出時不動庫存。'
+  '通用原因只收破損／過期／客人退；少收必須回 /wms/inbound 的原派貨單修改實收。'
+  '退貨量只收有限正數且最多 3 位小數；店別、tenant、庫存預鎖與待退量守門沿用 20260904020000；原回傳結構不變。';
+
+-- 2. 補貨需求中的 HQ 供給量改為「帳上 - 已保留」。
+--    欄位、排序、需求/已建 wave 篩選及權限不變。
+CREATE OR REPLACE VIEW public.v_picking_demand_no_po AS
+WITH hq_loc AS (
+  SELECT DISTINCT ON (tenant_id) tenant_id, id AS location_id
+    FROM locations
+   WHERE type = 'central_warehouse'
+   ORDER BY tenant_id, id
+),
+rr_lines AS (
+  SELECT
+    rr.id AS restock_request_id,
+    rr.tenant_id,
+    rr.status AS restock_status,
+    rr.requesting_store_id AS store_id,
+    rrl.sku_id,
+    rrl.qty AS demand_qty
+  FROM restock_requests rr
+  JOIN restock_request_lines rrl ON rrl.request_id = rr.id
+  WHERE rr.status = 'approved_transfer'
+    AND rr.linked_transfer_id IS NULL
+),
+hq_supply AS (
+  SELECT
+    sb.tenant_id,
+    sb.sku_id,
+    GREATEST(COALESCE(sb.on_hand, 0) - COALESCE(sb.reserved, 0), 0) AS on_hand
+  FROM stock_balances sb
+  JOIN hq_loc h ON h.tenant_id = sb.tenant_id AND h.location_id = sb.location_id
+),
+wave_qty AS (
+  SELECT pw.source_restock_request_id AS restock_request_id,
+         pwi.sku_id, pwi.store_id,
+         SUM(pwi.qty) AS wave_qty
+    FROM picking_wave_items pwi
+    JOIN picking_waves pw ON pw.id = pwi.wave_id
+   WHERE pw.status <> 'cancelled'
+     AND pw.source_restock_request_id IS NOT NULL
+   GROUP BY pw.source_restock_request_id, pwi.sku_id, pwi.store_id
+)
+SELECT
+  l.tenant_id,
+  NULL::BIGINT AS po_id,
+  'RR-' || l.restock_request_id::TEXT AS po_no,
+  'restock'::TEXT AS po_status,
+  NULL::BIGINT AS supplier_id,
+  NULL::BIGINT AS po_item_id,
+  l.sku_id,
+  s.sku_code,
+  COALESCE(s.product_name,'') || COALESCE(' ' || NULLIF(s.variant_name,''),'') AS sku_label,
+  l.demand_qty AS qty_ordered,
+  COALESCE(hs.on_hand, 0)::NUMERIC AS gr_qty,
+  0::NUMERIC AS qty_in_transit,
+  0::NUMERIC AS qty_shortage,
+  l.store_id,
+  st.code AS store_code,
+  st.name AS store_name,
+  l.demand_qty,
+  COALESCE(wq.wave_qty, 0)::NUMERIC AS wave_qty,
+  0::NUMERIC AS shipped_qty,
+  TRUE AS is_restock_sourced,
+  l.restock_request_id,
+  l.restock_status
+FROM rr_lines l
+JOIN skus s ON s.id = l.sku_id
+LEFT JOIN hq_supply hs ON hs.tenant_id = l.tenant_id AND hs.sku_id = l.sku_id
+LEFT JOIN stores st ON st.id = l.store_id
+LEFT JOIN wave_qty wq ON wq.restock_request_id = l.restock_request_id
+                     AND wq.sku_id = l.sku_id
+                     AND wq.store_id = l.store_id
+WHERE COALESCE(wq.wave_qty, 0) < l.demand_qty;
+
+GRANT SELECT ON public.v_picking_demand_no_po TO authenticated;
+
+COMMENT ON VIEW public.v_picking_demand_no_po IS
+  '已核准直派的補貨需求；gr_qty 是 HQ 可派量 GREATEST(on_hand-reserved,0)，未確認退回貨不算供給。';
+
+-- 3. 補貨建 wave：先驗每筆原始數量與 tenant/SKU，再固定順序鎖 HQ balance。
+CREATE OR REPLACE FUNCTION public.rpc_create_wave_from_restock(
+  p_restock_request_id BIGINT,
+  p_wave_date          DATE,
+  p_allocations        JSONB,
+  p_operator           UUID
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_request      restock_requests%ROWTYPE;
+  v_tenant       UUID;
+  v_wave_id      BIGINT;
+  v_wave_code    TEXT;
+  v_alloc        JSONB;
+  v_sku_id       BIGINT;
+  v_store_id     BIGINT;
+  v_qty          NUMERIC(18,3);
+  v_qty_text     TEXT;
+  v_total_qty    NUMERIC(18,3) := 0;
+  v_item_count   INTEGER := 0;
+  v_store_count  INTEGER := 0;
+  v_hq_location  BIGINT;
+  v_short        RECORD;
+BEGIN
+  SELECT * INTO v_request FROM restock_requests
+    WHERE id = p_restock_request_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '找不到補貨申請 #%', p_restock_request_id;
+  END IF;
+  IF v_request.status <> 'approved_transfer' THEN
+    RAISE EXCEPTION '補貨申請狀態為「%」、不可建撿貨單(需先在總倉收件匣點「派貨」)',
+      v_request.status;
+  END IF;
+  IF v_request.linked_transfer_id IS NOT NULL THEN
+    RAISE EXCEPTION '補貨申請 #% 已有直派 transfer(legacy),不可重複建單',
+      p_restock_request_id;
+  END IF;
+  v_tenant := v_request.tenant_id;
+
+  IF p_allocations IS NULL
+  OR jsonb_typeof(p_allocations) IS DISTINCT FROM 'array'
+  OR jsonb_array_length(p_allocations) = 0
+  THEN
+    RAISE EXCEPTION '請先填寫各分店分配量、不可全為空';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('wave:restock:' || p_restock_request_id::TEXT));
+
+  -- 先驗原始值，不讓 numeric(18,3) 自動四捨五入超過 3 位小數。
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations)
+  LOOP
+    IF jsonb_typeof(v_alloc) IS DISTINCT FROM 'object' THEN
+      RAISE EXCEPTION '每筆分配必須是包含 sku_id、store_id、qty 的資料';
+    END IF;
+
+    IF COALESCE(v_alloc->>'sku_id', '') !~ '^[0-9]+$'
+    OR COALESCE(v_alloc->>'store_id', '') !~ '^[0-9]+$'
+    THEN
+      RAISE EXCEPTION '分配的 sku_id 與 store_id 必須是正整數';
+    END IF;
+
+    v_sku_id   := (v_alloc->>'sku_id')::BIGINT;
+    v_store_id := (v_alloc->>'store_id')::BIGINT;
+    v_qty_text := v_alloc->>'qty';
+
+    IF v_sku_id <= 0 OR v_store_id <= 0 THEN
+      RAISE EXCEPTION '分配的 sku_id 與 store_id 必須是正整數';
+    END IF;
+
+    IF COALESCE(v_qty_text, '') !~ '^[0-9]+([.][0-9]{1,3})?$' THEN
+      RAISE EXCEPTION '分配數量必須是有限正數，且最多 3 位小數';
+    END IF;
+
+    v_qty := v_qty_text::NUMERIC;
+    IF v_qty <= 0 THEN
+      RAISE EXCEPTION '分配數量必須 > 0';
+    END IF;
+
+    IF v_store_id <> v_request.requesting_store_id THEN
+      RAISE EXCEPTION '補貨申請只能派給申請分店 #%、不可派往其他店',
+        v_request.requesting_store_id;
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM skus s
+       WHERE s.id = v_sku_id AND s.tenant_id = v_tenant
+    ) THEN
+      RAISE EXCEPTION '找不到 SKU #%（或不屬於這家公司）', v_sku_id;
+    END IF;
+  END LOOP;
+
+  SELECT id INTO v_hq_location FROM locations
+    WHERE tenant_id = v_tenant AND type = 'central_warehouse'
+    ORDER BY id LIMIT 1;
+  IF v_hq_location IS NULL THEN
+    RAISE EXCEPTION '找不到總倉 location(type=central_warehouse)';
+  END IF;
+
+  -- 與 _hq_hold_return 更新 reserved 共用同一 balance 鎖；SKU 升冪避免死鎖。
+  FOR v_sku_id IN
+    SELECT DISTINCT (a->>'sku_id')::BIGINT
+      FROM jsonb_array_elements(p_allocations) AS a
+     ORDER BY 1
+  LOOP
+    PERFORM 1
+      FROM stock_balances
+     WHERE tenant_id = v_tenant
+       AND location_id = v_hq_location
+       AND sku_id = v_sku_id
+     FOR UPDATE;
+  END LOOP;
+
+  -- 單次分配不可超過「申請量 - 已建 wave」，也不可超過 HQ 可派量。
+  WITH alloc_agg AS (
+    SELECT (a->>'sku_id')::BIGINT AS sku_id,
+           SUM((a->>'qty')::NUMERIC) AS total_alloc
+      FROM jsonb_array_elements(p_allocations) a
+     GROUP BY (a->>'sku_id')::BIGINT
+  ),
+  line_agg AS (
+    SELECT sku_id, SUM(qty) AS line_qty
+      FROM restock_request_lines
+     WHERE request_id = p_restock_request_id
+     GROUP BY sku_id
+  ),
+  waved_agg AS (
+    SELECT pwi.sku_id, SUM(pwi.qty) AS waved_qty
+      FROM picking_wave_items pwi
+      JOIN picking_waves pw ON pw.id = pwi.wave_id
+     WHERE pw.source_restock_request_id = p_restock_request_id
+       AND pw.status <> 'cancelled'
+     GROUP BY pwi.sku_id
+  )
+  SELECT
+    s.sku_code,
+    COALESCE(s.product_name,'') || COALESCE(' ' || NULLIF(s.variant_name,''),'') AS sku_label,
+    aa.total_alloc,
+    COALESCE(la.line_qty, 0) AS line_qty,
+    COALESCE(wa.waved_qty, 0) AS waved_qty,
+    GREATEST(0, COALESCE(la.line_qty, 0) - COALESCE(wa.waved_qty, 0)) AS line_left,
+    GREATEST(COALESCE(sb.on_hand, 0) - COALESCE(sb.reserved, 0), 0) AS available_qty
+  INTO v_short
+  FROM alloc_agg aa
+  JOIN skus s ON s.id = aa.sku_id AND s.tenant_id = v_tenant
+  LEFT JOIN line_agg la ON la.sku_id = aa.sku_id
+  LEFT JOIN waved_agg wa ON wa.sku_id = aa.sku_id
+  LEFT JOIN stock_balances sb
+    ON sb.tenant_id = v_tenant
+   AND sb.location_id = v_hq_location
+   AND sb.sku_id = aa.sku_id
+  WHERE aa.total_alloc > GREATEST(0, COALESCE(la.line_qty, 0) - COALESCE(wa.waved_qty, 0))
+     OR aa.total_alloc > GREATEST(COALESCE(sb.on_hand, 0) - COALESCE(sb.reserved, 0), 0)
+  LIMIT 1;
+
+  IF v_short.sku_code IS NOT NULL THEN
+    IF v_short.total_alloc > v_short.line_left THEN
+      RAISE EXCEPTION 'SKU「% %」分配 % 超過剩餘申請量 %（申請 %、已撿 %）',
+        v_short.sku_code, v_short.sku_label, v_short.total_alloc,
+        v_short.line_left, v_short.line_qty, v_short.waved_qty;
+    ELSE
+      RAISE EXCEPTION 'SKU「% %」分配 % 超過總倉可派量 %（帳上庫存已扣掉待確認保留量）',
+        v_short.sku_code, v_short.sku_label, v_short.total_alloc, v_short.available_qty;
+    END IF;
+  END IF;
+
+  v_wave_code := 'WV'
+              || to_char(NOW() AT TIME ZONE 'Asia/Taipei', 'YYMMDD')
+              || LPAD(nextval('public.picking_wave_code_seq')::TEXT, 6, '0');
+
+  INSERT INTO picking_waves (
+    tenant_id, wave_code, wave_date, status, source_restock_request_id,
+    created_by, updated_by
+  ) VALUES (
+    v_tenant, v_wave_code, p_wave_date, 'draft', p_restock_request_id,
+    p_operator, p_operator
+  ) RETURNING id INTO v_wave_id;
+
+  FOR v_alloc IN SELECT * FROM jsonb_array_elements(p_allocations)
+  LOOP
+    v_sku_id   := (v_alloc->>'sku_id')::BIGINT;
+    v_store_id := (v_alloc->>'store_id')::BIGINT;
+    v_qty      := (v_alloc->>'qty')::NUMERIC;
+
+    INSERT INTO picking_wave_items (
+      tenant_id, wave_id, sku_id, store_id, qty, campaign_id,
+      created_by, updated_by
+    ) VALUES (
+      v_tenant, v_wave_id, v_sku_id, v_store_id, v_qty, NULL,
+      p_operator, p_operator
+    )
+    ON CONFLICT (wave_id, sku_id, store_id) DO UPDATE
+      SET qty = picking_wave_items.qty + EXCLUDED.qty,
+          updated_by = p_operator,
+          updated_at = NOW();
+  END LOOP;
+
+  SELECT COUNT(*), COUNT(DISTINCT store_id), COALESCE(SUM(qty), 0)
+    INTO v_item_count, v_store_count, v_total_qty
+    FROM picking_wave_items WHERE wave_id = v_wave_id;
+
+  UPDATE picking_waves
+     SET item_count = v_item_count,
+         store_count = v_store_count,
+         total_qty = v_total_qty,
+         updated_at = NOW()
+   WHERE id = v_wave_id;
+
+  RETURN jsonb_build_object(
+    'wave_id', v_wave_id,
+    'wave_code', v_wave_code,
+    'item_count', v_item_count,
+    'store_count', v_store_count,
+    'total_qty', v_total_qty
+  );
+END $$;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_wave_from_restock(BIGINT, DATE, JSONB, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_create_wave_from_restock(BIGINT, DATE, JSONB, UUID) IS
+  '補貨申請（無 PO 來源）建撿貨單；保留 approved_transfer、申請剩餘量、已 wave 去重與申請分店守門。'
+  '分配只收有限正數且最多 3 位小數；先排序鎖 HQ balance，再以 GREATEST(on_hand-reserved,0) 驗後端可派量。';

--- a/tests/return-disposition-review/README.md
+++ b/tests/return-disposition-review/README.md
@@ -1,16 +1,29 @@
 # return-disposition-review
 
-阿審獨立驗收準備檔，不屬於阿寫的 `tests/return-disposition/fixture.sql` 或 `test.sql`。
+阿審獨立驗收檔。載入器正本是 `tests/return-disposition/fixture.cjs`，本資料夾不放功能碼，不另抄業務函式，不連 GitHub／Supabase。
 
 用途：
 
-- `review_assertions.sql`：在阿寫 fixture/test 跑完後，補做結構與防線斷言。
-- 本資料夾不放功能碼，不重寫阿寫函式，不連 GitHub/Supabase。
+- `core-runtime.cjs`：核心 16 群，含來源、完整重送、權限與並行；測試資料的延後事件會先驗完才切換來源 trigger。
+- `source-available-runtime.cjs`：B 來源與 F 可派量／原始數量／真並行；包含旧可派量反例。
+- `reversal-runtime.cjs`：C 與真月結的並行檢查，以最新審查報告記載的實跑項目為準。
+- `ui-input-runtime.cjs`／`ui-submit-runtime.cjs`：實際頁面函式與 jsdom 元件離線測試，不使用正式 API。
+- `shortage-ui-check.cjs`／`f-ui-copy-runtime.cjs`：少收引導與三個既有畫面口徑，包含舊版對照。
+- `../return-disposition/flow-smoke.cjs`：CEO 的真 RPC 流程抽驗（不是正式自審），每例強制驗延後限制後回滾。
+- `review_assertions.sql`：保留的早期結構草稿，末段仍按名字猜表，與目前 `hq_return_batches` 命名不合；**不列為現行驗收指令**，不可用它的命名失敗判定新功能錯誤。現行以 runtime 與獨立報告為準。
 
-預期本機 PostgreSQL：
+連線固定為專用本機 PostgreSQL，所有命令都從本機工地根目錄執行。每次 fixture 選新名字，不覆蓋既有假庫。禁止改成正式連線，也不要透過會整理共用依賴的 pnpm exec；直接用既有 Node 執行。
 
 ```powershell
-psql -h 127.0.0.1 -p 56427 -U returnlocal -d return_disposition_review -v ON_ERROR_STOP=1 -f .\tests\return-disposition-review\review_assertions.sql
+node tests/return-disposition/fixture.cjs --db-name return_disposition_test_verify_new --with-all
+node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_verify_new --case all
+node tests/return-disposition/flow-smoke.cjs --db-name return_disposition_test_verify_new
+node tests/return-disposition-review/source-available-runtime.cjs --db-name return_disposition_test_verify_new --case b_store_return,b_shortage,f_restock_available,f_restock_inputs,f_old_restock_available_baseline,f_restock_balance_race,f_store_return
+node tests/return-disposition-review/reversal-runtime.cjs --db-name return_disposition_test_verify_new
+node tests/return-disposition-review/ui-input-runtime.cjs
+node tests/return-disposition-review/ui-submit-runtime.cjs
+node tests/return-disposition-review/shortage-ui-check.cjs
+node tests/return-disposition-review/f-ui-copy-runtime.cjs
 ```
 
-正式審查時，如果這份斷言檔過不了，不代表阿寫一定錯，但代表 fixture 或候選 migration 至少有一個關鍵保護沒有證明到。
+這是有界假庫，不是完整 ERP：基底 auth／通知等模擬範圍見載入器 README；A/B/C/F 本身的 SQL、政策與授權原樣載入。完整送單／確認／收款、正式瀏覽器、真正帳務與部署未因此驗收。舊錯版反例的預期失敗不是目前修版失敗，報告必須分開記。

--- a/tests/return-disposition-review/README.md
+++ b/tests/return-disposition-review/README.md
@@ -1,0 +1,16 @@
+# return-disposition-review
+
+阿審獨立驗收準備檔，不屬於阿寫的 `tests/return-disposition/fixture.sql` 或 `test.sql`。
+
+用途：
+
+- `review_assertions.sql`：在阿寫 fixture/test 跑完後，補做結構與防線斷言。
+- 本資料夾不放功能碼，不重寫阿寫函式，不連 GitHub/Supabase。
+
+預期本機 PostgreSQL：
+
+```powershell
+psql -h 127.0.0.1 -p 56427 -U returnlocal -d return_disposition_review -v ON_ERROR_STOP=1 -f .\tests\return-disposition-review\review_assertions.sql
+```
+
+正式審查時，如果這份斷言檔過不了，不代表阿寫一定錯，但代表 fixture 或候選 migration 至少有一個關鍵保護沒有證明到。

--- a/tests/return-disposition-review/core-runtime.cjs
+++ b/tests/return-disposition-review/core-runtime.cjs
@@ -215,12 +215,51 @@ async function hold(c, s, qty = 10, sourceMovementId = s.sourceMovement, item = 
   return row.id;
 }
 
+async function holdEx(c, s, opts = {}) {
+  const row = await q1(c, `
+    select public._hq_hold_return($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) as id
+  `, [
+    opts.tenant || s.tenant,
+    opts.loc || s.hq,
+    opts.sku || s.sku,
+    opts.sourceMovement || s.sourceMovement,
+    opts.item || s.item,
+    opts.kind || 'store_return',
+    opts.reason ?? 'review fixture',
+    opts.qty ?? 10,
+    opts.operator || s.operator,
+    opts.auto || 'manual',
+  ]);
+  return row.id;
+}
+
 async function seedHeldBatch(c, qty = 10) {
   const s = await seedBasic(c, { qty });
   s.sourceMovement = await inboundMovement(c, s, qty);
   const existing = await q1(c, 'select id from hq_return_batches where source_movement_id = $1', [s.sourceMovement]);
   s.batch = existing?.id || await hold(c, s, qty);
   return s;
+}
+
+async function addSameSkuHeldBatch(c, s, qty) {
+  const transfer = (await q1(c, `
+    insert into transfers (tenant_id, transfer_no, source_location, dest_location, transfer_type, status, requested_by, created_by, notes)
+    values ($1,$2,$3,$4,'return_to_hq','shipped',$5,$5,$6) returning id
+  `, [s.tenant, `${code()}_tr2`, s.store, s.hq, s.operator, `${s.suffix} return_to_hq second`])).id;
+  const item = (await q1(c, `
+    insert into transfer_items (transfer_id, sku_id, qty_requested, qty_shipped, qty_received, created_by)
+    values ($1,$2,$3,$3,$3,$4) returning id
+  `, [transfer, s.sku, qty, s.operator])).id;
+  const row = await q1(c, `
+    insert into stock_movements
+      (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, source_doc_type, source_doc_id, operator_id, notes)
+    values ($1,$2,$3,$4,12.3456,'transfer_in','transfer',$5,$6,$7)
+    returning id
+  `, [s.tenant, s.hq, s.sku, qty, transfer, s.operator, `${s.suffix} second inbound`]);
+  await c.query('update transfer_items set in_movement_id = $1 where id = $2', [row.id, item]);
+  const batch = (await q1(c, 'select id from hq_return_batches where source_movement_id = $1', [row.id]))?.id;
+  assert.ok(batch, '第二批同 SKU 應由 B trigger 自動建待處理批次');
+  return { transfer, item, sourceMovement: row.id, batch };
 }
 
 async function snapshot(c, batchId) {
@@ -473,6 +512,47 @@ async function testIdempotencyPayloadFields(c) {
   });
 }
 
+async function testRequestIdTenantScoped(c) {
+  await tx(c, '同 UUID 在不同 tenant 不互相干擾', async () => {
+    const req = id();
+    const a = await seedHeldBatch(c, 2);
+    const b = await seedHeldBatch(c, 2);
+
+    await setAuth(c, a.tenant, a.operator, 'hq_manager');
+    const ra = await dispose(c, a.batch, req, 2, 0, 0, null, null, true, 'same uuid tenant a');
+    assert.equal(ra.idempotent, false);
+    assert.equal(ra.new_status, 'completed');
+
+    await resetRole(c);
+    await setAuth(c, b.tenant, b.operator, 'hq_manager');
+    const rb = await dispose(c, b.batch, req, 2, 0, 0, null, null, true, 'same uuid tenant b');
+    assert.equal(rb.idempotent, false);
+    assert.equal(rb.new_status, 'completed');
+    assert.notEqual(rb.event_id, ra.event_id);
+
+    const replay = await dispose(c, b.batch, req, 2, 0, 0, null, null, true, 'same uuid tenant b');
+    assert.equal(replay.idempotent, true);
+    assert.equal(replay.event_id, rb.event_id);
+  });
+}
+
+async function testHoldFullPayloadReplay(c) {
+  await tx(c, 'hold 同 source 重送必須完整 payload 一致才回既有批次', async () => {
+    const s = await seedBasic(c, { qty: 10 });
+    s.sourceMovement = await linkedRawInboundMovement(c, s, 10);
+    const first = await holdEx(c, s, { qty: 10, reason: '原原因', auto: 'manual' });
+    const snap = await snapshot(c, first);
+    const replay = await holdEx(c, s, { qty: 10, reason: '原原因', auto: 'manual' });
+    assert.equal(replay, first);
+    assert.deepEqual(await snapshot(c, first), snap);
+
+    const before = () => snapshot(c, first);
+    await expectReject(c, 'hold 同 source 改 reason 應拒絕', before, () => holdEx(c, s, { qty: 10, reason: '改原因', auto: 'manual' }), /different|payload|already held|reason/i);
+    await expectReject(c, 'hold 同 source 改 auto_flag 應拒絕', before, () => holdEx(c, s, { qty: 10, reason: '原原因', auto: 'system' }), /different|payload|already held|auto/i);
+    await expectReject(c, 'hold 同 source 改 operator 應拒絕', before, () => holdEx(c, s, { qty: 10, reason: '原原因', auto: 'manual', operator: id() }), /different|payload|already held|operator/i);
+  });
+}
+
 async function testBadNumbers(c) {
   await tx(c, 'NULL/NaN/Infinity/四位小數', async () => {
     const s2 = await seedHeldBatch(c, 10);
@@ -496,6 +576,35 @@ async function testBadNumbers(c) {
       select public.rpc_dispose_hq_return($1,$2,'Infinity'::numeric,0,0,null,null,true,'inf')
     `, [s2.batch, id()]), /numeric|Infinity|invalid|finite|數字/i);
     if (failures.length > 0) throw new Error(failures.join(' | '));
+  });
+}
+
+async function testMultiBatchReservedTotal(c) {
+  await tx(c, '同 SKU 多批 pending 要用總額保護 reserved / available', async () => {
+    const s = await seedHeldBatch(c, 5);
+    const second = await addSameSkuHeldBatch(c, s, 7);
+    assert.ok(second.batch);
+    await c.query(`
+      insert into stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, operator_id, notes)
+      values ($1,$2,$3,20,12.3456,'manual_adjust',$4,'既有好貨')
+    `, [s.tenant, s.hq, s.sku, s.operator]);
+
+    const bal = await q1(c, 'select on_hand::text, reserved::text from stock_balances where tenant_id=$1 and location_id=$2 and sku_id=$3', [s.tenant, s.hq, s.sku]);
+    assert.equal(bal.on_hand, '32.000');
+    assert.equal(bal.reserved, '12.000');
+
+    await c.query('savepoint multi_batch_available');
+    await c.query(`
+      insert into stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, operator_id, notes)
+      values ($1,$2,$3,-20,12.3456,'manual_adjust',$4,'multi batch allowed')
+    `, [s.tenant, s.hq, s.sku, s.operator]);
+    await c.query('rollback to savepoint multi_batch_available');
+    await c.query('release savepoint multi_batch_available');
+
+    await expectReject(c, '同 SKU 兩批 pending 共 12，不可出到只剩 11', () => snapshot(c, s.batch), () => c.query(`
+      insert into stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, operator_id, notes)
+      values ($1,$2,$3,-21,12.3456,'manual_adjust',$4,'multi batch blocked')
+    `, [s.tenant, s.hq, s.sku, s.operator]), /pending|guard|退回|待處理|reserved/i);
   });
 }
 
@@ -731,7 +840,10 @@ const CASES = [
   { name: 'idempotency', fn: testIdempotency, race: false },
   { name: 'idempotency_replay_after_complete', fn: testIdempotencyReplayAfterComplete, race: false },
   { name: 'idempotency_payload_fields', fn: testIdempotencyPayloadFields, race: false },
+  { name: 'request_id_tenant_scoped', fn: testRequestIdTenantScoped, race: false },
+  { name: 'hold_full_payload_replay', fn: testHoldFullPayloadReplay, race: false },
   { name: 'bad_numbers', fn: testBadNumbers, race: false },
+  { name: 'multi_batch_reserved_total', fn: testMultiBatchReservedTotal, race: false },
   { name: 'reserved_corruption', fn: testReservedCorruption, race: false },
   { name: 'pending_guard', fn: testPendingGuardAndGoodStock, race: false },
   { name: 'role_edges', fn: testRoleEdges, race: false },

--- a/tests/return-disposition-review/core-runtime.cjs
+++ b/tests/return-disposition-review/core-runtime.cjs
@@ -186,14 +186,22 @@ async function rawInboundMovement(c, s, qty, loc = s.hq, sku = s.sku, item = s.i
   return row.id;
 }
 
+async function flushDeferredConstraints(c) {
+  await c.query('set constraints all immediate');
+  await c.query('set constraints all deferred');
+}
+
 async function linkedRawInboundMovement(c, s, qty) {
   const movementId = await rawInboundMovement(c, s, qty);
+  await flushDeferredConstraints(c);
   await c.query('alter table public.transfer_items disable trigger trg_hq_return_source');
   try {
     await c.query('update transfer_items set in_movement_id = $1 where id = $2', [movementId, s.item]);
+    await flushDeferredConstraints(c);
   } finally {
     await c.query('alter table public.transfer_items enable trigger trg_hq_return_source');
   }
+  await flushDeferredConstraints(c);
   return movementId;
 }
 

--- a/tests/return-disposition-review/core-runtime.cjs
+++ b/tests/return-disposition-review/core-runtime.cjs
@@ -141,6 +141,10 @@ async function seedBasic(c, opts = {}) {
     insert into locations (tenant_id, code, name, type, created_by)
     values ($1,$2,$3,'central_warehouse',$4) returning id
   `, [otherTenant, `${suffix}_other_hq`, `${suffix} 別租戶總倉`, operator])).id;
+  const sameTenantOtherHq = (await q1(c, `
+    insert into locations (tenant_id, code, name, type, created_by)
+    values ($1,$2,$3,'central_warehouse',$4) returning id
+  `, [tenant, `${suffix}_same_tenant_hq`, `${suffix} 同租戶別總倉`, operator])).id;
   const product = (await q1(c, `
     insert into products (tenant_id, product_code, name, status, created_by)
     values ($1,$2,$3,'active',$4) returning id
@@ -158,7 +162,7 @@ async function seedBasic(c, opts = {}) {
     values ($1,$2,$3,$3,$3,$4) returning id
   `, [transfer, sku, opts.qty || 10, operator])).id;
 
-  return { suffix, tenant, otherTenant, operator, hq, store, otherHq, product, sku, transfer, item };
+  return { suffix, tenant, otherTenant, operator, hq, store, otherHq, sameTenantOtherHq, product, sku, transfer, item };
 }
 
 async function inboundMovement(c, s, qty, loc = s.hq, sku = s.sku, item = s.item, type = 'transfer_in') {
@@ -179,6 +183,28 @@ async function rawInboundMovement(c, s, qty, loc = s.hq, sku = s.sku, item = s.i
     values ($1,$2,$3,$4,12.3456,$5,'transfer',$6,$7,$8,$9)
     returning id
   `, [s.tenant, loc, sku, qty, type, s.transfer, item, s.operator, `${s.suffix} inbound raw`]);
+  return row.id;
+}
+
+async function linkedRawInboundMovement(c, s, qty) {
+  const movementId = await rawInboundMovement(c, s, qty);
+  await c.query('alter table public.transfer_items disable trigger trg_hq_return_source');
+  try {
+    await c.query('update transfer_items set in_movement_id = $1 where id = $2', [movementId, s.item]);
+  } finally {
+    await c.query('alter table public.transfer_items enable trigger trg_hq_return_source');
+  }
+  return movementId;
+}
+
+async function inboundMovementWithoutLine(c, s, qty) {
+  const row = await q1(c, `
+    insert into stock_movements
+      (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, source_doc_type, source_doc_id, operator_id, notes)
+    values ($1,$2,$3,$4,12.3456,'transfer_in','transfer',$5,$6,$7)
+    returning id
+  `, [s.tenant, s.hq, s.sku, qty, s.transfer, s.operator, `${s.suffix} inbound without line id`]);
+  await c.query('update transfer_items set in_movement_id = $1 where id = $2', [row.id, s.item]);
   return row.id;
 }
 
@@ -321,7 +347,7 @@ async function testDisposeHappyAndSplit(c) {
 async function testSourceValidation(c) {
   await tx(c, '來源數量、地點、品項、原單行不符要拒絕', async () => {
     const s = await seedBasic(c, { qty: 10 });
-    s.sourceMovement = await inboundMovement(c, s, 10);
+    s.sourceMovement = await linkedRawInboundMovement(c, s, 10);
     const before = () => q1(c, 'select count(*)::int as batches from hq_return_batches');
     const failures = [];
     const check = async (label, fn, re) => {
@@ -332,8 +358,14 @@ async function testSourceValidation(c) {
       }
     };
 
+    await c.query('savepoint source_control');
+    const control = await hold(c, s, 10);
+    assert.ok(control, '合法來源 control 應可建立待處理批次');
+    await c.query('rollback to savepoint source_control');
+    await c.query('release savepoint source_control');
+
     await check('hold qty 大於來源 movement', () => hold(c, s, 11), /qty|quantity|source|exceed|來源|數量/i);
-    await check('hold location 不等於來源 movement location', () => hold(c, s, 10, s.sourceMovement, s.item, s.otherHq), /location|source|movement|地點/i);
+    await check('hold location 不等於來源 movement location', () => hold(c, s, 10, s.sourceMovement, s.item, s.sameTenantOtherHq), /location|source|movement|地點/i);
 
     const product2 = (await q1(c, `
       insert into products (tenant_id, product_code, name, status, created_by)
@@ -354,6 +386,29 @@ async function testSourceValidation(c) {
   });
 }
 
+async function testSourceLineNullPositive(c) {
+  await tx(c, '真收貨 movement 無 source_doc_line_id 但 item 指回 movement 時 B 自動建批要成功', async () => {
+    const s = await seedBasic(c, { qty: 10 });
+    s.sourceMovement = await inboundMovementWithoutLine(c, s, 10);
+    s.batch = (await q1(c, 'select id from hq_return_batches where source_movement_id = $1', [s.sourceMovement]))?.id;
+    assert.ok(s.batch, 'B trigger 應依 transfer_items.in_movement_id 自動建待處理批次');
+    const row = await q1(c, `
+      select b.total_qty::text, b.unit_cost::text, m.unit_cost::text as source_unit_cost, b.source_transfer_item_id,
+             sb.on_hand::text, sb.reserved::text
+      from hq_return_batches b
+      join stock_movements m on m.id = b.source_movement_id
+      join stock_balances sb
+        on sb.tenant_id=b.tenant_id and sb.location_id=b.location_id and sb.sku_id=b.sku_id
+      where b.id = $1
+    `, [s.batch]);
+    assert.equal(row.source_transfer_item_id, s.item);
+    assert.equal(row.total_qty, '10.000');
+    assert.equal(row.unit_cost, row.source_unit_cost);
+    assert.equal(row.on_hand, '10.000');
+    assert.equal(row.reserved, '10.000');
+  });
+}
+
 async function testIdempotency(c) {
   await tx(c, '重送與同 request 不同 payload', async () => {
     const s = await seedHeldBatch(c, 10);
@@ -365,6 +420,56 @@ async function testIdempotency(c) {
     assert.equal(second.idempotent, true);
     assert.deepEqual(await ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' }), snap);
     await expectReject(c, '同 request_id 不同 reason/notes 不能算同一包', () => ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' }), () => dispose(c, s.batch, req, 7, 2, 1, '另一個破損原因', '遺失', true, 'changed'), /request_id|payload|different|reason|notes/i);
+  });
+}
+
+async function testIdempotencyReplayAfterComplete(c) {
+  await tx(c, '第一請求 partial，第二請求結案後重送第一請求仍回第一請求原結果', async () => {
+    const s = await seedHeldBatch(c, 10);
+    await setAuth(c, s.tenant, s.operator, 'hq_manager');
+    const req1 = id();
+    const first = await dispose(c, s.batch, req1, 4, 0, 0, null, null, true, 'first partial');
+    assert.equal(first.idempotent, false);
+    assert.equal(first.new_status, 'partial');
+    const firstEvent = first.event_id;
+
+    const req2 = id();
+    const second = await dispose(c, s.batch, req2, 6, 0, 0, null, null, true, 'complete later');
+    assert.equal(second.new_status, 'completed');
+    const completedSnap = await ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' });
+
+    const replay = await dispose(c, s.batch, req1, 4, 0, 0, null, null, true, 'first partial');
+    assert.equal(replay.idempotent, true);
+    assert.equal(replay.event_id, firstEvent);
+    assert.equal(replay.new_status, 'partial', '重送第一請求應回第一請求當時結果，不可回後來 completed 狀態或省略狀態');
+    assert.deepEqual(await ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' }), completedSnap);
+  });
+}
+
+async function testIdempotencyPayloadFields(c) {
+  await tx(c, '同 request id 變 goods_confirmed/notes/原因逐項拒絕且無副作用', async () => {
+    const s = await seedHeldBatch(c, 10);
+    await setAuth(c, s.tenant, s.operator, 'hq_manager');
+    const req = id();
+    await dispose(c, s.batch, req, 1, 1, 1, '破損A', '遺失A', true, 'notes A');
+    const snap = await ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' });
+    assert.equal(snap.status, 'partial');
+    assert.equal(String(Number(snap.total_qty) - Number(snap.qty_good) - Number(snap.qty_damaged) - Number(snap.qty_lost) - Number(snap.qty_revoked)), '7');
+
+    const before = () => ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' });
+    const failures = [];
+    const check = async (label, fn) => {
+      try {
+        await expectReject(c, label, before, fn, /request_id|payload|different|goods_confirmed|reason|notes/i);
+      } catch (e) {
+        failures.push(`${label}: ${e.message}`);
+      }
+    };
+    await check('同 request id 變 goods_confirmed 應拒絕', () => dispose(c, s.batch, req, 1, 1, 1, '破損A', '遺失A', false, 'notes A'));
+    await check('同 request id 變 notes 應拒絕', () => dispose(c, s.batch, req, 1, 1, 1, '破損A', '遺失A', true, 'notes B'));
+    await check('同 request id 變 damage_reason 應拒絕', () => dispose(c, s.batch, req, 1, 1, 1, '破損B', '遺失A', true, 'notes A'));
+    await check('同 request id 變 loss_reason 應拒絕', () => dispose(c, s.batch, req, 1, 1, 1, '破損A', '遺失B', true, 'notes A'));
+    if (failures.length > 0) throw new Error(failures.join(' | '));
   });
 }
 
@@ -391,6 +496,25 @@ async function testBadNumbers(c) {
       select public.rpc_dispose_hq_return($1,$2,'Infinity'::numeric,0,0,null,null,true,'inf')
     `, [s2.batch, id()]), /numeric|Infinity|invalid|finite|數字/i);
     if (failures.length > 0) throw new Error(failures.join(' | '));
+  });
+}
+
+async function testReservedCorruption(c) {
+  await tx(c, 'reserved 被人為破壞小於 pending 時 dispose 必須拒絕且無副作用', async () => {
+    const s = await seedHeldBatch(c, 10);
+    await c.query(`
+      update stock_balances
+         set reserved = 5
+       where tenant_id = $1 and location_id = $2 and sku_id = $3
+    `, [s.tenant, s.hq, s.sku]);
+    await setAuth(c, s.tenant, s.operator, 'hq_manager');
+    await expectReject(
+      c,
+      'reserved 小於 pending 時不可處理',
+      () => ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' }),
+      () => dispose(c, s.batch, id(), 1, 0, 0, null, null, true, 'reserved corrupt'),
+      /reserved|pending|inconsistent|保留|待處理/i,
+    );
   });
 }
 
@@ -422,6 +546,32 @@ async function testPendingGuardAndGoodStock(c) {
       insert into stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, operator_id, notes)
       values ($1,$2,$3,-21,12.3456,'manual_adjust',$4,'direct negative bypass')
     `, [s.tenant, s.hq, s.sku, s.operator]), /pending|guard|退回|待處理|reserved/i);
+  });
+}
+
+async function testRoleEdges(c) {
+  await tx(c, '越權 hq_accountant、空 role、缺 auth.uid 都要拒絕', async () => {
+    const s = await seedHeldBatch(c, 3);
+    const failures = [];
+    const check = async (label, tenant, user, appRole) => {
+      await resetRole(c);
+      await setAuth(c, tenant, user, appRole);
+      try {
+        await expectReject(
+          c,
+          label,
+          () => ownerSnapshot(c, s.batch, { tenant, user, appRole }),
+          () => dispose(c, s.batch, id(), 1, 0, 0, null, null, true, label),
+          /auth|permission|role|denied|權限|登入/i,
+        );
+      } catch (e) {
+        failures.push(`${label}: ${e.message}`);
+      }
+    };
+    await check('hq_accountant 不可處理', s.tenant, id(), 'hq_accountant');
+    await check('空 role 不可處理', s.tenant, id(), '');
+    await check('缺 auth.uid 不可處理', s.tenant, null, 'hq_manager');
+    if (failures.length > 0) throw new Error(failures.join(' | '));
   });
 }
 
@@ -577,9 +727,14 @@ async function testRaceHoldVsNegative(dbName) {
 const CASES = [
   { name: 'dispose_split', fn: testDisposeHappyAndSplit, race: false },
   { name: 'source_validation', fn: testSourceValidation, race: false },
+  { name: 'source_line_null_positive', fn: testSourceLineNullPositive, race: false },
   { name: 'idempotency', fn: testIdempotency, race: false },
+  { name: 'idempotency_replay_after_complete', fn: testIdempotencyReplayAfterComplete, race: false },
+  { name: 'idempotency_payload_fields', fn: testIdempotencyPayloadFields, race: false },
   { name: 'bad_numbers', fn: testBadNumbers, race: false },
+  { name: 'reserved_corruption', fn: testReservedCorruption, race: false },
   { name: 'pending_guard', fn: testPendingGuardAndGoodStock, race: false },
+  { name: 'role_edges', fn: testRoleEdges, race: false },
   { name: 'rls_roles', fn: testTenantRoleAndAnon, race: false },
   { name: 'race_same_request', fn: testRaceSameRequest, race: true },
   { name: 'race_hold_negative', fn: testRaceHoldVsNegative, race: true },

--- a/tests/return-disposition-review/core-runtime.cjs
+++ b/tests/return-disposition-review/core-runtime.cjs
@@ -1,0 +1,527 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const { Client } = require('pg');
+
+const DB_RE = /^return_disposition_test_[A-Za-z0-9_]+$/;
+const HOST = '127.0.0.1';
+const PORT = 56427;
+const USER = 'returnlocal';
+const OWNER = '00000000-0000-0000-0000-000000000000';
+
+function usage() {
+  console.error('usage: node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_<name>');
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    if (argv[i] === '--db-name') out.dbName = argv[++i];
+    else usage();
+  }
+  if (!out.dbName || !DB_RE.test(out.dbName)) {
+    throw new Error(`拒絕連線：--db-name 必須符合 ${DB_RE}`);
+  }
+  return out;
+}
+
+function id() {
+  return crypto.randomUUID();
+}
+
+function code() {
+  return `rt_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function client(dbName) {
+  return new Client({ host: HOST, port: PORT, user: USER, database: dbName });
+}
+
+async function connect(dbName) {
+  const c = client(dbName);
+  await c.connect();
+  const got = await c.query('select current_database() as db, current_user as usr, inet_server_addr()::text as host, inet_server_port() as port');
+  assert.equal(got.rows[0].db, dbName, '連到的資料庫名稱不符');
+  assert.equal(got.rows[0].usr, USER, '連線使用者不符');
+  assert.ok(String(got.rows[0].host).startsWith(HOST), '連線主機不符');
+  assert.equal(Number(got.rows[0].port), PORT, '連線 port 不符');
+  return c;
+}
+
+async function q1(c, sql, params = []) {
+  const r = await c.query(sql, params);
+  return r.rows[0];
+}
+
+async function tx(c, name, fn) {
+  await c.query('begin');
+  try {
+    await c.query(`set local statement_timeout = '3000ms'`);
+    await fn();
+    console.log(`ok - ${name}`);
+  } finally {
+    await c.query('rollback');
+  }
+}
+
+async function setAuth(c, tenantId, userId, appRole = 'owner', pgRole = 'authenticated') {
+  assert.match(pgRole, /^(authenticated|anon)$/);
+  await c.query(`set local role ${pgRole}`);
+  const claims = {
+    sub: userId,
+    tenant_id: tenantId,
+    role: appRole,
+    app_metadata: { role: appRole },
+    user_metadata: { tenant_id: tenantId },
+  };
+  await c.query('select set_config($1, $2, true)', ['request.jwt.claim.sub', userId || '']);
+  await c.query('select set_config($1, $2, true)', ['request.jwt.claims', JSON.stringify(claims)]);
+}
+
+async function resetRole(c) {
+  await c.query('reset role');
+}
+
+async function preflight(c) {
+  const requiredTables = [
+    'products',
+    'skus',
+    'locations',
+    'stock_balances',
+    'stock_movements',
+    'transfers',
+    'transfer_items',
+    'hq_return_batches',
+    'hq_return_events',
+  ];
+  const missingTables = [];
+  for (const t of requiredTables) {
+    const row = await q1(c, 'select to_regclass($1) as oid', [`public.${t}`]);
+    if (!row.oid) missingTables.push(t);
+  }
+  assert.deepEqual(missingTables, [], `fixture 缺表：${missingTables.join(', ')}`);
+
+  const requiredRoutines = [
+    'public._hq_hold_return(uuid,bigint,bigint,bigint,bigint,text,text,numeric,uuid,text)',
+    'public.rpc_dispose_hq_return(bigint,uuid,numeric,numeric,numeric,text,text,boolean,text)',
+    'public.rpc_outbound(uuid,bigint,bigint,numeric,text,text,bigint,uuid,boolean,numeric)',
+  ];
+  const missingRoutines = [];
+  for (const sig of requiredRoutines) {
+    const row = await q1(c, 'select to_regprocedure($1) as oid', [sig]);
+    if (!row.oid) missingRoutines.push(sig);
+  }
+  assert.deepEqual(missingRoutines, [], `fixture 缺函式：${missingRoutines.join(', ')}`);
+
+  const roles = await c.query(`select rolname from pg_roles where rolname in ('authenticated','anon')`);
+  assert.deepEqual(roles.rows.map((r) => r.rolname).sort(), ['anon', 'authenticated'], 'fixture 必須建立 authenticated/anon 角色，才能真驗 RLS/GRANT');
+}
+
+async function seedBasic(c, opts = {}) {
+  const suffix = opts.suffix || code();
+  const tenant = opts.tenant || id();
+  const operator = opts.operator || id();
+  const otherTenant = opts.otherTenant || id();
+
+  const hq = (await q1(c, `
+    insert into locations (tenant_id, code, name, type, created_by)
+    values ($1,$2,$3,'central_warehouse',$4) returning id
+  `, [tenant, `${suffix}_hq`, `${suffix} 總倉`, operator])).id;
+  const store = (await q1(c, `
+    insert into locations (tenant_id, code, name, type, created_by)
+    values ($1,$2,$3,'store',$4) returning id
+  `, [tenant, `${suffix}_store`, `${suffix} 店`, operator])).id;
+  const otherHq = (await q1(c, `
+    insert into locations (tenant_id, code, name, type, created_by)
+    values ($1,$2,$3,'central_warehouse',$4) returning id
+  `, [otherTenant, `${suffix}_other_hq`, `${suffix} 別租戶總倉`, operator])).id;
+  const product = (await q1(c, `
+    insert into products (tenant_id, product_code, name, status, created_by)
+    values ($1,$2,$3,'active',$4) returning id
+  `, [tenant, `${suffix}_p`, `${suffix} 商品`, operator])).id;
+  const sku = (await q1(c, `
+    insert into skus (tenant_id, product_id, sku_code, status, product_name, created_by)
+    values ($1,$2,$3,'active',$4,$5) returning id
+  `, [tenant, product, `${suffix}_sku`, `${suffix} 商品`, operator])).id;
+  const transfer = (await q1(c, `
+    insert into transfers (tenant_id, transfer_no, source_location, dest_location, transfer_type, status, requested_by, created_by, notes)
+    values ($1,$2,$3,$4,'return_to_hq','shipped',$5,$5,$6) returning id
+  `, [tenant, `${suffix}_tr`, store, hq, operator, `${suffix} return_to_hq`])).id;
+  const item = (await q1(c, `
+    insert into transfer_items (transfer_id, sku_id, qty_requested, qty_shipped, qty_received, created_by)
+    values ($1,$2,$3,$3,$3,$4) returning id
+  `, [transfer, sku, opts.qty || 10, operator])).id;
+
+  return { suffix, tenant, otherTenant, operator, hq, store, otherHq, product, sku, transfer, item };
+}
+
+async function inboundMovement(c, s, qty, loc = s.hq, sku = s.sku, item = s.item, type = 'transfer_in') {
+  const row = await q1(c, `
+    insert into stock_movements
+      (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, source_doc_type, source_doc_id, source_doc_line_id, operator_id, notes)
+    values ($1,$2,$3,$4,12.3456,$5,'transfer',$6,$7,$8,$9)
+    returning id
+  `, [s.tenant, loc, sku, qty, type, s.transfer, item, s.operator, `${s.suffix} inbound`]);
+  await c.query('update transfer_items set in_movement_id = $1 where id = $2', [row.id, s.item]);
+  return row.id;
+}
+
+async function rawInboundMovement(c, s, qty, loc = s.hq, sku = s.sku, item = s.item, type = 'transfer_in') {
+  const row = await q1(c, `
+    insert into stock_movements
+      (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, source_doc_type, source_doc_id, source_doc_line_id, operator_id, notes)
+    values ($1,$2,$3,$4,12.3456,$5,'transfer',$6,$7,$8,$9)
+    returning id
+  `, [s.tenant, loc, sku, qty, type, s.transfer, item, s.operator, `${s.suffix} inbound raw`]);
+  return row.id;
+}
+
+async function hold(c, s, qty = 10, sourceMovementId = s.sourceMovement, item = s.item, loc = s.hq, sku = s.sku) {
+  const row = await q1(c, `
+    select public._hq_hold_return($1,$2,$3,$4,$5,'store_return','review fixture',$6,$7,'manual') as id
+  `, [s.tenant, loc, sku, sourceMovementId, item, qty, s.operator]);
+  return row.id;
+}
+
+async function seedHeldBatch(c, qty = 10) {
+  const s = await seedBasic(c, { qty });
+  s.sourceMovement = await inboundMovement(c, s, qty);
+  const existing = await q1(c, 'select id from hq_return_batches where source_movement_id = $1', [s.sourceMovement]);
+  s.batch = existing?.id || await hold(c, s, qty);
+  return s;
+}
+
+async function snapshot(c, batchId) {
+  const row = await q1(c, `
+    select
+      b.id, b.tenant_id::text, b.location_id, b.sku_id, b.total_qty::text,
+      b.qty_good::text, b.qty_damaged::text, b.qty_lost::text, b.qty_revoked::text,
+      b.status, coalesce(sb.on_hand,0)::text as on_hand, coalesce(sb.reserved,0)::text as reserved,
+      (select count(*)::int from hq_return_events e where e.batch_id = b.id) as events,
+      (select coalesce(sum(abs(m.quantity)),0)::text from stock_movements m where m.source_doc_type='hq_return_batch' and m.source_doc_id=b.id and m.quantity < 0) as hq_neg_qty
+    from hq_return_batches b
+    left join stock_balances sb on sb.tenant_id=b.tenant_id and sb.location_id=b.location_id and sb.sku_id=b.sku_id
+    where b.id = $1
+  `, [batchId]);
+  assert.ok(row, `找不到 batch ${batchId}`);
+  return row;
+}
+
+async function ownerSnapshot(c, batchId, restoreAuth = null) {
+  await resetRole(c);
+  const snap = await snapshot(c, batchId);
+  if (restoreAuth) await setAuth(c, restoreAuth.tenant, restoreAuth.user, restoreAuth.appRole, restoreAuth.pgRole || 'authenticated');
+  return snap;
+}
+
+async function dispose(c, batchId, requestId, good, damaged, lost, damageReason, lossReason, confirmed, notes) {
+  const row = await q1(c, `
+    select public.rpc_dispose_hq_return($1,$2,$3::numeric,$4::numeric,$5::numeric,$6,$7,$8,$9) as result
+  `, [batchId, requestId, good, damaged, lost, damageReason, lossReason, confirmed, notes]);
+  return row.result;
+}
+
+let sp = 0;
+async function expectReject(c, label, beforeFn, fn, messageRe) {
+  const name = `sp_${sp += 1}`;
+  const before = await beforeFn();
+  await c.query(`savepoint ${name}`);
+  let err;
+  try {
+    await fn();
+  } catch (e) {
+    err = e;
+  }
+  assert.ok(err, `${label} 應該拒絕，但實際成功`);
+  assert.match(String(err.message), messageRe, `${label} 錯誤訊息不符合預期`);
+  await c.query(`rollback to savepoint ${name}`);
+  const after = await beforeFn();
+  assert.deepEqual(after, before, `${label} 失敗後狀態不應改變`);
+  await c.query(`release savepoint ${name}`);
+}
+
+async function expectNoRowsOrPermission(c, label, sql, params = []) {
+  const name = `sp_${sp += 1}`;
+  await c.query(`savepoint ${name}`);
+  let result;
+  let err;
+  try {
+    result = await c.query(sql, params);
+  } catch (e) {
+    err = e;
+  }
+  if (err) {
+    await c.query(`rollback to savepoint ${name}`);
+    assert.equal(err.code, '42501', `${label} 只能接受權限錯誤 42501，不接受任意錯誤：${err.message}`);
+    await c.query(`release savepoint ${name}`);
+    return;
+  }
+  assert.equal(result.rows.length, 0, label);
+  await c.query(`release savepoint ${name}`);
+}
+
+async function testDisposeHappyAndSplit(c) {
+  await tx(c, '10 件分 7 好 2 破 1 失，並支援分次', async () => {
+    const s = await seedHeldBatch(c, 10);
+    await setAuth(c, s.tenant, s.operator, 'hq_manager');
+    const r1 = await dispose(c, s.batch, id(), 4, 0, 0, null, null, true, 'first good');
+    assert.equal(r1.idempotent, false);
+    assert.equal(r1.new_status, 'partial');
+    let snap = await ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' });
+    assert.equal(snap.qty_good, '4.000');
+    assert.equal(snap.reserved, '6.000');
+    assert.equal(snap.on_hand, '10.000');
+
+    const r2 = await dispose(c, s.batch, id(), 3, 2, 1, '破損', '遺失', true, 'finish');
+    assert.equal(r2.new_status, 'completed');
+    snap = await ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' });
+    assert.equal(snap.qty_good, '7.000');
+    assert.equal(snap.qty_damaged, '2.000');
+    assert.equal(snap.qty_lost, '1.000');
+    assert.equal(snap.reserved, '0.000');
+    assert.equal(snap.on_hand, '7.000');
+    assert.equal(snap.hq_neg_qty, '3.000');
+  });
+}
+
+async function testSourceValidation(c) {
+  await tx(c, '來源數量、地點、品項、原單行不符要拒絕', async () => {
+    const s = await seedBasic(c, { qty: 10 });
+    s.sourceMovement = await inboundMovement(c, s, 10);
+    const before = () => q1(c, 'select count(*)::int as batches from hq_return_batches');
+
+    await expectReject(c, 'hold qty 大於來源 movement', before, () => hold(c, s, 11), /qty|quantity|source|exceed|來源|數量/i);
+    await expectReject(c, 'hold location 不等於來源 movement location', before, () => hold(c, s, 10, s.sourceMovement, s.item, s.otherHq), /location|source|movement|地點/i);
+
+    const product2 = (await q1(c, `
+      insert into products (tenant_id, product_code, name, status, created_by)
+      values ($1,$2,$3,'active',$4) returning id
+    `, [s.tenant, `${s.suffix}_p2`, `${s.suffix} 商品2`, s.operator])).id;
+    const sku2 = (await q1(c, `
+      insert into skus (tenant_id, product_id, sku_code, status, product_name, created_by)
+      values ($1,$2,$3,'active',$4,$5) returning id
+    `, [s.tenant, product2, `${s.suffix}_sku2`, `${s.suffix} 商品2`, s.operator])).id;
+    await expectReject(c, 'hold sku 不等於來源 movement sku', before, () => hold(c, s, 10, s.sourceMovement, s.item, s.hq, sku2), /sku|source|movement|品項/i);
+
+    const wrongItem = (await q1(c, `
+      insert into transfer_items (transfer_id, sku_id, qty_requested, qty_shipped, qty_received, created_by)
+      values ($1,$2,10,10,10,$3) returning id
+    `, [s.transfer, s.sku, s.operator])).id;
+    await expectReject(c, 'hold transfer_item 不等於來源 movement source_doc_line_id', before, () => hold(c, s, 10, s.sourceMovement, wrongItem), /item|line|source|transfer|原單/i);
+  });
+}
+
+async function testIdempotencyAndBadNumbers(c) {
+  await tx(c, '重送、不同 payload、NULL/NaN/Infinity/四位小數', async () => {
+    const s = await seedHeldBatch(c, 10);
+    await setAuth(c, s.tenant, s.operator, 'hq_manager');
+    const req = id();
+    const first = await dispose(c, s.batch, req, 7, 2, 1, '破損', '遺失', true, 'same');
+    const snap = await ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' });
+    const second = await dispose(c, s.batch, req, 7, 2, 1, '破損', '遺失', true, 'same');
+    assert.equal(second.idempotent, true);
+    assert.deepEqual(await ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' }), snap);
+    await expectReject(c, '同 request_id 不同 reason/notes 不能算同一包', () => ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' }), () => dispose(c, s.batch, req, 7, 2, 1, '另一個破損原因', '遺失', true, 'changed'), /request_id|payload|different|reason|notes/i);
+
+    await resetRole(c);
+    const s2 = await seedHeldBatch(c, 10);
+    await setAuth(c, s2.tenant, s2.operator, 'hq_manager');
+    await expectReject(c, 'NULL 數量拒絕', () => ownerSnapshot(c, s2.batch, { tenant: s2.tenant, user: s2.operator, appRole: 'hq_manager' }), () => dispose(c, s2.batch, id(), null, 0, 0, null, null, true, 'null'), /quantity|數量|null|non-negative/i);
+    await expectReject(c, '四位小數拒絕', () => ownerSnapshot(c, s2.batch, { tenant: s2.tenant, user: s2.operator, appRole: 'hq_manager' }), () => dispose(c, s2.batch, id(), 0.0001, 0, 0, null, null, true, 'scale'), /scale|precision|小數|3/i);
+    await expectReject(c, 'NaN 拒絕', () => ownerSnapshot(c, s2.batch, { tenant: s2.tenant, user: s2.operator, appRole: 'hq_manager' }), () => c.query(`
+      select public.rpc_dispose_hq_return($1,$2,'NaN'::numeric,0,0,null,null,true,'nan')
+    `, [s2.batch, id()]), /numeric|NaN|invalid|finite|數字/i);
+    await expectReject(c, 'Infinity 拒絕', () => ownerSnapshot(c, s2.batch, { tenant: s2.tenant, user: s2.operator, appRole: 'hq_manager' }), () => c.query(`
+      select public.rpc_dispose_hq_return($1,$2,'Infinity'::numeric,0,0,null,null,true,'inf')
+    `, [s2.batch, id()]), /numeric|Infinity|invalid|finite|數字/i);
+  });
+}
+
+async function testPendingGuardAndGoodStock(c) {
+  await tx(c, 'pending 不可派，但既有好貨仍可派', async () => {
+    const s = await seedHeldBatch(c, 5);
+    await c.query(`
+      insert into stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, operator_id, notes)
+      values ($1,$2,$3,20,12.3456,'manual_adjust',$4,'既有好貨')
+    `, [s.tenant, s.hq, s.sku, s.operator]);
+
+    const bal = await q1(c, 'select on_hand::text, reserved::text from stock_balances where tenant_id=$1 and location_id=$2 and sku_id=$3', [s.tenant, s.hq, s.sku]);
+    assert.equal(bal.on_hand, '25.000');
+    assert.equal(bal.reserved, '5.000');
+
+    await c.query('savepoint good_stock');
+    await q1(c, `select public.rpc_outbound($1,$2,$3,20,'transfer_out','review',1,$4,false,12.3456) as id`, [s.tenant, s.hq, s.sku, s.operator]);
+    await c.query('rollback to savepoint good_stock');
+
+    await expectReject(c, '派第 21 件應擋住', () => snapshot(c, s.batch), () => q1(c, `
+      select public.rpc_outbound($1,$2,$3,21,'transfer_out','review',1,$4,false,12.3456) as id
+    `, [s.tenant, s.hq, s.sku, s.operator]), /insufficient|available|stock|庫存|不足/i);
+
+    await expectReject(c, 'p_allow_negative 仍不得吃 pending', () => snapshot(c, s.batch), () => q1(c, `
+      select public.rpc_outbound($1,$2,$3,21,'transfer_out','review',1,$4,true,12.3456) as id
+    `, [s.tenant, s.hq, s.sku, s.operator]), /pending|guard|退回|待處理|reserved/i);
+
+    await expectReject(c, '直接負 movement 不得吃 pending', () => snapshot(c, s.batch), () => c.query(`
+      insert into stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, operator_id, notes)
+      values ($1,$2,$3,-21,12.3456,'manual_adjust',$4,'direct negative bypass')
+    `, [s.tenant, s.hq, s.sku, s.operator]), /pending|guard|退回|待處理|reserved/i);
+  });
+}
+
+async function testTenantRoleAndAnon(c) {
+  await tx(c, 'RLS/GRANT：店家、跨租戶、匿名都不能讀或處理', async () => {
+    const s = await seedHeldBatch(c, 3);
+    const hqUser = id();
+    const storeUser = id();
+    const crossUser = id();
+
+    await setAuth(c, s.tenant, hqUser, 'hq_manager');
+    const hqVisible = await c.query('select id from v_hq_return_batches_list where id = $1', [s.batch]);
+    assert.equal(hqVisible.rows.length, 1, 'HQ 角色應該讀得到同 tenant 待處理批次；否則不能把「看不到」當成安全');
+
+    await resetRole(c);
+    await setAuth(c, s.tenant, storeUser, 'store_manager');
+    await expectNoRowsOrPermission(c, '店家角色不應讀到總倉待處理批次', 'select id from v_hq_return_batches_list where id = $1', [s.batch]);
+    await expectReject(c, '店家角色不能處理', () => ownerSnapshot(c, s.batch, { tenant: s.tenant, user: storeUser, appRole: 'store_manager' }), () => dispose(c, s.batch, id(), 1, 0, 0, null, null, true, 'store'), /permission|role|denied|權限/i);
+
+    await resetRole(c);
+    await setAuth(c, s.otherTenant, crossUser, 'hq_manager');
+    await expectNoRowsOrPermission(c, '跨租戶不應讀到別人的批次', 'select id from v_hq_return_batches_list where id = $1', [s.batch]);
+    await expectReject(c, '跨租戶不能處理', () => ownerSnapshot(c, s.batch, { tenant: s.otherTenant, user: crossUser, appRole: 'hq_manager' }), () => dispose(c, s.batch, id(), 1, 0, 0, null, null, true, 'cross'), /tenant|not found|permission|different|租戶|權限/i);
+
+    await resetRole(c);
+    await setAuth(c, s.tenant, null, '', 'anon');
+    await expectNoRowsOrPermission(c, '匿名不應讀到批次', 'select id from v_hq_return_batches_list where id = $1', [s.batch]);
+    await expectReject(c, '匿名不能處理', () => ownerSnapshot(c, s.batch, { tenant: s.tenant, user: null, appRole: '', pgRole: 'anon' }), () => dispose(c, s.batch, id(), 1, 0, 0, null, null, true, 'anon'), /auth|permission|role|JWT|登入|權限/i);
+  });
+}
+
+function noteRaceTenant(tenant) {
+  console.warn(`race fixture retained for audit; tenant_id=${tenant}`);
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitUntilBlocked(observer, pid, label) {
+  for (let i = 0; i < 40; i += 1) {
+    const row = await q1(observer, `
+      select wait_event_type, wait_event, state
+      from pg_stat_activity
+      where pid = $1
+    `, [pid]);
+    if (row && row.wait_event_type === 'Lock') return row;
+    await wait(25);
+  }
+  throw new Error(`${label}：未觀察到第二連線等待 Lock，不能把固定等待當併發證據`);
+}
+
+async function testRaceSameRequest(dbName) {
+  const c0 = await connect(dbName);
+  const c1 = await connect(dbName);
+  const c2 = await connect(dbName);
+  let tenant;
+  try {
+    const s = await seedHeldBatch(c0, 10);
+    tenant = s.tenant;
+    await c1.query('begin');
+    await c1.query(`set local statement_timeout = '3000ms'`);
+    await setAuth(c1, s.tenant, s.operator, 'hq_manager');
+    const req = id();
+    const first = dispose(c1, s.batch, req, 10, 0, 0, null, null, true, 'race').catch((e) => { throw e; });
+    await first;
+
+    await c2.query('begin');
+    await c2.query(`set local statement_timeout = '1500ms'`);
+    await setAuth(c2, s.tenant, s.operator, 'hq_manager');
+    const second = dispose(c2, s.batch, req, 10, 0, 0, null, null, true, 'race').catch((e) => e);
+    await waitUntilBlocked(c0, c2.processID, 'same request dispose 等待第一個交易');
+    await c1.query('commit');
+    const r2 = await second;
+    if (r2 instanceof Error) throw r2;
+    assert.equal(r2.idempotent, true, '同 request 併發重送應回冪等結果，不應多扣或 already completed');
+    await c2.query('commit');
+    console.log('ok - 兩連線同 request 併發');
+  } catch (e) {
+    await c1.query('rollback').catch(() => undefined);
+    await c2.query('rollback').catch(() => undefined);
+    throw e;
+  } finally {
+    if (tenant) noteRaceTenant(tenant);
+    await c0.end();
+    await c1.end();
+    await c2.end();
+  }
+}
+
+async function testRaceHoldVsNegative(dbName) {
+  const c0 = await connect(dbName);
+  const c1 = await connect(dbName);
+  const c2 = await connect(dbName);
+  let tenant;
+  try {
+    const s = await seedBasic(c0, { qty: 5 });
+    tenant = s.tenant;
+    await c0.query(`
+      insert into stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, operator_id, notes)
+      values ($1,$2,$3,20,12.3456,'manual_adjust',$4,'既有好貨')
+    `, [s.tenant, s.hq, s.sku, s.operator]);
+
+    await c1.query('begin');
+    await c1.query(`set local statement_timeout = '3000ms'`);
+    const source = await rawInboundMovement(c1, s, 5);
+    await c1.query('update transfer_items set in_movement_id = $1 where id = $2', [source, s.item]);
+
+    await c2.query('begin');
+    await c2.query(`set local statement_timeout = '1500ms'`);
+    const out = c2.query(`
+      insert into stock_movements (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, operator_id, notes)
+      values ($1,$2,$3,-21,12.3456,'manual_adjust',$4,'race direct negative')
+    `, [s.tenant, s.hq, s.sku, s.operator]).catch((e) => e);
+    await waitUntilBlocked(c0, c2.processID, 'hold vs negative 等待第一個交易');
+    await c1.query('commit');
+
+    const err = await out;
+    assert.ok(err, 'hold 併發建立後，直接負異動吃 pending 應拒絕');
+    assert.ok(err instanceof Error, 'hold 併發建立後，直接負異動應回錯誤物件');
+    assert.match(String(err.message), /pending|guard|退回|待處理|reserved/i);
+    await c2.query('rollback');
+    console.log('ok - 兩連線 hold vs 直接負異動');
+  } catch (e) {
+    await c1.query('rollback').catch(() => undefined);
+    await c2.query('rollback').catch(() => undefined);
+    throw e;
+  } finally {
+    if (tenant) noteRaceTenant(tenant);
+    await c0.end();
+    await c1.end();
+    await c2.end();
+  }
+}
+
+async function main() {
+  const { dbName } = parseArgs(process.argv);
+  const c = await connect(dbName);
+  try {
+    await preflight(c);
+    await testDisposeHappyAndSplit(c);
+    await testSourceValidation(c);
+    await testIdempotencyAndBadNumbers(c);
+    await testPendingGuardAndGoodStock(c);
+    await testTenantRoleAndAnon(c);
+  } finally {
+    await c.end();
+  }
+  await testRaceSameRequest(dbName);
+  await testRaceHoldVsNegative(dbName);
+  console.log('core_runtime_ok');
+}
+
+main().catch((e) => {
+  console.error(e.stack || e.message);
+  process.exit(1);
+});

--- a/tests/return-disposition-review/core-runtime.cjs
+++ b/tests/return-disposition-review/core-runtime.cjs
@@ -9,10 +9,9 @@ const DB_RE = /^return_disposition_test_[A-Za-z0-9_]+$/;
 const HOST = '127.0.0.1';
 const PORT = 56427;
 const USER = 'returnlocal';
-const OWNER = '00000000-0000-0000-0000-000000000000';
 
 function usage() {
-  console.error('usage: node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_<name>');
+  console.error('usage: node tests/return-disposition-review/core-runtime.cjs --db-name return_disposition_test_<name> [--case name[,name...]]');
   process.exit(2);
 }
 
@@ -20,6 +19,10 @@ function parseArgs(argv) {
   const out = {};
   for (let i = 2; i < argv.length; i += 1) {
     if (argv[i] === '--db-name') out.dbName = argv[++i];
+    else if (argv[i] === '--case') {
+      if (!argv[i + 1] || argv[i + 1].startsWith('--')) usage();
+      out.caseNames = argv[++i];
+    }
     else usage();
   }
   if (!out.dbName || !DB_RE.test(out.dbName)) {
@@ -235,12 +238,40 @@ async function expectReject(c, label, beforeFn, fn, messageRe) {
   } catch (e) {
     err = e;
   }
-  assert.ok(err, `${label} 應該拒絕，但實際成功`);
-  assert.match(String(err.message), messageRe, `${label} 錯誤訊息不符合預期`);
+  if (!err) {
+    await c.query(`rollback to savepoint ${name}`);
+    await c.query(`release savepoint ${name}`);
+    assert.fail(`${label} 應該拒絕，但實際成功`);
+  }
+  if (!messageRe.test(String(err.message))) {
+    await c.query(`rollback to savepoint ${name}`);
+    await c.query(`release savepoint ${name}`);
+    assert.match(String(err.message), messageRe, `${label} 錯誤訊息不符合預期，實際訊息：${err.message}`);
+  }
   await c.query(`rollback to savepoint ${name}`);
   const after = await beforeFn();
   assert.deepEqual(after, before, `${label} 失敗後狀態不應改變`);
   await c.query(`release savepoint ${name}`);
+}
+
+async function expectRows(c, label, sql, params, expectedRows) {
+  const name = `sp_${sp += 1}`;
+  await c.query(`savepoint ${name}`);
+  let result;
+  let err;
+  try {
+    result = await c.query(sql, params);
+  } catch (e) {
+    err = e;
+  }
+  if (err) {
+    await c.query(`rollback to savepoint ${name}`);
+    await c.query(`release savepoint ${name}`);
+    throw err;
+  }
+  assert.equal(result.rows.length, expectedRows, label);
+  await c.query(`release savepoint ${name}`);
+  return result.rows;
 }
 
 async function expectNoRowsOrPermission(c, label, sql, params = []) {
@@ -292,9 +323,17 @@ async function testSourceValidation(c) {
     const s = await seedBasic(c, { qty: 10 });
     s.sourceMovement = await inboundMovement(c, s, 10);
     const before = () => q1(c, 'select count(*)::int as batches from hq_return_batches');
+    const failures = [];
+    const check = async (label, fn, re) => {
+      try {
+        await expectReject(c, label, before, fn, re);
+      } catch (e) {
+        failures.push(`${label}: ${e.message}`);
+      }
+    };
 
-    await expectReject(c, 'hold qty 大於來源 movement', before, () => hold(c, s, 11), /qty|quantity|source|exceed|來源|數量/i);
-    await expectReject(c, 'hold location 不等於來源 movement location', before, () => hold(c, s, 10, s.sourceMovement, s.item, s.otherHq), /location|source|movement|地點/i);
+    await check('hold qty 大於來源 movement', () => hold(c, s, 11), /qty|quantity|source|exceed|來源|數量/i);
+    await check('hold location 不等於來源 movement location', () => hold(c, s, 10, s.sourceMovement, s.item, s.otherHq), /location|source|movement|地點/i);
 
     const product2 = (await q1(c, `
       insert into products (tenant_id, product_code, name, status, created_by)
@@ -304,39 +343,54 @@ async function testSourceValidation(c) {
       insert into skus (tenant_id, product_id, sku_code, status, product_name, created_by)
       values ($1,$2,$3,'active',$4,$5) returning id
     `, [s.tenant, product2, `${s.suffix}_sku2`, `${s.suffix} 商品2`, s.operator])).id;
-    await expectReject(c, 'hold sku 不等於來源 movement sku', before, () => hold(c, s, 10, s.sourceMovement, s.item, s.hq, sku2), /sku|source|movement|品項/i);
+    await check('hold sku 不等於來源 movement sku', () => hold(c, s, 10, s.sourceMovement, s.item, s.hq, sku2), /sku|source|movement|品項/i);
 
     const wrongItem = (await q1(c, `
       insert into transfer_items (transfer_id, sku_id, qty_requested, qty_shipped, qty_received, created_by)
       values ($1,$2,10,10,10,$3) returning id
     `, [s.transfer, s.sku, s.operator])).id;
-    await expectReject(c, 'hold transfer_item 不等於來源 movement source_doc_line_id', before, () => hold(c, s, 10, s.sourceMovement, wrongItem), /item|line|source|transfer|原單/i);
+    await check('hold transfer_item 不等於來源 movement source_doc_line_id', () => hold(c, s, 10, s.sourceMovement, wrongItem), /item|line|source|transfer|原單/i);
+    if (failures.length > 0) throw new Error(failures.join(' | '));
   });
 }
 
-async function testIdempotencyAndBadNumbers(c) {
-  await tx(c, '重送、不同 payload、NULL/NaN/Infinity/四位小數', async () => {
+async function testIdempotency(c) {
+  await tx(c, '重送與同 request 不同 payload', async () => {
     const s = await seedHeldBatch(c, 10);
     await setAuth(c, s.tenant, s.operator, 'hq_manager');
     const req = id();
-    const first = await dispose(c, s.batch, req, 7, 2, 1, '破損', '遺失', true, 'same');
+    await dispose(c, s.batch, req, 7, 2, 1, '破損', '遺失', true, 'same');
     const snap = await ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' });
     const second = await dispose(c, s.batch, req, 7, 2, 1, '破損', '遺失', true, 'same');
     assert.equal(second.idempotent, true);
     assert.deepEqual(await ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' }), snap);
     await expectReject(c, '同 request_id 不同 reason/notes 不能算同一包', () => ownerSnapshot(c, s.batch, { tenant: s.tenant, user: s.operator, appRole: 'hq_manager' }), () => dispose(c, s.batch, req, 7, 2, 1, '另一個破損原因', '遺失', true, 'changed'), /request_id|payload|different|reason|notes/i);
+  });
+}
 
-    await resetRole(c);
+async function testBadNumbers(c) {
+  await tx(c, 'NULL/NaN/Infinity/四位小數', async () => {
     const s2 = await seedHeldBatch(c, 10);
     await setAuth(c, s2.tenant, s2.operator, 'hq_manager');
-    await expectReject(c, 'NULL 數量拒絕', () => ownerSnapshot(c, s2.batch, { tenant: s2.tenant, user: s2.operator, appRole: 'hq_manager' }), () => dispose(c, s2.batch, id(), null, 0, 0, null, null, true, 'null'), /quantity|數量|null|non-negative/i);
-    await expectReject(c, '四位小數拒絕', () => ownerSnapshot(c, s2.batch, { tenant: s2.tenant, user: s2.operator, appRole: 'hq_manager' }), () => dispose(c, s2.batch, id(), 0.0001, 0, 0, null, null, true, 'scale'), /scale|precision|小數|3/i);
-    await expectReject(c, 'NaN 拒絕', () => ownerSnapshot(c, s2.batch, { tenant: s2.tenant, user: s2.operator, appRole: 'hq_manager' }), () => c.query(`
+    const failures = [];
+    const check = async (label, fn, re) => {
+      try {
+        await expectReject(c, label, () => ownerSnapshot(c, s2.batch, { tenant: s2.tenant, user: s2.operator, appRole: 'hq_manager' }), fn, re);
+      } catch (e) {
+        failures.push(`${label}: ${e.message}`);
+      }
+    };
+    await check('NULL 完好數量拒絕', () => dispose(c, s2.batch, id(), null, 1, 0, '破損', null, false, 'null good'), /quantity|數量|null|non-negative/i);
+    await check('NULL 破損數量拒絕', () => dispose(c, s2.batch, id(), 1, null, 0, null, null, true, 'null damaged'), /quantity|數量|null|non-negative/i);
+    await check('NULL 遺失數量拒絕', () => dispose(c, s2.batch, id(), 1, 0, null, null, null, true, 'null lost'), /quantity|數量|null|non-negative/i);
+    await check('四位小數拒絕', () => dispose(c, s2.batch, id(), 1.0001, 0, 0, null, null, true, 'scale'), /scale|precision|小數|3/i);
+    await check('NaN 拒絕', () => c.query(`
       select public.rpc_dispose_hq_return($1,$2,'NaN'::numeric,0,0,null,null,true,'nan')
     `, [s2.batch, id()]), /numeric|NaN|invalid|finite|數字/i);
-    await expectReject(c, 'Infinity 拒絕', () => ownerSnapshot(c, s2.batch, { tenant: s2.tenant, user: s2.operator, appRole: 'hq_manager' }), () => c.query(`
+    await check('Infinity 拒絕', () => c.query(`
       select public.rpc_dispose_hq_return($1,$2,'Infinity'::numeric,0,0,null,null,true,'inf')
     `, [s2.batch, id()]), /numeric|Infinity|invalid|finite|數字/i);
+    if (failures.length > 0) throw new Error(failures.join(' | '));
   });
 }
 
@@ -378,24 +432,41 @@ async function testTenantRoleAndAnon(c) {
     const storeUser = id();
     const crossUser = id();
 
+    const failures = [];
     await setAuth(c, s.tenant, hqUser, 'hq_manager');
-    const hqVisible = await c.query('select id from v_hq_return_batches_list where id = $1', [s.batch]);
-    assert.equal(hqVisible.rows.length, 1, 'HQ 角色應該讀得到同 tenant 待處理批次；否則不能把「看不到」當成安全');
+    try {
+      await expectRows(c, 'HQ 角色應該讀得到同 tenant 待處理批次；否則不能把「看不到」當成安全', 'select id from v_hq_return_batches_list where id = $1', [s.batch], 1);
+    } catch (e) {
+      failures.push(`HQ view 正向讀取: ${e.message}`);
+    }
 
     await resetRole(c);
     await setAuth(c, s.tenant, storeUser, 'store_manager');
-    await expectNoRowsOrPermission(c, '店家角色不應讀到總倉待處理批次', 'select id from v_hq_return_batches_list where id = $1', [s.batch]);
-    await expectReject(c, '店家角色不能處理', () => ownerSnapshot(c, s.batch, { tenant: s.tenant, user: storeUser, appRole: 'store_manager' }), () => dispose(c, s.batch, id(), 1, 0, 0, null, null, true, 'store'), /permission|role|denied|權限/i);
+    try {
+      await expectNoRowsOrPermission(c, '店家角色不應讀到總倉待處理批次', 'select id from v_hq_return_batches_list where id = $1', [s.batch]);
+      await expectReject(c, '店家角色不能處理', () => ownerSnapshot(c, s.batch, { tenant: s.tenant, user: storeUser, appRole: 'store_manager' }), () => dispose(c, s.batch, id(), 1, 0, 0, null, null, true, 'store'), /permission|role|denied|權限/i);
+    } catch (e) {
+      failures.push(`店家角色限制: ${e.message}`);
+    }
 
     await resetRole(c);
     await setAuth(c, s.otherTenant, crossUser, 'hq_manager');
-    await expectNoRowsOrPermission(c, '跨租戶不應讀到別人的批次', 'select id from v_hq_return_batches_list where id = $1', [s.batch]);
-    await expectReject(c, '跨租戶不能處理', () => ownerSnapshot(c, s.batch, { tenant: s.otherTenant, user: crossUser, appRole: 'hq_manager' }), () => dispose(c, s.batch, id(), 1, 0, 0, null, null, true, 'cross'), /tenant|not found|permission|different|租戶|權限/i);
+    try {
+      await expectNoRowsOrPermission(c, '跨租戶不應讀到別人的批次', 'select id from v_hq_return_batches_list where id = $1', [s.batch]);
+      await expectReject(c, '跨租戶不能處理', () => ownerSnapshot(c, s.batch, { tenant: s.otherTenant, user: crossUser, appRole: 'hq_manager' }), () => dispose(c, s.batch, id(), 1, 0, 0, null, null, true, 'cross'), /tenant|not found|permission|different|租戶|權限/i);
+    } catch (e) {
+      failures.push(`跨租戶限制: ${e.message}`);
+    }
 
     await resetRole(c);
     await setAuth(c, s.tenant, null, '', 'anon');
-    await expectNoRowsOrPermission(c, '匿名不應讀到批次', 'select id from v_hq_return_batches_list where id = $1', [s.batch]);
-    await expectReject(c, '匿名不能處理', () => ownerSnapshot(c, s.batch, { tenant: s.tenant, user: null, appRole: '', pgRole: 'anon' }), () => dispose(c, s.batch, id(), 1, 0, 0, null, null, true, 'anon'), /auth|permission|role|JWT|登入|權限/i);
+    try {
+      await expectNoRowsOrPermission(c, '匿名不應讀到批次', 'select id from v_hq_return_batches_list where id = $1', [s.batch]);
+      await expectReject(c, '匿名不能處理', () => ownerSnapshot(c, s.batch, { tenant: s.tenant, user: null, appRole: '', pgRole: 'anon' }), () => dispose(c, s.batch, id(), 1, 0, 0, null, null, true, 'anon'), /auth|permission|role|JWT|登入|權限/i);
+    } catch (e) {
+      failures.push(`匿名限制: ${e.message}`);
+    }
+    if (failures.length > 0) throw new Error(failures.join(' | '));
   });
 }
 
@@ -503,22 +574,67 @@ async function testRaceHoldVsNegative(dbName) {
   }
 }
 
-async function main() {
-  const { dbName } = parseArgs(process.argv);
+const CASES = [
+  { name: 'dispose_split', fn: testDisposeHappyAndSplit, race: false },
+  { name: 'source_validation', fn: testSourceValidation, race: false },
+  { name: 'idempotency', fn: testIdempotency, race: false },
+  { name: 'bad_numbers', fn: testBadNumbers, race: false },
+  { name: 'pending_guard', fn: testPendingGuardAndGoodStock, race: false },
+  { name: 'rls_roles', fn: testTenantRoleAndAnon, race: false },
+  { name: 'race_same_request', fn: testRaceSameRequest, race: true },
+  { name: 'race_hold_negative', fn: testRaceHoldVsNegative, race: true },
+];
+
+function selectedCases(caseNames) {
+  if (!caseNames) return CASES;
+  const names = caseNames.split(',').map((s) => s.trim()).filter(Boolean);
+  if (names.length === 0) throw new Error('--case 不可為空');
+  if (names.includes('list')) {
+    console.log(CASES.map((c) => `${c.name}${c.race ? ' (race)' : ''}`).join('\n'));
+    process.exit(0);
+  }
+  if (names.includes('all')) return CASES;
+  const wanted = new Set(names);
+  const picked = CASES.filter((c) => wanted.has(c.name));
+  const missing = names.filter((n) => n !== 'all' && !CASES.some((c) => c.name === n));
+  if (missing.length > 0) throw new Error(`未知 --case：${missing.join(', ')}`);
+  if (picked.length === 0) throw new Error('--case 沒有選到任何測試組');
+  return picked;
+}
+
+async function runOne(dbName, testCase) {
+  if (testCase.race) {
+    await testCase.fn(dbName);
+    return;
+  }
   const c = await connect(dbName);
   try {
     await preflight(c);
-    await testDisposeHappyAndSplit(c);
-    await testSourceValidation(c);
-    await testIdempotencyAndBadNumbers(c);
-    await testPendingGuardAndGoodStock(c);
-    await testTenantRoleAndAnon(c);
+    await testCase.fn(c);
   } finally {
     await c.end();
   }
-  await testRaceSameRequest(dbName);
-  await testRaceHoldVsNegative(dbName);
-  console.log('core_runtime_ok');
+}
+
+async function main() {
+  const { dbName, caseNames } = parseArgs(process.argv);
+  const picked = selectedCases(caseNames);
+  const results = [];
+  for (const testCase of picked) {
+    try {
+      await runOne(dbName, testCase);
+      results.push({ name: testCase.name, ok: true });
+      console.log(`PASS ${testCase.name}`);
+    } catch (e) {
+      results.push({ name: testCase.name, ok: false, message: e.message });
+      console.error(`FAIL ${testCase.name}: ${e.message}`);
+    }
+  }
+  console.log('core_runtime_summary');
+  for (const r of results) {
+    console.log(`${r.ok ? 'PASS' : 'FAIL'} ${r.name}${r.ok ? '' : ` :: ${r.message}`}`);
+  }
+  if (results.some((r) => !r.ok)) process.exit(1);
 }
 
 main().catch((e) => {

--- a/tests/return-disposition-review/f-ui-copy-runtime.cjs
+++ b/tests/return-disposition-review/f-ui-copy-runtime.cjs
@@ -1,0 +1,47 @@
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "../..");
+const files = {
+  inventory: "apps/admin/src/app/(protected)/inventory/page.tsx",
+  shortage: "apps/admin/src/components/TransferShortageResolveModal.tsx",
+  picking: "apps/admin/src/app/(protected)/wms/picking/page.tsx",
+};
+
+function validate(source) {
+  assert.match(source.inventory, /const hqAvailable = Math\.max\(r\.on_hand - r\.reserved, 0\)/);
+  assert.match(source.inventory, /帳上[\s\S]*凍結[\s\S]*可派/);
+  assert.match(source.inventory, /commit\.free_with_pool/, "分店可分配仍須沿用客人承諾量口徑");
+
+  assert.match(source.shortage, /其他已確認可派的好貨/);
+  assert.match(source.shortage, /帳回不表示實物已到或已驗完/);
+  assert.match(source.shortage, /其他可派貨不夠時，剩下的需求會保留/);
+  assert.match(source.shortage, /role === "owner" \|\| role === "admin" \|\| role === "hq_manager"/);
+  assert.match(source.shortage, /href="\/wms\/return-disposition"/);
+  assert.match(source.shortage, /分店價和原本派車時不同[\s\S]*價差/);
+
+  assert.match(source.picking, />HQ 可派<\/Th>/);
+  assert.match(source.picking, /申請 \$\{ln\.demand_qty\}、可派 \$\{ln\.gr_qty\}、已撿/);
+  assert.match(source.picking, /po\.gr_qty - po\.already_wave_for_sku/, "採購單到貨累計口徑不可被取代");
+}
+
+const current = Object.fromEntries(
+  Object.entries(files).map(([key, file]) => [key, fs.readFileSync(path.join(repoRoot, file), "utf8")]),
+);
+validate(current);
+
+const baseline = Object.fromEntries(
+  Object.entries(files).map(([key, file]) => [
+    key,
+    execFileSync(
+      "git",
+      ["-c", `safe.directory=${repoRoot.replaceAll("\\", "/")}`, "-C", repoRoot, "show", `85c06f44:${file}`],
+      { encoding: "utf8" },
+    ),
+  ]),
+);
+assert.throws(() => validate(baseline), "舊版必須被新口徑驗收擋下");
+
+console.log("PASS F-UI：新版口徑通過，85c06f44 舊版如預期失敗");

--- a/tests/return-disposition-review/reversal-runtime.cjs
+++ b/tests/return-disposition-review/reversal-runtime.cjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const { Client } = require('pg');
+
+const args = process.argv.slice(2);
+if (args.length !== 2 || args[0] !== '--db-name' || !/^return_disposition_test_[A-Za-z0-9_]+$/.test(args[1])) {
+  console.error('usage: node tests/return-disposition-review/reversal-runtime.cjs --db-name return_disposition_test_<name>');
+  process.exit(2);
+}
+
+const dbName = args[1];
+const tenantId = '11111111-1111-1111-1111-111111111111';
+const operatorId = '22222222-2222-2222-2222-222222222222';
+const month = '2026-09-01';
+
+function client() {
+  return new Client({ host: '127.0.0.1', port: 56427, user: 'returnlocal', database: dbName });
+}
+
+async function q1(c, sql, params = []) {
+  return (await c.query(sql, params)).rows[0];
+}
+
+async function setAuth(c) {
+  await c.query("select set_config('request.jwt.claim.sub',$1,true)", [operatorId]);
+  await c.query("select set_config('request.jwt.claims',$1,true)", [
+    JSON.stringify({ tenant_id: tenantId, role: 'owner', app_metadata: { role: 'owner' } }),
+  ]);
+}
+
+async function lockSettlement(c) {
+  await c.query(
+    "select pg_advisory_xact_lock(hashtext('settlement:' || $1::text || ':' || $2::date::text))",
+    [tenantId, month],
+  );
+}
+
+async function createReturn(c, lines = [{ sku_id: 101, qty: 10 }]) {
+  const row = await q1(c, "select rpc_create_store_return(1,$1::jsonb,'破損',$2) as result", [
+    JSON.stringify(lines),
+    operatorId,
+  ]);
+  const transferId = row.result.transfer_id;
+  await c.query("select rpc_receive_transfer($1,null,$2,'review reversal runtime',false)", [transferId, operatorId]);
+  const items = (await c.query(
+    'select id, sku_id, in_movement_id from transfer_items where transfer_id=$1 order by id',
+    [transferId],
+  )).rows;
+  return { transferId, items };
+}
+
+async function createReturnWithNullCost(c) {
+  const transfer = await q1(c, `
+    insert into transfers (
+      tenant_id, transfer_no, source_location, dest_location, status, transfer_type,
+      shipped_by, shipped_at, received_by, received_at, created_by, updated_by
+    )
+    values (
+      $1, 'RETURN-NULL-COST-' || txid_current(), 20, 10, 'received', 'return_to_hq',
+      $2, now(), $2, now(), $2, $2
+    )
+    returning id
+  `, [tenantId, operatorId]);
+  const movement = await q1(c, `
+    insert into stock_movements (
+      tenant_id, location_id, sku_id, quantity, unit_cost,
+      movement_type, source_doc_type, source_doc_id, operator_id
+    )
+    values ($1, 20, 101, -1, null, 'transfer_out', 'transfer', $2, $3)
+    returning id
+  `, [tenantId, transfer.id, operatorId]);
+  await c.query(`
+    insert into transfer_items (
+      transfer_id, sku_id, qty_requested, qty_shipped, qty_received,
+      out_movement_id, created_by, updated_by
+    )
+    values ($1, 101, 1, 1, 1, $2, $3, $3)
+  `, [transfer.id, movement.id, operatorId]);
+  return transfer.id;
+}
+
+async function stockAndBatches(c, transferId) {
+  return q1(c, `
+    select
+      (
+        select coalesce(jsonb_agg(to_jsonb(b) order by b.id), '[]')
+          from hq_return_batches b
+         where b.source_transfer_item_id in (
+           select ti.id from transfer_items ti where ti.transfer_id=$1
+         )
+      ) as batches,
+      (
+        select coalesce(jsonb_agg(to_jsonb(ti) order by ti.id), '[]')
+          from transfer_items ti
+         where ti.transfer_id=$1
+      ) as items,
+      (
+        select coalesce(jsonb_agg(to_jsonb(sb) order by sb.location_id, sb.sku_id), '[]')
+          from stock_balances sb
+         where sb.tenant_id=$2
+           and sb.location_id=10
+           and sb.sku_id in (
+             select ti.sku_id from transfer_items ti where ti.transfer_id=$1
+           )
+      ) as balances
+  `, [transferId, tenantId]);
+}
+
+async function testGeneratorSharesCAdvisoryLock() {
+  const holder = client();
+  const contender = client();
+  const observer = client();
+  await holder.connect();
+  await contender.connect();
+  await observer.connect();
+  let holderOpen = false;
+  let contenderOpen = false;
+  try {
+    await holder.query('begin');
+    holderOpen = true;
+    await holder.query("set local statement_timeout='5000ms'");
+    await lockSettlement(holder);
+
+    await contender.query('begin');
+    contenderOpen = true;
+    await contender.query("set local statement_timeout='5000ms'");
+    let finished = false;
+    let result;
+    const pending = contender
+      .query('select public.rpc_generate_hq_to_store_settlement($1::date,$2::uuid)', [month, operatorId])
+      .then((r) => {
+        finished = true;
+        result = r;
+        return r;
+      }, (e) => {
+        finished = true;
+        result = e;
+        return e;
+      });
+
+    let sawAdvisoryWait = false;
+    for (let i = 0; i < 30; i += 1) {
+      const row = await q1(observer, `
+        select
+          exists (
+            select 1 from pg_locks
+             where pid=$1 and locktype='advisory' and granted=false
+          ) as waiting_advisory,
+          coalesce(max(wait_event), '') as wait_event
+        from pg_stat_activity
+        where pid=$1
+      `, [contender.processID]);
+      if (row.waiting_advisory || String(row.wait_event).toLowerCase().includes('advisory')) {
+        sawAdvisoryWait = true;
+        break;
+      }
+      if (finished) break;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    assert.ok(
+      sawAdvisoryWait,
+      `月結產生器沒有等待 C 使用的 settlement advisory lock；finished=${finished} result=${result instanceof Error ? `${result.code}:${result.message}` : 'completed'}`,
+    );
+
+    await holder.query('rollback');
+    holderOpen = false;
+    const releasedResult = await pending;
+    if (releasedResult instanceof Error) throw releasedResult;
+    assert.equal(releasedResult.rowCount, 1, '放鎖後真正月結產生器應完成，不可只靠逾時假通過');
+  } finally {
+    if (contenderOpen) await contender.query('rollback').catch(() => undefined);
+    if (holderOpen) await holder.query('rollback').catch(() => undefined);
+    await contender.end();
+    await holder.end();
+    await observer.end();
+  }
+}
+
+async function testGeneratorCompletesTwice() {
+  const c = client();
+  await c.connect();
+  try {
+    await c.query('begin');
+    await c.query("set local statement_timeout='5000ms'");
+    await c.query('update prices set effective_from = now() - make_interval(days => 30)');
+    const first = await q1(c, 'select public.rpc_generate_hq_to_store_settlement($1::date,$2::uuid) as result', [month, operatorId]);
+    const afterFirst = await q1(c, 'select count(*)::int as n from store_monthly_settlement_items');
+    const second = await q1(c, 'select public.rpc_generate_hq_to_store_settlement($1::date,$2::uuid) as result', [month, operatorId]);
+    const afterSecond = await q1(c, 'select count(*)::int as n from store_monthly_settlement_items');
+    assert.equal(first.result.month, '2026-09');
+    assert.equal(second.result.month, '2026-09');
+    assert.ok(afterFirst.n > 0, '第一次產生月結應建立真明細');
+    assert.equal(afterSecond.n, afterFirst.n, '第二次重建 draft 不應被舊 immutable trigger 擋住或重複膨脹');
+  } finally {
+    await c.query('rollback').catch(() => undefined);
+    await c.end();
+  }
+}
+
+async function testBusyMonthRejectsCWithoutSideEffects() {
+  const setup = client();
+  const holder = client();
+  const worker = client();
+  await setup.connect();
+  await holder.connect();
+  await worker.connect();
+  let setupOpen = false;
+  let holderOpen = false;
+  let workerOpen = false;
+  try {
+    await setup.query('begin');
+    setupOpen = true;
+    await setup.query("set local statement_timeout='5000ms'");
+    await setAuth(setup);
+    await setup.query("select rpc_inbound($1,20,101,20,100,'purchase_receipt','review',null,$2)", [tenantId, operatorId]);
+    const doc = await createReturn(setup);
+    await setup.query('commit');
+    setupOpen = false;
+    const before = await stockAndBatches(setup, doc.transferId);
+
+    await holder.query('begin');
+    holderOpen = true;
+    await lockSettlement(holder);
+
+    await worker.query('begin');
+    workerOpen = true;
+    await worker.query("set local statement_timeout='1200ms'");
+    await setAuth(worker);
+    const started = Date.now();
+    let error;
+    try {
+      await worker.query(
+        "select rpc_adjust_received_transfer($1,$2::jsonb,$3,'busy month review')",
+        [doc.transferId, JSON.stringify([{ transfer_item_id: doc.items[0].id, qty_received: 8 }]), operatorId],
+      );
+    } catch (e) {
+      error = e;
+    }
+    const elapsed = Date.now() - started;
+    assert.ok(error, 'C 遇到忙月鎖應快速拒絕，不可等鎖後偷偷成功');
+    assert.notEqual(error.code, '57014', 'C 忙月鎖應回業務拒絕，不應拖到 statement_timeout');
+    assert.ok(elapsed < 1000, `C 忙月鎖拒絕太慢：${elapsed}ms`);
+    await worker.query('rollback');
+    workerOpen = false;
+
+    assert.deepEqual(await stockAndBatches(setup, doc.transferId), before, '忙月鎖拒絕後，庫存/批次/item 不能留下半套');
+  } finally {
+    if (workerOpen) await worker.query('rollback').catch(() => undefined);
+    if (holderOpen) await holder.query('rollback').catch(() => undefined);
+    if (setupOpen) await setup.query('rollback').catch(() => undefined);
+    await setup.end();
+    await holder.end();
+    await worker.end();
+  }
+}
+
+async function testTryLockReentrantMultiItem() {
+  const c = client();
+  await c.connect();
+  try {
+    await c.query('begin');
+    await c.query("set local statement_timeout='5000ms'");
+    await setAuth(c);
+    await c.query("select rpc_inbound($1,20,101,10,100,'purchase_receipt','review',null,$2)", [tenantId, operatorId]);
+    await c.query("select rpc_inbound($1,20,102,10,80,'purchase_receipt','review',null,$2)", [tenantId, operatorId]);
+    const doc = await createReturn(c, [{ sku_id: 101, qty: 4 }, { sku_id: 102, qty: 3 }]);
+    const payload = doc.items.map((item) => ({
+      transfer_item_id: item.id,
+      qty_received: item.sku_id === 101 ? 2 : 1,
+    }));
+    await c.query("select rpc_adjust_received_transfer($1,$2::jsonb,$3,'multi item trylock review')", [
+      doc.transferId,
+      JSON.stringify(payload),
+      operatorId,
+    ]);
+    await c.query('set constraints all immediate');
+    const rows = (await c.query(`
+      select sku_id, status, count(*)::int as n
+      from hq_return_batches
+      where source_transfer_item_id = any($1::bigint[])
+      group by sku_id,status
+      order by sku_id,status
+    `, [doc.items.map((item) => item.id)])).rows;
+    assert.deepEqual(rows.map((r) => `${r.sku_id}:${r.status}:${r.n}`), [
+      '101:pending:1',
+      '101:revoked:1',
+      '102:pending:1',
+      '102:revoked:1',
+    ]);
+  } finally {
+    await c.query('rollback').catch(() => undefined);
+    await c.end();
+  }
+}
+
+async function testReturnOutUnknownCostStaysNull() {
+  const c = client();
+  await c.connect();
+  try {
+    await c.query('begin');
+    await c.query("set local statement_timeout='5000ms'");
+    await setAuth(c);
+    await c.query('update prices set effective_from = now() - make_interval(days => 30)');
+    const transferId = await createReturnWithNullCost(c);
+
+    await c.query('select public.rpc_generate_hq_to_store_settlement($1::date,$2::uuid)', [month, operatorId]);
+    const row = await q1(c, `
+      select unit_cost::text as unit_cost, line_amount::text as line_amount
+      from store_monthly_settlement_items
+      where entry_type='return_out'
+        and transfer_id=$1
+    `, [transferId]);
+    assert.deepEqual(
+      row,
+      { unit_cost: null, line_amount: null },
+      'return_out 未知成本不可被 COALESCE 成 0',
+    );
+  } finally {
+    await c.query('rollback').catch(() => undefined);
+    await c.end();
+  }
+}
+
+async function verifyIdentity() {
+  const c = client();
+  await c.connect();
+  try {
+    const identity = await q1(c, 'select current_database() db,current_user usr,inet_server_addr()::text host,inet_server_port() port');
+    assert.equal(identity.db, dbName);
+    assert.equal(identity.usr, 'returnlocal');
+    assert.match(identity.host, /^127\.0\.0\.1(?:\/32)?$/);
+    assert.equal(identity.port, 56427);
+  } finally {
+    await c.end();
+  }
+}
+
+const tests = [
+  ['settlement_generator_shares_c_advisory_lock', testGeneratorSharesCAdvisoryLock],
+  ['settlement_generator_completes_twice', testGeneratorCompletesTwice],
+  ['busy_month_rejects_c_without_side_effects', testBusyMonthRejectsCWithoutSideEffects],
+  ['trylock_reentrant_multi_item', testTryLockReentrantMultiItem],
+  ['return_out_unknown_cost_stays_null', testReturnOutUnknownCostStaysNull],
+];
+
+(async () => {
+  await verifyIdentity();
+  for (const [name, fn] of tests) {
+    await fn();
+    console.log(`PASS ${name}`);
+  }
+})().catch((e) => {
+  console.error(`FAIL reversal-runtime: ${e.code || 'assert'} ${e.message}`);
+  process.exitCode = 1;
+});

--- a/tests/return-disposition-review/review_assertions.sql
+++ b/tests/return-disposition-review/review_assertions.sql
@@ -1,0 +1,145 @@
+\set ON_ERROR_STOP on
+
+-- 阿審用補充斷言：只能在本機測試庫跑。
+-- 目的：抓 fixture 過度簡化、未載真函式、漏掉 reserved / p_allow_negative / 直接負異動旁路。
+
+DO $$
+DECLARE
+  v_missing text[];
+BEGIN
+  SELECT array_agg(x.name ORDER BY x.name)
+    INTO v_missing
+    FROM (
+      VALUES
+        ('locations'),
+        ('stock_balances'),
+        ('stock_movements'),
+        ('transfers'),
+        ('transfer_items'),
+        ('products'),
+        ('skus'),
+        ('stores'),
+        ('picking_waves'),
+        ('picking_wave_items'),
+        ('restock_requests'),
+        ('restock_request_lines'),
+        ('store_monthly_settlements')
+    ) AS x(name)
+   WHERE to_regclass('public.' || x.name) IS NULL;
+
+  IF v_missing IS NOT NULL THEN
+    RAISE EXCEPTION 'fixture 缺真 schema 表：%', array_to_string(v_missing, ', ');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'stock_balances'
+       AND column_name = 'reserved'
+  ) THEN
+    RAISE EXCEPTION 'stock_balances.reserved 不存在，無法驗待確認可派量';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_trigger
+     WHERE tgname = 'trg_apply_movement'
+       AND tgrelid = 'public.stock_movements'::regclass
+       AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'stock_movements 缺 trg_apply_movement，fixture 沒跑真庫存餘額機制';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_def text;
+BEGIN
+  SELECT pg_get_functiondef('public.rpc_outbound(uuid,bigint,bigint,numeric,text,text,bigint,uuid,boolean,numeric)'::regprocedure)
+    INTO v_def;
+
+  IF v_def IS NULL THEN
+    RAISE EXCEPTION '缺最新版 10 參數 rpc_outbound';
+  END IF;
+
+  IF position('on_hand - reserved' in v_def) = 0 THEN
+    RAISE EXCEPTION 'rpc_outbound 沒有使用 on_hand - reserved，fixture 可能載到舊版或假版';
+  END IF;
+
+  IF position('p_allow_negative' in v_def) = 0 THEN
+    RAISE EXCEPTION 'rpc_outbound 沒有 p_allow_negative，無法驗繞過 reserved 的旁路';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_missing text[];
+BEGIN
+  SELECT array_agg(x.sig ORDER BY x.sig)
+    INTO v_missing
+    FROM (
+      VALUES
+        ('public.rpc_receive_transfer(bigint,jsonb,uuid,text,boolean)'),
+        ('public.rpc_create_store_return(bigint,jsonb,text,uuid)'),
+        ('public.rpc_resolve_transfer_item_shortage(bigint,text,text,uuid)'),
+        ('public.rpc_undo_transfer_item_shortage(bigint,uuid,text)'),
+        ('public.rpc_adjust_received_transfer(bigint,jsonb,uuid,text)'),
+        ('public.rpc_unreceive_transfer(bigint,uuid,text)')
+    ) AS x(sig)
+   WHERE to_regprocedure(x.sig) IS NULL;
+
+  IF v_missing IS NOT NULL THEN
+    RAISE EXCEPTION 'fixture 缺真正最新版目標函式：%', array_to_string(v_missing, ', ');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'transfer_items'
+       AND column_name = 'shortage_return_transfer_id'
+  ) THEN
+    RAISE EXCEPTION '缺 shortage_return_transfer_id，無法驗短少沖帳/真回帳分流';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'transfer_items'
+       AND column_name = 'shortage_restock_movement_id'
+  ) THEN
+    RAISE EXCEPTION '缺 shortage_restock_movement_id，無法驗 restock_hq/redispatch 真回帳';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_candidate_tables text[];
+BEGIN
+  SELECT array_agg(c.relname ORDER BY c.relname)
+    INTO v_candidate_tables
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relkind IN ('r','p')
+     AND (
+       c.relname ILIKE '%return%disposition%'
+       OR c.relname ILIKE '%return%pending%'
+       OR c.relname ILIKE '%disposition%'
+     );
+
+  IF v_candidate_tables IS NULL THEN
+    RAISE EXCEPTION '找不到總倉退回貨待處理/處理明細表；若阿寫不用表，需在測試報告明確說明同等追蹤機制';
+  END IF;
+END $$;
+
+-- 這裡不直接做雙 session；雙 session 必須由兩個 psql 連線測。
+SELECT 'review_assertions_ok' AS result;

--- a/tests/return-disposition-review/shortage-ui-check.cjs
+++ b/tests/return-disposition-review/shortage-ui-check.cjs
@@ -1,0 +1,38 @@
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "../..");
+const relFile = "apps/admin/src/components/StoreReturnCreateModal.tsx";
+const file = path.join(repoRoot, relFile);
+const baseline = process.argv.includes("--baseline");
+const src = baseline
+  ? execFileSync("git", ["-c", `safe.directory=${repoRoot}`, "show", `cf10338c:${relFile}`], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    })
+  : fs.readFileSync(file, "utf8");
+
+const submitStart = src.indexOf("async function submit()");
+assert.notEqual(submitStart, -1, "找不到 submit()");
+const submitEnd = src.indexOf("const summary =", submitStart);
+assert.notEqual(submitEnd, -1, "找不到 submit() 送出摘要位置");
+const submitGuardBlock = src.slice(submitStart, submitEnd);
+
+const shortageGuard = submitGuardBlock.indexOf('if (reason === "少收") return;');
+const canSubmitGuard = submitGuardBlock.indexOf("if (!canSubmit) return;");
+assert(shortageGuard >= 0, "submit() 必須明確擋少收");
+assert(canSubmitGuard >= 0, "submit() 必須保留 canSubmit 防線");
+assert(shortageGuard < canSubmitGuard, "少收防線要放在 canSubmit 前，避免 TypeScript 窄化成永假");
+
+assert(src.includes('reason !== "少收"'), "canSubmit 必須擋少收，讓按鈕不能送出");
+assert(src.includes('href="/wms/inbound"'), "少收導路必須去收貨頁 /wms/inbound");
+assert(src.includes('target="_blank"'), "少收導路要新分頁，避免退貨草稿被切頁弄丟");
+assert(src.includes('rel="noopener noreferrer"'), "新分頁 Link 必須有 noopener noreferrer");
+assert(src.includes("已收") && src.includes("明細 / 改實收"), "文案必須告訴店家到已收分頁按明細 / 改實收");
+assert(src.includes("尚未收貨") && src.includes("原單核對實收"), "文案必須補尚未收貨走原單核對實收");
+assert(src.includes("依總倉回覆與月結規則算帳"), "錢的文案不能承諾立刻自動算完");
+assert(!src.includes("錢也會自動跟著算"), "不得保留過度承諾的錢文案");
+
+console.log(`shortage-ui-check ok (${baseline ? "baseline" : "working tree"})`);

--- a/tests/return-disposition-review/source-available-runtime.cjs
+++ b/tests/return-disposition-review/source-available-runtime.cjs
@@ -1,0 +1,442 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { Client } = require('pg');
+
+const DB_RE = /^return_disposition_test_[A-Za-z0-9_]+$/;
+const HOST = '127.0.0.1';
+const PORT = 56427;
+const USER = 'returnlocal';
+
+function usage() {
+  console.error('usage: node tests/return-disposition-review/source-available-runtime.cjs --db-name return_disposition_test_<name> [--case name[,name...]]');
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    if (argv[i] === '--db-name') out.dbName = argv[++i];
+    else if (argv[i] === '--case') {
+      if (!argv[i + 1] || argv[i + 1].startsWith('--')) usage();
+      out.caseNames = argv[++i];
+    } else usage();
+  }
+  if (!out.dbName || !DB_RE.test(out.dbName)) throw new Error(`拒絕連線：--db-name 必須符合 ${DB_RE}`);
+  return out;
+}
+
+function id() { return crypto.randomUUID(); }
+function code() { return `bf_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`; }
+
+async function connect(dbName) {
+  const c = new Client({ host: HOST, port: PORT, user: USER, database: dbName });
+  await c.connect();
+  c.__dbName = dbName;
+  const got = await c.query('select current_database() as db, current_user as usr, inet_server_addr()::text as host, inet_server_port() as port');
+  assert.equal(got.rows[0].db, dbName);
+  assert.equal(got.rows[0].usr, USER);
+  assert.ok(String(got.rows[0].host).startsWith(HOST));
+  assert.equal(Number(got.rows[0].port), PORT);
+  return c;
+}
+
+async function q1(c, sql, params = []) {
+  const r = await c.query(sql, params);
+  return r.rows[0];
+}
+
+async function tx(c, name, fn) {
+  await c.query('begin');
+  try {
+    await c.query(`set local statement_timeout = '3000ms'`);
+    await fn();
+    console.log(`ok - ${name}`);
+  } finally {
+    await c.query('rollback');
+  }
+}
+
+async function setAuth(c, tenantId, userId = id(), appRole = 'owner', pgRole = 'authenticated') {
+  await c.query(`set local role ${pgRole}`);
+  const claims = {
+    sub: userId,
+    tenant_id: tenantId,
+    role: appRole,
+    app_metadata: { role: appRole },
+    user_metadata: { tenant_id: tenantId },
+    store_ids: [],
+  };
+  await c.query('select set_config($1, $2, true)', ['request.jwt.claim.sub', userId || '']);
+  await c.query('select set_config($1, $2, true)', ['request.jwt.claims', JSON.stringify(claims)]);
+}
+
+async function resetRole(c) {
+  await c.query('reset role');
+}
+
+async function preflight(c, cases) {
+  const required = new Set();
+  if (cases.some((tc) => tc.name.startsWith('b_'))) {
+    required.add('public._hq_return_source_on_ti()');
+  }
+  if (cases.some((tc) => tc.name.startsWith('f_'))) {
+    required.add('public.rpc_create_store_return(bigint,jsonb,text,uuid)');
+    required.add('public.rpc_create_wave_from_restock(bigint,date,jsonb,uuid)');
+  }
+  const missing = [];
+  for (const sig of required) {
+    const row = await q1(c, 'select to_regprocedure($1) as oid', [sig]);
+    if (!row.oid) missing.push(sig);
+  }
+  assert.deepEqual(missing, [], `fixture 缺函式：${missing.join(', ')}`);
+}
+
+async function applyFInTransaction(c) {
+  await c.query(fs.readFileSync(path.join(process.cwd(), 'supabase/migrations/20260612000060_relax_restock_check_for_wave_flow.sql'), 'utf8'));
+  await c.query(fs.readFileSync(path.join(process.cwd(), 'supabase/migrations/20260907040000_hq_return_disposition_available.sql'), 'utf8'));
+}
+
+async function applyOldRestockWaveInTransaction(c) {
+  await c.query(fs.readFileSync(path.join(process.cwd(), 'supabase/migrations/20260612000060_relax_restock_check_for_wave_flow.sql'), 'utf8'));
+  const sql = fs.readFileSync(path.join(process.cwd(), 'supabase/migrations/20260715000020_restock_dispatch_dedup_guards.sql'), 'utf8');
+  const m = sql.match(/CREATE OR REPLACE FUNCTION public\.rpc_create_wave_from_restock[\s\S]*?COMMENT ON FUNCTION public\.rpc_create_wave_from_restock[\s\S]*?;/);
+  assert.ok(m, '找不到 20260715000020 的 rpc_create_wave_from_restock 定義');
+  await c.query(m[0]);
+}
+
+async function seed(c, opts = {}) {
+  const suffix = opts.suffix || code();
+  const tenant = opts.tenant || id();
+  const operator = opts.operator || id();
+  const otherTenant = opts.otherTenant || id();
+  const hq = (await q1(c, `
+    insert into locations (tenant_id, code, name, type, created_by)
+    values ($1,$2,$3,'central_warehouse',$4) returning id
+  `, [tenant, `${suffix}_hq`, `${suffix} 總倉`, operator])).id;
+  const storeLoc = (await q1(c, `
+    insert into locations (tenant_id, code, name, type, created_by)
+    values ($1,$2,$3,'store',$4) returning id
+  `, [tenant, `${suffix}_store_loc`, `${suffix} 店倉`, operator])).id;
+  const store = (await q1(c, `
+    insert into stores (tenant_id, code, name, location_id, created_by)
+    values ($1,$2,$3,$4,$5) returning id
+  `, [tenant, `${suffix}_store`, `${suffix} 店`, storeLoc, operator])).id;
+  const otherStoreLoc = (await q1(c, `
+    insert into locations (tenant_id, code, name, type, created_by)
+    values ($1,$2,$3,'store',$4) returning id
+  `, [tenant, `${suffix}_other_store_loc`, `${suffix} 其他店倉`, operator])).id;
+  const otherStore = (await q1(c, `
+    insert into stores (tenant_id, code, name, location_id, created_by)
+    values ($1,$2,$3,$4,$5) returning id
+  `, [tenant, `${suffix}_other_store`, `${suffix} 其他店`, otherStoreLoc, operator])).id;
+  const product = (await q1(c, `
+    insert into products (tenant_id, product_code, name, status, created_by)
+    values ($1,$2,$3,'active',$4) returning id
+  `, [tenant, `${suffix}_p`, `${suffix} 商品`, operator])).id;
+  const sku = (await q1(c, `
+    insert into skus (tenant_id, product_id, sku_code, status, product_name, created_by)
+    values ($1,$2,$3,'active',$4,$5) returning id
+  `, [tenant, product, `${suffix}_sku`, `${suffix} 商品`, operator])).id;
+  const otherProduct = (await q1(c, `
+    insert into products (tenant_id, product_code, name, status, created_by)
+    values ($1,$2,$3,'active',$4) returning id
+  `, [otherTenant, `${suffix}_op`, `${suffix} 別租戶商品`, operator])).id;
+  const otherSku = (await q1(c, `
+    insert into skus (tenant_id, product_id, sku_code, status, product_name, created_by)
+    values ($1,$2,$3,'active',$4,$5) returning id
+  `, [otherTenant, otherProduct, `${suffix}_osku`, `${suffix} 別租戶商品`, operator])).id;
+  return { suffix, tenant, otherTenant, operator, hq, storeLoc, store, otherStoreLoc, otherStore, sku, otherSku };
+}
+
+async function transferItem(c, s, type, sourceLoc, destLoc, qty = 10) {
+  const transfer = (await q1(c, `
+    insert into transfers (tenant_id, transfer_no, source_location, dest_location, transfer_type, status, requested_by, created_by, notes)
+    values ($1,$2,$3,$4,$5,'shipped',$6,$6,$7) returning id
+  `, [s.tenant, `${code()}_tr`, sourceLoc, destLoc, type, s.operator, `${type} notes`])).id;
+  const item = (await q1(c, `
+    insert into transfer_items (transfer_id, sku_id, qty_requested, qty_shipped, qty_received, created_by)
+    values ($1,$2,$3,$3,$4,$5) returning id
+  `, [transfer, s.sku, qty, type === 'return_to_hq' ? qty : 0, s.operator])).id;
+  return { transfer, item };
+}
+
+async function movement(c, s, loc, qty, type, transfer, operator = s.operator) {
+  return (await q1(c, `
+    insert into stock_movements
+      (tenant_id, location_id, sku_id, quantity, unit_cost, movement_type, source_doc_type, source_doc_id, operator_id, notes)
+    values ($1,$2,$3,$4,12.3456,$5,'transfer',$6,$7,$8) returning id
+  `, [s.tenant, loc, s.sku, qty, type, transfer, operator, `${type} source`])).id;
+}
+
+async function expectReject(c, label, fn, re) {
+  await c.query(`savepoint ${label.replace(/[^a-z0-9_]/gi, '_')}`);
+  let err;
+  try { await fn(); } catch (e) { err = e; }
+  await c.query(`rollback to savepoint ${label.replace(/[^a-z0-9_]/gi, '_')}`);
+  await c.query(`release savepoint ${label.replace(/[^a-z0-9_]/gi, '_')}`);
+  assert.ok(err, `${label} 應拒絕但成功`);
+  assert.match(String(err.message), re, `${label} 錯誤訊息不符：${err.message}`);
+}
+
+async function testBStoreReturn(c) {
+  await tx(c, 'B store_return 一批、人工/系統與 source_doc 鎖定', async () => {
+    const s = await seed(c);
+    const t = await transferItem(c, s, 'return_to_hq', s.storeLoc, s.hq, 10);
+    const mov = await movement(c, s, s.hq, 10, 'transfer_in', t.transfer, s.operator);
+    await c.query('update transfer_items set in_movement_id=$1 where id=$2', [mov, t.item]);
+    await c.query('update transfer_items set in_movement_id=$1 where id=$2', [mov, t.item]);
+    let rows = await c.query('select source_kind,total_qty::text,auto_flag,created_by from hq_return_batches where source_movement_id=$1', [mov]);
+    assert.equal(rows.rowCount, 1);
+    assert.equal(rows.rows[0].source_kind, 'store_return');
+    assert.equal(rows.rows[0].total_qty, '10.000');
+    assert.equal(rows.rows[0].auto_flag, 'manual');
+    assert.equal(rows.rows[0].created_by, s.operator);
+
+    const zero = '00000000-0000-0000-0000-000000000000';
+    const t2 = await transferItem(c, s, 'return_to_hq', s.storeLoc, s.hq, 3);
+    const mov2 = await movement(c, s, s.hq, 3, 'transfer_in', t2.transfer, zero);
+    await c.query('update transfer_items set in_movement_id=$1 where id=$2', [mov2, t2.item]);
+    rows = await c.query('select auto_flag,created_by from hq_return_batches where source_movement_id=$1', [mov2]);
+    assert.equal(rows.rowCount, 1);
+    assert.equal(rows.rows[0].auto_flag, 'system');
+    assert.equal(rows.rows[0].created_by, zero);
+
+    const wrong = await transferItem(c, s, 'return_to_hq', s.storeLoc, s.hq, 2);
+    const other = await transferItem(c, s, 'return_to_hq', s.storeLoc, s.hq, 2);
+    const badMov = await movement(c, s, s.hq, 2, 'transfer_in', other.transfer, s.operator);
+    await expectReject(c, 'B return source_doc 錯單', () => c.query('update transfer_items set in_movement_id=$1 where id=$2', [badMov, wrong.item]), /source|transfer|document|matching|單/i);
+  });
+}
+
+async function testBShortage(c) {
+  await tx(c, 'B shortage restock_hq/redispatch 回帳只建一批且鎖 source_doc', async () => {
+    const s = await seed(c);
+    const t = await transferItem(c, s, 'hq_to_store', s.hq, s.storeLoc, 15);
+    await c.query('update transfer_items set qty_received=5 where id=$1', [t.item]);
+    const mov = await movement(c, s, s.hq, 10, 'transfer_cancel', t.transfer, s.operator);
+    await c.query(`
+      update transfer_items
+         set shortage_resolution='restock_hq',
+             shortage_resolution_by=$1,
+             shortage_resolution_notes='short 10',
+             shortage_restock_movement_id=$2
+       where id=$3
+    `, [s.operator, mov, t.item]);
+    await c.query('update transfer_items set shortage_restock_movement_id=$1 where id=$2', [mov, t.item]);
+    const rows = await c.query('select source_kind,total_qty::text,auto_flag,created_by from hq_return_batches where source_movement_id=$1', [mov]);
+    assert.equal(rows.rowCount, 1);
+    assert.equal(rows.rows[0].source_kind, 'shortage');
+    assert.equal(rows.rows[0].total_qty, '10.000');
+    assert.equal(rows.rows[0].auto_flag, 'manual');
+    assert.equal(rows.rows[0].created_by, s.operator);
+
+    const wrong = await transferItem(c, s, 'hq_to_store', s.hq, s.storeLoc, 8);
+    await c.query('update transfer_items set qty_received=3, shortage_resolution=$1, shortage_resolution_by=$2 where id=$3', ['restock_hq', s.operator, wrong.item]);
+    const other = await transferItem(c, s, 'hq_to_store', s.hq, s.storeLoc, 8);
+    const badMov = await movement(c, s, s.hq, 5, 'transfer_cancel', other.transfer, s.operator);
+    await expectReject(c, 'B shortage source_doc 錯單', () => c.query('update transfer_items set shortage_restock_movement_id=$1 where id=$2', [badMov, wrong.item]), /source|transfer|document|matching|單/i);
+  });
+}
+
+async function seedRestock(c, qty = 10, opts = {}) {
+  const s = await seed(c);
+  await c.query('insert into stock_balances (tenant_id, location_id, sku_id, on_hand, reserved) values ($1,$2,$3,$4,$5)', [s.tenant, s.hq, s.sku, opts.onHand ?? 15, opts.reserved ?? 5]);
+  const rr = (await q1(c, `
+    insert into restock_requests (tenant_id, requesting_store_id, status, requested_by, approved_by, approved_at, created_by)
+    values ($1,$2,'approved_transfer',$3,$3,now(),$3) returning id
+  `, [s.tenant, s.store, s.operator])).id;
+  await c.query(`
+    insert into restock_request_lines (tenant_id, request_id, sku_id, qty, unit_price, created_by)
+    values ($1,$2,$3,$4,1,$5)
+  `, [s.tenant, rr, s.sku, qty, s.operator]);
+  return { ...s, rr };
+}
+
+async function wave(c, s, allocations) {
+  const row = await q1(c, `
+    select public.rpc_create_wave_from_restock($1,current_date,$2::jsonb,$3) as result
+  `, [s.rr, JSON.stringify(allocations), s.operator]);
+  return row.result;
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForLockWait(observer, pid, label) {
+  for (let i = 0; i < 30; i += 1) {
+    const row = await q1(observer, `
+      select wait_event_type, wait_event, state
+        from pg_stat_activity
+       where pid = $1
+    `, [pid]);
+    if (row && row.wait_event_type === 'Lock') return row;
+    await sleep(50);
+  }
+  throw new Error(`${label} 沒觀察到 row lock 等待`);
+}
+
+async function testFRestockAvailable(c) {
+  await tx(c, 'F 補貨可派量用 on_hand-reserved，draft 不加 reserved', async () => {
+    await applyFInTransaction(c);
+    const s = await seedRestock(c, 15);
+    const view = await q1(c, 'select gr_qty::text from v_picking_demand_no_po where restock_request_id=$1 and sku_id=$2', [s.rr, s.sku]);
+    assert.equal(Number(view.gr_qty), 10);
+    await expectReject(c, 'F draft 不可吃 reserved 的 5 件', () => wave(c, s, [{ sku_id: s.sku, store_id: s.store, qty: '15' }]), /可派量|reserved|保留|庫存/i);
+    const before = await q1(c, 'select reserved::text from stock_balances where tenant_id=$1 and location_id=$2 and sku_id=$3', [s.tenant, s.hq, s.sku]);
+    const made = await wave(c, s, [{ sku_id: s.sku, store_id: s.store, qty: '10' }]);
+    assert.ok(made.wave_id);
+    const after = await q1(c, 'select reserved::text from stock_balances where tenant_id=$1 and location_id=$2 and sku_id=$3', [s.tenant, s.hq, s.sku]);
+    assert.equal(after.reserved, before.reserved, 'draft wave 不應增加 reserved');
+    await expectReject(c, 'F 已建 10 後剩餘申請 5 不可再配 6', () => wave(c, s, [{ sku_id: s.sku, store_id: s.store, qty: '6' }]), /剩餘申請量|已撿|超過/i);
+  });
+}
+
+async function testFRestockInputs(c) {
+  await tx(c, 'F 補貨非法 qty/SKU/store 與重複行累加', async () => {
+    await applyFInTransaction(c);
+    const s = await seedRestock(c, 10);
+    await expectReject(c, 'F qty 四位小數拒絕', () => wave(c, s, [{ sku_id: s.sku, store_id: s.store, qty: '1.0001' }]), /有限正數|3 位小數|數量/i);
+    await expectReject(c, 'F qty NaN 拒絕', () => wave(c, s, [{ sku_id: s.sku, store_id: s.store, qty: 'NaN' }]), /有限正數|3 位小數|數量/i);
+    await expectReject(c, 'F 錯 tenant SKU 拒絕', () => wave(c, s, [{ sku_id: s.otherSku, store_id: s.store, qty: '1' }]), /找不到 SKU|不屬於/i);
+    await expectReject(c, 'F 錯店拒絕', () => wave(c, s, [{ sku_id: s.sku, store_id: s.otherStore, qty: '1' }]), /申請分店|其他店|不可派/i);
+    const made = await wave(c, s, [
+      { sku_id: s.sku, store_id: s.store, qty: '4' },
+      { sku_id: s.sku, store_id: s.store, qty: '6' },
+    ]);
+    const item = await q1(c, 'select qty::text from picking_wave_items where wave_id=$1 and sku_id=$2 and store_id=$3', [made.wave_id, s.sku, s.store]);
+    assert.equal(Number(item.qty), 10);
+  });
+}
+
+async function testFOldRestockAvailableBaseline(c) {
+  await tx(c, 'F 舊補貨可派量 baseline 會把 reserved 當可派', async () => {
+    await applyOldRestockWaveInTransaction(c);
+    const s = await seedRestock(c, 15);
+    const made = await wave(c, s, [{ sku_id: s.sku, store_id: s.store, qty: '15' }]);
+    assert.ok(made.wave_id, '舊版用 on_hand 當供給，15 帳 / 5 reserved 仍會建 draft15；新版測試應抓住這個錯');
+  });
+}
+
+async function testFRestockBalanceRace(c) {
+  const dbName = c.__dbName;
+  const holder = await connect(dbName);
+  const racer = await connect(dbName);
+  const observer = await connect(dbName);
+  try {
+    const s = await seedRestock(c, 15, { onHand: 15, reserved: 0 });
+
+    await holder.query('begin');
+    await holder.query(`set local statement_timeout = '3000ms'`);
+    await holder.query(
+      'update stock_balances set reserved = reserved + 5 where tenant_id=$1 and location_id=$2 and sku_id=$3',
+      [s.tenant, s.hq, s.sku],
+    );
+
+    await racer.query('begin');
+    await racer.query(`set local statement_timeout = '3000ms'`);
+    const racePromise = wave(racer, s, [{ sku_id: s.sku, store_id: s.store, qty: '15' }])
+      .then((value) => ({ ok: true, value }))
+      .catch((error) => ({ ok: false, error }));
+
+    await waitForLockWait(observer, racer.processID, 'F 建 wave 與 reserved 更新併發');
+    await holder.query('commit');
+    const result = await racePromise;
+    assert.equal(result.ok, false, 'reserved 併發增加後，建 wave 不應照舊吃 15 件');
+    assert.match(String(result.error.message), /可派量|reserved|保留|庫存/i);
+    await racer.query('rollback');
+  } finally {
+    await holder.query('rollback').catch(() => undefined);
+    await racer.query('rollback').catch(() => undefined);
+    await holder.end().catch(() => undefined);
+    await racer.end().catch(() => undefined);
+    await observer.end().catch(() => undefined);
+  }
+}
+
+async function testFStoreReturn(c) {
+  await tx(c, 'F 通用退貨擋少收且不破壞三個合法原因', async () => {
+    await applyFInTransaction(c);
+    const s = await seed(c);
+    await c.query('insert into stock_balances (tenant_id, location_id, sku_id, on_hand, reserved) values ($1,$2,$3,20,5)', [s.tenant, s.storeLoc, s.sku]);
+    await setAuth(c, s.tenant, s.operator, 'owner');
+    await expectReject(c, 'F 一般退貨少收拒絕', () => q1(c, 'select public.rpc_create_store_return($1,$2::jsonb,$3,$4) as result', [s.store, JSON.stringify([{ sku_id: s.sku, qty: '1' }]), '少收', s.operator]), /少收|修改實收|原派貨單/i);
+    for (const reason of ['破損', '過期', '客人退']) {
+      const r = await q1(c, 'select public.rpc_create_store_return($1,$2::jsonb,$3,$4) as result', [s.store, JSON.stringify([{ sku_id: s.sku, qty: '1' }]), reason, s.operator]);
+      assert.equal(r.result.stock_moved, false);
+      assert.equal(r.result.reason, reason);
+    }
+    const failures = [];
+    const check = async (label, qty, re) => {
+      try {
+        await expectReject(c, label, () => q1(c, 'select public.rpc_create_store_return($1,$2::jsonb,$3,$4) as result', [s.store, JSON.stringify([{ sku_id: s.sku, qty }]), '破損', s.operator]), re);
+      } catch (e) {
+        failures.push(`${label}: ${e.message}`);
+      }
+    };
+    await check('F 一般退貨 qty 四位小數應拒絕', '1.0001', /數量|3|有限|不完整/i);
+    await check('F 一般退貨 qty NaN 應拒絕', 'NaN', /數量|finite|NaN|有限|不完整/i);
+    await check('F 一般退貨 qty Infinity 應拒絕', 'Infinity', /數量|finite|Infinity|有限|不完整/i);
+    if (failures.length > 0) throw new Error(failures.join(' | '));
+  });
+}
+
+const CASES = [
+  { name: 'b_store_return', fn: testBStoreReturn },
+  { name: 'b_shortage', fn: testBShortage },
+  { name: 'f_restock_available', fn: testFRestockAvailable },
+  { name: 'f_restock_inputs', fn: testFRestockInputs },
+  { name: 'f_old_restock_available_baseline', fn: testFOldRestockAvailableBaseline },
+  { name: 'f_restock_balance_race', fn: testFRestockBalanceRace },
+  { name: 'f_store_return', fn: testFStoreReturn },
+];
+
+function selected(caseNames) {
+  if (!caseNames || caseNames === 'all') return CASES;
+  if (caseNames === 'list') {
+    console.log(CASES.map((c) => c.name).join('\n'));
+    process.exit(0);
+  }
+  const names = caseNames.split(',').map((s) => s.trim()).filter(Boolean);
+  if (names.length === 0) throw new Error('--case 不可為空');
+  const missing = names.filter((n) => !CASES.some((c) => c.name === n));
+  if (missing.length) throw new Error(`未知 --case：${missing.join(', ')}`);
+  return CASES.filter((c) => names.includes(c.name));
+}
+
+async function main() {
+  const { dbName, caseNames } = parseArgs(process.argv);
+  const picked = selected(caseNames);
+  const c = await connect(dbName);
+  const results = [];
+  try {
+    await preflight(c, picked);
+    for (const tc of picked) {
+      try {
+        await tc.fn(c);
+        console.log(`PASS ${tc.name}`);
+        results.push({ name: tc.name, ok: true });
+      } catch (e) {
+        console.error(`FAIL ${tc.name}: ${e.message}`);
+        results.push({ name: tc.name, ok: false, message: e.message });
+      } finally {
+        await resetRole(c).catch(() => undefined);
+      }
+    }
+  } finally {
+    await c.end();
+  }
+  console.log('source_available_summary');
+  for (const r of results) console.log(`${r.ok ? 'PASS' : 'FAIL'} ${r.name}${r.ok ? '' : ` :: ${r.message}`}`);
+  if (results.some((r) => !r.ok)) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(e.stack || e.message);
+  process.exit(1);
+});

--- a/tests/return-disposition-review/ui-input-runtime.cjs
+++ b/tests/return-disposition-review/ui-input-runtime.cjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const ts = require('typescript');
+
+const repoRoot = path.resolve(__dirname, '../..');
+const pageRel = 'apps/admin/src/app/(protected)/wms/return-disposition/page.tsx';
+const pageFile = path.join(repoRoot, pageRel);
+const source = fs.readFileSync(pageFile, 'utf8');
+const sourceFile = ts.createSourceFile(pageRel, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+
+function findFunction(name) {
+  let found = null;
+  function visit(node) {
+    if (ts.isFunctionDeclaration(node) && node.name && node.name.text === name) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  if (!found) {
+    throw new Error(`找不到 ${name}，測試不能跳過`);
+  }
+  const pos = sourceFile.getLineAndCharacterOfPosition(found.getStart(sourceFile));
+  return {
+    name,
+    line: pos.line + 1,
+    text: source.slice(found.getStart(sourceFile), found.end),
+  };
+}
+
+function loadHelpers(runtimeGlobals = {}) {
+  const helpers = [findFunction('newRequestId'), findFunction('clampDecimal')];
+  const js = ts.transpileModule(
+    helpers.map((h) => h.text).join('\n\n') + '\n\nmodule.exports = { newRequestId, clampDecimal };',
+    {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2020,
+      },
+      fileName: pageRel,
+    },
+  ).outputText;
+
+  const sandbox = {
+    module: { exports: {} },
+    exports: {},
+    ...runtimeGlobals,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(js, sandbox, { filename: 'return-disposition-page-helpers.js' });
+  return { helpers: sandbox.module.exports, locations: helpers };
+}
+
+function inspect(value) {
+  return JSON.stringify(value);
+}
+
+const failures = [];
+
+function equal(name, actual, expected) {
+  if (!Object.is(actual, expected)) {
+    failures.push({ name, actual: inspect(actual), expected: inspect(expected) });
+  }
+}
+
+function ok(name, pass, actual, expected) {
+  if (!pass) {
+    failures.push({ name, actual, expected });
+  }
+}
+
+const { helpers, locations } = loadHelpers();
+
+const clampCases = [
+  {
+    name: 'clampDecimal 編輯中小數點要保留',
+    input: '1.',
+    max: 10,
+    expected: '1.',
+  },
+  {
+    name: 'clampDecimal 非法格式不可吃前綴改數',
+    input: '1e3',
+    max: 10000,
+    expected: '1e3',
+  },
+  {
+    name: 'clampDecimal 超過上限不可靜默改成別的數',
+    input: '1',
+    max: 0.75,
+    expected: '1',
+  },
+  {
+    name: 'clampDecimal 超過三位小數不可靜默截斷',
+    input: '0.0009',
+    max: 10,
+    expected: '0.0009',
+  },
+];
+
+for (const c of clampCases) {
+  equal(c.name, helpers.clampDecimal(c.input, c.max), c.expected);
+}
+
+let getRandomValuesCalls = 0;
+let mathRandomCalls = 0;
+const fallbackCrypto = {
+  getRandomValues(view) {
+    getRandomValuesCalls += 1;
+    for (let i = 0; i < view.length; i += 1) view[i] = (i * 17 + 23) & 0xff;
+    return view;
+  },
+};
+const fakeMath = Object.create(Math);
+fakeMath.random = () => {
+  mathRandomCalls += 1;
+  return 0.123456789;
+};
+
+const { helpers: fallbackHelpers } = loadHelpers({
+  crypto: fallbackCrypto,
+  Date: { now: () => 1700000000000 },
+  Math: fakeMath,
+});
+const fallbackId = fallbackHelpers.newRequestId();
+const uuidV4Re = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+ok(
+  'newRequestId fallback 要產生 RFC4122 v4 UUID',
+  uuidV4Re.test(fallbackId),
+  inspect(fallbackId),
+  'RFC4122 v4 UUID（xxxxxxxx-xxxx-4xxx-[89ab]xxx-xxxxxxxxxxxx）',
+);
+ok(
+  'newRequestId fallback 要使用 crypto.getRandomValues',
+  getRandomValuesCalls > 0,
+  String(getRandomValuesCalls),
+  '> 0',
+);
+equal('newRequestId fallback 不可使用 Math.random', mathRandomCalls, 0);
+
+console.log(`extracted ${locations.map((h) => `${h.name}:L${h.line}`).join(', ')} from ${pageRel}`);
+
+if (failures.length === 0) {
+  console.log('ok - return-disposition UI input runtime checks');
+} else {
+  for (const f of failures) {
+    console.error(`FAIL - ${f.name}`);
+    console.error(`  actual:   ${f.actual}`);
+    console.error(`  expected: ${f.expected}`);
+  }
+  console.error(`${failures.length} failed`);
+  process.exitCode = 1;
+}

--- a/tests/return-disposition-review/ui-input-runtime.cjs
+++ b/tests/return-disposition-review/ui-input-runtime.cjs
@@ -11,8 +11,10 @@ const pageRel = 'apps/admin/src/app/(protected)/wms/return-disposition/page.tsx'
 const pageFile = path.join(repoRoot, pageRel);
 const source = fs.readFileSync(pageFile, 'utf8');
 const sourceFile = ts.createSourceFile(pageRel, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+const detailRel = 'apps/admin/src/app/(protected)/transfers/settlement/detail/page.tsx';
+const printRel = 'apps/admin/src/app/(protected)/finance/receivables/print/page.tsx';
 
-function findFunction(name) {
+function findFunction(name, sf = sourceFile, src = source) {
   let found = null;
   function visit(node) {
     if (ts.isFunctionDeclaration(node) && node.name && node.name.text === name) {
@@ -21,22 +23,22 @@ function findFunction(name) {
     }
     ts.forEachChild(node, visit);
   }
-  visit(sourceFile);
+  visit(sf);
   if (!found) {
     throw new Error(`找不到 ${name}，測試不能跳過`);
   }
-  const pos = sourceFile.getLineAndCharacterOfPosition(found.getStart(sourceFile));
+  const pos = sf.getLineAndCharacterOfPosition(found.getStart(sf));
   return {
     name,
     line: pos.line + 1,
-    text: source.slice(found.getStart(sourceFile), found.end),
+    text: src.slice(found.getStart(sf), found.end),
   };
 }
 
 function loadHelpers(runtimeGlobals = {}) {
-  const helpers = [findFunction('newRequestId'), findFunction('clampDecimal')];
+  const helpers = [findFunction('newRequestId'), findFunction('clampDecimal'), findFunction('fmtUnitCost')];
   const js = ts.transpileModule(
-    helpers.map((h) => h.text).join('\n\n') + '\n\nmodule.exports = { newRequestId, clampDecimal };',
+    helpers.map((h) => h.text).join('\n\n') + '\n\nmodule.exports = { newRequestId, clampDecimal, fmtUnitCost };',
     {
       compilerOptions: {
         module: ts.ModuleKind.CommonJS,
@@ -54,6 +56,27 @@ function loadHelpers(runtimeGlobals = {}) {
   vm.createContext(sandbox);
   vm.runInContext(js, sandbox, { filename: 'return-disposition-page-helpers.js' });
   return { helpers: sandbox.module.exports, locations: helpers };
+}
+
+function loadSingleHelper(rel, name) {
+  const file = path.join(repoRoot, rel);
+  const src = fs.readFileSync(file, 'utf8');
+  const sf = ts.createSourceFile(rel, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const helper = findFunction(name, sf, src);
+  const js = ts.transpileModule(
+    `${helper.text}\n\nmodule.exports = { ${name} };`,
+    {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2020,
+      },
+      fileName: rel,
+    },
+  ).outputText;
+  const sandbox = { module: { exports: {} }, exports: {} };
+  vm.createContext(sandbox);
+  vm.runInContext(js, sandbox, { filename: `${rel}-${name}.js` });
+  return { helper: sandbox.module.exports[name], location: { ...helper, rel } };
 }
 
 function inspect(value) {
@@ -75,6 +98,8 @@ function ok(name, pass, actual, expected) {
 }
 
 const { helpers, locations } = loadHelpers();
+const detailFmtCost = loadSingleHelper(detailRel, 'fmtCost');
+const printFmtCost = loadSingleHelper(printRel, 'fmtCost');
 
 const clampCases = [
   {
@@ -144,7 +169,18 @@ ok(
 );
 equal('newRequestId fallback 不可使用 Math.random', mathRandomCalls, 0);
 
+equal('fmtUnitCost NULL 不可顯示成 0 元', helpers.fmtUnitCost(null), '未提供成本');
+equal('fmtUnitCost 空字串不可顯示成 0 元', helpers.fmtUnitCost(''), '未提供成本');
+equal('fmtUnitCost 非數字不可顯示成 0 元', helpers.fmtUnitCost('not-a-number'), '未提供成本');
+equal('fmtUnitCost 真 0 才顯示 0 元', helpers.fmtUnitCost(0), '$0.00');
+equal('settlement detail NULL 成本不可顯示成 0 元', detailFmtCost.helper(null), '未提供成本');
+equal('settlement detail 真 0 才顯示 0 元', detailFmtCost.helper(0), '$0.00');
+equal('settlement print NULL 成本不可顯示成 0 元', printFmtCost.helper(null), '未提供成本');
+equal('settlement print 真 0 才顯示 0 元', printFmtCost.helper(0), '$0.00');
+
 console.log(`extracted ${locations.map((h) => `${h.name}:L${h.line}`).join(', ')} from ${pageRel}`);
+console.log(`extracted fmtCost:L${detailFmtCost.location.line} from ${detailRel}`);
+console.log(`extracted fmtCost:L${printFmtCost.location.line} from ${printRel}`);
 
 if (failures.length === 0) {
   console.log('ok - return-disposition UI input runtime checks');

--- a/tests/return-disposition-review/ui-submit-runtime.cjs
+++ b/tests/return-disposition-review/ui-submit-runtime.cjs
@@ -77,16 +77,21 @@ function makeUuidFactory() {
   };
 }
 
+const TENANT_A = '11111111-1111-1111-1111-111111111111';
+const TENANT_B = '33333333-3333-3333-3333-333333333333';
+const USER_A = '22222222-2222-2222-2222-222222222222';
+const USER_B = '44444444-4444-4444-4444-444444444444';
+
 function makeSupabase(rpcCalls) {
   const responses = {
     v_hq_return_batches_list: [
       {
         id: 101,
-        tenant_id: '11111111-1111-1111-1111-111111111111',
+        tenant_id: TENANT_A,
         location_id: 10,
         sku_id: 101,
         source_movement_id: 8001,
-        source_transfer_item_id: null,
+        source_transfer_item_id: 501,
         source_kind: 'store_return',
         source_reason: 'fixture',
         total_qty: 10,
@@ -98,24 +103,65 @@ function makeSupabase(rpcCalls) {
         qty_pending: 10,
         status: 'pending',
         auto_flag: 'manual',
-        created_by: '22222222-2222-2222-2222-222222222222',
+        created_by: USER_A,
         created_at: '2026-09-07T00:00:00Z',
         updated_at: '2026-09-07T00:00:00Z',
       },
+      {
+        id: 102,
+        tenant_id: TENANT_A,
+        location_id: 10,
+        sku_id: 101,
+        source_movement_id: 8002,
+        source_transfer_item_id: 502,
+        source_kind: 'shortage',
+        source_reason: 'shortage: fixture',
+        total_qty: 5,
+        unit_cost: 100,
+        qty_good: 0,
+        qty_damaged: 0,
+        qty_lost: 0,
+        qty_revoked: 0,
+        qty_pending: 5,
+        status: 'pending',
+        auto_flag: 'manual',
+        created_by: USER_A,
+        created_at: '2026-09-07T00:01:00Z',
+        updated_at: '2026-09-07T00:01:00Z',
+      },
     ],
     hq_return_events: [],
-    locations: [],
+    skus: [{ id: 101, sku_code: 'SKU-101', product_name: '測試商品', variant_name: null }],
+    transfer_items: [
+      { id: 501, transfer_id: 601 },
+      { id: 502, transfer_id: 602 },
+    ],
+    transfers: [
+      { id: 601, transfer_no: 'TR-STORE-RETURN', source_location: 21, dest_location: 10 },
+      { id: 602, transfer_no: 'TR-SHORTAGE', source_location: 10, dest_location: 22 },
+    ],
+    locations: [
+      { id: 10, name: '總倉' },
+      { id: 21, name: '退貨門市' },
+      { id: 22, name: '短少門市' },
+    ],
   };
 
   function query(table) {
+    const filters = [];
+    let rangeFrom = null;
+    let rangeTo = null;
     const q = {
       select() { return q; },
       order() { return q; },
       limit() { return q; },
-      in() { return q; },
-      eq() { return q; },
+      range(from, to) { rangeFrom = from; rangeTo = to; return q; },
+      in(column, values) { filters.push((row) => values.includes(row[column])); return q; },
+      eq(column, value) { filters.push((row) => row[column] === value); return q; },
       then(resolve, reject) {
-        return Promise.resolve({ data: responses[table] || [], error: null }).then(resolve, reject);
+        let data = (responses[table] || []).filter((row) => filters.every((fn) => fn(row)));
+        if (rangeFrom !== null && rangeTo !== null) data = data.slice(rangeFrom, rangeTo + 1);
+        return Promise.resolve({ data, error: null }).then(resolve, reject);
       },
     };
     return q;
@@ -137,7 +183,18 @@ function makeSupabase(rpcCalls) {
   };
 }
 
-function loadPage(rpcCalls) {
+function makeAuth(userId = USER_A, tenantId = TENANT_A, role = 'owner') {
+  return {
+    user: {
+      id: userId,
+      app_metadata: { role, tenant_id: tenantId },
+    },
+    tenant: { id: tenantId },
+    loading: false,
+  };
+}
+
+function loadPage(rpcCalls, auth = makeAuth()) {
   const js = ts.transpileModule(source, {
     compilerOptions: {
       module: ts.ModuleKind.CommonJS,
@@ -166,11 +223,18 @@ function loadPage(rpcCalls) {
         return { __esModule: true, default: ({ href, children, ...props }) => React.createElement('a', { href, ...props }, children) };
       }
       if (id === '@/lib/supabase') return { getSupabase: () => makeSupabase(rpcCalls) };
-      if (id === '@/lib/fetchAllRows') return { fetchAllRows: async () => [] };
+      if (id === '@/components/AuthProvider') return { useAuth: () => auth };
+      if (id === '@/lib/fetchAllRows') return {
+        fetchAllRows: async (builder) => {
+          const { data, error } = await builder();
+          if (error) throw error;
+          return data || [];
+        },
+      };
       if (id === '@/lib/rpcError') return { translateRpcError: (err) => err?.message || String(err) };
       if (id === '@/lib/role') {
         return {
-          useRole: () => 'owner',
+          useRole: () => auth.user?.app_metadata?.role ?? null,
           isHqRole: () => true,
           canSeeCost: () => false,
         };
@@ -197,27 +261,37 @@ async function renderPage(Page) {
 }
 
 async function submitGoodQty(value) {
-  const goodInput = document.querySelector('input[type="number"]');
+  const goodInput = document.querySelector('#return-good-qty');
   if (!goodInput) throw new Error('找不到完好數量 input');
   await input(goodInput, value);
-  const checks = [...document.querySelectorAll('input[type="checkbox"]')];
-  const goodsConfirmed = checks[1];
+  const goodsConfirmed = document.querySelector('#return-goods-confirmed');
   if (!goodsConfirmed) throw new Error('找不到實物已到 checkbox');
   if (!goodsConfirmed.checked) await click(goodsConfirmed);
   await click(byText('button', '送出處理'));
 }
 
 async function trySubmitGoodQty(value) {
-  const goodInput = document.querySelector('input[type="number"]');
+  const goodInput = document.querySelector('#return-good-qty');
   const submitButton = [...document.querySelectorAll('button')]
     .find((button) => textOf(button).includes('送出處理'));
   if (!goodInput || goodInput.disabled || !submitButton || submitButton.disabled) return false;
   await input(goodInput, value);
-  const checks = [...document.querySelectorAll('input[type="checkbox"]')];
-  const goodsConfirmed = checks[1];
+  const goodsConfirmed = document.querySelector('#return-goods-confirmed');
   if (!goodsConfirmed || goodsConfirmed.disabled) return false;
   if (!goodsConfirmed.checked) await click(goodsConfirmed);
   await click(submitButton);
+  return true;
+}
+
+async function clickBatch(id) {
+  await click(byText('button', `#${id}`));
+}
+
+async function clickIfEnabled(text) {
+  const button = [...document.querySelectorAll('button')]
+    .find((el) => textOf(el).includes(text));
+  if (!button || button.disabled) return false;
+  await click(button);
   return true;
 }
 
@@ -240,10 +314,196 @@ function payloadSnapshot(payload) {
 
 const failures = [];
 
+async function runUnknownDeliveryScenario() {
+  const rpcCalls = [];
+  const Page = loadPage(rpcCalls);
+  let root = await renderPage(Page);
+  await clickBatch(101);
+  await submitGoodQty('1');
+
+  const first = rpcCalls[0];
+  expect(
+    '第一次送出要打到 rpc_dispose_hq_return',
+    Boolean(first),
+    first ? payloadSnapshot(first) : 'missing first rpc',
+    'one rpc payload for initial submit',
+  );
+
+  const regenerateButton = [...document.querySelectorAll('button')]
+    .find((button) => textOf(button).includes('重新產生 Request ID'));
+  const enabledQtyInputsAfterUnknown = [...document.querySelectorAll('input[inputmode="decimal"]')]
+    .filter((el) => !el.disabled).length;
+
+  observe(
+    '未知錯誤後數量欄位啟用數',
+    `${enabledQtyInputsAfterUnknown} enabled decimal input(s)`,
+  );
+  expect(
+    '未知送出結果後不可提供可按的換 request id 按鈕',
+    !(regenerateButton && !regenerateButton.disabled),
+    regenerateButton ? `button enabled=${!regenerateButton.disabled} (L${lineOf('重新產生 Request ID')})` : 'button absent',
+    'button absent or disabled until request is confirmed/rejected',
+  );
+  expect(
+    '未知送出結果後數量欄位要鎖住',
+    enabledQtyInputsAfterUnknown === 0,
+    `${enabledQtyInputsAfterUnknown} enabled decimal input(s)`,
+    '0 enabled decimal input',
+  );
+
+  await clickBatch(102);
+  expect(
+    '未知送出結果後不可切到另一批',
+    document.querySelector('#return-good-qty')?.disabled === true && textOf(document.body).includes('批次 #101'),
+    textOf(document.body),
+    'still locked on batch #101',
+  );
+
+  const beforeResend = rpcCalls.length;
+  await clickIfEnabled('重新傳送原資料');
+  const resent = rpcCalls[beforeResend];
+  expect(
+    '未知結果後若重送，payload 要維持原包',
+    Boolean(resent) && payloadSnapshot(resent) === payloadSnapshot(first),
+    resent ? `resent ${payloadSnapshot(resent)}; first ${payloadSnapshot(first)}` : 'missing resend rpc',
+    'same full payload as first unknown request',
+  );
+  expect(
+    '未知結果後若重送，不得換新 request id',
+    Boolean(resent) && resent.p_request_id === first.p_request_id,
+    resent ? `resent request=${resent.p_request_id}; first request=${first.p_request_id}` : 'missing resend rpc',
+    'same request id as first unknown request',
+  );
+
+  await act(async () => root.unmount());
+  root = null;
+  root = await renderPage(Page);
+  expect(
+    '關頁重開後要恢復待確認批次',
+    textOf(document.body).includes('批次 #101') && textOf(document.body).includes('上一筆送出結果還沒查明'),
+    textOf(document.body),
+    'batch #101 restored and locked',
+  );
+  const beforeReopened = rpcCalls.length;
+  await clickIfEnabled('重新傳送原資料');
+  const reopened = rpcCalls[beforeReopened];
+  expect(
+    '關頁重開後若允許重送，payload 要維持原包',
+    Boolean(reopened) && payloadSnapshot(reopened) === payloadSnapshot(first),
+    reopened ? `reopened ${payloadSnapshot(reopened)}; first ${payloadSnapshot(first)}` : 'missing reopened rpc',
+    'same full payload restored after remount/reload',
+  );
+
+  await act(async () => root.unmount());
+}
+
+async function runInputGuardScenario() {
+  const rpcCalls = [];
+  const Page = loadPage(rpcCalls);
+  const root = await renderPage(Page);
+  await clickBatch(101);
+  const goodInput = document.querySelector('#return-good-qty');
+  if (!goodInput) throw new Error('找不到完好數量 input');
+  const cases = ['1e3', '-1', '1.0001', '11'];
+  for (const value of cases) {
+    await input(goodInput, value);
+    expect(
+      `非法/超量輸入 ${value} 編輯中不可被改值`,
+      goodInput.value === value,
+      goodInput.value,
+      value,
+    );
+    const before = rpcCalls.length;
+    await click(byText('button', '送出處理'));
+    expect(
+      `非法/超量輸入 ${value} 不可送 RPC`,
+      rpcCalls.length === before,
+      `${rpcCalls.length - before} new rpc call(s)`,
+      '0 new rpc call',
+    );
+  }
+  await input(goodInput, '0.125');
+  const goodsConfirmed = document.querySelector('#return-goods-confirmed');
+  if (goodsConfirmed && !goodsConfirmed.checked) await click(goodsConfirmed);
+  const before = rpcCalls.length;
+  await click(byText('button', '送出處理'));
+  expect(
+    '合法三位小數可送出',
+    rpcCalls.length === before + 1 && rpcCalls[before].p_qty_good === 0.125,
+    rpcCalls[before] ? payloadSnapshot(rpcCalls[before]) : 'no rpc',
+    'one rpc with p_qty_good=0.125',
+  );
+  await act(async () => root.unmount());
+}
+
+async function runStorageFailureScenario() {
+  const rpcCalls = [];
+  const originalSetItem = window.Storage.prototype.setItem;
+  window.Storage.prototype.setItem = function setItemFailure() {
+    throw new Error('storage disabled');
+  };
+  try {
+    const Page = loadPage(rpcCalls);
+    const root = await renderPage(Page);
+    await clickBatch(101);
+    await submitGoodQty('1');
+    expect(
+      '本機無法保存待確認包時不可送 RPC',
+      rpcCalls.length === 0,
+      `${rpcCalls.length} rpc call(s)`,
+      '0 rpc call',
+    );
+    await act(async () => root.unmount());
+  } finally {
+    window.Storage.prototype.setItem = originalSetItem;
+  }
+}
+
+async function runCrossTenantUserStorageScenario() {
+  const request = {
+    schemaVersion: 1,
+    tenantId: TENANT_A,
+    operatorId: USER_A,
+    batchId: 101,
+    requestId: '00000000-0000-4000-8000-000000000099',
+    createdAt: new Date().toISOString(),
+    payload: {
+      p_batch_id: 101,
+      p_request_id: '00000000-0000-4000-8000-000000000099',
+      p_qty_good: 1,
+      p_qty_damaged: 0,
+      p_qty_lost: 0,
+      p_damage_reason: null,
+      p_loss_reason: null,
+      p_goods_confirmed: true,
+      p_notes: null,
+    },
+  };
+  window.localStorage.setItem(`new-erp:hq-return-disposition:pending:v1:${TENANT_A}:${USER_A}`, JSON.stringify(request));
+
+  const rpcCalls = [];
+  const Page = loadPage(rpcCalls, makeAuth(USER_B, TENANT_B, 'owner'));
+  const root = await renderPage(Page);
+  expect(
+    '不同租戶/使用者不應恢復別人的待確認包',
+    !textOf(document.body).includes('上一筆送出結果還沒查明'),
+    textOf(document.body),
+    'no pending request restored',
+  );
+  await clickBatch(101);
+  await submitGoodQty('1');
+  expect(
+    '不同租戶/使用者送出前會因批次 tenant 不符被前端擋下',
+    rpcCalls.length === 0 && textOf(document.body).includes('不屬於目前登入的公司'),
+    `${rpcCalls.length} rpc call(s); body=${textOf(document.body)}`,
+    '0 rpc call and tenant mismatch error',
+  );
+  await act(async () => root.unmount());
+}
+
 (async () => {
   global.IS_REACT_ACT_ENVIRONMENT = true;
   const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost/wms/return-disposition' });
-  let root = null;
   try {
     global.window = dom.window;
     global.document = dom.window.document;
@@ -260,76 +520,13 @@ const failures = [];
     global.sessionStorage = dom.window.sessionStorage;
     ({ createRoot } = require('react-dom/client'));
 
-    const rpcCalls = [];
-    const Page = loadPage(rpcCalls);
-    root = await renderPage(Page);
-    await click(byText('tr', '#101'));
-    await submitGoodQty('1');
-
-    const first = rpcCalls[0];
-    expect(
-      '第一次送出要打到 rpc_dispose_hq_return',
-      Boolean(first),
-      first ? payloadSnapshot(first) : 'missing first rpc',
-      'one rpc payload for initial submit',
-    );
-
-    const regenerateButton = [...document.querySelectorAll('button')]
-      .find((button) => textOf(button).includes('重新產生 Request ID'));
-    const enabledNumberInputsAfterUnknown = [...document.querySelectorAll('input[type="number"]')]
-      .filter((el) => !el.disabled).length;
-
-    observe(
-      '未知錯誤後數量欄位啟用數',
-      `${enabledNumberInputsAfterUnknown} enabled number input(s)`,
-    );
-    expect(
-      '未知送出結果後不可提供可按的換 request id 按鈕',
-      !(regenerateButton && !regenerateButton.disabled),
-      regenerateButton ? `button enabled=${!regenerateButton.disabled} (L${lineOf('重新產生 Request ID')})` : 'button absent',
-      'button absent or disabled until request is confirmed/rejected',
-    );
-
-    const beforeSecond = rpcCalls.length;
-    if (regenerateButton && !regenerateButton.disabled) await click(regenerateButton);
-    await trySubmitGoodQty('2');
-    const second = rpcCalls[beforeSecond];
-    const secondDidNotWrite = rpcCalls.length === beforeSecond;
-
-    expect(
-      '未知結果後若再次送出，payload 要維持原包',
-      secondDidNotWrite || (second && payloadSnapshot(second) === payloadSnapshot(first)),
-      secondDidNotWrite ? 'no second rpc' : `second ${payloadSnapshot(second)}; first ${payloadSnapshot(first)}`,
-      'no new write, or same full payload as first unknown request',
-    );
-    expect(
-      '未知結果後若再次送出，不得換新 request id',
-      secondDidNotWrite || (second && second.p_request_id === first.p_request_id),
-      secondDidNotWrite ? 'no second rpc' : `second request=${second.p_request_id}; first request=${first.p_request_id}`,
-      'no new write, or same request id as first unknown request',
-    );
-
-    await act(async () => root.unmount());
-    root = null;
-    root = await renderPage(Page);
-    await click(byText('tr', '#101'));
-    const beforeReopened = rpcCalls.length;
-    await trySubmitGoodQty('1');
-    const reopened = rpcCalls[beforeReopened];
-    const reopenedDidNotWrite = rpcCalls.length === beforeReopened;
-
-    expect(
-      '關頁重開後不得用新 request id 重送待確認包',
-      reopenedDidNotWrite || (reopened && reopened.p_request_id === first.p_request_id),
-      reopenedDidNotWrite ? 'no reopened rpc' : `reopened request=${reopened.p_request_id}; first request=${first.p_request_id}`,
-      'no new write until confirmation, or same pending request id restored after remount/reload',
-    );
-    expect(
-      '關頁重開後若允許重送，payload 要維持原包',
-      reopenedDidNotWrite || (reopened && payloadSnapshot(reopened) === payloadSnapshot(first)),
-      reopenedDidNotWrite ? 'no reopened rpc' : `reopened ${payloadSnapshot(reopened)}; first ${payloadSnapshot(first)}`,
-      'no new write until confirmation, or same full payload restored after remount/reload',
-    );
+    await runUnknownDeliveryScenario();
+    window.localStorage.clear();
+    await runInputGuardScenario();
+    window.localStorage.clear();
+    await runStorageFailureScenario();
+    window.localStorage.clear();
+    await runCrossTenantUserStorageScenario();
 
     const hasDurableStorage = /\b(localStorage|sessionStorage|indexedDB)\b/.test(source);
     const looksUpEventByRequestId =
@@ -349,7 +546,6 @@ const failures = [];
     );
 
     console.log(`rendered ${pageRel}`);
-    console.log(`rpc calls: ${rpcCalls.map((p) => `${p.p_request_id}:${p.p_qty_good}`).join(', ') || '(none)'}`);
     for (const o of observations) {
       console.log(`OBSERVE - ${o.name}`);
       console.log(`  actual:   ${o.actual}`);
@@ -367,7 +563,6 @@ const failures = [];
       process.exitCode = 1;
     }
   } finally {
-    if (root) await act(async () => root.unmount());
     dom.window.close();
   }
 })().catch((err) => {

--- a/tests/return-disposition-review/ui-submit-runtime.cjs
+++ b/tests/return-disposition-review/ui-submit-runtime.cjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const ts = require('typescript');
+const { JSDOM } = require('jsdom');
+const React = require('react');
+const { act } = React;
+let createRoot;
+
+const repoRoot = path.resolve(__dirname, '../..');
+const pageRel = 'apps/admin/src/app/(protected)/wms/return-disposition/page.tsx';
+const pageFile = path.join(repoRoot, pageRel);
+const source = fs.readFileSync(pageFile, 'utf8');
+const sourceFile = ts.createSourceFile(pageRel, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+
+function lineOf(needle) {
+  const idx = source.indexOf(needle);
+  if (idx === -1) return '?';
+  return sourceFile.getLineAndCharacterOfPosition(idx).line + 1;
+}
+
+function fail(name, actual, expected) {
+  failures.push({ name, actual, expected });
+}
+
+function expect(name, pass, actual, expected) {
+  if (!pass) fail(name, actual, expected);
+}
+
+const observations = [];
+function observe(name, actual) {
+  observations.push({ name, actual });
+}
+
+function textOf(node) {
+  return (node.textContent || '').replace(/\s+/g, ' ').trim();
+}
+
+function byText(selector, text) {
+  const found = [...document.querySelectorAll(selector)].find((el) => textOf(el).includes(text));
+  if (!found) throw new Error(`找不到 ${selector} containing ${text}`);
+  return found;
+}
+
+async function tick() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+}
+
+async function click(el) {
+  await act(async () => {
+    el.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+  });
+  await tick();
+}
+
+async function input(el, value) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+  await act(async () => {
+    setter.call(el, value);
+    el.dispatchEvent(new window.InputEvent('input', { bubbles: true, data: value, inputType: 'insertText' }));
+    el.dispatchEvent(new window.Event('change', { bubbles: true }));
+  });
+  await tick();
+}
+
+function makeUuidFactory() {
+  let n = 0;
+  return () => {
+    n += 1;
+    return `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`;
+  };
+}
+
+function makeSupabase(rpcCalls) {
+  const responses = {
+    v_hq_return_batches_list: [
+      {
+        id: 101,
+        tenant_id: '11111111-1111-1111-1111-111111111111',
+        location_id: 10,
+        sku_id: 101,
+        source_movement_id: 8001,
+        source_transfer_item_id: null,
+        source_kind: 'store_return',
+        source_reason: 'fixture',
+        total_qty: 10,
+        unit_cost: 100,
+        qty_good: 0,
+        qty_damaged: 0,
+        qty_lost: 0,
+        qty_revoked: 0,
+        qty_pending: 10,
+        status: 'pending',
+        auto_flag: 'manual',
+        created_by: '22222222-2222-2222-2222-222222222222',
+        created_at: '2026-09-07T00:00:00Z',
+        updated_at: '2026-09-07T00:00:00Z',
+      },
+    ],
+    hq_return_events: [],
+    locations: [],
+  };
+
+  function query(table) {
+    const q = {
+      select() { return q; },
+      order() { return q; },
+      limit() { return q; },
+      in() { return q; },
+      eq() { return q; },
+      then(resolve, reject) {
+        return Promise.resolve({ data: responses[table] || [], error: null }).then(resolve, reject);
+      },
+    };
+    return q;
+  }
+
+  return {
+    from: query,
+    rpc(name, payload) {
+      if (name === 'rpc_get_staff_names') return Promise.resolve({ data: [], error: null });
+      if (name === 'rpc_dispose_hq_return') {
+        rpcCalls.push(payload);
+        return Promise.resolve({
+          data: null,
+          error: new Error('timeout after commit is unknown'),
+        });
+      }
+      return Promise.resolve({ data: null, error: new Error(`unexpected rpc ${name}`) });
+    },
+  };
+}
+
+function loadPage(rpcCalls) {
+  const js = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      jsx: ts.JsxEmit.ReactJSX,
+      esModuleInterop: true,
+    },
+    fileName: pageRel,
+  }).outputText;
+
+  const uuid = makeUuidFactory();
+  const sandbox = {
+    console,
+    crypto: { randomUUID: uuid },
+    window: global.window,
+    document: global.document,
+    navigator: global.navigator,
+    localStorage: global.localStorage,
+    sessionStorage: global.sessionStorage,
+    module: { exports: {} },
+    exports: {},
+    require(id) {
+      if (id === 'react') return React;
+      if (id === 'react/jsx-runtime') return require('react/jsx-runtime');
+      if (id === 'next/link') {
+        return { __esModule: true, default: ({ href, children, ...props }) => React.createElement('a', { href, ...props }, children) };
+      }
+      if (id === '@/lib/supabase') return { getSupabase: () => makeSupabase(rpcCalls) };
+      if (id === '@/lib/fetchAllRows') return { fetchAllRows: async () => [] };
+      if (id === '@/lib/rpcError') return { translateRpcError: (err) => err?.message || String(err) };
+      if (id === '@/lib/role') {
+        return {
+          useRole: () => 'owner',
+          isHqRole: () => true,
+          canSeeCost: () => false,
+        };
+      }
+      if (id === '@/components/Spinner') return { LoadingBlock: () => React.createElement('div', null, 'loading') };
+      if (id === '@/components/SpinButton') return { __esModule: true, default: ({ children, loading, ...props }) => React.createElement('button', props, children) };
+      throw new Error(`unexpected require: ${id}`);
+    },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(js, sandbox, { filename: pageRel });
+  return sandbox.module.exports.default || sandbox.exports.default;
+}
+
+async function renderPage(Page) {
+  document.body.innerHTML = '<div id="root"></div>';
+  const root = createRoot(document.getElementById('root'));
+  await act(async () => {
+    root.render(React.createElement(Page));
+  });
+  await tick();
+  await tick();
+  return root;
+}
+
+async function submitGoodQty(value) {
+  const goodInput = document.querySelector('input[type="number"]');
+  if (!goodInput) throw new Error('找不到完好數量 input');
+  await input(goodInput, value);
+  const checks = [...document.querySelectorAll('input[type="checkbox"]')];
+  const goodsConfirmed = checks[1];
+  if (!goodsConfirmed) throw new Error('找不到實物已到 checkbox');
+  if (!goodsConfirmed.checked) await click(goodsConfirmed);
+  await click(byText('button', '送出處理'));
+}
+
+async function trySubmitGoodQty(value) {
+  const goodInput = document.querySelector('input[type="number"]');
+  const submitButton = [...document.querySelectorAll('button')]
+    .find((button) => textOf(button).includes('送出處理'));
+  if (!goodInput || goodInput.disabled || !submitButton || submitButton.disabled) return false;
+  await input(goodInput, value);
+  const checks = [...document.querySelectorAll('input[type="checkbox"]')];
+  const goodsConfirmed = checks[1];
+  if (!goodsConfirmed || goodsConfirmed.disabled) return false;
+  if (!goodsConfirmed.checked) await click(goodsConfirmed);
+  await click(submitButton);
+  return true;
+}
+
+const SUBMIT_PAYLOAD_KEYS = [
+  'p_batch_id',
+  'p_request_id',
+  'p_qty_good',
+  'p_qty_damaged',
+  'p_qty_lost',
+  'p_damage_reason',
+  'p_loss_reason',
+  'p_goods_confirmed',
+  'p_notes',
+];
+
+function payloadSnapshot(payload) {
+  if (!payload) return '(missing)';
+  return SUBMIT_PAYLOAD_KEYS.map((key) => `${key}=${JSON.stringify(payload[key])}`).join(', ');
+}
+
+const failures = [];
+
+(async () => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost/wms/return-disposition' });
+  let root = null;
+  try {
+    global.window = dom.window;
+    global.document = dom.window.document;
+    Object.defineProperty(global, 'navigator', {
+      value: dom.window.navigator,
+      configurable: true,
+    });
+    global.HTMLElement = dom.window.HTMLElement;
+    global.HTMLInputElement = dom.window.HTMLInputElement;
+    global.Event = dom.window.Event;
+    global.InputEvent = dom.window.InputEvent;
+    global.MouseEvent = dom.window.MouseEvent;
+    global.localStorage = dom.window.localStorage;
+    global.sessionStorage = dom.window.sessionStorage;
+    ({ createRoot } = require('react-dom/client'));
+
+    const rpcCalls = [];
+    const Page = loadPage(rpcCalls);
+    root = await renderPage(Page);
+    await click(byText('tr', '#101'));
+    await submitGoodQty('1');
+
+    const first = rpcCalls[0];
+    expect(
+      '第一次送出要打到 rpc_dispose_hq_return',
+      Boolean(first),
+      first ? payloadSnapshot(first) : 'missing first rpc',
+      'one rpc payload for initial submit',
+    );
+
+    const regenerateButton = [...document.querySelectorAll('button')]
+      .find((button) => textOf(button).includes('重新產生 Request ID'));
+    const enabledNumberInputsAfterUnknown = [...document.querySelectorAll('input[type="number"]')]
+      .filter((el) => !el.disabled).length;
+
+    observe(
+      '未知錯誤後數量欄位啟用數',
+      `${enabledNumberInputsAfterUnknown} enabled number input(s)`,
+    );
+    expect(
+      '未知送出結果後不可提供可按的換 request id 按鈕',
+      !(regenerateButton && !regenerateButton.disabled),
+      regenerateButton ? `button enabled=${!regenerateButton.disabled} (L${lineOf('重新產生 Request ID')})` : 'button absent',
+      'button absent or disabled until request is confirmed/rejected',
+    );
+
+    const beforeSecond = rpcCalls.length;
+    if (regenerateButton && !regenerateButton.disabled) await click(regenerateButton);
+    await trySubmitGoodQty('2');
+    const second = rpcCalls[beforeSecond];
+    const secondDidNotWrite = rpcCalls.length === beforeSecond;
+
+    expect(
+      '未知結果後若再次送出，payload 要維持原包',
+      secondDidNotWrite || (second && payloadSnapshot(second) === payloadSnapshot(first)),
+      secondDidNotWrite ? 'no second rpc' : `second ${payloadSnapshot(second)}; first ${payloadSnapshot(first)}`,
+      'no new write, or same full payload as first unknown request',
+    );
+    expect(
+      '未知結果後若再次送出，不得換新 request id',
+      secondDidNotWrite || (second && second.p_request_id === first.p_request_id),
+      secondDidNotWrite ? 'no second rpc' : `second request=${second.p_request_id}; first request=${first.p_request_id}`,
+      'no new write, or same request id as first unknown request',
+    );
+
+    await act(async () => root.unmount());
+    root = null;
+    root = await renderPage(Page);
+    await click(byText('tr', '#101'));
+    const beforeReopened = rpcCalls.length;
+    await trySubmitGoodQty('1');
+    const reopened = rpcCalls[beforeReopened];
+    const reopenedDidNotWrite = rpcCalls.length === beforeReopened;
+
+    expect(
+      '關頁重開後不得用新 request id 重送待確認包',
+      reopenedDidNotWrite || (reopened && reopened.p_request_id === first.p_request_id),
+      reopenedDidNotWrite ? 'no reopened rpc' : `reopened request=${reopened.p_request_id}; first request=${first.p_request_id}`,
+      'no new write until confirmation, or same pending request id restored after remount/reload',
+    );
+    expect(
+      '關頁重開後若允許重送，payload 要維持原包',
+      reopenedDidNotWrite || (reopened && payloadSnapshot(reopened) === payloadSnapshot(first)),
+      reopenedDidNotWrite ? 'no reopened rpc' : `reopened ${payloadSnapshot(reopened)}; first ${payloadSnapshot(first)}`,
+      'no new write until confirmation, or same full payload restored after remount/reload',
+    );
+
+    const hasDurableStorage = /\b(localStorage|sessionStorage|indexedDB)\b/.test(source);
+    const looksUpEventByRequestId =
+      /\.from\("hq_return_events"\)[\s\S]*?\.eq\("request_id"/.test(source);
+    const usesMemoryRef = source.includes('const requestIdRef = useRef(newRequestId())');
+    const handleSelectClearsPending =
+      /const handleSelect = useCallback\([\s\S]*?resetForm\(\);[\s\S]*?\[resetForm\]/.test(source);
+    const resetRegeneratesRequest =
+      /const resetForm = useCallback\([\s\S]*?requestIdRef\.current = newRequestId\(\);[\s\S]*?\[\]/.test(source);
+    observe(
+      '原碼觀察：待確認包恢復機制',
+      `durableStorage=${hasDurableStorage}; eventLookupByRequestId=${looksUpEventByRequestId}; memoryRequestRef=${usesMemoryRef} (request ref L${lineOf('const requestIdRef = useRef(newRequestId())')})`,
+    );
+    observe(
+      '原碼觀察：切批是否會重設 request',
+      `handleSelectCallsReset=${handleSelectClearsPending} (L${lineOf('const handleSelect = useCallback')}); resetRegeneratesRequest=${resetRegeneratesRequest} (L${lineOf('const resetForm = useCallback')})`,
+    );
+
+    console.log(`rendered ${pageRel}`);
+    console.log(`rpc calls: ${rpcCalls.map((p) => `${p.p_request_id}:${p.p_qty_good}`).join(', ') || '(none)'}`);
+    for (const o of observations) {
+      console.log(`OBSERVE - ${o.name}`);
+      console.log(`  actual:   ${o.actual}`);
+    }
+
+    if (failures.length === 0) {
+      console.log('ok - return-disposition submit retry runtime checks');
+    } else {
+      for (const f of failures) {
+        console.log(`FAIL - ${f.name}`);
+        console.log(`  actual:   ${f.actual}`);
+        console.log(`  expected: ${f.expected}`);
+      }
+      console.log(`${failures.length} failed`);
+      process.exitCode = 1;
+    }
+  } finally {
+    if (root) await act(async () => root.unmount());
+    dom.window.close();
+  }
+})().catch((err) => {
+  console.error(err.stack || err);
+  process.exit(1);
+});

--- a/tests/return-disposition/README.md
+++ b/tests/return-disposition/README.md
@@ -1,0 +1,83 @@
+# 總倉退回貨處理：本機整合測試 fixture
+
+## 用法
+
+```bash
+# 建立測試 DB 並載入 schema + 真函式 + 假資料
+node tests/return-disposition/fixture.cjs
+
+# 指定 DB 名（必須符合 ^return_disposition_test_[a-z0-9_]+$）
+node tests/return-disposition/fixture.cjs --db-name return_disposition_test_run1
+
+# 載入阿寫核心 migration（若已生成）
+node tests/return-disposition/fixture.cjs --with-core
+```
+
+## 連線設定（硬鎖，不讀 .env）
+
+- host: 127.0.0.1
+- port: 56427
+- user: returnlocal
+- 管理用 DB: postgres
+
+## 載入流程（≠ 功能驗收）
+
+1. 建新 test DB（每次獨立，不 DROP）
+2. auth stub（`auth.uid()` 缺 sub 回 NULL、不冒充全零 user）
+3. FK stub 表 + tenants stub
+4. 從 migration 原文以 **AST 節點型別**（非 regex）拆取 DDL/FUNCTION/TRIGGER/INDEX
+   - `stmt_len === 0` 取到 buffer 尾端
+   - 跳過 RLS / POLICY / GRANT / COMMENT ON
+   - relation 不存在 → **fail**（不吞錯誤），只有 `already exists` 允許跳過
+5. Column additions（ALTER TABLE ADD COLUMN IF NOT EXISTS）
+6. Helper stubs（分三類：通知類 no-op / 庫存類 RAISE / 真實輕量）
+7. 真函式載入（AST 按名稱 pick，**逐一驗證** found = pick count）
+8. `--with-core`：明確載入 A（20260907010000）、B（20260907020000）
+9. Fixture 假資料 + setval sequences
+
+以上只驗證「可載入」，不等於功能驗收。
+
+## stub 清單
+
+以下只建空殼 DDL 或完全跳過，不載入真實邏輯：
+- `auth.uid()` / `auth.jwt()` — session variable 模擬（sub 缺值回 NULL）
+- RLS policies、GRANT/REVOKE — 全跳
+- COMMENT ON — 全跳（非必要）
+- cron / http / pg_net — 不載
+- 通知模組細節 — line_channels 等只建 FK 參照
+- 外部匯入 / POS — 不載
+
+## 真實定義載入的安全 helpers
+
+- `_current_tenant_id` — 從 20260707000020 載真版（查 tenants 表）
+- `_jwt_store_ids` / `_jwt_store_location_ids` — 從 20260707000070 載真版
+- `_is_branch_scoped_user` — 從 20260831000000 載真版
+- `rpc_inbound` — 從 20260903000100 載最新版（虛擬商品守衛）
+
+## helper stub 分類
+
+**✅ 可 no-op（通知/查詢，不動資料）：**
+- `is_order_pickup_ready` — 回 FALSE
+- `_restock_wave_progress` — 回 (FALSE, FALSE)
+- `rpc_mark_orders_shipping_for_wave` — 空
+- `ensure_store_supplier` — 回 1
+
+**⛔ RAISE（會動庫存/訂單/帳，假成功會掩蓋錯誤）：**
+- `_settle_arrived_backorders`
+- `_advance_arrived_confirmed_orders`
+- `_settle_restock_ride_along`
+- `_grow_internal_pool`
+
+## 真載入的函式（來源檔與行號可核對）
+
+見 fixture.cjs 內 FUNCTION_SOURCES 常數。
+
+**注意**：`rpc_adjust_received_transfer` 從 **20260904010000** 載入（庫存連動版），
+不是 20260903000200 的舊版（那份裡的 adjust 只改了守衛 B 訊息）。
+
+## --with-core 載入的檔案
+
+- A: `20260907010000_hq_return_disposition_core.sql`（資料表 + movement_type 擴充）
+- B: `20260907020000_hq_return_disposition_sources.sql`（來源函式）
+
+兩支都必須本地存在才會載入。不掃 pattern、不載其他 case 的 migration。

--- a/tests/return-disposition/README.md
+++ b/tests/return-disposition/README.md
@@ -33,10 +33,12 @@ node tests/return-disposition/fixture.cjs --with-all
    - 跳過 RLS / POLICY / GRANT / COMMENT ON
    - relation 不存在 → **fail**（不吞錯誤），只有 `already exists` 允許跳過
 5. Column additions（ALTER TABLE ADD COLUMN IF NOT EXISTS）
-6. Helper stubs（分三類：通知類 no-op / 庫存類 RAISE / 真實輕量）
+6. Helper stubs（通知／查詢類 no-op；會動庫存、訂單或帳的 helper 一律 RAISE）
+   - `trim_scale` 使用本機 PostgreSQL 18 內建函式，不由 fixture 提供 stub
 7. 真函式載入（AST 按名稱 pick，**逐一驗證** found = pick count）
 8. `--with-core`：明確載入 A（20260907010000）、B（20260907020000）
-9. Fixture 假資料 + setval sequences
+9. `--with-all`：在 C 前以 AST 精確載入真月結產生器完成兩次所需的有界前置
+10. Fixture 假資料 + setval sequences
 
 以上只驗證「可載入」，不等於功能驗收。
 
@@ -44,8 +46,8 @@ node tests/return-disposition/fixture.cjs --with-all
 
 以下只建空殼 DDL 或完全跳過，不載入真實邏輯：
 - `auth.uid()` / `auth.jwt()` — session variable 模擬（sub 缺值回 NULL）
-- RLS policies、GRANT/REVOKE — 全跳
-- COMMENT ON — 全跳（非必要）
+- 基底來源 migration 的 RLS policies、GRANT/REVOKE — 抽 schema 時跳過；**A/B/C/F 候選仍原樣完整執行，包含本案政策與授權**，不是全案跳過權限
+- 基底 COMMENT ON — 抽 schema 時跳過（候選 migration 的註解仍原樣執行）
 - cron / http / pg_net — 不載
 - 通知模組細節 — line_channels 等只建 FK 參照
 - 外部匯入 / POS — 不載
@@ -89,7 +91,32 @@ node tests/return-disposition/fixture.cjs --with-all
 - A + B（同上）
 - C: `20260907030000_hq_return_disposition_reversals.sql`
 - F: `20260907040000_hq_return_disposition_available.sql`
-- prerequisite: `v_picking_demand_no_po`（從 20260612000030 載真版）
+- prerequisite: `v_picking_demand_no_po`（從 20260612000040 以 AST 只抽該 view）
+
+`--with-all` 不會整支載入 20260612000040，避免其中舊版
+`rpc_create_wave_from_restock` 蓋掉 fixture 前面已載入的新版函式。這仍是 F 所需的
+有界前置，不代表 fixture 載入完整 ERP。
+
+為了讓 C 內的真 `rpc_generate_hq_to_store_settlement` 不只等鎖、而是能完整跑完並再次
+重建草稿明細，`--with-all` 會在 C 前從下列來源以 AST 精確抽取必要 statement：
+
+- `20260512000012`：明細 `entry_type` 欄位
+- `20260512000013`：草稿可重建、鎖定後不可改的真明細 trigger
+- `20260714000100`：六種明細類型 CHECK 與 `description`
+- `20260715000000`：雙口徑總額／明細欄位及真 `_branch_price_at`
+- `20260801000000`：`adjustment_amount` 與真 `store_settlement_adjustments` 表
+- `20260825030000`：真 `v_store_aid_transfer_legs` view
+
+每個指定物件或 DDL 必須剛好找到一筆，否則 fixture 直接失敗；這些 migration 內的舊版
+月結產生器與其他財務 RPC 都不會載入。本 fixture 仍不是完整 ERP，也沒有載入完整的
+送單、畫押、確認收款流程；若那些流程需要應收模組，須另列測試範圍與真前置，不能把
+本 fixture 的月結產生成功當成它們已通過。
+
+另外，fixture 會依來源 migration 原樣補齊三組必要 schema 前置：
+
+- `customer_orders.order_kind`：`TEXT NOT NULL DEFAULT 'normal'`，最新允許 `normal/offset/restock`
+- `restock_requests_check`：`approved_transfer` 不再強制已有 `linked_transfer_id`
+- `store_monthly_settlements.status`：允許 `draft/sent/disputed/confirmed/remitted/settled/cancelled`
 
 所有檔案必須本地存在才載入。不掃 pattern、不載其他 case 的 migration。
 以上只驗證「可載入」，不等於完整業務驗收。

--- a/tests/return-disposition/README.md
+++ b/tests/return-disposition/README.md
@@ -11,6 +11,9 @@ node tests/return-disposition/fixture.cjs --db-name return_disposition_test_run1
 
 # 載入阿寫核心 migration（若已生成）
 node tests/return-disposition/fixture.cjs --with-core
+
+# 載入全部 migration（A+B+C+F，缺檔即 fail）
+node tests/return-disposition/fixture.cjs --with-all
 ```
 
 ## 連線設定（硬鎖，不讀 .env）
@@ -50,6 +53,7 @@ node tests/return-disposition/fixture.cjs --with-core
 ## 真實定義載入的安全 helpers
 
 - `_current_tenant_id` — 從 20260707000020 載真版（查 tenants 表）
+- `_next_transfer_no` — 從 20260515000002 載真版（transfer_no_seq）
 - `_jwt_store_ids` / `_jwt_store_location_ids` — 從 20260707000070 載真版
 - `_is_branch_scoped_user` — 從 20260831000000 載真版
 - `rpc_inbound` — 從 20260903000100 載最新版（虛擬商品守衛）
@@ -59,10 +63,10 @@ node tests/return-disposition/fixture.cjs --with-core
 **✅ 可 no-op（通知/查詢，不動資料）：**
 - `is_order_pickup_ready` — 回 FALSE
 - `_restock_wave_progress` — 回 (FALSE, FALSE)
-- `rpc_mark_orders_shipping_for_wave` — 空
 - `ensure_store_supplier` — 回 1
 
 **⛔ RAISE（會動庫存/訂單/帳，假成功會掩蓋錯誤）：**
+- `rpc_mark_orders_shipping_for_wave` — 會改訂單狀態為 shipping
 - `_settle_arrived_backorders`
 - `_advance_arrived_confirmed_orders`
 - `_settle_restock_ride_along`
@@ -75,9 +79,17 @@ node tests/return-disposition/fixture.cjs --with-core
 **注意**：`rpc_adjust_received_transfer` 從 **20260904010000** 載入（庫存連動版），
 不是 20260903000200 的舊版（那份裡的 adjust 只改了守衛 B 訊息）。
 
-## --with-core 載入的檔案
+## --with-core / --with-all 載入的檔案
 
-- A: `20260907010000_hq_return_disposition_core.sql`（資料表 + movement_type 擴充）
-- B: `20260907020000_hq_return_disposition_sources.sql`（來源函式）
+`--with-core`（A+B）：
+- A: `20260907010000_hq_return_disposition_core.sql`
+- B: `20260907020000_hq_return_disposition_sources.sql`
 
-兩支都必須本地存在才會載入。不掃 pattern、不載其他 case 的 migration。
+`--with-all`（A+B+C+F，缺檔即 fail）：
+- A + B（同上）
+- C: `20260907030000_hq_return_disposition_reversals.sql`
+- F: `20260907040000_hq_return_disposition_available.sql`
+- prerequisite: `v_picking_demand_no_po`（從 20260612000030 載真版）
+
+所有檔案必須本地存在才載入。不掃 pattern、不載其他 case 的 migration。
+以上只驗證「可載入」，不等於完整業務驗收。

--- a/tests/return-disposition/fixture.cjs
+++ b/tests/return-disposition/fixture.cjs
@@ -36,6 +36,7 @@ function getDbName() {
 }
 
 const WITH_CORE = process.argv.includes('--with-core');
+const WITH_ALL  = process.argv.includes('--with-all');
 
 // ============================================================
 // Migration 根目錄
@@ -95,6 +96,14 @@ const FUNCTION_SOURCES = [
   { file: '20260715000020_restock_dispatch_dedup_guards.sql',
     desc: 'rpc_create_wave_from_restock',
     pick: ['rpc_create_wave_from_restock'] },
+  // --- _current_tenant_id 真版（tenant status 守門） ---
+  { file: '20260707000020_trial_expiry_enforcement.sql',
+    desc: '_current_tenant_id (tenant status gate)',
+    pick: ['_current_tenant_id'] },
+  // --- _next_transfer_no 真版 ---
+  { file: '20260515000002_rpc_store_self_service.sql',
+    desc: '_next_transfer_no (real, from store self-service)',
+    pick: ['_next_transfer_no'] },
   // --- 安全 helpers（真實定義） ---
   { file: '20260707000070_jwt_store_scope_helpers_and_stock_rls.sql',
     desc: '_jwt_store_ids + _jwt_store_location_ids (真實定義)',
@@ -390,24 +399,9 @@ CREATE TABLE IF NOT EXISTS tenants (
 //   🔧 真實輕量（trim_scale 等）
 // ============================================================
 const HELPER_STUBS_SQL = `
--- _next_transfer_no: real logic (lightweight, no external deps)
+-- sequences referenced by real functions
 CREATE SEQUENCE IF NOT EXISTS transfer_no_seq;
-CREATE OR REPLACE FUNCTION public._next_transfer_no()
-RETURNS TEXT
-LANGUAGE plpgsql AS $$
-BEGIN
-  RETURN 'TR' || to_char(NOW(), 'YYMMDD') || lpad(nextval('transfer_no_seq')::TEXT, 4, '0');
-END;
-$$;
-
--- picking_wave_code_seq
 CREATE SEQUENCE IF NOT EXISTS public.picking_wave_code_seq;
-
--- trim_scale: 真實輕量 helper
-CREATE OR REPLACE FUNCTION public.trim_scale(p NUMERIC)
-RETURNS TEXT LANGUAGE sql IMMUTABLE AS $$
-  SELECT regexp_replace(p::TEXT, '\\.?0+$', '')
-$$;
 
 -- ensure_store_supplier: 真實邏輯太簡單可 stub
 CREATE OR REPLACE FUNCTION public.ensure_store_supplier(p_store_id BIGINT)
@@ -424,10 +418,12 @@ LANGUAGE plpgsql AS $$ BEGIN
   RETURN QUERY SELECT FALSE, FALSE;
 END; $$;
 
--- ✅ 配單通知類 no-op（rpc_mark_orders_shipping_for_wave 只推通知）
+-- ⛔ rpc_mark_orders_shipping_for_wave 會改訂單狀態為 shipping，不可假成功
 CREATE OR REPLACE FUNCTION public.rpc_mark_orders_shipping_for_wave(
   p_wave_id BIGINT, p_operator UUID
-) RETURNS VOID LANGUAGE plpgsql AS $$ BEGIN NULL; END; $$;
+) RETURNS VOID LANGUAGE plpgsql AS $$ BEGIN
+  RAISE EXCEPTION 'fixture 未實作 rpc_mark_orders_shipping_for_wave — 會動訂單狀態';
+END; $$;
 
 -- ⛔ 會動庫存/訂單/帳的 helper — RAISE 讓測試 fail，不假成功
 CREATE OR REPLACE FUNCTION public._settle_arrived_backorders(
@@ -806,7 +802,7 @@ async function main() {
     }
 
     // 2g. --with-core: load HQ return disposition migrations (明確檔名)
-    if (WITH_CORE) {
+    if (WITH_CORE && !WITH_ALL) {
       const coreFiles = [
         '20260907010000_hq_return_disposition_core.sql',      // A: 資料與處理
         '20260907020000_hq_return_disposition_sources.sql',   // B: 來源函式
@@ -821,6 +817,43 @@ async function main() {
         const coreSql = fs.readFileSync(cfPath, 'utf8');
         await client.query(coreSql);
         console.log(`    ✓ Core migration applied`);
+      }
+    }
+
+    // 2g'. --with-all: A + B + C + F（缺檔即 fail）
+    if (WITH_ALL) {
+      // F 依賴 v_picking_demand_no_po — 先從真 migration 載入
+      const allPrereqs = [
+        { file: '20260612000030_v_picking_demand_no_po.sql', desc: 'v_picking_demand_no_po (F prerequisite)' },
+      ];
+      for (const pr of allPrereqs) {
+        const prPath = path.join(MIGRATIONS_DIR, pr.file);
+        if (!fs.existsSync(prPath)) {
+          console.error(`  ✗ --with-all prerequisite: ${pr.file} not found`);
+          process.exit(1);
+        }
+        console.log(`  Loading prerequisite: ${pr.desc}`);
+        const prSql = fs.readFileSync(prPath, 'utf8');
+        await client.query(prSql);
+        console.log(`    ✓ Prerequisite applied`);
+      }
+
+      const allFiles = [
+        '20260907010000_hq_return_disposition_core.sql',        // A
+        '20260907020000_hq_return_disposition_sources.sql',     // B
+        '20260907030000_hq_return_disposition_reversals.sql',   // C
+        '20260907040000_hq_return_disposition_available.sql',   // F
+      ];
+      for (const af of allFiles) {
+        const afPath = path.join(MIGRATIONS_DIR, af);
+        if (!fs.existsSync(afPath)) {
+          console.error(`  ✗ --with-all: ${af} not found. Has it been generated?`);
+          process.exit(1);
+        }
+        console.log(`  Loading migration: ${af}`);
+        const allSql = fs.readFileSync(afPath, 'utf8');
+        await client.query(allSql);
+        console.log(`    ✓ Migration applied`);
       }
     }
 

--- a/tests/return-disposition/fixture.cjs
+++ b/tests/return-disposition/fixture.cjs
@@ -238,6 +238,90 @@ async function extractSchemaStatements(filePath) {
   return results;
 }
 
+// --with-all 的月結前置只准從指定 migration 挑出指定 AST statement。
+// 每個 selector 必須剛好命中一筆；找不到或重複都 fail，避免誤載同檔舊版財務 RPC。
+async function extractSelectedStatements(filePath, selectors) {
+  const sql = fs.readFileSync(filePath, 'utf8');
+  const buf = Buffer.from(sql, 'utf8');
+  const PgQuery = await newParser();
+  const res = PgQuery.parse(sql);
+  if (res.error) {
+    throw new Error(`Parse error in ${filePath}: ${res.error.message}`);
+  }
+  const stmts = (res.parse_tree?.stmts ?? []).map((s) => ({
+    nodeType: stmtNodeType(s),
+    name: getObjectName(s),
+    text: sliceStmt(buf, s.stmt_location, s.stmt_len).trim(),
+  }));
+
+  return selectors.map((selector) => {
+    const matches = stmts.filter((stmt) =>
+      stmt.nodeType === selector.nodeType
+      && (!selector.name || stmt.name?.toLowerCase() === selector.name.toLowerCase())
+      && (!selector.match || selector.match.test(stmt.text))
+    );
+    if (matches.length !== 1) {
+      throw new Error(
+        `Expected exactly one ${selector.desc} in ${path.basename(filePath)}, found ${matches.length}`,
+      );
+    }
+    return matches[0];
+  });
+}
+
+const SETTLEMENT_PREREQ_SOURCES = [
+  {
+    file: '20260512000012_settlement_air_transfer_adjustment.sql',
+    desc: 'settlement items entry_type 基底欄位',
+    selectors: [
+      { nodeType: 'AlterTableStmt', match: /ADD COLUMN IF NOT EXISTS entry_type\s+TEXT NOT NULL DEFAULT 'hq_inbound'/i, desc: 'entry_type column DDL' },
+    ],
+  },
+  {
+    file: '20260512000013_settlement_items_trigger_allow_draft.sql',
+    desc: 'draft 月結明細可重建 trigger',
+    selectors: [
+      { nodeType: 'DropStmt', match: /DROP TRIGGER IF EXISTS trg_no_mut_smsi/i, desc: 'old immutable trigger drop' },
+      { nodeType: 'CreateFunctionStmt', name: 'forbid_smsi_mutation_when_locked', desc: 'draft-aware item mutation function' },
+      { nodeType: 'CreateTrigStmt', match: /CREATE TRIGGER trg_smsi_immutable_when_locked/i, desc: 'draft-aware item mutation trigger' },
+    ],
+  },
+  {
+    file: '20260714000100_settlement_free_transfer_and_return.sql',
+    desc: '六種月結明細類型與描述欄',
+    selectors: [
+      { nodeType: 'AlterTableStmt', match: /DROP CONSTRAINT IF EXISTS store_monthly_settlement_items_entry_type_check/i, desc: 'old entry_type check drop' },
+      { nodeType: 'AlterTableStmt', match: /DROP CONSTRAINT IF EXISTS smsi_entry_type_check_v2/i, desc: 'v2 entry_type check drop' },
+      { nodeType: 'AlterTableStmt', match: /ADD CONSTRAINT smsi_entry_type_check_v2[\s\S]*'return_out'/i, desc: 'six-way entry_type check' },
+      { nodeType: 'AlterTableStmt', match: /ADD COLUMN IF NOT EXISTS description TEXT/i, desc: 'settlement item description column' },
+    ],
+  },
+  {
+    file: '20260715000000_settlement_dual_price_basis.sql',
+    desc: '月結雙口徑欄位與分店價 helper',
+    selectors: [
+      { nodeType: 'AlterTableStmt', match: /ADD COLUMN IF NOT EXISTS cost_amount[\s\S]*ADD COLUMN IF NOT EXISTS branch_amount/i, desc: 'settlement dual total columns' },
+      { nodeType: 'AlterTableStmt', match: /ADD COLUMN IF NOT EXISTS unit_branch_price[\s\S]*ADD COLUMN IF NOT EXISTS branch_amount/i, desc: 'settlement item branch columns' },
+      { nodeType: 'CreateFunctionStmt', name: '_branch_price_at', desc: '_branch_price_at function' },
+    ],
+  },
+  {
+    file: '20260801000000_settlement_manual_adjustment.sql',
+    desc: '人工調整總額欄與真資料表',
+    selectors: [
+      { nodeType: 'AlterTableStmt', match: /ADD COLUMN IF NOT EXISTS adjustment_amount/i, desc: 'settlement adjustment total column' },
+      { nodeType: 'CreateStmt', match: /CREATE TABLE IF NOT EXISTS public\.store_settlement_adjustments/i, desc: 'store_settlement_adjustments table' },
+    ],
+  },
+  {
+    file: '20260825030000_settlement_ship_time_matching.sql',
+    desc: '店間轉貨真記帳 view',
+    selectors: [
+      { nodeType: 'ViewStmt', name: 'v_store_aid_transfer_legs', desc: 'v_store_aid_transfer_legs view' },
+    ],
+  },
+];
+
 // ============================================================
 // Auth stub SQL — sub 缺值回 NULL，不冒充全零 user
 // ============================================================
@@ -393,10 +477,10 @@ CREATE TABLE IF NOT EXISTS tenants (
 
 // ============================================================
 // Helper stubs：被函式引用但本測不需要真實邏輯的 helpers
-// 分三類：
+// 分兩類：
 //   ✅ 可 no-op（通知類、配單查詢類）
 //   ⛔ RAISE（會動庫存/訂單/帳，不可假成功）
-//   🔧 真實輕量（trim_scale 等）
+// trim_scale 是本機 PostgreSQL 18 內建函式，不由 fixture stub。
 // ============================================================
 const HELPER_STUBS_SQL = `
 -- sequences referenced by real functions
@@ -652,6 +736,26 @@ const COLUMN_ADDITIONS = [
   { sql: "ALTER TABLE picking_waves ADD COLUMN IF NOT EXISTS source_po_id BIGINT" },
   // picking_waves.source_restock_request_id
   { sql: "ALTER TABLE picking_waves ADD COLUMN IF NOT EXISTS source_restock_request_id BIGINT" },
+  // customer_orders.order_kind 型別/default 原樣取自 20260516000000，CHECK 取最新 20260612000020
+  { sql: `ALTER TABLE customer_orders
+    ADD COLUMN IF NOT EXISTS order_kind TEXT NOT NULL DEFAULT 'normal'
+      CHECK (order_kind IN ('normal', 'offset'))` },
+  { sql: "ALTER TABLE public.customer_orders DROP CONSTRAINT IF EXISTS customer_orders_order_kind_check" },
+  { sql: `ALTER TABLE public.customer_orders ADD CONSTRAINT customer_orders_order_kind_check
+    CHECK (order_kind = ANY (ARRAY['normal'::text, 'offset'::text, 'restock'::text]))` },
+  // approved_transfer 走 wave 時 linked_transfer_id 可為 NULL；原樣取自 20260612000060
+  { sql: "ALTER TABLE public.restock_requests DROP CONSTRAINT IF EXISTS restock_requests_check" },
+  { sql: `ALTER TABLE public.restock_requests
+    ADD CONSTRAINT restock_requests_check CHECK (
+      (status <> 'approved_pr' OR linked_pr_id IS NOT NULL) AND
+      (status <> 'rejected'    OR rejected_reason IS NOT NULL)
+    )` },
+  // 月結狀態最新 CHECK；原樣取自 20260715000120
+  { sql: "ALTER TABLE public.store_monthly_settlements DROP CONSTRAINT IF EXISTS store_monthly_settlements_status_check" },
+  { sql: "ALTER TABLE public.store_monthly_settlements DROP CONSTRAINT IF EXISTS sms_status_check_v2" },
+  { sql: `ALTER TABLE public.store_monthly_settlements
+    ADD CONSTRAINT sms_status_check_v2
+      CHECK (status IN ('draft','sent','disputed','confirmed','remitted','settled','cancelled'))` },
   // restock_request_lines.cancelled_at (referenced by rpc_receive_transfer D2 logic)
   { sql: "ALTER TABLE restock_request_lines ADD COLUMN IF NOT EXISTS cancelled_at TIMESTAMPTZ" },
   // customer_orders extra columns
@@ -822,9 +926,14 @@ async function main() {
 
     // 2g'. --with-all: A + B + C + F（缺檔即 fail）
     if (WITH_ALL) {
-      // F 依賴 v_picking_demand_no_po — 先從真 migration 載入
+      // F 依賴 v_picking_demand_no_po：只從 F 前的現行定義用 AST 抽 view，
+      // 不整支載入 040，避免它把 FUNCTION_SOURCES 載入的新版補貨 RPC 蓋回舊版。
       const allPrereqs = [
-        { file: '20260612000030_v_picking_demand_no_po.sql', desc: 'v_picking_demand_no_po (F prerequisite)' },
+        {
+          file: '20260612000040_approve_restock_via_picking_workstation.sql',
+          desc: 'v_picking_demand_no_po (F prerequisite view only)',
+          views: ['v_picking_demand_no_po'],
+        },
       ];
       for (const pr of allPrereqs) {
         const prPath = path.join(MIGRATIONS_DIR, pr.file);
@@ -833,9 +942,33 @@ async function main() {
           process.exit(1);
         }
         console.log(`  Loading prerequisite: ${pr.desc}`);
-        const prSql = fs.readFileSync(prPath, 'utf8');
-        await client.query(prSql);
-        console.log(`    ✓ Prerequisite applied`);
+        const extracted = await extractStatements(prPath, [], { alsoViews: pr.views });
+        const foundNames = new Set(extracted.map(item => item.name.toLowerCase()));
+        const missing = pr.views.filter(name => !foundNames.has(name.toLowerCase()));
+        if (missing.length > 0) {
+          console.error(`    ✗ Missing prerequisite views in ${pr.file}: ${missing.join(', ')}`);
+          process.exit(1);
+        }
+        for (const item of extracted) {
+          await client.query(item.sql);
+          console.log(`    ✓ ${item.type}: ${item.name}`);
+        }
+      }
+
+      // C 會載入「真月結產生器函式體 + 同月同步鎖」。在 C 之前只補該函式
+      // 完整跑兩次所需的真 schema/helper/view，不載任何來源檔裡的舊 generator。
+      for (const prereq of SETTLEMENT_PREREQ_SOURCES) {
+        const prereqPath = path.join(MIGRATIONS_DIR, prereq.file);
+        if (!fs.existsSync(prereqPath)) {
+          console.error(`  ✗ --with-all settlement prerequisite: ${prereq.file} not found`);
+          process.exit(1);
+        }
+        console.log(`  Loading settlement prerequisite: ${prereq.desc}`);
+        const selected = await extractSelectedStatements(prereqPath, prereq.selectors);
+        for (const item of selected) {
+          await client.query(item.text);
+          console.log(`    ✓ ${item.nodeType}: ${item.name ?? prereq.desc}`);
+        }
       }
 
       const allFiles = [

--- a/tests/return-disposition/fixture.cjs
+++ b/tests/return-disposition/fixture.cjs
@@ -1,0 +1,849 @@
+// tests/return-disposition/fixture.cjs
+// 本機 PG18 fixture 載入器 — 總倉退回貨處理整合測試
+// 硬鎖連線：127.0.0.1:56427 / returnlocal
+// ⛔ 不讀 .env、不讀 DATABASE_URL、不連外部服務
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { Client } = require('pg');
+
+// ============================================================
+// 連線設定（硬鎖）
+// ============================================================
+const PG_HOST = '127.0.0.1';
+const PG_PORT = 56427;
+const PG_USER = 'returnlocal';
+const PG_ADMIN_DB = 'postgres';
+
+// ============================================================
+// DB 名稱
+// ============================================================
+const DB_NAME_PATTERN = /^return_disposition_test_[a-z0-9_]+$/;
+
+function getDbName() {
+  const idx = process.argv.indexOf('--db-name');
+  if (idx !== -1 && process.argv[idx + 1]) {
+    const name = process.argv[idx + 1];
+    if (!DB_NAME_PATTERN.test(name)) {
+      console.error(`DB name must match ${DB_NAME_PATTERN}: got "${name}"`);
+      process.exit(1);
+    }
+    return name;
+  }
+  const ts = new Date().toISOString().replace(/[-:T]/g, '').replace(/\..+/, '').toLowerCase();
+  return `return_disposition_test_${ts}`;
+}
+
+const WITH_CORE = process.argv.includes('--with-core');
+
+// ============================================================
+// Migration 根目錄
+// ============================================================
+const MIGRATIONS_DIR = path.resolve(__dirname, '../../supabase/migrations');
+
+// ============================================================
+// 來源表：每個函式/觸發器從哪個 migration 檔案取
+// key = 描述, value = { file, objects: [要取的 CREATE FUNCTION/TRIGGER 名稱] }
+// ============================================================
+const FUNCTION_SOURCES = [
+  // --- 基底 helpers ---
+  { file: '20260422120001_product_schema.sql',
+    desc: 'product schema: touch_updated_at, forbid_sku_delete',
+    pick: ['touch_updated_at', 'forbid_sku_delete'] },
+  { file: '20260422120003_inventory_schema.sql',
+    desc: 'inventory trigger/functions: apply_movement_to_balance, forbid_movement_mutation, rpc_inbound',
+    pick: ['apply_movement_to_balance', 'forbid_movement_mutation', 'rpc_inbound'] },
+  { file: '20260423120000_stores_order_schema.sql',
+    desc: 'forbid_append_only_mutation',
+    pick: ['forbid_append_only_mutation'] },
+  // --- rpc_outbound 最新版（10 參數） ---
+  { file: '20260705000000_dispatch_price_guard.sql',
+    desc: 'rpc_outbound 10-param + _missing_dispatch_prices + _current_cost_price',
+    pick: ['_missing_dispatch_prices', '_current_cost_price', 'rpc_outbound'],
+    dropBefore: ['rpc_outbound(UUID, BIGINT, BIGINT, NUMERIC, TEXT, TEXT, BIGINT, UUID, BOOLEAN)'] },
+  // --- rpc_create_store_return ---
+  { file: '20260904020000_store_return_create_no_stock.sql',
+    desc: 'rpc_create_store_return + v_store_pending_returns view',
+    pick: ['rpc_create_store_return'],
+    alsoViews: ['v_store_pending_returns'] },
+  // --- rpc_receive_transfer ---
+  { file: '20260904020010_accept_store_return_deducts_stock.sql',
+    desc: 'rpc_receive_transfer (乙案：同意才扣)',
+    pick: ['rpc_receive_transfer'] },
+  // --- rpc_reject_transfer ---
+  { file: '20260904020020_reject_store_return_no_phantom_stock.sql',
+    desc: 'rpc_reject_transfer (不同意零庫存)',
+    pick: ['rpc_reject_transfer'] },
+  // --- shortage resolution + undo ---
+  { file: '20260903000200_shortage_resolution_undo.sql',
+    desc: 'rpc_resolve_transfer_item_shortage v6 + rpc_undo_transfer_item_shortage',
+    pick: ['rpc_resolve_transfer_item_shortage', 'rpc_undo_transfer_item_shortage'] },
+  // --- rpc_adjust_received_transfer 最新版（會連動庫存） ---
+  { file: '20260904010000_adjust_received_syncs_stock.sql',
+    desc: 'rpc_adjust_received_transfer v3 (庫存連動版)',
+    pick: ['rpc_adjust_received_transfer'] },
+  // --- unreceive ---
+  { file: '20260903000010_unreceive_reverse_inbound_regardless_of_qty.sql',
+    desc: 'rpc_unreceive_transfer',
+    pick: ['rpc_unreceive_transfer'] },
+  // --- auto accept ---
+  { file: '20260903010020_return_to_hq_auto_accept.sql',
+    desc: 'rpc_auto_accept_overdue_returns',
+    pick: ['rpc_auto_accept_overdue_returns'] },
+  // --- wave from restock ---
+  { file: '20260715000020_restock_dispatch_dedup_guards.sql',
+    desc: 'rpc_create_wave_from_restock',
+    pick: ['rpc_create_wave_from_restock'] },
+  // --- 安全 helpers（真實定義） ---
+  { file: '20260707000070_jwt_store_scope_helpers_and_stock_rls.sql',
+    desc: '_jwt_store_ids + _jwt_store_location_ids (真實定義)',
+    pick: ['_jwt_store_ids', '_jwt_store_location_ids'] },
+  { file: '20260831000000_store_self_campaign_schema.sql',
+    desc: '_is_branch_scoped_user (真實定義)',
+    pick: ['_is_branch_scoped_user'] },
+  // --- rpc_inbound 最新版（虛擬商品守衛） ---
+  { file: '20260903000100_virtual_sku_never_enters_stock_or_pool.sql',
+    desc: 'rpc_inbound latest (虛擬商品守衛)',
+    pick: ['rpc_inbound'] },
+];
+
+// ============================================================
+// pg-query-emscripten helpers
+// ============================================================
+const newParser = () => require('pg-query-emscripten').default();
+
+/** Byte-offset slice (migration 裡有中文，String.slice 會偏移) */
+function sliceStmt(buf, loc, len) {
+  const from = loc ?? 0;
+  // stmt_len === 0 在 protobuf 代表「到結尾」
+  if (!len) return buf.slice(from).toString('utf8');
+  return buf.slice(from, from + len).toString('utf8');
+}
+
+/** 取 AST 節點型別 — s.stmt 是 { CreateStmt: {...} } 這種結構 */
+function stmtNodeType(s) {
+  if (!s || !s.stmt) return null;
+  const keys = Object.keys(s.stmt);
+  return keys.length > 0 ? keys[0] : null;
+}
+
+/** 從 AST 節點提取物件名稱（function / view） */
+function getObjectName(s) {
+  const node = s?.stmt;
+  if (!node) return null;
+  const typ = stmtNodeType(s);
+  if (typ === 'CreateFunctionStmt') {
+    const parts = node.CreateFunctionStmt?.funcname ?? [];
+    // funcname 是 [{String: {sval: 'public'}}, {String: {sval: 'fn_name'}}] 結構
+    const last = parts[parts.length - 1];
+    return last?.String?.sval ?? last?.String?.str ?? null;
+  }
+  if (typ === 'ViewStmt') {
+    const rel = node.ViewStmt?.view;
+    return rel?.relname ?? null;
+  }
+  return null;
+}
+
+// ============================================================
+// 從 migration 檔以 pg-query-emscripten AST 拆出指定物件的 SQL
+// ============================================================
+async function extractStatements(filePath, pickNames, opts = {}) {
+  const sql = fs.readFileSync(filePath, 'utf8');
+  const buf = Buffer.from(sql, 'utf8');
+  const PgQuery = await newParser();
+  const res = PgQuery.parse(sql);
+  if (res.error) {
+    throw new Error(`Parse error in ${filePath}: ${res.error.message}`);
+  }
+  const stmts = res.parse_tree?.stmts ?? [];
+
+  const results = [];
+  const pickSet = new Set(pickNames.map(n => n.toLowerCase()));
+  const viewSet = opts.alsoViews ? new Set(opts.alsoViews.map(n => n.toLowerCase())) : new Set();
+
+  for (const s of stmts) {
+    const text = sliceStmt(buf, s.stmt_location, s.stmt_len).trim();
+    const typ = stmtNodeType(s);
+    const name = getObjectName(s);
+
+    if (typ === 'CreateFunctionStmt' && name && pickSet.has(name.toLowerCase())) {
+      results.push({ type: 'function', name, sql: text });
+    } else if (typ === 'ViewStmt' && name && viewSet.has(name.toLowerCase())) {
+      results.push({ type: 'view', name, sql: text });
+    }
+  }
+  return results;
+}
+
+// ============================================================
+// 從 migration 檔萃取 schema DDL（CREATE TABLE/INDEX/TRIGGER/SEQUENCE/ALTER TABLE + FUNCTION）
+// 用 AST 節點型別判定，不用 regex
+// ============================================================
+const SCHEMA_NODE_TYPES = new Set([
+  'CreateStmt',         // CREATE TABLE
+  'IndexStmt',          // CREATE INDEX / CREATE UNIQUE INDEX
+  'CreateTrigStmt',     // CREATE TRIGGER
+  'CreateSeqStmt',      // CREATE SEQUENCE
+  'AlterTableStmt',     // ALTER TABLE (ADD COLUMN / ADD CONSTRAINT / DROP CONSTRAINT)
+  'CreateFunctionStmt', // CREATE [OR REPLACE] FUNCTION
+  'CommentStmt',        // COMMENT ON (跳過 — 非必要)
+]);
+
+// RLS / POLICY / GRANT / REVOKE 節點型別
+const SKIP_NODE_TYPES = new Set([
+  'CreatePolicyStmt',       // CREATE POLICY
+  'GrantStmt',              // GRANT / REVOKE
+  'AlterDefaultPrivilegesStmt',
+]);
+
+function isRlsAlter(s, text) {
+  // ALTER TABLE ... ENABLE ROW LEVEL SECURITY 也是 AlterTableStmt，要跳過
+  if (stmtNodeType(s) === 'AlterTableStmt' && /ENABLE\s+ROW\s+LEVEL\s+SECURITY/i.test(text)) return true;
+  return false;
+}
+
+async function extractSchemaStatements(filePath) {
+  const sql = fs.readFileSync(filePath, 'utf8');
+  const buf = Buffer.from(sql, 'utf8');
+  const PgQuery = await newParser();
+  const res = PgQuery.parse(sql);
+  if (res.error) {
+    throw new Error(`Parse error in ${filePath}: ${res.error.message}`);
+  }
+  const stmts = res.parse_tree?.stmts ?? [];
+  const results = [];
+  for (const s of stmts) {
+    const text = sliceStmt(buf, s.stmt_location, s.stmt_len).trim();
+    const typ = stmtNodeType(s);
+    if (!text) continue;
+    if (SKIP_NODE_TYPES.has(typ)) continue;
+    if (isRlsAlter(s, text)) continue;
+    // COMMENT ON FUNCTION 會找不到函式（函式還沒建）—— 非必要，跳過
+    if (typ === 'CommentStmt') continue;
+    if (SCHEMA_NODE_TYPES.has(typ)) {
+      results.push({ text, nodeType: typ });
+    }
+  }
+  return results;
+}
+
+// ============================================================
+// Auth stub SQL — sub 缺值回 NULL，不冒充全零 user
+// ============================================================
+const AUTH_STUB_SQL = `
+-- Stub auth schema for local testing
+CREATE SCHEMA IF NOT EXISTS auth;
+
+-- Session variables to simulate auth.uid() and auth.jwt()
+-- Usage: SET LOCAL "request.jwt.claim.sub" = '<uuid>';
+--        SET LOCAL "request.jwt.claims" = '<json>';
+
+CREATE OR REPLACE FUNCTION auth.uid()
+RETURNS UUID
+LANGUAGE sql STABLE
+AS $$
+  SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::UUID
+$$;
+
+CREATE OR REPLACE FUNCTION auth.jwt()
+RETURNS JSONB
+LANGUAGE sql STABLE
+AS $$
+  SELECT COALESCE(
+    NULLIF(current_setting('request.jwt.claims', true), '')::JSONB,
+    '{}'::JSONB
+  )
+$$;
+
+-- Minimal auth.users stub (FK target only)
+CREATE TABLE IF NOT EXISTS auth.users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  raw_app_meta_data JSONB DEFAULT '{}'::JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Roles for RLS testing
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    CREATE ROLE authenticated NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    CREATE ROLE anon NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    CREATE ROLE service_role NOLOGIN;
+  END IF;
+END $$;
+GRANT USAGE ON SCHEMA auth   TO authenticated, anon, service_role;
+GRANT USAGE ON SCHEMA public TO authenticated, anon, service_role;
+`;
+
+// ============================================================
+// FK-stub 表（被函式 FK 參照但本測不關心的表，只建最小 DDL）
+// ============================================================
+const FK_STUB_SQL = `
+-- FK stub tables: minimal DDL for tables referenced by FK but not under test
+
+CREATE TABLE IF NOT EXISTS suppliers (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id UUID NOT NULL,
+  code TEXT,
+  name TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS members (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id UUID,
+  name TEXT,
+  phone TEXT,
+  email TEXT,
+  birthday DATE,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS purchase_orders (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id UUID,
+  po_no TEXT,
+  status TEXT DEFAULT 'draft',
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS purchase_requests (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id UUID,
+  status TEXT DEFAULT 'draft',
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS purchase_request_items (
+  id BIGSERIAL PRIMARY KEY,
+  pr_id BIGINT REFERENCES purchase_requests(id),
+  po_item_id BIGINT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS purchase_order_items (
+  id BIGSERIAL PRIMARY KEY,
+  po_id BIGINT REFERENCES purchase_orders(id),
+  sku_id BIGINT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS vendor_bills (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id UUID,
+  bill_no TEXT,
+  supplier_id BIGINT,
+  source_type TEXT CHECK (source_type = ANY(ARRAY[
+    'purchase_order','goods_receipt','transfer_settlement',
+    'store_monthly_settlement','xiaolan_import','manual'
+  ])),
+  source_id BIGINT,
+  bill_date DATE,
+  due_date DATE,
+  amount NUMERIC(18,4),
+  status TEXT DEFAULT 'pending',
+  currency TEXT DEFAULT 'TWD',
+  notes TEXT,
+  created_by UUID,
+  updated_by UUID,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS vendor_payments (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id UUID,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS pos_sales (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id UUID,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- tenants 表（_current_tenant_id 真版需要）
+CREATE TABLE IF NOT EXISTS tenants (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL DEFAULT 'test',
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('trial','active','suspended','deleted')),
+  is_protected BOOLEAN NOT NULL DEFAULT FALSE,
+  trial_started_at TIMESTAMPTZ,
+  trial_expires_at TIMESTAMPTZ,
+  contact_email TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  purged_at TIMESTAMPTZ
+);
+`;
+
+// ============================================================
+// Helper stubs：被函式引用但本測不需要真實邏輯的 helpers
+// 分三類：
+//   ✅ 可 no-op（通知類、配單查詢類）
+//   ⛔ RAISE（會動庫存/訂單/帳，不可假成功）
+//   🔧 真實輕量（trim_scale 等）
+// ============================================================
+const HELPER_STUBS_SQL = `
+-- _next_transfer_no: real logic (lightweight, no external deps)
+CREATE SEQUENCE IF NOT EXISTS transfer_no_seq;
+CREATE OR REPLACE FUNCTION public._next_transfer_no()
+RETURNS TEXT
+LANGUAGE plpgsql AS $$
+BEGIN
+  RETURN 'TR' || to_char(NOW(), 'YYMMDD') || lpad(nextval('transfer_no_seq')::TEXT, 4, '0');
+END;
+$$;
+
+-- picking_wave_code_seq
+CREATE SEQUENCE IF NOT EXISTS public.picking_wave_code_seq;
+
+-- trim_scale: 真實輕量 helper
+CREATE OR REPLACE FUNCTION public.trim_scale(p NUMERIC)
+RETURNS TEXT LANGUAGE sql IMMUTABLE AS $$
+  SELECT regexp_replace(p::TEXT, '\\.?0+$', '')
+$$;
+
+-- ensure_store_supplier: 真實邏輯太簡單可 stub
+CREATE OR REPLACE FUNCTION public.ensure_store_supplier(p_store_id BIGINT)
+RETURNS BIGINT LANGUAGE plpgsql AS $$ BEGIN RETURN 1; END; $$;
+
+-- ✅ 通知類 no-op（不動資料，只是通知/查詢）
+CREATE OR REPLACE FUNCTION public.is_order_pickup_ready(p_order_id BIGINT)
+RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+BEGIN RETURN FALSE; END; $$;
+
+CREATE OR REPLACE FUNCTION public._restock_wave_progress(p_rr_id BIGINT)
+RETURNS TABLE(fully_dispatched BOOLEAN, all_arrived BOOLEAN)
+LANGUAGE plpgsql AS $$ BEGIN
+  RETURN QUERY SELECT FALSE, FALSE;
+END; $$;
+
+-- ✅ 配單通知類 no-op（rpc_mark_orders_shipping_for_wave 只推通知）
+CREATE OR REPLACE FUNCTION public.rpc_mark_orders_shipping_for_wave(
+  p_wave_id BIGINT, p_operator UUID
+) RETURNS VOID LANGUAGE plpgsql AS $$ BEGIN NULL; END; $$;
+
+-- ⛔ 會動庫存/訂單/帳的 helper — RAISE 讓測試 fail，不假成功
+CREATE OR REPLACE FUNCTION public._settle_arrived_backorders(
+  p_store_id BIGINT, p_skus BIGINT[], p_operator UUID, p_now TIMESTAMPTZ
+) RETURNS INTEGER LANGUAGE plpgsql AS $$ BEGIN
+  RAISE EXCEPTION 'fixture 未實作 _settle_arrived_backorders — 需要時請載入真實定義';
+END; $$;
+
+CREATE OR REPLACE FUNCTION public._advance_arrived_confirmed_orders(
+  p_store_id BIGINT, p_skus BIGINT[], p_operator UUID, p_now TIMESTAMPTZ
+) RETURNS INTEGER LANGUAGE plpgsql AS $$ BEGIN
+  RAISE EXCEPTION 'fixture 未實作 _advance_arrived_confirmed_orders — 需要時請載入真實定義';
+END; $$;
+
+CREATE OR REPLACE FUNCTION public._settle_restock_ride_along(
+  p_rr_id BIGINT, p_operator UUID, p_now TIMESTAMPTZ
+) RETURNS VOID LANGUAGE plpgsql AS $$ BEGIN
+  RAISE EXCEPTION 'fixture 未實作 _settle_restock_ride_along — 需要時請載入真實定義';
+END; $$;
+
+CREATE OR REPLACE FUNCTION public._grow_internal_pool(
+  p_store BIGINT, p_sku BIGINT, p_received NUMERIC,
+  p_operator UUID, p_now TIMESTAMPTZ, p_note TEXT
+) RETURNS NUMERIC LANGUAGE plpgsql AS $$ BEGIN
+  RAISE EXCEPTION 'fixture 未實作 _grow_internal_pool — 需要時請載入真實定義';
+END; $$;
+`;
+
+// ============================================================
+// Fixture 假資料
+// ============================================================
+const FIXTURE_DATA_SQL = `
+-- ============================================================
+-- Fixture data: minimal set for return-disposition testing
+-- ============================================================
+
+-- 設定 auth session（假 JWT）
+SET LOCAL "request.jwt.claims" = '{"tenant_id":"11111111-1111-1111-1111-111111111111","role":"owner","app_metadata":{"role":"owner"}}';
+SET LOCAL "request.jwt.claim.sub" = '22222222-2222-2222-2222-222222222222';
+
+-- Tenant
+INSERT INTO tenants (id, name, status) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'test-tenant', 'active');
+
+-- Auth user
+INSERT INTO auth.users (id, raw_app_meta_data) VALUES
+  ('22222222-2222-2222-2222-222222222222', '{"tenant_id":"11111111-1111-1111-1111-111111111111","role":"owner"}');
+
+-- Products (is_virtual 欄位在 column additions 加)
+INSERT INTO products (id, tenant_id, product_code, name, status) VALUES
+  (1, '11111111-1111-1111-1111-111111111111', 'P-GOOD', '一般商品', 'active'),
+  (2, '11111111-1111-1111-1111-111111111111', 'P-OTHER', '另一商品', 'active'),
+  (3, '11111111-1111-1111-1111-111111111111', 'P-VIRTUAL', '虛擬商品', 'active');
+SELECT setval('products_id_seq', 3);
+
+UPDATE products SET is_virtual = TRUE WHERE id = 3;
+
+-- SKUs (product_name 是 denormalized 欄位)
+INSERT INTO skus (id, tenant_id, product_id, sku_code, product_name, status) VALUES
+  (101, '11111111-1111-1111-1111-111111111111', 1, 'SKU-GOOD', '一般商品', 'active'),
+  (102, '11111111-1111-1111-1111-111111111111', 2, 'SKU-OTHER', '另一商品', 'active'),
+  (103, '11111111-1111-1111-1111-111111111111', 3, 'MISC-01', '虛擬商品', 'active');
+SELECT setval('skus_id_seq', 103);
+
+-- Locations: HQ + 2 stores
+INSERT INTO locations (id, tenant_id, code, name, type) VALUES
+  (10, '11111111-1111-1111-1111-111111111111', 'HQ', '總倉', 'central_warehouse'),
+  (20, '11111111-1111-1111-1111-111111111111', 'STORE-A', 'A店', 'store'),
+  (30, '11111111-1111-1111-1111-111111111111', 'STORE-B', 'B店', 'store');
+SELECT setval('locations_id_seq', 30);
+
+-- Suppliers stub
+INSERT INTO suppliers (id, tenant_id, code, name) VALUES
+  (1, '11111111-1111-1111-1111-111111111111', 'SUP-SELF', '自家供應商');
+SELECT setval('suppliers_id_seq', 1);
+
+-- Stores: A, B
+INSERT INTO stores (id, tenant_id, code, name, location_id, supplier_id) VALUES
+  (1, '11111111-1111-1111-1111-111111111111', 'A', 'A店', 20, 1),
+  (2, '11111111-1111-1111-1111-111111111111', 'B', 'B店', 30, 1);
+SELECT setval('stores_id_seq', 2);
+
+-- Prices: cost + branch for SKU-GOOD (避免 dispatch price guard 擋)
+INSERT INTO prices (tenant_id, sku_id, scope, scope_id, price, created_by) VALUES
+  ('11111111-1111-1111-1111-111111111111', 101, 'cost', NULL, 100.0000, '22222222-2222-2222-2222-222222222222'),
+  ('11111111-1111-1111-1111-111111111111', 101, 'branch', NULL, 150.0000, '22222222-2222-2222-2222-222222222222'),
+  ('11111111-1111-1111-1111-111111111111', 102, 'cost', NULL, 80.0000, '22222222-2222-2222-2222-222222222222'),
+  ('11111111-1111-1111-1111-111111111111', 102, 'branch', NULL, 120.0000, '22222222-2222-2222-2222-222222222222');
+
+-- HQ stock_balances: 用 rpc_inbound 建立，讓 trigger 正確維護
+SELECT rpc_inbound(
+  '11111111-1111-1111-1111-111111111111', 10, 101, 20, 100.0000,
+  'purchase_receipt', 'fixture', NULL, '22222222-2222-2222-2222-222222222222'
+);
+SELECT rpc_inbound(
+  '11111111-1111-1111-1111-111111111111', 10, 102, 10, 80.0000,
+  'purchase_receipt', 'fixture', NULL, '22222222-2222-2222-2222-222222222222'
+);
+SELECT rpc_inbound(
+  '11111111-1111-1111-1111-111111111111', 20, 101, 10, 100.0000,
+  'purchase_receipt', 'fixture', NULL, '22222222-2222-2222-2222-222222222222'
+);
+SELECT rpc_inbound(
+  '11111111-1111-1111-1111-111111111111', 30, 101, 5, 100.0000,
+  'purchase_receipt', 'fixture', NULL, '22222222-2222-2222-2222-222222222222'
+);
+
+-- 一筆已收但短收的 hq_to_store transfer（測 shortage resolution）
+INSERT INTO transfers (id, tenant_id, transfer_no, source_location, dest_location,
+  status, transfer_type, shipped_by, shipped_at, received_by, received_at,
+  created_by, updated_by) VALUES
+  (900, '11111111-1111-1111-1111-111111111111', 'WAVE-TEST-S1', 10, 20,
+   'received', 'hq_to_store', '22222222-2222-2222-2222-222222222222', NOW() - INTERVAL '3 days',
+   '22222222-2222-2222-2222-222222222222', NOW() - INTERVAL '2 days',
+   '22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222');
+SELECT setval('transfers_id_seq', 900);
+
+-- 出庫異動（給 transfer_items.out_movement_id 參照）
+INSERT INTO stock_movements (id, tenant_id, location_id, sku_id, quantity, unit_cost,
+  movement_type, source_doc_type, source_doc_id, operator_id) VALUES
+  (8000, '11111111-1111-1111-1111-111111111111', 10, 101, -5, 100.0000,
+   'transfer_out', 'transfer', 900, '22222222-2222-2222-2222-222222222222');
+-- 入庫異動
+INSERT INTO stock_movements (id, tenant_id, location_id, sku_id, quantity, unit_cost,
+  movement_type, source_doc_type, source_doc_id, operator_id) VALUES
+  (8001, '11111111-1111-1111-1111-111111111111', 20, 101, 3, 100.0000,
+   'transfer_in', 'transfer', 900, '22222222-2222-2222-2222-222222222222');
+SELECT setval('stock_movements_id_seq', 8001);
+
+INSERT INTO transfer_items (id, transfer_id, sku_id, qty_requested, qty_shipped, qty_received,
+  out_movement_id, in_movement_id, created_by, updated_by) VALUES
+  (9000, 900, 101, 5, 5, 3,
+   8000, 8001, '22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222');
+SELECT setval('transfer_items_id_seq', 9000);
+
+-- 鎖月 settlement（測已鎖月份不可改）
+INSERT INTO store_monthly_settlements (tenant_id, settlement_month, store_id,
+  payable_amount, transfer_count, item_count, status,
+  confirmed_at, confirmed_by, created_by, updated_by) VALUES
+  ('11111111-1111-1111-1111-111111111111',
+   DATE_TRUNC('month', CURRENT_DATE - INTERVAL '1 month')::DATE,
+   1, 5000.0000, 2, 3, 'confirmed',
+   NOW() - INTERVAL '10 days', '22222222-2222-2222-2222-222222222222',
+   '22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222');
+
+-- 驗證 fixture 載入
+DO $$
+DECLARE v_cnt INT;
+BEGIN
+  SELECT COUNT(*) INTO v_cnt FROM stock_balances
+   WHERE tenant_id = '11111111-1111-1111-1111-111111111111'
+     AND location_id = 10 AND sku_id = 101;
+  ASSERT v_cnt = 1, 'HQ stock_balances for SKU-GOOD should exist';
+
+  SELECT on_hand INTO v_cnt FROM stock_balances
+   WHERE tenant_id = '11111111-1111-1111-1111-111111111111'
+     AND location_id = 10 AND sku_id = 101;
+  -- HQ(10): 20 (fixture inbound) + (-5) (movement 8000 trigger) = 15
+  -- A店(20): 10 (fixture inbound) + 3 (movement 8001 trigger) = 13
+  RAISE NOTICE 'Fixture loaded: HQ SKU-GOOD on_hand = %', v_cnt;
+END;
+$$;
+
+SELECT 'Fixture data loaded successfully' AS status;
+`;
+
+// ============================================================
+// Schema loading: 按順序載入表 DDL
+// ============================================================
+const SCHEMA_FILES = [
+  // 基底表（按 FK 順序）
+  { file: '20260422120001_product_schema.sql', desc: 'products/skus/prices/categories/brands + triggers' },
+  { file: '20260422120003_inventory_schema.sql', desc: 'locations/stock_balances/stock_movements/transfers/transfer_items + triggers + indexes' },
+  { file: '20260423120000_stores_order_schema.sql', desc: 'stores/customer_orders/customer_order_items + related' },
+  { file: '20260423120002_picking_waves.sql', desc: 'picking_waves/picking_wave_items + related' },
+  { file: '20260512000009_store_monthly_settlement.sql', desc: 'store_monthly_settlements' },
+  { file: '20260515000001_restock_requests_schema.sql', desc: 'restock_requests/restock_request_lines' },
+];
+
+// Column additions (ALTER TABLE ADD COLUMN) in order
+const COLUMN_ADDITIONS = [
+  // products.is_virtual
+  { sql: "ALTER TABLE products ADD COLUMN IF NOT EXISTS is_virtual BOOLEAN NOT NULL DEFAULT FALSE" },
+  // transfers.transfer_type
+  { sql: "ALTER TABLE transfers ADD COLUMN IF NOT EXISTS transfer_type TEXT NOT NULL DEFAULT 'store_to_store' CHECK (transfer_type IN ('store_to_store','return_to_hq','hq_to_store'))" },
+  // transfers.customer_order_id
+  { sql: "ALTER TABLE transfers ADD COLUMN IF NOT EXISTS customer_order_id BIGINT REFERENCES customer_orders(id)" },
+  // transfers.next_transfer_id
+  { sql: "ALTER TABLE transfers ADD COLUMN IF NOT EXISTS next_transfer_id BIGINT REFERENCES transfers(id)" },
+  // transfers.is_air_transfer
+  { sql: "ALTER TABLE transfers ADD COLUMN IF NOT EXISTS is_air_transfer BOOLEAN NOT NULL DEFAULT FALSE" },
+  // transfer_items.description
+  { sql: "ALTER TABLE transfer_items ADD COLUMN IF NOT EXISTS description TEXT" },
+  // transfer_items.estimated_amount
+  { sql: "ALTER TABLE transfer_items ADD COLUMN IF NOT EXISTS estimated_amount NUMERIC(18,4)" },
+  // transfer_items.shortage_resolution + related
+  { sql: `ALTER TABLE transfer_items
+    ADD COLUMN IF NOT EXISTS shortage_resolution TEXT,
+    ADD COLUMN IF NOT EXISTS shortage_resolution_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS shortage_resolution_by UUID,
+    ADD COLUMN IF NOT EXISTS shortage_resolution_notes TEXT` },
+  // transfer_items.shortage_restock_movement_id
+  { sql: "ALTER TABLE transfer_items ADD COLUMN IF NOT EXISTS shortage_restock_movement_id BIGINT" },
+  // transfer_items.shortage_redispatch_wave_id
+  { sql: "ALTER TABLE transfer_items ADD COLUMN IF NOT EXISTS shortage_redispatch_wave_id BIGINT REFERENCES picking_waves(id)" },
+  // transfer_items.shortage_return_transfer_id
+  { sql: "ALTER TABLE transfer_items ADD COLUMN IF NOT EXISTS shortage_return_transfer_id BIGINT REFERENCES transfers(id)" },
+  // transfer_items.shortage_prev_qty_received (20260903000200)
+  { sql: "ALTER TABLE transfer_items ADD COLUMN IF NOT EXISTS shortage_prev_qty_received NUMERIC(18,3)" },
+  // shortage_resolution CHECK (latest: 20260903000020)
+  { sql: `ALTER TABLE transfer_items DROP CONSTRAINT IF EXISTS transfer_items_shortage_resolution_check` },
+  { sql: `ALTER TABLE transfer_items ADD CONSTRAINT transfer_items_shortage_resolution_check
+    CHECK (shortage_resolution IS NULL OR shortage_resolution = ANY (ARRAY[
+      'replenish','cancel_orders','vendor_claim','accept',
+      'restock_hq','redispatch','over_ack','reject_return'
+    ]))` },
+  // stock_movements: latest movement_type CHECK (20260713000000)
+  { sql: "ALTER TABLE stock_movements DROP CONSTRAINT IF EXISTS stock_movements_movement_type_check" },
+  { sql: `ALTER TABLE stock_movements ADD CONSTRAINT stock_movements_movement_type_check CHECK (
+    movement_type = ANY (ARRAY[
+      'purchase_receipt','return_to_supplier','sale','customer_return',
+      'transfer_out','transfer_in','transfer_reject','transfer_cancel',
+      'stocktake_gain','stocktake_loss','damage','manual_adjust','reversal'
+    ]))` },
+  // picking_waves.source_po_id
+  { sql: "ALTER TABLE picking_waves ADD COLUMN IF NOT EXISTS source_po_id BIGINT" },
+  // picking_waves.source_restock_request_id
+  { sql: "ALTER TABLE picking_waves ADD COLUMN IF NOT EXISTS source_restock_request_id BIGINT" },
+  // restock_request_lines.cancelled_at (referenced by rpc_receive_transfer D2 logic)
+  { sql: "ALTER TABLE restock_request_lines ADD COLUMN IF NOT EXISTS cancelled_at TIMESTAMPTZ" },
+  // customer_orders extra columns
+  { sql: "ALTER TABLE customer_orders ADD COLUMN IF NOT EXISTS ready_at TIMESTAMPTZ" },
+  { sql: "ALTER TABLE customer_orders ADD COLUMN IF NOT EXISTS shortage_resolution TEXT" },
+  { sql: "ALTER TABLE customer_orders ADD COLUMN IF NOT EXISTS shortage_resolution_at TIMESTAMPTZ" },
+  { sql: "ALTER TABLE customer_orders ADD COLUMN IF NOT EXISTS shortage_resolution_by UUID" },
+  // customer_order_items.backorder_at
+  { sql: "ALTER TABLE customer_order_items ADD COLUMN IF NOT EXISTS backorder_at TIMESTAMPTZ" },
+  // prices.scope: 擴充加 cost/branch（20260514000000）
+  { sql: "ALTER TABLE prices DROP CONSTRAINT IF EXISTS prices_scope_check" },
+  { sql: "ALTER TABLE prices ADD CONSTRAINT prices_scope_check CHECK (scope IN ('retail','store','member_tier','promo','cost','branch'))" },
+];
+
+// ============================================================
+// Main
+// ============================================================
+async function main() {
+  const dbName = getDbName();
+  console.log(`Creating test database: ${dbName}`);
+  console.log(`Connection: ${PG_USER}@${PG_HOST}:${PG_PORT}`);
+
+  // Step 1: Create the database
+  const adminClient = new Client({
+    host: PG_HOST, port: PG_PORT, user: PG_USER, database: PG_ADMIN_DB
+  });
+  await adminClient.connect();
+  const existing = await adminClient.query(
+    `SELECT 1 FROM pg_database WHERE datname = $1`, [dbName]);
+  if (existing.rows.length > 0) {
+    console.error(`Database ${dbName} already exists, pick a different name or timestamp`);
+    await adminClient.end();
+    process.exit(1);
+  }
+  await adminClient.query(`CREATE DATABASE ${dbName}`);
+  console.log(`  ✓ Database created`);
+  await adminClient.end();
+
+  // Step 2: Connect to new DB and load schema
+  const client = new Client({
+    host: PG_HOST, port: PG_PORT, user: PG_USER, database: dbName
+  });
+  await client.connect();
+
+  try {
+    // 2a. Auth stub
+    console.log('  Loading auth stub...');
+    await client.query(AUTH_STUB_SQL);
+
+    // 2b. FK stub tables
+    console.log('  Loading FK stub tables...');
+    await client.query(FK_STUB_SQL);
+
+    // 2c. Schema DDL from real migrations (AST 節點型別判定)
+    for (const schema of SCHEMA_FILES) {
+      const filePath = path.join(MIGRATIONS_DIR, schema.file);
+      if (!fs.existsSync(filePath)) {
+        console.error(`  ✗ Migration file not found: ${schema.file}`);
+        process.exit(1);
+      }
+      console.log(`  Loading schema: ${schema.desc} (${schema.file})`);
+      const stmts = await extractSchemaStatements(filePath);
+      let loaded = 0;
+      for (const { text: stmt, nodeType } of stmts) {
+        try {
+          await client.query(stmt);
+          loaded++;
+        } catch (e) {
+          // 只允許 "already exists"（IF NOT EXISTS 語義）
+          if (e.message.includes('already exists')) {
+            console.log(`    ⚠ Already exists (${e.message.slice(0, 80)})`);
+          } else {
+            console.error(`    ✗ Failed [${nodeType}]: ${stmt.slice(0, 120)}`);
+            console.error(`      ${e.message}`);
+            throw e;
+          }
+        }
+      }
+      console.log(`    ✓ ${loaded} statements`);
+    }
+
+    // 2d. Column additions
+    console.log('  Applying column additions...');
+    for (const col of COLUMN_ADDITIONS) {
+      try {
+        await client.query(col.sql);
+      } catch (e) {
+        if (e.message.includes('already exists')) {
+          // IF NOT EXISTS 允許
+        } else {
+          console.error(`    ✗ Column addition failed: ${col.sql.slice(0, 80)}`);
+          console.error(`      ${e.message}`);
+          throw e;
+        }
+      }
+    }
+    console.log('    ✓ Column additions applied');
+
+    // 2e. Helper stubs
+    console.log('  Loading helper stubs...');
+    await client.query(HELPER_STUBS_SQL);
+    console.log('    ✓ Helpers loaded');
+
+    // 2f. Real functions from migration files (using AST extraction)
+    for (const src of FUNCTION_SOURCES) {
+      const filePath = path.join(MIGRATIONS_DIR, src.file);
+      if (!fs.existsSync(filePath)) {
+        console.error(`  ✗ Migration file not found: ${src.file}`);
+        process.exit(1);
+      }
+      console.log(`  Loading functions: ${src.desc}`);
+      console.log(`    Source: ${src.file}`);
+
+      // Drop old overloads if specified
+      if (src.dropBefore) {
+        for (const sig of src.dropBefore) {
+          try {
+            await client.query(`DROP FUNCTION IF EXISTS ${sig}`);
+          } catch (e) {
+            console.log(`    ⚠ Drop: ${e.message.slice(0, 80)}`);
+          }
+        }
+      }
+
+      const extracted = await extractStatements(filePath, src.pick, {
+        alsoViews: src.alsoViews
+      });
+
+      // 驗證每個 pick 都找到了（不能總長>0 就當全找到）
+      const allPicks = [...src.pick, ...(src.alsoViews || [])];
+      const foundNames = new Set(extracted.map(e => e.name.toLowerCase()));
+      const missing = allPicks.filter(p => !foundNames.has(p.toLowerCase()));
+      if (missing.length > 0) {
+        console.error(`    ✗ Missing objects in ${src.file}: ${missing.join(', ')}`);
+        console.error(`      Found: ${[...foundNames].join(', ') || '(none)'}`);
+        process.exit(1);
+      }
+
+      for (const item of extracted) {
+        try {
+          await client.query(item.sql);
+          console.log(`    ✓ ${item.type}: ${item.name}`);
+        } catch (e) {
+          console.error(`    ✗ ${item.type} ${item.name}: ${e.message}`);
+          throw e;
+        }
+      }
+    }
+
+    // 2g. --with-core: load HQ return disposition migrations (明確檔名)
+    if (WITH_CORE) {
+      const coreFiles = [
+        '20260907010000_hq_return_disposition_core.sql',      // A: 資料與處理
+        '20260907020000_hq_return_disposition_sources.sql',   // B: 來源函式
+      ];
+      for (const cf of coreFiles) {
+        const cfPath = path.join(MIGRATIONS_DIR, cf);
+        if (!fs.existsSync(cfPath)) {
+          console.error(`  ✗ --with-core: ${cf} not found. Has it been generated?`);
+          process.exit(1);
+        }
+        console.log(`  Loading core migration: ${cf}`);
+        const coreSql = fs.readFileSync(cfPath, 'utf8');
+        await client.query(coreSql);
+        console.log(`    ✓ Core migration applied`);
+      }
+    }
+
+    // 2h. Fixture data
+    console.log('  Loading fixture data...');
+    await client.query('BEGIN');
+    await client.query(FIXTURE_DATA_SQL);
+    await client.query('COMMIT');
+    console.log('    ✓ Fixture data loaded');
+
+    console.log(`\n✓ Test database ready: ${dbName}`);
+    console.log(`  Connect: psql -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USER} -d ${dbName}`);
+
+  } catch (e) {
+    console.error(`\n✗ Setup failed: ${e.message}`);
+    console.error(e.stack);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tests/return-disposition/flow-smoke.cjs
+++ b/tests/return-disposition/flow-smoke.cjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+'use strict';
+
+// CEO 的本機真 RPC 抽驗；不取代不同模型阿審的正式審查。
+// 固定專用假庫連線，所有案例 BEGIN/ROLLBACK，不讀環境或真資料。
+const assert = require('node:assert/strict');
+const { randomUUID } = require('node:crypto');
+const { Client } = require('pg');
+const args = process.argv.slice(2);
+if (args.length !== 2 || args[0] !== '--db-name' || !/^return_disposition_test_[A-Za-z0-9_]+$/.test(args[1])) {
+  console.error('usage: node tests/return-disposition/flow-smoke.cjs --db-name return_disposition_test_<name>');
+  process.exit(2);
+}
+const db = args[1];
+const tenant = '11111111-1111-1111-1111-111111111111';
+const operator = '22222222-2222-2222-2222-222222222222';
+const c = new Client({ host: '127.0.0.1', port: 56427, user: 'returnlocal', database: db });
+const cases = [];
+const test = (name, run) => cases.push({ name, run });
+const one = async (sql, values = []) => (await c.query(sql, values)).rows[0];
+async function stock() {
+  const row = await one('SELECT on_hand,reserved FROM stock_balances WHERE tenant_id=$1 AND location_id=10 AND sku_id=101', [tenant]);
+  return { on_hand: Number(row.on_hand), reserved: Number(row.reserved) };
+}
+async function batches(item) {
+  return (await c.query('SELECT * FROM hq_return_batches WHERE source_transfer_item_id=$1 ORDER BY id', [item])).rows;
+}
+async function receive(id) {
+  return one("SELECT rpc_receive_transfer($1,NULL,$2,'local flow smoke',FALSE) AS result", [id, operator]);
+}
+async function createReturn(qty = 10) {
+  const row = await one("SELECT rpc_create_store_return(1,$1::jsonb,'破損',$2) AS result", [JSON.stringify([{ sku_id: 101, qty }]), operator]);
+  const id = row.result.transfer_id;
+  await receive(id);
+  const item = await one('SELECT id,in_movement_id FROM transfer_items WHERE transfer_id=$1', [id]);
+  return { id, item: item.id, movement: item.in_movement_id };
+}
+async function adjust(doc, qty) {
+  return one("SELECT rpc_adjust_received_transfer($1,$2::jsonb,$3,'local flow correction') AS result", [doc.id, JSON.stringify([{ transfer_item_id: doc.item, qty_received: qty }]), operator]);
+}
+async function unreceive(doc) {
+  return one("SELECT rpc_unreceive_transfer($1,$2,'local flow unreceive') AS result", [doc.id, operator]);
+}
+async function snapshot() {
+  const out = {};
+  for (const table of ['stock_balances', 'stock_movements', 'transfers', 'transfer_items', 'hq_return_batches', 'hq_return_events', 'picking_waves', 'picking_wave_items']) {
+    out[table] = (await one(`SELECT COALESCE(jsonb_agg(to_jsonb(x) ORDER BY to_jsonb(x)::text),'[]') AS data FROM public.${table} x`)).data;
+  }
+  return out;
+}
+async function rejectAtomic(label, fn) {
+  const before = await snapshot();
+  await c.query('SAVEPOINT expected_rejection');
+  let error;
+  try {
+    await fn();
+    // 舊撤收 RPC 可先歸零再撤短少：數量一致性可能延後到交易末驗。
+    // 測試會 ROLLBACK，必須主動強制跑，不能因此漏掉延後的守門。
+    await c.query('SET CONSTRAINTS ALL IMMEDIATE');
+  } catch (e) { error = e; }
+  await c.query('ROLLBACK TO SAVEPOINT expected_rejection');
+  await c.query('RELEASE SAVEPOINT expected_rejection');
+  assert.ok(error, `${label}: 應拒絕，卻成功`);
+  assert.equal(error.code, 'P0001', `${label}: 不是業務守門錯誤，而是 ${error.code}: ${error.message}`);
+  assert.deepEqual(await snapshot(), before, `${label}: 失敗交易不能留下副作用`);
+}
+async function dispose(batch, good, damaged = 0, lost = 0) {
+  return one("SELECT rpc_dispose_hq_return($1,$2,$3,$4,$5,'包裝破裂','清點找不到',TRUE,'local flow disposition') result", [batch.id, randomUUID(), good, damaged, lost]);
+}
+async function lockMonth(status = 'confirmed') {
+  await c.query(`INSERT INTO store_monthly_settlements
+    (tenant_id,settlement_month,store_id,payable_amount,transfer_count,item_count,status,confirmed_at,confirmed_by,created_by,updated_by)
+    VALUES($1,date_trunc('month',NOW() AT TIME ZONE 'Asia/Taipei')::date,1,0,0,0,$2,NOW(),$3,$3,$3)`, [tenant, status, operator]);
+}
+async function directReverse(movement, item, quantity) {
+  return c.query(`INSERT INTO stock_movements
+    (tenant_id,location_id,sku_id,quantity,unit_cost,movement_type,source_doc_type,source_doc_id,source_doc_line_id,reverses,reason,operator_id)
+    SELECT tenant_id,location_id,sku_id,COALESCE($3,-quantity),unit_cost,'reversal',source_doc_type,source_doc_id,$2,id,'local direct reversal',$4
+    FROM stock_movements WHERE id=$1`, [movement, item, quantity ?? null, operator]);
+}
+
+test('人工退貨只建一批；帳上與凍結同步增加', async () => {
+  const before = await stock(); const doc = await createReturn(); const list = await batches(doc.item);
+  assert.equal(list.length, 1); assert.equal(Number(list[0].total_qty), 10);
+  assert.equal(list[0].source_kind, 'store_return'); assert.equal(list[0].auto_flag, 'manual');
+  assert.equal(list[0].created_by, operator);
+  assert.deepEqual(await stock(), { on_hand: before.on_hand + 10, reserved: before.reserved + 10 });
+});
+test('未處理10更正8：舊批撤10、新批待確認8', async () => {
+  const before = await stock(); const doc = await createReturn(); await adjust(doc, 8);
+  const list = await batches(doc.item); assert.equal(list.length, 2);
+  assert.equal(list[0].status, 'revoked'); assert.equal(Number(list[0].qty_revoked), 10);
+  assert.equal(list[1].status, 'pending'); assert.equal(Number(list[1].total_qty), 8);
+  assert.deepEqual(await stock(), { on_hand: before.on_hand + 8, reserved: before.reserved + 8 });
+});
+test('未處理更正0：只撤舊批，不能留幽靈凍結', async () => {
+  const before = await stock(); const doc = await createReturn(); await adjust(doc, 0);
+  const list = await batches(doc.item); assert.equal(list.length, 1); assert.equal(list[0].status, 'revoked');
+  assert.deepEqual(await stock(), before);
+});
+test('撤收再收：只一批有效且店庫不能再扣一次', async () => {
+  const before = await stock(); const doc = await createReturn();
+  const store = await one('SELECT on_hand FROM stock_balances WHERE location_id=20 AND sku_id=101');
+  await unreceive(doc); assert.deepEqual(await stock(), before);
+  assert.equal((await one('SELECT status FROM transfers WHERE id=$1', [doc.id])).status, 'shipped');
+  await receive(doc.id); const list = await batches(doc.item);
+  assert.equal(list.length, 2); assert.equal(list.filter(x => x.status === 'pending').length, 1);
+  assert.equal(list.filter(x => x.status === 'revoked').length, 1);
+  assert.deepEqual(await stock(), { on_hand: before.on_hand + 10, reserved: before.reserved + 10 });
+  assert.deepEqual(await one('SELECT on_hand FROM stock_balances WHERE location_id=20 AND sku_id=101'), store);
+});
+test('短少回帳再撤銷：撤凍結且取消沖帳子單', async () => {
+  const before = await stock();
+  await c.query("SELECT rpc_resolve_transfer_item_shortage(9000,'restock_hq','local smoke',$1)", [operator]);
+  const item = await one('SELECT shortage_return_transfer_id FROM transfer_items WHERE id=9000');
+  const list = await batches(9000); assert.equal(list.length, 1); assert.equal(list[0].source_kind, 'shortage');
+  assert.equal(Number(list[0].total_qty), 2); assert.deepEqual(await stock(), { on_hand: before.on_hand + 2, reserved: before.reserved + 2 });
+  await c.query("SELECT rpc_undo_transfer_item_shortage(9000,$1,'local smoke undo')", [operator]);
+  assert.equal((await batches(9000))[0].status, 'revoked'); assert.deepEqual(await stock(), before);
+  assert.equal((await one('SELECT status FROM transfers WHERE id=$1', [item.shortage_return_transfer_id])).status, 'cancelled');
+});
+test('部分已處理後更正或撤收：整筆拒絕', async () => {
+  const doc = await createReturn(); await dispose((await batches(doc.item))[0], 1);
+  await rejectAtomic('partial adjust', () => adjust(doc, 8));
+  await rejectAtomic('partial unreceive', () => unreceive(doc));
+});
+test('禁止直接清來源、改短少基準或假反向數量', async () => {
+  const doc = await createReturn();
+  await rejectAtomic('clear source', () => c.query('UPDATE transfer_items SET in_movement_id=NULL WHERE id=$1', [doc.item]));
+  await rejectAtomic('fake reversal amount', () => directReverse(doc.movement, doc.item, -1));
+  await c.query("SELECT rpc_resolve_transfer_item_shortage(9000,'restock_hq','local smoke',$1)", [operator]);
+  await rejectAtomic('change shortage source qty', () => c.query('UPDATE transfer_items SET qty_shipped=6 WHERE id=9000'));
+});
+test('撤回必須有真操作者與同公司身分', async () => {
+  const doc = await createReturn();
+  await rejectAtomic('missing operator identity', async () => {
+    await c.query("SELECT set_config('request.jwt.claim.sub','',true)");
+    await directReverse(doc.movement, doc.item);
+  });
+  await rejectAtomic('impersonated operator', async () => {
+    await c.query("SELECT set_config('request.jwt.claim.sub',$1,true)", [randomUUID()]);
+    await directReverse(doc.movement, doc.item);
+  });
+  for (const claims of [{ app_metadata: { role: 'owner' } }, { tenant_id: randomUUID(), app_metadata: { role: 'owner' } }]) {
+    await rejectAtomic('missing or different tenant', async () => {
+      await c.query("SELECT set_config('request.jwt.claims',$1,true)", [JSON.stringify(claims)]);
+      await directReverse(doc.movement, doc.item);
+    });
+  }
+});
+for (const status of ['confirmed', 'settled', 'remitted']) {
+  test(`真退貨${status}月鎖：更正、撤收、跨月、直接反向都擋`, async () => {
+    const doc = await createReturn(); await lockMonth(status);
+    await rejectAtomic('locked adjust', () => adjust(doc, 8));
+    await rejectAtomic('locked unreceive', () => unreceive(doc));
+    await rejectAtomic('locked month change', () => c.query("UPDATE transfers SET received_at=received_at+INTERVAL '1 month' WHERE id=$1", [doc.id]));
+    await rejectAtomic('locked direct reversal', () => directReverse(doc.movement, doc.item));
+  });
+}
+test('短少沖帳子單鎖月：撤銷與直接反向都擋', async () => {
+  await c.query("SELECT rpc_resolve_transfer_item_shortage(9000,'restock_hq','local smoke',$1)", [operator]);
+  const item = await one('SELECT shortage_restock_movement_id FROM transfer_items WHERE id=9000'); await lockMonth();
+  await rejectAtomic('locked shortage undo', () => c.query("SELECT rpc_undo_transfer_item_shortage(9000,$1,'local smoke')", [operator]));
+  await rejectAtomic('locked shortage direct', () => directReverse(item.shortage_restock_movement_id, 9000));
+});
+test('破損與遺失處理異動不能私自反向洗掉', async () => {
+  const doc = await createReturn(); const batch = (await batches(doc.item))[0]; await dispose(batch, 0, 1, 1);
+  const event = await one('SELECT damage_movement_id,loss_movement_id FROM hq_return_events WHERE batch_id=$1', [batch.id]);
+  await rejectAtomic('damage reversal', () => directReverse(event.damage_movement_id, batch.id));
+  await rejectAtomic('loss reversal', () => directReverse(event.loss_movement_id, batch.id));
+});
+
+(async () => {
+  await c.connect();
+  try {
+    const identity = await one('SELECT current_database() db,current_user usr,inet_server_addr()::text host,inet_server_port() port');
+    assert.equal(identity.db, db); assert.equal(identity.usr, 'returnlocal');
+    assert.match(identity.host, /^127\.0\.0\.1(?:\/32)?$/); assert.equal(identity.port, 56427);
+    let failures = 0;
+    for (const entry of cases) {
+      await c.query('BEGIN');
+      try {
+        await c.query("SET LOCAL statement_timeout='5000ms'");
+        await c.query("SELECT set_config('request.jwt.claim.sub',$1,true),set_config('request.jwt.claims',$2,true)", [operator, JSON.stringify({ tenant_id: tenant, app_metadata: { role: 'owner' }, role: 'owner' })]);
+        await entry.run();
+        await c.query('SET CONSTRAINTS ALL IMMEDIATE');
+        console.log(`PASS ${entry.name}`);
+      } catch (e) { failures += 1; console.error(`FAIL ${entry.name}: ${e.code || 'assert'} ${e.message}`); }
+      finally { await c.query('ROLLBACK'); }
+    }
+    console.log(`flow_smoke_summary: ${cases.length - failures}/${cases.length} PASS (all transactions rolled back)`);
+    if (failures) process.exitCode = 1;
+  } finally { await c.end(); }
+})().catch(e => { console.error(e); process.exitCode = 1; });


### PR DESCRIPTION
## Summary

- keep HQ return-to-warehouse stock frozen until HQ classifies it as good, damaged, or lost
- preserve source proof for store returns and shortage restock paths
- block generic `少收` store-return submissions and fix available stock to use `on_hand - reserved`
- add reversal/month-settlement guards so received returns cannot be silently changed after locked settlement months
- update HQ/admin copy so pending frozen stock is not described as dispatchable

## Local verification

- Fresh local fake DB: `return_disposition_test_full_v3`
- Core runtime: 16/16 PASS
- Flow smoke: 13/13 PASS
- Source/available runtime: 7/7 PASS
- Reversal/month mutex runtime: 5/5 PASS
- UI input/submit/shortage/FUI checks: PASS
- TypeScript: `tsc --noEmit --incremental false --project apps/admin/tsconfig.json` PASS

## Boundaries

- No Supabase or production data was touched.
- WV260831002454 historical inventory was not backfilled.
- This PR contains the code path for future correct handling; it does not repair old live records by itself.
