### PR TITLE
feat(line-notes): 貼文標題印團名、金額接在品項同一行、結單接在金額後面、留言教學不提會員編號

### DIFF
--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -598,7 +598,7 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
             </label>
             <label className="text-sm md:col-span-2">發文模板（留空用預設；可用 {"{{title}} {{items}} {{deadline}} {{description}} {{howto}} {{tag}} {{name}} {{end_at}} {{pickup_deadline}}"}）
               <textarea className={`${input} h-40 font-mono text-xs`} value={form.post_template} onChange={(e) => setForm({ ...form, post_template: e.target.value })}
-                placeholder={"{{title}}\n\n{{items}}\n\n{{deadline}}\n\n{{description}}\n\n{{howto}}\n⏰ 最後收單 {{end_at}}\n#開團\n{{tag}}"} />
+                placeholder={"{{title}}\n\n{{items}}\n\n{{deadline}}\n\n{{description}}\n\n{{howto}}\n#開團\n{{tag}}"} />
             </label>
           </div>
           <div className="mt-4 flex justify-end gap-2">

--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -596,9 +596,9 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
             <label className="flex items-center gap-2 text-sm">
               <input type="checkbox" checked={form.react_on_confirm} onChange={(e) => setForm({ ...form, react_on_confirm: e.target.checked })} /> 收到單後在客人留言上按 😄，讓他知道收到了
             </label>
-            <label className="text-sm md:col-span-2">發文模板（留空用預設；可用 {"{{title}} {{items}} {{description}} {{howto}} {{tag}} {{name}} {{end_at}} {{pickup_deadline}}"}）
+            <label className="text-sm md:col-span-2">發文模板（留空用預設；可用 {"{{title}} {{items}} {{deadline}} {{description}} {{howto}} {{tag}} {{name}} {{end_at}} {{pickup_deadline}}"}）
               <textarea className={`${input} h-40 font-mono text-xs`} value={form.post_template} onChange={(e) => setForm({ ...form, post_template: e.target.value })}
-                placeholder={"{{title}}\n\n{{items}}\n\n{{description}}\n\n{{howto}}\n#開團\n{{tag}}"} />
+                placeholder={"{{title}}\n\n{{items}}\n\n{{deadline}}\n\n{{description}}\n\n{{howto}}\n#開團\n{{tag}}"} />
             </label>
           </div>
           <div className="mt-4 flex justify-end gap-2">

