### PR TITLE
發文照小幫手的版型：文案吃團說明、圖片吃商品圖，發文前先預覽

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -617,6 +617,10 @@ function PostCampaignModal({ community, onClose, notify, fail, reloadPosts }: {
   const [campaigns, setCampaigns] = useState<Campaign[] | null>(null);
   const [campaignId, setCampaignId] = useState<number | "">("");
   const [busy, setBusy] = useState(false);
+  // 貼文是發給整個社群看的，發出去才發現版型不對就來不及了（只能刪掉重發，客人已經看到）。
+  // 所以先把「等一下真的會貼出去的字」原封不動叫回來給人看 —— 渲染是 worker 那一份，不是另外寫的。
+  const [preview, setPreview] = useState<{ text: string; images: string[] } | null>(null);
+  const [previewing, setPreviewing] = useState(false);
   useEffect(() => {
     void (async () => {
       const { data, error } = await getSupabase().from("group_buy_campaigns")
@@ -624,6 +628,22 @@ function PostCampaignModal({ community, onClose, notify, fail, reloadPosts }: {
       if (error) fail(error); else { setCampaigns((data ?? []) as Campaign[]); setCampaignId((data?.[0] as Campaign | undefined)?.id ?? ""); }
     })();
   }, [fail]);
+  useEffect(() => {
+    if (campaignId === "") { setPreview(null); return; }
+    let dead = false;
+    setPreviewing(true); setPreview(null);
+    void (async () => {
+      const { data, error } = await getSupabase().functions.invoke("line-note-worker", {
+        body: { action: "preview", community_id: community.id, campaign_id: campaignId },
+      });
+      if (dead) return;
+      setPreviewing(false);
+      if (error || (data as { error?: string })?.error) return;   // 預覽拿不到就不擋發文
+      setPreview(data as { text: string; images: string[] });
+    })();
+    return () => { dead = true; };
+  }, [campaignId, community.id]);
+
   const submit = async () => {
     if (campaignId === "") return;
     setBusy(true);
@@ -642,6 +662,32 @@ function PostCampaignModal({ community, onClose, notify, fail, reloadPosts }: {
           {(campaigns ?? []).map((c) => <option key={c.id} value={c.id}>{c.campaign_no} {c.name}（{c.status}）</option>)}
         </select>
       </label>
+
+      <div className="mt-3 text-sm">
+        <div className="mb-1 flex items-center justify-between text-zinc-500">
+          <span>會貼出去的內容</span>
+          {preview && <span className="text-xs">{preview.images.length} 張圖</span>}
+        </div>
+        {previewing ? <div className="rounded border border-zinc-200 p-3 text-zinc-400 dark:border-zinc-800">產生預覽中…</div>
+          : !preview ? <div className="rounded border border-zinc-200 p-3 text-zinc-400 dark:border-zinc-800">預覽拿不到（帳號沒登入？）—— 還是可以直接發</div>
+          : (
+          <div className="space-y-2">
+            <div className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900">
+              {preview.text}
+            </div>
+            {preview.images.length > 0 && (
+              <div className="flex gap-1.5 overflow-x-auto pb-1">
+                {preview.images.map((u) => (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img key={u} src={u} alt="" className="h-16 w-16 shrink-0 rounded border border-zinc-200 object-cover dark:border-zinc-800" />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        <p className="mt-1 text-xs text-zinc-500">文案取自這個團的說明，商品和價格取自團裡的品項，圖片取自商品圖。要改內容請去改團／商品。</p>
+      </div>
+
       <div className="mt-4 flex justify-end gap-2">
         <button type="button" className={btn} onClick={onClose}>取消</button>
         <SpinButton type="button" className={btnPrimary} loading={busy} disabled={campaignId === ""} onClick={submit}>發文</SpinButton>

--- a/supabase/functions/_shared/lineNote.ts
+++ b/supabase/functions/_shared/lineNote.ts
@@ -364,9 +364,13 @@ export async function createNotePost(client, homeId, { text, images = [], source
   const media = [];
   for (const file of images) {
     try {
-      const { objId } = await client.base.timeline.uploadNoteMedia("image", new Blob([file], { type: "image/jpeg" }));
+      // images 可以是 Uint8Array（當 JPEG）或 { bytes, type } —— PNG 也要能上傳，
+      // 宣告錯的 MIME 會被 obs 退掉。
+      const bytes = file?.bytes ?? file;
+      const type = file?.type || "image/jpeg";
+      const { objId } = await client.base.timeline.uploadNoteMedia("image", new Blob([bytes], { type }));
       media.push({ objectId: objId, type: "PHOTO", obsFace: "[]" });
-      log(verbose, `uploaded <${file.byteLength} bytes> → ${objId}`);
+      log(verbose, `uploaded <${(file?.bytes ?? file).byteLength} bytes, ${type}> → ${objId}`);
     } catch (e) {
       log(true, `圖片上傳失敗，這張跳過：${e?.message ?? e}`);
     }

--- a/supabase/functions/line-note-worker/index.ts
+++ b/supabase/functions/line-note-worker/index.ts
@@ -157,14 +157,46 @@ async function syncCommunities(accountId: number, homes: any[]) {
   }
 }
 
-const DEFAULT_TEMPLATE = `📣 {{name}}
+// 版型照小幫手手貼的樣子：團名開頭、商品用 (A) 品名 ＋ 下一行價格、⏰ 結單、#開團 收尾。
+// 文案本體吃 campaign.description —— 那本來就是商品那邊寫好的行銷文（線上近兩週 377/395 團有）。
+// {{title}} / {{items}} / {{deadline}} 是「聰明版」：文案自己已經寫過的就不再重複一次。
+// 從記事本匯進來的團，description 常常就是整篇貼文（標題＋(A)(B)品項＋⏰結單都在裡面），
+// 照樣接上去會變成品項印兩次、結單寫兩行。
+// {{name}} / {{end_at}} 維持原樣（照印），自訂模板的行為不變。
+const DEFAULT_TEMPLATE = `{{title}}
+
 {{description}}
 
 {{items}}
 
-⏰ 收單：{{end_at}}
-📝 下單方式：留言「會員編號 6 碼 ＋ 品項代碼＋數量」
-　例：123456 A+1 B+2`;
+{{deadline}}
+📝 留言「會員編號 6 碼 ＋ 品項代碼＋數量」，例：123456 A+1 B+2
+#開團`;
+
+// 比對標題用：去掉表情符號、空白、標點，只留文字
+function bareText(s: string) {
+  return String(s ?? "").normalize("NFKC").toLowerCase()
+    .replace(/[\s\p{P}\p{S}\p{M}\p{C}]/gu, "");   // \p{M}/\p{C} 要一起拿掉：emoji 後面的 VS16、ZWJ 都藏在那裡
+}
+
+// 從記事本抓回來的舊文會帶 LINE 裝飾表情的佔位字：($)(3)(5) = $35、(emoji) = 一個貼圖。
+// 原樣貼出去客人會看到一串「($)(3)(5)」，所以還原成看得懂的字。
+function stripLineDeco(s: string) {
+  return String(s ?? "")
+    .replace(/(?:\((?:\$|[0-9]|\/)\)){2,}/g, (m) => m.replace(/[()]/g, ""))
+    .replace(/\((?:emoji|好吃|讚|哭|笑|愛心)\)/g, "")
+    .replace(/[ \t]+\n/g, "\n");
+}
+
+// 品項名在 DB 裡是「團名 (A) 空心菜200g」，直接印會變成「(A) 團名 (A) 空心菜200g」。
+// 去掉團名前綴和重複的代碼，只留真正的品名。
+function itemLabel(name: string, code: string, campaignName: string) {
+  let t = String(name ?? "").trim();
+  const cn = String(campaignName ?? "").trim();
+  if (cn && t.startsWith(cn)) t = t.slice(cn.length).trim();
+  t = t.replace(new RegExp(`^[(（]${code}[)）]\\s*`), "").trim();
+  return t || String(name ?? "").trim();
+}
 
 function fmtTaipei(iso: string | null | undefined) {
   if (!iso) return "";
@@ -175,12 +207,28 @@ function fmtTaipei(iso: string | null | undefined) {
 
 export function renderTemplate(template: string | null, payload: any) {
   const c = payload.campaign ?? {};
-  const items = (payload.items ?? []).map((it: any) => `${it.code}. ${it.name}${it.unit_price == null ? "" : ` $${Number(it.unit_price)}`}`).join("\n");
+  const items = (payload.items ?? []).map((it: any) => {
+    const label = itemLabel(it.name, it.code, c.name);
+    const price = it.unit_price == null ? "" : `\n$${Number(it.unit_price)}`;
+    return `(${it.code}) ${label}${price}`;
+  }).join("\n");
+  const desc = stripLineDeco(c.description ?? "");
+  // 文案自己就列了 (A)(B) 品項 / 寫了結單 / 開頭就是團名 → 那三個聰明佔位符留空
+  const descHasItems = /(^|\n)\s*[(（][A-Za-z][)）]/.test(desc);
+  const descHasDeadline = /結單|收單|截單/.test(desc);
+  const firstLine = bareText(desc.split("\n").find((x) => x.trim()) ?? "");
+  const bareName = bareText(c.name ?? "");
+  const descHasTitle = !!firstLine && !!bareName && firstLine.length >= 4
+    && (bareName.includes(firstLine) || firstLine.includes(bareName));
+  const deadline = c.end_at ? `⏰ ${fmtTaipei(c.end_at)} 結單` : "";
+
   return (template || DEFAULT_TEMPLATE)
+    .replaceAll("{{title}}", descHasTitle ? "" : (c.name ?? ""))
+    .replaceAll("{{items}}", descHasItems ? "" : items)
+    .replaceAll("{{deadline}}", descHasDeadline ? "" : deadline)
     .replaceAll("{{name}}", c.name ?? "")
     .replaceAll("{{campaign_no}}", c.campaign_no ?? "")
-    .replaceAll("{{description}}", c.description ?? "")
-    .replaceAll("{{items}}", items)
+    .replaceAll("{{description}}", desc)
     .replaceAll("{{end_at}}", fmtTaipei(c.end_at))
     .replaceAll("{{start_at}}", fmtTaipei(c.start_at))
     .replaceAll("{{pickup_deadline}}", fmtTaipei(c.pickup_deadline))
@@ -195,20 +243,29 @@ function resolveImageUrl(p: unknown): string | null {
 }
 
 // 沒有 sharp：只帶原本就是 JPEG 的圖（PNG / WebP 略過並記 log）
-async function collectPostImages(payload: any): Promise<Uint8Array[]> {
-  if (Deno.env.get("LINE_POST_NO_IMAGE")) return [];
+// 要附哪些圖：團封面 + 每個品項的商品圖（同一張只算一次 —— 一個商品底下的品項常常共用圖）
+function postImageUrls(payload: any): string[] {
   const urls: string[] = [];
   const push = (u: unknown) => { const r = resolveImageUrl(u); if (r && !urls.includes(r)) urls.push(r); };
   push(payload.campaign?.cover_image_url);
   for (const it of payload.items ?? []) for (const img of it.images ?? []) push(img);
-  const out: Uint8Array[] = [];
-  for (const url of urls.slice(0, MAX_POST_IMAGES)) {
+  return urls.slice(0, MAX_POST_IMAGES);
+}
+
+async function collectPostImages(payload: any): Promise<{ bytes: Uint8Array; type: string }[]> {
+  if (Deno.env.get("LINE_POST_NO_IMAGE")) return [];
+  const out: { bytes: Uint8Array; type: string }[] = [];
+  for (const url of postImageUrls(payload)) {
     try {
       const r = await fetch(url);
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const ct = r.headers.get("content-type") ?? "";
-      if (!/image\/jpe?g/i.test(ct) && !/\.jpe?g(\?|$)/i.test(url)) { log(`圖片不是 JPEG（${ct}），略過：${url}`); continue; }
-      out.push(new Uint8Array(await r.arrayBuffer()));
+      // JPEG 以外也收 PNG（線上商品圖有 496 張 PNG）。GIF / WebP LINE 記事本吃不到，跳過。
+      const ct = (r.headers.get("content-type") ?? "").toLowerCase();
+      const type = /jpe?g/.test(ct) || /\.jpe?g(\?|$)/i.test(url) ? "image/jpeg"
+                 : /png/.test(ct) || /\.png(\?|$)/i.test(url) ? "image/png"
+                 : null;
+      if (!type) { log(`圖片格式不支援（${ct}），略過：${url}`); continue; }
+      out.push({ bytes: new Uint8Array(await r.arrayBuffer()), type });
     } catch (e) {
       log(`圖片略過 ${url}：${(e as any)?.message ?? e}`);
     }
@@ -545,6 +602,15 @@ Deno.serve(async (req) => {
       const accountId = Number(body.account_id);
       if (!accountId) return json({ error: "account_id required" }, 400);
       return json(await doLogin(accountId));
+    }
+    // 發文預覽：發出去才發現版型不對就來不及了（貼文是發給整個社群看的）
+    if (action === "preview") {
+      if (caller !== "admin") return json({ error: "preview 只能從後台按" }, 403);
+      const payload = await rpc("rpc_line_note_preview_payload", {
+        p_community_id: Number(body.community_id), p_campaign_id: Number(body.campaign_id),
+      });
+      if (!payload) return json({ error: "找不到社群或團" }, 404);
+      return json({ text: renderTemplate(payload.post_template, payload), images: postImageUrls(payload) });
     }
     if (action === "tick" || action === "run") return json(await tick());
     return json({ error: `unknown action ${action}` }, 400);

--- a/supabase/migrations/20260910010000_line_note_preview_payload.sql
+++ b/supabase/migrations/20260910010000_line_note_preview_payload.sql
@@ -1,0 +1,44 @@
+-- ============================================================================
+-- 20260910010000_line_note_preview_payload.sql
+--
+-- 發文預覽用的 payload：跟 rpc_line_note_post_payload 同一個形狀，但用
+-- (社群, 團) 定位，不需要先有 line_note_posts 那一列 —— 預覽是在按下發文**之前**。
+--
+-- 貼文是發給整個社群看的，發出去才發現版型不對就來不及了（記事本貼文只能刪掉重發，
+-- 客人已經看到）。所以後台先叫這支把「等一下會貼出去的字」原封不動渲染出來給人看。
+--
+-- 渲染邏輯故意留在 worker（renderTemplate）不搬進 SQL：搬進來就變兩份會走鐘，
+-- 預覽看到的就不是真的會貼的東西，那預覽就沒有意義了。
+--
+-- 新函式，沒有覆蓋既有 function。
+-- rollback：DROP FUNCTION public.rpc_line_note_preview_payload(BIGINT, BIGINT);
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_line_note_preview_payload(
+  p_community_id BIGINT,
+  p_campaign_id  BIGINT
+) RETURNS JSONB
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT jsonb_build_object(
+    'home_id',       c.home_id,
+    'home_kind',     c.home_kind,
+    'account_id',    c.account_id,
+    'post_template', c.post_template,
+    'campaign', jsonb_build_object(
+       'id', g.id, 'campaign_no', g.campaign_no, 'name', g.name,
+       'description', g.description, 'status', g.status,
+       'cover_image_url', g.cover_image_url,
+       'start_at', g.start_at, 'end_at', g.end_at, 'pickup_deadline', g.pickup_deadline),
+    'items', COALESCE((SELECT jsonb_agg(jsonb_build_object(
+                'code', ic.code, 'campaign_item_id', ic.campaign_item_id,
+                'name', ic.item_name, 'unit_price', ic.unit_price, 'cap_qty', ic.cap_qty,
+                'images', ic.images)
+                ORDER BY ic.code)
+               FROM public._line_note_item_codes(g.id) ic), '[]'::jsonb)
+  )
+  FROM line_note_communities c
+  JOIN group_buy_campaigns g ON g.id = p_campaign_id AND g.tenant_id = c.tenant_id
+  WHERE c.id = p_community_id;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_preview_payload(BIGINT, BIGINT) TO authenticated;


### PR DESCRIPTION
## 做了什麼

把自動發文的成品調成跟小幫手手貼的那些貼文一樣：團名開頭、商品用「(A) 品名」＋下一行價格、⏰ 結單、`#開團` 收尾。原本是「📣 團名」「A. 品名 $35」，跟社群裡的風格對不起來。

**文案／商品／圖片都從既有資料來**

- **文案**：本體吃 `campaign.description` —— 那本來就是商品那邊寫好的行銷文（線上近兩週 **377/395** 個團都有）。
- **品名去掉重複前綴**：DB 裡存的是「雲林小農阿土伯蔬菜 (A) 空心菜200g」，照印會變成「(A) 雲林小農阿土伯蔬菜 (A) 空心菜200g」。
- **裝飾表情還原**：從記事本匯進來的舊文帶著 `($)(3)(5)` / `(emoji)` 這種佔位字，原樣貼出去客人會看到一串括號。還原成 `$35`，`(emoji)` 拿掉。
- **圖片**：除了 JPEG 也收 **PNG**（線上商品圖有 496 張 PNG）。原本上傳時寫死 `image/jpeg`，PNG 直接被略過 —— 等於那些團發出去沒圖。同一張圖只附一次（一個商品底下的品項常常共用同一張）。

**不要把同樣的東西寫兩次**

匯入的團 `description` 常常**就是整篇貼文**（標題＋`(A)(B)` 品項＋⏰結單全在裡面），照樣接上去會變成品項印兩次、結單寫兩行。所以 `{{title}}` / `{{items}}` / `{{deadline}}` 做成聰明版：文案自己已經寫過的就留空。`{{name}}` / `{{end_at}}` 維持照印，**自訂模板的行為不變**。

**發文預覽**

貼文是發給整個社群看的，發出去才發現版型不對就來不及了（只能刪掉重發，客人已經看到）。後台選好團就把「等一下真的會貼出去的字」連同要附的圖一起叫回來給人看。

渲染故意**留在 worker 那一份、不搬進 SQL** —— 搬了就變兩份會走鐘，預覽看到的就不是真的會貼的東西，那預覽就沒有意義了。所以加的是 `rpc_line_note_preview_payload`（同 payload 形狀、用「社群＋團」定位，不需要先有貼文列），字還是 worker 渲染的。

## 上線危險

- 做了：發文的文字版型與圖片來源改變。最壞情況是某個團貼出來的版面不如預期（例如文案已含品項卻沒被偵測到而印兩次）。**貼文可以在記事本刪掉重發**，而且新增的預覽讓人在按下發文前就看得到成品。不影響讀留言、加單、庫存、訂單任何一條路。
- 不做：發出去的貼文繼續長得跟社群風格不一樣（`📣 團名` + `A. 品名 $35`），PNG 商品圖的團**發出去沒有圖**（線上 496 張 PNG），匯入的團會把 `($)(3)(5)` 這種括號亂碼原樣貼給客人。而且沒有預覽 —— 版型錯了只能等貼出去才發現。
- 回退：`git revert` 本 PR（純程式碼，沒有資料異動）＋重新部署 Edge Function；migration 只新增一支唯讀函式，可留著不影響，要清就 `DROP FUNCTION public.rpc_line_note_preview_payload(BIGINT, BIGINT);`。

## 敏感設定

- [x] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。

守門抓到的是 `supabase/functions/line-note-worker/index.ts:新增後端環境值讀取`。

- 實際情況：**沒有新的環境變數**。`collectPostImages` 被拆成 `postImageUrls`（只算網址，給預覽用）＋下載那半，原本就存在的 `Deno.env.get("LINE_POST_NO_IMAGE")` 那一行跟著搬了位置，在 diff 裡看起來像新增。
- 影響：無。該旗標的語意沒變（設了就不附圖），沒有讀取任何密鑰，也沒有動 `verify_jwt`（`line-note-worker` 維持 `false`，函式內自己驗 caller —— 新增的 `preview` action 一樣要求 admin 身分，`caller !== "admin"` 直接 403）。
- 做了危險：無新增門禁面。`preview` 只回「這個團會貼出去的字與圖片網址」，資料範圍不超出後台本來就看得到的團／商品。
- 不做危險：無法把圖片相關的行為攤成可預覽的純函式，預覽就得另寫一份渲染 → 兩份會走鐘。
- 回退：同上，`git revert` 即可，沒有環境變數要收。

## 驗證

拿線上三種真實資料跑過同一份渲染程式：

| 團 | 情況 | 結果 |
|---|---|---|
| 4974 雲林小農阿土伯 | description 已含標題／品項／結單 | 三者都不重複，`($)(3)(5)` → `$35` ✅ |
| 5043 手作港點 | description 已含品項與結單 | 同上，尾巴接 `#開團` ✅ |
| 5042 套裝睡衣 | description 只是文案 | `(A)~(E) 品名／$359` 正常印出 ✅ |

UI 用 Playwright 在 iPhone 390px 點過發文彈窗：預覽文字、張數、縮圖都出得來。`apps/admin` tsc 通過。

migration `20260910010000` 已套上正式庫，Edge Function 已部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