### PR TITLE
fix(orders): 測試團 GRP-20260910-041 的訂單搬到 GRP-20260910-021，然後刪掉測試團

### DIFF
--- a/supabase/migrations/20260910030000_move_orders_test_campaign_041_to_021.sql
+++ b/supabase/migrations/20260910030000_move_orders_test_campaign_041_to_021.sql
@@ -1,0 +1,196 @@
+-- ============================================================================
+-- 一次性資料搬移：把測試團 GRP-20260910-041 的訂單搬到正式團 GRP-20260910-021
+-- ============================================================================
+-- 需求（Alex 2026-09-10）：「幫我把第一張圖的團的人轉到第二張圖」。
+--   來源 GRP-20260910-041「中華一番・中式職人料理 350克+-10%test」（id 5050，
+--     09-10 17:50 開的測試團，兩分鐘後整團取消 → status='cancelled'）
+--   目標 GRP-20260910-021「中華一番・中式職人料理 350克+-10%」（id 5030，
+--     status='open'，收單到 09-15 23:59）
+-- 兩團的商品完全一樣（product_id 3746，SKU 7120 / 7141，都是 $99），
+-- 差別只在來源那團是誤開的測試團。
+--
+-- 搬的是**同一張訂單**（UPDATE campaign_id，不是複製一張新的）：
+--   customer_order_items.campaign_item_id 是 PR → campaign 的 1:1 連結，
+--   複製一份會多出一張孤兒訂單、而且客人在兩團各出現一次。
+--
+-- 每張訂單要動的四件事：
+--   1. campaign_id → 目標團
+--   2. order_no    → 目標團的 campaign_no + 下一個流水號。
+--      序號規則跟 rpc 一致（20260814000010：該團訂單 COUNT(*) + 1，含已取消），
+--      所以搬進去佔掉 -0003 之後，下一張新單自然拿到 -0004，不會撞號。
+--   3. 品項的 campaign_item_id → 目標團**同一個 sku_id** 的那一列
+--      （campaign_item_id 指向來源團的列，不改的話這張單會同時掛在兩個團上，
+--       v_picking_demand_by_po / v_order_shortage 之類靠它對團的地方會錯亂）
+--   4. status cancelled → pending：來源單是被「整團取消」連帶取消的（單頭
+--      cancelled、品項還是 pending），搬到還開著的團就要恢復成正常待處理單，
+--      否則畫面上人是進去了但訂單不算數。cancelled_at 一併清掉。
+--
+-- 守衛（任一不成立就整支 RAISE 中止，不搬一半）：
+--   - 來源／目標團必須是這兩支（campaign_no + name 都比對）、目標團必須 open
+--   - 來源訂單不能沾到實體流程：庫存異動 / 調撥單 / 轉單連結 / 撿貨波次 /
+--     取貨・短少・逾期事件 / 減抵單。沾到就不是純測試單，要人工處理。
+--   - 每個品項的 sku_id 在目標團都要找得到對應的 campaign_items 列
+--   - 目標團不能已經有同一個 (channel_id, member_id, order_kind) 的有效單
+--     （customer_orders_trio_kind_active_uniq，一團一人一單）
+--   - 只搬「單頭 cancelled 但還有 active 品項」或本來就 active 的單；
+--     品項也一起被取消的單不搬（那是真的取消，不是被整團連坐）
+--
+-- 冪等：來源團已經沒有訂單就直接跳過（NOTICE）。
+-- Rollback：把該張單的 campaign_id / order_no / campaign_item_id / status 改回
+--   5050 / 'GRP-20260910-041-0001' / 9812 / 'cancelled'，並還原 cancelled_at。
+-- ============================================================================
+
+DO $$
+DECLARE
+  v_tenant   CONSTANT UUID := '00000000-0000-0000-0000-000000000001';
+  v_src_no   CONSTANT TEXT := 'GRP-20260910-041';
+  v_dst_no   CONSTANT TEXT := 'GRP-20260910-021';
+  v_src      BIGINT;
+  v_dst      BIGINT;
+  v_dst_stat TEXT;
+  v_seq      INT;
+  v_cnt      INT;
+  v_moved    INT := 0;
+  v_new_no   TEXT;
+  r          RECORD;
+BEGIN
+  SELECT id INTO v_src
+    FROM group_buy_campaigns
+   WHERE tenant_id = v_tenant AND campaign_no = v_src_no
+     AND name = '中華一番・中式職人料理 350克+-10%test'
+   FOR UPDATE;
+
+  SELECT id, status INTO v_dst, v_dst_stat
+    FROM group_buy_campaigns
+   WHERE tenant_id = v_tenant AND campaign_no = v_dst_no
+     AND name = '中華一番・中式職人料理 350克+-10%'
+   FOR UPDATE;
+
+  IF v_src IS NULL THEN
+    RAISE NOTICE '[skip] 來源團 % 不存在（可能已刪除或改名）', v_src_no;
+    RETURN;
+  END IF;
+  IF v_dst IS NULL THEN
+    RAISE EXCEPTION '目標團 % 不存在，中止', v_dst_no;
+  END IF;
+  IF v_dst_stat <> 'open' THEN
+    RAISE EXCEPTION '目標團 % 不是 open（現在是 %），中止', v_dst_no, v_dst_stat;
+  END IF;
+
+  SELECT COUNT(*) INTO v_cnt FROM customer_orders WHERE tenant_id = v_tenant AND campaign_id = v_src;
+  IF v_cnt = 0 THEN
+    RAISE NOTICE '[skip] 來源團 % 已經沒有訂單，無事可做', v_src_no;
+    RETURN;
+  END IF;
+
+  -- ── 守衛 1：來源訂單不能沾到實體流程 ────────────────────────────────────
+  SELECT COUNT(*) INTO v_cnt
+    FROM customer_orders co
+   WHERE co.tenant_id = v_tenant AND co.campaign_id = v_src
+     AND (
+          EXISTS (SELECT 1 FROM stock_movements sm
+                   WHERE sm.source_doc_type = 'customer_order' AND sm.source_doc_id = co.id)
+       OR EXISTS (SELECT 1 FROM transfers t WHERE t.customer_order_id = co.id)
+       OR EXISTS (SELECT 1 FROM customer_order_transfer_links l
+                   WHERE l.source_order_id = co.id OR l.dest_order_id = co.id)
+       OR EXISTS (SELECT 1 FROM order_pickup_events e   WHERE e.order_id = co.id)
+       OR EXISTS (SELECT 1 FROM order_shortage_events e WHERE e.order_id = co.id)
+       OR EXISTS (SELECT 1 FROM order_expiry_events e   WHERE e.order_id = co.id)
+       OR co.transferred_from_order_id IS NOT NULL
+       OR co.transferred_to_order_id   IS NOT NULL
+     );
+  IF v_cnt > 0 THEN
+    RAISE EXCEPTION '來源團有 % 張訂單已經沾到庫存／調撥／轉單，不是純測試單，中止', v_cnt;
+  END IF;
+
+  SELECT COUNT(*) INTO v_cnt FROM picking_wave_items WHERE campaign_id = v_src;
+  IF v_cnt > 0 THEN
+    RAISE EXCEPTION '來源團有 % 筆撿貨波次明細，中止', v_cnt;
+  END IF;
+
+  SELECT COUNT(*) INTO v_cnt
+    FROM inventory_deduction_notes WHERE campaign_id = v_src AND cancelled_at IS NULL;
+  IF v_cnt > 0 THEN
+    RAISE EXCEPTION '來源團有 % 張未取消的庫存減抵單，中止', v_cnt;
+  END IF;
+
+  -- ── 守衛 2：每個品項的 SKU 在目標團都要有對應的 campaign_items 列 ────────
+  SELECT COUNT(*) INTO v_cnt
+    FROM customer_order_items coi
+    JOIN customer_orders co ON co.id = coi.order_id
+   WHERE co.tenant_id = v_tenant AND co.campaign_id = v_src
+     AND NOT EXISTS (
+           SELECT 1 FROM campaign_items ci
+            WHERE ci.campaign_id = v_dst AND ci.sku_id = coi.sku_id);
+  IF v_cnt > 0 THEN
+    RAISE EXCEPTION '有 % 個品項的 SKU 在目標團 % 找不到對應商品，中止', v_cnt, v_dst_no;
+  END IF;
+
+  -- ── 守衛 3：目標團不能已經有同一人的有效單（一團一人一單唯一索引）────────
+  SELECT COUNT(*) INTO v_cnt
+    FROM customer_orders s
+   WHERE s.tenant_id = v_tenant AND s.campaign_id = v_src
+     AND EXISTS (
+           SELECT 1 FROM customer_orders d
+            WHERE d.tenant_id = v_tenant AND d.campaign_id = v_dst
+              AND d.channel_id = s.channel_id
+              AND d.member_id  = s.member_id
+              AND COALESCE(d.order_kind, 'normal') = COALESCE(s.order_kind, 'normal')
+              AND d.status NOT IN ('cancelled', 'expired', 'transferred_out')
+              AND d.aid_board_id IS NULL);
+  IF v_cnt > 0 THEN
+    RAISE EXCEPTION '目標團 % 已經有 % 位相同會員的有效訂單，會撞一團一人一單的唯一索引，中止',
+                    v_dst_no, v_cnt;
+  END IF;
+
+  -- ── 搬移 ────────────────────────────────────────────────────────────────
+  SELECT COUNT(*) INTO v_seq FROM customer_orders WHERE tenant_id = v_tenant AND campaign_id = v_dst;
+
+  FOR r IN
+    SELECT co.id, co.order_no, co.status, co.member_id, co.nickname_snapshot
+      FROM customer_orders co
+     WHERE co.tenant_id = v_tenant AND co.campaign_id = v_src
+     ORDER BY co.created_at, co.order_no
+     FOR UPDATE
+  LOOP
+    -- 品項全被取消的單不搬（那是真的取消，不是被整團連坐）
+    IF NOT EXISTS (
+      SELECT 1 FROM customer_order_items coi
+       WHERE coi.order_id = r.id
+         AND coi.status IN ('pending', 'reserved', 'ready')
+    ) THEN
+      RAISE NOTICE '[skip] 訂單 % 沒有可搬的品項（全部已取消／已取貨），留在原團', r.order_no;
+      CONTINUE;
+    END IF;
+
+    v_seq    := v_seq + 1;
+    v_new_no := v_dst_no || '-' || LPAD(v_seq::TEXT, 4, '0');
+
+    -- 品項改掛目標團的同 SKU 商品列
+    UPDATE customer_order_items coi
+       SET campaign_item_id = ci.id
+      FROM campaign_items ci
+     WHERE coi.order_id = r.id
+       AND ci.campaign_id = v_dst
+       AND ci.sku_id = coi.sku_id
+       AND coi.campaign_item_id IS DISTINCT FROM ci.id;
+
+    UPDATE customer_orders
+       SET campaign_id  = v_dst,
+           order_no     = v_new_no,
+           status       = CASE WHEN status = 'cancelled' THEN 'pending' ELSE status END,
+           cancelled_at = CASE WHEN status = 'cancelled' THEN NULL ELSE cancelled_at END,
+           notes        = TRIM(BOTH E'\n' FROM COALESCE(notes || E'\n', '')
+                          || '[' || TO_CHAR(NOW() AT TIME ZONE 'Asia/Taipei', 'YYYY-MM-DD HH24:MI')
+                          || '] 由測試團 ' || v_src_no || '（原單號 ' || r.order_no
+                          || '）搬移至本團'),
+           updated_at   = NOW()
+     WHERE id = r.id;
+
+    v_moved := v_moved + 1;
+    RAISE NOTICE '[moved] % → %（%，原狀態 %）', r.order_no, v_new_no,
+                 COALESCE(r.nickname_snapshot, r.member_id::TEXT), r.status;
+  END LOOP;
+
+  RAISE NOTICE '完成：% → %，共搬移 % 張訂單', v_src_no, v_dst_no, v_moved;
+END $$;


