### PR TITLE
社群設定可以一次勾多個，撞號不再吐「資料重複衝突」

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -327,11 +327,16 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
   const [form, setForm] = useState<CommunityForm | null>(null);
   const [busy, setBusy] = useState<number | "save" | "homes" | null>(null);
   const [homes, setHomes] = useState<Home[] | null>(null);
+  // 新增時可以一次勾好幾個社群／群組，共用同一份設定（編輯時只認一個，所以不用）
+  const [picked, setPicked] = useState<Home[]>([]);
   const [postFor, setPostFor] = useState<Community | null>(null);
 
-  const openNew = () => { setHomes(null); setForm({ ...EMPTY_FORM, account_id: accounts[0]?.id ?? "" }); };
+  // 新增模式下勾了社群 = 批次建立；編輯模式永遠是單一社群
+  const multi = form?.id === null && picked.length > 0;
+
+  const openNew = () => { setHomes(null); setPicked([]); setForm({ ...EMPTY_FORM, account_id: accounts[0]?.id ?? "" }); };
   const openEdit = (c: Community) => {
-    setHomes(null);
+    setHomes(null); setPicked([]);
     setForm({ id: c.id, account_id: c.account_id, store_id: c.store_id ?? "", home_id: c.home_id, home_name: c.home_name ?? "",
       listen_enabled: c.listen_enabled, read_times: c.read_times.join(", "), auto_post_on_open: c.auto_post_on_open, post_template: c.post_template ?? "", read_days: c.read_days ?? 3, react_on_confirm: c.react_on_confirm ?? true });
   };
@@ -354,23 +359,39 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
     } catch (e) { fail(e); } finally { setBusy(null); }
   };
 
