### PR TITLE
feat(line-notes): 開團那邊直接發記事本，一次勾多個群組、看得到爬過的紀錄

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -24,6 +24,7 @@ import { CampaignThumb } from "@/components/CampaignThumb";
 import { campaignCoverUrl, type CampaignCoverItem } from "@/lib/campaignCover";
 import { exportLeleXls, type LeleCampaign, type LeleTruncation, type LeleSkip } from "@/lib/exportLeleXls";
 import FbPublishModal from "@/components/FbPublishModal";
+import LineNotePostsModal from "@/components/LineNotePostsModal";
 import FbBulkPublishModal from "@/components/FbBulkPublishModal";
 import { useRole, isAdmin, useMyStores } from "@/lib/role";
 import StoreCampaignCreateModal from "@/components/StoreCampaignCreateModal";
@@ -210,6 +211,8 @@ export default function CampaignsListPage() {
   const [reloadTick, setReloadTick] = useState(0);
   const [resyncTick, setResyncTick] = useState(0);
   const [fbPublishId, setFbPublishId] = useState<number | null>(null);
+  // LINE 記事本彈窗：發文到哪幾個群組 + 這團爬回來的貼文與留言（LineNotePostsModal）
+  const [lineNoteFor, setLineNoteFor] = useState<Row | null>(null);
   const [bulkFbOpen, setBulkFbOpen] = useState(false);
   const [closingId, setClosingId] = useState<number | null>(null);
   const [cloningId, setCloningId] = useState<number | null>(null);
@@ -858,6 +861,14 @@ export default function CampaignsListPage() {
           發 FB
         </SpinButton>
       )}