### PR DESCRIPTION
## 做了什麼

誤開的測試團 `GRP-20260910-041`「中華一番・中式職人料理 350克+-10%test」（id 5050，09-10 17:50 開、17:52 整團取消）底下有一張真的客人訂單：**美慧-中和／中和店／2 件 (B) 職人三杯雞腿丁 $99**。整團取消時單頭被連坐標成 `cancelled`，品項卻還是 `pending`。兩支 migration，先搬人再刪團：

### `20260910030000` 把訂單搬到正式團 `GRP-20260910-021`

兩團的商品完全一樣（product_id 3746、SKU 7120 / 7141、都是 $99），目標團 id 5030 還開著（收單到 09-15 23:59）。

搬的是**同一張訂單**（`UPDATE campaign_id`，不是複製一張新的 —— 複製會讓客人在兩團各出現一次、`campaign_item_id` 這條 PR → campaign 的 1:1 連結也會斷）。每張單動四件事：

1. `campaign_id` → 目標團
2. `order_no` → 依 rpc 的序號規則重編（`20260814000010`：該團訂單 `COUNT(*) + 1`，含已取消）→ `-0003`，下一張新單自然拿到 `-0004`，不會撞號
3. 品項的 `campaign_item_id` → 目標團**同 sku_id** 的那一列（9812 → 9719）
4. 單頭 `cancelled` → `pending`、清掉 `cancelled_at`，`notes` 留一行搬移軌跡

