### PR TITLE
feat(line-notes): 發出去的貼文可以從後台刪掉 LINE 上那篇

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -15,6 +15,7 @@ import { OrderDetail } from "@/components/OrderDetail";
 import {
   COMMENT_STATUS_LABEL, HOME_KIND_LABEL, POST_STATUS_LABEL, commentStats, fmtNoteTime, isTodoComment,
 } from "@/lib/lineNoteStatus";
+import { deleteLineNotePost } from "@/lib/lineNoteDelete";
 
 type Account = {
   id: number; label: string; status: "logged_out" | "pending_qr" | "active" | "error";
@@ -999,15 +1000,19 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
     setTimeout(() => { void loadCounts(); }, 6000);   // worker 跑完大概這個時間，順手把統計刷新
   };
 
+  // 預設連 LINE 上那篇一起刪（貼錯團 / 貼錯價格時才救得回來）；
+  // 刪不掉會問要不要只清後台紀錄。流程在 @/lib/lineNoteDelete，跟開團彈窗共用。
   const removePost = async (p: Post) => {
-    const name = p.group_buy_campaigns?.name ?? `#${p.id}`;
-    if (!window.confirm(`刪除「${name}」這篇貼文的紀錄？\n\n只清掉記事本這邊的貼文與留言紀錄，已經加出來的訂單不會動（要退單請到訂單那邊）。`)) return;
     setBusy(p.id);
-    const { error } = await getSupabase().rpc("rpc_line_note_post_delete", { p_id: p.id });
+    const r = await deleteLineNotePost({
+      id: p.id, line_post_id: p.line_post_id,
+      label: p.group_buy_campaigns?.name ?? postFirstLine(p.text),
+    });
     setBusy(null);
-    if (error) return fail(error);
+    if (r.kind === "cancelled") return;
+    if (r.kind === "failed") return fail(new Error(r.error));
     if (open === p.id) setOpen(null);
-    notify("已刪除");
+    notify(r.kind === "deleted" ? "已從 LINE 記事本刪除，紀錄也清掉了" : "已清掉後台紀錄（LINE 上那篇還在）");
     await reload();
   };
 
@@ -1108,7 +1113,10 @@ function PostsTab({ posts, communityById, reload, notify, fail }: {
                     <SpinButton type="button" className={btn} loading={busy === p.id} onClick={() => void reopenPost(p)}>恢復讀取</SpinButton>
                   )}
                   <SpinButton type="button" className={`${btn} ml-auto text-red-600`} loading={busy === p.id}
