### PR TITLE
漂漂館廠商選單新增漂漂館並排第一

### DIFF
--- a/apps/member/src/app/piaopiao/publisher/page.tsx
+++ b/apps/member/src/app/piaopiao/publisher/page.tsx
@@ -24,7 +24,7 @@ const MAX_BATCH_VARIANTS = 100;
 const MAX_IMAGES_PER_PRODUCT = 50;
 const MAX_UPLOAD_IMAGE_BYTES = 4.5 * 1024 * 1024;
 const MAX_IMAGE_SIDE = 1800;
-const SUPPLIER_OPTIONS = ["包子媽", "山瀾商行", "NO21", "精品", "599", "Diz.o", "芭斯特", "祥美", "亞諾"];
+const SUPPLIER_OPTIONS = ["漂漂館", "包子媽", "山瀾商行", "NO21", "精品", "599", "Diz.o", "芭斯特", "祥美", "亞諾"];
 
 export default function PiaopiaoPublisherPage() {
   const [token, setToken] = useState("");


### PR DESCRIPTION
## 目的
漂漂彤上架時，廠商選單新增「漂漂館」，並排在第一個。

## 修改範圍
- 只改漂漂館員工上架頁 1 個檔案、1 行
- 保留既有廠商與「自訂」
- 漂漂潮仍固定「潮包子」
- 不碰一般團購、SQL、後端或環境設定

## 檢查
- 阿審複審：P0=0、P1=0、P2=0
- `git diff --check` 通過
- 工地未安裝套件，因此未重裝套件跑完整編譯

## 危險
- 做了：只改漂漂彤廠商選單的顯示順序；若員工沒注意，可能更容易直接選到第一個「漂漂館」。
- 不做：員工每次仍需從其他選項或自訂處理「漂漂館」。