--- a/apps/admin/src/app/(protected)/line-notes/page.tsx
+++ b/apps/admin/src/app/(protected)/line-notes/page.tsx
@@ -598,7 +598,7 @@ function CommunitiesTab({ communities, accounts, stores, accountById, storeById,
             </label>
             <label className="text-sm md:col-span-2">發文模板（留空用預設；可用 {"{{title}} {{items}} {{deadline}} {{description}} {{howto}} {{tag}} {{name}} {{end_at}} {{pickup_deadline}}"}）
               <textarea className={`${input} h-40 font-mono text-xs`} value={form.post_template} onChange={(e) => setForm({ ...form, post_template: e.target.value })}
-                placeholder={"{{title}}\n\n{{items}}\n\n{{deadline}}\n\n{{description}}\n\n{{howto}}\n#開團\n{{tag}}"} />
+                placeholder={"{{title}}\n\n{{items}}\n\n{{deadline}}\n\n{{description}}\n\n{{howto}}\n⏰ 最後收單 {{end_at}}\n#開團\n{{tag}}"} />
             </label>
           </div>
           <div className="mt-4 flex justify-end gap-2">

--- a/supabase/functions/_shared/lineNoteRender.test.ts
+++ b/supabase/functions/_shared/lineNoteRender.test.ts
@@ -12,37 +12,40 @@ const payload = (campaign: Record<string, unknown>, items: Record<string, unknow
 
 Deno.test("預設版型：先團名、再金額、再結單時間、再文案；單品不印品名", () => {
   const text = renderPostText(payload({ name: "梨山高麗菜", description: "包子媽朋友自己種的" }, [{ code: "A", name: "梨山高麗菜 (A) 半顆", unit_price: 69 }]));
-  eq(text, `梨山高麗菜\n\n💲6️⃣9️⃣\n\n${DL}\n\n包子媽朋友自己種的\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品");
+  eq(text, `梨山高麗菜\n\n💰6️⃣9️⃣ 元\n\n${DL}\n\n包子媽朋友自己種的\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品");
 });
 
-Deno.test("多品項才列 (A) 品名 ＋ 下一行金額，教學帶代碼", () => {
+Deno.test("多品項才列 (A) 品名 ＋ 同一行金額，教學帶代碼", () => {
   const text = renderPostText(payload({ name: "所長茶葉蛋", description: "超入味" },
     [{ code: "A", name: "所長茶葉蛋 (A) 原味", unit_price: 195 }, { code: "B", name: "所長茶葉蛋 (B) 辣味", unit_price: 205 }]));
-  eq(text, `所長茶葉蛋\n\n(A) 原味\n💲1️⃣9️⃣5️⃣\n(B) 辣味\n💲2️⃣0️⃣5️⃣\n\n${DL}\n\n超入味\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "多品項");
+  eq(text, `所長茶葉蛋\n\n(A) 原味 1️⃣9️⃣5️⃣ 元\n(B) 辣味 2️⃣0️⃣5️⃣ 元\n\n${DL}\n\n超入味\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "多品項");
 });
 
 Deno.test("文案第一行就是團名 → 搬到最上面當標題（留住表情符號），不印兩次", () => {
   const text = renderPostText(payload({ name: "所長茶葉蛋", description: "<p>⭐️ <strong>所長茶葉蛋</strong></p><p>超入味</p>" },
     [{ code: "A", name: "原味", unit_price: 195 }]));
-  eq(text, `⭐️ 所長茶葉蛋\n\n💲1️⃣9️⃣5️⃣\n\n${DL}\n\n超入味\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "標題搬上去、HTML 也轉好");
+  eq(text, `⭐️ 所長茶葉蛋\n\n💰1️⃣9️⃣5️⃣ 元\n\n${DL}\n\n超入味\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "標題搬上去、HTML 也轉好");
 });
 
 Deno.test("記事本匯進來的單品文案已經寫了同一個金額 → 不再多印一行", () => {
   const text = renderPostText(payload({ name: "梨山高麗菜", description: "梨山高麗菜\n半顆($)(6)(9)\n(emoji)9/9到貨" }, [{ code: "A", name: "半顆", unit_price: 69 }]));
-  eq(text, `梨山高麗菜\n\n${DL}\n\n半顆💲6️⃣9️⃣\n9/9到貨\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "金額只出現一次");
+  eq(text, `梨山高麗菜\n\n${DL}\n\n半顆💲6️⃣9️⃣\n9/9到貨\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "金額只出現一次（行內金額不另外空行）");
   const diff = renderPostText(payload({ name: "梨山高麗菜", description: "梨山高麗菜\n半顆($)(6)(9)" }, [{ code: "A", name: "半顆", unit_price: 75 }]));
-  eq(diff.includes("💲7️⃣5️⃣") && diff.includes("半顆💲6️⃣9️⃣"), true, "金額不一樣就兩個都印，讓人看得出來要改");
+  eq(diff.includes("💰7️⃣5️⃣ 元") && diff.includes("半顆💲6️⃣9️⃣"), true, "金額不一樣就兩個都印，讓人看得出來要改");
 });
 
-Deno.test("文案自己列了 (A)(B) 品項 → 商品段留空", () => {
+Deno.test("文案自己列了 (A)(B) 品項 → 商品段留空；記事本「價格在下一行」的寫法併成同一行", () => {
   const text = renderPostText(payload({ name: "阿土伯", description: "阿土伯\n(A)空心菜\n($)(3)(5)\n(B)小白菜\n($)(3)(5)" },
     [{ code: "A", name: "空心菜", unit_price: 35 }, { code: "B", name: "小白菜", unit_price: 35 }]));
-  eq(text, `阿土伯\n\n${DL}\n\n(A)空心菜\n💲3️⃣5️⃣\n(B)小白菜\n💲3️⃣5️⃣\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "不重複列品項");
+  eq(text, `阿土伯\n\n${DL}\n\n(A)空心菜 3️⃣5️⃣ 元\n(B)小白菜 3️⃣5️⃣ 元\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "不重複列品項、併成一行");
+  const diff = renderPostText(payload({ name: "阿土伯", description: "阿土伯\n(A)空心菜\n($)(3)(0)\n(B)小白菜\n($)(3)(5)" },
+    [{ code: "A", name: "空心菜", unit_price: 35 }, { code: "B", name: "小白菜", unit_price: 35 }]));
+  eq(diff.includes("(A)空心菜\n💲3️⃣0️⃣\n(B)小白菜 3️⃣5️⃣ 元"), true, "小幫手寫的價格跟零售價不一樣 → 那一組兩行都不動、也不拆開");
 });
 
 Deno.test("自訂模板：{{deadline}} / {{end_at}} 照舊可用，沒寫 {{tag}} 也會補章", () => {
   const text = renderPostText(payload({ name: "測試", description: "" }, [{ code: "A", name: "x", unit_price: 100 }], "{{name}}\n{{items}}\n{{deadline}}"));
-  eq(text, `測試\n💲1️⃣0️⃣0️⃣\n⏰ 9/13 23:59 結單\n${tag}`, "自訂模板");
+  eq(text, `測試\n💰1️⃣0️⃣0️⃣ 元\n⏰ 9/13 23:59 結單\n${tag}`, "自訂模板");
 });
 
 Deno.test("文案用 A. B. 列品項（品名裡也帶 A.）→ 商品段留空，💰 價格照樣凸顯；口號在前、品名在第二行也認得出標題", () => {
@@ -50,13 +53,13 @@ Deno.test("文案用 A. B. 列品項（品名裡也帶 A.）→ 商品段留空�
     [{ code: "A", name: "A. 經典原味", unit_price: 195 }, { code: "B", name: "B. 麻香辣味", unit_price: 205 }]));
   eq(text, `⭐️ 所長茶葉蛋\n\n${DL}\n\n買一送一！\nA. 經典原味 💰1️⃣9️⃣5️⃣\nB. 麻香辣味 💰2️⃣0️⃣5️⃣\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "A. 列表");
   const own = renderPostText(payload({ name: "所長茶葉蛋", description: "超入味" }, [{ code: "A", name: "A. 經典原味", unit_price: 195 }, { code: "B", name: "B. 麻香辣味", unit_price: 205 }]));
-  eq(own.includes("(A) 經典原味\n💲1️⃣9️⃣5️⃣\n(B) 麻香辣味"), true, "品名裡的 A. 不印兩次");
+  eq(own.includes("(A) 經典原味 1️⃣9️⃣5️⃣ 元\n(B) 麻香辣味 2️⃣0️⃣5️⃣ 元"), true, "品名裡的 A. 不印兩次");
 });
 
 Deno.test("金額一律用零售價；沒設零售價（NULL / 0）才退回團購價", () => {
   const text = renderPostText(payload({ name: "港點", description: "好吃" },
     [{ code: "A", name: "蝦餃", unit_price: 168, retail_price: 249 }, { code: "B", name: "燒賣", unit_price: 69, retail_price: 0 }, { code: "C", name: "腸粉", unit_price: 88 }]));
-  eq(text.includes("(A) 蝦餃\n💲2️⃣4️⃣9️⃣\n(B) 燒賣\n💲6️⃣9️⃣\n(C) 腸粉\n💲8️⃣8️⃣"), true, "零售價優先");
+  eq(text.includes("(A) 蝦餃 2️⃣4️⃣9️⃣ 元\n(B) 燒賣 6️⃣9️⃣ 元\n(C) 腸粉 8️⃣8️⃣ 元"), true, "零售價優先");
   const single = renderPostText(payload({ name: "高麗菜", description: "高麗菜\n半顆($)(6)(9)" }, [{ code: "A", name: "半顆", unit_price: 60, retail_price: 69 }]));
   eq(single, `高麗菜\n\n${DL}\n\n半顆💲6️⃣9️⃣\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品去重也是拿零售價比");
 });
@@ -71,7 +74,20 @@ Deno.test("{{deadline}} / {{end_at}} 印客人收單；沒設客人收單就印�
 
 Deno.test("預設版型的結單時間印客人收單；文案自己寫了結單就不重複", () => {
   const cust = renderPostText(payload({ name: "測試", description: "好吃", customer_end_at: "2026-09-12T10:00:00Z" }, [{ code: "A", name: "x", unit_price: 50 }]));
-  eq(cust, `測試\n\n💲5️⃣0️⃣\n\n⏰ 9/12 18:00 結單\n\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "客人收單");
+  eq(cust, `測試\n\n💰5️⃣0️⃣ 元\n\n⏰ 9/12 18:00 結單\n\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "客人收單");
   const own = renderPostText(payload({ name: "測試", description: "⏰9/12結單\n好吃" }, [{ code: "A", name: "x", unit_price: 50 }]));
-  eq(own, `測試\n\n💲5️⃣0️⃣\n\n⏰9/12結單\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "文案有結單就不印");
+  eq(own, `測試\n\n💰5️⃣0️⃣ 元\n\n⏰9/12結單\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "文案有結單就不印");
+});
+
+Deno.test("文案列了 (A)(B) 但沒寫價格 → 金額接在同一行，整行只有金額的「💰一袋189元」拿掉", () => {
+  const text = renderPostText(payload({ name: "杰哥爆餡韭菜盒 675g", description: "🔥囤起來\n【杰哥爆餡盒子】\n💰一袋189元\n\n(A) 韭菜盒\n(B) 高麗菜盒（全素🌱）\n\n⏰9/14結單\n口味：(A)韭菜盒／(B)高麗菜盒" },
+    [{ code: "A", name: "韭菜盒", unit_price: 189, retail_price: 189 }, { code: "B", name: "高麗菜盒", unit_price: 189, retail_price: 189 }]));
+  eq(text, `杰哥爆餡韭菜盒 675g\n\n🔥囤起來\n【杰哥爆餡盒子】\n\n(A) 韭菜盒 1️⃣8️⃣9️⃣ 元\n(B) 高麗菜盒（全素🌱） 1️⃣8️⃣9️⃣ 元\n\n⏰9/14結單\n口味：(A)韭菜盒／(B)高麗菜盒\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "接價格、拿掉多的那行");
+  const keep = renderPostText(payload({ name: "杰哥", description: "杰哥\n💰滿1000免運\n(A) 韭菜盒 189元\n(B) 高麗菜盒" }, [{ code: "A", name: "韭菜盒", unit_price: 189 }, { code: "B", name: "高麗菜盒", unit_price: 199 }]));
+  eq(keep.includes("💰滿1️⃣0️⃣0️⃣0️⃣免運\n(A) 韭菜盒 189元\n(B) 高麗菜盒 1️⃣9️⃣9️⃣ 元"), true, "已有價格的行不動、不是純金額的 💰 行不拿");
+});
+
+Deno.test("整行只有金額的那一行，跟上一行之間空一行", () => {
+  const text = renderPostText(payload({ name: "磁吸迷你拆信刀(顏色隨機)", description: "✉️網購族一定懂\n【磁吸迷你拆信刀｜顏色隨機】\n💰105元\n\n🚚15～25天貨到通知\n⏰9/14結單" }, [{ code: "A", name: "拆信刀", unit_price: 105, retail_price: 105 }]));
+  eq(text, `【磁吸迷你拆信刀｜顏色隨機】\n\n✉️網購族一定懂\n\n💰1️⃣0️⃣5️⃣元\n\n🚚15～25天貨到通知\n⏰9/14結單\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "金額行上面補空行");
 });

--- a/supabase/functions/_shared/lineNoteRender.test.ts
+++ b/supabase/functions/_shared/lineNoteRender.test.ts
@@ -7,30 +7,29 @@ const HOWTO_MULTI = "📝 留言「品項代碼＋數量」，例：A+1 B+2";
 const HOWTO_SINGLE = "📝 留言「數量」，例：+1";
 const tag = "🔖 團號 GRP-1";
 const DL = "⏰ 9/13 23:59 結單";   // payload 預設 end_at = 2026-09-13T15:59Z（台北 23:59）
-const FINAL = "⏰ 最後收單 9/13 23:59";   // 預設版型最後一行：店家收單
 const payload = (campaign: Record<string, unknown>, items: Record<string, unknown>[], post_template: string | null = null) =>
   ({ post_template, campaign: { campaign_no: "GRP-1", end_at: "2026-09-13T15:59:00Z", ...campaign }, items });
 
 Deno.test("預設版型：先團名、再金額、再結單時間、再文案；單品不印品名", () => {
   const text = renderPostText(payload({ name: "梨山高麗菜", description: "包子媽朋友自己種的" }, [{ code: "A", name: "梨山高麗菜 (A) 半顆", unit_price: 69 }]));
-  eq(text, `梨山高麗菜\n\n💰6️⃣9️⃣ 元\n\n${DL}\n\n包子媽朋友自己種的\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "單品");
+  eq(text, `梨山高麗菜\n\n💰6️⃣9️⃣ 元\n\n${DL}\n\n包子媽朋友自己種的\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品");
 });
 
 Deno.test("多品項才列 (A) 品名 ＋ 同一行金額，教學帶代碼", () => {
   const text = renderPostText(payload({ name: "所長茶葉蛋", description: "超入味" },
     [{ code: "A", name: "所長茶葉蛋 (A) 原味", unit_price: 195 }, { code: "B", name: "所長茶葉蛋 (B) 辣味", unit_price: 205 }]));
-  eq(text, `所長茶葉蛋\n\n(A) 原味 1️⃣9️⃣5️⃣ 元\n(B) 辣味 2️⃣0️⃣5️⃣ 元\n\n${DL}\n\n超入味\n\n${HOWTO_MULTI}\n${FINAL}\n#開團\n${tag}`, "多品項");
+  eq(text, `所長茶葉蛋\n\n(A) 原味 1️⃣9️⃣5️⃣ 元\n(B) 辣味 2️⃣0️⃣5️⃣ 元\n\n${DL}\n\n超入味\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "多品項");
 });
 
-Deno.test("文案第一行就是團名 → 搬到最上面當標題（留住表情符號），不印兩次", () => {
+Deno.test("文案第一行就是團名 → 拿掉那一行，標題一律印團名", () => {
   const text = renderPostText(payload({ name: "所長茶葉蛋", description: "<p>⭐️ <strong>所長茶葉蛋</strong></p><p>超入味</p>" },
     [{ code: "A", name: "原味", unit_price: 195 }]));
-  eq(text, `⭐️ 所長茶葉蛋\n\n💰1️⃣9️⃣5️⃣ 元\n\n${DL}\n\n超入味\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "標題搬上去、HTML 也轉好");
+  eq(text, `所長茶葉蛋\n\n💰1️⃣9️⃣5️⃣ 元\n\n${DL}\n\n超入味\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "標題印團名、HTML 也轉好");
 });
 
 Deno.test("記事本匯進來的單品文案已經寫了同一個金額 → 不再多印一行", () => {
   const text = renderPostText(payload({ name: "梨山高麗菜", description: "梨山高麗菜\n半顆($)(6)(9)\n(emoji)9/9到貨" }, [{ code: "A", name: "半顆", unit_price: 69 }]));
-  eq(text, `梨山高麗菜\n\n${DL}\n\n半顆💲6️⃣9️⃣\n9/9到貨\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "金額只出現一次（行內金額不另外空行）");
+  eq(text, `梨山高麗菜\n\n半顆💲6️⃣9️⃣\n\n${DL}\n\n9/9到貨\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "金額只出現一次、結單插在金額後面");
   const diff = renderPostText(payload({ name: "梨山高麗菜", description: "梨山高麗菜\n半顆($)(6)(9)" }, [{ code: "A", name: "半顆", unit_price: 75 }]));
   eq(diff.includes("💰7️⃣5️⃣ 元") && diff.includes("半顆💲6️⃣9️⃣"), true, "金額不一樣就兩個都印，讓人看得出來要改");
 });
@@ -38,7 +37,7 @@ Deno.test("記事本匯進來的單品文案已經寫了同一個金額 → 不�
 Deno.test("文案自己列了 (A)(B) 品項 → 商品段留空；記事本「價格在下一行」的寫法併成同一行", () => {
   const text = renderPostText(payload({ name: "阿土伯", description: "阿土伯\n(A)空心菜\n($)(3)(5)\n(B)小白菜\n($)(3)(5)" },
     [{ code: "A", name: "空心菜", unit_price: 35 }, { code: "B", name: "小白菜", unit_price: 35 }]));
-  eq(text, `阿土伯\n\n${DL}\n\n(A)空心菜 3️⃣5️⃣ 元\n(B)小白菜 3️⃣5️⃣ 元\n\n${HOWTO_MULTI}\n${FINAL}\n#開團\n${tag}`, "不重複列品項、併成一行");
+  eq(text, `阿土伯\n\n(A)空心菜 3️⃣5️⃣ 元\n(B)小白菜 3️⃣5️⃣ 元\n\n${DL}\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "不重複列品項、併成一行、結單接在品項後面");
   const diff = renderPostText(payload({ name: "阿土伯", description: "阿土伯\n(A)空心菜\n($)(3)(0)\n(B)小白菜\n($)(3)(5)" },
     [{ code: "A", name: "空心菜", unit_price: 35 }, { code: "B", name: "小白菜", unit_price: 35 }]));
   eq(diff.includes("(A)空心菜\n💲3️⃣0️⃣\n(B)小白菜 3️⃣5️⃣ 元"), true, "小幫手寫的價格跟零售價不一樣 → 那一組兩行都不動、也不拆開");
@@ -52,7 +51,7 @@ Deno.test("自訂模板：{{deadline}} / {{end_at}} 照舊可用，沒寫 {{tag}
 Deno.test("文案用 A. B. 列品項（品名裡也帶 A.）→ 商品段留空，💰 價格照樣凸顯；口號在前、品名在第二行也認得出標題", () => {
   const text = renderPostText(payload({ name: "所長茶葉蛋", description: "<p>買一送一！</p><p>⭐️ <strong>所長茶葉蛋</strong></p><p>A. 經典原味 💰195<br>B. 麻香辣味 💰205</p>" },
     [{ code: "A", name: "A. 經典原味", unit_price: 195 }, { code: "B", name: "B. 麻香辣味", unit_price: 205 }]));
-  eq(text, `⭐️ 所長茶葉蛋\n\n${DL}\n\n買一送一！\nA. 經典原味 💰1️⃣9️⃣5️⃣\nB. 麻香辣味 💰2️⃣0️⃣5️⃣\n\n${HOWTO_MULTI}\n${FINAL}\n#開團\n${tag}`, "A. 列表");
+  eq(text, `所長茶葉蛋\n\n買一送一！\nA. 經典原味 💰1️⃣9️⃣5️⃣\nB. 麻香辣味 💰2️⃣0️⃣5️⃣\n\n${DL}\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "A. 列表，結單接在後面");
   const own = renderPostText(payload({ name: "所長茶葉蛋", description: "超入味" }, [{ code: "A", name: "A. 經典原味", unit_price: 195 }, { code: "B", name: "B. 麻香辣味", unit_price: 205 }]));
   eq(own.includes("(A) 經典原味 1️⃣9️⃣5️⃣ 元\n(B) 麻香辣味 2️⃣0️⃣5️⃣ 元"), true, "品名裡的 A. 不印兩次");
 });
@@ -62,38 +61,38 @@ Deno.test("金額一律用零售價；沒設零售價（NULL / 0）才退回團�
     [{ code: "A", name: "蝦餃", unit_price: 168, retail_price: 249 }, { code: "B", name: "燒賣", unit_price: 69, retail_price: 0 }, { code: "C", name: "腸粉", unit_price: 88 }]));
   eq(text.includes("(A) 蝦餃 2️⃣4️⃣9️⃣ 元\n(B) 燒賣 6️⃣9️⃣ 元\n(C) 腸粉 8️⃣8️⃣ 元"), true, "零售價優先");
   const single = renderPostText(payload({ name: "高麗菜", description: "高麗菜\n半顆($)(6)(9)" }, [{ code: "A", name: "半顆", unit_price: 60, retail_price: 69 }]));
-  eq(single, `高麗菜\n\n${DL}\n\n半顆💲6️⃣9️⃣\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "單品去重也是拿零售價比");
+  eq(single, `高麗菜\n\n半顆💲6️⃣9️⃣\n\n${DL}\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品去重也是拿零售價比");
 });
 
-Deno.test("{{deadline}} 印客人收單（沒設就是店家收單）；{{end_at}} 一律店家收單", () => {
+Deno.test("{{deadline}} / {{end_at}} 印客人收單；沒設客人收單就印店家收單", () => {
   const tpl = "{{name}}\n{{deadline}}\n{{end_at}}";
   const both = renderPostText(payload({ name: "測試", description: "", customer_end_at: "2026-09-12T10:00:00Z" }, [{ code: "A", name: "x", unit_price: 1 }], tpl));
-  eq(both, `測試\n⏰ 9/12 18:00 結單\n9/13 23:59\n${tag}`, "{{deadline}} 客人收單、{{end_at}} 店家收單");
+  eq(both, `測試\n⏰ 9/12 18:00 結單\n9/12 18:00\n${tag}`, "客人收單優先");
   const only = renderPostText(payload({ name: "測試", description: "" }, [{ code: "A", name: "x", unit_price: 1 }], tpl));
   eq(only, `測試\n⏰ 9/13 23:59 結單\n9/13 23:59\n${tag}`, "退回店家收單");
 });
 
-Deno.test("預設版型的結單時間印客人收單；文案自己寫了結單就不重複", () => {
+Deno.test("預設版型的結單時間印客人收單；文案自己寫的「⏰9/12結單」換成系統的", () => {
   const cust = renderPostText(payload({ name: "測試", description: "好吃", customer_end_at: "2026-09-12T10:00:00Z" }, [{ code: "A", name: "x", unit_price: 50 }]));
-  eq(cust, `測試\n\n💰5️⃣0️⃣ 元\n\n⏰ 9/12 18:00 結單\n\n好吃\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "客人收單");
+  eq(cust, `測試\n\n💰5️⃣0️⃣ 元\n\n⏰ 9/12 18:00 結單\n\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "客人收單");
   const own = renderPostText(payload({ name: "測試", description: "⏰9/12結單\n好吃" }, [{ code: "A", name: "x", unit_price: 50 }]));
-  eq(own, `測試\n\n💰5️⃣0️⃣ 元\n\n⏰9/12結單\n好吃\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "文案有結單就不印");
+  eq(own, `測試\n\n💰5️⃣0️⃣ 元\n\n${DL}\n\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "小幫手寫的結單行拿掉、印系統的");
 });
 
 Deno.test("文案列了 (A)(B) 但沒寫價格 → 金額接在同一行，整行只有金額的「💰一袋189元」拿掉", () => {
   const text = renderPostText(payload({ name: "杰哥爆餡韭菜盒 675g", description: "🔥囤起來\n【杰哥爆餡盒子】\n💰一袋189元\n\n(A) 韭菜盒\n(B) 高麗菜盒（全素🌱）\n\n⏰9/14結單\n口味：(A)韭菜盒／(B)高麗菜盒" },
     [{ code: "A", name: "韭菜盒", unit_price: 189, retail_price: 189 }, { code: "B", name: "高麗菜盒", unit_price: 189, retail_price: 189 }]));
-  eq(text, `杰哥爆餡韭菜盒 675g\n\n🔥囤起來\n【杰哥爆餡盒子】\n\n(A) 韭菜盒 1️⃣8️⃣9️⃣ 元\n(B) 高麗菜盒（全素🌱） 1️⃣8️⃣9️⃣ 元\n\n⏰9/14結單\n口味：(A)韭菜盒／(B)高麗菜盒\n\n${HOWTO_MULTI}\n${FINAL}\n#開團\n${tag}`, "接價格、拿掉多的那行");
+  eq(text, `杰哥爆餡韭菜盒 675g\n\n🔥囤起來\n【杰哥爆餡盒子】\n\n(A) 韭菜盒 1️⃣8️⃣9️⃣ 元\n(B) 高麗菜盒（全素🌱） 1️⃣8️⃣9️⃣ 元\n\n${DL}\n\n口味：(A)韭菜盒／(B)高麗菜盒\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "接價格、拿掉多的那行、結單換成系統的接在品項後面");
   const keep = renderPostText(payload({ name: "杰哥", description: "杰哥\n💰滿1000免運\n(A) 韭菜盒 189元\n(B) 高麗菜盒" }, [{ code: "A", name: "韭菜盒", unit_price: 189 }, { code: "B", name: "高麗菜盒", unit_price: 199 }]));
   eq(keep.includes("💰滿1️⃣0️⃣0️⃣0️⃣免運\n(A) 韭菜盒 189元\n(B) 高麗菜盒 1️⃣9️⃣9️⃣ 元"), true, "已有價格的行不動、不是純金額的 💰 行不拿");
 });
 
 Deno.test("整行只有金額的那一行，跟上一行之間空一行", () => {
   const text = renderPostText(payload({ name: "磁吸迷你拆信刀(顏色隨機)", description: "✉️網購族一定懂\n【磁吸迷你拆信刀｜顏色隨機】\n💰105元\n\n🚚15～25天貨到通知\n⏰9/14結單" }, [{ code: "A", name: "拆信刀", unit_price: 105, retail_price: 105 }]));
-  eq(text, `【磁吸迷你拆信刀｜顏色隨機】\n\n✉️網購族一定懂\n\n💰1️⃣0️⃣5️⃣元\n\n🚚15～25天貨到通知\n⏰9/14結單\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "金額行上面補空行");
+  eq(text, `磁吸迷你拆信刀(顏色隨機)\n\n✉️網購族一定懂\n\n💰1️⃣0️⃣5️⃣元\n\n${DL}\n\n🚚15～25天貨到通知\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "金額行上面補空行、結單接在金額後面、標題印團名");
 });
 
-Deno.test("預設版型最後一行「⏰ 最後收單」；沒有店家收單就整行不印", () => {
+Deno.test("沒有結單時間（無到期日）就不印結單那一行", () => {
   const none = renderPostText(payload({ name: "測試", description: "好吃", end_at: null }, [{ code: "A", name: "x", unit_price: 50 }]));
   eq(none, `測試\n\n💰5️⃣0️⃣ 元\n\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "無到期日");
 });

--- a/supabase/functions/_shared/lineNoteRender.test.ts
+++ b/supabase/functions/_shared/lineNoteRender.test.ts
@@ -7,29 +7,30 @@ const HOWTO_MULTI = "📝 留言「品項代碼＋數量」，例：A+1 B+2";
 const HOWTO_SINGLE = "📝 留言「數量」，例：+1";
 const tag = "🔖 團號 GRP-1";
 const DL = "⏰ 9/13 23:59 結單";   // payload 預設 end_at = 2026-09-13T15:59Z（台北 23:59）
+const FINAL = "⏰ 最後收單 9/13 23:59";   // 預設版型最後一行：店家收單
 const payload = (campaign: Record<string, unknown>, items: Record<string, unknown>[], post_template: string | null = null) =>
   ({ post_template, campaign: { campaign_no: "GRP-1", end_at: "2026-09-13T15:59:00Z", ...campaign }, items });
 
 Deno.test("預設版型：先團名、再金額、再結單時間、再文案；單品不印品名", () => {
   const text = renderPostText(payload({ name: "梨山高麗菜", description: "包子媽朋友自己種的" }, [{ code: "A", name: "梨山高麗菜 (A) 半顆", unit_price: 69 }]));
-  eq(text, `梨山高麗菜\n\n💰6️⃣9️⃣ 元\n\n${DL}\n\n包子媽朋友自己種的\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品");
+  eq(text, `梨山高麗菜\n\n💰6️⃣9️⃣ 元\n\n${DL}\n\n包子媽朋友自己種的\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "單品");
 });
 
 Deno.test("多品項才列 (A) 品名 ＋ 同一行金額，教學帶代碼", () => {
   const text = renderPostText(payload({ name: "所長茶葉蛋", description: "超入味" },
     [{ code: "A", name: "所長茶葉蛋 (A) 原味", unit_price: 195 }, { code: "B", name: "所長茶葉蛋 (B) 辣味", unit_price: 205 }]));
-  eq(text, `所長茶葉蛋\n\n(A) 原味 1️⃣9️⃣5️⃣ 元\n(B) 辣味 2️⃣0️⃣5️⃣ 元\n\n${DL}\n\n超入味\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "多品項");
+  eq(text, `所長茶葉蛋\n\n(A) 原味 1️⃣9️⃣5️⃣ 元\n(B) 辣味 2️⃣0️⃣5️⃣ 元\n\n${DL}\n\n超入味\n\n${HOWTO_MULTI}\n${FINAL}\n#開團\n${tag}`, "多品項");
 });
 
 Deno.test("文案第一行就是團名 → 搬到最上面當標題（留住表情符號），不印兩次", () => {
   const text = renderPostText(payload({ name: "所長茶葉蛋", description: "<p>⭐️ <strong>所長茶葉蛋</strong></p><p>超入味</p>" },
     [{ code: "A", name: "原味", unit_price: 195 }]));
-  eq(text, `⭐️ 所長茶葉蛋\n\n💰1️⃣9️⃣5️⃣ 元\n\n${DL}\n\n超入味\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "標題搬上去、HTML 也轉好");
+  eq(text, `⭐️ 所長茶葉蛋\n\n💰1️⃣9️⃣5️⃣ 元\n\n${DL}\n\n超入味\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "標題搬上去、HTML 也轉好");
 });
 
 Deno.test("記事本匯進來的單品文案已經寫了同一個金額 → 不再多印一行", () => {
   const text = renderPostText(payload({ name: "梨山高麗菜", description: "梨山高麗菜\n半顆($)(6)(9)\n(emoji)9/9到貨" }, [{ code: "A", name: "半顆", unit_price: 69 }]));
-  eq(text, `梨山高麗菜\n\n${DL}\n\n半顆💲6️⃣9️⃣\n9/9到貨\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "金額只出現一次（行內金額不另外空行）");
+  eq(text, `梨山高麗菜\n\n${DL}\n\n半顆💲6️⃣9️⃣\n9/9到貨\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "金額只出現一次（行內金額不另外空行）");
   const diff = renderPostText(payload({ name: "梨山高麗菜", description: "梨山高麗菜\n半顆($)(6)(9)" }, [{ code: "A", name: "半顆", unit_price: 75 }]));
   eq(diff.includes("💰7️⃣5️⃣ 元") && diff.includes("半顆💲6️⃣9️⃣"), true, "金額不一樣就兩個都印，讓人看得出來要改");
 });
@@ -37,7 +38,7 @@ Deno.test("記事本匯進來的單品文案已經寫了同一個金額 → 不�
 Deno.test("文案自己列了 (A)(B) 品項 → 商品段留空；記事本「價格在下一行」的寫法併成同一行", () => {
   const text = renderPostText(payload({ name: "阿土伯", description: "阿土伯\n(A)空心菜\n($)(3)(5)\n(B)小白菜\n($)(3)(5)" },
     [{ code: "A", name: "空心菜", unit_price: 35 }, { code: "B", name: "小白菜", unit_price: 35 }]));
-  eq(text, `阿土伯\n\n${DL}\n\n(A)空心菜 3️⃣5️⃣ 元\n(B)小白菜 3️⃣5️⃣ 元\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "不重複列品項、併成一行");
+  eq(text, `阿土伯\n\n${DL}\n\n(A)空心菜 3️⃣5️⃣ 元\n(B)小白菜 3️⃣5️⃣ 元\n\n${HOWTO_MULTI}\n${FINAL}\n#開團\n${tag}`, "不重複列品項、併成一行");
   const diff = renderPostText(payload({ name: "阿土伯", description: "阿土伯\n(A)空心菜\n($)(3)(0)\n(B)小白菜\n($)(3)(5)" },
     [{ code: "A", name: "空心菜", unit_price: 35 }, { code: "B", name: "小白菜", unit_price: 35 }]));
   eq(diff.includes("(A)空心菜\n💲3️⃣0️⃣\n(B)小白菜 3️⃣5️⃣ 元"), true, "小幫手寫的價格跟零售價不一樣 → 那一組兩行都不動、也不拆開");
@@ -51,7 +52,7 @@ Deno.test("自訂模板：{{deadline}} / {{end_at}} 照舊可用，沒寫 {{tag}
 Deno.test("文案用 A. B. 列品項（品名裡也帶 A.）→ 商品段留空，💰 價格照樣凸顯；口號在前、品名在第二行也認得出標題", () => {
   const text = renderPostText(payload({ name: "所長茶葉蛋", description: "<p>買一送一！</p><p>⭐️ <strong>所長茶葉蛋</strong></p><p>A. 經典原味 💰195<br>B. 麻香辣味 💰205</p>" },
     [{ code: "A", name: "A. 經典原味", unit_price: 195 }, { code: "B", name: "B. 麻香辣味", unit_price: 205 }]));
-  eq(text, `⭐️ 所長茶葉蛋\n\n${DL}\n\n買一送一！\nA. 經典原味 💰1️⃣9️⃣5️⃣\nB. 麻香辣味 💰2️⃣0️⃣5️⃣\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "A. 列表");
+  eq(text, `⭐️ 所長茶葉蛋\n\n${DL}\n\n買一送一！\nA. 經典原味 💰1️⃣9️⃣5️⃣\nB. 麻香辣味 💰2️⃣0️⃣5️⃣\n\n${HOWTO_MULTI}\n${FINAL}\n#開團\n${tag}`, "A. 列表");
   const own = renderPostText(payload({ name: "所長茶葉蛋", description: "超入味" }, [{ code: "A", name: "A. 經典原味", unit_price: 195 }, { code: "B", name: "B. 麻香辣味", unit_price: 205 }]));
   eq(own.includes("(A) 經典原味 1️⃣9️⃣5️⃣ 元\n(B) 麻香辣味 2️⃣0️⃣5️⃣ 元"), true, "品名裡的 A. 不印兩次");
 });
@@ -61,33 +62,38 @@ Deno.test("金額一律用零售價；沒設零售價（NULL / 0）才退回團�
     [{ code: "A", name: "蝦餃", unit_price: 168, retail_price: 249 }, { code: "B", name: "燒賣", unit_price: 69, retail_price: 0 }, { code: "C", name: "腸粉", unit_price: 88 }]));
   eq(text.includes("(A) 蝦餃 2️⃣4️⃣9️⃣ 元\n(B) 燒賣 6️⃣9️⃣ 元\n(C) 腸粉 8️⃣8️⃣ 元"), true, "零售價優先");
   const single = renderPostText(payload({ name: "高麗菜", description: "高麗菜\n半顆($)(6)(9)" }, [{ code: "A", name: "半顆", unit_price: 60, retail_price: 69 }]));
-  eq(single, `高麗菜\n\n${DL}\n\n半顆💲6️⃣9️⃣\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品去重也是拿零售價比");
+  eq(single, `高麗菜\n\n${DL}\n\n半顆💲6️⃣9️⃣\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "單品去重也是拿零售價比");
 });
 
-Deno.test("{{deadline}} / {{end_at}} 印客人收單；沒設客人收單就印店家收單", () => {
+Deno.test("{{deadline}} 印客人收單（沒設就是店家收單）；{{end_at}} 一律店家收單", () => {
   const tpl = "{{name}}\n{{deadline}}\n{{end_at}}";
   const both = renderPostText(payload({ name: "測試", description: "", customer_end_at: "2026-09-12T10:00:00Z" }, [{ code: "A", name: "x", unit_price: 1 }], tpl));
-  eq(both, `測試\n⏰ 9/12 18:00 結單\n9/12 18:00\n${tag}`, "客人收單優先");
+  eq(both, `測試\n⏰ 9/12 18:00 結單\n9/13 23:59\n${tag}`, "{{deadline}} 客人收單、{{end_at}} 店家收單");
   const only = renderPostText(payload({ name: "測試", description: "" }, [{ code: "A", name: "x", unit_price: 1 }], tpl));
   eq(only, `測試\n⏰ 9/13 23:59 結單\n9/13 23:59\n${tag}`, "退回店家收單");
 });
 
 Deno.test("預設版型的結單時間印客人收單；文案自己寫了結單就不重複", () => {
   const cust = renderPostText(payload({ name: "測試", description: "好吃", customer_end_at: "2026-09-12T10:00:00Z" }, [{ code: "A", name: "x", unit_price: 50 }]));
-  eq(cust, `測試\n\n💰5️⃣0️⃣ 元\n\n⏰ 9/12 18:00 結單\n\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "客人收單");
+  eq(cust, `測試\n\n💰5️⃣0️⃣ 元\n\n⏰ 9/12 18:00 結單\n\n好吃\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "客人收單");
   const own = renderPostText(payload({ name: "測試", description: "⏰9/12結單\n好吃" }, [{ code: "A", name: "x", unit_price: 50 }]));
-  eq(own, `測試\n\n💰5️⃣0️⃣ 元\n\n⏰9/12結單\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "文案有結單就不印");
+  eq(own, `測試\n\n💰5️⃣0️⃣ 元\n\n⏰9/12結單\n好吃\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "文案有結單就不印");
 });
 
 Deno.test("文案列了 (A)(B) 但沒寫價格 → 金額接在同一行，整行只有金額的「💰一袋189元」拿掉", () => {
   const text = renderPostText(payload({ name: "杰哥爆餡韭菜盒 675g", description: "🔥囤起來\n【杰哥爆餡盒子】\n💰一袋189元\n\n(A) 韭菜盒\n(B) 高麗菜盒（全素🌱）\n\n⏰9/14結單\n口味：(A)韭菜盒／(B)高麗菜盒" },
     [{ code: "A", name: "韭菜盒", unit_price: 189, retail_price: 189 }, { code: "B", name: "高麗菜盒", unit_price: 189, retail_price: 189 }]));
-  eq(text, `杰哥爆餡韭菜盒 675g\n\n🔥囤起來\n【杰哥爆餡盒子】\n\n(A) 韭菜盒 1️⃣8️⃣9️⃣ 元\n(B) 高麗菜盒（全素🌱） 1️⃣8️⃣9️⃣ 元\n\n⏰9/14結單\n口味：(A)韭菜盒／(B)高麗菜盒\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "接價格、拿掉多的那行");
+  eq(text, `杰哥爆餡韭菜盒 675g\n\n🔥囤起來\n【杰哥爆餡盒子】\n\n(A) 韭菜盒 1️⃣8️⃣9️⃣ 元\n(B) 高麗菜盒（全素🌱） 1️⃣8️⃣9️⃣ 元\n\n⏰9/14結單\n口味：(A)韭菜盒／(B)高麗菜盒\n\n${HOWTO_MULTI}\n${FINAL}\n#開團\n${tag}`, "接價格、拿掉多的那行");
   const keep = renderPostText(payload({ name: "杰哥", description: "杰哥\n💰滿1000免運\n(A) 韭菜盒 189元\n(B) 高麗菜盒" }, [{ code: "A", name: "韭菜盒", unit_price: 189 }, { code: "B", name: "高麗菜盒", unit_price: 199 }]));
   eq(keep.includes("💰滿1️⃣0️⃣0️⃣0️⃣免運\n(A) 韭菜盒 189元\n(B) 高麗菜盒 1️⃣9️⃣9️⃣ 元"), true, "已有價格的行不動、不是純金額的 💰 行不拿");
 });
 
 Deno.test("整行只有金額的那一行，跟上一行之間空一行", () => {
   const text = renderPostText(payload({ name: "磁吸迷你拆信刀(顏色隨機)", description: "✉️網購族一定懂\n【磁吸迷你拆信刀｜顏色隨機】\n💰105元\n\n🚚15～25天貨到通知\n⏰9/14結單" }, [{ code: "A", name: "拆信刀", unit_price: 105, retail_price: 105 }]));
-  eq(text, `【磁吸迷你拆信刀｜顏色隨機】\n\n✉️網購族一定懂\n\n💰1️⃣0️⃣5️⃣元\n\n🚚15～25天貨到通知\n⏰9/14結單\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "金額行上面補空行");
+  eq(text, `【磁吸迷你拆信刀｜顏色隨機】\n\n✉️網購族一定懂\n\n💰1️⃣0️⃣5️⃣元\n\n🚚15～25天貨到通知\n⏰9/14結單\n\n${HOWTO_SINGLE}\n${FINAL}\n#開團\n${tag}`, "金額行上面補空行");
+});
+
+Deno.test("預設版型最後一行「⏰ 最後收單」；沒有店家收單就整行不印", () => {
+  const none = renderPostText(payload({ name: "測試", description: "好吃", end_at: null }, [{ code: "A", name: "x", unit_price: 50 }]));
+  eq(none, `測試\n\n💰5️⃣0️⃣ 元\n\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "無到期日");
 });

--- a/supabase/functions/_shared/lineNoteRender.test.ts
+++ b/supabase/functions/_shared/lineNoteRender.test.ts
@@ -3,8 +3,8 @@ import { renderPostText } from "./lineNoteRender.ts";
 const eq = (got: unknown, want: unknown, why: string) => {
   if (got !== want) throw new Error(`${why}\n  想要 ${JSON.stringify(want)}\n  拿到 ${JSON.stringify(got)}`);
 };
-const HOWTO_MULTI = "📝 留言「會員編號 6 碼 ＋ 品項代碼＋數量」，例：123456 A+1 B+2";
-const HOWTO_SINGLE = "📝 留言「會員編號 6 碼 ＋ 數量」，例：123456 +1";
+const HOWTO_MULTI = "📝 留言「品項代碼＋數量」，例：A+1 B+2";
+const HOWTO_SINGLE = "📝 留言「數量」，例：+1";
 const tag = "🔖 團號 GRP-1";
 const DL = "⏰ 9/13 23:59 結單";   // payload 預設 end_at = 2026-09-13T15:59Z（台北 23:59）
 const payload = (campaign: Record<string, unknown>, items: Record<string, unknown>[], post_template: string | null = null) =>

--- a/supabase/functions/_shared/lineNoteRender.test.ts
+++ b/supabase/functions/_shared/lineNoteRender.test.ts
@@ -6,29 +6,30 @@ const eq = (got: unknown, want: unknown, why: string) => {
 const HOWTO_MULTI = "📝 留言「會員編號 6 碼 ＋ 品項代碼＋數量」，例：123456 A+1 B+2";
 const HOWTO_SINGLE = "📝 留言「會員編號 6 碼 ＋ 數量」，例：123456 +1";
 const tag = "🔖 團號 GRP-1";
+const DL = "⏰ 9/13 23:59 結單";   // payload 預設 end_at = 2026-09-13T15:59Z（台北 23:59）
 const payload = (campaign: Record<string, unknown>, items: Record<string, unknown>[], post_template: string | null = null) =>
   ({ post_template, campaign: { campaign_no: "GRP-1", end_at: "2026-09-13T15:59:00Z", ...campaign }, items });
 
-Deno.test("預設版型：先團名、再金額、再文案；單品不印品名，結單時間不印", () => {
+Deno.test("預設版型：先團名、再金額、再結單時間、再文案；單品不印品名", () => {
   const text = renderPostText(payload({ name: "梨山高麗菜", description: "包子媽朋友自己種的" }, [{ code: "A", name: "梨山高麗菜 (A) 半顆", unit_price: 69 }]));
-  eq(text, `梨山高麗菜\n\n💲6️⃣9️⃣\n\n包子媽朋友自己種的\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品");
+  eq(text, `梨山高麗菜\n\n💲6️⃣9️⃣\n\n${DL}\n\n包子媽朋友自己種的\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品");
 });
 
 Deno.test("多品項才列 (A) 品名 ＋ 下一行金額，教學帶代碼", () => {
   const text = renderPostText(payload({ name: "所長茶葉蛋", description: "超入味" },
     [{ code: "A", name: "所長茶葉蛋 (A) 原味", unit_price: 195 }, { code: "B", name: "所長茶葉蛋 (B) 辣味", unit_price: 205 }]));
-  eq(text, `所長茶葉蛋\n\n(A) 原味\n💲1️⃣9️⃣5️⃣\n(B) 辣味\n💲2️⃣0️⃣5️⃣\n\n超入味\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "多品項");
+  eq(text, `所長茶葉蛋\n\n(A) 原味\n💲1️⃣9️⃣5️⃣\n(B) 辣味\n💲2️⃣0️⃣5️⃣\n\n${DL}\n\n超入味\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "多品項");
 });
 
 Deno.test("文案第一行就是團名 → 搬到最上面當標題（留住表情符號），不印兩次", () => {
   const text = renderPostText(payload({ name: "所長茶葉蛋", description: "<p>⭐️ <strong>所長茶葉蛋</strong></p><p>超入味</p>" },
     [{ code: "A", name: "原味", unit_price: 195 }]));
-  eq(text, `⭐️ 所長茶葉蛋\n\n💲1️⃣9️⃣5️⃣\n\n超入味\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "標題搬上去、HTML 也轉好");
+  eq(text, `⭐️ 所長茶葉蛋\n\n💲1️⃣9️⃣5️⃣\n\n${DL}\n\n超入味\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "標題搬上去、HTML 也轉好");
 });
 
 Deno.test("記事本匯進來的單品文案已經寫了同一個金額 → 不再多印一行", () => {
   const text = renderPostText(payload({ name: "梨山高麗菜", description: "梨山高麗菜\n半顆($)(6)(9)\n(emoji)9/9到貨" }, [{ code: "A", name: "半顆", unit_price: 69 }]));
-  eq(text, `梨山高麗菜\n\n半顆💲6️⃣9️⃣\n9/9到貨\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "金額只出現一次");
+  eq(text, `梨山高麗菜\n\n${DL}\n\n半顆💲6️⃣9️⃣\n9/9到貨\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "金額只出現一次");
   const diff = renderPostText(payload({ name: "梨山高麗菜", description: "梨山高麗菜\n半顆($)(6)(9)" }, [{ code: "A", name: "半顆", unit_price: 75 }]));
   eq(diff.includes("💲7️⃣5️⃣") && diff.includes("半顆💲6️⃣9️⃣"), true, "金額不一樣就兩個都印，讓人看得出來要改");
 });
@@ -36,7 +37,7 @@ Deno.test("記事本匯進來的單品文案已經寫了同一個金額 → 不�
 Deno.test("文案自己列了 (A)(B) 品項 → 商品段留空", () => {
   const text = renderPostText(payload({ name: "阿土伯", description: "阿土伯\n(A)空心菜\n($)(3)(5)\n(B)小白菜\n($)(3)(5)" },
     [{ code: "A", name: "空心菜", unit_price: 35 }, { code: "B", name: "小白菜", unit_price: 35 }]));
-  eq(text, `阿土伯\n\n(A)空心菜\n💲3️⃣5️⃣\n(B)小白菜\n💲3️⃣5️⃣\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "不重複列品項");
+  eq(text, `阿土伯\n\n${DL}\n\n(A)空心菜\n💲3️⃣5️⃣\n(B)小白菜\n💲3️⃣5️⃣\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "不重複列品項");
 });
 
 Deno.test("自訂模板：{{deadline}} / {{end_at}} 照舊可用，沒寫 {{tag}} 也會補章", () => {
@@ -47,7 +48,7 @@ Deno.test("自訂模板：{{deadline}} / {{end_at}} 照舊可用，沒寫 {{tag}
 Deno.test("文案用 A. B. 列品項（品名裡也帶 A.）→ 商品段留空，💰 價格照樣凸顯；口號在前、品名在第二行也認得出標題", () => {
   const text = renderPostText(payload({ name: "所長茶葉蛋", description: "<p>買一送一！</p><p>⭐️ <strong>所長茶葉蛋</strong></p><p>A. 經典原味 💰195<br>B. 麻香辣味 💰205</p>" },
     [{ code: "A", name: "A. 經典原味", unit_price: 195 }, { code: "B", name: "B. 麻香辣味", unit_price: 205 }]));
-  eq(text, `⭐️ 所長茶葉蛋\n\n買一送一！\nA. 經典原味 💰1️⃣9️⃣5️⃣\nB. 麻香辣味 💰2️⃣0️⃣5️⃣\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "A. 列表");
+  eq(text, `⭐️ 所長茶葉蛋\n\n${DL}\n\n買一送一！\nA. 經典原味 💰1️⃣9️⃣5️⃣\nB. 麻香辣味 💰2️⃣0️⃣5️⃣\n\n${HOWTO_MULTI}\n#開團\n${tag}`, "A. 列表");
   const own = renderPostText(payload({ name: "所長茶葉蛋", description: "超入味" }, [{ code: "A", name: "A. 經典原味", unit_price: 195 }, { code: "B", name: "B. 麻香辣味", unit_price: 205 }]));
   eq(own.includes("(A) 經典原味\n💲1️⃣9️⃣5️⃣\n(B) 麻香辣味"), true, "品名裡的 A. 不印兩次");
 });
@@ -57,7 +58,7 @@ Deno.test("金額一律用零售價；沒設零售價（NULL / 0）才退回團�
     [{ code: "A", name: "蝦餃", unit_price: 168, retail_price: 249 }, { code: "B", name: "燒賣", unit_price: 69, retail_price: 0 }, { code: "C", name: "腸粉", unit_price: 88 }]));
   eq(text.includes("(A) 蝦餃\n💲2️⃣4️⃣9️⃣\n(B) 燒賣\n💲6️⃣9️⃣\n(C) 腸粉\n💲8️⃣8️⃣"), true, "零售價優先");
   const single = renderPostText(payload({ name: "高麗菜", description: "高麗菜\n半顆($)(6)(9)" }, [{ code: "A", name: "半顆", unit_price: 60, retail_price: 69 }]));
-  eq(single, `高麗菜\n\n半顆💲6️⃣9️⃣\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品去重也是拿零售價比");
+  eq(single, `高麗菜\n\n${DL}\n\n半顆💲6️⃣9️⃣\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "單品去重也是拿零售價比");
 });
 
 Deno.test("{{deadline}} / {{end_at}} 印客人收單；沒設客人收單就印店家收單", () => {
@@ -66,4 +67,11 @@ Deno.test("{{deadline}} / {{end_at}} 印客人收單；沒設客人收單就印�
   eq(both, `測試\n⏰ 9/12 18:00 結單\n9/12 18:00\n${tag}`, "客人收單優先");
   const only = renderPostText(payload({ name: "測試", description: "" }, [{ code: "A", name: "x", unit_price: 1 }], tpl));
   eq(only, `測試\n⏰ 9/13 23:59 結單\n9/13 23:59\n${tag}`, "退回店家收單");
+});
+
+Deno.test("預設版型的結單時間印客人收單；文案自己寫了結單就不重複", () => {
+  const cust = renderPostText(payload({ name: "測試", description: "好吃", customer_end_at: "2026-09-12T10:00:00Z" }, [{ code: "A", name: "x", unit_price: 50 }]));
+  eq(cust, `測試\n\n💲5️⃣0️⃣\n\n⏰ 9/12 18:00 結單\n\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "客人收單");
+  const own = renderPostText(payload({ name: "測試", description: "⏰9/12結單\n好吃" }, [{ code: "A", name: "x", unit_price: 50 }]));
+  eq(own, `測試\n\n💲5️⃣0️⃣\n\n⏰9/12結單\n好吃\n\n${HOWTO_SINGLE}\n#開團\n${tag}`, "文案有結單就不印");
 });

--- a/supabase/functions/_shared/lineNoteRender.ts
+++ b/supabase/functions/_shared/lineNoteRender.ts
@@ -4,7 +4,7 @@
 //
 // 版型照小幫手手貼的樣子：團名開頭、接著金額、再來才是文案，#開團 收尾。
 // 2026-09-10 老闆指定：先團名、再商品；只有一個品項就不印品名／代碼、直接金額；
-// 多品項才 (A) 品名 ＋ 下一行金額；結單時間不印。
+// 多品項才 (A) 品名 ＋ 下一行金額；結單時間印「客人收單」（customer_end_at，沒設就是店家收單）。
 //
 // 文案本體吃 campaign.description —— 那本來就是商品那邊寫好的行銷文（線上近兩週 377/395 團有）。
 // {{title}} / {{items}} / {{deadline}} / {{howto}} 是「聰明版」：文案自己已經寫過的就不再重複一次。
@@ -22,6 +22,8 @@ export const TZ = "Asia/Taipei";
 export const DEFAULT_TEMPLATE = `{{title}}
 
 {{items}}
+
+{{deadline}}
 
 {{description}}
 
@@ -116,7 +118,7 @@ export function renderTemplate(template: string | null, payload: any) {
   const descHasThisPrice = single && postPrice(items[0]) != null && decoPricesIn(desc).includes(postPrice(items[0]));
   const descHasDeadline = /結單|收單|截單/.test(desc);
   // 客人看的結單時間 = 客人收單（customer_end_at，20260910050000）跟店家收單取早的那個；
-  // 客人收單沒設就是店家收單。預設版型不印，自訂模板的 {{deadline}} / {{end_at}} 才會用到。
+  // 客人收單沒設就是店家收單。店家收單是小幫手還能補單的最後期限，客人不用知道。
   const closeAt = earliest(c.customer_end_at, c.end_at);
   const deadline = closeAt ? `⏰ ${fmtTaipei(closeAt)} 結單` : "";
 

--- a/supabase/functions/_shared/lineNoteRender.ts
+++ b/supabase/functions/_shared/lineNoteRender.ts
@@ -68,9 +68,63 @@ function fmtTaipei(iso: string | null | undefined) {
 // 貼文的金額一律用零售價（老闆 2026-09-10 交代）：unit_price 是團購價、開團後可以另外改低，
 // 社群貼文要的是現行零售價（payload 的 retail_price，20260910040000）。沒設零售價（NULL / 0）才退回團購價。
 function postPrice(it: any): number | null {
+  if (!it) return null;
   const retail = Number(it?.retail_price);
   if (Number.isFinite(retail) && retail > 0) return retail;
   return it?.unit_price == null ? null : Number(it.unit_price);
+}
+
+// 這一行已經有價格了嗎（純文字 189元／$189、已標起來的、或小幫手自己打的鍵帽數字）
+const LINE_HAS_PRICE = new RegExp(`\\d\\s*元|\\$\\s*\\d|${DECO_OPEN}|[0-9]\\uFE0F\\u20E3`);
+// 整行只有一個金額（「💰一袋189元」「$109」，已經被標起來的樣子）
+const PRICE_ONLY_LINE = new RegExp(`^\\s*(?:💰[^\\d\\n$💰]{0,6})?${DECO_OPEN}\\$?(\\d+(?:\\.\\d+)?)${DECO_CLOSE}\\s*元?\\s*$`);
+
+const ITEM_LINE = /^\s*(?:[(（]([A-Za-z])[)）]|([A-Za-z])[.．、:：])\s*(.*)$/;
+
+function injectItemPrices(desc: string, items: any[]): string {
+  const byCode = new Map<string, any>(items.map((it: any) => [String(it.code ?? "").toUpperCase(), it]));
+  const lines = desc.split("\n");
+  let injected = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(ITEM_LINE);
+    if (!m) continue;
+    const rest = m[3] ?? "";
+    if (/[(（][A-Za-z][)）]/.test(rest)) continue;          // 「(A)韭菜盒／(B)高麗菜盒」一行列兩個，不碰
+    const p = postPrice(byCode.get((m[1] ?? m[2]).toUpperCase()));
+    if (p == null || LINE_HAS_PRICE.test(lines[i])) continue;
+    // 記事本寫法：價格寫在下一行（「(A)空心菜200g／($)(3)(5)」）→ 跟零售價一樣就併進品項那一行；
+    // 不一樣就兩行都不動，預覽看得到、讓人去改團或改文案
+    let j = i + 1;
+    while (j < lines.length && !lines[j].trim()) j++;
+    const nm = j < lines.length ? lines[j].match(PRICE_ONLY_LINE) : null;
+    if (nm) {
+      if (Number(nm[1]) !== p) continue;
+      lines.splice(j, 1);
+    }
+    lines[i] = `${lines[i].trimEnd()} ${decoPrice(String(p))} 元`;
+    injected++;
+  }
+  if (!injected) return desc;
+  // 接完之後，文案裡整行只寫同一個金額的「💰一袋189元」就是多的；緊跟在品項後面的那種上面已經處理過，不碰
+  const prices = new Set(items.map((it: any) => postPrice(it)).filter((x) => x != null));
+  let prevText = "";
+  return lines.filter((line) => {
+    const m = line.match(PRICE_ONLY_LINE);
+    const drop = m && prices.has(Number(m[1])) && !ITEM_LINE.test(prevText);
+    if (line.trim()) prevText = line;
+    return !drop;
+  }).join("\n");
+}
+
+// 整行只有金額的那一行，上面沒有空行就補一行（緊跟在品項後面的那種是那一項的價格，不拆開）
+function spaceOutPriceLines(desc: string): string {
+  const out: string[] = [];
+  for (const line of desc.split("\n")) {
+    const prev = out.length ? out[out.length - 1] : "";
+    if (PRICE_ONLY_LINE.test(line) && prev.trim() && !ITEM_LINE.test(prev)) out.push("");
+    out.push(line);
+  }
+  return out.join("\n");
 }
 
 // 文案裡已經標起來的金額（記事本佔位字還原的、獨立一行的 $數字、💰 後面的數字）
@@ -106,14 +160,22 @@ export function renderTemplate(template: string | null, payload: any) {
     break;
   }
 
-  // 商品：只有一項 → 直接金額（沒有品名、沒有代碼）；多項 → (A) 品名 ＋ 下一行金額
+  // 商品（老闆 2026-09-10 的範例）：只有一項 → 「💰1️⃣0️⃣5️⃣ 元」一行，沒有品名、沒有代碼；
+  // 多項 → 「(A) 韭菜盒 1️⃣8️⃣9️⃣ 元」金額接在同一行
   const itemLines = items.map((it: any) => {
     const p = postPrice(it);
-    const price = p == null ? "" : decoPrice(`$${p}`);
-    if (single) return price;
+    const price = p == null ? "" : `${decoPrice(String(p))} 元`;
+    if (single) return price ? `💰${price}` : "";
     const label = itemLabel(it.name, it.code, c.name);
-    return `(${it.code}) ${label}${price ? `\n${price}` : ""}`;
+    return `(${it.code}) ${label}${price ? ` ${price}` : ""}`;
   }).filter(Boolean).join("\n");
+
+  // 文案自己列了 (A)(B) 品項但那一行沒寫價格（也不是像記事本那樣價格寫在下一行）→
+  // 把金額接在那一行後面，變成跟我們自己產的一樣「(A) 韭菜盒 1️⃣8️⃣9️⃣ 元」。
+  // 接完之後，文案裡只寫著同一個金額的「💰一袋189元」那種整行就是多的，拿掉。
+  desc = injectItemPrices(desc, items);
+  // 老闆 2026-09-10：金額行跟上一行之間要空一行（「💰1️⃣0️⃣5️⃣元」直接貼在文案下面太擠）
+  desc = spaceOutPriceLines(desc);
   // 文案自己就列了 (A)(B) 或 A. B. 品項 → 不重複；單品而文案已經寫了同一個金額（「一個$125」）→ 也不重複
   const descHasItems = /(^|\n)\s*(?:[(（][A-Za-z][)）]|[A-Za-z][.．、:：])/.test(desc);
   const descHasThisPrice = single && postPrice(items[0]) != null && decoPricesIn(desc).includes(postPrice(items[0]));

--- a/supabase/functions/_shared/lineNoteRender.ts
+++ b/supabase/functions/_shared/lineNoteRender.ts
@@ -31,9 +31,10 @@ export const DEFAULT_TEMPLATE = `{{title}}
 #開團
 {{tag}}`;
 
-// 留言教學：單品的貼文上沒有代碼，教學就不要提代碼（+1 沒帶代碼時 RPC 會落到唯一那一項）
-const HOWTO_MULTI = "📝 留言「會員編號 6 碼 ＋ 品項代碼＋數量」，例：123456 A+1 B+2";
-const HOWTO_SINGLE = "📝 留言「會員編號 6 碼 ＋ 數量」，例：123456 +1";
+// 留言教學（老闆 2026-09-10 定稿：不提會員編號）。單品的貼文上沒有代碼，教學就不要提代碼
+// （+1 沒帶代碼時 RPC 會落到唯一那一項）。
+const HOWTO_MULTI = "📝 留言「品項代碼＋數量」，例：A+1 B+2";
+const HOWTO_SINGLE = "📝 留言「數量」，例：+1";
 
 // 比對標題用：去掉表情符號、空白、標點，只留文字
 function bareText(s: string) {

--- a/supabase/functions/_shared/lineNoteRender.ts
+++ b/supabase/functions/_shared/lineNoteRender.ts
@@ -10,8 +10,10 @@
 // {{title}} / {{items}} / {{deadline}} / {{howto}} 是「聰明版」：文案自己已經寫過的就不再重複一次。
 // 從記事本匯進來的團，description 常常就是整篇貼文（標題＋(A)(B)品項＋⏰結單都在裡面），
 // 照樣接上去會變成品項印兩次、結單寫兩行。
-// {{name}} 維持原樣（照印）。{{deadline}} 是客人看的結單時間（客人收單，沒設就是店家收單）；
-// {{end_at}} 是店家收單（最後收單時間），老闆 2026-09-10 指定放在最後一行「⏰ 最後收單 9/15 23:59」。
+// {{name}} 維持原樣（照印）。{{deadline}} / {{end_at}} 是客人看的結單時間（客人收單，沒設就是店家收單）；
+// 店家收單是小幫手還能補單的最後期限，貼文上不印。
+// 結單那一行放在金額後面（老闆 2026-09-10 的範例）：文案自己有價格時就插進文案裡金額那一段的後面，
+// 文案自己寫的「⏰9/14結單」換成系統的時間。
 // {{tag}} 是團號章（🔖 團號 GRP-…）：爬回來的時候靠它精準認出是哪一團，不用猜團名。
 // 自訂模板沒寫 {{tag}} 也會被 withPostTag 補在文末 —— 章一定要有，不然這篇就只能靠猜。
 // ─────────────────────────────────────────────────────────────────────────────
@@ -29,7 +31,6 @@ export const DEFAULT_TEMPLATE = `{{title}}
 {{description}}
 
 {{howto}}
-⏰ 最後收單 {{end_at}}
 #開團
 {{tag}}`;
 
@@ -118,6 +119,26 @@ function injectItemPrices(desc: string, items: any[]): string {
   }).join("\n");
 }
 
+// 小幫手自己寫的結單那一行：「⏰9/14結單」「📅 9/8（二）晚上六點結單」—— 開頭最多三個字（表情符號），
+// 接著日期，結尾是結單／收單／截單。「結單後15-25天到貨」那種句子不算。
+const HELPER_DEADLINE_LINE = /^[^\d\n]{0,3}\d{1,2}[\/／月]\d{1,2}.*(?:結單|收單|截單)[^\d\n]{0,3}$/;
+
+// 把系統的結單那一行插進文案：先把小幫手自己寫的結單行拿掉（時間以系統為準），
+// 再找文案裡第一段連續的金額行（「💰95元」或「(A) 韭菜盒 1️⃣8️⃣9️⃣ 元」），插在那一段後面、前後各空一行。
+// 文案裡沒有金額行就不插（回 placed=false，走版型的 {{deadline}}）。
+function placeDeadline(desc: string, deadline: string): { desc: string; placed: boolean } {
+  if (!deadline) return { desc, placed: false };
+  const lines = desc.split("\n").filter((l) => !HELPER_DEADLINE_LINE.test(l.trim()));
+  const isPrice = (l: string) => l.includes(DECO_OPEN) || (ITEM_LINE.test(l) && LINE_HAS_PRICE.test(l));
+  const start = lines.findIndex(isPrice);
+  if (start < 0) return { desc: lines.join("\n"), placed: false };
+  let end = start;
+  while (end + 1 < lines.length && isPrice(lines[end + 1])) end++;
+  const after = lines[end + 1];
+  lines.splice(end + 1, 0, "", deadline, ...(after !== undefined && after.trim() ? [""] : []));
+  return { desc: lines.join("\n"), placed: true };
+}
+
 // 整行只有金額的那一行，上面沒有空行就補一行（緊跟在品項後面的那種是那一項的價格，不拆開）
 function spaceOutPriceLines(desc: string): string {
   const out: string[] = [];
@@ -142,10 +163,11 @@ export function renderTemplate(template: string | null, payload: any) {
   // 文案：富文字 HTML 轉純文字 → 記事本佔位字還原（金額順手標起來）→ 文案自己寫的價格也標起來
   let desc = decoTextPrices(stripLineDeco(htmlToText(c.description ?? "")));
 
-  // 文案開頭幾行裡有一行就是團名（匯進來的團幾乎都是第一行，也有先喊一句口號再寫品名的）
-  // → 那一行搬到最上面當標題，不要印兩次。用文案的那一行而不是 c.name，
-  // 小幫手打在標題上的表情符號才留得住。太短的行只認完全一樣，免得誤中。
-  let title = c.name ?? "";
+  // 標題一律印團名（老闆 2026-09-10：「商品 G02580 title 是 兒童防擠壓飲料杯托 (顏色隨機)」，
+  // 不要拿文案裡的「【兒童防擠壓飲料杯托｜顏色隨機】」當標題）。文案開頭幾行裡跟團名一樣的那一行
+  // （匯進來的團幾乎都是第一行，也有先喊一句口號再寫品名的）拿掉，不要印兩次。
+  // 太短的行只認完全一樣，免得誤中。
+  const title = c.name ?? "";
   const bareName = bareText(c.name ?? "");
   const lines = desc.split("\n");
   let seen = 0;
@@ -156,7 +178,6 @@ export function renderTemplate(template: string | null, payload: any) {
     const bare = bareText(line);
     const hit = bareName && (bare === bareName || (bare.length >= 4 && (bareName.includes(bare) || bare.includes(bareName))));
     if (!hit) continue;
-    title = line;
     lines.splice(i, 1);
     desc = lines.join("\n").replace(/^\n+/, "");
     break;
@@ -178,28 +199,28 @@ export function renderTemplate(template: string | null, payload: any) {
   desc = injectItemPrices(desc, items);
   // 老闆 2026-09-10：金額行跟上一行之間要空一行（「💰1️⃣0️⃣5️⃣元」直接貼在文案下面太擠）
   desc = spaceOutPriceLines(desc);
+  // 結單那一行：客人看的結單時間 = 客人收單（customer_end_at，20260910050000）跟店家收單取早的那個；
+  // 客人收單沒設就是店家收單。文案自己有金額時插在金額那一段後面，沒有就走版型的 {{deadline}}。
+  const closeAt = earliest(c.customer_end_at, c.end_at);
+  const deadline = closeAt ? `⏰ ${fmtTaipei(closeAt)} 結單` : "";
+  const placed = placeDeadline(desc, deadline);
+  desc = placed.desc;
   // 文案自己就列了 (A)(B) 或 A. B. 品項 → 不重複；單品而文案已經寫了同一個金額（「一個$125」）→ 也不重複
   const descHasItems = /(^|\n)\s*(?:[(（][A-Za-z][)）]|[A-Za-z][.．、:：])/.test(desc);
   const descHasThisPrice = single && postPrice(items[0]) != null && decoPricesIn(desc).includes(postPrice(items[0]));
-  const descHasDeadline = /結單|收單|截單/.test(desc);
-  // 客人看的結單時間 = 客人收單（customer_end_at，20260910050000）跟店家收單取早的那個；
-  // 客人收單沒設就是店家收單。店家收單是小幫手還能補單的最後期限，客人不用知道。
-  const closeAt = earliest(c.customer_end_at, c.end_at);
-  const deadline = closeAt ? `⏰ ${fmtTaipei(closeAt)} 結單` : "";
 
   const rendered = (template || DEFAULT_TEMPLATE)
     .replaceAll("{{tag}}", buildPostTag(c.campaign_no))
     .replaceAll("{{title}}", title)
     .replaceAll("{{items}}", descHasItems || descHasThisPrice ? "" : itemLines)
-    .replaceAll("{{deadline}}", descHasDeadline ? "" : deadline)
+    .replaceAll("{{deadline}}", placed.placed ? "" : deadline)
     .replaceAll("{{howto}}", single ? HOWTO_SINGLE : HOWTO_MULTI)
     .replaceAll("{{name}}", c.name ?? "")
     .replaceAll("{{campaign_no}}", c.campaign_no ?? "")
     .replaceAll("{{description}}", desc)
-    .replaceAll("{{end_at}}", fmtTaipei(c.end_at))
+    .replaceAll("{{end_at}}", fmtTaipei(closeAt))
     .replaceAll("{{start_at}}", fmtTaipei(c.start_at))
     .replaceAll("{{pickup_deadline}}", fmtTaipei(c.pickup_deadline))
-    .replace(/^⏰ 最後收單[ \t]*(?:\n|$)/gm, "")      // 沒有店家收單（無到期日）就整行不要
     .replace(/\n{3,}/g, "\n\n")
     .trim();
   return withPostTag(rendered, c.campaign_no);

--- a/supabase/functions/_shared/lineNoteRender.ts
+++ b/supabase/functions/_shared/lineNoteRender.ts
@@ -10,7 +10,8 @@
 // {{title}} / {{items}} / {{deadline}} / {{howto}} 是「聰明版」：文案自己已經寫過的就不再重複一次。
 // 從記事本匯進來的團，description 常常就是整篇貼文（標題＋(A)(B)品項＋⏰結單都在裡面），
 // 照樣接上去會變成品項印兩次、結單寫兩行。
-// {{name}} 維持原樣（照印）；{{end_at}} / {{deadline}} 印的是客人看的結單時間（客人收單，沒設就是店家收單）。
+// {{name}} 維持原樣（照印）。{{deadline}} 是客人看的結單時間（客人收單，沒設就是店家收單）；
+// {{end_at}} 是店家收單（最後收單時間），老闆 2026-09-10 指定放在最後一行「⏰ 最後收單 9/15 23:59」。
 // {{tag}} 是團號章（🔖 團號 GRP-…）：爬回來的時候靠它精準認出是哪一團，不用猜團名。
 // 自訂模板沒寫 {{tag}} 也會被 withPostTag 補在文末 —— 章一定要有，不然這篇就只能靠猜。
 // ─────────────────────────────────────────────────────────────────────────────
@@ -28,6 +29,7 @@ export const DEFAULT_TEMPLATE = `{{title}}
 {{description}}
 
 {{howto}}
+⏰ 最後收單 {{end_at}}
 #開團
 {{tag}}`;
 
@@ -194,9 +196,10 @@ export function renderTemplate(template: string | null, payload: any) {
     .replaceAll("{{name}}", c.name ?? "")
     .replaceAll("{{campaign_no}}", c.campaign_no ?? "")
     .replaceAll("{{description}}", desc)
-    .replaceAll("{{end_at}}", fmtTaipei(closeAt))
+    .replaceAll("{{end_at}}", fmtTaipei(c.end_at))
     .replaceAll("{{start_at}}", fmtTaipei(c.start_at))
     .replaceAll("{{pickup_deadline}}", fmtTaipei(c.pickup_deadline))
+    .replace(/^⏰ 最後收單[ \t]*(?:\n|$)/gm, "")      // 沒有店家收單（無到期日）就整行不要
     .replace(/\n{3,}/g, "\n\n")
     .trim();
   return withPostTag(rendered, c.campaign_no);


### PR DESCRIPTION
## 做了什麼

#944 合併之後老闆再改的幾件事（都是 `_shared/lineNoteRender.ts` 那一份，預覽、發文、存 DB 同步）：

- **標題一律印團名**（商品 G02580 的「兒童防擠壓飲料杯托 (顏色隨機)」），不拿文案裡的「【兒童防擠壓飲料杯托｜顏色隨機】」當標題；文案開頭幾行跟團名一樣的那一行拿掉，不印兩次。
- **結單那一行接在金額後面**，時間是客人看的結單時間（`customer_end_at`，#947 的欄位；沒設就是店家收單）。文案自己有金額（「💰95元」「(A) 韭菜盒 1️⃣8️⃣9️⃣ 元」）就插在那一段後面、前後各空一行；沒有就走版型的 `{{deadline}}`。文案自己寫的「⏰9/14結單」拿掉，時間以系統為準。
- **金額接在品項同一行**：多品項「(A) 韭菜盒 1️⃣8️⃣9️⃣ 元」、單品「💰1️⃣0️⃣5️⃣ 元」，不加 💲。文案自己列了 (A)(B) 但沒寫價格的也接上去；記事本「價格在下一行」的寫法跟零售價一樣就併成一行、不一樣就兩行都不動。接完之後文案裡整行只寫同一個金額的「💰一袋189元」拿掉。整行只有金額的那一行跟上一行之間空一行。
- **留言教學**改成「📝 留言「品項代碼＋數量」，例：A+1 B+2」，單品「📝 留言「數量」，例：+1」。
- 社群設定的模板提示同步（多 `{{deadline}}`）。版型：團名 → 金額 → ⏰ 結單 → 文案 → 留言教學 → #開團 → 🔖 團號。

## 上線危險

- 做了：`line-note-worker` 已部署到 version 27，OPTIONS 200、無 auth POST 回函式自家 401。沒有 migration。
- 不做：沒動留言解析、沒動 payload RPC、已發出去的貼文不會變。店家收單（最後收單）貼文上不印。
- 回退：重新部署 #944 合併時那份 `line-note-worker`（version 22）。

## 敏感設定

- [ ] 本 PR 有新增或修改門禁、環境設定、密鑰讀取、Vercel/Supabase/GitHub Actions 設定，已在本段寫清楚原因、影響、做了危險、不做危險、回退方式。
- [x] 本 PR 沒有碰上述敏感設定。

## 驗證

- `lineNoteRender.test.ts` 13 條 + `lineNoteDeco.test.ts` 5 條，esbuild 打包後在 node 跑過全綠。
- 對線上 `GRP-20260910-011`（杯托，單品）、`GRP-20260910-012`（杰哥韭菜盒，兩品項）、`GRP-20260909-014`（拆信刀，單品）渲染，跟老闆改給我看的版面一致：團名 → 文案開頭 → 金額 → ⏰ 結單 → 🚚 → 文案本體。`GRP-20260908-002`（四品項、價格寫在下一行的匯入團）併成四行「(A)空心菜200g 3️⃣5️⃣ 元」再接結單。
- 這支分支是 #944 squash 合併後從 main 重開的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhdcaVFVE5iGuHqtWFvEGV