### PR TITLE
社群清單跟著帳號走：登入完社群自己出現，不用手動新增

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -239,8 +239,30 @@ function AccountsTab({ accounts, reload, notify, fail }: {
     notify("已送出登出");
     await reload();
   };
+  // 刪帳號會連底下的社群 → 貼文 → 留言一路 CASCADE 掉，所以先把數量算給他看：
+  // 「會一起刪掉」講得太輕，真的按下去是一次刪掉上千筆留言紀錄。
   const remove = async (a: Account) => {
-    if (!window.confirm(`刪除帳號「${a.label}」？底下的社群設定與貼文紀錄會一起刪掉。`)) return;
+    setBusy(a.id);
+    const sb = getSupabase();
+    const { data: cs } = await sb.from("line_note_communities").select("id").eq("account_id", a.id);
+    const ids = (cs ?? []).map((c) => c.id);
+    let posts = 0, comments = 0;
+    if (ids.length) {
+      const { count: pc } = await sb.from("line_note_posts").select("id", { count: "exact", head: true }).in("community_id", ids);
+      posts = pc ?? 0;
+      const { data: ps } = await sb.from("line_note_posts").select("id").in("community_id", ids);
+      const pids = (ps ?? []).map((x) => x.id);
+      if (pids.length) {
+        const { count: cc } = await sb.from("line_note_comments").select("id", { count: "exact", head: true }).in("post_id", pids);
+        comments = cc ?? 0;
+      }
+    }
+    setBusy(null);
+    const scale = ids.length === 0 ? "底下沒有社群設定。"
+      : `會一起刪掉：社群設定 ${ids.length} 個、貼文紀錄 ${posts} 篇、留言紀錄 ${comments} 則。`;
+    if (!window.confirm(
+      `刪除帳號「${a.label}」？\n\n${scale}\n已經加出來的訂單不會動。\n\n` +
+      `只是要換帳號的話請按「登出」，不用刪除。`)) return;
     setBusy(a.id);
     const { error } = await getSupabase().rpc("rpc_line_note_account_delete", { p_id: a.id });
     setBusy(null);
@@ -326,7 +348,7 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
   reload: () => Promise<void>; reloadPosts: () => Promise<void>; notify: (m: string) => void; fail: (e: unknown) => void;
 }) {
   const [form, setForm] = useState<CommunityForm | null>(null);
-  const [busy, setBusy] = useState<number | "save" | "homes" | null>(null);
+  const [busy, setBusy] = useState<number | "save" | "homes" | "sync" | null>(null);
   const [homes, setHomes] = useState<Home[] | null>(null);
   // 新增時可以一次勾好幾個社群／群組，共用同一份設定（編輯時只認一個，所以不用）
   const [picked, setPicked] = useState<Home[]>([]);
@@ -395,13 +417,38 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
     setPicked([]);
   };
   const remove = async (c: Community) => {
-    if (!window.confirm(`刪除社群「${c.home_name || c.home_id}」的設定？`)) return;
+    if (!window.confirm(`刪除社群「${c.home_name || c.home_id}」的設定？\n\n之後同步也不會再自動把它加回來（要的話用「＋ 新增社群」再選一次）。`)) return;
     setBusy(c.id);
     const { error } = await getSupabase().rpc("rpc_line_note_community_delete", { p_id: c.id });
     setBusy(null);
     if (error) return fail(error);
     await reload();
   };
