### PR TITLE
發文的金額用 LINE 的彩色數字表情

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -619,7 +619,7 @@ function PostCampaignModal({ community, onClose, notify, fail, reloadPosts }: {
   const [busy, setBusy] = useState(false);
   // 貼文是發給整個社群看的，發出去才發現版型不對就來不及了（只能刪掉重發，客人已經看到）。
   // 所以先把「等一下真的會貼出去的字」原封不動叫回來給人看 —— 渲染是 worker 那一份，不是另外寫的。
-  const [preview, setPreview] = useState<{ text: string; images: string[] } | null>(null);
+  const [preview, setPreview] = useState<{ text: string; images: string[]; deco?: number } | null>(null);
   const [previewing, setPreviewing] = useState(false);
   useEffect(() => {
     void (async () => {
@@ -639,7 +639,7 @@ function PostCampaignModal({ community, onClose, notify, fail, reloadPosts }: {
       if (dead) return;
       setPreviewing(false);
       if (error || (data as { error?: string })?.error) return;   // 預覽拿不到就不擋發文
-      setPreview(data as { text: string; images: string[] });
+      setPreview(data as { text: string; images: string[]; deco?: number });
     })();
     return () => { dead = true; };
   }, [campaignId, community.id]);
@@ -685,7 +685,10 @@ function PostCampaignModal({ community, onClose, notify, fail, reloadPosts }: {
             )}
           </div>
         )}
-        <p className="mt-1 text-xs text-zinc-500">文案取自這個團的說明，商品和價格取自團裡的品項，圖片取自商品圖。要改內容請去改團／商品。</p>
+        <p className="mt-1 text-xs text-zinc-500">
+          文案取自這個團的說明，商品和價格取自團裡的品項，圖片取自商品圖。要改內容請去改團／商品。
+          {!!preview?.deco && <>　金額會用 LINE 的彩色數字表情貼出去（這裡先用一般數字顯示）。</>}
+        </p>
       </div>
 
       <div className="mt-4 flex justify-end gap-2">

--- a/supabase/functions/_shared/lineNote.ts
+++ b/supabase/functions/_shared/lineNote.ts
@@ -356,7 +356,7 @@ export async function likeComment(client, homeId, commentId, { likeType = "1003"
   return res;
 }
 
-export async function createNotePost(client, homeId, { text, images = [], sourceType, verbose = false } = {}) {
+export async function createNotePost(client, homeId, { text, images = [], sticonMetas = [], sourceType, verbose = false } = {}) {
   if (!text && images.length === 0) throw new Error("貼文至少要有文字或圖片");
 
   // 圖片上傳走 obs.line-apps.com（linejs 的 uploadNoteMedia），失敗就只發文字，
@@ -396,10 +396,21 @@ export async function createNotePost(client, homeId, { text, images = [], source
       locations: [],
       media,
       ...(text ? { text } : {}),
+      // LINE 裝飾表情（金額那種彩色數字）：text 裡放 (x) 佔位字，這裡給每個佔位字的位移與圖號
+      ...(sticonMetas?.length ? { sticonMetas } : {}),
     },
   };
-  const res = await noteRequest(client, homeId, "/api/v57/post/create.json",
-    { homeId, sourceType: sourceType ?? "TALKROOM" }, { method: "POST", body, verbose });
+  const params = { homeId, sourceType: sourceType ?? "TALKROOM" };
+  let res = await noteRequest(client, homeId, "/api/v57/post/create.json", { ...params }, { method: "POST", body, verbose });
+
+  // 裝飾表情是加分項，不能因為它讓整篇發不出去：被打槍就把佔位字還原成純文字重發一次
+  if ((!res || res.code !== 0) && sticonMetas?.length) {
+    log(true, `帶裝飾表情發文被退（code=${res?.code}），改用純文字重試`);
+    const plain = { ...body, contents: { ...body.contents, text: text.replace(/\((\$|[0-9])\)/g, "$1") } };
+    delete plain.contents.sticonMetas;
+    res = await noteRequest(client, homeId, "/api/v57/post/create.json", { ...params }, { method: "POST", body: plain, verbose });
+  }
+
   log(verbose, "createPost →", JSON.stringify(res).slice(0, 500));
   if (!res || res.code !== 0) {
     throw new Error(`發文失敗：code=${res?.code} ${res?.message ?? ""}\n${JSON.stringify(res).slice(0, 800)}`);

--- a/supabase/functions/_shared/lineNoteDeco.ts
+++ b/supabase/functions/_shared/lineNoteDeco.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+// ─────────────────────────────────────────────────────────────────────────────
+// LINE 裝飾表情（deco emoji / sticon）
+//
+// 小幫手手貼的貼文，金額是用 LINE 的數字表情打的（截圖那種彩色的 $ 7 9），
+// 不是純文字。它在 API 上長這樣：
+//   contents.text          "一份($)(7)(9)"      ← 每個表情佔一個 (x) 佔位字
+//   contents.sticonMetas   [{S,E,productId,sticonId,version,resourceType}, …]
+// S / E 是**UTF-16 位移**（JS 字串的原生索引），指向 text 裡那段佔位字。
+//
+// 下面的對照表不是猜的，是把松山社群 60 篇貼文的 sticonMetas 撈回來統計出來的
+// （1,125 筆）。注意 0 是 062 不是 052 —— 1~9 連號到 061 之後才輪到 0。
+// ─────────────────────────────────────────────────────────────────────────────
+
+// 金額（會動的那組，小幫手都用這個打價格）
+const PRICE = {
+  productId: "61f5f6d3e023eb1687b8e333",
+  version: 2,
+  resourceType: "ANIMATION",
+  map: {
+    "$": "068",
+    "1": "053", "2": "054", "3": "055", "4": "056", "5": "057",
+    "6": "058", "7": "059", "8": "060", "9": "061", "0": "062",
+  },
+} as const;
+
+// 用私有區的字當標記：渲染時把要裝飾的段落包起來，最後一次換成佔位字＋metas。
+// 這樣才只動我們自己產的那幾行，不會去改店家寫在文案裡的「（市價$150/盒）」。
+export const DECO_OPEN = "";
+export const DECO_CLOSE = "";
+
+export function decoPrice(s: string) {
+  return `${DECO_OPEN}${s}${DECO_CLOSE}`;
+}
+
+// 把標記過的段落換成 LINE 看得懂的 (x) 佔位字 + sticonMetas。
+// 表裡沒有的字（例如小數點）原樣留著，不會消失。
+export function applyDeco(raw: string): { text: string; sticonMetas: any[] } {
+  const metas: any[] = [];
+  let out = "";
+  let deco = false;
+  for (const ch of String(raw ?? "")) {
+    if (ch === DECO_OPEN) { deco = true; continue; }
+    if (ch === DECO_CLOSE) { deco = false; continue; }
+    const sticonId = deco ? (PRICE.map as Record<string, string>)[ch] : undefined;
+    if (!sticonId) { out += ch; continue; }
+    const S = out.length;                       // out 是 JS 字串 → 本來就是 UTF-16 位移
+    out += `(${ch})`;
+    metas.push({
+      S: String(S), E: String(out.length),
+      productId: PRICE.productId, sticonId,
+      version: PRICE.version, resourceType: PRICE.resourceType,
+    });
+  }
+  return { text: out, sticonMetas: metas };
+}
+
+// 預覽 / 存檔用：把標記拿掉，留下人看得懂的 "$79"
+export function stripDeco(raw: string) {
+  return String(raw ?? "").replaceAll(DECO_OPEN, "").replaceAll(DECO_CLOSE, "");
+}

--- a/supabase/functions/line-note-worker/index.ts
+++ b/supabase/functions/line-note-worker/index.ts
@@ -28,6 +28,7 @@ import {
   clientFromToken, createNotePost, likeComment, listComments, listHomes, listPosts, loginByQr, whoami,
 } from "../_shared/lineNote.ts";
 import { matchCampaign, parseNoteComment, postTitle } from "../_shared/lineNoteParse.ts";
+import { applyDeco, DECO_OPEN, decoPrice, stripDeco } from "../_shared/lineNoteDeco.ts";
 
 const SUPABASE_URL = requireEnv("SUPABASE_URL");
 const SERVICE_KEY = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
@@ -209,7 +210,9 @@ export function renderTemplate(template: string | null, payload: any) {
   const c = payload.campaign ?? {};
   const items = (payload.items ?? []).map((it: any) => {
     const label = itemLabel(it.name, it.code, c.name);
-    const price = it.unit_price == null ? "" : `\n$${Number(it.unit_price)}`;
+    // 金額用 LINE 的數字表情（小幫手手貼都是這樣打的），只包我們自己產的這一行 ——
+    // 店家寫在文案裡的「（市價$150/盒）」不要動
+    const price = it.unit_price == null ? "" : `\n${decoPrice(`$${Number(it.unit_price)}`)}`;
     return `(${it.code}) ${label}${price}`;
   }).join("\n");
   const desc = stripLineDeco(c.description ?? "");
@@ -234,6 +237,16 @@ export function renderTemplate(template: string | null, payload: any) {
     .replaceAll("{{pickup_deadline}}", fmtTaipei(c.pickup_deadline))
     .replace(/\n{3,}/g, "\n\n")
     .trim();
+}
+
+// 文案裡「自己獨立一行的 $數字」也是價格（匯進來的團，品項與價格都寫在 description 裡），
+// 一併用數字表情。行內的「（市價$150/盒）」不動 —— 那不是這團的售價。
+function decoStandalonePrices(text: string) {
+  return text.split("\n")
+    .map((line) => /^\s*\$\d+\s*$/.test(line) && !line.includes(DECO_OPEN)
+      ? line.replace(/\$\d+/, (m) => decoPrice(m))
+      : line)
+    .join("\n");
 }
 
 function resolveImageUrl(p: unknown): string | null {
@@ -280,16 +293,18 @@ async function jobPost(job: any) {
   if (!payload) throw new Error(`post ${job.post_id} not found`);
   const account = await loadAccount(payload.account_id);
   const client = await clientFor(account);
-  const text = renderTemplate(payload.post_template, payload);
+  const rendered = decoStandalonePrices(renderTemplate(payload.post_template, payload));
+  const { text, sticonMetas } = applyDeco(rendered);
+  const plain = stripDeco(rendered);          // 存 DB / 給人看的版本："$79" 而不是 "($)(7)(9)"
   const images = await collectPostImages(payload);
   try {
-    const post = await createNotePost(client, payload.home_id, { text, images, verbose: VERBOSE });
+    const post = await createNotePost(client, payload.home_id, { text, sticonMetas, images, verbose: VERBOSE });
     await patch("line_note_posts", `id=eq.${job.post_id}`, {
-      status: "posted", line_post_id: post.postId ?? null, text, posted_at: new Date().toISOString(), last_error: null,
+      status: "posted", line_post_id: post.postId ?? null, text: plain, posted_at: new Date().toISOString(), last_error: null,
     });
-    return { postId: post.postId, title: postTitle(text), images: images.length };
+    return { postId: post.postId, title: postTitle(plain), images: images.length, deco: sticonMetas.length };
   } catch (e) {
-    await patch("line_note_posts", `id=eq.${job.post_id}`, { status: "failed", text, last_error: String((e as any)?.message ?? e).slice(0, 1000) });
+    await patch("line_note_posts", `id=eq.${job.post_id}`, { status: "failed", text: plain, last_error: String((e as any)?.message ?? e).slice(0, 1000) });
     throw e;
   }
 }
@@ -610,7 +625,12 @@ Deno.serve(async (req) => {
         p_community_id: Number(body.community_id), p_campaign_id: Number(body.campaign_id),
       });
       if (!payload) return json({ error: "找不到社群或團" }, 404);
-      return json({ text: renderTemplate(payload.post_template, payload), images: postImageUrls(payload) });
+      const rendered = decoStandalonePrices(renderTemplate(payload.post_template, payload));
+      return json({
+        text: stripDeco(rendered),
+        deco: applyDeco(rendered).sticonMetas.length,   // 有幾個字會用 LINE 數字表情貼出去
+        images: postImageUrls(payload),
+      });
     }
     if (action === "tick" || action === "run") return json(await tick());
     return json({ error: `unknown action ${action}` }, 400);


### PR DESCRIPTION
## 做了什麼

小幫手手貼的貼文，金額是用 LINE 的**裝飾表情**打的（截圖那種彩色的 `$ 7 9`），不是純文字。自動發文照樣打純文字，貼出去就跟社群裡其他貼文長得不一樣。

在 API 上長這樣：

```
contents.text         "一份($)(7)(9)"          ← 每個表情佔一個 (x) 佔位字
contents.sticonMetas  [{S, E, productId, sticonId, version, resourceType}, …]
```

`S` / `E` 是 **UTF-16 位移**（JS 字串的原生索引），所以文案裡有 emoji（代理對）也不會算歪。

## 對照表是撈出來的，不是猜的

把松山社群 60 篇貼文的 `sticonMetas` 抓回來統計，共 1,125 筆。金額那組是 `61f5f6d3e023eb1687b8e333` / ver 2 / ANIMATION：

| 字 | sticonId | 樣本數 |
|---|---|---|
| `$` | 068 | 68 |
| 1〜9 | 053〜061 | 154 |
| **0** | **062** | 9 |

**`0` 是 062 不是 052** —— 連號到 9（061）之後才輪到 0。照直覺寫成「052 + 數字」會把 `$30` 貼成「$3」加一個看不懂的圖。

## 只裝飾兩種地方

- 我們自己產的**品項價格行**
- 文案裡**自己獨立一行的 `$數字`**（匯進來的團，品項與價格都寫在 `description` 裡）

行內的「（市價$150/盒）」維持純文字 —— 那不是這團的售價，不該去改店家自己寫的文案。

## 保險

裝飾表情是加分項，不能因為它讓整篇發不出去。`post/create.json` 被退（`code != 0`）就把佔位字還原成純文字**自動重發一次**。

存進 DB 與後台預覽都是人看得懂的 `$79`，不是 `($)(7)(9)`；預覽下方會註明「金額會用 LINE 的彩色數字表情貼出去」。

## 驗證

拿線上兩種真實資料跑過完整流程（渲染 → 標記 → 產生 metas）：

| 團 | 價格來源 | 結果 |
|---|---|---|
| 4974 雲林小農阿土伯 | 寫在 description 裡 | 4 行價格全部裝飾，共 12 個 metas，文案其他字沒動 ✅ |
| 5042 套裝睡衣 | 由品項產生 | `$359` → `($)(3)(5)(9)`，每項一組 ✅ |

位移正確性直接對拍：用產生的 `S`/`E` 回頭切 `text`，切出來剛好是 `($)(7)(9)`；且與線上那篇烏鱧魚貼文的位移（12-15 / 15-18 / 18-21）完全一致。

`apps/admin` tsc 通過，Edge Function 已部署。

## 上線危險

- 做了：貼出去的金額改用 LINE 表情呈現。最壞情況是某個社群不吃 `sticonMetas`，但已經有**純文字自動重發**接住，不會整篇發不出去。純顯示層，不影響讀留言、加單、庫存、訂單。
- 不做：自動發文的金額繼續是純文字，跟小幫手手貼的貼文放在一起看得出來是機器發的。
- 回退：`git revert` 本 PR ＋重新部署 Edge Function。沒有資料異動、沒有 migration。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8gTNuJ2nzsu9HqeiF1yuQ)_