### PR TITLE
feat(orders): 訂單明細的品項標出「機器人（LINE 留言）」加的，跟小幫手分開

### DIFF
--- a/apps/admin/src/components/OrderDetail.tsx
+++ b/apps/admin/src/components/OrderDetail.tsx
@@ -217,6 +217,14 @@ function staffLabel(uid: string | null, names: Map<string, string>): string {
   return names.get(uid) ?? uid.slice(0, 8);
 }
 
+// 品項的「誰加的 / 誰改的」：LINE 記事本機器人用 service_role 寫入，uid 是 NULL、
+// 品項 source 標 line_bot（20260909030000）。原本這種列只會印「—」，跟小幫手手動加的
+// 分不出來 —— 客人說「我只有 +1 怎麼變兩個」時，第一個要回答的就是這是人加的還是機器人加的。
+function byLabel(uid: string | null, source: string | null | undefined, names: Map<string, string>): string {
+  if (!uid && source === "line_bot") return "🤖 機器人（LINE 留言）";
+  return staffLabel(uid, names);
+}
+
 function fmtDt(iso: string): string {
   return new Date(iso).toLocaleString("zh-TW", { hour12: false });
 }
@@ -1625,11 +1633,11 @@ export function OrderDetail({
                     </td>
                     <td className="px-3 py-2 text-zinc-500">
                       {fmtDt(it.created_at)}<br />
-                      <span className="text-[10px]">by {staffLabel(it.created_by, staffNames)}</span>
+                      <span className="text-[10px]">by {byLabel(it.created_by, it.source, staffNames)}</span>
                     </td>
                     <td className="px-3 py-2 text-zinc-500">
                       {fmtDt(it.updated_at)}<br />
-                      <span className="text-[10px]">by {staffLabel(it.updated_by, staffNames)}</span>
+                      <span className="text-[10px]">by {byLabel(it.updated_by, it.source, staffNames)}</span>
                     </td>
                     {(canEditQty || canAssignStock) && (
                       <td className="px-3 py-2 text-right">


### PR DESCRIPTION
## 做了什麼

- 訂單明細的品項表「第一次加 / 最後更新」那兩格：LINE 記事本機器人用 service_role 寫入，`created_by` / `updated_by` 是 NULL、品項 `source` 標 `line_bot`（20260909030000），原本只印「by —」，跟小幫手手動加的分不出來。現在 uid 為 NULL 且 `source = line_bot` → 印「🤖 機器人（LINE 留言）」，其他照舊印人名。
- 起因：客人說「我只有 +1 怎麼變兩個」（GRP-20260906-025-0048）。查過是人加的：小幫手 9/8 17:44 先 key 一次，9/10 02:00 處理留言收件匣「637285松山+1」時又把數量改成 2、8 秒後把留言標已解決；機器人沒碰過那張單（那則留言因為多了「松山」兩個字解析不出來，一直停在待處理）。

## 上線危險

- 做了：純前端顯示，Vercel 部署後生效。
- 不做：沒動資料、沒動 RPC。
- 回退：revert 這個 commit。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- 一行條件式；線上機器人加的品項都是 `created_by IS NULL AND source = 'line_bot'`（20260909030000 的回填條件就是這一組）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhdcaVFVE5iGuHqtWFvEGV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhdcaVFVE5iGuHqtWFvEGV)_