### PR TITLE
記事本留言看到「結單」就停止爬那篇貼文

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -30,6 +30,7 @@ type Post = {
   id: number; community_id: number; campaign_id: number; line_post_id: string | null; text: string | null;
   status: "queued" | "posted" | "failed" | "closed"; posted_at: string | null; last_read_at: string | null;
   comment_count: number; last_error: string | null; created_at: string;
+  closed_at: string | null; closed_reason: string | null; closed_comment_id: number | null;
   group_buy_campaigns: { id: number; campaign_no: string; name: string; status: string } | null;
 };
 type Comment = {
@@ -783,6 +784,16 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
     await reload();
   };
 
+  // 誤判結單時一鍵恢復：那則留言會被標成「不是結單」，下次讀留言不會再關掉
+  const reopenPost = async (p: Post) => {
+    setBusy(p.id);
+    const { error } = await getSupabase().rpc("rpc_line_note_post_reopen", { p_id: p.id });
+    setBusy(null);
+    if (error) return fail(error);
+    notify("已恢復讀取，那則留言不會再被當成結單");
+    await reload();
+  };
+
   // 收合時顯示的統計徽章
   const statBadges = (st: PostStat | undefined) => {
     if (!st || st.total === 0) return <span className="text-xs text-zinc-400">—</span>;
@@ -824,6 +835,11 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
                 <Td className="whitespace-nowrap">
                   <Badge tone={p.status === "posted" ? "green" : p.status === "queued" ? "amber" : p.status === "failed" ? "red" : "gray"}>{POST_STATUS[p.status]}</Badge>
                   <div className="mt-0.5 text-xs text-zinc-500">{fmt(p.posted_at)}</div>
+                  {p.closed_reason && (
+                    <div className="mt-1 max-w-[14rem] truncate text-xs text-zinc-500" title={p.closed_reason}>
+                      讀到結單留言：{p.closed_reason}
+                    </div>
+                  )}
                   {p.last_error && <div className="mt-1 max-w-[14rem] truncate text-xs text-red-600" title={p.last_error}>{p.last_error}</div>}
                 </Td>
                 <Td>{statBadges(counts.get(p.id))}</Td>
@@ -834,6 +850,10 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
                     {p.status === "posted" && (
                       <SpinButton type="button" className={btn} loading={busy === p.id}
                         onClick={(e) => { e.stopPropagation(); void readNow(p); }}>立即讀取</SpinButton>
+                    )}
+                    {p.status === "closed" && p.closed_comment_id && (
+                      <SpinButton type="button" className={btn} loading={busy === p.id}
+                        onClick={(e) => { e.stopPropagation(); void reopenPost(p); }}>恢復讀取</SpinButton>
                     )}
                     <SpinButton type="button" className={`${btn} text-red-600`} loading={busy === p.id}
                       onClick={(e) => { e.stopPropagation(); void removePost(p); }}>刪除</SpinButton>

--- a/supabase/functions/line-note-worker/index.ts
+++ b/supabase/functions/line-note-worker/index.ts
@@ -229,7 +229,17 @@ async function readPost(client: any, post: any) {
       method: "POST", body: rows, prefer: "resolution=ignore-duplicates,return=minimal",
     });
   }
