### PR TITLE
fix(line-notes): 機器人來源標記、貼文可刪、統計移到列上、排程只在設定時間跑、忽略可重試

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -40,6 +40,7 @@ type Comment = {
 };
 type Row = Comment & { line_note_posts: { community_id: number; campaign_id: number; group_buy_campaigns: { name: string; campaign_no: string } | null } | null };
 type OrderInfo = { id: number; order_no: string; store_name: string | null };
+type PostStat = { ordered: number; duplicate: number; todo: number; total: number };
 type Home = { kind: string; homeId: string; name: string };
 type Campaign = { id: number; campaign_no: string; name: string; status: string };
 
@@ -148,7 +149,7 @@ export default function LineNotesPage() {
           <h1 className="text-xl font-semibold">LINE 記事本</h1>
           <p className="text-sm text-zinc-500">
             備用 LINE 帳號登入 → 綁社群 → 開團自動發文 → 定時讀留言，留言裡的「會員編號 6 碼 ＋ A+1」自動加單。
-            排程每分鐘自動跑（Supabase），不用另外開程式。
+            到設定的讀取時間自動跑（Supabase 排程），不用另外開程式。
           </p>
         </div>
         <nav className="flex gap-1 rounded-lg bg-zinc-100 p-1 dark:bg-zinc-800">
@@ -395,7 +396,7 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
       <Table>
         <THead><Th>社群</Th><Th>帳號</Th><Th>店家</Th><Th>監聽</Th><Th>讀取時間</Th><Th>開團自動發文</Th><Th>最後讀取</Th><Th align="right">操作</Th></THead>
         <TBody>
-          {communities === null ? <LoadingRow colSpan={8} /> : communities.length === 0 ? <EmptyRow colSpan={8}>還沒有社群</EmptyRow> : communities.map((c) => {
+          {communities === null ? <LoadingRow colSpan={7} /> : communities.length === 0 ? <EmptyRow colSpan={8}>還沒有社群</EmptyRow> : communities.map((c) => {
             const a = accountById.get(c.account_id);
             return (
               <Tr key={c.id}>
@@ -411,7 +412,7 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
                 <Td>{c.auto_post_on_open ? "是" : "否"}</Td>
                 <Td>{fmt(c.last_read_at)}</Td>
                 <Td align="right">
-                  <div className="flex justify-end gap-1">
+                  <div className="flex justify-end gap-1 whitespace-nowrap">
                     <SpinButton type="button" className={btn} loading={busy === c.id} onClick={() => readNow(c)}>立即讀取</SpinButton>
                     <button type="button" className={btn} onClick={() => setPostFor(c)}>發文</button>
                     <button type="button" className={btn} onClick={() => openEdit(c)}>編輯</button>
@@ -674,6 +675,28 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
   const [detail, setDetail] = useState<Map<number, Comment[]>>(new Map());
   const [orderNos, setOrderNos] = useState<Map<number, string>>(new Map());
   const [loadingId, setLoadingId] = useState<number | null>(null);
+  // 每篇貼文的留言統計。收合時也要看得到，所以一次把清單上所有貼文的留言狀態撈回來自己數
+  // （只取 post_id + status + member_no_hint 三欄，比逐篇展開才查省很多）。
+  const [counts, setCounts] = useState<Map<number, PostStat>>(new Map());
+
+  const loadCounts = useCallback(async () => {
+    const ids = (posts ?? []).map((p) => p.id);
+    if (ids.length === 0) { setCounts(new Map()); return; }
+    const { data, error } = await getSupabase().from("line_note_comments")
+      .select("post_id,status,member_no_hint").in("post_id", ids);
+    if (error) return;   // 統計拿不到就不顯示，不要擋住整頁
+    const m = new Map<number, PostStat>();
+    for (const r of (data ?? []) as { post_id: number; status: Comment["status"]; member_no_hint: string | null }[]) {
+      const cur = m.get(r.post_id) ?? { ordered: 0, duplicate: 0, todo: 0, total: 0 };
+      cur.total++;
+      if (r.status === "ordered") cur.ordered++;
+      else if (r.status === "duplicate") cur.duplicate++;
+      else if (["pending", "unmatched", "error"].includes(r.status) || (r.status === "no_order" && r.member_no_hint)) cur.todo++;
+      m.set(r.post_id, cur);
+    }
+    setCounts(m);
+  }, [posts]);
+  useEffect(() => { void loadCounts(); }, [loadCounts]);
 
   const toggle = async (p: Post) => {
     if (open === p.id) { setOpen(null); return; }
@@ -707,24 +730,44 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
     kickWorker();
     setDetail((m) => { const n = new Map(m); n.delete(p.id); return n; });
     notify("已開始讀取，留言幾秒後會出現在「留言加單」");
+    setTimeout(() => { void loadCounts(); }, 6000);   // worker 跑完大概這個時間，順手把統計刷新
   };
 
-  const stat = (cs: Comment[]) => ({
-    ordered: cs.filter((c) => c.status === "ordered").length,
-    duplicate: cs.filter((c) => c.status === "duplicate").length,
-    todo: cs.filter((c) => ["pending", "unmatched", "error"].includes(c.status) || (c.status === "no_order" && c.member_no_hint)).length,
-  });
+  const removePost = async (p: Post) => {
+    const name = p.group_buy_campaigns?.name ?? `#${p.id}`;
+    if (!window.confirm(`刪除「${name}」這篇貼文的紀錄？\n\n只清掉記事本這邊的貼文與留言紀錄，已經加出來的訂單不會動（要退單請到訂單那邊）。`)) return;
+    setBusy(p.id);
+    const { error } = await getSupabase().rpc("rpc_line_note_post_delete", { p_id: p.id });
+    setBusy(null);
+    if (error) return fail(error);
+    if (open === p.id) setOpen(null);
+    notify("已刪除");
+    await reload();
+  };
+
+  // 收合時顯示的統計徽章
+  const statBadges = (st: PostStat | undefined) => {
+    if (!st || st.total === 0) return <span className="text-xs text-zinc-400">—</span>;
+    return (
+      <div className="flex flex-wrap items-center gap-1">
+        {st.ordered > 0 && <Badge tone="green">已加單 {st.ordered}</Badge>}
+        {st.duplicate > 0 && <Badge tone="blue">已有訂單 {st.duplicate}</Badge>}
+        {st.todo > 0 && <Badge tone="red">待處理 {st.todo}</Badge>}
+        {st.ordered === 0 && st.duplicate === 0 && st.todo === 0 && <span className="text-xs text-zinc-400">無下單</span>}
+      </div>
+    );
+  };
 
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <p className="text-sm text-zinc-500">開團自動發的、和小幫手手貼後被系統認出來的貼文。點一列展開看加了幾單。</p>
+        <p className="text-sm text-zinc-500">開團自動發的、和小幫手手貼後被系統認出來的貼文。點一列展開看每則留言。</p>
         <button type="button" className={btn} onClick={() => void reload()}>重新整理</button>
       </div>
       <Table>
-        <THead><Th></Th><Th>團</Th><Th>社群</Th><Th>狀態</Th><Th>發文</Th><Th>最後讀取</Th><Th align="right">留言</Th><Th align="right"></Th></THead>
+        <THead><Th></Th><Th>團</Th><Th>發文</Th><Th>加單結果</Th><Th>最後讀取</Th><Th align="right">留言</Th><Th align="right"></Th></THead>
         <TBody>
-          {posts === null ? <LoadingRow colSpan={8} /> : posts.length === 0 ? <EmptyRow colSpan={8}>還沒有貼文</EmptyRow> : posts.flatMap((p) => {
+          {posts === null ? <LoadingRow colSpan={8} /> : posts.length === 0 ? <EmptyRow colSpan={7}>還沒有貼文</EmptyRow> : posts.flatMap((p) => {
             const c = communityById.get(p.community_id);
             const cs = p.group_buy_campaigns?.status;
             const expanded = open === p.id;
@@ -732,41 +775,40 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
             const rows = [
               <Tr key={p.id} onClick={() => void toggle(p)} className={expanded ? "bg-sky-50 dark:bg-sky-950/30" : ""}>
                 <Td className="w-8 text-zinc-400">{expanded ? "▾" : "▸"}</Td>
-                <Td>
+                <Td className="min-w-[16rem]">
                   <div className="font-medium">{p.group_buy_campaigns?.name ?? p.campaign_id}</div>
-                  <div className="mt-0.5 flex items-center gap-2 text-xs text-zinc-500">
+                  <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-zinc-500">
                     {cs && <span className={`rounded px-1.5 py-0.5 ${campaignStatusBadge(cs)}`}>{campaignStatusLabel(cs)}</span>}
                     <span className="font-mono">{p.group_buy_campaigns?.campaign_no}</span>
+                    <span>{c?.home_name || c?.home_id || p.community_id}</span>
                   </div>
                 </Td>
-                <Td className="whitespace-nowrap">{c?.home_name || c?.home_id || p.community_id}</Td>
-                <Td>
+                <Td className="whitespace-nowrap">
                   <Badge tone={p.status === "posted" ? "green" : p.status === "queued" ? "amber" : p.status === "failed" ? "red" : "gray"}>{POST_STATUS[p.status]}</Badge>
-                  {p.last_error && <div className="mt-1 max-w-xs truncate text-xs text-red-600" title={p.last_error}>{p.last_error}</div>}
+                  <div className="mt-0.5 text-xs text-zinc-500">{fmt(p.posted_at)}</div>
+                  {p.last_error && <div className="mt-1 max-w-[14rem] truncate text-xs text-red-600" title={p.last_error}>{p.last_error}</div>}
                 </Td>
-                <Td className="whitespace-nowrap">{fmt(p.posted_at)}</Td>
+                <Td>{statBadges(counts.get(p.id))}</Td>
                 <Td className="whitespace-nowrap">{fmt(p.last_read_at)}</Td>
-                <Td align="right" className="tabular-nums">{p.comment_count}</Td>
+                <Td align="right" className="tabular-nums">{counts.get(p.id)?.total ?? p.comment_count}</Td>
                 <Td align="right">
-                  {p.status === "posted" && (
-                    <SpinButton type="button" className={btn} loading={busy === p.id}
-                      onClick={(e) => { e.stopPropagation(); void readNow(p); }}>立即讀取</SpinButton>
-                  )}
+                  <div className="flex justify-end gap-1">
+                    {p.status === "posted" && (
+                      <SpinButton type="button" className={btn} loading={busy === p.id}
+                        onClick={(e) => { e.stopPropagation(); void readNow(p); }}>立即讀取</SpinButton>
+                    )}
+                    <SpinButton type="button" className={`${btn} text-red-600`} loading={busy === p.id}
+                      onClick={(e) => { e.stopPropagation(); void removePost(p); }}>刪除</SpinButton>
+                  </div>
                 </Td>
               </Tr>,
             ];
             if (expanded) {
               rows.push(
                 <tr key={`${p.id}-d`} className="bg-zinc-50 dark:bg-zinc-900/50">
-                  <td colSpan={8} className="px-4 py-3">
+                  <td colSpan={7} className="px-4 py-3">
                     {loadingId === p.id ? <div className="text-sm text-zinc-400">讀取中…</div> : !cmts ? null : (
                       <div className="space-y-2">
-                        <div className="flex flex-wrap items-center gap-2 text-sm">
-                          <Badge tone="green">已加單 {stat(cmts).ordered}</Badge>
-                          {stat(cmts).duplicate > 0 && <Badge tone="blue">已有訂單 {stat(cmts).duplicate}</Badge>}
-                          {stat(cmts).todo > 0 && <Badge tone="red">待處理 {stat(cmts).todo}</Badge>}
-                          <span className="text-zinc-500">共 {cmts.length} 則留言</span>
-                        </div>
                         {cmts.length === 0 ? <div className="text-sm text-zinc-400">還沒讀到留言</div> : (
                           <ul className="divide-y divide-zinc-200 rounded border border-zinc-200 bg-white dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
                             {cmts.map((cm) => (

--- a/supabase/migrations/20260909030000_line_note_bot_source_fix_and_post_delete.sql
+++ b/supabase/migrations/20260909030000_line_note_bot_source_fix_and_post_delete.sql
@@ -1,0 +1,252 @@
+-- ============================================================================
+-- 20260909030000_line_note_bot_source_fix_and_post_delete.sql
+--
+-- 1. 機器人加的單來源沒被標成 line_bot（還是顯示「小幫手」）。
+--    20260909020000 的收尾用 `coi.created_at >= v_t0`（v_t0 := clock_timestamp()），
+--    但 customer_order_items.created_at 的預設是 **NOW()＝交易開始時間**，
+--    而 v_t0 是函式內才取的、必定晚於 NOW() → 條件永遠 false，一列都沒更新。
+--    線上實例 GRP-20260906-022-0101：order_at = item_at = 11:51:07.925，source 仍是 manual。
+--    改成不看時間：只更新「這次要加的 campaign_item + 還是 pending + 來源 manual」的列。
+--    去重那段已經保證這些 campaign_item 在本單沒有 active 列，所以配到的一定是剛插進去的；
+--    先前被取消的舊列是 cancelled，不會被掃到。
+--
+-- 2. 回填已經加錯的：機器人建的單 created_by IS NULL（service_role 呼叫時 auth.uid() 是 NULL），
+--    小幫手從後台加的一定有 staff uid → 用這個區分，安全。
+--
+-- 3. 貼文可以刪除（rpc_line_note_post_delete）。失敗的貼文（fetch failed 那批）留著沒用，
+--    而且會一直出現在清單裡。line_note_posts 只 GRANT SELECT，所以走 RPC 刪。
+--
+-- 基底：rpc_line_note_apply_comment @ 20260909020000（唯一前版，已 grep 確認）。
+--       找人／取貨店／去重／duplicate 全部原樣，只動最後那段 UPDATE source。
+-- rollback：還原 20260909020000 的 rpc_line_note_apply_comment；
+--           DROP FUNCTION public.rpc_line_note_post_delete(BIGINT);
+--           （回填不還原 —— 那些單本來就是機器人加的）
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. 修 source 標記
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_apply_comment(p_comment_id BIGINT)
+RETURNS TABLE (out_status TEXT, out_order_id BIGINT, out_error TEXT)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_c            line_note_comments%ROWTYPE;
+  v_tenant       UUID;
+  v_campaign_id  BIGINT;
+  v_channel_id   BIGINT;
+  v_member_id    BIGINT;
+  v_member_home  BIGINT;
+  v_ambiguous    TEXT;
+  v_hint         TEXT;
+  v_items        JSONB := '[]'::jsonb;
+  v_new_items    JSONB := '[]'::jsonb;
+  v_dup_codes    TEXT[] := ARRAY[]::TEXT[];
+  v_dup_order    BIGINT;
+  v_p            JSONB;
+  v_code         TEXT;
+  v_qty          NUMERIC;
+  v_ci           BIGINT;
+  v_item_count   INT;
+  v_order_id     BIGINT;
+  v_err          TEXT;
+  v_claim_tenant TEXT := auth.jwt() ->> 'tenant_id';
+BEGIN
+  SELECT * INTO v_c FROM line_note_comments WHERE id = p_comment_id;
+  IF v_c.id IS NULL THEN RAISE EXCEPTION 'comment % not found', p_comment_id; END IF;
+  v_tenant := v_c.tenant_id;
+
+  -- 呼叫者是後台使用者 → tenant 要對得上；是 service_role → 補 claims 給下游 RPC 用
+  IF v_claim_tenant IS NOT NULL AND v_claim_tenant <> '' THEN
+    IF v_claim_tenant::uuid <> v_tenant THEN RAISE EXCEPTION 'comment % not in tenant', p_comment_id; END IF;
+  ELSE
+    PERFORM set_config('request.jwt.claims',
+      jsonb_build_object('tenant_id', v_tenant,
+                         'app_metadata', jsonb_build_object('tenant_id', v_tenant, 'role', 'admin'))::text,
+      TRUE);
+  END IF;
+
+  IF v_c.status IN ('ordered','ignored','resolved','duplicate') THEN
+    RETURN QUERY SELECT v_c.status, v_c.customer_order_id, v_c.error; RETURN;
+  END IF;
+
+  SELECT p.campaign_id INTO v_campaign_id FROM line_note_posts p WHERE p.id = v_c.post_id;
+
+  -- 沒有任何數量 → 不是下單留言
+  IF jsonb_array_length(COALESCE(v_c.parsed, '[]'::jsonb)) = 0 THEN
+    UPDATE line_note_comments SET status = 'no_order', processed_at = NOW() WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'no_order'::TEXT, NULL::BIGINT, NULL::TEXT; RETURN;
+  END IF;
+
+  -- 會員：6 碼 → member_no 或姓名裡的號碼
+  v_hint := NULLIF(TRIM(COALESCE(v_c.member_no_hint, '')), '');
+  IF v_hint IS NULL THEN
+    UPDATE line_note_comments SET status = 'unmatched', error = '留言裡沒有 6 碼會員編號', processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'unmatched'::TEXT, NULL::BIGINT, '留言裡沒有 6 碼會員編號'::TEXT; RETURN;
+  END IF;
+
+  SELECT f.member_id, f.home_store_id, f.ambiguous
+    INTO v_member_id, v_member_home, v_ambiguous
+    FROM public._line_note_find_member(v_tenant, v_hint) f;
+
+  IF v_member_id IS NULL THEN
+    v_err := COALESCE(v_ambiguous, '找不到會員編號 ' || v_hint);
+    UPDATE line_note_comments SET status = CASE WHEN v_ambiguous IS NULL THEN 'unmatched' ELSE 'error' END,
+                                  error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT (CASE WHEN v_ambiguous IS NULL THEN 'unmatched' ELSE 'error' END)::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+
+  -- 取貨店＝會員自己的店，沒有就不加
+  IF v_member_home IS NULL THEN
+    v_err := '會員沒有設定取貨店，請先到會員資料補上';
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+  v_channel_id := public._line_note_pick_channel(v_tenant, v_member_home);
+  IF v_channel_id IS NULL THEN
+    v_err := '這個租戶沒有任何啟用中的 LINE 渠道，無法建單';
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+
+  -- 品項：code → campaign_item；沒 code 且團只有一項 → 那一項
+  SELECT count(*) INTO v_item_count FROM public._line_note_item_codes(v_campaign_id);
+  FOR v_p IN SELECT * FROM jsonb_array_elements(v_c.parsed) LOOP
+    IF COALESCE((v_p ->> 'cancel')::boolean, FALSE) THEN CONTINUE; END IF;  -- 取消留言不自動處理，留給人看
+    v_qty  := (v_p ->> 'qty')::numeric;
+    v_code := UPPER(NULLIF(TRIM(COALESCE(v_p ->> 'code', '')), ''));
+    IF v_qty IS NULL OR v_qty <= 0 THEN CONTINUE; END IF;
+    IF v_code IS NULL THEN
+      IF v_item_count = 1 THEN
+        SELECT ic.campaign_item_id, ic.code INTO v_ci, v_code FROM public._line_note_item_codes(v_campaign_id) ic;
+      ELSE
+        v_err := '沒寫品項代碼（這團有 ' || v_item_count || ' 項）';
+        EXIT;
+      END IF;
+    ELSE
+      SELECT ic.campaign_item_id INTO v_ci FROM public._line_note_item_codes(v_campaign_id) ic WHERE ic.code = v_code;
+      IF v_ci IS NULL THEN v_err := '品項代碼 ' || v_code || ' 不在這團裡'; EXIT; END IF;
+    END IF;
+    v_items := v_items || jsonb_build_object('campaign_item_id', v_ci, 'qty', v_qty, 'code', v_code);
+  END LOOP;
+
+  IF v_err IS NOT NULL THEN
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+  IF jsonb_array_length(v_items) = 0 THEN
+    UPDATE line_note_comments SET status = 'no_order', member_id = v_member_id, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'no_order'::TEXT, NULL::BIGINT, NULL::TEXT; RETURN;
+  END IF;
+
+  -- 去重：這位會員在這團已經有同一品項的有效訂單（任何來源）→ 那一項不再加
+  FOR v_p IN SELECT * FROM jsonb_array_elements(v_items) LOOP
+    SELECT co.id INTO v_order_id
+      FROM customer_order_items coi
+      JOIN customer_orders co ON co.id = coi.order_id
+     WHERE co.tenant_id = v_tenant
+       AND co.campaign_id = v_campaign_id
+       AND co.member_id = v_member_id
+       AND co.status NOT IN ('cancelled','expired','transferred_out')
+       AND coi.campaign_item_id = (v_p ->> 'campaign_item_id')::bigint
+       AND coi.status <> 'cancelled'
+     ORDER BY co.id LIMIT 1;
+    IF v_order_id IS NOT NULL THEN
+      v_dup_codes := v_dup_codes || COALESCE(v_p ->> 'code', '?');
+      v_dup_order := COALESCE(v_dup_order, v_order_id);
+      v_order_id  := NULL;
+    ELSE
+      v_new_items := v_new_items || jsonb_build_object('campaign_item_id', (v_p ->> 'campaign_item_id')::bigint, 'qty', (v_p ->> 'qty')::numeric);
+    END IF;
+  END LOOP;
+
+  IF jsonb_array_length(v_new_items) = 0 THEN
+    v_err := '已有訂單（' || array_to_string(v_dup_codes, '、') || '），未重複加單';
+    UPDATE line_note_comments
+       SET status = 'duplicate', member_id = v_member_id, customer_order_id = v_dup_order,
+           error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'duplicate'::TEXT, v_dup_order, v_err; RETURN;
+  END IF;
+
+  BEGIN
+    SELECT r.out_order_id INTO v_order_id
+      FROM public.rpc_create_customer_orders(
+             v_campaign_id, v_channel_id,
+             jsonb_build_array(jsonb_build_object(
+               'member_id', v_member_id,
+               'nickname', v_c.commenter_name,
+               'pickup_store_id', v_member_home,
+               'items', v_new_items))) r
+     LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    v_err := SQLERRM;
+  END;
+
+  IF v_err IS NOT NULL THEN
+    UPDATE line_note_comments SET status = 'error', member_id = v_member_id, error = v_err, processed_at = NOW()
+     WHERE id = p_comment_id;
+    RETURN QUERY SELECT 'error'::TEXT, NULL::BIGINT, v_err; RETURN;
+  END IF;
+
+  -- 這次新建的品項列標成機器人來源。
+  -- ⚠ 不要用時間比對：created_at 預設是 NOW()（交易開始），任何在函式內取的
+  --   clock_timestamp() 都比它晚，`created_at >= v_t0` 永遠是 false（20260909020000 的 bug）。
+  --   去重已保證這些 campaign_item 在本單沒有 active 列 → status='pending' 的一定是剛插進去的；
+  --   先前被取消的舊列是 cancelled，掃不到。
+  UPDATE customer_order_items coi
+     SET source = 'line_bot'
+   WHERE coi.order_id = v_order_id
+     AND coi.source = 'manual'
+     AND coi.status = 'pending'
+     AND coi.campaign_item_id IN (SELECT (x ->> 'campaign_item_id')::bigint FROM jsonb_array_elements(v_new_items) x);
+
+  UPDATE line_note_comments
+     SET status = 'ordered', member_id = v_member_id, customer_order_id = v_order_id,
+         error = NULL, processed_at = NOW(),
+         resolution_note = CASE WHEN array_length(v_dup_codes, 1) > 0
+                                THEN '已略過重複：' || array_to_string(v_dup_codes, '、')
+                                ELSE resolution_note END
+   WHERE id = p_comment_id;
+  RETURN QUERY SELECT 'ordered'::TEXT, v_order_id, NULL::TEXT;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_apply_comment(BIGINT) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 2. 回填：機器人已經加過、卻被標成 manual 的品項
+--    判準：這張單被 line_note_comments 認領（customer_order_id），且該列 created_by IS NULL
+--    （service_role 呼叫時 auth.uid() 為 NULL；小幫手從後台加的一定帶 staff uid）。
+-- ----------------------------------------------------------------------------
+UPDATE customer_order_items coi
+   SET source = 'line_bot'
+ WHERE coi.source = 'manual'
+   AND coi.created_by IS NULL
+   AND coi.order_id IN (SELECT DISTINCT c.customer_order_id
+                          FROM line_note_comments c
+                         WHERE c.customer_order_id IS NOT NULL);
+
+-- ----------------------------------------------------------------------------
+-- 3. 刪貼文
+--    只刪 line_note_posts（留言 ON DELETE CASCADE 一起走）。已經建出來的訂單不動 ——
+--    要退單走訂單那邊，這裡只是把記事本這側的紀錄清掉。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_post_delete(p_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+BEGIN
+  DELETE FROM line_note_jobs WHERE post_id = p_id AND tenant_id = v_tenant AND status IN ('queued','running');
+  DELETE FROM line_note_posts WHERE id = p_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'post % not in tenant', p_id; END IF;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_post_delete(BIGINT) TO authenticated;

--- a/supabase/migrations/20260909040000_line_note_tick_only_when_needed.sql
+++ b/supabase/migrations/20260909040000_line_note_tick_only_when_needed.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- 20260909040000_line_note_tick_only_when_needed.sql
+--
+-- cron 還是每分鐘醒來（pg_cron 最小粒度就是分鐘，而且「立即讀取／發文」要能在
+-- 一分鐘內被撿走），但**不要每分鐘都去打 Edge Function**。
+--
+-- 20260909010000 的守門只問「有沒有開監聽的社群」，只要有一個社群開著監聽就每分鐘
+-- 打一次 —— 一天 1,440 次呼叫，其中絕大多數進去什麼都沒做就回來。
+--
+-- 改成兩個條件，符合其一才打：
+--   1. line_note_jobs 有 queued（後台按了立即讀取／發文／載入社群，要馬上跑）
+--   2. 現在這一分鐘（台北時間 HH:MM）正好是某個開監聽社群的 read_times
+-- 松山社群設 08:00 / 12:00 / 18:00 / 23:59 → 一天 4 次，其餘時間只有按鈕才會打。
+--
+-- 基底：_line_note_tick @ 20260909010000（唯一前版，已 grep 確認）。cron job 不動。
+-- rollback：還原 20260909010000 的 _line_note_tick()。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public._line_note_tick()
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_url    TEXT;
+  v_secret TEXT;
+  v_hhmm   TEXT := to_char(now() AT TIME ZONE 'Asia/Taipei', 'HH24:MI');
+BEGIN
+  -- 有事才做：排隊中的工作，或現在正好是某個社群設定的讀取時間
+  IF NOT EXISTS (SELECT 1 FROM line_note_jobs WHERE status = 'queued')
+     AND NOT EXISTS (SELECT 1 FROM line_note_communities
+                      WHERE listen_enabled AND v_hhmm = ANY (read_times))
+  THEN
+    RETURN;
+  END IF;
+
+  SELECT decrypted_secret INTO v_url    FROM vault.decrypted_secrets WHERE name = 'line_note_worker_url'  LIMIT 1;
+  SELECT decrypted_secret INTO v_secret FROM vault.decrypted_secrets WHERE name = 'line_note_cron_secret' LIMIT 1;
+  IF v_url IS NULL OR v_secret IS NULL THEN
+    RAISE NOTICE 'line-note-tick: vault 缺 line_note_worker_url / line_note_cron_secret，略過';
+    RETURN;
+  END IF;
+
+  PERFORM net.http_post(
+    url     := v_url,
+    headers := jsonb_build_object('Content-Type', 'application/json', 'x-line-note-secret', v_secret),
+    body    := '{"action":"tick"}'::jsonb,
+    timeout_milliseconds := 120000
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public._line_note_tick() FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
#929 合併時用到舊的 head，第一個 commit 沒跟著進去，所以重開這一支。**三支 migration 都已套上正式庫。**

## 1. 機器人加的單一直顯示「小幫手」（`20260909030000`）

`20260909020000` 的收尾寫成 `coi.created_at >= v_t0`，其中 `v_t0 := clock_timestamp()`。但 `customer_order_items.created_at` 的預設是 **`NOW()`＝交易開始時間**，必定早於函式內取的 `clock_timestamp()` → 條件永遠 false，一列都沒更新。線上實例 `GRP-20260906-022-0101`：`order_at = item_at = 11:51:07.925`，source 仍是 `manual`。

改成不看時間：只更新「這次要加的 campaign_item ＋ `status='pending'` ＋ `source='manual'`」的列。去重那段已保證這些 campaign_item 在本單沒有 active 列，配到的一定是剛插進去的；先前取消的舊列是 `cancelled`，掃不到。

**回填**：機器人建的單 `created_by IS NULL`（service_role 呼叫時 `auth.uid()` 為 NULL；小幫手從後台加的一定帶 staff uid）。已回填 9 筆，含上面那張。

## 2. 貼文可以刪（`rpc_line_note_post_delete`）

刪貼文＋留言（cascade）＋排隊中的 job；**已經建出來的訂單不動**，要退單走訂單那邊。`line_note_posts` 只 GRANT SELECT，所以走 RPC。

## 3. 加單統計移到列上（收合也看得到）

原本只在展開的面板裡，看起來像浮在別的列上。改成列上的固定欄位，一次撈清單上所有貼文的留言狀態自己數（只取三欄），不用逐篇展開才查。欄位收斂成 7 欄，社群併進團那格。

## 4. cron 不再每分鐘打 Edge Function（`20260909040000`）

原本守門只問「有沒有開監聽的社群」→ 只要有一個開著就每分鐘打，一天 1,440 次多半沒事做。改成符合其一才打：有 `queued` 的工作（後台按了立即讀取／發文），或現在正好是某個社群設定的 `read_times`。松山設 4 個時段 → 一天 4 次。

## 5. 標成忽略／已解決的可以直接「重試」（`20260909050000`）

RPC 原本對 `ordered/ignored/resolved/duplicate` 一律早退，後台只能先「退回待處理」再等排程，兩步而且要等。加 `p_force`，後台按「重試」時帶 TRUE。

9/8 會員比對還壞掉時有 11 則被標忽略（錯誤都是「找不到會員編號 …」），比對修好後那些號碼查得到人 → 要能一鍵重跑。`duplicate` 也放行（先前那張單若已取消，重跑就會真的加進去）；`ordered` 不放行，那會變成重複單。舊的單參數版本已 DROP，避免對 1 個引數的呼叫 ambiguous；Edge Function 已重新部署（v5）。

**線上實測**：一則 `ignored` 的留言帶 force 重跑 → 找到會員、且正確判定「已有訂單」沒重複加。

介面：忽略／已解決／已有訂單的列都給「重試」；篩選加「忽略」分頁。

驗證：三支 migration 過 pg-query 語法檢查（含 plpgsql body），套用後線上確認回填筆數、函式版本數（只剩兩參數版）；`tsc --noEmit` 通過；Playwright 假資料截圖確認收合列的徽章與刪除鈕。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