+  // 跟每個登入中的帳號要一次群組清單；worker 收到後會把沒看過的社群長出來（一律停用）
+  const syncAll = async () => {
+    const live = accounts.filter((a) => a.status === "active");
+    if (live.length === 0) return fail(new Error("沒有已登入的帳號，請先到「帳號」分頁登入"));
+    setBusy("sync");
+    const sb = getSupabase();
+    try {
+      const ids: number[] = [];
+      for (const a of live) {
+        const { data, error } = await sb.rpc("rpc_line_note_enqueue", { p_kind: "list_homes", p_account_id: a.id });
+        if (error) throw error;
+        ids.push(data as number);
+      }
+      kickWorker();
+      // 等 worker 跑完再刷新，不然畫面上還是舊的清單
+      for (let i = 0; i < 40; i++) {
+        await new Promise((r) => setTimeout(r, 1500));
+        const { data } = await sb.from("line_note_jobs").select("id,status").in("id", ids);
+        if ((data ?? []).every((j) => j.status === "done" || j.status === "failed")) break;
+      }
+      await reload();
+      notify("已同步；新出現的社群都是停用的，要哪幾個自己開監聽");
+    } catch (e) { fail(e); } finally { setBusy(null); }
+  };
+
   const readNow = async (c: Community) => {
     setBusy(c.id);
     const { error } = await getSupabase().rpc("rpc_line_note_enqueue", { p_kind: "read", p_account_id: c.account_id, p_community_id: c.id });
@@ -413,11 +460,16 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <p className="text-sm text-zinc-500">
+          清單跟著帳號走：帳號加入的群組／社群會自己出現在這裡，一開始都是<b>停用</b>的，要哪幾個自己開監聽。
           總部開的團會發到所有開自動發文的社群；店家自開的團只發到標了那家店的社群。加單的取貨店一律跟會員自己設定的店。
         </p>
-        <button type="button" className={btnPrimary} onClick={openNew} disabled={accounts.length === 0}>＋ 新增社群</button>
+        <div className="flex shrink-0 gap-2">
+          <SpinButton type="button" className={btn} loading={busy === "sync"} onClick={syncAll}
+            disabled={accounts.length === 0}>同步社群</SpinButton>
+          <button type="button" className={btnPrimary} onClick={openNew} disabled={accounts.length === 0}>＋ 新增社群</button>
+        </div>
       </div>
       <Table>
         <THead><Th>社群</Th><Th>帳號</Th><Th>店家</Th><Th>監聽</Th><Th>讀取時間</Th><Th>開團自動發文</Th><Th>最後讀取</Th><Th align="right">操作</Th></THead>

--- a/supabase/functions/line-note-worker/index.ts
+++ b/supabase/functions/line-note-worker/index.ts
@@ -106,8 +106,12 @@ async function doLogin(accountId: number) {
       status: "active", auth_token: client.base.authToken, line_mid: me.mid, display_name: me.displayName,
       qr_image: null, qr_url: null, pin_code: null, last_error: null, last_seen_at: new Date().toISOString(),
     });
