### PR TITLE
fix(line-notes): 貼文抓不齊、頁面留白、貼文展開看加了幾單

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -4,12 +4,14 @@
 // 真正跟 LINE 講話的是地端 worker（tools/line-note-scraper/src/worker.mjs），
 // 這頁只做設定、丟工作（line_note_jobs）、看結果。
 
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 import { getSupabase } from "@/lib/supabase";
 import SpinButton from "@/components/SpinButton";
 import { Table, THead, TBody, Tr, Th, Td, EmptyRow, LoadingRow } from "@/components/DataTable";
 import { translateRpcError } from "@/lib/rpcError";
 import { campaignStatusBadge, campaignStatusLabel } from "@/lib/campaignStatus";
+import { Modal as SharedModal } from "@/components/Modal";
+import { OrderDetail } from "@/components/OrderDetail";
 
 type Account = {
   id: number; label: string; status: "logged_out" | "pending_qr" | "active" | "error";
@@ -75,8 +77,25 @@ const btn = "rounded border border-zinc-300 px-2.5 py-1 text-sm hover:bg-zinc-10
 const btnPrimary = "rounded bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900";
 const input = "w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900";
 
+// 點訂單號開的明細彈窗（整頁共用一個；比照 CampaignOrdersPanel / MemberDetail 的用法）
+type OrderPopup = { id: number; no: string };
+const OrderPopupContext = createContext<((o: OrderPopup) => void) | null>(null);
+function useOpenOrder() { return useContext(OrderPopupContext); }
+
+/** 訂單號連結：點了開明細彈窗 */
+function OrderLink({ id, no }: { id: number; no: string }) {
+  const open = useOpenOrder();
+  return (
+    <button type="button" className="font-mono text-sky-700 underline hover:text-sky-900 dark:text-sky-400 dark:hover:text-sky-200"
+      onClick={(e) => { e.stopPropagation(); open?.({ id, no }); }}>
+      {no}
+    </button>
+  );
+}
+
 export default function LineNotesPage() {
   const [tab, setTab] = useState<"accounts" | "communities" | "comments" | "posts">("accounts");
+  const [orderPopup, setOrderPopup] = useState<OrderPopup | null>(null);
   const [accounts, setAccounts] = useState<Account[] | null>(null);
   const [stores, setStores] = useState<Store[]>([]);
   const [communities, setCommunities] = useState<Community[] | null>(null);
@@ -122,6 +141,7 @@ export default function LineNotesPage() {
   const communityById = useMemo(() => new Map((communities ?? []).map((c) => [c.id, c])), [communities]);
 
   return (
+    <OrderPopupContext.Provider value={setOrderPopup}>
     <div className="flex flex-1 flex-col gap-4 p-6">
       <div className="flex flex-wrap items-end justify-between gap-2">
         <div>
@@ -165,7 +185,19 @@ export default function LineNotesPage() {
       {tab === "posts" && (
         <PostsTab posts={posts} communityById={communityById} reload={loadPosts} notify={notify} fail={fail} />
       )}
+
+      <SharedModal
+        open={orderPopup !== null}
+        onClose={() => setOrderPopup(null)}
+        title={`訂單明細 ${orderPopup?.no ?? ""}`}
+        maxWidth="max-w-4xl"
+      >
+        {orderPopup && (
+          <OrderDetail orderId={orderPopup.id} onNavigate={(id, no) => setOrderPopup({ id, no })} />
+        )}
+      </SharedModal>
     </div>
+    </OrderPopupContext.Provider>
   );
 }
 
@@ -565,10 +597,12 @@ function CommentsTab({ communityById, notify, fail }: {
   // 結果欄：一個徽章 + 一句話
   const result = (c: Comment) => {
     const o = c.customer_order_id ? orders.get(c.customer_order_id) : null;
-    const orderText = o ? `${o.store_name ?? "？店"}　${o.order_no}` : c.customer_order_id ? `訂單 #${c.customer_order_id}` : "";
+    const orderCell = o
+      ? <><span className="text-zinc-600 dark:text-zinc-300">{o.store_name ?? "？店"}</span>{" "}<OrderLink id={o.id} no={o.order_no} /></>
+      : c.customer_order_id ? <span>訂單 #{c.customer_order_id}</span> : null;
     switch (c.status) {
-      case "ordered":   return <><Badge tone="green">已加單</Badge><span>{orderText}</span></>;
-      case "duplicate": return <><Badge tone="blue">已有訂單</Badge><span>{orderText}</span></>;
+      case "ordered":   return <><Badge tone="green">已加單</Badge>{orderCell}</>;
+      case "duplicate": return <><Badge tone="blue">已有訂單</Badge>{orderCell}</>;
       case "resolved":  return <><Badge tone="green">已解決</Badge><span className="text-zinc-500">{c.resolution_note ?? ""}</span></>;
       case "ignored":   return <Badge tone="gray">忽略</Badge>;
       case "pending":   return <Badge tone="amber">等 worker 處理</Badge>;
@@ -638,6 +672,7 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
   const [open, setOpen] = useState<number | null>(null);
   // 展開過的貼文留言（快取，收合再展開不用重抓）
   const [detail, setDetail] = useState<Map<number, Comment[]>>(new Map());
+  const [orderNos, setOrderNos] = useState<Map<number, string>>(new Map());
   const [loadingId, setLoadingId] = useState<number | null>(null);
 
   const toggle = async (p: Post) => {
@@ -649,7 +684,17 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
       .eq("post_id", p.id).order("commented_at", { ascending: true }).order("id");
     setLoadingId(null);
     if (error) return fail(error);
-    setDetail((m) => new Map(m).set(p.id, (data ?? []) as Comment[]));
+    const cs = (data ?? []) as Comment[];
+    setDetail((m) => new Map(m).set(p.id, cs));
+    // 有加到單的補查單號，才能做成連結
+    const ids = [...new Set(cs.map((c) => c.customer_order_id).filter((x): x is number => !!x))];
+    if (ids.length === 0) return;
+    const { data: od } = await getSupabase().from("customer_orders").select("id,order_no").in("id", ids);
+    setOrderNos((m) => {
+      const n = new Map(m);
+      for (const o of (od ?? []) as { id: number; order_no: string }[]) n.set(o.id, o.order_no);
+      return n;
+    });
   };
 
   const readNow = async (p: Post) => {
@@ -729,6 +774,9 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
                                 <span className="w-24 shrink-0 text-xs text-zinc-500">{fmt(cm.commented_at)}</span>
                                 <span className="w-40 shrink-0 truncate font-medium">{cm.commenter_name ?? "—"}</span>
                                 <span className="min-w-0 flex-1 truncate">{cm.text}</span>
+                                {cm.customer_order_id && orderNos.has(cm.customer_order_id) && (
+                                  <OrderLink id={cm.customer_order_id} no={orderNos.get(cm.customer_order_id)!} />
+                                )}
                                 <Badge tone={cm.status === "ordered" || cm.status === "resolved" ? "green"
                                   : cm.status === "duplicate" ? "blue"
                                   : cm.status === "pending" ? "amber"

--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -122,7 +122,7 @@ export default function LineNotesPage() {
   const communityById = useMemo(() => new Map((communities ?? []).map((c) => [c.id, c])), [communities]);
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-1 flex-col gap-4 p-6">
       <div className="flex flex-wrap items-end justify-between gap-2">
         <div>
           <h1 className="text-xl font-semibold">LINE 記事本</h1>
@@ -630,12 +630,28 @@ function CommentsTab({ communityById, notify, fail }: {
   );
 }
 
-// ── 貼文：哪些團已經發到哪些社群 ─────────────────────────────────────────────
+// ── 貼文：哪些團已經發到哪些社群；點一列展開看加了幾單 ─────────────────────
 function PostsTab({ posts, communityById, reload, notify, fail }: {
   posts: Post[] | null; communityById: Map<number, Community>; reload: () => Promise<void>; notify: (m: string) => void; fail: (e: unknown) => void;
 }) {
   const [busy, setBusy] = useState<number | null>(null);
   const [open, setOpen] = useState<number | null>(null);
+  // 展開過的貼文留言（快取，收合再展開不用重抓）
+  const [detail, setDetail] = useState<Map<number, Comment[]>>(new Map());
+  const [loadingId, setLoadingId] = useState<number | null>(null);
+
+  const toggle = async (p: Post) => {
+    if (open === p.id) { setOpen(null); return; }
+    setOpen(p.id);
+    if (detail.has(p.id)) return;
+    setLoadingId(p.id);
+    const { data, error } = await getSupabase().from("line_note_comments").select("*")
+      .eq("post_id", p.id).order("commented_at", { ascending: true }).order("id");
+    setLoadingId(null);
+    if (error) return fail(error);
+    setDetail((m) => new Map(m).set(p.id, (data ?? []) as Comment[]));
+  };
+
   const readNow = async (p: Post) => {
     const c = communityById.get(p.community_id);
     if (!c) return;
@@ -644,29 +660,39 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
     setBusy(null);
     if (error) return fail(error);
     kickWorker();
+    setDetail((m) => { const n = new Map(m); n.delete(p.id); return n; });
     notify("已開始讀取，留言幾秒後會出現在「留言加單」");
   };
+
+  const stat = (cs: Comment[]) => ({
+    ordered: cs.filter((c) => c.status === "ordered").length,
+    duplicate: cs.filter((c) => c.status === "duplicate").length,
+    todo: cs.filter((c) => ["pending", "unmatched", "error"].includes(c.status) || (c.status === "no_order" && c.member_no_hint)).length,
+  });
+
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <p className="text-sm text-zinc-500">開團自動發的、和小幫手手貼後被系統認出來的貼文。</p>
+        <p className="text-sm text-zinc-500">開團自動發的、和小幫手手貼後被系統認出來的貼文。點一列展開看加了幾單。</p>
         <button type="button" className={btn} onClick={() => void reload()}>重新整理</button>
       </div>
       <Table>
-        <THead><Th>團</Th><Th>社群</Th><Th>狀態</Th><Th>發文</Th><Th>最後讀取</Th><Th align="right">留言</Th><Th align="right"></Th></THead>
+        <THead><Th></Th><Th>團</Th><Th>社群</Th><Th>狀態</Th><Th>發文</Th><Th>最後讀取</Th><Th align="right">留言</Th><Th align="right"></Th></THead>
         <TBody>
-          {posts === null ? <LoadingRow colSpan={7} /> : posts.length === 0 ? <EmptyRow colSpan={7}>還沒有貼文</EmptyRow> : posts.map((p) => {
+          {posts === null ? <LoadingRow colSpan={8} /> : posts.length === 0 ? <EmptyRow colSpan={8}>還沒有貼文</EmptyRow> : posts.flatMap((p) => {
             const c = communityById.get(p.community_id);
             const cs = p.group_buy_campaigns?.status;
-            return (
-              <Tr key={p.id}>
+            const expanded = open === p.id;
+            const cmts = detail.get(p.id);
+            const rows = [
+              <Tr key={p.id} onClick={() => void toggle(p)} className={expanded ? "bg-sky-50 dark:bg-sky-950/30" : ""}>
+                <Td className="w-8 text-zinc-400">{expanded ? "▾" : "▸"}</Td>
                 <Td>
                   <div className="font-medium">{p.group_buy_campaigns?.name ?? p.campaign_id}</div>
                   <div className="mt-0.5 flex items-center gap-2 text-xs text-zinc-500">
                     {cs && <span className={`rounded px-1.5 py-0.5 ${campaignStatusBadge(cs)}`}>{campaignStatusLabel(cs)}</span>}
-                    {p.text && <button type="button" className="underline" onClick={() => setOpen(open === p.id ? null : p.id)}>{open === p.id ? "收起內容" : "看內容"}</button>}
+                    <span className="font-mono">{p.group_buy_campaigns?.campaign_no}</span>
                   </div>
-                  {open === p.id && p.text && <pre className="mt-2 whitespace-pre-wrap rounded bg-zinc-50 p-3 text-sm text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">{p.text}</pre>}
                 </Td>
                 <Td className="whitespace-nowrap">{c?.home_name || c?.home_id || p.community_id}</Td>
                 <Td>
@@ -677,10 +703,49 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
                 <Td className="whitespace-nowrap">{fmt(p.last_read_at)}</Td>
                 <Td align="right" className="tabular-nums">{p.comment_count}</Td>
                 <Td align="right">
-                  {p.status === "posted" && <SpinButton type="button" className={btn} loading={busy === p.id} onClick={() => readNow(p)}>立即讀取</SpinButton>}
+                  {p.status === "posted" && (
+                    <SpinButton type="button" className={btn} loading={busy === p.id}
+                      onClick={(e) => { e.stopPropagation(); void readNow(p); }}>立即讀取</SpinButton>
+                  )}
                 </Td>
-              </Tr>
-            );
+              </Tr>,
+            ];
+            if (expanded) {
+              rows.push(
+                <tr key={`${p.id}-d`} className="bg-zinc-50 dark:bg-zinc-900/50">
+                  <td colSpan={8} className="px-4 py-3">
+                    {loadingId === p.id ? <div className="text-sm text-zinc-400">讀取中…</div> : !cmts ? null : (
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center gap-2 text-sm">
+                          <Badge tone="green">已加單 {stat(cmts).ordered}</Badge>
+                          {stat(cmts).duplicate > 0 && <Badge tone="blue">已有訂單 {stat(cmts).duplicate}</Badge>}
+                          {stat(cmts).todo > 0 && <Badge tone="red">待處理 {stat(cmts).todo}</Badge>}
+                          <span className="text-zinc-500">共 {cmts.length} 則留言</span>
+                        </div>
+                        {cmts.length === 0 ? <div className="text-sm text-zinc-400">還沒讀到留言</div> : (
+                          <ul className="divide-y divide-zinc-200 rounded border border-zinc-200 bg-white dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
+                            {cmts.map((cm) => (
+                              <li key={cm.id} className="flex flex-wrap items-center gap-x-3 gap-y-1 px-3 py-2 text-sm">
+                                <span className="w-24 shrink-0 text-xs text-zinc-500">{fmt(cm.commented_at)}</span>
+                                <span className="w-40 shrink-0 truncate font-medium">{cm.commenter_name ?? "—"}</span>
+                                <span className="min-w-0 flex-1 truncate">{cm.text}</span>
+                                <Badge tone={cm.status === "ordered" || cm.status === "resolved" ? "green"
+                                  : cm.status === "duplicate" ? "blue"
+                                  : cm.status === "pending" ? "amber"
+                                  : cm.status === "unmatched" || cm.status === "error" ? "red" : "gray"}>
+                                  {COMMENT_STATUS[cm.status]}
+                                </Badge>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+                    )}
+                  </td>
+                </tr>,
+              );
+            }
+            return rows;
           })}
         </TBody>
       </Table>

--- a/supabase/functions/_shared/lineNote.ts
+++ b/supabase/functions/_shared/lineNote.ts
@@ -287,7 +287,11 @@ export async function listPosts(client, homeId, { limit = 200, since = null, ver
     let stop = false;
     for (const p of posts) {
       if (out.some((x) => x.postId === p.postId)) { stop = true; break; }
-      if (sinceMs && p.createdAt && new Date(p.createdAt).getTime() < sinceMs) { stop = true; break; }
+      // ⚠ LINE 的列表是依 updatedTime 排序（翻頁游標就是 updatedTime），所以「早於 since 就停」
+      //   要看 updatedAt，不能看 createdAt —— 舊貼文一有新留言就會排到最前面，用 createdAt 判斷
+      //   會在第一頁就停掉，後面幾十篇全漏（2026-09-09 抓不到全部貼文就是這個）。
+      const lastTouched = p.updatedAt ?? p.createdAt;
+      if (sinceMs && lastTouched && new Date(lastTouched).getTime() < sinceMs) { stop = true; break; }
       out.push(p);
     }
     if (stop) break;

--- a/supabase/functions/_shared/lineNoteParse.ts
+++ b/supabase/functions/_shared/lineNoteParse.ts
@@ -116,6 +116,46 @@ export function parseNoteComment(text, authorName = "") {
   return { memberNo: fromName, memberNoSource: fromName ? "name" : null, orders: parseOrderLines(rest) };
 }
 
+// ── 貼文 ↔ 團 的比對 ────────────────────────────────────────────────────────
+// 兩邊都正規化（NFKC、去空白、小寫）再比 includes。團名常有前後空白、全形字、
+// "N6090802#" / "#B2967" 這種代碼；記事本內文又常只寫商品名。依序試：
+// 團號 → 團名 → 團名裡的代碼 → 該團品項的商品名（團只有 ≤3 項時才用，免得誤中）。
+// 多個團都命中取「命中字串最長」的；一樣長就不猜（回 null，留給人工）。
+export function normalizeForMatch(s) {
+  return String(s ?? "").normalize("NFKC").toLowerCase().replace(/\s+/g, "");
+}
+
+export function matchCampaign(text, campaigns) {
+  const t = normalizeForMatch(text);
+  if (!t) return null;
+  let best = null;
+  let tie = false;
+  for (const c of campaigns ?? []) {
+    const keys = [];
+    if (c.campaign_no) keys.push(c.campaign_no);
+    if (c.name) {
+      keys.push(c.name);
+      const m = String(c.name).match(/([A-Za-z]?\d{4,}[A-Za-z0-9-]*)\s*#|#\s*([A-Za-z]?\d{3,}[A-Za-z0-9-]*)/);
+      const code = m?.[1] ?? m?.[2];
+      if (code && code.length >= 4) keys.push(code);
+    }
+    const items = c.campaign_items ?? [];
+    if (items.length > 0 && items.length <= 3) {
+      for (const it of items) {
+        const pn = it?.skus?.product_name;
+        if (pn && normalizeForMatch(pn).length >= 4) keys.push(pn);
+      }
+    }
+    for (const k of keys) {
+      const nk = normalizeForMatch(k);
+      if (nk.length < 3 || !t.includes(nk)) continue;
+      if (!best || nk.length > best.len) { best = { c, len: nk.length }; tie = false; }
+      else if (nk.length === best.len && best.c.id !== c.id) tie = true;
+    }
+  }
+  return best && !tie ? best.c : null;
+}
+
 /** 貼文標題：取第一個非空白行，最多 60 字 */
 export function postTitle(text) {
   const first = String(text ?? "").split(/\r?\n/).map((s) => s.trim()).find(Boolean) ?? "";

--- a/supabase/functions/line-note-worker/index.ts
+++ b/supabase/functions/line-note-worker/index.ts
@@ -27,7 +27,7 @@ import { corsHeaders } from "../_shared/cors.ts";
 import {
   clientFromToken, createNotePost, listComments, listHomes, listPosts, loginByQr, whoami,
 } from "../_shared/lineNote.ts";
-import { parseNoteComment, postTitle } from "../_shared/lineNoteParse.ts";
+import { matchCampaign, parseNoteComment, postTitle } from "../_shared/lineNoteParse.ts";
 
 const SUPABASE_URL = requireEnv("SUPABASE_URL");
 const SERVICE_KEY = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
@@ -245,20 +245,20 @@ async function readPost(client: any, post: any) {
   return { comments: comments.length, pending: pending?.length ?? 0, ordered, other };
 }
 
-// 認貼文：小幫手手貼的團（內文含開團中／已收單的團名或團號）也綁進來
+// 認貼文：小幫手手貼的團也綁進來（比對規則見 matchCampaign）
 async function discoverPosts(client: any, community: any) {
   const since = new Date(Date.now() - community.read_days * 86400_000).toISOString();
   const notes = await listPosts(client, community.home_id, { limit: 100, since, verbose: VERBOSE });
   if (notes.length === 0) return 0;
   const known = await rest(`line_note_posts?community_id=eq.${community.id}&select=id,status,line_post_id,campaign_id`);
   const knownByLineId = new Map((known ?? []).filter((p: any) => p.line_post_id).map((p: any) => [p.line_post_id, p]));
-  const campaigns = await rest(`group_buy_campaigns?tenant_id=eq.${community.tenant_id}&status=in.(open,closed)&select=id,name,campaign_no&order=id.desc&limit=200`);
+  const campaigns = await rest(`group_buy_campaigns?tenant_id=eq.${community.tenant_id}&status=in.(open,closed)&select=id,name,campaign_no,campaign_items(skus(product_name))&order=id.desc&limit=300`);
   let linked = 0;
   for (const n of notes) {
     if (!n.postId || knownByLineId.has(String(n.postId))) continue;
     const text = String(n.text ?? "");
-    const hit = (campaigns ?? []).find((c: any) => (c.name && text.includes(c.name)) || (c.campaign_no && text.includes(c.campaign_no)));
-    if (!hit) continue;
+    const hit = matchCampaign(text, campaigns ?? []);
+    if (!hit) { log(`認不出貼文 ${n.postId}：${postTitle(text)}`); continue; }
     const existing = (known ?? []).find((p: any) => p.campaign_id === hit.id);
     const row = { status: "posted", line_post_id: String(n.postId), text, posted_at: n.createdAt ?? new Date().toISOString(), last_error: null };
     if (existing) {

--- a/tools/line-note-scraper/src/line.mjs
+++ b/tools/line-note-scraper/src/line.mjs
@@ -302,7 +302,11 @@ export async function listPosts(client, homeId, { limit = 200, since = null, ver
     let stop = false;
     for (const p of posts) {
       if (out.some((x) => x.postId === p.postId)) { stop = true; break; }
-      if (sinceMs && p.createdAt && new Date(p.createdAt).getTime() < sinceMs) { stop = true; break; }
+      // ⚠ LINE 的列表是依 updatedTime 排序（翻頁游標就是 updatedTime），所以「早於 since 就停」
+      //   要看 updatedAt，不能看 createdAt —— 舊貼文一有新留言就會排到最前面，用 createdAt 判斷
+      //   會在第一頁就停掉，後面幾十篇全漏（2026-09-09 抓不到全部貼文就是這個）。
+      const lastTouched = p.updatedAt ?? p.createdAt;
+      if (sinceMs && lastTouched && new Date(lastTouched).getTime() < sinceMs) { stop = true; break; }
       out.push(p);
     }
     if (stop) break;

--- a/tools/line-note-scraper/src/parse.mjs
+++ b/tools/line-note-scraper/src/parse.mjs
@@ -111,6 +111,46 @@ export function parseNoteComment(text, authorName = "") {
   return { memberNo: fromName, memberNoSource: fromName ? "name" : null, orders: parseOrderLines(rest) };
 }
 
+// ── 貼文 ↔ 團 的比對 ────────────────────────────────────────────────────────
+// 兩邊都正規化（NFKC、去空白、小寫）再比 includes。團名常有前後空白、全形字、
+// "N6090802#" / "#B2967" 這種代碼；記事本內文又常只寫商品名。依序試：
+// 團號 → 團名 → 團名裡的代碼 → 該團品項的商品名（團只有 ≤3 項時才用，免得誤中）。
+// 多個團都命中取「命中字串最長」的；一樣長就不猜（回 null，留給人工）。
+export function normalizeForMatch(s) {
+  return String(s ?? "").normalize("NFKC").toLowerCase().replace(/\s+/g, "");
+}
+
+export function matchCampaign(text, campaigns) {
+  const t = normalizeForMatch(text);
+  if (!t) return null;
+  let best = null;
+  let tie = false;
+  for (const c of campaigns ?? []) {
+    const keys = [];
+    if (c.campaign_no) keys.push(c.campaign_no);
+    if (c.name) {
+      keys.push(c.name);
+      const m = String(c.name).match(/([A-Za-z]?\d{4,}[A-Za-z0-9-]*)\s*#|#\s*([A-Za-z]?\d{3,}[A-Za-z0-9-]*)/);
+      const code = m?.[1] ?? m?.[2];
+      if (code && code.length >= 4) keys.push(code);
+    }
+    const items = c.campaign_items ?? [];
+    if (items.length > 0 && items.length <= 3) {
+      for (const it of items) {
+        const pn = it?.skus?.product_name;
+        if (pn && normalizeForMatch(pn).length >= 4) keys.push(pn);
+      }
+    }
+    for (const k of keys) {
+      const nk = normalizeForMatch(k);
+      if (nk.length < 3 || !t.includes(nk)) continue;
+      if (!best || nk.length > best.len) { best = { c, len: nk.length }; tie = false; }
+      else if (nk.length === best.len && best.c.id !== c.id) tie = true;
+    }
+  }
+  return best && !tie ? best.c : null;
+}
+
 /** 貼文標題：取第一個非空白行，最多 60 字 */
 export function postTitle(text) {
   const first = String(text ?? "").split(/\r?\n/).map((s) => s.trim()).find(Boolean) ?? "";

--- a/tools/line-note-scraper/src/parse.test.mjs
+++ b/tools/line-note-scraper/src/parse.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseOrderLines, postTitle, normalize, extractMemberNo, parseNoteComment } from "./parse.mjs";
+import { parseOrderLines, postTitle, normalize, extractMemberNo, parseNoteComment, matchCampaign, normalizeForMatch } from "./parse.mjs";
 
 test("extractMemberNo", () => {
   assert.deepEqual(extractMemberNo("123456 A+1"), { hint: "123456", rest: "A+1" });
@@ -123,4 +123,42 @@ test("normalize + title", () => {
   assert.equal(normalize("Ａ＋１"), "Ａ+1");
   assert.equal(postTitle("\n  🍓 草莓開團  \n價格 100"), "🍓 草莓開團");
   assert.equal(postTitle("x".repeat(70)).length, 61);
+});
+
+// ── 貼文 ↔ 團 的比對（線上抓不到全部貼文那次的實際團名） ────────────────────
+const CAMPAIGNS = [
+  { id: 1, campaign_no: "GRP-20260909-017", name: "N6090802#抽繩系帶不規則屁簾長裙" },
+  { id: 2, campaign_no: "GRP-20260907-010", name: "#B2967 親膚百搭圓領長袖上衣" },
+  { id: 3, campaign_no: "GRP-20260906-022", name: "丹波黑豆 300克/包(全素)" },
+  { id: 4, campaign_no: "GRP-20260909-014", name: "磁吸迷你拆信刀(顏色隨機)" },
+  { id: 5, campaign_no: "GRP-20260909-007", name: "台南白菜胡椒雞", campaign_items: [{ skus: { product_name: "台南白菜胡椒雞900克大份量" } }] },
+];
+const hit = (text) => matchCampaign(text, CAMPAIGNS)?.id ?? null;
+
+test("normalizeForMatch", () => {
+  assert.equal(normalizeForMatch("　全形 空白　Ａ"), "全形空白a");
+  assert.equal(normalizeForMatch(null), "");
+});
+
+test("matchCampaign", () => {
+  assert.equal(hit("N6090802# 抽繩系帶不規則屁簾長裙\n$399"), 1);   // 團名帶代碼、內文多空白
+  assert.equal(hit("【#B2967】親膚百搭圓領長袖上衣 $290"), 2);        // # 在前的代碼
+  assert.equal(hit("丹波黑豆　300克／包(全素)\n$150"), 3);            // 全形空白／斜線
+  assert.equal(hit("磁吸迷你拆信刀(顏色隨機)\n($)(1)(0)(5)"), 4);
+  assert.equal(hit("GRP-20260906-022 補貼"), 3);                       // 團號
+  assert.equal(hit("台南白菜胡椒雞900克大份量 特價"), 5);              // 只寫商品名
+  assert.equal(hit("今天公休喔～"), null);                              // 聊天不該中
+  assert.equal(hit(""), null);
+  assert.equal(matchCampaign("丹波黑豆", null), null);
+});
+
+test("matchCampaign 取最長命中、平手不猜", () => {
+  const cs = [
+    { id: 10, name: "黑豆" },
+    { id: 11, name: "丹波黑豆 300克" },
+    { id: 12, name: "丹波黑豆 500克" },
+  ];
+  assert.equal(matchCampaign("丹波黑豆 300克/包", cs)?.id, 11);        // 比 id:10 長
+  assert.equal(matchCampaign("黑豆", cs), null);                        // 2 字太短，刻意不比（會誤中）
+  assert.equal(matchCampaign("丹波黑豆 300克 丹波黑豆 500克", cs), null); // 兩個一樣長 → 不猜
 });

--- a/tools/line-note-scraper/src/worker.mjs
+++ b/tools/line-note-scraper/src/worker.mjs
@@ -20,7 +20,7 @@ import { fileURLToPath } from "node:url";
 import { loginWithAuthToken, loginWithQR } from "@evex/linejs";
 import { FileStorage } from "@evex/linejs/storage";
 import { createNotePost, listComments, listHomes, listPosts, whoami } from "./line.mjs";
-import { parseNoteComment, postTitle } from "./parse.mjs";
+import { matchCampaign, parseNoteComment, postTitle } from "./parse.mjs";
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -270,13 +270,13 @@ async function discoverPosts(client, community) {
   if (notes.length === 0) return 0;
   const known = await rest(`line_note_posts?community_id=eq.${community.id}&select=id,status,line_post_id,campaign_id`);
   const knownByLineId = new Map((known ?? []).filter((p) => p.line_post_id).map((p) => [p.line_post_id, p]));
-  const campaigns = await rest(`group_buy_campaigns?tenant_id=eq.${community.tenant_id}&status=in.(open,closed)&select=id,name,campaign_no&order=id.desc&limit=200`);
+  const campaigns = await rest(`group_buy_campaigns?tenant_id=eq.${community.tenant_id}&status=in.(open,closed)&select=id,name,campaign_no,campaign_items(skus(product_name))&order=id.desc&limit=300`);
   let linked = 0;
   for (const n of notes) {
     if (!n.postId || knownByLineId.has(String(n.postId))) continue;
     const text = String(n.text ?? "");
-    const hit = (campaigns ?? []).find((c) => (c.name && text.includes(c.name)) || (c.campaign_no && text.includes(c.campaign_no)));
-    if (!hit) continue;
+    const hit = matchCampaign(text, campaigns ?? []);
+    if (!hit) { log(`認不出貼文 ${n.postId}：${postTitle(text)}`); continue; }
     const existing = (known ?? []).find((p) => p.campaign_id === hit.id);
     const row = { status: "posted", line_post_id: String(n.postId), text, posted_at: n.createdAt ?? new Date().toISOString(), last_error: null };
     if (existing) {


### PR DESCRIPTION
**已重建在最新 main 上，衝突解掉了**（原分支疊在 #925／#927 上，那兩支的內容已隨 #928 進 main）。現在只剩兩個 commit。

## 1. 貼文抓不齊（兩個原因）

**a. `since` 看錯欄位。** `listPosts` 的「早於 since 就停」用 `createdAt`，但 LINE 的列表是**依 `updatedTime` 排序**、翻頁游標也是 `updatedTime` —— 舊貼文只要有新留言就排到最前面，於是第一頁就停掉，後面幾十篇全漏。改看 `updatedAt`。

**b. 比對太嚴。** 原本是 `text.includes(團名)`，實際團名長這樣：`N6090802#抽繩系帶不規則屁簾長裙`、`#B2967 親膚百搭圓領長袖上衣`、`丹波黑豆 300克/包(全素)`，記事本內文空白／全形字對不上就整篇認不出來。

改用 `matchCampaign`：兩邊 NFKC + 去空白 + 小寫再比，依序試 團號 → 團名 → 團名裡的代碼 → 該團品項的商品名（團 ≤3 項才用，免得誤中）；多個命中取最長、平手不猜；認不出來的寫 log。放在 `parse.mjs`（純函式、有測試）。

**線上驗證**：Edge Function 部署 v4，跑一輪 read 後 `line_note_posts` 從 68 → 72 篇。

## 2. 頁面留白

`/line-notes` 補 `p-6`，不再貼齊左上角。

## 3. 貼文分頁改手風琴

點一列展開，顯示「已加單 N／已有訂單 N／待處理 N、共 N 則留言」加留言清單。不顯示貼文內容。

## 4. 訂單號可點

留言加單分頁與貼文展開清單的單號做成連結，點了開既有的 `OrderDetail` 彈窗（比照 `CampaignOrdersPanel` / `MemberDetail` 的用法，彈窗內再點別張單也能接著跳）。

測試：解析器 16/16（新增 `matchCampaign` / `normalizeForMatch` 案例，用線上真實團名）；對最新 main `tsc --noEmit` 通過；Playwright 假資料截圖確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