### PR TITLE
feat(line-notes): worker 雲端部署包（Docker / VM 一鍵腳本 / Fly.io）

### DIFF
--- a/tools/line-note-scraper/.dockerignore
+++ b/tools/line-note-scraper/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+storage
+storage.json
+out
+.env
+*.log

--- a/tools/line-note-scraper/Dockerfile
+++ b/tools/line-note-scraper/Dockerfile
@@ -1,0 +1,19 @@
+# line-notes worker：常駐程序，輪詢 Supabase 佇列、跟 LINE 講話。
+# 只需要 Node 22；sharp（PNG→JPEG）有 linux-x64 prebuilt，不用另裝 libvips。
+FROM node:22-slim
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+# 先裝相依（.npmrc 把 @jsr 指到 npm.jsr.io，一定要跟著進來）
+COPY package.json .npmrc ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+COPY src ./src
+
+# LINE token 存這裡；一定要掛 volume，不然重啟就要重掃 QR
+VOLUME ["/app/storage"]
+ENV LINE_STORAGE_DIR=/app/storage
+
+# 跟 .env 無關：雲端用平台的環境變數（SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY）
+CMD ["node", "src/worker.mjs"]

--- a/tools/line-note-scraper/README.md
+++ b/tools/line-note-scraper/README.md
@@ -69,6 +69,35 @@ npm run worker
 
 worker 一次只跑一支，多個帳號各自有 `storage/account-<id>.json`。登出會清 token。
 
