### PR TITLE
feat(line-notes): 開團的記事本彈窗分店只能看歷史，發文維持總部專屬

### DIFF
--- a/apps/admin/src/app/(protected)/campaigns/page.tsx
+++ b/apps/admin/src/app/(protected)/campaigns/page.tsx
@@ -861,7 +861,9 @@ export default function CampaignsListPage() {
           發 FB
         </SpinButton>
       )}
-      {showAdminActions && (["open", "closed", "locked", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
+      {/* 分店也給 —— 彈窗裡只有右邊的歷史，發文那半只有總部看得到（LineNotePostsModal）。
+          店家最常問的就是「我的團發到群組了沒、客人留了什麼」，這顆是唯一的入口。 */}
+      {(["open", "closed", "locked", "ordered", "receiving", "ready"] as Status[]).includes(r.status) && (
         <SpinButton
           onClick={() => setLineNoteFor(r)}
           className="text-xs text-emerald-600 hover:underline dark:text-emerald-400"

--- a/apps/admin/src/components/LineNotePostsModal.tsx
+++ b/apps/admin/src/components/LineNotePostsModal.tsx
@@ -7,7 +7,12 @@
 // 一團要發三個群組就得開三次彈窗、還得自己記得哪個發過了。開團才是小幫手的工作單位。
 // /line-notes 的「貼文」分頁留著 —— 未認出團的貼文沒有團可掛，只能在那邊指定。
 //
-// 群組清單與「能不能發」一律問 rpc_line_note_campaign_targets（20260910020000），
+// 分店帳號（store_manager / store_staff）只看得到右邊的歷史，左邊那半（挑群組、預覽、
+// 發文）整塊不畫 —— 發文到社群是總部的事。真正的門在 DB：rpc_line_note_queue_posts
+// 走 _line_note_require_admin()，分店按了也是 insufficient_role；這裡只是不要給一顆
+// 按下去必定失敗的按鈕。canOperateLineNotes() 那組角色跟 DB 那支是同一份。
+//
+// 群組清單與「能不能發」一律問 rpc_line_note_campaign_targets（20260910020000／30000），
 // 不要在這裡自己接 line_note_communities 再算一次店家範圍 ——
 // 那條規則的正主是開團自動發文的 trigger，散成三份就會走鐘。
 
@@ -18,6 +23,7 @@ import { OrderDetail } from "@/components/OrderDetail";
 import { getSupabase } from "@/lib/supabase";
 import { translateRpcError } from "@/lib/rpcError";
 import { withBasePath } from "@/lib/basePath";
+import { canOperateLineNotes, useRole } from "@/lib/role";
 import {
   COMMENT_STATUS_LABEL, HOME_KIND_LABEL, POST_STATUS_LABEL, commentStats, fmtNoteTime, isTodoComment,
   type LineNoteCommentStatus, type LineNotePostStatus,
@@ -97,6 +103,10 @@ export default function LineNotePostsModal({
   const [loadingPost, setLoadingPost] = useState<number | null>(null);
   const [orderPopup, setOrderPopup] = useState<{ id: number; no: string } | null>(null);
 
+  // 分店帳號只能看歷史：發文 / 立即讀留言 / 刪貼文那幾支 RPC 都只放總部角色
+  const role = useRole();
+  const canOperate = canOperateLineNotes(role);
+
   const fail = useCallback((e: unknown) => setError(translateRpcError(e)), []);
   const notify = useCallback((m: string) => { setToast(m); setTimeout(() => setToast(null), 3000); }, []);
 
@@ -123,7 +133,7 @@ export default function LineNotePostsModal({
 
   // 預覽：換群組就重新問一次（不同群組可能有不同模板）
   useEffect(() => {
-    if (!open || !campaignId || previewFor == null) { setPreview(null); return; }
+    if (!open || !campaignId || previewFor == null || !canOperate) { setPreview(null); return; }
     let dead = false;
     setPreviewing(true); setPreview(null);
     void (async () => {
@@ -136,7 +146,7 @@ export default function LineNotePostsModal({
       setPreview(data as { text: string; images: string[]; deco?: number });
     })();
     return () => { dead = true; };
-  }, [open, campaignId, previewFor]);
+  }, [open, campaignId, previewFor, canOperate]);
 
   const postable = useMemo(() => (targets ?? []).filter((t) => t.can_post), [targets]);
   const withPost = useMemo(() => (targets ?? []).filter((t) => t.post_id != null), [targets]);
@@ -177,9 +187,10 @@ export default function LineNotePostsModal({
     setOpenPost(t.post_id);
     if (comments.has(t.post_id)) return;
     setLoadingPost(t.post_id);
-    const { data, error } = await getSupabase().from("line_note_comments")
-      .select("id,line_comment_id,commenter_name,text,commented_at,member_no_hint,status,customer_order_id,error,reacted_at,resolution_note")
-      .eq("post_id", t.post_id).order("commented_at", { ascending: true }).order("id");
+    // 走 RPC 不直接 SELECT：line_note_comments 的 RLS 只放總部角色，
+    // 分店讀回來會是**空的而且不報錯** —— 畫面變成「24 則留言」但展開什麼都沒有。
+    const { data, error } = await getSupabase()
+      .rpc("rpc_line_note_post_comments", { p_post_id: t.post_id });
     setLoadingPost(null);
     if (error) return fail(error);
     const cs = (data ?? []) as Comment[];
@@ -224,7 +235,13 @@ export default function LineNotePostsModal({
           )}
           {toast && <div className="rounded bg-emerald-600 px-3 py-2 text-sm text-white">{toast}</div>}
 
-          {targets.length === 0 && (
+          {!canOperate && (
+            <div className="rounded border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">
+              發文到社群由總部操作。這裡可以看這團發到了哪些群組、客人在底下留了什麼、加成了哪幾張單。
+            </div>
+          )}
+
+          {canOperate && targets.length === 0 && (
             <div className="rounded border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
               沒有可以發文的社群。
               <ul className="ml-4 mt-1 list-disc space-y-0.5 text-xs">
@@ -236,7 +253,7 @@ export default function LineNotePostsModal({
 
           <div className="grid gap-4 lg:grid-cols-2">
             {/* ── 左：勾群組 + 預覽 + 發文 ───────────────────────────── */}
-            {targets.length > 0 && (
+            {canOperate && targets.length > 0 && (
             <section className="space-y-3">
               <div>
                 <div className="mb-1.5 flex items-center justify-between">
@@ -350,14 +367,14 @@ export default function LineNotePostsModal({
             )}
 
             {/* ── 右：爬過的歷史紀錄 ─────────────────────────────────── */}
-            <section className={targets.length > 0 ? "" : "lg:col-span-2"}>
+            <section className={canOperate && targets.length > 0 ? "" : "lg:col-span-2"}>
               <div className="mb-1.5 flex items-center justify-between">
                 <h3 className="text-sm font-semibold">爬過的歷史紀錄（{withPost.length} 篇貼文）</h3>
                 <button type="button" className={btn} onClick={() => void load(true)}>重新整理</button>
               </div>
               {withPost.length === 0 ? (
                 <div className="rounded border border-zinc-200 py-8 text-center text-sm text-zinc-400 dark:border-zinc-800">
-                  這團還沒有貼文
+                  這團還沒有發到任何社群
                 </div>
               ) : (
                 <ul className="space-y-2">
@@ -395,17 +412,20 @@ export default function LineNotePostsModal({
                           </div>
                         </button>
 
+                        {canOperate && (
                         <div className="flex flex-wrap gap-1.5 border-t border-zinc-100 px-2.5 py-1.5 dark:border-zinc-800">
                           {t.post_status === "posted" && (
                             <SpinButton className={btn} loading={busy === t.community_id} onClick={() => void readNow(t)}>
                               立即讀留言
                             </SpinButton>
                           )}
-                          {/* 退回未處理 / 忽略 / 重試那些留言操作都在記事本頁，這裡只給入口，不再抄一份 */}
+                          {/* 退回未處理 / 忽略 / 重試那些留言操作都在記事本頁，這裡只給入口，不再抄一份。
+                              /line-notes 整頁是總部專屬（RLS 只放總部角色），分店連結過去也是空的。 */}
                           <a className={`${btn} ml-auto`} href={withBasePath("/line-notes")} target="_blank" rel="noreferrer">
                             到記事本頁處理留言
                           </a>
                         </div>
+                        )}
 
                         {expanded && (
                           <div className="border-t border-zinc-100 bg-zinc-50 p-2.5 dark:border-zinc-800 dark:bg-zinc-900/50">

--- a/apps/admin/src/lib/role.ts
+++ b/apps/admin/src/lib/role.ts
@@ -60,6 +60,19 @@ export function canUnmergeMember(role: Role | null): boolean {
   return UNMERGE_ROLES.includes(role);
 }
 
+// LINE 記事本能不能「操作」（發文到社群 / 立即讀留言 / 刪貼文）。
+// ⚠ 這一組角色要跟 DB 的 _line_note_require_admin() 以及
+//   rpc_line_note_campaign_targets 裡的 v_may_post **完全一樣** ——
+//   前端寬了會出現「按下去回 insufficient_role」，前端嚴了會出現
+//   「明明有權限卻找不到按鈕」。分店角色（store_manager / store_staff）
+//   一律只能看歷史，發文由總部操作。
+const LINE_NOTE_OPERATE_ROLES: Role[] = ["owner", "admin", "hq_manager", "assistant", ""];
+
+export function canOperateLineNotes(role: Role | null): boolean {
+  if (role === null) return false;   // 還沒讀到 role 時當成不能操作，不要先閃一下再收回去
+  return LINE_NOTE_OPERATE_ROLES.includes(role);
+}
+
 /**
  * 這個帳號被指派到哪幾家店（app_metadata.stores，存的是**店名**）。
  * 非分店帳號通常沒有這個欄位 → 回空陣列。

--- a/supabase/migrations/20260910030000_line_note_targets_branch_readonly.sql
+++ b/supabase/migrations/20260910030000_line_note_targets_branch_readonly.sql
@@ -1,0 +1,220 @@
+-- ============================================================================
+-- 20260910030000_line_note_targets_branch_readonly.sql
+--
+-- 開團的「LINE 記事本」彈窗：分店帳號看得到歷史，但發文只有總部能按。
+--
+-- 原本 rpc_line_note_campaign_targets 開頭就是 _line_note_require_admin()，
+-- 分店帳號一問就 insufficient_role → 彈窗整個打不開，所以那顆按鈕乾脆只給
+-- admin 看。結果是店家完全不知道自家的團有沒有發到社群、客人在底下留了什麼，
+-- 只能回頭問總部。
+--
+-- 改成：**讀**放給同 tenant 的所有角色，**發文**維持原本那組角色。
+--
+-- ⚠ can_post 用的角色集合要跟 rpc_line_note_queue_posts 擋的那組**完全一樣**
+--   （= _line_note_require_admin 的 owner/admin/hq_manager/assistant/''），
+--   不是前端的 isAdmin(owner/admin/'')。兩邊各寫一套就會變成
+--   「畫面說可以發、按下去說 insufficient_role」——20260910020000 的檔頭就在講這件事。
+--   前端只負責「分店 → 整個發文區塊不畫出來」，寬嚴由這支決定。
+--
+-- 分店看得到的範圍（兩層都要，不然會看到別家店的客人留言）：
+--   團：總部的團，或自己店開的團（不是自己的 → wrong_store）
+--   社群：沒綁店的（總部社群，大家的團都發那裡），或綁到自己店的
+-- 目前線上兩個社群都是總部社群 → 分店照樣看得到歷史，不會開了是空的。
+--
+-- 另外新增 rpc_line_note_post_comments：彈窗原本直接 SELECT line_note_comments，
+-- 那張表的 RLS 只放總部角色，分店讀回來會是空的（不會報錯，就是空的 —— 比報錯更難查）。
+--
+-- 基底：rpc_line_note_campaign_targets @ 20260910020000（唯一前版，已 grep 確認）。
+--       欄位、母體、排序全部原樣，只動授權與 can_post/blocked_reason。
+-- rollback：還原 20260910020000 的 rpc_line_note_campaign_targets；
+--           DROP FUNCTION public.rpc_line_note_post_comments(BIGINT);
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 0. 「這個帳號看得到這篇貼文嗎」——targets 與 comments 共用同一套判斷
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._line_note_branch_visible_store(p_store_id BIGINT)
+RETURNS BOOLEAN
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  -- 沒綁店 = 總部社群／總部團，誰都看得到；綁了店就要是自己的店
+  SELECT NOT public._is_branch_scoped_user()
+      OR p_store_id IS NULL
+      OR EXISTS (
+           SELECT 1 FROM stores s
+            WHERE s.id = p_store_id
+              AND s.tenant_id = (auth.jwt() ->> 'tenant_id')::uuid
+              AND COALESCE(auth.jwt() -> 'app_metadata' -> 'stores', '[]'::jsonb) ? s.name);
+$$;
+GRANT EXECUTE ON FUNCTION public._line_note_branch_visible_store(BIGINT) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 1. 這團可以發到哪些群組 / 已經發成什麼樣（讀：全角色；發文：只有總部）
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_campaign_targets(p_campaign_id BIGINT)
+RETURNS TABLE (
+  community_id       BIGINT,
+  home_id            TEXT,
+  home_name          TEXT,
+  home_kind          TEXT,
+  store_id           BIGINT,
+  store_name         TEXT,
+  account_id         BIGINT,
+  account_label      TEXT,
+  account_status     TEXT,
+  auto_post_on_open  BOOLEAN,
+  listen_enabled     BOOLEAN,
+  in_scope           BOOLEAN,
+  can_post           BOOLEAN,
+  blocked_reason     TEXT,
+  post_id            BIGINT,
+  post_status        TEXT,
+  line_post_id       TEXT,
+  post_text          TEXT,
+  posted_at          TIMESTAMPTZ,
+  last_read_at       TIMESTAMPTZ,
+  closed_reason      TEXT,
+  post_error         TEXT,
+  comment_total      INT,
+  comment_ordered    INT,
+  comment_duplicate  INT,
+  comment_todo       INT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant   UUID    := public._current_tenant_id();
+  -- 發文的角色集合＝rpc_line_note_queue_posts 會放行的那組，不要另外定義
+  v_may_post BOOLEAN := COALESCE(auth.jwt() -> 'app_metadata' ->> 'role', '')
+                        = ANY (ARRAY['owner','admin','hq_manager','assistant','']);
+  v_owner    BIGINT;
+  v_cstat    TEXT;
+BEGIN
+  IF v_tenant IS NULL THEN RAISE EXCEPTION 'no tenant in token'; END IF;
+
+  SELECT g.owner_store_id, g.status INTO v_owner, v_cstat
+    FROM group_buy_campaigns g WHERE g.id = p_campaign_id AND g.tenant_id = v_tenant;
+  IF v_cstat IS NULL THEN RAISE EXCEPTION 'campaign % not in tenant', p_campaign_id; END IF;
+
+  -- 分店只能看總部的團與自己店開的團
+  IF NOT public._line_note_branch_visible_store(v_owner) THEN
+    RAISE EXCEPTION 'wrong_store: 這不是你的店開的團';
+  END IF;
+
+  RETURN QUERY
+  WITH c AS (
+    SELECT lc.*,
+           a.label  AS a_label,
+           a.status AS a_status,
+           -- 開團自動發文的範圍：總部的團發到所有社群，店家自開的團只發到那家店的
+           -- （跟 _line_note_on_campaign_open 同一條件，改一邊記得改另一邊）
+           (v_owner IS NULL OR lc.store_id = v_owner) AS scoped
+      FROM line_note_communities lc
+      JOIN line_note_accounts a ON a.id = lc.account_id
+     WHERE lc.tenant_id = v_tenant
+       -- 分店看不到別家店綁的社群（總部社群 store_id IS NULL，大家都看得到）
+       AND public._line_note_branch_visible_store(lc.store_id)
+  ), p AS (
+    SELECT lp.*,
+           COALESCE(s.total, 0)     AS n_total,
+           COALESCE(s.ordered, 0)   AS n_ordered,
+           COALESCE(s.duplicate, 0) AS n_duplicate,
+           COALESCE(s.todo, 0)      AS n_todo
+      FROM line_note_posts lp
+      LEFT JOIN LATERAL (
+        SELECT count(*)::INT AS total,
+               count(*) FILTER (WHERE cm.status = 'ordered')::INT   AS ordered,
+               count(*) FILTER (WHERE cm.status = 'duplicate')::INT AS duplicate,
+               count(*) FILTER (WHERE public._line_note_comment_is_todo(cm.status, cm.member_no_hint))::INT AS todo
+          FROM line_note_comments cm WHERE cm.post_id = lp.id
+      ) s ON TRUE
+     WHERE lp.tenant_id = v_tenant AND lp.campaign_id = p_campaign_id
+  )
+  SELECT c.id, c.home_id, c.home_name, c.home_kind,
+         c.store_id, st.name,
+         c.account_id, c.a_label, c.a_status,
+         c.auto_post_on_open, c.listen_enabled,
+         c.scoped,
+         -- can_post / blocked_reason 要跟 rpc_line_note_queue_posts 擋的東西**一模一樣**。
+         -- 注意「已經發過」的判準是 posted 或 line_post_id 有值，不是「有這一列」——
+         -- status='failed'（發文失敗、LINE 上根本沒東西）必須還能再發一次。
+         (v_may_post AND c.scoped AND c.a_status = 'active'
+            AND v_cstat IN ('open','closed')
+            AND NOT (p.id IS NOT NULL AND (p.status = 'posted' OR p.line_post_id IS NOT NULL))) AS can_post,
+         CASE WHEN p.id IS NOT NULL AND (p.status = 'posted' OR p.line_post_id IS NOT NULL)
+                                                    THEN '已經發過了'
+              WHEN NOT v_may_post                   THEN '發文到社群只有總部能操作'
+              WHEN NOT c.scoped                     THEN '這個社群只收該店自開的團'
+              WHEN c.a_status <> 'active'            THEN 'LINE 帳號沒有登入'
+              WHEN v_cstat NOT IN ('open','closed')  THEN '這團不是開團中／已收單'
+         END,
+         p.id, p.status, p.line_post_id, p.text,
+         p.posted_at, p.last_read_at, p.closed_reason, p.last_error,
+         p.n_total, p.n_ordered, p.n_duplicate, p.n_todo
+    FROM c
+    LEFT JOIN p ON p.community_id = c.id
+    LEFT JOIN stores st ON st.id = c.store_id
+   -- 範圍外但已經發過的也要列出來（範圍是後來才改的，歷史不能憑空消失）
+   WHERE c.scoped OR p.id IS NOT NULL
+   ORDER BY (p.id IS NOT NULL) DESC, c.home_name NULLS LAST, c.id;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_campaign_targets(BIGINT) TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 2. 一篇貼文爬回來的留言（讀：全角色，範圍同上）
+--    彈窗原本直接 SELECT line_note_comments，那張表的 RLS 只放總部角色 ——
+--    分店讀回來是**空的、不報錯**，畫面會變成「有 12 則留言」但展開什麼都沒有。
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_line_note_post_comments(p_post_id BIGINT)
+RETURNS TABLE (
+  id                BIGINT,
+  line_comment_id   TEXT,
+  commenter_name    TEXT,
+  text              TEXT,
+  commented_at      TIMESTAMPTZ,
+  member_no_hint    TEXT,
+  status            TEXT,
+  customer_order_id BIGINT,
+  error             TEXT,
+  reacted_at        TIMESTAMPTZ,
+  resolution_note   TEXT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant UUID := public._current_tenant_id();
+  v_cstore BIGINT;   -- 貼文所在社群綁的店
+  v_ostore BIGINT;   -- 這篇貼文那個團的主辦店
+  v_found  BOOLEAN;
+BEGIN
+  IF v_tenant IS NULL THEN RAISE EXCEPTION 'no tenant in token'; END IF;
+
+  SELECT TRUE, lc.store_id, g.owner_store_id
+    INTO v_found, v_cstore, v_ostore
+    FROM line_note_posts lp
+    JOIN line_note_communities lc ON lc.id = lp.community_id
+    LEFT JOIN group_buy_campaigns g ON g.id = lp.campaign_id
+   WHERE lp.id = p_post_id AND lp.tenant_id = v_tenant;
+  IF NOT COALESCE(v_found, FALSE) THEN RAISE EXCEPTION 'post % not in tenant', p_post_id; END IF;
+
+  IF NOT (public._line_note_branch_visible_store(v_cstore)
+          AND public._line_note_branch_visible_store(v_ostore)) THEN
+    RAISE EXCEPTION 'wrong_store: 這不是你的店看得到的貼文';
+  END IF;
+
+  RETURN QUERY
+  SELECT cm.id, cm.line_comment_id, cm.commenter_name, cm.text, cm.commented_at,
+         cm.member_no_hint, cm.status, cm.customer_order_id, cm.error,
+         cm.reacted_at, cm.resolution_note
+    FROM line_note_comments cm
+   WHERE cm.post_id = p_post_id AND cm.tenant_id = v_tenant
+   ORDER BY cm.commented_at NULLS LAST, cm.id;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_post_comments(BIGINT) TO authenticated;
+
+COMMENT ON FUNCTION public.rpc_line_note_post_comments(BIGINT) IS
+  '一篇記事本貼文爬回來的留言。分店帳號也讀得到（line_note_comments 的 RLS 只放總部角色），'
+  '範圍限「總部社群或自己店的社群」×「總部團或自己店開的團」。';


### PR DESCRIPTION
## 做了什麼

店家最常問的就是「我的團發到群組了沒、客人在底下留了什麼」，但開團列表那顆「LINE 記事本」原本**只有 admin 看得到**，分店只能回頭問總部。

現在分店也點得開，彈窗裡**只有右邊的歷史**：發到哪些群組、每篇的貼文 id、發文與讀取時間、已加單／已有訂單／待處理統計，點開看每一則留言。左半（挑群組、預覽、發文）整塊不畫，「立即讀留言」／「刪除貼文」／「到記事本頁」也不給 —— 那幾支本來就只放總部角色。

|  | admin | store_staff |
|---|---|---|
| 開團列表的「LINE 記事本」按鈕 | ✅ | ✅（新） |
| 挑群組 / 預覽 / 發文按鈕 | ✅ | ❌ |
| 爬過的歷史紀錄 | ✅ | ✅（新） |
| 「發文到社群由總部操作」說明 | ❌ | ✅ |

### 真正的門在 DB，前端只是不要給一顆按下去必定失敗的按鈕

- `rpc_line_note_campaign_targets` 原本開頭就 `_line_note_require_admin()`，分店一問就 `insufficient_role`、**彈窗整個打不開**。改成讀放給同 tenant 全角色，能不能發另外用 `v_may_post` 收斂。
- `rpc_line_note_queue_posts`（真正在發文的那支）**一個字沒動**，分店按了照樣 `insufficient_role`。
- `can_post` 的角色集合＝`_line_note_require_admin` 那組，**不是**前端的 `isAdmin`。前端新增的 `canOperateLineNotes()` 用同一份：前端寬了會「按下去報錯」，前端嚴了會「有權限卻找不到按鈕」。

### 分店看得到的範圍：兩層都要

不然會看到別家店的客人留言。團＝總部團或自己店開的團；社群＝沒綁店的（總部社群）或綁到自己店的。線上兩個社群都是總部社群，所以分店照樣看得到歷史，**不會開了是空的**。

### 新增 `rpc_line_note_post_comments`

彈窗原本直接 `SELECT line_note_comments`，那張表的 RLS 只放總部角色 —— 分店讀回來是**空的而且不報錯**，畫面會變成「24 則留言」但展開什麼都沒有，比報錯更難查。

## 上線危險

- **做了**：`rpc_line_note_campaign_targets` 的授權放寬（**讀**）、新增 `rpc_line_note_post_comments` 與 `_line_note_branch_visible_store`，migration 已套上正式庫；開團列表的「LINE 記事本」按鈕改成分店也看得到。
- **不做**：
  - 沒有放寬**發文**的權限，`rpc_line_note_queue_posts` 完全沒動。
  - 沒有讓分店看到別家店的社群或別家店開的團。
  - 沒有動 `/line-notes` 那一頁（它本來就在 `BRANCH_HIDDEN_HREFS` 裡，分店看不到那個側欄項目，不會有「點進去是空的」的死路）。
  - 沒有碰 Edge Function、沒有資料異動。
- **回退**：還原 20260910020000 版的 `rpc_line_note_campaign_targets`；`DROP FUNCTION public.rpc_line_note_post_comments(BIGINT);` `DROP FUNCTION public._line_note_branch_visible_store(BIGINT);`（migration 檔頭也寫了）＋ `git revert` 本 PR。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

沒有新增密鑰、環境變數或 CI 設定。**權限有放寬的只有「讀」那一支**：`rpc_line_note_campaign_targets` 從「總部角色專屬」改成「同 tenant 全角色可讀，範圍照上面兩層收斂」，理由是分店連彈窗都打不開。發文／刪除／讀留言處理的角色集合都沒動。

## 驗證

權限邊界（都在交易裡 `ROLLBACK`，事後確認 207 篇貼文與 0 筆 queued job 沒變）：

| 情境 | 結果 |
|---|---|
| 店員讀總部團 targets | 讀得到 2 個社群、`can_post` 全 false ✅ |
| 店員讀貼文留言 | 24 則讀得到（改走 RPC 之前是 **0 則**）✅ |
| 店員看沒發過的團 | 理由顯示「發文到社群只有總部能操作」✅ |
| 店員按發文 | `insufficient_role` ✅ |
| 店員看別家店開的團 | `wrong_store` ✅ |
| 社群改綁別家店後，店員看 | targets 少掉那一列；讀它的留言 → `wrong_store` ✅ |
| 社群改綁自己店 | 兩個社群都看得到 ✅ |
| admin 全路徑 | `can_post`／`blocked_reason` 與改版前逐項一致 ✅ |

UI：用 `apps/admin:verify`（起 dev server + 假 session + 攔截 REST）實跑 admin 與 store_staff 兩種角色，上面那張表的六個項目逐一斷言，並截圖確認分店版面沒破（歷史撐滿整個寬度、沒有留下空白的動作列）。

其他：`apps/admin` `npm run build` 綠（含 Safari 15.6 bundle 檢查：115 支 chunk 全過）、`tsc --noEmit` 乾淨。

> 這支是從 #941 拆出來的（原本疊在同一支上），base 是 main、不依賴 #941。兩支都動到 `LineNotePostsModal.tsx`，先合併的那支之後另一支我會把 main 併進來解掉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017j2CoHUU1bH2HFuUvzdutM

---
_Generated by [Claude Code](https://claude.ai/code/session_017j2CoHUU1bH2HFuUvzdutM)_