+  // 勾了好幾個社群就一個一個建（同一份設定）。一個失敗不影響其他個，
+  // 最後把失敗的社群名字一起講清楚，不要只說「儲存失敗」讓人不知道是哪一個。
   const save = async () => {
     if (!form) return;
+    const targets = multi
+      ? picked.map((h) => ({ home_id: h.homeId, home_name: h.name }))
+      : [{ home_id: form.home_id.trim(), home_name: form.home_name.trim() || null }];
+    if (targets.some((t) => !t.home_id)) return fail(new Error("請選擇社群"));
+
     setBusy("save");
-    const { error } = await getSupabase().rpc("rpc_line_note_community_upsert", {
-      p_id: form.id, p_account_id: form.account_id || null, p_store_id: form.store_id || null,
-      p_home_id: form.home_id.trim(), p_home_name: form.home_name.trim() || null, p_home_kind: kindOf(form.home_id.trim()),
+    const sb = getSupabase();
+    const shared = {
+      p_account_id: form.account_id || null, p_store_id: form.store_id || null,
       p_listen_enabled: form.listen_enabled,
       p_read_times: form.read_times.split(/[,\s，、]+/).map((s) => s.trim()).filter(Boolean),
       p_auto_post_on_open: form.auto_post_on_open, p_post_template: form.post_template || null,
       p_read_days: Math.min(30, Math.max(1, Math.round(form.read_days || 3))),
       p_react_on_confirm: form.react_on_confirm,
-    });
+    };
+    const failed: string[] = [];
+    for (const t of targets) {
+      const { error } = await sb.rpc("rpc_line_note_community_upsert", {
+        ...shared, p_id: multi ? null : form.id,
+        p_home_id: t.home_id, p_home_name: t.home_name, p_home_kind: kindOf(t.home_id),
+      });
+      if (error) failed.push(`${t.home_name || t.home_id}：${translateRpcError(error)}`);
+    }
     setBusy(null);
-    if (error) return fail(error);
-    notify("已儲存");
-    setForm(null);
     await reload();
+    if (failed.length) return fail(new Error(failed.join("\n")));
+    notify(targets.length > 1 ? `已儲存 ${targets.length} 個社群` : "已儲存");
+    setForm(null);
+    setPicked([]);
   };
   const remove = async (c: Community) => {
     if (!window.confirm(`刪除社群「${c.home_name || c.home_id}」的設定？`)) return;
@@ -430,7 +451,8 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
       </Table>
 
       {form && (
-        <Modal title={form.id ? "編輯社群" : "新增社群"} onClose={() => setForm(null)} wide>
+        <Modal title={form.id ? "編輯社群" : picked.length > 1 ? `新增 ${picked.length} 個社群` : "新增社群"}
+          onClose={() => setForm(null)} wide>
           <div className="grid gap-3 md:grid-cols-2">
             <label className="text-sm">帳號
               <select className={input} value={form.account_id} onChange={(e) => setForm({ ...form, account_id: Number(e.target.value) })}>
@@ -447,22 +469,62 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
             <div className="text-sm md:col-span-2">
               <div className="flex items-end gap-2">
                 <label className="flex-1">社群 homeId
-                  <input className={`${input} font-mono`} value={form.home_id} placeholder="m… / c… / s…"
+                  <input className={`${input} font-mono`} value={multi ? `已勾選 ${picked.length} 個` : form.home_id}
+                    placeholder="m… / c… / s…" disabled={multi}
                     onChange={(e) => setForm({ ...form, home_id: e.target.value })} />
                 </label>
                 <SpinButton type="button" className={btn} loading={busy === "homes"} onClick={loadHomes}>從帳號載入清單</SpinButton>
               </div>
-              {homes && (
+              {homes && homes.length === 0 && (
+                <p className="mt-2 text-sm text-zinc-500">這個帳號沒有加入任何群組／社群</p>
+              )}
+              {homes && homes.length > 0 && form.id === null && (
+                <>
+                  <div className="mt-2 flex items-center justify-between text-xs text-zinc-500">
+                    <span>勾幾個就建幾個，下面的設定會一起套用（已設定過的會被覆蓋成這裡的設定）</span>
+                    <button type="button" className={btn}
+                      onClick={() => setPicked(picked.length === homes.length ? [] : homes)}>
+                      {picked.length === homes.length ? "全部取消" : "全選"}
+                    </button>
+                  </div>
+                  <ul className="mt-1 max-h-60 divide-y divide-zinc-200 overflow-auto rounded border border-zinc-300 dark:divide-zinc-800 dark:border-zinc-700">
+                    {homes.map((h) => {
+                      const done = (communities ?? []).some((c) => c.home_id === h.homeId);
+                      return (
+                        <li key={h.homeId}>
+                          <label className="flex cursor-pointer items-center gap-2 px-2 py-1.5 text-sm hover:bg-zinc-50 dark:hover:bg-zinc-800">
+                            <input type="checkbox" checked={picked.some((x) => x.homeId === h.homeId)}
+                              onChange={(e) => setPicked(e.target.checked
+                                ? [...picked, h]
+                                : picked.filter((x) => x.homeId !== h.homeId))} />
+                            <span className="shrink-0 text-xs text-zinc-500">[{KIND_LABEL[h.kind] ?? h.kind}]</span>
+                            <span className="min-w-0 flex-1 truncate">{h.name}</span>
+                            {done && <Badge tone="gray">已設定</Badge>}
+                          </label>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </>
+              )}
+              {homes && homes.length > 0 && form.id !== null && (
                 <select className={`${input} mt-2`} size={Math.min(8, Math.max(2, homes.length))}
-                  onChange={(e) => { const h = homes.find((x) => x.homeId === e.target.value); if (h) setForm({ ...form, home_id: h.homeId, home_name: h.name }); }}>
-                  {homes.length === 0 && <option disabled>這個帳號沒有加入任何群組／社群</option>}
-                  {homes.map((h) => <option key={h.homeId} value={h.homeId}>[{KIND_LABEL[h.kind] ?? h.kind}] {h.name} — {h.homeId}</option>)}
+                  onChange={(e) => {
+                    const h = homes.find((x) => x.homeId === e.target.value);
+                    if (h) setForm({ ...form, home_id: h.homeId, home_name: h.name });
+                  }}>
+                  {homes.map((h) => (
+                    <option key={h.homeId} value={h.homeId}>
+                      [{KIND_LABEL[h.kind] ?? h.kind}] {h.name} — {h.homeId}
+                    </option>
+                  ))}
                 </select>
               )}
               <p className="mt-1 text-xs text-zinc-500">社群記事本先選「社群聊天室」（m…）；不行再試「社群」（s…）。群組用 c…。</p>
             </div>
             <label className="text-sm">顯示名稱
-              <input className={input} value={form.home_name} onChange={(e) => setForm({ ...form, home_name: e.target.value })} />
+              <input className={input} disabled={multi} value={multi ? "各自沿用社群名稱" : form.home_name}
+                onChange={(e) => setForm({ ...form, home_name: e.target.value })} />
             </label>
             <label className="text-sm">讀取範圍（最近幾天的貼文；也用來認小幫手手貼的團）
               <input type="number" min={1} max={30} className={input} value={form.read_days} onChange={(e) => setForm({ ...form, read_days: Number(e.target.value) })} />

--- a/supabase/migrations/20260909090000_line_note_community_real_upsert.sql
+++ b/supabase/migrations/20260909090000_line_note_community_real_upsert.sql
@@ -1,0 +1,117 @@
+-- ============================================================================
+-- 20260909090000_line_note_community_real_upsert.sql
+--
+-- rpc_line_note_community_upsert 名字叫 upsert，新增那半卻是純 INSERT，
+-- 撞到 UNIQUE (tenant_id, home_id) 就把原始的唯一鍵違規丟到前端，店家看到
+-- 「資料重複衝突(line_note_communities_tenant_id_home_id_key)，請重試或聯繫工程師」——
+-- 重試幾次都一樣，而且完全看不出「這個社群早就設定過了」。
+--
+-- 一個 (tenant, home_id) 本來就只該有一份設定，所以新增撞號 = 就是要改那一份：
+--   ON CONFLICT (tenant_id, home_id) DO UPDATE，回傳既有那筆的 id。
+-- 表單上的值就是店家剛剛填的，覆蓋過去正是他要的結果。
+--
+-- 編輯那半不能這樣做（兩筆各自掛著貼文，合併會弄丟其中一邊的 line_note_posts），
+-- 所以改成先問對手是誰、吐出點得出名字的錯誤。
+--
+-- 基底：rpc_line_note_community_upsert @ 20260909070000（12 參數，已 grep 確認為最新）。
+-- 參數與回傳型別完全不變，不用 DROP。
+-- rollback：還原 20260909070000 的版本。
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_line_note_community_upsert(
+  p_id                BIGINT,
+  p_account_id        BIGINT,
+  p_home_id           TEXT,
+  p_home_name         TEXT,
+  p_home_kind         TEXT,
+  p_listen_enabled    BOOLEAN,
+  p_read_times        TEXT[],
+  p_auto_post_on_open BOOLEAN,
+  p_post_template     TEXT,
+  p_read_days         INT DEFAULT 3,
+  p_store_id          BIGINT DEFAULT NULL,
+  p_react_on_confirm  BOOLEAN DEFAULT TRUE
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+  v_id     BIGINT;
+  v_t      TEXT;
+  v_home   TEXT := TRIM(p_home_id);
+  v_clash  TEXT;
+BEGIN
+  PERFORM 1 FROM line_note_accounts WHERE id = p_account_id AND tenant_id = v_tenant;
+  IF NOT FOUND THEN RAISE EXCEPTION 'account % not in tenant', p_account_id; END IF;
+  IF p_store_id IS NOT NULL THEN
+    PERFORM 1 FROM stores WHERE id = p_store_id AND tenant_id = v_tenant;
+    IF NOT FOUND THEN RAISE EXCEPTION 'store % not in tenant', p_store_id; END IF;
+  END IF;
+  IF COALESCE(v_home, '') = '' THEN RAISE EXCEPTION '請選擇社群'; END IF;
+  FOREACH v_t IN ARRAY COALESCE(p_read_times, ARRAY[]::TEXT[]) LOOP
+    IF v_t !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$' THEN
+      RAISE EXCEPTION '讀取時間格式要是 HH:MM（收到「%」）', v_t;
+    END IF;
+  END LOOP;
+  IF p_read_days IS NOT NULL AND (p_read_days < 1 OR p_read_days > 30) THEN
+    RAISE EXCEPTION '讀取範圍要在 1～30 天';
+  END IF;
+
+  IF p_id IS NULL THEN
+    -- 撞號 = 這個社群早就設定過了，把表單的值套到既有那筆（一個社群只有一份設定）
+    INSERT INTO line_note_communities
+      (tenant_id, account_id, store_id, home_id, home_name, home_kind,
+       listen_enabled, read_times, auto_post_on_open, post_template, read_days, react_on_confirm,
+       created_by, updated_by)
+    VALUES
+      (v_tenant, p_account_id, p_store_id, v_home, p_home_name,
+       COALESCE(p_home_kind, 'square_chat'),
+       COALESCE(p_listen_enabled, FALSE),
+       COALESCE(NULLIF(p_read_times, ARRAY[]::TEXT[]), ARRAY['12:00']),
+       COALESCE(p_auto_post_on_open, TRUE),
+       NULLIF(TRIM(COALESCE(p_post_template, '')), ''),
+       COALESCE(p_read_days, 3),
+       COALESCE(p_react_on_confirm, TRUE),
+       auth.uid(), auth.uid())
+    ON CONFLICT (tenant_id, home_id) DO UPDATE
+       SET account_id        = EXCLUDED.account_id,
+           store_id          = EXCLUDED.store_id,
+           home_name         = COALESCE(EXCLUDED.home_name, line_note_communities.home_name),
+           home_kind         = COALESCE(EXCLUDED.home_kind, line_note_communities.home_kind),
+           listen_enabled    = EXCLUDED.listen_enabled,
+           read_times        = EXCLUDED.read_times,
+           auto_post_on_open = EXCLUDED.auto_post_on_open,
+           post_template     = EXCLUDED.post_template,
+           read_days         = EXCLUDED.read_days,
+           react_on_confirm  = EXCLUDED.react_on_confirm,
+           updated_by        = auth.uid()
+    RETURNING id INTO v_id;
+  ELSE
+    -- 編輯不能合併：兩筆各自掛著 line_note_posts，硬合會弄丟其中一邊的貼文與留言
+    SELECT COALESCE(NULLIF(home_name, ''), home_id) INTO v_clash
+      FROM line_note_communities
+     WHERE tenant_id = v_tenant AND home_id = v_home AND id <> p_id;
+    IF v_clash IS NOT NULL THEN
+      RAISE EXCEPTION '社群「%」已經設定過了，請直接編輯那一筆，不要在這裡改成同一個社群', v_clash;
+    END IF;
+
+    UPDATE line_note_communities
+       SET account_id        = p_account_id,
+           store_id          = p_store_id,
+           home_id           = v_home,
+           home_name         = p_home_name,
+           home_kind         = COALESCE(p_home_kind, home_kind),
+           listen_enabled    = COALESCE(p_listen_enabled, listen_enabled),
+           read_times        = COALESCE(NULLIF(p_read_times, ARRAY[]::TEXT[]), read_times),
+           auto_post_on_open = COALESCE(p_auto_post_on_open, auto_post_on_open),
+           post_template     = NULLIF(TRIM(COALESCE(p_post_template, '')), ''),
+           read_days         = COALESCE(p_read_days, read_days),
+           react_on_confirm  = COALESCE(p_react_on_confirm, react_on_confirm),
+           updated_by        = auth.uid()
+     WHERE id = p_id AND tenant_id = v_tenant
+    RETURNING id INTO v_id;
+    IF v_id IS NULL THEN RAISE EXCEPTION 'community % not in tenant', p_id; END IF;
+  END IF;
+  RETURN v_id;
+END;
+$$;


### PR DESCRIPTION
## 回報的問題

新增社群按下儲存跳 `資料重複衝突(line_note_communities_tenant_id_home_id_key)，請重試或聯繫工程師`。重試幾次都一樣，而且完全看不出「這個社群早就設定過了」。

`rpc_line_note_community_upsert` 名字叫 upsert，新增那半卻是純 `INSERT`，撞到 `UNIQUE (tenant_id, home_id)` 就把原始的唯一鍵違規丟到前端。

## 修法

一個 `(tenant, home_id)` 本來就只該有一份設定，所以**新增撞號 = 就是要改那一份**：`ON CONFLICT (tenant_id, home_id) DO UPDATE`，回傳既有那筆的 id。表單上的值就是店家剛剛填的，覆蓋過去正是他要的結果。

**編輯那半不能這樣做** —— 兩筆各自掛著 `line_note_posts`，硬合會弄丟其中一邊的貼文與留言。改成先問對手是誰，吐出點得出名字的錯誤：

> 社群「⑦包子媽❤生鮮小舖(松山店)」已經設定過了，請直接編輯那一筆，不要在這裡改成同一個社群

## 順帶：一次可以勾多個社群／群組

載入清單後從單選 `<select>` 改成可複選的勾選列表（全選、`已設定` 標記），勾幾個就建幾個，下面那份設定一起套用。一個失敗不影響其他個，最後把失敗的社群名字一起列出來，不要只說「儲存失敗」讓人不知道是哪一個。

`顯示名稱` 在多選時顯示「各自沿用社群名稱」（每個社群名字不同，共用一個沒有意義）；`店家` 仍是共用，多店的情況建好後各自編輯。

## 驗證

正式庫實跑（全部 `ROLLBACK`，線上仍是原本那 1 筆）：

1. 之前會炸的那一刀（`p_id = NULL` + 已存在的 home_id）→ 現在成功，仍是 1 筆、值有更新 ✅
2. 編輯撞號 → 擋下，訊息帶得出社群名字 ✅
3. 模擬「一次勾三個」（1 個已設定 + 2 個新的）→ 既有那筆更新、兩筆新建，設定一致 ✅

UI 用 Playwright + fixture 實際點過：勾選清單、全選、`已設定` 標記、標題變「新增 2 個社群」都正確；`apps/admin` tsc 通過，eslint 沒有新增問題（既有 3 個 `react-hooks/set-state-in-effect` 在 main 上就有）。

migration `20260909090000` 已套上正式庫。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ)_