-  const pending = await rest(`line_note_comments?post_id=eq.${post.id}&status=eq.pending&select=id&order=commented_at.asc,id.asc`);
+  // 小幫手宣布結單之後，這篇就不再自動加單、也不再讀（詳見 detectClosing）
+  const closer = await detectClosing(post);
+  const pendingAll = await rest(
+    `line_note_comments?post_id=eq.${post.id}&status=eq.pending` +
+    `&select=id,commented_at&order=commented_at.asc,id.asc`);
+  // 結單之後才進來的留言不自動加單，留在「待處理」讓小幫手自己判斷要不要補。
+  // 宣告本身也不進加單流程（「結單囉 A+1」這種寫法不該被當成訂單）。
+  const pending = closer
+    ? (pendingAll ?? []).filter((c: any) => Number(c.id) !== Number(closer.id) && beforeOrSame(c, closer))
+    : (pendingAll ?? []);
+  const late = Math.max((pendingAll?.length ?? 0) - pending.length - (closer ? 1 : 0), 0);
   let ordered = 0, other = 0;
   for (const c of pending ?? []) {
     try {
@@ -242,8 +252,57 @@ async function readPost(client: any, post: any) {
     }
   }
   const reacted = await reactToConfirmed(client, post);
-  await patch("line_note_posts", `id=eq.${post.id}`, { last_read_at: new Date().toISOString(), comment_count: comments.length, last_error: null });
-  return { comments: comments.length, pending: pending?.length ?? 0, ordered, other, reacted };
+  const upd: Record<string, unknown> = {
+    last_read_at: new Date().toISOString(), comment_count: comments.length, last_error: null,
+  };
+  if (closer) {
+    upd.status = "closed";
+    upd.closed_at = new Date().toISOString();
+    upd.closed_reason = String(closer.text ?? "").slice(0, 200);
+    upd.closed_comment_id = closer.id;
+    // 宣告本身不是訂單，別讓它一直躺在「待處理」
+    if (closer.status === "pending") {
+      await patch("line_note_comments", `id=eq.${closer.id}`,
+        { status: "ignored", resolution_note: "結單宣告，這篇貼文停止自動加單" }).catch(() => {});
+    }
+    log(`貼文 ${post.id} 讀到結單宣告，停止自動讀取：${String(closer.text ?? "").slice(0, 40)}`);
+  }
+  await patch("line_note_posts", `id=eq.${post.id}`, upd);
+  return { comments: comments.length, pending: pending?.length ?? 0, ordered, other, reacted, closed: !!closer, late };
+}
+
+// 「結單」判定。誤判的代價是整團安靜地停止爬，所以只認宣告句 ——
+// 客人問「什麼時候結單？」「還沒結單嗎」不算。
+// 判過的結果寫回 is_closing_notice（NULL=沒判過 / TRUE=是 / FALSE=後台按過恢復讀取），
+// 沒有這個三態的話，恢復讀取後下一次讀留言會立刻再撞到同一則、又關掉。
+const CLOSE_RE = /結單|收單|截單|關單|關團|封單/;
+const CLOSE_ASK_RE = /[?？]|嗎|呢|吧|何時|什麼時候|幾點|還沒|沒有|可以|要不要|是不是|準備|快要/;
+
+function isClosingText(text: string): boolean {
+  const t = String(text ?? "").replace(/\s+/g, "");
+  return CLOSE_RE.test(t) && !CLOSE_ASK_RE.test(t);
+}
+
+function beforeOrSame(a: any, b: any): boolean {
+  const ta = Date.parse(a.commented_at ?? "") || 0;
+  const tb = Date.parse(b.commented_at ?? "") || 0;
+  return ta !== tb ? ta < tb : Number(a.id) <= Number(b.id);
+}
+
+async function detectClosing(post: any): Promise<any | null> {
+  const rows = await rest(
+    `line_note_comments?post_id=eq.${post.id}&is_closing_notice=not.is.false` +
+    `&select=id,text,status,commented_at,is_closing_notice&order=commented_at.asc,id.asc`);
+  let hit: any = null;
+  for (const c of rows ?? []) {
+    if (c.is_closing_notice !== true && !isClosingText(c.text)) continue;
+    if (c.is_closing_notice !== true) {
+      await patch("line_note_comments", `id=eq.${c.id}`, { is_closing_notice: true }).catch(() => {});
+    }
+    hit = c;
+    break;                                                 // 最早那則才算，後面的不用再看
+  }
+  return hit;
 }
 
 const REACT_BATCH = 40;                                  // 每則貼文一次最多按幾則