守衛（任一不成立就整支 RAISE 中止，不搬一半）：兩團的 `campaign_no` + `name` 都要對得上、目標團必須 `open`、來源訂單不能沾到庫存異動／調撥單／轉單連結／撿貨波次／取貨・短少・逾期事件／未取消的減抵單、每個 SKU 在目標團都要找得到、不能撞 `customer_orders_trio_kind_active_uniq`（一團一人一單）、品項全被取消的單不搬。

### `20260910040000` 刪掉空掉的測試團

搬完之後那團剩 0 張訂單、2 列商品、1 筆瀏覽紀錄，其餘 15 張會參照 `group_buy_campaigns` 的表全部 0 筆。

走 `rpc_delete_campaign`（＝後台「刪除」鈕的同一支），不自己抄一份 DELETE：它知道 `campaign_audit_log` / `customer_order_sources` 是 append-only、要先暫停 BEFORE DELETE 保護，`order_waitlist` 沒有 CASCADE 要手動清 —— 抄一份等於哪天那支加了新表這裡就漏。它讀 `auth.jwt()` 判角色（總倉團要 owner/admin/hq_manager/assistant/`''`），migration 沒有登入身分，所以灌一份 **transaction-local**（`set_config(..., true)`）的 claims 進去，呼叫完立刻還原、不外洩。