-                    onClick={() => void removePost(p)}>刪除</SpinButton>
+                    onClick={() => void removePost(p)}
+                    title={p.line_post_id ? "連 LINE 記事本上那篇一起刪掉" : "只清後台紀錄（這篇沒發到 LINE）"}>
+                    {p.line_post_id ? "刪除貼文" : "刪除紀錄"}
+                  </SpinButton>
                 </div>
 
                 {expanded && (

--- a/apps/admin/src/components/LineNotePostsModal.tsx
+++ b/apps/admin/src/components/LineNotePostsModal.tsx
@@ -18,6 +18,7 @@ import { OrderDetail } from "@/components/OrderDetail";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
 import { withBasePath } from "@/lib/basePath";
+import { deleteLineNotePost } from "@/lib/lineNoteDelete";
 import {
   COMMENT_STATUS_LABEL, HOME_KIND_LABEL, POST_STATUS_LABEL, commentStats, fmtNoteTime, isTodoComment,
   type LineNoteCommentStatus, type LineNotePostStatus,
@@ -206,6 +207,22 @@ export default function LineNotePostsModal({
     setComments((m) => { const n = new Map(m); n.delete(t.post_id!); return n; });
     notify("已開始讀留言，幾秒後重新整理就看得到");
     setTimeout(() => { void load(true); }, 8000);
+  };
+
+  const removePost = async (t: Target) => {
+    if (!t.post_id) return;
+    setBusy(t.community_id);
+    const r = await deleteLineNotePost({
+      id: t.post_id, line_post_id: t.line_post_id,
+      label: `${campaignName ?? ""}｜${t.home_name || t.home_id}`,
+    });
+    setBusy(null);
+    if (r.kind === "cancelled") return;
+    if (r.kind === "failed") return fail(new Error(r.error));
+    if (openPost === t.post_id) setOpenPost(null);
+    setComments((m) => { const n = new Map(m); n.delete(t.post_id!); return n; });
+    notify(r.kind === "deleted" ? "已從 LINE 記事本刪除，這個群組可以重新發一次" : "已清掉後台紀錄（LINE 上那篇還在）");
+    await load(true);   // can_post 會從「已經發過了」變回可以發
   };
 
   const title = `LINE 記事本｜${campaignNo ? `${campaignNo} ` : ""}${campaignName ?? ""}`;
@@ -405,6 +422,11 @@ export default function LineNotePostsModal({
                           <a className={`${btn} ml-auto`} href={withBasePath("/line-notes")} target="_blank" rel="noreferrer">
                             到記事本頁處理留言
                           </a>
+                          <SpinButton className={`${btn} text-red-600`} loading={busy === t.community_id}
+                            onClick={() => void removePost(t)}
+                            title={t.line_post_id ? "連 LINE 記事本上那篇一起刪掉，刪完可以重發" : "只清後台紀錄（這篇沒發到 LINE）"}>
+                            {t.line_post_id ? "刪除貼文" : "刪除紀錄"}
+                          </SpinButton>
                         </div>
 
                         {expanded && (

--- a/apps/admin/src/lib/lineNoteDelete.ts
+++ b/apps/admin/src/lib/lineNoteDelete.ts
@@ -1,0 +1,61 @@
+// 刪掉一篇記事本貼文。兩個入口共用：LINE 記事本頁的「貼文」分頁、開團的「LINE 記事本」彈窗。
+//
+// 「刪除」以前只清後台紀錄，貼文還躺在社群裡 —— 貼錯團、貼錯價格的時候等於沒救，
+// 只能拿備用帳號的手機自己進 LINE 刪。現在預設**連 LINE 上那篇一起刪掉**。
+//
+// 刪不掉的時候（帳號掉線最常見）不會硬清紀錄，而是問要不要只清後台的 ——
+// 靜靜清掉的話貼文會繼續收留言，而且下次讀取又會被 discoverPosts 當成新貼文認一次。
+
+import { getSupabase } from "@/lib/supabase";
+import { translateRpcError } from "@/lib/rpcError";
+
+export type LineNotePostRef = {
+  id: number;
+  line_post_id: string | null;
+  /** 顯示用的名字（團名 / 貼文第一行），只進確認視窗的文字 */
+  label: string;
+};
+
+export type DeleteOutcome =
+  | { kind: "cancelled" }
+  | { kind: "deleted" }            // LINE 上那篇也刪掉了，後台紀錄一併清除
+  | { kind: "record_only" }        // 只清了後台紀錄，LINE 上那篇還在（或本來就沒發出去）
+  | { kind: "failed"; error: string };
+
+const RECORD_ONLY_NOTE =
+  "只清掉後台的貼文與留言紀錄。已經加出來的訂單不會動（要退單請到訂單那邊）。";
+
+/** 只清後台紀錄，不碰 LINE */
+async function deleteRecord(postId: number): Promise<DeleteOutcome> {
+  const { error } = await getSupabase().rpc("rpc_line_note_post_delete", { p_id: postId });
+  return error ? { kind: "failed", error: translateRpcError(error) } : { kind: "record_only" };
+}
+
+export async function deleteLineNotePost(post: LineNotePostRef): Promise<DeleteOutcome> {
+  // 沒發到 LINE 過（排隊中 / 發文失敗 / 未認出團但抓不到 id）→ 沒東西可刪，就是清紀錄
+  if (!post.line_post_id) {
+    if (!window.confirm(`刪除「${post.label}」的貼文紀錄？\n\n${RECORD_ONLY_NOTE}`)) return { kind: "cancelled" };
+    return await deleteRecord(post.id);
+  }
+
+  if (!window.confirm(
+    `刪除「${post.label}」這篇貼文？\n\n` +
+    `會從 LINE 記事本把這篇**刪掉**，社群成員就看不到了，底下的留言也會跟著消失。\n` +
+    `後台的貼文與留言紀錄一併清除；已經加出來的訂單不會動（要退單請到訂單那邊）。\n\n` +
+    `刪掉之後這個團可以重新發一次。`)) return { kind: "cancelled" };
+
+  const { data, error } = await getSupabase().functions
+    .invoke("line-note-worker", { body: { action: "delete_post", post_id: post.id } });
+  const res = (data ?? {}) as { ok?: boolean; error?: string; noLinePost?: boolean };
+  if (!error && res.ok) return { kind: "deleted" };
+
+  // supabase-js 把非 2xx 包成 FunctionsHttpError，訊息看不出原因，優先用函式自己回的
+  const why = res.error ?? (error ? translateRpcError(error) : "未知錯誤");
+  if (!window.confirm(
+    `LINE 上那篇刪不掉：${why}\n\n` +
+    `（帳號掉線的話，到「LINE 記事本 → 帳號」重新登入再刪一次就好。）\n\n` +
+    `要改成只清後台紀錄嗎？\n貼文會**繼續留在社群裡**，之後讀取還可能把它重新認回來。`)) {
+    return { kind: "failed", error: why };
+  }
+  return await deleteRecord(post.id);
+}

--- a/supabase/functions/_shared/lineNote.ts
+++ b/supabase/functions/_shared/lineNote.ts
@@ -162,14 +162,16 @@ const routeCache = new Map();
  * `https://${client.request.endpoint}/…`，而 endpoint 預設是 legy.line-apps.com
  * （LEGY 加密閘道，不吃這種純 HTTPS JSON），直接丟 `fetch failed`。
  */
-export async function noteRequest(client, homeId, path, params, { method = "GET", body, verbose = false } = {}) {
+export async function noteRequest(client, homeId, path, params, { method = "GET", lhm, body, verbose = false } = {}) {
   const qs = new URLSearchParams(Object.fromEntries(Object.entries(params ?? {}).filter(([, v]) => v !== undefined && v !== null && v !== "")));
   const tryOne = async (host, prefix, channelId) => {
     const token = await channelToken(client, channelId, verbose);
     const url = `https://${host}${prefix}${path}?${qs}`;
     const res = await client.base.fetch(url, {
       method,
-      headers: { ...baseHeaders(client, token), "x-lhm": method },
+      // x-lhm 預設跟著 HTTP method，但不是每支都一樣 —— post/delete.json 是 POST 卻要送 GET
+      // （linejs 的 deletePost/getPost 都這樣，create 才是 POST）。要不一樣就用 lhm 指定。
+      headers: { ...baseHeaders(client, token), "x-lhm": lhm ?? method },
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
     });
     const text = await res.text();
@@ -352,6 +354,33 @@ export async function likeComment(client, homeId, commentId, { likeType = "1003"
     });
   if (!res || res.code !== 0) {
     throw new Error(`按表情失敗：code=${res?.code} ${res?.message ?? ""}`);
+  }
+  return res;
+}
+
+/**
+ * 刪掉記事本上的一篇貼文（社群成員就看不到了）。
+ * 端點與參數比照 linejs 的 timeline.deletePost：homeId / postId 走 query string、
+ * 沒有 body、而且 **x-lhm 要送 "GET"**（跟 create.json 不一樣）。
+ * 走跟讀貼文同一套 host/prefix/channel 探測，不用 linejs 那條寫死 legy 的路。
+ */
+export async function deleteNotePost(client, homeId, postId, { sourceType, verbose = false } = {}) {
+  if (!postId) throw new Error("沒有貼文 id，無法刪除");
+
+  // 先用唯讀的 list 把路由（host/prefix/channel）探出來並記住，delete 才不會拿**破壞性**的
+  // 請求去一組一組試。萬一某組真的刪掉了卻回非 0，探測會繼續往下試、最後回報失敗，
+  // 而貼文其實已經不見了 —— 那是最難查的一種狀況。（createNotePost 也是同樣的理由。）
+  try {
+    await noteGet(client, homeId, "/api/v57/post/list.json",
+      { homeId, sourceType: sourceType ?? "TALKROOM", likeLimit: "0", commentLimit: "0" }, verbose);
+  } catch (e) {
+    log(verbose, "探路用的 list 失敗（照樣試刪除）:", e?.message ?? e);
+  }
+
+  const res = await noteRequest(client, homeId, "/api/v57/post/delete.json",
+    { homeId, postId: String(postId) }, { method: "POST", lhm: "GET", verbose });
+  if (!res || res.code !== 0) {
+    throw new Error(`刪除貼文失敗：code=${res?.code} ${res?.message ?? ""}`);
   }
   return res;
 }

--- a/supabase/functions/line-note-worker/index.ts
+++ b/supabase/functions/line-note-worker/index.ts
@@ -25,7 +25,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.8";
 import QRCode from "npm:qrcode@1.5.4";
 import { corsHeaders } from "../_shared/cors.ts";
 import {
-  clientFromToken, createNotePost, likeComment, listComments, listHomes, listPosts, loginByQr, whoami,
+  clientFromToken, createNotePost, deleteNotePost, likeComment, listComments, listHomes, listPosts, loginByQr, whoami,
 } from "../_shared/lineNote.ts";
 import { buildPostTag, matchCampaign, parseNoteComment, postTitle, withPostTag } from "../_shared/lineNoteParse.ts";
 import { applyDeco, DECO_OPEN, decoPrice, stripDeco } from "../_shared/lineNoteDeco.ts";
@@ -312,6 +312,38 @@ async function jobPost(job: any) {
     await patch("line_note_posts", `id=eq.${job.post_id}`, { status: "failed", text: plain, last_error: String((e as any)?.message ?? e).slice(0, 1000) });
     throw e;
   }
+}
+
+// 刪掉 LINE 上那篇貼文，成功才連後台紀錄一起清掉。
+//
+// 順序不能反：先清紀錄再刪 LINE，萬一 LINE 那邊失敗（帳號掉線最常見），
+// 貼文還躺在社群裡收留言，後台卻已經看不到它 —— 那些留言之後會被 discoverPosts
+// 當成新貼文重新認一次，變成沒人管的孤兒。
+//
+// 反過來（LINE 刪掉了、清紀錄失敗）頂多留一列指向不存在貼文的紀錄，
+// 使用者再按一次「只清後台紀錄」就好，不會有人撲空。
+async function deletePost(postId: number, callerTenant: string | null) {
+  const rows = await rest(
+    `line_note_posts?id=eq.${postId}` +
+    `&select=id,tenant_id,line_post_id,line_note_communities(home_id,account_id)`);
+  const post = rows?.[0];
+  if (!post) return { ok: false, error: "找不到這篇貼文" };
+  // service_role 沒有 RLS，跨 tenant 的檢查只能自己來
+  if (callerTenant && post.tenant_id !== callerTenant) return { ok: false, error: "這篇貼文不屬於你的帳戶" };
+  if (!post.line_post_id) return { ok: false, error: "這篇沒有發到 LINE（沒有貼文 id），直接清紀錄就好", noLinePost: true };
+
+  try {
+    const account = await loadAccount(post.line_note_communities.account_id);
+    await deleteNotePost(await clientFor(account), post.line_note_communities.home_id, post.line_post_id, { verbose: VERBOSE });
+  } catch (e) {
+    const msg = String((e as any)?.message ?? e);
+    await patch("line_note_posts", `id=eq.${postId}`, { last_error: msg.slice(0, 1000) }).catch(() => {});
+    return { ok: false, error: msg };
+  }
+  await rest(`line_note_jobs?post_id=eq.${postId}&status=in.(queued,running)`, { method: "DELETE", prefer: "return=minimal" }).catch(() => {});
+  await rest(`line_note_posts?id=eq.${postId}`, { method: "DELETE", prefer: "return=minimal" });
+  log(`🗑 貼文 ${postId}（LINE ${post.line_post_id}）已從記事本刪除，後台紀錄一併清掉`);
+  return { ok: true, linePostId: post.line_post_id };
 }
 
 async function readPost(client: any, post: any) {
@@ -603,6 +635,7 @@ Deno.serve(async (req) => {
   // 認證：cron 用 secret header；後台用使用者 JWT（要是管理層級）
   const secret = req.headers.get("x-line-note-secret");
   let caller: "cron" | "admin" | null = null;
+  let callerTenant: string | null = null;
   if (CRON_SECRET && secret === CRON_SECRET) caller = "cron";
   else {
     const auth = req.headers.get("authorization") ?? "";
@@ -611,7 +644,12 @@ Deno.serve(async (req) => {
       const sb = createClient(SUPABASE_URL, SERVICE_KEY, { auth: { persistSession: false } });
       const { data: { user } } = await sb.auth.getUser(token);
       const role = String(user?.app_metadata?.role ?? "");
-      if (user && ["owner", "admin", "hq_manager", "assistant", ""].includes(role)) caller = "admin";
+      if (user && ["owner", "admin", "hq_manager", "assistant", ""].includes(role)) {
+        caller = "admin";
+        // 這支函式一律用 service_role 打 DB（RLS 擋不到），所以會動到資料的 action
+        // 要自己拿這個 tenant 去比對，不能只信前端傳來的 id
+        callerTenant = String(user.app_metadata?.tenant_id ?? "") || null;
+      }
     }
   }
   if (!caller) return json({ error: "unauthorized" }, 401);
@@ -636,6 +674,14 @@ Deno.serve(async (req) => {
         deco: applyDeco(rendered).sticonMetas.length,   // 有幾個字會用 LINE 數字表情貼出去
         images: postImageUrls(payload),
       });
+    }
+    // 刪掉已經貼出去的貼文：LINE 上那篇先刪掉，成功了才清後台紀錄。
+    // 走「後台直接呼叫」而不是排 job —— 這是破壞性動作，按下去要當場知道刪掉了沒。
+    if (action === "delete_post") {
+      if (caller !== "admin") return json({ error: "刪除貼文只能從後台按" }, 403);
+      const postId = Number(body.post_id);
+      if (!postId) return json({ error: "post_id required" }, 400);
+      return json(await deletePost(postId, callerTenant));
     }
     if (action === "tick" || action === "run") return json(await tick());
     return json({ error: `unknown action ${action}` }, 400);

--- a/tools/line-note-scraper/src/line.mjs
+++ b/tools/line-note-scraper/src/line.mjs
@@ -177,14 +177,16 @@ const routeCache = new Map();
  * `https://${client.request.endpoint}/…`，而 endpoint 預設是 legy.line-apps.com
  * （LEGY 加密閘道，不吃這種純 HTTPS JSON），直接丟 `fetch failed`。
  */
-export async function noteRequest(client, homeId, path, params, { method = "GET", body, verbose = false } = {}) {
+export async function noteRequest(client, homeId, path, params, { method = "GET", lhm, body, verbose = false } = {}) {
   const qs = new URLSearchParams(Object.fromEntries(Object.entries(params ?? {}).filter(([, v]) => v !== undefined && v !== null && v !== "")));
   const tryOne = async (host, prefix, channelId) => {
     const token = await channelToken(client, channelId, verbose);
     const url = `https://${host}${prefix}${path}?${qs}`;
     const res = await client.base.fetch(url, {
       method,
-      headers: { ...baseHeaders(client, token), "x-lhm": method },
+      // x-lhm 預設跟著 HTTP method，但不是每支都一樣 —— post/delete.json 是 POST 卻要送 GET
+      // （linejs 的 deletePost/getPost 都這樣，create 才是 POST）。要不一樣就用 lhm 指定。
+      headers: { ...baseHeaders(client, token), "x-lhm": lhm ?? method },
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
     });
     const text = await res.text();
@@ -367,6 +369,33 @@ export async function likeComment(client, homeId, commentId, { likeType = "1003"
     });
   if (!res || res.code !== 0) {
     throw new Error(`按表情失敗：code=${res?.code} ${res?.message ?? ""}`);
+  }
+  return res;
+}
+
+/**
+ * 刪掉記事本上的一篇貼文（社群成員就看不到了）。
+ * 端點與參數比照 linejs 的 timeline.deletePost：homeId / postId 走 query string、
+ * 沒有 body、而且 **x-lhm 要送 "GET"**（跟 create.json 不一樣）。
+ * 走跟讀貼文同一套 host/prefix/channel 探測，不用 linejs 那條寫死 legy 的路。
+ */
+export async function deleteNotePost(client, homeId, postId, { sourceType, verbose = false } = {}) {
+  if (!postId) throw new Error("沒有貼文 id，無法刪除");
+
+  // 先用唯讀的 list 把路由（host/prefix/channel）探出來並記住，delete 才不會拿**破壞性**的
+  // 請求去一組一組試。萬一某組真的刪掉了卻回非 0，探測會繼續往下試、最後回報失敗，
+  // 而貼文其實已經不見了 —— 那是最難查的一種狀況。（createNotePost 也是同樣的理由。）
+  try {
+    await noteGet(client, homeId, "/api/v57/post/list.json",
+      { homeId, sourceType: sourceType ?? "TALKROOM", likeLimit: "0", commentLimit: "0" }, verbose);
+  } catch (e) {
+    log(verbose, "探路用的 list 失敗（照樣試刪除）:", e?.message ?? e);
+  }
+
+  const res = await noteRequest(client, homeId, "/api/v57/post/delete.json",
+    { homeId, postId: String(postId) }, { method: "POST", lhm: "GET", verbose });
+  if (!res || res.code !== 0) {
+    throw new Error(`刪除貼文失敗：code=${res?.code} ${res?.message ?? ""}`);
   }
   return res;
 }


### PR DESCRIPTION
## 做了什麼

「刪除」以前**只清後台紀錄**，貼文還躺在社群裡 —— 貼錯團、貼錯價格的時候等於沒救，只能拿備用帳號的手機自己進 LINE 刪。

現在按「刪除貼文」會**連 LINE 記事本上那篇一起刪掉**，社群成員就看不到了。刪完那個團在該群組可以**重新發一次**（`can_post` 從「已經發過了」變回可以發）。

兩個入口都有：

- LINE 記事本頁的「貼文」分頁（按鈕依有沒有發到 LINE，顯示「刪除貼文」或「刪除紀錄」）
- 開團的「LINE 記事本」彈窗 —— **原本根本沒有刪除**，只能跳去記事本頁找

確認視窗的文字和失敗後的退路收在 `apps/admin/src/lib/lineNoteDelete.ts`，兩邊共用一份，不會各寫各的。

> 分店唯讀那件事拆成另一支 PR（#942），這支只有刪除。

### 順序刻意是「先刪 LINE、成功才清紀錄」

反過來的話，LINE 那邊失敗（帳號掉線最常見）會變成**貼文還在社群裡收留言、後台卻看不到它** —— 那些留言下次讀取會被 `discoverPosts` 當成新貼文重新認一次，變成沒人管的孤兒。

所以刪不掉的時候不會硬清紀錄，而是問要不要只清後台的，並講明「貼文會**繼續留在社群裡**，之後讀取還可能把它重新認回來」。反方向（LINE 刪掉了、清紀錄失敗）頂多留一列指向不存在貼文的紀錄，再按一次就好，不會有人撲空。

### 端點是查出來的，不是猜的

`deleteNotePost` 照 linejs 3.4.2 的 `timeline.deletePost` 寫：

```
POST /{mh|sn}/api/v57/post/delete.json?homeId=…&postId=…    ← 參數在 query string、沒有 body
x-lhm: GET                                                   ← 跟 create.json 送 POST 不一樣
```

`x-lhm` 在 linejs 裡是逐支端點指定的（`createPost` 送 `POST`，`deletePost` / `getPost` 送 `GET`），所以 `noteRequest` 多開一個 `lhm` 參數，不再一律跟著 HTTP method 走。

**呼叫前先用唯讀的 `list.json` 把路由（host/prefix/channel）探出來**，不要拿破壞性請求去一組一組試：萬一某組真的刪掉了卻回非 0，探測會繼續往下試、最後回報失敗，而貼文其實已經不見了 —— 那是最難查的一種狀況。（`createNotePost` 也是同樣的理由，只是它防的是重複貼文。）

### 順手補的安全性缺口

`line-note-worker` 一律用 `service_role` 打 DB（RLS 擋不到），而 `preview` 那類 action 完全沒比對 tenant。這次 `delete_post` 自己拿呼叫者 JWT 的 `app_metadata.tenant_id` 去比對貼文的 `tenant_id`；順帶把 `callerTenant` 抽出來，之後會動到資料的 action 都能用。

## 上線危險

- **做了**：
  - Edge Function 多一個 `delete_post` action（**admin 專屬**，排程／cron 呼叫不到），已部署（v19, ACTIVE）。
  - 後台兩個「刪除」按鈕的行為改變：從「只清紀錄」變成「連 LINE 上那篇一起刪」。這是破壞性動作，所以走後台直接呼叫、按下去當場知道結果，不排 job 慢慢跑。
  - `noteRequest` 多一個 `lhm` 參數（不傳就跟以前一模一樣，既有呼叫點行為不變）。
- **不做**：
  - 沒有批次刪除 —— 一次一篇，避免手滑清掉整團。
  - 沒有動 `rpc_line_note_post_delete`（只清紀錄那支原封不動，現在當退路用）。
  - 沒有 migration、沒有資料異動、沒有碰讀留言／加單／庫存／訂單。
  - 刪除失敗**不會**動到後台紀錄。
- **回退**：`git revert` 本 PR ＋重新部署 Edge Function。已經刪掉的 LINE 貼文救不回來（LINE 沒有還原），但那本來就是使用者按確認才會發生的事。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

`verify_jwt` 維持 `false`（跟 `supabase/config.toml` 一致，函式內自己驗）；沒有新增密鑰、環境變數或 CI 設定。新 action 的權限沿用既有那段角色檢查（owner/admin/hq_manager/assistant/''）。

## 驗證

- 端點、參數位置與 `x-lhm` 都是從 **linejs 3.4.2 原始碼**（`@evex/linejs` `/base/timeline/mod.ts`，就是我們現在依賴的同一版）查出來的：`createPost` 送 `x-lhm: POST`、`deletePost`／`getPost` 送 `GET`，`homeId`/`postId` 走 query string。
- Edge Function 已部署（v19, ACTIVE）並驗過：`OPTIONS` 回 200 帶 CORS、無 auth 的 `POST {"action":"delete_post"}` 回**函式自家的 401**（不是 gateway 404 —— 那句話代表函式根本沒部署）。
- `apps/admin` `npm run build` 綠（含 Safari 15.6 bundle 檢查：115 支 chunk 全過）、`tsc --noEmit` 乾淨。
- `tools/line-note-scraper` 單元測試 18 支全過；兩份 line client（Edge Function 版與 tools 版）的 `deleteNotePost` 逐字比對一致。

## 還沒驗的

- **沒有真的刪過一篇 LINE 上的貼文。** 線上兩個社群都是客人看得到的，不想為了測試在裡面貼一篇再刪。第一次請挑一篇不重要的貼文按按看。
- 失敗不會動到後台紀錄，所以最壞情況是「按了沒反應 ＋ 一則寫著 LINE 回傳什麼的錯誤訊息」，不會把資料弄壞。
- cron 呼叫者拿不到 `delete_post`（`caller !== "admin"` → 403）這條分支沒有端對端跑過（手上沒有正確的 `LINE_NOTE_CRON_SECRET`）；那段守衛跟已在線上運作的 `login`／`preview` 是同一份寫法。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017j2CoHUU1bH2HFuUvzdutM