--- a/supabase/migrations/20260909080000_line_note_close_on_comment.sql
+++ b/supabase/migrations/20260909080000_line_note_close_on_comment.sql
@@ -1,0 +1,72 @@
+-- ============================================================================
+-- 20260909080000_line_note_close_on_comment.sql
+--
+-- 小幫手在記事本留言區宣布「結單」之後，這篇貼文就不再自動爬、不再自動加單。
+--
+-- 判定放在 worker（正則），結果落在 line_note_comments.is_closing_notice：
+--   NULL  = 還沒判定（worker 讀到就判一次）
+--   TRUE  = 是結單宣告
+--   FALSE = 人工否決過（後台按「恢復讀取」）→ 永遠不會再被判成結單
+-- 沒有這個三態的話，恢復讀取之後下一次讀留言會立刻再撞到同一則、又關掉。
+--
+-- 誤判的代價是「整團安靜地停止爬」，所以只認宣告句、問句不算，
+-- 而且一定要留得下痕跡（closed_reason / closed_comment_id）+ 一鍵恢復
+-- （rpc_line_note_post_reopen），不要讓店家只看到「已結束」三個字查不出原因。
+--
+-- ⚠ closed_comment_id 刻意**不加 FK** —— line_note_comments 已經有一條 FK 指向
+--    line_note_posts，再加一條反向的會讓 PostgREST 的 embed 全部變 PGRST201
+--    （見 CLAUDE.md「對已經被前端 embed 的表加第二支 FK」）。
+--
+-- 新欄位 + 一支新 RPC，沒有覆蓋既有 function。
+-- rollback：
+--   DROP FUNCTION public.rpc_line_note_post_reopen(BIGINT);
+--   ALTER TABLE line_note_posts DROP COLUMN closed_at, DROP COLUMN closed_reason,
+--                               DROP COLUMN closed_comment_id;
+--   ALTER TABLE line_note_comments DROP COLUMN is_closing_notice;
+-- ============================================================================
+
+ALTER TABLE line_note_comments
+  ADD COLUMN IF NOT EXISTS is_closing_notice BOOLEAN;
+COMMENT ON COLUMN line_note_comments.is_closing_notice IS
+  '這則是不是「結單」宣告。NULL=還沒判定，TRUE=是，FALSE=人工否決（不再重判）。';
+
+ALTER TABLE line_note_posts
+  ADD COLUMN IF NOT EXISTS closed_at         TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS closed_reason     TEXT,
+  ADD COLUMN IF NOT EXISTS closed_comment_id BIGINT;
+COMMENT ON COLUMN line_note_posts.closed_reason IS
+  '停止自動讀取的原因（結單那則留言的原文）。';
+COMMENT ON COLUMN line_note_posts.closed_comment_id IS
+  '判定為結單宣告的那則 line_note_comments.id（刻意不加 FK，避免 PostgREST embed 歧義）。';
+
+-- ----------------------------------------------------------------------------
+-- 恢復讀取：誤判時一鍵還原，並把那則留言標成「不是結單」，下次不會再關掉
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_post_reopen(p_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant  UUID := public._line_note_require_admin();
+  v_comment BIGINT;
+BEGIN
+  SELECT closed_comment_id INTO v_comment
+    FROM line_note_posts WHERE id = p_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'post % not in tenant', p_id; END IF;
+
+  -- 否決那則宣告：worker 只判 is_closing_notice IS NULL 的留言，FALSE 之後不再重判
+  IF v_comment IS NOT NULL THEN
+    UPDATE line_note_comments
+       SET is_closing_notice = FALSE,
+           status     = CASE WHEN status = 'ignored' THEN 'pending' ELSE status END,
+           updated_at = NOW()
+     WHERE id = v_comment AND tenant_id = v_tenant;
+  END IF;
+
+  UPDATE line_note_posts
+     SET status = 'posted', closed_at = NULL, closed_reason = NULL, closed_comment_id = NULL,
+         updated_at = NOW()
+   WHERE id = p_id AND tenant_id = v_tenant AND status = 'closed';
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_post_reopen(BIGINT) TO authenticated;


### PR DESCRIPTION
小幫手在記事本留言區宣布「結單」之後，那篇貼文就不再自動讀留言、不再自動加單（貼文 `status` → `closed`，`jobRead` 本來就只撈 `posted`）。

## 判定規則

只認**宣告句**：`結單 / 收單 / 截單 / 關單 / 關團 / 封單`，但排除問句 —— `什麼時候結單？`、`還沒結單嗎`、`結單了嗎`、`準備結單`、`可以結單了嗎` 都**不算**。誤判的代價是整團安靜地停止爬，所以寧可漏判也不要誤判。

## 結單之後的留言怎麼辦

- 宣告**之後**才進來的留言 → 不自動加單，留在「待處理」讓小幫手自己判斷要不要補。
- 宣告**本身**也不進加單流程（`結單囉 A+1` 這種寫法不該被當成訂單），標成「忽略」。

## 誤判要救得回來

- `closed_reason` 存宣告原文、`closed_comment_id` 存那則 id → 後台顯示「讀到結單留言：xxx」，不是只有「已結束」三個字讓店家查不出原因。
- 「恢復讀取」按鈕 → `rpc_line_note_post_reopen`，貼文推回 `posted`，並把那則標成 `is_closing_notice = FALSE`。

`is_closing_notice` 的**三態**（NULL 沒判過 / TRUE 是 / FALSE 人工否決）是必要的：沒有它，恢復讀取之後下一次讀留言會立刻再撞到同一則、又關掉。

## 踩雷預防

`closed_comment_id` 刻意**不加 FK** —— `line_note_comments` 已經有一條 FK 指向 `line_note_posts`，再加一條反向的會讓 PostgREST 的 embed 全部變 `PGRST201`（見 CLAUDE.md「對已經被前端 embed 的表加第二支 FK」）。

## 驗證

正式庫實跑（用完即刪的測試留言，已清乾淨、`customer_order_id` 為 NULL、沒有生出訂單）：

1. 插一則「結單囉，謝謝大家」→ 跑 worker → 貼文變 `closed`、`closed_reason` 正確、那則標成忽略 ✅
2. 呼叫 `rpc_line_note_post_reopen`（灌 admin claims）→ 回 `posted`、旗標變 FALSE ✅
3. 再跑一次 worker → **沒有再關掉** ✅
4. 測試留言已刪除，`probes_left = 0`

另外：migration `20260909080000` 已套上正式庫、Edge Function 已部署；`apps/admin` tsc 通過；正則對 8 個宣告句 / 9 個問句與一般留言的判定全部正確。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ)_