### PR TITLE
記事本留言按笑臉：機器人收到 +1 就回按，讓客人知道

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -23,7 +23,8 @@ type Store = { id: number; code: string; name: string };
 type Community = {
   id: number; account_id: number; store_id: number | null; home_id: string; home_name: string | null;
   home_kind: "group" | "square" | "square_chat"; listen_enabled: boolean; read_times: string[];
-  auto_post_on_open: boolean; post_template: string | null; read_days: number; last_read_at: string | null; last_error: string | null;
+  auto_post_on_open: boolean; post_template: string | null; read_days: number; react_on_confirm: boolean;
+  last_read_at: string | null; last_error: string | null;
 };
 type Post = {
   id: number; community_id: number; campaign_id: number; line_post_id: string | null; text: string | null;
@@ -35,7 +36,7 @@ type Comment = {
   id: number; line_comment_id: string; commenter_id: string | null; commenter_name: string | null; text: string;
   commented_at: string | null; member_no_hint: string | null; parsed: { code: string | null; qty: number; cancel: boolean }[];
   status: "pending" | "ordered" | "unmatched" | "no_order" | "error" | "ignored" | "resolved" | "duplicate";
-  member_id: number | null; customer_order_id: number | null; error: string | null;
+  member_id: number | null; customer_order_id: number | null; error: string | null; reacted_at: string | null;
   resolved_at: string | null; resolution_note: string | null;
 };
 type Row = Comment & { line_note_posts: { community_id: number; campaign_id: number; group_buy_campaigns: { name: string; campaign_no: string } | null } | null };
@@ -310,10 +311,12 @@ function AccountsTab({ accounts, reload, notify, fail }: {
 type CommunityForm = {
   id: number | null; account_id: number | ""; store_id: number | ""; home_id: string; home_name: string;
   listen_enabled: boolean; read_times: string; auto_post_on_open: boolean; post_template: string; read_days: number;
+  react_on_confirm: boolean;
 };
 const EMPTY_FORM: CommunityForm = {
   id: null, account_id: "", store_id: "", home_id: "", home_name: "",
   listen_enabled: true, read_times: "12:00", auto_post_on_open: true, post_template: "", read_days: 3,
+  react_on_confirm: true,
 };
 
 function CommunitiesTab({ communities, accounts, stores, accountById, storeById, reload, reloadPosts, notify, fail }: {
@@ -330,7 +333,7 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
   const openEdit = (c: Community) => {
     setHomes(null);
     setForm({ id: c.id, account_id: c.account_id, store_id: c.store_id ?? "", home_id: c.home_id, home_name: c.home_name ?? "",
-      listen_enabled: c.listen_enabled, read_times: c.read_times.join(", "), auto_post_on_open: c.auto_post_on_open, post_template: c.post_template ?? "", read_days: c.read_days ?? 3 });
+      listen_enabled: c.listen_enabled, read_times: c.read_times.join(", "), auto_post_on_open: c.auto_post_on_open, post_template: c.post_template ?? "", read_days: c.read_days ?? 3, react_on_confirm: c.react_on_confirm ?? true });
   };
 
   const loadHomes = async () => {
@@ -361,6 +364,7 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
       p_read_times: form.read_times.split(/[,\s，、]+/).map((s) => s.trim()).filter(Boolean),
       p_auto_post_on_open: form.auto_post_on_open, p_post_template: form.post_template || null,
       p_read_days: Math.min(30, Math.max(1, Math.round(form.read_days || 3))),
+      p_react_on_confirm: form.react_on_confirm,
     });
     setBusy(null);
     if (error) return fail(error);
@@ -471,6 +475,9 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
             </label>
             <label className="flex items-center gap-2 text-sm">
               <input type="checkbox" checked={form.auto_post_on_open} onChange={(e) => setForm({ ...form, auto_post_on_open: e.target.checked })} /> 開團（狀態變「開團中」）時自動發文
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={form.react_on_confirm} onChange={(e) => setForm({ ...form, react_on_confirm: e.target.checked })} /> 收到單後在客人留言上按 😄，讓他知道收到了
             </label>
             <label className="text-sm md:col-span-2">發文模板（留空用預設；可用 {"{{name}} {{description}} {{items}} {{end_at}} {{pickup_deadline}}"}）
               <textarea className={`${input} h-40 font-mono text-xs`} value={form.post_template} onChange={(e) => setForm({ ...form, post_template: e.target.value })}
@@ -605,6 +612,10 @@ function CommentsTab({ communityById, notify, fail }: {
   const todoCount = rows?.filter(isTodo).length ?? 0;
   const ignoredCount = rows?.filter((c) => c.status === "ignored" || c.status === "resolved").length ?? 0;
 
+  // 已經在 LINE 那則留言上按過笑臉的標一下，沒按到的看得出來
+  const reacted = (c: Comment) =>
+    c.reacted_at ? <span title={`已在 LINE 留言上按 😄（${fmt(c.reacted_at)}）`}>😄</span> : null;
+
   // 結果欄：一個徽章 + 一句話
   const result = (c: Comment) => {
     const o = c.customer_order_id ? orders.get(c.customer_order_id) : null;
@@ -612,8 +623,8 @@ function CommentsTab({ communityById, notify, fail }: {
       ? <><span className="text-zinc-600 dark:text-zinc-300">{o.store_name ?? "？店"}</span>{" "}<OrderLink id={o.id} no={o.order_no} /></>
       : c.customer_order_id ? <span>訂單 #{c.customer_order_id}</span> : null;
     switch (c.status) {
-      case "ordered":   return <><Badge tone="green">已加單</Badge>{orderCell}</>;
-      case "duplicate": return <><Badge tone="blue">已有訂單</Badge>{orderCell}</>;
+      case "ordered":   return <><Badge tone="green">已加單</Badge>{orderCell}{reacted(c)}</>;
+      case "duplicate": return <><Badge tone="blue">已有訂單</Badge>{orderCell}{reacted(c)}</>;
       case "resolved":  return <><Badge tone="green">已解決</Badge><span className="text-zinc-500">{c.resolution_note ?? ""}</span></>;
       case "ignored":   return <Badge tone="gray">忽略</Badge>;
       case "pending":   return <Badge tone="amber">等 worker 處理</Badge>;

--- a/supabase/functions/_shared/lineNote.ts
+++ b/supabase/functions/_shared/lineNote.ts
@@ -337,6 +337,25 @@ export async function listComments(client, homeId, postId, { verbose = false, on
  * @param {string} opts.text
  * @param {Uint8Array[]} [opts.images]  JPEG bytes（上傳時 content-type 固定 image/jpeg）
  */
+/**
+ * 在某則留言上按表情（笑臉）。likeType 1003 = 笑
+ * （1001 讚 / 1002 愛心 / 1003 笑 / 1004 驚 / 1005 哭 / 1006 怒）。
+ * contentId 放**留言 id**；actorId 是自己的 mid。走跟讀留言同一套 host/prefix/channel 探測。
+ */
+export async function likeComment(client, homeId, commentId, { likeType = "1003", sourceType = "TIMELINE", verbose = false } = {}) {
+  const res = await noteRequest(client, homeId, "/api/v57/like/create.json",
+    { homeId, sourceType },
+    {
+      method: "POST",
+      body: { contentId: String(commentId), actorId: client.base.profile?.mid ?? "", likeType: String(likeType), sharable: false },
+      verbose,
+    });
+  if (!res || res.code !== 0) {
+    throw new Error(`按表情失敗：code=${res?.code} ${res?.message ?? ""}`);
+  }
+  return res;
+}
+
 export async function createNotePost(client, homeId, { text, images = [], sourceType, verbose = false } = {}) {
   if (!text && images.length === 0) throw new Error("貼文至少要有文字或圖片");
 

--- a/supabase/functions/line-note-worker/index.ts
+++ b/supabase/functions/line-note-worker/index.ts
@@ -25,7 +25,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.8";
 import QRCode from "npm:qrcode@1.5.4";
 import { corsHeaders } from "../_shared/cors.ts";
 import {
-  clientFromToken, createNotePost, listComments, listHomes, listPosts, loginByQr, whoami,
+  clientFromToken, createNotePost, likeComment, listComments, listHomes, listPosts, loginByQr, whoami,
 } from "../_shared/lineNote.ts";
 import { matchCampaign, parseNoteComment, postTitle } from "../_shared/lineNoteParse.ts";
 
@@ -241,8 +241,37 @@ async function readPost(client: any, post: any) {
       await patch("line_note_comments", `id=eq.${c.id}`, { status: "error", error: String((e as any)?.message ?? e).slice(0, 1000) }).catch(() => {});
     }
   }
+  const reacted = await reactToConfirmed(client, post);
   await patch("line_note_posts", `id=eq.${post.id}`, { last_read_at: new Date().toISOString(), comment_count: comments.length, last_error: null });
-  return { comments: comments.length, pending: pending?.length ?? 0, ordered, other };
+  return { comments: comments.length, pending: pending?.length ?? 0, ordered, other, reacted };
+}
+
+const REACT_BATCH = 40;                                  // 每則貼文一次最多按幾則
+const REACT_DEADLINE = Date.now() + 100_000;             // 本次呼叫按表情的總預算（idle timeout 150s）
+
+// 收到單的留言回按一個笑臉，讓客人知道「你的 +1 我收到了」。
+// 只按 ordered / duplicate / resolved —— unmatched、error 還沒處理完，按了會讓客人以為收到了。
+// 按過的記 reacted_at，下次讀留言不會重按。單一則失敗不影響其他則，也不影響讀留言本身。
+async function reactToConfirmed(client: any, post: any): Promise<number> {
+  if (post.react_on_confirm === false) return 0;
+  const rows = await rest(
+    `line_note_comments?post_id=eq.${post.id}&reacted_at=is.null` +
+    `&status=in.(ordered,duplicate,resolved)&select=id,line_comment_id&limit=${REACT_BATCH}`);
+  let n = 0;
+  for (const c of rows ?? []) {
+    if (!c.line_comment_id) continue;
+    // Edge Function 有 150 秒 idle timeout，按表情一則約 1 秒。
+    // 超過預算就留給下一次讀留言接手（reacted_at 是 NULL 的還在，不會漏）。
+    if (Date.now() > REACT_DEADLINE) { log("按表情時間到，剩下的留到下次讀留言"); break; }
+    try {
+      await likeComment(client, post.home_id, c.line_comment_id, { verbose: VERBOSE });
+      await patch("line_note_comments", `id=eq.${c.id}`, { reacted_at: new Date().toISOString() });
+      n++;
+    } catch (e) {
+      log(`留言 ${c.line_comment_id} 按表情失敗（略過）：${(e as any)?.message ?? e}`);
+    }
+  }
+  return n;
 }
 
 // 認貼文：小幫手手貼的團也綁進來（比對規則見 matchCampaign）
@@ -285,14 +314,17 @@ async function jobRead(job: any) {
     }
   }
   const filter = job.post_id ? `id=eq.${job.post_id}` : `community_id=eq.${job.community_id}${sinceFilter}`;
-  const posts = await rest(`line_note_posts?${filter}&status=eq.posted&select=id,tenant_id,line_post_id,community_id,group_buy_campaigns(status),line_note_communities(home_id,account_id)`);
+  const posts = await rest(`line_note_posts?${filter}&status=eq.posted&select=id,tenant_id,line_post_id,community_id,group_buy_campaigns(status),line_note_communities(home_id,account_id,react_on_confirm)`);
   const out: any[] = [];
   for (const p of posts ?? []) {
     const cst = p.group_buy_campaigns?.status;
     if (cst && !["open", "closed"].includes(cst)) { await patch("line_note_posts", `id=eq.${p.id}`, { status: "closed" }); continue; }
     const client = await clientFor(await loadAccount(p.line_note_communities.account_id));
     try {
-      out.push({ post_id: p.id, ...(await readPost(client, { ...p, home_id: p.line_note_communities.home_id })) });
+      out.push({ post_id: p.id, ...(await readPost(client, {
+        ...p, home_id: p.line_note_communities.home_id,
+        react_on_confirm: p.line_note_communities.react_on_confirm,
+      })) });
     } catch (e) {
       await patch("line_note_posts", `id=eq.${p.id}`, { last_error: String((e as any)?.message ?? e).slice(0, 1000) });
       out.push({ post_id: p.id, error: String((e as any)?.message ?? e) });

--- a/supabase/migrations/20260909060000_line_note_comment_reaction.sql
+++ b/supabase/migrations/20260909060000_line_note_comment_reaction.sql
@@ -1,0 +1,35 @@
+-- ============================================================================
+-- 20260909060000_line_note_comment_reaction.sql
+--
+-- 機器人處理完的留言，回頭在 LINE 記事本那則留言上按一個「笑臉」，
+-- 讓客人知道「你的 +1 我收到了」。
+--
+-- likeType 1003 = 笑（LINE 的表情：1001 讚 / 1002 愛心 / 1003 笑 / 1004 驚 / 1005 哭 / 1006 怒），
+-- 走 POST /<prefix>/api/v57/like/create.json（prefix 群組 /mh、社群 /sn，跟讀留言同一套探測）。
+--
+-- 只對「確定收到單」的留言按：ordered（加成單）、duplicate（本來就有單）、
+-- resolved（小幫手自己處理掉）。unmatched / error 不按 —— 那些還沒處理完，
+-- 按了等於跟客人說收到了，客人就不會再來問。
+--
+-- reacted_at 記已經按過的，避免每次讀留言都重按一次。
+-- react_on_confirm 是社群層級的開關（預設開），要關掉不用改程式。
+--
+-- 全部是新欄位，沒有覆蓋既有 function。
+-- rollback：
+--   ALTER TABLE line_note_comments DROP COLUMN reacted_at;
+--   ALTER TABLE line_note_communities DROP COLUMN react_on_confirm;
+-- ============================================================================
+
+ALTER TABLE line_note_comments
+  ADD COLUMN IF NOT EXISTS reacted_at TIMESTAMPTZ;
+COMMENT ON COLUMN line_note_comments.reacted_at IS
+  '已經在 LINE 記事本那則留言上按過表情的時間。NULL = 還沒按。';
+
+CREATE INDEX IF NOT EXISTS idx_line_note_comments_to_react
+  ON line_note_comments (post_id)
+  WHERE reacted_at IS NULL AND status IN ('ordered','duplicate','resolved');
+
+ALTER TABLE line_note_communities
+  ADD COLUMN IF NOT EXISTS react_on_confirm BOOLEAN NOT NULL DEFAULT TRUE;
+COMMENT ON COLUMN line_note_communities.react_on_confirm IS
+  '處理完的留言要不要在 LINE 上按笑臉回覆客人（預設開）。';

--- a/supabase/migrations/20260909070000_line_note_community_react_param.sql
+++ b/supabase/migrations/20260909070000_line_note_community_react_param.sql
@@ -1,0 +1,90 @@
+-- ============================================================================
+-- 20260909070000_line_note_community_react_param.sql
+--
+-- 社群設定加上「收到單後在客人留言按 😄」的開關（欄位 react_on_confirm 見 20260909060000），
+-- 讓 rpc_line_note_community_upsert 收得到它。舊簽名要先 DROP —— 帶預設值的新版對
+-- 既有引數數量的呼叫會 ambiguous。
+--
+-- 基底：rpc_line_note_community_upsert @ 20260909020000（唯一前版，已 grep 確認）。
+-- rollback：DROP 兩參數多出來的版本，還原 20260909020000 的簽名。
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.rpc_line_note_community_upsert(
+  BIGINT, BIGINT, TEXT, TEXT, TEXT, BOOLEAN, TEXT[], BOOLEAN, TEXT, INT, BIGINT);
+
+CREATE OR REPLACE FUNCTION public.rpc_line_note_community_upsert(
+  p_id                BIGINT,
+  p_account_id        BIGINT,
+  p_home_id           TEXT,
+  p_home_name         TEXT,
+  p_home_kind         TEXT,
+  p_listen_enabled    BOOLEAN,
+  p_read_times        TEXT[],
+  p_auto_post_on_open BOOLEAN,
+  p_post_template     TEXT,
+  p_read_days         INT DEFAULT 3,
+  p_store_id          BIGINT DEFAULT NULL,
+  p_react_on_confirm  BOOLEAN DEFAULT TRUE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+  v_id     BIGINT;
+  v_t      TEXT;
+BEGIN
+  PERFORM 1 FROM line_note_accounts WHERE id = p_account_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'account % not in tenant', p_account_id; END IF;
+  IF p_store_id IS NOT NULL THEN
+    PERFORM 1 FROM stores WHERE id = p_store_id AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'store % not in tenant', p_store_id; END IF;
+  END IF;
+  IF COALESCE(TRIM(p_home_id), '') = '' THEN RAISE EXCEPTION '請選擇社群'; END IF;
+  FOREACH v_t IN ARRAY COALESCE(p_read_times, ARRAY[]::TEXT[]) LOOP
+    IF v_t !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$' THEN
+      RAISE EXCEPTION '讀取時間格式要是 HH:MM（收到「%」）', v_t;
+    END IF;
+  END LOOP;
+  IF p_read_days IS NOT NULL AND (p_read_days < 1 OR p_read_days > 30) THEN
+    RAISE EXCEPTION '讀取範圍要在 1～30 天';
+  END IF;
+
+  IF p_id IS NULL THEN
+    INSERT INTO line_note_communities
+      (tenant_id, account_id, store_id, home_id, home_name, home_kind,
+       listen_enabled, read_times, auto_post_on_open, post_template, read_days, react_on_confirm,
+       created_by, updated_by)
+    VALUES
+      (v_tenant, p_account_id, p_store_id, TRIM(p_home_id), p_home_name,
+       COALESCE(p_home_kind, 'square_chat'),
+       COALESCE(p_listen_enabled, FALSE),
+       COALESCE(NULLIF(p_read_times, ARRAY[]::TEXT[]), ARRAY['12:00']),
+       COALESCE(p_auto_post_on_open, TRUE),
+       NULLIF(TRIM(COALESCE(p_post_template, '')), ''),
+       COALESCE(p_read_days, 3),
+       COALESCE(p_react_on_confirm, TRUE),
+       auth.uid(), auth.uid())
+    RETURNING id INTO v_id;
+  ELSE
+    UPDATE line_note_communities
+       SET account_id        = p_account_id,
+           store_id          = p_store_id,
+           home_id           = TRIM(p_home_id),
+           home_name         = p_home_name,
+           home_kind         = COALESCE(p_home_kind, home_kind),
+           listen_enabled    = COALESCE(p_listen_enabled, listen_enabled),
+           read_times        = COALESCE(NULLIF(p_read_times, ARRAY[]::TEXT[]), read_times),
+           auto_post_on_open = COALESCE(p_auto_post_on_open, auto_post_on_open),
+           post_template     = NULLIF(TRIM(COALESCE(p_post_template, '')), ''),
+           read_days         = COALESCE(p_read_days, read_days),
+           react_on_confirm  = COALESCE(p_react_on_confirm, react_on_confirm),
+           updated_by        = auth.uid()
+     WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'community % not in tenant', p_id; END IF;
+  END IF;
+  RETURN v_id;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_community_upsert(
+  BIGINT, BIGINT, TEXT, TEXT, TEXT, BOOLEAN, TEXT[], BOOLEAN, TEXT, INT, BIGINT, BOOLEAN) TO authenticated;

--- a/tools/line-note-scraper/src/line.mjs
+++ b/tools/line-note-scraper/src/line.mjs
@@ -352,6 +352,25 @@ export async function listComments(client, homeId, postId, { verbose = false, on
  * @param {string} opts.text
  * @param {(string|Buffer)[]} [opts.images]  JPEG 檔路徑或 Buffer（上傳時 content-type 固定 image/jpeg）
  */
+/**
+ * 在某則留言上按表情（笑臉）。likeType 1003 = 笑
+ * （1001 讚 / 1002 愛心 / 1003 笑 / 1004 驚 / 1005 哭 / 1006 怒）。
+ * contentId 放**留言 id**；actorId 是自己的 mid。走跟讀留言同一套 host/prefix/channel 探測。
+ */
+export async function likeComment(client, homeId, commentId, { likeType = "1003", sourceType = "TIMELINE", verbose = false } = {}) {
+  const res = await noteRequest(client, homeId, "/api/v57/like/create.json",
+    { homeId, sourceType },
+    {
+      method: "POST",
+      body: { contentId: String(commentId), actorId: client.base.profile?.mid ?? "", likeType: String(likeType), sharable: false },
+      verbose,
+    });
+  if (!res || res.code !== 0) {
+    throw new Error(`按表情失敗：code=${res?.code} ${res?.message ?? ""}`);
+  }
+  return res;
+}
+
 export async function createNotePost(client, homeId, { text, images = [], sourceType, verbose = false } = {}) {
   if (!text && images.length === 0) throw new Error("貼文至少要有文字或圖片");
 


### PR DESCRIPTION
機器人加完單後，回頭在客人那則記事本留言上按一個「笑臉」（likeType 1003），客人不用再私訊問「你有看到我的+1嗎」。

## 規則

- **只按確定收到單的**：`ordered`（加成單）／`duplicate`（本來就有單）／`resolved`（小幫手處理掉）。`unmatched` / `error` **不按** —— 那些還沒處理完，按了等於跟客人說收到了，客人就不會再來問。
- `reacted_at` 記已按過的，下次讀留言不會重按。
- 單則按失敗只記 log 略過，不影響其他則、也不影響讀留言本身。
- `react_on_confirm` 是社群層級開關（預設開），要關掉不用改程式。

## Edge Function 時間預算

按表情一則約 1 秒，實測一次補按 83 則就撞到 150s idle timeout。所以每則貼文一次最多 40 則、整支呼叫給 100 秒預算，超過就 break —— 剩下的 `reacted_at` 還是 NULL，下一次讀留言自然接手，不會漏。

## 改動

| 檔案 | 內容 |
|---|---|
| `20260909060000_line_note_comment_reaction.sql` | `line_note_comments.reacted_at`、partial index、`line_note_communities.react_on_confirm` |
| `20260909070000_line_note_community_react_param.sql` | `rpc_line_note_community_upsert` 加 `p_react_on_confirm`（DROP 舊 11 參數簽章） |
| `_shared/lineNote.ts` / `tools/line-note-scraper/src/line.mjs` | `likeComment()`，走 `POST /<prefix>/api/v57/like/create.json`，prefix 探測沿用讀留言那套 |
| `line-note-worker/index.ts` | `reactToConfirmed()`，`readPost` 尾端呼叫、回傳 `reacted` |
| `line-notes/page.tsx` | 社群設定勾選框、留言列表已按過顯示 😄 |

## 驗證

- 兩支 migration **已套上正式庫**（依 CLAUDE.md 當天要進 main）。
- Edge Function 已部署 v7 ACTIVE。
- 正式庫實跑：83 則留言的笑臉已按上、`reacted_at` 有值。
- `apps/admin` tsc 通過、scraper 16 個 parser 測試全過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ)_