-    if (job) await patch("line_note_jobs", `id=eq.${job.id}`, { status: "done", result: me, finished_at: new Date().toISOString() });
-    return { ok: true, ...me };
+    // 登入完馬上把這個帳號的群組／社群拉進來，店家不用再自己按一次同步
+    let synced: any = null;
+    try { synced = await syncCommunities(accountId, await listHomes(client, VERBOSE)); }
+    catch (e) { log("登入後同步社群失敗（略過）:", (e as any)?.message ?? e); }
+    if (job) await patch("line_note_jobs", `id=eq.${job.id}`, { status: "done", result: { ...me, sync: synced }, finished_at: new Date().toISOString() });
+    return { ok: true, ...me, sync: synced };
   } catch (e) {
     const msg = String((e as any)?.message ?? e);
     await patch("line_note_accounts", `id=eq.${accountId}`, { status: "error", last_error: msg.slice(0, 1000), qr_image: null, qr_url: null, pin_code: null });
@@ -131,7 +135,26 @@ async function jobLogout(job: any) {
 async function jobListHomes(job: any) {
   const account = await loadAccount(job.account_id);
   const client = await clientFor(account);
-  return { homes: await listHomes(client, VERBOSE) };
+  const homes = await listHomes(client, VERBOSE);
+  return { homes, sync: await syncCommunities(job.account_id, homes) };
+}
+
+// 社群清單跟著帳號走：帳號加入的群組／社群自己出現在後台，不用手動貼 homeId。
+// 新長出來的一律是關的（不監聽、不自動發文）—— 備用帳號身上常有私人群組。
+// 既有的只更新名字，設定一個字都不動；店家刪掉過的不會再長回來。
+async function syncCommunities(accountId: number, homes: any[]) {
+  try {
+    const r = await rpc("rpc_line_note_community_sync", {
+      p_account_id: accountId,
+      p_homes: (homes ?? []).map((h: any) => ({ homeId: h.homeId, name: h.name, kind: h.kind })),
+    });
+    const row = Array.isArray(r) ? r[0] : r;
+    log(`社群同步：新增 ${row?.out_added ?? 0}、更新 ${row?.out_updated ?? 0}、略過 ${row?.out_skipped ?? 0}`);
+    return row ?? null;
+  } catch (e) {
+    log("社群同步失敗（略過，不影響列清單）:", (e as any)?.message ?? e);
+    return null;
+  }
 }
 
 const DEFAULT_TEMPLATE = `📣 {{name}}

--- a/supabase/migrations/20260909100000_line_note_community_sync.sql
+++ b/supabase/migrations/20260909100000_line_note_community_sync.sql
@@ -1,0 +1,124 @@
+-- ============================================================================
+-- 20260909100000_line_note_community_sync.sql
+--
+-- 社群清單跟著帳號走：帳號登入（或按「同步社群」）之後，那個 LINE 帳號加入的
+-- 每一個群組／社群就自己出現在社群設定裡，不用一個一個手動新增 homeId。
+--
+-- 自動長出來的一律是**關的**（listen_enabled = FALSE、auto_post_on_open = FALSE）——
+-- 備用帳號身上常常還有私人群組，自動開監聽等於未經同意就去爬別人的對話、
+-- 開團還會自動發文進去。要哪幾個由店家自己開。
+--
+-- 已經存在的社群只更新名字／類型／synced_at，**設定一個字都不動** ——
+-- 同步不能把店家調好的讀取時間、模板洗掉。
+--
+-- 刪除掉的不要再自己長回來：line_note_home_dismissals 記「這個 home 我不要」，
+-- 同步的新增那半會跳過它。刻意做成**獨立的表**而不是在 line_note_communities
+-- 上加 dismissed_at：那張表身上有 UNIQUE (tenant_id, home_id)，加軟刪除欄位就會
+-- 變成「查詢母體 ≠ 索引母體」（見 CLAUDE.md 會員那條：查得到的人都說沒人用、
+-- 存下去卻一定撞）。手動「新增社群」照樣建得起來，建起來之後同步只會走更新那半，
+-- 所以 dismissal 留著也不會擋到人。
+--
+-- 新表 + 新欄位 + 一支新 RPC；rpc_line_note_community_delete 基底是
+-- 20260908010000（唯一前版，已 grep 確認），只在刪除後多寫一筆 dismissal。
+-- rollback：
+--   還原 20260908010000 的 rpc_line_note_community_delete；
+--   DROP FUNCTION public.rpc_line_note_community_sync(BIGINT, JSONB);
+--   DROP TABLE line_note_home_dismissals;
+--   ALTER TABLE line_note_communities DROP COLUMN synced_at;
+-- ============================================================================
+
+ALTER TABLE line_note_communities
+  ADD COLUMN IF NOT EXISTS synced_at TIMESTAMPTZ;
+COMMENT ON COLUMN line_note_communities.synced_at IS
+  '最後一次在帳號的群組清單裡看到這個社群的時間。NULL = 手動新增的，沒同步過。';
+
+CREATE TABLE IF NOT EXISTS line_note_home_dismissals (
+  tenant_id    UUID NOT NULL,
+  home_id      TEXT NOT NULL,
+  dismissed_by UUID,
+  dismissed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, home_id)
+);
+COMMENT ON TABLE line_note_home_dismissals IS
+  '店家從社群設定刪掉的 home：同步時不要再自動長回來（手動新增不受影響）。';
+ALTER TABLE line_note_home_dismissals ENABLE ROW LEVEL SECURITY;
+
+-- ----------------------------------------------------------------------------
+-- 同步：worker 拿到帳號的群組清單後呼叫（service_role）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_community_sync(
+  p_account_id BIGINT,
+  p_homes      JSONB
+) RETURNS TABLE (out_added INT, out_updated INT, out_skipped INT)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant  UUID;
+  v_h       JSONB;
+  v_home    TEXT;
+  v_kind    TEXT;
+  v_added   INT := 0;
+  v_updated INT := 0;
+  v_skipped INT := 0;
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM line_note_accounts WHERE id = p_account_id;
+  IF v_tenant IS NULL THEN RAISE EXCEPTION 'account % not found', p_account_id; END IF;
+
+  FOR v_h IN SELECT * FROM jsonb_array_elements(COALESCE(p_homes, '[]'::jsonb)) LOOP
+    v_home := TRIM(COALESCE(v_h ->> 'homeId', ''));
+    CONTINUE WHEN v_home = '';
+    v_kind := CASE WHEN v_h ->> 'kind' IN ('group','square','square_chat')
+                   THEN v_h ->> 'kind' ELSE 'square_chat' END;
+
+    -- 已經有了：只更新名字／類型，設定一個字都不動
+    UPDATE line_note_communities
+       SET home_name = COALESCE(NULLIF(v_h ->> 'name', ''), home_name),
+           home_kind = v_kind,
+           synced_at = NOW()
+     WHERE tenant_id = v_tenant AND home_id = v_home;
+    IF FOUND THEN v_updated := v_updated + 1; CONTINUE; END IF;
+
+    -- 店家刪掉過的不要再長回來
+    IF EXISTS (SELECT 1 FROM line_note_home_dismissals
+                WHERE tenant_id = v_tenant AND home_id = v_home) THEN
+      v_skipped := v_skipped + 1;
+      CONTINUE;
+    END IF;
+
+    -- 新的一律是關的：備用帳號身上常有私人群組，不能自動去爬、也不能自動發文
+    INSERT INTO line_note_communities
+      (tenant_id, account_id, home_id, home_name, home_kind,
+       listen_enabled, auto_post_on_open, read_times, read_days, synced_at)
+    VALUES
+      (v_tenant, p_account_id, v_home, NULLIF(v_h ->> 'name', ''), v_kind,
+       FALSE, FALSE, ARRAY['12:00'], 3, NOW());
+    v_added := v_added + 1;
+  END LOOP;
+
+  RETURN QUERY SELECT v_added, v_updated, v_skipped;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.rpc_line_note_community_sync(BIGINT, JSONB) FROM PUBLIC, anon, authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 刪除：順手記一筆「我不要這個」，同步才不會下一輪又把它長回來
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_community_delete(p_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+  v_home   TEXT;
+BEGIN
+  DELETE FROM line_note_communities WHERE id = p_id AND tenant_id = v_tenant
+  RETURNING home_id INTO v_home;
+  IF v_home IS NULL THEN RAISE EXCEPTION 'community % not in tenant', p_id; END IF;
+
+  INSERT INTO line_note_home_dismissals (tenant_id, home_id, dismissed_by)
+  VALUES (v_tenant, v_home, auth.uid())
+  ON CONFLICT (tenant_id, home_id) DO UPDATE
+     SET dismissed_at = NOW(), dismissed_by = auth.uid();
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_community_delete(BIGINT) TO authenticated;


### PR DESCRIPTION
回報：加了新的 LINE 帳號，社群設定卻什麼都沒出現。

原本社群要一個一個手動貼 homeId 進去，帳號本身加入了哪些群組完全不影響清單。改成**清單跟著帳號走**：帳號登入完（或按新的「同步社群」）之後，那個帳號加入的每一個群組／社群就自己出現在社群設定裡。

## 安全的預設值

自動長出來的一律是**關的** —— `listen_enabled = FALSE`、`auto_post_on_open = FALSE`。備用帳號身上常常還有私人群組，自動開監聽等於未經同意就去爬別人的對話，開團還會自動發文進去。線上實跑就長出一個「北區女子耍廢俱樂部」，正是不能預設開的理由。要哪幾個由店家自己開。

**已經存在的社群只更新名字／類型**，設定一個字都不動 —— 同步不能把店家調好的讀取時間、模板洗掉。

## 刪掉的不要再長回來

`line_note_home_dismissals` 記「這個 home 我不要」，同步的新增那半跳過它。

刻意做成**獨立的表**，而不是在 `line_note_communities` 上加 `dismissed_at`：那張表身上有 `UNIQUE (tenant_id, home_id)`，加軟刪除欄位就會變成「查詢母體 ≠ 索引母體」（CLAUDE.md 會員那條：查得到的人都說沒人用、存下去卻一定撞）。手動「新增社群」照樣建得起來，建起來之後同步只會走更新那半，所以 dismissal 留著也不會擋到人。

## 順帶：刪帳號的確認框要講清楚代價

刪帳號會一路 CASCADE 掉 社群 → 貼文 → 留言。原本只寫「底下的社群設定與貼文紀錄會一起刪掉」，講得太輕 —— 這次真的按下去，刪掉了 1 個社群、72 篇貼文、上千則留言紀錄。

現在確認框會先把數量算出來（社群 N 個、貼文 M 篇、留言 K 則），寫明「已經加出來的訂單不會動」，並提示「只是要換帳號的話請按『登出』，不用刪除」。

> 補充：已經加出來的訂單確實沒受影響，去重也不靠這些紀錄（`rpc_line_note_apply_comment` 是拿真實的 `customer_order_items` 比對），所以重讀不會重複加單。

## 驗證

正式庫實跑：新帳號同步 → 2 個社群長出來，`listen_enabled` / `auto_post_on_open` 都是 `false` ✅

migration `20260909100000` 已套上正式庫、Edge Function 已部署、`apps/admin` tsc 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ)_