呼叫前自己再驗一次：`campaign_no` + `name` 都要對得上（號碼是手選的會撞號）、0 訂單、沒有撿貨波次／採購單／待補貨參照、沒有庫存異動、沒有未取消的減抵單、不是店家自開團（那要走 `rpc_delete_store_campaign`）。

## 上線危險

- 做了：兩支都是一次性資料操作，只動這兩團。實際影響 1 張訂單 / 1 個品項 / 2 件，以及刪掉 1 個空的測試團（連帶 2 列商品、1 筆瀏覽紀錄）。動手前已確認該單與該團沒有任何庫存異動、調撥單、轉單連結、撿貨波次、採購單、取貨事件、減抵單；目標團也沒有同一位會員的有效單，不會撞唯一索引。
- 不做：不搬就是這位客人的訂單留在已取消的測試團裡，店端與會員端都看不到、也配不到貨，等同這筆訂單消失；不刪就是後台列表一直掛著一個名字幾乎一樣的 `…test` 團，開團／配單時容易點錯。
- 回退：搬移可回退 —— 把該張單改回 `campaign_id = 5050`、`order_no = 'GRP-20260910-041-0001'`、品項 `campaign_item_id = 9812`、`status = 'cancelled'`、`cancelled_at = '2026-09-10T09:52:29.108987+00'`。**刪除不可回退**（實體刪除，測試資料刪掉即為目的）；真要重建的完整欄位值寫在 `20260910040000` 檔頭，但 id 不會一樣，所以順序上要先重建團、再把單搬回去。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- 離線語法檢查：兩支都跑 `node scripts/check-sql-syntax.cjs …` → ✓
- 兩支都先對正式庫做 `BEGIN; <migration>; <驗證查詢>; ROLLBACK;` 乾跑，確認落點正確後才正式套用。
- **兩支都已套上正式庫**（Management API）。套用後：

  | 單號 | 狀態 | 會員 | 門市 | 品項 |
  |---|---|---|---|---|
  | GRP-20260910-021-0001 | pending | Wilma(威瑪)004615-三峽 | 三峽店 | ci 9718 ×1、ci 9719 ×2 |
  | GRP-20260910-021-0002 | pending | Lo Wan-Na羅灣娜235480-三峽 | 三峽店 | ci 9718 ×1 |
  | **GRP-20260910-021-0003** | **pending** | **美慧-中和** | **中和店** | **ci 9719 ×2** |

  新單的 `campaign_item_id` 已是目標團的 9719、`cancelled_at` 已清空、`notes` 有搬移軌跡。
- 刪除後複查：`group_buy_campaigns` / `campaign_items` / `campaign_views` 對 5050 皆 0 筆；目標團 5030 仍是 `open` 且 3 張訂單完好；`trg_no_mut_camp_audit` 與 `trg_no_mut_cos` 兩個 append-only 保護 trigger 已確認回到 enabled（`tgenabled = 'O'`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5rBbzAPosUWqsgip7Mg17