+## 部署到雲端（worker 常駐）
+
+worker 是一支要一直活著的 Node 程序，**Supabase / Vercel / GitHub Pages 跑不了**。
+要能跑常駐程序的機器。建議放台灣（LINE 帳號從國外 IP 上線容易被鎖）。
+
+### A. 自己一台 VM（推薦：GCP asia-east1 彰化，e2-micro 免費額度就夠）
+
+1. 開一台 Ubuntu 22.04/24.04，SSH 進去。
+2. 一鍵裝：
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/lt-foods/new_erp/main/tools/line-note-scraper/deploy/setup-vm.sh | bash
+   ```
+3. 填 `~/new_erp/tools/line-note-scraper/.env`（`SUPABASE_URL`、`SUPABASE_SERVICE_ROLE_KEY`），然後
+   ```bash
+   cd ~/new_erp/tools/line-note-scraper && docker compose up -d --build && docker compose logs -f
+   ```
+4. 後台「LINE 記事本 → 帳號 → 登入」掃 QR。token 存在 docker volume，重開機不用重掃。
+
+更新程式：`cd ~/new_erp && git pull && cd tools/line-note-scraper && docker compose up -d --build`
+
+### B. Fly.io（沒台灣機房，用東京）
+
+`fly.toml` 已備好，照檔頭的指令跑。
+
+### 環境變數
+
+跟本機一樣（`.env.example`）。雲端不用 `.env`，直接設在平台上：
+`SUPABASE_URL`、`SUPABASE_SERVICE_ROLE_KEY`，可選 `LINE_POST_MAX_IMAGES`、`VERBOSE=1`。
+
 ## 打不通的時候
 
 第一次一定加 `--verbose`：

--- a/tools/line-note-scraper/deploy/setup-vm.sh
+++ b/tools/line-note-scraper/deploy/setup-vm.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# 在一台全新的 Ubuntu 22.04 / 24.04 VM 上一鍵裝好 worker（Docker + compose + 開機自啟）。
+#
+#   curl -fsSL https://raw.githubusercontent.com/lt-foods/new_erp/main/tools/line-note-scraper/deploy/setup-vm.sh | bash
+#   （或先 clone 再 bash tools/line-note-scraper/deploy/setup-vm.sh）
+#
+# 跑完會停在「請填 .env」；填好再 `docker compose up -d --build`。
+# 建議機器放台灣（GCP asia-east1 彰化 e2-micro 就夠），LINE 帳號從國外 IP 上線容易被鎖。
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/lt-foods/new_erp.git}"
+APP_DIR="${APP_DIR:-$HOME/new_erp}"
+SUB="tools/line-note-scraper"
+
+echo "▶ 安裝 Docker"
+if ! command -v docker >/dev/null 2>&1; then
+  curl -fsSL https://get.docker.com | sh
+  sudo usermod -aG docker "$USER" || true
+fi
+sudo systemctl enable --now docker
+
+echo "▶ 取得程式碼 → $APP_DIR"
+if [ -d "$APP_DIR/.git" ]; then
+  git -C "$APP_DIR" pull --ff-only
+else
+  git clone --depth 1 "$REPO_URL" "$APP_DIR"
+fi
+cd "$APP_DIR/$SUB"
+
+if [ ! -f .env ]; then
+  cp .env.example .env
+  echo
+  echo "⚠ 請先填 $APP_DIR/$SUB/.env 的 SUPABASE_URL 與 SUPABASE_SERVICE_ROLE_KEY，然後："
+  echo "    cd $APP_DIR/$SUB && docker compose up -d --build && docker compose logs -f"
+  exit 0
+fi
+
+echo "▶ 啟動 worker"
+sudo docker compose up -d --build
+sudo docker compose logs --tail=20
+echo
+echo "✔ 跑起來了。看 log：cd $APP_DIR/$SUB && docker compose logs -f"
+echo "  更新程式：cd $APP_DIR && git pull && cd $SUB && docker compose up -d --build"

--- a/tools/line-note-scraper/docker-compose.yml
+++ b/tools/line-note-scraper/docker-compose.yml
@@ -1,0 +1,19 @@
+# 一台 VPS 上跑 worker：
+#   cp .env.example .env && 填 SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY
+#   docker compose up -d --build
+#   docker compose logs -f
+services:
+  worker:
+    build: .
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      TZ: Asia/Taipei
+    volumes:
+      - line-storage:/app/storage   # LINE token，重啟不用重掃 QR
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "5" }
+
+volumes:
+  line-storage:

--- a/tools/line-note-scraper/fly.toml
+++ b/tools/line-note-scraper/fly.toml
@@ -1,0 +1,29 @@
+# Fly.io 部署（沒有台灣機房，最近是東京 nrt；LINE 帳號從日本 IP 上線也還算常見）
+#   cd tools/line-note-scraper
+#   fly launch --no-deploy --copy-config --name lt-line-notes
+#   fly volumes create line_storage --region nrt --size 1
+#   fly secrets set SUPABASE_URL=https://xxx.supabase.co SUPABASE_SERVICE_ROLE_KEY=...
+#   fly deploy
+#   fly logs
+app = "lt-line-notes"
+primary_region = "nrt"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  TZ = "Asia/Taipei"
+  LINE_STORAGE_DIR = "/app/storage"
+
+[[mounts]]
+  source = "line_storage"
+  destination = "/app/storage"
+
+# 純背景程序，不開 HTTP port
+[processes]
+  worker = "node src/worker.mjs"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+  processes = ["worker"]


### PR DESCRIPTION
worker 是常駐 Node 程序，Supabase / Vercel / GitHub Pages 跑不了。這支給兩條部署路：

**A. 自己一台 VM**（建議 GCP asia-east1 台灣，e2-micro 免費額度夠）
`deploy/setup-vm.sh`：裝 Docker → clone → 填 `.env` → `docker compose up -d`。token 放 docker volume，重開機不用重掃 QR。開機自啟（`restart: unless-stopped`）。

**B. Fly.io**（東京 nrt）
`fly.toml`：純背景 process、掛 volume，檔頭有指令。

加的檔：`Dockerfile`、`.dockerignore`、`docker-compose.yml`、`deploy/setup-vm.sh`、`fly.toml`，README 補「部署到雲端」一節。不動程式碼。

沙盒沒有 docker daemon，image 沒實建；Dockerfile 只做 `npm install --omit=dev`（跟本機同一步）＋ copy src，compose YAML 與 shell 都過語法檢查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ)_