### PR TITLE
feat(line-notes): 貼文金額用 emoji 凸顯、先團名再金額、單品只印金額、一律零售價

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -629,7 +629,7 @@ function PostCampaignModal({ community, communities, accountById, onClose, notif
   const [busy, setBusy] = useState(false);
   // 貼文是發給整個社群看的，發出去才發現版型不對就來不及了（只能刪掉重發，客人已經看到）。
   // 所以先把「等一下真的會貼出去的字」原封不動叫回來給人看 —— 渲染是 worker 那一份，不是另外寫的。
-  const [preview, setPreview] = useState<{ text: string; images: string[]; deco?: number } | null>(null);
+  const [preview, setPreview] = useState<{ text: string; images: string[] } | null>(null);
   const [previewing, setPreviewing] = useState(false);
   useEffect(() => {
     void (async () => {
@@ -650,7 +650,7 @@ function PostCampaignModal({ community, communities, accountById, onClose, notif
       if (dead) return;
       setPreviewing(false);
       if (error || (data as { error?: string })?.error) return;   // 預覽拿不到就不擋發文
-      setPreview(data as { text: string; images: string[]; deco?: number });
+      setPreview(data as { text: string; images: string[] });
     })();
     return () => { dead = true; };
   }, [campaignId, previewFor]);
@@ -732,10 +732,7 @@ function PostCampaignModal({ community, communities, accountById, onClose, notif
             )}
           </div>
         )}
-        <p className="mt-1 text-xs text-zinc-500">
-          文案取自這個團的說明，商品和價格取自團裡的品項，圖片取自商品圖。要改內容請去改團／商品。
-          {!!preview?.deco && <>　金額會用 LINE 的彩色數字表情貼出去（這裡先用一般數字顯示）。</>}
-        </p>
+        <p className="mt-1 text-xs text-zinc-500">文案取自這個團的說明，商品和價格取自團裡的品項，圖片取自商品圖。要改內容請去改團／商品。</p>
       </div>
 
       <div className="mt-4 flex justify-end gap-2">

--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -596,9 +596,9 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
             <label className="flex items-center gap-2 text-sm">
               <input type="checkbox" checked={form.react_on_confirm} onChange={(e) => setForm({ ...form, react_on_confirm: e.target.checked })} /> 收到單後在客人留言上按 😄，讓他知道收到了
             </label>
-            <label className="text-sm md:col-span-2">發文模板（留空用預設；可用 {"{{name}} {{description}} {{items}} {{end_at}} {{pickup_deadline}}"}）
+            <label className="text-sm md:col-span-2">發文模板（留空用預設；可用 {"{{title}} {{items}} {{description}} {{howto}} {{tag}} {{name}} {{end_at}} {{pickup_deadline}}"}）
               <textarea className={`${input} h-40 font-mono text-xs`} value={form.post_template} onChange={(e) => setForm({ ...form, post_template: e.target.value })}
-                placeholder={"📣 {{name}}\n{{description}}\n\n{{items}}\n\n⏰ 收單：{{end_at}}\n📝 留言「會員編號 6 碼 ＋ A+1」"} />
+                placeholder={"{{title}}\n\n{{items}}\n\n{{description}}\n\n{{howto}}\n#開團\n{{tag}}"} />
             </label>
           </div>
           <div className="mt-4 flex justify-end gap-2">

--- a/apps/admin/src/components/LineNotePostsModal.tsx
+++ b/apps/admin/src/components/LineNotePostsModal.tsx
@@ -94,7 +94,7 @@ export default function LineNotePostsModal({
   // 預覽：worker 那一份 renderTemplate 渲染出來的「等一下真的會貼出去的字」。
   // 模板是掛在社群上的，所以預覽要指定看哪個群組的。
   const [previewFor, setPreviewFor] = useState<number | null>(null);
-  const [preview, setPreview] = useState<{ text: string; images: string[]; deco?: number } | null>(null);
+  const [preview, setPreview] = useState<{ text: string; images: string[] } | null>(null);
   const [previewing, setPreviewing] = useState(false);
 
   // 爬回來的留言（點貼文展開）
@@ -144,7 +144,7 @@ export default function LineNotePostsModal({
       if (dead) return;
       setPreviewing(false);
       if (error || (data as { error?: string })?.error) return;   // 預覽拿不到不擋發文
-      setPreview(data as { text: string; images: string[]; deco?: number });
+      setPreview(data as { text: string; images: string[] });
     })();
     return () => { dead = true; };
   }, [open, campaignId, previewFor, canOperate]);
@@ -349,7 +349,6 @@ export default function LineNotePostsModal({
                 <p className="mt-1 text-xs text-zinc-500">
                   文案取自這個團的說明、商品與價格取自團裡的品項、圖片取自商品圖。要改內容請去改團／商品。
                   文末的「🔖 團號」是給系統認的章，爬回來時靠它認出是哪一團。
-                  {!!preview?.deco && <>　金額會用 LINE 的彩色數字表情貼出去（這裡先用一般數字顯示）。</>}
                 </p>
               </div>
 

--- a/supabase/functions/_shared/lineNote.ts
+++ b/supabase/functions/_shared/lineNote.ts
@@ -385,7 +385,7 @@ export async function deleteNotePost(client, homeId, postId, { sourceType, verbo
   return res;
 }
 
-export async function createNotePost(client, homeId, { text, images = [], sticonMetas = [], sourceType, verbose = false } = {}) {
+export async function createNotePost(client, homeId, { text, images = [], sourceType, verbose = false } = {}) {
   if (!text && images.length === 0) throw new Error("貼文至少要有文字或圖片");
 
   // 圖片上傳走 obs.line-apps.com（linejs 的 uploadNoteMedia），失敗就只發文字，
@@ -425,21 +425,10 @@ export async function createNotePost(client, homeId, { text, images = [], sticon
       locations: [],
       media,
       ...(text ? { text } : {}),
-      // LINE 裝飾表情（金額那種彩色數字）：text 裡放 (x) 佔位字，這裡給每個佔位字的位移與圖號
-      ...(sticonMetas?.length ? { sticonMetas } : {}),
     },
   };
-  const params = { homeId, sourceType: sourceType ?? "TALKROOM" };
-  let res = await noteRequest(client, homeId, "/api/v57/post/create.json", { ...params }, { method: "POST", body, verbose });
-
-  // 裝飾表情是加分項，不能因為它讓整篇發不出去：被打槍就把佔位字還原成純文字重發一次
-  if ((!res || res.code !== 0) && sticonMetas?.length) {
-    log(true, `帶裝飾表情發文被退（code=${res?.code}），改用純文字重試`);
-    const plain = { ...body, contents: { ...body.contents, text: text.replace(/\((\$|[0-9])\)/g, "$1") } };
-    delete plain.contents.sticonMetas;
-    res = await noteRequest(client, homeId, "/api/v57/post/create.json", { ...params }, { method: "POST", body: plain, verbose });
-  }
-
+  const res = await noteRequest(client, homeId, "/api/v57/post/create.json",
+    { homeId, sourceType: sourceType ?? "TALKROOM" }, { method: "POST", body, verbose });
   log(verbose, "createPost →", JSON.stringify(res).slice(0, 500));
   if (!res || res.code !== 0) {
     throw new Error(`發文失敗：code=${res?.code} ${res?.message ?? ""}\n${JSON.stringify(res).slice(0, 800)}`);

--- a/supabase/functions/_shared/lineNoteDeco.test.ts
+++ b/supabase/functions/_shared/lineNoteDeco.test.ts
@@ -1,0 +1,35 @@
+import { applyDeco, decoPrice, decoStandalonePrices, htmlToText, stripLineDeco } from "./lineNoteDeco.ts";
+
+const eq = (got: unknown, want: unknown, why: string) => {
+  if (got !== want) throw new Error(`${why}\n  想要 ${JSON.stringify(want)}\n  拿到 ${JSON.stringify(got)}`);
+};
+
+Deno.test("標記過的金額換成 💲＋鍵帽數字，沒標記的一個字不動", () => {
+  eq(applyDeco(`一份 ${decoPrice("$120")}`), "一份 💲1️⃣2️⃣0️⃣", "基本");
+  eq(applyDeco(`${decoPrice("$30")}（市價$150/盒）`), "💲3️⃣0️⃣（市價$150/盒）", "行內市價維持純文字");
+  eq(applyDeco(decoPrice("$99.5")), "💲9️⃣9️⃣.5️⃣", "小數點原樣留著");
+  eq(applyDeco("沒標記 $88"), "沒標記 $88", "沒標記就原樣");
+});
+
+Deno.test("文案裡自己獨立一行的 $數字才標起來", () => {
+  const out = applyDeco(decoStandalonePrices("好兄弟組合10包\n$109\n一盒$85\n（市價$150/盒）"));
+  eq(out, "好兄弟組合10包\n💲1️⃣0️⃣9️⃣\n一盒$85\n（市價$150/盒）", "只動獨立一行的");
+});
+
+Deno.test("富文字 HTML 轉純文字：段落換行、粗體拿掉、實體字元還原", () => {
+  eq(htmlToText("<p>測試</p><p></p><p><strong>$100</strong></p>"), "測試\n\n$100", "段落＋空段落＋粗體");
+  eq(htmlToText("<p>A. 原味 💰195<br>B. 辣味 💰205</p><p>📦15-25天貨到通知</p>"), "A. 原味 💰195\nB. 辣味 💰205\n📦15-25天貨到通知", "<br> 換行");
+  eq(htmlToText("<ul><li><p>甲</p></li><li><p>乙</p></li></ul>"), "• 甲\n• 乙", "清單項目");
+  eq(htmlToText("<p>Tom&nbsp;&amp;&nbsp;Jerry &lt;3 &amp;lt;</p>"), "Tom & Jerry <3 &lt;", "實體字元，&amp; 最後才還原");
+  eq(htmlToText("純文字 <3 沒有標籤\n第二行"), "純文字 <3 沒有標籤\n第二行", "不像 HTML 的原樣回傳");
+});
+
+Deno.test("HTML 說明裡獨立一行的粗體金額，轉完會被凸顯", () => {
+  const text = applyDeco(decoStandalonePrices(htmlToText("<p>測試</p><p><strong>$100</strong></p>")));
+  eq(text, "測試\n💲1️⃣0️⃣0️⃣", "整條管線");
+});
+
+Deno.test("記事本抓回來的佔位字：金額還原成 emoji、日期還原成純文字、貼圖拿掉", () => {
+  const out = applyDeco(stripLineDeco("一個($)(1)(2)(5)\n(emoji)15-25天貨到通知\n(9)(/)(9)(emoji)(emoji)"));
+  eq(out, "一個💲1️⃣2️⃣5️⃣\n15-25天貨到通知\n9/9", "行內金額也凸顯，日期不動");
+});

--- a/supabase/functions/_shared/lineNoteDeco.test.ts
+++ b/supabase/functions/_shared/lineNoteDeco.test.ts
@@ -1,4 +1,4 @@
-import { applyDeco, decoPrice, decoStandalonePrices, htmlToText, stripLineDeco } from "./lineNoteDeco.ts";
+import { applyDeco, decoPrice, decoTextPrices, htmlToText, stripLineDeco } from "./lineNoteDeco.ts";
 
 const eq = (got: unknown, want: unknown, why: string) => {
   if (got !== want) throw new Error(`${why}\n  想要 ${JSON.stringify(want)}\n  拿到 ${JSON.stringify(got)}`);
@@ -11,9 +11,11 @@ Deno.test("標記過的金額換成 💲＋鍵帽數字，沒標記的一個字�
   eq(applyDeco("沒標記 $88"), "沒標記 $88", "沒標記就原樣");
 });
 
-Deno.test("文案裡自己獨立一行的 $數字才標起來", () => {
-  const out = applyDeco(decoStandalonePrices("好兄弟組合10包\n$109\n一盒$85\n（市價$150/盒）"));
+Deno.test("文案裡自己獨立一行的 $數字、💰 後面的數字才標起來", () => {
+  const out = applyDeco(decoTextPrices("好兄弟組合10包\n$109\n一盒$85\n（市價$150/盒）"));
   eq(out, "好兄弟組合10包\n💲1️⃣0️⃣9️⃣\n一盒$85\n（市價$150/盒）", "只動獨立一行的");
+  const bag = applyDeco(decoTextPrices("A. 原味 💰195\n💰 一盒 $275\n💰一包99元\n💰滿1000免運"));
+  eq(bag, "A. 原味 💰1️⃣9️⃣5️⃣\n💰 一盒 💲2️⃣7️⃣5️⃣\n💰一包9️⃣9️⃣元\n💰滿1️⃣0️⃣0️⃣0️⃣免運", "錢袋後面的數字");
 });
 
 Deno.test("富文字 HTML 轉純文字：段落換行、粗體拿掉、實體字元還原", () => {
@@ -25,7 +27,7 @@ Deno.test("富文字 HTML 轉純文字：段落換行、粗體拿掉、實體字
 });
 
 Deno.test("HTML 說明裡獨立一行的粗體金額，轉完會被凸顯", () => {
-  const text = applyDeco(decoStandalonePrices(htmlToText("<p>測試</p><p><strong>$100</strong></p>")));
+  const text = applyDeco(decoTextPrices(htmlToText("<p>測試</p><p><strong>$100</strong></p>")));
   eq(text, "測試\n💲1️⃣0️⃣0️⃣", "整條管線");
 });
 

--- a/supabase/functions/_shared/lineNoteDeco.ts
+++ b/supabase/functions/_shared/lineNoteDeco.ts
@@ -1,61 +1,88 @@
 // @ts-nocheck
 // ─────────────────────────────────────────────────────────────────────────────
-// LINE 裝飾表情（deco emoji / sticon）
+// 貼文文字的整理與金額凸顯
 //
-// 小幫手手貼的貼文，金額是用 LINE 的數字表情打的（截圖那種彩色的 $ 7 9），
-// 不是純文字。它在 API 上長這樣：
-//   contents.text          "一份($)(7)(9)"      ← 每個表情佔一個 (x) 佔位字
-//   contents.sticonMetas   [{S,E,productId,sticonId,version,resourceType}, …]
-// S / E 是**UTF-16 位移**（JS 字串的原生索引），指向 text 裡那段佔位字。
+// 金額用 emoji 數字凸顯：$120 → 💲1️⃣2️⃣0️⃣（鍵帽數字 = 數字 + U+FE0F + U+20E3）。
 //
-// 下面的對照表不是猜的，是把松山社群 60 篇貼文的 sticonMetas 撈回來統計出來的
-// （1,125 筆）。注意 0 是 062 不是 052 —— 1~9 連號到 061 之後才輪到 0。
+// 原本（#938）想照小幫手手貼的樣子用 LINE 的裝飾表情（contents.sticonMetas），
+// 帶著發出去，社群裡看到的還是普通數字（2026-09-10 實測）——
+// 那是 LINE 客戶端自己的貼圖管線，從外面打 API 模擬不出來、也沒辦法驗證。
+// 所以改用哪台手機都畫得出來的 Unicode emoji；預覽跟存進 DB 的就是貼出去的那份字。
+//
+// 只裝飾我們自己標記的段落（decoPrice 包起來的）；文案裡「（市價$150/盒）」那種一個字不動。
 // ─────────────────────────────────────────────────────────────────────────────
 
-// 金額（會動的那組，小幫手都用這個打價格）
-const PRICE = {
-  productId: "61f5f6d3e023eb1687b8e333",
-  version: 2,
-  resourceType: "ANIMATION",
-  map: {
-    "$": "068",
-    "1": "053", "2": "054", "3": "055", "4": "056", "5": "057",
-    "6": "058", "7": "059", "8": "060", "9": "061", "0": "062",
-  },
-} as const;
+const EMOJI: Record<string, string> = { "$": "💲" };
+for (const d of "0123456789") EMOJI[d] = `${d}️⃣`;
 
-// 用私有區的字當標記：渲染時把要裝飾的段落包起來，最後一次換成佔位字＋metas。
-// 這樣才只動我們自己產的那幾行，不會去改店家寫在文案裡的「（市價$150/盒）」。
-export const DECO_OPEN = "";
-export const DECO_CLOSE = "";
+// 用私有區的字當標記：渲染時把要裝飾的段落包起來，最後一次換成 emoji。
+export const DECO_OPEN = "\uE000";
+export const DECO_CLOSE = "\uE001";
 
 export function decoPrice(s: string) {
   return `${DECO_OPEN}${s}${DECO_CLOSE}`;
 }
 
-// 把標記過的段落換成 LINE 看得懂的 (x) 佔位字 + sticonMetas。
-// 表裡沒有的字（例如小數點）原樣留著，不會消失。
-export function applyDeco(raw: string): { text: string; sticonMetas: any[] } {
-  const metas: any[] = [];
+// 把標記過的段落換成 emoji；表裡沒有的字（例如小數點）原樣留著，不會消失。
+export function applyDeco(raw: string): string {
   let out = "";
   let deco = false;
   for (const ch of String(raw ?? "")) {
     if (ch === DECO_OPEN) { deco = true; continue; }
     if (ch === DECO_CLOSE) { deco = false; continue; }
-    const sticonId = deco ? (PRICE.map as Record<string, string>)[ch] : undefined;
-    if (!sticonId) { out += ch; continue; }
-    const S = out.length;                       // out 是 JS 字串 → 本來就是 UTF-16 位移
-    out += `(${ch})`;
-    metas.push({
-      S: String(S), E: String(out.length),
-      productId: PRICE.productId, sticonId,
-      version: PRICE.version, resourceType: PRICE.resourceType,
-    });
+    out += deco ? (EMOJI[ch] ?? ch) : ch;
   }
-  return { text: out, sticonMetas: metas };
+  return out;
 }
 
-// 預覽 / 存檔用：把標記拿掉，留下人看得懂的 "$79"
-export function stripDeco(raw: string) {
-  return String(raw ?? "").replaceAll(DECO_OPEN, "").replaceAll(DECO_CLOSE, "");
+// 文案裡「自己獨立一行的 $數字」也是價格（匯進來的團，品項與價格都寫在 description 裡），
+// 一併凸顯。行內的「（市價$150/盒）」不動 —— 那不是這團的售價。
+export function decoStandalonePrices(text: string) {
+  return String(text ?? "").split("\n")
+    .map((line) => /^\s*\$\d+\s*$/.test(line) && !line.includes(DECO_OPEN)
+      ? line.replace(/\$\d+/, (m) => decoPrice(m))
+      : line)
+    .join("\n");
+}
+
+// 團說明是富文字編輯器（TipTap）存的 HTML —— 線上 132 團、近兩個月 87 團都是
+// 「<p>…</p><p><strong>$100</strong></p>」這種。原樣貼出去，客人在 LINE 上看到的就是
+// 一串 <p><strong>。轉成純文字：換行照 <br> 與段落結尾、清單項目前面補「• 」、
+// 其他標籤全拿掉、實體字元還原。不像 HTML 的字串原樣回傳（沒有標籤就不碰，
+// 免得把文案裡的「<3」之類吃掉）。
+export function htmlToText(s: string) {
+  const t = String(s ?? "");
+  if (!/<[a-z][^>]*>/i.test(t)) return t;
+  return t
+    .replace(/\r?\n/g, "")                                  // 編輯器不靠換行字元排版
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>\s*<\/li>/gi, "\n")                     // <li><p>…</p></li> 只算一個換行
+    .replace(/<\/(p|div|h[1-6]|li|blockquote|pre|tr)>/gi, "\n")
+    .replace(/<li[^>]*>/gi, "• ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, "\"")
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&amp;/gi, "&")                                // 最後才還原 &，不然 &amp;lt; 會被拆兩次
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+// 從記事本抓回來的舊文會帶 LINE 裝飾表情的佔位字：($)(3)(5) = $35、(9)(/)(9) = 9/9、
+// (emoji) = 一個貼圖。原樣貼出去客人會看到一串「($)(3)(5)」，所以還原成看得懂的字。
+// 帶 ($) 的那段原文就是小幫手用彩色數字打的金額 → 順手標起來，貼出去一樣是凸顯的
+// （「一個($)(1)(2)(5)」寫在行內，獨立一行的規則抓不到它）。日期那種沒有 $ 的維持純文字。
+export function stripLineDeco(s: string) {
+  return String(s ?? "")
+    .replace(/(?:\((?:\$|[0-9]|\/)\)){2,}/g, (m) => {
+      const plain = m.replace(/[()]/g, "");
+      return m.includes("($)") ? decoPrice(plain) : plain;
+    })
+    .replace(/\((?:emoji|好吃|讚|哭|笑|愛心)\)/g, "")
+    .replace(/[ \t]+\n/g, "\n");
 }

--- a/supabase/functions/_shared/lineNoteDeco.ts
+++ b/supabase/functions/_shared/lineNoteDeco.ts
@@ -35,13 +35,17 @@ export function applyDeco(raw: string): string {
   return out;
 }
 
-// 文案裡「自己獨立一行的 $數字」也是價格（匯進來的團，品項與價格都寫在 description 裡），
-// 一併凸顯。行內的「（市價$150/盒）」不動 —— 那不是這團的售價。
-export function decoStandalonePrices(text: string) {
+// 文案裡自己寫的價格也一併凸顯（匯進來的團、富文字說明，品項與價格都寫在 description 裡）：
+// - 自己獨立一行的「$109」
+// - 小幫手的錢袋寫法「💰195」「💰 一盒 $275」「💰一包99元」→ 💰 後面那個數字
+// 行內的「（市價$150/盒）」不動 —— 那不是這團的售價。已經標過的行不再標。
+export function decoTextPrices(text: string) {
   return String(text ?? "").split("\n")
-    .map((line) => /^\s*\$\d+\s*$/.test(line) && !line.includes(DECO_OPEN)
-      ? line.replace(/\$\d+/, (m) => decoPrice(m))
-      : line)
+    .map((line) => {
+      if (line.includes(DECO_OPEN)) return line;
+      if (/^\s*\$\d+\s*$/.test(line)) return line.replace(/\$\d+/, (m) => decoPrice(m));
+      return line.replace(/💰([^\d\n$💰]{0,6})(\$?\d+)/g, (_, gap, price) => `💰${gap}${decoPrice(price)}`);
+    })
     .join("\n");
 }
 

--- a/supabase/functions/_shared/lineNoteRender.test.ts
+++ b/supabase/functions/_shared/lineNoteRender.test.ts
@@ -1,0 +1,61 @@
+import { renderPostText } from "./lineNoteRender.ts";
+
+const eq = (got: unknown, want: unknown, why: string) => {
+  if (got !== want) throw new Error(`${why}\n  想要 ${JSON.stringify(want)}\n  拿到 ${JSON.stringify(got)}`);
+};
+const HOWTO_MULTI = "📝 留言「會員編號 6 碼 ＋ 品項代碼＋數量」，例：123456 A+1 B+2";
+const HOWTO_SINGLE = "📝 留言「會員編號 6 碼 ＋ 數量」，例：123456 +1";
+const tag = "🔖 團號 GRP-1";
+const payload = (campaign: Record<string, unknown>, items: Record<string, unknown>[], post_template: string | null = null) =>
+  ({ post_template, campaign: { campaign_no: "GRP-1", end_at: "2026-09-13T15:59:00Z", ...campaign }, items });
+
+Deno.test("預設版型：先團名、再金額、再文案；單品不印品名，結單時間不印", () => {
+  const text = renderPostText(payload({ name: "梨山高麗菜", description: "包子媽朋友自己種的" }, [{ code: "A", name: "梨山高麗菜 (A) 半顆", unit_price: 69 }]));
+  eq(text, `梨山高麗菜\n\n💲6️⃣9️⃣\n\n包子媽朋友自己種的\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品");
+});
+
+Deno.test("多品項才列 (A) 品名 ＋ 下一行金額，教學帶代碼", () => {
+  const text = renderPostText(payload({ name: "所長茶葉蛋", description: "超入味" },
+    [{ code: "A", name: "所長茶葉蛋 (A) 原味", unit_price: 195 }, { code: "B", name: "所長茶葉蛋 (B) 辣味", unit_price: 205 }]));
+  eq(text, `所長茶葉蛋\n\n(A) 原味\n💲1️⃣9️⃣5️⃣\n(B) 辣味\n💲2️⃣0️⃣5️⃣\n\n超入味\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "多品項");
+});
+
+Deno.test("文案第一行就是團名 → 搬到最上面當標題（留住表情符號），不印兩次", () => {
+  const text = renderPostText(payload({ name: "所長茶葉蛋", description: "<p>⭐️ <strong>所長茶葉蛋</strong></p><p>超入味</p>" },
+    [{ code: "A", name: "原味", unit_price: 195 }]));
+  eq(text, `⭐️ 所長茶葉蛋\n\n💲1️⃣9️⃣5️⃣\n\n超入味\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "標題搬上去、HTML 也轉好");
+});
+
+Deno.test("記事本匯進來的單品文案已經寫了同一個金額 → 不再多印一行", () => {
+  const text = renderPostText(payload({ name: "梨山高麗菜", description: "梨山高麗菜\n半顆($)(6)(9)\n(emoji)9/9到貨" }, [{ code: "A", name: "半顆", unit_price: 69 }]));
+  eq(text, `梨山高麗菜\n\n半顆💲6️⃣9️⃣\n9/9到貨\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "金額只出現一次");
+  const diff = renderPostText(payload({ name: "梨山高麗菜", description: "梨山高麗菜\n半顆($)(6)(9)" }, [{ code: "A", name: "半顆", unit_price: 75 }]));
+  eq(diff.includes("💲7️⃣5️⃣") && diff.includes("半顆💲6️⃣9️⃣"), true, "金額不一樣就兩個都印，讓人看得出來要改");
+});
+
+Deno.test("文案自己列了 (A)(B) 品項 → 商品段留空", () => {
+  const text = renderPostText(payload({ name: "阿土伯", description: "阿土伯\n(A)空心菜\n($)(3)(5)\n(B)小白菜\n($)(3)(5)" },
+    [{ code: "A", name: "空心菜", unit_price: 35 }, { code: "B", name: "小白菜", unit_price: 35 }]));
+  eq(text, `阿土伯\n\n(A)空心菜\n💲3️⃣5️⃣\n(B)小白菜\n💲3️⃣5️⃣\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "不重複列品項");
+});
+
+Deno.test("自訂模板：{{deadline}} / {{end_at}} 照舊可用，沒寫 {{tag}} 也會補章", () => {
+  const text = renderPostText(payload({ name: "測試", description: "" }, [{ code: "A", name: "x", unit_price: 100 }], "{{name}}\n{{items}}\n{{deadline}}"));
+  eq(text, `測試\n💲1️⃣0️⃣0️⃣\n⏰ 9/13 23:59 結單\n${tag}`, "自訂模板");
+});
+
+Deno.test("文案用 A. B. 列品項（品名裡也帶 A.）→ 商品段留空，💰 價格照樣凸顯；口號在前、品名在第二行也認得出標題", () => {
+  const text = renderPostText(payload({ name: "所長茶葉蛋", description: "<p>買一送一！</p><p>⭐️ <strong>所長茶葉蛋</strong></p><p>A. 經典原味 💰195<br>B. 麻香辣味 💰205</p>" },
+    [{ code: "A", name: "A. 經典原味", unit_price: 195 }, { code: "B", name: "B. 麻香辣味", unit_price: 205 }]));
+  eq(text, `⭐️ 所長茶葉蛋\n\n買一送一！\nA. 經典原味 💰1️⃣9️⃣5️⃣\nB. 麻香辣味 💰2️⃣0️⃣5️⃣\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "A. 列表");
+  const own = renderPostText(payload({ name: "所長茶葉蛋", description: "超入味" }, [{ code: "A", name: "A. 經典原味", unit_price: 195 }, { code: "B", name: "B. 麻香辣味", unit_price: 205 }]));
+  eq(own.includes("(A) 經典原味\n💲1️⃣9️⃣5️⃣\n(B) 麻香辣味"), true, "品名裡的 A. 不印兩次");
+});
+
+Deno.test("金額一律用零售價；沒設零售價（NULL / 0）才退回團購價", () => {
+  const text = renderPostText(payload({ name: "港點", description: "好吃" },
+    [{ code: "A", name: "蝦餃", unit_price: 168, retail_price: 249 }, { code: "B", name: "燒賣", unit_price: 69, retail_price: 0 }, { code: "C", name: "腸粉", unit_price: 88 }]));
+  eq(text.includes("(A) 蝦餃\n💲2️⃣4️⃣9️⃣\n(B) 燒賣\n💲6️⃣9️⃣\n(C) 腸粉\n💲8️⃣8️⃣"), true, "零售價優先");
+  const single = renderPostText(payload({ name: "高麗菜", description: "高麗菜\n半顆($)(6)(9)" }, [{ code: "A", name: "半顆", unit_price: 60, retail_price: 69 }]));
+  eq(single, `高麗菜\n\n半顆💲6️⃣9️⃣\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品去重也是拿零售價比");
+});

--- a/supabase/functions/_shared/lineNoteRender.test.ts
+++ b/supabase/functions/_shared/lineNoteRender.test.ts
@@ -59,3 +59,11 @@ Deno.test("金額一律用零售價；沒設零售價（NULL / 0）才退回團�
   const single = renderPostText(payload({ name: "高麗菜", description: "高麗菜\n半顆($)(6)(9)" }, [{ code: "A", name: "半顆", unit_price: 60, retail_price: 69 }]));
   eq(single, `高麗菜\n\n半顆💲6️⃣9️⃣\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品去重也是拿零售價比");
 });
+
+Deno.test("{{deadline}} / {{end_at}} 印客人收單；沒設客人收單就印店家收單", () => {
+  const tpl = "{{name}}\n{{deadline}}\n{{end_at}}";
+  const both = renderPostText(payload({ name: "測試", description: "", customer_end_at: "2026-09-12T10:00:00Z" }, [{ code: "A", name: "x", unit_price: 1 }], tpl));
+  eq(both, `測試\n⏰ 9/12 18:00 結單\n9/12 18:00\n${tag}`, "客人收單優先");
+  const only = renderPostText(payload({ name: "測試", description: "" }, [{ code: "A", name: "x", unit_price: 1 }], tpl));
+  eq(only, `測試\n⏰ 9/13 23:59 結單\n9/13 23:59\n${tag}`, "退回店家收單");
+});

--- a/supabase/functions/_shared/lineNoteRender.ts
+++ b/supabase/functions/_shared/lineNoteRender.ts
@@ -1,0 +1,134 @@
+// @ts-nocheck
+// ─────────────────────────────────────────────────────────────────────────────
+// 開團貼文的版型渲染（預覽、發文、存 DB 三邊都走這一份）
+//
+// 版型照小幫手手貼的樣子：團名開頭、接著金額、再來才是文案，#開團 收尾。
+// 2026-09-10 老闆指定：先團名、再商品；只有一個品項就不印品名／代碼、直接金額；
+// 多品項才 (A) 品名 ＋ 下一行金額；結單時間不印。
+//
+// 文案本體吃 campaign.description —— 那本來就是商品那邊寫好的行銷文（線上近兩週 377/395 團有）。
+// {{title}} / {{items}} / {{deadline}} / {{howto}} 是「聰明版」：文案自己已經寫過的就不再重複一次。
+// 從記事本匯進來的團，description 常常就是整篇貼文（標題＋(A)(B)品項＋⏰結單都在裡面），
+// 照樣接上去會變成品項印兩次、結單寫兩行。
+// {{name}} / {{end_at}} 維持原樣（照印），自訂模板的行為不變。
+// {{tag}} 是團號章（🔖 團號 GRP-…）：爬回來的時候靠它精準認出是哪一團，不用猜團名。
+// 自訂模板沒寫 {{tag}} 也會被 withPostTag 補在文末 —— 章一定要有，不然這篇就只能靠猜。
+// ─────────────────────────────────────────────────────────────────────────────
+import { buildPostTag, withPostTag } from "./lineNoteParse.ts";
+import { applyDeco, DECO_CLOSE, DECO_OPEN, decoPrice, decoTextPrices, htmlToText, stripLineDeco } from "./lineNoteDeco.ts";
+
+export const TZ = "Asia/Taipei";
+
+export const DEFAULT_TEMPLATE = `{{title}}
+
+{{items}}
+
+{{description}}
+
+{{howto}}
+#開團
+{{tag}}`;
+
+// 留言教學：單品的貼文上沒有代碼，教學就不要提代碼（+1 沒帶代碼時 RPC 會落到唯一那一項）
+const HOWTO_MULTI = "📝 留言「會員編號 6 碼 ＋ 品項代碼＋數量」，例：123456 A+1 B+2";
+const HOWTO_SINGLE = "📝 留言「會員編號 6 碼 ＋ 數量」，例：123456 +1";
+
+// 比對標題用：去掉表情符號、空白、標點，只留文字
+function bareText(s: string) {
+  return String(s ?? "").normalize("NFKC").toLowerCase()
+    .replace(/[\s\p{P}\p{S}\p{M}\p{C}]/gu, "");   // \p{M}/\p{C} 要一起拿掉：emoji 後面的 VS16、ZWJ 都藏在那裡
+}
+
+// 品項名在 DB 裡是「團名 (A) 空心菜200g」，直接印會變成「(A) 團名 (A) 空心菜200g」。
+// 去掉團名前綴和重複的代碼（「(A) 」「A. 」「A、」都算），只留真正的品名。
+function itemLabel(name: string, code: string, campaignName: string) {
+  let t = String(name ?? "").trim();
+  const cn = String(campaignName ?? "").trim();
+  if (cn && t.startsWith(cn)) t = t.slice(cn.length).trim();
+  t = t.replace(new RegExp(`^(?:[(（]${code}[)）]|${code}[.．、:：])\\s*`), "").trim();
+  return t || String(name ?? "").trim();
+}
+
+function fmtTaipei(iso: string | null | undefined) {
+  if (!iso) return "";
+  const p = new Intl.DateTimeFormat("zh-TW", { timeZone: TZ, month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: false }).formatToParts(new Date(iso));
+  const g = (t: string) => p.find((x) => x.type === t)?.value ?? "";
+  return `${g("month")}/${g("day")} ${g("hour")}:${g("minute")}`;
+}
+
+// 貼文的金額一律用零售價（老闆 2026-09-10 交代）：unit_price 是團購價、開團後可以另外改低，
+// 社群貼文要的是現行零售價（payload 的 retail_price，20260910040000）。沒設零售價（NULL / 0）才退回團購價。
+function postPrice(it: any): number | null {
+  const retail = Number(it?.retail_price);
+  if (Number.isFinite(retail) && retail > 0) return retail;
+  return it?.unit_price == null ? null : Number(it.unit_price);
+}
+
+// 文案裡已經標起來的金額（記事本佔位字還原的、獨立一行的 $數字、💰 後面的數字）
+function decoPricesIn(desc: string): number[] {
+  return [...desc.matchAll(new RegExp(`${DECO_OPEN}\\$?(\\d+(?:\\.\\d+)?)${DECO_CLOSE}`, "g"))].map((m) => Number(m[1]));
+}
+
+export function renderTemplate(template: string | null, payload: any) {
+  const c = payload.campaign ?? {};
+  const items = payload.items ?? [];
+  const single = items.length === 1;
+
+  // 文案：富文字 HTML 轉純文字 → 記事本佔位字還原（金額順手標起來）→ 文案自己寫的價格也標起來
+  let desc = decoTextPrices(stripLineDeco(htmlToText(c.description ?? "")));
+
+  // 文案開頭幾行裡有一行就是團名（匯進來的團幾乎都是第一行，也有先喊一句口號再寫品名的）
+  // → 那一行搬到最上面當標題，不要印兩次。用文案的那一行而不是 c.name，
+  // 小幫手打在標題上的表情符號才留得住。太短的行只認完全一樣，免得誤中。
+  let title = c.name ?? "";
+  const bareName = bareText(c.name ?? "");
+  const lines = desc.split("\n");
+  let seen = 0;
+  for (let i = 0; i < lines.length && seen < 3; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    seen++;
+    const bare = bareText(line);
+    const hit = bareName && (bare === bareName || (bare.length >= 4 && (bareName.includes(bare) || bare.includes(bareName))));
+    if (!hit) continue;
+    title = line;
+    lines.splice(i, 1);
+    desc = lines.join("\n").replace(/^\n+/, "");
+    break;
+  }
+
+  // 商品：只有一項 → 直接金額（沒有品名、沒有代碼）；多項 → (A) 品名 ＋ 下一行金額
+  const itemLines = items.map((it: any) => {
+    const p = postPrice(it);
+    const price = p == null ? "" : decoPrice(`$${p}`);
+    if (single) return price;
+    const label = itemLabel(it.name, it.code, c.name);
+    return `(${it.code}) ${label}${price ? `\n${price}` : ""}`;
+  }).filter(Boolean).join("\n");
+  // 文案自己就列了 (A)(B) 或 A. B. 品項 → 不重複；單品而文案已經寫了同一個金額（「一個$125」）→ 也不重複
+  const descHasItems = /(^|\n)\s*(?:[(（][A-Za-z][)）]|[A-Za-z][.．、:：])/.test(desc);
+  const descHasThisPrice = single && postPrice(items[0]) != null && decoPricesIn(desc).includes(postPrice(items[0]));
+  const descHasDeadline = /結單|收單|截單/.test(desc);
+  const deadline = c.end_at ? `⏰ ${fmtTaipei(c.end_at)} 結單` : "";
+
+  const rendered = (template || DEFAULT_TEMPLATE)
+    .replaceAll("{{tag}}", buildPostTag(c.campaign_no))
+    .replaceAll("{{title}}", title)
+    .replaceAll("{{items}}", descHasItems || descHasThisPrice ? "" : itemLines)
+    .replaceAll("{{deadline}}", descHasDeadline ? "" : deadline)
+    .replaceAll("{{howto}}", single ? HOWTO_SINGLE : HOWTO_MULTI)
+    .replaceAll("{{name}}", c.name ?? "")
+    .replaceAll("{{campaign_no}}", c.campaign_no ?? "")
+    .replaceAll("{{description}}", desc)
+    .replaceAll("{{end_at}}", fmtTaipei(c.end_at))
+    .replaceAll("{{start_at}}", fmtTaipei(c.start_at))
+    .replaceAll("{{pickup_deadline}}", fmtTaipei(c.pickup_deadline))
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return withPostTag(rendered, c.campaign_no);
+}
+
+// 真的會貼出去的字：版型渲染完，把標起來的金額換成 emoji。
+export function renderPostText(payload: any) {
+  return applyDeco(renderTemplate(payload.post_template, payload));
+}

--- a/supabase/functions/_shared/lineNoteRender.ts
+++ b/supabase/functions/_shared/lineNoteRender.ts
@@ -10,7 +10,7 @@
 // {{title}} / {{items}} / {{deadline}} / {{howto}} 是「聰明版」：文案自己已經寫過的就不再重複一次。
 // 從記事本匯進來的團，description 常常就是整篇貼文（標題＋(A)(B)品項＋⏰結單都在裡面），
 // 照樣接上去會變成品項印兩次、結單寫兩行。
-// {{name}} / {{end_at}} 維持原樣（照印），自訂模板的行為不變。
+// {{name}} 維持原樣（照印）；{{end_at}} / {{deadline}} 印的是客人看的結單時間（客人收單，沒設就是店家收單）。
 // {{tag}} 是團號章（🔖 團號 GRP-…）：爬回來的時候靠它精準認出是哪一團，不用猜團名。
 // 自訂模板沒寫 {{tag}} 也會被 withPostTag 補在文末 —— 章一定要有，不然這篇就只能靠猜。
 // ─────────────────────────────────────────────────────────────────────────────
@@ -47,6 +47,12 @@ function itemLabel(name: string, code: string, campaignName: string) {
   if (cn && t.startsWith(cn)) t = t.slice(cn.length).trim();
   t = t.replace(new RegExp(`^(?:[(（]${code}[)）]|${code}[.．、:：])\\s*`), "").trim();
   return t || String(name ?? "").trim();
+}
+
+function earliest(a: string | null | undefined, b: string | null | undefined): string | null {
+  if (!a) return b ?? null;
+  if (!b) return a;
+  return new Date(a).getTime() <= new Date(b).getTime() ? a : b;
 }
 
 function fmtTaipei(iso: string | null | undefined) {
@@ -109,7 +115,10 @@ export function renderTemplate(template: string | null, payload: any) {
   const descHasItems = /(^|\n)\s*(?:[(（][A-Za-z][)）]|[A-Za-z][.．、:：])/.test(desc);
   const descHasThisPrice = single && postPrice(items[0]) != null && decoPricesIn(desc).includes(postPrice(items[0]));
   const descHasDeadline = /結單|收單|截單/.test(desc);
-  const deadline = c.end_at ? `⏰ ${fmtTaipei(c.end_at)} 結單` : "";
+  // 客人看的結單時間 = 客人收單（customer_end_at，20260910050000）跟店家收單取早的那個；
+  // 客人收單沒設就是店家收單。預設版型不印，自訂模板的 {{deadline}} / {{end_at}} 才會用到。
+  const closeAt = earliest(c.customer_end_at, c.end_at);
+  const deadline = closeAt ? `⏰ ${fmtTaipei(closeAt)} 結單` : "";
 
   const rendered = (template || DEFAULT_TEMPLATE)
     .replaceAll("{{tag}}", buildPostTag(c.campaign_no))
@@ -120,7 +129,7 @@ export function renderTemplate(template: string | null, payload: any) {
     .replaceAll("{{name}}", c.name ?? "")
     .replaceAll("{{campaign_no}}", c.campaign_no ?? "")
     .replaceAll("{{description}}", desc)
-    .replaceAll("{{end_at}}", fmtTaipei(c.end_at))
+    .replaceAll("{{end_at}}", fmtTaipei(closeAt))
     .replaceAll("{{start_at}}", fmtTaipei(c.start_at))
     .replaceAll("{{pickup_deadline}}", fmtTaipei(c.pickup_deadline))
     .replace(/\n{3,}/g, "\n\n")

--- a/supabase/functions/line-note-worker/index.ts
+++ b/supabase/functions/line-note-worker/index.ts
@@ -27,14 +27,13 @@ import { corsHeaders } from "../_shared/cors.ts";
 import {
   clientFromToken, createNotePost, deleteNotePost, likeComment, listComments, listHomes, listPosts, loginByQr, whoami,
 } from "../_shared/lineNote.ts";
-import { buildPostTag, matchCampaign, parseNoteComment, postTitle, withPostTag } from "../_shared/lineNoteParse.ts";
-import { applyDeco, decoPrice, decoStandalonePrices, htmlToText, stripLineDeco } from "../_shared/lineNoteDeco.ts";
+import { matchCampaign, parseNoteComment, postTitle } from "../_shared/lineNoteParse.ts";
+import { renderPostText, TZ } from "../_shared/lineNoteRender.ts";
 
 const SUPABASE_URL = requireEnv("SUPABASE_URL");
 const SERVICE_KEY = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
 const CRON_SECRET = Deno.env.get("LINE_NOTE_CRON_SECRET") ?? "";
 const VERBOSE = !!Deno.env.get("VERBOSE");
-const TZ = "Asia/Taipei";
 const TICK_BUDGET_MS = Number(Deno.env.get("LINE_NOTE_TICK_BUDGET_MS") || 100_000);
 const LOGIN_DEADLINE_MS = Number(Deno.env.get("LINE_NOTE_LOGIN_DEADLINE_MS") || 110_000);
 const MAX_POST_IMAGES = Number(Deno.env.get("LINE_POST_MAX_IMAGES") || 10);
@@ -156,90 +155,6 @@ async function syncCommunities(accountId: number, homes: any[]) {
     log("社群同步失敗（略過，不影響列清單）:", (e as any)?.message ?? e);
     return null;
   }
-}
-
-// 版型照小幫手手貼的樣子：團名開頭、商品用 (A) 品名 ＋ 下一行價格、⏰ 結單、#開團 收尾。
-// 文案本體吃 campaign.description —— 那本來就是商品那邊寫好的行銷文（線上近兩週 377/395 團有）。
-// {{title}} / {{items}} / {{deadline}} 是「聰明版」：文案自己已經寫過的就不再重複一次。
-// 從記事本匯進來的團，description 常常就是整篇貼文（標題＋(A)(B)品項＋⏰結單都在裡面），
-// 照樣接上去會變成品項印兩次、結單寫兩行。
-// {{name}} / {{end_at}} 維持原樣（照印），自訂模板的行為不變。
-// {{tag}} 是團號章（🔖 團號 GRP-…）：爬回來的時候靠它精準認出是哪一團，不用猜團名。
-// 自訂模板沒寫 {{tag}} 也會被 withPostTag 補在文末 —— 章一定要有，不然這篇就只能靠猜。
-const DEFAULT_TEMPLATE = `{{title}}
-
-{{description}}
-
-{{items}}
-
-{{deadline}}
-📝 留言「會員編號 6 碼 ＋ 品項代碼＋數量」，例：123456 A+1 B+2
-#開團
-{{tag}}`;
-
-// 比對標題用：去掉表情符號、空白、標點，只留文字
-function bareText(s: string) {
-  return String(s ?? "").normalize("NFKC").toLowerCase()
-    .replace(/[\s\p{P}\p{S}\p{M}\p{C}]/gu, "");   // \p{M}/\p{C} 要一起拿掉：emoji 後面的 VS16、ZWJ 都藏在那裡
-}
-
-// 品項名在 DB 裡是「團名 (A) 空心菜200g」，直接印會變成「(A) 團名 (A) 空心菜200g」。
-// 去掉團名前綴和重複的代碼，只留真正的品名。
-function itemLabel(name: string, code: string, campaignName: string) {
-  let t = String(name ?? "").trim();
-  const cn = String(campaignName ?? "").trim();
-  if (cn && t.startsWith(cn)) t = t.slice(cn.length).trim();
-  t = t.replace(new RegExp(`^[(（]${code}[)）]\\s*`), "").trim();
-  return t || String(name ?? "").trim();
-}
-
-function fmtTaipei(iso: string | null | undefined) {
-  if (!iso) return "";
-  const p = new Intl.DateTimeFormat("zh-TW", { timeZone: TZ, month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: false }).formatToParts(new Date(iso));
-  const g = (t: string) => p.find((x) => x.type === t)?.value ?? "";
-  return `${g("month")}/${g("day")} ${g("hour")}:${g("minute")}`;
-}
-
-export function renderTemplate(template: string | null, payload: any) {
-  const c = payload.campaign ?? {};
-  const items = (payload.items ?? []).map((it: any) => {
-    const label = itemLabel(it.name, it.code, c.name);
-    // 金額用 emoji 數字凸顯（💲1️⃣2️⃣0️⃣），只包我們自己產的這一行 ——
-    // 店家寫在文案裡的「（市價$150/盒）」不要動
-    const price = it.unit_price == null ? "" : `\n${decoPrice(`$${Number(it.unit_price)}`)}`;
-    return `(${it.code}) ${label}${price}`;
-  }).join("\n");
-  // 說明是富文字 HTML（<p><strong>$100</strong></p>）就先轉成純文字，不然標籤會原樣貼到 LINE 上
-  const desc = stripLineDeco(htmlToText(c.description ?? ""));
-  // 文案自己就列了 (A)(B) 品項 / 寫了結單 / 開頭就是團名 → 那三個聰明佔位符留空
-  const descHasItems = /(^|\n)\s*[(（][A-Za-z][)）]/.test(desc);
-  const descHasDeadline = /結單|收單|截單/.test(desc);
-  const firstLine = bareText(desc.split("\n").find((x) => x.trim()) ?? "");
-  const bareName = bareText(c.name ?? "");
-  const descHasTitle = !!firstLine && !!bareName && firstLine.length >= 4
-    && (bareName.includes(firstLine) || firstLine.includes(bareName));
-  const deadline = c.end_at ? `⏰ ${fmtTaipei(c.end_at)} 結單` : "";
-
-  const rendered = (template || DEFAULT_TEMPLATE)
-    .replaceAll("{{tag}}", buildPostTag(c.campaign_no))
-    .replaceAll("{{title}}", descHasTitle ? "" : (c.name ?? ""))
-    .replaceAll("{{items}}", descHasItems ? "" : items)
-    .replaceAll("{{deadline}}", descHasDeadline ? "" : deadline)
-    .replaceAll("{{name}}", c.name ?? "")
-    .replaceAll("{{campaign_no}}", c.campaign_no ?? "")
-    .replaceAll("{{description}}", desc)
-    .replaceAll("{{end_at}}", fmtTaipei(c.end_at))
-    .replaceAll("{{start_at}}", fmtTaipei(c.start_at))
-    .replaceAll("{{pickup_deadline}}", fmtTaipei(c.pickup_deadline))
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-  return withPostTag(rendered, c.campaign_no);
-}
-
-// 真的會貼出去的字：版型渲染 → 文案裡獨立一行的 $數字也標起來 → 金額換成 emoji。
-// 預覽、發文、存 DB 三邊都用這一份，後台看到的就是社群裡看到的。
-function renderPostText(payload: any) {
-  return applyDeco(decoStandalonePrices(renderTemplate(payload.post_template, payload)));
 }
 
 function resolveImageUrl(p: unknown): string | null {

--- a/supabase/functions/line-note-worker/index.ts
+++ b/supabase/functions/line-note-worker/index.ts
@@ -28,7 +28,7 @@ import {
   clientFromToken, createNotePost, deleteNotePost, likeComment, listComments, listHomes, listPosts, loginByQr, whoami,
 } from "../_shared/lineNote.ts";
 import { buildPostTag, matchCampaign, parseNoteComment, postTitle, withPostTag } from "../_shared/lineNoteParse.ts";
-import { applyDeco, DECO_OPEN, decoPrice, stripDeco } from "../_shared/lineNoteDeco.ts";
+import { applyDeco, decoPrice, decoStandalonePrices, htmlToText, stripLineDeco } from "../_shared/lineNoteDeco.ts";
 
 const SUPABASE_URL = requireEnv("SUPABASE_URL");
 const SERVICE_KEY = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
@@ -183,15 +183,6 @@ function bareText(s: string) {
     .replace(/[\s\p{P}\p{S}\p{M}\p{C}]/gu, "");   // \p{M}/\p{C} 要一起拿掉：emoji 後面的 VS16、ZWJ 都藏在那裡
 }
 
-// 從記事本抓回來的舊文會帶 LINE 裝飾表情的佔位字：($)(3)(5) = $35、(emoji) = 一個貼圖。
-// 原樣貼出去客人會看到一串「($)(3)(5)」，所以還原成看得懂的字。
-function stripLineDeco(s: string) {
-  return String(s ?? "")
-    .replace(/(?:\((?:\$|[0-9]|\/)\)){2,}/g, (m) => m.replace(/[()]/g, ""))
-    .replace(/\((?:emoji|好吃|讚|哭|笑|愛心)\)/g, "")
-    .replace(/[ \t]+\n/g, "\n");
-}
-
 // 品項名在 DB 裡是「團名 (A) 空心菜200g」，直接印會變成「(A) 團名 (A) 空心菜200g」。
 // 去掉團名前綴和重複的代碼，只留真正的品名。
 function itemLabel(name: string, code: string, campaignName: string) {
@@ -213,12 +204,13 @@ export function renderTemplate(template: string | null, payload: any) {
   const c = payload.campaign ?? {};
   const items = (payload.items ?? []).map((it: any) => {
     const label = itemLabel(it.name, it.code, c.name);
-    // 金額用 LINE 的數字表情（小幫手手貼都是這樣打的），只包我們自己產的這一行 ——
+    // 金額用 emoji 數字凸顯（💲1️⃣2️⃣0️⃣），只包我們自己產的這一行 ——
     // 店家寫在文案裡的「（市價$150/盒）」不要動
     const price = it.unit_price == null ? "" : `\n${decoPrice(`$${Number(it.unit_price)}`)}`;
     return `(${it.code}) ${label}${price}`;
   }).join("\n");
-  const desc = stripLineDeco(c.description ?? "");
+  // 說明是富文字 HTML（<p><strong>$100</strong></p>）就先轉成純文字，不然標籤會原樣貼到 LINE 上
+  const desc = stripLineDeco(htmlToText(c.description ?? ""));
   // 文案自己就列了 (A)(B) 品項 / 寫了結單 / 開頭就是團名 → 那三個聰明佔位符留空
   const descHasItems = /(^|\n)\s*[(（][A-Za-z][)）]/.test(desc);
   const descHasDeadline = /結單|收單|截單/.test(desc);
@@ -244,14 +236,10 @@ export function renderTemplate(template: string | null, payload: any) {
   return withPostTag(rendered, c.campaign_no);
 }
 
-// 文案裡「自己獨立一行的 $數字」也是價格（匯進來的團，品項與價格都寫在 description 裡），
-// 一併用數字表情。行內的「（市價$150/盒）」不動 —— 那不是這團的售價。
-function decoStandalonePrices(text: string) {
-  return text.split("\n")
-    .map((line) => /^\s*\$\d+\s*$/.test(line) && !line.includes(DECO_OPEN)
-      ? line.replace(/\$\d+/, (m) => decoPrice(m))
-      : line)
-    .join("\n");
+// 真的會貼出去的字：版型渲染 → 文案裡獨立一行的 $數字也標起來 → 金額換成 emoji。
+// 預覽、發文、存 DB 三邊都用這一份，後台看到的就是社群裡看到的。
+function renderPostText(payload: any) {
+  return applyDeco(decoStandalonePrices(renderTemplate(payload.post_template, payload)));
 }
 
 function resolveImageUrl(p: unknown): string | null {
@@ -298,18 +286,16 @@ async function jobPost(job: any) {
   if (!payload) throw new Error(`post ${job.post_id} not found`);
   const account = await loadAccount(payload.account_id);
   const client = await clientFor(account);
-  const rendered = decoStandalonePrices(renderTemplate(payload.post_template, payload));
-  const { text, sticonMetas } = applyDeco(rendered);
-  const plain = stripDeco(rendered);          // 存 DB / 給人看的版本："$79" 而不是 "($)(7)(9)"
+  const text = renderPostText(payload);
   const images = await collectPostImages(payload);
   try {
-    const post = await createNotePost(client, payload.home_id, { text, sticonMetas, images, verbose: VERBOSE });
+    const post = await createNotePost(client, payload.home_id, { text, images, verbose: VERBOSE });
     await patch("line_note_posts", `id=eq.${job.post_id}`, {
-      status: "posted", line_post_id: post.postId ?? null, text: plain, posted_at: new Date().toISOString(), last_error: null,
+      status: "posted", line_post_id: post.postId ?? null, text, posted_at: new Date().toISOString(), last_error: null,
     });
-    return { postId: post.postId, title: postTitle(plain), images: images.length, deco: sticonMetas.length };
+    return { postId: post.postId, title: postTitle(text), images: images.length };
   } catch (e) {
-    await patch("line_note_posts", `id=eq.${job.post_id}`, { status: "failed", text: plain, last_error: String((e as any)?.message ?? e).slice(0, 1000) });
+    await patch("line_note_posts", `id=eq.${job.post_id}`, { status: "failed", text, last_error: String((e as any)?.message ?? e).slice(0, 1000) });
     throw e;
   }
 }
@@ -668,12 +654,7 @@ Deno.serve(async (req) => {
         p_community_id: Number(body.community_id), p_campaign_id: Number(body.campaign_id),
       });
       if (!payload) return json({ error: "找不到社群或團" }, 404);
-      const rendered = decoStandalonePrices(renderTemplate(payload.post_template, payload));
-      return json({
-        text: stripDeco(rendered),
-        deco: applyDeco(rendered).sticonMetas.length,   // 有幾個字會用 LINE 數字表情貼出去
-        images: postImageUrls(payload),
-      });
+      return json({ text: renderPostText(payload), images: postImageUrls(payload) });
     }
     // 刪掉已經貼出去的貼文：LINE 上那篇先刪掉，成功了才清後台紀錄。
     // 走「後台直接呼叫」而不是排 job —— 這是破壞性動作，按下去要當場知道刪掉了沒。

--- a/supabase/migrations/20260910040000_line_note_post_retail_price.sql
+++ b/supabase/migrations/20260910040000_line_note_post_retail_price.sql
@@ -1,0 +1,104 @@
+-- ============================================================================
+-- 20260910040000_line_note_post_retail_price.sql
+--
+-- 記事本貼文的金額一律用**零售價**（老闆 2026-09-10 交代：「po 文的時間都是要零售價錢」）。
+-- campaign_items.unit_price 是團購價，開團時從現行零售價複製過來、之後可以另外改
+-- （近 30 天 2,416 個品項有 22 個改成比零售低：港點 168 vs 249、水餃 189 vs 199…）；
+-- 社群貼文要的是 prices 表 scope='retail'、effective_to IS NULL 的那一筆。
+--
+-- 做法：_line_note_item_codes 多回一欄 retail_price，兩支 payload RPC 一起帶出去，
+-- 取捨留給 worker（lineNoteRender：retail_price > 0 用它，否則退回 unit_price ——
+-- 線上有 SKU 零售價是 0 的，例：GRP-20260907-011 的高麗菜）。
+-- 每個 SKU 的現行零售價只有一筆（線上 6,237 筆、沒有重複，scope_id 全為 NULL）。
+--
+-- 基底：_line_note_item_codes / rpc_line_note_post_payload @ 20260908010000（唯一前版），
+--       rpc_line_note_preview_payload @ 20260910010000（唯一前版）。
+-- RETURNS TABLE 多一欄要 DROP 再建（CREATE OR REPLACE 不能改回傳型別）；
+-- 引用它的三支函式（apply_comment / post_payload / preview_payload）都是執行期解析，
+-- 沒有 view 依賴它（pg_views 查過）。
+-- rollback：把上面三個基底版本重新套一次（先 DROP _line_note_item_codes）。
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public._line_note_item_codes(BIGINT);
+CREATE FUNCTION public._line_note_item_codes(p_campaign_id BIGINT)
+RETURNS TABLE (code TEXT, campaign_item_id BIGINT, sku_id BIGINT,
+               item_name TEXT, unit_price NUMERIC, retail_price NUMERIC, cap_qty NUMERIC, images JSONB)
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT chr(64 + (ROW_NUMBER() OVER (ORDER BY ci.sort_order, ci.id))::int) AS code,
+         ci.id, ci.sku_id,
+         TRIM(COALESCE(s.product_name, '') || CASE WHEN COALESCE(s.variant_name, '') <> '' THEN ' ' || s.variant_name ELSE '' END),
+         ci.unit_price,
+         -- 現行零售價（貼文用）；沒設就 NULL，worker 退回 unit_price
+         (SELECT pr.price FROM prices pr
+           WHERE pr.sku_id = ci.sku_id AND pr.scope = 'retail' AND pr.effective_to IS NULL
+           ORDER BY pr.effective_from DESC NULLS LAST, pr.id DESC
+           LIMIT 1),
+         ci.cap_qty,
+         COALESCE(p.images, '[]'::jsonb)   -- 商品圖（storage 相對路徑或完整網址），worker 發文時附上
+    FROM campaign_items ci
+    JOIN skus s ON s.id = ci.sku_id
+    LEFT JOIN products p ON p.id = s.product_id
+   WHERE ci.campaign_id = p_campaign_id
+     AND COALESCE(ci.is_gift, FALSE) = FALSE
+   ORDER BY ci.sort_order, ci.id
+   LIMIT 26;   -- 超過 26 項就沒代碼了，那種團不適合記事本 +1
+$$;
+
+-- worker 發文用：把團的內容整包回來（模板由 worker 套）
+CREATE OR REPLACE FUNCTION public.rpc_line_note_post_payload(p_post_id BIGINT)
+RETURNS JSONB
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT jsonb_build_object(
+    'post_id',       p.id,
+    'home_id',       c.home_id,
+    'home_kind',     c.home_kind,
+    'account_id',    c.account_id,
+    'post_template', c.post_template,
+    'campaign', jsonb_build_object(
+       'id', g.id, 'campaign_no', g.campaign_no, 'name', g.name,
+       'description', g.description, 'status', g.status,
+       'cover_image_url', g.cover_image_url,
+       'start_at', g.start_at, 'end_at', g.end_at, 'pickup_deadline', g.pickup_deadline),
+    'items', COALESCE((SELECT jsonb_agg(jsonb_build_object(
+                'code', ic.code, 'campaign_item_id', ic.campaign_item_id,
+                'name', ic.item_name, 'unit_price', ic.unit_price, 'retail_price', ic.retail_price,
+                'cap_qty', ic.cap_qty, 'images', ic.images)
+                ORDER BY ic.code)
+               FROM public._line_note_item_codes(g.id) ic), '[]'::jsonb)
+  )
+  FROM line_note_posts p
+  JOIN line_note_communities c ON c.id = p.community_id
+  JOIN group_buy_campaigns g ON g.id = p.campaign_id
+  WHERE p.id = p_post_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public.rpc_line_note_preview_payload(
+  p_community_id BIGINT,
+  p_campaign_id  BIGINT
+) RETURNS JSONB
+LANGUAGE sql STABLE SECURITY DEFINER
+AS $$
+  SELECT jsonb_build_object(
+    'home_id',       c.home_id,
+    'home_kind',     c.home_kind,
+    'account_id',    c.account_id,
+    'post_template', c.post_template,
+    'campaign', jsonb_build_object(
+       'id', g.id, 'campaign_no', g.campaign_no, 'name', g.name,
+       'description', g.description, 'status', g.status,
+       'cover_image_url', g.cover_image_url,
+       'start_at', g.start_at, 'end_at', g.end_at, 'pickup_deadline', g.pickup_deadline),
+    'items', COALESCE((SELECT jsonb_agg(jsonb_build_object(
+                'code', ic.code, 'campaign_item_id', ic.campaign_item_id,
+                'name', ic.item_name, 'unit_price', ic.unit_price, 'retail_price', ic.retail_price,
+                'cap_qty', ic.cap_qty, 'images', ic.images)
+                ORDER BY ic.code)
+               FROM public._line_note_item_codes(g.id) ic), '[]'::jsonb)
+  )
+  FROM line_note_communities c
+  JOIN group_buy_campaigns g ON g.id = p_campaign_id AND g.tenant_id = c.tenant_id
+  WHERE c.id = p_community_id;
+$$;
+GRANT EXECUTE ON FUNCTION public.rpc_line_note_preview_payload(BIGINT, BIGINT) TO authenticated;


### PR DESCRIPTION
## 做了什麼

**金額用 emoji 凸顯**（commit 1）
- #938 帶 LINE 裝飾表情（`sticonMetas`）發文，社群裡看到的還是普通數字 —— 那是 LINE 客戶端自己的貼圖管線，從外面打 API 模擬不出來、也沒辦法驗證。改用哪台手機都畫得出來的 Unicode emoji：`$120` → `💲1️⃣2️⃣0️⃣`。預覽、發文、存進 DB 的是同一份字。
- 團說明是富文字編輯器存的 HTML（線上 132 團、近兩個月 87 團），今天的測試貼文就把 `<p><strong>$100</strong></p>` 原樣貼到 LINE 上了。發文前先轉純文字。

**版型改成老闆指定的樣子**（commit 2–4）
- 團名 → 商品 → ⏰ 結單 → 文案 → 留言教學。只有一個品項就不印品名／代碼、直接一行金額；多品項才 `(A) 品名` ＋ 下一行金額。留言教學跟著變（單品「例：123456 +1」）。
- **結單時間印「客人收單」**（`customer_end_at`，#947 新增的欄位；沒設就是店家收單）。文案自己寫了結單就不重複。
- **金額一律零售價**：`campaign_items.unit_price` 是團購價、開團後可以另外改低（近 30 天 22 個品項），社群貼文要的是 `prices` 表現行零售價。`20260910040000` 讓 `_line_note_item_codes` 多回 `retail_price`、兩支 payload RPC 帶出去；worker 端 `retail_price > 0` 才用，沒設（NULL / 0）退回團購價。
- 文案對齊：開頭幾行裡的團名搬到最上面當標題不印兩次；文案自己用 `(A)(B)` 或 `A. B.` 列了品項就不重列；單品而文案已寫同一個金額不重印；品名裡的「A. 」前綴不印成「(A) A. 原味」；小幫手的「💰195」「💰 一盒 $275」寫法 💰 後面的數字也凸顯；記事本抓回來的「一個($)(1)(2)(5)」還原成 emoji 金額。行內「（市價$150/盒）」維持純文字。
- `renderTemplate` 從 worker 搬到 `_shared/lineNoteRender.ts`（預覽、發文、存 DB 同一份），Deno 測試 10 + 5 條。社群設定的模板提示改成新的預設版型；`{{howto}}` 是新的佔位符。

## 上線危險

- 做了：`20260910040000` 已用 Management API 套上正式庫（`_line_note_item_codes` DROP 重建多一欄、兩支 payload RPC 重建，驗過回 `retail_price`）；`line-note-worker` 已部署（version 23），OPTIONS 200、無 auth POST 回函式自家 401。**本 PR 要今天進 main**，不然 repo ≠ 正式庫。
- 不做：沒動模板變數的舊語意（`{{name}}` 照舊）、沒動留言解析、已發出去的貼文不會變。
- 回退：重新部署 #943 那份 `line-note-worker`；migration 回退見檔頭（把三個基底版本重套）。
- 跟 #947 的關係：`customer_end_at` 欄位與 payload 帶欄位在 #947 的 migration；這裡的 render 對沒有那一欄的 payload 一樣能跑（退回 `end_at`）。兩支 migration 已都套上線。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `lineNoteDeco.test.ts`（5）+ `lineNoteRender.test.ts`（10）用 esbuild 打包後在 node 跑過全綠。
- 對線上 6 個團的 `rpc_line_note_preview_payload` 實際渲染：HTML 說明的 `GRP-20260910-041` 出來是「測試／💲1️⃣0️⃣0️⃣」；`GRP-20260908-003` 的 `⭐️ 所長茶葉蛋` 當標題、`A. 經典原味 💰1️⃣9️⃣5️⃣` 不重列；佔位字的 `GRP-20260908-002` 四個品項價格都成 emoji、日期 `9/14` 維持純文字；單品 `GRP-20260907-011` 只印一行 `💲6️⃣9️⃣`。
- 線上 `_line_note_item_codes` 對 `GRP-20260904-009` 回 `unit_price 168 / retail_price 249`，`GRP-20260907-011` 零售價 0 → worker 退回 69。
- 另外注意到：純文字（沒有圖）的貼文 `line_post_id` 沒記到（post 290），後台的刪文對它無效；不在本 PR 範圍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhdcaVFVE5iGuHqtWFvEGV