### PR TITLE
feat(line-notes): 取消渠道店、取貨店跟會員、同號多人不加單、機器人加單來源

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -9,6 +9,7 @@ import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 import { translateRpcError } from "@/lib/rpcError";
+import { campaignStatusBadge, campaignStatusLabel } from "@/lib/campaignStatus";
 
 type Account = {
   id: number; label: string; status: "logged_out" | "pending_qr" | "active" | "error";
@@ -550,110 +551,149 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
   const commentTone = (s: Comment["status"]) =>
     s === "ordered" || s === "resolved" ? "green" : s === "pending" ? "amber" : s === "unmatched" || s === "error" ? "red" : s === "duplicate" ? "blue" : "gray";
 
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-zinc-500">點一篇貼文看底下留言與加單結果。「找不到會員」「錯誤」可以修正後按「重試」，小幫手手動加完單按「已解決」，紀錄會留著。</p>
-        <button type="button" className={btn} onClick={() => { void reload(); void loadTodos(); }}>重新整理</button>
-      </div>
+  const reasonOf = (c: Comment) => c.error ?? (c.status === "no_order" ? "有會員編號，但看不出要買什麼、買幾個" : "");
+  const parsedChips = (c: Comment) => (c.parsed ?? []).map((o, i) => (
+    <span key={i} className={`inline-block rounded px-1.5 py-0.5 font-mono text-sm ${o.cancel ? "bg-red-50 text-red-700 line-through dark:bg-red-950/40 dark:text-red-300" : "bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200"}`}>
+      {o.code ?? "單品"} ×{o.qty}
+    </span>
+  ));
 
-      <section className="rounded border border-amber-300 bg-amber-50/60 p-3 dark:border-amber-800 dark:bg-amber-950/30">
-        <div className="mb-2 flex items-center justify-between">
-          <h2 className="font-medium">⚠️ 待小幫手處理 {todos ? `（${todos.length}）` : ""}</h2>
-          <span className="text-xs text-zinc-500">系統拆不出來或對不到的留言。加完單後按「已解決」。</span>
+  return (
+    <div className="space-y-5">
+      {/* ── 待小幫手處理：一則一張卡，留言原文放大、原因一行 ── */}
+      <section className="space-y-2">
+        <div className="flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <h2 className="text-base font-semibold">待小幫手處理{todos ? `　${todos.length} 則` : ""}</h2>
+            <p className="text-sm text-zinc-500">系統對不到人或拆不出品項的留言。手動加完單按「已解決」，紀錄會留著。</p>
+          </div>
+          <button type="button" className={btn} onClick={() => { void reload(); void loadTodos(); }}>重新整理</button>
         </div>
-        <Table>
-          <THead><Th>時間</Th><Th>團</Th><Th>留言者</Th><Th>留言</Th><Th>原因</Th><Th align="right">操作</Th></THead>
-          <TBody>
-            {todos === null ? <LoadingRow colSpan={6} /> : todos.length === 0 ? <EmptyRow colSpan={6}>目前沒有要人工處理的留言 🎉</EmptyRow> : todos.map((c) => (
-              <Tr key={c.id}>
-                <Td className="whitespace-nowrap text-xs">{fmt(c.commented_at)}</Td>
-                <Td className="text-sm">
-                  <div>{c.line_note_posts?.group_buy_campaigns?.name ?? "—"}</div>
-                  <div className="text-xs text-zinc-500">{c.line_note_posts?.group_buy_campaigns?.campaign_no} · {communityById.get(c.line_note_posts?.community_id ?? -1)?.home_name ?? ""}</div>
-                </Td>
-                <Td>{c.commenter_name ?? "—"}</Td>
-                <Td className="max-w-sm whitespace-pre-wrap text-sm">{c.text}</Td>
-                <Td className="text-xs">
-                  <Badge tone={commentTone(c.status)}>{COMMENT_STATUS[c.status]}</Badge>
-                  <div className="text-red-600">{c.error ?? (c.status === "no_order" ? "有會員編號但看不出數量" : "")}</div>
-                </Td>
-                <Td align="right">{todoActions(c)}</Td>
-              </Tr>
+        {todos === null ? (
+          <div className="rounded-lg border border-zinc-200 p-6 text-center text-sm text-zinc-400 dark:border-zinc-800">讀取中…</div>
+        ) : todos.length === 0 ? (
+          <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-6 text-center text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300">目前沒有要人工處理的留言 🎉</div>
+        ) : (
+          <ul className="space-y-2">
+            {todos.map((c) => (
+              <li key={c.id} className="rounded-lg border border-amber-300 bg-amber-50/50 p-4 dark:border-amber-800 dark:bg-amber-950/20">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1 space-y-1.5">
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm text-zinc-500">
+                      <span className="font-medium text-zinc-800 dark:text-zinc-200">{c.line_note_posts?.group_buy_campaigns?.name ?? "—"}</span>
+                      <span>·</span>
+                      <span>{communityById.get(c.line_note_posts?.community_id ?? -1)?.home_name ?? ""}</span>
+                      <span>·</span>
+                      <span>{fmt(c.commented_at)}</span>
+                    </div>
+                    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                      <span className="text-base font-semibold">{c.commenter_name ?? "—"}</span>
+                      <span className="whitespace-pre-wrap text-lg">{c.text}</span>
+                      {c.parsed?.length > 0 && <span className="flex flex-wrap gap-1">{parsedChips(c)}</span>}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2 text-sm">
+                      <Badge tone={commentTone(c.status)}>{COMMENT_STATUS[c.status]}</Badge>
+                      <span className="text-red-700 dark:text-red-300">{reasonOf(c)}</span>
+                    </div>
+                  </div>
+                  <div className="shrink-0">{todoActions(c)}</div>
+                </div>
+              </li>
             ))}
+          </ul>
+        )}
+      </section>
+
+      {/* ── 貼文列表 ── */}
+      <section className="space-y-2">
+        <h2 className="text-base font-semibold">貼文</h2>
+        <p className="text-sm text-zinc-500">點一篇看底下的留言與加單結果。</p>
+        <Table>
+          <THead><Th>團</Th><Th>社群</Th><Th>發文狀態</Th><Th>發文時間</Th><Th>最後讀取</Th><Th align="right">留言</Th><Th align="right"></Th></THead>
+          <TBody>
+            {posts === null ? <LoadingRow colSpan={7} /> : posts.length === 0 ? <EmptyRow colSpan={7}>還沒有貼文</EmptyRow> : posts.map((p) => {
+              const c = communityById.get(p.community_id);
+              const cs = p.group_buy_campaigns?.status;
+              return (
+                <Tr key={p.id} onClick={() => setSelected(p)} className={selected?.id === p.id ? "bg-sky-50 dark:bg-sky-950/30" : ""}>
+                  <Td>
+                    <div className="text-base font-medium">{p.group_buy_campaigns?.name ?? p.campaign_id}</div>
+                    <div className="mt-0.5 flex items-center gap-2 text-xs text-zinc-500">
+                      {cs && <span className={`rounded px-1.5 py-0.5 ${campaignStatusBadge(cs)}`}>{campaignStatusLabel(cs)}</span>}
+                      <span className="font-mono">{p.group_buy_campaigns?.campaign_no}</span>
+                    </div>
+                  </Td>
+                  <Td className="whitespace-nowrap">{c?.home_name || c?.home_id || p.community_id}</Td>
+                  <Td>
+                    <Badge tone={p.status === "posted" ? "green" : p.status === "queued" ? "amber" : p.status === "failed" ? "red" : "gray"}>{POST_STATUS[p.status]}</Badge>
+                    {p.last_error && <div className="mt-1 max-w-xs truncate text-xs text-red-600" title={p.last_error}>{p.last_error}</div>}
+                  </Td>
+                  <Td className="whitespace-nowrap">{fmt(p.posted_at)}</Td>
+                  <Td className="whitespace-nowrap">{fmt(p.last_read_at)}</Td>
+                  <Td align="right" className="tabular-nums">{p.comment_count}</Td>
+                  <Td align="right">
+                    {p.status === "posted" && (
+                      <SpinButton type="button" className={btn} loading={busy === p.id} onClick={(e) => { e.stopPropagation(); void readNow(p); }}>立即讀取</SpinButton>
+                    )}
+                  </Td>
+                </Tr>
+              );
+            })}
           </TBody>
         </Table>
       </section>
-      <Table>
-        <THead><Th>團</Th><Th>社群</Th><Th>狀態</Th><Th>發文時間</Th><Th>最後讀取</Th><Th align="right">留言數</Th><Th align="right">操作</Th></THead>
-        <TBody>
-          {posts === null ? <LoadingRow colSpan={7} /> : posts.length === 0 ? <EmptyRow colSpan={7}>還沒有貼文</EmptyRow> : posts.map((p) => {
-            const c = communityById.get(p.community_id);
-            return (
-              <Tr key={p.id} onClick={() => setSelected(p)} className={selected?.id === p.id ? "bg-zinc-100 dark:bg-zinc-800" : ""}>
-                <Td>
-                  <div>{p.group_buy_campaigns?.name ?? p.campaign_id}</div>
-                  <div className="text-xs text-zinc-500">{p.group_buy_campaigns?.campaign_no}（{p.group_buy_campaigns?.status}）</div>
-                </Td>
-                <Td>{c?.home_name || c?.home_id || p.community_id}</Td>
-                <Td>
-                  <Badge tone={p.status === "posted" ? "green" : p.status === "queued" ? "amber" : p.status === "failed" ? "red" : "gray"}>{POST_STATUS[p.status]}</Badge>
-                  {p.last_error && <div className="max-w-xs truncate text-xs text-red-600" title={p.last_error}>{p.last_error}</div>}
-                </Td>
-                <Td>{fmt(p.posted_at)}</Td>
-                <Td>{fmt(p.last_read_at)}</Td>
-                <Td align="right">{p.comment_count}</Td>
-                <Td align="right">
-                  {p.status === "posted" && (
-                    <SpinButton type="button" className={btn} loading={busy === p.id} onClick={(e) => { e.stopPropagation(); void readNow(p); }}>立即讀取</SpinButton>
-                  )}
-                </Td>
-              </Tr>
-            );
-          })}
-        </TBody>
-      </Table>
 
+      {/* ── 選中貼文的留言 ── */}
       {selected && (
-        <div className="space-y-2 rounded border border-zinc-200 p-3 dark:border-zinc-800">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <h2 className="font-medium">留言：{selected.group_buy_campaigns?.name}</h2>
+        <section className="space-y-3 rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div>
+              <h2 className="text-base font-semibold">留言：{selected.group_buy_campaigns?.name}</h2>
+              <div className="text-sm text-zinc-500">{communityById.get(selected.community_id)?.home_name ?? ""}　發文 {fmt(selected.posted_at)}　最後讀取 {fmt(selected.last_read_at)}</div>
+            </div>
             {summary && (
-              <div className="flex flex-wrap gap-1 text-xs">
-                <Badge tone="green">已加單 {summary.ordered}</Badge>
-                <Badge tone="amber">待處理 {summary.pending}</Badge>
-                <Badge tone="red">找不到會員 {summary.unmatched}</Badge>
-                <Badge tone="red">錯誤 {summary.error}</Badge>
-                <Badge tone="gray">非下單 {summary.no_order}</Badge>
-                <Badge tone="gray">忽略 {summary.ignored}</Badge>
-                <Badge tone="green">已解決 {summary.resolved}</Badge>
-                <Badge tone="blue">已有訂單 {summary.duplicate}</Badge>
+              <div className="flex flex-wrap gap-1.5">
+                {summary.ordered > 0 && <Badge tone="green">已加單 {summary.ordered}</Badge>}
+                {summary.duplicate > 0 && <Badge tone="blue">已有訂單 {summary.duplicate}</Badge>}
+                {summary.pending > 0 && <Badge tone="amber">待處理 {summary.pending}</Badge>}
+                {summary.unmatched > 0 && <Badge tone="red">找不到會員 {summary.unmatched}</Badge>}
+                {summary.error > 0 && <Badge tone="red">錯誤 {summary.error}</Badge>}
+                {summary.resolved > 0 && <Badge tone="green">已解決 {summary.resolved}</Badge>}
+                {summary.no_order > 0 && <Badge tone="gray">非下單 {summary.no_order}</Badge>}
+                {summary.ignored > 0 && <Badge tone="gray">忽略 {summary.ignored}</Badge>}
               </div>
             )}
           </div>
-          {selected.text && <details className="text-xs text-zinc-500"><summary>貼文內容</summary><pre className="whitespace-pre-wrap">{selected.text}</pre></details>}
+          {selected.text && <details className="text-sm text-zinc-500"><summary className="cursor-pointer">貼文內容</summary><pre className="mt-1 whitespace-pre-wrap rounded bg-zinc-50 p-3 text-sm text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">{selected.text}</pre></details>}
           <Table>
-            <THead><Th>時間</Th><Th>留言者</Th><Th>留言</Th><Th>會員編號</Th><Th>解析</Th><Th>狀態</Th><Th align="right">操作</Th></THead>
+            <THead><Th>時間</Th><Th>留言者</Th><Th>留言</Th><Th>結果</Th><Th align="right"></Th></THead>
             <TBody>
-              {comments === null ? <LoadingRow colSpan={7} /> : comments.length === 0 ? <EmptyRow colSpan={7}>還沒讀到留言</EmptyRow> : comments.map((c) => (
+              {comments === null ? <LoadingRow colSpan={5} /> : comments.length === 0 ? <EmptyRow colSpan={5}>還沒讀到留言</EmptyRow> : comments.map((c) => (
                 <Tr key={c.id}>
-                  <Td className="whitespace-nowrap text-xs">{fmt(c.commented_at)}</Td>
-                  <Td><div>{c.commenter_name ?? "—"}</div><div className="font-mono text-[10px] text-zinc-400">{c.commenter_id}</div></Td>
-                  <Td className="max-w-sm whitespace-pre-wrap text-sm">{c.text}</Td>
-                  <Td className="font-mono">{c.member_no_hint ?? "—"}</Td>
-                  <Td className="font-mono text-xs">{(c.parsed ?? []).map((o, i) => <div key={i}>{o.cancel ? "取消 " : ""}{o.code ?? "(單品)"} ×{o.qty}</div>)}</Td>
-                  <Td>
-                    <Badge tone={commentTone(c.status)}>{COMMENT_STATUS[c.status]}</Badge>
-                    {c.error && <div className={`max-w-xs text-xs ${c.status === "duplicate" ? "text-zinc-500" : "text-red-600"}`}>{c.error}</div>}
-                    {c.resolution_note && <div className="max-w-xs text-xs text-zinc-500">處理：{c.resolution_note}</div>}
-                    {c.customer_order_id && <div className="text-xs text-zinc-500">訂單 #{c.customer_order_id}</div>}
+                  <Td className="whitespace-nowrap text-sm text-zinc-500">{fmt(c.commented_at)}</Td>
+                  <Td className="whitespace-nowrap">
+                    <div className="font-medium">{c.commenter_name ?? "—"}</div>
+                    {c.member_no_hint && <div className="font-mono text-xs text-zinc-500">會員 {c.member_no_hint}</div>}
+                  </Td>
+                  <Td className="max-w-md">
+                    <div className="whitespace-pre-wrap text-base">{c.text}</div>
+                    {c.parsed?.length > 0 && <div className="mt-1 flex flex-wrap gap-1">{parsedChips(c)}</div>}
+                  </Td>
+                  <Td className="max-w-xs">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <Badge tone={commentTone(c.status)}>{COMMENT_STATUS[c.status]}</Badge>
+                      {c.customer_order_id && <span className="text-sm text-zinc-600 dark:text-zinc-300">訂單 #{c.customer_order_id}</span>}
+                    </div>
+                    {c.error && c.status !== "duplicate" && <div className="mt-1 text-sm text-red-700 dark:text-red-300">{c.error}</div>}
+                    {c.status === "no_order" && c.member_no_hint && <div className="mt-1 text-sm text-red-700 dark:text-red-300">{reasonOf(c)}</div>}
+                    {c.resolution_note && <div className="mt-1 text-sm text-zinc-500">處理：{c.resolution_note}</div>}
                   </Td>
                   <Td align="right">{todoActions(c)}</Td>
                 </Tr>
               ))}
             </TBody>
           </Table>
-        </div>
+        </section>
       )}
     </div>
   );

--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -36,7 +36,8 @@ type Comment = {
   member_id: number | null; customer_order_id: number | null; error: string | null;
   resolved_at: string | null; resolution_note: string | null;
 };
-type Todo = Comment & { line_note_posts: { community_id: number; campaign_id: number; group_buy_campaigns: { name: string; campaign_no: string } | null } | null };
+type Row = Comment & { line_note_posts: { community_id: number; campaign_id: number; group_buy_campaigns: { name: string; campaign_no: string } | null } | null };
+type OrderInfo = { id: number; order_no: string; store_name: string | null };
 type Home = { kind: string; homeId: string; name: string };
 type Campaign = { id: number; campaign_no: string; name: string; status: string };
 
@@ -70,7 +71,7 @@ const btnPrimary = "rounded bg-zinc-900 px-3 py-1.5 text-sm font-medium text-whi
 const input = "w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900";
 
 export default function LineNotesPage() {
-  const [tab, setTab] = useState<"accounts" | "communities" | "posts">("accounts");
+  const [tab, setTab] = useState<"accounts" | "communities" | "comments" | "posts">("accounts");
   const [accounts, setAccounts] = useState<Account[] | null>(null);
   const [channels, setChannels] = useState<Channel[]>([]);
   const [communities, setCommunities] = useState<Community[] | null>(null);
@@ -126,7 +127,7 @@ export default function LineNotesPage() {
           </p>
         </div>
         <nav className="flex gap-1 rounded-lg bg-zinc-100 p-1 dark:bg-zinc-800">
-          {([["accounts", "帳號"], ["communities", "社群設定"], ["posts", "貼文與留言"]] as const).map(([k, l]) => (
+          {([["accounts", "帳號"], ["communities", "社群設定"], ["comments", "留言加單"], ["posts", "貼文"]] as const).map(([k, l]) => (
             <button key={k} type="button" onClick={() => setTab(k)}
               className={`rounded-md px-3 py-1 text-sm ${tab === k ? "bg-white shadow dark:bg-zinc-900" : "text-zinc-600 dark:text-zinc-300"}`}>
               {l}
@@ -152,6 +153,9 @@ export default function LineNotesPage() {
           accountById={accountById} channelById={channelById}
           reload={loadCommunities} reloadPosts={loadPosts} notify={notify} fail={fail}
         />
+      )}
+      {tab === "comments" && (
+        <CommentsTab communityById={communityById} notify={notify} fail={fail} />
       )}
       {tab === "posts" && (
         <PostsTab posts={posts} communityById={communityById} reload={loadPosts} notify={notify} fail={fail} />
@@ -474,29 +478,40 @@ function PostCampaignModal({ community, onClose, notify, fail, reloadPosts }: {
 }
 
 // ── 貼文與留言 ───────────────────────────────────────────────────────────────
-function PostsTab({ posts, communityById, reload, notify, fail }: {
-  posts: Post[] | null; communityById: Map<number, Community>; reload: () => Promise<void>; notify: (m: string) => void; fail: (e: unknown) => void;
+type Filter = "todo" | "ordered" | "all";
+const TODO_STATUSES: Comment["status"][] = ["pending", "unmatched", "error"];
+const isTodo = (c: Comment) => TODO_STATUSES.includes(c.status) || (c.status === "no_order" && !!c.member_no_hint);
+
+// ── 留言加單：一張表，一則留言一列 ─────────────────────────────────────────
+function CommentsTab({ communityById, notify, fail }: {
+  communityById: Map<number, Community>; notify: (m: string) => void; fail: (e: unknown) => void;
 }) {
-  const [selected, setSelected] = useState<Post | null>(null);
-  const [comments, setComments] = useState<Comment[] | null>(null);
-  const [todos, setTodos] = useState<Todo[] | null>(null);
+  const [filter, setFilter] = useState<Filter>("todo");
+  const [rows, setRows] = useState<Row[] | null>(null);
+  const [orders, setOrders] = useState<Map<number, OrderInfo>>(new Map());
   const [busy, setBusy] = useState<number | null>(null);
 
-  // 待人工處理：找不到會員 / 品項對不上 / 加單失敗 / 有會員編號卻沒數量
-  const loadTodos = useCallback(async () => {
-    const { data, error } = await getSupabase().from("line_note_comments")
+  const load = useCallback(async () => {
+    const sb = getSupabase();
+    const { data, error } = await sb.from("line_note_comments")
       .select("*,line_note_posts(community_id,campaign_id,group_buy_campaigns(name,campaign_no))")
-      .or("status.in.(unmatched,error),and(status.eq.no_order,member_no_hint.not.is.null)")
-      .order("commented_at", { ascending: false }).limit(200);
-    if (error) fail(error); else setTodos((data ?? []) as Todo[]);
+      .order("commented_at", { ascending: false }).limit(300);
+    if (error) return fail(error);
+    const list = (data ?? []) as Row[];
+    setRows(list);
+    // 有加到單的 → 查訂單號與取貨店
+    const ids = [...new Set(list.map((c) => c.customer_order_id).filter((x): x is number => !!x))];
+    if (ids.length === 0) { setOrders(new Map()); return; }
+    const { data: od } = await sb.from("customer_orders")
+      .select("id,order_no,stores!customer_orders_pickup_store_id_fkey(name)").in("id", ids);
+    const m = new Map<number, OrderInfo>();
+    for (const o of (od ?? []) as { id: number; order_no: string; stores: { name: string } | { name: string }[] | null }[]) {
+      const st = Array.isArray(o.stores) ? o.stores[0] : o.stores;
+      m.set(o.id, { id: o.id, order_no: o.order_no, store_name: st?.name ?? null });
+    }
+    setOrders(m);
   }, [fail]);
-  useEffect(() => { void loadTodos(); }, [loadTodos]);
-
-  const loadComments = useCallback(async (post: Post) => {
-    const { data, error } = await getSupabase().from("line_note_comments").select("*").eq("post_id", post.id).order("commented_at", { ascending: true }).order("id");
-    if (error) fail(error); else setComments((data ?? []) as Comment[]);
-  }, [fail]);
-  useEffect(() => { if (selected) void loadComments(selected); else setComments(null); }, [selected, loadComments]);
+  useEffect(() => { void load(); }, [load]);
 
   const retry = async (c: Comment) => {
     setBusy(c.id);
@@ -504,26 +519,105 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
     setBusy(null);
     if (error) return fail(error);
     const r = (Array.isArray(data) ? data[0] : data) as { out_status?: string; out_error?: string } | null;
-    notify(r?.out_status === "ordered" ? "已加單" : `結果：${COMMENT_STATUS[(r?.out_status ?? "error") as Comment["status"]] ?? r?.out_status}${r?.out_error ? "：" + r.out_error : ""}`);
-    if (selected) await loadComments(selected);
-    await loadTodos();
+    notify(r?.out_status === "ordered" ? "已加單" : `${COMMENT_STATUS[(r?.out_status ?? "error") as Comment["status"]] ?? r?.out_status}${r?.out_error ? "：" + r.out_error : ""}`);
+    await load();
   };
   const setStatus = async (c: Comment, status: Comment["status"]) => {
     let note: string | null = null;
     if (status === "resolved") {
-      note = window.prompt("怎麼處理的？（選填，例：已用小幫手加單 / 客人說不要了）", c.resolution_note ?? "");
+      note = window.prompt("怎麼處理的？（選填）", c.resolution_note ?? "");
       if (note === null) return;
     }
     setBusy(c.id);
-    const body = status === "resolved"
-      ? { status, resolved_at: new Date().toISOString(), resolution_note: note || null }
-      : { status };
+    const body = status === "resolved" ? { status, resolved_at: new Date().toISOString(), resolution_note: note || null } : { status };
     const { error } = await getSupabase().from("line_note_comments").update(body).eq("id", c.id);
     setBusy(null);
     if (error) return fail(error);
-    if (selected) await loadComments(selected);
-    await loadTodos();
+    await load();
   };
+
+  const shown = useMemo(() => {
+    if (!rows) return null;
+    if (filter === "todo") return rows.filter(isTodo);
+    if (filter === "ordered") return rows.filter((c) => c.status === "ordered" || c.status === "duplicate");
+    return rows;
+  }, [rows, filter]);
+  const todoCount = rows?.filter(isTodo).length ?? 0;
+
+  // 結果欄：一個徽章 + 一句話
+  const result = (c: Comment) => {
+    const o = c.customer_order_id ? orders.get(c.customer_order_id) : null;
+    const orderText = o ? `${o.store_name ?? "？店"}　${o.order_no}` : c.customer_order_id ? `訂單 #${c.customer_order_id}` : "";
+    switch (c.status) {
+      case "ordered":   return <><Badge tone="green">已加單</Badge><span>{orderText}</span></>;
+      case "duplicate": return <><Badge tone="blue">已有訂單</Badge><span>{orderText}</span></>;
+      case "resolved":  return <><Badge tone="green">已解決</Badge><span className="text-zinc-500">{c.resolution_note ?? ""}</span></>;
+      case "ignored":   return <Badge tone="gray">忽略</Badge>;
+      case "pending":   return <Badge tone="amber">等 worker 處理</Badge>;
+      case "no_order":  return c.member_no_hint
+        ? <><Badge tone="red">看不懂</Badge><span className="text-red-700 dark:text-red-300">有會員編號，看不出要買什麼</span></>
+        : <Badge tone="gray">非下單</Badge>;
+      default:          return <><Badge tone="red">{COMMENT_STATUS[c.status]}</Badge><span className="text-red-700 dark:text-red-300">{c.error ?? ""}</span></>;
+    }
+  };
+  const actions = (c: Comment) => {
+    if (c.status === "ordered" || c.status === "duplicate") return null;
+    if (c.status === "ignored" || c.status === "resolved") {
+      return <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => setStatus(c, "pending")}>退回</SpinButton>;
+    }
+    return (
+      <div className="flex justify-end gap-1">
+        <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => retry(c)}>重試</SpinButton>
+        <SpinButton type="button" className={`${btn} text-emerald-700`} loading={busy === c.id} onClick={() => setStatus(c, "resolved")}>已解決</SpinButton>
+        <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => setStatus(c, "ignored")}>忽略</SpinButton>
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex gap-1 rounded-lg bg-zinc-100 p-1 dark:bg-zinc-800">
+          {([["todo", `待處理 ${todoCount}`], ["ordered", "已加單"], ["all", "全部"]] as const).map(([k, l]) => (
+            <button key={k} type="button" onClick={() => setFilter(k)}
+              className={`rounded-md px-3 py-1 text-sm ${filter === k ? "bg-white shadow dark:bg-zinc-900" : "text-zinc-600 dark:text-zinc-300"}`}>
+              {l}
+            </button>
+          ))}
+        </div>
+        <button type="button" className={btn} onClick={() => void load()}>重新整理</button>
+      </div>
+
+      <Table>
+        <THead><Th>時間</Th><Th>留言者</Th><Th>留言</Th><Th>團</Th><Th>結果</Th><Th align="right"></Th></THead>
+        <TBody>
+          {shown === null ? <LoadingRow colSpan={6} /> : shown.length === 0 ? (
+            <EmptyRow colSpan={6}>{filter === "todo" ? "沒有要處理的留言 🎉" : "沒有留言"}</EmptyRow>
+          ) : shown.map((c) => (
+            <Tr key={c.id} className={isTodo(c) ? "bg-amber-50/60 dark:bg-amber-950/20" : ""}>
+              <Td className="whitespace-nowrap text-sm text-zinc-500">{fmt(c.commented_at)}</Td>
+              <Td className="whitespace-nowrap font-medium">{c.commenter_name ?? "—"}</Td>
+              <Td className="max-w-xs whitespace-pre-wrap text-base">{c.text}</Td>
+              <Td className="max-w-[12rem] text-sm">
+                <div className="truncate" title={c.line_note_posts?.group_buy_campaigns?.name ?? ""}>{c.line_note_posts?.group_buy_campaigns?.name ?? "—"}</div>
+                <div className="truncate text-xs text-zinc-500">{communityById.get(c.line_note_posts?.community_id ?? -1)?.home_name ?? ""}</div>
+              </Td>
+              <Td><div className="flex flex-wrap items-center gap-2 text-sm">{result(c)}</div></Td>
+              <Td align="right" className="whitespace-nowrap">{actions(c)}</Td>
+            </Tr>
+          ))}
+        </TBody>
+      </Table>
+    </div>
+  );
+}
+
+// ── 貼文：哪些團已經發到哪些社群 ─────────────────────────────────────────────
+function PostsTab({ posts, communityById, reload, notify, fail }: {
+  posts: Post[] | null; communityById: Map<number, Community>; reload: () => Promise<void>; notify: (m: string) => void; fail: (e: unknown) => void;
+}) {
+  const [busy, setBusy] = useState<number | null>(null);
+  const [open, setOpen] = useState<number | null>(null);
   const readNow = async (p: Post) => {
     const c = communityById.get(p.community_id);
     if (!c) return;
@@ -531,170 +625,46 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
     const { error } = await getSupabase().rpc("rpc_line_note_enqueue", { p_kind: "read", p_account_id: c.account_id, p_community_id: c.id, p_post_id: p.id });
     setBusy(null);
     if (error) return fail(error);
-    notify("已排讀取這篇");
+    notify("已排讀取，留言幾秒後會出現在「留言加單」");
   };
-
-  const summary = useMemo(() => {
-    if (!comments) return null;
-    const n = (s: Comment["status"]) => comments.filter((c) => c.status === s).length;
-    return { ordered: n("ordered"), pending: n("pending"), unmatched: n("unmatched"), error: n("error"), no_order: n("no_order"), ignored: n("ignored"), resolved: n("resolved"), duplicate: n("duplicate") };
-  }, [comments]);
-
-  const todoActions = (c: Comment) => (
-    <div className="flex justify-end gap-1">
-      {!["ordered", "ignored", "resolved", "duplicate"].includes(c.status) && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => retry(c)}>重試</SpinButton>}
-      {!["ordered", "ignored", "resolved", "duplicate"].includes(c.status) && <SpinButton type="button" className={`${btn} text-emerald-700`} loading={busy === c.id} onClick={() => setStatus(c, "resolved")}>已解決</SpinButton>}
-      {!["ordered", "ignored", "resolved", "duplicate"].includes(c.status) && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => setStatus(c, "ignored")}>忽略</SpinButton>}
-      {(c.status === "ignored" || c.status === "resolved") && <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => setStatus(c, "pending")}>退回待處理</SpinButton>}
-    </div>
-  );
-  const commentTone = (s: Comment["status"]) =>
-    s === "ordered" || s === "resolved" ? "green" : s === "pending" ? "amber" : s === "unmatched" || s === "error" ? "red" : s === "duplicate" ? "blue" : "gray";
-
-  const reasonOf = (c: Comment) => c.error ?? (c.status === "no_order" ? "有會員編號，但看不出要買什麼、買幾個" : "");
-  const parsedChips = (c: Comment) => (c.parsed ?? []).map((o, i) => (
-    <span key={i} className={`inline-block rounded px-1.5 py-0.5 font-mono text-sm ${o.cancel ? "bg-red-50 text-red-700 line-through dark:bg-red-950/40 dark:text-red-300" : "bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200"}`}>
-      {o.code ?? "單品"} ×{o.qty}
-    </span>
-  ));
-
   return (
-    <div className="space-y-5">
-      {/* ── 待小幫手處理：一則一張卡，留言原文放大、原因一行 ── */}
-      <section className="space-y-2">
-        <div className="flex flex-wrap items-end justify-between gap-2">
-          <div>
-            <h2 className="text-base font-semibold">待小幫手處理{todos ? `　${todos.length} 則` : ""}</h2>
-            <p className="text-sm text-zinc-500">系統對不到人或拆不出品項的留言。手動加完單按「已解決」，紀錄會留著。</p>
-          </div>
-          <button type="button" className={btn} onClick={() => { void reload(); void loadTodos(); }}>重新整理</button>
-        </div>
-        {todos === null ? (
-          <div className="rounded-lg border border-zinc-200 p-6 text-center text-sm text-zinc-400 dark:border-zinc-800">讀取中…</div>
-        ) : todos.length === 0 ? (
-          <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-6 text-center text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300">目前沒有要人工處理的留言 🎉</div>
-        ) : (
-          <ul className="space-y-2">
-            {todos.map((c) => (
-              <li key={c.id} className="rounded-lg border border-amber-300 bg-amber-50/50 p-4 dark:border-amber-800 dark:bg-amber-950/20">
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="min-w-0 flex-1 space-y-1.5">
-                    <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm text-zinc-500">
-                      <span className="font-medium text-zinc-800 dark:text-zinc-200">{c.line_note_posts?.group_buy_campaigns?.name ?? "—"}</span>
-                      <span>·</span>
-                      <span>{communityById.get(c.line_note_posts?.community_id ?? -1)?.home_name ?? ""}</span>
-                      <span>·</span>
-                      <span>{fmt(c.commented_at)}</span>
-                    </div>
-                    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                      <span className="text-base font-semibold">{c.commenter_name ?? "—"}</span>
-                      <span className="whitespace-pre-wrap text-lg">{c.text}</span>
-                      {c.parsed?.length > 0 && <span className="flex flex-wrap gap-1">{parsedChips(c)}</span>}
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2 text-sm">
-                      <Badge tone={commentTone(c.status)}>{COMMENT_STATUS[c.status]}</Badge>
-                      <span className="text-red-700 dark:text-red-300">{reasonOf(c)}</span>
-                    </div>
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-zinc-500">開團自動發的、和小幫手手貼後被系統認出來的貼文。</p>
+        <button type="button" className={btn} onClick={() => void reload()}>重新整理</button>
+      </div>
+      <Table>
+        <THead><Th>團</Th><Th>社群</Th><Th>狀態</Th><Th>發文</Th><Th>最後讀取</Th><Th align="right">留言</Th><Th align="right"></Th></THead>
+        <TBody>
+          {posts === null ? <LoadingRow colSpan={7} /> : posts.length === 0 ? <EmptyRow colSpan={7}>還沒有貼文</EmptyRow> : posts.map((p) => {
+            const c = communityById.get(p.community_id);
+            const cs = p.group_buy_campaigns?.status;
+            return (
+              <Tr key={p.id}>
+                <Td>
+                  <div className="font-medium">{p.group_buy_campaigns?.name ?? p.campaign_id}</div>
+                  <div className="mt-0.5 flex items-center gap-2 text-xs text-zinc-500">
+                    {cs && <span className={`rounded px-1.5 py-0.5 ${campaignStatusBadge(cs)}`}>{campaignStatusLabel(cs)}</span>}
+                    {p.text && <button type="button" className="underline" onClick={() => setOpen(open === p.id ? null : p.id)}>{open === p.id ? "收起內容" : "看內容"}</button>}
                   </div>
-                  <div className="shrink-0">{todoActions(c)}</div>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-
-      {/* ── 貼文列表 ── */}
-      <section className="space-y-2">
-        <h2 className="text-base font-semibold">貼文</h2>
-        <p className="text-sm text-zinc-500">點一篇看底下的留言與加單結果。</p>
-        <Table>
-          <THead><Th>團</Th><Th>社群</Th><Th>發文狀態</Th><Th>發文時間</Th><Th>最後讀取</Th><Th align="right">留言</Th><Th align="right"></Th></THead>
-          <TBody>
-            {posts === null ? <LoadingRow colSpan={7} /> : posts.length === 0 ? <EmptyRow colSpan={7}>還沒有貼文</EmptyRow> : posts.map((p) => {
-              const c = communityById.get(p.community_id);
-              const cs = p.group_buy_campaigns?.status;
-              return (
-                <Tr key={p.id} onClick={() => setSelected(p)} className={selected?.id === p.id ? "bg-sky-50 dark:bg-sky-950/30" : ""}>
-                  <Td>
-                    <div className="text-base font-medium">{p.group_buy_campaigns?.name ?? p.campaign_id}</div>
-                    <div className="mt-0.5 flex items-center gap-2 text-xs text-zinc-500">
-                      {cs && <span className={`rounded px-1.5 py-0.5 ${campaignStatusBadge(cs)}`}>{campaignStatusLabel(cs)}</span>}
-                      <span className="font-mono">{p.group_buy_campaigns?.campaign_no}</span>
-                    </div>
-                  </Td>
-                  <Td className="whitespace-nowrap">{c?.home_name || c?.home_id || p.community_id}</Td>
-                  <Td>
-                    <Badge tone={p.status === "posted" ? "green" : p.status === "queued" ? "amber" : p.status === "failed" ? "red" : "gray"}>{POST_STATUS[p.status]}</Badge>
-                    {p.last_error && <div className="mt-1 max-w-xs truncate text-xs text-red-600" title={p.last_error}>{p.last_error}</div>}
-                  </Td>
-                  <Td className="whitespace-nowrap">{fmt(p.posted_at)}</Td>
-                  <Td className="whitespace-nowrap">{fmt(p.last_read_at)}</Td>
-                  <Td align="right" className="tabular-nums">{p.comment_count}</Td>
-                  <Td align="right">
-                    {p.status === "posted" && (
-                      <SpinButton type="button" className={btn} loading={busy === p.id} onClick={(e) => { e.stopPropagation(); void readNow(p); }}>立即讀取</SpinButton>
-                    )}
-                  </Td>
-                </Tr>
-              );
-            })}
-          </TBody>
-        </Table>
-      </section>
-
-      {/* ── 選中貼文的留言 ── */}
-      {selected && (
-        <section className="space-y-3 rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
-          <div className="flex flex-wrap items-start justify-between gap-2">
-            <div>
-              <h2 className="text-base font-semibold">留言：{selected.group_buy_campaigns?.name}</h2>
-              <div className="text-sm text-zinc-500">{communityById.get(selected.community_id)?.home_name ?? ""}　發文 {fmt(selected.posted_at)}　最後讀取 {fmt(selected.last_read_at)}</div>
-            </div>
-            {summary && (
-              <div className="flex flex-wrap gap-1.5">
-                {summary.ordered > 0 && <Badge tone="green">已加單 {summary.ordered}</Badge>}
-                {summary.duplicate > 0 && <Badge tone="blue">已有訂單 {summary.duplicate}</Badge>}
-                {summary.pending > 0 && <Badge tone="amber">待處理 {summary.pending}</Badge>}
-                {summary.unmatched > 0 && <Badge tone="red">找不到會員 {summary.unmatched}</Badge>}
-                {summary.error > 0 && <Badge tone="red">錯誤 {summary.error}</Badge>}
-                {summary.resolved > 0 && <Badge tone="green">已解決 {summary.resolved}</Badge>}
-                {summary.no_order > 0 && <Badge tone="gray">非下單 {summary.no_order}</Badge>}
-                {summary.ignored > 0 && <Badge tone="gray">忽略 {summary.ignored}</Badge>}
-              </div>
-            )}
-          </div>
-          {selected.text && <details className="text-sm text-zinc-500"><summary className="cursor-pointer">貼文內容</summary><pre className="mt-1 whitespace-pre-wrap rounded bg-zinc-50 p-3 text-sm text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">{selected.text}</pre></details>}
-          <Table>
-            <THead><Th>時間</Th><Th>留言者</Th><Th>留言</Th><Th>結果</Th><Th align="right"></Th></THead>
-            <TBody>
-              {comments === null ? <LoadingRow colSpan={5} /> : comments.length === 0 ? <EmptyRow colSpan={5}>還沒讀到留言</EmptyRow> : comments.map((c) => (
-                <Tr key={c.id}>
-                  <Td className="whitespace-nowrap text-sm text-zinc-500">{fmt(c.commented_at)}</Td>
-                  <Td className="whitespace-nowrap">
-                    <div className="font-medium">{c.commenter_name ?? "—"}</div>
-                    {c.member_no_hint && <div className="font-mono text-xs text-zinc-500">會員 {c.member_no_hint}</div>}
-                  </Td>
-                  <Td className="max-w-md">
-                    <div className="whitespace-pre-wrap text-base">{c.text}</div>
-                    {c.parsed?.length > 0 && <div className="mt-1 flex flex-wrap gap-1">{parsedChips(c)}</div>}
-                  </Td>
-                  <Td className="max-w-xs">
-                    <div className="flex flex-wrap items-center gap-1.5">
-                      <Badge tone={commentTone(c.status)}>{COMMENT_STATUS[c.status]}</Badge>
-                      {c.customer_order_id && <span className="text-sm text-zinc-600 dark:text-zinc-300">訂單 #{c.customer_order_id}</span>}
-                    </div>
-                    {c.error && c.status !== "duplicate" && <div className="mt-1 text-sm text-red-700 dark:text-red-300">{c.error}</div>}
-                    {c.status === "no_order" && c.member_no_hint && <div className="mt-1 text-sm text-red-700 dark:text-red-300">{reasonOf(c)}</div>}
-                    {c.resolution_note && <div className="mt-1 text-sm text-zinc-500">處理：{c.resolution_note}</div>}
-                  </Td>
-                  <Td align="right">{todoActions(c)}</Td>
-                </Tr>
-              ))}
-            </TBody>
-          </Table>
-        </section>
-      )}
+                  {open === p.id && p.text && <pre className="mt-2 whitespace-pre-wrap rounded bg-zinc-50 p-3 text-sm text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">{p.text}</pre>}
+                </Td>
+                <Td className="whitespace-nowrap">{c?.home_name || c?.home_id || p.community_id}</Td>
+                <Td>
+                  <Badge tone={p.status === "posted" ? "green" : p.status === "queued" ? "amber" : p.status === "failed" ? "red" : "gray"}>{POST_STATUS[p.status]}</Badge>
+                  {p.last_error && <div className="mt-1 max-w-xs truncate text-xs text-red-600" title={p.last_error}>{p.last_error}</div>}
+                </Td>
+                <Td className="whitespace-nowrap">{fmt(p.posted_at)}</Td>
+                <Td className="whitespace-nowrap">{fmt(p.last_read_at)}</Td>
+                <Td align="right" className="tabular-nums">{p.comment_count}</Td>
+                <Td align="right">
+                  {p.status === "posted" && <SpinButton type="button" className={btn} loading={busy === p.id} onClick={() => readNow(p)}>立即讀取</SpinButton>}
+                </Td>
+              </Tr>
+            );
+          })}
+        </TBody>
+      </Table>
     </div>
   );
 }

--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -17,9 +17,9 @@ type Account = {
   qr_image: string | null; qr_url: string | null; pin_code: string | null;
   last_error: string | null; last_seen_at: string | null;
 };
-type Channel = { id: number; code: string; name: string; channel_type: string; home_store_id: number };
+type Store = { id: number; code: string; name: string };
 type Community = {
-  id: number; account_id: number; channel_id: number; home_id: string; home_name: string | null;
+  id: number; account_id: number; store_id: number | null; home_id: string; home_name: string | null;
   home_kind: "group" | "square" | "square_chat"; listen_enabled: boolean; read_times: string[];
   auto_post_on_open: boolean; post_template: string | null; read_days: number; last_read_at: string | null; last_error: string | null;
 };
@@ -78,7 +78,7 @@ const input = "w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-s
 export default function LineNotesPage() {
   const [tab, setTab] = useState<"accounts" | "communities" | "comments" | "posts">("accounts");
   const [accounts, setAccounts] = useState<Account[] | null>(null);
-  const [channels, setChannels] = useState<Channel[]>([]);
+  const [stores, setStores] = useState<Store[]>([]);
   const [communities, setCommunities] = useState<Community[] | null>(null);
   const [posts, setPosts] = useState<Post[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -95,10 +95,10 @@ export default function LineNotesPage() {
     const sb = getSupabase();
     const [c, ch] = await Promise.all([
       sb.from("line_note_communities").select("*").order("id"),
-      sb.from("line_channels").select("id,code,name,channel_type,home_store_id").eq("is_active", true).order("name"),
+      sb.from("stores").select("id,code,name").eq("is_active", true).order("name"),
     ]);
     if (c.error) fail(c.error); else setCommunities((c.data ?? []) as Community[]);
-    if (!ch.error) setChannels((ch.data ?? []) as Channel[]);
+    if (!ch.error) setStores((ch.data ?? []) as Store[]);
   }, [fail]);
   const loadPosts = useCallback(async () => {
     const { data, error } = await getSupabase()
@@ -118,7 +118,7 @@ export default function LineNotesPage() {
   }, [loadAccounts]);
 
   const accountById = useMemo(() => new Map((accounts ?? []).map((a) => [a.id, a])), [accounts]);
-  const channelById = useMemo(() => new Map(channels.map((c) => [c.id, c])), [channels]);
+  const storeById = useMemo(() => new Map(stores.map((s) => [s.id, s])), [stores]);
   const communityById = useMemo(() => new Map((communities ?? []).map((c) => [c.id, c])), [communities]);
 
   return (
@@ -154,8 +154,8 @@ export default function LineNotesPage() {
       )}
       {tab === "communities" && (
         <CommunitiesTab
-          communities={communities} accounts={accounts ?? []} channels={channels}
-          accountById={accountById} channelById={channelById}
+          communities={communities} accounts={accounts ?? []} stores={stores}
+          accountById={accountById} storeById={storeById}
           reload={loadCommunities} reloadPosts={loadPosts} notify={notify} fail={fail}
         />
       )}
@@ -275,17 +275,17 @@ function AccountsTab({ accounts, reload, notify, fail }: {
 
 // ── 社群設定 ─────────────────────────────────────────────────────────────────
 type CommunityForm = {
-  id: number | null; account_id: number | ""; channel_id: number | ""; home_id: string; home_name: string;
+  id: number | null; account_id: number | ""; store_id: number | ""; home_id: string; home_name: string;
   listen_enabled: boolean; read_times: string; auto_post_on_open: boolean; post_template: string; read_days: number;
 };
 const EMPTY_FORM: CommunityForm = {
-  id: null, account_id: "", channel_id: "", home_id: "", home_name: "",
+  id: null, account_id: "", store_id: "", home_id: "", home_name: "",
   listen_enabled: true, read_times: "12:00", auto_post_on_open: true, post_template: "", read_days: 3,
 };
 
-function CommunitiesTab({ communities, accounts, channels, accountById, channelById, reload, reloadPosts, notify, fail }: {
-  communities: Community[] | null; accounts: Account[]; channels: Channel[];
-  accountById: Map<number, Account>; channelById: Map<number, Channel>;
+function CommunitiesTab({ communities, accounts, stores, accountById, storeById, reload, reloadPosts, notify, fail }: {
+  communities: Community[] | null; accounts: Account[]; stores: Store[];
+  accountById: Map<number, Account>; storeById: Map<number, Store>;
   reload: () => Promise<void>; reloadPosts: () => Promise<void>; notify: (m: string) => void; fail: (e: unknown) => void;
 }) {
   const [form, setForm] = useState<CommunityForm | null>(null);
@@ -293,10 +293,10 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
   const [homes, setHomes] = useState<Home[] | null>(null);
   const [postFor, setPostFor] = useState<Community | null>(null);
 
-  const openNew = () => { setHomes(null); setForm({ ...EMPTY_FORM, account_id: accounts[0]?.id ?? "", channel_id: channels[0]?.id ?? "" }); };
+  const openNew = () => { setHomes(null); setForm({ ...EMPTY_FORM, account_id: accounts[0]?.id ?? "" }); };
   const openEdit = (c: Community) => {
     setHomes(null);
-    setForm({ id: c.id, account_id: c.account_id, channel_id: c.channel_id, home_id: c.home_id, home_name: c.home_name ?? "",
+    setForm({ id: c.id, account_id: c.account_id, store_id: c.store_id ?? "", home_id: c.home_id, home_name: c.home_name ?? "",
       listen_enabled: c.listen_enabled, read_times: c.read_times.join(", "), auto_post_on_open: c.auto_post_on_open, post_template: c.post_template ?? "", read_days: c.read_days ?? 3 });
   };
 
@@ -322,7 +322,7 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
     if (!form) return;
     setBusy("save");
     const { error } = await getSupabase().rpc("rpc_line_note_community_upsert", {
-      p_id: form.id, p_account_id: form.account_id || null, p_channel_id: form.channel_id || null,
+      p_id: form.id, p_account_id: form.account_id || null, p_store_id: form.store_id || null,
       p_home_id: form.home_id.trim(), p_home_name: form.home_name.trim() || null, p_home_kind: kindOf(form.home_id.trim()),
       p_listen_enabled: form.listen_enabled,
       p_read_times: form.read_times.split(/[,\s，、]+/).map((s) => s.trim()).filter(Boolean),
@@ -356,12 +356,12 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <p className="text-sm text-zinc-500">
-          「取貨門市」跟開團的 LINE 渠道共用（line_channels）：開團時有勾到這個渠道，才會自動發到這個社群；加單的取貨店也用渠道的主店。
+          總部開的團會發到所有開自動發文的社群；店家自開的團只發到標了那家店的社群。加單的取貨店一律跟會員自己設定的店。
         </p>
         <button type="button" className={btnPrimary} onClick={openNew} disabled={accounts.length === 0}>＋ 新增社群</button>
       </div>
       <Table>
-        <THead><Th>社群</Th><Th>帳號</Th><Th>渠道 / 取貨店</Th><Th>監聽</Th><Th>讀取時間</Th><Th>開團自動發文</Th><Th>最後讀取</Th><Th align="right">操作</Th></THead>
+        <THead><Th>社群</Th><Th>帳號</Th><Th>店家</Th><Th>監聽</Th><Th>讀取時間</Th><Th>開團自動發文</Th><Th>最後讀取</Th><Th align="right">操作</Th></THead>
         <TBody>
           {communities === null ? <LoadingRow colSpan={8} /> : communities.length === 0 ? <EmptyRow colSpan={8}>還沒有社群</EmptyRow> : communities.map((c) => {
             const a = accountById.get(c.account_id);
@@ -373,7 +373,7 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
                   {c.last_error && <div className="text-xs text-red-600">{c.last_error}</div>}
                 </Td>
                 <Td>{a ? <>{a.label} <Badge tone={a.status === "active" ? "green" : "red"}>{ACCOUNT_STATUS[a.status]}</Badge></> : "—"}</Td>
-                <Td>{channelById.get(c.channel_id)?.name ?? c.channel_id}</Td>
+                <Td>{c.store_id ? (storeById.get(c.store_id)?.name ?? c.store_id) : <span className="text-zinc-400">總部（全部）</span>}</Td>
                 <Td><Badge tone={c.listen_enabled ? "green" : "gray"}>{c.listen_enabled ? "監聽中" : "停用"}</Badge></Td>
                 <Td className="font-mono text-xs">{c.read_times.join(" ")}<div className="text-zinc-400">近 {c.read_days} 天</div></Td>
                 <Td>{c.auto_post_on_open ? "是" : "否"}</Td>
@@ -400,10 +400,12 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
                 {accounts.map((a) => <option key={a.id} value={a.id}>{a.label}（{ACCOUNT_STATUS[a.status]}）</option>)}
               </select>
             </label>
-            <label className="text-sm">渠道（決定取貨店）
-              <select className={input} value={form.channel_id} onChange={(e) => setForm({ ...form, channel_id: Number(e.target.value) })}>
-                {channels.map((ch) => <option key={ch.id} value={ch.id}>{ch.name}（{ch.code}）</option>)}
+            <label className="text-sm">店家（選填）
+              <select className={input} value={form.store_id} onChange={(e) => setForm({ ...form, store_id: e.target.value ? Number(e.target.value) : "" })}>
+                <option value="">總部社群（所有團都發）</option>
+                {stores.map((st) => <option key={st.id} value={st.id}>{st.name}</option>)}
               </select>
+              <span className="text-xs text-zinc-500">只影響店家自開的團要不要發到這裡；取貨店跟會員走，不看這個。</span>
             </label>
             <div className="text-sm md:col-span-2">
               <div className="flex items-end gap-2">

--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -66,6 +66,11 @@ function Badge({ tone, children }: { tone: "gray" | "green" | "amber" | "red" | 
   return <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${cls}`}>{children}</span>;
 }
 
+// Edge Function line-note-worker：排程每分鐘會自己跑；按了按鈕就順手叫一下，不用等下一分鐘
+function kickWorker(body: Record<string, unknown> = { action: "run" }) {
+  void getSupabase().functions.invoke("line-note-worker", { body }).catch(() => {});
+}
+
 const btn = "rounded border border-zinc-300 px-2.5 py-1 text-sm hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800";
 const btnPrimary = "rounded bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900";
 const input = "w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900";
@@ -123,7 +128,7 @@ export default function LineNotesPage() {
           <h1 className="text-xl font-semibold">LINE 記事本</h1>
           <p className="text-sm text-zinc-500">
             備用 LINE 帳號登入 → 綁社群 → 開團自動發文 → 定時讀留言，留言裡的「會員編號 6 碼 ＋ A+1」自動加單。
-            要有地端 worker 在跑（<code>tools/line-note-scraper</code>：<code>npm run worker</code>）。
+            排程每分鐘自動跑（Supabase），不用另外開程式。
           </p>
         </div>
         <nav className="flex gap-1 rounded-lg bg-zinc-100 p-1 dark:bg-zinc-800">
@@ -184,11 +189,19 @@ function AccountsTab({ accounts, reload, notify, fail }: {
   };
   const enqueue = async (a: Account, kind: "login" | "logout") => {
     setBusy(a.id);
+    if (kind === "login") {
+      // 登入要等人掃 QR，直接叫 Edge Function 跑（它會把 QR 寫進 DB，這邊輪詢帳號列顯示）
+      kickWorker({ action: "login", account_id: a.id });
+      setBusy(null);
+      setLoginId(a.id);
+      await reload();
+      return;
+    }
     const { error } = await getSupabase().rpc("rpc_line_note_enqueue", { p_kind: kind, p_account_id: a.id });
     setBusy(null);
     if (error) return fail(error);
-    if (kind === "login") setLoginId(a.id);
-    else notify("已送出登出");
+    kickWorker();
+    notify("已送出登出");
     await reload();
   };
   const remove = async (a: Account) => {
@@ -241,7 +254,7 @@ function AccountsTab({ accounts, reload, notify, fail }: {
           ) : loginAccount.status === "error" ? (
             <p className="whitespace-pre-wrap text-red-600">登入失敗：{loginAccount.last_error}</p>
           ) : !loginAccount.qr_image && !loginAccount.qr_url ? (
-            <p className="text-zinc-500">等待 worker 產生 QR…（worker 沒在跑的話會一直停在這裡）</p>
+            <p className="text-zinc-500">正在產生 QR…（約 5 秒）。QR 出現後 2 分鐘內要掃完，逾時再按一次登入。</p>
           ) : (
             <div className="space-y-3 text-center">
               {loginAccount.qr_image
@@ -294,13 +307,14 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
       const sb = getSupabase();
       const { data: jobId, error } = await sb.rpc("rpc_line_note_enqueue", { p_kind: "list_homes", p_account_id: form.account_id });
       if (error) throw error;
+      kickWorker();
       for (let i = 0; i < 40; i++) {
         await new Promise((r) => setTimeout(r, 1500));
         const { data } = await sb.from("line_note_jobs").select("status,result,error").eq("id", jobId).single();
         if (data?.status === "done") { setHomes(((data.result as { homes?: Home[] })?.homes) ?? []); return; }
         if (data?.status === "failed") throw new Error(data.error ?? "worker 回報失敗");
       }
-      throw new Error("等太久沒回應：worker 有在跑嗎？帳號登入了嗎？");
+      throw new Error("等太久沒回應：帳號登入了嗎？");
     } catch (e) { fail(e); } finally { setBusy(null); }
   };
 
@@ -334,7 +348,8 @@ function CommunitiesTab({ communities, accounts, channels, accountById, channelB
     const { error } = await getSupabase().rpc("rpc_line_note_enqueue", { p_kind: "read", p_account_id: c.account_id, p_community_id: c.id });
     setBusy(null);
     if (error) return fail(error);
-    notify("已排立即讀取，worker 跑完後到「貼文與留言」看");
+    kickWorker();
+    notify("已開始讀取，幾秒後到「留言加單」看");
   };
 
   return (
@@ -458,7 +473,8 @@ function PostCampaignModal({ community, onClose, notify, fail, reloadPosts }: {
     const { error } = await getSupabase().rpc("rpc_line_note_queue_post", { p_community_id: community.id, p_campaign_id: campaignId });
     setBusy(false);
     if (error) return fail(error);
-    notify("已排發文，worker 跑完後到「貼文與留言」看");
+    kickWorker();
+    notify("已開始發文，幾秒後到「貼文」看");
     onClose();
     await reloadPosts();
   };
@@ -625,7 +641,8 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
     const { error } = await getSupabase().rpc("rpc_line_note_enqueue", { p_kind: "read", p_account_id: c.account_id, p_community_id: c.id, p_post_id: p.id });
     setBusy(null);
     if (error) return fail(error);
-    notify("已排讀取，留言幾秒後會出現在「留言加單」");
+    kickWorker();
+    notify("已開始讀取，留言幾秒後會出現在「留言加單」");
   };
   return (
     <div className="space-y-3">

--- a/apps/admin/src/lib/orderSource.ts
+++ b/apps/admin/src/lib/orderSource.ts
@@ -36,6 +36,7 @@ export const ORDER_ITEM_SOURCES = [
   "store_internal",
   "aid_transfer",
   "walk_in",
+  "line_bot",
 ] as const;
 
 export type OrderItemSource = (typeof ORDER_ITEM_SOURCES)[number];
@@ -60,6 +61,8 @@ export const ORDER_SOURCE_META: Record<OrderItemSource, SourceMeta> = {
   store_internal:   { label: "店長叫貨", short: "店叫",   icon: "🏬", cls: "bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-300" },
   aid_transfer:     { label: "互助轉手", short: "互助",   icon: "🤝", cls: "bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-300" },
   walk_in:          { label: "現場銷售", short: "現場",   icon: "🛒", cls: "bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-300" },
+  // LINE 記事本機器人自動加單（20260909020000）。跟小幫手分開，才看得出哪些是人加的
+  line_bot:         { label: "機器人加單", short: "機器人", icon: "🤖", cls: "bg-fuchsia-100 text-fuchsia-800 dark:bg-fuchsia-950 dark:text-fuchsia-300" },
 };
 
 // 訂單頁「下單來源」折線圖 KPI 的線 —— 只放「人是怎麼下這張單的」三個通路，
@@ -72,6 +75,7 @@ export const SOURCE_TREND_SERIES: { source: OrderItemSource; label: string; colo
   { source: "pwa",    label: "App",    color: "rgb(59 130 246)" },  // blue-500（blue-600 在深色底上太暗）
   { source: "liff",   label: "商城",   color: "rgb(5 150 105)" },   // emerald-600
   { source: "manual", label: "小幫手", color: "rgb(124 58 237)" },  // violet-600
+  { source: "line_bot", label: "機器人", color: "rgb(192 38 211)" }, // fuchsia-600
 ];
 
 const MIXED_META: SourceMeta = {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -452,3 +452,8 @@ verify_jwt = false
 
 [functions.piaopiao-publisher-admin]
 verify_jwt = false
+
+# line-note-worker：pg_cron 每分鐘打（x-line-note-secret），後台按「登入」也直接呼叫
+# （函式內自行驗 secret 或使用者 JWT 的管理角色），所以 verify_jwt 關掉。
+[functions.line-note-worker]
+verify_jwt = false

--- a/supabase/functions/_shared/lineNote.ts
+++ b/supabase/functions/_shared/lineNote.ts
@@ -1,0 +1,382 @@
+// @ts-nocheck — JS 移植，不做型別檢查
+// ⚠ 這是 tools/line-note-scraper/src/line.mjs 的 Deno 版（Edge Function 用）。
+// 差異：linejs 走 jsr、不用檔案 storage（token 在 line_note_accounts.auth_token）、
+// 圖片只收 Uint8Array。REST 探測 / 解析 / 發文邏輯要跟 tools 那邊保持一致，改一邊記得改另一邊。
+//
+// 記事本不是 Thrift，是 LINE 內部的 JSON REST（myhome / square-note）：
+//   群組  GET https://<host>/mh/api/v57/post/list.json?homeId=<c…>&sourceType=TALKROOM
+//   社群  GET https://<host>/sn/api/v57/post/list.json?homeId=<m…或 s…>
+//   留言  GET …/comment/getList.json?homeId=&contentId=<postId>[&scrollId=]
+// 沒有 wire trace，所以 host / 路徑前綴 / channel 都做了候選清單，第一個回 code 0 的就記住。
+// ⚠ 不要改用 linejs 內建的 timeline.createPost/listPost —— 它把網址寫死成 legy.line-apps.com
+// （LEGY 加密閘道，不吃純 HTTPS JSON），直接 fetch failed。
+// deno-lint-ignore-file no-explicit-any
+
+import { loginWithAuthToken, loginWithQR } from "jsr:@evex/linejs@^3.4.2";
+import { MemoryStorage } from "jsr:@evex/linejs@^3.4.2/storage";
+
+export const DEFAULT_DEVICE = Deno.env.get("LINE_DEVICE") || "ANDROIDSECONDARY";
+
+const CHANNEL_IDS = {
+  HOME: "1341209850",
+  TIMELINE: "1341209950",
+  NOTE: "1655599932",
+  SQUARE_NOTE: "1657618623",
+};
+
+export function log(verbose: any, ...args: any[]) {
+  if (verbose) console.log("[line-notes]", ...args);
+}
+
+/** 用存在 DB 的 token 登入（每次 Edge Function 冷啟動都會做一次，只有一趟 getProfile） */
+export async function clientFromToken(authToken: string, device = DEFAULT_DEVICE): Promise<any> {
+  return await loginWithAuthToken(authToken, { device, storage: new MemoryStorage() });
+}
+
+/**
+ * 掃 QR 登入。QR 網址 / PIN 透過 callback 回報（寫進 DB 給後台顯示）。
+ * 有 deadline：Edge Function 有時限，掃太慢就放棄，帳號標 error 請使用者再按一次。
+ */
+export async function loginByQr(opts: {
+  onQr: (url: string) => Promise<void> | void;
+  onPin: (pin: string) => Promise<void> | void;
+  deadlineMs: number;
+  device?: string;
+}): Promise<any> {
+  const login = loginWithQR(
+    { onReceiveQRUrl: opts.onQr, onPincodeRequest: opts.onPin },
+    { device: opts.device ?? DEFAULT_DEVICE, storage: new MemoryStorage() },
+  );
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error("等太久沒掃 QR，請回後台再按一次「登入」")), opts.deadlineMs));
+  return await Promise.race([login, timeout]);
+}
+
+export function whoami(client: any) {
+  const p = client.base.profile ?? {};
+  return { mid: p.mid as string, displayName: p.displayName as string };
+}
+
+/** 加入中的群組（c…）、社群（s…）與社群聊天室（m…）。 */
+export async function listHomes(client: any, verbose = false) {
+  const homes: { kind: string; homeId: string; name: string; squareMid?: string }[] = [];
+  try {
+    const chats = await client.fetchJoinedChats();
+    for (const c of chats) {
+      const type = c.raw?.type;
+      if (type === "GROUP" || type === 0 || String(c.mid).startsWith("c")) {
+        homes.push({ kind: "group", homeId: c.mid, name: c.name ?? "" });
+      }
+    }
+  } catch (e) {
+    log(true, "fetchJoinedChats failed:", (e as any)?.message ?? e);
+  }
+  try {
+    const squares = await client.fetchJoinedSquares();
+    for (const s of squares) homes.push({ kind: "square", homeId: s.raw?.mid, name: s.raw?.name ?? "" });
+  } catch (e) {
+    log(true, "fetchJoinedSquares failed:", (e as any)?.message ?? e);
+  }
+  try {
+    const r = await client.base.square.getJoinedSquareChats({ request: { limit: 100, continuationToken: "" } });
+    for (const c of r?.chats ?? []) {
+      homes.push({ kind: "square_chat", homeId: c.squareChatMid, name: c.name ?? "", squareMid: c.squareMid });
+    }
+  } catch (e) {
+    log(verbose, "getJoinedSquareChats failed (可忽略，用 s… 的 id 也行):", (e as any)?.message ?? e);
+  }
+  return homes;
+}
+
+// ── 記事本 REST ────────────────────────────────────────────────────────────
+
+function prefixCandidates(homeId) {
+  const forced = Deno.env.get("LINE_NOTE_PREFIX");
+  if (forced) return [forced];
+  const first = String(homeId)[0];
+  if (first === "s" || first === "m") return ["/sn", "/mh", "/ext/note/nt"];
+  return ["/mh", "/ext/note/nt"];
+}
+
+function hostCandidates(client) {
+  const forced = Deno.env.get("LINE_NOTE_HOST");
+  if (forced) return [forced];
+  const ep = client.base.request?.endpoint;
+  return [...new Set([ep, "gw.line.naver.jp", "ga2.line.naver.jp"].filter(Boolean))];
+}
+
+function channelCandidates(homeId) {
+  const forced = Deno.env.get("LINE_NOTE_CHANNEL");
+  if (forced) return [forced];
+  const first = String(homeId)[0];
+  return first === "s" || first === "m"
+    ? [CHANNEL_IDS.SQUARE_NOTE, CHANNEL_IDS.HOME, CHANNEL_IDS.TIMELINE, CHANNEL_IDS.NOTE]
+    : [CHANNEL_IDS.HOME, CHANNEL_IDS.NOTE, CHANNEL_IDS.TIMELINE, CHANNEL_IDS.SQUARE_NOTE];
+}
+
+const tokenCache = new Map();
+async function channelToken(client, channelId, verbose) {
+  if (tokenCache.has(channelId)) return tokenCache.get(channelId);
+  let token;
+  try {
+    const r = await client.base.channel.approveChannelAndIssueChannelToken({ channelId });
+    token = r?.channelAccessToken ?? r?.token;
+  } catch (e) {
+    log(verbose, `approveChannelAndIssueChannelToken(${channelId}) failed:`, e?.message ?? e);
+  }
+  if (!token) {
+    const r = await client.base.channel.issueChannelToken({ channelId });
+    token = r?.token ?? r?.channelAccessToken;
+  }
+  if (!token) throw new Error(`no channel token for ${channelId}`);
+  tokenCache.set(channelId, token);
+  return token;
+}
+
+function baseHeaders(client, token) {
+  return {
+    accept: "application/json",
+    "content-type": "application/json",
+    "user-agent": client.base.request.userAgent,
+    "x-line-application": client.base.request.systemType,
+    "x-line-mid": client.base.profile?.mid ?? "",
+    "x-line-access": client.base.authToken,
+    "x-line-channeltoken": token,
+    "x-lal": Deno.env.get("LINE_LANG") || "zh-Hant_TW",
+    "x-lsr": Deno.env.get("LINE_REGION") || "TW",
+    "x-lpv": "1",
+    "x-lhm": "GET",
+    "x-line-bdbtemplateversion": "v1",
+    "x-line-global-config": "discover.enable=true; follow.enable=true",
+  };
+}
+
+// 記住第一個打通的組合，之後同一個 homeId 直接用。
+const routeCache = new Map();
+
+/**
+ * 對記事本 REST 打一次請求。回 { code, message, result }。
+ * 會依序試 host × prefix × channel，直到有一組回 code 0，然後記住那組。
+ *
+ * ⚠ 不要改用 linejs 內建的 timeline.createPost/listPost —— 它把網址寫死成
+ * `https://${client.request.endpoint}/…`，而 endpoint 預設是 legy.line-apps.com
+ * （LEGY 加密閘道，不吃這種純 HTTPS JSON），直接丟 `fetch failed`。
+ */
+export async function noteRequest(client, homeId, path, params, { method = "GET", body, verbose = false } = {}) {
+  const qs = new URLSearchParams(Object.fromEntries(Object.entries(params ?? {}).filter(([, v]) => v !== undefined && v !== null && v !== "")));
+  const tryOne = async (host, prefix, channelId) => {
+    const token = await channelToken(client, channelId, verbose);
+    const url = `https://${host}${prefix}${path}?${qs}`;
+    const res = await client.base.fetch(url, {
+      method,
+      headers: { ...baseHeaders(client, token), "x-lhm": method },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    const text = await res.text();
+    // ⚠ 不要叫 body —— 外層參數就叫 body，同一個 scope 會 TDZ 炸掉
+    let json;
+    try { json = JSON.parse(text); } catch { json = { code: res.status, message: text.slice(0, 200), result: null }; }
+    log(verbose, `${res.status} ${url} ch=${channelId} → code=${json?.code} ${json?.message ?? ""}`);
+    return { httpStatus: res.status, body: json };
+  };
+
+  const cached = routeCache.get(homeId);
+  if (cached) {
+    const { body } = await tryOne(cached.host, cached.prefix, cached.channelId);
+    return body;
+  }
+  const attempts = [];
+  for (const host of hostCandidates(client)) {
+    for (const prefix of prefixCandidates(homeId)) {
+      for (const channelId of channelCandidates(homeId)) {
+        try {
+          const { httpStatus, body } = await tryOne(host, prefix, channelId);
+          if (body && body.code === 0) {
+            routeCache.set(homeId, { host, prefix, channelId });
+            log(verbose, `route ok: host=${host} prefix=${prefix} channel=${channelId}`);
+            return body;
+          }
+          attempts.push(`${httpStatus} ${host}${prefix}${path} ch=${channelId} code=${body?.code} ${body?.message ?? ""}`);
+        } catch (e) {
+          attempts.push(`ERR ${host}${prefix}${path} ch=${channelId}: ${e?.message ?? e}`);
+        }
+      }
+    }
+  }
+  throw new Error(`記事本 API 全部打不通（homeId=${homeId}）。把下面這段貼回來：\n` + attempts.join("\n"));
+}
+
+/** GET 版（大部分呼叫點用這支） */
+export async function noteGet(client, homeId, path, params, verbose = false) {
+  return await noteRequest(client, homeId, path, params, { method: "GET", verbose });
+}
+
+// ── 回應解析（結構沒 wire trace，寫成寬鬆版；raw 一律保留） ──────────────
+
+function pick(obj, ...paths) {
+  for (const p of paths) {
+    const v = p.split(".").reduce((o, k) => (o == null ? undefined : o[k]), obj);
+    if (v !== undefined && v !== null && v !== "") return v;
+  }
+  return undefined;
+}
+
+function toIso(ms) {
+  const n = Number(ms);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return new Date(n < 1e12 ? n * 1000 : n).toISOString();
+}
+
+export function normalizePost(p, homeId) {
+  const post = p?.post ?? p; // feeds[] 會包一層 { post: {...} }
+  return {
+    homeId,
+    postId: pick(post, "id", "postInfo.postId", "postId"),
+    authorMid: pick(post, "userInfo.mid", "userInfo.writerMid", "postInfo.userInfo.mid", "actorId"),
+    authorName: pick(post, "userInfo.nickname", "userInfo.displayName", "postInfo.userInfo.nickname"),
+    createdAt: toIso(pick(post, "postInfo.createdTime", "createdTime")),
+    updatedAt: toIso(pick(post, "postInfo.updatedTime", "updatedTime")),
+    text: pick(post, "contents.text", "contents.textMeta.text", "text") ?? "",
+    commentCount: Number(pick(post, "postInfo.commentCount", "commentCount") ?? 0),
+    likeCount: Number(pick(post, "postInfo.likeCount", "likeCount") ?? 0),
+    raw: post,
+  };
+}
+
+export function normalizeComment(c, homeId, postId) {
+  return {
+    homeId,
+    postId,
+    commentId: pick(c, "id", "commentId"),
+    authorMid: pick(c, "userInfo.mid", "userInfo.writerMid", "actorId", "mid"),
+    authorName: pick(c, "userInfo.nickname", "userInfo.displayName", "nickname"),
+    createdAt: toIso(pick(c, "createdTime", "postInfo.createdTime")),
+    text: pick(c, "commentText", "text", "contents.text") ?? "",
+    raw: c,
+  };
+}
+
+function extractPosts(result) {
+  if (!result) return [];
+  if (Array.isArray(result.posts)) return result.posts;
+  if (Array.isArray(result.feeds)) return result.feeds;
+  if (Array.isArray(result)) return result;
+  return [];
+}
+
+function extractComments(result) {
+  if (!result) return [];
+  if (Array.isArray(result.comments)) return result.comments;
+  if (Array.isArray(result.commentList)) return result.commentList;
+  if (Array.isArray(result)) return result;
+  return [];
+}
+
+/** 列貼文，自動翻頁（用最後一篇的 postId + updatedTime 當游標）。 */
+export async function listPosts(client, homeId, { limit = 200, since = null, verbose = false, onRaw } = {}) {
+  const out = [];
+  let postId, updatedTime;
+  const sinceMs = since ? new Date(since).getTime() : null;
+  for (let page = 0; page < 50 && out.length < limit; page++) {
+    const body = await noteGet(client, homeId, "/api/v57/post/list.json", {
+      homeId, sourceType: "TALKROOM", likeLimit: "0", commentLimit: "0", postId, updatedTime,
+    }, verbose);
+    onRaw?.(body);
+    const posts = extractPosts(body.result).map((p) => normalizePost(p, homeId));
+    if (posts.length === 0) break;
+    let stop = false;
+    for (const p of posts) {
+      if (out.some((x) => x.postId === p.postId)) { stop = true; break; }
+      if (sinceMs && p.createdAt && new Date(p.createdAt).getTime() < sinceMs) { stop = true; break; }
+      out.push(p);
+    }
+    if (stop) break;
+    const last = posts[posts.length - 1];
+    postId = last.postId;
+    updatedTime = pick(last.raw, "postInfo.updatedTime", "updatedTime");
+    if (!postId || !updatedTime) break;
+  }
+  return out.slice(0, limit);
+}
+
+/** 列一篇貼文的全部留言，用 scrollId 翻頁。 */
+export async function listComments(client, homeId, postId, { verbose = false, onRaw } = {}) {
+  const out = [];
+  let scrollId;
+  for (let page = 0; page < 200; page++) {
+    const body = await noteGet(client, homeId, "/api/v57/comment/getList.json", {
+      homeId, contentId: postId, limit: "50", scrollId,
+    }, verbose);
+    onRaw?.(body);
+    const comments = extractComments(body.result).map((c) => normalizeComment(c, homeId, postId));
+    if (comments.length === 0) break;
+    let added = 0;
+    for (const c of comments) {
+      if (out.some((x) => x.commentId === c.commentId)) continue;
+      out.push(c);
+      added++;
+    }
+    const next = pick(body.result, "scrollId", "nextScrollId", "cursor", "nextCursor");
+    if (!next || next === scrollId || added === 0) break;
+    scrollId = next;
+  }
+  return out;
+}
+
+// ── 發文 ───────────────────────────────────────────────────────────────────
+
+/**
+ * 在記事本發一篇貼文（文字 + 可選圖片）。走 linejs 內建的 createPost：
+ * 群組 → /mh/api/v57/post/create.json、社群（s…）→ /sn/…，
+ * 圖片先上傳到 obs（myhome/h）拿 objId 再掛進 contents.media。
+ * @param {object} opts
+ * @param {string} opts.text
+ * @param {Uint8Array[]} [opts.images]  JPEG bytes（上傳時 content-type 固定 image/jpeg）
+ */
+export async function createNotePost(client, homeId, { text, images = [], sourceType, verbose = false } = {}) {
+  if (!text && images.length === 0) throw new Error("貼文至少要有文字或圖片");
+
+  // 圖片上傳走 obs.line-apps.com（linejs 的 uploadNoteMedia），失敗就只發文字，
+  // 不要讓整篇貼文因為一張圖掛掉。
+  const media = [];
+  for (const file of images) {
+    try {
+      const { objId } = await client.base.timeline.uploadNoteMedia("image", new Blob([file], { type: "image/jpeg" }));
+      media.push({ objectId: objId, type: "PHOTO", obsFace: "[]" });
+      log(verbose, `uploaded <${file.byteLength} bytes> → ${objId}`);
+    } catch (e) {
+      log(true, `圖片上傳失敗，這張跳過：${e?.message ?? e}`);
+    }
+  }
+
+  // 先打一次 list 把路由（host/prefix/channel）探出來並記住，create 才不會在探路
+  // 的過程中對不同前綴各發一篇（重複貼文）。
+  try {
+    await noteGet(client, homeId, "/api/v57/post/list.json",
+      { homeId, sourceType: sourceType ?? "TALKROOM", likeLimit: "0", commentLimit: "0" }, verbose);
+  } catch (e) {
+    log(verbose, "探路用的 list 失敗（照樣試發文）:", e?.message ?? e);
+  }
+
+  const body = {
+    postInfo: { readPermission: { type: "ALL", gids: [] } },
+    contents: {
+      contentsStyle: {
+        textStyle: { textSizeMode: "AUTO", backgroundColor: "", textAnimation: "NONE" },
+        mediaStyle: { displayType: "GRID_1_A" },
+      },
+      stickers: [],
+      locations: [],
+      media,
+      ...(text ? { text } : {}),
+    },
+  };
+  const res = await noteRequest(client, homeId, "/api/v57/post/create.json",
+    { homeId, sourceType: sourceType ?? "TALKROOM" }, { method: "POST", body, verbose });
+  log(verbose, "createPost →", JSON.stringify(res).slice(0, 500));
+  if (!res || res.code !== 0) {
+    throw new Error(`發文失敗：code=${res?.code} ${res?.message ?? ""}\n${JSON.stringify(res).slice(0, 800)}`);
+  }
+  return normalizePost(res.result?.post ?? res.result, homeId);
+}
+

--- a/supabase/functions/_shared/lineNoteParse.ts
+++ b/supabase/functions/_shared/lineNoteParse.ts
@@ -1,0 +1,123 @@
+// @ts-nocheck — JS 移植，不做型別檢查
+// ⚠ 這是 tools/line-note-scraper/src/parse.mjs 的複本（Edge Function 只能 bundle supabase/functions 底下的檔案）。
+// 改規則時兩邊一起改；tools 那邊有單元測試（npm test）。
+// deno-lint-ignore-file no-explicit-any
+
+// 記事本留言 → 「+1」訂單行的解析器。純函式、無相依，方便測試。
+//
+// 支援的寫法（每一行各自解析，一則留言可以有多筆）：
+//   +1            → qty 1
+//   ＋２ / + 3     → 全形、空白都吃
+//   A+1 / A +2    → code A, qty
+//   A1+1 / B-2+1  → code 可含數字、連字號（品項編號）
+//   +1 A          → qty 在前、code 在後
+//   A x2 / A*2 / A×2 / A２個 / A 2份 → code + 數量
+//   2份 / 3組 / 1個（沒 code）→ qty
+//   -1 / A-1 / 取消 / 退 → cancel:true（qty 為負或標記）
+//
+// 不猜的：純數字「2」、只有品名沒數量的行、聊天內容。這些回空陣列。
+
+const FULLWIDTH_DIGITS = "０１２３４５６７８９";
+
+export function normalize(text) {
+  return String(text ?? "")
+    .replace(/[０-９]/g, (ch) => String(FULLWIDTH_DIGITS.indexOf(ch)))
+    .replace(/[＋]/g, "+")
+    .replace(/[－—–]/g, "-")
+    .replace(/[×Ｘｘ＊]/g, "x")
+    .replace(/[　]/g, " ")
+    .replace(/[：]/g, ":");
+}
+
+const UNIT = "(?:份|個|组|組|包|盒|箱|瓶|罐|袋|條|片|支|入|件|套|杯|顆|粒|斤|台|本)?";
+// 品項代碼：英文字母開頭，可接數字／連字號（A、B2、C-1、AB）
+const CODE = "([A-Za-z][A-Za-z0-9-]{0,7})";
+const CANCEL_WORDS = /(取消|退|刪|删|不要了|改為0|改成0)/;
+
+const MULTI_CODE_FIRST = /^\s*(?:[A-Za-z][A-Za-z0-9-]{0,7}\s*[+-]\s*\d{1,3}\s*){2,}$/;
+const MULTI_QTY_FIRST = /^\s*(?:[+-]\s*\d{1,3}\s*[A-Za-z][A-Za-z0-9-]{0,7}\s*){2,}$/;
+const TOKEN_CODE_FIRST = /[A-Za-z][A-Za-z0-9-]{0,7}\s*[+-]\s*\d{1,3}/g;
+const TOKEN_QTY_FIRST = /[+-]\s*\d{1,3}\s*[A-Za-z][A-Za-z0-9-]{0,7}/g;
+
+const PATTERNS = [
+  // A+1 / A +2 / B-2+1 / 取消 A-1
+  { re: new RegExp(`^\\s*${CODE}\\s*([+-])\\s*(\\d{1,3})${UNIT}\\s*$`), map: (m) => ({ code: m[1], sign: m[2], qty: m[3] }) },
+  // +1 A / +2 B2
+  { re: new RegExp(`^\\s*([+-])\\s*(\\d{1,3})${UNIT}\\s*${CODE}\\s*$`), map: (m) => ({ code: m[3], sign: m[1], qty: m[2] }) },
+  // +1 / + 3
+  { re: new RegExp(`^\\s*([+-])\\s*(\\d{1,3})${UNIT}\\s*$`), map: (m) => ({ code: null, sign: m[1], qty: m[2] }) },
+  // A x2 / A*2 / A 2份 / A2份（要有單位或 x，避免把 A2 品號當成 A×2）
+  { re: new RegExp(`^\\s*${CODE}\\s*(?:x\\s*(\\d{1,3})${UNIT}|(\\d{1,3})(?:份|個|组|組|包|盒|箱|瓶|罐|袋|條|片|支|件|套|杯|顆|粒|斤|台|本))\\s*$`), map: (m) => ({ code: m[1], sign: "+", qty: m[2] ?? m[3] }) },
+  // 2份 / 3組（沒 code，但有單位）
+  { re: /^\s*(\d{1,3})(?:份|個|组|組|包|盒|箱|瓶|罐|袋|條|片|支|件|套|杯|顆|粒|斤|台|本)\s*$/, map: (m) => ({ code: null, sign: "+", qty: m[1] }) },
+];
+
+/**
+ * @param {string} text 留言原文
+ * @returns {{code:string|null, qty:number, cancel:boolean, line:string}[]}
+ */
+export function parseOrderLines(text) {
+  const out = [];
+  const norm = normalize(text);
+  const segments = [];
+  for (const rawLine of norm.split(/\r?\n|[,，;；、/]/)) {
+    // 同一行寫多筆：整行都是「代碼+號+數」重複（A+1 B+5）或「號+數+代碼」重複（+1 A +2 B）才拆，
+    // 其他（B-2 +1 這種代碼帶連字號的）交給下面的單筆規則
+    if (MULTI_CODE_FIRST.test(rawLine)) segments.push(...(rawLine.match(TOKEN_CODE_FIRST) ?? []));
+    else if (MULTI_QTY_FIRST.test(rawLine)) segments.push(...(rawLine.match(TOKEN_QTY_FIRST) ?? []));
+    else segments.push(rawLine);
+  }
+  for (const rawLine of segments) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const cancelWord = CANCEL_WORDS.test(line);
+    // 把「取消」「退」這類字先拿掉再比對數量
+    const body = line.replace(CANCEL_WORDS, " ").trim();
+    let hit = null;
+    for (const p of PATTERNS) {
+      const m = body.match(p.re);
+      if (m) { hit = p.map(m); break; }
+    }
+    if (!hit) {
+      // 「取消」單獨一行也算一筆取消（qty 0，讓人工看）
+      if (cancelWord && body === "") out.push({ code: null, qty: 0, cancel: true, line });
+      continue;
+    }
+    const qty = Number(hit.qty);
+    if (!Number.isFinite(qty) || qty <= 0) continue;
+    const cancel = cancelWord || hit.sign === "-";
+    out.push({ code: hit.code ? hit.code.toUpperCase() : null, qty, cancel, line });
+  }
+  return out;
+}
+
+/**
+ * 從留言抓「6 碼會員編號」（members.member_no = 'M' + 6 碼）。
+ * 只認獨立的 6 位數（前後不是數字），所以手機號碼（10 碼）、A1 這種品號都不會誤抓；
+ * 允許寫成 M123456。回 { hint, rest }，rest 是把編號拿掉後的文字（拿去解析 +1）。
+ */
+export function extractMemberNo(text) {
+  const norm = normalize(text);
+  const m = norm.match(/(?<![0-9])[Mm]?([0-9]{6})(?![0-9])/);
+  if (!m) return { hint: null, rest: norm };
+  const rest = (norm.slice(0, m.index) + " " + norm.slice(m.index + m[0].length)).trim();
+  return { hint: m[1], rest };
+}
+
+/**
+ * 留言 → { memberNo, memberNoSource, orders[] }，給 worker 落地用。
+ * 6 碼先從留言內文找；沒有就看留言者的暱稱（很多社群規定暱稱要帶會員編號：
+ * 「涂003886」「Sherry061016/松山」「Ting/616582松山」）。
+ */
+export function parseNoteComment(text, authorName = "") {
+  const { hint, rest } = extractMemberNo(text);
+  if (hint) return { memberNo: hint, memberNoSource: "text", orders: parseOrderLines(rest) };
+  const fromName = extractMemberNo(authorName).hint;
+  return { memberNo: fromName, memberNoSource: fromName ? "name" : null, orders: parseOrderLines(rest) };
+}
+
+/** 貼文標題：取第一個非空白行，最多 60 字 */
+export function postTitle(text) {
+  const first = String(text ?? "").split(/\r?\n/).map((s) => s.trim()).find(Boolean) ?? "";
+  return first.length > 60 ? first.slice(0, 60) + "…" : first;
+}

--- a/supabase/functions/line-note-worker/index.ts
+++ b/supabase/functions/line-note-worker/index.ts
@@ -1,0 +1,425 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Edge Function: line-note-worker
+//
+// LINE 記事本整合的「worker」，排程版。取代 tools/line-note-scraper/src/worker.mjs
+// 那支要一直開著的程序 —— 每個工作都只是幾秒鐘的事，不需要常駐。
+//
+//   { action: "tick" }                 pg_cron 每分鐘打一次（header x-line-note-secret）
+//                                      → 到 read_times 就排 read；撿 line_note_jobs 裡
+//                                        queued 的工作跑（logout / list_homes / post / read）
+//   { action: "login", account_id }    後台按「登入」直接呼叫（Authorization: 使用者 JWT）
+//                                      → 掃 QR，QR 圖 / PIN 寫進 line_note_accounts 給後台顯示，
+//                                        掃完把 token 存進 DB，之後 tick 都用那把 token
+//   { action: "run" }                  後台按「立即讀取／發文」後順手叫一下，不用等下一分鐘
+//
+// token 失效（帳號 error）→ 後台再按一次登入就好。
+//
+// 跟 worker.mjs 的差異：
+//   - 沒有檔案 storage，token 只在 DB
+//   - 沒有 sharp：圖片只帶原本就是 JPEG 的（PNG / WebP 略過）
+//   - 有時間預算：tick 跑到 ~100 秒就停，剩下的下一分鐘再撿（Edge Function 有 wall-clock 上限）
+// ─────────────────────────────────────────────────────────────────────────────
+// deno-lint-ignore-file no-explicit-any
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.8";
+import QRCode from "npm:qrcode@1.5.4";
+import { corsHeaders } from "../_shared/cors.ts";
+import {
+  clientFromToken, createNotePost, listComments, listHomes, listPosts, loginByQr, whoami,
+} from "../_shared/lineNote.ts";
+import { parseNoteComment, postTitle } from "../_shared/lineNoteParse.ts";
+
+const SUPABASE_URL = requireEnv("SUPABASE_URL");
+const SERVICE_KEY = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+const CRON_SECRET = Deno.env.get("LINE_NOTE_CRON_SECRET") ?? "";
+const VERBOSE = !!Deno.env.get("VERBOSE");
+const TZ = "Asia/Taipei";
+const TICK_BUDGET_MS = Number(Deno.env.get("LINE_NOTE_TICK_BUDGET_MS") || 100_000);
+const LOGIN_DEADLINE_MS = Number(Deno.env.get("LINE_NOTE_LOGIN_DEADLINE_MS") || 110_000);
+const MAX_POST_IMAGES = Number(Deno.env.get("LINE_POST_MAX_IMAGES") || 10);
+const PRODUCTS_BUCKET = Deno.env.get("PRODUCTS_BUCKET") || "products";
+
+const log = (...a: any[]) => console.log(new Date().toISOString(), ...a);
+
+// ── PostgREST（service_role，跟 worker.mjs 同一套 helper，方便對照） ────────
+async function rest(pathAndQuery: string, opts: { method?: string; body?: unknown; prefer?: string } = {}) {
+  const method = opts.method ?? "GET";
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${pathAndQuery}`, {
+    method,
+    headers: {
+      apikey: SERVICE_KEY,
+      Authorization: `Bearer ${SERVICE_KEY}`,
+      "Content-Type": "application/json",
+      Prefer: opts.prefer ?? (method === "GET" ? "" : "return=representation"),
+    },
+    body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`${method} ${pathAndQuery} → ${res.status} ${text.slice(0, 300)}`);
+  return text ? JSON.parse(text) : null;
+}
+const rpc = (name: string, args: unknown) => rest(`rpc/${name}`, { method: "POST", body: args, prefer: "" });
+const patch = (table: string, filter: string, body: unknown) => rest(`${table}?${filter}`, { method: "PATCH", body });
+
+// ── LINE client（一次 invocation 內快取；token 在 DB） ─────────────────────
+const clients = new Map<number, any>();
+async function loadAccount(id: number) {
+  const rows = await rest(`line_note_accounts?id=eq.${id}&select=*`);
+  if (!rows?.[0]) throw new Error(`account ${id} not found`);
+  return rows[0];
+}
+async function clientFor(account: any) {
+  if (clients.has(account.id)) return clients.get(account.id);
+  if (!account.auth_token) throw new Error(`帳號「${account.label}」還沒登入`);
+  const client = await clientFromToken(account.auth_token);
+  client.base.on("update:authtoken", (t: string) =>
+    patch("line_note_accounts", `id=eq.${account.id}`, { auth_token: t }).catch(() => {}));
+  clients.set(account.id, client);
+  return client;
+}
+
+// ── 登入（後台按鈕直接呼叫） ────────────────────────────────────────────────
+async function doLogin(accountId: number) {
+  const account = await loadAccount(accountId);
+  await patch("line_note_accounts", `id=eq.${accountId}`, {
+    status: "pending_qr", qr_image: null, qr_url: null, pin_code: null, last_error: null,
+  });
+  const job = (await rest("line_note_jobs", {
+    method: "POST",
+    body: { tenant_id: account.tenant_id, kind: "login", account_id: accountId, status: "running", started_at: new Date().toISOString() },
+  }))?.[0];
+  try {
+    const client = await loginByQr({
+      deadlineMs: LOGIN_DEADLINE_MS,
+      async onQr(url) {
+        let qr_image: string | null = null;
+        try { qr_image = await QRCode.toDataURL(url, { width: 320, margin: 1 }); } catch (e) { log("qrcode 產圖失敗:", (e as any)?.message ?? e); }
+        await patch("line_note_accounts", `id=eq.${accountId}`, { status: "pending_qr", qr_url: url, qr_image, pin_code: null });
+        log(`[login ${account.label}] QR 已送到後台`);
+      },
+      async onPin(pin) {
+        await patch("line_note_accounts", `id=eq.${accountId}`, { pin_code: pin });
+      },
+    });
+    const me = whoami(client);
+    await patch("line_note_accounts", `id=eq.${accountId}`, {
+      status: "active", auth_token: client.base.authToken, line_mid: me.mid, display_name: me.displayName,
+      qr_image: null, qr_url: null, pin_code: null, last_error: null, last_seen_at: new Date().toISOString(),
+    });
+    if (job) await patch("line_note_jobs", `id=eq.${job.id}`, { status: "done", result: me, finished_at: new Date().toISOString() });
+    return { ok: true, ...me };
+  } catch (e) {
+    const msg = String((e as any)?.message ?? e);
+    await patch("line_note_accounts", `id=eq.${accountId}`, { status: "error", last_error: msg.slice(0, 1000), qr_image: null, qr_url: null, pin_code: null });
+    if (job) await patch("line_note_jobs", `id=eq.${job.id}`, { status: "failed", error: msg.slice(0, 2000), finished_at: new Date().toISOString() });
+    return { ok: false, error: msg };
+  }
+}
+
+// ── 工作 ────────────────────────────────────────────────────────────────────
+async function jobLogout(job: any) {
+  const account = await loadAccount(job.account_id);
+  const client = clients.get(account.id) ?? (account.auth_token ? await clientFor(account).catch(() => null) : null);
+  if (client) { try { await client.base.auth.logoutZ(); } catch { /* token 可能早就失效，略過 */ } }
+  clients.delete(account.id);
+  await patch("line_note_accounts", `id=eq.${account.id}`, {
+    status: "logged_out", auth_token: null, qr_image: null, qr_url: null, pin_code: null, last_error: null,
+  });
+  return { ok: true };
+}
+
+async function jobListHomes(job: any) {
+  const account = await loadAccount(job.account_id);
+  const client = await clientFor(account);
+  return { homes: await listHomes(client, VERBOSE) };
+}
+
+const DEFAULT_TEMPLATE = `📣 {{name}}
+{{description}}
+
+{{items}}
+
+⏰ 收單：{{end_at}}
+📝 下單方式：留言「會員編號 6 碼 ＋ 品項代碼＋數量」
+　例：123456 A+1 B+2`;
+
+function fmtTaipei(iso: string | null | undefined) {
+  if (!iso) return "";
+  const p = new Intl.DateTimeFormat("zh-TW", { timeZone: TZ, month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: false }).formatToParts(new Date(iso));
+  const g = (t: string) => p.find((x) => x.type === t)?.value ?? "";
+  return `${g("month")}/${g("day")} ${g("hour")}:${g("minute")}`;
+}
+
+export function renderTemplate(template: string | null, payload: any) {
+  const c = payload.campaign ?? {};
+  const items = (payload.items ?? []).map((it: any) => `${it.code}. ${it.name}${it.unit_price == null ? "" : ` $${Number(it.unit_price)}`}`).join("\n");
+  return (template || DEFAULT_TEMPLATE)
+    .replaceAll("{{name}}", c.name ?? "")
+    .replaceAll("{{campaign_no}}", c.campaign_no ?? "")
+    .replaceAll("{{description}}", c.description ?? "")
+    .replaceAll("{{items}}", items)
+    .replaceAll("{{end_at}}", fmtTaipei(c.end_at))
+    .replaceAll("{{start_at}}", fmtTaipei(c.start_at))
+    .replaceAll("{{pickup_deadline}}", fmtTaipei(c.pickup_deadline))
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function resolveImageUrl(p: unknown): string | null {
+  if (!p || typeof p !== "string") return null;
+  if (/^https?:\/\//i.test(p)) return p;
+  return `${SUPABASE_URL}/storage/v1/object/public/${PRODUCTS_BUCKET}/${p.replace(/^\/+/, "")}`;
+}
+
+// 沒有 sharp：只帶原本就是 JPEG 的圖（PNG / WebP 略過並記 log）
+async function collectPostImages(payload: any): Promise<Uint8Array[]> {
+  if (Deno.env.get("LINE_POST_NO_IMAGE")) return [];
+  const urls: string[] = [];
+  const push = (u: unknown) => { const r = resolveImageUrl(u); if (r && !urls.includes(r)) urls.push(r); };
+  push(payload.campaign?.cover_image_url);
+  for (const it of payload.items ?? []) for (const img of it.images ?? []) push(img);
+  const out: Uint8Array[] = [];
+  for (const url of urls.slice(0, MAX_POST_IMAGES)) {
+    try {
+      const r = await fetch(url);
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const ct = r.headers.get("content-type") ?? "";
+      if (!/image\/jpe?g/i.test(ct) && !/\.jpe?g(\?|$)/i.test(url)) { log(`圖片不是 JPEG（${ct}），略過：${url}`); continue; }
+      out.push(new Uint8Array(await r.arrayBuffer()));
+    } catch (e) {
+      log(`圖片略過 ${url}：${(e as any)?.message ?? e}`);
+    }
+  }
+  return out;
+}
+
+async function jobPost(job: any) {
+  const cur = await rest(`line_note_posts?id=eq.${job.post_id}&select=status,line_post_id`);
+  if (cur?.[0]?.status === "posted") return { skipped: "already posted", postId: cur[0].line_post_id };
+  const payload = await rpc("rpc_line_note_post_payload", { p_post_id: job.post_id });
+  if (!payload) throw new Error(`post ${job.post_id} not found`);
+  const account = await loadAccount(payload.account_id);
+  const client = await clientFor(account);
+  const text = renderTemplate(payload.post_template, payload);
+  const images = await collectPostImages(payload);
+  try {
+    const post = await createNotePost(client, payload.home_id, { text, images, verbose: VERBOSE });
+    await patch("line_note_posts", `id=eq.${job.post_id}`, {
+      status: "posted", line_post_id: post.postId ?? null, text, posted_at: new Date().toISOString(), last_error: null,
+    });
+    return { postId: post.postId, title: postTitle(text), images: images.length };
+  } catch (e) {
+    await patch("line_note_posts", `id=eq.${job.post_id}`, { status: "failed", text, last_error: String((e as any)?.message ?? e).slice(0, 1000) });
+    throw e;
+  }
+}
+
+async function readPost(client: any, post: any) {
+  const comments = await listComments(client, post.home_id, post.line_post_id, { verbose: VERBOSE });
+  if (comments.length) {
+    const rows = comments.map((c: any) => {
+      const parsed = parseNoteComment(c.text, c.authorName ?? "");
+      return {
+        tenant_id: post.tenant_id, post_id: post.id, line_comment_id: String(c.commentId ?? ""),
+        commenter_id: c.authorMid ?? null, commenter_name: c.authorName ?? null, text: c.text ?? "",
+        commented_at: c.createdAt ?? null, member_no_hint: parsed.memberNo, parsed: parsed.orders,
+      };
+    }).filter((r: any) => r.line_comment_id);
+    await rest(`line_note_comments?on_conflict=post_id,line_comment_id`, {
+      method: "POST", body: rows, prefer: "resolution=ignore-duplicates,return=minimal",
+    });
+  }
+  const pending = await rest(`line_note_comments?post_id=eq.${post.id}&status=eq.pending&select=id&order=commented_at.asc,id.asc`);
+  let ordered = 0, other = 0;
+  for (const c of pending ?? []) {
+    try {
+      const r = await rpc("rpc_line_note_apply_comment", { p_comment_id: c.id });
+      const st = Array.isArray(r) ? r[0]?.out_status : r?.out_status;
+      if (st === "ordered") ordered++; else other++;
+    } catch (e) {
+      other++;
+      await patch("line_note_comments", `id=eq.${c.id}`, { status: "error", error: String((e as any)?.message ?? e).slice(0, 1000) }).catch(() => {});
+    }
+  }
+  await patch("line_note_posts", `id=eq.${post.id}`, { last_read_at: new Date().toISOString(), comment_count: comments.length, last_error: null });
+  return { comments: comments.length, pending: pending?.length ?? 0, ordered, other };
+}
+
+// 認貼文：小幫手手貼的團（內文含開團中／已收單的團名或團號）也綁進來
+async function discoverPosts(client: any, community: any) {
+  const since = new Date(Date.now() - community.read_days * 86400_000).toISOString();
+  const notes = await listPosts(client, community.home_id, { limit: 100, since, verbose: VERBOSE });
+  if (notes.length === 0) return 0;
+  const known = await rest(`line_note_posts?community_id=eq.${community.id}&select=id,status,line_post_id,campaign_id`);
+  const knownByLineId = new Map((known ?? []).filter((p: any) => p.line_post_id).map((p: any) => [p.line_post_id, p]));
+  const campaigns = await rest(`group_buy_campaigns?tenant_id=eq.${community.tenant_id}&status=in.(open,closed)&select=id,name,campaign_no&order=id.desc&limit=200`);
+  let linked = 0;
+  for (const n of notes) {
+    if (!n.postId || knownByLineId.has(String(n.postId))) continue;
+    const text = String(n.text ?? "");
+    const hit = (campaigns ?? []).find((c: any) => (c.name && text.includes(c.name)) || (c.campaign_no && text.includes(c.campaign_no)));
+    if (!hit) continue;
+    const existing = (known ?? []).find((p: any) => p.campaign_id === hit.id);
+    const row = { status: "posted", line_post_id: String(n.postId), text, posted_at: n.createdAt ?? new Date().toISOString(), last_error: null };
+    if (existing) {
+      if (existing.status === "posted") continue;
+      await patch("line_note_posts", `id=eq.${existing.id}`, row);
+    } else {
+      await rest("line_note_posts", { method: "POST", body: { tenant_id: community.tenant_id, community_id: community.id, campaign_id: hit.id, ...row }, prefer: "return=minimal" });
+    }
+    linked++;
+    log(`🔗 認到貼文 ${n.postId} → 團 ${hit.campaign_no} ${hit.name}`);
+  }
+  return linked;
+}
+
+async function jobRead(job: any) {
+  let discovered = 0;
+  let sinceFilter = "";
+  if (!job.post_id && job.community_id) {
+    const c = (await rest(`line_note_communities?id=eq.${job.community_id}&select=id,tenant_id,home_id,account_id,read_days`))?.[0];
+    if (c) {
+      const client = await clientFor(await loadAccount(c.account_id));
+      try { discovered = await discoverPosts(client, c); } catch (e) { log("認貼文失敗（略過）:", (e as any)?.message ?? e); }
+      sinceFilter = `&posted_at=gte.${new Date(Date.now() - c.read_days * 86400_000).toISOString()}`;
+    }
+  }
+  const filter = job.post_id ? `id=eq.${job.post_id}` : `community_id=eq.${job.community_id}${sinceFilter}`;
+  const posts = await rest(`line_note_posts?${filter}&status=eq.posted&select=id,tenant_id,line_post_id,community_id,group_buy_campaigns(status),line_note_communities(home_id,account_id)`);
+  const out: any[] = [];
+  for (const p of posts ?? []) {
+    const cst = p.group_buy_campaigns?.status;
+    if (cst && !["open", "closed"].includes(cst)) { await patch("line_note_posts", `id=eq.${p.id}`, { status: "closed" }); continue; }
+    const client = await clientFor(await loadAccount(p.line_note_communities.account_id));
+    try {
+      out.push({ post_id: p.id, ...(await readPost(client, { ...p, home_id: p.line_note_communities.home_id })) });
+    } catch (e) {
+      await patch("line_note_posts", `id=eq.${p.id}`, { last_error: String((e as any)?.message ?? e).slice(0, 1000) });
+      out.push({ post_id: p.id, error: String((e as any)?.message ?? e) });
+    }
+  }
+  if (job.community_id) await patch("line_note_communities", `id=eq.${job.community_id}`, { last_read_at: new Date().toISOString(), last_error: null });
+  return { discovered, posts: out };
+}
+
+const HANDLERS: Record<string, (job: any) => Promise<unknown>> = {
+  logout: jobLogout, list_homes: jobListHomes, post: jobPost, read: jobRead,
+};
+
+async function claimNextJob() {
+  // login 不在排程裡跑（要等人掃 QR，會把整個 tick 卡住 110 秒），只走後台按鈕 → action=login
+  const rows = await rest(`line_note_jobs?status=eq.queued&kind=neq.login&select=*&order=created_at.asc&limit=1`);
+  const job = rows?.[0];
+  if (!job) return null;
+  const claimed = await patch("line_note_jobs", `id=eq.${job.id}&status=eq.queued`, { status: "running", started_at: new Date().toISOString() });
+  return claimed?.[0] ?? null;
+}
+
+async function runJob(job: any) {
+  log(`▶ job#${job.id} ${job.kind} account=${job.account_id} community=${job.community_id ?? "-"} post=${job.post_id ?? "-"}`);
+  try {
+    const result = await HANDLERS[job.kind](job);
+    await patch("line_note_jobs", `id=eq.${job.id}`, { status: "done", result, finished_at: new Date().toISOString() });
+    if (job.account_id) await patch("line_note_accounts", `id=eq.${job.account_id}`, { last_seen_at: new Date().toISOString() }).catch(() => {});
+    log(`✔ job#${job.id}`, JSON.stringify(result).slice(0, 300));
+    return { id: job.id, kind: job.kind, ok: true };
+  } catch (e) {
+    const msg = String((e as any)?.message ?? e);
+    log(`✖ job#${job.id}`, msg.slice(0, 500));
+    await patch("line_note_jobs", `id=eq.${job.id}`, { status: "failed", error: msg.slice(0, 2000), finished_at: new Date().toISOString() });
+    if (/還沒登入|NotAuthorized|token|401/i.test(msg) && job.account_id) {
+      clients.delete(job.account_id);
+      await patch("line_note_accounts", `id=eq.${job.account_id}`, { status: "error", last_error: msg.slice(0, 1000) }).catch(() => {});
+    }
+    return { id: job.id, kind: job.kind, ok: false, error: msg.slice(0, 200) };
+  }
+}
+
+// ── 排程：到 read_times 就排 read ───────────────────────────────────────────
+function nowHHMM() {
+  const p = new Intl.DateTimeFormat("en-GB", { timeZone: TZ, hour: "2-digit", minute: "2-digit", hour12: false }).formatToParts(new Date());
+  const g = (t: string) => p.find((x) => x.type === t)?.value ?? "00";
+  return `${g("hour")}:${g("minute")}`;
+}
+async function scheduleReads() {
+  const hhmm = nowHHMM();
+  const communities = await rest(`line_note_communities?listen_enabled=eq.true&read_times=cs.{${hhmm}}&select=id,tenant_id,account_id,last_read_at`);
+  let n = 0;
+  for (const c of communities ?? []) {
+    // 同一分鐘只排一次：剛讀過（<= 90 秒）或已經有排隊中的就略過
+    if (c.last_read_at && Date.now() - new Date(c.last_read_at).getTime() < 90_000) continue;
+    const dup = await rest(`line_note_jobs?kind=eq.read&community_id=eq.${c.id}&status=in.(queued,running)&select=id&limit=1`);
+    if (dup?.length) continue;
+    await rest("line_note_jobs", { method: "POST", body: { tenant_id: c.tenant_id, kind: "read", account_id: c.account_id, community_id: c.id }, prefer: "return=minimal" });
+    n++;
+    log(`⏰ ${hhmm} 排 read：community#${c.id}`);
+  }
+  return n;
+}
+
+async function tick() {
+  const started = Date.now();
+  // 上一次沒跑完（Edge Function 被砍）的 running 退回 queued，超過 10 分鐘才算
+  await patch("line_note_jobs", `status=eq.running&started_at=lt.${new Date(Date.now() - 600_000).toISOString()}`, { status: "queued", started_at: null }).catch(() => {});
+  // 舊路徑排進來的 login（rpc_line_note_enqueue）不跑，直接標失敗請使用者從後台按登入
+  await patch("line_note_jobs", "status=eq.queued&kind=eq.login", {
+    status: "failed", error: "登入請從後台「帳號 → 登入」按（排程不跑登入）", finished_at: new Date().toISOString(),
+  }).catch(() => {});
+  const scheduled = await scheduleReads();
+  const ran: any[] = [];
+  while (Date.now() - started < TICK_BUDGET_MS) {
+    const job = await claimNextJob();
+    if (!job) break;
+    ran.push(await runJob(job));
+  }
+  return { scheduled, ran, ms: Date.now() - started };
+}
+
+// ── HTTP ────────────────────────────────────────────────────────────────────
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+  let body: any = {};
+  try { body = await req.json(); } catch { /* 空 body 當 tick */ }
+  const action = String(body.action ?? "tick");
+
+  // 認證：cron 用 secret header；後台用使用者 JWT（要是管理層級）
+  const secret = req.headers.get("x-line-note-secret");
+  let caller: "cron" | "admin" | null = null;
+  if (CRON_SECRET && secret === CRON_SECRET) caller = "cron";
+  else {
+    const auth = req.headers.get("authorization") ?? "";
+    const token = auth.replace(/^Bearer\s+/i, "");
+    if (token) {
+      const sb = createClient(SUPABASE_URL, SERVICE_KEY, { auth: { persistSession: false } });
+      const { data: { user } } = await sb.auth.getUser(token);
+      const role = String(user?.app_metadata?.role ?? "");
+      if (user && ["owner", "admin", "hq_manager", "assistant", ""].includes(role)) caller = "admin";
+    }
+  }
+  if (!caller) return json({ error: "unauthorized" }, 401);
+
+  try {
+    if (action === "login") {
+      if (caller !== "admin") return json({ error: "login 只能從後台按" }, 403);
+      const accountId = Number(body.account_id);
+      if (!accountId) return json({ error: "account_id required" }, 400);
+      return json(await doLogin(accountId));
+    }
+    if (action === "tick" || action === "run") return json(await tick());
+    return json({ error: `unknown action ${action}` }, 400);
+  } catch (e) {
+    const msg = String((e as any)?.message ?? e);
+    log("error:", msg);
+    return json({ error: msg }, 500);
+  }
+});
+
+function requireEnv(name: string): string {
+  const v = Deno.env.get(name);
+  if (!v) throw new Error(`missing env ${name}`);
+  return v;
+}
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+}

--- a/supabase/migrations/20260909010000_line_note_cron.sql
+++ b/supabase/migrations/20260909010000_line_note_cron.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- 20260909010000_line_note_cron.sql
+--
+-- LINE 記事本 worker 改成排程：pg_cron 每分鐘打一次 Edge Function `line-note-worker`
+-- （action=tick），它會到 read_times 排讀留言、撿 line_note_jobs 裡的工作跑完就結束。
+-- 不再需要 tools/line-note-scraper 那支常駐 worker。
+--
+-- 需要兩個 vault 秘密（不進 migration，套完後另外跑一次）：
+--   SELECT vault.create_secret('https://<ref>.functions.supabase.co/line-note-worker', 'line_note_worker_url');
+--   SELECT vault.create_secret('<隨機字串>', 'line_note_cron_secret');
+--   -- 同一個隨機字串也要設成 Edge Function 的 secret LINE_NOTE_CRON_SECRET
+-- 兩個沒設好的話 _line_note_tick() 只 RAISE NOTICE 不做事，cron 不會炸。
+--
+-- rollback：
+--   SELECT cron.unschedule('line-note-tick');
+--   DROP FUNCTION public._line_note_tick();
+--   （pg_net 留著無妨）
+-- ============================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+CREATE OR REPLACE FUNCTION public._line_note_tick()
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_url    TEXT;
+  v_secret TEXT;
+BEGIN
+  SELECT decrypted_secret INTO v_url    FROM vault.decrypted_secrets WHERE name = 'line_note_worker_url'  LIMIT 1;
+  SELECT decrypted_secret INTO v_secret FROM vault.decrypted_secrets WHERE name = 'line_note_cron_secret' LIMIT 1;
+  IF v_url IS NULL OR v_secret IS NULL THEN
+    RAISE NOTICE 'line-note-tick: vault 缺 line_note_worker_url / line_note_cron_secret，略過';
+    RETURN;
+  END IF;
+
+  -- 只有排隊中的工作、或有社群開監聽時才打，省 Edge Function 呼叫數
+  IF NOT EXISTS (SELECT 1 FROM line_note_jobs WHERE status = 'queued')
+     AND NOT EXISTS (SELECT 1 FROM line_note_communities WHERE listen_enabled) THEN
+    RETURN;
+  END IF;
+
+  PERFORM net.http_post(
+    url     := v_url,
+    headers := jsonb_build_object('Content-Type', 'application/json', 'x-line-note-secret', v_secret),
+    body    := '{"action":"tick"}'::jsonb,
+    timeout_milliseconds := 120000
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public._line_note_tick() FROM PUBLIC, anon, authenticated;
+
+-- cron.schedule 同名 job 為 idempotent，重複 run migration 不會炸
+SELECT cron.schedule('line-note-tick', '* * * * *', $cron$ SELECT public._line_note_tick(); $cron$);

--- a/supabase/migrations/20260909020000_line_note_no_channel_bot_source.sql
+++ b/supabase/migrations/20260909020000_line_note_no_channel_bot_source.sql
@@ -1,0 +1,440 @@
+-- ============================================================================
+-- 20260909020000_line_note_no_channel_bot_source.sql
+--
+-- LINE 記事本（老闆 9/9 交代）：
+--   1. 社群設定拿掉「渠道店」。發文對象＝介面上設定的社群（總部的團 → 全部有開自動發文的
+--      社群；店家自開的團 → 只發到標了那家店的社群）；爬記事本也是同一份設定。
+--   2. 加單的取貨店＝**找到的那位會員自己設定的店**（members.home_store_id），沒有就不加，
+--      不再退回渠道店。訂單的 channel 比照 LIFF：會員店自己的 active channel，沒有就 tenant 任一。
+--   3. 同一個 6 碼找到兩個以上的會員（不同店或同店）→ 標錯誤不加單，訊息列出各是哪家店的誰。
+--   4. 機器人加的單品項 source = 'line_bot'，跟小幫手（manual）、商城（liff）分開；
+--      後台 orderSource.ts 同步加「機器人」。
+--
+-- 基底（都已 grep 全 migrations 確認是最新版）：
+--   customer_order_items_source_check   @ 20260901010000（加 'line_bot'）
+--   rpc_line_note_community_upsert      @ 20260908010000（唯一版；簽名改了 → DROP 舊的）
+--   _line_note_on_campaign_open         @ 20260908010000（唯一版）
+--   _line_note_find_member              @ 20260908030000（唯一版）
+--   rpc_line_note_apply_comment         @ 20260909000000
+-- rollback：
+--   還原上面五個物件到各自基底；
+--   ALTER TABLE line_note_communities DROP COLUMN store_id, ALTER COLUMN channel_id SET NOT NULL;
+--   （回滾 source CHECK 前要先確認沒有 source='line_bot' 的列）
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. 社群：渠道改選填、加「店家（選填）」
+-- ----------------------------------------------------------------------------
+ALTER TABLE line_note_communities ALTER COLUMN channel_id DROP NOT NULL;
+ALTER TABLE line_note_communities ADD COLUMN IF NOT EXISTS store_id BIGINT REFERENCES stores(id);
+COMMENT ON COLUMN line_note_communities.store_id IS
+  '這個社群是哪家店的（選填）。只影響「店家自開的團」要不要發到這裡；取貨店一律跟會員走。';
+COMMENT ON COLUMN line_note_communities.channel_id IS
+  '（已停用）20260909020000 起不再用渠道決定發文與取貨店，留欄位只為相容。';
+
+DROP FUNCTION IF EXISTS public.rpc_line_note_community_upsert(
+  BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT, BOOLEAN, TEXT[], BOOLEAN, TEXT, INT);
+
+CREATE OR REPLACE FUNCTION public.rpc_line_note_community_upsert(
+  p_id                BIGINT,
+  p_account_id        BIGINT,
+  p_home_id           TEXT,
+  p_home_name         TEXT,
+  p_home_kind         TEXT,
+  p_listen_enabled    BOOLEAN,
+  p_read_times        TEXT[],
+  p_auto_post_on_open BOOLEAN,
+  p_post_template     TEXT,
+  p_read_days         INT DEFAULT 3,
+  p_store_id          BIGINT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+  v_id     BIGINT;
+  v_t      TEXT;
+BEGIN
+  PERFORM 1 FROM line_note_accounts WHERE id = p_account_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'account % not in tenant', p_account_id; END IF;
+  IF p_store_id IS NOT NULL THEN
+    PERFORM 1 FROM stores WHERE id = p_store_id AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'store % not in tenant', p_store_id; END IF;
+  END IF;
+  IF COALESCE(TRIM(p_home_id), '') = '' THEN RAISE EXCEPTION '請選擇社群'; END IF;
+  FOREACH v_t IN ARRAY COALESCE(p_read_times, ARRAY[]::TEXT[]) LOOP
+    IF v_t !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$' THEN
+      RAISE EXCEPTION '讀取時間格式要是 HH:MM（收到「%」）', v_t;
+    END IF;
+  END LOOP;
+  IF p_read_days IS NOT NULL AND (p_read_days < 1 OR p_read_days > 30) THEN
+    RAISE EXCEPTION '讀取範圍要在 1～30 天';
+  END IF;
+
+  IF p_id IS NULL THEN
+    INSERT INTO line_note_communities
+      (tenant_id, account_id, store_id, home_id, home_name, home_kind,
+       listen_enabled, read_times, auto_post_on_open, post_template, read_days, created_by, updated_by)
+    VALUES
+      (v_tenant, p_account_id, p_store_id, TRIM(p_home_id), p_home_name,
+       COALESCE(p_home_kind, 'square_chat'),
+       COALESCE(p_listen_enabled, FALSE),
+       COALESCE(NULLIF(p_read_times, ARRAY[]::TEXT[]), ARRAY['12:00']),
+       COALESCE(p_auto_post_on_open, TRUE),
+       NULLIF(TRIM(COALESCE(p_post_template, '')), ''),
+       COALESCE(p_read_days, 3),
+       auth.uid(), auth.uid())
+    RETURNING id INTO v_id;
+  ELSE
+    UPDATE line_note_communities
+       SET account_id        = p_account_id,
+           store_id          = p_store_id,
+           home_id           = TRIM(p_home_id),
+           home_name         = p_home_name,
+           home_kind         = COALESCE(p_home_kind, home_kind),
+           listen_enabled    = COALESCE(p_listen_enabled, listen_enabled),
+           read_times        = COALESCE(NULLIF(p_read_times, ARRAY[]::TEXT[]), read_times),
+           auto_post_on_open = COALESCE(p_auto_post_on_open, auto_post_on_open),
+           post_template     = NULLIF(TRIM(COALESCE(p_post_template, '')), ''),
+           read_days         = COALESCE(p_read_days, read_days),
+           updated_by        = auth.uid()
+     WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'community % not in tenant', p_id; END IF;
+  END IF;
+  RETURN v_id;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_community_upsert(
+  BIGINT, BIGINT, TEXT, TEXT, TEXT, BOOLEAN, TEXT[], BOOLEAN, TEXT, INT, BIGINT) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 2. 開團自動發文：不看 campaign_channels，看社群設定
+--    總部的團（owner_store_id IS NULL）→ 所有開自動發文的社群
+--    店家自開的團 → 只發到 store_id = 那家店 的社群
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._line_note_on_campaign_open()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_c RECORD;
+  v_post BIGINT;
+BEGIN
+  IF NEW.status <> 'open' OR OLD.status = 'open' THEN RETURN NEW; END IF;
+  FOR v_c IN
+    SELECT c.id AS community_id, c.account_id
+      FROM line_note_communities c
+      JOIN line_note_accounts a ON a.id = c.account_id AND a.status = 'active'
+     WHERE c.tenant_id = NEW.tenant_id
+       AND c.auto_post_on_open
+       AND (NEW.owner_store_id IS NULL OR c.store_id = NEW.owner_store_id)
+  LOOP
+    INSERT INTO line_note_posts (tenant_id, community_id, campaign_id, status, created_by, updated_by)
+    VALUES (NEW.tenant_id, v_c.community_id, NEW.id, 'queued', NEW.updated_by, NEW.updated_by)
+    ON CONFLICT (community_id, campaign_id) DO NOTHING
+    RETURNING id INTO v_post;
+    IF v_post IS NOT NULL THEN
+      INSERT INTO line_note_jobs (tenant_id, kind, account_id, community_id, post_id, created_by)
+      VALUES (NEW.tenant_id, 'post', v_c.account_id, v_c.community_id, v_post, NEW.updated_by);
+    END IF;
+  END LOOP;
+  RETURN NEW;
+END;
+$$;
+
+-- ----------------------------------------------------------------------------
+-- 3. 品項來源加 'line_bot'（機器人加單）
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.customer_order_items DROP CONSTRAINT IF EXISTS customer_order_items_source_check;
+ALTER TABLE public.customer_order_items ADD CONSTRAINT customer_order_items_source_check CHECK (
+  source = ANY (ARRAY[
+    'manual'::text, 'screenshot_parse'::text, 'csv'::text, 'rollover'::text, 'liff'::text, 'pwa'::text,
+    'store_internal'::text, 'aid_transfer'::text, 'walk_in'::text, 'line_bot'::text
+  ])
+);
+COMMENT ON COLUMN customer_order_items.source IS
+  '品項來源通路。pwa=會員 App、liff=LINE 商城、manual=小幫手代客、line_bot=記事本機器人自動加單、'
+  'walk_in=現場銷售；其餘為系統流程（screenshot_parse/csv/rollover/store_internal/aid_transfer）。'
+  '中央定義見 apps/admin/src/lib/orderSource.ts。';
+
+-- ----------------------------------------------------------------------------
+-- 4. 6 碼 → 會員：多位（不管同店異店）就不猜，訊息列出各是哪家店的誰
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._line_note_find_member(p_tenant UUID, p_code TEXT)
+RETURNS TABLE (member_id BIGINT, home_store_id BIGINT, ambiguous TEXT)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+AS $$
+DECLARE
+  v_re      TEXT := '(^|[^0-9])' || p_code || '([^0-9]|$)';
+  v_id      BIGINT;
+  v_home    BIGINT;
+  v_cnt     INT;
+  v_who     TEXT;
+  v_status  TEXT;
+  v_next    BIGINT;
+  v_hops    INT := 0;
+BEGIN
+  -- 1) member_no 直接命中
+  SELECT m.id, m.home_store_id INTO v_id, v_home
+    FROM members m
+   WHERE m.tenant_id = p_tenant
+     AND (m.member_no = 'M' || p_code OR m.member_no = p_code)
+     AND m.status NOT IN ('merged','deleted')
+   ORDER BY m.id LIMIT 1;
+  IF v_id IS NOT NULL THEN
+    RETURN QUERY SELECT v_id, v_home, NULL::TEXT; RETURN;
+  END IF;
+
+  -- 2) 姓名帶這 6 碼的活人
+  SELECT count(*) INTO v_cnt
+    FROM members m
+   WHERE m.tenant_id = p_tenant AND m.name ~ v_re AND m.status NOT IN ('merged','deleted');
+
+  IF v_cnt = 1 THEN
+    SELECT m.id, m.home_store_id INTO v_id, v_home
+      FROM members m
+     WHERE m.tenant_id = p_tenant AND m.name ~ v_re AND m.status NOT IN ('merged','deleted');
+    RETURN QUERY SELECT v_id, v_home, NULL::TEXT; RETURN;
+  END IF;
+
+  IF v_cnt > 1 THEN
+    SELECT string_agg(COALESCE(s.name, '未設店') || '：' || COALESCE(m.name, m.member_no), '、' ORDER BY s.name, m.id)
+      INTO v_who
+      FROM members m LEFT JOIN stores s ON s.id = m.home_store_id
+     WHERE m.tenant_id = p_tenant AND m.name ~ v_re AND m.status NOT IN ('merged','deleted');
+    RETURN QUERY SELECT NULL::BIGINT, NULL::BIGINT,
+                        ('同一個號碼 ' || p_code || ' 有 ' || v_cnt || ' 位會員（' || v_who || '），不加單，請人工確認')::TEXT;
+    RETURN;
+  END IF;
+
+  -- 3) 只有被合併掉的舊帳號帶這組號碼 → 跟著 merged_into_member_id 走到本尊
+  SELECT m.merged_into_member_id INTO v_id
+    FROM members m
+   WHERE m.tenant_id = p_tenant AND m.name ~ v_re
+   ORDER BY m.id LIMIT 1;
+  WHILE v_id IS NOT NULL AND v_hops < 5 LOOP
+    v_hops := v_hops + 1;
+    SELECT m.home_store_id, m.status, m.merged_into_member_id
+      INTO v_home, v_status, v_next
+      FROM members m WHERE m.id = v_id AND m.tenant_id = p_tenant;
+    IF v_status IS NULL THEN EXIT; END IF;
+    IF v_status NOT IN ('merged','deleted') THEN
+      RETURN QUERY SELECT v_id, v_home, NULL::TEXT; RETURN;
+    END IF;
+    v_id := v_next;
+  END LOOP;
+
+  RETURN QUERY SELECT NULL::BIGINT, NULL::BIGINT, NULL::TEXT;
+END;
+$$;
+
+-- ----------------------------------------------------------------------------
+-- 5. 訂單 channel：比照 liff-api —— 會員店自己的 active channel，沒有就 tenant 任一
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._line_note_pick_channel(p_tenant UUID, p_store_id BIGINT)
+RETURNS BIGINT
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT id FROM (
+    SELECT id, 0 AS pri FROM line_channels
+     WHERE tenant_id = p_tenant AND is_active AND home_store_id = p_store_id
+    UNION ALL
+    SELECT id, 1 FROM line_channels WHERE tenant_id = p_tenant AND is_active
+  ) x ORDER BY pri, id LIMIT 1;
+$$;
+
+-- ----------------------------------------------------------------------------
+-- 6. 留言 → 訂單
+--    取貨店＝會員的店（沒有就 error）；channel 用 _line_note_pick_channel；
+--    新加的品項 source 改 'line_bot'。找人／去重／duplicate 同 20260909000000。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_apply_comment(p_comment_id BIGINT)
+RETURNS TABLE (out_status TEXT, out_order_id BIGINT, out_error TEXT)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_c            line_note_comments%ROWTYPE;
+  v_tenant       UUID;
+  v_campaign_id  BIGINT;
+  v_channel_id   BIGINT;
+  v_member_id    BIGINT;
+  v_member_home  BIGINT;
+  v_ambiguous    TEXT;
+  v_hint         TEXT;
+  v_items        JSONB := '[]'::jsonb;
+  v_new_items    JSONB := '[]'::jsonb;
+  v_dup_codes    TEXT[] := ARRAY[]::TEXT[];
+  v_dup_order    BIGINT;
+  v_p            JSONB;
+  v_code         TEXT;
+  v_qty          NUMERIC;
+  v_ci           BIGINT;
+  v_item_count   INT;
+  v_order_id     BIGINT;
+  v_err          TEXT;
+  v_t0           TIMESTAMPTZ := clock_timestamp();
+  v_claim_tenant TEXT := auth.jwt() ->> 'tenant_id';
+BEGIN
+  SELECT * INTO v_c FROM line_note_comments WHERE id = p_comment_id;
+  IF v_c.id IS NULL THEN RAISE EXCEPTION 'comment % not found', p_comment_id; END IF;
+  v_tenant := v_c.tenant_id;
+
+  -- 呼叫者是後台使用者 → tenant 要對得上；是 service_role → 補 claims 給下游 RPC 用
+  IF v_claim_tenant IS NOT NULL AND v_claim_tenant <> '' THEN
+    IF v_claim_tenant::uuid <> v_tenant THEN RAISE EXCEPTION 'comment % not in tenant', p_comment_id; END IF;
+  ELSE
+    PERFORM set_config('request.jwt.claims',
+      jsonb_build_object('tenant_id', v_tenant,
+                         'app_metadata', jsonb_build_object('tenant_id', v_tenant, 'role', 'admin'))::text,
+      TRUE);
+  END IF;
+
+  IF v_c.status IN ('ordered','ignored','resolved','duplicate') THEN
+    RETURN QUERY SELECT v_c.status, v_c.customer_order_id, v_c.error; RETURN;
+  END IF;
+
+  SELECT p.campaign_id INTO v_campaign_id FROM line_note_posts p WHERE p.id = v_c.post_id;
+
+  -- 沒有任何數量 → 不是下單留言
+  IF jsonb_array_length(COALESCE(v_c.parsed, '[]'::jsonb)) = 0 THEN
+    UPDATE line_note_comments SET status = 'no_order', processed_at = NOW() WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'no_order'::TEXT, NULL::BIGINT, NULL::TEXT; RETURN;
+  END IF;
+
+  -- 會員：6 碼 → member_no 或姓名裡的號碼
+  v_hint := NULLIF(TRIM(COALESCE(v_c.member_no_hint, '')), '');
+  IF v_hint IS NULL THEN
+    UPDATE line_note_comments SET status = 'unmatched', error = '留言裡沒有 6 碼會員編號', processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'unmatched'::TEXT, NULL::BIGINT, '留言裡沒有 6 碼會員編號'::TEXT; RETURN;
+  END IF;
+
+  SELECT f.member_id, f.home_store_id, f.ambiguous
+    INTO v_member_id, v_member_home, v_ambiguous
+    FROM public._line_note_find_member(v_tenant, v_hint) f;
+
+  IF v_member_id IS NULL THEN
+    v_err := COALESCE(v_ambiguous, '找不到會員編號 ' || v_hint);
+    UPDATE line_note_comments SET status = CASE WHEN v_ambiguous IS NULL THEN 'unmatched' ELSE 'error' END,
+                                  error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT (CASE WHEN v_ambiguous IS NULL THEN 'unmatched' ELSE 'error' END)::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+
+  -- 取貨店＝會員自己的店，沒有就不加
+  IF v_member_home IS NULL THEN
+    v_err := '會員沒有設定取貨店，請先到會員資料補上';
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+  v_channel_id := public._line_note_pick_channel(v_tenant, v_member_home);
+  IF v_channel_id IS NULL THEN
+    v_err := '這個租戶沒有任何啟用中的 LINE 渠道，無法建單';
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+
+  -- 品項：code → campaign_item；沒 code 且團只有一項 → 那一項
+  SELECT count(*) INTO v_item_count FROM public._line_note_item_codes(v_campaign_id);
+  FOR v_p IN SELECT * FROM jsonb_array_elements(v_c.parsed) LOOP
+    IF COALESCE((v_p ->> 'cancel')::boolean, FALSE) THEN CONTINUE; END IF;  -- 取消留言不自動處理，留給人看
+    v_qty  := (v_p ->> 'qty')::numeric;
+    v_code := UPPER(NULLIF(TRIM(COALESCE(v_p ->> 'code', '')), ''));
+    IF v_qty IS NULL OR v_qty <= 0 THEN CONTINUE; END IF;
+    IF v_code IS NULL THEN
+      IF v_item_count = 1 THEN
+        SELECT ic.campaign_item_id, ic.code INTO v_ci, v_code FROM public._line_note_item_codes(v_campaign_id) ic;
+      ELSE
+        v_err := '沒寫品項代碼（這團有 ' || v_item_count || ' 項）';
+        EXIT;
+      END IF;
+    ELSE
+      SELECT ic.campaign_item_id INTO v_ci FROM public._line_note_item_codes(v_campaign_id) ic WHERE ic.code = v_code;
+      IF v_ci IS NULL THEN v_err := '品項代碼 ' || v_code || ' 不在這團裡'; EXIT; END IF;
+    END IF;
+    v_items := v_items || jsonb_build_object('campaign_item_id', v_ci, 'qty', v_qty, 'code', v_code);
+  END LOOP;
+
+  IF v_err IS NOT NULL THEN
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+  IF jsonb_array_length(v_items) = 0 THEN
+    UPDATE line_note_comments SET status = 'no_order', member_id = v_member_id, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'no_order'::TEXT, NULL::BIGINT, NULL::TEXT; RETURN;
+  END IF;
+
+  -- 去重：這位會員在這團已經有同一品項的有效訂單（任何來源）→ 那一項不再加
+  FOR v_p IN SELECT * FROM jsonb_array_elements(v_items) LOOP
+    SELECT co.id INTO v_order_id
+      FROM customer_order_items coi
+      JOIN customer_orders co ON co.id = coi.order_id
+     WHERE co.tenant_id = v_tenant
+       AND co.campaign_id = v_campaign_id
+       AND co.member_id = v_member_id
+       AND co.status NOT IN ('cancelled','expired','transferred_out')
+       AND coi.campaign_item_id = (v_p ->> 'campaign_item_id')::bigint
+       AND coi.status <> 'cancelled'
+     ORDER BY co.id LIMIT 1;
+    IF v_order_id IS NOT NULL THEN
+      v_dup_codes := v_dup_codes || COALESCE(v_p ->> 'code', '?');
+      v_dup_order := COALESCE(v_dup_order, v_order_id);
+      v_order_id  := NULL;
+    ELSE
+      v_new_items := v_new_items || jsonb_build_object('campaign_item_id', (v_p ->> 'campaign_item_id')::bigint, 'qty', (v_p ->> 'qty')::numeric);
+    END IF;
+  END LOOP;
+
+  IF jsonb_array_length(v_new_items) = 0 THEN
+    v_err := '已有訂單（' || array_to_string(v_dup_codes, '、') || '），未重複加單';
+    UPDATE line_note_comments
+       SET status = 'duplicate', member_id = v_member_id, customer_order_id = v_dup_order,
+           error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'duplicate'::TEXT, v_dup_order, v_err; RETURN;
+  END IF;
+
+  BEGIN
+    SELECT r.out_order_id INTO v_order_id
+      FROM public.rpc_create_customer_orders(
+             v_campaign_id, v_channel_id,
+             jsonb_build_array(jsonb_build_object(
+               'member_id', v_member_id,
+               'nickname', v_c.commenter_name,
+               'pickup_store_id', v_member_home,
+               'items', v_new_items))) r
+     LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    v_err := SQLERRM;
+  END;
+
+  IF v_err IS NOT NULL THEN
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+
+  -- 這次新建的品項列標成機器人來源（併進既有列的維持原來源）
+  UPDATE customer_order_items coi
+     SET source = 'line_bot'
+   WHERE coi.order_id = v_order_id
+     AND coi.source = 'manual'
+     AND coi.created_at >= v_t0
+     AND coi.campaign_item_id IN (SELECT (x ->> 'campaign_item_id')::bigint FROM jsonb_array_elements(v_new_items) x);
+
+  UPDATE line_note_comments
+     SET status = 'ordered', member_id = v_member_id, customer_order_id = v_order_id,
+         error = NULL, processed_at = NOW(),
+         resolution_note = CASE WHEN array_length(v_dup_codes, 1) > 0
+                                THEN '已略過重複：' || array_to_string(v_dup_codes, '、')
+                                ELSE resolution_note END
+   WHERE id = p_comment_id;
+  RETURN QUERY SELECT 'ordered'::TEXT, v_order_id, NULL::TEXT;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_apply_comment(BIGINT) TO authenticated;

--- a/tools/line-note-scraper/README.md
+++ b/tools/line-note-scraper/README.md
@@ -51,6 +51,10 @@ node src/cli.mjs post <homeId> --file post.txt --image 1.jpg --image 2.jpg   # �
 
 ## 接後台（worker 模式）
 
+> **2026-09-09 起後台改用 Supabase 排程**（Edge Function `line-note-worker` + pg_cron 每分鐘），
+> **不用再跑這支 worker**。這節與「部署到雲端」留著當備援：Edge 跑不動時可以改回本機／VM 常駐，
+> 兩邊撿同一個佇列，但**不要同時跑**。Edge 版沒有 sharp，發文只帶 JPEG 圖。
+
 後台「設定 → LINE 記事本」頁面負責帳號登入、社群設定、看留言結果；真的跟 LINE 講話的是這支 worker，
 跑在你自己的電腦或 VPS 上，用 service_role 輪詢 `line_note_jobs`。
 


### PR DESCRIPTION
疊在 #927（Supabase 排程）上；前面的合併後這支只剩這一個 commit。

**`20260909020000_line_note_no_channel_bot_source.sql`（已套正式庫）**

1. **社群設定拿掉渠道**，改「店家（選填）」。發文對象＝介面上設定的社群：總部的團 → 所有開自動發文的社群；店家自開的團（`owner_store_id`）→ 只發到標了那家店的社群。爬記事本用同一份設定。`channel_id` 改 nullable 留著相容。
2. **取貨店＝找到的那位會員自己設定的店**（`members.home_store_id`），沒有就標錯誤不加。訂單 channel 比照 liff-api：會員店的 active channel，沒有就 tenant 任一（`_line_note_pick_channel`）。
3. **同一個 6 碼找到兩位以上會員**（不分同店異店）→ 標 `error` 不加單，訊息列出「松山店：安文298833、平鎮店：…」給小幫手。
4. **機器人加的品項 `source='line_bot'`**（CHECK 加值，基底 `20260901010000`），跟小幫手 `manual`／商城 `liff` 分開。後台 `orderSource.ts` 加「🤖 機器人」，訂單頁來源折線圖也多一條線。

基底：`rpc_line_note_community_upsert` / `_line_note_on_campaign_open` @ 20260908010000、`_line_note_find_member` @ 20260908030000、`rpc_line_note_apply_comment` @ 20260909000000（都已 grep 確認）。upsert 簽名改了（拿掉 channel、加 store）所以 DROP 舊的再建。

驗證：migration 過 pg-query 語法檢查（含 5 支 plpgsql）；套用後線上 `pg_get_functiondef` / `pg_get_constraintdef` 確認；`tsc --noEmit` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ)_