+      {showAdminActions && (["open", "closed", "locked", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
+        <SpinButton
+          onClick={() => setLineNoteFor(r)}
+          className="text-xs text-emerald-600 hover:underline dark:text-emerald-400"
+        >
+          LINE 記事本
+        </SpinButton>
+      )}
       {showAdminActions && (["closed", "locked", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
         <SpinButton
           onClick={() => finalizeCampaign(r.id, r.name)}
@@ -1409,7 +1420,7 @@ export default function CampaignsListPage() {
         open={!!modal}
         onClose={() => setModal(null)}
         title={modal ? `編輯開團 #${modal.values.campaign_no}｜${modal.values.name}` : ""}
-        maxWidth="max-w-4xl"
+        maxWidth="max-w-6xl"
       >
         {modal && (
           <div className="space-y-6">
@@ -1446,6 +1457,15 @@ export default function CampaignsListPage() {
         open={fbPublishId !== null}
         campaignId={fbPublishId}
         onClose={() => setFbPublishId(null)}
+      />
+
+      <LineNotePostsModal
+        open={lineNoteFor !== null}
+        campaignId={lineNoteFor?.id ?? null}
+        campaignNo={lineNoteFor?.campaign_no ?? null}
+        campaignName={lineNoteFor?.name ?? null}
+        campaignStatus={lineNoteFor?.status ?? null}
+        onClose={() => setLineNoteFor(null)}
       />
 
       <FbBulkPublishModal

--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -12,6 +12,9 @@ import { translateRpcError } from "@/lib/rpcError";
 import { campaignStatusBadge, campaignStatusLabel } from "@/lib/campaignStatus";
 import { Modal as SharedModal } from "@/components/Modal";
 import { OrderDetail } from "@/components/OrderDetail";
+import {
+  COMMENT_STATUS_LABEL, HOME_KIND_LABEL, POST_STATUS_LABEL, commentStats, fmtNoteTime, isTodoComment,
+} from "@/lib/lineNoteStatus";
 
 type Account = {
   id: number; label: string; status: "logged_out" | "pending_qr" | "active" | "error";
@@ -42,21 +45,19 @@ type Comment = {
 };
 type Row = Comment & { line_note_posts: { community_id: number; campaign_id: number; group_buy_campaigns: { name: string; campaign_no: string } | null } | null };
 type OrderInfo = { id: number; order_no: string; store_name: string | null };
-type PostStat = { ordered: number; duplicate: number; todo: number; total: number };
+type PostStat = ReturnType<typeof commentStats>;
 type Home = { kind: string; homeId: string; name: string };
 type Campaign = { id: number; campaign_no: string; name: string; status: string };
 
 const ACCOUNT_STATUS: Record<Account["status"], string> = {
   logged_out: "未登入", pending_qr: "等待掃 QR", active: "已登入", error: "錯誤",
 };
-const POST_STATUS: Record<Post["status"], string> = { queued: "排隊中", posted: "已發文", failed: "失敗", closed: "已結束", unlinked: "未認出團" };
-const COMMENT_STATUS: Record<Comment["status"], string> = {
-  pending: "待處理", ordered: "已加單", unmatched: "找不到會員", no_order: "非下單", error: "錯誤", ignored: "忽略", resolved: "已解決", duplicate: "已有訂單",
-};
-const KIND_LABEL: Record<string, string> = { group: "群組", square: "社群", square_chat: "社群聊天室" };
-
-const fmt = (iso: string | null | undefined) =>
-  iso ? new Date(iso).toLocaleString("zh-TW", { hour12: false, month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" }) : "—";
+// 狀態文字 / 留言統計 / 時間格式都在 @/lib/lineNoteStatus —— 開團的「LINE 記事本」
+// 彈窗（LineNotePostsModal）畫同一批東西，兩邊各寫一份就會出現徽章數字對不起來。
+const POST_STATUS = POST_STATUS_LABEL;
+const COMMENT_STATUS = COMMENT_STATUS_LABEL;
+const KIND_LABEL = HOME_KIND_LABEL;
+const fmt = fmtNoteTime;
 const kindOf = (homeId: string): Community["home_kind"] =>
   homeId.startsWith("c") ? "group" : homeId.startsWith("s") ? "square" : "square_chat";
 
@@ -698,8 +699,7 @@ function PostCampaignModal({ community, onClose, notify, fail, reloadPosts }: {
 
 // ── 貼文與留言 ───────────────────────────────────────────────────────────────
 type Filter = "todo" | "ordered" | "ignored" | "all";
-const TODO_STATUSES: Comment["status"][] = ["pending", "unmatched", "error"];
-const isTodo = (c: Comment) => TODO_STATUSES.includes(c.status) || (c.status === "no_order" && !!c.member_no_hint);
+const isTodo = isTodoComment;
 
 // ── 留言加單：一張表，一則留言一列 ─────────────────────────────────────────
 function CommentsTab({ communityById, notify, fail }: {
@@ -904,16 +904,12 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
     const { data, error } = await getSupabase().from("line_note_comments")
       .select("post_id,status,member_no_hint").in("post_id", ids);
     if (error) return;   // 統計拿不到就不顯示，不要擋住整頁
-    const m = new Map<number, PostStat>();
+    const byPost = new Map<number, { status: string; member_no_hint: string | null }[]>();
     for (const r of (data ?? []) as { post_id: number; status: Comment["status"]; member_no_hint: string | null }[]) {
-      const cur = m.get(r.post_id) ?? { ordered: 0, duplicate: 0, todo: 0, total: 0 };
-      cur.total++;
-      if (r.status === "ordered") cur.ordered++;
-      else if (r.status === "duplicate") cur.duplicate++;
-      else if (["pending", "unmatched", "error"].includes(r.status) || (r.status === "no_order" && r.member_no_hint)) cur.todo++;
-      m.set(r.post_id, cur);
+      const cur = byPost.get(r.post_id);
+      if (cur) cur.push(r); else byPost.set(r.post_id, [r]);
     }
-    setCounts(m);
+    setCounts(new Map([...byPost].map(([pid, rows]) => [pid, commentStats(rows)])));
   }, [posts]);
   useEffect(() => { void loadCounts(); }, [loadCounts]);
 
@@ -997,6 +993,8 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
       <p className="text-sm text-zinc-500">
         開團自動發的、和小幫手手貼後被系統認出來的貼文。點一則展開看每則留言。
         認不出是哪一團的會標<b>「未認出團」</b>，指定團之後才會開始讀留言加單。
+        <br />要<b>補發某一團</b>的話從「開團」列表那一團的「LINE 記事本」按鈕比較快 ——
+        可以一次勾好幾個群組，也看得到那團已經爬到什麼。
       </p>
 
       {posts === null ? <div className="py-8 text-center text-sm text-zinc-400">讀取中…</div>
@@ -1031,6 +1029,10 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
                             <span className="font-mono">{p.group_buy_campaigns?.campaign_no}</span>
                           </>}
                       {p.status !== "posted" && !unlinked && <Badge tone={p.status === "failed" ? "red" : "gray"}>{POST_STATUS[p.status]}</Badge>}
+                      {/* 兩個 id 都寫出來：#id 是後台這一列，LINE 那串才是記事本上那一篇
+                          —— 跟客服對答案時只有後者認得出是哪一篇貼文 */}
+                      <span className="font-mono">#{p.id}</span>
+                      {p.line_post_id && <span className="font-mono" title="LINE 記事本的貼文 id">LINE {p.line_post_id}</span>}
                       <span className="truncate">{c?.home_name || c?.home_id || `社群 #${p.community_id}`}</span>
                       <span>發文 {fmt(p.posted_at)}</span>
                       {p.last_read_at && <span>讀取 {fmt(p.last_read_at)}</span>}

--- a/apps/admin/src/components/LineNotePostsModal.tsx
+++ b/apps/admin/src/components/LineNotePostsModal.tsx
@@ -1,0 +1,470 @@
+"use client";
+
+// 開團列表每一團的「LINE 記事本」彈窗：勾群組 → 看預覽 → 一次發出去，
+// 同一個彈窗下半部就是這團爬回來的貼文與留言（爬過的歷史紀錄）。
+//
+// 為什麼不是把人送去 /line-notes：那頁是以「社群」為軸（一個社群一列，逐個按發文），
+// 一團要發三個群組就得開三次彈窗、還得自己記得哪個發過了。開團才是小幫手的工作單位。
+// /line-notes 的「貼文」分頁留著 —— 未認出團的貼文沒有團可掛，只能在那邊指定。
+//
+// 群組清單與「能不能發」一律問 rpc_line_note_campaign_targets（20260910020000），
+// 不要在這裡自己接 line_note_communities 再算一次店家範圍 ——
+// 那條規則的正主是開團自動發文的 trigger，散成三份就會走鐘。
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Modal } from "@/components/Modal";
+import SpinButton from "@/components/SpinButton";
+import { OrderDetail } from "@/components/OrderDetail";
+import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
+import { withBasePath } from "@/lib/basePath";
+import {
+  COMMENT_STATUS_LABEL, HOME_KIND_LABEL, POST_STATUS_LABEL, commentStats, fmtNoteTime, isTodoComment,
+  type LineNoteCommentStatus, type LineNotePostStatus,
+} from "@/lib/lineNoteStatus";
+
+type Target = {
+  community_id: number; home_id: string; home_name: string | null; home_kind: string;
+  store_id: number | null; store_name: string | null;
+  account_id: number; account_label: string; account_status: string;
+  auto_post_on_open: boolean; listen_enabled: boolean;
+  in_scope: boolean; can_post: boolean; blocked_reason: string | null;
+  post_id: number | null; post_status: LineNotePostStatus | null; line_post_id: string | null;
+  post_text: string | null; posted_at: string | null; last_read_at: string | null;
+  closed_reason: string | null; post_error: string | null;
+  comment_total: number | null; comment_ordered: number | null;
+  comment_duplicate: number | null; comment_todo: number | null;
+};
+
+type Comment = {
+  id: number; line_comment_id: string; commenter_name: string | null; text: string;
+  commented_at: string | null; member_no_hint: string | null;
+  status: LineNoteCommentStatus; customer_order_id: number | null; error: string | null;
+  reacted_at: string | null; resolution_note: string | null;
+};
+
+type QueueResult = { out_community_id: number; out_post_id: number | null; out_status: string; out_error: string | null };
+
+type Props = {
+  open: boolean;
+  campaignId: number | null;
+  campaignNo?: string | null;
+  campaignName?: string | null;
+  campaignStatus?: string | null;
+  onClose: () => void;
+};
+
+const btn = "rounded border border-zinc-300 px-2.5 py-1 text-sm hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800";
+const btnPrimary = "rounded bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900";
+const CAN_POST_STATUS = ["open", "closed"];
+
+function Badge({ tone, children }: { tone: "gray" | "green" | "amber" | "red" | "blue"; children: React.ReactNode }) {
+  const cls = {
+    gray: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+    green: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
+    amber: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+    red: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
+    blue: "bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-300",
+  }[tone];
+  return <span className={`inline-block whitespace-nowrap rounded px-1.5 py-0.5 text-xs font-medium ${cls}`}>{children}</span>;
+}
+
+// Edge Function line-note-worker：排程每分鐘會自己跑；按了按鈕就順手叫一下，不用等下一分鐘
+function kickWorker(body: Record<string, unknown> = { action: "run" }) {
+  void getSupabase().functions.invoke("line-note-worker", { body }).catch(() => {});
+}
+
+export default function LineNotePostsModal({
+  open, campaignId, campaignNo, campaignName, campaignStatus, onClose,
+}: Props) {
+  const [targets, setTargets] = useState<Target[] | null>(null);
+  const [picked, setPicked] = useState<Set<number>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [busy, setBusy] = useState<"send" | number | null>(null);
+  const [results, setResults] = useState<QueueResult[] | null>(null);
+
+  // 預覽：worker 那一份 renderTemplate 渲染出來的「等一下真的會貼出去的字」。
+  // 模板是掛在社群上的，所以預覽要指定看哪個群組的。
+  const [previewFor, setPreviewFor] = useState<number | null>(null);
+  const [preview, setPreview] = useState<{ text: string; images: string[] } | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+
+  // 爬回來的留言（點貼文展開）
+  const [openPost, setOpenPost] = useState<number | null>(null);
+  const [comments, setComments] = useState<Map<number, Comment[]>>(new Map());
+  const [orderNos, setOrderNos] = useState<Map<number, string>>(new Map());
+  const [loadingPost, setLoadingPost] = useState<number | null>(null);
+  const [orderPopup, setOrderPopup] = useState<{ id: number; no: string } | null>(null);
+
+  const fail = useCallback((e: unknown) => setError(translateRpcError(e)), []);
+  const notify = useCallback((m: string) => { setToast(m); setTimeout(() => setToast(null), 3000); }, []);
+
+  const load = useCallback(async (keepPicked = false) => {
+    if (!campaignId) return;
+    const { data, error } = await getSupabase().rpc("rpc_line_note_campaign_targets", { p_campaign_id: campaignId });
+    if (error) { setTargets([]); return fail(error); }
+    const rows = (data ?? []) as Target[];
+    setTargets(rows);
+    // 「預設全選」= 全部發得出去的群組。已經發過的不勾（重發會在 LINE 上多一篇，
+    // 而舊那篇的 line_post_id 被覆蓋掉之後留言就再也讀不回來了）。
+    if (!keepPicked) setPicked(new Set(rows.filter((t) => t.can_post).map((t) => t.community_id)));
+    setPreviewFor((cur) => (cur && rows.some((t) => t.community_id === cur)
+      ? cur
+      : (rows.find((t) => t.can_post) ?? rows[0])?.community_id ?? null));
+  }, [campaignId, fail]);
+
+  useEffect(() => {
+    if (!open || !campaignId) return;
+    setTargets(null); setPicked(new Set()); setResults(null); setError(null);
+    setOpenPost(null); setComments(new Map()); setOrderNos(new Map());
+    void load();
+  }, [open, campaignId, load]);
+
+  // 預覽：換群組就重新問一次（不同群組可能有不同模板）
+  useEffect(() => {
+    if (!open || !campaignId || previewFor == null) { setPreview(null); return; }
+    let dead = false;
+    setPreviewing(true); setPreview(null);
+    void (async () => {
+      const { data, error } = await getSupabase().functions.invoke("line-note-worker", {
+        body: { action: "preview", community_id: previewFor, campaign_id: campaignId },
+      });
+      if (dead) return;
+      setPreviewing(false);
+      if (error || (data as { error?: string })?.error) return;   // 預覽拿不到不擋發文
+      setPreview(data as { text: string; images: string[] });
+    })();
+    return () => { dead = true; };
+  }, [open, campaignId, previewFor]);
+
+  const postable = useMemo(() => (targets ?? []).filter((t) => t.can_post), [targets]);
+  const withPost = useMemo(() => (targets ?? []).filter((t) => t.post_id != null), [targets]);
+  const canSendStatus = !campaignStatus || CAN_POST_STATUS.includes(campaignStatus);
+
+  const toggle = (id: number) =>
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+
+  const send = async () => {
+    if (!campaignId || picked.size === 0) return;
+    setBusy("send"); setError(null); setResults(null);
+    const { data, error } = await getSupabase().rpc("rpc_line_note_queue_posts", {
+      p_campaign_id: campaignId, p_community_ids: [...picked],
+    });
+    setBusy(null);
+    if (error) return fail(error);
+    const rows = (data ?? []) as QueueResult[];
+    setResults(rows);
+    const queued = rows.filter((r) => r.out_status === "queued").length;
+    if (queued > 0) { kickWorker(); notify(`已排 ${queued} 個群組的發文，幾秒後下面就會出現貼文`); }
+    // 排掉的取消勾選，**只留下這次失敗的**（那些多半是帳號掉線，修好再按一次就好）。
+    // 不整批重新預設全選：排隊中的貼文 can_post 還是 true（worker 掛掉時要留一條重排的路），
+    // 全選回來就會誘導人再按一次「發文」。
+    const done = new Set(rows.filter((r) => r.out_status !== "error").map((r) => r.out_community_id));
+    setPicked((prev) => new Set([...prev].filter((id) => !done.has(id))));
+    await load(true);
+    // worker 大概這個時間發完，順手把貼文狀態刷新一次
+    if (queued > 0) setTimeout(() => { void load(true); }, 8000);
+  };
+
+  const toggleComments = async (t: Target) => {
+    if (!t.post_id) return;
+    if (openPost === t.post_id) { setOpenPost(null); return; }
+    setOpenPost(t.post_id);
+    if (comments.has(t.post_id)) return;
+    setLoadingPost(t.post_id);
+    const { data, error } = await getSupabase().from("line_note_comments")
+      .select("id,line_comment_id,commenter_name,text,commented_at,member_no_hint,status,customer_order_id,error,reacted_at,resolution_note")
+      .eq("post_id", t.post_id).order("commented_at", { ascending: true }).order("id");
+    setLoadingPost(null);
+    if (error) return fail(error);
+    const cs = (data ?? []) as Comment[];
+    setComments((m) => new Map(m).set(t.post_id!, cs));
+    const ids = [...new Set(cs.map((c) => c.customer_order_id).filter((x): x is number => !!x))];
+    if (ids.length === 0) return;
+    const { data: od } = await getSupabase().from("customer_orders").select("id,order_no").in("id", ids);
+    setOrderNos((m) => {
+      const n = new Map(m);
+      for (const o of (od ?? []) as { id: number; order_no: string }[]) n.set(o.id, o.order_no);
+      return n;
+    });
+  };
+
+  const readNow = async (t: Target) => {
+    if (!t.post_id) return;
+    setBusy(t.community_id);
+    const { error } = await getSupabase().rpc("rpc_line_note_enqueue", {
+      p_kind: "read", p_account_id: t.account_id, p_community_id: t.community_id, p_post_id: t.post_id,
+    });
+    setBusy(null);
+    if (error) return fail(error);
+    kickWorker();
+    setComments((m) => { const n = new Map(m); n.delete(t.post_id!); return n; });
+    notify("已開始讀留言，幾秒後重新整理就看得到");
+    setTimeout(() => { void load(true); }, 8000);
+  };
+
+  const title = `LINE 記事本｜${campaignNo ? `${campaignNo} ` : ""}${campaignName ?? ""}`;
+
+  return (
+    <Modal open={open} onClose={onClose} title={title} maxWidth="max-w-6xl">
+      {targets === null ? (
+        <div className="py-10 text-center text-sm text-zinc-500">載入中…</div>
+      ) : (
+        <div className="space-y-4">
+          {error && (
+            <div className="flex items-start justify-between rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
+              <span className="whitespace-pre-wrap">{error}</span>
+              <button type="button" className="ml-3 shrink-0 text-xs underline" onClick={() => setError(null)}>關閉</button>
+            </div>
+          )}
+          {toast && <div className="rounded bg-emerald-600 px-3 py-2 text-sm text-white">{toast}</div>}
+
+          {targets.length === 0 && (
+            <div className="rounded border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
+              沒有可以發文的社群。
+              <ul className="ml-4 mt-1 list-disc space-y-0.5 text-xs">
+                <li>店家自開的團只發到「標了那家店」的社群 —— 到「LINE 記事本 → 社群設定」把社群的店家設成那一家。</li>
+                <li>總部的團會發到所有社群；一個都沒有的話請先在那頁登入帳號、同步社群。</li>
+              </ul>
+            </div>
+          )}
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            {/* ── 左：勾群組 + 預覽 + 發文 ───────────────────────────── */}
+            {targets.length > 0 && (
+            <section className="space-y-3">
+              <div>
+                <div className="mb-1.5 flex items-center justify-between">
+                  <h3 className="text-sm font-semibold">發到哪幾個群組（{picked.size}/{postable.length}）</h3>
+                  <button type="button" className={btn} disabled={postable.length === 0}
+                    onClick={() => setPicked(picked.size === postable.length
+                      ? new Set()
+                      : new Set(postable.map((t) => t.community_id)))}>
+                    {picked.size === postable.length && postable.length > 0 ? "全部取消" : "全選"}
+                  </button>
+                </div>
+                <ul className="divide-y divide-zinc-200 overflow-hidden rounded border border-zinc-200 dark:divide-zinc-800 dark:border-zinc-800">
+                  {targets.map((t) => {
+                    const on = picked.has(t.community_id);
+                    return (
+                      <li key={t.community_id} className={t.can_post ? "" : "bg-zinc-50 dark:bg-zinc-900/40"}>
+                        <label className={`flex items-start gap-2 px-2.5 py-2 text-sm ${t.can_post ? "cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/60" : ""}`}>
+                          <input type="checkbox" className="mt-1" checked={on} disabled={!t.can_post || busy === "send"}
+                            onChange={() => toggle(t.community_id)} />
+                          <span className="min-w-0 flex-1">
+                            <span className="flex flex-wrap items-center gap-1.5">
+                              <span className="font-medium">{t.home_name || t.home_id}</span>
+                              <span className="text-xs text-zinc-500">{HOME_KIND_LABEL[t.home_kind] ?? t.home_kind}</span>
+                              {t.post_id != null && (
+                                t.post_status === "failed" ? <Badge tone="red">發文失敗</Badge>
+                                : t.post_status === "queued" ? <Badge tone="amber">排隊中</Badge>
+                                : <Badge tone="green">已發</Badge>
+                              )}
+                              {t.account_status !== "active" && <Badge tone="red">帳號未登入</Badge>}
+                              {!t.in_scope && <Badge tone="gray">不在發送範圍</Badge>}
+                            </span>
+                            <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-zinc-500">
+                              <span>{t.store_name ? `${t.store_name}` : "總部（全部團）"}</span>
+                              <span>{t.account_label}</span>
+                              {!t.can_post && t.blocked_reason && <span className="text-amber-700 dark:text-amber-400">{t.blocked_reason}</span>}
+                            </span>
+                          </span>
+                          <button type="button"
+                            className={`shrink-0 text-xs underline ${previewFor === t.community_id ? "text-sky-700 dark:text-sky-400" : "text-zinc-500"}`}
+                            onClick={(e) => { e.preventDefault(); setPreviewFor(t.community_id); }}>
+                            {previewFor === t.community_id ? "預覽中" : "看預覽"}
+                          </button>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+
+              <div>
+                <div className="mb-1 flex items-center justify-between text-sm">
+                  <h3 className="font-semibold">會貼出去的內容</h3>
+                  {preview && <span className="text-xs text-zinc-500">{preview.images.length} 張圖</span>}
+                </div>
+                {previewing ? (
+                  <div className="rounded border border-zinc-200 p-3 text-sm text-zinc-400 dark:border-zinc-800">產生預覽中…</div>
+                ) : !preview ? (
+                  <div className="rounded border border-zinc-200 p-3 text-sm text-zinc-400 dark:border-zinc-800">
+                    預覽拿不到（LINE 帳號沒登入？）—— 還是可以直接發
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    <div className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded border border-zinc-200 bg-zinc-50 p-3 text-sm dark:border-zinc-800 dark:bg-zinc-900">
+                      {preview.text}
+                    </div>
+                    {preview.images.length > 0 && (
+                      <div className="flex gap-1.5 overflow-x-auto pb-1">
+                        {preview.images.map((u) => (
+                          // eslint-disable-next-line @next/next/no-img-element -- Supabase storage 公開網址，不走 next/image
+                          <img key={u} src={u} alt="" className="h-16 w-16 shrink-0 rounded border border-zinc-200 object-cover dark:border-zinc-800" />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+                <p className="mt-1 text-xs text-zinc-500">
+                  文案取自這個團的說明、商品與價格取自團裡的品項、圖片取自商品圖。要改內容請去改團／商品。
+                  文末的「🔖 團號」是給系統認的章，爬回來時靠它認出是哪一團。
+                </p>
+              </div>
+
+              {results && results.length > 0 && (
+                <ul className="space-y-1 rounded border border-zinc-200 p-2 text-xs dark:border-zinc-800">
+                  {results.map((r) => {
+                    const t = targets.find((x) => x.community_id === r.out_community_id);
+                    const name = t?.home_name || t?.home_id || `社群 #${r.out_community_id}`;
+                    return (
+                      <li key={r.out_community_id} className="flex flex-wrap items-center gap-1.5">
+                        {r.out_status === "queued" ? <Badge tone="green">已排隊</Badge>
+                          : r.out_status === "already_posted" ? <Badge tone="gray">已發過，跳過</Badge>
+                          : <Badge tone="red">不能發</Badge>}
+                        <span>{name}</span>
+                        {r.out_error && <span className="text-red-600 dark:text-red-400">{r.out_error}</span>}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+
+              <div className="flex items-center justify-end gap-2">
+                {!canSendStatus && (
+                  <span className="text-xs text-amber-700 dark:text-amber-400">只有開團中／已收單的團可以發文</span>
+                )}
+                <SpinButton className={btnPrimary} loading={busy === "send"}
+                  disabled={picked.size === 0 || !canSendStatus} onClick={send}>
+                  發文到 {picked.size} 個群組
+                </SpinButton>
+              </div>
+            </section>
+            )}
+
+            {/* ── 右：爬過的歷史紀錄 ─────────────────────────────────── */}
+            <section className={targets.length > 0 ? "" : "lg:col-span-2"}>
+              <div className="mb-1.5 flex items-center justify-between">
+                <h3 className="text-sm font-semibold">爬過的歷史紀錄（{withPost.length} 篇貼文）</h3>
+                <button type="button" className={btn} onClick={() => void load(true)}>重新整理</button>
+              </div>
+              {withPost.length === 0 ? (
+                <div className="rounded border border-zinc-200 py-8 text-center text-sm text-zinc-400 dark:border-zinc-800">
+                  這團還沒有貼文
+                </div>
+              ) : (
+                <ul className="space-y-2">
+                  {withPost.map((t) => {
+                    const expanded = openPost === t.post_id;
+                    const cs = t.post_id != null ? comments.get(t.post_id) : undefined;
+                    return (
+                      <li key={t.community_id} className="overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+                        <button type="button" onClick={() => void toggleComments(t)}
+                          className="flex w-full items-start gap-2 p-2.5 text-left hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
+                          <span className="mt-0.5 shrink-0 text-zinc-400">{expanded ? "▾" : "▸"}</span>
+                          <div className="min-w-0 flex-1 space-y-1">
+                            <div className="flex items-start justify-between gap-2">
+                              <span className="min-w-0 flex-1 truncate text-sm font-medium">{t.home_name || t.home_id}</span>
+                              <span className="shrink-0 text-xs tabular-nums text-zinc-500">{t.comment_total ?? 0} 則留言</span>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-zinc-500">
+                              {/* 貼文 id：後台這一列的編號 + LINE 那邊的貼文 id，兩個都給 ——
+                                  跟客服對答案時只有 LINE 的 id 認得出是哪一篇 */}
+                              <span className="font-mono">貼文 #{t.post_id}</span>
+                              {t.line_post_id && <span className="font-mono" title="LINE 記事本的貼文 id">LINE {t.line_post_id}</span>}
+                              {t.post_status && t.post_status !== "posted" && (
+                                <Badge tone={t.post_status === "failed" ? "red" : "gray"}>{POST_STATUS_LABEL[t.post_status]}</Badge>
+                              )}
+                              <span>發文 {fmtNoteTime(t.posted_at)}</span>
+                              {t.last_read_at && <span>讀取 {fmtNoteTime(t.last_read_at)}</span>}
+                            </div>
+                            <div className="flex flex-wrap items-center gap-1">
+                              {(t.comment_ordered ?? 0) > 0 && <Badge tone="green">已加單 {t.comment_ordered}</Badge>}
+                              {(t.comment_duplicate ?? 0) > 0 && <Badge tone="blue">已有訂單 {t.comment_duplicate}</Badge>}
+                              {(t.comment_todo ?? 0) > 0 && <Badge tone="red">待處理 {t.comment_todo}</Badge>}
+                            </div>
+                            {t.closed_reason && <div className="text-xs text-zinc-500">讀到結單留言：{t.closed_reason}</div>}
+                            {t.post_error && <div className="text-xs text-red-600">{t.post_error}</div>}
+                          </div>
+                        </button>
+
+                        <div className="flex flex-wrap gap-1.5 border-t border-zinc-100 px-2.5 py-1.5 dark:border-zinc-800">
+                          {t.post_status === "posted" && (
+                            <SpinButton className={btn} loading={busy === t.community_id} onClick={() => void readNow(t)}>
+                              立即讀留言
+                            </SpinButton>
+                          )}
+                          {/* 退回未處理 / 忽略 / 重試那些留言操作都在記事本頁，這裡只給入口，不再抄一份 */}
+                          <a className={`${btn} ml-auto`} href={withBasePath("/line-notes")} target="_blank" rel="noreferrer">
+                            到記事本頁處理留言
+                          </a>
+                        </div>
+
+                        {expanded && (
+                          <div className="border-t border-zinc-100 bg-zinc-50 p-2.5 dark:border-zinc-800 dark:bg-zinc-900/50">
+                            {loadingPost === t.post_id ? <div className="text-sm text-zinc-400">讀取中…</div>
+                              : !cs ? null
+                              : cs.length === 0 ? <div className="text-sm text-zinc-400">還沒讀到留言</div> : (
+                              <>
+                                <div className="mb-1.5 text-xs text-zinc-500">
+                                  {(() => { const s = commentStats(cs);
+                                    return `共 ${s.total} 則：已加單 ${s.ordered}、已有訂單 ${s.duplicate}、待處理 ${s.todo}`; })()}
+                                </div>
+                                <ul className="divide-y divide-zinc-200 rounded border border-zinc-200 bg-white dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
+                                  {cs.map((cm) => (
+                                    <li key={cm.id} className={`px-2.5 py-2 text-sm ${isTodoComment(cm) ? "bg-amber-50/60 dark:bg-amber-950/20" : ""}`}>
+                                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                                        <span className="font-medium">{cm.commenter_name ?? "—"}</span>
+                                        <span className="text-xs text-zinc-500">{fmtNoteTime(cm.commented_at)}</span>
+                                        <Badge tone={cm.status === "ordered" || cm.status === "resolved" ? "green"
+                                          : cm.status === "duplicate" ? "blue"
+                                          : cm.status === "pending" ? "amber"
+                                          : cm.status === "unmatched" || cm.status === "error" ? "red" : "gray"}>
+                                          {COMMENT_STATUS_LABEL[cm.status]}
+                                        </Badge>
+                                        {cm.customer_order_id != null && orderNos.has(cm.customer_order_id) && (
+                                          <button type="button"
+                                            className="font-mono text-xs text-sky-700 underline hover:text-sky-900 dark:text-sky-400"
+                                            onClick={() => setOrderPopup({ id: cm.customer_order_id!, no: orderNos.get(cm.customer_order_id!)! })}>
+                                            {orderNos.get(cm.customer_order_id)}
+                                          </button>
+                                        )}
+                                        {cm.reacted_at && <span title={`已在 LINE 留言上按 😄（${fmtNoteTime(cm.reacted_at)}）`}>😄</span>}
+                                      </div>
+                                      <div className="mt-0.5 whitespace-pre-wrap break-words text-zinc-700 dark:text-zinc-300">{cm.text}</div>
+                                      {cm.error && <div className="mt-0.5 text-xs text-red-600 dark:text-red-400">{cm.error}</div>}
+                                    </li>
+                                  ))}
+                                </ul>
+                              </>
+                            )}
+                          </div>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </section>
+          </div>
+        </div>
+      )}
+
+      {/* 留言加出來的訂單：跟 CampaignOrdersPanel 一樣在彈窗裡再開一層 */}
+      <Modal
+        open={orderPopup !== null}
+        onClose={() => setOrderPopup(null)}
+        title={`訂單明細 ${orderPopup?.no ?? ""}`}
+        maxWidth="max-w-4xl"
+      >
+        {orderPopup && <OrderDetail orderId={orderPopup.id} onNavigate={(id, no) => setOrderPopup({ id, no })} />}
+      </Modal>
+    </Modal>
+  );
+}

--- a/apps/admin/src/lib/lineNoteStatus.ts
+++ b/apps/admin/src/lib/lineNoteStatus.ts
@@ -1,0 +1,56 @@
+// LINE 記事本的狀態文字與留言統計，一份。
+//
+// 同一套東西現在有兩個入口在畫：LINE 記事本頁的「貼文」分頁（全站，含未認出團的）
+// 與開團列表每一團的「LINE 記事本」彈窗（LineNotePostsModal，只看那一團）。
+// 兩邊各寫一份的話，同一則留言會在兩個畫面上被算成不同狀態 —— 徽章數字對不起來
+// 就沒人敢相信它。
+//
+// ⚠ isTodoComment 的判定 DB 也有一份：public._line_note_comment_is_todo
+// （20260910020000，rpc_line_note_campaign_targets 的統計用它），改這裡記得改那支。
+
+export type LineNotePostStatus = "queued" | "posted" | "failed" | "closed" | "unlinked";
+export type LineNoteCommentStatus =
+  | "pending" | "ordered" | "unmatched" | "no_order" | "error" | "ignored" | "resolved" | "duplicate";
+
+export const POST_STATUS_LABEL: Record<LineNotePostStatus, string> = {
+  queued: "排隊中", posted: "已發文", failed: "失敗", closed: "已結束", unlinked: "未認出團",
+};
+
+export const COMMENT_STATUS_LABEL: Record<LineNoteCommentStatus, string> = {
+  pending: "待處理", ordered: "已加單", unmatched: "找不到會員", no_order: "非下單",
+  error: "錯誤", ignored: "忽略", resolved: "已解決", duplicate: "已有訂單",
+};
+
+export const HOME_KIND_LABEL: Record<string, string> = {
+  group: "群組", square: "社群", square_chat: "社群聊天室",
+};
+
+/**
+ * 這則留言還要人看嗎？
+ * no_order（解析不出訂單）本來不算，但**留言裡有 6 碼會員編號**就算 ——
+ * 那是「客人想下單、我們看不懂他寫什麼」，放掉就是漏單。
+ */
+export function isTodoComment(c: { status: string; member_no_hint?: string | null }): boolean {
+  return ["pending", "unmatched", "error"].includes(c.status)
+    || (c.status === "no_order" && !!c.member_no_hint);
+}
+
+export type CommentStat = { total: number; ordered: number; duplicate: number; todo: number };
+
+export function commentStats(rows: { status: string; member_no_hint?: string | null }[]): CommentStat {
+  const st: CommentStat = { total: 0, ordered: 0, duplicate: 0, todo: 0 };
+  for (const c of rows) {
+    st.total++;
+    if (c.status === "ordered") st.ordered++;
+    else if (c.status === "duplicate") st.duplicate++;
+    else if (isTodoComment(c)) st.todo++;
+  }
+  return st;
+}
+
+/** 台北時間的短格式（月/日 時:分）；記事本相關畫面都用這個 */
+export function fmtNoteTime(iso: string | null | undefined): string {
+  return iso
+    ? new Date(iso).toLocaleString("zh-TW", { hour12: false, month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" })
+    : "—";
+}

--- a/supabase/functions/_shared/lineNoteParse.ts
+++ b/supabase/functions/_shared/lineNoteParse.ts
@@ -121,6 +121,7 @@ export function parseNoteComment(text, authorName = "") {
 // "N6090802#" / "#B2967" 這種代碼；記事本內文又常只寫商品名。依序試：
 // 團號 → 團名 → 團名裡的代碼 → 該團品項的商品名（團只有 ≤3 項時才用，免得誤中）。
 // 多個團都命中取「命中字串最長」的；一樣長就不猜（回 null，留給人工）。
+// ⚠ 以上都是「猜」，只用在沒蓋團號章的貼文（小幫手手貼的）。蓋了章的走精準比對。
 export function normalizeForMatch(s) {
   return String(s ?? "").normalize("NFKC").toLowerCase().replace(/\s+/g, "");
 }
@@ -128,6 +129,14 @@ export function normalizeForMatch(s) {
 export function matchCampaign(text, campaigns) {
   const t = normalizeForMatch(text);
   if (!t) return null;
+  // 蓋過團號章的貼文只認那個章，**不退回模糊比對**：章在但那一團不在候選清單裡
+  // （已結算 / 已取消 / 超出 limit）就回 null 讓它留成 unlinked，退回去猜的話
+  // 很可能中到另一個「團名剛好是子字串」的團，那就是認錯團。
+  const tagged = extractPostTag(text);
+  if (tagged) {
+    const want = normalizeForMatch(tagged);
+    return (campaigns ?? []).find((c) => normalizeForMatch(c.campaign_no) === want) ?? null;
+  }
   let best = null;
   let tie = false;
   for (const c of campaigns ?? []) {
@@ -154,6 +163,41 @@ export function matchCampaign(text, campaigns) {
     }
   }
   return best && !tie ? best.c : null;
+}
+
+// ── 貼文編號（🔖 團號）─────────────────────────────────────────────────────
+// 系統發出去的每一篇貼文都在文末蓋一個「🔖 團號 GRP-…」的章，讓爬回來的時候
+// **一眼認得出是哪一團**，不用靠團名子字串去猜（matchCampaign 猜錯 = 把客人的
+// +1 加到別的團上，比漏認嚴重得多；20260910000000 那次松山「雲林小農🍀阿土伯」
+// 就是團名對不上而整篇認不出來）。
+//
+// 小幫手自己手貼的文沒有這個章，照樣走下面的模糊比對 —— 但只要是從後台
+// 「LINE 記事本」發的（含預覽複製去手貼的），比對就是精準的。
+export const POST_TAG_MARK = "\u{1F516}";                    // 🔖
+
+/** 貼文文末的團號章。campaign_no 空的話回空字串（不硬蓋一個假的章）。 */
+export function buildPostTag(campaignNo) {
+  const no = String(campaignNo ?? "").trim();
+  return no ? `${POST_TAG_MARK} 團號 ${no}` : "";
+}
+
+/**
+ * 從貼文內文把團號章挖出來；沒蓋章回 null。
+ * ⚠「團號」兩個字是必要的，不能只認 🔖 —— 手貼的文很可能自己就用了 🔖 當裝飾
+ * （「🔖 好物推薦」），只認符號會把它當成蓋了章，然後因為對不到團而回 null，
+ * 反而害本來模糊比對得出來的貼文變成 unlinked。
+ */
+export function extractPostTag(text) {
+  const m = String(text ?? "").match(/\u{1F516}\s*團號\s*([A-Za-z0-9][A-Za-z0-9-]{2,})/u);
+  return m ? m[1] : null;
+}
+
+/** 沒蓋章就補一個蓋在最後（自訂模板沒寫 {{tag}} 也一樣有章）。 */
+export function withPostTag(text, campaignNo) {
+  const tag = buildPostTag(campaignNo);
+  if (!tag || extractPostTag(text)) return String(text ?? "");
+  const body = String(text ?? "").trimEnd();
+  return body ? `${body}\n${tag}` : tag;
 }
 
 /** 貼文標題：取第一個非空白行，最多 60 字 */

--- a/supabase/functions/line-note-worker/index.ts
+++ b/supabase/functions/line-note-worker/index.ts
@@ -27,7 +27,7 @@ import { corsHeaders } from "../_shared/cors.ts";
 import {
   clientFromToken, createNotePost, likeComment, listComments, listHomes, listPosts, loginByQr, whoami,
 } from "../_shared/lineNote.ts";
-import { matchCampaign, parseNoteComment, postTitle } from "../_shared/lineNoteParse.ts";
+import { buildPostTag, matchCampaign, parseNoteComment, postTitle, withPostTag } from "../_shared/lineNoteParse.ts";
 
 const SUPABASE_URL = requireEnv("SUPABASE_URL");
 const SERVICE_KEY = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
@@ -163,6 +163,8 @@ async function syncCommunities(accountId: number, homes: any[]) {
 // 從記事本匯進來的團，description 常常就是整篇貼文（標題＋(A)(B)品項＋⏰結單都在裡面），
 // 照樣接上去會變成品項印兩次、結單寫兩行。
 // {{name}} / {{end_at}} 維持原樣（照印），自訂模板的行為不變。
+// {{tag}} 是團號章（🔖 團號 GRP-…）：爬回來的時候靠它精準認出是哪一團，不用猜團名。
+// 自訂模板沒寫 {{tag}} 也會被 withPostTag 補在文末 —— 章一定要有，不然這篇就只能靠猜。
 const DEFAULT_TEMPLATE = `{{title}}
 
 {{description}}
@@ -171,7 +173,8 @@ const DEFAULT_TEMPLATE = `{{title}}
 
 {{deadline}}
 📝 留言「會員編號 6 碼 ＋ 品項代碼＋數量」，例：123456 A+1 B+2
-#開團`;
+#開團
+{{tag}}`;
 
 // 比對標題用：去掉表情符號、空白、標點，只留文字
 function bareText(s: string) {
@@ -222,7 +225,8 @@ export function renderTemplate(template: string | null, payload: any) {
     && (bareName.includes(firstLine) || firstLine.includes(bareName));
   const deadline = c.end_at ? `⏰ ${fmtTaipei(c.end_at)} 結單` : "";
 
-  return (template || DEFAULT_TEMPLATE)
+  const rendered = (template || DEFAULT_TEMPLATE)
+    .replaceAll("{{tag}}", buildPostTag(c.campaign_no))
     .replaceAll("{{title}}", descHasTitle ? "" : (c.name ?? ""))
     .replaceAll("{{items}}", descHasItems ? "" : items)
     .replaceAll("{{deadline}}", descHasDeadline ? "" : deadline)
@@ -234,6 +238,7 @@ export function renderTemplate(template: string | null, payload: any) {
     .replaceAll("{{pickup_deadline}}", fmtTaipei(c.pickup_deadline))
     .replace(/\n{3,}/g, "\n\n")
     .trim();
+  return withPostTag(rendered, c.campaign_no);
 }
 
 function resolveImageUrl(p: unknown): string | null {

--- a/supabase/migrations/20260910020000_line_note_campaign_publish.sql
+++ b/supabase/migrations/20260910020000_line_note_campaign_publish.sql
@@ -1,0 +1,229 @@
+-- ============================================================================
+-- 20260910020000_line_note_campaign_publish.sql
+--
+-- 記事本的貼文整合進「開團」：開團列表每一團自己有一顆 LINE 記事本按鈕，
+-- 在那邊勾要發到哪幾個群組、一次發出去，同一個彈窗也看得到這團爬回來的
+-- 貼文與留言。原本要先跑到「LINE 記事本 → 社群設定 → 逐個社群按發文」，
+-- 一團發三個群組就要開三次彈窗、還得自己記得哪個發過了。
+--
+-- 兩支新函式（沒有覆蓋既有 function）：
+--
+--  1. rpc_line_note_campaign_targets(campaign)
+--     這團「可以發到哪些群組 + 已經發成什麼樣」。母體 = 開團自動發文那支
+--     trigger（_line_note_on_campaign_open @ 20260909020000）認得的範圍
+--     ∪ 已經有貼文的群組（範圍後來改了也要看得到歷史）。
+--     ⚠ can_post 這一欄的判定要跟 rpc_line_note_queue_posts 一模一樣 ——
+--       彈窗的預設勾選（預設全選＝全部 can_post）、按鈕能不能按都吃它，
+--       兩邊各算一套就會出現「畫面說可以發、按下去說不行」，或反過來
+--       「畫面說不能發，其實那是一篇發失敗的貼文、本來就該能重發」。
+--
+--  2. rpc_line_note_queue_posts(campaign, community_ids[])
+--     一次排好幾個群組的發文工作，**逐群組回結果**，不用例外中斷整批。
+--     既有的 rpc_line_note_queue_post（單一社群、已發過就 RAISE）原封不動 ——
+--     「LINE 記事本 → 社群設定 → 發文」還在用它，它靠那個例外顯示錯誤。
+--
+-- 「已經發過」的判準是 status='posted' **或 line_post_id IS NOT NULL**：
+-- 光看 status 會漏掉「發成功了但後來被推成 closed」的貼文，重排一次
+-- 就是在 LINE 上多貼一篇、而 line_post_id 被覆蓋掉 → 舊那篇沒人管得到
+-- （留言也再也讀不回來）。記事本貼文只能刪掉重發，客人已經看到了。
+--
+-- rollback：
+--   DROP FUNCTION public.rpc_line_note_campaign_targets(BIGINT);
+--   DROP FUNCTION public.rpc_line_note_queue_posts(BIGINT, BIGINT[]);
+--   DROP FUNCTION public._line_note_comment_is_todo(TEXT, TEXT);
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 0. 「這則留言還要人看」的判定，收成一支
+--    前端同一套在 apps/admin/src/lib/lineNoteStatus.ts（isTodoComment），
+--    改一邊記得改另一邊 —— 貼文頁的待處理徽章與這裡的統計要對得上。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._line_note_comment_is_todo(
+  p_status TEXT, p_member_no_hint TEXT
+) RETURNS BOOLEAN
+LANGUAGE sql IMMUTABLE
+AS $$
+  SELECT p_status IN ('pending','unmatched','error')
+      OR (p_status = 'no_order' AND COALESCE(p_member_no_hint, '') <> '');
+$$;
+
+-- ----------------------------------------------------------------------------
+-- 1. 這團可以發到哪些群組 / 已經發成什麼樣
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_campaign_targets(p_campaign_id BIGINT)
+RETURNS TABLE (
+  community_id       BIGINT,
+  home_id            TEXT,
+  home_name          TEXT,
+  home_kind          TEXT,
+  store_id           BIGINT,
+  store_name         TEXT,
+  account_id         BIGINT,
+  account_label      TEXT,
+  account_status     TEXT,
+  auto_post_on_open  BOOLEAN,
+  listen_enabled     BOOLEAN,
+  in_scope           BOOLEAN,
+  can_post           BOOLEAN,
+  blocked_reason     TEXT,
+  post_id            BIGINT,
+  post_status        TEXT,
+  line_post_id       TEXT,
+  post_text          TEXT,
+  posted_at          TIMESTAMPTZ,
+  last_read_at       TIMESTAMPTZ,
+  closed_reason      TEXT,
+  post_error         TEXT,
+  comment_total      INT,
+  comment_ordered    INT,
+  comment_duplicate  INT,
+  comment_todo       INT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+  v_owner  BIGINT;
+  v_cstat  TEXT;
+BEGIN
+  SELECT g.owner_store_id, g.status INTO v_owner, v_cstat
+    FROM group_buy_campaigns g WHERE g.id = p_campaign_id AND g.tenant_id = v_tenant;
+  IF v_cstat IS NULL THEN RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id; END IF;
+
+  RETURN QUERY
+  WITH c AS (
+    SELECT lc.*,
+           a.label  AS a_label,
+           a.status AS a_status,
+           -- 開團自動發文的範圍：總部的團發到所有社群，店家自開的團只發到那家店的
+           -- （跟 _line_note_on_campaign_open 同一條件，改一邊記得改另一邊）
+           (v_owner IS NULL OR lc.store_id = v_owner) AS scoped
+      FROM line_note_communities lc
+      JOIN line_note_accounts a ON a.id = lc.account_id
+     WHERE lc.tenant_id = v_tenant
+  ), p AS (
+    SELECT lp.*,
+           COALESCE(s.total, 0)     AS n_total,
+           COALESCE(s.ordered, 0)   AS n_ordered,
+           COALESCE(s.duplicate, 0) AS n_duplicate,
+           COALESCE(s.todo, 0)      AS n_todo
+      FROM line_note_posts lp
+      LEFT JOIN LATERAL (
+        SELECT count(*)::INT AS total,
+               count(*) FILTER (WHERE cm.status = 'ordered')::INT   AS ordered,
+               count(*) FILTER (WHERE cm.status = 'duplicate')::INT AS duplicate,
+               count(*) FILTER (WHERE public._line_note_comment_is_todo(cm.status, cm.member_no_hint))::INT AS todo
+          FROM line_note_comments cm WHERE cm.post_id = lp.id
+      ) s ON TRUE
+     WHERE lp.tenant_id = v_tenant AND lp.campaign_id = p_campaign_id
+  )
+  SELECT c.id, c.home_id, c.home_name, c.home_kind,
+         c.store_id, st.name,
+         c.account_id, c.a_label, c.a_status,
+         c.auto_post_on_open, c.listen_enabled,
+         c.scoped,
+         -- can_post / blocked_reason 要跟 rpc_line_note_queue_posts 擋的東西**一模一樣**。
+         -- 注意「已經發過」的判準是 posted 或 line_post_id 有值，不是「有這一列」——
+         -- status='failed'（發文失敗、LINE 上根本沒東西）必須還能再發一次，
+         -- 不然一次失敗就只能跑去記事本頁繞，而那頁也只有「已發過就 RAISE」那條路。
+         (c.scoped AND c.a_status = 'active'
+            AND v_cstat IN ('open','closed')
+            AND NOT (p.id IS NOT NULL AND (p.status = 'posted' OR p.line_post_id IS NOT NULL))) AS can_post,
+         CASE WHEN p.id IS NOT NULL AND (p.status = 'posted' OR p.line_post_id IS NOT NULL)
+                                                    THEN '已經發過了'
+              WHEN NOT c.scoped                     THEN '這個社群只收該店自開的團'
+              WHEN c.a_status <> 'active'            THEN 'LINE 帳號沒有登入'
+              WHEN v_cstat NOT IN ('open','closed')  THEN '這團不是開團中／已收單'
+         END,
+         p.id, p.status, p.line_post_id, p.text,
+         p.posted_at, p.last_read_at, p.closed_reason, p.last_error,
+         p.n_total, p.n_ordered, p.n_duplicate, p.n_todo
+    FROM c
+    LEFT JOIN p ON p.community_id = c.id
+    LEFT JOIN stores st ON st.id = c.store_id
+   -- 範圍外但已經發過的也要列出來（範圍是後來才改的，歷史不能憑空消失）
+   WHERE c.scoped OR p.id IS NOT NULL
+   ORDER BY (p.id IS NOT NULL) DESC, c.home_name NULLS LAST, c.id;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_campaign_targets(BIGINT) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 2. 一次發到好幾個群組
+--    out_status：queued（已排隊）/ already_posted（跳過）/ error（這個群組不行）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_queue_posts(
+  p_campaign_id   BIGINT,
+  p_community_ids BIGINT[]
+) RETURNS TABLE (out_community_id BIGINT, out_post_id BIGINT, out_status TEXT, out_error TEXT)
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._line_note_require_admin();
+  v_owner  BIGINT;
+  v_cstat  TEXT;
+  v_cid    BIGINT;
+  v_c      RECORD;
+  v_exist  RECORD;
+  v_post   BIGINT;
+BEGIN
+  SELECT g.owner_store_id, g.status INTO v_owner, v_cstat
+    FROM group_buy_campaigns g WHERE g.id = p_campaign_id AND g.tenant_id = v_tenant;
+  IF v_cstat IS NULL THEN RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id; END IF;
+  IF v_cstat NOT IN ('open','closed') THEN
+    RAISE EXCEPTION '只有開團中／已收單的團可以發到記事本（這團是 %）', v_cstat;
+  END IF;
+
+  FOR v_cid IN
+    SELECT DISTINCT x FROM unnest(COALESCE(p_community_ids, ARRAY[]::BIGINT[])) AS x
+  LOOP
+    SELECT lc.id, lc.account_id, lc.store_id, a.status AS a_status
+      INTO v_c
+      FROM line_note_communities lc
+      JOIN line_note_accounts a ON a.id = lc.account_id
+     WHERE lc.id = v_cid AND lc.tenant_id = v_tenant;
+    IF v_c.id IS NULL THEN
+      RETURN QUERY SELECT v_cid, NULL::BIGINT, 'error'::TEXT, '找不到這個社群'::TEXT;
+      CONTINUE;
+    END IF;
+    IF v_owner IS NOT NULL AND v_c.store_id IS DISTINCT FROM v_owner THEN
+      RETURN QUERY SELECT v_cid, NULL::BIGINT, 'error'::TEXT, '這個社群只收該店自開的團'::TEXT;
+      CONTINUE;
+    END IF;
+    IF v_c.a_status <> 'active' THEN
+      RETURN QUERY SELECT v_cid, NULL::BIGINT, 'error'::TEXT, 'LINE 帳號沒有登入'::TEXT;
+      CONTINUE;
+    END IF;
+
+    SELECT lp.id, lp.status, lp.line_post_id INTO v_exist
+      FROM line_note_posts lp
+     WHERE lp.community_id = v_cid AND lp.campaign_id = p_campaign_id;
+    -- 已經貼在 LINE 上了就跳過：重排會多貼一篇，而 line_post_id 被覆蓋 → 舊那篇的留言再也讀不回來
+    IF v_exist.id IS NOT NULL AND (v_exist.status = 'posted' OR v_exist.line_post_id IS NOT NULL) THEN
+      RETURN QUERY SELECT v_cid, v_exist.id, 'already_posted'::TEXT, NULL::TEXT;
+      CONTINUE;
+    END IF;
+
+    INSERT INTO line_note_posts (tenant_id, community_id, campaign_id, status, created_by, updated_by)
+    VALUES (v_tenant, v_cid, p_campaign_id, 'queued', auth.uid(), auth.uid())
+    ON CONFLICT (community_id, campaign_id) DO UPDATE
+       SET status = 'queued', last_error = NULL, updated_by = auth.uid()
+    RETURNING id INTO v_post;
+
+    -- 手滑點兩下不要排兩次（worker 那邊 jobPost 也會擋已發，但沒必要留一堆廢工作）
+    IF NOT EXISTS (
+      SELECT 1 FROM line_note_jobs j
+       WHERE j.kind = 'post' AND j.post_id = v_post AND j.status IN ('queued','running')
+    ) THEN
+      INSERT INTO line_note_jobs (tenant_id, kind, account_id, community_id, post_id, created_by)
+      VALUES (v_tenant, 'post', v_c.account_id, v_cid, v_post, auth.uid());
+    END IF;
+    RETURN QUERY SELECT v_cid, v_post, 'queued'::TEXT, NULL::TEXT;
+  END LOOP;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_queue_posts(BIGINT, BIGINT[]) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_line_note_queue_posts(BIGINT, BIGINT[]) IS
+  '一次把一個團發到多個記事本社群，逐社群回結果（queued/already_posted/error）。'
+  '單一社群版是 rpc_line_note_queue_post（已發過會 RAISE）。';

--- a/tools/line-note-scraper/src/parse.mjs
+++ b/tools/line-note-scraper/src/parse.mjs
@@ -116,6 +116,7 @@ export function parseNoteComment(text, authorName = "") {
 // "N6090802#" / "#B2967" 這種代碼；記事本內文又常只寫商品名。依序試：
 // 團號 → 團名 → 團名裡的代碼 → 該團品項的商品名（團只有 ≤3 項時才用，免得誤中）。
 // 多個團都命中取「命中字串最長」的；一樣長就不猜（回 null，留給人工）。
+// ⚠ 以上都是「猜」，只用在沒蓋團號章的貼文（小幫手手貼的）。蓋了章的走精準比對。
 export function normalizeForMatch(s) {
   return String(s ?? "").normalize("NFKC").toLowerCase().replace(/\s+/g, "");
 }
@@ -123,6 +124,14 @@ export function normalizeForMatch(s) {
 export function matchCampaign(text, campaigns) {
   const t = normalizeForMatch(text);
   if (!t) return null;
+  // 蓋過團號章的貼文只認那個章，**不退回模糊比對**：章在但那一團不在候選清單裡
+  // （已結算 / 已取消 / 超出 limit）就回 null 讓它留成 unlinked，退回去猜的話
+  // 很可能中到另一個「團名剛好是子字串」的團，那就是認錯團。
+  const tagged = extractPostTag(text);
+  if (tagged) {
+    const want = normalizeForMatch(tagged);
+    return (campaigns ?? []).find((c) => normalizeForMatch(c.campaign_no) === want) ?? null;
+  }
   let best = null;
   let tie = false;
   for (const c of campaigns ?? []) {
@@ -149,6 +158,41 @@ export function matchCampaign(text, campaigns) {
     }
   }
   return best && !tie ? best.c : null;
+}
+
+// ── 貼文編號（🔖 團號）─────────────────────────────────────────────────────
+// 系統發出去的每一篇貼文都在文末蓋一個「🔖 團號 GRP-…」的章，讓爬回來的時候
+// **一眼認得出是哪一團**，不用靠團名子字串去猜（matchCampaign 猜錯 = 把客人的
+// +1 加到別的團上，比漏認嚴重得多；20260910000000 那次松山「雲林小農🍀阿土伯」
+// 就是團名對不上而整篇認不出來）。
+//
+// 小幫手自己手貼的文沒有這個章，照樣走下面的模糊比對 —— 但只要是從後台
+// 「LINE 記事本」發的（含預覽複製去手貼的），比對就是精準的。
+export const POST_TAG_MARK = "\u{1F516}";                    // 🔖
+
+/** 貼文文末的團號章。campaign_no 空的話回空字串（不硬蓋一個假的章）。 */
+export function buildPostTag(campaignNo) {
+  const no = String(campaignNo ?? "").trim();
+  return no ? `${POST_TAG_MARK} 團號 ${no}` : "";
+}
+
+/**
+ * 從貼文內文把團號章挖出來；沒蓋章回 null。
+ * ⚠「團號」兩個字是必要的，不能只認 🔖 —— 手貼的文很可能自己就用了 🔖 當裝飾
+ * （「🔖 好物推薦」），只認符號會把它當成蓋了章，然後因為對不到團而回 null，
+ * 反而害本來模糊比對得出來的貼文變成 unlinked。
+ */
+export function extractPostTag(text) {
+  const m = String(text ?? "").match(/\u{1F516}\s*團號\s*([A-Za-z0-9][A-Za-z0-9-]{2,})/u);
+  return m ? m[1] : null;
+}
+
+/** 沒蓋章就補一個蓋在最後（自訂模板沒寫 {{tag}} 也一樣有章）。 */
+export function withPostTag(text, campaignNo) {
+  const tag = buildPostTag(campaignNo);
+  if (!tag || extractPostTag(text)) return String(text ?? "");
+  const body = String(text ?? "").trimEnd();
+  return body ? `${body}\n${tag}` : tag;
 }
 
 /** 貼文標題：取第一個非空白行，最多 60 字 */

--- a/tools/line-note-scraper/src/parse.test.mjs
+++ b/tools/line-note-scraper/src/parse.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseOrderLines, postTitle, normalize, extractMemberNo, parseNoteComment, matchCampaign, normalizeForMatch } from "./parse.mjs";
+import { parseOrderLines, postTitle, normalize, extractMemberNo, parseNoteComment, matchCampaign, normalizeForMatch,
+  buildPostTag, extractPostTag, withPostTag } from "./parse.mjs";
 
 test("extractMemberNo", () => {
   assert.deepEqual(extractMemberNo("123456 A+1"), { hint: "123456", rest: "A+1" });
@@ -161,4 +162,29 @@ test("matchCampaign 取最長命中、平手不猜", () => {
   assert.equal(matchCampaign("丹波黑豆 300克/包", cs)?.id, 11);        // 比 id:10 長
   assert.equal(matchCampaign("黑豆", cs), null);                        // 2 字太短，刻意不比（會誤中）
   assert.equal(matchCampaign("丹波黑豆 300克 丹波黑豆 500克", cs), null); // 兩個一樣長 → 不猜
+});
+
+// ── 團號章（系統發文蓋的 🔖）────────────────────────────────────────────────
+test("buildPostTag / extractPostTag / withPostTag", () => {
+  assert.equal(buildPostTag("GRP-20260906-022"), "🔖 團號 GRP-20260906-022");
+  assert.equal(buildPostTag(null), "");                                  // 沒團號不硬蓋假的章
+  assert.equal(extractPostTag("…\n#開團\n🔖 團號 GRP-20260906-022"), "GRP-20260906-022");
+  assert.equal(extractPostTag("🔖團號GRP-20260906-022"), "GRP-20260906-022");   // 沒空白也認
+  assert.equal(extractPostTag("🔖 好物推薦 GRP-20260906-022"), null);           // 只有符號不算章
+  assert.equal(extractPostTag("丹波黑豆 300克"), null);
+  // 沒章就補一個；已經有章（自訂模板寫了 {{tag}}）不重複蓋
+  assert.equal(withPostTag("內文", "GRP-1234-001"), "內文\n🔖 團號 GRP-1234-001");
+  assert.equal(withPostTag("內文\n🔖 團號 GRP-1234-001", "GRP-1234-001"), "內文\n🔖 團號 GRP-1234-001");
+  assert.equal(withPostTag("內文", null), "內文");
+});
+
+test("matchCampaign：蓋了章就精準比對，不再猜", () => {
+  // 章指到 3，內文同時提到 1 的團名代碼 → 還是 3（章優先）
+  assert.equal(hit("N6090802# 抽繩系帶不規則屁簾長裙\n🔖 團號 GRP-20260906-022"), 3);
+  // 章在但那一團不在候選清單（已結算 / 已取消）→ 不退回模糊比對，回 null 留成 unlinked
+  assert.equal(hit("丹波黑豆 300克/包\n🔖 團號 GRP-19990101-999"), null);
+  // 兩個一樣長本來不猜；蓋了章就有答案
+  const cs = [{ id: 11, campaign_no: "GRP-2026-011", name: "丹波黑豆 300克" }, { id: 12, campaign_no: "GRP-2026-012", name: "丹波黑豆 500克" }];
+  assert.equal(matchCampaign("丹波黑豆 300克 丹波黑豆 500克", cs), null);
+  assert.equal(matchCampaign("丹波黑豆 300克 丹波黑豆 500克\n🔖 團號 GRP-2026-012", cs)?.id, 12);
 });


### PR DESCRIPTION
## 做了什麼

開團列表每一團多一顆綠色的「**LINE 記事本**」（擺在「發 FB」旁邊），點開是一個放大的彈窗：

- **勾要發到哪幾個群組**，預設把「發得出去的」全部勾好。已經發過的畫「已發」並鎖住不給勾、旁邊寫原因；帳號沒登入、店家團沒有對應社群也一樣寫清楚，不會只是安靜地少一列。
- **看得到等一下真的會貼出去的字**（連圖幾張都列出來）—— 渲染的是 worker 那一份 `renderTemplate`，不是另外寫的預覽，所以看到的就是會貼的。模板掛在社群上，換群組會重新產生預覽。
- **一次發出去**，逐群組回結果（已排隊／已發過跳過／不能發＋原因），一個群組失敗不影響其他群組。
- 下半部就是**這團爬回來的貼文與留言**：每篇貼文的後台 `#id`、LINE 那邊的貼文 id、發文與讀取時間、已加單／已有訂單／待處理的統計，點開看每一則留言與它加出來的訂單（點單號開訂單明細）。也可以直接「立即讀留言」。

**貼文文末蓋一個「🔖 團號 GRP-…」的章。** 爬回來就精準認出是哪一團，不用再靠團名子字串去猜 —— 猜錯等於把客人的 +1 加到別的團上，比漏認嚴重得多。自訂模板沒寫 `{{tag}}` 也會被補上。

`/line-notes` 的「貼文」分頁**留著**：未認出團的貼文沒有團可掛，只能在那邊指定是哪一團。那頁改成共用同一份狀態文字與統計，並補上同樣的兩個 id。

編輯開團彈窗也一起放大到 `max-w-6xl`（品項表＋表單＋訂單清單三段擠在 4xl 裡本來就很難看）。

### 幾個刻意的決定

- **蓋了章就不退回模糊比對。** 章在但那一團不在候選清單（已結算／已取消）時回 `null`，寧可留成「未認出團」讓人指定，也不要退回去猜、然後中到另一個「團名剛好是子字串」的團。
- **「團號」兩個字是必要的**，不能只認 🔖。手貼的文很可能自己就用 🔖 當裝飾（「🔖 好物推薦」），只認符號會把它當成蓋了章，反而害本來猜得出來的貼文變成未認出團。
- **「已經發過」看的是 `status='posted'` 或 `line_post_id` 有值，不是「有這一列」。** 發文失敗（LINE 上根本沒東西）必須還能再發一次；而 `status='closed'` 卻有 `line_post_id` 的貼文不能重發 —— 重發會在 LINE 上多一篇，舊那篇的 id 被覆蓋掉之後留言就再也讀不回來。
- 彈窗的預設勾選、按鈕能不能按，和 RPC 真正擋的東西**共用同一支 RPC 的 `can_post`**，不在前端另算一套。

## 上線危險

- **做了**：
  - 兩支**新** RPC（`rpc_line_note_campaign_targets`、`rpc_line_note_queue_posts`）＋一支小 helper（`_line_note_comment_is_todo`），沒有覆蓋任何既有 function。既有的 `rpc_line_note_queue_post`（單一社群、已發過就 RAISE）原封不動，記事本頁還在用它。
  - `line-note-worker` 的 `renderTemplate` 多蓋一個團號章、`matchCampaign` 多一條「有章就精準比對」的前置路。
  - migration 已套上正式庫，Edge Function 已重新部署（v16, ACTIVE）。
- **不做**：
  - 沒有放寬既有的模糊比對規則（認錯團比漏認嚴重）。
  - 沒有動任何既有貼文／留言／訂單資料，也沒有從這個 PR 發出任何一篇貼文。
  - 沒有把 `/line-notes` 的「貼文」分頁拿掉 —— 未認出團的貼文只有那邊能指定。
  - 沒有改「開團自動發文」那支 trigger 的行為。
- **回退**：
  - SQL：`DROP FUNCTION public.rpc_line_note_campaign_targets(BIGINT);` `DROP FUNCTION public.rpc_line_note_queue_posts(BIGINT, BIGINT[]);` `DROP FUNCTION public._line_note_comment_is_todo(TEXT, TEXT);`（migration 檔頭也寫了）
  - 前端：revert 這支 commit。
  - 團號章：把 worker 的 `withPostTag` 那一行拿掉再重新部署即可；已經蓋過章的舊貼文照樣認得出來（`matchCampaign` 對沒章的走原本那條路）。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

新 RPC 的權限沿用既有的 `_line_note_require_admin()`（owner/admin/hq_manager/assistant/''），`GRANT EXECUTE … TO authenticated`，跟同批其他記事本 RPC 一致；沒有新增密鑰、環境變數或 CI 設定。

## 驗證

- `tools/line-note-scraper` 單元測試 **18 支全過**（新增團號章相關 2 支：`buildPostTag`/`extractPostTag`/`withPostTag`，以及「蓋了章就精準比對、章對不到就不猜」）。
- **線上既有 207 篇貼文逐篇新舊對拍：一致 207、不一致 0。** 既有內文一個 🔖 都沒有（`line_note_posts` 0 篇、`line_note_comments` 0 則），所以新那條路對舊資料是完全休眠的。
- 真實團 `GRP-20260906-022` 用 worker 那份 `renderTemplate` 渲染 → 章蓋對、拿章去 `matchCampaign` 回同一團；把 `{{tag}}` 拔掉的自訂模板也一樣有章。既有的「文案自己寫過結單就不重複印」等聰明佔位符行為沒受影響。
- `rpc_line_note_queue_posts` 三條路都試過：`queued`（發文失敗的可以重發）／`already_posted`（`status='closed'` 但有 `line_post_id` 的擋住）／`error`（社群不存在）；非開團中／已收單的團被擋下並回看得懂的訊息；`store_staff` 回 `insufficient_role`。以上測試都包在交易裡 `ROLLBACK`，事後確認 207 篇貼文與 0 筆 queued job 都沒變。
- `rpc_line_note_campaign_targets` 與 `rpc_line_note_queue_posts` 對同一情境的 `can_post` 判定實測一致（含「發文失敗可重發」那組）。
- `apps/admin` `npm run build` 綠（含 Safari 15.6 bundle 檢查：115 支 chunk 全過）、`tsc --noEmit` 乾淨。
- Edge Function 部署後驗過：`OPTIONS` 回 200 帶 CORS、無 auth 的 `POST` 回函式自家的 401（不是 gateway 404）。

## 還沒做

- 沒有在真實社群發過任何一篇貼文（那會被客人看到），所以「章真的出現在 LINE 記事本上」只驗到渲染與比對這一段。第一次實際發文請挑一個團看一下版型。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017j2CoHUU1bH2HFuUvzdutM

---
_Generated by [Claude Code](https://claude.ai/code/session_017j2CoHUU1bH2HFuUvzdutM)_